### PR TITLE
feat: simproc for `Int.divisorsAntidiag`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -6527,6 +6527,7 @@ public import Mathlib.Tactic.SetLike
 public import Mathlib.Tactic.SimpIntro
 public import Mathlib.Tactic.SimpRw
 public import Mathlib.Tactic.Simproc.Divisors
+public import Mathlib.Tactic.Simproc.DivisorsAntidiag
 public import Mathlib.Tactic.Simproc.ExistsAndEq
 public import Mathlib.Tactic.Simproc.Factors
 public import Mathlib.Tactic.Simproc.FinsetInterval

--- a/Mathlib/Tactic.lean
+++ b/Mathlib/Tactic.lean
@@ -265,6 +265,7 @@ public import Mathlib.Tactic.SetLike
 public import Mathlib.Tactic.SimpIntro
 public import Mathlib.Tactic.SimpRw
 public import Mathlib.Tactic.Simproc.Divisors
+public import Mathlib.Tactic.Simproc.DivisorsAntidiag
 public import Mathlib.Tactic.Simproc.ExistsAndEq
 public import Mathlib.Tactic.Simproc.Factors
 public import Mathlib.Tactic.Simproc.FinsetInterval

--- a/Mathlib/Tactic/Simproc/DivisorsAntidiag.lean
+++ b/Mathlib/Tactic/Simproc/DivisorsAntidiag.lean
@@ -1,0 +1,73 @@
+/-
+Copyright (c) 2025 Yaël Dillies, Paul Lezeau. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yaël Dillies, Paul Lezeau
+-/
+module
+
+public import Mathlib.Data.Finset.Sort
+public import Mathlib.NumberTheory.Divisors
+
+/-!
+# Simproc for `Int.divisorsAntidiag`
+-/
+
+open
+  Qq
+  Lean
+    Meta
+      Simp
+    Elab
+      Term
+    Parser
+      Tactic
+
+namespace Mathlib.Tactic.Simp
+
+open Finset
+
+/-- Given a natural number `n`, returns `(s, ⊢ Nat.divisorsAntidiagonal n = s)`. -/
+def evalNatDivisorsAntidiag (n : ℕ) (en : Q(ℕ)) :
+    MetaM ((l : Q(Finset (ℕ × ℕ))) × Q(Nat.divisorsAntidiagonal $en = $l)) := do
+  match enl.natLit! with
+  | 0 =>
+    have _ : $enl =Q nat_lit 0 := ⟨⟩
+    have hen : Q($en = 0) := q($(hn).out)
+    return ⟨_, q($hen ▸ Nat.primeFactorsList_zero)⟩
+  | 1 =>
+    let _ : $enl =Q nat_lit 1 := ⟨⟩
+    have hen : Q($en = 1) := q($(hn).out)
+    return ⟨_, q($hen ▸ Nat.primeFactorsList_one)⟩
+  | _ => do
+    have h2 : Q(IsNat 2 (nat_lit 2)) := q(⟨Eq.refl (nat_lit 2)⟩)
+    let ⟨l, p⟩ ← evalPrimeFactorsListAux hn h2
+    return ⟨l, q(($p).primeFactorsList_eq)⟩
+
+/-- Given a natural number `n`, returns `(l, ⊢ Nat.primeFactorsList n = l)`. -/
+def evalDivisorsAntidiag
+    {en enl : Q(ℕ)} (hn : Q(IsNat $en $enl)) :
+    MetaM ((l : Q(List ℕ)) × Q(Nat.primeFactorsList $en = $l)) := do
+  match enl.natLit! with
+  | 0 =>
+    have _ : $enl =Q nat_lit 0 := ⟨⟩
+    have hen : Q($en = 0) := q($(hn).out)
+    return ⟨_, q($hen ▸ Nat.primeFactorsList_zero)⟩
+  | 1 =>
+    let _ : $enl =Q nat_lit 1 := ⟨⟩
+    have hen : Q($en = 1) := q($(hn).out)
+    return ⟨_, q($hen ▸ Nat.primeFactorsList_one)⟩
+  | _ => do
+    have h2 : Q(IsNat 2 (nat_lit 2)) := q(⟨Eq.refl (nat_lit 2)⟩)
+    let ⟨l, p⟩ ← evalPrimeFactorsListAux hn h2
+    return ⟨l, q(($p).primeFactorsList_eq)⟩
+
+simproc divisors_antidiag (Int.divisorsAntidiag _) := fun e ↦ do
+  let ⟨1, ~q(Finset (ℤ × ℤ)), ~q(Int.divisorsAntidiag <| OfNat.ofNat $e)⟩ ← inferTypeQ e
+    | return .continue
+  let ⟨l, p⟩ ← evalPrimeFactorsList hn
+  return .done { expr := l, proof? := p }
+
+example : Int.divisorsAntidiag 10 = {(-1, -1), (1, 1)} := by
+  simp
+
+end Mathlib.Tactic.Simp


### PR DESCRIPTION
Co-authored-by: Paul Lezeau

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->
- [x] depends on: #21912
- [x] depends on: #21991

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
