### PR TITLE
[Merged by Bors] - feat(Topology/Instances/EReal/Lemmas): add lemmas about limsup and multiplication

### DIFF
--- a/Mathlib/Data/Real/EReal.lean
+++ b/Mathlib/Data/Real/EReal.lean
@@ -2061,13 +2061,13 @@ private lemma exists_lt_mul_left_of_nonneg (ha : 0 ≤ a) (hc : 0 ≤ c) (h : c 
   · rcases eq_or_lt_of_le ha with rfl | ha
     · rw [zero_mul] at h
       exact (not_le_of_lt h hc).rec
-    · obtain ⟨a', a_pos', a_a'⟩ := exists_between ha
-      use a', mem_Ico.2 ⟨a_pos'.le, a_a'⟩
+    · obtain ⟨a', a0', aa'⟩ := exists_between ha
+      use a', mem_Ico.2 ⟨a0'.le, aa'⟩
       rw [mul_top_of_pos ha] at h
-      rwa [mul_top_of_pos a_pos']
-  · have b_pos : 0 < b := pos_of_mul_pos_right (hc.trans_lt h) ha
-    obtain ⟨a', ha', a_a'⟩ := exists_between ((div_lt_iff b_pos b_top).2 h)
-    exact ⟨a', ⟨(div_nonneg hc b_pos.le).trans ha'.le, a_a'⟩, (div_lt_iff b_pos b_top).1 ha'⟩
+      rwa [mul_top_of_pos a0']
+  · have b0 : 0 < b := pos_of_mul_pos_right (hc.trans_lt h) ha
+    obtain ⟨a', ha', aa'⟩ := exists_between ((div_lt_iff b0 b_top).2 h)
+    exact ⟨a', ⟨(div_nonneg hc b0.le).trans ha'.le, aa'⟩, (div_lt_iff b0 b_top).1 ha'⟩
 
 private lemma exists_lt_mul_right_of_nonneg (ha : 0 ≤ a) (hc : 0 ≤ c) (h : c < a * b) :
     ∃ b' ∈ Ico 0 b, c < a * b' := by
@@ -2102,18 +2102,18 @@ lemma le_mul_of_forall_lt (h₁ : 0 < a ∨ b ≠ ⊤) (h₂ : a ≠ ⊤ ∨ 0 <
   refine le_of_forall_gt_imp_ge_of_dense fun d hd ↦ ?_
   obtain ⟨a', aa', hd⟩ := exists_mul_left_lt (h₁.imp_left ne_of_gt) h₂ hd
   replace h₁ : 0 < a' ∨ b ≠ ⊤ := h₁.imp_left fun a0 ↦ a0.trans (mem_Ioo.1 aa').1
-  replace h₂ : a' ≠ ⊤ ∨ b ≠ 0 := by exact Or.inl (mem_Ioo.1 aa').2.ne
+  replace h₂ : a' ≠ ⊤ ∨ b ≠ 0 := Or.inl (mem_Ioo.1 aa').2.ne
   obtain ⟨b', bb', hd⟩ := exists_mul_right_lt h₁ h₂ hd
   exact (h a' (mem_Ioo.1 aa').1 b' (mem_Ioo.1 bb').1).trans hd.le
 
 lemma mul_le_of_forall_lt_of_nonneg (ha : 0 ≤ a) (hc : 0 ≤ c)
     (h : ∀ a' ∈ Ico 0 a, ∀ b' ∈ Ico 0 b, a' * b' ≤ c) : a * b ≤ c := by
-  refine le_of_forall_lt_imp_le_of_dense fun d d_ab ↦ ?_
-  rcases lt_or_le d 0 with hd | hd
-  · exact hd.le.trans hc
-  obtain ⟨a', ha', d_ab⟩ := exists_lt_mul_left_of_nonneg ha hd d_ab
-  obtain ⟨b', hb', d_ab⟩ := exists_lt_mul_right_of_nonneg ha'.1 hd d_ab
-  exact d_ab.le.trans (h a' ha' b' hb')
+  refine le_of_forall_lt_imp_le_of_dense fun d dab ↦ ?_
+  rcases lt_or_le d 0 with d0 | d0
+  · exact d0.le.trans hc
+  obtain ⟨a', aa', dab⟩ := exists_lt_mul_left_of_nonneg ha d0 dab
+  obtain ⟨b', bb', dab⟩ := exists_lt_mul_right_of_nonneg aa'.1 d0 dab
+  exact dab.le.trans (h a' aa' b' bb')
 
 /-! #### Division Distributivity -/
 

