### PR TITLE
[Merged by Bors] - feat(Analysis/Normed/Affine/Isometry): `ofTop`, `ofEq`

### DIFF
--- a/Mathlib/Analysis/Normed/Affine/Isometry.lean
+++ b/Mathlib/Analysis/Normed/Affine/Isometry.lean
@@ -577,6 +577,42 @@ theorem comp_continuous_iff {f : α → P} : Continuous (e ∘ f) ↔ Continuous
 
 section Constructions
 
+variable (s₁ s₂ : AffineSubspace 𝕜 P) [Nonempty s₁] [Nonempty s₂]
+
+/-- The identity equivalence of an affine subspace equal to `⊤` to the whole space. -/
+def ofTop (h : s₁ = ⊤) : s₁ ≃ᵃⁱ[𝕜] P :=
+  { (AffineEquiv.ofEq s₁ ⊤ h).trans (AffineSubspace.topEquiv 𝕜 V P) with norm_map := fun _ ↦ rfl }
+
+variable {s₁}
+
+@[simp]
+lemma ofTop_apply (h : s₁ = ⊤) (x : s₁) : (ofTop s₁ h x : P) = x :=
+  rfl
+
+@[simp]
+lemma ofTop_symm_apply_coe (h : s₁ = ⊤) (x : P) : (ofTop s₁ h).symm x = x :=
+  rfl
+
+variable (s₁)
+
+/-- `AffineEquiv.ofEq` as an `AffineIsometryEquiv`. -/
+def ofEq (h : s₁ = s₂) : s₁ ≃ᵃⁱ[𝕜] s₂ :=
+  { AffineEquiv.ofEq s₁ s₂ h with norm_map := fun _ ↦ rfl }
+
+variable {s₁ s₂}
+
+@[simp]
+lemma coe_ofEq_apply (h : s₁ = s₂) (x : s₁) : (ofEq s₁ s₂ h x : P) = x :=
+  rfl
+
+@[simp]
+lemma ofEq_symm (h : s₁ = s₂) : (ofEq s₁ s₂ h).symm = ofEq s₂ s₁ h.symm :=
+  rfl
+
+@[simp]
+lemma ofEq_rfl : ofEq s₁ s₁ rfl = refl 𝕜 s₁ :=
+  rfl
+
 variable (𝕜)
 
 /-- The map `v ↦ v +ᵥ p` as an affine isometric equivalence between `V` and `P`. -/


### PR DESCRIPTION
Add `AffineIsometryEquiv` definitions `ofTop` and `ofEq`, analogous to ones that already exist with those names for `LinearIsometryEquiv` (and with corresponding `simp` lemmas that also have the same named as the `LinearIsometryEquiv` ones).


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
