### PR TITLE
[Merged by Bors] - feat: let `notation3` handle `_` variables in extended binders

### DIFF
--- a/Mathlib/Util/Notation3.lean
+++ b/Mathlib/Util/Notation3.lean
@@ -51,7 +51,12 @@ macro_rules
     term.replaceM fun x' ↦ do
       unless x == x' do return none
       `(fun _%$ph : $ty ↦ expand_binders% ($x => $term) $[$binders]*, $res)
-  | `(expand_binders% ($x => $term) ($y:ident $pred:binderPred) $binders*, $res) =>
+  | `(expand_binders% ($x => $term) ($y:binderIdent $pred:binderPred) $binders*, $res) => do
+    let y ←
+      match y with
+      | `(binderIdent| $y:ident) => pure y
+      | `(binderIdent| _)        => Term.mkFreshIdent y
+      | _                        => Macro.throwUnsupported
     term.replaceM fun x' ↦ do
       unless x == x' do return none
       `(fun $y:ident ↦ expand_binders% ($x => $term) (h : satisfies_binder_pred% $y $pred)

--- a/MathlibTest/notation3.lean
+++ b/MathlibTest/notation3.lean
@@ -84,8 +84,12 @@ notation3 "∀ᶠᶠ " (...) " in " f ": "
 #guard_msgs in #check foobar (fun y ↦ Eq y 1) (Filter.atTop.eventually fun x ↦ LT.lt x 3)
 
 notation3 "∃' " (...) ", " r:(scoped p => Exists p) => r
-/-- info: ∃' (x : ℕ) (_ : x < 3), x < 3 : Prop -/
-#guard_msgs in #check ∃' x < 3, x < 3
+/-- info: ∃' (a : ℕ) (_ : a < 3), a < 3 : Prop -/
+#guard_msgs in #check ∃' a < 3, a < 3
+/-- info: ∃' (x : ℕ) (_ : x < 3), True : Prop -/
+#guard_msgs in #check ∃' _ < 3, True
+/-- info: ∃' (x : ℕ) (_ : x < 1) (x_1 : ℕ) (_ : x_1 < 2), x = 0 : Prop -/
+#guard_msgs in #check ∃' (x < 1) (_ < 2), x = 0
 
 def func (x : α) : α := x
 notation3 "func! " (...) ", " r:(scoped p => func p) => r


### PR DESCRIPTION
This PR enables writing terms like `⋃ _ ∈ s, Set.univ`, which is allowed by the syntax (and which is accepted by other notation that uses `extendedBinders` like `Exists`) but has been so far unsupported in `notation3`. To get this to work, when the extended binder is expanded we need to replace `_` with a fresh identifier, since we need to refer to the variable again in the predicate.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
