### PR TITLE
[Merged by Bors] - feat(Algebra/Algebra/Lie): isNilpotent_of_le for LieSubmodules

### DIFF
--- a/Mathlib/Algebra/Lie/Engel.lean
+++ b/Mathlib/Algebra/Lie/Engel.lean
@@ -172,7 +172,7 @@ theorem Function.Surjective.isEngelian {f : L →ₗ⁅R⁆ L₂} (hf : Function
   have hnp : ∀ x, IsNilpotent (toEnd R L M x) := fun x => h' (f x)
   have surj_id : Function.Surjective (LinearMap.id : M →ₗ[R] M) := Function.surjective_id
   haveI : LieModule.IsNilpotent L M := h M hnp
-  apply hf.lieModuleIsNilpotent surj_id
+  apply hf.lieModuleIsNilpotent _ surj_id
   aesop
 
 theorem LieEquiv.isEngelian_iff (e : L ≃ₗ⁅R⁆ L₂) :

--- a/Mathlib/Algebra/Lie/Nilpotent.lean
+++ b/Mathlib/Algebra/Lie/Nilpotent.lean
@@ -667,8 +667,7 @@ theorem Function.Surjective.lieModule_lcs_map_eq (k : ℕ) :
       simp only [← LieSubmodule.mem_toSubmodule] at this
       simp_rw [lowerCentralSeries_succ, LieSubmodule.lieIdeal_oper_eq_linear_span',
         Submodule.map_span, LieSubmodule.mem_top, true_and, ← LieSubmodule.mem_toSubmodule]
-      apply Submodule.span_mono
-      apply Set.Subset.trans _ this
+      refine Submodule.span_mono (Set.Subset.trans ?_ this)
       rintro m₁ ⟨x, n, hn, rfl⟩
       obtain ⟨n', hn', rfl⟩ := ih hn
       exact ⟨x, n', hn', rfl⟩

--- a/Mathlib/Algebra/Lie/Nilpotent.lean
+++ b/Mathlib/Algebra/Lie/Nilpotent.lean
@@ -634,10 +634,10 @@ theorem lieModule_lcs_map_le (k : ℕ) : (lowerCentralSeries R L M k : Submodule
     rw [lowerCentralSeries_succ, LieSubmodule.lieIdeal_oper_eq_linear_span', Submodule.map_span]
     apply Submodule.span_le.mpr
     rintro m₂ ⟨m, ⟨x, n, m_n, h⟩, rfl⟩
+    simp [lowerCentralSeries_succ, SetLike.mem_coe, LieSubmodule.mem_toSubmodule]
     have : ∃ y : L₂, ∃ n : lowerCentralSeries R L₂ M₂ k, ⁅y, n⁆ = g m := by
       use f x, ⟨g m_n, ih (Submodule.mem_map_of_mem h.1)⟩
       simp [LieSubmodule.mem_top, LieSubmodule.coe_bracket, hfg x m_n, h.2]
-    simp [lowerCentralSeries_succ, SetLike.mem_coe, LieSubmodule.mem_toSubmodule]
     obtain ⟨y, n, hn⟩ := this
     rw [← hn]
     apply LieSubmodule.lie_mem_lie
@@ -657,7 +657,7 @@ theorem Function.Injective.lieModuleIsNilpotent [IsNilpotent L₂ M₂] : IsNilp
   apply Submodule.map_injective_of_injective hg_inj
   have := lieModule_lcs_map_le hfg k
   rw [hk] at this
-  simp_all only [LieSubmodule.bot_toSubmodule, le_bot_iff, Submodule.map_bot]
+  simpa [LieSubmodule.bot_toSubmodule, le_bot_iff, Submodule.map_bot]
 
 include hf hg hfg in
 theorem Function.Surjective.lieModule_lcs_map_eq (k : ℕ) :
@@ -723,7 +723,7 @@ theorem isNilpotent_of_le (M₁ M₂ : LieSubmodule R L M)
   let g : M₁ →ₗ[R] M₂ := Submodule.inclusion h₁
   have hfg : ∀ x m, ⁅f x, g m⁆ = g ⁅x, m⁆ := by
     intro x m
-    simp_all only [LieHom.coe_one, id_eq, f, g]
+    simp [LieHom.coe_one, id_eq, f, g]
     obtain ⟨val, property⟩ := m
     rfl
   have hg_inj : Function.Injective g := by

--- a/Mathlib/Algebra/Lie/Nilpotent.lean
+++ b/Mathlib/Algebra/Lie/Nilpotent.lean
@@ -641,8 +641,7 @@ theorem lieModule_lcs_map_le (k : ℕ) :
     · simp
     · exact SetLike.coe_mem n
 
-variable [LieModule R L₂ M₂]
-variable (hg_inj : Injective g)
+variable [LieModule R L₂ M₂] (hg_inj : Injective g)
 
 include hg_inj hfg in
 theorem Function.Injective.lieModuleIsNilpotent [IsNilpotent L₂ M₂] : IsNilpotent L M := by

--- a/Mathlib/Algebra/Lie/Nilpotent.lean
+++ b/Mathlib/Algebra/Lie/Nilpotent.lean
@@ -625,8 +625,7 @@ variable (hg_inj : Injective g)
 section
 
 include hfg in
-theorem lieModule_lcs_map_le (k : ℕ) :
-    (lowerCentralSeries R L M k : Submodule R M).map g ≤
+theorem lieModule_lcs_map_le (k : ℕ) : (lowerCentralSeries R L M k : Submodule R M).map g ≤
     (lowerCentralSeries R L₂ M₂ k : Submodule R M₂) := by
   induction k with
   | zero =>
@@ -635,15 +634,14 @@ theorem lieModule_lcs_map_le (k : ℕ) :
     rw [lowerCentralSeries_succ, LieSubmodule.lieIdeal_oper_eq_linear_span', Submodule.map_span]
     apply Submodule.span_le.mpr
     rintro m₂ ⟨m, ⟨x, n, m_n, h⟩, rfl⟩
-    simp
     have : ∃ y : L₂, ∃ n : lowerCentralSeries R L₂ M₂ k, ⁅y, n⁆ = g m := by
-      use f x
-      use ⟨g m_n, ih (Submodule.mem_map_of_mem h.1)⟩
-      simp_all only [LieSubmodule.mem_top, LieSubmodule.coe_bracket]
+      use f x, ⟨g m_n, ih (Submodule.mem_map_of_mem h.1)⟩
+      simp [LieSubmodule.mem_top, LieSubmodule.coe_bracket, hfg x m_n, h.2]
+    simp [lowerCentralSeries_succ, SetLike.mem_coe, LieSubmodule.mem_toSubmodule]
     obtain ⟨y, n, hn⟩ := this
     rw [← hn]
     apply LieSubmodule.lie_mem_lie
-    · simp_all only [LieSubmodule.mem_top, LieSubmodule.coe_bracket]
+    · simp [LieSubmodule.mem_top, LieSubmodule.coe_bracket]
     · exact SetLike.coe_mem n
 
 end
@@ -719,7 +717,7 @@ section
 
 variable [LieModule R L M]
 
-theorem nilpotent_submodule_nilpotent (M₁ M₂ : LieSubmodule R L M)
+theorem isNilpotent_of_le (M₁ M₂ : LieSubmodule R L M)
     (h₁ : M₁ ≤ M₂) (h₂ : IsNilpotent L M₂) : IsNilpotent L M₁ := by
   let f : L →ₗ⁅R⁆ L := 1
   let g : M₁ →ₗ[R] M₂ := Submodule.inclusion h₁
@@ -730,7 +728,7 @@ theorem nilpotent_submodule_nilpotent (M₁ M₂ : LieSubmodule R L M)
     rfl
   have hg_inj : Function.Injective g := by
     apply Submodule.inclusion_injective
-  exact Function.Injective.lieModuleIsNilpotent hfg hg_inj
+  exact hg_inj.lieModuleIsNilpotent hfg
 
 end
 

--- a/Mathlib/Algebra/Lie/Nilpotent.lean
+++ b/Mathlib/Algebra/Lie/Nilpotent.lean
@@ -619,22 +619,19 @@ variable [LieModule R L M]
 variable {L₂ M₂ : Type*} [LieRing L₂] [LieAlgebra R L₂]
 variable [AddCommGroup M₂] [Module R M₂] [LieRingModule L₂ M₂]
 variable {f : L →ₗ⁅R⁆ L₂} {g : M →ₗ[R] M₂}
-variable (hf : Surjective f) (hg : Surjective g) (hfg : ∀ x m, ⁅f x, g m⁆ = g ⁅x, m⁆)
-variable (hg_inj : Injective g)
-
-section
+variable (hfg : ∀ x m, ⁅f x, g m⁆ = g ⁅x, m⁆)
 
 include hfg in
-theorem lieModule_lcs_map_le (k : ℕ) : (lowerCentralSeries R L M k : Submodule R M).map g ≤
-    (lowerCentralSeries R L₂ M₂ k : Submodule R M₂) := by
+theorem lieModule_lcs_map_le (k : ℕ) :
+    (lowerCentralSeries R L M k : Submodule R M).map g ≤ lowerCentralSeries R L₂ M₂ k := by
   induction k with
   | zero =>
     simp [LinearMap.range_eq_top, Submodule.map_top]
   | succ k ih =>
-    rw [lowerCentralSeries_succ, LieSubmodule.lieIdeal_oper_eq_linear_span', Submodule.map_span]
-    apply Submodule.span_le.mpr
+    rw [lowerCentralSeries_succ, LieSubmodule.lieIdeal_oper_eq_linear_span', Submodule.map_span,
+      Submodule.span_le]
     rintro m₂ ⟨m, ⟨x, n, m_n, ⟨h₁, h₂⟩⟩, rfl⟩
-    simp [lowerCentralSeries_succ, SetLike.mem_coe, LieSubmodule.mem_toSubmodule]
+    simp only [lowerCentralSeries_succ, SetLike.mem_coe, LieSubmodule.mem_toSubmodule]
     have : ∃ y : L₂, ∃ n : lowerCentralSeries R L₂ M₂ k, ⁅y, n⁆ = g m := by
       use f x, ⟨g m_n, ih (Submodule.mem_map_of_mem h₁)⟩
       simp [LieSubmodule.mem_top, LieSubmodule.coe_bracket, hfg x m_n, h₂]
@@ -644,9 +641,8 @@ theorem lieModule_lcs_map_le (k : ℕ) : (lowerCentralSeries R L M k : Submodule
     · simp [LieSubmodule.mem_top, LieSubmodule.coe_bracket]
     · exact SetLike.coe_mem n
 
-end
-
 variable [LieModule R L₂ M₂]
+variable (hg_inj : Injective g)
 
 include hg_inj hfg in
 theorem Function.Injective.lieModuleIsNilpotent [IsNilpotent L₂ M₂] : IsNilpotent L M := by
@@ -659,7 +655,9 @@ theorem Function.Injective.lieModuleIsNilpotent [IsNilpotent L₂ M₂] : IsNilp
   rw [hk] at this
   simpa [LieSubmodule.bot_toSubmodule, le_bot_iff, Submodule.map_bot]
 
-include hf hg hfg in
+variable (hf_surj : Surjective f) (hg_surj : Surjective g)
+
+include hf_surj hg_surj hfg in
 theorem Function.Surjective.lieModule_lcs_map_eq (k : ℕ) :
     (lowerCentralSeries R L M k : Submodule R M).map g = lowerCentralSeries R L₂ M₂ k := by
   induction k with
@@ -677,24 +675,24 @@ theorem Function.Surjective.lieModule_lcs_map_eq (k : ℕ) :
     · rintro ⟨m, ⟨x, n, hn, rfl⟩, rfl⟩
       exact ⟨f x, n, hn, hfg x n⟩
     · rintro ⟨x, n, hn, rfl⟩
-      obtain ⟨y, rfl⟩ := hf x
+      obtain ⟨y, rfl⟩ := hf_surj x
       exact ⟨⁅y, n⁆, ⟨y, n, hn, rfl⟩, (hfg y n).symm⟩
 
-include hf hg hfg in
+include hf_surj hg_surj hfg in
 theorem Function.Surjective.lieModuleIsNilpotent [IsNilpotent L M] : IsNilpotent L₂ M₂ := by
   obtain ⟨k, hk⟩ := IsNilpotent.nilpotent R L M
   rw [isNilpotent_iff R]
   use k
   rw [← LieSubmodule.toSubmodule_inj] at hk ⊢
-  simp [← hf.lieModule_lcs_map_eq hg hfg k, hk]
+  simp [← hf_surj.lieModule_lcs_map_eq hfg hg_surj k, hk]
 
 theorem Equiv.lieModule_isNilpotent_iff (f : L ≃ₗ⁅R⁆ L₂) (g : M ≃ₗ[R] M₂)
     (hfg : ∀ x m, ⁅f x, g m⁆ = g ⁅x, m⁆) : IsNilpotent L M ↔ IsNilpotent L₂ M₂ := by
   constructor <;> intro h
   · have hg : Surjective (g : M →ₗ[R] M₂) := g.surjective
-    exact f.surjective.lieModuleIsNilpotent hg hfg
+    exact f.surjective.lieModuleIsNilpotent hfg hg
   · have hg : Surjective (g.symm : M₂ →ₗ[R] M) := g.symm.surjective
-    refine f.symm.surjective.lieModuleIsNilpotent hg fun x m => ?_
+    refine f.symm.surjective.lieModuleIsNilpotent (fun x m => ?_) hg
     rw [LinearEquiv.coe_coe, LieEquiv.coe_toLieHom, ← g.symm_apply_apply ⁅f.symm x, g.symm m⁆, ←
       hfg, f.apply_symm_apply, g.apply_symm_apply]
 
@@ -723,7 +721,7 @@ theorem isNilpotent_of_le (M₁ M₂ : LieSubmodule R L M) (h₁ : M₁ ≤ M₂
   let g : M₁ →ₗ[R] M₂ := Submodule.inclusion h₁
   have hfg : ∀ x m, ⁅f x, g m⁆ = g ⁅x, m⁆ := by
     intro x m
-    simp [LieHom.coe_one, id_eq, f, g]
+    simp only [LieHom.coe_one, id_eq, f, g]
     obtain ⟨val, property⟩ := m
     rfl
   have hg_inj : Function.Injective g := by

--- a/Mathlib/Algebra/Lie/Nilpotent.lean
+++ b/Mathlib/Algebra/Lie/Nilpotent.lean
@@ -634,7 +634,7 @@ theorem lieModule_lcs_map_le (k : ℕ) :
     simp only [lowerCentralSeries_succ, SetLike.mem_coe, LieSubmodule.mem_toSubmodule]
     have : ∃ y : L₂, ∃ n : lowerCentralSeries R L₂ M₂ k, ⁅y, n⁆ = g m := by
       use f x, ⟨g m_n, ih (Submodule.mem_map_of_mem h₁)⟩
-      simp [LieSubmodule.mem_top, LieSubmodule.coe_bracket, hfg x m_n, h₂]
+      simp [hfg x m_n, h₂]
     obtain ⟨y, n, hn⟩ := this
     rw [← hn]
     apply LieSubmodule.lie_mem_lie

--- a/Mathlib/Algebra/Lie/Nilpotent.lean
+++ b/Mathlib/Algebra/Lie/Nilpotent.lean
@@ -707,9 +707,6 @@ end Morphisms
 namespace LieModule
 
 variable (R L M)
-
-section
-
 variable [LieModule R L M]
 
 theorem isNilpotent_of_le (M₁ M₂ : LieSubmodule R L M) (h₁ : M₁ ≤ M₂) (h₂ : IsNilpotent L M₂) :

--- a/Mathlib/Algebra/Lie/Nilpotent.lean
+++ b/Mathlib/Algebra/Lie/Nilpotent.lean
@@ -638,7 +638,7 @@ theorem lieModule_lcs_map_le (k : ℕ) :
     obtain ⟨y, n, hn⟩ := this
     rw [← hn]
     apply LieSubmodule.lie_mem_lie
-    · simp [LieSubmodule.mem_top, LieSubmodule.coe_bracket]
+    · simp
     · exact SetLike.coe_mem n
 
 variable [LieModule R L₂ M₂]

--- a/Mathlib/Algebra/Lie/Nilpotent.lean
+++ b/Mathlib/Algebra/Lie/Nilpotent.lean
@@ -716,8 +716,6 @@ theorem isNilpotent_of_le (M₁ M₂ : LieSubmodule R L M) (h₁ : M₁ ≤ M₂
   have hfg : ∀ x m, ⁅f x, g m⁆ = g ⁅x, m⁆ := by aesop
   exact (Submodule.inclusion_injective h₁).lieModuleIsNilpotent hfg
 
-end
-
 end LieModule
 
 end NilpotentModules

--- a/Mathlib/Algebra/Lie/Nilpotent.lean
+++ b/Mathlib/Algebra/Lie/Nilpotent.lean
@@ -660,23 +660,24 @@ variable (hf_surj : Surjective f) (hg_surj : Surjective g)
 include hf_surj hg_surj hfg in
 theorem Function.Surjective.lieModule_lcs_map_eq (k : ℕ) :
     (lowerCentralSeries R L M k : Submodule R M).map g = lowerCentralSeries R L₂ M₂ k := by
+  refine le_antisymm (lieModule_lcs_map_le hfg k) ?_
   induction k with
   | zero => simpa [LinearMap.range_eq_top]
   | succ k ih =>
     suffices
-      g '' {m | ∃ (x : L) (n : _), n ∈ lowerCentralSeries R L M k ∧ ⁅x, n⁆ = m} =
-        {m | ∃ (x : L₂) (n : _), n ∈ lowerCentralSeries R L M k ∧ ⁅x, g n⁆ = m} by
+      {m | ∃ (x : L₂) (n : _), n ∈ lowerCentralSeries R L M k ∧ ⁅x, g n⁆ = m} ⊆
+        g '' {m | ∃ (x : L) (n : _), n ∈ lowerCentralSeries R L M k ∧ ⁅x, n⁆ = m} by
       simp only [← LieSubmodule.mem_toSubmodule] at this
       simp_rw [lowerCentralSeries_succ, LieSubmodule.lieIdeal_oper_eq_linear_span',
-        Submodule.map_span, LieSubmodule.mem_top, true_and, ← LieSubmodule.mem_toSubmodule, this,
-        ← ih, Submodule.mem_map, exists_exists_and_eq_and]
-    ext m₂
-    constructor
-    · rintro ⟨m, ⟨x, n, hn, rfl⟩, rfl⟩
-      exact ⟨f x, n, hn, hfg x n⟩
-    · rintro ⟨x, n, hn, rfl⟩
-      obtain ⟨y, rfl⟩ := hf_surj x
-      exact ⟨⁅y, n⁆, ⟨y, n, hn, rfl⟩, (hfg y n).symm⟩
+        Submodule.map_span, LieSubmodule.mem_top, true_and, ← LieSubmodule.mem_toSubmodule]
+      apply Submodule.span_mono
+      apply Set.Subset.trans _ this
+      rintro m₁ ⟨x, n, hn, rfl⟩
+      obtain ⟨n', hn', rfl⟩ := ih hn
+      exact ⟨x, n', hn', rfl⟩
+    rintro m₂ ⟨x, n, hn, rfl⟩
+    obtain ⟨y, rfl⟩ := hf_surj x
+    exact ⟨⁅y, n⁆, ⟨y, n, hn, rfl⟩, (hfg y n).symm⟩
 
 include hf_surj hg_surj hfg in
 theorem Function.Surjective.lieModuleIsNilpotent [IsNilpotent L M] : IsNilpotent L₂ M₂ := by

--- a/Mathlib/Algebra/Lie/Nilpotent.lean
+++ b/Mathlib/Algebra/Lie/Nilpotent.lean
@@ -633,11 +633,11 @@ theorem lieModule_lcs_map_le (k : ℕ) : (lowerCentralSeries R L M k : Submodule
   | succ k ih =>
     rw [lowerCentralSeries_succ, LieSubmodule.lieIdeal_oper_eq_linear_span', Submodule.map_span]
     apply Submodule.span_le.mpr
-    rintro m₂ ⟨m, ⟨x, n, m_n, h⟩, rfl⟩
+    rintro m₂ ⟨m, ⟨x, n, m_n, ⟨h₁, h₂⟩⟩, rfl⟩
     simp [lowerCentralSeries_succ, SetLike.mem_coe, LieSubmodule.mem_toSubmodule]
     have : ∃ y : L₂, ∃ n : lowerCentralSeries R L₂ M₂ k, ⁅y, n⁆ = g m := by
-      use f x, ⟨g m_n, ih (Submodule.mem_map_of_mem h.1)⟩
-      simp [LieSubmodule.mem_top, LieSubmodule.coe_bracket, hfg x m_n, h.2]
+      use f x, ⟨g m_n, ih (Submodule.mem_map_of_mem h₁)⟩
+      simp [LieSubmodule.mem_top, LieSubmodule.coe_bracket, hfg x m_n, h₂]
     obtain ⟨y, n, hn⟩ := this
     rw [← hn]
     apply LieSubmodule.lie_mem_lie
@@ -717,8 +717,8 @@ section
 
 variable [LieModule R L M]
 
-theorem isNilpotent_of_le (M₁ M₂ : LieSubmodule R L M)
-    (h₁ : M₁ ≤ M₂) (h₂ : IsNilpotent L M₂) : IsNilpotent L M₁ := by
+theorem isNilpotent_of_le (M₁ M₂ : LieSubmodule R L M) (h₁ : M₁ ≤ M₂) (h₂ : IsNilpotent L M₂) :
+    IsNilpotent L M₁ := by
   let f : L →ₗ⁅R⁆ L := 1
   let g : M₁ →ₗ[R] M₂ := Submodule.inclusion h₁
   have hfg : ∀ x m, ⁅f x, g m⁆ = g ⁅x, m⁆ := by

--- a/Mathlib/Algebra/Lie/Nilpotent.lean
+++ b/Mathlib/Algebra/Lie/Nilpotent.lean
@@ -650,9 +650,7 @@ theorem Function.Injective.lieModuleIsNilpotent [IsNilpotent L₂ M₂] : IsNilp
   use k
   rw [← LieSubmodule.toSubmodule_inj] at hk ⊢
   apply Submodule.map_injective_of_injective hg_inj
-  have := lieModule_lcs_map_le hfg k
-  rw [hk] at this
-  simpa [LieSubmodule.bot_toSubmodule, le_bot_iff, Submodule.map_bot]
+  simpa [hk] using lieModule_lcs_map_le hfg k
 
 variable (hf_surj : Surjective f) (hg_surj : Surjective g)
 

--- a/Mathlib/Algebra/Lie/Nilpotent.lean
+++ b/Mathlib/Algebra/Lie/Nilpotent.lean
@@ -711,16 +711,10 @@ variable [LieModule R L M]
 
 theorem isNilpotent_of_le (M₁ M₂ : LieSubmodule R L M) (h₁ : M₁ ≤ M₂) (h₂ : IsNilpotent L M₂) :
     IsNilpotent L M₁ := by
-  let f : L →ₗ⁅R⁆ L := 1
+  let f : L →ₗ⁅R⁆ L := LieHom.id
   let g : M₁ →ₗ[R] M₂ := Submodule.inclusion h₁
-  have hfg : ∀ x m, ⁅f x, g m⁆ = g ⁅x, m⁆ := by
-    intro x m
-    simp only [LieHom.coe_one, id_eq, f, g]
-    obtain ⟨val, property⟩ := m
-    rfl
-  have hg_inj : Function.Injective g := by
-    apply Submodule.inclusion_injective
-  exact hg_inj.lieModuleIsNilpotent hfg
+  have hfg : ∀ x m, ⁅f x, g m⁆ = g ⁅x, m⁆ := by aesop
+  exact (Submodule.inclusion_injective h₁).lieModuleIsNilpotent hfg
 
 end
 


### PR DESCRIPTION
Prove isNilpotent_of_le for LieSubmodules
---
I am working on defining the largest nilpotent ideal of a Lie algebra within the framework:
https://github.com/orgs/leanprover-community/projects/17
A somewhat similar object, namely the radical of a Lie algebra (the largest solvable ideal), is already defined in [Algebra/Lie/Solvable.lean](https://github.com/leanprover-community/mathlib4/blob/master/Mathlib/Algebra/Lie/Solvable.lean).

In this PR, I prove that if M_1, M_2 are LieSubmodules with M_1 <= M_2 and M_2 is nilpotent, then M_1 is also nilpotent. To establish this, I introduce a new theorem in the Morphisms namespace:
Function.Injective.lieModuleIsNilpotent
This serves as the injective counterpart to the existing theorem:
Function.Surjective.lieModuleIsNilpotent

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
