### PR TITLE
[Merged by Bors] - feat(CategoryTheory/Subobject): hasCardinalLT_of_mono

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2343,6 +2343,7 @@ import Mathlib.CategoryTheory.Square
 import Mathlib.CategoryTheory.Subobject.Basic
 import Mathlib.CategoryTheory.Subobject.Comma
 import Mathlib.CategoryTheory.Subobject.FactorThru
+import Mathlib.CategoryTheory.Subobject.HasCardinalLT
 import Mathlib.CategoryTheory.Subobject.Lattice
 import Mathlib.CategoryTheory.Subobject.Limits
 import Mathlib.CategoryTheory.Subobject.MonoOver

--- a/Mathlib/CategoryTheory/Subobject/Basic.lean
+++ b/Mathlib/CategoryTheory/Subobject/Basic.lean
@@ -430,6 +430,22 @@ def isoOfMkEqMk {B A₁ A₂ : C} (f : A₁ ⟶ B) (g : A₂ ⟶ B) [Mono f] [Mo
   hom := ofMkLEMk f g h.le
   inv := ofMkLEMk g f h.ge
 
+lemma mk_lt_mk_of_comm {X A₁ A₂ : C} {i₁ : A₁ ⟶ X} {i₂ : A₂ ⟶ X} [Mono i₁] [Mono i₂]
+    (f : A₁ ⟶ A₂) (fac : f ≫ i₂ = i₁) (hf : ¬ IsIso f) :
+    Subobject.mk i₁ < Subobject.mk i₂ := by
+  obtain _ | h := (mk_le_mk_of_comm _ fac).lt_or_eq
+  · assumption
+  · exfalso
+    apply hf
+    convert (isoOfMkEqMk i₁ i₂ h).isIso_hom
+    rw [← cancel_mono i₂, isoOfMkEqMk_hom, ofMkLEMk_comp, fac]
+
+lemma mk_lt_mk_iff_of_comm {X A₁ A₂ : C} {i₁ : A₁ ⟶ X} {i₂ : A₂ ⟶ X} [Mono i₁] [Mono i₂]
+    (f : A₁ ⟶ A₂) (fac : f ≫ i₂ = i₁) :
+    Subobject.mk i₁ < Subobject.mk i₂ ↔ ¬ IsIso f :=
+  ⟨fun h hf ↦ by simp only [mk_eq_mk_of_comm i₁ i₂ (asIso f) fac, lt_self_iff_false] at h,
+    mk_lt_mk_of_comm f fac⟩
+
 end Subobject
 
 lemma MonoOver.subobjectMk_le_mk_of_hom {P Q : MonoOver X} (f : P ⟶ Q) :
@@ -513,6 +529,10 @@ by post-composition with a monomorphism `f : X ⟶ Y`.
 def map (f : X ⟶ Y) [Mono f] : Subobject X ⥤ Subobject Y :=
   lower (MonoOver.map f)
 
+lemma map_mk {A X Y : C} (i : A ⟶ X) [Mono i] (f : X ⟶ Y) [Mono f] :
+    (map f).obj (mk i) = mk (i ≫ f) :=
+  rfl
+
 theorem map_id (x : Subobject X) : (map (𝟙 X)).obj x = x := by
   induction' x using Quotient.inductionOn' with f
   exact Quotient.sound ⟨(MonoOver.mapId _).app f⟩
@@ -521,6 +541,14 @@ theorem map_comp (f : X ⟶ Y) (g : Y ⟶ Z) [Mono f] [Mono g] (x : Subobject X)
     (map (f ≫ g)).obj x = (map g).obj ((map f).obj x) := by
   induction' x using Quotient.inductionOn' with t
   exact Quotient.sound ⟨(MonoOver.mapComp _ _).app t⟩
+
+lemma map_obj_injective {X Y : C} (f : X ⟶ Y) [Mono f] :
+    Function.Injective (Subobject.map f).obj := by
+  intro X₁ X₂ h
+  induction' X₁ using Subobject.ind with X₁ i₁ _
+  induction' X₂ using Subobject.ind with X₂ i₂ _
+  simp only [map_mk] at h
+  exact mk_eq_mk_of_comm _ _ (isoOfMkEqMk _ _ h) (by simp [← cancel_mono f])
 
 /-- Isomorphic objects have equivalent subobject lattices. -/
 def mapIso {A B : C} (e : A ≅ B) : Subobject A ≌ Subobject B :=

--- a/Mathlib/CategoryTheory/Subobject/HasCardinalLT.lean
+++ b/Mathlib/CategoryTheory/Subobject/HasCardinalLT.lean
@@ -1,0 +1,28 @@
+/-
+Copyright (c) 2025 Joël Riou. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joël Riou
+-/
+import Mathlib.CategoryTheory.Subobject.Basic
+import Mathlib.SetTheory.Cardinal.HasCardinalLT
+
+/-!
+# Cardinality of Subobject
+
+If `X ⟶ Y` is a monomorphism, and the cardinality of `Subobject Y`
+is `< κ`, then the cardinality of `Subobject X` is also `< κ`.
+
+-/
+
+universe w v u
+
+namespace CategoryTheory.Subobject
+
+variable {C : Type u} [Category.{v} C]
+
+lemma hasCardinalLT_of_mono {Y : C} {κ : Cardinal.{w}}
+    (h : HasCardinalLT (Subobject Y) κ) {X : C} (f : X ⟶ Y) [Mono f] :
+    HasCardinalLT (Subobject X) κ :=
+  h.of_injective _ (map_obj_injective f)
+
+end CategoryTheory.Subobject


### PR DESCRIPTION
This PR adds API in order to get strict inequalities in `Subobject`, and it is shown that if `X ⟶ Y` is a monomorphism, and the cardinality of `Subobject Y` is `< κ`, then the cardinality of `Subobject X` is also `< κ`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
