### PR TITLE
[Merged by Bors] - chore: spaces around `to_additive`

### DIFF
--- a/Mathlib/Algebra/Group/Action/Faithful.lean
+++ b/Mathlib/Algebra/Group/Action/Faithful.lean
@@ -52,7 +52,7 @@ lemma smul_left_injective' [SMul M α] [FaithfulSMul M α] : Injective ((· • 
   fun _ _ h ↦ FaithfulSMul.eq_of_smul_eq_smul (congr_fun h)
 
 /-- `Monoid.toMulAction` is faithful on cancellative monoids. -/
-@[to_additive " `AddMonoid.toAddAction` is faithful on additive cancellative monoids. "]
+@[to_additive "`AddMonoid.toAddAction` is faithful on additive cancellative monoids."]
 instance RightCancelMonoid.faithfulSMul [RightCancelMonoid α] : FaithfulSMul α α :=
   ⟨fun h ↦ mul_right_cancel (h 1)⟩
 

--- a/Mathlib/Algebra/Group/Pointwise/Set/BigOperators.lean
+++ b/Mathlib/Algebra/Group/Pointwise/Set/BigOperators.lean
@@ -46,7 +46,7 @@ theorem image_finset_prod (f : F) (m : Finset ι) (s : ι → Set α) :
   (image_multiset_prod f _).trans <| congr_arg Multiset.prod <| Multiset.map_map _ _ _
 
 /-- The n-ary version of `Set.mem_mul`. -/
-@[to_additive " The n-ary version of `Set.mem_add`. "]
+@[to_additive "The n-ary version of `Set.mem_add`."]
 theorem mem_finset_prod (t : Finset ι) (f : ι → Set α) (a : α) :
     (a ∈ ∏ i ∈ t, f i) ↔ ∃ (g : ι → α) (_ : ∀ {i}, i ∈ t → g i ∈ f i), ∏ i ∈ t, g i = a := by
   classical
@@ -76,14 +76,14 @@ lemma mem_pow_iff_prod {n : ℕ} {s : Set α} {a : α} :
   simpa using mem_finset_prod (t := .univ) (f := fun _ : Fin n ↦ s) _
 
 /-- A version of `Set.mem_finset_prod` with a simpler RHS for products over a Fintype. -/
-@[to_additive " A version of `Set.mem_finset_sum` with a simpler RHS for sums over a Fintype. "]
+@[to_additive "A version of `Set.mem_finset_sum` with a simpler RHS for sums over a Fintype."]
 theorem mem_fintype_prod [Fintype ι] (f : ι → Set α) (a : α) :
     (a ∈ ∏ i, f i) ↔ ∃ (g : ι → α) (_ : ∀ i, g i ∈ f i), ∏ i, g i = a := by
   rw [mem_finset_prod]
   simp
 
 /-- An n-ary version of `Set.mul_mem_mul`. -/
-@[to_additive " An n-ary version of `Set.add_mem_add`. "]
+@[to_additive "An n-ary version of `Set.add_mem_add`."]
 theorem list_prod_mem_list_prod (t : List ι) (f : ι → Set α) (g : ι → α) (hg : ∀ i ∈ t, g i ∈ f i) :
     (t.map g).prod ∈ (t.map f).prod := by
   induction' t with h tl ih
