### PR TITLE
[Merged by Bors] - feat(CategoryTheory): embeddings for opposites of Grothendieck abelian categories

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1707,6 +1707,7 @@ import Mathlib.CategoryTheory.Abelian.GrothendieckAxioms.Types
 import Mathlib.CategoryTheory.Abelian.GrothendieckCategory.Basic
 import Mathlib.CategoryTheory.Abelian.GrothendieckCategory.ColimCoyoneda
 import Mathlib.CategoryTheory.Abelian.GrothendieckCategory.EnoughInjectives
+import Mathlib.CategoryTheory.Abelian.GrothendieckCategory.ModuleEmbedding.Opposite
 import Mathlib.CategoryTheory.Abelian.GrothendieckCategory.Monomorphisms
 import Mathlib.CategoryTheory.Abelian.GrothendieckCategory.Subobject
 import Mathlib.CategoryTheory.Abelian.Images

--- a/Mathlib/CategoryTheory/Abelian/GrothendieckCategory/ModuleEmbedding/Opposite.lean
+++ b/Mathlib/CategoryTheory/Abelian/GrothendieckCategory/ModuleEmbedding/Opposite.lean
@@ -14,7 +14,7 @@ universe w v u
 
 If `C` is Grothendieck abelian and `F : D ⥤ Cᵒᵖ` is a functor from a small category, we construct
 an object `G : Cᵒᵖ` such that `preadditiveCoyonedaObj G : Cᵒᵖ ⥤ ModuleCat (End G)ᵐᵒᵖ` is faithful
-and exact and its precomsosition with `F` is full if `F` is.
+and exact and its precomposition with `F` is full if `F` is.
 -/
 
 open CategoryTheory Limits Opposite ZeroObject

