### PR TITLE
[Merged by Bors] - refactor(*): get rid of last `HasForget.instFunLike` instances

### DIFF
--- a/Mathlib/Algebra/Homology/ConcreteCategory.lean
+++ b/Mathlib/Algebra/Homology/ConcreteCategory.lean
@@ -10,7 +10,7 @@ import Mathlib.Algebra.Homology.ShortComplex.ConcreteCategory
 # Homology of complexes in concrete categories
 
 The homology of short complexes in concrete categories was studied in
-`Mathlib.Algebra.Homology.ShortComplex.HasForget`. In this file,
+`Mathlib.Algebra.Homology.ShortComplex.ConcreteCategory`. In this file,
 we introduce specific definitions and lemmas for the homology
 of homological complexes in concrete categories. In particular,
 we give a computation of the connecting homomorphism of
@@ -22,7 +22,8 @@ open CategoryTheory
 
 universe v u
 
-variable {C : Type u} [Category.{v} C] [HasForget.{v} C] [HasForget₂ C Ab.{v}]
+variable {C : Type u} [Category.{v} C] {FC : C → C → Type*} {CC : C → Type v}
+  [∀ X Y, FunLike (FC X Y) (CC X) (CC Y)] [ConcreteCategory.{v} C FC] [HasForget₂ C Ab.{v}]
   [Abelian C] [(forget₂ C Ab).Additive] [(forget₂ C Ab).PreservesHomology]
   {ι : Type*} {c : ComplexShape ι}
 
@@ -75,30 +76,21 @@ lemma δ_apply (x₃ : (forget₂ C Ab).obj (S.X₃.X i))
         (forget₂ C Ab).map (S.X₁.homologyπ j) (S.X₁.cyclesMk x₁ k hk (by
           have := hS.mono_f
           apply (Preadditive.mono_iff_injective (S.f.f k)).1 inferInstance
-          -- Since `C` is only a `HasForget`, not a `ConcreteCategory` (for now),
-          -- we need to rewrite everything to `HasForget`.
-          have : ∀ {X Y : Ab} (f : X ⟶ Y), (f : X → Y) =
-            @DFunLike.coe _ _ _ (HasForget.toFunLike _ _ _) f := by intros; ext; rfl
-          rw [this, this, ← forget₂_comp_apply, ← HomologicalComplex.Hom.comm, forget₂_comp_apply,
-            ← this, ← this, hx₁, this, this,
-            ← forget₂_comp_apply, HomologicalComplex.d_comp_d, Functor.map_zero, ← this, ← this,
-            map_zero]; rfl)) := by
-  -- Since `C` is only a `HasForget`, not a `ConcreteCategory` (for now),
-  -- we need to rewrite everything to `HasForget`.
-  have : ∀ {X Y : Ab} (f : X ⟶ Y), (f : X → Y) =
-  @DFunLike.coe _ _ _ (HasForget.toFunLike _ _ _) f := by intros; ext; rfl
+          rw [← ConcreteCategory.forget₂_comp_apply, ← HomologicalComplex.Hom.comm,
+            ConcreteCategory.forget₂_comp_apply, hx₁, ← ConcreteCategory.forget₂_comp_apply,
+            HomologicalComplex.d_comp_d, Functor.map_zero, map_zero]; rfl)) := by
   refine hS.δ_apply' i j hij _ ((forget₂ C Ab).map (S.X₂.pOpcycles i) x₂) _ ?_ ?_
