### PR TITLE
[Merged by Bors] - chore(Cache): rename HashMap to ModuleHashMap

### DIFF
--- a/Cache/IO.lean
+++ b/Cache/IO.lean
@@ -263,6 +263,9 @@ partial def getFilesWithExtension
     (← fp.readDir).foldlM (fun acc dir => getFilesWithExtension dir.path extension acc) acc
   else return if fp.extension == some extension then acc.push fp else acc
 
+/--
+The Hash map of the cache.
+-/
 abbrev ModuleHashMap := Std.HashMap FilePath UInt64
 
 namespace ModuleHashMap

--- a/Cache/IO.lean
+++ b/Cache/IO.lean
@@ -263,25 +263,25 @@ partial def getFilesWithExtension
     (← fp.readDir).foldlM (fun acc dir => getFilesWithExtension dir.path extension acc) acc
   else return if fp.extension == some extension then acc.push fp else acc
 
-abbrev HashMap := Std.HashMap FilePath UInt64
+abbrev ModuleHashMap := Std.HashMap FilePath UInt64
 
-namespace HashMap
+namespace ModuleHashMap
 
 /-- Filter the hashmap by whether the entries exist as files in the cache directory.
 
 If `keep` is true, the result will contain the entries that do exist;
 if `keep` is false, the result will contain the entries that do not exist.
 -/
-def filterExists (hashMap : HashMap) (keep : Bool) : IO HashMap :=
+def filterExists (hashMap : ModuleHashMap) (keep : Bool) : IO ModuleHashMap :=
   hashMap.foldM (init := default) fun acc path hash => do
     let exist ← (CACHEDIR / hash.asLTar).pathExists
     let add := if keep then exist else !exist
     if add then return acc.insert path hash else return acc
 
-def hashes (hashMap : HashMap) : Lean.RBTree UInt64 compare :=
+def hashes (hashMap : ModuleHashMap) : Lean.RBTree UInt64 compare :=
   hashMap.fold (init := default) fun acc _ hash => acc.insert hash
 
-end HashMap
+end ModuleHashMap
 
 def mkDir (path : FilePath) : IO Unit := do
   if !(← path.pathExists) then IO.FS.createDirAll path
@@ -310,7 +310,7 @@ def allExist (paths : List (FilePath × Bool)) : IO Bool := do
   pure true
 
 /-- Compresses build files into the local cache and returns an array with the compressed files -/
-def packCache (hashMap : HashMap) (overwrite verbose unpackedOnly : Bool)
+def packCache (hashMap : ModuleHashMap) (overwrite verbose unpackedOnly : Bool)
     (comment : Option String := none) :
     CacheM <| Array String := do
   mkDir CACHEDIR
@@ -353,7 +353,7 @@ def isPathFromMathlib (path : FilePath) : Bool :=
   | _ => false
 
 /-- Decompresses build files into their respective folders -/
-def unpackCache (hashMap : HashMap) (force : Bool) : CacheM Unit := do
+def unpackCache (hashMap : ModuleHashMap) (force : Bool) : CacheM Unit := do
   let hashMap ← hashMap.filterExists true
   let size := hashMap.size
   if size > 0 then
@@ -387,7 +387,7 @@ def cleanCache (keep : Lean.RBTree FilePath compare := default) : IO Unit := do
 
 /-- Prints the LTAR file and embedded comments (in particular, the mathlib commit that built the
 file) regarding the files with specified paths. -/
-def lookup (hashMap : HashMap) (paths : List FilePath) : IO Unit := do
+def lookup (hashMap : ModuleHashMap) (paths : List FilePath) : IO Unit := do
   let mut err := false
   for path in paths do
     let some hash := hashMap[path]? | err := true

--- a/Cache/Requests.lean
+++ b/Cache/Requests.lean
@@ -38,7 +38,7 @@ def mkFileURL (URL fileName : String) : String :=
 section Get
 
 /-- Formats the config file for `curl`, containing the list of files to be downloaded -/
-def mkGetConfigContent (hashMap : IO.HashMap) : IO String := do
+def mkGetConfigContent (hashMap : IO.ModuleHashMap) : IO String := do
   hashMap.toArray.foldlM (init := "") fun acc ⟨_, hash⟩ => do
     let fileName := hash.asLTar
     -- Below we use `String.quote`, which is intended for quoting for use in Lean code
@@ -75,7 +75,8 @@ def downloadFile (hash : UInt64) : IO Bool := do
 
 /-- Call `curl` to download files from the server to `CACHEDIR` (`.cache`).
 Exit the process with exit code 1 if any files failed to download. -/
-def downloadFiles (hashMap : IO.HashMap) (forceDownload : Bool) (parallel : Bool) : IO Unit := do
+def downloadFiles (hashMap : IO.ModuleHashMap) (forceDownload : Bool) (parallel : Bool) :
+    IO Unit := do
   let hashMap ← if forceDownload then pure hashMap else hashMap.filterExists false
   let size := hashMap.size
   if size > 0 then
@@ -184,7 +185,7 @@ def getProofWidgets (buildDir : FilePath) : IO Unit := do
     throw <| IO.userError s!"Failed to prune ProofWidgets cloud release: {e}"
 
 /-- Downloads missing files, and unpacks files. -/
-def getFiles (hashMap : IO.HashMap) (forceDownload forceUnpack parallel decompress : Bool) :
+def getFiles (hashMap : IO.ModuleHashMap) (forceDownload forceUnpack parallel decompress : Bool) :
     IO.CacheM Unit := do
   let isMathlibRoot ← IO.isMathlibRoot
   unless isMathlibRoot do checkForToolchainMismatch
@@ -249,7 +250,7 @@ Sends a commit file to the server, containing the hashes of the respective commi
 
 The file name is the current Git hash and the `c/` prefix means that it's a commit file.
 -/
-def commit (hashMap : IO.HashMap) (overwrite : Bool) (token : String) : IO Unit := do
+def commit (hashMap : IO.ModuleHashMap) (overwrite : Bool) (token : String) : IO Unit := do
   let hash ← getGitCommitHash
   let path := IO.CACHEDIR / hash
   IO.mkDir IO.CACHEDIR


### PR DESCRIPTION
Rename `Cache.IO.HashMap` to `Cache.IO.ModuleHashMap` to avoid confusion with `Std.HashMap` and deprecated `Lean.HashMap`

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
