### PR TITLE
[Merged by Bors] - feat: delaborator for `∑ x ∈ s with p x, f x` notation

### DIFF
--- a/Mathlib/Algebra/BigOperators/Group/Finset/Defs.lean
+++ b/Mathlib/Algebra/BigOperators/Group/Finset/Defs.lean
@@ -290,7 +290,13 @@ to show the domain type when the product is over `Finset.univ`. -/
   | .filter ss p =>
     `(∏ $i:ident ∈ $ss with $p, $body)
   | .filterUniv p =>
-    `(∏ $i:ident with $p, $body)
+    let binder ←
+    if ppDomain then
+      let ty ← withNaryArg 0 delab
+      `(bigOpBinder| $i:ident : $ty)
+    else
+      `(bigOpBinder| $i:ident)
+    `(∏ $binder:bigOpBinder with $p, $body)
 
 /-- Delaborator for `Finset.sum`. The `pp.funBinderTypes` option controls whether
 to show the domain type when the sum is over `Finset.univ`. -/
@@ -315,7 +321,13 @@ to show the domain type when the sum is over `Finset.univ`. -/
   | .filter ss p =>
     `(∑ $i:ident ∈ $ss with $p, $body)
   | .filterUniv p =>
-    `(∑ $i:ident with $p, $body)
+    let binder ←
+    if ppDomain then
+      let ty ← withNaryArg 0 delab
+      `(bigOpBinder| $i:ident : $ty)
+    else
+      `(bigOpBinder| $i:ident)
+    `(∑ $binder:bigOpBinder with $p, $body)
 
 end BigOperators
 

--- a/Mathlib/Algebra/BigOperators/Group/Finset/Defs.lean
+++ b/Mathlib/Algebra/BigOperators/Group/Finset/Defs.lean
@@ -239,54 +239,92 @@ def getFinsetFilter {u : Level} {α : Q(Type u)} (s : Q(Finset $α)) :
   | ~q(@Finset.filter _ _ $s $p) => return (s, some p)
   | _ => return (s, none)
 
