### PR TITLE
[Merged by Bors] - chore: move `MulDistribMulAction` material earlier

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -405,6 +405,7 @@ import Mathlib.Algebra.Group.Units.Opposite
 import Mathlib.Algebra.Group.WithOne.Basic
 import Mathlib.Algebra.Group.WithOne.Defs
 import Mathlib.Algebra.GroupWithZero.Action.Basic
+import Mathlib.Algebra.GroupWithZero.Action.Center
 import Mathlib.Algebra.GroupWithZero.Action.ConjAct
 import Mathlib.Algebra.GroupWithZero.Action.Defs
 import Mathlib.Algebra.GroupWithZero.Action.End

--- a/Mathlib/Algebra/AddTorsor/Defs.lean
+++ b/Mathlib/Algebra/AddTorsor/Defs.lean
@@ -37,6 +37,8 @@ multiplicative group actions).
 
 -/
 
+assert_not_exists MonoidWithZero
+
 /-- An `AddTorsor G P` gives a structure to the nonempty type `P`,
 acted on by an `AddGroup G` with a transitive and free action given
 by the `+ᵥ` operation and a corresponding subtraction given by the

--- a/Mathlib/Algebra/Field/Action/ConjAct.lean
+++ b/Mathlib/Algebra/Field/Action/ConjAct.lean
@@ -5,6 +5,7 @@ Authors: Eric Wieser
 -/
 import Mathlib.Algebra.Field.Defs
 import Mathlib.Algebra.GroupWithZero.Action.ConjAct
+import Mathlib.Algebra.GroupWithZero.Action.Defs
 
 /-!
 # Conjugation action on a field on itself

--- a/Mathlib/Algebra/Group/Action/Basic.lean
+++ b/Mathlib/Algebra/Group/Action/Basic.lean
@@ -179,3 +179,15 @@ lemma smul_div' (r : M) (x y : A) : r • (x / y) = r • x / r • y :=
   map_div (MulDistribMulAction.toMonoidHom A r) x y
 
 end MulDistribMulAction
+
+section Arrow
+variable [Group G] [MulAction G A] [Monoid M]
+
+attribute [local instance] arrowAction
+
+/-- When `M` is a monoid, `ArrowAction` is additionally a `MulDistribMulAction`. -/
+def arrowMulDistribMulAction : MulDistribMulAction G (A → M) where
+  smul_one _ := rfl
+  smul_mul _ _ _ := rfl
+
+end Arrow

--- a/Mathlib/Algebra/Group/Action/End.lean
+++ b/Mathlib/Algebra/Group/Action/End.lean
@@ -24,7 +24,7 @@ assert_not_exists MonoidWithZero
 
 open Function (Injective Surjective)
 
-variable {G M N α : Type*}
+variable {G M N A α : Type*}
 
 /-! ### Tautological actions -/
 
@@ -97,6 +97,16 @@ instance applyMulAction : MulAction (MulAut M) M where
   smul := (· <| ·)
   one_smul _ := rfl
   mul_smul _ _ _ := rfl
+
+/-- The tautological action by `MulAut M` on `M`.
+
+This generalizes `Function.End.applyMulAction`. -/
+instance applyMulDistribMulAction : MulDistribMulAction (MulAut M) M where
+  smul := (· <| ·)
+  one_smul _ := rfl
+  mul_smul _ _ _ := rfl
+  smul_one := map_one
+  smul_mul := map_mul
 
 @[simp] protected lemma smul_def (f : MulAut M) (a : M) : f • a = f a := rfl
 
@@ -192,4 +202,25 @@ This is a stronger version of `MulAction.toPerm`. -/
 def MulDistribMulAction.toMulEquiv (x : G) : M ≃* M :=
   { MulDistribMulAction.toMonoidHom M x, MulAction.toPermHom G M x with }
 
