### PR TITLE
[Merged by Bors] - feat: add Is{Open,Closed}Embedding.sum_elim

### DIFF
--- a/Mathlib/Topology/Constructions.lean
+++ b/Mathlib/Topology/Constructions.lean
@@ -919,6 +919,12 @@ theorem isOpenMap_inl : IsOpenMap (@inl X Y) := fun u hu => by
 theorem isOpenMap_inr : IsOpenMap (@inr X Y) := fun u hu => by
   simpa [isOpen_sum_iff, preimage_image_eq u Sum.inr_injective]
 
+theorem isClosedMap_inl : IsClosedMap (@Sum.inl X Y) := fun u hu ↦ by
+  simpa [isClosed_sum_iff, preimage_image_eq u Sum.inl_injective]
+
+theorem isClosedMap_inr : IsClosedMap (@Sum.inr X Y) := fun u hu ↦ by
+  simpa [isClosed_sum_iff, preimage_image_eq u Sum.inr_injective]
+
 protected lemma Topology.IsOpenEmbedding.inl : IsOpenEmbedding (@inl X Y) :=
   .of_continuous_injective_isOpenMap continuous_inl inl_injective isOpenMap_inl
 
@@ -990,8 +996,8 @@ theorem isOpenMap_sum {f : X ⊕ Y → Z} :
   simp only [isOpenMap_iff_nhds_le, Sum.forall, nhds_inl, nhds_inr, Filter.map_map, comp_def]
 
 theorem IsOpenMap.sumMap {f : X → Y} {g : Z → W} (hf : IsOpenMap f) (hg : IsOpenMap g) :
-    IsOpenMap (Sum.map f g) := by
-  exact isOpenMap_sum.2 ⟨isOpenMap_inl.comp hf,isOpenMap_inr.comp hg⟩
+    IsOpenMap (Sum.map f g) :=
+  isOpenMap_sum.2 ⟨isOpenMap_inl.comp hf, isOpenMap_inr.comp hg⟩
 
 @[simp]
 theorem isOpenMap_sum_elim {f : X → Z} {g : Y → Z} :
@@ -1001,6 +1007,12 @@ theorem isOpenMap_sum_elim {f : X → Z} {g : Y → Z} :
 theorem IsOpenMap.sum_elim {f : X → Z} {g : Y → Z} (hf : IsOpenMap f) (hg : IsOpenMap g) :
     IsOpenMap (Sum.elim f g) :=
   isOpenMap_sum_elim.2 ⟨hf, hg⟩
+
+lemma IsOpenEmbedding.sum_elim {f : X → Z} {g : Y → Z}
+    (hf : IsOpenEmbedding f) (hg : IsOpenEmbedding g) (h : Injective (Sum.elim f g)) :
+    IsOpenEmbedding (Sum.elim f g) := by
+  rw [isOpenEmbedding_iff_continuous_injective_isOpenMap] at hf hg ⊢
+  exact ⟨hf.1.sum_elim hg.1, h, hf.2.2.sum_elim hg.2.2⟩
 
 theorem isClosedMap_sum {f : X ⊕ Y → Z} :
     IsClosedMap f ↔ (IsClosedMap fun a => f (.inl a)) ∧ IsClosedMap fun b => f (.inr b) := by
@@ -1012,6 +1024,25 @@ theorem isClosedMap_sum {f : X ⊕ Y → Z} :
     convert (h.1 _ hZ.1).union (h.2 _ hZ.2)
     ext
     simp only [mem_image, Sum.exists, mem_union, mem_preimage]
+
+theorem IsClosedMap.sumMap {f : X → Y} {g : Z → W} (hf : IsClosedMap f) (hg : IsClosedMap g) :
+    IsClosedMap (Sum.map f g) :=
+  isClosedMap_sum.2 ⟨isClosedMap_inl.comp hf, isClosedMap_inr.comp hg⟩
+
+@[simp]
+theorem isClosedMap_sum_elim {f : X → Z} {g : Y → Z} :
+    IsClosedMap (Sum.elim f g) ↔ IsClosedMap f ∧ IsClosedMap g := by
+  simp only [isClosedMap_sum, Sum.elim_inl, Sum.elim_inr]
+
+theorem IsClosedMap.sum_elim {f : X → Z} {g : Y → Z} (hf : IsClosedMap f) (hg : IsClosedMap g) :
+    IsClosedMap (Sum.elim f g) :=
+  isClosedMap_sum_elim.2 ⟨hf, hg⟩
+
+lemma IsClosedEmbedding.sum_elim {f : X → Z} {g : Y → Z}
+    (hf : IsClosedEmbedding f) (hg : IsClosedEmbedding g) (h : Injective (Sum.elim f g)) :
+    IsClosedEmbedding (Sum.elim f g) := by
+  rw [isClosedEmbedding_iff_continuous_injective_isClosedMap] at hf hg ⊢
+  exact ⟨hf.1.sum_elim hg.1, h, hf.2.2.sum_elim hg.2.2⟩
 
 end Sum
 

