### PR TITLE
[Merged by Bors] - chore(Algebra/BigOperators/Ring): don't import `Field`

### DIFF
--- a/Archive/Imo/Imo1975Q1.lean
+++ b/Archive/Imo/Imo1975Q1.lean
@@ -3,7 +3,7 @@ Copyright (c) 2022 Mantas Bakšys. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mantas Bakšys
 -/
-import Mathlib.Algebra.BigOperators.Ring
+import Mathlib.Algebra.BigOperators.Ring.Finset
 import Mathlib.Algebra.Order.Rearrangement
 import Mathlib.Data.Real.Basic
 import Mathlib.Order.Interval.Finset.Nat

--- a/Archive/Imo/Imo2024Q1.lean
+++ b/Archive/Imo/Imo2024Q1.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Joseph Myers
 -/
 import Mathlib.Algebra.BigOperators.Intervals
-import Mathlib.Algebra.BigOperators.Ring
+import Mathlib.Algebra.BigOperators.Ring.Finset
 import Mathlib.Algebra.Order.ToIntervalMod
 import Mathlib.Data.Real.Archimedean
 import Mathlib.Tactic.Peel

--- a/Archive/OxfordInvariants/Summer2021/Week3P1.lean
+++ b/Archive/OxfordInvariants/Summer2021/Week3P1.lean
@@ -3,7 +3,7 @@ Copyright (c) 2021 Yaël Dillies, Bhavik Mehta. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies, Bhavik Mehta
 -/
-import Mathlib.Algebra.BigOperators.Ring
+import Mathlib.Algebra.BigOperators.Ring.Finset
 import Mathlib.Algebra.Order.BigOperators.Group.Finset
 import Mathlib.Data.Nat.Cast.Field
 import Mathlib.Data.Nat.Cast.Order.Field

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -43,6 +43,7 @@ import Mathlib.Algebra.Azumaya.Matrix
 import Mathlib.Algebra.BigOperators.Associated
 import Mathlib.Algebra.BigOperators.Balance
 import Mathlib.Algebra.BigOperators.Expect
+import Mathlib.Algebra.BigOperators.Field
 import Mathlib.Algebra.BigOperators.Fin
 import Mathlib.Algebra.BigOperators.Finprod
 import Mathlib.Algebra.BigOperators.Finsupp
@@ -60,7 +61,7 @@ import Mathlib.Algebra.BigOperators.Module
 import Mathlib.Algebra.BigOperators.NatAntidiagonal
 import Mathlib.Algebra.BigOperators.Option
 import Mathlib.Algebra.BigOperators.Pi
-import Mathlib.Algebra.BigOperators.Ring
+import Mathlib.Algebra.BigOperators.Ring.Finset
 import Mathlib.Algebra.BigOperators.Ring.List
 import Mathlib.Algebra.BigOperators.Ring.Multiset
 import Mathlib.Algebra.BigOperators.Ring.Nat

--- a/Mathlib/Algebra/BigOperators/Associated.lean
+++ b/Mathlib/Algebra/BigOperators/Associated.lean
@@ -15,6 +15,7 @@ and products of multisets, finsets, and finsupps.
 
 -/
 
+assert_not_exists Field
 
 variable {α β γ δ : Type*}
 

--- a/Mathlib/Algebra/BigOperators/Expect.lean
+++ b/Mathlib/Algebra/BigOperators/Expect.lean
@@ -6,7 +6,7 @@ Authors: Yaël Dillies, Bhavik Mehta
 import Mathlib.Algebra.Algebra.Rat
 import Mathlib.Algebra.BigOperators.GroupWithZero.Action
 import Mathlib.Algebra.BigOperators.Pi
-import Mathlib.Algebra.BigOperators.Ring
+import Mathlib.Algebra.BigOperators.Ring.Finset
 import Mathlib.Algebra.Group.Pointwise.Finset.Basic
 import Mathlib.Algebra.Module.Pi
 import Mathlib.Data.Finset.Density

