### PR TITLE
[Merged by Bors] - chore(Algebra/Group/Action): move smul-as-function to `End.lean`

### DIFF
--- a/Mathlib/Algebra/Group/Action/Defs.lean
+++ b/Mathlib/Algebra/Group/Action/Defs.lean
@@ -5,10 +5,6 @@ Authors: Chris Hughes, Yury Kudryashov
 -/
 import Mathlib.Algebra.Group.Commute.Defs
 import Mathlib.Algebra.Opposites
-import Mathlib.Data.FunLike.Basic
-import Mathlib.Logic.Embedding.Basic
-import Mathlib.Logic.Function.Iterate
-import Mathlib.Logic.Nontrivial.Basic
 import Mathlib.Tactic.Spread
 
 /-!
@@ -444,19 +440,6 @@ lemma SMulCommClass.of_commMonoid
     rw [← one_smul G (s • x), ← smul_assoc, ← one_smul G x, ← smul_assoc s 1 x,
       smul_comm, smul_assoc, one_smul, smul_assoc, one_smul]
 
-namespace MulAction
-
-variable (M α) in
-/-- Embedding of `α` into functions `M → α` induced by a multiplicative action of `M` on `α`. -/
-@[to_additive
-"Embedding of `α` into functions `M → α` induced by an additive action of `M` on `α`."]
-def toFun : α ↪ M → α :=
-  ⟨fun y x ↦ x • y, fun y₁ y₂ H ↦ one_smul M y₁ ▸ one_smul M y₂ ▸ by convert congr_fun H 1⟩
-
-@[to_additive (attr := simp)]
-lemma toFun_apply (x : M) (y : α) : MulAction.toFun M α y x = x • y := rfl
-
-end MulAction
 end
 
 section CompatibleScalar

--- a/Mathlib/Algebra/Group/Action/End.lean
+++ b/Mathlib/Algebra/Group/Action/End.lean
@@ -5,6 +5,7 @@ Authors: Chris Hughes, Yury Kudryashov
 -/
 import Mathlib.Algebra.Group.Action.Defs
 import Mathlib.Algebra.Group.Hom.Defs
+import Mathlib.Logic.Embedding.Basic
 
 /-!
 # Endomorphisms, homomorphisms and group actions

--- a/Mathlib/Algebra/Group/Action/End.lean
+++ b/Mathlib/Algebra/Group/Action/End.lean
@@ -36,6 +36,20 @@ variable {M N α : Type*}
 section
 variable [Monoid M] [MulAction M α]
 
+namespace MulAction
+
+variable (M α) in
+/-- Embedding of `α` into functions `M → α` induced by a multiplicative action of `M` on `α`. -/
+@[to_additive
+"Embedding of `α` into functions `M → α` induced by an additive action of `M` on `α`."]
+def toFun : α ↪ M → α :=
+  ⟨fun y x ↦ x • y, fun y₁ y₂ H ↦ one_smul M y₁ ▸ one_smul M y₂ ▸ by convert congr_fun H 1⟩
+
+@[to_additive (attr := simp)]
+lemma toFun_apply (x : M) (y : α) : MulAction.toFun M α y x = x • y := rfl
+
+end MulAction
+
 /-- Push forward the action of `R` on `M` along a compatible surjective map `f : R →* S`.
 
 See also `Function.Surjective.distribMulActionLeft` and `Function.Surjective.moduleLeft`.


### PR DESCRIPTION
The definition `MulAction.toFun` is an ingredient in defining scalar actions as endomorphisms of various functions. If we remove it from the `Defs` file, that saves a relatively large amount of imports since `Actions.Defs` has few imports already.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
