### PR TITLE
[Merged by Bors] - chore: backport changes to `getElem` lemmas

### DIFF
--- a/Mathlib/Algebra/BigOperators/Group/List/Basic.lean
+++ b/Mathlib/Algebra/BigOperators/Group/List/Basic.lean
@@ -137,13 +137,16 @@ theorem prod_set :
 
 /-- We'd like to state this as `L.headI * L.tail.prod = L.prod`, but because `L.headI` relies on an
 inhabited instance to return a garbage value on the empty list, this is not possible.
-Instead, we write the statement in terms of `(L.get? 0).getD 1`.
+Instead, we write the statement in terms of `L[0]?.getD 1`.
 -/
 @[to_additive "We'd like to state this as `L.headI + L.tail.sum = L.sum`, but because `L.headI`
   relies on an inhabited instance to return a garbage value on the empty list, this is not possible.
-  Instead, we write the statement in terms of `(L.get? 0).getD 0`."]
-theorem get?_zero_mul_tail_prod (l : List M) : (l.get? 0).getD 1 * l.tail.prod = l.prod := by
+  Instead, we write the statement in terms of `L[0]?.getD 0`."]
+theorem getElem?_zero_mul_tail_prod (l : List M) : l[0]?.getD 1 * l.tail.prod = l.prod := by
   cases l <;> simp
+
+@[deprecated (since := "2025-02-15")] alias get?_zero_mul_tail_prod := getElem?_zero_mul_tail_prod
+@[deprecated (since := "2025-02-15")] alias get?_zero_add_tail_sum := getElem?_zero_add_tail_sum
 
 /-- Same as `get?_zero_mul_tail_prod`, but avoiding the `List.headI` garbage complication by
   requiring the list to be nonempty. -/

--- a/Mathlib/Data/List/Basic.lean
+++ b/Mathlib/Data/List/Basic.lean
@@ -452,9 +452,11 @@ theorem head!_mem_self [Inhabited α] {l : List α} (h : l ≠ nil) : l.head! �
   have h' := mem_cons_self l.head! l.tail
   rwa [cons_head!_tail h] at h'
 
-theorem get_eq_get? (l : List α) (i : Fin l.length) :
-    l.get i = (l.get? i).get (by simp [getElem?_eq_getElem]) := by
+theorem get_eq_getElem? (l : List α) (i : Fin l.length) :
+    l.get i = l[i]?.get (by simp [getElem?_eq_getElem]) := by
   simp
+
+@[deprecated (since := "2025-02-15")] alias get_eq_get? := get_eq_getElem?
 
 theorem exists_mem_iff_getElem {l : List α} {p : α → Prop} :
     (∃ x ∈ l, p x) ↔ ∃ (i : ℕ) (_ : i < l.length), p l[i] := by
@@ -609,16 +611,21 @@ theorem get_length_sub_one {l : List α} (h : l.length - 1 < l.length) :
     l.get ⟨l.length - 1, h⟩ = l.getLast (by rintro rfl; exact Nat.lt_irrefl 0 h) :=
   (getLast_eq_getElem l _).symm
 
-theorem ext_get?' {l₁ l₂ : List α} (h' : ∀ n < max l₁.length l₂.length, l₁.get? n = l₂.get? n) :
+theorem take_one_drop_eq_of_lt_length {l : List α} {n : ℕ} (h : n < l.length) :
+    (l.drop n).take 1 = [l.get ⟨n, h⟩] := by
+  rw [drop_eq_getElem_cons h, take, take]
+  simp
+
+theorem ext_getElem?' {l₁ l₂ : List α} (h' : ∀ n < max l₁.length l₂.length, l₁[n]? = l₂[n]?) :
     l₁ = l₂ := by
-  apply ext_get?
+  apply ext_getElem?
   intro n
   rcases Nat.lt_or_ge n <| max l₁.length l₂.length with hn | hn
   · exact h' n hn
   · simp_all [Nat.max_le, getElem?_eq_none]
 
-theorem ext_get?_iff {l₁ l₂ : List α} : l₁ = l₂ ↔ ∀ n, l₁.get? n = l₂.get? n :=
-  ⟨by rintro rfl _; rfl, ext_get?⟩
+@[deprecated (since := "2025-02-15")] alias ext_get?' := ext_getElem?'
+@[deprecated (since := "2025-02-15")] alias ext_get?_iff := List.ext_getElem?_iff
 
 theorem ext_get_iff {l₁ l₂ : List α} :
     l₁ = l₂ ↔ l₁.length = l₂.length ∧ ∀ n h₁ h₂, get l₁ ⟨n, h₁⟩ = get l₂ ⟨n, h₂⟩ := by
@@ -628,9 +635,11 @@ theorem ext_get_iff {l₁ l₂ : List α} :
   · intro ⟨h₁, h₂⟩
     exact ext_get h₁ h₂
 
-theorem ext_get?_iff' {l₁ l₂ : List α} : l₁ = l₂ ↔
-    ∀ n < max l₁.length l₂.length, l₁.get? n = l₂.get? n :=
-  ⟨by rintro rfl _ _; rfl, ext_get?'⟩
+theorem ext_getElem?_iff' {l₁ l₂ : List α} : l₁ = l₂ ↔
+    ∀ n < max l₁.length l₂.length, l₁[n]? = l₂[n]? :=
+  ⟨by rintro rfl _ _; rfl, ext_getElem?'⟩
+
+@[deprecated (since := "2025-02-15")] alias ext_get?_iff' := ext_getElem?_iff'
 
 /-- If two lists `l₁` and `l₂` are the same length and `l₁[n]! = l₂[n]!` for all `n`,
 then the lists are equal. -/
@@ -660,13 +669,8 @@ theorem getElem?_idxOf [DecidableEq α] {a : α} {l : List α} (h : a ∈ l) :
   rw [getElem?_eq_getElem, getElem_idxOf (idxOf_lt_length_iff.2 h)]
 
 @[deprecated (since := "2025-01-30")] alias getElem?_indexOf := getElem?_idxOf
