### PR TITLE
chore(SetTheory/Cardinal/Basic): generalize universes of `sum_le_iSup_lift`

### DIFF
--- a/Mathlib/MeasureTheory/MeasurableSpace/Card.lean
+++ b/Mathlib/MeasureTheory/MeasurableSpace/Card.lean
@@ -6,6 +6,7 @@ Authors: Sébastien Gouëzel, Violeta Hernández Palacios
 import Mathlib.MeasureTheory.MeasurableSpace.Defs
 import Mathlib.SetTheory.Cardinal.Cofinality
 import Mathlib.SetTheory.Cardinal.Continuum
+import Mathlib.SetTheory.Cardinal.Ordinal
 
 /-!
 # Cardinal of sigma-algebras

--- a/Mathlib/MeasureTheory/MeasurableSpace/Card.lean
+++ b/Mathlib/MeasureTheory/MeasurableSpace/Card.lean
@@ -6,7 +6,6 @@ Authors: Sébastien Gouëzel, Violeta Hernández Palacios
 import Mathlib.MeasureTheory.MeasurableSpace.Defs
 import Mathlib.SetTheory.Cardinal.Cofinality
 import Mathlib.SetTheory.Cardinal.Continuum
-import Mathlib.SetTheory.Cardinal.Ordinal
 
 /-!
 # Cardinal of sigma-algebras

--- a/Mathlib/SetTheory/Cardinal/Basic.lean
+++ b/Mathlib/SetTheory/Cardinal/Basic.lean
@@ -1911,7 +1911,7 @@ theorem mk_iUnion_le_lift {α : Type u} {ι : Type v} (f : ι → Set α) :
     lift.{v} #(⋃ i, f i) ≤ lift.{u} #ι * ⨆ i, lift.{v} #(f i) := by
   apply mk_iUnion_le_sum_mk_lift.trans
   convert sum_le_iSup_lift fun i ↦ lift.{v} #(f i)
