### PR TITLE
[Merged by Bors] - fix(1000.yaml): correct reference to Bézout's identity

### DIFF
--- a/docs/1000.yaml
+++ b/docs/1000.yaml
@@ -1603,8 +1603,6 @@ Q1535225:
 
 Q1542114:
   title: Bézout's theorem
-  decl: Nat.gcd_eq_gcd_ab
-  authors: mathlib
 
 Q1543149:
   title: Sokhatsky–Weierstrass theorem
@@ -2832,6 +2830,10 @@ Q5125859:
 
 Q5127710:
   title: Clark–Ocone theorem
+
+Q513028:
+  title: Bézout's identity
+  decl: Nat.gcd_eq_gcd_ab
 
 Q5132839:
   title: Clifford's circle theorems


### PR DESCRIPTION
There are (at least) two results commonly attributed to Bézout: one is Bézout's identity (a number theory lemma, which is in mathlib), the other is Bézout's theorem (an algebraic geometry results, which apparently is not).
To make matter worse, the 100 theorem project refers to the identity as "Bézout's theorem" (which is arguably incorrect), while the 1000+ project uses Bézout's theorem for the algebraic geometry result.

Correct 1000.yaml to account for this: fix the entry for Bézout's theorem, and add the wikidata tag for Bézout's identity (with the mathlib declaration). The latter tag is present on the wikipedia list, but not the 1000+ theorems repository yet.

Inspired/co-created with #21916.
Co-authored by: @fredrik-bakke

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
