### PR TITLE
[Merged by Bors] - chore(Data/Nat/Choose/Cast): generalise results to semifields

### DIFF
--- a/Mathlib/Data/Nat/Choose/Cast.lean
+++ b/Mathlib/Data/Nat/Choose/Cast.lean
@@ -16,9 +16,11 @@ of characteristic `0`.
 
 open Nat
 
-variable (K : Type*) [DivisionRing K] [CharZero K]
+variable (K : Type*)
 
 namespace Nat
+section DivisionSemiring
+variable [DivisionSemiring K] [CharZero K]
 
 theorem cast_choose {a b : ℕ} (h : a ≤ b) : (b.choose a : K) = b ! / (a ! * (b - a)!) := by
   have : ∀ {n : ℕ}, (n ! : K) ≠ 0 := Nat.cast_ne_zero.2 (factorial_ne_zero _)
@@ -33,8 +35,14 @@ theorem cast_choose_eq_ascPochhammer_div (a b : ℕ) :
   rw [eq_div_iff_mul_eq (cast_ne_zero.2 b.factorial_ne_zero : (b ! : K) ≠ 0), ← cast_mul,
     mul_comm, ← descFactorial_eq_factorial_mul_choose, ← cast_descFactorial]
 
+end DivisionSemiring
+
+section DivisionRing
+variable [DivisionRing K] [CharZero K]
+
 theorem cast_choose_two (a : ℕ) : (a.choose 2 : K) = a * (a - 1) / 2 := by
   rw [← cast_descFactorial_two, descFactorial_eq_factorial_mul_choose, factorial_two, mul_comm,
     cast_mul, cast_two, eq_div_iff_mul_eq (two_ne_zero : (2 : K) ≠ 0)]
 
+end DivisionRing
 end Nat


### PR DESCRIPTION
From LeanCamCombi


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
