### PR TITLE
feat(CategoryTheory): the Grothendieck construction is prefibered

### DIFF
--- a/Mathlib/CategoryTheory/Bicategory/Functor/Pseudofunctor.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Functor/Pseudofunctor.lean
@@ -238,6 +238,12 @@ lemma mapComp_id_right_inv (f : a ⟶ b) : (F.mapComp f (𝟙 b)).inv =
     F.map f ◁ (F.mapId b).hom ≫ (ρ_ (F.map f)).hom ≫ F.map₂ (ρ_ f).inv := by
   simp [mapComp_id_right]
 
+lemma mapComp_congr {a b c : B} {f f' : a ⟶ b} {g g' : b ⟶ c}
+      (hff' : f = f') (hgg' : g = g') :
+    F.mapComp f g =
+      eqToIso (by rw [hgg', hff']) ≪≫ F.mapComp f' g' ≪≫ eqToIso (by rw [hgg', hff']) := by
+  aesop_cat
+
 lemma whiskerLeftIso_mapId (f : a ⟶ b) : whiskerLeftIso (F.map f) (F.mapId b) =
     (F.mapComp f (𝟙 b)).symm ≪≫ F.map₂Iso (ρ_ f) ≪≫ (ρ_ (F.map f)).symm := by
   simp [mapComp_id_right]
@@ -319,18 +325,6 @@ noncomputable def mkOfLax' (F : LaxFunctor B C) [∀ a, IsIso (F.mapId a)]
   { mapIdIso := fun a => (asIso (F.mapId a)).symm
     mapCompIso := fun f g => (asIso (F.mapComp f g)).symm }
 
-end
-
-section
-
-variable {B : Type*} [Bicategory B] {C : Type*} [Bicategory C]
-variable (F : Pseudofunctor B C)
-
-lemma mapComp_congr {a b c : B} {f f' : a ⟶ b} {g g' : b ⟶ c}
-      (hff' : f = f') (hgg' : g = g') :
-    F.mapComp f g =
-      eqToIso (by rw [hgg', hff']) ≪≫ F.mapComp f' g' ≪≫ eqToIso (by rw [hgg', hff']) := by
-  aesop_cat
 end
 
 end Pseudofunctor

--- a/Mathlib/CategoryTheory/Bicategory/Functor/Pseudofunctor.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Functor/Pseudofunctor.lean
@@ -321,6 +321,18 @@ noncomputable def mkOfLax' (F : LaxFunctor B C) [∀ a, IsIso (F.mapId a)]
 
 end
 
+section
+
+variable {B : Type*} [Bicategory B] {C : Type*} [Bicategory C]
+variable (F : Pseudofunctor B C)
+
+lemma mapComp_congr {a b c : B} {f f' : a ⟶ b} {g g' : b ⟶ c}
+      (hff' : f = f') (hgg' : g = g') :
+    F.mapComp f g =
+      eqToIso (by rw [hgg', hff']) ≪≫ F.mapComp f' g' ≪≫ eqToIso (by rw [hgg', hff']) := by
+  aesop_cat
+end
+
 end Pseudofunctor
 
 end CategoryTheory

--- a/Mathlib/CategoryTheory/Bicategory/Grothendieck.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Grothendieck.lean
@@ -137,7 +137,7 @@ lemma isHomLift_cartesianLift :
 
 /-- Given some lift `g` of `f`, the canonical map from the domain of `g` to the domain of
 the cartesian lift of `f`. -/
-def homCartesianLift {a' : ∫ F} (g : a' ⟶ a) [inst : (forget F).IsHomLift f g] :
+def homCartesianLift {a' : ∫ F} (g : a' ⟶ a) [(forget F).IsHomLift f g] :
     a' ⟶ domainCartesianLift F f where
   base := eqToHom <| IsHomLift.domain_eq (forget F) f g
   fiber :=

--- a/Mathlib/CategoryTheory/Bicategory/Grothendieck.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Grothendieck.lean
@@ -136,11 +136,11 @@ lemma cartesianLift_isHomLift :
 /-- Given some lift `g` of `f`, the canonical map from the domain of `g` to the domain of
 the cartesian lift of `f`. -/
 def map_cartesianLift {a' : ∫ F} (g : a' ⟶ a) [inst : (forget F).IsHomLift f g] :
