### PR TITLE
[Merged by Bors] - chore(Algebra/Order/Monoid/Unbundled/WithTop): golf, clean up

### DIFF
--- a/Mathlib/Algebra/Order/AddGroupWithTop.lean
+++ b/Mathlib/Algebra/Order/AddGroupWithTop.lean
@@ -7,7 +7,6 @@ import Mathlib.Algebra.Order.Group.Defs
 import Mathlib.Algebra.Order.Monoid.WithTop
 import Mathlib.Algebra.Group.Hom.Defs
 import Mathlib.Algebra.CharZero.Defs
-import Mathlib.Algebra.Order.Monoid.Unbundled.OrderDual
 import Mathlib.Algebra.Order.Monoid.Canonical.Defs
 
 /-!

--- a/Mathlib/Algebra/Order/Monoid/Unbundled/WithTop.lean
+++ b/Mathlib/Algebra/Order/Monoid/Unbundled/WithTop.lean
@@ -5,12 +5,10 @@ Authors: Jeremy Avigad, Leonardo de Moura, Mario Carneiro, Johannes Hölzl
 -/
 import Mathlib.Algebra.CharZero.Defs
 import Mathlib.Algebra.Group.Hom.Defs
-import Mathlib.Algebra.Order.ZeroLEOne
-import Mathlib.Data.Nat.Cast.Defs
-import Mathlib.Order.WithBot
-import Mathlib.Algebra.Order.Monoid.Unbundled.Basic
 import Mathlib.Algebra.Order.Monoid.Unbundled.ExistsOfLE
-import Mathlib.Algebra.Order.Monoid.Unbundled.OrderDual
+import Mathlib.Algebra.Order.ZeroLEOne
+import Mathlib.Order.WithBot
+import Mathlib.Tactic.MinImports
 
 /-! # Adjoining top/bottom elements to ordered monoids.
 -/

--- a/Mathlib/Algebra/Order/Monoid/Unbundled/WithTop.lean
+++ b/Mathlib/Algebra/Order/Monoid/Unbundled/WithTop.lean
@@ -94,31 +94,22 @@ end One
 
 section Add
 
-variable [Add α] {a b c d : WithTop α} {x : α}
+variable [Add α] {w x y z : WithTop α} {a b : α}
 
 instance add : Add (WithTop α) :=
   ⟨Option.map₂ (· + ·)⟩
 
 @[simp, norm_cast] lemma coe_add (a b : α) : ↑(a + b) = (a + b : WithTop α) := rfl
 
-@[simp]
-theorem top_add (a : WithTop α) : ⊤ + a = ⊤ :=
-  rfl
+@[simp] lemma top_add (x : WithTop α) : ⊤ + x = ⊤ := rfl
+@[simp] lemma add_top (x : WithTop α) : x + ⊤ = ⊤ := by cases x <;> rfl
+
+@[simp] lemma add_eq_top : x + y = ⊤ ↔ x = ⊤ ∨ y = ⊤ := by cases x <;> cases y <;> simp [← coe_add]
+
+lemma add_ne_top : x + y ≠ ⊤ ↔ x ≠ ⊤ ∧ y ≠ ⊤ := by cases x <;> cases y <;> simp [← coe_add]
 
 @[simp]
-theorem add_top (a : WithTop α) : a + ⊤ = ⊤ := by cases a <;> rfl
-
-@[simp]
-theorem add_eq_top : a + b = ⊤ ↔ a = ⊤ ∨ b = ⊤ := by
-  match a, b with
-  | ⊤, _ => simp
-  | _, ⊤ => simp
-  | (a : α), (b : α) => simp only [← coe_add, coe_ne_top, or_false]
-
-theorem add_ne_top : a + b ≠ ⊤ ↔ a ≠ ⊤ ∧ b ≠ ⊤ :=
-  add_eq_top.not.trans not_or
-
-theorem add_lt_top [LT α] {a b : WithTop α} : a + b < ⊤ ↔ a < ⊤ ∧ b < ⊤ := by
+lemma add_lt_top [LT α] : x + y < ⊤ ↔ x < ⊤ ∧ y < ⊤ := by
   simp_rw [WithTop.lt_top_iff_ne_top, add_ne_top]
 
 theorem add_eq_coe :
@@ -127,131 +118,89 @@ theorem add_eq_coe :
   | some a, ⊤, c => by simp
   | some a, some b, c => by norm_cast; simp
 
-theorem add_coe_eq_top_iff {x : WithTop α} {y : α} : x + y = ⊤ ↔ x = ⊤ := by simp
+lemma add_coe_eq_top_iff : x + b = ⊤ ↔ x = ⊤ := by simp
+lemma coe_add_eq_top_iff : a + y = ⊤ ↔ y = ⊤ := by simp
 
-theorem coe_add_eq_top_iff {y : WithTop α} : ↑x + y = ⊤ ↔ y = ⊤ := by simp
+lemma add_right_inj [IsRightCancelAdd α] (hz : z ≠ ⊤) : x + z = y + z ↔ x = y := by
+  lift z to α using hz; cases x <;> cases y <;> simp [← coe_add]
 
