### PR TITLE
[Merged by Bors] - refactor(LinearIndependent): refactor to use LinearIndepOn

### DIFF
--- a/Mathlib/Algebra/Module/ZLattice/Basic.lean
+++ b/Mathlib/Algebra/Module/ZLattice/Basic.lean
@@ -535,8 +535,8 @@ theorem ZLattice.rank [hs : IsZLattice K L] : finrank ℤ L = finrank K E := by
     -- `e` is a `K`-basis of `E` formed of vectors of `b`
     let e : Basis t K E := Basis.mk ht_lin (by simp [ht_span, h_spanE])
     have : Fintype t := Set.Finite.fintype ((Set.range b).toFinite.subset ht_inc)
-    have h : LinearIndependent ℤ (fun x : (Set.range b) => (x : E)) := by
-      rwa [linearIndependent_subtype_range (Subtype.coe_injective.comp b₀.injective)]
+    have h : LinearIndepOn ℤ id (Set.range b) := by
+      rwa [linearIndepOn_id_range_iff (Subtype.coe_injective.comp b₀.injective)]
     contrapose! h
     -- Since `finrank ℤ L > finrank K E`, there exists a vector `v ∈ b` with `v ∉ e`
     obtain ⟨v, hv⟩ : (Set.range b \ Set.range e).Nonempty := by
@@ -548,14 +548,14 @@ theorem ZLattice.rank [hs : IsZLattice K L] : finrank ℤ L = finrank K E := by
       rwa [not_lt, h_card, ← topEquiv.finrank_eq, ← h_spanE, ← ht_span,
         finrank_span_set_eq_card ht_lin]
     -- Assume that `e ∪ {v}` is not `ℤ`-linear independent then we get the contradiction
-    suffices ¬ LinearIndependent ℤ (fun x : ↥(insert v (Set.range e)) => (x : E)) by
+    suffices ¬ LinearIndepOn ℤ id (insert v (Set.range e)) by
       contrapose! this
-      refine LinearIndependent.mono ?_ this
+      refine this.mono ?_
       exact Set.insert_subset (Set.mem_of_mem_diff hv) (by simp [e, ht_inc])
     -- We prove finally that `e ∪ {v}` is not ℤ-linear independent or, equivalently,
     -- not ℚ-linear independent by showing that `v ∈ span ℚ e`.
-    rw [LinearIndependent.iff_fractionRing ℤ ℚ,
-      linearIndependent_insert (Set.not_mem_of_mem_diff hv),  not_and, not_not]
+    rw [LinearIndepOn, LinearIndependent.iff_fractionRing ℤ ℚ, ← LinearIndepOn,
+      linearIndepOn_id_insert (Set.not_mem_of_mem_diff hv), not_and, not_not]
     intro _
     -- But that follows from the fact that there exist `n, m : ℕ`, `n ≠ m`
     -- such that `(n - m) • v ∈ span ℤ e` which is true since `n ↦ ZSpan.fract e (n • v)`

--- a/Mathlib/FieldTheory/Fixed.lean
+++ b/Mathlib/FieldTheory/Fixed.lean
@@ -111,8 +111,8 @@ theorem coe_algebraMap :
   rfl
 
 theorem linearIndependent_smul_of_linearIndependent {s : Finset F} :
-    (LinearIndependent (FixedPoints.subfield G F) fun i : (s : Set F) => (i : F)) →
-      LinearIndependent F fun i : (s : Set F) => MulAction.toFun G F i := by
+    (LinearIndepOn (FixedPoints.subfield G F) id s) →
+      LinearIndepOn F (MulAction.toFun G F i) s := by
   classical
   have : IsEmpty ((∅ : Finset F) : Set F) := by simp
   refine Finset.induction_on s (fun _ => linearIndependent_empty_type) fun a s has ih hs => ?_

--- a/Mathlib/FieldTheory/Fixed.lean
+++ b/Mathlib/FieldTheory/Fixed.lean
@@ -126,7 +126,7 @@ theorem linearIndependent_smul_of_linearIndependent {s : Finset F} :
     simp_rw [Pi.smul_apply, toFun_apply, one_smul] at hla
     refine hs.2 (hla ▸ Submodule.sum_mem _ fun c hcs => ?_)
     change (⟨l c, this c hcs⟩ : FixedPoints.subfield G F) • c ∈ _
-    refine Submodule.smul_mem _ _ (Submodule.subset_span <| by simpa)
+    exact Submodule.smul_mem _ _ <| Submodule.subset_span <| by simpa
 
   intro i his g
   refine

--- a/Mathlib/FieldTheory/Fixed.lean
+++ b/Mathlib/FieldTheory/Fixed.lean
@@ -111,14 +111,14 @@ theorem coe_algebraMap :
   rfl
 
 theorem linearIndependent_smul_of_linearIndependent {s : Finset F} :
-    (LinearIndepOn (FixedPoints.subfield G F) id s) →
-      LinearIndepOn F (MulAction.toFun G F i) s := by
+    (LinearIndepOn (FixedPoints.subfield G F) id (s : Set F)) →
+      LinearIndepOn F (MulAction.toFun G F) s := by
   classical
   have : IsEmpty ((∅ : Finset F) : Set F) := by simp
   refine Finset.induction_on s (fun _ => linearIndependent_empty_type) fun a s has ih hs => ?_
   rw [coe_insert] at hs ⊢
-  rw [linearIndependent_insert (mt mem_coe.1 has)] at hs
-  rw [linearIndependent_insert' (mt mem_coe.1 has)]; refine ⟨ih hs.1, fun ha => ?_⟩
+  rw [linearIndepOn_insert (mt mem_coe.1 has)] at hs
+  rw [linearIndepOn_insert (mt mem_coe.1 has)]; refine ⟨ih hs.1, fun ha => ?_⟩
   rw [Finsupp.mem_span_image_iff_linearCombination] at ha; rcases ha with ⟨l, hl, hla⟩
   rw [Finsupp.linearCombination_apply_of_mem_supported F hl] at hla
   suffices ∀ i ∈ s, l i ∈ FixedPoints.subfield G F by
@@ -126,7 +126,8 @@ theorem linearIndependent_smul_of_linearIndependent {s : Finset F} :
     simp_rw [Pi.smul_apply, toFun_apply, one_smul] at hla
     refine hs.2 (hla ▸ Submodule.sum_mem _ fun c hcs => ?_)
     change (⟨l c, this c hcs⟩ : FixedPoints.subfield G F) • c ∈ _
-    exact Submodule.smul_mem _ _ (Submodule.subset_span <| mem_coe.2 hcs)
+    refine Submodule.smul_mem _ _ (Submodule.subset_span <| by simpa)
+
   intro i his g
   refine
     eq_of_sub_eq_zero

--- a/Mathlib/FieldTheory/PurelyInseparable/PerfectClosure.lean
+++ b/Mathlib/FieldTheory/PurelyInseparable/PerfectClosure.lean
@@ -332,7 +332,7 @@ and is an intermediate result used to prove it. -/
 private theorem LinearIndependent.map_pow_expChar_pow_of_fd_isSeparable
     [FiniteDimensional F E] [Algebra.IsSeparable F E]
     (h : LinearIndependent F v) : LinearIndependent F (v · ^ q ^ n) := by
-  have h' := h.linearIndepOn_id_range
+  have h' := h.linearIndepOn_id
   let ι' := h'.extend (Set.range v).subset_univ
   let b : Basis ι' F E := Basis.extend h'
   letI : Fintype ι' := FiniteDimensional.fintypeBasisIndex b

--- a/Mathlib/FieldTheory/PurelyInseparable/PerfectClosure.lean
+++ b/Mathlib/FieldTheory/PurelyInseparable/PerfectClosure.lean
@@ -332,7 +332,7 @@ and is an intermediate result used to prove it. -/
 private theorem LinearIndependent.map_pow_expChar_pow_of_fd_isSeparable
     [FiniteDimensional F E] [Algebra.IsSeparable F E]
     (h : LinearIndependent F v) : LinearIndependent F (v · ^ q ^ n) := by
-  have h' := h.coe_range
+  have h' := h.linearIndepOn_id_range
   let ι' := h'.extend (Set.range v).subset_univ
   let b : Basis ι' F E := Basis.extend h'
   letI : Fintype ι' := FiniteDimensional.fintypeBasisIndex b

--- a/Mathlib/Geometry/Euclidean/MongePoint.lean
+++ b/Mathlib/Geometry/Euclidean/MongePoint.lean
@@ -396,7 +396,7 @@ theorem affineSpan_pair_eq_altitude_iff {n : ℕ} (s : Simplex ℝ P (n + 1)) (i
       simpa using h
     · rw [finrank_direction_altitude, finrank_span_set_eq_card]
       · simp
-      · exact linearIndepOn_id_singleton _ <| by simpa using hne
+      · exact LinearIndepOn.id_singleton _ <| by simpa using hne
 
 end Simplex
 

--- a/Mathlib/Geometry/Euclidean/MongePoint.lean
+++ b/Mathlib/Geometry/Euclidean/MongePoint.lean
@@ -396,8 +396,7 @@ theorem affineSpan_pair_eq_altitude_iff {n : ℕ} (s : Simplex ℝ P (n + 1)) (i
       simpa using h
     · rw [finrank_direction_altitude, finrank_span_set_eq_card]
       · simp
-      · refine linearIndependent_singleton ?_
-        simpa using hne
+      · exact linearIndepOn_id_singleton _ <| by simpa using hne
 
 end Simplex
 

--- a/Mathlib/LinearAlgebra/AffineSpace/Independent.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/Independent.lean
@@ -571,11 +571,13 @@ theorem exists_subset_affineIndependent_affineSpan_eq_top {s : Set P}
     have hsvi := bsv.linearIndependent
     have hsvt := bsv.span_eq
     rw [Basis.coe_extend] at hsvi hsvt
+    rw [linearIndependent_subtype_iff] at hsvi h
     have hsv := h.subset_extend (Set.subset_univ _)
     have h0 : ∀ v : V, v ∈ h.extend (Set.subset_univ _) → v ≠ 0 := by
       intro v hv
       simpa [bsv] using bsv.ne_zero ⟨v, hv⟩
-    rw [linearIndependent_set_iff_affineIndependent_vadd_union_singleton k h0 p₁] at hsvi
+    rw [← linearIndependent_subtype_iff,
+      linearIndependent_set_iff_affineIndependent_vadd_union_singleton k h0 p₁] at hsvi
     refine ⟨{p₁} ∪ (fun v => v +ᵥ p₁) '' h.extend (Set.subset_univ _), ?_, ?_⟩
     · refine Set.Subset.trans ?_ (Set.union_subset_union_right _ (Set.image_subset _ hsv))
       simp [Set.image_image]

--- a/Mathlib/LinearAlgebra/Basis/Cardinality.lean
+++ b/Mathlib/LinearAlgebra/Basis/Cardinality.lean
@@ -98,8 +98,8 @@ theorem union_support_maximal_linearIndependent_eq_range_basis {ι : Type w} (b 
   have r' : b i ∉ range v := fun ⟨k, p⟩ ↦ by simpa [w] using congr(b.repr $p i)
   have r'' : range v ≠ range v' := (r' <| · ▸ ⟨none, rfl⟩)
   -- The key step in the proof is checking that this strictly larger family is linearly independent.
-  have i' : LinearIndependent R ((↑) : range v' → M) := by
-    apply LinearIndependent.to_subtype_range
+  have i' : LinearIndepOn R id (range v') := by
+    apply LinearIndependent.linearIndepOn_id_range
     rw [linearIndependent_iffₛ]
     intro l l' z
     simp_rw [linearCombination_option, v', Option.elim'] at z

--- a/Mathlib/LinearAlgebra/Basis/Cardinality.lean
+++ b/Mathlib/LinearAlgebra/Basis/Cardinality.lean
@@ -99,7 +99,7 @@ theorem union_support_maximal_linearIndependent_eq_range_basis {ι : Type w} (b 
   have r'' : range v ≠ range v' := (r' <| · ▸ ⟨none, rfl⟩)
   -- The key step in the proof is checking that this strictly larger family is linearly independent.
   have i' : LinearIndepOn R id (range v') := by
-    apply LinearIndependent.linearIndepOn_id_range
+    apply LinearIndependent.linearIndepOn_id
     rw [linearIndependent_iffₛ]
     intro l l' z
     simp_rw [linearCombination_option, v', Option.elim'] at z

--- a/Mathlib/LinearAlgebra/Basis/VectorSpace.lean
+++ b/Mathlib/LinearAlgebra/Basis/VectorSpace.lean
@@ -66,20 +66,20 @@ theorem range_extend (hs : LinearIndepOn K id s) :
 The specific value of this definition should be considered an implementation detail.
 -/
 def sumExtendIndex (hs : LinearIndependent K v) : Set V :=
-  LinearIndepOn.extend hs.linearIndepOn_id_range (subset_univ _) \ range v
+  LinearIndepOn.extend hs.linearIndepOn_id (subset_univ _) \ range v
 
 /-- If `v` is a linear independent family of vectors, extend it to a basis indexed by a sum type. -/
 noncomputable def sumExtend (hs : LinearIndependent K v) : Basis (ι ⊕ sumExtendIndex hs) K V :=
   let s := Set.range v
   let e : ι ≃ s := Equiv.ofInjective v hs.injective
-  let b := hs.linearIndepOn_id_range.extend (subset_univ (Set.range v))
-  (Basis.extend hs.linearIndepOn_id_range).reindex <|
+  let b := hs.linearIndepOn_id.extend (subset_univ (Set.range v))
+  (Basis.extend hs.linearIndepOn_id).reindex <|
     Equiv.symm <|
       calc
         ι ⊕ (b \ s : Set V) ≃ s ⊕ (b \ s : Set V) := Equiv.sumCongr e (Equiv.refl _)
         _ ≃ b :=
           haveI := Classical.decPred (· ∈ s)
-          Equiv.Set.sumDiffSubset (hs.linearIndepOn_id_range.subset_extend _)
+          Equiv.Set.sumDiffSubset (hs.linearIndepOn_id.subset_extend _)
 
 theorem subset_extend {s : Set V} (hs : LinearIndepOn K id s) : s ⊆ hs.extend (Set.subset_univ _) :=
   hs.subset_extend _
