### PR TITLE
[Merged by Bors] - feat(CI): add awaiting-CI label when a build finishes

### DIFF
--- a/.github/build.in.yml
+++ b/.github/build.in.yml
@@ -322,6 +322,15 @@ jobs:
           cp ../lean-toolchain .
           lake build
 
+      - name: Add the "awaiting-CI" label
+        if: always()
+        # we use curl rather than octokit/request-action so that the job won't fail
+        # (and send an annoying email) if the labels don't exist
+        run: |
+          curl --request ADD \
+            --url https://api.github.com/repos/${{ github.repository }}/issues/${{ steps.PR.outputs.number }}/labels/awaiting-CI \
+            --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}'
+
   final:
     name: Post-CI jobJOB_NAME
     if: github.repository MAIN_OR_FORK 'leanprover-community/mathlib4'

--- a/.github/build.in.yml
+++ b/.github/build.in.yml
@@ -328,7 +328,7 @@ jobs:
         # (and send an annoying email) if the labels don't exist
         run: |
           curl --request ADD \
-            --url https://api.github.com/repos/${{ github.repository }}/issues/${{ steps.PR.outputs.number }}/labels/awaiting-CI \
+            --url https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/labels/awaiting-CI \
             --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}'
 
   final:

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -332,6 +332,15 @@ jobs:
           cp ../lean-toolchain .
           lake build
 
+      - name: Add the "awaiting-CI" label
+        if: always()
+        # we use curl rather than octokit/request-action so that the job won't fail
+        # (and send an annoying email) if the labels don't exist
+        run: |
+          curl --request ADD \
+            --url https://api.github.com/repos/${{ github.repository }}/issues/${{ steps.PR.outputs.number }}/labels/awaiting-CI \
+            --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}'
+
   final:
     name: Post-CI job
     if: github.repository == 'leanprover-community/mathlib4'

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -338,7 +338,7 @@ jobs:
         # (and send an annoying email) if the labels don't exist
         run: |
           curl --request ADD \
-            --url https://api.github.com/repos/${{ github.repository }}/issues/${{ steps.PR.outputs.number }}/labels/awaiting-CI \
+            --url https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/labels/awaiting-CI \
             --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}'
 
   final:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -339,6 +339,15 @@ jobs:
           cp ../lean-toolchain .
           lake build
 
+      - name: Add the "awaiting-CI" label
+        if: always()
+        # we use curl rather than octokit/request-action so that the job won't fail
+        # (and send an annoying email) if the labels don't exist
+        run: |
+          curl --request ADD \
+            --url https://api.github.com/repos/${{ github.repository }}/issues/${{ steps.PR.outputs.number }}/labels/awaiting-CI \
+            --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}'
+
   final:
     name: Post-CI job
     if: github.repository == 'leanprover-community/mathlib4'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -345,7 +345,7 @@ jobs:
         # (and send an annoying email) if the labels don't exist
         run: |
           curl --request ADD \
-            --url https://api.github.com/repos/${{ github.repository }}/issues/${{ steps.PR.outputs.number }}/labels/awaiting-CI \
+            --url https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/labels/awaiting-CI \
             --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}'
 
   final:

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -377,7 +377,7 @@ jobs:
         # (and send an annoying email) if the labels don't exist
         run: |
           curl --request DELETE \
-            --url https://api.github.com/repos/${{ github.repository }}/issues/${{ steps.PR.outputs.number }}/labels/awaiting-CI \
+            --url https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/labels/awaiting-CI \
             --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}'
 
       - if: contains(steps.PR.outputs.pr_labels, 'auto-merge-after-CI')

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -336,6 +336,15 @@ jobs:
           cp ../lean-toolchain .
           lake build
 
+      - name: Add the "awaiting-CI" label
+        if: always()
+        # we use curl rather than octokit/request-action so that the job won't fail
+        # (and send an annoying email) if the labels don't exist
+        run: |
+          curl --request ADD \
+            --url https://api.github.com/repos/${{ github.repository }}/issues/${{ steps.PR.outputs.number }}/labels/awaiting-CI \
+            --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}'
+
   final:
     name: Post-CI job (fork)
     if: github.repository != 'leanprover-community/mathlib4'

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -342,7 +342,7 @@ jobs:
         # (and send an annoying email) if the labels don't exist
         run: |
           curl --request ADD \
-            --url https://api.github.com/repos/${{ github.repository }}/issues/${{ steps.PR.outputs.number }}/labels/awaiting-CI \
+            --url https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/labels/awaiting-CI \
             --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}'
 
   final:
@@ -377,7 +377,7 @@ jobs:
         # (and send an annoying email) if the labels don't exist
         run: |
           curl --request DELETE \
-            --url https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/labels/awaiting-CI \
+            --url https://api.github.com/repos/${{ github.repository }}/issues/${{ steps.PR.outputs.number }}/labels/awaiting-CI \
             --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}'
 
       - if: contains(steps.PR.outputs.pr_labels, 'auto-merge-after-CI')


### PR DESCRIPTION
If the build passed, the label will be removed shortly thereafter; for failing builds, the label will stay around (which is a small change in behaviour).

This has the side-effect that completing CI always causes a visible state change to a PR, so e.g. the queueboard can pick up this change reliably.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