-theorem add_right_cancel_iff [IsRightCancelAdd α] (ha : a ≠ ⊤) : b + a = c + a ↔ b = c := by
-  lift a to α using ha
-  obtain rfl | hb := eq_or_ne b ⊤
-  · rw [top_add, eq_comm, WithTop.add_coe_eq_top_iff, eq_comm]
-  lift b to α using hb
-  simp_rw [← WithTop.coe_add, eq_comm, WithTop.add_eq_coe, coe_eq_coe, exists_and_left,
-    exists_eq_left, add_left_inj, exists_eq_right, eq_comm]
+lemma add_right_cancel [IsRightCancelAdd α] (hz : z ≠ ⊤) (h : x + z = y + z) : x = y :=
+  (WithTop.add_right_inj hz).1 h
 
-theorem add_right_cancel [IsRightCancelAdd α] (ha : a ≠ ⊤) (h : b + a = c + a) : b = c :=
-  (WithTop.add_right_cancel_iff ha).1 h
+lemma add_left_inj [IsLeftCancelAdd α] (hx : x ≠ ⊤) : x + y = x + z ↔ y = z := by
+  lift x to α using hx; cases y <;> cases z <;> simp [← coe_add]
 
-theorem add_left_cancel_iff [IsLeftCancelAdd α] (ha : a ≠ ⊤) : a + b = a + c ↔ b = c := by
-  lift a to α using ha
-  obtain rfl | hb := eq_or_ne b ⊤
-  · rw [add_top, eq_comm, WithTop.coe_add_eq_top_iff, eq_comm]
-  lift b to α using hb
-  simp_rw [← WithTop.coe_add, eq_comm, WithTop.add_eq_coe, eq_comm, coe_eq_coe,
-    exists_and_left, exists_eq_left', add_right_inj, exists_eq_right']
+lemma add_left_cancel [IsLeftCancelAdd α] (hx : x ≠ ⊤) (h : x + y = x + z) : y = z :=
+  (WithTop.add_left_inj hx).1 h
 
-theorem add_left_cancel [IsLeftCancelAdd α] (ha : a ≠ ⊤) (h : a + b = a + c) : b = c :=
-  (WithTop.add_left_cancel_iff ha).1 h
+@[deprecated (since := "2025-02-19")] alias add_left_cancel_iff := add_left_inj
+@[deprecated (since := "2025-02-19")] alias add_right_cancel_iff := add_right_inj
 
-instance addLeftMono [LE α] [AddLeftMono α] : AddLeftMono (WithTop α) :=
-  ⟨fun a b c h => by
-    cases a <;> cases c <;> try exact le_top
-    rcases le_coe_iff.1 h with ⟨b, rfl, _⟩
-    exact coe_le_coe.2 (add_le_add_left (coe_le_coe.1 h) _)⟩
+instance addLeftMono [LE α] [AddLeftMono α] : AddLeftMono (WithTop α) where
+  elim x y z := by
+    cases x <;> cases y <;> cases z <;> simp [← coe_add]; simpa using (add_le_add_left · _)
 
-instance addRightMono [LE α] [AddRightMono α] : AddRightMono (WithTop α) :=
-  ⟨fun a b c h => by
-    cases a <;> cases c <;> try exact le_top
-    rcases le_coe_iff.1 h with ⟨b, rfl, _⟩
-    exact coe_le_coe.2 (add_le_add_right (coe_le_coe.1 h) _)⟩
+instance addRightMono [LE α] [AddRightMono α] : AddRightMono (WithTop α) where
+  elim x y z := by
+    cases x <;> cases y <;> cases z <;> simp [← coe_add, swap]; simpa using (add_le_add_right · _)
 
-instance addLeftReflectLT [LT α] [AddLeftReflectLT α] : AddLeftReflectLT (WithTop α) :=
-  ⟨fun a b c h => by
-    induction a; · exact (WithTop.not_top_lt _ h).elim
-    induction b; · exact (WithTop.not_top_lt _ h).elim
-    induction c
-    · exact coe_lt_top _
-    · exact coe_lt_coe.2 (lt_of_add_lt_add_left <| coe_lt_coe.1 h)⟩
+instance addLeftReflectLT [LT α] [AddLeftReflectLT α] : AddLeftReflectLT (WithTop α) where
+  elim x y z := by
+    cases x <;> cases y <;> cases z <;> simp [← coe_add, swap]; simpa using lt_of_add_lt_add_left
 
-instance addRightReflectLT [LT α] [AddRightReflectLT α] : AddRightReflectLT (WithTop α) :=
-  ⟨fun a b c h => by
-    cases a <;> cases b <;> try exact (WithTop.not_top_lt _ h).elim
-    cases c
-    · exact coe_lt_top _
-    · exact coe_lt_coe.2 (lt_of_add_lt_add_right <| coe_lt_coe.1 h)⟩
+instance addRightReflectLT [LT α] [AddRightReflectLT α] : AddRightReflectLT (WithTop α) where
+  elim x y z := by
+    cases x <;> cases y <;> cases z <;> simp [← coe_add, swap]; simpa using lt_of_add_lt_add_right
 
-protected theorem le_of_add_le_add_left [LE α] [AddLeftReflectLE α] (ha : a ≠ ⊤)
-    (h : a + b ≤ a + c) : b ≤ c := by
-  lift a to α using ha
-  induction c
-  · exact le_top
-  · induction b
-    · exact (not_top_le_coe _ h).elim
-    · simp only [← coe_add, coe_le_coe] at h ⊢
-      exact le_of_add_le_add_left h
+protected lemma le_of_add_le_add_left [LE α] [AddLeftReflectLE α] (hx : x ≠ ⊤) :
+    x + y ≤ x + z → y ≤ z := by
+  lift x to α using hx; cases y <;> cases z <;> simp [← coe_add]; simpa using le_of_add_le_add_left
 
