### PR TITLE
[Merged by Bors] - chore(NumberTheory/Harmonic): move some results downstream from `Defs.lean`

### DIFF
--- a/Mathlib/NumberTheory/Harmonic/Bounds.lean
+++ b/Mathlib/NumberTheory/Harmonic/Bounds.lean
@@ -14,6 +14,12 @@ This file proves $\log(n+1) \le H_n \le 1 + \log(n)$ for all natural numbers $n$
 
 -/
 
+lemma harmonic_eq_sum_Icc {n : ℕ} : harmonic n = ∑ i ∈ Finset.Icc 1 n, (↑i)⁻¹ := by
+  rw [harmonic, Finset.range_eq_Ico, Finset.sum_Ico_add' (fun (i : ℕ) ↦ (i : ℚ)⁻¹) 0 n (c := 1)]
+  -- It might be better to restate `Nat.Ico_succ_right` in terms of `+ 1`,
+  -- as we try to move away from `Nat.succ`.
+  simp only [Nat.add_one, Nat.Ico_succ_right]
+
 theorem log_add_one_le_harmonic (n : ℕ) :
     Real.log ↑(n+1) ≤ harmonic n := by
   calc _ = ∫ x in (1 : ℕ)..↑(n+1), x⁻¹ := ?_

--- a/Mathlib/NumberTheory/Harmonic/Defs.lean
+++ b/Mathlib/NumberTheory/Harmonic/Defs.lean
@@ -3,9 +3,8 @@ Copyright (c) 2023 Koundinya Vajjha. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Koundinya Vajjha, Thomas Browning
 -/
-import Mathlib.Algebra.BigOperators.Intervals
-import Mathlib.Algebra.Order.Field.Basic
-import Mathlib.Tactic.Positivity
+import Mathlib.Data.Rat.Defs
+import Mathlib.Algebra.BigOperators.Group.Finset.Basic
 
 /-!
 
@@ -26,15 +25,3 @@ lemma harmonic_zero : harmonic 0 = 0 :=
 @[simp]
 lemma harmonic_succ (n : ℕ) : harmonic (n + 1) = harmonic n + (↑(n + 1))⁻¹ :=
   Finset.sum_range_succ ..
-
-lemma harmonic_pos {n : ℕ} (Hn : n ≠ 0) : 0 < harmonic n := by
-  unfold harmonic
-  rw [← Finset.nonempty_range_iff] at Hn
-  positivity
-
-
-lemma harmonic_eq_sum_Icc {n : ℕ} :  harmonic n = ∑ i ∈ Finset.Icc 1 n, (↑i)⁻¹ := by
-  rw [harmonic, Finset.range_eq_Ico, Finset.sum_Ico_add' (fun (i : ℕ) ↦ (i : ℚ)⁻¹) 0 n (c := 1)]
-  -- It might be better to restate `Nat.Ico_succ_right` in terms of `+ 1`,
-  -- as we try to move away from `Nat.succ`.
-  simp only [Nat.add_one, Nat.Ico_succ_right]

--- a/Mathlib/NumberTheory/Harmonic/Int.lean
+++ b/Mathlib/NumberTheory/Harmonic/Int.lean
@@ -16,6 +16,11 @@ https://kconrad.math.uconn.edu/blurbs/gradnumthy/padicharmonicsum.pdf
 
 -/
 
+lemma harmonic_pos {n : ℕ} (Hn : n ≠ 0) : 0 < harmonic n := by
+  unfold harmonic
+  rw [← Finset.nonempty_range_iff] at Hn
+  positivity
+
 /-- The 2-adic valuation of the n-th harmonic number is the negative of the logarithm
     of n. -/
 theorem padicValRat_two_harmonic (n : ℕ) : padicValRat 2 (harmonic n) = -Nat.log 2 n := by

--- a/Mathlib/NumberTheory/Harmonic/Int.lean
+++ b/Mathlib/NumberTheory/Harmonic/Int.lean
@@ -5,6 +5,7 @@ Authors: Koundinya Vajjha, Thomas Browning
 -/
 import Mathlib.NumberTheory.Harmonic.Defs
 import Mathlib.NumberTheory.Padics.PadicNumbers
+import Mathlib.Tactic.Positivity
 
 /-!
 


### PR DESCRIPTION
This `Defs` file relies on quite a bit of theory. We can move the lemmas inside closer to the place of usage and shake imports that way. I don't know how important this is overall, but it does make for a nice local reduction.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
