### PR TITLE
[Merged by Bors] - chore(Data/Set/Finite): avoid importing algebra in `Data.Set.Finite`

### DIFF
--- a/Mathlib/Algebra/Group/TypeTags/Fintype.lean
+++ b/Mathlib/Algebra/Group/TypeTags/Fintype.lean
@@ -3,9 +3,11 @@ Copyright (c) 2017 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
+import Mathlib.Algebra.Group.Commute.Defs
 import Mathlib.Algebra.Group.Equiv.Defs
 import Mathlib.Algebra.Group.TypeTags.Basic
 import Mathlib.Data.Fintype.Card
+import Mathlib.Data.Fintype.EquivFin
 
 /-!
 # Finite types with addition/multiplications
@@ -56,3 +58,7 @@ instance Multiplicative.fintype : ∀ [Fintype α], Fintype (Multiplicative α) 
 
 @[simp] lemma Fintype.card_additive (α : Type*) [Fintype α] : card (Additive α) = card α :=
   Finset.card_map _
+
+instance instInfiniteProdSubtypeCommute [Mul α] [Infinite α] :
+    Infinite { p : α × α // Commute p.1 p.2 } :=
+  Infinite.of_injective (fun a => ⟨⟨a, a⟩, rfl⟩) (by intro; simp)

--- a/Mathlib/Data/DFinsupp/Defs.lean
+++ b/Mathlib/Data/DFinsupp/Defs.lean
@@ -3,6 +3,7 @@ Copyright (c) 2018 Kenny Lau. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Kenny Lau
 -/
+import Mathlib.Algebra.Group.Prod
 import Mathlib.Data.Set.Finite.Basic
 
 /-!

--- a/Mathlib/Data/Finsupp/Defs.lean
+++ b/Mathlib/Data/Finsupp/Defs.lean
@@ -4,8 +4,10 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Kim Morrison
 -/
 import Mathlib.Algebra.Group.Indicator
+import Mathlib.Algebra.Group.InjSurj
 import Mathlib.Data.Set.Finite.Basic
 import Mathlib.Tactic.FastInstance
+import Mathlib.Algebra.Group.Equiv.Defs
 
 /-!
 # Type of functions with finite support

--- a/Mathlib/Data/Fintype/EquivFin.lean
+++ b/Mathlib/Data/Fintype/EquivFin.lean
@@ -33,7 +33,7 @@ We provide `Infinite` instances for
 
 -/
 
-assert_not_exists Monoid MonoidWithZero MulAction
+assert_not_exists Monoid
 
 open Function
 

--- a/Mathlib/Data/Fintype/EquivFin.lean
+++ b/Mathlib/Data/Fintype/EquivFin.lean
@@ -3,7 +3,6 @@ Copyright (c) 2017 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
-import Mathlib.Algebra.BigOperators.Group.List.Lemmas
 import Mathlib.Data.Fintype.Card
 import Mathlib.Data.List.NodupEquivFin
 
@@ -34,7 +33,7 @@ We provide `Infinite` instances for
 
 -/
 
-assert_not_exists MonoidWithZero MulAction
+assert_not_exists Monoid MonoidWithZero MulAction
 
 open Function
 
@@ -530,10 +529,6 @@ instance Prod.infinite_of_right [Nonempty α] [Infinite β] : Infinite (α × β
 instance Prod.infinite_of_left [Infinite α] [Nonempty β] : Infinite (α × β) :=
   Infinite.of_surjective Prod.fst Prod.fst_surjective
 
-instance instInfiniteProdSubtypeCommute [Mul α] [Infinite α] :
-    Infinite { p : α × α // Commute p.1 p.2 } :=
-  Infinite.of_injective (fun a => ⟨⟨a, a⟩, rfl⟩) (by intro; simp)
-
 namespace Infinite
 
 private noncomputable def natEmbeddingAux (α : Type*) [Infinite α] : ℕ → α
@@ -600,56 +595,3 @@ instance Function.Embedding.is_empty {α β} [Infinite α] [Finite β] : IsEmpty
 
 theorem not_surjective_finite_infinite {α β} [Finite α] [Infinite β] (f : α → β) : ¬Surjective f :=
   fun hf => (Infinite.of_surjective f hf).not_finite ‹_›
-
-section Ranges
-
-/-- For any `c : List ℕ` whose sum is at most `Fintype.card α`,
-  we can find `o : List (List α)` whose members have no duplicate,
-  whose lengths given by `c`, and which are pairwise disjoint -/
-theorem List.exists_pw_disjoint_with_card {α : Type*} [Fintype α]
-    {c : List ℕ} (hc : c.sum ≤ Fintype.card α) :
-    ∃ o : List (List α),
-      o.map length = c ∧ (∀ s ∈ o, s.Nodup) ∧ Pairwise List.Disjoint o := by
-  let klift (n : ℕ) (hn : n < Fintype.card α) : Fin (Fintype.card α) :=
-    (⟨n, hn⟩ : Fin (Fintype.card α))
-  let klift' (l : List ℕ) (hl : ∀ a ∈ l, a < Fintype.card α) :
-    List (Fin (Fintype.card α)) := List.pmap klift l hl
-  have hc'_lt : ∀ l ∈ c.ranges, ∀ n ∈ l, n < Fintype.card α := by
-    intro l hl n hn
-    apply lt_of_lt_of_le _ hc
-    rw [← mem_mem_ranges_iff_lt_sum]
-    exact ⟨l, hl, hn⟩
-  let l := (ranges c).pmap klift' hc'_lt
-  have hl : ∀ (a : List ℕ) (ha : a ∈ c.ranges),
-    (klift' a (hc'_lt a ha)).map Fin.valEmbedding = a := by
-    intro a ha
-    conv_rhs => rw [← List.map_id a]
-    rw [List.map_pmap]
-    simp [klift, Fin.valEmbedding_apply, Fin.val_mk, List.pmap_eq_map, List.map_id']
-  use l.map (List.map (Fintype.equivFin α).symm)
-  constructor
-  · -- length
-    rw [← ranges_length c]
-    simp only [l, klift', map_map, map_pmap, Function.comp_apply, length_map, length_pmap,
-      pmap_eq_map]
-  constructor
-  · -- nodup
-    intro s
-    rw [mem_map]
-    rintro ⟨t, ht, rfl⟩
-    apply Nodup.map (Equiv.injective _)
-    obtain ⟨u, hu, rfl⟩ := mem_pmap.mp ht
-    apply Nodup.of_map
-    rw [hl u hu]
-    exact ranges_nodup hu
-  · -- pairwise disjoint
-    refine Pairwise.map _ (fun s t ↦ disjoint_map (Equiv.injective _)) ?_
-    -- List.Pairwise List.disjoint l
-    apply Pairwise.pmap (List.ranges_disjoint c)
-    intro u hu v hv huv
-    apply disjoint_pmap
-    · intro a a' ha ha' h
-      simpa only [klift, Fin.mk_eq_mk] using h
-    exact huv
-
-end Ranges

--- a/Mathlib/Data/Fintype/Perm.lean
+++ b/Mathlib/Data/Fintype/Perm.lean
@@ -3,7 +3,8 @@ Copyright (c) 2017 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
-import Mathlib.Data.Fintype.Card
+import Mathlib.Algebra.BigOperators.Group.List.Defs
+import Mathlib.Algebra.Group.Nat.Defs
 import Mathlib.Data.Fintype.EquivFin
 import Mathlib.Data.Nat.Factorial.Basic
 import Mathlib.GroupTheory.Perm.Basic

--- a/Mathlib/Data/List/ToFinsupp.lean
+++ b/Mathlib/Data/List/ToFinsupp.lean
@@ -3,7 +3,9 @@ Copyright (c) 2022 Yakov Pechersky. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yakov Pechersky
 -/
+import Mathlib.Algebra.BigOperators.Group.List.Basic
 import Mathlib.Algebra.Group.Embedding
+import Mathlib.Algebra.Group.Nat.Defs
 import Mathlib.Data.Finsupp.Single
 import Mathlib.Data.List.GetD
 

--- a/Mathlib/Data/Set/Finite/Basic.lean
+++ b/Mathlib/Data/Set/Finite/Basic.lean
@@ -40,7 +40,7 @@ instances since they do not compute anything.
 finite sets
 -/
 
-assert_not_exists Monoid MonoidWithZero OrderedRing
+assert_not_exists Monoid
 
 open Set Function
 open scoped symmDiff

--- a/Mathlib/Data/Set/Finite/Basic.lean
+++ b/Mathlib/Data/Set/Finite/Basic.lean
@@ -4,8 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Mario Carneiro, Kyle Miller
 -/
 import Mathlib.Data.Finite.Defs
-import Mathlib.Data.Finset.Union
+import Mathlib.Data.Finset.Image
 import Mathlib.Data.Fintype.EquivFin
+import Mathlib.Tactic.Nontriviality
 
 /-!
 # Finite sets
@@ -39,7 +40,7 @@ instances since they do not compute anything.
 finite sets
 -/
 
-assert_not_exists OrderedRing MonoidWithZero
+assert_not_exists Monoid MonoidWithZero OrderedRing
 
 open Set Function
 open scoped symmDiff
@@ -275,17 +276,6 @@ instance fintypeDiff [DecidableEq α] (s t : Set α) [Fintype s] [Fintype t] :
 instance fintypeDiffLeft (s t : Set α) [Fintype s] [DecidablePred (· ∈ t)] :
     Fintype (s \ t : Set α) :=
   Set.fintypeSep s (· ∈ tᶜ)
-
-/-- A union of sets with `Fintype` structure over a set with `Fintype` structure has a `Fintype`
-structure. -/
-def fintypeBiUnion [DecidableEq α] {ι : Type*} (s : Set ι) [Fintype s] (t : ι → Set α)
-    (H : ∀ i ∈ s, Fintype (t i)) : Fintype (⋃ x ∈ s, t x) :=
-  haveI : ∀ i : toFinset s, Fintype (t i) := fun i => H i (mem_toFinset.1 i.2)
-  Fintype.ofFinset (s.toFinset.attach.biUnion fun x => (t x).toFinset) fun x => by simp
-
-instance fintypeBiUnion' [DecidableEq α] {ι : Type*} (s : Set ι) [Fintype s] (t : ι → Set α)
-    [∀ i, Fintype (t i)] : Fintype (⋃ x ∈ s, t x) :=
-  Fintype.ofFinset (s.toFinset.biUnion fun x => (t x).toFinset) <| by simp
 
 instance fintypeEmpty : Fintype (∅ : Set α) :=
   Fintype.ofFinset ∅ <| by simp
@@ -979,16 +969,5 @@ lemma Finite.of_forall_not_lt_lt (h : ∀ ⦃x y z : α⦄, x < y → y < z → 
 lemma Set.finite_of_forall_not_lt_lt (h : ∀ x ∈ s, ∀ y ∈ s, ∀ z ∈ s, x < y → y < z → False) :
     Set.Finite s :=
   @Set.toFinite _ s <| Finite.of_forall_not_lt_lt <| by simpa only [SetCoe.forall'] using h
-
-lemma Directed.exists_mem_subset_of_finset_subset_biUnion {α ι : Type*} [Nonempty ι]
-    {f : ι → Set α} (h : Directed (· ⊆ ·) f) {s : Finset α} (hs : (s : Set α) ⊆ ⋃ i, f i) :
-    ∃ i, (s : Set α) ⊆ f i := by
-  induction s using Finset.cons_induction with
-  | empty => simp
-  | cons b t hbt iht =>
-    simp only [Finset.coe_cons, Set.insert_subset_iff, Set.mem_iUnion] at hs ⊢
-    rcases hs.imp_right iht with ⟨⟨i, hi⟩, j, hj⟩
-    rcases h i j with ⟨k, hik, hjk⟩
-    exact ⟨k, hik hi, hj.trans hjk⟩
 
 end LinearOrder

--- a/Mathlib/GroupTheory/GroupAction/CardCommute.lean
+++ b/Mathlib/GroupTheory/GroupAction/CardCommute.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes, Thomas Browning
 -/
 import Mathlib.Algebra.Group.ConjFinite
+import Mathlib.Algebra.Group.TypeTags.Fintype
 import Mathlib.GroupTheory.GroupAction.Quotient
 
 /-!

--- a/Mathlib/GroupTheory/Perm/Cycle/PossibleTypes.lean
+++ b/Mathlib/GroupTheory/Perm/Cycle/PossibleTypes.lean
@@ -16,6 +16,59 @@ import Mathlib.GroupTheory.Perm.Cycle.Concrete
 
 variable (α : Type*) [DecidableEq α] [Fintype α]
 
+section Ranges
+
+/-- For any `c : List ℕ` whose sum is at most `Fintype.card α`,
+  we can find `o : List (List α)` whose members have no duplicate,
+  whose lengths given by `c`, and which are pairwise disjoint -/
+theorem List.exists_pw_disjoint_with_card {α : Type*} [Fintype α]
+    {c : List ℕ} (hc : c.sum ≤ Fintype.card α) :
+    ∃ o : List (List α),
+      o.map length = c ∧ (∀ s ∈ o, s.Nodup) ∧ Pairwise List.Disjoint o := by
+  let klift (n : ℕ) (hn : n < Fintype.card α) : Fin (Fintype.card α) :=
+    (⟨n, hn⟩ : Fin (Fintype.card α))
+  let klift' (l : List ℕ) (hl : ∀ a ∈ l, a < Fintype.card α) :
+    List (Fin (Fintype.card α)) := List.pmap klift l hl
+  have hc'_lt : ∀ l ∈ c.ranges, ∀ n ∈ l, n < Fintype.card α := by
+    intro l hl n hn
+    apply lt_of_lt_of_le _ hc
+    rw [← mem_mem_ranges_iff_lt_sum]
+    exact ⟨l, hl, hn⟩
+  let l := (ranges c).pmap klift' hc'_lt
+  have hl : ∀ (a : List ℕ) (ha : a ∈ c.ranges),
+    (klift' a (hc'_lt a ha)).map Fin.valEmbedding = a := by
+    intro a ha
+    conv_rhs => rw [← List.map_id a]
+    rw [List.map_pmap]
+    simp [klift, Fin.valEmbedding_apply, Fin.val_mk, List.pmap_eq_map, List.map_id']
+  use l.map (List.map (Fintype.equivFin α).symm)
+  constructor
+  · -- length
+    rw [← ranges_length c]
+    simp only [l, klift', map_map, map_pmap, Function.comp_apply, length_map, length_pmap,
+      pmap_eq_map]
+  constructor
+  · -- nodup
+    intro s
+    rw [mem_map]
+    rintro ⟨t, ht, rfl⟩
+    apply Nodup.map (Equiv.injective _)
+    obtain ⟨u, hu, rfl⟩ := mem_pmap.mp ht
+    apply Nodup.of_map
+    rw [hl u hu]
+    exact ranges_nodup hu
+  · -- pairwise disjoint
+    refine Pairwise.map _ (fun s t ↦ disjoint_map (Equiv.injective _)) ?_
+    -- List.Pairwise List.disjoint l
+    apply Pairwise.pmap (List.ranges_disjoint c)
+    intro u hu v hv huv
+    apply disjoint_pmap
+    · intro a a' ha ha' h
+      simpa only [klift, Fin.mk_eq_mk] using h
+    exact huv
+
+end Ranges
+
 /-- There are permutations with cycleType `m` if and only if
   its sum is at most `Fintype.card α` and its members are at least 2. -/
 theorem Equiv.Perm.exists_with_cycleType_iff {m : Multiset ℕ} :

--- a/Mathlib/Logic/Denumerable.lean
+++ b/Mathlib/Logic/Denumerable.lean
@@ -21,7 +21,7 @@ This property already has a name, namely `α ≃ ℕ`, but here we are intereste
 typeclass.
 -/
 
-assert_not_exists OrderedSemiring
+assert_not_exists Monoid OrderedSemiring
 
 variable {α β : Type*}
 
@@ -186,7 +186,7 @@ section Classical
 theorem exists_succ (x : s) : ∃ n, (x : ℕ) + n + 1 ∈ s := by
   by_contra h
   have : ∀ (a : ℕ) (_ : a ∈ s), a < x + 1 := fun a ha =>
-    lt_of_not_ge fun hax => h ⟨a - (x + 1), by rwa [add_right_comm, Nat.add_sub_cancel' hax]⟩
+    lt_of_not_ge fun hax => h ⟨a - (x + 1), by rwa [Nat.add_right_comm, Nat.add_sub_cancel' hax]⟩
   classical
   exact Fintype.false
     ⟨(((Multiset.range (succ x)).filter (· ∈ s)).pmap

--- a/Mathlib/Logic/Denumerable.lean
+++ b/Mathlib/Logic/Denumerable.lean
@@ -21,7 +21,7 @@ This property already has a name, namely `α ≃ ℕ`, but here we are intereste
 typeclass.
 -/
 
-assert_not_exists Monoid OrderedSemiring
+assert_not_exists Monoid
 
 variable {α β : Type*}
 

--- a/Mathlib/Logic/Equiv/List.lean
+++ b/Mathlib/Logic/Equiv/List.lean
@@ -3,6 +3,7 @@ Copyright (c) 2018 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
+import Mathlib.Data.List.Chain
 import Mathlib.Data.Finset.Sort
 import Mathlib.Data.Vector.Basic
 import Mathlib.Logic.Denumerable

--- a/MathlibTest/dfinsupp_notation.lean
+++ b/MathlibTest/dfinsupp_notation.lean
@@ -1,3 +1,4 @@
+import Mathlib.Algebra.Group.Int.Defs
 import Mathlib.Data.DFinsupp.Notation
 
 example : (fun₀ | 1 => 3 : Π₀ i, Fin (i + 10)) 1 = 3 := by


### PR DESCRIPTION
By moving a few lemmas we can avoid knowing about monoids when defining basic lemmas on finite sets.

---

- [x] depends on: #21866

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
