### PR TITLE
[Merged by Bors] - feat(CategoryTheory): subobjects in Grothendieck abelian categories

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1694,6 +1694,7 @@ import Mathlib.CategoryTheory.Abelian.GrothendieckAxioms.Indization
 import Mathlib.CategoryTheory.Abelian.GrothendieckAxioms.Sheaf
 import Mathlib.CategoryTheory.Abelian.GrothendieckAxioms.Types
 import Mathlib.CategoryTheory.Abelian.GrothendieckCategory.Basic
+import Mathlib.CategoryTheory.Abelian.GrothendieckCategory.Subobject
 import Mathlib.CategoryTheory.Abelian.Images
 import Mathlib.CategoryTheory.Abelian.Injective
 import Mathlib.CategoryTheory.Abelian.InjectiveResolution

--- a/Mathlib/CategoryTheory/Abelian/GrothendieckCategory/Subobject.lean
+++ b/Mathlib/CategoryTheory/Abelian/GrothendieckCategory/Subobject.lean
@@ -1,0 +1,113 @@
+/-
+Copyright (c) 2025 Joël Riou. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joël Riou
+-/
+import Mathlib.CategoryTheory.Abelian.GrothendieckAxioms.Colim
+import Mathlib.CategoryTheory.Abelian.GrothendieckCategory.Basic
+import Mathlib.CategoryTheory.Presentable.Basic
+import Mathlib.CategoryTheory.Subobject.Lattice
+
+/-!
+# Subobjects in Grothendieck abelian categories
+
+We study the complete lattice of subjects of `X : C`
+when `C` is a Grothendieck abelian cateogry. In particular,
+for a functor `F : J ⥤ MonoOver X` from a filtered category,
+we relate the colimit of `F` (computed in `C`) and the
+supremum of the subobjects corresponding to the objects
+in the image of `F`.
+
+-/
+
+universe w v' v u' u
+
+namespace CategoryTheory
+
+open Limits
+
+namespace IsGrothendieckAbelian
+
+attribute [local instance] IsFiltered.isConnected
+
+variable {C : Type u} [Category.{v} C] [Abelian C] [IsGrothendieckAbelian.{w} C]
+  {X : C} {J : Type w} [SmallCategory J] (F : J ⥤ MonoOver X)
+
+section
+
+variable [IsFiltered J] {c : Cocone (F ⋙ MonoOver.forget _ ⋙ Over.forget _)}
+  (hc : IsColimit c) (f : c.pt ⟶ X) (hf : ∀ (j : J), c.ι.app j ≫ f = (F.obj j).obj.hom)
+
+include hc hf
+
+/-- If `C` is a Grothendieck abelian category, `X : C`, if `F : J ⥤ MonoOver X` is a
+functor from a filtered category `J`, `c` is a colimit cocone for the corresponding
+functor `J ⥤ C`, and `f : c.pt ⟶ X` is induced by the inclusions,
+then `f` is a monomorphism. -/
+lemma mono_of_isColimit_monoOver : Mono f := by
+  let α : F ⋙ MonoOver.forget _ ⋙ Over.forget _ ⟶ (Functor.const _).obj X :=
+    { app j := (F.obj j).obj.hom
+      naturality _ _ f := (F.map f).w }
+  have := NatTrans.mono_of_mono_app α
+  exact colim.map_mono' α hc (isColimitConstCocone J X) f (by simpa using hf)
+
+/-- If `C` is a Grothendieck abelian category, `X : C`, if `F : J ⥤ MonoOver X` is a
+functor from a filtered category `J`, the colimit of `F` (computed in `C`) gives
+a subobject of `F` which is a supremum of the subobjects corresponding to
+the objects in the image of the functor `F`. -/
+lemma subobject_mk_of_isColimit_eq_iSup :
+    haveI := mono_of_isColimit_monoOver F hc f hf
+    Subobject.mk f = ⨆ j, Subobject.mk (F.obj j).obj.hom := by
+  haveI := mono_of_isColimit_monoOver F hc f hf
+  apply le_antisymm
+  · rw [le_iSup_iff]
+    intro s H
+    induction' s using Subobject.ind with Z g _
+    let c' : Cocone (F ⋙ MonoOver.forget _ ⋙ Over.forget _) := Cocone.mk Z
+      { app j := Subobject.ofMkLEMk _ _ (H j)
+        naturality j j' f := by
+          dsimp
+          simpa only [← cancel_mono g, Category.assoc, Subobject.ofMkLEMk_comp,
+            Category.comp_id] using MonoOver.w (F.map f) }
+    exact Subobject.mk_le_mk_of_comm (hc.desc c')
+      (hc.hom_ext (fun j ↦ by rw [hc.fac_assoc c' j, hf, Subobject.ofMkLEMk_comp]))
+  · rw [iSup_le_iff]
+    intro j
+    exact Subobject.mk_le_mk_of_comm (c.ι.app j) (hf j)
+
+end
+
+/-- If `C` is a Grothendieck abelian category, `X : C`, if `F : J ⥤ MonoOver X` is a
+functor from a `κ`-filtered category `J` with `κ` a regular cardinal such
+that `HasCardinalLT (Subobject X) κ`, and if the colimit of `F` (computed in `C`)
+maps epimorphically onto `X`, then there exists `j : J` such that `(F.obj j).obj.hom`
+is an isomorphism. -/
+lemma exists_isIso_of_functor_from_monoOver
+    {κ : Cardinal.{w}} [hκ : Fact κ.IsRegular] [IsCardinalFiltered J κ]
+    (hXκ : HasCardinalLT (Subobject X) κ)
+    (c : Cocone (F ⋙ MonoOver.forget _ ⋙ Over.forget _)) (hc : IsColimit c)
+    (f : c.pt ⟶ X) (hf : ∀ (j : J), c.ι.app j ≫ f = (F.obj j).obj.hom)(h : Epi f) :
+    ∃ (j : J), IsIso (F.obj j).obj.hom := by
+  have := isFiltered_of_isCardinalDirected J κ
+  have := mono_of_isColimit_monoOver F hc f hf
+  rw [Subobject.epi_iff_mk_eq_top f,
+    subobject_mk_of_isColimit_eq_iSup F hc f hf] at h
+  let s (j : J) : Subobject X := Subobject.mk (F.obj j).obj.hom
+  have h' : Function.Surjective (fun (j : J) ↦ (⟨s j, _, rfl⟩ : Set.range s)) := by
+    rintro ⟨_, j, rfl⟩
+    exact ⟨j, rfl⟩
+  obtain ⟨σ, hσ⟩ := h'.hasRightInverse
+  have hs : HasCardinalLT (Set.range s) κ :=
+    hXκ.of_injective (f := Subtype.val) Subtype.val_injective
+  refine ⟨IsCardinalFiltered.max σ hs, ?_⟩
+  rw [Subobject.isIso_iff_mk_eq_top, ← top_le_iff, ← h, iSup_le_iff]
+  intro j
+  let t : Set.range s := ⟨_, j, rfl⟩
+  trans Subobject.mk (F.obj (σ t)).obj.hom
+  · exact (hσ t).symm.le
+  · exact MonoOver.subobjectMk_le_mk_of_hom
+      (F.map (IsCardinalFiltered.toMax σ hs t))
+
+end IsGrothendieckAbelian
+
+end CategoryTheory

--- a/Mathlib/CategoryTheory/Abelian/GrothendieckCategory/Subobject.lean
+++ b/Mathlib/CategoryTheory/Abelian/GrothendieckCategory/Subobject.lean
@@ -86,7 +86,7 @@ lemma exists_isIso_of_functor_from_monoOver
     {κ : Cardinal.{w}} [hκ : Fact κ.IsRegular] [IsCardinalFiltered J κ]
     (hXκ : HasCardinalLT (Subobject X) κ)
     (c : Cocone (F ⋙ MonoOver.forget _ ⋙ Over.forget _)) (hc : IsColimit c)
-    (f : c.pt ⟶ X) (hf : ∀ (j : J), c.ι.app j ≫ f = (F.obj j).obj.hom)(h : Epi f) :
+    (f : c.pt ⟶ X) (hf : ∀ (j : J), c.ι.app j ≫ f = (F.obj j).obj.hom) (h : Epi f) :
     ∃ (j : J), IsIso (F.obj j).obj.hom := by
   have := isFiltered_of_isCardinalDirected J κ
   have := mono_of_isColimit_monoOver F hc f hf

--- a/Mathlib/CategoryTheory/Abelian/GrothendieckCategory/Subobject.lean
+++ b/Mathlib/CategoryTheory/Abelian/GrothendieckCategory/Subobject.lean
@@ -5,7 +5,7 @@ Authors: Joël Riou
 -/
 import Mathlib.CategoryTheory.Abelian.GrothendieckAxioms.Colim
 import Mathlib.CategoryTheory.Abelian.GrothendieckCategory.Basic
-import Mathlib.CategoryTheory.Presentable.Basic
+import Mathlib.CategoryTheory.Presentable.IsCardinalFiltered
 import Mathlib.CategoryTheory.Subobject.Lattice
 
 /-!

--- a/Mathlib/CategoryTheory/Subobject/Basic.lean
+++ b/Mathlib/CategoryTheory/Subobject/Basic.lean
@@ -432,6 +432,10 @@ def isoOfMkEqMk {B A₁ A₂ : C} (f : A₁ ⟶ B) (g : A₂ ⟶ B) [Mono f] [Mo
 
 end Subobject
 
+lemma MonoOver.subobjectMk_le_mk_of_hom {P Q : MonoOver X} (f : P ⟶ Q) :
+    Subobject.mk P.obj.hom ≤ Subobject.mk Q.obj.hom :=
+  Subobject.mk_le_mk_of_comm f.left (by simp)
+
 open CategoryTheory.Limits
 
 namespace Subobject

--- a/Mathlib/CategoryTheory/Subobject/Lattice.lean
+++ b/Mathlib/CategoryTheory/Subobject/Lattice.lean
@@ -242,6 +242,11 @@ theorem mk_eq_top_of_isIso {X Y : C} (f : X ⟶ Y) [IsIso f] : mk f = ⊤ :=
 theorem eq_top_of_isIso_arrow {Y : C} (P : Subobject Y) [IsIso P.arrow] : P = ⊤ :=
   (isIso_arrow_iff_eq_top P).mp inferInstance
 
+lemma epi_iff_mk_eq_top [Balanced C] (f : X ⟶ Y) [Mono f] :
+    Epi f ↔ Subobject.mk f = ⊤ := by
+  rw [← isIso_iff_mk_eq_top]
+  exact ⟨fun _ ↦ isIso_of_mono_of_epi f, fun _ ↦ inferInstance⟩
+
 section
 
 variable [HasPullbacks C]

--- a/Mathlib/CategoryTheory/Subobject/MonoOver.lean
+++ b/Mathlib/CategoryTheory/Subobject/MonoOver.lean
@@ -57,6 +57,8 @@ instance (X : C) : Category (MonoOver X) :=
 
 namespace MonoOver
 
+instance mono_obj_hom (S : MonoOver X) : Mono S.obj.hom := S.2
+
 /-- Construct a `MonoOver X`. -/
 @[simps]
 def mk' {X A : C} (f : A ⟶ X) [hf : Mono f] : MonoOver X where


### PR DESCRIPTION
We study the complete lattice of subjects of `X : C` when `C` is a Grothendieck abelian cateogry. In particular, for a functor `F : J ⥤ MonoOver X` from a filtered category, we relate the colimit of `F` (computed in `C`) and the supremum of the subobjects corresponding to the objects in the image of `F`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
