### PR TITLE
chore(Algebra/Order/Group): downstream lemmas in `Defs.lean`

### DIFF
--- a/Archive/Imo/Imo2011Q5.lean
+++ b/Archive/Imo/Imo2011Q5.lean
@@ -3,6 +3,7 @@ Copyright (c) 2021 Alain Verberkmoes. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Alain Verberkmoes
 -/
+import Mathlib.Algebra.Order.Group.Basic
 import Mathlib.Algebra.Order.Group.Int
 import Mathlib.Algebra.Ring.Divisibility.Basic
 import Mathlib.Algebra.Ring.Int.Defs

--- a/Mathlib/Algebra/Order/Group/Abs.lean
+++ b/Mathlib/Algebra/Order/Group/Abs.lean
@@ -3,7 +3,7 @@ Copyright (c) 2016 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Leonardo de Moura, Mario Carneiro, Johannes Hölzl
 -/
-import Mathlib.Algebra.Order.Group.Defs
+import Mathlib.Algebra.Order.Group.Basic
 import Mathlib.Algebra.Order.Group.Unbundled.Abs
 import Mathlib.Algebra.Order.Monoid.Unbundled.Pow
 

--- a/Mathlib/Algebra/Order/Group/Basic.lean
+++ b/Mathlib/Algebra/Order/Group/Basic.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Robert Y. Lewis
 -/
 import Mathlib.Algebra.Order.Group.Defs
+import Mathlib.Algebra.Order.Group.Unbundled.Basic
 import Mathlib.Algebra.Order.Monoid.Unbundled.Pow
 
 /-!
@@ -105,6 +106,50 @@ section LinearOrderedCommGroup
 
 variable [LinearOrderedCommGroup α] {n : ℤ} {a b : α}
 
