### PR TITLE
[Merged by Bors] - feat: decomposition into independent atoms

### DIFF
--- a/Mathlib/NumberTheory/NumberField/Ideal/KummerDedekind.lean
+++ b/Mathlib/NumberTheory/NumberField/Ideal/KummerDedekind.lean
@@ -44,8 +44,8 @@ theorem exponent_eq_one_iff : exponent θ = 1 ↔ Algebra.adjoin ℤ {θ} = ⊤ 
   rw [exponent, absNorm_eq_one_iff, comap_eq_top_iff, conductor_eq_top_iff_adjoin_eq_top]
 
 theorem not_dvd_exponent_iff {p : ℕ} [Fact (Nat.Prime p)] :
-    ¬ p ∣ exponent θ ↔ comap (algebraMap ℤ (𝓞 K)) (conductor ℤ θ) ⊔ span {(p : ℤ)} = ⊤ := by
-  rw [sup_comm, IsCoatom.sup_eq_top_iff, ← under_def, ← Ideal.dvd_iff_le,
+    ¬ p ∣ exponent θ ↔ Codisjoint (comap (algebraMap ℤ (𝓞 K)) (conductor ℤ θ)) (span {↑p}) := by
+  rw [codisjoint_comm, ← IsCoatom.not_le_iff_codisjoint, ← under_def, ← Ideal.dvd_iff_le,
     ← Int.ideal_span_absNorm_eq_self (under ℤ (conductor ℤ θ)),
     span_singleton_dvd_span_singleton_iff_dvd, Int.natCast_dvd_natCast, exponent]
   exact isMaximal_def.mp <| Int.ideal_span_isMaximal_of_prime p

--- a/Mathlib/NumberTheory/NumberField/Ideal/KummerDedekind.lean
+++ b/Mathlib/NumberTheory/NumberField/Ideal/KummerDedekind.lean
@@ -63,7 +63,7 @@ def ZModXQuotSpanEquivQuotSpan (hp : ¬ p ∣ exponent θ) :
       𝓞 K ⧸ span {(p : 𝓞 K)} :=
   (quotientEquivAlgOfEq ℤ (by simp [Ideal.map_span, Polynomial.map_map])).toRingEquiv.trans
     ((quotientEquiv _ _ (mapEquiv (Int.quotientSpanNatEquivZMod p)) rfl).symm.trans
-      ((quotMapEquivQuotQuotMap (not_dvd_exponent_iff.mp hp) θ.isIntegral).symm.trans
+      ((quotMapEquivQuotQuotMap (not_dvd_exponent_iff.mp hp).eq_top θ.isIntegral).symm.trans
         (quotientEquivAlgOfEq ℤ (by simp [map_span])).toRingEquiv))
 
 theorem ZModXQuotSpanEquivQuotSpan_mk_apply (hp : ¬ p ∣ exponent θ) (Q : ℤ[X]) :
@@ -75,7 +75,7 @@ theorem ZModXQuotSpanEquivQuotSpan_mk_apply (hp : ¬ p ∣ exponent θ) (Q : ℤ
     quotientEquiv_symm_apply, quotientMap_mk, RingHom.coe_coe, mapEquiv_symm_apply,
     Polynomial.map_map, Int.quotientSpanNatEquivZMod_comp_castRingHom]
   exact congr_arg (quotientEquivAlgOfEq ℤ (by simp [map_span])) <|
-    quotMapEquivQuotQuotMap_symm_apply (not_dvd_exponent_iff.mp hp) θ.isIntegral Q
+    quotMapEquivQuotQuotMap_symm_apply (not_dvd_exponent_iff.mp hp).eq_top θ.isIntegral Q
 
 variable (p θ) in
 /--

--- a/Mathlib/Order/BooleanAlgebra/Set.lean
+++ b/Mathlib/Order/BooleanAlgebra/Set.lean
@@ -420,6 +420,9 @@ alias insert_diff_self_of_not_mem := insert_diff_self_of_notMem
 lemma insert_diff_self_of_mem (ha : a ∈ s) : insert a (s \ {a}) = s := by
   ext; simp +contextual [or_and_left, em, ha]
 
+lemma insert_diff_subset : insert a s \ t ⊆ insert a (s \ t) := by
+  rintro b ⟨rfl | hbs, hbt⟩ <;> simp [*]
+
 lemma insert_erase_invOn :
     InvOn (insert a) (fun s ↦ s \ {a}) {s : Set α | a ∈ s} {s : Set α | a ∉ s} :=
   ⟨fun _s ha ↦ insert_diff_self_of_mem ha, fun _s ↦ insert_diff_self_of_notMem⟩

--- a/Mathlib/Order/CompactlyGenerated/Basic.lean
+++ b/Mathlib/Order/CompactlyGenerated/Basic.lean
@@ -663,10 +663,10 @@ alias exists_setIndependent_of_sSup_atoms_eq_top := exists_sSupIndep_of_sSup_ato
 
 /-- See [Theorem 6.6][calugareanu]. -/
 theorem complementedLattice_of_sSup_atoms_eq_top (h : sSup { a : α | IsAtom a } = ⊤) :
-    ComplementedLattice α :=
-  ⟨fun b =>
-    let ⟨s, _, hbs_inf, hbs_sup, _⟩ := exists_sSupIndep_isCompl_sSup_atoms b ⊤ le_top (by simpa)
-    ⟨sSup s, hbs_inf, codisjoint_iff.2 hbs_sup⟩⟩
+    ComplementedLattice α where
+  exists_isCompl b :=
+    let ⟨s, _, hcompl, _⟩ := exists_sSupIndep_isCompl_sSup_atoms (by simpa) b
+    ⟨sSup s, hcompl⟩
 
 /-- See [Theorem 6.6][calugareanu]. -/
 theorem complementedLattice_of_isAtomistic [IsAtomistic α] : ComplementedLattice α :=

--- a/Mathlib/Order/CompactlyGenerated/Basic.lean
+++ b/Mathlib/Order/CompactlyGenerated/Basic.lean
@@ -583,9 +583,10 @@ Now we will prove that a compactly generated modular atomistic lattice is a comp
 Most explicitly, every element is the complement of a supremum of indepedendent atoms.
 -/
 
-/-- In an atomic lattice, every element `b` has a complement of the form `sSup s`, where each
-element of `s` is an atom. See also `complementedLattice_of_sSup_atoms_eq_top`. -/
-theorem exists_sSupIndep_isCompl_sSup_atoms (b c : α) (hbc : b ≤ c)
+/-- In an atomic lattice, every element `b` has a complement of the form `sSup s` relative to a
+given element `c`, where each element of `s` is an atom.
+See also `complementedLattice_of_sSup_atoms_eq_top`. -/
+theorem exists_sSupIndep_disjoint_sSup_atoms (b c : α) (hbc : b ≤ c)
     (h : sSup {a ≤ c | IsAtom a} = c) :
     ∃ s : Set α, sSupIndep s ∧ Disjoint b (sSup s) ∧ b ⊔ sSup s = c ∧ ∀ ⦃a⦄, a ∈ s → IsAtom a := by
   -- porting note(https://github.com/leanprover-community/mathlib4/issues/5732):
@@ -638,12 +639,19 @@ theorem exists_sSupIndep_isCompl_sSup_atoms (b c : α) (hbc : b ≤ c)
     · exact s_atoms x hx
     · exact ha.symm
 
+/-- In an atomic lattice, every element `b` has a complement of the form `sSup s`, where each
+element of `s` is an atom. See also `complementedLattice_of_sSup_atoms_eq_top`. -/
+theorem exists_sSupIndep_isCompl_sSup_atoms (h : sSup { a : α | IsAtom a } = ⊤) (b : α) :
+    ∃ s : Set α, sSupIndep s ∧ IsCompl b (sSup s) ∧ ∀ ⦃a⦄, a ∈ s → IsAtom a := by
+  simpa [isCompl_iff, codisjoint_iff, and_assoc]
+    using exists_sSupIndep_disjoint_sSup_atoms b ⊤ le_top <| by simpa using h
+
 @[deprecated (since := "2024-11-24")]
 alias exists_setIndependent_isCompl_sSup_atoms := exists_sSupIndep_isCompl_sSup_atoms
 
 theorem exists_sSupIndep_of_sSup_atoms (b : α) (h : sSup {a ≤ b | IsAtom a} = b) :
     ∃ s : Set α, sSupIndep s ∧ sSup s = b ∧ ∀ ⦃a⦄, a ∈ s → IsAtom a :=
-  let ⟨s, s_ind, _, s_atoms⟩ := exists_sSupIndep_isCompl_sSup_atoms ⊥ b bot_le h
+  let ⟨s, s_ind, _, s_atoms⟩ := exists_sSupIndep_disjoint_sSup_atoms ⊥ b bot_le h
   ⟨s, s_ind, by simpa using s_atoms⟩
 
 theorem exists_sSupIndep_of_sSup_atoms_eq_top (h : sSup {a : α | IsAtom a} = ⊤) :

--- a/Mathlib/Order/CompactlyGenerated/Basic.lean
+++ b/Mathlib/Order/CompactlyGenerated/Basic.lean
@@ -585,13 +585,13 @@ Most explicitly, every element is the complement of a supremum of indepedendent 
 
 /-- In an atomic lattice, every element `b` has a complement of the form `sSup s`, where each
 element of `s` is an atom. See also `complementedLattice_of_sSup_atoms_eq_top`. -/
-theorem exists_sSupIndep_isCompl_sSup_atoms (h : sSup { a : α | IsAtom a } = ⊤) (b : α) :
-    ∃ s : Set α, sSupIndep s ∧
-    IsCompl b (sSup s) ∧ ∀ ⦃a⦄, a ∈ s → IsAtom a := by
+theorem exists_sSupIndep_isCompl_sSup_atoms (b c : α) (hbc : b ≤ c)
+    (h : sSup {a ≤ c | IsAtom a} = c) :
+    ∃ s : Set α, sSupIndep s ∧ Disjoint b (sSup s) ∧ b ⊔ sSup s = c ∧ ∀ ⦃a⦄, a ∈ s → IsAtom a := by
   -- porting note(https://github.com/leanprover-community/mathlib4/issues/5732):
   -- `obtain` chokes on the placeholder.
   have zorn := zorn_subset
-    (S := {s : Set α | sSupIndep s ∧ Disjoint b (sSup s) ∧ ∀ a ∈ s, IsAtom a})
+    (S := {s : Set α | sSupIndep s ∧ Disjoint b (sSup s) ∧ ∀ a ∈ s, IsAtom a ∧ a ≤ c})
     fun c hc1 hc2 =>
       ⟨⋃₀ c,
         ⟨iSupIndep_sUnion_of_directed hc2.directedOn fun s hs => (hc1 hs).1, ?_,
@@ -605,11 +605,12 @@ theorem exists_sSupIndep_isCompl_sSup_atoms (h : sSup { a : α | IsAtom a } = �
       exact hc2.directedOn.mono @fun s t => sSup_le_sSup
   simp_rw [maximal_subset_iff] at zorn
   obtain ⟨s, ⟨s_ind, b_inf_Sup_s, s_atoms⟩, s_max⟩ := zorn
-  refine ⟨s, s_ind, ⟨b_inf_Sup_s, ?_⟩, s_atoms⟩
-  rw [codisjoint_iff_le_sup, ← h, sSup_le_iff]
+  refine ⟨s, s_ind, b_inf_Sup_s, le_antisymm ?_ ?_, fun a ha ↦ (s_atoms a ha).1⟩
+  · aesop
+  rw [← h, sSup_le_iff]
   intro a ha
   rw [← inf_eq_left]
-  refine (ha.le_iff.mp inf_le_left).resolve_left fun con => ha.1 ?_
+  refine (ha.2.le_iff.mp inf_le_left).resolve_left fun con => ha.2.1 ?_
   rw [← con, eq_comm, inf_eq_left]
   refine (le_sSup ?_).trans le_sup_right
   rw [← disjoint_iff] at con
@@ -635,15 +636,15 @@ theorem exists_sSupIndep_isCompl_sSup_atoms (h : sSup { a : α | IsAtom a } = �
   · rw [Set.mem_union, Set.mem_singleton_iff] at hx
     obtain hx | rfl := hx
     · exact s_atoms x hx
-    · exact ha
+    · exact ha.symm
 
 @[deprecated (since := "2024-11-24")]
 alias exists_setIndependent_isCompl_sSup_atoms := exists_sSupIndep_isCompl_sSup_atoms
 
-theorem exists_sSupIndep_of_sSup_atoms_eq_top (h : sSup { a : α | IsAtom a } = ⊤) :
-    ∃ s : Set α, sSupIndep s ∧ sSup s = ⊤ ∧ ∀ ⦃a⦄, a ∈ s → IsAtom a :=
-  let ⟨s, s_ind, s_top, s_atoms⟩ := exists_sSupIndep_isCompl_sSup_atoms h ⊥
-  ⟨s, s_ind, eq_top_of_isCompl_bot s_top.symm, s_atoms⟩
+theorem exists_sSupIndep_of_sSup_atoms_eq_top (b : α) (h : sSup {a ≤ b | IsAtom a} = b) :
+    ∃ s : Set α, sSupIndep s ∧ sSup s = b ∧ ∀ ⦃a⦄, a ∈ s → IsAtom a :=
+  let ⟨s, s_ind, _, s_atoms⟩ := exists_sSupIndep_isCompl_sSup_atoms ⊥ b bot_le h
+  ⟨s, s_ind, by simpa using s_atoms⟩
 
 @[deprecated (since := "2024-11-24")]
 alias exists_setIndependent_of_sSup_atoms_eq_top := exists_sSupIndep_of_sSup_atoms_eq_top
@@ -652,8 +653,8 @@ alias exists_setIndependent_of_sSup_atoms_eq_top := exists_sSupIndep_of_sSup_ato
 theorem complementedLattice_of_sSup_atoms_eq_top (h : sSup { a : α | IsAtom a } = ⊤) :
     ComplementedLattice α :=
   ⟨fun b =>
-    let ⟨s, _, s_top, _⟩ := exists_sSupIndep_isCompl_sSup_atoms h b
-    ⟨sSup s, s_top⟩⟩
+    let ⟨s, _, hbs_inf, hbs_sup, _⟩ := exists_sSupIndep_isCompl_sSup_atoms b ⊤ le_top (by simpa)
+    ⟨sSup s, hbs_inf, codisjoint_iff.2 hbs_sup⟩⟩
 
 /-- See [Theorem 6.6][calugareanu]. -/
 theorem complementedLattice_of_isAtomistic [IsAtomistic α] : ComplementedLattice α :=

--- a/Mathlib/Order/CompactlyGenerated/Basic.lean
+++ b/Mathlib/Order/CompactlyGenerated/Basic.lean
@@ -641,10 +641,14 @@ theorem exists_sSupIndep_isCompl_sSup_atoms (b c : α) (hbc : b ≤ c)
 @[deprecated (since := "2024-11-24")]
 alias exists_setIndependent_isCompl_sSup_atoms := exists_sSupIndep_isCompl_sSup_atoms
 
-theorem exists_sSupIndep_of_sSup_atoms_eq_top (b : α) (h : sSup {a ≤ b | IsAtom a} = b) :
+theorem exists_sSupIndep_of_sSup_atoms (b : α) (h : sSup {a ≤ b | IsAtom a} = b) :
     ∃ s : Set α, sSupIndep s ∧ sSup s = b ∧ ∀ ⦃a⦄, a ∈ s → IsAtom a :=
   let ⟨s, s_ind, _, s_atoms⟩ := exists_sSupIndep_isCompl_sSup_atoms ⊥ b bot_le h
   ⟨s, s_ind, by simpa using s_atoms⟩
+
+theorem exists_sSupIndep_of_sSup_atoms_eq_top (h : sSup {a : α | IsAtom a} = ⊤) :
+    ∃ s : Set α, sSupIndep s ∧ sSup s = ⊤ ∧ ∀ ⦃a⦄, a ∈ s → IsAtom a :=
+  exists_sSupIndep_of_sSup_atoms ⊤ (by simpa)
 
 @[deprecated (since := "2024-11-24")]
 alias exists_setIndependent_of_sSup_atoms_eq_top := exists_sSupIndep_of_sSup_atoms_eq_top


### PR DESCRIPTION
Prove that any element in a compactly generated modular atomistic lattice (eg the lattice of submodules of a module) can be written as the supremum of independent atoms. We already knew that `⊤` could be decomposed as such, and all this PR is doing is generalising a few intermediate statements.

From PersistentDecomp and Xena


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
