### PR TITLE
[Merged by Bors] - chore(Data/Set): avoid importing algebra in `Data/Set/Countable.lean`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3823,6 +3823,7 @@ import Mathlib.Logic.Embedding.Basic
 import Mathlib.Logic.Embedding.Set
 import Mathlib.Logic.Encodable.Basic
 import Mathlib.Logic.Encodable.Lattice
+import Mathlib.Logic.Encodable.Pi
 import Mathlib.Logic.Equiv.Array
 import Mathlib.Logic.Equiv.Basic
 import Mathlib.Logic.Equiv.Defs

--- a/Mathlib/Analysis/Normed/Module/FiniteDimension.lean
+++ b/Mathlib/Analysis/Normed/Module/FiniteDimension.lean
@@ -10,6 +10,7 @@ import Mathlib.Analysis.Normed.Affine.Isometry
 import Mathlib.Analysis.NormedSpace.OperatorNorm.NormedSpace
 import Mathlib.Analysis.NormedSpace.RieszLemma
 import Mathlib.Analysis.NormedSpace.Pointwise
+import Mathlib.Logic.Encodable.Pi
 import Mathlib.Topology.Algebra.Module.FiniteDimension
 import Mathlib.Topology.Algebra.InfiniteSum.Module
 import Mathlib.Topology.Instances.Matrix

--- a/Mathlib/Computability/Primrec.lean
+++ b/Mathlib/Computability/Primrec.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
 import Mathlib.Algebra.Order.Ring.Nat
-import Mathlib.Logic.Equiv.List
+import Mathlib.Logic.Encodable.Pi
 import Mathlib.Logic.Function.Iterate
 
 /-!

--- a/Mathlib/Data/DFinsupp/Encodable.lean
+++ b/Mathlib/Data/DFinsupp/Encodable.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury Kudryashov
 -/
 import Mathlib.Data.DFinsupp.Defs
-import Mathlib.Logic.Equiv.List
+import Mathlib.Logic.Encodable.Pi
 /-!
 # `Encodable` and `Countable` instances for `Π₀ i, α i`
 

--- a/Mathlib/Data/Finset/Max.lean
+++ b/Mathlib/Data/Finset/Max.lean
@@ -5,13 +5,12 @@ Authors: Mario Carneiro
 -/
 import Mathlib.Data.Finset.Card
 import Mathlib.Data.Finset.Lattice.Fold
-import Mathlib.Data.Finset.Sort
 
 /-!
 # Maximum and minimum of finite sets
 -/
 
-assert_not_exists OrderedCommMonoid MonoidWithZero
+assert_not_exists Monoid OrderedCommMonoid MonoidWithZero
 
 open Function Multiset OrderDual
 
