### PR TITLE
draft(Module): Module length is additive in short exact sequences

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4422,6 +4422,7 @@ import Mathlib.Order.SupIndep
 import Mathlib.Order.SymmDiff
 import Mathlib.Order.Synonym
 import Mathlib.Order.TransfiniteIteration
+import Mathlib.Order.TrimmedLength
 import Mathlib.Order.TypeTags
 import Mathlib.Order.ULift
 import Mathlib.Order.UpperLower.Basic

--- a/Mathlib/Algebra/Module/Length.lean
+++ b/Mathlib/Algebra/Module/Length.lean
@@ -45,52 +45,88 @@ theorem RelSeries.moduleLength_ge_trimmedLength
 
 
 open Classical in
-  /--
-  The module length is additive in short exact sequences.
-  -/
-    theorem Module.length_additive
-    {S : CategoryTheory.ShortComplex (ModuleCat R)} (hS : S.ShortExact) :
-      Module.length R S.X₂ = Module.length R S.X₁ + Module.length R S.X₃ := by
-    simp only [length, krullDim, le_antisymm_iff, iSup_le_iff]
-    constructor
-    · intro rs
-      trans ↑((RelSeries.submoduleComap rs S.f.hom).trimmedLength +
-             (RelSeries.submoduleMap rs S.g.hom).trimmedLength)
-      · apply Nat.mono_cast
-        have trimmedProof := RelSeries.trimmedLength_additive hS rs
-        rwa[Nat.add_comm] at trimmedProof
-      · have trimleft :=
-          RelSeries.moduleLength_ge_trimmedLength (RelSeries.submoduleComap rs S.f.hom)
-        have trimright :=
-          RelSeries.moduleLength_ge_trimmedLength (RelSeries.submoduleMap rs S.g.hom)
-        exact add_le_add trimleft trimright
-    · rw[WithBot.iSup_le_add]
-      intro rstemp rstemp'
-      obtain ⟨rs, hrs⟩ := RelSeries.exists_ltSeries_ge_head_bot_last_top rstemp
-      obtain ⟨rs', hrs'⟩ := RelSeries.exists_ltSeries_ge_head_bot_last_top rstemp'
+/--
+The module length is additive in short exact sequences.
+-/
+theorem Module.length_additive
+{S : CategoryTheory.ShortComplex (ModuleCat R)} (hS : S.ShortExact) :
+  Module.length R S.X₂ = Module.length R S.X₁ + Module.length R S.X₃ := by
+simp only [length, krullDim, le_antisymm_iff, iSup_le_iff]
+constructor
+· intro rs
+  trans ↑((RelSeries.submoduleComap rs S.f.hom).trimmedLength +
+          (RelSeries.submoduleMap rs S.g.hom).trimmedLength)
+  · apply Nat.mono_cast
+    have trimmedProof := RelSeries.trimmedLength_additive hS rs
+    rwa[Nat.add_comm] at trimmedProof
+  · have trimleft :=
+      RelSeries.moduleLength_ge_trimmedLength (RelSeries.submoduleComap rs S.f.hom)
+    have trimright :=
+      RelSeries.moduleLength_ge_trimmedLength (RelSeries.submoduleMap rs S.g.hom)
+    exact add_le_add trimleft trimright
+· rw[WithBot.iSup_le_add]
+  intro rstemp rstemp'
+  obtain ⟨rs, hrs⟩ := RelSeries.exists_ltSeries_ge_head_bot_last_top rstemp
+  obtain ⟨rs', hrs'⟩ := RelSeries.exists_ltSeries_ge_head_bot_last_top rstemp'
 
-      let gInv : RelSeries (fun (a : Submodule R S.X₂) (b : Submodule R S.X₂) => a < b) :=
-        LTSeries.map rs' (Submodule.comap S.g.hom)
-        (Submodule.comap_strictMono_of_surjective hS.moduleCat_surjective_g)
+  let gInv : RelSeries (fun (a : Submodule R S.X₂) (b : Submodule R S.X₂) => a < b) :=
+    LTSeries.map rs' (Submodule.comap S.g.hom)
+    (Submodule.comap_strictMono_of_surjective hS.moduleCat_surjective_g)
 
-      let fIm : RelSeries (fun (a : Submodule R S.X₂) (b : Submodule R S.X₂) => a < b) :=
-        LTSeries.map rs (Submodule.map S.f.hom)
-        (Submodule.map_strictMono_of_injective hS.moduleCat_injective_f)
+  let fIm : RelSeries (fun (a : Submodule R S.X₂) (b : Submodule R S.X₂) => a < b) :=
+    LTSeries.map rs (Submodule.map S.f.hom)
+    (Submodule.map_strictMono_of_injective hS.moduleCat_injective_f)
 
-      have connect : fIm.last = gInv.head := by
-        convert CategoryTheory.ShortComplex.Exact.moduleCat_range_eq_ker hS.exact
-        · simp only [RelSeries.last, LTSeries.map_length, LTSeries.map_toFun, fIm]
-          have obv : (rs.toFun (Fin.last rs.length)) = ⊤ := hrs.2.2
-          rw[obv]; exact Submodule.map_top S.f.hom
-        · simp only [RelSeries.head, LTSeries.map_toFun, gInv]
-          have obv : rs'.toFun 0 = ⊥ := hrs'.2.1
-          rw[obv]; exact rfl
+  have connect : fIm.last = gInv.head := by
+    convert CategoryTheory.ShortComplex.Exact.moduleCat_range_eq_ker hS.exact
+    · simp only [RelSeries.last, LTSeries.map_length, LTSeries.map_toFun, fIm]
+      have obv : (rs.toFun (Fin.last rs.length)) = ⊤ := hrs.2.2
+      rw[obv]; exact Submodule.map_top S.f.hom
+    · simp only [RelSeries.head, LTSeries.map_toFun, gInv]
+      have obv : rs'.toFun 0 = ⊥ := hrs'.2.1
+      rw[obv]; exact rfl
 
