### PR TITLE
[Merged by Bors] - chore(Order/Monotone): split `Basic.lean` into `Basic.lean` and `Defs.lean`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4396,6 +4396,7 @@ import Mathlib.Order.MinMax
 import Mathlib.Order.Minimal
 import Mathlib.Order.ModularLattice
 import Mathlib.Order.Monotone.Basic
+import Mathlib.Order.Monotone.Defs
 import Mathlib.Order.Monotone.Extension
 import Mathlib.Order.Monotone.Monovary
 import Mathlib.Order.Monotone.MonovaryOrder

--- a/Mathlib/Algebra/Order/GroupWithZero/Unbundled.lean
+++ b/Mathlib/Algebra/Order/GroupWithZero/Unbundled.lean
@@ -7,6 +7,7 @@ import Mathlib.Algebra.Group.Pi.Basic
 import Mathlib.Algebra.GroupWithZero.Units.Basic
 import Mathlib.Algebra.Order.Monoid.Unbundled.Defs
 import Mathlib.Algebra.Order.ZeroLEOne
+import Mathlib.Order.Monotone.Basic
 import Mathlib.Tactic.Bound.Attribute
 import Mathlib.Tactic.GCongr.CoreAttrs
 import Mathlib.Tactic.Monotonicity.Attr

--- a/Mathlib/Algebra/Order/Monoid/Unbundled/Defs.lean
+++ b/Mathlib/Algebra/Order/Monoid/Unbundled/Defs.lean
@@ -5,7 +5,7 @@ Authors: Damiano Testa
 -/
 import Mathlib.Algebra.Group.Basic
 import Mathlib.Order.Basic
-import Mathlib.Order.Monotone.Basic
+import Mathlib.Order.Monotone.Defs
 
 /-!
 

--- a/Mathlib/Algebra/Prime/Lemmas.lean
+++ b/Mathlib/Algebra/Prime/Lemmas.lean
@@ -9,7 +9,7 @@ import Mathlib.Algebra.Group.Even
 import Mathlib.Algebra.Group.Units.Equiv
 import Mathlib.Algebra.GroupWithZero.Hom
 import Mathlib.Algebra.Prime.Defs
-import Mathlib.Order.Monotone.Basic
+import Mathlib.Order.Monotone.Defs
 
 /-!
 # Associated, prime, and irreducible elements.

--- a/Mathlib/Data/Nat/Choose/Basic.lean
+++ b/Mathlib/Data/Nat/Choose/Basic.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes, Bhavik Mehta, Stuart Presnell
 -/
 import Mathlib.Data.Nat.Factorial.Basic
-import Mathlib.Order.Monotone.Basic
+import Mathlib.Order.Monotone.Defs
 
 /-!
 # Binomial coefficients

--- a/Mathlib/Order/Monotone/Basic.lean
+++ b/Mathlib/Order/Monotone/Basic.lean
@@ -3,14 +3,12 @@ Copyright (c) 2014 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Mario Carneiro, Yaël Dillies
 -/
-import Mathlib.Logic.Function.Iterate
 import Mathlib.Data.Nat.Defs
 import Mathlib.Data.Int.Order.Basic
 import Mathlib.Order.Compare
 import Mathlib.Order.Max
+import Mathlib.Order.Monotone.Defs
 import Mathlib.Order.RelClasses
-import Mathlib.Tactic.Coe
-import Mathlib.Tactic.Contrapose
 import Mathlib.Tactic.Choose
 
 /-!
@@ -19,19 +17,6 @@ import Mathlib.Tactic.Choose
 This file defines (strictly) monotone/antitone functions. Contrary to standard mathematical usage,
 "monotone"/"mono" here means "increasing", not "increasing or decreasing". We use "antitone"/"anti"
 to mean "decreasing".
-
-## Definitions
-
-* `Monotone f`: A function `f` between two preorders is monotone if `a ≤ b` implies `f a ≤ f b`.
-* `Antitone f`: A function `f` between two preorders is antitone if `a ≤ b` implies `f b ≤ f a`.
-* `MonotoneOn f s`: Same as `Monotone f`, but for all `a, b ∈ s`.
-* `AntitoneOn f s`: Same as `Antitone f`, but for all `a, b ∈ s`.
-* `StrictMono f` : A function `f` between two preorders is strictly monotone if `a < b` implies
-  `f a < f b`.
-* `StrictAnti f` : A function `f` between two preorders is strictly antitone if `a < b` implies
-  `f b < f a`.
-* `StrictMonoOn f s`: Same as `StrictMono f`, but for all `a, b ∈ s`.
-* `StrictAntiOn f s`: Same as `StrictAnti f`, but for all `a, b ∈ s`.
 
 ## Main theorems
 
@@ -62,52 +47,11 @@ monotone, strictly monotone, antitone, strictly antitone, increasing, strictly i
 decreasing, strictly decreasing
 -/
 
-
 open Function OrderDual
 
 universe u v w
 
 variable {ι : Type*} {α : Type u} {β : Type v} {γ : Type w} {δ : Type*} {π : ι → Type*}
-
-section MonotoneDef
-
-variable [Preorder α] [Preorder β]
-
-/-- A function `f` is monotone if `a ≤ b` implies `f a ≤ f b`. -/
-def Monotone (f : α → β) : Prop :=
-  ∀ ⦃a b⦄, a ≤ b → f a ≤ f b
-
-/-- A function `f` is antitone if `a ≤ b` implies `f b ≤ f a`. -/
-def Antitone (f : α → β) : Prop :=
-  ∀ ⦃a b⦄, a ≤ b → f b ≤ f a
-
-/-- A function `f` is monotone on `s` if, for all `a, b ∈ s`, `a ≤ b` implies `f a ≤ f b`. -/
-def MonotoneOn (f : α → β) (s : Set α) : Prop :=
-  ∀ ⦃a⦄ (_ : a ∈ s) ⦃b⦄ (_ : b ∈ s), a ≤ b → f a ≤ f b
-
-/-- A function `f` is antitone on `s` if, for all `a, b ∈ s`, `a ≤ b` implies `f b ≤ f a`. -/
-def AntitoneOn (f : α → β) (s : Set α) : Prop :=
-  ∀ ⦃a⦄ (_ : a ∈ s) ⦃b⦄ (_ : b ∈ s), a ≤ b → f b ≤ f a
-
-/-- A function `f` is strictly monotone if `a < b` implies `f a < f b`. -/
-def StrictMono (f : α → β) : Prop :=
-  ∀ ⦃a b⦄, a < b → f a < f b
-
-/-- A function `f` is strictly antitone if `a < b` implies `f b < f a`. -/
-def StrictAnti (f : α → β) : Prop :=
-  ∀ ⦃a b⦄, a < b → f b < f a
-
-/-- A function `f` is strictly monotone on `s` if, for all `a, b ∈ s`, `a < b` implies
-`f a < f b`. -/
-def StrictMonoOn (f : α → β) (s : Set α) : Prop :=
-  ∀ ⦃a⦄ (_ : a ∈ s) ⦃b⦄ (_ : b ∈ s), a < b → f a < f b
-
-/-- A function `f` is strictly antitone on `s` if, for all `a, b ∈ s`, `a < b` implies
-`f b < f a`. -/
-def StrictAntiOn (f : α → β) (s : Set α) : Prop :=
-  ∀ ⦃a⦄ (_ : a ∈ s) ⦃b⦄ (_ : b ∈ s), a < b → f b < f a
-
-end MonotoneDef
 
 section Decidable
 
@@ -310,217 +254,7 @@ theorem StrictAnti.wellFoundedGT [WellFoundedLT β] (hf : StrictAnti f) : WellFo
 
 end WellFounded
 