+variable (G) in
+/-- Each element of the group defines a multiplicative monoid isomorphism.
+
+This is a stronger version of `MulAction.toPermHom`. -/
+@[simps]
+def MulDistribMulAction.toMulAut : G →* MulAut M where
+  toFun := MulDistribMulAction.toMulEquiv M
+  map_one' := MulEquiv.ext (one_smul _)
+  map_mul' _ _ := MulEquiv.ext (mul_smul _ _)
+
 end MulDistribMulAction
+
+section Arrow
+variable [Group G] [MulAction G A] [Monoid M]
+
+attribute [local instance] arrowMulDistribMulAction
+
+/-- Given groups `G H` with `G` acting on `A`, `G` acts by
+multiplicative automorphisms on `A → H`. -/
+@[simps!] def mulAutArrow : G →* MulAut (A → M) := MulDistribMulAction.toMulAut _ _
+
+end Arrow

--- a/Mathlib/Algebra/Group/Pointwise/Set/Finite.lean
+++ b/Mathlib/Algebra/Group/Pointwise/Set/Finite.lean
@@ -9,6 +9,7 @@ import Mathlib.Data.Finite.Prod
 
 /-! # Finiteness lemmas for pointwise operations on sets -/
 
+assert_not_exists MonoidWithZero
 
 open Pointwise
 

