### PR TITLE
[Merged by Bors] - feat(CategoryTheory/Abelian): mono are stable under cobase change

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1706,6 +1706,7 @@ import Mathlib.CategoryTheory.Abelian.Images
 import Mathlib.CategoryTheory.Abelian.Injective
 import Mathlib.CategoryTheory.Abelian.InjectiveResolution
 import Mathlib.CategoryTheory.Abelian.LeftDerived
+import Mathlib.CategoryTheory.Abelian.Monomorphisms
 import Mathlib.CategoryTheory.Abelian.NonPreadditive
 import Mathlib.CategoryTheory.Abelian.Opposite
 import Mathlib.CategoryTheory.Abelian.Projective

--- a/Mathlib/CategoryTheory/Abelian/Monomorphisms.lean
+++ b/Mathlib/CategoryTheory/Abelian/Monomorphisms.lean
@@ -1,0 +1,36 @@
+/-
+Copyright (c) 2025 Joël Riou. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joël Riou
+-/
+import Mathlib.CategoryTheory.MorphismProperty.Limits
+import Mathlib.CategoryTheory.Abelian.Basic
+
+/-!
+# Monomorphisms are stable under cobase change
+
+In an abelian category `C`, the class of morphism
+`monomorphisms C` is stable under cobase change and
+`epimorphisms C` is stable under base change.
+
+-/
+
+universe v u
+
+namespace CategoryTheory.Abelian
+
+variable {C : Type u} [Category.{v} C] [Abelian C]
+
+open MorphismProperty
+
+instance : (monomorphisms C).IsStableUnderCobaseChange :=
+  IsStableUnderCobaseChange.mk' (fun _ _ _ f g _ hf ↦ by
+    simp only [monomorphisms.iff] at hf ⊢
+    infer_instance)
+
+instance : (epimorphisms C).IsStableUnderBaseChange :=
+  IsStableUnderBaseChange.mk' (fun _ _ _ f g _ hf ↦ by
+    simp only [epimorphisms.iff] at hf ⊢
+    infer_instance)
+
+end CategoryTheory.Abelian


### PR DESCRIPTION
In this PR, we get the instances `(monomorphisms C).IsStableUnderCobaseChange` and `(epimorphisms C).IsStableUnderBaseChange` in an abelian category `C`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
