### PR TITLE
[Merged by Bors] - feat(FieldTheory/Minpoly): lifting a.k.a. restricting base field of a `minpoly`

### DIFF
--- a/Mathlib/FieldTheory/Minpoly/Field.lean
+++ b/Mathlib/FieldTheory/Minpoly/Field.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Riccardo Brasca, Johan Commelin
 -/
 import Mathlib.Algebra.Polynomial.FieldDivision
+import Mathlib.Algebra.Polynomial.Lifts
 import Mathlib.FieldTheory.Minpoly.Basic
 import Mathlib.RingTheory.Algebraic.Integral
 import Mathlib.RingTheory.LocalRing.Basic
@@ -99,6 +100,22 @@ theorem aeval_of_isScalarTower (R : Type*) {K T U : Type*} [CommRing R] [Field K
   aeval_map_algebraMap K y (minpoly R x) ▸
     eval₂_eq_zero_of_dvd_of_eval₂_eq_zero (algebraMap K U) y
       (minpoly.dvd_map_of_isScalarTower R K x) hy
+
+/-- If a subfield `F` of `E` contains all the coefficients of `minpoly E a`, then
+`minpoly F a` maps to `minpoly E a` via `algebraMap F E`. -/
+theorem minpoly_lift {F E A : Type*} [Field F] [Field E] [CommRing A]
+    [Algebra F E] [Algebra E A] [Algebra F A] [IsScalarTower F E A]
+    {a : A} (ha : IsIntegral F a) (h : minpoly E a ∈ lifts (algebraMap F E)) :
+    (minpoly F a).map (algebraMap F E) = minpoly E a := by
+  refine eq_of_monic_of_dvd_of_natDegree_le (minpoly.monic ha.tower_top)
+    ((algebraMap F E).injective.monic_map_iff.mp <| minpoly.monic ha)
+    (minpoly.dvd E a (by simp)) ?_
+  obtain ⟨g, hg, hgdeg, hgmon⟩ := lifts_and_natDegree_eq_and_monic h (minpoly.monic ha.tower_top)
+  rw [natDegree_map, ← hgdeg]
+  refine natDegree_le_of_dvd (minpoly.dvd F a ?_) hgmon.ne_zero
+  rw [← aeval_map_algebraMap A, IsScalarTower.algebraMap_eq F E A, ← coe_mapRingHom,
+    ← mapRingHom_comp, RingHom.comp_apply, coe_mapRingHom, coe_mapRingHom, hg,
+    aeval_map_algebraMap, minpoly.aeval]
 
 /-- See also `minpoly.ker_eval` which relaxes the assumptions on `A` in exchange for
 stronger assumptions on `B`. -/


### PR DESCRIPTION
Add the result that if all the coefficients of the `minpoly E a` lie in a subfield `F` of `E` then `minpoly F a` is essentially equal to `minpoly E a` (it maps via `algebraMap F E` to `minpoly E a`).


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
