### PR TITLE
[Merged by Bors] - chore(Data/Fintype/Perm): don't import `MonoidWithZero`

### DIFF
--- a/Archive/Imo/Imo1987Q1.lean
+++ b/Archive/Imo/Imo1987Q1.lean
@@ -5,7 +5,6 @@ Authors: Yury Kudryashov
 -/
 import Mathlib.Data.Fintype.BigOperators
 import Mathlib.Data.Fintype.Perm
-import Mathlib.Data.Fintype.Prod
 import Mathlib.Dynamics.FixedPoints.Basic
 
 /-!
@@ -96,6 +95,6 @@ theorem main₀ (n : ℕ) : ∑ k ∈ range (n + 1), k * p (Fin n) k = n * (n - 
 
 /-- Main statement for permutations of `Fin n`. -/
 theorem main {n : ℕ} (hn : 1 ≤ n) : ∑ k ∈ range (n + 1), k * p (Fin n) k = n ! := by
-  rw [main₀, Nat.mul_factorial_pred (zero_lt_one.trans_le hn)]
+  rw [main₀, Nat.mul_factorial_pred hn]
 
 end Imo1987Q1

--- a/Mathlib/Data/Finite/Perm.lean
+++ b/Mathlib/Data/Finite/Perm.lean
@@ -11,6 +11,8 @@ import Mathlib.SetTheory.Cardinal.Finite
 
 -/
 
+assert_not_exists Field
+
 namespace Nat
 
 theorem card_perm {α : Type*} [Finite α] : Nat.card (Equiv.Perm α) = (Nat.card α)! := by

--- a/Mathlib/Data/Fintype/Perm.lean
+++ b/Mathlib/Data/Fintype/Perm.lean
@@ -4,9 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
 import Mathlib.Data.Fintype.Card
-import Mathlib.GroupTheory.Perm.Basic
-import Mathlib.Tactic.Ring
 import Mathlib.Data.Nat.Factorial.Basic
+import Mathlib.GroupTheory.Perm.Basic
 
 /-!
 # `Fintype` instances for `Equiv` and `Perm`
@@ -15,6 +14,8 @@ Main declarations:
 * `permsOfFinset s`: The finset of permutations of the finset `s`.
 
 -/
+
+assert_not_exists MonoidWithZero
 
 open Function
 
@@ -36,10 +37,7 @@ def permsOfList : List α → List (Perm α)
 theorem length_permsOfList : ∀ l : List α, length (permsOfList l) = l.length !
   | [] => rfl
   | a :: l => by
-    rw [length_cons, Nat.factorial_succ]
-    simp only [permsOfList, length_append, length_permsOfList, length_flatMap, comp_def,
-     length_map, map_const', sum_replicate, smul_eq_mul, succ_mul]
-    ring
+    simp [Nat.factorial_succ, permsOfList, length_permsOfList, comp_def, succ_mul, add_comm]
 
 theorem mem_permsOfList_of_mem {l : List α} {f : Perm α} (h : ∀ x, f x ≠ x → x ∈ l) :
     f ∈ permsOfList l := by

--- a/Mathlib/GroupTheory/IndexNormal.lean
+++ b/Mathlib/GroupTheory/IndexNormal.lean
@@ -17,11 +17,13 @@ import Mathlib.GroupTheory.Index
 
 -/
 
+assert_not_exists Field
+
+open MulAction MonoidHom Nat
+
 variable {G : Type*} [Group G] {H : Subgroup G} {p : ℕ}
 
 namespace Subgroup
-
-open MulAction MonoidHom Nat
 
 /-- A subgroup of index 1 is normal (does not require finiteness of G) -/
 theorem normal_of_index_eq_one (hH : H.index = 1) : H.Normal := by

--- a/Mathlib/GroupTheory/Perm/DomMulAct.lean
+++ b/Mathlib/GroupTheory/Perm/DomMulAct.lean
@@ -11,7 +11,8 @@ import Mathlib.GroupTheory.GroupAction.Defs
 import Mathlib.GroupTheory.GroupAction.DomAct.Basic
 import Mathlib.SetTheory.Cardinal.Finite
 
-/-!  Subgroup of `Equiv.Perm α` preserving a function
+/-!
+# Subgroup of `Equiv.Perm α` preserving a function
 
 Let `α` and `ι` by types and let `f : α → ι`
 
@@ -33,9 +34,11 @@ Let `α` and `ι` by types and let `f : α → ι`
   formula, where the product is restricted to `Finset.univ.image f`.
 -/
 
-variable {α ι : Type*} {f : α → ι}
+assert_not_exists Field
 
 open Equiv MulAction
+
+variable {α ι : Type*} {f : α → ι}
 
 namespace DomMulAct
 

--- a/Mathlib/GroupTheory/Perm/Option.lean
+++ b/Mathlib/GroupTheory/Perm/Option.lean
@@ -4,10 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Eric Wieser
 -/
 import Mathlib.Data.Fintype.Option
-import Mathlib.Data.Fintype.Perm
-import Mathlib.Data.Fintype.Prod
 import Mathlib.GroupTheory.Perm.Sign
-import Mathlib.Logic.Equiv.Option
 
 /-!
 # Permutations of `Option α`

--- a/Mathlib/GroupTheory/Perm/Sign.lean
+++ b/Mathlib/GroupTheory/Perm/Sign.lean
@@ -6,7 +6,6 @@ Authors: Chris Hughes
 import Mathlib.Algebra.Group.Conj
 import Mathlib.Algebra.Group.Subgroup.Lattice
 import Mathlib.Algebra.Group.Submonoid.BigOperators
-import Mathlib.Algebra.Ring.Int.Units
 import Mathlib.Data.Finset.Fin
 import Mathlib.Data.Finset.Sort
 import Mathlib.Data.Fintype.Perm

--- a/Mathlib/GroupTheory/Perm/Subgroup.lean
+++ b/Mathlib/GroupTheory/Perm/Subgroup.lean
@@ -21,6 +21,7 @@ The presence of these instances induces a `Fintype` instance on the `QuotientGro
 these subgroups.
 -/
 
+assert_not_exists Field
 
 namespace Equiv
 

--- a/Mathlib/LinearAlgebra/Alternating/Basic.lean
+++ b/Mathlib/LinearAlgebra/Alternating/Basic.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Eric Wieser, Zhangir Azerbayev
 -/
 import Mathlib.GroupTheory.Perm.Sign
-import Mathlib.Data.Fintype.Perm
 import Mathlib.LinearAlgebra.Multilinear.Basis
 import Mathlib.LinearAlgebra.LinearIndependent
 

--- a/Mathlib/LinearAlgebra/Matrix/SemiringInverse.lean
+++ b/Mathlib/LinearAlgebra/Matrix/SemiringInverse.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Thomas Browning
 -/
 import Mathlib.Algebra.Group.Embedding
-import Mathlib.Data.Fintype.Perm
 import Mathlib.Data.Matrix.Mul
 import Mathlib.GroupTheory.Perm.Sign
 


### PR DESCRIPTION
The `ring` call was equivalent to `rw [add_comm]`.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
