### PR TITLE
[Merged by Bors] - chore(CategoryTheory): fix incorrect name

### DIFF
--- a/Mathlib/CategoryTheory/Limits/FunctorCategory/Shapes/Products.lean
+++ b/Mathlib/CategoryTheory/Limits/FunctorCategory/Shapes/Products.lean
@@ -36,9 +36,12 @@ theorem piObjIso_hom_comp_π (f : α → D ⥤ C) (d : D) (s : α) :
   simp [piObjIso]
 
 @[reassoc (attr := simp)]
-theorem piObjIso_inv_comp_pi (f : α → D ⥤ C) (d : D) (s : α) :
+theorem piObjIso_inv_comp_π (f : α → D ⥤ C) (d : D) (s : α) :
     (piObjIso f d).inv ≫ (Pi.π f s).app d = Pi.π (fun s => (f s).obj d) s := by
   simp [piObjIso]
+
+@[deprecated (since := "2025-02-23")]
+alias piObjIso_inv_comp_pi := piObjIso_inv_comp_π
 
 end Product
 


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
