### PR TITLE
[Merged by Bors] - feat: more measurability for `updateFinset`

### DIFF
--- a/Mathlib/MeasureTheory/MeasurableSpace/Basic.lean
+++ b/Mathlib/MeasureTheory/MeasurableSpace/Basic.lean
@@ -868,7 +868,7 @@ theorem measurable_uniqueElim [Unique δ] :
 @[measurability, fun_prop]
 theorem measurable_updateFinset' [DecidableEq δ] {s : Finset δ} :
     Measurable (fun p : (Π i, π i) × (Π i : s, π i) ↦ updateFinset p.1 s p.2) := by
-  simp (config := { unfoldPartialApp := true }) only [updateFinset, measurable_pi_iff]
+  simp only [updateFinset, measurable_pi_iff]
   intro i
   by_cases h : i ∈ s <;> simp [h]
   · exact Measurable.eval measurable_snd

--- a/Mathlib/MeasureTheory/MeasurableSpace/Basic.lean
+++ b/Mathlib/MeasureTheory/MeasurableSpace/Basic.lean
@@ -866,11 +866,23 @@ theorem measurable_uniqueElim [Unique δ] :
   simp_rw [measurable_pi_iff, Unique.forall_iff, uniqueElim_default]; exact measurable_id
 
 @[measurability, fun_prop]
-theorem measurable_updateFinset [DecidableEq δ] {s : Finset δ} {x : ∀ i, π i} :
-    Measurable (updateFinset x s) := by
+theorem measurable_updateFinset' [DecidableEq δ] {s : Finset δ} :
+    Measurable (fun p : (Π i, π i) × (Π i : s, π i) ↦ updateFinset p.1 s p.2) := by
   simp (config := { unfoldPartialApp := true }) only [updateFinset, measurable_pi_iff]
   intro i
-  by_cases h : i ∈ s <;> simp [h, measurable_pi_apply]
+  by_cases h : i ∈ s <;> simp [h]
+  · exact Measurable.eval measurable_snd
+  · exact Measurable.eval measurable_fst
+
+@[measurability, fun_prop]
+theorem measurable_updateFinset [DecidableEq δ] {s : Finset δ} {x : Π i, π i} :
+    Measurable (updateFinset x s) :=
+  measurable_updateFinset'.comp measurable_prod_mk_left
+
+@[measurability, fun_prop]
+theorem measurable_updateFinset_left [DecidableEq δ] {s : Finset δ} {x : Π i : s, π i} :
+    Measurable (updateFinset · s x) :=
+  measurable_updateFinset'.comp measurable_prod_mk_right
 
 /-- The function `update f a : π a → Π a, π a` is always measurable.
   This doesn't require `f` to be measurable.


### PR DESCRIPTION
`updateFinset` is measurable with respect to both arguments.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