-  · rw [← lift_sum, lift_id'.{_,u}]
+  · rw [← lift_sum, lift_id']
   · exact lift_umax.symm
   · rw [lift_lift]
 

--- a/Mathlib/SetTheory/Cardinal/Basic.lean
+++ b/Mathlib/SetTheory/Cardinal/Basic.lean
@@ -1916,8 +1916,7 @@ theorem mk_iUnion_le {α ι : Type u} (f : ι → Set α) : #(⋃ i, f i) ≤ #�
 
 theorem mk_iUnion_le_lift {α : Type u} {ι : Type v} (f : ι → Set α) :
     lift.{v} #(⋃ i, f i) ≤ lift.{u} #ι * ⨆ i, lift.{v} #(f i) := by
-  apply mk_iUnion_le_sum_mk_lift.trans
-  convert sum_le_iSup_lift fun i ↦ lift.{v} #(f i)
+  refine mk_iUnion_le_sum_mk_lift.trans <| Eq.trans_le ?_ (sum_le_iSup_lift _)
   rw [← lift_sum, lift_id']
 
 theorem mk_sUnion_le {α : Type u} (A : Set (Set α)) : #(⋃₀ A) ≤ #A * ⨆ s : A, #s := by

--- a/Mathlib/SetTheory/Cardinal/Basic.lean
+++ b/Mathlib/SetTheory/Cardinal/Basic.lean
@@ -1082,13 +1082,20 @@ theorem lift_iSup_le_lift_iSup' {ι : Type v} {ι' : Type v'} {f : ι → Cardin
     (h : ∀ i, lift.{v'} (f i) ≤ lift.{v} (f' (g i))) : lift.{v'} (iSup f) ≤ lift.{v} (iSup f') :=
   lift_iSup_le_lift_iSup hf hf' h
 
-theorem sum_le_iSup_lift {ι : Type u} [Small.{v} ι]
+/-- See also the specializations `sum_le_iSup_lift` and `sum_le_iSup`. -/
+theorem sum_le_iSup_lift' {ι : Type u} [Small.{v} ι]
     (f : ι → Cardinal.{v}) : sum f ≤ lift.{v} (#ι) * ⨆ i, lift.{u} (f i) := by
   rw [← lift_iSup (bddAbove_of_small _), ← (iSup f).lift_id, ← sum_const, lift_id]
   exact sum_le_sum _ _ (le_ciSup <| bddAbove_of_small _)
 
+theorem sum_le_iSup_lift {ι : Type u}
+    (f : ι → Cardinal.{max u v}) : sum f ≤ lift.{v} (#ι) * ⨆ i, f i := by
+  convert sum_le_iSup_lift' f
+  · exact lift_umax.symm
+  · rw [lift_id']
+
 theorem sum_le_iSup {ι : Type u} (f : ι → Cardinal.{u}) : sum f ≤ #ι * iSup f := by
-  simpa using sum_le_iSup_lift f
+  simpa using sum_le_iSup_lift' f
 
 lemma exists_eq_of_iSup_eq_of_not_isSuccPrelimit
     {ι : Type u} (f : ι → Cardinal.{v}) (ω : Cardinal.{v})
@@ -1911,9 +1918,7 @@ theorem mk_iUnion_le_lift {α : Type u} {ι : Type v} (f : ι → Set α) :
     lift.{v} #(⋃ i, f i) ≤ lift.{u} #ι * ⨆ i, lift.{v} #(f i) := by
   apply mk_iUnion_le_sum_mk_lift.trans
   convert sum_le_iSup_lift fun i ↦ lift.{v} #(f i)
-  · rw [← lift_sum, lift_id']
-  · exact lift_umax.symm
-  · rw [lift_lift]
+  rw [← lift_sum, lift_id']
 
 theorem mk_sUnion_le {α : Type u} (A : Set (Set α)) : #(⋃₀ A) ≤ #A * ⨆ s : A, #s := by
   rw [sUnion_eq_iUnion]

--- a/Mathlib/SetTheory/Cardinal/Basic.lean
+++ b/Mathlib/SetTheory/Cardinal/Basic.lean
@@ -1033,15 +1033,6 @@ theorem bddAbove_range_comp {ι : Type u} {f : ι → Cardinal.{v}} (hf : BddAbo
 
 /-! ### Bounds on suprema -/
 
-theorem sum_le_iSup_lift {ι : Type u}
-    (f : ι → Cardinal.{max u v}) : sum f ≤ Cardinal.lift #ι * iSup f := by
-  rw [← (iSup f).lift_id, ← lift_umax, lift_umax.{max u v, u}, ← sum_const]
-  exact sum_le_sum _ _ (le_ciSup <| bddAbove_of_small _)
-
-theorem sum_le_iSup {ι : Type u} (f : ι → Cardinal.{u}) : sum f ≤ #ι * iSup f := by
-  rw [← lift_id #ι]
-  exact sum_le_iSup_lift f
-
 /-- The lift of a supremum is the supremum of the lifts. -/
 theorem lift_sSup {s : Set Cardinal} (hs : BddAbove s) :
     lift.{u} (sSup s) = sSup (lift.{u} '' s) := by
@@ -1090,6 +1081,14 @@ theorem lift_iSup_le_lift_iSup' {ι : Type v} {ι' : Type v'} {f : ι → Cardin
     {f' : ι' → Cardinal.{v'}} (hf : BddAbove (range f)) (hf' : BddAbove (range f')) (g : ι → ι')
     (h : ∀ i, lift.{v'} (f i) ≤ lift.{v} (f' (g i))) : lift.{v'} (iSup f) ≤ lift.{v} (iSup f') :=
   lift_iSup_le_lift_iSup hf hf' h
+
+theorem sum_le_iSup_lift {ι : Type u} [Small.{v} ι]
+    (f : ι → Cardinal.{v}) : sum f ≤ lift.{v} (#ι) * ⨆ i, lift.{u} (f i) := by
+  rw [← lift_iSup (bddAbove_of_small _), ← (iSup f).lift_id, ← sum_const, lift_id]
+  exact sum_le_sum _ _ (le_ciSup <| bddAbove_of_small _)
+
+theorem sum_le_iSup {ι : Type u} (f : ι → Cardinal.{u}) : sum f ≤ #ι * iSup f := by
+  simpa using sum_le_iSup_lift f
 
 lemma exists_eq_of_iSup_eq_of_not_isSuccPrelimit
     {ι : Type u} (f : ι → Cardinal.{v}) (ω : Cardinal.{v})
@@ -1910,8 +1909,11 @@ theorem mk_iUnion_le {α ι : Type u} (f : ι → Set α) : #(⋃ i, f i) ≤ #�
 
 theorem mk_iUnion_le_lift {α : Type u} {ι : Type v} (f : ι → Set α) :
     lift.{v} #(⋃ i, f i) ≤ lift.{u} #ι * ⨆ i, lift.{v} #(f i) := by
-  refine mk_iUnion_le_sum_mk_lift.trans <| Eq.trans_le ?_ (sum_le_iSup_lift _)
-  rw [← lift_sum, lift_id'.{_,u}]
+  apply mk_iUnion_le_sum_mk_lift.trans
+  convert sum_le_iSup_lift fun i ↦ lift.{v} #(f i)
+  · rw [← lift_sum, lift_id'.{_,u}]
+  · exact lift_umax.symm
+  · rw [lift_lift]
 
 theorem mk_sUnion_le {α : Type u} (A : Set (Set α)) : #(⋃₀ A) ≤ #A * ⨆ s : A, #s := by
   rw [sUnion_eq_iUnion]


### PR DESCRIPTION
We prove a more general version of the lemma which talks about families `ι → Cardinal.{v}` with `Small.{v} ι`, rather than just families `f : ι → Cardinal.{max u v}` with `ι : Type v`.

We keep the old version, as it's seemingly more useful under common circumstances.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