-protected theorem le_of_add_le_add_right [LE α] [AddRightReflectLE α]
-    (ha : a ≠ ⊤) (h : b + a ≤ c + a) : b ≤ c := by
-  lift a to α using ha
-  cases c
-  · exact le_top
-  · cases b
-    · exact (not_top_le_coe _ h).elim
-    · exact coe_le_coe.2 (le_of_add_le_add_right <| coe_le_coe.1 h)
+protected lemma le_of_add_le_add_right [LE α] [AddRightReflectLE α] (hz : z ≠ ⊤) :
+    x + z ≤ y + z → x ≤ y := by
+  lift z to α using hz; cases x <;> cases y <;> simp [← coe_add]; simpa using le_of_add_le_add_right
 
-protected theorem add_lt_add_left [LT α] [AddLeftStrictMono α] (ha : a ≠ ⊤)
-    (h : b < c) : a + b < a + c := by
-  lift a to α using ha
-  rcases lt_iff_exists_coe.1 h with ⟨b, rfl, h'⟩
-  cases c
-  · exact coe_lt_top _
-  · exact coe_lt_coe.2 (add_lt_add_left (coe_lt_coe.1 h) _)
+protected lemma add_lt_add_left [LT α] [AddLeftStrictMono α] (hx : x ≠ ⊤) :
+    y < z → x + y < x + z := by
+  lift x to α using hx; cases y <;> cases z <;> simp [← coe_add]; simpa using (add_lt_add_left · _)
 
-protected theorem add_lt_add_right [LT α] [AddRightStrictMono α] (ha : a ≠ ⊤)
-    (h : b < c) : b + a < c + a := by
-  lift a to α using ha
-  rcases lt_iff_exists_coe.1 h with ⟨b, rfl, h'⟩
-  cases c
-  · exact coe_lt_top _
-  · exact coe_lt_coe.2 (add_lt_add_right (coe_lt_coe.1 h) _)
+protected lemma add_lt_add_right [LT α] [AddRightStrictMono α] (hz : z ≠ ⊤) :
+    x < y → x + z < y + z := by
+  lift z to α using hz; cases x <;> cases y <;> simp [← coe_add]; simpa using (add_lt_add_right · _)
 
-protected theorem add_le_add_iff_left [LE α] [AddLeftMono α]
-    [AddLeftReflectLE α] (ha : a ≠ ⊤) : a + b ≤ a + c ↔ b ≤ c :=
-  ⟨WithTop.le_of_add_le_add_left ha, fun h => add_le_add_left h a⟩
+protected lemma add_le_add_iff_left [LE α] [AddLeftMono α] [AddLeftReflectLE α] (hx : x ≠ ⊤) :
+    x + y ≤ x + z ↔ y ≤ z := ⟨WithTop.le_of_add_le_add_left hx, (add_le_add_left · _)⟩
 
-protected theorem add_le_add_iff_right [LE α] [AddRightMono α]
-    [AddRightReflectLE α] (ha : a ≠ ⊤) : b + a ≤ c + a ↔ b ≤ c :=
-  ⟨WithTop.le_of_add_le_add_right ha, fun h => add_le_add_right h a⟩
+protected lemma add_le_add_iff_right [LE α] [AddRightMono α] [AddRightReflectLE α] (hz : z ≠ ⊤) :
+    x + z ≤ y + z ↔ x ≤ y := ⟨WithTop.le_of_add_le_add_right hz, (add_le_add_right · _)⟩
 
-protected theorem add_lt_add_iff_left [LT α] [AddLeftStrictMono α]
-    [AddLeftReflectLT α] (ha : a ≠ ⊤) : a + b < a + c ↔ b < c :=
-  ⟨lt_of_add_lt_add_left, WithTop.add_lt_add_left ha⟩
+protected lemma add_lt_add_iff_left [LT α] [AddLeftStrictMono α] [AddLeftReflectLT α] (hx : x ≠ ⊤) :
+    x + y < x + z ↔ y < z := ⟨lt_of_add_lt_add_left, WithTop.add_lt_add_left hx⟩
 
-protected theorem add_lt_add_iff_right [LT α] [AddRightStrictMono α]
-    [AddRightReflectLT α] (ha : a ≠ ⊤) : b + a < c + a ↔ b < c :=
-  ⟨lt_of_add_lt_add_right, WithTop.add_lt_add_right ha⟩
+protected lemma add_lt_add_iff_right [LT α] [AddRightStrictMono α] [AddRightReflectLT α]
+    (hz : z ≠ ⊤) : x + z < y + z ↔ x < y := ⟨lt_of_add_lt_add_right, WithTop.add_lt_add_right hz⟩
 
 protected theorem add_lt_add_of_le_of_lt [Preorder α] [AddLeftStrictMono α]
-    [AddRightMono α] (ha : a ≠ ⊤) (hab : a ≤ b) (hcd : c < d) :
-    a + c < b + d :=
-  (WithTop.add_lt_add_left ha hcd).trans_le <| add_le_add_right hab _
+    [AddRightMono α] (hw : w ≠ ⊤) (hwy : w ≤ y) (hxz : x < z) :
+    w + x < y + z :=
+  (WithTop.add_lt_add_left hw hxz).trans_le <| add_le_add_right hwy _
 
 protected theorem add_lt_add_of_lt_of_le [Preorder α] [AddLeftMono α]
