### PR TITLE
[Merged by Bors] - feat: Giry monoidal product

### DIFF
--- a/Mathlib/MeasureTheory/Measure/FiniteMeasure.lean
+++ b/Mathlib/MeasureTheory/Measure/FiniteMeasure.lean
@@ -141,7 +141,7 @@ lemma coeFn_mk (μ : Measure Ω) (hμ) :
 instance {α : Type*} [MeasurableSpace α] : MeasurableSpace (FiniteMeasure α) :=
     Subtype.instMeasurableSpace
 
-/-- The set of all finite measures is a measurable set in the Giry monad -/
+/-- The set of all finite measures is a measurable set in the Giry monad. -/
 lemma measurableSet_isFiniteMeasure {α : Type*} [MeasurableSpace α] :
     MeasurableSet { μ : Measure α | IsFiniteMeasure μ } := by
   suffices { μ : Measure α | IsFiniteMeasure μ } = (fun μ => μ univ) ⁻¹' (Set.Ico 0 ∞) by

--- a/Mathlib/MeasureTheory/Measure/FiniteMeasure.lean
+++ b/Mathlib/MeasureTheory/Measure/FiniteMeasure.lean
@@ -137,7 +137,7 @@ lemma coeFn_def (μ : FiniteMeasure Ω) : μ = fun s ↦ ((μ : Measure Ω) s).t
 lemma coeFn_mk (μ : Measure Ω) (hμ) :
     DFunLike.coe (F := FiniteMeasure Ω) ⟨μ, hμ⟩ = fun s ↦ (μ s).toNNReal := rfl
 
-/-- The type of probability measures is a measurable space when equipped with the Giry monad. -/
+/-- The type of finite measures is a measurable space when equipped with the Giry monad. -/
 instance {α : Type*} [MeasurableSpace α] : MeasurableSpace (FiniteMeasure α) :=
     Subtype.instMeasurableSpace
 

--- a/Mathlib/MeasureTheory/Measure/FiniteMeasure.lean
+++ b/Mathlib/MeasureTheory/Measure/FiniteMeasure.lean
@@ -142,7 +142,7 @@ instance {α : Type*} [MeasurableSpace α] : MeasurableSpace (FiniteMeasure α) 
     Subtype.instMeasurableSpace
 
 /-- The set of all finite measures is a measurable set in the Giry monad -/
-lemma finite_measures_measurable_set {α : Type*} [MeasurableSpace α] :
+lemma measurableSet_isFiniteMeasure {α : Type*} [MeasurableSpace α] :
     MeasurableSet { μ : Measure α | IsFiniteMeasure μ } := by
   suffices { μ : Measure α | IsFiniteMeasure μ } = (fun μ => μ univ) ⁻¹' (Set.Ico 0 ∞) by
     rw [this]

--- a/Mathlib/MeasureTheory/Measure/FiniteMeasure.lean
+++ b/Mathlib/MeasureTheory/Measure/FiniteMeasure.lean
@@ -7,6 +7,7 @@ import Mathlib.Topology.Algebra.Module.WeakDual
 import Mathlib.MeasureTheory.Integral.BoundedContinuousFunction
 import Mathlib.MeasureTheory.Measure.HasOuterApproxClosed
 import Mathlib.MeasureTheory.Measure.GiryMonad
+import Mathlib.MeasureTheory.Measure.Prod
 
 /-!
 # Finite measures
@@ -284,6 +285,29 @@ theorem restrict_eq_zero_iff (μ : FiniteMeasure Ω) (A : Set Ω) : μ.restrict 
 
 theorem restrict_nonzero_iff (μ : FiniteMeasure Ω) (A : Set Ω) : μ.restrict A ≠ 0 ↔ μ A ≠ 0 := by
   rw [← mass_nonzero_iff, restrict_mass]
+
+section MonoidalProduct
+
+open Measure
+
+/-- The monoidal product is a measurabule function from the product of finite measures over
+`α` and `β` into the type of finite measures over `α × β`. -/
+theorem measurable_prod {α β : Type*} [MeasurableSpace α] [MeasurableSpace β] :
+    Measurable (fun (μ : FiniteMeasure α × FiniteMeasure β)
+      ↦ μ.1.toMeasure.prod μ.2.toMeasure) := by
+  have Heval {u v} (Hu : MeasurableSet u) (Hv : MeasurableSet v):
+      Measurable fun a : (FiniteMeasure α × FiniteMeasure β) ↦
+      a.1.toMeasure u * a.2.toMeasure v :=
+    Measurable.mul
+      ((measurable_coe Hu).comp (measurable_subtype_coe.comp measurable_fst))
+      ((measurable_coe Hv).comp (measurable_subtype_coe.comp measurable_snd))
+  apply Measurable.measure_of_isPiSystem generateFrom_prod.symm isPiSystem_prod _
+  · simp_rw [← Set.univ_prod_univ, prod_prod, Heval MeasurableSet.univ MeasurableSet.univ]
+  simp only [mem_image2, mem_setOf_eq, forall_exists_index, and_imp]
+  intros _ _ Hu _ Hv Heq
+  simp_rw [← Heq, prod_prod, Heval Hu Hv]
+
+end MonoidalProduct
 
 variable [TopologicalSpace Ω]
 

