### PR TITLE
[Merged by Bors] - feat(CategoryTheory): detecting limit cones over connected diagrams

### DIFF
--- a/Mathlib/CategoryTheory/Limits/Connected.lean
+++ b/Mathlib/CategoryTheory/Limits/Connected.lean
@@ -106,7 +106,7 @@ def Cone.isLimitOfIsIsoLimMapπ {F : J ⥤ C} [HasLimit F] (c : Cone F)
   congr 1
   simp [← Iso.inv_comp_eq_id]
 
-theorem isIso_limMap_π {F : J ⥤ C} [HasLimit F] {c : Cone F} (hc : IsLimit c) :
+theorem IsLimit.isIso_limMap_π {F : J ⥤ C} [HasLimit F] {c : Cone F} (hc : IsLimit c) :
     IsIso (limMap c.π) := by
   suffices limMap c.π = ((limit.isLimit _).conePointUniqueUpToIso (isLimitConstCone J c.pt) ≪≫
       hc.conePointUniqueUpToIso (limit.isLimit _)).hom by
@@ -119,7 +119,7 @@ theorem isIso_limMap_π {F : J ⥤ C} [HasLimit F] {c : Cone F} (hc : IsLimit c)
 
 theorem Cone.isLimit_iff_isIso_limMap_π {F : J ⥤ C} [HasLimit F] (c : Cone F) :
     Nonempty (IsLimit c) ↔ IsIso (limMap c.π) :=
-  ⟨fun ⟨h⟩ => isIso_limMap_π h, fun _ => ⟨c.isLimitOfIsIsoLimMapπ⟩⟩
+  ⟨fun ⟨h⟩ => IsLimit.isIso_limMap_π h, fun _ => ⟨c.isLimitOfIsIsoLimMapπ⟩⟩
 
 /-- If `J` is connected, `f : J ⥤ C` and `C` is a cocone on `F`, then to check that `c` is a
 colimit it is sufficient to check that `colimMap c.ι` is an isomorphism. The converse is also