-
--- This is incorrectly named and should be `get?_idxOf`;
--- this already exists, so will require a deprecation dance.
-theorem idxOf_get? [DecidableEq α] {a : α} {l : List α} (h : a ∈ l) :
-    get? l (idxOf a l) = some a := by simp [h]
-
-@[deprecated (since := "2025-01-30")] alias indexOf_get? := idxOf_get?
+@[deprecated (since := "2025-02-15")] alias idxOf_get? := getElem?_idxOf
+@[deprecated (since := "2025-01-30")] alias indexOf_get? := getElem?_idxOf
 
 theorem idxOf_inj [DecidableEq α] {l : List α} {x y : α} (hx : x ∈ l) (hy : y ∈ l) :
     idxOf x l = idxOf y l ↔ x = y :=
@@ -857,11 +861,11 @@ theorem foldl_fixed {a : α} : ∀ l : List β, foldl (fun a _ => a) a l = a :=
 theorem foldr_fixed {b : β} : ∀ l : List α, foldr (fun _ b => b) b l = b :=
   foldr_fixed' fun _ => rfl
 
-theorem foldr_eta : ∀ l : List α, foldr cons [] l = l := by
-  simp only [foldr_cons_eq_append, append_nil, forall_const]
+@[deprecated foldr_cons_nil (since := "2025-02-10")]
+theorem foldr_eta (l : List α) : foldr cons [] l = l := foldr_cons_nil l
 
 theorem reverse_foldl {l : List α} : reverse (foldl (fun t h => h :: t) [] l) = l := by
-  rw [← foldr_reverse]; simp only [foldr_cons_eq_append, append_nil, reverse_reverse]
+  simp
 
 theorem foldl_hom₂ (l : List ι) (f : α → β → γ) (op₁ : α → ι → α) (op₂ : β → ι → β)
     (op₃ : γ → ι → γ) (a : α) (b : β) (h : ∀ a b i, f (op₁ a i) (op₂ b i) = op₃ (f a b) i) :

--- a/Mathlib/Data/List/Cycle.lean
+++ b/Mathlib/Data/List/Cycle.lean
@@ -318,7 +318,7 @@ theorem prev_getElem (l : List α) (h : Nodup l) (i : Nat) (hi : i < l.length) :
           rw [nodup_iff_injective_get] at h
           apply h; rw [← H]; simp
 
-@[deprecated (since := "2025-02-015")] alias prev_get := prev_getElem
+@[deprecated (since := "2025-02-21")] alias prev_get := prev_getElem
 
 theorem pmap_next_eq_rotate_one (h : Nodup l) : (l.pmap l.next fun _ h => h) = l.rotate 1 := by
   apply List.ext_getElem
@@ -335,7 +335,6 @@ theorem pmap_prev_eq_rotate_length_sub_one (h : Nodup l) :
 
 theorem prev_next (l : List α) (h : Nodup l) (x : α) (hx : x ∈ l) :
     prev l (next l x hx) (next_mem _ _ _) = x := by
-
   obtain ⟨n, hn, rfl⟩ := getElem_of_mem hx
   simp only [next_getElem, prev_getElem, h, Nat.mod_add_mod]
   rcases l with - | ⟨hd, tl⟩

