### PR TITLE
[Merged by Bors] - refactor(Limits/Preserves/Finite): review API

### DIFF
--- a/Mathlib/CategoryTheory/Closed/Ideal.lean
+++ b/Mathlib/CategoryTheory/Closed/Ideal.lean
@@ -302,7 +302,7 @@ lemma preservesBinaryProducts_of_exponentialIdeal :
 /--
 If a reflective subcategory is an exponential ideal, then the reflector preserves finite products.
 -/
-lemma preservesFiniteProducts_of_exponentialIdeal (J : Type) [Fintype J] :
+lemma preservesFiniteProducts_of_exponentialIdeal (J : Type) [Finite J] :
     PreservesLimitsOfShape (Discrete J) (reflector i) := by
   letI := preservesBinaryProducts_of_exponentialIdeal i
   letI : PreservesLimitsOfShape _ (reflector i) := leftAdjoint_preservesTerminal_of_reflective.{0} i

--- a/Mathlib/CategoryTheory/Galois/Action.lean
+++ b/Mathlib/CategoryTheory/Galois/Action.lean
@@ -69,12 +69,12 @@ instance : Functor.ReflectsIsomorphisms (functorToAction F) where
     isIso_of_reflects_iso f F
 
 noncomputable instance : PreservesFiniteCoproducts (functorToAction F) :=
-  ⟨fun J _ ↦ Action.preservesColimitsOfShape_of_preserves (functorToAction F)
-    (inferInstanceAs <| PreservesColimitsOfShape (Discrete J) F)⟩
+  ⟨fun _ ↦ Action.preservesColimitsOfShape_of_preserves (functorToAction F)
+    (inferInstanceAs <| PreservesColimitsOfShape (Discrete _) F)⟩
 
 noncomputable instance : PreservesFiniteProducts (functorToAction F) :=
-  ⟨fun J _ ↦ Action.preservesLimitsOfShape_of_preserves (functorToAction F)
-    (inferInstanceAs <| PreservesLimitsOfShape (Discrete J) F)⟩
+  ⟨fun _ ↦ Action.preservesLimitsOfShape_of_preserves (functorToAction F)
+    (inferInstanceAs <| PreservesLimitsOfShape (Discrete _) F)⟩
 
 noncomputable instance (G : Type*) [Group G] [Finite G] :
     PreservesColimitsOfShape (SingleObj G) (functorToAction F) :=

--- a/Mathlib/CategoryTheory/Galois/Examples.lean
+++ b/Mathlib/CategoryTheory/Galois/Examples.lean
@@ -89,7 +89,7 @@ instance : PreGaloisCategory (Action FintypeCat (MonCat.of G)) where
 
 /-- The forgetful functor from finite `G`-sets to sets is a `FiberFunctor`. -/
 noncomputable instance : FiberFunctor (Action.forget FintypeCat (MonCat.of G)) where
-  preservesFiniteCoproducts := ⟨fun _ _ ↦ inferInstance⟩
+  preservesFiniteCoproducts := ⟨fun _ ↦ inferInstance⟩
   preservesQuotientsByFiniteGroups _ _ _ := inferInstance
   reflectsIsos := ⟨fun f (_ : IsIso f.hom) => inferInstance⟩
 

--- a/Mathlib/CategoryTheory/Limits/Constructions/FiniteProductsOfBinaryProducts.lean
+++ b/Mathlib/CategoryTheory/Limits/Constructions/FiniteProductsOfBinaryProducts.lean
@@ -156,12 +156,11 @@ lemma preservesShape_fin_of_preserves_binary_and_terminal (n : ℕ) :
     apply preservesLimit_of_iso_diagram F that
 
 /-- If `F` preserves the terminal object and binary products then it preserves finite products. -/
-lemma preservesFiniteProducts_of_preserves_binary_and_terminal (J : Type*) [Fintype J] :
-    PreservesLimitsOfShape (Discrete J) F := by
-  classical
-    let e := Fintype.equivFin J
-    haveI := preservesShape_fin_of_preserves_binary_and_terminal F (Fintype.card J)
-    apply preservesLimitsOfShape_of_equiv (Discrete.equivalence e).symm
+lemma preservesFiniteProducts_of_preserves_binary_and_terminal (J : Type*) [Finite J] :
+    PreservesLimitsOfShape (Discrete J) F :=
+  let ⟨n, ⟨e⟩⟩ := Finite.exists_equiv_fin J
+  have := preservesShape_fin_of_preserves_binary_and_terminal F n
+  preservesLimitsOfShape_of_equiv (Discrete.equivalence e).symm _
 
 end Preserves
 
