### PR TITLE
[Merged by Bors] - feat(Order/Interval): Order.succ on Set.Iic

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4360,6 +4360,7 @@ import Mathlib.Order.Interval.Set.OrderEmbedding
 import Mathlib.Order.Interval.Set.OrderIso
 import Mathlib.Order.Interval.Set.Pi
 import Mathlib.Order.Interval.Set.ProjIcc
+import Mathlib.Order.Interval.Set.SuccOrder
 import Mathlib.Order.Interval.Set.SurjOn
 import Mathlib.Order.Interval.Set.UnorderedInterval
 import Mathlib.Order.Interval.Set.WithBotTop

--- a/Mathlib/Order/Interval/Set/SuccOrder.lean
+++ b/Mathlib/Order/Interval/Set/SuccOrder.lean
@@ -26,11 +26,27 @@ lemma Iic.succ_coe_of_not_isMax
   apply Order.succ_le_of_lt
   exact lt_of_le_of_ne (α := Set.Iic j) le_top (by simpa using hi)
 
+lemma Iic.succ_eq_of_not_isMax
+    [SuccOrder J] {j : J} {i : Set.Iic j} (hi : ¬ IsMax i) :
+    Order.succ i = ⟨Order.succ i.1, by
+      rw [← succ_coe_of_not_isMax hi]
+      apply Subtype.coe_prop⟩ := by
+  ext
+  simp only [succ_coe_of_not_isMax hi]
+
 lemma Ici.pred_coe_of_not_isMin
     [PredOrder J] {j : J} {i : Set.Ici j} (hi : ¬ IsMin i) :
     (Order.pred i).1 = Order.pred i.1 := by
   rw [coe_pred_of_mem]
   apply Order.le_pred_of_lt
   exact lt_of_le_of_ne (α := Set.Ici j) bot_le (Ne.symm (by simpa using hi))
+
+lemma Ici.pred_eq_of_not_isMin
+    [PredOrder J] {j : J} {i : Set.Ici j} (hi : ¬ IsMin i) :
+    Order.pred i = ⟨Order.pred i.1, by
+      rw [← pred_coe_of_not_isMin hi]
+      apply Subtype.coe_prop⟩ := by
+  ext
+  simp only [pred_coe_of_not_isMin hi]
 
 end Set

--- a/Mathlib/Order/Interval/Set/SuccOrder.lean
+++ b/Mathlib/Order/Interval/Set/SuccOrder.lean
@@ -19,7 +19,7 @@ namespace Set
 
 variable {J : Type*} [PartialOrder J]
 
-lemma Iic.succ_coe_of_not_isMax
+lemma Iic.coe_succ_of_not_isMax
     [SuccOrder J] {j : J} {i : Set.Iic j} (hi : ¬ IsMax i) :
     (Order.succ i).1 = Order.succ i.1 := by
   rw [coe_succ_of_mem]
@@ -29,12 +29,12 @@ lemma Iic.succ_coe_of_not_isMax
 lemma Iic.succ_eq_of_not_isMax
     [SuccOrder J] {j : J} {i : Set.Iic j} (hi : ¬ IsMax i) :
     Order.succ i = ⟨Order.succ i.1, by
-      rw [← succ_coe_of_not_isMax hi]
+      rw [← coe_succ_of_not_isMax hi]
       apply Subtype.coe_prop⟩ := by
   ext
-  simp only [succ_coe_of_not_isMax hi]
+  simp only [coe_succ_of_not_isMax hi]
 
-lemma Ici.pred_coe_of_not_isMin
+lemma Ici.coe_pred_of_not_isMin
     [PredOrder J] {j : J} {i : Set.Ici j} (hi : ¬ IsMin i) :
     (Order.pred i).1 = Order.pred i.1 := by
   rw [coe_pred_of_mem]
@@ -44,9 +44,9 @@ lemma Ici.pred_coe_of_not_isMin
 lemma Ici.pred_eq_of_not_isMin
     [PredOrder J] {j : J} {i : Set.Ici j} (hi : ¬ IsMin i) :
     Order.pred i = ⟨Order.pred i.1, by
-      rw [← pred_coe_of_not_isMin hi]
+      rw [← coe_pred_of_not_isMin hi]
       apply Subtype.coe_prop⟩ := by
   ext
-  simp only [pred_coe_of_not_isMin hi]
+  simp only [coe_pred_of_not_isMin hi]
 
 end Set

--- a/Mathlib/Order/Interval/Set/SuccOrder.lean
+++ b/Mathlib/Order/Interval/Set/SuccOrder.lean
@@ -1,0 +1,36 @@
+/-
+Copyright (c) 2025 Joël Riou. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joël Riou
+-/
+import Mathlib.Order.LatticeIntervals
+import Mathlib.Order.SuccPred.Basic
+
+/-!
+# Successors in intervals
+
+If `j` is an element of a partially ordered set equipped
+with a successor function, then for any element `i : Set.Iic j`
+which is not the maximum, we have `↑(Order.succ i) = Order.succ ↑i`.
+
+-/
+
+namespace Set
+
+variable {J : Type*} [PartialOrder J]
+
+lemma Iic.succ_coe_of_not_isMax
+    [SuccOrder J] {j : J} {i : Set.Iic j} (hi : ¬ IsMax i) :
+    (Order.succ i).1 = Order.succ i.1 := by
+  rw [coe_succ_of_mem]
+  apply Order.succ_le_of_lt
+  exact lt_of_le_of_ne (α := Set.Iic j) le_top (by simpa using hi)
+
+lemma Ici.pred_coe_of_not_isMin
+    [PredOrder J] {j : J} {i : Set.Ici j} (hi : ¬ IsMin i) :
+    (Order.pred i).1 = Order.pred i.1 := by
+  rw [coe_pred_of_mem]
+  apply Order.le_pred_of_lt
+  exact lt_of_le_of_ne (α := Set.Ici j) bot_le (Ne.symm (by simpa using hi))
+
+end Set


### PR DESCRIPTION
In this PR, it shown that `↑(Order.succ i) = Order.succ ↑i` when `i` is a non maximal element of `Set.Iic j`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
