### PR TITLE
[Merged by Bors] - feat(Data/List): `List.maximum` is monotone

### DIFF
--- a/Mathlib/Data/List/MinMax.lean
+++ b/Mathlib/Data/List/MinMax.lean
@@ -352,13 +352,8 @@ theorem le_minimum_of_forall_le {b : WithTop α} (h : ∀ a ∈ l, b ≤ a) : b 
     simp only [minimum_cons, le_min_iff]
     exact ⟨h a (by simp), ih fun a w => h a (mem_cons.mpr (Or.inr w))⟩
 
-theorem maximum_mono {l₁ l₂ : List α} (h : l₁ ⊆ l₂) : l₁.maximum ≤ l₂.maximum := by
-  induction l₁ with
-  | nil => exact inf_eq_left.mp rfl
-  | cons _ _ ih =>
-    rw [List.cons_subset] at h
-    rw [List.maximum_cons]
-    exact max_le (List.le_maximum_of_mem' h.1) (ih h.2)
+theorem maximum_mono {l₁ l₂ : List α} (h : l₁ ⊆ l₂) : l₁.maximum ≤ l₂.maximum :=
+  maximum_le_of_forall_le fun _ ↦ (le_maximum_of_mem' <| h ·)
 
 theorem minimum_anti {l₁ l₂ : List α} (h : l₁ ⊆ l₂) : l₂.minimum ≤ l₁.minimum :=
   @maximum_mono αᵒᵈ _ _ _ h

--- a/Mathlib/Data/List/MinMax.lean
+++ b/Mathlib/Data/List/MinMax.lean
@@ -352,6 +352,19 @@ theorem le_minimum_of_forall_le {b : WithTop α} (h : ∀ a ∈ l, b ≤ a) : b 
     simp only [minimum_cons, le_min_iff]
     exact ⟨h a (by simp), ih fun a w => h a (mem_cons.mpr (Or.inr w))⟩
 
+theorem maximum_mono {l₁ l₂ : List α} (h : l₁ ⊆ l₂) :
+    l₁.maximum ≤ l₂.maximum := by
+  induction l₁ with
+  | nil => exact inf_eq_left.mp rfl
+  | cons _ _ ih =>
+    rw [List.cons_subset] at h
+    rw [List.maximum_cons]
+    exact max_le (List.le_maximum_of_mem' h.1) (ih h.2)
+
+theorem minimum_anti {l₁ l₂ : List α} (h : l₁ ⊆ l₂) :
+    l₂.minimum ≤ l₁.minimum :=
+  @maximum_mono αᵒᵈ _ _ _ h
+
 theorem maximum_eq_coe_iff : maximum l = m ↔ m ∈ l ∧ ∀ a ∈ l, a ≤ m := by
   rw [maximum, ← WithBot.some_eq_coe, argmax_eq_some_iff]
   simp only [id_eq, and_congr_right_iff, and_iff_left_iff_imp]

--- a/Mathlib/Data/List/MinMax.lean
+++ b/Mathlib/Data/List/MinMax.lean
@@ -352,8 +352,7 @@ theorem le_minimum_of_forall_le {b : WithTop α} (h : ∀ a ∈ l, b ≤ a) : b 
     simp only [minimum_cons, le_min_iff]
     exact ⟨h a (by simp), ih fun a w => h a (mem_cons.mpr (Or.inr w))⟩
 
-theorem maximum_mono {l₁ l₂ : List α} (h : l₁ ⊆ l₂) :
-    l₁.maximum ≤ l₂.maximum := by
+theorem maximum_mono {l₁ l₂ : List α} (h : l₁ ⊆ l₂) : l₁.maximum ≤ l₂.maximum := by
   induction l₁ with
   | nil => exact inf_eq_left.mp rfl
   | cons _ _ ih =>
@@ -361,8 +360,7 @@ theorem maximum_mono {l₁ l₂ : List α} (h : l₁ ⊆ l₂) :
     rw [List.maximum_cons]
     exact max_le (List.le_maximum_of_mem' h.1) (ih h.2)
 
-theorem minimum_anti {l₁ l₂ : List α} (h : l₁ ⊆ l₂) :
-    l₂.minimum ≤ l₁.minimum :=
+theorem minimum_anti {l₁ l₂ : List α} (h : l₁ ⊆ l₂) : l₂.minimum ≤ l₁.minimum :=
   @maximum_mono αᵒᵈ _ _ _ h
 
 theorem maximum_eq_coe_iff : maximum l = m ↔ m ∈ l ∧ ∀ a ∈ l, a ≤ m := by


### PR DESCRIPTION
also proves the `List.minimum` counterpart

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
