### PR TITLE
[Merged by Bors] - chore(LinearAlgebra): fix some `Fintype`/`DecidableEq`

### DIFF
--- a/Mathlib/LinearAlgebra/Matrix/BaseChange.lean
+++ b/Mathlib/LinearAlgebra/Matrix/BaseChange.lean
@@ -21,9 +21,7 @@ This file is a home for results about base change for matrices.
 
 namespace Matrix
 
-open scoped Matrix
-
-variable {m n L : Type*} [Fintype m] [Fintype n] [DecidableEq m] [Field L]
+variable {m n L : Type*} [Finite m] [Fintype n] [DecidableEq m] [Field L]
   (e : m ≃ n) (K : Subfield L) {A : Matrix m n L} {B : Matrix n m L} (hAB : A * B = 1)
 
 include e hAB
@@ -31,6 +29,7 @@ include e hAB
 lemma mem_subfield_of_mul_eq_one_of_mem_subfield_right
     (h_mem : ∀ i j, A i j ∈ K) (i : n) (j : m) :
     B i j ∈ K := by
+  cases nonempty_fintype m
   let A' : Matrix m m K := of fun i j ↦ ⟨A.submatrix id e i j, h_mem i (e j)⟩
   have hA' : A'.map K.subtype = A.submatrix id e := rfl
   have hA : IsUnit A' := by

--- a/Mathlib/LinearAlgebra/Matrix/Basis.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Basis.lean
@@ -230,10 +230,12 @@ theorem Basis.toMatrix_reindex' [DecidableEq ι] [DecidableEq ι'] (b : Basis ι
     Matrix.reindex_apply, Matrix.submatrix_apply, Function.comp_apply, e.apply_symm_apply,
     Finsupp.mapDomain_equiv_apply]
 
+omit [Fintype ι'] in
 @[simp]
-lemma Basis.toMatrix_mulVec_repr (m : M) :
+lemma Basis.toMatrix_mulVec_repr [Finite ι'] (m : M) :
     b'.toMatrix b *ᵥ b.repr m = b'.repr m := by
   classical
+  cases nonempty_fintype ι'
   simp [← LinearMap.toMatrix_id_eq_basis_toMatrix, LinearMap.toMatrix_mulVec_repr]
 
 end Fintype

--- a/Mathlib/LinearAlgebra/RootSystem/Finite/CanonicalBilinear.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Finite/CanonicalBilinear.lean
@@ -58,11 +58,11 @@ variable [CommRing R] [AddCommGroup M] [Module R M] [AddCommGroup N] [Module R N
 
 section Fintype
 
+instance [Finite ι] : Module.Finite R P.rootSpan := .span_of_finite R <| finite_range P.root
+
+instance [Finite ι] : Module.Finite R P.corootSpan := .span_of_finite R <| finite_range P.coroot
+
 variable [Fintype ι]
-
-instance : Module.Finite R P.rootSpan := Finite.span_of_finite R <| finite_range P.root
-
-instance : Module.Finite R P.corootSpan := Finite.span_of_finite R <| finite_range P.coroot
 
 /-- An invariant linear map from weight space to coweight space. -/
 def Polarization : M →ₗ[R] N :=


### PR DESCRIPTION
Found by the linters in #10235


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
