### PR TITLE
[Merged by Bors] - chore(Logic/Hydra): remove initial intros in lemma cutExpand_closed

### DIFF
--- a/Mathlib/Logic/Hydra.lean
+++ b/Mathlib/Logic/Hydra.lean
@@ -118,9 +118,8 @@ theorem cutExpand_fibration (r : α → α → Prop) :
 
 /-- `CutExpand` preserves leftward-closedness under a relation. -/
 lemma cutExpand_closed [IsIrrefl α r] (p : α → Prop)
-    (h : ∀ {a' a}, r a' a → p a → p a') :
-    ∀ {s' s}, CutExpand r s' s → (∀ a ∈ s, p a) → ∀ a ∈ s', p a := by
-  intros s' s
+    (h : ∀ {a' a}, r a' a → p a → p a') (s' s : Multiset α) :
+    CutExpand r s' s → (∀ a ∈ s, p a) → ∀ a ∈ s', p a := by
   classical
   rw [cutExpand_iff]
   rintro ⟨t, a, hr, ha, rfl⟩ hsp a' h'

--- a/Mathlib/Logic/Hydra.lean
+++ b/Mathlib/Logic/Hydra.lean
@@ -118,7 +118,7 @@ theorem cutExpand_fibration (r : α → α → Prop) :
 
 /-- `CutExpand` preserves leftward-closedness under a relation. -/
 lemma cutExpand_closed [IsIrrefl α r] (p : α → Prop)
-    (h : ∀ {a' a}, r a' a → p a → p a') (s' s : Multiset α) :
+    (h : ∀ {a' a}, r a' a → p a → p a') {s' s : Multiset α} :
     CutExpand r s' s → (∀ a ∈ s, p a) → ∀ a ∈ s', p a := by
   classical
   rw [cutExpand_iff]


### PR DESCRIPTION
This PR updates the lemma to be consistent with Mathlib4 style conventions

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
