### PR TITLE
feat(IsHomLift): add name to argument

### DIFF
--- a/Mathlib/CategoryTheory/FiberedCategory/HomLift.lean
+++ b/Mathlib/CategoryTheory/FiberedCategory/HomLift.lean
@@ -79,7 +79,7 @@ lemma domain_eq (f : R ⟶ S) (φ : a ⟶ b) [p.IsHomLift f φ] : p.obj a = R :=
 lemma codomain_eq (f : R ⟶ S) (φ : a ⟶ b) [p.IsHomLift f φ] : p.obj b = S := by
   subst_hom_lift p f φ; rfl
 
-variable (f : R ⟶ S) (φ : a ⟶ b) [p.IsHomLift f φ]
+variable (f : R ⟶ S) (φ : a ⟶ b) [l : p.IsHomLift f φ]
 
 lemma fac : f = eqToHom (domain_eq p f φ).symm ≫ p.map φ ≫ eqToHom (codomain_eq p f φ) := by
   subst_hom_lift p f φ; simp


### PR DESCRIPTION
Add a name to the typeclass argument on `fac` and `fac'`.

---

This is so that we can more easily take backwards reasoning steps as below
```lean
example : 𝟙 R = eqToHom sorry ≫ (𝟭 𝒮).map (𝟙 R) ≫ eqToHom sorry := by
  -- apply fac -- failed to synthesize instance
  apply fac (l := _)
  constructor; constructor
```

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
