### PR TITLE
[Merged by Bors] - feat(Order): Set.Ici.isSuccLimit_coe

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4450,6 +4450,7 @@ import Mathlib.Order.RelSeries
 import Mathlib.Order.Restriction
 import Mathlib.Order.ScottContinuity
 import Mathlib.Order.SemiconjSup
+import Mathlib.Order.SetIsMax
 import Mathlib.Order.SetNotation
 import Mathlib.Order.Shrink
 import Mathlib.Order.Sublattice

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4394,6 +4394,7 @@ import Mathlib.Order.Interval.Set.Image
 import Mathlib.Order.Interval.Set.Infinite
 import Mathlib.Order.Interval.Set.InitialSeg
 import Mathlib.Order.Interval.Set.IsoIoo
+import Mathlib.Order.Interval.Set.Limit
 import Mathlib.Order.Interval.Set.Monotone
 import Mathlib.Order.Interval.Set.OrdConnected
 import Mathlib.Order.Interval.Set.OrdConnectedComponent

--- a/Mathlib/Order/Interval/Set/Limit.lean
+++ b/Mathlib/Order/Interval/Set/Limit.lean
@@ -1,0 +1,40 @@
+/-
+Copyright (c) 2025 Joël Riou. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joël Riou
+-/
+import Mathlib.Order.SetIsMax
+import Mathlib.Order.SuccPred.Limit
+
+/-!
+# Limit elements in Set.Ici
+
+If `J` is a linearly ordered type, `j : J`,
+and `m : Set.Ici j` is successor limit, then
+`↑m : J` is also successor limit.
+
+-/
+
+universe u
+
+namespace Set.Ici
+
+lemma isSuccLimit_coe {J : Type u} [LinearOrder J] {j : J}
+    (m : Set.Ici j) (hm : Order.IsSuccLimit m) :
+    Order.IsSuccLimit m.1 :=
+  ⟨Set.not_isMin_coe _ hm.1, fun b ↦ by
+    simp only [CovBy, not_lt, not_and, not_forall, Classical.not_imp, not_le]
+    intro hb
+    by_cases hb' : j ≤ b
+    · have := hm.2 ⟨b, hb'⟩
+      rw [not_covBy_iff (by exact hb)] at this
+      obtain ⟨⟨x, h₁⟩, h₂, h₃⟩ := this
+      refine ⟨x, h₂, h₃⟩
+    · simp only [not_le] at hb'
+      refine ⟨j, hb', ?_⟩
+      by_contra!
+      apply hm.1
+      rintro ⟨k, hk⟩ _
+      exact this.trans (by simpa using hk)⟩
+
+end Set.Ici

--- a/Mathlib/Order/SetIsMax.lean
+++ b/Mathlib/Order/SetIsMax.lean
@@ -24,7 +24,7 @@ lemma not_isMax_coe (hm : ¬ IsMax m) :
     ¬ IsMax m.1 :=
   fun h ↦ hm (fun _ hb ↦ h hb)
 
-lemma not_isMin_coe {S : Set J} (m : S) (hm : ¬ IsMin m) :
+lemma not_isMin_coe (hm : ¬ IsMin m) :
     ¬ IsMin m.1 :=
   fun h ↦ hm (fun _ hb ↦ h hb)
 

--- a/Mathlib/Order/SetIsMax.lean
+++ b/Mathlib/Order/SetIsMax.lean
@@ -9,8 +9,8 @@ import Mathlib.Data.Set.CoeSort
 /-!
 # Maximum of a subset
 
-Let `S : Set J` and `m : S`. If `m` is not the maximum of `S`,
-then `↑m : J` is not the maxium of `J`.
+Let `S : Set J` and `m : S`. If `m` is not a maximal element of `S`,
+then `↑m : J` is not maximal in `J`.
 
 -/
 

--- a/Mathlib/Order/SetIsMax.lean
+++ b/Mathlib/Order/SetIsMax.lean
@@ -1,0 +1,31 @@
+/-
+Copyright (c) 2025 Joël Riou. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joël Riou
+-/
+import Mathlib.Order.Max
+import Mathlib.Data.Set.CoeSort
+
+/-!
+# Maximum of a subset
+
+Let `S : Set J` and `m : S`. If `m` is not the maximum of `S`,
+then `↑m : J` is not the maxium of `J`.
+
+-/
+
+universe u
+
+namespace Set
+
+variable {J : Type u} [Preorder J] {S : Set J} (m : S)
+
+lemma not_isMax_coe (hm : ¬ IsMax m) :
+    ¬ IsMax m.1 :=
+  fun h ↦ hm (fun _ hb ↦ h hb)
+
+lemma not_isMin_coe {S : Set J} (m : S) (hm : ¬ IsMin m) :
+    ¬ IsMin m.1 :=
+  fun h ↦ hm (fun _ hb ↦ h hb)
+
+end Set

--- a/Mathlib/Order/SetIsMax.lean
+++ b/Mathlib/Order/SetIsMax.lean
@@ -7,7 +7,7 @@ import Mathlib.Order.Max
 import Mathlib.Data.Set.CoeSort
 
 /-!
-# Maximum of a subset
+# Maximal elements of subsets
 
 Let `S : Set J` and `m : S`. If `m` is not a maximal element of `S`,
 then `↑m : J` is not maximal in `J`.


### PR DESCRIPTION
If `J` is a linearly ordered type, `j : J`, and `m : Set.Ici j` is successor limit, then `↑m : J` is also successor limit.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
