### PR TITLE
feat(SetTheory/Surreal/Ordinal): move `Surreal.toOrdinal` to new file

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -5042,6 +5042,7 @@ import Mathlib.SetTheory.Ordinal.Veblen
 import Mathlib.SetTheory.Surreal.Basic
 import Mathlib.SetTheory.Surreal.Dyadic
 import Mathlib.SetTheory.Surreal.Multiplication
+import Mathlib.SetTheory.Surreal.Ordinal
 import Mathlib.SetTheory.ZFC.Basic
 import Mathlib.SetTheory.ZFC.Ordinal
 import Mathlib.SetTheory.ZFC.Rank

--- a/Mathlib/SetTheory/Game/Birthday.lean
+++ b/Mathlib/SetTheory/Game/Birthday.lean
@@ -208,7 +208,7 @@ theorem birthday_ordinalToGame (o : Ordinal) : birthday o.toGame = o := by
     apply birthday_quot_le_pGameBirthday
   · let ⟨x, hx₁, hx₂⟩ := birthday_eq_pGameBirthday o.toGame
     rw [← hx₂, ← toPGame_le_iff]
-    rw [← mk_toPGame, ← PGame.equiv_iff_game_eq] at hx₁
+    rw [← Game.mk_toPGame, ← PGame.equiv_iff_game_eq] at hx₁
     exact hx₁.2.trans (PGame.le_birthday x)
 
 @[simp, norm_cast]

--- a/Mathlib/SetTheory/Game/Birthday.lean
+++ b/Mathlib/SetTheory/Game/Birthday.lean
@@ -208,7 +208,7 @@ theorem birthday_ordinalToGame (o : Ordinal) : birthday o.toGame = o := by
     apply birthday_quot_le_pGameBirthday
   · let ⟨x, hx₁, hx₂⟩ := birthday_eq_pGameBirthday o.toGame
     rw [← hx₂, ← toPGame_le_iff]
-    rw [← Game.mk_toPGame, ← PGame.equiv_iff_game_eq] at hx₁
+    rw [← mk_toPGame, ← PGame.equiv_iff_game_eq] at hx₁
     exact hx₁.2.trans (PGame.le_birthday x)
 
 @[simp, norm_cast]

--- a/Mathlib/SetTheory/Game/Ordinal.lean
+++ b/Mathlib/SetTheory/Game/Ordinal.lean
@@ -3,8 +3,8 @@ Copyright (c) 2022 Violeta Hernández Palacios. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Violeta Hernández Palacios
 -/
-import Mathlib.SetTheory.Game.Basic
 import Mathlib.SetTheory.Ordinal.NaturalOps
+import Mathlib.SetTheory.Surreal.Basic
 
 /-!
 # Ordinals as games
@@ -12,14 +12,13 @@ import Mathlib.SetTheory.Ordinal.NaturalOps
 We define the canonical map `Ordinal → SetTheory.PGame`, where every ordinal is mapped to the
 game whose left set consists of all previous ordinals.
 
-The map to surreals is defined in `Ordinal.toSurreal`.
+The map to surreals is defined in `SetTheory.Surreal.Ordinal`.
 
 # Main declarations
 
 - `Ordinal.toPGame`: The canonical map between ordinals and pre-games.
-- `Ordinal.toPGameEmbedding`: The order embedding version of the previous map.
+- `Ordinal.toGame`: The canonical map between ordinals and games.
 -/
-
 
 universe u
 
@@ -28,6 +27,8 @@ open SetTheory PGame
 open scoped NaturalOps PGame
 
 namespace Ordinal
+
+/-! ### `Ordinal` to `PGame` -/
 
 /-- Converts an ordinal into the corresponding pre-game. -/
 noncomputable def toPGame (o : Ordinal.{u}) : PGame.{u} :=
@@ -156,6 +157,8 @@ noncomputable def toPGameEmbedding : Ordinal.{u} ↪o PGame.{u} where
   inj' := toPGame_injective
   map_rel_iff' := @toPGame_le_iff
 
+/-! ### `Ordinal` to `Game` -/
+
 /-- Converts an ordinal into the corresponding game. -/
 noncomputable def toGame : Ordinal.{u} ↪o Game.{u} where
   toFun o := ⟦o.toPGame⟧
@@ -163,8 +166,11 @@ noncomputable def toGame : Ordinal.{u} ↪o Game.{u} where
   map_rel_iff' := toPGame_le_iff
 
 @[simp]