-    a' ⟶ domain_cartesianLift F f := by
-  constructor; swap
-  · exact eqToHom <| IsHomLift.domain_eq (forget F) f g
-  · have := by simpa using IsHomLift.fac' (forget F) f g
-    exact g.fiber ≫ ((eqToIso (congrArg (fun u ↦ F.map u.op.toLoc) this)).app a.fiber).hom ≫
+    a' ⟶ domain_cartesianLift F f where
+  base := eqToHom <| IsHomLift.domain_eq (forget F) f g
+  fiber :=
+    have : g.base = eqToHom _ ≫ f := by simpa using IsHomLift.fac' (forget F) f g
+    g.fiber ≫ ((eqToIso (congrArg (fun u ↦ F.map u.op.toLoc) this)).app a.fiber).hom ≫
       ((F.mapComp f.op.toLoc _).app _).hom
 
 lemma isHomLift_mapCartesianLift {a' : ∫ F} (g : a' ⟶ a) [inst : (forget F).IsHomLift f g] :

--- a/Mathlib/CategoryTheory/Bicategory/Grothendieck.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Grothendieck.lean
@@ -137,7 +137,7 @@ lemma isHomLift_cartesianLift :
 
 /-- Given some lift `g` of `f`, the canonical map from the domain of `g` to the domain of
 the cartesian lift of `f`. -/
-def map_cartesianLift {a' : ∫ F} (g : a' ⟶ a) [inst : (forget F).IsHomLift f g] :
+def homCartesianLift {a' : ∫ F} (g : a' ⟶ a) [inst : (forget F).IsHomLift f g] :
     a' ⟶ domainCartesianLift F f where
   base := eqToHom <| IsHomLift.domain_eq (forget F) f g
   fiber :=
