### PR TITLE
[Merged by Bors] - chore(Data/Int): split `Defs` into `Init` and `Basic`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2761,6 +2761,7 @@ import Mathlib.Data.Holor
 import Mathlib.Data.Ineq
 import Mathlib.Data.Int.AbsoluteValue
 import Mathlib.Data.Int.Associated
+import Mathlib.Data.Int.Basic
 import Mathlib.Data.Int.Bitwise
 import Mathlib.Data.Int.CardIntervalMod
 import Mathlib.Data.Int.Cast.Basic
@@ -2771,9 +2772,9 @@ import Mathlib.Data.Int.Cast.Pi
 import Mathlib.Data.Int.Cast.Prod
 import Mathlib.Data.Int.CharZero
 import Mathlib.Data.Int.ConditionallyCompleteOrder
-import Mathlib.Data.Int.Defs
 import Mathlib.Data.Int.DivMod
 import Mathlib.Data.Int.GCD
+import Mathlib.Data.Int.Init
 import Mathlib.Data.Int.Interval
 import Mathlib.Data.Int.LeastGreatest
 import Mathlib.Data.Int.Lemmas

--- a/Mathlib/Algebra/Group/Basic.lean
+++ b/Mathlib/Algebra/Group/Basic.lean
@@ -5,7 +5,7 @@ Authors: Jeremy Avigad, Leonardo de Moura, Simon Hudon, Mario Carneiro
 -/
 import Aesop
 import Mathlib.Algebra.Group.Defs
-import Mathlib.Data.Int.Defs
+import Mathlib.Data.Int.Basic
 import Mathlib.Logic.Function.Basic
 import Mathlib.Tactic.SimpRw
 import Mathlib.Tactic.SplitIfs

--- a/Mathlib/Algebra/Group/Basic.lean
+++ b/Mathlib/Algebra/Group/Basic.lean
@@ -5,7 +5,8 @@ Authors: Jeremy Avigad, Leonardo de Moura, Simon Hudon, Mario Carneiro
 -/
 import Aesop
 import Mathlib.Algebra.Group.Defs
-import Mathlib.Data.Int.Basic
+import Mathlib.Data.Nat.Init
+import Mathlib.Data.Int.Init
 import Mathlib.Logic.Function.Basic
 import Mathlib.Tactic.SimpRw
 import Mathlib.Tactic.SplitIfs

--- a/Mathlib/Algebra/Group/Idempotent.lean
+++ b/Mathlib/Algebra/Group/Idempotent.lean
@@ -7,6 +7,7 @@ import Mathlib.Algebra.Group.Basic
 import Mathlib.Algebra.Group.Commute.Defs
 import Mathlib.Algebra.Group.Hom.Defs
 import Mathlib.Data.Subtype
+import Mathlib.Tactic.Conv
 import Mathlib.Tactic.MinImports
 
 /-!

--- a/Mathlib/Algebra/Group/Submonoid/Membership.lean
+++ b/Mathlib/Algebra/Group/Submonoid/Membership.lean
@@ -10,6 +10,7 @@ import Mathlib.Algebra.Group.Nat.Hom
 import Mathlib.Algebra.Group.Submonoid.MulOpposite
 import Mathlib.Algebra.Group.Submonoid.Operations
 import Mathlib.Data.Fintype.Card
+import Mathlib.Data.Int.Basic
 
 /-!
 # Submonoids: membership criteria

--- a/Mathlib/Algebra/GroupWithZero/Basic.lean
+++ b/Mathlib/Algebra/GroupWithZero/Basic.lean
@@ -6,6 +6,7 @@ Authors: Johan Commelin
 import Mathlib.Algebra.Group.Basic
 import Mathlib.Algebra.GroupWithZero.NeZero
 import Mathlib.Logic.Unique
+import Mathlib.Tactic.Conv
 
 /-!
 # Groups with an adjoined zero element

--- a/Mathlib/Algebra/GroupWithZero/Divisibility.lean
+++ b/Mathlib/Algebra/GroupWithZero/Divisibility.lean
@@ -6,6 +6,7 @@ Neil Strickland, Aaron Anderson
 -/
 import Mathlib.Algebra.GroupWithZero.Units.Basic
 import Mathlib.Algebra.Divisibility.Units
+import Mathlib.Data.Nat.Basic
 
 /-!
 # Divisibility in groups with zero.

--- a/Mathlib/Algebra/GroupWithZero/Units/Basic.lean
+++ b/Mathlib/Algebra/GroupWithZero/Units/Basic.lean
@@ -5,6 +5,8 @@ Authors: Johan Commelin
 -/
 import Mathlib.Algebra.Group.Units.Basic
 import Mathlib.Algebra.GroupWithZero.Basic
+import Mathlib.Data.Int.Basic
+import Mathlib.Lean.Meta.CongrTheorems
 import Mathlib.Tactic.Contrapose
 import Mathlib.Tactic.Nontriviality
 import Mathlib.Tactic.Spread

--- a/Mathlib/Algebra/Order/Group/Unbundled/Int.lean
+++ b/Mathlib/Algebra/Order/Group/Unbundled/Int.lean
@@ -5,6 +5,7 @@ Authors: Jeremy Avigad
 -/
 import Mathlib.Algebra.Order.Group.Unbundled.Abs
 import Mathlib.Algebra.Group.Int.Defs