-    [AddRightStrictMono α] (hc : c ≠ ⊤) (hab : a < b) (hcd : c ≤ d) :
-    a + c < b + d :=
-  (WithTop.add_lt_add_right hc hab).trans_le <| add_le_add_left hcd _
+    [AddRightStrictMono α] (hx : x ≠ ⊤) (hwy : w < y) (hxz : x ≤ z) :
+    w + x < y + z :=
+  (WithTop.add_lt_add_right hx hwy).trans_le <| add_le_add_left hxz _
 
 lemma addLECancellable_of_ne_top [Preorder α] [ContravariantClass α α (· + ·) (· ≤ ·)]
-    (ha : a ≠ ⊤) : AddLECancellable a := fun _b _c ↦ WithTop.le_of_add_le_add_left ha
+    (hx : x ≠ ⊤) : AddLECancellable x := fun _b _c ↦ WithTop.le_of_add_le_add_left hx
 
 lemma addLECancellable_of_lt_top [Preorder α] [ContravariantClass α α (· + ·) (· ≤ ·)]
-    (ha : a < ⊤) : AddLECancellable a := addLECancellable_of_ne_top ha.ne
+    (hx : x < ⊤) : AddLECancellable x := addLECancellable_of_ne_top hx.ne
 
 lemma addLECancellable_coe [Preorder α] [ContravariantClass α α (· + ·) (· ≤ ·)] (a : α) :
     AddLECancellable (a : WithTop α) := addLECancellable_of_ne_top coe_ne_top
 
 lemma addLECancellable_iff_ne_top [Nonempty α] [Preorder α]
-    [ContravariantClass α α (· + ·) (· ≤ ·)] : AddLECancellable a ↔ a ≠ ⊤ where
+    [ContravariantClass α α (· + ·) (· ≤ ·)] : AddLECancellable x ↔ x ≠ ⊤ where
   mp := by rintro h rfl; exact (coe_lt_top <| Classical.arbitrary _).not_le <| h <| by simp
   mpr := addLECancellable_of_ne_top
 
