### PR TITLE
[Merged by Bors] - chore(*): address a few porting notes in concrete categories

### DIFF
--- a/Mathlib/Algebra/Category/ModuleCat/Limits.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Limits.lean
@@ -133,8 +133,6 @@ instance hasLimit : HasLimit F := HasLimit.mk {
 /-- If `J` is `u`-small, the category of `R`-modules has limits of shape `J`. -/
 lemma hasLimitsOfShape [Small.{w} J] : HasLimitsOfShape J (ModuleCat.{w} R) where
 
--- Porting note: mathport translated this as `irreducible_def`, but as `HasLimitsOfSize`
--- is a `Prop`, declaring this as `irreducible` should presumably have no effect
 /-- The category of R-modules has all limits. -/
 lemma hasLimitsOfSize [UnivLE.{v, w}] : HasLimitsOfSize.{t, v} (ModuleCat.{w} R) where
   has_limits_of_shape _ := hasLimitsOfShape

--- a/Mathlib/Algebra/Category/MonCat/Basic.lean
+++ b/Mathlib/Algebra/Category/MonCat/Basic.lean
@@ -490,9 +490,9 @@ instance CommMonCat.forget_reflects_isos : (forget CommMonCat.{u}).ReflectsIsomo
     let e : X ≃* Y := { f.hom, i.toEquiv with }
     exact e.toCommMonCatIso.isIso_hom
 
--- Porting note: this was added in order to ensure that `forget₂ CommMonCat MonCat`
--- automatically reflects isomorphisms
--- we could have used `CategoryTheory.HasForget.ReflectsIso` alternatively
+/-- Ensure that `forget₂ CommMonCat MonCat` automatically reflects isomorphisms.
+We could have used `CategoryTheory.HasForget.ReflectsIso` alternatively.
+-/
 @[to_additive]
 instance CommMonCat.forget₂_full : (forget₂ CommMonCat MonCat).Full where
   map_surjective f := ⟨ofHom f.hom, rfl⟩

--- a/Mathlib/Algebra/Category/MonCat/FilteredColimits.lean
+++ b/Mathlib/Algebra/Category/MonCat/FilteredColimits.lean
@@ -108,15 +108,8 @@ theorem colimitMulAux_eq_of_rel_left {x x' y : Σ j, F.obj j}
       (IsFiltered.rightToMax j₃ j₂) (IsFiltered.leftToMax j₃ j₂) f g
   apply M.mk_eq
   use s, α, γ
-  dsimp
-  simp_rw [MonoidHom.map_mul]
-  -- Porting note: Lean cannot seem to use lemmas from concrete categories directly
-  change (F.map _ ≫ F.map _) _ * (F.map _ ≫ F.map _) _ =
-    (F.map _ ≫ F.map _) _ * (F.map _ ≫ F.map _) _
-  simp_rw [← F.map_comp, h₁, h₂, h₃, F.map_comp]
-  congr 1
-  change F.map _ (F.map _ _) = F.map _ (F.map _ _)
-  rw [hfg]
+  simp_rw [MonoidHom.map_mul, ← ConcreteCategory.comp_apply, ← F.map_comp, h₁, h₂, h₃, F.map_comp,
+    ConcreteCategory.comp_apply, hfg]
 
 /-- Multiplication in the colimit is well-defined in the right argument. -/
 @[to_additive "Addition in the colimit is well-defined in the right argument."]
@@ -132,14 +125,8 @@ theorem colimitMulAux_eq_of_rel_right {x y y' : Σ j, F.obj j}
   apply M.mk_eq
   use s, α, γ
   dsimp
-  simp_rw [MonoidHom.map_mul]
-  -- Porting note: Lean cannot seem to use lemmas from concrete categories directly
-  change (F.map _ ≫ F.map _) _ * (F.map _ ≫ F.map _) _ =
-    (F.map _ ≫ F.map _) _ * (F.map _ ≫ F.map _) _
-  simp_rw [← F.map_comp, h₁, h₂, h₃, F.map_comp]
-  congr 1
-  change F.map _ (F.map _ _) = F.map _ (F.map _ _)
-  rw [hfg]
+  simp_rw [MonoidHom.map_mul, ← ConcreteCategory.comp_apply, ← F.map_comp, h₁, h₂, h₃, F.map_comp,
+    ConcreteCategory.comp_apply, hfg]
 
 /-- Multiplication in the colimit. See also `colimitMulAux`. -/
 @[to_additive "Addition in the colimit. See also `colimitAddAux`."]
@@ -171,11 +158,7 @@ theorem colimit_mul_mk_eq (x y : Σ j, F.obj j) (k : J) (f : x.1 ⟶ k) (g : y.1
   refine M.mk_eq F _ _ ?_
   use s, α, β
   dsimp
-  simp_rw [MonoidHom.map_mul]
-  -- Porting note: Lean cannot seem to use lemmas from concrete categories directly
-  change (F.map _ ≫ F.map _) _ * (F.map _ ≫ F.map _) _ =
-    (F.map _ ≫ F.map _) _ * (F.map _ ≫ F.map _) _
-  simp_rw [← F.map_comp, h₁, h₂]
+  simp_rw [MonoidHom.map_mul, ← ConcreteCategory.comp_apply, ← F.map_comp, h₁, h₂]
 
 @[to_additive]
 noncomputable instance colimitMulOneClass : MulOneClass (M.{v, u} F) :=
@@ -186,17 +169,13 @@ noncomputable instance colimitMulOneClass : MulOneClass (M.{v, u} F) :=
       intro x
       obtain ⟨j, x⟩ := x
       rw [colimit_one_eq F j, colimit_mul_mk_eq F ⟨j, 1⟩ ⟨j, x⟩ j (𝟙 j) (𝟙 j), MonoidHom.map_one,
-        one_mul, F.map_id]
-      -- Porting note: `id_apply` does not work here, but the two sides are def-eq
-      rfl
+        one_mul, F.map_id, id_apply]
     mul_one := fun x => by
       refine Quot.inductionOn x ?_
       intro x
       obtain ⟨j, x⟩ := x
       rw [colimit_one_eq F j, colimit_mul_mk_eq F ⟨j, x⟩ ⟨j, 1⟩ j (𝟙 j) (𝟙 j), MonoidHom.map_one,
-        mul_one, F.map_id]
-      -- Porting note: `id_apply` does not work here, but the two sides are def-eq
-      rfl }
+        mul_one, F.map_id, id_apply] }
 
 @[to_additive]
 noncomputable instance colimitMonoid : Monoid (M.{v, u} F) :=

