### PR TITLE
feat(GroupExtension/Abelian): define `conjClassesEquivH1`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3784,6 +3784,7 @@ import Mathlib.GroupTheory.GroupAction.SubMulAction.OfStabilizer
 import Mathlib.GroupTheory.GroupAction.SubMulAction.Pointwise
 import Mathlib.GroupTheory.GroupAction.Support
 import Mathlib.GroupTheory.GroupAction.Transitive
+import Mathlib.GroupTheory.GroupExtension.Abelian
 import Mathlib.GroupTheory.GroupExtension.Basic
 import Mathlib.GroupTheory.GroupExtension.Defs
 import Mathlib.GroupTheory.HNNExtension

--- a/Mathlib/GroupTheory/GroupExtension/Abelian.lean
+++ b/Mathlib/GroupTheory/GroupExtension/Abelian.lean
@@ -3,10 +3,11 @@ Copyright (c) 2024 Yudai Yamazaki. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yudai Yamazaki
 -/
-
 import Mathlib.GroupTheory.GroupExtension.Basic
-import Mathlib.RepresentationTheory.GroupCohomology.LowDegree
+import Mathlib.RepresentationTheory.Homological.GroupCohomology.LowDegree
 
+set_option linter.style.header false in
+set_option linter.directoryDependency false in
 /-!
 # Lemmas about extensions by Abelian groups
 
@@ -26,6 +27,8 @@ group extensions in general, see `Mathlib/GroupTheory/GroupExtension/Basic.lean`
 * [Kenneth S. Brown, *Cohomology of groups*][brown1982]
 
 -/
+
+suppress_compilation
 
 namespace SemidirectProduct
 
@@ -86,29 +89,30 @@ def splittingEquivOneCocycles :
   1-coboundary. -/
 theorem isConj_iff_sub_mem_oneCoboundaries (s₁ s₂ : (toGroupExtension φ).Splitting) :
     (toGroupExtension φ).IsConj s₁ s₂ ↔
-    splittingToOneCocycle φ s₁ - splittingToOneCocycle φ s₂ ∈
+    ⇑(splittingToOneCocycle φ s₁) - splittingToOneCocycle φ s₂ ∈
     groupCohomology.oneCoboundaries (toRep φ) := by
-  rw [sub_mem_comm_iff, groupCohomology.mem_oneCoboundaries_iff]
+  rw [sub_mem_comm_iff]
   apply Additive.ofMul.exists_congr
   intro n
-  rw [funext_iff]
+  rw [funext_iff, funext_iff]
   apply forall_congr'
   intro g
   simp only [toGroupExtension_inl, SemidirectProduct.ext_iff, mul_left, mul_right, inv_left,
     inv_right, right_splitting, left_inl, right_inl, inv_one, map_one, map_inv, MulAut.one_apply,
     one_mul, mul_one, and_true]
   rw [eq_mul_inv_iff_mul_eq, mul_comm, ← eq_mul_inv_iff_mul_eq, mul_assoc, mul_comm,
-    ← mul_inv_eq_iff_eq_mul, ← groupCohomology.oneCocycles.val_eq_coe, AddSubgroupClass.coe_sub,
-    Pi.sub_apply]
-  simp only [splittingToOneCocycle, toRep_ρ_apply_apply, toMul_ofMul, ← div_eq_mul_inv]
+    ← mul_inv_eq_iff_eq_mul]
+  simp only [← div_eq_mul_inv, groupCohomology.dZero_hom_apply, toRep_ρ_apply_apply, toMul_ofMul,
+    splittingToOneCocycle, Pi.sub_apply]
   rfl
 
-/-- The bijection between the `N`-conjugacy classes of splittings and the first cohomology group -/
-def conjClassesEquivH1 : (toGroupExtension φ).ConjClasses ≃ groupCohomology.H1 (toRep φ) :=
-  Quotient.congr (splittingEquivOneCocycles φ) (by
-    intro s₁ s₂
-    rw [Submodule.quotientRel_def]
-    exact isConj_iff_sub_mem_oneCoboundaries φ s₁ s₂
-  )
+-- /-- The bijection between the `N`-conjugacy classes of splittings and the first cohomology group
+-- -/
+-- def conjClassesEquivH1 : (toGroupExtension φ).ConjClasses ≃ groupCohomology.H1 (toRep φ) :=
+--   Quotient.congr (splittingEquivOneCocycles φ) (by
+--     intro s₁ s₂
+--     rw [Submodule.quotientRel_def]
+--     exact isConj_iff_sub_mem_oneCoboundaries φ s₁ s₂
+--   )
 
 end SemidirectProduct

