### PR TITLE
[Merged by Bors] - feat: absolute continuity results for composition of measures and kernels

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4468,6 +4468,7 @@ import Mathlib.Probability.Independence.Kernel
 import Mathlib.Probability.Independence.ZeroOne
 import Mathlib.Probability.Integration
 import Mathlib.Probability.Kernel.Basic
+import Mathlib.Probability.Kernel.Composition.AbsolutelyContinuous
 import Mathlib.Probability.Kernel.Composition.Basic
 import Mathlib.Probability.Kernel.Composition.CompNotation
 import Mathlib.Probability.Kernel.Composition.IntegralCompProd

--- a/Mathlib/Probability/Kernel/Composition/AbsolutelyContinuous.lean
+++ b/Mathlib/Probability/Kernel/Composition/AbsolutelyContinuous.lean
@@ -72,12 +72,8 @@ lemma AbsolutelyContinuous.kernel_of_compProd [SFinite μ] (h : μ ⊗ₘ κ ≪
   rw [← κ.rnDeriv_add_singularPart η, compProd_add_right, AbsolutelyContinuous.add_left_iff] at h
   have : μ ⊗ₘ κ.singularPart η ⟂ₘ ν ⊗ₘ η :=
     MutuallySingular.compProd_of_right μ ν (.of_forall <| Kernel.mutuallySingular_singularPart _ _)
-  have h_zero : μ ⊗ₘ κ.singularPart η = 0 :=
-    eq_zero_of_absolutelyContinuous_of_mutuallySingular h.2 this
-  simp_rw [← measure_univ_eq_zero]
-  refine (lintegral_eq_zero_iff (Kernel.measurable_coe _ .univ)).mp ?_
-  rw [← setLIntegral_univ, ← compProd_apply_prod .univ .univ, h_zero]
-  simp
+  refine compProd_eq_zero_iff.mp ?_
+  exact eq_zero_of_absolutelyContinuous_of_mutuallySingular h.2 this
 
 lemma absolutelyContinuous_compProd_iff' [SFinite μ] [SFinite ν] [∀ a, NeZero (κ a)] :
     μ ⊗ₘ κ ≪ ν ⊗ₘ η ↔ μ ≪ ν ∧ ∀ᵐ a ∂μ, κ a ≪ η a :=

--- a/Mathlib/Probability/Kernel/Composition/AbsolutelyContinuous.lean
+++ b/Mathlib/Probability/Kernel/Composition/AbsolutelyContinuous.lean
@@ -50,9 +50,8 @@ lemma MutuallySingular.compProd_of_right (μ ν : Measure α) (hκη : ∀ᵐ a 
   have h1 a : η a (Prod.mk a ⁻¹' s) = 0 := by rw [h_eq, Kernel.measure_mutuallySingularSetSlice]
   have h2 : ∀ᵐ a ∂μ, κ a (Prod.mk a ⁻¹' s)ᶜ = 0 := by
     filter_upwards [hκη] with a ha
-    rw [h_eq, ← Kernel.withDensity_rnDeriv_eq_zero_iff_measure_eq_zero κ η a,
+    rwa [h_eq, ← Kernel.withDensity_rnDeriv_eq_zero_iff_measure_eq_zero κ η a,
       Kernel.withDensity_rnDeriv_eq_zero_iff_mutuallySingular]
-    exact ha
   simp [h1, lintegral_congr_ae h2]
 
 lemma MutuallySingular.compProd_of_right' (μ ν : Measure α) (hκη : ∀ᵐ a ∂ν, κ a ⟂ₘ η a) :

--- a/Mathlib/Probability/Kernel/Composition/AbsolutelyContinuous.lean
+++ b/Mathlib/Probability/Kernel/Composition/AbsolutelyContinuous.lean
@@ -65,7 +65,7 @@ lemma mutuallySingular_compProd_right_iff [SFinite μ] :
   ⟨fun h ↦ mutuallySingular_of_mutuallySingular_compProd h AbsolutelyContinuous.rfl
     AbsolutelyContinuous.rfl, MutuallySingular.compProd_of_right _ _⟩
 
-lemma AbsolutelyContinuous.kernel_of_compProd [SFinite μ] [SFinite ν] (h : μ ⊗ₘ κ ≪ ν ⊗ₘ η) :
+lemma AbsolutelyContinuous.kernel_of_compProd [SFinite μ] (h : μ ⊗ₘ κ ≪ ν ⊗ₘ η) :
     ∀ᵐ a ∂μ, κ a ≪ η a := by
   suffices ∀ᵐ a ∂μ, κ.singularPart η a = 0 by
     filter_upwards [this] with a ha

--- a/Mathlib/Probability/Kernel/Composition/AbsolutelyContinuous.lean
+++ b/Mathlib/Probability/Kernel/Composition/AbsolutelyContinuous.lean
@@ -1,0 +1,91 @@
+/-
+Copyright (c) 2025 Rémy Degenne. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Rémy Degenne
+-/
+import Mathlib.Probability.Kernel.Composition.MeasureCompProd
+import Mathlib.Probability.Kernel.RadonNikodym
+
+/-!
+# Absolute continuity of the composition of measures and kernels
+
+This file contains some results about the absolute continuity of the composition of measures and
+kernels which use an assumption `CountableOrCountablyGenerated α β` on the measurable spaces.
+
+Results that hold without that assumption are in files about the definitions of compositions and
+products, like `Mathlib.Probability.Kernel.Composition.MeasureCompProd` and
+`Mathlib.Probability.Kernel.Composition.MeasureComp`.
+
+The assumption ensures the measurability of the sets where two kernels are absolutely continuous
+or mutually singular.
+
+## Main statements
+
+* `absolutelyContinuous_compProd_iff'`: `μ ⊗ₘ κ ≪ ν ⊗ₘ η ↔ μ ≪ ν ∧ ∀ᵐ a ∂μ, κ a ≪ η a`.
+
+-/
+
+open ProbabilityTheory Filter
+
+open scoped ENNReal
+
+namespace MeasureTheory.Measure
+
+variable {α β : Type*} {mα : MeasurableSpace α} {mβ : MeasurableSpace β}
+  {μ ν : Measure α} {κ η : Kernel α β} [IsFiniteKernel κ] [IsFiniteKernel η]
+  [MeasurableSpace.CountableOrCountablyGenerated α β]
+
+lemma MutuallySingular.compProd_of_right (μ ν : Measure α) (hκη : ∀ᵐ a ∂μ, κ a ⟂ₘ η a) :
+    μ ⊗ₘ κ ⟂ₘ ν ⊗ₘ η := by
+  by_cases hμ : SFinite μ
+  swap; · rw [compProd_of_not_sfinite _ _ hμ]; simp
+  by_cases hν : SFinite ν
+  swap; · rw [compProd_of_not_sfinite _ _ hν]; simp
+  let s := κ.mutuallySingularSet η
+  have hs : MeasurableSet s := Kernel.measurableSet_mutuallySingularSet κ η
+  symm
+  refine ⟨s, hs, ?_⟩
+  rw [compProd_apply hs, compProd_apply hs.compl]
+  have h_eq a : Prod.mk a ⁻¹' s = Kernel.mutuallySingularSetSlice κ η a := rfl
+  have h1 a : η a (Prod.mk a ⁻¹' s) = 0 := by rw [h_eq, Kernel.measure_mutuallySingularSetSlice]
+  have h2 : ∀ᵐ a ∂μ, κ a (Prod.mk a ⁻¹' s)ᶜ = 0 := by
+    filter_upwards [hκη] with a ha
+    rw [h_eq, ← Kernel.withDensity_rnDeriv_eq_zero_iff_measure_eq_zero κ η a,
+      Kernel.withDensity_rnDeriv_eq_zero_iff_mutuallySingular]
+    exact ha
+  simp [h1, lintegral_congr_ae h2]
+
+lemma MutuallySingular.compProd_of_right' (μ ν : Measure α) (hκη : ∀ᵐ a ∂ν, κ a ⟂ₘ η a) :
+    μ ⊗ₘ κ ⟂ₘ ν ⊗ₘ η := by
+  refine (MutuallySingular.compProd_of_right _ _ ?_).symm
+  simp_rw [MutuallySingular.comm, hκη]
+
+lemma mutuallySingular_compProd_right_iff [SFinite μ] :
+    μ ⊗ₘ κ ⟂ₘ μ ⊗ₘ η ↔ ∀ᵐ a ∂μ, κ a ⟂ₘ η a :=
+  ⟨fun h ↦ mutuallySingular_of_mutuallySingular_compProd h AbsolutelyContinuous.rfl
+    AbsolutelyContinuous.rfl, MutuallySingular.compProd_of_right _ _⟩
+
+lemma AbsolutelyContinuous.kernel_of_compProd [SFinite μ] [SFinite ν] (h : μ ⊗ₘ κ ≪ ν ⊗ₘ η) :
+    ∀ᵐ a ∂μ, κ a ≪ η a := by
+  suffices ∀ᵐ a ∂μ, κ.singularPart η a = 0 by
+    filter_upwards [this] with a ha
+    rwa [Kernel.singularPart_eq_zero_iff_absolutelyContinuous] at ha
+  rw [← κ.rnDeriv_add_singularPart η, compProd_add_right, AbsolutelyContinuous.add_left_iff] at h
+  have : μ ⊗ₘ κ.singularPart η ⟂ₘ ν ⊗ₘ η :=
+    MutuallySingular.compProd_of_right μ ν (.of_forall <| Kernel.mutuallySingular_singularPart _ _)
+  have h_zero : μ ⊗ₘ κ.singularPart η = 0 :=
+    eq_zero_of_absolutelyContinuous_of_mutuallySingular h.2 this
+  simp_rw [← measure_univ_eq_zero]
+  refine (lintegral_eq_zero_iff (Kernel.measurable_coe _ .univ)).mp ?_
+  rw [← setLIntegral_univ, ← compProd_apply_prod .univ .univ, h_zero]
+  simp
+
+lemma absolutelyContinuous_compProd_iff' [SFinite μ] [SFinite ν] [∀ a, NeZero (κ a)] :
+    μ ⊗ₘ κ ≪ ν ⊗ₘ η ↔ μ ≪ ν ∧ ∀ᵐ a ∂μ, κ a ≪ η a :=
+  ⟨fun h ↦ ⟨absolutelyContinuous_of_compProd h, h.kernel_of_compProd⟩, fun h ↦ h.1.compProd h.2⟩
+
+lemma absolutelyContinuous_compProd_right_iff [SFinite μ] :
+    μ ⊗ₘ κ ≪ μ ⊗ₘ η ↔ ∀ᵐ a ∂μ, κ a ≪ η a :=
+  ⟨AbsolutelyContinuous.kernel_of_compProd, AbsolutelyContinuous.compProd_right⟩
+
+end MeasureTheory.Measure

--- a/Mathlib/Probability/Kernel/Composition/AbsolutelyContinuous.lean
+++ b/Mathlib/Probability/Kernel/Composition/AbsolutelyContinuous.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2025 Rémy Degenne. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Rémy Degenne
+Authors: Rémy Degenne, Lorenzo Luccioli
 -/
 import Mathlib.Probability.Kernel.Composition.MeasureCompProd
 import Mathlib.Probability.Kernel.RadonNikodym

--- a/Mathlib/Probability/Kernel/Composition/Basic.lean
+++ b/Mathlib/Probability/Kernel/Composition/Basic.lean
@@ -66,7 +66,7 @@ namespace ProbabilityTheory
 
 namespace Kernel
 
-variable {α β : Type*} {mα : MeasurableSpace α} {mβ : MeasurableSpace β}
+variable {α β γ : Type*} {mα : MeasurableSpace α} {mβ : MeasurableSpace β} {mγ : MeasurableSpace γ}
 
 section CompositionProduct
 
@@ -79,7 +79,7 @@ We define a kernel composition-product
 
 open scoped Function -- required for scoped `on` notation
 
-variable {γ : Type*} {mγ : MeasurableSpace γ} {s : Set (β × γ)}
+variable {s : Set (β × γ)}
 
 /-- Auxiliary function for the definition of the composition-product of two kernels.
 For all `a : α`, `compProdFun κ η a` is a countably additive function with value zero on the empty
@@ -226,6 +226,34 @@ theorem le_compProd_apply (κ : Kernel α β) [IsSFiniteKernel κ] (η : Kernel 
     _ = (κ ⊗ₖ η) a s := measure_toMeasurable s
 
 @[simp]
+lemma compProd_apply_univ {κ : Kernel α β} {η : Kernel (α × β) γ}
+    [IsSFiniteKernel κ] [IsMarkovKernel η] {a : α} :
+    (κ ⊗ₖ η) a Set.univ = κ a Set.univ := by
+  rw [compProd_apply MeasurableSet.univ]
+  simp
+
+lemma compProd_apply_prod {κ : Kernel α β} {η : Kernel (α × β) γ}
+    [IsSFiniteKernel κ] [IsSFiniteKernel η] {a : α}
+    {s : Set β} {t : Set γ} (hs : MeasurableSet s) (ht : MeasurableSet t) :
+    (κ ⊗ₖ η) a (s ×ˢ t) = ∫⁻ b in s, η (a, b) t ∂(κ a) := by
+  rw [compProd_apply (hs.prod ht), ← lintegral_indicator hs]
+  congr with a
+  classical
+  rw [Set.indicator_apply]
+  split_ifs with ha <;> simp [ha]
+
+lemma compProd_congr {κ : Kernel α β} {η η' : Kernel (α × β) γ}
+    [IsSFiniteKernel η] [IsSFiniteKernel η']
+    (h : ∀ a, ∀ᵐ b ∂(κ a), η (a, b) = η' (a, b)) :
+    κ ⊗ₖ η = κ ⊗ₖ η' := by
+  by_cases hκ : IsSFiniteKernel κ
+  swap; · simp_rw [compProd_of_not_isSFiniteKernel_left _ _ hκ]
+  ext a s hs
+  rw [compProd_apply hs, compProd_apply hs]
+  refine lintegral_congr_ae ?_
+  filter_upwards [h a] with b hb using by rw [hb]
+
+@[simp]
 lemma compProd_zero_left (κ : Kernel (α × β) γ) :
     (0 : Kernel α β) ⊗ₖ κ = 0 := by
   by_cases h : IsSFiniteKernel κ
@@ -242,6 +270,18 @@ lemma compProd_zero_right (κ : Kernel α β) (γ : Type*) {mγ : MeasurableSpac
     rw [Kernel.compProd_apply hs]
     simp
   · rw [Kernel.compProd_of_not_isSFiniteKernel_left _ _ h]
+
+lemma compProd_eq_zero_iff {κ : Kernel α β} {η : Kernel (α × β) γ}
+    [IsSFiniteKernel κ] [IsSFiniteKernel η] :
+    κ ⊗ₖ η = 0 ↔ ∀ a, ∀ᵐ b ∂(κ a), η (a, b) = 0 := by
+  refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
+  · simp_rw [← Measure.measure_univ_eq_zero]
+    refine fun a ↦ (lintegral_eq_zero_iff ?_).mp ?_
+    · exact (η.measurable_coe .univ).comp measurable_prod_mk_left
+    · rw [← setLIntegral_univ, ← Kernel.compProd_apply_prod .univ .univ, h]
+      simp
+  · rw [← Kernel.compProd_zero_right κ]
+    exact Kernel.compProd_congr h
 
 lemma compProd_preimage_fst {s : Set β} (hs : MeasurableSet s) (κ : Kernel α β)
     (η : Kernel (α × β) γ) [IsSFiniteKernel κ] [IsMarkovKernel η] (x : α) :
@@ -749,8 +789,6 @@ def prodMkLeft (γ : Type*) [MeasurableSpace γ] (κ : Kernel α β) : Kernel (�
 def prodMkRight (γ : Type*) [MeasurableSpace γ] (κ : Kernel α β) : Kernel (α × γ) β :=
   comap κ Prod.fst measurable_fst
 
-variable {γ : Type*} {mγ : MeasurableSpace γ}
-
 @[simp]
 theorem prodMkLeft_apply (κ : Kernel α β) (ca : γ × α) : prodMkLeft γ κ ca = κ ca.snd :=
   rfl
@@ -949,8 +987,7 @@ lemma fst_map_prod (κ : Kernel α β) {f : β → γ} {g : β → δ} (hg : Mea
       contrapose! hf; exact hf.fst
     simp [map_of_not_measurable _ hf, map_of_not_measurable _ this]
 
-lemma fst_map_id_prod (κ : Kernel α β) {γ : Type*} {mγ : MeasurableSpace γ}
-    {f : β → γ} (hf : Measurable f) :
+lemma fst_map_id_prod (κ : Kernel α β) {f : β → γ} (hf : Measurable f) :
     fst (map κ (fun a ↦ (a, f a))) = κ := by
   rw [fst_map_prod _ hf, Kernel.map_id']
 
@@ -1026,8 +1063,7 @@ lemma snd_map_prod (κ : Kernel α β) {f : β → γ} {g : β → δ} (hf : Mea
       contrapose! hg; exact hg.snd
     simp [map_of_not_measurable _ hg, map_of_not_measurable _ this]
 
-lemma snd_map_prod_id (κ : Kernel α β) {γ : Type*} {mγ : MeasurableSpace γ}
-    {f : β → γ} (hf : Measurable f) :
+lemma snd_map_prod_id (κ : Kernel α β) {f : β → γ} (hf : Measurable f) :
     snd (map κ (fun a ↦ (f a, a))) = κ := by
   rw [snd_map_prod _ hf, Kernel.map_id']
 

--- a/Mathlib/Probability/Kernel/Composition/Basic.lean
+++ b/Mathlib/Probability/Kernel/Composition/Basic.lean
@@ -238,13 +238,10 @@ lemma compProd_apply_prod {κ : Kernel α β} {η : Kernel (α × β) γ}
     (κ ⊗ₖ η) a (s ×ˢ t) = ∫⁻ b in s, η (a, b) t ∂(κ a) := by
   rw [compProd_apply (hs.prod ht), ← lintegral_indicator hs]
   congr with a
-  classical
-  rw [Set.indicator_apply]
-  split_ifs with ha <;> simp [ha]
+  by_cases ha : a ∈ s <;> simp [ha]
 
 lemma compProd_congr {κ : Kernel α β} {η η' : Kernel (α × β) γ}
-    [IsSFiniteKernel η] [IsSFiniteKernel η']
-    (h : ∀ a, ∀ᵐ b ∂(κ a), η (a, b) = η' (a, b)) :
+    [IsSFiniteKernel η] [IsSFiniteKernel η'] (h : ∀ a, ∀ᵐ b ∂(κ a), η (a, b) = η' (a, b)) :
     κ ⊗ₖ η = κ ⊗ₖ η' := by
   by_cases hκ : IsSFiniteKernel κ
   swap; · simp_rw [compProd_of_not_isSFiniteKernel_left _ _ hκ]

--- a/Mathlib/Probability/Kernel/Composition/MeasureCompProd.lean
+++ b/Mathlib/Probability/Kernel/Composition/MeasureCompProd.lean
@@ -65,14 +65,15 @@ lemma compProd_apply_prod [SFinite μ] [IsSFiniteKernel κ]
     (μ ⊗ₘ κ) (s ×ˢ t) = ∫⁻ a in s, κ a t ∂μ := by
   simp [compProd, Kernel.compProd_apply_prod hs ht]
 
-lemma compProd_congr [IsSFiniteKernel κ] [IsSFiniteKernel η]
-    (h : κ =ᵐ[μ] η) : μ ⊗ₘ κ = μ ⊗ₘ η := by
+lemma compProd_congr [IsSFiniteKernel κ] [IsSFiniteKernel η] (h : κ =ᵐ[μ] η) :
+    μ ⊗ₘ κ = μ ⊗ₘ η := by
   rw [compProd, compProd]
   congr 1
   refine Kernel.compProd_congr ?_
   simpa
 
 @[simp] lemma compProd_zero_left (κ : Kernel α β) : (0 : Measure α) ⊗ₘ κ = 0 := by simp [compProd]
+
 @[simp] lemma compProd_zero_right (μ : Measure α) : μ ⊗ₘ (0 : Kernel α β) = 0 := by simp [compProd]
 
 lemma compProd_eq_zero_iff [SFinite μ] [IsSFiniteKernel κ] :

--- a/Mathlib/Probability/Kernel/Composition/MeasureCompProd.lean
+++ b/Mathlib/Probability/Kernel/Composition/MeasureCompProd.lean
@@ -51,9 +51,6 @@ lemma compProd_of_not_isSFiniteKernel (μ : Measure α) (κ : Kernel α β) (h :
   rw [compProd, Kernel.compProd_of_not_isSFiniteKernel_right, Kernel.zero_apply]
   rwa [Kernel.isSFiniteKernel_prodMkLeft_unit]
 
-@[simp] lemma compProd_zero_left (κ : Kernel α β) : (0 : Measure α) ⊗ₘ κ = 0 := by simp [compProd]
-@[simp] lemma compProd_zero_right (μ : Measure α) : μ ⊗ₘ (0 : Kernel α β) = 0 := by simp [compProd]
-
 lemma compProd_apply [SFinite μ] [IsSFiniteKernel κ] {s : Set (α × β)} (hs : MeasurableSet s) :
     (μ ⊗ₘ κ) s = ∫⁻ a, κ a (Prod.mk a ⁻¹' s) ∂μ := by
   simp_rw [compProd, Kernel.compProd_apply hs, Kernel.const_apply, Kernel.prodMkLeft_apply']
@@ -61,17 +58,32 @@ lemma compProd_apply [SFinite μ] [IsSFiniteKernel κ] {s : Set (α × β)} (hs 
 
 @[simp]
 lemma compProd_apply_univ [SFinite μ] [IsMarkovKernel κ] : (μ ⊗ₘ κ) univ = μ univ := by
-  rw [compProd_apply MeasurableSet.univ]
-  simp
+  simp [compProd]
 
 lemma compProd_apply_prod [SFinite μ] [IsSFiniteKernel κ]
     {s : Set α} {t : Set β} (hs : MeasurableSet s) (ht : MeasurableSet t) :
     (μ ⊗ₘ κ) (s ×ˢ t) = ∫⁻ a in s, κ a t ∂μ := by
-  rw [compProd_apply (hs.prod ht), ← lintegral_indicator hs]
-  congr with a
-  classical
-  rw [indicator_apply]
-  split_ifs with ha <;> simp [ha]
+  simp [compProd, Kernel.compProd_apply_prod hs ht]
+
+lemma compProd_congr [IsSFiniteKernel κ] [IsSFiniteKernel η]
+    (h : κ =ᵐ[μ] η) : μ ⊗ₘ κ = μ ⊗ₘ η := by
+  rw [compProd, compProd]
+  congr 1
+  refine Kernel.compProd_congr ?_
+  simpa
+
+@[simp] lemma compProd_zero_left (κ : Kernel α β) : (0 : Measure α) ⊗ₘ κ = 0 := by simp [compProd]
+@[simp] lemma compProd_zero_right (μ : Measure α) : μ ⊗ₘ (0 : Kernel α β) = 0 := by simp [compProd]
+
+lemma compProd_eq_zero_iff [SFinite μ] [IsSFiniteKernel κ] :
+    μ ⊗ₘ κ = 0 ↔ ∀ᵐ a ∂μ, κ a = 0 := by
+  refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
+  · simp_rw [← measure_univ_eq_zero]
+    refine (lintegral_eq_zero_iff (Kernel.measurable_coe _ .univ)).mp ?_
+    rw [← setLIntegral_univ, ← compProd_apply_prod .univ .univ, h]
+    simp
+  · rw [← compProd_zero_right μ]
+    exact compProd_congr h
 
 lemma _root_.ProbabilityTheory.Kernel.compProd_apply_eq_compProd_sectR {γ : Type*}
     {mγ : MeasurableSpace γ} (κ : Kernel α β) (η : Kernel (α × β) γ)
@@ -91,15 +103,6 @@ lemma compProd_id [SFinite μ] : μ ⊗ₘ Kernel.id = μ.map (fun x ↦ (x, x))
   _ = μ ((fun x ↦ (x, x)) ⁻¹' s) := by
     rw [lintegral_indicator_one]
     exact (measurable_id.prod measurable_id) hs
-
-lemma compProd_congr [IsSFiniteKernel κ] [IsSFiniteKernel η]
-    (h : κ =ᵐ[μ] η) : μ ⊗ₘ κ = μ ⊗ₘ η := by
-  by_cases hμ : SFinite μ
-  · ext s hs
-    have : (fun a ↦ κ a (Prod.mk a ⁻¹' s)) =ᵐ[μ] fun a ↦ η a (Prod.mk a ⁻¹' s) := by
-      filter_upwards [h] with a ha using by rw [ha]
-    rw [compProd_apply hs, lintegral_congr_ae this, compProd_apply hs]
-  · simp [compProd_of_not_sfinite _ _ hμ]
 
 lemma ae_compProd_of_ae_ae {p : α × β → Prop}
     (hp : MeasurableSet {x | p x}) (h : ∀ᵐ a ∂μ, ∀ᵐ b ∂(κ a), p (a, b)) :


### PR DESCRIPTION
A new file with results about the absolute continuity of the composition of measures and kernels which use an assumption `CountableOrCountablyGenerated α β` on the measurable spaces.

From the TestingLowerBounds project.
Co-authored-by: Lorenzo Luccioli

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
