### PR TITLE
[Merged by Bors] - feat(CategoryTheory): `preadditiveYonedaMap`

### DIFF
--- a/Mathlib/CategoryTheory/Preadditive/Yoneda/Basic.lean
+++ b/Mathlib/CategoryTheory/Preadditive/Yoneda/Basic.lean
@@ -23,7 +23,7 @@ embedding in the expected way and deduce that the preadditive Yoneda embedding i
 -/
 
 
-universe v u
+universe v u u₁
 
 open CategoryTheory.Preadditive Opposite CategoryTheory.Limits
 
@@ -132,5 +132,18 @@ instance faithful_preadditiveYoneda : (preadditiveYoneda : C ⥤ Cᵒᵖ ⥤ Add
 instance faithful_preadditiveCoyoneda :
     (preadditiveCoyoneda : Cᵒᵖ ⥤ C ⥤ AddCommGrp).Faithful :=
   Functor.Faithful.of_comp_eq whiskering_preadditiveCoyoneda
+
+section
+
+variable {D : Type u₁} [Category.{v} D] [Preadditive D] (F : C ⥤ D) [F.Additive]
+
+/-- The natural transformation `preadditiveYoneda.obj X ⟶ F.op ⋙ preadditiveYoneda.obj (F.obj X)`
+when `F : C ⥤ D` is an additive functor between preadditive categories and `X : C`. -/
+@[simps]
+def preadditiveYonedaMap (X : C) :
+    preadditiveYoneda.obj X ⟶ F.op ⋙ preadditiveYoneda.obj (F.obj X) where
+  app Y := AddCommGrp.ofHom F.mapAddHom
+
+end
 
 end CategoryTheory


### PR DESCRIPTION
This is the preadditive version of `yonedaMap`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
