### PR TITLE
[Merged by Bors] - chore(LightProfinite): remove unecessary `have`

### DIFF
--- a/Mathlib/Topology/Category/LightProfinite/Basic.lean
+++ b/Mathlib/Topology/Category/LightProfinite/Basic.lean
@@ -157,7 +157,6 @@ def limitConeIsLimit {J : Type v} [SmallCategory J] [CountableCategory J]
 noncomputable instance createsCountableLimits {J : Type v} [SmallCategory J] [CountableCategory J] :
     CreatesLimitsOfShape J lightToProfinite.{max v u} where
   CreatesLimit {F} :=
-    have : HasLimitsOfSize Profinite := hasLimitsOfSizeShrink _
     createsLimitOfFullyFaithfulOfIso (limitCone.{v, u} F).pt <|
       (Profinite.limitConeIsLimit.{v, u} (F ⋙ lightToProfinite)).conePointUniqueUpToIso
         (limit.isLimit _)


### PR DESCRIPTION
The `have` can be synthesized and deleting it results in a term equivalent at reducible and instances transparency.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