--- a/Mathlib/Data/List/Cycle.lean
+++ b/Mathlib/Data/List/Cycle.lean
@@ -164,9 +164,9 @@ theorem next_getLast_cons (h : x ∈ l) (y : α) (h : x ∈ y :: l) (hy : x ≠ 
   rw [next, get, ← dropLast_append_getLast (cons_ne_nil y l), hx, nextOr_concat]
   subst hx
   intro H
-  obtain ⟨⟨_ | k, hk⟩, hk'⟩ := get_of_mem H
+  obtain ⟨_ | k, hk, hk'⟩ := getElem_of_mem H
   · rw [← Option.some_inj] at hk'
-    rw [← get?_eq_get, dropLast_eq_take, get?_eq_getElem?, getElem?_take_of_lt, getElem?_cons_zero,
+    rw [← getElem?_eq_getElem, dropLast_eq_take, getElem?_take_of_lt, getElem?_cons_zero,
       Option.some_inj] at hk'
     · exact hy (Eq.symm hk')
     rw [length_cons]
@@ -179,7 +179,7 @@ theorem next_getLast_cons (h : x ∈ l) (y : α) (h : x ∈ y :: l) (hy : x ≠ 
     refine Fin.val_eq_of_eq <| @hl ⟨k, Nat.lt_of_succ_lt <| by simpa using hk⟩
       ⟨tl.length, by simp⟩ ?_
     rw [← Option.some_inj] at hk'
-    rw [← get?_eq_get, dropLast_eq_take, get?_eq_getElem?, getElem?_take_of_lt, getElem?_cons_succ,
+    rw [← getElem?_eq_getElem, dropLast_eq_take, getElem?_take_of_lt, getElem?_cons_succ,
       getElem?_eq_getElem, Option.some_inj] at hk'
     · rw [get_eq_getElem, hk']
       simp only [getLast_eq_getElem, length_cons, Nat.succ_eq_add_one, Nat.succ_sub_succ_eq_sub,
@@ -233,18 +233,18 @@ theorem prev_mem (h : x ∈ l) : l.prev x h ∈ l := by
       · exact mem_cons_self _ _
       · exact mem_cons_of_mem _ (hl _ _)
 
-theorem next_get (l : List α) (h : Nodup l) (i : Fin l.length) :
-    next l (l.get i) (get_mem _ _) =
-      l.get ⟨(i + 1) % l.length, Nat.mod_lt _ (i.1.zero_le.trans_lt i.2)⟩ :=
-  match l, h, i with
-  | [], _, i => by simpa using i.2
-  | [_], _, _ => by simp
-  | x::y::l, _h, ⟨0, h0⟩ => by
-    have h₁ : get (x :: y :: l) ⟨0, h0⟩ = x := by simp
+theorem next_getElem (l : List α) (h : Nodup l) (i : Nat) (hi : i < l.length) :
+    next l l[i] (get_mem _ _) =
+      (l[(i + 1) % l.length]'(Nat.mod_lt _ (i.zero_le.trans_lt hi))) :=
+  match l, h, i, hi with
+  | [], _, i, hi => by simp at hi
+  | [_], _, _, _ => by simp
+  | x::y::l, _h, 0, h0 => by
+    have h₁ : (x :: y :: l)[0] = x := by simp
     rw [next_cons_cons_eq' _ _ _ _ _ h₁]
     simp
-  | x::y::l, hn, ⟨i+1, hi⟩ => by
-    have hx' : (x :: y :: l).get ⟨i+1, hi⟩ ≠ x := by
+  | x::y::l, hn, i+1, hi => by
+    have hx' : (x :: y :: l)[i+1] ≠ x := by
       intro H
       suffices (i + 1 : ℕ) = 0 by simpa
       rw [nodup_iff_injective_get] at hn
@@ -255,13 +255,13 @@ theorem next_get (l : List α) (h : Nodup l) (i : Fin l.length) :
     · subst hi'
       rw [next_getLast_cons]
       · simp [hi', get]
-      · rw [get_cons_succ]; exact get_mem _ _
+      · rw [getElem_cons_succ]; exact get_mem _ _
       · exact hx'
       · simp [getLast_eq_getElem]
       · exact hn.of_cons
     · rw [next_ne_head_ne_getLast _ _ _ _ _ hx']
-      · simp only [get_cons_succ]
-        rw [next_get (y::l), ← get_cons_succ (a := x)]
+      · simp only [getElem_cons_succ]
+        rw [next_getElem (y::l), ← getElem_cons_succ (a := x)]
         · congr
           dsimp
           rw [Nat.mod_eq_of_lt (Nat.succ_lt_succ_iff.2 hi'),
@@ -272,67 +272,72 @@ theorem next_get (l : List α) (h : Nodup l) (i : Fin l.length) :
         intro h
         have := nodup_iff_injective_get.1 hn h
         simp at this; simp [this] at hi'
-      · rw [get_cons_succ]; exact get_mem _ _
+      · rw [getElem_cons_succ]; exact get_mem _ _
+
+@[deprecated (since := "2025-02-015")] alias next_get := next_getElem
 
 -- Unused variable linter incorrectly reports that `h` is unused here.
 set_option linter.unusedVariables false in
-theorem prev_get (l : List α) (h : Nodup l) (i : Fin l.length) :
-    prev l (l.get i) (get_mem _ _) =
-      l.get ⟨(i + (l.length - 1)) % l.length, Nat.mod_lt _ i.pos⟩ :=
+theorem prev_getElem (l : List α) (h : Nodup l) (i : Nat) (hi : i < l.length) :
+    prev l l[i] (get_mem _ _) =
+      (l[(i + (l.length - 1)) % l.length]'(Nat.mod_lt _ (by omega))) :=
   match l with
-  | [] => by simpa using i.2
+  | [] => by simp at hi
   | x::l => by
-    obtain ⟨n, hn⟩ := i
-    induction l generalizing n x with
+    induction l generalizing i x with
     | nil => simp
     | cons y l hl =>
-      rcases n with (_ | _ | n)
+      rcases i with (_ | _ | i)
       · simp [getLast_eq_getElem]
       · simp only [mem_cons, nodup_cons] at h
         push_neg at h
-        simp only [List.prev_cons_cons_of_ne _ _ _ _ h.left.left.symm, List.length,
-          List.get, add_comm, Nat.succ_add_sub_one, Nat.mod_self, zero_add]
+        simp only [zero_add, getElem_cons_succ, getElem_cons_zero,
+          List.prev_cons_cons_of_ne _ _ _ _ h.left.left.symm, length, add_comm,
+          Nat.add_sub_cancel_left, Nat.mod_self]
       · rw [prev_ne_cons_cons]
-        · convert hl y h.of_cons n.succ (Nat.le_of_succ_le_succ hn) using 1
-          have : ∀ k hk, (y :: l).get ⟨k, hk⟩ = (x :: y :: l).get ⟨k + 1, Nat.succ_lt_succ hk⟩ := by
-            simp [List.get]
+        · convert hl i.succ y h.of_cons (Nat.le_of_succ_le_succ hi) using 1
+          have : ∀ k hk, (y :: l)[k] = (x :: y :: l)[k + 1]'(Nat.succ_lt_succ hk) := by
+            simp
           rw [this]
           congr
           simp only [Nat.add_succ_sub_one, add_zero, length]
-          simp only [length, Nat.succ_lt_succ_iff] at hn
+          simp only [length, Nat.succ_lt_succ_iff] at hi
           set k := l.length
           rw [Nat.succ_add, ← Nat.add_succ, Nat.add_mod_right, Nat.succ_add, ← Nat.add_succ _ k,
             Nat.add_mod_right, Nat.mod_eq_of_lt, Nat.mod_eq_of_lt]
-          · exact Nat.lt_succ_of_lt hn
-          · exact Nat.succ_lt_succ (Nat.lt_succ_of_lt hn)
+          · exact Nat.lt_succ_of_lt hi
+          · exact Nat.succ_lt_succ (Nat.lt_succ_of_lt hi)
         · intro H
-          suffices n.succ.succ = 0 by simpa
-          suffices Fin.mk _ hn = ⟨0, by omega⟩ by rwa [Fin.mk.inj_iff] at this
+          suffices i.succ.succ = 0 by simpa
+          suffices Fin.mk _ hi = ⟨0, by omega⟩ by rwa [Fin.mk.inj_iff] at this
           rw [nodup_iff_injective_get] at h
           apply h; rw [← H]; simp
         · intro H
-          suffices n.succ.succ = 1 by simpa
-          suffices Fin.mk _ hn = ⟨1, by omega⟩ by rwa [Fin.mk.inj_iff] at this
+          suffices i.succ.succ = 1 by simpa
+          suffices Fin.mk _ hi = ⟨1, by omega⟩ by rwa [Fin.mk.inj_iff] at this
           rw [nodup_iff_injective_get] at h
           apply h; rw [← H]; simp
 
+@[deprecated (since := "2025-02-015")] alias prev_get := prev_getElem
+
 theorem pmap_next_eq_rotate_one (h : Nodup l) : (l.pmap l.next fun _ h => h) = l.rotate 1 := by
-  apply List.ext_get
+  apply List.ext_getElem
   · simp
   · intros
-    rw [get_pmap, get_rotate, next_get _ h]
+    rw [getElem_pmap, getElem_rotate, next_getElem _ h]
 
 theorem pmap_prev_eq_rotate_length_sub_one (h : Nodup l) :
     (l.pmap l.prev fun _ h => h) = l.rotate (l.length - 1) := by
-  apply List.ext_get
+  apply List.ext_getElem
   · simp
   · intro n hn hn'
-    rw [get_rotate, get_pmap, prev_get _ h]
+    rw [getElem_rotate, getElem_pmap, prev_getElem _ h]
 
 theorem prev_next (l : List α) (h : Nodup l) (x : α) (hx : x ∈ l) :
     prev l (next l x hx) (next_mem _ _ _) = x := by
-  obtain ⟨⟨n, hn⟩, rfl⟩ := get_of_mem hx
-  simp only [next_get, prev_get, h, Nat.mod_add_mod]
+
+  obtain ⟨n, hn, rfl⟩ := getElem_of_mem hx
+  simp only [next_getElem, prev_getElem, h, Nat.mod_add_mod]
   rcases l with - | ⟨hd, tl⟩
   · simp at hn
   · have : (n + 1 + length tl) % (length tl + 1) = n := by
@@ -342,8 +347,8 @@ theorem prev_next (l : List α) (h : Nodup l) (x : α) (hx : x ∈ l) :
 
 theorem next_prev (l : List α) (h : Nodup l) (x : α) (hx : x ∈ l) :
     next l (prev l x hx) (prev_mem _ _ _) = x := by
-  obtain ⟨⟨n, hn⟩, rfl⟩ := get_of_mem hx
-  simp only [next_get, prev_get, h, Nat.mod_add_mod]
+  obtain ⟨n, hn, rfl⟩ := getElem_of_mem hx
+  simp only [next_getElem, prev_getElem, h, Nat.mod_add_mod]
   rcases l with - | ⟨hd, tl⟩
   · simp at hn
   · have : (n + length tl + 1) % (length tl + 1) = n := by
@@ -373,11 +378,11 @@ theorem next_reverse_eq_prev (l : List α) (h : Nodup l) (x : α) (hx : x ∈ l)
 
 theorem isRotated_next_eq {l l' : List α} (h : l ~r l') (hn : Nodup l) {x : α} (hx : x ∈ l) :
     l.next x hx = l'.next x (h.mem_iff.mp hx) := by
-  obtain ⟨k, hk, rfl⟩ := get_of_mem hx
+  obtain ⟨k, hk, rfl⟩ := getElem_of_mem hx
   obtain ⟨n, rfl⟩ := id h
-  rw [next_get _ hn]
-  simp_rw [get_eq_get_rotate _ n k]
-  rw [next_get _ (h.nodup_iff.mp hn), get_eq_get_rotate _ n]
+  rw [next_getElem _ hn]
+  simp_rw [getElem_eq_getElem_rotate _ n k]
+  rw [next_getElem _ (h.nodup_iff.mp hn), getElem_eq_getElem_rotate _ n]
   simp [add_assoc]
 
 theorem isRotated_prev_eq {l l' : List α} (h : l ~r l') (hn : Nodup l) {x : α} (hx : x ∈ l) :

--- a/Mathlib/Data/List/GetD.lean
+++ b/Mathlib/Data/List/GetD.lean
@@ -87,10 +87,12 @@ theorem getD_append_right (l l' : List α) (d : α) (n : ℕ) (h : l.length ≤ 
     rw [getD_eq_default _ _ h', getD_eq_default]
     rwa [Nat.le_sub_iff_add_le' h, ← length_append]
 
-theorem getD_eq_getD_get? (n : ℕ) : l.getD n d = (l.get? n).getD d := by
+theorem getD_eq_getD_getElem? (n : ℕ) : l.getD n d = l[n]?.getD d := by
   cases Nat.lt_or_ge n l.length with
-  | inl h => rw [getD_eq_getElem _ _ h, get?_eq_get h, get_eq_getElem, Option.getD_some]
-  | inr h => rw [getD_eq_default _ _ h, get?_eq_none_iff.mpr h, Option.getD_none]
+  | inl h => rw [getD_eq_getElem _ _ h, getElem?_eq_getElem h, Option.getD_some]
+  | inr h => rw [getD_eq_default _ _ h, getElem?_eq_none_iff.mpr h, Option.getD_none]
+
+@[deprecated (since := "2025-02-14")] alias getD_eq_getD_get? := getD_eq_getD_getElem?
 
 end getD
 
@@ -130,11 +132,10 @@ theorem getI_append_right (l l' : List α) (n : ℕ) (h : l.length ≤ n) :
     (l ++ l').getI n = l'.getI (n - l.length) :=
   getD_append_right _ _ _ _ h
 
-theorem getI_eq_iget_get? (n : ℕ) : l.getI n = (l.get? n).iget := by
-  rw [← getD_default_eq_getI, getD_eq_getD_get?, Option.getD_default_eq_iget]
-
 theorem getI_eq_iget_getElem? (n : ℕ) : l.getI n = l[n]?.iget := by
-  rw [← getD_default_eq_getI, getD_eq_getElem?_getD, Option.getD_default_eq_iget]
+  rw [← getD_default_eq_getI, getD_eq_getD_getElem?, Option.getD_default_eq_iget]
+
+@[deprecated (since := "2025-02-14")] alias getI_eq_iget_get? := getI_eq_iget_getElem?
 
 theorem getI_zero_eq_headI : l.getI 0 = l.headI := by cases l <;> rfl
 

--- a/Mathlib/Data/List/Iterate.lean
+++ b/Mathlib/Data/List/Iterate.lean
@@ -31,6 +31,7 @@ theorem getElem?_iterate (f : α → α) (a : α) :
   | n + 1, 0    , _ => by simp
   | n + 1, i + 1, h => by simp [getElem?_iterate f (f a) n i (by simpa using h)]
 
+set_option linter.deprecated false in
 @[deprecated getElem?_iterate (since := "2024-08-23")]
 theorem get?_iterate (f : α → α) (a : α) (n i : ℕ) (h : i < n) :
     get? (iterate f a n) i = f^[i] a := by

--- a/Mathlib/Data/List/Nodup.lean
+++ b/Mathlib/Data/List/Nodup.lean
@@ -104,6 +104,8 @@ theorem nodup_iff_getElem?_ne_getElem? {l : List α} :
     rw [Ne, ← Option.some_inj, ← getElem?_eq_getElem, ← getElem?_eq_getElem]
     exact h i j hij hj
 
+set_option linter.deprecated false in
+@[deprecated nodup_iff_getElem?_ne_getElem? (since := "2025-02-17")]
 theorem nodup_iff_get?_ne_get? {l : List α} :
     l.Nodup ↔ ∀ i j : ℕ, i < j → j < l.length → l.get? i ≠ l.get? j := by
   simp [nodup_iff_getElem?_ne_getElem?]
@@ -244,7 +246,7 @@ lemma nodup_tail_reverse (l : List α) (h : l[0]? = l.getLast?) :
   | cons a l ih =>
     by_cases hl : l = []
     · aesop
-    · simp_all only [List.get?_eq_getElem?, List.tail_reverse, List.nodup_reverse,
+    · simp_all only [List.tail_reverse, List.nodup_reverse,
         List.dropLast_cons_of_ne_nil hl, List.tail_cons]
       simp only [length_cons, Nat.zero_lt_succ, getElem?_eq_getElem, getElem_cons_zero,
         Nat.add_one_sub_one, Nat.lt_add_one, Option.some.injEq, List.getElem_cons,

--- a/Mathlib/Data/List/NodupEquivFin.lean
+++ b/Mathlib/Data/List/NodupEquivFin.lean
@@ -103,12 +103,12 @@ section Sublist
 any element of `l` found at index `ix` can be found at index `f ix` in `l'`,
 then `Sublist l l'`.
 -/
-theorem sublist_of_orderEmbedding_get?_eq {l l' : List α} (f : ℕ ↪o ℕ)
-    (hf : ∀ ix : ℕ, l.get? ix = l'.get? (f ix)) : l <+ l' := by
+theorem sublist_of_orderEmbedding_getElem?_eq {l l' : List α} (f : ℕ ↪o ℕ)
+    (hf : ∀ ix : ℕ, l[ix]? = l'[f ix]?) : l <+ l' := by
   induction' l with hd tl IH generalizing l' f
   · simp
-  have : some hd = _ := hf 0
-  rw [eq_comm, List.get?_eq_some_iff] at this
+  have : some hd = l'[f 0]? := by simpa using hf 0
+  rw [eq_comm, List.getElem?_eq_some_iff] at this
   obtain ⟨w, h⟩ := this
   let f' : ℕ ↪o ℕ :=
     OrderEmbedding.ofMapLEIff (fun i => f (i + 1) - (f 0 + 1)) fun a b => by
@@ -116,8 +116,6 @@ theorem sublist_of_orderEmbedding_get?_eq {l l' : List α} (f : ℕ ↪o ℕ)
       rw [Nat.sub_le_sub_iff_right, OrderEmbedding.le_iff_le, Nat.succ_le_succ_iff]
       rw [Nat.succ_le_iff, OrderEmbedding.lt_iff_lt]
       exact b.succ_pos
-  simp only [get_eq_getElem] at h
-  simp only [get?_eq_getElem?] at hf IH
   have : ∀ ix, tl[ix]? = (l'.drop (f 0 + 1))[f' ix]? := by
     intro ix
     rw [List.getElem?_drop, OrderEmbedding.coe_ofMapLEIff, Nat.add_sub_cancel', ← hf]
@@ -129,12 +127,15 @@ theorem sublist_of_orderEmbedding_get?_eq {l l' : List α} (f : ℕ ↪o ℕ)
   rw [List.singleton_sublist, ← h, l'.getElem_take' _ (Nat.lt_succ_self _)]
   exact List.getElem_mem _
 
+@[deprecated (since := "2025-02-15")] alias sublist_of_orderEmbedding_get?_eq :=
+sublist_of_orderEmbedding_getElem?_eq
+
 /-- A `l : List α` is `Sublist l l'` for `l' : List α` iff
 there is `f`, an order-preserving embedding of `ℕ` into `ℕ` such that
 any element of `l` found at index `ix` can be found at index `f ix` in `l'`.
 -/
-theorem sublist_iff_exists_orderEmbedding_get?_eq {l l' : List α} :
-    l <+ l' ↔ ∃ f : ℕ ↪o ℕ, ∀ ix : ℕ, l.get? ix = l'.get? (f ix) := by
+theorem sublist_iff_exists_orderEmbedding_getElem?_eq {l l' : List α} :
+    l <+ l' ↔ ∃ f : ℕ ↪o ℕ, ∀ ix : ℕ, l[ix]? = l'[f ix]? := by
   constructor
   · intro H
     induction H with
@@ -152,7 +153,10 @@ theorem sublist_iff_exists_orderEmbedding_get?_eq {l l' : List α} :
         · simp
         · simpa using hf _
   · rintro ⟨f, hf⟩
-    exact sublist_of_orderEmbedding_get?_eq f hf
+    exact sublist_of_orderEmbedding_getElem?_eq f hf
+
+@[deprecated (since := "2025-02-15")] alias sublist_iff_exists_orderEmbedding_get?_eq :=
+sublist_iff_exists_orderEmbedding_getElem?_eq
 
 /-- A `l : List α` is `Sublist l l'` for `l' : List α` iff
 there is `f`, an order-preserving embedding of `Fin l.length` into `Fin l'.length` such that
@@ -162,13 +166,13 @@ theorem sublist_iff_exists_fin_orderEmbedding_get_eq {l l' : List α} :
     l <+ l' ↔
       ∃ f : Fin l.length ↪o Fin l'.length,
         ∀ ix : Fin l.length, l.get ix = l'.get (f ix) := by
-  rw [sublist_iff_exists_orderEmbedding_get?_eq]
+  rw [sublist_iff_exists_orderEmbedding_getElem?_eq]
   constructor
   · rintro ⟨f, hf⟩
     have h : ∀ {i : ℕ}, i < l.length → f i < l'.length := by
       intro i hi
       specialize hf i
-      rw [get?_eq_get hi, eq_comm, get?_eq_some_iff] at hf
+      rw [getElem?_eq_getElem hi, eq_comm, getElem?_eq_some_iff] at hf
       obtain ⟨h, -⟩ := hf
       exact h
     refine ⟨OrderEmbedding.ofMapLEIff (fun ix => ⟨f ix, h ix.is_lt⟩) ?_, ?_⟩
@@ -191,8 +195,9 @@ theorem sublist_iff_exists_fin_orderEmbedding_get_eq {l l' : List α} :
     · intro i
       simp only [OrderEmbedding.coe_ofStrictMono]
       split_ifs with hi
-      · rw [get?_eq_get hi, get?_eq_get, ← hf]
-      · rw [get?_eq_none_iff.mpr, get?_eq_none_iff.mpr]
+      · specialize hf ⟨i, hi⟩
+        simp_all
+      · rw [getElem?_eq_none_iff.mpr, getElem?_eq_none_iff.mpr]
         · simp
         · simpa using hi
 

--- a/Mathlib/Data/List/OfFn.lean
+++ b/Mathlib/Data/List/OfFn.lean
@@ -33,9 +33,7 @@ namespace List
 theorem get_ofFn {n} (f : Fin n → α) (i) : get (ofFn f) i = f (Fin.cast (by simp) i) := by
   simp; congr
 
-/-- The `n`th element of a list -/
-theorem get?_ofFn {n} (f : Fin n → α) (i) : get? (ofFn f) i = ofFnNthVal f i := by
-  simp [ofFnNthVal]
+@[deprecated (since := "2025-02-15")] alias get?_ofFn := List.getElem?_ofFn
 
 @[simp]
 theorem map_ofFn {β : Type*} {n : ℕ} (f : Fin n → α) (g : α → β) :

--- a/Mathlib/Data/List/ReduceOption.lean
+++ b/Mathlib/Data/List/ReduceOption.lean
@@ -135,8 +135,11 @@ theorem reduceOption_concat_of_some (l : List (Option α)) (x : α) :
 theorem reduceOption_mem_iff {l : List (Option α)} {x : α} : x ∈ l.reduceOption ↔ some x ∈ l := by
   simp only [reduceOption, id, mem_filterMap, exists_eq_right]
 
-theorem reduceOption_get?_iff {l : List (Option α)} {x : α} :
-    (∃ i, l.get? i = some (some x)) ↔ ∃ i, l.reduceOption.get? i = some x := by
-  rw [← mem_iff_get?, ← mem_iff_get?, reduceOption_mem_iff]
+theorem reduceOption_getElem?_iff {l : List (Option α)} {x : α} :
+    (∃ i : ℕ, l[i]? = some (some x)) ↔ ∃ i : ℕ, l.reduceOption[i]? = some x := by
+  rw [← mem_iff_getElem?, ← mem_iff_getElem?, reduceOption_mem_iff]
+
+@[deprecated (since := "2025-02-21")]
+alias reduceOption_get?_iff := reduceOption_getElem?_iff
 
 end List

--- a/Mathlib/Data/List/Rotate.lean
+++ b/Mathlib/Data/List/Rotate.lean
@@ -210,6 +210,8 @@ theorem getElem_rotate (l : List α) (n : ℕ) (k : Nat) (h : k < (l.rotate n).l
   rw [← Option.some_inj, ← getElem?_eq_getElem, ← getElem?_eq_getElem, getElem?_rotate]
   exact h.trans_eq (length_rotate _ _)
 
+set_option linter.deprecated false in
+@[deprecated getElem?_rotate (since := "2025-02-14")]
 theorem get?_rotate {l : List α} {n m : ℕ} (hml : m < l.length) :
     (l.rotate n).get? m = l.get? ((m + n) % l.length) := by
   simp only [get?_eq_getElem?, length_rotate, hml, getElem?_eq_getElem, getElem_rotate]
@@ -221,14 +223,25 @@ theorem get_rotate (l : List α) (n : ℕ) (k : Fin (l.rotate n).length) :
   simp [getElem_rotate]
 
 theorem head?_rotate {l : List α} {n : ℕ} (h : n < l.length) : head? (l.rotate n) = l[n]? := by
-  rw [← get?_zero, get?_rotate (n.zero_le.trans_lt h), Nat.zero_add, Nat.mod_eq_of_lt h,
-    get?_eq_getElem?]
+  rw [head?_eq_getElem?, getElem?_rotate (n.zero_le.trans_lt h), Nat.zero_add, Nat.mod_eq_of_lt h]
 
 theorem get_rotate_one (l : List α) (k : Fin (l.rotate 1).length) :
     (l.rotate 1).get k = l.get ⟨(k + 1) % l.length, mod_lt _ (length_rotate l 1 ▸ k.pos)⟩ :=
   get_rotate l 1 k
 
 @[deprecated (since := "2024-08-19")] alias nthLe_rotate_one := get_rotate_one
+
+/-- A version of `List.getElem_rotate` that represents `l[k]` in terms of
+`(List.rotate l n)[⋯]`, not vice versa. Can be used instead of rewriting `List.getElem_rotate`
+from right to left. -/
+theorem getElem_eq_getElem_rotate (l : List α) (n : ℕ) (k : Nat) (hk : k < l.length) :
+    l[k] = ((l.rotate n)[(l.length - n % l.length + k) % l.length]'
+      ((Nat.mod_lt _ (k.zero_le.trans_lt hk)).trans_eq (length_rotate _ _).symm)) := by
+  rw [getElem_rotate]
+  refine congr_arg l.get (Fin.eq_of_val_eq ?_)
+  simp only [mod_add_mod]
+  rw [← add_mod_mod, Nat.add_right_comm, Nat.sub_add_cancel, add_mod_left, mod_eq_of_lt]
+  exacts [hk, (mod_lt _ (k.zero_le.trans_lt hk)).le]
 
 /-- A version of `List.get_rotate` that represents `List.get l` in terms of
 `List.get (List.rotate l n)`, not vice versa. Can be used instead of rewriting `List.get_rotate`

--- a/Mathlib/Data/List/Scan.lean
+++ b/Mathlib/Data/List/Scan.lean
@@ -42,16 +42,18 @@ theorem getElem_scanl_zero {h : 0 < (scanl f b l).length} : (scanl f b l)[0] = b
   · simp [scanl_nil]
   · simp [scanl_cons, singleton_append]
 
-theorem get?_succ_scanl {i : ℕ} : (scanl f b l).get? (i + 1) =
-    ((scanl f b l).get? i).bind fun x => (l.get? i).map fun y => f x y := by
+theorem getElem?_succ_scanl {i : ℕ} : (scanl f b l)[i + 1]? =
+    (scanl f b l)[i]?.bind fun x => l[i]?.map fun y => f x y := by
   induction' l with hd tl hl generalizing b i
   · symm
-    simp only [Option.bind_eq_none', get?, forall₂_true_iff, not_false_iff, Option.map_none',
-      scanl_nil, Option.not_mem_none, forall_true_iff]
+    simp only [scanl, getElem?_nil, Option.map_none', Option.bind_none, getElem?_cons_succ]
   · simp only [scanl_cons, singleton_append]
     cases i
     · simp
-    · simp only [hl, get?]
+    · simp only [hl, getElem?_cons_succ]
+
+@[deprecated (since := "2025-02-21")]
+alias get?_succ_scanl := getElem?_succ_scanl
 
 theorem getElem_succ_scanl {i : ℕ} (h : i + 1 < (scanl f b l).length) :
     (scanl f b l)[i + 1] =

--- a/Mathlib/Data/List/Zip.lean
+++ b/Mathlib/Data/List/Zip.lean
@@ -117,18 +117,9 @@ theorem reverse_revzip (l : List α) : reverse l.revzip = revzip l.reverse := by
 
 theorem revzip_swap (l : List α) : (revzip l).map Prod.swap = revzip l.reverse := by simp [revzip]
 
-theorem get?_zipWith' (f : α → β → γ) (l₁ : List α) (l₂ : List β) (i : ℕ) :
-    (zipWith f l₁ l₂).get? i = ((l₁.get? i).map f).bind fun g => (l₂.get? i).map g := by
-  simp [getElem?_zipWith']
-
-theorem get?_zipWith_eq_some (f : α → β → γ) (l₁ : List α) (l₂ : List β) (z : γ) (i : ℕ) :
-    (zipWith f l₁ l₂).get? i = some z ↔
-      ∃ x y, l₁.get? i = some x ∧ l₂.get? i = some y ∧ f x y = z := by
-  simp [getElem?_zipWith_eq_some]
-
-theorem get?_zip_eq_some (l₁ : List α) (l₂ : List β) (z : α × β) (i : ℕ) :
-    (zip l₁ l₂).get? i = some z ↔ l₁.get? i = some z.1 ∧ l₂.get? i = some z.2 := by
-  simp [getElem?_zip_eq_some]
+@[deprecated (since := "2025-02-14")] alias get?_zipWith' := getElem?_zipWith'
+@[deprecated (since := "2025-02-14")] alias get?_zipWith_eq_some := getElem?_zipWith_eq_some
+@[deprecated (since := "2025-02-14")] alias get?_zip_eq_some := getElem?_zip_eq_some
 
 theorem mem_zip_inits_tails {l : List α} {init tail : List α} :
     (init, tail) ∈ zip l.inits l.tails ↔ init ++ tail = l := by

--- a/Mathlib/Data/Set/List.lean
+++ b/Mathlib/Data/Set/List.lean
@@ -37,21 +37,25 @@ theorem range_list_get : range l.get = { x | x ∈ l } := by
   ext x
   rw [mem_setOf_eq, mem_iff_get, mem_range]
 
-theorem range_list_get? : range l.get? = insert none (some '' { x | x ∈ l }) := by
+theorem range_list_getElem? :
+    range (l[·]? : ℕ → Option α) = insert none (some '' { x | x ∈ l }) := by
   rw [← range_list_get, ← range_comp]
   refine (range_subset_iff.2 fun n => ?_).antisymm (insert_subset_iff.2 ⟨?_, ?_⟩)
-  · exact (le_or_lt l.length n).imp get?_eq_none_iff.mpr
-      (fun hlt => ⟨⟨_, hlt⟩, (get?_eq_get hlt).symm⟩)
-  · exact ⟨_, get?_eq_none_iff.mpr le_rfl⟩
-  · exact range_subset_iff.2 fun k => ⟨_, get?_eq_get _⟩
+  · exact (le_or_lt l.length n).imp getElem?_eq_none_iff.mpr
+      (fun hlt => ⟨⟨_, hlt⟩, (getElem?_eq_getElem hlt).symm⟩)
+  · exact ⟨_, getElem?_eq_none_iff.mpr le_rfl⟩
+  · exact range_subset_iff.2 fun k => ⟨_, getElem?_eq_getElem _⟩
+
+@[deprecated (since := "2025-02-15")] alias range_list_get? := range_list_getElem?
 
 @[simp]
 theorem range_list_getD (d : α) : (range fun n : Nat => l[n]?.getD d) = insert d { x | x ∈ l } :=
   calc
-    (range fun n => l[n]?.getD d) = (fun o : Option α => o.getD d) '' range l.get? := by
-      simp [← range_comp, Function.comp_def]
+    (range fun n => l[n]?.getD d) = (fun o : Option α => o.getD d) '' range (l[·]?) := by
+      simp only [← range_comp, Function.comp_def]
+      rfl
     _ = insert d { x | x ∈ l } := by
-      simp only [range_list_get?, image_insert_eq, Option.getD, image_image, image_id']
+      simp only [Option.getD, range_list_getElem?, image_insert_eq, image_image, image_id']
 
 @[simp]
 theorem range_list_getI [Inhabited α] (l : List α) :

--- a/Mathlib/GroupTheory/Perm/Cycle/Concrete.lean
+++ b/Mathlib/GroupTheory/Perm/Cycle/Concrete.lean
@@ -109,8 +109,8 @@ theorem cycleType_formPerm (hl : Nodup l) (hn : 2 ≤ l.length) :
 
 theorem formPerm_apply_mem_eq_next (hl : Nodup l) (x : α) (hx : x ∈ l) :
     formPerm l x = next l x hx := by
-  obtain ⟨k, rfl⟩ := get_of_mem hx
-  rw [next_get _ hl, get_eq_getElem, formPerm_apply_getElem _ hl]; rfl
+  obtain ⟨k, hk, rfl⟩ := getElem_of_mem hx
+  rw [next_getElem _ hl, formPerm_apply_getElem _ hl]
 
 end List
 
@@ -212,9 +212,17 @@ theorem two_le_length_toList_iff_mem_support {p : Perm α} {x : α} :
 theorem length_toList_pos_of_mem_support (h : x ∈ p.support) : 0 < length (toList p x) :=
   zero_lt_two.trans_le (two_le_length_toList_iff_mem_support.mpr h)
 
+theorem getElem_toList (n : ℕ) (hn : n < length (toList p x)) :
+    (toList p x)[n] = (p ^ n) x := by simp [toList]
+
+@[deprecated getElem_toList (since := "2025-02-17")]
 theorem get_toList (n : ℕ) (hn : n < length (toList p x)) :
     (toList p x).get ⟨n, hn⟩ = (p ^ n) x := by simp [toList]
 
+theorem toList_getElem_zero (h : x ∈ p.support) :
+    (toList p x)[0]'(length_toList_pos_of_mem_support _ _ h) = x := by simp [toList]
+
+@[deprecated toList_getElem_zero (since := "2025-02-17")]
 theorem toList_get_zero (h : x ∈ p.support) :
     (toList p x).get ⟨0, (length_toList_pos_of_mem_support _ _ h)⟩ = x := by simp [toList]
 
@@ -236,11 +244,12 @@ theorem nodup_toList (p : Perm α) (x : α) : Nodup (toList p x) := by
   · rw [← not_mem_support, ← toList_eq_nil_iff] at hx
     simp [hx]
   have hc : IsCycle (cycleOf p x) := isCycle_cycleOf p hx
-  rw [nodup_iff_injective_get]
+  rw [nodup_iff_injective_getElem]
   intro ⟨n, hn⟩ ⟨m, hm⟩
   rw [length_toList, ← hc.orderOf] at hm hn
   rw [← cycleOf_apply_self, ← Ne, ← mem_support] at hx
-  rw [get_toList, get_toList, ← cycleOf_pow_apply_self p x n, ←
+  simp only [Fin.mk.injEq]
+  rw [getElem_toList, getElem_toList, ← cycleOf_pow_apply_self p x n, ←
     cycleOf_pow_apply_self p x m]
   rcases n with - | n <;> rcases m with - | m
   · simp
@@ -254,7 +263,7 @@ theorem nodup_toList (p : Perm α) (x : α) : Nodup (toList p x) := by
   have hn' : ¬orderOf (p.cycleOf x) ∣ n.succ := Nat.not_dvd_of_pos_of_lt n.zero_lt_succ hn
   have hm' : ¬orderOf (p.cycleOf x) ∣ m.succ := Nat.not_dvd_of_pos_of_lt m.zero_lt_succ hm
   rw [← hc.support_pow_eq_iff] at hn' hm'
-  rw [Fin.mk_eq_mk, ← Nat.mod_eq_of_lt hn, ← Nat.mod_eq_of_lt hm, ← pow_inj_mod]
+  rw [← Nat.mod_eq_of_lt hn, ← Nat.mod_eq_of_lt hm, ← pow_inj_mod]
   refine support_congr ?_ ?_
   · rw [hm', hn']
   · rw [hm']
@@ -267,19 +276,19 @@ theorem next_toList_eq_apply (p : Perm α) (x y : α) (hy : y ∈ toList p x) :
     next (toList p x) y hy = p y := by
   rw [mem_toList_iff] at hy
   obtain ⟨k, hk, hk'⟩ := hy.left.exists_pow_eq_of_mem_support hy.right
-  rw [← get_toList p x k (by simpa using hk)] at hk'
+  rw [← getElem_toList p x k (by simpa using hk)] at hk'
   simp_rw [← hk']
-  rw [next_get _ (nodup_toList _ _), get_toList, get_toList, ← mul_apply, ← pow_succ']
+  rw [next_getElem _ (nodup_toList _ _), getElem_toList, getElem_toList, ← mul_apply, ← pow_succ']
   simp_rw [length_toList]
   rw [← pow_mod_orderOf_cycleOf_apply p (k + 1), IsCycle.orderOf]
   exact isCycle_cycleOf _ (mem_support.mp hy.right)
 
 theorem toList_pow_apply_eq_rotate (p : Perm α) (x : α) (k : ℕ) :
     p.toList ((p ^ k) x) = (p.toList x).rotate k := by
-  apply ext_get
+  apply ext_getElem
   · simp only [length_toList, cycleOf_self_apply_pow, length_rotate]
   · intro n hn hn'
-    rw [get_toList, get_rotate, get_toList, length_toList,
+    rw [getElem_toList, getElem_rotate, getElem_toList, length_toList,
       pow_mod_card_support_cycleOf_self_apply, pow_add, mul_apply]
 
 theorem SameCycle.toList_isRotated {f : Perm α} {x y : α} (h : SameCycle f x y) :

--- a/Mathlib/Logic/Equiv/List.lean
+++ b/Mathlib/Logic/Equiv/List.lean
@@ -112,7 +112,7 @@ end Finset
 
 /-- A listable type with decidable equality is encodable. -/
 def encodableOfList [DecidableEq α] (l : List α) (H : ∀ x, x ∈ l) : Encodable α :=
-  ⟨fun a => idxOf a l, l.get?, fun _ => idxOf_get? (H _)⟩
+  ⟨fun a => idxOf a l, (l[·]?), fun _ => getElem?_idxOf (H _)⟩
 
 /-- A finite type is encodable. Because the encoding is not unique, we wrap it in `Trunc` to
 preserve computability. -/


### PR DESCRIPTION
These changes are backports from `bump/nightly-2025-02-20`.