--- a/Mathlib/Algebra/BigOperators/Field.lean
+++ b/Mathlib/Algebra/BigOperators/Field.lean
@@ -1,0 +1,22 @@
+/-
+Copyright (c) 2020 Bhavik Mehta. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Bhavik Mehta, Daniel Weber
+-/
+import Mathlib.Algebra.BigOperators.Ring.Finset
+import Mathlib.Algebra.Field.Defs
+
+/-!
+# Results about big operators with values in a field
+-/
+
+open Fintype
+
+variable {ι K : Type*} [DivisionSemiring K]
+
+lemma Multiset.sum_map_div (s : Multiset ι) (f : ι → K) (a : K) :
+    (s.map (fun x ↦ f x / a)).sum = (s.map f).sum / a := by
+  simp only [div_eq_mul_inv, Multiset.sum_map_mul_right]
+
+lemma Finset.sum_div (s : Finset ι) (f : ι → K) (a : K) :
+    (∑ i ∈ s, f i) / a = ∑ i ∈ s, f i / a := by simp only [div_eq_mul_inv, sum_mul]

--- a/Mathlib/Algebra/BigOperators/Fin.lean
+++ b/Mathlib/Algebra/BigOperators/Fin.lean
@@ -3,7 +3,7 @@ Copyright (c) 2020 Yury Kudryashov, Anne Baanen. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury Kudryashov, Anne Baanen
 -/
-import Mathlib.Algebra.BigOperators.Ring
+import Mathlib.Algebra.BigOperators.Ring.Finset
 import Mathlib.Algebra.Group.Action.Pi
 import Mathlib.Data.Fintype.BigOperators
 import Mathlib.Data.Fintype.Fin

--- a/Mathlib/Algebra/BigOperators/Fin.lean
+++ b/Mathlib/Algebra/BigOperators/Fin.lean
@@ -23,6 +23,8 @@ constant function. These results have variants for sums instead of products.
 * `finFunctionFinEquiv`: An explicit equivalence between `Fin n → Fin m` and `Fin (m ^ n)`.
 -/
 
+assert_not_exists Field
+
 open Finset
 
 variable {α : Type*} {β : Type*}

--- a/Mathlib/Algebra/BigOperators/Finsupp.lean
+++ b/Mathlib/Algebra/BigOperators/Finsupp.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kenny Lau
 -/
 import Mathlib.Algebra.BigOperators.Pi
-import Mathlib.Algebra.BigOperators.Ring
+import Mathlib.Algebra.BigOperators.Ring.Finset
 import Mathlib.Algebra.BigOperators.Fin
 import Mathlib.Algebra.Group.Submonoid.BigOperators
 import Mathlib.Data.Finsupp.Ext

--- a/Mathlib/Algebra/BigOperators/Finsupp.lean
+++ b/Mathlib/Algebra/BigOperators/Finsupp.lean
@@ -17,6 +17,7 @@ import Mathlib.Data.Finsupp.Indicator
 This file contains theorems relevant to big operators in finitely supported functions.
 -/
 
+assert_not_exists Field
 
 noncomputable section
 

--- a/Mathlib/Algebra/BigOperators/Ring/Finset.lean
+++ b/Mathlib/Algebra/BigOperators/Ring/Finset.lean
@@ -5,7 +5,8 @@ Authors: Johannes Hölzl
 -/
 import Mathlib.Algebra.BigOperators.GroupWithZero.Finset
 import Mathlib.Algebra.BigOperators.Ring.Multiset
-import Mathlib.Algebra.Field.Defs
+import Mathlib.Algebra.Ring.Defs
+import Mathlib.Data.Rat.Init
 import Mathlib.Data.Finset.Max
 import Mathlib.Data.Fintype.Powerset
 import Mathlib.Data.Int.Cast.Lemmas
@@ -16,6 +17,8 @@ import Mathlib.Data.Int.Cast.Lemmas
 We prove results about big operators that involve some interaction between
 multiplicative and additive structures on the values being combined.
 -/
+
+assert_not_exists Field
 
 open Fintype
 
@@ -266,20 +269,7 @@ theorem prod_range_natCast_sub (n k : ℕ) :
   · rw [← mem_range] at hnk
     rw [prod_eq_zero hnk, prod_eq_zero hnk] <;> simp
 
-
 end CommRing
-
-section DivisionSemiring
-variable [DivisionSemiring α]
-
-lemma _root_.Multiset.sum_map_div {s : Multiset ι} {f : ι → α} {a : α} :
-    (s.map (fun x ↦ f x / a)).sum = (s.map f).sum / a := by
-  simp only [div_eq_mul_inv, Multiset.sum_map_mul_right]
-
-lemma sum_div (s : Finset ι) (f : ι → α) (a : α) :
-    (∑ i ∈ s, f i) / a = ∑ i ∈ s, f i / a := by simp only [div_eq_mul_inv, sum_mul]
-
-end DivisionSemiring
 end Finset
 
 open Finset

