### PR TITLE
[Merged by Bors] - docs(Algebra/BigOperators/Group/List/Defs): fix a typo

### DIFF
--- a/Mathlib/Algebra/BigOperators/Group/List/Defs.lean
+++ b/Mathlib/Algebra/BigOperators/Group/List/Defs.lean
@@ -20,7 +20,7 @@ section Defs
 
 /-- Product of a list.
 
-`List.prod [a, b, c] = ((1 * a) * b) * c` -/
+`List.prod [a, b, c] = a * (b * (c * 1))` -/
 @[to_additive existing]
 def prod {α} [Mul α] [One α] : List α → α :=
   foldr (· * ·) 1


### PR DESCRIPTION
The docstring for `List.prod` says `List.prod [a, b, c] = ((1 * a) * b) * c` while it actually computes `a * (b * (c * 1))`.

The additive variant (`List.sum`) is already annotated accurately.

---

I believe #17851 accidentally reverted the docstring edited in #17223, but please let me know if the current docstring is intentionally kept.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
