### PR TITLE
[Merged by Bors] - feat(Combinatorics/SimpleGraphs): various path and edge lemmas

### DIFF
--- a/Mathlib/Combinatorics/SimpleGraph/Connectivity/Subgraph.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Connectivity/Subgraph.lean
@@ -190,6 +190,13 @@ theorem toSubgraph_map (f : G →g G') (p : G.Walk u v) :
     (p.map f).toSubgraph = p.toSubgraph.map f := by induction p <;> simp [*, Subgraph.map_sup]
 
 @[simp]
+lemma adj_toSubgraph_mapLe {G' : SimpleGraph V} {w x : V} (p : G.Walk u v) (h : G ≤ G') :
+    (p.mapLe h).toSubgraph.Adj w x ↔ p.toSubgraph.Adj w x  := by
+  simp only [Walk.toSubgraph_map, Subgraph.map_adj]
+  nth_rewrite 1 [← Hom.mapSpanningSubgraphs_apply h w, ← Hom.mapSpanningSubgraphs_apply h x]
+  rw [Relation.map_apply_apply (Hom.mapSpanningSubgraph_inj h) (Hom.mapSpanningSubgraph_inj h)]
+
+@[simp]
 theorem finite_neighborSet_toSubgraph (p : G.Walk u v) : (p.toSubgraph.neighborSet w).Finite := by
   induction p with
   | nil =>

--- a/Mathlib/Combinatorics/SimpleGraph/Connectivity/Subgraph.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Connectivity/Subgraph.lean
@@ -193,7 +193,8 @@ lemma adj_toSubgraph_mapLe {G' : SimpleGraph V} {w x : V} {p : G.Walk u v} (h : 
     (p.mapLe h).toSubgraph.Adj w x ↔ p.toSubgraph.Adj w x := by
   simp only [toSubgraph_map, Subgraph.map_adj]
   nth_rewrite 1 [← Hom.mapSpanningSubgraphs_apply h w, ← Hom.mapSpanningSubgraphs_apply h x]
-  rw [Relation.map_apply_apply (Hom.mapSpanningSubgraphs_inj h) (Hom.mapSpanningSubgraphs_inj h)]
+  rw [Relation.map_apply_apply (Hom.mapSpanningSubgraphs_injective h)
+    (Hom.mapSpanningSubgraphs_injective h)]
 
 @[simp]
 theorem finite_neighborSet_toSubgraph (p : G.Walk u v) : (p.toSubgraph.neighborSet w).Finite := by

--- a/Mathlib/Combinatorics/SimpleGraph/Connectivity/Subgraph.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Connectivity/Subgraph.lean
@@ -189,7 +189,7 @@ theorem toSubgraph_rotate [DecidableEq V] (c : G.Walk v v) (h : u ∈ c.support)
 theorem toSubgraph_map (f : G →g G') (p : G.Walk u v) :
     (p.map f).toSubgraph = p.toSubgraph.map f := by induction p <;> simp [*, Subgraph.map_sup]
 
-lemma adj_toSubgraph_mapLe {G' : SimpleGraph V} {w x : V} (p : G.Walk u v) (h : G ≤ G') :
+lemma adj_toSubgraph_mapLe {G' : SimpleGraph V} {w x : V} {p : G.Walk u v} (h : G ≤ G') :
     (p.mapLe h).toSubgraph.Adj w x ↔ p.toSubgraph.Adj w x := by
   simp only [toSubgraph_map, Subgraph.map_adj]
   nth_rewrite 1 [← Hom.mapSpanningSubgraphs_apply h w, ← Hom.mapSpanningSubgraphs_apply h x]

--- a/Mathlib/Combinatorics/SimpleGraph/Connectivity/Subgraph.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Connectivity/Subgraph.lean
@@ -145,7 +145,7 @@ theorem mem_verts_toSubgraph (p : G.Walk u v) : w ∈ p.toSubgraph.verts ↔ w �
       ⟨by rintro (rfl | h) <;> simp [*], by simp (config := { contextual := true })⟩
     simp [ih, or_assoc, this]
 
-lemma not_nil_of_adj_toSubgraph {u v} {x : V} (p : G.Walk u v) (hadj : p.toSubgraph.Adj w x) :
+lemma not_nil_of_adj_toSubgraph {u v} {x : V} {p : G.Walk u v} (hadj : p.toSubgraph.Adj w x) :
     ¬p.Nil := by
   cases p <;> simp_all
 
@@ -189,12 +189,11 @@ theorem toSubgraph_rotate [DecidableEq V] (c : G.Walk v v) (h : u ∈ c.support)
 theorem toSubgraph_map (f : G →g G') (p : G.Walk u v) :
     (p.map f).toSubgraph = p.toSubgraph.map f := by induction p <;> simp [*, Subgraph.map_sup]
 
-@[simp]
 lemma adj_toSubgraph_mapLe {G' : SimpleGraph V} {w x : V} (p : G.Walk u v) (h : G ≤ G') :
-    (p.mapLe h).toSubgraph.Adj w x ↔ p.toSubgraph.Adj w x  := by
-  simp only [Walk.toSubgraph_map, Subgraph.map_adj]
+    (p.mapLe h).toSubgraph.Adj w x ↔ p.toSubgraph.Adj w x := by
+  simp only [toSubgraph_map, Subgraph.map_adj]
   nth_rewrite 1 [← Hom.mapSpanningSubgraphs_apply h w, ← Hom.mapSpanningSubgraphs_apply h x]
-  rw [Relation.map_apply_apply (Hom.mapSpanningSubgraph_inj h) (Hom.mapSpanningSubgraph_inj h)]
+  rw [Relation.map_apply_apply (Hom.mapSpanningSubgraphs_inj h) (Hom.mapSpanningSubgraphs_inj h)]
 
 @[simp]
 theorem finite_neighborSet_toSubgraph (p : G.Walk u v) : (p.toSubgraph.neighborSet w).Finite := by
@@ -381,7 +380,7 @@ lemma ncard_neighborSet_toSubgraph_eq_two {u v} {p : G.Walk u u} (hpc : p.IsCycl
   rw [← hi.1, hpc.neighborSet_toSubgraph_internal he.1 (by omega)]
   exact Set.ncard_pair (hpc.getVert_sub_one_neq_getVert_add_one (by omega))
 
-lemma exists_snd_verts_eq {p : G.Walk v v} (h : p.IsCycle) (hadj : p.toSubgraph.Adj v w) :
+lemma exists_isCycle_snd_verts_eq {p : G.Walk v v} (h : p.IsCycle) (hadj : p.toSubgraph.Adj v w) :
     ∃ (p' : G.Walk v v), p'.IsCycle ∧ p'.snd = w ∧ p'.toSubgraph.verts = p.toSubgraph.verts := by
   have : w ∈ p.toSubgraph.neighborSet v := hadj
   rw [h.neighborSet_toSubgraph_endpoint] at this
@@ -389,8 +388,8 @@ lemma exists_snd_verts_eq {p : G.Walk v v} (h : p.IsCycle) (hadj : p.toSubgraph.
   obtain hl | hr := this
   · exact ⟨p, ⟨h, hl.symm, rfl⟩⟩
   · use p.reverse
-    rw [Walk.penultimate, ← @Walk.getVert_reverse] at hr
-    exact ⟨h.reverse, hr.symm, by rw [SimpleGraph.Walk.toSubgraph_reverse _]⟩
+    rw [penultimate, ← getVert_reverse] at hr
+    exact ⟨h.reverse, hr.symm, by rw [toSubgraph_reverse _]⟩
 
 end IsCycle
 

--- a/Mathlib/Combinatorics/SimpleGraph/Connectivity/Subgraph.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Connectivity/Subgraph.lean
@@ -145,6 +145,10 @@ theorem mem_verts_toSubgraph (p : G.Walk u v) : w ∈ p.toSubgraph.verts ↔ w �
       ⟨by rintro (rfl | h) <;> simp [*], by simp (config := { contextual := true })⟩
     simp [ih, or_assoc, this]
 
+lemma not_nil_of_adj_toSubgraph {u v} {x : V} (p : G.Walk u v) (hadj : p.toSubgraph.Adj w x) :
+    ¬p.Nil := by
+  cases p <;> simp_all
+
 lemma start_mem_verts_toSubgraph (p : G.Walk u v) : u ∈ p.toSubgraph.verts := by
   simp [mem_verts_toSubgraph]
 
@@ -369,6 +373,17 @@ lemma ncard_neighborSet_toSubgraph_eq_two {u v} {p : G.Walk u u} (hpc : p.IsCycl
   push_neg at he
   rw [← hi.1, hpc.neighborSet_toSubgraph_internal he.1 (by omega)]
   exact Set.ncard_pair (hpc.getVert_sub_one_neq_getVert_add_one (by omega))
+
+lemma exists_snd_verts_eq {p : G.Walk v v} (h : p.IsCycle) (hadj : p.toSubgraph.Adj v w) :
+    ∃ (p' : G.Walk v v), p'.IsCycle ∧ p'.snd = w ∧ p'.toSubgraph.verts = p.toSubgraph.verts := by
+  have : w ∈ p.toSubgraph.neighborSet v := hadj
+  rw [h.neighborSet_toSubgraph_endpoint] at this
+  simp only [Set.mem_insert_iff, Set.mem_singleton_iff] at this
+  obtain hl | hr := this
+  · exact ⟨p, ⟨h, hl.symm, rfl⟩⟩
+  · use p.reverse
+    rw [Walk.penultimate, ← @Walk.getVert_reverse] at hr
+    exact ⟨h.reverse, hr.symm, by rw [SimpleGraph.Walk.toSubgraph_reverse _]⟩
 
 end IsCycle
 

--- a/Mathlib/Combinatorics/SimpleGraph/Maps.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Maps.lean
@@ -272,6 +272,11 @@ def mapSpanningSubgraphs {G G' : SimpleGraph V} (h : G ≤ G') : G →g G' where
   toFun x := x
   map_rel' ha := h ha
 
+lemma mapSpanningSubgraph_inj {G G' : SimpleGraph V} (h : G ≤ G') :
+    Function.Injective (Hom.mapSpanningSubgraphs h) := by
+  intro v w hvw
+  simpa [Hom.mapSpanningSubgraphs_apply] using hvw
+
 theorem mapEdgeSet.injective (hinj : Function.Injective f) : Function.Injective f.mapEdgeSet := by
   rintro ⟨e₁, h₁⟩ ⟨e₂, h₂⟩
   dsimp [Hom.mapEdgeSet]

--- a/Mathlib/Combinatorics/SimpleGraph/Maps.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Maps.lean
@@ -272,6 +272,9 @@ def mapSpanningSubgraphs {G G' : SimpleGraph V} (h : G ≤ G') : G →g G' where
   toFun x := x
   map_rel' ha := h ha
 
+lemma mapSpanningSubgraphs_inj {G G' : SimpleGraph V} {v w : V} (h : G ≤ G') :
+    (mapSpanningSubgraphs h) v = (mapSpanningSubgraphs h) w ↔ v = w := by simp
+
 lemma mapSpanningSubgraphs_injective {G G' : SimpleGraph V} (h : G ≤ G') :
     Injective (mapSpanningSubgraphs h) :=
   fun v w hvw ↦ by simpa [mapSpanningSubgraphs_apply] using hvw

--- a/Mathlib/Combinatorics/SimpleGraph/Maps.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Maps.lean
@@ -272,7 +272,7 @@ def mapSpanningSubgraphs {G G' : SimpleGraph V} (h : G ≤ G') : G →g G' where
   toFun x := x
   map_rel' ha := h ha
 
-lemma mapSpanningSubgraphs_inj {G G' : SimpleGraph V} (h : G ≤ G') :
+lemma mapSpanningSubgraphs_injective {G G' : SimpleGraph V} (h : G ≤ G') :
     Injective (mapSpanningSubgraphs h) :=
   fun v w hvw ↦ by simpa [mapSpanningSubgraphs_apply] using hvw
 

--- a/Mathlib/Combinatorics/SimpleGraph/Maps.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Maps.lean
@@ -273,7 +273,7 @@ def mapSpanningSubgraphs {G G' : SimpleGraph V} (h : G ≤ G') : G →g G' where
   map_rel' ha := h ha
 
 lemma mapSpanningSubgraphs_inj {G G' : SimpleGraph V} {v w : V} (h : G ≤ G') :
-    (mapSpanningSubgraphs h) v = (mapSpanningSubgraphs h) w ↔ v = w := by simp
+    mapSpanningSubgraphs h v = mapSpanningSubgraphs h w ↔ v = w := by simp
 
 lemma mapSpanningSubgraphs_injective {G G' : SimpleGraph V} (h : G ≤ G') :
     Injective (mapSpanningSubgraphs h) :=

--- a/Mathlib/Combinatorics/SimpleGraph/Maps.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Maps.lean
@@ -272,10 +272,9 @@ def mapSpanningSubgraphs {G G' : SimpleGraph V} (h : G ≤ G') : G →g G' where
   toFun x := x
   map_rel' ha := h ha
 
-lemma mapSpanningSubgraph_inj {G G' : SimpleGraph V} (h : G ≤ G') :
-    Function.Injective (Hom.mapSpanningSubgraphs h) := by
-  intro v w hvw
-  simpa [Hom.mapSpanningSubgraphs_apply] using hvw
+lemma mapSpanningSubgraphs_inj {G G' : SimpleGraph V} (h : G ≤ G') :
+    Injective (mapSpanningSubgraphs h) :=
+  fun v w hvw ↦ by simpa [mapSpanningSubgraphs_apply] using hvw
 
 theorem mapEdgeSet.injective (hinj : Function.Injective f) : Function.Injective f.mapEdgeSet := by
   rintro ⟨e₁, h₁⟩ ⟨e₂, h₂⟩

--- a/Mathlib/Combinatorics/SimpleGraph/Matching.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Matching.lean
@@ -97,7 +97,7 @@ lemma IsMatching.not_adj_left_of_ne {M : Subgraph G} {u v w : V} (hM : M.IsMatch
   exact huv (hx.2 _ hadj ▸ (hx.2 _ hadj').symm)
 
 lemma IsMatching.not_adj_rigth_of_ne {M : Subgraph G} {u v w : V} (hM : M.IsMatching) (huw : u ≠ w)
-    (hadj : M.Adj u v) : ¬M.Adj w v  := 
+    (hadj : M.Adj u v) : ¬M.Adj w v  :=
   fun hadj' ↦ hM.not_adj_left_of_ne huw hadj.symm hadj'.symm
 
 lemma IsMatching.sup (hM : M.IsMatching) (hM' : M'.IsMatching)

--- a/Mathlib/Combinatorics/SimpleGraph/Matching.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Matching.lean
@@ -90,7 +90,7 @@ lemma IsMatching.map_ofLE (h : M.IsMatching) (hGG' : G ≤ G') :
   use w
   simpa using hv' ▸ hw
 
-lemma IsMatching.not_adj_of_ne {M : Subgraph G} {u v w : V} (hM : M.IsMatching) (huv : v ≠ w)
+lemma IsMatching.not_adj_left_of_ne {M : Subgraph G} {u v w : V} (hM : M.IsMatching) (huv : v ≠ w)
     (hadj : M.Adj u v) : ¬M.Adj u w := by
   intro hadj'
   obtain ⟨x, hx⟩ := hM (M.edge_vert hadj)

--- a/Mathlib/Combinatorics/SimpleGraph/Matching.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Matching.lean
@@ -96,7 +96,7 @@ lemma IsMatching.not_adj_left_of_ne {M : Subgraph G} {u v w : V} (hM : M.IsMatch
   obtain ⟨x, hx⟩ := hM (M.edge_vert hadj)
   exact huv (hx.2 _ hadj ▸ (hx.2 _ hadj').symm)
 
-lemma IsMatching.not_adj_rigth_of_ne {M : Subgraph G} {u v w : V} (hM : M.IsMatching) (huw : u ≠ w)
+lemma IsMatching.not_adj_right_of_ne {M : Subgraph G} {u v w : V} (hM : M.IsMatching) (huw : u ≠ w)
     (hadj : M.Adj u v) : ¬M.Adj w v  :=
   fun hadj' ↦ hM.not_adj_left_of_ne huw hadj.symm hadj'.symm
 

--- a/Mathlib/Combinatorics/SimpleGraph/Matching.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Matching.lean
@@ -96,6 +96,10 @@ lemma IsMatching.not_adj_left_of_ne {M : Subgraph G} {u v w : V} (hM : M.IsMatch
   obtain ⟨x, hx⟩ := hM (M.edge_vert hadj)
   exact huv (hx.2 _ hadj ▸ (hx.2 _ hadj').symm)
 
+lemma IsMatching.not_adj_rigth_of_ne {M : Subgraph G} {u v w : V} (hM : M.IsMatching) (huw : u ≠ w)
+    (hadj : M.Adj u v) : ¬M.Adj w v  := 
+  fun hadj' ↦ hM.not_adj_left_of_ne huw hadj.symm hadj'.symm
+
 lemma IsMatching.sup (hM : M.IsMatching) (hM' : M'.IsMatching)
     (hd : Disjoint M.support M'.support) : (M ⊔ M').IsMatching := by
   intro v hv

--- a/Mathlib/Combinatorics/SimpleGraph/Matching.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Matching.lean
@@ -6,6 +6,7 @@ Authors: Alena Gusakov, Arthur Paulino, Kyle Miller, Pim Otte
 import Mathlib.Combinatorics.SimpleGraph.Connectivity.Subgraph
 import Mathlib.Combinatorics.SimpleGraph.Connectivity.WalkCounting
 import Mathlib.Combinatorics.SimpleGraph.DegreeSum
+import Mathlib.Combinatorics.SimpleGraph.Operations
 import Mathlib.Data.Fintype.Order
 import Mathlib.Data.Set.Functor
 
@@ -88,6 +89,12 @@ lemma IsMatching.map_ofLE (h : M.IsMatching) (hGG' : G ≤ G') :
   obtain ⟨w, hw⟩ := h hv
   use w
   simpa using hv' ▸ hw
+
+lemma IsMatching.not_adj_of_ne {M : Subgraph G} {u v w : V} (hM : M.IsMatching) (huv : v ≠ w)
+    (hadj : M.Adj u v) : ¬ M.Adj u w := by
+  intro hadj'
+  obtain ⟨x, hx⟩ := hM (M.edge_vert hadj)
+  exact huv (hx.2 _ hadj ▸ (hx.2 _ hadj').symm)
 
 lemma IsMatching.sup (hM : M.IsMatching) (hM' : M'.IsMatching)
     (hd : Disjoint M.support M'.support) : (M ⊔ M').IsMatching := by
@@ -354,6 +361,25 @@ lemma IsCycles.induce_supp (c : G.ConnectedComponent) (h : G.IsCycles) :
   ext w'
   simp only [mem_neighborSet, c.adj_spanningCoe_induce_supp, hw, true_and]
 
+lemma IsCycle.IsCycles_toSubgraph_spanningCoe {u : V} {p : G.Walk u u} (hpc : p.IsCycle) :
+    p.toSubgraph.spanningCoe.IsCycles := by
+  intro v hv
+  apply hpc.ncard_neighborSet_toSubgraph_eq_two
+  obtain ⟨_, hw⟩ := hv
+  exact p.mem_verts_toSubgraph.mp <| p.toSubgraph.edge_vert hw
+
+lemma Walk.IsCycle.toSubgraph_adj_iff_of_isCycles [Finite V] {u} {p : G.Walk u u} (hp : p.IsCycle)
+    (hcyc : G.IsCycles) (hv : v ∈ p.toSubgraph.verts) : ∀ w, p.toSubgraph.Adj v w ↔ G.Adj v w := by
+  refine fun w ↦ Subgraph.adj_iff_of_neighborSet_equiv
+    (?_ : Inhabited ((G.neighborSet v) ≃ (p.toSubgraph.neighborSet v))).default (Set.toFinite _)
+  apply Classical.inhabited_of_nonempty
+  have h := Set.Nonempty.mono (p.toSubgraph.neighborSet_subset v) <|
+           Set.nonempty_of_ncard_ne_zero <| by simp [Set.Nonempty.mono,
+            hp.ncard_neighborSet_toSubgraph_eq_two (by aesop), Set.nonempty_of_ncard_ne_zero]
+  rw [← Cardinal.eq, ← Set.cast_ncard (Set.toFinite _), ← Set.cast_ncard (Set.toFinite _),
+        hcyc h, hp.ncard_neighborSet_toSubgraph_eq_two (by aesop)]
+
+
 open scoped symmDiff
 
 lemma Subgraph.IsPerfectMatching.symmDiff_isCycles
@@ -489,6 +515,35 @@ def IsAlternating (G G' : SimpleGraph V) :=
 
 lemma IsAlternating.mono {G'' : SimpleGraph V} (halt : G.IsAlternating G') (h : G'' ≤ G) :
     G''.IsAlternating G' := fun _ _ _ hww' hvw hvw' ↦ halt hww' (h hvw) (h hvw')
+
+lemma IsAlternating.spanningCoe (H : Subgraph G) (halt : G.IsAlternating G') :
+    H.spanningCoe.IsAlternating G' := by
+  intro v w w' hww' hvw hvv'
+  simp only [Subgraph.spanningCoe_adj] at hvw hvv'
+  exact halt hww' hvw.adj_sub hvv'.adj_sub
+
+lemma IsAlternating.sup_edge {u x : V} (halt : G.IsAlternating G') (hnadj : ¬G'.Adj u x)
+    (hu' : ∀ u', u' ≠ u → G.Adj x u' → G'.Adj x u')
+    (hx' : ∀ x', x' ≠ x → G.Adj x' u → G'.Adj x' u) : (G ⊔ edge u x).IsAlternating G' := by
+  by_cases hadj : G.Adj u x
+  · rwa [sup_edge_of_adj G hadj]
+  intro v w w' hww' hvw hvv'
+  simp only [sup_adj, edge_adj] at hvw hvv'
+  obtain hl | hr := hvw <;> obtain h1 | h2 := hvv'
+  · exact halt hww' hl h1
+  · rw [G'.adj_congr_of_sym2 (by aesop : s(v, w') = s(u, x))]
+    simp only [hnadj, not_false_eq_true, iff_true]
+    rcases h2.1 with (⟨h2l1, h2l2⟩| ⟨h2r1, h2r2⟩)
+    · subst h2l1 h2l2
+      exact (hx' _ hww' hl.symm).symm
+    · aesop
+  · rw [G'.adj_congr_of_sym2 (by aesop : s(v, w) = s(u, x))]
+    simp only [hnadj, false_iff, not_not]
+    rcases hr.1 with (⟨hrl1, hrl2⟩| ⟨hrr1, hrr2⟩)
+    · subst hrl1 hrl2
+      exact (hx' _ hww'.symm h1.symm).symm
+    · aesop
+  · aesop
 
 lemma IsPerfectMatching.symmDiff_of_isAlternating (hM : M.IsPerfectMatching)
     (hG' : G'.IsAlternating M.spanningCoe) (hG'cyc : G'.IsCycles) :

--- a/Mathlib/Combinatorics/SimpleGraph/Matching.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Matching.lean
@@ -91,7 +91,7 @@ lemma IsMatching.map_ofLE (h : M.IsMatching) (hGG' : G ≤ G') :
   simpa using hv' ▸ hw
 
 lemma IsMatching.not_adj_of_ne {M : Subgraph G} {u v w : V} (hM : M.IsMatching) (huv : v ≠ w)
-    (hadj : M.Adj u v) : ¬ M.Adj u w := by
+    (hadj : M.Adj u v) : ¬M.Adj u w := by
   intro hadj'
   obtain ⟨x, hx⟩ := hM (M.edge_vert hadj)
   exact huv (hx.2 _ hadj ▸ (hx.2 _ hadj').symm)
@@ -361,34 +361,34 @@ lemma IsCycles.induce_supp (c : G.ConnectedComponent) (h : G.IsCycles) :
   ext w'
   simp only [mem_neighborSet, c.adj_spanningCoe_induce_supp, hw, true_and]
 
-lemma IsCycle.isCycles_toSubgraph_spanningCoe {u : V} {p : G.Walk u u} (hpc : p.IsCycle) :
+lemma Walk.IsCycle.isCycles_spanningCoe_toSubgraph {u : V} {p : G.Walk u u} (hpc : p.IsCycle) :
     p.toSubgraph.spanningCoe.IsCycles := by
   intro v hv
   apply hpc.ncard_neighborSet_toSubgraph_eq_two
   obtain ⟨_, hw⟩ := hv
   exact p.mem_verts_toSubgraph.mp <| p.toSubgraph.edge_vert hw
 
-lemma Walk.IsPath.isCycles_toSubgraph_sup_edge {u v} {p : G.Walk u v} (hp : p.IsPath) (h : u ≠ v)
-    (hs : s(v, u) ∉ p.edges) : (p.toSubgraph.spanningCoe ⊔ edge v u).IsCycles := by
-  let c := Walk.cons (by simp [h.symm] : (completeGraph V).Adj v u) (p.mapLe (OrderTop.le_top G))
+lemma Walk.IsPath.isCycles_spanningCoe_toSubgraph_sup_edge {u v} {p : G.Walk u v} (hp : p.IsPath)
+    (h : u ≠ v) (hs : s(v, u) ∉ p.edges) : (p.toSubgraph.spanningCoe ⊔ edge v u).IsCycles := by
+  let c := (p.mapLe (OrderTop.le_top G)).cons (by simp [h.symm] : (completeGraph V).Adj v u)
   have : p.toSubgraph.spanningCoe ⊔ edge v u = c.toSubgraph.spanningCoe := by
     ext w x
     simp only [sup_adj, Subgraph.spanningCoe_adj, completeGraph_eq_top, edge_adj, c,
-      SimpleGraph.Walk.toSubgraph.eq_2, Subgraph.sup_adj, subgraphOfAdj_adj,
-      Walk.adj_toSubgraph_mapLe]
+      Walk.toSubgraph, Subgraph.sup_adj, subgraphOfAdj_adj, adj_toSubgraph_mapLe]
     aesop
-  exact this ▸ IsCycle.isCycles_toSubgraph_spanningCoe (by simp [Walk.cons_isCycle_iff, c, hp, hs])
+  exact this ▸ IsCycle.isCycles_spanningCoe_toSubgraph (by simp [Walk.cons_isCycle_iff, c, hp, hs])
 
-lemma Walk.IsCycle.toSubgraph_adj_iff_of_isCycles [Finite V] {u} {p : G.Walk u u} (hp : p.IsCycle)
-    (hcyc : G.IsCycles) (hv : v ∈ p.toSubgraph.verts) : ∀ w, p.toSubgraph.Adj v w ↔ G.Adj v w := by
-  refine fun w ↦ Subgraph.adj_iff_of_neighborSet_equiv
-    (?_ : Inhabited ((G.neighborSet v) ≃ (p.toSubgraph.neighborSet v))).default (Set.toFinite _)
+lemma Walk.IsCycle.adj_toSubgraph_iff_of_isCycles [LocallyFinite G] {u} {p : G.Walk u u}
+    (hp : p.IsCycle) (hcyc : G.IsCycles) (hv : v ∈ p.toSubgraph.verts) :
+    ∀ w, p.toSubgraph.Adj v w ↔ G.Adj v w := by
+  refine fun w ↦ Subgraph.adj_iff_of_neighborSet_equiv (?_ : Inhabited _).default (Set.toFinite _)
   apply Classical.inhabited_of_nonempty
-  have h := Set.Nonempty.mono (p.toSubgraph.neighborSet_subset v) <|
-           Set.nonempty_of_ncard_ne_zero <| by simp [Set.Nonempty.mono,
-            hp.ncard_neighborSet_toSubgraph_eq_two (by aesop), Set.nonempty_of_ncard_ne_zero]
-  rw [← Cardinal.eq, ← Set.cast_ncard (Set.toFinite _), ← Set.cast_ncard (Set.toFinite _),
-        hcyc h, hp.ncard_neighborSet_toSubgraph_eq_two (by aesop)]
+  rw [← Cardinal.eq, ← Set.cast_ncard (Set.toFinite _),
+      ← Set.cast_ncard (finite_neighborSet_toSubgraph p), hcyc
+        (Set.Nonempty.mono (p.toSubgraph.neighborSet_subset v) <|
+          Set.nonempty_of_ncard_ne_zero <| by simp [Set.Nonempty.mono,
+          hp.ncard_neighborSet_toSubgraph_eq_two (by aesop), Set.nonempty_of_ncard_ne_zero]),
+      hp.ncard_neighborSet_toSubgraph_eq_two (by aesop)]
 
 open scoped symmDiff
 
@@ -526,7 +526,7 @@ def IsAlternating (G G' : SimpleGraph V) :=
 lemma IsAlternating.mono {G'' : SimpleGraph V} (halt : G.IsAlternating G') (h : G'' ≤ G) :
     G''.IsAlternating G' := fun _ _ _ hww' hvw hvw' ↦ halt hww' (h hvw) (h hvw')
 
-lemma IsAlternating.spanningCoe (H : Subgraph G) (halt : G.IsAlternating G') :
+lemma IsAlternating.spanningCoe (halt : G.IsAlternating G') (H : Subgraph G)  :
     H.spanningCoe.IsAlternating G' := by
   intro v w w' hww' hvw hvv'
   simp only [Subgraph.spanningCoe_adj] at hvw hvv'
@@ -543,13 +543,13 @@ lemma IsAlternating.sup_edge {u x : V} (halt : G.IsAlternating G') (hnadj : ¬G'
   · exact halt hww' hl h1
   · rw [G'.adj_congr_of_sym2 (by aesop : s(v, w') = s(u, x))]
     simp only [hnadj, not_false_eq_true, iff_true]
-    rcases h2.1 with (⟨h2l1, h2l2⟩| ⟨h2r1, h2r2⟩)
+    rcases h2.1 with ⟨h2l1, h2l2⟩ | ⟨h2r1,h2r2⟩
     · subst h2l1 h2l2
       exact (hx' _ hww' hl.symm).symm
     · aesop
   · rw [G'.adj_congr_of_sym2 (by aesop : s(v, w) = s(u, x))]
     simp only [hnadj, false_iff, not_not]
-    rcases hr.1 with (⟨hrl1, hrl2⟩| ⟨hrr1, hrr2⟩)
+    rcases hr.1 with ⟨hrl1, hrl2⟩ | ⟨hrr1, hrr2⟩
     · subst hrl1 hrl2
       exact (hx' _ hww'.symm h1.symm).symm
     · aesop

--- a/Mathlib/Combinatorics/SimpleGraph/Matching.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Matching.lean
@@ -361,12 +361,23 @@ lemma IsCycles.induce_supp (c : G.ConnectedComponent) (h : G.IsCycles) :
   ext w'
   simp only [mem_neighborSet, c.adj_spanningCoe_induce_supp, hw, true_and]
 
-lemma IsCycle.IsCycles_toSubgraph_spanningCoe {u : V} {p : G.Walk u u} (hpc : p.IsCycle) :
+lemma IsCycle.isCycles_toSubgraph_spanningCoe {u : V} {p : G.Walk u u} (hpc : p.IsCycle) :
     p.toSubgraph.spanningCoe.IsCycles := by
   intro v hv
   apply hpc.ncard_neighborSet_toSubgraph_eq_two
   obtain ⟨_, hw⟩ := hv
   exact p.mem_verts_toSubgraph.mp <| p.toSubgraph.edge_vert hw
+
+lemma Walk.IsPath.isCycles_toSubgraph_sup_edge {u v} {p : G.Walk u v} (hp : p.IsPath) (h : u ≠ v)
+    (hs : s(v, u) ∉ p.edges) : (p.toSubgraph.spanningCoe ⊔ edge v u).IsCycles := by
+  let c := Walk.cons (by simp [h.symm] : (completeGraph V).Adj v u) (p.mapLe (OrderTop.le_top G))
+  have : p.toSubgraph.spanningCoe ⊔ edge v u = c.toSubgraph.spanningCoe := by
+    ext w x
+    simp only [sup_adj, Subgraph.spanningCoe_adj, completeGraph_eq_top, edge_adj, c,
+      SimpleGraph.Walk.toSubgraph.eq_2, Subgraph.sup_adj, subgraphOfAdj_adj,
+      Walk.adj_toSubgraph_mapLe]
+    aesop
+  exact this ▸ IsCycle.isCycles_toSubgraph_spanningCoe (by simp [Walk.cons_isCycle_iff, c, hp, hs])
 
 lemma Walk.IsCycle.toSubgraph_adj_iff_of_isCycles [Finite V] {u} {p : G.Walk u u} (hp : p.IsCycle)
     (hcyc : G.IsCycles) (hv : v ∈ p.toSubgraph.verts) : ∀ w, p.toSubgraph.Adj v w ↔ G.Adj v w := by
@@ -378,7 +389,6 @@ lemma Walk.IsCycle.toSubgraph_adj_iff_of_isCycles [Finite V] {u} {p : G.Walk u u
             hp.ncard_neighborSet_toSubgraph_eq_two (by aesop), Set.nonempty_of_ncard_ne_zero]
   rw [← Cardinal.eq, ← Set.cast_ncard (Set.toFinite _), ← Set.cast_ncard (Set.toFinite _),
         hcyc h, hp.ncard_neighborSet_toSubgraph_eq_two (by aesop)]
-
 
 open scoped symmDiff
 

--- a/Mathlib/Combinatorics/SimpleGraph/Operations.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Operations.lean
@@ -180,7 +180,7 @@ lemma sup_edge_of_adj (h : G.Adj s t) : G ⊔ edge s t = G := by
   rwa [sup_eq_left, ← edgeSet_subset_edgeSet, edge_edgeSet_of_ne h.ne, Set.singleton_subset_iff,
     mem_edgeSet]
 
-lemma disjoint_edge {u v : V} (h : u ≠ v): Disjoint G (edge u v) ↔ ¬G.Adj u v := by
+lemma disjoint_edge {u v : V} (h : u ≠ v) : Disjoint G (edge u v) ↔ ¬G.Adj u v := by
   simp [← disjoint_edgeSet, edge_edgeSet_of_ne h]
 
 lemma sdiff_edge {u v : V} (h : ¬G.Adj u v) : G \ edge u v = G := by

--- a/Mathlib/Combinatorics/SimpleGraph/Operations.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Operations.lean
@@ -180,14 +180,14 @@ lemma sup_edge_of_adj (h : G.Adj s t) : G ⊔ edge s t = G := by
   rwa [sup_eq_left, ← edgeSet_subset_edgeSet, edge_edgeSet_of_ne h.ne, Set.singleton_subset_iff,
     mem_edgeSet]
 
-lemma disjoint_edge {u v : V} (h : u ≠ v) : Disjoint G (edge u v) ↔ ¬G.Adj u v := by
+lemma disjoint_edge {u v : V} : Disjoint G (edge u v) ↔ ¬G.Adj u v := by
+  by_cases h : u = v
+  · subst h
+    simp [edge_self_eq_bot]
   simp [← disjoint_edgeSet, edge_edgeSet_of_ne h]
 
 lemma sdiff_edge {u v : V} (h : ¬G.Adj u v) : G \ edge u v = G := by
-  by_cases huv : u = v
-  · subst huv
-    simp [edge_self_eq_bot]
-  · simp [disjoint_edge _ huv, h]
+  simp [disjoint_edge, h]
 
 theorem Subgraph.spanningCoe_sup_edge_le {H : Subgraph (G ⊔ edge s t)} (h : ¬ H.Adj s t) :
     H.spanningCoe ≤ G := by

--- a/Mathlib/Combinatorics/SimpleGraph/Operations.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Operations.lean
@@ -148,6 +148,11 @@ def edge : SimpleGraph V := fromEdgeSet {s(s, t)}
 lemma edge_adj (v w : V) : (edge s t).Adj v w ↔ (v = s ∧ w = t ∨ v = t ∧ w = s) ∧ v ≠ w := by
   rw [edge, fromEdgeSet_adj, Set.mem_singleton_iff, Sym2.eq_iff]
 
+lemma edge_adj_iff {v w : V} : (edge s t).Adj v w ↔ (s(s, t) = s(v, w) ∧ (v ≠ w)) := by
+  simp only [edge_adj, ne_eq, Sym2.eq, Sym2.rel_iff', Prod.mk.injEq, Prod.swap_prod_mk,
+    and_congr_left_iff]
+  tauto
+
 lemma edge_comm : edge s t = edge t s := by
   rw [edge, edge, Sym2.eq_swap]
 
@@ -174,6 +179,15 @@ lemma edge_edgeSet_of_ne (h : s ≠ t) : (edge s t).edgeSet = {s(s, t)} := by
 lemma sup_edge_of_adj (h : G.Adj s t) : G ⊔ edge s t = G := by
   rwa [sup_eq_left, ← edgeSet_subset_edgeSet, edge_edgeSet_of_ne h.ne, Set.singleton_subset_iff,
     mem_edgeSet]
+
+lemma disjoint_edge {u v : V} (h : u ≠ v): Disjoint G (edge u v) ↔ ¬G.Adj u v := by
+  simp [← disjoint_edgeSet, edge_edgeSet_of_ne h]
+
+lemma sdiff_edge {u v : V} (h : ¬G.Adj u v) : G \ edge u v = G := by
+  by_cases huv : u = v
+  · subst huv
+    simp [edge_self_eq_bot]
+  · simp [disjoint_edge _ huv, h]
 
 theorem Subgraph.spanningCoe_sup_edge_le {H : Subgraph (G ⊔ edge s t)} (h : ¬ H.Adj s t) :
     H.spanningCoe ≤ G := by

--- a/Mathlib/Combinatorics/SimpleGraph/Operations.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Operations.lean
@@ -148,7 +148,7 @@ def edge : SimpleGraph V := fromEdgeSet {s(s, t)}
 lemma edge_adj (v w : V) : (edge s t).Adj v w ↔ (v = s ∧ w = t ∨ v = t ∧ w = s) ∧ v ≠ w := by
   rw [edge, fromEdgeSet_adj, Set.mem_singleton_iff, Sym2.eq_iff]
 
-lemma edge_adj_iff {v w : V} : (edge s t).Adj v w ↔ (s(s, t) = s(v, w) ∧ (v ≠ w)) := by
+lemma adj_edge {v w : V} : (edge s t).Adj v w ↔ s(s, t) = s(v, w) ∧ v ≠ w := by
   simp only [edge_adj, ne_eq, Sym2.eq, Sym2.rel_iff', Prod.mk.injEq, Prod.swap_prod_mk,
     and_congr_left_iff]
   tauto

--- a/Mathlib/Combinatorics/SimpleGraph/Path.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Path.lean
@@ -304,6 +304,44 @@ lemma IsPath.getVert_injOn {p : G.Walk u v} (hp : p.IsPath) :
         (by omega : (m - 1) ≤ p.length) hnm
       omega
 
+lemma IsPath.getVert_start_iff {i : ℕ} {p : G.Walk u w} (hp : p.IsPath) (hi : i ≤ p.length) :
+    p.getVert i = u ↔ i = 0 := by
+  refine ⟨?_, by aesop⟩
+  intro h
+  by_cases hi : i = 0
+  · exact hi
+  · apply hp.getVert_injOn (by rw [Set.mem_setOf]; omega) (by rw [Set.mem_setOf]; omega)
+    simp [h]
+
+lemma IsPath.getVert_end_iff {i : ℕ} {p : G.Walk u w} (hp : p.IsPath) (hi : i ≤ p.length) :
+    p.getVert i = w ↔ i = p.length := by
+  have := hp.reverse.getVert_start_iff (by omega : p.reverse.length - i ≤ p.reverse.length)
+  simp only [length_reverse, getVert_reverse,
+    show p.length - (p.length - i) = i from by omega] at this
+  rw [this]
+  omega
+
+lemma IsPath.getVert_injOn_iff (p : G.Walk u v): Set.InjOn p.getVert {i | i ≤ p.length} ↔
+    p.IsPath := by
+  refine ⟨?_, fun a => a.getVert_injOn⟩
+  induction p with
+  | nil => simp
+  | cons h q ih =>
+    intro hinj
+    rw [cons_isPath_iff]
+    refine ⟨ih (by
+      intro n hn m hm hnm
+      simp only [Set.mem_setOf_eq] at hn hm
+      have := hinj (by rw [length_cons]; omega : n + 1 ≤ (q.cons h).length)
+          (by rw [length_cons]; omega : m + 1 ≤ (q.cons h).length)
+          (by simpa [getVert_cons] using hnm)
+      omega), fun h' => ?_⟩
+    obtain ⟨n, ⟨hn, hnl⟩⟩ := mem_support_iff_exists_getVert.mp h'
+    have := hinj (by rw [length_cons]; omega : (n + 1) ≤ (q.cons h).length)
+      (by omega : 0 ≤ (q.cons h).length) (show (q.cons h).getVert (n + 1) = (q.cons h).getVert 0
+        from by rwa [getVert_cons _ _ (by omega : n + 1 ≠ 0), getVert_zero])
+    omega
+
 /-! ### About cycles -/
 
 -- TODO: These results could possibly be less laborious with a periodic function getCycleVert

--- a/Mathlib/Combinatorics/SimpleGraph/Path.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Path.lean
@@ -304,7 +304,7 @@ lemma IsPath.getVert_injOn {p : G.Walk u v} (hp : p.IsPath) :
         (by omega : (m - 1) ≤ p.length) hnm
       omega
 
-lemma IsPath.getVert_start_iff {i : ℕ} {p : G.Walk u w} (hp : p.IsPath) (hi : i ≤ p.length) :
+lemma IsPath.getVert_eq_start_iff {i : ℕ} {p : G.Walk u w} (hp : p.IsPath) (hi : i ≤ p.length) :
     p.getVert i = u ↔ i = 0 := by
   refine ⟨?_, by aesop⟩
   intro h
@@ -313,15 +313,15 @@ lemma IsPath.getVert_start_iff {i : ℕ} {p : G.Walk u w} (hp : p.IsPath) (hi : 
   · apply hp.getVert_injOn (by rw [Set.mem_setOf]; omega) (by rw [Set.mem_setOf]; omega)
     simp [h]
 
-lemma IsPath.getVert_end_iff {i : ℕ} {p : G.Walk u w} (hp : p.IsPath) (hi : i ≤ p.length) :
+lemma IsPath.getVert_eq_end_iff {i : ℕ} {p : G.Walk u w} (hp : p.IsPath) (hi : i ≤ p.length) :
     p.getVert i = w ↔ i = p.length := by
-  have := hp.reverse.getVert_start_iff (by omega : p.reverse.length - i ≤ p.reverse.length)
+  have := hp.reverse.getVert_eq_start_iff (by omega : p.reverse.length - i ≤ p.reverse.length)
   simp only [length_reverse, getVert_reverse,
     show p.length - (p.length - i) = i from by omega] at this
   rw [this]
   omega
 
-lemma IsPath.getVert_injOn_iff (p : G.Walk u v): Set.InjOn p.getVert {i | i ≤ p.length} ↔
+lemma IsPath.getVert_injOn_iff (p : G.Walk u v) : Set.InjOn p.getVert {i | i ≤ p.length} ↔
     p.IsPath := by
   refine ⟨?_, fun a => a.getVert_injOn⟩
   induction p with


### PR DESCRIPTION
Adds a number of miscellaneous lemmas, mostly on paths and edges, in preparation for Tutte's theorem.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

[Zulip thread on Tutte's](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Tutte's.20theorem)
[Context](https://github.com/pimotte/TutteLean/blob/43501417b0aa127b13efdea0473cb91de000cf21/TutteLean/Part2.lean#L77) (Lemma's with "In path_edge" as a comment are in this PR, possibly slightly modified).

I acknowledge this is a little bit of a hodgepodge of results, if there's any that look funky or are perhaps not as useful as I think they are, I'm happy to cut them out and include them in the PR where they are used.