-  · rw [this, this, ← forget₂_comp_apply, this, this, ← forget₂_comp_apply,
-      HomologicalComplex.p_opcyclesMap, Functor.map_comp, CategoryTheory.comp_apply,
-      HomologicalComplex.homology_π_ι, forget₂_comp_apply, ← this, ← this, hx₂, ← this,
+  · rw [← ConcreteCategory.forget₂_comp_apply, ← ConcreteCategory.forget₂_comp_apply,
+      HomologicalComplex.p_opcyclesMap, Functor.map_comp, ConcreteCategory.comp_apply,
+      HomologicalComplex.homology_π_ι, ConcreteCategory.forget₂_comp_apply, hx₂,
       HomologicalComplex.i_cyclesMk]
   · apply (Preadditive.mono_iff_injective (S.X₂.iCycles j)).1 inferInstance
     conv_lhs =>
-      rw [this, this, ← forget₂_comp_apply, HomologicalComplex.cyclesMap_i, forget₂_comp_apply,
-        ← this ((forget₂ C Ab).map (S.X₁.iCycles j)), HomologicalComplex.i_cyclesMk, ← this, hx₁]
+      rw [← ConcreteCategory.forget₂_comp_apply, HomologicalComplex.cyclesMap_i,
+        ConcreteCategory.forget₂_comp_apply, HomologicalComplex.i_cyclesMk, hx₁]
     conv_rhs =>
-      rw [this, this, ← forget₂_comp_apply, this, ← forget₂_comp_apply,
-        HomologicalComplex.pOpcycles_opcyclesToCycles_assoc, HomologicalComplex.toCycles_i, ← this]
+      rw [← ConcreteCategory.forget₂_comp_apply, ← ConcreteCategory.forget₂_comp_apply,
+        HomologicalComplex.pOpcycles_opcyclesToCycles_assoc, HomologicalComplex.toCycles_i]
 
 end ShortExact
 

--- a/Mathlib/Algebra/Homology/ShortComplex/ConcreteCategory.lean
+++ b/Mathlib/Algebra/Homology/ShortComplex/ConcreteCategory.lean
@@ -25,7 +25,8 @@ open Limits
 
 section
 
-variable {C : Type u} [Category.{v} C] [HasForget.{w} C] [HasForget₂ C Ab]
+variable {C : Type u} [Category.{v} C] {FC : C → C → Type*} {CC : C → Type w}
+variable [∀ X Y, FunLike (FC X Y) (CC X) (CC Y)] [ConcreteCategory.{w} C FC] [HasForget₂ C Ab]
 
 @[simp]
 lemma ShortComplex.zero_apply
@@ -52,7 +53,7 @@ lemma Preadditive.mono_iff_injective {X Y : C} (f : X ⟶ Y) :
   · apply Functor.mono_of_mono_map
 
 lemma Preadditive.mono_iff_injective' {X Y : C} (f : X ⟶ Y) :
-    Mono f ↔ Function.Injective ((forget C).map f) := by
+    Mono f ↔ Function.Injective f := by
   simp only [mono_iff_injective, ← CategoryTheory.mono_iff_injective]
   apply (MorphismProperty.monomorphisms (Type w)).arrow_mk_iso_iff
   have e : forget₂ C Ab ⋙ forget Ab ≅ forget C := eqToIso (HasForget₂.forget_comp)
@@ -67,7 +68,7 @@ lemma Preadditive.epi_iff_surjective {X Y : C} (f : X ⟶ Y) :
   · apply Functor.epi_of_epi_map
 
 lemma Preadditive.epi_iff_surjective' {X Y : C} (f : X ⟶ Y) :
-    Epi f ↔ Function.Surjective ((forget C).map f) := by
+    Epi f ↔ Function.Surjective f := by
   simp only [epi_iff_surjective, ← CategoryTheory.epi_iff_surjective]
   apply (MorphismProperty.epimorphisms (Type w)).arrow_mk_iso_iff
   have e : forget₂ C Ab ⋙ forget Ab ≅ forget C := eqToIso (HasForget₂.forget_comp)
@@ -112,8 +113,11 @@ lemma i_cyclesMk [S.HasHomology] (x₂ : (forget₂ C Ab).obj S.X₂)
     (hx₂ : ((forget₂ C Ab).map S.g) x₂ = 0) :
     (forget₂ C Ab).map S.iCycles (S.cyclesMk x₂ hx₂) = x₂ := by
   dsimp [cyclesMk]
-  erw [← ConcreteCategory.comp_apply, S.mapCyclesIso_hom_iCycles (forget₂ C Ab),
-    ← ConcreteCategory.comp_apply, abCyclesIso_inv_apply_iCycles]
+  -- `abCyclesIso_inv_apply_iCycles` is not in `simp`-normal form, so we first
+  -- have to simplify it.
+  have := abCyclesIso_inv_apply_iCycles (S.map (forget₂ C Ab)) ⟨x₂, hx₂⟩
+  simp only [map_X₂, map_X₃, map_g] at this
+  rw [← ConcreteCategory.comp_apply, S.mapCyclesIso_hom_iCycles (forget₂ C Ab), this]
 
 end ShortComplex
 
@@ -123,10 +127,9 @@ end
 
 section abelian
 
-variable {C : Type u} [Category.{v} C] [HasForget.{v} C] [HasForget₂ C Ab]
+variable {C : Type u} [Category.{v} C] {FC : C → C → Type*} {CC : C → Type v}
+  [∀ X Y, FunLike (FC X Y) (CC X) (CC Y)] [ConcreteCategory.{v} C FC] [HasForget₂ C Ab]
   [Abelian C] [(forget₂ C Ab).Additive] [(forget₂ C Ab).PreservesHomology]
-
-attribute [local instance] HasForget.instFunLike HasForget.hasCoeToSort
 
 namespace ShortComplex
 
@@ -136,25 +139,24 @@ variable (D : SnakeInput C)
 
 /-- This lemma allows the computation of the connecting homomorphism
 `D.δ` when `D : SnakeInput C` and `C` is a concrete category. -/
-lemma δ_apply (x₃ : D.L₀.X₃) (x₂ : D.L₁.X₂) (x₁ : D.L₂.X₁)
+lemma δ_apply (x₃ : ToType (D.L₀.X₃)) (x₂ : ToType (D.L₁.X₂)) (x₁ : ToType (D.L₂.X₁))
     (h₂ : D.L₁.g x₂ = D.v₀₁.τ₃ x₃) (h₁ : D.L₂.f x₁ = D.v₁₂.τ₂ x₂) :
     D.δ x₃ = D.v₂₃.τ₁ x₁ := by
   have := (forget₂ C Ab).preservesFiniteLimits_of_preservesHomology
   have : PreservesFiniteLimits (forget C) := by
     have : forget₂ C Ab ⋙ forget Ab = forget C := HasForget₂.forget_comp
     simpa only [← this] using comp_preservesFiniteLimits _ _
-  have eq := congr_fun ((forget C).congr_map D.snd_δ)
+  have eq := CategoryTheory.congr_fun (D.snd_δ)
     (Limits.Concrete.pullbackMk D.L₁.g D.v₀₁.τ₃ x₂ x₃ h₂)
   have eq₁ := Concrete.pullbackMk_fst D.L₁.g D.v₀₁.τ₃ x₂ x₃ h₂
   have eq₂ := Concrete.pullbackMk_snd D.L₁.g D.v₀₁.τ₃ x₂ x₃ h₂
-  dsimp [DFunLike.coe] at eq₁ eq₂
-  rw [Functor.map_comp, types_comp_apply, FunctorToTypes.map_comp_apply] at eq
+  rw [ConcreteCategory.comp_apply, ConcreteCategory.comp_apply] at eq
   rw [eq₂] at eq
-  refine eq.trans (congr_arg ((forget C).map D.v₂₃.τ₁) ?_)
+  refine eq.trans (CategoryTheory.congr_arg (D.v₂₃.τ₁) ?_)
   apply (Preadditive.mono_iff_injective' D.L₂.f).1 inferInstance
-  rw [← FunctorToTypes.map_comp_apply, φ₁_L₂_f]
+  rw [← ConcreteCategory.comp_apply, φ₁_L₂_f]
   dsimp [φ₂]
-  rw [Functor.map_comp, types_comp_apply, eq₁]
+  rw [ConcreteCategory.comp_apply, eq₁]
   exact h₁.symm
 
 /-- This lemma allows the computation of the connecting homomorphism
@@ -169,18 +171,14 @@ lemma δ_apply' (x₃ : (forget₂ C Ab).obj D.L₀.X₃)
   refine (congr_hom (e.hom.naturality D.δ) x₃).trans
     ((D.δ_apply (e.hom.app _ x₃) (e.hom.app _ x₂) (e.hom.app _ x₁) ?_ ?_ ).trans
     (congr_hom (e.hom.naturality D.v₂₃.τ₁).symm x₁))
-  · refine ((congr_hom (e.hom.naturality D.L₁.g) x₂).symm.trans ?_).trans
-      (congr_hom (e.hom.naturality D.v₀₁.τ₃) x₃)
+  · refine ((congr_fun (e.hom.naturality D.L₁.g) x₂).symm.trans ?_).trans
+      (congr_fun (e.hom.naturality D.v₀₁.τ₃) x₃)
     dsimp
-    rw [CategoryTheory.comp_apply, CategoryTheory.comp_apply]
-    erw [h₂]
-    rfl
-  · refine ((congr_hom (e.hom.naturality D.L₂.f) x₁).symm.trans ?_).trans
-      (congr_hom (e.hom.naturality D.v₁₂.τ₂) x₂)
+    rw [h₂]
+  · refine ((congr_fun (e.hom.naturality D.L₂.f) x₁).symm.trans ?_).trans
+      (congr_fun (e.hom.naturality D.v₁₂.τ₂) x₂)
     dsimp
-    rw [CategoryTheory.comp_apply, CategoryTheory.comp_apply]
-    erw [h₁]
-    rfl
+    rw [h₁]
 
 end SnakeInput
 

--- a/Mathlib/AlgebraicGeometry/Morphisms/QuasiSeparated.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/QuasiSeparated.lean
@@ -85,8 +85,7 @@ theorem quasiCompact_affineProperty_iff_quasiSeparatedSpace {X Y : Scheme} [IsAf
     haveI : IsAffine _ := U.2
     haveI : IsAffine _ := V.2
     let g : pullback U.1.ι V.1.ι ⟶ X := pullback.fst _ _ ≫ U.1.ι
-    -- Porting note: `inferInstance` does not work here
-    have : IsOpenImmersion g := PresheafedSpace.IsOpenImmersion.comp _ _
+    have : IsOpenImmersion g := inferInstance
     have e := Homeomorph.ofIsEmbedding _ this.base_open.isEmbedding
     rw [IsOpenImmersion.range_pullback_to_base_of_left] at e
     erw [Subtype.range_coe, Subtype.range_coe] at e
@@ -94,8 +93,7 @@ theorem quasiCompact_affineProperty_iff_quasiSeparatedSpace {X Y : Scheme} [IsAf
     exact @Homeomorph.compactSpace _ _ _ _ (H _ _) e
   · introv H h₁ h₂
     let g : pullback f₁ f₂ ⟶ X := pullback.fst _ _ ≫ f₁
-    -- Porting note: `inferInstance` does not work here
-    have : IsOpenImmersion g := PresheafedSpace.IsOpenImmersion.comp _ _
+    have : IsOpenImmersion g := inferInstance
     have e := Homeomorph.ofIsEmbedding _ this.base_open.isEmbedding
     rw [IsOpenImmersion.range_pullback_to_base_of_left] at e
     simp_rw [isCompact_iff_compactSpace] at H
@@ -283,14 +281,12 @@ theorem exists_eq_pow_mul_of_isCompact_of_isQuasiSeparated (X : Scheme.{u}) (U :
       intro i; change (i : X.Opens) ≤ S
       refine le_trans ?_ (inf_le_left (b := U.1))
       rw [hs]
-      -- Porting note: have to add argument explicitly
-      exact @le_iSup X.Opens s _ (fun (i : s) => (i : X.Opens)) i
+      exact le_iSup (fun (i : s) => (i : X.Opens)) i
     have hs₂ : ∀ i : s, i.1.1 ≤ U.1 := by
       intro i; change (i : X.Opens) ≤ U
       refine le_trans ?_ (inf_le_right (a := S))
       rw [hs]
-      -- Porting note: have to add argument explicitly
-      exact @le_iSup X.Opens s _ (fun (i : s) => (i : X.Opens)) i
+      exact le_iSup (fun (i : s) => (i : X.Opens)) i
     -- On each affine open in the intersection, we have `f ^ (n + n₂) * y₁ = f ^ (n + n₁) * y₂`
     -- for some `n` since `f ^ n₂ * y₁ = f ^ (n₁ + n₂) * x = f ^ n₁ * y₂` on `X_f`.
     have := fun i ↦ exists_eq_pow_mul_of_is_compact_of_quasi_separated_space_aux
@@ -305,11 +301,10 @@ theorem exists_eq_pow_mul_of_isCompact_of_isQuasiSeparated (X : Scheme.{u}) (U :
           (X.presheaf.map (homOfLE le_sup_right).op f ^ (Finset.univ.sup n + n₁) * y₂) := by
       fapply X.sheaf.eq_of_locally_eq' fun i : s => i.1.1
       · refine fun i => homOfLE ?_; rw [hs]
-        -- Porting note: have to add argument explicitly
-        exact @le_iSup X.Opens s _ (fun (i : s) => (i : X.Opens)) i
+        exact le_iSup (fun (i : s) => (i : X.Opens)) i
       · exact le_of_eq hs
       · intro i
-        -- This unfolds `X.sheaf` and ensures we use `CommRingCat.hom` to apply the morphism
+        -- This unfolds `X.sheaf`
         show (X.presheaf.map _) _ = (X.presheaf.map _) _
         simp only [← CommRingCat.comp_apply, ← Functor.map_comp, ← op_comp]
         apply hn
@@ -320,12 +315,12 @@ theorem exists_eq_pow_mul_of_isCompact_of_isQuasiSeparated (X : Scheme.{u}) (U :
     use (X.sheaf.objSupIsoProdEqLocus S U.1).inv ⟨⟨_ * _, _ * _⟩, this⟩
     refine (X.sheaf.objSupIsoProdEqLocus_inv_eq_iff _ _ _ (X.basicOpen_res _
       (homOfLE le_sup_left).op) (X.basicOpen_res _ (homOfLE le_sup_right).op)).mpr ⟨?_, ?_⟩
-    · -- This unfolds `X.sheaf` and ensures we use `CommRingCat.hom` to apply the morphism
+    · -- This unfolds `X.sheaf`
       show (X.presheaf.map _) _ = (X.presheaf.map _) _
       rw [add_assoc, add_comm n₁]
       simp only [pow_add, map_pow, map_mul, hy₁, ← CommRingCat.comp_apply, ← mul_assoc,
         ← Functor.map_comp, ← op_comp, homOfLE_comp]
-    · -- This unfolds `X.sheaf` and ensures we use `CommRingCat.hom` to apply the morphism
+    · -- This unfolds `X.sheaf`
       show (X.presheaf.map _) _ = (X.presheaf.map _) _
       simp only [pow_add, map_pow, map_mul, hy₂, ← CommRingCat.comp_apply, ← mul_assoc,
         ← Functor.map_comp, ← op_comp, homOfLE_comp]
@@ -385,15 +380,13 @@ theorem isIso_ΓSpec_adjunction_unit_app_basicOpen {X : Scheme} [CompactSpace X]
     IsIso ((ΓSpec.adjunction.unit.app X).c.app (op (PrimeSpectrum.basicOpen f))) := by
   refine @IsIso.of_isIso_comp_right _ _ _ _ _ _ (X.presheaf.map
     (eqToHom (Scheme.toSpecΓ_preimage_basicOpen _ _).symm).op) _ ?_
-  rw [ConcreteCategory.isIso_iff_bijective, CommRingCat.forget_map]
+  rw [ConcreteCategory.isIso_iff_bijective]
   apply (config := { allowSynthFailures := true }) IsLocalization.bijective
   · exact StructureSheaf.IsLocalization.to_basicOpen _ _
   · refine is_localization_basicOpen_of_qcqs ?_ ?_ _
     · exact isCompact_univ
     · exact isQuasiSeparated_univ
-  · simp only [RingHom.algebraMap_toAlgebra]
-    -- This `rw` doesn't fire as a `simp` (`only`).
-    rw [← CommRingCat.hom_comp]
-    simp [RingHom.algebraMap_toAlgebra, ← Functor.map_comp]
+  · simp [RingHom.algebraMap_toAlgebra, ← CommRingCat.hom_comp, RingHom.algebraMap_toAlgebra,
+      ← Functor.map_comp]
 
 end AlgebraicGeometry

--- a/Mathlib/AlgebraicGeometry/OpenImmersion.lean
+++ b/Mathlib/AlgebraicGeometry/OpenImmersion.lean
@@ -189,12 +189,7 @@ theorem appIso_inv_app (U) :
     (f.appIso U).inv ≫ f.app (f ''ᵁ U) = X.presheaf.map (eqToHom (preimage_image_eq f U)).op :=
   (PresheafedSpace.IsOpenImmersion.invApp_app _ _).trans (by rw [eqToHom_op])
 
-/--
-`elementwise` generates the `HasForget.instFunLike` lemma, we want `CommRingCat.Hom.hom`.
--/
-theorem appIso_inv_app_apply' (U) (x) :
-    f.app (f ''ᵁ U) ((f.appIso U).inv x) = X.presheaf.map (eqToHom (preimage_image_eq f U)).op x :=
-  appIso_inv_app_apply f U x
+@[deprecated (since := "2025-02-11")] alias appIso_inv_app_apply' := appIso_inv_app_apply
 
 @[reassoc (attr := simp), elementwise nosimp]
 lemma appLE_appIso_inv {X Y : Scheme.{u}} (f : X ⟶ Y) [IsOpenImmersion f] {U : Y.Opens}
@@ -692,7 +687,7 @@ variable {X Y : Scheme.{u}} (f : X ⟶ Y) [H : IsOpenImmersion f]
 theorem image_basicOpen {U : X.Opens} (r : Γ(X, U)) :
     f ''ᵁ X.basicOpen r = Y.basicOpen ((f.appIso U).inv r) := by
   have e := Scheme.preimage_basicOpen f ((f.appIso U).inv r)
-  rw [Scheme.Hom.appIso_inv_app_apply', Scheme.basicOpen_res, inf_eq_right.mpr _] at e
+  rw [Scheme.Hom.appIso_inv_app_apply, Scheme.basicOpen_res, inf_eq_right.mpr _] at e
   · rw [← e, f.image_preimage_eq_opensRange_inter, inf_eq_right]
     refine Set.Subset.trans (Scheme.basicOpen_le _ _) (Set.image_subset_range _ _)
   · exact (X.basicOpen_le r).trans (f.preimage_image_eq _).ge

--- a/Mathlib/CategoryTheory/ConcreteCategory/Basic.lean
+++ b/Mathlib/CategoryTheory/ConcreteCategory/Basic.lean
@@ -362,6 +362,19 @@ theorem coe_toHasForget_instFunLike {C : Type*} [Category C] {FC : C → C → T
     (f : X ⟶ Y) :
     @DFunLike.coe (X ⟶ Y) (ToType X) (fun _ => ToType Y) HasForget.instFunLike f = f := rfl
 
+lemma ConcreteCategory.forget₂_comp_apply {C : Type u} {D : Type u'} [Category.{v} C]
+    {FC : C → C → Type*} {CC : C → Type w} [∀ X Y, FunLike (FC X Y) (CC X) (CC Y)]
+    [ConcreteCategory.{w} C FC] [Category.{v'} D] {FD : D → D → Type*} {CD : D → Type w}
+    [∀ X Y, FunLike (FD X Y) (CD X) (CD Y)] [ConcreteCategory.{w} D FD] [HasForget₂ C D] {X Y Z : C}
+    (f : X ⟶ Y) (g : Y ⟶ Z) (x : ToType ((forget₂ C D).obj X)) :
+    ((forget₂ C D).map (f ≫ g) x) =
+      (forget₂ C D).map g ((forget₂ C D).map f x) := by
+  rw [Functor.map_comp, ConcreteCategory.comp_apply]
+
+instance hom_isIso {X Y : C} (f : X ⟶ Y) [IsIso f] :
+    IsIso (C := Type _) ⇑(ConcreteCategory.hom f) :=
+  ((forget C).mapIso (asIso f)).isIso_hom
+
 section
 
 variable (C)

--- a/Mathlib/CategoryTheory/ConcreteCategory/EpiMono.lean
+++ b/Mathlib/CategoryTheory/ConcreteCategory/EpiMono.lean
@@ -25,7 +25,8 @@ universe w v v' u u'
 
 namespace CategoryTheory
 
-variable {C : Type u} [Category.{v} C] [HasForget.{w} C]
+variable {C : Type u} [Category.{v} C] {FC : C → C → Type*} {CC : C → Type w}
+variable [∀ X Y, FunLike (FC X Y) (CC X) (CC Y)] [ConcreteCategory.{w} C FC]
 
 open Limits MorphismProperty
 
@@ -33,7 +34,6 @@ namespace ConcreteCategory
 
 section
 
-attribute [local instance] HasForget.instFunLike in
 /-- In any concrete category, injective morphisms are monomorphisms. -/
 theorem mono_of_injective {X Y : C} (f : X ⟶ Y) (i : Function.Injective f) :
     Mono f :=
@@ -133,9 +133,6 @@ section
 
 open CategoryTheory.Limits
 
-attribute [local instance] HasForget.hasCoeToSort
-attribute [local instance] HasForget.instFunLike
-
 theorem injective_of_mono_of_preservesPullback {X Y : C} (f : X ⟶ Y) [Mono f]
     [PreservesLimitsOfShape WalkingCospan (forget C)] : Function.Injective f :=
   (mono_iff_injective ((forget C).map f)).mp inferInstance
@@ -158,14 +155,14 @@ theorem epi_iff_surjective_of_preservesPushout {X Y : C} (f : X ⟶ Y)
   ((forget C).epi_map_iff_epi _).symm.trans (epi_iff_surjective _)
 
 theorem bijective_of_isIso {X Y : C} (f : X ⟶ Y) [IsIso f] :
-    Function.Bijective ((forget C).map f) := by
+    Function.Bijective f := by
   rw [← isIso_iff_bijective]
   infer_instance
 
 /-- If the forgetful functor of a concrete category reflects isomorphisms, being an isomorphism
 is equivalent to being bijective. -/
 theorem isIso_iff_bijective [(forget C).ReflectsIsomorphisms]
-    {X Y : C} (f : X ⟶ Y) : IsIso f ↔ Function.Bijective ((forget C).map f) := by
+    {X Y : C} (f : X ⟶ Y) : IsIso f ↔ Function.Bijective f := by
   rw [← CategoryTheory.isIso_iff_bijective]
   exact ⟨fun _ ↦ inferInstance, fun _ ↦ isIso_of_reflects_iso f (forget C)⟩
 

--- a/Mathlib/CategoryTheory/Galois/Examples.lean
+++ b/Mathlib/CategoryTheory/Galois/Examples.lean
@@ -62,6 +62,7 @@ def Action.imageComplementIncl {X Y : Action FintypeCat (MonCat.of G)} (f : X ‚ü
   hom := FintypeCat.imageComplementIncl f.hom
   comm _ := rfl
 
+attribute [local instance] Types.instFunLike Types.instConcreteCategory in
 instance {X Y : Action FintypeCat (MonCat.of G)} (f : X ‚ü∂ Y) :
     Mono (Action.imageComplementIncl G f) := by
   apply Functor.mono_of_mono_map (forget _)

--- a/Mathlib/CategoryTheory/Limits/ConcreteCategory/WithAlgebraicStructures.lean
+++ b/Mathlib/CategoryTheory/Limits/ConcreteCategory/WithAlgebraicStructures.lean
@@ -45,12 +45,9 @@ theorem colimit_rep_eq_zero
     (F : J ⥤ ModuleCat.{max t w} R) [PreservesColimit F (forget (ModuleCat R))] [IsFiltered J]
     [HasColimit F] (j : J) (x : F.obj j) (hx : colimit.ι F j x = 0) :
     ∃ (j' : J) (i : j ⟶ j'), (F.map i).hom x = 0 := by
-  -- Break the abstraction barrier between homs and functions for `colimit_rep_eq_iff_exists`.
-  have : ∀ (X Y : ModuleCat R) (f : X ⟶ Y),
-    DFunLike.coe f.hom = DFunLike.coe (self := HasForget.instFunLike) f := fun _ _ _ => rfl
-  rw [show 0 = colimit.ι F j 0 by simp, this, colimit_rep_eq_iff_exists] at hx
+  rw [show 0 = colimit.ι F j 0 by simp, colimit_rep_eq_iff_exists] at hx
   obtain ⟨j', i, y, g⟩ := hx
-  exact ⟨j', i, g ▸ by simp [← this]⟩
+  exact ⟨j', i, g ▸ by simp⟩
 
 end zero
 
@@ -64,17 +61,13 @@ lemma colimit_no_zero_smul_divisor
     (F : J ⥤ ModuleCat.{max t w} R) [PreservesColimit F (forget (ModuleCat R))]
     [IsFiltered J] [HasColimit F]
     (r : R) (H : ∃ (j' : J), ∀ (j : J) (_ : j' ⟶ j), ∀ (c : F.obj j), r • c = 0 → c = 0)
-    (x : (forget (ModuleCat R)).obj (colimit F)) (hx : r • x = 0) : x = 0 := by
-
-  -- Break the abstraction barrier between homs and functions for `Concrete.colimit_exists_rep`.
-  have : ∀ (X Y : ModuleCat R) (f : X ⟶ Y),
-    DFunLike.coe f.hom = DFunLike.coe (self := HasForget.instFunLike) f := fun _ _ _ => rfl
+    (x : ToType (colimit F)) (hx : r • x = 0) : x = 0 := by
   classical
   obtain ⟨j, x, rfl⟩ := Concrete.colimit_exists_rep F x
-  rw [← this, ← map_smul (colimit.ι F j).hom] at hx
+  rw [← map_smul (colimit.ι F j).hom] at hx
   obtain ⟨j', i, h⟩ := Concrete.colimit_rep_eq_zero (hx := hx)
   obtain ⟨j'', H⟩ := H
-  simpa [elementwise_of% (colimit.w F), ← this, map_zero] using congr(colimit.ι F _
+  simpa [elementwise_of% (colimit.w F), map_zero] using congr(colimit.ι F _
     $(H (IsFiltered.sup {j, j', j''} { ⟨j, j', by simp, by simp, i⟩ })
       (IsFiltered.toSup _ _ <| by simp)
       (F.map (IsFiltered.toSup _ _ <| by simp) x)

--- a/Mathlib/CategoryTheory/Limits/Shapes/ConcreteCategory.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/ConcreteCategory.lean
@@ -20,7 +20,7 @@ the preservation of products and pullbacks in order to describe these limits in 
 concrete category `C`.
 
 If `F : J → C` is a family of objects in `C`, we define a bijection
-`Limits.Concrete.productEquiv F : (forget C).obj (∏ᶜ F) ≃ ∀ j, F j`.
+`Limits.Concrete.productEquiv F : ToType (∏ᶜ F) ≃ ∀ j, ToType (F j)`.
 
 Similarly, if `f₁ : X₁ ⟶ S` and `f₂ : X₂ ⟶ S` are two morphisms, the elements
 in `pullback f₁ f₂` are identified by `Limits.Concrete.pullbackEquiv`
@@ -35,29 +35,28 @@ universe w w' v u t r
 
 namespace CategoryTheory.Limits.Concrete
 
-attribute [local instance] HasForget.instFunLike HasForget.hasCoeToSort
-
 variable {C : Type u} [Category.{v} C]
 
 section Products
 
 section ProductEquiv
 
-variable [HasForget.{max w v} C] {J : Type w} (F : J → C)
+variable {FC : C → C → Type*} {CC : C → Type max w v} [∀ X Y, FunLike (FC X Y) (CC X) (CC Y)]
+variable [ConcreteCategory.{max w v} C FC] {J : Type w} (F : J → C)
   [HasProduct F] [PreservesLimit (Discrete.functor F) (forget C)]
 
-/-- The equivalence `(forget C).obj (∏ᶜ F) ≃ ∀ j, F j` if `F : J → C` is a family of objects
+/-- The equivalence `ToType (∏ᶜ F) ≃ ∀ j, ToType (F j)` if `F : J → C` is a family of objects
 in a concrete category `C`. -/
-noncomputable def productEquiv : (forget C).obj (∏ᶜ F) ≃ ∀ j, F j :=
-  ((PreservesProduct.iso (forget C) F) ≪≫ (Types.productIso.{w, v} (fun j => F j))).toEquiv
+noncomputable def productEquiv : ToType (∏ᶜ F) ≃ ∀ j, ToType (F j) :=
+  ((PreservesProduct.iso (forget C) F) ≪≫ (Types.productIso.{w, v} fun j => ToType (F j))).toEquiv
 
 @[simp]
-lemma productEquiv_apply_apply (x : (forget C).obj (∏ᶜ F)) (j : J) :
+lemma productEquiv_apply_apply (x : ToType (∏ᶜ F)) (j : J) :
     productEquiv F x j = Pi.π F j x :=
   congr_fun (piComparison_comp_π (forget C) F j) x
 
 @[simp]
-lemma productEquiv_symm_apply_π (x : ∀ j, F j) (j : J) :
+lemma productEquiv_symm_apply_π (x : ∀ j, ToType (F j)) (j : J) :
     Pi.π F j ((productEquiv F).symm x) = x j := by
   rw [← productEquiv_apply_apply, Equiv.apply_symm_apply]
 
@@ -66,21 +65,19 @@ end ProductEquiv
 section ProductExt
 
 variable {J : Type w} (f : J → C) [HasProduct f] {D : Type t} [Category.{r} D]
-  [HasForget.{max w r} D] (F : C ⥤ D)
+variable {FD : D → D → Type*} {DD : D → Type max w r} [∀ X Y, FunLike (FD X Y) (DD X) (DD Y)]
+variable [ConcreteCategory.{max w r} D FD] (F : C ⥤ D)
   [PreservesLimit (Discrete.functor f) F]
   [HasProduct fun j => F.obj (f j)]
   [PreservesLimitsOfShape WalkingCospan (forget D)]
   [PreservesLimit (Discrete.functor fun b ↦ F.toPrefunctor.obj (f b)) (forget D)]
 
-lemma Pi.map_ext (x y : F.obj (∏ᶜ f : C))
+lemma Pi.map_ext (x y : ToType (F.obj (∏ᶜ f : C)))
     (h : ∀ i, F.map (Pi.π f i) x = F.map (Pi.π f i) y) : x = y := by
   apply ConcreteCategory.injective_of_mono_of_preservesPullback (PreservesProduct.iso F f).hom
-  apply @Concrete.limit_ext.{w, w, r, t} D
-    _ _ (Discrete J) _ _ _ _ (piComparison F _ x) (piComparison F _ y)
-  intro ⟨(j : J)⟩
-  show ((forget D).map (piComparison F f) ≫ (forget D).map (limit.π _ _)) x =
-    ((forget D).map (piComparison F f) ≫ (forget D).map _) y
-  rw [← (forget D).map_comp, piComparison_comp_π]
+  apply Concrete.limit_ext _ (piComparison F _ x) (piComparison F _ y)
+  intro ⟨j⟩
+  rw [← ConcreteCategory.comp_apply, ← ConcreteCategory.comp_apply, piComparison_comp_π]
   exact h j
 
 end ProductExt
@@ -89,34 +86,35 @@ end Products
 
 section Terminal
 
-variable [HasForget.{w} C]
+variable {FC : C → C → Type*} {CC : C → Type w} [∀ X Y, FunLike (FC X Y) (CC X) (CC Y)]
+variable [ConcreteCategory.{w} C FC]
 
-/-- If `forget C` preserves terminals and `X` is terminal, then `(forget C).obj X` is a
+/-- If `forget C` preserves terminals and `X` is terminal, then `ToType X` is a
 singleton. -/
 noncomputable def uniqueOfTerminalOfPreserves [PreservesLimit (Functor.empty.{0} C) (forget C)]
-    (X : C) (h : IsTerminal X) : Unique ((forget C).obj X) :=
-  Types.isTerminalEquivUnique ((forget C).obj X) <| IsTerminal.isTerminalObj (forget C) X h
+    (X : C) (h : IsTerminal X) : Unique (ToType X) :=
+  Types.isTerminalEquivUnique (ToType X) <| IsTerminal.isTerminalObj (forget C) X h
 
-/-- If `forget C` reflects terminals and `(forget C).obj X` is a singleton, then `X` is terminal. -/
+/-- If `forget C` reflects terminals and `ToType X` is a singleton, then `X` is terminal. -/
 noncomputable def terminalOfUniqueOfReflects [ReflectsLimit (Functor.empty.{0} C) (forget C)]
-    (X : C) (h : Unique ((forget C).obj X)) : IsTerminal X :=
-  IsTerminal.isTerminalOfObj (forget C) X <| (Types.isTerminalEquivUnique ((forget C).obj X)).symm h
+    (X : C) (h : Unique (ToType X)) : IsTerminal X :=
+  IsTerminal.isTerminalOfObj (forget C) X <| (Types.isTerminalEquivUnique (ToType X)).symm h
 
-/-- The equivalence `IsTerminal X ≃ Unique ((forget C).obj X)` if the forgetful functor
+/-- The equivalence `IsTerminal X ≃ Unique (ToType X)` if the forgetful functor
 preserves and reflects terminals. -/
 noncomputable def terminalIffUnique [PreservesLimit (Functor.empty.{0} C) (forget C)]
     [ReflectsLimit (Functor.empty.{0} C) (forget C)] (X : C) :
-    IsTerminal X ≃ Unique ((forget C).obj X) :=
+    IsTerminal X ≃ Unique (ToType X) :=
   (IsTerminal.isTerminalIffObj (forget C) X).trans <| Types.isTerminalEquivUnique _
 
 variable (C)
 variable [HasTerminal C] [PreservesLimit (Functor.empty.{0} C) (forget C)]
 
-/-- The equivalence `(forget C).obj (⊤_ C) ≃ PUnit` when `C` is a concrete category. -/
-noncomputable def terminalEquiv : (forget C).obj (⊤_ C) ≃ PUnit :=
+/-- The equivalence `ToType (⊤_ C) ≃ PUnit` when `C` is a concrete category. -/
+noncomputable def terminalEquiv : ToType (⊤_ C) ≃ PUnit :=
   (PreservesTerminal.iso (forget C) ≪≫ Types.terminalIso).toEquiv
 
-noncomputable instance : Unique ((forget C).obj (⊤_ C)) where
+noncomputable instance : Unique (ToType (⊤_ C)) where
   default := (terminalEquiv C).symm PUnit.unit
   uniq _ := (terminalEquiv C).injective (Subsingleton.elim _ _)
 
@@ -124,57 +122,60 @@ end Terminal
 
 section Initial
 
-variable [HasForget.{w} C]
+variable {FC : C → C → Type*} {CC : C → Type w} [∀ X Y, FunLike (FC X Y) (CC X) (CC Y)]
+variable [ConcreteCategory.{w} C FC]
 
-/-- If `forget C` preserves initials and `X` is initial, then `(forget C).obj X` is empty. -/
+/-- If `forget C` preserves initials and `X` is initial, then `ToType X` is empty. -/
 lemma empty_of_initial_of_preserves [PreservesColimit (Functor.empty.{0} C) (forget C)] (X : C)
-    (h : Nonempty (IsInitial X)) : IsEmpty ((forget C).obj X) := by
+    (h : Nonempty (IsInitial X)) : IsEmpty (ToType X) := by
   rw [← Types.initial_iff_empty]
   exact Nonempty.map (IsInitial.isInitialObj (forget C) _) h
 
-/-- If `forget C` reflects initials and `(forget C).obj X` is empty, then `X` is initial. -/
+/-- If `forget C` reflects initials and `ToType X` is empty, then `X` is initial. -/
 lemma initial_of_empty_of_reflects [ReflectsColimit (Functor.empty.{0} C) (forget C)] (X : C)
-    (h : IsEmpty ((forget C).obj X)) : Nonempty (IsInitial X) :=
+    (h : IsEmpty (ToType X)) : Nonempty (IsInitial X) :=
   Nonempty.map (IsInitial.isInitialOfObj (forget C) _) <|
-    (Types.initial_iff_empty ((forget C).obj X)).mpr h
+    (Types.initial_iff_empty (ToType X)).mpr h
 
 /-- If `forget C` preserves and reflects initials, then `X` is initial if and only if
-`(forget C).obj X` is empty. -/
+`ToType X` is empty. -/
 lemma initial_iff_empty_of_preserves_of_reflects [PreservesColimit (Functor.empty.{0} C) (forget C)]
     [ReflectsColimit (Functor.empty.{0} C) (forget C)] (X : C) :
-    Nonempty (IsInitial X) ↔ IsEmpty ((forget C).obj X) := by
+    Nonempty (IsInitial X) ↔ IsEmpty (ToType X) := by
   rw [← Types.initial_iff_empty, (IsInitial.isInitialIffObj (forget C) X).nonempty_congr]
+  rfl
 
 end Initial
 
 section BinaryProducts
 
-variable [HasForget.{w} C] (X₁ X₂ : C) [HasBinaryProduct X₁ X₂]
+variable {FC : C → C → Type*} {CC : C → Type w} [∀ X Y, FunLike (FC X Y) (CC X) (CC Y)]
+variable [ConcreteCategory.{w} C FC] (X₁ X₂ : C) [HasBinaryProduct X₁ X₂]
   [PreservesLimit (pair X₁ X₂) (forget C)]
 
-/-- The equivalence `(forget C).obj (X₁ ⨯ X₂) ≃ ((forget C).obj X₁) × ((forget C).obj X₂)`
+/-- The equivalence `ToType (X₁ ⨯ X₂) ≃ (ToType X₁) × (ToType X₂)`
 if `X₁` and `X₂` are objects in a concrete category `C`. -/
-noncomputable def prodEquiv : (forget C).obj (X₁ ⨯ X₂) ≃ X₁ × X₂ :=
+noncomputable def prodEquiv : ToType (X₁ ⨯ X₂) ≃ ToType X₁ × ToType X₂ :=
   (PreservesLimitPair.iso (forget C) X₁ X₂ ≪≫ Types.binaryProductIso _ _).toEquiv
 
 @[simp]
-lemma prodEquiv_apply_fst (x : (forget C).obj (X₁ ⨯ X₂)) :
+lemma prodEquiv_apply_fst (x : ToType (X₁ ⨯ X₂)) :
     (prodEquiv X₁ X₂ x).fst = (Limits.prod.fst : X₁ ⨯ X₂ ⟶ X₁) x :=
   congr_fun (prodComparison_fst (forget C) X₁ X₂) x
 
 @[simp]
-lemma prodEquiv_apply_snd (x : (forget C).obj (X₁ ⨯ X₂)) :
+lemma prodEquiv_apply_snd (x : ToType (X₁ ⨯ X₂)) :
     (prodEquiv X₁ X₂ x).snd = (Limits.prod.snd : X₁ ⨯ X₂ ⟶ X₂) x :=
   congr_fun (prodComparison_snd (forget C) X₁ X₂) x
 
 @[simp]
-lemma prodEquiv_symm_apply_fst (x : X₁ × X₂) :
+lemma prodEquiv_symm_apply_fst (x : ToType X₁ × ToType X₂) :
     (Limits.prod.fst : X₁ ⨯ X₂ ⟶ X₁) ((prodEquiv X₁ X₂).symm x) = x.1 := by
   obtain ⟨y, rfl⟩ := (prodEquiv X₁ X₂).surjective x
   simp
 
 @[simp]
-lemma prodEquiv_symm_apply_snd (x : X₁ × X₂) :
+lemma prodEquiv_symm_apply_snd (x : ToType X₁ × ToType X₂) :
     (Limits.prod.snd : X₁ ⨯ X₂ ⟶ X₂) ((prodEquiv X₁ X₂).symm x) = x.2 := by
   obtain ⟨y, rfl⟩ := (prodEquiv X₁ X₂).surjective x
   simp
@@ -183,35 +184,37 @@ end BinaryProducts
 
 section Pullbacks
 
-variable [HasForget.{v} C] {X₁ X₂ S : C} (f₁ : X₁ ⟶ S) (f₂ : X₂ ⟶ S)
+variable {FC : C → C → Type*} {CC : C → Type v} [∀ X Y, FunLike (FC X Y) (CC X) (CC Y)]
+variable [ConcreteCategory.{v} C FC]
+variable {X₁ X₂ S : C} (f₁ : X₁ ⟶ S) (f₂ : X₂ ⟶ S)
     [HasPullback f₁ f₂] [PreservesLimit (cospan f₁ f₂) (forget C)]
 
 /-- In a concrete category `C`, given two morphisms `f₁ : X₁ ⟶ S` and `f₂ : X₂ ⟶ S`,
 the elements in `pullback f₁ f₁` can be identified to compatible tuples of
 elements in `X₁` and `X₂`. -/
 noncomputable def pullbackEquiv :
-    (forget C).obj (pullback f₁ f₂) ≃ { p : X₁ × X₂ // f₁ p.1 = f₂ p.2 } :=
+    ToType (pullback f₁ f₂) ≃ { p : ToType X₁ × ToType X₂ // f₁ p.1 = f₂ p.2 } :=
   (PreservesPullback.iso (forget C) f₁ f₂ ≪≫
     Types.pullbackIsoPullback ((forget C).map f₁) ((forget C).map f₂)).toEquiv
 
 /-- Constructor for elements in a pullback in a concrete category. -/
-noncomputable def pullbackMk (x₁ : X₁) (x₂ : X₂) (h : f₁ x₁ = f₂ x₂) :
-    (forget C).obj (pullback f₁ f₂) :=
+noncomputable def pullbackMk (x₁ : ToType X₁) (x₂ : ToType X₂) (h : f₁ x₁ = f₂ x₂) :
+    ToType (pullback f₁ f₂) :=
   (pullbackEquiv f₁ f₂).symm ⟨⟨x₁, x₂⟩, h⟩
 
-lemma pullbackMk_surjective (x : (forget C).obj (pullback f₁ f₂)) :
-    ∃ (x₁ : X₁) (x₂ : X₂) (h : f₁ x₁ = f₂ x₂), x = pullbackMk f₁ f₂ x₁ x₂ h := by
+lemma pullbackMk_surjective (x : ToType (pullback f₁ f₂)) :
+    ∃ (x₁ : ToType X₁) (x₂ : ToType X₂) (h : f₁ x₁ = f₂ x₂), x = pullbackMk f₁ f₂ x₁ x₂ h := by
   obtain ⟨⟨⟨x₁, x₂⟩, h⟩, rfl⟩ := (pullbackEquiv f₁ f₂).symm.surjective x
   exact ⟨x₁, x₂, h, rfl⟩
 
 @[simp]
-lemma pullbackMk_fst (x₁ : X₁) (x₂ : X₂) (h : f₁ x₁ = f₂ x₂) :
+lemma pullbackMk_fst (x₁ : ToType X₁) (x₂ : ToType X₂) (h : f₁ x₁ = f₂ x₂) :
     pullback.fst f₁ f₂ (pullbackMk f₁ f₂ x₁ x₂ h) = x₁ :=
   (congr_fun (PreservesPullback.iso_inv_fst (forget C) f₁ f₂) _).trans
     (congr_fun (Types.pullbackIsoPullback_inv_fst ((forget C).map f₁) ((forget C).map f₂)) _)
 
 @[simp]
-lemma pullbackMk_snd (x₁ : X₁) (x₂ : X₂) (h : f₁ x₁ = f₂ x₂) :
+lemma pullbackMk_snd (x₁ : ToType X₁) (x₂ : ToType X₂) (h : f₁ x₁ = f₂ x₂) :
     pullback.snd f₁ f₂ (pullbackMk f₁ f₂ x₁ x₂ h) = x₂ :=
   (congr_fun (PreservesPullback.iso_inv_snd (forget C) f₁ f₂) _).trans
     (congr_fun (Types.pullbackIsoPullback_inv_snd ((forget C).map f₁) ((forget C).map f₂)) _)
@@ -220,7 +223,8 @@ end Pullbacks
 
 section WidePullback
 
-variable [HasForget.{max w v} C]
+variable {FC : C → C → Type*} {CC : C → Type (max v w)} [∀ X Y, FunLike (FC X Y) (CC X) (CC Y)]
+variable [ConcreteCategory.{max v w} C FC]
 
 open WidePullback
 
@@ -228,7 +232,7 @@ open WidePullbackShape
 
 theorem widePullback_ext {B : C} {ι : Type w} {X : ι → C} (f : ∀ j : ι, X j ⟶ B)
     [HasWidePullback B X f] [PreservesLimit (wideCospan B X f) (forget C)]
-    (x y : ↑(widePullback B X f)) (h₀ : base f x = base f y) (h : ∀ j, π f j x = π f j y) :
+    (x y : ToType (widePullback B X f)) (h₀ : base f x = base f y) (h : ∀ j, π f j x = π f j y) :
     x = y := by
   apply Concrete.limit_ext
   rintro (_ | j)
@@ -237,33 +241,34 @@ theorem widePullback_ext {B : C} {ι : Type w} {X : ι → C} (f : ∀ j : ι, X
 
 theorem widePullback_ext' {B : C} {ι : Type w} [Nonempty ι] {X : ι → C}
     (f : ∀ j : ι, X j ⟶ B) [HasWidePullback.{w} B X f]
-    [PreservesLimit (wideCospan B X f) (forget C)] (x y : ↑(widePullback B X f))
+    [PreservesLimit (wideCospan B X f) (forget C)] (x y : ToType (widePullback B X f))
     (h : ∀ j, π f j x = π f j y) : x = y := by
   apply Concrete.widePullback_ext _ _ _ _ h
   inhabit ι
-  simp only [← π_arrow f default, CategoryTheory.comp_apply, h]
+  simp only [← π_arrow f default, ConcreteCategory.comp_apply, h]
 
 end WidePullback
 
 section Multiequalizer
 
-variable [HasForget.{max w w' v} C]
+variable {FC : C → C → Type*} {CC : C → Type (max w w' v)} [∀ X Y, FunLike (FC X Y) (CC X) (CC Y)]
+variable [ConcreteCategory.{max w w' v} C FC]
 
 theorem multiequalizer_ext {J : MulticospanShape.{w, w'}}
     {I : MulticospanIndex J C} [HasMultiequalizer I]
-    [PreservesLimit I.multicospan (forget C)] (x y : ↑(multiequalizer I))
+    [PreservesLimit I.multicospan (forget C)] (x y : ToType (multiequalizer I))
     (h : ∀ t : J.L, Multiequalizer.ι I t x = Multiequalizer.ι I t y) : x = y := by
   apply Concrete.limit_ext
   rintro (a | b)
   · apply h
-  · rw [← limit.w I.multicospan (WalkingMulticospan.Hom.fst b), CategoryTheory.comp_apply,
-      CategoryTheory.comp_apply]
+  · rw [← limit.w I.multicospan (WalkingMulticospan.Hom.fst b), ConcreteCategory.comp_apply,
+      ConcreteCategory.comp_apply]
     simp [h]
 
 /-- An auxiliary equivalence to be used in `multiequalizerEquiv` below. -/
 def multiequalizerEquivAux {J : MulticospanShape.{w, w'}} (I : MulticospanIndex J C) :
     (I.multicospan ⋙ forget C).sections ≃
-    { x : ∀ i : J.L, I.left i // ∀ i : J.R, I.fst i (x _) = I.snd i (x _) } where
+    { x : ∀ i : J.L, ToType (I.left i) // ∀ i : J.R, I.fst i (x _) = I.snd i (x _) } where
   toFun x :=
     ⟨fun _ => x.1 (WalkingMulticospan.left _), fun i => by
       have a := x.2 (WalkingMulticospan.Hom.fst i)
@@ -297,8 +302,8 @@ the concrete multiequalizer. -/
 noncomputable def multiequalizerEquiv {J : MulticospanShape.{w, w'}}
     (I : MulticospanIndex J C) [HasMultiequalizer I]
     [PreservesLimit I.multicospan (forget C)] :
-    (multiequalizer I : C) ≃
-      { x : ∀ i : J.L, I.left i // ∀ i : J.R, I.fst i (x _) = I.snd i (x _) } :=
+    ToType (multiequalizer I) ≃
+      { x : ∀ i : J.L, ToType (I.left i) // ∀ i : J.R, I.fst i (x _) = I.snd i (x _) } :=
   letI h1 := limit.isLimit I.multicospan
   letI h2 := isLimitOfPreserves (forget C) h1
   letI E := h2.conePointUniqueUpToIso (Types.limitConeIsLimit.{max w w', v} _)
@@ -307,8 +312,9 @@ noncomputable def multiequalizerEquiv {J : MulticospanShape.{w, w'}}
 @[simp]
 theorem multiequalizerEquiv_apply {J : MulticospanShape.{w, w'}}
     (I : MulticospanIndex J C) [HasMultiequalizer I]
-    [PreservesLimit I.multicospan (forget C)] (x : ↑(multiequalizer I)) (i : J.L) :
-    ((Concrete.multiequalizerEquiv I) x : ∀ i : J.L, I.left i) i = Multiequalizer.ι I i x :=
+    [PreservesLimit I.multicospan (forget C)] (x : ToType (multiequalizer I)) (i : J.L) :
+    ((Concrete.multiequalizerEquiv I) x : ∀ i : J.L, ToType (I.left i)) i =
+      Multiequalizer.ι I i x :=
   rfl
 
 end Multiequalizer
@@ -319,11 +325,13 @@ open WidePushout
 
 open WidePushoutShape
 
-variable [HasForget.{v} C]
+variable {FC : C → C → Type*} {CC : C → Type v} [∀ X Y, FunLike (FC X Y) (CC X) (CC Y)]
+variable [ConcreteCategory.{v} C FC]
 
 theorem widePushout_exists_rep {B : C} {α : Type _} {X : α → C} (f : ∀ j : α, B ⟶ X j)
     [HasWidePushout.{v} B X f] [PreservesColimit (wideSpan B X f) (forget C)]
-    (x : ↑(widePushout B X f)) : (∃ y : B, head f y = x) ∨ ∃ (i : α) (y : X i), ι f i y = x := by
+    (x : ToType (widePushout B X f)) :
+    (∃ y : ToType B, head f y = x) ∨ ∃ (i : α) (y : ToType (X i)), ι f i y = x := by
   obtain ⟨_ | j, y, rfl⟩ := Concrete.colimit_exists_rep _ x
   · left
     use y
@@ -334,19 +342,21 @@ theorem widePushout_exists_rep {B : C} {α : Type _} {X : α → C} (f : ∀ j :
 
 theorem widePushout_exists_rep' {B : C} {α : Type _} [Nonempty α] {X : α → C}
     (f : ∀ j : α, B ⟶ X j) [HasWidePushout.{v} B X f] [PreservesColimit (wideSpan B X f) (forget C)]
-    (x : ↑(widePushout B X f)) : ∃ (i : α) (y : X i), ι f i y = x := by
+    (x : ToType (widePushout B X f)) : ∃ (i : α) (y : ToType (X i)), ι f i y = x := by
   rcases Concrete.widePushout_exists_rep f x with (⟨y, rfl⟩ | ⟨i, y, rfl⟩)
   · inhabit α
     use default, f _ y
-    simp only [← arrow_ι _ default, CategoryTheory.comp_apply]
+    simp only [← arrow_ι _ default, ConcreteCategory.comp_apply]
   · use i, y
 
 end WidePushout
 
+attribute [local ext] ConcreteCategory.hom_ext in
 -- We don't mark this as an `@[ext]` lemma as we don't always want to work elementwise.
-theorem cokernel_funext {C : Type*} [Category C] [HasZeroMorphisms C] [HasForget C]
+theorem cokernel_funext {C : Type*} [Category C] [HasZeroMorphisms C] {FC : C → C → Type*}
+    {CC : C → Type*} [∀ X Y, FunLike (FC X Y) (CC X) (CC Y)] [ConcreteCategory C FC]
     {M N K : C} {f : M ⟶ N} [HasCokernel f] {g h : cokernel f ⟶ K}
-    (w : ∀ n : N, g (cokernel.π f n) = h (cokernel.π f n)) : g = h := by
+    (w : ∀ n : ToType N, g (cokernel.π f n) = h (cokernel.π f n)) : g = h := by
   ext x
   simpa using w x
 

--- a/Mathlib/CategoryTheory/MorphismProperty/Concrete.lean
+++ b/Mathlib/CategoryTheory/MorphismProperty/Concrete.lean
@@ -25,13 +25,12 @@ universe v u
 
 namespace CategoryTheory
 
-variable (C : Type u) [Category.{v} C] [HasForget C]
+variable (C : Type u) [Category.{v} C] {FC : C → C → Type*} {CC : C → Type*}
+variable [∀ X Y, FunLike (FC X Y) (CC X) (CC Y)] [ConcreteCategory C FC]
 
 namespace MorphismProperty
 
 open Function
-
-attribute [local instance] HasForget.instFunLike HasForget.hasCoeToSort
 
 /-- Injectiveness (in a concrete category) as a `MorphismProperty` -/
 protected def injective : MorphismProperty C := fun _ _ f => Injective f
@@ -53,7 +52,7 @@ instance : (MorphismProperty.injective C).IsMultiplicative where
     aesop
   comp_mem f g hf hg := by
     delta MorphismProperty.injective
-    rw [coe_comp]
+    rw [hom_comp]
     exact hg.comp hf
 
 instance : (MorphismProperty.surjective C).IsMultiplicative where
@@ -63,7 +62,7 @@ instance : (MorphismProperty.surjective C).IsMultiplicative where
     aesop
   comp_mem f g hf hg := by
     delta MorphismProperty.surjective
-    rw [coe_comp]
+    rw [hom_comp]
     exact hg.comp hf
 
 instance : (MorphismProperty.bijective C).IsMultiplicative where
@@ -73,7 +72,7 @@ instance : (MorphismProperty.bijective C).IsMultiplicative where
     aesop
   comp_mem f g hf hg := by
     delta MorphismProperty.bijective
-    rw [coe_comp]
+    rw [hom_comp]
     exact hg.comp hf
 
 instance injective_respectsIso : (MorphismProperty.injective C).RespectsIso :=
@@ -111,6 +110,7 @@ end ConcreteCategory
 
 open ConcreteCategory
 
+attribute [local instance] Types.instFunLike Types.instConcreteCategory in
 /-- In the category of types, any map can be functorially factored as a surjective
 map followed by an injective map. -/
 def functorialSurjectiveInjectiveFactorizationData :
@@ -136,6 +136,7 @@ def functorialSurjectiveInjectiveFactorizationData :
     rw [Subtype.ext_iff]
     exact h
 
+attribute [local instance] Types.instFunLike Types.instConcreteCategory in
 instance : HasFunctorialSurjectiveInjectiveFactorization (Type u) where
   nonempty_functorialFactorizationData :=
     ⟨functorialSurjectiveInjectiveFactorizationData⟩

--- a/Mathlib/Topology/Category/TopCat/Limits/Pullbacks.lean
+++ b/Mathlib/Topology/Category/TopCat/Limits/Pullbacks.lean
@@ -138,14 +138,11 @@ theorem range_pullback_to_prod {X Y Z : TopCat} (f : X ⟶ Z) (g : Y ⟶ Z) :
     simp [pullback.condition]
   · rintro (h : f (_, _).1 = g (_, _).2)
     use (pullbackIsoProdSubtype f g).inv ⟨⟨_, _⟩, h⟩
-    -- new `change` after https://github.com/leanprover-community/mathlib4/pull/13170
-    -- should be removed when we redo limits for `ConcreteCategory` instead of `HasForget`
-    change (forget TopCat).map _ _ = _
     apply Concrete.limit_ext
     rintro ⟨⟨⟩⟩ <;>
-    erw [← CategoryTheory.comp_apply, ← CategoryTheory.comp_apply, limit.lift_π] <;> -- now `erw` after https://github.com/leanprover-community/mathlib4/pull/13170
-    -- This used to be `simp` before https://github.com/leanprover/lean4/pull/2644
-    aesop_cat
+      rw [← ConcreteCategory.comp_apply, ← ConcreteCategory.comp_apply, limit.lift_π] <;>
+      -- This used to be `simp` before https://github.com/leanprover/lean4/pull/2644
+      aesop_cat
 
 /-- The pullback along an embedding is (isomorphic to) the preimage. -/
 noncomputable
@@ -196,7 +193,7 @@ theorem range_pullback_map {W X Y Z S T : TopCat} (f₁ : W ⟶ S) (f₂ : X ⟶
   · rintro ⟨y, rfl⟩
     simp only [Set.mem_inter_iff, Set.mem_preimage, Set.mem_range]
     rw [← ConcreteCategory.comp_apply, ← ConcreteCategory.comp_apply]
-    simp only [limit.lift_π, PullbackCone.mk_pt, PullbackCone.mk_π_app, CategoryTheory.comp_apply]
+    simp only [limit.lift_π, PullbackCone.mk_pt, PullbackCone.mk_π_app]
     exact ⟨exists_apply_eq_apply _ _, exists_apply_eq_apply _ _⟩
   rintro ⟨⟨x₁, hx₁⟩, ⟨x₂, hx₂⟩⟩
   have : f₁ x₁ = f₂ x₂ := by
@@ -205,28 +202,12 @@ theorem range_pullback_map {W X Y Z S T : TopCat} (f₁ : W ⟶ S) (f₂ : X ⟶
       ConcreteCategory.comp_apply, ConcreteCategory.comp_apply, hx₁, hx₂,
       ← ConcreteCategory.comp_apply, pullback.condition, ConcreteCategory.comp_apply]
   use (pullbackIsoProdSubtype f₁ f₂).inv ⟨⟨x₁, x₂⟩, this⟩
-  -- `change` should be removed when we redo limits for `ConcreteCategory` instead of `HasForget`
-  change (forget TopCat).map _ _ = _
   apply Concrete.limit_ext
   rintro (_ | _ | _) <;>
-  erw [← CategoryTheory.comp_apply, ← CategoryTheory.comp_apply] -- now `erw` after https://github.com/leanprover-community/mathlib4/pull/13170
-  · simp only [Category.assoc, limit.lift_π, PullbackCone.mk_π_app_one]
-    simp only [cospan_one, pullbackIsoProdSubtype_inv_fst_assoc, ConcreteCategory.comp_apply,
-      CategoryTheory.comp_apply]
-    -- Work around the `ConcreteCategory`/`HasForget` mismatch:
-    change g₁ (i₁ ((pullbackFst f₁ f₂) ⟨(x₁, x₂), this⟩)) = (limit.π (cospan g₁ g₂) none) _
-    simp [pullbackFst_apply, hx₁, ← limit.w _ WalkingCospan.Hom.inl, cospan_map_inl]
-  · simp only [cospan_left, limit.lift_π, PullbackCone.mk_pt, PullbackCone.mk_π_app,
-      pullbackIsoProdSubtype_inv_fst_assoc, CategoryTheory.comp_apply]
-    -- Work around the `ConcreteCategory`/`HasForget` mismatch:
-    change i₁ ((pullbackFst f₁ f₂) ⟨(x₁, x₂), this⟩) =
-      limit.π (cospan g₁ g₂) (some WalkingPair.left) _
-    simp [hx₁]
-  · simp only [cospan_right, limit.lift_π, PullbackCone.mk_pt, PullbackCone.mk_π_app,
-      pullbackIsoProdSubtype_inv_snd_assoc, CategoryTheory.comp_apply]
-    change i₂ (pullbackSnd f₁ f₂ ⟨(x₁, x₂), this⟩) =
-      limit.π (cospan g₁ g₂) (some WalkingPair.right) _
-    simp [hx₂]
+  rw [← ConcreteCategory.comp_apply, ← ConcreteCategory.comp_apply]
+  · simp [hx₁, ← limit.w _ WalkingCospan.Hom.inl]
+  · simp [hx₁]
+  · simp [hx₂]
 
 theorem pullback_fst_range {X Y S : TopCat} (f : X ⟶ S) (g : Y ⟶ S) :
     Set.range (pullback.fst f g) = { x : X | ∃ y : Y, f x = g y } := by
@@ -312,8 +293,7 @@ lemma snd_isEmbedding_of_left {X Y S : TopCat} {f : X ⟶ S} (H : IsEmbedding f)
   convert (homeoOfIso (asIso (pullback.snd (𝟙 S) g))).isEmbedding.comp
       (pullback_map_isEmbedding (i₂ := 𝟙 Y)
         f g (𝟙 S) g H (homeoOfIso (Iso.refl _)).isEmbedding (𝟙 _) rfl (by simp))
-  erw [← coe_comp]
-  simp
+  simp [homeoOfIso, ← coe_comp]
 
 @[deprecated (since := "2024-10-26")]
 alias snd_embedding_of_left_embedding := snd_isEmbedding_of_left
@@ -323,8 +303,7 @@ theorem fst_isEmbedding_of_right {X Y S : TopCat} (f : X ⟶ S) {g : Y ⟶ S}
   convert (homeoOfIso (asIso (pullback.fst f (𝟙 S)))).isEmbedding.comp
       (pullback_map_isEmbedding (i₁ := 𝟙 X)
         f g f (𝟙 _) (homeoOfIso (Iso.refl _)).isEmbedding H (𝟙 _) rfl (by simp))
-  erw [← coe_comp]
-  simp
+  simp [homeoOfIso, ← coe_comp]
 
 @[deprecated (since := "2024-10-26")]
 alias fst_embedding_of_right_embedding := fst_isEmbedding_of_right
@@ -343,8 +322,7 @@ theorem snd_isOpenEmbedding_of_left {X Y S : TopCat} {f : X ⟶ S} (H : IsOpenEm
   convert (homeoOfIso (asIso (pullback.snd (𝟙 S) g))).isOpenEmbedding.comp
       (pullback_map_isOpenEmbedding (i₂ := 𝟙 Y) f g (𝟙 _) g H
         (homeoOfIso (Iso.refl _)).isOpenEmbedding (𝟙 _) rfl (by simp))
-  erw [← coe_comp]
-  simp
+  simp [homeoOfIso, ← coe_comp]
 
 @[deprecated (since := "2024-10-18")]
 alias snd_openEmbedding_of_left_openEmbedding := snd_isOpenEmbedding_of_left
@@ -354,8 +332,7 @@ theorem fst_isOpenEmbedding_of_right {X Y S : TopCat} (f : X ⟶ S) {g : Y ⟶ S
   convert (homeoOfIso (asIso (pullback.fst f (𝟙 S)))).isOpenEmbedding.comp
       (pullback_map_isOpenEmbedding (i₁ := 𝟙 X) f g f (𝟙 _)
         (homeoOfIso (Iso.refl _)).isOpenEmbedding H (𝟙 _) rfl (by simp))
-  erw [← coe_comp]
-  simp
+  simp [homeoOfIso, ← coe_comp]
 
 @[deprecated (since := "2024-10-18")]
 alias fst_openEmbedding_of_right_openEmbedding := fst_isOpenEmbedding_of_right

--- a/Mathlib/Topology/Order/Category/AlexDisc.lean
+++ b/Mathlib/Topology/Order/Category/AlexDisc.lean
@@ -50,16 +50,13 @@ lemma coe_of (α : Type*) [TopologicalSpace α] [AlexandrovDiscrete α] : ↥(of
 
 @[simp] lemma coe_forgetToTop (X : AlexDisc) : ↥((forget₂ _ TopCat).obj X) = X := rfl
 
--- This was a global instance prior to https://github.com/leanprover-community/mathlib4/pull/13170. We may experiment with removing it.
-attribute [local instance] CategoryTheory.HasForget.instFunLike
-
 /-- Constructs an equivalence between preorders from an order isomorphism between them. -/
 @[simps]
 def Iso.mk {α β : AlexDisc} (e : α ≃ₜ β) : α ≅ β where
   hom := TopCat.ofHom (e : ContinuousMap α β)
   inv := TopCat.ofHom (e.symm : ContinuousMap β α)
-  hom_inv_id := DFunLike.ext _ _ e.symm_apply_apply
-  inv_hom_id := DFunLike.ext _ _ e.apply_symm_apply
+  hom_inv_id := by ext; apply e.symm_apply_apply
+  inv_hom_id := by ext; apply e.apply_symm_apply
 
 end AlexDisc
 

--- a/Mathlib/Topology/Sheaves/CommRingCat.lean
+++ b/Mathlib/Topology/Sheaves/CommRingCat.lean
@@ -107,8 +107,7 @@ protected noncomputable def SubmonoidPresheaf.localizationPresheaf : X.Presheaf 
   map_id U := by
     simp_rw [F.map_id]
     ext x
-    -- Porting note: `M` and `S` needs to be specified manually
-    exact IsLocalization.map_id (M := G.obj U) (S := Localization (G.obj U)) x
+    exact IsLocalization.map_id x
   map_comp {U V W} i j := by
     delta CommRingCat.ofHom CommRingCat.of Bundled.of
     simp_rw [F.map_comp]
@@ -116,11 +115,9 @@ protected noncomputable def SubmonoidPresheaf.localizationPresheaf : X.Presheaf 
     dsimp
     rw [IsLocalization.map_comp_map]
 
--- Porting note: this instance can't be synthesized
 instance (U) : Algebra (F.obj U) (G.localizationPresheaf.obj U) :=
   show Algebra _ (Localization (G.obj U)) from inferInstance
 
--- Porting note: this instance can't be synthesized
 instance (U) : IsLocalization (G.obj U) (G.localizationPresheaf.obj U) :=
   show IsLocalization (G.obj U) (Localization (G.obj U)) from inferInstance
 
@@ -170,18 +167,14 @@ instance (F : X.Sheaf CommRingCat.{w}) : Mono F.presheaf.toTotalQuotientPresheaf
     NatTrans.mono_of_mono_app _
   intro U
   apply ConcreteCategory.mono_of_injective
-  dsimp [toTotalQuotientPresheaf, CommRingCat.ofHom]
-  -- Porting note: this is a hack to make the `refine` below works
+  dsimp [toTotalQuotientPresheaf]
+  -- Porting note: `M` and `S` need to be specified manually, so used a hack to save some typing
   set m := _
   change Function.Injective (algebraMap _ (Localization m))
-  change Function.Injective (algebraMap (F.presheaf.obj U) _)
-  haveI : IsLocalization _ (Localization m) := Localization.isLocalization
-  -- Porting note: `M` and `S` need to be specified manually, so used a hack to save some typing
   refine IsLocalization.injective (M := m) (S := Localization m) ?_
   intro s hs t e
   apply section_ext F (unop U)
   intro x hx
-  show (F.presheaf.germ (unop U) x hx) t = (F.presheaf.germ (unop U) x hx) 0
   rw [RingHom.map_zero]
   apply Submonoid.mem_iInf.mp hs ⟨x, hx⟩
   rw [← map_mul, e, map_zero]
@@ -387,14 +380,10 @@ theorem objSupIsoProdEqLocus_inv_eq_iff {X : TopCat.{u}} (F : X.Sheaf CommRingCa
       (homOfLE (inf_le_right : U ⊓ W ≤ W)) (homOfLE (inf_le_right : V ⊓ W ≤ W)) ?_ _ _ ?_ ?_
     · rw [← inf_sup_right]
       exact le_inf e le_rfl
-    · change (F.val.map _)
-        ((F.val.map (homOfLE e).op).hom ((F.objSupIsoProdEqLocus U V).inv.hom x)) = (F.val.map _) y
-      rw [← e₁, ← TopCat.Sheaf.objSupIsoProdEqLocus_inv_fst]
+    · rw [← e₁, ← TopCat.Sheaf.objSupIsoProdEqLocus_inv_fst]
       simp only [← CommRingCat.comp_apply, ← Functor.map_comp, ← op_comp, Category.assoc,
         homOfLE_comp]
-    · show (F.val.map _)
-        ((F.val.map (homOfLE e).op).hom ((F.objSupIsoProdEqLocus U V).inv.hom x)) = (F.val.map _) y
-      rw [← e₂, ← TopCat.Sheaf.objSupIsoProdEqLocus_inv_snd]
+    · rw [← e₂, ← TopCat.Sheaf.objSupIsoProdEqLocus_inv_snd]
       simp only [← CommRingCat.comp_apply, ← Functor.map_comp, ← op_comp, Category.assoc,
         homOfLE_comp]
 


### PR DESCRIPTION
This PR should get rid of the last lines of the form:
```
attribute [local instance] HasForget.instFunLike HasForget.hasCoeToSort
```
anywhere in Mathlib.

A few places provided some nice cleanup opportunities.

There are still quite some `(forget _).obj` and `(forget _).map` calls remaining, I'll tackle those in a follow up PR.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