@@ -287,12 +286,11 @@ lemma preservesShape_fin_of_preserves_binary_and_initial (n : ℕ) :
     apply preservesColimit_of_iso_diagram F that
 
 /-- If `F` preserves the initial object and binary coproducts then it preserves finite products. -/
-lemma preservesFiniteCoproductsOfPreservesBinaryAndInitial (J : Type*) [Fintype J] :
-    PreservesColimitsOfShape (Discrete J) F := by
-  classical
-    let e := Fintype.equivFin J
-    haveI := preservesShape_fin_of_preserves_binary_and_initial F (Fintype.card J)
-    apply preservesColimitsOfShape_of_equiv (Discrete.equivalence e).symm
+lemma preservesFiniteCoproductsOfPreservesBinaryAndInitial (J : Type*) [Finite J] :
+    PreservesColimitsOfShape (Discrete J) F :=
+  let ⟨n, ⟨e⟩⟩ := Finite.exists_equiv_fin J
+  have := preservesShape_fin_of_preserves_binary_and_initial F n
+  preservesColimitsOfShape_of_equiv (Discrete.equivalence e).symm _
 
 end Preserves
 

--- a/Mathlib/CategoryTheory/Limits/Constructions/LimitsOfProductsAndEqualizers.lean
+++ b/Mathlib/CategoryTheory/Limits/Constructions/LimitsOfProductsAndEqualizers.lean
@@ -204,14 +204,9 @@ lemma preservesFiniteLimits_of_preservesEqualizers_and_finiteProducts [HasEquali
     [HasFiniteProducts C] (G : C ⥤ D) [PreservesLimitsOfShape WalkingParallelPair G]
     [PreservesFiniteProducts G] : PreservesFiniteLimits G where
   preservesFiniteLimits := by
-    intro J sJ fJ
-    haveI : Fintype J := inferInstance
-    haveI : Fintype ((p : J × J) × (p.fst ⟶ p.snd)) := inferInstance
-    apply @preservesLimit_of_preservesEqualizers_and_product _ _ _ sJ _ _ ?_ ?_ _ G _ ?_ ?_
-    · apply hasLimitsOfShape_discrete _ _
-    · apply hasLimitsOfShape_discrete _
-    · apply PreservesFiniteProducts.preserves _
-    · apply PreservesFiniteProducts.preserves _
+    intros
+    apply preservesLimit_of_preservesEqualizers_and_product
+
 
 /-- If G preserves equalizers and products, it preserves all limits. -/
 lemma preservesLimits_of_preservesEqualizers_and_products [HasEqualizers C]
@@ -292,7 +287,7 @@ lemma preservesFiniteLimits_of_preservesTerminal_and_pullbacks [HasTerminal C]
       preservesEqualizers_of_preservesPullbacks_and_binaryProducts G
   apply
     @preservesFiniteLimits_of_preservesEqualizers_and_finiteProducts _ _ _ _ _ _ G _ ?_
-  apply PreservesFiniteProducts.mk
+  refine ⟨fun n ↦ ?_⟩
   apply preservesFiniteProducts_of_preserves_binary_and_terminal G
 
 attribute [local instance] preservesFiniteLimits_of_preservesTerminal_and_pullbacks in
@@ -493,13 +488,7 @@ lemma preservesFiniteColimits_of_preservesCoequalizers_and_finiteCoproducts
     [PreservesFiniteCoproducts G] : PreservesFiniteColimits G where
   preservesFiniteColimits := by
     intro J sJ fJ
-    haveI : Fintype J := inferInstance
-    haveI : Fintype ((p : J × J) × (p.fst ⟶ p.snd)) := inferInstance
-    apply @preservesColimit_of_preservesCoequalizers_and_coproduct _ _ _ sJ _ _ ?_ ?_ _ G _ ?_ ?_
-    · apply hasColimitsOfShape_discrete _ _
-    · apply hasColimitsOfShape_discrete _
-    · apply PreservesFiniteCoproducts.preserves _
-    · apply PreservesFiniteCoproducts.preserves _
+    apply preservesColimit_of_preservesCoequalizers_and_coproduct
 
 /-- If G preserves coequalizers and coproducts, it preserves all colimits. -/
 lemma preservesColimits_of_preservesCoequalizers_and_coproducts [HasCoequalizers C]
@@ -580,7 +569,7 @@ lemma preservesFiniteColimits_of_preservesInitial_and_pushouts [HasInitial C]
       (preservesCoequalizers_of_preservesPushouts_and_binaryCoproducts G)
   refine
     @preservesFiniteColimits_of_preservesCoequalizers_and_finiteCoproducts _ _ _ _ _ _ G _ ?_
-  apply PreservesFiniteCoproducts.mk
+  refine ⟨fun _ ↦ ?_⟩
   apply preservesFiniteCoproductsOfPreservesBinaryAndInitial G
 
 attribute [local instance] preservesFiniteColimits_of_preservesInitial_and_pushouts in

--- a/Mathlib/CategoryTheory/Limits/Preserves/Opposites.lean
+++ b/Mathlib/CategoryTheory/Limits/Preserves/Opposites.lean
@@ -468,64 +468,64 @@ lemma preservesFiniteColimits_of_unop (F : Cᵒᵖ ⥤ Dᵒᵖ) [PreservesFinite
     products. -/
 lemma preservesFiniteProducts_op (F : C ⥤ D) [PreservesFiniteCoproducts F] :
     PreservesFiniteProducts F.op where
-  preserves J _ := by
+  preserves n := by
     apply (config := { allowSynthFailures := true }) preservesLimitsOfShape_op
-    exact preservesColimitsOfShape_of_equiv (Discrete.opposite J).symm _
+    exact preservesColimitsOfShape_of_equiv (Discrete.opposite _).symm _
 
 /-- If `F : C ⥤ Dᵒᵖ` preserves finite coproducts, then `F.leftOp : Cᵒᵖ ⥤ D` preserves finite
     products. -/
 lemma preservesFiniteProducts_leftOp (F : C ⥤ Dᵒᵖ) [PreservesFiniteCoproducts F] :
     PreservesFiniteProducts F.leftOp where
-  preserves J _ := by
+  preserves _ := by
     apply (config := { allowSynthFailures := true }) preservesLimitsOfShape_leftOp
-    exact preservesColimitsOfShape_of_equiv (Discrete.opposite J).symm _
+    exact preservesColimitsOfShape_of_equiv (Discrete.opposite _).symm _
 
 /-- If `F : Cᵒᵖ ⥤ D` preserves finite coproducts, then `F.rightOp : C ⥤ Dᵒᵖ` preserves finite
     products. -/
 lemma preservesFiniteProducts_rightOp (F : Cᵒᵖ ⥤ D) [PreservesFiniteCoproducts F] :
     PreservesFiniteProducts F.rightOp where
-  preserves J _ := by
+  preserves _ := by
     apply (config := { allowSynthFailures := true }) preservesLimitsOfShape_rightOp
-    exact preservesColimitsOfShape_of_equiv (Discrete.opposite J).symm _
+    exact preservesColimitsOfShape_of_equiv (Discrete.opposite _).symm _
 
 /-- If `F : Cᵒᵖ ⥤ Dᵒᵖ` preserves finite coproducts, then `F.unop : C ⥤ D` preserves finite
     products. -/
 lemma preservesFiniteProducts_unop (F : Cᵒᵖ ⥤ Dᵒᵖ) [PreservesFiniteCoproducts F] :
     PreservesFiniteProducts F.unop where
-  preserves J _ := by
+  preserves _ := by
     apply (config := { allowSynthFailures := true }) preservesLimitsOfShape_unop
-    exact preservesColimitsOfShape_of_equiv (Discrete.opposite J).symm _
+    exact preservesColimitsOfShape_of_equiv (Discrete.opposite _).symm _
 
 /-- If `F : C ⥤ D` preserves finite products, then `F.op : Cᵒᵖ ⥤ Dᵒᵖ` preserves finite
     coproducts. -/
 lemma preservesFiniteCoproducts_op (F : C ⥤ D) [PreservesFiniteProducts F] :
     PreservesFiniteCoproducts F.op where
-  preserves J _ := by
+  preserves _ := by
     apply (config := { allowSynthFailures := true }) preservesColimitsOfShape_op
-    exact preservesLimitsOfShape_of_equiv (Discrete.opposite J).symm _
+    exact preservesLimitsOfShape_of_equiv (Discrete.opposite _).symm _
 
 /-- If `F : C ⥤ Dᵒᵖ` preserves finite products, then `F.leftOp : Cᵒᵖ ⥤ D` preserves finite
     coproducts. -/
 lemma preservesFiniteCoproducts_leftOp (F : C ⥤ Dᵒᵖ) [PreservesFiniteProducts F] :
     PreservesFiniteCoproducts F.leftOp where
-  preserves J _ := by
+  preserves _ := by
     apply (config := { allowSynthFailures := true }) preservesColimitsOfShape_leftOp
-    exact preservesLimitsOfShape_of_equiv (Discrete.opposite J).symm _
+    exact preservesLimitsOfShape_of_equiv (Discrete.opposite _).symm _
 
 /-- If `F : Cᵒᵖ ⥤ D` preserves finite products, then `F.rightOp : C ⥤ Dᵒᵖ` preserves finite
     coproducts. -/
 lemma preservesFiniteCoproducts_rightOp (F : Cᵒᵖ ⥤ D) [PreservesFiniteProducts F] :
     PreservesFiniteCoproducts F.rightOp where
-  preserves J _ := by
+  preserves _ := by
     apply (config := { allowSynthFailures := true }) preservesColimitsOfShape_rightOp
-    exact preservesLimitsOfShape_of_equiv (Discrete.opposite J).symm _
+    exact preservesLimitsOfShape_of_equiv (Discrete.opposite _).symm _
 
 /-- If `F : Cᵒᵖ ⥤ Dᵒᵖ` preserves finite products, then `F.unop : C ⥤ D` preserves finite
     coproducts. -/
 lemma preservesFiniteCoproducts_unop (F : Cᵒᵖ ⥤ Dᵒᵖ) [PreservesFiniteProducts F] :
     PreservesFiniteCoproducts F.unop where
-  preserves J _ := by
+  preserves _ := by
     apply (config := { allowSynthFailures := true }) preservesColimitsOfShape_unop
-    exact preservesLimitsOfShape_of_equiv (Discrete.opposite J).symm _
+    exact preservesLimitsOfShape_of_equiv (Discrete.opposite _).symm _
 
 end CategoryTheory.Limits

--- a/Mathlib/CategoryTheory/Localization/FiniteProducts.lean
+++ b/Mathlib/CategoryTheory/Localization/FiniteProducts.lean
@@ -118,7 +118,7 @@ identities and is stable by finite products,
 then any localization functor for `W` preserves finite products. -/
 lemma preservesFiniteProducts :
     PreservesFiniteProducts L where
-  preserves J _ := preservesProductsOfShape L W J
+  preserves _ := preservesProductsOfShape L W _
       (W.isStableUnderProductsOfShape_of_isStableUnderFiniteProducts _)
 
 instance : HasFiniteProducts (W.Localization) := hasFiniteProducts W.Q W

--- a/Mathlib/CategoryTheory/Preadditive/LeftExact.lean
+++ b/Mathlib/CategoryTheory/Preadditive/LeftExact.lean
@@ -114,7 +114,8 @@ lemma preservesFiniteLimits_of_preservesKernels [HasFiniteProducts C] [HasEquali
   letI := preservesEqualizers_of_preservesKernels F
   letI := preservesTerminalObject_of_preservesZeroMorphisms F
   letI := preservesLimitsOfShape_pempty_of_preservesTerminal F
-  letI : PreservesFiniteProducts F := ⟨preservesFiniteProducts_of_preserves_binary_and_terminal F⟩
+  letI : PreservesFiniteProducts F :=
+    ⟨fun _ ↦ preservesFiniteProducts_of_preserves_binary_and_terminal F _⟩
   exact preservesFiniteLimits_of_preservesEqualizers_and_finiteProducts F
 
 end FiniteLimits
@@ -198,7 +199,8 @@ lemma preservesFiniteColimits_of_preservesCokernels [HasFiniteCoproducts C] [Has
   letI := preservesCoequalizers_of_preservesCokernels F
   letI := preservesInitialObject_of_preservesZeroMorphisms F
   letI := preservesColimitsOfShape_pempty_of_preservesInitial F
-  letI : PreservesFiniteCoproducts F := ⟨preservesFiniteCoproductsOfPreservesBinaryAndInitial F⟩
+  letI : PreservesFiniteCoproducts F :=
+    ⟨fun _ ↦ preservesFiniteCoproductsOfPreservesBinaryAndInitial F _⟩
   exact preservesFiniteColimits_of_preservesCoequalizers_and_finiteCoproducts F
 
 end FiniteColimits

--- a/Mathlib/CategoryTheory/Sites/Coherent/ExtensiveColimits.lean
+++ b/Mathlib/CategoryTheory/Sites/Coherent/ExtensiveColimits.lean
@@ -41,7 +41,7 @@ lemma isSheaf_pointwiseColimit [PreservesFiniteProducts (colim (J := J) (C := A)
     inferInstanceAs (PreservesLimitsOfShape _ ((G ⋙ sheafToPresheaf _ _).obj d))⟩
 
 instance [Preadditive A] : PreservesFiniteProducts (colim (J := J) (C := A)) where
-  preserves I _ := by
+  preserves _ := by
     apply ( config := {allowSynthFailures := true} )
       preservesProductsOfShape_of_preservesBiproductsOfShape
     apply preservesBiproductsOfShape_of_preservesCoproductsOfShape

--- a/Mathlib/CategoryTheory/Sites/Coherent/ExtensiveSheaves.lean
+++ b/Mathlib/CategoryTheory/Sites/Coherent/ExtensiveSheaves.lean
@@ -79,15 +79,14 @@ A presheaf of sets on a category which is `FinitaryExtensive` is a sheaf iff it 
 products.
 -/
 theorem Presieve.isSheaf_iff_preservesFiniteProducts (F : Cᵒᵖ ⥤ Type w) :
-    Presieve.IsSheaf (extensiveTopology C) F ↔
-    Nonempty (PreservesFiniteProducts F) := by
-  refine ⟨fun hF ↦ ⟨⟨fun α _ ↦ ⟨fun {K} ↦ ?_⟩⟩⟩, fun hF ↦ ?_⟩
+    Presieve.IsSheaf (extensiveTopology C) F ↔ PreservesFiniteProducts F := by
+  refine ⟨fun hF ↦ ⟨fun n ↦ ⟨fun {K} ↦ ?_⟩⟩, fun hF ↦ ?_⟩
   · rw [extensiveTopology, isSheaf_coverage] at hF
-    let Z : α → C := fun i ↦ unop (K.obj ⟨i⟩)
+    let Z : Fin n → C := fun i ↦ unop (K.obj ⟨i⟩)
     have : (ofArrows Z (Cofan.mk (∐ Z) (Sigma.ι Z)).inj).hasPullbacks :=
       inferInstanceAs (ofArrows Z (Sigma.ι Z)).hasPullbacks
-    have : ∀ (i : α), Mono (Cofan.inj (Cofan.mk (∐ Z) (Sigma.ι Z)) i) :=
-      inferInstanceAs <| ∀ (i : α), Mono (Sigma.ι Z i)
+    have : ∀ (i : Fin n), Mono (Cofan.inj (Cofan.mk (∐ Z) (Sigma.ι Z)) i) :=
+      inferInstanceAs <| ∀ (i : Fin n), Mono (Sigma.ι Z i)
     let i : K ≅ Discrete.functor (fun i ↦ op (Z i)) := Discrete.natIsoFunctor
     let _ : PreservesLimit (Discrete.functor (fun i ↦ op (Z i))) F :=
         Presieve.preservesProduct_of_isSheafFor F ?_ initialIsInitial _ (coproductIsCoproduct Z)
@@ -99,12 +98,11 @@ theorem Presieve.isSheaf_iff_preservesFiniteProducts (F : Cᵒᵖ ⥤ Type w) :
       · ext b
         cases b
       · simp only [eq_iff_true_of_subsingleton]
-    · refine ⟨α, inferInstance, Z, (fun i ↦ Sigma.ι Z i), rfl, ?_⟩
+    · refine ⟨Fin n, inferInstance, Z, (fun i ↦ Sigma.ι Z i), rfl, ?_⟩
       suffices Sigma.desc (fun i ↦ Sigma.ι Z i) = 𝟙 _ by rw [this]; infer_instance
       ext
       simp
-  · let _ := hF.some
-    rw [extensiveTopology, Presieve.isSheaf_coverage]
+  · rw [extensiveTopology, Presieve.isSheaf_coverage]
     intro X R ⟨Y, α, Z, π, hR, hi⟩
     have : IsIso (Sigma.desc (Cofan.inj (Cofan.mk X π))) := hi
     have : R.Extensive := ⟨Y, α, Z, π, hR, ⟨Cofan.isColimitOfIsIsoSigmaDesc (Cofan.mk X π)⟩⟩
@@ -118,13 +116,12 @@ theorem Presheaf.isSheaf_iff_preservesFiniteProducts (F : Cᵒᵖ ⥤ D) :
   constructor
   · intro h
     rw [IsSheaf] at h
-    refine ⟨fun J _ ↦ ⟨fun {K} ↦ ⟨fun {c} hc ↦ ?_⟩⟩⟩
+    refine ⟨fun n ↦ ⟨fun {K} ↦ ⟨fun {c} hc ↦ ?_⟩⟩⟩
     constructor
     apply coyonedaJointlyReflectsLimits
     intro ⟨E⟩
     specialize h E
     rw [Presieve.isSheaf_iff_preservesFiniteProducts] at h
-    have : PreservesLimit K (F.comp (coyoneda.obj ⟨E⟩)) := (h.some.preserves J).preservesLimit
     exact isLimitOfPreserves (F.comp (coyoneda.obj ⟨E⟩)) hc
   · intro _ E
     rw [Presieve.isSheaf_iff_preservesFiniteProducts]

--- a/Mathlib/CategoryTheory/Sites/Coherent/SheafComparison.lean
+++ b/Mathlib/CategoryTheory/Sites/Coherent/SheafComparison.lean
@@ -282,7 +282,7 @@ lemma isSheaf_coherent_of_hasPullbacks_of_comp [Preregular C] [FinitaryExtensive
     (hF : IsSheaf (coherentTopology C) (F ⋙ s)) : IsSheaf (coherentTopology C) F := by
   rw [isSheaf_iff_preservesFiniteProducts_and_equalizerCondition (h := h)] at hF ⊢
   obtain ⟨_, hF₂⟩ := hF
-  refine ⟨⟨fun J _ ↦ ⟨fun {K} ↦ ⟨fun {c} hc ↦ ?_⟩⟩⟩, fun _ _ π _ c hc ↦ ⟨?_⟩⟩
+  refine ⟨⟨fun n ↦ ⟨fun {K} ↦ ⟨fun {c} hc ↦ ?_⟩⟩⟩, fun _ _ π _ c hc ↦ ⟨?_⟩⟩
   · exact ⟨isLimitOfReflects s (isLimitOfPreserves (F ⋙ s) hc)⟩
   · exact isLimitOfIsLimitForkMap s _ (hF₂ π c hc).some
 
@@ -297,8 +297,7 @@ lemma isSheaf_coherent_of_projective_of_comp [Preregular C] [FinitaryExtensive C
     [ReflectsFiniteProducts s]
     (hF : IsSheaf (coherentTopology C) (F ⋙ s)) : IsSheaf (coherentTopology C) F := by
   rw [isSheaf_iff_preservesFiniteProducts_of_projective] at hF ⊢
-  exact ⟨fun J _ ↦ ⟨fun {K} ↦ ⟨fun {c} hc ↦
-    ⟨isLimitOfReflects s (isLimitOfPreserves (F ⋙ s) hc)⟩⟩⟩⟩
+  exact ⟨fun n ↦ ⟨fun {K} ↦ ⟨fun {c} hc ↦ ⟨isLimitOfReflects s (isLimitOfPreserves (F ⋙ s) hc)⟩⟩⟩⟩
 
 instance [Preregular C] [FinitaryExtensive C]
     [h : ∀ {Y X : C} (f : Y ⟶ X) [EffectiveEpi f], HasPullback f f]

--- a/Mathlib/CategoryTheory/Sites/Preserves.lean
+++ b/Mathlib/CategoryTheory/Sites/Preserves.lean
@@ -154,10 +154,9 @@ lemma preservesProduct_of_isSheafFor
 
 include hc hd hF hI in
 theorem isSheafFor_iff_preservesProduct : (ofArrows X c.inj).IsSheafFor F ↔
-    Nonempty (PreservesLimit (Discrete.functor (fun x ↦ op (X x))) F) := by
-  refine ⟨fun hF' ↦ ⟨preservesProduct_of_isSheafFor _ hF hI c hc hd hF'⟩, fun hF' ↦ ?_⟩
-  let _ := hF'.some
-  exact isSheafFor_of_preservesProduct F c hc
+    PreservesLimit (Discrete.functor (fun x ↦ op (X x))) F :=
+  ⟨fun hF' ↦ preservesProduct_of_isSheafFor _ hF hI c hc hd hF',
+    fun _ ↦ isSheafFor_of_preservesProduct F c hc⟩
 
 end Product
 

--- a/Mathlib/CategoryTheory/Sites/Sheafification.lean
+++ b/Mathlib/CategoryTheory/Sites/Sheafification.lean
@@ -41,29 +41,29 @@ Given a finite limit preserving functor `F : (Cᵒᵖ ⥤ A) ⥤ Sheaf J A` and 
 -/
 class HasSheafify : Prop where
   isRightAdjoint : HasWeakSheafify J A
-  isLeftExact : Nonempty (PreservesFiniteLimits ((sheafToPresheaf J A).leftAdjoint))
+  isLeftExact : PreservesFiniteLimits ((sheafToPresheaf J A).leftAdjoint)
 
 instance [HasSheafify J A] : HasWeakSheafify J A := HasSheafify.isRightAdjoint
 
 noncomputable section
 
 instance [HasSheafify J A] : PreservesFiniteLimits ((sheafToPresheaf J A).leftAdjoint) :=
-  HasSheafify.isLeftExact.some
+  HasSheafify.isLeftExact
 
 theorem HasSheafify.mk' {F : (Cᵒᵖ ⥤ A) ⥤ Sheaf J A} (adj : F ⊣ sheafToPresheaf J A)
     [PreservesFiniteLimits F] : HasSheafify J A where
   isRightAdjoint := ⟨F, ⟨adj⟩⟩
   isLeftExact := ⟨by
     have : (sheafToPresheaf J A).IsRightAdjoint := ⟨_, ⟨adj⟩⟩
-    exact ⟨fun _ _ _ ↦ preservesLimitsOfShape_of_natIso
-      (adj.leftAdjointUniq (Adjunction.ofIsRightAdjoint (sheafToPresheaf J A)))⟩⟩
+    exact fun _ _ _ ↦ preservesLimitsOfShape_of_natIso
+      (adj.leftAdjointUniq (Adjunction.ofIsRightAdjoint (sheafToPresheaf J A)))⟩
 
 /-- The sheafification functor, left adjoint to the inclusion. -/
 def presheafToSheaf [HasWeakSheafify J A] : (Cᵒᵖ ⥤ A) ⥤ Sheaf J A :=
   (sheafToPresheaf J A).leftAdjoint
 
 instance [HasSheafify J A] : PreservesFiniteLimits (presheafToSheaf J A) :=
-  HasSheafify.isLeftExact.some
+  HasSheafify.isLeftExact
 
 /-- The sheafification-inclusion adjunction. -/
 def sheafificationAdjunction [HasWeakSheafify J A] :

--- a/Mathlib/Condensed/Explicit.lean
+++ b/Mathlib/Condensed/Explicit.lean
@@ -46,7 +46,7 @@ noncomputable def ofSheafStonean
     val := F
     cond := by
       rw [isSheaf_iff_preservesFiniteProducts_of_projective F]
-      exact ⟨fun _ _ ↦ inferInstance⟩ }
+      exact ⟨fun _ ↦ inferInstance⟩ }
 
 /--
 The condensed object associated to a presheaf on `Stonean` whose postcomposition with the
@@ -62,7 +62,7 @@ noncomputable def ofSheafForgetStonean
     cond := by
       apply isSheaf_coherent_of_projective_of_comp F (CategoryTheory.forget A)
       rw [isSheaf_iff_preservesFiniteProducts_of_projective]
-      exact ⟨fun _ _ ↦ inferInstance⟩ }
+      exact ⟨fun _ ↦ inferInstance⟩ }
 
 /--
 The condensed object associated to a presheaf on `Profinite` which preserves finite products and
@@ -76,7 +76,7 @@ noncomputable def ofSheafProfinite
     val := F
     cond := by
       rw [isSheaf_iff_preservesFiniteProducts_and_equalizerCondition F]
-      exact ⟨⟨fun _ _ ↦ inferInstance⟩, hF⟩ }
+      exact ⟨⟨fun _ ↦ inferInstance⟩, hF⟩ }
 
 /--
 The condensed object associated to a presheaf on `Profinite` whose postcomposition with the
@@ -93,7 +93,7 @@ noncomputable def ofSheafForgetProfinite
     cond := by
       apply isSheaf_coherent_of_hasPullbacks_of_comp F (CategoryTheory.forget A)
       rw [isSheaf_iff_preservesFiniteProducts_and_equalizerCondition]
-      exact ⟨⟨fun _ _ ↦ inferInstance⟩, hF⟩ }
+      exact ⟨⟨fun _ ↦ inferInstance⟩, hF⟩ }
 
 /--
 The condensed object associated to a presheaf on `CompHaus` which preserves finite products and
