### PR TITLE
[Merged by Bors] - feat: register `tauto` and `trivial` for `hint`

### DIFF
--- a/Mathlib/Tactic/Common.lean
+++ b/Mathlib/Tactic/Common.lean
@@ -128,11 +128,12 @@ import hierarchy.
 -/
 
 /-!
-# Register tactics with `hint`.
+# Register tactics with `hint`. Tactics are tried in reverse registration order.
 -/
 
 section Hint
 
+register_hint tauto
 register_hint split
 register_hint intro
 register_hint aesop

--- a/Mathlib/Tactic/Common.lean
+++ b/Mathlib/Tactic/Common.lean
@@ -133,6 +133,7 @@ import hierarchy.
 
 section Hint
 
+register_hint trivial
 register_hint tauto
 register_hint split
 register_hint intro


### PR DESCRIPTION
Examples:

```
import Mathlib

register_hint tauto

example (P : Nat → Prop) (n : Nat) : P n → n = 7 ∨ n = 0 ∨ ¬ (n = 7 ∨ n = 0) ∧ P n := by hint
```

```
import Mathlib

register_hint trivial

example (m : Nat) (h : m ≠ 1) : True ∧ m ≠ 1 ∧ ∀ n < 100, n^2 < 10000 := by hint
```