### PR TITLE
[Merged by Bors] - feat(Set): aliases for disjoint dot notation

### DIFF
--- a/Mathlib/Data/Finset/Disjoint.lean
+++ b/Mathlib/Data/Finset/Disjoint.lean
@@ -52,7 +52,7 @@ alias ⟨_root_.Disjoint.not_mem_of_mem_left_finset, _⟩ := disjoint_left
 theorem disjoint_right : Disjoint s t ↔ ∀ ⦃a⦄, a ∈ t → a ∉ s := by
   rw [_root_.disjoint_comm, disjoint_left]
 
-alias ⟨_root_.Disjoint.not_mem_of_mem_right_finset, _⟩ := disjoint_left
+alias ⟨_root_.Disjoint.not_mem_of_mem_right_finset, _⟩ := disjoint_right
 
 theorem disjoint_iff_ne : Disjoint s t ↔ ∀ a ∈ s, ∀ b ∈ t, a ≠ b := by
   simp only [disjoint_left, imp_not_comm, forall_eq']

--- a/Mathlib/Data/Finset/Disjoint.lean
+++ b/Mathlib/Data/Finset/Disjoint.lean
@@ -47,8 +47,12 @@ theorem disjoint_left : Disjoint s t ↔ ∀ ⦃a⦄, a ∈ s → a ∉ t :=
     singleton_subset_iff.mp (h (singleton_subset_iff.mpr hs) (singleton_subset_iff.mpr ht)),
     fun h _ hs ht _ ha => (h (hs ha) (ht ha)).elim⟩
 
+alias ⟨_root_.Disjoint.not_mem_of_mem_left_finset, _⟩ := disjoint_left
+
 theorem disjoint_right : Disjoint s t ↔ ∀ ⦃a⦄, a ∈ t → a ∉ s := by
   rw [_root_.disjoint_comm, disjoint_left]
+
+alias ⟨_root_.Disjoint.not_mem_of_mem_right_finset, _⟩ := disjoint_left
 
 theorem disjoint_iff_ne : Disjoint s t ↔ ∀ a ∈ s, ∀ b ∈ t, a ≠ b := by
   simp only [disjoint_left, imp_not_comm, forall_eq']

--- a/Mathlib/Data/Multiset/Basic.lean
+++ b/Mathlib/Data/Multiset/Basic.lean
@@ -2512,6 +2512,8 @@ theorem disjoint_left {s t : Multiset α} : Disjoint s t ↔ ∀ {a}, a ∈ s �
   · rw [le_bot_iff, bot_eq_zero, eq_zero_iff_forall_not_mem]
     exact fun a ha ↦ h (subset_of_le hs ha) (subset_of_le ht ha)
 
+alias ⟨_root_.Disjoint.not_mem_of_mem_left_multiset, _⟩ := disjoint_left
+
 @[simp, norm_cast]
 theorem coe_disjoint (l₁ l₂ : List α) : Disjoint (l₁ : Multiset α) l₂ ↔ l₁.Disjoint l₂ :=
   disjoint_left
@@ -2521,6 +2523,8 @@ theorem coe_disjoint (l₁ l₂ : List α) : Disjoint (l₁ : Multiset α) l₂ 
 
 theorem disjoint_right {s t : Multiset α} : Disjoint s t ↔ ∀ {a}, a ∈ t → a ∉ s :=
   disjoint_comm.trans disjoint_left
+
+alias ⟨_root_.Disjoint.not_mem_of_mem_right_multiset, _⟩ := disjoint_right
 
 theorem disjoint_iff_ne {s t : Multiset α} : Disjoint s t ↔ ∀ a ∈ s, ∀ b ∈ t, a ≠ b := by
   simp [disjoint_left, imp_not_comm]

--- a/Mathlib/Data/Set/Basic.lean
+++ b/Mathlib/Data/Set/Basic.lean
@@ -949,7 +949,11 @@ theorem _root_.Disjoint.inter_eq : Disjoint s t → s ∩ t = ∅ :=
 theorem disjoint_left : Disjoint s t ↔ ∀ ⦃a⦄, a ∈ s → a ∉ t :=
   disjoint_iff_inf_le.trans <| forall_congr' fun _ => not_and
 
+alias ⟨_root_.Disjoint.not_mem_of_mem_left, _⟩ := disjoint_left
+
 theorem disjoint_right : Disjoint s t ↔ ∀ ⦃a⦄, a ∈ t → a ∉ s := by rw [disjoint_comm, disjoint_left]
+
+alias ⟨_root_.Disjoint.not_mem_of_mem_right, _⟩ := disjoint_right
 
 lemma not_disjoint_iff : ¬Disjoint s t ↔ ∃ x, x ∈ s ∧ x ∈ t :=
   Set.disjoint_iff.not.trans <| not_forall.trans <| exists_congr fun _ ↦ not_not


### PR DESCRIPTION
We add one-way aliases for `disjoint_left` and `disjoint_right`  so for `h : Disjoint s t` and `hx : x ∈ s`, one can write `h.not_mem_of_mem_left hx` to prove `x ∉ t`. 

We also do the same for finsets and multisets. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
