### PR TITLE
[Merged by Bors] - chore(Matroid/Restrict): fix omissions in #21879

### DIFF
--- a/Mathlib/Data/Matroid/Basic.lean
+++ b/Mathlib/Data/Matroid/Basic.lean
@@ -324,7 +324,7 @@ theorem encard_diff_eq (exch : ExchangeProperty IsBase) (hB₁ : IsBase B₁) (h
 
 /-- Any two sets `B₁`, `B₂` in a family with the exchange property have the same
 `ℕ∞`-cardinality. -/
-theorem encard_base_eq (exch : ExchangeProperty IsBase) (hB₁ : IsBase B₁) (hB₂ : IsBase B₂) :
+theorem encard_isBase_eq (exch : ExchangeProperty IsBase) (hB₁ : IsBase B₁) (hB₂ : IsBase B₂) :
     B₁.encard = B₂.encard := by
   rw [← encard_diff_add_encard_inter B₁ B₂, exch.encard_diff_eq hB₁ hB₂, inter_comm,
     encard_diff_add_encard_inter]
@@ -426,7 +426,7 @@ theorem IsBase.ncard_diff_comm (hB₁ : M.IsBase B₁) (hB₂ : M.IsBase B₂) :
 
 theorem IsBase.encard_eq_encard_of_isBase (hB₁ : M.IsBase B₁) (hB₂ : M.IsBase B₂) :
     B₁.encard = B₂.encard := by
-  rw [M.isBase_exchange.encard_base_eq hB₁ hB₂]
+  rw [M.isBase_exchange.encard_isBase_eq hB₁ hB₂]
 
 theorem IsBase.ncard_eq_ncard_of_isBase (hB₁ : M.IsBase B₁) (hB₂ : M.IsBase B₂) :
     B₁.ncard = B₂.ncard := by

--- a/Mathlib/Data/Matroid/Closure.lean
+++ b/Mathlib/Data/Matroid/Closure.lean
@@ -509,7 +509,7 @@ lemma Indep.closure_inter_eq_inter_closure (h : M.Indep (I ∪ J)) :
   · exact iInter_congr (by simp)
   rwa [← union_eq_iUnion]
 
-lemma Indep.inter_IsBasis_biInter {ι : Type*} (hI : M.Indep I) {X : ι → Set α} {A : Set ι}
+lemma Indep.inter_isBasis_biInter {ι : Type*} (hI : M.Indep I) {X : ι → Set α} {A : Set ι}
     (hA : A.Nonempty) (h : ∀ i ∈ A, M.IsBasis ((X i) ∩ I) (X i)) :
     M.IsBasis ((⋂ i ∈ A, X i) ∩ I) (⋂ i ∈ A, X i) := by
   refine (hI.inter_left _).isBasis_of_subset_of_subset_closure inter_subset_left ?_
@@ -518,17 +518,17 @@ lemma Indep.inter_IsBasis_biInter {ι : Type*} (hI : M.Indep I) {X : ι → Set 
       (hI.subset (by simp)), subset_iInter_iff]
   exact fun i hiA ↦ (biInter_subset_of_mem hiA).trans (h i hiA).subset_closure
 
-lemma Indep.inter_IsBasis_iInter [Nonempty ι] {X : ι → Set α} (hI : M.Indep I)
+lemma Indep.inter_isBasis_iInter [Nonempty ι] {X : ι → Set α} (hI : M.Indep I)
     (h : ∀ i, M.IsBasis ((X i) ∩ I) (X i)) : M.IsBasis ((⋂ i, X i) ∩ I) (⋂ i, X i) := by
-  convert hI.inter_IsBasis_biInter (ι := PLift ι) univ_nonempty (X := fun i ↦ X i.down)
+  convert hI.inter_isBasis_biInter (ι := PLift ι) univ_nonempty (X := fun i ↦ X i.down)
     (by simpa using fun (i : PLift ι) ↦ h i.down) <;>
   · simp only [mem_univ, iInter_true]
     exact (iInter_plift_down X).symm
 
-lemma Indep.inter_IsBasis_sInter {Xs : Set (Set α)} (hI : M.Indep I) (hXs : Xs.Nonempty)
+lemma Indep.inter_isBasis_sInter {Xs : Set (Set α)} (hI : M.Indep I) (hXs : Xs.Nonempty)
     (h : ∀ X ∈ Xs, M.IsBasis (X ∩ I) X) : M.IsBasis (⋂₀ Xs ∩ I) (⋂₀ Xs) := by
   rw [sInter_eq_biInter]
-  exact hI.inter_IsBasis_biInter hXs h
+  exact hI.inter_isBasis_biInter hXs h
 
 lemma isBasis_iff_isBasis_closure_of_subset (hIX : I ⊆ X) (hX : X ⊆ M.E := by aesop_mat) :
     M.IsBasis I X ↔ M.IsBasis I (M.closure X) :=

--- a/Mathlib/Data/Matroid/IndepAxioms.lean
+++ b/Mathlib/Data/Matroid/IndepAxioms.lean
@@ -515,7 +515,7 @@ namespace Matroid
     obtain ⟨B, hB, hfin⟩ := exists_finite_base
     refine fun X _ ↦ Matroid.existsMaximalSubsetProperty_of_bdd
       ⟨B.ncard, fun Y ⟨B', hB', hYB'⟩ ↦ ?_⟩ X
-    rw [hfin.cast_ncard_eq, isBase_exchange.encard_base_eq hB hB']
+    rw [hfin.cast_ncard_eq, isBase_exchange.encard_isBase_eq hB hB']
     exact encard_mono hYB')
   (subset_ground := subset_ground)
 

--- a/Mathlib/Data/Matroid/Restrict.lean
+++ b/Mathlib/Data/Matroid/Restrict.lean
@@ -161,7 +161,7 @@ theorem isBase_restrict_iff' : (M ↾ X).IsBase I ↔ M.IsBasis' I X := by
 theorem IsBasis'.isBase_restrict (hI : M.IsBasis' I X) : (M ↾ X).IsBase I :=
   isBase_restrict_iff'.1 hI
 
-theorem IsBasis.restrict_base (h : M.IsBasis I X) : (M ↾ X).IsBase I :=
+theorem IsBasis.restrict_isBase (h : M.IsBasis I X) : (M ↾ X).IsBase I :=
   (isBase_restrict_iff h.subset_ground).2 h
 
 instance restrict_rankFinite [M.RankFinite] (R : Set α) : (M ↾ R).RankFinite :=
@@ -381,7 +381,7 @@ theorem Base.isBasis_of_isRestriction (hI : N.IsBase I) (hNM : N ≤r M) : M.IsB
 
 theorem IsRestriction.base_iff (hMN : N ≤r M) {B : Set α} : N.IsBase B ↔ M.IsBasis B N.E :=
   ⟨fun h ↦ Base.isBasis_of_isRestriction h hMN,
-    fun h ↦ by simpa [hMN.eq_restrict] using h.restrict_base⟩
+    fun h ↦ by simpa [hMN.eq_restrict] using h.restrict_isBase⟩
 
 theorem IsRestriction.isBasis_iff (hMN : N ≤r M) : N.IsBasis I X ↔ M.IsBasis I X ∧ X ⊆ N.E :=
   ⟨fun h ↦ ⟨h.of_isRestriction hMN, h.subset_ground⟩, fun h ↦ h.1.isBasis_isRestriction hMN h.2⟩
@@ -442,7 +442,7 @@ theorem IsBasis.isBase_of_isBase_subset (hIX : M.IsBasis I X) (hB : M.IsBase B) 
 
 theorem IsBasis.exchange (hIX : M.IsBasis I X) (hJX : M.IsBasis J X) (he : e ∈ I \ J) :
     ∃ f ∈ J \ I, M.IsBasis (insert f (I \ {e})) X := by
-  obtain ⟨y,hy, h⟩ := hIX.restrict_base.exchange hJX.restrict_base he
+  obtain ⟨y,hy, h⟩ := hIX.restrict_isBase.exchange hJX.restrict_isBase he
   exact ⟨y, hy, by rwa [isBase_restrict_iff] at h⟩
 
 theorem IsBasis.eq_exchange_of_diff_eq_singleton (hI : M.IsBasis I X) (hJ : M.IsBasis J X)

--- a/Mathlib/Data/Matroid/Restrict.lean
+++ b/Mathlib/Data/Matroid/Restrict.lean
@@ -376,11 +376,11 @@ theorem IsBasis.isBasis_isRestriction (hI : M.IsBasis I X) (hNM : N ≤r M) (hX 
 theorem IsBasis.of_isRestriction (hI : N.IsBasis I X) (hNM : N ≤r M) : M.IsBasis I X := by
   obtain ⟨R, hR, rfl⟩ := hNM; exact ((isBasis_restrict_iff hR).1 hI).1
 
-theorem Base.isBasis_of_isRestriction (hI : N.IsBase I) (hNM : N ≤r M) : M.IsBasis I N.E := by
+theorem IsBase.isBasis_of_isRestriction (hI : N.IsBase I) (hNM : N ≤r M) : M.IsBasis I N.E := by
   obtain ⟨R, hR, rfl⟩ := hNM; rwa [isBase_restrict_iff] at hI
 
 theorem IsRestriction.base_iff (hMN : N ≤r M) {B : Set α} : N.IsBase B ↔ M.IsBasis B N.E :=
-  ⟨fun h ↦ Base.isBasis_of_isRestriction h hMN,
+  ⟨fun h ↦ IsBase.isBasis_of_isRestriction h hMN,
     fun h ↦ by simpa [hMN.eq_restrict] using h.restrict_isBase⟩
 
 theorem IsRestriction.isBasis_iff (hMN : N ≤r M) : N.IsBasis I X ↔ M.IsBasis I X ∧ X ⊆ N.E :=

--- a/Mathlib/Data/Matroid/Restrict.lean
+++ b/Mathlib/Data/Matroid/Restrict.lean
@@ -436,7 +436,7 @@ theorem Indep.exists_insert_of_not_isBasis (hI : M.Indep I) (hIX : I ⊆ X) (hI'
   obtain ⟨e, he, hi⟩ := (hI.indep_restrict_of_subset hIX).exists_insert_of_not_isBase hI' hJ
   exact ⟨e, he, (restrict_indep_iff.mp hi).1⟩
 
-theorem IsBasis.base_of_base_subset (hIX : M.IsBasis I X) (hB : M.IsBase B) (hBX : B ⊆ X) :
+theorem IsBasis.isBase_of_isBase_subset (hIX : M.IsBasis I X) (hB : M.IsBase B) (hBX : B ⊆ X) :
     M.IsBase I :=
   hB.isBase_of_isBasis_superset hBX hIX
 


### PR DESCRIPTION
While updating my repo, I discovered a few mistakes I made in #21879 . This PR fixes them.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