--- a/Mathlib/MeasureTheory/Measure/FiniteMeasure.lean
+++ b/Mathlib/MeasureTheory/Measure/FiniteMeasure.lean
@@ -138,20 +138,6 @@ lemma coeFn_def (μ : FiniteMeasure Ω) : μ = fun s ↦ ((μ : Measure Ω) s).t
 lemma coeFn_mk (μ : Measure Ω) (hμ) :
     DFunLike.coe (F := FiniteMeasure Ω) ⟨μ, hμ⟩ = fun s ↦ (μ s).toNNReal := rfl
 
-/-- The type of finite measures is a measurable space when equipped with the Giry monad. -/
-instance {α : Type*} [MeasurableSpace α] : MeasurableSpace (FiniteMeasure α) :=
-    Subtype.instMeasurableSpace
-
-/-- The set of all finite measures is a measurable set in the Giry monad. -/
-lemma measurableSet_isFiniteMeasure {α : Type*} [MeasurableSpace α] :
-    MeasurableSet { μ : Measure α | IsFiniteMeasure μ } := by
-  suffices { μ : Measure α | IsFiniteMeasure μ } = (fun μ => μ univ) ⁻¹' (Set.Ico 0 ∞) by
-    rw [this]
-    exact Measure.measurable_coe MeasurableSet.univ measurableSet_Ico
-  ext μ
-  simp only [mem_setOf_eq, mem_iUnion, mem_preimage, mem_Ico, zero_le, true_and, exists_const]
-  exact isFiniteMeasure_iff μ
-
 @[simp, norm_cast]
 lemma mk_apply (μ : Measure Ω) (hμ) (s : Set Ω) :
     DFunLike.coe (F := FiniteMeasure Ω) ⟨μ, hμ⟩ s = (μ s).toNNReal := rfl
@@ -286,9 +272,17 @@ theorem restrict_eq_zero_iff (μ : FiniteMeasure Ω) (A : Set Ω) : μ.restrict 
 theorem restrict_nonzero_iff (μ : FiniteMeasure Ω) (A : Set Ω) : μ.restrict A ≠ 0 ↔ μ A ≠ 0 := by
   rw [← mass_nonzero_iff, restrict_mass]
 
-section MonoidalProduct
+/-- The type of finite measures is a measurable space when equipped with the Giry monad. -/
+instance : MeasurableSpace (FiniteMeasure Ω) := Subtype.instMeasurableSpace
 
-open Measure
+/-- The set of all finite measures is a measurable set in the Giry monad. -/
+lemma measurableSet_isFiniteMeasure : MeasurableSet { μ : Measure Ω | IsFiniteMeasure μ } := by
+  suffices { μ : Measure Ω | IsFiniteMeasure μ } = (fun μ => μ univ) ⁻¹' (Set.Ico 0 ∞) by
+    rw [this]
+    exact Measure.measurable_coe MeasurableSet.univ measurableSet_Ico
+  ext μ
+  simp only [mem_setOf_eq, mem_iUnion, mem_preimage, mem_Ico, zero_le, true_and, exists_const]
+  exact isFiniteMeasure_iff μ
 
 /-- The monoidal product is a measurabule function from the product of finite measures over
 `α` and `β` into the type of finite measures over `α × β`. -/
