### PR TITLE
[Merged by Bors] - fix(minImports): reset state after parsing attributes

### DIFF
--- a/Mathlib/Tactic/MinImports.lean
+++ b/Mathlib/Tactic/MinImports.lean
@@ -144,7 +144,10 @@ def getDeclName (cmd : Syntax) : CommandElabM Name := do
   let some declStx := cmd.find? (·.isOfKind ``Parser.Command.declaration) | pure default
   let some modifiersStx := declStx.find? (·.isOfKind ``Parser.Command.declModifiers) | pure default
   let modifiers : TSyntax ``Parser.Command.declModifiers := ⟨modifiersStx⟩
+  -- the `get`/`set` state catches issues with elaboration of, for instance, `scoped` attributes
+  let s ← get
   let modifiers ← elabModifiers modifiers
+  set s
   liftCoreM do (
     -- Try applying the algorithm in `Lean.mkDeclName` to attach a namespace to the name.
     -- Unfortunately calling `Lean.mkDeclName` directly won't work: it will complain that there is

--- a/MathlibTest/MinImports.lean
+++ b/MathlibTest/MinImports.lean
@@ -16,6 +16,12 @@ run_cmd
 #guard_msgs in
 #min_imports in (← `(declModifiers|@[fun_prop]))
 
+-- check that `scoped` attributes do not cause elaboration problems
+/-- info: import Lean.Parser.Command -/
+#guard_msgs in
+#min_imports in
+@[scoped simp] theorem XX.YY : 0 = 0 := rfl
+
 namespace X
 /-- info: import Mathlib.Algebra.Ring.Nat -/
 #guard_msgs in


### PR DESCRIPTION
Yet another bug fix, this time found thanks to [this run](https://github.com/leanprover-community/mathlib4/actions/runs/13284754011) of the late importers report.

Here is the underlying issue.  The declaration
```lean
@[scoped simp] theorem XX.YY : 0 = 0 := rfl
```
accepts the `scoped` modifier to the `simp` attribute, *because* the namespacing is taken care of by `XX.YY`.  However, when the `minImports` machinery parses the attribute, it does not have access to the declaration name and this triggers an error if there is no explicit open namespace.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
