### PR TITLE
[Merged by Bors] - feat: introduce a predicate `DependsOn`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3829,6 +3829,7 @@ import Mathlib.Logic.Function.Coequalizer
 import Mathlib.Logic.Function.CompTypeclasses
 import Mathlib.Logic.Function.Conjugate
 import Mathlib.Logic.Function.Defs
+import Mathlib.Logic.Function.DependsOn
 import Mathlib.Logic.Function.FiberPartition
 import Mathlib.Logic.Function.FromTypes
 import Mathlib.Logic.Function.Iterate

--- a/Mathlib/Data/Finset/Pi.lean
+++ b/Mathlib/Data/Finset/Pi.lean
@@ -6,6 +6,7 @@ Authors: Johannes Hölzl
 import Mathlib.Data.Finset.Card
 import Mathlib.Data.Finset.Union
 import Mathlib.Data.Multiset.Pi
+import Mathlib.Logic.Function.DependsOn
 
 /-!
 # The cartesian product of finsets
@@ -178,6 +179,9 @@ theorem restrict₂_comp_restrict {s t : Finset ι} (hst : s ⊆ t) :
 
 theorem restrict₂_comp_restrict₂ {s t u : Finset ι} (hst : s ⊆ t) (htu : t ⊆ u) :
     (restrict₂ (π := π) hst) ∘ (restrict₂ htu) = restrict₂ (hst.trans htu) := rfl
+
+lemma dependsOn_restrict (s : Finset ι) : DependsOn (s.restrict (π := π)) s :=
+  (s : Set ι).dependsOn_restrict
 
 end Pi
 

--- a/Mathlib/Data/Finset/Update.lean
+++ b/Mathlib/Data/Finset/Update.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Floris van Doorn
 -/
 import Mathlib.Data.Finset.Basic
+import Mathlib.Logic.Function.DependsOn
 
 /-!
 # Update a function on a set of values
@@ -48,6 +49,23 @@ theorem update_eq_updateFinset {i y} :
     simp only [dif_pos, Finset.mem_singleton, update_self, updateFinset]
     exact uniqueElim_default (α := fun j : ({i} : Finset ι) => π j) y
   · simp [hj, updateFinset]
+
+/-- If one replaces the variables indexed by a finite set `t`, then `f` no longer depends on
+those variables. -/
+theorem _root_.DependsOn.updateFinset {α : Type*} {f : (Π i, π i) → α} {s : Set ι}
+    (hf : DependsOn f s) {t : Finset ι} (y : Π i : t, π i) :
+    DependsOn (fun x ↦ f (updateFinset x t y)) (s \ t) := by
+  refine fun x₁ x₂ h ↦ hf (fun i hi ↦ ?_)
+  simp only [Function.updateFinset]
+  split_ifs; · rfl
+  simp_all
+
+/-- If one replaces the variable indexed by `i`, then `f` no longer depends on
+this variable. -/
+theorem _root_.DependsOn.update {α : Type*} {f : (Π i, π i) → α} {s : Finset ι} (hf : DependsOn f s)
+    (i : ι) (y : π i) : DependsOn (fun x ↦ f (Function.update x i y)) (s.erase i) := by
+  simp_rw [Function.update_eq_updateFinset, erase_eq, coe_sdiff]
+  exact hf.updateFinset _
 
 theorem updateFinset_updateFinset {s t : Finset ι} (hst : Disjoint s t)
     {y : ∀ i : ↥s, π i} {z : ∀ i : ↥t, π i} :

--- a/Mathlib/Logic/Function/DependsOn.lean
+++ b/Mathlib/Logic/Function/DependsOn.lean
@@ -46,6 +46,10 @@ lemma dependsOn_iff_factorsThrough {f : (Π i, α i) → β} {s : Set ι} :
   rw [DependsOn, Function.FactorsThrough]
   simp [funext_iff]
 
