### PR TITLE
[Merged by Bors] - feat: tweak calc widget

### DIFF
--- a/Mathlib/Tactic/Widget/Calc.lean
+++ b/Mathlib/Tactic/Widget/Calc.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Patrick Massot
 -/
 import Lean.Elab.Tactic.Calc
+import Lean.Meta.Tactic.TryThis
 
 import Mathlib.Data.String.Defs
 import Mathlib.Tactic.Widget.SelectPanelUtils
@@ -76,7 +77,8 @@ def suggestSteps (pos : Array Lean.SubExpr.GoalsLocation) (goalType : Expr) (par
   let mut goalType := goalType
   for pos in subexprPos do
     goalType ← insertMetaVar goalType pos
-  let some (_, newLhs, newRhs) ← Lean.Elab.Term.getCalcRelation? goalType | unreachable!
+  let some (_, newLhs, newRhs) ← Lean.Elab.Term.getCalcRelation? goalType |
+      throwError "invalid 'calc' step, relation expected{indentExpr goalType}"
 
   let lhsStr := (toString <| ← Meta.ppExpr lhs).renameMetaVar
   let newLhsStr := (toString <| ← Meta.ppExpr newLhs).renameMetaVar
@@ -115,7 +117,7 @@ def suggestSteps (pos : Array Lean.SubExpr.GoalsLocation) (goalType : Expr) (par
 /-- Rpc function for the calc widget. -/
 @[server_rpc_method]
 def CalcPanel.rpc := mkSelectionPanelRPC suggestSteps
-  "Please select subterms."
+  "Please select subterms using Shift-click."
   "Calc 🔍"
 
 /-- The calc widget. -/
@@ -124,19 +126,29 @@ def CalcPanel : Component CalcParams :=
   mk_rpc_widget% CalcPanel.rpc
 
 namespace Lean.Elab.Tactic
-open Meta
+
+open Lean Meta Tactic TryThis in
+elab stx:"calc?" : tactic => do
+  let some calcRange := (← getFileMap).rangeOfStx? stx | throwError "calc? failed"
+  let indent := calcRange.start.character + 2
+  let spc := String.replicate indent ' '
+  let goalType ← getMainTarget
+  unless (← Lean.Elab.Term.getCalcRelation? goalType).isSome do
+    throwError "Cannot start a calculation here: the goal{indentExpr goalType}\nis not a relation."
+  let goalFmt ← Meta.ppExpr (← getMainTarget)
+  let s := s!"calc\n{spc}{goalFmt} := by sorry"
+  addSuggestions (← getRef) #[.suggestion s] (header := "Create calc tactic:")
+  evalTactic (← `(tactic|sorry))
 
 /-- Elaborator for the `calc` tactic mode variant with widgets. -/
 elab_rules : tactic
 | `(tactic|calc%$calcstx $steps) => do
-  let some calcRange := (← getFileMap).rangeOfStx? calcstx | unreachable!
-  let indent := calcRange.start.character
   let mut isFirst := true
   for step in ← Lean.Elab.Term.mkCalcStepViews steps do
-    let some replaceRange := (← getFileMap).rangeOfStx? step.ref | unreachable!
+    let some replaceRange := (← getFileMap).rangeOfStx? step.ref | continue
     let json := json% {"replaceRange": $(replaceRange),
                         "isFirst": $(isFirst),
-                        "indent": $(indent)}
+                        "indent": $(replaceRange.start.character)}
     Widget.savePanelWidgetInfo CalcPanel.javascriptHash (pure json) step.proof
     isFirst := false
   evalCalc (← `(tactic|calc%$calcstx $steps))

--- a/Mathlib/Tactic/Widget/Calc.lean
+++ b/Mathlib/Tactic/Widget/Calc.lean
@@ -130,15 +130,11 @@ namespace Lean.Elab.Tactic
 open Lean Meta Tactic TryThis in
 /-- Create a `calc` proof. -/
 elab stx:"calc?" : tactic => withMainContext do
-  let some calcRange := (← getFileMap).rangeOfStx? stx | throwError "calc? failed"
-  let indent := calcRange.start.character + 2
-  let spc := String.replicate indent ' '
   let goalType ← whnfR (← getMainTarget)
   unless (← Lean.Elab.Term.getCalcRelation? goalType).isSome do
     throwError "Cannot start a calculation here: the goal{indentExpr goalType}\nis not a relation."
-  let goalFmt ← Meta.ppExpr (← getMainTarget)
-  let s := s!"calc\n{spc}{goalFmt} := by sorry"
-  addSuggestions (← getRef) #[.suggestion s] (header := "Create calc tactic:")
+  let s ← `(tactic| calc $(← Lean.PrettyPrinter.delab (← getMainTarget)) := by sorry)
+  addSuggestions stx #[.suggestion s] (header := "Create calc tactic:")
   evalTactic (← `(tactic|sorry))
 
 /-- Elaborator for the `calc` tactic mode variant with widgets. -/

--- a/Mathlib/Tactic/Widget/Calc.lean
+++ b/Mathlib/Tactic/Widget/Calc.lean
@@ -133,7 +133,7 @@ elab stx:"calc?" : tactic => withMainContext do
   let some calcRange := (← getFileMap).rangeOfStx? stx | throwError "calc? failed"
   let indent := calcRange.start.character + 2
   let spc := String.replicate indent ' '
-  let goalType ← getMainTarget
+  let goalType ← whnfR (← getMainTarget)
   unless (← Lean.Elab.Term.getCalcRelation? goalType).isSome do
     throwError "Cannot start a calculation here: the goal{indentExpr goalType}\nis not a relation."
   let goalFmt ← Meta.ppExpr (← getMainTarget)

--- a/Mathlib/Tactic/Widget/Calc.lean
+++ b/Mathlib/Tactic/Widget/Calc.lean
@@ -128,6 +128,7 @@ def CalcPanel : Component CalcParams :=
 namespace Lean.Elab.Tactic
 
 open Lean Meta Tactic TryThis in
+/-- Create a `calc` proof. -/
 elab stx:"calc?" : tactic => do
   let some calcRange := (← getFileMap).rangeOfStx? stx | throwError "calc? failed"
   let indent := calcRange.start.character + 2

--- a/Mathlib/Tactic/Widget/Calc.lean
+++ b/Mathlib/Tactic/Widget/Calc.lean
@@ -129,7 +129,7 @@ namespace Lean.Elab.Tactic
 
 open Lean Meta Tactic TryThis in
 /-- Create a `calc` proof. -/
-elab stx:"calc?" : tactic => do
+elab stx:"calc?" : tactic => withMainContext do
   let some calcRange := (← getFileMap).rangeOfStx? stx | throwError "calc? failed"
   let indent := calcRange.start.character + 2
   let spc := String.replicate indent ' '

--- a/MathlibTest/CalcQuestionMark.lean
+++ b/MathlibTest/CalcQuestionMark.lean
@@ -1,9 +1,16 @@
 import Mathlib.Tactic.Widget.Calc
 
+/-!
+Note that while the suggestions look incorrectly indented here,
+this is an artifact of the rendering to a string for `guard_msgs` (leanprover/lean4#7191).
+
+When used from the widget that appears in VSCode, they insert correctly-indented code.
+-/
+
 /--
 info: Create calc tactic:
 • calc
-    1 = 1 := by sorry
+  1 = 1 := by sorry
 ---
 warning: declaration uses 'sorry'
 -/
@@ -16,7 +23,7 @@ example : 1 = 1 := by
 /--
 info: Create calc tactic:
 • calc
-    a ≤ a := by sorry
+  a ≤ a := by sorry
 ---
 warning: declaration uses 'sorry'
 -/
@@ -29,7 +36,7 @@ example (a : Nat) : a ≤ a := by
 /--
 info: Create calc tactic:
 • calc
-      a ≤ a := by sorry
+  a ≤ a := by sorry
 ---
 warning: declaration uses 'sorry'
 -/
@@ -42,10 +49,12 @@ example (a : Nat) : a ≤ a := by
 /--
 info: Create calc tactic:
 • calc
-    1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 +
-      1 +
-    1 =
-  8 + 8 + 8 + 8 := by sorry
+  1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 +
+            1 +
+          1 +
+        1 =
+      8 + 8 + 8 + 8 :=
+    by sorry
 ---
 warning: declaration uses 'sorry'
 -/

--- a/MathlibTest/CalcQuestionMark.lean
+++ b/MathlibTest/CalcQuestionMark.lean
@@ -24,6 +24,20 @@ warning: declaration uses 'sorry'
 example (a : Nat) : a ≤ a := by
   calc?
 
+-- an indented `calc?`
+
+/--
+info: Create calc tactic:
+• calc
+      a ≤ a := by sorry
+---
+warning: declaration uses 'sorry'
+-/
+-- #guard_msgs in
+example (a : Nat) : a ≤ a := by
+  all_goals
+    calc?
+
 -- a deliberately long line
 /--
 info: Create calc tactic:

--- a/MathlibTest/CalcQuestionMark.lean
+++ b/MathlibTest/CalcQuestionMark.lean
@@ -9,6 +9,7 @@ warning: declaration uses 'sorry'
 -/
 #guard_msgs in
 example : 1 = 1 := by
+  have := 0
   calc?
 
 

--- a/MathlibTest/CalcQuestionMark.lean
+++ b/MathlibTest/CalcQuestionMark.lean
@@ -1,0 +1,24 @@
+import Mathlib.Tactic.Widget.Calc
+
+/--
+info: Create calc tactic:
+• calc
+    1 = 1 := by sorry
+---
+warning: declaration uses 'sorry'
+-/
+#guard_msgs in
+example : 1 = 1 := by
+  calc?
+
+
+/--
+info: Create calc tactic:
+• calc
+    a ≤ a := by sorry
+---
+warning: declaration uses 'sorry'
+-/
+#guard_msgs in
+example (a : Nat) : a ≤ a := by
+  calc?

--- a/MathlibTest/CalcQuestionMark.lean
+++ b/MathlibTest/CalcQuestionMark.lean
@@ -33,7 +33,7 @@ info: Create calc tactic:
 ---
 warning: declaration uses 'sorry'
 -/
--- #guard_msgs in
+#guard_msgs in
 example (a : Nat) : a ≤ a := by
   all_goals
     calc?

--- a/MathlibTest/CalcQuestionMark.lean
+++ b/MathlibTest/CalcQuestionMark.lean
@@ -23,3 +23,22 @@ warning: declaration uses 'sorry'
 #guard_msgs in
 example (a : Nat) : a ≤ a := by
   calc?
+
+-- a deliberately long line
+/--
+info: Create calc tactic:
+• calc
+    1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 +
+      1 +
+    1 =
+  8 + 8 + 8 + 8 := by sorry
+---
+warning: declaration uses 'sorry'
+-/
+#guard_msgs in
+example :
+    1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 +
+    1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 +
+    1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 +
+    1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 = 8 + 8 + 8 + 8 := by
+  calc?


### PR DESCRIPTION
First make the help text clearer for people who do not know how to select stuff in the info view (in VSCode or lean4web) by mentioning Shift-click.

Then make the indentation handling more robust to various calc layouts.

Also introduces a calc? tactic to complement the calc code action. The issues with the calc code action are:
1) it requires a valid calc syntax so writing calc is not enough. I
   typically write calc _ to get the code action. But when you write
   calc and there is already something below that could vaguely be
   mistaken for a calc then the code action triggers and the replacement
   swallows the following syntax.
2) A code action is less visible than a TryThis (but this wouldn’t be
   enough motivation for me without the previous point).

Also get rid of two `unreachable!` since experience show that those branches can be reached when handling malformed inputs, and the panic is awful for users.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
