### PR TITLE
[Merged by Bors] - chore(Algebra): split `Zero/One` instance on products

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1017,6 +1017,7 @@ import Mathlib.Algebra.Tropical.Lattice
 import Mathlib.Algebra.Vertex.HVertexOperator
 import Mathlib.Algebra.Vertex.VertexOperator
 import Mathlib.Algebra.ZeroOne.Lemmas
+import Mathlib.Algebra.ZeroOne.Prod
 import Mathlib.AlgebraicGeometry.AffineScheme
 import Mathlib.AlgebraicGeometry.AffineSpace
 import Mathlib.AlgebraicGeometry.Cover.MorphismProperty

--- a/Mathlib/Algebra/Group/Prod.lean
+++ b/Mathlib/Algebra/Group/Prod.lean
@@ -5,6 +5,7 @@ Authors: Simon Hudon, Patrick Massot, Yury Kudryashov
 -/
 import Mathlib.Algebra.Group.Opposite
 import Mathlib.Algebra.Group.Units.Hom
+import Mathlib.Algebra.ZeroOne.Prod
 
 /-!
 # Monoid, group etc structures on `M × N`
@@ -71,33 +72,6 @@ theorem one_mk_mul_one_mk [Monoid M] [Mul N] (b₁ b₂ : N) :
 theorem mk_one_mul_mk_one [Mul M] [Monoid N] (a₁ a₂ : M) :
     (a₁, (1 : N)) * (a₂, 1) = (a₁ * a₂, 1) := by
   rw [mk_mul_mk, mul_one]
-
-@[to_additive]
-instance instOne [One M] [One N] : One (M × N) :=
-  ⟨(1, 1)⟩
-
-@[to_additive (attr := simp)]
-theorem fst_one [One M] [One N] : (1 : M × N).1 = 1 :=
-  rfl
-
-@[to_additive (attr := simp)]
-theorem snd_one [One M] [One N] : (1 : M × N).2 = 1 :=
-  rfl
-
-@[to_additive]
-theorem one_eq_mk [One M] [One N] : (1 : M × N) = (1, 1) :=
-  rfl
-
-@[to_additive (attr := simp)]
-theorem mk_one_one [One M] [One N] : ((1 : M), (1 : N)) = 1 := rfl
-
-@[to_additive (attr := simp)]
-theorem mk_eq_one [One M] [One N] {x : M} {y : N} : (x, y) = 1 ↔ x = 1 ∧ y = 1 :=
-  mk.inj_iff
-
-@[to_additive (attr := simp)]
-theorem swap_one [One M] [One N] : (1 : M × N).swap = 1 :=
-  rfl
 
 @[to_additive]
 theorem fst_mul_snd [MulOneClass M] [MulOneClass N] (p : M × N) : (p.fst, 1) * (1, p.snd) = p :=

--- a/Mathlib/Algebra/Group/Support.lean
+++ b/Mathlib/Algebra/Group/Support.lean
@@ -3,7 +3,9 @@ Copyright (c) 2020 Yury Kudryashov. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury Kudryashov
 -/
-import Mathlib.Algebra.Group.Prod
+import Mathlib.Algebra.Group.Basic
+import Mathlib.Algebra.Group.Pi.Basic
+import Mathlib.Algebra.ZeroOne.Prod
 import Mathlib.Order.Cover
 
 /-!

--- a/Mathlib/Algebra/ZeroOne/Prod.lean
+++ b/Mathlib/Algebra/ZeroOne/Prod.lean
@@ -1,0 +1,52 @@
+/-
+Copyright (c) 2020 Yury Kudryashov. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Simon Hudon, Patrick Massot, Yury Kudryashov
+-/
+import Mathlib.Util.AssertExists
+import Mathlib.Data.One.Defs
+import Mathlib.Data.Prod.Basic
+
+/-!
+# `Zero` and `One` instances on `M × N`
+
+In this file we define `0` and `1` on `M × N` as the pair `(0, 0)` and `(1, 1)` respectively.
+We also prove trivial `simp` lemmas:
+-/
+
+assert_not_exists AddMonoidWithOne
+assert_not_exists DenselyOrdered
+assert_not_exists MonoidWithZero
+
+variable {G : Type*} {H : Type*} {M : Type*} {N : Type*} {P : Type*}
+
+namespace Prod
+
+@[to_additive]
+instance instOne [One M] [One N] : One (M × N) :=
+  ⟨(1, 1)⟩
+
+@[to_additive (attr := simp)]
+theorem fst_one [One M] [One N] : (1 : M × N).1 = 1 :=
+  rfl
+
+@[to_additive (attr := simp)]
+theorem snd_one [One M] [One N] : (1 : M × N).2 = 1 :=
+  rfl
+
+@[to_additive]
+theorem one_eq_mk [One M] [One N] : (1 : M × N) = (1, 1) :=
+  rfl
+
+@[to_additive (attr := simp)]
+theorem mk_one_one [One M] [One N] : ((1 : M), (1 : N)) = 1 := rfl
+
+@[to_additive (attr := simp)]
+theorem mk_eq_one [One M] [One N] {x : M} {y : N} : (x, y) = 1 ↔ x = 1 ∧ y = 1 :=
+  mk.inj_iff
+
+@[to_additive (attr := simp)]
+theorem swap_one [One M] [One N] : (1 : M × N).swap = 1 :=
+  rfl
+
+end Prod

