### PR TITLE
[Merged by Bors] - chore: replace `cases'` without `with` with `cases`

### DIFF
--- a/Mathlib/Algebra/Group/Fin/Basic.lean
+++ b/Mathlib/Algebra/Group/Fin/Basic.lean
@@ -136,7 +136,7 @@ lemma neg_natCast_eq_one (n : ℕ) : -(n : Fin (n + 1)) = 1 := by
   simp only [natCast_eq_last, neg_last]
 
 lemma rev_add (a b : Fin n) : rev (a + b) = rev a - b := by
-  cases' n
+  cases n
   · exact a.elim0
   rw [← last_sub, ← last_sub, sub_add_eq_sub_sub]
 

--- a/Mathlib/CategoryTheory/Limits/Shapes/Images.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Images.lean
@@ -101,7 +101,7 @@ determined. -/
 theorem ext {F F' : MonoFactorisation f} (hI : F.I = F'.I)
     (hm : F.m = eqToHom hI ≫ F'.m) : F = F' := by
   cases' F with _ Fm _ _ Ffac; cases' F' with _ Fm' _ _ Ffac'
-  cases' hI
+  cases hI
   simp? at hm says simp only [eqToHom_refl, Category.id_comp] at hm
   congr
   apply (cancel_mono Fm).1

--- a/Mathlib/Data/Nat/Bitwise.lean
+++ b/Mathlib/Data/Nat/Bitwise.lean
@@ -262,7 +262,7 @@ theorem land_comm (n m : ℕ) : n &&& m = m &&& n :=
 
 lemma and_two_pow (n i : ℕ) : n &&& 2 ^ i = (n.testBit i).toNat * 2 ^ i := by
   refine eq_of_testBit_eq fun j => ?_
-  obtain rfl | hij := Decidable.eq_or_ne i j <;> cases' h : n.testBit i
+  obtain rfl | hij := Decidable.eq_or_ne i j <;> cases h : n.testBit i
   · simp [h]
   · simp [h]
   · simp [h, testBit_two_pow_of_ne hij]

--- a/Mathlib/Data/Sign.lean
+++ b/Mathlib/Data/Sign.lean
@@ -344,7 +344,7 @@ theorem sign_eq_zero_iff : sign a = 0 ↔ a = 0 := by
   refine ⟨fun h => ?_, fun h => h.symm ▸ sign_zero⟩
   rw [sign_apply] at h
   split_ifs at h with h_1 h_2
-  cases' h
+  cases h
   exact (le_of_not_lt h_1).eq_of_not_lt h_2
 
 theorem sign_ne_zero : sign a ≠ 0 ↔ a ≠ 0 :=

--- a/Mathlib/Geometry/Euclidean/Circumcenter.lean
+++ b/Mathlib/Geometry/Euclidean/Circumcenter.lean
@@ -141,7 +141,7 @@ theorem existsUnique_dist_eq_of_insert {s : AffineSubspace ℝ P}
     -- Porting note: was
     -- cases' hu with hucc hucr
     -- substs hucc hucr
-    cases' hu
+    cases hu
     have hcr₃val : cr₃ = √(cr * cr + t₃ * y * (t₃ * y)) := by
       cases' hnps with p0 hp0
       have h' : ↑(⟨cc, hcc₃'⟩ : s) = cc := rfl

--- a/Mathlib/GroupTheory/Nilpotent.lean
+++ b/Mathlib/GroupTheory/Nilpotent.lean
@@ -806,7 +806,7 @@ variable {G : Type*} [hG : Group G]
 /-- A p-group is nilpotent -/
 theorem IsPGroup.isNilpotent [Finite G] {p : ℕ} [hp : Fact (Nat.Prime p)] (h : IsPGroup p G) :
     IsNilpotent G := by
-  cases' nonempty_fintype G
+  cases nonempty_fintype G
   classical
     revert hG
     apply @Fintype.induction_subsingleton_or_nontrivial _ G _

--- a/Mathlib/MeasureTheory/Measure/MeasureSpace.lean
+++ b/Mathlib/MeasureTheory/Measure/MeasureSpace.lean
@@ -619,7 +619,7 @@ theorem tendsto_measure_iInter_le {α ι : Type*} {_ : MeasurableSpace α} {μ :
     (hf : ∃ i, μ (f i) ≠ ∞) :
     Tendsto (fun i ↦ μ (⋂ j ≤ i, f j)) atTop (𝓝 (μ (⋂ i, f i))) := by
   refine .of_neBot_imp fun hne ↦ ?_
-  cases' atTop_neBot_iff.mp hne
+  cases atTop_neBot_iff.mp hne
   rw [measure_iInter_eq_iInf_measure_iInter_le hm hf]
   exact tendsto_atTop_iInf
     fun i j hij ↦ measure_mono <| biInter_subset_biInter_left fun k hki ↦ le_trans hki hij


### PR DESCRIPTION
These were found (as panic obstacles) when trying to get a more usable [machine-readable report of `cases'` uses](https://github.com/leanprover-community/mathlib4/actions/runs/13345696051/job/37275876859).

`cases'` without `with` to name the new variables can always be replaced with unprimed `cases`.