@@ -492,8 +441,130 @@ instance zeroLEOneClass [Zero α] [LE α] [ZeroLEOneClass α] : ZeroLEOneClass (
 
 end One
 
-instance add [Add α] : Add (WithBot α) :=
-  WithTop.add
+section Add
+variable [Add α] {w x y z : WithBot α} {a b : α}
+
+instance add : Add (WithBot α) :=
+  ⟨Option.map₂ (· + ·)⟩
+
+@[simp, norm_cast] lemma coe_add (a b : α) : ↑(a + b) = (a + b : WithBot α) := rfl
+
+@[simp] lemma bot_add (x : WithBot α) : ⊥ + x = ⊥ := rfl
+@[simp] lemma add_bot (x : WithBot α) : x + ⊥ = ⊥ := by cases x <;> rfl
+
+@[simp] lemma add_eq_bot : x + y = ⊥ ↔ x = ⊥ ∨ y = ⊥ := by cases x <;> cases y <;> simp [← coe_add]
+
+lemma add_ne_bot : x + y ≠ ⊥ ↔ x ≠ ⊥ ∧ y ≠ ⊥ := by cases x <;> cases y <;> simp [← coe_add]
+
+@[simp]
+lemma bot_lt_add [LT α] : ⊥ < x + y ↔ ⊥ < x ∧ ⊥ < y := by
+  simp_rw [WithBot.bot_lt_iff_ne_bot, add_ne_bot]
+
+theorem add_eq_coe :
+    ∀ {a b : WithBot α} {c : α}, a + b = c ↔ ∃ a' b' : α, ↑a' = a ∧ ↑b' = b ∧ a' + b' = c
+  | ⊥, b, c => by simp
+  | some a, ⊥, c => by simp
+  | some a, some b, c => by norm_cast; simp
+
+lemma add_coe_eq_bot_iff : x + b = ⊥ ↔ x = ⊥ := by simp
+lemma coe_add_eq_bot_iff : a + y = ⊥ ↔ y = ⊥ := by simp
+
+lemma add_right_inj [IsRightCancelAdd α] (hz : z ≠ ⊥) : x + z = y + z ↔ x = y := by
+  lift z to α using hz; cases x <;> cases y <;> simp [← coe_add]
+
+lemma add_right_cancel [IsRightCancelAdd α] (hz : z ≠ ⊥) (h : x + z = y + z) : x = y :=
+  (WithBot.add_right_inj hz).1 h
+
+lemma add_left_inj [IsLeftCancelAdd α] (hx : x ≠ ⊥) : x + y = x + z ↔ y = z := by
+  lift x to α using hx; cases y <;> cases z <;> simp [← coe_add]
+
+lemma add_left_cancel [IsLeftCancelAdd α] (hx : x ≠ ⊥) (h : x + y = x + z) : y = z :=
+  (WithBot.add_left_inj hx).1 h
+
+@[deprecated (since := "2025-02-19")] alias add_left_cancel_iff := add_left_inj
+@[deprecated (since := "2025-02-19")] alias add_right_cancel_iff := add_right_inj
+
+instance addLeftMono [LE α] [AddLeftMono α] : AddLeftMono (WithBot α) where
+  elim x y z := by
+    cases x <;> cases y <;> cases z <;> simp [← coe_add]; simpa using (add_le_add_left · _)
+
+instance addRightMono [LE α] [AddRightMono α] : AddRightMono (WithBot α) where
+  elim x y z := by
+    cases x <;> cases y <;> cases z <;> simp [← coe_add, swap]; simpa using (add_le_add_right · _)
+
+instance addLeftReflectLT [LT α] [AddLeftReflectLT α] : AddLeftReflectLT (WithBot α) where
+  elim x y z := by
+    cases x <;> cases y <;> cases z <;> simp [← coe_add, swap]; simpa using lt_of_add_lt_add_left
+
+instance addRightReflectLT [LT α] [AddRightReflectLT α] : AddRightReflectLT (WithBot α) where
+  elim x y z := by
+    cases x <;> cases y <;> cases z <;> simp [← coe_add, swap]; simpa using lt_of_add_lt_add_right
+
+protected lemma le_of_add_le_add_left [LE α] [AddLeftReflectLE α] (hx : x ≠ ⊥) :
+    x + y ≤ x + z → y ≤ z := by
+  lift x to α using hx; cases y <;> cases z <;> simp [← coe_add]; simpa using le_of_add_le_add_left
+
+protected lemma le_of_add_le_add_right [LE α] [AddRightReflectLE α] (hz : z ≠ ⊥) :
+    x + z ≤ y + z → x ≤ y := by
+  lift z to α using hz; cases x <;> cases y <;> simp [← coe_add]; simpa using le_of_add_le_add_right
+
+protected lemma add_lt_add_left [LT α] [AddLeftStrictMono α] (hx : x ≠ ⊥) :
+    y < z → x + y < x + z := by
+  lift x to α using hx; cases y <;> cases z <;> simp [← coe_add]; simpa using (add_lt_add_left · _)
+
+protected lemma add_lt_add_right [LT α] [AddRightStrictMono α] (hz : z ≠ ⊥) :
+    x < y → x + z < y + z := by
+  lift z to α using hz; cases x <;> cases y <;> simp [← coe_add]; simpa using (add_lt_add_right · _)
+
+protected lemma add_le_add_iff_left [LE α] [AddLeftMono α] [AddLeftReflectLE α] (hx : x ≠ ⊥) :
+    x + y ≤ x + z ↔ y ≤ z := ⟨WithBot.le_of_add_le_add_left hx, (add_le_add_left · _)⟩
+
+protected lemma add_le_add_iff_right [LE α] [AddRightMono α] [AddRightReflectLE α] (hz : z ≠ ⊥) :
+    x + z ≤ y + z ↔ x ≤ y := ⟨WithBot.le_of_add_le_add_right hz, (add_le_add_right · _)⟩
+
+protected lemma add_lt_add_iff_left [LT α] [AddLeftStrictMono α] [AddLeftReflectLT α] (hx : x ≠ ⊥) :
+    x + y < x + z ↔ y < z := ⟨lt_of_add_lt_add_left, WithBot.add_lt_add_left hx⟩
+
+protected lemma add_lt_add_iff_right [LT α] [AddRightStrictMono α] [AddRightReflectLT α]
+    (hz : z ≠ ⊥) : x + z < y + z ↔ x < y := ⟨lt_of_add_lt_add_right, WithBot.add_lt_add_right hz⟩
+
+protected theorem add_lt_add_of_le_of_lt [Preorder α] [AddLeftStrictMono α]
+    [AddRightMono α] (hw : w ≠ ⊥) (hwy : w ≤ y) (hxz : x < z) :
+    w + x < y + z :=
+  (WithBot.add_lt_add_left hw hxz).trans_le <| add_le_add_right hwy _
+
+protected theorem add_lt_add_of_lt_of_le [Preorder α] [AddLeftMono α]
+    [AddRightStrictMono α] (hx : x ≠ ⊥) (hwy : w < y) (hxz : x ≤ z) :
+    w + x < y + z :=
+  (WithBot.add_lt_add_right hx hwy).trans_le <| add_le_add_left hxz _
+
+lemma addLECancellable_of_ne_bot [Preorder α] [ContravariantClass α α (· + ·) (· ≤ ·)]
+    (hx : x ≠ ⊥) : AddLECancellable x := fun _b _c ↦ WithBot.le_of_add_le_add_left hx
+
+lemma addLECancellable_of_lt_bot [Preorder α] [ContravariantClass α α (· + ·) (· ≤ ·)]
+    (hx : x < ⊥) : AddLECancellable x := addLECancellable_of_ne_bot hx.ne
+
+lemma addLECancellable_coe [Preorder α] [ContravariantClass α α (· + ·) (· ≤ ·)] (a : α) :
+    AddLECancellable (a : WithBot α) := addLECancellable_of_ne_bot coe_ne_bot
+
+lemma addLECancellable_iff_ne_bot [Nonempty α] [Preorder α]
+    [ContravariantClass α α (· + ·) (· ≤ ·)] : AddLECancellable x ↔ x ≠ ⊥ where
+  mp := by rintro h rfl; exact (bot_lt_coe <| Classical.arbitrary _).not_le <| h <| by simp
+  mpr := addLECancellable_of_ne_bot
+
+--  There is no `WithBot.map_mul_of_mulHom`, since `WithBot` does not have a multiplication.
+@[simp]
+protected theorem map_add {F} [Add β] [FunLike F α β] [AddHomClass F α β]
+    (f : F) (a b : WithBot α) :
+    (a + b).map f = a.map f + b.map f := by
+  induction a
+  · exact (bot_add _).symm
+  · induction b
+    · exact (add_bot _).symm
+    · rw [map_coe, map_coe, ← coe_add, ← coe_add, ← map_add]
+      rfl
+
+end Add
 
 instance AddSemigroup [AddSemigroup α] : AddSemigroup (WithBot α) :=
   WithTop.addSemigroup
@@ -576,59 +647,6 @@ instance charZero [AddMonoidWithOne α] [CharZero α] : CharZero (WithBot α) :=
 instance addCommMonoidWithOne [AddCommMonoidWithOne α] : AddCommMonoidWithOne (WithBot α) :=
   WithTop.addCommMonoidWithOne
 
-section Add
-
-variable [Add α] {a b c d : WithBot α} {x y : α}
-
-@[simp, norm_cast]
-theorem coe_add (a b : α) : ((a + b : α) : WithBot α) = a + b :=
-  rfl
-
-@[simp]
-theorem bot_add (a : WithBot α) : ⊥ + a = ⊥ :=
-  rfl
-
-@[simp]
-theorem add_bot (a : WithBot α) : a + ⊥ = ⊥ := by cases a <;> rfl
-
-@[simp]
-theorem add_eq_bot : a + b = ⊥ ↔ a = ⊥ ∨ b = ⊥ :=
-  WithTop.add_eq_top
-
-theorem add_ne_bot : a + b ≠ ⊥ ↔ a ≠ ⊥ ∧ b ≠ ⊥ :=
-  WithTop.add_ne_top
-
-theorem bot_lt_add [LT α] {a b : WithBot α} : ⊥ < a + b ↔ ⊥ < a ∧ ⊥ < b :=
-  WithTop.add_lt_top (α := αᵒᵈ)
-
-theorem add_eq_coe : a + b = x ↔ ∃ a' b' : α, ↑a' = a ∧ ↑b' = b ∧ a' + b' = x :=
-  WithTop.add_eq_coe
-
-theorem add_coe_eq_bot_iff : a + y = ⊥ ↔ a = ⊥ :=
-  WithTop.add_coe_eq_top_iff
-
-theorem coe_add_eq_bot_iff : ↑x + b = ⊥ ↔ b = ⊥ :=
-  WithTop.coe_add_eq_top_iff
-
-theorem add_right_cancel_iff [IsRightCancelAdd α] (ha : a ≠ ⊥) : b + a = c + a ↔ b = c :=
-  WithTop.add_right_cancel_iff ha
-
-theorem add_right_cancel [IsRightCancelAdd α] (ha : a ≠ ⊥) (h : b + a = c + a) : b = c :=
-  WithTop.add_right_cancel ha h
-
-theorem add_left_cancel_iff [IsLeftCancelAdd α] (ha : a ≠ ⊥) : a + b = a + c ↔ b = c :=
-  WithTop.add_left_cancel_iff ha
-
-theorem add_left_cancel [IsLeftCancelAdd α] (ha : a ≠ ⊥) (h : a + b = a + c) : b = c :=
-  WithTop.add_left_cancel ha h
-
--- There is no `WithBot.map_mul_of_mulHom`, since `WithBot` does not have a multiplication.
-@[simp]
-protected theorem map_add {F} [Add β] [FunLike F α β] [AddHomClass F α β]
-    (f : F) (a b : WithBot α) :
-    (a + b).map f = a.map f + b.map f :=
-  WithTop.map_add f a b
-
 /-- A version of `WithBot.map` for `OneHom`s. -/
 @[to_additive (attr := simps (config := .asFn))
   "A version of `WithBot.map` for `ZeroHom`s"]
@@ -649,64 +667,6 @@ protected def _root_.AddHom.withBotMap {M N : Type*} [Add M] [Add N] (f : AddHom
 protected def _root_.AddMonoidHom.withBotMap {M N : Type*} [AddZeroClass M] [AddZeroClass N]
     (f : M →+ N) : WithBot M →+ WithBot N :=
   { ZeroHom.withBotMap f.toZeroHom, AddHom.withBotMap f.toAddHom with toFun := WithBot.map f }
-
-variable [Preorder α]
-
-instance addLeftMono [AddLeftMono α] : AddLeftMono (WithBot α) :=
-  OrderDual.addLeftMono (α := WithTop αᵒᵈ)
-
-instance addRightMono [AddRightMono α] : AddRightMono (WithBot α) :=
-  OrderDual.addRightMono (α := WithTop αᵒᵈ)
-
-instance addLeftReflectLT [AddLeftReflectLT α] : AddLeftReflectLT (WithBot α) :=
-  OrderDual.addLeftReflectLT (α := WithTop αᵒᵈ)
-
-instance addRightReflectLT [AddRightReflectLT α] : AddRightReflectLT (WithBot α) :=
-  OrderDual.addRightReflectLT (α := WithTop αᵒᵈ)
-
-protected theorem le_of_add_le_add_left [AddLeftReflectLE α] (ha : a ≠ ⊥)
-    (h : a + b ≤ a + c) : b ≤ c :=
-  WithTop.le_of_add_le_add_left (α := αᵒᵈ) ha h
-
-protected theorem le_of_add_le_add_right [AddRightReflectLE α]
-    (ha : a ≠ ⊥) (h : b + a ≤ c + a) : b ≤ c :=
-  WithTop.le_of_add_le_add_right (α := αᵒᵈ) ha h
-
-protected theorem add_lt_add_left [AddLeftStrictMono α] (ha : a ≠ ⊥) (h : b < c) :
-    a + b < a + c :=
-  WithTop.add_lt_add_left (α := αᵒᵈ) ha h
-
-protected theorem add_lt_add_right [AddRightStrictMono α] (ha : a ≠ ⊥)
-    (h : b < c) : b + a < c + a :=
-  WithTop.add_lt_add_right (α := αᵒᵈ) ha h
-
-protected theorem add_le_add_iff_left [AddLeftMono α]
-    [AddLeftReflectLE α] (ha : a ≠ ⊥) : a + b ≤ a + c ↔ b ≤ c :=
-  ⟨WithBot.le_of_add_le_add_left ha, fun h => add_le_add_left h a⟩
-
-protected theorem add_le_add_iff_right [AddRightMono α]
-    [AddRightReflectLE α] (ha : a ≠ ⊥) : b + a ≤ c + a ↔ b ≤ c :=
-  ⟨WithBot.le_of_add_le_add_right ha, fun h => add_le_add_right h a⟩
-
-protected theorem add_lt_add_iff_left [AddLeftStrictMono α]
-    [AddLeftReflectLT α] (ha : a ≠ ⊥) : a + b < a + c ↔ b < c :=
-  ⟨lt_of_add_lt_add_left, WithBot.add_lt_add_left ha⟩
-
-protected theorem add_lt_add_iff_right [AddRightStrictMono α]
-    [AddRightReflectLT α] (ha : a ≠ ⊥) : b + a < c + a ↔ b < c :=
-  ⟨lt_of_add_lt_add_right, WithBot.add_lt_add_right ha⟩
-
-protected theorem add_lt_add_of_le_of_lt [AddLeftStrictMono α]
-    [AddRightMono α] (hb : b ≠ ⊥) (hab : a ≤ b) (hcd : c < d) :
-    a + c < b + d :=
-  WithTop.add_lt_add_of_le_of_lt (α := αᵒᵈ) hb hab hcd
-
-protected theorem add_lt_add_of_lt_of_le [AddLeftMono α]
-    [AddRightStrictMono α] (hd : d ≠ ⊥) (hab : a < b) (hcd : c ≤ d) :
-    a + c < b + d :=
-  WithTop.add_lt_add_of_lt_of_le (α := αᵒᵈ) hd hab hcd
-
-end Add
 
 -- instance orderedAddCommMonoid [OrderedAddCommMonoid α] : OrderedAddCommMonoid (WithBot α) :=
 --   { WithBot.partialOrder, WithBot.addCommMonoid with

--- a/Mathlib/Data/Nat/Multiplicity.lean
+++ b/Mathlib/Data/Nat/Multiplicity.lean
@@ -147,8 +147,8 @@ theorem emultiplicity_factorial_mul_succ {n p : ℕ} (hp : p.Prime) :
   simp_rw [← prod_Ico_id_eq_factorial, Finset.emultiplicity_prod hp', ← sum_Ico_consecutive _ h1 h3,
     add_assoc]
   intro h
-  rw [WithTop.add_left_cancel_iff h, sum_Ico_succ_top h2, hp.emultiplicity_mul,
-    hp.emultiplicity_self, sum_congr rfl h4, sum_const_zero, zero_add, add_comm 1]
+  rw [WithTop.add_left_inj h, sum_Ico_succ_top h2, hp.emultiplicity_mul, hp.emultiplicity_self,
+    sum_congr rfl h4, sum_const_zero, zero_add, add_comm 1]
 
 /-- The multiplicity of `p` in `(p * n)!` is `n` more than that of `n!`. -/
 theorem emultiplicity_factorial_mul {n p : ℕ} (hp : p.Prime) :
@@ -200,7 +200,7 @@ theorem emultiplicity_choose' {p n k b : ℕ} (hp : p.Prime) (hnb : log p (n + k
       hp.emultiplicity_factorial ((log_mono_right (le_add_left n k)).trans_lt
       (add_comm n k ▸ hnb)), multiplicity_choose_aux hp (le_add_left k n)]
     simp [add_comm]
-  refine (WithTop.add_right_cancel_iff ?_).1 h₁
+  refine WithTop.add_right_cancel ?_ h₁
   apply finiteMultiplicity_iff_emultiplicity_ne_top.1
   exact Nat.finiteMultiplicity_iff.2 ⟨hp.ne_one, mul_pos (factorial_pos k) (factorial_pos n)⟩
 

--- a/Mathlib/Data/Set/Card.lean
+++ b/Mathlib/Data/Set/Card.lean
@@ -173,7 +173,7 @@ theorem encard_union_add_encard_inter (s t : Set α) :
 theorem encard_eq_encard_iff_encard_diff_eq_encard_diff (h : (s ∩ t).Finite) :
     s.encard = t.encard ↔ (s \ t).encard = (t \ s).encard := by
   rw [← encard_diff_add_encard_inter s t, ← encard_diff_add_encard_inter t s, inter_comm t s,
-    WithTop.add_right_cancel_iff h.encard_lt_top.ne]
+    WithTop.add_right_inj h.encard_lt_top.ne]
 
 theorem encard_le_encard_iff_encard_diff_le_encard_diff (h : (s ∩ t).Finite) :
     s.encard ≤ t.encard ↔ (s \ t).encard ≤ (t \ s).encard := by
@@ -245,7 +245,7 @@ theorem encard_diff_singleton_add_one (h : a ∈ s) :
 
 theorem encard_diff_singleton_of_mem (h : a ∈ s) :
     (s \ {a}).encard = s.encard - 1 := by
-  rw [← encard_diff_singleton_add_one h, ← WithTop.add_right_cancel_iff WithTop.one_ne_top,
+  rw [← encard_diff_singleton_add_one h, ← WithTop.add_right_inj WithTop.one_ne_top,
     tsub_add_cancel_of_le (self_le_add_left _ _)]
 
 theorem encard_tsub_one_le_encard_diff_singleton (s : Set α) (x : α) :
@@ -264,7 +264,7 @@ theorem encard_eq_add_one_iff {k : ℕ∞} :
   refine ⟨fun h ↦ ?_, ?_⟩
   · obtain ⟨a, ha⟩ := nonempty_of_encard_ne_zero (s := s) (by simp [h])
     refine ⟨a, s \ {a}, fun h ↦ h.2 rfl, by rwa [insert_diff_singleton, insert_eq_of_mem], ?_⟩
-    rw [← WithTop.add_right_cancel_iff WithTop.one_ne_top, ← h,
+    rw [← WithTop.add_right_inj WithTop.one_ne_top, ← h,
       encard_diff_singleton_add_one ha]
   rintro ⟨a, t, h, rfl, rfl⟩
   rw [encard_insert_of_not_mem h]
@@ -284,7 +284,7 @@ section SmallSets
 
 theorem encard_pair {x y : α} (hne : x ≠ y) : ({x, y} : Set α).encard = 2 := by
   rw [encard_insert_of_not_mem (by simpa), ← one_add_one_eq_two,
-    WithTop.add_right_cancel_iff WithTop.one_ne_top, encard_singleton]
+    WithTop.add_right_inj WithTop.one_ne_top, encard_singleton]
 
 theorem encard_eq_one : s.encard = 1 ↔ ∃ x, s = {x} := by
   refine ⟨fun h ↦ ?_, fun ⟨x, hx⟩ ↦ by rw [hx, encard_singleton]⟩
@@ -315,7 +315,7 @@ theorem encard_eq_two : s.encard = 2 ↔ ∃ x y, x ≠ y ∧ s = {x, y} := by
   refine ⟨fun h ↦ ?_, fun ⟨x, y, hne, hs⟩ ↦ by rw [hs, encard_pair hne]⟩
   obtain ⟨x, hx⟩ := nonempty_of_encard_ne_zero (s := s) (by rw [h]; simp)
   rw [← insert_eq_of_mem hx, ← insert_diff_singleton, encard_insert_of_not_mem (fun h ↦ h.2 rfl),
-    ← one_add_one_eq_two, WithTop.add_right_cancel_iff (WithTop.one_ne_top), encard_eq_one] at h
+    ← one_add_one_eq_two, WithTop.add_right_inj (WithTop.one_ne_top), encard_eq_one] at h
   obtain ⟨y, h⟩ := h
   refine ⟨x, y, by rintro rfl; exact (h.symm.subset rfl).2 rfl, ?_⟩
   rw [← h, insert_diff_singleton, insert_eq_of_mem hx]
@@ -326,7 +326,7 @@ theorem encard_eq_three {α : Type u_1} {s : Set α} :
   · obtain ⟨x, hx⟩ := nonempty_of_encard_ne_zero (s := s) (by rw [h]; simp)
     rw [← insert_eq_of_mem hx, ← insert_diff_singleton,
       encard_insert_of_not_mem (fun h ↦ h.2 rfl), (by exact rfl : (3 : ℕ∞) = 2 + 1),
-      WithTop.add_right_cancel_iff WithTop.one_ne_top, encard_eq_two] at h
+      WithTop.add_right_inj WithTop.one_ne_top, encard_eq_two] at h
     obtain ⟨y, z, hne, hs⟩ := h
     refine ⟨x, y, z, ?_, ?_, hne, ?_⟩
     · rintro rfl; exact (hs.symm.subset (Or.inl rfl)).2 rfl