-      let smashfg := RelSeries.smash fIm gInv connect
-      trans ↑smashfg.length
-      · have this' : smashfg.length = rs.length + rs'.length := rfl
-        rw[this']
-        simp only [Nat.cast_add, ge_iff_le]
-        refine add_le_add ?h₁ ?h₂
-        all_goals simp only [Nat.cast_le, hrs.1, hrs'.1]
-      · exact le_iSup_iff.mpr fun b a ↦ a smashfg
+  let smashfg := RelSeries.smash fIm gInv connect
+  trans ↑smashfg.length
+  · have this' : smashfg.length = rs.length + rs'.length := rfl
+    rw[this']
+    simp only [Nat.cast_add, ge_iff_le]
+    refine add_le_add ?h₁ ?h₂
+    all_goals simp only [Nat.cast_le, hrs.1, hrs'.1]
+  · exact le_iSup_iff.mpr fun b a ↦ a smashfg
+
+theorem Module.length_additive_of_quotient {N : Submodule R M} :
+  Module.length R M = Module.length R N + Module.length R (M ⧸ N) := by
+  let quotientSeq : CategoryTheory.ShortComplex (ModuleCat R) := {
+    X₁ := ModuleCat.of R N
+    X₂ := ModuleCat.of R M
+    X₃ := ModuleCat.of R (M ⧸ N)
+    f := ModuleCat.ofHom <| Submodule.subtype N
+    g := ModuleCat.ofHom <| Submodule.mkQ N
+    zero := by
+      ext a
+      simp
+    }
+  let ex : quotientSeq.ShortExact := {
+    exact := by
+      simp[CategoryTheory.ShortComplex.moduleCat_exact_iff]
+      intro a b
+      have X2 : ↑quotientSeq.X₂ = M := rfl
+      have X1 : ↑quotientSeq.X₁ = @Subtype M fun x ↦ x ∈ N := rfl
+      let a'' : N := {
+        val := a
+        property := (Submodule.Quotient.mk_eq_zero N).mp b
+      }
+      use a''
+      aesop
+    mono_f := by
+      simp[quotientSeq]
+      have : Function.Injective (N.subtype) := by exact Submodule.injective_subtype N
+      exact (ModuleCat.mono_iff_injective (ModuleCat.ofHom N.subtype)).mpr this
+    epi_g := by
+      simp[quotientSeq]
+      have : Function.Surjective (N.mkQ) := by exact Submodule.mkQ_surjective N
+      exact (ModuleCat.epi_iff_surjective (ModuleCat.ofHom N.mkQ)).mpr this
+  }
+  have := Module.length_additive ex
+  aesop

--- a/Mathlib/Algebra/Module/Length.lean
+++ b/Mathlib/Algebra/Module/Length.lean
@@ -1,0 +1,96 @@
+import Mathlib.Order.KrullDimension
+import Mathlib.Order.TrimmedLength
+import Mathlib.LinearAlgebra.Span.Basic
+import Mathlib.Data.ENat.Lattice
+import Mathlib.Algebra.Homology.ShortComplex.Basic
+import Mathlib.Order.Hom.Basic
+import Mathlib.Algebra.Category.ModuleCat.Basic
+import Mathlib.Algebra.Homology.ShortComplex.ModuleCat
+import Mathlib.Data.ENat.Lattice
+
+
+
+variable {R : Type*}
+          [Ring R]
+          {M M' : Type*}
+          [AddCommGroup M]
+          [AddCommGroup M']
+          [Module R M]
+          [Module R M']
+
+open Order
+
+variable (R M) in
+open Classical in
+/--
+The length of a module M is defined to be the supremum of lengths of chains of submodules of M. We
+define this using the existing krull dimension api, and as a result this takes values in
+WithBot ℕ∞ in spite of the fact that there is no module with length equal to ⊥.
+-/
+noncomputable
+def Module.length : WithBot ℕ∞ := krullDim (α := Submodule R M)
+
+
+open Classical in
+/--
+The length of a module is greater than or equal to the trimmedLength of any
+rs : RelSeries (α := Submodule R M) (· ≤ ·).
+-/
+theorem RelSeries.moduleLength_ge_trimmedLength
+(rs : RelSeries (α := Submodule R M) (· ≤ ·))
+  : RelSeries.trimmedLength rs ≤ Module.length R M := by
+  rw[← rs.trim_length]
+  rw[Module.length, krullDim]
+  exact le_iSup_iff.mpr fun b a ↦ a rs.trim
+
+
+open Classical in
+  /--
+  The module length is additive in short exact sequences.
+  -/
+    theorem Module.length_additive
+    {S : CategoryTheory.ShortComplex (ModuleCat R)} (hS : S.ShortExact) :
+      Module.length R S.X₂ = Module.length R S.X₁ + Module.length R S.X₃ := by
+    simp only [length, krullDim, le_antisymm_iff, iSup_le_iff]
+    constructor
+    · intro rs
+      trans ↑((RelSeries.submoduleComap rs S.f.hom).trimmedLength +
+             (RelSeries.submoduleMap rs S.g.hom).trimmedLength)
+      · apply Nat.mono_cast
+        have trimmedProof := RelSeries.trimmedLength_additive hS rs
+        rwa[Nat.add_comm] at trimmedProof
+      · have trimleft :=
+          RelSeries.moduleLength_ge_trimmedLength (RelSeries.submoduleComap rs S.f.hom)
+        have trimright :=
+          RelSeries.moduleLength_ge_trimmedLength (RelSeries.submoduleMap rs S.g.hom)
+        exact add_le_add trimleft trimright
+    · rw[WithBot.iSup_le_add]
+      intro rstemp rstemp'
+      obtain ⟨rs, hrs⟩ := RelSeries.exists_ltSeries_ge_head_bot_last_top rstemp
+      obtain ⟨rs', hrs'⟩ := RelSeries.exists_ltSeries_ge_head_bot_last_top rstemp'
+
+      let gInv : RelSeries (fun (a : Submodule R S.X₂) (b : Submodule R S.X₂) => a < b) :=
+        LTSeries.map rs' (Submodule.comap S.g.hom)
+        (Submodule.comap_strictMono_of_surjective hS.moduleCat_surjective_g)
+
+      let fIm : RelSeries (fun (a : Submodule R S.X₂) (b : Submodule R S.X₂) => a < b) :=
+        LTSeries.map rs (Submodule.map S.f.hom)
+        (Submodule.map_strictMono_of_injective hS.moduleCat_injective_f)
+
+      have connect : fIm.last = gInv.head := by
+        convert CategoryTheory.ShortComplex.Exact.moduleCat_range_eq_ker hS.exact
+        · simp only [RelSeries.last, LTSeries.map_length, LTSeries.map_toFun, fIm]
+          have obv : (rs.toFun (Fin.last rs.length)) = ⊤ := hrs.2.2
+          rw[obv]; exact Submodule.map_top S.f.hom
+        · simp only [RelSeries.head, LTSeries.map_toFun, gInv]
+          have obv : rs'.toFun 0 = ⊥ := hrs'.2.1
+          rw[obv]; exact rfl
+
+      let smashfg := RelSeries.smash fIm gInv connect
+      trans ↑smashfg.length
+      · have this' : smashfg.length = rs.length + rs'.length := rfl
+        rw[this']
+        simp only [Nat.cast_add, ge_iff_le]
+        refine add_le_add ?h₁ ?h₂
+        all_goals simp only [Nat.cast_le, hrs.1, hrs'.1]
+      · exact le_iSup_iff.mpr fun b a ↦ a smashfg

--- a/Mathlib/Algebra/Module/Length.lean
+++ b/Mathlib/Algebra/Module/Length.lean
@@ -8,89 +8,79 @@ import Mathlib.Algebra.Category.ModuleCat.Basic
 import Mathlib.Algebra.Homology.ShortComplex.ModuleCat
 import Mathlib.Data.ENat.Lattice
 
+/-!
+# The length of a module
 
+-/
 
-variable {R : Type*}
-          [Ring R]
-          {M M' : Type*}
-          [AddCommGroup M]
-          [AddCommGroup M']
-          [Module R M]
-          [Module R M']
+variable {R : Type*} [Ring R] {M M' : Type*} [AddCommGroup M] [AddCommGroup M']
+variable [Module R M] [Module R M']
 
 open Order
 
 variable (R M) in
-open Classical in
 /--
 The length of a module M is defined to be the supremum of lengths of chains of submodules of M. We
 define this using the existing krull dimension api, and as a result this takes values in
 WithBot ℕ∞ in spite of the fact that there is no module with length equal to ⊥.
 -/
-noncomputable
-def Module.length : WithBot ℕ∞ := krullDim (α := Submodule R M)
-
+noncomputable def Module.length : WithBot ℕ∞ := krullDim (α := Submodule R M)
 
 open Classical in
 /--
 The length of a module is greater than or equal to the trimmedLength of any
 rs : RelSeries (α := Submodule R M) (· ≤ ·).
 -/
-theorem RelSeries.moduleLength_ge_trimmedLength
-(rs : RelSeries (α := Submodule R M) (· ≤ ·))
-  : RelSeries.trimmedLength rs ≤ Module.length R M := by
-  rw[← rs.trim_length]
-  rw[Module.length, krullDim]
+theorem RelSeries.moduleLength_ge_trimmedLength (rs : RelSeries (α := Submodule R M) (· ≤ ·)) :
+    RelSeries.trimmedLength rs ≤ Module.length R M := by
+  rw [← rs.trim_length, Module.length, krullDim]
   exact le_iSup_iff.mpr fun b a ↦ a rs.trim
 
 
 open Classical in
-  /--
-  The module length is additive in short exact sequences.
-  -/
-    theorem Module.length_additive
-    {S : CategoryTheory.ShortComplex (ModuleCat R)} (hS : S.ShortExact) :
-      Module.length R S.X₂ = Module.length R S.X₁ + Module.length R S.X₃ := by
-    simp only [length, krullDim, le_antisymm_iff, iSup_le_iff]
-    constructor
-    · intro rs
-      trans ↑((RelSeries.submoduleComap rs S.f.hom).trimmedLength +
-             (RelSeries.submoduleMap rs S.g.hom).trimmedLength)
-      · apply Nat.mono_cast
-        have trimmedProof := RelSeries.trimmedLength_additive hS rs
-        rwa[Nat.add_comm] at trimmedProof
-      · have trimleft :=
-          RelSeries.moduleLength_ge_trimmedLength (RelSeries.submoduleComap rs S.f.hom)
-        have trimright :=
-          RelSeries.moduleLength_ge_trimmedLength (RelSeries.submoduleMap rs S.g.hom)
-        exact add_le_add trimleft trimright
-    · rw[WithBot.iSup_le_add]
-      intro rstemp rstemp'
-      obtain ⟨rs, hrs⟩ := RelSeries.exists_ltSeries_ge_head_bot_last_top rstemp
-      obtain ⟨rs', hrs'⟩ := RelSeries.exists_ltSeries_ge_head_bot_last_top rstemp'
+/-- The module length is additive in short exact sequences. -/
+theorem Module.length_additive {S : CategoryTheory.ShortComplex (ModuleCat R)} (hS : S.ShortExact) :
+    Module.length R S.X₂ = Module.length R S.X₁ + Module.length R S.X₃ := by
+  simp only [length, krullDim, le_antisymm_iff, iSup_le_iff]
+  constructor
+  · intro rs
+    trans ((RelSeries.submoduleComap rs S.f.hom).trimmedLength +
+            (RelSeries.submoduleMap rs S.g.hom).trimmedLength)
+    · apply Nat.mono_cast
+      have trimmedProof := RelSeries.trimmedLength_additive hS rs
+      rwa [Nat.add_comm] at trimmedProof
+    · have trimleft :=
+        RelSeries.moduleLength_ge_trimmedLength (RelSeries.submoduleComap rs S.f.hom)
+      have trimright :=
+        RelSeries.moduleLength_ge_trimmedLength (RelSeries.submoduleMap rs S.g.hom)
+      exact add_le_add trimleft trimright
+  · rw [WithBot.iSup_le_add]
+    intro rstemp rstemp'
+    obtain ⟨rs, hrs⟩ := RelSeries.exists_ltSeries_ge_head_bot_last_top rstemp
+    obtain ⟨rs', hrs'⟩ := RelSeries.exists_ltSeries_ge_head_bot_last_top rstemp'
 
-      let gInv : RelSeries (fun (a : Submodule R S.X₂) (b : Submodule R S.X₂) => a < b) :=
-        LTSeries.map rs' (Submodule.comap S.g.hom)
-        (Submodule.comap_strictMono_of_surjective hS.moduleCat_surjective_g)
+    let gInv : RelSeries (fun (a : Submodule R S.X₂) (b : Submodule R S.X₂) => a < b) :=
+      LTSeries.map rs' (Submodule.comap S.g.hom)
+      (Submodule.comap_strictMono_of_surjective hS.moduleCat_surjective_g)
 
-      let fIm : RelSeries (fun (a : Submodule R S.X₂) (b : Submodule R S.X₂) => a < b) :=
-        LTSeries.map rs (Submodule.map S.f.hom)
-        (Submodule.map_strictMono_of_injective hS.moduleCat_injective_f)
+    let fIm : RelSeries (fun (a : Submodule R S.X₂) (b : Submodule R S.X₂) => a < b) :=
+      LTSeries.map rs (Submodule.map S.f.hom)
+      (Submodule.map_strictMono_of_injective hS.moduleCat_injective_f)
 
-      have connect : fIm.last = gInv.head := by
-        convert CategoryTheory.ShortComplex.Exact.moduleCat_range_eq_ker hS.exact
-        · simp only [RelSeries.last, LTSeries.map_length, LTSeries.map_toFun, fIm]
-          have obv : (rs.toFun (Fin.last rs.length)) = ⊤ := hrs.2.2
-          rw[obv]; exact Submodule.map_top S.f.hom
-        · simp only [RelSeries.head, LTSeries.map_toFun, gInv]
-          have obv : rs'.toFun 0 = ⊥ := hrs'.2.1
-          rw[obv]; exact rfl
+    have connect : fIm.last = gInv.head := by
+      convert CategoryTheory.ShortComplex.Exact.moduleCat_range_eq_ker hS.exact
+      · simp only [RelSeries.last, LTSeries.map_length, LTSeries.map_toFun, fIm]
+        have obv : (rs.toFun (Fin.last rs.length)) = ⊤ := hrs.2.2
+        rw [obv]; exact Submodule.map_top S.f.hom
+      · simp only [RelSeries.head, LTSeries.map_toFun, gInv]
+        have obv : rs'.toFun 0 = ⊥ := hrs'.2.1
+        rw [obv]; exact rfl
 
-      let smashfg := RelSeries.smash fIm gInv connect
-      trans ↑smashfg.length
-      · have this' : smashfg.length = rs.length + rs'.length := rfl
-        rw[this']
-        simp only [Nat.cast_add, ge_iff_le]
-        refine add_le_add ?h₁ ?h₂
-        all_goals simp only [Nat.cast_le, hrs.1, hrs'.1]
-      · exact le_iSup_iff.mpr fun b a ↦ a smashfg
+    let smashfg := RelSeries.smash fIm gInv connect
+    trans ↑smashfg.length
+    · have this' : smashfg.length = rs.length + rs'.length := rfl
+      rw [this']
+      simp only [Nat.cast_add, ge_iff_le]
+      apply add_le_add
+      all_goals simp only [Nat.cast_le, hrs.1, hrs'.1]
+    · exact le_iSup_iff.mpr fun b a ↦ a smashfg

--- a/Mathlib/Algebra/Module/Submodule/Ker.lean
+++ b/Mathlib/Algebra/Module/Submodule/Ker.lean
@@ -201,7 +201,7 @@ theorem ker_eq_bot {f : M →ₛₗ[τ₁₂] M₂} : ker f = ⊥ ↔ Injective 
   rw [← ker_eq_bot, ker_restrict hf, ← ker_domRestrict, ker_eq_bot, injective_domRestrict_iff,
     disjoint_iff]
 
-theorem ne_map_or_ne_kernel_intersection_of_lt {M' : Type*} [AddCommGroup M'] [Module R M']
+theorem ne_map_or_ne_kernel_inter_of_lt {M' : Type*} [AddCommGroup M'] [Module R M']
     {A B : Submodule R M} (f : M →ₗ[R] M') (hab : A < B) :
     Submodule.map f A ≠ Submodule.map f B ∨ ker f ⊓ A ≠ ker f ⊓ B := by
       by_cases q : ker f ⊓ A ≠ ker f ⊓ B
@@ -216,18 +216,18 @@ theorem ne_map_or_ne_kernel_intersection_of_lt {M' : Type*} [AddCommGroup M'] [M
         suffices x - z ∈ LinearMap.ker f ⊓ A by simpa using add_mem this.2 hz
         exact q ▸ ⟨by simp[hzy], sub_mem hx (hab.le hz)⟩
 
-theorem ker_intersection_mono_of_map_eq {M' : Type*} [AddCommGroup M'] [Module R M']
+theorem ker_inter_mono_of_map_eq {M' : Type*} [AddCommGroup M'] [Module R M']
     {A B : Submodule R M} {f :  M →ₗ[R] M'} (hab : A < B)
     (q : Submodule.map f A = Submodule.map f B) : LinearMap.ker f ⊓ A < LinearMap.ker f ⊓ B :=
       lt_iff_le_and_ne.mpr ⟨inf_le_inf le_rfl hab.le,
-       Or.elim (LinearMap.ne_map_or_ne_kernel_intersection_of_lt f hab)
+       Or.elim (LinearMap.ne_map_or_ne_kernel_inter_of_lt f hab)
         (fun h ↦ False.elim (h q)) (fun h ↦ h)⟩
 
-theorem map_mono_of_ker_intersection_eq {M' : Type*} [AddCommGroup M'] [Module R M']
+theorem map_mono_of_ker_inter_eq {M' : Type*} [AddCommGroup M'] [Module R M']
     {A B : Submodule R M} {f :  M →ₗ[R] M'} (hab : A < B)
     (q : LinearMap.ker f ⊓ A = LinearMap.ker f ⊓ B) : Submodule.map f A < Submodule.map f B :=
       lt_iff_le_and_ne.mpr ⟨Set.image_mono hab.le,
-       Or.elim (LinearMap.ne_map_or_ne_kernel_intersection_of_lt f hab)
+       Or.elim (LinearMap.ne_map_or_ne_kernel_inter_of_lt f hab)
         (fun h ↦ h) (fun h ↦ False.elim (h q))⟩
 
 end Ring

--- a/Mathlib/Algebra/Module/Submodule/Ker.lean
+++ b/Mathlib/Algebra/Module/Submodule/Ker.lean
@@ -201,6 +201,35 @@ theorem ker_eq_bot {f : M →ₛₗ[τ₁₂] M₂} : ker f = ⊥ ↔ Injective 
   rw [← ker_eq_bot, ker_restrict hf, ← ker_domRestrict, ker_eq_bot, injective_domRestrict_iff,
     disjoint_iff]
 
+theorem ne_map_or_ne_kernel_intersection_of_lt {M' : Type*} [AddCommGroup M'] [Module R M']
+    {A B : Submodule R M} (f : M →ₗ[R] M') (hab : A < B) :
+    Submodule.map f A ≠ Submodule.map f B ∨ ker f ⊓ A ≠ ker f ⊓ B := by
+      by_cases q : ker f ⊓ A ≠ ker f ⊓ B
+      · exact Or.inr q
+      · simp only [ne_eq, not_not] at q
+        apply Or.inl
+        intro h
+        apply hab.ne
+        apply le_antisymm hab.le
+        intro x hx
+        obtain ⟨z, hz, hzy⟩ := (h ▸ ⟨x, hx, rfl⟩ : f x ∈ Submodule.map f A)
+        suffices x - z ∈ LinearMap.ker f ⊓ A by simpa using add_mem this.2 hz
+        exact q ▸ ⟨by simp[hzy], sub_mem hx (hab.le hz)⟩
+
+theorem ker_intersection_mono_of_map_eq {M' : Type*} [AddCommGroup M'] [Module R M']
+    {A B : Submodule R M} {f :  M →ₗ[R] M'} (hab : A < B)
+    (q : Submodule.map f A = Submodule.map f B) : LinearMap.ker f ⊓ A < LinearMap.ker f ⊓ B :=
+      lt_iff_le_and_ne.mpr ⟨inf_le_inf le_rfl hab.le,
+       Or.elim (LinearMap.ne_map_or_ne_kernel_intersection_of_lt f hab)
+        (fun h ↦ False.elim (h q)) (fun h ↦ h)⟩
+
+theorem map_mono_of_ker_intersection_eq {M' : Type*} [AddCommGroup M'] [Module R M']
+    {A B : Submodule R M} {f :  M →ₗ[R] M'} (hab : A < B)
+    (q : LinearMap.ker f ⊓ A = LinearMap.ker f ⊓ B) : Submodule.map f A < Submodule.map f B :=
+      lt_iff_le_and_ne.mpr ⟨Set.image_mono hab.le,
+       Or.elim (LinearMap.ne_map_or_ne_kernel_intersection_of_lt f hab)
+        (fun h ↦ h) (fun h ↦ False.elim (h q))⟩
+
 end Ring
 
 section Semifield

--- a/Mathlib/Data/ENat/Lattice.lean
+++ b/Mathlib/Data/ENat/Lattice.lean
@@ -217,5 +217,96 @@ lemma sub_iSup [Nonempty ι] (ha : a ≠ ⊤) : a - ⨆ i, f i = ⨅ i, a - f i 
     iSup_le fun i ↦ ?_
   rw [← ENat.sub_sub_cancel ha (h _)]
   exact tsub_le_tsub_left (iInf_le (a - f ·) i) _
-
 end ENat
+
+namespace WithBot
+
+lemma coe_unbotD_iSup {ι : Sort*} [Nonempty ι] {f : ι → WithBot ℕ∞} (ex : ∃ i, f i ≠ ⊥) :
+    ⨆ i, f i = ⨆ i, (WithBot.unbotD 0 (f i) : ℕ∞) := by
+  rw[WithBot.coe_iSup]
+  · rw[iSup_eq_of_forall_le_of_forall_lt_exists_gt]
+    · intro i
+      by_cases o : (f i = ⊥)
+      · rw[o]; simp
+      · have : ↑(WithBot.unbotD 0 (f i)) = f i := by
+          cases k : (f i)
+          · contradiction
+          · exact rfl
+        rw[← this]
+        exact le_iSup_iff.mpr fun b a ↦ a i
+    · intro w hw
+      obtain ⟨i, hi⟩ := lt_iSup_iff.mp hw
+      by_cases o : (f i = ⊥)
+      · obtain ⟨j, hj⟩ := ex
+        use j
+        have : f j ≥ 0 := by
+          cases k : (f j)
+          · contradiction
+          · simp
+        apply lt_of_lt_of_le (b := 0)
+        · simp[o] at hi
+          assumption
+        · exact this
+      · use i
+        simp_all
+        have : ↑(WithBot.unbotD 0 (f i)) = f i := by
+          cases k : (f i)
+          · contradiction
+          · rename_i a
+            exact rfl
+        rw[←this]
+        exact hi
+  · exact OrderTop.bddAbove (Set.range fun i ↦ WithBot.unbotD 0 (f i))
+
+lemma add_iSup {ι : Sort*} [Nonempty ι] {a : WithBot ℕ∞} (f : ι → WithBot ℕ∞) :
+    a + ⨆ i, f i = ⨆ i, a + f i := by
+  refine le_antisymm ?_ <| iSup_le fun i ↦ add_le_add_left (le_iSup ..) _
+  obtain m | hf := eq_or_ne (⨆ i, f i) ⊥
+  · simp[m]
+  cases a
+  · simp
+  · rename_i a
+    let g : ι → ℕ∞ := fun i ↦ WithBot.unbotD 0 (f i)
+    have h1 : ∀ i, unbotD 0 (f i) = f i ∨ f i = ⊥ := by
+      intro i
+      cases (f i)
+      · exact add_eq_bot.mp rfl
+      · exact unbotD_eq_self_iff.mp rfl
+    have enatStat := ENat.add_iSup (fun i ↦ WithBot.unbotD 0 (f i)) (a := a)
+    simp at hf
+    rw[coe_unbotD_iSup hf]
+    obtain ⟨x, hx⟩ := hf
+    simp[WithBot.ne_bot_iff_exists] at hx
+    obtain ⟨fx, hfx⟩ := hx
+
+    rw[← WithBot.coe_add, enatStat, WithBot.coe_iSup]
+    · simp only [coe_add, iSup_le_iff]
+      intro i
+      obtain h | h := h1 i
+      · rw[h]
+        exact le_iSup_iff.mpr fun b a ↦ a i
+      · simp[h]
+        refine le_iSup_iff.mpr ?_
+        intro b j
+        specialize j x
+        have : unbotD 0 (f x) = f x := by
+          nth_rw 2 [←(WithBot.unbotD_coe 0 (f x))]
+          rw[←hfx]
+          rfl
+        have : f x ≥ 0 := by
+          rw[←hfx]
+          simp[zero_le fx]
+        exact le_trans (b := (↑a + f x)) (le_add_of_nonneg_right this) j
+    · exact OrderTop.bddAbove (Set.range fun i ↦ a + unbotD 0 (f i))
+
+
+lemma iSup_add {ι : Sort*} [Nonempty ι] {a : WithBot ℕ∞} (f : ι → WithBot ℕ∞) :
+    (⨆ i, f i) + a = ⨆ i, f i + a := by simp [add_comm, WithBot.add_iSup]
+
+theorem iSup_le_add {ι ι': Sort*} [Nonempty ι] [Nonempty ι']
+  {f : ι → WithBot ℕ∞} {g : ι' → WithBot ℕ∞} {a : WithBot ℕ∞} :
+iSup f + iSup g ≤ a ↔ ∀ (i: ι) (j : ι'), f i + g j ≤ a := by
+  simp_rw [WithBot.iSup_add, WithBot.add_iSup]
+  exact iSup₂_le_iff
+
+end WithBot

--- a/Mathlib/Data/Set/Basic.lean
+++ b/Mathlib/Data/Set/Basic.lean
@@ -334,6 +334,9 @@ protected theorem ssubset_iff_subset_ne {s t : Set α} : s ⊂ t ↔ s ⊆ t ∧
 theorem ssubset_iff_of_subset {s t : Set α} (h : s ⊆ t) : s ⊂ t ↔ ∃ x ∈ t, x ∉ s :=
   ⟨exists_of_ssubset, fun ⟨_, hxt, hxs⟩ => ⟨h, fun h => hxs <| h hxt⟩⟩
 
+theorem ssubset_iff_exists {s t : Set α} : s ⊂ t ↔ s ⊆ t ∧ ∃ x ∈ t, x ∉ s :=
+  ⟨fun h ↦ ⟨h.le, Set.exists_of_ssubset h⟩, fun ⟨h1, h2⟩ ↦ (Set.ssubset_iff_of_subset h1).mpr h2⟩
+
 protected theorem ssubset_of_ssubset_of_subset {s₁ s₂ s₃ : Set α} (hs₁s₂ : s₁ ⊂ s₂)
     (hs₂s₃ : s₂ ⊆ s₃) : s₁ ⊂ s₃ :=
   ⟨Subset.trans hs₁s₂.1 hs₂s₃, fun hs₃s₁ => hs₁s₂.2 (Subset.trans hs₂s₃ hs₃s₁)⟩

--- a/Mathlib/Data/Set/Image.lean
+++ b/Mathlib/Data/Set/Image.lean
@@ -336,7 +336,7 @@ theorem image_subset_preimage_of_inverse {f : α → β} {g : β → α} (I : Le
 theorem preimage_subset_image_of_inverse {f : α → β} {g : β → α} (I : LeftInverse g f) (s : Set β) :
     f ⁻¹' s ⊆ g '' s := fun b h => ⟨f b, h, I b⟩
 
-theorem range_intersection_ssubset_iff_preimage_ssubset {f : α → β} {S S' : Set β} :
+theorem range_inter_ssubset_iff_preimage_ssubset {f : α → β} {S S' : Set β} :
   range f ∩ S ⊂ range f ∩ S' ↔ f ⁻¹' S ⊂ f ⁻¹' S' := by
     simp only [Set.ssubset_iff_exists]
     apply and_congr ?_ (by aesop)

--- a/Mathlib/Data/Set/Image.lean
+++ b/Mathlib/Data/Set/Image.lean
@@ -340,7 +340,12 @@ theorem range_inter_ssubset_iff_preimage_ssubset {f : α → β} {S S' : Set β}
   range f ∩ S ⊂ range f ∩ S' ↔ f ⁻¹' S ⊂ f ⁻¹' S' := by
     simp only [Set.ssubset_iff_exists]
     apply and_congr ?_ (by aesop)
-    simp [← Set.preimage_subset_preimage_iff (f := f)]
+    constructor
+    all_goals
+      intro r x hx
+      simp_all only [subset_inter_iff, inter_subset_left, true_and, mem_preimage,
+        mem_inter_iff, mem_range, true_and]
+      aesop
 
 theorem image_eq_preimage_of_inverse {f : α → β} {g : β → α} (h₁ : LeftInverse g f)
     (h₂ : RightInverse g f) : image f = preimage g :=

--- a/Mathlib/Data/Set/Image.lean
+++ b/Mathlib/Data/Set/Image.lean
@@ -339,13 +339,8 @@ theorem preimage_subset_image_of_inverse {f : α → β} {g : β → α} (I : Le
 theorem range_intersection_ssubset_iff_preimage_ssubset {f : α → β} {S S' : Set β} :
   range f ∩ S ⊂ range f ∩ S' ↔ f ⁻¹' S ⊂ f ⁻¹' S' := by
     simp only [Set.ssubset_iff_exists]
-    apply and_congr (?_) (by aesop)
-    constructor
-    all_goals
-      intro r x hx
-      simp_all only [subset_inter_iff, inter_subset_left, true_and, mem_preimage,
-        mem_inter_iff, mem_range, true_and]
-      aesop
+    apply and_congr ?_ (by aesop)
+    simp [← Set.preimage_subset_preimage_iff (f := f)]
 
 theorem image_eq_preimage_of_inverse {f : α → β} {g : β → α} (h₁ : LeftInverse g f)
     (h₂ : RightInverse g f) : image f = preimage g :=

--- a/Mathlib/Data/Set/Image.lean
+++ b/Mathlib/Data/Set/Image.lean
@@ -336,6 +336,17 @@ theorem image_subset_preimage_of_inverse {f : α → β} {g : β → α} (I : Le
 theorem preimage_subset_image_of_inverse {f : α → β} {g : β → α} (I : LeftInverse g f) (s : Set β) :
     f ⁻¹' s ⊆ g '' s := fun b h => ⟨f b, h, I b⟩
 
+theorem range_intersection_ssubset_iff_preimage_ssubset {f : α → β} {S S' : Set β} :
+  range f ∩ S ⊂ range f ∩ S' ↔ f ⁻¹' S ⊂ f ⁻¹' S' := by
+    simp only [Set.ssubset_iff_exists]
+    apply and_congr (?_) (by aesop)
+    constructor
+    all_goals
+      intro r x hx
+      simp_all only [subset_inter_iff, inter_subset_left, true_and, mem_preimage,
+        mem_inter_iff, mem_range, true_and]
+      aesop
+
 theorem image_eq_preimage_of_inverse {f : α → β} {g : β → α} (h₁ : LeftInverse g f)
     (h₂ : RightInverse g f) : image f = preimage g :=
   funext fun s =>

--- a/Mathlib/LinearAlgebra/Span/Basic.lean
+++ b/Mathlib/LinearAlgebra/Span/Basic.lean
@@ -468,6 +468,7 @@ theorem map_iInf_of_ker_le {f : F} (hf : Surjective f) {ι} {p : ι → Submodul
   conv_rhs => rw [← map_comap_eq_of_surjective hf (⨅ _, _), comap_iInf]
   simp_rw [fun i ↦ comap_map_eq_self (le_iInf_iff.mp h i)]
 
+
 lemma _root_.LinearMap.range_domRestrict_eq_range_iff {f : M →ₛₗ[τ₁₂] M₂} {S : Submodule R M} :
     LinearMap.range (f.domRestrict S) = LinearMap.range f ↔ S ⊔ (LinearMap.ker f) = ⊤ := by
   refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
@@ -645,6 +646,33 @@ theorem isIdempotentElem_apply_one_iff {f : Module.End R R} :
   exact ⟨fun h r ↦ by rw [← mul_one r, ← smul_eq_mul, map_smul, map_smul, h], (· 1)⟩
 
 end
+
+section AddCommGroup
+
+variable {R M M' : Type*}
+         [Ring R]
+         [AddCommGroup M]
+         [AddCommGroup M']
+         [Module R M]
+         [Module R M']
+         {A B : Submodule R M}
+
+theorem map_lt_map_or (f : M →ₗ[R] M') (hab : A < B) :
+    Submodule.map f A < Submodule.map f B ∨ LinearMap.ker f ⊓ A < LinearMap.ker f ⊓ B := by
+  obtain (⟨h, -⟩ | ⟨-, h⟩) := Prod.mk_lt_mk.mp <| strictMono_inf_prod_sup (z := LinearMap.ker f) hab
+  · exact .inr <| by simpa [inf_comm]
+  · simp_rw [← Submodule.comap_map_eq] at h
+    exact Or.inl <| lt_of_le_of_ne (Submodule.map_mono hab.le) fun _ ↦ h.ne <| by congr
+
+theorem ker_inf_lt_ker_inf {f :  M →ₗ[R] M'} (hab : A < B)
+    (q : Submodule.map f A = Submodule.map f B) : LinearMap.ker f ⊓ A < LinearMap.ker f ⊓ B :=
+  f.map_lt_map_or hab |>.resolve_left q.not_lt
+
+theorem map_lt_map_of_ker_inf_eq {f :  M →ₗ[R] M'} (hab : A < B)
+    (q : LinearMap.ker f ⊓ A = LinearMap.ker f ⊓ B) : Submodule.map f A < Submodule.map f B :=
+  f.map_lt_map_or hab |>.resolve_right q.not_lt
+
+end AddCommGroup
 
 section AddCommMonoid
 

--- a/Mathlib/Order/RelSeries.lean
+++ b/Mathlib/Order/RelSeries.lean
@@ -73,6 +73,10 @@ lemma rel_or_eq_of_le [IsTrans α r] (x : RelSeries r) {i j : Fin (x.length + 1)
     r (x i) (x j) ∨ x i = x j :=
   (Fin.lt_or_eq_of_le h).imp (x.rel_of_lt ·) (by rw [·])
 
+lemma rel_of_le [IsTrans α r] [IsRefl α r] (x : RelSeries r)
+  {i j : Fin (x.length + 1)} (h : i ≤ j) : r (x i) (x j) :=
+  Or.casesOn (rel_or_eq_of_le x h) (by tauto) (by intro l; rw[l]; apply refl)
+
 /--
 Given two relations `r, s` on `α` such that `r ≤ s`, any relation series of `r` induces a relation
 series of `s`

--- a/Mathlib/Order/TrimmedLength.lean
+++ b/Mathlib/Order/TrimmedLength.lean
@@ -1,0 +1,249 @@
+/-
+Copyright (c) 2025 Raphael Douglas Giles. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Raphael Douglas Giles
+-/
+
+import Mathlib
+
+/-!
+# Trimmed Length
+
+Given a relseries rs : RelSeries (· ≤ ·), we define the trimmed length of rs to be the cardinality
+of the underlying function rs.toFun of rs minus 1. This models the number of `<` relations occuring
+in rs. In this file we develop the main API for working with the trimmed length.
+
+-/
+
+open Order
+
+variable {α : Type*}
+/--
+Given a relseries rs : RelSeries (α := α) r with transitive and reflixive r, i ≤ j implies
+r (rs i) (rs j)
+-/
+theorem RelSeries.map_le {r : Rel α α} [IsTrans α r] [IsRefl α r] (rs : RelSeries (α := α) r)
+  {i j : Fin (rs.length + 1)}
+  (hij : i ≤ j) : r (rs i) (rs j) := by
+    have := rel_or_eq_of_le rs hij
+    cases this
+    · assumption
+    · rename_i h
+      rw[h]
+      apply refl (r := r)
+
+variable [PartialOrder α] [DecidableEq α]
+  (rs : RelSeries (α := α) (· ≤ ·))
+
+/--
+Given (rs : RelSeries (α := α) (· ≤ ·)), rs.trimmedLength measures the number of `<`s appearing
+in rs defined as the image of the underlying function of rs, rs.toFun.
+-/
+def RelSeries.trimmedLength (rs : RelSeries (α := α) (· ≤ ·)) : ℕ :=
+  (Finset.image rs.toFun Finset.univ).card - 1
+
+/--
+The trimmed length of a relseries is bounded by the length of that relseries.
+-/
+lemma RelSeries.trimmedLength_le_length : rs.trimmedLength ≤ rs.length := by
+  simp only [RelSeries.trimmedLength, tsub_le_iff_right]
+  have := Finset.card_image_le (f := rs.toFun) (s := .univ)
+  simp only [Finset.card_univ, Fintype.card_fin] at this
+  exact this
+
+/--
+The length of a relseries rs is equal to the trimmed length if and only if the underlying function
+of rs (i.e. rs.toFun) is injective.
+-/
+lemma RelSeries.length_eq_trimmedLength_iff :
+  rs.length = rs.trimmedLength ↔ rs.toFun.Injective := by
+  constructor
+  · intro h
+    simp[RelSeries.trimmedLength] at h
+    have := Finset.card_image_iff (s := .univ) (f := rs.toFun)
+    simp_all only [Finset.card_univ, Finset.one_le_card,
+      Finset.image_nonempty, Finset.univ_nonempty,
+      Nat.sub_add_cancel, Fintype.card_fin, Finset.coe_univ, true_iff]
+    exact fun ⦃a₁ a₂⦄ ↦ this trivial trivial
+  · intro h
+    apply antisymm (r := (· ≤ ·))
+    · have := Finset.card_le_card_of_injOn (s := .univ) (t := Finset.image rs.toFun Finset.univ)
+        rs.toFun (by simp) h.injOn
+      simp at this
+      simp[RelSeries.trimmedLength]
+      omega
+    · exact RelSeries.trimmedLength_le_length rs
+
+variable {rs} in
+/--
+If rs has length greater than 0, there must be some index i such that rs i.castSucc < rs i.succ
+-/
+theorem RelSeries.trimmedLength_exists_le
+(hrs : rs.trimmedLength > 0) : ∃ (i : Fin rs.length), rs i.castSucc < rs i.succ := by
+  contrapose! hrs
+  replace hrs (i : Fin rs.length) : rs.toFun i.castSucc = rs.toFun i.succ :=
+    eq_of_le_of_not_lt (rs.step i) (hrs i)
+  have H (i) : rs i = rs 0 := by
+    induction' i using Fin.induction with m ih
+    · rfl
+    · rwa [← hrs m]
+  unfold RelSeries.trimmedLength
+  suffices Finset.image rs.toFun Finset.univ = {rs.toFun 0} by simp [this]
+  suffices rs.toFun = fun i ↦ rs.toFun 0 by
+    rw[this, Finset.image_const]
+    use 0
+    simp
+  ext : 1
+  apply H
+
+
+variable {rs} in
+/--
+If the last two elements of rs are equal, then rs.trimmedLength = rs.eraseLast.trimmedLength. Note
+that if rs only has one element, the "last two elements" are both just the unique element of rs.
+-/
+theorem RelSeries.trimmedLength_eraseLast_of_eq
+  (lasteq : ∃ i : Fin (rs.length), rs.toFun i.castSucc = rs.toFun i.succ ∧ (i + 1 : ℕ) = rs.length)
+  : rs.trimmedLength = rs.eraseLast.trimmedLength := by
+    simp only [trimmedLength, eraseLast_length]
+    congr 2
+    apply le_antisymm
+    · intro x hx
+      simp only [Finset.mem_image, Finset.mem_univ, eraseLast_toFun, true_and] at hx ⊢
+      obtain ⟨i, rfl⟩ := hx
+      by_cases hi : i = Fin.last _
+      · obtain ⟨j, hj1, hj2⟩ := lasteq
+        use j.cast (m := rs.length - 1 + 1) (by omega)
+        subst i
+        convert hj1 using 2
+        ext
+        exact hj2.symm
+      · use (i.castPred hi).cast (m := rs.length - 1 + 1) (by omega)
+        rfl
+    · intro x hx
+      simp only [Finset.mem_image, Finset.mem_univ, eraseLast_toFun, true_and] at hx ⊢
+      obtain ⟨i, rfl⟩ := hx
+      exact ⟨_, rfl⟩
+
+
+variable {rs} in
+/--
+If the last two elements a, b of rs satisfy a < b, then
+rs.trimmedLength = rs.eraseLast.trimmedLength. Note that if rs only has one element,
+the "last two elements" are both just the unique element of rs.
+In this case the condition is vacuous.
+-/
+theorem RelSeries.trimmedLength_eraseLast_of_lt
+    (lastlt : ∃ i : Fin (rs.length), rs i.castSucc < rs i.succ ∧ (i + 1:ℕ) = rs.length)
+    : rs.trimmedLength = rs.eraseLast.trimmedLength + 1 := by
+      simp only [trimmedLength, eraseLast_length, Finset.one_le_card, Finset.image_nonempty,
+        Finset.univ_nonempty, Nat.sub_add_cancel]
+      obtain ⟨i, hi1, hi2⟩ := lastlt
+      suffices (Finset.image rs.toFun Finset.univ).card =
+               (Finset.image rs.eraseLast.toFun Finset.univ ∪ {rs.toFun i.succ}).card by
+        simp_all only [eraseLast_length]
+        rw[Finset.card_union_of_disjoint]
+        · simp
+        · simp only [Finset.disjoint_singleton_right, Finset.mem_image, Finset.mem_univ,
+          eraseLast_toFun, true_and, not_exists]
+          intro x
+          suffices rs.toFun ⟨↑x, by omega⟩ < rs.toFun i.succ by exact ne_of_lt this
+          apply LT.lt.trans_le' (b := rs.toFun i.castSucc)
+          · exact hi1
+          · apply rs.map_le
+            apply Fin.mk_le_of_le_val
+            simp only [Fin.coe_castSucc]; omega
+      congr
+      apply le_antisymm
+      · intro x hx
+        simp only [Finset.mem_image, Finset.mem_univ, eraseLast_toFun, true_and] at hx ⊢
+        obtain ⟨j, rfl⟩ := hx
+        by_cases hj : j = i.succ
+        · simp only [eraseLast_length, Finset.mem_union, Finset.mem_image, Finset.mem_univ,
+          eraseLast_toFun, true_and, Finset.mem_singleton]
+          apply Or.inr
+          rw[hj]
+        · simp only [eraseLast_length, Finset.mem_union, Finset.mem_image, Finset.mem_univ,
+          eraseLast_toFun, true_and, Finset.mem_singleton]
+          apply Or.inl
+          have hj' : j ≠ Fin.last rs.length := by
+            have : i.succ = Fin.last _ := by
+              exact Eq.symm (Fin.eq_of_val_eq (id (Eq.symm hi2)))
+            rw[← this]
+            exact hj
+          use (j.castPred hj').cast (m := rs.length - 1 + 1) (by omega)
+          rfl
+      · intro x hx
+        simp only [eraseLast_length, Finset.mem_union, Finset.mem_image, Finset.mem_univ,
+          eraseLast_toFun, true_and, Finset.mem_singleton] at hx
+        obtain h | h := hx
+        · simp only [Finset.mem_image, Finset.mem_univ, eraseLast_toFun, true_and] at h ⊢
+          obtain ⟨i, rfl⟩ := h
+          exact ⟨_, rfl⟩
+        · simp[h]
+
+
+/--
+The trimmed length of rs.eraseLast is less than or equal to the trimmed length of rs
+-/
+theorem RelSeries.trimmedLength_eraseLast_le :
+  rs.eraseLast.trimmedLength ≤ rs.trimmedLength := by
+    by_cases h : ∃ i : Fin rs.length, rs.toFun i.castSucc = rs.toFun i.succ ∧ ↑i + 1 = rs.length
+    · exact Nat.le_of_eq (id (Eq.symm (rs.trimmedLength_eraseLast_of_eq h)))
+    · by_cases nontriv : rs.length = 0
+      · simp_all only [AddLeftCancelMonoid.add_eq_zero, one_ne_zero, and_false, exists_false,
+        not_false_eq_true]
+        have : rs.eraseLast = rs := by aesop
+        exact Nat.le_of_eq (congrArg trimmedLength this)
+      have : ∃ i : Fin rs.length, rs.toFun i.castSucc < rs.toFun i.succ ∧ ↑i + 1 = rs.length := by
+        simp_all only [not_exists, not_and]
+        let secondlast : Fin rs.length := ⟨rs.length - 1, by omega⟩
+        use secondlast
+        specialize h secondlast
+        have neq : rs secondlast.succ ≠ rs secondlast.castSucc := by
+          contrapose h
+          simp_all only [ne_eq, Decidable.not_not, forall_const, secondlast]
+          omega
+        have := rs.step secondlast
+        constructor
+        · apply lt_of_le_of_ne
+          · exact this
+          · exact id (Ne.symm neq)
+        · exact Nat.succ_pred_eq_of_ne_zero nontriv
+      have := rs.trimmedLength_eraseLast_of_lt this
+      omega
+
+variable [DecidableRel (α := α) (· ≤ ·)]
+
+instance (rs : RelSeries (α := α) (· ≤ ·)) :
+  LinearOrder { x // x ∈ Finset.image rs.toFun Finset.univ } where
+    __ := Subtype.partialOrder _
+    le_total := by
+      rintro ⟨a, ha⟩ ⟨b, hb⟩
+      simp only [Finset.mem_image, Finset.mem_univ, true_and] at ha hb
+      obtain ⟨i, rfl⟩ := ha
+      obtain ⟨j, rfl⟩ := hb
+      simp only [Subtype.mk_le_mk]
+      exact (le_total i j).imp (RelSeries.map_le rs) (RelSeries.map_le rs)
+    decidableLE := inferInstance
+
+/--
+Constructs LTSeries associated to a given RelSeries (α := α) (· ≤ ·) constructed by
+taking only those places where the relation is not equality.
+-/
+def RelSeries.trim (rs : RelSeries (α := α) (· ≤ ·)) :
+ RelSeries (α := α) (· < ·) where
+   length := rs.trimmedLength
+   toFun := by
+    refine Subtype.val ∘ monoEquivOfFin (Finset.image rs.toFun Finset.univ) ?_
+    simp[RelSeries.trimmedLength]
+   step := by
+    intro i
+    simp
+
+/--
+The length of the rs.trim is equal to the trimmed length of rs.
+-/
+lemma RelSeries.length_trim (rs : RelSeries (α := α) (· ≤ ·)) :
+  rs.trim.length = rs.trimmedLength := by
+    simp[trim]

--- a/Mathlib/Order/TrimmedLength.lean
+++ b/Mathlib/Order/TrimmedLength.lean
@@ -4,11 +4,10 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Raphael Douglas Giles
 -/
 
-import Mathlib.Algebra.Module.Submodule.Lattice
+import Mathlib.Algebra.Order.Sub.Basic
+import Mathlib.Order.RelSeries
 import Mathlib.Data.Fintype.Sort
-import Mathlib.Order.Category.NonemptyFinLinOrd
-import Mathlib.Order.CompletePartialOrder
-import Mathlib.Order.KrullDimension
+
 
 /-!
 

--- a/Mathlib/Order/TrimmedLength.lean
+++ b/Mathlib/Order/TrimmedLength.lean
@@ -4,7 +4,11 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Raphael Douglas Giles
 -/
 
-import Mathlib
+import Mathlib.Algebra.Module.Submodule.Lattice
+import Mathlib.Data.Fintype.Sort
+import Mathlib.Order.Category.NonemptyFinLinOrd
+import Mathlib.Order.CompletePartialOrder
+import Mathlib.Order.KrullDimension
 
 /-!
 

--- a/Mathlib/Order/TrimmedLength.lean
+++ b/Mathlib/Order/TrimmedLength.lean
@@ -7,6 +7,7 @@ Authors: Raphael Douglas Giles
 import Mathlib
 
 /-!
+
 # Trimmed Length
 
 Given a relseries rs : RelSeries (· ≤ ·), we define the trimmed length of rs to be the cardinality
@@ -18,19 +19,7 @@ in rs. In this file we develop the main API for working with the trimmed length.
 open Order
 
 variable {α : Type*}
-/--
-Given a relseries rs : RelSeries (α := α) r with transitive and reflixive r, i ≤ j implies
-r (rs i) (rs j)
--/
-theorem RelSeries.map_le {r : Rel α α} [IsTrans α r] [IsRefl α r] (rs : RelSeries (α := α) r)
-  {i j : Fin (rs.length + 1)}
-  (hij : i ≤ j) : r (rs i) (rs j) := by
-    have := rel_or_eq_of_le rs hij
-    cases this
-    · assumption
-    · rename_i h
-      rw[h]
-      apply refl (r := r)
+
 
 variable [PartialOrder α] [DecidableEq α]
   (rs : RelSeries (α := α) (· ≤ ·))
@@ -150,7 +139,7 @@ theorem RelSeries.trimmedLength_eraseLast_of_lt
           suffices rs.toFun ⟨↑x, by omega⟩ < rs.toFun i.succ by exact ne_of_lt this
           apply LT.lt.trans_le' (b := rs.toFun i.castSucc)
           · exact hi1
-          · apply rs.map_le
+          · apply rs.rel_of_le
             apply Fin.mk_le_of_le_val
             simp only [Fin.coe_castSucc]; omega
       congr
@@ -224,7 +213,7 @@ instance (rs : RelSeries (α := α) (· ≤ ·)) :
       obtain ⟨i, rfl⟩ := ha
       obtain ⟨j, rfl⟩ := hb
       simp only [Subtype.mk_le_mk]
-      exact (le_total i j).imp (RelSeries.map_le rs) (RelSeries.map_le rs)
+      exact (le_total i j).imp (RelSeries.rel_of_le rs) (RelSeries.rel_of_le rs)
     decidableLE := inferInstance
 
 /--

--- a/Mathlib/Order/TrimmedLength.lean
+++ b/Mathlib/Order/TrimmedLength.lean
@@ -13,9 +13,9 @@ import Mathlib.Data.Fintype.Sort
 
 # Trimmed Length
 
-Given a relseries rs : RelSeries (· ≤ ·), we define the trimmed length of rs to be the cardinality
-of the underlying function rs.toFun of rs minus 1. This models the number of `<` relations occuring
-in rs. In this file we develop the main API for working with the trimmed length.
+Given a relseries `rs : RelSeries (· ≤ ·)`, we define the trimmed length of `rs` to be the
+cardinality of the underlying function `rs.toFun` of `rs` minus `1`. This models the number of `<`
+relations occuring in `rs`. In this file we develop the main API for working with the trimmed length
 
 -/
 
@@ -28,8 +28,8 @@ variable [PartialOrder α] [DecidableEq α]
   (rs : RelSeries (α := α) (· ≤ ·))
 
 /--
-Given (rs : RelSeries (α := α) (· ≤ ·)), rs.trimmedLength measures the number of `<`s appearing
-in rs defined as the image of the underlying function of rs, rs.toFun.
+Given `rs : RelSeries (α := α) (· ≤ ·)`,  `rs.trimmedLength` measures the number of `<`s appearing
+in `rs` defined as the image of the underlying function of `rs`, i.e. `rs.toFun`.
 -/
 def RelSeries.trimmedLength (rs : RelSeries (α := α) (· ≤ ·)) : ℕ :=
   (Finset.image rs.toFun Finset.univ).card - 1
@@ -44,14 +44,14 @@ lemma RelSeries.trimmedLength_le_length : rs.trimmedLength ≤ rs.length := by
   exact this
 
 /--
-The length of a relseries rs is equal to the trimmed length if and only if the underlying function
-of rs (i.e. rs.toFun) is injective.
+The length of a relseries `rs` is equal to the trimmed length if and only if the underlying function
+of `rs` (i.e. `rs.toFun`) is injective.
 -/
 lemma RelSeries.length_eq_trimmedLength_iff :
   rs.length = rs.trimmedLength ↔ rs.toFun.Injective := by
   constructor
   · intro h
-    simp[RelSeries.trimmedLength] at h
+    simp only [trimmedLength] at h
     have := Finset.card_image_iff (s := .univ) (f := rs.toFun)
     simp_all only [Finset.card_univ, Finset.one_le_card,
       Finset.image_nonempty, Finset.univ_nonempty,
@@ -61,14 +61,14 @@ lemma RelSeries.length_eq_trimmedLength_iff :
     apply antisymm (r := (· ≤ ·))
     · have := Finset.card_le_card_of_injOn (s := .univ) (t := Finset.image rs.toFun Finset.univ)
         rs.toFun (by simp) h.injOn
-      simp at this
-      simp[RelSeries.trimmedLength]
+      simp only [Finset.card_univ, Fintype.card_fin, trimmedLength, ge_iff_le] at this ⊢
       omega
     · exact RelSeries.trimmedLength_le_length rs
 
 variable {rs} in
 /--
-If rs has length greater than 0, there must be some index i such that rs i.castSucc < rs i.succ
+If `rs` has length greater than `0`, there must be some index `i` such that
+`rs i.castSucc < rs i.succ`.
 -/
 theorem RelSeries.trimmedLength_exists_le
 (hrs : rs.trimmedLength > 0) : ∃ (i : Fin rs.length), rs i.castSucc < rs i.succ := by
@@ -91,8 +91,9 @@ theorem RelSeries.trimmedLength_exists_le
 
 variable {rs} in
 /--
-If the last two elements of rs are equal, then rs.trimmedLength = rs.eraseLast.trimmedLength. Note
-that if rs only has one element, the "last two elements" are both just the unique element of rs.
+If the last two elements of `rs` are equal, then `rs.trimmedLength = rs.eraseLast.trimmedLength`.
+Note that if `rs` only has one element, the "last two elements" are both just the unique element of
+`rs`.
 -/
 theorem RelSeries.trimmedLength_eraseLast_of_eq
   (lasteq : ∃ i : Fin (rs.length), rs.toFun i.castSucc = rs.toFun i.succ ∧ (i + 1 : ℕ) = rs.length)
@@ -120,9 +121,9 @@ theorem RelSeries.trimmedLength_eraseLast_of_eq
 
 variable {rs} in
 /--
-If the last two elements a, b of rs satisfy a < b, then
-rs.trimmedLength = rs.eraseLast.trimmedLength. Note that if rs only has one element,
-the "last two elements" are both just the unique element of rs.
+If the last two elements `a, b` of `rs` satisfy `a < b`, then
+`rs.trimmedLength = rs.eraseLast.trimmedLength`. Note that if `rs` only has one element,
+the "last two elements" are both just the unique element of `rs`.
 In this case the condition is vacuous.
 -/
 theorem RelSeries.trimmedLength_eraseLast_of_lt
@@ -139,7 +140,7 @@ theorem RelSeries.trimmedLength_eraseLast_of_lt
         · simp only [Finset.disjoint_singleton_right, Finset.mem_image, Finset.mem_univ,
           eraseLast_toFun, true_and, not_exists]
           intro x
-          suffices rs.toFun ⟨↑x, by omega⟩ < rs.toFun i.succ by exact ne_of_lt this
+          suffices rs.toFun ⟨↑x, by omega⟩ < rs.toFun i.succ from ne_of_lt this
           apply LT.lt.trans_le' (b := rs.toFun i.castSucc)
           · exact hi1
           · apply rs.rel_of_le
@@ -158,12 +159,8 @@ theorem RelSeries.trimmedLength_eraseLast_of_lt
         · simp only [eraseLast_length, Finset.mem_union, Finset.mem_image, Finset.mem_univ,
           eraseLast_toFun, true_and, Finset.mem_singleton]
           apply Or.inl
-          have hj' : j ≠ Fin.last rs.length := by
-            have : i.succ = Fin.last _ := by
-              exact Eq.symm (Fin.eq_of_val_eq (id (Eq.symm hi2)))
-            rw[← this]
-            exact hj
-          use (j.castPred hj').cast (m := rs.length - 1 + 1) (by omega)
+          use (j.castPred (ne_of_ne_of_eq hj ((Fin.eq_of_val_eq hi2) : i.succ = Fin.last _))).cast
+           (m := rs.length - 1 + 1) (by omega)
           rfl
       · intro x hx
         simp only [eraseLast_length, Finset.mem_union, Finset.mem_image, Finset.mem_univ,
@@ -176,7 +173,7 @@ theorem RelSeries.trimmedLength_eraseLast_of_lt
 
 
 /--
-The trimmed length of rs.eraseLast is less than or equal to the trimmed length of rs
+The trimmed length of `rs.eraseLast` is less than or equal to the trimmed length of `rs`.
 -/
 theorem RelSeries.trimmedLength_eraseLast_le :
   rs.eraseLast.trimmedLength ≤ rs.trimmedLength := by
@@ -220,22 +217,15 @@ instance (rs : RelSeries (α := α) (· ≤ ·)) :
     decidableLE := inferInstance
 
 /--
-Constructs LTSeries associated to a given RelSeries (α := α) (· ≤ ·) constructed by
+Constructs the `LTSeries` associated to a given `RelSeries (α := α) (· ≤ ·)` constructed by
 taking only those places where the relation is not equality.
 -/
+@[simps]
 def RelSeries.trim (rs : RelSeries (α := α) (· ≤ ·)) :
  RelSeries (α := α) (· < ·) where
    length := rs.trimmedLength
-   toFun := by
-    refine Subtype.val ∘ monoEquivOfFin (Finset.image rs.toFun Finset.univ) ?_
-    simp[RelSeries.trimmedLength]
+   toFun := Subtype.val ∘ monoEquivOfFin (Finset.image rs.toFun Finset.univ)
+    (by simp[RelSeries.trimmedLength])
    step := by
     intro i
     simp
-
-/--
-The length of the rs.trim is equal to the trimmed length of rs.
--/
-lemma RelSeries.length_trim (rs : RelSeries (α := α) (· ≤ ·)) :
-  rs.trim.length = rs.trimmedLength := by
-    simp[trim]


### PR DESCRIPTION
In this PR, we define the module length to be the krull dimension of the lattice of submodules and prove that it is additive in short exact sequences. Relies on #22069, #22036 and #21869

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

- [x] depends on: #22036 
- [ ] depends on: #22069 
- [x] depends on: #21869 
