### PR TITLE
[Merged by Bors] - feat: prove isNilpotentAdd for LieSubmodules

### DIFF
--- a/Mathlib/Algebra/Lie/Nilpotent.lean
+++ b/Mathlib/Algebra/Lie/Nilpotent.lean
@@ -148,16 +148,12 @@ theorem lowerCentralSeries_map_eq_lcs : (lowerCentralSeries R L N k).map N.incl 
   apply lcs_le_self
 
 theorem lowerCentralSeries_eq_bot_iff_lcs_eq_bot:
-    (lowerCentralSeries R L N k = ⊥) ↔ (lcs k N = ⊥) := by
-  constructor
-  · intro h
-    rw [← N.lowerCentralSeries_map_eq_lcs]
-    refine (LieModuleHom.le_ker_iff_map (lowerCentralSeries R L N k)).mp ?_
-    simp_all only [ker_incl, le_bot_iff]
-  intro h
-  rw [N.lowerCentralSeries_eq_lcs_comap]
-  refine comap_incl_eq_bot.mpr ?_
-  simp_all only [bot_le, inf_of_le_right]
+    lowerCentralSeries R L N k = ⊥ ↔ lcs k N = ⊥ := by
+  refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
+  · rw [← N.lowerCentralSeries_map_eq_lcs, ← LieModuleHom.le_ker_iff_map]
+    simpa
+  · rw [N.lowerCentralSeries_eq_lcs_comap, comap_incl_eq_bot]
+    simp [h]
 
 end LieSubmodule
 

--- a/Mathlib/Algebra/Lie/Nilpotent.lean
+++ b/Mathlib/Algebra/Lie/Nilpotent.lean
@@ -304,7 +304,7 @@ variable (R L M)
 instance (priority := 100) trivialIsNilpotent [IsTrivial L M] : IsNilpotent L M :=
   ⟨by use 1; change ⁅⊤, ⊤⁆ = ⊥; simp⟩
 
-instance isNilpotentAdd (M₁ M₂ : LieSubmodule R L M) [IsNilpotent L M₁] [IsNilpotent L M₂] :
+instance instIsNilpotentAdd (M₁ M₂ : LieSubmodule R L M) [IsNilpotent L M₁] [IsNilpotent L M₂] :
     IsNilpotent L (M₁ + M₂) := by
   obtain ⟨k, hk⟩ := IsNilpotent.nilpotent R L M₁
   obtain ⟨l, hl⟩ := IsNilpotent.nilpotent R L M₂

--- a/Mathlib/Algebra/Lie/Nilpotent.lean
+++ b/Mathlib/Algebra/Lie/Nilpotent.lean
@@ -306,24 +306,17 @@ instance (priority := 100) trivialIsNilpotent [IsTrivial L M] : IsNilpotent L M 
 
 instance isNilpotentAdd (M₁ M₂ : LieSubmodule R L M) [IsNilpotent L M₁] [IsNilpotent L M₂] :
     IsNilpotent L (M₁ + M₂) := by
-  obtain ⟨k, hk⟩ := (isNilpotent_iff R L M₁).1 (inferInstance)
-  obtain ⟨l, hl⟩ := (isNilpotent_iff R L M₂).1 (inferInstance)
-  let lcs_eq_bot {m n : ℕ} (N : LieSubmodule R L M) (le : m ≤ n)
-      (hn : lowerCentralSeries R L N m = ⊥) :
+  obtain ⟨k, hk⟩ := IsNilpotent.nilpotent R L M₁
+  obtain ⟨l, hl⟩ := IsNilpotent.nilpotent R L M₂
+  let lcs_eq_bot {m n} (N : LieSubmodule R L M) (le : m ≤ n) (hn : lowerCentralSeries R L N m = ⊥) :
     lowerCentralSeries R L N n = ⊥ := by
-    have := antitone_lowerCentralSeries R L N le
-    simp_all only [le_sup_iff, le_bot_iff]
+    simpa [hn] using antitone_lowerCentralSeries R L N le
   have h₁ : lowerCentralSeries R L M₁ (k ⊔ l) = ⊥ := lcs_eq_bot M₁ (Nat.le_max_left k l) hk
   have h₂ : lowerCentralSeries R L M₂ (k ⊔ l) = ⊥ := lcs_eq_bot M₂ (Nat.le_max_right k l) hl
