### PR TITLE
[Merged by Bors] - feat(Algebra/Algebra/Lie): define the maximal nilpotent ideal of Lie algebras

### DIFF
--- a/Mathlib/Algebra/Lie/Nilpotent.lean
+++ b/Mathlib/Algebra/Lie/Nilpotent.lean
@@ -995,14 +995,14 @@ instance maxNilpotentIdealIsNilpotent [IsNoetherian R L] :
     IsNilpotent L (maxNilpotentIdeal R L) :=
   instMaxNilpotentSubmoduleIsNilpotent R L L
 
-theorem LieIdeal.nilpotent_iff_le_max_nilpotent_ideal [IsNoetherian R L] (I : LieIdeal R L) :
+theorem LieIdeal.nilpotent_iff_le_maxNilpotentIdeal [IsNoetherian R L] (I : LieIdeal R L) :
     IsNilpotent L I ↔ I ≤ maxNilpotentIdeal R L :=
   nilpotent_iff_le_max_nilpotent_submodule R L L I
 
-theorem center_le_max_nilpotent_ideal : center R L ≤ maxNilpotentIdeal R L :=
+theorem center_le_maxNilpotentIdeal : center R L ≤ maxNilpotentIdeal R L :=
   le_sSup (trivialIsNilpotent L (center R L))
 
-@[simp] lemma max_nilpotent_ideal_eq_top_of_isNilpotent [LieRing.IsNilpotent L] :
+@[simp] lemma maxNilpotentIdeal_eq_top_of_isNilpotent [LieRing.IsNilpotent L] :
     maxNilpotentIdeal R L = ⊤ :=
   maxNilpotentSubmodule_eq_top_of_isNilpotent R L L
 

--- a/Mathlib/Algebra/Lie/Nilpotent.lean
+++ b/Mathlib/Algebra/Lie/Nilpotent.lean
@@ -306,8 +306,8 @@ variable (R L M)
 instance (priority := 100) trivialIsNilpotent [IsTrivial L M] : IsNilpotent L M :=
   ⟨by use 1; change ⁅⊤, ⊤⁆ = ⊥; simp⟩
 
-instance instIsNilpotentAdd (M₁ M₂ : LieSubmodule R L M) [IsNilpotent L M₁] [IsNilpotent L M₂] :
-    IsNilpotent L (M₁ + M₂) := by
+instance instIsNilpotentSup (M₁ M₂ : LieSubmodule R L M) [IsNilpotent L M₁] [IsNilpotent L M₂] :
+    IsNilpotent L (M₁ ⊔ M₂ : LieSubmodule R L M) := by
   obtain ⟨k, hk⟩ := IsNilpotent.nilpotent R L M₁
   obtain ⟨l, hl⟩ := IsNilpotent.nilpotent R L M₂
   let lcs_eq_bot {m n} (N : LieSubmodule R L M) (le : m ≤ n) (hn : lowerCentralSeries R L N m = ⊥) :
@@ -731,7 +731,7 @@ instance instMaxNilpotentSubmoduleIsNilpotent [IsNoetherian R M] :
 theorem nilpotent_iff_le_max_nilpotent_submodule [IsNoetherian R M] (N : LieSubmodule R L M) :
     IsNilpotent L N ↔ N ≤ maxNilpotentSubmodule R L M :=
   ⟨fun h ↦ le_sSup h, fun h ↦ isNilpotent_of_le R L M N (maxNilpotentSubmodule R L M) h
-    (maxNilpotentSubmoduleIsNilpotent R L M)⟩
+    (instMaxNilpotentSubmoduleIsNilpotent R L M)⟩
 
 end LieModule
 
@@ -987,7 +987,7 @@ def maxNilpotentIdeal := maxNilpotentSubmodule R L L
 
 instance maxNilpotentIdealIsNilpotent [IsNoetherian R L] :
     IsNilpotent L (maxNilpotentIdeal R L) := by
-  apply maxNilpotentSubmoduleIsNilpotent
+  apply instMaxNilpotentSubmoduleIsNilpotent
 
 theorem LieIdeal.nilpotent_iff_le_max_nilpotent_ideal [IsNoetherian R L] (I : LieIdeal R L) :
     IsNilpotent L I ↔ I ≤ maxNilpotentIdeal R L := by

