### PR TITLE
[Merged by Bors] - chore(Data/ENNReal): restructure lemma files

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2575,10 +2575,12 @@ import Mathlib.Data.DFinsupp.Small
 import Mathlib.Data.DFinsupp.Submonoid
 import Mathlib.Data.DFinsupp.WellFounded
 import Mathlib.Data.DList.Instances
+import Mathlib.Data.ENNReal.Action
 import Mathlib.Data.ENNReal.Basic
 import Mathlib.Data.ENNReal.Inv
 import Mathlib.Data.ENNReal.Lemmas
 import Mathlib.Data.ENNReal.Operations
+import Mathlib.Data.ENNReal.Order
 import Mathlib.Data.ENNReal.Real
 import Mathlib.Data.ENat.Basic
 import Mathlib.Data.ENat.BigOperators

--- a/Mathlib/AlgebraicTopology/TopologicalSimplex.lean
+++ b/Mathlib/AlgebraicTopology/TopologicalSimplex.lean
@@ -3,7 +3,7 @@ Copyright (c) 2021 Adam Topaz. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johan Commelin, Adam Topaz
 -/
-import Mathlib.Algebra.BigOperators.Ring
+import Mathlib.Algebra.BigOperators.Ring.Finset
 import Mathlib.AlgebraicTopology.SimplexCategory
 import Mathlib.Topology.Category.TopCat.Basic
 import Mathlib.Topology.Connected.PathConnected

--- a/Mathlib/AlgebraicTopology/TopologicalSimplex.lean
+++ b/Mathlib/AlgebraicTopology/TopologicalSimplex.lean
@@ -3,10 +3,11 @@ Copyright (c) 2021 Adam Topaz. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johan Commelin, Adam Topaz
 -/
+import Mathlib.Algebra.BigOperators.Ring
 import Mathlib.AlgebraicTopology.SimplexCategory
 import Mathlib.Topology.Category.TopCat.Basic
-import Mathlib.Topology.Instances.NNReal.Defs
 import Mathlib.Topology.Connected.PathConnected
+import Mathlib.Topology.Instances.NNReal.Defs
 
 /-!
 # Topological simplices

--- a/Mathlib/Analysis/BoxIntegral/Box/Basic.lean
+++ b/Mathlib/Analysis/BoxIntegral/Box/Basic.lean
@@ -3,12 +3,13 @@ Copyright (c) 2021 Yury Kudryashov. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury Kudryashov
 -/
+import Mathlib.Data.NNReal.Basic
 import Mathlib.Order.Fin.Tuple
 import Mathlib.Order.Interval.Set.Monotone
 import Mathlib.Topology.MetricSpace.Basic
 import Mathlib.Topology.MetricSpace.Bounded
-import Mathlib.Topology.Order.MonotoneConvergence
 import Mathlib.Topology.MetricSpace.Pseudo.Real
+import Mathlib.Topology.Order.MonotoneConvergence
 /-!
 # Rectangular boxes in `ℝⁿ`
 

--- a/Mathlib/Analysis/Normed/Group/Basic.lean
+++ b/Mathlib/Analysis/Normed/Group/Basic.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Patrick Massot, Johannes Hölzl, Yaël Dillies
 -/
 import Mathlib.Analysis.Normed.Group.Seminorm
+import Mathlib.Data.NNReal.Basic
 import Mathlib.Topology.MetricSpace.Basic
 
 /-!

--- a/Mathlib/Analysis/Normed/MulAction.lean
+++ b/Mathlib/Analysis/Normed/MulAction.lean
@@ -4,8 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Eric Wieser
 -/
 import Mathlib.Analysis.Normed.Field.Basic
-import Mathlib.Topology.MetricSpace.Algebra
+import Mathlib.Data.ENNReal.Action
 import Mathlib.Topology.Algebra.UniformMulAction
+import Mathlib.Topology.MetricSpace.Algebra
 
 /-!
 # Lemmas for `BoundedSMul` over normed additive groups

--- a/Mathlib/Data/ENNReal/Action.lean
+++ b/Mathlib/Data/ENNReal/Action.lean
@@ -8,7 +8,7 @@ import Mathlib.Data.ENNReal.Order
 /-!
 # Scalar multiplication on `ℝ≥0∞`.
 
-This file defines basic scalar actions on extended nonnegative reals, showing that 
+This file defines basic scalar actions on extended nonnegative reals, showing that
 `MulAction`s, `DistribMulAction`s, `Module`s and `Algebra`s restrict from `ℝ≥0∞` to `ℝ≥0`.
 -/
 

