### PR TITLE
[Merged by Bors] - refactor(CategoryTheory): redefine action of endomorphisms on morphisms

### DIFF
--- a/Mathlib/CategoryTheory/Abelian/Projective.lean
+++ b/Mathlib/CategoryTheory/Abelian/Projective.lean
@@ -28,7 +28,7 @@ variable {C : Type u} [Category.{v} C] [Abelian C]
 /-- The preadditive Co-Yoneda functor on `P` preserves homology if `P` is projective. -/
 noncomputable instance preservesHomology_preadditiveCoyonedaObj_of_projective
     (P : C) [hP : Projective P] :
-    (preadditiveCoyonedaObj (op P)).PreservesHomology := by
+    (preadditiveCoyonedaObj P).PreservesHomology := by
   haveI := (projective_iff_preservesEpimorphisms_preadditiveCoyoneda_obj' P).mp hP
   haveI := @Functor.preservesEpimorphisms_of_preserves_of_reflects _ _ _ _ _ _ _ _ this _
   apply Functor.preservesHomology_of_preservesEpis_and_kernels
@@ -36,15 +36,15 @@ noncomputable instance preservesHomology_preadditiveCoyonedaObj_of_projective
 /-- The preadditive Co-Yoneda functor on `P` preserves finite colimits if `P` is projective. -/
 noncomputable instance preservesFiniteColimits_preadditiveCoyonedaObj_of_projective
     (P : C) [hP : Projective P] :
-    PreservesFiniteColimits (preadditiveCoyonedaObj (op P)) := by
+    PreservesFiniteColimits (preadditiveCoyonedaObj P) := by
   apply Functor.preservesFiniteColimits_of_preservesHomology
 
 /-- An object is projective if its preadditive Co-Yoneda functor preserves finite colimits. -/
 theorem projective_of_preservesFiniteColimits_preadditiveCoyonedaObj (P : C)
-    [hP : PreservesFiniteColimits (preadditiveCoyonedaObj (op P))] : Projective P := by
+    [hP : PreservesFiniteColimits (preadditiveCoyonedaObj P)] : Projective P := by
   rw [projective_iff_preservesEpimorphisms_preadditiveCoyoneda_obj']
   dsimp
-  have := Functor.preservesHomologyOfExact (preadditiveCoyonedaObj (op P))
+  have := Functor.preservesHomologyOfExact (preadditiveCoyonedaObj P)
   infer_instance
 
 end CategoryTheory

--- a/Mathlib/CategoryTheory/Endomorphism.lean
+++ b/Mathlib/CategoryTheory/Endomorphism.lean
@@ -4,11 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury Kudryashov, Kim Morrison, Simon Hudon
 -/
 import Mathlib.Algebra.Group.Action.Defs
-import Mathlib.Algebra.Group.Equiv.Defs
-import Mathlib.Algebra.Group.Units.Basic
+import Mathlib.Algebra.Group.Opposite
 import Mathlib.Algebra.Group.Units.Hom
 import Mathlib.CategoryTheory.Groupoid
-import Mathlib.CategoryTheory.Opposites
 
 /-!
 # Endomorphisms
@@ -78,7 +76,7 @@ instance mulActionRight {X Y : C} : MulAction (End Y) (X ⟶ Y) where
   one_smul := Category.comp_id
   mul_smul _ _ _ := Eq.symm <| Category.assoc _ _ _
 
-instance mulActionLeft {X : Cᵒᵖ} {Y : C} : MulAction (End X) (unop X ⟶ Y) where
+instance mulActionLeft {X Y : C} : MulAction (End X)ᵐᵒᵖ (X ⟶ Y) where
   smul r f := r.unop ≫ f
   one_smul := Category.id_comp
   mul_smul _ _ _ := Category.assoc _ _ _
@@ -86,7 +84,7 @@ instance mulActionLeft {X : Cᵒᵖ} {Y : C} : MulAction (End X) (unop X ⟶ Y) 
 theorem smul_right {X Y : C} {r : End Y} {f : X ⟶ Y} : r • f = f ≫ r :=
   rfl
 
-theorem smul_left {X : Cᵒᵖ} {Y : C} {r : End X} {f : unop X ⟶ Y} : r • f = r.unop ≫ f :=
+theorem smul_left {X Y : C} {r : (End X)ᵐᵒᵖ} {f : X ⟶ Y} : r • f = r.unop ≫ f :=
   rfl
 
 end MulAction

--- a/Mathlib/CategoryTheory/Generator/Preadditive.lean
+++ b/Mathlib/CategoryTheory/Generator/Preadditive.lean
@@ -53,7 +53,7 @@ theorem isSeparator_iff_faithful_preadditiveCoyoneda (G : C) :
     fun h => Functor.Faithful.comp _ _⟩
 
 theorem isSeparator_iff_faithful_preadditiveCoyonedaObj (G : C) :
-    IsSeparator G ↔ (preadditiveCoyonedaObj (op G)).Faithful := by
+    IsSeparator G ↔ (preadditiveCoyonedaObj G).Faithful := by
   rw [isSeparator_iff_faithful_preadditiveCoyoneda, preadditiveCoyoneda_obj]
   exact ⟨fun h => Functor.Faithful.of_comp _ (forget₂ _ AddCommGrp.{v}),
     fun h => Functor.Faithful.comp _ _⟩

--- a/Mathlib/CategoryTheory/Preadditive/Opposite.lean
+++ b/Mathlib/CategoryTheory/Preadditive/Opposite.lean
@@ -23,7 +23,7 @@ instance : Preadditive Cᵒᵖ where
   add_comp _ _ _ f f' g := Quiver.Hom.unop_inj (Preadditive.comp_add _ _ _ g.unop f.unop f'.unop)
   comp_add _ _ _ f g g' := Quiver.Hom.unop_inj (Preadditive.add_comp _ _ _ g.unop g'.unop f.unop)
 
