### PR TITLE
[Merged by Bors] - feat(LinearIndependent): LinearIndepOn predicate

### DIFF
--- a/Mathlib/LinearAlgebra/LinearIndependent.lean
+++ b/Mathlib/LinearAlgebra/LinearIndependent.lean
@@ -520,7 +520,7 @@ theorem LinearIndependent.mono {t s : Set M} (h : t ⊆ s)
 
 theorem LinearIndependentOn.mono {t s : Set ι} (hs : LinearIndependentOn R v s) (h : t ⊆ s) :
     LinearIndependentOn R v t :=
-  LinearIndependent.comp hs _ (Set.inclusion_injective h)
+  hs.comp _ (Set.inclusion_injective h)
 
 theorem linearIndependent_of_finite (s : Set M)
     (H : ∀ t ⊆ s, Set.Finite t → LinearIndependent R (fun x ↦ x : t → M)) :

--- a/Mathlib/LinearAlgebra/LinearIndependent.lean
+++ b/Mathlib/LinearAlgebra/LinearIndependent.lean
@@ -36,6 +36,9 @@ vector space and `ι : Type*` is an arbitrary indexing type.
 
 * `LinearIndependent R v` states that the elements of the family `v` are linearly independent.
 
+* `LinearIndependentOn R v s` states that the elements of the family `v` indexed by the members
+of the set `s : Set ι` are linearly independent.
+
 * `LinearIndependent.repr hv x` returns the linear combination representing `x : span R (range v)`
 on the linearly independent vectors `v`, given `hv : LinearIndependent R v`
 (using classical choice). `LinearIndependent.repr hv` is provided as a linear map.
@@ -125,6 +128,10 @@ def delabLinearIndependent : Delab :=
       withNaryArg 0 do return (← read).optionsPerPos.setBool (← getPos) `pp.analysis.namedArg true
     withTheReader Context ({· with optionsPerPos}) delab
 
+/-- `LinearIndependentOn R v s` states that the vectors in the family `v` that are indexed
+by the elements of `s` are linearly independent over `R`. -/
+def LinearIndependentOn (s : Set ι) : Prop := LinearIndependent R (fun x : s ↦ v x)
+
 variable {R v}
 
 theorem linearIndependent_iff_injective_linearCombination :
@@ -158,6 +165,13 @@ theorem linearIndependent_zero_iff [Nontrivial R] : LinearIndependent R (0 : ι 
 variable (R M) in
 theorem linearIndependent_empty : LinearIndependent R (fun x => x : (∅ : Set M) → M) :=
   linearIndependent_empty_type
+
+variable (R v) in
+theorem linearIndependentOn_empty : LinearIndependentOn R v ∅ :=
+  linearIndependent_empty_type ..
+
+theorem linearIndependent_set_subtype {s : Set ι} :
+    LinearIndependent R (fun x : s ↦ v x) ↔ LinearIndependentOn R v s := Iff.rfl
 
 /-- A subfamily of a linearly independent family (i.e., a composition with an injective map) is a
 linearly independent family. -/
@@ -366,6 +380,10 @@ theorem linearIndependent_equiv' (e : ι ≃ ι') {f : ι' → M} {g : ι → M}
     LinearIndependent R g ↔ LinearIndependent R f :=
   h ▸ linearIndependent_equiv e
 
+@[simp]
+theorem linearIndependentOn_univ : LinearIndependentOn R v univ ↔ LinearIndependent R v :=
+  linearIndependent_equiv' (Equiv.Set.univ ι) rfl
+
 theorem linearIndependent_subtype_range {ι} {f : ι → M} (hf : Injective f) :
     LinearIndependent R ((↑) : range f → M) ↔ LinearIndependent R f :=
   Iff.symm <| linearIndependent_equiv' (Equiv.ofInjective f hf) rfl
@@ -499,6 +517,10 @@ theorem LinearIndependent.restrict_of_comp_subtype {s : Set ι}
 theorem LinearIndependent.mono {t s : Set M} (h : t ⊆ s)
     (hs : LinearIndependent R (fun x ↦ x : s → M)) : LinearIndependent R (fun x ↦ x : t → M) :=
   hs.comp _ (Set.inclusion_injective h)
+
+theorem LinearIndependentOn.mono {t s : Set ι} (hs : LinearIndependentOn R v s) (h : t ⊆ s) :
+    LinearIndependentOn R v t :=
+  LinearIndependent.comp hs _ (Set.inclusion_injective h)
 
 theorem linearIndependent_of_finite (s : Set M)
     (H : ∀ t ⊆ s, Set.Finite t → LinearIndependent R (fun x ↦ x : t → M)) :

--- a/Mathlib/LinearAlgebra/LinearIndependent.lean
+++ b/Mathlib/LinearAlgebra/LinearIndependent.lean
@@ -8,7 +8,7 @@ import Mathlib.Data.Fin.Tuple.Reflection
 import Mathlib.Data.Set.Subsingleton
 import Mathlib.Lean.Expr.ExtraRecognizers
 import Mathlib.LinearAlgebra.Finsupp.SumProd
-import Mathlib.LinearAlgebra.Prodb
+import Mathlib.LinearAlgebra.Prod
 import Mathlib.Tactic.FinCases
 import Mathlib.Tactic.LinearCombination
 import Mathlib.Tactic.Module

--- a/Mathlib/LinearAlgebra/LinearIndependent.lean
+++ b/Mathlib/LinearAlgebra/LinearIndependent.lean
@@ -167,7 +167,7 @@ theorem linearIndependent_empty : LinearIndependent R (fun x => x : (∅ : Set M
   linearIndependent_empty_type
 
 variable (R v) in
-theorem linearIndepOn_empty : LinearIndepOn R v ∅ :=
+@[simp] theorem linearIndepOn_empty : LinearIndepOn R v ∅ :=
   linearIndependent_empty_type ..
 
 theorem linearIndependent_set_subtype {s : Set ι} :

--- a/Mathlib/LinearAlgebra/LinearIndependent.lean
+++ b/Mathlib/LinearAlgebra/LinearIndependent.lean
@@ -167,7 +167,8 @@ theorem linearIndependent_empty : LinearIndependent R (fun x => x : (∅ : Set M
   linearIndependent_empty_type
 
 variable (R v) in
-@[simp] theorem linearIndepOn_empty : LinearIndepOn R v ∅ :=
+@[simp]
+theorem linearIndepOn_empty : LinearIndepOn R v ∅ :=
   linearIndependent_empty_type ..
 
 theorem linearIndependent_set_subtype {s : Set ι} :
@@ -520,7 +521,7 @@ theorem LinearIndependent.mono {t s : Set M} (h : t ⊆ s)
 
 theorem LinearIndepOn.mono {t s : Set ι} (hs : LinearIndepOn R v s) (h : t ⊆ s) :
     LinearIndepOn R v t :=
-  hs.comp _ (Set.inclusion_injective h)
+  hs.comp _ <| Set.inclusion_injective h
 
 theorem linearIndependent_of_finite (s : Set M)
     (H : ∀ t ⊆ s, Set.Finite t → LinearIndependent R (fun x ↦ x : t → M)) :

--- a/Mathlib/LinearAlgebra/LinearIndependent.lean
+++ b/Mathlib/LinearAlgebra/LinearIndependent.lean
@@ -8,7 +8,7 @@ import Mathlib.Data.Fin.Tuple.Reflection
 import Mathlib.Data.Set.Subsingleton
 import Mathlib.Lean.Expr.ExtraRecognizers
 import Mathlib.LinearAlgebra.Finsupp.SumProd
-import Mathlib.LinearAlgebra.Prod
+import Mathlib.LinearAlgebra.Prodb
 import Mathlib.Tactic.FinCases
 import Mathlib.Tactic.LinearCombination
 import Mathlib.Tactic.Module
@@ -36,7 +36,7 @@ vector space and `ι : Type*` is an arbitrary indexing type.
 
 * `LinearIndependent R v` states that the elements of the family `v` are linearly independent.
 
-* `LinearIndependentOn R v s` states that the elements of the family `v` indexed by the members
+* `LinearIndepOn R v s` states that the elements of the family `v` indexed by the members
 of the set `s : Set ι` are linearly independent.
 
 * `LinearIndependent.repr hv x` returns the linear combination representing `x : span R (range v)`
@@ -128,9 +128,9 @@ def delabLinearIndependent : Delab :=
       withNaryArg 0 do return (← read).optionsPerPos.setBool (← getPos) `pp.analysis.namedArg true
     withTheReader Context ({· with optionsPerPos}) delab
 