+lemma dependsOn_iff_exists_comp [Nonempty β] {f : (Π i, α i) → β} {s : Set ι} :
+    DependsOn f s ↔ ∃ g : (Π i : s, α i) → β, f = g ∘ s.restrict := by
+  rw [dependsOn_iff_factorsThrough, Function.factorsThrough_iff]
+
 lemma dependsOn_univ (f : (Π i, α i) → β) : DependsOn f univ :=
   fun _ _ h ↦ congrArg _ <| funext fun i ↦ h i trivial
 

--- a/Mathlib/Logic/Function/DependsOn.lean
+++ b/Mathlib/Logic/Function/DependsOn.lean
@@ -14,9 +14,9 @@ may get rid of the dependency on some variables (see `Function.updateFinset` or
 as having a different domain with fewer points is not comfortable in Lean, as it requires the use
 of subtypes and can lead to tedious writing.
 
-On the other hand one wants to be able for example to call some function constant with respect to
-some variables and be able to infer this when applying transformations mentioned above.
-This is why introduce the predicate `DependsOn f s`, which states that if `x` and `y` coincide over
+On the other hand one wants to be able for example to describe some function as constant with respect to
+some variables, and be able to deduce this when applying transformations mentioned above.
+This is why we introduce the predicate `DependsOn f s`, which states that if `x` and `y` coincide over
 the set `s`, then `f x = f y`. This is equivalent to `Function.FactorsThrough f s.restrict`.
 
 ## Main definition

--- a/Mathlib/Logic/Function/DependsOn.lean
+++ b/Mathlib/Logic/Function/DependsOn.lean
@@ -1,0 +1,64 @@
+/-
+Copyright (c) 2024 Etienne Marion. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Etienne Marion
+-/
+import Mathlib.Data.Set.Function
+
+/-!
+# Functions depending only on some variables
+
+When dealing with a function `f : Π i, α i` depending on many variables, some operations
+may get rid of the dependency on some variables (see `Function.updateFinset` or
+`MeasureTheory.lmarginal` for example). However considering this new function
+as having a different domain with fewer points is not comfortable in lean, as it requires the use
+of subtypes and can lead to tedious writing.
+
+On the other hand one wants to be able for example to call some function constant with respect to
+some variables and be able to infer this when applying transformations mentioned above.
+This is why introduce the predicate `DependsOn f s`, which states that if `x` and `y` coincide over
+the set `s`, then `f x = f y`. This is equivalent to `Function.FactorsThrough f s.restrict`.
+
+## Main definition
+
+* `DependsOn f s`: If `x` and `y` coincide over the set `s`, then `f x` equals `f y`.
+
+## Main statement
+
+* `dependsOn_iff_factorsThrough`: A function `f` depends on `s` if and only if it factors
+  through `s.restrict`.
+
+## Tags
+
+depends on
+-/
+
+open Set
+
+variable {ι : Type*} {α : ι → Type*} {β : Type*}
+
+/-- A function `f` depends on `s` if, whenever `x` and `y` coincide over `s`, `f x = f y`. -/
+def DependsOn (f : (Π i, α i) → β) (s : Set ι) : Prop :=
+  ∀ ⦃x y⦄, (∀ i ∈ s, x i = y i) → f x = f y
+
+lemma dependsOn_iff_factorsThrough {f : (Π i, α i) → β} {s : Set ι} :
+    DependsOn f s ↔ Function.FactorsThrough f s.restrict := by
+  rw [DependsOn, Function.FactorsThrough]
+  simp [funext_iff]
+
+lemma dependsOn_univ (f : (Π i, α i) → β) : DependsOn f univ :=
+  fun _ _ h ↦ congrArg _ <| funext fun i ↦ h i trivial
+
+variable {f : (Π i, α i) → β}
+
+/-- A constant function does not depend on any variable. -/
+lemma dependsOn_const (b : β) : DependsOn (fun _ : Π i, α i ↦ b) ∅ := by simp [DependsOn]
+
+lemma DependsOn.mono {s t : Set ι} (hst : s ⊆ t) (hf : DependsOn f s) : DependsOn f t :=
+  fun _ _ h ↦ hf fun i hi ↦ h i (hst hi)
+
+/-- A function which depends on the empty set is constant. -/
+lemma DependsOn.empty (hf : DependsOn f ∅) (x y : Π i, α i) : f x = f y := hf (by simp)
+
+lemma Set.dependsOn_restrict (s : Set ι) : DependsOn (s.restrict (π := α)) s :=
+  fun _ _ h ↦ funext fun i ↦ h i.1 i.2

--- a/Mathlib/Logic/Function/DependsOn.lean
+++ b/Mathlib/Logic/Function/DependsOn.lean
@@ -28,7 +28,7 @@ the set `s`, then `f x = f y`. This is equivalent to `Function.FactorsThrough f 
 * `dependsOn_iff_factorsThrough`: A function `f` depends on `s` if and only if it factors
   through `s.restrict`.
 
-## Implementation note
+## Implementation notes
 
 When we write `DependsOn f s`, i.e. `f` only depends on `s`, it should be interpreted as
 "`f` _potentially_ depends only on variables in `s`". However it might be the case

--- a/Mathlib/Logic/Function/DependsOn.lean
+++ b/Mathlib/Logic/Function/DependsOn.lean
@@ -11,7 +11,7 @@ import Mathlib.Data.Set.Function
 When dealing with a function `f : Π i, α i` depending on many variables, some operations
 may get rid of the dependency on some variables (see `Function.updateFinset` or
 `MeasureTheory.lmarginal` for example). However considering this new function
-as having a different domain with fewer points is not comfortable in lean, as it requires the use
+as having a different domain with fewer points is not comfortable in Lean, as it requires the use
 of subtypes and can lead to tedious writing.
 
 On the other hand one wants to be able for example to call some function constant with respect to
@@ -27,6 +27,18 @@ the set `s`, then `f x = f y`. This is equivalent to `Function.FactorsThrough f 
 
 * `dependsOn_iff_factorsThrough`: A function `f` depends on `s` if and only if it factors
   through `s.restrict`.
+
+## Implementation note
+
+It should be noted that when we say `DependsOn f s`, i.e. `f` only depends on `s`, it should be
+interpreted as "`f` _potentially_ depends only on variables in `s`". However it might be the case
+that `f` does not depend at all on variables in `s`, for example if `f` is constant`. On the other
+hand, `DependsOn f univ` is always true, see `dependsOn_univ`.
+
+The predicate `DependsOn f s` can also be interpreted as saying that `f` is independent of all
+the variables which are not in `s`. Although this phrasing might seem more natural, we choose to go
+with `DependsOn` because writing mathematically "independent of variables in `s`" would boil down to
+`∀ x y, (∀ i ∉ s, x i = y i) → f x = f y`, which is the same as `DependsOn f sᶜ`.
 
 ## Tags
 

--- a/Mathlib/Logic/Function/DependsOn.lean
+++ b/Mathlib/Logic/Function/DependsOn.lean
@@ -49,7 +49,12 @@ open Function Set
 
 variable {ι : Type*} {α : ι → Type*} {β : Type*}
 
-/-- A function `f` depends on `s` if, whenever `x` and `y` coincide over `s`, `f x = f y`. -/
+/-- A function `f` depends on `s` if, whenever `x` and `y` coincide over `s`, `f x = f y`.
+
+It should be interpreted as "`f` _potentially_ depends only on variables in `s`".
+However it might be the case that `f` does not depend at all on variables in `s`,
+for example if `f` is constant. On the other hand `DependsOn f univ` is always true,
+see `dependsOn_univ`. -/
 def DependsOn (f : (Π i, α i) → β) (s : Set ι) : Prop :=
   ∀ ⦃x y⦄, (∀ i ∈ s, x i = y i) → f x = f y
 

--- a/Mathlib/Logic/Function/DependsOn.lean
+++ b/Mathlib/Logic/Function/DependsOn.lean
@@ -30,8 +30,8 @@ the set `s`, then `f x = f y`. This is equivalent to `Function.FactorsThrough f 
 
 ## Implementation note
 
-It should be noted that when we say `DependsOn f s`, i.e. `f` only depends on `s`, it should be
-interpreted as "`f` _potentially_ depends only on variables in `s`". However it might be the case
+When we write `DependsOn f s`, i.e. `f` only depends on `s`, it should be interpreted as
+"`f` _potentially_ depends only on variables in `s`". However it might be the case
 that `f` does not depend at all on variables in `s`, for example if `f` is constant`. On the other
 hand, `DependsOn f univ` is always true, see `dependsOn_univ`.
 

--- a/Mathlib/Logic/Function/DependsOn.lean
+++ b/Mathlib/Logic/Function/DependsOn.lean
@@ -14,10 +14,11 @@ may get rid of the dependency on some variables (see `Function.updateFinset` or
 as having a different domain with fewer points is not comfortable in Lean, as it requires the use
 of subtypes and can lead to tedious writing.
 
-On the other hand one wants to be able for example to describe some function as constant with respect to
-some variables, and be able to deduce this when applying transformations mentioned above.
-This is why we introduce the predicate `DependsOn f s`, which states that if `x` and `y` coincide over
-the set `s`, then `f x = f y`. This is equivalent to `Function.FactorsThrough f s.restrict`.
+On the other hand one wants to be able for example to describe some function as constant
+with respect to some variables, and be able to deduce this when applying transformations
+mentioned above. This is why we introduce the predicate `DependsOn f s`, which states that
+if `x` and `y` coincide over the set `s`, then `f x = f y`.
+This is equivalent to `Function.FactorsThrough f s.restrict`.
 
 ## Main definition
 
@@ -32,8 +33,8 @@ the set `s`, then `f x = f y`. This is equivalent to `Function.FactorsThrough f 
 
 When we write `DependsOn f s`, i.e. `f` only depends on `s`, it should be interpreted as
 "`f` _potentially_ depends only on variables in `s`". However it might be the case
-that `f` does not depend at all on variables in `s`, for example if `f` is constant`. On the other
-hand, `DependsOn f univ` is always true, see `dependsOn_univ`.
+that `f` does not depend at all on variables in `s`, for example if `f` is constant.
+As a consequence, `DependsOn f univ` is always true, see `dependsOn_univ`.
 
 The predicate `DependsOn f s` can also be interpreted as saying that `f` is independent of all
 the variables which are not in `s`. Although this phrasing might seem more natural, we choose to go
@@ -53,7 +54,7 @@ variable {ι : Type*} {α : ι → Type*} {β : Type*}
 
 It should be interpreted as "`f` _potentially_ depends only on variables in `s`".
 However it might be the case that `f` does not depend at all on variables in `s`,
-for example if `f` is constant. On the other hand `DependsOn f univ` is always true,
+for example if `f` is constant. As a consequence, `DependsOn f univ` is always true,
 see `dependsOn_univ`. -/
 def DependsOn (f : (Π i, α i) → β) (s : Set ι) : Prop :=
   ∀ ⦃x y⦄, (∀ i ∈ s, x i = y i) → f x = f y

--- a/Mathlib/Logic/Function/DependsOn.lean
+++ b/Mathlib/Logic/Function/DependsOn.lean
@@ -45,7 +45,7 @@ with `DependsOn` because writing mathematically "independent of variables in `s`
 depends on
 -/
 
-open Set
+open Function Set
 
 variable {ι : Type*} {α : ι → Type*} {β : Type*}
 
@@ -54,13 +54,13 @@ def DependsOn (f : (Π i, α i) → β) (s : Set ι) : Prop :=
   ∀ ⦃x y⦄, (∀ i ∈ s, x i = y i) → f x = f y
 
 lemma dependsOn_iff_factorsThrough {f : (Π i, α i) → β} {s : Set ι} :
-    DependsOn f s ↔ Function.FactorsThrough f s.restrict := by
-  rw [DependsOn, Function.FactorsThrough]
+    DependsOn f s ↔ FactorsThrough f s.restrict := by
+  rw [DependsOn, FactorsThrough]
   simp [funext_iff]
 
 lemma dependsOn_iff_exists_comp [Nonempty β] {f : (Π i, α i) → β} {s : Set ι} :
     DependsOn f s ↔ ∃ g : (Π i : s, α i) → β, f = g ∘ s.restrict := by
-  rw [dependsOn_iff_factorsThrough, Function.factorsThrough_iff]
+  rw [dependsOn_iff_factorsThrough, factorsThrough_iff]
 
 lemma dependsOn_univ (f : (Π i, α i) → β) : DependsOn f univ :=
   fun _ _ h ↦ congrArg _ <| funext fun i ↦ h i trivial

--- a/Mathlib/Order/Restriction.lean
+++ b/Mathlib/Order/Restriction.lean
@@ -52,6 +52,9 @@ theorem restrictLe₂_comp_restrictLe {a b : α} (hab : a ≤ b) :
 theorem restrictLe₂_comp_restrictLe₂ {a b c : α} (hab : a ≤ b) (hbc : b ≤ c) :
     (restrictLe₂ (π := π) hab) ∘ (restrictLe₂ hbc) = restrictLe₂ (hab.trans hbc) := rfl
 
+lemma dependsOn_restrictLe (a : α) : DependsOn (restrictLe (π := π) a) (Iic a) :=
+  (Iic a).dependsOn_restrict
+
 end Set
 
 section Finset
@@ -68,7 +71,7 @@ lemma frestrictLe_apply (a : α) (f : (a : α) → π a) (i : Iic a) : frestrict
 
 /-- If a function `f` indexed by `α` is restricted to elements `≤ b`, and `a ≤ b`,
 this is the restriction to elements `≤ b`. Intervals are seen as finite sets. -/
-def frestrictLe₂ {a b : α} (hab : a ≤ b) := Finset.restrict₂ (π := π) (Iic_subset_Iic.2 hab)
+def frestrictLe₂ {a b : α} (hab : a ≤ b) := restrict₂ (π := π) (Iic_subset_Iic.2 hab)
 
 @[simp]
 lemma frestrictLe₂_apply {a b : α} (hab : a ≤ b) (f : (i : Iic b) → π i) (i : Iic a) :
@@ -79,6 +82,9 @@ theorem frestrictLe₂_comp_frestrictLe {a b : α} (hab : a ≤ b) :
 
 theorem frestrictLe₂_comp_frestrictLe₂ {a b c : α} (hab : a ≤ b) (hbc : b ≤ c) :
     (frestrictLe₂ (π := π) hab) ∘ (frestrictLe₂ hbc) = frestrictLe₂ (hab.trans hbc) := rfl
+
+lemma dependsOn_frestrictLe (a : α) : DependsOn (frestrictLe (π := π) a) (Set.Iic a) :=
+  coe_Iic a ▸ (Finset.Iic a).dependsOn_restrict
 
 end Finset
 


### PR DESCRIPTION
When dealing with a function `f : Π i, α i` depending on many variables, some operations may get rid of the dependency on some variables (see `Function.updateFinset` or `MeasureTheory.lmarginal` for example). However considering this new function as having a different domain can lead to tedious writing.

On the other hand one wants to be able for example to call some function constant with respect to some variables and be able to infer this when applying transformations mentioned above. This PR introduces the predicate `DependsOn f s`, which states that if `x` and `y` coincide over the set `s`, then `f x = f y`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
