### PR TITLE
[Merged by Bors] - feat(Order/KrullDimension): some lemmas relating `Order.height`, `Order.coheight` and `krullDim`

### DIFF
--- a/Mathlib/Order/KrullDimension.lean
+++ b/Mathlib/Order/KrullDimension.lean
@@ -781,7 +781,7 @@ lemma coheight_bot_eq_krullDim [OrderBot α] : coheight (⊥ : α) = krullDim α
   rw [← krullDim_orderDual]
   exact height_top_eq_krullDim (α := αᵒᵈ)
 
-lemma height_eq_krullDim_Iic {α : Type*} [Preorder α] (x : α) :
+lemma height_eq_krullDim_Iic (x : α) :
     (height x : ℕ∞) = krullDim (Set.Iic x) := by
   rw [← height_top_eq_krullDim, height, height, WithBot.coe_inj]
   apply le_antisymm
@@ -819,11 +819,9 @@ variable {α : Type*} [Preorder α]
 lemma finiteDimensionalOrder_iff_krullDim_ne_bot_and_top :
     FiniteDimensionalOrder α ↔ (krullDim α ≠ ⊥ ∧ krullDim α ≠ ⊤) := by
   by_cases h : Nonempty α
-  · haveI := h
-    rw [← not_infiniteDimensionalOrder_iff, ← krullDim_eq_top_iff]
-    simp
+  · simp [← not_infiniteDimensionalOrder_iff, ← krullDim_eq_top_iff]
   · constructor
-    · exact (fun h1 ↦ False.elim (h (@LTSeries.nonempty_of_finiteDimensionalType α ‹_› ‹_›)))
+    · exact (fun h1 ↦ False.elim (h (LTSeries.nonempty_of_finiteDimensionalType (α := α))))
     · exact (fun h1 ↦ False.elim (h1.1 (krullDim_eq_bot_iff.mpr (not_nonempty_iff.mp h))))
 
 end finiteDimensional

--- a/Mathlib/Order/KrullDimension.lean
+++ b/Mathlib/Order/KrullDimension.lean
@@ -835,7 +835,7 @@ end typeclass
 
 section calculations
 
-@[simp] lemma krullDim_isSimpleOrder {α : Type*} [PartialOrder α] [BoundedOrder α]
+@[simp] lemma krullDim_of_isSimpleOrder {α : Type*} [PartialOrder α] [BoundedOrder α]
     [IsSimpleOrder α] : krullDim α = 1 := by
   rw [krullDim]
   let q : LTSeries α := ⟨1, (fun n ↦ if n == 0 then ⊥ else ⊤), by simp [Fin.fin_one_eq_zero]⟩

--- a/Mathlib/Order/KrullDimension.lean
+++ b/Mathlib/Order/KrullDimension.lean
@@ -799,10 +799,8 @@ lemma height_eq_krullDim_Iic (x : α) :
 
 lemma coheight_eq_krullDim_Ici {α : Type*} [Preorder α] (x : α) :
     (coheight x : ℕ∞) = krullDim (Set.Ici x) := by
-  rw [coheight, ← krullDim_orderDual]
-  let iso : (Set.Ici x)ᵒᵈ ≃o Set.Iic (α := αᵒᵈ) x := OrderIso.refl _
-  rw [Order.krullDim_eq_of_orderIso iso]
-  apply height_eq_krullDim_Iic
+  rw [coheight, ← krullDim_orderDual, Order.krullDim_eq_of_orderIso (OrderIso.refl _)]
+  exact height_eq_krullDim_Iic _
 
 end krullDim
 

--- a/Mathlib/Order/KrullDimension.lean
+++ b/Mathlib/Order/KrullDimension.lean
@@ -781,16 +781,14 @@ lemma coheight_bot_eq_krullDim [OrderBot α] : coheight (⊥ : α) = krullDim α
   rw [← krullDim_orderDual]
   exact height_top_eq_krullDim (α := αᵒᵈ)
 
