### PR TITLE
issues with Finset subtype coercion

### DIFF
--- a/Mathlib/Data/Finset/Defs.lean
+++ b/Mathlib/Data/Finset/Defs.lean
@@ -156,6 +156,12 @@ theorem coe_injective {α} : Injective ((↑) : Finset α → Set α) := fun _s 
 /-! ### type coercion -/
 
 
+@[coe, reducible] def Elem {α : Type u} (s : Finset α) : Type u := { x // x ∈ s}
+
+/-- Coercion from a finset to the corresponding subtype. -/
+instance {α : Type u} : CoeSort (Finset α) (Type u) :=
+  ⟨Elem⟩
+
 /-- Coercion from a finset to the corresponding subtype. -/
 instance {α : Type u} : CoeSort (Finset α) (Type u) :=
   ⟨fun s => { x // x ∈ s }⟩

--- a/Mathlib/MeasureTheory/Constructions/Projective.lean
+++ b/Mathlib/MeasureTheory/Constructions/Projective.lean
@@ -61,7 +61,7 @@ lemma measure_univ_eq_of_subset (hP : IsProjectiveMeasureFamily P) (hJI : J ⊆ 
     P I univ = P J univ := by
   classical
   have : (univ : Set (∀ i : I, α i)) =
-      Finset.restrict₂ hJI ⁻¹' (univ : Set (∀ i : J, α i)) := by
+      Set.restrict₂ hJI ⁻¹' (univ : Set (∀ i : J, α i)) := by
     rw [preimage_univ]
   rw [this, ← Measure.map_apply _ MeasurableSet.univ]
   · rw [hP I J hJI]


### PR DESCRIPTION
[Zulip discussion](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Finset.20subtype.20changes)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
