### PR TITLE
[Merged by Bors] - doc(Tactic/ToAdditive/Frontend): more helpful error message when a name cannot be tr…

### DIFF
--- a/Mathlib/Tactic/ToAdditive/Frontend.lean
+++ b/Mathlib/Tactic/ToAdditive/Frontend.lean
@@ -1103,10 +1103,11 @@ def targetName (cfg : Config) (src : Name) : CoreM Name := do
   let res := if cfg.tgt == .anonymous then pre.str tgt_auto else pre1 ++ cfg.tgt
   -- we allow translating to itself if `tgt == src`, which is occasionally useful for `additiveTest`
   if res == src && cfg.tgt != src then
-    throwError "to_additive: the generated additivised name equals the original name {src}.\n\
-    Usually, this means you need to name your declaration correctly\n\
-    (e.g., name instances with a name that can be additivised).\n\
-    Sometimes, this means you need to extend to_additive to handle the new names."
+    throwError "to_additive: the generated additivised name equals the original name {src}, \
+    meaning that no part of the name was additivised.\n\
+    Check that your declaration name is correct \
+    (if your declaration is an instance, try naming it)\n\
+    or provide an additivised name using the 'to_additive my_add_name' syntax."
   if cfg.tgt != .anonymous then
     trace[to_additive_detail] "The automatically generated name would be {pre.str tgt_auto}"
   return res

--- a/Mathlib/Tactic/ToAdditive/Frontend.lean
+++ b/Mathlib/Tactic/ToAdditive/Frontend.lean
@@ -1103,11 +1103,11 @@ def targetName (cfg : Config) (src : Name) : CoreM Name := do
   let res := if cfg.tgt == .anonymous then pre.str tgt_auto else pre1 ++ cfg.tgt
   -- we allow translating to itself if `tgt == src`, which is occasionally useful for `additiveTest`
   if res == src && cfg.tgt != src then
-    throwError "to_additive: the generated additivised name equals the original name {src}, \
+    throwError "to_additive: the generated additivised name equals the original name '{src}', \
     meaning that no part of the name was additivised.\n\
     Check that your declaration name is correct \
     (if your declaration is an instance, try naming it)\n\
-    or provide an additivised name using the 'to_additive my_add_name' syntax."
+    or provide an additivised name using the '@[to_additive my_add_name]' syntax."
   if cfg.tgt != .anonymous then
     trace[to_additive_detail] "The automatically generated name would be {pre.str tgt_auto}"
   return res

--- a/Mathlib/Tactic/ToAdditive/Frontend.lean
+++ b/Mathlib/Tactic/ToAdditive/Frontend.lean
@@ -1103,9 +1103,9 @@ def targetName (cfg : Config) (src : Name) : CoreM Name := do
   let res := if cfg.tgt == .anonymous then pre.str tgt_auto else pre1 ++ cfg.tgt
   -- we allow translating to itself if `tgt == src`, which is occasionally useful for `additiveTest`
   if res == src && cfg.tgt != src then
-    throwError "to_additive: the generated additivised name equals the original name {src}.\
-    Usually, this means you need to name your declaration correctly \
-    (e.g., name instances with a name that can be additivised). \
+    throwError "to_additive: the generated additivised name equals the original name {src}.\n\
+    Usually, this means you need to name your declaration correctly\n\
+    (e.g., name instances with a name that can be additivised).\n\
     Sometimes, this means you need to extend to_additive to handle the new names."
   if cfg.tgt != .anonymous then
     trace[to_additive_detail] "The automatically generated name would be {pre.str tgt_auto}"

--- a/Mathlib/Tactic/ToAdditive/Frontend.lean
+++ b/Mathlib/Tactic/ToAdditive/Frontend.lean
@@ -1103,7 +1103,10 @@ def targetName (cfg : Config) (src : Name) : CoreM Name := do
   let res := if cfg.tgt == .anonymous then pre.str tgt_auto else pre1 ++ cfg.tgt
   -- we allow translating to itself if `tgt == src`, which is occasionally useful for `additiveTest`
   if res == src && cfg.tgt != src then
-    throwError "to_additive: can't transport {src} to itself."
+    throwError "to_additive: the generated additivised name equals the original name {src}.\
+    Usually, this means you need to name your declaration correctly \
+    (e.g., name instances with a name that can be additivised). \
+    Sometimes, this means you need to extend to_additive to handle the new names."
   if cfg.tgt != .anonymous then
     trace[to_additive_detail] "The automatically generated name would be {pre.str tgt_auto}"
   return res

