### PR TITLE
[Merged by Bors] - feat: finset of pairs of divisors of an integer

### DIFF
--- a/Mathlib/Data/Nat/Cast/Order/Ring.lean
+++ b/Mathlib/Data/Nat/Cast/Order/Ring.lean
@@ -13,7 +13,7 @@ import Mathlib.Data.Nat.Cast.Order.Basic
 
 -/
 
-variable {α : Type*}
+variable {R α : Type*}
 
 namespace Nat
 
@@ -78,14 +78,22 @@ theorem cast_tsub [OrderedCommSemiring α] [CanonicallyOrderedAdd α] [Sub α] [
   · rcases le_iff_exists_add'.mp h with ⟨m, rfl⟩
     rw [add_tsub_cancel_right, cast_add, add_tsub_cancel_right]
 
+section LinearOrderedRing
+variable [LinearOrderedRing R] {m n : ℕ}
+
 @[simp, norm_cast]
-theorem abs_cast [LinearOrderedRing α] (a : ℕ) : |(a : α)| = a :=
-  abs_of_nonneg (cast_nonneg a)
+theorem abs_cast (n : ℕ) : |(n : R)| = n := abs_of_nonneg n.cast_nonneg
 
 @[simp]
-theorem abs_ofNat [LinearOrderedRing α] (n : ℕ) [n.AtLeastTwo] :
-    |(ofNat(n) : α)| = ofNat(n) :=
-  abs_cast n
+theorem abs_ofNat (n : ℕ) [n.AtLeastTwo] : |(ofNat(n) : R)| = ofNat(n) := abs_cast n
+
+@[simp, norm_cast] lemma neg_cast_eq_cast : (-m : R) = n ↔ m = 0 ∧ n = 0 := by
+  simp [neg_eq_iff_add_eq_zero, ← cast_add]
+
+@[simp, norm_cast] lemma cast_eq_neg_cast : (m : R) = -n ↔ m = 0 ∧ n = 0 := by
+  simp [eq_neg_iff_add_eq_zero, ← cast_add]
+
+end LinearOrderedRing
 
 lemma mul_le_pow {a : ℕ} (ha : a ≠ 1) (b : ℕ) :
     a * b ≤ a ^ b := by

--- a/Mathlib/NumberTheory/Divisors.lean
+++ b/Mathlib/NumberTheory/Divisors.lean
@@ -3,9 +3,11 @@ Copyright (c) 2020 Aaron Anderson. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Aaron Anderson
 -/
-import Mathlib.Algebra.Order.BigOperators.Group.Finset
-import Mathlib.Algebra.Order.Ring.Nat
 import Mathlib.Algebra.IsPrimePow
+import Mathlib.Algebra.Order.BigOperators.Group.Finset
+import Mathlib.Algebra.Order.Ring.Int
+import Mathlib.Algebra.Ring.CharZero
+import Mathlib.Data.Nat.Cast.Order.Ring
 import Mathlib.Data.Nat.PrimeFin
 import Mathlib.Order.Interval.Finset.Nat
 
@@ -43,8 +45,12 @@ def divisors : Finset ℕ := {d ∈ Ico 1 (n + 1) | d ∣ n}
   As a special case, `properDivisors 0 = ∅`. -/
 def properDivisors : Finset ℕ := {d ∈ Ico 1 n | d ∣ n}
 
-/-- `divisorsAntidiagonal n` is the `Finset` of pairs `(x,y)` such that `x * y = n`.
-  As a special case, `divisorsAntidiagonal 0 = ∅`. -/
+/-- Pairs of divisors of a natural number as a finset.
+
+`n.divisorsAntidiagonal` is the finset of pairs `(a, b) : ℕ × ℕ` such that `a * b = n`.
+As a special case, `Nat.divisorsAntidiagonal 0 = ∅`.
+
+O(n). -/
 def divisorsAntidiagonal : Finset (ℕ × ℕ) :=
   (Icc 1 n).filterMap (fun x ↦ let y := n / x; if x * y = n then some (x, y) else none)
     fun x₁ x₂ (x, y) hx₁ hx₂ ↦ by aesop
@@ -242,10 +248,14 @@ theorem swap_mem_divisorsAntidiagonal {x : ℕ × ℕ} :
     x.swap ∈ divisorsAntidiagonal n ↔ x ∈ divisorsAntidiagonal n := by
   rw [mem_divisorsAntidiagonal, mem_divisorsAntidiagonal, mul_comm, Prod.swap]
 
+/-- Simp normal form of `Nat.swap_mem_divisorsAntidiagonal`. -/
 @[simp]
 theorem swap_mem_divisorsAntidiagonal_aux {x : ℕ × ℕ} :
     x.snd * x.fst = n ∧ ¬n = 0 ↔ x ∈ divisorsAntidiagonal n := by
   rw [mem_divisorsAntidiagonal, mul_comm]
+
+lemma prodMk_mem_divisorsAntidiag {x y : ℕ} (hn : n ≠ 0) :
+    (x, y) ∈ n.divisorsAntidiagonal ↔ x * y = n := by simp [hn]
 
 theorem fst_mem_divisors_of_mem_antidiagonal {x : ℕ × ℕ} (h : x ∈ divisorsAntidiagonal n) :
     x.fst ∈ divisors n := by
@@ -514,3 +524,113 @@ theorem disjoint_divisors_filter_isPrimePow {a b : ℕ} (hab : a.Coprime b) :
   exact hn.ne_one (Nat.eq_one_of_dvd_coprimes hab han hbn)
 
 end Nat
+
+namespace Int
+variable {xy : ℤ × ℤ} {x y z : ℤ}
+
+-- Local notation for the embeddings `n ↦ n, n ↦ -n : ℕ → ℤ`
+local notation "natCast" => Nat.castEmbedding (R := ℤ)
+local notation "negNatCast" =>
+  Function.Embedding.trans Nat.castEmbedding (Equiv.toEmbedding (Equiv.neg ℤ))
+
+/-- Pairs of divisors of an integer as a finset.
+
+`z.divisorsAntidiag` is the finset of pairs `(a, b) : ℤ × ℤ` such that `a * b = z`.
+As a special case, `Int.divisorsAntidiag 0 = ∅`.
+
+O(|z|). Computed from `Nat.divisorsAntidiagonal`. -/
+def divisorsAntidiag : (z : ℤ) → Finset (ℤ × ℤ)
+  | (n : ℕ) =>
+    let s : Finset (ℕ × ℕ) := n.divisorsAntidiagonal
+    (s.map <| .prodMap natCast natCast).disjUnion (s.map <| .prodMap negNatCast negNatCast) <| by
+      simp +contextual [s, disjoint_left, eq_comm]
+  | negSucc n =>
+    let s : Finset (ℕ × ℕ) := (n + 1).divisorsAntidiagonal
+    (s.map <| .prodMap natCast negNatCast).disjUnion (s.map <| .prodMap negNatCast natCast) <| by
+      simp +contextual [s, disjoint_left, eq_comm, forall_swap (α := _ * _ = _)]
+
+@[simp]
+lemma mem_divisorsAntidiag :
+    ∀ {z} {xy : ℤ × ℤ}, xy ∈ divisorsAntidiag z ↔ xy.fst * xy.snd = z ∧ z ≠ 0
+  | (n : ℕ), ((x : ℕ), (y : ℕ)) => by
+    simp [divisorsAntidiag]
+    norm_cast
+    simp +contextual [eq_comm]
+  | (n : ℕ), (negSucc x, negSucc y) => by
+    simp [divisorsAntidiag, negSucc_eq, -neg_add_rev]
+    norm_cast
+    simp +contextual [eq_comm]
+  | (n : ℕ), ((x : ℕ), negSucc y) => by
+    simp [divisorsAntidiag, negSucc_eq, -neg_add_rev]
+    norm_cast
+    aesop
+  | (n : ℕ), (negSucc x, (y : ℕ)) => by
+    simp [divisorsAntidiag]
+    norm_cast
+    aesop
+  | .negSucc n, ((x : ℕ), (y : ℕ)) => by
+    simp [divisorsAntidiag]
+    norm_cast
+    aesop
+  | .negSucc n, (negSucc x, negSucc y) => by
+    simp [divisorsAntidiag, negSucc_eq, -neg_add_rev]
+    norm_cast
+    simp +contextual [eq_comm]
+  | .negSucc n, ((x : ℕ), negSucc y) => by
+    simp [divisorsAntidiag, negSucc_eq, -neg_add_rev]
+    norm_cast
+    aesop
+  | .negSucc n, (negSucc x, (y : ℕ)) => by
+    simp [divisorsAntidiag, negSucc_eq, -neg_add_rev]
+    norm_cast
+    simp +contextual [eq_comm]
+
+@[simp] lemma divisorsAntidiag_zero : divisorsAntidiag 0 = ∅ := rfl
+
+lemma prodMk_mem_divisorsAntidiag (hz : z ≠ 0) : (x, y) ∈ z.divisorsAntidiag ↔ x * y = z := by
+  simp [hz]
+
+lemma swap_mem_divisorsAntidiag : xy.swap ∈ z.divisorsAntidiag ↔ xy ∈ z.divisorsAntidiag := by
+  simp [mul_comm]
+
+/-- Simp normal form of `Nat.swap_mem_divisorsAntidiagonal`. -/
+@[simp]
+lemma swap_mem_divisorsAntidiagonal_aux :
+    xy.snd * xy.fst = z ∧ ¬z = 0 ↔ xy ∈ z.divisorsAntidiag := by simp [mul_comm]
+
+lemma neg_mem_divisorsAntidiag : -xy ∈ z.divisorsAntidiag ↔ xy ∈ z.divisorsAntidiag := by simp
+
+@[simp]
+lemma map_prodComm_divisorsAntidiag :
+    z.divisorsAntidiag.map (Equiv.prodComm _ _).toEmbedding = z.divisorsAntidiag := by
+  ext; simp [mem_divisorsAntidiag, mul_comm]
+
+@[simp]
+lemma map_neg_divisorsAntidiag :
+    z.divisorsAntidiag.map (Equiv.neg _).toEmbedding = z.divisorsAntidiag := by
+  ext; simp [mem_divisorsAntidiag, mul_comm]
+
+lemma divisorsAntidiag_neg :
+    (-z).divisorsAntidiag =
+      z.divisorsAntidiag.map (.prodMap (.refl _) (Equiv.neg _).toEmbedding) := by
+  ext; simp [mem_divisorsAntidiag, Prod.ext_iff, neg_eq_iff_eq_neg]
+
+lemma divisorsAntidiag_natCast (n : ℕ) :
+    divisorsAntidiag n =
+      (n.divisorsAntidiagonal.map <| .prodMap natCast natCast).disjUnion
+        (n.divisorsAntidiagonal.map <| .prodMap negNatCast negNatCast) (by
+          simp +contextual [disjoint_left, eq_comm]) := rfl
+
+lemma divisorsAntidiag_neg_natCast (n : ℕ) :
+    divisorsAntidiag (-n) =
+      (n.divisorsAntidiagonal.map <| .prodMap natCast negNatCast).disjUnion
+        (n.divisorsAntidiagonal.map <| .prodMap negNatCast natCast) (by
+          simp +contextual [disjoint_left, eq_comm]) := by cases n <;> rfl
+
+lemma divisorsAntidiag_ofNat (n : ℕ) :
+    divisorsAntidiag ofNat(n) =
+      (n.divisorsAntidiagonal.map <| .prodMap natCast natCast).disjUnion
+        (n.divisorsAntidiagonal.map <| .prodMap negNatCast negNatCast) (by
+          simp +contextual [disjoint_left, eq_comm]) := rfl
+
+end Int

--- a/Mathlib/NumberTheory/Divisors.lean
+++ b/Mathlib/NumberTheory/Divisors.lean
@@ -246,19 +246,16 @@ theorem divisorsAntidiagonal_one : divisorsAntidiagonal 1 = {(1, 1)} := by
   ext
   simp [mul_eq_one, Prod.ext_iff]
 
--- The left hand side is not in simp normal form, see the variant below.
+@[simp high]
 theorem swap_mem_divisorsAntidiagonal {x : ℕ × ℕ} :
     x.swap ∈ divisorsAntidiagonal n ↔ x ∈ divisorsAntidiagonal n := by
   rw [mem_divisorsAntidiagonal, mem_divisorsAntidiagonal, mul_comm, Prod.swap]
 
 /-- `Nat.swap_mem_divisorsAntidiagonal` with the LHS in simp normal form. -/
-@[simp]
-theorem swap_mem_divisorsAntidiagonal_simpNF {x : ℕ × ℕ} :
+@[deprecated swap_mem_divisorsAntidiagonal (since := "2025-02-17")]
+theorem swap_mem_divisorsAntidiagonal_aux {x : ℕ × ℕ} :
     x.snd * x.fst = n ∧ ¬n = 0 ↔ x ∈ divisorsAntidiagonal n := by
   rw [mem_divisorsAntidiagonal, mul_comm]
-
-@[deprecated (since := "2025-02-16")]
-alias swap_mem_divisorsAntidiagonal_aux := swap_mem_divisorsAntidiagonal_simpNF
 
 lemma prodMk_mem_divisorsAntidiag {x y : ℕ} (hn : n ≠ 0) :
     (x, y) ∈ n.divisorsAntidiagonal ↔ x * y = n := by simp [hn]
@@ -596,14 +593,9 @@ lemma mem_divisorsAntidiag :
 lemma prodMk_mem_divisorsAntidiag (hz : z ≠ 0) : (x, y) ∈ z.divisorsAntidiag ↔ x * y = z := by
   simp [hz]
 
--- The left hand side is not in simp normal form, see the variant below.
+@[simp high]
 lemma swap_mem_divisorsAntidiag : xy.swap ∈ z.divisorsAntidiag ↔ xy ∈ z.divisorsAntidiag := by
   simp [mul_comm]
-
-/-- `Int.swap_mem_divisorsAntidiag` with the LHS in simp normal form. -/
-@[simp]
-lemma swap_mem_divisorsAntidiag_simpNF :
-    xy.snd * xy.fst = z ∧ ¬z = 0 ↔ xy ∈ z.divisorsAntidiag := by simp [mul_comm]
 
 lemma neg_mem_divisorsAntidiag : -xy ∈ z.divisorsAntidiag ↔ xy ∈ z.divisorsAntidiag := by simp
 

--- a/Mathlib/NumberTheory/Divisors.lean
+++ b/Mathlib/NumberTheory/Divisors.lean
@@ -24,8 +24,11 @@ Let `n : ℕ`. All of the following definitions are in the `Nat` namespace:
  * `divisorsAntidiagonal n` is the `Finset` of pairs `(x,y)` such that `x * y = n`.
  * `Perfect n` is true when `n` is positive and the sum of `properDivisors n` is `n`.
 
-## Implementation details
- * `divisors 0`, `properDivisors 0`, and `divisorsAntidiagonal 0` are defined to be `∅`.
+## Conventions
+
+Since `0` has infinitely many divisors, none of the definitions in this file make sense for it.
+Therefore we adopt the convention that `Nat.divisors 0`, `Nat.properDivisors 0`,
+`Nat.divisorsAntidiagonal 0` and `Int.divisorsAntidiag 0` are all `∅`.
 
 ## Tags
 divisors, perfect numbers
@@ -38,17 +41,17 @@ namespace Nat
 
 variable (n : ℕ)
 
-/-- `divisors n` is the `Finset` of divisors of `n`. As a special case, `divisors 0 = ∅`. -/
+/-- `divisors n` is the `Finset` of divisors of `n`. By convention, we set `divisors 0 = ∅`. -/
 def divisors : Finset ℕ := {d ∈ Ico 1 (n + 1) | d ∣ n}
 
 /-- `properDivisors n` is the `Finset` of divisors of `n`, other than `n`.
-  As a special case, `properDivisors 0 = ∅`. -/
+By convention, we set `properDivisors 0 = ∅`. -/
 def properDivisors : Finset ℕ := {d ∈ Ico 1 n | d ∣ n}
 
 /-- Pairs of divisors of a natural number as a finset.
 
 `n.divisorsAntidiagonal` is the finset of pairs `(a, b) : ℕ × ℕ` such that `a * b = n`.
-As a special case, `Nat.divisorsAntidiagonal 0 = ∅`.
+By convention, we set `Nat.divisorsAntidiagonal 0 = ∅`.
 
 O(n). -/
 def divisorsAntidiagonal : Finset (ℕ × ℕ) :=
@@ -248,11 +251,14 @@ theorem swap_mem_divisorsAntidiagonal {x : ℕ × ℕ} :
     x.swap ∈ divisorsAntidiagonal n ↔ x ∈ divisorsAntidiagonal n := by
   rw [mem_divisorsAntidiagonal, mem_divisorsAntidiagonal, mul_comm, Prod.swap]
 
-/-- Simp normal form of `Nat.swap_mem_divisorsAntidiagonal`. -/
+/-- `Nat.swap_mem_divisorsAntidiagonal` with the LHS in simp normal form. -/
 @[simp]
-theorem swap_mem_divisorsAntidiagonal_aux {x : ℕ × ℕ} :
+theorem swap_mem_divisorsAntidiagonal_simpNF {x : ℕ × ℕ} :
     x.snd * x.fst = n ∧ ¬n = 0 ↔ x ∈ divisorsAntidiagonal n := by
   rw [mem_divisorsAntidiagonal, mul_comm]
+
+@[deprecated (since := "2025-02-16")]
+alias swap_mem_divisorsAntidiagonal_aux := swap_mem_divisorsAntidiagonal_simpNF
 
 lemma prodMk_mem_divisorsAntidiag {x y : ℕ} (hn : n ≠ 0) :
     (x, y) ∈ n.divisorsAntidiagonal ↔ x * y = n := by simp [hn]
@@ -536,7 +542,7 @@ local notation "negNatCast" =>
 /-- Pairs of divisors of an integer as a finset.
 
 `z.divisorsAntidiag` is the finset of pairs `(a, b) : ℤ × ℤ` such that `a * b = z`.
-As a special case, `Int.divisorsAntidiag 0 = ∅`.
+By convention, we set `Int.divisorsAntidiag 0 = ∅`.
 
 O(|z|). Computed from `Nat.divisorsAntidiagonal`. -/
 def divisorsAntidiag : (z : ℤ) → Finset (ℤ × ℤ)
@@ -590,12 +596,13 @@ lemma mem_divisorsAntidiag :
 lemma prodMk_mem_divisorsAntidiag (hz : z ≠ 0) : (x, y) ∈ z.divisorsAntidiag ↔ x * y = z := by
   simp [hz]
 
+-- The left hand side is not in simp normal form, see the variant below.
 lemma swap_mem_divisorsAntidiag : xy.swap ∈ z.divisorsAntidiag ↔ xy ∈ z.divisorsAntidiag := by
   simp [mul_comm]
 
-/-- Simp normal form of `Nat.swap_mem_divisorsAntidiagonal`. -/
+/-- `Int.swap_mem_divisorsAntidiag` with the LHS in simp normal form. -/
 @[simp]
-lemma swap_mem_divisorsAntidiagonal_aux :
+lemma swap_mem_divisorsAntidiag_simpNF :
     xy.snd * xy.fst = z ∧ ¬z = 0 ↔ xy ∈ z.divisorsAntidiag := by simp [mul_comm]
 
 lemma neg_mem_divisorsAntidiag : -xy ∈ z.divisorsAntidiag ↔ xy ∈ z.divisorsAntidiag := by simp


### PR DESCRIPTION
Compute the antidiagonal of divisors of an integer `z`, namely the finset of pairs `(a, b) : ℤ × ℤ` such that `a * b = n` (unless `z = 0`, in which case we set the finset to be empty by convention).


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->
- [x] depends on: #21920

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