+@[to_additive eq_zero_of_neg_eq]
+theorem eq_one_of_inv_eq' (h : a⁻¹ = a) : a = 1 :=
+  match lt_trichotomy a 1 with
+  | Or.inl h₁ =>
+    have : 1 < a := h ▸ one_lt_inv_of_inv h₁
+    absurd h₁ this.asymm
+  | Or.inr (Or.inl h₁) => h₁
+  | Or.inr (Or.inr h₁) =>
+    have : a < 1 := h ▸ inv_lt_one'.mpr h₁
+    absurd h₁ this.asymm
+
+@[to_additive exists_zero_lt]
+theorem exists_one_lt' [Nontrivial α] : ∃ a : α, 1 < a := by
+  obtain ⟨y, hy⟩ := Decidable.exists_ne (1 : α)
+  obtain h|h := hy.lt_or_lt
+  · exact ⟨y⁻¹, one_lt_inv'.mpr h⟩
+  · exact ⟨y, h⟩
+
+-- see Note [lower instance priority]
+@[to_additive]
+instance (priority := 100) LinearOrderedCommGroup.to_noMaxOrder [Nontrivial α] : NoMaxOrder α :=
+  ⟨by
+    obtain ⟨y, hy⟩ : ∃ a : α, 1 < a := exists_one_lt'
+    exact fun a => ⟨a * y, lt_mul_of_one_lt_right' a hy⟩⟩
+
+-- see Note [lower instance priority]
+@[to_additive]
+instance (priority := 100) LinearOrderedCommGroup.to_noMinOrder [Nontrivial α] : NoMinOrder α :=
+  ⟨by
+    obtain ⟨y, hy⟩ : ∃ a : α, 1 < a := exists_one_lt'
+    exact fun a => ⟨a / y, (div_lt_self_iff a).mpr hy⟩⟩
+
+@[to_additive (attr := simp)]
+theorem inv_le_self_iff : a⁻¹ ≤ a ↔ 1 ≤ a := by simp [inv_le_iff_one_le_mul']
+
+@[to_additive (attr := simp)]
+theorem inv_lt_self_iff : a⁻¹ < a ↔ 1 < a := by simp [inv_lt_iff_one_lt_mul]
+
+@[to_additive (attr := simp)]
+theorem le_inv_self_iff : a ≤ a⁻¹ ↔ a ≤ 1 := by simp [← not_iff_not]
+
+@[to_additive (attr := simp)]
+theorem lt_inv_self_iff : a < a⁻¹ ↔ a < 1 := by simp [← not_iff_not]
+
 @[to_additive zsmul_le_zsmul_iff_right]
 lemma zpow_le_zpow_iff_left (hn : 0 < n) : a ^ n ≤ b ^ n ↔ a ≤ b :=
   (zpow_left_strictMono α hn).le_iff_le
@@ -159,3 +204,33 @@ theorem not_isCyclic_of_denselyOrdered [DenselyOrdered α] [Nontrivial α] : ¬I
     simp_all
 
 end LinearOrderedCommGroup
+
+section NormNumLemmas
+
+/- The following lemmas are stated so that the `norm_num` tactic can use them with the
+expected signatures. -/
+variable [OrderedCommGroup α] {a b : α}
+
+@[to_additive (attr := gcongr) neg_le_neg]
+theorem inv_le_inv' : a ≤ b → b⁻¹ ≤ a⁻¹ :=
+  inv_le_inv_iff.mpr
+
+@[to_additive (attr := gcongr) neg_lt_neg]
+theorem inv_lt_inv' : a < b → b⁻¹ < a⁻¹ :=
+  inv_lt_inv_iff.mpr
+
+--  The additive version is also a `linarith` lemma.
+@[to_additive]
+theorem inv_lt_one_of_one_lt : 1 < a → a⁻¹ < 1 :=
+  inv_lt_one_iff_one_lt.mpr
+
+--  The additive version is also a `linarith` lemma.
+@[to_additive]
+theorem inv_le_one_of_one_le : 1 ≤ a → a⁻¹ ≤ 1 :=
+  inv_le_one'.mpr
+
+@[to_additive neg_nonneg_of_nonpos]
+theorem one_le_inv_of_le_one : a ≤ 1 → 1 ≤ a⁻¹ :=
+  one_le_inv'.mpr
+
+end NormNumLemmas

--- a/Mathlib/Algebra/Order/Group/Bounds.lean
+++ b/Mathlib/Algebra/Order/Group/Bounds.lean
@@ -3,7 +3,8 @@ Copyright (c) 2017 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Yury Kudryashov
 -/
-import Mathlib.Algebra.Order.Group.Basic
+import Mathlib.Algebra.Order.Group.Defs
+import Mathlib.Algebra.Order.Group.Unbundled.Basic
 import Mathlib.Order.Bounds.Basic
 
 /-!

--- a/Mathlib/Algebra/Order/Group/Bounds.lean
+++ b/Mathlib/Algebra/Order/Group/Bounds.lean
@@ -3,8 +3,8 @@ Copyright (c) 2017 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Yury Kudryashov
 -/
+import Mathlib.Algebra.Order.Group.Basic
 import Mathlib.Order.Bounds.Basic
-import Mathlib.Algebra.Order.Group.Defs
 
 /-!
 # Least upper bound and the greatest lower bound in linear ordered additive commutative groups

--- a/Mathlib/Algebra/Order/Group/Cone.lean
+++ b/Mathlib/Algebra/Order/Group/Cone.lean
@@ -3,7 +3,7 @@ Copyright (c) 2017 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Kim Morrison, Artie Khovanov
 -/
-import Mathlib.Algebra.Order.Group.Defs
+import Mathlib.Algebra.Order.Group.Basic
 import Mathlib.Algebra.Order.Monoid.Submonoid
 
 /-!

--- a/Mathlib/Algebra/Order/Group/Cone.lean
+++ b/Mathlib/Algebra/Order/Group/Cone.lean
@@ -3,7 +3,8 @@ Copyright (c) 2017 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Kim Morrison, Artie Khovanov
 -/
-import Mathlib.Algebra.Order.Group.Basic
+import Mathlib.Algebra.Order.Group.Defs
+import Mathlib.Algebra.Order.Group.Unbundled.Basic
 import Mathlib.Algebra.Order.Monoid.Submonoid
 
 /-!

--- a/Mathlib/Algebra/Order/Group/Defs.lean
+++ b/Mathlib/Algebra/Order/Group/Defs.lean
@@ -3,7 +3,6 @@ Copyright (c) 2016 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Leonardo de Moura, Mario Carneiro, Johannes Hölzl
 -/
-import Mathlib.Algebra.Order.Group.Unbundled.Basic
 import Mathlib.Algebra.Order.Monoid.Defs
 import Mathlib.Algebra.Order.Sub.Defs
 import Mathlib.Util.AssertExists
@@ -115,84 +114,10 @@ variable [LinearOrderedCommGroup α] {a : α}
 theorem LinearOrderedCommGroup.mul_lt_mul_left' (a b : α) (h : a < b) (c : α) : c * a < c * b :=
   _root_.mul_lt_mul_left' h c
 
-@[to_additive eq_zero_of_neg_eq]
-theorem eq_one_of_inv_eq' (h : a⁻¹ = a) : a = 1 :=
-  match lt_trichotomy a 1 with
-  | Or.inl h₁ =>
-    have : 1 < a := h ▸ one_lt_inv_of_inv h₁
-    absurd h₁ this.asymm
-  | Or.inr (Or.inl h₁) => h₁
-  | Or.inr (Or.inr h₁) =>
-    have : a < 1 := h ▸ inv_lt_one'.mpr h₁
-    absurd h₁ this.asymm
-
-@[to_additive exists_zero_lt]
-theorem exists_one_lt' [Nontrivial α] : ∃ a : α, 1 < a := by
-  obtain ⟨y, hy⟩ := Decidable.exists_ne (1 : α)
-  obtain h|h := hy.lt_or_lt
-  · exact ⟨y⁻¹, one_lt_inv'.mpr h⟩
-  · exact ⟨y, h⟩
-
--- see Note [lower instance priority]
-@[to_additive]
-instance (priority := 100) LinearOrderedCommGroup.to_noMaxOrder [Nontrivial α] : NoMaxOrder α :=
-  ⟨by
-    obtain ⟨y, hy⟩ : ∃ a : α, 1 < a := exists_one_lt'
-    exact fun a => ⟨a * y, lt_mul_of_one_lt_right' a hy⟩⟩
-
--- see Note [lower instance priority]
-@[to_additive]
-instance (priority := 100) LinearOrderedCommGroup.to_noMinOrder [Nontrivial α] : NoMinOrder α :=
-  ⟨by
-    obtain ⟨y, hy⟩ : ∃ a : α, 1 < a := exists_one_lt'
-    exact fun a => ⟨a / y, (div_lt_self_iff a).mpr hy⟩⟩
-
 -- See note [lower instance priority]
 @[to_additive]
 instance (priority := 100) LinearOrderedCommGroup.toLinearOrderedCancelCommMonoid
     [LinearOrderedCommGroup α] : LinearOrderedCancelCommMonoid α :=
 { ‹LinearOrderedCommGroup α›, OrderedCommGroup.toOrderedCancelCommMonoid with }
 
-@[to_additive (attr := simp)]
-theorem inv_le_self_iff : a⁻¹ ≤ a ↔ 1 ≤ a := by simp [inv_le_iff_one_le_mul']
-
-@[to_additive (attr := simp)]
-theorem inv_lt_self_iff : a⁻¹ < a ↔ 1 < a := by simp [inv_lt_iff_one_lt_mul]
-
-@[to_additive (attr := simp)]
-theorem le_inv_self_iff : a ≤ a⁻¹ ↔ a ≤ 1 := by simp [← not_iff_not]
-
-@[to_additive (attr := simp)]
-theorem lt_inv_self_iff : a < a⁻¹ ↔ a < 1 := by simp [← not_iff_not]
-
 end LinearOrderedCommGroup
-
-section NormNumLemmas
-
-/- The following lemmas are stated so that the `norm_num` tactic can use them with the
-expected signatures. -/
-variable [OrderedCommGroup α] {a b : α}
-
-@[to_additive (attr := gcongr) neg_le_neg]
-theorem inv_le_inv' : a ≤ b → b⁻¹ ≤ a⁻¹ :=
-  inv_le_inv_iff.mpr
-
-@[to_additive (attr := gcongr) neg_lt_neg]
-theorem inv_lt_inv' : a < b → b⁻¹ < a⁻¹ :=
-  inv_lt_inv_iff.mpr
-
---  The additive version is also a `linarith` lemma.
-@[to_additive]
-theorem inv_lt_one_of_one_lt : 1 < a → a⁻¹ < 1 :=
-  inv_lt_one_iff_one_lt.mpr
-
---  The additive version is also a `linarith` lemma.
-@[to_additive]
-theorem inv_le_one_of_one_le : 1 ≤ a → a⁻¹ ≤ 1 :=
-  inv_le_one'.mpr
-
-@[to_additive neg_nonneg_of_nonpos]
-theorem one_le_inv_of_le_one : a ≤ 1 → 1 ≤ a⁻¹ :=
-  one_le_inv'.mpr
-
-end NormNumLemmas

--- a/Mathlib/Algebra/Order/Group/Defs.lean
+++ b/Mathlib/Algebra/Order/Group/Defs.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Leonardo de Moura, Mario Carneiro, Johannes Hölzl
 -/
 import Mathlib.Algebra.Order.Monoid.Defs
-import Mathlib.Algebra.Order.Sub.Defs
 import Mathlib.Util.AssertExists
 
 /-!

--- a/Mathlib/Algebra/Order/Hom/Monoid.lean
+++ b/Mathlib/Algebra/Order/Hom/Monoid.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies
 -/
 import Mathlib.Algebra.GroupWithZero.Hom
+import Mathlib.Algebra.Order.Group.Basic
 import Mathlib.Algebra.Order.Group.Instances
 import Mathlib.Algebra.Order.GroupWithZero.Canonical
 import Mathlib.Algebra.Order.Monoid.Units

--- a/Mathlib/Algebra/Order/Hom/Monoid.lean
+++ b/Mathlib/Algebra/Order/Hom/Monoid.lean
@@ -4,8 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies
 -/
 import Mathlib.Algebra.GroupWithZero.Hom
-import Mathlib.Algebra.Order.Group.Basic
 import Mathlib.Algebra.Order.Group.Instances
+import Mathlib.Algebra.Order.Group.Unbundled.Basic
 import Mathlib.Algebra.Order.GroupWithZero.Canonical
 import Mathlib.Algebra.Order.Monoid.Units
 import Mathlib.Order.Hom.Basic

--- a/Mathlib/Algebra/Order/UpperLower.lean
+++ b/Mathlib/Algebra/Order/UpperLower.lean
@@ -3,6 +3,7 @@ Copyright (c) 2022 Yaël Dillies. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies
 -/
+import Mathlib.Algebra.Order.Group.Basic
 import Mathlib.Algebra.Order.Group.Instances
 import Mathlib.Algebra.Order.Group.OrderIso
 import Mathlib.Data.Set.Pointwise.SMul

--- a/Mathlib/Algebra/Order/UpperLower.lean
+++ b/Mathlib/Algebra/Order/UpperLower.lean
@@ -3,9 +3,10 @@ Copyright (c) 2022 Yaël Dillies. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies
 -/
-import Mathlib.Algebra.Order.Group.Basic
+import Mathlib.Algebra.Order.Group.Defs
 import Mathlib.Algebra.Order.Group.Instances
 import Mathlib.Algebra.Order.Group.OrderIso
+import Mathlib.Algebra.Order.Group.Unbundled.Basic
 import Mathlib.Data.Set.Pointwise.SMul
 import Mathlib.Order.UpperLower.Basic
 /-!
@@ -65,10 +66,12 @@ theorem IsLowerSet.mul_left (ht : IsLowerSet t) : IsLowerSet (s * t) := ht.toDua
 theorem IsLowerSet.mul_right (hs : IsLowerSet s) : IsLowerSet (s * t) := hs.toDual.mul_right
 
 @[to_additive]
-theorem IsUpperSet.inv (hs : IsUpperSet s) : IsLowerSet s⁻¹ := fun _ _ h ↦ hs <| inv_le_inv' h
+theorem IsUpperSet.inv (hs : IsUpperSet s) : IsLowerSet s⁻¹ := fun _ _ h ↦ hs <|
+  inv_le_inv_iff.mpr h
 
 @[to_additive]
-theorem IsLowerSet.inv (hs : IsLowerSet s) : IsUpperSet s⁻¹ := fun _ _ h ↦ hs <| inv_le_inv' h
+theorem IsLowerSet.inv (hs : IsLowerSet s) : IsUpperSet s⁻¹ := fun _ _ h ↦ hs <|
+  inv_le_inv_iff.mpr h
 
 @[to_additive]
 theorem IsUpperSet.div_left (ht : IsUpperSet t) : IsLowerSet (s / t) := by

--- a/Mathlib/Data/Int/SuccPred.lean
+++ b/Mathlib/Data/Int/SuccPred.lean
@@ -3,6 +3,7 @@ Copyright (c) 2021 Yaël Dillies. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies
 -/
+import Mathlib.Algebra.Order.Group.Basic
 import Mathlib.Algebra.Order.Ring.Int
 import Mathlib.Data.Nat.SuccPred
 

--- a/Mathlib/Order/Filter/Extr.lean
+++ b/Mathlib/Order/Filter/Extr.lean
@@ -3,7 +3,8 @@ Copyright (c) 2019 Yury Kudryashov. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury Kudryashov
 -/
-import Mathlib.Algebra.Order.Group.Basic
+import Mathlib.Algebra.Order.Group.Defs
+import Mathlib.Algebra.Order.Group.Unbundled.Basic
 import Mathlib.Data.Finset.Lattice.Fold
 import Mathlib.Order.ConditionallyCompleteLattice.Indexed
 import Mathlib.Order.Filter.Tendsto
@@ -394,19 +395,19 @@ section OrderedAddCommGroup
 variable [OrderedAddCommGroup β] {f g : α → β} {a : α} {s : Set α} {l : Filter α}
 
 theorem IsMinFilter.neg (hf : IsMinFilter f l a) : IsMaxFilter (fun x => -f x) l a :=
-  hf.comp_antitone fun _x _y hx => neg_le_neg hx
+  hf.comp_antitone fun _x _y hx => neg_le_neg_iff.mpr hx
 
 theorem IsMaxFilter.neg (hf : IsMaxFilter f l a) : IsMinFilter (fun x => -f x) l a :=
-  hf.comp_antitone fun _x _y hx => neg_le_neg hx
+  hf.comp_antitone fun _x _y hx => neg_le_neg_iff.mpr hx
 
 theorem IsExtrFilter.neg (hf : IsExtrFilter f l a) : IsExtrFilter (fun x => -f x) l a :=
   hf.elim (fun hf => hf.neg.isExtr) fun hf => hf.neg.isExtr
 
 theorem IsMinOn.neg (hf : IsMinOn f s a) : IsMaxOn (fun x => -f x) s a :=
-  hf.comp_antitone fun _x _y hx => neg_le_neg hx
+  hf.comp_antitone fun _x _y hx => neg_le_neg_iff.mpr hx
 
 theorem IsMaxOn.neg (hf : IsMaxOn f s a) : IsMinOn (fun x => -f x) s a :=
-  hf.comp_antitone fun _x _y hx => neg_le_neg hx
+  hf.comp_antitone fun _x _y hx => neg_le_neg_iff.mpr hx
 
 theorem IsExtrOn.neg (hf : IsExtrOn f s a) : IsExtrOn (fun x => -f x) s a :=
   hf.elim (fun hf => hf.neg.isExtr) fun hf => hf.neg.isExtr

--- a/Mathlib/Order/Filter/Extr.lean
+++ b/Mathlib/Order/Filter/Extr.lean
@@ -3,10 +3,10 @@ Copyright (c) 2019 Yury Kudryashov. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury Kudryashov
 -/
-import Mathlib.Order.Filter.Tendsto
-import Mathlib.Order.ConditionallyCompleteLattice.Indexed
-import Mathlib.Algebra.Order.Group.Defs
+import Mathlib.Algebra.Order.Group.Basic
 import Mathlib.Data.Finset.Lattice.Fold
+import Mathlib.Order.ConditionallyCompleteLattice.Indexed
+import Mathlib.Order.Filter.Tendsto
 
 /-!
 # Minimum and maximum w.r.t. a filter and on a set

--- a/Mathlib/Order/KrullDimension.lean
+++ b/Mathlib/Order/KrullDimension.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jujian Zhang, Fangming Li, Joachim Breitner
 -/
 
+import Mathlib.Algebra.Order.Group.Basic
 import Mathlib.Algebra.Order.Group.Int
 import Mathlib.Data.ENat.Lattice
 import Mathlib.Order.Minimal

--- a/Mathlib/Order/Monotone/Odd.lean
+++ b/Mathlib/Order/Monotone/Odd.lean
@@ -3,8 +3,9 @@ Copyright (c) 2022 Yury Kudryashov. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury Kudryashov
 -/
-import Mathlib.Algebra.Order.Group.Basic
+import Mathlib.Algebra.Order.Group.Defs
 import Mathlib.Algebra.Order.Group.Instances
+import Mathlib.Algebra.Order.Group.Unbundled.Basic
 import Mathlib.Order.Monotone.Union
 
 /-!
@@ -26,7 +27,7 @@ theorem strictMono_of_odd_strictMonoOn_nonneg {f : G → H} (h₁ : ∀ x, f (-x
     (h₂ : StrictMonoOn f (Ici 0)) : StrictMono f := by
   refine StrictMonoOn.Iic_union_Ici (fun x hx y hy hxy => neg_lt_neg_iff.1 ?_) h₂
   rw [← h₁, ← h₁]
-  exact h₂ (neg_nonneg.2 hy) (neg_nonneg.2 hx) (neg_lt_neg hxy)
+  exact h₂ (neg_nonneg.2 hy) (neg_nonneg.2 hx) (neg_lt_neg_iff.2 hxy)
 
 /-- An odd function on a linear ordered additive commutative group is strictly antitone on the whole
 group provided that it is strictly antitone on `Set.Ici 0`. -/
@@ -40,7 +41,7 @@ theorem monotone_of_odd_of_monotoneOn_nonneg {f : G → H} (h₁ : ∀ x, f (-x)
     (h₂ : MonotoneOn f (Ici 0)) : Monotone f := by
   refine MonotoneOn.Iic_union_Ici (fun x hx y hy hxy => neg_le_neg_iff.1 ?_) h₂
   rw [← h₁, ← h₁]
-  exact h₂ (neg_nonneg.2 hy) (neg_nonneg.2 hx) (neg_le_neg hxy)
+  exact h₂ (neg_nonneg.2 hy) (neg_nonneg.2 hx) (neg_le_neg_iff.2 hxy)
 
 /-- An odd function on a linear ordered additive commutative group is antitone on the whole group
 provided that it is monotone on `Set.Ici 0`. -/

--- a/Mathlib/Order/Monotone/Odd.lean
+++ b/Mathlib/Order/Monotone/Odd.lean
@@ -3,8 +3,9 @@ Copyright (c) 2022 Yury Kudryashov. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury Kudryashov
 -/
-import Mathlib.Order.Monotone.Union
+import Mathlib.Algebra.Order.Group.Basic
 import Mathlib.Algebra.Order.Group.Instances
+import Mathlib.Order.Monotone.Union
 
 /-!
 # Monotonicity of odd functions

--- a/Mathlib/Tactic/Bound.lean
+++ b/Mathlib/Tactic/Bound.lean
@@ -5,6 +5,7 @@ Authors: Geoffrey Irving
 -/
 
 import Aesop
+import Mathlib.Algebra.Order.Group.Basic
 import Mathlib.Tactic.Bound.Attribute
 import Mathlib.Tactic.Lemma
 import Mathlib.Tactic.Linarith.Frontend

--- a/Mathlib/Tactic/Linarith/Lemmas.lean
+++ b/Mathlib/Tactic/Linarith/Lemmas.lean
@@ -4,8 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Y. Lewis
 -/
 import Batteries.Tactic.Lint.Basic
+import Mathlib.Algebra.Order.Group.Defs
 import Mathlib.Algebra.Order.Monoid.Unbundled.Basic
-import Mathlib.Algebra.Order.Group.Basic
 import Mathlib.Algebra.Order.Ring.Defs
 import Mathlib.Algebra.Order.ZeroLEOne
 import Mathlib.Data.Nat.Cast.Order.Ring
@@ -59,11 +59,11 @@ theorem add_neg {α : Type*} [StrictOrderedSemiring α] {a b : α} (ha : a < 0)
   _root_.add_neg ha hb
 
 theorem mul_neg {α} [StrictOrderedRing α] {a b : α} (ha : a < 0) (hb : 0 < b) : b * a < 0 :=
-  have : (-b)*a > 0 := mul_pos_of_neg_of_neg (neg_neg_of_pos hb) ha
+  have : (-b)*a > 0 := mul_pos_of_neg_of_neg (neg_neg_iff_pos.mpr hb) ha
   neg_of_neg_pos (by simpa)
 
 theorem mul_nonpos {α} [OrderedRing α] {a b : α} (ha : a ≤ 0) (hb : 0 < b) : b * a ≤ 0 :=
-  have : (-b)*a ≥ 0 := mul_nonneg_of_nonpos_of_nonpos (le_of_lt (neg_neg_of_pos hb)) ha
+  have : (-b)*a ≥ 0 := mul_nonneg_of_nonpos_of_nonpos (le_of_lt (neg_neg_iff_pos.mpr hb)) ha
   by simpa
 
 -- used alongside `mul_neg` and `mul_nonpos`, so has the same argument pattern for uniformity

--- a/Mathlib/Tactic/Linarith/Lemmas.lean
+++ b/Mathlib/Tactic/Linarith/Lemmas.lean
@@ -5,6 +5,7 @@ Authors: Robert Y. Lewis
 -/
 import Batteries.Tactic.Lint.Basic
 import Mathlib.Algebra.Order.Monoid.Unbundled.Basic
+import Mathlib.Algebra.Order.Group.Basic
 import Mathlib.Algebra.Order.Ring.Defs
 import Mathlib.Algebra.Order.ZeroLEOne
 import Mathlib.Data.Nat.Cast.Order.Ring

--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -316,6 +316,7 @@
   "Mathlib.Tactic.Bound":
   ["Mathlib.Algebra.Order.AbsoluteValue",
    "Mathlib.Algebra.Order.Floor",
+   "Mathlib.Algebra.Order.Group.Basic",
    "Mathlib.Analysis.Analytic.Basic",
    "Mathlib.Tactic.Bound.Init"],
   "Mathlib.Tactic.Basic": ["Mathlib.Tactic.Linter.OldObtain"],
@@ -394,7 +395,6 @@
   ["Batteries.Tactic.Init", "Mathlib.Logic.Function.Defs"],
   "Mathlib.Data.Nat.Find": ["Batteries.WF"],
   "Mathlib.Data.Multiset.Bind": ["Mathlib.Algebra.GroupWithZero.Action.Defs"],
-  "Mathlib.Data.List.TakeDrop": ["Mathlib.Tactic.Common"],
   "Mathlib.Data.List.Range": ["Batteries.Data.Nat.Lemmas"],
   "Mathlib.Data.List.ProdSigma":
   ["Batteries.Data.Nat.Lemmas", "Mathlib.Data.List.Basic"],


### PR DESCRIPTION
This PR moves a few lemmas in `Algebra.Order.Group.Defs` downstream to `Algebra.Order.Group.Basic`, so that we can define ordered group with minimal imports. It means we have to add some extra imports of `Order.Group.Basic` to other files, so let's see how much we actually save with this change.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
