### PR TITLE
[Merged by Bors] - fix(minImports): extract declModifiers

### DIFF
--- a/Mathlib/Tactic/MinImports.lean
+++ b/Mathlib/Tactic/MinImports.lean
@@ -141,7 +141,9 @@ def getDeclName (cmd : Syntax) : CommandElabM Name := do
   let ns ← getCurrNamespace
   let id1 ← getId cmd
   let id2 := mkIdentFrom id1 (previousInstName id1.getId)
-  let modifiers : TSyntax ``Parser.Command.declModifiers := ⟨cmd[0]⟩
+  let some declStx := cmd.find? (·.isOfKind ``Parser.Command.declaration) | pure default
+  let some modifiersStx := declStx.find? (·.isOfKind ``Parser.Command.declModifiers) | pure default
+  let modifiers : TSyntax ``Parser.Command.declModifiers := ⟨modifiersStx⟩
   let modifiers ← elabModifiers modifiers
   liftCoreM do (
     -- Try applying the algorithm in `Lean.mkDeclName` to attach a namespace to the name.

--- a/MathlibTest/MinImports.lean
+++ b/MathlibTest/MinImports.lean
@@ -6,6 +6,12 @@ run_cmd liftTermElabM do
   guard ([`A, `A.B.C_3, `A.B.C_2, `A.B.C_1, `A.B.C_0, `A.B.C].map previousInstName
       == [`A, `A.B.C_2, `A.B.C_1, `A.B.C,   `A.B.C,   `A.B.C])
 
+run_cmd
+  let stx ← `(variable (a : Nat) in theorem TestingAttributes : a = a := rfl)
+  let nm ← Mathlib.Command.MinImports.getDeclName stx
+  if `TestingAttributes != nm.eraseMacroScopes then
+    Lean.logWarning "Possible misparsing of declaration modifiers!"
+
 /-- info: import Mathlib.Tactic.FunProp.Attr -/
 #guard_msgs in
 #min_imports in (← `(declModifiers|@[fun_prop]))


### PR DESCRIPTION
Try harder to find the declaration modifiers.

I noticed this bug since the late importers workflow [did not post its report](https://github.com/leanprover-community/mathlib4/actions/runs/13233308897).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
