### PR TITLE
[Merged by Bors] - chore(Matroid): add 'Is' to predicate names

### DIFF
--- a/Mathlib/Data/Matroid/Basic.lean
+++ b/Mathlib/Data/Matroid/Basic.lean
@@ -808,11 +808,15 @@ section IsBasis
 def IsBasis (M : Matroid α) (I X : Set α) : Prop :=
   Maximal (fun A ↦ M.Indep A ∧ A ⊆ X) I ∧ X ⊆ M.E
 
+@[deprecated (since := "2025-02-14")] alias Basis := IsBasis
+
 /-- `Matroid.IsBasis' I X` is the same as `Matroid.IsBasis I X`,
 without the requirement that `X ⊆ M.E`. This is convenient for some
 API building, especially when working with rank and closure. -/
 def IsBasis' (M : Matroid α) (I X : Set α) : Prop :=
   Maximal (fun A ↦ M.Indep A ∧ A ⊆ X) I
+
+@[deprecated (since := "2025-02-14")] alias Basis' := IsBasis'
 
 variable {B I J X Y : Set α} {e : α}
 

--- a/Mathlib/Data/Matroid/Basic.lean
+++ b/Mathlib/Data/Matroid/Basic.lean
@@ -32,7 +32,7 @@ basis of a set `X` (a maximal independent subset of `X`).
 Given `M : Matroid α` ...
 
 * `M.E` denotes the ground set of `M`, which has type `Set α`
-* For `B : Set α`, `M.Base B` means that `B` is a base of `M`.
+* For `B : Set α`, `M.IsBase B` means that `B` is a base of `M`.
 * For `I : Set α`, `M.Indep I` means that `I` is independent in `M`
     (that is, `I` is contained in a base of `M`).
 * For `D : Set α`, `M.Dep D` means that `D` is contained in the ground set of `M`
@@ -146,11 +146,11 @@ There are a few design decisions worth discussing.
   a set `X ⊆ M.E` *within* the ground set, giving `M.E \ X`.
   For this reason, we use the term `compl` in theorem names to refer to taking a set difference
   with respect to the ground set, rather than a complement within a type. The lemma
-  `compl_base_dual` is one of the many examples of this.
+  `compl_isBase_dual` is one of the many examples of this.
 
   Finally, in theorem names, matroid predicates that apply to sets
   (such as `Base`, `Indep`, `Basis`) are typically used as suffixes rather than prefixes.
-  For instance, we have `ground_indep_iff_base` rather than `indep_ground_iff_base`.
+  For instance, we have `ground_indep_iff_isBase` rather than `indep_ground_iff_isBase`.
 
 ## References
 
@@ -195,21 +195,21 @@ structure Matroid (α : Type _) where
   /-- `M` has a ground set `E`. -/
   (E : Set α)
   /-- `M` has a predicate `Base` defining its bases. -/
-  (Base : Set α → Prop)
+  (IsBase : Set α → Prop)
   /-- `M` has a predicate `Indep` defining its independent sets. -/
   (Indep : Set α → Prop)
   /-- The `Indep`endent sets are those contained in `Base`s. -/
-  (indep_iff' : ∀ ⦃I⦄, Indep I ↔ ∃ B, Base B ∧ I ⊆ B)
+  (indep_iff' : ∀ ⦃I⦄, Indep I ↔ ∃ B, IsBase B ∧ I ⊆ B)
   /-- There is at least one `Base`. -/
-  (exists_base : ∃ B, Base B)
+  (exists_isBase : ∃ B, IsBase B)
   /-- For any bases `B`, `B'` and `e ∈ B \ B'`, there is some `f ∈ B' \ B` for which `B-e+f`
     is a base. -/
-  (base_exchange : Matroid.ExchangeProperty Base)
+  (isBase_exchange : Matroid.ExchangeProperty IsBase)
   /-- Every independent subset `I` of a set `X` for is contained in a maximal independent
     subset of `X`. -/
   (maximality : ∀ X, X ⊆ E → Matroid.ExistsMaximalSubsetProperty Indep X)
   /-- Every base is contained in the ground set. -/
-  (subset_ground : ∀ B, Base B → B ⊆ E)
+  (subset_ground : ∀ B, IsBase B → B ⊆ E)
 
 attribute [local ext] Matroid
 
@@ -217,8 +217,10 @@ namespace Matroid
 
 variable {α : Type*} {M : Matroid α}
 
-instance (M : Matroid α) : Nonempty {B // M.Base B} :=
-  nonempty_subtype.2 M.exists_base
+@[deprecated (since := "2025-02-14")] alias Base := IsBase
+
+instance (M : Matroid α) : Nonempty {B // M.IsBase B} :=
+  nonempty_subtype.2 M.exists_isBase
 
 /-- Typeclass for a matroid having finite ground set. Just a wrapper for `M.E.Finite`-/
 @[mk_iff] protected class Finite (M : Matroid α) : Prop where
@@ -251,31 +253,31 @@ instance finite_of_finite [Finite α] {M : Matroid α} : M.Finite :=
 /-- A `RankFinite` matroid is one whose bases are finite -/
 @[mk_iff] class RankFinite (M : Matroid α) : Prop where
   /-- There is a finite base -/
-  exists_finite_base : ∃ B, M.Base B ∧ B.Finite
+  exists_finite_isBase : ∃ B, M.IsBase B ∧ B.Finite
 
 @[deprecated (since := "2025-02-09")] alias FiniteRk := RankFinite
 
 instance rankFinite_of_finite (M : Matroid α) [M.Finite] : RankFinite M :=
-  ⟨M.exists_base.imp (fun B hB ↦ ⟨hB, M.set_finite B (M.subset_ground _ hB)⟩)⟩
+  ⟨M.exists_isBase.imp (fun B hB ↦ ⟨hB, M.set_finite B (M.subset_ground _ hB)⟩)⟩
 
 /-- An `RankInfinite` matroid is one whose bases are infinite. -/
 @[mk_iff] class RankInfinite (M : Matroid α) : Prop where
   /-- There is an infinite base -/
-  exists_infinite_base : ∃ B, M.Base B ∧ B.Infinite
+  exists_infinite_isBase : ∃ B, M.IsBase B ∧ B.Infinite
 
 @[deprecated (since := "2025-02-09")] alias InfiniteRk := RankInfinite
 
 /-- A `RankPos` matroid is one whose bases are nonempty. -/
 @[mk_iff] class RankPos (M : Matroid α) : Prop where
   /-- The empty set isn't a base -/
-  empty_not_base : ¬M.Base ∅
+  empty_not_isBase : ¬M.IsBase ∅
 
 @[deprecated (since := "2025-02-09")] alias RkPos := RankPos
 
 instance rankPos_nonempty {M : Matroid α} [M.RankPos] : M.Nonempty := by
-  obtain ⟨B, hB⟩ := M.exists_base
+  obtain ⟨B, hB⟩ := M.exists_isBase
   obtain rfl | ⟨e, heB⟩ := B.eq_empty_or_nonempty
-  · exact False.elim <| RankPos.empty_not_base hB
+  · exact False.elim <| RankPos.empty_not_isBase hB
   exact ⟨e, M.subset_ground B hB heB ⟩
 
 @[deprecated (since := "2025-01-20")] alias rkPos_iff_empty_not_base := rankPos_iff
@@ -283,16 +285,16 @@ instance rankPos_nonempty {M : Matroid α} [M.RankPos] : M.Nonempty := by
 section exchange
 namespace ExchangeProperty
 
-variable {Base : Set α → Prop} {B B' : Set α}
+variable {IsBase : Set α → Prop} {B B' : Set α}
 
 /-- A family of sets with the exchange property is an antichain. -/
-theorem antichain (exch : ExchangeProperty Base) (hB : Base B) (hB' : Base B') (h : B ⊆ B') :
+theorem antichain (exch : ExchangeProperty IsBase) (hB : IsBase B) (hB' : IsBase B') (h : B ⊆ B') :
     B = B' :=
   h.antisymm (fun x hx ↦ by_contra
     (fun hxB ↦ let ⟨_, hy, _⟩ := exch B' B hB' hB x ⟨hx, hxB⟩; hy.2 <| h hy.1))
 
 theorem encard_diff_le_aux {B₁ B₂ : Set α}
-    (exch : ExchangeProperty Base) (hB₁ : Base B₁) (hB₂ : Base B₂) :
+    (exch : ExchangeProperty IsBase) (hB₁ : IsBase B₁) (hB₂ : IsBase B₂) :
     (B₁ \ B₂).encard ≤ (B₂ \ B₁).encard := by
   obtain (he | hinf | ⟨e, he, hcard⟩) :=
     (B₂ \ B₁).eq_empty_or_encard_eq_top_or_encard_diff_singleton_lt
@@ -316,13 +318,13 @@ variable {B₁ B₂ : Set α}
 
 /-- For any two sets `B₁`, `B₂` in a family with the exchange property, the differences `B₁ \ B₂`
 and `B₂ \ B₁` have the same `ℕ∞`-cardinality. -/
-theorem encard_diff_eq (exch : ExchangeProperty Base) (hB₁ : Base B₁) (hB₂ : Base B₂) :
+theorem encard_diff_eq (exch : ExchangeProperty IsBase) (hB₁ : IsBase B₁) (hB₂ : IsBase B₂) :
     (B₁ \ B₂).encard = (B₂ \ B₁).encard :=
   (encard_diff_le_aux exch hB₁ hB₂).antisymm (encard_diff_le_aux exch hB₂ hB₁)
 
 /-- Any two sets `B₁`, `B₂` in a family with the exchange property have the same
 `ℕ∞`-cardinality. -/
-theorem encard_base_eq (exch : ExchangeProperty Base) (hB₁ : Base B₁) (hB₂ : Base B₂) :
+theorem encard_base_eq (exch : ExchangeProperty IsBase) (hB₁ : IsBase B₁) (hB₂ : IsBase B₂) :
     B₁.encard = B₂.encard := by
   rw [← encard_diff_add_encard_inter B₁ B₂, exch.encard_diff_eq hB₁ hB₂, inter_comm,
     encard_diff_add_encard_inter]
@@ -386,120 +388,122 @@ attribute [aesop safe (rule_sets := [Matroid])] empty_subset union_subset iUnion
 
 end aesop
 
-section Base
+section IsBase
 
 variable {B B₁ B₂ : Set α}
 
 @[aesop unsafe 10% (rule_sets := [Matroid])]
-theorem Base.subset_ground (hB : M.Base B) : B ⊆ M.E :=
+theorem IsBase.subset_ground (hB : M.IsBase B) : B ⊆ M.E :=
   M.subset_ground B hB
 
-theorem Base.exchange {e : α} (hB₁ : M.Base B₁) (hB₂ : M.Base B₂) (hx : e ∈ B₁ \ B₂) :
-    ∃ y ∈ B₂ \ B₁, M.Base (insert y (B₁ \ {e}))  :=
-  M.base_exchange B₁ B₂ hB₁ hB₂ _ hx
+theorem IsBase.exchange {e : α} (hB₁ : M.IsBase B₁) (hB₂ : M.IsBase B₂) (hx : e ∈ B₁ \ B₂) :
+    ∃ y ∈ B₂ \ B₁, M.IsBase (insert y (B₁ \ {e}))  :=
+  M.isBase_exchange B₁ B₂ hB₁ hB₂ _ hx
 
-theorem Base.exchange_mem {e : α}
-    (hB₁ : M.Base B₁) (hB₂ : M.Base B₂) (hxB₁ : e ∈ B₁) (hxB₂ : e ∉ B₂) :
-    ∃ y, (y ∈ B₂ ∧ y ∉ B₁) ∧ M.Base (insert y (B₁ \ {e})) := by
+theorem IsBase.exchange_mem {e : α}
+    (hB₁ : M.IsBase B₁) (hB₂ : M.IsBase B₂) (hxB₁ : e ∈ B₁) (hxB₂ : e ∉ B₂) :
+    ∃ y, (y ∈ B₂ ∧ y ∉ B₁) ∧ M.IsBase (insert y (B₁ \ {e})) := by
   simpa using hB₁.exchange hB₂ ⟨hxB₁, hxB₂⟩
 
-theorem Base.eq_of_subset_base (hB₁ : M.Base B₁) (hB₂ : M.Base B₂) (hB₁B₂ : B₁ ⊆ B₂) :
+theorem IsBase.eq_of_subset_isBase (hB₁ : M.IsBase B₁) (hB₂ : M.IsBase B₂) (hB₁B₂ : B₁ ⊆ B₂) :
     B₁ = B₂ :=
-  M.base_exchange.antichain hB₁ hB₂ hB₁B₂
+  M.isBase_exchange.antichain hB₁ hB₂ hB₁B₂
 
-theorem Base.not_base_of_ssubset {X : Set α} (hB : M.Base B) (hX : X ⊂ B) : ¬ M.Base X :=
-  fun h ↦ hX.ne (h.eq_of_subset_base hB hX.subset)
+theorem IsBase.not_isBase_of_ssubset {X : Set α} (hB : M.IsBase B) (hX : X ⊂ B) : ¬ M.IsBase X :=
+  fun h ↦ hX.ne (h.eq_of_subset_isBase hB hX.subset)
 
-theorem Base.insert_not_base {e : α} (hB : M.Base B) (heB : e ∉ B) : ¬ M.Base (insert e B) :=
-  fun h ↦ h.not_base_of_ssubset (ssubset_insert heB) hB
+theorem IsBase.insert_not_isBase {e : α} (hB : M.IsBase B) (heB : e ∉ B) :
+    ¬ M.IsBase (insert e B) :=
+  fun h ↦ h.not_isBase_of_ssubset (ssubset_insert heB) hB
 
-theorem Base.encard_diff_comm (hB₁ : M.Base B₁) (hB₂ : M.Base B₂) :
+theorem IsBase.encard_diff_comm (hB₁ : M.IsBase B₁) (hB₂ : M.IsBase B₂) :
     (B₁ \ B₂).encard = (B₂ \ B₁).encard :=
-  M.base_exchange.encard_diff_eq hB₁ hB₂
+  M.isBase_exchange.encard_diff_eq hB₁ hB₂
 
-theorem Base.ncard_diff_comm (hB₁ : M.Base B₁) (hB₂ : M.Base B₂) :
+theorem IsBase.ncard_diff_comm (hB₁ : M.IsBase B₁) (hB₂ : M.IsBase B₂) :
     (B₁ \ B₂).ncard = (B₂ \ B₁).ncard := by
   rw [ncard_def, hB₁.encard_diff_comm hB₂, ← ncard_def]
 
-theorem Base.card_eq_card_of_base (hB₁ : M.Base B₁) (hB₂ : M.Base B₂) :
+theorem IsBase.encard_eq_encard_of_isBase (hB₁ : M.IsBase B₁) (hB₂ : M.IsBase B₂) :
     B₁.encard = B₂.encard := by
-  rw [M.base_exchange.encard_base_eq hB₁ hB₂]
+  rw [M.isBase_exchange.encard_base_eq hB₁ hB₂]
 
-theorem Base.ncard_eq_ncard_of_base (hB₁ : M.Base B₁) (hB₂ : M.Base B₂) : B₁.ncard = B₂.ncard := by
-  rw [ncard_def B₁, hB₁.card_eq_card_of_base hB₂, ← ncard_def]
+theorem IsBase.ncard_eq_ncard_of_isBase (hB₁ : M.IsBase B₁) (hB₂ : M.IsBase B₂) :
+    B₁.ncard = B₂.ncard := by
+  rw [ncard_def B₁, hB₁.encard_eq_encard_of_isBase hB₂, ← ncard_def]
 
-theorem Base.finite_of_finite {B' : Set α}
-    (hB : M.Base B) (h : B.Finite) (hB' : M.Base B') : B'.Finite :=
-  (finite_iff_finite_of_encard_eq_encard (hB.card_eq_card_of_base hB')).mp h
+theorem IsBase.finite_of_finite {B' : Set α}
+    (hB : M.IsBase B) (h : B.Finite) (hB' : M.IsBase B') : B'.Finite :=
+  (finite_iff_finite_of_encard_eq_encard (hB.encard_eq_encard_of_isBase hB')).mp h
 
-theorem Base.infinite_of_infinite (hB : M.Base B) (h : B.Infinite) (hB₁ : M.Base B₁) :
+theorem IsBase.infinite_of_infinite (hB : M.IsBase B) (h : B.Infinite) (hB₁ : M.IsBase B₁) :
     B₁.Infinite :=
   by_contra (fun hB_inf ↦ (hB₁.finite_of_finite (not_infinite.mp hB_inf) hB).not_infinite h)
 
-theorem Base.finite [RankFinite M] (hB : M.Base B) : B.Finite :=
-  let ⟨_,hB₀⟩ := ‹RankFinite M›.exists_finite_base
+theorem IsBase.finite [RankFinite M] (hB : M.IsBase B) : B.Finite :=
+  let ⟨_,hB₀⟩ := ‹RankFinite M›.exists_finite_isBase
   hB₀.1.finite_of_finite hB₀.2 hB
 
-theorem Base.infinite [RankInfinite M] (hB : M.Base B) : B.Infinite :=
-  let ⟨_,hB₀⟩ := ‹RankInfinite M›.exists_infinite_base
+theorem IsBase.infinite [RankInfinite M] (hB : M.IsBase B) : B.Infinite :=
+  let ⟨_,hB₀⟩ := ‹RankInfinite M›.exists_infinite_isBase
   hB₀.1.infinite_of_infinite hB₀.2 hB
 
-theorem empty_not_base [h : RankPos M] : ¬M.Base ∅ :=
-  h.empty_not_base
+theorem empty_not_isBase [h : RankPos M] : ¬M.IsBase ∅ :=
+  h.empty_not_isBase
 
-theorem Base.nonempty [RankPos M] (hB : M.Base B) : B.Nonempty := by
-  rw [nonempty_iff_ne_empty]; rintro rfl; exact M.empty_not_base hB
+theorem IsBase.nonempty [RankPos M] (hB : M.IsBase B) : B.Nonempty := by
+  rw [nonempty_iff_ne_empty]; rintro rfl; exact M.empty_not_isBase hB
 
-theorem Base.rankPos_of_nonempty (hB : M.Base B) (h : B.Nonempty) : M.RankPos := by
+theorem IsBase.rankPos_of_nonempty (hB : M.IsBase B) (h : B.Nonempty) : M.RankPos := by
   rw [rankPos_iff]
   intro he
-  obtain rfl := he.eq_of_subset_base hB (empty_subset B)
+  obtain rfl := he.eq_of_subset_isBase hB (empty_subset B)
   simp at h
 
-theorem Base.rankFinite_of_finite (hB : M.Base B) (hfin : B.Finite) : RankFinite M :=
+theorem IsBase.rankFinite_of_finite (hB : M.IsBase B) (hfin : B.Finite) : RankFinite M :=
   ⟨⟨B, hB, hfin⟩⟩
 
-theorem Base.rankInfinite_of_infinite (hB : M.Base B) (h : B.Infinite) : RankInfinite M :=
+theorem IsBase.rankInfinite_of_infinite (hB : M.IsBase B) (h : B.Infinite) : RankInfinite M :=
   ⟨⟨B, hB, h⟩⟩
 
 theorem not_rankFinite (M : Matroid α) [RankInfinite M] : ¬ RankFinite M := by
-  intro h; obtain ⟨B,hB⟩ := M.exists_base; exact hB.infinite hB.finite
+  intro h; obtain ⟨B,hB⟩ := M.exists_isBase; exact hB.infinite hB.finite
 
 theorem not_rankInfinite (M : Matroid α) [RankFinite M] : ¬ RankInfinite M := by
-  intro h; obtain ⟨B,hB⟩ := M.exists_base; exact hB.infinite hB.finite
+  intro h; obtain ⟨B,hB⟩ := M.exists_isBase; exact hB.infinite hB.finite
 
 theorem finite_or_rankInfinite (M : Matroid α) : RankFinite M ∨ RankInfinite M :=
-  let ⟨B, hB⟩ := M.exists_base
+  let ⟨B, hB⟩ := M.exists_isBase
   B.finite_or_infinite.elim
   (Or.inl ∘ hB.rankFinite_of_finite) (Or.inr ∘ hB.rankInfinite_of_infinite)
 
-theorem Base.diff_finite_comm (hB₁ : M.Base B₁) (hB₂ : M.Base B₂) :
+theorem IsBase.diff_finite_comm (hB₁ : M.IsBase B₁) (hB₂ : M.IsBase B₂) :
     (B₁ \ B₂).Finite ↔ (B₂ \ B₁).Finite :=
   finite_iff_finite_of_encard_eq_encard (hB₁.encard_diff_comm hB₂)
 
-theorem Base.diff_infinite_comm (hB₁ : M.Base B₁) (hB₂ : M.Base B₂) :
+theorem IsBase.diff_infinite_comm (hB₁ : M.IsBase B₁) (hB₂ : M.IsBase B₂) :
     (B₁ \ B₂).Infinite ↔ (B₂ \ B₁).Infinite :=
   infinite_iff_infinite_of_encard_eq_encard (hB₁.encard_diff_comm hB₂)
 
-theorem ext_base {M₁ M₂ : Matroid α} (hE : M₁.E = M₂.E)
-    (h : ∀ ⦃B⦄, B ⊆ M₁.E → (M₁.Base B ↔ M₂.Base B)) : M₁ = M₂ := by
-  have h' : ∀ B, M₁.Base B ↔ M₂.Base B :=
+theorem ext_isBase {M₁ M₂ : Matroid α} (hE : M₁.E = M₂.E)
+    (h : ∀ ⦃B⦄, B ⊆ M₁.E → (M₁.IsBase B ↔ M₂.IsBase B)) : M₁ = M₂ := by
+  have h' : ∀ B, M₁.IsBase B ↔ M₂.IsBase B :=
     fun B ↦ ⟨fun hB ↦ (h hB.subset_ground).1 hB,
       fun hB ↦ (h <| hB.subset_ground.trans_eq hE.symm).2 hB⟩
   ext <;> simp [hE, M₁.indep_iff', M₂.indep_iff', h']
 
-@[deprecated (since := "2024-12-25")] alias eq_of_base_iff_base_forall := ext_base
+@[deprecated (since := "2024-12-25")] alias eq_of_isBase_iff_isBase_forall := ext_isBase
 
-theorem ext_iff_base {M₁ M₂ : Matroid α} :
-    M₁ = M₂ ↔ M₁.E = M₂.E ∧ ∀ ⦃B⦄, B ⊆ M₁.E → (M₁.Base B ↔ M₂.Base B) :=
-  ⟨fun h ↦ by simp [h], fun ⟨hE, h⟩ ↦ ext_base hE h⟩
+theorem ext_iff_isBase {M₁ M₂ : Matroid α} :
+    M₁ = M₂ ↔ M₁.E = M₂.E ∧ ∀ ⦃B⦄, B ⊆ M₁.E → (M₁.IsBase B ↔ M₂.IsBase B) :=
+  ⟨fun h ↦ by simp [h], fun ⟨hE, h⟩ ↦ ext_isBase hE h⟩
 
-theorem base_compl_iff_maximal_disjoint_base (hB : B ⊆ M.E := by aesop_mat) :
-    M.Base (M.E \ B) ↔ Maximal (fun I ↦ I ⊆ M.E ∧ ∃ B, M.Base B ∧ Disjoint I B) B := by
+theorem isBase_compl_iff_maximal_disjoint_isBase (hB : B ⊆ M.E := by aesop_mat) :
+    M.IsBase (M.E \ B) ↔ Maximal (fun I ↦ I ⊆ M.E ∧ ∃ B, M.IsBase B ∧ Disjoint I B) B := by
   simp_rw [maximal_iff, and_iff_right hB, and_imp, forall_exists_index]
   refine ⟨fun h ↦ ⟨⟨_, h, disjoint_sdiff_right⟩,
     fun I hI B' ⟨hB', hIB'⟩ hBI ↦ hBI.antisymm ?_⟩, fun ⟨⟨B', hB', hBB'⟩,h⟩ ↦ ?_⟩
-  · rw [hB'.eq_of_subset_base h, ← subset_compl_iff_disjoint_right, diff_eq, compl_inter,
+  · rw [hB'.eq_of_subset_isBase h, ← subset_compl_iff_disjoint_right, diff_eq, compl_inter,
       compl_compl] at hIB'
     · exact fun e he ↦ (hIB' he).elim (fun h' ↦ (h' (hI he)).elim) id
     rw [subset_diff, and_iff_right hB'.subset_ground, disjoint_comm]
@@ -508,7 +512,7 @@ theorem base_compl_iff_maximal_disjoint_base (hB : B ⊆ M.E := by aesop_mat) :
   · simpa [hB'.subset_ground]
   simp [subset_diff, hB, hBB']
 
-end Base
+end IsBase
 section dep_indep
 
 /-- A subset of `M.E` is `Dep`endent if it is not `Indep`endent . -/
@@ -516,14 +520,14 @@ def Dep (M : Matroid α) (D : Set α) : Prop := ¬M.Indep D ∧ D ⊆ M.E
 
 variable {B B' I J D X : Set α} {e f : α}
 
-theorem indep_iff : M.Indep I ↔ ∃ B, M.Base B ∧ I ⊆ B :=
+theorem indep_iff : M.Indep I ↔ ∃ B, M.IsBase B ∧ I ⊆ B :=
   M.indep_iff' (I := I)
 
-theorem setOf_indep_eq (M : Matroid α) : {I | M.Indep I} = lowerClosure ({B | M.Base B}) := by
+theorem setOf_indep_eq (M : Matroid α) : {I | M.Indep I} = lowerClosure ({B | M.IsBase B}) := by
   simp_rw [indep_iff]
   rfl
 
-theorem Indep.exists_base_superset (hI : M.Indep I) : ∃ B, M.Base B ∧ I ⊆ B :=
+theorem Indep.exists_isBase_superset (hI : M.Indep I) : ∃ B, M.IsBase B ∧ I ⊆ B :=
   indep_iff.1 hI
 
 theorem dep_iff : M.Dep D ↔ ¬M.Indep D ∧ D ⊆ M.E := Iff.rfl
@@ -532,7 +536,7 @@ theorem setOf_dep_eq (M : Matroid α) : {D | M.Dep D} = {I | M.Indep I}ᶜ ∩ I
 
 @[aesop unsafe 30% (rule_sets := [Matroid])]
 theorem Indep.subset_ground (hI : M.Indep I) : I ⊆ M.E := by
-  obtain ⟨B, hB, hIB⟩ := hI.exists_base_superset
+  obtain ⟨B, hB, hIB⟩ := hI.exists_isBase_superset
   exact hIB.trans hB.subset_ground
 
 @[aesop unsafe 20% (rule_sets := [Matroid])]
@@ -566,27 +570,27 @@ theorem indep_iff_not_dep : M.Indep I ↔ ¬M.Dep I ∧ I ⊆ M.E := by
   exact ⟨fun h ↦ ⟨fun _ ↦ h, h.subset_ground⟩, fun h ↦ h.1 h.2⟩
 
 theorem Indep.subset (hJ : M.Indep J) (hIJ : I ⊆ J) : M.Indep I := by
-  obtain ⟨B, hB, hJB⟩ := hJ.exists_base_superset
+  obtain ⟨B, hB, hJB⟩ := hJ.exists_isBase_superset
   exact indep_iff.2 ⟨B, hB, hIJ.trans hJB⟩
 
 theorem Dep.superset (hD : M.Dep D) (hDX : D ⊆ X) (hXE : X ⊆ M.E := by aesop_mat) : M.Dep X :=
   dep_of_not_indep (fun hI ↦ (hI.subset hDX).not_dep hD)
 
-theorem Base.indep (hB : M.Base B) : M.Indep B :=
+theorem IsBase.indep (hB : M.IsBase B) : M.Indep B :=
   indep_iff.2 ⟨B, hB, subset_rfl⟩
 
 @[simp] theorem empty_indep (M : Matroid α) : M.Indep ∅ :=
-  Exists.elim M.exists_base (fun _ hB ↦ hB.indep.subset (empty_subset _))
+  Exists.elim M.exists_isBase (fun _ hB ↦ hB.indep.subset (empty_subset _))
 
 theorem Dep.nonempty (hD : M.Dep D) : D.Nonempty := by
   rw [nonempty_iff_ne_empty]; rintro rfl; exact hD.not_indep M.empty_indep
 
 theorem Indep.finite [RankFinite M] (hI : M.Indep I) : I.Finite :=
-  let ⟨_, hB, hIB⟩ := hI.exists_base_superset
+  let ⟨_, hB, hIB⟩ := hI.exists_isBase_superset
   hB.finite.subset hIB
 
 theorem Indep.rankPos_of_nonempty (hI : M.Indep I) (hne : I.Nonempty) : M.RankPos := by
-  obtain ⟨B, hB, hIB⟩ := hI.exists_base_superset
+  obtain ⟨B, hB, hIB⟩ := hI.exists_isBase_superset
   exact hB.rankPos_of_nonempty (hne.mono hIB)
 
 theorem Indep.inter_right (hI : M.Indep I) (X : Set α) : M.Indep (I ∩ X) :=
@@ -598,42 +602,43 @@ theorem Indep.inter_left (hI : M.Indep I) (X : Set α) : M.Indep (X ∩ I) :=
 theorem Indep.diff (hI : M.Indep I) (X : Set α) : M.Indep (I \ X) :=
   hI.subset diff_subset
 
-theorem Base.eq_of_subset_indep (hB : M.Base B) (hI : M.Indep I) (hBI : B ⊆ I) : B = I :=
-  let ⟨B', hB', hB'I⟩ := hI.exists_base_superset
-  hBI.antisymm (by rwa [hB.eq_of_subset_base hB' (hBI.trans hB'I)])
+theorem IsBase.eq_of_subset_indep (hB : M.IsBase B) (hI : M.Indep I) (hBI : B ⊆ I) : B = I :=
+  let ⟨B', hB', hB'I⟩ := hI.exists_isBase_superset
+  hBI.antisymm (by rwa [hB.eq_of_subset_isBase hB' (hBI.trans hB'I)])
 
-theorem base_iff_maximal_indep : M.Base B ↔ Maximal M.Indep B := by
+theorem isBase_iff_maximal_indep : M.IsBase B ↔ Maximal M.Indep B := by
   rw [maximal_subset_iff]
   refine ⟨fun h ↦ ⟨h.indep, fun _ ↦ h.eq_of_subset_indep⟩, fun ⟨h, h'⟩ ↦ ?_⟩
-  obtain ⟨B', hB', hBB'⟩ := h.exists_base_superset
+  obtain ⟨B', hB', hBB'⟩ := h.exists_isBase_superset
   rwa [h' hB'.indep hBB']
 
-theorem Indep.base_of_maximal (hI : M.Indep I) (h : ∀ ⦃J⦄, M.Indep J → I ⊆ J → I = J) :
-    M.Base I := by
-  rwa [base_iff_maximal_indep, maximal_subset_iff, and_iff_right hI]
+theorem Indep.isBase_of_maximal (hI : M.Indep I) (h : ∀ ⦃J⦄, M.Indep J → I ⊆ J → I = J) :
+    M.IsBase I := by
+  rwa [isBase_iff_maximal_indep, maximal_subset_iff, and_iff_right hI]
 
-theorem Base.dep_of_ssubset (hB : M.Base B) (h : B ⊂ X) (hX : X ⊆ M.E := by aesop_mat) : M.Dep X :=
+theorem IsBase.dep_of_ssubset (hB : M.IsBase B) (h : B ⊂ X) (hX : X ⊆ M.E := by aesop_mat) :
+    M.Dep X :=
   ⟨fun hX ↦ h.ne (hB.eq_of_subset_indep hX h.subset), hX⟩
 
-theorem Base.dep_of_insert (hB : M.Base B) (heB : e ∉ B) (he : e ∈ M.E := by aesop_mat) :
+theorem IsBase.dep_of_insert (hB : M.IsBase B) (heB : e ∉ B) (he : e ∈ M.E := by aesop_mat) :
     M.Dep (insert e B) := hB.dep_of_ssubset (ssubset_insert heB) (insert_subset he hB.subset_ground)
 
-theorem Base.mem_of_insert_indep (hB : M.Base B) (heB : M.Indep (insert e B)) : e ∈ B :=
+theorem IsBase.mem_of_insert_indep (hB : M.IsBase B) (heB : M.Indep (insert e B)) : e ∈ B :=
   by_contra fun he ↦ (hB.dep_of_insert he (heB.subset_ground (mem_insert _ _))).not_indep heB
 
-/-- If the difference of two Bases is a singleton, then they differ by an insertion/removal -/
-theorem Base.eq_exchange_of_diff_eq_singleton (hB : M.Base B) (hB' : M.Base B') (h : B \ B' = {e}) :
-    ∃ f ∈ B' \ B, B' = (insert f B) \ {e} := by
+/-- If the difference of two IsBases is a singleton, then they differ by an insertion/removal -/
+theorem IsBase.eq_exchange_of_diff_eq_singleton (hB : M.IsBase B) (hB' : M.IsBase B')
+    (h : B \ B' = {e}) : ∃ f ∈ B' \ B, B' = (insert f B) \ {e} := by
   obtain ⟨f, hf, hb⟩ := hB.exchange hB' (h.symm.subset (mem_singleton e))
   have hne : f ≠ e := by rintro rfl; exact hf.2 (h.symm.subset (mem_singleton f)).1
   rw [insert_diff_singleton_comm hne] at hb
-  refine ⟨f, hf, (hb.eq_of_subset_base hB' ?_).symm⟩
+  refine ⟨f, hf, (hb.eq_of_subset_isBase hB' ?_).symm⟩
   rw [diff_subset_iff, insert_subset_iff, union_comm, ← diff_subset_iff, h, and_iff_left rfl.subset]
   exact Or.inl hf.1
 
-theorem Base.exchange_base_of_indep (hB : M.Base B) (hf : f ∉ B)
-    (hI : M.Indep (insert f (B \ {e}))) : M.Base (insert f (B \ {e})) := by
-  obtain ⟨B', hB', hIB'⟩ := hI.exists_base_superset
+theorem IsBase.exchange_isBase_of_indep (hB : M.IsBase B) (hf : f ∉ B)
+    (hI : M.Indep (insert f (B \ {e}))) : M.IsBase (insert f (B \ {e})) := by
+  obtain ⟨B', hB', hIB'⟩ := hI.exists_isBase_superset
   have hcard := hB'.encard_diff_comm hB
   rw [insert_subset_iff, ← diff_eq_empty, diff_diff_comm, diff_eq_empty, subset_singleton_iff_eq]
     at hIB'
@@ -647,27 +652,27 @@ theorem Base.exchange_base_of_indep (hB : M.Base B) (hf : f ∉ B)
     diff_union_inter]
   exact hB'
 
-theorem Base.exchange_base_of_indep' (hB : M.Base B) (he : e ∈ B) (hf : f ∉ B)
-    (hI : M.Indep (insert f B \ {e})) : M.Base (insert f B \ {e}) := by
+theorem IsBase.exchange_isBase_of_indep' (hB : M.IsBase B) (he : e ∈ B) (hf : f ∉ B)
+    (hI : M.Indep (insert f B \ {e})) : M.IsBase (insert f B \ {e}) := by
   have hfe : f ≠ e := by rintro rfl; exact hf he
   rw [← insert_diff_singleton_comm hfe] at *
-  exact hB.exchange_base_of_indep hf hI
+  exact hB.exchange_isBase_of_indep hf hI
 
-lemma insert_base_of_insert_indep {M : Matroid α} {I : Set α} {e f : α}
-    (he : e ∉ I) (hf : f ∉ I) (heI : M.Base (insert e I)) (hfI : M.Indep (insert f I)) :
-    M.Base (insert f I) := by
+lemma insert_isBase_of_insert_indep {M : Matroid α} {I : Set α} {e f : α}
+    (he : e ∉ I) (hf : f ∉ I) (heI : M.IsBase (insert e I)) (hfI : M.Indep (insert f I)) :
+    M.IsBase (insert f I) := by
   obtain rfl | hef := eq_or_ne e f
   · assumption
   simpa [diff_singleton_eq_self he, hfI]
-    using heI.exchange_base_of_indep (e := e) (f := f) (by simp [hef.symm, hf])
+    using heI.exchange_isBase_of_indep (e := e) (f := f) (by simp [hef.symm, hf])
 
-theorem Base.insert_dep (hB : M.Base B) (h : e ∈ M.E \ B) : M.Dep (insert e B) := by
+theorem IsBase.insert_dep (hB : M.IsBase B) (h : e ∈ M.E \ B) : M.Dep (insert e B) := by
   rw [← not_indep_iff (insert_subset h.1 hB.subset_ground)]
   exact h.2 ∘ (fun hi ↦ insert_eq_self.mp (hB.eq_of_subset_indep hi (subset_insert e B)).symm)
 
-theorem Indep.exists_insert_of_not_base (hI : M.Indep I) (hI' : ¬M.Base I) (hB : M.Base B) :
+theorem Indep.exists_insert_of_not_isBase (hI : M.Indep I) (hI' : ¬M.IsBase I) (hB : M.IsBase B) :
     ∃ e ∈ B \ I, M.Indep (insert e I) := by
-  obtain ⟨B', hB', hIB'⟩ := hI.exists_base_superset
+  obtain ⟨B', hB', hIB'⟩ := hI.exists_isBase_superset
   obtain ⟨x, hxB', hx⟩ := exists_of_ssubset (hIB'.ssubset_of_ne (by (rintro rfl; exact hI' hB')))
   by_cases hxB : x ∈ B
   · exact ⟨x, ⟨hxB, hx⟩, hB'.indep.subset (insert_subset hxB' hIB')⟩
@@ -675,31 +680,31 @@ theorem Indep.exists_insert_of_not_base (hI : M.Indep I) (hI' : ¬M.Base I) (hB 
   exact ⟨e, ⟨he.1, not_mem_subset hIB' he.2⟩,
     indep_iff.2 ⟨_, hBase, insert_subset_insert (subset_diff_singleton hIB' hx)⟩⟩
 
-/-- This is the same as `Indep.exists_insert_of_not_base`, but phrased so that
+/-- This is the same as `Indep.exists_insert_of_not_isBase`, but phrased so that
   it is defeq to the augmentation axiom for independent sets. -/
 theorem Indep.exists_insert_of_not_maximal (M : Matroid α) ⦃I B : Set α⦄ (hI : M.Indep I)
     (hInotmax : ¬ Maximal M.Indep I) (hB : Maximal M.Indep B) :
     ∃ x ∈ B \ I, M.Indep (insert x I) := by
   simp only [maximal_subset_iff, hI, not_and, not_forall, exists_prop, true_imp_iff] at hB hInotmax
-  refine hI.exists_insert_of_not_base (fun hIb ↦ ?_) ?_
+  refine hI.exists_insert_of_not_isBase (fun hIb ↦ ?_) ?_
   · obtain ⟨I', hII', hI', hne⟩ := hInotmax
     exact hne <| hIb.eq_of_subset_indep hII' hI'
-  exact hB.1.base_of_maximal fun J hJ hBJ ↦ hB.2 hJ hBJ
+  exact hB.1.isBase_of_maximal fun J hJ hBJ ↦ hB.2 hJ hBJ
 
-theorem Indep.base_of_forall_insert (hB : M.Indep B)
-    (hBmax : ∀ e ∈ M.E \ B, ¬ M.Indep (insert e B)) : M.Base B := by
+theorem Indep.isBase_of_forall_insert (hB : M.Indep B)
+    (hBmax : ∀ e ∈ M.E \ B, ¬ M.Indep (insert e B)) : M.IsBase B := by
   refine by_contra fun hnb ↦ ?_
-  obtain ⟨B', hB'⟩ := M.exists_base
-  obtain ⟨e, he, h⟩ := hB.exists_insert_of_not_base hnb hB'
+  obtain ⟨B', hB'⟩ := M.exists_isBase
+  obtain ⟨e, he, h⟩ := hB.exists_insert_of_not_isBase hnb hB'
   exact hBmax e ⟨hB'.subset_ground he.1, he.2⟩ h
 
-theorem ground_indep_iff_base : M.Indep M.E ↔ M.Base M.E :=
-  ⟨fun h ↦ h.base_of_maximal (fun _ hJ hEJ ↦ hEJ.antisymm hJ.subset_ground), Base.indep⟩
+theorem ground_indep_iff_isBase : M.Indep M.E ↔ M.IsBase M.E :=
+  ⟨fun h ↦ h.isBase_of_maximal (fun _ hJ hEJ ↦ hEJ.antisymm hJ.subset_ground), IsBase.indep⟩
 
-theorem Base.exists_insert_of_ssubset (hB : M.Base B) (hIB : I ⊂ B) (hB' : M.Base B') :
+theorem IsBase.exists_insert_of_ssubset (hB : M.IsBase B) (hIB : I ⊂ B) (hB' : M.IsBase B') :
     ∃ e ∈ B' \ I, M.Indep (insert e I) :=
-  (hB.indep.subset hIB.subset).exists_insert_of_not_base
-    (fun hI ↦ hIB.ne (hI.eq_of_subset_base hB hIB.subset)) hB'
+  (hB.indep.subset hIB.subset).exists_insert_of_not_isBase
+    (fun hI ↦ hIB.ne (hI.eq_of_subset_isBase hB hIB.subset)) hB'
 
 @[ext] theorem ext_indep {M₁ M₂ : Matroid α} (hE : M₁.E = M₂.E)
     (h : ∀ ⦃I⦄, I ⊆ M₁.E → (M₁.Indep I ↔ M₂.Indep I)) : M₁ = M₂ :=
@@ -709,7 +714,7 @@ theorem Base.exists_insert_of_ssubset (hB : M.Base B) (hIB : I ⊂ B) (hB' : M.B
     · rwa [h]
     exact iff_of_false (fun hi ↦ hI hi.subset_ground)
       (fun hi ↦ hI (hi.subset_ground.trans_eq hE.symm))
-  ext_base hE (fun B _ ↦ by simp_rw [base_iff_maximal_indep, h'])
+  ext_isBase hE (fun B _ ↦ by simp_rw [isBase_iff_maximal_indep, h'])
 
 @[deprecated (since := "2024-12-25")] alias eq_of_indep_iff_indep_forall := ext_indep
 
@@ -720,12 +725,12 @@ theorem ext_iff_indep {M₁ M₂ : Matroid α} :
 @[deprecated (since := "2024-12-25")] alias eq_iff_indep_iff_indep_forall := ext_iff_indep
 
 /-- If every base of `M₁` is independent in `M₂` and vice versa, then `M₁ = M₂`. -/
-lemma ext_base_indep {M₁ M₂ : Matroid α} (hE : M₁.E = M₂.E) (hM₁ : ∀ ⦃B⦄, M₁.Base B → M₂.Indep B)
-    (hM₂ : ∀ ⦃B⦄, M₂.Base B → M₁.Indep B) : M₁ = M₂ := by
+lemma ext_isBase_indep {M₁ M₂ : Matroid α} (hE : M₁.E = M₂.E)
+    (hM₁ : ∀ ⦃B⦄, M₁.IsBase B → M₂.Indep B) (hM₂ : ∀ ⦃B⦄, M₂.IsBase B → M₁.Indep B) : M₁ = M₂ := by
   refine ext_indep hE fun I hIE ↦ ⟨fun hI ↦ ?_, fun hI ↦ ?_⟩
-  · obtain ⟨B, hB, hIB⟩ := hI.exists_base_superset
+  · obtain ⟨B, hB, hIB⟩ := hI.exists_isBase_superset
     exact (hM₁ hB).subset hIB
-  obtain ⟨B, hB, hIB⟩ := hI.exists_base_superset
+  obtain ⟨B, hB, hIB⟩ := hI.exists_isBase_superset
   exact (hM₂ hB).subset hIB
 
 /-- A `Finitary` matroid is one where a set is independent if and only if it all
@@ -745,11 +750,11 @@ theorem indep_iff_forall_finite_subset_indep {M : Matroid α} [Finitary M] :
 instance finitary_of_rankFinite {M : Matroid α} [RankFinite M] : Finitary M :=
 ⟨ by
   refine fun I hI ↦ I.finite_or_infinite.elim (hI _ Subset.rfl) (fun h ↦ False.elim ?_)
-  obtain ⟨B, hB⟩ := M.exists_base
+  obtain ⟨B, hB⟩ := M.exists_isBase
   obtain ⟨I₀, hI₀I, hI₀fin, hI₀card⟩ := h.exists_subset_ncard_eq (B.ncard + 1)
-  obtain ⟨B', hB', hI₀B'⟩ := (hI _ hI₀I hI₀fin).exists_base_superset
+  obtain ⟨B', hB', hI₀B'⟩ := (hI _ hI₀I hI₀fin).exists_isBase_superset
   have hle := ncard_le_ncard hI₀B' hB'.finite
-  rw [hI₀card, hB'.ncard_eq_ncard_of_base hB, Nat.add_one_le_iff] at hle
+  rw [hI₀card, hB'.ncard_eq_ncard_of_isBase hB, Nat.add_one_le_iff] at hle
   exact hle.ne rfl ⟩
 
 /-- Matroids obey the maximality axiom -/
@@ -763,18 +768,18 @@ section copy
 
 /-- create a copy of `M : Matroid α` with independence and base predicates and ground set defeq
 to supplied arguments that are provably equal to those of `M`. -/
-@[simps] def copy (M : Matroid α) (E : Set α) (Base Indep : Set α → Prop)
-    (hE : E = M.E) (hB : ∀ B, Base B ↔ M.Base B) (hI : ∀ I, Indep I ↔ M.Indep I) : Matroid α where
+@[simps] def copy (M : Matroid α) (E : Set α) (IsBase Indep : Set α → Prop) (hE : E = M.E)
+    (hB : ∀ B, IsBase B ↔ M.IsBase B) (hI : ∀ I, Indep I ↔ M.Indep I) : Matroid α where
   E := E
-  Base := Base
+  IsBase := IsBase
   Indep := Indep
   indep_iff' _ := by simp_rw [hI, hB, M.indep_iff]
-  exists_base := by
+  exists_isBase := by
     simp_rw [hB]
-    exact M.exists_base
-  base_exchange := by
-    simp_rw [show Base = M.Base from funext (by simp [hB])]
-    exact M.base_exchange
+    exact M.exists_isBase
+  isBase_exchange := by
+    simp_rw [show IsBase = M.IsBase from funext (by simp [hB])]
+    exact M.isBase_exchange
   maximality := by
     simp_rw [hE, show Indep = M.Indep from funext (by simp [hI])]
     exact M.maximality
@@ -786,13 +791,13 @@ to supplied arguments that are provably equal to those of `M`. -/
 to supplied arguments that are provably equal to those of `M`. -/
 @[simps!] def copyIndep (M : Matroid α) (E : Set α) (Indep : Set α → Prop)
     (hE : E = M.E) (h : ∀ I, Indep I ↔ M.Indep I) : Matroid α :=
-  M.copy E M.Base Indep hE (fun _ ↦ Iff.rfl) h
+  M.copy E M.IsBase Indep hE (fun _ ↦ Iff.rfl) h
 
 /-- create a copy of `M : Matroid α` with a base predicate and ground set defeq
 to supplied arguments that are provably equal to those of `M`. -/
-@[simps!] def copyBase (M : Matroid α) (E : Set α) (Base : Set α → Prop)
-    (hE : E = M.E) (h : ∀ B, Base B ↔ M.Base B) : Matroid α :=
-  M.copy E Base M.Indep hE h (fun _ ↦ Iff.rfl)
+@[simps!] def copyBase (M : Matroid α) (E : Set α) (IsBase : Set α → Prop)
+    (hE : E = M.E) (h : ∀ B, IsBase B ↔ M.IsBase B) : Matroid α :=
+  M.copy E IsBase M.Indep hE h (fun _ ↦ Iff.rfl)
 
 end copy
 
@@ -961,18 +966,18 @@ theorem exists_basis_union_inter_basis (M : Matroid α) (X Y : Set α) (hX : X �
 theorem Indep.eq_of_basis (hI : M.Indep I) (hJ : M.Basis J I) : J = I :=
   hJ.eq_of_subset_indep hI hJ.subset rfl.subset
 
-theorem Basis.exists_base (hI : M.Basis I X) : ∃ B, M.Base B ∧ I = B ∩ X :=
-  let ⟨B,hB, hIB⟩ := hI.indep.exists_base_superset
+theorem Basis.exists_isBase (hI : M.Basis I X) : ∃ B, M.IsBase B ∧ I = B ∩ X :=
+  let ⟨B,hB, hIB⟩ := hI.indep.exists_isBase_superset
   ⟨B, hB, subset_antisymm (subset_inter hIB hI.subset)
     (by rw [hI.eq_of_subset_indep (hB.indep.inter_right X) (subset_inter hIB hI.subset)
     inter_subset_right])⟩
 
-@[simp] theorem basis_ground_iff : M.Basis B M.E ↔ M.Base B := by
-  rw [Basis, and_iff_left rfl.subset, base_iff_maximal_indep,
+@[simp] theorem basis_ground_iff : M.Basis B M.E ↔ M.IsBase B := by
+  rw [Basis, and_iff_left rfl.subset, isBase_iff_maximal_indep,
     maximal_and_iff_right_of_imp (fun _ h ↦ h.subset_ground),
     and_iff_left_of_imp (fun h ↦ h.1.subset_ground)]
 
-theorem Base.basis_ground (hB : M.Base B) : M.Basis B M.E :=
+theorem IsBase.basis_ground (hB : M.IsBase B) : M.Basis B M.E :=
   basis_ground_iff.mpr hB
 
 theorem Indep.basis_iff_forall_insert_dep (hI : M.Indep I) (hIX : I ⊆ X) :
@@ -1044,16 +1049,16 @@ theorem Basis.insert_basis_insert (hI : M.Basis I X) (h : M.Indep (insert e I)) 
   simp_rw [← union_singleton] at *
   exact hI.union_basis_union (h.subset subset_union_right).basis_self h
 
-theorem Base.base_of_basis_superset (hB : M.Base B) (hBX : B ⊆ X) (hIX : M.Basis I X) :
-    M.Base I := by
+theorem IsBase.isBase_of_basis_superset (hB : M.IsBase B) (hBX : B ⊆ X) (hIX : M.Basis I X) :
+    M.IsBase I := by
   by_contra h
-  obtain ⟨e,heBI,he⟩ := hIX.indep.exists_insert_of_not_base h hB
+  obtain ⟨e,heBI,he⟩ := hIX.indep.exists_insert_of_not_isBase h hB
   exact heBI.2 (hIX.mem_of_insert_indep (hBX heBI.1) he)
 
-theorem Indep.exists_base_subset_union_base (hI : M.Indep I) (hB : M.Base B) :
-    ∃ B', M.Base B' ∧ I ⊆ B' ∧ B' ⊆ I ∪ B := by
+theorem Indep.exists_isBase_subset_union_isBase (hI : M.Indep I) (hB : M.IsBase B) :
+    ∃ B', M.IsBase B' ∧ I ⊆ B' ∧ B' ⊆ I ∪ B := by
   obtain ⟨B', hB', hIB'⟩ := hI.subset_basis_of_subset <| subset_union_left (t := B)
-  exact ⟨B', hB.base_of_basis_superset subset_union_right hB', hIB', hB'.subset⟩
+  exact ⟨B', hB.isBase_of_basis_superset subset_union_right hB', hIB', hB'.subset⟩
 
 theorem Basis.inter_eq_of_subset_indep (hIX : M.Basis I X) (hIJ : I ⊆ J) (hJ : M.Indep J) :
     J ∩ X = I :=
@@ -1065,7 +1070,7 @@ theorem Basis'.inter_eq_of_subset_indep (hI : M.Basis' I X) (hIJ : I ⊆ J) (hJ 
   rw [← hI.basis_inter_ground.inter_eq_of_subset_indep hIJ hJ, inter_comm X, ← inter_assoc,
     inter_eq_self_of_subset_left hJ.subset_ground]
 
-theorem Base.basis_of_subset (hX : X ⊆ M.E := by aesop_mat) (hB : M.Base B) (hBX : B ⊆ X) :
+theorem IsBase.basis_of_subset (hX : X ⊆ M.E := by aesop_mat) (hB : M.IsBase B) (hBX : B ⊆ X) :
     M.Basis B X := by
   rw [basis_iff, and_iff_right hB.indep, and_iff_right hBX]
   exact fun J hJ hBJ _ ↦ hB.eq_of_subset_indep hJ hBJ
@@ -1084,11 +1089,11 @@ section Finite
 
 /-- For finite `E`, finitely many matroids have ground set contained in `E`. -/
 theorem finite_setOf_matroid {E : Set α} (hE : E.Finite) : {M : Matroid α | M.E ⊆ E}.Finite := by
-  set f : Matroid α → Set α × (Set (Set α)) := fun M ↦ ⟨M.E, {B | M.Base B}⟩
+  set f : Matroid α → Set α × (Set (Set α)) := fun M ↦ ⟨M.E, {B | M.IsBase B}⟩
   have hf : f.Injective := by
     refine fun M M' hMM' ↦ ?_
     rw [Prod.mk.injEq, and_comm, Set.ext_iff, and_comm] at hMM'
-    exact ext_base hMM'.1 (fun B _ ↦ hMM'.2 B)
+    exact ext_isBase hMM'.1 (fun B _ ↦ hMM'.2 B)
   rw [← Set.finite_image_iff hf.injOn]
   refine (hE.finite_subsets.prod hE.finite_subsets.finite_subsets).subset ?_
   rintro _ ⟨M, hE : M.E ⊆ E, rfl⟩

--- a/Mathlib/Data/Matroid/Circuit.lean
+++ b/Mathlib/Data/Matroid/Circuit.lean
@@ -241,7 +241,7 @@ lemma Indep.mem_fundCircuit_iff (hI : M.Indep I) (hecl : e ∈ M.closure I) (heI
   refine ⟨fun h hecl ↦ (h _ diff_subset hecl).2 rfl, fun h J hJ heJ ↦ by_contra fun hxJ ↦ h ?_⟩
   exact M.closure_subset_closure (subset_diff_singleton hJ hxJ) heJ
 
-lemma Base.fundCircuit_circuit {B : Set α} (hB : M.Base B) (hxE : x ∈ M.E) (hxB : x ∉ B) :
+lemma Base.fundCircuit_circuit {B : Set α} (hB : M.IsBase B) (hxE : x ∈ M.E) (hxB : x ∉ B) :
     M.Circuit (M.fundCircuit x B) :=
   hB.indep.fundCircuit_circuit (by rwa [hB.closure_eq]) hxB
 

--- a/Mathlib/Data/Matroid/Circuit.lean
+++ b/Mathlib/Data/Matroid/Circuit.lean
@@ -8,8 +8,8 @@ import Mathlib.Data.Matroid.Closure
 /-!
 # Matroid IsCircuits
 
-A `Circuit` of a matroid `M` is a minimal set `C` that is dependent in `M`.
-A matroid is determined by its set of isCircuits, and often the circuits
+A 'Circuit' of a matroid `M` is a minimal set `C` that is dependent in `M`.
+A matroid is determined by its set of circuits, and often the circuits
 offer a more compact description of a matroid than the collection of independent sets or bases.
 In matroids arising from graphs, circuits correspond to graphical cycles.
 
@@ -360,7 +360,7 @@ lemma ext_isCircuit {M₁ M₂ : Matroid α} (hE : M₁.E = M₂.E)
     indep_iff_forall_subset_not_isCircuit (hI.trans_eq hE)]
 
 /-- A stronger version of `Matroid.ext_isCircuit`:
-two matroids on the same ground set are equal if no isCircuit of one is independent in the other. -/
+two matroids on the same ground set are equal if no circuit of one is independent in the other. -/
 lemma ext_isCircuit_not_indep {M₁ M₂ : Matroid α} (hE : M₁.E = M₂.E)
     (h₁ : ∀ C, M₁.IsCircuit C → ¬ M₂.Indep C) (h₂ : ∀ C, M₂.IsCircuit C → ¬ M₁.Indep C) :
     M₁ = M₂ := by
@@ -407,11 +407,11 @@ lemma IsCircuit.strong_multi_elimination_insert (x : ι → α) (I : ι → Set 
 /-- A generalization of the strong circuit elimination axiom `Matroid.IsCircuit.strong_elimination`
 to an infinite collection of isCircuits.
 
-It states that, given a isCircuit `C₀`, a arbitrary collection `C : ι → Set α` of isCircuits,
+It states that, given a circuit `C₀`, a arbitrary collection `C : ι → Set α` of circuits,
 an element `x i` of `C₀ ∩ C i` for each `i`, and an element `z ∈ C₀` outside all the `C i`,
-the union of `C₀` and the `C i` contains a isCircuit containing `z` but none of the `x i`.
+the union of `C₀` and the `C i` contains a circuit containing `z` but none of the `x i`.
 
-This is one of the axioms when defining infinite matroids via isCircuits.
+This is one of the axioms when defining infinite matroids via circuits.
 
 TODO : A similar statement will hold even when all mentions of `z` are removed. -/
 lemma IsCircuit.strong_multi_elimination (hC₀ : M.IsCircuit C₀) (x : ι → α) (C : ι → Set α) (z : α)
@@ -438,7 +438,7 @@ lemma IsCircuit.strong_multi_elimination (hC₀ : M.IsCircuit C₀) (x : ι → 
   simp only [mem_diff, mem_singleton_iff, not_and, not_not]
   exact fun i hzi ↦ (hzC i hzi).elim
 
-/-- A version of `Circuit.strong_multi_elimination` where the collection of isCircuits is
+/-- A version of `Circuit.strong_multi_elimination` where the collection of circuits is
 a `Set (Set α)` and the distinguished elements are a `Set α`, rather than both being indexed. -/
 lemma IsCircuit.strong_multi_elimination_set (hC₀ : M.IsCircuit C₀) (X : Set α) (S : Set (Set α))
     (z : α) (hCS : ∀ C ∈ S, M.IsCircuit C) (hXC₀ : X ⊆ C₀) (hX : ∀ x ∈ X, ∃ C ∈ S, C ∩ X = {x})
@@ -458,8 +458,8 @@ lemma IsCircuit.strong_multi_elimination_set (hC₀ : M.IsCircuit C₀) (X : Set
     simpa [hC.2 f hfX] using subset_inter (singleton_subset_iff.2 hef) (singleton_subset_iff.2 heX)
   simpa using fun e heX heC ↦ hz _ (hC.1 e heX) heC
 
-/-- The strong isCircuit elimination axiom. For any pair of distinct isCircuits `C₁, C₂` and all
-`e ∈ C₁ ∩ C₂` and `f ∈ C₁ \ C₂`, there is a isCircuit `C` with `f ∈ C ⊆ (C₁ ∪ C₂) \ {e}`. -/
+/-- The strong isCircuit elimination axiom. For any pair of distinct circuits `C₁, C₂` and all
+`e ∈ C₁ ∩ C₂` and `f ∈ C₁ \ C₂`, there is a circuit `C` with `f ∈ C ⊆ (C₁ ∪ C₂) \ {e}`. -/
 lemma IsCircuit.strong_elimination (hC₁ : M.IsCircuit C₁) (hC₂ : M.IsCircuit C₂) (heC₁ : e ∈ C₁)
     (heC₂ : e ∈ C₂) (hfC₁ : f ∈ C₁) (hfC₂ : f ∉ C₂) :
     ∃ C ⊆ (C₁ ∪ C₂) \ {e}, M.IsCircuit C ∧ f ∈ C := by
@@ -467,10 +467,10 @@ lemma IsCircuit.strong_elimination (hC₁ : M.IsCircuit C₁) (hC₂ : M.IsCircu
     (by simpa) (by simpa) (by simpa) (by simp) (by simpa) (by simpa)
   exact ⟨C, hCs.trans (diff_subset_diff (by simp) (by simp)), hC, hfC⟩
 
-/-- The isCircuit elimination axiom : for any pair of distinct isCircuits `C₁, C₂` and any `e`,
-some isCircuit is contained in `(C₁ ∪ C₂) \ {e}`.
+/-- The circuit elimination axiom : for any pair of distinct isCircuits `C₁, C₂` and any `e`,
+some circuit is contained in `(C₁ ∪ C₂) \ {e}`.
 
-This is one of the axioms when definining a finitary matroid via isCircuits;
+This is one of the axioms when definining a finitary matroid via circuits;
 as an axiom, it is usually stated with the extra assumption that `e ∈ C₁ ∩ C₂`. -/
 lemma IsCircuit.elimination (hC₁ : M.IsCircuit C₁) (hC₂ : M.IsCircuit C₂) (h : C₁ ≠ C₂) (e : α) :
     ∃ C ⊆ (C₁ ∪ C₂) \ {e}, M.IsCircuit C := by

--- a/Mathlib/Data/Matroid/Circuit.lean
+++ b/Mathlib/Data/Matroid/Circuit.lean
@@ -6,28 +6,28 @@ Authors: Peter Nelson
 import Mathlib.Data.Matroid.Closure
 
 /-!
-# Matroid Circuits
+# Matroid IsCircuits
 
 A `Circuit` of a matroid `M` is a minimal set `C` that is dependent in `M`.
-A matroid is determined by its set of circuits, and often the circuits
+A matroid is determined by its set of isCircuits, and often the circuits
 offer a more compact description of a matroid than the collection of independent sets or bases.
 In matroids arising from graphs, circuits correspond to graphical cycles.
 
 # Main Declarations
 
-* `Matroid.Circuit M C` means that `C` is minimally dependent in `M`.
+* `Matroid.IsCircuit M C` means that `C` is minimally dependent in `M`.
 * For an `Indep`endent set `I` whose closure contains an element `e ∉ I`,
   `Matroid.fundCircuit M e I` is the unique circuit contained in `insert e I`.
-* `Matroid.Indep.fundCircuit_circuit` states that `Matroid.fundCircuit M e I` is indeed a circuit.
+* `Matroid.Indep.fundCircuit_isCircuit` states that `Matroid.fundCircuit M e I` is indeed a circuit.
 * `Circuit.eq_fundCircuit_of_subset` states that `Matroid.fundCircuit M e I` is the
   unique circuit contained in `insert e I`.
-* `Matroid.dep_iff_superset_circuit` states that the dependent subsets of the ground set
+* `Matroid.dep_iff_superset_isCircuit` states that the dependent subsets of the ground set
   are precisely those that contain a circuit.
-* `Matroid.ext_circuit` : a matroid is determined by its collection of circuits.
-* `Matroid.Circuit.strong_multi_elimination` : the strong circuit elimination rule for an
+* `Matroid.ext_isCircuit` : a matroid is determined by its collection of circuits.
+* `Matroid.IsCircuit.strong_multi_elimination` : the strong circuit elimination rule for an
   infinite collection of circuits.
-* `Matroid.Circuit.strong_elimination` : the strong circuit elimination rule for two circuits.
-* `Matroid.finitary_iff_forall_circuit_finite` : finitary matroids are precisely those whose
+* `Matroid.IsCircuit.strong_elimination` : the strong circuit elimination rule for two circuits.
+* `Matroid.finitary_iff_forall_isCircuit_finite` : finitary matroids are precisely those whose
   circuits are all finite.
 
 # Implementation Details
@@ -48,116 +48,120 @@ open Set
 namespace Matroid
 
 /-- A `Circuit` of `M` is a minimal dependent set in `M` -/
-def Circuit (M : Matroid α) := Minimal M.Dep
+def IsCircuit (M : Matroid α) := Minimal M.Dep
 
-lemma circuit_def : M.Circuit C ↔ Minimal M.Dep C := Iff.rfl
+@[deprecated (since := "2025-02-14")] alias Circuit := IsCircuit
 
-lemma Circuit.dep (hC : M.Circuit C) : M.Dep C :=
+lemma isCircuit_def : M.IsCircuit C ↔ Minimal M.Dep C := Iff.rfl
+
+lemma IsCircuit.dep (hC : M.IsCircuit C) : M.Dep C :=
   hC.prop
 
-lemma Circuit.not_indep (hC : M.Circuit C) : ¬ M.Indep C :=
+lemma IsCircuit.not_indep (hC : M.IsCircuit C) : ¬ M.Indep C :=
   hC.dep.not_indep
 
-lemma Circuit.minimal (hC : M.Circuit C) : Minimal M.Dep C :=
+lemma IsCircuit.minimal (hC : M.IsCircuit C) : Minimal M.Dep C :=
   hC
 
 @[aesop unsafe 20% (rule_sets := [Matroid])]
-lemma Circuit.subset_ground (hC : M.Circuit C) : C ⊆ M.E :=
+lemma IsCircuit.subset_ground (hC : M.IsCircuit C) : C ⊆ M.E :=
   hC.dep.subset_ground
 
-lemma Circuit.nonempty (hC : M.Circuit C) : C.Nonempty :=
+lemma IsCircuit.nonempty (hC : M.IsCircuit C) : C.Nonempty :=
   hC.dep.nonempty
 
-lemma empty_not_circuit (M : Matroid α) : ¬M.Circuit ∅ :=
+lemma empty_not_isCircuit (M : Matroid α) : ¬M.IsCircuit ∅ :=
   fun h ↦ by simpa using h.nonempty
 
-lemma circuit_iff : M.Circuit C ↔ M.Dep C ∧ ∀ ⦃D⦄, M.Dep D → D ⊆ C → D = C := by
-  simp_rw [circuit_def, minimal_subset_iff, eq_comm (a := C)]
+lemma isCircuit_iff : M.IsCircuit C ↔ M.Dep C ∧ ∀ ⦃D⦄, M.Dep D → D ⊆ C → D = C := by
+  simp_rw [isCircuit_def, minimal_subset_iff, eq_comm (a := C)]
 
-lemma Circuit.ssubset_indep (hC : M.Circuit C) (hXC : X ⊂ C) : M.Indep X := by
+lemma IsCircuit.ssubset_indep (hC : M.IsCircuit C) (hXC : X ⊂ C) : M.Indep X := by
   rw [← not_dep_iff (hXC.subset.trans hC.subset_ground)]
-  exact fun h ↦ hXC.ne ((circuit_iff.1 hC).2 h hXC.subset)
+  exact fun h ↦ hXC.ne ((isCircuit_iff.1 hC).2 h hXC.subset)
 
-lemma Circuit.minimal_not_indep (hC : M.Circuit C) : Minimal (¬ M.Indep ·) C := by
+lemma IsCircuit.minimal_not_indep (hC : M.IsCircuit C) : Minimal (¬ M.Indep ·) C := by
   simp_rw [minimal_iff_forall_ssubset, and_iff_right hC.not_indep, not_not]
   exact fun ⦃t⦄ a ↦ ssubset_indep hC a
 
-lemma circuit_iff_minimal_not_indep (hCE : C ⊆ M.E) : M.Circuit C ↔ Minimal (¬ M.Indep ·) C :=
-  ⟨Circuit.minimal_not_indep, fun h ↦ ⟨(not_indep_iff hCE).1 h.prop,
+lemma isCircuit_iff_minimal_not_indep (hCE : C ⊆ M.E) : M.IsCircuit C ↔ Minimal (¬ M.Indep ·) C :=
+  ⟨IsCircuit.minimal_not_indep, fun h ↦ ⟨(not_indep_iff hCE).1 h.prop,
     fun _ hJ hJC ↦ (h.eq_of_superset hJ.not_indep hJC).le⟩⟩
 
-lemma Circuit.diff_singleton_indep (hC : M.Circuit C) (he : e ∈ C) : M.Indep (C \ {e}) :=
+lemma IsCircuit.diff_singleton_indep (hC : M.IsCircuit C) (he : e ∈ C) : M.Indep (C \ {e}) :=
   hC.ssubset_indep (diff_singleton_sSubset.2 he)
 
-lemma circuit_iff_forall_ssubset : M.Circuit C ↔ M.Dep C ∧ ∀ ⦃I⦄, I ⊂ C → M.Indep I := by
-  rw [Circuit, minimal_iff_forall_ssubset, and_congr_right_iff]
+lemma isCircuit_iff_forall_ssubset : M.IsCircuit C ↔ M.Dep C ∧ ∀ ⦃I⦄, I ⊂ C → M.Indep I := by
+  rw [IsCircuit, minimal_iff_forall_ssubset, and_congr_right_iff]
   exact fun h ↦ ⟨fun h' I hIC ↦ ((not_dep_iff (hIC.subset.trans h.subset_ground)).1 (h' hIC)),
     fun h I hIC ↦ (h hIC).not_dep⟩
 
-lemma circuit_antichain : IsAntichain (· ⊆ ·) (setOf M.Circuit) :=
-  fun _ hC _ hC' hne hss ↦ hne <| (Circuit.minimal hC').eq_of_subset hC.dep hss
+lemma isCircuit_antichain : IsAntichain (· ⊆ ·) (setOf M.IsCircuit) :=
+  fun _ hC _ hC' hne hss ↦ hne <| (IsCircuit.minimal hC').eq_of_subset hC.dep hss
 
-lemma Circuit.eq_of_not_indep_subset (hC : M.Circuit C) (hX : ¬ M.Indep X) (hXC : X ⊆ C) :
+lemma IsCircuit.eq_of_not_indep_subset (hC : M.IsCircuit C) (hX : ¬ M.Indep X) (hXC : X ⊆ C) :
     X = C :=
   eq_of_le_of_not_lt hXC (hX ∘ hC.ssubset_indep)
 
-lemma Circuit.eq_of_dep_subset (hC : M.Circuit C) (hX : M.Dep X) (hXC : X ⊆ C) : X = C :=
+lemma IsCircuit.eq_of_dep_subset (hC : M.IsCircuit C) (hX : M.Dep X) (hXC : X ⊆ C) : X = C :=
   hC.eq_of_not_indep_subset hX.not_indep hXC
 
-lemma Circuit.not_ssubset (hC : M.Circuit C) (hC' : M.Circuit C') : ¬C' ⊂ C :=
+lemma IsCircuit.not_ssubset (hC : M.IsCircuit C) (hC' : M.IsCircuit C') : ¬C' ⊂ C :=
   fun h' ↦ h'.ne (hC.eq_of_dep_subset hC'.dep h'.subset)
 
-lemma Circuit.eq_of_subset_circuit (hC : M.Circuit C) (hC' : M.Circuit C') (h : C ⊆ C') : C = C' :=
+lemma IsCircuit.eq_of_subset_isCircuit (hC : M.IsCircuit C) (hC' : M.IsCircuit C') (h : C ⊆ C') :
+    C = C' :=
   hC'.eq_of_dep_subset hC.dep h
 
-lemma Circuit.eq_of_superset_circuit (hC : M.Circuit C) (hC' : M.Circuit C') (h : C' ⊆ C) :
+lemma IsCircuit.eq_of_superset_isCircuit (hC : M.IsCircuit C) (hC' : M.IsCircuit C') (h : C' ⊆ C) :
     C = C' :=
-  (hC'.eq_of_subset_circuit hC h).symm
+  (hC'.eq_of_subset_isCircuit hC h).symm
 
-lemma circuit_iff_dep_forall_diff_singleton_indep :
-    M.Circuit C ↔ M.Dep C ∧ ∀ e ∈ C, M.Indep (C \ {e}) := by
+lemma isCircuit_iff_dep_forall_diff_singleton_indep :
+    M.IsCircuit C ↔ M.Dep C ∧ ∀ e ∈ C, M.Indep (C \ {e}) := by
   wlog hCE : C ⊆ M.E
-  · exact iff_of_false (hCE ∘ Circuit.subset_ground) (fun h ↦ hCE h.1.subset_ground)
-  simp [circuit_iff_minimal_not_indep hCE, ← not_indep_iff hCE,
+  · exact iff_of_false (hCE ∘ IsCircuit.subset_ground) (fun h ↦ hCE h.1.subset_ground)
+  simp [isCircuit_iff_minimal_not_indep hCE, ← not_indep_iff hCE,
     minimal_iff_forall_diff_singleton (P := (¬ M.Indep ·))
     (fun _ _ hY hYX hX ↦ hY <| hX.subset hYX)]
 
 /-! ### Independence and bases -/
 
-lemma Indep.insert_circuit_of_forall (hI : M.Indep I) (heI : e ∉ I) (he : e ∈ M.closure I)
-    (h : ∀ f ∈ I, e ∉ M.closure (I \ {f})) : M.Circuit (insert e I) := by
-  rw [circuit_iff_dep_forall_diff_singleton_indep, hI.insert_dep_iff, and_iff_right ⟨he, heI⟩]
+lemma Indep.insert_isCircuit_of_forall (hI : M.Indep I) (heI : e ∉ I) (he : e ∈ M.closure I)
+    (h : ∀ f ∈ I, e ∉ M.closure (I \ {f})) : M.IsCircuit (insert e I) := by
+  rw [isCircuit_iff_dep_forall_diff_singleton_indep, hI.insert_dep_iff, and_iff_right ⟨he, heI⟩]
   rintro f (rfl | hfI)
   · simpa [heI]
   rw [← insert_diff_singleton_comm (by rintro rfl; contradiction),
     (hI.diff _).insert_indep_iff_of_not_mem (by simp [heI])]
   exact ⟨mem_ground_of_mem_closure he, h f hfI⟩
 
-lemma Indep.insert_circuit_of_forall_of_nontrivial (hI : M.Indep I) (hInt : I.Nontrivial)
-    (he : e ∈ M.closure I) (h : ∀ f ∈ I, e ∉ M.closure (I \ {f})) : M.Circuit (insert e I) := by
-  refine hI.insert_circuit_of_forall (fun heI ↦ ?_) he h
+lemma Indep.insert_isCircuit_of_forall_of_nontrivial (hI : M.Indep I) (hInt : I.Nontrivial)
+    (he : e ∈ M.closure I) (h : ∀ f ∈ I, e ∉ M.closure (I \ {f})) : M.IsCircuit (insert e I) := by
+  refine hI.insert_isCircuit_of_forall (fun heI ↦ ?_) he h
   obtain ⟨f, hf, hne⟩ := hInt.exists_ne e
   exact h f hf (mem_closure_of_mem' _ (by simp [heI, hne.symm]))
 
-lemma Circuit.diff_singleton_basis (hC : M.Circuit C) (he : e ∈ C) : M.Basis (C \ {e}) C := by
+lemma IsCircuit.diff_singleton_isBasis (hC : M.IsCircuit C) (he : e ∈ C) :
+    M.IsBasis (C \ {e}) C := by
   nth_rw 2 [← insert_eq_of_mem he]
-  rw [← insert_diff_singleton, (hC.diff_singleton_indep he).basis_insert_iff,
+  rw [← insert_diff_singleton, (hC.diff_singleton_indep he).isBasis_insert_iff,
     insert_diff_singleton, insert_eq_of_mem he]
   exact Or.inl hC.dep
 
-lemma Circuit.basis_iff_eq_diff_singleton (hC : M.Circuit C) :
-    M.Basis I C ↔ ∃ e ∈ C, I = C \ {e} := by
+lemma IsCircuit.isBasis_iff_eq_diff_singleton (hC : M.IsCircuit C) :
+    M.IsBasis I C ↔ ∃ e ∈ C, I = C \ {e} := by
   refine ⟨fun h ↦ ?_, ?_⟩
   · obtain ⟨e, he⟩ := exists_of_ssubset
       (h.subset.ssubset_of_ne (by rintro rfl; exact hC.dep.not_indep h.indep))
     exact ⟨e, he.1, h.eq_of_subset_indep (hC.diff_singleton_indep he.1)
       (subset_diff_singleton h.subset he.2) diff_subset⟩
   rintro ⟨e, he, rfl⟩
-  exact hC.diff_singleton_basis he
+  exact hC.diff_singleton_isBasis he
 
-lemma Circuit.basis_iff_insert_eq (hC : M.Circuit C) :
-    M.Basis I C ↔ ∃ e ∈ C \ I, C = insert e I := by
-  rw [hC.basis_iff_eq_diff_singleton]
+lemma IsCircuit.isBasis_iff_insert_eq (hC : M.IsCircuit C) :
+    M.IsBasis I C ↔ ∃ e ∈ C \ I, C = insert e I := by
+  rw [hC.isBasis_iff_eq_diff_singleton]
   refine ⟨fun ⟨e, he, hI⟩ ↦ ⟨e, ⟨he, fun heI ↦ (hI.subset heI).2 rfl⟩, ?_⟩,
     fun ⟨e, he, hC⟩ ↦ ⟨e, he.1, ?_⟩⟩
   · rw [hI, insert_diff_singleton, insert_eq_of_mem he]
@@ -165,22 +169,23 @@ lemma Circuit.basis_iff_insert_eq (hC : M.Circuit C) :
 
 /-! ### Restriction -/
 
-lemma Circuit.circuit_restrict_of_subset (hC : M.Circuit C) (hCR : C ⊆ R) : (M ↾ R).Circuit C := by
-  simp_rw [circuit_iff, restrict_dep_iff, dep_iff, and_imp] at *
+lemma IsCircuit.isCircuit_restrict_of_subset (hC : M.IsCircuit C) (hCR : C ⊆ R) :
+    (M ↾ R).IsCircuit C := by
+  simp_rw [isCircuit_iff, restrict_dep_iff, dep_iff, and_imp] at *
   exact ⟨⟨hC.1.1, hCR⟩, fun I hI _ hIC ↦ hC.2 hI (hIC.trans hC.1.2) hIC⟩
 
-lemma restrict_circuit_iff (hR : R ⊆ M.E := by aesop_mat) :
-    (M ↾ R).Circuit C ↔ M.Circuit C ∧ C ⊆ R := by
-  refine ⟨?_, fun h ↦ h.1.circuit_restrict_of_subset h.2⟩
-  simp_rw [circuit_iff, restrict_dep_iff, and_imp, dep_iff]
+lemma restrict_isCircuit_iff (hR : R ⊆ M.E := by aesop_mat) :
+    (M ↾ R).IsCircuit C ↔ M.IsCircuit C ∧ C ⊆ R := by
+  refine ⟨?_, fun h ↦ h.1.isCircuit_restrict_of_subset h.2⟩
+  simp_rw [isCircuit_iff, restrict_dep_iff, and_imp, dep_iff]
   exact fun hC hCR h ↦ ⟨⟨⟨hC,hCR.trans hR⟩,fun I hI hIC ↦ h hI.1 (hIC.trans hCR) hIC⟩,hCR⟩
 
-/-! ### Fundamental Circuits -/
+/-! ### Fundamental IsCircuits -/
 
 /-- For an independent set `I` and some `e ∈ M.closure I \ I`,
-`M.fundCircuit e I` is the unique circuit contained in `insert e I`.
-For the fact that this is a circuit, see `Matroid.Indep.fundCircuit_circuit`,
-and the fact that it is unique, see `Matroid.Circuit.eq_fundCircuit_of_subset`.
+`M.fundCircuit e I` is the unique isCircuit contained in `insert e I`.
+For the fact that this is a isCircuit, see `Matroid.Indep.fundCircuit_isCircuit`,
+and the fact that it is unique, see `Matroid.IsCircuit.eq_fundCircuit_of_subset`.
 Has the junk value `{e}` if `e ∈ I` or `e ∉ M.E`, and `insert e I` if `e ∈ M.E \ M.closure I`. -/
 def fundCircuit (M : Matroid α) (e : α) (I : Set α) : Set α :=
   insert e (I ∩ ⋂₀ {J | J ⊆ I ∧ M.closure {e} ⊆ M.closure J})
@@ -208,7 +213,7 @@ lemma fundCircuit_diff_eq_inter (M : Matroid α) (heI : e ∉ I) :
   (subset_inter diff_subset (by simp [fundCircuit_subset_insert])).antisymm
     (subset_diff_singleton inter_subset_left (by simp [heI]))
 
-/-- The fundamental circuit of `e` and `X` has the junk value `{e}` if `e ∈ X` -/
+/-- The fundamental isCircuit of `e` and `X` has the junk value `{e}` if `e ∈ X` -/
 lemma fundCircuit_eq_of_mem (heX : e ∈ X) : M.fundCircuit e X = {e} := by
   suffices h : ∀ a ∈ X, (∀ t ⊆ X, M.closure {e} ⊆ M.closure t → a ∈ t) → a = e by
     simpa [subset_antisymm_iff, fundCircuit]
@@ -220,11 +225,11 @@ lemma fundCircuit_eq_of_not_mem_ground (heX : e ∉ M.E) : M.fundCircuit e X = {
   simp_rw [← M.closure_inter_ground {e}, singleton_inter_eq_empty.2 heX]
   exact fun a haX h ↦ by simpa using h ∅ (empty_subset X) rfl.subset
 
-lemma Indep.fundCircuit_circuit (hI : M.Indep I) (hecl : e ∈ M.closure I) (heI : e ∉ I) :
-    M.Circuit (M.fundCircuit e I) := by
+lemma Indep.fundCircuit_isCircuit (hI : M.Indep I) (hecl : e ∈ M.closure I) (heI : e ∉ I) :
+    M.IsCircuit (M.fundCircuit e I) := by
   have aux : ⋂₀ {J | J ⊆ I ∧ e ∈ M.closure J} ⊆ I := sInter_subset_of_mem (by simpa)
   rw [fundCircuit_eq_sInter hecl]
-  refine (hI.subset aux).insert_circuit_of_forall ?_ ?_ ?_
+  refine (hI.subset aux).insert_isCircuit_of_forall ?_ ?_ ?_
   · simp [show ∃ x ⊆ I, e ∈ M.closure x ∧ e ∉ x from ⟨I, by simp [hecl, heI]⟩]
   · rw [hI.closure_sInter_eq_biInter_closure_of_forall_subset ⟨I, by simpa⟩ (by simp +contextual)]
     simp
@@ -241,21 +246,21 @@ lemma Indep.mem_fundCircuit_iff (hI : M.Indep I) (hecl : e ∈ M.closure I) (heI
   refine ⟨fun h hecl ↦ (h _ diff_subset hecl).2 rfl, fun h J hJ heJ ↦ by_contra fun hxJ ↦ h ?_⟩
   exact M.closure_subset_closure (subset_diff_singleton hJ hxJ) heJ
 
-lemma Base.fundCircuit_circuit {B : Set α} (hB : M.IsBase B) (hxE : x ∈ M.E) (hxB : x ∉ B) :
-    M.Circuit (M.fundCircuit x B) :=
-  hB.indep.fundCircuit_circuit (by rwa [hB.closure_eq]) hxB
+lemma IsBase.fundCircuit_isCircuit {B : Set α} (hB : M.IsBase B) (hxE : x ∈ M.E) (hxB : x ∉ B) :
+    M.IsCircuit (M.fundCircuit x B) :=
+  hB.indep.fundCircuit_isCircuit (by rwa [hB.closure_eq]) hxB
 
 /-- For `I` independent, `M.fundCircuit e I` is the only circuit contained in `insert e I`. -/
-lemma Circuit.eq_fundCircuit_of_subset (hC : M.Circuit C) (hI : M.Indep I) (hCs : C ⊆ insert e I) :
-    C = M.fundCircuit e I := by
+lemma IsCircuit.eq_fundCircuit_of_subset (hC : M.IsCircuit C) (hI : M.Indep I)
+    (hCs : C ⊆ insert e I) : C = M.fundCircuit e I := by
   obtain hCI | ⟨heC, hCeI⟩ := subset_insert_iff.1 hCs
   · exact (hC.not_indep (hI.subset hCI)).elim
   suffices hss : M.fundCircuit e I ⊆ C by
-    refine hC.eq_of_superset_circuit (hI.fundCircuit_circuit ?_ fun heI ↦ ?_) hss
+    refine hC.eq_of_superset_isCircuit (hI.fundCircuit_isCircuit ?_ fun heI ↦ ?_) hss
     · rw [hI.mem_closure_iff]
       exact .inl (hC.dep.superset hCs (insert_subset (hC.subset_ground heC) hI.subset_ground))
     exact hC.not_indep (hI.subset (hCs.trans (by simp [heI])))
-  have heCcl := (hC.diff_singleton_basis heC).subset_closure heC
+  have heCcl := (hC.diff_singleton_isBasis heC).subset_closure heC
   have heI : e ∈ M.closure I := M.closure_subset_closure hCeI heCcl
   rw [fundCircuit_eq_sInter heI]
   refine insert_subset heC <| (sInter_subset_of_mem (t := C \ {e}) ?_).trans diff_subset
@@ -286,105 +291,106 @@ lemma fundCircuit_restrict {R : Set α} (hIR : I ⊆ R) (heR : e ∈ R) (hR : R 
 
 /-! ### Dependence -/
 
-lemma Dep.exists_circuit_subset (hX : M.Dep X) : ∃ C, C ⊆ X ∧ M.Circuit C := by
-  obtain ⟨I, hI⟩ := M.exists_basis X
+lemma Dep.exists_isCircuit_subset (hX : M.Dep X) : ∃ C, C ⊆ X ∧ M.IsCircuit C := by
+  obtain ⟨I, hI⟩ := M.exists_isBasis X
   obtain ⟨e, heX, heI⟩ := exists_of_ssubset
     (hI.subset.ssubset_of_ne (by rintro rfl; exact hI.indep.not_dep hX))
   exact ⟨M.fundCircuit e I, (M.fundCircuit_subset_insert e I).trans (insert_subset heX hI.subset),
-    hI.indep.fundCircuit_circuit (hI.subset_closure heX) heI⟩
+    hI.indep.fundCircuit_isCircuit (hI.subset_closure heX) heI⟩
 
-lemma dep_iff_superset_circuit (hX : X ⊆ M.E := by aesop_mat) :
-    M.Dep X ↔ ∃ C, C ⊆ X ∧ M.Circuit C :=
-  ⟨Dep.exists_circuit_subset, fun ⟨C, hCX, hC⟩ ↦ hC.dep.superset hCX⟩
+lemma dep_iff_superset_isCircuit (hX : X ⊆ M.E := by aesop_mat) :
+    M.Dep X ↔ ∃ C, C ⊆ X ∧ M.IsCircuit C :=
+  ⟨Dep.exists_isCircuit_subset, fun ⟨C, hCX, hC⟩ ↦ hC.dep.superset hCX⟩
 
-/-- A version of `Matroid.dep_iff_superset_circuit` that has the supportedness hypothesis
+/-- A version of `Matroid.dep_iff_superset_isCircuit` that has the supportedness hypothesis
 as part of the equivalence, rather than a hypothesis. -/
-lemma dep_iff_superset_circuit' : M.Dep X ↔ (∃ C, C ⊆ X ∧ M.Circuit C) ∧ X ⊆ M.E :=
-  ⟨fun h ↦ ⟨h.exists_circuit_subset, h.subset_ground⟩, fun ⟨⟨C, hCX, hC⟩, h⟩ ↦ hC.dep.superset hCX⟩
+lemma dep_iff_superset_isCircuit' : M.Dep X ↔ (∃ C, C ⊆ X ∧ M.IsCircuit C) ∧ X ⊆ M.E :=
+  ⟨fun h ↦ ⟨h.exists_isCircuit_subset, h.subset_ground⟩,
+    fun ⟨⟨C, hCX, hC⟩, h⟩ ↦ hC.dep.superset hCX⟩
 
-/-- A version of `Matroid.indep_iff_forall_subset_not_circuit` that has the supportedness hypothesis
-as part of the equivalence, rather than a hypothesis. -/
-lemma indep_iff_forall_subset_not_circuit' :
-    M.Indep I ↔ (∀ C, C ⊆ I → ¬M.Circuit C) ∧ I ⊆ M.E := by
-  simp_rw [indep_iff_not_dep, dep_iff_superset_circuit']
+/-- A version of `Matroid.indep_iff_forall_subset_not_isCircuit` that has the supportedness
+hypothesis as part of the equivalence, rather than a hypothesis. -/
+lemma indep_iff_forall_subset_not_isCircuit' :
+    M.Indep I ↔ (∀ C, C ⊆ I → ¬M.IsCircuit C) ∧ I ⊆ M.E := by
+  simp_rw [indep_iff_not_dep, dep_iff_superset_isCircuit']
   aesop
 
-lemma indep_iff_forall_subset_not_circuit (hI : I ⊆ M.E := by aesop_mat) :
-    M.Indep I ↔ ∀ C, C ⊆ I → ¬M.Circuit C := by
-  rw [indep_iff_forall_subset_not_circuit', and_iff_left hI]
+lemma indep_iff_forall_subset_not_isCircuit (hI : I ⊆ M.E := by aesop_mat) :
+    M.Indep I ↔ ∀ C, C ⊆ I → ¬M.IsCircuit C := by
+  rw [indep_iff_forall_subset_not_isCircuit', and_iff_left hI]
 
 /-! ### Closure -/
 
-lemma Circuit.closure_diff_singleton_eq (hC : M.Circuit C) (e : α) :
+lemma IsCircuit.closure_diff_singleton_eq (hC : M.IsCircuit C) (e : α) :
     M.closure (C \ {e}) = M.closure C :=
   (em (e ∈ C)).elim
-    (fun he ↦ by rw [(hC.diff_singleton_basis he).closure_eq_closure])
+    (fun he ↦ by rw [(hC.diff_singleton_isBasis he).closure_eq_closure])
     (fun he ↦ by rw [diff_singleton_eq_self he])
 
-lemma Circuit.subset_closure_diff_singleton (hC : M.Circuit C) (e : α) :
+lemma IsCircuit.subset_closure_diff_singleton (hC : M.IsCircuit C) (e : α) :
     C ⊆ M.closure (C \ {e}) := by
   rw [hC.closure_diff_singleton_eq]
   exact M.subset_closure _ hC.subset_ground
 
-lemma Circuit.mem_closure_diff_singleton_of_mem (hC : M.Circuit C) (heC : e ∈ C) :
+lemma IsCircuit.mem_closure_diff_singleton_of_mem (hC : M.IsCircuit C) (heC : e ∈ C) :
     e ∈ M.closure (C \ {e}) :=
   hC.subset_closure_diff_singleton e heC
 
-lemma exists_circuit_of_mem_closure (he : e ∈ M.closure X) (heX : e ∉ X) :
-    ∃ C ⊆ insert e X, M.Circuit C ∧ e ∈ C :=
-  let ⟨I, hI⟩ := M.exists_basis' X
+lemma exists_isCircuit_of_mem_closure (he : e ∈ M.closure X) (heX : e ∉ X) :
+    ∃ C ⊆ insert e X, M.IsCircuit C ∧ e ∈ C :=
+  let ⟨I, hI⟩ := M.exists_isBasis' X
   ⟨_, (fundCircuit_subset_insert ..).trans (insert_subset_insert hI.subset),
-    hI.indep.fundCircuit_circuit (by rwa [hI.closure_eq_closure]) (not_mem_subset
+    hI.indep.fundCircuit_isCircuit (by rwa [hI.closure_eq_closure]) (not_mem_subset
     hI.subset heX), M.mem_fundCircuit e I⟩
 
-lemma mem_closure_iff_exists_circuit (he : e ∉ X) :
-    e ∈ M.closure X ↔ ∃ C ⊆ insert e X, M.Circuit C ∧ e ∈ C :=
-  ⟨fun h ↦ exists_circuit_of_mem_closure h he, fun ⟨C, hCX, hC, heC⟩ ↦ mem_of_mem_of_subset
+lemma mem_closure_iff_exists_isCircuit (he : e ∉ X) :
+    e ∈ M.closure X ↔ ∃ C ⊆ insert e X, M.IsCircuit C ∧ e ∈ C :=
+  ⟨fun h ↦ exists_isCircuit_of_mem_closure h he, fun ⟨C, hCX, hC, heC⟩ ↦ mem_of_mem_of_subset
     (hC.mem_closure_diff_singleton_of_mem heC) (M.closure_subset_closure (by simpa))⟩
 
 /-! ### Extensionality -/
 
-lemma ext_circuit {M₁ M₂ : Matroid α} (hE : M₁.E = M₂.E)
-    (h : ∀ ⦃C⦄, C ⊆ M₁.E → (M₁.Circuit C ↔ M₂.Circuit C)) : M₁ = M₂ := by
-  have h' {C} : M₁.Circuit C ↔ M₂.Circuit C :=
-    (em (C ⊆ M₁.E)).elim (h (C := C)) (fun hC ↦ iff_of_false (mt Circuit.subset_ground hC)
-      (mt Circuit.subset_ground fun hss ↦ hC (hss.trans_eq hE.symm)))
+lemma ext_isCircuit {M₁ M₂ : Matroid α} (hE : M₁.E = M₂.E)
+    (h : ∀ ⦃C⦄, C ⊆ M₁.E → (M₁.IsCircuit C ↔ M₂.IsCircuit C)) : M₁ = M₂ := by
+  have h' {C} : M₁.IsCircuit C ↔ M₂.IsCircuit C :=
+    (em (C ⊆ M₁.E)).elim (h (C := C)) (fun hC ↦ iff_of_false (mt IsCircuit.subset_ground hC)
+      (mt IsCircuit.subset_ground fun hss ↦ hC (hss.trans_eq hE.symm)))
   refine ext_indep hE fun I hI ↦ ?_
-  simp_rw [indep_iff_forall_subset_not_circuit hI, h',
-    indep_iff_forall_subset_not_circuit (hI.trans_eq hE)]
+  simp_rw [indep_iff_forall_subset_not_isCircuit hI, h',
+    indep_iff_forall_subset_not_isCircuit (hI.trans_eq hE)]
 
-/-- A stronger version of `Matroid.ext_circuit`:
-two matroids on the same ground set are equal if no circuit of one is independent in the other. -/
-lemma ext_circuit_not_indep {M₁ M₂ : Matroid α} (hE : M₁.E = M₂.E)
-    (h₁ : ∀ C, M₁.Circuit C → ¬ M₂.Indep C) (h₂ : ∀ C, M₂.Circuit C → ¬ M₁.Indep C) :
+/-- A stronger version of `Matroid.ext_isCircuit`:
+two matroids on the same ground set are equal if no isCircuit of one is independent in the other. -/
+lemma ext_isCircuit_not_indep {M₁ M₂ : Matroid α} (hE : M₁.E = M₂.E)
+    (h₁ : ∀ C, M₁.IsCircuit C → ¬ M₂.Indep C) (h₂ : ∀ C, M₂.IsCircuit C → ¬ M₁.Indep C) :
     M₁ = M₂ := by
-  refine ext_circuit hE fun C hCE ↦ ⟨fun hC ↦ ?_, fun hC ↦ ?_⟩
-  · obtain ⟨C', hC'C, hC'⟩ := ((not_indep_iff (by rwa [← hE])).1 (h₁ C hC)).exists_circuit_subset
+  refine ext_isCircuit hE fun C hCE ↦ ⟨fun hC ↦ ?_, fun hC ↦ ?_⟩
+  · obtain ⟨C', hC'C, hC'⟩ := ((not_indep_iff (by rwa [← hE])).1 (h₁ C hC)).exists_isCircuit_subset
     rwa [← hC.eq_of_not_indep_subset (h₂ C' hC') hC'C]
-  obtain ⟨C', hC'C, hC'⟩ := ((not_indep_iff hCE).1 (h₂ C hC)).exists_circuit_subset
+  obtain ⟨C', hC'C, hC'⟩ := ((not_indep_iff hCE).1 (h₂ C hC)).exists_isCircuit_subset
   rwa [← hC.eq_of_not_indep_subset (h₁ C' hC') hC'C]
 
-lemma ext_iff_circuit {M₁ M₂ : Matroid α} :
-    M₁ = M₂ ↔ M₁.E = M₂.E ∧ ∀ C, M₁.Circuit C ↔ M₂.Circuit C :=
-  ⟨fun h ↦ by simp [h], fun h ↦ ext_circuit h.1 fun C hC ↦ h.2 (C := C)⟩
+lemma ext_iff_isCircuit {M₁ M₂ : Matroid α} :
+    M₁ = M₂ ↔ M₁.E = M₂.E ∧ ∀ C, M₁.IsCircuit C ↔ M₂.IsCircuit C :=
+  ⟨fun h ↦ by simp [h], fun h ↦ ext_isCircuit h.1 fun C hC ↦ h.2 (C := C)⟩
 
 section Elimination
 
-/-! ### Circuit Elimination -/
+/-! ### IsCircuit Elimination -/
 
 variable {ι : Type*} {J C₀ C₁ C₂ : Set α}
 
-/-- A version of `Matroid.Circuit.strong_multi_elimination` that is phrased using insertion. -/
-lemma Circuit.strong_multi_elimination_insert (x : ι → α) (I : ι → Set α) (z : α)
-    (hxI : ∀ i, x i ∉ I i) (hC : ∀ i, M.Circuit (insert (x i) (I i)))
-    (hJx : M.Circuit (J ∪ range x)) (hzJ : z ∈ J) (hzI : ∀ i, z ∉ I i) :
-    ∃ C' ⊆ J ∪ ⋃ i, I i, M.Circuit C' ∧ z ∈ C' := by
+/-- A version of `Matroid.IsCircuit.strong_multi_elimination` that is phrased using insertion. -/
+lemma IsCircuit.strong_multi_elimination_insert (x : ι → α) (I : ι → Set α) (z : α)
+    (hxI : ∀ i, x i ∉ I i) (hC : ∀ i, M.IsCircuit (insert (x i) (I i)))
+    (hJx : M.IsCircuit (J ∪ range x)) (hzJ : z ∈ J) (hzI : ∀ i, z ∉ I i) :
+    ∃ C' ⊆ J ∪ ⋃ i, I i, M.IsCircuit C' ∧ z ∈ C' := by
   -- we may assume that `ι` is nonempty, and it suffices to show that
   -- `z` is spanned by the union of the `I` and `J \ {z}`.
   obtain hι | hι := isEmpty_or_nonempty ι
   · exact ⟨J, by simp, by simpa [range_eq_empty] using hJx, hzJ⟩
   suffices hcl : z ∈ M.closure ((⋃ i, I i) ∪ (J \ {z})) by
-    rw [mem_closure_iff_exists_circuit (by simp [hzI])] at hcl
+    rw [mem_closure_iff_exists_isCircuit (by simp [hzI])] at hcl
     obtain ⟨C', hC'ss, hC', hzC'⟩ := hcl
     refine ⟨C', ?_, hC', hzC'⟩
     rwa [union_comm, ← insert_union, insert_diff_singleton, insert_eq_of_mem hzJ] at hC'ss
@@ -398,21 +404,21 @@ lemma Circuit.strong_multi_elimination_insert (x : ι → α) (I : ι → Set α
   rw [union_diff_distrib, union_comm]
   exact union_subset_union_left _ diff_subset
 
-/-- A generalization of the strong circuit elimination axiom `Matroid.Circuit.strong_elimination`
-to an infinite collection of circuits.
+/-- A generalization of the strong circuit elimination axiom `Matroid.IsCircuit.strong_elimination`
+to an infinite collection of isCircuits.
 
-It states that, given a circuit `C₀`, a arbitrary collection `C : ι → Set α` of circuits,
+It states that, given a isCircuit `C₀`, a arbitrary collection `C : ι → Set α` of isCircuits,
 an element `x i` of `C₀ ∩ C i` for each `i`, and an element `z ∈ C₀` outside all the `C i`,
-the union of `C₀` and the `C i` contains a circuit containing `z` but none of the `x i`.
+the union of `C₀` and the `C i` contains a isCircuit containing `z` but none of the `x i`.
 
-This is one of the axioms when defining infinite matroids via circuits.
+This is one of the axioms when defining infinite matroids via isCircuits.
 
 TODO : A similar statement will hold even when all mentions of `z` are removed. -/
-lemma Circuit.strong_multi_elimination (hC₀ : M.Circuit C₀) (x : ι → α) (C : ι → Set α) (z : α)
-    (hC : ∀ i, M.Circuit (C i)) (h_mem_C₀ : ∀ i, x i ∈ C₀) (h_mem : ∀ i, x i ∈ C i)
+lemma IsCircuit.strong_multi_elimination (hC₀ : M.IsCircuit C₀) (x : ι → α) (C : ι → Set α) (z : α)
+    (hC : ∀ i, M.IsCircuit (C i)) (h_mem_C₀ : ∀ i, x i ∈ C₀) (h_mem : ∀ i, x i ∈ C i)
     (h_unique : ∀ ⦃i i'⦄, x i ∈ C i' → i = i') (hzC₀ : z ∈ C₀) (hzC : ∀ i, z ∉ C i) :
-    ∃ C' ⊆ (C₀ ∪ ⋃ i, C i) \ range x, M.Circuit C' ∧ z ∈ C' := by
-  have hwin := Circuit.strong_multi_elimination_insert (M := M) x (fun i ↦ (C i \ {x i}))
+    ∃ C' ⊆ (C₀ ∪ ⋃ i, C i) \ range x, M.IsCircuit C' ∧ z ∈ C' := by
+  have hwin := IsCircuit.strong_multi_elimination_insert (M := M) x (fun i ↦ (C i \ {x i}))
     (J := C₀ \ range x) (z := z) (by simp) (fun i ↦ ?_) ?_ ⟨hzC₀, ?_⟩ ?_
   · obtain ⟨C', hC'ss, hC', hzC'⟩ := hwin
     refine ⟨C', hC'ss.trans ?_, hC', hzC'⟩
@@ -432,11 +438,11 @@ lemma Circuit.strong_multi_elimination (hC₀ : M.Circuit C₀) (x : ι → α) 
   simp only [mem_diff, mem_singleton_iff, not_and, not_not]
   exact fun i hzi ↦ (hzC i hzi).elim
 
-/-- A version of `Circuit.strong_multi_elimination` where the collection of circuits is
+/-- A version of `Circuit.strong_multi_elimination` where the collection of isCircuits is
 a `Set (Set α)` and the distinguished elements are a `Set α`, rather than both being indexed. -/
-lemma Circuit.strong_multi_elimination_set (hC₀ : M.Circuit C₀) (X : Set α) (S : Set (Set α))
-    (z : α) (hCS : ∀ C ∈ S, M.Circuit C) (hXC₀ : X ⊆ C₀) (hX : ∀ x ∈ X, ∃ C ∈ S, C ∩ X = {x})
-    (hzC₀ : z ∈ C₀) (hz : ∀ C ∈ S, z ∉ C) : ∃ C' ⊆ (C₀ ∪ ⋃₀ S) \ X, M.Circuit C' ∧ z ∈ C' := by
+lemma IsCircuit.strong_multi_elimination_set (hC₀ : M.IsCircuit C₀) (X : Set α) (S : Set (Set α))
+    (z : α) (hCS : ∀ C ∈ S, M.IsCircuit C) (hXC₀ : X ⊆ C₀) (hX : ∀ x ∈ X, ∃ C ∈ S, C ∩ X = {x})
+    (hzC₀ : z ∈ C₀) (hz : ∀ C ∈ S, z ∉ C) : ∃ C' ⊆ (C₀ ∪ ⋃₀ S) \ X, M.IsCircuit C' ∧ z ∈ C' := by
   choose! C hC using hX
   simp only [and_imp, forall_and, and_assoc] at hC
   have hwin := hC₀.strong_multi_elimination (fun x : X ↦ x) (fun x ↦ C x) z ?_ ?_ ?_ ?_ hzC₀ ?_
@@ -452,23 +458,23 @@ lemma Circuit.strong_multi_elimination_set (hC₀ : M.Circuit C₀) (X : Set α)
     simpa [hC.2 f hfX] using subset_inter (singleton_subset_iff.2 hef) (singleton_subset_iff.2 heX)
   simpa using fun e heX heC ↦ hz _ (hC.1 e heX) heC
 
-/-- The strong circuit elimination axiom. For any pair of distinct circuits `C₁, C₂` and all
-`e ∈ C₁ ∩ C₂` and `f ∈ C₁ \ C₂`, there is a circuit `C` with `f ∈ C ⊆ (C₁ ∪ C₂) \ {e}`. -/
-lemma Circuit.strong_elimination (hC₁ : M.Circuit C₁) (hC₂ : M.Circuit C₂) (heC₁ : e ∈ C₁)
+/-- The strong isCircuit elimination axiom. For any pair of distinct isCircuits `C₁, C₂` and all
+`e ∈ C₁ ∩ C₂` and `f ∈ C₁ \ C₂`, there is a isCircuit `C` with `f ∈ C ⊆ (C₁ ∪ C₂) \ {e}`. -/
+lemma IsCircuit.strong_elimination (hC₁ : M.IsCircuit C₁) (hC₂ : M.IsCircuit C₂) (heC₁ : e ∈ C₁)
     (heC₂ : e ∈ C₂) (hfC₁ : f ∈ C₁) (hfC₂ : f ∉ C₂) :
-    ∃ C ⊆ (C₁ ∪ C₂) \ {e}, M.Circuit C ∧ f ∈ C := by
+    ∃ C ⊆ (C₁ ∪ C₂) \ {e}, M.IsCircuit C ∧ f ∈ C := by
   obtain ⟨C, hCs, hC, hfC⟩ := hC₁.strong_multi_elimination (fun i : Unit ↦ e) (fun _ ↦ C₂) f
     (by simpa) (by simpa) (by simpa) (by simp) (by simpa) (by simpa)
   exact ⟨C, hCs.trans (diff_subset_diff (by simp) (by simp)), hC, hfC⟩
 
-/-- The circuit elimination axiom : for any pair of distinct circuits `C₁, C₂` and any `e`,
-some circuit is contained in `(C₁ ∪ C₂) \ {e}`.
+/-- The isCircuit elimination axiom : for any pair of distinct isCircuits `C₁, C₂` and any `e`,
+some isCircuit is contained in `(C₁ ∪ C₂) \ {e}`.
 
-This is one of the axioms when definining a finitary matroid via circuits;
+This is one of the axioms when definining a finitary matroid via isCircuits;
 as an axiom, it is usually stated with the extra assumption that `e ∈ C₁ ∩ C₂`. -/
-lemma Circuit.elimination (hC₁ : M.Circuit C₁) (hC₂ : M.Circuit C₂) (h : C₁ ≠ C₂) (e : α) :
-    ∃ C ⊆ (C₁ ∪ C₂) \ {e}, M.Circuit C := by
-  have hnss : ¬ (C₁ ⊆ C₂) := fun hss ↦ h <| hC₁.eq_of_subset_circuit hC₂ hss
+lemma IsCircuit.elimination (hC₁ : M.IsCircuit C₁) (hC₂ : M.IsCircuit C₂) (h : C₁ ≠ C₂) (e : α) :
+    ∃ C ⊆ (C₁ ∪ C₂) \ {e}, M.IsCircuit C := by
+  have hnss : ¬ (C₁ ⊆ C₂) := fun hss ↦ h <| hC₁.eq_of_subset_isCircuit hC₂ hss
   obtain ⟨f, hf₁, hf₂⟩ := not_subset.1 hnss
   by_cases he₁ : e ∈ C₁
   · by_cases he₂ : e ∈ C₂
@@ -481,16 +487,16 @@ end Elimination
 
 /-! ### Finitary Matroids -/
 
-lemma Circuit.finite [Finitary M] (hC : M.Circuit C) : C.Finite := by
+lemma IsCircuit.finite [Finitary M] (hC : M.IsCircuit C) : C.Finite := by
   have hi := hC.dep.not_indep
   rw [indep_iff_forall_finite_subset_indep] at hi; push_neg at hi
   obtain ⟨J, hJC, hJfin, hJ⟩ := hi
   rwa [← hC.eq_of_not_indep_subset hJ hJC]
 
-lemma finitary_iff_forall_circuit_finite : M.Finitary ↔ ∀ C, M.Circuit C → C.Finite := by
-  refine ⟨fun _ _ ↦ Circuit.finite, fun h ↦
+lemma finitary_iff_forall_isCircuit_finite : M.Finitary ↔ ∀ C, M.IsCircuit C → C.Finite := by
+  refine ⟨fun _ _ ↦ IsCircuit.finite, fun h ↦
     ⟨fun I hI ↦ indep_iff_not_dep.2 ⟨fun hd ↦ ?_,fun x hx ↦ ?_⟩⟩⟩
-  · obtain ⟨C, hCI, hC⟩ := hd.exists_circuit_subset
+  · obtain ⟨C, hCI, hC⟩ := hd.exists_isCircuit_subset
     exact hC.dep.not_indep <| hI _ hCI (h C hC)
   simpa using (hI {x} (by simpa) (finite_singleton _)).subset_ground
 
@@ -499,10 +505,10 @@ spanned by a finite independent subset of `X`.  -/
 lemma exists_mem_finite_closure_of_mem_closure [M.Finitary] (he : e ∈ M.closure X) :
     ∃ I ⊆ X, I.Finite ∧ M.Indep I ∧ e ∈ M.closure I := by
   by_cases heY : e ∈ X
-  · obtain ⟨J, hJ⟩ := M.exists_basis {e}
+  · obtain ⟨J, hJ⟩ := M.exists_isBasis {e}
     exact ⟨J, hJ.subset.trans (by simpa), (finite_singleton e).subset hJ.subset, hJ.indep,
       by simpa using hJ.subset_closure⟩
-  obtain ⟨C, hCs, hC, heC⟩ := exists_circuit_of_mem_closure he heY
+  obtain ⟨C, hCs, hC, heC⟩ := exists_isCircuit_of_mem_closure he heY
   exact ⟨C \ {e}, by simpa, hC.finite.diff, hC.diff_singleton_indep heC,
     hC.mem_closure_diff_singleton_of_mem heC⟩
 
@@ -512,7 +518,7 @@ lemma exists_subset_finite_closure_of_subset_closure [M.Finitary] (hX : X.Finite
     (hXY : X ⊆ M.closure Y) : ∃ I ⊆ Y, I.Finite ∧ M.Indep I ∧ X ⊆ M.closure I := by
   suffices aux : ∃ T ⊆ Y, T.Finite ∧ X ⊆ M.closure T by
     obtain ⟨T, hT, hTfin, hXT⟩ := aux
-    obtain ⟨I, hI⟩ := M.exists_basis' T
+    obtain ⟨I, hI⟩ := M.exists_isBasis' T
     exact ⟨_, hI.subset.trans hT, hTfin.subset hI.subset, hI.indep, by rwa [hI.closure_eq_closure]⟩
   refine Finite.induction_on_subset X hX ⟨∅, by simp⟩ (@fun e Z heX _ heZ ⟨T, hTY, hTfin, hT⟩ ↦ ?_)
   obtain ⟨S, hSY, hSfin, -, heS⟩ := exists_mem_finite_closure_of_mem_closure (hXY heX)

--- a/Mathlib/Data/Matroid/Closure.lean
+++ b/Mathlib/Data/Matroid/Closure.lean
@@ -85,7 +85,7 @@ variable {ι α : Type*} {M : Matroid α} {F X Y : Set α} {e f : α}
 
 section IsFlat
 
-/-- A isFlat is a maximal set having a given isBasis  -/
+/-- A flat is a maximal set having a given basis  -/
 @[mk_iff]
 structure IsFlat (M : Matroid α) (F : Set α) : Prop where
   subset_of_isBasis_of_isBasis : ∀ ⦃I X⦄, M.IsBasis I F → M.IsBasis I X → X ⊆ F
@@ -107,10 +107,10 @@ lemma IsFlat.iInter {ι : Type*} [Nonempty ι] {Fs : ι → Set α}
   convert hIJ.isBasis_union (hIX.isBasis_union_of_subset hIJ.indep hJ) using 1
   rw [← union_assoc, union_eq_self_of_subset_right hIJ.subset]
 
-/-- The property of being a isFlat gives rise to a `ClosureOperator` on the subsets of `M.E`,
-in which the `IsClosed` sets correspond to `IsFlat`s.
+/-- The property of being a flat gives rise to a `ClosureOperator` on the subsets of `M.E`,
+in which the `IsClosed` sets correspond to flats.
 (We can't define such an operator on all of `Set α`,
-since this would incorrectly force `univ` to always be a isFlat.) -/
+since this would incorrectly force `univ` to always be a flat.) -/
 def subtypeClosure (M : Matroid α) : ClosureOperator (Iic M.E) :=
   ClosureOperator.ofCompletePred (fun F ↦ M.IsFlat F.1) fun s hs ↦ by
     obtain (rfl | hne) := s.eq_empty_or_nonempty
@@ -128,7 +128,7 @@ lemma isClosed_iff_isFlat {F : Iic M.E} : M.subtypeClosure.IsClosed F ↔ M.IsFl
 
 end IsFlat
 
-/-- The closure of `X ⊆ M.E` is the intersection of all the isFlats of `M` containing `X`.
+/-- The closure of `X ⊆ M.E` is the intersection of all the flats of `M` containing `X`.
 A set `X` that doesn't satisfy `X ⊆ M.E` has the junk value `M.closure X := M.closure (X ∩ M.E)`. -/
 def closure (M : Matroid α) (X : Set α) : Set α := ⋂₀ {F | M.IsFlat F ∧ X ∩ M.E ⊆ F}
 
@@ -727,7 +727,7 @@ section Spanning
 variable {S T I B : Set α}
 
 /-- A set is `spanning` in `M` if its closure is equal to `M.E`, or equivalently if it contains
-  a isBase of `M`. -/
+a base of `M`. -/
 @[mk_iff]
 structure Spanning (M : Matroid α) (S : Set α) : Prop where
   closure_eq : M.closure S = M.E

--- a/Mathlib/Data/Matroid/Closure.lean
+++ b/Mathlib/Data/Matroid/Closure.lean
@@ -10,23 +10,23 @@ import Mathlib.Order.CompleteLatticeIntervals
 /-!
 # Matroid Closure
 
-A `Flat` of a matroid `M` is a combinatorial analogue of a subspace of a vector space,
-and is defined to be a subset `F` of the ground set of `M` such that for each basis
-`I` for `M`, every set having `I` as a basis is contained in `F`.
+A `IsFlat` of a matroid `M` is a combinatorial analogue of a subspace of a vector space,
+and is defined to be a subset `F` of the ground set of `M` such that for each isBasis
+`I` for `M`, every set having `I` as a isBasis is contained in `F`.
 
 The *closure* of a set `X` in a matroid `M` is the intersection of all flats of `M` containing `X`.
 This is a combinatorial analogue of the linear span of a set of vectors.
 
-For `M : Matroid α`, this file defines a predicate `M.Flat : Set α → Prop` and a function
+For `M : Matroid α`, this file defines a predicate `M.IsFlat : Set α → Prop` and a function
 `M.closure : Set α → Set α` corresponding to these notions, and develops API for the latter.
-API for `Matroid.Flat` will appear in another file; we include the definition here since
+API for `Matroid.IsFlat` will appear in another file; we include the definition here since
 it is used in the definition of `Matroid.closure`.
 
 We also define a predicate `Spanning`, to describe a set whose closure is the entire ground set.
 
 ## Main definitions
 
-* For `M : Matroid α` and `F : Set α`, `M.Flat F` means that `F` is a flat of `M`.
+* For `M : Matroid α` and `F : Set α`, `M.IsFlat F` means that `F` is a isFlat of `M`.
 * For `M : Matroid α` and `X : Set α`, `M.closure X` is the closure of `X` in `M`.
 * For `M : Matroid α` and `X : ↑(Iic M.E)` (i.e. a bundled subset of `M.E`),
   `M.subtypeClosure X` is the closure of `X`, viewed as a term in `↑(Iic M.E)`.
@@ -59,7 +59,7 @@ It has a couple of other advantages too: it is actually the closure function of 
 with ground set `univ` (specifically, the direct sum of `M` and a free matroid on `M.Eᶜ`),
 and because of this, it is an example of a `ClosureOperator` on `α`, which in turn gives access
 to nice existing API for both `ClosureOperator` and `GaloisInsertion`.
-This also relates to flats; `F ⊆ M.E ∧ ClosureOperator.IsClosed F` is equivalent to `M.Flat F`.
+This also relates to flats; `F ⊆ M.E ∧ ClosureOperator.IsClosed F` is equivalent to `M.IsFlat F`.
 (All of this fails for choice (1), since `X ⊆ M.closure X` is required for
 a `ClosureOperator`, but isn't true for non-subsets of `M.E`)
 
@@ -72,7 +72,7 @@ the subtype `↑(Iic M.E)` via `Matroid.SubtypeClosure`, albeit less elegantly.
 
 ## Naming conventions
 
-In lemma names, the words `spanning` and `flat` are used as suffixes,
+In lemma names, the words `spanning` and `isFlat` are used as suffixes,
 for instance we have `ground_spanning` rather than `spanning_ground`.
 -/
 
@@ -83,72 +83,75 @@ namespace Matroid
 
 variable {ι α : Type*} {M : Matroid α} {F X Y : Set α} {e f : α}
 
-section Flat
+section IsFlat
 
-/-- A flat is a maximal set having a given basis  -/
+/-- A isFlat is a maximal set having a given isBasis  -/
 @[mk_iff]
-structure Flat (M : Matroid α) (F : Set α) : Prop where
-  subset_of_basis_of_basis : ∀ ⦃I X⦄, M.Basis I F → M.Basis I X → X ⊆ F
+structure IsFlat (M : Matroid α) (F : Set α) : Prop where
+  subset_of_isBasis_of_isBasis : ∀ ⦃I X⦄, M.IsBasis I F → M.IsBasis I X → X ⊆ F
   subset_ground : F ⊆ M.E
 
-attribute [aesop unsafe 20% (rule_sets := [Matroid])] Flat.subset_ground
+@[deprecated (since := "2025-02-14")] alias Flat := IsFlat
 
-@[simp] lemma ground_flat (M : Matroid α) : M.Flat M.E :=
-  ⟨fun _ _ _ ↦ Basis.subset_ground, Subset.rfl⟩
+attribute [aesop unsafe 20% (rule_sets := [Matroid])] IsFlat.subset_ground
 
-lemma Flat.iInter {ι : Type*} [Nonempty ι] {Fs : ι → Set α}
-    (hFs : ∀ i, M.Flat (Fs i)) : M.Flat (⋂ i, Fs i) := by
+@[simp] lemma ground_isFlat (M : Matroid α) : M.IsFlat M.E :=
+  ⟨fun _ _ _ ↦ IsBasis.subset_ground, Subset.rfl⟩
+
+lemma IsFlat.iInter {ι : Type*} [Nonempty ι] {Fs : ι → Set α}
+    (hFs : ∀ i, M.IsFlat (Fs i)) : M.IsFlat (⋂ i, Fs i) := by
   refine ⟨fun I X hI hIX ↦ subset_iInter fun i ↦ ?_,
     (iInter_subset _ (Classical.arbitrary _)).trans (hFs _).subset_ground⟩
-  obtain ⟨J, hIJ, hJ⟩ := hI.indep.subset_basis_of_subset (hI.subset.trans (iInter_subset _ i))
+  obtain ⟨J, hIJ, hJ⟩ := hI.indep.subset_isBasis_of_subset (hI.subset.trans (iInter_subset _ i))
   refine subset_union_right.trans ((hFs i).1 (X := Fs i ∪ X) hIJ ?_)
-  convert hIJ.basis_union (hIX.basis_union_of_subset hIJ.indep hJ) using 1
+  convert hIJ.isBasis_union (hIX.isBasis_union_of_subset hIJ.indep hJ) using 1
   rw [← union_assoc, union_eq_self_of_subset_right hIJ.subset]
 
-/-- The property of being a flat gives rise to a `ClosureOperator` on the subsets of `M.E`,
-in which the `IsClosed` sets correspond to `Flat`s.
+/-- The property of being a isFlat gives rise to a `ClosureOperator` on the subsets of `M.E`,
+in which the `IsClosed` sets correspond to `IsFlat`s.
 (We can't define such an operator on all of `Set α`,
-since this would incorrectly force `univ` to always be a flat.) -/
+since this would incorrectly force `univ` to always be a isFlat.) -/
 def subtypeClosure (M : Matroid α) : ClosureOperator (Iic M.E) :=
-  ClosureOperator.ofCompletePred (fun F ↦ M.Flat F.1) fun s hs ↦ by
+  ClosureOperator.ofCompletePred (fun F ↦ M.IsFlat F.1) fun s hs ↦ by
     obtain (rfl | hne) := s.eq_empty_or_nonempty
     · simp
     have _ := hne.coe_sort
-    convert Flat.iInter (M := M) (Fs := fun (F : s) ↦ F.1.1) (fun F ↦ hs F.1 F.2)
+    convert IsFlat.iInter (M := M) (Fs := fun (F : s) ↦ F.1.1) (fun F ↦ hs F.1 F.2)
     ext
     aesop
 
-lemma flat_iff_isClosed : M.Flat F ↔ ∃ h : F ⊆ M.E, M.subtypeClosure.IsClosed ⟨F, h⟩ := by
-  simpa [subtypeClosure] using Flat.subset_ground
+lemma isFlat_iff_isClosed : M.IsFlat F ↔ ∃ h : F ⊆ M.E, M.subtypeClosure.IsClosed ⟨F, h⟩ := by
+  simpa [subtypeClosure] using IsFlat.subset_ground
 
-lemma isClosed_iff_flat {F : Iic M.E} : M.subtypeClosure.IsClosed F ↔ M.Flat F := by
+lemma isClosed_iff_isFlat {F : Iic M.E} : M.subtypeClosure.IsClosed F ↔ M.IsFlat F := by
   simp [subtypeClosure]
 
-end Flat
+end IsFlat
 
-/-- The closure of `X ⊆ M.E` is the intersection of all the flats of `M` containing `X`.
+/-- The closure of `X ⊆ M.E` is the intersection of all the isFlats of `M` containing `X`.
 A set `X` that doesn't satisfy `X ⊆ M.E` has the junk value `M.closure X := M.closure (X ∩ M.E)`. -/
-def closure (M : Matroid α) (X : Set α) : Set α := ⋂₀ {F | M.Flat F ∧ X ∩ M.E ⊆ F}
+def closure (M : Matroid α) (X : Set α) : Set α := ⋂₀ {F | M.IsFlat F ∧ X ∩ M.E ⊆ F}
 
-lemma closure_def (M : Matroid α) (X : Set α) : M.closure X = ⋂₀ {F | M.Flat F ∧ X ∩ M.E ⊆ F} := rfl
+lemma closure_def (M : Matroid α) (X : Set α) : M.closure X = ⋂₀ {F | M.IsFlat F ∧ X ∩ M.E ⊆ F} :=
+  rfl
 
 lemma closure_def' (M : Matroid α) (X : Set α) (hX : X ⊆ M.E := by aesop_mat) :
-    M.closure X = ⋂₀ {F | M.Flat F ∧ X ⊆ F} := by
+    M.closure X = ⋂₀ {F | M.IsFlat F ∧ X ⊆ F} := by
   rw [closure, inter_eq_self_of_subset_left hX]
 
-instance : Nonempty {F | M.Flat F ∧ X ∩ M.E ⊆ F} := ⟨M.E, M.ground_flat, inter_subset_right⟩
+instance : Nonempty {F | M.IsFlat F ∧ X ∩ M.E ⊆ F} := ⟨M.E, M.ground_isFlat, inter_subset_right⟩
 
 lemma closure_eq_subtypeClosure (M : Matroid α) (X : Set α) :
     M.closure X = M.subtypeClosure ⟨X ∩ M.E, inter_subset_right⟩  := by
-  suffices ∀ (x : α), (∀ (t : Set α), M.Flat t → X ∩ M.E ⊆ t → x ∈ t) ↔
-    (x ∈ M.E ∧ ∀ a ⊆ M.E, X ∩ M.E ⊆ a → M.Flat a → x ∈ a) by
+  suffices ∀ (x : α), (∀ (t : Set α), M.IsFlat t → X ∩ M.E ⊆ t → x ∈ t) ↔
+    (x ∈ M.E ∧ ∀ a ⊆ M.E, X ∩ M.E ⊆ a → M.IsFlat a → x ∈ a) by
     simpa [closure, subtypeClosure, Set.ext_iff]
-  exact fun x ↦ ⟨fun h ↦ ⟨h _ M.ground_flat inter_subset_right, fun F _ hXF hF ↦ h F hF hXF⟩,
+  exact fun x ↦ ⟨fun h ↦ ⟨h _ M.ground_isFlat inter_subset_right, fun F _ hXF hF ↦ h F hF hXF⟩,
     fun ⟨_, h⟩ F hF hXF ↦ h F hF.subset_ground hXF hF⟩
 
 @[aesop unsafe 10% (rule_sets := [Matroid])]
 lemma closure_subset_ground (M : Matroid α) (X : Set α) : M.closure X ⊆ M.E :=
-  sInter_subset_of_mem ⟨M.ground_flat, inter_subset_right⟩
+  sInter_subset_of_mem ⟨M.ground_isFlat, inter_subset_right⟩
 
 @[simp] lemma ground_subset_closure_iff : M.E ⊆ M.closure X ↔ M.closure X = M.E := by
   simp [M.closure_subset_ground X, subset_antisymm_iff]
@@ -160,26 +163,26 @@ lemma closure_subset_ground (M : Matroid α) (X : Set α) : M.closure X ⊆ M.E 
 lemma inter_ground_subset_closure (M : Matroid α) (X : Set α) : X ∩ M.E ⊆ M.closure X := by
   simp_rw [closure_def, subset_sInter_iff]; simp
 
-lemma mem_closure_iff_forall_mem_flat (X : Set α) (hX : X ⊆ M.E := by aesop_mat) :
-    e ∈ M.closure X ↔ ∀ F, M.Flat F → X ⊆ F → e ∈ F := by
+lemma mem_closure_iff_forall_mem_isFlat (X : Set α) (hX : X ⊆ M.E := by aesop_mat) :
+    e ∈ M.closure X ↔ ∀ F, M.IsFlat F → X ⊆ F → e ∈ F := by
   simp_rw [M.closure_def' X, mem_sInter, mem_setOf, and_imp]
 
-lemma subset_closure_iff_forall_subset_flat (X : Set α) (hX : X ⊆ M.E := by aesop_mat) :
-    Y ⊆ M.closure X ↔ ∀ F, M.Flat F → X ⊆ F → Y ⊆ F := by
+lemma subset_closure_iff_forall_subset_isFlat (X : Set α) (hX : X ⊆ M.E := by aesop_mat) :
+    Y ⊆ M.closure X ↔ ∀ F, M.IsFlat F → X ⊆ F → Y ⊆ F := by
   simp_rw [M.closure_def' X, subset_sInter_iff, mem_setOf, and_imp]
 
 lemma subset_closure (M : Matroid α) (X : Set α) (hX : X ⊆ M.E := by aesop_mat) :
     X ⊆ M.closure X := by
   simp [M.closure_def' X, subset_sInter_iff]
 
-lemma Flat.closure (hF : M.Flat F) : M.closure F = F :=
+lemma IsFlat.closure (hF : M.IsFlat F) : M.closure F = F :=
   (sInter_subset_of_mem (by simpa)).antisymm (M.subset_closure F)
 
 variable (X) in
-@[simp] lemma flat_closure : M.Flat (M.closure X) := by
+@[simp] lemma isFlat_closure : M.IsFlat (M.closure X) := by
   rw [closure, sInter_eq_iInter]; exact .iInter (·.2.1)
 
-lemma flat_iff_closure_eq : M.Flat F ↔ M.closure F = F := ⟨(·.closure), (· ▸ flat_closure F)⟩
+lemma isFlat_iff_closure_eq : M.IsFlat F ↔ M.closure F = F := ⟨(·.closure), (· ▸ isFlat_closure F)⟩
 
 @[simp] lemma closure_ground (M : Matroid α) : M.closure M.E = M.E :=
   (M.closure_subset_ground M.E).antisymm (M.subset_closure M.E)
@@ -309,55 +312,55 @@ section Indep
 
 variable {ι : Sort*} {I J B : Set α} {x : α}
 
-lemma Indep.closure_eq_setOf_basis_insert (hI : M.Indep I) :
-    M.closure I = {x | M.Basis I (insert x I)} := by
-  set F := {x | M.Basis I (insert x I)}
-  have hIF : M.Basis I F := hI.basis_setOf_insert_basis
+lemma Indep.closure_eq_setOf_isBasis_insert (hI : M.Indep I) :
+    M.closure I = {x | M.IsBasis I (insert x I)} := by
+  set F := {x | M.IsBasis I (insert x I)}
+  have hIF : M.IsBasis I F := hI.isBasis_setOf_insert_isBasis
 
-  have hF : M.Flat F := by
-    refine ⟨fun J X hJF hJX e heX ↦ show M.Basis _ _ from ?_, hIF.subset_ground⟩
-    exact (hIF.basis_of_basis_of_subset_of_subset (hJX.basis_union hJF) hJF.subset
-      (hIF.subset.trans subset_union_right)).basis_subset (subset_insert _ _)
+  have hF : M.IsFlat F := by
+    refine ⟨fun J X hJF hJX e heX ↦ show M.IsBasis _ _ from ?_, hIF.subset_ground⟩
+    exact (hIF.isBasis_of_isBasis_of_subset_of_subset (hJX.isBasis_union hJF) hJF.subset
+      (hIF.subset.trans subset_union_right)).isBasis_subset (subset_insert _ _)
       (insert_subset (Or.inl heX) (hIF.subset.trans subset_union_right))
 
   rw [subset_antisymm_iff, closure_def, subset_sInter_iff, and_iff_right (sInter_subset_of_mem _)]
-  · rintro F' ⟨hF', hIF'⟩ e (he : M.Basis I (insert e I))
+  · rintro F' ⟨hF', hIF'⟩ e (he : M.IsBasis I (insert e I))
     rw [inter_eq_left.mpr (hIF.subset.trans hIF.subset_ground)] at hIF'
-    obtain ⟨J, hJ, hIJ⟩ := hI.subset_basis_of_subset hIF' hF'.2
-    exact (hF'.1 hJ (he.basis_union_of_subset hJ.indep hIJ)) (Or.inr (mem_insert _ _))
+    obtain ⟨J, hJ, hIJ⟩ := hI.subset_isBasis_of_subset hIF' hF'.2
+    exact (hF'.1 hJ (he.isBasis_union_of_subset hJ.indep hIJ)) (Or.inr (mem_insert _ _))
   exact ⟨hF, inter_subset_left.trans hIF.subset⟩
 
-lemma Indep.insert_basis_iff_mem_closure (hI : M.Indep I) :
-    M.Basis I (insert e I) ↔ e ∈ M.closure I := by
-  rw [hI.closure_eq_setOf_basis_insert, mem_setOf]
+lemma Indep.insert_isBasis_iff_mem_closure (hI : M.Indep I) :
+    M.IsBasis I (insert e I) ↔ e ∈ M.closure I := by
+  rw [hI.closure_eq_setOf_isBasis_insert, mem_setOf]
 
-lemma Indep.basis_closure (hI : M.Indep I) : M.Basis I (M.closure I) := by
-  rw [hI.closure_eq_setOf_basis_insert]; exact hI.basis_setOf_insert_basis
+lemma Indep.isBasis_closure (hI : M.Indep I) : M.IsBasis I (M.closure I) := by
+  rw [hI.closure_eq_setOf_isBasis_insert]; exact hI.isBasis_setOf_insert_isBasis
 
-lemma Basis.closure_eq_closure (h : M.Basis I X) : M.closure I = M.closure X := by
+lemma IsBasis.closure_eq_closure (h : M.IsBasis I X) : M.closure I = M.closure X := by
   refine subset_antisymm (M.closure_subset_closure h.subset) ?_
-  rw [← M.closure_closure I, h.indep.closure_eq_setOf_basis_insert]
-  exact M.closure_subset_closure fun e he ↦ (h.basis_subset (subset_insert _ _)
+  rw [← M.closure_closure I, h.indep.closure_eq_setOf_isBasis_insert]
+  exact M.closure_subset_closure fun e he ↦ (h.isBasis_subset (subset_insert _ _)
     (insert_subset he h.subset))
 
-lemma Basis.closure_eq_right (h : M.Basis I (M.closure X)) : M.closure I = M.closure X :=
+lemma IsBasis.closure_eq_right (h : M.IsBasis I (M.closure X)) : M.closure I = M.closure X :=
   M.closure_closure X ▸ h.closure_eq_closure
 
-lemma Basis'.closure_eq_closure (h : M.Basis' I X) : M.closure I = M.closure X := by
-  rw [← closure_inter_ground _ X, h.basis_inter_ground.closure_eq_closure]
+lemma IsBasis'.closure_eq_closure (h : M.IsBasis' I X) : M.closure I = M.closure X := by
+  rw [← closure_inter_ground _ X, h.isBasis_inter_ground.closure_eq_closure]
 
-lemma Basis.subset_closure (h : M.Basis I X) : X ⊆ M.closure I := by
+lemma IsBasis.subset_closure (h : M.IsBasis I X) : X ⊆ M.closure I := by
   rw [← closure_subset_closure_iff_subset_closure, h.closure_eq_closure]
 
-lemma Basis'.basis_closure_right (h : M.Basis' I X) : M.Basis I (M.closure X) := by
-  rw [← h.closure_eq_closure]; exact h.indep.basis_closure
+lemma IsBasis'.isBasis_closure_right (h : M.IsBasis' I X) : M.IsBasis I (M.closure X) := by
+  rw [← h.closure_eq_closure]; exact h.indep.isBasis_closure
 
-lemma Basis.basis_closure_right (h : M.Basis I X) : M.Basis I (M.closure X) :=
-  h.basis'.basis_closure_right
+lemma IsBasis.isBasis_closure_right (h : M.IsBasis I X) : M.IsBasis I (M.closure X) :=
+  h.isBasis'.isBasis_closure_right
 
 lemma Indep.mem_closure_iff (hI : M.Indep I) :
     x ∈ M.closure I ↔ M.Dep (insert x I) ∨ x ∈ I := by
-  rwa [hI.closure_eq_setOf_basis_insert, mem_setOf, basis_insert_iff]
+  rwa [hI.closure_eq_setOf_isBasis_insert, mem_setOf, isBasis_insert_iff]
 
 lemma Indep.mem_closure_iff' (hI : M.Indep I) :
     x ∈ M.closure I ↔ x ∈ M.E ∧ (M.Indep (insert x I) → x ∈ I) := by
@@ -409,26 +412,26 @@ lemma Indep.insert_diff_indep_iff (hI : M.Indep (I \ {e})) (heI : e ∈ I) :
   rw [← insert_diff_singleton_comm hne.symm, hI.insert_indep_iff, mem_diff_singleton,
     and_iff_left hne.symm]
 
-lemma Indep.basis_of_subset_of_subset_closure (hI : M.Indep I) (hIX : I ⊆ X)
-    (hXI : X ⊆ M.closure I) : M.Basis I X :=
-  hI.basis_closure.basis_subset hIX hXI
+lemma Indep.isBasis_of_subset_of_subset_closure (hI : M.Indep I) (hIX : I ⊆ X)
+    (hXI : X ⊆ M.closure I) : M.IsBasis I X :=
+  hI.isBasis_closure.isBasis_subset hIX hXI
 
-lemma basis_iff_indep_subset_closure : M.Basis I X ↔ M.Indep I ∧ I ⊆ X ∧ X ⊆ M.closure I :=
+lemma isBasis_iff_indep_subset_closure : M.IsBasis I X ↔ M.Indep I ∧ I ⊆ X ∧ X ⊆ M.closure I :=
   ⟨fun h ↦ ⟨h.indep, h.subset, h.subset_closure⟩,
-    fun h ↦ h.1.basis_of_subset_of_subset_closure h.2.1 h.2.2⟩
+    fun h ↦ h.1.isBasis_of_subset_of_subset_closure h.2.1 h.2.2⟩
 
 lemma Indep.isBase_of_ground_subset_closure (hI : M.Indep I) (h : M.E ⊆ M.closure I) :
     M.IsBase I := by
-  rw [← basis_ground_iff]; exact hI.basis_of_subset_of_subset_closure hI.subset_ground h
+  rw [← isBasis_ground_iff]; exact hI.isBasis_of_subset_of_subset_closure hI.subset_ground h
 
 lemma IsBase.closure_eq (hB : M.IsBase B) : M.closure B = M.E := by
-  rw [← basis_ground_iff] at hB; rw [hB.closure_eq_closure, closure_ground]
+  rw [← isBasis_ground_iff] at hB; rw [hB.closure_eq_closure, closure_ground]
 
 lemma IsBase.closure_of_superset (hB : M.IsBase B) (hBX : B ⊆ X) : M.closure X = M.E :=
   (M.closure_subset_ground _).antisymm (hB.closure_eq ▸ M.closure_subset_closure hBX)
 
 lemma isBase_iff_indep_closure_eq : M.IsBase B ↔ M.Indep B ∧ M.closure B = M.E := by
-  rw [← basis_ground_iff, basis_iff_indep_subset_closure, and_congr_right_iff]
+  rw [← isBasis_ground_iff, isBasis_iff_indep_subset_closure, and_congr_right_iff]
   exact fun hI ↦ ⟨fun h ↦ (M.closure_subset_ground _).antisymm h.2,
     fun h ↦ ⟨(M.subset_closure B).trans_eq h, h.symm.subset⟩⟩
 
@@ -440,7 +443,7 @@ lemma Indep.closure_inter_eq_self_of_subset (hI : M.Indep I) (hJI : J ⊆ I) :
   have hJ := hI.subset hJI
   rw [subset_antisymm_iff, and_iff_left (subset_inter (M.subset_closure _) hJI)]
   rintro e ⟨heJ, heI⟩
-  exact hJ.basis_closure.mem_of_insert_indep heJ (hI.subset (insert_subset heI hJI))
+  exact hJ.isBasis_closure.mem_of_insert_indep heJ (hI.subset (insert_subset heI hJI))
 
 /-- For a nonempty collection of subsets of a given independent set,
 the closure of the intersection is the intersection of the closure. -/
@@ -459,15 +462,15 @@ lemma Indep.closure_sInter_eq_biInter_closure_of_forall_subset {Js : Set (Set α
     exact ⟨he X hX', heI⟩
 
   rw [hiI.not_mem_closure_iff_of_not_mem (not_mem_subset hiX heEI.2)] at he'
-  obtain ⟨J, hJI, heJ⟩ := he'.subset_basis_of_subset (insert_subset_insert hiX)
+  obtain ⟨J, hJI, heJ⟩ := he'.subset_isBasis_of_subset (insert_subset_insert hiX)
     (insert_subset heEI.1 hI.subset_ground)
 
-  have hIb : M.Basis I (insert e I) := by
-    rw [hI.insert_basis_iff_mem_closure]
+  have hIb : M.IsBasis I (insert e I) := by
+    rw [hI.insert_isBasis_iff_mem_closure]
     exact (M.closure_subset_closure (hIs _ hne.some_mem)) (he _ hne.some_mem)
 
   obtain ⟨f, hfIJ, hfb⟩ :=  hJI.exchange hIb ⟨heJ (mem_insert e _), heEI.2⟩
-  obtain rfl := hI.eq_of_basis (hfb.basis_subset (insert_subset hfIJ.1
+  obtain rfl := hI.eq_of_isBasis (hfb.isBasis_subset (insert_subset hfIJ.1
     (by (rw [diff_subset_iff, singleton_union]; exact hJI.subset))) (subset_insert _ _))
 
   refine hfIJ.2 (heJ (mem_insert_of_mem _ fun X hX' ↦ by_contra fun hfX ↦ ?_))
@@ -506,88 +509,88 @@ lemma Indep.closure_inter_eq_inter_closure (h : M.Indep (I ∪ J)) :
   · exact iInter_congr (by simp)
   rwa [← union_eq_iUnion]
 
-lemma Indep.inter_Basis_biInter {ι : Type*} (hI : M.Indep I) {X : ι → Set α} {A : Set ι}
-    (hA : A.Nonempty) (h : ∀ i ∈ A, M.Basis ((X i) ∩ I) (X i)) :
-    M.Basis ((⋂ i ∈ A, X i) ∩ I) (⋂ i ∈ A, X i) := by
-  refine (hI.inter_left _).basis_of_subset_of_subset_closure inter_subset_left ?_
+lemma Indep.inter_IsBasis_biInter {ι : Type*} (hI : M.Indep I) {X : ι → Set α} {A : Set ι}
+    (hA : A.Nonempty) (h : ∀ i ∈ A, M.IsBasis ((X i) ∩ I) (X i)) :
+    M.IsBasis ((⋂ i ∈ A, X i) ∩ I) (⋂ i ∈ A, X i) := by
+  refine (hI.inter_left _).isBasis_of_subset_of_subset_closure inter_subset_left ?_
   simp_rw [← biInter_inter hA,
   closure_biInter_eq_biInter_closure_of_biUnion_indep hA (I := fun i ↦ (X i) ∩ I)
       (hI.subset (by simp)), subset_iInter_iff]
   exact fun i hiA ↦ (biInter_subset_of_mem hiA).trans (h i hiA).subset_closure
 
-lemma Indep.inter_Basis_iInter [Nonempty ι] {X : ι → Set α} (hI : M.Indep I)
-    (h : ∀ i, M.Basis ((X i) ∩ I) (X i)) : M.Basis ((⋂ i, X i) ∩ I) (⋂ i, X i) := by
-  convert hI.inter_Basis_biInter (ι := PLift ι) univ_nonempty (X := fun i ↦ X i.down)
+lemma Indep.inter_IsBasis_iInter [Nonempty ι] {X : ι → Set α} (hI : M.Indep I)
+    (h : ∀ i, M.IsBasis ((X i) ∩ I) (X i)) : M.IsBasis ((⋂ i, X i) ∩ I) (⋂ i, X i) := by
+  convert hI.inter_IsBasis_biInter (ι := PLift ι) univ_nonempty (X := fun i ↦ X i.down)
     (by simpa using fun (i : PLift ι) ↦ h i.down) <;>
   · simp only [mem_univ, iInter_true]
     exact (iInter_plift_down X).symm
 
-lemma Indep.inter_Basis_sInter {Xs : Set (Set α)} (hI : M.Indep I) (hXs : Xs.Nonempty)
-    (h : ∀ X ∈ Xs, M.Basis (X ∩ I) X) : M.Basis (⋂₀ Xs ∩ I) (⋂₀ Xs) := by
+lemma Indep.inter_IsBasis_sInter {Xs : Set (Set α)} (hI : M.Indep I) (hXs : Xs.Nonempty)
+    (h : ∀ X ∈ Xs, M.IsBasis (X ∩ I) X) : M.IsBasis (⋂₀ Xs ∩ I) (⋂₀ Xs) := by
   rw [sInter_eq_biInter]
-  exact hI.inter_Basis_biInter hXs h
+  exact hI.inter_IsBasis_biInter hXs h
 
-lemma basis_iff_basis_closure_of_subset (hIX : I ⊆ X) (hX : X ⊆ M.E := by aesop_mat) :
-    M.Basis I X ↔ M.Basis I (M.closure X) :=
-  ⟨fun h ↦ h.basis_closure_right, fun h ↦ h.basis_subset hIX (M.subset_closure X hX)⟩
+lemma isBasis_iff_isBasis_closure_of_subset (hIX : I ⊆ X) (hX : X ⊆ M.E := by aesop_mat) :
+    M.IsBasis I X ↔ M.IsBasis I (M.closure X) :=
+  ⟨fun h ↦ h.isBasis_closure_right, fun h ↦ h.isBasis_subset hIX (M.subset_closure X hX)⟩
 
-lemma basis_iff_basis_closure_of_subset' (hIX : I ⊆ X) :
-    M.Basis I X ↔ M.Basis I (M.closure X) ∧ X ⊆ M.E :=
-  ⟨fun h ↦ ⟨h.basis_closure_right, h.subset_ground⟩,
-    fun h ↦ h.1.basis_subset hIX (M.subset_closure X h.2)⟩
+lemma isBasis_iff_isBasis_closure_of_subset' (hIX : I ⊆ X) :
+    M.IsBasis I X ↔ M.IsBasis I (M.closure X) ∧ X ⊆ M.E :=
+  ⟨fun h ↦ ⟨h.isBasis_closure_right, h.subset_ground⟩,
+    fun h ↦ h.1.isBasis_subset hIX (M.subset_closure X h.2)⟩
 
-lemma basis'_iff_basis_closure : M.Basis' I X ↔ M.Basis I (M.closure X) ∧ I ⊆ X := by
-  rw [← closure_inter_ground, basis'_iff_basis_inter_ground]
-  exact ⟨fun h ↦ ⟨h.basis_closure_right, h.subset.trans inter_subset_left⟩,
-    fun h ↦ h.1.basis_subset (subset_inter h.2 h.1.indep.subset_ground) (M.subset_closure _)⟩
+lemma isBasis'_iff_isBasis_closure : M.IsBasis' I X ↔ M.IsBasis I (M.closure X) ∧ I ⊆ X := by
+  rw [← closure_inter_ground, isBasis'_iff_isBasis_inter_ground]
+  exact ⟨fun h ↦ ⟨h.isBasis_closure_right, h.subset.trans inter_subset_left⟩,
+    fun h ↦ h.1.isBasis_subset (subset_inter h.2 h.1.indep.subset_ground) (M.subset_closure _)⟩
 
-lemma exists_basis_inter_ground_basis_closure (M : Matroid α) (X : Set α) :
-    ∃ I, M.Basis I (X ∩ M.E) ∧ M.Basis I (M.closure X) := by
-  obtain ⟨I, hI⟩ := M.exists_basis (X ∩ M.E)
-  have hI' := hI.basis_closure_right; rw [closure_inter_ground] at hI'
+lemma exists_isBasis_inter_ground_isBasis_closure (M : Matroid α) (X : Set α) :
+    ∃ I, M.IsBasis I (X ∩ M.E) ∧ M.IsBasis I (M.closure X) := by
+  obtain ⟨I, hI⟩ := M.exists_isBasis (X ∩ M.E)
+  have hI' := hI.isBasis_closure_right; rw [closure_inter_ground] at hI'
   exact ⟨_, hI, hI'⟩
 
-lemma Basis.basis_of_closure_eq_closure (hI : M.Basis I X) (hY : I ⊆ Y)
-    (h : M.closure X = M.closure Y) (hYE : Y ⊆ M.E := by aesop_mat) : M.Basis I Y := by
-  refine hI.indep.basis_of_subset_of_subset_closure hY ?_
+lemma IsBasis.isBasis_of_closure_eq_closure (hI : M.IsBasis I X) (hY : I ⊆ Y)
+    (h : M.closure X = M.closure Y) (hYE : Y ⊆ M.E := by aesop_mat) : M.IsBasis I Y := by
+  refine hI.indep.isBasis_of_subset_of_subset_closure hY ?_
   rw [hI.closure_eq_closure, h]
   exact M.subset_closure Y
 
-lemma basis_union_iff_indep_closure : M.Basis I (I ∪ X) ↔ M.Indep I ∧ X ⊆ M.closure I :=
+lemma isBasis_union_iff_indep_closure : M.IsBasis I (I ∪ X) ↔ M.Indep I ∧ X ⊆ M.closure I :=
   ⟨fun h ↦ ⟨h.indep, subset_union_right.trans h.subset_closure⟩, fun ⟨hI, hXI⟩ ↦
-    hI.basis_closure.basis_subset subset_union_left (union_subset (M.subset_closure I) hXI)⟩
+    hI.isBasis_closure.isBasis_subset subset_union_left (union_subset (M.subset_closure I) hXI)⟩
 
-lemma basis_iff_indep_closure : M.Basis I X ↔ M.Indep I ∧ X ⊆ M.closure I ∧ I ⊆ X :=
+lemma isBasis_iff_indep_closure : M.IsBasis I X ↔ M.Indep I ∧ X ⊆ M.closure I ∧ I ⊆ X :=
   ⟨fun h ↦ ⟨h.indep, h.subset_closure, h.subset⟩, fun h ↦
-    (basis_union_iff_indep_closure.mpr ⟨h.1, h.2.1⟩).basis_subset h.2.2 subset_union_right⟩
+    (isBasis_union_iff_indep_closure.mpr ⟨h.1, h.2.1⟩).isBasis_subset h.2.2 subset_union_right⟩
 
-lemma Indep.inter_basis_closure_iff_subset_closure_inter {X : Set α} (hI : M.Indep I) :
-    M.Basis (X ∩ I) X ↔ X ⊆ M.closure (X ∩ I) :=
-  ⟨Basis.subset_closure, (hI.inter_left X).basis_of_subset_of_subset_closure inter_subset_left⟩
+lemma Indep.inter_isBasis_closure_iff_subset_closure_inter {X : Set α} (hI : M.Indep I) :
+    M.IsBasis (X ∩ I) X ↔ X ⊆ M.closure (X ∩ I) :=
+  ⟨IsBasis.subset_closure, (hI.inter_left X).isBasis_of_subset_of_subset_closure inter_subset_left⟩
 
-lemma Basis.closure_inter_basis_closure (h : M.Basis (X ∩ I) X) (hI : M.Indep I) :
-    M.Basis (M.closure X ∩ I) (M.closure X) := by
-  rw [hI.inter_basis_closure_iff_subset_closure_inter] at h ⊢
+lemma IsBasis.closure_inter_isBasis_closure (h : M.IsBasis (X ∩ I) X) (hI : M.Indep I) :
+    M.IsBasis (M.closure X ∩ I) (M.closure X) := by
+  rw [hI.inter_isBasis_closure_iff_subset_closure_inter] at h ⊢
   exact (M.closure_subset_closure_of_subset_closure h).trans (M.closure_subset_closure
     (inter_subset_inter_left _ (h.trans (M.closure_subset_closure inter_subset_left))))
 
-lemma Basis.eq_of_closure_subset (hI : M.Basis I X) (hJI : J ⊆ I) (hJ : X ⊆ M.closure J) :
+lemma IsBasis.eq_of_closure_subset (hI : M.IsBasis I X) (hJI : J ⊆ I) (hJ : X ⊆ M.closure J) :
     J = I := by
   rw [← hI.indep.closure_inter_eq_self_of_subset hJI, inter_eq_self_of_subset_right]
   exact hI.subset.trans hJ
 
-lemma Basis.insert_basis_insert_of_not_mem_closure (hIX : M.Basis I X) (heI : e ∉ M.closure I)
-    (heE : e ∈ M.E := by aesop_mat) : M.Basis (insert e I) (insert e X) :=
-  hIX.insert_basis_insert <| hIX.indep.insert_indep_iff.2 <| .inl ⟨heE, heI⟩
+lemma IsBasis.insert_isBasis_insert_of_not_mem_closure (hIX : M.IsBasis I X) (heI : e ∉ M.closure I)
+    (heE : e ∈ M.E := by aesop_mat) : M.IsBasis (insert e I) (insert e X) :=
+  hIX.insert_isBasis_insert <| hIX.indep.insert_indep_iff.2 <| .inl ⟨heE, heI⟩
 
-@[simp] lemma empty_basis_iff : M.Basis ∅ X ↔ X ⊆ M.closure ∅ := by
-  rw [basis_iff_indep_closure, and_iff_right M.empty_indep, and_iff_left (empty_subset _)]
+@[simp] lemma empty_isBasis_iff : M.IsBasis ∅ X ↔ X ⊆ M.closure ∅ := by
+  rw [isBasis_iff_indep_closure, and_iff_right M.empty_indep, and_iff_left (empty_subset _)]
 
 lemma indep_iff_forall_not_mem_closure_diff (hI : I ⊆ M.E := by aesop_mat) :
     M.Indep I ↔ ∀ ⦃e⦄, e ∈ I → e ∉ M.closure (I \ {e}) := by
   use fun h e heI he ↦ ((h.closure_inter_eq_self_of_subset diff_subset).subset ⟨he, heI⟩).2 rfl
   intro h
-  obtain ⟨J, hJ⟩ := M.exists_basis I
+  obtain ⟨J, hJ⟩ := M.exists_isBasis I
   convert hJ.indep
   refine hJ.subset.antisymm' (fun e he ↦ by_contra fun heJ ↦ h he ?_)
   exact mem_of_mem_of_subset
@@ -617,7 +620,7 @@ lemma Indep.union_indep_iff_forall_not_mem_closure_right (hI : M.Indep I) (hJ : 
     M.Indep (I ∪ J) ↔ ∀ e ∈ J \ I, e ∉ M.closure (I ∪ (J \ {e})) := by
   refine ⟨fun h e heJ hecl ↦ h.not_mem_closure_diff_of_mem (.inr heJ.1) ?_, fun h ↦ ?_⟩
   · rwa [union_diff_distrib, diff_singleton_eq_self heJ.2]
-  obtain ⟨K, hKIJ, hK⟩ := hI.subset_basis_of_subset (show I ⊆ I ∪ J from subset_union_left)
+  obtain ⟨K, hKIJ, hK⟩ := hI.subset_isBasis_of_subset (show I ⊆ I ∪ J from subset_union_left)
   obtain rfl | hssu := hKIJ.subset.eq_or_ssubset
   · exact hKIJ.indep
   exfalso
@@ -669,7 +672,7 @@ lemma mem_closure_insert (he : e ∉ M.closure X) (hef : e ∈ M.closure (insert
   have heE : e ∈ M.E := (M.closure_subset_ground _) hef
   rw [insert_inter_of_mem hfE] at hef; rw [insert_inter_of_mem heE]
 
-  obtain ⟨I, hI⟩ := M.exists_basis (X ∩ M.E)
+  obtain ⟨I, hI⟩ := M.exists_isBasis (X ∩ M.E)
   rw [← hI.closure_eq_closure, hI.indep.not_mem_closure_iff] at he
   rw [← closure_insert_closure_eq_closure_insert, ← hI.closure_eq_closure,
     closure_insert_closure_eq_closure_insert, he.1.mem_closure_iff] at *
@@ -780,9 +783,9 @@ lemma IsBase.spanning_of_superset (hB : M.IsBase B) (hBX : B ⊆ X) (hX : X ⊆ 
 appears in the RHS of the equivalence rather than as a hypothesis. -/
 lemma spanning_iff_exists_isBase_subset' : M.Spanning S ↔ (∃ B, M.IsBase B ∧ B ⊆ S) ∧ S ⊆ M.E := by
   refine ⟨fun h ↦ ⟨?_, h.subset_ground⟩, fun ⟨⟨B, hB, hBS⟩, hSE⟩ ↦ hB.spanning.superset hBS⟩
-  obtain ⟨B, hB⟩ := M.exists_basis S
-  have hB' := hB.basis_closure_right
-  rw [h.closure_eq, basis_ground_iff] at hB'
+  obtain ⟨B, hB⟩ := M.exists_isBasis S
+  have hB' := hB.isBasis_closure_right
+  rw [h.closure_eq, isBasis_ground_iff] at hB'
   exact ⟨B, hB', hB.subset⟩
 
 lemma spanning_iff_exists_isBase_subset (hS : S ⊆ M.E := by aesop_mat) :
@@ -819,12 +822,12 @@ lemma Spanning.isBase_of_indep (hIs : M.Spanning I) (hI : M.Indep I) : M.IsBase 
 lemma Indep.eq_of_spanning_subset (hI : M.Indep I) (hS : M.Spanning S) (hSI : S ⊆ I) : S = I :=
   ((hI.subset hSI).isBase_of_spanning hS).eq_of_subset_indep hI hSI
 
-lemma Basis.spanning_iff_spanning (hIX : M.Basis I X) : M.Spanning I ↔ M.Spanning X := by
+lemma IsBasis.spanning_iff_spanning (hIX : M.IsBasis I X) : M.Spanning I ↔ M.Spanning X := by
   rw [spanning_iff_closure_eq, spanning_iff_closure_eq, hIX.closure_eq_closure]
 
 lemma Spanning.isBase_restrict_iff (hS : M.Spanning S) : (M ↾ S).IsBase B ↔ M.IsBase B ∧ B ⊆ S := by
-  rw [isBase_restrict_iff', basis'_iff_basis]
-  refine ⟨fun h ↦ ⟨?_, h.subset⟩, fun h ↦ h.1.indep.basis_of_subset_of_subset_closure h.2 ?_⟩
+  rw [isBase_restrict_iff', isBasis'_iff_isBasis]
+  refine ⟨fun h ↦ ⟨?_, h.subset⟩, fun h ↦ h.1.indep.isBasis_of_subset_of_subset_closure h.2 ?_⟩
   · exact h.indep.isBase_of_spanning <| by rwa [h.spanning_iff_spanning]
   rw [h.1.closure_eq]
   exact hS.subset_ground
@@ -832,12 +835,12 @@ lemma Spanning.isBase_restrict_iff (hS : M.Spanning S) : (M ↾ S).IsBase B ↔ 
 lemma Spanning.compl_coindep (hS : M.Spanning S) : M.Coindep (M.E \ S) := by
   rwa [← spanning_iff_compl_coindep]
 
-lemma Basis.isBase_of_spanning (hIX : M.Basis I X) (hX : M.Spanning X) : M.IsBase I :=
+lemma IsBasis.isBase_of_spanning (hIX : M.IsBasis I X) (hX : M.Spanning X) : M.IsBase I :=
   hIX.indep.isBase_of_spanning <| by rwa [hIX.spanning_iff_spanning]
 
 lemma Indep.exists_isBase_subset_spanning (hI : M.Indep I) (hS : M.Spanning S) (hIS : I ⊆ S) :
     ∃ B, M.IsBase B ∧ I ⊆ B ∧ B ⊆ S := by
-  obtain ⟨B, hB⟩ := hI.subset_basis_of_subset hIS
+  obtain ⟨B, hB⟩ := hI.subset_isBasis_of_subset hIS
   exact ⟨B, hB.1.isBase_of_spanning hS, hB.2, hB.1.subset⟩
 
 lemma Restriction.isBase_iff_of_spanning {N : Matroid α} (hR : N ≤r M) (hN : M.Spanning N.E) :
@@ -878,8 +881,8 @@ variable {R S : Set α}
 
 @[simp] lemma restrict_closure_eq' (M : Matroid α) (X R : Set α) :
     (M ↾ R).closure X = (M.closure (X ∩ R) ∩ R) ∪ (R \ M.E) := by
-  obtain ⟨I, hI⟩ := (M ↾ R).exists_basis' X
-  obtain ⟨hI', hIR⟩ := basis'_restrict_iff.1 hI
+  obtain ⟨I, hI⟩ := (M ↾ R).exists_isBasis' X
+  obtain ⟨hI', hIR⟩ := isBasis'_restrict_iff.1 hI
   ext e
   rw [← hI.closure_eq_closure, ← hI'.closure_eq_closure, hI.indep.mem_closure_iff', mem_union,
     mem_inter_iff, hI'.indep.mem_closure_iff', restrict_ground_eq, restrict_indep_iff, mem_diff]
@@ -918,8 +921,8 @@ lemma closure_empty_eq_ground_iff : M.closure ∅ = M.E ↔ M = loopyOn M.E := b
 @[simp] lemma comap_closure_eq {β : Type*} (M : Matroid β) (f : α → β) (X : Set α) :
     (M.comap f).closure X = f ⁻¹' M.closure (f '' X) := by
   -- Use a choice of basis and extensionality to change the goal to a statement about independence.
-  obtain ⟨I, hI⟩ := (M.comap f).exists_basis' X
-  obtain ⟨hI', hIinj, -⟩ := comap_basis'_iff.1 hI
+  obtain ⟨I, hI⟩ := (M.comap f).exists_isBasis' X
+  obtain ⟨hI', hIinj, -⟩ := comap_isBasis'_iff.1 hI
   simp_rw [← hI.closure_eq_closure, ← hI'.closure_eq_closure, Set.ext_iff,
     hI.indep.mem_closure_iff', comap_ground_eq, mem_preimage, hI'.indep.mem_closure_iff',
     comap_indep_iff, and_imp, mem_image, and_congr_right_iff, ← image_insert_eq]
@@ -933,7 +936,7 @@ lemma closure_empty_eq_ground_iff : M.closure ∅ = M.E ↔ M = loopyOn M.E := b
     (M.map f hf).closure X = f '' M.closure (f ⁻¹' X) := by
   -- It is enough to prove that `map` and `closure` commute for `M`-independent sets.
   suffices aux : ∀ ⦃I⦄, M.Indep I → (M.map f hf).closure (f '' I) = f '' (M.closure I) by
-    obtain ⟨I, hI⟩ := M.exists_basis (f ⁻¹' X ∩ M.E)
+    obtain ⟨I, hI⟩ := M.exists_isBasis (f ⁻¹' X ∩ M.E)
     rw [← closure_inter_ground, map_ground, ← M.closure_inter_ground, ← hI.closure_eq_closure,
       ← aux hI.indep, ← image_preimage_inter, ← (hI.map hf).closure_eq_closure]
   -- Let `I` be independent, and transform the goal using closure/independence lemmas

--- a/Mathlib/Data/Matroid/Constructions.lean
+++ b/Mathlib/Data/Matroid/Constructions.lean
@@ -101,9 +101,9 @@ theorem eq_loopyOn_iff : M = loopyOn E ↔ M.E = E ∧ ∀ X ⊆ M.E, M.Indep X 
 @[simp] theorem loopyOn_isBase_iff : (loopyOn E).IsBase B ↔ B = ∅ := by
   simp [Maximal, isBase_iff_maximal_indep]
 
-@[simp] theorem loopyOn_basis_iff : (loopyOn E).Basis I X ↔ I = ∅ ∧ X ⊆ E :=
+@[simp] theorem loopyOn_isBasis_iff : (loopyOn E).IsBasis I X ↔ I = ∅ ∧ X ⊆ E :=
   ⟨fun h ↦ ⟨loopyOn_indep_iff.mp h.indep, h.subset_ground⟩,
-    by rintro ⟨rfl, hX⟩; rw [basis_iff]; simp⟩
+    by rintro ⟨rfl, hX⟩; rw [isBasis_iff]; simp⟩
 
 instance : RankFinite (loopyOn E) :=
   ⟨⟨∅, loopyOn_isBase_iff.2 rfl, finite_empty⟩⟩
@@ -158,13 +158,13 @@ def freeOn (E : Set α) : Matroid α := (loopyOn E)✶
 theorem freeOn_indep (hIE : I ⊆ E) : (freeOn E).Indep I :=
   freeOn_indep_iff.2 hIE
 
-@[simp] theorem freeOn_basis_iff : (freeOn E).Basis I X ↔ I = X ∧ X ⊆ E := by
-  use fun h ↦ ⟨(freeOn_indep h.subset_ground).eq_of_basis h ,h.subset_ground⟩
+@[simp] theorem freeOn_isBasis_iff : (freeOn E).IsBasis I X ↔ I = X ∧ X ⊆ E := by
+  use fun h ↦ ⟨(freeOn_indep h.subset_ground).eq_of_isBasis h ,h.subset_ground⟩
   rintro ⟨rfl, hIE⟩
-  exact (freeOn_indep hIE).basis_self
+  exact (freeOn_indep hIE).isBasis_self
 
-@[simp] theorem freeOn_basis'_iff : (freeOn E).Basis' I X ↔ I = X ∩ E := by
-  rw [basis'_iff_basis_inter_ground, freeOn_basis_iff, freeOn_ground,
+@[simp] theorem freeOn_isBasis'_iff : (freeOn E).IsBasis' I X ↔ I = X ∩ E := by
+  rw [isBasis'_iff_isBasis_inter_ground, freeOn_isBasis_iff, freeOn_ground,
     and_iff_left inter_subset_right]
 
 theorem eq_freeOn_iff : M = freeOn E ↔ M.E = E ∧ M.Indep E := by
@@ -205,7 +205,7 @@ def uniqueBaseOn (I E : Set α) : Matroid α := freeOn I ↾ E
   rfl
 
 theorem uniqueBaseOn_isBase_iff (hIE : I ⊆ E) : (uniqueBaseOn I E).IsBase B ↔ B = I := by
-  rw [uniqueBaseOn, isBase_restrict_iff', freeOn_basis'_iff, inter_eq_self_of_subset_right hIE]
+  rw [uniqueBaseOn, isBase_restrict_iff', freeOn_isBasis'_iff, inter_eq_self_of_subset_right hIE]
 
 theorem uniqueBaseOn_inter_ground_eq (I E : Set α) :
     uniqueBaseOn (I ∩ E) E = uniqueBaseOn I E := by
@@ -220,13 +220,13 @@ theorem uniqueBaseOn_indep_iff (hIE : I ⊆ E) : (uniqueBaseOn I E).Indep J ↔ 
   rw [uniqueBaseOn, restrict_indep_iff, freeOn_indep_iff, and_iff_left_iff_imp]
   exact fun h ↦ h.trans hIE
 
-theorem uniqueBaseOn_basis_iff (hX : X ⊆ E) : (uniqueBaseOn I E).Basis J X ↔ J = X ∩ I := by
-  rw [basis_iff_maximal]
+theorem uniqueBaseOn_isBasis_iff (hX : X ⊆ E) : (uniqueBaseOn I E).IsBasis J X ↔ J = X ∩ I := by
+  rw [isBasis_iff_maximal]
   exact maximal_iff_eq (by simp [inter_subset_left.trans hX])
     (by simp (config := {contextual := true}))
 
-theorem uniqueBaseOn_inter_basis (hX : X ⊆ E) : (uniqueBaseOn I E).Basis (X ∩ I) X := by
-  rw [uniqueBaseOn_basis_iff hX]
+theorem uniqueBaseOn_inter_isBasis (hX : X ⊆ E) : (uniqueBaseOn I E).IsBasis (X ∩ I) X := by
+  rw [uniqueBaseOn_isBasis_iff hX]
 
 @[simp] theorem uniqueBaseOn_dual_eq (I E : Set α) :
     (uniqueBaseOn I E)✶ = uniqueBaseOn (E \ I) E := by

--- a/Mathlib/Data/Matroid/Constructions.lean
+++ b/Mathlib/Data/Matroid/Constructions.lean
@@ -42,17 +42,17 @@ section EmptyOn
 /-- The `Matroid α` with empty ground set. -/
 def emptyOn (α : Type*) : Matroid α where
   E := ∅
-  Base := (· = ∅)
+  IsBase := (· = ∅)
   Indep := (· = ∅)
   indep_iff' := by simp [subset_empty_iff]
-  exists_base := ⟨∅, rfl⟩
-  base_exchange := by rintro _ _ rfl; simp
+  exists_isBase := ⟨∅, rfl⟩
+  isBase_exchange := by rintro _ _ rfl; simp
   maximality := by rintro _ _ _ rfl -; exact ⟨∅, by simp [Maximal]⟩
   subset_ground := by simp
 
 @[simp] theorem emptyOn_ground : (emptyOn α).E = ∅ := rfl
 
-@[simp] theorem emptyOn_base_iff : (emptyOn α).Base B ↔ B = ∅ := Iff.rfl
+@[simp] theorem emptyOn_isBase_iff : (emptyOn α).IsBase B ↔ B = ∅ := Iff.rfl
 
 @[simp] theorem emptyOn_indep_iff : (emptyOn α).Indep I ↔ I = ∅ := Iff.rfl
 
@@ -98,15 +98,15 @@ theorem eq_loopyOn_iff : M = loopyOn E ↔ M.E = E ∧ ∀ X ⊆ M.E, M.Indep X 
   rintro rfl
   refine ⟨fun h I hI ↦ (h hI).1, fun h I hIE ↦ ⟨h I hIE, by rintro rfl; simp⟩⟩
 
-@[simp] theorem loopyOn_base_iff : (loopyOn E).Base B ↔ B = ∅ := by
-  simp [Maximal, base_iff_maximal_indep]
+@[simp] theorem loopyOn_isBase_iff : (loopyOn E).IsBase B ↔ B = ∅ := by
+  simp [Maximal, isBase_iff_maximal_indep]
 
 @[simp] theorem loopyOn_basis_iff : (loopyOn E).Basis I X ↔ I = ∅ ∧ X ⊆ E :=
   ⟨fun h ↦ ⟨loopyOn_indep_iff.mp h.indep, h.subset_ground⟩,
     by rintro ⟨rfl, hX⟩; rw [basis_iff]; simp⟩
 
 instance : RankFinite (loopyOn E) :=
-  ⟨⟨∅, loopyOn_base_iff.2 rfl, finite_empty⟩⟩
+  ⟨⟨∅, loopyOn_isBase_iff.2 rfl, finite_empty⟩⟩
 
 theorem Finite.loopyOn_finite (hE : E.Finite) : Matroid.Finite (loopyOn E) :=
   ⟨hE⟩
@@ -116,17 +116,17 @@ theorem Finite.loopyOn_finite (hE : E.Finite) : Matroid.Finite (loopyOn E) :=
   simp only [restrict_ground_eq, restrict_indep_iff, loopyOn_indep_iff, and_iff_left_iff_imp]
   exact fun _ h _ ↦ h
 
-theorem empty_base_iff : M.Base ∅ ↔ M = loopyOn M.E := by
-  simp only [base_iff_maximal_indep, Maximal, empty_indep, le_eq_subset, empty_subset,
+theorem empty_isBase_iff : M.IsBase ∅ ↔ M = loopyOn M.E := by
+  simp only [isBase_iff_maximal_indep, Maximal, empty_indep, le_eq_subset, empty_subset,
     subset_empty_iff, true_implies, true_and, ext_iff_indep, loopyOn_ground,
     loopyOn_indep_iff]
   exact ⟨fun h I _ ↦ ⟨@h _, fun hI ↦ by simp [hI]⟩, fun h I hI ↦ (h hI.subset_ground).1 hI⟩
 
 theorem eq_loopyOn_or_rankPos (M : Matroid α) : M = loopyOn M.E ∨ RankPos M := by
-  rw [← empty_base_iff, rankPos_iff]; apply em
+  rw [← empty_isBase_iff, rankPos_iff]; apply em
 
 theorem not_rankPos_iff : ¬RankPos M ↔ M = loopyOn M.E := by
-  rw [rankPos_iff, not_iff_comm, empty_base_iff]
+  rw [rankPos_iff, not_iff_comm, empty_isBase_iff]
 
 instance loopyOn_rankFinite : RankFinite (loopyOn E) :=
   ⟨∅, by simp⟩
@@ -148,8 +148,8 @@ def freeOn (E : Set α) : Matroid α := (loopyOn E)✶
 @[simp] theorem freeOn_empty (α : Type*) : freeOn (∅ : Set α) = emptyOn α := by
   simp [freeOn]
 
-@[simp] theorem freeOn_base_iff : (freeOn E).Base B ↔ B = E := by
-  simp only [freeOn, loopyOn_ground, dual_base_iff', loopyOn_base_iff, diff_eq_empty,
+@[simp] theorem freeOn_isBase_iff : (freeOn E).IsBase B ↔ B = E := by
+  simp only [freeOn, loopyOn_ground, dual_isBase_iff', loopyOn_isBase_iff, diff_eq_empty,
     ← subset_antisymm_iff, eq_comm (a := E)]
 
 @[simp] theorem freeOn_indep_iff : (freeOn E).Indep I ↔ I ⊆ E := by
@@ -204,8 +204,8 @@ def uniqueBaseOn (I E : Set α) : Matroid α := freeOn I ↾ E
 @[simp] theorem uniqueBaseOn_ground : (uniqueBaseOn I E).E = E :=
   rfl
 
-theorem uniqueBaseOn_base_iff (hIE : I ⊆ E) : (uniqueBaseOn I E).Base B ↔ B = I := by
-  rw [uniqueBaseOn, base_restrict_iff', freeOn_basis'_iff, inter_eq_self_of_subset_right hIE]
+theorem uniqueBaseOn_isBase_iff (hIE : I ⊆ E) : (uniqueBaseOn I E).IsBase B ↔ B = I := by
+  rw [uniqueBaseOn, isBase_restrict_iff', freeOn_basis'_iff, inter_eq_self_of_subset_right hIE]
 
 theorem uniqueBaseOn_inter_ground_eq (I E : Set α) :
     uniqueBaseOn (I ∩ E) E = uniqueBaseOn I E := by
@@ -231,9 +231,9 @@ theorem uniqueBaseOn_inter_basis (hX : X ⊆ E) : (uniqueBaseOn I E).Basis (X �
 @[simp] theorem uniqueBaseOn_dual_eq (I E : Set α) :
     (uniqueBaseOn I E)✶ = uniqueBaseOn (E \ I) E := by
   rw [← uniqueBaseOn_inter_ground_eq]
-  refine ext_base rfl (fun B (hB : B ⊆ E) ↦ ?_)
-  rw [dual_base_iff, uniqueBaseOn_base_iff inter_subset_right, uniqueBaseOn_base_iff diff_subset,
-    uniqueBaseOn_ground]
+  refine ext_isBase rfl (fun B (hB : B ⊆ E) ↦ ?_)
+  rw [dual_isBase_iff, uniqueBaseOn_isBase_iff inter_subset_right,
+    uniqueBaseOn_isBase_iff diff_subset, uniqueBaseOn_ground]
   exact ⟨fun h ↦ by rw [← diff_diff_cancel_left hB, h, diff_inter_self_eq_diff],
     fun h ↦ by rw [h, inter_comm I]; simp⟩
 
@@ -256,7 +256,7 @@ theorem uniqueBaseOn_restrict (h : I ⊆ E) (R : Set α) :
 lemma uniqueBaseOn_rankFinite (hI : I.Finite) : RankFinite (uniqueBaseOn I E) := by
   rw [← uniqueBaseOn_inter_ground_eq]
   refine ⟨I ∩ E, ?_⟩
-  rw [uniqueBaseOn_base_iff inter_subset_right, and_iff_right rfl]
+  rw [uniqueBaseOn_isBase_iff inter_subset_right, and_iff_right rfl]
   exact hI.subset inter_subset_left
 
 instance uniqueBaseOn_finitary : Finitary (uniqueBaseOn I E) := by
@@ -265,7 +265,7 @@ instance uniqueBaseOn_finitary : Finitary (uniqueBaseOn I E) := by
   exact fun e heK ↦ singleton_subset_iff.1 <| hK _ (by simpa) (by simp)
 
 lemma uniqueBaseOn_rankPos (hIE : I ⊆ E) (hI : I.Nonempty) : RankPos (uniqueBaseOn I E) where
-  empty_not_base := by simpa [uniqueBaseOn_base_iff hIE] using Ne.symm <| hI.ne_empty
+  empty_not_isBase := by simpa [uniqueBaseOn_isBase_iff hIE] using Ne.symm <| hI.ne_empty
 
 end uniqueBaseOn
 

--- a/Mathlib/Data/Matroid/Dual.lean
+++ b/Mathlib/Data/Matroid/Dual.lean
@@ -70,7 +70,7 @@ section dual
     exact disjoint_of_subset_left hB''₂.2 disjoint_compl_left
   indep_maximal := by
     rintro X - I' ⟨hI'E, B, hB, hI'B⟩ hI'X
-    obtain ⟨I, hI⟩ := M.exists_basis (M.E \ X)
+    obtain ⟨I, hI⟩ := M.exists_isBasis (M.E \ X)
     obtain ⟨B', hB', hIB', hB'IB⟩ := hI.indep.exists_isBase_subset_union_isBase hB
 
     obtain rfl : I = B' \ X := hI.eq_of_subset_indep (hB'.indep.diff _)
@@ -176,9 +176,9 @@ theorem IsBase.compl_isBase_of_dual (h : M✶.IsBase B) : M.IsBase (M.E \ B) :=
 theorem IsBase.compl_isBase_dual (h : M.IsBase B) : M✶.IsBase (M.E \ B) := by
   rwa [dual_isBase_iff, diff_diff_cancel_left h.subset_ground]
 
-theorem IsBase.compl_inter_basis_of_inter_basis (hB : M.IsBase B) (hBX : M.Basis (B ∩ X) X) :
-    M✶.Basis ((M.E \ B) ∩ (M.E \ X)) (M.E \ X) := by
-  refine Indep.basis_of_forall_insert ?_ inter_subset_right (fun e he ↦ ?_)
+theorem IsBase.compl_inter_isBasis_of_inter_isBasis (hB : M.IsBase B) (hBX : M.IsBasis (B ∩ X) X) :
+    M✶.IsBasis ((M.E \ B) ∩ (M.E \ X)) (M.E \ X) := by
+  refine Indep.isBasis_of_forall_insert ?_ inter_subset_right (fun e he ↦ ?_)
   · rw [dual_indep_iff_exists]
     exact ⟨B, hB, disjoint_of_subset_left inter_subset_left disjoint_sdiff_left⟩
   simp only [diff_inter_self_eq_diff, mem_diff, not_and, not_not, imp_iff_right he.1.1] at he
@@ -197,12 +197,12 @@ theorem IsBase.compl_inter_basis_of_inter_basis (hB : M.IsBase B) (hBX : M.Basis
       mem_inter_iff, iff_false_intro he.1.2, and_false, not_false_iff]
   exact hfb.2 (hBX.mem_of_insert_indep (Or.elim (hem.1 hfb.1) (False.elim ∘ hfb.2) id) hi).1
 
-theorem IsBase.inter_basis_iff_compl_inter_basis_dual (hB : M.IsBase B)
+theorem IsBase.inter_isBasis_iff_compl_inter_isBasis_dual (hB : M.IsBase B)
     (hX : X ⊆ M.E := by aesop_mat) :
-    M.Basis (B ∩ X) X ↔ M✶.Basis ((M.E \ B) ∩ (M.E \ X)) (M.E \ X) := by
-  refine ⟨hB.compl_inter_basis_of_inter_basis, fun h ↦ ?_⟩
+    M.IsBasis (B ∩ X) X ↔ M✶.IsBasis ((M.E \ B) ∩ (M.E \ X)) (M.E \ X) := by
+  refine ⟨hB.compl_inter_isBasis_of_inter_isBasis, fun h ↦ ?_⟩
   simpa [inter_eq_self_of_subset_right hX, inter_eq_self_of_subset_right hB.subset_ground] using
-    hB.compl_isBase_dual.compl_inter_basis_of_inter_basis h
+    hB.compl_isBase_dual.compl_inter_isBasis_of_inter_isBasis h
 
 theorem base_iff_dual_isBase_compl (hB : B ⊆ M.E := by aesop_mat) :
     M.IsBase B ↔ M✶.IsBase (M.E \ B) := by

--- a/Mathlib/Data/Matroid/Dual.lean
+++ b/Mathlib/Data/Matroid/Dual.lean
@@ -42,19 +42,19 @@ section dual
   the subsets of `M.E` that are disjoint from some base of `M` -/
 @[simps] def dualIndepMatroid (M : Matroid α) : IndepMatroid α where
   E := M.E
-  Indep I := I ⊆ M.E ∧ ∃ B, M.Base B ∧ Disjoint I B
-  indep_empty := ⟨empty_subset M.E, M.exists_base.imp (fun _ hB ↦ ⟨hB, empty_disjoint _⟩)⟩
+  Indep I := I ⊆ M.E ∧ ∃ B, M.IsBase B ∧ Disjoint I B
+  indep_empty := ⟨empty_subset M.E, M.exists_isBase.imp (fun _ hB ↦ ⟨hB, empty_disjoint _⟩)⟩
   indep_subset := by
     rintro I J ⟨hJE, B, hB, hJB⟩ hIJ
     exact ⟨hIJ.trans hJE, ⟨B, hB, disjoint_of_subset_left hIJ hJB⟩⟩
   indep_aug := by
     rintro I X ⟨hIE, B, hB, hIB⟩ hI_not_max hX_max
     have hXE := hX_max.1.1
-    have hB' := (base_compl_iff_maximal_disjoint_base hXE).mpr hX_max
+    have hB' := (isBase_compl_iff_maximal_disjoint_isBase hXE).mpr hX_max
 
     set B' := M.E \ X with hX
-    have hI := (not_iff_not.mpr (base_compl_iff_maximal_disjoint_base)).mpr hI_not_max
-    obtain ⟨B'', hB'', hB''₁, hB''₂⟩ := (hB'.indep.diff I).exists_base_subset_union_base hB
+    have hI := (not_iff_not.mpr (isBase_compl_iff_maximal_disjoint_isBase)).mpr hI_not_max
+    obtain ⟨B'', hB'', hB''₁, hB''₂⟩ := (hB'.indep.diff I).exists_isBase_subset_union_isBase hB
     rw [← compl_subset_compl, ← hIB.sdiff_eq_right, ← union_diff_distrib, diff_eq, compl_inter,
       compl_compl, union_subset_iff, compl_subset_compl] at hB''₂
 
@@ -71,7 +71,7 @@ section dual
   indep_maximal := by
     rintro X - I' ⟨hI'E, B, hB, hI'B⟩ hI'X
     obtain ⟨I, hI⟩ := M.exists_basis (M.E \ X)
-    obtain ⟨B', hB', hIB', hB'IB⟩ := hI.indep.exists_base_subset_union_base hB
+    obtain ⟨B', hB', hIB', hB'IB⟩ := hI.indep.exists_isBase_subset_union_isBase hB
 
     obtain rfl : I = B' \ X := hI.eq_of_subset_indep (hB'.indep.diff _)
       (subset_diff.2 ⟨hIB', (subset_diff.1 hI.subset).2⟩)
@@ -92,7 +92,7 @@ section dual
         ← diff_eq, diff_subset_comm, diff_eq, inter_assoc, ← diff_eq, inter_comm]
       exact subset_trans (inter_subset_inter_right _ hB''.subset_ground) hXJ
 
-    obtain ⟨B₁,hB₁,hI'B₁,hB₁I⟩ := (hB'.indep.subset hI').exists_base_subset_union_base hB''
+    obtain ⟨B₁,hB₁,hI'B₁,hB₁I⟩ := (hB'.indep.subset hI').exists_isBase_subset_union_isBase hB''
     rw [union_comm, ← union_assoc, union_eq_self_of_subset_right inter_subset_left] at hB₁I
 
     obtain rfl : B₁ = B' := by
@@ -115,15 +115,16 @@ def dual (M : Matroid α) : Matroid α := M.dualIndepMatroid.matroid
   (This is distinct from the usual `*` symbol for multiplication, due to precedence issues. )-/
 postfix:max "✶" => Matroid.dual
 
-theorem dual_indep_iff_exists' : (M✶.Indep I) ↔ I ⊆ M.E ∧ (∃ B, M.Base B ∧ Disjoint I B) := Iff.rfl
+theorem dual_indep_iff_exists' : (M✶.Indep I) ↔ I ⊆ M.E ∧ (∃ B, M.IsBase B ∧ Disjoint I B) :=
+  Iff.rfl
 
 @[simp] theorem dual_ground : M✶.E = M.E := rfl
 
 theorem dual_indep_iff_exists (hI : I ⊆ M.E := by aesop_mat) :
-    M✶.Indep I ↔ (∃ B, M.Base B ∧ Disjoint I B) := by
+    M✶.Indep I ↔ (∃ B, M.IsBase B ∧ Disjoint I B) := by
   rw [dual_indep_iff_exists', and_iff_right hI]
 
-theorem dual_dep_iff_forall : (M✶.Dep I) ↔ (∀ B, M.Base B → (I ∩ B).Nonempty) ∧ I ⊆ M.E := by
+theorem dual_dep_iff_forall : (M✶.Dep I) ↔ (∀ B, M.IsBase B → (I ∩ B).Nonempty) ∧ I ⊆ M.E := by
   simp_rw [dep_iff, dual_indep_iff_exists', dual_ground, and_congr_left_iff, not_and,
     not_exists, not_and, not_disjoint_iff_nonempty_inter, Classical.imp_iff_right_iff,
     iff_true_intro Or.inl]
@@ -134,25 +135,26 @@ instance dual_finite [M.Finite] : M✶.Finite :=
 instance dual_nonempty [M.Nonempty] : M✶.Nonempty :=
   ⟨M.ground_nonempty⟩
 
-@[simp] theorem dual_base_iff (hB : B ⊆ M.E := by aesop_mat) : M✶.Base B ↔ M.Base (M.E \ B) := by
-  rw [base_compl_iff_maximal_disjoint_base, base_iff_maximal_indep, maximal_subset_iff,
+@[simp] theorem dual_isBase_iff (hB : B ⊆ M.E := by aesop_mat) :
+    M✶.IsBase B ↔ M.IsBase (M.E \ B) := by
+  rw [isBase_compl_iff_maximal_disjoint_isBase, isBase_iff_maximal_indep, maximal_subset_iff,
     maximal_subset_iff]
   simp [dual_indep_iff_exists', hB]
 
-theorem dual_base_iff' : M✶.Base B ↔ M.Base (M.E \ B) ∧ B ⊆ M.E :=
-  (em (B ⊆ M.E)).elim (fun h ↦ by rw [dual_base_iff, and_iff_left h])
+theorem dual_isBase_iff' : M✶.IsBase B ↔ M.IsBase (M.E \ B) ∧ B ⊆ M.E :=
+  (em (B ⊆ M.E)).elim (fun h ↦ by rw [dual_isBase_iff, and_iff_left h])
     (fun h ↦ iff_of_false (h ∘ (fun h' ↦ h'.subset_ground)) (h ∘ And.right))
 
-theorem setOf_dual_base_eq : {B | M✶.Base B} = (fun X ↦ M.E \ X) '' {B | M.Base B} := by
+theorem setOf_dual_isBase_eq : {B | M✶.IsBase B} = (fun X ↦ M.E \ X) '' {B | M.IsBase B} := by
   ext B
-  simp only [mem_setOf_eq, mem_image, dual_base_iff']
+  simp only [mem_setOf_eq, mem_image, dual_isBase_iff']
   refine ⟨fun h ↦ ⟨_, h.1, diff_diff_cancel_left h.2⟩,
     fun ⟨B', hB', h⟩ ↦ ⟨?_,h.symm.trans_subset diff_subset⟩⟩
   rwa [← h, diff_diff_cancel_left hB'.subset_ground]
 
 @[simp] theorem dual_dual (M : Matroid α) : M✶✶ = M :=
-  ext_base rfl (fun B (h : B ⊆ M.E) ↦
-    by rw [dual_base_iff, dual_base_iff, dual_ground, diff_diff_cancel_left h])
+  ext_isBase rfl (fun B (h : B ⊆ M.E) ↦
+    by rw [dual_isBase_iff, dual_isBase_iff, dual_ground, diff_diff_cancel_left h])
 
 theorem dual_involutive : Function.Involutive (dual : Matroid α → Matroid α) := dual_dual
 
@@ -168,13 +170,13 @@ theorem eq_dual_comm {M₁ M₂ : Matroid α} : M₁ = M₂✶ ↔ M₂ = M₁�
 theorem eq_dual_iff_dual_eq {M₁ M₂ : Matroid α} : M₁ = M₂✶ ↔ M₁✶ = M₂ :=
   dual_involutive.eq_iff.symm
 
-theorem Base.compl_base_of_dual (h : M✶.Base B) : M.Base (M.E \ B) :=
-  (dual_base_iff'.1 h).1
+theorem IsBase.compl_isBase_of_dual (h : M✶.IsBase B) : M.IsBase (M.E \ B) :=
+  (dual_isBase_iff'.1 h).1
 
-theorem Base.compl_base_dual (h : M.Base B) : M✶.Base (M.E \ B) := by
-  rwa [dual_base_iff, diff_diff_cancel_left h.subset_ground]
+theorem IsBase.compl_isBase_dual (h : M.IsBase B) : M✶.IsBase (M.E \ B) := by
+  rwa [dual_isBase_iff, diff_diff_cancel_left h.subset_ground]
 
-theorem Base.compl_inter_basis_of_inter_basis (hB : M.Base B) (hBX : M.Basis (B ∩ X) X) :
+theorem IsBase.compl_inter_basis_of_inter_basis (hB : M.IsBase B) (hBX : M.Basis (B ∩ X) X) :
     M✶.Basis ((M.E \ B) ∩ (M.E \ X)) (M.E \ X) := by
   refine Indep.basis_of_forall_insert ?_ inter_subset_right (fun e he ↦ ?_)
   · rw [dual_indep_iff_exists]
@@ -195,24 +197,25 @@ theorem Base.compl_inter_basis_of_inter_basis (hB : M.Base B) (hBX : M.Basis (B 
       mem_inter_iff, iff_false_intro he.1.2, and_false, not_false_iff]
   exact hfb.2 (hBX.mem_of_insert_indep (Or.elim (hem.1 hfb.1) (False.elim ∘ hfb.2) id) hi).1
 
-theorem Base.inter_basis_iff_compl_inter_basis_dual (hB : M.Base B) (hX : X ⊆ M.E := by aesop_mat) :
+theorem IsBase.inter_basis_iff_compl_inter_basis_dual (hB : M.IsBase B)
+    (hX : X ⊆ M.E := by aesop_mat) :
     M.Basis (B ∩ X) X ↔ M✶.Basis ((M.E \ B) ∩ (M.E \ X)) (M.E \ X) := by
   refine ⟨hB.compl_inter_basis_of_inter_basis, fun h ↦ ?_⟩
   simpa [inter_eq_self_of_subset_right hX, inter_eq_self_of_subset_right hB.subset_ground] using
-    hB.compl_base_dual.compl_inter_basis_of_inter_basis h
+    hB.compl_isBase_dual.compl_inter_basis_of_inter_basis h
 
-theorem base_iff_dual_base_compl (hB : B ⊆ M.E := by aesop_mat) :
-    M.Base B ↔ M✶.Base (M.E \ B) := by
-  rw [dual_base_iff, diff_diff_cancel_left hB]
+theorem base_iff_dual_isBase_compl (hB : B ⊆ M.E := by aesop_mat) :
+    M.IsBase B ↔ M✶.IsBase (M.E \ B) := by
+  rw [dual_isBase_iff, diff_diff_cancel_left hB]
 
-theorem ground_not_base (M : Matroid α) [h : RankPos M✶] : ¬M.Base M.E := by
-  rwa [rankPos_iff, dual_base_iff, diff_empty] at h
+theorem ground_not_isBase (M : Matroid α) [h : RankPos M✶] : ¬M.IsBase M.E := by
+  rwa [rankPos_iff, dual_isBase_iff, diff_empty] at h
 
-theorem Base.ssubset_ground [h : RankPos M✶] (hB : M.Base B) : B ⊂ M.E :=
-  hB.subset_ground.ssubset_of_ne (by rintro rfl; exact M.ground_not_base hB)
+theorem IsBase.ssubset_ground [h : RankPos M✶] (hB : M.IsBase B) : B ⊂ M.E :=
+  hB.subset_ground.ssubset_of_ne (by rintro rfl; exact M.ground_not_isBase hB)
 
 theorem Indep.ssubset_ground [h : RankPos M✶] (hI : M.Indep I) : I ⊂ M.E := by
-  obtain ⟨B, hB⟩ := hI.exists_base_superset; exact hB.2.trans_ssubset hB.1.ssubset_ground
+  obtain ⟨B, hB⟩ := hI.exists_isBase_superset; exact hB.2.trans_ssubset hB.1.ssubset_ground
 
 /-- A coindependent set of `M` is an independent set of the dual of `M✶`. we give it a separate
   definition to enable dot notation. Which spelling is better depends on context. -/
@@ -229,16 +232,16 @@ theorem Coindep.indep (hX : M.Coindep X) : M✶.Indep X :=
 theorem Indep.coindep (hI : M.Indep I) : M✶.Coindep I :=
   dual_coindep_iff.2 hI
 
-theorem coindep_iff_exists' : M.Coindep X ↔ (∃ B, M.Base B ∧ B ⊆ M.E \ X) ∧ X ⊆ M.E := by
+theorem coindep_iff_exists' : M.Coindep X ↔ (∃ B, M.IsBase B ∧ B ⊆ M.E \ X) ∧ X ⊆ M.E := by
   simp_rw [Coindep, dual_indep_iff_exists', and_comm (a := _ ⊆ _), and_congr_left_iff, subset_diff]
   exact fun _ ↦ ⟨fun ⟨B, hB, hXB⟩ ↦ ⟨B, hB, hB.subset_ground, hXB.symm⟩,
     fun ⟨B, hB, _, hBX⟩ ↦ ⟨B, hB, hBX.symm⟩⟩
 
 theorem coindep_iff_exists (hX : X ⊆ M.E := by aesop_mat) :
-    M.Coindep X ↔ ∃ B, M.Base B ∧ B ⊆ M.E \ X := by
+    M.Coindep X ↔ ∃ B, M.IsBase B ∧ B ⊆ M.E \ X := by
   rw [coindep_iff_exists', and_iff_left hX]
 
-theorem coindep_iff_subset_compl_base : M.Coindep X ↔ ∃ B, M.Base B ∧ X ⊆ M.E \ B := by
+theorem coindep_iff_subset_compl_isBase : M.Coindep X ↔ ∃ B, M.IsBase B ∧ X ⊆ M.E \ B := by
   simp_rw [coindep_iff_exists', subset_diff]
   exact ⟨fun ⟨⟨B, hB, _, hBX⟩, hX⟩ ↦ ⟨B, hB, hX, hBX.symm⟩,
     fun ⟨B, hB, hXE, hXB⟩ ↦ ⟨⟨B, hB, hB.subset_ground,  hXB.symm⟩, hXE⟩⟩
@@ -247,11 +250,11 @@ theorem coindep_iff_subset_compl_base : M.Coindep X ↔ ∃ B, M.Base B ∧ X �
 theorem Coindep.subset_ground (hX : M.Coindep X) : X ⊆ M.E :=
   hX.indep.subset_ground
 
-theorem Coindep.exists_base_subset_compl (h : M.Coindep X) : ∃ B, M.Base B ∧ B ⊆ M.E \ X :=
+theorem Coindep.exists_isBase_subset_compl (h : M.Coindep X) : ∃ B, M.IsBase B ∧ B ⊆ M.E \ X :=
   (coindep_iff_exists h.subset_ground).1 h
 
-theorem Coindep.exists_subset_compl_base (h : M.Coindep X) : ∃ B, M.Base B ∧ X ⊆ M.E \ B :=
-  coindep_iff_subset_compl_base.1 h
+theorem Coindep.exists_subset_compl_isBase (h : M.Coindep X) : ∃ B, M.IsBase B ∧ X ⊆ M.E \ B :=
+  coindep_iff_subset_compl_isBase.1 h
 
 end dual
 

--- a/Mathlib/Data/Matroid/IndepAxioms.lean
+++ b/Mathlib/Data/Matroid/IndepAxioms.lean
@@ -79,10 +79,10 @@ for the inverse of `e`).
 * `Matroid.ofExistsMatroid` constructs a 'copy' of a matroid that is known only
   existentially, but whose independence predicate is known explicitly.
 
-* `Matroid.ofExistsFiniteBase` constructs a matroid from its bases, if it is known that one
+* `Matroid.ofExistsFiniteIsBase` constructs a matroid from its bases, if it is known that one
   of them is finite. This gives a `RankFinite` matroid.
 
-* `Matroid.ofBaseOfFinite` constructs a `Finite` matroid from its bases.
+* `Matroid.ofIsBaseOfFinite` constructs a `Finite` matroid from its bases.
 -/
 
 assert_not_exists Field
@@ -504,7 +504,7 @@ namespace Matroid
   subset_ground := subset_ground
 
 /-- A collection of bases with the exchange property and at least one finite member is a matroid -/
-@[simps! E] protected def ofExistsFiniteBase (E : Set α) (IsBase : Set α → Prop)
+@[simps! E] protected def ofExistsFiniteIsBase (E : Set α) (IsBase : Set α → Prop)
     (exists_finite_base : ∃ B, IsBase B ∧ B.Finite) (isBase_exchange : ExchangeProperty IsBase)
     (subset_ground : ∀ B, IsBase B → B ⊆ E) : Matroid α := Matroid.ofBase
   (E := E)
@@ -519,38 +519,38 @@ namespace Matroid
     exact encard_mono hYB')
   (subset_ground := subset_ground)
 
-@[simp] theorem ofExistsFiniteBase_base (E : Set α) IsBase exists_finite_base
-    isBase_exchange subset_ground : (Matroid.ofExistsFiniteBase
+@[simp] theorem ofExistsFiniteIsBase_isBase (E : Set α) IsBase exists_finite_base
+    isBase_exchange subset_ground : (Matroid.ofExistsFiniteIsBase
       E IsBase exists_finite_base isBase_exchange subset_ground).IsBase = IsBase := rfl
 
-instance ofExistsFiniteBase_rankFinite (E : Set α) IsBase exists_finite_base
-    isBase_exchange subset_ground : RankFinite (Matroid.ofExistsFiniteBase
+instance ofExistsFiniteIsBase_rankFinite (E : Set α) IsBase exists_finite_base
+    isBase_exchange subset_ground : RankFinite (Matroid.ofExistsFiniteIsBase
       E IsBase exists_finite_base isBase_exchange subset_ground) := by
   obtain ⟨B, hB, hfin⟩ := exists_finite_base
   exact Matroid.IsBase.rankFinite_of_finite (by simpa) hfin
 
 /-- If `E` is finite, then any nonempty collection of its subsets
   with the exchange property is the collection of bases of a matroid on `E`. -/
-protected def ofBaseOfFinite {E : Set α} (hE : E.Finite) (IsBase : Set α → Prop)
+protected def ofIsBaseOfFinite {E : Set α} (hE : E.Finite) (IsBase : Set α → Prop)
     (exists_isBase : ∃ B, IsBase B) (isBase_exchange : ExchangeProperty IsBase)
     (subset_ground : ∀ B, IsBase B → B ⊆ E) : Matroid α :=
-  Matroid.ofExistsFiniteBase (E := E) (IsBase := IsBase)
+  Matroid.ofExistsFiniteIsBase (E := E) (IsBase := IsBase)
     (exists_finite_base :=
       let ⟨B, hB⟩ := exists_isBase
       ⟨B, hB, hE.subset (subset_ground B hB)⟩)
     (isBase_exchange := isBase_exchange)
     (subset_ground := subset_ground)
 
-@[simp] theorem ofBaseOfFinite_E {E : Set α} (hE : E.Finite) IsBase exists_isBase isBase_exchange
-    subset_ground : (Matroid.ofBaseOfFinite
+@[simp] theorem ofIsBaseOfFinite_E {E : Set α} (hE : E.Finite) IsBase exists_isBase isBase_exchange
+    subset_ground : (Matroid.ofIsBaseOfFinite
       hE IsBase exists_isBase isBase_exchange subset_ground).E = E := rfl
 
-@[simp] theorem ofBaseOfFinite_isBase {E : Set α} (hE : E.Finite) IsBase exists_isBase
-    isBase_exchange subset_ground : (Matroid.ofBaseOfFinite
+@[simp] theorem ofIsBaseOfFinite_isBase {E : Set α} (hE : E.Finite) IsBase exists_isBase
+    isBase_exchange subset_ground : (Matroid.ofIsBaseOfFinite
       hE IsBase exists_isBase isBase_exchange subset_ground).IsBase = IsBase := rfl
 
 instance ofBaseOfFinite_finite {E : Set α} (hE : E.Finite) IsBase exists_isBase
-    isBase_exchange subset_ground : (Matroid.ofBaseOfFinite
+    isBase_exchange subset_ground : (Matroid.ofIsBaseOfFinite
       hE IsBase exists_isBase isBase_exchange subset_ground).Finite :=
   ⟨hE⟩
 

--- a/Mathlib/Data/Matroid/IndepAxioms.lean
+++ b/Mathlib/Data/Matroid/IndepAxioms.lean
@@ -136,18 +136,18 @@ namespace IndepMatroid
 /-- An `M : IndepMatroid α` gives a `Matroid α` whose bases are the maximal `M`-independent sets. -/
 @[simps] protected def matroid (M : IndepMatroid α) : Matroid α where
   E := M.E
-  Base := Maximal M.Indep
+  IsBase := Maximal M.Indep
   Indep := M.Indep
   indep_iff' := by
     refine fun I ↦ ⟨fun h ↦ ?_, fun ⟨B, ⟨h, _⟩, hIB'⟩ ↦ M.indep_subset h hIB'⟩
     obtain ⟨J, hIJ, hmax⟩ := M.indep_maximal M.E rfl.subset I h (M.subset_ground I h)
     rw [maximal_and_iff_right_of_imp M.subset_ground] at hmax
     exact ⟨J, hmax.1, hIJ⟩
-  exists_base := by
+  exists_isBase := by
     obtain ⟨B, -, hB⟩ := M.indep_maximal M.E rfl.subset ∅ M.indep_empty <| empty_subset _
     rw [maximal_and_iff_right_of_imp M.subset_ground] at hB
     exact ⟨B, hB.1⟩
-  base_exchange B B' hB hB' e he := by
+  isBase_exchange B B' hB hB' e he := by
     have hnotmax : ¬ Maximal M.Indep (B \ {e}) :=
       fun h ↦ h.not_prop_of_ssuperset (diff_singleton_sSubset.2 he.1) hB.prop
     obtain ⟨f, hf, hfB⟩ := M.indep_aug (M.indep_subset hB.prop diff_subset) hnotmax hB'
@@ -347,7 +347,7 @@ theorem _root_.Matroid.existsMaximalSubsetProperty_of_bdd {P : Set α → Prop}
 instance (E : Set α) (Indep : Set α → Prop) indep_empty indep_subset indep_aug subset_ground h_bdd :
     RankFinite (IndepMatroid.ofBdd
       E Indep indep_empty indep_subset indep_aug subset_ground h_bdd).matroid := by
-  obtain ⟨B, hB⟩ := (IndepMatroid.ofBdd E Indep _ _ _ _ _).matroid.exists_base
+  obtain ⟨B, hB⟩ := (IndepMatroid.ofBdd E Indep _ _ _ _ _).matroid.exists_isBase
   refine hB.rankFinite_of_finite ?_
   obtain ⟨n, hn⟩ := h_bdd
   exact finite_of_encard_le_coe <| hn B (by simpa using hB.indep)
@@ -469,7 +469,7 @@ theorem ofFinset_indep' [DecidableEq α] (E : Set α) Indep indep_empty indep_su
 
 end IndepMatroid
 
-section Base
+section IsBase
 
 namespace Matroid
 
@@ -490,72 +490,72 @@ namespace Matroid
   (subset_ground := by obtain ⟨M, rfl, rfl⟩ := hex; exact fun I ↦ Indep.subset_ground)
 
 /-- A matroid defined purely in terms of its bases. -/
-@[simps E] protected def ofBase (E : Set α) (Base : Set α → Prop) (exists_base : ∃ B, Base B)
-    (base_exchange : ExchangeProperty Base)
-    (maximality : ∀ X, X ⊆ E → Matroid.ExistsMaximalSubsetProperty (∃ B, Base B ∧ · ⊆ B) X)
-    (subset_ground : ∀ B, Base B → B ⊆ E) : Matroid α where
+@[simps E] protected def ofBase (E : Set α) (IsBase : Set α → Prop) (exists_isBase : ∃ B, IsBase B)
+    (isBase_exchange : ExchangeProperty IsBase)
+    (maximality : ∀ X, X ⊆ E → Matroid.ExistsMaximalSubsetProperty (∃ B, IsBase B ∧ · ⊆ B) X)
+    (subset_ground : ∀ B, IsBase B → B ⊆ E) : Matroid α where
   E := E
-  Base := Base
-  Indep I := (∃ B, Base B ∧ I ⊆ B)
+  IsBase := IsBase
+  Indep I := (∃ B, IsBase B ∧ I ⊆ B)
   indep_iff' _ := Iff.rfl
-  exists_base := exists_base
-  base_exchange := base_exchange
+  exists_isBase := exists_isBase
+  isBase_exchange := isBase_exchange
   maximality := maximality
   subset_ground := subset_ground
 
 /-- A collection of bases with the exchange property and at least one finite member is a matroid -/
-@[simps! E] protected def ofExistsFiniteBase (E : Set α) (Base : Set α → Prop)
-    (exists_finite_base : ∃ B, Base B ∧ B.Finite) (base_exchange : ExchangeProperty Base)
-    (subset_ground : ∀ B, Base B → B ⊆ E) : Matroid α := Matroid.ofBase
+@[simps! E] protected def ofExistsFiniteBase (E : Set α) (IsBase : Set α → Prop)
+    (exists_finite_base : ∃ B, IsBase B ∧ B.Finite) (isBase_exchange : ExchangeProperty IsBase)
+    (subset_ground : ∀ B, IsBase B → B ⊆ E) : Matroid α := Matroid.ofBase
   (E := E)
-  (Base := Base)
-  (exists_base := by obtain ⟨B,h⟩ := exists_finite_base; exact ⟨B, h.1⟩)
-  (base_exchange := base_exchange)
+  (IsBase := IsBase)
+  (exists_isBase := by obtain ⟨B,h⟩ := exists_finite_base; exact ⟨B, h.1⟩)
+  (isBase_exchange := isBase_exchange)
   (maximality := by
     obtain ⟨B, hB, hfin⟩ := exists_finite_base
     refine fun X _ ↦ Matroid.existsMaximalSubsetProperty_of_bdd
       ⟨B.ncard, fun Y ⟨B', hB', hYB'⟩ ↦ ?_⟩ X
-    rw [hfin.cast_ncard_eq, base_exchange.encard_base_eq hB hB']
+    rw [hfin.cast_ncard_eq, isBase_exchange.encard_base_eq hB hB']
     exact encard_mono hYB')
   (subset_ground := subset_ground)
 
-@[simp] theorem ofExistsFiniteBase_base (E : Set α) Base exists_finite_base
-    base_exchange subset_ground : (Matroid.ofExistsFiniteBase
-      E Base exists_finite_base base_exchange subset_ground).Base = Base := rfl
+@[simp] theorem ofExistsFiniteBase_base (E : Set α) IsBase exists_finite_base
+    isBase_exchange subset_ground : (Matroid.ofExistsFiniteBase
+      E IsBase exists_finite_base isBase_exchange subset_ground).IsBase = IsBase := rfl
 
-instance ofExistsFiniteBase_rankFinite (E : Set α) Base exists_finite_base
-    base_exchange subset_ground : RankFinite (Matroid.ofExistsFiniteBase
-      E Base exists_finite_base base_exchange subset_ground) := by
+instance ofExistsFiniteBase_rankFinite (E : Set α) IsBase exists_finite_base
+    isBase_exchange subset_ground : RankFinite (Matroid.ofExistsFiniteBase
+      E IsBase exists_finite_base isBase_exchange subset_ground) := by
   obtain ⟨B, hB, hfin⟩ := exists_finite_base
-  exact Matroid.Base.rankFinite_of_finite (by simpa) hfin
+  exact Matroid.IsBase.rankFinite_of_finite (by simpa) hfin
 
 /-- If `E` is finite, then any nonempty collection of its subsets
   with the exchange property is the collection of bases of a matroid on `E`. -/
-protected def ofBaseOfFinite {E : Set α} (hE : E.Finite) (Base : Set α → Prop)
-    (exists_base : ∃ B, Base B) (base_exchange : ExchangeProperty Base)
-    (subset_ground : ∀ B, Base B → B ⊆ E) : Matroid α :=
-  Matroid.ofExistsFiniteBase (E := E) (Base := Base)
+protected def ofBaseOfFinite {E : Set α} (hE : E.Finite) (IsBase : Set α → Prop)
+    (exists_isBase : ∃ B, IsBase B) (isBase_exchange : ExchangeProperty IsBase)
+    (subset_ground : ∀ B, IsBase B → B ⊆ E) : Matroid α :=
+  Matroid.ofExistsFiniteBase (E := E) (IsBase := IsBase)
     (exists_finite_base :=
-      let ⟨B, hB⟩ := exists_base
+      let ⟨B, hB⟩ := exists_isBase
       ⟨B, hB, hE.subset (subset_ground B hB)⟩)
-    (base_exchange := base_exchange)
+    (isBase_exchange := isBase_exchange)
     (subset_ground := subset_ground)
 
-@[simp] theorem ofBaseOfFinite_E {E : Set α} (hE : E.Finite) Base exists_base base_exchange
+@[simp] theorem ofBaseOfFinite_E {E : Set α} (hE : E.Finite) IsBase exists_isBase isBase_exchange
     subset_ground : (Matroid.ofBaseOfFinite
-      hE Base exists_base base_exchange subset_ground).E = E := rfl
+      hE IsBase exists_isBase isBase_exchange subset_ground).E = E := rfl
 
-@[simp] theorem ofBaseOfFinite_base {E : Set α} (hE : E.Finite) Base exists_base
-    base_exchange subset_ground : (Matroid.ofBaseOfFinite
-      hE Base exists_base base_exchange subset_ground).Base = Base := rfl
+@[simp] theorem ofBaseOfFinite_isBase {E : Set α} (hE : E.Finite) IsBase exists_isBase
+    isBase_exchange subset_ground : (Matroid.ofBaseOfFinite
+      hE IsBase exists_isBase isBase_exchange subset_ground).IsBase = IsBase := rfl
 
-instance ofBaseOfFinite_finite {E : Set α} (hE : E.Finite) Base exists_base
-    base_exchange subset_ground : (Matroid.ofBaseOfFinite
-      hE Base exists_base base_exchange subset_ground).Finite :=
+instance ofBaseOfFinite_finite {E : Set α} (hE : E.Finite) IsBase exists_isBase
+    isBase_exchange subset_ground : (Matroid.ofBaseOfFinite
+      hE IsBase exists_isBase isBase_exchange subset_ground).Finite :=
   ⟨hE⟩
 
 end Matroid
 
-end Base
+end IsBase
 
 end IndepMatroid

--- a/Mathlib/Data/Matroid/Map.lean
+++ b/Mathlib/Data/Matroid/Map.lean
@@ -78,7 +78,7 @@ we define `mapEmbedding` and `mapEquiv` separately from `map`.
 For finite matroids, both maps and comaps are a special case of a construction of
 Perfect [perfect1969matroid] in which a matroid structure can be transported across an arbitrary
 bipartite graph that may not correspond to a function at all (See [oxley2011], Theorem 11.2.12).
-It would have been nice to use this more general construction as a basis for the definition
+It would have been nice to use this more general construction as a isBasis for the definition
 of both `Matroid.map` and `Matroid.comap`.
 
 Unfortunately, we can't do this, because the construction doesn't extend to infinite matroids.
@@ -190,11 +190,11 @@ lemma comap_indep_iff_of_injOn (hf : InjOn f (f ⁻¹' N.E)) :
 @[simp] lemma comap_loopyOn (f : α → β) (E : Set β) : comap (loopyOn E) f = loopyOn (f ⁻¹' E) := by
   rw [eq_loopyOn_iff]; aesop
 
-@[simp] lemma comap_basis_iff {I X : Set α} :
-    (N.comap f).Basis I X ↔ N.Basis (f '' I) (f '' X) ∧ I.InjOn f ∧ I ⊆ X  := by
+@[simp] lemma comap_isBasis_iff {I X : Set α} :
+    (N.comap f).IsBasis I X ↔ N.IsBasis (f '' I) (f '' X) ∧ I.InjOn f ∧ I ⊆ X  := by
   refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
   · obtain ⟨hI, hinj⟩ := comap_indep_iff.1 h.indep
-    refine ⟨hI.basis_of_forall_insert (image_subset f h.subset) fun e he ↦ ?_, hinj, h.subset⟩
+    refine ⟨hI.isBasis_of_forall_insert (image_subset f h.subset) fun e he ↦ ?_, hinj, h.subset⟩
     simp only [mem_diff, mem_image, not_exists, not_and, and_imp, forall_exists_index,
       forall_apply_eq_imp_iff₂] at he
     obtain ⟨⟨e, heX, rfl⟩, he⟩ := he
@@ -203,7 +203,7 @@ lemma comap_indep_iff_of_injOn (hf : InjOn f (f ⁻¹' N.E)) :
     simp only [comap_dep_iff, image_insert_eq, or_iff_not_imp_right, injOn_insert heI,
       hinj, mem_image, not_exists, not_and, true_and, not_forall, Classical.not_imp, not_not] at h
     exact h (fun _ ↦ he)
-  refine Indep.basis_of_forall_insert ?_ h.2.2 fun e ⟨heX, heI⟩ ↦ ?_
+  refine Indep.isBasis_of_forall_insert ?_ h.2.2 fun e ⟨heX, heI⟩ ↦ ?_
   · simp [comap_indep_iff, h.1.indep, h.2]
   have hIE : insert e I ⊆ (N.comap f).E := by
       simp_rw [comap_ground_eq, ← image_subset_iff]
@@ -213,13 +213,14 @@ lemma comap_indep_iff_of_injOn (hf : InjOn f (f ⁻¹' N.E)) :
   exact h.1.mem_of_insert_indep (mem_image_of_mem f heX)
 
 @[simp] lemma comap_isBase_iff {B : Set α} :
-    (N.comap f).IsBase B ↔ N.Basis (f '' B) (f '' (f ⁻¹' N.E)) ∧ B.InjOn f ∧ B ⊆ f ⁻¹' N.E := by
-  rw [← basis_ground_iff, comap_basis_iff]; rfl
+    (N.comap f).IsBase B ↔ N.IsBasis (f '' B) (f '' (f ⁻¹' N.E)) ∧ B.InjOn f ∧ B ⊆ f ⁻¹' N.E := by
+  rw [← isBasis_ground_iff, comap_isBasis_iff]; rfl
 
-@[simp] lemma comap_basis'_iff {I X : Set α} :
-    (N.comap f).Basis' I X ↔ N.Basis' (f '' I) (f '' X) ∧ I.InjOn f ∧ I ⊆ X := by
-  simp only [basis'_iff_basis_inter_ground, comap_ground_eq, comap_basis_iff, image_inter_preimage,
-    subset_inter_iff, ← and_assoc, and_congr_left_iff, and_iff_left_iff_imp, and_imp]
+@[simp] lemma comap_isBasis'_iff {I X : Set α} :
+    (N.comap f).IsBasis' I X ↔ N.IsBasis' (f '' I) (f '' X) ∧ I.InjOn f ∧ I ⊆ X := by
+  simp only [isBasis'_iff_isBasis_inter_ground, comap_ground_eq, comap_isBasis_iff,
+    image_inter_preimage, subset_inter_iff, ← and_assoc, and_congr_left_iff, and_iff_left_iff_imp,
+    and_imp]
   exact fun h _ _ ↦ (image_subset_iff.1 h.indep.subset_ground)
 
 instance comap_finitary (N : Matroid β) [N.Finitary] (f : α → β) : (N.comap f).Finitary := by
@@ -260,13 +261,13 @@ lemma comapOn_preimage_eq (N : Matroid β) (f : α → β) : N.comapOn (f ⁻¹'
 @[simp] lemma comapOn_ground_eq : (N.comapOn E f).E = E := rfl
 
 lemma comapOn_isBase_iff :
-    (N.comapOn E f).IsBase B ↔ N.Basis' (f '' B) (f '' E) ∧ B.InjOn f ∧ B ⊆ E := by
-  rw [comapOn, isBase_restrict_iff', comap_basis'_iff]
+    (N.comapOn E f).IsBase B ↔ N.IsBasis' (f '' B) (f '' E) ∧ B.InjOn f ∧ B ⊆ E := by
+  rw [comapOn, isBase_restrict_iff', comap_isBasis'_iff]
 
 lemma comapOn_isBase_iff_of_surjOn (h : SurjOn f E N.E) :
     (N.comapOn E f).IsBase B ↔ (N.IsBase (f '' B) ∧ InjOn f B ∧ B ⊆ E) := by
-  simp_rw [comapOn_isBase_iff, and_congr_left_iff, and_imp,
-    basis'_iff_basis_inter_ground, inter_eq_self_of_subset_right h, basis_ground_iff, implies_true]
+  simp_rw [comapOn_isBase_iff, and_congr_left_iff, and_imp, isBasis'_iff_isBasis_inter_ground,
+    inter_eq_self_of_subset_right h, isBasis_ground_iff, implies_true]
 
 lemma comapOn_isBase_iff_of_bijOn (h : BijOn f E N.E) :
     (N.comapOn E f).IsBase B ↔ N.IsBase (f '' B) ∧ B ⊆ E := by
@@ -405,9 +406,9 @@ lemma map_image_isBase_iff {hf} {B : Set α} (hB : B ⊆ M.E) :
   refine ⟨fun ⟨J, hJ, hIJ⟩ ↦ ?_, fun h ↦ ⟨B, h, rfl⟩⟩
   rw [hf.image_eq_image_iff hB hJ.subset_ground] at hIJ; rwa [hIJ]
 
-lemma Basis.map {X : Set α} (hIX : M.Basis I X) {f : α → β} (hf) :
-    (M.map f hf).Basis (f '' I) (f '' X) := by
-  refine (hIX.indep.map f hf).basis_of_forall_insert (image_subset _ hIX.subset) ?_
+lemma IsBasis.map {X : Set α} (hIX : M.IsBasis I X) {f : α → β} (hf) :
+    (M.map f hf).IsBasis (f '' I) (f '' X) := by
+  refine (hIX.indep.map f hf).isBasis_of_forall_insert (image_subset _ hIX.subset) ?_
   rintro _ ⟨⟨e,he,rfl⟩, he'⟩
   have hss := insert_subset (hIX.subset_ground he) hIX.indep.subset_ground
   rw [← not_indep_iff (by simpa [← image_insert_eq] using image_subset f hss)]
@@ -417,24 +418,24 @@ lemma Basis.map {X : Set α} (hIX : M.Basis I X) {f : α → β} (hf) :
   obtain rfl := hins
   exact he' (mem_image_of_mem f (hIX.mem_of_insert_indep he hJ))
 
-lemma map_basis_iff {I X : Set α} (f : α → β) (hf) (hI : I ⊆ M.E) (hX : X ⊆ M.E) :
-    (M.map f hf).Basis (f '' I) (f '' X) ↔ M.Basis I X := by
+lemma map_isBasis_iff {I X : Set α} (f : α → β) (hf) (hI : I ⊆ M.E) (hX : X ⊆ M.E) :
+    (M.map f hf).IsBasis (f '' I) (f '' X) ↔ M.IsBasis I X := by
   refine ⟨fun h ↦ ?_, fun h ↦ h.map hf⟩
   obtain ⟨I', hI', hII'⟩ := map_indep_iff.1 h.indep
   rw [hf.image_eq_image_iff hI hI'.subset_ground] at hII'
   obtain rfl := hII'
   have hss := (hf.image_subset_image_iff hI hX).1 h.subset
-  refine hI'.basis_of_maximal_subset hss (fun J hJ hIJ hJX ↦ ?_)
+  refine hI'.isBasis_of_maximal_subset hss (fun J hJ hIJ hJX ↦ ?_)
   have hIJ' := h.eq_of_subset_indep (hJ.map f hf) (image_subset f hIJ) (image_subset f hJX)
   rw [hf.image_eq_image_iff hI hJ.subset_ground] at hIJ'
   exact hIJ'.symm.subset
 
-lemma map_basis_iff' {I X : Set β} {hf} :
-    (M.map f hf).Basis I X ↔ ∃ I₀ X₀, M.Basis I₀ X₀ ∧ I = f '' I₀ ∧ X = f '' X₀ := by
+lemma map_isBasis_iff' {I X : Set β} {hf} :
+    (M.map f hf).IsBasis I X ↔ ∃ I₀ X₀, M.IsBasis I₀ X₀ ∧ I = f '' I₀ ∧ X = f '' X₀ := by
   refine ⟨fun h ↦ ?_, ?_⟩
   · obtain ⟨I, hI, rfl⟩ := subset_image_iff.1 h.indep.subset_ground
     obtain ⟨X, hX, rfl⟩ := subset_image_iff.1 h.subset_ground
-    rw [map_basis_iff _ _ hI hX] at h
+    rw [map_isBasis_iff _ _ hI hX] at h
     exact ⟨I, X, h, rfl, rfl⟩
   rintro ⟨I, X, hIX, rfl, rfl⟩
   exact hIX.map hf
@@ -541,8 +542,8 @@ lemma IsBase.mapEmbedding {B : Set α} (hB : M.IsBase B) (f : α ↪ β) :
   rw [Matroid.mapEmbedding, map_isBase_iff]
   exact ⟨B, hB, rfl⟩
 
-lemma Basis.mapEmbedding {X : Set α} (hIX : M.Basis I X) (f : α ↪ β) :
-    (M.mapEmbedding f).Basis (f '' I) (f '' X) := by
+lemma IsBasis.mapEmbedding {X : Set α} (hIX : M.IsBasis I X) (f : α ↪ β) :
+    (M.mapEmbedding f).IsBasis (f '' I) (f '' X) := by
   apply hIX.map
 
 @[simp] lemma mapEmbedding_isBase_iff {f : α ↪ β} {B : Set β} :
@@ -553,9 +554,9 @@ lemma Basis.mapEmbedding {X : Set α} (hIX : M.Basis I X) (f : α ↪ β) :
   rw [preimage_image_eq _ f.injective]
   exact ⟨hB, image_subset_range _ _⟩
 
-@[simp] lemma mapEmbedding_basis_iff {f : α ↪ β} {I X : Set β} :
-    (M.mapEmbedding f).Basis I X ↔ M.Basis (f ⁻¹' I) (f ⁻¹' X) ∧ I ⊆ X ∧ X ⊆ range f := by
-  rw [mapEmbedding, map_basis_iff']
+@[simp] lemma mapEmbedding_isBasis_iff {f : α ↪ β} {I X : Set β} :
+    (M.mapEmbedding f).IsBasis I X ↔ M.IsBasis (f ⁻¹' I) (f ⁻¹' X) ∧ I ⊆ X ∧ X ⊆ range f := by
+  rw [mapEmbedding, map_isBasis_iff']
   refine ⟨?_, fun ⟨hb, hIX, hX⟩ ↦ ?_⟩
   · rintro ⟨I, X, hIX, rfl, rfl⟩
     simp [preimage_image_eq _ f.injective, image_subset f hIX.subset, hIX]
@@ -605,9 +606,9 @@ lemma mapEquiv_eq_map (f : α ≃ β) : M.mapEquiv f = M.map f f.injective.injOn
   rw [mapEquiv_eq_map, map_isBase_iff]
   exact ⟨by rintro ⟨I, hI, rfl⟩; simpa, fun h ↦ ⟨_, h, by simp⟩⟩
 
-@[simp] lemma mapEquiv_basis_iff {α β : Type*} {M : Matroid α} (f : α ≃ β) {I X : Set β} :
-    (M.mapEquiv f).Basis I X ↔ M.Basis (f.symm '' I) (f.symm '' X) := by
-  rw [mapEquiv_eq_map, map_basis_iff']
+@[simp] lemma mapEquiv_isBasis_iff {α β : Type*} {M : Matroid α} (f : α ≃ β) {I X : Set β} :
+    (M.mapEquiv f).IsBasis I X ↔ M.IsBasis (f.symm '' I) (f.symm '' X) := by
+  rw [mapEquiv_eq_map, map_isBasis_iff']
   refine ⟨fun h ↦ ?_, fun h ↦ ⟨_, _, h, by simp, by simp⟩⟩
   obtain ⟨I, X, hIX, rfl, rfl⟩ := h
   simpa
@@ -653,24 +654,25 @@ lemma restrictSubtype_inter_indep_iff :
     (M.restrictSubtype X).Indep (X ↓∩ I) ↔ M.Indep (X ∩ I) := by
   simp [restrictSubtype, Subtype.val_injective.injOn]
 
-lemma restrictSubtype_basis_iff {Y : Set α} {I X : Set Y} :
-    (M.restrictSubtype Y).Basis I X ↔ M.Basis' I X := by
-  rw [restrictSubtype, comap_basis_iff, and_iff_right Subtype.val_injective.injOn,
-    and_iff_left_of_imp, basis_restrict_iff', basis'_iff_basis_inter_ground]
+lemma restrictSubtype_isBasis_iff {Y : Set α} {I X : Set Y} :
+    (M.restrictSubtype Y).IsBasis I X ↔ M.IsBasis' I X := by
+  rw [restrictSubtype, comap_isBasis_iff, and_iff_right Subtype.val_injective.injOn,
+    and_iff_left_of_imp, isBasis_restrict_iff', isBasis'_iff_isBasis_inter_ground]
   · simp
   exact fun h ↦ (image_subset_image_iff Subtype.val_injective).1 h.subset
 
-lemma restrictSubtype_isBase_iff {B : Set X} : (M.restrictSubtype X).IsBase B ↔ M.Basis' B X := by
+lemma restrictSubtype_isBase_iff {B : Set X} : (M.restrictSubtype X).IsBase B ↔ M.IsBasis' B X := by
   rw [restrictSubtype, comap_isBase_iff]
-  simp [Subtype.val_injective.injOn, Subset.rfl, basis_restrict_iff', basis'_iff_basis_inter_ground]
+  simp [Subtype.val_injective.injOn, Subset.rfl, isBasis_restrict_iff',
+    isBasis'_iff_isBasis_inter_ground]
 
 @[simp] lemma restrictSubtype_ground_isBase_iff {B : Set M.E} :
     (M.restrictSubtype M.E).IsBase B ↔ M.IsBase B := by
-  rw [restrictSubtype_isBase_iff, basis'_iff_basis, basis_ground_iff]
+  rw [restrictSubtype_isBase_iff, isBasis'_iff_isBasis, isBasis_ground_iff]
 
-@[simp] lemma restrictSubtype_ground_basis_iff {I X : Set M.E} :
-    (M.restrictSubtype M.E).Basis I X ↔ M.Basis I X := by
-  rw [restrictSubtype_basis_iff, basis'_iff_basis]
+@[simp] lemma restrictSubtype_ground_isBasis_iff {I X : Set M.E} :
+    (M.restrictSubtype M.E).IsBasis I X ↔ M.IsBasis I X := by
+  rw [restrictSubtype_isBasis_iff, isBasis'_iff_isBasis]
 
 lemma eq_of_restrictSubtype_eq {N : Matroid α} (hM : M.E = E) (hN : N.E = E)
     (h : M.restrictSubtype E = N.restrictSubtype E) : M = N := by

--- a/Mathlib/Data/Matroid/Map.lean
+++ b/Mathlib/Data/Matroid/Map.lean
@@ -123,13 +123,13 @@ def comap (N : Matroid β) (f : α → β) : Matroid α :=
       rintro I B ⟨hI, hIinj⟩ hImax hBmax
       obtain ⟨I', hII', hI', hI'inj⟩ := (not_maximal_subset_iff ⟨hI, hIinj⟩).1 hImax
 
-      have h₁ : ¬(N ↾ range f).Base (f '' I) := by
+      have h₁ : ¬(N ↾ range f).IsBase (f '' I) := by
         refine fun hB ↦ hII'.ne ?_
         have h_im := hB.eq_of_subset_indep (by simpa) (image_subset _ hII'.subset)
         rwa [hI'inj.image_eq_image_iff hII'.subset Subset.rfl] at h_im
 
-      have h₂ : (N ↾ range f).Base (f '' B) := by
-        refine Indep.base_of_forall_insert (by simpa using hBmax.1.1) ?_
+      have h₂ : (N ↾ range f).IsBase (f '' B) := by
+        refine Indep.isBase_of_forall_insert (by simpa using hBmax.1.1) ?_
         rintro _ ⟨⟨e, heB, rfl⟩, hfe⟩ hi
         rw [restrict_indep_iff, ← image_insert_eq] at hi
         have hinj : InjOn f (insert e B) := by
@@ -138,7 +138,7 @@ def comap (N : Matroid β) (f : α → β) : Matroid α :=
         refine hBmax.not_prop_of_ssuperset (t := insert e B) (ssubset_insert ?_) ⟨hi.1, hinj⟩
         exact fun heB ↦ hfe <| mem_image_of_mem f heB
 
-      obtain ⟨_, ⟨⟨e, he, rfl⟩, he'⟩, hei⟩ := Indep.exists_insert_of_not_base (by simpa) h₁ h₂
+      obtain ⟨_, ⟨⟨e, he, rfl⟩, he'⟩, hei⟩ := Indep.exists_insert_of_not_isBase (by simpa) h₁ h₂
       have heI : e ∉ I := fun heI ↦ he' (mem_image_of_mem f heI)
       rw [← image_insert_eq, restrict_indep_iff] at hei
       exact ⟨e, ⟨he, heI⟩, hei.1, (injOn_insert heI).2 ⟨hIinj, he'⟩⟩
@@ -212,8 +212,8 @@ lemma comap_indep_iff_of_injOn (hf : InjOn f (f ⁻¹' N.E)) :
     by simpa [← not_indep_iff hIE, injOn_insert heI, h.2.1, image_insert_eq]
   exact h.1.mem_of_insert_indep (mem_image_of_mem f heX)
 
-@[simp] lemma comap_base_iff {B : Set α} :
-    (N.comap f).Base B ↔ N.Basis (f '' B) (f '' (f ⁻¹' N.E)) ∧ B.InjOn f ∧ B ⊆ f ⁻¹' N.E := by
+@[simp] lemma comap_isBase_iff {B : Set α} :
+    (N.comap f).IsBase B ↔ N.Basis (f '' B) (f '' (f ⁻¹' N.E)) ∧ B.InjOn f ∧ B ⊆ f ⁻¹' N.E := by
   rw [← basis_ground_iff, comap_basis_iff]; rfl
 
 @[simp] lemma comap_basis'_iff {I X : Set α} :
@@ -233,9 +233,9 @@ instance comap_finitary (N : Matroid β) [N.Finitary] (f : α → β) : (N.comap
   exact (hI J' (hJ'J.trans hJ) (hfin.of_finite_image hJ'.injOn)).1
 
 instance comap_rankFinite (N : Matroid β) [N.RankFinite] (f : α → β) : (N.comap f).RankFinite := by
-  obtain ⟨B, hB⟩ := (N.comap f).exists_base
+  obtain ⟨B, hB⟩ := (N.comap f).exists_isBase
   refine hB.rankFinite_of_finite ?_
-  simp only [comap_base_iff] at hB
+  simp only [comap_isBase_iff] at hB
   exact (hB.1.indep.finite.of_finite_image hB.2.1)
 
 end comap
@@ -259,28 +259,28 @@ lemma comapOn_preimage_eq (N : Matroid β) (f : α → β) : N.comapOn (f ⁻¹'
 
 @[simp] lemma comapOn_ground_eq : (N.comapOn E f).E = E := rfl
 
-lemma comapOn_base_iff :
-    (N.comapOn E f).Base B ↔ N.Basis' (f '' B) (f '' E) ∧ B.InjOn f ∧ B ⊆ E := by
-  rw [comapOn, base_restrict_iff', comap_basis'_iff]
+lemma comapOn_isBase_iff :
+    (N.comapOn E f).IsBase B ↔ N.Basis' (f '' B) (f '' E) ∧ B.InjOn f ∧ B ⊆ E := by
+  rw [comapOn, isBase_restrict_iff', comap_basis'_iff]
 
-lemma comapOn_base_iff_of_surjOn (h : SurjOn f E N.E) :
-    (N.comapOn E f).Base B ↔ (N.Base (f '' B) ∧ InjOn f B ∧ B ⊆ E) := by
-  simp_rw [comapOn_base_iff, and_congr_left_iff, and_imp,
+lemma comapOn_isBase_iff_of_surjOn (h : SurjOn f E N.E) :
+    (N.comapOn E f).IsBase B ↔ (N.IsBase (f '' B) ∧ InjOn f B ∧ B ⊆ E) := by
+  simp_rw [comapOn_isBase_iff, and_congr_left_iff, and_imp,
     basis'_iff_basis_inter_ground, inter_eq_self_of_subset_right h, basis_ground_iff, implies_true]
 
-lemma comapOn_base_iff_of_bijOn (h : BijOn f E N.E) :
-    (N.comapOn E f).Base B ↔ N.Base (f '' B) ∧ B ⊆ E := by
-  rw [← and_iff_left_of_imp (Base.subset_ground (M := N.comapOn E f) (B := B)),
+lemma comapOn_isBase_iff_of_bijOn (h : BijOn f E N.E) :
+    (N.comapOn E f).IsBase B ↔ N.IsBase (f '' B) ∧ B ⊆ E := by
+  rw [← and_iff_left_of_imp (IsBase.subset_ground (M := N.comapOn E f) (B := B)),
     comapOn_ground_eq, and_congr_left_iff]
   suffices h' : B ⊆ E → InjOn f B from fun hB ↦
-    by simp [hB, comapOn_base_iff_of_surjOn h.surjOn, h']
+    by simp [hB, comapOn_isBase_iff_of_surjOn h.surjOn, h']
   exact fun hBE ↦ h.injOn.mono hBE
 
 lemma comapOn_dual_eq_of_bijOn (h : BijOn f E N.E) :
     (N.comapOn E f)✶ = N✶.comapOn E f := by
-  refine ext_base (by simp) (fun B hB ↦ ?_)
-  rw [comapOn_base_iff_of_bijOn (by simpa), dual_base_iff, comapOn_base_iff_of_bijOn h,
-    dual_base_iff _, comapOn_ground_eq, and_iff_left diff_subset, and_iff_left (by simpa),
+  refine ext_isBase (by simp) (fun B hB ↦ ?_)
+  rw [comapOn_isBase_iff_of_bijOn (by simpa), dual_isBase_iff, comapOn_isBase_iff_of_bijOn h,
+    dual_isBase_iff _, comapOn_ground_eq, and_iff_left diff_subset, and_iff_left (by simpa),
     h.injOn.image_diff_subset (by simpa), h.image_eq]
   exact (h.mapsTo.mono_left (show B ⊆ E by simpa)).image_subset
 
@@ -370,12 +370,12 @@ lemma map_image_indep_iff {hf} {I : Set α} (hI : I ⊆ M.E) :
   refine ⟨fun ⟨J, hJ, hIJ⟩ ↦ ?_, fun h ↦ ⟨I, h, rfl⟩⟩
   rw [hf.image_eq_image_iff hI hJ.subset_ground] at hIJ; rwa [hIJ]
 
-@[simp] lemma map_base_iff (M : Matroid α) (f : α → β) (hf) {B : Set β} :
-    (M.map f hf).Base B ↔ ∃ B₀, M.Base B₀ ∧ B = f '' B₀ := by
-  rw [base_iff_maximal_indep]
+@[simp] lemma map_isBase_iff (M : Matroid α) (f : α → β) (hf) {B : Set β} :
+    (M.map f hf).IsBase B ↔ ∃ B₀, M.IsBase B₀ ∧ B = f '' B₀ := by
+  rw [isBase_iff_maximal_indep]
   refine ⟨fun h ↦ ?_, ?_⟩
   · obtain ⟨B₀, hB₀, hbij⟩ := h.prop.exists_bijOn_of_map
-    refine ⟨B₀, hB₀.base_of_maximal fun J hJ hB₀J ↦ ?_, hbij.image_eq.symm⟩
+    refine ⟨B₀, hB₀.isBase_of_maximal fun J hJ hB₀J ↦ ?_, hbij.image_eq.symm⟩
     rw [← hf.image_eq_image_iff hB₀.subset_ground hJ.subset_ground, hbij.image_eq]
     exact h.eq_of_subset (hJ.map f hf) (hbij.image_eq ▸ image_subset f hB₀J)
   rintro ⟨B, hB, rfl⟩
@@ -385,8 +385,8 @@ lemma map_image_indep_iff {hf} {I : Set α} (hI : I ⊆ M.E) :
   rw [← hbij.image_eq, hf.image_subset_image_iff hB.subset_ground hI₀.subset_ground] at hBI
   rw [hB.eq_of_subset_indep hI₀ hBI, hbij.image_eq]
 
-lemma Base.map {B : Set α} (hB : M.Base B) {f : α → β} (hf) : (M.map f hf).Base (f '' B) := by
-  rw [map_base_iff]; exact ⟨B, hB, rfl⟩
+lemma IsBase.map {B : Set α} (hB : M.IsBase B) {f : α → β} (hf) : (M.map f hf).IsBase (f '' B) := by
+  rw [map_isBase_iff]; exact ⟨B, hB, rfl⟩
 
 lemma map_dep_iff {hf} {D : Set β} :
     (M.map f hf).Dep D ↔ ∃ D₀, M.Dep D₀ ∧ D = f '' D₀ := by
@@ -399,9 +399,9 @@ lemma map_dep_iff {hf} {D : Set β} :
   rw [hf.image_eq_image_iff hD₀E hI.subset_ground] at h_eq
   subst h_eq; contradiction
 
-lemma map_image_base_iff {hf} {B : Set α} (hB : B ⊆ M.E) :
-    (M.map f hf).Base (f '' B) ↔ M.Base B := by
-  rw [map_base_iff]
+lemma map_image_isBase_iff {hf} {B : Set α} (hB : B ⊆ M.E) :
+    (M.map f hf).IsBase (f '' B) ↔ M.IsBase B := by
+  rw [map_isBase_iff]
   refine ⟨fun ⟨J, hJ, hIJ⟩ ↦ ?_, fun h ↦ ⟨B, h, rfl⟩⟩
   rw [hf.image_eq_image_iff hB hJ.subset_ground] at hIJ; rwa [hIJ]
 
@@ -440,12 +440,12 @@ lemma map_basis_iff' {I X : Set β} {hf} :
   exact hIX.map hf
 
 @[simp] lemma map_dual {hf} : (M.map f hf)✶ = M✶.map f hf := by
-  apply ext_base (by simp)
+  apply ext_isBase (by simp)
   simp only [dual_ground, map_ground, subset_image_iff, forall_exists_index, and_imp,
-    forall_apply_eq_imp_iff₂, dual_base_iff']
+    forall_apply_eq_imp_iff₂, dual_isBase_iff']
   intro B hB
-  simp_rw [← hf.image_diff_subset hB, map_image_base_iff diff_subset,
-    map_image_base_iff (show B ⊆ M✶.E from hB), dual_base_iff hB, and_iff_left_iff_imp]
+  simp_rw [← hf.image_diff_subset hB, map_image_isBase_iff diff_subset,
+    map_image_isBase_iff (show B ⊆ M✶.E from hB), dual_isBase_iff hB, and_iff_left_iff_imp]
   exact fun _ ↦ ⟨B, hB, rfl⟩
 
 @[simp] lemma map_emptyOn (f : α → β) : (emptyOn α).map f (by simp) = emptyOn β := by
@@ -491,11 +491,11 @@ instance [M.Finitary] {f : α → β} (hf) : (M.map f hf).Finitary := by
   rwa [map_image_indep_iff (hJ₀I₀.trans hI₀E)] at hI
 
 instance [M.RankFinite] {f : α → β} (hf) : (M.map f hf).RankFinite :=
-  let ⟨_, hB⟩ := M.exists_base
+  let ⟨_, hB⟩ := M.exists_isBase
   (hB.map hf).rankFinite_of_finite (hB.finite.image _)
 
 instance [M.RankPos] {f : α → β} (hf) : (M.map f hf).RankPos :=
-  let ⟨_, hB⟩ := M.exists_base
+  let ⟨_, hB⟩ := M.exists_isBase
   (hB.map hf).rankPos_of_nonempty (hB.nonempty.image _)
 
 end map
@@ -536,18 +536,18 @@ def mapEmbedding (M : Matroid α) (f : α ↪ β) : Matroid β := M.map f f.inje
 lemma Indep.mapEmbedding (hI : M.Indep I) (f : α ↪ β) : (M.mapEmbedding f).Indep (f '' I) := by
   simpa [preimage_image_eq I f.injective]
 
-lemma Base.mapEmbedding {B : Set α} (hB : M.Base B) (f : α ↪ β) :
-    (M.mapEmbedding f).Base (f '' B) := by
-  rw [Matroid.mapEmbedding, map_base_iff]
+lemma IsBase.mapEmbedding {B : Set α} (hB : M.IsBase B) (f : α ↪ β) :
+    (M.mapEmbedding f).IsBase (f '' B) := by
+  rw [Matroid.mapEmbedding, map_isBase_iff]
   exact ⟨B, hB, rfl⟩
 
 lemma Basis.mapEmbedding {X : Set α} (hIX : M.Basis I X) (f : α ↪ β) :
     (M.mapEmbedding f).Basis (f '' I) (f '' X) := by
   apply hIX.map
 
-@[simp] lemma mapEmbedding_base_iff {f : α ↪ β} {B : Set β} :
-    (M.mapEmbedding f).Base B ↔ M.Base (f ⁻¹' B) ∧ B ⊆ range f := by
-  rw [mapEmbedding, map_base_iff]
+@[simp] lemma mapEmbedding_isBase_iff {f : α ↪ β} {B : Set β} :
+    (M.mapEmbedding f).IsBase B ↔ M.IsBase (f ⁻¹' B) ∧ B ⊆ range f := by
+  rw [mapEmbedding, map_isBase_iff]
   refine ⟨?_, fun ⟨h,h'⟩ ↦ ⟨f ⁻¹' B, h, by rwa [eq_comm, image_preimage_eq_iff]⟩⟩
   rintro ⟨B, hB, rfl⟩
   rw [preimage_image_eq _ f.injective]
@@ -600,8 +600,9 @@ lemma mapEquiv_eq_map (f : α ≃ β) : M.mapEquiv f = M.map f f.injective.injOn
   rw [mapEquiv_eq_map, map_dep_iff]
   exact ⟨by rintro ⟨I, hI, rfl⟩; simpa, fun h ↦ ⟨_, h, by simp⟩⟩
 
-@[simp] lemma mapEquiv_base_iff {B : Set β} : (M.mapEquiv f).Base B ↔ M.Base (f.symm '' B) := by
-  rw [mapEquiv_eq_map, map_base_iff]
+@[simp] lemma mapEquiv_isBase_iff {B : Set β} :
+    (M.mapEquiv f).IsBase B ↔ M.IsBase (f.symm '' B) := by
+  rw [mapEquiv_eq_map, map_isBase_iff]
   exact ⟨by rintro ⟨I, hI, rfl⟩; simpa, fun h ↦ ⟨_, h, by simp⟩⟩
 
 @[simp] lemma mapEquiv_basis_iff {α β : Type*} {M : Matroid α} (f : α ≃ β) {I X : Set β} :
@@ -659,13 +660,13 @@ lemma restrictSubtype_basis_iff {Y : Set α} {I X : Set Y} :
   · simp
   exact fun h ↦ (image_subset_image_iff Subtype.val_injective).1 h.subset
 
-lemma restrictSubtype_base_iff {B : Set X} : (M.restrictSubtype X).Base B ↔ M.Basis' B X := by
-  rw [restrictSubtype, comap_base_iff]
+lemma restrictSubtype_isBase_iff {B : Set X} : (M.restrictSubtype X).IsBase B ↔ M.Basis' B X := by
+  rw [restrictSubtype, comap_isBase_iff]
   simp [Subtype.val_injective.injOn, Subset.rfl, basis_restrict_iff', basis'_iff_basis_inter_ground]
 
-@[simp] lemma restrictSubtype_ground_base_iff {B : Set M.E} :
-    (M.restrictSubtype M.E).Base B ↔ M.Base B := by
-  rw [restrictSubtype_base_iff, basis'_iff_basis, basis_ground_iff]
+@[simp] lemma restrictSubtype_ground_isBase_iff {B : Set M.E} :
+    (M.restrictSubtype M.E).IsBase B ↔ M.IsBase B := by
+  rw [restrictSubtype_isBase_iff, basis'_iff_basis, basis_ground_iff]
 
 @[simp] lemma restrictSubtype_ground_basis_iff {I X : Set M.E} :
     (M.restrictSubtype M.E).Basis I X ↔ M.Basis I X := by
@@ -710,8 +711,8 @@ instance [M.Nonempty] : (M.restrictSubtype M.E).Nonempty :=
   ⟨by simp⟩
 
 instance [M.RankPos] : (M.restrictSubtype M.E).RankPos := by
-  obtain ⟨B, hB⟩ := (M.restrictSubtype M.E).exists_base
-  have hB' : M.Base ↑B := by simpa using hB.map Subtype.val_injective.injOn
+  obtain ⟨B, hB⟩ := (M.restrictSubtype M.E).exists_isBase
+  have hB' : M.IsBase ↑B := by simpa using hB.map Subtype.val_injective.injOn
   exact hB.rankPos_of_nonempty <| by simpa using hB'.nonempty
 
 end restrictSubtype

--- a/Mathlib/Data/Matroid/Rank/Cardinal.lean
+++ b/Mathlib/Data/Matroid/Rank/Cardinal.lean
@@ -10,8 +10,8 @@ import Mathlib.SetTheory.Cardinal.Arithmetic
 /-!
 # Cardinal-valued rank
 
-In a finitary matroid, all isBases have the same cardinality.
-In fact, something stronger holds: if `I` and `J` are both isBases for a set `X`,
+In a finitary matroid, all bases have the same cardinality.
+In fact, something stronger holds: if each of `I` and `J` is a basis for a set `X`,
 then `#(I \ J) = #(J \ I)` and (consequently) `#I = #J`.
 This file introduces a typeclass `InvariantCardinalRank` that applies to any matroid
 such that this property holds for all `I`, `J` and `X`.
@@ -68,10 +68,10 @@ section Rank
 
 variable {κ : Cardinal}
 
-/-- The rank (supremum of the cardinalities of isBases) of a matroid `M` as a `Cardinal`. -/
+/-- The rank (supremum of the cardinalities of bases) of a matroid `M` as a `Cardinal`. -/
 noncomputable def cRank (M : Matroid α) := ⨆ B : {B // M.IsBase B}, #B
 
-/-- The rank (supremum of the cardinalities of isBases) of a set `X` in a matroid `M`,
+/-- The rank (supremum of the cardinalities of bases) of a set `X` in a matroid `M`,
 as a `Cardinal`. -/
 noncomputable def cRk (M : Matroid α) (X : Set α) := (M ↾ X).cRank
 
@@ -88,20 +88,20 @@ theorem cRank_eq_iSup_cardinalMk_indep : M.cRank = ⨆ I : {I // M.Indep I}, #I 
       have ⟨B, isBase, hIB⟩ := I.2.exists_isBase_superset
       le_ciSup_of_le (bddAbove_range _) ⟨B, isBase⟩ (mk_le_mk_of_subset hIB)
 
-theorem Basis'.cardinalMk_le_cRk (hIX : M.Basis' I X) : #I ≤ M.cRk X :=
+theorem IsBasis'.cardinalMk_le_cRk (hIX : M.IsBasis' I X) : #I ≤ M.cRk X :=
   (isBase_restrict_iff'.2 hIX).cardinalMk_le_cRank
 
-theorem Basis.cardinalMk_le_cRk (hIX : M.Basis I X) : #I ≤ M.cRk X :=
-  hIX.basis'.cardinalMk_le_cRk
+theorem IsBasis.cardinalMk_le_cRk (hIX : M.IsBasis I X) : #I ≤ M.cRk X :=
+  hIX.isBasis'.cardinalMk_le_cRk
 
 theorem cRank_le_iff : M.cRank ≤ κ ↔ ∀ ⦃B⦄, M.IsBase B → #B ≤ κ :=
   ⟨fun h _ hB ↦ (hB.cardinalMk_le_cRank.trans h), fun h ↦ ciSup_le fun ⟨_, hB⟩ ↦ h hB⟩
 
-theorem cRk_le_iff : M.cRk X ≤ κ ↔ ∀ ⦃I⦄, M.Basis' I X → #I ≤ κ := by
+theorem cRk_le_iff : M.cRk X ≤ κ ↔ ∀ ⦃I⦄, M.IsBasis' I X → #I ≤ κ := by
   simp_rw [cRk, cRank_le_iff, isBase_restrict_iff']
 
 theorem Indep.cardinalMk_le_cRk_of_subset (hI : M.Indep I) (hIX : I ⊆ X) : #I ≤ M.cRk X :=
-  let ⟨_, hJ, hIJ⟩ := hI.subset_basis'_of_subset hIX
+  let ⟨_, hJ, hIJ⟩ := hI.subset_isBasis'_of_subset hIX
   (mk_le_mk_of_subset hIJ).trans hJ.cardinalMk_le_cRk
 
 theorem cRk_le_cardinalMk (M : Matroid α) (X : Set α) : M.cRk X ≤ #X :=
@@ -115,7 +115,7 @@ theorem cRk_le_cardinalMk (M : Matroid α) (X : Set α) : M.cRk X ≤ #X :=
 theorem cRk_mono (M : Matroid α) : Monotone M.cRk := by
   simp only [Monotone, le_eq_subset, cRk_le_iff]
   intro X Y hXY I hIX
-  obtain ⟨J, hJ, hIJ⟩ := hIX.indep.subset_basis'_of_subset (hIX.subset.trans hXY)
+  obtain ⟨J, hJ, hIJ⟩ := hIX.indep.subset_isBasis'_of_subset (hIX.subset.trans hXY)
   exact (mk_le_mk_of_subset hIJ).trans hJ.cardinalMk_le_cRk
 
 theorem cRk_le_of_subset (M : Matroid α) (hXY : X ⊆ Y) : M.cRk X ≤ M.cRk Y :=
@@ -123,11 +123,11 @@ theorem cRk_le_of_subset (M : Matroid α) (hXY : X ⊆ Y) : M.cRk X ≤ M.cRk Y 
 
 @[simp] theorem cRk_inter_ground (M : Matroid α) (X : Set α) : M.cRk (X ∩ M.E) = M.cRk X :=
   (M.cRk_le_of_subset inter_subset_left).antisymm <| cRk_le_iff.2
-    fun _ h ↦ h.basis_inter_ground.cardinalMk_le_cRk
+    fun _ h ↦ h.isBasis_inter_ground.cardinalMk_le_cRk
 
 theorem cRk_restrict_subset (M : Matroid α) (hYX : Y ⊆ X) : (M ↾ X).cRk Y = M.cRk Y := by
-  have aux : ∀ ⦃I⦄, M.Basis' I Y ↔ (M ↾ X).Basis' I Y := by
-    simp_rw [basis'_restrict_iff, inter_eq_self_of_subset_left hYX, iff_self_and]
+  have aux : ∀ ⦃I⦄, M.IsBasis' I Y ↔ (M ↾ X).IsBasis' I Y := by
+    simp_rw [isBasis'_restrict_iff, inter_eq_self_of_subset_left hYX, iff_self_and]
     exact fun I h ↦ h.subset.trans hYX
   simp_rw [le_antisymm_iff, cRk_le_iff]
   exact ⟨fun I hI ↦ (aux.2 hI).cardinalMk_le_cRk, fun I hI ↦ (aux.1 hI).cardinalMk_le_cRk⟩
@@ -137,16 +137,16 @@ theorem cRk_restrict (M : Matroid α) (X Y : Set α) : (M ↾ X).cRk Y = M.cRk (
     inter_comm]
 
 theorem Indep.cRk_eq_cardinalMk (hI : M.Indep I) : #I = M.cRk I :=
-  (M.cRk_le_cardinalMk I).antisymm' (hI.basis_self.cardinalMk_le_cRk)
+  (M.cRk_le_cardinalMk I).antisymm' (hI.isBasis_self.cardinalMk_le_cRk)
 
 @[simp] theorem cRk_map_image_lift (M : Matroid α) (hf : InjOn f M.E) (X : Set α)
     (hX : X ⊆ M.E := by aesop_mat) : lift.{u,v} ((M.map f hf).cRk (f '' X)) = lift (M.cRk X) := by
   nth_rw 1 [cRk, cRank, le_antisymm_iff, lift_iSup (bddAbove_range _), cRk, cRank, cRk, cRank]
   nth_rw 2 [lift_iSup (bddAbove_range _)]
   simp only [ciSup_le_iff (bddAbove_range _), ge_iff_le, Subtype.forall, isBase_restrict_iff',
-    basis'_iff_basis hX, basis'_iff_basis (show f '' X ⊆ (M.map f hf).E from image_mono hX)]
+    isBasis'_iff_isBasis hX, isBasis'_iff_isBasis (show f '' X ⊆ (M.map f hf).E from image_mono hX)]
   refine ⟨fun I hI ↦ ?_, fun I hI ↦ ?_⟩
-  · obtain ⟨I, X', hIX, rfl, hXX'⟩ := map_basis_iff'.1 hI
+  · obtain ⟨I, X', hIX, rfl, hXX'⟩ := map_isBasis_iff'.1 hI
     rw [mk_image_eq_of_injOn_lift _ _ (hf.mono hIX.indep.subset_ground), lift_le]
     obtain rfl : X = X' := by rwa [hf.image_eq_image_iff hX hIX.subset_ground] at hXX'
     exact hIX.cardinalMk_le_cRk
@@ -167,7 +167,7 @@ theorem cRk_map_eq {β : Type u} {f : α → β} {X : Set β} (M : Matroid α) (
   nth_rw 1 [cRk, cRank, le_antisymm_iff, lift_iSup (bddAbove_range _), cRk, cRank, cRk, cRank]
   nth_rw 2 [lift_iSup (bddAbove_range _)]
   simp only [ciSup_le_iff (bddAbove_range _), ge_iff_le, Subtype.forall, isBase_restrict_iff',
-    comap_basis'_iff, and_imp]
+    comap_isBasis'_iff, and_imp]
   refine ⟨fun I hI hfI hIX ↦ ?_, fun I hIX ↦ ?_⟩
   · rw [← mk_image_eq_of_injOn_lift _ _ hfI, lift_le]
     exact hI.cardinalMk_le_cRk
@@ -176,7 +176,7 @@ theorem cRk_map_eq {β : Type u} {f : α → β} {X : Set β} (M : Matroid α) (
     refine ⟨I₀, hI₀ss.trans inter_subset_right, ?_, hbij.injOn⟩
     rw [hbij.image_eq, image_preimage_inter, inter_eq_self_of_subset_left hIX.subset]
   rw [mk_image_eq_of_injOn_lift _ _ hfI₀, lift_le]
-  exact Basis'.cardinalMk_le_cRk <| comap_basis'_iff.2 ⟨hIX, hfI₀, hI₀X⟩
+  exact IsBasis'.cardinalMk_le_cRk <| comap_isBasis'_iff.2 ⟨hIX, hfI₀, hI₀X⟩
 
 @[simp] theorem cRk_comap {β : Type u} (M : Matroid β) (f : α → β) (X : Set α) :
     (M.comap f).cRk X = M.cRk (f '' X) :=
@@ -191,48 +191,48 @@ section Invariant
 Notably, this holds for `Finitary` matroids; see `Matroid.invariantCardinalRank_of_finitary`.  -/
 @[mk_iff]
 class InvariantCardinalRank (M : Matroid α) : Prop where
-  forall_card_basis_diff :
-    ∀ ⦃I J X⦄, M.Basis I X → M.Basis J X → #(I \ J : Set α) = #(J \ I : Set α)
+  forall_card_isBasis_diff :
+    ∀ ⦃I J X⦄, M.IsBasis I X → M.IsBasis J X → #(I \ J : Set α) = #(J \ I : Set α)
 
 variable [InvariantCardinalRank M]
 
-theorem Basis.cardinalMk_diff_comm (hIX : M.Basis I X) (hJX : M.Basis J X) :
+theorem IsBasis.cardinalMk_diff_comm (hIX : M.IsBasis I X) (hJX : M.IsBasis J X) :
     #(I \ J : Set α) = #(J \ I : Set α) :=
-  InvariantCardinalRank.forall_card_basis_diff hIX hJX
+  InvariantCardinalRank.forall_card_isBasis_diff hIX hJX
 
-theorem Basis'.cardinalMk_diff_comm (hIX : M.Basis' I X) (hJX : M.Basis' J X) :
+theorem IsBasis'.cardinalMk_diff_comm (hIX : M.IsBasis' I X) (hJX : M.IsBasis' J X) :
     #(I \ J : Set α) = #(J \ I : Set α) :=
-  hIX.basis_inter_ground.cardinalMk_diff_comm hJX.basis_inter_ground
+  hIX.isBasis_inter_ground.cardinalMk_diff_comm hJX.isBasis_inter_ground
 
 theorem IsBase.cardinalMk_diff_comm (hB : M.IsBase B) (hB' : M.IsBase B') :
     #(B \ B' : Set α) = #(B' \ B : Set α) :=
-  hB.basis_ground.cardinalMk_diff_comm hB'.basis_ground
+  hB.isBasis_ground.cardinalMk_diff_comm hB'.isBasis_ground
 
-theorem Basis.cardinalMk_eq (hIX : M.Basis I X) (hJX : M.Basis J X) : #I = #J := by
+theorem IsBasis.cardinalMk_eq (hIX : M.IsBasis I X) (hJX : M.IsBasis J X) : #I = #J := by
   rw [← diff_union_inter I J,
     mk_union_of_disjoint (disjoint_sdiff_left.mono_right inter_subset_right),
     hIX.cardinalMk_diff_comm hJX,
     ← mk_union_of_disjoint (disjoint_sdiff_left.mono_right inter_subset_left),
     inter_comm, diff_union_inter]
 
-theorem Basis'.cardinalMk_eq (hIX : M.Basis' I X) (hJX : M.Basis' J X) : #I = #J :=
-  hIX.basis_inter_ground.cardinalMk_eq hJX.basis_inter_ground
+theorem IsBasis'.cardinalMk_eq (hIX : M.IsBasis' I X) (hJX : M.IsBasis' J X) : #I = #J :=
+  hIX.isBasis_inter_ground.cardinalMk_eq hJX.isBasis_inter_ground
 
 theorem IsBase.cardinalMk_eq (hB : M.IsBase B) (hB' : M.IsBase B') : #B = #B' :=
-  hB.basis_ground.cardinalMk_eq hB'.basis_ground
+  hB.isBasis_ground.cardinalMk_eq hB'.isBasis_ground
 
 theorem Indep.cardinalMk_le_isBase (hI : M.Indep I) (hB : M.IsBase B) : #I ≤ #B :=
   have ⟨_B', hB', hIB'⟩ := hI.exists_isBase_superset
   hB'.cardinalMk_eq hB ▸ mk_le_mk_of_subset hIB'
 
-theorem Indep.cardinalMk_le_basis' (hI : M.Indep I) (hJ : M.Basis' J X) (hIX : I ⊆ X) :
+theorem Indep.cardinalMk_le_isBasis' (hI : M.Indep I) (hJ : M.IsBasis' J X) (hIX : I ⊆ X) :
     #I ≤ #J :=
-  have ⟨_J', hJ', hIJ'⟩ := hI.subset_basis'_of_subset hIX
+  have ⟨_J', hJ', hIJ'⟩ := hI.subset_isBasis'_of_subset hIX
   hJ'.cardinalMk_eq hJ ▸ mk_le_mk_of_subset hIJ'
 
-theorem Indep.cardinalMk_le_basis (hI : M.Indep I) (hJ : M.Basis J X) (hIX : I ⊆ X) :
+theorem Indep.cardinalMk_le_isBasis (hI : M.Indep I) (hJ : M.IsBasis J X) (hIX : I ⊆ X) :
     #I ≤ #J :=
-  hI.cardinalMk_le_basis' hJ.basis' hIX
+  hI.cardinalMk_le_isBasis' hJ.isBasis' hIX
 
 theorem IsBase.cardinalMk_eq_cRank (hB : M.IsBase B) : #B = M.cRank := by
   have hrw : ∀ B' : {B : Set α // M.IsBase B}, #B' = #B := fun B' ↦ B'.2.cardinalMk_eq hB
@@ -242,19 +242,19 @@ theorem IsBase.cardinalMk_eq_cRank (hB : M.IsBase B) : #B = M.cRank := by
 instance invariantCardinalRank_restrict [InvariantCardinalRank M] :
     InvariantCardinalRank (M ↾ X) := by
   refine ⟨fun I J Y hI hJ ↦ ?_⟩
-  rw [basis_restrict_iff'] at hI hJ
+  rw [isBasis_restrict_iff'] at hI hJ
   exact hI.1.cardinalMk_diff_comm hJ.1
 
-theorem Basis'.cardinalMk_eq_cRk (hIX : M.Basis' I X) : #I = M.cRk X := by
+theorem IsBasis'.cardinalMk_eq_cRk (hIX : M.IsBasis' I X) : #I = M.cRk X := by
   rw [cRk, (isBase_restrict_iff'.2 hIX).cardinalMk_eq_cRank]
 
-theorem Basis.cardinalMk_eq_cRk (hIX : M.Basis I X) : #I = M.cRk X :=
-  hIX.basis'.cardinalMk_eq_cRk
+theorem IsBasis.cardinalMk_eq_cRk (hIX : M.IsBasis I X) : #I = M.cRk X :=
+  hIX.isBasis'.cardinalMk_eq_cRk
 
 @[simp] theorem cRk_closure (M : Matroid α) [InvariantCardinalRank M] (X : Set α) :
     M.cRk (M.closure X) = M.cRk X := by
-  obtain ⟨I, hI⟩ := M.exists_basis' X
-  rw [← hI.basis_closure_right.cardinalMk_eq_cRk, ← hI.cardinalMk_eq_cRk]
+  obtain ⟨I, hI⟩ := M.exists_isBasis' X
+  rw [← hI.isBasis_closure_right.cardinalMk_eq_cRk, ← hI.cardinalMk_eq_cRk]
 
 theorem cRk_closure_congr (hXY : M.closure X = M.closure Y) : M.cRk X = M.cRk Y := by
   rw [← cRk_closure, hXY, cRk_closure]
@@ -279,11 +279,11 @@ theorem cRk_union_closure_eq : M.cRk (M.closure X ∪ M.closure Y) = M.cRk (X �
 
 /-- The `Cardinal` rank function is submodular. -/
 theorem cRk_inter_add_cRk_union_le : M.cRk (X ∩ Y) + M.cRk (X ∪ Y) ≤ M.cRk X + M.cRk Y := by
-  obtain ⟨Ii, hIi⟩ := M.exists_basis' (X ∩ Y)
+  obtain ⟨Ii, hIi⟩ := M.exists_isBasis' (X ∩ Y)
   obtain ⟨IX, hIX, hIX'⟩ :=
-    hIi.indep.subset_basis'_of_subset (hIi.subset.trans inter_subset_left)
+    hIi.indep.subset_isBasis'_of_subset (hIi.subset.trans inter_subset_left)
   obtain ⟨IY, hIY, hIY'⟩ :=
-    hIi.indep.subset_basis'_of_subset (hIi.subset.trans inter_subset_right)
+    hIi.indep.subset_isBasis'_of_subset (hIi.subset.trans inter_subset_right)
   rw [← cRk_union_closure_eq, ← hIX.closure_eq_closure, ← hIY.closure_eq_closure,
     cRk_union_closure_eq, ← hIi.cardinalMk_eq_cRk, ← hIX.cardinalMk_eq_cRk,
     ← hIY.cardinalMk_eq_cRk, ← mk_union_add_mk_inter, add_comm]
@@ -328,8 +328,8 @@ instance invariantCardinalRank_of_finitary [Finitary M] : InvariantCardinalRank 
 instance invariantCardinalRank_map (M : Matroid α) [InvariantCardinalRank M] (hf : InjOn f M.E) :
     InvariantCardinalRank (M.map f hf) := by
   refine ⟨fun I J X hI hJ ↦ ?_⟩
-  obtain ⟨I, X, hIX, rfl, rfl⟩ := map_basis_iff'.1 hI
-  obtain ⟨J, X', hJX, rfl, h'⟩ := map_basis_iff'.1 hJ
+  obtain ⟨I, X, hIX, rfl, rfl⟩ := map_isBasis_iff'.1 hI
+  obtain ⟨J, X', hJX, rfl, h'⟩ := map_isBasis_iff'.1 hJ
   obtain rfl : X = X' := by
     rwa [InjOn.image_eq_image_iff hf hIX.subset_ground hJX.subset_ground] at h'
   have hcard := hIX.cardinalMk_diff_comm hJX
@@ -344,8 +344,8 @@ instance invariantCardinalRank_map (M : Matroid α) [InvariantCardinalRank M] (h
 instance invariantCardinalRank_comap (M : Matroid β) [InvariantCardinalRank M] (f : α → β) :
     InvariantCardinalRank (M.comap f) := by
   refine ⟨fun I J X hI hJ ↦ ?_⟩
-  obtain ⟨hI, hfI, hIX⟩ := comap_basis_iff.1 hI
-  obtain ⟨hJ, hfJ, hJX⟩ := comap_basis_iff.1 hJ
+  obtain ⟨hI, hfI, hIX⟩ := comap_isBasis_iff.1 hI
+  obtain ⟨hJ, hfJ, hJX⟩ := comap_isBasis_iff.1 hJ
   rw [← lift_inj.{u,v}, ← mk_image_eq_of_injOn_lift _ _ (hfI.mono diff_subset),
     ← mk_image_eq_of_injOn_lift _ _ (hfJ.mono diff_subset), lift_inj, hfI.image_diff,
     hfJ.image_diff, ← diff_union_diff_cancel inter_subset_left (image_inter_subset f I J),

--- a/Mathlib/Data/Matroid/Rank/Cardinal.lean
+++ b/Mathlib/Data/Matroid/Rank/Cardinal.lean
@@ -10,8 +10,8 @@ import Mathlib.SetTheory.Cardinal.Arithmetic
 /-!
 # Cardinal-valued rank
 
-In a finitary matroid, all bases have the same cardinality.
-In fact, something stronger holds: if `I` and `J` are both bases for a set `X`,
+In a finitary matroid, all isBases have the same cardinality.
+In fact, something stronger holds: if `I` and `J` are both isBases for a set `X`,
 then `#(I \ J) = #(J \ I)` and (consequently) `#I = #J`.
 This file introduces a typeclass `InvariantCardinalRank` that applies to any matroid
 such that this property holds for all `I`, `J` and `X`.
@@ -32,7 +32,7 @@ both for itself and all its minors.
 # Notes
 
 It is not the case that all matroids are `InvariantCardinalRank`,
-since the equicardinality of bases in general matroids is independent of ZFC
+since the equicardinality of isBases in general matroids is independent of ZFC
 (see the module docstring of `Mathlib.Data.Matroid.Basic`).
 Lemmas like `Matroid.Base.cardinalMk_diff_comm` become true for all matroids
 only if they are weakened by replacing `Cardinal.mk`
@@ -68,37 +68,37 @@ section Rank
 
 variable {κ : Cardinal}
 
-/-- The rank (supremum of the cardinalities of bases) of a matroid `M` as a `Cardinal`. -/
-noncomputable def cRank (M : Matroid α) := ⨆ B : {B // M.Base B}, #B
+/-- The rank (supremum of the cardinalities of isBases) of a matroid `M` as a `Cardinal`. -/
+noncomputable def cRank (M : Matroid α) := ⨆ B : {B // M.IsBase B}, #B
 
-/-- The rank (supremum of the cardinalities of bases) of a set `X` in a matroid `M`,
+/-- The rank (supremum of the cardinalities of isBases) of a set `X` in a matroid `M`,
 as a `Cardinal`. -/
 noncomputable def cRk (M : Matroid α) (X : Set α) := (M ↾ X).cRank
 
-theorem Base.cardinalMk_le_cRank (hB : M.Base B) : #B ≤ M.cRank :=
-  le_ciSup (f := fun B : {B // M.Base B} ↦ #B.1) (bddAbove_range _) ⟨B, hB⟩
+theorem IsBase.cardinalMk_le_cRank (hB : M.IsBase B) : #B ≤ M.cRank :=
+  le_ciSup (f := fun B : {B // M.IsBase B} ↦ #B.1) (bddAbove_range _) ⟨B, hB⟩
 
 theorem Indep.cardinalMk_le_cRank (ind : M.Indep I) : #I ≤ M.cRank :=
-  have ⟨B, base, hIB⟩ := ind.exists_base_superset
-  le_ciSup_of_le (bddAbove_range _) ⟨B, base⟩ (mk_le_mk_of_subset hIB)
+  have ⟨B, isBase, hIB⟩ := ind.exists_isBase_superset
+  le_ciSup_of_le (bddAbove_range _) ⟨B, isBase⟩ (mk_le_mk_of_subset hIB)
 
 theorem cRank_eq_iSup_cardinalMk_indep : M.cRank = ⨆ I : {I // M.Indep I}, #I :=
   (ciSup_le' fun B ↦ le_ciSup_of_le (bddAbove_range _) ⟨B, B.2.indep⟩ <| by rfl).antisymm <|
     ciSup_le' fun I ↦
-      have ⟨B, base, hIB⟩ := I.2.exists_base_superset
-      le_ciSup_of_le (bddAbove_range _) ⟨B, base⟩ (mk_le_mk_of_subset hIB)
+      have ⟨B, isBase, hIB⟩ := I.2.exists_isBase_superset
+      le_ciSup_of_le (bddAbove_range _) ⟨B, isBase⟩ (mk_le_mk_of_subset hIB)
 
 theorem Basis'.cardinalMk_le_cRk (hIX : M.Basis' I X) : #I ≤ M.cRk X :=
-  (base_restrict_iff'.2 hIX).cardinalMk_le_cRank
+  (isBase_restrict_iff'.2 hIX).cardinalMk_le_cRank
 
 theorem Basis.cardinalMk_le_cRk (hIX : M.Basis I X) : #I ≤ M.cRk X :=
   hIX.basis'.cardinalMk_le_cRk
 
-theorem cRank_le_iff : M.cRank ≤ κ ↔ ∀ ⦃B⦄, M.Base B → #B ≤ κ :=
+theorem cRank_le_iff : M.cRank ≤ κ ↔ ∀ ⦃B⦄, M.IsBase B → #B ≤ κ :=
   ⟨fun h _ hB ↦ (hB.cardinalMk_le_cRank.trans h), fun h ↦ ciSup_le fun ⟨_, hB⟩ ↦ h hB⟩
 
 theorem cRk_le_iff : M.cRk X ≤ κ ↔ ∀ ⦃I⦄, M.Basis' I X → #I ≤ κ := by
-  simp_rw [cRk, cRank_le_iff, base_restrict_iff']
+  simp_rw [cRk, cRank_le_iff, isBase_restrict_iff']
 
 theorem Indep.cardinalMk_le_cRk_of_subset (hI : M.Indep I) (hIX : I ⊆ X) : #I ≤ M.cRk X :=
   let ⟨_, hJ, hIJ⟩ := hI.subset_basis'_of_subset hIX
@@ -143,7 +143,7 @@ theorem Indep.cRk_eq_cardinalMk (hI : M.Indep I) : #I = M.cRk I :=
     (hX : X ⊆ M.E := by aesop_mat) : lift.{u,v} ((M.map f hf).cRk (f '' X)) = lift (M.cRk X) := by
   nth_rw 1 [cRk, cRank, le_antisymm_iff, lift_iSup (bddAbove_range _), cRk, cRank, cRk, cRank]
   nth_rw 2 [lift_iSup (bddAbove_range _)]
-  simp only [ciSup_le_iff (bddAbove_range _), ge_iff_le, Subtype.forall, base_restrict_iff',
+  simp only [ciSup_le_iff (bddAbove_range _), ge_iff_le, Subtype.forall, isBase_restrict_iff',
     basis'_iff_basis hX, basis'_iff_basis (show f '' X ⊆ (M.map f hf).E from image_mono hX)]
   refine ⟨fun I hI ↦ ?_, fun I hI ↦ ?_⟩
   · obtain ⟨I, X', hIX, rfl, hXX'⟩ := map_basis_iff'.1 hI
@@ -166,7 +166,7 @@ theorem cRk_map_eq {β : Type u} {f : α → β} {X : Set β} (M : Matroid α) (
     lift.{v,u} ((M.comap f).cRk X) = lift (M.cRk (f '' X)) := by
   nth_rw 1 [cRk, cRank, le_antisymm_iff, lift_iSup (bddAbove_range _), cRk, cRank, cRk, cRank]
   nth_rw 2 [lift_iSup (bddAbove_range _)]
-  simp only [ciSup_le_iff (bddAbove_range _), ge_iff_le, Subtype.forall, base_restrict_iff',
+  simp only [ciSup_le_iff (bddAbove_range _), ge_iff_le, Subtype.forall, isBase_restrict_iff',
     comap_basis'_iff, and_imp]
   refine ⟨fun I hI hfI hIX ↦ ?_, fun I hIX ↦ ?_⟩
   · rw [← mk_image_eq_of_injOn_lift _ _ hfI, lift_le]
@@ -187,7 +187,7 @@ end Rank
 section Invariant
 
 /-- A class stating that cardinality-valued rank is well-defined
-(i.e. all bases are equicardinal) for a matroid `M` and its minors.
+(i.e. all isBases are equicardinal) for a matroid `M` and its minors.
 Notably, this holds for `Finitary` matroids; see `Matroid.invariantCardinalRank_of_finitary`.  -/
 @[mk_iff]
 class InvariantCardinalRank (M : Matroid α) : Prop where
@@ -204,7 +204,7 @@ theorem Basis'.cardinalMk_diff_comm (hIX : M.Basis' I X) (hJX : M.Basis' J X) :
     #(I \ J : Set α) = #(J \ I : Set α) :=
   hIX.basis_inter_ground.cardinalMk_diff_comm hJX.basis_inter_ground
 
-theorem Base.cardinalMk_diff_comm (hB : M.Base B) (hB' : M.Base B') :
+theorem IsBase.cardinalMk_diff_comm (hB : M.IsBase B) (hB' : M.IsBase B') :
     #(B \ B' : Set α) = #(B' \ B : Set α) :=
   hB.basis_ground.cardinalMk_diff_comm hB'.basis_ground
 
@@ -218,11 +218,11 @@ theorem Basis.cardinalMk_eq (hIX : M.Basis I X) (hJX : M.Basis J X) : #I = #J :=
 theorem Basis'.cardinalMk_eq (hIX : M.Basis' I X) (hJX : M.Basis' J X) : #I = #J :=
   hIX.basis_inter_ground.cardinalMk_eq hJX.basis_inter_ground
 
-theorem Base.cardinalMk_eq (hB : M.Base B) (hB' : M.Base B') : #B = #B' :=
+theorem IsBase.cardinalMk_eq (hB : M.IsBase B) (hB' : M.IsBase B') : #B = #B' :=
   hB.basis_ground.cardinalMk_eq hB'.basis_ground
 
-theorem Indep.cardinalMk_le_base (hI : M.Indep I) (hB : M.Base B) : #I ≤ #B :=
-  have ⟨_B', hB', hIB'⟩ := hI.exists_base_superset
+theorem Indep.cardinalMk_le_isBase (hI : M.Indep I) (hB : M.IsBase B) : #I ≤ #B :=
+  have ⟨_B', hB', hIB'⟩ := hI.exists_isBase_superset
   hB'.cardinalMk_eq hB ▸ mk_le_mk_of_subset hIB'
 
 theorem Indep.cardinalMk_le_basis' (hI : M.Indep I) (hJ : M.Basis' J X) (hIX : I ⊆ X) :
@@ -234,8 +234,8 @@ theorem Indep.cardinalMk_le_basis (hI : M.Indep I) (hJ : M.Basis J X) (hIX : I �
     #I ≤ #J :=
   hI.cardinalMk_le_basis' hJ.basis' hIX
 
-theorem Base.cardinalMk_eq_cRank (hB : M.Base B) : #B = M.cRank := by
-  have hrw : ∀ B' : {B : Set α // M.Base B}, #B' = #B := fun B' ↦ B'.2.cardinalMk_eq hB
+theorem IsBase.cardinalMk_eq_cRank (hB : M.IsBase B) : #B = M.cRank := by
+  have hrw : ∀ B' : {B : Set α // M.IsBase B}, #B' = #B := fun B' ↦ B'.2.cardinalMk_eq hB
   simp [cRank, hrw]
 
 /-- Restrictions of matroids with cardinal rank functions have cardinal rank functions- -/
@@ -246,7 +246,7 @@ instance invariantCardinalRank_restrict [InvariantCardinalRank M] :
   exact hI.1.cardinalMk_diff_comm hJ.1
 
 theorem Basis'.cardinalMk_eq_cRk (hIX : M.Basis' I X) : #I = M.cRk X := by
-  rw [cRk, (base_restrict_iff'.2 hIX).cardinalMk_eq_cRank]
+  rw [cRk, (isBase_restrict_iff'.2 hIX).cardinalMk_eq_cRank]
 
 theorem Basis.cardinalMk_eq_cRk (hIX : M.Basis I X) : #I = M.cRk X :=
   hIX.basis'.cardinalMk_eq_cRk
@@ -260,7 +260,7 @@ theorem cRk_closure_congr (hXY : M.closure X = M.closure Y) : M.cRk X = M.cRk Y 
   rw [← cRk_closure, hXY, cRk_closure]
 
 theorem Spanning.cRank_le_cardinalMk (h : M.Spanning X) : M.cRank ≤ #X :=
-  have ⟨_B, hB, hBX⟩ := h.exists_base_subset
+  have ⟨_B, hB, hBX⟩ := h.exists_isBase_subset
   (hB.cardinalMk_eq_cRank).symm.trans_le (mk_le_mk_of_subset hBX)
 
 variable (M : Matroid α) [InvariantCardinalRank M] (e : α) (X Y : Set α)
@@ -295,10 +295,10 @@ section Instances
 
 /-- `Finitary` matroids have a cardinality-valued rank function. -/
 instance invariantCardinalRank_of_finitary [Finitary M] : InvariantCardinalRank M := by
-  suffices aux : ∀ ⦃B B'⦄ ⦃N : Matroid α⦄, Finitary N → N.Base B → N.Base B' →
+  suffices aux : ∀ ⦃B B'⦄ ⦃N : Matroid α⦄, Finitary N → N.IsBase B → N.IsBase B' →
       #(B \ B' : Set α) ≤ #(B' \ B : Set α) from
-    ⟨fun I J X hI hJ ↦ (aux (restrict_finitary X) hI.base_restrict hJ.base_restrict).antisymm
-      (aux (restrict_finitary X) hJ.base_restrict hI.base_restrict)⟩
+    ⟨fun I J X hI hJ ↦ (aux (restrict_finitary X) hI.isBase_restrict hJ.isBase_restrict).antisymm
+      (aux (restrict_finitary X) hJ.isBase_restrict hI.isBase_restrict)⟩
   intro B B' N hfin hB hB'
   by_cases h : (B' \ B).Finite
   · rw [← cast_ncard h, ← cast_ncard, hB.ncard_diff_comm hB']
@@ -360,32 +360,33 @@ theorem rankFinite_iff_cRank_lt_aleph0 : M.RankFinite ↔ M.cRank < ℵ₀ := by
   refine ⟨fun h ↦ ?_, fun h ↦ ⟨?_⟩⟩
   · have ⟨B, hB, fin⟩ := h
     exact hB.cardinalMk_eq_cRank ▸ lt_aleph0_iff_finite.mpr fin
-  have ⟨B, hB⟩ := M.exists_base
+  have ⟨B, hB⟩ := M.exists_isBase
   simp_rw [← finite_coe_iff, ← lt_aleph0_iff_finite]
   exact ⟨B, hB, hB.cardinalMk_le_cRank.trans_lt h⟩
 
 theorem isRkFinite_iff_cRk_lt_aleph0 : M.IsRkFinite X ↔ M.cRk X < ℵ₀ := by
   rw [IsRkFinite, rankFinite_iff_cRank_lt_aleph0, cRank_restrict]
 
-theorem Indep.base_of_cRank_le [M.RankFinite] (ind : M.Indep I) (le : M.cRank ≤ #I) : M.Base I :=
-  ind.base_of_maximal fun _J ind_J hIJ ↦ ind.finite.eq_of_subset_of_encard_le' hIJ <|
+theorem Indep.isBase_of_cRank_le [M.RankFinite] (ind : M.Indep I) (le : M.cRank ≤ #I) :
+    M.IsBase I :=
+  ind.isBase_of_maximal fun _J ind_J hIJ ↦ ind.finite.eq_of_subset_of_encard_le' hIJ <|
     toENat.monotone' <| ind_J.cardinalMk_le_cRank.trans le
 
-theorem Spanning.base_of_le_cRank [M.RankFinite] (h : M.Spanning X) (le : #X ≤ M.cRank) :
-    M.Base X := by
-  have ⟨B, hB, hBX⟩ := h.exists_base_subset
+theorem Spanning.isBase_of_le_cRank [M.RankFinite] (h : M.Spanning X) (le : #X ≤ M.cRank) :
+    M.IsBase X := by
+  have ⟨B, hB, hBX⟩ := h.exists_isBase_subset
   rwa [← hB.finite.eq_of_subset_of_encard_le' hBX
     (toENat.monotone' <| le.trans hB.cardinalMk_eq_cRank.ge)]
 
-theorem Indep.base_of_cRank_le_of_finite (ind : M.Indep I)
-    (le : M.cRank ≤ #I) (fin : I.Finite) : M.Base I :=
+theorem Indep.isBase_of_cRank_le_of_finite (ind : M.Indep I)
+    (le : M.cRank ≤ #I) (fin : I.Finite) : M.IsBase I :=
   have := rankFinite_iff_cRank_lt_aleph0.mpr (le.trans_lt <| lt_aleph0_iff_finite.mpr fin)
-  ind.base_of_cRank_le le
+  ind.isBase_of_cRank_le le
 
-theorem Spanning.base_of_le_cRank_of_finite (h : M.Spanning X)
-    (le : #X ≤ M.cRank) (fin : X.Finite) : M.Base X :=
-  have ⟨_B, hB, hBX⟩ := h.exists_base_subset
+theorem Spanning.isBase_of_le_cRank_of_finite (h : M.Spanning X)
+    (le : #X ≤ M.cRank) (fin : X.Finite) : M.IsBase X :=
+  have ⟨_B, hB, hBX⟩ := h.exists_isBase_subset
   have := hB.rankFinite_of_finite (fin.subset hBX)
-  h.base_of_le_cRank le
+  h.isBase_of_le_cRank le
 
 end Matroid

--- a/Mathlib/Data/Matroid/Rank/Finite.lean
+++ b/Mathlib/Data/Matroid/Rank/Finite.lean
@@ -8,7 +8,7 @@ import Mathlib.Data.Matroid.Closure
 /-!
 # Finite-rank sets
 
-`Matroid.IsRkFinite M X`  means that every basis of the set `X` in the matroid `M` is finite,
+`Matroid.IsRkFinite M X`  means that every isBasis of the set `X` in the matroid `M` is finite,
 or equivalently that the restriction of `M` to `X` is `Matroid.RankFinite`.
 Sets in a matroid with `IsRkFinite` are the largest class of sets for which one can do nontrivial
 integer arithmetic involving the rank function.
@@ -25,83 +25,83 @@ open Set
 
 namespace Matroid
 
-/-- `Matroid.IsRkFinite M X` means that every basis of `X` in `M` is finite. -/
+/-- `Matroid.IsRkFinite M X` means that every isBasis of `X` in `M` is finite. -/
 def IsRkFinite (M : Matroid α) (X : Set α) : Prop := (M ↾ X).RankFinite
 
 lemma IsRkFinite.rankFinite (hX : M.IsRkFinite X) : (M ↾ X).RankFinite :=
   hX
 
-lemma Basis'.finite_iff_isRkFinite (hI : M.Basis' I X) : I.Finite ↔ M.IsRkFinite X :=
+lemma IsBasis'.finite_iff_isRkFinite (hI : M.IsBasis' I X) : I.Finite ↔ M.IsRkFinite X :=
   ⟨fun h ↦ ⟨I, hI, h⟩, fun (_ : (M ↾ X).RankFinite) ↦ hI.isBase_restrict.finite⟩
 
-alias ⟨_, Basis'.finite_of_isRkFinite⟩ := Basis'.finite_iff_isRkFinite
+alias ⟨_, IsBasis'.finite_of_isRkFinite⟩ := IsBasis'.finite_iff_isRkFinite
 
-lemma Basis.finite_iff_isRkFinite (hI : M.Basis I X) : I.Finite ↔ M.IsRkFinite X :=
-  hI.basis'.finite_iff_isRkFinite
+lemma IsBasis.finite_iff_isRkFinite (hI : M.IsBasis I X) : I.Finite ↔ M.IsRkFinite X :=
+  hI.isBasis'.finite_iff_isRkFinite
 
-alias ⟨_, Basis.finite_of_isRkFinite⟩ := Basis.finite_iff_isRkFinite
+alias ⟨_, IsBasis.finite_of_isRkFinite⟩ := IsBasis.finite_iff_isRkFinite
 
-lemma Basis'.isRkFinite_of_finite (hI : M.Basis' I X) (hIfin : I.Finite) : M.IsRkFinite X :=
+lemma IsBasis'.isRkFinite_of_finite (hI : M.IsBasis' I X) (hIfin : I.Finite) : M.IsRkFinite X :=
   ⟨I, hI, hIfin⟩
 
-lemma Basis.isRkFinite_of_finite (hI : M.Basis I X) (hIfin : I.Finite) : M.IsRkFinite X :=
-  ⟨I, hI.basis', hIfin⟩
+lemma IsBasis.isRkFinite_of_finite (hI : M.IsBasis I X) (hIfin : I.Finite) : M.IsRkFinite X :=
+  ⟨I, hI.isBasis', hIfin⟩
 
-/-- A `Basis'` of an `IsRkFinite` set is finite. -/
-lemma IsRkFinite.finite_of_basis' (h : M.IsRkFinite X) (hI : M.Basis' I X) : I.Finite :=
+/-- A `IsBasis'` of an `IsRkFinite` set is finite. -/
+lemma IsRkFinite.finite_of_isBasis' (h : M.IsRkFinite X) (hI : M.IsBasis' I X) : I.Finite :=
   have := h.rankFinite
   (isBase_restrict_iff'.2 hI).finite
 
-lemma IsRkFinite.finite_of_basis (h : M.IsRkFinite X) (hI : M.Basis I X) : I.Finite :=
-  h.finite_of_basis' hI.basis'
+lemma IsRkFinite.finite_of_isBasis (h : M.IsRkFinite X) (hI : M.IsBasis I X) : I.Finite :=
+  h.finite_of_isBasis' hI.isBasis'
 
-/-- An `IsRkFinite` set has a finite `Basis'`-/
-lemma IsRkFinite.exists_finite_basis' (h : M.IsRkFinite X) : ∃ I, M.Basis' I X ∧ I.Finite :=
+/-- An `IsRkFinite` set has a finite `IsBasis'`-/
+lemma IsRkFinite.exists_finite_isBasis' (h : M.IsRkFinite X) : ∃ I, M.IsBasis' I X ∧ I.Finite :=
   h.exists_finite_isBase
 
-/-- An `IsRkFinite` set has a finset `Basis'` -/
-lemma IsRkFinite.exists_finset_basis' (h : M.IsRkFinite X) : ∃ (I : Finset α), M.Basis' I X :=
-  let ⟨I, hI, hIfin⟩ := h.exists_finite_basis'
+/-- An `IsRkFinite` set has a finset `IsBasis'` -/
+lemma IsRkFinite.exists_finset_isBasis' (h : M.IsRkFinite X) : ∃ (I : Finset α), M.IsBasis' I X :=
+  let ⟨I, hI, hIfin⟩ := h.exists_finite_isBasis'
   ⟨hIfin.toFinset, by simpa⟩
 
-/-- A set satisfies `IsRkFinite` iff it has a finite `Basis'` -/
-lemma isRkFinite_iff_exists_basis' : M.IsRkFinite X ↔ ∃ I, M.Basis' I X ∧ I.Finite :=
-  ⟨IsRkFinite.exists_finite_basis', fun ⟨_, hIX, hI⟩ ↦ hIX.isRkFinite_of_finite hI⟩
+/-- A set satisfies `IsRkFinite` iff it has a finite `IsBasis'` -/
+lemma isRkFinite_iff_exists_isBasis' : M.IsRkFinite X ↔ ∃ I, M.IsBasis' I X ∧ I.Finite :=
+  ⟨IsRkFinite.exists_finite_isBasis', fun ⟨_, hIX, hI⟩ ↦ hIX.isRkFinite_of_finite hI⟩
 
 lemma IsRkFinite.subset (h : M.IsRkFinite X) (hXY : Y ⊆ X) : M.IsRkFinite Y := by
-  obtain ⟨I, hI⟩ := M.exists_basis' Y
-  obtain ⟨J, hJ, hIJ⟩ := hI.indep.subset_basis'_of_subset (hI.subset.trans hXY)
+  obtain ⟨I, hI⟩ := M.exists_isBasis' Y
+  obtain ⟨J, hJ, hIJ⟩ := hI.indep.subset_isBasis'_of_subset (hI.subset.trans hXY)
   exact hI.isRkFinite_of_finite <| (hJ.finite_of_isRkFinite h).subset hIJ
 
 @[simp]
 lemma isRkFinite_inter_ground_iff : M.IsRkFinite (X ∩ M.E) ↔ M.IsRkFinite X :=
-  let ⟨_I, hI⟩ := M.exists_basis' X
-  ⟨fun h ↦ hI.isRkFinite_of_finite (hI.basis_inter_ground.finite_of_isRkFinite h),
+  let ⟨_I, hI⟩ := M.exists_isBasis' X
+  ⟨fun h ↦ hI.isRkFinite_of_finite (hI.isBasis_inter_ground.finite_of_isRkFinite h),
     fun h ↦ h.subset inter_subset_left⟩
 
 lemma IsRkFinite.inter_ground (h : M.IsRkFinite X) : M.IsRkFinite (X ∩ M.E) :=
   isRkFinite_inter_ground_iff.2 h
 
 lemma isRkFinite_iff (hX : X ⊆ M.E := by aesop_mat) :
-    M.IsRkFinite X ↔ ∃ I, M.Basis I X ∧ I.Finite := by
-  simp_rw [isRkFinite_iff_exists_basis', M.basis'_iff_basis hX]
+    M.IsRkFinite X ↔ ∃ I, M.IsBasis I X ∧ I.Finite := by
+  simp_rw [isRkFinite_iff_exists_isBasis', M.isBasis'_iff_isBasis hX]
 
 lemma Indep.isRkFinite_iff_finite (hI : M.Indep I) : M.IsRkFinite I ↔ I.Finite :=
-  hI.basis_self.finite_iff_isRkFinite.symm
+  hI.isBasis_self.finite_iff_isRkFinite.symm
 
 alias ⟨Indep.finite_of_isRkFinite, _⟩ := Indep.isRkFinite_iff_finite
 
 lemma isRkFinite_of_finite (M : Matroid α) (hX : X.Finite) : M.IsRkFinite X :=
-  let ⟨_, hI⟩ := M.exists_basis' X
+  let ⟨_, hI⟩ := M.exists_isBasis' X
   hI.isRkFinite_of_finite (hX.subset hI.subset)
 
-lemma Indep.subset_finite_basis'_of_subset_of_isRkFinite (hI : M.Indep I) (hIX : I ⊆ X)
-    (hX : M.IsRkFinite X) : ∃ J, M.Basis' J X ∧ I ⊆ J ∧ J.Finite :=
-  (hI.subset_basis'_of_subset hIX).imp fun _ hJ => ⟨hJ.1, hJ.2, hJ.1.finite_of_isRkFinite hX⟩
+lemma Indep.subset_finite_isBasis'_of_subset_of_isRkFinite (hI : M.Indep I) (hIX : I ⊆ X)
+    (hX : M.IsRkFinite X) : ∃ J, M.IsBasis' J X ∧ I ⊆ J ∧ J.Finite :=
+  (hI.subset_isBasis'_of_subset hIX).imp fun _ hJ => ⟨hJ.1, hJ.2, hJ.1.finite_of_isRkFinite hX⟩
 
-lemma Indep.subset_finite_basis_of_subset_of_isRkFinite (hI : M.Indep I) (hIX : I ⊆ X)
-    (hX : M.IsRkFinite X) (hXE : X ⊆ M.E := by aesop_mat) : ∃ J, M.Basis J X ∧ I ⊆ J ∧ J.Finite :=
-  (hI.subset_basis_of_subset hIX).imp fun _ hJ => ⟨hJ.1, hJ.2, hJ.1.finite_of_isRkFinite hX⟩
+lemma Indep.subset_finite_isBasis_of_subset_of_isRkFinite (hI : M.Indep I) (hIX : I ⊆ X)
+    (hX : M.IsRkFinite X) (hXE : X ⊆ M.E := by aesop_mat) : ∃ J, M.IsBasis J X ∧ I ⊆ J ∧ J.Finite :=
+  (hI.subset_isBasis_of_subset hIX).imp fun _ hJ => ⟨hJ.1, hJ.2, hJ.1.finite_of_isRkFinite hX⟩
 
 lemma isRkFinite_singleton : M.IsRkFinite {e} :=
   isRkFinite_of_finite M (finite_singleton e)
@@ -126,8 +126,8 @@ lemma Indep.finite_of_subset_isRkFinite (hI : M.Indep I) (hIX : I ⊆ X) (hX : M
   hX.finite_of_indep_subset hI hIX
 
 lemma IsRkFinite.closure (h : M.IsRkFinite X) : M.IsRkFinite (M.closure X) :=
-  let ⟨_, hI⟩ := M.exists_basis' X
-  hI.basis_closure_right.isRkFinite_of_finite <| hI.finite_of_isRkFinite h
+  let ⟨_, hI⟩ := M.exists_isBasis' X
+  hI.isBasis_closure_right.isRkFinite_of_finite <| hI.finite_of_isRkFinite h
 
 @[simp]
 lemma isRkFinite_closure_iff : M.IsRkFinite (M.closure X) ↔ M.IsRkFinite X := by
@@ -135,8 +135,8 @@ lemma isRkFinite_closure_iff : M.IsRkFinite (M.closure X) ↔ M.IsRkFinite X := 
   exact ⟨fun h ↦ h.subset <| M.inter_ground_subset_closure X, fun h ↦ by simpa using h.closure⟩
 
 lemma IsRkFinite.union (hX : M.IsRkFinite X) (hY : M.IsRkFinite Y) : M.IsRkFinite (X ∪ Y) := by
-  obtain ⟨I, hI, hIfin⟩ := hX.exists_finite_basis'
-  obtain ⟨J, hJ, hJfin⟩ := hY.exists_finite_basis'
+  obtain ⟨I, hI, hIfin⟩ := hX.exists_finite_isBasis'
+  obtain ⟨J, hJ, hJfin⟩ := hY.exists_finite_isBasis'
   rw [← isRkFinite_inter_ground_iff]
   refine (M.isRkFinite_of_finite (hIfin.union hJfin)).closure.subset ?_
   rw [closure_union_congr_left hI.closure_eq_closure,
@@ -173,17 +173,17 @@ lemma IsRkFinite.diff_singleton_iff : M.IsRkFinite (X \ {e}) ↔ M.IsRkFinite X 
   rw [isRkFinite_singleton.isRkFinite_diff_iff]
 
 lemma isRkFinite_set (M : Matroid α) [RankFinite M] (X : Set α) : M.IsRkFinite X :=
-  let ⟨_, hI⟩ := M.exists_basis' X
+  let ⟨_, hI⟩ := M.exists_isBasis' X
   hI.isRkFinite_of_finite hI.indep.finite
 
 /-- A union of finitely many `IsRkFinite` sets is `IsRkFinite`. -/
 lemma IsRkFinite.iUnion {ι : Type*} [Fintype ι] {Xs : ι → Set α} (h : ∀ i, M.IsRkFinite (Xs i)) :
     M.IsRkFinite (⋃ i, Xs i) := by
-  choose Is hIs using fun i ↦ M.exists_basis' (Xs i)
-  have hfin : (⋃ i, Is i).Finite := finite_iUnion <| fun i ↦ (h i).finite_of_basis' (hIs i)
+  choose Is hIs using fun i ↦ M.exists_isBasis' (Xs i)
+  have hfin : (⋃ i, Is i).Finite := finite_iUnion <| fun i ↦ (h i).finite_of_isBasis' (hIs i)
   refine isRkFinite_inter_ground_iff.1 <| (M.isRkFinite_of_finite hfin).closure.subset ?_
   rw [iUnion_inter, iUnion_subset_iff]
-  exact fun i ↦ (hIs i).basis_inter_ground.subset_closure.trans <| M.closure_subset_closure <|
+  exact fun i ↦ (hIs i).isBasis_inter_ground.subset_closure.trans <| M.closure_subset_closure <|
     subset_iUnion ..
 
 end Matroid

--- a/Mathlib/Data/Matroid/Rank/Finite.lean
+++ b/Mathlib/Data/Matroid/Rank/Finite.lean
@@ -8,7 +8,7 @@ import Mathlib.Data.Matroid.Closure
 /-!
 # Finite-rank sets
 
-`Matroid.IsRkFinite M X`  means that every isBasis of the set `X` in the matroid `M` is finite,
+`Matroid.IsRkFinite M X`  means that every basis of the set `X` in the matroid `M` is finite,
 or equivalently that the restriction of `M` to `X` is `Matroid.RankFinite`.
 Sets in a matroid with `IsRkFinite` are the largest class of sets for which one can do nontrivial
 integer arithmetic involving the rank function.
@@ -25,7 +25,7 @@ open Set
 
 namespace Matroid
 
-/-- `Matroid.IsRkFinite M X` means that every isBasis of `X` in `M` is finite. -/
+/-- `Matroid.IsRkFinite M X` means that every basis of `X` in `M` is finite. -/
 def IsRkFinite (M : Matroid α) (X : Set α) : Prop := (M ↾ X).RankFinite
 
 lemma IsRkFinite.rankFinite (hX : M.IsRkFinite X) : (M ↾ X).RankFinite :=
@@ -47,7 +47,7 @@ lemma IsBasis'.isRkFinite_of_finite (hI : M.IsBasis' I X) (hIfin : I.Finite) : M
 lemma IsBasis.isRkFinite_of_finite (hI : M.IsBasis I X) (hIfin : I.Finite) : M.IsRkFinite X :=
   ⟨I, hI.isBasis', hIfin⟩
 
-/-- A `IsBasis'` of an `IsRkFinite` set is finite. -/
+/-- A basis' of an `IsRkFinite` set is finite. -/
 lemma IsRkFinite.finite_of_isBasis' (h : M.IsRkFinite X) (hI : M.IsBasis' I X) : I.Finite :=
   have := h.rankFinite
   (isBase_restrict_iff'.2 hI).finite
@@ -55,16 +55,16 @@ lemma IsRkFinite.finite_of_isBasis' (h : M.IsRkFinite X) (hI : M.IsBasis' I X) :
 lemma IsRkFinite.finite_of_isBasis (h : M.IsRkFinite X) (hI : M.IsBasis I X) : I.Finite :=
   h.finite_of_isBasis' hI.isBasis'
 
-/-- An `IsRkFinite` set has a finite `IsBasis'`-/
+/-- An `IsRkFinite` set has a finite basis' -/
 lemma IsRkFinite.exists_finite_isBasis' (h : M.IsRkFinite X) : ∃ I, M.IsBasis' I X ∧ I.Finite :=
   h.exists_finite_isBase
 
-/-- An `IsRkFinite` set has a finset `IsBasis'` -/
+/-- An `IsRkFinite` set has a finset basis' -/
 lemma IsRkFinite.exists_finset_isBasis' (h : M.IsRkFinite X) : ∃ (I : Finset α), M.IsBasis' I X :=
   let ⟨I, hI, hIfin⟩ := h.exists_finite_isBasis'
   ⟨hIfin.toFinset, by simpa⟩
 
-/-- A set satisfies `IsRkFinite` iff it has a finite `IsBasis'` -/
+/-- A set satisfies `IsRkFinite` iff it has a finite basis' -/
 lemma isRkFinite_iff_exists_isBasis' : M.IsRkFinite X ↔ ∃ I, M.IsBasis' I X ∧ I.Finite :=
   ⟨IsRkFinite.exists_finite_isBasis', fun ⟨_, hIX, hI⟩ ↦ hIX.isRkFinite_of_finite hI⟩
 

--- a/Mathlib/Data/Matroid/Rank/Finite.lean
+++ b/Mathlib/Data/Matroid/Rank/Finite.lean
@@ -32,7 +32,7 @@ lemma IsRkFinite.rankFinite (hX : M.IsRkFinite X) : (M ↾ X).RankFinite :=
   hX
 
 lemma Basis'.finite_iff_isRkFinite (hI : M.Basis' I X) : I.Finite ↔ M.IsRkFinite X :=
-  ⟨fun h ↦ ⟨I, hI, h⟩, fun (_ : (M ↾ X).RankFinite) ↦ hI.base_restrict.finite⟩
+  ⟨fun h ↦ ⟨I, hI, h⟩, fun (_ : (M ↾ X).RankFinite) ↦ hI.isBase_restrict.finite⟩
 
 alias ⟨_, Basis'.finite_of_isRkFinite⟩ := Basis'.finite_iff_isRkFinite
 
@@ -50,14 +50,14 @@ lemma Basis.isRkFinite_of_finite (hI : M.Basis I X) (hIfin : I.Finite) : M.IsRkF
 /-- A `Basis'` of an `IsRkFinite` set is finite. -/
 lemma IsRkFinite.finite_of_basis' (h : M.IsRkFinite X) (hI : M.Basis' I X) : I.Finite :=
   have := h.rankFinite
-  (base_restrict_iff'.2 hI).finite
+  (isBase_restrict_iff'.2 hI).finite
 
 lemma IsRkFinite.finite_of_basis (h : M.IsRkFinite X) (hI : M.Basis I X) : I.Finite :=
   h.finite_of_basis' hI.basis'
 
 /-- An `IsRkFinite` set has a finite `Basis'`-/
 lemma IsRkFinite.exists_finite_basis' (h : M.IsRkFinite X) : ∃ I, M.Basis' I X ∧ I.Finite :=
-  h.exists_finite_base
+  h.exists_finite_isBase
 
 /-- An `IsRkFinite` set has a finset `Basis'` -/
 lemma IsRkFinite.exists_finset_basis' (h : M.IsRkFinite X) : ∃ (I : Finset α), M.Basis' I X :=

--- a/Mathlib/Data/Matroid/Restrict.lean
+++ b/Mathlib/Data/Matroid/Restrict.lean
@@ -6,40 +6,40 @@ Authors: Peter Nelson
 import Mathlib.Data.Matroid.Dual
 
 /-!
-# Matroid Restriction
+# Matroid IsRestriction
 
 Given `M : Matroid α` and `R : Set α`, the independent sets of `M` that are contained in `R`
 are the independent sets of another matroid `M ↾ R` with ground set `R`,
-called the 'restriction' of `M` to `R`.
-For `I, R ⊆ M.E`, `I` is a basis of `R` in `M` if and only if `I` is a base
-of the restriction `M ↾ R`, so this construction relates `Matroid.Basis` to `Matroid.Base`.
+called the 'isRestriction' of `M` to `R`.
+For `I, R ⊆ M.E`, `I` is a isBasis of `R` in `M` if and only if `I` is a base
+of the isRestriction `M ↾ R`, so this construction relates `Matroid.IsBasis` to `Matroid.Base`.
 
 If `N M : Matroid α` satisfy `N = M ↾ R` for some `R ⊆ M.E`,
-then we call `N` a 'restriction of `M`', and write `N ≤r M`. This is a partial order.
+then we call `N` a 'isRestriction of `M`', and write `N ≤r M`. This is a partial order.
 
-This file proves that the restriction is a matroid and that the `≤r` order is a partial order,
+This file proves that the isRestriction is a matroid and that the `≤r` order is a partial order,
 and gives related API.
-It also proves some `Basis` analogues of `Base` lemmas that, while they could be stated in
+It also proves some `IsBasis` analogues of `Base` lemmas that, while they could be stated in
 `Data.Matroid.Basic`, are hard to prove without `Matroid.restrict` API.
 
 ## Main Definitions
 
-* `M.restrict R`, written `M ↾ R`, is the restriction of `M : Matroid α` to `R : Set α`: i.e.
+* `M.restrict R`, written `M ↾ R`, is the isRestriction of `M : Matroid α` to `R : Set α`: i.e.
   the matroid with ground set `R` whose independent sets are the `M`-independent subsets of `R`.
 
 * `Matroid.Restriction N M`, written `N ≤r M`, means that `N = M ↾ R` for some `R ⊆ M.E`.
 
-* `Matroid.StrictRestriction N M`, written `N <r M`, means that `N = M ↾ R` for some `R ⊂ M.E`.
+* `Matroid.IsStrictRestriction N M`, written `N <r M`, means that `N = M ↾ R` for some `R ⊂ M.E`.
 
 * `Matroidᵣ α` is a type synonym for `Matroid α`, equipped with the `PartialOrder` `≤r`.
 
 ## Implementation Notes
 
-Since `R` and `M.E` are both terms in `Set α`, to define the restriction `M ↾ R`,
+Since `R` and `M.E` are both terms in `Set α`, to define the isRestriction `M ↾ R`,
 we need to either insist that `R ⊆ M.E`, or to say what happens when `R` contains the junk
 outside `M.E`.
 
-It turns out that `R ⊆ M.E` is just an unnecessary hypothesis; if we say the restriction
+It turns out that `R ⊆ M.E` is just an unnecessary hypothesis; if we say the isRestriction
 `M ↾ R` has ground set `R` and its independent sets are the `M`-independent subsets of `R`,
 we always get a matroid, in which the elements of `R \ M.E` aren't in any independent sets.
 We could instead define this matroid to always be 'smaller' than `M` by setting
@@ -51,13 +51,13 @@ where the empty set is only the independent set.
 (Elements of `R` outside the ground set are all 'loops' of the matroid.)
 This is mathematically strange, but is useful for API building.
 
-The cost of allowing a restriction of `M` to be 'bigger' than the `M` itself is that
+The cost of allowing a isRestriction of `M` to be 'bigger' than the `M` itself is that
 the statement `M ↾ R ≤r M` is only true with the hypothesis `R ⊆ M.E`
 (at least, if we want `≤r` to be a partial order).
 But this isn't too inconvenient in practice. Indeed `(· ⊆ M.E)` proofs
 can often be automatically provided by `aesop_mat`.
 
-We define the restriction order `≤r` to give a `PartialOrder` instance on the type synonym
+We define the isRestriction order `≤r` to give a `PartialOrder` instance on the type synonym
 `Matroidᵣ α` rather than `Matroid α` itself, because the `PartialOrder (Matroid α)` instance is
 reserved for the more mathematically important 'minor' order.
 -/
@@ -79,11 +79,11 @@ section restrict
   indep_empty := ⟨M.empty_indep, empty_subset _⟩
   indep_subset := fun _ _ h hIJ ↦ ⟨h.1.subset hIJ, hIJ.trans h.2⟩
   indep_aug := by
-    rintro I I' ⟨hI, hIY⟩ (hIn : ¬ M.Basis' I R) (hI' : M.Basis' I' R)
-    rw [basis'_iff_basis_inter_ground] at hIn hI'
+    rintro I I' ⟨hI, hIY⟩ (hIn : ¬ M.IsBasis' I R) (hI' : M.IsBasis' I' R)
+    rw [isBasis'_iff_isBasis_inter_ground] at hIn hI'
     obtain ⟨B', hB', rfl⟩ := hI'.exists_isBase
     obtain ⟨B, hB, hIB, hBIB'⟩ := hI.exists_isBase_subset_union_isBase hB'
-    rw [hB'.inter_basis_iff_compl_inter_basis_dual, diff_inter_diff] at hI'
+    rw [hB'.inter_isBasis_iff_compl_inter_isBasis_dual, diff_inter_diff] at hI'
 
     have hss : M.E \ (B' ∪ (R ∩ M.E)) ⊆ M.E \ (B ∪ (R ∩ M.E)) := by
       apply diff_subset_diff_right
@@ -96,11 +96,11 @@ section restrict
 
     have h_eq := hI'.eq_of_subset_indep hi hss
       (diff_subset_diff_right subset_union_right)
-    rw [h_eq, ← diff_inter_diff, ← hB.inter_basis_iff_compl_inter_basis_dual] at hI'
+    rw [h_eq, ← diff_inter_diff, ← hB.inter_isBasis_iff_compl_inter_isBasis_dual] at hI'
 
-    obtain ⟨J, hJ, hIJ⟩ := hI.subset_basis_of_subset
+    obtain ⟨J, hJ, hIJ⟩ := hI.subset_isBasis_of_subset
       (subset_inter hIB (subset_inter hIY hI.subset_ground))
-    obtain rfl := hI'.indep.eq_of_basis hJ
+    obtain rfl := hI'.indep.eq_of_isBasis hJ
 
     have hIJ' : I ⊂ B ∩ (R ∩ M.E) := hIJ.ssubset_of_ne (fun he ↦ hIn (by rwa [he]))
     obtain ⟨e, he⟩ := exists_of_ssubset hIJ'
@@ -108,7 +108,7 @@ section restrict
       hI'.indep.subset (insert_subset he.1 hIJ), insert_subset he.1.2.1 hIY⟩
   indep_maximal := by
     rintro A hAR I ⟨hI, _⟩ hIA
-    obtain ⟨J, hJ, hIJ⟩ := hI.subset_basis'_of_subset hIA
+    obtain ⟨J, hJ, hIJ⟩ := hI.subset_isBasis'_of_subset hIA
     use J
     simp only [hIJ, and_assoc, maximal_subset_iff, hJ.indep, hJ.subset, and_imp, true_and,
       hJ.subset.trans hAR]
@@ -116,8 +116,8 @@ section restrict
   subset_ground _ := And.right
 
 /-- Change the ground set of a matroid to some `R : Set α`. The independent sets of the restriction
-  are the independent subsets of the new ground set. Most commonly used when `R ⊆ M.E`,
-  but it is convenient not to require this. The elements of `R \ M.E` become 'loops'. -/
+are the independent subsets of the new ground set. Most commonly used when `R ⊆ M.E`,
+but it is convenient not to require this. The elements of `R \ M.E` become 'loops'. -/
 def restrict (M : Matroid α) (R : Set α) : Matroid α := (M.restrictIndepMatroid R).matroid
 
 /-- `M ↾ R` means `M.restrict R`. -/
@@ -152,16 +152,16 @@ theorem restrict_restrict_eq {R₁ R₂ : Set α} (M : Matroid α) (hR : R₂ �
   rw [M.restrict_restrict_eq Subset.rfl]
 
 @[simp] theorem isBase_restrict_iff (hX : X ⊆ M.E := by aesop_mat) :
-    (M ↾ X).IsBase I ↔ M.Basis I X := by
-  simp_rw [isBase_iff_maximal_indep, Basis, and_iff_left hX, maximal_iff, restrict_indep_iff]
+    (M ↾ X).IsBase I ↔ M.IsBasis I X := by
+  simp_rw [isBase_iff_maximal_indep, IsBasis, and_iff_left hX, maximal_iff, restrict_indep_iff]
 
-theorem isBase_restrict_iff' : (M ↾ X).IsBase I ↔ M.Basis' I X := by
-  simp_rw [isBase_iff_maximal_indep, Basis', maximal_iff, restrict_indep_iff]
+theorem isBase_restrict_iff' : (M ↾ X).IsBase I ↔ M.IsBasis' I X := by
+  simp_rw [isBase_iff_maximal_indep, IsBasis', maximal_iff, restrict_indep_iff]
 
-theorem Basis'.isBase_restrict (hI : M.Basis' I X) : (M ↾ X).IsBase I :=
+theorem IsBasis'.isBase_restrict (hI : M.IsBasis' I X) : (M ↾ X).IsBase I :=
   isBase_restrict_iff'.1 hI
 
-theorem Basis.restrict_base (h : M.Basis I X) : (M ↾ X).IsBase I :=
+theorem IsBasis.restrict_base (h : M.IsBasis I X) : (M ↾ X).IsBase I :=
   (isBase_restrict_iff h.subset_ground).2 h
 
 instance restrict_rankFinite [M.RankFinite] (R : Set α) : (M ↾ R).RankFinite :=
@@ -175,31 +175,32 @@ instance restrict_finitary [Finitary M] (R : Set α) : Finitary (M ↾ R) := by
   exact ⟨fun J hJ hJfin ↦ (hI J hJ hJfin).1,
     fun e heI ↦ singleton_subset_iff.1 (hI _ (by simpa) (toFinite _)).2⟩
 
-@[simp] theorem Basis.isBase_restrict (h : M.Basis I X) : (M ↾ X).IsBase I :=
+@[simp] theorem IsBasis.isBase_restrict (h : M.IsBasis I X) : (M ↾ X).IsBase I :=
   (isBase_restrict_iff h.subset_ground).mpr h
 
-theorem Basis.basis_restrict_of_subset (hI : M.Basis I X) (hXY : X ⊆ Y) : (M ↾ Y).Basis I X := by
+theorem IsBasis.isBasis_restrict_of_subset (hI : M.IsBasis I X) (hXY : X ⊆ Y) :
+    (M ↾ Y).IsBasis I X := by
   rwa [← isBase_restrict_iff, M.restrict_restrict_eq hXY, isBase_restrict_iff]
 
-theorem basis'_restrict_iff : (M ↾ R).Basis' I X ↔ M.Basis' I (X ∩ R) ∧ I ⊆ R := by
-  simp_rw [Basis', maximal_iff, restrict_indep_iff, subset_inter_iff, and_imp]
+theorem isBasis'_restrict_iff : (M ↾ R).IsBasis' I X ↔ M.IsBasis' I (X ∩ R) ∧ I ⊆ R := by
+  simp_rw [IsBasis', maximal_iff, restrict_indep_iff, subset_inter_iff, and_imp]
   tauto
 
-theorem basis_restrict_iff' : (M ↾ R).Basis I X ↔ M.Basis I (X ∩ M.E) ∧ X ⊆ R := by
-  rw [basis_iff_basis'_subset_ground, basis'_restrict_iff, restrict_ground_eq, and_congr_left_iff,
-    ← basis'_iff_basis_inter_ground]
+theorem isBasis_restrict_iff' : (M ↾ R).IsBasis I X ↔ M.IsBasis I (X ∩ M.E) ∧ X ⊆ R := by
+  rw [isBasis_iff_isBasis'_subset_ground, isBasis'_restrict_iff, restrict_ground_eq,
+    and_congr_left_iff, ← isBasis'_iff_isBasis_inter_ground]
   intro hXR
   rw [inter_eq_self_of_subset_left hXR, and_iff_left_iff_imp]
   exact fun h ↦ h.subset.trans hXR
 
-theorem basis_restrict_iff (hR : R ⊆ M.E := by aesop_mat) :
-    (M ↾ R).Basis I X ↔ M.Basis I X ∧ X ⊆ R := by
-  rw [basis_restrict_iff', and_congr_left_iff]
+theorem isBasis_restrict_iff (hR : R ⊆ M.E := by aesop_mat) :
+    (M ↾ R).IsBasis I X ↔ M.IsBasis I X ∧ X ⊆ R := by
+  rw [isBasis_restrict_iff', and_congr_left_iff]
   intro hXR
-  rw [← basis'_iff_basis_inter_ground, basis'_iff_basis]
+  rw [← isBasis'_iff_isBasis_inter_ground, isBasis'_iff_isBasis]
 
-lemma basis'_iff_basis_restrict_univ : M.Basis' I X ↔ (M ↾ univ).Basis I X := by
-  rw [basis_restrict_iff', basis'_iff_basis_inter_ground, and_iff_left (subset_univ _)]
+lemma isBasis'_iff_isBasis_restrict_univ : M.IsBasis' I X ↔ (M ↾ univ).IsBasis I X := by
+  rw [isBasis_restrict_iff', isBasis'_iff_isBasis_inter_ground, and_iff_left (subset_univ _)]
 
 theorem restrict_eq_restrict_iff (M M' : Matroid α) (X : Set α) :
     M ↾ X = M' ↾ X ↔ ∀ I, I ⊆ X → (M.Indep I ↔ M'.Indep I) := by
@@ -213,23 +214,27 @@ theorem restrict_eq_restrict_iff (M M' : Matroid α) (X : Set α) :
 
 end restrict
 
-section Restriction
+section IsRestriction
 
 variable {N : Matroid α}
 
 /-- `Restriction N M` means that `N = M ↾ R` for some subset `R` of `M.E` -/
-def Restriction (N M : Matroid α) : Prop := ∃ R ⊆ M.E, N = M ↾ R
+def IsRestriction (N M : Matroid α) : Prop := ∃ R ⊆ M.E, N = M ↾ R
 
-/-- `StrictRestriction N M` means that `N = M ↾ R` for some strict subset `R` of `M.E` -/
-def StrictRestriction (N M : Matroid α) : Prop := Restriction N M ∧ ¬ Restriction M N
+@[deprecated (since := "2025-02-14")] alias Restriction := IsRestriction
+
+/-- `IsStrictRestriction N M` means that `N = M ↾ R` for some strict subset `R` of `M.E` -/
+def IsStrictRestriction (N M : Matroid α) : Prop := IsRestriction N M ∧ ¬ IsRestriction M N
+
+@[deprecated (since := "2025-02-14")] alias StrictRestriction := IsStrictRestriction
 
 /-- `N ≤r M` means that `N` is a `Restriction` of `M`. -/
-scoped infix:50  " ≤r " => Restriction
+scoped infix:50  " ≤r " => IsRestriction
 
-/-- `N <r M` means that `N` is a `StrictRestriction` of `M`. -/
-scoped infix:50  " <r " => StrictRestriction
+/-- `N <r M` means that `N` is a `IsStrictRestriction` of `M`. -/
+scoped infix:50  " <r " => IsStrictRestriction
 
-/-- A type synonym for matroids with the restriction order.
+/-- A type synonym for matroids with the isRestriction order.
   (The `PartialOrder` on `Matroid α` is reserved for the minor order)  -/
 @[ext] structure Matroidᵣ (α : Type*) where ofMatroid ::
   /-- The underlying `Matroid`.-/
@@ -271,192 +276,195 @@ theorem ofMatroid_lt_iff {M M' : Matroid α} :
     Matroidᵣ.ofMatroid M < Matroidᵣ.ofMatroid M' ↔ M <r M' := by
   simp
 
-theorem Restriction.refl : M ≤r M :=
+theorem IsRestriction.refl : M ≤r M :=
   le_refl (Matroidᵣ.ofMatroid M)
 
-theorem Restriction.antisymm {M' : Matroid α} (h : M ≤r M') (h' : M' ≤r M) : M = M' := by
+theorem IsRestriction.antisymm {M' : Matroid α} (h : M ≤r M') (h' : M' ≤r M) : M = M' := by
   simpa using (ofMatroid_le_iff.2 h).antisymm (ofMatroid_le_iff.2 h')
 
-theorem Restriction.trans {M₁ M₂ M₃ : Matroid α} (h : M₁ ≤r M₂) (h' : M₂ ≤r M₃) : M₁ ≤r M₃ :=
+theorem IsRestriction.trans {M₁ M₂ M₃ : Matroid α} (h : M₁ ≤r M₂) (h' : M₂ ≤r M₃) : M₁ ≤r M₃ :=
   le_trans (α := Matroidᵣ α) h h'
 
-theorem restrict_restriction (M : Matroid α) (R : Set α) (hR : R ⊆ M.E := by aesop_mat) :
+theorem restrict_isRestriction (M : Matroid α) (R : Set α) (hR : R ⊆ M.E := by aesop_mat) :
     M ↾ R ≤r M :=
   ⟨R, hR, rfl⟩
 
-theorem Restriction.eq_restrict (h : N ≤r M) : M ↾ N.E = N := by
+theorem IsRestriction.eq_restrict (h : N ≤r M) : M ↾ N.E = N := by
   obtain ⟨R, -, rfl⟩ := h; rw [restrict_ground_eq]
 
-theorem Restriction.subset (h : N ≤r M) : N.E ⊆ M.E := by
+theorem IsRestriction.subset (h : N ≤r M) : N.E ⊆ M.E := by
   obtain ⟨R, hR, rfl⟩ := h; exact hR
 
-theorem Restriction.exists_eq_restrict (h : N ≤r M) : ∃ R ⊆ M.E, N = M ↾ R :=
+theorem IsRestriction.exists_eq_restrict (h : N ≤r M) : ∃ R ⊆ M.E, N = M ↾ R :=
   h
 
-theorem Restriction.of_subset {R' : Set α} (M : Matroid α) (h : R ⊆ R') : (M ↾ R) ≤r (M ↾ R') := by
-  rw [← restrict_restrict_eq M h]; exact restrict_restriction _ _ h
+theorem IsRestriction.of_subset {R' : Set α} (M : Matroid α) (h : R ⊆ R') :
+    (M ↾ R) ≤r (M ↾ R') := by
+  rw [← restrict_restrict_eq M h]; exact restrict_isRestriction _ _ h
 
-theorem restriction_iff_exists : (N ≤r M) ↔ ∃ R, R ⊆ M.E ∧ N = M ↾ R := by
-  use Restriction.exists_eq_restrict; rintro ⟨R, hR, rfl⟩; exact restrict_restriction M R hR
+theorem isRestriction_iff_exists : (N ≤r M) ↔ ∃ R, R ⊆ M.E ∧ N = M ↾ R := by
+  use IsRestriction.exists_eq_restrict; rintro ⟨R, hR, rfl⟩; exact restrict_isRestriction M R hR
 
-theorem StrictRestriction.restriction (h : N <r M) : N ≤r M :=
+theorem IsStrictRestriction.isRestriction (h : N <r M) : N ≤r M :=
   h.1
 
-theorem StrictRestriction.ne (h : N <r M) : N ≠ M := by
+theorem IsStrictRestriction.ne (h : N <r M) : N ≠ M := by
   rintro rfl; rw [← ofMatroid_lt_iff] at h; simp at h
 
-theorem StrictRestriction.irrefl (M : Matroid α) : ¬ (M <r M) :=
+theorem IsStrictRestriction.irrefl (M : Matroid α) : ¬ (M <r M) :=
   fun h ↦ h.ne rfl
 
-theorem StrictRestriction.ssubset (h : N <r M) : N.E ⊂ M.E := by
+theorem IsStrictRestriction.ssubset (h : N <r M) : N.E ⊂ M.E := by
   obtain ⟨R, -, rfl⟩ := h.1
-  refine h.restriction.subset.ssubset_of_ne (fun h' ↦ h.2 ⟨R, Subset.rfl, ?_⟩)
+  refine h.isRestriction.subset.ssubset_of_ne (fun h' ↦ h.2 ⟨R, Subset.rfl, ?_⟩)
   rw [show R = M.E from h', restrict_idem, restrict_ground_eq_self]
 
-theorem StrictRestriction.eq_restrict (h : N <r M) : M ↾ N.E = N :=
-  h.restriction.eq_restrict
+theorem IsStrictRestriction.eq_restrict (h : N <r M) : M ↾ N.E = N :=
+  h.isRestriction.eq_restrict
 
-theorem StrictRestriction.exists_eq_restrict (h : N <r M) : ∃ R, R ⊂ M.E ∧ N = M ↾ R :=
+theorem IsStrictRestriction.exists_eq_restrict (h : N <r M) : ∃ R, R ⊂ M.E ∧ N = M ↾ R :=
   ⟨N.E, h.ssubset, by rw [h.eq_restrict]⟩
 
-theorem Restriction.strictRestriction_of_ne (h : N ≤r M) (hne : N ≠ M) : N <r M :=
+theorem IsRestriction.isStrictRestriction_of_ne (h : N ≤r M) (hne : N ≠ M) : N <r M :=
   ⟨h, fun h' ↦ hne <| h.antisymm h'⟩
 
-theorem Restriction.eq_or_strictRestriction (h : N ≤r M) : N = M ∨ N <r M := by
+theorem IsRestriction.eq_or_isStrictRestriction (h : N ≤r M) : N = M ∨ N <r M := by
   simpa using eq_or_lt_of_le (ofMatroid_le_iff.2 h)
 
-theorem restrict_strictRestriction {M : Matroid α} (hR : R ⊂ M.E) : M ↾ R <r M := by
-  refine (M.restrict_restriction R hR.subset).strictRestriction_of_ne (fun h ↦ ?_)
+theorem restrict_isStrictRestriction {M : Matroid α} (hR : R ⊂ M.E) : M ↾ R <r M := by
+  refine (M.restrict_isRestriction R hR.subset).isStrictRestriction_of_ne (fun h ↦ ?_)
   rw [← h, restrict_ground_eq] at hR
   exact hR.ne rfl
 
-theorem Restriction.strictRestriction_of_ground_ne (h : N ≤r M) (hne : N.E ≠ M.E) : N <r M := by
+theorem IsRestriction.isStrictRestriction_of_ground_ne (h : N ≤r M) (hne : N.E ≠ M.E) : N <r M := by
   rw [← h.eq_restrict]
-  exact restrict_strictRestriction (h.subset.ssubset_of_ne hne)
+  exact restrict_isStrictRestriction (h.subset.ssubset_of_ne hne)
 
-theorem StrictRestriction.of_ssubset {R' : Set α} (M : Matroid α) (h : R ⊂ R') :
+theorem IsStrictRestriction.of_ssubset {R' : Set α} (M : Matroid α) (h : R ⊂ R') :
     (M ↾ R) <r (M ↾ R') :=
-  (Restriction.of_subset M h.subset).strictRestriction_of_ground_ne h.ne
+  (IsRestriction.of_subset M h.subset).isStrictRestriction_of_ground_ne h.ne
 
-theorem Restriction.finite {M : Matroid α} [M.Finite] (h : N ≤r M) : N.Finite := by
+theorem IsRestriction.finite {M : Matroid α} [M.Finite] (h : N ≤r M) : N.Finite := by
   obtain ⟨R, hR, rfl⟩ := h
   exact restrict_finite <| M.ground_finite.subset hR
 
-theorem Restriction.rankFinite {M : Matroid α} [RankFinite M] (h : N ≤r M) : N.RankFinite := by
+theorem IsRestriction.rankFinite {M : Matroid α} [RankFinite M] (h : N ≤r M) : N.RankFinite := by
   obtain ⟨R, -, rfl⟩ := h
   infer_instance
 
-theorem Restriction.finitary {M : Matroid α} [Finitary M] (h : N ≤r M) : N.Finitary := by
+theorem IsRestriction.finitary {M : Matroid α} [Finitary M] (h : N ≤r M) : N.Finitary := by
   obtain ⟨R, -, rfl⟩ := h
   infer_instance
 
-theorem finite_setOf_restriction (M : Matroid α) [M.Finite] : {N | N ≤r M}.Finite :=
+theorem finite_setOf_isRestriction (M : Matroid α) [M.Finite] : {N | N ≤r M}.Finite :=
   (M.ground_finite.finite_subsets.image (fun R ↦ M ↾ R)).subset <|
     by rintro _ ⟨R, hR, rfl⟩; exact ⟨_, hR, rfl⟩
 
-theorem Indep.of_restriction (hI : N.Indep I) (hNM : N ≤r M) : M.Indep I := by
+theorem Indep.of_isRestriction (hI : N.Indep I) (hNM : N ≤r M) : M.Indep I := by
   obtain ⟨R, -, rfl⟩ := hNM; exact hI.of_restrict
 
-theorem Indep.indep_restriction (hI : M.Indep I) (hNM : N ≤r M) (hIN : I ⊆ N.E) : N.Indep I := by
+theorem Indep.indep_isRestriction (hI : M.Indep I) (hNM : N ≤r M) (hIN : I ⊆ N.E) : N.Indep I := by
   obtain ⟨R, -, rfl⟩ := hNM; simpa [hI]
 
-theorem Restriction.indep_iff (hMN : N ≤r M) : N.Indep I ↔ M.Indep I ∧ I ⊆ N.E :=
-  ⟨fun h ↦ ⟨h.of_restriction hMN, h.subset_ground⟩, fun h ↦ h.1.indep_restriction hMN h.2⟩
+theorem IsRestriction.indep_iff (hMN : N ≤r M) : N.Indep I ↔ M.Indep I ∧ I ⊆ N.E :=
+  ⟨fun h ↦ ⟨h.of_isRestriction hMN, h.subset_ground⟩, fun h ↦ h.1.indep_isRestriction hMN h.2⟩
 
-theorem Basis.basis_restriction (hI : M.Basis I X) (hNM : N ≤r M) (hX : X ⊆ N.E) : N.Basis I X := by
-  obtain ⟨R, hR, rfl⟩ := hNM; rwa [basis_restrict_iff, and_iff_left (show X ⊆ R from hX)]
+theorem IsBasis.isBasis_isRestriction (hI : M.IsBasis I X) (hNM : N ≤r M) (hX : X ⊆ N.E) :
+    N.IsBasis I X := by
+  obtain ⟨R, hR, rfl⟩ := hNM; rwa [isBasis_restrict_iff, and_iff_left (show X ⊆ R from hX)]
 
-theorem Basis.of_restriction (hI : N.Basis I X) (hNM : N ≤r M) : M.Basis I X := by
-  obtain ⟨R, hR, rfl⟩ := hNM; exact ((basis_restrict_iff hR).1 hI).1
+theorem IsBasis.of_isRestriction (hI : N.IsBasis I X) (hNM : N ≤r M) : M.IsBasis I X := by
+  obtain ⟨R, hR, rfl⟩ := hNM; exact ((isBasis_restrict_iff hR).1 hI).1
 
-theorem Base.basis_of_restriction (hI : N.IsBase I) (hNM : N ≤r M) : M.Basis I N.E := by
+theorem Base.isBasis_of_isRestriction (hI : N.IsBase I) (hNM : N ≤r M) : M.IsBasis I N.E := by
   obtain ⟨R, hR, rfl⟩ := hNM; rwa [isBase_restrict_iff] at hI
 
-theorem Restriction.base_iff (hMN : N ≤r M) {B : Set α} : N.IsBase B ↔ M.Basis B N.E :=
-  ⟨fun h ↦ Base.basis_of_restriction h hMN,
+theorem IsRestriction.base_iff (hMN : N ≤r M) {B : Set α} : N.IsBase B ↔ M.IsBasis B N.E :=
+  ⟨fun h ↦ Base.isBasis_of_isRestriction h hMN,
     fun h ↦ by simpa [hMN.eq_restrict] using h.restrict_base⟩
 
-theorem Restriction.basis_iff (hMN : N ≤r M) : N.Basis I X ↔ M.Basis I X ∧ X ⊆ N.E :=
-  ⟨fun h ↦ ⟨h.of_restriction hMN, h.subset_ground⟩, fun h ↦ h.1.basis_restriction hMN h.2⟩
+theorem IsRestriction.isBasis_iff (hMN : N ≤r M) : N.IsBasis I X ↔ M.IsBasis I X ∧ X ⊆ N.E :=
+  ⟨fun h ↦ ⟨h.of_isRestriction hMN, h.subset_ground⟩, fun h ↦ h.1.isBasis_isRestriction hMN h.2⟩
 
-theorem Dep.of_restriction (hX : N.Dep X) (hNM : N ≤r M) : M.Dep X := by
+theorem Dep.of_isRestriction (hX : N.Dep X) (hNM : N ≤r M) : M.Dep X := by
   obtain ⟨R, hR, rfl⟩ := hNM
   rw [restrict_dep_iff] at hX
   exact ⟨hX.1, hX.2.trans hR⟩
 
-theorem Dep.dep_restriction (hX : M.Dep X) (hNM : N ≤r M) (hXE : X ⊆ N.E := by aesop_mat) :
+theorem Dep.dep_isRestriction (hX : M.Dep X) (hNM : N ≤r M) (hXE : X ⊆ N.E := by aesop_mat) :
     N.Dep X := by
   obtain ⟨R, -, rfl⟩ := hNM; simpa [hX.not_indep]
 
-theorem Restriction.dep_iff (hMN : N ≤r M) : N.Dep X ↔ M.Dep X ∧ X ⊆ N.E :=
-  ⟨fun h ↦ ⟨h.of_restriction hMN, h.subset_ground⟩, fun h ↦ h.1.dep_restriction hMN h.2⟩
+theorem IsRestriction.dep_iff (hMN : N ≤r M) : N.Dep X ↔ M.Dep X ∧ X ⊆ N.E :=
+  ⟨fun h ↦ ⟨h.of_isRestriction hMN, h.subset_ground⟩, fun h ↦ h.1.dep_isRestriction hMN h.2⟩
 
-end Restriction
+end IsRestriction
 
 /-!
-### `Basis` and `Base`
-The lemmas below exploit the fact that `(M ↾ X).Base I ↔ M.Basis I X` to transfer facts about
-`Matroid.Base` to facts about `Matroid.Basis`.
+### `IsBasis` and `Base`
+The lemmas below exploit the fact that `(M ↾ X).Base I ↔ M.IsBasis I X` to transfer facts about
+`Matroid.Base` to facts about `Matroid.IsBasis`.
 Their statements thematically belong in `Data.Matroid.Basic`, but they appear here because their
 proofs depend on the API for `Matroid.restrict`,
 -/
 
-section Basis
+section IsBasis
 
 variable {B J : Set α} {e : α}
 
-theorem Basis.transfer (hIX : M.Basis I X) (hJX : M.Basis J X) (hXY : X ⊆ Y) (hJY : M.Basis J Y) :
-    M.Basis I Y := by
+theorem IsBasis.transfer (hIX : M.IsBasis I X) (hJX : M.IsBasis J X) (hXY : X ⊆ Y)
+    (hJY : M.IsBasis J Y) : M.IsBasis I Y := by
   rw [← isBase_restrict_iff]; rw [← isBase_restrict_iff] at hJY
-  exact hJY.isBase_of_basis_superset hJX.subset (hIX.basis_restrict_of_subset hXY)
+  exact hJY.isBase_of_isBasis_superset hJX.subset (hIX.isBasis_restrict_of_subset hXY)
 
-theorem Basis.basis_of_basis_of_subset_of_subset (hI : M.Basis I X) (hJ : M.Basis J Y) (hJX : J ⊆ X)
-    (hIY : I ⊆ Y) : M.Basis I Y := by
-  have hI' := hI.basis_subset (subset_inter hI.subset hIY) inter_subset_left
-  have hJ' := hJ.basis_subset (subset_inter hJX hJ.subset) inter_subset_right
+theorem IsBasis.isBasis_of_isBasis_of_subset_of_subset (hI : M.IsBasis I X) (hJ : M.IsBasis J Y)
+    (hJX : J ⊆ X) (hIY : I ⊆ Y) : M.IsBasis I Y := by
+  have hI' := hI.isBasis_subset (subset_inter hI.subset hIY) inter_subset_left
+  have hJ' := hJ.isBasis_subset (subset_inter hJX hJ.subset) inter_subset_right
   exact hI'.transfer hJ' inter_subset_right hJ
 
-theorem Indep.exists_basis_subset_union_basis (hI : M.Indep I) (hIX : I ⊆ X) (hJ : M.Basis J X) :
-    ∃ I', M.Basis I' X ∧ I ⊆ I' ∧ I' ⊆ I ∪ J := by
+theorem Indep.exists_isBasis_subset_union_isBasis (hI : M.Indep I) (hIX : I ⊆ X)
+    (hJ : M.IsBasis J X) : ∃ I', M.IsBasis I' X ∧ I ⊆ I' ∧ I' ⊆ I ∪ J := by
   obtain ⟨I', hI', hII', hI'IJ⟩ :=
-    (hI.indep_restrict_of_subset hIX).exists_isBase_subset_union_isBase (Basis.isBase_restrict hJ)
+    (hI.indep_restrict_of_subset hIX).exists_isBase_subset_union_isBase (IsBasis.isBase_restrict hJ)
   rw [isBase_restrict_iff] at hI'
   exact ⟨I', hI', hII', hI'IJ⟩
 
-theorem Indep.exists_insert_of_not_basis (hI : M.Indep I) (hIX : I ⊆ X) (hI' : ¬M.Basis I X)
-    (hJ : M.Basis J X) : ∃ e ∈ J \ I, M.Indep (insert e I) := by
+theorem Indep.exists_insert_of_not_isBasis (hI : M.Indep I) (hIX : I ⊆ X) (hI' : ¬M.IsBasis I X)
+    (hJ : M.IsBasis J X) : ∃ e ∈ J \ I, M.Indep (insert e I) := by
   rw [← isBase_restrict_iff] at hI'; rw [← isBase_restrict_iff] at hJ
   obtain ⟨e, he, hi⟩ := (hI.indep_restrict_of_subset hIX).exists_insert_of_not_isBase hI' hJ
   exact ⟨e, he, (restrict_indep_iff.mp hi).1⟩
 
-theorem Basis.base_of_base_subset (hIX : M.Basis I X) (hB : M.IsBase B) (hBX : B ⊆ X) :
+theorem IsBasis.base_of_base_subset (hIX : M.IsBasis I X) (hB : M.IsBase B) (hBX : B ⊆ X) :
     M.IsBase I :=
-  hB.isBase_of_basis_superset hBX hIX
+  hB.isBase_of_isBasis_superset hBX hIX
 
-theorem Basis.exchange (hIX : M.Basis I X) (hJX : M.Basis J X) (he : e ∈ I \ J) :
-    ∃ f ∈ J \ I, M.Basis (insert f (I \ {e})) X := by
+theorem IsBasis.exchange (hIX : M.IsBasis I X) (hJX : M.IsBasis J X) (he : e ∈ I \ J) :
+    ∃ f ∈ J \ I, M.IsBasis (insert f (I \ {e})) X := by
   obtain ⟨y,hy, h⟩ := hIX.restrict_base.exchange hJX.restrict_base he
   exact ⟨y, hy, by rwa [isBase_restrict_iff] at h⟩
 
-theorem Basis.eq_exchange_of_diff_eq_singleton (hI : M.Basis I X) (hJ : M.Basis J X)
+theorem IsBasis.eq_exchange_of_diff_eq_singleton (hI : M.IsBasis I X) (hJ : M.IsBasis J X)
     (hIJ : I \ J = {e}) : ∃ f ∈ J \ I, J = insert f I \ {e} := by
   rw [← isBase_restrict_iff] at hI hJ; exact hI.eq_exchange_of_diff_eq_singleton hJ hIJ
 
-theorem Basis'.encard_eq_encard (hI : M.Basis' I X) (hJ : M.Basis' J X) : I.encard = J.encard := by
+theorem IsBasis'.encard_eq_encard (hI : M.IsBasis' I X) (hJ : M.IsBasis' J X) :
+    I.encard = J.encard := by
   rw [← isBase_restrict_iff'] at hI hJ; exact hI.encard_eq_encard_of_isBase hJ
 
-theorem Basis.encard_eq_encard (hI : M.Basis I X) (hJ : M.Basis J X) : I.encard = J.encard :=
-  hI.basis'.encard_eq_encard hJ.basis'
+theorem IsBasis.encard_eq_encard (hI : M.IsBasis I X) (hJ : M.IsBasis J X) : I.encard = J.encard :=
+  hI.isBasis'.encard_eq_encard hJ.isBasis'
 
 /-- Any independent set can be extended into a larger independent set. -/
 theorem Indep.augment (hI : M.Indep I) (hJ : M.Indep J) (hIJ : I.encard < J.encard) :
     ∃ e ∈ J \ I, M.Indep (insert e I) := by
   by_contra! he
-  have hb : M.Basis I (I ∪ J) := by
-    simp_rw [hI.basis_iff_forall_insert_dep subset_union_left, union_diff_left, mem_diff,
+  have hb : M.IsBasis I (I ∪ J) := by
+    simp_rw [hI.isBasis_iff_forall_insert_dep subset_union_left, union_diff_left, mem_diff,
       and_imp, dep_iff, insert_subset_iff, and_iff_left hI.subset_ground]
     exact fun e heJ heI ↦ ⟨he e ⟨heJ, heI⟩, hJ.subset_ground heJ⟩
-  obtain ⟨J', hJ', hJJ'⟩ := hJ.subset_basis_of_subset I.subset_union_right
+  obtain ⟨J', hJ', hJJ'⟩ := hJ.subset_isBasis_of_subset I.subset_union_right
   rw [← hJ'.encard_eq_encard hb] at hIJ
   exact hIJ.not_le (encard_mono hJJ')
 
@@ -466,6 +474,6 @@ lemma Indep.augment_finset {I J : Finset α} (hI : M.Indep I) (hJ : M.Indep J)
   simp only [mem_diff, Finset.mem_coe] at hx
   exact ⟨x, hx.1, hx.2, hxI⟩
 
-end Basis
+end IsBasis
 
 end Matroid

--- a/Mathlib/Data/Matroid/Restrict.lean
+++ b/Mathlib/Data/Matroid/Restrict.lean
@@ -81,8 +81,8 @@ section restrict
   indep_aug := by
     rintro I I' ⟨hI, hIY⟩ (hIn : ¬ M.Basis' I R) (hI' : M.Basis' I' R)
     rw [basis'_iff_basis_inter_ground] at hIn hI'
-    obtain ⟨B', hB', rfl⟩ := hI'.exists_base
-    obtain ⟨B, hB, hIB, hBIB'⟩ := hI.exists_base_subset_union_base hB'
+    obtain ⟨B', hB', rfl⟩ := hI'.exists_isBase
+    obtain ⟨B, hB, hIB, hBIB'⟩ := hI.exists_isBase_subset_union_isBase hB'
     rw [hB'.inter_basis_iff_compl_inter_basis_dual, diff_inter_diff] at hI'
 
     have hss : M.E \ (B' ∪ (R ∩ M.E)) ⊆ M.E \ (B ∪ (R ∩ M.E)) := by
@@ -151,21 +151,21 @@ theorem restrict_restrict_eq {R₁ R₂ : Set α} (M : Matroid α) (hR : R₂ �
 @[simp] theorem restrict_idem (M : Matroid α) (R : Set α) : M ↾ R ↾ R = M ↾ R := by
   rw [M.restrict_restrict_eq Subset.rfl]
 
-@[simp] theorem base_restrict_iff (hX : X ⊆ M.E := by aesop_mat) :
-    (M ↾ X).Base I ↔ M.Basis I X := by
-  simp_rw [base_iff_maximal_indep, Basis, and_iff_left hX, maximal_iff, restrict_indep_iff]
+@[simp] theorem isBase_restrict_iff (hX : X ⊆ M.E := by aesop_mat) :
+    (M ↾ X).IsBase I ↔ M.Basis I X := by
+  simp_rw [isBase_iff_maximal_indep, Basis, and_iff_left hX, maximal_iff, restrict_indep_iff]
 
-theorem base_restrict_iff' : (M ↾ X).Base I ↔ M.Basis' I X := by
-  simp_rw [base_iff_maximal_indep, Basis', maximal_iff, restrict_indep_iff]
+theorem isBase_restrict_iff' : (M ↾ X).IsBase I ↔ M.Basis' I X := by
+  simp_rw [isBase_iff_maximal_indep, Basis', maximal_iff, restrict_indep_iff]
 
-theorem Basis'.base_restrict (hI : M.Basis' I X) : (M ↾ X).Base I :=
-  base_restrict_iff'.1 hI
+theorem Basis'.isBase_restrict (hI : M.Basis' I X) : (M ↾ X).IsBase I :=
+  isBase_restrict_iff'.1 hI
 
-theorem Basis.restrict_base (h : M.Basis I X) : (M ↾ X).Base I :=
-  (base_restrict_iff h.subset_ground).2 h
+theorem Basis.restrict_base (h : M.Basis I X) : (M ↾ X).IsBase I :=
+  (isBase_restrict_iff h.subset_ground).2 h
 
 instance restrict_rankFinite [M.RankFinite] (R : Set α) : (M ↾ R).RankFinite :=
-  let ⟨_, hB⟩ := (M ↾ R).exists_base
+  let ⟨_, hB⟩ := (M ↾ R).exists_isBase
   hB.rankFinite_of_finite (hB.indep.of_restrict.finite)
 
 instance restrict_finitary [Finitary M] (R : Set α) : Finitary (M ↾ R) := by
@@ -175,11 +175,11 @@ instance restrict_finitary [Finitary M] (R : Set α) : Finitary (M ↾ R) := by
   exact ⟨fun J hJ hJfin ↦ (hI J hJ hJfin).1,
     fun e heI ↦ singleton_subset_iff.1 (hI _ (by simpa) (toFinite _)).2⟩
 
-@[simp] theorem Basis.base_restrict (h : M.Basis I X) : (M ↾ X).Base I :=
-  (base_restrict_iff h.subset_ground).mpr h
+@[simp] theorem Basis.isBase_restrict (h : M.Basis I X) : (M ↾ X).IsBase I :=
+  (isBase_restrict_iff h.subset_ground).mpr h
 
 theorem Basis.basis_restrict_of_subset (hI : M.Basis I X) (hXY : X ⊆ Y) : (M ↾ Y).Basis I X := by
-  rwa [← base_restrict_iff, M.restrict_restrict_eq hXY, base_restrict_iff]
+  rwa [← isBase_restrict_iff, M.restrict_restrict_eq hXY, isBase_restrict_iff]
 
 theorem basis'_restrict_iff : (M ↾ R).Basis' I X ↔ M.Basis' I (X ∩ R) ∧ I ⊆ R := by
   simp_rw [Basis', maximal_iff, restrict_indep_iff, subset_inter_iff, and_imp]
@@ -369,10 +369,10 @@ theorem Basis.basis_restriction (hI : M.Basis I X) (hNM : N ≤r M) (hX : X ⊆ 
 theorem Basis.of_restriction (hI : N.Basis I X) (hNM : N ≤r M) : M.Basis I X := by
   obtain ⟨R, hR, rfl⟩ := hNM; exact ((basis_restrict_iff hR).1 hI).1
 
-theorem Base.basis_of_restriction (hI : N.Base I) (hNM : N ≤r M) : M.Basis I N.E := by
-  obtain ⟨R, hR, rfl⟩ := hNM; rwa [base_restrict_iff] at hI
+theorem Base.basis_of_restriction (hI : N.IsBase I) (hNM : N ≤r M) : M.Basis I N.E := by
+  obtain ⟨R, hR, rfl⟩ := hNM; rwa [isBase_restrict_iff] at hI
 
-theorem Restriction.base_iff (hMN : N ≤r M) {B : Set α} : N.Base B ↔ M.Basis B N.E :=
+theorem Restriction.base_iff (hMN : N ≤r M) {B : Set α} : N.IsBase B ↔ M.Basis B N.E :=
   ⟨fun h ↦ Base.basis_of_restriction h hMN,
     fun h ↦ by simpa [hMN.eq_restrict] using h.restrict_base⟩
 
@@ -407,8 +407,8 @@ variable {B J : Set α} {e : α}
 
 theorem Basis.transfer (hIX : M.Basis I X) (hJX : M.Basis J X) (hXY : X ⊆ Y) (hJY : M.Basis J Y) :
     M.Basis I Y := by
-  rw [← base_restrict_iff]; rw [← base_restrict_iff] at hJY
-  exact hJY.base_of_basis_superset hJX.subset (hIX.basis_restrict_of_subset hXY)
+  rw [← isBase_restrict_iff]; rw [← isBase_restrict_iff] at hJY
+  exact hJY.isBase_of_basis_superset hJX.subset (hIX.basis_restrict_of_subset hXY)
 
 theorem Basis.basis_of_basis_of_subset_of_subset (hI : M.Basis I X) (hJ : M.Basis J Y) (hJX : J ⊆ X)
     (hIY : I ⊆ Y) : M.Basis I Y := by
@@ -419,30 +419,31 @@ theorem Basis.basis_of_basis_of_subset_of_subset (hI : M.Basis I X) (hJ : M.Basi
 theorem Indep.exists_basis_subset_union_basis (hI : M.Indep I) (hIX : I ⊆ X) (hJ : M.Basis J X) :
     ∃ I', M.Basis I' X ∧ I ⊆ I' ∧ I' ⊆ I ∪ J := by
   obtain ⟨I', hI', hII', hI'IJ⟩ :=
-    (hI.indep_restrict_of_subset hIX).exists_base_subset_union_base (Basis.base_restrict hJ)
-  rw [base_restrict_iff] at hI'
+    (hI.indep_restrict_of_subset hIX).exists_isBase_subset_union_isBase (Basis.isBase_restrict hJ)
+  rw [isBase_restrict_iff] at hI'
   exact ⟨I', hI', hII', hI'IJ⟩
 
 theorem Indep.exists_insert_of_not_basis (hI : M.Indep I) (hIX : I ⊆ X) (hI' : ¬M.Basis I X)
     (hJ : M.Basis J X) : ∃ e ∈ J \ I, M.Indep (insert e I) := by
-  rw [← base_restrict_iff] at hI'; rw [← base_restrict_iff] at hJ
-  obtain ⟨e, he, hi⟩ := (hI.indep_restrict_of_subset hIX).exists_insert_of_not_base hI' hJ
+  rw [← isBase_restrict_iff] at hI'; rw [← isBase_restrict_iff] at hJ
+  obtain ⟨e, he, hi⟩ := (hI.indep_restrict_of_subset hIX).exists_insert_of_not_isBase hI' hJ
   exact ⟨e, he, (restrict_indep_iff.mp hi).1⟩
 
-theorem Basis.base_of_base_subset (hIX : M.Basis I X) (hB : M.Base B) (hBX : B ⊆ X) : M.Base I :=
-  hB.base_of_basis_superset hBX hIX
+theorem Basis.base_of_base_subset (hIX : M.Basis I X) (hB : M.IsBase B) (hBX : B ⊆ X) :
+    M.IsBase I :=
+  hB.isBase_of_basis_superset hBX hIX
 
 theorem Basis.exchange (hIX : M.Basis I X) (hJX : M.Basis J X) (he : e ∈ I \ J) :
     ∃ f ∈ J \ I, M.Basis (insert f (I \ {e})) X := by
   obtain ⟨y,hy, h⟩ := hIX.restrict_base.exchange hJX.restrict_base he
-  exact ⟨y, hy, by rwa [base_restrict_iff] at h⟩
+  exact ⟨y, hy, by rwa [isBase_restrict_iff] at h⟩
 
 theorem Basis.eq_exchange_of_diff_eq_singleton (hI : M.Basis I X) (hJ : M.Basis J X)
     (hIJ : I \ J = {e}) : ∃ f ∈ J \ I, J = insert f I \ {e} := by
-  rw [← base_restrict_iff] at hI hJ; exact hI.eq_exchange_of_diff_eq_singleton hJ hIJ
+  rw [← isBase_restrict_iff] at hI hJ; exact hI.eq_exchange_of_diff_eq_singleton hJ hIJ
 
 theorem Basis'.encard_eq_encard (hI : M.Basis' I X) (hJ : M.Basis' J X) : I.encard = J.encard := by
-  rw [← base_restrict_iff'] at hI hJ; exact hI.card_eq_card_of_base hJ
+  rw [← isBase_restrict_iff'] at hI hJ; exact hI.encard_eq_encard_of_isBase hJ
 
 theorem Basis.encard_eq_encard (hI : M.Basis I X) (hJ : M.Basis J X) : I.encard = J.encard :=
   hI.basis'.encard_eq_encard hJ.basis'

--- a/Mathlib/Data/Matroid/Sum.lean
+++ b/Mathlib/Data/Matroid/Sum.lean
@@ -55,20 +55,20 @@ variable {ι : Type*} {α : ι → Type*} {M : (i : ι) → Matroid (α i)}
 protected def sigma (M : (i : ι) → Matroid (α i)) : Matroid ((i : ι) × α i) where
   E := univ.sigma (fun i ↦ (M i).E)
   Indep I := ∀ i, (M i).Indep (Sigma.mk i ⁻¹' I)
-  Base B := ∀ i, (M i).Base (Sigma.mk i ⁻¹' B)
+  IsBase B := ∀ i, (M i).IsBase (Sigma.mk i ⁻¹' B)
 
   indep_iff' I := by
     refine ⟨fun h ↦ ?_, fun ⟨B, hB, hIB⟩ i ↦ (hB i).indep.subset (preimage_mono hIB)⟩
-    choose Bs hBs using fun i ↦ (h i).exists_base_superset
+    choose Bs hBs using fun i ↦ (h i).exists_isBase_superset
     refine ⟨univ.sigma Bs, fun i ↦ by simpa using (hBs i).1, ?_⟩
     rw [← univ_sigma_preimage_mk I]
     refine sigma_mono rfl.subset fun i ↦ (hBs i).2
 
-  exists_base := by
-    choose B hB using fun i ↦ (M i).exists_base
+  exists_isBase := by
+    choose B hB using fun i ↦ (M i).exists_isBase
     exact ⟨univ.sigma B, by simpa⟩
 
-  base_exchange B₁ B₂ h₁ h₂ := by
+  isBase_exchange B₁ B₂ h₁ h₂ := by
     simp only [mem_diff, Sigma.exists, and_imp, Sigma.forall]
     intro i e he₁ he₂
     have hf_ex := (h₁ i).exchange (h₂ i) ⟨he₁, by simpa⟩
@@ -106,8 +106,8 @@ protected def sigma (M : (i : ι) → Matroid (α i)) : Matroid ((i : ι) × α 
 @[simp] lemma sigma_indep_iff {I} :
     (Matroid.sigma M).Indep I ↔ ∀ i, (M i).Indep (Sigma.mk i ⁻¹' I) := Iff.rfl
 
-@[simp] lemma sigma_base_iff {B} :
-    (Matroid.sigma M).Base B ↔ ∀ i, (M i).Base (Sigma.mk i ⁻¹' B) := Iff.rfl
+@[simp] lemma sigma_isBase_iff {B} :
+    (Matroid.sigma M).IsBase B ↔ ∀ i, (M i).IsBase (Sigma.mk i ⁻¹' B) := Iff.rfl
 
 @[simp] lemma sigma_ground_eq : (Matroid.sigma M).E = univ.sigma fun i ↦ (M i).E := rfl
 
@@ -166,8 +166,9 @@ protected def sum' (M : ι → Matroid α) : Matroid (ι × α) :=
   ext
   simp [Matroid.sum']
 
-@[simp] lemma sum'_base_iff {B} : (Matroid.sum' M).Base B ↔ ∀ i, (M i).Base (Prod.mk i ⁻¹' B) := by
-  simp only [Matroid.sum', mapEquiv_base_iff, Equiv.sigmaEquivProd_symm_apply, sigma_base_iff]
+@[simp] lemma sum'_isBase_iff {B} :
+    (Matroid.sum' M).IsBase B ↔ ∀ i, (M i).IsBase (Prod.mk i ⁻¹' B) := by
+  simp only [Matroid.sum', mapEquiv_isBase_iff, Equiv.sigmaEquivProd_symm_apply, sigma_isBase_iff]
   convert Iff.rfl
   ext
   simp
@@ -206,9 +207,9 @@ protected def disjointSigma (M : ι → Matroid α) (h : Pairwise (Disjoint on f
       (∀ i, (M i).Indep (I ∩ (M i).E)) ∧ I ⊆ ⋃ i, (M i).E := by
   simp [Matroid.disjointSigma, (Function.Embedding.sigmaSet_preimage h)]
 
-@[simp] lemma disjointSigma_base_iff {h B} :
-    (Matroid.disjointSigma M h).Base B ↔
-      (∀ i, (M i).Base (B ∩ (M i).E)) ∧ B ⊆ ⋃ i, (M i).E := by
+@[simp] lemma disjointSigma_isBase_iff {h B} :
+    (Matroid.disjointSigma M h).IsBase B ↔
+      (∀ i, (M i).IsBase (B ∩ (M i).E)) ∧ B ⊆ ⋃ i, (M i).E := by
   simp [Matroid.disjointSigma, (Function.Embedding.sigmaSet_preimage h)]
 
 @[simp] lemma disjointSigma_basis_iff {h I X} :
@@ -239,10 +240,10 @@ protected def sum (M : Matroid α) (N : Matroid β) : Matroid (α ⊕ β) :=
   convert Iff.rfl <;>
     simp [Set.ext_iff, Equiv.ulift, Equiv.sumEquivSigmaBool]
 
-@[simp] lemma sum_base_iff {M : Matroid α} {N : Matroid β} {B : Set (α ⊕ β)} :
-    (M.sum N).Base B ↔ M.Base (.inl ⁻¹' B) ∧ N.Base (.inr ⁻¹' B) := by
-  simp only [Matroid.sum, mapEquiv_base_iff, Equiv.sumCongr_symm, Equiv.sumCongr_apply,
-    Equiv.symm_symm, sigma_base_iff, Bool.forall_bool, Equiv.ulift_apply]
+@[simp] lemma sum_isBase_iff {M : Matroid α} {N : Matroid β} {B : Set (α ⊕ β)} :
+    (M.sum N).IsBase B ↔ M.IsBase (.inl ⁻¹' B) ∧ N.IsBase (.inr ⁻¹' B) := by
+  simp only [Matroid.sum, mapEquiv_isBase_iff, Equiv.sumCongr_symm, Equiv.sumCongr_apply,
+    Equiv.symm_symm, sigma_isBase_iff, Bool.forall_bool, Equiv.ulift_apply]
   convert Iff.rfl <;>
     simp [Set.ext_iff, Equiv.ulift, Equiv.sumEquivSigmaBool]
 
@@ -271,8 +272,8 @@ def disjointSum (M N : Matroid α) (h : Disjoint M.E N.E) : Matroid α :=
     (M.disjointSum N h).Indep I ↔ M.Indep (I ∩ M.E) ∧ N.Indep (I ∩ N.E) ∧ I ⊆ M.E ∪ N.E := by
   simp [disjointSum, and_assoc]
 
-@[simp] lemma disjointSum_base_iff {h B} :
-    (M.disjointSum N h).Base B ↔ M.Base (B ∩ M.E) ∧ N.Base (B ∩ N.E) ∧ B ⊆ M.E ∪ N.E := by
+@[simp] lemma disjointSum_isBase_iff {h B} :
+    (M.disjointSum N h).IsBase B ↔ M.IsBase (B ∩ M.E) ∧ N.IsBase (B ∩ N.E) ∧ B ⊆ M.E ∪ N.E := by
   simp [disjointSum, and_assoc]
 
 @[simp] lemma disjointSum_basis_iff {h I X} :
@@ -292,9 +293,9 @@ lemma Indep.eq_union_image_of_disjointSum {h I} (hI : (disjointSum M N h).Indep 
   refine ⟨_, _, hI.1, hI.2.1, h.mono inter_subset_right inter_subset_right, ?_⟩
   rw [← inter_union_distrib_left, inter_eq_self_of_subset_left hI.2.2]
 
-lemma Base.eq_union_image_of_disjointSum {h B} (hB : (disjointSum M N h).Base B) :
-    ∃ BM BN, M.Base BM ∧ N.Base BN ∧ Disjoint BM BN ∧ B = BM ∪ BN := by
-  rw [disjointSum_base_iff] at hB
+lemma Base.eq_union_image_of_disjointSum {h B} (hB : (disjointSum M N h).IsBase B) :
+    ∃ BM BN, M.IsBase BM ∧ N.IsBase BN ∧ Disjoint BM BN ∧ B = BM ∪ BN := by
+  rw [disjointSum_isBase_iff] at hB
   refine ⟨_, _, hB.1, hB.2.1, h.mono inter_subset_right inter_subset_right, ?_⟩
   rw [← inter_union_distrib_left, inter_eq_self_of_subset_left hB.2.2]
 

--- a/Mathlib/Data/Matroid/Sum.lean
+++ b/Mathlib/Data/Matroid/Sum.lean
@@ -84,7 +84,7 @@ protected def sigma (M : (i : ι) → Matroid (α i)) : Matroid ((i : ι) × α 
 
   maximality X _ I hI hIX := by
     choose Js hJs using
-      fun i ↦ (hI i).subset_basis'_of_subset (preimage_mono (f := Sigma.mk i) hIX)
+      fun i ↦ (hI i).subset_isBasis'_of_subset (preimage_mono (f := Sigma.mk i) hIX)
 
     use univ.sigma Js
     simp only [maximal_subset_iff', mem_univ, mk_preimage_sigma, le_eq_subset, and_imp]
@@ -111,9 +111,9 @@ protected def sigma (M : (i : ι) → Matroid (α i)) : Matroid ((i : ι) × α 
 
 @[simp] lemma sigma_ground_eq : (Matroid.sigma M).E = univ.sigma fun i ↦ (M i).E := rfl
 
-@[simp] lemma sigma_basis_iff {I X} :
-    (Matroid.sigma M).Basis I X ↔ ∀ i, (M i).Basis (Sigma.mk i ⁻¹' I) (Sigma.mk i ⁻¹' X) := by
-  simp only [Basis, sigma_indep_iff, maximal_subset_iff, and_imp, and_assoc, sigma_ground_eq,
+@[simp] lemma sigma_isBasis_iff {I X} :
+    (Matroid.sigma M).IsBasis I X ↔ ∀ i, (M i).IsBasis (Sigma.mk i ⁻¹' I) (Sigma.mk i ⁻¹' X) := by
+  simp only [IsBasis, sigma_indep_iff, maximal_subset_iff, and_imp, and_assoc, sigma_ground_eq,
     forall_and, and_congr_right_iff]
   refine fun hI ↦ ⟨fun ⟨hIX, h, h'⟩ ↦ ⟨fun i ↦ preimage_mono hIX, fun i I₀ hI₀ hI₀X hII₀ ↦ ?_, ?_⟩,
     fun ⟨hIX, h', h''⟩ ↦ ⟨?_, ?_, ?_⟩⟩
@@ -173,8 +173,8 @@ protected def sum' (M : ι → Matroid α) : Matroid (ι × α) :=
   ext
   simp
 
-@[simp] lemma sum'_basis_iff {I X} :
-    (Matroid.sum' M).Basis I X ↔ ∀ i, (M i).Basis (Prod.mk i ⁻¹' I) (Prod.mk i ⁻¹' X) := by
+@[simp] lemma sum'_isBasis_iff {I X} :
+    (Matroid.sum' M).IsBasis I X ↔ ∀ i, (M i).IsBasis (Prod.mk i ⁻¹' I) (Prod.mk i ⁻¹' X) := by
   simp [Matroid.sum']
   convert Iff.rfl <;>
   exact ext <| by simp
@@ -212,9 +212,9 @@ protected def disjointSigma (M : ι → Matroid α) (h : Pairwise (Disjoint on f
       (∀ i, (M i).IsBase (B ∩ (M i).E)) ∧ B ⊆ ⋃ i, (M i).E := by
   simp [Matroid.disjointSigma, (Function.Embedding.sigmaSet_preimage h)]
 
-@[simp] lemma disjointSigma_basis_iff {h I X} :
-    (Matroid.disjointSigma M h).Basis I X ↔
-      (∀ i, (M i).Basis (I ∩ (M i).E) (X ∩ (M i).E)) ∧ I ⊆ X ∧ X ⊆ ⋃ i, (M i).E := by
+@[simp] lemma disjointSigma_isBasis_iff {h I X} :
+    (Matroid.disjointSigma M h).IsBasis I X ↔
+      (∀ i, (M i).IsBasis (I ∩ (M i).E) (X ∩ (M i).E)) ∧ I ⊆ X ∧ X ⊆ ⋃ i, (M i).E := by
   simp [Matroid.disjointSigma, Function.Embedding.sigmaSet_preimage h]
 
 end disjointSigma
@@ -247,11 +247,11 @@ protected def sum (M : Matroid α) (N : Matroid β) : Matroid (α ⊕ β) :=
   convert Iff.rfl <;>
     simp [Set.ext_iff, Equiv.ulift, Equiv.sumEquivSigmaBool]
 
-@[simp] lemma sum_basis_iff {M : Matroid α} {N : Matroid β} {I X : Set (α ⊕ β)} :
-    (M.sum N).Basis I X ↔
-      (M.Basis (Sum.inl ⁻¹' I) (Sum.inl ⁻¹' X) ∧ N.Basis (Sum.inr ⁻¹' I) (Sum.inr ⁻¹' X)) := by
-  simp only [Matroid.sum, mapEquiv_basis_iff, Equiv.sumCongr_symm,
-    Equiv.sumCongr_apply, Equiv.symm_symm, sigma_basis_iff, Bool.forall_bool, Equiv.ulift_apply,
+@[simp] lemma sum_isBasis_iff {M : Matroid α} {N : Matroid β} {I X : Set (α ⊕ β)} :
+    (M.sum N).IsBasis I X ↔
+      (M.IsBasis (Sum.inl ⁻¹' I) (Sum.inl ⁻¹' X) ∧ N.IsBasis (Sum.inr ⁻¹' I) (Sum.inr ⁻¹' X)) := by
+  simp only [Matroid.sum, mapEquiv_isBasis_iff, Equiv.sumCongr_symm,
+    Equiv.sumCongr_apply, Equiv.symm_symm, sigma_isBasis_iff, Bool.forall_bool, Equiv.ulift_apply,
     Equiv.sumEquivSigmaBool, Equiv.coe_fn_mk, Equiv.ulift]
   convert Iff.rfl <;> exact ext <| by simp
 
@@ -276,9 +276,9 @@ def disjointSum (M N : Matroid α) (h : Disjoint M.E N.E) : Matroid α :=
     (M.disjointSum N h).IsBase B ↔ M.IsBase (B ∩ M.E) ∧ N.IsBase (B ∩ N.E) ∧ B ⊆ M.E ∪ N.E := by
   simp [disjointSum, and_assoc]
 
-@[simp] lemma disjointSum_basis_iff {h I X} :
-    (M.disjointSum N h).Basis I X ↔ M.Basis (I ∩ M.E) (X ∩ M.E) ∧
-      N.Basis (I ∩ N.E) (X ∩ N.E) ∧ I ⊆ X ∧ X ⊆ M.E ∪ N.E := by
+@[simp] lemma disjointSum_isBasis_iff {h I X} :
+    (M.disjointSum N h).IsBasis I X ↔ M.IsBasis (I ∩ M.E) (X ∩ M.E) ∧
+      N.IsBasis (I ∩ N.E) (X ∩ N.E) ∧ I ⊆ X ∧ X ⊆ M.E ∪ N.E := by
   simp [disjointSum, and_assoc]
 
 lemma disjointSum_comm {h} : M.disjointSum N h = N.disjointSum M h.symm := by
@@ -293,7 +293,7 @@ lemma Indep.eq_union_image_of_disjointSum {h I} (hI : (disjointSum M N h).Indep 
   refine ⟨_, _, hI.1, hI.2.1, h.mono inter_subset_right inter_subset_right, ?_⟩
   rw [← inter_union_distrib_left, inter_eq_self_of_subset_left hI.2.2]
 
-lemma Base.eq_union_image_of_disjointSum {h B} (hB : (disjointSum M N h).IsBase B) :
+lemma IsBase.eq_union_image_of_disjointSum {h B} (hB : (disjointSum M N h).IsBase B) :
     ∃ BM BN, M.IsBase BM ∧ N.IsBase BN ∧ Disjoint BM BN ∧ B = BM ∪ BN := by
   rw [disjointSum_isBase_iff] at hB
   refine ⟨_, _, hB.1, hB.2.1, h.mono inter_subset_right inter_subset_right, ?_⟩


### PR DESCRIPTION
In accordance with [emerging guidelines](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Naming.20conventions.20for.20.60Prop.60-valued.20defs.20and.20classes), and to minimize impact on the growing API, we rename `Noun`-style matroid predicates to `IsNoun`, deprecating the old names in each case. 

This includes
`Base` -> `IsBase`
`Basis` -> `IsBasis`
`Basis'` -> `IsBasis'`
`Circuit` -> `IsCircuit`
`Flat` -> `IsFlat`
`Restriction` -> `IsRestriction`. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
