### PR TITLE
[Merged by Bors] - chore(List): add `@[gcongr]` lemmas about `List.flatten`

### DIFF
--- a/Mathlib/Data/List/Flatten.lean
+++ b/Mathlib/Data/List/Flatten.lean
@@ -29,6 +29,11 @@ protected theorem Sublist.flatten {l₁ l₂ : List (List α)} (h : l₁ <+ l₂
     exact ih.trans (sublist_append_right _ _)
   | cons₂ _ _ ih => simpa
 
+@[gcongr]
+protected theorem Sublist.flatMap {l₁ l₂ : List α} (h : l₁ <+ l₂) (f : α → List β) :
+    l₁.flatMap f <+ l₂.flatMap f :=
+  (h.map f).flatten
+
 set_option linter.deprecated false in
 /-- See `List.length_flatten` for the corresponding statement using `List.sum`. -/
 @[deprecated length_flatten (since := "2024-10-17")]

--- a/Mathlib/Data/List/Flatten.lean
+++ b/Mathlib/Data/List/Flatten.lean
@@ -19,6 +19,16 @@ variable {α β : Type*}
 
 namespace List
 
+@[gcongr]
+protected theorem Sublist.flatten {l₁ l₂ : List (List α)} (h : l₁ <+ l₂) :
+    l₁.flatten <+ l₂.flatten := by
+  induction h with
+  | slnil => simp
+  | cons _ _ ih =>
+    rw [flatten_cons]
+    exact ih.trans (sublist_append_right _ _)
+  | cons₂ _ _ ih => simpa
+
 set_option linter.deprecated false in
 /-- See `List.length_flatten` for the corresponding statement using `List.sum`. -/
 @[deprecated length_flatten (since := "2024-10-17")]

--- a/Mathlib/Data/List/Infix.lean
+++ b/Mathlib/Data/List/Infix.lean
@@ -66,6 +66,24 @@ lemma isPrefix_append_of_length (h : l₁.length ≤ l₂.length) : l₁ <+: l�
 @[simp] lemma take_isPrefix_take {m n : ℕ} : l.take m <+: l.take n ↔ m ≤ n ∨ l.length ≤ n := by
   simp [prefix_take_iff, take_prefix]; omega
 
+@[gcongr]
+protected theorem IsPrefix.flatten {l₁ l₂ : List (List α)} (h : l₁ <+: l₂) :
+    l₁.flatten <+: l₂.flatten := by
+  rcases h with ⟨l, rfl⟩
+  simp
+
+@[gcongr]
+protected theorem IsSuffix.flatten {l₁ l₂ : List (List α)} (h : l₁ <:+ l₂) :
+    l₁.flatten <:+ l₂.flatten := by
+  rcases h with ⟨l, rfl⟩
+  simp
+
+@[gcongr]
+protected theorem IsInfix.flatten {l₁ l₂ : List (List α)} (h : l₁ <:+: l₂) :
+    l₁.flatten <:+: l₂.flatten := by
+  rcases h with ⟨l, l', rfl⟩
+  simp
+
 lemma dropSlice_sublist (n m : ℕ) (l : List α) : l.dropSlice n m <+ l :=
   calc
     l.dropSlice n m = take n l ++ drop m (drop n l) := by rw [dropSlice_eq, drop_drop, Nat.add_comm]

--- a/Mathlib/Data/List/Infix.lean
+++ b/Mathlib/Data/List/Infix.lean
@@ -25,7 +25,7 @@ All those (except `insert`) are defined in `Mathlib.Data.List.Defs`.
 * `l₁ <:+: l₂`: `l₁` is an infix of `l₂`.
 -/
 
-variable {α : Type*}
+variable {α β : Type*}
 
 namespace List
 
@@ -73,16 +73,31 @@ protected theorem IsPrefix.flatten {l₁ l₂ : List (List α)} (h : l₁ <+: l�
   simp
 
 @[gcongr]
+protected theorem IsPrefix.flatMap (h : l₁ <+: l₂) (f : α → List β) :
+    l₁.flatMap f <+: l₂.flatMap f :=
+  (h.map _).flatten
+
+@[gcongr]
 protected theorem IsSuffix.flatten {l₁ l₂ : List (List α)} (h : l₁ <:+ l₂) :
     l₁.flatten <:+ l₂.flatten := by
   rcases h with ⟨l, rfl⟩
   simp
 
 @[gcongr]
+protected theorem IsSuffix.flatMap (h : l₁ <:+ l₂) (f : α → List β) :
+    l₁.flatMap f <:+ l₂.flatMap f :=
+  (h.map _).flatten
+
+@[gcongr]
 protected theorem IsInfix.flatten {l₁ l₂ : List (List α)} (h : l₁ <:+: l₂) :
     l₁.flatten <:+: l₂.flatten := by
   rcases h with ⟨l, l', rfl⟩
   simp
+
+@[gcongr]
+protected theorem IsInfix.flatMap (h : l₁ <:+: l₂) (f : α → List β) :
+    l₁.flatMap f <:+: l₂.flatMap f :=
+  (h.map _).flatten
 
 lemma dropSlice_sublist (n m : ℕ) (l : List α) : l.dropSlice n m <+ l :=
   calc


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
