### PR TITLE
feat: add `cases'/induction'` to the technical debt counter

### DIFF
--- a/scripts/technical-debt-metrics.sh
+++ b/scripts/technical-debt-metrics.sh
@@ -85,7 +85,7 @@ titlesPathsAndRegexes=(
   "erw"                            "*"      "erw \["
   "maxHeartBeats modifications"    ":^MathlibTest" "^ *set_option .*maxHeartbeats"
   "cases'"                         "*"      " cases' "
-  "induction'"                     "*"      " induction' (?!\w+\s*:)"
+  "induction'"                     "*"      " induction' "
 )
 
 for i in ${!titlesPathsAndRegexes[@]}; do

--- a/scripts/technical-debt-metrics.sh
+++ b/scripts/technical-debt-metrics.sh
@@ -85,7 +85,7 @@ titlesPathsAndRegexes=(
   "erw"                            "*"      "erw \["
   "maxHeartBeats modifications"    ":^MathlibTest" "^ *set_option .*maxHeartbeats"
   "cases'"                         "*"      " cases' "
-  "induction'"                     "*"      " induction' "
+  "induction'"                     "*"      " induction' (?!\w+\s*:)"
 )
 
 for i in ${!titlesPathsAndRegexes[@]}; do

--- a/scripts/technical-debt-metrics.sh
+++ b/scripts/technical-debt-metrics.sh
@@ -84,6 +84,8 @@ titlesPathsAndRegexes=(
   "disabled simpNF lints"          "*"      "nolint simpNF"
   "erw"                            "*"      "erw \["
   "maxHeartBeats modifications"    ":^MathlibTest" "^ *set_option .*maxHeartbeats"
+  "cases'"                         "*"      " cases' "
+  "induction'"                     "*"      " induction' "
 )
 
 for i in ${!titlesPathsAndRegexes[@]}; do


### PR DESCRIPTION
See [Zulip](https://leanprover.zulipchat.com/#narrow/channel/270676-lean4/topic/To.20replace.20.60induction'.20h.20.3A.20f.20x.60/near/499482173).