### PR TITLE
[Merged by Bors] - feat: properties of condExpKernel and condDistrib

### DIFF
--- a/Mathlib/MeasureTheory/Measure/Trim.lean
+++ b/Mathlib/MeasureTheory/Measure/Trim.lean
@@ -53,6 +53,11 @@ theorem le_trim (hm : m ≤ m0) : μ s ≤ μ.trim hm s := by
   simp_rw [Measure.trim]
   exact @le_toMeasure_apply _ m _ _ _
 
+lemma trim_eq_map (hm : m ≤ m0) : μ.trim hm = @Measure.map _ _ _ m id μ := by
+  refine @Measure.ext α m _ _ (fun s hs ↦ ?_)
+  rw [@Measure.map_apply _ _ _ m _ _ (measurable_id'' hm) _ hs, trim_measurableSet_eq hm hs,
+    Set.preimage_id]
+
 lemma trim_add {ν : Measure α} (hm : m ≤ m0) : (μ + ν).trim hm = μ.trim hm + ν.trim hm :=
   @Measure.ext _ m _ _ (fun s hs ↦ by simp [trim_measurableSet_eq hm hs])
 

--- a/Mathlib/MeasureTheory/Measure/Trim.lean
+++ b/Mathlib/MeasureTheory/Measure/Trim.lean
@@ -55,8 +55,7 @@ theorem le_trim (hm : m ≤ m0) : μ s ≤ μ.trim hm s := by
 
 lemma trim_eq_map (hm : m ≤ m0) : μ.trim hm = @Measure.map _ _ _ m id μ := by
   refine @Measure.ext α m _ _ (fun s hs ↦ ?_)
-  rw [@Measure.map_apply _ _ _ m _ _ (measurable_id'' hm) _ hs, trim_measurableSet_eq hm hs,
-    Set.preimage_id]
+  rw [Measure.map_apply (measurable_id'' hm) hs, trim_measurableSet_eq hm hs, Set.preimage_id]
 
 lemma trim_add {ν : Measure α} (hm : m ≤ m0) : (μ + ν).trim hm = μ.trim hm + ν.trim hm :=
   @Measure.ext _ m _ _ (fun s hs ↦ by simp [trim_measurableSet_eq hm hs])

--- a/Mathlib/Probability/Kernel/CondDistrib.lean
+++ b/Mathlib/Probability/Kernel/CondDistrib.lean
@@ -96,7 +96,7 @@ variable [NormedSpace ℝ F]
 
 theorem _root_.MeasureTheory.StronglyMeasurable.integral_condDistrib (hf : StronglyMeasurable f) :
     StronglyMeasurable (fun x ↦ ∫ y, f (x, y) ∂condDistrib Y X μ x) := by
-  rw [condDistrib]; exact hf.integral_condKernel
+  rw [condDistrib]; exact hf.integral_kernel_prod_right'
 
 theorem _root_.MeasureTheory.AEStronglyMeasurable.integral_condDistrib_map
     (hY : AEMeasurable Y μ) (hf : AEStronglyMeasurable f (μ.map fun a => (X a, Y a))) :

--- a/Mathlib/Probability/Kernel/CondDistrib.lean
+++ b/Mathlib/Probability/Kernel/CondDistrib.lean
@@ -75,6 +75,10 @@ lemma condDistrib_apply_of_ne_zero [MeasurableSingletonClass β]
   · rw [Measure.fst_map_prod_mk hY]
   · rwa [Measure.fst_map_prod_mk hY]
 
+lemma compProd_map_condDistrib (hY : AEMeasurable Y μ) :
+    (μ.map X) ⊗ₘ condDistrib Y X μ = μ.map fun a ↦ (X a, Y a) := by
+  rw [condDistrib, ← Measure.fst_map_prod_mk₀ hY, Measure.disintegrate]
+
 section Measurability
 
 theorem measurable_condDistrib (hs : MeasurableSet s) :
@@ -90,6 +94,10 @@ theorem _root_.MeasureTheory.AEStronglyMeasurable.ae_integrable_condDistrib_map_
 
 variable [NormedSpace ℝ F]
 
+theorem _root_.MeasureTheory.StronglyMeasurable.integral_condDistrib (hf : StronglyMeasurable f) :
+    StronglyMeasurable (fun x ↦ ∫ y, f (x, y) ∂condDistrib Y X μ x) := by
+  rw [condDistrib]; exact hf.integral_condKernel
+
 theorem _root_.MeasureTheory.AEStronglyMeasurable.integral_condDistrib_map
     (hY : AEMeasurable Y μ) (hf : AEStronglyMeasurable f (μ.map fun a => (X a, Y a))) :
     AEStronglyMeasurable (fun x => ∫ y, f (x, y) ∂condDistrib Y X μ x) (μ.map X) := by
