### PR TITLE
[Merged by Bors] - feat(CategoryTheory): if J is κ-filtered, so is Under j

### DIFF
--- a/Mathlib/CategoryTheory/Presentable/IsCardinalFiltered.lean
+++ b/Mathlib/CategoryTheory/Presentable/IsCardinalFiltered.lean
@@ -185,6 +185,6 @@ instance isCardinalFiltered_under
               ext
               have := c.w f
               dsimp at this ⊢
-              simp only [reassoc_of% this, Category.assoc, Category.comp_id]} }⟩
+              simp only [reassoc_of% this, Category.assoc, Category.comp_id] } }⟩
 
 end CategoryTheory

--- a/Mathlib/CategoryTheory/Presentable/IsCardinalFiltered.lean
+++ b/Mathlib/CategoryTheory/Presentable/IsCardinalFiltered.lean
@@ -165,4 +165,26 @@ lemma isCardinalFiltered_preorder (J : Type w) [Preorder J]
       { app a := homOfLE (hj a)
         naturality _ _ _ := rfl }⟩
 
+open IsCardinalFiltered
+
+instance isCardinalFiltered_under
+    (J : Type u) [Category.{v} J] (κ : Cardinal.{w}) [Fact κ.IsRegular]
+    [IsCardinalFiltered J κ] (j₀ : J) : IsCardinalFiltered (Under j₀) κ where
+  nonempty_cocone {A _} F hA := ⟨by
+    have := isFiltered_of_isCardinalDirected J κ
+    let c := cocone (F ⋙ Under.forget j₀) hA
+    let x (a : A) : j₀ ⟶ IsFiltered.max j₀ c.pt := (F.obj a).hom ≫ c.ι.app a ≫
+      IsFiltered.rightToMax j₀ c.pt
+    have hκ' : HasCardinalLT A κ := hasCardinalLT_of_hasCardinalLT_arrow hA
+    exact
+      { pt := Under.mk (toCoeq x hκ')
+        ι :=
+          { app a := Under.homMk (c.ι.app a ≫ IsFiltered.rightToMax j₀ c.pt ≫ coeqHom x hκ')
+              (by simpa [x] using coeq_condition x hκ' a)
+            naturality a b f := by
+              ext
+              have := c.w f
+              dsimp at this ⊢
+              simp only [reassoc_of% this, Category.assoc, Category.comp_id]} }⟩
+
 end CategoryTheory


### PR DESCRIPTION
If `κ` is a regular cardinal and `J` is a `κ`-filtered category, then so is `Under j` for any `j : J`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