--- a/Mathlib/Algebra/GroupWithZero/Action/Basic.lean
+++ b/Mathlib/Algebra/GroupWithZero/Action/Basic.lean
@@ -95,36 +95,6 @@ def smulMonoidWithZeroHom [MonoidWithZero M₀] [MulZeroOneClass N₀] [MulActio
     [IsScalarTower M₀ N₀ N₀] [SMulCommClass M₀ N₀ N₀] : M₀ × N₀ →*₀ N₀ :=
   { smulMonoidHom with map_zero' := smul_zero _ }
 
-section MulDistribMulAction
-variable [Group G] [Monoid M] [MulDistribMulAction G M]
-
-variable (M G) in
-/-- Each element of the group defines a multiplicative monoid isomorphism.
-
-This is a stronger version of `MulAction.toPermHom`. -/
-@[simps]
-def MulDistribMulAction.toMulAut : G →* MulAut M where
-  toFun := MulDistribMulAction.toMulEquiv M
-  map_one' := MulEquiv.ext (one_smul _)
-  map_mul' _ _ := MulEquiv.ext (mul_smul _ _)
-
-end MulDistribMulAction
-
-
-namespace MulAut
-
-/-- The tautological action by `MulAut M` on `M`.
-
-This generalizes `Function.End.applyMulAction`. -/
-instance applyMulDistribMulAction [Monoid M] : MulDistribMulAction (MulAut M) M where
-  smul := (· <| ·)
-  one_smul _ := rfl
-  mul_smul _ _ _ := rfl
-  smul_one := map_one
-  smul_mul := map_mul
-
-end MulAut
-
 namespace AddAut
 
 /-- The tautological action by `AddAut A` on `A`.
@@ -138,24 +108,6 @@ instance applyDistribMulAction [AddMonoid A] : DistribMulAction (AddAut A) A whe
   mul_smul _ _ _ := rfl
 
 end AddAut
-
-section Arrow
-variable [Group G] [MulAction G A] [Monoid M]
-
-attribute [local instance] arrowAction
-
-/-- When `M` is a monoid, `ArrowAction` is additionally a `MulDistribMulAction`. -/
-def arrowMulDistribMulAction : MulDistribMulAction G (A → M) where
-  smul_one _ := rfl
-  smul_mul _ _ _ := rfl
-
-attribute [local instance] arrowMulDistribMulAction
-
-/-- Given groups `G H` with `G` acting on `A`, `G` acts by
-multiplicative automorphisms on `A → H`. -/
-@[simps!] def mulAutArrow : G →* MulAut (A → M) := MulDistribMulAction.toMulAut _ _
-
-end Arrow
 
 lemma IsUnit.smul_sub_iff_sub_inv_smul [Group G] [Monoid R] [AddGroup R] [DistribMulAction G R]
     [IsScalarTower G R R] [SMulCommClass G R R] (r : G) (a : R) :

--- a/Mathlib/Algebra/GroupWithZero/Action/Center.lean
+++ b/Mathlib/Algebra/GroupWithZero/Action/Center.lean
@@ -1,0 +1,28 @@
+/-
+Copyright (c) 2020 Kexing Ying. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kexing Ying
+-/
+import Mathlib.Algebra.GroupWithZero.Units.Basic
+import Mathlib.GroupTheory.Subgroup.Center
+
+/-!
+# The center of a group with zero
+-/
+
+/-- For a group with zero, the center of the units is the same as the units of the center. -/
+@[simps! apply_val_coe symm_apply_coe_val]
+def Subgroup.centerUnitsEquivUnitsCenter (G₀ : Type*) [GroupWithZero G₀] :
+    center G₀ˣ ≃* (Submonoid.center G₀)ˣ where
+  toFun := MonoidHom.toHomUnits
+    { toFun u := by
+        refine ⟨(u : G₀ˣ), Submonoid.mem_center_iff.mpr fun r ↦ ?_⟩
+        obtain rfl | hr := eq_or_ne r 0
+        · rw [mul_zero, zero_mul]
+        · exact congrArg Units.val <| (u.2.comm <| Units.mk0 r hr).symm
+      map_one' := rfl
+      map_mul' _ _ := rfl }
+  invFun u := unitsCenterToCenterUnits G₀ u
+  left_inv _ := by ext; rfl
+  right_inv _ := by ext; rfl
+  map_mul' := map_mul _

--- a/Mathlib/Algebra/GroupWithZero/Action/ConjAct.lean
+++ b/Mathlib/Algebra/GroupWithZero/Action/ConjAct.lean
@@ -3,6 +3,7 @@ Copyright (c) 2022 Eric Wieser. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Eric Wieser
 -/
+import Mathlib.Algebra.GroupWithZero.Basic
 import Mathlib.GroupTheory.GroupAction.ConjAct
 
 /-!

--- a/Mathlib/GroupTheory/GroupAction/ConjAct.lean
+++ b/Mathlib/GroupTheory/GroupAction/ConjAct.lean
@@ -32,9 +32,7 @@ is that some theorems about the group actions will not apply when since this
 
 -/
 
--- TODO
--- assert_not_exists GroupWithZero
-assert_not_exists Ring
+assert_not_exists MonoidWithZero
 
 variable (α M G : Type*)
 

--- a/Mathlib/GroupTheory/GroupAction/Defs.lean
+++ b/Mathlib/GroupTheory/GroupAction/Defs.lean
@@ -23,6 +23,7 @@ This file defines orbits, stabilizers, and other objects defined in terms of act
 
 -/
 
+assert_not_exists MonoidWithZero
 
 universe u v
 

--- a/Mathlib/GroupTheory/GroupAction/Embedding.lean
+++ b/Mathlib/GroupTheory/GroupAction/Embedding.lean
@@ -17,6 +17,7 @@ instances defined by `Pi.mulAction`.
 Note that unlike the `Pi` instance, this requires `G` to be a group.
 -/
 
+assert_not_exists MonoidWithZero
 
 universe u v w
 

--- a/Mathlib/GroupTheory/GroupAction/Support.lean
+++ b/Mathlib/GroupTheory/GroupAction/Support.lean
@@ -15,6 +15,8 @@ Given an action of a group `G` on a type `α`, we say that a set `s : Set α` su
 This is crucial in Fourier-Motzkin constructions.
 -/
 
+assert_not_exists MonoidWithZero
+
 open Pointwise
 
 variable {G H α β : Type*}

--- a/Mathlib/GroupTheory/Subgroup/Center.lean
+++ b/Mathlib/GroupTheory/Subgroup/Center.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kexing Ying
 -/
 import Mathlib.Algebra.Group.Subgroup.Basic
-import Mathlib.Algebra.GroupWithZero.Units.Basic
 import Mathlib.GroupTheory.Submonoid.Center
 
 /-!
@@ -12,7 +11,7 @@ import Mathlib.GroupTheory.Submonoid.Center
 
 -/
 
-assert_not_exists Multiset Ring
+assert_not_exists MonoidWithZero Multiset
 
 variable {G : Type*} [Group G]
 
@@ -49,23 +48,6 @@ def centerCongr {H} [Group H] (e : G ≃* H) : center G ≃* center H := Submono
 @[to_additive (attr := simps!)
 "The center of an additive group is isomorphic to the center of its opposite."]
 def centerToMulOpposite : center G ≃* center Gᵐᵒᵖ := Submonoid.centerToMulOpposite
-
-/-- For a group with zero, the center of the units is the same as the units of the center. -/
-@[simps! apply_val_coe symm_apply_coe_val]
-def centerUnitsEquivUnitsCenter (G₀ : Type*) [GroupWithZero G₀] :
-    Subgroup.center (G₀ˣ) ≃* (Submonoid.center G₀)ˣ where
-  toFun := MonoidHom.toHomUnits <|
-    { toFun := fun u ↦ ⟨(u : G₀ˣ),
-      (Submonoid.mem_center_iff.mpr (fun r ↦ by
-          rcases eq_or_ne r 0 with (rfl | hr)
-          · rw [mul_zero, zero_mul]
-          exact congrArg Units.val <| (u.2.comm <| Units.mk0 r hr).symm))⟩
-      map_one' := rfl
-      map_mul' := fun _ _ ↦ rfl }
-  invFun u := unitsCenterToCenterUnits G₀ u
-  left_inv _ := by ext; rfl
-  right_inv _ := by ext; rfl
-  map_mul' := map_mul _
 
 variable {G}
 

--- a/Mathlib/GroupTheory/Subgroup/Centralizer.lean
+++ b/Mathlib/GroupTheory/Subgroup/Centralizer.lean
@@ -3,13 +3,15 @@ Copyright (c) 2020 Kexing Ying. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kexing Ying
 -/
-import Mathlib.Algebra.GroupWithZero.Action.Basic
+import Mathlib.Algebra.Group.Action.End
 import Mathlib.GroupTheory.Subgroup.Center
 import Mathlib.GroupTheory.Submonoid.Centralizer
 
 /-!
 # Centralizers of subgroups
 -/
+
+assert_not_exists MonoidWithZero
 
 variable {G G' : Type*} [Group G] [Group G']
 

--- a/Mathlib/LinearAlgebra/AffineSpace/Defs.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/Defs.lean
@@ -37,5 +37,6 @@ Some key definitions are not yet present.
   coordinates, with appropriate proofs of existence when `k` is a field.
 -/
 
+assert_not_exists MonoidWithZero
 
 @[inherit_doc] scoped[Affine] notation "AffineSpace" => AddTorsor

--- a/Mathlib/RingTheory/LittleWedderburn.lean
+++ b/Mathlib/RingTheory/LittleWedderburn.lean
@@ -3,10 +3,9 @@ Copyright (c) 2021 Johan Commelin. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johan Commelin, Eric Rodriguez
 -/
+import Mathlib.Algebra.GroupWithZero.Action.Center
 import Mathlib.GroupTheory.ClassEquation
-import Mathlib.GroupTheory.GroupAction.ConjAct
 import Mathlib.RingTheory.Polynomial.Cyclotomic.Eval
-import Mathlib.LinearAlgebra.FreeModule.StrongRankCondition
 
 /-!
 # Wedderburn's Little Theorem


### PR DESCRIPTION

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->
- [x] depends on: #20773

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