-  apply (isNilpotent_iff R L (M₁ + M₂)).2
-  use (k ⊔ l)
-  simp [LieSubmodule.add_eq_sup]
-  rw [(M₁ ⊔ M₂).lowerCentralSeries_eq_lcs_comap]
-  simp [LieSubmodule.lcs_sup]
-  rw [(M₁.lowerCentralSeries_eq_bot_iff_lcs_eq_bot (k ⊔ l)).1 h₁,
-      (M₂.lowerCentralSeries_eq_bot_iff_lcs_eq_bot (k ⊔ l)).1 h₂]
-  refine LieSubmodule.comap_incl_eq_bot.mpr ?_
-  simp [le_refl, sup_of_le_left, bot_le, inf_of_le_right]
+  refine (isNilpotent_iff R L (M₁ + M₂)).mpr ⟨k ⊔ l, ?_⟩
+  simp [LieSubmodule.add_eq_sup, (M₁ ⊔ M₂).lowerCentralSeries_eq_lcs_comap, LieSubmodule.lcs_sup,
+    (M₁.lowerCentralSeries_eq_bot_iff_lcs_eq_bot (k ⊔ l)).1 h₁,
+    (M₂.lowerCentralSeries_eq_bot_iff_lcs_eq_bot (k ⊔ l)).1 h₂, LieSubmodule.comap_incl_eq_bot]
 
 theorem exists_forall_pow_toEnd_eq_zero [IsNilpotent L M] :
     ∃ k : ℕ, ∀ x : L, toEnd R L M x ^ k = 0 := by

--- a/Mathlib/Algebra/Lie/Nilpotent.lean
+++ b/Mathlib/Algebra/Lie/Nilpotent.lean
@@ -147,6 +147,18 @@ theorem lowerCentralSeries_map_eq_lcs : (lowerCentralSeries R L N k).map N.incl 
   rw [lowerCentralSeries_eq_lcs_comap, LieSubmodule.map_comap_incl, inf_eq_right]
   apply lcs_le_self
 
+theorem lowerCentralSeries_eq_bot_iff_lcs_eq_bot:
+    (lowerCentralSeries R L N k = ⊥) ↔ (lcs k N = ⊥) := by
+  constructor
+  · intro h
+    rw [← N.lowerCentralSeries_map_eq_lcs]
+    refine (LieModuleHom.le_ker_iff_map (lowerCentralSeries R L N k)).mp ?_
+    simp_all only [ker_incl, le_bot_iff]
+  intro h
+  rw [N.lowerCentralSeries_eq_lcs_comap]
+  refine comap_incl_eq_bot.mpr ?_
+  simp_all only [bot_le, inf_of_le_right]
+
 end LieSubmodule
 
 namespace LieModule
@@ -295,6 +307,27 @@ variable (R L M)
 
 instance (priority := 100) trivialIsNilpotent [IsTrivial L M] : IsNilpotent L M :=
   ⟨by use 1; change ⁅⊤, ⊤⁆ = ⊥; simp⟩
+
+instance isNilpotentAdd (M₁ M₂ : LieSubmodule R L M) [IsNilpotent L M₁] [IsNilpotent L M₂] :
+    IsNilpotent L (M₁ + M₂) := by
+  obtain ⟨k, hk⟩ := (isNilpotent_iff R L M₁).1 (inferInstance)
+  obtain ⟨l, hl⟩ := (isNilpotent_iff R L M₂).1 (inferInstance)
+  let lcs_eq_bot {m n : ℕ} (N : LieSubmodule R L M) (le : m ≤ n)
+      (hn : lowerCentralSeries R L N m = ⊥) :
+    lowerCentralSeries R L N n = ⊥ := by
+    have := antitone_lowerCentralSeries R L N le
+    simp_all only [le_sup_iff, le_bot_iff]
+  have h₁ : lowerCentralSeries R L M₁ (k ⊔ l) = ⊥ := lcs_eq_bot M₁ (Nat.le_max_left k l) hk
+  have h₂ : lowerCentralSeries R L M₂ (k ⊔ l) = ⊥ := lcs_eq_bot M₂ (Nat.le_max_right k l) hl
+  apply (isNilpotent_iff R L (M₁ + M₂)).2
+  use (k ⊔ l)
+  simp [LieSubmodule.add_eq_sup]
+  rw [(M₁ ⊔ M₂).lowerCentralSeries_eq_lcs_comap]
+  simp [LieSubmodule.lcs_sup]
+  rw [(M₁.lowerCentralSeries_eq_bot_iff_lcs_eq_bot (k ⊔ l)).1 h₁,
+      (M₂.lowerCentralSeries_eq_bot_iff_lcs_eq_bot (k ⊔ l)).1 h₂]
+  refine LieSubmodule.comap_incl_eq_bot.mpr ?_
+  simp [le_refl, sup_of_le_left, bot_le, inf_of_le_right]
 
 theorem exists_forall_pow_toEnd_eq_zero [IsNilpotent L M] :
     ∃ k : ℕ, ∀ x : L, toEnd R L M x ^ k = 0 := by


### PR DESCRIPTION
Prove isNilpotentAdd for LieSubmodules

---
I am working on defining the largest nilpotent ideal of a Lie algebra within the framework:
https://github.com/orgs/leanprover-community/projects/17
A somewhat similar object, namely the radical of a Lie algebra (the largest solvable ideal), is already defined in [Algebra/Lie/Solvable.lean](https://github.com/leanprover-community/mathlib4/blob/master/Mathlib/Algebra/Lie/Solvable.lean).

In this PR, I prove that if M_1 and M_2 are nilpotent LieSubmodules, then so is M_1 + M_2.
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