@@ -299,15 +293,13 @@ theorem measurable_prod {α β : Type*} [MeasurableSpace α] [MeasurableSpace β
       Measurable fun a : (FiniteMeasure α × FiniteMeasure β) ↦
       a.1.toMeasure u * a.2.toMeasure v :=
     Measurable.mul
-      ((measurable_coe Hu).comp (measurable_subtype_coe.comp measurable_fst))
-      ((measurable_coe Hv).comp (measurable_subtype_coe.comp measurable_snd))
+      ((Measure.measurable_coe Hu).comp (measurable_subtype_coe.comp measurable_fst))
+      ((Measure.measurable_coe Hv).comp (measurable_subtype_coe.comp measurable_snd))
   apply Measurable.measure_of_isPiSystem generateFrom_prod.symm isPiSystem_prod _
-  · simp_rw [← Set.univ_prod_univ, prod_prod, Heval MeasurableSet.univ MeasurableSet.univ]
+  · simp_rw [← Set.univ_prod_univ, Measure.prod_prod, Heval MeasurableSet.univ MeasurableSet.univ]
   simp only [mem_image2, mem_setOf_eq, forall_exists_index, and_imp]
   intros _ _ Hu _ Hv Heq
-  simp_rw [← Heq, prod_prod, Heval Hu Hv]
-
-end MonoidalProduct
+  simp_rw [← Heq, Measure.prod_prod, Heval Hu Hv]
 
 variable [TopologicalSpace Ω]
 

--- a/Mathlib/MeasureTheory/Measure/FiniteMeasure.lean
+++ b/Mathlib/MeasureTheory/Measure/FiniteMeasure.lean
@@ -6,6 +6,7 @@ Authors: Kalle Kytölä
 import Mathlib.Topology.Algebra.Module.WeakDual
 import Mathlib.MeasureTheory.Integral.BoundedContinuousFunction
 import Mathlib.MeasureTheory.Measure.HasOuterApproxClosed
+import Mathlib.MeasureTheory.Measure.GiryMonad
 
 /-!
 # Finite measures
@@ -135,6 +136,20 @@ lemma coeFn_def (μ : FiniteMeasure Ω) : μ = fun s ↦ ((μ : Measure Ω) s).t
 
 lemma coeFn_mk (μ : Measure Ω) (hμ) :
     DFunLike.coe (F := FiniteMeasure Ω) ⟨μ, hμ⟩ = fun s ↦ (μ s).toNNReal := rfl
+
+/-- The type of probability measures is a measurable space when equipped with the Giry monad. -/
+instance {α : Type*} [MeasurableSpace α] : MeasurableSpace (FiniteMeasure α) :=
+    Subtype.instMeasurableSpace
+
+/-- The set of all finite measures is a measurable set in the Giry monad -/
+lemma finite_measures_measurable_set {α : Type*} [MeasurableSpace α] :
+    MeasurableSet { μ : Measure α | IsFiniteMeasure μ } := by
+  suffices { μ : Measure α | IsFiniteMeasure μ } = (fun μ => μ univ) ⁻¹' (Set.Ico 0 ∞) by
+    rw [this]
+    exact Measure.measurable_coe MeasurableSet.univ measurableSet_Ico
+  ext μ
+  simp only [mem_setOf_eq, mem_iUnion, mem_preimage, mem_Ico, zero_le, true_and, exists_const]
+  exact isFiniteMeasure_iff μ
 
 @[simp, norm_cast]
 lemma mk_apply (μ : Measure Ω) (hμ) (s : Set Ω) :

--- a/Mathlib/MeasureTheory/Measure/ProbabilityMeasure.lean
+++ b/Mathlib/MeasureTheory/Measure/ProbabilityMeasure.lean
@@ -581,7 +581,7 @@ theorem ProbabilityMeasure.measurable_prod {α β : Type*} [MeasurableSpace α] 
   · exact (measurable_coe Hv).comp (measurable_subtype_coe.comp measurable_snd)
 
 /-- The monoidal product is a measurabule function from the product of finite measures over
-``α`` and ``β`` into the type of finite measures over ``α × β``. -/
+`α` and `β` into the type of finite measures over `α × β`. -/
 theorem FiniteMeasure.measurable_prod {α β : Type*} [MeasurableSpace α] [MeasurableSpace β] :
     Measurable (fun (μ : FiniteMeasure α × FiniteMeasure β)
       ↦ μ.1.toMeasure.prod μ.2.toMeasure) := by

--- a/Mathlib/MeasureTheory/Measure/ProbabilityMeasure.lean
+++ b/Mathlib/MeasureTheory/Measure/ProbabilityMeasure.lean
@@ -572,7 +572,8 @@ https://doi.org/10.1016/j.aim.2020.107239.
 theorem ProbabilityMeasure.measurable_prod {α β : Type*} [MeasurableSpace α] [MeasurableSpace β] :
     Measurable (fun (μ : ProbabilityMeasure α × ProbabilityMeasure β)
       ↦ μ.1.toMeasure.prod μ.2.toMeasure) := by
-  apply Measurable.measure_of_isPiSystem generateFrom_prod.symm isPiSystem_prod _ (by simp)
+  apply Measurable.measure_of_isPiSystem_of_isProbabilityMeasure generateFrom_prod.symm
+    isPiSystem_prod _
   simp only [mem_image2, mem_setOf_eq, forall_exists_index, and_imp]
   intros _ u Hu v Hv Heq
   simp_rw [← Heq, prod_prod]

--- a/Mathlib/MeasureTheory/Measure/ProbabilityMeasure.lean
+++ b/Mathlib/MeasureTheory/Measure/ProbabilityMeasure.lean
@@ -567,8 +567,7 @@ open Measure
 
 /-- The monoidal product is a measurable function from the product of probability spaces over
 ``α`` and ``β`` into the type of probability spaces over ``α × β``. Lemma 4.1 of
-https://doi.org/10.1016/j.aim.2020.107239.
--/
+https://doi.org/10.1016/j.aim.2020.107239. -/
 theorem ProbabilityMeasure.measurable_prod {α β : Type*} [MeasurableSpace α] [MeasurableSpace β] :
     Measurable (fun (μ : ProbabilityMeasure α × ProbabilityMeasure β)
       ↦ μ.1.toMeasure.prod μ.2.toMeasure) := by

--- a/Mathlib/MeasureTheory/Measure/ProbabilityMeasure.lean
+++ b/Mathlib/MeasureTheory/Measure/ProbabilityMeasure.lean
@@ -566,7 +566,7 @@ section MonoidalProduct
 open Measure
 
 /-- The monoidal product is a measurable function from the product of probability spaces over
-``α`` and ``β`` into the type of probability spaces over ``α × β``. Lemma 4.1 of
+`α` and `β` into the type of probability spaces over `α × β`. Lemma 4.1 of
 https://doi.org/10.1016/j.aim.2020.107239. -/
 theorem ProbabilityMeasure.measurable_prod {α β : Type*} [MeasurableSpace α] [MeasurableSpace β] :
     Measurable (fun (μ : ProbabilityMeasure α × ProbabilityMeasure β)

--- a/Mathlib/MeasureTheory/Measure/ProbabilityMeasure.lean
+++ b/Mathlib/MeasureTheory/Measure/ProbabilityMeasure.lean
@@ -580,23 +580,6 @@ theorem ProbabilityMeasure.measurable_prod {α β : Type*} [MeasurableSpace α] 
   · exact (measurable_coe Hu).comp (measurable_subtype_coe.comp measurable_fst)
   · exact (measurable_coe Hv).comp (measurable_subtype_coe.comp measurable_snd)
 
-/-- The monoidal product is a measurabule function from the product of finite measures over
-`α` and `β` into the type of finite measures over `α × β`. -/
-theorem FiniteMeasure.measurable_prod {α β : Type*} [MeasurableSpace α] [MeasurableSpace β] :
-    Measurable (fun (μ : FiniteMeasure α × FiniteMeasure β)
-      ↦ μ.1.toMeasure.prod μ.2.toMeasure) := by
-  apply Measurable.measure_of_isPiSystem generateFrom_prod.symm isPiSystem_prod _
-  · simp_rw [← Set.univ_prod_univ, prod_prod]
-    apply Measurable.mul
-    · exact (measurable_coe MeasurableSet.univ).comp (measurable_subtype_coe.comp measurable_fst)
-    · exact (measurable_coe MeasurableSet.univ).comp (measurable_subtype_coe.comp measurable_snd)
-  simp only [mem_image2, mem_setOf_eq, forall_exists_index, and_imp]
-  intros _ u Hu v Hv Heq
-  simp_rw [← Heq, prod_prod]
-  apply Measurable.mul
-  · exact (measurable_coe Hu).comp (measurable_subtype_coe.comp measurable_fst)
-  · exact (measurable_coe Hv).comp (measurable_subtype_coe.comp measurable_snd)
-
 end MonoidalProduct
 
 end MeasureTheory -- namespace

--- a/Mathlib/MeasureTheory/Measure/ProbabilityMeasure.lean
+++ b/Mathlib/MeasureTheory/Measure/ProbabilityMeasure.lean
@@ -129,7 +129,7 @@ theorem toMeasure_injective : Function.Injective ((↑) : ProbabilityMeasure Ω 
 instance {α : Type*} [MeasurableSpace α] : MeasurableSpace (ProbabilityMeasure α) :=
     Subtype.instMeasurableSpace
 
-lemma probability_measures_measurable_set {α : Type*} [MeasurableSpace α] :
+lemma measurableSet_isProbabilityMeasure {α : Type*} [MeasurableSpace α] :
     MeasurableSet { μ : Measure α | IsProbabilityMeasure μ } := by
   suffices { μ : Measure α | IsProbabilityMeasure μ } = (fun μ => μ univ) ⁻¹' {1} by
     rw [this]

--- a/Mathlib/MeasureTheory/Measure/ProbabilityMeasure.lean
+++ b/Mathlib/MeasureTheory/Measure/ProbabilityMeasure.lean
@@ -562,39 +562,18 @@ open Measure
 local instance {α : Type*} [MeasurableSpace α] : MeasurableSpace (ProbabilityMeasure α) :=
   Subtype.instMeasurableSpace
 
-/-- Monoidal product for probability measures: The product of two probability measures
-is their product measure. -/
-abbrev monoidal_product {α β : Type*} [MeasurableSpace α] [MeasurableSpace β] :
-    (ProbabilityMeasure α × ProbabilityMeasure β) -> Measure (α × β) :=
-  fun μ => Measure.prod (Subtype.val μ.1) (Subtype.val μ.2)
-
-/-- The monoidal product of two probability measures is a probability measure. -/
-local instance (α β : Type*) [MeasurableSpace α] [MeasurableSpace β]
-  (μ : ProbabilityMeasure α × ProbabilityMeasure β) :
-    IsProbabilityMeasure (monoidal_product μ) where
-  measure_univ := by rcases μ with ⟨⟨_, _⟩, ⟨_, _⟩⟩; simp
-
-local instance (α β : Type*) [MeasurableSpace α] [MeasurableSpace β]
-  (μ : ProbabilityMeasure α × ProbabilityMeasure β) :
-    SFinite (μ.2.val) := by rcases μ with ⟨_, ⟨_, _⟩⟩; simp; infer_instance
-
 /-- The monoidal product is a measurable function from the product of probability spaces over
 ``α`` and ``β`` into the type of probability spaces over ``α × β`` -/
-theorem measurable_monoidal_product {α β : Type*} [MeasurableSpace α] [MeasurableSpace β] :
-    Measurable (@monoidal_product α β _ _) := by
+theorem measurable_prod {α β : Type*} [MeasurableSpace α] [MeasurableSpace β] :
+    Measurable (fun (μ : ProbabilityMeasure α × ProbabilityMeasure β)
+      ↦ μ.1.toMeasure.prod μ.2.toMeasure) := by
   apply Measurable.measure_of_isPiSystem generateFrom_prod.symm isPiSystem_prod _ (by simp)
   simp only [mem_image2, mem_setOf_eq, forall_exists_index, and_imp]
   intros _ u Hu v Hv Heq
-  rw [<- Heq, funext <| fun a => MeasureTheory.Measure.prod_prod u v]
+  simp_rw [← Heq, prod_prod]
   apply Measurable.mul
-  · rw [<- comp_def (fun μ => μ u) (fun (μ : ProbabilityMeasure _ × _) => μ.1.val),
-        <- comp_def _ Prod.fst]
-    apply Measurable.comp (measurable_coe Hu) <|
-          Measurable.comp measurable_subtype_coe measurable_fst
-  · rw [<- comp_def (fun μ => μ v) (fun (μ : _ × ProbabilityMeasure _) => μ.2.val),
-        <- comp_def _ Prod.snd]
-    apply Measurable.comp (measurable_coe Hv) <|
-          Measurable.comp measurable_subtype_coe measurable_snd
+  · exact (measurable_coe Hu).comp (measurable_subtype_coe.comp measurable_fst)
+  · exact (measurable_coe Hv).comp (measurable_subtype_coe.comp measurable_snd)
 
 end MonoidalProduct
 

--- a/Mathlib/MeasureTheory/Measure/ProbabilityMeasure.lean
+++ b/Mathlib/MeasureTheory/Measure/ProbabilityMeasure.lean
@@ -561,13 +561,13 @@ open Measure
 local instance {α : Type*} [MeasurableSpace α] : MeasurableSpace (ProbabilityMeasure α) :=
   Subtype.instMeasurableSpace
 
-abbrev monoidal_product (α β : Type*) [MeasurableSpace α] [MeasurableSpace β] :
+abbrev monoidal_product {α β : Type*} [MeasurableSpace α] [MeasurableSpace β] :
     (ProbabilityMeasure α × ProbabilityMeasure β) -> Measure (α × β) :=
   fun μ => Measure.prod (Subtype.val μ.1) (Subtype.val μ.2)
 
 local instance (α β : Type*) [MeasurableSpace α] [MeasurableSpace β]
   (μ : ProbabilityMeasure α × ProbabilityMeasure β) :
-    IsProbabilityMeasure (monoidal_product α β μ) where
+    IsProbabilityMeasure (monoidal_product μ) where
   measure_univ := by rcases μ with ⟨⟨_, _⟩, ⟨_, _⟩⟩; simp
 
 local instance (α β : Type*) [MeasurableSpace α] [MeasurableSpace β]
@@ -575,19 +575,17 @@ local instance (α β : Type*) [MeasurableSpace α] [MeasurableSpace β]
     SFinite (μ.2.val) := by rcases μ with ⟨_, ⟨_, _⟩⟩; simp; infer_instance
 
 theorem measurable_monoidal_product {α β : Type*} [MeasurableSpace α] [MeasurableSpace β] :
-    Measurable (monoidal_product α β) := by
+    Measurable (@monoidal_product α β _ _) := by
   apply Measurable.measure_of_isPiSystem generateFrom_prod.symm isPiSystem_prod _ (by simp)
   simp only [mem_image2, mem_setOf_eq, forall_exists_index, and_imp]
   intros _ u Hu v Hv Heq
   rw [<- Heq, funext <| fun a => MeasureTheory.Measure.prod_prod u v]
   apply Measurable.mul
-  · rw [<- comp_def (fun μ => μ u)
-                    (fun (μ : ProbabilityMeasure α × ProbabilityMeasure β) => μ.1.val),
+  · rw [<- comp_def (fun μ => μ u) (fun (μ : ProbabilityMeasure _ × _) => μ.1.val),
         <- comp_def _ Prod.fst]
     apply Measurable.comp (measurable_coe Hu) <|
           Measurable.comp measurable_subtype_coe measurable_fst
-  · rw [<- comp_def (fun μ => μ v)
-                    (fun (μ : ProbabilityMeasure α × ProbabilityMeasure β) => μ.2.val),
+  · rw [<- comp_def (fun μ => μ v) (fun (μ : _ × ProbabilityMeasure _) => μ.2.val),
         <- comp_def _ Prod.snd]
     apply Measurable.comp (measurable_coe Hv) <|
           Measurable.comp measurable_subtype_coe measurable_snd

--- a/Mathlib/MeasureTheory/Measure/ProbabilityMeasure.lean
+++ b/Mathlib/MeasureTheory/Measure/ProbabilityMeasure.lean
@@ -586,7 +586,7 @@ theorem FiniteMeasure.measurable_prod {α β : Type*} [MeasurableSpace α] [Meas
     Measurable (fun (μ : FiniteMeasure α × FiniteMeasure β)
       ↦ μ.1.toMeasure.prod μ.2.toMeasure) := by
   apply Measurable.measure_of_isPiSystem generateFrom_prod.symm isPiSystem_prod _
-  · simp_rw [<- Set.univ_prod_univ, prod_prod]
+  · simp_rw [← Set.univ_prod_univ, prod_prod]
     apply Measurable.mul
     · exact (measurable_coe MeasurableSet.univ).comp (measurable_subtype_coe.comp measurable_fst)
     · exact (measurable_coe MeasurableSet.univ).comp (measurable_subtype_coe.comp measurable_snd)

--- a/Mathlib/MeasureTheory/Measure/ProbabilityMeasure.lean
+++ b/Mathlib/MeasureTheory/Measure/ProbabilityMeasure.lean
@@ -5,6 +5,7 @@ Authors: Kalle Kytölä
 -/
 import Mathlib.MeasureTheory.Measure.FiniteMeasure
 import Mathlib.MeasureTheory.Integral.Average
+import Mathlib.MeasureTheory.Measure.Prod
 
 /-!
 # Probability measures
@@ -547,5 +548,50 @@ lemma continuous_map {f : Ω → Ω'} (f_cont : Continuous f) :
 end ProbabilityMeasure -- namespace
 
 end map -- section
+
+section MonoidalProduct
+/-! ### The monoidal product in the Giry monad
+Lemma 4.1 of https://doi.org/10.1016/j.aim.2020.10723
+-/
+
+open Function
+
+open Measure
+
+local instance {α : Type*} [MeasurableSpace α] : MeasurableSpace (ProbabilityMeasure α) :=
+  Subtype.instMeasurableSpace
+
+abbrev monoidal_product (α β : Type*) [MeasurableSpace α] [MeasurableSpace β] :
+    (ProbabilityMeasure α × ProbabilityMeasure β) -> Measure (α × β) :=
+  fun μ => Measure.prod (Subtype.val μ.1) (Subtype.val μ.2)
+
+local instance (α β : Type*) [MeasurableSpace α] [MeasurableSpace β]
+  (μ : ProbabilityMeasure α × ProbabilityMeasure β) :
+    IsProbabilityMeasure (monoidal_product α β μ) where
+  measure_univ := by rcases μ with ⟨⟨_, _⟩, ⟨_, _⟩⟩; simp
+
+local instance (α β : Type*) [MeasurableSpace α] [MeasurableSpace β]
+  (μ : ProbabilityMeasure α × ProbabilityMeasure β) :
+    SFinite (μ.2.val) := by rcases μ with ⟨_, ⟨_, _⟩⟩; simp; infer_instance
+
+theorem measurable_monoidal_product {α β : Type*} [MeasurableSpace α] [MeasurableSpace β] :
+    Measurable (monoidal_product α β) := by
+  apply Measurable.measure_of_isPiSystem generateFrom_prod.symm isPiSystem_prod _ (by simp)
+  simp only [mem_image2, mem_setOf_eq, forall_exists_index, and_imp]
+  intros _ u Hu v Hv Heq
+  rw [<- Heq, funext <| fun a => MeasureTheory.Measure.prod_prod u v]
+  apply Measurable.mul
+  · rw [<- comp_def (fun μ => μ u)
+                    (fun (μ : ProbabilityMeasure α × ProbabilityMeasure β) => μ.1.val),
+        <- comp_def _ Prod.fst]
+    apply Measurable.comp (measurable_coe Hu) <|
+          Measurable.comp measurable_subtype_coe measurable_fst
+  · rw [<- comp_def (fun μ => μ v)
+                    (fun (μ : ProbabilityMeasure α × ProbabilityMeasure β) => μ.2.val),
+        <- comp_def _ Prod.snd]
+    apply Measurable.comp (measurable_coe Hv) <|
+          Measurable.comp measurable_subtype_coe measurable_snd
+
+end MonoidalProduct
 
 end MeasureTheory -- namespace

--- a/Mathlib/MeasureTheory/Measure/ProbabilityMeasure.lean
+++ b/Mathlib/MeasureTheory/Measure/ProbabilityMeasure.lean
@@ -125,6 +125,10 @@ theorem val_eq_to_measure (ν : ProbabilityMeasure Ω) : ν.val = (ν : Measure 
 theorem toMeasure_injective : Function.Injective ((↑) : ProbabilityMeasure Ω → Measure Ω) :=
   Subtype.coe_injective
 
+/-- The type of probability measures is a measurable space when equipped with the Giry monad. -/
+instance {α : Type*} [MeasurableSpace α] : MeasurableSpace (ProbabilityMeasure α) :=
+  Subtype.instMeasurableSpace
+
 instance instFunLike : FunLike (ProbabilityMeasure Ω) (Set Ω) ℝ≥0 where
   coe μ s := ((μ : Measure Ω) s).toNNReal
   coe_injective' μ ν h := toMeasure_injective <| Measure.ext fun s _ ↦ by
@@ -557,10 +561,6 @@ Lemma 4.1 of https://doi.org/10.1016/j.aim.2020.107239
 open Function
 
 open Measure
-
-/-- The type of probability measures is a measurable space when equipped with the Giry monad. -/
-local instance {α : Type*} [MeasurableSpace α] : MeasurableSpace (ProbabilityMeasure α) :=
-  Subtype.instMeasurableSpace
 
 /-- The monoidal product is a measurable function from the product of probability spaces over
 ``α`` and ``β`` into the type of probability spaces over ``α × β`` -/

--- a/Mathlib/MeasureTheory/Measure/ProbabilityMeasure.lean
+++ b/Mathlib/MeasureTheory/Measure/ProbabilityMeasure.lean
@@ -551,20 +551,24 @@ end map -- section
 
 section MonoidalProduct
 /-! ### The monoidal product in the Giry monad
-Lemma 4.1 of https://doi.org/10.1016/j.aim.2020.10723
+Lemma 4.1 of https://doi.org/10.1016/j.aim.2020.107239
 -/
 
 open Function
 
 open Measure
 
+/-- The type of probability measures is a measurable space when equipped with the Giry monad. -/
 local instance {α : Type*} [MeasurableSpace α] : MeasurableSpace (ProbabilityMeasure α) :=
   Subtype.instMeasurableSpace
 
+/-- Monoidal product for probability measures: The product of two probability measures
+is their product measure. -/
 abbrev monoidal_product {α β : Type*} [MeasurableSpace α] [MeasurableSpace β] :
     (ProbabilityMeasure α × ProbabilityMeasure β) -> Measure (α × β) :=
   fun μ => Measure.prod (Subtype.val μ.1) (Subtype.val μ.2)
 
+/-- The monoidal product of two probability measures is a probability measure. -/
 local instance (α β : Type*) [MeasurableSpace α] [MeasurableSpace β]
   (μ : ProbabilityMeasure α × ProbabilityMeasure β) :
     IsProbabilityMeasure (monoidal_product μ) where
@@ -574,6 +578,8 @@ local instance (α β : Type*) [MeasurableSpace α] [MeasurableSpace β]
   (μ : ProbabilityMeasure α × ProbabilityMeasure β) :
     SFinite (μ.2.val) := by rcases μ with ⟨_, ⟨_, _⟩⟩; simp; infer_instance
 
+/-- The monoidal product is a measurable function from the product of probability spaces over
+``α`` and ``β`` into the type of probability spaces over ``α × β`` -/
 theorem measurable_monoidal_product {α β : Type*} [MeasurableSpace α] [MeasurableSpace β] :
     Measurable (@monoidal_product α β _ _) := by
   apply Measurable.measure_of_isPiSystem generateFrom_prod.symm isPiSystem_prod _ (by simp)

--- a/Mathlib/MeasureTheory/Measure/Prod.lean
+++ b/Mathlib/MeasureTheory/Measure/Prod.lean
@@ -644,57 +644,36 @@ theorem map_prod_map {δ} [MeasurableSpace δ] {f : α → β} {g : γ → δ} (
   exact prod_prod (f ⁻¹' s) (g ⁻¹' t)
 
 
-/-! ### The monoidal product in the Giry monad -/
+/-! ### The monoidal product in the Giry monad
+Lemma 4.1 of https://doi.org/10.1016/j.aim.2020.10723
+-/
 
--- theorem _root_.Measurable.measure_of_isPiSystem {μ : α → Measure β} [∀ a, IsFiniteMeasure (μ a)]
---     {S : Set (Set β)} (hgen : ‹MeasurableSpace β› = .generateFrom S) (hpi : IsPiSystem S)
---     (h_basic : ∀ s ∈ S, Measurable fun a ↦ μ a s) (h_univ : Measurable fun a ↦ μ a univ) :
---     Measurable μ := by
---   rw [measurable_measure]
---   intro s hs
---   induction s, hs using MeasurableSpace.induction_on_inter hgen hpi with
---   | empty => simp
---   | basic s hs => exact h_basic s hs
---   | compl s hsm ihs =>
---     simp only [measure_compl hsm (measure_ne_top _ _)]
---     exact h_univ.sub ihs
---   | iUnion f hfd hfm ihf =>
---     simpa only [measure_iUnion hfd hfm] using .ennreal_tsum ihf
---
--- theorem _root_.Measurable.measure_of_isPiSystem_of_isProbabilityMeasure {μ : α → Measure β}
---     [∀ a, IsProbabilityMeasure (μ a)]
---     {S : Set (Set β)} (hgen : ‹MeasurableSpace β› = .generateFrom S) (hpi : IsPiSystem S)
---     (h_basic : ∀ s ∈ S, Measurable fun a ↦ μ a s) : Measurable μ :=
---   .measure_of_isPiSystem hgen hpi h_basic <| by simp
-
-abbrev ProbProduct (α β : Type*) [MeasurableSpace α] [MeasurableSpace β] :=
+abbrev ProbProdMeasure (α β : Type*) [MeasurableSpace α] [MeasurableSpace β] :=
   { μ : Measure α × Measure β // IsProbabilityMeasure μ.1 ∧ IsProbabilityMeasure μ.2 }
 
 abbrev monoidal_product (α β : Type*) [MeasurableSpace α] [MeasurableSpace β] :
-    ProbProduct α β -> Measure (α × β) :=
+    ProbProdMeasure α β -> Measure (α × β) :=
   fun μ => Measure.prod (Subtype.val μ).1 (Subtype.val μ).2
 
-local instance (α β : Type*) [MeasurableSpace α] [MeasurableSpace β] (z : ProbProduct α β) :
+local instance (α β : Type*) [MeasurableSpace α] [MeasurableSpace β] (z : ProbProdMeasure α β) :
     IsProbabilityMeasure (monoidal_product α β z) where
   measure_univ := by rcases z with ⟨_, ⟨_, _⟩⟩; simp
 
-theorem measurable_monoidal_product : Measurable (monoidal_product α β) :=
-  Measurable.measure_of_isPiSystem_of_isProbabilityMeasure
-    generateFrom_prod.symm isPiSystem_prod <| by
-    simp only [Set.mem_image2, forall_exists_index, and_imp]
-    intros _ u Hu v Hv Heq
-    let _ (a : ProbProduct α β) : SFinite a.val.2 := by rcases a with ⟨_, ⟨_, _⟩⟩; infer_instance
-    rw [<- Heq, funext <| fun a => MeasureTheory.Measure.prod_prod u v]
-    apply Measurable.mul
-    · rw [<- comp_def (fun μ => μ u) (fun (μ : ProbProduct α β) => (Subtype.val μ).1),
-          <- comp_def Prod.fst _]
-      apply Measurable.comp (measurable_coe Hu) <|
-            Measurable.comp measurable_fst measurable_subtype_coe
-    · rw [<- comp_def (fun μ => μ v) (fun (μ : ProbProduct α β) => (Subtype.val μ).2),
-          <- comp_def Prod.snd _]
-      apply Measurable.comp (measurable_coe Hv) <|
-            Measurable.comp measurable_snd measurable_subtype_coe
-
+theorem measurable_monoidal_product : Measurable (monoidal_product α β) := by
+  apply Measurable.measure_of_isPiSystem generateFrom_prod.symm isPiSystem_prod _ (by simp)
+  simp only [mem_image2, mem_setOf_eq, forall_exists_index, and_imp]
+  intros _ u Hu v Hv Heq
+  let _ (a : ProbProdMeasure α β) : SFinite a.val.2 := by rcases a with ⟨_, ⟨_, _⟩⟩; infer_instance
+  rw [<- Heq, funext <| fun a => MeasureTheory.Measure.prod_prod u v]
+  apply Measurable.mul
+  · rw [<- comp_def (fun μ => μ u) (fun (μ : ProbProdMeasure α β) => (Subtype.val μ).1),
+        <- comp_def Prod.fst _]
+    apply Measurable.comp (measurable_coe Hu) <|
+          Measurable.comp measurable_fst measurable_subtype_coe
+  · rw [<- comp_def (fun μ => μ v) (fun (μ : ProbProdMeasure α β) => (Subtype.val μ).2),
+        <- comp_def Prod.snd _]
+    apply Measurable.comp (measurable_coe Hv) <|
+          Measurable.comp measurable_snd measurable_subtype_coe
 
 end Measure
 

--- a/Mathlib/MeasureTheory/Measure/Prod.lean
+++ b/Mathlib/MeasureTheory/Measure/Prod.lean
@@ -643,38 +643,6 @@ theorem map_prod_map {δ} [MeasurableSpace δ] {f : α → β} {g : γ → δ} (
   rw [map_apply (hf.prod_map hg) (hs.prod ht), map_apply hf hs, map_apply hg ht]
   exact prod_prod (f ⁻¹' s) (g ⁻¹' t)
 
-
-/-! ### The monoidal product in the Giry monad
-Lemma 4.1 of https://doi.org/10.1016/j.aim.2020.10723
--/
-
-abbrev ProbProdMeasure (α β : Type*) [MeasurableSpace α] [MeasurableSpace β] :=
-  { μ : Measure α × Measure β // IsProbabilityMeasure μ.1 ∧ IsProbabilityMeasure μ.2 }
-
-abbrev monoidal_product (α β : Type*) [MeasurableSpace α] [MeasurableSpace β] :
-    ProbProdMeasure α β -> Measure (α × β) :=
-  fun μ => Measure.prod (Subtype.val μ).1 (Subtype.val μ).2
-
-local instance (α β : Type*) [MeasurableSpace α] [MeasurableSpace β] (z : ProbProdMeasure α β) :
-    IsProbabilityMeasure (monoidal_product α β z) where
-  measure_univ := by rcases z with ⟨_, ⟨_, _⟩⟩; simp
-
-theorem measurable_monoidal_product : Measurable (monoidal_product α β) := by
-  apply Measurable.measure_of_isPiSystem generateFrom_prod.symm isPiSystem_prod _ (by simp)
-  simp only [mem_image2, mem_setOf_eq, forall_exists_index, and_imp]
-  intros _ u Hu v Hv Heq
-  let _ (a : ProbProdMeasure α β) : SFinite a.val.2 := by rcases a with ⟨_, ⟨_, _⟩⟩; infer_instance
-  rw [<- Heq, funext <| fun a => MeasureTheory.Measure.prod_prod u v]
-  apply Measurable.mul
-  · rw [<- comp_def (fun μ => μ u) (fun (μ : ProbProdMeasure α β) => (Subtype.val μ).1),
-        <- comp_def Prod.fst _]
-    apply Measurable.comp (measurable_coe Hu) <|
-          Measurable.comp measurable_fst measurable_subtype_coe
-  · rw [<- comp_def (fun μ => μ v) (fun (μ : ProbProdMeasure α β) => (Subtype.val μ).2),
-        <- comp_def Prod.snd _]
-    apply Measurable.comp (measurable_coe Hv) <|
-          Measurable.comp measurable_snd measurable_subtype_coe
-
 end Measure
 
 open Measure


### PR DESCRIPTION
Description:
Proves that the monoidal product of the Giry monoidal monad is measurable, following Lemma 4.1 https://doi.org/10.1016/j.aim.2020.107239

The file ``MeasureTheory/Measure/Prod.lean`` proves that partial applications of ``Prod.mk`` are measurable (eg. ``Measurable.map_prod_mk_left``) but this does not suffice to show that ``Prod.mk`` is a measurable function out of both arguments at once. 

Therefore, this lemma is useful for doing monadic probability theory without using Markov kernels. 

I'm a first-time contributor, so feedback is very welcome :) 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