--- a/Mathlib/Algebra/Category/Ring/Limits.lean
+++ b/Mathlib/Algebra/Category/Ring/Limits.lean
@@ -208,12 +208,8 @@ and then reuse the existing limit.
 -/
 instance :
     CreatesLimit F (forget₂ CommSemiRingCat.{u} SemiRingCat.{u}) :=
-  -- Porting note: `CommSemiRingCat ⥤ Type` reflecting isomorphism is needed to make Lean see that
-  -- `CommSemiRingCat ⥤ SemiRingCat` reflects isomorphism. `CommSemiRingCat ⥤ Type` reflecting
-  -- isomorphism is added manually since Lean can't see it, but even with this addition Lean can not
-  -- see `CommSemiRingCat ⥤ SemiRingCat` reflects isomorphism, so this instance is also added.
-  letI : (forget CommSemiRingCat.{u}).ReflectsIsomorphisms :=
-    CommSemiRingCat.forgetReflectIsos.{u}
+  -- Porting note: Lean can not see `CommSemiRingCat ⥤ SemiRingCat` reflects isomorphism, so this
+  -- instance is added.
   letI : (forget₂ CommSemiRingCat.{u} SemiRingCat.{u}).ReflectsIsomorphisms :=
     CategoryTheory.reflectsIsomorphisms_forget₂ CommSemiRingCat.{u} SemiRingCat.{u}
   letI : Small.{u} (Functor.sections ((F ⋙ forget₂ _ SemiRingCat) ⋙ forget _)) :=

--- a/Mathlib/Algebra/Category/Semigrp/Basic.lean
+++ b/Mathlib/Algebra/Category/Semigrp/Basic.lean
@@ -447,9 +447,10 @@ instance Semigrp.forgetReflectsIsos : (forget Semigrp.{u}).ReflectsIsomorphisms 
     let e : X ≃* Y := { f.hom, i.toEquiv with }
     exact e.toSemigrpIso.isIso_hom
 
--- Porting note: this was added in order to ensure that `forget₂ CommMonCat MonCat`
--- automatically reflects isomorphisms
--- we could have used `CategoryTheory.HasForget.ReflectsIso` alternatively
+/--
+Ensure that `forget₂ CommMonCat MonCat` automatically reflects isomorphisms.
+We could have used `CategoryTheory.HasForget.ReflectsIso` alternatively.
+-/
 @[to_additive]
 instance Semigrp.forget₂_full : (forget₂ Semigrp MagmaCat).Full where
   map_surjective f := ⟨ofHom f.hom, rfl⟩

