### PR TITLE
perf: lower gcongr priority in group mono lemmas

### DIFF
--- a/Mathlib/Algebra/Order/Monoid/Unbundled/Basic.lean
+++ b/Mathlib/Algebra/Order/Monoid/Unbundled/Basic.lean
@@ -60,7 +60,7 @@ variable [LE α]
 /- The prime on this lemma is present only on the multiplicative version. The unprimed version
 is taken by the analogous lemma for semiring, with an extra non-negativity assumption.
 We also lower the `gcongr` priority, so that the semiring-version is used more eagerly by `gcongr`.
-(The priority on the additive version doesn't matter) -/
+(The priority on the additive version doesn't matter.) -/
 @[to_additive (attr := gcongr 500) add_le_add_left]
 theorem mul_le_mul_left' [MulLeftMono α] {b c : α} (bc : b ≤ c) (a : α) :
     a * b ≤ a * c :=
@@ -73,7 +73,9 @@ theorem le_of_mul_le_mul_left' [MulLeftReflectLE α] {a b c : α}
   ContravariantClass.elim _ bc
 
 /- The prime on this lemma is present only on the multiplicative version.  The unprimed version
-is taken by the analogous lemma for semiring, with an extra non-negativity assumption. -/
+is taken by the analogous lemma for semiring, with an extra non-negativity assumption.
+We also lower the `gcongr` priority, so that the semiring-version is used more eagerly by `gcongr`.
+(The priority on the additive version doesn't matter.) -/
 @[to_additive (attr := gcongr 500) add_le_add_right]
 theorem mul_le_mul_right' [i : MulRightMono α] {b c : α} (bc : b ≤ c)
     (a : α) :

--- a/Mathlib/Algebra/Order/Monoid/Unbundled/Basic.lean
+++ b/Mathlib/Algebra/Order/Monoid/Unbundled/Basic.lean
@@ -58,11 +58,14 @@ section LE
 variable [LE α]
 
 /- The prime on this lemma is present only on the multiplicative version.  The unprimed version
-is taken by the analogous lemma for semiring, with an extra non-negativity assumption. -/
-@[to_additive (attr := gcongr) add_le_add_left]
+is taken by the analogous lemma for semiring, with an extra non-negativity assumption.
+We also lower the `gcongr` priority for the multiplicative version. -/
+@[to_additive add_le_add_left, gcongr 100]
 theorem mul_le_mul_left' [MulLeftMono α] {b c : α} (bc : b ≤ c) (a : α) :
     a * b ≤ a * c :=
   CovariantClass.elim _ bc
+
+attribute [gcongr] add_le_add_left
 
 @[to_additive le_of_add_le_add_left]
 theorem le_of_mul_le_mul_left' [MulLeftReflectLE α] {a b c : α}
@@ -71,12 +74,15 @@ theorem le_of_mul_le_mul_left' [MulLeftReflectLE α] {a b c : α}
   ContravariantClass.elim _ bc
 
 /- The prime on this lemma is present only on the multiplicative version.  The unprimed version
-is taken by the analogous lemma for semiring, with an extra non-negativity assumption. -/
-@[to_additive (attr := gcongr) add_le_add_right]
+is taken by the analogous lemma for semiring, with an extra non-negativity assumption.
+We also lower the `gcongr` priority for the multiplicative version. -/
+@[to_additive add_le_add_right, gcongr 100]
 theorem mul_le_mul_right' [i : MulRightMono α] {b c : α} (bc : b ≤ c)
     (a : α) :
     b * a ≤ c * a :=
   i.elim a bc
+
+attribute [gcongr] add_le_add_right
 
 @[to_additive le_of_add_le_add_right]
 theorem le_of_mul_le_mul_right' [i : MulRightReflectLE α] {a b c : α}
@@ -114,10 +120,12 @@ theorem mul_lt_mul_iff_right [MulRightStrictMono α]
     b * a < c * a ↔ b < c :=
   rel_iff_cov α α (swap (· * ·)) (· < ·) a
 
-@[to_additive (attr := gcongr) add_lt_add_left]
+@[to_additive add_lt_add_left, gcongr 100]
 theorem mul_lt_mul_left' [MulLeftStrictMono α] {b c : α} (bc : b < c) (a : α) :
     a * b < a * c :=
   CovariantClass.elim _ bc
+
+attribute [gcongr] add_lt_add_left
 
 @[to_additive lt_of_add_lt_add_left]
 theorem lt_of_mul_lt_mul_left' [MulLeftReflectLT α] {a b c : α}
@@ -125,11 +133,13 @@ theorem lt_of_mul_lt_mul_left' [MulLeftReflectLT α] {a b c : α}
     b < c :=
   ContravariantClass.elim _ bc
 
-@[to_additive (attr := gcongr) add_lt_add_right]
+@[to_additive add_lt_add_right, gcongr 100]
 theorem mul_lt_mul_right' [i : MulRightStrictMono α] {b c : α} (bc : b < c)
     (a : α) :
     b * a < c * a :=
   i.elim a bc
+
+attribute [gcongr] add_lt_add_right
 
 @[to_additive lt_of_add_lt_add_right]
 theorem lt_of_mul_lt_mul_right' [i : MulRightReflectLT α] {a b c : α}
@@ -159,7 +169,7 @@ lemma mul_left_strictMono [MulLeftStrictMono α] {a : α} : StrictMono (a * ·) 
 lemma mul_right_strictMono [MulRightStrictMono α] {a : α} : StrictMono (· * a) :=
   fun _ _ h ↦ mul_lt_mul_right' h _
 
-@[to_additive (attr := gcongr)]
+@[to_additive, gcongr 100]
 theorem mul_lt_mul_of_lt_of_lt [MulLeftStrictMono α]
     [MulRightStrictMono α]
     {a b c d : α} (h₁ : a < b) (h₂ : c < d) : a * c < b * d :=
@@ -167,6 +177,7 @@ theorem mul_lt_mul_of_lt_of_lt [MulLeftStrictMono α]
     a * c < a * d := mul_lt_mul_left' h₂ a
     _ < b * d := mul_lt_mul_right' h₁ d
 
+attribute [gcongr] add_lt_add_of_lt_of_lt
 alias add_lt_add := add_lt_add_of_lt_of_lt
 
 @[to_additive]
@@ -196,11 +207,13 @@ theorem Right.mul_lt_mul [MulLeftMono α]
     a * c < b * d :=
   mul_lt_mul_of_lt_of_le h₁ h₂.le
 
-@[to_additive (attr := gcongr) add_le_add]
+@[to_additive add_le_add, gcongr 100]
 theorem mul_le_mul' [MulLeftMono α] [MulRightMono α]
     {a b c d : α} (h₁ : a ≤ b) (h₂ : c ≤ d) :
     a * c ≤ b * d :=
   (mul_le_mul_left' h₂ _).trans (mul_le_mul_right' h₁ d)
+
+attribute [gcongr] add_le_add
 
 @[to_additive]
 theorem mul_le_mul_three [MulLeftMono α]

--- a/Mathlib/Algebra/Order/Monoid/Unbundled/Basic.lean
+++ b/Mathlib/Algebra/Order/Monoid/Unbundled/Basic.lean
@@ -57,15 +57,14 @@ section LE
 
 variable [LE α]
 
-/- The prime on this lemma is present only on the multiplicative version.  The unprimed version
+/- The prime on this lemma is present only on the multiplicative version. The unprimed version
 is taken by the analogous lemma for semiring, with an extra non-negativity assumption.
-We also lower the `gcongr` priority for the multiplicative version. -/
-@[to_additive add_le_add_left, gcongr 100]
+We also lower the `gcongr` priority, so that the semiring-version is used more eagerly by `gcongr`.
+(The priority on the additive version doesn't matter) -/
+@[to_additive (attr := gcongr 500) add_le_add_left]
 theorem mul_le_mul_left' [MulLeftMono α] {b c : α} (bc : b ≤ c) (a : α) :
     a * b ≤ a * c :=
   CovariantClass.elim _ bc
-
-attribute [gcongr] add_le_add_left
 
 @[to_additive le_of_add_le_add_left]
 theorem le_of_mul_le_mul_left' [MulLeftReflectLE α] {a b c : α}
@@ -74,15 +73,12 @@ theorem le_of_mul_le_mul_left' [MulLeftReflectLE α] {a b c : α}
   ContravariantClass.elim _ bc
 
 /- The prime on this lemma is present only on the multiplicative version.  The unprimed version
-is taken by the analogous lemma for semiring, with an extra non-negativity assumption.
-We also lower the `gcongr` priority for the multiplicative version. -/
-@[to_additive add_le_add_right, gcongr 100]
+is taken by the analogous lemma for semiring, with an extra non-negativity assumption. -/
+@[to_additive (attr := gcongr 500) add_le_add_right]
 theorem mul_le_mul_right' [i : MulRightMono α] {b c : α} (bc : b ≤ c)
     (a : α) :
     b * a ≤ c * a :=
   i.elim a bc
-
-attribute [gcongr] add_le_add_right
 
 @[to_additive le_of_add_le_add_right]
 theorem le_of_mul_le_mul_right' [i : MulRightReflectLE α] {a b c : α}
@@ -120,12 +116,10 @@ theorem mul_lt_mul_iff_right [MulRightStrictMono α]
     b * a < c * a ↔ b < c :=
   rel_iff_cov α α (swap (· * ·)) (· < ·) a
 
-@[to_additive add_lt_add_left, gcongr 100]
+@[to_additive (attr := gcongr 500) add_lt_add_left]
 theorem mul_lt_mul_left' [MulLeftStrictMono α] {b c : α} (bc : b < c) (a : α) :
     a * b < a * c :=
   CovariantClass.elim _ bc
-
-attribute [gcongr] add_lt_add_left
 
 @[to_additive lt_of_add_lt_add_left]
 theorem lt_of_mul_lt_mul_left' [MulLeftReflectLT α] {a b c : α}
@@ -133,13 +127,11 @@ theorem lt_of_mul_lt_mul_left' [MulLeftReflectLT α] {a b c : α}
     b < c :=
   ContravariantClass.elim _ bc
 
-@[to_additive add_lt_add_right, gcongr 100]
+@[to_additive (attr := gcongr 500) add_lt_add_right]
 theorem mul_lt_mul_right' [i : MulRightStrictMono α] {b c : α} (bc : b < c)
     (a : α) :
     b * a < c * a :=
   i.elim a bc
-
-attribute [gcongr] add_lt_add_right
 
 @[to_additive lt_of_add_lt_add_right]
 theorem lt_of_mul_lt_mul_right' [i : MulRightReflectLT α] {a b c : α}
@@ -169,7 +161,7 @@ lemma mul_left_strictMono [MulLeftStrictMono α] {a : α} : StrictMono (a * ·) 
 lemma mul_right_strictMono [MulRightStrictMono α] {a : α} : StrictMono (· * a) :=
   fun _ _ h ↦ mul_lt_mul_right' h _
 
-@[to_additive, gcongr 100]
+@[to_additive (attr := gcongr 500)]
 theorem mul_lt_mul_of_lt_of_lt [MulLeftStrictMono α]
     [MulRightStrictMono α]
     {a b c d : α} (h₁ : a < b) (h₂ : c < d) : a * c < b * d :=
@@ -177,7 +169,6 @@ theorem mul_lt_mul_of_lt_of_lt [MulLeftStrictMono α]
     a * c < a * d := mul_lt_mul_left' h₂ a
     _ < b * d := mul_lt_mul_right' h₁ d
 
-attribute [gcongr] add_lt_add_of_lt_of_lt
 alias add_lt_add := add_lt_add_of_lt_of_lt
 
 @[to_additive]
@@ -207,13 +198,11 @@ theorem Right.mul_lt_mul [MulLeftMono α]
     a * c < b * d :=
   mul_lt_mul_of_lt_of_le h₁ h₂.le
 
-@[to_additive add_le_add, gcongr 100]
+@[to_additive (attr := gcongr 500) add_le_add]
 theorem mul_le_mul' [MulLeftMono α] [MulRightMono α]
     {a b c d : α} (h₁ : a ≤ b) (h₂ : c ≤ d) :
     a * c ≤ b * d :=
   (mul_le_mul_left' h₂ _).trans (mul_le_mul_right' h₁ d)
-
-attribute [gcongr] add_le_add
 
 @[to_additive]
 theorem mul_le_mul_three [MulLeftMono α]


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