--- a/Mathlib/Algebra/GeomSum.lean
+++ b/Mathlib/Algebra/GeomSum.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Neil Strickland
 -/
 import Mathlib.Algebra.BigOperators.Intervals
-import Mathlib.Algebra.BigOperators.Ring
+import Mathlib.Algebra.BigOperators.Ring.Finset
 import Mathlib.Algebra.Group.NatPowAssoc
 import Mathlib.Algebra.Order.BigOperators.Ring.Finset
 import Mathlib.Algebra.Ring.Opposite

--- a/Mathlib/Algebra/Group/AddChar.lean
+++ b/Mathlib/Algebra/Group/AddChar.lean
@@ -6,7 +6,7 @@ Authors: Michael Stoll
 import Mathlib.Algebra.Ring.Regular
 import Mathlib.Algebra.Equiv.TransferInstance
 import Mathlib.Algebra.BigOperators.Pi
-import Mathlib.Algebra.BigOperators.Ring
+import Mathlib.Algebra.BigOperators.Ring.Finset
 
 /-!
 # Characters from additive to multiplicative monoids

--- a/Mathlib/Algebra/Group/Subgroup/Finsupp.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Finsupp.lean
@@ -8,6 +8,8 @@ import Mathlib.Algebra.Group.Subgroup.Lattice
 
 /-! # Connection between `Subgroup.closure` and `Finsupp.prod` -/
 
+assert_not_exists Field
+
 namespace Subgroup
 
 variable {M : Type*} [CommGroup M] {ι : Type*} (f : ι → M) (x : M)

--- a/Mathlib/Algebra/Group/Submonoid/Finsupp.lean
+++ b/Mathlib/Algebra/Group/Submonoid/Finsupp.lean
@@ -7,6 +7,8 @@ import Mathlib.Algebra.BigOperators.Finsupp
 
 /-! # Connection between `Submonoid.closure` and `Finsupp.prod` -/
 
+assert_not_exists Field
+
 namespace Submonoid
 
 variable {M : Type*} [CommMonoid M] {ι : Type*} (f : ι → M) (x : M)

--- a/Mathlib/Algebra/MvPolynomial/SchwartzZippel.lean
+++ b/Mathlib/Algebra/MvPolynomial/SchwartzZippel.lean
@@ -3,6 +3,7 @@ Copyright (c) 2023 Bolton Bailey. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Bolton Bailey, Yaël Dillies, Andrew Yang
 -/
+import Mathlib.Algebra.BigOperators.Field
 import Mathlib.Algebra.MvPolynomial.Equiv
 import Mathlib.Algebra.MvPolynomial.Variables
 import Mathlib.Algebra.Order.Group.Finset

--- a/Mathlib/Algebra/Order/BigOperators/Ring/Finset.lean
+++ b/Mathlib/Algebra/Order/BigOperators/Ring/Finset.lean
@@ -3,7 +3,7 @@ Copyright (c) 2019 Floris van Doorn. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Floris van Doorn
 -/
-import Mathlib.Algebra.BigOperators.Ring
+import Mathlib.Algebra.BigOperators.Ring.Finset
 import Mathlib.Algebra.Order.AbsoluteValue.Basic
 import Mathlib.Algebra.Order.BigOperators.Group.Finset
 import Mathlib.Algebra.Order.BigOperators.Ring.Multiset

--- a/Mathlib/Analysis/Convex/Visible.lean
+++ b/Mathlib/Analysis/Convex/Visible.lean
@@ -3,6 +3,7 @@ Copyright (c) 2024 Yaël Dillies. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies
 -/
+import Mathlib.Algebra.BigOperators.Field
 import Mathlib.Algebra.Group.Pointwise.Set.Card
 import Mathlib.Analysis.Convex.Between
 import Mathlib.Analysis.Convex.Combination

--- a/Mathlib/Analysis/InnerProductSpace/Basic.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Basic.lean
@@ -3,7 +3,7 @@ Copyright (c) 2019 Zhouhang Zhou. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Zhouhang Zhou, Sébastien Gouëzel, Frédéric Dupuis
 -/
-
+import Mathlib.Algebra.BigOperators.Field
 import Mathlib.Algebra.EuclideanDomain.Field
 import Mathlib.Analysis.Complex.Basic
 import Mathlib.Analysis.InnerProductSpace.Defs

--- a/Mathlib/Analysis/MeanInequalities.lean
+++ b/Mathlib/Analysis/MeanInequalities.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury Kudryashov, Sébastien Gouëzel, Rémy Degenne
 -/
 import Mathlib.Algebra.BigOperators.Expect