@@ -93,7 +93,7 @@ theorem list_prod_mem_list_prod (t : List ι) (f : ι → Set α) (g : ι → α
       (ih fun i hi ↦ hg i <| List.mem_cons_of_mem _ hi)
 
 /-- An n-ary version of `Set.mul_subset_mul`. -/
-@[to_additive " An n-ary version of `Set.add_subset_add`. "]
+@[to_additive "An n-ary version of `Set.add_subset_add`."]
 theorem list_prod_subset_list_prod (t : List ι) (f₁ f₂ : ι → Set α) (hf : ∀ i ∈ t, f₁ i ⊆ f₂ i) :
     (t.map f₁).prod ⊆ (t.map f₂).prod := by
   induction' t with h tl ih
@@ -108,7 +108,7 @@ theorem list_prod_singleton {M : Type*} [CommMonoid M] (s : List M) :
   (map_list_prod (singletonMonoidHom : M →* Set M) _).symm
 
 /-- An n-ary version of `Set.mul_mem_mul`. -/
-@[to_additive " An n-ary version of `Set.add_mem_add`. "]
+@[to_additive "An n-ary version of `Set.add_mem_add`."]
 theorem multiset_prod_mem_multiset_prod (t : Multiset ι) (f : ι → Set α) (g : ι → α)
     (hg : ∀ i ∈ t, g i ∈ f i) : (t.map g).prod ∈ (t.map f).prod := by
   induction t using Quotient.inductionOn
@@ -116,7 +116,7 @@ theorem multiset_prod_mem_multiset_prod (t : Multiset ι) (f : ι → Set α) (g
   exact list_prod_mem_list_prod _ _ _ hg
 
 /-- An n-ary version of `Set.mul_subset_mul`. -/
-@[to_additive " An n-ary version of `Set.add_subset_add`. "]
+@[to_additive "An n-ary version of `Set.add_subset_add`."]
 theorem multiset_prod_subset_multiset_prod (t : Multiset ι) (f₁ f₂ : ι → Set α)
     (hf : ∀ i ∈ t, f₁ i ⊆ f₂ i) : (t.map f₁).prod ⊆ (t.map f₂).prod := by
   induction t using Quotient.inductionOn
@@ -129,13 +129,13 @@ theorem multiset_prod_singleton {M : Type*} [CommMonoid M] (s : Multiset M) :
   (map_multiset_prod (singletonMonoidHom : M →* Set M) _).symm
 
 /-- An n-ary version of `Set.mul_mem_mul`. -/
-@[to_additive " An n-ary version of `Set.add_mem_add`. "]
+@[to_additive "An n-ary version of `Set.add_mem_add`."]
 theorem finset_prod_mem_finset_prod (t : Finset ι) (f : ι → Set α) (g : ι → α)
     (hg : ∀ i ∈ t, g i ∈ f i) : (∏ i ∈ t, g i) ∈ ∏ i ∈ t, f i :=
   multiset_prod_mem_multiset_prod _ _ _ hg
 
 /-- An n-ary version of `Set.mul_subset_mul`. -/
-@[to_additive " An n-ary version of `Set.add_subset_add`. "]
+@[to_additive "An n-ary version of `Set.add_subset_add`."]
 theorem finset_prod_subset_finset_prod (t : Finset ι) (f₁ f₂ : ι → Set α)
     (hf : ∀ i ∈ t, f₁ i ⊆ f₂ i) : ∏ i ∈ t, f₁ i ⊆ ∏ i ∈ t, f₂ i :=
   multiset_prod_subset_multiset_prod _ _ _ hf
@@ -146,14 +146,14 @@ theorem finset_prod_singleton {M ι : Type*} [CommMonoid M] (s : Finset ι) (I :
   (map_prod (singletonMonoidHom : M →* Set M) _ _).symm
 
 /-- The n-ary version of `Set.image_mul_prod`. -/
-@[to_additive "The n-ary version of `Set.add_image_prod`. "]
+@[to_additive "The n-ary version of `Set.add_image_prod`."]
 theorem image_finset_prod_pi (l : Finset ι) (S : ι → Set α) :
     (fun f : ι → α => ∏ i ∈ l, f i) '' (l : Set ι).pi S = ∏ i ∈ l, S i := by
   ext
   simp_rw [mem_finset_prod, mem_image, mem_pi, exists_prop, Finset.mem_coe]
 
 /-- A special case of `Set.image_finset_prod_pi` for `Finset.univ`. -/
-@[to_additive "A special case of `Set.image_finset_sum_pi` for `Finset.univ`. "]
+@[to_additive "A special case of `Set.image_finset_sum_pi` for `Finset.univ`."]
 theorem image_fintype_prod_pi [Fintype ι] (S : ι → Set α) :
     (fun f : ι → α => ∏ i, f i) '' univ.pi S = ∏ i, S i := by
   simpa only [Finset.coe_univ] using image_finset_prod_pi Finset.univ S

--- a/Mathlib/Algebra/Group/Submonoid/Operations.lean
+++ b/Mathlib/Algebra/Group/Submonoid/Operations.lean
@@ -314,7 +314,7 @@ section GaloisCoinsertion
 variable {ι : Type*} {f : F}
 
 /-- `map f` and `comap f` form a `GaloisCoinsertion` when `f` is injective. -/
-@[to_additive " `map f` and `comap f` form a `GaloisCoinsertion` when `f` is injective. "]
+@[to_additive "`map f` and `comap f` form a `GaloisCoinsertion` when `f` is injective."]
 def gciMapComap (hf : Function.Injective f) : GaloisCoinsertion (map f) (comap f) :=
   (gc_map_comap f).toGaloisCoinsertion fun S x => by simp [mem_comap, mem_map, hf.eq_iff]
 
@@ -364,7 +364,7 @@ section GaloisInsertion
 variable {ι : Type*} {f : F}
 
 /-- `map f` and `comap f` form a `GaloisInsertion` when `f` is surjective. -/
-@[to_additive " `map f` and `comap f` form a `GaloisInsertion` when `f` is surjective. "]
+@[to_additive "`map f` and `comap f` form a `GaloisInsertion` when `f` is surjective."]
 def giMapComap (hf : Function.Surjective f) : GaloisInsertion (map f) (comap f) :=
   (gc_map_comap f).toGaloisInsertion fun S x h =>
     let ⟨y, hy⟩ := hf x

--- a/Mathlib/Algebra/Group/Submonoid/Pointwise.lean
+++ b/Mathlib/Algebra/Group/Submonoid/Pointwise.lean
@@ -134,7 +134,7 @@ theorem pow_smul_mem_closure_smul {N : Type*} [CommMonoid N] [MulAction M N] [Is
 variable [Group G]
 
 /-- The submonoid with every element inverted. -/
-@[to_additive " The additive submonoid with every element negated. "]
+@[to_additive "The additive submonoid with every element negated."]
 protected def inv : Inv (Submonoid G) where
   inv S :=
     { carrier := (S : Set G)⁻¹

--- a/Mathlib/Algebra/Group/Submonoid/Units.lean
+++ b/Mathlib/Algebra/Group/Submonoid/Units.lean
@@ -41,13 +41,13 @@ open Units
 
 open Pointwise in
 /-- The units of `S`, packaged as a subgroup of `Mˣ`. -/
-@[to_additive " The additive units of `S`, packaged as an additive subgroup of `AddUnits M`. "]
+@[to_additive "The additive units of `S`, packaged as an additive subgroup of `AddUnits M`."]
 def Submonoid.units (S : Submonoid M) : Subgroup Mˣ where
   toSubmonoid := S.comap (coeHom M) ⊓ (S.comap (coeHom M))⁻¹
   inv_mem' ha := ⟨ha.2, ha.1⟩
 
 /-- A subgroup of units represented as a submonoid of `M`. -/
-@[to_additive " A additive subgroup of additive units represented as a additive submonoid of `M`. "]
+@[to_additive "A additive subgroup of additive units represented as a additive submonoid of `M`."]
 def Subgroup.ofUnits (S : Subgroup Mˣ) : Submonoid M := S.toSubmonoid.map (coeHom M)
 
 @[to_additive]
@@ -69,9 +69,9 @@ lemma Subgroup.units_ofUnits_eq (S : Subgroup Mˣ) : S.ofUnits.units = S :=
 
 /-- A Galois coinsertion exists between the coercion from a subgroup of units to a submonoid and
 the reduction from a submonoid to its unit group. -/
-@[to_additive " A Galois coinsertion exists between the coercion from a additive subgroup of
+@[to_additive "A Galois coinsertion exists between the coercion from a additive subgroup of
 additive units to a additive submonoid and the reduction from a additive submonoid to its unit
-group. " ]
+group."]
 def ofUnits_units_gci : GaloisCoinsertion (Subgroup.ofUnits (M := M)) (Submonoid.units) :=
   GaloisCoinsertion.monotoneIntro Submonoid.units_mono Subgroup.ofUnits_mono
   Submonoid.ofUnits_units_le Subgroup.units_ofUnits_eq
@@ -130,8 +130,8 @@ lemma inv_mem_units (S : Submonoid M) {x : Mˣ} (h : x ∈ S.units) : x⁻¹ ∈
 lemma inv_mem_units_iff (S : Submonoid M) {x : Mˣ} : x⁻¹ ∈ S.units ↔ x ∈ S.units := inv_mem_iff
 
 /-- The equivalence between the subgroup of units of `S` and the type of units of `S`. -/
-@[to_additive " The equivalence between the additive subgroup of additive units of
-`S` and the type of additive units of `S`. "]
+@[to_additive "The equivalence between the additive subgroup of additive units of
+`S` and the type of additive units of `S`."]
 def unitsEquivUnitsType (S : Submonoid M) : S.units ≃* Sˣ where
   toFun := fun ⟨_, h⟩ => ⟨⟨_, h.1⟩, ⟨_, h.2⟩, S.mk_mul_mk_inv_eq_one h, S.mk_inv_mul_mk_eq_one h⟩
   invFun := fun x => ⟨⟨_, _, S.coe_val_mul_coe_inv_val, S.coe_inv_val_mul_coe_val⟩, ⟨x.1.2, x.2.2⟩⟩
@@ -173,8 +173,8 @@ lemma units_left_inverse :
 
 /-- The equivalence between the subgroup of units of `S` and the submonoid of unit
 elements of `S`. -/
-@[to_additive " The equivalence between the additive subgroup of additive units of
-`S` and the additive submonoid of additive unit elements of `S`.  "]
+@[to_additive "The equivalence between the additive subgroup of additive units of
+`S` and the additive submonoid of additive unit elements of `S`."]
 noncomputable def unitsEquivIsUnitSubmonoid (S : Submonoid M) : S.units ≃* IsUnit.submonoid S :=
 S.unitsEquivUnitsType.trans unitsTypeEquivIsUnitSubmonoid
 
@@ -206,10 +206,10 @@ lemma isUnit_of_mem_ofUnits (S : Subgroup Mˣ) {x : M} (hx : x ∈ S.ofUnits) : 
   | ⟨_, _, h⟩ => ⟨_, h⟩
 
 /-- Given some `x : M` which is a member of the submonoid of unit elements corresponding to a
-  subgroup of units, produce a unit of `M` whose coercion is equal to `x`. `-/
-@[to_additive " Given some `x : M` which is a member of the additive submonoid of additive unit
+subgroup of units, produce a unit of `M` whose coercion is equal to `x`. -/
+@[to_additive "Given some `x : M` which is a member of the additive submonoid of additive unit
 elements corresponding to a subgroup of units, produce a unit of `M` whose coercion is equal to
-`x`. "]
+`x`."]
 noncomputable def unit_of_mem_ofUnits (S : Subgroup Mˣ) {x : M} (h : x ∈ S.ofUnits) : Mˣ :=
   (Classical.choose h).copy x (Classical.choose_spec h).2.symm _ rfl
 
@@ -246,8 +246,8 @@ lemma mem_ofUnits_iff_exists_isUnit (S : Subgroup Mˣ) (x : M) :
 
 /-- The equivalence between the coercion of a subgroup `S` of `Mˣ` to a submonoid of `M` and
 the subgroup itself as a type. -/
-@[to_additive " The equivalence between the coercion of an additive subgroup `S` of
-`Mˣ` to an additive submonoid of `M` and the additive subgroup itself as a type. "]
+@[to_additive "The equivalence between the coercion of an additive subgroup `S` of
+`Mˣ` to an additive submonoid of `M` and the additive subgroup itself as a type."]
 noncomputable def ofUnitsEquivType (S : Subgroup Mˣ) : S.ofUnits ≃* S where
   toFun := fun x => ⟨S.unit_of_mem_ofUnits x.2, S.unit_of_mem_ofUnits_spec_mem⟩
   invFun := fun x => ⟨x.1, ⟨x.1, x.2, rfl⟩⟩
@@ -300,8 +300,8 @@ lemma ofUnits_le_ofUnits_iff {S T : Subgroup Mˣ} : S.ofUnits ≤ T.ofUnits ↔ 
 
 /-- The equivalence between the top subgroup of `Mˣ` coerced to a submonoid `M` and the
 units of `M`. -/
-@[to_additive " The equivalence between the additive subgroup of additive units of
-`S` and the additive submonoid of additive unit elements of `S`.  "]
+@[to_additive "The equivalence between the additive subgroup of additive units of
+`S` and the additive submonoid of additive unit elements of `S`."]
 noncomputable def ofUnitsTopEquiv : (⊤ : Subgroup Mˣ).ofUnits ≃* Mˣ :=
   (⊤ : Subgroup Mˣ).ofUnitsEquivType.trans topEquiv
 
@@ -324,8 +324,8 @@ lemma val_mem_ofUnits_iff_mem (H : Subgroup Gˣ) (x : Gˣ) : (x : G) ∈ H.ofUni
   simp_rw [mem_ofUnits_iff_toUnits_mem, toUnits_val_apply]
 
 /-- The equivalence between the greatest subgroup of units contained within `T` and `T` itself. -/
-@[to_additive " The equivalence between the greatest subgroup of additive units
-contained within `T` and `T` itself. "]
+@[to_additive "The equivalence between the greatest subgroup of additive units
+contained within `T` and `T` itself."]
 def unitsEquivSelf (H : Subgroup G) : H.units ≃* H :=
   H.unitsEquivUnitsType.trans (toUnits (G := H)).symm
 

--- a/Mathlib/Algebra/Group/Subsemigroup/Operations.lean
+++ b/Mathlib/Algebra/Group/Subsemigroup/Operations.lean
@@ -314,7 +314,7 @@ section GaloisCoinsertion
 variable {ι : Type*} {f : M →ₙ* N}
 
 /-- `map f` and `comap f` form a `GaloisCoinsertion` when `f` is injective. -/
-@[to_additive " `map f` and `comap f` form a `GaloisCoinsertion` when `f` is injective. "]
+@[to_additive "`map f` and `comap f` form a `GaloisCoinsertion` when `f` is injective."]
 def gciMapComap (hf : Function.Injective f) : GaloisCoinsertion (map f) (comap f) :=
   (gc_map_comap f).toGaloisCoinsertion fun S x => by simp [mem_comap, mem_map, hf.eq_iff]
 
@@ -367,7 +367,7 @@ variable {ι : Type*} {f : M →ₙ* N} (hf : Function.Surjective f)
 include hf
 
 /-- `map f` and `comap f` form a `GaloisInsertion` when `f` is surjective. -/
-@[to_additive " `map f` and `comap f` form a `GaloisInsertion` when `f` is surjective. "]
+@[to_additive "`map f` and `comap f` form a `GaloisInsertion` when `f` is surjective."]
 def giMapComap : GaloisInsertion (map f) (comap f) :=
   (gc_map_comap f).toGaloisInsertion fun S x h =>
     let ⟨y, hy⟩ := hf x

--- a/Mathlib/GroupTheory/GroupAction/FixingSubgroup.lean
+++ b/Mathlib/GroupTheory/GroupAction/FixingSubgroup.lean
@@ -46,7 +46,7 @@ open MulAction
 variable (M : Type*) {α : Type*} [Monoid M] [MulAction M α]
 
 /-- The submonoid fixing a set under a `MulAction`. -/
-@[to_additive " The additive submonoid fixing a set under an `AddAction`. "]
+@[to_additive "The additive submonoid fixing a set under an `AddAction`."]
 def fixingSubmonoid (s : Set α) : Submonoid M where
   carrier := { ϕ : M | ∀ x : s, ϕ • (x : α) = x }
   one_mem' _ := one_smul _ _
@@ -99,7 +99,7 @@ open MulAction
 variable (M : Type*) {α : Type*} [Group M] [MulAction M α]
 
 /-- The subgroup fixing a set under a `MulAction`. -/
-@[to_additive " The additive subgroup fixing a set under an `AddAction`. "]
+@[to_additive "The additive subgroup fixing a set under an `AddAction`."]
 def fixingSubgroup (s : Set α) : Subgroup M :=
   { fixingSubmonoid M s with inv_mem' := fun hx z => by rw [inv_smul_eq_iff, hx z] }
 

--- a/Mathlib/MeasureTheory/Group/Arithmetic.lean
+++ b/Mathlib/MeasureTheory/Group/Arithmetic.lean
@@ -152,8 +152,8 @@ end Mul
 
 /-- A version of `measurable_div_const` that assumes `MeasurableMul` instead of
   `MeasurableDiv`. This can be nice to avoid unnecessary type-class assumptions. -/
-@[to_additive " A version of `measurable_sub_const` that assumes `MeasurableAdd` instead of
-  `MeasurableSub`. This can be nice to avoid unnecessary type-class assumptions. "]
+@[to_additive "A version of `measurable_sub_const` that assumes `MeasurableAdd` instead of
+  `MeasurableSub`. This can be nice to avoid unnecessary type-class assumptions."]
 theorem measurable_div_const' {G : Type*} [DivInvMonoid G] [MeasurableSpace G] [MeasurableMul G]
     (g : G) : Measurable fun h => h / g := by simp_rw [div_eq_mul_inv, measurable_mul_const]
 

--- a/Mathlib/MeasureTheory/Group/MeasurableEquiv.lean
+++ b/Mathlib/MeasureTheory/Group/MeasurableEquiv.lean
@@ -189,14 +189,14 @@ theorem symm_inv {G} [MeasurableSpace G] [InvolutiveInv G] [MeasurableInv G] :
   rfl
 
 /-- `equiv.divRight` as a `MeasurableEquiv`. -/
-@[to_additive " `equiv.subRight` as a `MeasurableEquiv` "]
+@[to_additive "`equiv.subRight` as a `MeasurableEquiv`"]
 def divRight [MeasurableMul G] (g : G) : G ≃ᵐ G where
   toEquiv := Equiv.divRight g
   measurable_toFun := measurable_div_const' g
   measurable_invFun := measurable_mul_const g
 
 /-- `equiv.divLeft` as a `MeasurableEquiv` -/
-@[to_additive " `equiv.subLeft` as a `MeasurableEquiv` "]
+@[to_additive "`equiv.subLeft` as a `MeasurableEquiv`"]
 def divLeft [MeasurableMul G] [MeasurableInv G] (g : G) : G ≃ᵐ G where
   toEquiv := Equiv.divLeft g
   measurable_toFun := measurable_id.const_div g

--- a/Mathlib/MeasureTheory/Group/Measure.lean
+++ b/Mathlib/MeasureTheory/Group/Measure.lean
@@ -99,7 +99,7 @@ instance Subgroup.smulInvariantMeasure {G α : Type*} [Group G] [MulAction G α]
   ⟨fun y s hs => by convert SMulInvariantMeasure.measure_preimage_smul (μ := μ) (y : G) hs⟩
 
 /-- An alternative way to prove that `μ` is left invariant under multiplication. -/
-@[to_additive " An alternative way to prove that `μ` is left invariant under addition. "]
+@[to_additive "An alternative way to prove that `μ` is left invariant under addition."]
 theorem forall_measure_preimage_mul_iff (μ : Measure G) :
     (∀ (g : G) (A : Set G), MeasurableSet A → μ ((fun h => g * h) ⁻¹' A) = μ A) ↔
       IsMulLeftInvariant μ := by
@@ -110,7 +110,7 @@ theorem forall_measure_preimage_mul_iff (μ : Measure G) :
   exact ⟨fun h => ⟨h⟩, fun h => h.1⟩
 
 /-- An alternative way to prove that `μ` is right invariant under multiplication. -/
-@[to_additive " An alternative way to prove that `μ` is right invariant under addition. "]
+@[to_additive "An alternative way to prove that `μ` is right invariant under addition."]
 theorem forall_measure_preimage_mul_right_iff (μ : Measure G) :
     (∀ (g : G) (A : Set G), MeasurableSet A → μ ((fun h => h * g) ⁻¹' A) = μ A) ↔
       IsMulRightInvariant μ := by

--- a/Mathlib/Topology/Algebra/Group/Basic.lean
+++ b/Mathlib/Topology/Algebra/Group/Basic.lean
@@ -1053,7 +1053,7 @@ variable [Group G] [TopologicalSpace G] [IsTopologicalGroup G]
 
 /-- A version of `Homeomorph.mulLeft a b⁻¹` that is defeq to `a / b`. -/
 @[to_additive (attr := simps! (config := { simpRhs := true }))
-  " A version of `Homeomorph.addLeft a (-b)` that is defeq to `a - b`. "]
+  "A version of `Homeomorph.addLeft a (-b)` that is defeq to `a - b`."]
 def Homeomorph.divLeft (x : G) : G ≃ₜ G :=
   { Equiv.divLeft x with
     continuous_toFun := continuous_const.div' continuous_id
@@ -1631,7 +1631,7 @@ instance {G} [TopologicalSpace G] [AddGroup G] [IsTopologicalAddGroup G] :
   continuous_inv := @continuous_neg G _ _ _
 
 /-- If `G` is a group with topological `⁻¹`, then it is homeomorphic to its units. -/
-@[to_additive " If `G` is an additive group with topological negation, then it is homeomorphic to
+@[to_additive "If `G` is an additive group with topological negation, then it is homeomorphic to
 its additive units."]
 def toUnits_homeomorph [Group G] [TopologicalSpace G] [ContinuousInv G] : G ≃ₜ Gˣ where
   toEquiv := toUnits.toEquiv

--- a/Mathlib/Topology/Algebra/Support.lean
+++ b/Mathlib/Topology/Algebra/Support.lean
@@ -38,9 +38,9 @@ section One
 variable [One α] [TopologicalSpace X]
 
 /-- The topological support of a function is the closure of its support, i.e. the closure of the
-  set of all elements where the function is not equal to 1. -/
-@[to_additive " The topological support of a function is the closure of its support. i.e. the
-closure of the set of all elements where the function is nonzero. "]
+set of all elements where the function is not equal to 1. -/
+@[to_additive "The topological support of a function is the closure of its support. i.e. the
+closure of the set of all elements where the function is nonzero."]
 def mulTSupport (f : X → α) : Set X := closure (mulSupport f)
 
 @[to_additive]
@@ -123,9 +123,9 @@ variable {g : β → γ} {f : α → β} {f₂ : α → γ} {m : β → γ → �
 /-- A function `f` *has compact multiplicative support* or is *compactly supported* if the closure
 of the multiplicative support of `f` is compact. In a T₂ space this is equivalent to `f` being equal
 to `1` outside a compact set. -/
-@[to_additive " A function `f` *has compact support* or is *compactly supported* if the closure of
+@[to_additive "A function `f` *has compact support* or is *compactly supported* if the closure of
 the support of `f` is compact. In a T₂ space this is equivalent to `f` being equal to `0` outside a
-compact set. "]
+compact set."]
 def HasCompactMulSupport (f : α → β) : Prop :=
   IsCompact (mulTSupport f)
 
@@ -376,9 +376,9 @@ variable {ι : Type*} [TopologicalSpace X]
 /-- If a family of functions `f` has locally-finite multiplicative support, subordinate to a family
 of open sets, then for any point we can find a neighbourhood on which only finitely-many members of
 `f` are not equal to 1. -/
-@[to_additive " If a family of functions `f` has locally-finite support, subordinate to a family of
+@[to_additive "If a family of functions `f` has locally-finite support, subordinate to a family of
 open sets, then for any point we can find a neighbourhood on which only finitely-many members of `f`
-are non-zero. "]
+are non-zero."]
 theorem LocallyFinite.exists_finset_nhd_mulSupport_subset {U : ι → Set X} [One R] {f : ι → X → R}
     (hlf : LocallyFinite fun i => mulSupport (f i)) (hso : ∀ i, mulTSupport (f i) ⊆ U i)
     (ho : ∀ i, IsOpen (U i)) (x : X) :

--- a/Mathlib/Topology/Order/Compact.lean
+++ b/Mathlib/Topology/Order/Compact.lean
@@ -375,13 +375,13 @@ theorem IsCompact.bddAbove_image [ClosedIciTopology α] [Nonempty α] {f : β �
   IsCompact.bddBelow_image (α := αᵒᵈ) hK hf
 
 /-- A continuous function with compact support is bounded below. -/
-@[to_additive " A continuous function with compact support is bounded below. "]
+@[to_additive "A continuous function with compact support is bounded below."]
 theorem Continuous.bddBelow_range_of_hasCompactMulSupport [ClosedIicTopology α] [One α]
     {f : β → α} (hf : Continuous f) (h : HasCompactMulSupport f) : BddBelow (range f) :=
   (h.isCompact_range hf).bddBelow
 
 /-- A continuous function with compact support is bounded above. -/
-@[to_additive " A continuous function with compact support is bounded above. "]
+@[to_additive "A continuous function with compact support is bounded above."]
 theorem Continuous.bddAbove_range_of_hasCompactMulSupport [ClosedIciTopology α] [One α]
     {f : β → α} (hf : Continuous f) (h : HasCompactMulSupport f) : BddAbove (range f) :=
   Continuous.bddBelow_range_of_hasCompactMulSupport (α := αᵒᵈ) hf h


### PR DESCRIPTION
More space changes, mostly about removing spaces in `@[to_additive " Text. " ]` around `"`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