+/-- The possibilities we distinguish to delaborate the finset indexing a big operator:
+* `finset s` corresponds to `∑ x ∈ s, f x`
+* `univ` corresponds to `∑ x, f x`
+* `filter s p` corresponds to `∑ x ∈ s with p x, f x`
+* `filterUniv p` corresponds to `∑ x with p x, f x`
+-/
+private inductive FinsetResult where
+  | finset (s : Term)
+  | univ
+  | filter (s : Term) (p : Term)
+  | filterUniv (p : Term)
+
+/-- Delaborates a finset. In case it is a `Finset.filter`, `i` is used for the binder name. -/
+private def delabFinsetArg (i : Ident) : DelabM FinsetResult := do
+  let s ← getExpr
+  if s.isAppOfArity ``Finset.univ 2 then
+    return .univ
+  else if s.isAppOfArity ``Finset.filter 4 then
+    let #[_, _, _, t] := s.getAppArgs | failure
+    let p ←
+      withNaryArg 1 do
+        if (← getExpr).isLambda then
+          withBindingBody i.getId do
+            let p ← delab
+            return p
+        else
+          let p ← delab
+          return (← `($p $i))
+    if t.isAppOfArity ``Finset.univ 2 then
+      return .filterUniv p
+    else
+      let ss ← withNaryArg 3 delab
+      return .filter ss p
+  else
+    let ss ← delab
+    return .finset ss
+
 /-- Delaborator for `Finset.prod`. The `pp.funBinderTypes` option controls whether
 to show the domain type when the product is over `Finset.univ`. -/
 @[app_delab Finset.prod] def delabFinsetProd : Delab :=
   whenPPOption getPPNotation <| withOverApp 5 <| do
-  let #[_, _, _, s, f] := (← getExpr).getAppArgs | failure
+  let #[_, _, _, _, f] := (← getExpr).getAppArgs | failure
   guard f.isLambda
   let ppDomain ← getPPOption getPPFunBinderTypes
   let (i, body) ← withAppArg <| withBindingBodyUnusedName fun i => do
-    return (i, ← delab)
-  let ⟨.succ _, ~q(Finset $α), s⟩ ← inferTypeQ s | failure
-  let (s, p) ← getFinsetFilter (α := α) s
-  if s.isAppOfArity ``Finset.univ 2 then
+    return (⟨i⟩, ← delab)
+  let res ← withNaryArg 3 <| delabFinsetArg i
+  match res with
+  | .finset ss => `(∏ $i:ident ∈ $ss, $body)
+  | .univ =>
     let binder ←
       if ppDomain then
         let ty ← withNaryArg 0 delab
-        `(bigOpBinder| $(.mk i):ident : $ty)
+        `(bigOpBinder| $i:ident : $ty)
       else
-        `(bigOpBinder| $(.mk i):ident)
-    -- Help! How do I delaborate `s` and `p` here?
-    match p with
-    | some _ => `(∏ $binder:bigOpBinder, $body)
-    | none => `(∏ $binder:bigOpBinder, $body)
-  else
-    let ss ← withNaryArg 3 delab
-    match p with
-    | some _ => `(∏ $(.mk i):ident ∈ $ss, $body)
-    | none => `(∏ $(.mk i):ident ∈ $ss, $body)
+        `(bigOpBinder| $i:ident)
+    `(∏ $binder:bigOpBinder, $body)
+  | .filter ss p =>
+    `(∏ $i:ident ∈ $ss with $p, $body)
+  | .filterUniv p =>
+    `(∏ $i:ident with $p, $body)
 
 /-- Delaborator for `Finset.sum`. The `pp.funBinderTypes` option controls whether
 to show the domain type when the sum is over `Finset.univ`. -/
 @[app_delab Finset.sum] def delabFinsetSum : Delab :=
   whenPPOption getPPNotation <| withOverApp 5 <| do
-  let #[_, _, _, s, f] := (← getExpr).getAppArgs | failure
+  let #[_, _, _, _, f] := (← getExpr).getAppArgs | failure
   guard f.isLambda
   let ppDomain ← getPPOption getPPFunBinderTypes
   let (i, body) ← withAppArg <| withBindingBodyUnusedName fun i => do
-    return (i, ← delab)
-  if s.isAppOfArity ``Finset.univ 2 then
+    return ((⟨i⟩ : Ident), ← delab)
+  let res ← withNaryArg 3 <| delabFinsetArg i
+  match res with
+  | .finset ss => `(∑ $i:ident ∈ $ss, $body)
+  | .univ =>
     let binder ←
-      if ppDomain then
-        let ty ← withNaryArg 0 delab
-        `(bigOpBinder| $(.mk i):ident : $ty)
-      else
-        `(bigOpBinder| $(.mk i):ident)
+    if ppDomain then
+      let ty ← withNaryArg 0 delab
+      `(bigOpBinder| $i:ident : $ty)
+    else
+      `(bigOpBinder| $i:ident)
     `(∑ $binder:bigOpBinder, $body)
-  else
-    let ss ← withNaryArg 3 delab
-    `(∑ $(.mk i):ident ∈ $ss, $body)
+  | .filter ss p =>
+    `(∑ $i:ident ∈ $ss with $p, $body)
+  | .filterUniv p =>
+    `(∑ $i:ident with $p, $body)
 
 end BigOperators
 

--- a/Mathlib/Algebra/BigOperators/Group/Finset/Defs.lean
+++ b/Mathlib/Algebra/BigOperators/Group/Finset/Defs.lean
@@ -228,16 +228,8 @@ elab_rules : term
 
 end deprecated
 
-open Lean Meta Parser.Term PrettyPrinter.Delaborator SubExpr Qq
+open Lean Meta Parser.Term PrettyPrinter.Delaborator SubExpr
 open scoped Batteries.ExtendedBinder
-
-/-- For a finset of the form `{x ∈ s | p x}`, returns `(s, some p)`. For any other finset `s`,
-returns `(s, none)`. -/
-def getFinsetFilter {u : Level} {α : Q(Type u)} (s : Q(Finset $α)) :
-    MetaM (Q(Finset $α) × Option Q($α → Prop)) := do
-  match s with
-  | ~q(@Finset.filter _ _ $s $p) => return (s, some p)
-  | _ => return (s, none)
 
 /-- The possibilities we distinguish to delaborate the finset indexing a big operator:
 * `finset s` corresponds to `∑ x ∈ s, f x`
@@ -251,7 +243,8 @@ private inductive FinsetResult where
   | filter (s : Term) (p : Term)
   | filterUniv (p : Term)
 
-/-- Delaborates a finset. In case it is a `Finset.filter`, `i` is used for the binder name. -/
+/-- Delaborates a finset indexing a big operator. In case it is a `Finset.filter`, `i` is used for
+the binder name. -/
 private def delabFinsetArg (i : Ident) : DelabM FinsetResult := do
   let s ← getExpr
   if s.isAppOfArity ``Finset.univ 2 then

--- a/Mathlib/Algebra/BigOperators/Group/Finset/Defs.lean
+++ b/Mathlib/Algebra/BigOperators/Group/Finset/Defs.lean
@@ -261,9 +261,7 @@ private def delabFinsetArg (i : Ident) : DelabM FinsetResult := do
     let p ←
       withNaryArg 1 do
         if (← getExpr).isLambda then
-          withBindingBody i.getId do
-            let p ← delab
-            return p
+          withBindingBody i.getId delab
         else
           let p ← delab
           return (← `($p $i))

--- a/MathlibTest/BigOps.lean
+++ b/MathlibTest/BigOps.lean
@@ -23,18 +23,18 @@ variable {ι M : Type*} [CommMonoid M] [AddCommMonoid M] [Fintype ι] {s : Finse
 
 /-- info: ∑ i with p i, f i : M -/
 #guard_msgs in
-#check Finset.sum {i | p i} fun i ↦ f i
+#check Finset.sum {j | p j} fun i ↦ f i
 
 /-- info: ∏ i with p i, f i : M -/
-#guard_msgs in 
-#check Finset.prod {i | p i} fun i ↦ f i
+#guard_msgs in
+#check Finset.prod {j | p j} fun i ↦ f i
 
 /-- info: ∑ i ∈ s with p i, f i : M -/
 #guard_msgs in
-#check Finset.sum {i ∈ s | p i} fun i ↦ f i
+#check Finset.sum {j ∈ s | p j} fun i ↦ f i
 
 /-- info: ∏ i ∈ s with p i, f i : M -/
 #guard_msgs in
-#check Finset.prod {i ∈ s | p i} fun i ↦ f i
+#check Finset.prod {j ∈ s | p j} fun i ↦ f i
 
 end

--- a/MathlibTest/BigOps.lean
+++ b/MathlibTest/BigOps.lean
@@ -4,14 +4,7 @@ section
 variable {ι M : Type*} [CommMonoid M] [AddCommMonoid M] [Fintype ι] {s : Finset ι} {p : ι → Prop}
   [DecidablePred p] {f : ι → M}
 
-
-/-- info: ∑ i : ι, f i : M -/
-#guard_msgs in
-#check Finset.sum Finset.univ fun i ↦ f i
-
-/-- info: ∏ i : ι, f i : M -/
-#guard_msgs in
-#check Finset.prod Finset.univ fun i ↦ f i
+/-! ### Big operators over a finset -/
 
 /-- info: ∑ i ∈ s, f i : M -/
 #guard_msgs in
@@ -21,14 +14,6 @@ variable {ι M : Type*} [CommMonoid M] [AddCommMonoid M] [Fintype ι] {s : Finse
 #guard_msgs in
 #check Finset.prod s fun i ↦ f i
 
-/-- info: ∑ i with p i, f i : M -/
-#guard_msgs in
-#check Finset.sum {j | p j} fun i ↦ f i
-
-/-- info: ∏ i with p i, f i : M -/
-#guard_msgs in
-#check Finset.prod {j | p j} fun i ↦ f i
-
 /-- info: ∑ i ∈ s with p i, f i : M -/
 #guard_msgs in
 #check Finset.sum {j ∈ s | p j} fun i ↦ f i
@@ -36,5 +21,43 @@ variable {ι M : Type*} [CommMonoid M] [AddCommMonoid M] [Fintype ι] {s : Finse
 /-- info: ∏ i ∈ s with p i, f i : M -/
 #guard_msgs in
 #check Finset.prod {j ∈ s | p j} fun i ↦ f i
+
+/-! ### Big operators over a finset with `piBinderTypes` on -/
+
+/-- info: ∑ i : ι, f i : M -/
+#guard_msgs in
+#check Finset.sum Finset.univ fun i ↦ f i
+
+/-- info: ∏ i : ι, f i : M -/
+#guard_msgs in
+#check Finset.prod Finset.univ fun i ↦ f i
+
+/-- info: ∑ i : ι with p i, f i : M -/
+#guard_msgs in
+#check Finset.sum {j | p j} fun i ↦ f i
+
+/-- info: ∏ i : ι with p i, f i : M -/
+#guard_msgs in
+#check Finset.prod {j | p j} fun i ↦ f i
+
+/-! ### Big operators over a finset with `piBinderTypes` off -/
+
+set_option pp.piBinderTypes false
+
+/-- info: ∑ i, f i : M -/
+#guard_msgs in
+#check Finset.sum Finset.univ fun i ↦ f i
+
+/-- info: ∏ i, f i : M -/
+#guard_msgs in
+#check Finset.prod Finset.univ fun i ↦ f i
+
+/-- info: ∑ i with p i, f i : M -/
+#guard_msgs in
+#check Finset.sum {j | p j} fun i ↦ f i
+
+/-- info: ∏ i with p i, f i : M -/
+#guard_msgs in
+#check Finset.prod {j | p j} fun i ↦ f i
 
 end

--- a/MathlibTest/BigOps.lean
+++ b/MathlibTest/BigOps.lean
@@ -1,0 +1,16 @@
+import Mathlib.Algebra.BigOperators.Group.Finset.Basic
+
+section
+variable {ι M : Type*} [CommMonoid M] [AddCommMonoid M] [Fintype ι] {s : Finset ι} {p : ι → Prop}
+  [DecidablePred p] {f : ι → M}
+
+#guard_expr ∑ i, f i = Finset.sum Finset.univ fun i ↦ f i
+#guard_expr ∏ i, f i = Finset.prod Finset.univ fun i ↦ f i
+#guard_expr ∑ i ∈ s, f i = Finset.sum s fun i ↦ f i
+#guard_expr ∏ i ∈ s, f i = Finset.prod s fun i ↦ f i
+#guard_expr ∑ i with p i, f i = Finset.sum {i | p i} fun i ↦ f i
+#guard_expr ∏ i with p i, f i = Finset.prod {i | p i} fun i ↦ f i
+#guard_expr ∑ i ∈ s with p i, f i = Finset.sum {i ∈ s | p i} fun i ↦ f i
+#guard_expr ∏ i ∈ s with p i, f i = Finset.prod {i ∈ s | p i} fun i ↦ f i
+
+end

--- a/MathlibTest/BigOps.lean
+++ b/MathlibTest/BigOps.lean
@@ -22,7 +22,9 @@ variable {ι M : Type*} [CommMonoid M] [AddCommMonoid M] [Fintype ι] {s : Finse
 #guard_msgs in
 #check Finset.prod {j ∈ s | p j} fun i ↦ f i
 
-/-! ### Big operators over a finset with `piBinderTypes` on -/
+/-! ### Big operators over a finset with `funBinderTypes` on -/
+
+set_option pp.funBinderTypes true
 
 /-- info: ∑ i : ι, f i : M -/
 #guard_msgs in
@@ -40,9 +42,9 @@ variable {ι M : Type*} [CommMonoid M] [AddCommMonoid M] [Fintype ι] {s : Finse
 #guard_msgs in
 #check Finset.prod {j | p j} fun i ↦ f i
 
-/-! ### Big operators over a finset with `piBinderTypes` off -/
+/-! ### Big operators over a finset with `funBinderTypes` off -/
 
-set_option pp.piBinderTypes false
+set_option pp.funBinderTypes false
 
 /-- info: ∑ i, f i : M -/
 #guard_msgs in

--- a/MathlibTest/BigOps.lean
+++ b/MathlibTest/BigOps.lean
@@ -4,13 +4,37 @@ section
 variable {ι M : Type*} [CommMonoid M] [AddCommMonoid M] [Fintype ι] {s : Finset ι} {p : ι → Prop}
   [DecidablePred p] {f : ι → M}
 
-#guard_expr ∑ i, f i = Finset.sum Finset.univ fun i ↦ f i
-#guard_expr ∏ i, f i = Finset.prod Finset.univ fun i ↦ f i
-#guard_expr ∑ i ∈ s, f i = Finset.sum s fun i ↦ f i
-#guard_expr ∏ i ∈ s, f i = Finset.prod s fun i ↦ f i
-#guard_expr ∑ i with p i, f i = Finset.sum {i | p i} fun i ↦ f i
-#guard_expr ∏ i with p i, f i = Finset.prod {i | p i} fun i ↦ f i
-#guard_expr ∑ i ∈ s with p i, f i = Finset.sum {i ∈ s | p i} fun i ↦ f i
-#guard_expr ∏ i ∈ s with p i, f i = Finset.prod {i ∈ s | p i} fun i ↦ f i
+
+/-- info: ∑ i : ι, f i : M -/
+#guard_msgs in
+#check Finset.sum Finset.univ fun i ↦ f i
+
+/-- info: ∏ i : ι, f i : M -/
+#guard_msgs in
+#check Finset.prod Finset.univ fun i ↦ f i
+
+/-- info: ∑ i ∈ s, f i : M -/
+#guard_msgs in
+#check Finset.sum s fun i ↦ f i
+
+/-- info: ∏ i ∈ s, f i : M -/
+#guard_msgs in
+#check Finset.prod s fun i ↦ f i
+
+/-- info: ∑ i with p i, f i : M -/
+#guard_msgs in
+#check Finset.sum {i | p i} fun i ↦ f i
+
+/-- info: ∏ i with p i, f i : M -/
+#guard_msgs in 
+#check Finset.prod {i | p i} fun i ↦ f i
+
+/-- info: ∑ i ∈ s with p i, f i : M -/
+#guard_msgs in
+#check Finset.sum {i ∈ s | p i} fun i ↦ f i
+
+/-- info: ∏ i ∈ s with p i, f i : M -/
+#guard_msgs in
+#check Finset.prod {i ∈ s | p i} fun i ↦ f i
 
 end


### PR DESCRIPTION
Co-authored-by: Kyle Miller <kmill31415@gmail.com>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