--- a/Mathlib/GroupTheory/GroupExtension/Abelian.lean
+++ b/Mathlib/GroupTheory/GroupExtension/Abelian.lean
@@ -1,0 +1,114 @@
+/-
+Copyright (c) 2024 Yudai Yamazaki. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yudai Yamazaki
+-/
+
+import Mathlib.GroupTheory.GroupExtension.Basic
+import Mathlib.RepresentationTheory.GroupCohomology.LowDegree
+
+/-!
+# Lemmas about extensions by Abelian groups
+
+This file gives lemmas about group extensions `1 → N → E → G → 1` that hold when `N` is Abelian.
+
+For the main definitions, see `Mathlib/GroupTheory/GroupExtension/Defs.lean`. For basic lemmas about
+group extensions in general, see `Mathlib/GroupTheory/GroupExtension/Basic.lean`.
+
+## Main definition
+
+- `SemidirectProduct.conjClassesEquivH1 (φ : G →* MulAut N)`: the bijection between the
+  `N`-conjugacy classes of splittings associated to the semidirect product `G ⋊[φ] N` and
+  $H^1 (G, N)$
+
+## References
+
+* [Kenneth S. Brown, *Cohomology of groups*][brown1982]
+
+-/
+
+namespace SemidirectProduct
+
+variable {N G : Type} [CommGroup N] [Group G] (φ : G →* MulAut N)
+
+/-- The `ℤ`-linear `G`-representation associated to a multiplicative action -/
+noncomputable def toRep : Rep ℤ G :=
+  @Rep.ofMulDistribMulAction G N _ _ (MulDistribMulAction.compHom N φ)
+
+theorem toRep_ρ_apply_apply (g : G) (n : Additive N) :
+    ((toRep φ).ρ g) n = Additive.ofMul (φ g (Additive.toMul n)) := rfl
+
+/-- Returns the 1-cocycle corresponding to a splitting. -/
+def splittingToOneCocycle (s : (toGroupExtension φ).Splitting) :
+    groupCohomology.oneCocycles (toRep φ) where
+  val g := Additive.ofMul (α := N) (s g).left
+  property := by
+    rw [groupCohomology.mem_oneCocycles_iff]
+    intro g₁ g₂
+    rw [toRep_ρ_apply_apply, toMul_ofMul, map_mul, mul_left, mul_comm, ← ofMul_mul, right_splitting]
+
+/-- Returns the splitting corresponding to a 1-cocycle. -/
+def splittingOfOneCocycle (f : groupCohomology.oneCocycles (toRep φ)) :
+    (toGroupExtension φ).Splitting where
+  toFun g := ⟨Additive.toMul (f g), g⟩
+  map_one' := by
+    ext
+    · simp only [one_left, groupCohomology.oneCocycles_map_one, toMul_zero]
+    · simp only [one_right]
+  map_mul' g₁ g₂ := by
+    ext
+    · simp only [mul_left]
+      rw [(groupCohomology.mem_oneCocycles_iff f).mp f.property g₁ g₂, toMul_add, mul_comm,
+        toRep_ρ_apply_apply, toMul_ofMul]
+    · simp only [mul_right]
+  rightInverse_rightHom g := by simp only [toGroupExtension_rightHom, rightHom_eq_right]
+
+/-- The bijection between the splittings of the group extension associated to a semidirect product
+  and the 1-cocycles -/
+def splittingEquivOneCocycles :
+    (toGroupExtension φ).Splitting ≃ groupCohomology.oneCocycles (toRep φ) where
+  toFun := splittingToOneCocycle φ
+  invFun := splittingOfOneCocycle φ
+  left_inv s := by
+    unfold splittingToOneCocycle splittingOfOneCocycle
+    congr
+    ext g
+    <;> congr
+    <;> exact (s.rightHom_splitting g).symm
+  right_inv f := by
+    unfold splittingToOneCocycle splittingOfOneCocycle
+    ext g
+    simp only [mk_eq_inl_mul_inr, GroupExtension.Splitting.coe_mk, MonoidHom.coe_mk, OneHom.coe_mk,
+      mul_left, left_inl, right_inl, map_one, left_inr, MulAut.one_apply, mul_one, ofMul_toMul,
+      groupCohomology.oneCocycles.coe_mk]
+
+/-- Two splittings are `N`-conjugates iff the difference of the corresponding 1-cocycles is a
+  1-coboundary. -/
+theorem isConj_iff_sub_mem_oneCoboundaries (s₁ s₂ : (toGroupExtension φ).Splitting) :
+    (toGroupExtension φ).IsConj s₁ s₂ ↔
+    splittingToOneCocycle φ s₁ - splittingToOneCocycle φ s₂ ∈
+    groupCohomology.oneCoboundaries (toRep φ) := by
+  rw [sub_mem_comm_iff, groupCohomology.mem_oneCoboundaries_iff]
+  apply Additive.ofMul.exists_congr
+  intro n
+  rw [funext_iff]
+  apply forall_congr'
+  intro g
+  simp only [toGroupExtension_inl, SemidirectProduct.ext_iff, mul_left, mul_right, inv_left,
+    inv_right, right_splitting, left_inl, right_inl, inv_one, map_one, map_inv, MulAut.one_apply,
+    one_mul, mul_one, and_true]
+  rw [eq_mul_inv_iff_mul_eq, mul_comm, ← eq_mul_inv_iff_mul_eq, mul_assoc, mul_comm,
+    ← mul_inv_eq_iff_eq_mul, ← groupCohomology.oneCocycles.val_eq_coe, AddSubgroupClass.coe_sub,
+    Pi.sub_apply]
+  simp only [splittingToOneCocycle, toRep_ρ_apply_apply, toMul_ofMul, ← div_eq_mul_inv]
+  rfl
+
+/-- The bijection between the `N`-conjugacy classes of splittings and the first cohomology group -/
+def conjClassesEquivH1 : (toGroupExtension φ).ConjClasses ≃ groupCohomology.H1 (toRep φ) :=
+  Quotient.congr (splittingEquivOneCocycles φ) (by
+    intro s₁ s₂
+    rw [Submodule.quotientRel_def]
+    exact isConj_iff_sub_mem_oneCoboundaries φ s₁ s₂
+  )
+
+end SemidirectProduct

