### PR TITLE
[Merged by Bors] - feat(CategoryTheory/MorphismProperty): more basic API

### DIFF
--- a/Mathlib/CategoryTheory/MorphismProperty/Limits.lean
+++ b/Mathlib/CategoryTheory/MorphismProperty/Limits.lean
@@ -88,6 +88,16 @@ instance : P.pullbacks.RespectsIso :=
     exact ⟨X, Y, p, e.inv.left ≫ f, e.inv.right ≫ g, hp,
       IsPullback.paste_horiz (IsPullback.of_horiz_isIso ⟨e.inv.w⟩) h⟩)
 
+/-- If `P : MorphismPropety C` is such that any object in `C` maps to the
+target of some morphism in `P`, then `P.pushouts` contains the isomorphisms. -/
+lemma isomorphisms_le_pushouts
+    (h : ∀ (X : C), ∃ (A B : C) (p : A ⟶ B) (_ : P p) (_ : B ⟶ X), IsIso p) :
+    isomorphisms C ≤ P.pushouts := by
+  intro X Y f (_ : IsIso f)
+  obtain ⟨A, B, p, hp, g, _⟩ := h X
+  exact ⟨A, B, p, p ≫ g, g ≫ f, hp, (IsPushout.of_id_snd (f := p ≫ g)).of_iso
+    (Iso.refl _) (Iso.refl _) (asIso p) (asIso f) (by simp) (by simp) (by simp) (by simp)⟩
+
 /-- A morphism property is `IsStableUnderBaseChange` if the base change of such a morphism
 still falls in the class. -/
 class IsStableUnderBaseChange : Prop where
@@ -125,6 +135,9 @@ lemma isStableUnderBaseChange_iff_pullbacks_le :
     constructor
     intro _ _ _ _ _ _ _ _ h₁ h₂
     exact h _ ⟨_, _, _, _, _, h₂, h₁⟩
+
+lemma pullbacks_le [P.IsStableUnderBaseChange] : P.pullbacks ≤ P := by
+  rwa [← isStableUnderBaseChange_iff_pullbacks_le]
 
 variable {P} in
 /-- Alternative constructor for `IsStableUnderBaseChange`. -/
@@ -245,6 +258,17 @@ lemma isStableUnderCobaseChange_iff_pushouts_le :
     intro _ _ _ _ _ _ _ _ h₁ h₂
     exact h _ ⟨_, _, _, _, _, h₂, h₁⟩
 
