### PR TITLE
[Merged by Bors] - feat(Algebra/Polynomial): polynomial lifts iff its coefficients are in the range

### DIFF
--- a/Mathlib/Algebra/Polynomial/Lifts.lean
+++ b/Mathlib/Algebra/Polynomial/Lifts.lean
@@ -69,8 +69,8 @@ theorem lifts_iff_coeff_lifts (p : S[X]) : p ∈ lifts f ↔ ∀ n : ℕ, p.coef
   rw [lifts_iff_ringHom_rangeS, mem_map_rangeS f]
   rfl
 
-theorem lifts_iff_coeffs_subset_range {R S : Type*} [Semiring R] [Semiring S] (f : R →+* S)
-    (p : S[X]) : p ∈ lifts f ↔ (p.coeffs : Set S) ⊆ Set.range f := by
+theorem lifts_iff_coeffs_subset_range (p : S[X]) :
+    p ∈ lifts f ↔ (p.coeffs : Set S) ⊆ Set.range f := by
   rw [lifts_iff_coeff_lifts]
   constructor
   · intro h _ hc

--- a/Mathlib/Algebra/Polynomial/Lifts.lean
+++ b/Mathlib/Algebra/Polynomial/Lifts.lean
@@ -69,6 +69,18 @@ theorem lifts_iff_coeff_lifts (p : S[X]) : p ∈ lifts f ↔ ∀ n : ℕ, p.coef
   rw [lifts_iff_ringHom_rangeS, mem_map_rangeS f]
   rfl
 
+theorem lifts_iff_coeffs_subset_range {R S : Type*} [Semiring R] [Semiring S] (f : R →+* S)
+    (p : S[X]) : p ∈ lifts f ↔ (p.coeffs : Set S) ⊆ Set.range f := by
+  rw [lifts_iff_coeff_lifts]
+  constructor
+  · intro h _ hc
+    obtain ⟨n, ⟨-, hn⟩⟩ := mem_coeffs_iff.mp hc
+    exact hn ▸ h n
+  · intro h n
+    by_cases hn : p.coeff n = 0
+    · exact ⟨0, by simp [hn]⟩
+    · exact h <| coeff_mem_coeffs _ _ hn
+
 /-- If `(r : R)`, then `C (f r)` lifts. -/
 theorem C_mem_lifts (f : R →+* S) (r : R) : C (f r) ∈ lifts f :=
   ⟨C r, by


### PR DESCRIPTION
Version of `Polynomial.lifts_iff_coeff_lifts` that uses `Polynomial.coeffs`.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
