### PR TITLE
[Merged by Bors] - feat: trivial lemmas adjacent to `AddMonoidAlgebra M ι ≃ (⨁ i : ι, M)`

### DIFF
--- a/Mathlib/Algebra/MonoidAlgebra/ToDirectSum.lean
+++ b/Mathlib/Algebra/MonoidAlgebra/ToDirectSum.lean
@@ -144,6 +144,11 @@ theorem toDirectSum_intCast [DecidableEq ι] [AddMonoid ι] [Ring M] (z : ℤ) :
   Finsupp.toDFinsupp_single _ _
 
 @[simp]
+theorem toDirectSum_one [DecidableEq ι] [Zero ι] [Semiring M] :
+    (1 : AddMonoidAlgebra M ι).toDirectSum = 1 :=
+  Finsupp.toDFinsupp_single _ _
+
+@[simp]
 theorem toDirectSum_mul [DecidableEq ι] [AddMonoid ι] [Semiring M] (f g : AddMonoidAlgebra M ι) :
     (f * g).toDirectSum = f.toDirectSum * g.toDirectSum := by
   let to_hom : AddMonoidAlgebra M ι →+ ⨁ _ : ι, M :=
@@ -196,6 +201,11 @@ theorem toAddMonoidAlgebra_neg [Ring M] [∀ m : M, Decidable (m ≠ 0)] (f : �
 @[simp]
 theorem toAddMonoidAlgebra_intCast [AddMonoid ι] [Ring M] [∀ m : M, Decidable (m ≠ 0)] (z : ℤ) :
     (z : ⨁ _ : ι, M).toAddMonoidAlgebra = z :=
+  DFinsupp.toFinsupp_single _ _
+
+@[simp]
+theorem toAddMonoidAlgebra_one [Zero ι] [Semiring M] [∀ m : M, Decidable (m ≠ 0)] :
+    (1 : ⨁ _ : ι, M).toAddMonoidAlgebra = 1 :=
   DFinsupp.toFinsupp_single _ _
 
 @[simp]

--- a/Mathlib/Algebra/MonoidAlgebra/ToDirectSum.lean
+++ b/Mathlib/Algebra/MonoidAlgebra/ToDirectSum.lean
@@ -13,7 +13,7 @@ import Mathlib.Data.Finsupp.ToDFinsupp
 This module provides conversions between `AddMonoidAlgebra` and `DirectSum`.
 The latter is essentially a dependent version of the former.
 
-Note that since `direct_sum.has_mul` combines indices additively, there is no equivalent to
+Note that since `DirectSum.instMul` combines indices additively, there is no equivalent to
 `MonoidAlgebra`.
 
 ## Main definitions
@@ -119,6 +119,31 @@ theorem toDirectSum_add [Semiring M] (f g : AddMonoidAlgebra M ι) :
   Finsupp.toDFinsupp_add _ _
 
 @[simp]
+theorem toDirectSum_natCast [DecidableEq ι] [AddMonoid ι] [Semiring M] (n : ℕ) :
+    (n : AddMonoidAlgebra M ι).toDirectSum = n :=
+  Finsupp.toDFinsupp_single _ _
+
+@[simp]
+theorem toDirectSum_ofNat [DecidableEq ι] [AddMonoid ι] [Semiring M] (n : ℕ) [n.AtLeastTwo] :
+    (ofNat(n) : AddMonoidAlgebra M ι).toDirectSum = ofNat(n) :=
+  Finsupp.toDFinsupp_single _ _
+
+@[simp]
+theorem toDirectSum_sub [Ring M] (f g : AddMonoidAlgebra M ι) :
+    (f - g).toDirectSum = f.toDirectSum - g.toDirectSum :=
+  Finsupp.toDFinsupp_sub _ _
+
+@[simp]
+theorem toDirectSum_neg [Ring M] (f : AddMonoidAlgebra M ι) :
+    (- f).toDirectSum = - f.toDirectSum :=
+  Finsupp.toDFinsupp_neg _
+
+@[simp]
+theorem toDirectSum_intCast [DecidableEq ι] [AddMonoid ι] [Ring M] (z : ℤ) :
+    (Int.cast z : AddMonoidAlgebra M ι).toDirectSum = z :=
+  Finsupp.toDFinsupp_single _ _
+
+@[simp]
 theorem toDirectSum_mul [DecidableEq ι] [AddMonoid ι] [Semiring M] (f g : AddMonoidAlgebra M ι) :
     (f * g).toDirectSum = f.toDirectSum * g.toDirectSum := by
   let to_hom : AddMonoidAlgebra M ι →+ ⨁ _ : ι, M :=
@@ -146,6 +171,32 @@ theorem toAddMonoidAlgebra_zero [Semiring M] [∀ m : M, Decidable (m ≠ 0)] :
 theorem toAddMonoidAlgebra_add [Semiring M] [∀ m : M, Decidable (m ≠ 0)] (f g : ⨁ _ : ι, M) :
     (f + g).toAddMonoidAlgebra = toAddMonoidAlgebra f + toAddMonoidAlgebra g :=
   DFinsupp.toFinsupp_add _ _
+
+@[simp]
+theorem toAddMonoidAlgebra_natCast [AddMonoid ι] [Semiring M] [∀ m : M, Decidable (m ≠ 0)] (n : ℕ) :
+    (n : ⨁ _ : ι, M).toAddMonoidAlgebra = n :=
+  DFinsupp.toFinsupp_single _ _
+
+@[simp]
+theorem toAddMonoidAlgebra_ofNat [AddMonoid ι] [Semiring M] [∀ m : M, Decidable (m ≠ 0)] (n : ℕ)
+    [n.AtLeastTwo] :
+    (ofNat(n) : ⨁ _ : ι, M).toAddMonoidAlgebra = ofNat(n) :=
+  DFinsupp.toFinsupp_single _ _
+
+@[simp]
+theorem toAddMonoidAlgebra_sub [Ring M] [∀ m : M, Decidable (m ≠ 0)] (f g : ⨁ _ : ι, M) :
+    (f - g).toAddMonoidAlgebra = toAddMonoidAlgebra f - toAddMonoidAlgebra g :=
+  DFinsupp.toFinsupp_sub _ _
+
+@[simp]
+theorem toAddMonoidAlgebra_neg [Ring M] [∀ m : M, Decidable (m ≠ 0)] (f : ⨁ _ : ι, M) :
+    (- f).toAddMonoidAlgebra = - toAddMonoidAlgebra f :=
+  DFinsupp.toFinsupp_neg _
+
+@[simp]
+theorem toAddMonoidAlgebra_intCast [AddMonoid ι] [Ring M] [∀ m : M, Decidable (m ≠ 0)] (z : ℤ) :
+    (z : ⨁ _ : ι, M).toAddMonoidAlgebra = z :=
+  DFinsupp.toFinsupp_single _ _
 
 @[simp]
 theorem toAddMonoidAlgebra_mul [AddMonoid ι] [Semiring M]
@@ -200,5 +251,17 @@ def addMonoidAlgebraAlgEquivDirectSum [DecidableEq ι] [AddMonoid ι] [CommSemir
     toFun := AddMonoidAlgebra.toDirectSum
     invFun := DirectSum.toAddMonoidAlgebra
     commutes' := fun _r => AddMonoidAlgebra.toDirectSum_single _ _ }
+
+@[simp]
+theorem AddMonoidAlgebra.toDirectSum_pow [DecidableEq ι] [AddMonoid ι] [Semiring M]
+    (f : AddMonoidAlgebra M ι) (n : ℕ) :
+    (f ^ n).toDirectSum = f.toDirectSum ^ n := by
+  classical exact map_pow addMonoidAlgebraRingEquivDirectSum f n
+
+@[simp]
+theorem DirectSum.toAddMonoidAlgebra_pow [DecidableEq ι] [AddMonoid ι] [Semiring M]
+    [∀ m : M, Decidable (m ≠ 0)] (f : ⨁ _ : ι, M) (n : ℕ):
+    (f ^ n).toAddMonoidAlgebra = toAddMonoidAlgebra f ^ n :=  by
+  classical exact map_pow addMonoidAlgebraRingEquivDirectSum.symm f n
 
 end Equivs


### PR DESCRIPTION
This proves some basic lemmas about `AddMonoidAlgebra.toDirectSum` and `DirectSum.toAddMonoidAlgebra`,
for `sub`, `neg`, `one`, `pow`, `natCast`, `intCast`, and `ofNat`.

This matches the `zero`, `add`, `mul` that already exist.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