-lemma height_eq_krullDim_Iic (x : α) :
-    (height x : ℕ∞) = krullDim (Set.Iic x) := by
+lemma height_eq_krullDim_Iic (x : α) : (height x : ℕ∞) = krullDim (Set.Iic x) := by
   rw [← height_top_eq_krullDim, height, height, WithBot.coe_inj]
   apply le_antisymm
   · apply iSup_le; intro p; apply iSup_le; intro hp
     let q := LTSeries.mk p.length (fun i ↦ (⟨p.toFun i, le_trans (p.monotone (Fin.le_last _)) hp⟩
      : Set.Iic x)) (fun _ _ h ↦ p.strictMono h)
-    rw [show p.length = q.length by rfl]
     simp only [le_top, iSup_pos, ge_iff_le]
-    apply le_iSup (fun p ↦ (p.length : ℕ∞)) q
+    exact le_iSup (fun p ↦ (p.length : ℕ∞)) q
   · apply iSup_le; intro p; apply iSup_le; intro _
     have mono : StrictMono (fun (y : Set.Iic x) ↦ y.1) := fun _ _ h ↦ h
     rw [← LTSeries.map_length p (fun x ↦ x.1) mono, ]
@@ -813,7 +811,7 @@ lemma finiteDimensionalOrder_iff_krullDim_ne_bot_and_top :
   by_cases h : Nonempty α
   · simp [← not_infiniteDimensionalOrder_iff, ← krullDim_eq_top_iff]
   · constructor
-    · exact (fun h1 ↦ False.elim (h (LTSeries.nonempty_of_finiteDimensionalType (α := α))))
+    · exact (fun h1 ↦ False.elim (h (LTSeries.nonempty_of_finiteDimensionalType α)))
     · exact (fun h1 ↦ False.elim (h1.1 (krullDim_eq_bot_iff.mpr (not_nonempty_iff.mp h))))
 
 end finiteDimensional

--- a/Mathlib/Order/KrullDimension.lean
+++ b/Mathlib/Order/KrullDimension.lean
@@ -811,7 +811,7 @@ lemma finiteDimensionalOrder_iff_krullDim_ne_bot_and_top :
   by_cases h : Nonempty α
   · simp [← not_infiniteDimensionalOrder_iff, ← krullDim_eq_top_iff]
   · constructor
-    · exact (fun h1 ↦ False.elim (h (LTSeries.nonempty_of_finiteDimensionalType α)))
+    · exact (fun h1 ↦ False.elim (h (LTSeries.nonempty_of_finiteDimensionalOrder α)))
     · exact (fun h1 ↦ False.elim (h1.1 (krullDim_eq_bot_iff.mpr (not_nonempty_iff.mp h))))
 
 end finiteDimensional

--- a/Mathlib/Order/KrullDimension.lean
+++ b/Mathlib/Order/KrullDimension.lean
@@ -7,6 +7,7 @@ Authors: Jujian Zhang, Fangming Li, Joachim Breitner
 import Mathlib.Algebra.Order.Group.Int
 import Mathlib.Data.ENat.Lattice
 import Mathlib.Data.Int.Basic
+import Mathlib.Order.Atoms
 import Mathlib.Order.Minimal
 import Mathlib.Order.RelSeries
 import Mathlib.Order.LatticeIntervals
@@ -845,6 +846,19 @@ end typeclass
 -/
 
 section calculations
