### PR TITLE
[Merged by Bors] - feat(List/Sort): generalize `sorted_mergeSort'`

### DIFF
--- a/Mathlib/Data/List/Sort.lean
+++ b/Mathlib/Data/List/Sort.lean
@@ -526,25 +526,22 @@ theorem Sorted.merge {l l' : List α} (h : Sorted r l) (h' : Sorted r l') :
 
 variable (r)
 
-/-- Variant of `sorted_mergeSort` using order typeclasses. -/
-theorem sorted_mergeSort' [Preorder α] [DecidableRel ((· : α) ≤ ·)] [IsTotal α (· ≤ ·)]
-    (l : List α) : Sorted (· ≤ ·) (mergeSort l) := by
-  simpa using sorted_mergeSort (le := fun a b => a ≤ b)
-    (fun a b c h₁ h₂ => by simpa using le_trans (by simpa using h₁) (by simpa using h₂))
-    (fun a b => by simpa using IsTotal.total a b)
+/-- Variant of `sorted_mergeSort` using relation typeclasses. -/
+theorem sorted_mergeSort' (l : List α) : Sorted r (mergeSort l (r · ·)) := by
+  simpa using sorted_mergeSort (le := (r · ·))
+    (fun _ _ _ => by simpa using trans_of r)
+    (by simpa using total_of r)
     l
 
-theorem mergeSort_eq_self [LinearOrder α] {l : List α} : Sorted (· ≤ ·) l → mergeSort l = l :=
-  eq_of_perm_of_sorted (mergeSort_perm _ _) (sorted_mergeSort' l)
+variable [IsAntisymm α r]
 
-theorem mergeSort_eq_insertionSort [IsAntisymm α r] (l : List α) :
+theorem mergeSort_eq_self {l : List α} : Sorted r l → mergeSort l (r · ·) = l :=
+  eq_of_perm_of_sorted (mergeSort_perm _ _) (sorted_mergeSort' _ l)
+
+theorem mergeSort_eq_insertionSort (l : List α) :
     mergeSort l (r · ·) = insertionSort r l :=
   eq_of_perm_of_sorted ((mergeSort_perm l _).trans (perm_insertionSort r l).symm)
-    (sorted_mergeSort (le := (r · ·))
-      (fun a b c h₁ h₂ => by simpa using _root_.trans (by simpa using h₁) (by simpa using h₂))
-      (fun a b => by simpa using IsTotal.total a b)
-      l)
-    (sorted_insertionSort r l).decide
+    (sorted_mergeSort' r l) (sorted_insertionSort r l)
 
 end TotalAndTransitive
 

--- a/Mathlib/Data/Multiset/Sort.lean
+++ b/Mathlib/Data/Multiset/Sort.lean
@@ -37,9 +37,7 @@ theorem coe_sort (l : List α) : sort r l = mergeSort l (r · ·) :=
 
 @[simp]
 theorem sort_sorted (s : Multiset α) : Sorted r (sort r s) :=
-  Quot.inductionOn s fun l => by
-    simpa using sorted_mergeSort (le := (r · ·)) IsTrans.trans
-      (fun a b => by simpa using IsTotal.total a b) l
+  Quot.inductionOn s (sorted_mergeSort' _)
 
 @[simp]
 theorem sort_eq (s : Multiset α) : ↑(sort r s) = s :=
@@ -73,7 +71,7 @@ theorem sort_cons (a : α) (s : Multiset α) :
 
 @[simp]
 theorem sort_range (n : ℕ) : sort (· ≤ ·) (range n) = List.range n :=
-  List.mergeSort_eq_self (sorted_le_range n)
+  List.mergeSort_eq_self _ (sorted_le_range n)
 
 end sort
 

--- a/Mathlib/Logic/Equiv/List.lean
+++ b/Mathlib/Logic/Equiv/List.lean
@@ -289,7 +289,7 @@ instance multiset : Denumerable (Multiset α) :=
         raise_lower (List.sorted_cons.2 ⟨fun n _ => Nat.zero_le n, (s.map encode).sort_sorted _⟩)
       simp [-Multiset.map_coe, this],
      fun n => by
-      simp [-Multiset.map_coe, List.mergeSort_eq_self (raise_sorted _ _), lower_raise]⟩
+      simp [-Multiset.map_coe, List.mergeSort_eq_self _ (raise_sorted _ _), lower_raise]⟩
 
 end Multiset
 
@@ -344,7 +344,7 @@ instance finset : Denumerable (Finset α) :=
           raise_lower' (fun n _ => Nat.zero_le n) (Finset.sort_sorted_lt _)],
       fun n => by
       simp [-Multiset.map_coe, Finset.map, raise'Finset, Finset.sort,
-        List.mergeSort_eq_self ((raise'_sorted _ _).imp (@le_of_lt _ _)), lower_raise']⟩
+        List.mergeSort_eq_self _ (raise'_sorted _ _).le_of_lt, lower_raise']⟩
 
 end Finset
 


### PR DESCRIPTION
.. to any transitive total relation.

Also generalize `mergeSort_eq_self` to any transitive total antisymmetric relation.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
