### PR TITLE
[Merged by Bors] - feat(Data/Finsupp/Pointwise): Add Finsupp.support_mul_subset_left/right

### DIFF
--- a/Mathlib/Data/Finsupp/Pointwise.lean
+++ b/Mathlib/Data/Finsupp/Pointwise.lean
@@ -51,15 +51,17 @@ theorem mul_apply {g₁ g₂ : α →₀ β} {a : α} : (g₁ * g₂) a = g₁ a
 theorem single_mul (a : α) (b₁ b₂ : β) : single a (b₁ * b₂) = single a b₁ * single a b₂ :=
   (zipWith_single_single _ _ _ _ _).symm
 
+lemma support_mul_subset_left {g₁ g₂ : α →₀ β} :
+    (g₁ * g₂).support ⊆ g₁.support := fun x hx => by
+  aesop
+
+lemma support_mul_subset_right {g₁ g₂ : α →₀ β} :
+    (g₁ * g₂).support ⊆ g₂.support := fun x hx => by
+  aesop
+
 theorem support_mul [DecidableEq α] {g₁ g₂ : α →₀ β} :
-    (g₁ * g₂).support ⊆ g₁.support ∩ g₂.support := by
-  intro a h
-  simp only [mul_apply, mem_support_iff] at h
-  simp only [mem_support_iff, mem_inter, Ne]
-  rw [← not_or]
-  intro w
-  apply h
-  cases' w with w w <;> (rw [w]; simp)
+    (g₁ * g₂).support ⊆ g₁.support ∩ g₂.support :=
+  subset_inter support_mul_subset_left support_mul_subset_right
 
 instance : MulZeroClass (α →₀ β) :=
   DFunLike.coe_injective.mulZeroClass _ coe_zero coe_mul


### PR DESCRIPTION
Has the advantage over `Finsupp.support_mul` on not requiring the `[DecidableEq α]` hypothesis.

Needed for #18578.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
