### PR TITLE
[Merged by Bors] - chore(RingTheory): golf `IsPrimitiveRoot.exists_pos`

### DIFF
--- a/Mathlib/RingTheory/RootsOfUnity/PrimitiveRoots.lean
+++ b/Mathlib/RingTheory/RootsOfUnity/PrimitiveRoots.lean
@@ -248,36 +248,13 @@ lemma injOn_pow {n : ℕ} {ζ : M} (hζ : IsPrimitiveRoot ζ n) :
   exact hζ.pow_inj hi hj e
 
 lemma exists_pos {k : ℕ} (hζ : ζ ^ k = 1) (hk : k ≠ 0) :
-    ∃ k' > 0, IsPrimitiveRoot ζ k' := by
-  classical
-  have H : ∃ k ≠ 0, ζ ^ k = 1 := ⟨k, hk, hζ⟩
-  let k' := Nat.find H
-  have hk' : 0 < k' := Nat.pos_iff_ne_zero.mpr (Nat.find_spec H).1
-  refine ⟨k', hk', (Nat.find_spec H).2, ?_⟩
-  intro l hl
-  have := Nat.find_min' H (m := .gcd k' l) ⟨Nat.gcd_ne_zero_left hk'.ne', ?_⟩
-  · exact Nat.gcd_eq_left_iff_dvd.mpr ((Nat.gcd_le_left l hk').antisymm this)
-  · have : IsUnit ζ := by
-      refine isUnit_iff_exists_inv.mpr ⟨ζ ^ (k - 1), ?_⟩
-      rw [← pow_succ', tsub_add_cancel_of_le, hζ]
-      rwa [Nat.one_le_iff_ne_zero]
-    have h₁ : this.unit ^ k' = 1 := by ext; simpa using (Nat.find_spec H).2
-    have h₂ : this.unit ^ l = 1 := by ext; simpa
-    suffices this.unit ^ (k'.gcd l : ℤ) = 1 by simpa using congr($(this).1)
-    simp [Nat.gcd_eq_gcd_ab, zpow_add, zpow_mul, zpow_natCast, h₁, h₂]
-
-variable (ζ) in
-lemma «exists» : ∃ k, IsPrimitiveRoot ζ k := by
-  by_cases hζ : ∃ k ≠ 0, ζ ^ k = 1
-  · obtain ⟨k, hk, hζ⟩ := hζ
-    obtain ⟨k', -, hk'⟩ := exists_pos hζ hk
-    exact ⟨k', hk'⟩
-  · simp only [ne_eq, not_exists, not_and, not_imp_not] at hζ
-    exact ⟨0, pow_zero _, fun l hl ↦ zero_dvd_iff.mpr (hζ l hl)⟩
+    ∃ k' > 0, IsPrimitiveRoot ζ k' :=
+  ⟨orderOf ζ, by
+    rw [gt_iff_lt, orderOf_pos_iff, isOfFinOrder_iff_pow_eq_one]
+    exact ⟨k, Nat.pos_iff_ne_zero.mpr hk, hζ⟩, .orderOf _⟩
 
 lemma existsUnique : ∃! k, IsPrimitiveRoot ζ k :=
-  let ⟨k, hk⟩ := IsPrimitiveRoot.exists ζ
-  ⟨k, hk, fun _ hl ↦ unique hl hk⟩
+  ⟨_, .orderOf _, fun _ hl ↦ unique hl (.orderOf _)⟩
 
 section Maps
 


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

Removed `IsPrimitiveRoot.exists` but I don't think it needs a deprecation as it is only added 2 days ago by me.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
