### PR TITLE
[Merged by Bors] - feat: a function on a discrete space is smooth

### DIFF
--- a/Mathlib/Geometry/Manifold/ContMDiff/Basic.lean
+++ b/Mathlib/Geometry/Manifold/ContMDiff/Basic.lean
@@ -257,8 +257,8 @@ lemma contMDiff_of_discreteTopology [DiscreteTopology M] :
     ContMDiff I I' n f := by
   intro x
   -- f is locally constant, and constant functions are smooth.
-  apply ((contMDiff_const (c := f x)).contMDiffAt).congr_of_eventuallyEq
-  exact eventually_of_mem ((isOpen_discrete {x}).mem_nhds rfl) (by simp)
+  apply contMDiff_const.contMDiffAt.congr_of_eventuallyEq
+  simp [EventuallyEq]
 
 end const
 

--- a/Mathlib/Geometry/Manifold/ContMDiff/Basic.lean
+++ b/Mathlib/Geometry/Manifold/ContMDiff/Basic.lean
@@ -253,19 +253,15 @@ theorem contMDiffWithinAt_of_subsingleton [Subsingleton M'] : ContMDiffWithinAt 
 theorem contMDiffOn_of_subsingleton [Subsingleton M'] : ContMDiffOn I I' n f s :=
   contMDiff_of_subsingleton.contMDiffOn
 
--- idea: locally, f is constant near x, and constant functions are contMDiff
-lemma contMDiff_of_discreteTopology [DiscreteTopology M] [IsManifold I n M] [IsManifold I' n M'] :
+lemma contMDiff_of_discreteTopology [DiscreteTopology M] :
     ContMDiff I I' n f := by
   intro x
-  -- XXX: assume we're not smooth, by descending to all n or so
-  rw [contMDiffAt_iff_contMDiffOn_nhds sorry]
-  refine ⟨{x}, ?_, ?_⟩
-  · apply (isOpen_discrete {x}).mem_nhds; rw [Set.mem_singleton_iff]
-  · exact contMDiffOn_const (c := f x).congr (fun y hy ↦ by rw [hy])
+  -- f is locally constant, and constant functions are smooth.
+  apply ((contMDiff_const (c := f x)).contMDiffAt).congr_of_eventuallyEq
+  exact eventually_of_mem ((isOpen_discrete {x}).mem_nhds rfl) (by simp)
 
 end const
 
-#exit
 /-- `f` is continuously differentiable if it is cont. differentiable at
 each `x ∈ mulTSupport f`. -/
 @[to_additive "`f` is continuously differentiable if it is continuously

--- a/Mathlib/Geometry/Manifold/ContMDiff/Basic.lean
+++ b/Mathlib/Geometry/Manifold/ContMDiff/Basic.lean
@@ -257,7 +257,7 @@ lemma contMDiff_of_discreteTopology [DiscreteTopology M] :
     ContMDiff I I' n f := by
   intro x
   -- f is locally constant, and constant functions are smooth.
-  apply contMDiff_const.contMDiffAt.congr_of_eventuallyEq
+  apply contMDiff_const (c := f x).contMDiffAt.congr_of_eventuallyEq
   simp [EventuallyEq]
 
 end const

--- a/Mathlib/Geometry/Manifold/ContMDiff/Basic.lean
+++ b/Mathlib/Geometry/Manifold/ContMDiff/Basic.lean
@@ -253,8 +253,19 @@ theorem contMDiffWithinAt_of_subsingleton [Subsingleton M'] : ContMDiffWithinAt 
 theorem contMDiffOn_of_subsingleton [Subsingleton M'] : ContMDiffOn I I' n f s :=
   contMDiff_of_subsingleton.contMDiffOn
 
+-- idea: locally, f is constant near x, and constant functions are contMDiff
+lemma contMDiff_of_discreteTopology [DiscreteTopology M] [IsManifold I n M] [IsManifold I' n M'] :
+    ContMDiff I I' n f := by
+  intro x
+  -- XXX: assume we're not smooth, by descending to all n or so
+  rw [contMDiffAt_iff_contMDiffOn_nhds sorry]
+  refine ⟨{x}, ?_, ?_⟩
+  · apply (isOpen_discrete {x}).mem_nhds; rw [Set.mem_singleton_iff]
+  · exact contMDiffOn_const (c := f x).congr (fun y hy ↦ by rw [hy])
+
 end const
 
+#exit
 /-- `f` is continuously differentiable if it is cont. differentiable at
 each `x ∈ mulTSupport f`. -/
 @[to_additive "`f` is continuously differentiable if it is continuously


### PR DESCRIPTION
Unlike `ContMDiff.of_subsingleton`, this assumes the *domain* is discrete.

This is used in my bordism theory project.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
