### PR TITLE
[Merged by Bors] - chore(Algebra/EuclideanDomain): clean up imports for `Defs.lean`

### DIFF
--- a/Mathlib/Algebra/EuclideanDomain/Basic.lean
+++ b/Mathlib/Algebra/EuclideanDomain/Basic.lean
@@ -27,7 +27,7 @@ variable {R : Type u}
 variable [EuclideanDomain R]
 
 /-- The well founded relation in a Euclidean Domain satisfying `a % b ≺ b` for `b ≠ 0`  -/
-local infixl:50 " ≺ " => EuclideanDomain.R
+local infixl:50 " ≺ " => EuclideanDomain.r
 
 -- See note [lower instance priority]
 instance (priority := 100) toMulDivCancelClass : MulDivCancelClass R where
@@ -37,6 +37,14 @@ instance (priority := 100) toMulDivCancelClass : MulDivCancelClass R where
     have := mul_right_not_lt b h
     rw [sub_mul, mul_comm (_ / _), sub_eq_iff_eq_add'.2 (div_add_mod (a * b) b).symm] at this
     exact this (mod_lt _ hb)
+
+theorem mod_eq_sub_mul_div {R : Type*} [EuclideanDomain R] (a b : R) : a % b = a - b * (a / b) :=
+  calc
+    a % b = b * (a / b) + a % b - b * (a / b) := (add_sub_cancel_left _ _).symm
+    _ = a - b * (a / b) := by rw [div_add_mod]
+
+theorem val_dvd_le : ∀ a b : R, b ∣ a → a ≠ 0 → ¬a ≺ b
+  | _, b, ⟨d, rfl⟩, ha => mul_left_not_lt b (mt (by rintro rfl; exact mul_zero _) ha)
 
 @[simp]
 theorem mod_eq_zero {a b : R} : a % b = 0 ↔ b ∣ a :=

--- a/Mathlib/Algebra/EuclideanDomain/Defs.lean
+++ b/Mathlib/Algebra/EuclideanDomain/Defs.lean
@@ -3,8 +3,6 @@ Copyright (c) 2018 Louis Carlin. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Louis Carlin, Mario Carneiro
 -/
-import Mathlib.Algebra.Divisibility.Basic
-import Mathlib.Algebra.Group.Basic
 import Mathlib.Algebra.Ring.Defs
 import Mathlib.Order.RelClasses
 
@@ -60,7 +58,6 @@ value of `j`.
 
 Euclidean domain, transfinite Euclidean domain, Bézout's lemma
 -/
-
 
 universe u
 
@@ -127,11 +124,6 @@ theorem div_add_mod' (m k : R) : m / k * k + m % k = m := by
   rw [mul_comm]
   exact div_add_mod _ _
 
-theorem mod_eq_sub_mul_div {R : Type*} [EuclideanDomain R] (a b : R) : a % b = a - b * (a / b) :=
-  calc
-    a % b = b * (a / b) + a % b - b * (a / b) := (add_sub_cancel_left _ _).symm
-    _ = a - b * (a / b) := by rw [div_add_mod]
-
 theorem mod_lt : ∀ (a) {b : R}, b ≠ 0 → a % b ≺ b :=
   EuclideanDomain.remainder_lt
 
@@ -145,9 +137,6 @@ theorem mod_zero (a : R) : a % 0 = a := by simpa only [zero_mul, zero_add] using
 theorem lt_one (a : R) : a ≺ (1 : R) → a = 0 :=
   haveI := Classical.dec
   not_imp_not.1 fun h => by simpa only [one_mul] using mul_left_not_lt 1 h
-
-theorem val_dvd_le : ∀ a b : R, b ∣ a → a ≠ 0 → ¬a ≺ b
-  | _, b, ⟨d, rfl⟩, ha => mul_left_not_lt b (mt (by rintro rfl; exact mul_zero _) ha)
 
 @[simp]
 theorem div_zero (a : R) : a / 0 = 0 :=

--- a/Mathlib/RingTheory/PrincipalIdealDomain.lean
+++ b/Mathlib/RingTheory/PrincipalIdealDomain.lean
@@ -3,6 +3,7 @@ Copyright (c) 2018 Chris Hughes. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes, Morenikeji Neri
 -/
+import Mathlib.Algebra.EuclideanDomain.Basic
 import Mathlib.Algebra.EuclideanDomain.Field
 import Mathlib.Algebra.GCDMonoid.Basic
 import Mathlib.RingTheory.Ideal.Maps


### PR DESCRIPTION
We can reduce the imports of this file if we move some lemmas downstream. It's a -137 / 50% reduction for definition of euclidean domains and a few downstream files, and a +1 / +0.1% increase for `PrincipalIdealDomain` and a lot of downstream files: I think that's definitely worth it. (Especially if we can split `PrincipalIdealDomain` later on.)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