--- a/Mathlib/CategoryTheory/Abelian/GrothendieckCategory/ModuleEmbedding/Opposite.lean
+++ b/Mathlib/CategoryTheory/Abelian/GrothendieckCategory/ModuleEmbedding/Opposite.lean
@@ -15,7 +15,7 @@ an object `G : Cᵒᵖ` such that `preadditiveCoyonedaObj G : Cᵒᵖ ⥤ Module
 and exact and its precomposition with `F` is full if `F` is.
 -/
 
-universe w v u
+universe v u
 
 open CategoryTheory Limits Opposite ZeroObject
 

--- a/Mathlib/CategoryTheory/Abelian/GrothendieckCategory/ModuleEmbedding/Opposite.lean
+++ b/Mathlib/CategoryTheory/Abelian/GrothendieckCategory/ModuleEmbedding/Opposite.lean
@@ -23,10 +23,6 @@ namespace CategoryTheory.Abelian.IsGrothendieckAbelian
 
 variable {C : Type u} [Category.{v} C] {D : Type v} [SmallCategory D] (F : D ⥤ Cᵒᵖ)
 
-theorem epi_comp' {X Y Z : C} {f : X ⟶ Y} {g : Y ⟶ Z} (hf : Epi f) (hg : Epi g) :
-    Epi (f ≫ g) :=
-  inferInstance
-
 namespace OppositeModuleEmbedding
 
 variable [Abelian C] [IsGrothendieckAbelian.{v} C]

--- a/Mathlib/CategoryTheory/Abelian/GrothendieckCategory/ModuleEmbedding/Opposite.lean
+++ b/Mathlib/CategoryTheory/Abelian/GrothendieckCategory/ModuleEmbedding/Opposite.lean
@@ -1,0 +1,93 @@
+/-
+Copyright (c) 2025 Markus Himmel. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Markus Himmel
+-/
+import Mathlib.CategoryTheory.Abelian.Yoneda
+import Mathlib.CategoryTheory.Generator.Abelian
+import Mathlib.CategoryTheory.Abelian.GrothendieckCategory.EnoughInjectives
+
+universe w v u
+
+/-!
+# Embedding opposites of Grothendieck categories
+
+If `C` is Grothendieck abelian and `F : D ⥤ Cᵒᵖ` is a functor from a small category, we construct
+an object `G : Cᵒᵖ` such that `preadditiveCoyonedaObj G : Cᵒᵖ ⥤ ModuleCat (End G)ᵐᵒᵖ` is faithful
+and exact and its precomsosition with `F` is full if `F` is.
+-/
+
+open CategoryTheory Limits Opposite ZeroObject
+
+namespace CategoryTheory.Abelian.IsGrothendieckAbelian
+
+variable {C : Type u} [Category.{v} C] {D : Type v} [SmallCategory D] (F : D ⥤ Cᵒᵖ)
+
+theorem epi_comp' {X Y Z : C} {f : X ⟶ Y} {g : Y ⟶ Z} (hf : Epi f) (hg : Epi g) :
+    Epi (f ≫ g) :=
+  inferInstance
+
+namespace OppositeModuleEmbedding
+
+variable [Abelian C] [IsGrothendieckAbelian.{v} C]
+
+variable (C) in
+private noncomputable def projectiveSeparator : Cᵒᵖ :=
+  (has_projective_separator (coseparator Cᵒᵖ) (isCoseparator_coseparator Cᵒᵖ)).choose
+
+private instance : Projective (projectiveSeparator C) :=
+  (has_projective_separator (coseparator Cᵒᵖ) (isCoseparator_coseparator Cᵒᵖ)).choose_spec.1
+
+private theorem isSeparator_projectiveSeparator : IsSeparator (projectiveSeparator C) :=
+  (has_projective_separator (coseparator Cᵒᵖ) (isCoseparator_coseparator Cᵒᵖ)).choose_spec.2
+
+private noncomputable def generator : Cᵒᵖ :=
+  ∐ (fun (X : D) => ∐ fun (_ : projectiveSeparator C ⟶ F.obj X) => projectiveSeparator C)
+
+private theorem exists_epi (X : D) : ∃ f : generator F ⟶ F.obj X, Epi f := by
+  classical
+  refine ⟨Sigma.desc (Pi.single X (𝟙 _)) ≫ Sigma.desc (fun f => f), ?_⟩
+  have h := (isSeparator_iff_epi (projectiveSeparator C)).1
+    isSeparator_projectiveSeparator (F.obj X)
+  suffices Epi (Sigma.desc (Pi.single X (𝟙 _))) from epi_comp' this h
+  exact SplitEpi.epi ⟨Sigma.ι (fun (X : D) => ∐ fun _ => projectiveSeparator C) X, by simp⟩
+
+private instance : Projective (generator F) := by
+  rw [generator]
+  infer_instance
+
+private theorem isSeparator [Nonempty D] : IsSeparator (generator F) := by
+  apply isSeparator_sigma_of_isSeparator _ Classical.ofNonempty
+  apply isSeparator_sigma_of_isSeparator _ 0
+  exact isSeparator_projectiveSeparator
+
+/-- Given a functor `F : D ⥤ Cᵒᵖ`, where `C` is Grothendieck abelian, this is a ring `R` such that
+`Cᵒᵖ` has a nice embedding into `ModuleCat (EmbeddingRing F)`; see
+`OppositeModuleEmbedding.embedding`. -/
+def EmbeddingRing : Type v := (End (generator F))ᵐᵒᵖ
+
+noncomputable instance : Ring (EmbeddingRing F) :=
+  inferInstanceAs <| Ring (End (generator F))ᵐᵒᵖ
+
+/-- This is a functor `embedding F : Cᵒᵖ ⥤ ModuleCat (EmbeddingRing F)`. We have that `embedding F`
+is faithful and preserves finite limits and colimits. Furthermore, `F ⋙ embedding F` is full. -/
+noncomputable def embedding : Cᵒᵖ ⥤ ModuleCat.{v} (EmbeddingRing F) :=
+  preadditiveCoyonedaObj (generator F)
+
+instance [Nonempty D] : (embedding F).Faithful :=
+  (isSeparator_iff_faithful_preadditiveCoyonedaObj _).1 (isSeparator F)
+
+instance [Nonempty D] [F.Full] : (F ⋙ embedding F).Full :=
+  full_comp_preadditiveCoyonedaObj _ (isSeparator F) (exists_epi F)
+
+instance : PreservesFiniteLimits (embedding F) := by
+  rw [embedding]
+  apply preservesFiniteLimits_of_preservesFiniteLimitsOfSize
+  infer_instance
+
+instance : PreservesFiniteColimits (embedding F) := by
+  apply preservesFiniteColimits_preadditiveCoyonedaObj_of_projective
+
+end OppositeModuleEmbedding
+
+end CategoryTheory.Abelian.IsGrothendieckAbelian

--- a/Mathlib/CategoryTheory/Abelian/GrothendieckCategory/ModuleEmbedding/Opposite.lean
+++ b/Mathlib/CategoryTheory/Abelian/GrothendieckCategory/ModuleEmbedding/Opposite.lean
@@ -7,8 +7,6 @@ import Mathlib.CategoryTheory.Abelian.Yoneda
 import Mathlib.CategoryTheory.Generator.Abelian
 import Mathlib.CategoryTheory.Abelian.GrothendieckCategory.EnoughInjectives
 
-universe w v u
-
 /-!
 # Embedding opposites of Grothendieck categories
 
@@ -16,6 +14,8 @@ If `C` is Grothendieck abelian and `F : D ⥤ Cᵒᵖ` is a functor from a small
 an object `G : Cᵒᵖ` such that `preadditiveCoyonedaObj G : Cᵒᵖ ⥤ ModuleCat (End G)ᵐᵒᵖ` is faithful
 and exact and its precomposition with `F` is full if `F` is.
 -/
+
+universe w v u
 
 open CategoryTheory Limits Opposite ZeroObject
 

--- a/Mathlib/CategoryTheory/Category/Basic.lean
+++ b/Mathlib/CategoryTheory/Category/Basic.lean
@@ -275,7 +275,7 @@ theorem cancel_mono_id (f : X ⟶ Y) [Mono f] {g : X ⟶ X} : g ≫ f = f ↔ g 
   simp
 
 /-- The composition of epimorphisms is again an epimorphism. This version takes `Epi f` and `Epi g`
-as typeclass arguments. For a version taking them as explicit arguments, see `epi_comp`. -/
+as typeclass arguments. For a version taking them as explicit arguments, see `epi_comp'`. -/
 instance epi_comp {X Y Z : C} (f : X ⟶ Y) [Epi f] (g : Y ⟶ Z) [Epi g] : Epi (f ≫ g) :=
   ⟨fun _ _ w => (cancel_epi g).1 <| (cancel_epi_assoc_iff f).1 w⟩
 