--- a/Mathlib/AlgebraicGeometry/Cover/Open.lean
+++ b/Mathlib/AlgebraicGeometry/Cover/Open.lean
@@ -251,10 +251,7 @@ def affineBasisCoverOfAffine (R : CommRingCat.{u}) : OpenCover (Spec R) where
   covers r := by
     rw [Set.range_eq_univ.mpr ((TopCat.epi_iff_surjective _).mp _)]
     · exact trivial
-    · -- Porting note: need more hand holding here because Lean knows that
-      -- `CommRing.ofHom ...` is iso, but without `ofHom` Lean does not know what to do
-      change Epi (Spec.map (CommRingCat.ofHom (algebraMap _ _))).base
-      infer_instance
+    · infer_instance
   map_prop x := AlgebraicGeometry.Scheme.basic_open_isOpenImmersion x
 
 /-- We may bind the basic open sets of an open affine cover to form an affine cover that is also

--- a/Mathlib/AlgebraicGeometry/GammaSpecAdjunction.lean
+++ b/Mathlib/AlgebraicGeometry/GammaSpecAdjunction.lean
@@ -229,10 +229,11 @@ lemma toΓSpec_preimage_zeroLocus_eq {X : LocallyRingedSpace.{u}}
     X.toΓSpec.base ⁻¹' PrimeSpectrum.zeroLocus s = X.toRingedSpace.zeroLocus s := by
   simp only [RingedSpace.zeroLocus]
   have (i : LocallyRingedSpace.Γ.obj (op X)) (_ : i ∈ s) :
-      ((X.toRingedSpace.basicOpen i).carrier)ᶜ =
-        X.toΓSpec.base ⁻¹' (PrimeSpectrum.basicOpen i).carrierᶜ := by
+      (SetLike.coe (X.toRingedSpace.basicOpen i))ᶜ =
+        X.toΓSpec.base ⁻¹' ((PrimeSpectrum.basicOpen i).carrier)ᶜ := by
     symm
-    erw [Set.preimage_compl, X.toΓSpec_preimage_basicOpen_eq i]
+    rw [Set.preimage_compl, Opens.carrier_eq_coe]
+    erw [X.toΓSpec_preimage_basicOpen_eq i]
   erw [Set.iInter₂_congr this]
   simp_rw [← Set.preimage_iInter₂, Opens.carrier_eq_coe, PrimeSpectrum.basicOpen_eq_zeroLocus_compl,
     compl_compl]

--- a/Mathlib/AlgebraicGeometry/GammaSpecAdjunction.lean
+++ b/Mathlib/AlgebraicGeometry/GammaSpecAdjunction.lean
@@ -67,12 +67,12 @@ def toΓSpecFun : X → PrimeSpectrum (Γ.obj (op X)) := fun x =>
 
 theorem not_mem_prime_iff_unit_in_stalk (r : Γ.obj (op X)) (x : X) :
     r ∉ (X.toΓSpecFun x).asIdeal ↔ IsUnit (X.presheaf.Γgerm x r) := by
-  erw [IsLocalRing.mem_maximalIdeal, Classical.not_not]
+  simp [toΓSpecFun, IsLocalRing.closedPoint]
 
 /-- The preimage of a basic open in `Spec Γ(X)` under the unit is the basic
 open in `X` defined by the same element (they are equal as sets). -/
 theorem toΓSpec_preimage_basicOpen_eq (r : Γ.obj (op X)) :
-    X.toΓSpecFun ⁻¹' (basicOpen r).1 = (X.toRingedSpace.basicOpen r).1 := by
+    X.toΓSpecFun ⁻¹' basicOpen r = SetLike.coe (X.toRingedSpace.basicOpen r) := by
       ext
       dsimp
       simp only [Set.mem_preimage, SetLike.mem_coe]
@@ -83,7 +83,7 @@ theorem toΓSpec_preimage_basicOpen_eq (r : Γ.obj (op X)) :
 theorem toΓSpec_continuous : Continuous X.toΓSpecFun := by
   rw [isTopologicalBasis_basic_opens.continuous_iff]
   rintro _ ⟨r, rfl⟩
-  erw [X.toΓSpec_preimage_basicOpen_eq r]
+  rw [X.toΓSpec_preimage_basicOpen_eq r]
   exact (X.toRingedSpace.basicOpen r).2
 
 /-- The canonical (bundled) continuous map from the underlying topological