-theorem mk_toPGame (o : Ordinal) : ⟦o.toPGame⟧ = o.toGame :=
+theorem _root_.Game.mk_toPGame (o : Ordinal) : ⟦o.toPGame⟧ = o.toGame :=
   rfl
+
+@[deprecated (since := "2025-02-17")]
+alias mk_toPGame := Game.mk_toPGame
 
 @[deprecated toGame (since := "2024-11-23")]
 alias toGameEmbedding := toGame
@@ -224,8 +230,8 @@ theorem toPGame_nmul (a b : Ordinal) : (a ⨳ b).toPGame ≈ a.toPGame * b.toPGa
   refine ⟨le_of_forall_lf (fun i => ?_) isEmptyElim, le_of_forall_lf (fun i => ?_) isEmptyElim⟩
   · rw [toPGame_moveLeft']
     rcases lt_nmul_iff.1 (toLeftMovesToPGame_symm_lt i) with ⟨c, hc, d, hd, h⟩
-    rw [← toPGame_le_iff, le_iff_game_le, mk_toPGame, mk_toPGame, toGame_nadd _ _, toGame_nadd _ _,
-      ← le_sub_iff_add_le] at h
+    rw [← toPGame_le_iff, le_iff_game_le, Game.mk_toPGame, Game.mk_toPGame,
+      toGame_nadd _ _, toGame_nadd _ _, ← le_sub_iff_add_le] at h
     refine lf_of_le_of_lf h <| (lf_congr_left ?_).1 <| moveLeft_lf <| toLeftMovesMul <| Sum.inl
       ⟨toLeftMovesToPGame ⟨c, hc⟩, toLeftMovesToPGame ⟨d, hd⟩⟩
     simp only [mul_moveLeft_inl, toPGame_moveLeft', Equiv.symm_apply_apply, equiv_iff_game_eq,
@@ -237,7 +243,7 @@ theorem toPGame_nmul (a b : Ordinal) : (a ⨳ b).toPGame ≈ a.toPGame * b.toPGa
     rw [mul_moveLeft_inl, toPGame_moveLeft', toPGame_moveLeft', lf_iff_game_lf,
       quot_sub, quot_add, ← Game.not_le, le_sub_iff_add_le]
     repeat rw [← game_eq (toPGame_nmul _ _)]
-    simp_rw [mk_toPGame, ← toGame_nadd]
+    simp_rw [Game.mk_toPGame, ← toGame_nadd]
     apply toPGame_lf (nmul_nadd_lt _ _) <;>
     exact toLeftMovesToPGame_symm_lt _
 termination_by (a, b)
@@ -254,6 +260,6 @@ theorem toGame_natCast : ∀ n : ℕ, toGame n = n
     rfl
 
 theorem toPGame_natCast (n : ℕ) : toPGame n ≈ n := by
-  rw [PGame.equiv_iff_game_eq, mk_toPGame, toGame_natCast, quot_natCast]
+  rw [PGame.equiv_iff_game_eq, Game.mk_toPGame, toGame_natCast, quot_natCast]
 
 end Ordinal

--- a/Mathlib/SetTheory/Game/Ordinal.lean
+++ b/Mathlib/SetTheory/Game/Ordinal.lean
@@ -3,8 +3,8 @@ Copyright (c) 2022 Violeta Hernández Palacios. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Violeta Hernández Palacios
 -/
+import Mathlib.SetTheory.Game.Basic
 import Mathlib.SetTheory.Ordinal.NaturalOps
-import Mathlib.SetTheory.Surreal.Basic
 
 /-!
 # Ordinals as games

--- a/Mathlib/SetTheory/Game/Ordinal.lean
+++ b/Mathlib/SetTheory/Game/Ordinal.lean
@@ -166,11 +166,8 @@ noncomputable def toGame : Ordinal.{u} ↪o Game.{u} where
   map_rel_iff' := toPGame_le_iff
 
 @[simp]
-theorem _root_.Game.mk_toPGame (o : Ordinal) : ⟦o.toPGame⟧ = o.toGame :=
+theorem mk_toPGame (o : Ordinal) : ⟦o.toPGame⟧ = o.toGame :=
   rfl
-
-@[deprecated (since := "2025-02-17")]
-alias mk_toPGame := Game.mk_toPGame
 
 @[deprecated toGame (since := "2024-11-23")]
 alias toGameEmbedding := toGame
@@ -230,8 +227,8 @@ theorem toPGame_nmul (a b : Ordinal) : (a ⨳ b).toPGame ≈ a.toPGame * b.toPGa
   refine ⟨le_of_forall_lf (fun i => ?_) isEmptyElim, le_of_forall_lf (fun i => ?_) isEmptyElim⟩
   · rw [toPGame_moveLeft']
     rcases lt_nmul_iff.1 (toLeftMovesToPGame_symm_lt i) with ⟨c, hc, d, hd, h⟩
-    rw [← toPGame_le_iff, le_iff_game_le, Game.mk_toPGame, Game.mk_toPGame,
-      toGame_nadd _ _, toGame_nadd _ _, ← le_sub_iff_add_le] at h
+    rw [← toPGame_le_iff, le_iff_game_le, mk_toPGame, mk_toPGame, toGame_nadd _ _, toGame_nadd _ _,
+      ← le_sub_iff_add_le] at h
     refine lf_of_le_of_lf h <| (lf_congr_left ?_).1 <| moveLeft_lf <| toLeftMovesMul <| Sum.inl
       ⟨toLeftMovesToPGame ⟨c, hc⟩, toLeftMovesToPGame ⟨d, hd⟩⟩
     simp only [mul_moveLeft_inl, toPGame_moveLeft', Equiv.symm_apply_apply, equiv_iff_game_eq,
@@ -243,7 +240,7 @@ theorem toPGame_nmul (a b : Ordinal) : (a ⨳ b).toPGame ≈ a.toPGame * b.toPGa
     rw [mul_moveLeft_inl, toPGame_moveLeft', toPGame_moveLeft', lf_iff_game_lf,
       quot_sub, quot_add, ← Game.not_le, le_sub_iff_add_le]
     repeat rw [← game_eq (toPGame_nmul _ _)]
-    simp_rw [Game.mk_toPGame, ← toGame_nadd]
+    simp_rw [mk_toPGame, ← toGame_nadd]
     apply toPGame_lf (nmul_nadd_lt _ _) <;>
     exact toLeftMovesToPGame_symm_lt _
 termination_by (a, b)
@@ -260,6 +257,6 @@ theorem toGame_natCast : ∀ n : ℕ, toGame n = n
     rfl
 
 theorem toPGame_natCast (n : ℕ) : toPGame n ≈ n := by
-  rw [PGame.equiv_iff_game_eq, Game.mk_toPGame, toGame_natCast, quot_natCast]
+  rw [PGame.equiv_iff_game_eq, mk_toPGame, toGame_natCast, quot_natCast]
 
 end Ordinal

--- a/Mathlib/SetTheory/Game/Ordinal.lean
+++ b/Mathlib/SetTheory/Game/Ordinal.lean
@@ -12,7 +12,7 @@ import Mathlib.SetTheory.Ordinal.NaturalOps
 We define the canonical map `Ordinal → SetTheory.PGame`, where every ordinal is mapped to the
 game whose left set consists of all previous ordinals.
 
-The map to surreals is defined in `SetTheory.Surreal.Ordinal`.
+The map to surreals is defined in `Ordinal.toSurreal`.
 
 # Main declarations
 

--- a/Mathlib/SetTheory/Surreal/Basic.lean
+++ b/Mathlib/SetTheory/Surreal/Basic.lean
@@ -278,8 +278,6 @@ instance : Inhabited Surreal :=
 
 lemma mk_eq_mk {x y : PGame.{u}} {hx hy} : mk x hx = mk y hy ↔ x ≈ y := Quotient.eq
 
-alias ⟨_, mk_eq⟩ := mk_eq_mk
-
 lemma mk_eq_zero {x : PGame.{u}} {hx} : mk x hx = 0 ↔ x ≈ 0 := Quotient.eq
 
 /-- Lift an equivalence-respecting function on pre-games to surreals. -/

--- a/Mathlib/SetTheory/Surreal/Basic.lean
+++ b/Mathlib/SetTheory/Surreal/Basic.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Kim Morrison
 -/
 import Mathlib.Algebra.Order.Hom.Monoid
-import Mathlib.SetTheory.Game.Ordinal
+import Mathlib.SetTheory.Game.Basic
 
 /-!
 # Surreal numbers
@@ -24,7 +24,7 @@ besides!) but we do not yet have a complete development.
 ## Order properties
 
 Surreal numbers inherit the relations `≤` and `<` from games (`Surreal.instLE` and
-`Surreal.instLT`), and these relations satisfy the axioms of a partial order.
+`Surreal.instLT`), and these relations satisfy the axioms of a linear order.
 
 ## Algebraic operations
 
@@ -249,12 +249,6 @@ theorem numeric_nat : ∀ n : ℕ, Numeric n
   | 0 => numeric_zero
   | n + 1 => (numeric_nat n).add numeric_one
 
-/-- Ordinal games are numeric. -/
-theorem numeric_toPGame (o : Ordinal) : o.toPGame.Numeric := by
-  induction' o using Ordinal.induction with o IH
-  apply numeric_of_isEmpty_rightMoves
-  simpa using fun i => IH _ (Ordinal.toLeftMovesToPGame_symm_lt i)
-
 end PGame
 
 end SetTheory
@@ -283,6 +277,8 @@ instance : Inhabited Surreal :=
   ⟨0⟩
 
 lemma mk_eq_mk {x y : PGame.{u}} {hx hy} : mk x hx = mk y hy ↔ x ≈ y := Quotient.eq
+
+alias ⟨_, mk_eq⟩ := mk_eq_mk
 
 lemma mk_eq_zero {x : PGame.{u}} {hx} : mk x hx = 0 ↔ x ≈ 0 := Quotient.eq
 
@@ -435,13 +431,3 @@ lemma bddBelow_of_small (s : Set Surreal.{u}) [Small.{u} s] : BddBelow s := by
 end Surreal
 
 open Surreal
-
-namespace Ordinal
-
-/-- Converts an ordinal into the corresponding surreal. -/
-noncomputable def toSurreal : Ordinal ↪o Surreal where
-  toFun o := mk _ (numeric_toPGame o)
-  inj' a b h := toPGame_equiv_iff.1 (by apply Quotient.exact h) -- Porting note: Added `by apply`
-  map_rel_iff' := @toPGame_le_iff
-
-end Ordinal

--- a/Mathlib/SetTheory/Surreal/Ordinal.lean
+++ b/Mathlib/SetTheory/Surreal/Ordinal.lean
@@ -1,0 +1,67 @@
+/-
+Copyright (c) 2022 Violeta Hernández Palacios. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Violeta Hernández Palacios
+-/
+import Mathlib.SetTheory.Game.Ordinal
+import Mathlib.SetTheory.Surreal.Multiplication
+
+/-!
+# Surreals as games
+
+We define the canonical map `Ordinal → Surreal` in terms of the map `Ordinal.toPGame`.
+
+# Main declarations
+
+- `Ordinal.toSurreal`: The canonical map between ordinals and surreal numbers.
+-/
+
+open Surreal SetTheory PGame
+
+open scoped NaturalOps
+
+namespace Ordinal
+
+/-- Ordinal games are numeric. -/
+theorem numeric_toPGame (o : Ordinal) : o.toPGame.Numeric := by
+  induction' o using Ordinal.induction with o IH
+  apply numeric_of_isEmpty_rightMoves
+  simpa using fun i => IH _ (Ordinal.toLeftMovesToPGame_symm_lt i)
+
+/-- Converts an ordinal into the corresponding surreal. -/
+noncomputable def toSurreal : Ordinal ↪o Surreal where
+  toFun o := .mk _ o.numeric_toPGame
+  inj' a b h := toPGame_equiv_iff.1 (by apply Quotient.exact h) -- Porting note: Added `by apply`
+  map_rel_iff' := @toPGame_le_iff
+
+@[simp]
+theorem _root_.Surreal.mk_toPGame (o : Ordinal) : .mk _ (numeric_toPGame o) = o.toSurreal :=
+  rfl
+
+@[simp]
+theorem toSurreal_zero : toSurreal 0 = 0 :=
+  Surreal.mk_eq toPGame_zero
+
+@[simp]
+theorem toSurreal_one : toSurreal 1 = 1 :=
+  Surreal.mk_eq toPGame_one
+
+theorem toSurreal_injective : Function.Injective toSurreal :=
+  toSurreal.injective
+
+theorem toSurreal_le_iff {a b : Ordinal} : a.toSurreal ≤ b.toSurreal ↔ a ≤ b :=
+  toPGame_le_iff
+
+theorem toSurreal_lt_iff {a b : Ordinal} : a.toSurreal < b.toSurreal ↔ a < b :=
+  toPGame_lt_iff
+
+theorem toSurreal_inj {a b : Ordinal} : a.toSurreal = b.toSurreal ↔ a = b :=
+  toSurreal.inj
+
+theorem toSurreal_nadd (a b : Ordinal) : (a ♯ b).toSurreal = a.toSurreal + b.toSurreal :=
+  mk_eq (toPGame_nadd a b)
+
+theorem toSurreal_nmul (a b : Ordinal) : (a ⨳ b).toSurreal = a.toSurreal * b.toSurreal :=
+  mk_eq (toPGame_nmul a b)
+
+end Ordinal

--- a/Mathlib/SetTheory/Surreal/Ordinal.lean
+++ b/Mathlib/SetTheory/Surreal/Ordinal.lean
@@ -29,7 +29,7 @@ theorem numeric_toPGame (o : Ordinal) : o.toPGame.Numeric := by
 /-- Converts an ordinal into the corresponding surreal. -/
 noncomputable def toSurreal : Ordinal ↪o Surreal where
   toFun o := .mk _ o.numeric_toPGame
-  inj' a b h := toPGame_equiv_iff.1 (by apply Quotient.exact h) -- Porting note: Added `by apply`
+  inj' a b h := toPGame_equiv_iff.1 (Quotient.exact h :)
   map_rel_iff' := @toPGame_le_iff
 
 end Ordinal

--- a/Mathlib/SetTheory/Surreal/Ordinal.lean
+++ b/Mathlib/SetTheory/Surreal/Ordinal.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Violeta Hernández Palacios
 -/
 import Mathlib.SetTheory.Game.Ordinal
-import Mathlib.SetTheory.Surreal.Multiplication
+import Mathlib.SetTheory.Surreal.Basic
 
 /-!
 # Surreals as games
@@ -33,35 +33,5 @@ noncomputable def toSurreal : Ordinal ↪o Surreal where
   toFun o := .mk _ o.numeric_toPGame
   inj' a b h := toPGame_equiv_iff.1 (by apply Quotient.exact h) -- Porting note: Added `by apply`
   map_rel_iff' := @toPGame_le_iff
-
-@[simp]
-theorem _root_.Surreal.mk_toPGame (o : Ordinal) : .mk _ (numeric_toPGame o) = o.toSurreal :=
-  rfl
-
-@[simp]
-theorem toSurreal_zero : toSurreal 0 = 0 :=
-  Surreal.mk_eq toPGame_zero
-
-@[simp]
-theorem toSurreal_one : toSurreal 1 = 1 :=
-  Surreal.mk_eq toPGame_one
-
-theorem toSurreal_injective : Function.Injective toSurreal :=
-  toSurreal.injective
-
-theorem toSurreal_le_iff {a b : Ordinal} : a.toSurreal ≤ b.toSurreal ↔ a ≤ b :=
-  toPGame_le_iff
-
-theorem toSurreal_lt_iff {a b : Ordinal} : a.toSurreal < b.toSurreal ↔ a < b :=
-  toPGame_lt_iff
-
-theorem toSurreal_inj {a b : Ordinal} : a.toSurreal = b.toSurreal ↔ a = b :=
-  toSurreal.inj
-
-theorem toSurreal_nadd (a b : Ordinal) : (a ♯ b).toSurreal = a.toSurreal + b.toSurreal :=
-  mk_eq (toPGame_nadd a b)
-
-theorem toSurreal_nmul (a b : Ordinal) : (a ⨳ b).toSurreal = a.toSurreal * b.toSurreal :=
-  mk_eq (toPGame_nmul a b)
 
 end Ordinal

--- a/Mathlib/SetTheory/Surreal/Ordinal.lean
+++ b/Mathlib/SetTheory/Surreal/Ordinal.lean
@@ -18,8 +18,6 @@ We define the canonical map `Ordinal → Surreal` in terms of the map `Ordinal.t
 
 open Surreal SetTheory PGame
 
-open scoped NaturalOps
-
 namespace Ordinal
 
 /-- Ordinal games are numeric. -/

--- a/Mathlib/SetTheory/Surreal/Ordinal.lean
+++ b/Mathlib/SetTheory/Surreal/Ordinal.lean
@@ -29,7 +29,7 @@ theorem numeric_toPGame (o : Ordinal) : o.toPGame.Numeric := by
 /-- Converts an ordinal into the corresponding surreal. -/
 noncomputable def toSurreal : Ordinal ↪o Surreal where
   toFun o := .mk _ o.numeric_toPGame
-  inj' a b h := toPGame_equiv_iff.1 (Quotient.exact h :)
+  inj' _ _ h := toPGame_equiv_iff.1 (Quotient.exact h :)
   map_rel_iff' := @toPGame_le_iff
 
 end Ordinal


### PR DESCRIPTION
The basic theory of surreal numbers need not import ordinal numbers.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
