### PR TITLE
feat(Order): Trimmed length of a RelSeries 

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4422,6 +4422,7 @@ import Mathlib.Order.SupIndep
 import Mathlib.Order.SymmDiff
 import Mathlib.Order.Synonym
 import Mathlib.Order.TransfiniteIteration
+import Mathlib.Order.TrimmedLength
 import Mathlib.Order.TypeTags
 import Mathlib.Order.ULift
 import Mathlib.Order.UpperLower.Basic

--- a/Mathlib/Order/RelSeries.lean
+++ b/Mathlib/Order/RelSeries.lean
@@ -73,6 +73,10 @@ lemma rel_or_eq_of_le [IsTrans α r] (x : RelSeries r) {i j : Fin (x.length + 1)
     r (x i) (x j) ∨ x i = x j :=
   (Fin.lt_or_eq_of_le h).imp (x.rel_of_lt ·) (by rw [·])
 
+lemma rel_of_le [IsTrans α r] [IsRefl α r] (x : RelSeries r)
+  {i j : Fin (x.length + 1)} (h : i ≤ j) : r (x i) (x j) :=
+  Or.casesOn (rel_or_eq_of_le x h) (by tauto) (by intro l; rw[l]; apply refl)
+
 /--
 Given two relations `r, s` on `α` such that `r ≤ s`, any relation series of `r` induces a relation
 series of `s`

--- a/Mathlib/Order/TrimmedLength.lean
+++ b/Mathlib/Order/TrimmedLength.lean
@@ -1,0 +1,249 @@
+/-
+Copyright (c) 2025 Raphael Douglas Giles. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Raphael Douglas Giles
+-/
+
+import Mathlib
+
+/-!
+# Trimmed Length
+
+Given a relseries rs : RelSeries (· ≤ ·), we define the trimmed length of rs to be the cardinality
+of the underlying function rs.toFun of rs minus 1. This models the number of `<` relations occuring
+in rs. In this file we develop the main API for working with the trimmed length.
+
+-/
+
+open Order
+
+variable {α : Type*}
+/--
+Given a relseries rs : RelSeries (α := α) r with transitive and reflixive r, i ≤ j implies
+r (rs i) (rs j)
+-/
+theorem RelSeries.map_le {r : Rel α α} [IsTrans α r] [IsRefl α r] (rs : RelSeries (α := α) r)
+  {i j : Fin (rs.length + 1)}
+  (hij : i ≤ j) : r (rs i) (rs j) := by
+    have := rel_or_eq_of_le rs hij
+    cases this
+    · assumption
+    · rename_i h
+      rw[h]
+      apply refl (r := r)
+
+variable [PartialOrder α] [DecidableEq α]
+  (rs : RelSeries (α := α) (· ≤ ·))
+
+/--
+Given (rs : RelSeries (α := α) (· ≤ ·)), rs.trimmedLength measures the number of `<`s appearing
+in rs defined as the image of the underlying function of rs, rs.toFun.
+-/
+def RelSeries.trimmedLength (rs : RelSeries (α := α) (· ≤ ·)) : ℕ :=
+  (Finset.image rs.toFun Finset.univ).card - 1
+
+/--
+The trimmed length of a relseries is bounded by the length of that relseries.
+-/
+lemma RelSeries.trimmedLength_le_length : rs.trimmedLength ≤ rs.length := by
+  simp only [RelSeries.trimmedLength, tsub_le_iff_right]
+  have := Finset.card_image_le (f := rs.toFun) (s := .univ)
+  simp only [Finset.card_univ, Fintype.card_fin] at this
+  exact this
+
+/--
+The length of a relseries rs is equal to the trimmed length if and only if the underlying function
+of rs (i.e. rs.toFun) is injective.
+-/
+lemma RelSeries.length_eq_trimmedLength_iff :
+  rs.length = rs.trimmedLength ↔ rs.toFun.Injective := by
+  constructor
+  · intro h
+    simp[RelSeries.trimmedLength] at h
+    have := Finset.card_image_iff (s := .univ) (f := rs.toFun)
+    simp_all only [Finset.card_univ, Finset.one_le_card,
+      Finset.image_nonempty, Finset.univ_nonempty,
+      Nat.sub_add_cancel, Fintype.card_fin, Finset.coe_univ, true_iff]
+    exact fun ⦃a₁ a₂⦄ ↦ this trivial trivial
+  · intro h
+    apply antisymm (r := (· ≤ ·))
+    · have := Finset.card_le_card_of_injOn (s := .univ) (t := Finset.image rs.toFun Finset.univ)
+        rs.toFun (by simp) h.injOn
+      simp at this
+      simp[RelSeries.trimmedLength]
+      omega
+    · exact RelSeries.trimmedLength_le_length rs
+
+variable {rs} in
+/--
+If rs has length greater than 0, there must be some index i such that rs i.castSucc < rs i.succ
+-/
+theorem RelSeries.trimmedLength_exists_le
+(hrs : rs.trimmedLength > 0) : ∃ (i : Fin rs.length), rs i.castSucc < rs i.succ := by
+  contrapose! hrs
+  replace hrs (i : Fin rs.length) : rs.toFun i.castSucc = rs.toFun i.succ :=
+    eq_of_le_of_not_lt (rs.step i) (hrs i)
+  have H (i) : rs i = rs 0 := by
+    induction' i using Fin.induction with m ih
+    · rfl
+    · rwa [← hrs m]
+  unfold RelSeries.trimmedLength
+  suffices Finset.image rs.toFun Finset.univ = {rs.toFun 0} by simp [this]
+  suffices rs.toFun = fun i ↦ rs.toFun 0 by
+    rw[this, Finset.image_const]
+    use 0
+    simp
+  ext : 1
+  apply H
+
+
+variable {rs} in
+/--
+If the last two elements of rs are equal, then rs.trimmedLength = rs.eraseLast.trimmedLength. Note
+that if rs only has one element, the "last two elements" are both just the unique element of rs.
+-/
+theorem RelSeries.trimmedLength_eraseLast_of_eq
+  (lasteq : ∃ i : Fin (rs.length), rs.toFun i.castSucc = rs.toFun i.succ ∧ (i + 1 : ℕ) = rs.length)
+  : rs.trimmedLength = rs.eraseLast.trimmedLength := by
+    simp only [trimmedLength, eraseLast_length]
+    congr 2
+    apply le_antisymm
+    · intro x hx
+      simp only [Finset.mem_image, Finset.mem_univ, eraseLast_toFun, true_and] at hx ⊢
+      obtain ⟨i, rfl⟩ := hx
+      by_cases hi : i = Fin.last _
+      · obtain ⟨j, hj1, hj2⟩ := lasteq
+        use j.cast (m := rs.length - 1 + 1) (by omega)
+        subst i
+        convert hj1 using 2
+        ext
+        exact hj2.symm
+      · use (i.castPred hi).cast (m := rs.length - 1 + 1) (by omega)
+        rfl
+    · intro x hx
+      simp only [Finset.mem_image, Finset.mem_univ, eraseLast_toFun, true_and] at hx ⊢
+      obtain ⟨i, rfl⟩ := hx
+      exact ⟨_, rfl⟩
+
+
+variable {rs} in
+/--
+If the last two elements a, b of rs satisfy a < b, then
+rs.trimmedLength = rs.eraseLast.trimmedLength. Note that if rs only has one element,
+the "last two elements" are both just the unique element of rs.
+In this case the condition is vacuous.
+-/
+theorem RelSeries.trimmedLength_eraseLast_of_lt
+    (lastlt : ∃ i : Fin (rs.length), rs i.castSucc < rs i.succ ∧ (i + 1:ℕ) = rs.length)
+    : rs.trimmedLength = rs.eraseLast.trimmedLength + 1 := by
+      simp only [trimmedLength, eraseLast_length, Finset.one_le_card, Finset.image_nonempty,
+        Finset.univ_nonempty, Nat.sub_add_cancel]
+      obtain ⟨i, hi1, hi2⟩ := lastlt
+      suffices (Finset.image rs.toFun Finset.univ).card =
+               (Finset.image rs.eraseLast.toFun Finset.univ ∪ {rs.toFun i.succ}).card by
+        simp_all only [eraseLast_length]
+        rw[Finset.card_union_of_disjoint]
+        · simp
+        · simp only [Finset.disjoint_singleton_right, Finset.mem_image, Finset.mem_univ,
+          eraseLast_toFun, true_and, not_exists]
+          intro x
+          suffices rs.toFun ⟨↑x, by omega⟩ < rs.toFun i.succ by exact ne_of_lt this
+          apply LT.lt.trans_le' (b := rs.toFun i.castSucc)
+          · exact hi1
+          · apply rs.map_le
+            apply Fin.mk_le_of_le_val
+            simp only [Fin.coe_castSucc]; omega
+      congr
+      apply le_antisymm
+      · intro x hx
+        simp only [Finset.mem_image, Finset.mem_univ, eraseLast_toFun, true_and] at hx ⊢
+        obtain ⟨j, rfl⟩ := hx
+        by_cases hj : j = i.succ
+        · simp only [eraseLast_length, Finset.mem_union, Finset.mem_image, Finset.mem_univ,
+          eraseLast_toFun, true_and, Finset.mem_singleton]
+          apply Or.inr
+          rw[hj]
+        · simp only [eraseLast_length, Finset.mem_union, Finset.mem_image, Finset.mem_univ,
+          eraseLast_toFun, true_and, Finset.mem_singleton]
+          apply Or.inl
+          have hj' : j ≠ Fin.last rs.length := by
+            have : i.succ = Fin.last _ := by
+              exact Eq.symm (Fin.eq_of_val_eq (id (Eq.symm hi2)))
+            rw[← this]
+            exact hj
+          use (j.castPred hj').cast (m := rs.length - 1 + 1) (by omega)
+          rfl
+      · intro x hx
+        simp only [eraseLast_length, Finset.mem_union, Finset.mem_image, Finset.mem_univ,
+          eraseLast_toFun, true_and, Finset.mem_singleton] at hx
+        obtain h | h := hx
+        · simp only [Finset.mem_image, Finset.mem_univ, eraseLast_toFun, true_and] at h ⊢
+          obtain ⟨i, rfl⟩ := h
+          exact ⟨_, rfl⟩
+        · simp[h]
+
+
+/--
+The trimmed length of rs.eraseLast is less than or equal to the trimmed length of rs
+-/
+theorem RelSeries.trimmedLength_eraseLast_le :
+  rs.eraseLast.trimmedLength ≤ rs.trimmedLength := by
+    by_cases h : ∃ i : Fin rs.length, rs.toFun i.castSucc = rs.toFun i.succ ∧ ↑i + 1 = rs.length
+    · exact Nat.le_of_eq (id (Eq.symm (rs.trimmedLength_eraseLast_of_eq h)))
+    · by_cases nontriv : rs.length = 0
+      · simp_all only [AddLeftCancelMonoid.add_eq_zero, one_ne_zero, and_false, exists_false,
+        not_false_eq_true]
+        have : rs.eraseLast = rs := by aesop
+        exact Nat.le_of_eq (congrArg trimmedLength this)
+      have : ∃ i : Fin rs.length, rs.toFun i.castSucc < rs.toFun i.succ ∧ ↑i + 1 = rs.length := by
+        simp_all only [not_exists, not_and]
+        let secondlast : Fin rs.length := ⟨rs.length - 1, by omega⟩
+        use secondlast
+        specialize h secondlast
+        have neq : rs secondlast.succ ≠ rs secondlast.castSucc := by
+          contrapose h
+          simp_all only [ne_eq, Decidable.not_not, forall_const, secondlast]
+          omega
+        have := rs.step secondlast
+        constructor
+        · apply lt_of_le_of_ne
+          · exact this
+          · exact id (Ne.symm neq)
+        · exact Nat.succ_pred_eq_of_ne_zero nontriv
+      have := rs.trimmedLength_eraseLast_of_lt this
+      omega
+
+variable [DecidableRel (α := α) (· ≤ ·)]
+
+instance (rs : RelSeries (α := α) (· ≤ ·)) :
+  LinearOrder { x // x ∈ Finset.image rs.toFun Finset.univ } where
+    __ := Subtype.partialOrder _
+    le_total := by
+      rintro ⟨a, ha⟩ ⟨b, hb⟩
+      simp only [Finset.mem_image, Finset.mem_univ, true_and] at ha hb
+      obtain ⟨i, rfl⟩ := ha
+      obtain ⟨j, rfl⟩ := hb
+      simp only [Subtype.mk_le_mk]
+      exact (le_total i j).imp (RelSeries.map_le rs) (RelSeries.map_le rs)
+    decidableLE := inferInstance
+
+/--
+Constructs LTSeries associated to a given RelSeries (α := α) (· ≤ ·) constructed by
+taking only those places where the relation is not equality.
+-/
+def RelSeries.trim (rs : RelSeries (α := α) (· ≤ ·)) :
+ RelSeries (α := α) (· < ·) where
+   length := rs.trimmedLength
+   toFun := by
+    refine Subtype.val ∘ monoEquivOfFin (Finset.image rs.toFun Finset.univ) ?_
+    simp[RelSeries.trimmedLength]
+   step := by
+    intro i
+    simp
+
+/--
+The length of the rs.trim is equal to the trimmed length of rs.
+-/
+lemma RelSeries.length_trim (rs : RelSeries (α := α) (· ≤ ·)) :
+  rs.trim.length = rs.trimmedLength := by
+    simp[trim]

--- a/Mathlib/Order/TrimmedLength.lean
+++ b/Mathlib/Order/TrimmedLength.lean
@@ -4,11 +4,10 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Raphael Douglas Giles
 -/
 
-import Mathlib.Algebra.Module.Submodule.Lattice
+import Mathlib.Algebra.Order.Sub.Basic
+import Mathlib.Order.RelSeries
 import Mathlib.Data.Fintype.Sort
-import Mathlib.Order.Category.NonemptyFinLinOrd
-import Mathlib.Order.CompletePartialOrder
-import Mathlib.Order.KrullDimension
+
 
 /-!
 

--- a/Mathlib/Order/TrimmedLength.lean
+++ b/Mathlib/Order/TrimmedLength.lean
@@ -4,7 +4,11 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Raphael Douglas Giles
 -/
 
-import Mathlib
+import Mathlib.Algebra.Module.Submodule.Lattice
+import Mathlib.Data.Fintype.Sort
+import Mathlib.Order.Category.NonemptyFinLinOrd
+import Mathlib.Order.CompletePartialOrder
+import Mathlib.Order.KrullDimension
 
 /-!
 

--- a/Mathlib/Order/TrimmedLength.lean
+++ b/Mathlib/Order/TrimmedLength.lean
@@ -7,6 +7,7 @@ Authors: Raphael Douglas Giles
 import Mathlib
 
 /-!
+
 # Trimmed Length
 
 Given a relseries rs : RelSeries (· ≤ ·), we define the trimmed length of rs to be the cardinality
@@ -18,19 +19,7 @@ in rs. In this file we develop the main API for working with the trimmed length.
 open Order
 
 variable {α : Type*}
-/--
-Given a relseries rs : RelSeries (α := α) r with transitive and reflixive r, i ≤ j implies
-r (rs i) (rs j)
--/
-theorem RelSeries.map_le {r : Rel α α} [IsTrans α r] [IsRefl α r] (rs : RelSeries (α := α) r)
-  {i j : Fin (rs.length + 1)}
-  (hij : i ≤ j) : r (rs i) (rs j) := by
-    have := rel_or_eq_of_le rs hij
-    cases this
-    · assumption
-    · rename_i h
-      rw[h]
-      apply refl (r := r)
+
 
 variable [PartialOrder α] [DecidableEq α]
   (rs : RelSeries (α := α) (· ≤ ·))
@@ -150,7 +139,7 @@ theorem RelSeries.trimmedLength_eraseLast_of_lt
           suffices rs.toFun ⟨↑x, by omega⟩ < rs.toFun i.succ by exact ne_of_lt this
           apply LT.lt.trans_le' (b := rs.toFun i.castSucc)
           · exact hi1
-          · apply rs.map_le
+          · apply rs.rel_of_le
             apply Fin.mk_le_of_le_val
             simp only [Fin.coe_castSucc]; omega
       congr
@@ -224,7 +213,7 @@ instance (rs : RelSeries (α := α) (· ≤ ·)) :
       obtain ⟨i, rfl⟩ := ha
       obtain ⟨j, rfl⟩ := hb
       simp only [Subtype.mk_le_mk]
-      exact (le_total i j).imp (RelSeries.map_le rs) (RelSeries.map_le rs)
+      exact (le_total i j).imp (RelSeries.rel_of_le rs) (RelSeries.rel_of_le rs)
     decidableLE := inferInstance
 
 /--

--- a/Mathlib/Order/TrimmedLength.lean
+++ b/Mathlib/Order/TrimmedLength.lean
@@ -13,9 +13,9 @@ import Mathlib.Data.Fintype.Sort
 
 # Trimmed Length
 
-Given a relseries rs : RelSeries (· ≤ ·), we define the trimmed length of rs to be the cardinality
-of the underlying function rs.toFun of rs minus 1. This models the number of `<` relations occuring
-in rs. In this file we develop the main API for working with the trimmed length.
+Given a relseries `rs : RelSeries (· ≤ ·)`, we define the trimmed length of `rs` to be the
+cardinality of the underlying function `rs.toFun` of `rs` minus `1`. This models the number of `<`
+relations occuring in `rs`. In this file we develop the main API for working with the trimmed length
 
 -/
 
@@ -28,8 +28,8 @@ variable [PartialOrder α] [DecidableEq α]
   (rs : RelSeries (α := α) (· ≤ ·))
 
 /--
-Given (rs : RelSeries (α := α) (· ≤ ·)), rs.trimmedLength measures the number of `<`s appearing
-in rs defined as the image of the underlying function of rs, rs.toFun.
+Given `rs : RelSeries (α := α) (· ≤ ·)`,  `rs.trimmedLength` measures the number of `<`s appearing
+in `rs` defined as the image of the underlying function of `rs`, i.e. `rs.toFun`.
 -/
 def RelSeries.trimmedLength (rs : RelSeries (α := α) (· ≤ ·)) : ℕ :=
   (Finset.image rs.toFun Finset.univ).card - 1
@@ -44,14 +44,14 @@ lemma RelSeries.trimmedLength_le_length : rs.trimmedLength ≤ rs.length := by
   exact this
 
 /--
-The length of a relseries rs is equal to the trimmed length if and only if the underlying function
-of rs (i.e. rs.toFun) is injective.
+The length of a relseries `rs` is equal to the trimmed length if and only if the underlying function
+of `rs` (i.e. `rs.toFun`) is injective.
 -/
 lemma RelSeries.length_eq_trimmedLength_iff :
   rs.length = rs.trimmedLength ↔ rs.toFun.Injective := by
   constructor
   · intro h
-    simp[RelSeries.trimmedLength] at h
+    simp only [trimmedLength] at h
     have := Finset.card_image_iff (s := .univ) (f := rs.toFun)
     simp_all only [Finset.card_univ, Finset.one_le_card,
       Finset.image_nonempty, Finset.univ_nonempty,
@@ -61,14 +61,14 @@ lemma RelSeries.length_eq_trimmedLength_iff :
     apply antisymm (r := (· ≤ ·))
     · have := Finset.card_le_card_of_injOn (s := .univ) (t := Finset.image rs.toFun Finset.univ)
         rs.toFun (by simp) h.injOn
-      simp at this
-      simp[RelSeries.trimmedLength]
+      simp only [Finset.card_univ, Fintype.card_fin, trimmedLength, ge_iff_le] at this ⊢
       omega
     · exact RelSeries.trimmedLength_le_length rs
 
 variable {rs} in
 /--
-If rs has length greater than 0, there must be some index i such that rs i.castSucc < rs i.succ
+If `rs` has length greater than `0`, there must be some index `i` such that
+`rs i.castSucc < rs i.succ`.
 -/
 theorem RelSeries.trimmedLength_exists_le
 (hrs : rs.trimmedLength > 0) : ∃ (i : Fin rs.length), rs i.castSucc < rs i.succ := by
@@ -91,8 +91,9 @@ theorem RelSeries.trimmedLength_exists_le
 
 variable {rs} in
 /--
-If the last two elements of rs are equal, then rs.trimmedLength = rs.eraseLast.trimmedLength. Note
-that if rs only has one element, the "last two elements" are both just the unique element of rs.
+If the last two elements of `rs` are equal, then `rs.trimmedLength = rs.eraseLast.trimmedLength`.
+Note that if `rs` only has one element, the "last two elements" are both just the unique element of
+`rs`.
 -/
 theorem RelSeries.trimmedLength_eraseLast_of_eq
   (lasteq : ∃ i : Fin (rs.length), rs.toFun i.castSucc = rs.toFun i.succ ∧ (i + 1 : ℕ) = rs.length)
@@ -120,9 +121,9 @@ theorem RelSeries.trimmedLength_eraseLast_of_eq
 
 variable {rs} in
 /--
-If the last two elements a, b of rs satisfy a < b, then
-rs.trimmedLength = rs.eraseLast.trimmedLength. Note that if rs only has one element,
-the "last two elements" are both just the unique element of rs.
+If the last two elements `a, b` of `rs` satisfy `a < b`, then
+`rs.trimmedLength = rs.eraseLast.trimmedLength`. Note that if `rs` only has one element,
+the "last two elements" are both just the unique element of `rs`.
 In this case the condition is vacuous.
 -/
 theorem RelSeries.trimmedLength_eraseLast_of_lt
@@ -139,7 +140,7 @@ theorem RelSeries.trimmedLength_eraseLast_of_lt
         · simp only [Finset.disjoint_singleton_right, Finset.mem_image, Finset.mem_univ,
           eraseLast_toFun, true_and, not_exists]
           intro x
-          suffices rs.toFun ⟨↑x, by omega⟩ < rs.toFun i.succ by exact ne_of_lt this
+          suffices rs.toFun ⟨↑x, by omega⟩ < rs.toFun i.succ from ne_of_lt this
           apply LT.lt.trans_le' (b := rs.toFun i.castSucc)
           · exact hi1
           · apply rs.rel_of_le
@@ -158,12 +159,8 @@ theorem RelSeries.trimmedLength_eraseLast_of_lt
         · simp only [eraseLast_length, Finset.mem_union, Finset.mem_image, Finset.mem_univ,
           eraseLast_toFun, true_and, Finset.mem_singleton]
           apply Or.inl
-          have hj' : j ≠ Fin.last rs.length := by
-            have : i.succ = Fin.last _ := by
-              exact Eq.symm (Fin.eq_of_val_eq (id (Eq.symm hi2)))
-            rw[← this]
-            exact hj
-          use (j.castPred hj').cast (m := rs.length - 1 + 1) (by omega)
+          use (j.castPred (ne_of_ne_of_eq hj ((Fin.eq_of_val_eq hi2) : i.succ = Fin.last _))).cast
+           (m := rs.length - 1 + 1) (by omega)
           rfl
       · intro x hx
         simp only [eraseLast_length, Finset.mem_union, Finset.mem_image, Finset.mem_univ,
@@ -176,7 +173,7 @@ theorem RelSeries.trimmedLength_eraseLast_of_lt
 
 
 /--
-The trimmed length of rs.eraseLast is less than or equal to the trimmed length of rs
+The trimmed length of `rs.eraseLast` is less than or equal to the trimmed length of `rs`.
 -/
 theorem RelSeries.trimmedLength_eraseLast_le :
   rs.eraseLast.trimmedLength ≤ rs.trimmedLength := by
@@ -220,22 +217,15 @@ instance (rs : RelSeries (α := α) (· ≤ ·)) :
     decidableLE := inferInstance
 
 /--
-Constructs LTSeries associated to a given RelSeries (α := α) (· ≤ ·) constructed by
+Constructs the `LTSeries` associated to a given `RelSeries (α := α) (· ≤ ·)` constructed by
 taking only those places where the relation is not equality.
 -/
+@[simps]
 def RelSeries.trim (rs : RelSeries (α := α) (· ≤ ·)) :
  RelSeries (α := α) (· < ·) where
    length := rs.trimmedLength
-   toFun := by
-    refine Subtype.val ∘ monoEquivOfFin (Finset.image rs.toFun Finset.univ) ?_
-    simp[RelSeries.trimmedLength]
+   toFun := Subtype.val ∘ monoEquivOfFin (Finset.image rs.toFun Finset.univ)
+    (by simp[RelSeries.trimmedLength])
    step := by
     intro i
     simp
-
-/--
-The length of the rs.trim is equal to the trimmed length of rs.
--/
-lemma RelSeries.length_trim (rs : RelSeries (α := α) (· ≤ ·)) :
-  rs.trim.length = rs.trimmedLength := by
-    simp[trim]


### PR DESCRIPTION
In this PR, we define the trimmed length of a relseries rs : RelSeries (· ≤ ·) to be the cardinality of the underlying function rs.toFun of rs minus 1. This models the number of `<` relations occuring in rs. We develop some basic API for this notion, with the main intended application being a proof that module length is additive.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