--- a/Mathlib/AlgebraicGeometry/StructureSheaf.lean
+++ b/Mathlib/AlgebraicGeometry/StructureSheaf.lean
@@ -643,11 +643,7 @@ theorem locally_const_basicOpen (U : Opens (PrimeSpectrum.Top R))
   have i_basic_open := eqToHom basic_opens_eq ≫ homOfLE hDhV
   -- We claim that `(f * c) / h ^ (n+1)` is our desired representation
   use f * c, h ^ (n + 1), i_basic_open ≫ iVU, (basic_opens_eq.symm.le :) hxDh
-  rw [op_comp, Functor.map_comp] --, comp_apply, ← s_eq, res_const]
-  -- Porting note: `comp_apply` can't be rewritten, so use a change
-  change const R _ _ _ _ = (structureSheaf R).1.map i_basic_open.op
-    ((structureSheaf R).1.map iVU.op s)
-  rw [← s_eq, res_const]
+  rw [op_comp, Functor.map_comp, ConcreteCategory.comp_apply, ← s_eq, res_const]
   -- Note that the last rewrite here generated an additional goal, which was a parameter
   -- of `res_const`. We prove this goal first
   swap
@@ -737,11 +733,7 @@ theorem normalize_finite_fraction_representation (U : Opens (PrimeSpectrum.Top R
       · simp only [n, mul_pow]; ring
   -- Lastly, we need to show that the new fractions still represent our original `s`
   intro i _
-  rw [op_comp, Functor.map_comp]
-  -- Porting note: `comp_apply` can't be rewritten, so use a change
-  change (structureSheaf R).1.map (eqToHom (basic_opens_eq _)).op
-    ((structureSheaf R).1.map (iDh i).op s) = _
-  rw [← hs, res_const]
+  rw [op_comp, Functor.map_comp, ConcreteCategory.comp_apply, ← hs, res_const]
   -- additional goal spit out by `res_const`
   swap
   · exact (basic_opens_eq i).le

--- a/Mathlib/AlgebraicTopology/FundamentalGroupoid/Basic.lean
+++ b/Mathlib/AlgebraicTopology/FundamentalGroupoid/Basic.lean
@@ -379,9 +379,8 @@ abbrev fromTop {X : TopCat} (x : X) : πₓ X := ⟨x⟩
 
 /-- Help the typechecker by converting an arrow in the fundamental groupoid of
 a topological space back to a path in that space (i.e., `Path.Homotopic.Quotient`). -/
--- Porting note: Added `(X := X)` to the type.
 abbrev toPath {X : TopCat} {x₀ x₁ : πₓ X} (p : x₀ ⟶ x₁) :
-    Path.Homotopic.Quotient (X := X) x₀.as x₁.as :=
+    Path.Homotopic.Quotient x₀.as x₁.as :=
   p
 
 /-- Help the typechecker by converting a path in a topological space to an arrow in the

--- a/Mathlib/AlgebraicTopology/FundamentalGroupoid/Product.lean
+++ b/Mathlib/AlgebraicTopology/FundamentalGroupoid/Product.lean
@@ -185,12 +185,7 @@ def prodIso : CategoryTheory.Grpd.of (πₓ A × πₓ B) ≅ πₓ (TopCat.of (
     apply CategoryTheory.Functor.hext
     · intros; apply FundamentalGroupoid.ext; apply Prod.ext <;> simp <;> rfl
     rintro ⟨x₀, x₁⟩ ⟨y₀, y₁⟩ f
-    have := Path.Homotopic.prod_projLeft_projRight f
-    -- Porting note: was simpa but TopSpace instances might be getting in the way
-    simp only [CategoryTheory.Functor.comp_obj, CategoryTheory.Functor.prod'_obj, prodToProdTop_obj,
-      CategoryTheory.Functor.comp_map, CategoryTheory.Functor.prod'_map, projLeft_map,
-      projRight_map, CategoryTheory.Functor.id_obj, CategoryTheory.Functor.id_map, heq_eq_eq]
-    apply this
+    simpa [-Path.Homotopic.prod_projLeft_projRight] using Path.Homotopic.prod_projLeft_projRight f
 
 end Prod
 

--- a/Mathlib/AlgebraicTopology/SimplexCategory.lean
+++ b/Mathlib/AlgebraicTopology/SimplexCategory.lean
@@ -864,12 +864,10 @@ theorem iso_eq_iso_refl {x : SimplexCategory} (e : x ≅ x) : e = Iso.refl x := 
   have eq₁ := Finset.orderEmbOfFin_unique' h fun i => Finset.mem_univ ((orderIsoOfIso e) i)
   have eq₂ :=
     Finset.orderEmbOfFin_unique' h fun i => Finset.mem_univ ((orderIsoOfIso (Iso.refl x)) i)
-  -- Porting note: the proof was rewritten from this point in https://github.com/leanprover-community/mathlib4/pull/3414 (reenableeta)
-  -- It could be investigated again to see if the original can be restored.
-  ext x
-  replace eq₁ := congr_arg (· x) eq₁
-  replace eq₂ := congr_arg (· x) eq₂.symm
-  simp_all
+  ext : 2
+  convert congr_arg (fun φ => (OrderEmbedding.toOrderHom φ)) (eq₁.trans eq₂.symm)
+  ext i : 2
+  rfl
 
 theorem eq_id_of_isIso {x : SimplexCategory} (f : x ⟶ x) [IsIso f] : f = 𝟙 _ :=
   congr_arg (fun φ : _ ≅ _ => φ.hom) (iso_eq_iso_refl (asIso f))
@@ -882,9 +880,7 @@ theorem eq_σ_comp_of_not_injective' {n : ℕ} {Δ' : SimplexCategory} (θ : mk 
   simp only [len_mk, σ, mkHom, comp_toOrderHom, Hom.toOrderHom_mk, OrderHom.comp_coe,
     OrderHom.coe_mk, Function.comp_apply]
   by_cases h' : x ≤ Fin.castSucc i
-  · -- This was not needed before https://github.com/leanprover/lean4/pull/2644
-    dsimp
-    rw [Fin.predAbove_of_le_castSucc i x h']
+  · rw [Fin.predAbove_of_le_castSucc i x h']
     dsimp [δ]
     rw [Fin.succAbove_of_castSucc_lt _ _ _]
     · rw [Fin.castSucc_castPred]
@@ -893,8 +889,6 @@ theorem eq_σ_comp_of_not_injective' {n : ℕ} {Δ' : SimplexCategory} (θ : mk 
     let y := x.pred <| by rintro (rfl : x = 0); simp at h'
     have hy : x = y.succ := (Fin.succ_pred x _).symm
     rw [hy] at h' ⊢
-    -- This was not needed before https://github.com/leanprover/lean4/pull/2644
-    conv_rhs => dsimp
     rw [Fin.predAbove_of_castSucc_lt i y.succ h', Fin.pred_succ]
     by_cases h'' : y = i
     · rw [h'']
@@ -936,9 +930,7 @@ theorem eq_comp_δ_of_not_surjective' {n : ℕ} {Δ : SimplexCategory} (θ : Δ 
     (i : Fin (n + 2)) (hi : ∀ x, θ.toOrderHom x ≠ i) : ∃ θ' : Δ ⟶ mk n, θ = θ' ≫ δ i := by
   by_cases h : i < Fin.last (n + 1)
   · use θ ≫ σ (Fin.castPred i h.ne)
-    ext1
-    ext1
-    ext1 x
+    ext x : 3
     simp only [len_mk, Category.assoc, comp_toOrderHom, OrderHom.comp_coe, Function.comp_apply]
     by_cases h' : θ.toOrderHom x ≤ i
     · simp only [σ, mkHom, Hom.toOrderHom_mk, OrderHom.coe_mk]

--- a/Mathlib/Topology/Category/Compactum.lean
+++ b/Mathlib/Topology/Category/Compactum.lean
@@ -148,8 +148,7 @@ theorem join_distrib (X : Compactum) (uux : Ultrafilter (Ultrafilter X)) :
   rw [Monad.Algebra.assoc]
   rfl
 
--- Porting note: changes to X.A from X since Lean can't see through X to X.A below
-instance {X : Compactum} : TopologicalSpace X.A where
+instance {X : Compactum} : TopologicalSpace X where
   IsOpen U := ∀ F : Ultrafilter X, X.str F ∈ U → U ∈ F
   isOpen_univ _ _ := Filter.univ_sets _
   isOpen_inter _ _ h3 h4 _ h6 := Filter.inter_sets _ (h3 _ h6.1) (h4 _ h6.2)


### PR DESCRIPTION
A not particularly exhaustive fix of a few porting notes in `Algebra/Category`, `AlgebraicGeometry`, `AlgebraicTopology` and `Topology/Category`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
