### PR TITLE
[Merged by Bors] - chore: import the flexible linter in Mathlib.Init

### DIFF
--- a/Mathlib/Init.lean
+++ b/Mathlib/Init.lean
@@ -5,9 +5,8 @@ import Mathlib.Tactic.Linter.DocString
 import Mathlib.Tactic.Linter.GlobalAttributeIn
 import Mathlib.Tactic.Linter.HashCommandLinter
 import Mathlib.Tactic.Linter.Header
--- This linter is disabled by default, but downstream projects may want to enable it: to enable
--- this, we import the linter here. Otherwise, downstream projects would need to import the linter
--- in every file, to ensure it is available.
+-- This linter is disabled by default, but downstream projects may want to enable it:
+-- to facilitate this, we import the linter here.
 import Mathlib.Tactic.Linter.FlexibleLinter
 -- This file imports Batteries.Tactic.Lint, where the `env_linter` attribute is defined.
 import Mathlib.Tactic.Linter.Lint

--- a/Mathlib/Init.lean
+++ b/Mathlib/Init.lean
@@ -5,6 +5,9 @@ import Mathlib.Tactic.Linter.DocString
 import Mathlib.Tactic.Linter.GlobalAttributeIn
 import Mathlib.Tactic.Linter.HashCommandLinter
 import Mathlib.Tactic.Linter.Header
+-- This linter is disabled by default: we import it here so downstream projects can enable it
+-- project-wide without having to wonder if that linter was imported.
+import Mathlib.Tactic.Linter.FlexibleLinter
 -- This file imports Batteries.Tactic.Lint, where the `env_linter` attribute is defined.
 import Mathlib.Tactic.Linter.Lint
 import Mathlib.Tactic.Linter.Multigoal

--- a/Mathlib/Init.lean
+++ b/Mathlib/Init.lean
@@ -5,8 +5,9 @@ import Mathlib.Tactic.Linter.DocString
 import Mathlib.Tactic.Linter.GlobalAttributeIn
 import Mathlib.Tactic.Linter.HashCommandLinter
 import Mathlib.Tactic.Linter.Header
--- This linter is disabled by default: we import it here so downstream projects can enable it
--- project-wide without having to wonder if that linter was imported.
+-- This linter is disabled by default, but downstream projects may want to enable it: to enable
+-- this, we import the linter here. Otherwise, downstream projects would need to import the linter
+-- in every file, to ensure it is available.
 import Mathlib.Tactic.Linter.FlexibleLinter
 -- This file imports Batteries.Tactic.Lint, where the `env_linter` attribute is defined.
 import Mathlib.Tactic.Linter.Lint
@@ -40,7 +41,10 @@ as early as possible.
 All linters imported here have no bulk imports;
 **Not** imported in this file are
 - the text-based linters in `Linters/TextBased.lean`, as they can be imported later
-- the `minImports` linter, as that is still disabled by default
-- the `haveLet` linter, as it is currently disabled by default
+- the `haveLet` linter, as it is currently disabled by default due to crashes
+- the `ppRoundTrip` linter, which is current disabled (as this is not mature enough)
+- the `minImports` linter, as that linter is disabled by default (and has an informational function;
+  it is useful for debugging, but not as a permanently enabled lint)
+- the `upstreamableDecls` linter, as it is also mostly informational
 
 -/

--- a/Mathlib/Tactic/Linter.lean
+++ b/Mathlib/Tactic/Linter.lean
@@ -1,14 +1,13 @@
 /-
 This is the `Linter`s file: it imports files defining linters.
 All syntax linters enabled by default are imported in `Mathlib.Init`;
-this file contains all other linters.
+this file contains all linters not imported in that file.
 
 This file is ignored by `shake`:
 * it is in `ignoreAll`, meaning that all its imports are considered necessary;
 * it is in `ignoreImport`, meaning that where it is imported, it is considered necessary.
 -/
 
-import Mathlib.Tactic.Linter.FlexibleLinter
 import Mathlib.Tactic.Linter.HaveLetLinter
 import Mathlib.Tactic.Linter.MinImports
 import Mathlib.Tactic.Linter.PPRoundtrip

--- a/Mathlib/Tactic/Linter.lean
+++ b/Mathlib/Tactic/Linter.lean
@@ -1,6 +1,6 @@
 /-
 This is the `Linter`s file: it imports files defining linters.
-All syntax linters enabled by default are imported in `Mathlib.Init`;
+Most syntax linters, in particular the ones enabled by default, are imported in `Mathlib.Init`;
 this file contains all linters not imported in that file.
 
 This file is ignored by `shake`:

--- a/Mathlib/Tactic/Linter/FlexibleLinter.lean
+++ b/Mathlib/Tactic/Linter/FlexibleLinter.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Damiano Testa
 -/
 import Lean.Elab.Command
-import Mathlib.Init
 
 /-!
 #  The "flexible" linter

--- a/Mathlib/Tactic/Linter/FlexibleLinter.lean
+++ b/Mathlib/Tactic/Linter/FlexibleLinter.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Damiano Testa
 -/
 import Lean.Elab.Command
+import Mathlib.Tactic.Linter.Header
 
 /-!
 #  The "flexible" linter


### PR DESCRIPTION
This enables projects downstream of mathlib to enable it project-wide: previously, a file not importing this linter (as it e.g. imported only a single mathlib file not importing this linter) would fail to build because the linter option was not recognised.

Document why the remaining linters in `Mathlib.Tactic.Linter` are not enabled in `Mathlib.Init`.
Either, they are informational (like the `minImports` linter), or not ready to be used project-wide.
The `ppRoundtrip` linter arguably covers a middle ground; while it currently has too many false positives to be usable, one could conceivably also add it to Mathlib.Init. This can happen in a future PR, if there are reasons for doing so.

See [zulip discussion](https://leanprover.zulipchat.com/#narrow/channel/270676-lean4/topic/lake.20doesn't.20find.20option/near/499315240).


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
