### PR TITLE
fix(1000.yaml): correct identifier for Bézout's identity

### DIFF
--- a/docs/1000.yaml
+++ b/docs/1000.yaml
@@ -475,7 +475,6 @@ Q512897:
 Q513028:
   title: Bézout's identity
   decl: Nat.gcd_eq_gcd_ab
-  authors: mathlib
 
 Q523832:
   title: Carathéodory–Jacobi–Lie theorem

--- a/docs/1000.yaml
+++ b/docs/1000.yaml
@@ -472,6 +472,11 @@ Q510197:
 Q512897:
   title: Brooks's theorem
 
+Q513028:
+  title: Bézout's identity
+  decl: Nat.gcd_eq_gcd_ab
+  authors: mathlib
+
 Q523832:
   title: Carathéodory–Jacobi–Lie theorem
 
@@ -1603,8 +1608,6 @@ Q1535225:
 
 Q1542114:
   title: Bézout's theorem
-  decl: Nat.gcd_eq_gcd_ab
-  authors: mathlib
 
 Q1543149:
   title: Sokhatsky–Weierstrass theorem


### PR DESCRIPTION
Bézout's theorem was listed as formalized, but the formalization links to Bézout's identity. This PR fixes that by adding Bézout's identity to the list, and removing the pointer from Bézout's theorem.

---

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
