### PR TITLE
[Merged by Bors] - chore(MathlibTest/Bound): replace `Complex.abs` by `norm`

### DIFF
--- a/Mathlib/Analysis/Normed/Group/Basic.lean
+++ b/Mathlib/Analysis/Normed/Group/Basic.lean
@@ -483,6 +483,10 @@ theorem abs_norm_sub_norm_le' (a b : E) : |‖a‖ - ‖b‖| ≤ ‖a / b‖ :=
 theorem norm_sub_norm_le' (a b : E) : ‖a‖ - ‖b‖ ≤ ‖a / b‖ :=
   (le_abs_self _).trans (abs_norm_sub_norm_le' a b)
 
+@[to_additive (attr := bound)]
+theorem norm_sub_le_norm_mul (a b : E) : ‖a‖ - ‖b‖ ≤ ‖a * b‖ := by
+  simpa using norm_mul_le' (a * b) (b⁻¹)
+
 @[to_additive dist_norm_norm_le]
 theorem dist_norm_norm_le' (a b : E) : dist ‖a‖ ‖b‖ ≤ ‖a / b‖ :=
   abs_norm_sub_norm_le' a b

--- a/Mathlib/Tactic/Bound.lean
+++ b/Mathlib/Tactic/Bound.lean
@@ -220,13 +220,14 @@ An example use case is
 
 ```
 -- Calc example: A weak lower bound for `z ↦ z^2 + c`
-lemma le_sqr_add {c z : ℂ} (cz : abs c ≤ abs z) (z3 : 3 ≤ abs z) :
-    2 * abs z ≤ abs (z^2 + c) := by
-  calc abs (z^2 + c)
-    _ ≥ abs (z^2) - abs c := by bound
-    _ ≥ abs (z^2) - abs z := by bound
-    _ ≥ (abs z - 1) * abs z := by rw [mul_comm, mul_sub_one, ← pow_two, ← abs.map_pow]
-    _ ≥ 2 * abs z := by bound
+lemma le_sqr_add (c z : ℝ) (cz : ‖c‖ ≤ ‖z‖) (z3 : 3 ≤ ‖z‖) :
+    2 * ‖z‖ ≤ ‖z^2 + c‖ := by
+  calc ‖z^2 + c‖
+    _ ≥ ‖z^2‖ - ‖c‖ := by bound
+    _ ≥ ‖z^2‖ - ‖z‖ := by  bound
+    _ ≥ (‖z‖ - 1) * ‖z‖ := by
+      rw [mul_comm, mul_sub_one, ← pow_two, ← norm_pow]
+    _ ≥ 2 * ‖z‖ := by bound
 ```
 
 `bound` is built on top of `aesop`, and uses

--- a/MathlibTest/Bound/bound.lean
+++ b/MathlibTest/Bound/bound.lean
@@ -29,14 +29,14 @@ example {α : Type} {s : Finset α} {f g : α → ℂ} :  -- An example that req
 end bound_only
 
 -- Calc example: A weak lower bound for `z ← z^2 + c`
-example {c z : ℂ} (cz : Complex.abs c ≤ Complex.abs z) (z3 : 3 ≤ Complex.abs z) :
-    2 * Complex.abs z ≤ Complex.abs (z^2 + c) := by
-  calc Complex.abs (z^2 + c)
-    _ ≥ Complex.abs (z^2) - Complex.abs c := by bound
-    _ ≥ Complex.abs (z^2) - Complex.abs z := by bound  -- gcongr works here, not for the other two
-    _ ≥ (Complex.abs z - 1) * Complex.abs z := by
-      rw [mul_comm, mul_sub_one, ← pow_two, ← Complex.abs.map_pow]
-    _ ≥ 2 * Complex.abs z := by bound
+example {c z : ℝ} (cz : ‖c‖ ≤ ‖z‖) (z3 : 3 ≤ ‖z‖) :
+    2 * ‖z‖ ≤ ‖z^2 + c‖ := by
+  calc ‖z^2 + c‖
+    _ ≥ ‖z^2‖ - ‖c‖ := by bound
+    _ ≥ ‖z^2‖ - ‖z‖ := by  bound  -- gcongr works here, not for the other two
+    _ ≥ (‖z‖ - 1) * ‖z‖ := by
+      rw [mul_comm, mul_sub_one, ← pow_two, ← norm_pow]
+    _ ≥ 2 * ‖z‖ := by bound
 
 -- Testing branching functionality. None of these tests work with `positivity` or `bound`.
 section guess_tests


### PR DESCRIPTION
See [Zulib](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Turn.20.60Complex.2Eabs.60.20into.20.60Norm.60/near/499295319)


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