@@ -291,7 +291,7 @@ instance mono_comp {X Y Z : C} (f : X ⟶ Y) [Mono f] (g : Y ⟶ Z) [Mono g] : M
   ⟨fun _ _ w => (cancel_mono f).1 <| (cancel_mono_assoc_iff g).1 w⟩
 
 /-- The composition of monomorphisms is again a monomorphism. This version takes `Mono f` and
-`Mono g` as explicit arguments. For a version taking them as typeclass arguments, see `mono_comp'`.
+`Mono g` as explicit arguments. For a version taking them as typeclass arguments, see `mono_comp`.
 -/
 theorem mono_comp' {X Y Z : C} {f : X ⟶ Y} {g : Y ⟶ Z} (hf : Mono f) (hg : Mono g) :
     Mono (f ≫ g) :=

--- a/Mathlib/CategoryTheory/Category/Basic.lean
+++ b/Mathlib/CategoryTheory/Category/Basic.lean
@@ -274,11 +274,28 @@ theorem cancel_mono_id (f : X ⟶ Y) [Mono f] {g : X ⟶ X} : g ≫ f = f ↔ g 
   convert cancel_mono f
   simp
 
+/-- The composition of epimorphisms is again an epimorphism. This version takes `Epi f` and `Epi g`
+as typeclass arguments. For a version taking them as explicit arguments, see `epi_comp`. -/
 instance epi_comp {X Y Z : C} (f : X ⟶ Y) [Epi f] (g : Y ⟶ Z) [Epi g] : Epi (f ≫ g) :=
   ⟨fun _ _ w => (cancel_epi g).1 <| (cancel_epi_assoc_iff f).1 w⟩
 
+/-- The composition of epimorphisms is again an epimorphism. This version takes `Epi f` and `Epi g`
+as explicit arguments. For a version taking them as typeclass arguments, see `epi_comp`. -/
+theorem epi_comp' {X Y Z : C} {f : X ⟶ Y} {g : Y ⟶ Z} (hf : Epi f) (hg : Epi g) : Epi (f ≫ g) :=
+  inferInstance
+
+/-- The composition of monomorphisms is again a monomorphism. This version takes `Mono f` and
+`Mono g` as typeclass arguments. For a version taking them as explicit arguments, see `mono_comp'`.
+-/
 instance mono_comp {X Y Z : C} (f : X ⟶ Y) [Mono f] (g : Y ⟶ Z) [Mono g] : Mono (f ≫ g) :=
   ⟨fun _ _ w => (cancel_mono f).1 <| (cancel_mono_assoc_iff g).1 w⟩
+
+/-- The composition of monomorphisms is again a monomorphism. This version takes `Mono f` and
+`Mono g` as explicit arguments. For a version taking them as typeclass arguments, see `mono_comp'`.
+-/
+theorem mono_comp' {X Y Z : C} {f : X ⟶ Y} {g : Y ⟶ Z} (hf : Mono f) (hg : Mono g) :
+    Mono (f ≫ g) :=
+  inferInstance
 
 theorem mono_of_mono {X Y Z : C} (f : X ⟶ Y) (g : Y ⟶ Z) [Mono (f ≫ g)] : Mono f :=
   ⟨fun _ _ w => (cancel_mono (f ≫ g)).1 <| by simp only [← Category.assoc, w]⟩


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

- [ ] depends on: #22181

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
