### PR TITLE
[Merged by Bors] - chore(FLT/Polynomial): drop unneeded `DecidableEq` assumptions

### DIFF
--- a/Mathlib/NumberTheory/FLT/Polynomial.lean
+++ b/Mathlib/NumberTheory/FLT/Polynomial.lean
@@ -66,7 +66,7 @@ private lemma ineq_pqr_contradiction {p q r a b c : ℕ}
     _ = (q * r + r * p + p * q) * (a + b + c) := by ring
     _ ≤ _ := by gcongr
 
-private theorem Polynomial.flt_catalan_deriv [DecidableEq k]
+private theorem Polynomial.flt_catalan_deriv
     {p q r : ℕ} (hp : 0 < p) (hq : 0 < q) (hr : 0 < r)
     (hineq : q * r + r * p + p * q ≤ p * q * r)
     (chp : (p : k) ≠ 0) (chq : (q : k) ≠ 0) (chr : (r : k) ≠ 0)
@@ -92,6 +92,7 @@ private theorem Polynomial.flt_catalan_deriv [DecidableEq k]
   have habcp := hcap.symm.mul_left hbcp
 
   -- Use Mason-Stothers theorem
+  classical
   rcases Polynomial.abc
       (mul_ne_zero hCu hap) (mul_ne_zero hCv hbq) (mul_ne_zero hCw hcr)
       habp heq with nd_lt | dr0
@@ -137,7 +138,6 @@ private lemma find_contract {a : k[X]}
     exact ha heq
   · rw [← natDegree_expand, ← heq]
 
-variable [DecidableEq k]
 
 private theorem Polynomial.flt_catalan_aux
     {p q r : ℕ} {a b c : k[X]} {u v w : k}
@@ -234,6 +234,7 @@ theorem Polynomial.flt
 
 theorem fermatLastTheoremWith'_polynomial {n : ℕ} (hn : 3 ≤ n) (chn : (n : k) ≠ 0) :
     FermatLastTheoremWith' k[X] n := by
+  classical
   rw [FermatLastTheoremWith']
   intros a b c ha hb hc heq
   obtain ⟨a', eq_a⟩ := gcd_dvd_left a b


### PR DESCRIPTION
Found by the linters in #10235


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