--- a/Mathlib/Tactic/ToAdditive/Frontend.lean
+++ b/Mathlib/Tactic/ToAdditive/Frontend.lean
@@ -1194,8 +1194,8 @@ partial def applyAttributes (stx : Syntax) (rawAttrs : Array Syntax) (thisAttr s
       -- Note: we're not bothering to print the correct attribute arguments.
       Linter.logLintIf linter.existingAttributeWarning stx m!"\
         The source declaration {src} was given the simp-attribute(s) {appliedAttrs} before \
-        calling @[{thisAttr}]. The preferred method is to use something like \
-        `@[{thisAttr} (attr := {appliedAttrs})]` to apply the attribute to both \
+        calling @[{thisAttr}].\nThe preferred method is to use something like \
+        `@[{thisAttr} (attr := {appliedAttrs})]`\nto apply the attribute to both \
         {src} and the target declaration {tgt}."
     warnAttr stx Lean.Elab.Tactic.Ext.extExtension
       (fun b n => (b.tree.values.any fun t => t.declName = n)) thisAttr `ext src tgt

--- a/MathlibTest/toAdditive.lean
+++ b/MathlibTest/toAdditive.lean
@@ -322,7 +322,7 @@ def Ones : ℕ → Q(Nat)
   | (n+1) => q($(Ones n) + $(Ones n))
 
 
--- this test just exists to see if this finishes in finite time. It should take <100ms.
+-- This test just exists to see if this finishes in finite time. It should take <100ms.
 -- #time
 run_cmd do
   let e : Expr := Ones 300
@@ -422,7 +422,9 @@ run_cmd do
   unless findTranslation? (← getEnv) `localize.s == some `add_localize.s do throwError "3"
 
 /--
-warning: The source declaration one_eq_one was given the simp-attribute(s) simp, reduce_mod_char before calling @[to_additive]. The preferred method is to use something like `@[to_additive (attr := simp, reduce_mod_char)]` to apply the attribute to both one_eq_one and the target declaration zero_eq_zero.
+warning: The source declaration one_eq_one was given the simp-attribute(s) simp, reduce_mod_char before calling @[to_additive].
+The preferred method is to use something like `@[to_additive (attr := simp, reduce_mod_char)]`
+to apply the attribute to both one_eq_one and the target declaration zero_eq_zero.
 note: this linter can be disabled with `set_option linter.existingAttributeWarning false`
 -/
 #guard_msgs in

--- a/MathlibTest/toAdditive.lean
+++ b/MathlibTest/toAdditive.lean
@@ -439,9 +439,9 @@ lemma one_eq_one' {α : Type*} [One α] : (1 : α) = 1 := rfl
 /--
 warning: declaration uses 'sorry'
 ---
-error: to_additive: the generated additivised name equals the original name foo, meaning that no part of the name was additivised.
+error: to_additive: the generated additivised name equals the original name 'foo', meaning that no part of the name was additivised.
 Check that your declaration name is correct (if your declaration is an instance, try naming it)
-or provide an additivised name using the 'to_additive my_add_name' syntax.
+or provide an additivised name using the '@[to_additive my_add_name]' syntax.
 -/
 #guard_msgs in
 @[to_additive]

--- a/MathlibTest/toAdditive.lean
+++ b/MathlibTest/toAdditive.lean
@@ -431,3 +431,17 @@ lemma one_eq_one {α : Type*} [One α] : (1 : α) = 1 := rfl
 
 @[to_additive (attr := reduce_mod_char, simp)]
 lemma one_eq_one' {α : Type*} [One α] : (1 : α) = 1 := rfl
+
+-- Test the error message for a name that cannot be additivised.
+
+/--
+warning: declaration uses 'sorry'
+---
+error: to_additive: the generated additivised name equals the original name foo.
+Usually, this means you need to name your declaration correctly
+(e.g., name instances with a name that can be additivised).
+Sometimes, this means you need to extend to_additive to handle the new names.
+-/
+#guard_msgs in
+@[to_additive]
+instance foo {α : Type*} [Semigroup α] : Monoid α := sorry

--- a/MathlibTest/toAdditive.lean
+++ b/MathlibTest/toAdditive.lean
@@ -437,10 +437,9 @@ lemma one_eq_one' {α : Type*} [One α] : (1 : α) = 1 := rfl
 /--
 warning: declaration uses 'sorry'
 ---
-error: to_additive: the generated additivised name equals the original name foo.
-Usually, this means you need to name your declaration correctly
-(e.g., name instances with a name that can be additivised).
-Sometimes, this means you need to extend to_additive to handle the new names.
+error: to_additive: the generated additivised name equals the original name foo, meaning that no part of the name was additivised.
+Check that your declaration name is correct (if your declaration is an instance, try naming it)
+or provide an additivised name using the 'to_additive my_add_name' syntax.
 -/
 #guard_msgs in
 @[to_additive]


### PR DESCRIPTION
…ansported

This would have helped me in #21422.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
