### PR TITLE
[Merged by Bors] - chore(Cache): move helper functions to `Cache.Lean`

### DIFF
--- a/Cache/IO.lean
+++ b/Cache/IO.lean
@@ -8,27 +8,9 @@ import Std.Data.HashMap
 import Lean.Data.RBMap
 import Lean.Data.RBTree
 import Lean.Data.Json.Printer
-import Lean.Util.Paths
+import Cache.Lean
 
 variable {α : Type}
-
-/-- Removes a parent path from the beginning of a path -/
-def System.FilePath.withoutParent (path parent : FilePath) : FilePath :=
-  let rec aux : List String → List String → List String
-    | z@(x :: xs), y :: ys => if x == y then aux xs ys else z
-    | [], _ => []
-    | x, [] => x
-  mkFilePath <| aux path.components parent.components
-
-def Nat.toHexDigits (n : Nat) : Nat → (res : String := "") → String
-  | 0, s => s
-  | len+1, s =>
-    let b := UInt8.ofNat (n >>> (len * 8))
-    Nat.toHexDigits n len <|
-      s.push (Nat.digitChar (b >>> 4).toNat) |>.push (Nat.digitChar (b &&& 15).toNat)
-
-def UInt64.asLTar (n : UInt64) : String :=
-  s!"{Nat.toHexDigits n.toNat 8}.ltar"
 
 open Lean
 

--- a/Cache/Lean.lean
+++ b/Cache/Lean.lean
@@ -1,0 +1,42 @@
+/-
+Copyright (c) 2025 Jon Eugster. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jon Eugster, Arthur Paulino
+-/
+
+import Lean.Data.Name
+import Lean.Util.Paths
+
+/-!
+# Helper Functions
+
+This file contains helper functions that could potentially be upstreamed to Lean
+or replaced by an appropriate function from Lean.
+
+Some functions here are duplicates from the folder `Mathlib/Lean/`.
+-/
+
+/-- Format as hex digit string. Used by `Cache` to format hashes. -/
+def Nat.toHexDigits (n : Nat) : Nat → (res : String := "") → String
+  | 0, s => s
+  | len+1, s =>
+    let b := UInt8.ofNat (n >>> (len * 8))
+    Nat.toHexDigits n len <|
+      s.push (Nat.digitChar (b >>> 4).toNat) |>.push (Nat.digitChar (b &&& 15).toNat)
+
+/-- Format hash as hex digit with extension `.ltar` -/
+def UInt64.asLTar (n : UInt64) : String :=
+  s!"{Nat.toHexDigits n.toNat 8}.ltar"
+
+namespace System.FilePath
+
+/-- Removes a parent path from the beginning of a path -/
+def withoutParent (path parent : FilePath) : FilePath :=
+  mkFilePath <| go path.components parent.components
+where
+  go : List String → List String → List String
+  | path@(x :: xs), y :: ys => if x == y then go xs ys else path
+  | [], _ => []
+  | path, [] => path
+
+end System.FilePath

--- a/Cache/Lean.lean
+++ b/Cache/Lean.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jon Eugster, Arthur Paulino
 -/
 
-import Lean.Data.Name
 import Lean.Util.Paths
 
 /-!


### PR DESCRIPTION
Move functions about basic Lean types to preliminary file in order to add more such helper functions in the future.

---

Note: declaration diff gives a false-positive because I changed `def System.FilePath.withoutParent ...` to

```
namespace System.FilePath

def withoutParent ...
```

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