+import Mathlib.Data.Int.Basic
 
 /-!
 # Facts about `ℤ` as an (unbundled) ordered group

--- a/Mathlib/Algebra/Ring/Divisibility/Basic.lean
+++ b/Mathlib/Algebra/Ring/Divisibility/Basic.lean
@@ -6,6 +6,7 @@ Authors: Jeremy Avigad, Leonardo de Moura, Floris van Doorn, Yury Kudryashov, Ne
 import Mathlib.Algebra.Divisibility.Hom
 import Mathlib.Algebra.Group.Equiv.Basic
 import Mathlib.Algebra.Ring.Defs
+import Mathlib.Data.Nat.Basic
 
 /-!
 # Lemmas about divisibility in rings

--- a/Mathlib/Algebra/Ring/Idempotent.lean
+++ b/Mathlib/Algebra/Ring/Idempotent.lean
@@ -6,6 +6,7 @@ Authors: Christopher Hoskin
 import Mathlib.Algebra.GroupWithZero.Idempotent
 import Mathlib.Algebra.Ring.Defs
 import Mathlib.Order.Notation
+import Mathlib.Tactic.Convert
 
 /-!
 # Idempotent elements of a ring

--- a/Mathlib/Data/Int/Basic.lean
+++ b/Mathlib/Data/Int/Basic.lean
@@ -1,0 +1,102 @@
+/-
+Copyright (c) 2016 Jeremy Avigad. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jeremy Avigad
+-/
+import Mathlib.Data.Int.Init
+import Mathlib.Data.Nat.Basic
+import Mathlib.Logic.Nontrivial.Defs
+import Mathlib.Tactic.Convert
+import Mathlib.Tactic.Lift
+import Mathlib.Tactic.OfNat
+
+/-!
+# Basic operations on the integers
+
+This file builds on `Data.Int.Init` by adding basic lemmas on natural numbers
+depending on Mathlib definitions.
+-/
+
+open Nat
+
+namespace Int
+variable {a b c d m n : ℤ}
+
+-- TODO: Tag in Lean
+attribute [simp] natAbs_pos
+
+instance instNontrivial : Nontrivial ℤ := ⟨⟨0, 1, Int.zero_ne_one⟩⟩
+
+section inductionOn'
+
+variable {C : ℤ → Sort*} (z b : ℤ)
+  (H0 : C b) (Hs : ∀ k, b ≤ k → C k → C (k + 1)) (Hp : ∀ k ≤ b, C k → C (k - 1))
+
+variable {z b H0 Hs Hp}
+
+lemma inductionOn'_add_one (hz : b ≤ z) :
+    (z + 1).inductionOn' b H0 Hs Hp = Hs z hz (z.inductionOn' b H0 Hs Hp) := by
+  apply cast_eq_iff_heq.mpr
+  lift z - b to ℕ using Int.sub_nonneg.mpr hz with zb hzb
+  rw [show z + 1 - b = zb + 1 by omega]
+  have : b + zb = z := by omega
+  subst this
+  convert cast_heq _ _
+  rw [Int.inductionOn', cast_eq_iff_heq, ← hzb]
+
+end inductionOn'
+
+/-! ### nat abs -/
+
+lemma natAbs_surjective : natAbs.Surjective := fun n => ⟨n, natAbs_ofNat n⟩
+
+lemma pow_right_injective (h : 1 < a.natAbs) : ((a ^ ·) : ℕ → ℤ).Injective := by
+  refine (?_ : (natAbs ∘ (a ^ · : ℕ → ℤ)).Injective).of_comp
+  convert Nat.pow_right_injective h using 2
+  rw [Function.comp_apply, natAbs_pow]
+
+/-! ### dvd -/
+
+@[norm_cast] lemma natCast_dvd_natCast {m n : ℕ} : (↑m : ℤ) ∣ ↑n ↔ m ∣ n where
+  mp := by
+    rintro ⟨a, h⟩
+    obtain rfl | hm := m.eq_zero_or_pos
+    · simpa using h
+    have ha : 0 ≤ a := Int.not_lt.1 fun ha ↦ by
+      simpa [← h, Int.not_lt.2 (Int.natCast_nonneg _)]
+        using Int.mul_neg_of_pos_of_neg (natCast_pos.2 hm) ha
+    lift a to ℕ using ha
+    norm_cast at h
+    exact ⟨a, h⟩
+  mpr := by rintro ⟨a, rfl⟩; simp [Int.dvd_mul_right]
+
+@[norm_cast] theorem ofNat_dvd_natCast {x y : ℕ} : (ofNat(x) : ℤ) ∣ (y : ℤ) ↔ OfNat.ofNat x ∣ y :=
+  natCast_dvd_natCast
+
+@[norm_cast] theorem natCast_dvd_ofNat {x y : ℕ} : (x : ℤ) ∣ (ofNat(y) : ℤ) ↔ x ∣ OfNat.ofNat y :=
+  natCast_dvd_natCast
+
+lemma natCast_dvd {m : ℕ} : (m : ℤ) ∣ n ↔ m ∣ n.natAbs := by
+  obtain hn | hn := natAbs_eq n <;> rw [hn] <;> simp [← natCast_dvd_natCast, Int.dvd_neg]
+
+lemma dvd_natCast {n : ℕ} : m ∣ (n : ℤ) ↔ m.natAbs ∣ n := by
+  obtain hn | hn := natAbs_eq m <;> rw [hn] <;> simp [← natCast_dvd_natCast, Int.neg_dvd]
+
+/-- If an integer with larger absolute value divides an integer, it is zero. -/
+lemma eq_zero_of_dvd_of_natAbs_lt_natAbs (hmn : m ∣ n) (hnm : natAbs n < natAbs m) : n = 0 := by
+  rw [← natAbs_dvd, ← dvd_natAbs, natCast_dvd_natCast] at hmn
+  rw [← natAbs_eq_zero]
+  exact Nat.eq_zero_of_dvd_of_lt hmn hnm
+
+lemma eq_zero_of_dvd_of_nonneg_of_lt (hm : 0 ≤ m) (hmn : m < n) (hnm : n ∣ m) : m = 0 :=
+  eq_zero_of_dvd_of_natAbs_lt_natAbs hnm (natAbs_lt_natAbs_of_nonneg_of_lt hm hmn)
+
+/-- If two integers are congruent to a sufficiently large modulus, they are equal. -/
+lemma eq_of_mod_eq_of_natAbs_sub_lt_natAbs {a b c : ℤ} (h1 : a % b = c)
+    (h2 : natAbs (a - c) < natAbs b) : a = c :=
+  Int.eq_of_sub_eq_zero (eq_zero_of_dvd_of_natAbs_lt_natAbs (dvd_sub_of_emod_eq h1) h2)
+
+lemma natAbs_le_of_dvd_ne_zero (hmn : m ∣ n) (hn : n ≠ 0) : natAbs m ≤ natAbs n :=
+  not_lt.mp (mt (eq_zero_of_dvd_of_natAbs_lt_natAbs hmn) hn)
+
+end Int

--- a/Mathlib/Data/Int/Basic.lean
+++ b/Mathlib/Data/Int/Basic.lean
@@ -27,6 +27,8 @@ attribute [simp] natAbs_pos
 
 instance instNontrivial : Nontrivial ℤ := ⟨⟨0, 1, Int.zero_ne_one⟩⟩
 
+@[simp] lemma ofNat_injective : Function.Injective ofNat := @Int.ofNat.inj
+
 section inductionOn'
 
 variable {C : ℤ → Sort*} (z b : ℤ)
@@ -45,6 +47,25 @@ lemma inductionOn'_add_one (hz : b ≤ z) :
   rw [Int.inductionOn', cast_eq_iff_heq, ← hzb]
 
 end inductionOn'
+
+section strongRec
+
+variable {P : ℤ → Sort*} {lt : ∀ n < m, P n} {ge : ∀ n ≥ m, (∀ k < n, P k) → P n}
+
+lemma strongRec_of_ge :
+    ∀ hn : m ≤ n, m.strongRec lt ge n = ge n hn fun k _ ↦ m.strongRec lt ge k := by
+  refine m.strongRec (fun n hnm hmn ↦ (Int.not_lt.mpr hmn hnm).elim) (fun n _ ih hn ↦ ?_) n
+  rw [Int.strongRec, dif_neg (Int.not_lt.mpr hn)]
+  congr; revert ih
+  refine n.inductionOn' m (fun _ ↦ ?_) (fun k hmk ih' ih ↦ ?_) (fun k hkm ih' _ ↦ ?_) <;> ext l hl
+  · rw [inductionOn'_self, strongRec_of_lt hl]
+  · rw [inductionOn'_add_one hmk]; split_ifs with hlm
+    · rw [strongRec_of_lt hlm]
+    · rw [ih' fun l hl ↦ ih l (Int.lt_trans hl k.lt_succ), ih _ hl]
+  · rw [inductionOn'_sub_one hkm, ih']
+    exact fun l hlk hml ↦ (Int.not_lt.mpr hkm <| Int.lt_of_le_of_lt hml hlk).elim
+
+end strongRec
 
 /-! ### nat abs -/
 

--- a/Mathlib/Data/Int/Basic.lean
+++ b/Mathlib/Data/Int/Basic.lean
@@ -13,7 +13,7 @@ import Mathlib.Tactic.OfNat
 /-!
 # Basic operations on the integers
 
-This file builds on `Data.Int.Init` by adding basic lemmas on natural numbers
+This file builds on `Data.Int.Init` by adding basic lemmas on integers.
 depending on Mathlib definitions.
 -/
 

--- a/Mathlib/Data/Int/Cast/Basic.lean
+++ b/Mathlib/Data/Int/Cast/Basic.lean
@@ -5,6 +5,7 @@ Authors: Mario Carneiro, Gabriel Ebner
 -/
 import Mathlib.Data.Int.Cast.Defs
 import Mathlib.Algebra.Group.Basic
+import Mathlib.Data.Nat.Basic
 
 /-!
 # Cast of integers (additional theorems)

--- a/Mathlib/Data/Int/GCD.lean
+++ b/Mathlib/Data/Int/GCD.lean
@@ -10,6 +10,7 @@ import Mathlib.Data.Set.Operations
 import Mathlib.Order.Basic
 import Mathlib.Order.Bounds.Defs
 import Mathlib.Algebra.Group.Int.Defs
+import Mathlib.Data.Int.Basic
 
 /-!
 # Extended GCD and divisibility over ℤ

--- a/Mathlib/Data/Int/Init.lean
+++ b/Mathlib/Data/Int/Init.lean
@@ -3,12 +3,9 @@ Copyright (c) 2016 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad
 -/
+import Batteries.Logic
 import Mathlib.Data.Int.Notation
-import Mathlib.Data.Nat.Basic
-import Mathlib.Logic.Nontrivial.Defs
-import Mathlib.Tactic.Convert
-import Mathlib.Tactic.Lift
-import Mathlib.Tactic.OfNat
+import Mathlib.Data.Nat.Init
 
 /-!
 # Basic operations on the integers
@@ -17,11 +14,8 @@ This file contains some basic lemmas about integers.
 
 See note [foundational algebra order theory].
 
-## TODO
-
-Split this file into:
-* `Data.Int.Init` (or maybe `Data.Int.Batteries`?) for lemmas that could go to Batteries
-* `Data.Int.Basic` for the lemmas that require mathlib definitions
+This file should not depend on anything defined in Mathlib (except for notation), so that it can be
+upstreamed to Batteries easily.
 -/
 
 open Nat
@@ -33,7 +27,7 @@ section Order
 
 protected lemma le_rfl : a ≤ a := a.le_refl
 protected lemma lt_or_lt_of_ne : a ≠ b → a < b ∨ b < a := Int.lt_or_gt_of_ne
-protected lemma lt_or_le (a b : ℤ) : a < b ∨ b ≤ a := by rw [← Int.not_lt]; exact em _
+protected lemma lt_or_le (a b : ℤ) : a < b ∨ b ≤ a := by rw [← Int.not_lt]; exact Decidable.em _
 protected lemma le_or_lt (a b : ℤ) : a ≤ b ∨ b < a := (b.lt_or_le a).symm
 protected lemma lt_asymm : a < b → ¬ b < a := by rw [Int.not_lt]; exact Int.le_of_lt
 protected lemma le_of_eq (hab : a = b) : a ≤ b := by rw [hab]; exact Int.le_rfl
@@ -41,7 +35,7 @@ protected lemma ge_of_eq (hab : a = b) : b ≤ a := Int.le_of_eq hab.symm
 protected lemma le_antisymm_iff : a = b ↔ a ≤ b ∧ b ≤ a :=
   ⟨fun h ↦ ⟨Int.le_of_eq h, Int.ge_of_eq h⟩, fun h ↦ Int.le_antisymm h.1 h.2⟩
 protected lemma le_iff_eq_or_lt : a ≤ b ↔ a = b ∨ a < b := by
-  rw [Int.le_antisymm_iff, Int.lt_iff_le_not_le, ← and_or_left]; simp [em]
+  rw [Int.le_antisymm_iff, Int.lt_iff_le_not_le, ← and_or_left]; simp [Decidable.em]
 
 protected lemma le_iff_lt_or_eq : a ≤ b ↔ a < b ∨ a = b := by rw [Int.le_iff_eq_or_lt, or_comm]
 
@@ -80,15 +74,11 @@ protected lemma sub_pos : 0 < a - b ↔ b < a := ⟨Int.lt_of_sub_pos, Int.sub_p
 @[simp, nolint simpNF]
 protected lemma sub_nonneg : 0 ≤ a - b ↔ b ≤ a := ⟨Int.le_of_sub_nonneg, Int.sub_nonneg_of_le⟩
 
-instance instNontrivial : Nontrivial ℤ := ⟨⟨0, 1, Int.zero_ne_one⟩⟩
-
 protected theorem ofNat_add_out (m n : ℕ) : ↑m + ↑n = (↑(m + n) : ℤ) := rfl
 
 protected theorem ofNat_mul_out (m n : ℕ) : ↑m * ↑n = (↑(m * n) : ℤ) := rfl
 
 protected theorem ofNat_add_one_out (n : ℕ) : ↑n + (1 : ℤ) = ↑(succ n) := rfl
-
-@[simp] lemma ofNat_injective : Function.Injective ofNat := @Int.ofNat.inj
 
 @[simp] lemma ofNat_eq_natCast (n : ℕ) : Int.ofNat n = n := rfl
 
@@ -209,7 +199,7 @@ It is used as the default induction principle for the `induction` tactic.
     suffices ∀ n : ℕ, p (-n) from this (i + 1)
     intro n; induction n with
     | zero => simp [hz]
-    | succ n ih => convert hn _ ih using 1; simp [ofNat_succ, Int.neg_add, Int.sub_eq_add_neg]
+    | succ n ih => simpa [ofNat_succ, Int.neg_add, Int.sub_eq_add_neg] using hn _ ih
 
 section inductionOn'
 
@@ -219,7 +209,7 @@ variable {C : ℤ → Sort*} (z b : ℤ)
 /-- Inductively define a function on `ℤ` by defining it at `b`, for the `succ` of a number greater
 than `b`, and the `pred` of a number less than `b`. -/
 @[elab_as_elim] protected def inductionOn' : C z :=
-  cast (congr_arg C <| show b + (z - b) = z by rw [Int.add_comm, z.sub_add_cancel b]) <|
+  cast (congrArg C <| show b + (z - b) = z by rw [Int.add_comm, z.sub_add_cancel b]) <|
   match z - b with
   | .ofNat n => pos n
   | .negSucc n => neg n
@@ -242,16 +232,6 @@ variable {z b H0 Hs Hp}
 lemma inductionOn'_self : b.inductionOn' b H0 Hs Hp = H0 :=
   cast_eq_iff_heq.mpr <| .symm <| by rw [b.sub_self, ← cast_eq_iff_heq]; rfl
 
-lemma inductionOn'_add_one (hz : b ≤ z) :
-    (z + 1).inductionOn' b H0 Hs Hp = Hs z hz (z.inductionOn' b H0 Hs Hp) := by
-  apply cast_eq_iff_heq.mpr
-  lift z - b to ℕ using Int.sub_nonneg.mpr hz with zb hzb
-  rw [show z + 1 - b = zb + 1 by omega]
-  have : b + zb = z := by omega
-  subst this
-  convert cast_heq _ _
-  rw [Int.inductionOn', cast_eq_iff_heq, ← hzb]
-
 lemma inductionOn'_sub_one (hz : z ≤ b) :
     (z - 1).inductionOn' b H0 Hs Hp = Hp z hz (z.inductionOn' b H0 Hs Hp) := by
   apply cast_eq_iff_heq.mpr
@@ -263,7 +243,9 @@ lemma inductionOn'_sub_one (hz : z ≤ b) :
     subst this; rw [inductionOn'_self]; exact heq_of_eq rfl
   · have : z = b + -[n+1] := by rw [Int.negSucc_eq] at hn ⊢; omega
     subst this
-    convert cast_heq _ _
+    refine (cast_heq _ _).trans ?_
+    congr
+    symm
     rw [Int.inductionOn', cast_eq_iff_heq, show b + -[n+1] - b = -[n+1] by omega]
 
 end inductionOn'
@@ -306,19 +288,6 @@ and is analogous to `Nat.strongRec` for integers on or above the threshold. -/
 variable {lt ge}
 lemma strongRec_of_lt (hn : n < m) : m.strongRec lt ge n = lt n hn := dif_pos _
 
-lemma strongRec_of_ge :
-    ∀ hn : m ≤ n, m.strongRec lt ge n = ge n hn fun k _ ↦ m.strongRec lt ge k := by
-  refine m.strongRec (fun n hnm hmn ↦ (Int.not_lt.mpr hmn hnm).elim) (fun n _ ih hn ↦ ?_) n
-  rw [Int.strongRec, dif_neg (Int.not_lt.mpr hn)]
-  congr; revert ih
-  refine n.inductionOn' m (fun _ ↦ ?_) (fun k hmk ih' ih ↦ ?_) (fun k hkm ih' _ ↦ ?_) <;> ext l hl
-  · rw [inductionOn'_self, strongRec_of_lt hl]
-  · rw [inductionOn'_add_one hmk]; split_ifs with hlm
-    · rw [strongRec_of_lt hlm]
-    · rw [ih' fun l hl ↦ ih l (Int.lt_trans hl k.lt_succ), ih _ hl]
-  · rw [inductionOn'_sub_one hkm, ih']
-    exact fun l hlk hml ↦ (Int.not_lt.mpr hkm <| Int.lt_of_le_of_lt hml hlk).elim
-
 end strongRec
 
 /-! ### nat abs -/
@@ -333,17 +302,10 @@ lemma natAbs_add_of_nonpos {a b : Int} (ha : a ≤ 0) (hb : b ≤ 0) :
     natAbs (a + b) = natAbs a + natAbs b := by
   omega
 
-lemma natAbs_surjective : natAbs.Surjective := fun n => ⟨n, natAbs_ofNat n⟩
-
 lemma natAbs_pow (n : ℤ) (k : ℕ) : Int.natAbs (n ^ k) = Int.natAbs n ^ k := by
   induction k with
   | zero => rfl
   | succ k ih => rw [Int.pow_succ, natAbs_mul, Nat.pow_succ, ih, Nat.mul_comm]
-
-lemma pow_right_injective (h : 1 < a.natAbs) : ((a ^ ·) : ℕ → ℤ).Injective := by
-  refine (?_ : (natAbs ∘ (a ^ · : ℕ → ℤ)).Injective).of_comp
-  convert Nat.pow_right_injective h using 2
-  rw [Function.comp_apply, natAbs_pow]
 
 lemma natAbs_sq (x : ℤ) : (x.natAbs : ℤ) ^ 2 = x ^ 2 := by
   simp [Int.pow_succ, Int.pow_zero, Int.natAbs_mul_self']
@@ -407,7 +369,7 @@ lemma mul_dvd_of_dvd_div (hcb : c ∣ b) (h : a ∣ b / c) : c * a ∣ b :=
   ⟨d, by simpa [Int.mul_comm, Int.mul_left_comm] using Int.eq_mul_of_ediv_eq_left hcb hd⟩
 
 lemma dvd_div_of_mul_dvd (h : a * b ∣ c) : b ∣ c / a := by
-  obtain rfl | ha := eq_or_ne a 0
+  obtain rfl | ha := Decidable.em (a = 0)
   · simp
   · obtain ⟨d, rfl⟩ := h
     simp [Int.mul_assoc, ha]
@@ -440,31 +402,6 @@ lemma exists_lt_and_lt_iff_not_dvd (m : ℤ) (hn : 0 < n) :
     · rw [Int.add_comm _ (1 : ℤ), Int.mul_add, Int.mul_one]
       exact Int.add_lt_add_right (emod_lt_of_pos _ hn) _
 
-@[norm_cast] lemma natCast_dvd_natCast {m n : ℕ} : (↑m : ℤ) ∣ ↑n ↔ m ∣ n where
-  mp := by
-    rintro ⟨a, h⟩
-    obtain rfl | hm := m.eq_zero_or_pos
-    · simpa using h
-    have ha : 0 ≤ a := Int.not_lt.1 fun ha ↦ by
-      simpa [← h, Int.not_lt.2 (Int.natCast_nonneg _)]
-        using Int.mul_neg_of_pos_of_neg (natCast_pos.2 hm) ha
-    lift a to ℕ using ha
-    norm_cast at h
-    exact ⟨a, h⟩
-  mpr := by rintro ⟨a, rfl⟩; simp [Int.dvd_mul_right]
-
-@[norm_cast] theorem ofNat_dvd_natCast {x y : ℕ} : (ofNat(x) : ℤ) ∣ (y : ℤ) ↔ OfNat.ofNat x ∣ y :=
-  natCast_dvd_natCast
-
-@[norm_cast] theorem natCast_dvd_ofNat {x y : ℕ} : (x : ℤ) ∣ (ofNat(y) : ℤ) ↔ x ∣ OfNat.ofNat y :=
-  natCast_dvd_natCast
-
-lemma natCast_dvd {m : ℕ} : (m : ℤ) ∣ n ↔ m ∣ n.natAbs := by
-  obtain hn | hn := natAbs_eq n <;> rw [hn] <;> simp [← natCast_dvd_natCast, Int.dvd_neg]
-
-lemma dvd_natCast {n : ℕ} : m ∣ (n : ℤ) ↔ m.natAbs ∣ n := by
-  obtain hn | hn := natAbs_eq m <;> rw [hn] <;> simp [← natCast_dvd_natCast, Int.neg_dvd]
-
 lemma natAbs_ediv (a b : ℤ) (H : b ∣ a) : natAbs (a / b) = natAbs a / natAbs b := by
   rcases Nat.eq_zero_or_pos (natAbs b) with (h | h)
   · rw [natAbs_eq_zero.1 h]
@@ -490,27 +427,10 @@ lemma eq_mul_div_of_mul_eq_mul_of_dvd_left (hb : b ≠ 0) (hbc : b ∣ c) (h : b
   rw [Int.mul_ediv_cancel_left _ hb]
   rwa [Int.mul_assoc, Int.mul_eq_mul_left_iff hb] at h
 
-/-- If an integer with larger absolute value divides an integer, it is zero. -/
-lemma eq_zero_of_dvd_of_natAbs_lt_natAbs (hmn : m ∣ n) (hnm : natAbs n < natAbs m) : n = 0 := by
-  rw [← natAbs_dvd, ← dvd_natAbs, natCast_dvd_natCast] at hmn
-  rw [← natAbs_eq_zero]
-  exact Nat.eq_zero_of_dvd_of_lt hmn hnm
-
-lemma eq_zero_of_dvd_of_nonneg_of_lt (hm : 0 ≤ m) (hmn : m < n) (hnm : n ∣ m) : m = 0 :=
-  eq_zero_of_dvd_of_natAbs_lt_natAbs hnm (natAbs_lt_natAbs_of_nonneg_of_lt hm hmn)
-
-/-- If two integers are congruent to a sufficiently large modulus, they are equal. -/
-lemma eq_of_mod_eq_of_natAbs_sub_lt_natAbs {a b c : ℤ} (h1 : a % b = c)
-    (h2 : natAbs (a - c) < natAbs b) : a = c :=
-  Int.eq_of_sub_eq_zero (eq_zero_of_dvd_of_natAbs_lt_natAbs (dvd_sub_of_emod_eq h1) h2)
-
 lemma ofNat_add_negSucc_of_ge {m n : ℕ} (h : n.succ ≤ m) :
     ofNat m + -[n+1] = ofNat (m - n.succ) := by
   rw [negSucc_eq, ofNat_eq_natCast, ofNat_eq_natCast, ← natCast_one, ← natCast_add,
     ← Int.sub_eq_add_neg, ← Int.natCast_sub h]
-
-lemma natAbs_le_of_dvd_ne_zero (hmn : m ∣ n) (hn : n ≠ 0) : natAbs m ≤ natAbs n :=
-  not_lt.mp (mt (eq_zero_of_dvd_of_natAbs_lt_natAbs hmn) hn)
 
 /-! #### `/` and ordering -/
 
@@ -518,7 +438,7 @@ lemma natAbs_eq_of_dvd_dvd (hmn : m ∣ n) (hnm : n ∣ m) : natAbs m = natAbs n
   Nat.dvd_antisymm (natAbs_dvd_natAbs.2 hmn) (natAbs_dvd_natAbs.2 hnm)
 
 lemma ediv_dvd_of_dvd (hmn : m ∣ n) : n / m ∣ n := by
-  obtain rfl | hm := eq_or_ne m 0
+  obtain rfl | hm := Decidable.em (m = 0)
   · simpa using hmn
   · obtain ⟨a, ha⟩ := hmn
     simp [ha, Int.mul_ediv_cancel_left _ hm, Int.dvd_mul_left]

--- a/Mathlib/Data/Int/Init.lean
+++ b/Mathlib/Data/Int/Init.lean
@@ -4,8 +4,11 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad
 -/
 import Batteries.Logic
+import Batteries.Tactic.Init
 import Mathlib.Data.Int.Notation
-import Mathlib.Data.Nat.Init
+import Mathlib.Data.Nat.Notation
+import Mathlib.Tactic.Lemma
+import Mathlib.Tactic.TypeStar
 
 /-!
 # Basic operations on the integers

--- a/Mathlib/Data/Int/NatPrime.lean
+++ b/Mathlib/Data/Int/NatPrime.lean
@@ -5,6 +5,7 @@ Authors: Kevin Lacker, Bryan Gin-ge Chen
 -/
 import Mathlib.Data.Nat.Prime.Basic
 import Mathlib.Algebra.Group.Int.Defs
+import Mathlib.Data.Int.Basic
 
 /-!
 # Lemmas about `Nat.Prime` using `Int`s

--- a/Mathlib/Data/Int/Sqrt.lean
+++ b/Mathlib/Data/Int/Sqrt.lean
@@ -3,9 +3,9 @@ Copyright (c) 2018 Kenny Lau. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kenny Lau
 -/
-import Mathlib.Data.Int.Basic
 import Mathlib.Data.Nat.Sqrt
 import Mathlib.Tactic.Common
+import Mathlib.Data.Int.Init
 
 /-!
 # Square root of integers

--- a/Mathlib/Data/Int/Sqrt.lean
+++ b/Mathlib/Data/Int/Sqrt.lean
@@ -3,7 +3,7 @@ Copyright (c) 2018 Kenny Lau. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kenny Lau
 -/
-import Mathlib.Data.Int.Defs
+import Mathlib.Data.Int.Basic
 import Mathlib.Data.Nat.Sqrt
 import Mathlib.Tactic.Common
 

--- a/Mathlib/Data/Nat/Init.lean
+++ b/Mathlib/Data/Nat/Init.lean
@@ -40,7 +40,7 @@ Less basic uses of `ℕ` and `ℤ` should however use the typeclass-mediated dev
 
 The relevant files are:
 * `Mathlib.Data.Nat.Basic` for the continuation of the home-baked development on `ℕ`
-* `Mathlib.Data.Int.Defs` for the continuation of the home-baked development on `ℤ`
+* `Mathlib.Data.Int.Init` for the continuation of the home-baked development on `ℤ`
 * `Mathlib.Algebra.Group.Nat` for the monoid instances on `ℕ`
 * `Mathlib.Algebra.Group.Int` for the group instance on `ℤ`
 * `Mathlib.Algebra.Ring.Nat` for the semiring instance on `ℕ`

--- a/Mathlib/Data/Nat/PSub.lean
+++ b/Mathlib/Data/Nat/PSub.lean
@@ -5,6 +5,7 @@ Authors: Mario Carneiro
 -/
 import Mathlib.Algebra.Group.Basic
 import Mathlib.Algebra.Group.Nat.Defs
+import Mathlib.Data.Nat.Basic
 
 /-!
 # Partial predecessor and partial subtraction on the natural numbers

--- a/Mathlib/Data/Nat/Prime/Int.lean
+++ b/Mathlib/Data/Nat/Prime/Int.lean
@@ -6,6 +6,7 @@ Authors: Leonardo de Moura, Jeremy Avigad, Mario Carneiro
 import Mathlib.Algebra.Ring.Int.Defs
 import Mathlib.Data.Nat.Prime.Basic
 import Mathlib.Algebra.Group.Int.Units
+import Mathlib.Data.Int.Basic
 
 /-!
 # Prime numbers in the naturals and the integers

--- a/Mathlib/Data/Rat/Defs.lean
+++ b/Mathlib/Data/Rat/Defs.lean
@@ -5,10 +5,11 @@ Authors: Johannes Hölzl, Mario Carneiro
 -/
 import Batteries.Data.Rat.Lemmas
 import Mathlib.Algebra.Group.Defs
-import Mathlib.Data.Int.Basic
 import Mathlib.Data.Rat.Init
 import Mathlib.Order.Basic
 import Mathlib.Tactic.Common
+import Mathlib.Data.Int.Init
+import Mathlib.Data.Nat.Basic
 
 /-!
 # Basics for the Rational Numbers

--- a/Mathlib/Data/Rat/Defs.lean
+++ b/Mathlib/Data/Rat/Defs.lean
@@ -3,12 +3,12 @@ Copyright (c) 2019 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Mario Carneiro
 -/
+import Batteries.Data.Rat.Lemmas
 import Mathlib.Algebra.Group.Defs
-import Mathlib.Data.Int.Defs
+import Mathlib.Data.Int.Basic
 import Mathlib.Data.Rat.Init
 import Mathlib.Order.Basic
 import Mathlib.Tactic.Common
-import Batteries.Data.Rat.Lemmas
 
 /-!
 # Basics for the Rational Numbers

--- a/Mathlib/Dynamics/PeriodicPts/Defs.lean
+++ b/Mathlib/Dynamics/PeriodicPts/Defs.lean
@@ -9,6 +9,7 @@ import Mathlib.Algebra.Order.Sub.Basic
 import Mathlib.Data.List.Cycle
 import Mathlib.Data.PNat.Notation
 import Mathlib.Dynamics.FixedPoints.Basic
+import Mathlib.Data.Int.Basic
 
 /-!
 # Periodic points

--- a/Mathlib/Logic/Equiv/Fin.lean
+++ b/Mathlib/Logic/Equiv/Fin.lean
@@ -3,8 +3,8 @@ Copyright (c) 2018 Kenny Lau. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kenny Lau
 -/
-import Mathlib.Data.Int.Defs
 import Mathlib.Data.Fin.VecNotation
+import Mathlib.Data.Int.Basic
 import Mathlib.Logic.Embedding.Set
 import Mathlib.Logic.Equiv.Option
 

--- a/Mathlib/Logic/Equiv/Fin.lean
+++ b/Mathlib/Logic/Equiv/Fin.lean
@@ -4,9 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kenny Lau
 -/
 import Mathlib.Data.Fin.VecNotation
-import Mathlib.Data.Int.Basic
 import Mathlib.Logic.Embedding.Set
 import Mathlib.Logic.Equiv.Option
+import Mathlib.Data.Int.Init
 
 /-!
 # Equivalences for `Fin n`

--- a/Mathlib/Order/KrullDimension.lean
+++ b/Mathlib/Order/KrullDimension.lean
@@ -6,6 +6,7 @@ Authors: Jujian Zhang, Fangming Li, Joachim Breitner
 
 import Mathlib.Algebra.Order.Group.Int
 import Mathlib.Data.ENat.Lattice
+import Mathlib.Data.Int.Basic
 import Mathlib.Order.Minimal
 import Mathlib.Order.RelSeries
 import Mathlib.Tactic.FinCases

--- a/Mathlib/Tactic/MoveAdd.lean
+++ b/Mathlib/Tactic/MoveAdd.lean
@@ -5,6 +5,7 @@ Authors: Arthur Paulino, Damiano Testa
 -/
 import Mathlib.Algebra.Group.Basic
 import Mathlib.Lean.Meta
+import Mathlib.Order.Defs.LinearOrder
 
 /-!
 

--- a/MathlibTest/MoveAdd.lean
+++ b/MathlibTest/MoveAdd.lean
@@ -1,5 +1,6 @@
 import Mathlib.Tactic.MoveAdd
 import Mathlib.Algebra.Ring.Nat
+import Mathlib.Data.Nat.Basic
 
 universe u
 

--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -244,7 +244,9 @@
   "Mathlib.Tactic.Nontriviality.Core": ["Mathlib.Logic.Nontrivial.Basic"],
   "Mathlib.Tactic.NoncommRing": ["Mathlib.Algebra.Group.Action.Defs"],
   "Mathlib.Tactic.MoveAdd":
-  ["Mathlib.Algebra.Group.Basic", "Mathlib.Init.Order.LinearOrder"],
+  ["Mathlib.Algebra.Group.Basic",
+   "Mathlib.Init.Order.LinearOrder",
+   "Mathlib.Order.Defs.LinearOrder"],
   "Mathlib.Tactic.Measurability":
   ["Mathlib.Algebra.Group.Defs", "Mathlib.Tactic.Measurability.Init"],
   "Mathlib.Tactic.Linter.UnusedTactic":
@@ -405,9 +407,11 @@
   "Mathlib.Data.List.Basic":
   ["Mathlib.Control.Basic", "Mathlib.Data.Option.Basic"],
   "Mathlib.Data.LazyList.Basic": ["Mathlib.Lean.Thunk"],
+  "Mathlib.Data.Int.Init": ["Batteries.Tactic.Init"],
   "Mathlib.Data.Int.Defs": ["Batteries.Data.Int.Order", "Mathlib.Tactic.OfNat"],
   "Mathlib.Data.Int.ConditionallyCompleteOrder":
   ["Mathlib.Order.ConditionallyCompleteLattice.Basic"],
+  "Mathlib.Data.Int.Basic": ["Mathlib.Tactic.OfNat"],
   "Mathlib.Data.FunLike.Basic": ["Mathlib.Logic.Function.Basic"],
   "Mathlib.Data.Finsupp.Notation": ["Mathlib.Data.Finsupp.Single"],
   "Mathlib.Data.Finset.Insert": ["Mathlib.Data.Finset.Attr"],
@@ -476,6 +480,7 @@
   "Mathlib.Algebra.Module.LinearMap.Basic": ["Mathlib.Algebra.Star.Basic"],
   "Mathlib.Algebra.Module.Equiv": ["Mathlib.Algebra.Star.Basic"],
   "Mathlib.Algebra.Homology.ModuleCat": ["Mathlib.Algebra.Homology.Homotopy"],
+  "Mathlib.Algebra.GroupWithZero.Units.Basic": ["Mathlib.Data.Int.Basic"],
   "Mathlib.Algebra.Group.Units.Basic": ["Mathlib.Tactic.Subsingleton"],
   "Mathlib.Algebra.Group.Units": ["Mathlib.Tactic.Subsingleton"],
   "Mathlib.Algebra.Group.Pi.Basic": ["Batteries.Tactic.Classical"],


### PR DESCRIPTION
This PR follows the instructions in a TODO comment in `Data/Int/Defs.lean` to split it into an `Init.lean` file for everything that doesn't meaningfully depend on Mathlib, and a `Basic.lean` file for things that do. I redid a few proofs in `Int.Init` so they are provable without reference to Mathlib.

---

- [x] depends on: #22008

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
