### PR TITLE
fix: cache lib dir (adaption for lean4#7001)

### DIFF
--- a/Cache/IO.lean
+++ b/Cache/IO.lean
@@ -16,7 +16,7 @@ open System (FilePath)
 
 /-- Target directory for build files -/
 def LIBDIR : FilePath :=
-  ".lake" / "build" / "lib"
+  ".lake" / "build" / "lib" / "lean"
 
 /-- Target directory for IR files -/
 def IRDIR : FilePath :=


### PR DESCRIPTION
The default library build directory for oleans changed in leanprover/lean4#7001, which broke cache (as it hardcodes it). This updates cache to match.