--- a/Mathlib/Data/Real/EReal.lean
+++ b/Mathlib/Data/Real/EReal.lean
@@ -1762,8 +1762,12 @@ instance : MulPosMono EReal := posMulMono_iff_mulPosMono.1 inferInstance
 
 instance : PosMulReflectLT EReal := PosMulMono.toPosMulReflectLT
 
-instance : MulPosReflectLT EReal :=
-  MulPosMono.toMulPosReflectLT
+instance : MulPosReflectLT EReal := MulPosMono.toMulPosReflectLT
+
+lemma mul_le_mul_of_nonpos_right {a b c : EReal} (h : b ≤ a) (hc : c ≤ 0) : a * c ≤ b * c := by
+  rw [mul_comm a c, mul_comm b c, ← neg_le_neg_iff, ← neg_mul c b, ← neg_mul c a]
+  rw [← neg_zero, EReal.le_neg] at hc
+  exact mul_le_mul_of_nonneg_left h hc
 
 @[simp, norm_cast]
 theorem coe_pow (x : ℝ) (n : ℕ) : (↑(x ^ n) : EReal) = (x : EReal) ^ n :=
@@ -1945,46 +1949,44 @@ lemma mul_div (a b c : EReal) : a * (b / c) = (a * b) / c := by
   change a * (b * c⁻¹) = (a * b) * c⁻¹
   rw [mul_assoc]
 
-lemma mul_div_right (a b c : EReal) : (a / b) * c = (a * c) / b := by
+lemma mul_div_right (a b c : EReal) : a / b * c = a * c / b := by
   rw [mul_comm, EReal.mul_div, mul_comm]
+
+lemma mul_div_left_comm (a b c : EReal) : a * (b / c) = b * (a / c) := by
+  rw [mul_div a b c, mul_comm a b, ← mul_div b a c]
 
 lemma div_div (a b c : EReal) : a / b / c = a / (b * c) := by
   change (a * b⁻¹) * c⁻¹ = a * (b * c)⁻¹
   rw [mul_assoc a b⁻¹, mul_inv]
 
-lemma div_mul_cancel {a b : EReal} (h₁ : b ≠ ⊥) (h₂ : b ≠ ⊤) (h₃ : b ≠ 0) : (a / b) * b = a := by
-  change (a * b⁻¹) * b = a
-  rw [mul_assoc, mul_comm b⁻¹ b]
-  change a * (b / b) = a
-  rw [div_self h₁ h₂ h₃, mul_one]
+lemma div_mul_div_comm (a b c d : EReal) : a / b * (c / d) = a * c / (b * d) := by
+  rw [← mul_div a, mul_comm b d, ← div_div c, ← mul_div_left_comm (c / d), mul_comm (a / b)]
 
-lemma mul_div_cancel {a b : EReal} (h₁ : b ≠ ⊥) (h₂ : b ≠ ⊤) (h₃ : b ≠ 0) : b * (a / b) = a := by
+variable {a b c : EReal}
+
+lemma div_mul_cancel (h₁ : b ≠ ⊥) (h₂ : b ≠ ⊤) (h₃ : b ≠ 0) : a / b * b = a := by
+  rw [mul_comm (a / b) b, ← mul_div_left_comm a b b, div_self h₁ h₂ h₃, mul_one]
+
+lemma mul_div_cancel (h₁ : b ≠ ⊥) (h₂ : b ≠ ⊤) (h₃ : b ≠ 0) : b * (a / b) = a := by
   rw [mul_comm, div_mul_cancel h₁ h₂ h₃]
 
-lemma mul_div_mul_cancel {a b c : EReal} (h₁ : c ≠ ⊥) (h₂ : c ≠ ⊤) (h₃ : c ≠ 0) :
-    (a * c) / (b * c) = a / b := by
-  change (a * c) * (b * c)⁻¹ = a * b⁻¹
-  rw [mul_assoc, mul_inv b c]
-  congr
-  exact mul_div_cancel h₁ h₂ h₃
+lemma mul_div_mul_cancel (h₁ : c ≠ ⊥) (h₂ : c ≠ ⊤) (h₃ : c ≠ 0) : (a * c) / (b * c) = a / b := by
+  rw [← mul_div_right a (b * c) c, ← div_div a b c, div_mul_cancel h₁ h₂ h₃]
 