+
+@[simp] lemma krullDim_isSimpleOrder {α : Type*} [PartialOrder α] [BoundedOrder α]
+    [IsSimpleOrder α] : krullDim α = 1 := by
+  rw [krullDim]
+  let q : LTSeries α := ⟨1, (fun n ↦ if n == 0 then ⊥ else ⊤), by simp [Fin.fin_one_eq_zero]⟩
+  refine le_antisymm (iSup_le fun p ↦ ?_) (le_iSup (fun p ↦ (p.length : WithBot ℕ∞)) q)
+  by_contra h; simp only [Nat.cast_le_one, not_le] at h
+  have h2 : 2 < p.length + 1 := add_lt_add_of_lt_of_le h (le_refl 1)
+  have h0' : 0 < p.length := lt_trans (show 0 < 1 by decide) h
+  have h1 : 1 < p.length + 1 := lt_of_le_of_lt (show 1 ≤ 2 by decide) h2
+  have : p ⟨1, h1⟩ = ⊤ := IsSimpleOrder.eq_top_of_lt (p.step ⟨0, h0'⟩)
+  have : p ⟨1, h1⟩ < p ⟨2, h2⟩ := p.step ⟨1, h⟩
+  simp_all
 
 variable {α : Type*} [Preorder α]
 

--- a/Mathlib/Order/KrullDimension.lean
+++ b/Mathlib/Order/KrullDimension.lean
@@ -800,13 +800,7 @@ lemma height_eq_krullDim_Iic (x : α) :
 lemma coheight_eq_krullDim_Ici {α : Type*} [Preorder α] (x : α) :
     (coheight x : ℕ∞) = krullDim (Set.Ici x) := by
   rw [coheight, ← krullDim_orderDual]
-  let iso : (Set.Ici x)ᵒᵈ ≃o Set.Iic (α := αᵒᵈ) x := {
-    toFun := fun x ↦ x
-    invFun := fun x ↦ x
-    left_inv := fun x ↦ rfl
-    right_inv := fun x ↦ rfl
-    map_rel_iff' := fun {x y} ↦ by simp
-  }
+  let iso : (Set.Ici x)ᵒᵈ ≃o Set.Iic (α := αᵒᵈ) x := OrderIso.refl _
   rw [Order.krullDim_eq_of_orderIso iso]
   apply height_eq_krullDim_Iic
 

--- a/Mathlib/Order/KrullDimension.lean
+++ b/Mathlib/Order/KrullDimension.lean
@@ -9,6 +9,7 @@ import Mathlib.Data.ENat.Lattice
 import Mathlib.Data.Int.Basic
 import Mathlib.Order.Minimal
 import Mathlib.Order.RelSeries
+import Mathlib.Order.LatticeIntervals
 import Mathlib.Tactic.FinCases
 
 /-!
@@ -542,6 +543,7 @@ variable [Preorder α] [Preorder β]
 
 lemma LTSeries.length_le_krullDim (p : LTSeries α) : p.length ≤ krullDim α := le_sSup ⟨_, rfl⟩
 
+@[simp]
 lemma krullDim_eq_bot_iff : krullDim α = ⊥ ↔ IsEmpty α := by
   rw [eq_bot_iff, krullDim, iSup_le_iff]
   simp only [le_bot_iff, WithBot.natCast_ne_bot, isEmpty_iff]
@@ -778,7 +780,52 @@ lemma coheight_bot_eq_krullDim [OrderBot α] : coheight (⊥ : α) = krullDim α
   rw [← krullDim_orderDual]
   exact height_top_eq_krullDim (α := αᵒᵈ)
 
+lemma height_eq_krullDim_Iic {α : Type*} [Preorder α] (x : α) :
+    (height x : ℕ∞) = krullDim (Set.Iic x) := by
+  rw [← height_top_eq_krullDim, height, height, WithBot.coe_inj]
+  apply le_antisymm
+  · apply iSup_le; intro p; apply iSup_le; intro hp
+    let q := LTSeries.mk p.length (fun i ↦ (⟨p.toFun i, le_trans (p.monotone (Fin.le_last _)) hp⟩
+     : Set.Iic x)) (fun _ _ h ↦ p.strictMono h)
+    rw [show p.length = q.length by rfl]
+    simp only [le_top, iSup_pos, ge_iff_le]
+    apply le_iSup (fun p ↦ (p.length : ℕ∞)) q
+  · apply iSup_le; intro p; apply iSup_le; intro _
+    have mono : StrictMono (fun (y : Set.Iic x) ↦ y.1) := fun _ _ h ↦ h
+    rw [← LTSeries.map_length p (fun x ↦ x.1) mono, ]
+    refine le_iSup₂ (f := fun p hp ↦ (p.length : ℕ∞)) (p.map (fun x ↦ x.1) mono) ?_
+    exact (p.toFun (Fin.last p.length)).2
+
+lemma coheight_eq_krullDim_Ici {α : Type*} [Preorder α] (x : α) :
+    (coheight x : ℕ∞) = krullDim (Set.Ici x) := by
+  rw [coheight, ← krullDim_orderDual]
+  let iso : (Set.Ici x)ᵒᵈ ≃o Set.Iic (α := αᵒᵈ) x := {
+    toFun := fun x ↦ x
+    invFun := fun x ↦ x
+    left_inv := fun x ↦ rfl
+    right_inv := fun x ↦ rfl
+    map_rel_iff' := fun {x y} ↦ by simp
+  }
+  rw [Order.krullDim_eq_of_orderIso iso]
+  apply height_eq_krullDim_Iic
+
 end krullDim
+
+section finiteDimensional
+
+variable {α : Type*} [Preorder α]
+
+lemma finiteDimensionalOrder_iff_krullDim_ne_bot_and_top :
+    FiniteDimensionalOrder α ↔ (krullDim α ≠ ⊥ ∧ krullDim α ≠ ⊤) := by
+  by_cases h : Nonempty α
+  · haveI := h
+    rw [← not_infiniteDimensionalOrder_iff, ← krullDim_eq_top_iff]
+    simp
+  · constructor
+    · exact (fun h1 ↦ False.elim (h (@LTSeries.nonempty_of_finiteDimensionalType α ‹_› ‹_›)))
+    · exact (fun h1 ↦ False.elim (h1.1 (krullDim_eq_bot_iff.mpr (not_nonempty_iff.mp h))))
+
+end finiteDimensional
 
 section typeclass
 

--- a/Mathlib/Order/KrullDimension.lean
+++ b/Mathlib/Order/KrullDimension.lean
@@ -807,7 +807,7 @@ section finiteDimensional
 variable {α : Type*} [Preorder α]
 
 lemma finiteDimensionalOrder_iff_krullDim_ne_bot_and_top :
-    FiniteDimensionalOrder α ↔ (krullDim α ≠ ⊥ ∧ krullDim α ≠ ⊤) := by
+    FiniteDimensionalOrder α ↔ krullDim α ≠ ⊥ ∧ krullDim α ≠ ⊤ := by
   by_cases h : Nonempty α
   · simp [← not_infiniteDimensionalOrder_iff, ← krullDim_eq_top_iff]
   · constructor

--- a/Mathlib/Order/RelSeries.lean
+++ b/Mathlib/Order/RelSeries.lean
@@ -693,10 +693,10 @@ protected noncomputable def withLength [InfiniteDimensionalOrder α] (n : ℕ) :
   RelSeries.length_withLength _ _
 
 /-- if `α` is infinite dimensional, then `α` is nonempty. -/
-lemma nonempty_of_infiniteDimensionalType [InfiniteDimensionalOrder α] : Nonempty α :=
+lemma nonempty_of_infiniteDimensionalOrder [InfiniteDimensionalOrder α] : Nonempty α :=
   ⟨LTSeries.withLength α 0 0⟩
 
-lemma nonempty_of_finiteDimensionalType [FiniteDimensionalOrder α] : Nonempty α := by
+lemma nonempty_of_finiteDimensionalOrder [FiniteDimensionalOrder α] : Nonempty α := by
   obtain ⟨p, _⟩ := (Rel.finiteDimensional_iff _).mp ‹_›
   exact ⟨p 0⟩
 

--- a/Mathlib/Order/RelSeries.lean
+++ b/Mathlib/Order/RelSeries.lean
@@ -696,6 +696,9 @@ protected noncomputable def withLength [InfiniteDimensionalOrder α] (n : ℕ) :
 lemma nonempty_of_infiniteDimensionalOrder [InfiniteDimensionalOrder α] : Nonempty α :=
   ⟨LTSeries.withLength α 0 0⟩
 
+@[deprecated (since := "2025-03-01")]
+alias nonempty_of_infiniteDimensionalType := nonempty_of_infiniteDimensionalOrder
+
 lemma nonempty_of_finiteDimensionalOrder [FiniteDimensionalOrder α] : Nonempty α := by
   obtain ⟨p, _⟩ := (Rel.finiteDimensional_iff _).mp ‹_›
   exact ⟨p 0⟩

--- a/Mathlib/Order/RelSeries.lean
+++ b/Mathlib/Order/RelSeries.lean
@@ -171,6 +171,10 @@ variable {r} {s : RelSeries r} {x : α}
 lemma nonempty_of_infiniteDimensional [r.InfiniteDimensional] : Nonempty α :=
   ⟨RelSeries.withLength r 0 0⟩
 
+lemma nonempty_of_finiteDimensional [r.FiniteDimensional] : Nonempty α := by
+  obtain ⟨p, _⟩ := (Rel.finiteDimensional_iff r).mp ‹r.FiniteDimensional›
+  exact ⟨p 0⟩
+
 instance membership : Membership α (RelSeries r) :=
   ⟨Function.swap (· ∈ Set.range ·)⟩
 
@@ -691,6 +695,10 @@ protected noncomputable def withLength [InfiniteDimensionalOrder α] (n : ℕ) :
 /-- if `α` is infinite dimensional, then `α` is nonempty. -/
 lemma nonempty_of_infiniteDimensionalType [InfiniteDimensionalOrder α] : Nonempty α :=
   ⟨LTSeries.withLength α 0 0⟩
+
+lemma nonempty_of_finiteDimensionalType [FiniteDimensionalOrder α] : Nonempty α := by
+  obtain ⟨p, _⟩ := (Rel.finiteDimensional_iff (· < ·)).mp ‹_›
+  exact ⟨p 0⟩
 
 variable {α}
 

--- a/Mathlib/Order/RelSeries.lean
+++ b/Mathlib/Order/RelSeries.lean
@@ -172,7 +172,7 @@ lemma nonempty_of_infiniteDimensional [r.InfiniteDimensional] : Nonempty α :=
   ⟨RelSeries.withLength r 0 0⟩
 
 lemma nonempty_of_finiteDimensional [r.FiniteDimensional] : Nonempty α := by
-  obtain ⟨p, _⟩ := (Rel.finiteDimensional_iff r).mp ‹r.FiniteDimensional›
+  obtain ⟨p, _⟩ := (Rel.finiteDimensional_iff r).mp ‹_›
   exact ⟨p 0⟩
 
 instance membership : Membership α (RelSeries r) :=
@@ -697,7 +697,7 @@ lemma nonempty_of_infiniteDimensionalType [InfiniteDimensionalOrder α] : Nonemp
   ⟨LTSeries.withLength α 0 0⟩
 
 lemma nonempty_of_finiteDimensionalType [FiniteDimensionalOrder α] : Nonempty α := by
-  obtain ⟨p, _⟩ := (Rel.finiteDimensional_iff (· < ·)).mp ‹_›
+  obtain ⟨p, _⟩ := (Rel.finiteDimensional_iff _).mp ‹_›
   exact ⟨p 0⟩
 
 variable {α}


### PR DESCRIPTION
This PR mostly consists of the lemmas related to `Order.height`, `Order.coheight`, and `krullDim` appearing in the process of working on PR #21041. We thought that the lemmas may be useful to other PRs (like #22127 perhaps?), so we decided to open it into a separate PR to accelerate the review process.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