--- a/Mathlib/Data/Countable/Basic.lean
+++ b/Mathlib/Data/Countable/Basic.lean
@@ -14,6 +14,7 @@ import Mathlib.Logic.Equiv.Nat
 In this file we provide basic instances of the `Countable` typeclass defined elsewhere.
 -/
 
+assert_not_exists Group
 
 universe u v w
 

--- a/Mathlib/Data/Countable/Basic.lean
+++ b/Mathlib/Data/Countable/Basic.lean
@@ -14,7 +14,7 @@ import Mathlib.Logic.Equiv.Nat
 In this file we provide basic instances of the `Countable` typeclass defined elsewhere.
 -/
 
-assert_not_exists Group
+assert_not_exists Monoid
 
 universe u v w
 

--- a/Mathlib/Data/Finset/Image.lean
+++ b/Mathlib/Data/Finset/Image.lean
@@ -31,7 +31,7 @@ choosing between `insert` and `Finset.cons`, or between `Finset.union` and `Fins
 Move the material about `Finset.range` so that the `Mathlib.Algebra.Group.Embedding` import can be
 removed.
 -/
-assert_not_exists OrderedCommMonoid MonoidWithZero MulAction
+assert_not_exists MonoidWithZero MulAction OrderedCommMonoid
 
 variable {α β γ : Type*}
 

--- a/Mathlib/Data/Nat/Bits.lean
+++ b/Mathlib/Data/Nat/Bits.lean
@@ -22,7 +22,7 @@ See also: `Nat.bitwise`, `Nat.pow` (for various lemmas about `size` and `shiftLe
 and `Nat.digits`.
 -/
 
-assert_not_exists Group
+assert_not_exists Monoid
 
 -- Once we're in the `Nat` namespace, `xor` will inconveniently resolve to `Nat.xor`.
 /-- `bxor` denotes the `xor` function i.e. the exclusive-or function on type `Bool`. -/

--- a/Mathlib/Data/Nat/Bits.lean
+++ b/Mathlib/Data/Nat/Bits.lean
@@ -3,7 +3,6 @@ Copyright (c) 2022 Praneeth Kolichala. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Praneeth Kolichala
 -/
-import Mathlib.Algebra.Group.Nat.Defs
 import Mathlib.Data.Nat.Defs
 import Mathlib.Data.Nat.BinaryRec
 import Mathlib.Data.List.Defs
@@ -22,6 +21,8 @@ For example, we can more easily work with `Nat.bits` and `Nat.size`.
 See also: `Nat.bitwise`, `Nat.pow` (for various lemmas about `size` and `shiftLeft`/`shiftRight`),
 and `Nat.digits`.
 -/
+
+assert_not_exists Group
 
 -- Once we're in the `Nat` namespace, `xor` will inconveniently resolve to `Nat.xor`.
 /-- `bxor` denotes the `xor` function i.e. the exclusive-or function on type `Bool`. -/

--- a/Mathlib/Data/Nat/Pairing.lean
+++ b/Mathlib/Data/Nat/Pairing.lean
@@ -3,9 +3,9 @@ Copyright (c) 2015 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leonardo de Moura, Mario Carneiro
 -/
-import Mathlib.Algebra.Group.Prod
-import Mathlib.Data.Set.Lattice
+import Mathlib.Algebra.ZeroOne.Prod
 import Mathlib.Data.Nat.Sqrt
+import Mathlib.Data.Set.Lattice
 
 /-!
 # Naturals pairing function