@@ -129,7 +129,7 @@ def Cocone.isColimitOfIsIsoColimMapι {F : J ⥤ C} [HasColimit F] (c : Cocone F
   IsColimit.ofIsoColimit (colimit.isColimit _) (Cocones.ext (asIso (colimMap c.ι) ≪≫
     (colimit.isColimit _).coconePointUniqueUpToIso (isColimitConstCocone J c.pt)) (by simp))
 
-theorem isIso_colimMap_ι {F : J ⥤ C} [HasColimit F] {c : Cocone F} (hc : IsColimit c) :
+theorem IsColimit.isIso_colimMap_ι {F : J ⥤ C} [HasColimit F] {c : Cocone F} (hc : IsColimit c) :
     IsIso (colimMap c.ι) := by
   suffices colimMap c.ι = ((colimit.isColimit _).coconePointUniqueUpToIso hc ≪≫
       (isColimitConstCocone J c.pt).coconePointUniqueUpToIso (colimit.isColimit _)).hom by
@@ -142,7 +142,7 @@ theorem isIso_colimMap_ι {F : J ⥤ C} [HasColimit F] {c : Cocone F} (hc : IsCo
 
 theorem Cocone.isColimit_iff_isIso_colimMap_ι {F : J ⥤ C} [HasColimit F] (c : Cocone F) :
     Nonempty (IsColimit c) ↔ IsIso (colimMap c.ι) :=
-  ⟨fun ⟨h⟩ => isIso_colimMap_ι h, fun _ => ⟨c.isColimitOfIsIsoColimMapι⟩⟩
+  ⟨fun ⟨h⟩ => IsColimit.isIso_colimMap_ι h, fun _ => ⟨c.isColimitOfIsIsoColimMapι⟩⟩
 
 end
 

--- a/Mathlib/CategoryTheory/Limits/Connected.lean
+++ b/Mathlib/CategoryTheory/Limits/Connected.lean
@@ -121,7 +121,7 @@ theorem Cone.isLimit_iff_isIso_limMap_π {F : J ⥤ C} [HasLimit F] (c : Cone F)
     Nonempty (IsLimit c) ↔ IsIso (limMap c.π) :=
   ⟨fun ⟨h⟩ => IsLimit.isIso_limMap_π h, fun _ => ⟨c.isLimitOfIsIsoLimMapπ⟩⟩
 
-/-- If `J` is connected, `f : J ⥤ C` and `C` is a cocone on `F`, then to check that `c` is a
+/-- If `J` is connected, `F : J ⥤ C` and `C` is a cocone on `F`, then to check that `c` is a
 colimit it is sufficient to check that `colimMap c.ι` is an isomorphism. The converse is also
 true, see `Cocone.isColimit_iff_isIso_colimMap_ι`. -/
 def Cocone.isColimitOfIsIsoColimMapι {F : J ⥤ C} [HasColimit F] (c : Cocone F)

--- a/Mathlib/CategoryTheory/Limits/Connected.lean
+++ b/Mathlib/CategoryTheory/Limits/Connected.lean
@@ -15,7 +15,12 @@ import Mathlib.CategoryTheory.Limits.Preserves.Basic
 A connected limit is a limit whose shape is a connected category.
 
 We show that constant functors from a connected category have a limit
-and a colimit, give examples of connected categories, and prove
+and a colimit. From this we deduce that a cocone `c` over a connected diagram
+is a colimit cocone if and only if `colimMap c.ι` is an isomorphism (where
+`c.ι : F ⟶ const c.pt` is the natural transformation that defines the
+cocone).
+
+We give examples of connected categories, and prove
 that the functor given by `(X × -)` preserves any connected limit.
 That is, any limit of shape `J` where `J` is a connected category is
 preserved by the functor `(X × -)`.
@@ -34,7 +39,11 @@ section Const
 
 namespace Limits
 
-variable (J : Type u₁) [Category.{v₁} J] {C : Type u₂} [Category.{v₂} C] (X : C)
+variable {J : Type u₁} [Category.{v₁} J] {C : Type u₂} [Category.{v₂} C] (X : C)
+
+section
+
+variable (J)
 
 /-- The obvious cone of a constant functor. -/
 @[simps]
@@ -71,6 +80,71 @@ def isColimitConstCocone : IsColimit (constCocone J X) where
     exact constant_of_preserves_morphisms _
       (fun _ _ f ↦ by simpa using (s.w f).symm) _ _
   uniq s m hm := by simpa using hm (Classical.arbitrary _)
+
+instance hasLimit_const_of_isConnected : HasLimit ((Functor.const J).obj X) :=
+  ⟨_, isLimitConstCone J X⟩
+
+instance hasColimit_const_of_isConnected : HasColimit ((Functor.const J).obj X) :=
+  ⟨_, isColimitConstCocone J X⟩
+
+end
+
+section
+
+variable [IsConnected J]
+
+/-- If `J` is connected, `F : J ⥤ C` and `c` is a cone on `F`, then to check that `c` is a
+limit it is sufficient to check that `limMap c.π` is an isomorphism. The converse is also
+true, see `Cone.isLimit_iff_isIso_limMap_π`. -/
+def Cone.isLimitOfIsIsoLimMapπ {F : J ⥤ C} [HasLimit F] (c : Cone F)
+    [IsIso (limMap c.π)] : IsLimit c := by
+  refine IsLimit.ofIsoLimit (limit.isLimit _) (Cones.ext ((asIso (limMap c.π)).symm ≪≫
+    (limit.isLimit _).conePointUniqueUpToIso (isLimitConstCone J c.pt)) ?_)
+  intro j
+  simp only [limit.cone_x, Functor.const_obj_obj, limit.cone_π, Iso.trans_hom, Iso.symm_hom,
+    asIso_inv, assoc, IsIso.eq_inv_comp, limMap_π]
+  congr 1
+  simp [← Iso.inv_comp_eq_id]
+
+theorem isIso_limMap_π {F : J ⥤ C} [HasLimit F] {c : Cone F} (hc : IsLimit c) :
+    IsIso (limMap c.π) := by
+  suffices limMap c.π = ((limit.isLimit _).conePointUniqueUpToIso (isLimitConstCone J c.pt) ≪≫
+      hc.conePointUniqueUpToIso (limit.isLimit _)).hom by
+    rw [this]; infer_instance
+  ext j
+  simp only [limMap_π, Functor.const_obj_obj, limit.cone_x, constCone_pt, Iso.trans_hom, assoc,
+    limit.conePointUniqueUpToIso_hom_comp]
+  congr 1
+  simp [← Iso.inv_comp_eq_id]
+
+theorem Cone.isLimit_iff_isIso_limMap_π {F : J ⥤ C} [HasLimit F] (c : Cone F) :
+    Nonempty (IsLimit c) ↔ IsIso (limMap c.π) :=
+  ⟨fun ⟨h⟩ => isIso_limMap_π h, fun _ => ⟨c.isLimitOfIsIsoLimMapπ⟩⟩
+
+/-- If `J` is connected, `f : J ⥤ C` and `C` is a cocone on `F`, then to check that `c` is a
+colimit it is sufficient to check that `colimMap c.ι` is an isomorphism. The converse is also
+true, see `Cocone.isColimit_iff_isIso_colimMap_ι`. -/
+def Cocone.isColimitOfIsIsoColimMapι {F : J ⥤ C} [HasColimit F] (c : Cocone F)
+    [IsIso (colimMap c.ι)] : IsColimit c :=
+  IsColimit.ofIsoColimit (colimit.isColimit _) (Cocones.ext (asIso (colimMap c.ι) ≪≫
+    (colimit.isColimit _).coconePointUniqueUpToIso (isColimitConstCocone J c.pt)) (by simp))
+
+theorem isIso_colimMap_ι {F : J ⥤ C} [HasColimit F] {c : Cocone F} (hc : IsColimit c) :
+    IsIso (colimMap c.ι) := by
+  suffices colimMap c.ι = ((colimit.isColimit _).coconePointUniqueUpToIso hc ≪≫
+      (isColimitConstCocone J c.pt).coconePointUniqueUpToIso (colimit.isColimit _)).hom by
+    rw [this]; infer_instance
+  ext j
+  simp only [ι_colimMap, Functor.const_obj_obj, colimit.cocone_x, Iso.trans_hom,
+    colimit.comp_coconePointUniqueUpToIso_hom_assoc]
+  congr 1
+  simp [← Iso.comp_inv_eq_id]
+
+theorem Cocone.isColimit_iff_isIso_colimMap_ι {F : J ⥤ C} [HasColimit F] (c : Cocone F) :
+    Nonempty (IsColimit c) ↔ IsIso (colimMap c.ι) :=
+  ⟨fun ⟨h⟩ => isIso_colimMap_ι h, fun _ => ⟨c.isColimitOfIsIsoColimMapι⟩⟩
+
+end
 
 end Limits
 


### PR DESCRIPTION
A cocone `c` over a connected diagram is a colimit cocone if and only if `colimMap c.ι` is an isomorphism (where `c.ι : F ⟶ const c.pt` is the natural transformation that defines the cocone).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
