### PR TITLE
[Merged by Bors] - chore: manually deprime `cases'`, part 1

### DIFF
--- a/Mathlib/Algebra/Order/CauSeq/Basic.lean
+++ b/Mathlib/Algebra/Order/CauSeq/Basic.lean
@@ -828,8 +828,8 @@ protected theorem inf_le_right {a b : CauSeq α abs} : a ⊓ b ≤ b :=
   le_of_exists ⟨0, fun _ _ => inf_le_right⟩
 
 protected theorem sup_le {a b c : CauSeq α abs} (ha : a ≤ c) (hb : b ≤ c) : a ⊔ b ≤ c := by
-  cases' ha with ha ha
-  · cases' hb with hb hb
+  obtain ha | ha := ha
+  · obtain hb | hb := hb
     · exact Or.inl (CauSeq.sup_lt ha hb)
     · replace ha := le_of_le_of_eq ha.le (Setoid.symm hb)
       refine le_of_le_of_eq (Or.inr ?_) hb
@@ -839,8 +839,8 @@ protected theorem sup_le {a b c : CauSeq α abs} (ha : a ≤ c) (hb : b ≤ c) :
     exact CauSeq.sup_eq_left hb
 
 protected theorem le_inf {a b c : CauSeq α abs} (hb : a ≤ b) (hc : a ≤ c) : a ≤ b ⊓ c := by
-  cases' hb with hb hb
-  · cases' hc with hc hc
+  obtain hb | hb := hb
+  · obtain hc | hc := hc
     · exact Or.inl (CauSeq.lt_inf hb hc)
     · replace hb := le_of_eq_of_le (Setoid.symm hc) hb.le
       refine le_of_eq_of_le hc (Or.inr ?_)

--- a/Mathlib/Algebra/Ring/WithZero.lean
+++ b/Mathlib/Algebra/Ring/WithZero.lean
@@ -16,16 +16,15 @@ variable {α : Type*}
 instance instLeftDistribClass [Mul α] [Add α] [LeftDistribClass α] :
     LeftDistribClass (WithZero α) where
   left_distrib a b c := by
-    cases' a with a; · rfl
-    cases' b with b <;> cases' c with c <;> try rfl
+    cases a; · rfl
+    cases b <;> cases c <;> try rfl
     exact congr_arg some (left_distrib _ _ _)
 
 instance instRightDistribClass [Mul α] [Add α] [RightDistribClass α] :
     RightDistribClass (WithZero α) where
   right_distrib a b c := by
-    cases' c with c
-    · simp
-    cases' a with a <;> cases' b with b <;> try rfl
+    cases c; · simp
+    cases a <;> cases b <;> try rfl
     exact congr_arg some (right_distrib _ _ _)
 
 instance instDistrib [Distrib α] : Distrib (WithZero α) where

--- a/Mathlib/AlgebraicTopology/SimplexCategory/Basic.lean
+++ b/Mathlib/AlgebraicTopology/SimplexCategory/Basic.lean
@@ -365,14 +365,17 @@ theorem σ_comp_σ {n} {i j : Fin (n + 1)} (H : i ≤ j) :
     σ (Fin.castSucc i) ≫ σ j = σ j.succ ≫ σ i := by
   ext k : 3
   dsimp [σ]
