### PR TITLE
feat: add definition of pushdown automata

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2512,6 +2512,7 @@ import Mathlib.Computability.Halting
 import Mathlib.Computability.Language
 import Mathlib.Computability.MyhillNerode
 import Mathlib.Computability.NFA
+import Mathlib.Computability.PDA
 import Mathlib.Computability.Partrec
 import Mathlib.Computability.PartrecCode
 import Mathlib.Computability.PostTuringMachine

--- a/Mathlib/Computability/PDA.lean
+++ b/Mathlib/Computability/PDA.lean
@@ -42,37 +42,37 @@ structure Conf (p : PDA Q T S) where
   /-- Current stack. -/
   stack : List S
 
-variable {pda : PDA Q T S}
+variable {M : PDA Q T S}
 
 /-- `step r₁` is the set of configurations reachable from `r₁` in one step. -/
-def step (r₁ : Conf pda) : Set (Conf pda) :=
+def step (r₁ : Conf M) : Set (Conf M) :=
   match r₁ with
     | ⟨q, a::w, Z::α⟩ =>
-        { r₂ : Conf pda | ∃ (p : Q) (β : List S), (p,β) ∈ pda.transition_fun q (some a) Z ∧
+        { r₂ : Conf M | ∃ (p : Q) (β : List S), (p,β) ∈ M.transition_fun q (some a) Z ∧
                           r₂ = ⟨p, w, (β ++ α)⟩ } ∪
-        { r₂ : Conf pda | ∃ (p : Q) (β : List S), (p,β) ∈ pda.transition_fun q none Z ∧
+        { r₂ : Conf M | ∃ (p : Q) (β : List S), (p,β) ∈ M.transition_fun q none Z ∧
                           r₂ = ⟨p, a :: w, (β ++ α)⟩ }
-    | ⟨q, [], Z::α⟩ => { r₂ : Conf pda | ∃ (p : Q) (β : List S),
-                                          (p,β) ∈ pda.transition_fun q none Z
+    | ⟨q, [], Z::α⟩ => { r₂ : Conf M | ∃ (p : Q) (β : List S),
+                                          (p,β) ∈ M.transition_fun q none Z
                                           ∧ r₂ = ⟨p, [], (β ++ α)⟩ }
     | ⟨_, _, []⟩ => ∅
 
 /-- `Reaches₁ r₁ r₂` means that `r₂` is reachable from `r₁` in one step. -/
-def Reaches₁ (r₁ r₂ : Conf pda) : Prop := r₂ ∈ step r₁
+def Reaches₁ (r₁ r₂ : Conf M) : Prop := r₂ ∈ step r₁
 
 /-- `Reaches r₁ r₂` means that `r₂` is reachable from `r₁` in finitely many steps. -/
-def Reaches : Conf pda → Conf pda → Prop := Relation.ReflTransGen Reaches₁
+def Reaches : Conf M → Conf M → Prop := Relation.ReflTransGen Reaches₁
 
-/-- `acceptsByEmptyStack pda` is the language accepted by the PDA `pda` based on the empty-stack
+/-- `acceptsByEmptyStack M` is the language accepted by the PDA `M` based on the empty-stack
   condition. -/
-def acceptsByEmptyStack (pda : PDA Q T S) : Language T :=
+def acceptsByEmptyStack (M : PDA Q T S) : Language T :=
   { w : List T | ∃ q : Q,
-      Reaches (⟨pda.initial_state, w, [pda.start_symbol]⟩ : Conf pda) ⟨q, [], []⟩ }
+      Reaches (⟨M.initial_state, w, [M.start_symbol]⟩ : Conf M) ⟨q, [], []⟩ }
 
-/-- `acceptsByFinalState pda` is the language accepted by the PDA `pda` based on the final-state
+/-- `acceptsByFinalState M` is the language accepted by the PDA `M` based on the final-state
   condition. -/
-def acceptsByFinalState (pda : PDA Q T S) : Language T :=
-  { w : List T | ∃ q ∈ pda.final_states, ∃ γ : List S,
-      Reaches (⟨pda.initial_state, w, [pda.start_symbol]⟩ : Conf pda) ⟨q, [], γ⟩ }
+def acceptsByFinalState (M : PDA Q T S) : Language T :=
+  { w : List T | ∃ q ∈ M.final_states, ∃ γ : List S,
+      Reaches (⟨M.initial_state, w, [M.start_symbol]⟩ : Conf M) ⟨q, [], γ⟩ }
 
 end PDA

--- a/Mathlib/Computability/PDA.lean
+++ b/Mathlib/Computability/PDA.lean
@@ -1,0 +1,62 @@
+/-
+Copyright (c) 2025 Stefan Hetzl. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Tobias Leichtfried, Stefan Hetzl
+-/
+import Mathlib.Computability.Language
+
+/-!
+# Pushdown Automata
+
+This file contains the definition of a Pushdown Automaton (PDA). Pushdown automata recognize
+exactly the context-free languages.
+-/
+
+/-- A PDA is a set of states (`Q`), a tape alphabet (`T`), a stack alphabet (`S`),  an inital state
+  (`initial_state`), a start symbol (`start_symbol`), a set of final states (`final_states`), and a
+  transition function. The transition function is given in two parts: `transition_fun` reads a
+  letter and `transition_fun'` makes an epsilon transition. -/
+structure PDA (Q T S : Type) [Fintype Q] [Fintype T] [Fintype S] where
+  initial_state : Q
+  start_symbol : S
+  final_states : Set Q
+  transition_fun : Q → T → S → Set (Q × List S)
+  transition_fun' : Q → S → Set (Q × List S)
+  finite (q : Q)(a : T)(Z : S): (transition_fun q a Z).Finite
+  finite' (q : Q)(Z : S): (transition_fun' q Z).Finite
+
+namespace PDA
+
+variable {Q T S : Type} [Fintype Q] [Fintype T] [Fintype S]
+
+@[ext]
+structure conf (p : PDA Q T S) where
+  state : Q
+  input : List T
+  stack : List S
+
+variable {pda : PDA Q T S}
+
+def step (r₁ : conf pda) : Set (conf pda) :=
+  match r₁ with
+    | ⟨q, a::w, Z::α⟩ =>
+        { r₂ : conf pda | ∃ (p : Q) (β : List S), (p,β) ∈ pda.transition_fun q a Z ∧
+                          r₂ = ⟨p, w, (β ++ α)⟩ } ∪
+        { r₂ : conf pda | ∃ (p : Q) (β : List S), (p,β) ∈ pda.transition_fun' q Z ∧
+                          r₂ = ⟨p, a :: w, (β ++ α)⟩ }
+    | ⟨q, [], Z::α⟩ => { r₂ : conf pda | ∃ (p : Q) (β : List S), (p,β) ∈ pda.transition_fun' q Z ∧
+                                          r₂ = ⟨p, [], (β ++ α)⟩ }
+    | ⟨_, _, []⟩ => ∅
+
+def Reaches₁ (r₁ r₂ : conf pda) : Prop := r₂ ∈ step r₁
+def Reaches : conf pda → conf pda → Prop := Relation.ReflTransGen Reaches₁
+
+def acceptsByEmptyStack (pda : PDA Q T S) : Language T :=
+  { w : List T | ∃ q : Q,
+      Reaches (⟨pda.initial_state, w, [pda.start_symbol]⟩ : conf pda) ⟨q, [], []⟩ }
+
+def acceptsByFinalState (pda : PDA Q T S) : Language T :=
+  { w : List T | ∃ q  ∈ pda.final_states, ∃ γ : List S,
+      Reaches (⟨pda.initial_state, w, [pda.start_symbol]⟩ : conf pda) ⟨q, [], γ⟩ }
+
+end PDA

--- a/Mathlib/Computability/PDA.lean
+++ b/Mathlib/Computability/PDA.lean
@@ -44,19 +44,6 @@ structure Conf (p : PDA Q T S) where
 
 variable {M : PDA Q T S}
 
-/-- `step r₁` is the set of configurations reachable from `r₁` in one step. -/
-def step (r₁ : Conf M) : Set (Conf M) :=
-  match r₁ with
-    | ⟨q, a::w, Z::α⟩ =>
-        { r₂ : Conf M | ∃ (p : Q) (β : List S), (p,β) ∈ M.transition_fun q (some a) Z ∧
-                          r₂ = ⟨p, w, (β ++ α)⟩ } ∪
-        { r₂ : Conf M | ∃ (p : Q) (β : List S), (p,β) ∈ M.transition_fun q none Z ∧
-                          r₂ = ⟨p, a :: w, (β ++ α)⟩ }
-    | ⟨q, [], Z::α⟩ => { r₂ : Conf M | ∃ (p : Q) (β : List S),
-                                          (p,β) ∈ M.transition_fun q none Z
-                                          ∧ r₂ = ⟨p, [], (β ++ α)⟩ }
-    | ⟨_, _, []⟩ => ∅
-
 /-- `Reaches₁ r₁ r₂` means that `r₂` is reachable from `r₁` in one step. -/
 def Reaches₁ (r₁ r₂ : Conf M) : Prop :=
   ∃ (Z : S) (α : List S) (β : List S), r₁.stack = Z::α ∧ r₂.stack = β++α ∧ (

--- a/Mathlib/Computability/PDA.lean
+++ b/Mathlib/Computability/PDA.lean
@@ -74,7 +74,7 @@ def acceptsByEmptyStack (pda : PDA Q T S) : Language T :=
 /-- `acceptsByFinalState pda` is the language accepted by the PDA `pda` based on the final-state
   condition. -/
 def acceptsByFinalState (pda : PDA Q T S) : Language T :=
-  { w : List T | ∃ q  ∈ pda.final_states, ∃ γ : List S,
+  { w : List T | ∃ q ∈ pda.final_states, ∃ γ : List S,
       Reaches (⟨pda.initial_state, w, [pda.start_symbol]⟩ : conf pda) ⟨q, [], γ⟩ }
 
 end PDA

--- a/Mathlib/Computability/PDA.lean
+++ b/Mathlib/Computability/PDA.lean
@@ -34,7 +34,7 @@ variable {Q T S : Type} [Fintype Q] [Fintype T] [Fintype S]
 /-- A configuration of a PDA is a state (`state`), the remaining input (`input`), and the current
   stack. -/
 @[ext]
-structure conf (p : PDA Q T S) where
+structure Conf (p : PDA Q T S) where
   /-- Current state. -/
   state : Q
   /-- Remaining input. -/
@@ -45,34 +45,34 @@ structure conf (p : PDA Q T S) where
 variable {pda : PDA Q T S}
 
 /-- `step r₁` is the set of configurations reachable from `r₁` in one step. -/
-def step (r₁ : conf pda) : Set (conf pda) :=
+def step (r₁ : Conf pda) : Set (Conf pda) :=
   match r₁ with
     | ⟨q, a::w, Z::α⟩ =>
-        { r₂ : conf pda | ∃ (p : Q) (β : List S), (p,β) ∈ pda.transition_fun q (some a) Z ∧
+        { r₂ : Conf pda | ∃ (p : Q) (β : List S), (p,β) ∈ pda.transition_fun q (some a) Z ∧
                           r₂ = ⟨p, w, (β ++ α)⟩ } ∪
-        { r₂ : conf pda | ∃ (p : Q) (β : List S), (p,β) ∈ pda.transition_fun q none Z ∧
+        { r₂ : Conf pda | ∃ (p : Q) (β : List S), (p,β) ∈ pda.transition_fun q none Z ∧
                           r₂ = ⟨p, a :: w, (β ++ α)⟩ }
-    | ⟨q, [], Z::α⟩ => { r₂ : conf pda | ∃ (p : Q) (β : List S),
+    | ⟨q, [], Z::α⟩ => { r₂ : Conf pda | ∃ (p : Q) (β : List S),
                                           (p,β) ∈ pda.transition_fun q none Z
                                           ∧ r₂ = ⟨p, [], (β ++ α)⟩ }
     | ⟨_, _, []⟩ => ∅
 
 /-- `Reaches₁ r₁ r₂` means that `r₂` is reachable from `r₁` in one step. -/
-def Reaches₁ (r₁ r₂ : conf pda) : Prop := r₂ ∈ step r₁
+def Reaches₁ (r₁ r₂ : Conf pda) : Prop := r₂ ∈ step r₁
 
 /-- `Reaches r₁ r₂` means that `r₂` is reachable from `r₁` in finitely many steps. -/
-def Reaches : conf pda → conf pda → Prop := Relation.ReflTransGen Reaches₁
+def Reaches : Conf pda → Conf pda → Prop := Relation.ReflTransGen Reaches₁
 
 /-- `acceptsByEmptyStack pda` is the language accepted by the PDA `pda` based on the empty-stack
   condition. -/
 def acceptsByEmptyStack (pda : PDA Q T S) : Language T :=
   { w : List T | ∃ q : Q,
-      Reaches (⟨pda.initial_state, w, [pda.start_symbol]⟩ : conf pda) ⟨q, [], []⟩ }
+      Reaches (⟨pda.initial_state, w, [pda.start_symbol]⟩ : Conf pda) ⟨q, [], []⟩ }
 
 /-- `acceptsByFinalState pda` is the language accepted by the PDA `pda` based on the final-state
   condition. -/
 def acceptsByFinalState (pda : PDA Q T S) : Language T :=
   { w : List T | ∃ q ∈ pda.final_states, ∃ γ : List S,
-      Reaches (⟨pda.initial_state, w, [pda.start_symbol]⟩ : conf pda) ⟨q, [], γ⟩ }
+      Reaches (⟨pda.initial_state, w, [pda.start_symbol]⟩ : Conf pda) ⟨q, [], γ⟩ }
 
 end PDA

--- a/Mathlib/Computability/PDA.lean
+++ b/Mathlib/Computability/PDA.lean
@@ -12,7 +12,7 @@ This file contains the definition of a Pushdown Automaton (PDA). Pushdown automa
 exactly the context-free languages.
 -/
 
-/-- A PDA is a set of states (`Q`), a tape alphabet (`T`), a stack alphabet (`S`),  an inital state
+/-- A PDA is a set of states (`Q`), a tape alphabet (`T`), a stack alphabet (`S`), an initial state
   (`initial_state`), a start symbol (`start_symbol`), a set of final states (`final_states`), and a
   transition function. The transition function is given in two parts: `transition_fun` reads a
   letter and `transition_fun'` makes an epsilon transition. -/

--- a/Mathlib/Computability/PDA.lean
+++ b/Mathlib/Computability/PDA.lean
@@ -58,7 +58,11 @@ def step (r₁ : Conf M) : Set (Conf M) :=
     | ⟨_, _, []⟩ => ∅
 
 /-- `Reaches₁ r₁ r₂` means that `r₂` is reachable from `r₁` in one step. -/
-def Reaches₁ (r₁ r₂ : Conf M) : Prop := r₂ ∈ step r₁
+def Reaches₁ (r₁ r₂ : Conf M) : Prop :=
+  ∃ (Z : S) (α : List S) (β : List S), r₁.stack = Z::α ∧ r₂.stack = β++α ∧ (
+    (r₁.input = r₂.input ∧ (r₂.state, β) ∈ (M.transition_fun r₁.state none Z)) ∨
+    (∃ (a : T), r₁.input = a::r₂.input ∧ (r₂.state, β) ∈ (M.transition_fun r₁.state (some a) Z))
+  )
 
 /-- `Reaches r₁ r₂` means that `r₂` is reachable from `r₁` in finitely many steps. -/
 def Reaches : Conf M → Conf M → Prop := Relation.ReflTransGen Reaches₁

--- a/Mathlib/Computability/PDA.lean
+++ b/Mathlib/Computability/PDA.lean
@@ -23,7 +23,7 @@ structure PDA (Q T S : Type) [Fintype Q] [Fintype T] [Fintype S] where
   start_symbol : S
   /-- Set of final states. -/
   final_states : Set Q
-  /-- Transition function reading a letter from T. -/
+  /-- Transition function reading a letter from `T`. -/
   transition_fun : Q → T → S → Set (Q × List S)
   /-- Epsilon transition function. -/
   transition_fun' : Q → S → Set (Q × List S)

--- a/Mathlib/Computability/PDA.lean
+++ b/Mathlib/Computability/PDA.lean
@@ -28,7 +28,7 @@ structure PDA (Q T S : Type) [Fintype Q] [Fintype T] [Fintype S] where
   /-- Epsilon transition function. -/
   transition_fun' : Q → S → Set (Q × List S)
   finite (q : Q) (a : T) (Z : S) : (transition_fun q a Z).Finite
-  finite' (q : Q)(Z : S): (transition_fun' q Z).Finite
+  finite' (q : Q) (Z : S) : (transition_fun' q Z).Finite
 
 namespace PDA
 

--- a/Mathlib/Computability/PDA.lean
+++ b/Mathlib/Computability/PDA.lean
@@ -27,7 +27,7 @@ structure PDA (Q T S : Type) [Fintype Q] [Fintype T] [Fintype S] where
   transition_fun : Q → T → S → Set (Q × List S)
   /-- Epsilon transition function. -/
   transition_fun' : Q → S → Set (Q × List S)
-  finite (q : Q)(a : T)(Z : S): (transition_fun q a Z).Finite
+  finite (q : Q) (a : T) (Z : S) : (transition_fun q a Z).Finite
   finite' (q : Q)(Z : S): (transition_fun' q Z).Finite
 
 namespace PDA

--- a/Mathlib/Computability/PDA.lean
+++ b/Mathlib/Computability/PDA.lean
@@ -17,10 +17,15 @@ exactly the context-free languages.
   transition function. The transition function is given in two parts: `transition_fun` reads a
   letter and `transition_fun'` makes an epsilon transition. -/
 structure PDA (Q T S : Type) [Fintype Q] [Fintype T] [Fintype S] where
+  /-- Initial state. -/
   initial_state : Q
+  /-- Start symbol on the stack. -/
   start_symbol : S
+  /-- Set of final states. -/
   final_states : Set Q
+  /-- Transition function reading a letter from T. -/
   transition_fun : Q → T → S → Set (Q × List S)
+  /-- Epsilon transition function. -/
   transition_fun' : Q → S → Set (Q × List S)
   finite (q : Q)(a : T)(Z : S): (transition_fun q a Z).Finite
   finite' (q : Q)(Z : S): (transition_fun' q Z).Finite
