### PR TITLE
feat: if `s ∈ 𝓝 a` then there exists `y ∈ s` with `y < a`

### DIFF
--- a/Mathlib/Topology/Order/Basic.lean
+++ b/Mathlib/Topology/Order/Basic.lean
@@ -463,6 +463,20 @@ theorem mem_nhds_iff_exists_Ioo_subset [OrderTopology α] [NoMaxOrder α] [NoMin
     {s : Set α} : s ∈ 𝓝 a ↔ ∃ l u, a ∈ Ioo l u ∧ Ioo l u ⊆ s :=
   mem_nhds_iff_exists_Ioo_subset' (exists_lt a) (exists_gt a)
 
+theorem exists_lt_mem_of_mem_nhds [OrderTopology α] [NoMinOrder α] [DenselyOrdered α]
+    {a : α} {s : Set α} (hs : s ∈ 𝓝 a) :
+    ∃ y ∈ s, y < a := by
+  obtain ⟨b, hba, hbs⟩ := exists_Ioc_subset_of_mem_nhds hs (exists_lt a)
+  obtain ⟨y, hby, hya⟩ := exists_between hba
+  exact ⟨y, hbs ⟨hby, hya.le⟩, hya⟩
+
+theorem exists_gt_mem_of_mem_nhds [OrderTopology α] [NoMaxOrder α] [DenselyOrdered α]
+    {a : α} {s : Set α} (hs : s ∈ 𝓝 a) :
+    ∃ y ∈ s, a < y := by
+  obtain ⟨b, hab, hbs⟩ := exists_Ico_subset_of_mem_nhds hs (exists_gt a)
+  obtain ⟨y, hay, hyb⟩ := exists_between hab
+  exact ⟨y, hbs ⟨hay.le, hyb⟩, hay⟩
+
 theorem nhds_basis_Ioo' [OrderTopology α] {a : α} (hl : ∃ l, l < a) (hu : ∃ u, a < u) :
     (𝓝 a).HasBasis (fun b : α × α => b.1 < a ∧ a < b.2) fun b => Ioo b.1 b.2 :=
   ⟨fun s => (mem_nhds_iff_exists_Ioo_subset' hl hu).trans <| by simp⟩


### PR DESCRIPTION
That result is proved under the assumptions `[OrderTopology α] [NoMinOrder α] [DenselyOrdered α]`.

Also prove the dual result of existence of `y > a`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
