### PR TITLE
[Merged by Bors] - doc(Data/Set/Operations): typo and punctuation

### DIFF
--- a/Mathlib/Data/Set/Operations.lean
+++ b/Mathlib/Data/Set/Operations.lean
@@ -29,7 +29,7 @@ More advanced theorems about these definitions are located in other files in `Ma
 - `Set.pi`: indexed product of a family of sets `∀ i, Set (α i)`,
   as a set in `∀ i, α i`;
 - `Set.EqOn f g s`: the predicate saying that two functions are equal on a set;
-- `Set.MapsTo f s t`: the predicate syaing that `f` sends all points of `s` to `t;
+- `Set.MapsTo f s t`: the predicate saying that `f` sends all points of `s` to `t`;
 - `Set.MapsTo.restrict`: restrict `f : α → β` to `f' : s → t` provided that `Set.MapsTo f s t`;
 - `Set.restrictPreimage`: restrict `f : α → β` to `f' : (f ⁻¹' t) → t`;
 - `Set.InjOn`: the predicate saying that `f` is injective on a set;
@@ -41,7 +41,7 @@ More advanced theorems about these definitions are located in other files in `Ma
 - `Set.image2`: the image of a pair of sets under a binary operation,
   mostly useful to define pointwise algebraic operations on sets;
 - `Set.seq`: monadic `seq` operation on sets;
-  we don't use monadic notation to ensure support for maps between different universes;
+  we don't use monadic notation to ensure support for maps between different universes.
 
 ## Notations
 


### PR DESCRIPTION
Fix a typo, add a backtick, change the semicolon at the end of the **Main definitions** section to a period.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
