### PR TITLE
[Merged by Bors] - chore: fix ending commas in doc-strings

### DIFF
--- a/Mathlib/Algebra/Algebra/Pi.lean
+++ b/Mathlib/Algebra/Algebra/Pi.lean
@@ -98,7 +98,7 @@ theorem constAlgHom_eq_algebra_ofId : constAlgHom R A R = Algebra.ofId R (A → 
 end Pi
 
 /-- A special case of `Pi.algebra` for non-dependent types. Lean struggles to elaborate
-definitions elsewhere in the library without this, -/
+definitions elsewhere in the library without this. -/
 instance Function.algebra {R : Type*} (ι : Type*) (A : Type*) [CommSemiring R] [Semiring A]
     [Algebra R A] : Algebra R (ι → A) :=
   Pi.algebra _ _

--- a/Mathlib/Algebra/MvPolynomial/CommRing.lean
+++ b/Mathlib/Algebra/MvPolynomial/CommRing.lean
@@ -145,8 +145,8 @@ theorem eval_neg (f : σ → R) : eval f (-p) = -eval f p :=
 theorem hom_C (f : MvPolynomial σ ℤ →+* S) (n : ℤ) : f (C n) = (n : S) :=
   eq_intCast (f.comp C) n
 
-/-- A ring homomorphism f : Z[X_1, X_2, ...] → R
-is determined by the evaluations f(X_1), f(X_2), ... -/
+/-- A ring homomorphism `f : Z[X_1, X_2, ...] → R`
+is determined by the evaluations `f(X_1)`, `f(X_2)`, ... -/
 @[simp]
 theorem eval₂Hom_X {R : Type u} (c : ℤ →+* S) (f : MvPolynomial R ℤ →+* S) (x : MvPolynomial R ℤ) :
     eval₂ c (f ∘ X) x = f x := by
@@ -162,7 +162,7 @@ theorem eval₂Hom_X {R : Type u} (c : ℤ →+* S) (f : MvPolynomial R ℤ →+
       exact (f.map_mul _ _).symm)
 
 /-- Ring homomorphisms out of integer polynomials on a type `σ` are the same as
-functions out of the type `σ`, -/
+functions out of the type `σ`. -/
 def homEquiv : (MvPolynomial σ ℤ →+* S) ≃ (σ → S) where
   toFun f := f ∘ X
   invFun f := eval₂Hom (Int.castRingHom S) f

--- a/Mathlib/CategoryTheory/Sites/CoverLifting.lean
+++ b/Mathlib/CategoryTheory/Sites/CoverLifting.lean
@@ -199,7 +199,7 @@ lemma hom_ext {W : A} {f g : W ⟶ R.obj (op X)}
 variable (S)
 
 /-- Auxiliary definition for `ran_isSheaf_of_isCocontinuous`: if `G : C ⥤ D` is a
-cocontinuous functor,   -/
+cocontinuous functor. -/
 def isLimitMultifork : IsLimit (S.multifork R) :=
   Multifork.IsLimit.mk _ (lift hF hR) (fac hF hR)
     (fun s _ hm ↦ hom_ext K hF hR (fun i ↦ (hm i).trans (fac hF hR s i).symm))

--- a/Mathlib/Data/DFinsupp/BigOperators.lean
+++ b/Mathlib/Data/DFinsupp/BigOperators.lean
@@ -293,7 +293,7 @@ theorem sumAddHom_comm {ι₁ ι₂ : Sort _} {β₁ : ι₁ → Type*} {β₂ :
     AddMonoidHom.flip_apply, Trunc.lift, toFun_eq_coe, ZeroHom.coe_mk, coe_mk']
   exact Finset.sum_comm
 
-/-- The `DFinsupp` version of `Finsupp.liftAddHom`,-/
+/-- The `DFinsupp` version of `Finsupp.liftAddHom` -/
 @[simps apply symm_apply]
 def liftAddHom [∀ i, AddZeroClass (β i)] [AddCommMonoid γ] :
     (∀ i, β i →+ γ) ≃+ ((Π₀ i, β i) →+ γ) where
@@ -306,20 +306,20 @@ def liftAddHom [∀ i, AddZeroClass (β i)] [AddCommMonoid γ] :
 -- Porting note: The elaborator is struggling with `liftAddHom`. Passing it `β` explicitly helps.
 -- This applies to roughly the remainder of the file.
 
-/-- The `DFinsupp` version of `Finsupp.liftAddHom_singleAddHom`,-/
+/-- The `DFinsupp` version of `Finsupp.liftAddHom_singleAddHom` -/
 theorem liftAddHom_singleAddHom [∀ i, AddCommMonoid (β i)] :
     liftAddHom (β := β) (singleAddHom β) = AddMonoidHom.id (Π₀ i, β i) :=
   (liftAddHom (β := β)).toEquiv.apply_eq_iff_eq_symm_apply.2 rfl
 
-/-- The `DFinsupp` version of `Finsupp.liftAddHom_apply_single`,-/
+/-- The `DFinsupp` version of `Finsupp.liftAddHom_apply_single` -/
 theorem liftAddHom_apply_single [∀ i, AddZeroClass (β i)] [AddCommMonoid γ] (f : ∀ i, β i →+ γ)
     (i : ι) (x : β i) : liftAddHom (β := β) f (single i x) = f i x := by simp
 
-/-- The `DFinsupp` version of `Finsupp.liftAddHom_comp_single`,-/
+/-- The `DFinsupp` version of `Finsupp.liftAddHom_comp_single` -/
 theorem liftAddHom_comp_single [∀ i, AddZeroClass (β i)] [AddCommMonoid γ] (f : ∀ i, β i →+ γ)
     (i : ι) : (liftAddHom (β := β) f).comp (singleAddHom β i) = f i := by simp
 
-/-- The `DFinsupp` version of `Finsupp.comp_liftAddHom`,-/
+/-- The `DFinsupp` version of `Finsupp.comp_liftAddHom` -/
 theorem comp_liftAddHom {δ : Type*} [∀ i, AddZeroClass (β i)] [AddCommMonoid γ] [AddCommMonoid δ]
     (g : γ →+ δ) (f : ∀ i, β i →+ γ) :
     g.comp (liftAddHom (β := β) f) = liftAddHom (β := β) fun a => g.comp (f a) :=

--- a/Mathlib/Data/Num/Basic.lean
+++ b/Mathlib/Data/Num/Basic.lean
@@ -505,7 +505,7 @@ def divMod (d : PosNum) : PosNum → Num × Num
     divModAux d q (Num.bit1 r₁)
   | 1 => divModAux d 0 1
 
-/-- Division of `PosNum`, -/
+/-- Division of `PosNum` -/
 def div' (n d : PosNum) : Num :=
   (divMod d n).1
 

--- a/Mathlib/Lean/Expr/Basic.lean
+++ b/Mathlib/Lean/Expr/Basic.lean
@@ -101,12 +101,12 @@ end Name
 
 namespace ConstantInfo
 
-/-- Checks whether this `ConstantInfo` is a definition, -/
+/-- Checks whether this `ConstantInfo` is a definition. -/
 def isDef : ConstantInfo → Bool
   | defnInfo _ => true
   | _          => false
 
-/-- Checks whether this `ConstantInfo` is a theorem, -/
+/-- Checks whether this `ConstantInfo` is a theorem. -/
 def isThm : ConstantInfo → Bool
   | thmInfo _ => true
   | _          => false


### PR DESCRIPTION
Spotted by Michael in a different PR.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