+lemma pushouts_le [P.IsStableUnderCobaseChange] : P.pushouts ≤ P := by
+  rwa [← isStableUnderCobaseChange_iff_pushouts_le]
+
+@[simp]
+lemma pushouts_le_iff {P Q : MorphismProperty C} [Q.IsStableUnderCobaseChange] :
+    P.pushouts ≤ Q ↔ P ≤ Q := by
+  constructor
+  · exact le_trans P.le_pushouts
+  · intro h
+    exact le_trans (pushouts_monotone h) pushouts_le
+
 /-- An alternative constructor for `IsStableUnderCobaseChange`. -/
 theorem IsStableUnderCobaseChange.mk' [RespectsIso P]
     (hP₂ : ∀ (A B A' : C) (f : A ⟶ A') (g : A ⟶ B) [HasPushout f g] (_ : P f),
@@ -339,6 +363,12 @@ inductive limitsOfShape : MorphismProperty C
   | mk (X₁ X₂ : J ⥤ C) (c₁ : Cone X₁) (c₂ : Cone X₂)
     (_ : IsLimit c₁) (h₂ : IsLimit c₂) (f : X₁ ⟶ X₂) (_ : W.functorCategory J f) :
       limitsOfShape (h₂.lift (Cone.mk _ (c₁.π ≫ f)))
+
+lemma limitsOfShape_monotone {W₁ W₂ : MorphismProperty C} (h : W₁ ≤ W₂)
+    (J : Type*) [Category J] :
+    W₁.limitsOfShape J ≤ W₂.limitsOfShape J := by
+  rintro _ _ _ ⟨_, _, _, _, h₁, _, f, hf⟩
+  exact ⟨_, _, _, _, h₁, _, f, fun j ↦ h _ (hf j)⟩
 
 instance : (W.limitsOfShape J).RespectsIso :=
   RespectsIso.of_respects_arrow_iso _ (by
@@ -533,6 +563,13 @@ lemma le_coproducts : W ≤ coproducts.{w} W :=
   (le_colimitsOfShape_punit.{w} W).trans
     (colimitsOfShape_le_coproducts W PUnit.{w + 1})
 
+lemma coproducts_monotone : Monotone (coproducts.{w} (C := C)) := by
+  rintro W₁ W₂ h X Y f hf
+  rw [coproducts_iff] at hf
+  obtain ⟨J, hf⟩ := hf
+  exact W₂.colimitsOfShape_le_coproducts J _
+    (colimitsOfShape_monotone h _ _ hf)
+
 end Coproducts
 
 section Products
@@ -604,6 +641,35 @@ lemma isStableUnderCoproductsOfShape_of_isStableUnderFiniteCoproducts
     (J : Type) [Finite J] [W.IsStableUnderFiniteCoproducts] :
     W.IsStableUnderCoproductsOfShape J :=
   IsStableUnderFiniteCoproducts.isStableUnderCoproductsOfShape J
+
+/-- The condition that a property of morphisms is stable by coproducts. -/
+class IsStableUnderCoproducts : Prop where
+  isStableUnderCoproductsOfShape (J : Type w) : W.IsStableUnderCoproductsOfShape J
+
+lemma isStableUnderCoproductsOfShape_of_isStableUnderCoproducts
+    [IsStableUnderCoproducts.{w} W] (J : Type w) :
+    W.IsStableUnderCoproductsOfShape J :=
+  IsStableUnderCoproducts.isStableUnderCoproductsOfShape _
+
+lemma coproducts_le [IsStableUnderCoproducts.{w} W] :
+    coproducts.{w} W ≤ W := by
+  intro X Y f hf
+  rw [coproducts_iff] at hf
+  obtain ⟨J, hf⟩ := hf
+  exact (isStableUnderCoproductsOfShape_of_isStableUnderCoproducts W J).colimitsOfShape_le _ hf
+
+@[simp]
+lemma coproducts_eq_self [IsStableUnderCoproducts.{w} W] :
+    coproducts.{w} W = W :=
+  le_antisymm W.coproducts_le W.le_coproducts
+
+@[simp]
+lemma coproducts_le_iff {P Q : MorphismProperty C} [IsStableUnderCoproducts.{w} Q] :
+    coproducts.{w} P ≤ Q ↔ P ≤ Q := by
+  constructor
+  · exact le_trans P.le_coproducts
+  · intro h
+    exact le_trans (coproducts_monotone h) Q.coproducts_le
 
 end Products
 

--- a/Mathlib/CategoryTheory/MorphismProperty/Limits.lean
+++ b/Mathlib/CategoryTheory/MorphismProperty/Limits.lean
@@ -527,6 +527,7 @@ variable (W : MorphismProperty C)
 
 /-- Given `W : MorphismProperty C`, this is class of morphisms that are
 isomorphic to a coproduct of a family (indexed by some `J : Type w`) of maps in `W`. -/
+@[pp_with_univ]
 def coproducts : MorphismProperty C := ⨆ (J : Type w), W.colimitsOfShape (Discrete J)
 
 lemma colimitsOfShape_le_coproducts (J : Type w) :
@@ -643,6 +644,7 @@ lemma isStableUnderCoproductsOfShape_of_isStableUnderFiniteCoproducts
   IsStableUnderFiniteCoproducts.isStableUnderCoproductsOfShape J
 
 /-- The condition that a property of morphisms is stable by coproducts. -/
+@[pp_with_univ]
 class IsStableUnderCoproducts : Prop where
   isStableUnderCoproductsOfShape (J : Type w) : W.IsStableUnderCoproductsOfShape J
 

--- a/Mathlib/CategoryTheory/MorphismProperty/Retract.lean
+++ b/Mathlib/CategoryTheory/MorphismProperty/Retract.lean
@@ -79,6 +79,14 @@ lemma retracts_le (P : MorphismProperty C) [P.IsStableUnderRetracts] :
     P.retracts ≤ P := by
   rwa [← isStableUnderRetracts_iff_retracts_le]
 
+@[simp]
+lemma retracts_le_iff {P Q : MorphismProperty C} [Q.IsStableUnderRetracts] :
+    P.retracts ≤ Q ↔ P ≤ Q := by
+  constructor
+  · exact le_trans P.le_retracts
+  · intro h
+    exact le_trans (retracts_monotone h) Q.retracts_le
+
 end MorphismProperty
 
 end CategoryTheory

--- a/Mathlib/CategoryTheory/MorphismProperty/TransfiniteComposition.lean
+++ b/Mathlib/CategoryTheory/MorphismProperty/TransfiniteComposition.lean
@@ -321,6 +321,37 @@ lemma transfiniteCompositionsOfShape_le_transfiniteCompositions
   rw [transfiniteCompositions_iff]
   exact ⟨_, _, _, _, _, hf⟩
 
+lemma transfiniteCompositions_monotone :
+    Monotone (transfiniteCompositions.{w} (C := C)) := by
+  intro W₁ W₂ h X Y f hf
+  rw [transfiniteCompositions_iff] at hf
+  obtain ⟨J, _, _, _, _, hf⟩ := hf
+  exact transfiniteCompositionsOfShape_le_transfiniteCompositions _ _ _
+    (transfiniteCompositionsOfShape_monotone J h _ hf)
+
+lemma le_transfiniteCompositions :
+    W ≤ transfiniteCompositions.{w} W :=
+  le_trans (fun _ _ _ hf ↦
+    (MorphismProperty.TransfiniteCompositionOfShape.ofOrderIso (.ofMem _ hf)
+      (orderIsoShrink.{w} (Fin 2)).symm).mem)
+    (transfiniteCompositionsOfShape_le_transfiniteCompositions _ _)
+
+lemma transfiniteCompositions_le [IsStableUnderTransfiniteComposition.{w} W] :
+    transfiniteCompositions.{w} W ≤ W := by
+  intro _ _ f hf
+  rw [transfiniteCompositions_iff] at hf
+  obtain ⟨J, _, _, _, _, hf⟩ := hf
+  exact W.transfiniteCompositionsOfShape_le J _ hf
+
+@[simp]
+lemma transfiniteCompositions_le_iff {P Q : MorphismProperty C}
+    [IsStableUnderTransfiniteComposition.{w} Q] :
+    transfiniteCompositions.{w} P ≤ Q ↔ P ≤ Q := by
+  constructor
+  · exact (le_transfiniteCompositions P).trans
+  · intro h
+    exact (transfiniteCompositions_monotone.{w} h).trans Q.transfiniteCompositions_le
+
 end MorphismProperty
 
 end CategoryTheory


### PR DESCRIPTION
Basic lemmas are added in the `Limits`, `Retract` and `TransfiniteComposition` files. We add certain lemmas like `transfiniteCompositions_monotone`, and like `transfiniteCompositions_le_iff` (the latter states the equivalence `transfiniteCompositions.{w} P ≤ Q ↔ P ≤ Q ` when `Q` is stable under transfinite composition).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
