### PR TITLE
[Merged by Bors] - chore(Algebra/Order/Ring/Unbundled/Rat): split proof, process porting note

### DIFF
--- a/Mathlib/Algebra/Order/Ring/Unbundled/Rat.lean
+++ b/Mathlib/Algebra/Order/Ring/Unbundled/Rat.lean
@@ -81,44 +81,45 @@ protected lemma mul_nonneg : 0 ≤ a → 0 ≤ b → 0 ≤ a * b :=
         divInt_mul_divInt _ _ d₁0.ne' d₂0.ne']
       apply Int.mul_nonneg
 
--- Porting note (https://github.com/leanprover-community/mathlib4/issues/11215): TODO can this be shortened?
+protected theorem not_le {a b : ℚ} : ¬a ≤ b ↔ b < a := (Bool.not_eq_false _).to_iff
+
+protected theorem not_lt {a b : ℚ} : ¬a < b ↔ b ≤ a := by
+  rw [← Rat.not_le, not_not]
+
+protected theorem lt_iff (a b : ℚ) : a < b ↔ a.num * b.den < b.num * a.den :=
+  numDenCasesOn'' a fun na da ha hared =>
+    numDenCasesOn'' b fun nb db hb hbred => by
+      show Rat.blt _ _ = true ↔ _
+      suffices
+        (na < 0 ∧ 0 ≤ nb ∨ if na = 0 then 0 < nb else (na ≤ 0 ∨ 0 < nb) ∧ na * ↑db < nb * da) ↔
+        na * db < nb * da by simpa [Rat.blt]
+      split_ifs with h
+      · suffices 0 < nb ↔ 0 < nb * da by simpa [h]
+        refine ⟨(Int.mul_pos · (by omega)), ?_⟩
+        contrapose!
+        exact (Int.mul_nonpos_of_nonpos_of_nonneg · (by omega))
+      · constructor
+        · refine (·.elim ?_ And.right)
+          rintro ⟨hna, nb0⟩
+          apply (Int.mul_neg_of_neg_of_pos hna _).trans_le (Int.mul_nonneg nb0 _) <;> omega
+        · intro h
+          suffices na < 0 ∧ 0 ≤ nb ∨ na ≤ 0 ∨ 0 < nb by simpa [h]
+          contrapose! h
+          apply (Int.mul_nonpos_of_nonpos_of_nonneg _ _).trans (Int.mul_nonneg _ _) <;> omega
+
+protected theorem le_iff (a b : ℚ) : a ≤ b ↔ a.num * b.den ≤ b.num * a.den := by
+  simpa only [Rat.not_lt, not_lt] using (Rat.lt_iff b a).not
+
 protected theorem le_iff_sub_nonneg (a b : ℚ) : a ≤ b ↔ 0 ≤ b - a :=
   numDenCasesOn'' a fun na da ha hared =>
     numDenCasesOn'' b fun nb db hb hbred => by
-      change Rat.blt _ _ = false ↔ _
-      unfold Rat.blt
-      simp only [Bool.and_eq_true, decide_eq_true_eq, Bool.ite_eq_false_distrib,
-        decide_eq_false_iff_not, not_lt, ite_eq_left_iff, not_and, not_le, ← num_nonneg]
-      split_ifs with h h'
-      · rw [Rat.sub_def]
-        simp only [false_iff, not_le, reduceCtorEq]
-        simp only [normalize_eq]
-        apply Int.ediv_neg'
-        · rw [sub_neg]
-          apply lt_of_lt_of_le
-          · apply Int.mul_neg_of_neg_of_pos h.1
-            rwa [Int.natCast_pos, Nat.pos_iff_ne_zero]
-          · apply Int.mul_nonneg h.2 (Int.natCast_nonneg _)
-        · simp only [Int.natCast_pos, Nat.pos_iff_ne_zero]
-          exact Nat.gcd_ne_zero_right (Nat.mul_ne_zero hb ha)
-      · simp [h']
-      · simp only [Rat.sub_def, normalize_eq]
-        refine ⟨fun H => ?_, fun H _ => ?_⟩
-        · refine Int.ediv_nonneg ?_ (Int.natCast_nonneg _)
-          rw [Int.sub_nonneg]
-          obtain hb|hb := Ne.lt_or_lt h'
-          · apply H
-            intro H'
-            exact (hb.trans H').false.elim
-          · obtain ha|ha := le_or_lt na 0
-            · apply le_trans <| Int.mul_nonpos_of_nonpos_of_nonneg ha (Int.natCast_nonneg _)
-              exact Int.mul_nonneg hb.le (Int.natCast_nonneg _)
-            · exact H (fun _ => ha)
-        · rw [← Int.sub_nonneg]
-          contrapose! H
-          apply Int.ediv_neg' H
-          simp only [Int.natCast_pos, Nat.pos_iff_ne_zero]
-          exact Nat.gcd_ne_zero_right (Nat.mul_ne_zero hb ha)
+      rw [Rat.le_iff, sub_def, normalize_eq, ← num_nonneg, ← Int.sub_nonneg]
+      dsimp only
+      refine ⟨(Int.ediv_nonneg · (Int.natCast_nonneg _)), fun H ↦ ?_⟩
+      contrapose! H
+      apply Int.ediv_neg' H
+      simp only [Int.natCast_pos, Nat.pos_iff_ne_zero]
+      exact Nat.gcd_ne_zero_right (Nat.mul_ne_zero hb ha)
 
 protected lemma divInt_le_divInt {a b c d : ℤ} (b0 : 0 < b) (d0 : 0 < d) :
     a /. b ≤ c /. d ↔ a * d ≤ c * b := by
@@ -127,8 +128,6 @@ protected lemma divInt_le_divInt {a b c d : ℤ} (b0 : 0 < b) (d0 : 0 < d) :
 
 protected lemma le_total : a ≤ b ∨ b ≤ a := by
   simpa only [← Rat.le_iff_sub_nonneg, neg_sub] using Rat.nonneg_total (b - a)
-
-protected theorem not_le {a b : ℚ} : ¬a ≤ b ↔ b < a := (Bool.not_eq_false _).to_iff
 
 instance linearOrder : LinearOrder ℚ where
   le_refl a := by rw [Rat.le_iff_sub_nonneg, ← num_nonneg]; simp


### PR DESCRIPTION

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