@@ -29,14 +34,20 @@ namespace PDA
 
 variable {Q T S : Type} [Fintype Q] [Fintype T] [Fintype S]
 
+/-- A configuration of a PDA is a state (`state`), the remaining input (`input`), and the current
+  stack. -/
 @[ext]
 structure conf (p : PDA Q T S) where
+  /-- Current state. -/
   state : Q
+  /-- Remaining input. -/
   input : List T
+  /-- Current stack. -/
   stack : List S
 
 variable {pda : PDA Q T S}
 
+/-- `step r₁` is the set of configurations reachable from `r₁` in one step. -/
 def step (r₁ : conf pda) : Set (conf pda) :=
   match r₁ with
     | ⟨q, a::w, Z::α⟩ =>
@@ -48,13 +59,20 @@ def step (r₁ : conf pda) : Set (conf pda) :=
                                           r₂ = ⟨p, [], (β ++ α)⟩ }
     | ⟨_, _, []⟩ => ∅
 
+/-- `Reaches₁ r₁ r₂` means that `r₂` is reachable from `r₁` in one step. -/
 def Reaches₁ (r₁ r₂ : conf pda) : Prop := r₂ ∈ step r₁
+
+/-- `Reaches r₁ r₂` means that `r₂` is reachable from `r₁` in finitely many steps. -/
 def Reaches : conf pda → conf pda → Prop := Relation.ReflTransGen Reaches₁
 
