### PR TITLE
[Merged by Bors] - feat(CategoryTheory/Abelian): mono are stable under transfinite composition

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1701,6 +1701,7 @@ import Mathlib.CategoryTheory.Abelian.GrothendieckAxioms.Sheaf
 import Mathlib.CategoryTheory.Abelian.GrothendieckAxioms.Types
 import Mathlib.CategoryTheory.Abelian.GrothendieckCategory.Basic
 import Mathlib.CategoryTheory.Abelian.GrothendieckCategory.ColimCoyoneda
+import Mathlib.CategoryTheory.Abelian.GrothendieckCategory.Monomorphisms
 import Mathlib.CategoryTheory.Abelian.GrothendieckCategory.Subobject
 import Mathlib.CategoryTheory.Abelian.Images
 import Mathlib.CategoryTheory.Abelian.Injective

--- a/Mathlib/CategoryTheory/Abelian/GrothendieckCategory/Monomorphisms.lean
+++ b/Mathlib/CategoryTheory/Abelian/GrothendieckCategory/Monomorphisms.lean
@@ -1,0 +1,90 @@
+/-
+Copyright (c) 2025 Joël Riou. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joël Riou
+-/
+import Mathlib.CategoryTheory.Abelian.GrothendieckCategory.Basic
+import Mathlib.CategoryTheory.Abelian.GrothendieckAxioms.Colim
+import Mathlib.CategoryTheory.MorphismProperty.TransfiniteComposition
+
+/-!
+# Monomorphisms in Grothendieck abelian categories
+
+In this file, we show that in a Grothendieck abelian category,
+monomorphisms are stable under transfinite composition.
+
+-/
+
+universe w v u
+
+namespace CategoryTheory
+
+open Limits
+
+variable {C : Type u} [Category.{v} C] [Abelian C] [IsGrothendieckAbelian.{w} C]
+
+namespace MorphismProperty.TransfiniteCompositionOfShape
+
+variable {J : Type w} [LinearOrder J] [SuccOrder J] [OrderBot J] [WellFoundedLT J]
+  {X Y : C} {f : X ⟶ Y} (h : (monomorphisms C).TransfiniteCompositionOfShape J f)
+
+attribute [local instance] IsCofiltered.isConnected
+
+namespace mono
+
+instance map_bot_le (j : J) : Mono (h.F.map (homOfLE bot_le : ⊥ ⟶ j)) := by
+  induction j using SuccOrder.limitRecOn with
+  | hm j hj =>
+      obtain rfl := hj.eq_bot
+      exact inferInstanceAs (Mono (h.F.map (𝟙 _)))
+  | hs j hj hj' =>
+    have : Mono _ := h.map_mem j hj
+    rw [← homOfLE_comp bot_le (Order.le_succ j), Functor.map_comp]
+    infer_instance
+  | hl j hj hj' =>
+    have : OrderBot (Set.Iio j) :=
+      { bot := ⟨⊥, Order.IsSuccLimit.bot_lt hj ⟩
+        bot_le _ := bot_le }
+    let φ : (Functor.const _).obj (h.F.obj ⊥) ⟶
+        (Set.principalSegIio j).monotone.functor ⋙ h.F :=
+      { app k := h.F.map (homOfLE bot_le)
+        naturality k k' hkk' := by
+          dsimp
+          rw [Category.id_comp, ← Functor.map_comp]
+          rfl }
+    have (k : Set.Iio j) : Mono (φ.app k) := hj' k.1 k.2
+    have : Mono φ := NatTrans.mono_of_mono_app φ
+    apply colim.map_mono' φ
+      (isColimitConstCocone (Set.Iio j) (h.F.obj ⊥))
+      (h.F.isColimitOfIsWellOrderContinuous j hj)
+    rintro k
+    dsimp [φ]
+    rw [Category.id_comp, ← Functor.map_comp]
+    rfl
+
+end mono
+
+include h
+lemma mono : Mono f := by
+  let φ : (Functor.const _).obj X ⟶ h.F :=
+    { app k := h.isoBot.inv ≫ h.F.map (homOfLE bot_le)
+      naturality k k' hkk' := by
+        dsimp
+        rw [Category.id_comp, Category.assoc, ← Functor.map_comp]
+        rfl }
+  have : Mono φ := NatTrans.mono_of_mono_app φ
+  exact colim.map_mono' φ (isColimitConstCocone J X) (h.isColimit) f (by aesop_cat)
+
+end MorphismProperty.TransfiniteCompositionOfShape
+
+namespace IsGrothendieckAbelian
+
+open MorphismProperty
+
+instance : IsStableUnderTransfiniteComposition.{w} (monomorphisms C) where
+  isStableUnderTransfiniteCompositionOfShape _ _ _ _ _ :=
+    ⟨fun _ _ _ ⟨hf⟩ ↦ hf.mono⟩
+
+end IsGrothendieckAbelian
+
+end CategoryTheory

--- a/Mathlib/CategoryTheory/Abelian/GrothendieckCategory/Monomorphisms.lean
+++ b/Mathlib/CategoryTheory/Abelian/GrothendieckCategory/Monomorphisms.lean
@@ -64,7 +64,7 @@ instance map_bot_le (j : J) : Mono (h.F.map (homOfLE bot_le : ⊥ ⟶ j)) := by
 
 end mono
 
-include h
+include h in
 lemma mono : Mono f := by
   let φ : (Functor.const _).obj X ⟶ h.F :=
     { app k := h.isoBot.inv ≫ h.F.map (homOfLE bot_le)

--- a/Mathlib/CategoryTheory/Abelian/GrothendieckCategory/Monomorphisms.lean
+++ b/Mathlib/CategoryTheory/Abelian/GrothendieckCategory/Monomorphisms.lean
@@ -35,8 +35,8 @@ namespace mono
 instance map_bot_le (j : J) : Mono (h.F.map (homOfLE bot_le : ⊥ ⟶ j)) := by
   induction j using SuccOrder.limitRecOn with
   | hm j hj =>
-      obtain rfl := hj.eq_bot
-      exact inferInstanceAs (Mono (h.F.map (𝟙 _)))
+    obtain rfl := hj.eq_bot
+    exact inferInstanceAs (Mono (h.F.map (𝟙 _)))
   | hs j hj hj' =>
     have : Mono _ := h.map_mem j hj
     rw [← homOfLE_comp bot_le (Order.le_succ j), Functor.map_comp]


### PR DESCRIPTION
In a Grothendieck abelian category, monomorphisms are stable under transfinite composition.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
