### PR TITLE
[Merged by Bors] - chore(Data/Finset): don't import algebra in `Finset.Lattice.Fold`

### DIFF
--- a/Archive/Wiedijk100Theorems/AscendingDescendingSequences.lean
+++ b/Archive/Wiedijk100Theorems/AscendingDescendingSequences.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Bhavik Mehta
 -/
 import Mathlib.Data.Finset.Max
+import Mathlib.Data.Finset.Prod
 import Mathlib.Data.Fintype.Powerset
 
 /-!

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2650,6 +2650,9 @@ import Mathlib.Data.Finset.Interval
 import Mathlib.Data.Finset.Lattice.Basic
 import Mathlib.Data.Finset.Lattice.Fold
 import Mathlib.Data.Finset.Lattice.Lemmas
+import Mathlib.Data.Finset.Lattice.Pi
+import Mathlib.Data.Finset.Lattice.Prod
+import Mathlib.Data.Finset.Lattice.Union
 import Mathlib.Data.Finset.Max
 import Mathlib.Data.Finset.MulAntidiagonal
 import Mathlib.Data.Finset.NAry

--- a/Mathlib/Algebra/BigOperators/Group/Finset/Basic.lean
+++ b/Mathlib/Algebra/BigOperators/Group/Finset/Basic.lean
@@ -9,6 +9,7 @@ import Mathlib.Algebra.Group.Even
 import Mathlib.Data.Finset.Piecewise
 import Mathlib.Data.Finset.Powerset
 import Mathlib.Data.Finset.Preimage
+import Mathlib.Data.Finset.Prod
 import Mathlib.Data.Fintype.Pi
 
 /-!

--- a/Mathlib/Algebra/GCDMonoid/Multiset.lean
+++ b/Mathlib/Algebra/GCDMonoid/Multiset.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Aaron Anderson
 -/
 import Mathlib.Algebra.GCDMonoid.Basic
+import Mathlib.Algebra.Order.Group.Multiset
 import Mathlib.Data.Multiset.FinsetOps
 import Mathlib.Data.Multiset.Fold
 

--- a/Mathlib/Algebra/Order/BigOperators/Group/Multiset.lean
+++ b/Mathlib/Algebra/Order/BigOperators/Group/Multiset.lean
@@ -3,12 +3,12 @@ Copyright (c) 2019 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl
 -/
-import Mathlib.Algebra.BigOperators.Group.Multiset.Basic
+import Mathlib.Algebra.BigOperators.Group.Multiset.Defs
 import Mathlib.Algebra.Order.BigOperators.Group.List
 import Mathlib.Algebra.Order.Group.Abs
+import Mathlib.Algebra.Order.Monoid.OrderDual
 import Mathlib.Data.List.MinMax
 import Mathlib.Data.Multiset.Fold
-import Mathlib.Algebra.Order.Monoid.OrderDual
 
 /-!
 # Big operators on a multiset in ordered groups

--- a/Mathlib/Algebra/Order/Field/Pi.lean
+++ b/Mathlib/Algebra/Order/Field/Pi.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies
 -/
 import Mathlib.Algebra.Order.Monoid.Defs
+import Mathlib.Algebra.Order.Monoid.Unbundled.ExistsOfLE
 import Mathlib.Data.Finset.Lattice.Fold
 import Mathlib.Data.Fintype.Basic
 

--- a/Mathlib/Algebra/Order/Group/Finset.lean
+++ b/Mathlib/Algebra/Order/Group/Finset.lean
@@ -8,7 +8,7 @@ import Mathlib.Algebra.Order.Monoid.Canonical.Defs
 import Mathlib.Algebra.Order.Monoid.Unbundled.MinMax
 import Mathlib.Algebra.Order.Monoid.Unbundled.Pow
 import Mathlib.Algebra.Order.Monoid.Unbundled.WithTop
-import Mathlib.Data.Finset.Lattice.Fold
+import Mathlib.Data.Finset.Lattice.Prod
 
 /-!
 # `Finset.sup` in a group

--- a/Mathlib/Algebra/Order/Group/Multiset.lean
+++ b/Mathlib/Algebra/Order/Group/Multiset.lean
@@ -7,7 +7,7 @@ import Mathlib.Algebra.Group.Hom.Defs
 import Mathlib.Algebra.Group.Nat.Defs
 import Mathlib.Algebra.Order.Monoid.Unbundled.ExistsOfLE
 import Mathlib.Algebra.Order.Sub.Defs
-import Mathlib.Data.Multiset.Dedup
+import Mathlib.Data.Multiset.Fold
 
 /-!
 # Multisets form an ordered monoid
