### PR TITLE
[Merged by Bors] - chore(Multilinear/DFinsupp): drop an unused `DecidableEq` assumption

### DIFF
--- a/Mathlib/LinearAlgebra/Multilinear/DFinsupp.lean
+++ b/Mathlib/LinearAlgebra/Multilinear/DFinsupp.lean
@@ -36,7 +36,7 @@ namespace MultilinearMap
 section Semiring
 variable {M : ∀ i, κ i → Type uM} {N : Type uN}
 
-variable [DecidableEq ι] [Fintype ι] [Semiring R]
+variable [Fintype ι] [Semiring R]
 variable [∀ i k, AddCommMonoid (M i k)] [ AddCommMonoid N]
 variable [∀ i k, Module R (M i k)] [Module R N]
 


### PR DESCRIPTION
Found by the linters in #10235


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
