### PR TITLE
[Merged by Bors] - chore: simplify a proof

### DIFF
--- a/Mathlib/Algebra/MvPolynomial/Basic.lean
+++ b/Mathlib/Algebra/MvPolynomial/Basic.lean
@@ -147,6 +147,8 @@ variable [CommSemiring R] [CommSemiring S₁] {p q : MvPolynomial σ R}
 def monomial (s : σ →₀ ℕ) : R →ₗ[R] MvPolynomial σ R :=
   AddMonoidAlgebra.lsingle s
 
+theorem one_def : (1 : MvPolynomial σ R) = monomial 0 1 := rfl
+
 theorem single_eq_monomial (s : σ →₀ ℕ) (a : R) : Finsupp.single s a = monomial s a :=
   rfl
 

--- a/Mathlib/RingTheory/MvPolynomial/MonomialOrder.lean
+++ b/Mathlib/RingTheory/MvPolynomial/MonomialOrder.lean
@@ -165,11 +165,9 @@ theorem degree_X [Nontrivial R] {s : σ} :
   change m.degree (monomial (Finsupp.single s 1) (1 : R)) = _
   rw [degree_monomial, if_neg one_ne_zero]
 
-@[nontriviality, simp] theorem degree_one : m.degree (1 : MvPolynomial σ R) = 0 := by
+@[simp] theorem degree_one : m.degree (1 : MvPolynomial σ R) = 0 := by
   nontriviality R
-  change m.degree (monomial 0 1) = 0
-  classical
-  rw [degree_monomial]
+  classical rw [MvPolynomial.one_def, degree_monomial]
   simp
 
 @[simp]

--- a/Mathlib/RingTheory/MvPolynomial/MonomialOrder.lean
+++ b/Mathlib/RingTheory/MvPolynomial/MonomialOrder.lean
@@ -165,13 +165,12 @@ theorem degree_X [Nontrivial R] {s : σ} :
   change m.degree (monomial (Finsupp.single s 1) (1 : R)) = _
   rw [degree_monomial, if_neg one_ne_zero]
 
-@[simp] theorem degree_one : m.degree (1 : MvPolynomial σ R) = 0 := by
-  obtain h | h' := subsingleton_or_nontrivial R
-  · rw [Subsingleton.eq_zero 1, degree_zero]
-  · change m.degree (monomial 0 1) = 0
-    classical
-    rw [degree_monomial]
-    simp
+@[nontriviality, simp] theorem degree_one : m.degree (1 : MvPolynomial σ R) = 0 := by
+  nontriviality R
+  change m.degree (monomial 0 1) = 0
+  classical
+  rw [degree_monomial]
+  simp
 
 @[simp]
 theorem leadingCoeff_monomial {d : σ →₀ ℕ} (c : R) :


### PR DESCRIPTION
This simplifies a proof, as suggested by @acmepjz  just after the preceding PR was merged.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
