### PR TITLE
[Merged by Bors] - feat(Logic/Equiv/List): lists on a unique type are equivalent to `ℕ`

### DIFF
--- a/Mathlib/Logic/Equiv/List.lean
+++ b/Mathlib/Logic/Equiv/List.lean
@@ -354,7 +354,7 @@ namespace Equiv
 
 /-- A list on a unique type is equivalent to ℕ by sending each list to its length. -/
 @[simps!]
-theorem listUniqueEquiv (α : Type*) [Unique α] : List α ≃ ℕ where
+def listUniqueEquiv (α : Type*) [Unique α] : List α ≃ ℕ where
   toFun := List.length
   invFun n := List.replicate n default
   left_inv u := List.length_injective (by simp)

--- a/Mathlib/Logic/Equiv/List.lean
+++ b/Mathlib/Logic/Equiv/List.lean
@@ -358,7 +358,7 @@ def listUniqueEquiv (α : Type*) [Unique α] : List α ≃ ℕ where
   toFun := List.length
   invFun n := List.replicate n default
   left_inv u := List.length_injective (by simp)
-  right_inv n := List.length_replicate n default
+  right_inv n := List.length_replicate n _
 
 /-- The type lists on unit is canonically equivalent to the natural numbers. -/
 @[deprecated listUniqueEquiv (since := "2025-02-17")]

--- a/Mathlib/Logic/Equiv/List.lean
+++ b/Mathlib/Logic/Equiv/List.lean
@@ -352,12 +352,17 @@ end Denumerable
 
 namespace Equiv
 
-/-- The type lists on unit is canonically equivalent to the natural numbers. -/
-def listUnitEquiv : List Unit ≃ ℕ where
+@[simps!]
+theorem listUniqueEquiv (α : Type*) [Unique α] : List α ≃ ℕ where
   toFun := List.length
-  invFun n := List.replicate n ()
+  invFun n := List.replicate n default
   left_inv u := List.length_injective (by simp)
-  right_inv n := List.length_replicate n ()
+  right_inv n := List.length_replicate n default
+
+/-- The type lists on unit is canonically equivalent to the natural numbers. -/
+@[deprecated listUniqueEquiv (since := "2025-02-17")]
+def listUnitEquiv : List Unit ≃ ℕ :=
+  listUniqueEquiv _
 
 /-- `List ℕ` is equivalent to `ℕ`. -/
 def listNatEquivNat : List ℕ ≃ ℕ :=

--- a/Mathlib/Logic/Equiv/List.lean
+++ b/Mathlib/Logic/Equiv/List.lean
@@ -352,6 +352,7 @@ end Denumerable
 
 namespace Equiv
 
+/-- A list on a unique type is equivalent to ℕ by sending each list to its length. -/
 @[simps!]
 theorem listUniqueEquiv (α : Type*) [Unique α] : List α ≃ ℕ where
   toFun := List.length


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