-/-! ### Monotonicity in function spaces -/
-
-
-section Preorder
-
-variable [Preorder α]
-
-theorem Monotone.comp_le_comp_left
-    [Preorder β] {f : β → α} {g h : γ → β} (hf : Monotone f) (le_gh : g ≤ h) :
-    LE.le.{max w u} (f ∘ g) (f ∘ h) :=
-  fun x ↦ hf (le_gh x)
-
-variable [Preorder γ]
-
-theorem monotone_lam {f : α → β → γ} (hf : ∀ b, Monotone fun a ↦ f a b) : Monotone f :=
-  fun _ _ h b ↦ hf b h
-
-theorem monotone_app (f : β → α → γ) (b : β) (hf : Monotone fun a b ↦ f b a) : Monotone (f b) :=
-  fun _ _ h ↦ hf h b
-
-theorem antitone_lam {f : α → β → γ} (hf : ∀ b, Antitone fun a ↦ f a b) : Antitone f :=
-  fun _ _ h b ↦ hf b h
-
-theorem antitone_app (f : β → α → γ) (b : β) (hf : Antitone fun a b ↦ f b a) : Antitone (f b) :=
-  fun _ _ h ↦ hf h b
-
-end Preorder
-
-theorem Function.monotone_eval {ι : Type u} {α : ι → Type v} [∀ i, Preorder (α i)] (i : ι) :
-    Monotone (Function.eval i : (∀ i, α i) → α i) := fun _ _ H ↦ H i
-
-/-! ### Monotonicity hierarchy -/
-
-
-section Preorder
-
-variable [Preorder α]
-
-section Preorder
-
-variable [Preorder β] {f : α → β} {a b : α}
-
-/-!
-These four lemmas are there to strip off the semi-implicit arguments `⦃a b : α⦄`. This is useful
-when you do not want to apply a `Monotone` assumption (i.e. your goal is `a ≤ b → f a ≤ f b`).
-However if you find yourself writing `hf.imp h`, then you should have written `hf h` instead.
--/
-
-
-theorem Monotone.imp (hf : Monotone f) (h : a ≤ b) : f a ≤ f b :=
-  hf h
-
-theorem Antitone.imp (hf : Antitone f) (h : a ≤ b) : f b ≤ f a :=
-  hf h
-
-theorem StrictMono.imp (hf : StrictMono f) (h : a < b) : f a < f b :=
-  hf h
-
-theorem StrictAnti.imp (hf : StrictAnti f) (h : a < b) : f b < f a :=
-  hf h
-
-protected theorem Monotone.monotoneOn (hf : Monotone f) (s : Set α) : MonotoneOn f s :=
-  fun _ _ _ _ ↦ hf.imp
-
-protected theorem Antitone.antitoneOn (hf : Antitone f) (s : Set α) : AntitoneOn f s :=
-  fun _ _ _ _ ↦ hf.imp
-
-@[simp] theorem monotoneOn_univ : MonotoneOn f Set.univ ↔ Monotone f :=
-  ⟨fun h _ _ ↦ h trivial trivial, fun h ↦ h.monotoneOn _⟩
-
-@[simp] theorem antitoneOn_univ : AntitoneOn f Set.univ ↔ Antitone f :=
-  ⟨fun h _ _ ↦ h trivial trivial, fun h ↦ h.antitoneOn _⟩
-
-protected theorem StrictMono.strictMonoOn (hf : StrictMono f) (s : Set α) : StrictMonoOn f s :=
-  fun _ _ _ _ ↦ hf.imp
-
-protected theorem StrictAnti.strictAntiOn (hf : StrictAnti f) (s : Set α) : StrictAntiOn f s :=
-  fun _ _ _ _ ↦ hf.imp
-
-@[simp] theorem strictMonoOn_univ : StrictMonoOn f Set.univ ↔ StrictMono f :=
-  ⟨fun h _ _ ↦ h trivial trivial, fun h ↦ h.strictMonoOn _⟩
-
-@[simp] theorem strictAntiOn_univ : StrictAntiOn f Set.univ ↔ StrictAnti f :=
-  ⟨fun h _ _ ↦ h trivial trivial, fun h ↦ h.strictAntiOn _⟩
-
-end Preorder
-
-section PartialOrder
-
-variable [PartialOrder β] {f : α → β}
-
-theorem Monotone.strictMono_of_injective (h₁ : Monotone f) (h₂ : Injective f) : StrictMono f :=
-  fun _ _ h ↦ (h₁ h.le).lt_of_ne fun H ↦ h.ne <| h₂ H
-
-theorem Antitone.strictAnti_of_injective (h₁ : Antitone f) (h₂ : Injective f) : StrictAnti f :=
-  fun _ _ h ↦ (h₁ h.le).lt_of_ne fun H ↦ h.ne <| h₂ H.symm
-
-end PartialOrder
-
-end Preorder
-
-section PartialOrder
-
-variable [PartialOrder α] [Preorder β] {f : α → β} {s : Set α}
-
-theorem monotone_iff_forall_lt : Monotone f ↔ ∀ ⦃a b⦄, a < b → f a ≤ f b :=
-  forall₂_congr fun _ _ ↦
-    ⟨fun hf h ↦ hf h.le, fun hf h ↦ h.eq_or_lt.elim (fun H ↦ (congr_arg _ H).le) hf⟩
-
-theorem antitone_iff_forall_lt : Antitone f ↔ ∀ ⦃a b⦄, a < b → f b ≤ f a :=
-  forall₂_congr fun _ _ ↦
-    ⟨fun hf h ↦ hf h.le, fun hf h ↦ h.eq_or_lt.elim (fun H ↦ (congr_arg _ H).ge) hf⟩
-
-theorem monotoneOn_iff_forall_lt :
-    MonotoneOn f s ↔ ∀ ⦃a⦄ (_ : a ∈ s) ⦃b⦄ (_ : b ∈ s), a < b → f a ≤ f b :=
-  ⟨fun hf _ ha _ hb h ↦ hf ha hb h.le,
-   fun hf _ ha _ hb h ↦ h.eq_or_lt.elim (fun H ↦ (congr_arg _ H).le) (hf ha hb)⟩
-
-theorem antitoneOn_iff_forall_lt :
-    AntitoneOn f s ↔ ∀ ⦃a⦄ (_ : a ∈ s) ⦃b⦄ (_ : b ∈ s), a < b → f b ≤ f a :=
-  ⟨fun hf _ ha _ hb h ↦ hf ha hb h.le,
-   fun hf _ ha _ hb h ↦ h.eq_or_lt.elim (fun H ↦ (congr_arg _ H).ge) (hf ha hb)⟩
-
--- `Preorder α` isn't strong enough: if the preorder on `α` is an equivalence relation,
--- then `StrictMono f` is vacuously true.
-protected theorem StrictMonoOn.monotoneOn (hf : StrictMonoOn f s) : MonotoneOn f s :=
-  monotoneOn_iff_forall_lt.2 fun _ ha _ hb h ↦ (hf ha hb h).le
-
-protected theorem StrictAntiOn.antitoneOn (hf : StrictAntiOn f s) : AntitoneOn f s :=
-  antitoneOn_iff_forall_lt.2 fun _ ha _ hb h ↦ (hf ha hb h).le
-
-protected theorem StrictMono.monotone (hf : StrictMono f) : Monotone f :=
-  monotone_iff_forall_lt.2 fun _ _ h ↦ (hf h).le
-
-protected theorem StrictAnti.antitone (hf : StrictAnti f) : Antitone f :=
-  antitone_iff_forall_lt.2 fun _ _ h ↦ (hf h).le
-
-end PartialOrder
-
-/-! ### Monotonicity from and to subsingletons -/
-
-
-namespace Subsingleton
-
-variable [Preorder α] [Preorder β]
-
-protected theorem monotone [Subsingleton α] (f : α → β) : Monotone f :=
-  fun _ _ _ ↦ (congr_arg _ <| Subsingleton.elim _ _).le
-
-protected theorem antitone [Subsingleton α] (f : α → β) : Antitone f :=
-  fun _ _ _ ↦ (congr_arg _ <| Subsingleton.elim _ _).le
-
-theorem monotone' [Subsingleton β] (f : α → β) : Monotone f :=
-  fun _ _ _ ↦ (Subsingleton.elim _ _).le
-
-theorem antitone' [Subsingleton β] (f : α → β) : Antitone f :=
-  fun _ _ _ ↦ (Subsingleton.elim _ _).le
-
-protected theorem strictMono [Subsingleton α] (f : α → β) : StrictMono f :=
-  fun _ _ h ↦ (h.ne <| Subsingleton.elim _ _).elim
-
-protected theorem strictAnti [Subsingleton α] (f : α → β) : StrictAnti f :=
-  fun _ _ h ↦ (h.ne <| Subsingleton.elim _ _).elim
-
-end Subsingleton
-
 /-! ### Miscellaneous monotonicity results -/
