### PR TITLE
[Merged by Bors] - chore(Matroid/Circuit): fix typos

### DIFF
--- a/Mathlib/Data/Matroid/Circuit.lean
+++ b/Mathlib/Data/Matroid/Circuit.lean
@@ -382,7 +382,7 @@ lemma ext_iff_isCircuit {M₁ M₂ : Matroid α} :
 
 section Elimination
 
-/-! ### IsCircuit Elimination -/
+/-! ### Circuit Elimination -/
 
 variable {ι : Type*} {J C₀ C₁ C₂ : Set α}
 
@@ -545,10 +545,10 @@ abbrev IsCocircuit (M : Matroid α) (K : Set α) : Prop := M✶.IsCircuit K
 
 lemma isCocircuit_def : M.IsCocircuit K ↔ M✶.IsCircuit K := Iff.rfl
 
-lemma IsCocircuit.circuit (hK : M.IsCocircuit K) : M✶.IsCircuit K :=
+lemma IsCocircuit.isCircuit (hK : M.IsCocircuit K) : M✶.IsCircuit K :=
   hK
 
-lemma Circuit.isCocircuit (hC : M.IsCircuit C) : M✶.IsCocircuit C := by
+lemma IsCircuit.isCocircuit (hC : M.IsCircuit C) : M✶.IsCocircuit C := by
   rwa [isCocircuit_def, dual_dual]
 
 @[aesop unsafe 10% (rule_sets := [Matroid])]
@@ -636,19 +636,19 @@ lemma IsCircuit.isCocircuit_disjoint_or_nontrivial_inter (hC : M.IsCircuit C)
   rw [or_iff_not_imp_left, disjoint_iff_inter_eq_empty, ← ne_eq, ← nonempty_iff_ne_empty]
   exact hC.isCocircuit_inter_nontrivial hK
 
-lemma dual_rankPos_iff_exists_circuit : M✶.RankPos ↔ ∃ C, M.IsCircuit C := by
+lemma dual_rankPos_iff_exists_isCircuit : M✶.RankPos ↔ ∃ C, M.IsCircuit C := by
   rw [rankPos_iff, dual_isBase_iff, diff_empty, not_iff_comm, not_exists,
     ← ground_indep_iff_isBase, indep_iff_forall_subset_not_isCircuit]
   exact ⟨fun h C _ ↦ h C, fun h C hC ↦ h C hC.subset_ground hC⟩
 
 lemma IsCircuit.dual_rankPos (hC : M.IsCircuit C) : M✶.RankPos :=
-  dual_rankPos_iff_exists_circuit.mpr ⟨C, hC⟩
+  dual_rankPos_iff_exists_isCircuit.mpr ⟨C, hC⟩
 
-lemma exists_circuit [RankPos M✶] : ∃ C, M.IsCircuit C :=
-  dual_rankPos_iff_exists_circuit.1 (by assumption)
+lemma exists_isCircuit [RankPos M✶] : ∃ C, M.IsCircuit C :=
+  dual_rankPos_iff_exists_isCircuit.1 (by assumption)
 
 lemma rankPos_iff_exists_isCocircuit : M.RankPos ↔ ∃ K, M.IsCocircuit K := by
-  rw [← dual_dual M, dual_rankPos_iff_exists_circuit, dual_dual M]
+  rw [← dual_dual M, dual_rankPos_iff_exists_isCircuit, dual_dual M]
 
 /-- The fundamental cocircuit for `B` and `e`:
 that is, the unique cocircuit `K` of `M` for which `K ∩ B = {e}`.

--- a/Mathlib/Data/Matroid/Circuit.lean
+++ b/Mathlib/Data/Matroid/Circuit.lean
@@ -553,7 +553,7 @@ lemma IsCircuit.isCocircuit (hC : M.IsCircuit C) : M✶.IsCocircuit C := by
 
 @[aesop unsafe 10% (rule_sets := [Matroid])]
 lemma IsCocircuit.subset_ground (hC : M.IsCocircuit C) : C ⊆ M.E :=
-  hC.circuit.subset_ground
+  hC.isCircuit.subset_ground
 
 @[simp] lemma dual_isCocircuit_iff : M✶.IsCocircuit C ↔ M.IsCircuit C := by
   rw [isCocircuit_def, dual_dual]


### PR DESCRIPTION
We fix some typos in the names of very recently committed lemmas about matroid circuits. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
