### PR TITLE
refactor(Cache): change `getPackageDir` to use search path instead of hard-coded package directories

### DIFF
--- a/Cache/Lean.lean
+++ b/Cache/Lean.lean
@@ -137,6 +137,102 @@ where
 #guard FilePath.clean ".lake/packages/mathlib/lean-toolchain" != "lean-toolchain"
 #guard FilePath.clean "./.lake/packages/mathlib/lean-toolchain" != "lean-toolchain"
 
+/--
+Test if the `target` path lies inside `parent`.
+This is purely done by comparing the paths' components.
+It does not have access to `IO` so it does not check if any paths actually exist.
+The paths can contain arbitrary amounts of `"."`, `""`.
+If the `target` contains any `".."`, the result will only be `true` if these are
+part of a shared prefix with `parent`,
+i.e. `../A/..` contains `../A/../B` but not `../A/../B/../B`
+-/
+def contains (parent target : FilePath) : Bool :=
+  go parent.clean.components target.clean.components
+where
+  go : List String → List String → Bool
+    | [], [] => true
+    -- ignore leanding `"."`
+    | "." :: parent, target => go parent target
+    | parent, "." :: target => go parent target
+    -- special-case for `/` and `//`
+    | "" :: "" :: "" :: [], "" :: "" :: [] => false
+    | "" :: "" :: [], "" :: "" :: "" :: [] => false
+    | "" :: "" :: [], "" :: _ => true
+    -- must start with equal quantity of `""`
+    | "" :: parent, "" :: target => go parent target
+    | "" :: _, _ => false
+    | _, "" :: _ => false
+    -- must start with equal quantity of `".."`
+    | ".." :: parent, ".." :: target => go parent target
+    | ".." :: _, _ => false
+    | _, ".." :: _ => false
+    -- `parent` is longer
+    | _ :: _, [] => false
+    -- check `target` does not contain any more `..`
+    | [], _ :: target => go [] target
+    -- recursion
+    | p :: arent, t :: arget => if p == t then go arent arget else false
+
+-- unit tests for `System.FilePath.contains`
+/-- info: true -/ #guard_msgs in #eval FilePath.contains "." "."
+/-- info: true -/ #guard_msgs in #eval FilePath.contains "./." "."
+/-- info: true -/ #guard_msgs in #eval FilePath.contains "." "./."
+/-- info: true -/ #guard_msgs in #eval FilePath.contains "." "A"
+/-- info: true -/ #guard_msgs in #eval FilePath.contains "././." "A"
+/-- info: true -/ #guard_msgs in #eval FilePath.contains "././." "././A"
+/-- info: true -/ #guard_msgs in #eval FilePath.contains "A" "A/B"
+/-- info: true -/ #guard_msgs in #eval FilePath.contains "A" "A//B"
+/-- info: true -/ #guard_msgs in #eval FilePath.contains "A//B" "A/B///C//"
+/-- info: true -/ #guard_msgs in #eval FilePath.contains "/" "/"
+/-- info: true -/ #guard_msgs in #eval FilePath.contains "/" "/A"
+/-- info: true -/ #guard_msgs in #eval FilePath.contains "/A" "/A/B"
+/-- info: true -/ #guard_msgs in #eval FilePath.contains "//" "//A"
+/-- info: true -/ #guard_msgs in #eval FilePath.contains "//A" "//A/B"
+/-- info: true -/ #guard_msgs in #eval FilePath.contains "//" "//"
+/-- info: true -/ #guard_msgs in #eval FilePath.contains "/" "///"
+/-- info: true -/ #guard_msgs in #eval FilePath.contains "///" "/"
+/-- info: true -/ #guard_msgs in #eval FilePath.contains "///" "/A"
+/-- info: true -/ #guard_msgs in #eval FilePath.contains "/" "///A"
+/-- info: true -/ #guard_msgs in #eval FilePath.contains ".." ".."
+/-- info: true -/ #guard_msgs in #eval FilePath.contains "../.." "../.."
+/-- info: true -/ #guard_msgs in #eval FilePath.contains "A/../B" "A/../B/C"
+/-- info: true -/ #guard_msgs in #eval FilePath.contains "A/.." "A/../A"
+/-- info: true -/ #guard_msgs in #eval FilePath.contains "../A/.." "../A/../B"
+/-- info: true -/ #guard_msgs in #eval FilePath.contains "../../A" "../../A/B"
+/-- info: true -/ #guard_msgs in #eval FilePath.contains "../A/.." "../A/../B"
+
+/-- info: false -/ #guard_msgs in #eval FilePath.contains "/" "//"
+/-- info: false -/ #guard_msgs in #eval FilePath.contains "//" "/"
+/-- info: false -/ #guard_msgs in #eval FilePath.contains "//A" "/A"
+/-- info: false -/ #guard_msgs in #eval FilePath.contains "/" "."
+/-- info: false -/ #guard_msgs in #eval FilePath.contains "." "/"
+/-- info: false -/ #guard_msgs in #eval FilePath.contains "/" "A"
+/-- info: false -/ #guard_msgs in #eval FilePath.contains "A" "."
+/-- info: false -/ #guard_msgs in #eval FilePath.contains "A" "/"
+/-- info: false -/ #guard_msgs in #eval FilePath.contains "A" "B/A"
+/-- info: false -/ #guard_msgs in #eval FilePath.contains "A/B" "A"
+/-- info: false -/ #guard_msgs in #eval FilePath.contains "A/B" "A/C/B"
+/-- info: false -/ #guard_msgs in #eval FilePath.contains "A" "A/../A"
+/-- info: false -/ #guard_msgs in #eval FilePath.contains "A" "A/B/../B"
+/-- info: false -/ #guard_msgs in #eval FilePath.contains "." ".."
+/-- info: false -/ #guard_msgs in #eval FilePath.contains "/" ".."
+/-- info: false -/ #guard_msgs in #eval FilePath.contains ".." "."
+/-- info: false -/ #guard_msgs in #eval FilePath.contains ".." "/"
+/-- info: false -/ #guard_msgs in #eval FilePath.contains "../.." ".."
+/-- info: false -/ #guard_msgs in #eval FilePath.contains ".." "../.."
+/-- info: false -/ #guard_msgs in #eval FilePath.contains "../A/.." "."
+/-- info: false -/ #guard_msgs in #eval FilePath.contains "../A/.." "A"
+/-- info: false -/ #guard_msgs in #eval FilePath.contains "A" "A/../A"
+/-- info: false -/ #guard_msgs in #eval FilePath.contains "A" "B/../A"
+/-- info: false -/ #guard_msgs in #eval FilePath.contains "A/../A" "A/C"
+/-- info: false -/ #guard_msgs in #eval FilePath.contains "B/../A" "A/C"
+/-- info: false -/ #guard_msgs in #eval FilePath.contains "A/B/../../C" "C/D"
+/-- info: false -/ #guard_msgs in #eval FilePath.contains "C" "A/B/../../C"
+/-- info: false -/ #guard_msgs in #eval FilePath.contains "A" "../../A"
+/-- info: false -/ #guard_msgs in #eval FilePath.contains "A/B/../../../C" "C/D"
+/-- info: false -/ #guard_msgs in #eval FilePath.contains "." "A/B/C/../../../../D"
+/-- info: false -/ #guard_msgs in #eval FilePath.contains "../A/.." "../A/../B/../B"
+
 /-- Removes a parent path from the beginning of a path -/
 def withoutParent (path parent : FilePath) : FilePath :=
   mkFilePath <| go path.components parent.components


### PR DESCRIPTION
Change the way cache finds the package directories without changing any behaviour.

---

- [x] depends on: #21663

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
