### PR TITLE
[Merged by Bors] - fix: add missing withMainContext for hint

### DIFF
--- a/Mathlib/Tactic/Hint.lean
+++ b/Mathlib/Tactic/Hint.lean
@@ -100,7 +100,7 @@ If one tactic succeeds and closes the goal, we don't look at subsequent tactics.
 -- TODO We could run the tactics in parallel.
 -- TODO With widget support, could we run the tactics in parallel
 --      and do live updates of the widget as results come in?
-def hint (stx : Syntax) : TacticM Unit := do
+def hint (stx : Syntax) : TacticM Unit := withMainContext do
   let tacs := Nondet.ofList (← getHints)
   let results := tacs.filterMapM fun t : TSyntax `tactic => do
     if let some msgs ← observing? (withMessageLog (withoutInfoTrees (evalTactic t))) then


### PR DESCRIPTION
I’d love to add a test but I don’t know how to test what the suggestion widget shows. A simple test case is

```
example (P : Nat → Prop) : ∀ n, P n := by
  hint
```

which shows a `_fvar` on master.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