-/-- `LinearIndependentOn R v s` states that the vectors in the family `v` that are indexed
+/-- `LinearIndepOn R v s` states that the vectors in the family `v` that are indexed
 by the elements of `s` are linearly independent over `R`. -/
-def LinearIndependentOn (s : Set ι) : Prop := LinearIndependent R (fun x : s ↦ v x)
+def LinearIndepOn (s : Set ι) : Prop := LinearIndependent R (fun x : s ↦ v x)
 
 variable {R v}
 
@@ -167,11 +167,11 @@ theorem linearIndependent_empty : LinearIndependent R (fun x => x : (∅ : Set M
   linearIndependent_empty_type
 
 variable (R v) in
-theorem linearIndependentOn_empty : LinearIndependentOn R v ∅ :=
+theorem linearIndepOn_empty : LinearIndepOn R v ∅ :=
   linearIndependent_empty_type ..
 
 theorem linearIndependent_set_subtype {s : Set ι} :
-    LinearIndependent R (fun x : s ↦ v x) ↔ LinearIndependentOn R v s := Iff.rfl
+    LinearIndependent R (fun x : s ↦ v x) ↔ LinearIndepOn R v s := Iff.rfl
 
 /-- A subfamily of a linearly independent family (i.e., a composition with an injective map) is a
 linearly independent family. -/
@@ -381,7 +381,7 @@ theorem linearIndependent_equiv' (e : ι ≃ ι') {f : ι' → M} {g : ι → M}
   h ▸ linearIndependent_equiv e
 
 @[simp]
-theorem linearIndependentOn_univ : LinearIndependentOn R v univ ↔ LinearIndependent R v :=
+theorem linearIndepOn_univ : LinearIndepOn R v univ ↔ LinearIndependent R v :=
   linearIndependent_equiv' (Equiv.Set.univ ι) rfl
 
 theorem linearIndependent_subtype_range {ι} {f : ι → M} (hf : Injective f) :
@@ -518,8 +518,8 @@ theorem LinearIndependent.mono {t s : Set M} (h : t ⊆ s)
     (hs : LinearIndependent R (fun x ↦ x : s → M)) : LinearIndependent R (fun x ↦ x : t → M) :=
   hs.comp _ (Set.inclusion_injective h)
 
-theorem LinearIndependentOn.mono {t s : Set ι} (hs : LinearIndependentOn R v s) (h : t ⊆ s) :
-    LinearIndependentOn R v t :=
+theorem LinearIndepOn.mono {t s : Set ι} (hs : LinearIndepOn R v s) (h : t ⊆ s) :
+    LinearIndepOn R v t :=
   hs.comp _ (Set.inclusion_injective h)
 
 theorem linearIndependent_of_finite (s : Set M)


### PR DESCRIPTION
Added a predicate stating that the vectors in a family indexed by a set are linearly independent.
As per [discussion on zulip](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/.60Set.2Eincl.60)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
