### PR TITLE
[Merged by Bors] - feat: discrete topological spaces are 0-manifolds

### DIFF
--- a/Mathlib/Geometry/Manifold/ChartedSpace.lean
+++ b/Mathlib/Geometry/Manifold/ChartedSpace.lean
@@ -764,7 +764,7 @@ theorem chartAt_self_eq {H : Type*} [TopologicalSpace H] {x : H} :
 /-- Any discrete space is a charted space over a singleton set. -/
 -- XXX: this definition is not quite right yet, shouldn't need to specify b...
 instance ChartedSpace.of_discreteTopology [TopologicalSpace M] [TopologicalSpace H]
-    [DiscreteTopology M] [h : Inhabited H] [Subsingleton H] : ChartedSpace H M where
+    [DiscreteTopology M] [h: Unique H] : ChartedSpace H M where
   atlas :=
     letI f := fun x : M ↦ PartialHomeomorph.const
       (isOpen_discrete {x}) (isOpen_discrete {h.default})
@@ -777,10 +777,8 @@ instance ChartedSpace.of_discreteTopology [TopologicalSpace M] [TopologicalSpace
 -- /-- A chart on the discrete space is the constant chart. -/
 -- @[simp, mfld_simps]
 -- lemma chartedSpace_of_discreteTopology_chartAt [TopologicalSpace M] [TopologicalSpace H]
---     [DiscreteTopology M] [h : Inhabited H] [Subsingleton H] {x : M} :
+--     [DiscreteTopology M] [h : Unique H] {x : M} :
 --     chartAt H x = PartialHomeomorph.const (isOpen_discrete {x}) (isOpen_discrete {h.default}) := rfl
-
-#exit
 
 section Products
 

--- a/Mathlib/Geometry/Manifold/ChartedSpace.lean
+++ b/Mathlib/Geometry/Manifold/ChartedSpace.lean
@@ -761,9 +761,11 @@ theorem chartedSpaceSelf_atlas {H : Type*} [TopologicalSpace H] {e : PartialHome
 theorem chartAt_self_eq {H : Type*} [TopologicalSpace H] {x : H} :
     chartAt H x = PartialHomeomorph.refl H := rfl
 
-/-- Any discrete space is a charted space over a singleton set. -/
--- XXX: this definition is not quite right yet, shouldn't need to specify b...
-instance ChartedSpace.of_discreteTopology [TopologicalSpace M] [TopologicalSpace H]
+/-- Any discrete space is a charted space over a singleton set.
+We keep this as a definition (not an instance) to avoid instance search trying to search for
+`DiscreteTopology` or `Unique` instances.
+-/
+def ChartedSpace.of_discreteTopology [TopologicalSpace M] [TopologicalSpace H]
     [DiscreteTopology M] [h: Unique H] : ChartedSpace H M where
   atlas :=
     letI f := fun x : M ↦ PartialHomeomorph.const
@@ -773,12 +775,12 @@ instance ChartedSpace.of_discreteTopology [TopologicalSpace M] [TopologicalSpace
   mem_chart_source x := by simp
   chart_mem_atlas x := by simp
 
--- this is true, but not meaningful on paper... should still state it?
--- /-- A chart on the discrete space is the constant chart. -/
--- @[simp, mfld_simps]
--- lemma chartedSpace_of_discreteTopology_chartAt [TopologicalSpace M] [TopologicalSpace H]
---     [DiscreteTopology M] [h : Unique H] {x : M} :
---     chartAt H x = PartialHomeomorph.const (isOpen_discrete {x}) (isOpen_discrete {h.default}) := rfl
+/-- A chart on the discrete space is the constant chart. -/
+@[simp, mfld_simps]
+lemma chartedSpace_of_discreteTopology_chartAt [TopologicalSpace M] [TopologicalSpace H]
+    [DiscreteTopology M] [h : Unique H] {x : M} :
+    haveI := ChartedSpace.of_discreteTopology (M := M) (H := H);
+    chartAt H x = PartialHomeomorph.const (isOpen_discrete {x}) (isOpen_discrete {h.default}) := rfl
 
 section Products
 

--- a/Mathlib/Geometry/Manifold/ChartedSpace.lean
+++ b/Mathlib/Geometry/Manifold/ChartedSpace.lean
@@ -761,6 +761,27 @@ theorem chartedSpaceSelf_atlas {H : Type*} [TopologicalSpace H] {e : PartialHome
 theorem chartAt_self_eq {H : Type*} [TopologicalSpace H] {x : H} :
     chartAt H x = PartialHomeomorph.refl H := rfl
 
+/-- Any discrete space is a charted space over a singleton set. -/
+-- XXX: this definition is not quite right yet, shouldn't need to specify b...
+instance ChartedSpace.of_discreteTopology [TopologicalSpace M] [TopologicalSpace H]
+    [DiscreteTopology M] [h : Inhabited H] [Subsingleton H] : ChartedSpace H M where
+  atlas :=
+    letI f := fun x : M ↦ PartialHomeomorph.const
+      (isOpen_discrete {x}) (isOpen_discrete {h.default})
+    Set.image f univ
+  chartAt x := PartialHomeomorph.const (isOpen_discrete {x}) (isOpen_discrete {h.default})
+  mem_chart_source x := by simp
+  chart_mem_atlas x := by simp
+
+-- this is true, but not meaningful on paper... should still state it?
+-- /-- A chart on the discrete space is the constant chart. -/
+-- @[simp, mfld_simps]
+-- lemma chartedSpace_of_discreteTopology_chartAt [TopologicalSpace M] [TopologicalSpace H]
+--     [DiscreteTopology M] [h : Inhabited H] [Subsingleton H] {x : M} :
+--     chartAt H x = PartialHomeomorph.const (isOpen_discrete {x}) (isOpen_discrete {h.default}) := rfl
+
+#exit
+
 section Products
 
 library_note "Manifold type tags" /-- For technical reasons we introduce two type tags:

--- a/Mathlib/Geometry/Manifold/IsManifold/Basic.lean
+++ b/Mathlib/Geometry/Manifold/IsManifold/Basic.lean
@@ -801,11 +801,13 @@ instance empty [IsEmpty M] : IsManifold I n M := by
     _ = ∅ := empty_inter (range I)
   apply (this ▸ hx).elim
 
+attribute [local instance] ChartedSpace.of_discreteTopology in
 variable (n) in
 def of_discreteTopology [DiscreteTopology M] [Unique E] :
-    IsManifold (modelWithCornersSelf 𝕜 E) n M :=
-  isManifold_of_contDiffOn _ _ _ (fun _ _ _ _ ↦ contDiff_of_subsingleton.contDiffOn)
+    IsManifold (modelWithCornersSelf 𝕜 E) n M := by
+  apply isManifold_of_contDiffOn _ _ _ (fun _ _ _ _ ↦ contDiff_of_subsingleton.contDiffOn)
 
+attribute [local instance] ChartedSpace.of_discreteTopology in
 example [Unique E] : IsManifold (𝓘(𝕜, E)) n (Fin 2) := of_discreteTopology _
 
 /-- The product of two `C^n` manifolds is naturally a `C^n` manifold. -/

--- a/Mathlib/Geometry/Manifold/IsManifold/Basic.lean
+++ b/Mathlib/Geometry/Manifold/IsManifold/Basic.lean
@@ -803,7 +803,8 @@ instance empty [IsEmpty M] : IsManifold I n M := by
 
 attribute [local instance] ChartedSpace.of_discreteTopology in
 variable (n) in
-def of_discreteTopology [DiscreteTopology M] [Unique E] :
+/-- A discrete space `M` is a smooth manifold over the trivial model on a trivial normed space. -/
+theorem of_discreteTopology [DiscreteTopology M] [Unique E] :
     IsManifold (modelWithCornersSelf 𝕜 E) n M := by
   apply isManifold_of_contDiffOn _ _ _ (fun _ _ _ _ ↦ contDiff_of_subsingleton.contDiffOn)
 

--- a/Mathlib/Geometry/Manifold/IsManifold/Basic.lean
+++ b/Mathlib/Geometry/Manifold/IsManifold/Basic.lean
@@ -801,11 +801,12 @@ instance empty [IsEmpty M] : IsManifold I n M := by
     _ = ∅ := empty_inter (range I)
   apply (this ▸ hx).elim
 
--- `Unique E` is required to have a `ChartedSpace` instance
 variable (n) in
 def of_discreteTopology [DiscreteTopology M] [Unique E] :
     IsManifold (modelWithCornersSelf 𝕜 E) n M :=
   isManifold_of_contDiffOn _ _ _ (fun _ _ _ _ ↦ contDiff_of_subsingleton.contDiffOn)
+
+example [Unique E] : IsManifold (𝓘(𝕜, E)) n (Fin 2) := of_discreteTopology _
 
 /-- The product of two `C^n` manifolds is naturally a `C^n` manifold. -/
 instance prod {𝕜 : Type*} [NontriviallyNormedField 𝕜] {E : Type*} [NormedAddCommGroup E]

--- a/Mathlib/Geometry/Manifold/IsManifold/Basic.lean
+++ b/Mathlib/Geometry/Manifold/IsManifold/Basic.lean
@@ -782,6 +782,7 @@ lemma maximalAtlas_subset_of_le {m n : WithTop ℕ∞} (h : m ≤ n) :
     maximalAtlas I n M ⊆ maximalAtlas I m M :=
   StructureGroupoid.maximalAtlas_mono (contDiffGroupoid_le h)
 
+variable (n) in
 /-- The empty set is a `C^n` manifold w.r.t. any charted space and model. -/
 instance empty [IsEmpty M] : IsManifold I n M := by
   apply isManifold_of_contDiffOn
@@ -799,6 +800,12 @@ instance empty [IsEmpty M] : IsManifold I n M := by
     _ = ∅ ∩ range I := by rw [this, preimage_empty]
     _ = ∅ := empty_inter (range I)
   apply (this ▸ hx).elim
+
+-- `Unique E` is required to have a `ChartedSpace` instance
+variable (n) in
+def of_discreteTopology [DiscreteTopology M] [Unique E] :
+    IsManifold (modelWithCornersSelf 𝕜 E) n M :=
+  isManifold_of_contDiffOn _ _ _ (fun _ _ _ _ ↦ contDiff_of_subsingleton.contDiffOn)
 
 /-- The product of two `C^n` manifolds is naturally a `C^n` manifold. -/
 instance prod {𝕜 : Type*} [NontriviallyNormedField 𝕜] {E : Type*} [NormedAddCommGroup E]

--- a/Mathlib/Topology/PartialHomeomorph.lean
+++ b/Mathlib/Topology/PartialHomeomorph.lean
@@ -661,16 +661,27 @@ theorem refl_symm : (PartialHomeomorph.refl X).symm = PartialHomeomorph.refl X :
 /-! const: `PartialEquiv.const` as a partial homeomorphism -/
 section const
 
+variable {a : X} {b : Y}
+
 /--
 This is `PartialEquiv.single` as a partial homeomorphism: a constant map,
 whose source and target are necessarily singleton sets.
 -/
-def const {a : X} {b : Y} (ha : IsOpen {a}) (hb : IsOpen {b}) : PartialHomeomorph X Y where
+def const (ha : IsOpen {a}) (hb : IsOpen {b}) : PartialHomeomorph X Y where
   toPartialEquiv := PartialEquiv.single a b
   open_source := ha
   open_target := hb
   continuousOn_toFun := by simp
   continuousOn_invFun := by simp
+
+@[simp, mfld_simps]
+lemma const_apply (ha : IsOpen {a}) (hb : IsOpen {b}) (x : X) : (const ha hb) x = b := rfl
+
+@[simp, mfld_simps]
+lemma const_source (ha : IsOpen {a}) (hb : IsOpen {b}) : (const ha hb).source = {a} := rfl
+
+@[simp, mfld_simps]
+lemma const_target (ha : IsOpen {a}) (hb : IsOpen {b}) : (const ha hb).target = {b} := rfl
 
 end const
 


### PR DESCRIPTION
If `M` has the discrete topology:
- if `Unique H`, we provide a charted space instance `ChartedSpace H M`,
- if `Unique E`, we prove that `M` is a manifold w.r.t. `modelWithCornersSelf 𝕜 E`

#5462 claimed the same for `Subsingleton H` (and `E`): this is not quite correct, as a non-empty space `M` is not a manifold over an empty type `H`. Using `Unique` works, however (and is equally good in practice).

Fixes #5462. Part of my bordism theory project.

---

- depends on: #22107 (preliminary clean-up, the first commit)

Open question: how to expose this instance, without causing diamonds?
> With any reasonable definition, this will create a diamond with the "self" instance. Should it be scoped?

At the moment, these constructions are definitions, but having to make the charted space construction a local instance is burdensome.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