@@ -235,7 +235,7 @@ theorem LinearMap.exists_leftInverse_of_injective (f : V →ₗ[K] V') (hf_inj :
     ∃ g : V' →ₗ[K] V, g.comp f = LinearMap.id := by
   let B := Basis.ofVectorSpaceIndex K V
   let hB := Basis.ofVectorSpace K V
-  have hB₀ : _ := hB.linearIndependent.linearIndepOn_id_range
+  have hB₀ : _ := hB.linearIndependent.linearIndepOn_id
   have : LinearIndepOn K _root_.id (f '' B) := by
     have h₁ : LinearIndepOn K _root_.id (f '' Set.range (Basis.ofVectorSpace K V)) :=
       LinearIndepOn.image (f := f) hB₀ (show Disjoint _ _ by simp [hf_inj])

--- a/Mathlib/LinearAlgebra/Basis/VectorSpace.lean
+++ b/Mathlib/LinearAlgebra/Basis/VectorSpace.lean
@@ -43,21 +43,20 @@ namespace Basis
 section ExistsBasis
 
 /-- If `s` is a linear independent set of vectors, we can extend it to a basis. -/
-noncomputable def extend (hs : LinearIndependent K ((↑) : s → V)) :
+noncomputable def extend (hs : LinearIndepOn K id s) :
     Basis (hs.extend (subset_univ s)) K V :=
   Basis.mk
-    (@LinearIndependent.restrict_of_comp_subtype _ _ _ id _ _ _ _ (hs.linearIndependent_extend _))
+    (hs.linearIndepOn_extend _).linearIndependent_restrict
     (SetLike.coe_subset_coe.mp <| by simpa using hs.subset_span_extend (subset_univ s))
 
-theorem extend_apply_self (hs : LinearIndependent K ((↑) : s → V)) (x : hs.extend _) :
-    Basis.extend hs x = x :=
+theorem extend_apply_self (hs : LinearIndepOn K id s) (x : hs.extend _) : Basis.extend hs x = x :=
   Basis.mk_apply _ _ _
 
 @[simp]
-theorem coe_extend (hs : LinearIndependent K ((↑) : s → V)) : ⇑(Basis.extend hs) = ((↑) : _ → _) :=
+theorem coe_extend (hs : LinearIndepOn K id s) : ⇑(Basis.extend hs) = ((↑) : _ → _) :=
   funext (extend_apply_self hs)
 
-theorem range_extend (hs : LinearIndependent K ((↑) : s → V)) :
+theorem range_extend (hs : LinearIndepOn K id s) :
     range (Basis.extend hs) = hs.extend (subset_univ _) := by
   rw [coe_extend, Subtype.range_coe_subtype, setOf_mem_eq]
 
@@ -67,66 +66,60 @@ theorem range_extend (hs : LinearIndependent K ((↑) : s → V)) :
 The specific value of this definition should be considered an implementation detail.
 -/
 def sumExtendIndex (hs : LinearIndependent K v) : Set V :=
-  LinearIndependent.extend hs.to_subtype_range (subset_univ _) \ range v
+  LinearIndepOn.extend hs.linearIndepOn_id_range (subset_univ _) \ range v
 
 /-- If `v` is a linear independent family of vectors, extend it to a basis indexed by a sum type. -/
 noncomputable def sumExtend (hs : LinearIndependent K v) : Basis (ι ⊕ sumExtendIndex hs) K V :=
   let s := Set.range v
   let e : ι ≃ s := Equiv.ofInjective v hs.injective
-  let b := hs.to_subtype_range.extend (subset_univ (Set.range v))
-  (Basis.extend hs.to_subtype_range).reindex <|
+  let b := hs.linearIndepOn_id_range.extend (subset_univ (Set.range v))
+  (Basis.extend hs.linearIndepOn_id_range).reindex <|
     Equiv.symm <|
       calc
         ι ⊕ (b \ s : Set V) ≃ s ⊕ (b \ s : Set V) := Equiv.sumCongr e (Equiv.refl _)
         _ ≃ b :=
           haveI := Classical.decPred (· ∈ s)
-          Equiv.Set.sumDiffSubset (hs.to_subtype_range.subset_extend _)
+          Equiv.Set.sumDiffSubset (hs.linearIndepOn_id_range.subset_extend _)
 
-theorem subset_extend {s : Set V} (hs : LinearIndependent K ((↑) : s → V)) :
-    s ⊆ hs.extend (Set.subset_univ _) :=
+theorem subset_extend {s : Set V} (hs : LinearIndepOn K id s) : s ⊆ hs.extend (Set.subset_univ _) :=
   hs.subset_extend _
 
 /-- If `s` is a family of linearly independent vectors contained in a set `t` spanning `V`,
 then one can get a basis of `V` containing `s` and contained in `t`. -/
-noncomputable def extendLe (hs : LinearIndependent K ((↑) : s → V))
-    (hst : s ⊆ t) (ht : ⊤ ≤ span K t) :
+noncomputable def extendLe (hs : LinearIndepOn K id s) (hst : s ⊆ t) (ht : ⊤ ≤ span K t) :
     Basis (hs.extend hst) K V :=
   Basis.mk
-    (@LinearIndependent.restrict_of_comp_subtype _ _ _ id _ _ _ _ (hs.linearIndependent_extend _))
+    ((hs.linearIndepOn_extend _).linearIndependent ..)
     (le_trans ht <| Submodule.span_le.2 <| by simpa using hs.subset_span_extend hst)
 
-theorem extendLe_apply_self (hs : LinearIndependent K ((↑) : s → V))
-    (hst : s ⊆ t) (ht : ⊤ ≤ span K t) (x : hs.extend hst) :
-    Basis.extendLe hs hst ht x = x :=
+theorem extendLe_apply_self (hs : LinearIndepOn K id s) (hst : s ⊆ t) (ht : ⊤ ≤ span K t)
+    (x : hs.extend hst) : Basis.extendLe hs hst ht x = x :=
   Basis.mk_apply _ _ _
 
 @[simp]
-theorem coe_extendLe (hs : LinearIndependent K ((↑) : s → V))
-    (hst : s ⊆ t) (ht : ⊤ ≤ span K t) : ⇑(Basis.extendLe hs hst ht) = ((↑) : _ → _) :=
+theorem coe_extendLe (hs : LinearIndepOn K id s) (hst : s ⊆ t) (ht : ⊤ ≤ span K t) :
+    ⇑(Basis.extendLe hs hst ht) = ((↑) : _ → _) :=
   funext (extendLe_apply_self hs hst ht)
 
-theorem range_extendLe (hs : LinearIndependent K ((↑) : s → V))
-    (hst : s ⊆ t) (ht : ⊤ ≤ span K t) :
+theorem range_extendLe (hs : LinearIndepOn K id s) (hst : s ⊆ t) (ht : ⊤ ≤ span K t) :
     range (Basis.extendLe hs hst ht) = hs.extend hst := by
   rw [coe_extendLe, Subtype.range_coe_subtype, setOf_mem_eq]
 
-theorem subset_extendLe (hs : LinearIndependent K ((↑) : s → V))
-    (hst : s ⊆ t) (ht : ⊤ ≤ span K t) :
+theorem subset_extendLe (hs : LinearIndepOn K id s) (hst : s ⊆ t) (ht : ⊤ ≤ span K t) :
     s ⊆ range (Basis.extendLe hs hst ht) :=
   (range_extendLe hs hst ht).symm ▸ hs.subset_extend hst
 
-theorem extendLe_subset (hs : LinearIndependent K ((↑) : s → V))
-    (hst : s ⊆ t) (ht : ⊤ ≤ span K t) :
+theorem extendLe_subset (hs : LinearIndepOn K id s) (hst : s ⊆ t) (ht : ⊤ ≤ span K t) :
     range (Basis.extendLe hs hst ht) ⊆ t :=
   (range_extendLe hs hst ht).symm ▸ hs.extend_subset hst
 
 /-- If a set `s` spans the space, this is a basis contained in `s`. -/
 noncomputable def ofSpan (hs : ⊤ ≤ span K s) :
-    Basis ((linearIndependent_empty K V).extend (empty_subset s)) K V :=
+    Basis ((linearIndepOn_empty K id).extend (empty_subset s)) K V :=
   extendLe (linearIndependent_empty K V) (empty_subset s) hs
 
 theorem ofSpan_apply_self (hs : ⊤ ≤ span K s)
-    (x : (linearIndependent_empty K V).extend (empty_subset s)) :
+    (x : (linearIndepOn_empty K id).extend (empty_subset s)) :
     Basis.ofSpan hs x = x :=
   extendLe_apply_self (linearIndependent_empty K V) (empty_subset s) hs x
 
@@ -135,7 +128,7 @@ theorem coe_ofSpan (hs : ⊤ ≤ span K s) : ⇑(ofSpan hs) = ((↑) : _ → _) 
   funext (ofSpan_apply_self hs)
 
 theorem range_ofSpan (hs : ⊤ ≤ span K s) :
-    range (ofSpan hs) = (linearIndependent_empty K V).extend (empty_subset s) := by
+    range (ofSpan hs) = (linearIndepOn_empty K id).extend (empty_subset s) := by
   rw [coe_ofSpan, Subtype.range_coe_subtype, setOf_mem_eq]
 
 theorem ofSpan_subset (hs : ⊤ ≤ span K s) : range (ofSpan hs) ⊆ s :=
@@ -147,7 +140,7 @@ variable (K V)
 
 /-- A set used to index `Basis.ofVectorSpace`. -/
 noncomputable def ofVectorSpaceIndex : Set V :=
-  (linearIndependent_empty K V).extend (subset_univ _)
+  (linearIndepOn_empty K id).extend (subset_univ _)
 
 /-- Each vector space has a basis. -/
 noncomputable def ofVectorSpace : Basis (ofVectorSpaceIndex K V) K V :=
@@ -242,10 +235,10 @@ theorem LinearMap.exists_leftInverse_of_injective (f : V →ₗ[K] V') (hf_inj :
     ∃ g : V' →ₗ[K] V, g.comp f = LinearMap.id := by
   let B := Basis.ofVectorSpaceIndex K V
   let hB := Basis.ofVectorSpace K V
-  have hB₀ : _ := hB.linearIndependent.to_subtype_range
-  have : LinearIndependent K (fun x => x : f '' B → V') := by
-    have h₁ : LinearIndependent K ((↑) : ↥(f '' Set.range (Basis.ofVectorSpace K V)) → V') :=
-      LinearIndependent.image_subtype (f := f) hB₀ (show Disjoint _ _ by simp [hf_inj])
+  have hB₀ : _ := hB.linearIndependent.linearIndepOn_id_range
+  have : LinearIndepOn K _root_.id (f '' B) := by
+    have h₁ : LinearIndepOn K _root_.id (f '' Set.range (Basis.ofVectorSpace K V)) :=
+      LinearIndepOn.image (f := f) hB₀ (show Disjoint _ _ by simp [hf_inj])
     rwa [Basis.range_ofVectorSpace K V] at h₁
   let C := this.extend (subset_univ _)
   have BC := this.subset_extend (subset_univ _)

--- a/Mathlib/LinearAlgebra/Dimension/Basic.lean
+++ b/Mathlib/LinearAlgebra/Dimension/Basic.lean
@@ -57,13 +57,13 @@ this is the same as the dimension of the space (i.e. the cardinality of any basi
 In particular this agrees with the usual notion of the dimension of a vector space. -/
 @[stacks 09G3 "first part"]
 protected irreducible_def Module.rank : Cardinal :=
-  ⨆ ι : { s : Set M // LinearIndependent R ((↑) : s → M) }, (#ι.1)
+  ⨆ ι : { s : Set M // LinearIndepOn R id s }, (#ι.1)
 
 theorem rank_le_card : Module.rank R M ≤ #M :=
   (Module.rank_def _ _).trans_le (ciSup_le' fun _ ↦ mk_set_le _)
 
-lemma nonempty_linearIndependent_set : Nonempty {s : Set M // LinearIndependent R ((↑) : s → M)} :=
-  ⟨⟨∅, linearIndependent_empty _ _⟩⟩
+lemma nonempty_linearIndependent_set : Nonempty {s : Set M // LinearIndepOn R id s } :=
+  ⟨⟨∅, linearIndepOn_empty _ _⟩⟩
 
 end
 
@@ -77,7 +77,7 @@ theorem cardinal_lift_le_rank {ι : Type w} {v : ι → M}
     (hv : LinearIndependent R v) :
     Cardinal.lift.{v} #ι ≤ Cardinal.lift.{w} (Module.rank R M) := by
   rw [Module.rank]
-  refine le_trans ?_ (lift_le.mpr <| le_ciSup (bddAbove_range _) ⟨_, hv.coe_range⟩)
+  refine le_trans ?_ (lift_le.mpr <| le_ciSup (bddAbove_range _) ⟨_, hv.linearIndepOn_id_range⟩)
   exact lift_mk_le'.mpr ⟨(Equiv.ofInjective _ hv.injective).toEmbedding⟩
 
 lemma aleph0_le_rank {ι : Type w} [Infinite ι] {v : ι → M}
@@ -113,8 +113,8 @@ theorem lift_rank_le_of_injective_injectiveₛ (i : R' → R) (j : M →+ M')
     lift.{v'} (Module.rank R M) ≤ lift.{v} (Module.rank R' M') := by
   simp_rw [Module.rank, lift_iSup (bddAbove_range _)]
   exact ciSup_mono' (bddAbove_range _) fun ⟨s, h⟩ ↦ ⟨⟨j '' s,
-    (h.map_of_injective_injectiveₛ i j hi hj hc).image⟩,
-      lift_mk_le'.mpr ⟨(Equiv.Set.image j s hj).toEmbedding⟩⟩
+    LinearIndepOn.id_image (h.linearIndependent.map_of_injective_injectiveₛ i j hi hj hc)⟩,
+    lift_mk_le'.mpr ⟨(Equiv.Set.image j s hj).toEmbedding⟩⟩
 
 /-- If `M / R` and `M' / R'` are modules, `i : R → R'` is a surjective map, and
 `j : M →+ M'` is an injective monoid homomorphism, such that the scalar multiplications on `M` and
@@ -180,9 +180,10 @@ theorem lift_rank_le_of_injective_injective [AddCommGroup M'] [Module R' M']
     (hc : ∀ (r : R') (m : M), j (i r • m) = r • j m) :
     lift.{v'} (Module.rank R M) ≤ lift.{v} (Module.rank R' M') := by
   simp_rw [Module.rank, lift_iSup (bddAbove_range _)]
-  exact ciSup_mono' (bddAbove_range _) fun ⟨s, h⟩ ↦ ⟨⟨j '' s,
-    (h.map_of_injective_injective i j hi (fun _ _ ↦ hj <| by rwa [j.map_zero]) hc).image⟩,
-      lift_mk_le'.mpr ⟨(Equiv.Set.image j s hj).toEmbedding⟩⟩
+  exact ciSup_mono' (bddAbove_range _) fun ⟨s, h⟩ ↦
+    ⟨⟨j '' s, LinearIndepOn.id_image <| h.linearIndependent.map_of_injective_injective i j hi
+      (fun _ _ ↦ hj <| by rwa [j.map_zero]) hc⟩,
+    lift_mk_le'.mpr ⟨(Equiv.Set.image j s hj).toEmbedding⟩⟩
 
 /-- The same-universe version of `lift_rank_le_of_injective_injective`. -/
 theorem rank_le_of_injective_injective [AddCommGroup M₁] [Module R' M₁]
@@ -367,17 +368,13 @@ theorem LinearMap.rank_le_of_surjective (f : M →ₗ[R] M₁) (h : Surjective f
 @[nontriviality, simp]
 theorem rank_subsingleton [Subsingleton R] : Module.rank R M = 1 := by
   haveI := Module.subsingleton R M
-  have : Nonempty { s : Set M // LinearIndependent R ((↑) : s → M) } :=
-    ⟨⟨∅, linearIndependent_empty _ _⟩⟩
+  have : Nonempty { s : Set M // LinearIndepOn R id s} := ⟨⟨∅, linearIndepOn_empty _ _⟩⟩
   rw [Module.rank_def, ciSup_eq_of_forall_le_of_forall_lt_exists_gt]
   · rintro ⟨s, hs⟩
     rw [Cardinal.mk_le_one_iff_set_subsingleton]
     apply subsingleton_of_subsingleton
   intro w hw
-  refine ⟨⟨{0}, ?_⟩, ?_⟩
-  · rw [linearIndependent_iff'ₛ]
-    subsingleton
-  · exact hw.trans_eq (Cardinal.mk_singleton _).symm
+  exact ⟨⟨{0}, linearIndepOn_of_subsingleton⟩, hw.trans_eq (Cardinal.mk_singleton _).symm⟩
 
 lemma rank_le_of_isSMulRegular {S : Type*} [CommSemiring S] [Algebra S R] [Module S M]
     [IsScalarTower S R M] (L L' : Submodule R M) {s : S} (hr : IsSMulRegular M s)

--- a/Mathlib/LinearAlgebra/Dimension/Basic.lean
+++ b/Mathlib/LinearAlgebra/Dimension/Basic.lean
@@ -374,7 +374,7 @@ theorem rank_subsingleton [Subsingleton R] : Module.rank R M = 1 := by
     rw [Cardinal.mk_le_one_iff_set_subsingleton]
     apply subsingleton_of_subsingleton
   intro w hw
-  exact ⟨⟨{0}, linearIndepOn_of_subsingleton⟩, hw.trans_eq (Cardinal.mk_singleton _).symm⟩
+  exact ⟨⟨{0}, LinearIndepOn.of_subsingleton⟩, hw.trans_eq (Cardinal.mk_singleton _).symm⟩
 
 lemma rank_le_of_isSMulRegular {S : Type*} [CommSemiring S] [Algebra S R] [Module S M]
     [IsScalarTower S R M] (L L' : Submodule R M) {s : S} (hr : IsSMulRegular M s)

--- a/Mathlib/LinearAlgebra/Dimension/Basic.lean
+++ b/Mathlib/LinearAlgebra/Dimension/Basic.lean
@@ -77,7 +77,7 @@ theorem cardinal_lift_le_rank {ι : Type w} {v : ι → M}
     (hv : LinearIndependent R v) :
     Cardinal.lift.{v} #ι ≤ Cardinal.lift.{w} (Module.rank R M) := by
   rw [Module.rank]
-  refine le_trans ?_ (lift_le.mpr <| le_ciSup (bddAbove_range _) ⟨_, hv.linearIndepOn_id_range⟩)
+  refine le_trans ?_ (lift_le.mpr <| le_ciSup (bddAbove_range _) ⟨_, hv.linearIndepOn_id⟩)
   exact lift_mk_le'.mpr ⟨(Equiv.ofInjective _ hv.injective).toEmbedding⟩
 
 lemma aleph0_le_rank {ι : Type w} [Infinite ι] {v : ι → M}

--- a/Mathlib/LinearAlgebra/Dimension/Constructions.lean
+++ b/Mathlib/LinearAlgebra/Dimension/Constructions.lean
@@ -58,7 +58,7 @@ theorem LinearIndepOn.union_of_quotient {M' : Submodule R M}
     (ht : LinearIndepOn R (Submodule.Quotient.mk (p := M')) t) : LinearIndepOn R id (s ∪ t) :=
   have h := (LinearIndependent.sum_elim_of_quotient (f := Set.embeddingOfSubset s M' hs)
     (LinearIndependent.of_comp M'.subtype (by simpa using hs')) Subtype.val ht)
-  h.linearIndepOn_id_range' <| by
+  h.linearIndepOn_id' <| by
     simp only [embeddingOfSubset_apply_coe, Sum.elim_range, Subtype.range_val]
 
 @[deprecated (since := "2025-02-16")] alias LinearIndependent.union_of_quotient :=
@@ -530,7 +530,7 @@ theorem Subalgebra.rank_bot : Module.rank F (⊥ : Subalgebra F E) = 1 :=
   (Subalgebra.toSubmoduleEquiv (⊥ : Subalgebra F E)).symm.rank_eq.trans <| by
     rw [Algebra.toSubmodule_bot, one_eq_span, rank_span_set, mk_singleton _]
     letI := Module.nontrivial F E
-    exact linearIndepOn_id_singleton _ one_ne_zero
+    exact LinearIndepOn.id_singleton _ one_ne_zero
 
 @[simp]
 theorem Subalgebra.finrank_bot : finrank F (⊥ : Subalgebra F E) = 1 :=

--- a/Mathlib/LinearAlgebra/Dimension/Constructions.lean
+++ b/Mathlib/LinearAlgebra/Dimension/Constructions.lean
@@ -456,14 +456,14 @@ theorem finrank_span_eq_card [Nontrivial R] {ι : Type*} [Fintype ι] {b : ι �
       rwa [← lift_inj, mk_range_eq_of_injective hb.injective, Cardinal.mk_fintype, lift_natCast,
         lift_eq_nat_iff] at this)
 
-theorem finrank_span_set_eq_card {s : Set M} [Fintype s] (hs : LinearIndependent R ((↑) : s → M)) :
+theorem finrank_span_set_eq_card {s : Set M} [Fintype s] (hs : LinearIndepOn R id s) :
     finrank R (span R s) = s.toFinset.card :=
   finrank_eq_of_rank_eq
     (by
       have : Module.rank R (span R s) = #s := rank_span_set hs
       rwa [Cardinal.mk_fintype, ← Set.toFinset_card] at this)
 
-theorem finrank_span_finset_eq_card {s : Finset M} (hs : LinearIndependent R ((↑) : s → M)) :
+theorem finrank_span_finset_eq_card {s : Finset M} (hs : LinearIndepOn R id (s : Set M)) :
     finrank R (span R (s : Set M)) = s.card := by
   convert finrank_span_set_eq_card (s := (s : Set M)) hs
   ext

--- a/Mathlib/LinearAlgebra/Dimension/Constructions.lean
+++ b/Mathlib/LinearAlgebra/Dimension/Constructions.lean
@@ -53,13 +53,16 @@ theorem LinearIndependent.sum_elim_of_quotient
   simp_rw [← Quotient.mk_eq_zero, ← mkQ_apply, map_finsupp_sum, map_smul, mkQ_apply] at this
   rw [linearIndependent_iff.mp hg _ this, Finsupp.sum_zero_index]
 
-theorem LinearIndependent.union_of_quotient {M' : Submodule R M}
-    {s : Set M} (hs : s ⊆ M') (hs' : LinearIndependent (ι := s) R Subtype.val) {t : Set M}
-    (ht : LinearIndependent (ι := t) R (Submodule.Quotient.mk (p := M') ∘ Subtype.val)) :
-    LinearIndependent (ι := (s ∪ t :)) R Subtype.val := by
-  refine (LinearIndependent.sum_elim_of_quotient (f := Set.embeddingOfSubset s M' hs)
-    (of_comp M'.subtype (by simpa using hs')) Subtype.val ht).to_subtype_range' ?_
-  simp only [embeddingOfSubset_apply_coe, Sum.elim_range, Subtype.range_val]
+theorem LinearIndepOn.union_of_quotient {M' : Submodule R M}
+    {s : Set M} (hs : s ⊆ M') (hs' : LinearIndepOn R id s) {t : Set M}
+    (ht : LinearIndepOn R (Submodule.Quotient.mk (p := M')) t) : LinearIndepOn R id (s ∪ t) :=
+  have h := (LinearIndependent.sum_elim_of_quotient (f := Set.embeddingOfSubset s M' hs)
+    (LinearIndependent.of_comp M'.subtype (by simpa using hs')) Subtype.val ht)
+  h.linearIndepOn_id_range' <| by
+    simp only [embeddingOfSubset_apply_coe, Sum.elim_range, Subtype.range_val]
+
+@[deprecated (since := "2025-02-16")] alias LinearIndependent.union_of_quotient :=
+  LinearIndepOn.union_of_quotient
 
 theorem rank_quotient_add_rank_le [Nontrivial R] (M' : Submodule R M) :
     Module.rank R (M ⧸ M') + Module.rank R M' ≤ Module.rank R M := by
@@ -527,7 +530,7 @@ theorem Subalgebra.rank_bot : Module.rank F (⊥ : Subalgebra F E) = 1 :=
   (Subalgebra.toSubmoduleEquiv (⊥ : Subalgebra F E)).symm.rank_eq.trans <| by
     rw [Algebra.toSubmodule_bot, one_eq_span, rank_span_set, mk_singleton _]
     letI := Module.nontrivial F E
-    exact linearIndependent_singleton one_ne_zero
+    exact linearIndepOn_id_singleton _ one_ne_zero
 
 @[simp]
 theorem Subalgebra.finrank_bot : finrank F (⊥ : Subalgebra F E) = 1 :=

--- a/Mathlib/LinearAlgebra/Dimension/DivisionRing.lean
+++ b/Mathlib/LinearAlgebra/Dimension/DivisionRing.lean
@@ -61,7 +61,7 @@ instance DivisionRing.hasRankNullity : HasRankNullity.{u₀} K where
   rank_quotient_add_rank := rank_quotient_add_rank_of_divisionRing
   exists_set_linearIndependent V _ _ := by
     let b := Module.Free.chooseBasis K V
-    refine ⟨range b, ?_, b.linearIndependent.to_subtype_range⟩
+    refine ⟨range b, ?_, b.linearIndependent.linearIndepOn_id_range⟩
     rw [← lift_injective.eq_iff, mk_range_eq_of_injective b.injective,
       Module.Free.rank_eq_card_chooseBasisIndex]
 

--- a/Mathlib/LinearAlgebra/Dimension/DivisionRing.lean
+++ b/Mathlib/LinearAlgebra/Dimension/DivisionRing.lean
@@ -61,7 +61,7 @@ instance DivisionRing.hasRankNullity : HasRankNullity.{u₀} K where
   rank_quotient_add_rank := rank_quotient_add_rank_of_divisionRing
   exists_set_linearIndependent V _ _ := by
     let b := Module.Free.chooseBasis K V
-    refine ⟨range b, ?_, b.linearIndependent.linearIndepOn_id_range⟩
+    refine ⟨range b, ?_, b.linearIndependent.linearIndepOn_id⟩
     rw [← lift_injective.eq_iff, mk_range_eq_of_injective b.injective,
       Module.Free.rank_eq_card_chooseBasisIndex]
 

--- a/Mathlib/LinearAlgebra/Dimension/Finite.lean
+++ b/Mathlib/LinearAlgebra/Dimension/Finite.lean
@@ -201,24 +201,24 @@ theorem setFinite [Module.Finite R M] {b : Set M}
 end LinearIndependent
 
 lemma exists_set_linearIndependent_of_lt_rank {n : Cardinal} (hn : n < Module.rank R M) :
-    ∃ s : Set M, #s = n ∧ LinearIndependent R ((↑) : s → M) := by
+    ∃ s : Set M, #s = n ∧ LinearIndepOn R id s := by
   obtain ⟨⟨s, hs⟩, hs'⟩ := exists_lt_of_lt_ciSup' (hn.trans_eq (Module.rank_def R M))
   obtain ⟨t, ht, ht'⟩ := le_mk_iff_exists_subset.mp hs'.le
-  exact ⟨t, ht', .mono ht hs⟩
+  exact ⟨t, ht', hs.mono ht⟩
 
 lemma exists_finset_linearIndependent_of_le_rank {n : ℕ} (hn : n ≤ Module.rank R M) :
-    ∃ s : Finset M, s.card = n ∧ LinearIndependent R ((↑) : s → M) := by
+    ∃ s : Finset M, s.card = n ∧ LinearIndepOn R id (s : Set M) := by
   have := nonempty_linearIndependent_set
   rcases hn.eq_or_lt with h | h
   · obtain ⟨⟨s, hs⟩, hs'⟩ := Cardinal.exists_eq_natCast_of_iSup_eq _
       (Cardinal.bddAbove_range _) _ (h.trans (Module.rank_def R M)).symm
     have : Finite s := lt_aleph0_iff_finite.mp (hs' ▸ nat_lt_aleph0 n)
     cases nonempty_fintype s
-    exact ⟨s.toFinset, by simpa using hs', by convert hs using 3 <;> exact Set.mem_toFinset⟩
+    refine ⟨s.toFinset, by simpa using hs', by simpa⟩
   · obtain ⟨s, hs, hs'⟩ := exists_set_linearIndependent_of_lt_rank h
     have : Finite s := lt_aleph0_iff_finite.mp (hs ▸ nat_lt_aleph0 n)
     cases nonempty_fintype s
-    exact ⟨s.toFinset, by simpa using hs, by convert hs' using 3 <;> exact Set.mem_toFinset⟩
+    exact ⟨s.toFinset, by simpa using hs, by simpa⟩
 
 lemma exists_linearIndependent_of_le_rank {n : ℕ} (hn : n ≤ Module.rank R M) :
     ∃ f : Fin n → M, LinearIndependent R f :=

--- a/Mathlib/LinearAlgebra/Dimension/FreeAndStrongRankCondition.lean
+++ b/Mathlib/LinearAlgebra/Dimension/FreeAndStrongRankCondition.lean
@@ -49,7 +49,7 @@ theorem le_rank_iff_exists_linearIndependent [Module.Free K V] {c : Cardinal} :
     obtain ⟨κ, t'⟩ := Module.Free.exists_basis (R := K) (M := V)
     let t := t'.reindexRange
     have : LinearIndepOn K id (Set.range t') := by
-      convert t.linearIndependent.linearIndepOn_id_range
+      convert t.linearIndependent.linearIndepOn_id
       ext
       simp [t]
     rw [← t.mk_eq_rank'', le_mk_iff_exists_subset] at h

--- a/Mathlib/LinearAlgebra/Dimension/FreeAndStrongRankCondition.lean
+++ b/Mathlib/LinearAlgebra/Dimension/FreeAndStrongRankCondition.lean
@@ -42,15 +42,16 @@ theorem Basis.ofRankEqZero_apply [Module.Free K V] {ι : Type*} [IsEmpty ι]
     (hV : Module.rank K V = 0) (i : ι) : Basis.ofRankEqZero hV i = 0 := rfl
 
 theorem le_rank_iff_exists_linearIndependent [Module.Free K V] {c : Cardinal} :
-    c ≤ Module.rank K V ↔ ∃ s : Set V, #s = c ∧ LinearIndependent K ((↑) : s → V) := by
+    c ≤ Module.rank K V ↔ ∃ s : Set V, #s = c ∧ LinearIndepOn K id s := by
   haveI := nontrivial_of_invariantBasisNumber K
   constructor
   · intro h
     obtain ⟨κ, t'⟩ := Module.Free.exists_basis (R := K) (M := V)
     let t := t'.reindexRange
-    have : LinearIndependent K ((↑) : Set.range t' → V) := by
-      convert t.linearIndependent
-      ext; exact (Basis.reindexRange_apply _ _).symm
+    have : LinearIndepOn K id (Set.range t') := by
+      convert t.linearIndependent.linearIndepOn_id_range
+      ext
+      simp [t]
     rw [← t.mk_eq_rank'', le_mk_iff_exists_subset] at h
     rcases h with ⟨s, hst, hsc⟩
     exact ⟨s, hsc, this.mono hst⟩

--- a/Mathlib/LinearAlgebra/Dimension/LinearMap.lean
+++ b/Mathlib/LinearAlgebra/Dimension/LinearMap.lean
@@ -96,7 +96,7 @@ theorem rank_finset_sum_le {η} (s : Finset η) (f : η → V →ₗ[K] V') :
 
 theorem le_rank_iff_exists_linearIndependent {c : Cardinal} {f : V →ₗ[K] V'} :
     c ≤ rank f ↔ ∃ s : Set V,
-    Cardinal.lift.{v'} #s = Cardinal.lift.{v} c ∧ LinearIndependent K (fun x : s => f x) := by
+    Cardinal.lift.{v'} #s = Cardinal.lift.{v} c ∧ LinearIndepOn K f s := by
   rcases f.rangeRestrict.exists_rightInverse_of_surjective f.range_rangeRestrict with ⟨g, hg⟩
   have fg : LeftInverse f.rangeRestrict g := LinearMap.congr_fun hg
   refine ⟨fun h => ?_, ?_⟩
@@ -105,13 +105,13 @@ theorem le_rank_iff_exists_linearIndependent {c : Cardinal} {f : V →ₗ[K] V'}
     replace fg : ∀ x, f (g x) = x := by
       intro x
       convert congr_arg Subtype.val (fg x)
-    replace si : LinearIndependent K fun x : s => f (g x) := by
+    replace si : LinearIndepOn K (fun x => f (g x)) s := by
       simpa only [fg] using si.map' _ (ker_subtype _)
-    exact si.image_of_comp s g f
+    exact si.image_of_comp
   · rintro ⟨s, hsc, si⟩
-    have : LinearIndependent K fun x : s => f.rangeRestrict x :=
+    have : LinearIndepOn K f.rangeRestrict s :=
       LinearIndependent.of_comp f.range.subtype (by convert si)
-    convert this.image.cardinal_le_rank
+    convert this.id_image.cardinal_le_rank
     rw [← Cardinal.lift_inj, ← hsc, Cardinal.mk_image_eq_of_injOn_lift]
     exact injOn_iff_injective.2 this.injective
 

--- a/Mathlib/LinearAlgebra/Dimension/Localization.lean
+++ b/Mathlib/LinearAlgebra/Dimension/Localization.lean
@@ -61,6 +61,7 @@ lemma IsLocalizedModule.lift_rank_eq :
   · exact (IsLocalizedModule.linearIndependent_lift p f hp hs).choose_spec.cardinal_lift_le_rank
   · choose sec hsec using IsLocalization.surj p (S := S)
     refine LinearIndependent.cardinal_lift_le_rank (ι := s) (v := fun i ↦ f i) ?_
+    rw [LinearIndepOn] at hs
     rw [linearIndependent_iff'] at hs ⊢
     intro t g hg i hit
     apply (IsLocalization.map_units S (sec (g i)).2).mul_left_injective
@@ -90,11 +91,11 @@ end
 
 variable (R M) in
 theorem exists_set_linearIndependent_of_isDomain [IsDomain R] :
-    ∃ s : Set M, #s = Module.rank R M ∧ LinearIndependent (ι := s) R Subtype.val := by
+    ∃ s : Set M, #s = Module.rank R M ∧ LinearIndepOn R id s := by
   obtain ⟨w, hw⟩ :=
     IsLocalizedModule.linearIndependent_lift R⁰ (LocalizedModule.mkLinearMap R⁰ M) le_rfl
       (Module.Free.chooseBasis (FractionRing R) (LocalizedModule R⁰ M)).linearIndependent
-  refine ⟨Set.range w, ?_, (linearIndependent_subtype_range hw.injective).mpr hw⟩
+  refine ⟨Set.range w, ?_, (linearIndepOn_id_range_iff hw.injective).mpr hw⟩
   apply Cardinal.lift_injective.{max u v}
   rw [Cardinal.mk_range_eq_of_injective hw.injective, ← Module.Free.rank_eq_card_chooseBasisIndex,
   IsLocalizedModule.lift_rank_eq (FractionRing R) R⁰ (LocalizedModule.mkLinearMap R⁰ M) le_rfl]

--- a/Mathlib/LinearAlgebra/Dimension/RankNullity.lean
+++ b/Mathlib/LinearAlgebra/Dimension/RankNullity.lean
@@ -44,7 +44,7 @@ See `DivisionRing.hasRankNullity` and `IsDomain.hasRankNullity`.
 @[pp_with_univ]
 class HasRankNullity (R : Type v) [inst : Ring R] : Prop where
   exists_set_linearIndependent : ∀ (M : Type u) [AddCommGroup M] [Module R M],
-    ∃ s : Set M, #s = Module.rank R M ∧ LinearIndependent (ι := s) R Subtype.val
+    ∃ s : Set M, #s = Module.rank R M ∧ LinearIndepOn R id s
   rank_quotient_add_rank : ∀ {M : Type u} [AddCommGroup M] [Module R M] (N : Submodule R M),
     Module.rank R (M ⧸ N) + Module.rank R N = Module.rank R M
 
@@ -88,9 +88,9 @@ theorem LinearMap.rank_eq_of_surjective {f : M →ₗ[R] M₁} (h : Surjective f
     Module.rank R M = Module.rank R M₁ + Module.rank R (LinearMap.ker f) := by
   rw [← rank_range_add_rank_ker f, ← rank_range_of_surjective f h]
 
-theorem exists_linearIndependent_of_lt_rank [StrongRankCondition R]
-    {s : Set M} (hs : LinearIndependent (ι := s) R Subtype.val) :
-    ∃ t, s ⊆ t ∧ #t = Module.rank R M ∧ LinearIndependent (ι := t) R Subtype.val := by
+theorem exists_linearIndepOn_of_lt_rank [StrongRankCondition R]
+    {s : Set M} (hs : LinearIndepOn R id s) :
+    ∃ t, s ⊆ t ∧ #t = Module.rank R M ∧ LinearIndepOn R id t := by
   obtain ⟨t, ht, ht'⟩ := exists_set_linearIndependent R (M ⧸ Submodule.span R s)
   choose sec hsec using Submodule.Quotient.mk_surjective (Submodule.span R s)
   have hsec' : Submodule.Quotient.mk ∘ sec = _root_.id := funext hsec
@@ -104,22 +104,25 @@ theorem exists_linearIndependent_of_lt_rank [StrongRankCondition R]
   · rw [Cardinal.mk_union_of_disjoint hst, Cardinal.mk_image_eq, ht,
       ← rank_quotient_add_rank (Submodule.span R s), add_comm, rank_span_set hs]
     exact HasLeftInverse.injective ⟨Submodule.Quotient.mk, hsec⟩
-  · apply LinearIndependent.union_of_quotient Submodule.subset_span hs
-    rwa [Function.comp_def, linearIndependent_image (hsec'.symm ▸ injective_id).injOn.image_of_comp,
+  · apply LinearIndepOn.union_of_quotient Submodule.subset_span hs
+    rwa [linearIndepOn_iff_image (hsec'.symm ▸ injective_id).injOn.image_of_comp,
       ← image_comp, hsec', image_id]
+
+@[deprecated (since := "2025-02-17")] alias
+    exists_linearIndependent_of_lt_rank := exists_linearIndepOn_of_lt_rank
 
 /-- Given a family of `n` linearly independent vectors in a space of dimension `> n`, one may extend
 the family by another vector while retaining linear independence. -/
 theorem exists_linearIndependent_cons_of_lt_rank [StrongRankCondition R] {n : ℕ} {v : Fin n → M}
     (hv : LinearIndependent R v) (h : n < Module.rank R M) :
     ∃ (x : M), LinearIndependent R (Fin.cons x v) := by
-  obtain ⟨t, h₁, h₂, h₃⟩ := exists_linearIndependent_of_lt_rank hv.to_subtype_range
+  obtain ⟨t, h₁, h₂, h₃⟩ := exists_linearIndepOn_of_lt_rank hv.linearIndepOn_id_range
   have : range v ≠ t := by
     refine fun e ↦ h.ne ?_
     rw [← e, ← lift_injective.eq_iff, mk_range_eq_of_injective hv.injective] at h₂
     simpa only [mk_fintype, Fintype.card_fin, lift_natCast, lift_id'] using h₂
   obtain ⟨x, hx, hx'⟩ := nonempty_of_ssubset (h₁.ssubset_of_ne this)
-  exact ⟨x, (linearIndependent_subtype_range (Fin.cons_injective_iff.mpr ⟨hx', hv.injective⟩)).mp
+  exact ⟨x, (linearIndepOn_id_range_iff (Fin.cons_injective_iff.mpr ⟨hx', hv.injective⟩)).mp
     (h₃.mono (Fin.range_cons x v ▸ insert_subset hx h₁))⟩
 
 /-- Given a family of `n` linearly independent vectors in a space of dimension `> n`, one may extend

--- a/Mathlib/LinearAlgebra/Dimension/RankNullity.lean
+++ b/Mathlib/LinearAlgebra/Dimension/RankNullity.lean
@@ -116,7 +116,7 @@ the family by another vector while retaining linear independence. -/
 theorem exists_linearIndependent_cons_of_lt_rank [StrongRankCondition R] {n : ℕ} {v : Fin n → M}
     (hv : LinearIndependent R v) (h : n < Module.rank R M) :
     ∃ (x : M), LinearIndependent R (Fin.cons x v) := by
-  obtain ⟨t, h₁, h₂, h₃⟩ := exists_linearIndepOn_of_lt_rank hv.linearIndepOn_id_range
+  obtain ⟨t, h₁, h₂, h₃⟩ := exists_linearIndepOn_of_lt_rank hv.linearIndepOn_id
   have : range v ≠ t := by
     refine fun e ↦ h.ne ?_
     rw [← e, ← lift_injective.eq_iff, mk_range_eq_of_injective hv.injective] at h₂

--- a/Mathlib/LinearAlgebra/Dimension/StrongRankCondition.lean
+++ b/Mathlib/LinearAlgebra/Dimension/StrongRankCondition.lean
@@ -292,8 +292,8 @@ theorem Basis.mk_eq_rank'' {ι : Type v} (v : Basis ι R M) : #ι = Module.rank 
     · apply le_ciSup (Cardinal.bddAbove_range _)
       exact
         ⟨Set.range v, by
+          rw [LinearIndepOn]
           convert v.reindexRange.linearIndependent
-          ext
           simp⟩
     · exact (Cardinal.mk_range_eq v v.injective).ge
   · apply ciSup_le'
@@ -342,8 +342,7 @@ theorem rank_span {v : ι → M} (hv : LinearIndependent R v) :
   rw [← Cardinal.lift_inj, ← (Basis.span hv).mk_eq_rank,
     Cardinal.mk_range_eq_of_injective (@LinearIndependent.injective ι R M v _ _ _ _ hv)]
 
-theorem rank_span_set {s : Set M} (hs : LinearIndependent R (fun x => x : s → M)) :
-    Module.rank R ↑(span R s) = #s := by
+theorem rank_span_set {s : Set M} (hs : LinearIndepOn R id s) : Module.rank R ↑(span R s) = #s := by
   rw [← @setOf_mem_eq _ s, ← Subtype.range_coe_subtype]
   exact rank_span hs
 
@@ -434,10 +433,10 @@ theorem rank_lt_aleph0 [Module.Finite R M] : Module.rank R M < ℵ₀ := by
 
 noncomputable instance {R M : Type*} [DivisionRing R] [AddCommGroup M] [Module R M]
     {s t : Set M} [Module.Finite R (span R t)]
-    (hs : LinearIndependent R ((↑) : s → M)) (hst : s ⊆ t) :
+    (hs : LinearIndepOn R id s) (hst : s ⊆ t) :
     Fintype (hs.extend hst) := by
   refine Classical.choice (Cardinal.lt_aleph0_iff_fintype.1 ?_)
-  rw [← rank_span_set (hs.linearIndependent_extend hst), hs.span_extend_eq_span]
+  rw [← rank_span_set (hs.linearIndepOn_extend hst), hs.span_extend_eq_span]
   exact Module.rank_lt_aleph0 ..
 
 /-- If `M` is finite, `finrank M = rank M`. -/

--- a/Mathlib/LinearAlgebra/Dimension/Torsion/Basic.lean
+++ b/Mathlib/LinearAlgebra/Dimension/Torsion/Basic.lean
@@ -23,8 +23,8 @@ theorem rank_quotient_eq_of_le_torsion {R M : Type*} [CommRing R] [AddCommGroup 
     rw [Module.rank]
     have := nonempty_linearIndependent_set R M
     refine ciSup_le fun ⟨s, hs⟩ ↦ LinearIndependent.cardinal_le_rank (v := (M'.mkQ ·)) ?_
-    rw [linearIndependent_iff'] at hs ⊢
-    simp_rw [← map_smul, ← map_sum, mkQ_apply, Quotient.mk_eq_zero]
+    rw [LinearIndepOn, linearIndependent_iff'] at hs
+    simp_rw [linearIndependent_iff', ← map_smul, ← map_sum, mkQ_apply, Quotient.mk_eq_zero]
     intro t g hg i hi
     obtain ⟨r, hg⟩ := hN hg
     simp_rw [Finset.smul_sum, Submonoid.smul_def, smul_smul] at hg

--- a/Mathlib/LinearAlgebra/FiniteDimensional/Defs.lean
+++ b/Mathlib/LinearAlgebra/FiniteDimensional/Defs.lean
@@ -200,12 +200,8 @@ theorem _root_.Submodule.eq_top_of_finrank_eq [FiniteDimensional K V] {S : Submo
   haveI : IsNoetherian K V := iff_fg.2 inferInstance
   set bS := Basis.ofVectorSpace K S with bS_eq
   have : LinearIndepOn K id (Subtype.val '' Basis.ofVectorSpaceIndex K S) := by
-    refine LinearIndepOn.id_image ?_
-
-    have := bS.linearIndependent
-    simp [bS] at this
-
-    -- have := LinearIndepOn.id_image (by simpa [bS] using bS.linearIndependent) (by simp)
+    simpa [bS] using bS.linearIndependent.linearIndepOn_id_range.image
+      (f := Submodule.subtype S) (by simp)
   set b := Basis.extend this with b_eq
   -- Porting note: `letI` now uses `this` so we need to give different names
   letI i1 : Fintype (this.extend _) :=
@@ -718,7 +714,7 @@ theorem finrank_eq_one_iff_of_nonzero (v : V) (nz : v ≠ 0) :
     finrank K V = 1 ↔ span K ({v} : Set V) = ⊤ :=
   ⟨fun h => by simpa using (basisSingleton Unit h v nz).span_eq, fun s =>
     finrank_eq_card_basis
-      (Basis.mk (linearIndependent_singleton nz)
+      (Basis.mk (linearIndepOn_id_singleton _ nz)
         (by
           convert s.ge  -- Porting note: added `.ge` to make things easier for `convert`
           simp))⟩

--- a/Mathlib/LinearAlgebra/FiniteDimensional/Defs.lean
+++ b/Mathlib/LinearAlgebra/FiniteDimensional/Defs.lean
@@ -199,9 +199,13 @@ theorem _root_.Submodule.eq_top_of_finrank_eq [FiniteDimensional K V] {S : Submo
     (h : finrank K S = finrank K V) : S = ⊤ := by
   haveI : IsNoetherian K V := iff_fg.2 inferInstance
   set bS := Basis.ofVectorSpace K S with bS_eq
-  have : LinearIndependent K ((↑) : ((↑) '' Basis.ofVectorSpaceIndex K S : Set V) → V) :=
-    LinearIndependent.image_subtype (f := Submodule.subtype S)
-      (by simpa [bS] using bS.linearIndependent) (by simp)
+  have : LinearIndepOn K id (Subtype.val '' Basis.ofVectorSpaceIndex K S) := by
+    refine LinearIndepOn.id_image ?_
+
+    have := bS.linearIndependent
+    simp [bS] at this
+
+    -- have := LinearIndepOn.id_image (by simpa [bS] using bS.linearIndependent) (by simp)
   set b := Basis.extend this with b_eq
   -- Porting note: `letI` now uses `this` so we need to give different names
   letI i1 : Fintype (this.extend _) :=

--- a/Mathlib/LinearAlgebra/FiniteDimensional/Defs.lean
+++ b/Mathlib/LinearAlgebra/FiniteDimensional/Defs.lean
@@ -714,7 +714,7 @@ theorem finrank_eq_one_iff_of_nonzero (v : V) (nz : v ≠ 0) :
     finrank K V = 1 ↔ span K ({v} : Set V) = ⊤ :=
   ⟨fun h => by simpa using (basisSingleton Unit h v nz).span_eq, fun s =>
     finrank_eq_card_basis
-      (Basis.mk (linearIndepOn_id_singleton _ nz)
+      (Basis.mk (LinearIndepOn.id_singleton _ nz)
         (by
           convert s.ge  -- Porting note: added `.ge` to make things easier for `convert`
           simp))⟩

--- a/Mathlib/LinearAlgebra/FiniteDimensional/Defs.lean
+++ b/Mathlib/LinearAlgebra/FiniteDimensional/Defs.lean
@@ -200,7 +200,7 @@ theorem _root_.Submodule.eq_top_of_finrank_eq [FiniteDimensional K V] {S : Submo
   haveI : IsNoetherian K V := iff_fg.2 inferInstance
   set bS := Basis.ofVectorSpace K S with bS_eq
   have : LinearIndepOn K id (Subtype.val '' Basis.ofVectorSpaceIndex K S) := by
-    simpa [bS] using bS.linearIndependent.linearIndepOn_id_range.image
+    simpa [bS] using bS.linearIndependent.linearIndepOn_id.image
       (f := Submodule.subtype S) (by simp)
   set b := Basis.extend this with b_eq
   -- Porting note: `letI` now uses `this` so we need to give different names

--- a/Mathlib/LinearAlgebra/FreeModule/PID.lean
+++ b/Mathlib/LinearAlgebra/FreeModule/PID.lean
@@ -334,7 +334,7 @@ noncomputable def Module.basisOfFiniteTypeTorsionFree [Fintype ι] {s : ι → M
     (hs : span R (range s) = ⊤) [NoZeroSMulDivisors R M] : Σn : ℕ, Basis (Fin n) R M := by
   classical
     -- We define `N` as the submodule spanned by a maximal linear independent subfamily of `s`
-    have := exists_maximal_independent R s
+    have := exists_maximal_linearIndepOn R s
     let I : Set ι := this.choose
     obtain
       ⟨indepI : LinearIndependent R (s ∘ (fun x => x) : I → M), hI :

--- a/Mathlib/LinearAlgebra/LinearIndependent.lean
+++ b/Mathlib/LinearAlgebra/LinearIndependent.lean
@@ -131,6 +131,7 @@ def delabLinearIndependent : Delab :=
     else
       withNaryArg 0 do return (← read).optionsPerPos.setBool (← getPos) `pp.analysis.namedArg true
     withTheReader Context ({· with optionsPerPos}) delab
+
 /-- `LinearIndepOn R v s` states that the vectors in the family `v` that are indexed
 by the elements of `s` are linearly independent over `R`. -/
 def LinearIndepOn (s : Set ι) : Prop := LinearIndependent R (fun x : s ↦ v x)
@@ -186,6 +187,9 @@ theorem linearIndepOn_empty : LinearIndepOn R v ∅ :=
 
 theorem linearIndependent_set_coe_iff :
     LinearIndependent R (fun x : s ↦ v x) ↔ LinearIndepOn R v s := Iff.rfl
+
+@[deprecated (since := "2025-02-20")] alias
+  linearIndependent_set_subtype := linearIndependent_set_coe_iff
 
 theorem linearIndependent_subtype_iff {s : Set M} :
     LinearIndependent R (Subtype.val : s → M) ↔ LinearIndepOn R id s := Iff.rfl

--- a/Mathlib/LinearAlgebra/LinearIndependent.lean
+++ b/Mathlib/LinearAlgebra/LinearIndependent.lean
@@ -1673,39 +1673,54 @@ lemma exists_linearIndependent' (v : ι → V) :
 
 variable {K t}
 
-/-- `LinearIndependent.extend` adds vectors to a linear independent set `s ⊆ t` until it spans
-all elements of `t`. -/
-noncomputable def LinearIndependent.extend (hs : LinearIndependent K (fun x => x : s → V))
-    (hst : s ⊆ t) : Set V :=
+/-- `LinearIndepOn.extend` adds vectors to a linear independent set `s ⊆ t` until it spans
+all elements of `t`.
+TODO - generalize the lemmas below to functions that aren't the identity. -/
+noncomputable def LinearIndepOn.extend (hs : LinearIndepOn K id s) (hst : s ⊆ t) : Set V :=
   Classical.choose (exists_linearIndepOn_id_extension hs hst)
 
-theorem LinearIndependent.extend_subset (hs : LinearIndependent K (fun x => x : s → V))
-    (hst : s ⊆ t) : hs.extend hst ⊆ t :=
+@[deprecated (since := "2025-02-15")] alias LinearIndependent.extend := LinearIndepOn.extend
+
+theorem LinearIndepOn.extend_subset (hs : LinearIndepOn K id s) (hst : s ⊆ t) : hs.extend hst ⊆ t :=
   let ⟨hbt, _hsb, _htb, _hli⟩ := Classical.choose_spec (exists_linearIndepOn_id_extension hs hst)
   hbt
 
-theorem LinearIndependent.subset_extend (hs : LinearIndependent K (fun x => x : s → V))
-    (hst : s ⊆ t) : s ⊆ hs.extend hst :=
+@[deprecated (since := "2025-02-15")] alias
+  LinearIndependent.extend_subset := LinearIndepOn.extend_subset
+
+theorem LinearIndepOn.subset_extend (hs : LinearIndepOn K id s) (hst : s ⊆ t) : s ⊆ hs.extend hst :=
   let ⟨_hbt, hsb, _htb, _hli⟩ := Classical.choose_spec (exists_linearIndepOn_id_extension hs hst)
   hsb
 
-theorem LinearIndependent.subset_span_extend (hs : LinearIndependent K (fun x => x : s → V))
-    (hst : s ⊆ t) : t ⊆ span K (hs.extend hst) :=
+@[deprecated (since := "2025-02-15")] alias
+  LinearIndependent.subset_extend := LinearIndepOn.subset_extend
+
+theorem LinearIndepOn.subset_span_extend (hs : LinearIndepOn K id s) (hst : s ⊆ t) :
+    t ⊆ span K (hs.extend hst) :=
   let ⟨_hbt, _hsb, htb, _hli⟩ := Classical.choose_spec (exists_linearIndepOn_id_extension hs hst)
   htb
 
-theorem LinearIndependent.span_extend_eq_span (hs : LinearIndependent K (fun x => x : s → V))
-    (hst : s ⊆ t) : span K (hs.extend hst) = span K t :=
+@[deprecated (since := "2025-02-15")] alias
+  LinearIndependent.subset_span_extend := LinearIndepOn.subset_span_extend
+
+theorem LinearIndepOn.span_extend_eq_span (hs : LinearIndepOn K id s) (hst : s ⊆ t) :
+    span K (hs.extend hst) = span K t :=
   le_antisymm (span_mono (hs.extend_subset hst)) (span_le.2 (hs.subset_span_extend hst))
 
-theorem LinearIndependent.linearIndependent_extend (hs : LinearIndependent K (fun x => x : s → V))
-    (hst : s ⊆ t) : LinearIndependent K ((↑) : hs.extend hst → V) :=
+@[deprecated (since := "2025-02-15")] alias
+  LinearIndependent.span_extend_eq_span := LinearIndepOn.span_extend_eq_span
+
+theorem LinearIndepOn.linearIndepOn_extend (hs : LinearIndepOn K id s) (hst : s ⊆ t) :
+    LinearIndepOn K id (hs.extend hst) :=
   let ⟨_hbt, _hsb, _htb, hli⟩ := Classical.choose_spec (exists_linearIndepOn_id_extension hs hst)
   hli
 
+@[deprecated (since := "2025-02-15")] alias
+  LinearIndependent.linearIndependent_extend := LinearIndepOn.linearIndepOn_extend
+
 -- TODO(Mario): rewrite?
-theorem exists_of_linearIndependent_of_finite_span {t : Finset V}
-    (hs : LinearIndependent K (fun x => x : s → V)) (hst : s ⊆ (span K ↑t : Submodule K V)) :
+theorem exists_of_linearIndepOn_of_finite_span {t : Finset V}
+    (hs : LinearIndepOn K id s) (hst : s ⊆ (span K ↑t : Submodule K V)) :
     ∃ t' : Finset V, ↑t' ⊆ s ∪ ↑t ∧ s ⊆ ↑t' ∧ t'.card = t.card := by
   classical
   have :
@@ -1770,14 +1785,17 @@ theorem exists_of_linearIndependent_of_finite_span {t : Finset V}
     ⟨u, Subset.trans h.1 (by simp +contextual [subset_def, and_imp, or_imp]),
       h.2.1, by simp only [h.2.2, eq]⟩
 
+@[deprecated (since := "2025-02-15")] alias
+  exists_of_linearIndependent_of_finite_span := exists_of_linearIndepOn_of_finite_span
+
 theorem exists_finite_card_le_of_finite_of_linearIndependent_of_span (ht : t.Finite)
-    (hs : LinearIndependent K (fun x => x : s → V)) (hst : s ⊆ span K t) :
+    (hs : LinearIndepOn K id s) (hst : s ⊆ span K t) :
     ∃ h : s.Finite, h.toFinset.card ≤ ht.toFinset.card :=
   have : s ⊆ (span K ↑ht.toFinset : Submodule K V) := by simpa
-  let ⟨u, _hust, hsu, Eq⟩ := exists_of_linearIndependent_of_finite_span hs this
+  let ⟨u, _hust, hsu, Eq⟩ := exists_of_linearIndepOn_of_finite_span hs this
   have : s.Finite := u.finite_toSet.subset hsu
   ⟨this, by rw [← Eq]; exact Finset.card_le_card <| Finset.coe_subset.mp <| by simp [hsu]⟩
 
 end Module
 
-set_option linter.style.longFile 1800
+set_option linter.style.longFile 2000

--- a/Mathlib/LinearAlgebra/LinearIndependent.lean
+++ b/Mathlib/LinearAlgebra/LinearIndependent.lean
@@ -441,6 +441,13 @@ theorem LinearIndependent.linearIndepOn_id_range (i : LinearIndependent R v) :
 @[deprecated (since := "2025-02-14")] alias
   LinearIndependent.coe_range := LinearIndependent.linearIndepOn_id_range
 
+theorem LinearIndependent.linearIndepOn_id_range' (hv : LinearIndependent R v) {t : Set M}
+    (ht : Set.range v = t) : LinearIndepOn R id t :=
+  ht ▸ hv.linearIndepOn_id_range
+
+@[deprecated (since := "2025-02-16")] alias LinearIndependent.to_subtype_range' :=
+    LinearIndependent.linearIndepOn_id_range'
+
 theorem LinearIndepOn.comp_of_image {s : Set ι'} {f : ι' → ι} (h : LinearIndepOn R v (f '' s))
     (hf : InjOn f s) : LinearIndepOn R (v ∘ f) s :=
   LinearIndependent.comp h _ (Equiv.Set.imageOfInjOn _ _ hf).injective

--- a/Mathlib/LinearAlgebra/LinearIndependent.lean
+++ b/Mathlib/LinearAlgebra/LinearIndependent.lean
@@ -165,8 +165,14 @@ variable (R v) in
 theorem linearIndepOn_empty : LinearIndepOn R v ∅ :=
   linearIndependent_empty_type ..
 
-theorem linearIndependent_set_subtype {s : Set ι} :
+theorem linearIndependent_set_coe_iff :
     LinearIndependent R (fun x : s ↦ v x) ↔ LinearIndepOn R v s := Iff.rfl
+
+theorem linearIndependent_subtype_iff {s : Set M} :
+    LinearIndependent R (Subtype.val : s → M) ↔ LinearIndepOn R id s := Iff.rfl
+
+theorem linearIndependent_comp_subtype_iff :
+    LinearIndependent R (v ∘ Subtype.val : s → M) ↔ LinearIndepOn R v s := Iff.rfl
 
 /-- A subfamily of a linearly independent family (i.e., a composition with an injective map) is a
 linearly independent family. -/
@@ -177,7 +183,8 @@ theorem LinearIndependent.comp (h : LinearIndependent R v) (f : ι' → ι) (hf 
 /-- A set of linearly independent vectors in a module `M` over a semiring `K` is also linearly
 independent over a subring `R` of `K`.
 The implementation uses minimal assumptions about the relationship between `R`, `K` and `M`.
-The version where `K` is an `R`-algebra is `LinearIndependent.restrict_scalars_algebras`. -/
+The version where `K` is an `R`-algebra is `LinearIndependent.restrict_scalars_algebras`.
+TODO : `LinearIndepOn` version.  -/
 theorem LinearIndependent.restrict_scalars [Semiring K] [SMulWithZero R K] [Module K M]
     [IsScalarTower R K M] (hinj : Injective fun r : R ↦ r • (1 : K))
     (li : LinearIndependent K v) : LinearIndependent R v := by
@@ -295,7 +302,8 @@ theorem linearIndependent_iff_finset_linearIndependent :
       (by simpa only [← s.sum_coe_sort] using eq) ⟨i, hi⟩⟩
 
 /-- If `v` is an injective family of vectors such that `f ∘ v` is linearly independent, then `v`
-    spans a submodule disjoint from the kernel of `f` -/
+    spans a submodule disjoint from the kernel of `f`.
+TODO : `LinearIndepOn` version. -/
 theorem Submodule.range_ker_disjoint {f : M →ₗ[R] M'}
     (hv : LinearIndependent R (f ∘ v)) :
     Disjoint (span R (range v)) (LinearMap.ker f) := by
@@ -308,7 +316,8 @@ theorem Submodule.range_ker_disjoint {f : M →ₗ[R] M'}
 such that they are both injective, and compatible with the scalar
 multiplications on `M` and `M'`, then `j` sends linearly independent families of vectors to
 linearly independent families of vectors. As a special case, taking `R = R'`
-it is `LinearIndependent.map_injOn`. -/
+it is `LinearIndependent.map_injOn`.
+TODO : `LinearIndepOn` version.  -/
 theorem LinearIndependent.map_of_injective_injectiveₛ {R' M' : Type*}
     [Semiring R'] [AddCommMonoid M'] [Module R' M'] (hv : LinearIndependent R v)
     (i : R' → R) (j : M →+ M') (hi : Injective i) (hj : Injective j)
@@ -322,7 +331,8 @@ theorem LinearIndependent.map_of_injective_injectiveₛ {R' M' : Type*}
 and `j : M →+ M'` is an injective monoid map, such that the scalar multiplications
 on `M` and `M'` are compatible, then `j` sends linearly independent families
 of vectors to linearly independent families of vectors. As a special case, taking `R = R'`
-it is `LinearIndependent.map_injOn`. -/
+it is `LinearIndependent.map_injOn`.
+TODO : `LinearIndepOn` version.  -/
 theorem LinearIndependent.map_of_surjective_injectiveₛ {R' M' : Type*}
     [Semiring R'] [AddCommMonoid M'] [Module R' M'] (hv : LinearIndependent R v)
     (i : R → R') (j : M →+ M') (hi : Surjective i) (hj : Injective j)
@@ -1195,24 +1205,6 @@ theorem LinearIndepOn.id_union {s t : Set M} (hs : LinearIndepOn R id s)
 
 @[deprecated (since := "2025-02-14")] alias LinearIndependent.union := LinearIndepOn.id_union
 
--- theorem linearIndependent_iUnion_finite_subtype {ι : Type*} {f : ι → Set M}
---     (hl : ∀ i, LinearIndependent R (fun x => x : f i → M))
---     (hd : ∀ i, ∀ t : Set ι, t.Finite → i ∉ t → Disjoint (span R (f i)) (⨆ i ∈ t, span R (f i))) :
---     LinearIndependent R (fun x => x : (⋃ i, f i) → M) := by
---   classical
---   rw [iUnion_eq_iUnion_finset f]
---   apply linearIndependent_iUnion_of_directed
---   · apply directed_of_isDirected_le
---     exact fun t₁ t₂ ht => iUnion_mono fun i => iUnion_subset_iUnion_const fun h => ht h
---   intro t
---   induction t using Finset.induction_on with
---   | empty => exact (linearIndependent_empty R M).mono (by simp)
---   | @insert i s his ih =>
---     rw [Finset.set_biUnion_insert]
---     refine (hl _).union ih ?_
---     rw [span_iUnion₂]
---     exact hd i s s.finite_toSet his
-/-- TODO : generalize this to non-identity functions. -/
 theorem linearIndepOn_id_iUnion_finite {f : ι → Set M} (hl : ∀ i, LinearIndepOn R id (f i))
     (hd : ∀ i, ∀ t : Set ι, t.Finite → i ∉ t → Disjoint (span R (f i)) (⨆ i ∈ t, span R (f i))) :
     LinearIndepOn R id (⋃ i, f i) := by

--- a/Mathlib/LinearAlgebra/LinearIndependent.lean
+++ b/Mathlib/LinearAlgebra/LinearIndependent.lean
@@ -452,11 +452,11 @@ theorem LinearIndepOn.image_of_comp (f : ι → ι') (g : ι' → M) (hs : Linea
 @[deprecated (since := "2025-02-14")] alias
   LinearIndependent.image_of_comp := LinearIndepOn.image_of_comp
 
-theorem LinearIndepOn.image {f : ι → M} (hs : LinearIndepOn R f s) : LinearIndepOn R id (f '' s) :=
-  LinearIndepOn.image_of_comp f id hs
+theorem LinearIndepOn.id_image (hs : LinearIndepOn R v s) : LinearIndepOn R id (v '' s) :=
+  LinearIndepOn.image_of_comp v id hs
 
 @[deprecated (since := "2025-02-14")] alias
-  LinearIndependent.image := LinearIndepOn.image
+  LinearIndependent.image := LinearIndepOn.id_image
 
 theorem LinearIndependent.group_smul {G : Type*} [hG : Group G] [DistribMulAction G R]
     [DistribMulAction G M] [IsScalarTower G R M] [SMulCommClass G R M] {v : ι → M}
@@ -505,15 +505,12 @@ theorem linearIndependent_finset_map_embedding_subtype (s : Set M)
     LinearIndependent R ((↑) : Finset.map (Embedding.subtype s) t → M) :=
   li.comp (fun _ ↦ ⟨_, _⟩) <| by intro; aesop
 
-section Subtype
+section Indexed
 
-/-! The following lemmas use the subtype defined by a set in `M` as the index set `ι`. -/
-
-theorem linearIndependent_comp_subtypeₛ {s : Set ι} :
-    LinearIndependent R (v ∘ (↑) : s → M) ↔
+theorem linearIndepOn_iffₛ : LinearIndepOn R v s ↔
       ∀ f ∈ Finsupp.supported R R s, ∀ g ∈ Finsupp.supported R R s,
         Finsupp.linearCombination R v f = Finsupp.linearCombination R v g → f = g := by
-  simp only [linearIndependent_iffₛ, (· ∘ ·), Finsupp.mem_supported,
+  simp only [LinearIndepOn, linearIndependent_iffₛ, (· ∘ ·), Finsupp.mem_supported,
     Finsupp.linearCombination_apply, Set.subset_def, Finset.mem_coe]
   refine ⟨fun h l₁ h₁ l₂ h₂ eq ↦ (Finsupp.subtypeDomain_eq_iff h₁ h₂).1 <| h _ _ <|
     (Finsupp.sum_subtypeDomain_index h₁).trans eq ▸ (Finsupp.sum_subtypeDomain_index h₂).symm,
@@ -524,80 +521,89 @@ theorem linearIndependent_comp_subtypeₛ {s : Set ι} :
   rwa [Finsupp.sum_mapDomain_index, Finsupp.sum_mapDomain_index] <;>
     intros <;> simp only [zero_smul, add_smul]
 
-theorem linearDependent_comp_subtype'ₛ {s : Set ι} :
-    ¬LinearIndependent R (v ∘ (↑) : s → M) ↔
+@[deprecated (since := "2025-02-15")] alias linearIndependent_comp_subtypeₛ := linearIndepOn_iffₛ
+
+theorem linearDepOn_iff'ₛ : ¬LinearIndepOn R v s ↔
       ∃ f g : ι →₀ R, f ∈ Finsupp.supported R R s ∧ g ∈ Finsupp.supported R R s ∧
         Finsupp.linearCombination R v f = Finsupp.linearCombination R v g ∧ f ≠ g := by
-  simp [linearIndependent_comp_subtypeₛ, and_left_comm]
+  simp [linearIndepOn_iffₛ, and_left_comm]
 
-/-- A version of `linearDependent_comp_subtype'ₛ` with `Finsupp.linearCombination` unfolded. -/
-theorem linearDependent_comp_subtypeₛ {s : Set ι} :
-    ¬LinearIndependent R (v ∘ (↑) : s → M) ↔
+@[deprecated (since := "2025-02-15")] alias linearDependent_comp_subtype'ₛ := linearDepOn_iff'ₛ
+
+/-- A version of `linearDepOn_iff'ₛ` with `Finsupp.linearCombination` unfolded. -/
+theorem linearDepOn_iffₛ : ¬LinearIndepOn R v s ↔
       ∃ f g : ι →₀ R, f ∈ Finsupp.supported R R s ∧ g ∈ Finsupp.supported R R s ∧
         ∑ i ∈ f.support, f i • v i = ∑ i ∈ g.support, g i • v i ∧ f ≠ g :=
-  linearDependent_comp_subtype'ₛ
+  linearDepOn_iff'ₛ
 
-theorem linearIndependent_subtypeₛ {s : Set M} :
-    LinearIndependent R (fun x ↦ x : s → M) ↔
-      ∀ f ∈ Finsupp.supported R R s, ∀ g ∈ Finsupp.supported R R s,
-        Finsupp.linearCombination R id f = Finsupp.linearCombination R id g → f = g :=
-  linearIndependent_comp_subtypeₛ (v := id)
+@[deprecated (since := "2025-02-15")] alias linearDependent_comp_subtypeₛ := linearDepOn_iffₛ
 
-theorem linearIndependent_restrict_iff {s : Set ι} :
-    LinearIndependent R (s.restrict v) ↔
-      Injective (Finsupp.linearCombinationOn ι M R v s) := by
-  simp [LinearIndependent, Finsupp.linearCombination_restrict]
+@[deprecated (since := "2025-02-15")] alias linearIndependent_subtypeₛ := linearIndepOn_iffₛ
 
-theorem linearIndependent_iff_linearCombinationOnₛ {s : Set M} :
-    LinearIndependent R (fun x ↦ x : s → M) ↔
-      Injective (Finsupp.linearCombinationOn M M R id s) :=
-  linearIndependent_restrict_iff (v := id)
+theorem linearIndependent_restrict_iff :
+    LinearIndependent R (s.restrict v) ↔ LinearIndepOn R v s := Iff.rfl
 
-theorem LinearIndependent.restrict_of_comp_subtype {s : Set ι}
-    (hs : LinearIndependent R (v ∘ (↑) : s → M)) : LinearIndependent R (s.restrict v) :=
+theorem LinearIndepOn.linearIndependent_restrict (hs : LinearIndepOn R v s) :
+    LinearIndependent R (s.restrict v) :=
   hs
 
-theorem LinearIndependent.mono {t s : Set M} (h : t ⊆ s)
-    (hs : LinearIndependent R (fun x ↦ x : s → M)) : LinearIndependent R (fun x ↦ x : t → M) :=
-  hs.comp _ (Set.inclusion_injective h)
+@[deprecated (since := "2025-02-15")] alias LinearIndependent.restrict_of_comp_subtype :=
+    LinearIndepOn.linearIndependent_restrict
+
+theorem linearIndepOn_iff_linearCombinationOnₛ :
+    LinearIndepOn R v s ↔ Injective (Finsupp.linearCombinationOn ι M R v s) := by
+  rw [← linearIndependent_restrict_iff]
+  simp [LinearIndependent, Finsupp.linearCombination_restrict]
+
+@[deprecated (since := "2025-02-15")] alias
+  linearIndependent_iff_linearCombinationOnₛ := linearIndepOn_iff_linearCombinationOnₛ
 
 theorem LinearIndepOn.mono {t s : Set ι} (hs : LinearIndepOn R v s) (h : t ⊆ s) :
     LinearIndepOn R v t :=
   hs.comp _ <| Set.inclusion_injective h
 
-theorem linearIndependent_of_finite (s : Set M)
-    (H : ∀ t ⊆ s, Set.Finite t → LinearIndependent R (fun x ↦ x : t → M)) :
-    LinearIndependent R (fun x ↦ x : s → M) :=
-  linearIndependent_subtypeₛ.2 fun f hf g hg eq ↦
-    linearIndependent_subtypeₛ.1 (H _ (union_subset hf hg) <| (Finset.finite_toSet _).union <|
+@[deprecated (since := "2025-02-15")] alias LinearIndependent.mono := LinearIndepOn.mono
+
+theorem linearIndepOn_of_finite (s : Set ι) (H : ∀ t ⊆ s, Set.Finite t → LinearIndepOn R v t) :
+    LinearIndepOn R v s :=
+  linearIndepOn_iffₛ.2 fun f hf g hg eq ↦
+    linearIndepOn_iffₛ.1 (H _ (union_subset hf hg) <| (Finset.finite_toSet _).union <|
       Finset.finite_toSet _) f Set.subset_union_left g Set.subset_union_right eq
 
-theorem linearIndependent_iUnion_of_directed {η : Type*} {s : η → Set M} (hs : Directed (· ⊆ ·) s)
-    (h : ∀ i, LinearIndependent R (fun x ↦ x : s i → M)) :
-    LinearIndependent R (fun x ↦ x : (⋃ i, s i) → M) := by
+@[deprecated (since := "2025-02-15")] alias linearIndependent_of_finite := linearIndepOn_of_finite
+
+theorem linearIndepOn_iUnion_of_directed {η : Type*} {s : η → Set ι} (hs : Directed (· ⊆ ·) s)
+    (h : ∀ i, LinearIndepOn R v (s i)) : LinearIndepOn R v (⋃ i, s i) := by
   by_cases hη : Nonempty η
-  · refine linearIndependent_of_finite (⋃ i, s i) fun t ht ft => ?_
+  · refine linearIndepOn_of_finite (⋃ i, s i) fun t ht ft => ?_
     rcases finite_subset_iUnion ft ht with ⟨I, fi, hI⟩
     rcases hs.finset_le fi.toFinset with ⟨i, hi⟩
     exact (h i).mono (Subset.trans hI <| iUnion₂_subset fun j hj => hi j (fi.mem_toFinset.2 hj))
-  · refine (linearIndependent_empty R M).mono (t := iUnion (s ·)) ?_
+  · refine (linearIndepOn_empty R v).mono (t := iUnion (s ·)) ?_
     rintro _ ⟨_, ⟨i, _⟩, _⟩
     exact hη ⟨i⟩
 
-theorem linearIndependent_sUnion_of_directed {s : Set (Set M)} (hs : DirectedOn (· ⊆ ·) s)
-    (h : ∀ a ∈ s, LinearIndependent R ((↑) : ((a : Set M) : Type _) → M)) :
-    LinearIndependent R (fun x => x : ⋃₀ s → M) := by
+@[deprecated (since := "2025-02-15")] alias
+    linearIndependent_iUnion_of_directed := linearIndepOn_iUnion_of_directed
+
+theorem linearIndepOn_sUnion_of_directed {s : Set (Set ι)} (hs : DirectedOn (· ⊆ ·) s)
+    (h : ∀ a ∈ s, LinearIndepOn R v a) : LinearIndepOn R v (⋃₀ s) := by
   rw [sUnion_eq_iUnion]
-  exact linearIndependent_iUnion_of_directed hs.directed_val (by simpa using h)
+  exact linearIndepOn_iUnion_of_directed hs.directed_val (by simpa using h)
 
-theorem linearIndependent_biUnion_of_directed {η} {s : Set η} {t : η → Set M}
-    (hs : DirectedOn (t ⁻¹'o (· ⊆ ·)) s) (h : ∀ a ∈ s, LinearIndependent R (fun x ↦ x : t a → M)) :
-    LinearIndependent R (fun x ↦ x : (⋃ a ∈ s, t a) → M) := by
+@[deprecated (since := "2025-02-15")] alias
+    linearIndependent_sUnion_of_directed := linearIndepOn_sUnion_of_directed
+
+theorem linearIndepOn_biUnion_of_directed {η} {s : Set η} {t : η → Set ι}
+    (hs : DirectedOn (t ⁻¹'o (· ⊆ ·)) s) (h : ∀ a ∈ s, LinearIndepOn R v (t a)) :
+    LinearIndepOn R v (⋃ a ∈ s, t a) := by
   rw [biUnion_eq_iUnion]
-  exact
-    linearIndependent_iUnion_of_directed (directed_comp.2 <| hs.directed_val) (by simpa using h)
+  exact linearIndepOn_iUnion_of_directed (directed_comp.2 <| hs.directed_val) (by simpa using h)
 
-end Subtype
+@[deprecated (since := "2025-02-15")] alias
+    linearIndependent_biUnion_of_directed := linearIndepOn_biUnion_of_directed
+
+end Indexed
 
 /-- Linear independent families are injective, even if you multiply either side. -/
 theorem LinearIndependent.eq_of_smul_apply_eq_smul_apply {M : Type*} [AddCommMonoid M] [Module R M]
@@ -769,7 +775,7 @@ open LinearMap Finsupp
 
 theorem LinearIndepOn.id_imageₛ {s : Set M} {f : M →ₗ[R] M'} (hs : LinearIndepOn R id s)
     (hf_inj : Set.InjOn f (span R s)) : LinearIndepOn R id (f '' s) :=
-  image <| hs.map_injOn f (by simpa using hf_inj)
+  id_image <| hs.map_injOn f (by simpa using hf_inj)
 
 @[deprecated (since := "2025-02-14")] alias
     LinearIndependent.image_subtypeₛ := LinearIndepOn.id_imageₛ
@@ -836,17 +842,16 @@ theorem LinearIndependent.maximal_iff {ι : Type w} {R : Type u} [Semiring R] [N
 
 variable (R)
 
-theorem exists_maximal_independent' (s : ι → M) :
-    ∃ I : Set ι,
-      (LinearIndependent R fun x : I => s x) ∧
-        ∀ J : Set ι, I ⊆ J → (LinearIndependent R fun x : J => s x) → I = J := by
-  let indep : Set ι → Prop := fun I => LinearIndependent R (s ∘ (↑) : I → M)
+/-- TODO : refactor to use `Maximal`. -/
+theorem exists_maximal_linearIndepOn' (v : ι → M) :
+    ∃ s : Set ι, (LinearIndepOn R v s) ∧ ∀ t : Set ι, s ⊆ t → (LinearIndepOn R v t) → s = t := by
+  let indep : Set ι → Prop := fun s => LinearIndepOn R v s
   let X := { I : Set ι // indep I }
   let r : X → X → Prop := fun I J => I.1 ⊆ J.1
   have key : ∀ c : Set X, IsChain r c → indep (⋃ (I : X) (_ : I ∈ c), I) := by
     intro c hc
     dsimp [indep]
-    rw [linearIndependent_comp_subtypeₛ]
+    rw [linearIndepOn_iffₛ]
     intro f hfsupp g hgsupp hsum
     rcases eq_empty_or_nonempty c with (rfl | hn)
     · rw [show f = 0 by simpa using hfsupp, show g = 0 by simpa using hgsupp]
@@ -855,13 +860,16 @@ theorem exists_maximal_independent' (s : ι → M) :
     obtain ⟨I, _I_mem, hI⟩ : ∃ I ∈ c, (f.support ∪ g.support : Set ι) ⊆ I :=
       f.support.coe_union _ ▸ hc.directedOn.exists_mem_subset_of_finset_subset_biUnion hn <| by
         simpa using And.intro hfsupp hgsupp
-    exact linearIndependent_comp_subtypeₛ.mp I.2 f (subset_union_left.trans hI)
+    exact linearIndepOn_iffₛ.mp I.2 f (subset_union_left.trans hI)
       g (subset_union_right.trans hI) hsum
   have trans : Transitive r := fun I J K => Set.Subset.trans
   obtain ⟨⟨I, hli : indep I⟩, hmax : ∀ a, r ⟨I, hli⟩ a → r a ⟨I, hli⟩⟩ :=
     exists_maximal_of_chains_bounded
       (fun c hc => ⟨⟨⋃ I ∈ c, (I : Set ι), key c hc⟩, fun I => Set.subset_biUnion_of_mem⟩) @trans
   exact ⟨I, hli, fun J hsub hli => Set.Subset.antisymm hsub (hmax ⟨J, hli⟩ hsub)⟩
+
+@[deprecated (since := "2025-02-15")] alias
+  exists_maximal_independent' :=  exists_maximal_linearIndepOn'
 
 end Maximal
 
@@ -886,8 +894,8 @@ theorem surjective_of_linearIndependent_of_span [Nontrivial R] (hv : LinearIndep
   use i'
   exact hi'.2
 
-theorem eq_of_linearIndependent_of_span_subtype [Nontrivial R] {s t : Set M}
-    (hs : LinearIndependent R (fun x => x : s → M)) (h : t ⊆ s) (hst : s ⊆ span R t) : s = t := by
+theorem eq_of_linearIndepOn_id_of_span_subtype [Nontrivial R] {s t : Set M}
+    (hs : LinearIndepOn R id s) (h : t ⊆ s) (hst : s ⊆ span R t) : s = t := by
   let f : t ↪ s :=
     ⟨fun x => ⟨x.1, h x.2⟩, fun a b hab => Subtype.coe_injective (Subtype.mk.inj hab)⟩
   have h_surj : Surjective f := by
@@ -900,10 +908,13 @@ theorem eq_of_linearIndependent_of_span_subtype [Nontrivial R] {s t : Set M}
   convert y.mem
   rw [← Subtype.mk.inj hy]
 
-theorem le_of_span_le_span [Nontrivial R] {s t u : Set M} (hl : LinearIndependent R ((↑) : u → M))
+@[deprecated (since := "2025-02-15")] alias
+  eq_of_linearIndependent_of_span_subtype := eq_of_linearIndepOn_id_of_span_subtype
+
+theorem le_of_span_le_span [Nontrivial R] {s t u : Set M} (hl : LinearIndepOn R id u)
     (hsu : s ⊆ u) (htu : t ⊆ u) (hst : span R s ≤ span R t) : s ⊆ t := by
   have :=
-    eq_of_linearIndependent_of_span_subtype (hl.mono (Set.union_subset hsu htu))
+    eq_of_linearIndepOn_id_of_span_subtype (hl.mono (Set.union_subset hsu htu))
       Set.subset_union_right (Set.union_subset (Set.Subset.trans subset_span hst) subset_span)
   rw [← this]; apply Set.subset_union_left
 
@@ -1061,46 +1072,48 @@ section Subtype
 
 /-! The following lemmas use the subtype defined by a set in `M` as the index set `ι`. -/
 
-theorem linearIndependent_comp_subtype {s : Set ι} :
-    LinearIndependent R (v ∘ (↑) : s → M) ↔
+theorem linearIndepOn_iff : LinearIndepOn R v s ↔
       ∀ l ∈ Finsupp.supported R R s, (Finsupp.linearCombination R v) l = 0 → l = 0 :=
-  linearIndependent_comp_subtypeₛ.trans ⟨fun h l hl ↦ h l hl 0 (zero_mem _), fun h f hf g hg eq ↦
+  linearIndepOn_iffₛ.trans ⟨fun h l hl ↦ h l hl 0 (zero_mem _), fun h f hf g hg eq ↦
     sub_eq_zero.mp (h (f - g) (sub_mem hf hg) <| by rw [map_sub, eq, sub_self])⟩
 
-theorem linearDependent_comp_subtype' {s : Set ι} :
-    ¬LinearIndependent R (v ∘ (↑) : s → M) ↔
+@[deprecated (since := "2025-02-15")] alias linearIndependent_comp_subtype := linearIndepOn_iff
+
+@[deprecated (since := "2025-02-15")] alias linearIndependent_subtype := linearIndepOn_iff
+
+theorem linearDepOn_iff' : ¬LinearIndepOn R v s ↔
       ∃ f : ι →₀ R, f ∈ Finsupp.supported R R s ∧ Finsupp.linearCombination R v f = 0 ∧ f ≠ 0 := by
-  simp [linearIndependent_comp_subtype, and_left_comm]
+  simp [linearIndepOn_iff, and_left_comm]
 
-/-- A version of `linearDependent_comp_subtype'` with `Finsupp.linearCombination` unfolded. -/
-theorem linearDependent_comp_subtype {s : Set ι} :
-    ¬LinearIndependent R (v ∘ (↑) : s → M) ↔
+@[deprecated (since := "2025-02-15")] alias linearDependent_comp_subtype' := linearDepOn_iff'
+
+/-- A version of `linearDepOn_iff'` with `Finsupp.linearCombination` unfolded. -/
+theorem linearDepOn_iff : ¬LinearIndepOn R v s ↔
       ∃ f : ι →₀ R, f ∈ Finsupp.supported R R s ∧ ∑ i ∈ f.support, f i • v i = 0 ∧ f ≠ 0 :=
-  linearDependent_comp_subtype'
+  linearDepOn_iff'
 
-theorem linearIndependent_subtype {s : Set M} :
-    LinearIndependent R (fun x => x : s → M) ↔
-      ∀ l ∈ Finsupp.supported R R s, (Finsupp.linearCombination R id) l = 0 → l = 0 := by
-  apply linearIndependent_comp_subtype (v := id)
+@[deprecated (since := "2025-02-15")] alias linearDependent_comp_subtype := linearDepOn_iff
 
-theorem linearIndependent_comp_subtype_disjoint {s : Set ι} :
-    LinearIndependent R (v ∘ (↑) : s → M) ↔
+theorem linearIndepOn_iff_disjoint: LinearIndepOn R v s ↔
       Disjoint (Finsupp.supported R R s) (LinearMap.ker <| Finsupp.linearCombination R v) := by
-  rw [linearIndependent_comp_subtype, LinearMap.disjoint_ker]
+  rw [linearIndepOn_iff, LinearMap.disjoint_ker]
 
-theorem linearIndependent_subtype_disjoint {s : Set M} :
-    LinearIndependent R (fun x ↦ x : s → M) ↔
-      Disjoint (Finsupp.supported R R s) (LinearMap.ker <| Finsupp.linearCombination R id) := by
-  apply linearIndependent_comp_subtype_disjoint (v := id)
+@[deprecated (since := "2025-02-15")] alias linearIndependent_comp_subtype_disjoint :=
+    linearIndepOn_iff_disjoint
 
-theorem linearIndependent_iff_linearCombinationOn {s : Set M} :
-    LinearIndependent R (fun x ↦ x : s → M) ↔
-    (LinearMap.ker <| Finsupp.linearCombinationOn M M R id s) = ⊥ :=
-  linearIndependent_iff_linearCombinationOnₛ.trans <|
+@[deprecated (since := "2025-02-15")] alias linearIndependent_subtype_disjoint :=
+    linearIndepOn_iff_disjoint
+
+theorem linearIndepOn_iff_linearCombinationOn :
+    LinearIndepOn R v s ↔ (LinearMap.ker <| Finsupp.linearCombinationOn ι M R v s) = ⊥ :=
+  linearIndepOn_iff_linearCombinationOnₛ.trans <|
     LinearMap.ker_eq_bot (M := Finsupp.supported R R s).symm
 
 @[deprecated (since := "2024-08-29")] alias linearIndependent_iff_totalOn :=
-  linearIndependent_iff_linearCombinationOn
+  linearIndepOn_iff_linearCombinationOn
+
+@[deprecated (since := "2025-02-15")] alias linearIndependent_iff_linearCombinationOn :=
+  linearIndepOn_iff_linearCombinationOn
 
 end Subtype
 
@@ -1178,6 +1191,7 @@ theorem LinearIndependent.sum_type {v' : ι' → M} (hv : LinearIndependent R v)
     LinearIndependent R (Sum.elim v v') :=
   linearIndependent_sum.2 ⟨hv, hv', h⟩
 
+-- TODO - generalize this to non-identity functions
 theorem LinearIndepOn.id_union {s t : Set M} (hs : LinearIndepOn R id s)
     (ht : LinearIndepOn R id t) (hst : Disjoint (span R s) (span R t)) :
     LinearIndepOn R id (s ∪ t) := by
@@ -1186,23 +1200,47 @@ theorem LinearIndepOn.id_union {s t : Set M} (hs : LinearIndepOn R id s)
 
 @[deprecated (since := "2025-02-14")] alias LinearIndependent.union := LinearIndepOn.id_union
 
-theorem linearIndependent_iUnion_finite_subtype {ι : Type*} {f : ι → Set M}
-    (hl : ∀ i, LinearIndependent R (fun x => x : f i → M))
+-- theorem linearIndependent_iUnion_finite_subtype {ι : Type*} {f : ι → Set M}
+--     (hl : ∀ i, LinearIndependent R (fun x => x : f i → M))
+--     (hd : ∀ i, ∀ t : Set ι, t.Finite → i ∉ t → Disjoint (span R (f i)) (⨆ i ∈ t, span R (f i))) :
+--     LinearIndependent R (fun x => x : (⋃ i, f i) → M) := by
+--   classical
+--   rw [iUnion_eq_iUnion_finset f]
+--   apply linearIndependent_iUnion_of_directed
+--   · apply directed_of_isDirected_le
+--     exact fun t₁ t₂ ht => iUnion_mono fun i => iUnion_subset_iUnion_const fun h => ht h
+--   intro t
+--   induction t using Finset.induction_on with
+--   | empty => exact (linearIndependent_empty R M).mono (by simp)
+--   | @insert i s his ih =>
+--     rw [Finset.set_biUnion_insert]
+--     refine (hl _).union ih ?_
+--     rw [span_iUnion₂]
+--     exact hd i s s.finite_toSet his
+/-- TODO : generalize this to non-identity functions. -/
+theorem linearIndepOn_id_iUnion_finite {η : Type*} {f : ι → Set M}
+    (hl : ∀ i, LinearIndepOn R id (f i))
     (hd : ∀ i, ∀ t : Set ι, t.Finite → i ∉ t → Disjoint (span R (f i)) (⨆ i ∈ t, span R (f i))) :
-    LinearIndependent R (fun x => x : (⋃ i, f i) → M) := by
+    LinearIndepOn R id (⋃ i, f i) := by
   classical
   rw [iUnion_eq_iUnion_finset f]
-  apply linearIndependent_iUnion_of_directed
+  apply linearIndepOn_iUnion_of_directed
   · apply directed_of_isDirected_le
     exact fun t₁ t₂ ht => iUnion_mono fun i => iUnion_subset_iUnion_const fun h => ht h
   intro t
   induction t using Finset.induction_on with
-  | empty => exact (linearIndependent_empty R M).mono (by simp)
+  | empty =>
+      sorry
+      -- _exact (linearIndepOn_empty _ M).mono (by simp)
   | @insert i s his ih =>
-    rw [Finset.set_biUnion_insert]
-    refine (hl _).union ih ?_
-    rw [span_iUnion₂]
-    exact hd i s s.finite_toSet his
+      sorry
+    -- rw [Finset.set_biUnion_insert]
+    -- refine (hl _).union ih ?_
+    -- rw [span_iUnion₂]
+    -- exact hd i s s.finite_toSet his
+
+@[deprecated (since := "2025-02-15")] alias
+    linearIndependent_iUnion_finite_subtype := linearIndepOn_id_iUnion_finite
 
 theorem linearIndependent_iUnion_finite {η : Type*} {ιs : η → Type*} {f : ∀ j : η, ιs j → M}
     (hindep : ∀ j, LinearIndependent R (f j))
@@ -1210,23 +1248,24 @@ theorem linearIndependent_iUnion_finite {η : Type*} {ιs : η → Type*} {f : �
       t.Finite → i ∉ t → Disjoint (span R (range (f i))) (⨆ i ∈ t, span R (range (f i)))) :
     LinearIndependent R fun ji : Σ j, ιs j => f ji.1 ji.2 := by
   nontriviality R
-  apply LinearIndependent.of_subtype_range
-  · rintro ⟨x₁, x₂⟩ ⟨y₁, y₂⟩ hxy
-    by_cases h_cases : x₁ = y₁
-    · subst h_cases
-      refine Sigma.eq rfl ?_
-      rw [LinearIndependent.injective (hindep _) hxy]
-    · have h0 : f x₁ x₂ = 0 := by
-        apply
-          disjoint_def.1 (hd x₁ {y₁} (finite_singleton y₁) fun h => h_cases (eq_of_mem_singleton h))
-            (f x₁ x₂) (subset_span (mem_range_self _))
-        rw [iSup_singleton]
-        simp only at hxy
-        rw [hxy]
-        exact subset_span (mem_range_self y₂)
-      exact False.elim ((hindep x₁).ne_zero _ h0)
-  rw [range_sigma_eq_iUnion_range]
-  apply linearIndependent_iUnion_finite_subtype (fun j => (hindep j).to_subtype_range) hd
+  sorry
+  -- apply LinearIndependent.of_subtype_range
+  -- · rintro ⟨x₁, x₂⟩ ⟨y₁, y₂⟩ hxy
+  --   by_cases h_cases : x₁ = y₁
+  --   · subst h_cases
+  --     refine Sigma.eq rfl ?_
+  --     rw [LinearIndependent.injective (hindep _) hxy]
+  --   · have h0 : f x₁ x₂ = 0 := by
+  --       apply
+  --         disjoint_def.1 (hd x₁ {y₁} (finite_singleton y₁) fun h => h_cases (eq_of_mem_singleton h))
+  --           (f x₁ x₂) (subset_span (mem_range_self _))
+  --       rw [iSup_singleton]
+  --       simp only at hxy
+  --       rw [hxy]
+  --       exact subset_span (mem_range_self y₂)
+  --     exact False.elim ((hindep x₁).ne_zero _ h0)
+  -- rw [range_sigma_eq_iUnion_range]
+  -- apply linearIndependent_iUnion_finite_subtype (fun j => (hindep j).to_subtype_range) hd
 
 open LinearMap
 
@@ -1247,12 +1286,10 @@ theorem linearIndependent_iff_not_smul_mem_span :
       · simp [hl]⟩
 
 variable (R) in
-theorem exists_maximal_independent (s : ι → M) :
-    ∃ I : Set ι,
-      (LinearIndependent R fun x : I => s x) ∧
-        ∀ i ∉ I, ∃ a : R, a ≠ 0 ∧ a • s i ∈ span R (s '' I) := by
+theorem exists_maximal_linearIndepOn (v : ι → M) :
+    ∃ s : Set ι, (LinearIndepOn R v s) ∧ ∀ i ∉ s, ∃ a : R, a ≠ 0 ∧ a • v i ∈ span R (v '' s) := by
   classical
-    rcases exists_maximal_independent' R s with ⟨I, hIlinind, hImaximal⟩
+    rcases exists_maximal_linearIndepOn' R v with ⟨I, hIlinind, hImaximal⟩
     use I, hIlinind
     intro i hi
     specialize hImaximal (I ∪ {i}) (by simp)
@@ -1264,10 +1301,10 @@ theorem exists_maximal_independent (s : ι → M) :
       · intro h2
         rw [h2] at hi
         exact absurd hiJ hi
-    obtain ⟨f, supp_f, sum_f, f_ne⟩ := linearDependent_comp_subtype.mp h
+    obtain ⟨f, supp_f, sum_f, f_ne⟩ := linearDepOn_iff.mp h
     have hfi : f i ≠ 0 := by
       contrapose hIlinind
-      refine linearDependent_comp_subtype.mpr ⟨f, ?_, sum_f, f_ne⟩
+      refine linearDepOn_iff.mpr ⟨f, ?_, sum_f, f_ne⟩
       simp only [Finsupp.mem_supported, hJ] at supp_f ⊢
       rintro x hx
       refine (memJ.mp (supp_f hx)).resolve_left ?_
@@ -1281,11 +1318,16 @@ theorem exists_maximal_independent (s : ι → M) :
     refine neg_mem (sum_mem fun c hc => smul_mem _ _ (subset_span ⟨c, ?_, rfl⟩))
     exact (memJ.mp (supp_f (Finset.erase_subset _ _ hc))).resolve_left (Finset.ne_of_mem_erase hc)
 
-theorem LinearIndependent.image_subtype {s : Set M} {f : M →ₗ[R] M'}
-    (hs : LinearIndependent R (fun x ↦ x : s → M))
-    (hf_inj : Disjoint (span R s) (LinearMap.ker f)) :
-    LinearIndependent R (fun x ↦ x : f '' s → M') :=
-  hs.image_subtypeₛ <| LinearMap.injOn_of_disjoint_ker le_rfl hf_inj
+@[deprecated (since := "2025-02-15")] alias
+  exists_maximal_independent := exists_maximal_linearIndepOn
+
+theorem LinearIndepOn.image {s : Set M} {f : M →ₗ[R] M'}
+    (hs : LinearIndepOn R id s) (hf_inj : Disjoint (span R s) (LinearMap.ker f)) :
+    LinearIndepOn R id (f '' s) :=
+  hs.id_imageₛ <| LinearMap.injOn_of_disjoint_ker le_rfl hf_inj
+
+@[deprecated (since := "2025-02-15")] alias LinearIndependent.image_subtype :=
+  LinearIndepOn.image
 
 -- See, for example, Keith Conrad's note
 --  <https://kconrad.math.uconn.edu/blurbs/galoistheory/linearchar.pdf>
@@ -1472,12 +1514,14 @@ theorem linearIndependent_iff_not_mem_span :
     by_contra ha'
     exact False.elim (h _ ((smul_mem_iff _ ha').1 ha))
 
-protected theorem LinearIndependent.insert (hs : LinearIndependent K (fun b => b : s → V))
-    (hx : x ∉ span K s) : LinearIndependent K (fun b => b : ↥(insert x s) → V) := by
+protected theorem LinearIndepOn.insert (hs : LinearIndepOn K id s) (hx : x ∉ span K s) :
+    LinearIndepOn K id (insert x s) := by
   rw [← union_singleton]
   have x0 : x ≠ 0 := mt (by rintro rfl; apply zero_mem (span K s)) hx
-  apply hs.union (linearIndependent_singleton x0)
+  apply hs.id_union (linearIndependent_singleton x0)
   rwa [disjoint_span_singleton' x0]
+
+@[deprecated (since := "2025-02-15")] alias LinearIndependent.insert := LinearIndepOn.insert
 
 theorem linearIndependent_option' :
     LinearIndependent K (fun o => Option.casesOn' o x v : Option ι → V) ↔
@@ -1500,7 +1544,7 @@ theorem linearIndependent_option {v : Option ι → V} : LinearIndependent K v �
       v none ∉ Submodule.span K (range (v ∘ (↑) : ι → V)) := by
   simp only [← linearIndependent_option', Option.casesOn'_none_coe]
 
-theorem linearIndependent_insert' {ι} {s : Set ι} {a : ι} {f : ι → V} (has : a ∉ s) :
+theorem linearIndepOn_insert' {ι} {s : Set ι} {a : ι} {f : ι → V} (has : a ∉ s) :
     (LinearIndependent K fun x : ↥(insert a s) => f x) ↔
       (LinearIndependent K fun x : s => f x) ∧ f a ∉ Submodule.span K (f '' s) := by
   classical
@@ -1509,6 +1553,8 @@ theorem linearIndependent_insert' {ι} {s : Set ι} {a : ι} {f : ι → V} (has
   simp only [comp_def]
   rw [range_comp']
   simp
+
+@[deprecated (since := "2025-02-15")] alias linearIndependent_insert' := linearIndepOn_insert'
 
 theorem linearIndependent_insert (hxs : x ∉ s) :
     (LinearIndependent K fun b : ↥(insert x s) => (b : V)) ↔

--- a/Mathlib/LinearAlgebra/LinearIndependent.lean
+++ b/Mathlib/LinearAlgebra/LinearIndependent.lean
@@ -401,12 +401,13 @@ theorem LinearIndepOn.map_injOn (hv : LinearIndepOn R v s) (f : M →ₗ[R] M')
     (hf_inj : Set.InjOn f (span R (v '' s))) : LinearIndepOn R (f ∘ v) s :=
   (f.linearIndepOn_iff_of_injOn hf_inj).mpr hv
 
+-- TODO : Rename this `LinearIndependent.of_subsingleton`.
 @[nontriviality]
 theorem linearIndependent_of_subsingleton [Subsingleton R] : LinearIndependent R v :=
   linearIndependent_iffₛ.2 fun _l _l' _hl => Subsingleton.elim _ _
 
 @[nontriviality]
-theorem linearIndepOn_of_subsingleton [Subsingleton R] : LinearIndepOn R v s :=
+theorem LinearIndepOn.of_subsingleton [Subsingleton R] : LinearIndepOn R v s :=
   linearIndependent_of_subsingleton
 
 theorem linearIndependent_equiv (e : ι ≃ ι') {f : ι' → M} :
@@ -425,6 +426,8 @@ theorem linearIndepOn_equiv (e : ι ≃ ι') {f : ι' → M} {s : Set ι} :
 @[simp]
 theorem linearIndepOn_univ : LinearIndepOn R v univ ↔ LinearIndependent R v :=
   linearIndependent_equiv' (Equiv.Set.univ ι) rfl
+
+alias ⟨_, LinearIndependent.linearIndepOn⟩ := linearIndepOn_univ
 
 theorem linearIndepOn_iff_image {ι} {s : Set ι} {f : ι → M} (hf : Set.InjOn f s) :
     LinearIndepOn R f s ↔ LinearIndepOn R id (f '' s) :=
@@ -450,22 +453,23 @@ alias ⟨LinearIndependent.of_linearIndepOn_id_range, _⟩ := linearIndepOn_id_r
 @[deprecated (since := "2025-02-15")] alias LinearIndependent.of_subtype_range :=
     LinearIndependent.of_linearIndepOn_id_range
 
-theorem LinearIndependent.linearIndepOn_id_range (i : LinearIndependent R v) :
+theorem LinearIndependent.linearIndepOn_id (i : LinearIndependent R v) :
     LinearIndepOn R id (range v) := by
   simpa using i.comp _ (rangeSplitting_injective v)
 
 @[deprecated (since := "2025-02-15")] alias LinearIndependent.to_subtype_range :=
-    LinearIndependent.linearIndepOn_id_range
+    LinearIndependent.linearIndepOn_id
 
 @[deprecated (since := "2025-02-14")] alias
-  LinearIndependent.coe_range := LinearIndependent.linearIndepOn_id_range
+  LinearIndependent.coe_range := LinearIndependent.linearIndepOn_id
 
-theorem LinearIndependent.linearIndepOn_id_range' (hv : LinearIndependent R v) {t : Set M}
+/-- A version of `LinearIndependent.linearIndepOn_id` with the set range equality as a hypothesis.-/
+theorem LinearIndependent.linearIndepOn_id' (hv : LinearIndependent R v) {t : Set M}
     (ht : Set.range v = t) : LinearIndepOn R id t :=
-  ht ▸ hv.linearIndepOn_id_range
+  ht ▸ hv.linearIndepOn_id
 
 @[deprecated (since := "2025-02-16")] alias LinearIndependent.to_subtype_range' :=
-    LinearIndependent.linearIndepOn_id_range'
+    LinearIndependent.linearIndepOn_id'
 
 theorem LinearIndepOn.comp_of_image {s : Set ι'} {f : ι' → ι} (h : LinearIndepOn R v (f '' s))
     (hf : InjOn f s) : LinearIndepOn R (v ∘ f) s :=
@@ -554,6 +558,8 @@ theorem linearIndepOn_iffₛ : LinearIndepOn R v s ↔
 
 @[deprecated (since := "2025-02-15")] alias linearIndependent_comp_subtypeₛ := linearIndepOn_iffₛ
 
+/-- An indexed set of vectors is linearly dependent iff there are two distinct
+`Finsupp.LinearCombination`s of the vectors with the same value. -/
 theorem linearDepOn_iff'ₛ : ¬LinearIndepOn R v s ↔
       ∃ f g : ι →₀ R, f ∈ Finsupp.supported R R s ∧ g ∈ Finsupp.supported R R s ∧
         Finsupp.linearCombination R v f = Finsupp.linearCombination R v g ∧ f ≠ g := by
@@ -857,7 +863,7 @@ theorem LinearIndependent.maximal_iff {ι : Type w} {R : Type u} [Semiring R] [N
         Surjective j := by
   constructor
   · rintro p κ w i' j rfl
-    specialize p (range w) i'.linearIndepOn_id_range (range_comp_subset_range _ _)
+    specialize p (range w) i'.linearIndepOn_id (range_comp_subset_range _ _)
     rw [range_comp, ← image_univ (f := w)] at p
     exact range_eq_univ.mp (image_injective.mpr i'.injective p)
   · intro p w i' h
@@ -1099,9 +1105,9 @@ theorem LinearIndependent.fin_cons' {m : ℕ} (x : M) (v : Fin m → M) (hli : L
   rw [this, zero_smul, zero_add] at total_eq
   exact Fin.cases this (hli _ total_eq) j
 
-section Subtype
+section LinearIndepOn
 
-/-! The following lemmas use the subtype defined by a set in `M` as the index set `ι`. -/
+/-! The following give equivalent versions of `LinearIndepOn` and its negation. -/
 
 theorem linearIndepOn_iff : LinearIndepOn R v s ↔
       ∀ l ∈ Finsupp.supported R R s, (Finsupp.linearCombination R v) l = 0 → l = 0 :=
@@ -1112,6 +1118,8 @@ theorem linearIndepOn_iff : LinearIndepOn R v s ↔
 
 @[deprecated (since := "2025-02-15")] alias linearIndependent_subtype := linearIndepOn_iff
 
+/-- An indexed set of vectors is linearly dependent iff there is a nontrivial
+`Finsupp.linearCombination` of the vectors that is zero. -/
 theorem linearDepOn_iff' : ¬LinearIndepOn R v s ↔
       ∃ f : ι →₀ R, f ∈ Finsupp.supported R R s ∧ Finsupp.linearCombination R v f = 0 ∧ f ≠ 0 := by
   simp [linearIndepOn_iff, and_left_comm]
@@ -1146,7 +1154,7 @@ theorem linearIndepOn_iff_linearCombinationOn :
 @[deprecated (since := "2025-02-15")] alias linearIndependent_iff_linearCombinationOn :=
   linearIndepOn_iff_linearCombinationOn
 
-end Subtype
+end LinearIndepOn
 
 end Module
 
@@ -1227,7 +1235,7 @@ theorem LinearIndepOn.id_union {s t : Set M} (hs : LinearIndepOn R id s)
     (ht : LinearIndepOn R id t) (hst : Disjoint (span R s) (span R t)) :
     LinearIndepOn R id (s ∪ t) := by
   have h := hs.linearIndependent.sum_type ht.linearIndependent (by simpa)
-  simpa [id_eq] using h.linearIndepOn_id_range
+  simpa [id_eq] using h.linearIndepOn_id
 
 @[deprecated (since := "2025-02-14")] alias LinearIndependent.union := LinearIndepOn.id_union
 
@@ -1241,13 +1249,12 @@ theorem linearIndepOn_id_iUnion_finite {f : ι → Set M} (hl : ∀ i, LinearInd
     exact fun t₁ t₂ ht => iUnion_mono fun i => iUnion_subset_iUnion_const fun h => ht h
   intro t
   induction t using Finset.induction_on with
-  | empty =>
-      simp
+  | empty => simp
   | @insert i s his ih =>
-      rw [Finset.set_biUnion_insert]
-      refine (hl _).id_union ih ?_
-      rw [span_iUnion₂]
-      exact hd i s s.finite_toSet his
+    rw [Finset.set_biUnion_insert]
+    refine (hl _).id_union ih ?_
+    rw [span_iUnion₂]
+    exact hd i s s.finite_toSet his
 
 @[deprecated (since := "2025-02-15")] alias
     linearIndependent_iUnion_finite_subtype := linearIndepOn_id_iUnion_finite
@@ -1274,7 +1281,7 @@ theorem linearIndependent_iUnion_finite {η : Type*} {ιs : η → Type*} {f : �
         exact subset_span (mem_range_self y₂)
       exact False.elim ((hindep x₁).ne_zero _ h0)
   rw [range_sigma_eq_iUnion_range]
-  apply linearIndepOn_id_iUnion_finite (fun j => (hindep j).linearIndepOn_id_range) hd
+  apply linearIndepOn_id_iUnion_finite (fun j => (hindep j).linearIndepOn_id) hd
 
 open LinearMap
 
@@ -1465,15 +1472,15 @@ theorem linearIndependent_unique_iff (v : ι → M) [Unique ι] :
 
 alias ⟨_, linearIndependent_unique⟩ := linearIndependent_unique_iff
 
-theorem linearIndepOn_singleton {v : ι → M} {i : ι} (hi : v i ≠ 0) : LinearIndepOn R v {i} :=
+theorem LinearIndepOn.singleton {v : ι → M} {i : ι} (hi : v i ≠ 0) : LinearIndepOn R v {i} :=
   linearIndependent_unique _ hi
 
 variable (R) in
-theorem linearIndepOn_id_singleton {x : M} (hx : x ≠ 0) : LinearIndepOn R id {x} :=
+theorem LinearIndepOn.id_singleton {x : M} (hx : x ≠ 0) : LinearIndepOn R id {x} :=
   linearIndependent_unique Subtype.val hx
 
 @[deprecated (since := "2025-02-15")] alias
-    linearIndependent_singleton := linearIndepOn_id_singleton
+    linearIndependent_singleton := LinearIndepOn.id_singleton
 
 @[simp]
 theorem linearIndependent_subsingleton_index_iff [Subsingleton ι] (f : ι → M) :
@@ -1533,7 +1540,7 @@ protected theorem LinearIndepOn.insert (hs : LinearIndepOn K id s) (hx : x ∉ s
     LinearIndepOn K id (insert x s) := by
   rw [← union_singleton]
   have x0 : x ≠ 0 := mt (by rintro rfl; apply zero_mem (span K s)) hx
-  apply hs.id_union (linearIndepOn_singleton x0)
+  apply hs.id_union (LinearIndepOn.singleton x0)
   rwa [disjoint_span_singleton' x0]
 
 @[deprecated (since := "2025-02-15")] alias LinearIndependent.insert := LinearIndepOn.insert
@@ -1578,7 +1585,7 @@ theorem linearIndepOn_id_insert (hxs : x ∉ s) :
 
 theorem linearIndepOn_id_pair {x y : V} (hx : x ≠ 0) (hy : ∀ a : K, a • x ≠ y) :
     LinearIndepOn K id {x, y} :=
-  pair_comm y x ▸ (linearIndepOn_id_singleton K hx).insert (x := y) <|
+  pair_comm y x ▸ (LinearIndepOn.id_singleton K hx).insert (x := y) <|
     mt mem_span_singleton.1 <| not_exists.2 hy
 
 @[deprecated (since := "2025-02-15")] alias linearIndependent_pair := linearIndepOn_id_pair

--- a/Mathlib/RingTheory/Unramified/Field.lean
+++ b/Mathlib/RingTheory/Unramified/Field.lean
@@ -177,7 +177,7 @@ theorem range_eq_top_of_isPurelyInseparable
     have inst : IsReduced (L ⊗[K] L) := isReduced_of_field L _
     exact sub_eq_zero.mp (IsNilpotent.eq_zero ⟨_, this⟩)
   by_cases h' : LinearIndependent K ![1, x]
-  · have h := h'.linearIndepOn_id_range
+  · have h := h'.linearIndepOn_id
     let S := h.extend (Set.subset_univ _)
     let a : S := ⟨1, h.subset_extend _ (by simp)⟩
     have ha : Basis.extend h a = 1 := by simp [a]

--- a/Mathlib/RingTheory/Unramified/Field.lean
+++ b/Mathlib/RingTheory/Unramified/Field.lean
@@ -177,7 +177,7 @@ theorem range_eq_top_of_isPurelyInseparable
     have inst : IsReduced (L ⊗[K] L) := isReduced_of_field L _
     exact sub_eq_zero.mp (IsNilpotent.eq_zero ⟨_, this⟩)
   by_cases h' : LinearIndependent K ![1, x]
-  · have h := h'.coe_range
+  · have h := h'.linearIndepOn_id_range
     let S := h.extend (Set.subset_univ _)
     let a : S := ⟨1, h.subset_extend _ (by simp)⟩
     have ha : Basis.extend h a = 1 := by simp [a]

--- a/Mathlib/Topology/Category/Profinite/Nobeling.lean
+++ b/Mathlib/Topology/Category/Profinite/Nobeling.lean
@@ -1746,8 +1746,8 @@ theorem GoodProducts.P0 : P I 0 := fun _ C _ hsC ↦ by
 theorem GoodProducts.Plimit (o : Ordinal) (ho : Ordinal.IsLimit o) :
     (∀ (o' : Ordinal), o' < o → P I o') → P I o := by
   intro h hho C hC hsC
-  rw [linearIndependent_iff_union_smaller C ho hsC]
-  exact linearIndependent_iUnion_of_directed
+  rw [linearIndependent_iff_union_smaller C ho hsC, linearIndependent_subtype_iff]
+  exact linearIndepOn_iUnion_of_directed
     (Monotone.directed_le fun _ _ h ↦ GoodProducts.smaller_mono C h) fun ⟨o', ho'⟩ ↦
     (linearIndependent_iff_smaller _ _).mp (h o' ho' (le_of_lt (lt_of_lt_of_le ho' hho))
     (π C (ord I · < o')) (isClosed_proj _ _ hC) (contained_proj _ _))


### PR DESCRIPTION
Currently, if `s` is a set of vectors in a module `W`, the way to state that the vectors in `s` are linearly independent is 
`LinearIndependent R (Subtype.val : ↥s → W)` (or similar), and if `v : ι -> W` and `s : Set ι` is a set of indices, the way to state that `s` indexes a linearly independent subcollection is `LinearIndependent  R (fun x : ↥s ↦ (f x : W))` or similar. 

#21799 introduced a definition `LinearIndepOn`, which gives an alternative spelling 
`LinearIndepOn R f s` instead of `LinearIndependent  R (fun x : ↥s ↦ (f x : W))` for the indexed version, and (therefore) `LinearIndepOn R id s` for the set version. 

This PR updates spellings throughout mathlib, changing terms of type `LinearIndependent R (Subtype.val : ↥s → W)` to `LinearIndepOn R id s` and 
`LinearIndependent  R (fun x : ↥s ↦ (f x : W))` to `LinearIndepOn R f s`.

The API using the old spellings has been deprecated, and replaced with new one - the diff is designed to be as small as possible subject to deprecating the old spellings. In some cases, where no extra work was needed, we generalized lemmas that previously apply to `LinearIndepOn R id s` to `LinearIndepOn R v s` for arbitrary `v`. But there is room to do this further in other places, some of which have been marked TODO. 

Most changes happen in `LinearAlgebra/LinearIndependent.lean`, but only about 100 lines have been added to the length, many of which are deprecated alias lines.  Nearly all other changes are knock-on effects, where statements, proofs and (in two cases) definitions that use the old spellings are updated.  22 files are affected, but the majority only in the form of slight modifications of proofs to avoid deprecated lemmas. 

The two files other than `LinearIndependent.lean` with changed definitions are: 

- `Mathlib/LinearAlgebra/Dimension/Basic.lean` (definition of Module.rank)
- `Mathlib/LinearAlgebra/Dimension/RankNullity.lean` (changed structure field of `HasRankNullity`)

The files with changed theorem statements are: 

- `Mathlib/FieldTheory/Fixed.lean`
- `Mathlib/LinearAlgebra/Basis/VectorSpace.lean`
- `Mathlib/LinearAlgebra/Dimension/Constructions.lean`
- `Mathlib/LinearAlgebra/Dimension/Finite.lean`
- `Mathlib/LinearAlgebra/Dimension/FreeAndStrongRankCondition.lean`
- `Mathlib/LinearAlgebra/Dimension/LinearMap.lean`
- `Mathlib/LinearAlgebra/Dimension/Localization.lean`
- `Mathlib/LinearAlgebra/Dimension/StrongRankCondition.lean`

[Zulip discussion](https://leanprover.zulipchat.com/#narrow/channel/144837-PR-reviews/topic/.2321886.20LinearIndepOn.20refactor/near/500527995)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