@@ -23,7 +23,7 @@ It has the advantage of being monotone in both directions and sending `⟦0, n^2
 `⟦0, n - 1⟧²`.
 -/
 
-assert_not_exists MonoidWithZero
+assert_not_exists Group MonoidWithZero
 
 open Prod Decidable Function
 

--- a/Mathlib/Data/Nat/Pairing.lean
+++ b/Mathlib/Data/Nat/Pairing.lean
@@ -23,7 +23,7 @@ It has the advantage of being monotone in both directions and sending `⟦0, n^2
 `⟦0, n - 1⟧²`.
 -/
 
-assert_not_exists Group MonoidWithZero
+assert_not_exists Monoid MonoidWithZero
 
 open Prod Decidable Function
 

--- a/Mathlib/Data/Nat/Pairing.lean
+++ b/Mathlib/Data/Nat/Pairing.lean
@@ -23,7 +23,7 @@ It has the advantage of being monotone in both directions and sending `⟦0, n^2
 `⟦0, n - 1⟧²`.
 -/
 
-assert_not_exists Monoid MonoidWithZero
+assert_not_exists Monoid
 
 open Prod Decidable Function
 

--- a/Mathlib/Data/Nat/Size.lean
+++ b/Mathlib/Data/Nat/Size.lean
@@ -3,6 +3,7 @@ Copyright (c) 2014 Floris van Doorn (c) 2016 Microsoft Corporation. All rights r
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Floris van Doorn, Leonardo de Moura, Jeremy Avigad, Mario Carneiro
 -/
+import Mathlib.Algebra.Group.Nat.Defs
 import Mathlib.Algebra.Group.Basic
 import Mathlib.Data.Nat.Bits
 

--- a/Mathlib/Logic/Encodable/Basic.lean
+++ b/Mathlib/Logic/Encodable/Basic.lean
@@ -35,7 +35,7 @@ The point of asking for an explicit partial inverse `decode : ℕ → Option α`
 to make the range of `encode` decidable even when the finiteness of `α` is not.
 -/
 
-assert_not_exists Group
+assert_not_exists Monoid
 
 open Option List Nat Function
 

--- a/Mathlib/Logic/Encodable/Basic.lean
+++ b/Mathlib/Logic/Encodable/Basic.lean
@@ -35,6 +35,8 @@ The point of asking for an explicit partial inverse `decode : ℕ → Option α`
 to make the range of `encode` decidable even when the finiteness of `α` is not.
 -/
 
+assert_not_exists Group
+
 open Option List Nat Function
 
 /-- Constructively countable type. Made from an explicit injection `encode : α → ℕ` and a partial
@@ -550,7 +552,7 @@ theorem sequence_mono_nat {r : β → β → Prop} {f : α → β} (hf : Directe
 
 theorem rel_sequence {r : β → β → Prop} {f : α → β} (hf : Directed r f) (a : α) :
     r (f a) (f (hf.sequence f (encode a + 1))) := by
-  simp only [Directed.sequence, add_eq, add_zero, encodek, and_self]
+  simp only [Directed.sequence, add_eq, Nat.add_zero, encodek, and_self]
   exact (Classical.choose_spec (hf _ a)).2
 
 variable [Preorder β] {f : α → β}

--- a/Mathlib/Logic/Equiv/Nat.lean
+++ b/Mathlib/Logic/Equiv/Nat.lean
@@ -13,6 +13,7 @@ This file defines some additional constructive equivalences using `Encodable` an
 function on `ℕ`.
 -/
 
+assert_not_exists Group
 
 open Nat Function
 

--- a/Mathlib/Logic/Equiv/Nat.lean
+++ b/Mathlib/Logic/Equiv/Nat.lean
@@ -13,7 +13,7 @@ This file defines some additional constructive equivalences using `Encodable` an
 function on `ℕ`.
 -/
 
-assert_not_exists Group
+assert_not_exists Monoid
 
 open Nat Function
 

--- a/Mathlib/MeasureTheory/MeasurableSpace/Defs.lean
+++ b/Mathlib/MeasureTheory/MeasurableSpace/Defs.lean
@@ -35,7 +35,6 @@ contains all of them.
 measurable space, σ-algebra, measurable function
 -/
 
-
 open Set Encodable Function Equiv
 
 variable {α β γ δ δ' : Type*} {ι : Sort*} {s t u : Set α}


### PR DESCRIPTION
This PR is a step on the way to completely removing algebra from the dependencies of measure theory. It splits off the notation typeclass instances on `Prod` from the `Group` instances.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
