### PR TITLE
[Merged by Bors] - feat(Data/Matroid/Loop): matroid loops

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2883,6 +2883,7 @@ import Mathlib.Data.Matroid.Constructions
 import Mathlib.Data.Matroid.Dual
 import Mathlib.Data.Matroid.IndepAxioms
 import Mathlib.Data.Matroid.Init
+import Mathlib.Data.Matroid.Loop
 import Mathlib.Data.Matroid.Map
 import Mathlib.Data.Matroid.Rank.Cardinal
 import Mathlib.Data.Matroid.Rank.Finite

--- a/Mathlib/Data/Matroid/Constructions.lean
+++ b/Mathlib/Data/Matroid/Constructions.lean
@@ -81,7 +81,8 @@ end EmptyOn
 
 section LoopyOn
 
-/-- The `Matroid α` with ground set `E` whose only base is `∅` -/
+/-- The `Matroid α` with ground set `E` whose only base is `∅`.
+The elements are all 'loops' - see `Matroid.IsLoop` and `Matroid.loopyOn_isLoop_iff`. -/
 def loopyOn (E : Set α) : Matroid α := emptyOn α ↾ E
 
 @[simp] theorem loopyOn_ground (E : Set α) : (loopyOn E).E = E := rfl

--- a/Mathlib/Data/Matroid/Loop.lean
+++ b/Mathlib/Data/Matroid/Loop.lean
@@ -169,9 +169,8 @@ lemma IsLoop.of_isRestriction (he : N.IsLoop e) (hNM : N ≤r M) : M.IsLoop e :=
 lemma IsLoop.isLoop_isRestriction (he : M.IsLoop e) (hNM : N ≤r M) (heN : e ∈ N.E) : N.IsLoop e :=
   (hNM.isLoop_iff).2 ⟨heN, he⟩
 
-@[simp]
 lemma map_loops {f : α → β} {hf : InjOn f M.E} : (M.map f hf).loops = f '' M.loops := by
-  rw [loops, map_closure_eq, preimage_empty]
+  simp
 
 @[simp]
 lemma map_isLoop_iff {f : α → β} {hf : InjOn f M.E} (he : e ∈ M.E := by aesop_mat) :
