### PR TITLE
[Merged by Bors] - chore(CStarMatrix): drop unneeded `DecidableEq` assumptions

### DIFF
--- a/Mathlib/Analysis/CStarAlgebra/CStarMatrix.lean
+++ b/Mathlib/Analysis/CStarAlgebra/CStarMatrix.lean
@@ -402,7 +402,8 @@ lemma mul_entry_mul_eq_inner_toCLM [DecidableEq m] [DecidableEq n] {M : CStarMat
       = ⟪equiv _ |>.symm (Pi.single i a), toCLM M (equiv _ |>.symm <| Pi.single j b)⟫_A := by
   simp [mul_assoc, inner_def]
 
-lemma toCLM_injective [DecidableEq n] : Function.Injective (toCLM (A := A) (m := m) (n := n)) := by
+lemma toCLM_injective : Function.Injective (toCLM (A := A) (m := m) (n := n)) := by
+  classical
   rw [injective_iff_map_eq_zero]
   intro M h
   ext i j
@@ -432,7 +433,7 @@ lemma norm_def {M : CStarMatrix m n A} : ‖M‖ = ‖toCLM M‖ := rfl
 lemma norm_def' {M : CStarMatrix n n A} : ‖M‖ = ‖toCLMNonUnitalAlgHom (A := A) M‖ := rfl
 
 set_option maxSynthPendingDepth 2 in
-lemma normedSpaceCore [DecidableEq n]: NormedSpace.Core ℂ (CStarMatrix m n A) where
+lemma normedSpaceCore: NormedSpace.Core ℂ (CStarMatrix m n A) where
   norm_nonneg M := (toCLM M).opNorm_nonneg
   norm_smul c M := by rw [norm_def, norm_def, map_smul, norm_smul _ (toCLM M)]
   norm_triangle M₁ M₂ := by simpa [← map_add] using norm_add_le (toCLM M₁) (toCLM M₂)
@@ -440,8 +441,9 @@ lemma normedSpaceCore [DecidableEq n]: NormedSpace.Core ℂ (CStarMatrix m n A) 
     simpa only [norm_def, norm_eq_zero, ← injective_iff_map_eq_zero'] using toCLM_injective
 
 open WithCStarModule in
-lemma norm_entry_le_norm [DecidableEq n] {M : CStarMatrix m n A} {i : m} {j : n} :
+lemma norm_entry_le_norm {M : CStarMatrix m n A} {i : m} {j : n} :
     ‖M i j‖ ≤ ‖M‖ := by
+  classical
   suffices ‖M i j‖ * ‖M i j‖ ≤ ‖M‖ * ‖M i j‖ by
     obtain (h | h) := eq_zero_or_norm_pos (M i j)
     · set_option maxSynthPendingDepth 2 in
@@ -483,7 +485,7 @@ in order to show that the map `ofMatrix` is bilipschitz. We then finally registe
 
 namespace CStarMatrix
 
-variable {m n A : Type*} [Fintype m] [Fintype n] [DecidableEq n]
+variable {m n A : Type*} [Fintype m] [Fintype n]
   [NonUnitalCStarAlgebra A] [PartialOrder A] [StarOrderedRing A]
 
 private noncomputable def normedAddCommGroupAux : NormedAddCommGroup (CStarMatrix m n A) :=
@@ -504,7 +506,7 @@ private lemma nnnorm_le_of_forall_inner_le {M : CStarMatrix m n A} {C : ℝ≥0}
   CStarMatrix.norm_le_of_forall_inner_le fun v w => h v w
 
 open Finset in
-private lemma lipschitzWith_toMatrixAux [DecidableEq m] :
+private lemma lipschitzWith_toMatrixAux :
     LipschitzWith 1 (ofMatrixₗ.symm (R := ℂ) : CStarMatrix m n A → Matrix m n A) := by
   refine AddMonoidHomClass.lipschitz_of_bound_nnnorm _ _ fun M => ?_
   rw [one_mul, ← NNReal.coe_le_coe, coe_nnnorm, coe_nnnorm, Matrix.norm_le_iff (norm_nonneg _)]
@@ -532,12 +534,12 @@ private lemma antilipschitzWith_toMatrixAux :
       exact ofMatrixₗ.symm (R := ℂ) M |>.norm_entry_le_entrywise_sup_norm
     _ = _ := by simp [mul_assoc]
 
-private lemma uniformInducing_toMatrixAux [DecidableEq m] :
+private lemma uniformInducing_toMatrixAux :
     IsUniformInducing (ofMatrix.symm : CStarMatrix m n A → Matrix m n A) :=
   AntilipschitzWith.isUniformInducing antilipschitzWith_toMatrixAux
     lipschitzWith_toMatrixAux.uniformContinuous
 
-private lemma uniformity_eq_aux [DecidableEq m] :
+private lemma uniformity_eq_aux :
     𝓤 (CStarMatrix m n A) = (𝓤[Pi.uniformSpace _] :
       Filter (CStarMatrix m n A × CStarMatrix m n A)) := by
   have :
@@ -548,7 +550,7 @@ private lemma uniformity_eq_aux [DecidableEq m] :
   rfl
 
 open Bornology in
-private lemma cobounded_eq_aux [DecidableEq m] :
+private lemma cobounded_eq_aux :
     cobounded (CStarMatrix m n A) = @cobounded _ Pi.instBornology := by
   have : cobounded (CStarMatrix m n A) = Filter.comap ofMatrix.symm (cobounded _) := by
     refine le_antisymm ?_ ?_
@@ -566,7 +568,7 @@ section non_unital
 
 variable {A : Type*} [NonUnitalCStarAlgebra A] [PartialOrder A] [StarOrderedRing A]
 
-variable {m n : Type*} [Fintype m] [Fintype n] [DecidableEq m]
+variable {m n : Type*} [Fintype m] [Fintype n]
 
 instance instTopologicalSpace : TopologicalSpace (CStarMatrix m n A) := Pi.topologicalSpace
 instance instUniformSpace : UniformSpace (CStarMatrix m n A) := Pi.uniformSpace _
@@ -584,16 +586,16 @@ instance instUniformAddGroup : UniformAddGroup (CStarMatrix m n A) :=
 instance instContinuousSMul {R : Type*} [SMul R A] [TopologicalSpace R] [ContinuousSMul R A] :
     ContinuousSMul R (CStarMatrix m n A) := instContinuousSMulForall
 
-noncomputable instance instNormedAddCommGroup [DecidableEq n] :
+noncomputable instance instNormedAddCommGroup :
     NormedAddCommGroup (CStarMatrix m n A) :=
   .ofCoreReplaceAll CStarMatrix.normedSpaceCore
     CStarMatrix.uniformity_eq_aux.symm
       fun _ => Filter.ext_iff.1 CStarMatrix.cobounded_eq_aux.symm _
 
-instance instNormedSpace [DecidableEq n] : NormedSpace ℂ (CStarMatrix m n A) :=
+instance instNormedSpace : NormedSpace ℂ (CStarMatrix m n A) :=
   .ofCore CStarMatrix.normedSpaceCore
 
-noncomputable instance instNonUnitalNormedRing [DecidableEq n] :
+noncomputable instance instNonUnitalNormedRing :
     NonUnitalNormedRing (CStarMatrix n n A) where
   dist_eq _ _ := rfl
   norm_mul _ _ := by
@@ -602,7 +604,7 @@ noncomputable instance instNonUnitalNormedRing [DecidableEq n] :
 
 open ContinuousLinearMap CStarModule in
 /-- Matrices with entries in a C⋆-algebra form a C⋆-algebra. -/
-instance instCStarRing [DecidableEq n] : CStarRing (CStarMatrix n n A) where
+instance instCStarRing : CStarRing (CStarMatrix n n A) where
   norm_mul_self_le M := by
     have hmain : ‖M‖ ≤ √‖star M * M‖ := by
       change ‖toCLM M‖ ≤ √‖star M * M‖
@@ -630,14 +632,14 @@ instance instCStarRing [DecidableEq n] : CStarRing (CStarMatrix n n A) where
     simp [hmain]
 
 /-- Matrices with entries in a non-unital C⋆-algebra form a non-unital C⋆-algebra. -/
-noncomputable instance instNonUnitalCStarAlgebra [DecidableEq n] :
+noncomputable instance instNonUnitalCStarAlgebra :
     NonUnitalCStarAlgebra (CStarMatrix n n A) where
   smul_assoc x y z := by simp
   smul_comm m a b := (Matrix.mul_smul _ _ _).symm
 
-instance instPartialOrder [DecidableEq n] :
+instance instPartialOrder :
     PartialOrder (CStarMatrix n n A) := CStarAlgebra.spectralOrder _
-instance instStarOrderedRing [DecidableEq n] :
+instance instStarOrderedRing :
     StarOrderedRing (CStarMatrix n n A) := CStarAlgebra.spectralOrderedRing _
 
 end non_unital


### PR DESCRIPTION
Found by the linters in #10235


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
