### PR TITLE
[Merged by Bors] - chore(Algebra): upstream `Int.cast_mul_eq_zsmul_cast`

### DIFF
--- a/Mathlib/Algebra/ModEq.lean
+++ b/Mathlib/Algebra/ModEq.lean
@@ -5,7 +5,6 @@ Authors: Yaël Dillies
 -/
 import Mathlib.Algebra.Field.Basic
 import Mathlib.Algebra.NoZeroSMulDivisors.Basic
-import Mathlib.Algebra.Order.Ring.Int
 import Mathlib.Data.Int.ModEq
 import Mathlib.GroupTheory.QuotientGroup.Defs
 import Mathlib.Algebra.Group.Subgroup.ZPowers.Basic

--- a/Mathlib/Algebra/Order/Ring/Int.lean
+++ b/Mathlib/Algebra/Order/Ring/Int.lean
@@ -56,12 +56,6 @@ lemma isCompl_even_odd : IsCompl { n : ℤ | Even n } { n | Odd n } := by
 lemma _root_.Nat.cast_natAbs {α : Type*} [AddGroupWithOne α] (n : ℤ) : (n.natAbs : α) = |n| := by
   rw [← natCast_natAbs, Int.cast_natCast]
 
-/-- Note this holds in marginally more generality than `Int.cast_mul` -/
-lemma cast_mul_eq_zsmul_cast {α : Type*} [AddCommGroupWithOne α] :
-    ∀ m n : ℤ, ↑(m * n) = m • (n : α) :=
-  fun m ↦ Int.induction_on m (by simp) (fun _ ih ↦ by simp [add_mul, add_zsmul, ih]) fun _ ih ↦ by
-    simp only [sub_mul, one_mul, cast_sub, ih, sub_zsmul, one_zsmul, ← sub_eq_add_neg, forall_const]
-
 lemma two_le_iff_pos_of_even {m : ℤ} (even : Even m) : 2 ≤ m ↔ 0 < m :=
   le_iff_pos_of_dvd (by decide) even.two_dvd
 

--- a/Mathlib/Algebra/Ring/Int/Defs.lean
+++ b/Mathlib/Algebra/Ring/Int/Defs.lean
@@ -57,6 +57,12 @@ lemma cast_mul {α : Type*} [NonAssocRing α] : ∀ m n, ((m * n : ℤ) : α) = 
     | zero => simp
     | succ m ih => simp_all [add_mul]
 
+/-- Note this holds in marginally more generality than `Int.cast_mul` -/
+lemma cast_mul_eq_zsmul_cast {α : Type*} [AddCommGroupWithOne α] :
+    ∀ m n : ℤ, ↑(m * n) = m • (n : α) :=
+  fun m ↦ Int.induction_on m (by simp) (fun _ ih ↦ by simp [add_mul, add_zsmul, ih]) fun _ ih ↦ by
+    simp only [sub_mul, one_mul, cast_sub, ih, sub_zsmul, one_zsmul, ← sub_eq_add_neg, forall_const]
+
 @[simp, norm_cast] lemma cast_pow {R : Type*} [Ring R] (n : ℤ) (m : ℕ) :
     ↑(n ^ m) = (n ^ m : R) := by
   induction' m with m ih <;> simp [_root_.pow_succ, *]


### PR DESCRIPTION
This lemma lives in a file about the ordered ring structure on Int but can happily live without knowing about orders, next to `Int.cast_mul` which it is a slight generalization of. Spotted while looking at grey imports for `Algebra.ModEq` in `Algebra.CharP.Defs`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