@@ -105,7 +105,7 @@ noncomputable def ofSheafCompHaus
   val := F
   cond := by
     rw [isSheaf_iff_preservesFiniteProducts_and_equalizerCondition F]
-    exact ⟨⟨fun _ _ ↦ inferInstance⟩, hF⟩
+    exact ⟨⟨fun _ ↦ inferInstance⟩, hF⟩
 
 /--
 The condensed object associated to a presheaf on `CompHaus` whose postcomposition with the
@@ -119,7 +119,7 @@ noncomputable def ofSheafForgetCompHaus
   cond := by
     apply isSheaf_coherent_of_hasPullbacks_of_comp F (CategoryTheory.forget A)
     rw [isSheaf_iff_preservesFiniteProducts_and_equalizerCondition]
-    exact ⟨⟨fun _ _ ↦ inferInstance⟩, hF⟩
+    exact ⟨⟨fun _ ↦ inferInstance⟩, hF⟩
 
 /-- A condensed object satisfies the equalizer condition. -/
 theorem equalizerCondition (X : Condensed A) : EqualizerCondition X.val :=

--- a/Mathlib/Condensed/Light/Explicit.lean
+++ b/Mathlib/Condensed/Light/Explicit.lean
@@ -42,7 +42,7 @@ noncomputable def ofSheafLightProfinite (F : LightProfinite.{u}ᵒᵖ ⥤ A) [Pr
   val := F
   cond := by
     rw [isSheaf_iff_preservesFiniteProducts_and_equalizerCondition F]
-    exact ⟨⟨fun _ _ ↦ inferInstance⟩, hF⟩
+    exact ⟨⟨fun _ ↦ inferInstance⟩, hF⟩
 
 /--
 The light condensed object associated to a presheaf on `LightProfinite` whose postcomposition with
@@ -57,7 +57,7 @@ noncomputable def ofSheafForgetLightProfinite
   cond := by
     apply isSheaf_coherent_of_hasPullbacks_of_comp F (CategoryTheory.forget A)
     rw [isSheaf_iff_preservesFiniteProducts_and_equalizerCondition]
-    exact ⟨⟨fun _ _ ↦ inferInstance⟩, hF⟩
+    exact ⟨⟨fun _ ↦ inferInstance⟩, hF⟩
 
 /-- A light condensed object satisfies the equalizer condition. -/
 theorem equalizerCondition (X : LightCondensed A) : EqualizerCondition X.val :=

--- a/Mathlib/Topology/Category/CompHausLike/Limits.lean
+++ b/Mathlib/Topology/Category/CompHausLike/Limits.lean
@@ -173,7 +173,7 @@ alias Sigma.openEmbedding_ι := Sigma.isOpenEmbedding_ι
 /-- The functor to `TopCat` preserves finite coproducts if they exist. -/
 instance (P) [HasExplicitFiniteCoproducts.{0} P] :
     PreservesFiniteCoproducts (compHausLikeToTop P) := by
-  refine ⟨fun J hJ ↦ ⟨fun {F} ↦ ?_⟩⟩
+  refine ⟨fun _ ↦ ⟨fun {F} ↦ ?_⟩⟩
   suffices PreservesColimit (Discrete.functor (F.obj ∘ Discrete.mk)) (compHausLikeToTop P) from
     preservesColimit_of_iso_diagram _ Discrete.natIsoFunctor.symm
   apply preservesColimit_of_preserves_colimit_cocone (CompHausLike.finiteCoproduct.isColimit _)

--- a/Mathlib/Topology/Category/TopCat/Yoneda.lean
+++ b/Mathlib/Topology/Category/TopCat/Yoneda.lean
@@ -59,7 +59,7 @@ theorem piComparison_fac {α : Type} (X : α → TopCat) :
 
 /-- The universe polymorphic Yoneda presheaf on `TopCat` preserves finite products. -/
 noncomputable instance : PreservesFiniteProducts (yonedaPresheaf'.{w, w'} Y) where