+import Mathlib.Algebra.BigOperators.Field
 import Mathlib.Analysis.Convex.Jensen
 import Mathlib.Analysis.Convex.SpecificFunctions.Basic
 import Mathlib.Analysis.SpecialFunctions.Pow.NNReal

--- a/Mathlib/Analysis/SpecialFunctions/Log/Base.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Log/Base.lean
@@ -3,6 +3,7 @@ Copyright (c) 2022 Bolton Bailey. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Bolton Bailey, Chris Hughes, Abhimanyu Pallavi Sudhir, Jean Lo, Calle Sönne
 -/
+import Mathlib.Algebra.BigOperators.Field
 import Mathlib.Analysis.SpecialFunctions.Pow.Real
 import Mathlib.Data.Int.Log
 

--- a/Mathlib/Combinatorics/Additive/AP/Three/Defs.lean
+++ b/Mathlib/Combinatorics/Additive/AP/Three/Defs.lean
@@ -43,7 +43,7 @@ the size of the biggest 3AP-free subset of `{0, ..., n - 1}`.
 3AP-free, Salem-Spencer, Roth, arithmetic progression, average, three-free
 -/
 
-assert_not_exists Ideal TwoSidedIdeal
+assert_not_exists Field Ideal TwoSidedIdeal
 
 open Finset Function
 open scoped Pointwise