@@ -99,6 +107,10 @@ theorem _root_.MeasureTheory.AEStronglyMeasurable.integral_condDistrib (hX : AEM
     (hY : AEMeasurable Y μ) (hf : AEStronglyMeasurable f (μ.map fun a => (X a, Y a))) :
     AEStronglyMeasurable (fun a => ∫ y, f (X a, y) ∂condDistrib Y X μ (X a)) μ :=
   (hf.integral_condDistrib_map hY).comp_aemeasurable hX
+
+theorem stronglyMeasurable_integral_condDistrib (hf : StronglyMeasurable f) :
+    StronglyMeasurable[mβ.comap X] (fun a ↦ ∫ y, f (X a, y) ∂condDistrib Y X μ (X a)) :=
+  (hf.integral_condDistrib).comp_measurable <| Measurable.of_comap_le le_rfl
 
 theorem aestronglyMeasurable_integral_condDistrib (hX : AEMeasurable X μ) (hY : AEMeasurable Y μ)
     (hf : AEStronglyMeasurable f (μ.map fun a => (X a, Y a))) :

--- a/Mathlib/Probability/Kernel/Condexp.lean
+++ b/Mathlib/Probability/Kernel/Condexp.lean
@@ -111,7 +111,7 @@ lemma compProd_trim_condExpKernel (hm : m ≤ mΩ) :
   simp only [Kernel.coe_comap, Function.comp_apply, id_eq]
   congr
 
-lemma condExpKernel_comp_trim (hm : m ≤ mΩ) : (condExpKernel μ m) ∘ₘ (μ.trim hm) = μ := by
+lemma condExpKernel_comp_trim (hm : m ≤ mΩ) : condExpKernel μ m ∘ₘ μ.trim hm = μ := by
   rw [← Measure.snd_compProd, compProd_trim_condExpKernel, @Measure.snd_map_prod_mk]
   · simp
   · exact measurable_id'' hm

--- a/Mathlib/Probability/Kernel/Condexp.lean
+++ b/Mathlib/Probability/Kernel/Condexp.lean
@@ -136,8 +136,7 @@ theorem _root_.MeasureTheory.StronglyMeasurable.integral_condExpKernel' [NormedS
     StronglyMeasurable[m ⊓ mΩ] (fun ω ↦ ∫ y, f y ∂condExpKernel μ m ω) := by
   nontriviality Ω
   simp_rw [condExpKernel_apply_eq_condDistrib]
-  refine StronglyMeasurable.integral_condDistrib (f := fun p ↦ f p.2) ?_
-  exact hf.comp_measurable measurable_snd
+  exact (hf.comp_measurable measurable_snd).integral_condDistrib
 
 theorem _root_.MeasureTheory.StronglyMeasurable.integral_condExpKernel [NormedSpace ℝ F]
     (hf : StronglyMeasurable f) :

--- a/Mathlib/Probability/Kernel/Condexp.lean
+++ b/Mathlib/Probability/Kernel/Condexp.lean
@@ -96,6 +96,20 @@ instance : IsMarkovKernel (condExpKernel μ m) := by
   · exact ⟨fun a ↦ (IsEmpty.false a).elim⟩
   · simp [condExpKernel, h]; infer_instance
 
+lemma compProd_trim_condExpKernel (hm : m ≤ mΩ) :
+    (μ.trim hm) ⊗ₘ condExpKernel μ m
+      = @Measure.map Ω (Ω × Ω) mΩ (m.prod mΩ) (fun ω ↦ (id ω, id ω)) μ := by
+  rcases isEmpty_or_nonempty Ω with h | h
+  · simp [Measure.eq_zero_of_isEmpty μ]
+  rw [condExpKernel_eq]
+  have : m ⊓ mΩ = m := inf_of_le_left hm
+  have h := compProd_map_condDistrib (mβ := m) (μ := μ) (X := id) measurable_id.aemeasurable
+  rw [← h, trim_eq_map hm]
+  congr 1
+  ext a s hs
+  simp only [Kernel.coe_comap, Function.comp_apply, id_eq]
+  congr
+
 section Measurability
 
 variable [NormedAddCommGroup F] {f : Ω → F}
@@ -116,6 +130,19 @@ theorem stronglyMeasurable_condExpKernel {s : Set Ω} (hs : MeasurableSet s) :
 
 @[deprecated (since := "2025-01-21")]
 alias stronglyMeasurable_condexpKernel := stronglyMeasurable_condExpKernel
+
+theorem _root_.MeasureTheory.StronglyMeasurable.integral_condExpKernel' [NormedSpace ℝ F]
+    (hf : StronglyMeasurable f) :
+    StronglyMeasurable[m ⊓ mΩ] (fun ω ↦ ∫ y, f y ∂condExpKernel μ m ω) := by
+  nontriviality Ω
+  simp_rw [condExpKernel_apply_eq_condDistrib]
+  refine StronglyMeasurable.integral_condDistrib (f := fun p ↦ f p.2) ?_
+  exact hf.comp_measurable measurable_snd
+
+theorem _root_.MeasureTheory.StronglyMeasurable.integral_condExpKernel [NormedSpace ℝ F]
+    (hf : StronglyMeasurable f) :
+    StronglyMeasurable[m] (fun ω ↦ ∫ y, f y ∂condExpKernel μ m ω) :=
+  hf.integral_condExpKernel'.mono inf_le_left
 
 theorem _root_.MeasureTheory.AEStronglyMeasurable.integral_condExpKernel [NormedSpace ℝ F]
     (hf : AEStronglyMeasurable f μ) :

--- a/Mathlib/Probability/Kernel/Condexp.lean
+++ b/Mathlib/Probability/Kernel/Condexp.lean
@@ -3,6 +3,7 @@ Copyright (c) 2023 Rémy Degenne. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Rémy Degenne
 -/
+import Mathlib.Probability.Kernel.Composition.MeasureComp
 import Mathlib.Probability.Kernel.CondDistrib
 import Mathlib.Probability.ConditionalProbability
 
@@ -109,6 +110,11 @@ lemma compProd_trim_condExpKernel (hm : m ≤ mΩ) :
   ext a s hs
   simp only [Kernel.coe_comap, Function.comp_apply, id_eq]
   congr
+
+lemma condExpKernel_comp_trim (hm : m ≤ mΩ) : (condExpKernel μ m) ∘ₘ (μ.trim hm) = μ := by
+  rw [← Measure.snd_compProd, compProd_trim_condExpKernel, @Measure.snd_map_prod_mk]
+  · simp
+  · exact measurable_id'' hm
 
 section Measurability
 

--- a/Mathlib/Probability/Kernel/Condexp.lean
+++ b/Mathlib/Probability/Kernel/Condexp.lean
@@ -112,9 +112,8 @@ lemma compProd_trim_condExpKernel (hm : m ≤ mΩ) :
   congr
 
 lemma condExpKernel_comp_trim (hm : m ≤ mΩ) : condExpKernel μ m ∘ₘ μ.trim hm = μ := by
-  rw [← Measure.snd_compProd, compProd_trim_condExpKernel, @Measure.snd_map_prod_mk]
-  · simp
-  · exact measurable_id'' hm
+   rw [← Measure.snd_compProd, compProd_trim_condExpKernel, @Measure.snd_map_prod_mk, Measure.map_id]
+  exact measurable_id'' hm
 
 section Measurability
 

--- a/Mathlib/Probability/Kernel/Condexp.lean
+++ b/Mathlib/Probability/Kernel/Condexp.lean
@@ -112,7 +112,7 @@ lemma compProd_trim_condExpKernel (hm : m ≤ mΩ) :
   congr
 
 lemma condExpKernel_comp_trim (hm : m ≤ mΩ) : condExpKernel μ m ∘ₘ μ.trim hm = μ := by
-   rw [← Measure.snd_compProd, compProd_trim_condExpKernel, @Measure.snd_map_prod_mk, Measure.map_id]
+  rw [← Measure.snd_compProd, compProd_trim_condExpKernel, @Measure.snd_map_prod_mk, Measure.map_id]
   exact measurable_id'' hm
 
 section Measurability

--- a/Mathlib/Probability/Kernel/Disintegration/Integral.lean
+++ b/Mathlib/Probability/Kernel/Disintegration/Integral.lean
@@ -184,6 +184,11 @@ section Integral
 variable {ρ : Measure (β × Ω)} [IsFiniteMeasure ρ]
   {E : Type*} {f : β × Ω → E} [NormedAddCommGroup E] [NormedSpace ℝ E]
 
+lemma _root_.MeasureTheory.StronglyMeasurable.integral_condKernel
+    (hf : StronglyMeasurable f) :
+    StronglyMeasurable (fun x ↦ ∫ y, f (x, y) ∂ρ.condKernel x) :=
+  hf.integral_kernel_prod_right'
+
 lemma _root_.MeasureTheory.AEStronglyMeasurable.integral_condKernel
     (hf : AEStronglyMeasurable f ρ) :
     AEStronglyMeasurable (fun x ↦ ∫ y, f (x, y) ∂ρ.condKernel x) ρ.fst := by

--- a/Mathlib/Probability/Kernel/Disintegration/Integral.lean
+++ b/Mathlib/Probability/Kernel/Disintegration/Integral.lean
@@ -184,11 +184,6 @@ section Integral
 variable {ρ : Measure (β × Ω)} [IsFiniteMeasure ρ]
   {E : Type*} {f : β × Ω → E} [NormedAddCommGroup E] [NormedSpace ℝ E]
 
-lemma _root_.MeasureTheory.StronglyMeasurable.integral_condKernel
-    (hf : StronglyMeasurable f) :
-    StronglyMeasurable (fun x ↦ ∫ y, f (x, y) ∂ρ.condKernel x) :=
-  hf.integral_kernel_prod_right'
-
 lemma _root_.MeasureTheory.AEStronglyMeasurable.integral_condKernel
     (hf : AEStronglyMeasurable f ρ) :
     AEStronglyMeasurable (fun x ↦ ∫ y, f (x, y) ∂ρ.condKernel x) ρ.fst := by


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
