### PR TITLE
[Merged by Bors] - feat(Analysis): lower bound for `log (1 + x)`

### DIFF
--- a/Mathlib/Analysis/SpecialFunctions/Integrals.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Integrals.lean
@@ -520,40 +520,6 @@ alias integral_log_of_pos := integral_log
 @[deprecated (since := "2025-01-12")]
 alias integral_log_of_neg := integral_log
 
-lemma Real.lt_log_add_one_of_pos {x : ℝ} (hx : 0 < x) : 2 * x / (x + 2) < log (x + 1) :=
-  have : ∀ {t}, 0 < t → (4 : ℝ) / (t + 2) ^ 2 < 1 / (t + 1) := fun ht => by
-    apply lt_of_sub_pos
-    rw [div_sub_div _ _ (by positivity) (by positivity)]
-    conv_rhs => enter [1]; ring_nf
-    positivity
-  have : ∫ (t : ℝ) in (0)..x, 4 / (t + 2) ^ 2 < ∫ (t : ℝ) in (0)..x, 1 / (t + 1) :=
-    intervalIntegral.integral_lt_integral_of_continuousOn_of_le_of_exists_lt hx
-      (continuousOn_const.div₀ ((continuousOn_id.add continuousOn_const).pow 2)
-        fun _ ⟨_, _⟩ => (by positivity))
-      (continuousOn_const.div₀ (continuousOn_id.add continuousOn_const)
-        fun _ ht => by rcases ht; positivity)
-      (fun _ ht => le_of_lt (this ht.1)) ⟨x, by simp_all [le_of_lt hx], this hx⟩
-  calc 2 * x / (x + 2) = ∫ t in (0).. x, 4 / (t + 2) ^ (2 : ℕ) := by {
-      rw [intervalIntegral.integral_comp_add_right (fun t => 4 / t ^ (2 : ℕ))]
-      simp only [← mul_one_div (4 : ℝ), one_div]
-      rw [intervalIntegral.integral_const_mul,
-        intervalIntegral.integral_congr_ae (g := (· ^ (- (2 : ℝ)))) <|
-        MeasureTheory.ae_of_all _ fun t ⟨ht, ht'⟩ => by
-          simp only [zero_add, inf_lt_iff, le_sup_iff, rpow_two] at ht ht' ⊢
-          rw [← rpow_two, rpow_neg]
-          rcases ht with ht|ht <;> rcases ht' with ht'|ht' <;> linarith,
-        integral_rpow
-          (.inr ⟨by norm_num, Set.not_mem_Icc_of_lt (lt_min (by norm_num) (by positivity))⟩)]
-      norm_num
-      rw [div_neg, div_one, neg_sub, rpow_neg_one, mul_sub, div_eq_of_eq_mul (by positivity)]
-      rw [sub_mul, inv_mul_cancel_right₀ (by positivity)]
-      ring_nf }
-    _ < ∫ t in (0)..x, 1 / (t + 1) := this
-    _ = log (x + 1) := by
-      rw [intervalIntegral.integral_comp_add_right,
-        integral_one_div (Set.not_mem_Icc_of_lt (lt_min (by norm_num) (by positivity)))]
-      simp
-
 @[simp]
 theorem integral_sin : ∫ x in a..b, sin x = cos a - cos b := by
   rw [integral_deriv_eq_sub' fun x => -cos x]

--- a/Mathlib/Analysis/SpecialFunctions/Log/Deriv.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Log/Deriv.lean
@@ -319,7 +319,7 @@ theorem hasSum_log_one_add_inv {a : ℝ} (h : 0 < a) :
     linarith
   · field_simp
 
-/-- Expansion of `log (a + 1)` as a series in powers of `a / (a + 2)`. -/
+/-- Expansion of `log (1 + a)` as a series in powers of `a / (a + 2)`. -/
 theorem hasSum_log_one_add {a : ℝ} (h : 0 ≤ a) :
     HasSum (fun k : ℕ => (2 : ℝ) * (1 / (2 * k + 1)) * (a / (a + 2)) ^ (2 * k + 1))
       (log (1 + a)) := by

--- a/Mathlib/Analysis/SpecialFunctions/Log/Deriv.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Log/Deriv.lean
@@ -320,22 +320,24 @@ theorem hasSum_log_one_add_inv {a : ℝ} (h : 0 < a) :
   · field_simp
 
 /-- Expansion of `log (a + 1)` as a series in powers of `a / (a + 2)`. -/
-theorem hasSum_log_one_add {a : ℝ} (h : 0 < a) :
+theorem hasSum_log_one_add {a : ℝ} (h : 0 ≤ a) :
     HasSum (fun k : ℕ => (2 : ℝ) * (1 / (2 * k + 1)) * (a / (a + 2)) ^ (2 * k + 1))
       (log (1 + a)) := by
-  have key := hasSum_log_one_add_inv (inv_pos.mpr h)
-  rw [inv_inv, add_comm] at key
-  exact key.congr_fun fun k ↦ by field_simp
+  by_cases ha0 : a = 0
+  · simp [ha0, hasSum_zero]
+  · have key := hasSum_log_one_add_inv (inv_pos.mpr (lt_of_le_of_ne h (Ne.symm ha0)))
+    rw [inv_inv, add_comm] at key
+    exact key.congr_fun fun k ↦ by field_simp
 
-lemma lt_log_one_add_of_pos {x : ℝ} (hx : 0 < x) : 2 * x / (x + 2) < log (1 + x) := by
-  have key := lt_hasSum (Real.hasSum_log_one_add hx) 0 (by intros; positivity)
-    1 (by positivity) (by positivity)
+lemma le_log_one_add_of_nonneg {x : ℝ} (hx : 0 ≤ x) : 2 * x / (x + 2) ≤ log (1 + x) := by
+  have key := le_hasSum (hasSum_log_one_add hx) 0 (by intros; positivity)
   field_simp at key
   exact key
 
-lemma le_log_one_add_of_nonneg {x : ℝ} (hx : 0 ≤ x) : 2 * x / (x + 2) ≤ log (1 + x) := by
-  rcases lt_or_eq_of_le hx with hx | rfl
-  · exact le_of_lt (lt_log_one_add_of_pos hx)
-  · norm_num
+lemma lt_log_one_add_of_pos {x : ℝ} (hx : 0 < x) : 2 * x / (x + 2) < log (1 + x) := by
+  have key := lt_hasSum (hasSum_log_one_add (le_of_lt hx)) 0 (by intros; positivity)
+    1 (by positivity) (by positivity)
+  field_simp at key
+  exact key
 
 end Real

--- a/Mathlib/Analysis/SpecialFunctions/Log/Deriv.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Log/Deriv.lean
@@ -323,7 +323,7 @@ theorem hasSum_log_one_add_inv {a : ℝ} (h : 0 < a) :
 theorem hasSum_log_one_add {a : ℝ} (h : 0 < a) :
     HasSum (fun k : ℕ => (2 : ℝ) * (1 / (2 * k + 1)) * (a / (a + 2)) ^ (2 * k + 1))
       (log (1 + a)) := by
-  have key := Real.hasSum_log_one_add_inv (inv_pos.mpr h)
+  have key := hasSum_log_one_add_inv (inv_pos.mpr h)
   rw [inv_inv, add_comm] at key
   exact key.congr_fun fun k ↦ by field_simp
 
@@ -332,5 +332,10 @@ lemma lt_log_add_one_of_pos {x : ℝ} (hx : 0 < x) : 2 * x / (x + 2) < log (1 + 
     1 (by positivity) (by positivity)
   field_simp at key
   exact key
+
+lemma le_log_add_one_of_nonneg {x : ℝ} (hx : 0 ≤ x) : 2 * x / (x + 2) ≤ log (1 + x) := by
+  rcases lt_or_eq_of_le hx with hx | rfl
+  · exact le_of_lt (lt_log_add_one_of_pos hx)
+  · norm_num
 
 end Real

--- a/Mathlib/Analysis/SpecialFunctions/Log/Deriv.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Log/Deriv.lean
@@ -327,15 +327,15 @@ theorem hasSum_log_one_add {a : ℝ} (h : 0 < a) :
   rw [inv_inv, add_comm] at key
   exact key.congr_fun fun k ↦ by field_simp
 
-lemma lt_log_add_one_of_pos {x : ℝ} (hx : 0 < x) : 2 * x / (x + 2) < log (1 + x) := by
+lemma lt_log_one_add_of_pos {x : ℝ} (hx : 0 < x) : 2 * x / (x + 2) < log (1 + x) := by
   have key := lt_hasSum (Real.hasSum_log_one_add hx) 0 (by intros; positivity)
     1 (by positivity) (by positivity)
   field_simp at key
   exact key
 
-lemma le_log_add_one_of_nonneg {x : ℝ} (hx : 0 ≤ x) : 2 * x / (x + 2) ≤ log (1 + x) := by
+lemma le_log_one_add_of_nonneg {x : ℝ} (hx : 0 ≤ x) : 2 * x / (x + 2) ≤ log (1 + x) := by
   rcases lt_or_eq_of_le hx with hx | rfl
-  · exact le_of_lt (lt_log_add_one_of_pos hx)
+  · exact le_of_lt (lt_log_one_add_of_pos hx)
   · norm_num
 
 end Real

--- a/Mathlib/Analysis/SpecialFunctions/Log/Deriv.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Log/Deriv.lean
@@ -319,4 +319,18 @@ theorem hasSum_log_one_add_inv {a : ℝ} (h : 0 < a) :
     linarith
   · field_simp
 
+/-- Expansion of `log (a + 1)` as a series in powers of `a / (a + 2)`. -/
+theorem hasSum_log_one_add {a : ℝ} (h : 0 < a) :
+    HasSum (fun k : ℕ => (2 : ℝ) * (1 / (2 * k + 1)) * (a / (a + 2)) ^ (2 * k + 1))
+      (log (1 + a)) := by
+  have key := Real.hasSum_log_one_add_inv (inv_pos.mpr h)
+  rw [inv_inv, add_comm] at key
+  exact key.congr_fun fun k ↦ by field_simp
+
+lemma lt_log_add_one_of_pos {x : ℝ} (hx : 0 < x) : 2 * x / (x + 2) < log (1 + x) := by
+  have key := lt_hasSum (Real.hasSum_log_one_add hx) 0 (by intros; positivity)
+    1 (by positivity) (by positivity)
+  field_simp at key
+  exact key
+
 end Real

--- a/Mathlib/Analysis/SpecialFunctions/Log/Deriv.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Log/Deriv.lean
@@ -323,21 +323,18 @@ theorem hasSum_log_one_add_inv {a : ℝ} (h : 0 < a) :
 theorem hasSum_log_one_add {a : ℝ} (h : 0 ≤ a) :
     HasSum (fun k : ℕ => (2 : ℝ) * (1 / (2 * k + 1)) * (a / (a + 2)) ^ (2 * k + 1))
       (log (1 + a)) := by
-  by_cases ha0 : a = 0
-  · simp [ha0, hasSum_zero]
-  · have key := hasSum_log_one_add_inv (inv_pos.mpr (lt_of_le_of_ne h (Ne.symm ha0)))
-    rw [inv_inv, add_comm] at key
-    exact key.congr_fun fun k ↦ by field_simp
+  obtain (rfl | ha0) := eq_or_ne a 0
+  · simp [hasSum_zero]
+  · convert hasSum_log_one_add_inv (inv_pos.mpr (lt_of_le_of_ne h ha0.symm)) using 4
+    all_goals field_simp [add_comm]
 
 lemma le_log_one_add_of_nonneg {x : ℝ} (hx : 0 ≤ x) : 2 * x / (x + 2) ≤ log (1 + x) := by
-  have key := le_hasSum (hasSum_log_one_add hx) 0 (by intros; positivity)
-  field_simp at key
-  exact key
+  convert le_hasSum (hasSum_log_one_add hx) 0 (by intros; positivity) using 1
+  field_simp
 
 lemma lt_log_one_add_of_pos {x : ℝ} (hx : 0 < x) : 2 * x / (x + 2) < log (1 + x) := by
-  have key := lt_hasSum (hasSum_log_one_add (le_of_lt hx)) 0 (by intros; positivity)
-    1 (by positivity) (by positivity)
-  field_simp at key
-  exact key
+  convert lt_hasSum (hasSum_log_one_add hx.le) 0 (by intros; positivity)
+    1 (by positivity) (by positivity) using 1
+  field_simp
 
 end Real

--- a/Mathlib/Topology/Algebra/InfiniteSum/Order.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/Order.lean
@@ -101,6 +101,16 @@ theorem le_hasProd (hf : HasProd f a) (i : ι) (hb : ∀ j, j ≠ i → 1 ≤ f 
     _ ≤ a := prod_le_hasProd _ (by simpa) hf
 
 @[to_additive]
+theorem lt_hasProd [MulRightStrictMono α] (hf : HasProd f a) (i : ι)
+    (hi : ∀ (j : ι), j ≠ i → 1 ≤ f j) (j : ι) (hij : j ≠ i) (hj : 1 < f j) :
+    f i < a := by
+  classical
+  calc
+    f i < f j * f i := lt_mul_of_one_lt_left' (f i) hj
+    _ = ∏ k ∈ {j, i}, f k := by rw [Finset.prod_pair hij]
+    _ ≤ a := prod_le_hasProd _ (fun k hk ↦ hi k (hk ∘ mem_insert_of_mem ∘ mem_singleton.mpr)) hf
+
+@[to_additive]
 theorem prod_le_tprod {f : ι → α} (s : Finset ι) (hs : ∀ i, i ∉ s → 1 ≤ f i) (hf : Multipliable f) :
     ∏ i ∈ s, f i ≤ ∏' i, f i :=
   prod_le_hasProd s hs hf.hasProd


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