@@ -182,7 +181,6 @@ lemma map_isLoop_iff {f : α → β} {hf : InjOn f M.E} (he : e ∈ M.E := by ae
 lemma mapEmbedding_isLoop_iff {f : α ↪ β} : (M.mapEmbedding f).IsLoop (f e) ↔ M.IsLoop e := by
   simp [mapEmbedding, isLoop_iff, isLoop_iff, map_closure_eq, preimage_empty]
 
-@[simp]
 lemma comap_loops {M : Matroid β} {f : α → β} : (M.comap f).loops = f ⁻¹' M.loops := by
    rw [loops, comap_closure_eq, image_empty]
 

--- a/Mathlib/Data/Matroid/Loop.lean
+++ b/Mathlib/Data/Matroid/Loop.lean
@@ -18,9 +18,11 @@ and for graphic matroids, they correspond to edges incident with just one vertex
 As trivial as they are, loops can be created from matroids with no loops by taking minors or duals,
 so in many contexts it is unreasonable to simply forbid loops from appearing.
 This file defines loops, and provides API for interacting with them.
+
 # Main Declarations
 * For `M : Matroid α` and `e : α`, `M.IsLoop e` means that `e` is a loop of `M`,
   defined as the statement `e ∈ M.closure ∅`.
+
 # Terminology
 The set `M.closure ∅ = {e | M.IsLoop e}` appears frequently in statements about loops.
 To avoid favouring one term such as `setOf_isLoop` or `closure_empty`,
@@ -30,7 +32,6 @@ we instead refer to it in lemma names by the shorter term `loops`.
 variable {α β : Type*} {M N : Matroid α} {e f : α} {F X C I : Set α}
 
 open Set
-open scoped symmDiff
 
 namespace Matroid
 
@@ -46,10 +47,12 @@ lemma closure_empty_eq_loops (M : Matroid α) : M.closure ∅ = {e | M.IsLoop e}
 lemma IsLoop.mem_ground (he : M.IsLoop e) : e ∈ M.E :=
   closure_subset_ground M ∅ he
 
-@[simp] lemma singleton_dep : M.Dep {e} ↔ M.IsLoop e := by
+@[simp]
+lemma singleton_dep : M.Dep {e} ↔ M.IsLoop e := by
   rw [isLoop_iff, M.empty_indep.mem_closure_iff_of_not_mem (not_mem_empty e), insert_emptyc_eq]
 
-@[simp] lemma singleton_not_indep (he : e ∈ M.E := by aesop_mat) : ¬M.Indep {e} ↔ M.IsLoop e :=
+@[simp]
+lemma singleton_not_indep (he : e ∈ M.E := by aesop_mat) : ¬M.Indep {e} ↔ M.IsLoop e :=
   by rw [← singleton_dep, ← not_indep_iff]
 
 lemma IsLoop.dep (he : M.IsLoop e) : M.Dep {e} :=
@@ -58,10 +61,15 @@ lemma IsLoop.dep (he : M.IsLoop e) : M.Dep {e} :=
 lemma singleton_isCircuit : M.IsCircuit {e} ↔ M.IsLoop e := by
   simp [← singleton_dep, isCircuit_def, minimal_iff_forall_ssubset, ssubset_singleton_iff]
 
-lemma isLoop_iff_not_mem_isBase_forall (he : e ∈ M.E := by aesop_mat) :
+lemma isLoop_iff_forall_not_mem_isBase (he : e ∈ M.E := by aesop_mat) :
     M.IsLoop e ↔ ∀ B, M.IsBase B → e ∉ B := by
   rw [← singleton_dep, ← not_indep_iff, not_iff_comm, not_forall]
   simp_rw [_root_.not_imp, not_not, ← singleton_subset_iff, indep_iff]
+
+lemma isLoop_iff_forall_mem_compl_isBase : M.IsLoop e ↔ ∀ B, M.IsBase B → e ∈ M.E \ B := by
+  wlog he : e ∈ M.E
+  · simpa [show ¬ M.IsLoop e from fun h ↦ he h.mem_ground, he] using M.exists_isBase
+  simp_rw [isLoop_iff_forall_not_mem_isBase he, mem_diff, and_iff_right he]
 
 lemma IsLoop.isCircuit (he : M.IsLoop e) : M.IsCircuit {e} :=
   singleton_isCircuit.mpr he
@@ -69,19 +77,20 @@ lemma IsLoop.isCircuit (he : M.IsLoop e) : M.IsCircuit {e} :=
 lemma IsLoop.mem_closure (he : M.IsLoop e) (X : Set α) : e ∈ M.closure X :=
   M.closure_mono (empty_subset _) he
 
-lemma IsLoop.mem_isFlat (he : M.IsLoop e) {F : Set α} (hF : M.IsFlat F) : e ∈ F := by
-  have := he.mem_closure F; rwa [hF.closure] at this
+lemma IsLoop.mem_isFlat (he : M.IsLoop e) {F : Set α} (hF : M.IsFlat F) : e ∈ F :=
+  hF.closure ▸ he.mem_closure F
 
-lemma IsFlat.loops_subset (hF : M.IsFlat F) : M.closure ∅ ⊆ F := fun _ he ↦ IsLoop.mem_isFlat he hF
+lemma IsFlat.loops_subset (hF : M.IsFlat F) : M.closure ∅ ⊆ F :=
+  fun _ he ↦ IsLoop.mem_isFlat he hF
 
 lemma IsLoop.dep_of_mem (he : M.IsLoop e) (h : e ∈ X) (hXE : X ⊆ M.E := by aesop_mat) : M.Dep X :=
   he.dep.superset (singleton_subset_iff.mpr h) hXE
 
-lemma IsLoop.not_indep_of_mem (he : M.IsLoop e) (h : e ∈ X) : ¬M.Indep X := fun hX ↦
-  he.dep.not_indep (hX.subset (singleton_subset_iff.mpr h))
+lemma IsLoop.not_indep_of_mem (he : M.IsLoop e) (h : e ∈ X) : ¬M.Indep X :=
+  fun hX ↦ he.dep.not_indep (hX.subset (singleton_subset_iff.mpr h))
 
-lemma IsLoop.not_mem_of_indep (he : M.IsLoop e) (hI : M.Indep I) : e ∉ I := fun h ↦
-  he.not_indep_of_mem h hI
+lemma IsLoop.not_mem_of_indep (he : M.IsLoop e) (hI : M.Indep I) : e ∉ I :=
+  fun h ↦ he.not_indep_of_mem h hI
 
 lemma IsLoop.eq_of_isCircuit_mem (he : M.IsLoop e) (hC : M.IsCircuit C) (h : e ∈ C) : C = {e} := by
   rw [he.isCircuit.eq_of_subset_isCircuit hC (singleton_subset_iff.mpr h)]
@@ -94,69 +103,74 @@ lemma Indep.disjoint_loops (hI : M.Indep I) : Disjoint I (M.closure ∅) :=
 lemma Indep.eq_empty_of_subset_loops (hI : M.Indep I) (h : I ⊆ M.closure ∅) : I = ∅ :=
   eq_empty_iff_forall_not_mem.mpr fun _ he ↦ IsLoop.not_mem_of_indep (h he) hI he
 
-@[simp] lemma isBasis_loops_iff : M.IsBasis I (M.closure ∅) ↔ I = ∅ := by
-  refine ⟨fun h ↦ h.indep.eq_empty_of_subset_loops h.subset, ?_⟩
-  rintro rfl
-  exact M.empty_indep.isBasis_closure
+@[simp]
+lemma isBasis_loops_iff : M.IsBasis I (M.closure ∅) ↔ I = ∅ :=
+  ⟨fun h ↦ h.indep.eq_empty_of_subset_loops h.subset,
+    by simp +contextual [M.empty_indep.isBasis_closure]⟩
 
 lemma closure_eq_loops_of_subset (h : X ⊆ M.closure ∅) : M.closure X = M.closure ∅ :=
   (closure_subset_closure_of_subset_closure h).antisymm (M.closure_mono (empty_subset _))
 
 lemma isBasis_iff_empty_of_subset_loops (hX : X ⊆ M.closure ∅) : M.IsBasis I X ↔ I = ∅ := by
   refine ⟨fun h ↦ ?_, by rintro rfl; simpa⟩
-  replace h := (closure_eq_loops_of_subset hX) ▸ h.isBasis_closure_right
-  simpa using h
+  have := (closure_eq_loops_of_subset hX) ▸ h.isBasis_closure_right
+  simpa using this
 
 lemma IsLoop.closure (he : M.IsLoop e) : M.closure {e} = M.closure ∅ :=
   closure_eq_loops_of_subset (singleton_subset_iff.mpr he)
 
-lemma isLoop_iff_closure_eq_loops' :
+lemma isLoop_iff_closure_eq_loops (he : e ∈ M.E := by aesop_mat) :
+    M.IsLoop e ↔ M.closure {e} = M.closure ∅ := by
+  rw [isLoop_iff, subset_antisymm_iff, and_iff_left (M.closure_subset_closure (empty_subset {e})),
+    closure_subset_closure_iff_subset_closure (by simpa), singleton_subset_iff]
+
+lemma isLoop_iff_closure_eq_loops_and_mem_ground :
     M.IsLoop e ↔ M.closure {e} = M.closure ∅ ∧ e ∈ M.E := by
   wlog he : e ∈ M.E
   · simp [he, show ¬ M.IsLoop e from fun h ↦ he h.mem_ground]
-  rw [isLoop_iff, and_iff_left he, subset_antisymm_iff,
-    and_iff_left (M.closure_subset_closure (empty_subset {e})),
-    closure_subset_closure_iff_subset_closure (by simpa), singleton_subset_iff]
+  rw [isLoop_iff_closure_eq_loops, and_iff_left he]
 
-lemma isLoop_iff_closure_eq_loops (he : e ∈ M.E := by aesop_mat) :
-    M.IsLoop e ↔ M.closure {e} = M.closure ∅ := by
-  rw [isLoop_iff_closure_eq_loops', and_iff_left he]
-
-lemma isLoop_iff_forall_mem_compl_isBase : M.IsLoop e ↔ ∀ B, M.IsBase B → e ∈ M.E \ B := by
-  refine ⟨fun h B hB ↦ mem_of_mem_of_subset h ?_, fun h ↦ ?_⟩
-  · rw [subset_diff, and_iff_right (closure_subset_ground _ _), disjoint_iff_inter_eq_empty,
-      hB.indep.closure_inter_eq_self_of_subset (empty_subset B)]
-  have he : e ∈ M.E := M.exists_isBase.elim (fun B hB ↦ (h B hB).1)
-  rw [← singleton_dep, ← not_indep_iff]
-  intro hei
-  obtain ⟨B, hB, heB⟩ := hei.exists_isBase_superset
-  exact (h B hB).2 (singleton_subset_iff.mp heB)
-
-@[simp] lemma restrict_isLoop_iff {R : Set α} :
+@[simp]
+lemma restrict_isLoop_iff {R : Set α} :
     (M ↾ R).IsLoop e ↔ e ∈ R ∧ (M.IsLoop e ∨ e ∉ M.E) := by
-  rw [← singleton_dep, restrict_dep_iff, singleton_subset_iff, ← singleton_dep, and_comm,
-    and_congr_right_iff, Dep, and_or_right, singleton_subset_iff, and_iff_left or_not,
-    or_iff_left_of_imp (fun he hi ↦ he (singleton_subset_iff.1 hi.subset_ground))]
-  simp only [singleton_subset_iff, implies_true]
+  simp only [isLoop_iff, restrict_closure_eq', empty_inter, mem_union, mem_inter_iff, mem_diff]
+  tauto
 
-lemma isRestriction_isLoop_iff (hNM : N ≤r M) :
-    N.IsLoop e ↔ e ∈ N.E ∧ M.IsLoop e := by
+lemma IsRestriction.isLoop_iff (hNM : N ≤r M) : N.IsLoop e ↔ e ∈ N.E ∧ M.IsLoop e := by
   obtain ⟨R, hR, rfl⟩ := hNM
   simp only [restrict_isLoop_iff, restrict_ground_eq, and_congr_right_iff, or_iff_left_iff_imp]
   exact fun heR heE ↦ (heE (hR heR)).elim
 
 lemma IsLoop.of_isRestriction (he : N.IsLoop e) (hNM : N ≤r M) : M.IsLoop e :=
-  ((isRestriction_isLoop_iff hNM).1 he).2
+  ((hNM.isLoop_iff).1 he).2
 
 lemma IsLoop.isLoop_isRestriction (he : M.IsLoop e) (hNM : N ≤r M) (heN : e ∈ N.E) : N.IsLoop e :=
-  (isRestriction_isLoop_iff hNM).2 ⟨heN, he⟩
+  (hNM.isLoop_iff).2 ⟨heN, he⟩
 
-@[simp] lemma comap_isLoop_iff {M : Matroid β} {f : α → β} :
-    (M.comap f).IsLoop e ↔ M.IsLoop (f e) := by
+@[simp]
+lemma map_isLoop_iff {f : α → β} {hf : InjOn f M.E} (he : e ∈ M.E := by aesop_mat) :
+    (M.map f hf).IsLoop (f e) ↔ M.IsLoop e := by
+  rw [isLoop_iff, map_closure_eq, preimage_empty, hf.mem_image_iff (M.closure_subset_ground _) he,
+    isLoop_iff]
+
+lemma mapEmbedding_isLoop_iff {f : α ↪ β} : (M.mapEmbedding f).IsLoop (f e) ↔ M.IsLoop e := by
+  simp [mapEmbedding, isLoop_iff, isLoop_iff, map_closure_eq, preimage_empty]
+
+@[simp]
+lemma comap_isLoop_iff {M : Matroid β} {f : α → β} : (M.comap f).IsLoop e ↔ M.IsLoop (f e) := by
   rw [← singleton_dep, comap_dep_iff]
   simp
 
-@[simp] lemma loopyOn_isLoop_iff {E : Set α} : (loopyOn E).IsLoop e ↔ e ∈ E := by
-  simp [IsLoop]
+@[simp]
+lemma loopyOn_isLoop_iff {E : Set α} : (loopyOn E).IsLoop e ↔ e ∈ E := by
+  simp [isLoop_iff]
+
+@[simp]
+lemma freeOn_not_isLoop (E : Set α) (e : α) : ¬ (freeOn E).IsLoop e := by
+  simp [isLoop_iff]
+
+@[simp]
+lemma uniqueBaseOn_isLoop_iff {I E : Set α} : (uniqueBaseOn I E).IsLoop e ↔ e ∈ E \ I := by
+  simp [isLoop_iff]
 
 end Matroid

--- a/Mathlib/Data/Matroid/Loop.lean
+++ b/Mathlib/Data/Matroid/Loop.lean
@@ -60,13 +60,12 @@ lemma isLoop_tfae (M : Matroid α) (e : α) : List.TFAE [
   tfae_have 2 <-> 3 := by simp [M.empty_indep.mem_closure_iff_of_not_mem (not_mem_empty e),
     isCircuit_def, minimal_iff_forall_ssubset, ssubset_singleton_iff]
   tfae_have 2 <-> 4 := by simp [M.empty_indep.mem_closure_iff_of_not_mem (not_mem_empty e)]
-  tfae_have 4 -> 5 := fun h B hB ↦
-    ⟨by simpa using h.subset_ground, fun heB ↦ h.not_indep (hB.indep.subset (by simpa))⟩
-  tfae_have 5 -> 4 := by
-    rw [dep_iff, singleton_subset_iff]
-    refine fun h ↦ ⟨fun hi ↦ ?_, (h M.exists_isBase.choose_spec).1⟩
+  tfae_have 4 <-> 5 := by
+    simp only [dep_iff, singleton_subset_iff, mem_diff, forall_and]
+    refine ⟨fun h ↦ ⟨fun _ _ ↦ h.2, fun B hB heB ↦ h.1 (hB.indep.subset (by simpa))⟩,
+      fun h ↦ ⟨fun hi ↦ ?_, h.1 _ M.exists_isBase.choose_spec⟩⟩
     obtain ⟨B, hB, heB⟩ := hi.exists_isBase_superset
-    exact (h hB).2 (by simpa using heB)
+    exact h.2 _ hB (by simpa using heB)
   tfae_finish
 
 @[simp]

--- a/Mathlib/Data/Matroid/Loop.lean
+++ b/Mathlib/Data/Matroid/Loop.lean
@@ -1,0 +1,162 @@
+/-
+Copyright (c) 2025 Peter Nelson. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Peter Nelson
+-/
+import Mathlib.Data.Matroid.Circuit
+
+/-!
+# Matroid Loops
+A 'loop' of a matroid `M` is an element `e` satisfying one of the following equivalent conditions:
+* `e ∈ M.closure ∅`;
+* `{e}` is dependent in `M`;
+* `{e}` is a circuit of `M`;
+* no base of `M` contains `e`.
+In many mathematical contexts, loops can be thought of as 'trivial' or 'zero' elements;
+For linearly representable matroids, they correspond to the zero vector,
+and for graphic matroids, they correspond to edges incident with just one vertex (aka 'loops').
+As trivial as they are, loops can be created from matroids with no loops by taking minors or duals,
+so in many contexts it is unreasonable to simply forbid loops from appearing.
+This file defines loops, and provides API for interacting with them.
+# Main Declarations
+* For `M : Matroid α` and `e : α`, `M.IsLoop e` means that `e` is a loop of `M`,
+  defined as the statement `e ∈ M.closure ∅`.
+# Terminology
+The set `M.closure ∅ = {e | M.IsLoop e}` appears frequently in statements about loops.
+To avoid favouring one term such as `setOf_isLoop` or `closure_empty`,
+we instead refer to it in lemma names by the shorter term `loops`.
+-/
+
+variable {α β : Type*} {M N : Matroid α} {e f : α} {F X C I : Set α}
+
+open Set
+open scoped symmDiff
+
+namespace Matroid
+
+/-- A 'loop' is a member of the closure of the empty set -/
+def IsLoop (M : Matroid α) (e : α) : Prop :=
+  e ∈ M.closure ∅
+
+lemma isLoop_iff : M.IsLoop e ↔ e ∈ M.closure ∅ := Iff.rfl
+
+lemma closure_empty_eq_loops (M : Matroid α) : M.closure ∅ = {e | M.IsLoop e} := rfl
+
+@[aesop unsafe 20% (rule_sets := [Matroid])]
+lemma IsLoop.mem_ground (he : M.IsLoop e) : e ∈ M.E :=
+  closure_subset_ground M ∅ he
+
+@[simp] lemma singleton_dep : M.Dep {e} ↔ M.IsLoop e := by
+  rw [isLoop_iff, M.empty_indep.mem_closure_iff_of_not_mem (not_mem_empty e), insert_emptyc_eq]
+
+@[simp] lemma singleton_not_indep (he : e ∈ M.E := by aesop_mat) : ¬M.Indep {e} ↔ M.IsLoop e :=
+  by rw [← singleton_dep, ← not_indep_iff]
+
+lemma IsLoop.dep (he : M.IsLoop e) : M.Dep {e} :=
+  singleton_dep.2 he
+
+lemma singleton_isCircuit : M.IsCircuit {e} ↔ M.IsLoop e := by
+  simp [← singleton_dep, isCircuit_def, minimal_iff_forall_ssubset, ssubset_singleton_iff]
+
+lemma isLoop_iff_not_mem_isBase_forall (he : e ∈ M.E := by aesop_mat) :
+    M.IsLoop e ↔ ∀ B, M.IsBase B → e ∉ B := by
+  rw [← singleton_dep, ← not_indep_iff, not_iff_comm, not_forall]
+  simp_rw [_root_.not_imp, not_not, ← singleton_subset_iff, indep_iff]
+
+lemma IsLoop.isCircuit (he : M.IsLoop e) : M.IsCircuit {e} :=
+  singleton_isCircuit.mpr he
+
+lemma IsLoop.mem_closure (he : M.IsLoop e) (X : Set α) : e ∈ M.closure X :=
+  M.closure_mono (empty_subset _) he
+
+lemma IsLoop.mem_isFlat (he : M.IsLoop e) {F : Set α} (hF : M.IsFlat F) : e ∈ F := by
+  have := he.mem_closure F; rwa [hF.closure] at this
+
+lemma IsFlat.loops_subset (hF : M.IsFlat F) : M.closure ∅ ⊆ F := fun _ he ↦ IsLoop.mem_isFlat he hF
+
+lemma IsLoop.dep_of_mem (he : M.IsLoop e) (h : e ∈ X) (hXE : X ⊆ M.E := by aesop_mat) : M.Dep X :=
+  he.dep.superset (singleton_subset_iff.mpr h) hXE
+
+lemma IsLoop.not_indep_of_mem (he : M.IsLoop e) (h : e ∈ X) : ¬M.Indep X := fun hX ↦
+  he.dep.not_indep (hX.subset (singleton_subset_iff.mpr h))
+
+lemma IsLoop.not_mem_of_indep (he : M.IsLoop e) (hI : M.Indep I) : e ∉ I := fun h ↦
+  he.not_indep_of_mem h hI
+
+lemma IsLoop.eq_of_isCircuit_mem (he : M.IsLoop e) (hC : M.IsCircuit C) (h : e ∈ C) : C = {e} := by
+  rw [he.isCircuit.eq_of_subset_isCircuit hC (singleton_subset_iff.mpr h)]
+
+lemma Indep.disjoint_loops (hI : M.Indep I) : Disjoint I (M.closure ∅) :=
+  by_contra fun h ↦
+    let ⟨_, ⟨heI, he⟩⟩ := not_disjoint_iff.mp h
+    IsLoop.not_mem_of_indep he hI heI
+
+lemma Indep.eq_empty_of_subset_loops (hI : M.Indep I) (h : I ⊆ M.closure ∅) : I = ∅ :=
+  eq_empty_iff_forall_not_mem.mpr fun _ he ↦ IsLoop.not_mem_of_indep (h he) hI he
+
+@[simp] lemma isBasis_loops_iff : M.IsBasis I (M.closure ∅) ↔ I = ∅ := by
+  refine ⟨fun h ↦ h.indep.eq_empty_of_subset_loops h.subset, ?_⟩
+  rintro rfl
+  exact M.empty_indep.isBasis_closure
+
+lemma closure_eq_loops_of_subset (h : X ⊆ M.closure ∅) : M.closure X = M.closure ∅ :=
+  (closure_subset_closure_of_subset_closure h).antisymm (M.closure_mono (empty_subset _))
+
+lemma isBasis_iff_empty_of_subset_loops (hX : X ⊆ M.closure ∅) : M.IsBasis I X ↔ I = ∅ := by
+  refine ⟨fun h ↦ ?_, by rintro rfl; simpa⟩
+  replace h := (closure_eq_loops_of_subset hX) ▸ h.isBasis_closure_right
+  simpa using h
+
+lemma IsLoop.closure (he : M.IsLoop e) : M.closure {e} = M.closure ∅ :=
+  closure_eq_loops_of_subset (singleton_subset_iff.mpr he)
+
+lemma isLoop_iff_closure_eq_loops' :
+    M.IsLoop e ↔ M.closure {e} = M.closure ∅ ∧ e ∈ M.E := by
+  wlog he : e ∈ M.E
+  · simp [he, show ¬ M.IsLoop e from fun h ↦ he h.mem_ground]
+  rw [isLoop_iff, and_iff_left he, subset_antisymm_iff,
+    and_iff_left (M.closure_subset_closure (empty_subset {e})),
+    closure_subset_closure_iff_subset_closure (by simpa), singleton_subset_iff]
+
+lemma isLoop_iff_closure_eq_loops (he : e ∈ M.E := by aesop_mat) :
+    M.IsLoop e ↔ M.closure {e} = M.closure ∅ := by
+  rw [isLoop_iff_closure_eq_loops', and_iff_left he]
+
+lemma isLoop_iff_forall_mem_compl_isBase : M.IsLoop e ↔ ∀ B, M.IsBase B → e ∈ M.E \ B := by
+  refine ⟨fun h B hB ↦ mem_of_mem_of_subset h ?_, fun h ↦ ?_⟩
+  · rw [subset_diff, and_iff_right (closure_subset_ground _ _), disjoint_iff_inter_eq_empty,
+      hB.indep.closure_inter_eq_self_of_subset (empty_subset B)]
+  have he : e ∈ M.E := M.exists_isBase.elim (fun B hB ↦ (h B hB).1)
+  rw [← singleton_dep, ← not_indep_iff]
+  intro hei
+  obtain ⟨B, hB, heB⟩ := hei.exists_isBase_superset
+  exact (h B hB).2 (singleton_subset_iff.mp heB)
+
+@[simp] lemma restrict_isLoop_iff {R : Set α} :
+    (M ↾ R).IsLoop e ↔ e ∈ R ∧ (M.IsLoop e ∨ e ∉ M.E) := by
+  rw [← singleton_dep, restrict_dep_iff, singleton_subset_iff, ← singleton_dep, and_comm,
+    and_congr_right_iff, Dep, and_or_right, singleton_subset_iff, and_iff_left or_not,
+    or_iff_left_of_imp (fun he hi ↦ he (singleton_subset_iff.1 hi.subset_ground))]
+  simp only [singleton_subset_iff, implies_true]
+
+lemma isRestriction_isLoop_iff (hNM : N ≤r M) :
+    N.IsLoop e ↔ e ∈ N.E ∧ M.IsLoop e := by
+  obtain ⟨R, hR, rfl⟩ := hNM
+  simp only [restrict_isLoop_iff, restrict_ground_eq, and_congr_right_iff, or_iff_left_iff_imp]
+  exact fun heR heE ↦ (heE (hR heR)).elim
+
+lemma IsLoop.of_isRestriction (he : N.IsLoop e) (hNM : N ≤r M) : M.IsLoop e :=
+  ((isRestriction_isLoop_iff hNM).1 he).2
+
+lemma IsLoop.isLoop_isRestriction (he : M.IsLoop e) (hNM : N ≤r M) (heN : e ∈ N.E) : N.IsLoop e :=
+  (isRestriction_isLoop_iff hNM).2 ⟨heN, he⟩
+
+@[simp] lemma comap_isLoop_iff {M : Matroid β} {f : α → β} :
+    (M.comap f).IsLoop e ↔ M.IsLoop (f e) := by
+  rw [← singleton_dep, comap_dep_iff]
+  simp
+
+@[simp] lemma loopyOn_isLoop_iff {E : Set α} : (loopyOn E).IsLoop e ↔ e ∈ E := by
+  simp [IsLoop]
+
+end Matroid

--- a/Mathlib/Data/Matroid/Loop.lean
+++ b/Mathlib/Data/Matroid/Loop.lean
@@ -25,8 +25,8 @@ This file defines loops, and provides API for interacting with them.
 
 # Terminology
 The set `M.closure ∅ = {e | M.IsLoop e}` appears frequently in statements about loops.
-To avoid favouring one term such as `setOf_isLoop` or `closure_empty`,
-we instead refer to it in lemma names by the shorter term `loops`.
+we stick with the more convenient spelling `M.closure ∅`,
+but refer to it in lemma names by the shorter term `loops`.
 -/
 
 variable {α β : Type*} {M N : Matroid α} {e f : α} {F X C I : Set α}

--- a/Mathlib/Data/Matroid/Restrict.lean
+++ b/Mathlib/Data/Matroid/Restrict.lean
@@ -6,25 +6,26 @@ Authors: Peter Nelson
 import Mathlib.Data.Matroid.Dual
 
 /-!
-# Matroid IsRestriction
+# Matroid Restriction
 
 Given `M : Matroid α` and `R : Set α`, the independent sets of `M` that are contained in `R`
 are the independent sets of another matroid `M ↾ R` with ground set `R`,
-called the 'isRestriction' of `M` to `R`.
-For `I, R ⊆ M.E`, `I` is a isBasis of `R` in `M` if and only if `I` is a base
-of the isRestriction `M ↾ R`, so this construction relates `Matroid.IsBasis` to `Matroid.Base`.
+called the 'restriction' of `M` to `R`.
+For `I ⊆ R ⊆ M.E`, `I` is a basis of `R` in `M` if and only if `I` is a base
+of the restriction `M ↾ R`, so this construction relates `Matroid.IsBasis` to `Matroid.IsBase`.
 
 If `N M : Matroid α` satisfy `N = M ↾ R` for some `R ⊆ M.E`,
-then we call `N` a 'isRestriction of `M`', and write `N ≤r M`. This is a partial order.
+then we call `N` a 'restriction of `M`', and write `N ≤r M`. This is a partial order.
 
-This file proves that the isRestriction is a matroid and that the `≤r` order is a partial order,
+This file proves that the restriction is a matroid and that the `≤r` order is a partial order,
 and gives related API.
-It also proves some `IsBasis` analogues of `Base` lemmas that, while they could be stated in
-`Data.Matroid.Basic`, are hard to prove without `Matroid.restrict` API.
+It also proves some `Matroid.IsBasis` analogues of `Matroid.IsBase` lemmas that,
+while they could be stated in `Data.Matroid.Basic`,
+are hard to prove without `Matroid.restrict` API.
 
 ## Main Definitions
 
-* `M.restrict R`, written `M ↾ R`, is the isRestriction of `M : Matroid α` to `R : Set α`: i.e.
+* `M.restrict R`, written `M ↾ R`, is the restriction of `M : Matroid α` to `R : Set α`: i.e.
   the matroid with ground set `R` whose independent sets are the `M`-independent subsets of `R`.
 
 * `Matroid.Restriction N M`, written `N ≤r M`, means that `N = M ↾ R` for some `R ⊆ M.E`.
@@ -35,11 +36,11 @@ It also proves some `IsBasis` analogues of `Base` lemmas that, while they could 
 
 ## Implementation Notes
 
-Since `R` and `M.E` are both terms in `Set α`, to define the isRestriction `M ↾ R`,
+Since `R` and `M.E` are both terms in `Set α`, to define the restriction `M ↾ R`,
 we need to either insist that `R ⊆ M.E`, or to say what happens when `R` contains the junk
 outside `M.E`.
 
-It turns out that `R ⊆ M.E` is just an unnecessary hypothesis; if we say the isRestriction
+It turns out that `R ⊆ M.E` is just an unnecessary hypothesis; if we say the restriction
 `M ↾ R` has ground set `R` and its independent sets are the `M`-independent subsets of `R`,
 we always get a matroid, in which the elements of `R \ M.E` aren't in any independent sets.
 We could instead define this matroid to always be 'smaller' than `M` by setting
@@ -48,16 +49,17 @@ We could instead define this matroid to always be 'smaller' than `M` by setting
 This makes it possible to actually restrict a matroid 'upwards'; for instance, if `M : Matroid α`
 satisfies `M.E = ∅`, then `M ↾ Set.univ` is the matroid on `α` whose ground set is all of `α`,
 where the empty set is only the independent set.
-(Elements of `R` outside the ground set are all 'loops' of the matroid.)
+(In general, elements of `R \ M.E` are all 'loops' of the matroid `M ↾ R`;
+see `Matroid.loops` and `Matroid.restrict_loops_eq'` for a precise version of this statement.)
 This is mathematically strange, but is useful for API building.
 
-The cost of allowing a isRestriction of `M` to be 'bigger' than the `M` itself is that
+The cost of allowing a restriction of `M` to be 'bigger' than `M` itself is that
 the statement `M ↾ R ≤r M` is only true with the hypothesis `R ⊆ M.E`
 (at least, if we want `≤r` to be a partial order).
 But this isn't too inconvenient in practice. Indeed `(· ⊆ M.E)` proofs
 can often be automatically provided by `aesop_mat`.
 
-We define the isRestriction order `≤r` to give a `PartialOrder` instance on the type synonym
+We define the restriction order `≤r` to give a `PartialOrder` instance on the type synonym
 `Matroidᵣ α` rather than `Matroid α` itself, because the `PartialOrder (Matroid α)` instance is
 reserved for the more mathematically important 'minor' order.
 -/
@@ -234,7 +236,7 @@ scoped infix:50  " ≤r " => IsRestriction
 /-- `N <r M` means that `N` is a `IsStrictRestriction` of `M`. -/
 scoped infix:50  " <r " => IsStrictRestriction
 
-/-- A type synonym for matroids with the isRestriction order.
+/-- A type synonym for matroids with the restriction order.
   (The `PartialOrder` on `Matroid α` is reserved for the minor order)  -/
 @[ext] structure Matroidᵣ (α : Type*) where ofMatroid ::
   /-- The underlying `Matroid`.-/


### PR DESCRIPTION
We add a definition of a loop element of a matroid, with basic API. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