@@ -550,73 +549,5 @@ theorem isGLB_mem [LinearOrder α] {i : α} (s : Finset α) (his : IsGLB (s : Se
 theorem isLUB_mem [LinearOrder α] {i : α} (s : Finset α) (his : IsLUB (s : Set α) i)
     (hs : s.Nonempty) : i ∈ s :=
   @isGLB_mem αᵒᵈ _ i s his hs
-
-section SortLinearOrder
-
-variable [LinearOrder α]
-
-theorem sorted_zero_eq_min'_aux (s : Finset α) (h : 0 < (s.sort (· ≤ ·)).length) (H : s.Nonempty) :
-    (s.sort (· ≤ ·)).get ⟨0, h⟩ = s.min' H := by
-  let l := s.sort (· ≤ ·)
-  apply le_antisymm
-  · have : s.min' H ∈ l := (Finset.mem_sort (α := α) (· ≤ ·)).mpr (s.min'_mem H)
-    obtain ⟨i, hi⟩ : ∃ i, l.get i = s.min' H := List.mem_iff_get.1 this
-    rw [← hi]
-    exact (s.sort_sorted (· ≤ ·)).rel_get_of_le (Nat.zero_le i)
-  · have : l.get ⟨0, h⟩ ∈ s := (Finset.mem_sort (α := α) (· ≤ ·)).1 (List.get_mem l _)
-    exact s.min'_le _ this
-
-theorem sorted_zero_eq_min' {s : Finset α} {h : 0 < (s.sort (· ≤ ·)).length} :
-    (s.sort (· ≤ ·))[0] = s.min' (card_pos.1 <| by rwa [length_sort] at h) :=
-  sorted_zero_eq_min'_aux _ _ _
-
-theorem min'_eq_sorted_zero {s : Finset α} {h : s.Nonempty} :
-    s.min' h = (s.sort (· ≤ ·))[0]'(by rw [length_sort]; exact card_pos.2 h) :=
-  (sorted_zero_eq_min'_aux _ _ _).symm
-
-theorem sorted_last_eq_max'_aux (s : Finset α)
-    (h : (s.sort (· ≤ ·)).length - 1 < (s.sort (· ≤ ·)).length) (H : s.Nonempty) :
-    (s.sort (· ≤ ·))[(s.sort (· ≤ ·)).length - 1] = s.max' H := by
-  let l := s.sort (· ≤ ·)
-  apply le_antisymm
-  · have : l.get ⟨(s.sort (· ≤ ·)).length - 1, h⟩ ∈ s :=
-      (Finset.mem_sort (α := α) (· ≤ ·)).1 (List.get_mem l _)
-    exact s.le_max' _ this
-  · have : s.max' H ∈ l := (Finset.mem_sort (α := α) (· ≤ ·)).mpr (s.max'_mem H)
-    obtain ⟨i, hi⟩ : ∃ i, l.get i = s.max' H := List.mem_iff_get.1 this
-    rw [← hi]
-    exact (s.sort_sorted (· ≤ ·)).rel_get_of_le (Nat.le_sub_one_of_lt i.prop)
-
-theorem sorted_last_eq_max' {s : Finset α}
-    {h : (s.sort (· ≤ ·)).length - 1 < (s.sort (· ≤ ·)).length} :
-    (s.sort (· ≤ ·))[(s.sort (· ≤ ·)).length - 1] =
-      s.max' (by rw [length_sort] at h; exact card_pos.1 (lt_of_le_of_lt bot_le h)) :=
-  sorted_last_eq_max'_aux _ h _
-
-theorem max'_eq_sorted_last {s : Finset α} {h : s.Nonempty} :
-    s.max' h =
-      (s.sort (· ≤ ·))[(s.sort (· ≤ ·)).length - 1]'
-        (by simpa using Nat.sub_lt (card_pos.mpr h) Nat.zero_lt_one) :=
-  (sorted_last_eq_max'_aux _ (by simpa using Nat.sub_lt (card_pos.mpr h) Nat.zero_lt_one) _).symm
-
-/-- The bijection `orderEmbOfFin s h` sends `0` to the minimum of `s`. -/
-theorem orderEmbOfFin_zero {s : Finset α} {k : ℕ} (h : s.card = k) (hz : 0 < k) :
-    orderEmbOfFin s h ⟨0, hz⟩ = s.min' (card_pos.mp (h.symm ▸ hz)) := by
-  simp only [orderEmbOfFin_apply, Fin.getElem_fin, sorted_zero_eq_min']
-
-/-- The bijection `orderEmbOfFin s h` sends `k-1` to the maximum of `s`. -/
-theorem orderEmbOfFin_last {s : Finset α} {k : ℕ} (h : s.card = k) (hz : 0 < k) :
-    orderEmbOfFin s h ⟨k - 1, Nat.sub_lt hz (Nat.succ_pos 0)⟩ =
-      s.max' (card_pos.mp (h.symm ▸ hz)) := by
-  simp [orderEmbOfFin_apply, max'_eq_sorted_last, h]
-
-/-- `orderEmbOfFin {a} h` sends any argument to `a`. -/
-@[simp]
-theorem orderEmbOfFin_singleton (a : α) (i : Fin 1) :
-    orderEmbOfFin {a} (card_singleton a) i = a := by
-  rw [Subsingleton.elim i ⟨0, Nat.zero_lt_one⟩, orderEmbOfFin_zero _ Nat.zero_lt_one,
-    min'_singleton]
-
-end SortLinearOrder
 
 end Finset

--- a/Mathlib/Data/Finset/Max.lean
+++ b/Mathlib/Data/Finset/Max.lean
@@ -5,6 +5,7 @@ Authors: Mario Carneiro
 -/
 import Mathlib.Data.Finset.Card
 import Mathlib.Data.Finset.Lattice.Fold
+import Mathlib.Data.Finset.Sort
 
 /-!
 # Maximum and minimum of finite sets
@@ -549,5 +550,73 @@ theorem isGLB_mem [LinearOrder α] {i : α} (s : Finset α) (his : IsGLB (s : Se
 theorem isLUB_mem [LinearOrder α] {i : α} (s : Finset α) (his : IsLUB (s : Set α) i)
     (hs : s.Nonempty) : i ∈ s :=
   @isGLB_mem αᵒᵈ _ i s his hs
+
+section SortLinearOrder
+
+variable [LinearOrder α]
+
+theorem sorted_zero_eq_min'_aux (s : Finset α) (h : 0 < (s.sort (· ≤ ·)).length) (H : s.Nonempty) :
+    (s.sort (· ≤ ·)).get ⟨0, h⟩ = s.min' H := by
+  let l := s.sort (· ≤ ·)
+  apply le_antisymm
+  · have : s.min' H ∈ l := (Finset.mem_sort (α := α) (· ≤ ·)).mpr (s.min'_mem H)
+    obtain ⟨i, hi⟩ : ∃ i, l.get i = s.min' H := List.mem_iff_get.1 this
+    rw [← hi]
+    exact (s.sort_sorted (· ≤ ·)).rel_get_of_le (Nat.zero_le i)
+  · have : l.get ⟨0, h⟩ ∈ s := (Finset.mem_sort (α := α) (· ≤ ·)).1 (List.get_mem l _)
+    exact s.min'_le _ this
+
+theorem sorted_zero_eq_min' {s : Finset α} {h : 0 < (s.sort (· ≤ ·)).length} :
+    (s.sort (· ≤ ·))[0] = s.min' (card_pos.1 <| by rwa [length_sort] at h) :=
+  sorted_zero_eq_min'_aux _ _ _
+
+theorem min'_eq_sorted_zero {s : Finset α} {h : s.Nonempty} :
+    s.min' h = (s.sort (· ≤ ·))[0]'(by rw [length_sort]; exact card_pos.2 h) :=
+  (sorted_zero_eq_min'_aux _ _ _).symm
+
+theorem sorted_last_eq_max'_aux (s : Finset α)
+    (h : (s.sort (· ≤ ·)).length - 1 < (s.sort (· ≤ ·)).length) (H : s.Nonempty) :
+    (s.sort (· ≤ ·))[(s.sort (· ≤ ·)).length - 1] = s.max' H := by
+  let l := s.sort (· ≤ ·)
+  apply le_antisymm
+  · have : l.get ⟨(s.sort (· ≤ ·)).length - 1, h⟩ ∈ s :=
+      (Finset.mem_sort (α := α) (· ≤ ·)).1 (List.get_mem l _)
+    exact s.le_max' _ this
+  · have : s.max' H ∈ l := (Finset.mem_sort (α := α) (· ≤ ·)).mpr (s.max'_mem H)
+    obtain ⟨i, hi⟩ : ∃ i, l.get i = s.max' H := List.mem_iff_get.1 this
+    rw [← hi]
+    exact (s.sort_sorted (· ≤ ·)).rel_get_of_le (Nat.le_sub_one_of_lt i.prop)
+
+theorem sorted_last_eq_max' {s : Finset α}
+    {h : (s.sort (· ≤ ·)).length - 1 < (s.sort (· ≤ ·)).length} :
+    (s.sort (· ≤ ·))[(s.sort (· ≤ ·)).length - 1] =
+      s.max' (by rw [length_sort] at h; exact card_pos.1 (lt_of_le_of_lt bot_le h)) :=
+  sorted_last_eq_max'_aux _ h _
+
+theorem max'_eq_sorted_last {s : Finset α} {h : s.Nonempty} :
+    s.max' h =
+      (s.sort (· ≤ ·))[(s.sort (· ≤ ·)).length - 1]'
+        (by simpa using Nat.sub_lt (card_pos.mpr h) Nat.zero_lt_one) :=
+  (sorted_last_eq_max'_aux _ (by simpa using Nat.sub_lt (card_pos.mpr h) Nat.zero_lt_one) _).symm
+
+/-- The bijection `orderEmbOfFin s h` sends `0` to the minimum of `s`. -/
+theorem orderEmbOfFin_zero {s : Finset α} {k : ℕ} (h : s.card = k) (hz : 0 < k) :
+    orderEmbOfFin s h ⟨0, hz⟩ = s.min' (card_pos.mp (h.symm ▸ hz)) := by
+  simp only [orderEmbOfFin_apply, Fin.getElem_fin, sorted_zero_eq_min']
+
+/-- The bijection `orderEmbOfFin s h` sends `k-1` to the maximum of `s`. -/
+theorem orderEmbOfFin_last {s : Finset α} {k : ℕ} (h : s.card = k) (hz : 0 < k) :
+    orderEmbOfFin s h ⟨k - 1, Nat.sub_lt hz (Nat.succ_pos 0)⟩ =
+      s.max' (card_pos.mp (h.symm ▸ hz)) := by
+  simp [orderEmbOfFin_apply, max'_eq_sorted_last, h]
+
+/-- `orderEmbOfFin {a} h` sends any argument to `a`. -/
+@[simp]
+theorem orderEmbOfFin_singleton (a : α) (i : Fin 1) :
+    orderEmbOfFin {a} (card_singleton a) i = a := by
+  rw [Subsingleton.elim i ⟨0, Nat.zero_lt_one⟩, orderEmbOfFin_zero _ Nat.zero_lt_one,
+    min'_singleton]
+
+end SortLinearOrder
 
 end Finset

--- a/Mathlib/Data/Finset/Sort.lean
+++ b/Mathlib/Data/Finset/Sort.lean
@@ -3,17 +3,15 @@ Copyright (c) 2017 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
-import Mathlib.Order.RelIso.Set
-import Mathlib.Data.Multiset.Sort
-import Mathlib.Data.List.NodupEquivFin
-import Mathlib.Data.Finset.Max
-import Mathlib.Data.Fintype.Card
 import Mathlib.Data.Fintype.EquivFin
+import Mathlib.Data.Multiset.Sort
+import Mathlib.Order.RelIso.Set
 
 /-!
 # Construct a sorted list from a finset.
 -/
 
+assert_not_exists Monoid
 
 namespace Finset
 
@@ -106,50 +104,6 @@ theorem sort_sorted_lt (s : Finset α) : List.Sorted (· < ·) (sort (· ≤ ·)
 theorem sort_sorted_gt (s : Finset α) : List.Sorted (· > ·) (sort (· ≥ ·) s) :=
   (sort_sorted _ _).gt_of_ge (sort_nodup _ _)
 
-theorem sorted_zero_eq_min'_aux (s : Finset α) (h : 0 < (s.sort (· ≤ ·)).length) (H : s.Nonempty) :
-    (s.sort (· ≤ ·)).get ⟨0, h⟩ = s.min' H := by
-  let l := s.sort (· ≤ ·)
-  apply le_antisymm
-  · have : s.min' H ∈ l := (Finset.mem_sort (α := α) (· ≤ ·)).mpr (s.min'_mem H)
-    obtain ⟨i, hi⟩ : ∃ i, l.get i = s.min' H := List.mem_iff_get.1 this
-    rw [← hi]
-    exact (s.sort_sorted (· ≤ ·)).rel_get_of_le (Nat.zero_le i)
-  · have : l.get ⟨0, h⟩ ∈ s := (Finset.mem_sort (α := α) (· ≤ ·)).1 (List.get_mem l _)
-    exact s.min'_le _ this
-
-theorem sorted_zero_eq_min' {s : Finset α} {h : 0 < (s.sort (· ≤ ·)).length} :
-    (s.sort (· ≤ ·))[0] = s.min' (card_pos.1 <| by rwa [length_sort] at h) :=
-  sorted_zero_eq_min'_aux _ _ _
-
-theorem min'_eq_sorted_zero {s : Finset α} {h : s.Nonempty} :
-    s.min' h = (s.sort (· ≤ ·))[0]'(by rw [length_sort]; exact card_pos.2 h) :=
-  (sorted_zero_eq_min'_aux _ _ _).symm
-
-theorem sorted_last_eq_max'_aux (s : Finset α)
-    (h : (s.sort (· ≤ ·)).length - 1 < (s.sort (· ≤ ·)).length) (H : s.Nonempty) :
-    (s.sort (· ≤ ·))[(s.sort (· ≤ ·)).length - 1] = s.max' H := by
-  let l := s.sort (· ≤ ·)
-  apply le_antisymm
-  · have : l.get ⟨(s.sort (· ≤ ·)).length - 1, h⟩ ∈ s :=
-      (Finset.mem_sort (α := α) (· ≤ ·)).1 (List.get_mem l _)
-    exact s.le_max' _ this
-  · have : s.max' H ∈ l := (Finset.mem_sort (α := α) (· ≤ ·)).mpr (s.max'_mem H)
-    obtain ⟨i, hi⟩ : ∃ i, l.get i = s.max' H := List.mem_iff_get.1 this
-    rw [← hi]
-    exact (s.sort_sorted (· ≤ ·)).rel_get_of_le (Nat.le_sub_one_of_lt i.prop)
-
-theorem sorted_last_eq_max' {s : Finset α}
-    {h : (s.sort (· ≤ ·)).length - 1 < (s.sort (· ≤ ·)).length} :
-    (s.sort (· ≤ ·))[(s.sort (· ≤ ·)).length - 1] =
-      s.max' (by rw [length_sort] at h; exact card_pos.1 (lt_of_le_of_lt bot_le h)) :=
-  sorted_last_eq_max'_aux _ h _
-
-theorem max'_eq_sorted_last {s : Finset α} {h : s.Nonempty} :
-    s.max' h =
-      (s.sort (· ≤ ·))[(s.sort (· ≤ ·)).length - 1]'
-        (by simpa using Nat.sub_lt (card_pos.mpr h) Nat.zero_lt_one) :=
-  (sorted_last_eq_max'_aux _ (by simpa using Nat.sub_lt (card_pos.mpr h) Nat.zero_lt_one) _).symm
-
 /-- Given a finset `s` of cardinality `k` in a linear order `α`, the map `orderIsoOfFin s h`
 is the increasing bijection between `Fin k` and `s` as an `OrderIso`. Here, `h` is a proof that
 the cardinality of `s` is `k`. We use this instead of an iso `Fin s.card ≃o s` to avoid
@@ -190,24 +144,6 @@ theorem range_orderEmbOfFin (s : Finset α) {k : ℕ} (h : s.card = k) :
   RelEmbedding.coe_trans, Set.image_univ, Finset.orderEmbOfFin, RelIso.range_eq,
     OrderEmbedding.subtype_apply, OrderIso.coe_toOrderEmbedding, eq_self_iff_true,
     Subtype.range_coe_subtype, Finset.setOf_mem, Finset.coe_inj]
-
-/-- The bijection `orderEmbOfFin s h` sends `0` to the minimum of `s`. -/
-theorem orderEmbOfFin_zero {s : Finset α} {k : ℕ} (h : s.card = k) (hz : 0 < k) :
-    orderEmbOfFin s h ⟨0, hz⟩ = s.min' (card_pos.mp (h.symm ▸ hz)) := by
-  simp only [orderEmbOfFin_apply, Fin.getElem_fin, sorted_zero_eq_min']
-
-/-- The bijection `orderEmbOfFin s h` sends `k-1` to the maximum of `s`. -/
-theorem orderEmbOfFin_last {s : Finset α} {k : ℕ} (h : s.card = k) (hz : 0 < k) :
-    orderEmbOfFin s h ⟨k - 1, Nat.sub_lt hz (Nat.succ_pos 0)⟩ =
-      s.max' (card_pos.mp (h.symm ▸ hz)) := by
-  simp [orderEmbOfFin_apply, max'_eq_sorted_last, h]
-
-/-- `orderEmbOfFin {a} h` sends any argument to `a`. -/
-@[simp]
-theorem orderEmbOfFin_singleton (a : α) (i : Fin 1) :
-    orderEmbOfFin {a} (card_singleton a) i = a := by
-  rw [Subsingleton.elim i ⟨0, Nat.zero_lt_one⟩, orderEmbOfFin_zero _ Nat.zero_lt_one,
-    min'_singleton]
 
 /-- Any increasing map `f` from `Fin k` to a finset of cardinality `k` has to coincide with
 the increasing bijection `orderEmbOfFin s h`. -/

--- a/Mathlib/Data/Finset/Sort.lean
+++ b/Mathlib/Data/Finset/Sort.lean
@@ -5,7 +5,6 @@ Authors: Mario Carneiro
 -/
 import Mathlib.Data.Finset.Max
 import Mathlib.Data.Fintype.EquivFin
-import Mathlib.Data.List.NodupEquivFin
 import Mathlib.Data.Multiset.Sort
 import Mathlib.Order.RelIso.Set
 

--- a/Mathlib/Data/Finset/Sort.lean
+++ b/Mathlib/Data/Finset/Sort.lean
@@ -3,15 +3,15 @@ Copyright (c) 2017 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
+import Mathlib.Data.Finset.Max
 import Mathlib.Data.Fintype.EquivFin
+import Mathlib.Data.List.NodupEquivFin
 import Mathlib.Data.Multiset.Sort
 import Mathlib.Order.RelIso.Set
 
 /-!
 # Construct a sorted list from a finset.
 -/
-
-assert_not_exists Monoid
 
 namespace Finset
 
@@ -104,6 +104,50 @@ theorem sort_sorted_lt (s : Finset α) : List.Sorted (· < ·) (sort (· ≤ ·)
 theorem sort_sorted_gt (s : Finset α) : List.Sorted (· > ·) (sort (· ≥ ·) s) :=
   (sort_sorted _ _).gt_of_ge (sort_nodup _ _)
 
+theorem sorted_zero_eq_min'_aux (s : Finset α) (h : 0 < (s.sort (· ≤ ·)).length) (H : s.Nonempty) :
+    (s.sort (· ≤ ·)).get ⟨0, h⟩ = s.min' H := by
+  let l := s.sort (· ≤ ·)
+  apply le_antisymm
+  · have : s.min' H ∈ l := (Finset.mem_sort (α := α) (· ≤ ·)).mpr (s.min'_mem H)
+    obtain ⟨i, hi⟩ : ∃ i, l.get i = s.min' H := List.mem_iff_get.1 this
+    rw [← hi]
+    exact (s.sort_sorted (· ≤ ·)).rel_get_of_le (Nat.zero_le i)
+  · have : l.get ⟨0, h⟩ ∈ s := (Finset.mem_sort (α := α) (· ≤ ·)).1 (List.get_mem l _)
+    exact s.min'_le _ this
+
+theorem sorted_zero_eq_min' {s : Finset α} {h : 0 < (s.sort (· ≤ ·)).length} :
+    (s.sort (· ≤ ·))[0] = s.min' (card_pos.1 <| by rwa [length_sort] at h) :=
+  sorted_zero_eq_min'_aux _ _ _
+
+theorem min'_eq_sorted_zero {s : Finset α} {h : s.Nonempty} :
+    s.min' h = (s.sort (· ≤ ·))[0]'(by rw [length_sort]; exact card_pos.2 h) :=
+  (sorted_zero_eq_min'_aux _ _ _).symm
+
+theorem sorted_last_eq_max'_aux (s : Finset α)
+    (h : (s.sort (· ≤ ·)).length - 1 < (s.sort (· ≤ ·)).length) (H : s.Nonempty) :
+    (s.sort (· ≤ ·))[(s.sort (· ≤ ·)).length - 1] = s.max' H := by
+  let l := s.sort (· ≤ ·)
+  apply le_antisymm
+  · have : l.get ⟨(s.sort (· ≤ ·)).length - 1, h⟩ ∈ s :=
+      (Finset.mem_sort (α := α) (· ≤ ·)).1 (List.get_mem l _)
+    exact s.le_max' _ this
+  · have : s.max' H ∈ l := (Finset.mem_sort (α := α) (· ≤ ·)).mpr (s.max'_mem H)
+    obtain ⟨i, hi⟩ : ∃ i, l.get i = s.max' H := List.mem_iff_get.1 this
+    rw [← hi]
+    exact (s.sort_sorted (· ≤ ·)).rel_get_of_le (Nat.le_sub_one_of_lt i.prop)
+
+theorem sorted_last_eq_max' {s : Finset α}
+    {h : (s.sort (· ≤ ·)).length - 1 < (s.sort (· ≤ ·)).length} :
+    (s.sort (· ≤ ·))[(s.sort (· ≤ ·)).length - 1] =
+      s.max' (by rw [length_sort] at h; exact card_pos.1 (lt_of_le_of_lt bot_le h)) :=
+  sorted_last_eq_max'_aux _ h _
+
+theorem max'_eq_sorted_last {s : Finset α} {h : s.Nonempty} :
+    s.max' h =
+      (s.sort (· ≤ ·))[(s.sort (· ≤ ·)).length - 1]'
+        (by simpa using Nat.sub_lt (card_pos.mpr h) Nat.zero_lt_one) :=
+  (sorted_last_eq_max'_aux _ (by simpa using Nat.sub_lt (card_pos.mpr h) Nat.zero_lt_one) _).symm
+
 /-- Given a finset `s` of cardinality `k` in a linear order `α`, the map `orderIsoOfFin s h`
 is the increasing bijection between `Fin k` and `s` as an `OrderIso`. Here, `h` is a proof that
 the cardinality of `s` is `k`. We use this instead of an iso `Fin s.card ≃o s` to avoid
@@ -144,6 +188,24 @@ theorem range_orderEmbOfFin (s : Finset α) {k : ℕ} (h : s.card = k) :
   RelEmbedding.coe_trans, Set.image_univ, Finset.orderEmbOfFin, RelIso.range_eq,
     OrderEmbedding.subtype_apply, OrderIso.coe_toOrderEmbedding, eq_self_iff_true,
     Subtype.range_coe_subtype, Finset.setOf_mem, Finset.coe_inj]
+
+/-- The bijection `orderEmbOfFin s h` sends `0` to the minimum of `s`. -/
+theorem orderEmbOfFin_zero {s : Finset α} {k : ℕ} (h : s.card = k) (hz : 0 < k) :
+    orderEmbOfFin s h ⟨0, hz⟩ = s.min' (card_pos.mp (h.symm ▸ hz)) := by
+  simp only [orderEmbOfFin_apply, Fin.getElem_fin, sorted_zero_eq_min']
+
+/-- The bijection `orderEmbOfFin s h` sends `k-1` to the maximum of `s`. -/
+theorem orderEmbOfFin_last {s : Finset α} {k : ℕ} (h : s.card = k) (hz : 0 < k) :
+    orderEmbOfFin s h ⟨k - 1, Nat.sub_lt hz (Nat.succ_pos 0)⟩ =
+      s.max' (card_pos.mp (h.symm ▸ hz)) := by
+  simp [orderEmbOfFin_apply, max'_eq_sorted_last, h]
+
+/-- `orderEmbOfFin {a} h` sends any argument to `a`. -/
+@[simp]
+theorem orderEmbOfFin_singleton (a : α) (i : Fin 1) :
+    orderEmbOfFin {a} (card_singleton a) i = a := by
+  rw [Subsingleton.elim i ⟨0, Nat.zero_lt_one⟩, orderEmbOfFin_zero _ Nat.zero_lt_one,
+    min'_singleton]
 
 /-- Any increasing map `f` from `Fin k` to a finset of cardinality `k` has to coincide with
 the increasing bijection `orderEmbOfFin s h`. -/

--- a/Mathlib/Data/Set/Countable.lean
+++ b/Mathlib/Data/Set/Countable.lean
@@ -22,6 +22,8 @@ For a noncomputable conversion to `Encodable s`, use `Set.Countable.nonempty_enc
 sets, countable set
 -/
 
+assert_not_exists Monoid
+
 noncomputable section
 
 open Function Set Encodable

--- a/Mathlib/Data/W/Basic.lean
+++ b/Mathlib/Data/W/Basic.lean
@@ -3,7 +3,8 @@ Copyright (c) 2019 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad
 -/
-import Mathlib.Logic.Equiv.List
+import Mathlib.Data.Finset.Lattice.Fold
+import Mathlib.Logic.Encodable.Pi
 
 /-!
 # W types

--- a/Mathlib/Logic/Encodable/Pi.lean
+++ b/Mathlib/Logic/Encodable/Pi.lean
@@ -1,0 +1,65 @@
+/-
+Copyright (c) 2018 Mario Carneiro. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mario Carneiro
+-/
+import Mathlib.Data.Vector.Basic
+import Mathlib.Logic.Equiv.List
+
+/-!
+# Encodability of Pi types
+
+This file provides instances of `Encodable` for types of vectors and (dependent) functions:
+
+* `Encodable.List.Vector.encodable`: vectors of length `n` (represented by lists) are encodable
+* `Encodable.finArrow`: vectors of length `n` (represented by `Fin`-indexed functions) are encodable
+* `Encodable.fintypeArrow`, `Encodable.fintypePi`: (dependent) functions with
+  finite domain and countable codomain are encodable
+-/
+
+open List (Vector)
+open Nat List
+
+namespace Encodable
+
+variable {α : Type*}
+
+/-- If `α` is encodable, then so is `Vector α n`. -/
+instance List.Vector.encodable [Encodable α] {n} : Encodable (List.Vector α n) :=
+  Subtype.encodable
+
+/-- If `α` is countable, then so is `Vector α n`. -/
+instance List.Vector.countable [Countable α] {n} : Countable (List.Vector α n) :=
+  Subtype.countable
+
+/-- If `α` is encodable, then so is `Fin n → α`. -/
+instance finArrow [Encodable α] {n} : Encodable (Fin n → α) :=
+  ofEquiv _ (Equiv.vectorEquivFin _ _).symm
+
+instance finPi (n) (π : Fin n → Type*) [∀ i, Encodable (π i)] : Encodable (∀ i, π i) :=
+  ofEquiv _ (Equiv.piEquivSubtypeSigma (Fin n) π)
+
+-- TODO: Unify with `fintypePi` and find a better name
+/-- When `α` is finite and `β` is encodable, `α → β` is encodable too. Because the encoding is not
+unique, we wrap it in `Trunc` to preserve computability. -/
+def fintypeArrow (α : Type*) (β : Type*) [DecidableEq α] [Fintype α] [Encodable β] :
+    Trunc (Encodable (α → β)) :=
+  (Fintype.truncEquivFin α).map fun f =>
+    Encodable.ofEquiv (Fin (Fintype.card α) → β) <| Equiv.arrowCongr f (Equiv.refl _)
+
+/-- When `α` is finite and all `π a` are encodable, `Π a, π a` is encodable too. Because the
+encoding is not unique, we wrap it in `Trunc` to preserve computability. -/
+def fintypePi (α : Type*) (π : α → Type*) [DecidableEq α] [Fintype α] [∀ a, Encodable (π a)] :
+    Trunc (Encodable (∀ a, π a)) :=
+  (Fintype.truncEncodable α).bind fun a =>
+    (@fintypeArrow α (Σa, π a) _ _ (@Sigma.encodable _ _ a _)).bind fun f =>
+      Trunc.mk <|
+        @Encodable.ofEquiv _ _ (@Subtype.encodable _ _ f _)
+          (Equiv.piEquivSubtypeSigma α π)
+
+/-- If `α` and `β` are encodable and `α` is a fintype, then `α → β` is encodable as well. -/
+instance fintypeArrowOfEncodable {α β : Type*} [Encodable α] [Fintype α] [Encodable β] :
+    Encodable (α → β) :=
+  ofEquiv (Fin (Fintype.card α) → β) <| Equiv.arrowCongr fintypeEquivFin (Equiv.refl _)
+
+end Encodable

--- a/Mathlib/Logic/Equiv/List.lean
+++ b/Mathlib/Logic/Equiv/List.lean
@@ -3,7 +3,6 @@ Copyright (c) 2018 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
-import Mathlib.Data.List.Chain
 import Mathlib.Data.Finset.Sort
 import Mathlib.Data.List.Chain
 import Mathlib.Logic.Denumerable

--- a/Mathlib/Logic/Equiv/List.lean
+++ b/Mathlib/Logic/Equiv/List.lean
@@ -5,7 +5,7 @@ Authors: Mario Carneiro
 -/
 import Mathlib.Data.List.Chain
 import Mathlib.Data.Finset.Sort
-import Mathlib.Data.Vector.Basic
+import Mathlib.Data.List.Chain
 import Mathlib.Logic.Denumerable
 
 /-!
@@ -15,7 +15,9 @@ This file defines some additional constructive equivalences using `Encodable` an
 function on `ℕ`.
 -/
 
-open List (Vector)
+assert_not_exists Monoid
+
+open List
 open Nat List
 
 namespace Encodable
@@ -127,21 +129,6 @@ This can be locally made into an instance with `attribute [local instance] Finty
 noncomputable def _root_.Fintype.toEncodable (α : Type*) [Fintype α] : Encodable α := by
   classical exact (Fintype.truncEncodable α).out
 
-/-- If `α` is encodable, then so is `Vector α n`. -/
-instance List.Vector.encodable [Encodable α] {n} : Encodable (List.Vector α n) :=
-  Subtype.encodable
-
-/-- If `α` is countable, then so is `Vector α n`. -/
-instance List.Vector.countable [Countable α] {n} : Countable (List.Vector α n) :=
-  Subtype.countable
-
-/-- If `α` is encodable, then so is `Fin n → α`. -/
-instance finArrow [Encodable α] {n} : Encodable (Fin n → α) :=
-  ofEquiv _ (Equiv.vectorEquivFin _ _).symm
-
-instance finPi (n) (π : Fin n → Type*) [∀ i, Encodable (π i)] : Encodable (∀ i, π i) :=
-  ofEquiv _ (Equiv.piEquivSubtypeSigma (Fin n) π)
-
 /-- If `α` is encodable, then so is `Finset α`. -/
 instance _root_.Finset.encodable [Encodable α] : Encodable (Finset α) :=
   haveI := decidableEqOfEncodable α
@@ -151,24 +138,6 @@ instance _root_.Finset.encodable [Encodable α] : Encodable (Finset α) :=
 /-- If `α` is countable, then so is `Finset α`. -/
 instance _root_.Finset.countable [Countable α] : Countable (Finset α) :=
   Finset.val_injective.countable
-
--- TODO: Unify with `fintypePi` and find a better name
-/-- When `α` is finite and `β` is encodable, `α → β` is encodable too. Because the encoding is not
-unique, we wrap it in `Trunc` to preserve computability. -/
-def fintypeArrow (α : Type*) (β : Type*) [DecidableEq α] [Fintype α] [Encodable β] :
-    Trunc (Encodable (α → β)) :=
-  (Fintype.truncEquivFin α).map fun f =>
-    Encodable.ofEquiv (Fin (Fintype.card α) → β) <| Equiv.arrowCongr f (Equiv.refl _)
-
-/-- When `α` is finite and all `π a` are encodable, `Π a, π a` is encodable too. Because the
-encoding is not unique, we wrap it in `Trunc` to preserve computability. -/
-def fintypePi (α : Type*) (π : α → Type*) [DecidableEq α] [Fintype α] [∀ a, Encodable (π a)] :
-    Trunc (Encodable (∀ a, π a)) :=
-  (Fintype.truncEncodable α).bind fun a =>
-    (@fintypeArrow α (Σa, π a) _ _ (@Sigma.encodable _ _ a _)).bind fun f =>
-      Trunc.mk <|
-        @Encodable.ofEquiv _ _ (@Subtype.encodable _ _ f _)
-          (Equiv.piEquivSubtypeSigma α π)
 
 /-- The elements of a `Fintype` as a sorted list. -/
 def sortedUniv (α) [Fintype α] [Encodable α] : List α :=
@@ -197,11 +166,6 @@ def fintypeEquivFin {α} [Fintype α] [Encodable α] : α ≃ Fin (Fintype.card 
   -- Porting note: used the `trans` tactic
   ((sortedUniv_nodup α).getEquivOfForallMemList _ mem_sortedUniv).symm.trans <|
     Equiv.cast (congr_arg _ (length_sortedUniv α))
-
-/-- If `α` and `β` are encodable and `α` is a fintype, then `α → β` is encodable as well. -/
-instance fintypeArrowOfEncodable {α β : Type*} [Encodable α] [Fintype α] [Encodable β] :
-    Encodable (α → β) :=
-  ofEquiv (Fin (Fintype.card α) → β) <| Equiv.arrowCongr fintypeEquivFin (Equiv.refl _)
 
 end Encodable
 

--- a/Mathlib/MeasureTheory/Constructions/Pi.lean
+++ b/Mathlib/MeasureTheory/Constructions/Pi.lean
@@ -3,6 +3,7 @@ Copyright (c) 2020 Floris van Doorn. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Floris van Doorn
 -/
+import Mathlib.Logic.Encodable.Pi
 import Mathlib.MeasureTheory.Group.Measure
 import Mathlib.MeasureTheory.MeasurableSpace.Pi
 import Mathlib.MeasureTheory.Measure.Prod

--- a/Mathlib/Topology/MetricSpace/GromovHausdorff.lean
+++ b/Mathlib/Topology/MetricSpace/GromovHausdorff.lean
@@ -3,6 +3,7 @@ Copyright (c) 2019 Sébastien Gouëzel. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sébastien Gouëzel
 -/
+import Mathlib.Logic.Encodable.Pi
 import Mathlib.SetTheory.Cardinal.Basic
 import Mathlib.Topology.MetricSpace.Closeds
 import Mathlib.Topology.MetricSpace.Completion


### PR DESCRIPTION
By splitting off `Encodable` instances for vectors / Pi types, we can avoid importing `Monoid` in `Data/Set/Countable.lean`.

An alternative approach is to redo the proofs in `Logic.Encodable.Pi` to reduce the dependencies. Looking at the dependency graph for `MeasureTheory.MeasureSpace.Defs` this whole swath of files is unused, so we might as well move them out to skip them all.

---

- [x] depends on: #21870
- [x] depends on: #21883

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
