### PR TITLE
[Merged by Bors] - feat(Algebra/QuadraticDiscriminant): `discrim_eq_zero_iff`

### DIFF
--- a/Mathlib/Algebra/QuadraticDiscriminant.lean
+++ b/Mathlib/Algebra/QuadraticDiscriminant.lean
@@ -98,6 +98,21 @@ theorem quadratic_eq_zero_iff_of_discrim_eq_zero (ha : a ≠ 0) (h : discrim a b
   have : discrim a b c = 0 * 0 := by rw [h, mul_zero]
   rw [quadratic_eq_zero_iff ha this, add_zero, sub_zero, or_self_iff]
 
+theorem discrim_eq_zero_of_existsUnique (ha : a ≠ 0) :
+    (∃! x, a * (x * x) + b * x + c = 0) → discrim a b c = 0 := by
+  simp_rw [quadratic_eq_zero_iff_discrim_eq_sq ha]
+  generalize discrim a b c = d
+  rintro ⟨x, rfl, hx⟩
+  specialize hx (-(x + b / a))
+  field_simp [ha] at hx
+  specialize hx (by ring)
+  linear_combination -(2 * a * x + b) * hx
+
+theorem discrim_eq_zero_iff (ha : a ≠ 0) :
+    discrim a b c = 0 ↔ (∃! x, a * (x * x) + b * x + c = 0) := by
+  refine ⟨fun hd => ?_, discrim_eq_zero_of_existsUnique ha⟩
+  simp_rw [quadratic_eq_zero_iff_of_discrim_eq_zero ha hd, existsUnique_eq]
+
 end Field
 
 section LinearOrderedField

--- a/Mathlib/Algebra/QuadraticDiscriminant.lean
+++ b/Mathlib/Algebra/QuadraticDiscriminant.lean
@@ -98,11 +98,11 @@ theorem quadratic_eq_zero_iff_of_discrim_eq_zero (ha : a ≠ 0) (h : discrim a b
   have : discrim a b c = 0 * 0 := by rw [h, mul_zero]
   rw [quadratic_eq_zero_iff ha this, add_zero, sub_zero, or_self_iff]
 
-theorem discrim_eq_zero_of_existsUnique (ha : a ≠ 0) :
-    (∃! x, a * (x * x) + b * x + c = 0) → discrim a b c = 0 := by
-  simp_rw [quadratic_eq_zero_iff_discrim_eq_sq ha]
-  generalize discrim a b c = d
-  rintro ⟨x, rfl, hx⟩
+theorem discrim_eq_zero_of_existsUnique (ha : a ≠ 0) (h : ∃! x, a * (x * x) + b * x + c = 0) :
+    discrim a b c = 0 := by
+  simp_rw [quadratic_eq_zero_iff_discrim_eq_sq ha] at h
+  generalize discrim a b c = d at h
+  obtain ⟨x, rfl, hx⟩ := h
   specialize hx (-(x + b / a))
   field_simp [ha] at hx
   specialize hx (by ring)


### PR DESCRIPTION
Revived from the abandoned #20158


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
