### PR TITLE
[Merged by Bors] - chore(Cache): cleanup getMathlibRoot

### DIFF
--- a/Cache/Hashing.lean
+++ b/Cache/Hashing.lean
@@ -61,21 +61,19 @@ Computes the root hash, which mixes the hashes of the content of:
 * `lakefile.lean`
 * `lean-toolchain`
 * `lake-manifest.json`
-and the hash of `Lean.gitHash`.
+and the hash of `Lean.githash`.
 
-(We hash `Lean.gitHash` in case the toolchain changes even though `lean-toolchain` hasn't.
+(We hash `Lean.githash` in case the toolchain changes even though `lean-toolchain` hasn't.
 This happens with the `lean-pr-testing-NNNN` toolchains when Lean 4 PRs are updated.)
 -/
 def getRootHash : CacheM UInt64 := do
-  let rootFiles : List FilePath := ["lakefile.lean", "lean-toolchain", "lake-manifest.json"]
-  let isMathlibRoot ← isMathlibRoot
-  let qualifyPath ←
-    if isMathlibRoot then
-      pure id
-    else
-      pure ((← read).mathlibDepPath / ·)
+  let mathlibDepPath := (← read).mathlibDepPath
+  let rootFiles : List FilePath := [
+    mathlibDepPath / "lakefile.lean",
+    mathlibDepPath / "lean-toolchain",
+    mathlibDepPath / "lake-manifest.json"]
   let hashes ← rootFiles.mapM fun path =>
-    hashFileContents <$> IO.FS.readFile (qualifyPath path)
+    hashFileContents <$> IO.FS.readFile path
   return hash (hash Lean.githash :: hashes)
 
 /--


### PR DESCRIPTION
Cleanup `getMathlibRoot` preparing to remove `isMathlibRoot` in a future PR. 


If `isMathlibRoot` is `true` then the `mathlibDepPath` is something like `./././.`, and as the path string itself is not used in the cache (only the contents of the file it points to), we can do this simplification.

---

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
