### PR TITLE
[Merged by Bors] - chore(SetTheory/Ordinal/Enum): enumerator function of closed set is normal

### DIFF
--- a/Mathlib/SetTheory/Ordinal/Enum.lean
+++ b/Mathlib/SetTheory/Ordinal/Enum.lean
@@ -126,6 +126,20 @@ theorem eq_enumOrd (f : Ordinal → Ordinal) (hs : ¬ BddAbove s) :
 theorem enumOrd_range {f : Ordinal → Ordinal} (hf : StrictMono f) : enumOrd (range f) = f :=
   (eq_enumOrd _ hf.not_bddAbove_range_of_wellFoundedLT).2 ⟨hf, rfl⟩
 
+/-- If `s` is closed under nonempty suprema, then its enumerator function is normal.
+See also `enumOrd_isNormal_iff_isClosed`. -/
+theorem isNormal_enumOrd (H : ∀ t ⊆ s, t.Nonempty → BddAbove t → sSup t ∈ s) (hs : ¬ BddAbove s) :
+    IsNormal (enumOrd s) := by
+  refine (isNormal_iff_strictMono_limit _).2 ⟨enumOrd_strictMono hs, fun o ho a ha ↦ ?_⟩
+  trans ⨆ b : Iio o, enumOrd s b
+  · refine enumOrd_le_of_forall_lt ?_ (fun b hb ↦ (enumOrd_strictMono hs (lt_succ b)).trans_le ?_)
+    · have : Nonempty (Iio o) := ⟨0, ho.pos⟩
+      apply H _ _ (range_nonempty _) (bddAbove_of_small _)
+      rintro _ ⟨c, rfl⟩
+      exact enumOrd_mem hs c
+    · exact Ordinal.le_iSup _ (⟨_, ho.succ_lt hb⟩ : Iio o)
+  · exact Ordinal.iSup_le fun x ↦ ha _ x.2
+
 @[simp]
 theorem enumOrd_univ : enumOrd Set.univ = id := by
   rw [← range_id]


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

This result already exists as `enumOrd_isNormal_iff_isClosed`, however that version of the statement adds a large amount of imports due to the fact that it refers to the topological notion of closedness. This is intended as a more lightweight/convenient substitute.

I intend to eventually golf down `enumOrd_isNormal_iff_isClosed` using this, but the `Ordinal.Topology` file requires large refactoring anyways (in the form of generalizing results to other linear orders, and getting rid of `bsup`). So I'd rather get that out of the way first.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