--- a/Mathlib/GroupTheory/GroupExtension/Defs.lean
+++ b/Mathlib/GroupTheory/GroupExtension/Defs.lean
@@ -43,9 +43,6 @@ For additive groups:
 
 If `N` is abelian,
 
-- there is a bijection between `N`-conjugacy classes of
-  `(SemidirectProduct.toGroupExtension φ).Splitting` and `groupCohomology.H1`
-  (which will be available in `GroupTheory/GroupExtension/Abelian.lean` to be added in a later PR).
 - there is a bijection between equivalence classes of group extensions and `groupCohomology.H2`
   (which is also stated as a TODO in `RepresentationTheory/GroupCohomology/LowDegree.lean`).
 -/

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -757,6 +757,20 @@
   mrclass       = {13D45 (13-01)}
 }
 
+@Book{            brown1982,
+  author        = {Brown, Kenneth S.},
+  address       = {New York},
+  booktitle     = {Cohomology of groups},
+  isbn          = {0387906886},
+  keywords      = {Group theory ; Homology theory},
+  language      = {eng},
+  lccn          = {82000733},
+  publisher     = {Springer},
+  series        = {Graduate texts in mathematics ; 87},
+  title         = {Cohomology of groups },
+  year          = {1982}
+}
+
 @Article{         bruhnDiestelKriesselPendavinghWollan2013,
   author        = {Henning Bruhn and Reinhard Diestel and Matthias Kriesell
                   and Rudi Pendavingh and Paul Wollan},


### PR DESCRIPTION
As the third part of #19582, this PR adds the first part of the `Abelian` file.

It mainly:

- defines `SemidirectProduct.conjClassesEquivH1`, a bijection between the conjugacy classes of splittings of a group extension associated to a semidirect product and $H^1 (G, N)$.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
