### PR TITLE
feat(AlgebraicTopology): generalize universes for toTop : SimplexCategory ⥤ TopCat

### DIFF
--- a/Mathlib/AlgebraicTopology/TopologicalSimplex.lean
+++ b/Mathlib/AlgebraicTopology/TopologicalSimplex.lean
@@ -5,7 +5,7 @@ Authors: Johan Commelin, Adam Topaz
 -/
 import Mathlib.Algebra.BigOperators.Ring.Finset
 import Mathlib.AlgebraicTopology.SimplexCategory.Basic
-import Mathlib.Topology.Category.TopCat.Basic
+import Mathlib.Topology.Category.TopCat.ULift
 import Mathlib.Topology.Connected.PathConnected
 import Mathlib.Topology.Instances.NNReal.Defs
 
@@ -17,6 +17,7 @@ topological `n`-simplex.
 This is used to define `TopCat.toSSet` in `AlgebraicTopology.SingularSet`.
 -/
 
+universe u
 
 noncomputable section
 
@@ -100,7 +101,7 @@ theorem continuous_toTopMap {x y : SimplexCategory} (f : x ⟶ y) : Continuous (
 
 /-- The functor associating the topological `n`-simplex to `⦋n⦌ : SimplexCategory`. -/
 @[simps obj map]
-def toTop : SimplexCategory ⥤ TopCat where
+def toTop₀ : SimplexCategory ⥤ TopCat.{0} where
   obj x := TopCat.of x.toTopObj
   map f := TopCat.ofHom ⟨toTopMap f, by continuity⟩
   map_id := by
@@ -117,5 +118,10 @@ def toTop : SimplexCategory ⥤ TopCat where
       · exact Finset.ext (fun j => ⟨fun hj => by simpa using hj, fun hj => by simpa using hj⟩)
       · tauto
     · apply Set.pairwiseDisjoint_filter
+
+/-- The functor associating the topological `n`-simplex to `⦋n⦌ : SimplexCategory`. -/
+@[simps! (config := .lemmasOnly) obj map]
+def toTop : SimplexCategory ⥤ TopCat.{u} :=
+  toTop₀ ⋙ TopCat.uliftFunctor
 
 end SimplexCategory


### PR DESCRIPTION
`toTop` is generalized as `SimplexCategory ⥤ TopCat.{u}` for any universe `u`. This prepares for a future similar generalization for the topological realization functor `SSet.{u} ⥤ TopCat.{u}`.

---
(Not ready yet.)

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