-  preserves _ _ :=
+  preserves _ :=
     { preservesLimit := fun {K} =>
       have : ∀ {α : Type} (X : α → TopCat), PreservesLimit (Discrete.functor (fun x ↦ op (X x)))
           (yonedaPresheaf'.{w, w'} Y) := fun X => @PreservesProduct.of_iso_comparison _ _ _ _

--- a/Mathlib/Topology/Sheaves/SheafCondition/PairwiseIntersections.lean
+++ b/Mathlib/Topology/Sheaves/SheafCondition/PairwiseIntersections.lean
@@ -67,7 +67,7 @@ A presheaf is a sheaf if `F` preserves the limit of `Pairwise.diagram U`.
 `U i ⊓ U j` mapping into the open sets `U i`. This diagram has limit `iSup U`.)
 -/
 def IsSheafPreservesLimitPairwiseIntersections (F : Presheaf C X) : Prop :=
-  ∀ ⦃ι : Type w⦄ (U : ι → Opens X), Nonempty (PreservesLimit (Pairwise.diagram U).op F)
+  ∀ ⦃ι : Type w⦄ (U : ι → Opens X), PreservesLimit (Pairwise.diagram U).op F
 
 end
 
@@ -272,9 +272,9 @@ theorem isSheaf_iff_isSheafPreservesLimitPairwiseIntersections :
   rw [isSheaf_iff_isSheafPairwiseIntersections]
   constructor
   · intro h ι U
-    exact ⟨preservesLimit_of_preserves_limit_cone (Pairwise.coconeIsColimit U).op (h U).some⟩
+    exact preservesLimit_of_preserves_limit_cone (Pairwise.coconeIsColimit U).op (h U).some
   · intro h ι U
-    haveI := (h U).some
+    haveI := h U
     exact ⟨isLimitOfPreserves _ (Pairwise.coconeIsColimit U).op⟩
 
 end TopCat.Presheaf


### PR DESCRIPTION
- Discard unneeded `Subsingleton` instances. Probably, these instances were added when the typeclasses were in `Type*`.
- Require a proof for `Fin _` in the definition, then prove an instance for `J : Type u`.
- Assume `Finite _` instead of `Fintype _` here and there.
- Drop some no longer needed `Nonempty` wrappers.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
