### PR TITLE
[Merged by Bors] - chore(Tactic/Linter/TextBased): update module doc-string

### DIFF
--- a/Mathlib/Tactic/Linter/TextBased.lean
+++ b/Mathlib/Tactic/Linter/TextBased.lean
@@ -16,7 +16,7 @@ In practice, all such linters check for code style issues.
 Currently, this file contains linters checking
 - if the string "adaptation note" is used instead of the command #adaptation_note,
 - for lines with windows line endings,
-- for lines containing trailing whitespace
+- for lines containing trailing whitespace.
 
 For historic reasons, some further such check checks are written in a Python script `lint-style.py`:
 these are gradually being rewritten in Lean.

--- a/Mathlib/Tactic/Linter/TextBased.lean
+++ b/Mathlib/Tactic/Linter/TextBased.lean
@@ -13,24 +13,16 @@ import Mathlib.Data.Nat.Notation
 This file defines various mathlib linters which are based on reading the source code only.
 In practice, all such linters check for code style issues.
 
-For now, this only contains linters checking
-- that the copyright header and authors line are correctly formatted
-- existence of module docstrings (in the right place)
-- for certain disallowed imports
-- if the string "adaptation note" is used instead of the command #adaptation_note
-- files are at most 1500 lines long (unless specifically allowed).
+Currently, this file contains linters checking
+- if the string "adaptation note" is used instead of the command #adaptation_note,
+- for lines with windows line endings,
+- for lines containing trailing whitespace
 
-For historic reasons, some of these checks are still written in a Python script `lint-style.py`:
+For historic reasons, some further such check checks are written in a Python script `lint-style.py`:
 these are gradually being rewritten in Lean.
 
-This linter maintains a list of exceptions, for legacy reasons.
-Ideally, the length of the list of exceptions tends to 0.
-
-The `longFile` and the `longLine` *syntax* linter take care of flagging lines that exceed the
-100 character limit and files that exceed the 1500 line limit.
-The text-based versions of this file are still used for the files where the linter is not imported.
-This means that the exceptions for the text-based linters are shorter, as they do not need to
-include those handled with `set_option linter.style.longFile x`/`set_option linter.longLine false`.
+This linter has a file for style exceptions (to avoid false positives in the implementation),
+or for downstream projects to allow a gradual adoption of this linter.
 
 An executable running all these linters is defined in `scripts/lint-style.lean`.
 -/


### PR DESCRIPTION
Various past PRs ported linters, but forgot to update the module doc-string.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