--- a/Mathlib/Combinatorics/Additive/Corner/Defs.lean
+++ b/Mathlib/Combinatorics/Additive/Corner/Defs.lean
@@ -17,7 +17,7 @@ property of being corner-free.
 * [Wikipedia, *Corners theorem*](https://en.wikipedia.org/wiki/Corners_theorem)
 -/
 
-assert_not_exists Ideal TwoSidedIdeal
+assert_not_exists Field Ideal TwoSidedIdeal
 
 open Set
 

--- a/Mathlib/Combinatorics/Additive/ErdosGinzburgZiv.lean
+++ b/Mathlib/Combinatorics/Additive/ErdosGinzburgZiv.lean
@@ -3,7 +3,7 @@ Copyright (c) 2023 Yaël Dillies. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies
 -/
-import Mathlib.Algebra.BigOperators.Ring
+import Mathlib.Algebra.BigOperators.Ring.Finset
 import Mathlib.Data.Multiset.Fintype
 import Mathlib.FieldTheory.ChevalleyWarning
 

--- a/Mathlib/Combinatorics/Additive/FreimanHom.lean
+++ b/Mathlib/Combinatorics/Additive/FreimanHom.lean
@@ -3,7 +3,7 @@ Copyright (c) 2022 Yaël Dillies. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies, Bhavik Mehta
 -/
-import Mathlib.Algebra.BigOperators.Ring
+import Mathlib.Algebra.BigOperators.Ring.Finset
 import Mathlib.Algebra.CharP.Basic
 import Mathlib.Algebra.Group.Pointwise.Set.Basic
 import Mathlib.Algebra.Group.Submonoid.Defs

--- a/Mathlib/Combinatorics/Additive/FreimanHom.lean
+++ b/Mathlib/Combinatorics/Additive/FreimanHom.lean
@@ -60,7 +60,7 @@ an `AddMonoid`/`Monoid` instead of the `AddMonoid`/`Monoid` itself.
 * Affine maps are Freiman homs.
 -/
 
-assert_not_exists Ideal TwoSidedIdeal
+assert_not_exists Field Ideal TwoSidedIdeal
 
 open Multiset Set
 open scoped Pointwise

--- a/Mathlib/Combinatorics/Additive/VerySmallDoubling.lean
+++ b/Mathlib/Combinatorics/Additive/VerySmallDoubling.lean
@@ -3,7 +3,7 @@ Copyright (c) 2024 Yaël Dillies, Patrick Luo, Bhavik Mehta. All rights reserved
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies, Patrick Luo, Bhavik Mehta
 -/
-import Mathlib.Algebra.BigOperators.Ring
+import Mathlib.Algebra.BigOperators.Ring.Finset
 import Mathlib.Algebra.Group.Pointwise.Finset.Basic
 import Mathlib.Algebra.Group.Submonoid.Pointwise
 import Mathlib.Algebra.Order.BigOperators.Group.Finset

--- a/Mathlib/Combinatorics/Derangements/Exponential.lean
+++ b/Mathlib/Combinatorics/Derangements/Exponential.lean
@@ -3,6 +3,7 @@ Copyright (c) 2021 Henry Swanson. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Henry Swanson, Patrick Massot
 -/
+import Mathlib.Algebra.BigOperators.Field
 import Mathlib.Analysis.SpecialFunctions.Exponential
 import Mathlib.Combinatorics.Derangements.Finite
 import Mathlib.Order.Filter.Tendsto

--- a/Mathlib/Combinatorics/Derangements/Finite.lean
+++ b/Mathlib/Combinatorics/Derangements/Finite.lean
@@ -3,7 +3,7 @@ Copyright (c) 2021 Henry Swanson. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Henry Swanson
 -/
-import Mathlib.Algebra.BigOperators.Ring
+import Mathlib.Algebra.BigOperators.Ring.Finset
 import Mathlib.Combinatorics.Derangements.Basic
 import Mathlib.Data.Fintype.BigOperators
 import Mathlib.Tactic.Ring

--- a/Mathlib/Combinatorics/Enumerative/Composition.lean
+++ b/Mathlib/Combinatorics/Enumerative/Composition.lean
@@ -86,6 +86,8 @@ Composition, partition
 <https://en.wikipedia.org/wiki/Composition_(combinatorics)>
 -/
 
+assert_not_exists Field
+
 open List
 
 variable {n : ℕ}

--- a/Mathlib/Combinatorics/Enumerative/DoubleCounting.lean
+++ b/Mathlib/Combinatorics/Enumerative/DoubleCounting.lean
@@ -3,7 +3,7 @@ Copyright (c) 2022 Yaël Dillies. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies
 -/
-import Mathlib.Algebra.BigOperators.Ring
+import Mathlib.Algebra.BigOperators.Ring.Finset
 import Mathlib.Algebra.Order.BigOperators.Group.Finset
 import Mathlib.Algebra.Order.Ring.Nat
 

--- a/Mathlib/Combinatorics/Enumerative/DoubleCounting.lean
+++ b/Mathlib/Combinatorics/Enumerative/DoubleCounting.lean
@@ -28,6 +28,7 @@ and `t`.
 * `card_mul_eq_card_mul`: Equality combination of the previous.
 -/
 
+assert_not_exists Field
 
 open Finset Function Relator
 

--- a/Mathlib/Combinatorics/Enumerative/IncidenceAlgebra.lean
+++ b/Mathlib/Combinatorics/Enumerative/IncidenceAlgebra.lean
@@ -5,7 +5,7 @@ Authors: Alex J. Best, Yaël Dillies
 -/
 import Mathlib.Algebra.Algebra.Defs
 import Mathlib.Algebra.BigOperators.Intervals
-import Mathlib.Algebra.BigOperators.Ring
+import Mathlib.Algebra.BigOperators.Ring.Finset
 import Mathlib.Algebra.Module.BigOperators
 import Mathlib.Algebra.Module.Pi
 

--- a/Mathlib/Combinatorics/Enumerative/InclusionExclusion.lean
+++ b/Mathlib/Combinatorics/Enumerative/InclusionExclusion.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies
 -/
 import Mathlib.Algebra.BigOperators.Pi
-import Mathlib.Algebra.BigOperators.Ring
+import Mathlib.Algebra.BigOperators.Ring.Finset
 import Mathlib.Algebra.Module.BigOperators
 
 /-!

--- a/Mathlib/Combinatorics/Enumerative/InclusionExclusion.lean
+++ b/Mathlib/Combinatorics/Enumerative/InclusionExclusion.lean
@@ -40,6 +40,8 @@ Per the above explanation, this file contains the following variants of inclusio
 * Prove that truncating the series alternatively gives an upper/lower bound to the true value.
 -/
 
+assert_not_exists Field
+
 namespace Finset
 variable {ι α G : Type*} [DecidableEq α] [AddCommGroup G] {s : Finset ι}
 

--- a/Mathlib/Combinatorics/Enumerative/Partition.lean
+++ b/Mathlib/Combinatorics/Enumerative/Partition.lean
@@ -41,6 +41,8 @@ Partition
 <https://en.wikipedia.org/wiki/Partition_(number_theory)>
 -/
 
+assert_not_exists Field
+
 open Multiset
 
 namespace Nat

--- a/Mathlib/Combinatorics/SetFamily/AhlswedeZhang.lean
+++ b/Mathlib/Combinatorics/SetFamily/AhlswedeZhang.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies, Vladimir Ivanov
 -/
 import Mathlib.Algebra.BigOperators.Intervals
-import Mathlib.Algebra.BigOperators.Ring
+import Mathlib.Algebra.BigOperators.Ring.Finset
 import Mathlib.Algebra.Order.BigOperators.Group.Finset
 import Mathlib.Algebra.Order.Field.Basic
 import Mathlib.Data.Finset.Sups

--- a/Mathlib/Combinatorics/SetFamily/LYM.lean
+++ b/Mathlib/Combinatorics/SetFamily/LYM.lean
@@ -3,7 +3,7 @@ Copyright (c) 2022 Bhavik Mehta, Yaël Dillies. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Bhavik Mehta, Alena Gusakov, Yaël Dillies
 -/
-import Mathlib.Algebra.BigOperators.Ring
+import Mathlib.Algebra.BigOperators.Ring.Finset
 import Mathlib.Algebra.Field.Rat
 import Mathlib.Algebra.Order.Field.Basic
 import Mathlib.Algebra.Order.Field.Rat

--- a/Mathlib/Combinatorics/SetFamily/LYM.lean
+++ b/Mathlib/Combinatorics/SetFamily/LYM.lean
@@ -3,6 +3,7 @@ Copyright (c) 2022 Bhavik Mehta, Yaël Dillies. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Bhavik Mehta, Alena Gusakov, Yaël Dillies
 -/
+import Mathlib.Algebra.BigOperators.Field
 import Mathlib.Algebra.BigOperators.Ring.Finset
 import Mathlib.Algebra.Field.Rat
 import Mathlib.Algebra.Order.Field.Basic

--- a/Mathlib/Combinatorics/SimpleGraph/DegreeSum.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/DegreeSum.lean
@@ -3,7 +3,7 @@ Copyright (c) 2020 Kyle Miller. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kyle Miller
 -/
-import Mathlib.Algebra.BigOperators.Ring
+import Mathlib.Algebra.BigOperators.Ring.Finset
 import Mathlib.Combinatorics.SimpleGraph.Dart
 import Mathlib.Combinatorics.SimpleGraph.Finite
 import Mathlib.Data.ZMod.Basic

--- a/Mathlib/Combinatorics/SimpleGraph/IncMatrix.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/IncMatrix.lean
@@ -41,10 +41,9 @@ incidence matrix for each `SimpleGraph α` has the same type.
   arbitrary orientation of a simple graph.
 -/
 
+assert_not_exists Field
 
 open Finset Matrix SimpleGraph Sym2
-
-open Matrix
 
 namespace SimpleGraph
 

--- a/Mathlib/Combinatorics/SimpleGraph/Regularity/Bound.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Regularity/Bound.lean
@@ -3,6 +3,7 @@ Copyright (c) 2022 Yaël Dillies, Bhavik Mehta. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies, Bhavik Mehta
 -/
+import Mathlib.Algebra.BigOperators.Field
 import Mathlib.Algebra.Order.Chebyshev
 import Mathlib.Analysis.SpecialFunctions.Pow.Real
 import Mathlib.Order.Partition.Equipartition

--- a/Mathlib/Combinatorics/SimpleGraph/Regularity/Uniform.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Regularity/Uniform.lean
@@ -3,7 +3,7 @@ Copyright (c) 2022 Yaël Dillies, Bhavik Mehta. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies, Bhavik Mehta
 -/
-import Mathlib.Algebra.BigOperators.Ring
+import Mathlib.Algebra.BigOperators.Ring.Finset
 import Mathlib.Combinatorics.SimpleGraph.Density
 import Mathlib.Data.Nat.Cast.Order.Field
 import Mathlib.Order.Partition.Equipartition

--- a/Mathlib/Data/Fin/Tuple/Reflection.lean
+++ b/Mathlib/Data/Fin/Tuple/Reflection.lean
@@ -27,6 +27,7 @@ corresponding `*_eq` lemmas to be used in a place where they are definitionally 
 * `FinVec.etaExpand`
 -/
 
+assert_not_exists Field
 
 namespace FinVec
 

--- a/Mathlib/Data/Finset/NatAntidiagonal.lean
+++ b/Mathlib/Data/Finset/NatAntidiagonal.lean
@@ -21,6 +21,8 @@ This refines files `Data.List.NatAntidiagonal` and `Data.Multiset.NatAntidiagona
 instance enabling `Finset.antidiagonal` on `Nat`.
 -/
 
+assert_not_exists Field
+
 open Function
 
 namespace Finset

--- a/Mathlib/Data/Matrix/ConjTranspose.lean
+++ b/Mathlib/Data/Matrix/ConjTranspose.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Ellen Arlt, Blair Shi, Sean Leather, Mario Carneiro, Johan Commelin, Lu-Ming Zhang
 -/
 import Mathlib.Algebra.BigOperators.GroupWithZero.Action
-import Mathlib.Algebra.BigOperators.Ring
+import Mathlib.Algebra.BigOperators.Ring.Finset
 import Mathlib.Algebra.BigOperators.RingEquiv
 import Mathlib.Algebra.Module.Pi
 import Mathlib.Algebra.Star.BigOperators

--- a/Mathlib/Data/Matrix/Mul.lean
+++ b/Mathlib/Data/Matrix/Mul.lean
@@ -46,7 +46,7 @@ Under various conditions, multiplication of infinite matrices makes sense.
 These have not yet been implemented.
 -/
 
-assert_not_exists Algebra Star
+assert_not_exists Algebra Field Star
 
 universe u u' v w
 

--- a/Mathlib/Data/Matrix/Mul.lean
+++ b/Mathlib/Data/Matrix/Mul.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Ellen Arlt, Blair Shi, Sean Leather, Mario Carneiro, Johan Commelin, Lu-Ming Zhang
 -/
 import Mathlib.Algebra.BigOperators.GroupWithZero.Action
-import Mathlib.Algebra.BigOperators.Ring
+import Mathlib.Algebra.BigOperators.Ring.Finset
 import Mathlib.Data.Fintype.BigOperators
 import Mathlib.Data.Matrix.Diagonal
 

--- a/Mathlib/Data/Matrix/PEquiv.lean
+++ b/Mathlib/Data/Matrix/PEquiv.lean
@@ -32,6 +32,7 @@ inverse of this map, sending anything not in the image to zero.
 This file uses `ᵀ` for `Matrix.transpose`.
 -/
 
+assert_not_exists Field
 
 namespace PEquiv
 

--- a/Mathlib/Data/Nat/Choose/Sum.lean
+++ b/Mathlib/Data/Nat/Choose/Sum.lean
@@ -5,7 +5,7 @@ Authors: Chris Hughes, Patrick Stevens
 -/
 import Mathlib.Algebra.BigOperators.Intervals
 import Mathlib.Algebra.BigOperators.NatAntidiagonal
-import Mathlib.Algebra.BigOperators.Ring
+import Mathlib.Algebra.BigOperators.Ring.Finset
 import Mathlib.Algebra.Order.BigOperators.Group.Finset
 import Mathlib.Tactic.Linarith
 import Mathlib.Tactic.Ring

--- a/Mathlib/FieldTheory/Differential/Liouville.lean
+++ b/Mathlib/FieldTheory/Differential/Liouville.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Daniel Weber
 -/
 import Mathlib.Algebra.Algebra.Field
+import Mathlib.Algebra.BigOperators.Field
 import Mathlib.FieldTheory.Differential.Basic
 import Mathlib.FieldTheory.Galois.Basic
 import Mathlib.FieldTheory.IsAlgClosed.AlgebraicClosure

--- a/Mathlib/LinearAlgebra/Matrix/Orthogonal.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Orthogonal.lean
@@ -22,6 +22,7 @@ This file contains definitions and properties concerning orthogonality of rows a
 orthogonal
 -/
 
+assert_not_exists Field
 
 namespace Matrix
 

--- a/Mathlib/NumberTheory/ArithmeticFunction.lean
+++ b/Mathlib/NumberTheory/ArithmeticFunction.lean
@@ -3,7 +3,7 @@ Copyright (c) 2020 Aaron Anderson. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Aaron Anderson
 -/
-import Mathlib.Algebra.BigOperators.Ring
+import Mathlib.Algebra.BigOperators.Ring.Finset
 import Mathlib.Algebra.Module.BigOperators
 import Mathlib.NumberTheory.Divisors
 import Mathlib.Data.Nat.Squarefree

--- a/Mathlib/NumberTheory/Bernoulli.lean
+++ b/Mathlib/NumberTheory/Bernoulli.lean
@@ -3,6 +3,7 @@ Copyright (c) 2020 Johan Commelin. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johan Commelin, Kevin Buzzard
 -/
+import Mathlib.Algebra.BigOperators.Field
 import Mathlib.RingTheory.PowerSeries.Inverse
 import Mathlib.RingTheory.PowerSeries.WellKnown
 

--- a/Mathlib/NumberTheory/LSeries/Linearity.lean
+++ b/Mathlib/NumberTheory/LSeries/Linearity.lean
@@ -3,6 +3,7 @@ Copyright (c) 2024 Michael Stoll. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Michael Stoll
 -/
+import Mathlib.Algebra.BigOperators.Field
 import Mathlib.NumberTheory.LSeries.Basic
 
 /-!

--- a/Mathlib/RingTheory/ChainOfDivisors.lean
+++ b/Mathlib/RingTheory/ChainOfDivisors.lean
@@ -36,6 +36,7 @@ and the set of factors of `a`.
 
 -/
 
+assert_not_exists Field
 
 variable {M : Type*} [CancelCommMonoidWithZero M]
 

--- a/Mathlib/RingTheory/Coprime/Lemmas.lean
+++ b/Mathlib/RingTheory/Coprime/Lemmas.lean
@@ -3,7 +3,7 @@ Copyright (c) 2020 Kenny Lau. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kenny Lau, Ken Lee, Chris Hughes
 -/
-import Mathlib.Algebra.BigOperators.Ring
+import Mathlib.Algebra.BigOperators.Ring.Finset
 import Mathlib.Data.Fintype.Basic
 import Mathlib.Data.Int.GCD
 import Mathlib.RingTheory.Coprime.Basic

--- a/Mathlib/RingTheory/UniqueFactorizationDomain/Basic.lean
+++ b/Mathlib/RingTheory/UniqueFactorizationDomain/Basic.lean
@@ -28,6 +28,7 @@ import Mathlib.RingTheory.UniqueFactorizationDomain.Defs
   to get relatively prime elements.
 -/
 
+assert_not_exists Field
 
 variable {α : Type*}
 

--- a/Mathlib/RingTheory/UniqueFactorizationDomain/Finite.lean
+++ b/Mathlib/RingTheory/UniqueFactorizationDomain/Finite.lean
@@ -13,6 +13,8 @@ import Mathlib.RingTheory.UniqueFactorizationDomain.NormalizedFactors
   finitely many divisors.
 -/
 
+assert_not_exists Field
+
 variable {α : Type*}
 
 local infixl:50 " ~ᵤ " => Associated

--- a/Mathlib/RingTheory/UniqueFactorizationDomain/Multiplicative.lean
+++ b/Mathlib/RingTheory/UniqueFactorizationDomain/Multiplicative.lean
@@ -15,6 +15,7 @@ import Mathlib.RingTheory.UniqueFactorizationDomain.NormalizedFactors
   primes `p`, and `f` is multiplicative on coprime elements, then `f` is multiplicative everywhere.
 -/
 
+assert_not_exists Field
 
 variable {α : Type*}
 

--- a/Mathlib/RingTheory/UniqueFactorizationDomain/Multiplicity.lean
+++ b/Mathlib/RingTheory/UniqueFactorizationDomain/Multiplicity.lean
@@ -16,6 +16,7 @@ import Mathlib.RingTheory.UniqueFactorizationDomain.NormalizedFactors
   occurs in the `normalizedFactors`.
 -/
 
+assert_not_exists Field
 
 variable {α : Type*}
 

--- a/Mathlib/RingTheory/UniqueFactorizationDomain/Nat.lean
+++ b/Mathlib/RingTheory/UniqueFactorizationDomain/Nat.lean
@@ -15,6 +15,8 @@ import Mathlib.RingTheory.UniqueFactorizationDomain.NormalizedFactors
 * `Nat.instUniqueFactorizationMonoid`: the natural numbers have unique factorization
 -/
 
+assert_not_exists Field
+
 namespace Nat
 
 instance instWfDvdMonoid : WfDvdMonoid ℕ where

--- a/Mathlib/RingTheory/UniqueFactorizationDomain/NormalizedFactors.lean
+++ b/Mathlib/RingTheory/UniqueFactorizationDomain/NormalizedFactors.lean
@@ -15,6 +15,7 @@ import Mathlib.RingTheory.UniqueFactorizationDomain.Basic
 * `UniqueFactorizationMonoid.normalizationMonoid`: choose a way of normalizing the elements of a UFM
 -/
 
+assert_not_exists Field
 
 variable {α : Type*}
 


### PR DESCRIPTION
Split the file into the part talking about rings and the part talking about fields.

See https://github.com/leanprover-community/mathlib3/pull/2152 and https://github.com/leanprover-community/mathlib4/pull/19630 for the new copyright header.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
