### PR TITLE
[Merged by Bors] - feat(CategoryTheory/Abelian/GrothendieckCategory): computing colimits in Subobject

### DIFF
--- a/Mathlib/CategoryTheory/Abelian/GrothendieckCategory/Subobject.lean
+++ b/Mathlib/CategoryTheory/Abelian/GrothendieckCategory/Subobject.lean
@@ -92,7 +92,7 @@ noncomputable def isColimitMapCoconeOfSubobjectMkEqISup
     colimit.desc _ (Cocone.mk X
       { app j := (F.obj j).obj.hom
         naturality {j j'} g := by simp [MonoOver.forget] })
-  have := mono_of_isColimit_monoOver F (colimit.isColimit _) f (by simp [f])
+  haveI := mono_of_isColimit_monoOver F (colimit.isColimit _) f (by simp [f])
   have := subobjectMk_of_isColimit_eq_iSup F (colimit.isColimit _) f (by simp [f])
   rw [← h] at this
   refine IsColimit.ofIsoColimit (colimit.isColimit _)

--- a/Mathlib/CategoryTheory/Abelian/GrothendieckCategory/Subobject.lean
+++ b/Mathlib/CategoryTheory/Abelian/GrothendieckCategory/Subobject.lean
@@ -80,8 +80,8 @@ end
 /-- Let `X : C` be an object in a Grothendieck abelian category,
 `F : J ⥤ MonoOver X` a functor from a filtered category, `c` a cocone for
 the composition `F ⋙ MonoOver.forget _ : J ⥤ Over X`. We assume
-that `c.pt.hom : c.pt.left ⟶ X` is a monomorphism and the corresponding
-subobject is the supremum of the subobjects given by `(F.obj j).obj.hom`,
+that `c.pt.hom : c.pt.left ⟶ X` is a monomorphism and that the corresponding
+subobject of `X` is the supremum of the subobjects given by `(F.obj j).obj.hom`,
 then `c` becomes a colimit cocone after the application of
 the forget functor `Over X ⥤ C`. (See also `subobjectMk_of_isColimit_eq_iSup`.) -/
 noncomputable def isColimitMapCoconeOfSubobjectMkEqISup

--- a/Mathlib/CategoryTheory/Abelian/GrothendieckCategory/Subobject.lean
+++ b/Mathlib/CategoryTheory/Abelian/GrothendieckCategory/Subobject.lean
@@ -55,7 +55,7 @@ lemma mono_of_isColimit_monoOver : Mono f := by
 functor from a filtered category `J`, the colimit of `F` (computed in `C`) gives
 a subobject of `F` which is a supremum of the subobjects corresponding to
 the objects in the image of the functor `F`. -/
-lemma subobject_mk_of_isColimit_eq_iSup :
+lemma subobjectMk_of_isColimit_eq_iSup :
     haveI := mono_of_isColimit_monoOver F hc f hf
     Subobject.mk f = ⨆ j, Subobject.mk (F.obj j).obj.hom := by
   haveI := mono_of_isColimit_monoOver F hc f hf
@@ -77,6 +77,31 @@ lemma subobject_mk_of_isColimit_eq_iSup :
 
 end
 
+/-- Let `X : C` be an object in a Grothendieck abelian category,
+`F : J ⥤ MonoOver X` a functor from a filtered category, `c` a cocone for
+the composition `F ⋙ MonoOver.forget _ : J ⥤ Over X`. We assume
+that `c.pt.hom : c.pt.left ⟶ X` is a monomorphism and the corresponding
+subobject is the supremum of the subobjects given by `(F.obj j).obj.hom`,
+then `c` becomes a colimit cocone after the application of
+the forget functor `Over X ⥤ C`. (See also `subobjectMk_of_isColimit_eq_iSup`.) -/
+noncomputable def isColimitMapCoconeOfSubobjectMkEqISup
+    [IsFiltered J] (c : Cocone (F ⋙ MonoOver.forget _)) [Mono c.pt.hom]
+    (h : Subobject.mk c.pt.hom = ⨆ j, Subobject.mk (F.obj j).obj.hom) :
+    IsColimit ((Over.forget _).mapCocone c) := by
+  let f : colimit (F ⋙ MonoOver.forget X ⋙ Over.forget X) ⟶ X :=
+    colimit.desc _ (Cocone.mk X
+      { app j := (F.obj j).obj.hom
+        naturality {j j'} g := by simp [MonoOver.forget] })
+  have := mono_of_isColimit_monoOver F (colimit.isColimit _) f (by simp [f])
+  have := subobjectMk_of_isColimit_eq_iSup F (colimit.isColimit _) f (by simp [f])
+  rw [← h] at this
+  refine IsColimit.ofIsoColimit (colimit.isColimit _)
+    (Cocones.ext (Subobject.isoOfMkEqMk _ _ this) (fun j ↦ ?_))
+  rw [← cancel_mono (c.pt.hom)]
+  dsimp
+  rw [Category.assoc, Subobject.ofMkLEMk_comp, Over.w]
+  apply colimit.ι_desc
+
 /-- If `C` is a Grothendieck abelian category, `X : C`, if `F : J ⥤ MonoOver X` is a
 functor from a `κ`-filtered category `J` with `κ` a regular cardinal such
 that `HasCardinalLT (Subobject X) κ`, and if the colimit of `F` (computed in `C`)
@@ -91,7 +116,7 @@ lemma exists_isIso_of_functor_from_monoOver
   have := isFiltered_of_isCardinalDirected J κ
   have := mono_of_isColimit_monoOver F hc f hf
   rw [Subobject.epi_iff_mk_eq_top f,
-    subobject_mk_of_isColimit_eq_iSup F hc f hf] at h
+    subobjectMk_of_isColimit_eq_iSup F hc f hf] at h
   let s (j : J) : Subobject X := Subobject.mk (F.obj j).obj.hom
   have h' : Function.Surjective (fun (j : J) ↦ (⟨s j, _, rfl⟩ : Set.range s)) := by
     rintro ⟨_, j, rfl⟩


### PR DESCRIPTION
Let `X : C` be an object in a Grothendieck abelian category, `F : J ⥤ MonoOver X` a functor from a filtered category, `c` a cocone for the composition `F ⋙ MonoOver.forget _ : J ⥤ Over X`. We assume that `c.pt.hom : c.pt.left ⟶ X` is a monomorphism and that the corresponding subobject of `X` is the supremum of the subobjects given by `(F.obj j).obj.hom`, then `c` becomes a colimit cocone after the application of the forget functor `Over X ⥤ C`. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
