### PR TITLE
[Merged by Bors] - chore(Matroid/Dual): desimp dual_indep_iff_exists

### DIFF
--- a/Mathlib/Data/Matroid/Dual.lean
+++ b/Mathlib/Data/Matroid/Dual.lean
@@ -119,7 +119,7 @@ theorem dual_indep_iff_exists' : (M✶.Indep I) ↔ I ⊆ M.E ∧ (∃ B, M.Base
 
 @[simp] theorem dual_ground : M✶.E = M.E := rfl
 
-@[simp] theorem dual_indep_iff_exists (hI : I ⊆ M.E := by aesop_mat) :
+theorem dual_indep_iff_exists (hI : I ⊆ M.E := by aesop_mat) :
     M✶.Indep I ↔ (∃ B, M.Base B ∧ Disjoint I B) := by
   rw [dual_indep_iff_exists', and_iff_right hI]
 


### PR DESCRIPTION
It was never a good idea for this to be a simp lemma, which was my bad decision in the first place - dual independence is often best spelled `Coindep`, and the RHS of this one often makes things actively more complicated. 

The tiny diff indicates this lemma was never used in simplification. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
