### PR TITLE
[Merged by Bors] - feat: add `sq_nonpos_iff`

### DIFF
--- a/Mathlib/Algebra/Order/Ring/Unbundled/Basic.lean
+++ b/Mathlib/Algebra/Order/Ring/Unbundled/Basic.lean
@@ -699,6 +699,14 @@ lemma sq_nonneg [IsRightCancelAdd α]
     _ = a * (a + b) := by simp [← hab]
     _ = a ^ 2 + a * b := by rw [sq, mul_add]
 
+@[simp]
+lemma sq_nonpos_iff [IsRightCancelAdd α] [ZeroLEOneClass α] [ExistsAddOfLE α]
+    [PosMulMono α] [AddLeftStrictMono α] [NoZeroDivisors α] (r : α) :
+    r ^ 2 ≤ 0 ↔ r = 0 := by
+  trans r ^ 2 = 0
+  · rw [le_antisymm_iff, and_iff_left (sq_nonneg r)]
+  · exact sq_eq_zero_iff
+
 alias pow_two_nonneg := sq_nonneg
 
 lemma mul_self_nonneg [IsRightCancelAdd α]


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