--- a/Mathlib/Topology/Constructions.lean
+++ b/Mathlib/Topology/Constructions.lean
@@ -919,10 +919,10 @@ theorem isOpenMap_inl : IsOpenMap (@inl X Y) := fun u hu => by
 theorem isOpenMap_inr : IsOpenMap (@inr X Y) := fun u hu => by
   simpa [isOpen_sum_iff, preimage_image_eq u Sum.inr_injective]
 
-theorem isClosedMap_inl : IsClosedMap (@Sum.inl X Y) := fun u hu ↦ by
+theorem isClosedMap_inl : IsClosedMap (@inl X Y) := fun u hu ↦ by
   simpa [isClosed_sum_iff, preimage_image_eq u Sum.inl_injective]
 
-theorem isClosedMap_inr : IsClosedMap (@Sum.inr X Y) := fun u hu ↦ by
+theorem isClosedMap_inr : IsClosedMap (@inr X Y) := fun u hu ↦ by
   simpa [isClosed_sum_iff, preimage_image_eq u Sum.inr_injective]
 
 protected lemma Topology.IsOpenEmbedding.inl : IsOpenEmbedding (@inl X Y) :=

--- a/Mathlib/Topology/Constructions.lean
+++ b/Mathlib/Topology/Constructions.lean
@@ -1041,7 +1041,7 @@ theorem IsClosedMap.sum_elim {f : X → Z} {g : Y → Z} (hf : IsClosedMap f) (h
 lemma IsClosedEmbedding.sum_elim {f : X → Z} {g : Y → Z}
     (hf : IsClosedEmbedding f) (hg : IsClosedEmbedding g) (h : Injective (Sum.elim f g)) :
     IsClosedEmbedding (Sum.elim f g) := by
-  rw [isClosedEmbedding_iff_continuous_injective_isClosedMap] at hf hg ⊢
+  rw [IsClosedEmbedding.isClosedEmbedding_iff_continuous_injective_isClosedMap] at hf hg ⊢
   exact ⟨hf.1.sum_elim hg.1, h, hf.2.2.sum_elim hg.2.2⟩
 
 end Sum

--- a/Mathlib/Topology/Constructions.lean
+++ b/Mathlib/Topology/Constructions.lean
@@ -1920,4 +1920,4 @@ theorem Filter.Eventually.prod_nhdsSet {p : X × Y → Prop} {px : X → Prop} {
 
 end NhdsSet
 
-set_option linter.style.longFile 1900
+set_option linter.style.longFile 2100

--- a/Mathlib/Topology/Maps/Basic.lean
+++ b/Mathlib/Topology/Maps/Basic.lean
@@ -758,6 +758,11 @@ lemma of_continuous_injective_isClosedMap (h₁ : Continuous f) (h₂ : Injectiv
 alias _root_.closedEmbedding_of_continuous_injective_closed :=
   IsClosedEmbedding.of_continuous_injective_isClosedMap
 
+lemma isClosedEmbedding_iff_continuous_injective_isClosedMap {f : X → Y} :
+    IsClosedEmbedding f ↔ Continuous f ∧ Injective f ∧ IsClosedMap f :=
+  ⟨fun h ↦ ⟨h.continuous, h.injective, h.isClosedMap⟩, fun h ↦
+    .of_continuous_injective_isClosedMap h.1 h.2.1 h.2.2⟩
+
 protected theorem id : IsClosedEmbedding (@id X) := ⟨.id, IsClosedMap.id.isClosed_range⟩
 
 @[deprecated (since := "2024-10-20")]

--- a/Mathlib/Topology/Maps/Basic.lean
+++ b/Mathlib/Topology/Maps/Basic.lean
@@ -759,9 +759,9 @@ alias _root_.closedEmbedding_of_continuous_injective_closed :=
   IsClosedEmbedding.of_continuous_injective_isClosedMap
 
 lemma isClosedEmbedding_iff_continuous_injective_isClosedMap {f : X → Y} :
-    IsClosedEmbedding f ↔ Continuous f ∧ Injective f ∧ IsClosedMap f :=
-  ⟨fun h ↦ ⟨h.continuous, h.injective, h.isClosedMap⟩, fun h ↦
-    .of_continuous_injective_isClosedMap h.1 h.2.1 h.2.2⟩
+    IsClosedEmbedding f ↔ Continuous f ∧ Injective f ∧ IsClosedMap f where
+  mp h := ⟨h.continuous, h.injective, h.isClosedMap⟩
+  mpr h := .of_continuous_injective_isClosedMap h.1 h.2.1 h.2.2
 
 protected theorem id : IsClosedEmbedding (@id X) := ⟨.id, IsClosedMap.id.isClosed_range⟩
 


### PR DESCRIPTION
The necessary pieces are all in mathlib (for the open and/or the closed case), this is just a matter of putting them together. This comes up when constructing the smooth boundary of a disjoint union.

Extracted from #22059; from my bordism theory project.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
