### PR TITLE
[Merged by Bors] - chore(Algebra/Ring/Subring): avoid importing `Int.Cast.Lemmas` in `Defs.lean`

### DIFF
--- a/Mathlib/Algebra/Ring/Subring/Basic.lean
+++ b/Mathlib/Algebra/Ring/Subring/Basic.lean
@@ -1071,3 +1071,8 @@ theorem comap_map_eq_self_of_injective
   SetLike.coe_injective (Set.preimage_image_eq _ hf)
 
 end Subring
+
+theorem AddSubgroup.int_mul_mem {G : AddSubgroup R} (k : ℤ) {g : R} (h : g ∈ G) :
+    (k : R) * g ∈ G := by
+  convert AddSubgroup.zsmul_mem G h k using 1
+  rw [zsmul_eq_mul]

--- a/Mathlib/Algebra/Ring/Subring/Defs.lean
+++ b/Mathlib/Algebra/Ring/Subring/Defs.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Ashvni Narayanan
 -/
 import Mathlib.Algebra.Ring.Subsemiring.Defs
-import Mathlib.Data.Int.Cast.Lemmas
 import Mathlib.RingTheory.NonUnitalSubring.Defs
 
 /-!
@@ -62,7 +61,7 @@ Lattice inclusion (e.g. `≤` and `⊓`) is used rather than set notation (`⊆`
 subring, subrings
 -/
 
-assert_not_exists OrderedRing
+assert_not_exists Even OrderedRing
 
 universe u v w
 
@@ -122,12 +121,10 @@ theorem coeSubtype : (subtype s : s → R) = ((↑) : s → R) :=
   rfl
 
 @[simp, norm_cast]
-theorem coe_natCast (n : ℕ) : ((n : s) : R) = n :=
-  map_natCast (subtype s) n
+theorem coe_natCast (n : ℕ) : ((n : s) : R) = n := rfl
 
 @[simp, norm_cast]
-theorem coe_intCast (n : ℤ) : ((n : s) : R) = n :=
-  map_intCast (subtype s) n
+theorem coe_intCast (n : ℤ) : ((n : s) : R) = n := rfl
 
 end SubringClass
 
@@ -331,12 +328,10 @@ theorem coeSubtype : ⇑s.subtype = ((↑) : s → R) :=
   rfl
 
 @[norm_cast]
-theorem coe_natCast : ∀ n : ℕ, ((n : s) : R) = n :=
-  map_natCast s.subtype
+theorem coe_natCast (n : ℕ) : ((n : s) : R) = n := rfl
 
 @[norm_cast]
-theorem coe_intCast : ∀ n : ℤ, ((n : s) : R) = n :=
-  map_intCast s.subtype
+theorem coe_intCast (n : ℤ) : ((n : s) : R) = n := rfl
 
 /-! ## Partial order -/
 
@@ -378,8 +373,3 @@ lemma Subring.toNonUnitalSubring_toSubring (S : Subring R) :
 
 lemma NonUnitalSubring.toSubring_toNonUnitalSubring (S : NonUnitalSubring R) (h1 : (1 : R) ∈ S) :
     (NonUnitalSubring.toSubring S h1).toNonUnitalSubring = S := by cases S; rfl
-
-theorem AddSubgroup.int_mul_mem {G : AddSubgroup R} (k : ℤ) {g : R} (h : g ∈ G) :
-    (k : R) * g ∈ G := by
-  convert AddSubgroup.zsmul_mem G h k using 1
-  simp


### PR DESCRIPTION
The file `Data.Int.Cast.Lemmas` is quite theory-heavy in itself, and brings along a lot more. We can get rid of the import by replacing a couple proofs with `rfl` and moving a lemma to a downstream file.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
