### PR TITLE
[Merged by Bors] - feat(List/Count): add `countP_lt_length_iff`

### DIFF
--- a/Mathlib/Data/List/Count.lean
+++ b/Mathlib/Data/List/Count.lean
@@ -18,23 +18,33 @@ assert_not_exists Monoid Set.range
 
 open Nat
 
-variable {α : Type*}
+variable {α β : Type*}
 
 namespace List
 
-lemma countP_erase [DecidableEq α] (p : α → Bool) (l : List α) (a : α) :
+@[simp]
+theorem countP_lt_length_iff {l : List α} {p : α → Bool} :
+    l.countP p < l.length ↔ ∃ a ∈ l, p a = false := by
+  simp [Nat.lt_iff_le_and_ne, countP_le_length]
+
+variable [DecidableEq α] {l l₁ l₂ : List α}
+
+@[simp]
+theorem count_lt_length_iff {a : α} : l.count a < l.length ↔ ∃ b ∈ l, b ≠ a := by simp [count]
+
+lemma countP_erase (p : α → Bool) (l : List α) (a : α) :
     countP p (l.erase a) = countP p l - if a ∈ l ∧ p a then 1 else 0 := by
   rw [countP_eq_length_filter, countP_eq_length_filter, ← erase_filter, length_erase]
   aesop
 
-lemma count_diff [DecidableEq α] (a : α) (l₁ : List α) :
+lemma count_diff (a : α) (l₁ : List α) :
     ∀ l₂, count a (l₁.diff l₂) = count a l₁ - count a l₂
   | [] => rfl
   | b :: l₂ => by
     simp only [diff_cons, count_diff, count_erase, beq_iff_eq, Nat.sub_right_comm, count_cons,
       Nat.sub_add_eq]
 
-lemma countP_diff [DecidableEq α] {l₁ l₂ : List α} (hl : l₂ <+~ l₁) (p : α → Bool) :
+lemma countP_diff (hl : l₂ <+~ l₁) (p : α → Bool) :
     countP p (l₁.diff l₂) = countP p l₁ - countP p l₂ := by
   refine (Nat.sub_eq_of_eq_add ?_).symm
   rw [← countP_append]
@@ -42,7 +52,7 @@ lemma countP_diff [DecidableEq α] {l₁ l₂ : List α} (hl : l₂ <+~ l₁) (p
     perm_append_comm).countP_eq _
 
 @[simp]
-theorem count_map_of_injective {β} [DecidableEq α] [DecidableEq β] (l : List α) (f : α → β)
+theorem count_map_of_injective [DecidableEq β] (l : List α) (f : α → β)
     (hf : Function.Injective f) (x : α) : count (f x) (map f l) = count x l := by
   simp only [count, countP_map]
   unfold Function.comp


### PR DESCRIPTION
... and `count_lt_length_iff`.
Also use `variable`s for implicit arguments.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