-
-
-theorem monotone_id [Preorder α] : Monotone (id : α → α) := fun _ _ ↦ id
-
-theorem monotoneOn_id [Preorder α] {s : Set α} : MonotoneOn id s := fun _ _ _ _ ↦ id
-
-theorem strictMono_id [Preorder α] : StrictMono (id : α → α) := fun _ _ ↦ id
-
-theorem strictMonoOn_id [Preorder α] {s : Set α} : StrictMonoOn id s := fun _ _ _ _ ↦ id
-
-theorem monotone_const [Preorder α] [Preorder β] {c : β} : Monotone fun _ : α ↦ c :=
-  fun _ _ _ ↦ le_rfl
-
-theorem monotoneOn_const [Preorder α] [Preorder β] {c : β} {s : Set α} :
-    MonotoneOn (fun _ : α ↦ c) s :=
-  fun _ _ _ _ _ ↦ le_rfl
-
-theorem antitone_const [Preorder α] [Preorder β] {c : β} : Antitone fun _ : α ↦ c :=
-  fun _ _ _ ↦ le_refl c
-
-theorem antitoneOn_const [Preorder α] [Preorder β] {c : β} {s : Set α} :
-    AntitoneOn (fun _ : α ↦ c) s :=
-  fun _ _ _ _ _ ↦ le_rfl
-
-theorem strictMono_of_le_iff_le [Preorder α] [Preorder β] {f : α → β}
-    (h : ∀ x y, x ≤ y ↔ f x ≤ f y) : StrictMono f :=
-  fun _ _ ↦ (lt_iff_lt_of_le_iff_le' (h _ _) (h _ _)).1
-
-theorem strictAnti_of_le_iff_le [Preorder α] [Preorder β] {f : α → β}
-    (h : ∀ x y, x ≤ y ↔ f y ≤ f x) : StrictAnti f :=
-  fun _ _ ↦ (lt_iff_lt_of_le_iff_le' (h _ _) (h _ _)).1
-
--- Porting note: mathlib3 proof uses `contrapose` tactic
-theorem injective_of_lt_imp_ne [LinearOrder α] {f : α → β} (h : ∀ x y, x < y → f x ≠ f y) :
-    Injective f := by
-  intro x y hf
-  rcases lt_trichotomy x y with (hxy | rfl | hxy)
-  · exact absurd hf <| h _ _ hxy
-  · rfl
-  · exact absurd hf.symm <| h _ _ hxy
-
-theorem injective_of_le_imp_le [PartialOrder α] [Preorder β] (f : α → β)
-    (h : ∀ {x y}, f x ≤ f y → x ≤ y) : Injective f :=
-  fun _ _ hxy ↦ (h hxy.le).antisymm (h hxy.ge)
 
 section Preorder
 
@@ -585,75 +319,6 @@ protected theorem StrictAnti.ite (hf : StrictAnti f) (hg : StrictAnti g) {p : α
 
 end Preorder
 
-/-! ### Monotonicity under composition -/
-
-
-section Composition
-
-variable [Preorder α] [Preorder β] [Preorder γ] {g : β → γ} {f : α → β} {s : Set α}
-
-protected theorem Monotone.comp (hg : Monotone g) (hf : Monotone f) : Monotone (g ∘ f) :=
-  fun _ _ h ↦ hg (hf h)
-
-theorem Monotone.comp_antitone (hg : Monotone g) (hf : Antitone f) : Antitone (g ∘ f) :=
-  fun _ _ h ↦ hg (hf h)
-
-protected theorem Antitone.comp (hg : Antitone g) (hf : Antitone f) : Monotone (g ∘ f) :=
-  fun _ _ h ↦ hg (hf h)
-
-theorem Antitone.comp_monotone (hg : Antitone g) (hf : Monotone f) : Antitone (g ∘ f) :=
-  fun _ _ h ↦ hg (hf h)
-
-protected theorem Monotone.iterate {f : α → α} (hf : Monotone f) (n : ℕ) : Monotone f^[n] :=
-  Nat.recOn n monotone_id fun _ h ↦ h.comp hf
-
-protected theorem Monotone.comp_monotoneOn (hg : Monotone g) (hf : MonotoneOn f s) :
-    MonotoneOn (g ∘ f) s :=
-  fun _ ha _ hb h ↦ hg (hf ha hb h)
-
-theorem Monotone.comp_antitoneOn (hg : Monotone g) (hf : AntitoneOn f s) : AntitoneOn (g ∘ f) s :=
-  fun _ ha _ hb h ↦ hg (hf ha hb h)
-
-protected theorem Antitone.comp_antitoneOn (hg : Antitone g) (hf : AntitoneOn f s) :
-    MonotoneOn (g ∘ f) s :=
-  fun _ ha _ hb h ↦ hg (hf ha hb h)
-
-theorem Antitone.comp_monotoneOn (hg : Antitone g) (hf : MonotoneOn f s) : AntitoneOn (g ∘ f) s :=
-  fun _ ha _ hb h ↦ hg (hf ha hb h)
-
-protected theorem StrictMono.comp (hg : StrictMono g) (hf : StrictMono f) : StrictMono (g ∘ f) :=
-  fun _ _ h ↦ hg (hf h)
-
-theorem StrictMono.comp_strictAnti (hg : StrictMono g) (hf : StrictAnti f) : StrictAnti (g ∘ f) :=
-  fun _ _ h ↦ hg (hf h)
-
-protected theorem StrictAnti.comp (hg : StrictAnti g) (hf : StrictAnti f) : StrictMono (g ∘ f) :=
-  fun _ _ h ↦ hg (hf h)
-
-theorem StrictAnti.comp_strictMono (hg : StrictAnti g) (hf : StrictMono f) : StrictAnti (g ∘ f) :=
-  fun _ _ h ↦ hg (hf h)
-
-protected theorem StrictMono.iterate {f : α → α} (hf : StrictMono f) (n : ℕ) : StrictMono f^[n] :=
-  Nat.recOn n strictMono_id fun _ h ↦ h.comp hf
-
-protected theorem StrictMono.comp_strictMonoOn (hg : StrictMono g) (hf : StrictMonoOn f s) :
-    StrictMonoOn (g ∘ f) s :=
-  fun _ ha _ hb h ↦ hg (hf ha hb h)
-
-theorem StrictMono.comp_strictAntiOn (hg : StrictMono g) (hf : StrictAntiOn f s) :
-    StrictAntiOn (g ∘ f) s :=
-  fun _ ha _ hb h ↦ hg (hf ha hb h)
-
-protected theorem StrictAnti.comp_strictAntiOn (hg : StrictAnti g) (hf : StrictAntiOn f s) :
-    StrictMonoOn (g ∘ f) s :=
-  fun _ ha _ hb h ↦ hg (hf ha hb h)
-
-theorem StrictAnti.comp_strictMonoOn (hg : StrictAnti g) (hf : StrictMonoOn f s) :
-    StrictAntiOn (g ∘ f) s :=
-  fun _ ha _ hb h ↦ hg (hf ha hb h)
-
-end Composition
-
 namespace List
 
 section Fold
@@ -688,20 +353,6 @@ section Preorder
 variable [Preorder β] {f : α → β} {s : Set α}
 
 open Ordering
-
-theorem Monotone.reflect_lt (hf : Monotone f) {a b : α} (h : f a < f b) : a < b :=
-  lt_of_not_ge fun h' ↦ h.not_le (hf h')
-
-theorem Antitone.reflect_lt (hf : Antitone f) {a b : α} (h : f a < f b) : b < a :=
-  lt_of_not_ge fun h' ↦ h.not_le (hf h')
-
-theorem MonotoneOn.reflect_lt (hf : MonotoneOn f s) {a b : α} (ha : a ∈ s) (hb : b ∈ s)
-    (h : f a < f b) : a < b :=
-  lt_of_not_ge fun h' ↦ h.not_le <| hf hb ha h'
-
-theorem AntitoneOn.reflect_lt (hf : AntitoneOn f s) {a b : α} (ha : a ∈ s) (hb : b ∈ s)
-    (h : f a < f b) : b < a :=
-  lt_of_not_ge fun h' ↦ h.not_le <| hf ha hb h'
 
 theorem StrictMonoOn.le_iff_le (hf : StrictMonoOn f s) {a b : α} (ha : a ∈ s) (hb : b ∈ s) :
     f a ≤ f b ↔ a ≤ b :=
@@ -1034,89 +685,6 @@ theorem Antitone.ne_of_lt_of_lt_int {f : ℤ → α} (hf : Antitone f) (n : ℤ)
   exact (hf.reflect_lt h2).not_le (Int.le_of_lt_add_one <| hf.reflect_lt h1)
 
 end Preorder
-
-theorem Subtype.mono_coe [Preorder α] (t : Set α) : Monotone ((↑) : Subtype t → α) :=
-  fun _ _ ↦ id
-
-theorem Subtype.strictMono_coe [Preorder α] (t : Set α) :
-    StrictMono ((↑) : Subtype t → α) :=
-  fun _ _ ↦ id
-
-section Preorder
-
-variable [Preorder α] [Preorder β] [Preorder γ] [Preorder δ] {f : α → γ} {g : β → δ}
-
-theorem monotone_fst : Monotone (@Prod.fst α β) := fun _ _ ↦ And.left
-
-theorem monotone_snd : Monotone (@Prod.snd α β) := fun _ _ ↦ And.right
-
-theorem Monotone.prod_map (hf : Monotone f) (hg : Monotone g) : Monotone (Prod.map f g) :=
-  fun _ _ h ↦ ⟨hf h.1, hg h.2⟩
-
-theorem Antitone.prod_map (hf : Antitone f) (hg : Antitone g) : Antitone (Prod.map f g) :=
-  fun _ _ h ↦ ⟨hf h.1, hg h.2⟩
-
-lemma monotone_prod_iff {h : α × β → γ} :
-    Monotone h ↔ (∀ a, Monotone (fun b => h (a, b))) ∧ (∀ b, Monotone (fun a => h (a, b))) where
-  mp h := ⟨fun _ _ _ hab => h (Prod.mk_le_mk_iff_right.mpr hab),
-    fun _ _ _ hab => h (Prod.mk_le_mk_iff_left.mpr hab)⟩
-  mpr h _ _ hab := le_trans (h.1 _ (Prod.mk_le_mk.mp hab).2) (h.2 _ (Prod.mk_le_mk.mp hab).1)
-
-lemma antitone_prod_iff {h : α × β → γ} :
-    Antitone h ↔ (∀ a, Antitone (fun b => h (a, b))) ∧ (∀ b, Antitone (fun a => h (a, b))) where
-  mp h := ⟨fun _ _ _ hab => h (Prod.mk_le_mk_iff_right.mpr hab),
-    fun _ _ _ hab => h (Prod.mk_le_mk_iff_left.mpr hab)⟩
-  mpr h _ _ hab := le_trans (h.1 _ (Prod.mk_le_mk.mp hab).2) (h.2 _ (Prod.mk_le_mk.mp hab).1)
-
-end Preorder
-
-section PartialOrder
-
-variable [PartialOrder α] [PartialOrder β] [Preorder γ] [Preorder δ] {f : α → γ} {g : β → δ}
-
-theorem StrictMono.prod_map (hf : StrictMono f) (hg : StrictMono g) : StrictMono (Prod.map f g) :=
-  fun a b ↦ by
-  simp only [Prod.lt_iff]
-  exact Or.imp (And.imp hf.imp hg.monotone.imp) (And.imp hf.monotone.imp hg.imp)
-
-theorem StrictAnti.prod_map (hf : StrictAnti f) (hg : StrictAnti g) : StrictAnti (Prod.map f g) :=
-  fun a b ↦ by
-  simp only [Prod.lt_iff]
-  exact Or.imp (And.imp hf.imp hg.antitone.imp) (And.imp hf.antitone.imp hg.imp)
-
-end PartialOrder
-
-/-! ### Pi types -/
-
-namespace Function
-
-variable [Preorder α] [DecidableEq ι] [∀ i, Preorder (π i)] {f : ∀ i, π i} {i : ι}
-
--- Porting note: Dot notation breaks in `f.update i`
-theorem update_mono : Monotone (update f i) := fun _ _ => update_le_update_iff'.2
-
-theorem update_strictMono : StrictMono (update f i) := fun _ _ => update_lt_update_iff.2
-
-theorem const_mono : Monotone (const β : α → β → α) := fun _ _ h _ ↦ h
-
-theorem const_strictMono [Nonempty β] : StrictMono (const β : α → β → α) :=
-  fun _ _ ↦ const_lt_const.2
-
-end Function
-
-section apply
-variable {β : ι → Type*} [∀ i, Preorder (β i)] [Preorder α] {f : α → ∀ i, β i}
-
-lemma monotone_iff_apply₂ : Monotone f ↔ ∀ i, Monotone (f · i) := by
-  simp [Monotone, Pi.le_def, @forall_swap ι]
-
-lemma antitone_iff_apply₂ : Antitone f ↔ ∀ i, Antitone (f · i) := by
-  simp [Antitone, Pi.le_def, @forall_swap ι]
-
-alias ⟨Monotone.apply₂, Monotone.of_apply₂⟩ := monotone_iff_apply₂
-alias ⟨Antitone.apply₂, Antitone.of_apply₂⟩ := antitone_iff_apply₂
-
-end apply
 
 /-- A monotone function `f : ℕ → ℕ` bounded by `b`, which is constant after stabilising for the
 first time, stabilises in at most `b` steps. -/

--- a/Mathlib/Order/Monotone/Defs.lean
+++ b/Mathlib/Order/Monotone/Defs.lean
@@ -28,28 +28,12 @@ to mean "decreasing".
 * `StrictMonoOn f s`: Same as `StrictMono f`, but for all `a, b ∈ s`.
 * `StrictAntiOn f s`: Same as `StrictAnti f`, but for all `a, b ∈ s`.
 
-## Main theorems
-
-* `monotone_nat_of_le_succ`, `monotone_int_of_le_succ`: If `f : ℕ → α` or `f : ℤ → α` and
-  `f n ≤ f (n + 1)` for all `n`, then `f` is monotone.
-* `antitone_nat_of_succ_le`, `antitone_int_of_succ_le`: If `f : ℕ → α` or `f : ℤ → α` and
-  `f (n + 1) ≤ f n` for all `n`, then `f` is antitone.
-* `strictMono_nat_of_lt_succ`, `strictMono_int_of_lt_succ`: If `f : ℕ → α` or `f : ℤ → α` and
-  `f n < f (n + 1)` for all `n`, then `f` is strictly monotone.
-* `strictAnti_nat_of_succ_lt`, `strictAnti_int_of_succ_lt`: If `f : ℕ → α` or `f : ℤ → α` and
-  `f (n + 1) < f n` for all `n`, then `f` is strictly antitone.
-
 ## Implementation notes
 
 Some of these definitions used to only require `LE α` or `LT α`. The advantage of this is
 unclear and it led to slight elaboration issues. Now, everything requires `Preorder α` and seems to
 work fine. Related Zulip discussion:
 https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/Order.20diamond/near/254353352.
-
-## TODO
-
-The above theorems are also true in `ℕ+`, `Fin n`... To make that work, we need `SuccOrder α`
-and `IsSuccArchimedean α`.
 
 ## Tags
 

--- a/Mathlib/Order/Monotone/Defs.lean
+++ b/Mathlib/Order/Monotone/Defs.lean
@@ -1,0 +1,526 @@
+/-
+Copyright (c) 2014 Jeremy Avigad. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jeremy Avigad, Mario Carneiro, Yaël Dillies
+-/
+import Mathlib.Logic.Function.Iterate
+import Mathlib.Order.Basic
+import Mathlib.Tactic.Coe
+import Mathlib.Util.AssertExists
+
+/-!
+# Monotonicity
+
+This file defines (strictly) monotone/antitone functions. Contrary to standard mathematical usage,
+"monotone"/"mono" here means "increasing", not "increasing or decreasing". We use "antitone"/"anti"
+to mean "decreasing".
+
+## Definitions
+
+* `Monotone f`: A function `f` between two preorders is monotone if `a ≤ b` implies `f a ≤ f b`.
+* `Antitone f`: A function `f` between two preorders is antitone if `a ≤ b` implies `f b ≤ f a`.
+* `MonotoneOn f s`: Same as `Monotone f`, but for all `a, b ∈ s`.
+* `AntitoneOn f s`: Same as `Antitone f`, but for all `a, b ∈ s`.
+* `StrictMono f` : A function `f` between two preorders is strictly monotone if `a < b` implies
+  `f a < f b`.
+* `StrictAnti f` : A function `f` between two preorders is strictly antitone if `a < b` implies
+  `f b < f a`.
+* `StrictMonoOn f s`: Same as `StrictMono f`, but for all `a, b ∈ s`.
+* `StrictAntiOn f s`: Same as `StrictAnti f`, but for all `a, b ∈ s`.
+
+## Main theorems
+
+* `monotone_nat_of_le_succ`, `monotone_int_of_le_succ`: If `f : ℕ → α` or `f : ℤ → α` and
+  `f n ≤ f (n + 1)` for all `n`, then `f` is monotone.
+* `antitone_nat_of_succ_le`, `antitone_int_of_succ_le`: If `f : ℕ → α` or `f : ℤ → α` and
+  `f (n + 1) ≤ f n` for all `n`, then `f` is antitone.
+* `strictMono_nat_of_lt_succ`, `strictMono_int_of_lt_succ`: If `f : ℕ → α` or `f : ℤ → α` and
+  `f n < f (n + 1)` for all `n`, then `f` is strictly monotone.
+* `strictAnti_nat_of_succ_lt`, `strictAnti_int_of_succ_lt`: If `f : ℕ → α` or `f : ℤ → α` and
+  `f (n + 1) < f n` for all `n`, then `f` is strictly antitone.
+
+## Implementation notes
+
+Some of these definitions used to only require `LE α` or `LT α`. The advantage of this is
+unclear and it led to slight elaboration issues. Now, everything requires `Preorder α` and seems to
+work fine. Related Zulip discussion:
+https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/Order.20diamond/near/254353352.
+
+## TODO
+
+The above theorems are also true in `ℕ+`, `Fin n`... To make that work, we need `SuccOrder α`
+and `IsSuccArchimedean α`.
+
+## Tags
+
+monotone, strictly monotone, antitone, strictly antitone, increasing, strictly increasing,
+decreasing, strictly decreasing
+-/
+
+assert_not_exists Nat.instLinearOrder Int.instLinearOrder
+
+
+open Function OrderDual
+
+universe u v w
+
+variable {ι : Type*} {α : Type u} {β : Type v} {γ : Type w} {δ : Type*} {π : ι → Type*}
+
+section MonotoneDef
+
+variable [Preorder α] [Preorder β]
+
+/-- A function `f` is monotone if `a ≤ b` implies `f a ≤ f b`. -/
+def Monotone (f : α → β) : Prop :=
+  ∀ ⦃a b⦄, a ≤ b → f a ≤ f b
+
+/-- A function `f` is antitone if `a ≤ b` implies `f b ≤ f a`. -/
+def Antitone (f : α → β) : Prop :=
+  ∀ ⦃a b⦄, a ≤ b → f b ≤ f a
+
+/-- A function `f` is monotone on `s` if, for all `a, b ∈ s`, `a ≤ b` implies `f a ≤ f b`. -/
+def MonotoneOn (f : α → β) (s : Set α) : Prop :=
+  ∀ ⦃a⦄ (_ : a ∈ s) ⦃b⦄ (_ : b ∈ s), a ≤ b → f a ≤ f b
+
+/-- A function `f` is antitone on `s` if, for all `a, b ∈ s`, `a ≤ b` implies `f b ≤ f a`. -/
+def AntitoneOn (f : α → β) (s : Set α) : Prop :=
+  ∀ ⦃a⦄ (_ : a ∈ s) ⦃b⦄ (_ : b ∈ s), a ≤ b → f b ≤ f a
+
+/-- A function `f` is strictly monotone if `a < b` implies `f a < f b`. -/
+def StrictMono (f : α → β) : Prop :=
+  ∀ ⦃a b⦄, a < b → f a < f b
+
+/-- A function `f` is strictly antitone if `a < b` implies `f b < f a`. -/
+def StrictAnti (f : α → β) : Prop :=
+  ∀ ⦃a b⦄, a < b → f b < f a
+
+/-- A function `f` is strictly monotone on `s` if, for all `a, b ∈ s`, `a < b` implies
+`f a < f b`. -/
+def StrictMonoOn (f : α → β) (s : Set α) : Prop :=
+  ∀ ⦃a⦄ (_ : a ∈ s) ⦃b⦄ (_ : b ∈ s), a < b → f a < f b
+
+/-- A function `f` is strictly antitone on `s` if, for all `a, b ∈ s`, `a < b` implies
+`f b < f a`. -/
+def StrictAntiOn (f : α → β) (s : Set α) : Prop :=
+  ∀ ⦃a⦄ (_ : a ∈ s) ⦃b⦄ (_ : b ∈ s), a < b → f b < f a
+
+end MonotoneDef
+
+section Decidable
+
+variable [Preorder α] [Preorder β] {f : α → β} {s : Set α}
+
+instance [i : Decidable (∀ a b, a ≤ b → f a ≤ f b)] : Decidable (Monotone f) := i
+instance [i : Decidable (∀ a b, a ≤ b → f b ≤ f a)] : Decidable (Antitone f) := i
+
+instance [i : Decidable (∀ a ∈ s, ∀ b ∈ s, a ≤ b → f a ≤ f b)] :
+    Decidable (MonotoneOn f s) := i
+
+instance [i : Decidable (∀ a ∈ s, ∀ b ∈ s, a ≤ b → f b ≤ f a)] :
+    Decidable (AntitoneOn f s) := i
+
+instance [i : Decidable (∀ a b, a < b → f a < f b)] : Decidable (StrictMono f) := i
+instance [i : Decidable (∀ a b, a < b → f b < f a)] : Decidable (StrictAnti f) := i
+
+instance [i : Decidable (∀ a ∈ s, ∀ b ∈ s, a < b → f a < f b)] :
+    Decidable (StrictMonoOn f s) := i
+
+instance [i : Decidable (∀ a ∈ s, ∀ b ∈ s, a < b → f b < f a)] :
+    Decidable (StrictAntiOn f s) := i
+
+end Decidable
+
+/-! ### Monotonicity in function spaces -/
+
+
+section Preorder
+
+variable [Preorder α]
+
+theorem Monotone.comp_le_comp_left
+    [Preorder β] {f : β → α} {g h : γ → β} (hf : Monotone f) (le_gh : g ≤ h) :
+    LE.le.{max w u} (f ∘ g) (f ∘ h) :=
+  fun x ↦ hf (le_gh x)
+
+variable [Preorder γ]
+
+theorem monotone_lam {f : α → β → γ} (hf : ∀ b, Monotone fun a ↦ f a b) : Monotone f :=
+  fun _ _ h b ↦ hf b h
+
+theorem monotone_app (f : β → α → γ) (b : β) (hf : Monotone fun a b ↦ f b a) : Monotone (f b) :=
+  fun _ _ h ↦ hf h b
+
+theorem antitone_lam {f : α → β → γ} (hf : ∀ b, Antitone fun a ↦ f a b) : Antitone f :=
+  fun _ _ h b ↦ hf b h
+
+theorem antitone_app (f : β → α → γ) (b : β) (hf : Antitone fun a b ↦ f b a) : Antitone (f b) :=
+  fun _ _ h ↦ hf h b
+
+end Preorder
+
+theorem Function.monotone_eval {ι : Type u} {α : ι → Type v} [∀ i, Preorder (α i)] (i : ι) :
+    Monotone (Function.eval i : (∀ i, α i) → α i) := fun _ _ H ↦ H i
+
+/-! ### Monotonicity hierarchy -/
+
+
+section Preorder
+
+variable [Preorder α]
+
+section Preorder
+
+variable [Preorder β] {f : α → β} {a b : α}
+
+/-!
+These four lemmas are there to strip off the semi-implicit arguments `⦃a b : α⦄`. This is useful
+when you do not want to apply a `Monotone` assumption (i.e. your goal is `a ≤ b → f a ≤ f b`).
+However if you find yourself writing `hf.imp h`, then you should have written `hf h` instead.
+-/
+
+
+theorem Monotone.imp (hf : Monotone f) (h : a ≤ b) : f a ≤ f b :=
+  hf h
+
+theorem Antitone.imp (hf : Antitone f) (h : a ≤ b) : f b ≤ f a :=
+  hf h
+
+theorem StrictMono.imp (hf : StrictMono f) (h : a < b) : f a < f b :=
+  hf h
+
+theorem StrictAnti.imp (hf : StrictAnti f) (h : a < b) : f b < f a :=
+  hf h
+
+protected theorem Monotone.monotoneOn (hf : Monotone f) (s : Set α) : MonotoneOn f s :=
+  fun _ _ _ _ ↦ hf.imp
+
+protected theorem Antitone.antitoneOn (hf : Antitone f) (s : Set α) : AntitoneOn f s :=
+  fun _ _ _ _ ↦ hf.imp
+
+@[simp] theorem monotoneOn_univ : MonotoneOn f Set.univ ↔ Monotone f :=
+  ⟨fun h _ _ ↦ h trivial trivial, fun h ↦ h.monotoneOn _⟩
+
+@[simp] theorem antitoneOn_univ : AntitoneOn f Set.univ ↔ Antitone f :=
+  ⟨fun h _ _ ↦ h trivial trivial, fun h ↦ h.antitoneOn _⟩
+
+protected theorem StrictMono.strictMonoOn (hf : StrictMono f) (s : Set α) : StrictMonoOn f s :=
+  fun _ _ _ _ ↦ hf.imp
+
+protected theorem StrictAnti.strictAntiOn (hf : StrictAnti f) (s : Set α) : StrictAntiOn f s :=
+  fun _ _ _ _ ↦ hf.imp
+
+@[simp] theorem strictMonoOn_univ : StrictMonoOn f Set.univ ↔ StrictMono f :=
+  ⟨fun h _ _ ↦ h trivial trivial, fun h ↦ h.strictMonoOn _⟩
+
+@[simp] theorem strictAntiOn_univ : StrictAntiOn f Set.univ ↔ StrictAnti f :=
+  ⟨fun h _ _ ↦ h trivial trivial, fun h ↦ h.strictAntiOn _⟩
+
+end Preorder
+
+section PartialOrder
+
+variable [PartialOrder β] {f : α → β}
+
+theorem Monotone.strictMono_of_injective (h₁ : Monotone f) (h₂ : Injective f) : StrictMono f :=
+  fun _ _ h ↦ (h₁ h.le).lt_of_ne fun H ↦ h.ne <| h₂ H
+
+theorem Antitone.strictAnti_of_injective (h₁ : Antitone f) (h₂ : Injective f) : StrictAnti f :=
+  fun _ _ h ↦ (h₁ h.le).lt_of_ne fun H ↦ h.ne <| h₂ H.symm
+
+end PartialOrder
+
+end Preorder
+
+section PartialOrder
+
+variable [PartialOrder α] [Preorder β] {f : α → β} {s : Set α}
+
+theorem monotone_iff_forall_lt : Monotone f ↔ ∀ ⦃a b⦄, a < b → f a ≤ f b :=
+  forall₂_congr fun _ _ ↦
+    ⟨fun hf h ↦ hf h.le, fun hf h ↦ h.eq_or_lt.elim (fun H ↦ (congr_arg _ H).le) hf⟩
+
+theorem antitone_iff_forall_lt : Antitone f ↔ ∀ ⦃a b⦄, a < b → f b ≤ f a :=
+  forall₂_congr fun _ _ ↦
+    ⟨fun hf h ↦ hf h.le, fun hf h ↦ h.eq_or_lt.elim (fun H ↦ (congr_arg _ H).ge) hf⟩
+
+theorem monotoneOn_iff_forall_lt :
+    MonotoneOn f s ↔ ∀ ⦃a⦄ (_ : a ∈ s) ⦃b⦄ (_ : b ∈ s), a < b → f a ≤ f b :=
+  ⟨fun hf _ ha _ hb h ↦ hf ha hb h.le,
+   fun hf _ ha _ hb h ↦ h.eq_or_lt.elim (fun H ↦ (congr_arg _ H).le) (hf ha hb)⟩
+
+theorem antitoneOn_iff_forall_lt :
+    AntitoneOn f s ↔ ∀ ⦃a⦄ (_ : a ∈ s) ⦃b⦄ (_ : b ∈ s), a < b → f b ≤ f a :=
+  ⟨fun hf _ ha _ hb h ↦ hf ha hb h.le,
+   fun hf _ ha _ hb h ↦ h.eq_or_lt.elim (fun H ↦ (congr_arg _ H).ge) (hf ha hb)⟩
+
+-- `Preorder α` isn't strong enough: if the preorder on `α` is an equivalence relation,
+-- then `StrictMono f` is vacuously true.
+protected theorem StrictMonoOn.monotoneOn (hf : StrictMonoOn f s) : MonotoneOn f s :=
+  monotoneOn_iff_forall_lt.2 fun _ ha _ hb h ↦ (hf ha hb h).le
+
+protected theorem StrictAntiOn.antitoneOn (hf : StrictAntiOn f s) : AntitoneOn f s :=
+  antitoneOn_iff_forall_lt.2 fun _ ha _ hb h ↦ (hf ha hb h).le
+
+protected theorem StrictMono.monotone (hf : StrictMono f) : Monotone f :=
+  monotone_iff_forall_lt.2 fun _ _ h ↦ (hf h).le
+
+protected theorem StrictAnti.antitone (hf : StrictAnti f) : Antitone f :=
+  antitone_iff_forall_lt.2 fun _ _ h ↦ (hf h).le
+
+end PartialOrder
+
+/-! ### Monotonicity from and to subsingletons -/
+
+
+namespace Subsingleton
+
+variable [Preorder α] [Preorder β]
+
+protected theorem monotone [Subsingleton α] (f : α → β) : Monotone f :=
+  fun _ _ _ ↦ (congr_arg _ <| Subsingleton.elim _ _).le
+
+protected theorem antitone [Subsingleton α] (f : α → β) : Antitone f :=
+  fun _ _ _ ↦ (congr_arg _ <| Subsingleton.elim _ _).le
+
+theorem monotone' [Subsingleton β] (f : α → β) : Monotone f :=
+  fun _ _ _ ↦ (Subsingleton.elim _ _).le
+
+theorem antitone' [Subsingleton β] (f : α → β) : Antitone f :=
+  fun _ _ _ ↦ (Subsingleton.elim _ _).le
+
+protected theorem strictMono [Subsingleton α] (f : α → β) : StrictMono f :=
+  fun _ _ h ↦ (h.ne <| Subsingleton.elim _ _).elim
+
+protected theorem strictAnti [Subsingleton α] (f : α → β) : StrictAnti f :=
+  fun _ _ h ↦ (h.ne <| Subsingleton.elim _ _).elim
+
+end Subsingleton
+
+/-! ### Miscellaneous monotonicity results -/
+
+
+theorem monotone_id [Preorder α] : Monotone (id : α → α) := fun _ _ ↦ id
+
+theorem monotoneOn_id [Preorder α] {s : Set α} : MonotoneOn id s := fun _ _ _ _ ↦ id
+
+theorem strictMono_id [Preorder α] : StrictMono (id : α → α) := fun _ _ ↦ id
+
+theorem strictMonoOn_id [Preorder α] {s : Set α} : StrictMonoOn id s := fun _ _ _ _ ↦ id
+
+theorem monotone_const [Preorder α] [Preorder β] {c : β} : Monotone fun _ : α ↦ c :=
+  fun _ _ _ ↦ le_rfl
+
+theorem monotoneOn_const [Preorder α] [Preorder β] {c : β} {s : Set α} :
+    MonotoneOn (fun _ : α ↦ c) s :=
+  fun _ _ _ _ _ ↦ le_rfl
+
+theorem antitone_const [Preorder α] [Preorder β] {c : β} : Antitone fun _ : α ↦ c :=
+  fun _ _ _ ↦ le_refl c
+
+theorem antitoneOn_const [Preorder α] [Preorder β] {c : β} {s : Set α} :
+    AntitoneOn (fun _ : α ↦ c) s :=
+  fun _ _ _ _ _ ↦ le_rfl
+
+theorem strictMono_of_le_iff_le [Preorder α] [Preorder β] {f : α → β}
+    (h : ∀ x y, x ≤ y ↔ f x ≤ f y) : StrictMono f :=
+  fun _ _ ↦ (lt_iff_lt_of_le_iff_le' (h _ _) (h _ _)).1
+
+theorem strictAnti_of_le_iff_le [Preorder α] [Preorder β] {f : α → β}
+    (h : ∀ x y, x ≤ y ↔ f y ≤ f x) : StrictAnti f :=
+  fun _ _ ↦ (lt_iff_lt_of_le_iff_le' (h _ _) (h _ _)).1
+
+-- Porting note: mathlib3 proof uses `contrapose` tactic
+theorem injective_of_lt_imp_ne [LinearOrder α] {f : α → β} (h : ∀ x y, x < y → f x ≠ f y) :
+    Injective f := by
+  intro x y hf
+  rcases lt_trichotomy x y with (hxy | rfl | hxy)
+  · exact absurd hf <| h _ _ hxy
+  · rfl
+  · exact absurd hf.symm <| h _ _ hxy
+
+theorem injective_of_le_imp_le [PartialOrder α] [Preorder β] (f : α → β)
+    (h : ∀ {x y}, f x ≤ f y → x ≤ y) : Injective f :=
+  fun _ _ hxy ↦ (h hxy.le).antisymm (h hxy.ge)
+
+/-! ### Monotonicity under composition -/
+
+
+section Composition
+
+variable [Preorder α] [Preorder β] [Preorder γ] {g : β → γ} {f : α → β} {s : Set α}
+
+protected theorem Monotone.comp (hg : Monotone g) (hf : Monotone f) : Monotone (g ∘ f) :=
+  fun _ _ h ↦ hg (hf h)
+
+theorem Monotone.comp_antitone (hg : Monotone g) (hf : Antitone f) : Antitone (g ∘ f) :=
+  fun _ _ h ↦ hg (hf h)
+
+protected theorem Antitone.comp (hg : Antitone g) (hf : Antitone f) : Monotone (g ∘ f) :=
+  fun _ _ h ↦ hg (hf h)
+
+theorem Antitone.comp_monotone (hg : Antitone g) (hf : Monotone f) : Antitone (g ∘ f) :=
+  fun _ _ h ↦ hg (hf h)
+
+protected theorem Monotone.iterate {f : α → α} (hf : Monotone f) (n : ℕ) : Monotone f^[n] :=
+  Nat.recOn n monotone_id fun _ h ↦ h.comp hf
+
+protected theorem Monotone.comp_monotoneOn (hg : Monotone g) (hf : MonotoneOn f s) :
+    MonotoneOn (g ∘ f) s :=
+  fun _ ha _ hb h ↦ hg (hf ha hb h)
+
+theorem Monotone.comp_antitoneOn (hg : Monotone g) (hf : AntitoneOn f s) : AntitoneOn (g ∘ f) s :=
+  fun _ ha _ hb h ↦ hg (hf ha hb h)
+
+protected theorem Antitone.comp_antitoneOn (hg : Antitone g) (hf : AntitoneOn f s) :
+    MonotoneOn (g ∘ f) s :=
+  fun _ ha _ hb h ↦ hg (hf ha hb h)
+
+theorem Antitone.comp_monotoneOn (hg : Antitone g) (hf : MonotoneOn f s) : AntitoneOn (g ∘ f) s :=
+  fun _ ha _ hb h ↦ hg (hf ha hb h)
+
+protected theorem StrictMono.comp (hg : StrictMono g) (hf : StrictMono f) : StrictMono (g ∘ f) :=
+  fun _ _ h ↦ hg (hf h)
+
+theorem StrictMono.comp_strictAnti (hg : StrictMono g) (hf : StrictAnti f) : StrictAnti (g ∘ f) :=
+  fun _ _ h ↦ hg (hf h)
+
+protected theorem StrictAnti.comp (hg : StrictAnti g) (hf : StrictAnti f) : StrictMono (g ∘ f) :=
+  fun _ _ h ↦ hg (hf h)
+
+theorem StrictAnti.comp_strictMono (hg : StrictAnti g) (hf : StrictMono f) : StrictAnti (g ∘ f) :=
+  fun _ _ h ↦ hg (hf h)
+
+protected theorem StrictMono.iterate {f : α → α} (hf : StrictMono f) (n : ℕ) : StrictMono f^[n] :=
+  Nat.recOn n strictMono_id fun _ h ↦ h.comp hf
+
+protected theorem StrictMono.comp_strictMonoOn (hg : StrictMono g) (hf : StrictMonoOn f s) :
+    StrictMonoOn (g ∘ f) s :=
+  fun _ ha _ hb h ↦ hg (hf ha hb h)
+
+theorem StrictMono.comp_strictAntiOn (hg : StrictMono g) (hf : StrictAntiOn f s) :
+    StrictAntiOn (g ∘ f) s :=
+  fun _ ha _ hb h ↦ hg (hf ha hb h)
+
+protected theorem StrictAnti.comp_strictAntiOn (hg : StrictAnti g) (hf : StrictAntiOn f s) :
+    StrictMonoOn (g ∘ f) s :=
+  fun _ ha _ hb h ↦ hg (hf ha hb h)
+
+theorem StrictAnti.comp_strictMonoOn (hg : StrictAnti g) (hf : StrictMonoOn f s) :
+    StrictAntiOn (g ∘ f) s :=
+  fun _ ha _ hb h ↦ hg (hf ha hb h)
+
+end Composition
+
+/-! ### Monotonicity in linear orders  -/
+
+
+section LinearOrder
+
+variable [LinearOrder α]
+
+section Preorder
+
+variable [Preorder β] {f : α → β} {s : Set α}
+
+open Ordering
+
+theorem Monotone.reflect_lt (hf : Monotone f) {a b : α} (h : f a < f b) : a < b :=
+  lt_of_not_ge fun h' ↦ h.not_le (hf h')
+
+theorem Antitone.reflect_lt (hf : Antitone f) {a b : α} (h : f a < f b) : b < a :=
+  lt_of_not_ge fun h' ↦ h.not_le (hf h')
+
+theorem MonotoneOn.reflect_lt (hf : MonotoneOn f s) {a b : α} (ha : a ∈ s) (hb : b ∈ s)
+    (h : f a < f b) : a < b :=
+  lt_of_not_ge fun h' ↦ h.not_le <| hf hb ha h'
+
+theorem AntitoneOn.reflect_lt (hf : AntitoneOn f s) {a b : α} (ha : a ∈ s) (hb : b ∈ s)
+    (h : f a < f b) : b < a :=
+  lt_of_not_ge fun h' ↦ h.not_le <| hf ha hb h'
+
+end Preorder
+
+end LinearOrder
+
+theorem Subtype.mono_coe [Preorder α] (t : Set α) : Monotone ((↑) : Subtype t → α) :=
+  fun _ _ ↦ id
+
+theorem Subtype.strictMono_coe [Preorder α] (t : Set α) :
+    StrictMono ((↑) : Subtype t → α) :=
+  fun _ _ ↦ id
+
+section Preorder
+
+variable [Preorder α] [Preorder β] [Preorder γ] [Preorder δ] {f : α → γ} {g : β → δ}
+
+theorem monotone_fst : Monotone (@Prod.fst α β) := fun _ _ ↦ And.left
+
+theorem monotone_snd : Monotone (@Prod.snd α β) := fun _ _ ↦ And.right
+
+theorem Monotone.prod_map (hf : Monotone f) (hg : Monotone g) : Monotone (Prod.map f g) :=
+  fun _ _ h ↦ ⟨hf h.1, hg h.2⟩
+
+theorem Antitone.prod_map (hf : Antitone f) (hg : Antitone g) : Antitone (Prod.map f g) :=
+  fun _ _ h ↦ ⟨hf h.1, hg h.2⟩
+
+lemma monotone_prod_iff {h : α × β → γ} :
+    Monotone h ↔ (∀ a, Monotone (fun b => h (a, b))) ∧ (∀ b, Monotone (fun a => h (a, b))) where
+  mp h := ⟨fun _ _ _ hab => h (Prod.mk_le_mk_iff_right.mpr hab),
+    fun _ _ _ hab => h (Prod.mk_le_mk_iff_left.mpr hab)⟩
+  mpr h _ _ hab := le_trans (h.1 _ (Prod.mk_le_mk.mp hab).2) (h.2 _ (Prod.mk_le_mk.mp hab).1)
+
+lemma antitone_prod_iff {h : α × β → γ} :
+    Antitone h ↔ (∀ a, Antitone (fun b => h (a, b))) ∧ (∀ b, Antitone (fun a => h (a, b))) where
+  mp h := ⟨fun _ _ _ hab => h (Prod.mk_le_mk_iff_right.mpr hab),
+    fun _ _ _ hab => h (Prod.mk_le_mk_iff_left.mpr hab)⟩
+  mpr h _ _ hab := le_trans (h.1 _ (Prod.mk_le_mk.mp hab).2) (h.2 _ (Prod.mk_le_mk.mp hab).1)
+
+end Preorder
+
+section PartialOrder
+
+variable [PartialOrder α] [PartialOrder β] [Preorder γ] [Preorder δ] {f : α → γ} {g : β → δ}
+
+theorem StrictMono.prod_map (hf : StrictMono f) (hg : StrictMono g) : StrictMono (Prod.map f g) :=
+  fun a b ↦ by
+  simp only [Prod.lt_iff]
+  exact Or.imp (And.imp hf.imp hg.monotone.imp) (And.imp hf.monotone.imp hg.imp)
+
+theorem StrictAnti.prod_map (hf : StrictAnti f) (hg : StrictAnti g) : StrictAnti (Prod.map f g) :=
+  fun a b ↦ by
+  simp only [Prod.lt_iff]
+  exact Or.imp (And.imp hf.imp hg.antitone.imp) (And.imp hf.antitone.imp hg.imp)
+
+end PartialOrder
+
+/-! ### Pi types -/
+
+namespace Function
+
+variable [Preorder α] [DecidableEq ι] [∀ i, Preorder (π i)] {f : ∀ i, π i} {i : ι}
+
+-- Porting note: Dot notation breaks in `f.update i`
+theorem update_mono : Monotone (update f i) := fun _ _ => update_le_update_iff'.2
+
+theorem update_strictMono : StrictMono (update f i) := fun _ _ => update_lt_update_iff.2
+
+theorem const_mono : Monotone (const β : α → β → α) := fun _ _ h _ ↦ h
+
+theorem const_strictMono [Nonempty β] : StrictMono (const β : α → β → α) :=
+  fun _ _ ↦ const_lt_const.2
+
+end Function
+
+section apply
+variable {β : ι → Type*} [∀ i, Preorder (β i)] [Preorder α] {f : α → ∀ i, β i}
+
+lemma monotone_iff_apply₂ : Monotone f ↔ ∀ i, Monotone (f · i) := by
+  simp [Monotone, Pi.le_def, @forall_swap ι]
+
+lemma antitone_iff_apply₂ : Antitone f ↔ ∀ i, Antitone (f · i) := by
+  simp [Antitone, Pi.le_def, @forall_swap ι]
+
+alias ⟨Monotone.apply₂, Monotone.of_apply₂⟩ := monotone_iff_apply₂
+alias ⟨Antitone.apply₂, Antitone.of_apply₂⟩ := antitone_iff_apply₂
+
+end apply


### PR DESCRIPTION
`Order.Monotone.Basic` is a rather large file and contains a mix of definitions and results. This PR splits it in two files:

* `Monotone.Defs` contains the definition of `Monotone`, `StrictMonotone`, `Antitone`, etc, and proofs for basic functions such as identity, composition and product projections.
* `Monotone.Basic` contains the remaining theory, especially that involving the order on natural numbers and integers.


---

Still needs to be shaken.


<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