+/-- `acceptsByEmptyStack pda` is the language accepted by the PDA `pda` based on the empty-stack
+  condition. -/
 def acceptsByEmptyStack (pda : PDA Q T S) : Language T :=
   { w : List T | ∃ q : Q,
       Reaches (⟨pda.initial_state, w, [pda.start_symbol]⟩ : conf pda) ⟨q, [], []⟩ }
 
+/-- `acceptsByFinalState pda` is the language accepted by the PDA `pda` based on the final-state
+  condition. -/
 def acceptsByFinalState (pda : PDA Q T S) : Language T :=
   { w : List T | ∃ q  ∈ pda.final_states, ∃ γ : List S,
       Reaches (⟨pda.initial_state, w, [pda.start_symbol]⟩ : conf pda) ⟨q, [], γ⟩ }

--- a/Mathlib/Computability/PDA.lean
+++ b/Mathlib/Computability/PDA.lean
@@ -13,19 +13,19 @@ exactly the context-free languages.
 -/
 
 /-- A PDA is a set of states (`Q`), a tape alphabet (`T`), a stack alphabet (`S`), an initial state
-  (`initial_state`), a start symbol (`start_symbol`), a set of final states (`final_states`), a
-  transition function (`transition_fun`), and a proof that, for any input, the transition function
-  returns a finite set as output. -/
+(`initial_state`), a start symbol (`start_symbol`), a set of final states (`final_states`), a
+transition function (`transition_fun`), and a proof that, for any input, the transition function
+returns a finite set as output. -/
 structure PDA (Q T S : Type) [Fintype Q] [Fintype T] [Fintype S] where
   /-- Initial state. -/