--- a/Mathlib/Algebra/Lie/Nilpotent.lean
+++ b/Mathlib/Algebra/Lie/Nilpotent.lean
@@ -996,8 +996,8 @@ instance maxNilpotentIdealIsNilpotent [IsNoetherian R L] :
   instMaxNilpotentSubmoduleIsNilpotent R L L
 
 theorem LieIdeal.nilpotent_iff_le_max_nilpotent_ideal [IsNoetherian R L] (I : LieIdeal R L) :
-    IsNilpotent L I ↔ I ≤ maxNilpotentIdeal R L := by
-  apply nilpotent_iff_le_max_nilpotent_submodule
+    IsNilpotent L I ↔ I ≤ maxNilpotentIdeal R L :=
+  nilpotent_iff_le_max_nilpotent_submodule R L L I
 
 theorem center_le_max_nilpotent_ideal : center R L ≤ maxNilpotentIdeal R L :=
   le_sSup (trivialIsNilpotent L (center R L))

--- a/Mathlib/Algebra/Lie/Nilpotent.lean
+++ b/Mathlib/Algebra/Lie/Nilpotent.lean
@@ -728,7 +728,7 @@ instance instMaxNilpotentSubmoduleIsNilpotent [IsNoetherian R M] :
   refine hwf { N : LieSubmodule R L M | IsNilpotent L N } ⟨⊥, ?_⟩ fun N₁ h₁ N₂ h₂ => ?_ <;>
   simp_all <;> infer_instance
 
-theorem nilpotent_iff_le_max_nilpotent_submodule [IsNoetherian R M] (N : LieSubmodule R L M) :
+theorem nilpotent_iff_le_maxNilpotentSubmodule [IsNoetherian R M] (N : LieSubmodule R L M) :
     IsNilpotent L N ↔ N ≤ maxNilpotentSubmodule R L M :=
   ⟨fun h ↦ le_sSup h, fun h ↦ isNilpotent_of_le R L M N (maxNilpotentSubmodule R L M) h
     (instMaxNilpotentSubmoduleIsNilpotent R L M)⟩
@@ -997,7 +997,7 @@ instance maxNilpotentIdealIsNilpotent [IsNoetherian R L] :
 
 theorem LieIdeal.nilpotent_iff_le_maxNilpotentIdeal [IsNoetherian R L] (I : LieIdeal R L) :
     IsNilpotent L I ↔ I ≤ maxNilpotentIdeal R L :=
-  nilpotent_iff_le_max_nilpotent_submodule R L L I
+  nilpotent_iff_le_maxNilpotentSubmodule R L L I
 
 theorem center_le_maxNilpotentIdeal : center R L ≤ maxNilpotentIdeal R L :=
   le_sSup (trivialIsNilpotent L (center R L))