@@ -343,8 +343,8 @@ end SmallSets
 
 theorem Finite.eq_insert_of_subset_of_encard_eq_succ (hs : s.Finite) (h : s ⊆ t)
     (hst : t.encard = s.encard + 1) : ∃ a, t = insert a s := by
-  rw [← encard_diff_add_encard_of_subset h, add_comm,
-    WithTop.add_left_cancel_iff hs.encard_lt_top.ne, encard_eq_one] at hst
+  rw [← encard_diff_add_encard_of_subset h, add_comm, WithTop.add_left_inj hs.encard_lt_top.ne,
+    encard_eq_one] at hst
   obtain ⟨x, hx⟩ := hst; use x; rw [← diff_union_of_subset h, hx, singleton_union]
 
 theorem exists_subset_encard_eq {k : ℕ∞} (hk : k ≤ s.encard) : ∃ t, t ⊆ s ∧ t.encard = k := by


### PR DESCRIPTION
* Shorten proofs
* Make the `WithBot` and `WithTop` sections analogous
* Avoid relying on the defeq `(WithTop α)ᵒᵈ = WithBot αᵒᵈ`
* Pull more implicit variables to `variable` statements
* Stick to the convention that `a b : α` and `x y : WithBot α`

This is a follow-up to #21274.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