--- a/Mathlib/Data/ENNReal/Action.lean
+++ b/Mathlib/Data/ENNReal/Action.lean
@@ -1,0 +1,100 @@
+/-
+Copyright (c) 2017 Johannes Hölzl. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Johannes Hölzl, Yury Kudryashov
+-/
+import Mathlib.Data.ENNReal.Order
+
+/-!
+# Scalar multiplication on `ℝ≥0∞`.
+
+This file defines basic scalar actions on extended nonnegative reals, showing that 
+`MulAction`s, `DistribMulAction`s, `Module`s and `Algebra`s restrict from `ℝ≥0∞` to `ℝ≥0`.
+-/
+
+open Set NNReal ENNReal
+
+namespace ENNReal
+
+variable {a b c d : ℝ≥0∞} {r p q : ℝ≥0}
+
+-- TODO: generalize some of these to `WithTop α`
+section Actions
+
+/-- A `MulAction` over `ℝ≥0∞` restricts to a `MulAction` over `ℝ≥0`. -/
+noncomputable instance {M : Type*} [MulAction ℝ≥0∞ M] : MulAction ℝ≥0 M :=
+  MulAction.compHom M ofNNRealHom.toMonoidHom
+
+theorem smul_def {M : Type*} [MulAction ℝ≥0∞ M] (c : ℝ≥0) (x : M) : c • x = (c : ℝ≥0∞) • x :=
+  rfl
+
+instance {M N : Type*} [MulAction ℝ≥0∞ M] [MulAction ℝ≥0∞ N] [SMul M N] [IsScalarTower ℝ≥0∞ M N] :
+    IsScalarTower ℝ≥0 M N where smul_assoc r := smul_assoc (r : ℝ≥0∞)
+
+instance smulCommClass_left {M N : Type*} [MulAction ℝ≥0∞ N] [SMul M N] [SMulCommClass ℝ≥0∞ M N] :
+    SMulCommClass ℝ≥0 M N where smul_comm r := smul_comm (r : ℝ≥0∞)
+
+instance smulCommClass_right {M N : Type*} [MulAction ℝ≥0∞ N] [SMul M N] [SMulCommClass M ℝ≥0∞ N] :
+    SMulCommClass M ℝ≥0 N where smul_comm m r := smul_comm m (r : ℝ≥0∞)
+
+/-- A `DistribMulAction` over `ℝ≥0∞` restricts to a `DistribMulAction` over `ℝ≥0`. -/
+noncomputable instance {M : Type*} [AddMonoid M] [DistribMulAction ℝ≥0∞ M] :
+    DistribMulAction ℝ≥0 M :=
+  DistribMulAction.compHom M ofNNRealHom.toMonoidHom
+
+/-- A `Module` over `ℝ≥0∞` restricts to a `Module` over `ℝ≥0`. -/
+noncomputable instance {M : Type*} [AddCommMonoid M] [Module ℝ≥0∞ M] : Module ℝ≥0 M :=
+  Module.compHom M ofNNRealHom
+
+/-- An `Algebra` over `ℝ≥0∞` restricts to an `Algebra` over `ℝ≥0`. -/
+noncomputable instance {A : Type*} [Semiring A] [Algebra ℝ≥0∞ A] : Algebra ℝ≥0 A where
+  smul := (· • ·)
+  commutes' r x := by simp [Algebra.commutes]
+  smul_def' r x := by simp [← Algebra.smul_def (r : ℝ≥0∞) x, smul_def]
+  algebraMap := (algebraMap ℝ≥0∞ A).comp (ofNNRealHom : ℝ≥0 →+* ℝ≥0∞)
+
+-- verify that the above produces instances we might care about
+noncomputable example : Algebra ℝ≥0 ℝ≥0∞ := inferInstance
+
+noncomputable example : DistribMulAction ℝ≥0ˣ ℝ≥0∞ := inferInstance
+
+theorem coe_smul {R} (r : R) (s : ℝ≥0) [SMul R ℝ≥0] [SMul R ℝ≥0∞] [IsScalarTower R ℝ≥0 ℝ≥0]
+    [IsScalarTower R ℝ≥0 ℝ≥0∞] : (↑(r • s) : ℝ≥0∞) = (r : R) • (s : ℝ≥0∞) := by
+  rw [← smul_one_smul ℝ≥0 r (s : ℝ≥0∞), smul_def, smul_eq_mul, ← ENNReal.coe_mul, smul_mul_assoc,
+    one_mul]
+
+-- Porting note: added missing `DecidableEq R`
+theorem smul_top {R} [Zero R] [SMulWithZero R ℝ≥0∞] [IsScalarTower R ℝ≥0∞ ℝ≥0∞]
+    [NoZeroSMulDivisors R ℝ≥0∞] [DecidableEq R] (c : R) :
+    c • ∞ = if c = 0 then 0 else ∞ := by
+  rw [← smul_one_mul, mul_top']
+  -- Porting note: need the primed version of `one_ne_zero` now
+  simp_rw [smul_eq_zero, or_iff_left (one_ne_zero' ℝ≥0∞)]
+
+lemma nnreal_smul_lt_top {x : ℝ≥0} {y : ℝ≥0∞} (hy : y < ⊤) : x • y < ⊤ := mul_lt_top (by simp) hy
+lemma nnreal_smul_ne_top {x : ℝ≥0} {y : ℝ≥0∞} (hy : y ≠ ⊤) : x • y ≠ ⊤ := mul_ne_top (by simp) hy
+
+lemma nnreal_smul_ne_top_iff {x : ℝ≥0} {y : ℝ≥0∞} (hx : x ≠ 0) : x • y ≠ ⊤ ↔ y ≠ ⊤ :=
+  ⟨by rintro h rfl; simp [smul_top, hx] at h, nnreal_smul_ne_top⟩
+
+lemma nnreal_smul_lt_top_iff {x : ℝ≥0} {y : ℝ≥0∞} (hx : x ≠ 0) : x • y < ⊤ ↔ y < ⊤ := by
+  rw [lt_top_iff_ne_top, lt_top_iff_ne_top, nnreal_smul_ne_top_iff hx]
+
+@[simp]
+theorem smul_toNNReal (a : ℝ≥0) (b : ℝ≥0∞) : (a • b).toNNReal = a * b.toNNReal := by
+  change ((a : ℝ≥0∞) * b).toNNReal = a * b.toNNReal
+  simp only [ENNReal.toNNReal_mul, ENNReal.toNNReal_coe]
+
+theorem toReal_smul (r : ℝ≥0) (s : ℝ≥0∞) : (r • s).toReal = r • s.toReal := by
+  rw [ENNReal.smul_def, smul_eq_mul, toReal_mul, coe_toReal]
+  rfl
+
+instance : PosSMulStrictMono ℝ≥0 ℝ≥0∞ where
+  elim _r hr _a _b hab := ENNReal.mul_lt_mul_left' (coe_pos.2 hr).ne' coe_ne_top hab
+
+instance : SMulPosMono ℝ≥0 ℝ≥0∞ where
+  elim _r _ _a _b hab := mul_le_mul_right' (coe_le_coe.2 hab) _
+
+end Actions
+
+end ENNReal

--- a/Mathlib/Data/ENNReal/Inv.lean
+++ b/Mathlib/Data/ENNReal/Inv.lean
@@ -3,7 +3,7 @@ Copyright (c) 2017 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Yury Kudryashov
 -/
-import Mathlib.Data.ENNReal.Operations
+import Mathlib.Data.ENNReal.Order
 
 /-!
 # Results about division in extended non-negative reals
@@ -29,6 +29,8 @@ A few order isomorphisms are worthy of mention:
     the extended nonnegative real numbers and the unit interval. This is `orderIsoIicOneBirational`
     composed with the identity order isomorphism between `Iic (1 : ℝ≥0∞)` and `Icc (0 : ℝ) 1`.
 -/
+
+assert_not_exists Finset
 
 open Set NNReal
 
@@ -244,16 +246,6 @@ protected theorem inv_div {a b : ℝ≥0∞} (htop : b ≠ ∞ ∨ a ≠ ∞) (h
   rw [← ENNReal.inv_ne_top] at hzero
   rw [ENNReal.div_eq_inv_mul, ENNReal.div_eq_inv_mul, ENNReal.mul_inv htop hzero, mul_comm, inv_inv]
 
-lemma prod_inv_distrib {ι : Type*} {f : ι → ℝ≥0∞} {s : Finset ι}
-    (hf : s.toSet.Pairwise fun i j ↦ f i ≠ 0 ∨ f j ≠ ∞) : (∏ i ∈ s, f i)⁻¹ = ∏ i ∈ s, (f i)⁻¹ := by
-  induction' s using Finset.cons_induction with i s hi ih
-  · simp
-  simp [← ih (hf.mono <| by simp)]
-  refine ENNReal.mul_inv (not_or_of_imp fun hi₀ ↦ prod_ne_top fun j hj ↦ ?_)
-    (not_or_of_imp fun hi₀ ↦ Finset.prod_ne_zero_iff.2 fun j hj ↦ ?_)
-  · exact imp_iff_not_or.2 (hf (by simp) (by simp [hj]) <| .symm <| ne_of_mem_of_not_mem hj hi) hi₀
-  · exact imp_iff_not_or.2 (hf (by simp [hj]) (by simp) <| ne_of_mem_of_not_mem hj hi).symm hi₀
-
 protected theorem mul_div_mul_left (a b : ℝ≥0∞) (hc : c ≠ 0) (hc' : c ≠ ⊤) :
     c * a / (c * b) = a / b := by
   rw [div_eq_mul_inv, div_eq_mul_inv, ENNReal.mul_inv (Or.inl hc) (Or.inl hc'), mul_mul_mul_comm,
@@ -437,12 +429,6 @@ protected theorem eq_inv_of_mul_eq_one_left (h : a * b = 1) : a = b⁻¹ := by
 theorem mul_le_iff_le_inv {a b r : ℝ≥0∞} (hr₀ : r ≠ 0) (hr₁ : r ≠ ∞) : r * a ≤ b ↔ a ≤ r⁻¹ * b := by
   rw [← @ENNReal.mul_le_mul_left _ a _ hr₀ hr₁, ← mul_assoc, ENNReal.mul_inv_cancel hr₀ hr₁,
     one_mul]
-
-instance : PosSMulStrictMono ℝ≥0 ℝ≥0∞ where
-  elim _r hr _a _b hab := ENNReal.mul_lt_mul_left' (coe_pos.2 hr).ne' coe_ne_top hab
-
-instance : SMulPosMono ℝ≥0 ℝ≥0∞ where
-  elim _r _ _a _b hab := mul_le_mul_right' (coe_le_coe.2 hab) _
 
 theorem le_of_forall_nnreal_lt {x y : ℝ≥0∞} (h : ∀ r : ℝ≥0, ↑r < x → ↑r ≤ y) : x ≤ y := by
   refine le_of_forall_lt_imp_le_of_dense fun r hr => ?_
@@ -900,20 +886,6 @@ lemma iSup_add_iSup_of_monotone {ι : Type*} [Preorder ι] [IsDirected ι (· �
     (hf : Monotone f) (hg : Monotone g) : iSup f + iSup g = ⨆ a, f a + g a :=
   iSup_add_iSup fun i j ↦ (exists_ge_ge i j).imp fun _k ⟨hi, hj⟩ ↦ by gcongr <;> apply_rules
 
-lemma finsetSum_iSup {α ι : Type*} {s : Finset α} {f : α → ι → ℝ≥0∞}
-    (hf : ∀ i j, ∃ k, ∀ a, f a i ≤ f a k ∧ f a j ≤ f a k) :
-    ∑ a ∈ s, ⨆ i, f a i = ⨆ i, ∑ a ∈ s, f a i := by
-  induction' s using Finset.cons_induction with a s ha ihs
-  · simp
-  simp_rw [Finset.sum_cons, ihs]
-  refine iSup_add_iSup fun i j ↦ (hf i j).imp fun k hk ↦ ?_
-  gcongr
-  exacts [(hk a).1, (hk _).2]
-
-lemma finsetSum_iSup_of_monotone {α ι : Type*} [Preorder ι] [IsDirected ι (· ≤ ·)] {s : Finset α}
-    {f : α → ι → ℝ≥0∞} (hf : ∀ a, Monotone (f a)) : (∑ a ∈ s, iSup (f a)) = ⨆ n, ∑ a ∈ s, f a n :=
-  finsetSum_iSup fun i j ↦ (exists_ge_ge i j).imp fun _k ⟨hi, hj⟩ a ↦ ⟨hf a hi, hf a hj⟩
-
 lemma le_iInf_mul_iInf {g : κ → ℝ≥0∞} (hf : ∃ i, f i ≠ ∞) (hg : ∃ j, g j ≠ ∞)
     (ha : ∀ i j, a ≤ f i * g j) : a ≤ (⨅ i, f i) * ⨅ j, g j := by
   rw [← iInf_ne_top_subtype]
@@ -956,6 +928,28 @@ lemma exists_lt_add_of_lt_add {x y z : ℝ≥0∞} (h : x < y + z) (hy : y ≠ 0
     ∃ y' < y, ∃ z' < z, x < y' + z' := by
   contrapose! h
   simpa using biSup_add_biSup_le' (by exact ⟨0, hy.bot_lt⟩) (by exact ⟨0, hz.bot_lt⟩) h
+
+theorem ofReal_inv_of_pos {x : ℝ} (hx : 0 < x) : ENNReal.ofReal x⁻¹ = (ENNReal.ofReal x)⁻¹ := by
+  rw [ENNReal.ofReal, ENNReal.ofReal, ← @coe_inv (Real.toNNReal x) (by simp [hx]), coe_inj,
+    ← Real.toNNReal_inv]
+
+theorem ofReal_div_of_pos {x y : ℝ} (hy : 0 < y) :
+    ENNReal.ofReal (x / y) = ENNReal.ofReal x / ENNReal.ofReal y := by
+  rw [div_eq_mul_inv, div_eq_mul_inv, ofReal_mul' (inv_nonneg.2 hy.le), ofReal_inv_of_pos hy]
+
+@[simp] theorem toNNReal_inv (a : ℝ≥0∞) : a⁻¹.toNNReal = a.toNNReal⁻¹ := by
+  induction' a with a; · simp
+  rcases eq_or_ne a 0 with (rfl | ha); · simp
+  rw [← coe_inv ha, toNNReal_coe, toNNReal_coe]
+
+@[simp] theorem toNNReal_div (a b : ℝ≥0∞) : (a / b).toNNReal = a.toNNReal / b.toNNReal := by
+  rw [div_eq_mul_inv, toNNReal_mul, toNNReal_inv, div_eq_mul_inv]
+
+@[simp] theorem toReal_inv (a : ℝ≥0∞) : a⁻¹.toReal = a.toReal⁻¹ := by
+  simp only [ENNReal.toReal, toNNReal_inv, NNReal.coe_inv]
+
+@[simp] theorem toReal_div (a b : ℝ≥0∞) : (a / b).toReal = a.toReal / b.toReal := by
+  rw [div_eq_mul_inv, toReal_mul, toReal_inv, div_eq_mul_inv]
 
 end Inv
 end ENNReal

--- a/Mathlib/Data/ENNReal/Operations.lean
+++ b/Mathlib/Data/ENNReal/Operations.lean
@@ -4,20 +4,14 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Yury Kudryashov
 -/
 import Mathlib.Algebra.BigOperators.WithTop
-import Mathlib.Algebra.GroupWithZero.Divisibility
-import Mathlib.Data.ENNReal.Basic
 import Mathlib.Data.NNReal.Basic
+import Mathlib.Data.ENNReal.Inv
 
 /-!
-# Properties of addition, multiplication and subtraction on extended non-negative real numbers
+# Properties of big operators extended non-negative real numbers
 
-In this file we prove elementary properties of algebraic operations on `ℝ≥0∞`, including addition,
-multiplication, natural powers and truncated subtraction, as well as how these interact with the
-order structure on `ℝ≥0∞`. Notably excluded from this list are inversion and division, the
-definitions and properties of which can be found in `Mathlib.Data.ENNReal.Inv`.
-
-Note: the definitions of the operations included in this file can be found in
-`Mathlib.Data.ENNReal.Basic`.
+In this file we prove elementary properties of sums and products on `ℝ≥0∞`, as well as how these
+interact with the order structure on `ℝ≥0∞`.
 -/
 
 open Set NNReal ENNReal
@@ -26,221 +20,9 @@ namespace ENNReal
 
 variable {a b c d : ℝ≥0∞} {r p q : ℝ≥0}
 
-section Mul
-
-@[mono, gcongr]
-theorem mul_lt_mul (ac : a < c) (bd : b < d) : a * b < c * d := WithTop.mul_lt_mul ac bd
-
-@[deprecated mul_left_mono (since := "2024-10-15")]
-protected theorem mul_left_mono : Monotone (a * ·) := mul_left_mono
-
-@[deprecated mul_right_mono (since := "2024-10-15")]
-protected theorem mul_right_mono : Monotone (· * a) := mul_right_mono
-
-protected lemma pow_right_strictMono {n : ℕ} (hn : n ≠ 0) : StrictMono fun a : ℝ≥0∞ ↦ a ^ n :=
-  WithTop.pow_right_strictMono hn
-
-@[deprecated (since := "2024-10-15")] alias pow_strictMono := ENNReal.pow_right_strictMono
-
-@[gcongr] protected lemma pow_lt_pow_left (hab : a < b) {n : ℕ} (hn : n ≠ 0) : a ^ n < b ^ n :=
-  WithTop.pow_lt_pow_left hab hn
-
-@[deprecated max_mul (since := "2024-10-15")]
-protected theorem max_mul : max a b * c = max (a * c) (b * c) := mul_right_mono.map_max
-
-@[deprecated mul_max (since := "2024-10-15")]
-protected theorem mul_max : a * max b c = max (a * b) (a * c) := mul_left_mono.map_max
-
--- Porting note (https://github.com/leanprover-community/mathlib4/issues/11215): TODO: generalize to `WithTop`
-theorem mul_left_strictMono (h0 : a ≠ 0) (hinf : a ≠ ∞) : StrictMono (a * ·) := by
-  lift a to ℝ≥0 using hinf
-  rw [coe_ne_zero] at h0
-  intro x y h
-  contrapose! h
-  simpa only [← mul_assoc, ← coe_mul, inv_mul_cancel₀ h0, coe_one, one_mul]
-    using mul_le_mul_left' h (↑a⁻¹)
-
-@[gcongr] protected theorem mul_lt_mul_left' (h0 : a ≠ 0) (hinf : a ≠ ⊤) (bc : b < c) :
-    a * b < a * c :=
-  ENNReal.mul_left_strictMono h0 hinf bc
-
-@[gcongr] protected theorem mul_lt_mul_right' (h0 : a ≠ 0) (hinf : a ≠ ⊤) (bc : b < c) :
-    b * a < c * a :=
-  mul_comm b a ▸ mul_comm c a ▸ ENNReal.mul_left_strictMono h0 hinf bc
-
--- Porting note (https://github.com/leanprover-community/mathlib4/issues/11215): TODO: generalize to `WithTop`
-protected theorem mul_right_inj (h0 : a ≠ 0) (hinf : a ≠ ∞) : a * b = a * c ↔ b = c :=
-  (mul_left_strictMono h0 hinf).injective.eq_iff
-
-@[deprecated (since := "2025-01-20")]
-alias mul_eq_mul_left := ENNReal.mul_right_inj
-
--- Porting note (https://github.com/leanprover-community/mathlib4/issues/11215): TODO: generalize to `WithTop`
-protected theorem mul_left_inj (h0 : c ≠ 0) (hinf : c ≠ ∞) : a * c = b * c ↔ a = b :=
-  mul_comm c a ▸ mul_comm c b ▸ ENNReal.mul_right_inj h0 hinf
-
-@[deprecated (since := "2025-01-20")]
-alias mul_eq_mul_right := ENNReal.mul_left_inj
-
--- Porting note (https://github.com/leanprover-community/mathlib4/issues/11215): TODO: generalize to `WithTop`
-theorem mul_le_mul_left (h0 : a ≠ 0) (hinf : a ≠ ∞) : a * b ≤ a * c ↔ b ≤ c :=
-  (mul_left_strictMono h0 hinf).le_iff_le
-
--- Porting note (https://github.com/leanprover-community/mathlib4/issues/11215): TODO: generalize to `WithTop`
-theorem mul_le_mul_right : c ≠ 0 → c ≠ ∞ → (a * c ≤ b * c ↔ a ≤ b) :=
-  mul_comm c a ▸ mul_comm c b ▸ mul_le_mul_left
-
--- Porting note (https://github.com/leanprover-community/mathlib4/issues/11215): TODO: generalize to `WithTop`
-theorem mul_lt_mul_left (h0 : a ≠ 0) (hinf : a ≠ ∞) : a * b < a * c ↔ b < c :=
-  (mul_left_strictMono h0 hinf).lt_iff_lt
-
--- Porting note (https://github.com/leanprover-community/mathlib4/issues/11215): TODO: generalize to `WithTop`
-theorem mul_lt_mul_right : c ≠ 0 → c ≠ ∞ → (a * c < b * c ↔ a < b) :=
-  mul_comm c a ▸ mul_comm c b ▸ mul_lt_mul_left
-
-protected lemma mul_eq_left (ha₀ : a ≠ 0) (ha : a ≠ ∞) : a * b = a ↔ b = 1 := by
-  simpa using ENNReal.mul_right_inj ha₀ ha (c := 1)
-
-protected lemma mul_eq_right (hb₀ : b ≠ 0) (hb : b ≠ ∞) : a * b = b ↔ a = 1 := by
-  simpa using ENNReal.mul_left_inj hb₀ hb (b := 1)
-
-end Mul
-
-section OperationsAndOrder
-
-protected theorem pow_pos : 0 < a → ∀ n : ℕ, 0 < a ^ n :=
-  CanonicallyOrderedAdd.pow_pos
-
-protected theorem pow_ne_zero : a ≠ 0 → ∀ n : ℕ, a ^ n ≠ 0 := by
-  simpa only [pos_iff_ne_zero] using ENNReal.pow_pos
-
-theorem not_lt_zero : ¬a < 0 := by simp
-
-protected theorem le_of_add_le_add_left : a ≠ ∞ → a + b ≤ a + c → b ≤ c :=
-  WithTop.le_of_add_le_add_left
-
-protected theorem le_of_add_le_add_right : a ≠ ∞ → b + a ≤ c + a → b ≤ c :=
-  WithTop.le_of_add_le_add_right
-
-@[gcongr] protected theorem add_lt_add_left : a ≠ ∞ → b < c → a + b < a + c :=
-  WithTop.add_lt_add_left
-
-@[gcongr] protected theorem add_lt_add_right : a ≠ ∞ → b < c → b + a < c + a :=
-  WithTop.add_lt_add_right
-
-protected theorem add_le_add_iff_left : a ≠ ∞ → (a + b ≤ a + c ↔ b ≤ c) :=
-  WithTop.add_le_add_iff_left
-
-protected theorem add_le_add_iff_right : a ≠ ∞ → (b + a ≤ c + a ↔ b ≤ c) :=
-  WithTop.add_le_add_iff_right
-
-protected theorem add_lt_add_iff_left : a ≠ ∞ → (a + b < a + c ↔ b < c) :=
-  WithTop.add_lt_add_iff_left
-
-protected theorem add_lt_add_iff_right : a ≠ ∞ → (b + a < c + a ↔ b < c) :=
-  WithTop.add_lt_add_iff_right
-
-protected theorem add_lt_add_of_le_of_lt : a ≠ ∞ → a ≤ b → c < d → a + c < b + d :=
-  WithTop.add_lt_add_of_le_of_lt
-
-protected theorem add_lt_add_of_lt_of_le : c ≠ ∞ → a < b → c ≤ d → a + c < b + d :=
-  WithTop.add_lt_add_of_lt_of_le
-
-instance addLeftReflectLT : AddLeftReflectLT ℝ≥0∞ :=
-  WithTop.addLeftReflectLT
-
-theorem lt_add_right (ha : a ≠ ∞) (hb : b ≠ 0) : a < a + b := by
-  rwa [← pos_iff_ne_zero, ← ENNReal.add_lt_add_iff_left ha, add_zero] at hb
-
-end OperationsAndOrder
-
 section OperationsAndInfty
 
 variable {α : Type*}
-
-@[simp] theorem add_eq_top : a + b = ∞ ↔ a = ∞ ∨ b = ∞ := WithTop.add_eq_top
-
-@[simp] theorem add_lt_top : a + b < ∞ ↔ a < ∞ ∧ b < ∞ := WithTop.add_lt_top
-
-theorem toNNReal_add {r₁ r₂ : ℝ≥0∞} (h₁ : r₁ ≠ ∞) (h₂ : r₂ ≠ ∞) :
-    (r₁ + r₂).toNNReal = r₁.toNNReal + r₂.toNNReal := by
-  lift r₁ to ℝ≥0 using h₁
-  lift r₂ to ℝ≥0 using h₂
-  rfl
-
-theorem not_lt_top {x : ℝ≥0∞} : ¬x < ∞ ↔ x = ∞ := by rw [lt_top_iff_ne_top, Classical.not_not]
-
-theorem add_ne_top : a + b ≠ ∞ ↔ a ≠ ∞ ∧ b ≠ ∞ := by simpa only [lt_top_iff_ne_top] using add_lt_top
-
-@[aesop (rule_sets := [finiteness]) safe apply]
-protected lemma Finiteness.add_ne_top {a b : ℝ≥0∞} (ha : a ≠ ∞) (hb : b ≠ ∞) : a + b ≠ ∞ :=
-  ENNReal.add_ne_top.2 ⟨ha, hb⟩
-
-theorem mul_top' : a * ∞ = if a = 0 then 0 else ∞ := by convert WithTop.mul_top' a
-
--- Porting note: added because `simp` no longer uses `WithTop` lemmas for `ℝ≥0∞`
-@[simp] theorem mul_top (h : a ≠ 0) : a * ∞ = ∞ := WithTop.mul_top h
-
-theorem top_mul' : ∞ * a = if a = 0 then 0 else ∞ := by convert WithTop.top_mul' a
-
--- Porting note: added because `simp` no longer uses `WithTop` lemmas for `ℝ≥0∞`
-@[simp] theorem top_mul (h : a ≠ 0) : ∞ * a = ∞ := WithTop.top_mul h
-
-theorem top_mul_top : ∞ * ∞ = ∞ := WithTop.top_mul_top
-
--- Porting note (https://github.com/leanprover-community/mathlib4/issues/11215): TODO: assume `n ≠ 0` instead of `0 < n`
-theorem top_pow {n : ℕ} (n_pos : 0 < n) : (∞ : ℝ≥0∞) ^ n = ∞ := WithTop.top_pow n_pos
-
-theorem mul_eq_top : a * b = ∞ ↔ a ≠ 0 ∧ b = ∞ ∨ a = ∞ ∧ b ≠ 0 :=
-  WithTop.mul_eq_top_iff
-
-theorem mul_lt_top : a < ∞ → b < ∞ → a * b < ∞ := WithTop.mul_lt_top
-
--- This is unsafe because we could have `a = ∞` and `b = 0` or vice-versa
-@[aesop (rule_sets := [finiteness]) unsafe 75% apply]
-theorem mul_ne_top : a ≠ ∞ → b ≠ ∞ → a * b ≠ ∞ := WithTop.mul_ne_top
-
-theorem lt_top_of_mul_ne_top_left (h : a * b ≠ ∞) (hb : b ≠ 0) : a < ∞ :=
-  lt_top_iff_ne_top.2 fun ha => h <| mul_eq_top.2 (Or.inr ⟨ha, hb⟩)
-
-theorem lt_top_of_mul_ne_top_right (h : a * b ≠ ∞) (ha : a ≠ 0) : b < ∞ :=
-  lt_top_of_mul_ne_top_left (by rwa [mul_comm]) ha
-
-theorem mul_lt_top_iff {a b : ℝ≥0∞} : a * b < ∞ ↔ a < ∞ ∧ b < ∞ ∨ a = 0 ∨ b = 0 := by
-  constructor
-  · intro h
-    rw [← or_assoc, or_iff_not_imp_right, or_iff_not_imp_right]
-    intro hb ha
-    exact ⟨lt_top_of_mul_ne_top_left h.ne hb, lt_top_of_mul_ne_top_right h.ne ha⟩
-  · rintro (⟨ha, hb⟩ | rfl | rfl) <;> [exact mul_lt_top ha hb; simp; simp]
-
-theorem mul_self_lt_top_iff {a : ℝ≥0∞} : a * a < ⊤ ↔ a < ⊤ := by
-  rw [ENNReal.mul_lt_top_iff, and_self, or_self, or_iff_left_iff_imp]
-  rintro rfl
-  exact zero_lt_top
-
-theorem mul_pos_iff : 0 < a * b ↔ 0 < a ∧ 0 < b :=
-  CanonicallyOrderedAdd.mul_pos
-
-theorem mul_pos (ha : a ≠ 0) (hb : b ≠ 0) : 0 < a * b :=
-  mul_pos_iff.2 ⟨pos_iff_ne_zero.2 ha, pos_iff_ne_zero.2 hb⟩
-
--- Porting note (https://github.com/leanprover-community/mathlib4/issues/11215): TODO: generalize to `WithTop`
-@[simp] theorem pow_eq_top_iff {n : ℕ} : a ^ n = ∞ ↔ a = ∞ ∧ n ≠ 0 := by
-  rcases n.eq_zero_or_pos with rfl | (hn : 0 < n)
-  · simp
-  · induction a
-    · simp only [Ne, hn.ne', top_pow hn, not_false_eq_true, and_self]
-    · simp only [← coe_pow, coe_ne_top, false_and]
-
-theorem pow_eq_top (n : ℕ) (h : a ^ n = ∞) : a = ∞ :=
-  (pow_eq_top_iff.1 h).1
-
-theorem pow_ne_top (h : a ≠ ∞) {n : ℕ} : a ^ n ≠ ∞ :=
-  mt (pow_eq_top n) h
-
-theorem pow_lt_top : a < ∞ → ∀ n : ℕ, a ^ n < ∞ := by
-  simpa only [lt_top_iff_ne_top] using pow_ne_top
 
 @[simp, norm_cast]
 theorem coe_finset_sum {s : Finset α} {f : α → ℝ≥0} : ↑(∑ a ∈ s, f a) = ∑ a ∈ s, (f a : ℝ≥0∞) :=
@@ -250,184 +32,33 @@ theorem coe_finset_sum {s : Finset α} {f : α → ℝ≥0} : ↑(∑ a ∈ s, f
 theorem coe_finset_prod {s : Finset α} {f : α → ℝ≥0} : ↑(∏ a ∈ s, f a) = ∏ a ∈ s, (f a : ℝ≥0∞) :=
   map_prod ofNNRealHom f s
 
+@[simp]
+theorem toNNReal_prod {ι : Type*} {s : Finset ι} {f : ι → ℝ≥0∞} :
+    (∏ i ∈ s, f i).toNNReal = ∏ i ∈ s, (f i).toNNReal :=
+  map_prod toNNRealHom _ _
+
+@[simp]
+theorem toReal_prod {ι : Type*} {s : Finset ι} {f : ι → ℝ≥0∞} :
+    (∏ i ∈ s, f i).toReal = ∏ i ∈ s, (f i).toReal :=
+  map_prod toRealHom _ _
+
+theorem ofReal_prod_of_nonneg {α : Type*} {s : Finset α} {f : α → ℝ} (hf : ∀ i, i ∈ s → 0 ≤ f i) :
+    ENNReal.ofReal (∏ i ∈ s, f i) = ∏ i ∈ s, ENNReal.ofReal (f i) := by
+  simp_rw [ENNReal.ofReal, ← coe_finset_prod, coe_inj]
+  exact Real.toNNReal_prod_of_nonneg hf
+
+theorem iInf_sum {ι α : Type*} {f : ι → α → ℝ≥0∞} {s : Finset α} [Nonempty ι]
+    (h : ∀ (t : Finset α) (i j : ι), ∃ k, ∀ a ∈ t, f k a ≤ f i a ∧ f k a ≤ f j a) :
+    ⨅ i, ∑ a ∈ s, f i a = ∑ a ∈ s, ⨅ i, f i a := by
+  induction' s using Finset.cons_induction_on with a s ha ih
+  · simp only [Finset.sum_empty, ciInf_const]
+  · simp only [Finset.sum_cons, ← ih]
+    refine (iInf_add_iInf fun i j => ?_).symm
+    refine (h (Finset.cons a s ha) i j).imp fun k hk => ?_
+    rw [Finset.forall_mem_cons] at hk
+    exact add_le_add hk.1.1 (Finset.sum_le_sum fun a ha => (hk.2 a ha).2)
+
 end OperationsAndInfty
-
--- Porting note (https://github.com/leanprover-community/mathlib4/issues/11215): TODO: generalize to `WithTop`
-@[gcongr] protected theorem add_lt_add (ac : a < c) (bd : b < d) : a + b < c + d := by
-  lift a to ℝ≥0 using ac.ne_top
-  lift b to ℝ≥0 using bd.ne_top
-  cases c; · simp
-  cases d; · simp
-  simp only [← coe_add, some_eq_coe, coe_lt_coe] at *
-  exact add_lt_add ac bd
-
-section Cancel
-
--- Porting note (https://github.com/leanprover-community/mathlib4/issues/11215): TODO: generalize to `WithTop`
-/-- An element `a` is `AddLECancellable` if `a + b ≤ a + c` implies `b ≤ c` for all `b` and `c`.
-  This is true in `ℝ≥0∞` for all elements except `∞`. -/
-@[simp]
-theorem addLECancellable_iff_ne {a : ℝ≥0∞} : AddLECancellable a ↔ a ≠ ∞ := by
-  constructor
-  · rintro h rfl
-    refine zero_lt_one.not_le (h ?_)
-    simp
-  · rintro h b c hbc
-    apply ENNReal.le_of_add_le_add_left h hbc
-
-/-- This lemma has an abbreviated name because it is used frequently. -/
-theorem cancel_of_ne {a : ℝ≥0∞} (h : a ≠ ∞) : AddLECancellable a :=
-  addLECancellable_iff_ne.mpr h
-
-/-- This lemma has an abbreviated name because it is used frequently. -/
-theorem cancel_of_lt {a : ℝ≥0∞} (h : a < ∞) : AddLECancellable a :=
-  cancel_of_ne h.ne
-
-/-- This lemma has an abbreviated name because it is used frequently. -/
-theorem cancel_of_lt' {a b : ℝ≥0∞} (h : a < b) : AddLECancellable a :=
-  cancel_of_ne h.ne_top
-
-/-- This lemma has an abbreviated name because it is used frequently. -/
-theorem cancel_coe {a : ℝ≥0} : AddLECancellable (a : ℝ≥0∞) :=
-  cancel_of_ne coe_ne_top
-
-theorem add_right_inj (h : a ≠ ∞) : a + b = a + c ↔ b = c :=
-  (cancel_of_ne h).inj
-
-theorem add_left_inj (h : a ≠ ∞) : b + a = c + a ↔ b = c :=
-  (cancel_of_ne h).inj_left
-
-end Cancel
-
-section Sub
-
-theorem sub_eq_sInf {a b : ℝ≥0∞} : a - b = sInf { d | a ≤ d + b } :=
-  le_antisymm (le_sInf fun _ h => tsub_le_iff_right.mpr h) <| sInf_le <| mem_setOf.2 le_tsub_add
-
-/-- This is a special case of `WithTop.coe_sub` in the `ENNReal` namespace -/
-@[simp, norm_cast] theorem coe_sub : (↑(r - p) : ℝ≥0∞) = ↑r - ↑p := WithTop.coe_sub
-
-/-- This is a special case of `WithTop.top_sub_coe` in the `ENNReal` namespace -/
-@[simp] theorem top_sub_coe : ∞ - ↑r = ∞ := WithTop.top_sub_coe
-
-@[simp] lemma top_sub (ha : a ≠ ∞) : ∞ - a = ∞ := by lift a to ℝ≥0 using ha; exact top_sub_coe
-
-/-- This is a special case of `WithTop.sub_top` in the `ENNReal` namespace -/
-theorem sub_top : a - ∞ = 0 := WithTop.sub_top
-
-@[simp] theorem sub_eq_top_iff : a - b = ∞ ↔ a = ∞ ∧ b ≠ ∞ := WithTop.sub_eq_top_iff
-lemma sub_ne_top_iff : a - b ≠ ∞ ↔ a ≠ ∞ ∨ b = ∞ := WithTop.sub_ne_top_iff
-
--- This is unsafe because we could have `a = b = ∞`
-@[aesop (rule_sets := [finiteness]) unsafe 75% apply]
-theorem sub_ne_top (ha : a ≠ ∞) : a - b ≠ ∞ := mt sub_eq_top_iff.mp <| mt And.left ha
-
-@[simp, norm_cast]
-theorem natCast_sub (m n : ℕ) : ↑(m - n) = (m - n : ℝ≥0∞) := by
-  rw [← coe_natCast, Nat.cast_tsub, coe_sub, coe_natCast, coe_natCast]
-
-/-- See `ENNReal.sub_eq_of_eq_add'` for a version assuming that `a = c + b` itself is finite rather
-than `b`. -/
-protected theorem sub_eq_of_eq_add (hb : b ≠ ∞) : a = c + b → a - b = c :=
-  (cancel_of_ne hb).tsub_eq_of_eq_add
-
-/-- Weaker version of `ENNReal.sub_eq_of_eq_add` assuming that `a = c + b` itself is finite rather
-han `b`. -/
-protected lemma sub_eq_of_eq_add' (ha : a ≠ ∞) : a = c + b → a - b = c :=
-  (cancel_of_ne ha).tsub_eq_of_eq_add'
-
-/-- See `ENNReal.eq_sub_of_add_eq'` for a version assuming that `b = a + c` itself is finite rather
-than `c`. -/
-protected theorem eq_sub_of_add_eq (hc : c ≠ ∞) : a + c = b → a = b - c :=
-  (cancel_of_ne hc).eq_tsub_of_add_eq
-
-/-- Weaker version of `ENNReal.eq_sub_of_add_eq` assuming that `b = a + c` itself is finite rather
-than `c`. -/
-protected lemma eq_sub_of_add_eq' (hb : b ≠ ∞) : a + c = b → a = b - c :=
-  (cancel_of_ne hb).eq_tsub_of_add_eq'
-
-/-- See `ENNReal.sub_eq_of_eq_add_rev'` for a version assuming that `a = b + c` itself is finite
-rather than `b`. -/
-protected theorem sub_eq_of_eq_add_rev (hb : b ≠ ∞) : a = b + c → a - b = c :=
-  (cancel_of_ne hb).tsub_eq_of_eq_add_rev
-
-/-- Weaker version of `ENNReal.sub_eq_of_eq_add_rev` assuming that `a = b + c` itself is finite
-rather than `b`. -/
-protected lemma sub_eq_of_eq_add_rev' (ha : a ≠ ∞) : a = b + c → a - b = c :=
-  (cancel_of_ne ha).tsub_eq_of_eq_add_rev'
-
-@[deprecated ENNReal.sub_eq_of_eq_add (since := "2024-09-30")]
-theorem sub_eq_of_add_eq (hb : b ≠ ∞) (hc : a + b = c) : c - b = a :=
-  ENNReal.sub_eq_of_eq_add hb hc.symm
-
-@[simp]
-protected theorem add_sub_cancel_left (ha : a ≠ ∞) : a + b - a = b :=
-  (cancel_of_ne ha).add_tsub_cancel_left
-
-@[simp]
-protected theorem add_sub_cancel_right (hb : b ≠ ∞) : a + b - b = a :=
-  (cancel_of_ne hb).add_tsub_cancel_right
-
-protected theorem sub_add_eq_add_sub (hab : b ≤ a) (b_ne_top : b ≠ ∞) :
-    a - b + c = a + c - b := by
-  by_cases c_top : c = ∞
-  · simpa [c_top] using ENNReal.eq_sub_of_add_eq b_ne_top rfl
-  refine ENNReal.eq_sub_of_add_eq b_ne_top ?_
-  simp only [add_assoc, add_comm c b]
-  simpa only [← add_assoc] using (add_left_inj c_top).mpr <| tsub_add_cancel_of_le hab
-
-protected theorem lt_add_of_sub_lt_left (h : a ≠ ∞ ∨ b ≠ ∞) : a - b < c → a < b + c := by
-  obtain rfl | hb := eq_or_ne b ∞
-  · rw [top_add, lt_top_iff_ne_top]
-    exact fun _ => h.resolve_right (Classical.not_not.2 rfl)
-  · exact (cancel_of_ne hb).lt_add_of_tsub_lt_left
-
-protected theorem lt_add_of_sub_lt_right (h : a ≠ ∞ ∨ c ≠ ∞) : a - c < b → a < b + c :=
-  add_comm c b ▸ ENNReal.lt_add_of_sub_lt_left h
-
-theorem le_sub_of_add_le_left (ha : a ≠ ∞) : a + b ≤ c → b ≤ c - a :=
-  (cancel_of_ne ha).le_tsub_of_add_le_left
-
-theorem le_sub_of_add_le_right (hb : b ≠ ∞) : a + b ≤ c → a ≤ c - b :=
-  (cancel_of_ne hb).le_tsub_of_add_le_right
-
-protected theorem sub_lt_of_lt_add (hac : c ≤ a) (h : a < b + c) : a - c < b :=
-  ((cancel_of_lt' <| hac.trans_lt h).tsub_lt_iff_right hac).mpr h
-
-protected theorem sub_lt_iff_lt_right (hb : b ≠ ∞) (hab : b ≤ a) : a - b < c ↔ a < c + b :=
-  (cancel_of_ne hb).tsub_lt_iff_right hab
-
-protected theorem sub_lt_self (ha : a ≠ ∞) (ha₀ : a ≠ 0) (hb : b ≠ 0) : a - b < a :=
-  (cancel_of_ne ha).tsub_lt_self (pos_iff_ne_zero.2 ha₀) (pos_iff_ne_zero.2 hb)
-
-protected theorem sub_lt_self_iff (ha : a ≠ ∞) : a - b < a ↔ 0 < a ∧ 0 < b :=
-  (cancel_of_ne ha).tsub_lt_self_iff
-
-theorem sub_lt_of_sub_lt (h₂ : c ≤ a) (h₃ : a ≠ ∞ ∨ b ≠ ∞) (h₁ : a - b < c) : a - c < b :=
-  ENNReal.sub_lt_of_lt_add h₂ (add_comm c b ▸ ENNReal.lt_add_of_sub_lt_right h₃ h₁)
-
-theorem sub_sub_cancel (h : a ≠ ∞) (h2 : b ≤ a) : a - (a - b) = b :=
-  (cancel_of_ne <| sub_ne_top h).tsub_tsub_cancel_of_le h2
-
-theorem sub_right_inj {a b c : ℝ≥0∞} (ha : a ≠ ∞) (hb : b ≤ a) (hc : c ≤ a) :
-    a - b = a - c ↔ b = c :=
-  (cancel_of_ne ha).tsub_right_inj (cancel_of_ne <| ne_top_of_le_ne_top ha hb)
-    (cancel_of_ne <| ne_top_of_le_ne_top ha hc) hb hc
-
-protected theorem sub_mul (h : 0 < b → b < a → c ≠ ∞) : (a - b) * c = a * c - b * c := by
-  rcases le_or_lt a b with hab | hab; · simp [hab, mul_right_mono hab, tsub_eq_zero_of_le]
-  rcases eq_or_lt_of_le (zero_le b) with (rfl | hb); · simp
-  exact (cancel_of_ne <| mul_ne_top hab.ne_top (h hb hab)).tsub_mul
-
-protected theorem mul_sub (h : 0 < c → c < b → a ≠ ∞) : a * (b - c) = a * b - a * c := by
-  simp only [mul_comm a]
-  exact ENNReal.sub_mul h
-
-theorem sub_le_sub_iff_left (h : c ≤ a) (h' : a ≠ ∞) :
-    (a - b ≤ a - c) ↔ c ≤ b :=
-  (cancel_of_ne h').tsub_le_tsub_iff_left (cancel_of_ne (ne_top_of_le_ne_top h' h)) h
-
-end Sub
 
 section Sum
 
@@ -491,82 +122,32 @@ theorem exists_le_of_sum_le {s : Finset α} (hs : s.Nonempty) {f g : α → ℝ�
 
 end Sum
 
-section Interval
+section Inv
 
-variable {x y z : ℝ≥0∞} {ε ε₁ ε₂ : ℝ≥0∞} {s : Set ℝ≥0∞}
+lemma prod_inv_distrib {ι : Type*} {f : ι → ℝ≥0∞} {s : Finset ι}
+    (hf : s.toSet.Pairwise fun i j ↦ f i ≠ 0 ∨ f j ≠ ∞) : (∏ i ∈ s, f i)⁻¹ = ∏ i ∈ s, (f i)⁻¹ := by
+  induction' s using Finset.cons_induction with i s hi ih
+  · simp
+  simp [← ih (hf.mono <| by simp)]
+  refine ENNReal.mul_inv (not_or_of_imp fun hi₀ ↦ prod_ne_top fun j hj ↦ ?_)
+    (not_or_of_imp fun hi₀ ↦ Finset.prod_ne_zero_iff.2 fun j hj ↦ ?_)
+  · exact imp_iff_not_or.2 (hf (by simp) (by simp [hj]) <| .symm <| ne_of_mem_of_not_mem hj hi) hi₀
+  · exact imp_iff_not_or.2 (hf (by simp [hj]) (by simp) <| ne_of_mem_of_not_mem hj hi).symm hi₀
 
-protected theorem Ico_eq_Iio : Ico 0 y = Iio y :=
-  Ico_bot
+lemma finsetSum_iSup {α ι : Type*} {s : Finset α} {f : α → ι → ℝ≥0∞}
+    (hf : ∀ i j, ∃ k, ∀ a, f a i ≤ f a k ∧ f a j ≤ f a k) :
+    ∑ a ∈ s, ⨆ i, f a i = ⨆ i, ∑ a ∈ s, f a i := by
+  induction' s using Finset.cons_induction with a s ha ihs
+  · simp
+  simp_rw [Finset.sum_cons, ihs]
+  refine iSup_add_iSup fun i j ↦ (hf i j).imp fun k hk ↦ ?_
+  gcongr
+  exacts [(hk a).1, (hk _).2]
 
-theorem mem_Iio_self_add : x ≠ ∞ → ε ≠ 0 → x ∈ Iio (x + ε) := fun xt ε0 => lt_add_right xt ε0
+lemma finsetSum_iSup_of_monotone {α ι : Type*} [Preorder ι] [IsDirected ι (· ≤ ·)] {s : Finset α}
+    {f : α → ι → ℝ≥0∞} (hf : ∀ a, Monotone (f a)) : (∑ a ∈ s, iSup (f a)) = ⨆ n, ∑ a ∈ s, f a n :=
+  finsetSum_iSup fun i j ↦ (exists_ge_ge i j).imp fun _k ⟨hi, hj⟩ a ↦ ⟨hf a hi, hf a hj⟩
 
-theorem mem_Ioo_self_sub_add : x ≠ ∞ → x ≠ 0 → ε₁ ≠ 0 → ε₂ ≠ 0 → x ∈ Ioo (x - ε₁) (x + ε₂) :=
-  fun xt x0 ε0 ε0' => ⟨ENNReal.sub_lt_self xt x0 ε0, lt_add_right xt ε0'⟩
-
-end Interval
-
--- TODO: generalize some of these to `WithTop α`
-section Actions
-
-/-- A `MulAction` over `ℝ≥0∞` restricts to a `MulAction` over `ℝ≥0`. -/
-noncomputable instance {M : Type*} [MulAction ℝ≥0∞ M] : MulAction ℝ≥0 M :=
-  MulAction.compHom M ofNNRealHom.toMonoidHom
-
-theorem smul_def {M : Type*} [MulAction ℝ≥0∞ M] (c : ℝ≥0) (x : M) : c • x = (c : ℝ≥0∞) • x :=
-  rfl
-
-instance {M N : Type*} [MulAction ℝ≥0∞ M] [MulAction ℝ≥0∞ N] [SMul M N] [IsScalarTower ℝ≥0∞ M N] :
-    IsScalarTower ℝ≥0 M N where smul_assoc r := smul_assoc (r : ℝ≥0∞)
-
-instance smulCommClass_left {M N : Type*} [MulAction ℝ≥0∞ N] [SMul M N] [SMulCommClass ℝ≥0∞ M N] :
-    SMulCommClass ℝ≥0 M N where smul_comm r := smul_comm (r : ℝ≥0∞)
-
-instance smulCommClass_right {M N : Type*} [MulAction ℝ≥0∞ N] [SMul M N] [SMulCommClass M ℝ≥0∞ N] :
-    SMulCommClass M ℝ≥0 N where smul_comm m r := smul_comm m (r : ℝ≥0∞)
-
-/-- A `DistribMulAction` over `ℝ≥0∞` restricts to a `DistribMulAction` over `ℝ≥0`. -/
-noncomputable instance {M : Type*} [AddMonoid M] [DistribMulAction ℝ≥0∞ M] :
-    DistribMulAction ℝ≥0 M :=
-  DistribMulAction.compHom M ofNNRealHom.toMonoidHom
-
-/-- A `Module` over `ℝ≥0∞` restricts to a `Module` over `ℝ≥0`. -/
-noncomputable instance {M : Type*} [AddCommMonoid M] [Module ℝ≥0∞ M] : Module ℝ≥0 M :=
-  Module.compHom M ofNNRealHom
-
-/-- An `Algebra` over `ℝ≥0∞` restricts to an `Algebra` over `ℝ≥0`. -/
-noncomputable instance {A : Type*} [Semiring A] [Algebra ℝ≥0∞ A] : Algebra ℝ≥0 A where
-  smul := (· • ·)
-  commutes' r x := by simp [Algebra.commutes]
-  smul_def' r x := by simp [← Algebra.smul_def (r : ℝ≥0∞) x, smul_def]
-  algebraMap := (algebraMap ℝ≥0∞ A).comp (ofNNRealHom : ℝ≥0 →+* ℝ≥0∞)
-
--- verify that the above produces instances we might care about
-noncomputable example : Algebra ℝ≥0 ℝ≥0∞ := inferInstance
-
-noncomputable example : DistribMulAction ℝ≥0ˣ ℝ≥0∞ := inferInstance
-
-theorem coe_smul {R} (r : R) (s : ℝ≥0) [SMul R ℝ≥0] [SMul R ℝ≥0∞] [IsScalarTower R ℝ≥0 ℝ≥0]
-    [IsScalarTower R ℝ≥0 ℝ≥0∞] : (↑(r • s) : ℝ≥0∞) = (r : R) • (s : ℝ≥0∞) := by
-  rw [← smul_one_smul ℝ≥0 r (s : ℝ≥0∞), smul_def, smul_eq_mul, ← ENNReal.coe_mul, smul_mul_assoc,
-    one_mul]
-
--- Porting note: added missing `DecidableEq R`
-theorem smul_top {R} [Zero R] [SMulWithZero R ℝ≥0∞] [IsScalarTower R ℝ≥0∞ ℝ≥0∞]
-    [NoZeroSMulDivisors R ℝ≥0∞] [DecidableEq R] (c : R) :
-    c • ∞ = if c = 0 then 0 else ∞ := by
-  rw [← smul_one_mul, mul_top']
-  -- Porting note: need the primed version of `one_ne_zero` now
-  simp_rw [smul_eq_zero, or_iff_left (one_ne_zero' ℝ≥0∞)]
-
-lemma nnreal_smul_lt_top {x : ℝ≥0} {y : ℝ≥0∞} (hy : y < ⊤) : x • y < ⊤ := mul_lt_top (by simp) hy
-lemma nnreal_smul_ne_top {x : ℝ≥0} {y : ℝ≥0∞} (hy : y ≠ ⊤) : x • y ≠ ⊤ := mul_ne_top (by simp) hy
-
-lemma nnreal_smul_ne_top_iff {x : ℝ≥0} {y : ℝ≥0∞} (hx : x ≠ 0) : x • y ≠ ⊤ ↔ y ≠ ⊤ :=
-  ⟨by rintro h rfl; simp [smul_top, hx] at h, nnreal_smul_ne_top⟩
-
-lemma nnreal_smul_lt_top_iff {x : ℝ≥0} {y : ℝ≥0∞} (hx : x ≠ 0) : x • y < ⊤ ↔ y < ⊤ := by
-  rw [lt_top_iff_ne_top, lt_top_iff_ne_top, nnreal_smul_ne_top_iff hx]
-
-end Actions
+end Inv
 
 end ENNReal

--- a/Mathlib/Data/ENNReal/Order.lean
+++ b/Mathlib/Data/ENNReal/Order.lean
@@ -1,0 +1,472 @@
+/-
+Copyright (c) 2017 Johannes Hölzl. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Johannes Hölzl, Yury Kudryashov
+-/
+import Mathlib.Data.ENNReal.Real
+
+/-!
+# Properties of addition, multiplication and subtraction on extended non-negative real numbers
+
+In this file we prove elementary properties of algebraic operations on `ℝ≥0∞`, including addition,
+multiplication, natural powers and truncated subtraction, as well as how these interact with the
+order structure on `ℝ≥0∞`. Notably excluded from this list are inversion and division, the
+definitions and properties of which can be found in `Mathlib.Data.ENNReal.Inv`.
+
+Note: the definitions of the operations included in this file can be found in
+`Mathlib.Data.ENNReal.Basic`.
+-/
+
+assert_not_exists Finset
+
+open Set NNReal ENNReal
+
+namespace ENNReal
+
+variable {a b c d : ℝ≥0∞} {r p q : ℝ≥0}
+
+section Mul
+
+@[mono, gcongr]
+theorem mul_lt_mul (ac : a < c) (bd : b < d) : a * b < c * d := WithTop.mul_lt_mul ac bd
+
+@[deprecated mul_left_mono (since := "2024-10-15")]
+protected theorem mul_left_mono : Monotone (a * ·) := mul_left_mono
+
+@[deprecated mul_right_mono (since := "2024-10-15")]
+protected theorem mul_right_mono : Monotone (· * a) := mul_right_mono
+
+protected lemma pow_right_strictMono {n : ℕ} (hn : n ≠ 0) : StrictMono fun a : ℝ≥0∞ ↦ a ^ n :=
+  WithTop.pow_right_strictMono hn
+
+@[deprecated (since := "2024-10-15")] alias pow_strictMono := ENNReal.pow_right_strictMono
+
+@[gcongr] protected lemma pow_lt_pow_left (hab : a < b) {n : ℕ} (hn : n ≠ 0) : a ^ n < b ^ n :=
+  WithTop.pow_lt_pow_left hab hn
+
+@[deprecated max_mul (since := "2024-10-15")]
+protected theorem max_mul : max a b * c = max (a * c) (b * c) := mul_right_mono.map_max
+
+@[deprecated mul_max (since := "2024-10-15")]
+protected theorem mul_max : a * max b c = max (a * b) (a * c) := mul_left_mono.map_max
+
+-- Porting note (https://github.com/leanprover-community/mathlib4/issues/11215): TODO: generalize to `WithTop`
+theorem mul_left_strictMono (h0 : a ≠ 0) (hinf : a ≠ ∞) : StrictMono (a * ·) := by
+  lift a to ℝ≥0 using hinf
+  rw [coe_ne_zero] at h0
+  intro x y h
+  contrapose! h
+  simpa only [← mul_assoc, ← coe_mul, inv_mul_cancel₀ h0, coe_one, one_mul]
+    using mul_le_mul_left' h (↑a⁻¹)
+
+@[gcongr] protected theorem mul_lt_mul_left' (h0 : a ≠ 0) (hinf : a ≠ ⊤) (bc : b < c) :
+    a * b < a * c :=
+  ENNReal.mul_left_strictMono h0 hinf bc
+
+@[gcongr] protected theorem mul_lt_mul_right' (h0 : a ≠ 0) (hinf : a ≠ ⊤) (bc : b < c) :
+    b * a < c * a :=
+  mul_comm b a ▸ mul_comm c a ▸ ENNReal.mul_left_strictMono h0 hinf bc
+
+-- Porting note (https://github.com/leanprover-community/mathlib4/issues/11215): TODO: generalize to `WithTop`
+protected theorem mul_right_inj (h0 : a ≠ 0) (hinf : a ≠ ∞) : a * b = a * c ↔ b = c :=
+  (mul_left_strictMono h0 hinf).injective.eq_iff
+
+@[deprecated (since := "2025-01-20")]
+alias mul_eq_mul_left := ENNReal.mul_right_inj
+
+-- Porting note (https://github.com/leanprover-community/mathlib4/issues/11215): TODO: generalize to `WithTop`
+protected theorem mul_left_inj (h0 : c ≠ 0) (hinf : c ≠ ∞) : a * c = b * c ↔ a = b :=
+  mul_comm c a ▸ mul_comm c b ▸ ENNReal.mul_right_inj h0 hinf
+
+@[deprecated (since := "2025-01-20")]
+alias mul_eq_mul_right := ENNReal.mul_left_inj
+
+-- Porting note (https://github.com/leanprover-community/mathlib4/issues/11215): TODO: generalize to `WithTop`
+theorem mul_le_mul_left (h0 : a ≠ 0) (hinf : a ≠ ∞) : a * b ≤ a * c ↔ b ≤ c :=
+  (mul_left_strictMono h0 hinf).le_iff_le
+
+-- Porting note (https://github.com/leanprover-community/mathlib4/issues/11215): TODO: generalize to `WithTop`
+theorem mul_le_mul_right : c ≠ 0 → c ≠ ∞ → (a * c ≤ b * c ↔ a ≤ b) :=
+  mul_comm c a ▸ mul_comm c b ▸ mul_le_mul_left
+
+-- Porting note (https://github.com/leanprover-community/mathlib4/issues/11215): TODO: generalize to `WithTop`
+theorem mul_lt_mul_left (h0 : a ≠ 0) (hinf : a ≠ ∞) : a * b < a * c ↔ b < c :=
+  (mul_left_strictMono h0 hinf).lt_iff_lt
+
+-- Porting note (https://github.com/leanprover-community/mathlib4/issues/11215): TODO: generalize to `WithTop`
+theorem mul_lt_mul_right : c ≠ 0 → c ≠ ∞ → (a * c < b * c ↔ a < b) :=
+  mul_comm c a ▸ mul_comm c b ▸ mul_lt_mul_left
+
+protected lemma mul_eq_left (ha₀ : a ≠ 0) (ha : a ≠ ∞) : a * b = a ↔ b = 1 := by
+  simpa using ENNReal.mul_right_inj ha₀ ha (c := 1)
+
+protected lemma mul_eq_right (hb₀ : b ≠ 0) (hb : b ≠ ∞) : a * b = b ↔ a = 1 := by
+  simpa using ENNReal.mul_left_inj hb₀ hb (b := 1)
+
+end Mul
+
+section OperationsAndOrder
+
+protected theorem pow_pos : 0 < a → ∀ n : ℕ, 0 < a ^ n :=
+  CanonicallyOrderedAdd.pow_pos
+
+protected theorem pow_ne_zero : a ≠ 0 → ∀ n : ℕ, a ^ n ≠ 0 := by
+  simpa only [pos_iff_ne_zero] using ENNReal.pow_pos
+
+theorem not_lt_zero : ¬a < 0 := by simp
+
+protected theorem le_of_add_le_add_left : a ≠ ∞ → a + b ≤ a + c → b ≤ c :=
+  WithTop.le_of_add_le_add_left
+
+protected theorem le_of_add_le_add_right : a ≠ ∞ → b + a ≤ c + a → b ≤ c :=
+  WithTop.le_of_add_le_add_right
+
+@[gcongr] protected theorem add_lt_add_left : a ≠ ∞ → b < c → a + b < a + c :=
+  WithTop.add_lt_add_left
+
+@[gcongr] protected theorem add_lt_add_right : a ≠ ∞ → b < c → b + a < c + a :=
+  WithTop.add_lt_add_right
+
+protected theorem add_le_add_iff_left : a ≠ ∞ → (a + b ≤ a + c ↔ b ≤ c) :=
+  WithTop.add_le_add_iff_left
+
+protected theorem add_le_add_iff_right : a ≠ ∞ → (b + a ≤ c + a ↔ b ≤ c) :=
+  WithTop.add_le_add_iff_right
+
+protected theorem add_lt_add_iff_left : a ≠ ∞ → (a + b < a + c ↔ b < c) :=
+  WithTop.add_lt_add_iff_left
+
+protected theorem add_lt_add_iff_right : a ≠ ∞ → (b + a < c + a ↔ b < c) :=
+  WithTop.add_lt_add_iff_right
+
+protected theorem add_lt_add_of_le_of_lt : a ≠ ∞ → a ≤ b → c < d → a + c < b + d :=
+  WithTop.add_lt_add_of_le_of_lt
+
+protected theorem add_lt_add_of_lt_of_le : c ≠ ∞ → a < b → c ≤ d → a + c < b + d :=
+  WithTop.add_lt_add_of_lt_of_le
+
+instance addLeftReflectLT : AddLeftReflectLT ℝ≥0∞ :=
+  WithTop.addLeftReflectLT
+
+theorem lt_add_right (ha : a ≠ ∞) (hb : b ≠ 0) : a < a + b := by
+  rwa [← pos_iff_ne_zero, ← ENNReal.add_lt_add_iff_left ha, add_zero] at hb
+
+end OperationsAndOrder
+
+section OperationsAndInfty
+
+variable {α : Type*}
+
+@[simp] theorem add_eq_top : a + b = ∞ ↔ a = ∞ ∨ b = ∞ := WithTop.add_eq_top
+
+@[simp] theorem add_lt_top : a + b < ∞ ↔ a < ∞ ∧ b < ∞ := WithTop.add_lt_top
+
+theorem toNNReal_add {r₁ r₂ : ℝ≥0∞} (h₁ : r₁ ≠ ∞) (h₂ : r₂ ≠ ∞) :
+    (r₁ + r₂).toNNReal = r₁.toNNReal + r₂.toNNReal := by
+  lift r₁ to ℝ≥0 using h₁
+  lift r₂ to ℝ≥0 using h₂
+  rfl
+
+/-- If `a ≤ b + c` and `a = ∞` whenever `b = ∞` or `c = ∞`, then
+`ENNReal.toReal a ≤ ENNReal.toReal b + ENNReal.toReal c`. This lemma is useful to transfer
+triangle-like inequalities from `ENNReal`s to `Real`s. -/
+theorem toReal_le_add' (hle : a ≤ b + c) (hb : b = ∞ → a = ∞) (hc : c = ∞ → a = ∞) :
+    a.toReal ≤ b.toReal + c.toReal := by
+  refine le_trans (toReal_mono' hle ?_) toReal_add_le
+  simpa only [add_eq_top, or_imp] using And.intro hb hc
+
+/-- If `a ≤ b + c`, `b ≠ ∞`, and `c ≠ ∞`, then
+`ENNReal.toReal a ≤ ENNReal.toReal b + ENNReal.toReal c`. This lemma is useful to transfer
+triangle-like inequalities from `ENNReal`s to `Real`s. -/
+theorem toReal_le_add (hle : a ≤ b + c) (hb : b ≠ ∞) (hc : c ≠ ∞) :
+    a.toReal ≤ b.toReal + c.toReal :=
+  toReal_le_add' hle (flip absurd hb) (flip absurd hc)
+
+theorem not_lt_top {x : ℝ≥0∞} : ¬x < ∞ ↔ x = ∞ := by rw [lt_top_iff_ne_top, Classical.not_not]
+
+theorem add_ne_top : a + b ≠ ∞ ↔ a ≠ ∞ ∧ b ≠ ∞ := by simpa only [lt_top_iff_ne_top] using add_lt_top
+
+@[aesop (rule_sets := [finiteness]) safe apply]
+protected lemma Finiteness.add_ne_top {a b : ℝ≥0∞} (ha : a ≠ ∞) (hb : b ≠ ∞) : a + b ≠ ∞ :=
+  ENNReal.add_ne_top.2 ⟨ha, hb⟩
+
+theorem mul_top' : a * ∞ = if a = 0 then 0 else ∞ := by convert WithTop.mul_top' a
+
+-- Porting note: added because `simp` no longer uses `WithTop` lemmas for `ℝ≥0∞`
+@[simp] theorem mul_top (h : a ≠ 0) : a * ∞ = ∞ := WithTop.mul_top h
+
+theorem top_mul' : ∞ * a = if a = 0 then 0 else ∞ := by convert WithTop.top_mul' a
+
+-- Porting note: added because `simp` no longer uses `WithTop` lemmas for `ℝ≥0∞`
+@[simp] theorem top_mul (h : a ≠ 0) : ∞ * a = ∞ := WithTop.top_mul h
+
+theorem top_mul_top : ∞ * ∞ = ∞ := WithTop.top_mul_top
+
+-- Porting note (https://github.com/leanprover-community/mathlib4/issues/11215): TODO: assume `n ≠ 0` instead of `0 < n`
+theorem top_pow {n : ℕ} (n_pos : 0 < n) : (∞ : ℝ≥0∞) ^ n = ∞ := WithTop.top_pow n_pos
+
+theorem mul_eq_top : a * b = ∞ ↔ a ≠ 0 ∧ b = ∞ ∨ a = ∞ ∧ b ≠ 0 :=
+  WithTop.mul_eq_top_iff
+
+theorem mul_lt_top : a < ∞ → b < ∞ → a * b < ∞ := WithTop.mul_lt_top
+
+-- This is unsafe because we could have `a = ∞` and `b = 0` or vice-versa
+@[aesop (rule_sets := [finiteness]) unsafe 75% apply]
+theorem mul_ne_top : a ≠ ∞ → b ≠ ∞ → a * b ≠ ∞ := WithTop.mul_ne_top
+
+theorem lt_top_of_mul_ne_top_left (h : a * b ≠ ∞) (hb : b ≠ 0) : a < ∞ :=
+  lt_top_iff_ne_top.2 fun ha => h <| mul_eq_top.2 (Or.inr ⟨ha, hb⟩)
+
+theorem lt_top_of_mul_ne_top_right (h : a * b ≠ ∞) (ha : a ≠ 0) : b < ∞ :=
+  lt_top_of_mul_ne_top_left (by rwa [mul_comm]) ha
+
+theorem mul_lt_top_iff {a b : ℝ≥0∞} : a * b < ∞ ↔ a < ∞ ∧ b < ∞ ∨ a = 0 ∨ b = 0 := by
+  constructor
+  · intro h
+    rw [← or_assoc, or_iff_not_imp_right, or_iff_not_imp_right]
+    intro hb ha
+    exact ⟨lt_top_of_mul_ne_top_left h.ne hb, lt_top_of_mul_ne_top_right h.ne ha⟩
+  · rintro (⟨ha, hb⟩ | rfl | rfl) <;> [exact mul_lt_top ha hb; simp; simp]
+
+theorem mul_self_lt_top_iff {a : ℝ≥0∞} : a * a < ⊤ ↔ a < ⊤ := by
+  rw [ENNReal.mul_lt_top_iff, and_self, or_self, or_iff_left_iff_imp]
+  rintro rfl
+  exact zero_lt_top
+
+theorem mul_pos_iff : 0 < a * b ↔ 0 < a ∧ 0 < b :=
+  CanonicallyOrderedAdd.mul_pos
+
+theorem mul_pos (ha : a ≠ 0) (hb : b ≠ 0) : 0 < a * b :=
+  mul_pos_iff.2 ⟨pos_iff_ne_zero.2 ha, pos_iff_ne_zero.2 hb⟩
+
+-- Porting note (https://github.com/leanprover-community/mathlib4/issues/11215): TODO: generalize to `WithTop`
+@[simp] theorem pow_eq_top_iff {n : ℕ} : a ^ n = ∞ ↔ a = ∞ ∧ n ≠ 0 := by
+  rcases n.eq_zero_or_pos with rfl | (hn : 0 < n)
+  · simp
+  · induction a
+    · simp only [Ne, hn.ne', top_pow hn, not_false_eq_true, and_self]
+    · simp only [← coe_pow, coe_ne_top, false_and]
+
+theorem pow_eq_top (n : ℕ) (h : a ^ n = ∞) : a = ∞ :=
+  (pow_eq_top_iff.1 h).1
+
+theorem pow_ne_top (h : a ≠ ∞) {n : ℕ} : a ^ n ≠ ∞ :=
+  mt (pow_eq_top n) h
+
+theorem pow_lt_top : a < ∞ → ∀ n : ℕ, a ^ n < ∞ := by
+  simpa only [lt_top_iff_ne_top] using pow_ne_top
+
+end OperationsAndInfty
+
+-- Porting note (https://github.com/leanprover-community/mathlib4/issues/11215): TODO: generalize to `WithTop`
+@[gcongr] protected theorem add_lt_add (ac : a < c) (bd : b < d) : a + b < c + d := by
+  lift a to ℝ≥0 using ac.ne_top
+  lift b to ℝ≥0 using bd.ne_top
+  cases c; · simp
+  cases d; · simp
+  simp only [← coe_add, some_eq_coe, coe_lt_coe] at *
+  exact add_lt_add ac bd
+
+section Cancel
+
+-- Porting note (https://github.com/leanprover-community/mathlib4/issues/11215): TODO: generalize to `WithTop`
+/-- An element `a` is `AddLECancellable` if `a + b ≤ a + c` implies `b ≤ c` for all `b` and `c`.
+  This is true in `ℝ≥0∞` for all elements except `∞`. -/
+@[simp]
+theorem addLECancellable_iff_ne {a : ℝ≥0∞} : AddLECancellable a ↔ a ≠ ∞ := by
+  constructor
+  · rintro h rfl
+    refine zero_lt_one.not_le (h ?_)
+    simp
+  · rintro h b c hbc
+    apply ENNReal.le_of_add_le_add_left h hbc
+
+/-- This lemma has an abbreviated name because it is used frequently. -/
+theorem cancel_of_ne {a : ℝ≥0∞} (h : a ≠ ∞) : AddLECancellable a :=
+  addLECancellable_iff_ne.mpr h
+
+/-- This lemma has an abbreviated name because it is used frequently. -/
+theorem cancel_of_lt {a : ℝ≥0∞} (h : a < ∞) : AddLECancellable a :=
+  cancel_of_ne h.ne
+
+/-- This lemma has an abbreviated name because it is used frequently. -/
+theorem cancel_of_lt' {a b : ℝ≥0∞} (h : a < b) : AddLECancellable a :=
+  cancel_of_ne h.ne_top
+
+/-- This lemma has an abbreviated name because it is used frequently. -/
+theorem cancel_coe {a : ℝ≥0} : AddLECancellable (a : ℝ≥0∞) :=
+  cancel_of_ne coe_ne_top
+
+theorem add_right_inj (h : a ≠ ∞) : a + b = a + c ↔ b = c :=
+  (cancel_of_ne h).inj
+
+theorem add_left_inj (h : a ≠ ∞) : b + a = c + a ↔ b = c :=
+  (cancel_of_ne h).inj_left
+
+end Cancel
+
+section Sub
+
+theorem sub_eq_sInf {a b : ℝ≥0∞} : a - b = sInf { d | a ≤ d + b } :=
+  le_antisymm (le_sInf fun _ h => tsub_le_iff_right.mpr h) <| sInf_le <| mem_setOf.2 le_tsub_add
+
+/-- This is a special case of `WithTop.coe_sub` in the `ENNReal` namespace -/
+@[simp, norm_cast] theorem coe_sub : (↑(r - p) : ℝ≥0∞) = ↑r - ↑p := WithTop.coe_sub
+
+/-- This is a special case of `WithTop.top_sub_coe` in the `ENNReal` namespace -/
+@[simp] theorem top_sub_coe : ∞ - ↑r = ∞ := WithTop.top_sub_coe
+
+@[simp] lemma top_sub (ha : a ≠ ∞) : ∞ - a = ∞ := by lift a to ℝ≥0 using ha; exact top_sub_coe
+
+/-- This is a special case of `WithTop.sub_top` in the `ENNReal` namespace -/
+theorem sub_top : a - ∞ = 0 := WithTop.sub_top
+
+@[simp] theorem sub_eq_top_iff : a - b = ∞ ↔ a = ∞ ∧ b ≠ ∞ := WithTop.sub_eq_top_iff
+lemma sub_ne_top_iff : a - b ≠ ∞ ↔ a ≠ ∞ ∨ b = ∞ := WithTop.sub_ne_top_iff
+
+-- This is unsafe because we could have `a = b = ∞`
+@[aesop (rule_sets := [finiteness]) unsafe 75% apply]
+theorem sub_ne_top (ha : a ≠ ∞) : a - b ≠ ∞ := mt sub_eq_top_iff.mp <| mt And.left ha
+
+@[simp, norm_cast]
+theorem natCast_sub (m n : ℕ) : ↑(m - n) = (m - n : ℝ≥0∞) := by
+  rw [← coe_natCast, Nat.cast_tsub, coe_sub, coe_natCast, coe_natCast]
+
+/-- See `ENNReal.sub_eq_of_eq_add'` for a version assuming that `a = c + b` itself is finite rather
+than `b`. -/
+protected theorem sub_eq_of_eq_add (hb : b ≠ ∞) : a = c + b → a - b = c :=
+  (cancel_of_ne hb).tsub_eq_of_eq_add
+
+/-- Weaker version of `ENNReal.sub_eq_of_eq_add` assuming that `a = c + b` itself is finite rather
+han `b`. -/
+protected lemma sub_eq_of_eq_add' (ha : a ≠ ∞) : a = c + b → a - b = c :=
+  (cancel_of_ne ha).tsub_eq_of_eq_add'
+
+/-- See `ENNReal.eq_sub_of_add_eq'` for a version assuming that `b = a + c` itself is finite rather
+than `c`. -/
+protected theorem eq_sub_of_add_eq (hc : c ≠ ∞) : a + c = b → a = b - c :=
+  (cancel_of_ne hc).eq_tsub_of_add_eq
+
+/-- Weaker version of `ENNReal.eq_sub_of_add_eq` assuming that `b = a + c` itself is finite rather
+than `c`. -/
+protected lemma eq_sub_of_add_eq' (hb : b ≠ ∞) : a + c = b → a = b - c :=
+  (cancel_of_ne hb).eq_tsub_of_add_eq'
+
+/-- See `ENNReal.sub_eq_of_eq_add_rev'` for a version assuming that `a = b + c` itself is finite
+rather than `b`. -/
+protected theorem sub_eq_of_eq_add_rev (hb : b ≠ ∞) : a = b + c → a - b = c :=
+  (cancel_of_ne hb).tsub_eq_of_eq_add_rev
+
+/-- Weaker version of `ENNReal.sub_eq_of_eq_add_rev` assuming that `a = b + c` itself is finite
+rather than `b`. -/
+protected lemma sub_eq_of_eq_add_rev' (ha : a ≠ ∞) : a = b + c → a - b = c :=
+  (cancel_of_ne ha).tsub_eq_of_eq_add_rev'
+
+@[deprecated ENNReal.sub_eq_of_eq_add (since := "2024-09-30")]
+theorem sub_eq_of_add_eq (hb : b ≠ ∞) (hc : a + b = c) : c - b = a :=
+  ENNReal.sub_eq_of_eq_add hb hc.symm
+
+@[simp]
+protected theorem add_sub_cancel_left (ha : a ≠ ∞) : a + b - a = b :=
+  (cancel_of_ne ha).add_tsub_cancel_left
+
+@[simp]
+protected theorem add_sub_cancel_right (hb : b ≠ ∞) : a + b - b = a :=
+  (cancel_of_ne hb).add_tsub_cancel_right
+
+protected theorem sub_add_eq_add_sub (hab : b ≤ a) (b_ne_top : b ≠ ∞) :
+    a - b + c = a + c - b := by
+  by_cases c_top : c = ∞
+  · simpa [c_top] using ENNReal.eq_sub_of_add_eq b_ne_top rfl
+  refine ENNReal.eq_sub_of_add_eq b_ne_top ?_
+  simp only [add_assoc, add_comm c b]
+  simpa only [← add_assoc] using (add_left_inj c_top).mpr <| tsub_add_cancel_of_le hab
+
+protected theorem lt_add_of_sub_lt_left (h : a ≠ ∞ ∨ b ≠ ∞) : a - b < c → a < b + c := by
+  obtain rfl | hb := eq_or_ne b ∞
+  · rw [top_add, lt_top_iff_ne_top]
+    exact fun _ => h.resolve_right (Classical.not_not.2 rfl)
+  · exact (cancel_of_ne hb).lt_add_of_tsub_lt_left
+
+protected theorem lt_add_of_sub_lt_right (h : a ≠ ∞ ∨ c ≠ ∞) : a - c < b → a < b + c :=
+  add_comm c b ▸ ENNReal.lt_add_of_sub_lt_left h
+
+theorem le_sub_of_add_le_left (ha : a ≠ ∞) : a + b ≤ c → b ≤ c - a :=
+  (cancel_of_ne ha).le_tsub_of_add_le_left
+
+theorem le_sub_of_add_le_right (hb : b ≠ ∞) : a + b ≤ c → a ≤ c - b :=
+  (cancel_of_ne hb).le_tsub_of_add_le_right
+
+protected theorem sub_lt_of_lt_add (hac : c ≤ a) (h : a < b + c) : a - c < b :=
+  ((cancel_of_lt' <| hac.trans_lt h).tsub_lt_iff_right hac).mpr h
+
+protected theorem sub_lt_iff_lt_right (hb : b ≠ ∞) (hab : b ≤ a) : a - b < c ↔ a < c + b :=
+  (cancel_of_ne hb).tsub_lt_iff_right hab
+
+protected theorem sub_lt_self (ha : a ≠ ∞) (ha₀ : a ≠ 0) (hb : b ≠ 0) : a - b < a :=
+  (cancel_of_ne ha).tsub_lt_self (pos_iff_ne_zero.2 ha₀) (pos_iff_ne_zero.2 hb)
+
+protected theorem sub_lt_self_iff (ha : a ≠ ∞) : a - b < a ↔ 0 < a ∧ 0 < b :=
+  (cancel_of_ne ha).tsub_lt_self_iff
+
+theorem sub_lt_of_sub_lt (h₂ : c ≤ a) (h₃ : a ≠ ∞ ∨ b ≠ ∞) (h₁ : a - b < c) : a - c < b :=
+  ENNReal.sub_lt_of_lt_add h₂ (add_comm c b ▸ ENNReal.lt_add_of_sub_lt_right h₃ h₁)
+
+theorem sub_sub_cancel (h : a ≠ ∞) (h2 : b ≤ a) : a - (a - b) = b :=
+  (cancel_of_ne <| sub_ne_top h).tsub_tsub_cancel_of_le h2
+
+theorem sub_right_inj {a b c : ℝ≥0∞} (ha : a ≠ ∞) (hb : b ≤ a) (hc : c ≤ a) :
+    a - b = a - c ↔ b = c :=
+  (cancel_of_ne ha).tsub_right_inj (cancel_of_ne <| ne_top_of_le_ne_top ha hb)
+    (cancel_of_ne <| ne_top_of_le_ne_top ha hc) hb hc
+
+protected theorem sub_mul (h : 0 < b → b < a → c ≠ ∞) : (a - b) * c = a * c - b * c := by
+  rcases le_or_lt a b with hab | hab; · simp [hab, mul_right_mono hab, tsub_eq_zero_of_le]
+  rcases eq_or_lt_of_le (zero_le b) with (rfl | hb); · simp
+  exact (cancel_of_ne <| mul_ne_top hab.ne_top (h hb hab)).tsub_mul
+
+protected theorem mul_sub (h : 0 < c → c < b → a ≠ ∞) : a * (b - c) = a * b - a * c := by
+  simp only [mul_comm a]
+  exact ENNReal.sub_mul h
+
+theorem sub_le_sub_iff_left (h : c ≤ a) (h' : a ≠ ∞) :
+    (a - b ≤ a - c) ↔ c ≤ b :=
+  (cancel_of_ne h').tsub_le_tsub_iff_left (cancel_of_ne (ne_top_of_le_ne_top h' h)) h
+
+theorem toReal_sub_of_le {a b : ℝ≥0∞} (h : b ≤ a) (ha : a ≠ ∞) :
+    (a - b).toReal = a.toReal - b.toReal := by
+  lift b to ℝ≥0 using ne_top_of_le_ne_top ha h
+  lift a to ℝ≥0 using ha
+  simp only [← ENNReal.coe_sub, ENNReal.coe_toReal, NNReal.coe_sub (ENNReal.coe_le_coe.mp h)]
+
+theorem le_toReal_sub {a b : ℝ≥0∞} (hb : b ≠ ∞) : a.toReal - b.toReal ≤ (a - b).toReal := by
+  lift b to ℝ≥0 using hb
+  induction a
+  · simp
+  · simp only [← coe_sub, NNReal.sub_def, Real.coe_toNNReal', coe_toReal]
+    exact le_max_left _ _
+
+theorem ofReal_sub (p : ℝ) {q : ℝ} (hq : 0 ≤ q) :
+    ENNReal.ofReal (p - q) = ENNReal.ofReal p - ENNReal.ofReal q := by
+  obtain h | h := le_total p q
+  · rw [ofReal_of_nonpos (sub_nonpos_of_le h), tsub_eq_zero_of_le (ofReal_le_ofReal h)]
+  refine ENNReal.eq_sub_of_add_eq ofReal_ne_top ?_
+  rw [← ofReal_add (sub_nonneg_of_le h) hq, sub_add_cancel]
+
+end Sub
+
+section Interval
+
+variable {x y z : ℝ≥0∞} {ε ε₁ ε₂ : ℝ≥0∞} {s : Set ℝ≥0∞}
+
+protected theorem Ico_eq_Iio : Ico 0 y = Iio y :=
+  Ico_bot
+
+theorem mem_Iio_self_add : x ≠ ∞ → ε ≠ 0 → x ∈ Iio (x + ε) := fun xt ε0 => lt_add_right xt ε0
+
+theorem mem_Ioo_self_sub_add : x ≠ ∞ → x ≠ 0 → ε₁ ≠ 0 → ε₂ ≠ 0 → x ∈ Ioo (x - ε₁) (x + ε₂) :=
+  fun xt x0 ε0 ε0' => ⟨ENNReal.sub_lt_self xt x0 ε0, lt_add_right xt ε0'⟩
+
+end Interval
+
+end ENNReal

--- a/Mathlib/Data/ENNReal/Real.lean
+++ b/Mathlib/Data/ENNReal/Real.lean
@@ -3,8 +3,7 @@ Copyright (c) 2017 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Yury Kudryashov
 -/
-import Mathlib.Data.ENNReal.Inv
-import Mathlib.Tactic.Bound.Attribute
+import Mathlib.Data.ENNReal.Basic
 
 /-!
 # Maps between real and extended non-negative real numbers
@@ -25,6 +24,8 @@ This file provides a `positivity` extension for `ENNReal.ofReal`.
     `ℝ≥0∞` is a complete lattice.
 -/
 
+assert_not_exists Finset
+
 open Set NNReal ENNReal
 
 namespace ENNReal
@@ -37,19 +38,6 @@ theorem toReal_add (ha : a ≠ ∞) (hb : b ≠ ∞) : (a + b).toReal = a.toReal
   lift a to ℝ≥0 using ha
   lift b to ℝ≥0 using hb
   rfl
-
-theorem toReal_sub_of_le {a b : ℝ≥0∞} (h : b ≤ a) (ha : a ≠ ∞) :
-    (a - b).toReal = a.toReal - b.toReal := by
-  lift b to ℝ≥0 using ne_top_of_le_ne_top ha h
-  lift a to ℝ≥0 using ha
-  simp only [← ENNReal.coe_sub, ENNReal.coe_toReal, NNReal.coe_sub (ENNReal.coe_le_coe.mp h)]
-
-theorem le_toReal_sub {a b : ℝ≥0∞} (hb : b ≠ ∞) : a.toReal - b.toReal ≤ (a - b).toReal := by
-  lift b to ℝ≥0 using hb
-  induction a
-  · simp
-  · simp only [← coe_sub, NNReal.sub_def, Real.coe_toNNReal', coe_toReal]
-    exact le_max_left _ _
 
 theorem toReal_add_le : (a + b).toReal ≤ a.toReal + b.toReal :=
   if ha : a = ∞ then by simp only [ha, top_add, top_toReal, zero_add, toReal_nonneg]
@@ -96,21 +84,6 @@ theorem toNNReal_mono (hb : b ≠ ∞) (h : a ≤ b) : a.toNNReal ≤ b.toNNReal
 
 theorem le_toNNReal_of_coe_le (h : p ≤ a) (ha : a ≠ ∞) : p ≤ a.toNNReal :=
   @toNNReal_coe p ▸ toNNReal_mono ha h
-
-/-- If `a ≤ b + c` and `a = ∞` whenever `b = ∞` or `c = ∞`, then
-`ENNReal.toReal a ≤ ENNReal.toReal b + ENNReal.toReal c`. This lemma is useful to transfer
-triangle-like inequalities from `ENNReal`s to `Real`s. -/
-theorem toReal_le_add' (hle : a ≤ b + c) (hb : b = ∞ → a = ∞) (hc : c = ∞ → a = ∞) :
-    a.toReal ≤ b.toReal + c.toReal := by
-  refine le_trans (toReal_mono' hle ?_) toReal_add_le
-  simpa only [add_eq_top, or_imp] using And.intro hb hc
-
-/-- If `a ≤ b + c`, `b ≠ ∞`, and `c ≠ ∞`, then
-`ENNReal.toReal a ≤ ENNReal.toReal b + ENNReal.toReal c`. This lemma is useful to transfer
-triangle-like inequalities from `ENNReal`s to `Real`s. -/
-theorem toReal_le_add (hle : a ≤ b + c) (hb : b ≠ ∞) (hc : c ≠ ∞) :
-    a.toReal ≤ b.toReal + c.toReal :=
-  toReal_le_add' hle (flip absurd hb) (flip absurd hc)
 
 @[simp]
 theorem toNNReal_le_toNNReal (ha : a ≠ ∞) (hb : b ≠ ∞) : a.toNNReal ≤ b.toNNReal ↔ a ≤ b :=
@@ -267,13 +240,6 @@ lemma ofReal_eq_ofNat {r : ℝ} {n : ℕ} [n.AtLeastTwo] :
     ENNReal.ofReal r = ofNat(n) ↔ r = OfNat.ofNat n :=
   ofReal_eq_natCast (NeZero.ne n)
 
-theorem ofReal_sub (p : ℝ) {q : ℝ} (hq : 0 ≤ q) :
-    ENNReal.ofReal (p - q) = ENNReal.ofReal p - ENNReal.ofReal q := by
-  obtain h | h := le_total p q
-  · rw [ofReal_of_nonpos (sub_nonpos_of_le h), tsub_eq_zero_of_le (ofReal_le_ofReal h)]
-  refine ENNReal.eq_sub_of_add_eq ofReal_ne_top ?_
-  rw [← ofReal_add (sub_nonneg_of_le h) hq, sub_add_cancel]
-
 theorem ofReal_le_iff_le_toReal {a : ℝ} {b : ℝ≥0∞} (hb : b ≠ ∞) :
     ENNReal.ofReal a ≤ b ↔ a ≤ ENNReal.toReal b := by
   lift b to ℝ≥0 using hb
@@ -320,14 +286,6 @@ theorem ofReal_pow {p : ℝ} (hp : 0 ≤ p) (n : ℕ) :
 theorem ofReal_nsmul {x : ℝ} {n : ℕ} : ENNReal.ofReal (n • x) = n • ENNReal.ofReal x := by
   simp only [nsmul_eq_mul, ← ofReal_natCast n, ← ofReal_mul n.cast_nonneg]
 
-theorem ofReal_inv_of_pos {x : ℝ} (hx : 0 < x) : ENNReal.ofReal x⁻¹ = (ENNReal.ofReal x)⁻¹ := by
-  rw [ENNReal.ofReal, ENNReal.ofReal, ← @coe_inv (Real.toNNReal x) (by simp [hx]), coe_inj,
-    ← Real.toNNReal_inv]
-
-theorem ofReal_div_of_pos {x y : ℝ} (hy : 0 < y) :
-    ENNReal.ofReal (x / y) = ENNReal.ofReal x / ENNReal.ofReal y := by
-  rw [div_eq_mul_inv, div_eq_mul_inv, ofReal_mul' (inv_nonneg.2 hy.le), ofReal_inv_of_pos hy]
-
 @[simp]
 theorem toNNReal_mul {a b : ℝ≥0∞} : (a * b).toNNReal = a.toNNReal * b.toNNReal :=
   WithTop.untop'_zero_mul a b
@@ -335,11 +293,6 @@ theorem toNNReal_mul {a b : ℝ≥0∞} : (a * b).toNNReal = a.toNNReal * b.toNN
 theorem toNNReal_mul_top (a : ℝ≥0∞) : ENNReal.toNNReal (a * ∞) = 0 := by simp
 
 theorem toNNReal_top_mul (a : ℝ≥0∞) : ENNReal.toNNReal (∞ * a) = 0 := by simp
-
-@[simp]
-theorem smul_toNNReal (a : ℝ≥0) (b : ℝ≥0∞) : (a • b).toNNReal = a * b.toNNReal := by
-  change ((a : ℝ≥0∞) * b).toNNReal = a * b.toNNReal
-  simp only [ENNReal.toNNReal_mul, ENNReal.toNNReal_coe]
 
 -- Porting note (https://github.com/leanprover-community/mathlib4/issues/11215): TODO: upgrade to `→*₀`
 /-- `ENNReal.toNNReal` as a `MonoidHom`. -/
@@ -351,11 +304,6 @@ def toNNRealHom : ℝ≥0∞ →* ℝ≥0 where
 @[simp]
 theorem toNNReal_pow (a : ℝ≥0∞) (n : ℕ) : (a ^ n).toNNReal = a.toNNReal ^ n :=
   toNNRealHom.map_pow a n
-
-@[simp]
-theorem toNNReal_prod {ι : Type*} {s : Finset ι} {f : ι → ℝ≥0∞} :
-    (∏ i ∈ s, f i).toNNReal = ∏ i ∈ s, (f i).toNNReal :=
-  map_prod toNNRealHom _ _
 
 -- Porting note (https://github.com/leanprover-community/mathlib4/issues/11215): TODO: upgrade to `→*₀`
 /-- `ENNReal.toReal` as a `MonoidHom`. -/
@@ -372,11 +320,6 @@ theorem toReal_nsmul (a : ℝ≥0∞) (n : ℕ) : (n • a).toReal = n • a.toR
 theorem toReal_pow (a : ℝ≥0∞) (n : ℕ) : (a ^ n).toReal = a.toReal ^ n :=
   toRealHom.map_pow a n
 
-@[simp]
-theorem toReal_prod {ι : Type*} {s : Finset ι} {f : ι → ℝ≥0∞} :
-    (∏ i ∈ s, f i).toReal = ∏ i ∈ s, (f i).toReal :=
-  map_prod toRealHom _ _
-
 theorem toReal_ofReal_mul (c : ℝ) (a : ℝ≥0∞) (h : 0 ≤ c) :
     ENNReal.toReal (ENNReal.ofReal c * a) = c * ENNReal.toReal a := by
   rw [ENNReal.toReal_mul, ENNReal.toReal_ofReal h]
@@ -392,10 +335,6 @@ theorem toReal_eq_toReal (ha : a ≠ ∞) (hb : b ≠ ∞) : a.toReal = b.toReal
   lift a to ℝ≥0 using ha
   lift b to ℝ≥0 using hb
   simp only [coe_inj, NNReal.coe_inj, coe_toReal]
-
-theorem toReal_smul (r : ℝ≥0) (s : ℝ≥0∞) : (r • s).toReal = r • s.toReal := by
-  rw [ENNReal.smul_def, smul_eq_mul, toReal_mul, coe_toReal]
-  rfl
 
 protected theorem trichotomy (p : ℝ≥0∞) : p = 0 ∨ p = ∞ ∨ 0 < p.toReal := by
   simpa only [or_iff_not_imp_left] using toReal_pos
@@ -425,25 +364,6 @@ theorem toReal_pos_iff_ne_top (p : ℝ≥0∞) [Fact (1 ≤ p)] : 0 < p.toReal �
     have : (0 : ℝ) ≠ 0 := top_toReal ▸ (hp ▸ h.ne : 0 ≠ ∞.toReal)
     this rfl,
     fun h => zero_lt_one.trans_le (p.dichotomy.resolve_left h)⟩
-
-@[simp] theorem toNNReal_inv (a : ℝ≥0∞) : a⁻¹.toNNReal = a.toNNReal⁻¹ := by
-  induction' a with a; · simp
-  rcases eq_or_ne a 0 with (rfl | ha); · simp
-  rw [← coe_inv ha, toNNReal_coe, toNNReal_coe]
-
-@[simp] theorem toNNReal_div (a b : ℝ≥0∞) : (a / b).toNNReal = a.toNNReal / b.toNNReal := by
-  rw [div_eq_mul_inv, toNNReal_mul, toNNReal_inv, div_eq_mul_inv]
-
-@[simp] theorem toReal_inv (a : ℝ≥0∞) : a⁻¹.toReal = a.toReal⁻¹ := by
-  simp only [ENNReal.toReal, toNNReal_inv, NNReal.coe_inv]
-
-@[simp] theorem toReal_div (a b : ℝ≥0∞) : (a / b).toReal = a.toReal / b.toReal := by
-  rw [div_eq_mul_inv, toReal_mul, toReal_inv, div_eq_mul_inv]
-
-theorem ofReal_prod_of_nonneg {α : Type*} {s : Finset α} {f : α → ℝ} (hf : ∀ i, i ∈ s → 0 ≤ f i) :
-    ENNReal.ofReal (∏ i ∈ s, f i) = ∏ i ∈ s, ENNReal.ofReal (f i) := by
-  simp_rw [ENNReal.ofReal, ← coe_finset_prod, coe_inj]
-  exact Real.toNNReal_prod_of_nonneg hf
 
 end Real
 
@@ -531,17 +451,6 @@ theorem iInf_add_iInf (h : ∀ i j, ∃ k, f k + g k ≤ f i + g j) : iInf f + i
     ⨅ a, f a + g a ≤ ⨅ (a) (a'), f a + g a' :=
       le_iInf₂ fun a a' => let ⟨k, h⟩ := h a a'; iInf_le_of_le k h
     _ = iInf f + iInf g := by simp_rw [iInf_add, add_iInf]
-
-theorem iInf_sum {α : Type*} {f : ι → α → ℝ≥0∞} {s : Finset α} [Nonempty ι]
-    (h : ∀ (t : Finset α) (i j : ι), ∃ k, ∀ a ∈ t, f k a ≤ f i a ∧ f k a ≤ f j a) :
-    ⨅ i, ∑ a ∈ s, f i a = ∑ a ∈ s, ⨅ i, f i a := by
-  induction' s using Finset.cons_induction_on with a s ha ih
-  · simp only [Finset.sum_empty, ciInf_const]
-  · simp only [Finset.sum_cons, ← ih]
-    refine (iInf_add_iInf fun i j => ?_).symm
-    refine (h (Finset.cons a s ha) i j).imp fun k hk => ?_
-    rw [Finset.forall_mem_cons] at hk
-    exact add_le_add hk.1.1 (Finset.sum_le_sum fun a ha => (hk.2 a ha).2)
 
 end iInf
 

--- a/Mathlib/Data/Real/ConjExponents.lean
+++ b/Mathlib/Data/Real/ConjExponents.lean
@@ -3,7 +3,7 @@ Copyright (c) 2020 Sébastien Gouëzel. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sébastien Gouëzel, Yury Kudryashov
 -/
-import Mathlib.Data.ENNReal.Real
+import Mathlib.Data.ENNReal.Inv
 
 /-!
 # Real conjugate exponents

--- a/Mathlib/Data/Real/EReal.lean
+++ b/Mathlib/Data/Real/EReal.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kevin Buzzard
 -/
 import Mathlib.Data.Real.Basic
-import Mathlib.Data.ENNReal.Real
+import Mathlib.Data.ENNReal.Inv
 import Mathlib.Data.Sign
 
 /-!

--- a/Mathlib/MeasureTheory/OuterMeasure/Induced.lean
+++ b/Mathlib/MeasureTheory/OuterMeasure/Induced.lean
@@ -3,6 +3,7 @@ Copyright (c) 2017 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Mario Carneiro
 -/
+import Mathlib.Data.ENNReal.Action
 import Mathlib.MeasureTheory.OuterMeasure.Caratheodory
 
 /-!

--- a/Mathlib/Topology/EMetricSpace/Basic.lean
+++ b/Mathlib/Topology/EMetricSpace/Basic.lean
@@ -3,6 +3,7 @@ Copyright (c) 2015, 2017 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Robert Y. Lewis, Johannes Hölzl, Mario Carneiro, Sébastien Gouëzel
 -/
+import Mathlib.Algebra.Order.BigOperators.Group.Finset
 import Mathlib.Order.Interval.Finset.Nat
 import Mathlib.Topology.EMetricSpace.Defs
 import Mathlib.Topology.UniformSpace.UniformConvergence

--- a/Mathlib/Topology/Instances/ENNReal/Lemmas.lean
+++ b/Mathlib/Topology/Instances/ENNReal/Lemmas.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl
 -/
 import Mathlib.Algebra.BigOperators.Intervals
+import Mathlib.Data.ENNReal.Operations
 import Mathlib.Topology.Algebra.Order.LiminfLimsup
 import Mathlib.Topology.Instances.ENNReal.Defs
 import Mathlib.Topology.Instances.NNReal.Lemmas

--- a/Mathlib/Topology/Instances/NNReal/Defs.lean
+++ b/Mathlib/Topology/Instances/NNReal/Defs.lean
@@ -3,10 +3,11 @@ Copyright (c) 2018 Johan Commelin. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johan Commelin
 -/
+import Mathlib.Algebra.Algebra.Rat
 import Mathlib.Data.NNReal.Star
 import Mathlib.Topology.ContinuousMap.Basic
-import Mathlib.Topology.MetricSpace.Isometry
 import Mathlib.Topology.Instances.Real.Defs
+import Mathlib.Topology.MetricSpace.Isometry
 
 /-!
 # Topology on `ℝ≥0`

--- a/Mathlib/Topology/Instances/NNReal/Lemmas.lean
+++ b/Mathlib/Topology/Instances/NNReal/Lemmas.lean
@@ -3,12 +3,13 @@ Copyright (c) 2018 Johan Commelin. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johan Commelin
 -/
+import Mathlib.Data.NNReal.Basic
 import Mathlib.Data.NNReal.Star
 import Mathlib.Topology.Algebra.InfiniteSum.Order
 import Mathlib.Topology.Algebra.InfiniteSum.Ring
 import Mathlib.Topology.ContinuousMap.Basic
-import Mathlib.Topology.MetricSpace.Isometry
 import Mathlib.Topology.Instances.NNReal.Defs
+import Mathlib.Topology.MetricSpace.Isometry
 
 /-!
 # Topology on `ℝ≥0`

--- a/Mathlib/Topology/Instances/ZMultiples.lean
+++ b/Mathlib/Topology/Instances/ZMultiples.lean
@@ -3,11 +3,12 @@ Copyright (c) 2017 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Mario Carneiro
 -/
+import Mathlib.Algebra.Algebra.Rat
 import Mathlib.Algebra.Module.Rat
 import Mathlib.Algebra.Module.Submodule.Lattice
 import Mathlib.Topology.Algebra.UniformGroup.Basic
-import Mathlib.Topology.Metrizable.Basic
 import Mathlib.Topology.Instances.Real.Defs
+import Mathlib.Topology.Metrizable.Basic
 
 /-!
 The subgroup "multiples of `a`" (`zmultiples a`) is a discrete subgroup of `ℝ`, i.e. its

--- a/Mathlib/Topology/MetricSpace/Gluing.lean
+++ b/Mathlib/Topology/MetricSpace/Gluing.lean
@@ -3,6 +3,7 @@ Copyright (c) 2019 Sébastien Gouëzel. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sébastien Gouëzel
 -/
+import Mathlib.Order.ConditionallyCompleteLattice.Group
 import Mathlib.Topology.MetricSpace.Isometry
 
 /-!

--- a/Mathlib/Topology/MetricSpace/Isometry.lean
+++ b/Mathlib/Topology/MetricSpace/Isometry.lean
@@ -3,8 +3,9 @@ Copyright (c) 2018 Sébastien Gouëzel. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sébastien Gouëzel
 -/
-import Mathlib.Topology.MetricSpace.Antilipschitz
 import Mathlib.Data.Fintype.Lattice
+import Mathlib.Data.Fintype.Sum
+import Mathlib.Topology.MetricSpace.Antilipschitz
 
 /-!
 # Isometries

--- a/Mathlib/Topology/Metrizable/Uniformity.lean
+++ b/Mathlib/Topology/Metrizable/Uniformity.lean
@@ -3,8 +3,9 @@ Copyright (c) 2022 Yury Kudryashov. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury Kudryashov
 -/
-import Mathlib.Topology.Metrizable.Basic
 import Mathlib.Data.Nat.Lattice
+import Mathlib.Data.NNReal.Basic
+import Mathlib.Topology.Metrizable.Basic
 
 /-!
 # Metrizable uniform spaces


### PR DESCRIPTION
This PR redoes the file structure in `ENNReal` in order to clean up (transitive) dependencies. Previously we had the import order `Basic.lean -> Operations.lean -> Inv.lean -> Real.lean`, and this PR updates it to follow `Basic.lean -> Real.lean -> Order.lean -> Inv.lean -> Operations.lean`. The motivation is that this order seems to follow the number of files that actually depend on declarations in each of these files. (See for example the import graph for metric spaces.)

More specifically:
* `Real.lean` includes lemmas on `toReal` that can be proven without further assumptions. (This is the bulk of previous `Real.lean`.)
* `Order.lean` includes lemmas on monotonicity and operations applied to infinity. (This is the bulk of previous `Operations.lean`, and includes a bit of `Real.lean`.)
* `Inv.lean` includes lemmas on inverses and division. (This is the bulk of previous `Inv.lean`, and includes a bit of `Real.lean`.)
* `Action.lean` includes lemmas on scalar multiplication with `NNReal`. (This is mostly split off from `Operations.lean`.)
* `Operations.lean` includes lemmas on big operations such as finset sum and product. (This is the remainder of `Operations.lean`, and includes a bit of `Real.lean`.)


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