-lemma div_eq_iff {a b c : EReal} (hbot : b ≠ ⊥) (htop : b ≠ ⊤) (hzero : b ≠ 0) :
-    c / b = a ↔ c = a * b := by
+lemma div_eq_iff (hbot : b ≠ ⊥) (htop : b ≠ ⊤) (hzero : b ≠ 0) : c / b = a ↔ c = a * b := by
   refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
   · rw [← @mul_div_cancel c b hbot htop hzero, h, mul_comm a b]
   · rw [h, mul_comm a b, ← mul_div b a b, @mul_div_cancel a b hbot htop hzero]
 
 /-! #### Division and Order -/
 
-lemma monotone_div_right_of_nonneg {b : EReal} (h : 0 ≤ b) : Monotone fun a ↦ a / b :=
+lemma monotone_div_right_of_nonneg (h : 0 ≤ b) : Monotone fun a ↦ a / b :=
   fun _ _ h' ↦ mul_le_mul_of_nonneg_right h' (inv_nonneg_of_nonneg h)
 
-lemma div_le_div_right_of_nonneg {a a' b : EReal} (h : 0 ≤ b) (h' : a ≤ a') :
-    a / b ≤ a' / b :=
+lemma div_le_div_right_of_nonneg (h : 0 ≤ c) (h' : a ≤ b) : a / c ≤ b / c :=
   monotone_div_right_of_nonneg h h'
 
-lemma strictMono_div_right_of_pos {b : EReal} (h : 0 < b) (h' : b ≠ ⊤) :
-    StrictMono fun a ↦ a / b := by
+lemma strictMono_div_right_of_pos (h : 0 < b) (h' : b ≠ ⊤) : StrictMono fun a ↦ a / b := by
   intro a a' a_lt_a'
   apply lt_of_le_of_ne <| div_le_div_right_of_nonneg (le_of_lt h) (le_of_lt a_lt_a')
   intro hyp
@@ -1992,11 +1994,10 @@ lemma strictMono_div_right_of_pos {b : EReal} (h : 0 < b) (h' : b ≠ ⊤) :
   rw [← @EReal.mul_div_cancel a b (ne_bot_of_gt h) h' (ne_of_gt h), hyp,
     @EReal.mul_div_cancel a' b (ne_bot_of_gt h) h' (ne_of_gt h)]
 
-lemma div_lt_div_right_of_pos {a a' b : EReal} (h₁ : 0 < b) (h₂ : b ≠ ⊤)
-    (h₃ : a < a') : a / b < a' / b :=
+lemma div_lt_div_right_of_pos (h₁ : 0 < c) (h₂ : c ≠ ⊤) (h₃ : a < b) : a / c < b / c :=
   strictMono_div_right_of_pos h₁ h₂ h₃
 
-lemma antitone_div_right_of_nonpos {b : EReal} (h : b ≤ 0) : Antitone fun a ↦ a / b := by
+lemma antitone_div_right_of_nonpos (h : b ≤ 0) : Antitone fun a ↦ a / b := by
   intro a a' h'
   change a' * b⁻¹ ≤ a * b⁻¹
   rw [← neg_neg (a * b⁻¹), ← neg_neg (a' * b⁻¹), neg_le_neg_iff, mul_comm a b⁻¹, mul_comm a' b⁻¹,
@@ -2004,12 +2005,10 @@ lemma antitone_div_right_of_nonpos {b : EReal} (h : b ≤ 0) : Antitone fun a �
   have : 0 ≤ -b := by apply EReal.le_neg_of_le_neg; simp [h]
   exact div_le_div_right_of_nonneg this h'
 
-lemma div_le_div_right_of_nonpos {a a' b : EReal} (h : b ≤ 0) (h' : a ≤ a') :
-    a' / b ≤ a / b :=
+lemma div_le_div_right_of_nonpos (h : c ≤ 0) (h' : a ≤ b) : b / c ≤ a / c :=
   antitone_div_right_of_nonpos h h'
 
-lemma strictAnti_div_right_of_neg {b : EReal} (h : b < 0) (h' : b ≠ ⊥) :
-    StrictAnti fun a ↦ a / b := by
+lemma strictAnti_div_right_of_neg (h : b < 0) (h' : b ≠ ⊥) : StrictAnti fun a ↦ a / b := by
   intro a a' a_lt_a'
   simp only
   apply lt_of_le_of_ne <| div_le_div_right_of_nonpos (le_of_lt h) (le_of_lt a_lt_a')
@@ -2018,53 +2017,111 @@ lemma strictAnti_div_right_of_neg {b : EReal} (h : b < 0) (h' : b ≠ ⊥) :
   rw [← @EReal.mul_div_cancel a b h' (ne_top_of_lt h) (ne_of_lt h), ← hyp,
     @EReal.mul_div_cancel a' b h' (ne_top_of_lt h) (ne_of_lt h)]
 
-lemma div_lt_div_right_of_neg {a a' b : EReal} (h₁ : b < 0) (h₂ : b ≠ ⊥)
-    (h₃ : a < a') : a' / b < a / b :=
+lemma div_lt_div_right_of_neg (h₁ : c < 0) (h₂ : c ≠ ⊥) (h₃ : a < b) : b / c < a / c :=
   strictAnti_div_right_of_neg h₁ h₂ h₃
 
-lemma le_div_iff_mul_le {a b c : EReal} (h : b > 0) (h' : b ≠ ⊤) :
-    a ≤ c / b ↔ a * b ≤ c := by
+lemma le_div_iff_mul_le (h : b > 0) (h' : b ≠ ⊤) : a ≤ c / b ↔ a * b ≤ c := by
   nth_rw 1 [← @mul_div_cancel a b (ne_bot_of_gt h) h' (ne_of_gt h)]
   rw [mul_div b a b, mul_comm a b]
   exact StrictMono.le_iff_le (strictMono_div_right_of_pos h h')
 
-lemma div_le_iff_le_mul {a b c : EReal} (h : 0 < b) (h' : b ≠ ⊤) :
-    a / b ≤ c ↔ a ≤ b * c := by
+lemma div_le_iff_le_mul (h : 0 < b) (h' : b ≠ ⊤) : a / b ≤ c ↔ a ≤ b * c := by
   nth_rw 1 [← @mul_div_cancel c b (ne_bot_of_gt h) h' (ne_of_gt h)]
   rw [mul_div b c b, mul_comm b]
   exact StrictMono.le_iff_le (strictMono_div_right_of_pos h h')
 
-lemma lt_div_iff {a b c : EReal} (h : 0 < b) (h' : b ≠ ⊤) :
-    a < c / b ↔ a * b < c := by
+lemma lt_div_iff (h : 0 < b) (h' : b ≠ ⊤) : a < c / b ↔ a * b < c := by
   nth_rw 1 [← @mul_div_cancel a b (ne_bot_of_gt h) h' (ne_of_gt h)]
   rw [EReal.mul_div b a b, mul_comm a b]
   exact (strictMono_div_right_of_pos h h').lt_iff_lt
 
-lemma div_lt_iff {a b c : EReal} (h : 0 < b) (h' : b ≠ ⊤) :
-    c / b < a ↔ c < a * b := by
-  nth_rw 1 [← @mul_div_cancel a b (ne_bot_of_gt h) h' (ne_of_gt h)]
-  rw [EReal.mul_div b a b, mul_comm a b]
+lemma div_lt_iff (h : 0 < c) (h' : c ≠ ⊤) :  b / c < a ↔ b < a * c := by
+  nth_rw 1 [← @mul_div_cancel a c (ne_bot_of_gt h) h' (ne_of_gt h)]
+  rw [EReal.mul_div c a c, mul_comm a c]
   exact (strictMono_div_right_of_pos h h').lt_iff_lt
 
-lemma div_nonneg {a b : EReal} (h : 0 ≤ a) (h' : 0 ≤ b) : 0 ≤ a / b :=
+lemma div_nonneg (h : 0 ≤ a) (h' : 0 ≤ b) : 0 ≤ a / b :=
   mul_nonneg h (inv_nonneg_of_nonneg h')
 
-lemma div_nonpos_of_nonpos_of_nonneg {a b : EReal} (h : a ≤ 0) (h' : 0 ≤ b) : a / b ≤ 0 :=
+lemma div_pos (ha : 0 < a) (hb : 0 < b) (hb' : b ≠ ⊤) : 0 < a / b :=
+  mul_pos ha (inv_pos_of_pos_ne_top hb hb')
+
+lemma div_nonpos_of_nonpos_of_nonneg (h : a ≤ 0) (h' : 0 ≤ b) : a / b ≤ 0 :=
   mul_nonpos_of_nonpos_of_nonneg h (inv_nonneg_of_nonneg h')
 
-lemma div_nonpos_of_nonneg_of_nonpos {a b : EReal} (h : 0 ≤ a) (h' : b ≤ 0) : a / b ≤ 0 :=
+lemma div_nonpos_of_nonneg_of_nonpos (h : 0 ≤ a) (h' : b ≤ 0) : a / b ≤ 0 :=
   mul_nonpos_of_nonneg_of_nonpos h (inv_nonpos_of_nonpos h')
 
-lemma div_nonneg_of_nonpos_of_nonpos {a b : EReal} (h : a ≤ 0) (h' : b ≤ 0) : 0 ≤ a / b :=
-  le_of_eq_of_le (Eq.symm zero_div) (div_le_div_right_of_nonpos h' h)
+lemma div_nonneg_of_nonpos_of_nonpos (h : a ≤ 0) (h' : b ≤ 0) : 0 ≤ a / b :=
+  le_of_eq_of_le zero_div.symm (div_le_div_right_of_nonpos h' h)
+
+private lemma exists_lt_mul_left_of_nonneg (ha : 0 ≤ a) (hc : 0 ≤ c) (h : c < a * b) :
+    ∃ a' ∈ Ico 0 a, c < a' * b := by
+  rcases eq_or_ne b ⊤ with rfl | b_top
+  · rcases eq_or_lt_of_le ha with rfl | ha
+    · rw [zero_mul] at h
+      exact (not_le_of_lt h hc).rec
+    · obtain ⟨a', a_pos', a_a'⟩ := exists_between ha
+      use a', mem_Ico.2 ⟨a_pos'.le, a_a'⟩
+      rw [mul_top_of_pos ha] at h
+      rwa [mul_top_of_pos a_pos']
+  · have b_pos : 0 < b := pos_of_mul_pos_right (hc.trans_lt h) ha
+    obtain ⟨a', ha', a_a'⟩ := exists_between ((div_lt_iff b_pos b_top).2 h)
+    exact ⟨a', ⟨(div_nonneg hc b_pos.le).trans ha'.le, a_a'⟩, (div_lt_iff b_pos b_top).1 ha'⟩
+
+private lemma exists_lt_mul_right_of_nonneg (ha : 0 ≤ a) (hc : 0 ≤ c) (h : c < a * b) :
+    ∃ b' ∈ Ico 0 b, c < a * b' := by
+  have hb : 0 < b := pos_of_mul_pos_right (hc.trans_lt h) ha
+  simp_rw [mul_comm a] at h ⊢
+  exact exists_lt_mul_left_of_nonneg hb.le hc h
+
+private lemma exists_mul_left_lt (h₁ : a ≠ 0 ∨ b ≠ ⊤) (h₂ : a ≠ ⊤ ∨ 0 < b) (hc : a * b < c) :
+    ∃ a' ∈ Ioo a ⊤, a' * b < c := by
+  rcases eq_top_or_lt_top a with rfl | a_top
+  · rw [ne_self_iff_false, false_or] at h₂; rw [top_mul_of_pos h₂] at hc; exact (not_top_lt hc).rec
+  rcases le_or_lt b 0 with b0 | b0
+  · obtain ⟨a', aa', a_top'⟩ := exists_between a_top
+    exact ⟨a', mem_Ioo.2 ⟨aa', a_top'⟩, lt_of_le_of_lt (mul_le_mul_of_nonpos_right aa'.le b0) hc⟩
+  rcases eq_top_or_lt_top b with rfl | b_top
+  · rcases lt_trichotomy a 0 with a0 | rfl | a0
+    · obtain ⟨a', aa', a0'⟩ := exists_between a0
+      rw [mul_top_of_neg a0] at hc
+      refine ⟨a', mem_Ioo.2 ⟨aa', lt_top_of_lt a0'⟩, mul_top_of_neg a0' ▸ hc⟩
+    · rw [ne_self_iff_false, ne_self_iff_false, false_or] at h₁; exact h₁.rec
+    · rw [mul_top_of_pos a0] at hc; exact (not_top_lt hc).rec
+  · obtain ⟨a', aa', hc'⟩ := exists_between ((lt_div_iff b0 b_top.ne).2 hc)
+    exact ⟨a', mem_Ioo.2 ⟨aa', lt_top_of_lt hc'⟩, (lt_div_iff b0 b_top.ne).1 hc'⟩
+
+private lemma exists_mul_right_lt (h₁ : 0 < a ∨ b ≠ ⊤) (h₂ : a ≠ ⊤ ∨ b ≠ 0) (hc : a * b < c) :
+    ∃ b' ∈ Ioo b ⊤, a * b' < c := by
+  simp_rw [mul_comm a] at hc ⊢
+  exact exists_mul_left_lt h₂.symm h₁.symm hc
+
+lemma le_mul_of_forall_lt (h₁ : 0 < a ∨ b ≠ ⊤) (h₂ : a ≠ ⊤ ∨ 0 < b)
+    (h : ∀ a' > a, ∀ b' > b, c ≤ a' * b') : c ≤ a * b := by
+  refine le_of_forall_gt_imp_ge_of_dense fun d hd ↦ ?_
+  obtain ⟨a', aa', hd⟩ := exists_mul_left_lt (h₁.imp_left ne_of_gt) h₂ hd
+  replace h₁ : 0 < a' ∨ b ≠ ⊤ := h₁.imp_left fun a0 ↦ a0.trans (mem_Ioo.1 aa').1
+  replace h₂ : a' ≠ ⊤ ∨ b ≠ 0 := by exact Or.inl (mem_Ioo.1 aa').2.ne
+  obtain ⟨b', bb', hd⟩ := exists_mul_right_lt h₁ h₂ hd
+  exact (h a' (mem_Ioo.1 aa').1 b' (mem_Ioo.1 bb').1).trans hd.le
+
+lemma mul_le_of_forall_lt_of_nonneg (ha : 0 ≤ a) (hc : 0 ≤ c)
+    (h : ∀ a' ∈ Ico 0 a, ∀ b' ∈ Ico 0 b, a' * b' ≤ c) : a * b ≤ c := by
+  refine le_of_forall_lt_imp_le_of_dense fun d d_ab ↦ ?_
+  rcases lt_or_le d 0 with hd | hd
+  · exact hd.le.trans hc
+  obtain ⟨a', ha', d_ab⟩ := exists_lt_mul_left_of_nonneg ha hd d_ab
+  obtain ⟨b', hb', d_ab⟩ := exists_lt_mul_right_of_nonneg ha'.1 hd d_ab
+  exact d_ab.le.trans (h a' ha' b' hb')
 
 /-! #### Division Distributivity -/
 
-lemma div_right_distrib_of_nonneg {a b c : EReal} (h : 0 ≤ a) (h' : 0 ≤ b) :
-    (a + b) / c = (a / c) + (b / c) :=
+lemma div_right_distrib_of_nonneg (h : 0 ≤ a) (h' : 0 ≤ b) :
+    (a + b) / c = a / c + b / c :=
   EReal.right_distrib_of_nonneg h h'
 
-lemma add_div_of_nonneg_right {a b c : EReal} (h : 0 ≤ c) :
+lemma add_div_of_nonneg_right (h : 0 ≤ c) :
     (a + b) / c = a / c + b / c := by
   apply right_distrib_of_nonneg_of_ne_top (inv_nonneg_of_nonneg h) (inv_lt_top c).ne
 

--- a/Mathlib/Data/Real/EReal.lean
+++ b/Mathlib/Data/Real/EReal.lean
@@ -1970,7 +1970,7 @@ lemma div_mul_cancel (h₁ : b ≠ ⊥) (h₂ : b ≠ ⊤) (h₃ : b ≠ 0) : a 
 lemma mul_div_cancel (h₁ : b ≠ ⊥) (h₂ : b ≠ ⊤) (h₃ : b ≠ 0) : b * (a / b) = a := by
   rw [mul_comm, div_mul_cancel h₁ h₂ h₃]
 
-lemma mul_div_mul_cancel (h₁ : c ≠ ⊥) (h₂ : c ≠ ⊤) (h₃ : c ≠ 0) : (a * c) / (b * c) = a / b := by
+lemma mul_div_mul_cancel (h₁ : c ≠ ⊥) (h₂ : c ≠ ⊤) (h₃ : c ≠ 0) : a * c / (b * c) = a / b := by
   rw [← mul_div_right a (b * c) c, ← div_div a b c, div_mul_cancel h₁ h₂ h₃]
 
 lemma div_eq_iff (hbot : b ≠ ⊥) (htop : b ≠ ⊤) (hzero : b ≠ 0) : c / b = a ↔ c = a * b := by

--- a/Mathlib/Topology/Instances/EReal/Lemmas.lean
+++ b/Mathlib/Topology/Instances/EReal/Lemmas.lean
@@ -275,21 +275,19 @@ lemma liminf_add_le (h : limsup u f ≠ ⊥ ∨ liminf v f ≠ ⊤) (h' : limsup
 @[deprecated (since := "2024-11-11")] alias limsup_add_liminf_le_limsup_add := le_limsup_add
 @[deprecated (since := "2024-11-11")] alias liminf_add_le_limsup_add_liminf := liminf_add_le
 
-variable {a b : EReal}
-
 lemma limsup_add_bot_of_ne_top (h : limsup u f = ⊥) (h' : limsup v f ≠ ⊤) :
     limsup (u + v) f = ⊥ := by
   apply le_bot_iff.1 ((limsup_add_le (.inr h') _).trans _)
   · rw [h]; exact .inl bot_ne_top
   · rw [h, bot_add]
 
-lemma limsup_add_le_of_le (ha : limsup u f < a) (hb : limsup v f ≤ b) :
+lemma limsup_add_le_of_le {a b : EReal} (ha : limsup u f < a) (hb : limsup v f ≤ b) :
     limsup (u + v) f ≤ a + b := by
   rcases eq_top_or_lt_top b with rfl | h
   · rw [add_top_of_ne_bot ha.ne_bot]; exact le_top
   · exact (limsup_add_le (.inr (hb.trans_lt h).ne) (.inl ha.ne_top)).trans (add_le_add ha.le hb)
 
-lemma liminf_add_gt_of_gt (ha : a < liminf u f) (hb : b < liminf v f) :
+lemma liminf_add_gt_of_gt {a b : EReal} (ha : a < liminf u f) (hb : b < liminf v f) :
     a + b < liminf (u + v) f :=
   (add_lt_add ha hb).trans_le le_liminf_add
 
@@ -297,6 +295,58 @@ lemma liminf_add_top_of_ne_bot (h : liminf u f = ⊤) (h' : liminf v f ≠ ⊥) 
     liminf (u + v) f = ⊤ := by
   apply top_le_iff.1 (le_trans _ le_liminf_add)
   rw [h, top_add_of_ne_bot h']
+
+lemma le_limsup_mul (hu : 0 ≤ᶠ[f] u) (hv : 0 ≤ᶠ[f] v) :
+    limsup u f * liminf v f ≤ limsup (u * v) f := by
+  rcases f.eq_or_neBot with rfl | _
+  · rw [limsup_bot, limsup_bot, liminf_bot, bot_mul_top]
+  have u0 : 0 ≤ limsup u f := le_limsup_of_frequently_le hu.frequently
+  have uv0 : 0 ≤ limsup (u * v) f :=
+    le_limsup_of_frequently_le ((hu.and hv).mono fun _ ⟨hu, hv⟩ ↦ mul_nonneg hu hv).frequently
+  refine mul_le_of_forall_lt_of_nonneg u0 uv0 fun a ha b hb ↦ (le_limsup_iff).2 fun c c_ab ↦ ?_
+  refine (((frequently_lt_of_lt_limsup) (mem_Ico.1 ha).2).and_eventually
+    <| (eventually_lt_of_lt_liminf (mem_Ico.1 hb).2).and
+    <| hu.and hv).mono fun x ⟨xa, ⟨xb, u0, _⟩⟩ ↦ ?_
+  exact c_ab.trans_le (mul_le_mul xa.le xb.le (mem_Ico.1 hb).1 u0)
+
+lemma limsup_mul_le (hu : 0 ≤ᶠ[f] u) (hv : 0 ≤ᶠ[f] v) (h₁ : limsup u f ≠ 0 ∨ limsup v f ≠ ⊤)
+    (h₂ : limsup u f ≠ ⊤ ∨ limsup v f ≠ 0) :
+    limsup (u * v) f ≤ limsup u f * limsup v f := by
+  rcases f.eq_or_neBot with rfl | _
+  · rw [limsup_bot]; exact bot_le
+  replace h₁ : 0 < limsup u f ∨ limsup v f ≠ ⊤ := by
+    refine h₁.imp_left fun h ↦ lt_of_le_of_ne ?_ h.symm
+    exact le_of_eq_of_le (limsup_const 0).symm (limsup_le_limsup hu)
+  replace h₂ : limsup u f ≠ ⊤ ∨ 0 < limsup v f := by
+    refine h₂.imp_right fun h ↦ lt_of_le_of_ne ?_ h.symm
+    exact le_of_eq_of_le (limsup_const 0).symm (limsup_le_limsup hv)
+  refine le_mul_of_forall_lt h₁ h₂ fun a a_u b b_v ↦ (limsup_le_iff).2 fun c c_ab ↦ ?_
+  filter_upwards [eventually_lt_of_limsup_lt a_u, eventually_lt_of_limsup_lt b_v, hu, hv]
+    with x x_a x_b u_0 v_0
+  exact (mul_le_mul x_a.le x_b.le v_0 (u_0.trans x_a.le)).trans_lt c_ab
+
+lemma le_liminf_mul (hu : 0 ≤ᶠ[f] u) (hv : 0 ≤ᶠ[f] v) :
+    liminf u f * liminf v f ≤ liminf (u * v) f := by
+  apply mul_le_of_forall_lt_of_nonneg ((le_liminf_of_le) hu)
+    <| (le_liminf_of_le) ((hu.and hv).mono fun x ⟨u0, v0⟩ ↦ mul_nonneg u0 v0)
+  refine fun a ha b hb ↦ (le_liminf_iff).2 fun c c_ab ↦ ?_
+  filter_upwards [eventually_lt_of_lt_liminf (mem_Ico.1 ha).2,
+    eventually_lt_of_lt_liminf (mem_Ico.1 hb).2] with x xa xb
+  exact c_ab.trans_le (mul_le_mul xa.le xb.le (mem_Ico.1 hb).1 ((mem_Ico.1 ha).1.trans xa.le))
+
+lemma liminf_mul_le [NeBot f] (hu : 0 ≤ᶠ[f] u) (hv : 0 ≤ᶠ[f] v)
+    (h₁ : limsup u f ≠ 0 ∨ liminf v f ≠ ⊤) (h₂ : limsup u f ≠ ⊤ ∨ liminf v f ≠ 0) :
+    liminf (u * v) f ≤ limsup u f * liminf v f := by
+  replace h₁ : 0 < limsup u f ∨ liminf v f ≠ ⊤ := by
+    refine h₁.imp_left fun h ↦ lt_of_le_of_ne ?_ h.symm
+    exact le_of_eq_of_le (limsup_const 0).symm (limsup_le_limsup hu)
+  replace h₂ : limsup u f ≠ ⊤ ∨ 0 < liminf v f := by
+    refine h₂.imp_right fun h ↦ lt_of_le_of_ne ?_ h.symm
+    exact le_of_eq_of_le (liminf_const 0).symm (liminf_le_liminf hv)
+  refine le_mul_of_forall_lt h₁ h₂ fun a a_u b b_v ↦ (liminf_le_iff).2 fun c c_ab ↦ ?_
+  refine (((frequently_lt_of_liminf_lt) b_v).and_eventually <| (eventually_lt_of_limsup_lt a_u).and
+    <| hu.and hv).mono fun x ⟨x_v, x_u, u_0, v_0⟩ ↦ ?_
+  exact (mul_le_mul x_u.le x_v.le v_0 (u_0.trans x_u.le)).trans_lt c_ab
 
 end LimInfSup
 
@@ -436,8 +486,8 @@ private lemma continuousAt_mul_top_pos {a : ℝ} (h : 0 < a) :
     have key := mul_le_mul_of_nonneg_left (le_of_lt p2_gt) (le_of_lt p1_pos)
     replace lock := le_trans lock key
     apply lt_of_lt_of_le _ lock
-    rw [← EReal.coe_mul, EReal.coe_lt_coe_iff, div_mul_div_comm, mul_comm,
-      ← div_mul_div_comm, mul_div_right_comm]
+    rw [← EReal.coe_mul, EReal.coe_lt_coe_iff, _root_.div_mul_div_comm, mul_comm,
+      ← _root_.div_mul_div_comm, mul_div_right_comm]
     simp only [ne_eq, Ne.symm (ne_of_lt h), not_false_eq_true, _root_.div_self, OfNat.ofNat_ne_zero,
       one_mul, lt_max_iff, lt_add_iff_pos_right, zero_lt_one, true_or]
   · exact IsOpen.prod isOpen_Ioi isOpen_Ioi


### PR DESCRIPTION
This PR adds lemmas about `liminf (u * v)` and `limsup (u * v)` in extended reals. See [this file](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Topology/Algebra/Order/LiminfLimsup.html#limsup_mul_le) for similar results in the reals.

The strategy is the same, with a bunch of auxiliary lemmas in [Data/Real/EReal](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Data/Real/EReal).

I also took this opportunity to do some moderate cleaning in [Data/Real/EReal](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Data/Real/EReal): minor golfing and uniformization of variable names.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