--- a/Mathlib/Algebra/Lie/Nilpotent.lean
+++ b/Mathlib/Algebra/Lie/Nilpotent.lean
@@ -733,6 +733,12 @@ theorem nilpotent_iff_le_max_nilpotent_submodule [IsNoetherian R M] (N : LieSubm
   ⟨fun h ↦ le_sSup h, fun h ↦ isNilpotent_of_le R L M N (maxNilpotentSubmodule R L M) h
     (instMaxNilpotentSubmoduleIsNilpotent R L M)⟩
 
+@[simp] lemma maxNilpotentSubmodule_eq_top_of_isNilpotent [LieModule.IsNilpotent L M] :
+    maxNilpotentSubmodule R L M = ⊤ := by
+  rw [eq_top_iff]
+  apply le_sSup
+  simpa
+
 end LieModule
 
 end NilpotentModules
@@ -986,20 +992,18 @@ variable [CommRing R] [LieRing L] [LieAlgebra R L]
 def maxNilpotentIdeal := maxNilpotentSubmodule R L L
 
 instance maxNilpotentIdealIsNilpotent [IsNoetherian R L] :
-    IsNilpotent L (maxNilpotentIdeal R L) := by
-  apply instMaxNilpotentSubmoduleIsNilpotent
+    IsNilpotent L (maxNilpotentIdeal R L) :=
+  instMaxNilpotentSubmoduleIsNilpotent R L L
 
 theorem LieIdeal.nilpotent_iff_le_max_nilpotent_ideal [IsNoetherian R L] (I : LieIdeal R L) :
     IsNilpotent L I ↔ I ≤ maxNilpotentIdeal R L := by
   apply nilpotent_iff_le_max_nilpotent_submodule
 
-theorem center_le_max_nilpotent_ideal : center R L ≤ maxNilpotentIdeal R L := by
-  exact le_sSup (trivialIsNilpotent L (center R L))
+theorem center_le_max_nilpotent_ideal : center R L ≤ maxNilpotentIdeal R L :=
+  le_sSup (trivialIsNilpotent L (center R L))
 
 @[simp] lemma max_nilpotent_ideal_eq_top_of_isNilpotent [LieRing.IsNilpotent L] :
-    maxNilpotentIdeal R L = ⊤ := by
-  rw [eq_top_iff]
-  apply le_sSup
-  simpa
+    maxNilpotentIdeal R L = ⊤ :=
+  maxNilpotentSubmodule_eq_top_of_isNilpotent R L L
 
 end LieAlgebra

--- a/Mathlib/Algebra/Lie/Nilpotent.lean
+++ b/Mathlib/Algebra/Lie/Nilpotent.lean
@@ -711,7 +711,7 @@ namespace LieModule
 variable (R L M)
 variable [LieModule R L M]
 
-theorem isNilpotent_of_le (M₁ M₂ : LieSubmodule R L M) (h₁ : M₁ ≤ M₂) (h₂ : IsNilpotent L M₂) :
+theorem isNilpotent_of_le (M₁ M₂ : LieSubmodule R L M) (h₁ : M₁ ≤ M₂) [IsNilpotent L M₂] :
     IsNilpotent L M₁ := by
   let f : L →ₗ⁅R⁆ L := LieHom.id
   let g : M₁ →ₗ[R] M₂ := Submodule.inclusion h₁
@@ -730,8 +730,7 @@ instance instMaxNilpotentSubmoduleIsNilpotent [IsNoetherian R M] :
 
 theorem isNilpotent_iff_le_maxNilpotentSubmodule [IsNoetherian R M] (N : LieSubmodule R L M) :
     IsNilpotent L N ↔ N ≤ maxNilpotentSubmodule R L M :=
-  ⟨fun h ↦ le_sSup h, fun h ↦ isNilpotent_of_le R L M N (maxNilpotentSubmodule R L M) h
-    (instMaxNilpotentSubmoduleIsNilpotent R L M)⟩
+  ⟨fun h ↦ le_sSup h, fun h ↦ isNilpotent_of_le R L M N (maxNilpotentSubmodule R L M) h⟩
 
 @[simp] lemma maxNilpotentSubmodule_eq_top_of_isNilpotent [LieModule.IsNilpotent L M] :
     maxNilpotentSubmodule R L M = ⊤ := by

--- a/Mathlib/Algebra/Lie/Nilpotent.lean
+++ b/Mathlib/Algebra/Lie/Nilpotent.lean
@@ -725,10 +725,8 @@ def maxNilpotentSubmodule :=
 instance maxNilpotentSubmoduleIsNilpotent [IsNoetherian R M] :
     IsNilpotent L (maxNilpotentSubmodule R L M) := by
   have hwf := CompleteLattice.WellFoundedGT.isSupClosedCompact (LieSubmodule R L M) inferInstance
-  refine hwf { N : LieSubmodule R L M | IsNilpotent L N } ⟨⊥, ?_⟩ fun N₁ h₁ N₂ h₂ => ?_
-  · simp [trivialIsNilpotent L]
-  · rw [Set.mem_setOf_eq] at h₁ h₂
-    apply instIsNilpotentAdd R L
+  refine hwf { N : LieSubmodule R L M | IsNilpotent L N } ⟨⊥, ?_⟩ fun N₁ h₁ N₂ h₂ => ?_ <;>
+  simp_all <;> infer_instance
 
 theorem nilpotent_iff_le_max_nilpotent_submodule [IsNoetherian R M] (N : LieSubmodule R L M) :
     IsNilpotent L N ↔ N ≤ maxNilpotentSubmodule R L M :=

--- a/Mathlib/Algebra/Lie/Nilpotent.lean
+++ b/Mathlib/Algebra/Lie/Nilpotent.lean
@@ -728,7 +728,7 @@ instance instMaxNilpotentSubmoduleIsNilpotent [IsNoetherian R M] :
   refine hwf { N : LieSubmodule R L M | IsNilpotent L N } ⟨⊥, ?_⟩ fun N₁ h₁ N₂ h₂ => ?_ <;>
   simp_all <;> infer_instance
 
-theorem nilpotent_iff_le_maxNilpotentSubmodule [IsNoetherian R M] (N : LieSubmodule R L M) :
+theorem isNilpotent_iff_le_maxNilpotentSubmodule [IsNoetherian R M] (N : LieSubmodule R L M) :
     IsNilpotent L N ↔ N ≤ maxNilpotentSubmodule R L M :=
   ⟨fun h ↦ le_sSup h, fun h ↦ isNilpotent_of_le R L M N (maxNilpotentSubmodule R L M) h
     (instMaxNilpotentSubmoduleIsNilpotent R L M)⟩
@@ -995,9 +995,9 @@ instance maxNilpotentIdealIsNilpotent [IsNoetherian R L] :
     IsNilpotent L (maxNilpotentIdeal R L) :=
   instMaxNilpotentSubmoduleIsNilpotent R L L
 
-theorem LieIdeal.nilpotent_iff_le_maxNilpotentIdeal [IsNoetherian R L] (I : LieIdeal R L) :
+theorem LieIdeal.isNilpotent_iff_le_maxNilpotentIdeal [IsNoetherian R L] (I : LieIdeal R L) :
     IsNilpotent L I ↔ I ≤ maxNilpotentIdeal R L :=
-  nilpotent_iff_le_maxNilpotentSubmodule R L L I
+  isNilpotent_iff_le_maxNilpotentSubmodule R L L I
 
 theorem center_le_maxNilpotentIdeal : center R L ≤ maxNilpotentIdeal R L :=
   le_sSup (trivialIsNilpotent L (center R L))

--- a/Mathlib/Algebra/Lie/Nilpotent.lean
+++ b/Mathlib/Algebra/Lie/Nilpotent.lean
@@ -722,7 +722,7 @@ theorem isNilpotent_of_le (M₁ M₂ : LieSubmodule R L M) (h₁ : M₁ ≤ M₂
 def maxNilpotentSubmodule :=
   sSup { N : LieSubmodule R L M | IsNilpotent L N }
 
-instance maxNilpotentSubmoduleIsNilpotent [IsNoetherian R M] :
+instance instMaxNilpotentSubmoduleIsNilpotent [IsNoetherian R M] :
     IsNilpotent L (maxNilpotentSubmodule R L M) := by
   have hwf := CompleteLattice.WellFoundedGT.isSupClosedCompact (LieSubmodule R L M) inferInstance
   refine hwf { N : LieSubmodule R L M | IsNilpotent L N } ⟨⊥, ?_⟩ fun N₁ h₁ N₂ h₂ => ?_ <;>

--- a/Mathlib/Algebra/Lie/Nilpotent.lean
+++ b/Mathlib/Algebra/Lie/Nilpotent.lean
@@ -724,8 +724,7 @@ def maxNilpotentSubmodule :=
 
 instance maxNilpotentSubmoduleIsNilpotent [IsNoetherian R M] :
     IsNilpotent L (maxNilpotentSubmodule R L M) := by
-  have hwf := LieSubmodule.wellFoundedGT_of_noetherian R L M
-  rw [← CompleteLattice.isSupClosedCompact_iff_wellFoundedGT] at hwf
+  have hwf := CompleteLattice.WellFoundedGT.isSupClosedCompact (LieSubmodule R L M) inferInstance
   refine hwf { N : LieSubmodule R L M | IsNilpotent L N } ⟨⊥, ?_⟩ fun N₁ h₁ N₂ h₂ => ?_
   · simp [trivialIsNilpotent L]
   · rw [Set.mem_setOf_eq] at h₁ h₂


### PR DESCRIPTION
Define the maximal nilpotent ideal of Lie algebras
---
In this PR, I define the maximal nilpotent ideal of a Lie algebra.
A closely related concept—the radical of a Lie algebra (the maximal solvable ideal)—is already defined in Algebra/Lie/Solvable.lean.

I prove the analogous results for the maximal nilpotent ideal that have been established for the radical.

This work is part of the framework:
https://github.com/orgs/leanprover-community/projects/17
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