@@ -145,8 +145,8 @@ def map_cartesianLift {a' : ∫ F} (g : a' ⟶ a) [inst : (forget F).IsHomLift f
     g.fiber ≫ ((eqToIso (congrArg (fun u ↦ F.map u.op.toLoc) this)).app a.fiber).hom ≫
       ((F.mapComp f.op.toLoc _).app _).hom
 
-lemma isHomLift_mapCartesianLift {a' : ∫ F} (g : a' ⟶ a) [inst : (forget F).IsHomLift f g] :
-    (forget F).IsHomLift (𝟙 b) (map_cartesianLift F f g) := by
+lemma isHomLift_homCartesianLift {a' : ∫ F} (g : a' ⟶ a) [(forget F).IsHomLift f g] :
+    (forget F).IsHomLift (𝟙 b) (homCartesianLift F f g) := by
   apply IsHomLift.of_fac'
   · simp; rfl
   · apply IsHomLift.domain_eq (forget F) f g
@@ -157,9 +157,9 @@ instance isPreFibered : IsPreFibered (forget F) := by
   refine ⟨fun {a b} f ↦ ⟨domainCartesianLift F f, cartesianLift F f, ?_⟩⟩
   refine {cond := (isHomLift_cartesianLift F f).cond, universal_property := ?_}
   intro a' g hfg
-  refine ⟨map_cartesianLift F f g, ?_⟩
-  simp only [categoryStruct_Hom, and_imp, map_cartesianLift, cartesianLift]
-  refine ⟨⟨isHomLift_mapCartesianLift _ _ _, ?_⟩, ?_⟩
+  refine ⟨homCartesianLift F f g, ?_⟩
+  simp only [categoryStruct_Hom, and_imp, homCartesianLift, cartesianLift]
+  refine ⟨⟨isHomLift_homCartesianLift _ _ _, ?_⟩, ?_⟩
   · exact Hom.ext _ _ (by simpa using (IsHomLift.fac' (forget F) f g).symm) (by simp)
   · rintro H K rfl
     apply Hom.ext

--- a/Mathlib/CategoryTheory/Bicategory/Grothendieck.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Grothendieck.lean
@@ -128,17 +128,17 @@ def domainCartesianLift : ∫ F :=
 
 /-- The cartesian lift of `f`. -/
 @[simps]
-def cartesianLift : domain_cartesianLift F f ⟶ a :=
+def cartesianLift : domainCartesianLift F f ⟶ a :=
   ⟨f, 𝟙 _⟩
 
 lemma isHomLift_cartesianLift :
-    IsHomLift (forget F) f (cartesianLift F f) := by
-  ⟨IsHomLiftAux.map (p := forget F) (a := domain_cartesianLift F f) ⟨f, 𝟙 _⟩⟩
+    IsHomLift (forget F) f (cartesianLift F f) :=
+  ⟨IsHomLiftAux.map (p := forget F) (a := domainCartesianLift F f) ⟨f, 𝟙 _⟩⟩
 
 /-- Given some lift `g` of `f`, the canonical map from the domain of `g` to the domain of
 the cartesian lift of `f`. -/
 def map_cartesianLift {a' : ∫ F} (g : a' ⟶ a) [inst : (forget F).IsHomLift f g] :
-    a' ⟶ domain_cartesianLift F f where
+    a' ⟶ domainCartesianLift F f where
   base := eqToHom <| IsHomLift.domain_eq (forget F) f g
   fiber :=
     have : g.base = eqToHom _ ≫ f := by simpa using IsHomLift.fac' (forget F) f g
@@ -154,12 +154,12 @@ lemma isHomLift_mapCartesianLift {a' : ∫ F} (g : a' ⟶ a) [inst : (forget F).
 
 /-- The preFibered structure on `∫ F`, using the forgetful functor `forget F`. -/
 instance isPreFibered : IsPreFibered (forget F) := by
-  refine ⟨fun {a b} f ↦ ⟨domain_cartesianLift F f, cartesianLift F f, ?_⟩⟩
-  refine {cond := (cartesianLift_isHomLift F f).cond, universal_property := ?_}
+  refine ⟨fun {a b} f ↦ ⟨domainCartesianLift F f, cartesianLift F f, ?_⟩⟩
+  refine {cond := (isHomLift_cartesianLift F f).cond, universal_property := ?_}
   intro a' g hfg
   refine ⟨map_cartesianLift F f g, ?_⟩
   simp only [categoryStruct_Hom, and_imp, map_cartesianLift, cartesianLift]
-  refine ⟨⟨map_cartesianLift_isHomLift _ _ _, ?_⟩, ?_⟩
+  refine ⟨⟨isHomLift_mapCartesianLift _ _ _, ?_⟩, ?_⟩
   · exact Hom.ext _ _ (by simpa using (IsHomLift.fac' (forget F) f g).symm) (by simp)
   · rintro H K rfl
     apply Hom.ext

--- a/Mathlib/CategoryTheory/Bicategory/Grothendieck.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Grothendieck.lean
@@ -129,7 +129,7 @@ def domain_cartesianLift : ∫ F :=
 def cartesianLift : domain_cartesianLift F f ⟶ a :=
   ⟨f, 𝟙 _⟩
 
-lemma cartesianLift_isHomLift :
+lemma isHomLift_cartesianLift :
     IsHomLift (forget F) f (cartesianLift F f) := by
   ⟨IsHomLiftAux.map (p := forget F) (a := domain_cartesianLift F f) ⟨f, 𝟙 _⟩⟩
 

--- a/Mathlib/CategoryTheory/Bicategory/Grothendieck.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Grothendieck.lean
@@ -143,7 +143,7 @@ def map_cartesianLift {a' : ∫ F} (g : a' ⟶ a) [inst : (forget F).IsHomLift f
     exact g.fiber ≫ ((eqToIso (congrArg (fun u ↦ F.map u.op.toLoc) this)).app a.fiber).hom ≫
       ((F.mapComp f.op.toLoc _).app _).hom
 
-lemma map_cartesianLift_isHomLift {a' : ∫ F} (g : a' ⟶ a) [inst : (forget F).IsHomLift f g] :
+lemma isHomLift_mapCartesianLift {a' : ∫ F} (g : a' ⟶ a) [inst : (forget F).IsHomLift f g] :
     (forget F).IsHomLift (𝟙 b) (map_cartesianLift F f g) := by
   apply IsHomLift.of_fac'
   · simp; rfl

--- a/Mathlib/CategoryTheory/Bicategory/Grothendieck.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Grothendieck.lean
@@ -131,7 +131,7 @@ def cartesianLift : domain_cartesianLift F f ⟶ a :=
 
 lemma cartesianLift_isHomLift :
     IsHomLift (forget F) f (cartesianLift F f) := by
-  constructor; apply IsHomLiftAux.map (p := forget F) (a := domain_cartesianLift F f) ⟨f, 𝟙 _⟩
+  ⟨IsHomLiftAux.map (p := forget F) (a := domain_cartesianLift F f) ⟨f, 𝟙 _⟩⟩
 
 /-- Given some lift `g` of `f`, the canonical map from the domain of `g` to the domain of
 the cartesian lift of `f`. -/

--- a/Mathlib/CategoryTheory/Bicategory/Grothendieck.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Grothendieck.lean
@@ -152,21 +152,16 @@ lemma map_cartesianLift_isHomLift {a' : ∫ F} (g : a' ⟶ a) [inst : (forget F)
 
 /-- The preFibered structure on `∫ F`, using the forgetful functor `forget F`. -/
 instance isPreFibered : IsPreFibered (forget F) := by
-  constructor; intro a b f
-  use domain_cartesianLift F f, cartesianLift F f
+  refine ⟨fun {a b} f ↦ ⟨domain_cartesianLift F f, cartesianLift F f, ?_⟩⟩
   refine {cond := (cartesianLift_isHomLift F f).cond, universal_property := ?_}
   intro a' g hfg
   refine ⟨map_cartesianLift F f g, ?_⟩
   simp only [categoryStruct_Hom, and_imp, map_cartesianLift, cartesianLift]
-  constructor
-  · constructor
-    · apply map_cartesianLift_isHomLift
-    · apply Hom.ext <;> simpa using (IsHomLift.fac' (forget F) f g).symm
+  refine ⟨⟨map_cartesianLift_isHomLift _ _ _, ?_⟩, ?_⟩
+  · exact Hom.ext _ _ (by simpa using (IsHomLift.fac' (forget F) f g).symm) (by simp)
   · rintro H K rfl
     apply Hom.ext
-    · simp only [categoryStruct_comp_base, op_comp, Quiver.Hom.comp_toLoc, id_comp, eqToHom_app,
-      assoc, categoryStruct_comp_fiber, forget_obj, Iso.app_hom, eqToIso.hom, Cat.comp_obj, map_id]
-      have := by simpa using IsHomLift.fac' (forget F) (𝟙 b) H
+    · have := by simpa using IsHomLift.fac' (forget F) (𝟙 b) H
       simp [F.mapComp_congr rfl (congrArg (fun u ↦ u.op.toLoc) this)]
     · simpa using IsHomLift.fac' (forget F) (𝟙 b) H
 

--- a/Mathlib/CategoryTheory/Bicategory/Grothendieck.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Grothendieck.lean
@@ -127,6 +127,7 @@ def domainCartesianLift : ∫ F :=
   ⟨b, (F.map f.op.toLoc).obj a.fiber⟩
 
 /-- The cartesian lift of `f`. -/
+@[simps]
 def cartesianLift : domain_cartesianLift F f ⟶ a :=
   ⟨f, 𝟙 _⟩
 

--- a/Mathlib/CategoryTheory/Bicategory/Grothendieck.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Grothendieck.lean
@@ -122,7 +122,8 @@ def forget : ∫ F ⥤ 𝒮 where
 variable {a : ∫ F} {b : 𝒮} (f : b ⟶ (forget F).obj a)
 
 /-- The domain of the cartesian lift of `f`. -/
-def domain_cartesianLift : ∫ F :=
+@[simps]
+def domainCartesianLift : ∫ F :=
   ⟨b, (F.map f.op.toLoc).obj a.fiber⟩
 
 /-- The cartesian lift of `f`. -/


### PR DESCRIPTION
Adds a `isPreFibered` instance for the Grothendieck construction.

Co-authored-by: Christian Merten <c.j.merten@uu.nl>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)