@@ -181,5 +181,18 @@ lemma addHom_ext [AddZeroClass β] ⦃f g : Multiset α →+ β⦄ (h : ∀ x, f
   induction' s using Multiset.induction_on with a s ih
   · simp only [_root_.map_zero]
   · simp only [← singleton_add, _root_.map_add, ih, h]
+
+open Nat
+
+theorem le_smul_dedup [DecidableEq α] (s : Multiset α) : ∃ n : ℕ, s ≤ n • dedup s :=
+  ⟨(s.map fun a => count a s).fold max 0,
+    le_iff_count.2 fun a => by
+      rw [count_nsmul]; by_cases h : a ∈ s
+      · refine le_trans ?_ (Nat.mul_le_mul_left _ <| count_pos.2 <| mem_dedup.2 h)
+        have : count a s ≤ fold max 0 (map (fun a => count a s) (a ::ₘ erase s a)) := by
+          simp [le_max_left]
+        rw [cons_erase h] at this
+        simpa [mul_succ] using this
+      · simp [count_eq_zero.2 h, Nat.zero_le]⟩
 
 end Multiset

--- a/Mathlib/Combinatorics/SetFamily/Compression/Down.lean
+++ b/Mathlib/Combinatorics/SetFamily/Compression/Down.lean
@@ -3,6 +3,7 @@ Copyright (c) 2022 Yaël Dillies. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies
 -/
+import Mathlib.Data.Finset.Card
 import Mathlib.Data.Finset.Lattice.Fold
 
 /-!

--- a/Mathlib/Combinatorics/Young/YoungDiagram.lean
+++ b/Mathlib/Combinatorics/Young/YoungDiagram.lean
@@ -3,8 +3,9 @@ Copyright (c) 2022 Jake Levinson. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jake Levinson
 -/
-import Mathlib.Order.UpperLower.Basic
 import Mathlib.Data.Finset.Preimage
+import Mathlib.Data.Finset.Prod
+import Mathlib.Order.UpperLower.Basic
 
 /-!
 # Young diagrams

--- a/Mathlib/Data/Finset/Fold.lean
+++ b/Mathlib/Data/Finset/Fold.lean
@@ -3,14 +3,14 @@ Copyright (c) 2017 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
-import Mathlib.Data.Finset.Union
+import Mathlib.Data.Finset.Image
 import Mathlib.Data.Multiset.Fold
 
 /-!
 # The fold operation for a commutative associative operation over a finset.
 -/
 
-assert_not_exists OrderedCommMonoid MonoidWithZero
+assert_not_exists Monoid
 
 namespace Finset
 
@@ -89,10 +89,6 @@ theorem fold_hom {op' : γ → γ → γ} [Std.Commutative op'] [Std.Associative
 theorem fold_disjUnion {s₁ s₂ : Finset α} {b₁ b₂ : β} (h) :
     (s₁.disjUnion s₂ h).fold op (b₁ * b₂) f = s₁.fold op b₁ f * s₂.fold op b₂ f :=
   (congr_arg _ <| Multiset.map_add _ _ _).trans (Multiset.fold_add _ _ _ _ _)
-
-theorem fold_disjiUnion {ι : Type*} {s : Finset ι} {t : ι → Finset α} {b : ι → β} {b₀ : β} (h) :
-    (s.disjiUnion t h).fold op (s.fold op b₀ b) f = s.fold op b₀ fun i => (t i).fold op (b i) f :=
-  (congr_arg _ <| Multiset.map_bind _ _ _).trans (Multiset.fold_bind _ _ _ _ _)
 
 theorem fold_union_inter [DecidableEq α] {s₁ s₂ : Finset α} {b₁ b₂ : β} :
     ((s₁ ∪ s₂).fold op b₁ f * (s₁ ∩ s₂).fold op b₂ f) = s₁.fold op b₂ f * s₂.fold op b₁ f := by

--- a/Mathlib/Data/Finset/Functor.lean
+++ b/Mathlib/Data/Finset/Functor.lean
@@ -3,7 +3,7 @@ Copyright (c) 2021 Yaël Dillies. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies, Kim Morrison
 -/
-import Mathlib.Data.Finset.Lattice.Fold
+import Mathlib.Data.Finset.Lattice.Union
 import Mathlib.Data.Finset.NAry
 import Mathlib.Data.Multiset.Functor
 

--- a/Mathlib/Data/Finset/Lattice/Fold.lean
+++ b/Mathlib/Data/Finset/Lattice/Fold.lean
@@ -4,8 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
 import Mathlib.Data.Finset.Fold
-import Mathlib.Data.Finset.Pi
-import Mathlib.Data.Finset.Prod
 import Mathlib.Data.Multiset.Lattice
 import Mathlib.Data.Set.Lattice
 import Mathlib.Order.Hom.Lattice
@@ -21,8 +19,6 @@ For the special case of maximum and minimum of a finset, see Max.lean.
 See also `Mathlib/Order/CompleteLattice/Finset.lean`, which is instead concerned with how big
 lattice or set operations behave when indexed by a finset.
 -/
-
-assert_not_exists OrderedCommMonoid MonoidWithZero
 
 open Function Multiset OrderDual
 
@@ -113,11 +109,6 @@ theorem le_sup_of_le {b : β} (hb : b ∈ s) (h : a ≤ f b) : a ≤ s.sup f := 
 theorem sup_union [DecidableEq β] : (s₁ ∪ s₂).sup f = s₁.sup f ⊔ s₂.sup f :=
   eq_of_forall_ge_iff fun c => by simp [or_imp, forall_and]
 
-@[simp]
-theorem sup_biUnion [DecidableEq β] (s : Finset γ) (t : γ → Finset β) :
-    (s.biUnion t).sup f = s.sup fun x => (t x).sup f :=
-  eq_of_forall_ge_iff fun c => by simp [@forall_swap _ β]
-
 theorem sup_const {s : Finset β} (h : s.Nonempty) (c : α) : (s.sup fun _ => c) = c :=
   eq_of_forall_ge_iff (fun _ => Finset.sup_le_iff.trans h.forall_const)
 
@@ -146,29 +137,6 @@ protected theorem sup_comm (s : Finset β) (t : Finset γ) (f : β → γ → α
 @[simp]
 theorem sup_attach (s : Finset β) (f : β → α) : (s.attach.sup fun x => f x) = s.sup f :=
   (s.attach.sup_map (Function.Embedding.subtype _) f).symm.trans <| congr_arg _ attach_map_val
-
-/-- See also `Finset.product_biUnion`. -/
-theorem sup_product_left (s : Finset β) (t : Finset γ) (f : β × γ → α) :
-    (s ×ˢ t).sup f = s.sup fun i => t.sup fun i' => f ⟨i, i'⟩ :=
-  eq_of_forall_ge_iff fun a => by simp [@forall_swap _ γ]
-
-theorem sup_product_right (s : Finset β) (t : Finset γ) (f : β × γ → α) :
-    (s ×ˢ t).sup f = t.sup fun i' => s.sup fun i => f ⟨i, i'⟩ := by
-  rw [sup_product_left, Finset.sup_comm]
-
-section Prod
-variable {ι κ α β : Type*} [SemilatticeSup α] [SemilatticeSup β] [OrderBot α] [OrderBot β]
-  {s : Finset ι} {t : Finset κ}
-
-@[simp] lemma sup_prodMap (hs : s.Nonempty) (ht : t.Nonempty) (f : ι → α) (g : κ → β) :
-    sup (s ×ˢ t) (Prod.map f g) = (sup s f, sup t g) :=
-  eq_of_forall_ge_iff fun i ↦ by
-    obtain ⟨a, ha⟩ := hs
-    obtain ⟨b, hb⟩ := ht
-    simp only [Prod.map, Finset.sup_le_iff, mem_product, and_imp, Prod.forall, Prod.le_def]
-    exact ⟨fun h ↦ ⟨fun i hi ↦ (h _ _ hi hb).1, fun j hj ↦ (h _ _ ha hj).2⟩, by aesop⟩
-
-end Prod
 
 @[simp]
 theorem sup_erase_bot [DecidableEq α] (s : Finset α) : (s.erase ⊥).sup id = s.sup id := by
@@ -367,10 +335,6 @@ theorem inf_le_of_le {b : β} (hb : b ∈ s) (h : f b ≤ a) : s.inf f ≤ a := 
 theorem inf_union [DecidableEq β] : (s₁ ∪ s₂).inf f = s₁.inf f ⊓ s₂.inf f :=
   eq_of_forall_le_iff fun c ↦ by simp [or_imp, forall_and]
 
-@[simp] theorem inf_biUnion [DecidableEq β] (s : Finset γ) (t : γ → Finset β) :
-    (s.biUnion t).inf f = s.inf fun x => (t x).inf f :=
-  @sup_biUnion αᵒᵈ _ _ _ _ _ _ _ _
-
 theorem inf_const (h : s.Nonempty) (c : α) : (s.inf fun _ => c) = c := @sup_const αᵒᵈ _ _ _ _ h _
 
 @[simp] theorem inf_top (s : Finset β) : (s.inf fun _ => ⊤) = (⊤ : α) := @sup_bot αᵒᵈ _ _ _ _
@@ -393,24 +357,6 @@ protected theorem inf_comm (s : Finset β) (t : Finset γ) (f : β → γ → α
 
 theorem inf_attach (s : Finset β) (f : β → α) : (s.attach.inf fun x => f x) = s.inf f :=
   @sup_attach αᵒᵈ _ _ _ _ _
-
-theorem inf_product_left (s : Finset β) (t : Finset γ) (f : β × γ → α) :
-    (s ×ˢ t).inf f = s.inf fun i => t.inf fun i' => f ⟨i, i'⟩ :=
-  @sup_product_left αᵒᵈ _ _ _ _ _ _ _
-
-theorem inf_product_right (s : Finset β) (t : Finset γ) (f : β × γ → α) :
-    (s ×ˢ t).inf f = t.inf fun i' => s.inf fun i => f ⟨i, i'⟩ :=
-  @sup_product_right αᵒᵈ _ _ _ _ _ _ _
-
-section Prod
-variable {ι κ α β : Type*} [SemilatticeInf α] [SemilatticeInf β] [OrderTop α] [OrderTop β]
- {s : Finset ι} {t : Finset κ}
-
-@[simp] lemma inf_prodMap (hs : s.Nonempty) (ht : t.Nonempty) (f : ι → α) (g : κ → β) :
-    inf (s ×ˢ t) (Prod.map f g) = (inf s f, inf t g) :=
-  sup_prodMap (α := αᵒᵈ) (β := βᵒᵈ) hs ht _ _
-
-end Prod
 
 @[simp]
 theorem inf_erase_top [DecidableEq α] (s : Finset α) : (s.erase ⊤).inf id = s.inf id :=
@@ -492,10 +438,6 @@ protected theorem disjoint_sup_right : Disjoint a (s.sup f) ↔ ∀ ⦃i⦄, i �
 protected theorem disjoint_sup_left : Disjoint (s.sup f) a ↔ ∀ ⦃i⦄, i ∈ s → Disjoint (f i) a := by
   simp only [disjoint_iff, sup_inf_distrib_right, Finset.sup_eq_bot_iff]
 
-theorem sup_inf_sup (s : Finset ι) (t : Finset κ) (f : ι → α) (g : κ → α) :
-    s.sup f ⊓ t.sup g = (s ×ˢ t).sup fun i => f i.1 ⊓ g i.2 := by
-  simp_rw [Finset.sup_inf_distrib_right, Finset.sup_inf_distrib_left, sup_product_left]
-
 end OrderBot
 
 section OrderTop
@@ -518,47 +460,7 @@ protected theorem codisjoint_inf_left :
     Codisjoint (s.inf f) a ↔ ∀ ⦃i⦄, i ∈ s → Codisjoint (f i) a :=
   @Finset.disjoint_sup_left αᵒᵈ _ _ _ _ _ _
 
-theorem inf_sup_inf (s : Finset ι) (t : Finset κ) (f : ι → α) (g : κ → α) :
-    s.inf f ⊔ t.inf g = (s ×ˢ t).inf fun i => f i.1 ⊔ g i.2 :=
-  @sup_inf_sup αᵒᵈ _ _ _ _ _ _ _ _
-
 end OrderTop
-
-section BoundedOrder
-
-variable [BoundedOrder α] [DecidableEq ι]
-
---TODO: Extract out the obvious isomorphism `(insert i s).pi t ≃ t i ×ˢ s.pi t` from this proof
-theorem inf_sup {κ : ι → Type*} (s : Finset ι) (t : ∀ i, Finset (κ i)) (f : ∀ i, κ i → α) :
-    (s.inf fun i => (t i).sup (f i)) =
-      (s.pi t).sup fun g => s.attach.inf fun i => f _ <| g _ i.2 := by
-  induction' s using Finset.induction with i s hi ih
-  · simp
-  rw [inf_insert, ih, attach_insert, sup_inf_sup]
-  refine eq_of_forall_ge_iff fun c => ?_
-  simp only [Finset.sup_le_iff, mem_product, mem_pi, and_imp, Prod.forall,
-    inf_insert, inf_image]
-  refine
-    ⟨fun h g hg =>
-      h (g i <| mem_insert_self _ _) (fun j hj => g j <| mem_insert_of_mem hj)
-        (hg _ <| mem_insert_self _ _) fun j hj => hg _ <| mem_insert_of_mem hj,
-      fun h a g ha hg => ?_⟩
-  -- TODO: This `have` must be named to prevent it being shadowed by the internal `this` in `simpa`
-  have aux : ∀ j : { x // x ∈ s }, ↑j ≠ i := fun j : s => ne_of_mem_of_not_mem j.2 hi
-  -- Porting note: `simpa` doesn't support placeholders in proof terms
-  have := h (fun j hj => if hji : j = i then cast (congr_arg κ hji.symm) a
-      else g _ <| mem_of_mem_insert_of_ne hj hji) (fun j hj => ?_)
-  · simpa only [cast_eq, dif_pos, Function.comp_def, Subtype.coe_mk, dif_neg, aux] using this
-  rw [mem_insert] at hj
-  obtain (rfl | hj) := hj
-  · simpa
-  · simpa [ne_of_mem_of_not_mem hj hi] using hg _ _
-
-theorem sup_inf {κ : ι → Type*} (s : Finset ι) (t : ∀ i, Finset (κ i)) (f : ∀ i, κ i → α) :
-    (s.sup fun i => (t i).inf (f i)) = (s.pi t).inf fun g => s.attach.sup fun i => f _ <| g _ i.2 :=
-  @inf_sup αᵒᵈ _ _ _ _ _ _ _ _
-
-end BoundedOrder
 
 end DistribLattice
 
@@ -803,42 +705,9 @@ theorem sup'_union [DecidableEq β] {s₁ s₂ : Finset β} (h₁ : s₁.Nonempt
     (s₁ ∪ s₂).sup' (h₁.mono subset_union_left) f = s₁.sup' h₁ f ⊔ s₂.sup' h₂ f :=
   eq_of_forall_ge_iff fun a => by simp [or_imp, forall_and]
 
-theorem sup'_biUnion [DecidableEq β] {s : Finset γ} (Hs : s.Nonempty) {t : γ → Finset β}
-    (Ht : ∀ b, (t b).Nonempty) :
-    (s.biUnion t).sup' (Hs.biUnion fun b _ => Ht b) f = s.sup' Hs (fun b => (t b).sup' (Ht b) f) :=
-  eq_of_forall_ge_iff fun c => by simp [@forall_swap _ β]
-
 protected theorem sup'_comm {t : Finset γ} (hs : s.Nonempty) (ht : t.Nonempty) (f : β → γ → α) :
     (s.sup' hs fun b => t.sup' ht (f b)) = t.sup' ht fun c => s.sup' hs fun b => f b c :=
   eq_of_forall_ge_iff fun a => by simpa using forall₂_swap
-
-theorem sup'_product_left {t : Finset γ} (h : (s ×ˢ t).Nonempty) (f : β × γ → α) :
-    (s ×ˢ t).sup' h f = s.sup' h.fst fun i => t.sup' h.snd fun i' => f ⟨i, i'⟩ :=
-  eq_of_forall_ge_iff fun a => by simp [@forall_swap _ γ]
-
-theorem sup'_product_right {t : Finset γ} (h : (s ×ˢ t).Nonempty) (f : β × γ → α) :
-    (s ×ˢ t).sup' h f = t.sup' h.snd fun i' => s.sup' h.fst fun i => f ⟨i, i'⟩ := by
-  rw [sup'_product_left, Finset.sup'_comm]
-
-section Prod
-variable {ι κ α β : Type*} [SemilatticeSup α] [SemilatticeSup β] {s : Finset ι} {t : Finset κ}
-
-/-- See also `Finset.sup'_prodMap`. -/
-lemma prodMk_sup'_sup' (hs : s.Nonempty) (ht : t.Nonempty) (f : ι → α) (g : κ → β) :
-    (sup' s hs f, sup' t ht g) = sup' (s ×ˢ t) (hs.product ht) (Prod.map f g) :=
-  eq_of_forall_ge_iff fun i ↦ by
-    obtain ⟨a, ha⟩ := hs
-    obtain ⟨b, hb⟩ := ht
-    simp only [Prod.map, sup'_le_iff, mem_product, and_imp, Prod.forall, Prod.le_def]
-    exact ⟨by aesop, fun h ↦ ⟨fun i hi ↦ (h _ _ hi hb).1, fun j hj ↦ (h _ _ ha hj).2⟩⟩
-
-/-- See also `Finset.prodMk_sup'_sup'`. -/
--- @[simp] -- TODO: Why does `Prod.map_apply` simplify the LHS?
-lemma sup'_prodMap (hst : (s ×ˢ t).Nonempty) (f : ι → α) (g : κ → β) :
-    sup' (s ×ˢ t) hst (Prod.map f g) = (sup' s hst.fst f, sup' t hst.snd g) :=
-  (prodMk_sup'_sup' _ _ _ _).symm
-
-end Prod
 
 theorem sup'_induction {p : α → Prop} (hp : ∀ a₁, p a₁ → ∀ a₂, p a₂ → p (a₁ ⊔ a₂))
     (hs : ∀ b ∈ s, p (f b)) : p (s.sup' H f) := by
@@ -972,38 +841,9 @@ theorem inf'_union [DecidableEq β] {s₁ s₂ : Finset β} (h₁ : s₁.Nonempt
     (s₁ ∪ s₂).inf' (h₁.mono subset_union_left) f = s₁.inf' h₁ f ⊓ s₂.inf' h₂ f :=
   @sup'_union αᵒᵈ _ _ _ _ _ h₁ h₂ _
 
-theorem inf'_biUnion [DecidableEq β] {s : Finset γ} (Hs : s.Nonempty) {t : γ → Finset β}
-    (Ht : ∀ b, (t b).Nonempty) :
-    (s.biUnion t).inf' (Hs.biUnion fun b _ => Ht b) f = s.inf' Hs (fun b => (t b).inf' (Ht b) f) :=
-  sup'_biUnion (α := αᵒᵈ) _ Hs Ht
-
 protected theorem inf'_comm {t : Finset γ} (hs : s.Nonempty) (ht : t.Nonempty) (f : β → γ → α) :
     (s.inf' hs fun b => t.inf' ht (f b)) = t.inf' ht fun c => s.inf' hs fun b => f b c :=
   @Finset.sup'_comm αᵒᵈ _ _ _ _ _ hs ht _
-
-theorem inf'_product_left {t : Finset γ} (h : (s ×ˢ t).Nonempty) (f : β × γ → α) :
-    (s ×ˢ t).inf' h f = s.inf' h.fst fun i => t.inf' h.snd fun i' => f ⟨i, i'⟩ :=
-  sup'_product_left (α := αᵒᵈ) h f
-
-theorem inf'_product_right {t : Finset γ} (h : (s ×ˢ t).Nonempty) (f : β × γ → α) :
-    (s ×ˢ t).inf' h f = t.inf' h.snd fun i' => s.inf' h.fst fun i => f ⟨i, i'⟩ :=
-  sup'_product_right (α := αᵒᵈ) h f
-
-section Prod
-variable {ι κ α β : Type*} [SemilatticeInf α] [SemilatticeInf β] {s : Finset ι} {t : Finset κ}
-
-/-- See also `Finset.inf'_prodMap`. -/
-lemma prodMk_inf'_inf' (hs : s.Nonempty) (ht : t.Nonempty) (f : ι → α) (g : κ → β) :
-    (inf' s hs f, inf' t ht g) = inf' (s ×ˢ t) (hs.product ht) (Prod.map f g) :=
-  prodMk_sup'_sup' (α := αᵒᵈ) (β := βᵒᵈ) hs ht _ _
-
-/-- See also `Finset.prodMk_inf'_inf'`. -/
--- @[simp] -- TODO: Why does `Prod.map_apply` simplify the LHS?
-lemma inf'_prodMap (hst : (s ×ˢ t).Nonempty) (f : ι → α) (g : κ → β) :
-    inf' (s ×ˢ t) hst (Prod.map f g) = (inf' s hst.fst f, inf' t hst.snd g) :=
-  (prodMk_inf'_inf' _ _ _ _).symm
-
-end Prod
 
 theorem comp_inf'_eq_inf'_comp [SemilatticeInf γ] {s : Finset β} (H : s.Nonempty) {f : β → α}
     (g : α → γ) (g_inf : ∀ x y, g (x ⊓ y) = g x ⊓ g y) : g (s.inf' H f) = s.inf' H (g ∘ f) :=
@@ -1143,19 +983,11 @@ theorem sup'_inf_distrib_right (f : ι → α) (a : α) :
     s.sup' hs f ⊓ a = s.sup' hs fun i => f i ⊓ a := by
   rw [inf_comm, sup'_inf_distrib_left]; simp_rw [inf_comm]
 
-theorem sup'_inf_sup' (f : ι → α) (g : κ → α) :
-    s.sup' hs f ⊓ t.sup' ht g = (s ×ˢ t).sup' (hs.product ht) fun i => f i.1 ⊓ g i.2 := by
-  simp_rw [Finset.sup'_inf_distrib_right, Finset.sup'_inf_distrib_left, sup'_product_left]
-
 theorem inf'_sup_distrib_left (f : ι → α) (a : α) : a ⊔ s.inf' hs f = s.inf' hs fun i => a ⊔ f i :=
   @sup'_inf_distrib_left αᵒᵈ _ _ _ hs _ _
 
 theorem inf'_sup_distrib_right (f : ι → α) (a : α) : s.inf' hs f ⊔ a = s.inf' hs fun i => f i ⊔ a :=
   @sup'_inf_distrib_right αᵒᵈ _ _ _ hs _ _
-
-theorem inf'_sup_inf' (f : ι → α) (g : κ → α) :
-    s.inf' hs f ⊔ t.inf' ht g = (s ×ˢ t).inf' (hs.product ht) fun i => f i.1 ⊔ g i.2 :=
-  @sup'_inf_sup' αᵒᵈ _ _ _ _ _ hs ht _ _
 
 end DistribLattice
 
@@ -1253,11 +1085,6 @@ set_option linter.docPrime false in
 
 @[simp] lemma mem_sup : a ∈ s.sup f ↔ ∃ i ∈ s, a ∈ f i := by
   induction' s using cons_induction <;> simp [*]
-
-theorem sup_eq_biUnion {α β} [DecidableEq β] (s : Finset α) (t : α → Finset β) :
-    s.sup t = s.biUnion t := by
-  ext
-  rw [mem_sup, mem_biUnion]
 
 @[simp]
 theorem sup_singleton'' (s : Finset β) (f : β → α) :

--- a/Mathlib/Data/Finset/Lattice/Pi.lean
+++ b/Mathlib/Data/Finset/Lattice/Pi.lean
@@ -1,0 +1,53 @@
+/-
+Copyright (c) 2018 Mario Carneiro. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mario Carneiro
+-/
+import Mathlib.Data.Finset.Lattice.Prod
+import Mathlib.Data.Finset.Pi
+
+/-!
+# Lattice operations on finsets of functions
+
+This file is concerned with folding binary lattice operations over finsets.
+-/
+
+assert_not_exists OrderedCommMonoid MonoidWithZero
+
+variable {α ι : Type*}
+
+namespace Finset
+
+variable [DistribLattice α] [BoundedOrder α] [DecidableEq ι]
+
+--TODO: Extract out the obvious isomorphism `(insert i s).pi t ≃ t i ×ˢ s.pi t` from this proof
+theorem inf_sup {κ : ι → Type*} (s : Finset ι) (t : ∀ i, Finset (κ i)) (f : ∀ i, κ i → α) :
+    (s.inf fun i => (t i).sup (f i)) =
+      (s.pi t).sup fun g => s.attach.inf fun i => f _ <| g _ i.2 := by
+  induction' s using Finset.induction with i s hi ih
+  · simp
+  rw [inf_insert, ih, attach_insert, sup_inf_sup]
+  refine eq_of_forall_ge_iff fun c => ?_
+  simp only [Finset.sup_le_iff, mem_product, mem_pi, and_imp, Prod.forall,
+    inf_insert, inf_image]
+  refine
+    ⟨fun h g hg =>
+      h (g i <| mem_insert_self _ _) (fun j hj => g j <| mem_insert_of_mem hj)
+        (hg _ <| mem_insert_self _ _) fun j hj => hg _ <| mem_insert_of_mem hj,
+      fun h a g ha hg => ?_⟩
+  -- TODO: This `have` must be named to prevent it being shadowed by the internal `this` in `simpa`
+  have aux : ∀ j : { x // x ∈ s }, ↑j ≠ i := fun j : s => ne_of_mem_of_not_mem j.2 hi
+  -- Porting note: `simpa` doesn't support placeholders in proof terms
+  have := h (fun j hj => if hji : j = i then cast (congr_arg κ hji.symm) a
+      else g _ <| mem_of_mem_insert_of_ne hj hji) (fun j hj => ?_)
+  · simpa only [cast_eq, dif_pos, Function.comp_def, Subtype.coe_mk, dif_neg, aux] using this
+  rw [mem_insert] at hj
+  obtain (rfl | hj) := hj
+  · simpa
+  · simpa [ne_of_mem_of_not_mem hj hi] using hg _ _
+
+theorem sup_inf {κ : ι → Type*} (s : Finset ι) (t : ∀ i, Finset (κ i)) (f : ∀ i, κ i → α) :
+    (s.sup fun i => (t i).inf (f i)) = (s.pi t).inf fun g => s.attach.sup fun i => f _ <| g _ i.2 :=
+  @inf_sup αᵒᵈ _ _ _ _ _ _ _ _
+
+end Finset

--- a/Mathlib/Data/Finset/Lattice/Prod.lean
+++ b/Mathlib/Data/Finset/Lattice/Prod.lean
@@ -1,0 +1,192 @@
+/-
+Copyright (c) 2018 Mario Carneiro. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mario Carneiro
+-/
+import Mathlib.Data.Finset.Lattice.Fold
+import Mathlib.Data.Finset.Prod
+
+/-!
+# Lattice operations on finsets of products
+
+This file is concerned with folding binary lattice operations over finsets.
+-/
+
+assert_not_exists OrderedCommMonoid MonoidWithZero
+
+open Function Multiset OrderDual
+
+variable {F α β γ ι κ : Type*}
+
+namespace Finset
+
+/-! ### sup -/
+
+
+section Sup
+
+-- TODO: define with just `[Bot α]` where some lemmas hold without requiring `[OrderBot α]`
+variable [SemilatticeSup α] [OrderBot α]
+
+/-- See also `Finset.product_biUnion`. -/
+theorem sup_product_left (s : Finset β) (t : Finset γ) (f : β × γ → α) :
+    (s ×ˢ t).sup f = s.sup fun i => t.sup fun i' => f ⟨i, i'⟩ :=
+  eq_of_forall_ge_iff fun a => by simp [@forall_swap _ γ]
+
+theorem sup_product_right (s : Finset β) (t : Finset γ) (f : β × γ → α) :
+    (s ×ˢ t).sup f = t.sup fun i' => s.sup fun i => f ⟨i, i'⟩ := by
+  rw [sup_product_left, Finset.sup_comm]
+
+section Prod
+variable {ι κ α β : Type*} [SemilatticeSup α] [SemilatticeSup β] [OrderBot α] [OrderBot β]
+  {s : Finset ι} {t : Finset κ}
+
+@[simp] lemma sup_prodMap (hs : s.Nonempty) (ht : t.Nonempty) (f : ι → α) (g : κ → β) :
+    sup (s ×ˢ t) (Prod.map f g) = (sup s f, sup t g) :=
+  eq_of_forall_ge_iff fun i ↦ by
+    obtain ⟨a, ha⟩ := hs
+    obtain ⟨b, hb⟩ := ht
+    simp only [Prod.map, Finset.sup_le_iff, mem_product, and_imp, Prod.forall, Prod.le_def]
+    exact ⟨fun h ↦ ⟨fun i hi ↦ (h _ _ hi hb).1, fun j hj ↦ (h _ _ ha hj).2⟩, by aesop⟩
+
+end Prod
+
+end Sup
+
+/-! ### inf -/
+
+
+section Inf
+
+-- TODO: define with just `[Top α]` where some lemmas hold without requiring `[OrderTop α]`
+variable [SemilatticeInf α] [OrderTop α]
+
+theorem inf_product_left (s : Finset β) (t : Finset γ) (f : β × γ → α) :
+    (s ×ˢ t).inf f = s.inf fun i => t.inf fun i' => f ⟨i, i'⟩ :=
+  @sup_product_left αᵒᵈ _ _ _ _ _ _ _
+
+theorem inf_product_right (s : Finset β) (t : Finset γ) (f : β × γ → α) :
+    (s ×ˢ t).inf f = t.inf fun i' => s.inf fun i => f ⟨i, i'⟩ :=
+  @sup_product_right αᵒᵈ _ _ _ _ _ _ _
+
+section Prod
+variable {ι κ α β : Type*} [SemilatticeInf α] [SemilatticeInf β] [OrderTop α] [OrderTop β]
+ {s : Finset ι} {t : Finset κ}
+
+@[simp] lemma inf_prodMap (hs : s.Nonempty) (ht : t.Nonempty) (f : ι → α) (g : κ → β) :
+    inf (s ×ˢ t) (Prod.map f g) = (inf s f, inf t g) :=
+  sup_prodMap (α := αᵒᵈ) (β := βᵒᵈ) hs ht _ _
+
+end Prod
+
+end Inf
+
+section DistribLattice
+
+variable [DistribLattice α]
+
+section OrderBot
+
+variable [OrderBot α] {s : Finset ι} {t : Finset κ} {f : ι → α} {g : κ → α} {a : α}
+
+theorem sup_inf_sup (s : Finset ι) (t : Finset κ) (f : ι → α) (g : κ → α) :
+    s.sup f ⊓ t.sup g = (s ×ˢ t).sup fun i => f i.1 ⊓ g i.2 := by
+  simp_rw [Finset.sup_inf_distrib_right, Finset.sup_inf_distrib_left, sup_product_left]
+
+end OrderBot
+
+section OrderTop
+
+variable [OrderTop α] {f : ι → α} {g : κ → α} {s : Finset ι} {t : Finset κ} {a : α}
+
+theorem inf_sup_inf (s : Finset ι) (t : Finset κ) (f : ι → α) (g : κ → α) :
+    s.inf f ⊔ t.inf g = (s ×ˢ t).inf fun i => f i.1 ⊔ g i.2 :=
+  @sup_inf_sup αᵒᵈ _ _ _ _ _ _ _ _
+
+end OrderTop
+
+end DistribLattice
+
+section Sup'
+
+variable [SemilatticeSup α]
+
+variable {s : Finset β} (H : s.Nonempty) (f : β → α)
+
+theorem sup'_product_left {t : Finset γ} (h : (s ×ˢ t).Nonempty) (f : β × γ → α) :
+    (s ×ˢ t).sup' h f = s.sup' h.fst fun i => t.sup' h.snd fun i' => f ⟨i, i'⟩ :=
+  eq_of_forall_ge_iff fun a => by simp [@forall_swap _ γ]
+
+theorem sup'_product_right {t : Finset γ} (h : (s ×ˢ t).Nonempty) (f : β × γ → α) :
+    (s ×ˢ t).sup' h f = t.sup' h.snd fun i' => s.sup' h.fst fun i => f ⟨i, i'⟩ := by
+  rw [sup'_product_left, Finset.sup'_comm]
+
+section Prod
+variable {ι κ α β : Type*} [SemilatticeSup α] [SemilatticeSup β] {s : Finset ι} {t : Finset κ}
+
+/-- See also `Finset.sup'_prodMap`. -/
+lemma prodMk_sup'_sup' (hs : s.Nonempty) (ht : t.Nonempty) (f : ι → α) (g : κ → β) :
+    (sup' s hs f, sup' t ht g) = sup' (s ×ˢ t) (hs.product ht) (Prod.map f g) :=
+  eq_of_forall_ge_iff fun i ↦ by
+    obtain ⟨a, ha⟩ := hs
+    obtain ⟨b, hb⟩ := ht
+    simp only [Prod.map, sup'_le_iff, mem_product, and_imp, Prod.forall, Prod.le_def]
+    exact ⟨by aesop, fun h ↦ ⟨fun i hi ↦ (h _ _ hi hb).1, fun j hj ↦ (h _ _ ha hj).2⟩⟩
+
+/-- See also `Finset.prodMk_sup'_sup'`. -/
+-- @[simp] -- TODO: Why does `Prod.map_apply` simplify the LHS?
+lemma sup'_prodMap (hst : (s ×ˢ t).Nonempty) (f : ι → α) (g : κ → β) :
+    sup' (s ×ˢ t) hst (Prod.map f g) = (sup' s hst.fst f, sup' t hst.snd g) :=
+  (prodMk_sup'_sup' _ _ _ _).symm
+
+end Prod
+
+end Sup'
+
+section Inf'
+
+variable [SemilatticeInf α]
+
+variable {s : Finset β} (H : s.Nonempty) (f : β → α)
+
+theorem inf'_product_left {t : Finset γ} (h : (s ×ˢ t).Nonempty) (f : β × γ → α) :
+    (s ×ˢ t).inf' h f = s.inf' h.fst fun i => t.inf' h.snd fun i' => f ⟨i, i'⟩ :=
+  sup'_product_left (α := αᵒᵈ) h f
+
+theorem inf'_product_right {t : Finset γ} (h : (s ×ˢ t).Nonempty) (f : β × γ → α) :
+    (s ×ˢ t).inf' h f = t.inf' h.snd fun i' => s.inf' h.fst fun i => f ⟨i, i'⟩ :=
+  sup'_product_right (α := αᵒᵈ) h f
+
+section Prod
+variable {ι κ α β : Type*} [SemilatticeInf α] [SemilatticeInf β] {s : Finset ι} {t : Finset κ}
+
+/-- See also `Finset.inf'_prodMap`. -/
+lemma prodMk_inf'_inf' (hs : s.Nonempty) (ht : t.Nonempty) (f : ι → α) (g : κ → β) :
+    (inf' s hs f, inf' t ht g) = inf' (s ×ˢ t) (hs.product ht) (Prod.map f g) :=
+  prodMk_sup'_sup' (α := αᵒᵈ) (β := βᵒᵈ) hs ht _ _
+
+/-- See also `Finset.prodMk_inf'_inf'`. -/
+-- @[simp] -- TODO: Why does `Prod.map_apply` simplify the LHS?
+lemma inf'_prodMap (hst : (s ×ˢ t).Nonempty) (f : ι → α) (g : κ → β) :
+    inf' (s ×ˢ t) hst (Prod.map f g) = (inf' s hst.fst f, inf' t hst.snd g) :=
+  (prodMk_inf'_inf' _ _ _ _).symm
+
+end Prod
+
+end Inf'
+
+section DistribLattice
+variable [DistribLattice α] {s : Finset ι} {t : Finset κ} (hs : s.Nonempty) (ht : t.Nonempty)
+  {f : ι → α} {g : κ → α} {a : α}
+
+theorem sup'_inf_sup' (f : ι → α) (g : κ → α) :
+    s.sup' hs f ⊓ t.sup' ht g = (s ×ˢ t).sup' (hs.product ht) fun i => f i.1 ⊓ g i.2 := by
+  simp_rw [Finset.sup'_inf_distrib_right, Finset.sup'_inf_distrib_left, sup'_product_left]
+
+theorem inf'_sup_inf' (f : ι → α) (g : κ → α) :
+    s.inf' hs f ⊔ t.inf' ht g = (s ×ˢ t).inf' (hs.product ht) fun i => f i.1 ⊔ g i.2 :=
+  @sup'_inf_sup' αᵒᵈ _ _ _ _ _ hs ht _ _
+
+end DistribLattice
+
+end Finset

--- a/Mathlib/Data/Finset/Lattice/Union.lean
+++ b/Mathlib/Data/Finset/Lattice/Union.lean
@@ -1,0 +1,80 @@
+/-
+Copyright (c) 2018 Mario Carneiro. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mario Carneiro
+-/
+import Mathlib.Data.Finset.Lattice.Fold
+import Mathlib.Data.Finset.Union
+
+/-!
+# Relating `Finset.biUnion` with lattice operations
+
+This file shows `Finset.biUnion` could alternatively be defined in terms of `Finset.sup`.
+
+## TODO
+
+Remove `Finset.biUnion` in favour of `Finset.sup`.
+-/
+
+open Function Multiset OrderDual
+
+variable {F α β γ ι κ : Type*}
+variable {s s₁ s₂ : Finset β} {f g : β → α} {a : α}
+
+namespace Finset
+
+section Sup
+
+variable [SemilatticeSup α] [OrderBot α]
+
+@[simp]
+theorem sup_biUnion [DecidableEq β] (s : Finset γ) (t : γ → Finset β) :
+    (s.biUnion t).sup f = s.sup fun x => (t x).sup f :=
+  eq_of_forall_ge_iff fun c => by simp [@forall_swap _ β]
+
+end Sup
+
+section Inf
+
+variable [SemilatticeInf α] [OrderTop α]
+
+@[simp] theorem inf_biUnion [DecidableEq β] (s : Finset γ) (t : γ → Finset β) :
+    (s.biUnion t).inf f = s.inf fun x => (t x).inf f :=
+  @sup_biUnion αᵒᵈ _ _ _ _ _ _ _ _
+
+end Inf
+
+section Sup'
+
+variable [SemilatticeSup α]
+
+variable {s : Finset β} (H : s.Nonempty) (f : β → α)
+
+theorem sup'_biUnion [DecidableEq β] {s : Finset γ} (Hs : s.Nonempty) {t : γ → Finset β}
+    (Ht : ∀ b, (t b).Nonempty) :
+    (s.biUnion t).sup' (Hs.biUnion fun b _ => Ht b) f = s.sup' Hs (fun b => (t b).sup' (Ht b) f) :=
+  eq_of_forall_ge_iff fun c => by simp [@forall_swap _ β]
+
+end Sup'
+
+section Inf'
+
+variable [SemilatticeInf α]
+
+variable {s : Finset β} (H : s.Nonempty) (f : β → α)
+
+theorem inf'_biUnion [DecidableEq β] {s : Finset γ} (Hs : s.Nonempty) {t : γ → Finset β}
+    (Ht : ∀ b, (t b).Nonempty) :
+    (s.biUnion t).inf' (Hs.biUnion fun b _ => Ht b) f = s.inf' Hs (fun b => (t b).inf' (Ht b) f) :=
+  sup'_biUnion (α := αᵒᵈ) _ Hs Ht
+
+end Inf'
+
+variable [DecidableEq α] {s : Finset ι} {f : ι → Finset α} {a : α}
+
+theorem sup_eq_biUnion {α β} [DecidableEq β] (s : Finset α) (t : α → Finset β) :
+    s.sup t = s.biUnion t := by
+  ext
+  rw [mem_sup, mem_biUnion]
+
+end Finset

--- a/Mathlib/Data/Finset/Max.lean
+++ b/Mathlib/Data/Finset/Max.lean
@@ -3,6 +3,7 @@ Copyright (c) 2018 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
+import Mathlib.Data.Finset.Card
 import Mathlib.Data.Finset.Lattice.Fold
 
 /-!

--- a/Mathlib/Data/Finset/NAry.lean
+++ b/Mathlib/Data/Finset/NAry.lean
@@ -3,7 +3,7 @@ Copyright (c) 2022 Yaël Dillies. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies
 -/
-import Mathlib.Data.Finset.Lattice.Fold
+import Mathlib.Data.Finset.Lattice.Prod
 import Mathlib.Data.Finite.Prod
 
 /-!

--- a/Mathlib/Data/Finset/Pi.lean
+++ b/Mathlib/Data/Finset/Pi.lean
@@ -180,4 +180,5 @@ theorem restrict₂_comp_restrict₂ {s t u : Finset ι} (hst : s ⊆ t) (htu : 
     (restrict₂ (π := π) hst) ∘ (restrict₂ htu) = restrict₂ (hst.trans htu) := rfl
 
 end Pi
+
 end Finset

--- a/Mathlib/Data/Finset/Powerset.lean
+++ b/Mathlib/Data/Finset/Powerset.lean
@@ -3,7 +3,8 @@ Copyright (c) 2018 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
-import Mathlib.Data.Finset.Lattice.Fold
+import Mathlib.Data.Finset.Card
+import Mathlib.Data.Finset.Lattice.Union
 import Mathlib.Data.Multiset.Powerset
 import Mathlib.Data.Set.Pairwise.Lattice
 

--- a/Mathlib/Data/Finset/Sort.lean
+++ b/Mathlib/Data/Finset/Sort.lean
@@ -6,8 +6,8 @@ Authors: Mario Carneiro
 import Mathlib.Order.RelIso.Set
 import Mathlib.Data.Multiset.Sort
 import Mathlib.Data.List.NodupEquivFin
-import Mathlib.Data.Finset.Max
 import Mathlib.Data.Fintype.Card
+import Mathlib.Data.Finset.Max
 
 /-!
 # Construct a sorted list from a finset.

--- a/Mathlib/Data/Finset/Union.lean
+++ b/Mathlib/Data/Finset/Union.lean
@@ -3,7 +3,7 @@ Copyright (c) 2017 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
-import Mathlib.Data.Finset.Image
+import Mathlib.Data.Finset.Fold
 import Mathlib.Data.Multiset.Bind
 import Mathlib.Order.SetNotation
 
@@ -88,6 +88,8 @@ lemma sUnion_disjiUnion {f : α → Finset (Set β)} (I : Finset α)
   simp only [coe_disjiUnion, Set.mem_sUnion, Set.mem_iUnion, mem_coe, exists_prop]
   tauto
 
+section DecidableEq
+
 variable [DecidableEq β] {s : Finset α} {t : Finset β} {f : α → β}
 
 private lemma pairwiseDisjoint_fibers : Set.PairwiseDisjoint ↑t fun a ↦ s.filter (f · = a) :=
@@ -103,18 +105,24 @@ lemma disjiUnion_filter_eq_of_maps_to (h : ∀ x ∈ s, f x ∈ t) :
     t.disjiUnion (fun a ↦ s.filter (f · = a)) pairwiseDisjoint_fibers = s := by
   simpa [filter_eq_self]
 
-omit [DecidableEq β] in
+end DecidableEq
+
 theorem map_disjiUnion {f : α ↪ β} {s : Finset α} {t : β → Finset γ} {h} :
     (s.map f).disjiUnion t h =
       s.disjiUnion (fun a => t (f a)) fun _ ha _ hb hab =>
         h (mem_map_of_mem _ ha) (mem_map_of_mem _ hb) (f.injective.ne hab) :=
   eq_of_veq <| Multiset.bind_map _ _ _
 
-omit [DecidableEq β] in
 theorem disjiUnion_map {s : Finset α} {t : α → Finset β} {f : β ↪ γ} {h} :
     (s.disjiUnion t h).map f =
       s.disjiUnion (fun a => (t a).map f) (h.mono' fun _ _ ↦ (disjoint_map _).2) :=
   eq_of_veq <| Multiset.map_bind _ _ _
+
+variable {f : α → β} {op : β → β → β} [hc : Std.Commutative op] [ha : Std.Associative op]
+
+theorem fold_disjiUnion {ι : Type*} {s : Finset ι} {t : ι → Finset α} {b : ι → β} {b₀ : β} (h) :
+    (s.disjiUnion t h).fold op (s.fold op b₀ b) f = s.fold op b₀ fun i => (t i).fold op (b i) f :=
+  (congr_arg _ <| Multiset.map_bind _ _ _).trans (Multiset.fold_bind _ _ _ _ _)
 
 end DisjiUnion
 

--- a/Mathlib/Data/Multiset/Bind.lean
+++ b/Mathlib/Data/Multiset/Bind.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
 import Mathlib.Algebra.BigOperators.Group.Multiset.Basic
-import Mathlib.Data.Multiset.Dedup
 
 /-!
 # Bind operation for multisets
@@ -219,6 +218,15 @@ lemma dedup_bind_dedup [DecidableEq α] [DecidableEq β] (s : Multiset α) (f : 
   simp_rw [count_dedup]
   refine if_congr ?_ rfl rfl
   simp
+
+variable (op : α → α → α) [hc : Std.Commutative op] [ha : Std.Associative op]
+
+theorem fold_bind {ι : Type*} (s : Multiset ι) (t : ι → Multiset α) (b : ι → α) (b₀ : α) :
+    (s.bind t).fold op ((s.map b).fold op b₀) =
+    (s.map fun i => (t i).fold op (b i)).fold op b₀ := by
+  induction' s using Multiset.induction_on with a ha ih
+  · rw [zero_bind, map_zero, map_zero, fold_zero]
+  · rw [cons_bind, map_cons, map_cons, fold_cons_left, fold_cons_left, fold_add, ih]
 
 end Bind
 

--- a/Mathlib/Data/Multiset/Fold.lean
+++ b/Mathlib/Data/Multiset/Fold.lean
@@ -3,12 +3,11 @@ Copyright (c) 2017 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
-import Mathlib.Data.Multiset.Bind
+import Mathlib.Data.Multiset.Dedup
 
 /-!
 # The fold operation for a commutative associative operation over a multiset.
 -/
-
 
 namespace Multiset
 
@@ -62,16 +61,10 @@ theorem fold_cons'_left (b a : α) (s : Multiset α) : (a ::ₘ s).fold op b = s
 
 theorem fold_add (b₁ b₂ : α) (s₁ s₂ : Multiset α) :
     (s₁ + s₂).fold op (b₁ * b₂) = s₁.fold op b₁ * s₂.fold op b₂ :=
-  Multiset.induction_on s₂ (by rw [add_zero, fold_zero, ← fold_cons'_right, ← fold_cons_right op])
+  Multiset.induction_on s₂
+    (by rw [Multiset.add_zero, fold_zero, ← fold_cons'_right, ← fold_cons_right op])
     (fun a b h => by rw [fold_cons_left, add_cons, fold_cons_left, h, ← ha.assoc, hc.comm a,
       ha.assoc])
-
-theorem fold_bind {ι : Type*} (s : Multiset ι) (t : ι → Multiset α) (b : ι → α) (b₀ : α) :
-    (s.bind t).fold op ((s.map b).fold op b₀) =
-    (s.map fun i => (t i).fold op (b i)).fold op b₀ := by
-  induction' s using Multiset.induction_on with a ha ih
-  · rw [zero_bind, map_zero, map_zero, fold_zero]
-  · rw [cons_bind, map_cons, map_cons, fold_cons_left, fold_cons_left, fold_add, ih]
 
 theorem fold_singleton (b a : α) : ({a} : Multiset α).fold op b = a * b :=
   foldr_singleton _ _ _
@@ -101,18 +94,5 @@ theorem fold_dedup_idem [DecidableEq α] [hi : Std.IdempotentOp op] (s : Multise
     rw [← cons_erase h, fold_cons_left, ← ha.assoc, hi.idempotent]
 
 end Fold
-
-open Nat
-
-theorem le_smul_dedup [DecidableEq α] (s : Multiset α) : ∃ n : ℕ, s ≤ n • dedup s :=
-  ⟨(s.map fun a => count a s).fold max 0,
-    le_iff_count.2 fun a => by
-      rw [count_nsmul]; by_cases h : a ∈ s
-      · refine le_trans ?_ (Nat.mul_le_mul_left _ <| count_pos.2 <| mem_dedup.2 h)
-        have : count a s ≤ fold max 0 (map (fun a => count a s) (a ::ₘ erase s a)) := by
-          simp [le_max_left]
-        rw [cons_erase h] at this
-        simpa [mul_succ] using this
-      · simp [count_eq_zero.2 h, Nat.zero_le]⟩
 
 end Multiset

--- a/Mathlib/Order/Interval/Finset/Defs.lean
+++ b/Mathlib/Order/Interval/Finset/Defs.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies
 -/
 import Mathlib.Data.Finset.Preimage
+import Mathlib.Data.Finset.Prod
 import Mathlib.Order.Interval.Set.Image
 import Mathlib.Order.Interval.Set.UnorderedInterval
 

--- a/Mathlib/Order/Partition/Finpartition.lean
+++ b/Mathlib/Order/Partition/Finpartition.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies, Bhavik Mehta
 -/
 import Mathlib.Algebra.BigOperators.Group.Finset.Basic
+import Mathlib.Data.Finset.Lattice.Prod
 import Mathlib.Data.Fintype.Powerset
 import Mathlib.Data.Setoid.Basic
 import Mathlib.Order.Atoms

--- a/Mathlib/Order/Restriction.lean
+++ b/Mathlib/Order/Restriction.lean
@@ -3,6 +3,7 @@ Copyright (c) 2024 Etienne Marion. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Etienne Marion
 -/
+import Mathlib.Data.Finset.Pi
 import Mathlib.Order.Interval.Set.Basic
 import Mathlib.Order.Interval.Finset.Basic
 

--- a/Mathlib/Order/SupClosed.lean
+++ b/Mathlib/Order/SupClosed.lean
@@ -3,7 +3,7 @@ Copyright (c) 2023 Yaël Dillies, Christopher Hoskin. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies, Christopher Hoskin
 -/
-import Mathlib.Data.Finset.Lattice.Fold
+import Mathlib.Data.Finset.Lattice.Prod
 import Mathlib.Data.Finset.Powerset
 import Mathlib.Data.Set.Finite.Basic
 import Mathlib.Order.Closure

--- a/Mathlib/Order/SupIndep.lean
+++ b/Mathlib/Order/SupIndep.lean
@@ -3,8 +3,10 @@ Copyright (c) 2021 Aaron Anderson, Yaël Dillies. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Aaron Anderson, Kevin Buzzard, Yaël Dillies, Eric Wieser
 -/
-import Mathlib.Data.Finset.Sigma
+import Mathlib.Data.Finset.Lattice.Union
 import Mathlib.Data.Finset.Pairwise
+import Mathlib.Data.Finset.Prod
+import Mathlib.Data.Finset.Sigma
 import Mathlib.Data.Fintype.Basic
 import Mathlib.Order.CompleteLatticeIntervals
 


### PR DESCRIPTION
We don't need to know what a monoid is in order to define the maximum of a finset. This PR replaces the approach of #21874 (reversing the `Finset.Max` -> `Finset.Sort` import) with cleaning up `Finset.Max`'s dependencies.

In particular, we reverse the import direction for `Multiset.Bind` and `Multiset.Fold` (the former imports a lot anyway), and split some results off from `Finset.Lattice.Fold` based on dependencies: `Finset.{Pi,Prod,Union}` mapping to `Finset.Lattice.{Pi,Prod,Union}`.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