-  initial_state : Q
+  initialState : Q
   /-- Start symbol on the stack. -/
-  start_symbol : S
+  startSymbol : S
   /-- Set of final states. -/
-  final_states : Set Q
+  finalStates : Set Q
   /-- Transition function reading a letter from `T` if present and an epsilon otherwise. -/
-  transition_fun : Q → (Option T) → S → Set (Q × List S)
-  finite (q : Q) (x : (Option T)) (Z : S) : (transition_fun q x Z).Finite
+  transitionFun : Q → Option T → S → Set (Q × List S)
+  finite_transitionFun (q : Q) (x : Option T) (Z : S) : (transitionFun q x Z).Finite
 
 namespace PDA
 
@@ -46,9 +46,9 @@ variable {M : PDA Q T S}
 
 /-- `Reaches₁ r₁ r₂` means that `r₂` is reachable from `r₁` in one step. -/
 def Reaches₁ (r₁ r₂ : Conf M) : Prop :=
-  ∃ (Z : S) (α : List S) (β : List S), r₁.stack = Z::α ∧ r₂.stack = β++α ∧ (
-    (r₁.input = r₂.input ∧ (r₂.state, β) ∈ (M.transition_fun r₁.state none Z)) ∨
-    (∃ (a : T), r₁.input = a::r₂.input ∧ (r₂.state, β) ∈ (M.transition_fun r₁.state (some a) Z))
+  ∃ (Z : S) (α : List S) (β : List S), r₁.stack = Z :: α ∧ r₂.stack = β ++ α ∧ (
+    r₁.input = r₂.input ∧ (r₂.state, β) ∈ M.transition_fun r₁.state none Z ∨
+    ∃ (a : T), r₁.input = a :: r₂.input ∧ (r₂.state, β) ∈ (M.transition_fun r₁.state (some a) Z)
   )
 
 /-- `Reaches r₁ r₂` means that `r₂` is reachable from `r₁` in finitely many steps. -/

--- a/Mathlib/Computability/PDA.lean
+++ b/Mathlib/Computability/PDA.lean
@@ -47,8 +47,8 @@ variable {M : PDA Q T S}
 /-- `Reaches₁ r₁ r₂` means that `r₂` is reachable from `r₁` in one step. -/
 def Reaches₁ (r₁ r₂ : Conf M) : Prop :=
   ∃ (Z : S) (α : List S) (β : List S), r₁.stack = Z :: α ∧ r₂.stack = β ++ α ∧ (
-    r₁.input = r₂.input ∧ (r₂.state, β) ∈ M.transition_fun r₁.state none Z ∨
-    ∃ (a : T), r₁.input = a :: r₂.input ∧ (r₂.state, β) ∈ (M.transition_fun r₁.state (some a) Z)
+    r₁.input = r₂.input ∧ (r₂.state, β) ∈ M.transitionFun r₁.state none Z ∨
+    ∃ (a : T), r₁.input = a :: r₂.input ∧ (r₂.state, β) ∈ (M.transitionFun r₁.state (some a) Z)
   )
 
 /-- `Reaches r₁ r₂` means that `r₂` is reachable from `r₁` in finitely many steps. -/
@@ -58,12 +58,12 @@ def Reaches : Conf M → Conf M → Prop := Relation.ReflTransGen Reaches₁
   condition. -/
 def acceptsByEmptyStack (M : PDA Q T S) : Language T :=
   { w : List T | ∃ q : Q,
-      Reaches (⟨M.initial_state, w, [M.start_symbol]⟩ : Conf M) ⟨q, [], []⟩ }
+      Reaches (⟨M.initialState, w, [M.startSymbol]⟩ : Conf M) ⟨q, [], []⟩ }
 
 /-- `acceptsByFinalState M` is the language accepted by the PDA `M` based on the final-state
   condition. -/
 def acceptsByFinalState (M : PDA Q T S) : Language T :=
-  { w : List T | ∃ q ∈ M.final_states, ∃ γ : List S,
-      Reaches (⟨M.initial_state, w, [M.start_symbol]⟩ : Conf M) ⟨q, [], γ⟩ }
+  { w : List T | ∃ q ∈ M.finalStates, ∃ γ : List S,
+      Reaches (⟨M.initialState, w, [M.startSymbol]⟩ : Conf M) ⟨q, [], γ⟩ }
 
 end PDA


### PR DESCRIPTION
Add the definition of pushdown automata and their two acceptance conditions: acceptance based on empty stack and acceptance based on final state.

Co-authored-by: Tobias Leichtfried <tobias.leichtfried@tuwien.ac.at>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