-  cases' k using Fin.lastCases with k
-  · simp only [len_mk, Fin.predAbove_right_last]
-  · cases' k using Fin.cases with k
-    · rw [Fin.castSucc_zero, Fin.predAbove_of_le_castSucc _ 0 (Fin.zero_le _),
+  cases k using Fin.lastCases with
+  | last => simp only [len_mk, Fin.predAbove_right_last]
+  | cast k =>
+    cases k using Fin.cases with
+    | zero =>
+      rw [Fin.castSucc_zero, Fin.predAbove_of_le_castSucc _ 0 (Fin.zero_le _),
       Fin.predAbove_of_le_castSucc _ _ (Fin.zero_le _), Fin.castPred_zero,
       Fin.predAbove_of_le_castSucc _ 0 (Fin.zero_le _),
       Fin.predAbove_of_le_castSucc _ _ (Fin.zero_le _)]
-    · rcases le_or_lt i k with (h | h)
+    | succ k =>
+      rcases le_or_lt i k with (h | h)
       · simp_rw [Fin.predAbove_of_castSucc_lt i.castSucc _ (Fin.castSucc_lt_castSucc_iff.mpr
         (Fin.castSucc_lt_succ_iff.mpr h)), ← Fin.succ_castSucc, Fin.pred_succ,
         Fin.succ_predAbove_succ]
@@ -408,11 +411,13 @@ lemma factor_δ_spec {m n : ℕ} (f : ⦋m⦌ ⟶ ⦋n+1⦌) (j : Fin (n+2))
   ext k : 3
   specialize hj k
   dsimp [factor_δ, δ, σ]
-  cases' j using cases with j
-  · rw [predAbove_of_le_castSucc _ _ (zero_le _), castPred_zero, predAbove_of_castSucc_lt 0 _
+  cases j using cases with
+  | zero =>
+    rw [predAbove_of_le_castSucc _ _ (zero_le _), castPred_zero, predAbove_of_castSucc_lt 0 _
     (castSucc_zero ▸ pos_of_ne_zero hj),
     zero_succAbove, succ_pred]
-  · rw [predAbove_of_castSucc_lt 0 _ (castSucc_zero ▸ succ_pos _), pred_succ]
+  | succ j =>
+    rw [predAbove_of_castSucc_lt 0 _ (castSucc_zero ▸ succ_pos _), pred_succ]
     rcases hj.lt_or_lt with (hj | hj)
     · rw [predAbove_of_le_castSucc j _]
       swap

--- a/Mathlib/Analysis/Calculus/ParametricIntegral.lean
+++ b/Mathlib/Analysis/Calculus/ParametricIntegral.lean
@@ -261,10 +261,8 @@ theorem hasDerivAt_integral_of_dominated_loc_of_lip {F' : α → E} (ε_pos : 0 
   replace h_diff : ∀ᵐ a ∂μ, HasFDerivAt (F · a) (L (F' a)) x₀ :=
     h_diff.mono fun x hx ↦ hx.hasFDerivAt
   have hm : AEStronglyMeasurable (L ∘ F') μ := L.continuous.comp_aestronglyMeasurable hF'_meas
-  cases'
-    hasFDerivAt_integral_of_dominated_loc_of_lip ε_pos hF_meas hF_int hm h_lipsch bound_integrable
-      h_diff with
-    hF'_int key
+  obtain ⟨hF'_int, key⟩ := hasFDerivAt_integral_of_dominated_loc_of_lip
+    ε_pos hF_meas hF_int hm h_lipsch bound_integrable h_diff
   replace hF'_int : Integrable F' μ := by
     rw [← integrable_norm_iff hm] at hF'_int
     simpa only [L, (· ∘ ·), integrable_norm_iff, hF'_meas, one_mul, norm_one,

--- a/Mathlib/Analysis/Meromorphic/Order.lean
+++ b/Mathlib/Analysis/Meromorphic/Order.lean
@@ -119,19 +119,22 @@ theorem order_smul {f : 𝕜 → 𝕜} {g : 𝕜 → E} {x : 𝕜}
     (hf : MeromorphicAt f x) (hg : MeromorphicAt g x) :
     (hf.smul hg).order = hf.order + hg.order := by
   -- Trivial cases: one of the functions vanishes around z₀
-  cases' h₂f : hf.order with m h₂f
-  · simp only [top_add, order_eq_top_iff] at h₂f ⊢
+  cases h₂f : hf.order with
+  | top =>
+    simp only [top_add, order_eq_top_iff] at h₂f ⊢
     filter_upwards [h₂f] with z hz using by simp [hz]
-  cases' h₂g : hg.order with n h₂f
-  · simp only [add_top, order_eq_top_iff] at h₂g ⊢
-    filter_upwards [h₂g] with z hz using by simp [hz]
-  -- Non-trivial case: both functions do not vanish around z₀
-  rw [← WithTop.coe_add, order_eq_int_iff]
-  obtain ⟨F, h₁F, h₂F, h₃F⟩ := (hf.order_eq_int_iff _).1 h₂f
-  obtain ⟨G, h₁G, h₂G, h₃G⟩ := (hg.order_eq_int_iff _).1 h₂g
-  use F • G, h₁F.smul h₁G, by simp [h₂F, h₂G]
-  filter_upwards [self_mem_nhdsWithin, h₃F, h₃G] with a ha hfa hga
-  simp [hfa, hga, smul_comm (F a), zpow_add₀ (sub_ne_zero.mpr ha), mul_smul]
+  | coe m =>
+    cases h₂g : hg.order with
+    | top =>
+      simp only [add_top, order_eq_top_iff] at h₂g ⊢
+      filter_upwards [h₂g] with z hz using by simp [hz]
+    | coe n => -- Non-trivial case: both functions do not vanish around z₀
+      rw [← WithTop.coe_add, order_eq_int_iff]
+      obtain ⟨F, h₁F, h₂F, h₃F⟩ := (hf.order_eq_int_iff _).1 h₂f
+      obtain ⟨G, h₁G, h₂G, h₃G⟩ := (hg.order_eq_int_iff _).1 h₂g
+      use F • G, h₁F.smul h₁G, by simp [h₂F, h₂G]
+      filter_upwards [self_mem_nhdsWithin, h₃F, h₃G] with a ha hfa hga
+      simp [hfa, hga, smul_comm (F a), zpow_add₀ (sub_ne_zero.mpr ha), mul_smul]
 
 /-- The order is additive when multiplying meromorphic functions. -/
 theorem order_mul {f g : 𝕜 → 𝕜} {x : 𝕜} (hf : MeromorphicAt f x) (hg : MeromorphicAt g x) :

--- a/Mathlib/Analysis/NormedSpace/Pointwise.lean
+++ b/Mathlib/Analysis/NormedSpace/Pointwise.lean
@@ -236,19 +236,21 @@ theorem infEdist_thickening (hδ : 0 < δ) (s : Set E) (x : E) :
   refine (tsub_le_iff_right.2 infEdist_le_infEdist_thickening_add).antisymm' ?_
   refine le_sub_of_add_le_right ofReal_ne_top ?_
   refine le_infEdist.2 fun z hz => le_of_forall_lt' fun r h => ?_
-  cases' r with r
-  · exact add_lt_top.2 ⟨lt_top_iff_ne_top.2 <| infEdist_ne_top ⟨z, self_subset_thickening hδ _ hz⟩,
+  cases r with
+  | top =>
+    exact add_lt_top.2 ⟨lt_top_iff_ne_top.2 <| infEdist_ne_top ⟨z, self_subset_thickening hδ _ hz⟩,
       ofReal_lt_top⟩
-  have hr : 0 < ↑r - δ := by
-    refine sub_pos_of_lt ?_
-    have := hs.trans_lt ((infEdist_le_edist_of_mem hz).trans_lt h)
-    rw [ofReal_eq_coe_nnreal hδ.le] at this
-    exact mod_cast this
-  rw [edist_lt_coe, ← dist_lt_coe, ← add_sub_cancel δ ↑r] at h
-  obtain ⟨y, hxy, hyz⟩ := exists_dist_lt_lt hr hδ h
-  refine (ENNReal.add_lt_add_right ofReal_ne_top <|
-    infEdist_lt_iff.2 ⟨_, mem_thickening_iff.2 ⟨_, hz, hyz⟩, edist_lt_ofReal.2 hxy⟩).trans_le ?_
-  rw [← ofReal_add hr.le hδ.le, sub_add_cancel, ofReal_coe_nnreal]
+  | coe r =>
+    have hr : 0 < ↑r - δ := by
+      refine sub_pos_of_lt ?_
+      have := hs.trans_lt ((infEdist_le_edist_of_mem hz).trans_lt h)
+      rw [ofReal_eq_coe_nnreal hδ.le] at this
+      exact mod_cast this
+    rw [edist_lt_coe, ← dist_lt_coe, ← add_sub_cancel δ ↑r] at h
+    obtain ⟨y, hxy, hyz⟩ := exists_dist_lt_lt hr hδ h
+    refine (ENNReal.add_lt_add_right ofReal_ne_top <|
+      infEdist_lt_iff.2 ⟨_, mem_thickening_iff.2 ⟨_, hz, hyz⟩, edist_lt_ofReal.2 hxy⟩).trans_le ?_
+    rw [← ofReal_add hr.le hδ.le, sub_add_cancel, ofReal_coe_nnreal]
 
 @[simp]
 theorem thickening_thickening (hε : 0 < ε) (hδ : 0 < δ) (s : Set E) :

--- a/Mathlib/Analysis/SpecialFunctions/Pow/NNReal.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Pow/NNReal.lean
@@ -519,10 +519,12 @@ theorem one_rpow (x : ℝ) : (1 : ℝ≥0∞) ^ x = 1 := by
 
 @[simp]
 theorem rpow_eq_zero_iff {x : ℝ≥0∞} {y : ℝ} : x ^ y = 0 ↔ x = 0 ∧ 0 < y ∨ x = ⊤ ∧ y < 0 := by
-  cases' x with x
-  · rcases lt_trichotomy y 0 with (H | H | H) <;>
+  cases x with
+  | top =>
+    rcases lt_trichotomy y 0 with (H | H | H) <;>
       simp [H, top_rpow_of_neg, top_rpow_of_pos, le_of_lt]
-  · by_cases h : x = 0
+  | coe x =>
+    by_cases h : x = 0
     · rcases lt_trichotomy y 0 with (H | H | H) <;>
         simp [h, H, zero_rpow_of_neg, zero_rpow_of_pos, le_of_lt]
     · simp [← coe_rpow_of_ne_zero h, h]
@@ -532,10 +534,12 @@ lemma rpow_eq_zero_iff_of_pos {x : ℝ≥0∞} {y : ℝ} (hy : 0 < y) : x ^ y = 
 
 @[simp]
 theorem rpow_eq_top_iff {x : ℝ≥0∞} {y : ℝ} : x ^ y = ⊤ ↔ x = 0 ∧ y < 0 ∨ x = ⊤ ∧ 0 < y := by
-  cases' x with x
-  · rcases lt_trichotomy y 0 with (H | H | H) <;>
+  cases x with
+  | top =>
+    rcases lt_trichotomy y 0 with (H | H | H) <;>
       simp [H, top_rpow_of_neg, top_rpow_of_pos, le_of_lt]
-  · by_cases h : x = 0
+  | coe x =>
+    by_cases h : x = 0
     · rcases lt_trichotomy y 0 with (H | H | H) <;>
         simp [h, H, zero_rpow_of_neg, zero_rpow_of_pos, le_of_lt]
     · simp [← coe_rpow_of_ne_zero h, h]
@@ -561,10 +565,11 @@ theorem rpow_lt_top_of_nonneg {x : ℝ≥0∞} {y : ℝ} (hy0 : 0 ≤ y) (h : x 
   lt_top_iff_ne_top.mpr (ENNReal.rpow_ne_top_of_nonneg hy0 h)
 
 theorem rpow_add {x : ℝ≥0∞} (y z : ℝ) (hx : x ≠ 0) (h'x : x ≠ ⊤) : x ^ (y + z) = x ^ y * x ^ z := by
-  cases' x with x
-  · exact (h'x rfl).elim
-  have : x ≠ 0 := fun h => by simp [h] at hx
-  simp [← coe_rpow_of_ne_zero this, NNReal.rpow_add this]
+  cases x with
+  | top => exact (h'x rfl).elim
+  | coe x =>
+    have : x ≠ 0 := fun h => by simp [h] at hx
+    simp [← coe_rpow_of_ne_zero this, NNReal.rpow_add this]
 
 theorem rpow_add_of_nonneg {x : ℝ≥0∞} (y z : ℝ) (hy : 0 ≤ y) (hz : 0 ≤ z) :
     x ^ (y + z) = x ^ y * x ^ z := by
@@ -577,10 +582,12 @@ theorem rpow_add_of_nonneg {x : ℝ≥0∞} (y z : ℝ) (hy : 0 ≤ y) (hz : 0 �
   simp [← coe_rpow_of_nonneg, hy, hz, add_nonneg hy hz, NNReal.rpow_add_of_nonneg _ hy hz]
 
 theorem rpow_neg (x : ℝ≥0∞) (y : ℝ) : x ^ (-y) = (x ^ y)⁻¹ := by
-  cases' x with x
-  · rcases lt_trichotomy y 0 with (H | H | H) <;>
+  cases x with
+  | top =>
+    rcases lt_trichotomy y 0 with (H | H | H) <;>
       simp [top_rpow_of_pos, top_rpow_of_neg, H, neg_pos.mpr]
-  · by_cases h : x = 0
+  | coe x =>
+    by_cases h : x = 0
     · rcases lt_trichotomy y 0 with (H | H | H) <;>
         simp [h, zero_rpow_of_pos, zero_rpow_of_neg, H, neg_pos.mpr]
     · have A : x ^ y ≠ 0 := by simp [h]
@@ -592,12 +599,14 @@ theorem rpow_sub {x : ℝ≥0∞} (y z : ℝ) (hx : x ≠ 0) (h'x : x ≠ ⊤) :
 theorem rpow_neg_one (x : ℝ≥0∞) : x ^ (-1 : ℝ) = x⁻¹ := by simp [rpow_neg]
 
 theorem rpow_mul (x : ℝ≥0∞) (y z : ℝ) : x ^ (y * z) = (x ^ y) ^ z := by
-  cases' x with x
-  · rcases lt_trichotomy y 0 with (Hy | Hy | Hy) <;>
+  cases x with
+  | top =>
+    rcases lt_trichotomy y 0 with (Hy | Hy | Hy) <;>
         rcases lt_trichotomy z 0 with (Hz | Hz | Hz) <;>
       simp [Hy, Hz, zero_rpow_of_neg, zero_rpow_of_pos, top_rpow_of_neg, top_rpow_of_pos,
         mul_pos_of_neg_of_neg, mul_neg_of_neg_of_pos, mul_neg_of_pos_of_neg]
-  · by_cases h : x = 0
+  | coe x =>
+    by_cases h : x = 0
     · rcases lt_trichotomy y 0 with (Hy | Hy | Hy) <;>
           rcases lt_trichotomy z 0 with (Hz | Hz | Hz) <;>
         simp [h, Hy, Hz, zero_rpow_of_neg, zero_rpow_of_pos, top_rpow_of_neg, top_rpow_of_pos,
@@ -857,11 +866,12 @@ theorem one_le_rpow_of_pos_of_le_one_of_neg {x : ℝ≥0∞} {z : ℝ} (hx1 : 0 
 
 @[simp] lemma toNNReal_rpow (x : ℝ≥0∞) (z : ℝ) : (x ^ z).toNNReal = x.toNNReal ^ z := by
   rcases lt_trichotomy z 0 with (H | H | H)
-  · cases' x with x
-    · simp [H, ne_of_lt]
-    by_cases hx : x = 0
-    · simp [hx, H, ne_of_lt]
-    · simp [← coe_rpow_of_ne_zero hx]
+  · cases x with
+    | top => simp [H, ne_of_lt]
+    | coe x =>
+      by_cases hx : x = 0
+      · simp [hx, H, ne_of_lt]
+      · simp [← coe_rpow_of_ne_zero hx]
   · simp [H]
   · cases x
     · simp [H, ne_of_gt]

--- a/Mathlib/CategoryTheory/Extensive.lean
+++ b/Mathlib/CategoryTheory/Extensive.lean
@@ -218,7 +218,7 @@ instance types.finitaryExtensive : FinitaryExtensive (Type u) := by
       intro s
       have : ∀ x, ∃! y, s.fst x = Sum.inl y := by
         intro x
-        cases' h : s.fst x with val val
+        rcases h : s.fst x with val | val
         · simp only [Types.binaryCoproductCocone_pt, Functor.const_obj_obj, Sum.inl.injEq,
             existsUnique_eq']
         · apply_fun f at h
@@ -231,7 +231,7 @@ instance types.finitaryExtensive : FinitaryExtensive (Type u) := by
       intro s
       have : ∀ x, ∃! y, s.fst x = Sum.inr y := by
         intro x
-        cases' h : s.fst x with val val
+        rcases h : s.fst x with val | val
         · apply_fun f at h
           cases ((congr_fun s.condition x).symm.trans h).trans (congr_fun hαX val :).symm
         · simp only [Types.binaryCoproductCocone_pt, Functor.const_obj_obj, Sum.inr.injEq,
@@ -310,7 +310,7 @@ instance finitaryExtensive_TopCat : FinitaryExtensive TopCat.{u} := by
       intro s
       have : ∀ x, ∃! y, s.fst x = Sum.inl y := by
         intro x
-        cases' h : s.fst x with val val
+        rcases h : s.fst x with val | val
         · exact ⟨val, rfl, fun y h => Sum.inl_injective h.symm⟩
         · apply_fun f at h
           cases ((ConcreteCategory.congr_hom s.condition x).symm.trans h).trans
@@ -328,7 +328,7 @@ instance finitaryExtensive_TopCat : FinitaryExtensive TopCat.{u} := by
       intro s
       have : ∀ x, ∃! y, s.fst x = Sum.inr y := by
         intro x
-        cases' h : s.fst x with val val
+        rcases h : s.fst x with val | val
         · apply_fun f at h
           cases ((ConcreteCategory.congr_hom s.condition x).symm.trans h).trans
             (ConcreteCategory.congr_hom hαX val :).symm

--- a/Mathlib/CategoryTheory/Limits/Constructions/Over/Products.lean
+++ b/Mathlib/CategoryTheory/Limits/Constructions/Over/Products.lean
@@ -56,7 +56,7 @@ def conesEquivInverse (B : C) {J : Type w} (F : Discrete J ⥤ Over B) :
   map f :=
     { hom := f.hom.left
       w := fun j => by
-        cases' j with j
+        obtain - | j := j
         · simp
         · dsimp
           rw [← f.w ⟨j⟩]

--- a/Mathlib/CategoryTheory/Limits/Shapes/FiniteLimits.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/FiniteLimits.lean
@@ -167,8 +167,8 @@ instance fintypeObj [Fintype J] : Fintype (WidePullbackShape J) :=
 
 instance fintypeHom (j j' : WidePullbackShape J) : Fintype (j ⟶ j') where
   elems := by
-    cases' j' with j'
-    · cases' j with j
+    obtain - | j' := j'
+    · obtain - | j := j
       · exact {Hom.id none}
       · exact {Hom.term j}
     · by_cases h : some j' = j
@@ -189,8 +189,8 @@ instance fintypeObj [Fintype J] : Fintype (WidePushoutShape J) := by
 
 instance fintypeHom (j j' : WidePushoutShape J) : Fintype (j ⟶ j') where
   elems := by
-    cases' j with j
-    · cases' j' with j'
+    obtain - | j := j
+    · obtain - | j' := j'
       · exact {Hom.id none}
       · exact {Hom.init j'}
     · by_cases h : some j = j'

--- a/Mathlib/CategoryTheory/Limits/Shapes/WideEqualizers.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/WideEqualizers.lean
@@ -218,7 +218,7 @@ def Trident.ofι [Nonempty J] {P : C} (ι : P ⟶ X) (w : ∀ j₁ j₂, ι ≫ 
     { app := fun X => WalkingParallelFamily.casesOn X ι (ι ≫ f (Classical.arbitrary J))
       naturality := fun i j f => by
         dsimp
-        cases' f with _ k
+        obtain - | k := f
         · simp
         · simp [w (Classical.arbitrary J) k] }
 
@@ -233,7 +233,7 @@ def Cotrident.ofπ [Nonempty J] {P : C} (π : Y ⟶ P) (w : ∀ j₁ j₂, f j�
     { app := fun X => WalkingParallelFamily.casesOn X (f (Classical.arbitrary J) ≫ π) π
       naturality := fun i j f => by
         dsimp
-        cases' f with _ k
+        obtain - | k := f
         · simp
         · simp [w (Classical.arbitrary J) k] }
 

--- a/Mathlib/CategoryTheory/Limits/Shapes/WidePullbacks.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/WidePullbacks.lean
@@ -206,7 +206,7 @@ fixed object.
 def wideSpan (B : C) (objs : J → C) (arrows : ∀ j : J, B ⟶ objs j) : WidePushoutShape J ⥤ C where
   obj j := Option.casesOn j B objs
   map f := by
-    cases' f with _ j
+    obtain - | j := f
     · apply 𝟙 _
     · exact arrows j
   map_comp := fun f g => by

--- a/Mathlib/CategoryTheory/Limits/Shapes/WidePullbacks.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/WidePullbacks.lean
@@ -108,7 +108,7 @@ fixed object.
 def wideCospan (B : C) (objs : J → C) (arrows : ∀ j : J, objs j ⟶ B) : WidePullbackShape J ⥤ C where
   obj j := Option.casesOn j B objs
   map f := by
-    cases' f with _ j
+    obtain - | j := f
     · apply 𝟙 _
     · exact arrows j
 

--- a/Mathlib/Computability/Encoding.lean
+++ b/Mathlib/Computability/Encoding.lean
@@ -122,7 +122,7 @@ theorem encodePosNum_nonempty (n : PosNum) : encodePosNum n ≠ [] :=
 
 @[simp] theorem decode_encodeNum : ∀ n, decodeNum (encodeNum n) = n := by
   intro n
-  cases' n with n <;> unfold encodeNum decodeNum
+  obtain - | n := n <;> unfold encodeNum decodeNum
   · rfl
   rw [decode_encodePosNum n]
   rw [PosNum.cast_to_num]

--- a/Mathlib/Computability/PartrecCode.lean
+++ b/Mathlib/Computability/PartrecCode.lean
@@ -931,7 +931,7 @@ theorem evaln_prim : Primrec fun a : (ℕ × Code) × ℕ => evaln a.1.1 a.1.2 a
             evaln k' c' n := by
         intro k₁ c₁ n₁ hl
         simp [lup, List.getElem?_range hl, evaln_map, Bind.bind, Option.bind_map]
-      cases' c with cf cg cf cg cf cg cf <;>
+      obtain - | - | - | - | ⟨cf, cg⟩ | ⟨cf, cg⟩ | ⟨cf, cg⟩ | cf := c <;>
         simp [evaln, nk, Bind.bind, Functor.map, Seq.seq, pure]
       · obtain ⟨lf, lg⟩ := encode_lt_pair cf cg
         rw [hg (Nat.pair_lt_pair_right _ lf), hg (Nat.pair_lt_pair_right _ lg)]

--- a/Mathlib/Computability/PostTuringMachine.lean
+++ b/Mathlib/Computability/PostTuringMachine.lean
@@ -1215,7 +1215,7 @@ theorem tr_respects : Respects (TM0.step M) (TM1.step (tr M)) fun a b ↦ trCfg 
     have : TM1.step (tr M) ⟨some (Λ'.act s q'), (), T⟩ = some ⟨some (Λ'.normal q'), (), match s with
         | TM0.Stmt.move d => T.move d
         | TM0.Stmt.write a => T.write a⟩ := by
-      cases' s with d a <;> rfl
+      cases s <;> rfl
     intro e
     refine TransGen.head ?_ (TransGen.head' this ?_)
     · simp only [TM1.step, TM1.stepAux, tr]

--- a/Mathlib/Computability/RegularExpressions.lean
+++ b/Mathlib/Computability/RegularExpressions.lean
@@ -279,7 +279,7 @@ theorem star_rmatch_iff (P : RegularExpression α) :
       · rw [rmatch, deriv, mul_rmatch_iff]
         rcases S with - | ⟨t', U⟩
         · exact ⟨[], [], by tauto⟩
-        · cases' t' with b t
+        · obtain - | ⟨b, t⟩ := t'
           · simp only [forall_eq_or_imp, List.mem_cons] at helem
             simp only [eq_self_iff_true, not_true, Ne, false_and] at helem
           simp only [List.flatten, List.cons_append, List.cons_eq_cons] at hsum

--- a/Mathlib/Computability/TMToPartrec.lean
+++ b/Mathlib/Computability/TMToPartrec.lean
@@ -1400,7 +1400,7 @@ theorem succ_ok {q s n} {c d : List Γ'} :
     Reaches₁ (TM2.step tr) ⟨some (Λ'.succ q), s, K'.elim (trList [n]) [] c d⟩
       ⟨some q, none, K'.elim (trList [n.succ]) [] c d⟩ := by
   simp only [TM2.step, trList, trNat.eq_1, Nat.cast_succ, Num.add_one]
-  cases' (n : Num) with a
+  rcases (n : Num) with - | a
   · refine TransGen.head rfl ?_
     simp only [Option.mem_def, TM2.stepAux, elim_main, decide_false, elim_update_main, ne_eq,
       Function.update_of_ne, elim_rev, elim_update_rev, decide_true, Function.update_self,
@@ -1443,7 +1443,7 @@ theorem pred_ok (q₁ q₂ s v) (c d : List Γ') : ∃ s',
   refine ⟨none, ?_⟩
   simp only [TM2.step, trList, trNat.eq_1, trNum, Nat.cast_succ, Num.add_one, Num.succ,
     List.tail_cons, List.headI_cons]
-  cases' (n : Num) with a
+  rcases (n : Num) with - | a
   · simp only [trPosNum, Num.succ', List.singleton_append, List.nil_append]
     refine TransGen.head rfl ?_
     rw [tr]; simp only [pop', TM2.stepAux, cond_false]
@@ -1543,7 +1543,7 @@ theorem tr_ret_respects (k v s) : ∃ b₂,
       else
         natEnd (trList v).head?.iget = false ∧
           (trList v).tail = (trNat v.headI).tail ++ Γ'.cons :: trList v.tail := by
-      cases' v with n
+      obtain - | n := v
       · exact ⟨rfl, rfl⟩
       rcases n with - | n
       · simp

--- a/Mathlib/Data/DFinsupp/Defs.lean
+++ b/Mathlib/Data/DFinsupp/Defs.lean
@@ -1184,7 +1184,7 @@ noncomputable def equivProdDFinsupp [∀ i, Zero (α i)] :
   toFun f := (f none, comapDomain some (Option.some_injective _) f)
   invFun f := f.2.extendWith f.1
   left_inv f := by
-    ext i; cases' i with i
+    ext i; obtain - | i := i
     · rw [extendWith_none]
     · rw [extendWith_some, comapDomain_apply]
   right_inv x := by

--- a/Mathlib/Data/ENNReal/Inv.lean
+++ b/Mathlib/Data/ENNReal/Inv.lean
@@ -660,7 +660,7 @@ theorem Ioo_zero_top_eq_iUnion_Ico_zpow {y : ℝ≥0∞} (hy : 1 < y) (h'y : y �
 
 @[gcongr]
 theorem zpow_le_of_le {x : ℝ≥0∞} (hx : 1 ≤ x) {a b : ℤ} (h : a ≤ b) : x ^ a ≤ x ^ b := by
-  cases' a with a a <;> cases' b with b b
+  obtain a | a := a <;> obtain b | b := b
   · simp only [Int.ofNat_eq_coe, zpow_natCast]
     exact pow_right_mono₀ hx (Int.le_of_ofNat_le_ofNat h)
   · apply absurd h (not_le_of_gt _)

--- a/Mathlib/Data/Fin/Basic.lean
+++ b/Mathlib/Data/Fin/Basic.lean
@@ -750,7 +750,7 @@ theorem castSucc_pred_eq_pred_castSucc {a : Fin (n + 1)} (ha : a ≠ 0)
 
 theorem castSucc_pred_add_one_eq {a : Fin (n + 1)} (ha : a ≠ 0) :
     (a.pred ha).castSucc + 1 = a := by
-  cases' a using cases with a
+  cases a using cases
   · exact (ha rfl).elim
   · rw [pred_succ, coeSucc_eq_succ]
 
@@ -854,7 +854,7 @@ theorem succ_castPred_eq_castPred_succ {a : Fin (n + 1)} (ha : a ≠ last n)
 
 theorem succ_castPred_eq_add_one {a : Fin (n + 1)} (ha : a ≠ last n) :
     (a.castPred ha).succ = a + 1 := by
-  cases' a using lastCases with a
+  cases a using lastCases
   · exact (ha rfl).elim
   · rw [castPred_castSucc, coeSucc_eq_succ]
 

--- a/Mathlib/Data/Finset/Card.lean
+++ b/Mathlib/Data/Finset/Card.lean
@@ -80,7 +80,7 @@ theorem card_singleton (a : α) : #{a} = 1 :=
   Multiset.card_singleton _
 
 theorem card_singleton_inter [DecidableEq α] : #({a} ∩ s) ≤ 1 := by
-  cases' Finset.decidableMem a s with h h
+  obtain h | h := Finset.decidableMem a s
   · simp [Finset.singleton_inter_of_not_mem h]
   · simp [Finset.singleton_inter_of_mem h]
 

--- a/Mathlib/Data/List/Cycle.lean
+++ b/Mathlib/Data/List/Cycle.lean
@@ -579,7 +579,7 @@ theorem nodup_reverse_iff {s : Cycle α} : s.reverse.Nodup ↔ s.Nodup :=
 
 theorem Subsingleton.nodup {s : Cycle α} (h : Subsingleton s) : Nodup s := by
   induction' s using Quot.inductionOn with l
-  cases' l with hd tl
+  obtain - | ⟨hd, tl⟩ := l
   · simp
   · have : tl = [] := by simpa [Subsingleton, length_eq_zero, Nat.succ_le_succ_iff] using h
     simp [this]

--- a/Mathlib/Data/List/Duplicate.lean
+++ b/Mathlib/Data/List/Duplicate.lean
@@ -44,7 +44,7 @@ theorem Duplicate.mem (h : x ∈+ l) : x ∈ l := by
   | cons_duplicate _ hm => exact mem_cons_of_mem _ hm
 
 theorem Duplicate.mem_cons_self (h : x ∈+ x :: l) : x ∈ l := by
-  cases' h with _ h _ _ h
+  obtain h | h := h
   · exact h
   · exact h.mem
 
@@ -73,7 +73,7 @@ theorem Duplicate.elim_singleton {y : α} (h : x ∈+ [y]) : False :=
 
 theorem duplicate_cons_iff {y : α} : x ∈+ y :: l ↔ y = x ∧ x ∈ l ∨ x ∈+ l := by
   refine ⟨fun h => ?_, fun h => ?_⟩
-  · cases' h with _ hm _ _ hm
+  · obtain hm | hm := h
     · exact Or.inl ⟨rfl, hm⟩
     · exact Or.inr hm
   · rcases h with (⟨rfl | h⟩ | h)

--- a/Mathlib/Data/List/Lex.lean
+++ b/Mathlib/Data/List/Lex.lean
@@ -39,7 +39,7 @@ namespace Lex
 
 theorem cons_iff {r : α → α → Prop} [IsIrrefl α r] {a l₁ l₂} :
     Lex r (a :: l₁) (a :: l₂) ↔ Lex r l₁ l₂ :=
-  ⟨fun h => by cases' h with _ _ _ _ _ h _ _ _ _ h; exacts [h, (irrefl_of r a h).elim], Lex.cons⟩
+  ⟨fun h => by obtain - | h | h := h; exacts [h, (irrefl_of r a h).elim], Lex.cons⟩
 
 @[deprecated (since := "2024-12-21")] alias not_nil_right := not_lex_nil
 

--- a/Mathlib/Data/List/Sublists.lean
+++ b/Mathlib/Data/List/Sublists.lean
@@ -79,9 +79,9 @@ theorem mem_sublists' {s t : List α} : s ∈ sublists' t ↔ s <+ t := by
   · rcases h with (h | ⟨s, h, rfl⟩)
     · exact sublist_cons_of_sublist _ h
     · exact h.cons_cons _
-  · cases' h with _ _ _ h s _ _ h
+  · obtain - | ⟨-, h⟩ | ⟨-, h⟩ := h
     · exact Or.inl h
-    · exact Or.inr ⟨s, h, rfl⟩
+    · exact Or.inr ⟨_, h, rfl⟩
 
 @[simp]
 theorem length_sublists' : ∀ l : List α, length (sublists' l) = 2 ^ length l

--- a/Mathlib/Data/Num/Lemmas.lean
+++ b/Mathlib/Data/Num/Lemmas.lean
@@ -116,7 +116,7 @@ theorem cmp_to_nat_lemma {m n : PosNum} : (m : ℕ) < n → (bit1 m : ℕ) < bit
     intro h; rw [Nat.add_right_comm m m 1, add_assoc]; exact Nat.add_le_add h h
 
 theorem cmp_swap (m) : ∀ n, (cmp m n).swap = cmp n m := by
-  induction' m with m IH m IH <;> intro n <;> cases' n with n n <;> unfold cmp <;>
+  induction' m with m IH m IH <;> intro n <;> obtain - | n | n := n <;> unfold cmp <;>
     try { rfl } <;> rw [← IH] <;> cases cmp m n <;> rfl
 
 theorem cmp_to_nat : ∀ m n, (Ordering.casesOn (cmp m n) ((m : ℕ) < n) (m = n) ((n : ℕ) < m) : Prop)
@@ -761,7 +761,7 @@ theorem castNum_eq_bitwise {f : Num → Num → Num} {g : Bool → Bool → Bool
     (pbb : ∀ a b m n, p (PosNum.bit a m) (PosNum.bit b n) = bit (g a b) (p m n)) :
     ∀ m n : Num, (f m n : ℕ) = Nat.bitwise g m n := by
   intros m n
-  cases' m with m <;> cases' n with n <;>
+  obtain - | m := m <;> obtain - | n := n <;>
       try simp only [show zero = 0 from rfl, show ((0 : Num) : ℕ) = 0 from rfl]
   · rw [f00, Nat.bitwise_zero]; rfl
   · rw [f0n, Nat.bitwise_zero_left]
@@ -771,7 +771,7 @@ theorem castNum_eq_bitwise {f : Num → Num → Num} {g : Bool → Bool → Bool
   · rw [fnn]
     have : ∀ (b) (n : PosNum), (cond b (↑n) 0 : ℕ) = ↑(cond b (pos n) 0 : Num) := by
       intros b _; cases b <;> rfl
-    induction' m with m IH m IH generalizing n <;> cases' n with n n
+    induction' m with m IH m IH generalizing n <;> obtain - | n | n := n
     any_goals simp only [show one = 1 from rfl, show pos 1 = 1 from rfl,
       show PosNum.bit0 = PosNum.bit false from rfl, show PosNum.bit1 = PosNum.bit true from rfl,
       show ((1 : Num) : ℕ) = Nat.bit true 0 from rfl]
@@ -819,13 +819,13 @@ theorem castNum_shiftLeft (m : Num) (n : Nat) : ↑(m <<< n) = (m : ℕ) <<< (n 
 
 @[simp, norm_cast]
 theorem castNum_shiftRight (m : Num) (n : Nat) : ↑(m >>> n) = (m : ℕ) >>> (n : ℕ) := by
-  cases' m with m <;> dsimp only [← shiftr_eq_shiftRight, shiftr]
+  obtain - | m := m <;> dsimp only [← shiftr_eq_shiftRight, shiftr]
   · symm
     apply Nat.zero_shiftRight
   induction' n with n IH generalizing m
   · cases m <;> rfl
   have hdiv2 : ∀ m, Nat.div2 (m + m) = m := by intro; rw [Nat.div2_val]; omega
-  cases' m with m m <;> dsimp only [PosNum.shiftr, ← PosNum.shiftr_eq_shiftRight]
+  obtain - | m | m := m <;> dsimp only [PosNum.shiftr, ← PosNum.shiftr_eq_shiftRight]
   · rw [Nat.shiftRight_eq_div_pow]
     symm
     apply Nat.div_eq_of_lt
@@ -851,7 +851,7 @@ theorem castNum_testBit (m n) : testBit m n = Nat.testBit m n := by
     rw [show (Num.zero : Nat) = 0 from rfl, Nat.zero_testBit]
   | pos m =>
     rw [cast_pos]
-    induction' n with n IH generalizing m <;> cases' m with m m
+    induction' n with n IH generalizing m <;> obtain - | m | m := m
         <;> simp only [PosNum.testBit]
     · rfl
     · rw [PosNum.cast_bit1, ← two_mul, ← congr_fun Nat.bit_true, Nat.testBit_bit_zero]
@@ -955,7 +955,7 @@ theorem cast_bit1 [AddGroupWithOne α] : ∀ n : ZNum, (n.bit1 : α) = ((n : α)
   | pos p => by rw [ZNum.bit1, cast_pos, cast_pos]; rfl
   | neg p => by
     rw [ZNum.bit1, cast_neg, cast_neg]
-    cases' e : pred' p with a <;>
+    rcases e : pred' p with - | a <;>
       have ep : p = _ := (succ'_pred' p).symm.trans (congr_arg Num.succ' e)
     · conv at ep => change p = 1
       subst p

--- a/Mathlib/Data/Num/Prime.lean
+++ b/Mathlib/Data/Num/Prime.lean
@@ -57,7 +57,7 @@ def minFac : PosNum → PosNum
 
 @[simp]
 theorem minFac_to_nat (n : PosNum) : (minFac n : ℕ) = Nat.minFac n := by
-  cases' n with n
+  obtain - | n := n
   · rfl
   · rw [minFac, Nat.minFac_eq, if_neg]
     swap

--- a/Mathlib/Data/Sym/Sym2.lean
+++ b/Mathlib/Data/Sym/Sym2.lean
@@ -640,7 +640,7 @@ def sym2EquivSym' : Equiv (Sym2 α) (Sym' α 2) where
   right_inv x := by
     refine x.recOnSubsingleton fun x => ?_
     obtain ⟨x, hx⟩ := x
-    cases' x with _ x
+    obtain - | ⟨-, x⟩ := x
     · simp at hx
     rcases x with - | ⟨_, x⟩
     · simp at hx

--- a/Mathlib/Geometry/Manifold/ContMDiff/Defs.lean
+++ b/Mathlib/Geometry/Manifold/ContMDiff/Defs.lean
@@ -615,7 +615,7 @@ theorem contMDiff_infty : ContMDiff I I' ∞ f ↔ ∀ n : ℕ, ContMDiff I I' n
 theorem contMDiffWithinAt_iff_nat {n : ℕ∞} :
     ContMDiffWithinAt I I' n f s x ↔ ∀ m : ℕ, (m : ℕ∞) ≤ n → ContMDiffWithinAt I I' m f s x := by
   refine ⟨fun h m hm => h.of_le (mod_cast hm), fun h => ?_⟩
-  cases' n with n
+  obtain - | n := n
   · exact contMDiffWithinAt_infty.2 fun n => h n le_top
   · exact h n le_rfl
 

--- a/Mathlib/GroupTheory/OrderOfElement.lean
+++ b/Mathlib/GroupTheory/OrderOfElement.lean
@@ -875,7 +875,7 @@ theorem orderOf_dvd_card : orderOf x ∣ Fintype.card G := by
 
 @[to_additive]
 theorem orderOf_dvd_natCard {G : Type*} [Group G] (x : G) : orderOf x ∣ Nat.card G := by
-  cases' fintypeOrInfinite G with h h
+  obtain h | h := fintypeOrInfinite G
   · simp only [Nat.card_eq_fintype_card, orderOf_dvd_card]
   · simp only [card_eq_zero_of_infinite, dvd_zero]
 

--- a/Mathlib/GroupTheory/Perm/Option.lean
+++ b/Mathlib/GroupTheory/Perm/Option.lean
@@ -40,7 +40,7 @@ theorem map_equiv_removeNone {α : Type*} [DecidableEq α] (σ : Perm (Option α
     (removeNone σ).optionCongr = swap none (σ none) * σ := by
   ext1 x
   have : Option.map (⇑(removeNone σ)) x = (swap none (σ none)) (σ x) := by
-    cases' x with x
+    obtain - | x := x
     · simp
     · cases h : σ (some _)
       · simp [removeNone_none _ h]

--- a/Mathlib/Logic/Denumerable.lean
+++ b/Mathlib/Logic/Denumerable.lean
@@ -238,13 +238,15 @@ theorem ofNat_surjective : Surjective (ofNat s)
         (by intros a ha; simpa using (List.mem_filter.mp ha).2) with ht
     have hmt : ∀ {y : s}, y ∈ t ↔ y < ⟨x, hx⟩ := by
       simp [List.mem_filter, Subtype.ext_iff_val, ht]
-    cases' hmax : List.maximum t with m
-    · refine ⟨0, le_antisymm bot_le (le_of_not_gt fun h => List.not_mem_nil (⊥ : s) ?_)⟩
+    cases hmax : List.maximum t with
+    | bot =>
+      refine ⟨0, le_antisymm bot_le (le_of_not_gt fun h => List.not_mem_nil (⊥ : s) ?_)⟩
       rwa [← List.maximum_eq_bot.1 hmax, hmt]
-    have wf : ↑m < x := by simpa using hmt.mp (List.maximum_mem hmax)
-    rcases ofNat_surjective m with ⟨a, rfl⟩
-    refine ⟨a + 1, le_antisymm (succ_le_of_lt wf) ?_⟩
-    exact le_succ_of_forall_lt_le fun z hz => List.le_maximum_of_mem (hmt.2 hz) hmax
+    | coe m =>
+      have wf : ↑m < x := by simpa using hmt.mp (List.maximum_mem hmax)
+      rcases ofNat_surjective m with ⟨a, rfl⟩
+      refine ⟨a + 1, le_antisymm (succ_le_of_lt wf) ?_⟩
+      exact le_succ_of_forall_lt_le fun z hz => List.le_maximum_of_mem (hmt.2 hz) hmax
   termination_by n => n.val
 
 @[simp]

--- a/Mathlib/Order/Chain.lean
+++ b/Mathlib/Order/Chain.lean
@@ -228,7 +228,7 @@ private theorem chainClosure_succ_total_aux (hc₁ : ChainClosure r c₁)
     SuccChain r c₂ ⊆ c₁ ∨ c₁ ⊆ c₂ := by
   induction hc₁ with
   | @succ c₃ hc₃ ih =>
-    cases' ih with ih ih
+    obtain ih | ih := ih
     · exact Or.inl (ih.trans subset_succChain)
     · exact (h hc₃ ih).imp_left fun (h : c₂ = c₃) => h ▸ Subset.rfl
   | union _ ih =>

--- a/Mathlib/Order/ConditionallyCompleteLattice/Basic.lean
+++ b/Mathlib/Order/ConditionallyCompleteLattice/Basic.lean
@@ -934,7 +934,7 @@ noncomputable instance WithTop.WithBot.completeLattice {α : Type*}
       show ite _ _ _ ≤ a by
         simp only [OrderBot.bddBelow, not_true_eq_false, or_false]
         split_ifs with h₁
-        · cases' a with a
+        · cases a
           · exact le_rfl
           cases h₁ haS
         · cases a

--- a/Mathlib/Order/SuccPred/Basic.lean
+++ b/Mathlib/Order/SuccPred/Basic.lean
@@ -1000,7 +1000,7 @@ instance : SuccOrder (WithTop α) where
     | ⊤ => ⊤
     | Option.some a => ite (succ a = a) ⊤ (some (succ a))
   le_succ a := by
-    cases' a with a a
+    obtain - | a := a
     · exact le_top
     change _ ≤ ite _ _ _
     split_ifs
@@ -1085,9 +1085,10 @@ variable [Preorder α] [NoMaxOrder α]
 instance [hα : Nonempty α] : IsEmpty (PredOrder (WithTop α)) :=
   ⟨by
     intro
-    cases' h : pred (⊤ : WithTop α) with a ha
-    · exact hα.elim fun a => (min_of_le_pred h.ge).not_lt <| coe_lt_top a
-    · obtain ⟨c, hc⟩ := exists_gt a
+    cases h : pred (⊤ : WithTop α) with
+    | top => exact hα.elim fun a => (min_of_le_pred h.ge).not_lt <| coe_lt_top a
+    | coe a =>
+      obtain ⟨c, hc⟩ := exists_gt a
       rw [← coe_lt_coe, ← h] at hc
       exact (le_pred_of_lt (coe_lt_top c)).not_lt hc⟩
 
@@ -1148,20 +1149,21 @@ instance : PredOrder (WithBot α) where
     | ⊥ => ⊥
     | Option.some a => ite (pred a = a) ⊥ (some (pred a))
   pred_le a := by
-    cases' a with a a
+    obtain - | a := a
     · exact bot_le
     change ite _ _ _ ≤ _
     split_ifs
     · exact bot_le
     · exact coe_le_coe.2 (pred_le a)
   min_of_le_pred {a} ha := by
-    cases' a with a a
-    · exact isMin_bot
-    dsimp only at ha
-    split_ifs at ha with ha'
-    · exact (not_coe_le_bot _ ha).elim
-    · rw [coe_le_coe, le_pred_iff_isMin, ← pred_eq_iff_isMin] at ha
-      exact (ha' ha).elim
+    cases a with
+    | bot => exact isMin_bot
+    | coe a =>
+      dsimp only at ha
+      split_ifs at ha with ha'
+      · exact (not_coe_le_bot _ ha).elim
+      · rw [coe_le_coe, le_pred_iff_isMin, ← pred_eq_iff_isMin] at ha
+        exact (ha' ha).elim
   le_pred_of_lt {a b} h := by
     cases a
     · exact bot_le
@@ -1195,9 +1197,10 @@ variable [Preorder α] [NoMinOrder α]
 instance [hα : Nonempty α] : IsEmpty (SuccOrder (WithBot α)) :=
   ⟨by
     intro
-    cases' h : succ (⊥ : WithBot α) with a ha
-    · exact hα.elim fun a => (max_of_succ_le h.le).not_lt <| bot_lt_coe a
-    · obtain ⟨c, hc⟩ := exists_lt a
+    cases h : succ (⊥ : WithBot α) with
+    | bot => exact hα.elim fun a => (max_of_succ_le h.le).not_lt <| bot_lt_coe a
+    | coe a =>
+      obtain ⟨c, hc⟩ := exists_lt a
       rw [← coe_lt_coe, ← h] at hc
       exact (succ_le_of_lt (bot_lt_coe _)).not_lt hc⟩
 

--- a/Mathlib/SetTheory/Ordinal/Arithmetic.lean
+++ b/Mathlib/SetTheory/Ordinal/Arithmetic.lean
@@ -697,7 +697,7 @@ instance mulLeftMono : MulLeftMono Ordinal.{u} :=
     Quotient.inductionOn₃ a b c fun ⟨α, r, _⟩ ⟨β, s, _⟩ ⟨γ, t, _⟩ ⟨f⟩ => by
       refine
         (RelEmbedding.ofMonotone (fun a : α × γ => (f a.1, a.2)) fun a b h => ?_).ordinal_type_le
-      cases' h with a₁ b₁ a₂ b₂ h' a b₁ b₂ h'
+      obtain ⟨-, -, h'⟩ | ⟨-, h'⟩ := h
       · exact Prod.Lex.left _ _ (f.toRelEmbedding.map_rel_iff.2 h')
       · exact Prod.Lex.right _ h'⟩
 
@@ -706,7 +706,7 @@ instance mulRightMono : MulRightMono Ordinal.{u} :=
     Quotient.inductionOn₃ a b c fun ⟨α, r, _⟩ ⟨β, s, _⟩ ⟨γ, t, _⟩ ⟨f⟩ => by
       refine
         (RelEmbedding.ofMonotone (fun a : γ × α => (a.1, f a.2)) fun a b h => ?_).ordinal_type_le
-      cases' h with a₁ b₁ a₂ b₂ h' a b₁ b₂ h'
+      obtain ⟨-, -, h'⟩ | ⟨-, h'⟩ := h
       · exact Prod.Lex.left _ _ h'
       · exact Prod.Lex.right _ (f.toRelEmbedding.map_rel_iff.2 h')⟩
 
@@ -734,11 +734,11 @@ private theorem mul_le_of_limit_aux {α β r s} [IsWellOrder α r] [IsWellOrder 
     by_cases e : b = b'
     · refine Sum.inr ⟨a', ?_⟩
       subst e
-      cases' h with _ _ _ _ h _ _ _ h
+      obtain ⟨-, -, h⟩ | ⟨-, h⟩ := h
       · exact (irrefl _ h).elim
       · exact h
     · refine Sum.inl (⟨b', ?_⟩, a')
-      cases' h with _ _ _ _ h _ _ _ h
+      obtain ⟨-, -, h⟩ | ⟨e, h⟩ := h
       · exact h
       · exact (e rfl).elim
   · rcases a with ⟨⟨b₁, a₁⟩, h₁⟩
@@ -751,7 +751,7 @@ private theorem mul_le_of_limit_aux {α β r s} [IsWellOrder α r] [IsWellOrder 
     · subst b₁
       simp only [subrel_val, Prod.lex_def, e₂, Prod.lex_def, dif_pos, subrel_val, eq_self_iff_true,
         or_false, dif_neg, not_false_iff, Sum.lex_inr_inl, false_and] at h ⊢
-      cases' h₂ with _ _ _ _ h₂_h h₂_h <;> [exact asymm h h₂_h; exact e₂ rfl]
+      obtain ⟨-, -, h₂_h⟩ | e₂ := h₂ <;> [exact asymm h h₂_h; exact e₂ rfl]
     · simp [e₂, dif_neg e₁, show b₂ ≠ b₁ from e₂ ▸ e₁]
     · simpa only [dif_neg e₁, dif_neg e₂, Prod.lex_def, subrel_val, Subtype.mk_eq_mk,
         Sum.lex_inl_inl] using h
@@ -1505,12 +1505,7 @@ private theorem sup_le_sup {ι ι' : Type u} (r : ι → ι → Prop) (r' : ι' 
     (f : ∀ a < o, Ordinal.{max u v}) :
     sup.{_, v} (familyOfBFamily' r ho f) ≤ sup.{_, v} (familyOfBFamily' r' ho' f) :=
   sup_le fun i => by
-    cases'
-      typein_surj r'
-        (by
-          rw [ho', ← ho]
-          exact typein_lt_type r i) with
-      j hj
+    obtain ⟨j, hj⟩ := typein_surj r' (by rw [ho', ← ho]; exact typein_lt_type r i)
     simp_rw [familyOfBFamily', ← hj]
     apply le_sup
 


### PR DESCRIPTION
Files to deprime were obtained from [this run](https://github.com/leanprover-community/mathlib4/actions/runs/13409529665/job/37456254391). I started from `Data.Num.Prime` and worked upwards, skipping `Data.Seq.Seq` due to its large number of `cases'`.