-instance moduleEndLeft {X : Cᵒᵖ} {Y : C} : Module (End X) (unop X ⟶ Y) where
+instance moduleEndLeft {X Y : C} : Module (End X)ᵐᵒᵖ (X ⟶ Y) where
   smul_add _ _ _ := Preadditive.comp_add _ _ _ _ _ _
   smul_zero _ := Limits.comp_zero
   add_smul _ _ _ := Preadditive.add_comp _ _ _ _ _ _

--- a/Mathlib/CategoryTheory/Preadditive/Yoneda/Basic.lean
+++ b/Mathlib/CategoryTheory/Preadditive/Yoneda/Basic.lean
@@ -62,8 +62,8 @@ def preadditiveYoneda : C ⥤ Cᵒᵖ ⥤ AddCommGrp.{v} where
 object `Y` to the `End X`-module of morphisms `X ⟶ Y`.
 -/
 @[simps]
-def preadditiveCoyonedaObj (X : Cᵒᵖ) : C ⥤ ModuleCat.{v} (End X) where
-  obj Y := ModuleCat.of _ (unop X ⟶ Y)
+def preadditiveCoyonedaObj (X : C) : C ⥤ ModuleCat.{v} (End X)ᵐᵒᵖ where
+  obj Y := ModuleCat.of _ (X ⟶ Y)
   map f := ModuleCat.ofHom
     { toFun := fun g => g ≫ f
       map_add' := fun _ _ => add_comp _ _ _ _ _ _
@@ -75,7 +75,7 @@ structure, see `preadditiveCoyonedaObj`.
 -/
 @[simps obj]
 def preadditiveCoyoneda : Cᵒᵖ ⥤ C ⥤ AddCommGrp.{v} where
-  obj X := preadditiveCoyonedaObj X ⋙ forget₂ _ _
+  obj X := preadditiveCoyonedaObj (unop X) ⋙ forget₂ _ _
   map f :=
     { app := fun _ => AddCommGrp.ofHom
         { toFun := fun g => f.unop ≫ g
@@ -88,7 +88,7 @@ instance additive_yonedaObj (X : C) : Functor.Additive (preadditiveYonedaObj X) 
 
 instance additive_yonedaObj' (X : C) : Functor.Additive (preadditiveYoneda.obj X) where
 
-instance additive_coyonedaObj (X : Cᵒᵖ) : Functor.Additive (preadditiveCoyonedaObj X) where
+instance additive_coyonedaObj (X : C) : Functor.Additive (preadditiveCoyonedaObj X) where
 
 instance additive_coyonedaObj' (X : Cᵒᵖ) : Functor.Additive (preadditiveCoyoneda.obj X) where
 

--- a/Mathlib/CategoryTheory/Preadditive/Yoneda/Limits.lean
+++ b/Mathlib/CategoryTheory/Preadditive/Yoneda/Limits.lean
@@ -35,10 +35,10 @@ instance preservesLimits_preadditiveYonedaObj (X : C) : PreservesLimits (preaddi
     (inferInstance : PreservesLimits (yoneda.obj X))
   preservesLimits_of_reflects_of_preserves _ (forget _)
 
-instance preservesLimits_preadditiveCoyonedaObj (X : Cᵒᵖ) :
+instance preservesLimits_preadditiveCoyonedaObj (X : C) :
     PreservesLimits (preadditiveCoyonedaObj X) :=
   have : PreservesLimits (preadditiveCoyonedaObj X ⋙ forget _) :=
-    (inferInstance : PreservesLimits (coyoneda.obj X))
+    (inferInstance : PreservesLimits (coyoneda.obj (op X)))
   preservesLimits_of_reflects_of_preserves _ (forget _)
 
 instance preservesLimits_preadditiveYoneda_obj (X : C) :
@@ -47,6 +47,6 @@ instance preservesLimits_preadditiveYoneda_obj (X : C) :
 
 instance preservesLimits_preadditiveCoyoneda_obj (X : Cᵒᵖ) :
     PreservesLimits (preadditiveCoyoneda.obj X) :=
-  show PreservesLimits (preadditiveCoyonedaObj X ⋙ forget₂ _ _) from inferInstance
+  show PreservesLimits (preadditiveCoyonedaObj (unop X) ⋙ forget₂ _ _) from inferInstance
 
 end CategoryTheory


### PR DESCRIPTION
Right now the `End X`-action on `X ⟶ Y` is defined as

```lean
instance mulActionLeft {X : Cᵒᵖ} {Y : C} : MulAction (End X) (unop X ⟶ Y) where
  smul r f := r.unop ≫ f
  one_smul := Category.id_comp
  mul_smul _ _ _ := Category.assoc _ _ _
```

which works really badly in practice. One big reason is that not all hom-sets get the action, so while you have `unop (op X) ⟶ Y` you have the module structure, but if you `dsimp` this you suddenly have `X ⟶ Y` which isn't a module anymore. But even if things work out syntactically, things go wrong, as the following example shows:
```lean
import Mathlib

open CategoryTheory Opposite

variable {C : Type u} [Category.{v} C] [Preadditive C] {X Y : C}

example : Module (End (op X)) (unop (op X) ⟶ Y) := inferInstance -- failed to synthesize
example : Module (End (op X)) (unop (op X) ⟶ Y) := moduleEndLeft _ -- works
```
Even if you remind Lean what the action is, you get mysterious problem like `simp` lemmas not firing even though `rw` works. I clearly remember this action being a pain to work with in Lean 3, and it is still bad in Lean 4.

This PR redefines the action as
```lean
instance mulActionLeft {X Y : C} : MulAction (End X)ᵐᵒᵖ (X ⟶ Y) where
  smul r f := r.unop ≫ f
  one_smul := Category.id_comp
  mul_smul _ _ _ := Category.assoc _ _ _
```
which makes all these problems go away in my applications.

The diff is pretty small, and I don't think many people are using this action, so I don't think there will be many problems caused by this change.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
