### PR TITLE
[Merged by Bors] - feat(CategoryTheory): 2-squares of functors

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1908,6 +1908,7 @@ import Mathlib.CategoryTheory.Functor.KanExtension.Pointwise
 import Mathlib.CategoryTheory.Functor.OfSequence
 import Mathlib.CategoryTheory.Functor.ReflectsIso
 import Mathlib.CategoryTheory.Functor.Trifunctor
+import Mathlib.CategoryTheory.Functor.TwoSquare
 import Mathlib.CategoryTheory.Galois.Action
 import Mathlib.CategoryTheory.Galois.Basic
 import Mathlib.CategoryTheory.Galois.Decomposition

--- a/Mathlib/CategoryTheory/Adjunction/Mates.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Mates.lean
@@ -75,18 +75,18 @@ Note that if one of the transformations is an iso, it does not imply the other i
 def mateEquiv : TwoSquare G L₁ L₂ H ≃ TwoSquare R₁ H G R₂ where
   toFun α := .mk _ _ _ _ <|
     whiskerLeft (R₁ ⋙ G) adj₂.unit ≫
-    whiskerRight (whiskerLeft R₁ α.out) R₂ ≫
+    whiskerRight (whiskerLeft R₁ α.natTrans) R₂ ≫
     whiskerRight adj₁.counit (H ⋙ R₂)
   invFun β := .mk _ _ _ _ <|
     whiskerRight adj₁.unit (G ⋙ L₂) ≫
-    whiskerRight (whiskerLeft L₁ β.out) L₂ ≫
+    whiskerRight (whiskerLeft L₁ β.natTrans) L₂ ≫
     whiskerLeft (L₁ ⋙ H) adj₂.counit
   left_inv α := by
     ext
     unfold whiskerRight whiskerLeft
     simp only [comp_obj, id_obj, Functor.comp_map, comp_app, map_comp, assoc, counit_naturality,
       counit_naturality_assoc, left_triangle_components_assoc]
-    rw [← assoc, ← Functor.comp_map, α.naturality, Functor.comp_map, assoc, ← H.map_comp,
+    rw [← assoc, ← Functor.comp_map, α.natTrans.naturality, Functor.comp_map, assoc, ← H.map_comp,
       left_triangle_components, map_id]
     simp only [comp_obj, comp_id]
   right_inv β := by
@@ -94,7 +94,7 @@ def mateEquiv : TwoSquare G L₁ L₂ H ≃ TwoSquare R₁ H G R₂ where
     unfold whiskerLeft whiskerRight
     simp only [comp_obj, id_obj, Functor.comp_map, comp_app, map_comp, assoc,
       unit_naturality_assoc, right_triangle_components_assoc]
-    rw [← assoc, ← Functor.comp_map, assoc, ← β.naturality, ← assoc, Functor.comp_map,
+    rw [← assoc, ← Functor.comp_map, assoc, ← β.natTrans.naturality, ← assoc, Functor.comp_map,
       ← G.map_comp, right_triangle_components, map_id, id_comp]
 
 /-- A component of a transposed version of the mates correspondence. -/
@@ -423,7 +423,7 @@ isomorphism if and only if the original transformation is. This explains why som
 natural transformations are natural isomorphisms.
 -/
 theorem iterated_mateEquiv_conjugateEquiv (α : TwoSquare F₁ L₁ L₂ F₂) :
-    (mateEquiv adj₄ adj₃ (mateEquiv adj₁ adj₂ α)).out =
+    (mateEquiv adj₄ adj₃ (mateEquiv adj₁ adj₂ α)).natTrans =
       conjugateEquiv (adj₁.comp adj₄) (adj₃.comp adj₂) α := by
   ext d
   unfold conjugateEquiv mateEquiv Adjunction.comp

--- a/Mathlib/CategoryTheory/Adjunction/Mates.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Mates.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Bhavik Mehta, Emily Riehl
 -/
 import Mathlib.CategoryTheory.Adjunction.Basic
+import Mathlib.CategoryTheory.Functor.TwoSquare
 import Mathlib.CategoryTheory.HomCongr
 
 import Mathlib.Tactic.ApplyFun
@@ -43,7 +44,7 @@ mathlib: https://ncatlab.org/nlab/show/six+operations.
 universe v₁ v₂ v₃ v₄ v₅ v₆ v₇ v₈ v₉ u₁ u₂ u₃ u₄ u₅ u₆ u₇ u₈ u₉
 namespace CategoryTheory
 
-open Category Functor Adjunction NatTrans
+open Category Functor Adjunction NatTrans TwoSquare
 
 section mateEquiv
 
@@ -71,7 +72,7 @@ Then we have a bijection between natural transformations `G ⋙ L₂ ⟶ L₁ �
 Note that if one of the transformations is an iso, it does not imply the other is an iso.
 -/
 @[simps]
-def mateEquiv : (G ⋙ L₂ ⟶ L₁ ⋙ H) ≃ (R₁ ⋙ G ⟶ H ⋙ R₂) where
+def mateEquiv : TwoSquare G L₁ L₂ H ≃ TwoSquare R₁ H G R₂ where
   toFun α :=
     whiskerLeft (R₁ ⋙ G) adj₂.unit ≫
     whiskerRight (whiskerLeft R₁ α) R₂ ≫
@@ -97,19 +98,19 @@ def mateEquiv : (G ⋙ L₂ ⟶ L₁ ⋙ H) ≃ (R₁ ⋙ G ⟶ H ⋙ R₂) wher
       ← G.map_comp, right_triangle_components, map_id, id_comp]
 
 /-- A component of a transposed version of the mates correspondence. -/
-theorem mateEquiv_counit (α : G ⋙ L₂ ⟶ L₁ ⋙ H) (d : D) :
+theorem mateEquiv_counit (α : TwoSquare G L₁ L₂ H) (d : D) :
     L₂.map ((mateEquiv adj₁ adj₂ α).app _) ≫ adj₂.counit.app _ =
       α.app _ ≫ H.map (adj₁.counit.app d) := by simp
 
 /-- A component of a transposed version of the inverse mates correspondence. -/
-theorem mateEquiv_counit_symm (α : R₁ ⋙ G ⟶ H ⋙ R₂) (d : D) :
+theorem mateEquiv_counit_symm (α : TwoSquare R₁ H G R₂) (d : D) :
     L₂.map (α.app _) ≫ adj₂.counit.app _ =
       ((mateEquiv adj₁ adj₂).symm α).app _ ≫ H.map (adj₁.counit.app d) := by
   conv_lhs => rw [← (mateEquiv adj₁ adj₂).right_inv α]
   exact (mateEquiv_counit adj₁ adj₂ ((mateEquiv adj₁ adj₂).symm α) d)
 
 /- A component of a transposed version of the mates correspondence. -/
-theorem unit_mateEquiv (α : G ⋙ L₂ ⟶ L₁ ⋙ H) (c : C) :
+theorem unit_mateEquiv (α : TwoSquare G L₁ L₂ H) (c : C) :
     G.map (adj₁.unit.app c) ≫ (mateEquiv adj₁ adj₂ α).app _ =
       adj₂.unit.app _ ≫ R₂.map (α.app _) := by
   dsimp [mateEquiv]
@@ -122,7 +123,7 @@ theorem unit_mateEquiv (α : G ⋙ L₂ ⟶ L₁ ⋙ H) (c : C) :
   simp only [comp_obj, map_id, comp_id]
 
 /-- A component of a transposed version of the inverse mates correspondence. -/
-theorem unit_mateEquiv_symm (α : R₁ ⋙ G ⟶ H ⋙ R₂) (c : C) :
+theorem unit_mateEquiv_symm (α : TwoSquare R₁ H G R₂) (c : C) :
     G.map (adj₁.unit.app c) ≫ α.app _ =
       adj₂.unit.app _ ≫ R₂.map (((mateEquiv adj₁ adj₂).symm α).app _) := by
   conv_lhs => rw [← (mateEquiv adj₁ adj₂).right_inv α]
@@ -139,26 +140,14 @@ variable {G₁ : A ⥤ C} {G₂ : C ⥤ E} {H₁ : B ⥤ D} {H₂ : D ⥤ F}
 variable {L₁ : A ⥤ B} {R₁ : B ⥤ A} {L₂ : C ⥤ D} {R₂ : D ⥤ C} {L₃ : E ⥤ F} {R₃ : F ⥤ E}
 variable (adj₁ : L₁ ⊣ R₁) (adj₂ : L₂ ⊣ R₂) (adj₃ : L₃ ⊣ R₃)
 
-/-- Squares between left adjoints can be composed "vertically" by pasting. -/
-def leftAdjointSquare.vcomp :
-    (G₁ ⋙ L₂ ⟶ L₁ ⋙ H₁) → (G₂ ⋙ L₃ ⟶ L₂ ⋙ H₂) → ((G₁ ⋙ G₂) ⋙ L₃ ⟶ L₁ ⋙ (H₁ ⋙ H₂)) :=
-  fun α β ↦ (whiskerLeft G₁ β) ≫ (whiskerRight α H₂)
-
-/-- Squares between right adjoints can be composed "vertically" by pasting. -/
-def rightAdjointSquare.vcomp :
-    (R₁ ⋙ G₁ ⟶ H₁ ⋙ R₂) → (R₂ ⋙ G₂ ⟶ H₂ ⋙ R₃) → (R₁ ⋙ (G₁ ⋙ G₂) ⟶ (H₁ ⋙ H₂) ⋙ R₃) :=
-  fun α β ↦ (whiskerRight α G₂) ≫ (whiskerLeft H₁ β)
-
 /-- The mates equivalence commutes with vertical composition. -/
-theorem mateEquiv_vcomp
-    (α : G₁ ⋙ L₂ ⟶ L₁ ⋙ H₁) (β : G₂ ⋙ L₃ ⟶ L₂ ⋙ H₂) :
-    (mateEquiv (G := G₁ ⋙ G₂) (H := H₁ ⋙ H₂) adj₁ adj₃) (leftAdjointSquare.vcomp α β) =
-      rightAdjointSquare.vcomp (mateEquiv adj₁ adj₂ α) (mateEquiv adj₂ adj₃ β) := by
-  unfold leftAdjointSquare.vcomp rightAdjointSquare.vcomp mateEquiv
+theorem mateEquiv_vcomp (α : TwoSquare G₁ L₁ L₂ H₁) (β : TwoSquare G₂ L₂ L₃ H₂) :
+    (mateEquiv adj₁ adj₃) (α ≫ₕ β) = (mateEquiv adj₁ adj₂ α) ≫ᵥ (mateEquiv adj₂ adj₃ β) := by
+  unfold hComp vComp mateEquiv
   ext b
   simp only [comp_obj, Equiv.coe_fn_mk, whiskerLeft_comp, whiskerLeft_twice, whiskerRight_comp,
-    assoc, comp_app, whiskerLeft_app, whiskerRight_app, id_obj, Functor.comp_map,
-    whiskerRight_twice]
+    assoc, comp_app, whiskerLeft_app, whiskerRight_app, associator_hom_app, map_id,
+    associator_inv_app, id_obj, Functor.comp_map, id_comp, whiskerRight_twice, comp_id]
   slice_rhs 1 4 => rw [← assoc, ← assoc, ← unit_naturality (adj₃)]
   rw [L₃.map_comp, R₃.map_comp]
   slice_rhs 2 4 =>
@@ -188,22 +177,11 @@ variable {L₁ : A ⥤ B} {R₁ : B ⥤ A} {L₂ : D ⥤ E} {R₂ : E ⥤ D}
 variable {L₃ : B ⥤ C} {R₃ : C ⥤ B} {L₄ : E ⥤ F} {R₄ : F ⥤ E}
 variable (adj₁ : L₁ ⊣ R₁) (adj₂ : L₂ ⊣ R₂) (adj₃ : L₃ ⊣ R₃) (adj₄ : L₄ ⊣ R₄)
 
-/-- Squares between left adjoints can be composed "horizontally" by pasting. -/
-def leftAdjointSquare.hcomp :
-    (G ⋙ L₂ ⟶ L₁ ⋙ H) → (H ⋙ L₄ ⟶ L₃ ⋙ K) → (G ⋙ (L₂ ⋙ L₄) ⟶ (L₁ ⋙ L₃) ⋙ K) := fun α β ↦
-  (whiskerRight α L₄) ≫ (whiskerLeft L₁ β)
-
-/-- Squares between right adjoints can be composed "horizontally" by pasting. -/
-def rightAdjointSquare.hcomp :
-    (R₁ ⋙ G ⟶ H ⋙ R₂) → (R₃ ⋙ H ⟶ K ⋙ R₄) → ((R₃ ⋙ R₁) ⋙ G ⟶ K ⋙ (R₄ ⋙ R₂)) := fun α β ↦
-  (whiskerLeft R₃ α) ≫ (whiskerRight β R₂)
-
 /-- The mates equivalence commutes with horizontal composition of squares. -/
-theorem mateEquiv_hcomp
-    (α : G ⋙ L₂ ⟶ L₁ ⋙ H) (β : H ⋙ L₄ ⟶ L₃ ⋙ K) :
-    (mateEquiv (adj₁.comp adj₃) (adj₂.comp adj₄)) (leftAdjointSquare.hcomp α β) =
-      rightAdjointSquare.hcomp (mateEquiv adj₁ adj₂ α) (mateEquiv adj₃ adj₄ β) := by
-  unfold leftAdjointSquare.hcomp rightAdjointSquare.hcomp mateEquiv Adjunction.comp
+theorem mateEquiv_hcomp (α : TwoSquare G L₁ L₂ H) (β : TwoSquare H L₃ L₄ K) :
+    (mateEquiv (adj₁.comp adj₃) (adj₂.comp adj₄)) (α ≫ᵥ β) =
+      (mateEquiv adj₃ adj₄ β) ≫ₕ (mateEquiv adj₁ adj₂ α) := by
+  unfold vComp hComp mateEquiv Adjunction.comp
   ext c
   dsimp
   simp only [comp_id, map_comp, id_comp, assoc]
@@ -230,82 +208,18 @@ variable {L₄ : E ⥤ F} {R₄ : F ⥤ E} {L₅ : X ⥤ Y} {R₅ : Y ⥤ X} {L�
 variable (adj₁ : L₁ ⊣ R₁) (adj₂ : L₂ ⊣ R₂) (adj₃ : L₃ ⊣ R₃)
 variable (adj₄ : L₄ ⊣ R₄) (adj₅ : L₅ ⊣ R₅) (adj₆ : L₆ ⊣ R₆)
 
-/-- Squares of squares between left adjoints can be composed by iterating vertical and horizontal
-composition.
--/
-def leftAdjointSquare.comp
-    (α : G₁ ⋙ L₃ ⟶ L₁ ⋙ H₁) (β : H₁ ⋙ L₄ ⟶ L₂ ⋙ K₁)
-    (γ : G₂ ⋙ L₅ ⟶ L₃ ⋙ H₂) (δ : H₂ ⋙ L₆ ⟶ L₄ ⋙ K₂) :
-    ((G₁ ⋙ G₂) ⋙ (L₅ ⋙ L₆)) ⟶ ((L₁ ⋙ L₂) ⋙ (K₁ ⋙ K₂)) :=
-  leftAdjointSquare.vcomp (leftAdjointSquare.hcomp α β) (leftAdjointSquare.hcomp γ δ)
-
-theorem leftAdjointSquare.comp_vhcomp
-    (α : G₁ ⋙ L₃ ⟶ L₁ ⋙ H₁) (β : H₁ ⋙ L₄ ⟶ L₂ ⋙ K₁)
-    (γ : G₂ ⋙ L₅ ⟶ L₃ ⋙ H₂) (δ : H₂ ⋙ L₆ ⟶ L₄ ⋙ K₂) :
-    leftAdjointSquare.comp α β γ δ =
-      leftAdjointSquare.vcomp (leftAdjointSquare.hcomp α β) (leftAdjointSquare.hcomp γ δ) := rfl
-
-/-- Horizontal and vertical composition of squares commutes. -/
-theorem leftAdjointSquare.comp_hvcomp
-    (α : G₁ ⋙ L₃ ⟶ L₁ ⋙ H₁) (β : H₁ ⋙ L₄ ⟶ L₂ ⋙ K₁)
-    (γ : G₂ ⋙ L₅ ⟶ L₃ ⋙ H₂) (δ : H₂ ⋙ L₆ ⟶ L₄ ⋙ K₂) :
-    leftAdjointSquare.comp α β γ δ =
-      leftAdjointSquare.hcomp (leftAdjointSquare.vcomp α γ) (leftAdjointSquare.vcomp β δ) := by
-  unfold leftAdjointSquare.comp leftAdjointSquare.hcomp leftAdjointSquare.vcomp
-  unfold whiskerLeft whiskerRight
-  ext a
-  simp only [comp_obj, comp_app, map_comp, assoc]
-  slice_rhs 2 3 =>
-    rw [← Functor.comp_map _ L₆, δ.naturality]
-  simp only [comp_obj, Functor.comp_map, assoc]
-
-/-- Squares of squares between right adjoints can be composed by iterating vertical and horizontal
-composition.
--/
-def rightAdjointSquare.comp
-    (α : R₁ ⋙ G₁ ⟶ H₁ ⋙ R₃) (β : R₂ ⋙ H₁ ⟶ K₁ ⋙ R₄)
-    (γ : R₃ ⋙ G₂ ⟶ H₂ ⋙ R₅) (δ : R₄ ⋙ H₂ ⟶ K₂ ⋙ R₆) :
-    ((R₂ ⋙ R₁) ⋙ (G₁ ⋙ G₂) ⟶ (K₁ ⋙ K₂) ⋙ (R₆ ⋙ R₅)) :=
-  rightAdjointSquare.vcomp (rightAdjointSquare.hcomp α β) (rightAdjointSquare.hcomp γ δ)
-
-theorem rightAdjointSquare.comp_vhcomp
-    (α : R₁ ⋙ G₁ ⟶ H₁ ⋙ R₃) (β : R₂ ⋙ H₁ ⟶ K₁ ⋙ R₄)
-    (γ : R₃ ⋙ G₂ ⟶ H₂ ⋙ R₅) (δ : R₄ ⋙ H₂ ⟶ K₂ ⋙ R₆) :
-    rightAdjointSquare.comp α β γ δ =
-    rightAdjointSquare.vcomp (rightAdjointSquare.hcomp α β) (rightAdjointSquare.hcomp γ δ) := rfl
-
-/-- Horizontal and vertical composition of squares commutes. -/
-theorem rightAdjointSquare.comp_hvcomp
-    (α : R₁ ⋙ G₁ ⟶ H₁ ⋙ R₃) (β : R₂ ⋙ H₁ ⟶ K₁ ⋙ R₄)
-    (γ : R₃ ⋙ G₂ ⟶ H₂ ⋙ R₅) (δ : R₄ ⋙ H₂ ⟶ K₂ ⋙ R₆) :
-    rightAdjointSquare.comp α β γ δ =
-    rightAdjointSquare.hcomp (rightAdjointSquare.vcomp α γ) (rightAdjointSquare.vcomp β δ) := by
-  unfold rightAdjointSquare.comp rightAdjointSquare.hcomp rightAdjointSquare.vcomp
-  unfold whiskerLeft whiskerRight
-  ext c
-  simp only [comp_obj, comp_app, map_comp, assoc]
-  slice_rhs 2 3 =>
-    rw [← Functor.comp_map _ R₅, ← γ.naturality]
-  simp only [comp_obj, Functor.comp_map, assoc]
-
 /-- The mates equivalence commutes with composition of squares of squares. These results form the
 basis for an isomorphism of double categories to be proven later.
 -/
-theorem mateEquiv_square
-    (α : G₁ ⋙ L₃ ⟶ L₁ ⋙ H₁) (β : H₁ ⋙ L₄ ⟶ L₂ ⋙ K₁)
-    (γ : G₂ ⋙ L₅ ⟶ L₃ ⋙ H₂) (δ : H₂ ⋙ L₆ ⟶ L₄ ⋙ K₂) :
-    (mateEquiv (G := G₁ ⋙ G₂) (H := K₁ ⋙ K₂) (adj₁.comp adj₂) (adj₅.comp adj₆))
-        (leftAdjointSquare.comp α β γ δ) =
-      rightAdjointSquare.comp
-        (mateEquiv adj₁ adj₃ α) (mateEquiv adj₂ adj₄ β)
-        (mateEquiv adj₃ adj₅ γ) (mateEquiv adj₄ adj₆ δ) := by
+theorem mateEquiv_square (α : TwoSquare G₁ L₁ L₃ H₁) (β : TwoSquare H₁ L₂ L₄ K₁)
+    (γ : TwoSquare G₂ L₃ L₅ H₂) (δ : TwoSquare H₂ L₄ L₆ K₂) :
+    (mateEquiv (adj₁.comp adj₂) (adj₅.comp adj₆)) ((α ≫ᵥ β) ≫ₕ (γ ≫ᵥ δ)) =
+      ((mateEquiv adj₂ adj₄ β) ≫ₕ (mateEquiv adj₁ adj₃ α))
+         ≫ᵥ ((mateEquiv adj₄ adj₆ δ) ≫ₕ (mateEquiv adj₃ adj₅ γ)) := by
   have vcomp :=
-    mateEquiv_vcomp (adj₁.comp adj₂) (adj₃.comp adj₄) (adj₅.comp adj₆)
-      (leftAdjointSquare.hcomp α β) (leftAdjointSquare.hcomp γ δ)
-  have hcomp1 := mateEquiv_hcomp adj₁ adj₃ adj₂ adj₄ α β
-  have hcomp2 := mateEquiv_hcomp adj₃ adj₅ adj₄ adj₆ γ δ
-  rw [hcomp1, hcomp2] at vcomp
-  exact vcomp
+    mateEquiv_vcomp (adj₁.comp adj₂) (adj₃.comp adj₄) (adj₅.comp adj₆) (α ≫ᵥ β) (γ ≫ᵥ δ)
+  simp only [mateEquiv_hcomp] at vcomp
+  assumption
 
 end mateEquivSquareComp
 
@@ -338,6 +252,8 @@ theorem conjugateEquiv_counit (α : L₂ ⟶ L₁) (d : D) :
     L₂.map ((conjugateEquiv adj₁ adj₂ α).app _) ≫ adj₂.counit.app d =
       α.app _ ≫ adj₁.counit.app d := by
   dsimp [conjugateEquiv]
+  erw [Iso.homCongr_apply, mateEquiv_apply]
+  dsimp
   rw [id_comp, comp_id]
   have := mateEquiv_counit adj₁ adj₂ (L₂.leftUnitor.hom ≫ α ≫ L₁.rightUnitor.inv) d
   dsimp at this
@@ -356,6 +272,8 @@ theorem unit_conjugateEquiv (α : L₂ ⟶ L₁) (c : C) :
     adj₁.unit.app _ ≫ (conjugateEquiv adj₁ adj₂ α).app _ =
       adj₂.unit.app c ≫ R₂.map (α.app _) := by
   dsimp [conjugateEquiv]
+  erw [Iso.homCongr_apply, mateEquiv_apply]
+  dsimp
   rw [id_comp, comp_id]
   have := unit_mateEquiv adj₁ adj₂ (L₂.leftUnitor.hom ≫ α ≫ L₁.rightUnitor.inv) c
   dsimp at this
@@ -373,6 +291,8 @@ theorem unit_conjugateEquiv_symm (α : R₁ ⟶ R₂) (c : C) :
 theorem conjugateEquiv_id : conjugateEquiv adj₁ adj₁ (𝟙 _) = 𝟙 _ := by
   ext
   dsimp [conjugateEquiv, mateEquiv]
+  erw [Iso.homCongr_apply]
+  dsimp
   simp only [comp_id, map_id, id_comp, right_triangle_components]
 
 @[simp]
@@ -383,14 +303,18 @@ theorem conjugateEquiv_symm_id : (conjugateEquiv adj₁ adj₁).symm (𝟙 _) = 
 theorem conjugateEquiv_adjunction_id {L R : C ⥤ C} (adj : L ⊣ R) (α : 𝟭 C ⟶ L) (c : C) :
     (conjugateEquiv adj Adjunction.id α).app c = α.app (R.obj c) ≫ adj.counit.app c := by
   dsimp [conjugateEquiv, mateEquiv, Adjunction.id]
+  erw [Iso.homCongr_apply]
+  dsimp
   simp only [comp_id, id_comp]
 
 theorem conjugateEquiv_adjunction_id_symm {L R : C ⥤ C} (adj : L ⊣ R) (α : R ⟶ 𝟭 C) (c : C) :
     ((conjugateEquiv adj Adjunction.id).symm α).app c = adj.unit.app c ≫ α.app (L.obj c) := by
   dsimp [conjugateEquiv, mateEquiv, Adjunction.id]
   simp only [comp_id, id_comp]
-end conjugateEquiv
+  erw [Iso.homCongr_symm_apply]
+  simp
 
+end conjugateEquiv
 
 section ConjugateComposition
 variable {C : Type u₁} {D : Type u₂}
@@ -408,8 +332,12 @@ theorem conjugateEquiv_comp (α : L₂ ⟶ L₁) (β : L₃ ⟶ L₂) :
     (L₂.leftUnitor.hom ≫ α ≫ L₁.rightUnitor.inv)
     (L₃.leftUnitor.hom ≫ β ≫ L₂.rightUnitor.inv)
   have vcompd := congr_app vcomp d
-  dsimp [mateEquiv, leftAdjointSquare.vcomp, rightAdjointSquare.vcomp] at vcompd
+  dsimp [mateEquiv, vComp, vComp] at vcompd
   simp only [comp_id, id_comp, assoc, map_comp] at vcompd ⊢
+  erw [Iso.homCongr_apply, Iso.homCongr_apply, Iso.homCongr_apply]
+  simp only [hComp_app, id_obj, comp_app, comp_obj, leftUnitor_hom_app, rightUnitor_inv_app,
+    comp_id, id_comp, Functor.id_map, map_comp, assoc, whiskerRight_comp, whiskerLeft_app,
+    whiskerRight_app, map_id, Functor.comp_map] at vcompd ⊢
   rw [vcompd]
 
 @[simp]
@@ -511,12 +439,17 @@ theorem iterated_mateEquiv_conjugateEquiv (α : F₁ ⋙ L₂ ⟶ L₁ ⋙ F₂)
       conjugateEquiv (adj₁.comp adj₄) (adj₃.comp adj₂) α := by
   ext d
   unfold conjugateEquiv mateEquiv Adjunction.comp
+  simp only [comp_obj, Equiv.coe_fn_mk, whiskerLeft_comp, whiskerLeft_twice, whiskerRight_comp,
+    assoc, comp_app, whiskerLeft_app, whiskerRight_app, id_obj, Functor.comp_map, Iso.homCongr_symm,
+    mk'_unit, mk'_counit, whiskerRight_twice, Equiv.instTrans_trans, Equiv.trans_apply,
+    Iso.homCongr_apply, Iso.symm_inv, Iso.symm_hom]
+  erw [Iso.homCongr_apply]
   simp
 
 theorem iterated_mateEquiv_conjugateEquiv_symm (α : U₂ ⋙ R₁ ⟶ R₂ ⋙ U₁) :
     (mateEquiv adj₁ adj₂).symm ((mateEquiv adj₄ adj₃).symm α) =
       (conjugateEquiv (adj₁.comp adj₄) (adj₃.comp adj₂)).symm α := by
-  rw [Equiv.eq_symm_apply, ← iterated_mateEquiv_conjugateEquiv]
+  erw [Equiv.eq_symm_apply, ← iterated_mateEquiv_conjugateEquiv]
   simp only [Equiv.apply_symm_apply]
 
 end IteratedmateEquiv
@@ -532,12 +465,12 @@ variable (adj₁ : L₁ ⊣ R₁) (adj₂ : L₂ ⊣ R₂) (adj₃ : L₃ ⊣ R�
 
 /-- Composition of a squares between left adjoints with a conjugate square. -/
 def leftAdjointSquareConjugate.vcomp :
-    (G ⋙ L₂ ⟶ L₁ ⋙ H) → (L₃ ⟶ L₂) → (G ⋙ L₃ ⟶ L₁ ⋙ H) :=
+    TwoSquare G L₁ L₂ H → (L₃ ⟶ L₂) → TwoSquare G L₁ L₃ H :=
   fun α β ↦ (whiskerLeft G β) ≫ α
 
 /-- Composition of a squares between right adjoints with a conjugate square. -/
 def rightAdjointSquareConjugate.vcomp :
-    (R₁ ⋙ G ⟶ H ⋙ R₂) → (R₂ ⟶ R₃) → (R₁ ⋙ G ⟶ H ⋙ R₃) :=
+    TwoSquare R₁ H G R₂ → (R₂ ⟶ R₃) → TwoSquare R₁ H G R₃ :=
   fun α β ↦ α ≫ (whiskerLeft H β)
 
 /-- The mates equivalence commutes with this composition, essentially by `mateEquiv_vcomp`. -/
@@ -547,7 +480,7 @@ theorem mateEquiv_conjugateEquiv_vcomp
       rightAdjointSquareConjugate.vcomp (mateEquiv adj₁ adj₂ α) (conjugateEquiv adj₂ adj₃ β) := by
   ext b
   have vcomp := mateEquiv_vcomp adj₁ adj₂ adj₃ α (L₃.leftUnitor.hom ≫ β ≫ L₂.rightUnitor.inv)
-  unfold leftAdjointSquare.vcomp rightAdjointSquare.vcomp at vcomp
+  unfold vComp hComp at vcomp
   unfold leftAdjointSquareConjugate.vcomp rightAdjointSquareConjugate.vcomp conjugateEquiv
   have vcompb := congr_app vcomp b
   simp at vcompb
@@ -556,7 +489,8 @@ theorem mateEquiv_conjugateEquiv_vcomp
     assoc, comp_app, whiskerLeft_app, whiskerRight_app, id_obj, Functor.comp_map, Iso.homCongr_symm,
     Equiv.instTrans_trans, Equiv.trans_apply, Iso.homCongr_apply, Iso.symm_inv, Iso.symm_hom,
     rightUnitor_inv_app, leftUnitor_hom_app, map_id, Functor.id_map, comp_id, id_comp]
-  exact vcompb
+  erw [Iso.homCongr_apply]
+  simpa
 
 end mateEquivconjugateEquivVComp
 
@@ -571,12 +505,12 @@ variable (adj₁ : L₁ ⊣ R₁) (adj₂ : L₂ ⊣ R₂) (adj₃ : L₃ ⊣ R�
 
 /-- Composition of a conjugate square with a squares between left adjoints. -/
 def leftAdjointConjugateSquare.vcomp :
-    (L₂ ⟶ L₁) → (G ⋙ L₃ ⟶ L₂ ⋙ H) → (G ⋙ L₃ ⟶ L₁ ⋙ H) :=
+    (L₂ ⟶ L₁) → TwoSquare G L₂ L₃ H → TwoSquare G L₁ L₃ H :=
   fun α β ↦ β ≫ (whiskerRight α H)
 
 /-- Composition of a conjugate square with a squares between right adjoints. -/
 def rightAdjointConjugateSquare.vcomp :
-    (R₁ ⟶ R₂) → (R₂ ⋙ G ⟶ H ⋙ R₃) → (R₁ ⋙ G ⟶ H ⋙ R₃) :=
+    (R₁ ⟶ R₂) → TwoSquare R₂ H G R₃ → TwoSquare R₁ H G R₃ :=
   fun α β ↦ (whiskerRight α G) ≫ β
 
 /-- The mates equivalence commutes with this composition, essentially by `mateEquiv_vcomp`. -/
@@ -586,7 +520,7 @@ theorem conjugateEquiv_mateEquiv_vcomp
       rightAdjointConjugateSquare.vcomp (conjugateEquiv adj₁ adj₂ α) (mateEquiv adj₂ adj₃ β) := by
   ext b
   have vcomp := mateEquiv_vcomp adj₁ adj₂ adj₃ (L₂.leftUnitor.hom ≫ α ≫ L₁.rightUnitor.inv) β
-  unfold leftAdjointSquare.vcomp rightAdjointSquare.vcomp at vcomp
+  unfold vComp hComp at vcomp
   unfold leftAdjointConjugateSquare.vcomp rightAdjointConjugateSquare.vcomp conjugateEquiv
   have vcompb := congr_app vcomp b
   simp at vcompb
@@ -595,7 +529,8 @@ theorem conjugateEquiv_mateEquiv_vcomp
     assoc, comp_app, whiskerLeft_app, whiskerRight_app, id_obj, Functor.comp_map, Iso.homCongr_symm,
     Equiv.instTrans_trans, Equiv.trans_apply, Iso.homCongr_apply, Iso.symm_inv, Iso.symm_hom,
     rightUnitor_inv_app, leftUnitor_hom_app, map_id, Functor.id_map, comp_id, id_comp]
-  exact vcompb
+  erw [Iso.homCongr_apply]
+  simpa
 
 end conjugateEquivmateEquivVComp
 

--- a/Mathlib/CategoryTheory/Adjunction/Mates.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Mates.lean
@@ -474,14 +474,13 @@ def rightAdjointSquareConjugate.vcomp :
   fun α β ↦ α ≫ (whiskerLeft H β)
 
 /-- The mates equivalence commutes with this composition, essentially by `mateEquiv_vcomp`. -/
-theorem mateEquiv_conjugateEquiv_vcomp
-    (α : G ⋙ L₂ ⟶ L₁ ⋙ H) (β : L₃ ⟶ L₂) :
-    (mateEquiv adj₁ adj₃) (leftAdjointSquareConjugate.vcomp α β) =
-      rightAdjointSquareConjugate.vcomp (mateEquiv adj₁ adj₂ α) (conjugateEquiv adj₂ adj₃ β) := by
+theorem mateEquiv_conjugateEquiv_vcomp (α : TwoSquare G L₁ L₂ H) (β : L₃ ⟶ L₂) :
+    (mateEquiv adj₁ adj₃) (α.whiskerRight β) =
+      (mateEquiv adj₁ adj₂ α).whiskerBottom (conjugateEquiv adj₂ adj₃ β) := by
   ext b
   have vcomp := mateEquiv_vcomp adj₁ adj₂ adj₃ α (L₃.leftUnitor.hom ≫ β ≫ L₂.rightUnitor.inv)
   unfold vComp hComp at vcomp
-  unfold leftAdjointSquareConjugate.vcomp rightAdjointSquareConjugate.vcomp conjugateEquiv
+  unfold TwoSquare.whiskerRight TwoSquare.whiskerBottom conjugateEquiv
   have vcompb := congr_app vcomp b
   simp at vcompb
   unfold mateEquiv
@@ -503,25 +502,14 @@ variable {G : A ⥤ C} {H : B ⥤ D}
 variable {L₁ : A ⥤ B} {R₁ : B ⥤ A} {L₂ : A ⥤ B} {R₂ : B ⥤ A} {L₃ : C ⥤ D} {R₃ : D ⥤ C}
 variable (adj₁ : L₁ ⊣ R₁) (adj₂ : L₂ ⊣ R₂) (adj₃ : L₃ ⊣ R₃)
 
-/-- Composition of a conjugate square with a squares between left adjoints. -/
-def leftAdjointConjugateSquare.vcomp :
-    (L₂ ⟶ L₁) → TwoSquare G L₂ L₃ H → TwoSquare G L₁ L₃ H :=
-  fun α β ↦ β ≫ (whiskerRight α H)
-
-/-- Composition of a conjugate square with a squares between right adjoints. -/
-def rightAdjointConjugateSquare.vcomp :
-    (R₁ ⟶ R₂) → TwoSquare R₂ H G R₃ → TwoSquare R₁ H G R₃ :=
-  fun α β ↦ (whiskerRight α G) ≫ β
-
 /-- The mates equivalence commutes with this composition, essentially by `mateEquiv_vcomp`. -/
-theorem conjugateEquiv_mateEquiv_vcomp
-    (α : L₂ ⟶ L₁) (β : G ⋙ L₃ ⟶ L₂ ⋙ H) :
-    (mateEquiv adj₁ adj₃) (leftAdjointConjugateSquare.vcomp α β) =
-      rightAdjointConjugateSquare.vcomp (conjugateEquiv adj₁ adj₂ α) (mateEquiv adj₂ adj₃ β) := by
+theorem conjugateEquiv_mateEquiv_vcomp (α : L₂ ⟶ L₁) (β : TwoSquare G L₂ L₃ H) :
+    (mateEquiv adj₁ adj₃) (β.whiskerLeft α) =
+      (mateEquiv adj₂ adj₃ β).whiskerTop (conjugateEquiv adj₁ adj₂ α) := by
   ext b
   have vcomp := mateEquiv_vcomp adj₁ adj₂ adj₃ (L₂.leftUnitor.hom ≫ α ≫ L₁.rightUnitor.inv) β
   unfold vComp hComp at vcomp
-  unfold leftAdjointConjugateSquare.vcomp rightAdjointConjugateSquare.vcomp conjugateEquiv
+  unfold TwoSquare.whiskerLeft TwoSquare.whiskerTop conjugateEquiv
   have vcompb := congr_app vcomp b
   simp at vcompb
   unfold mateEquiv

--- a/Mathlib/CategoryTheory/Adjunction/Mates.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Mates.lean
@@ -73,13 +73,13 @@ Note that if one of the transformations is an iso, it does not imply the other i
 -/
 @[simps]
 def mateEquiv : TwoSquare G L₁ L₂ H ≃ TwoSquare R₁ H G R₂ where
-  toFun α :=
+  toFun α := .mk _ _ _ _ <|
     whiskerLeft (R₁ ⋙ G) adj₂.unit ≫
-    whiskerRight (whiskerLeft R₁ α) R₂ ≫
+    whiskerRight (whiskerLeft R₁ α.out) R₂ ≫
     whiskerRight adj₁.counit (H ⋙ R₂)
-  invFun β :=
+  invFun β := .mk _ _ _ _ <|
     whiskerRight adj₁.unit (G ⋙ L₂) ≫
-    whiskerRight (whiskerLeft L₁ β) L₂ ≫
+    whiskerRight (whiskerLeft L₁ β.out) L₂ ≫
     whiskerLeft (L₁ ⋙ H) adj₂.counit
   left_inv α := by
     ext
@@ -243,8 +243,10 @@ This is in contrast to the general case `mateEquiv` which does not in general ha
 @[simps!]
 def conjugateEquiv : (L₂ ⟶ L₁) ≃ (R₁ ⟶ R₂) :=
   calc
-    (L₂ ⟶ L₁) ≃ _ := (Iso.homCongr L₂.leftUnitor L₁.rightUnitor).symm
+    (L₂ ⟶ L₁) ≃ (𝟭 C ⋙ L₂ ⟶ L₁ ⋙ 𝟭 D) := (Iso.homCongr L₂.leftUnitor L₁.rightUnitor).symm
+    _ ≃ TwoSquare _ _ _ _ := (TwoSquare.equivNatTrans _ _ _ _).symm
     _ ≃ _ := mateEquiv adj₁ adj₂
+    _ ≃ (R₁ ⋙ 𝟭 C ⟶ 𝟭 D ⋙ R₂) := TwoSquare.equivNatTrans _ _ _ _
     _ ≃ (R₁ ⟶ R₂) := R₁.rightUnitor.homCongr R₂.leftUnitor
 
 /-- A component of a transposed form of the conjugation definition. -/
@@ -252,8 +254,6 @@ theorem conjugateEquiv_counit (α : L₂ ⟶ L₁) (d : D) :
     L₂.map ((conjugateEquiv adj₁ adj₂ α).app _) ≫ adj₂.counit.app d =
       α.app _ ≫ adj₁.counit.app d := by
   dsimp [conjugateEquiv]
-  erw [Iso.homCongr_apply, mateEquiv_apply]
-  dsimp
   rw [id_comp, comp_id]
   have := mateEquiv_counit adj₁ adj₂ (L₂.leftUnitor.hom ≫ α ≫ L₁.rightUnitor.inv) d
   dsimp at this
@@ -272,8 +272,6 @@ theorem unit_conjugateEquiv (α : L₂ ⟶ L₁) (c : C) :
     adj₁.unit.app _ ≫ (conjugateEquiv adj₁ adj₂ α).app _ =
       adj₂.unit.app c ≫ R₂.map (α.app _) := by
   dsimp [conjugateEquiv]
-  erw [Iso.homCongr_apply, mateEquiv_apply]
-  dsimp
   rw [id_comp, comp_id]
   have := unit_mateEquiv adj₁ adj₂ (L₂.leftUnitor.hom ≫ α ≫ L₁.rightUnitor.inv) c
   dsimp at this
@@ -290,10 +288,7 @@ theorem unit_conjugateEquiv_symm (α : R₁ ⟶ R₂) (c : C) :
 @[simp]
 theorem conjugateEquiv_id : conjugateEquiv adj₁ adj₁ (𝟙 _) = 𝟙 _ := by
   ext
-  dsimp [conjugateEquiv, mateEquiv]
-  erw [Iso.homCongr_apply]
-  dsimp
-  simp only [comp_id, map_id, id_comp, right_triangle_components]
+  simp
 
 @[simp]
 theorem conjugateEquiv_symm_id : (conjugateEquiv adj₁ adj₁).symm (𝟙 _) = 𝟙 _ := by
@@ -302,17 +297,11 @@ theorem conjugateEquiv_symm_id : (conjugateEquiv adj₁ adj₁).symm (𝟙 _) = 
 
 theorem conjugateEquiv_adjunction_id {L R : C ⥤ C} (adj : L ⊣ R) (α : 𝟭 C ⟶ L) (c : C) :
     (conjugateEquiv adj Adjunction.id α).app c = α.app (R.obj c) ≫ adj.counit.app c := by
-  dsimp [conjugateEquiv, mateEquiv, Adjunction.id]
-  erw [Iso.homCongr_apply]
-  dsimp
-  simp only [comp_id, id_comp]
+  simp [conjugateEquiv, mateEquiv, Adjunction.id]
 
 theorem conjugateEquiv_adjunction_id_symm {L R : C ⥤ C} (adj : L ⊣ R) (α : R ⟶ 𝟭 C) (c : C) :
     ((conjugateEquiv adj Adjunction.id).symm α).app c = adj.unit.app c ≫ α.app (L.obj c) := by
-  dsimp [conjugateEquiv, mateEquiv, Adjunction.id]
-  simp only [comp_id, id_comp]
-  erw [Iso.homCongr_symm_apply]
-  simp
+  simp [conjugateEquiv, mateEquiv, Adjunction.id]
 
 end conjugateEquiv
 
@@ -333,11 +322,8 @@ theorem conjugateEquiv_comp (α : L₂ ⟶ L₁) (β : L₃ ⟶ L₂) :
     (L₃.leftUnitor.hom ≫ β ≫ L₂.rightUnitor.inv)
   have vcompd := congr_app vcomp d
   dsimp [mateEquiv, vComp, vComp] at vcompd
-  simp only [comp_id, id_comp, assoc, map_comp] at vcompd ⊢
-  erw [Iso.homCongr_apply, Iso.homCongr_apply, Iso.homCongr_apply]
   simp only [hComp_app, id_obj, comp_app, comp_obj, leftUnitor_hom_app, rightUnitor_inv_app,
-    comp_id, id_comp, Functor.id_map, map_comp, assoc, whiskerRight_comp, whiskerLeft_app,
-    whiskerRight_app, map_id, Functor.comp_map] at vcompd ⊢
+    comp_id, id_comp, Functor.id_map, map_comp, assoc] at vcompd ⊢
   rw [vcompd]
 
 @[simp]
@@ -415,9 +401,11 @@ def conjugateIsoEquiv : (L₂ ≅ L₁) ≃ (R₁ ≅ R₂) where
 
 end ConjugateIsomorphism
 
-section IteratedmateEquiv
 variable {A : Type u₁} {B : Type u₂} {C : Type u₃} {D : Type u₄}
 variable [Category.{v₁} A] [Category.{v₂} B] [Category.{v₃} C] [Category.{v₄} D]
+
+section IteratedmateEquiv
+
 variable {F₁ : A ⥤ C} {U₁ : C ⥤ A} {F₂ : B ⥤ D} {U₂ : D ⥤ B}
 variable {L₁ : A ⥤ B} {R₁ : B ⥤ A} {L₂ : C ⥤ D} {R₂ : D ⥤ C}
 variable (adj₁ : L₁ ⊣ R₁) (adj₂ : L₂ ⊣ R₂) (adj₃ : F₁ ⊣ U₁) (adj₄ : F₂ ⊣ U₂)
@@ -434,47 +422,28 @@ In this case the iterated mate equals the conjugate of the original transformati
 isomorphism if and only if the original transformation is. This explains why some Beck-Chevalley
 natural transformations are natural isomorphisms.
 -/
-theorem iterated_mateEquiv_conjugateEquiv (α : F₁ ⋙ L₂ ⟶ L₁ ⋙ F₂) :
-    mateEquiv adj₄ adj₃ (mateEquiv adj₁ adj₂ α) =
+theorem iterated_mateEquiv_conjugateEquiv (α : TwoSquare F₁ L₁ L₂ F₂) :
+    (mateEquiv adj₄ adj₃ (mateEquiv adj₁ adj₂ α)).out =
       conjugateEquiv (adj₁.comp adj₄) (adj₃.comp adj₂) α := by
   ext d
   unfold conjugateEquiv mateEquiv Adjunction.comp
-  simp only [comp_obj, Equiv.coe_fn_mk, whiskerLeft_comp, whiskerLeft_twice, whiskerRight_comp,
-    assoc, comp_app, whiskerLeft_app, whiskerRight_app, id_obj, Functor.comp_map, Iso.homCongr_symm,
-    mk'_unit, mk'_counit, whiskerRight_twice, Equiv.instTrans_trans, Equiv.trans_apply,
-    Iso.homCongr_apply, Iso.symm_inv, Iso.symm_hom]
-  erw [Iso.homCongr_apply]
   simp
 
-theorem iterated_mateEquiv_conjugateEquiv_symm (α : U₂ ⋙ R₁ ⟶ R₂ ⋙ U₁) :
+theorem iterated_mateEquiv_conjugateEquiv_symm (α : TwoSquare U₂ R₂ R₁ U₁) :
     (mateEquiv adj₁ adj₂).symm ((mateEquiv adj₄ adj₃).symm α) =
-      (conjugateEquiv (adj₁.comp adj₄) (adj₃.comp adj₂)).symm α := by
-  erw [Equiv.eq_symm_apply, ← iterated_mateEquiv_conjugateEquiv]
-  simp only [Equiv.apply_symm_apply]
+      (conjugateEquiv (adj₁.comp adj₄) (adj₃.comp adj₂)).symm.trans
+        (equivNatTrans _ _ _ _).symm α := by
+  ext
+  simp
 
 end IteratedmateEquiv
 
-section mateEquivconjugateEquivVComp
-
-variable {A : Type u₁} {B : Type u₂} {C : Type u₃} {D : Type u₄}
-variable [Category.{v₁} A] [Category.{v₂} B] [Category.{v₃} C]
-variable [Category.{v₄} D]
 variable {G : A ⥤ C} {H : B ⥤ D}
-variable {L₁ : A ⥤ B} {R₁ : B ⥤ A} {L₂ : C ⥤ D} {R₂ : D ⥤ C} {L₃ : C ⥤ D} {R₃ : D ⥤ C}
-variable (adj₁ : L₁ ⊣ R₁) (adj₂ : L₂ ⊣ R₂) (adj₃ : L₃ ⊣ R₃)
-
-/-- Composition of a squares between left adjoints with a conjugate square. -/
-def leftAdjointSquareConjugate.vcomp :
-    TwoSquare G L₁ L₂ H → (L₃ ⟶ L₂) → TwoSquare G L₁ L₃ H :=
-  fun α β ↦ (whiskerLeft G β) ≫ α
-
-/-- Composition of a squares between right adjoints with a conjugate square. -/
-def rightAdjointSquareConjugate.vcomp :
-    TwoSquare R₁ H G R₂ → (R₂ ⟶ R₃) → TwoSquare R₁ H G R₃ :=
-  fun α β ↦ α ≫ (whiskerLeft H β)
 
 /-- The mates equivalence commutes with this composition, essentially by `mateEquiv_vcomp`. -/
-theorem mateEquiv_conjugateEquiv_vcomp (α : TwoSquare G L₁ L₂ H) (β : L₃ ⟶ L₂) :
+theorem mateEquiv_conjugateEquiv_vcomp {L₁ : A ⥤ B} {R₁ : B ⥤ A} {L₂ : C ⥤ D} {R₂ : D ⥤ C}
+    {L₃ : C ⥤ D} {R₃ : D ⥤ C}
+    (adj₁ : L₁ ⊣ R₁) (adj₂ : L₂ ⊣ R₂) (adj₃ : L₃ ⊣ R₃) (α : TwoSquare G L₁ L₂ H) (β : L₃ ⟶ L₂) :
     (mateEquiv adj₁ adj₃) (α.whiskerRight β) =
       (mateEquiv adj₁ adj₂ α).whiskerBottom (conjugateEquiv adj₂ adj₃ β) := by
   ext b
@@ -482,28 +451,16 @@ theorem mateEquiv_conjugateEquiv_vcomp (α : TwoSquare G L₁ L₂ H) (β : L₃
   unfold vComp hComp at vcomp
   unfold TwoSquare.whiskerRight TwoSquare.whiskerBottom conjugateEquiv
   have vcompb := congr_app vcomp b
-  simp at vcompb
-  unfold mateEquiv
-  simp only [comp_obj, Equiv.coe_fn_mk, whiskerLeft_comp, whiskerLeft_twice, whiskerRight_comp,
-    assoc, comp_app, whiskerLeft_app, whiskerRight_app, id_obj, Functor.comp_map, Iso.homCongr_symm,
-    Equiv.instTrans_trans, Equiv.trans_apply, Iso.homCongr_apply, Iso.symm_inv, Iso.symm_hom,
-    rightUnitor_inv_app, leftUnitor_hom_app, map_id, Functor.id_map, comp_id, id_comp]
-  erw [Iso.homCongr_apply]
-  simpa
-
-end mateEquivconjugateEquivVComp
-
-section conjugateEquivmateEquivVComp
-
-variable {A : Type u₁} {B : Type u₂} {C : Type u₃} {D : Type u₄}
-variable [Category.{v₁} A] [Category.{v₂} B] [Category.{v₃} C]
-variable [Category.{v₄} D]
-variable {G : A ⥤ C} {H : B ⥤ D}
-variable {L₁ : A ⥤ B} {R₁ : B ⥤ A} {L₂ : A ⥤ B} {R₂ : B ⥤ A} {L₃ : C ⥤ D} {R₃ : D ⥤ C}
-variable (adj₁ : L₁ ⊣ R₁) (adj₂ : L₂ ⊣ R₂) (adj₃ : L₃ ⊣ R₃)
+  simp only [comp_obj, id_obj, whiskerLeft_comp, assoc, mateEquiv_apply, whiskerLeft_twice,
+    whiskerRight_comp, comp_app, whiskerLeft_app, whiskerRight_app, associator_hom_app, map_id,
+    leftUnitor_hom_app, rightUnitor_inv_app, associator_inv_app, Functor.id_map, Functor.comp_map,
+    id_comp, whiskerRight_twice, comp_id] at vcompb
+  simpa [mateEquiv]
 
 /-- The mates equivalence commutes with this composition, essentially by `mateEquiv_vcomp`. -/
-theorem conjugateEquiv_mateEquiv_vcomp (α : L₂ ⟶ L₁) (β : TwoSquare G L₂ L₃ H) :
+theorem conjugateEquiv_mateEquiv_vcomp {L₁ : A ⥤ B} {R₁ : B ⥤ A} {L₂ : A ⥤ B} {R₂ : B ⥤ A}
+    {L₃ : C ⥤ D} {R₃ : D ⥤ C}
+    (adj₁ : L₁ ⊣ R₁) (adj₂ : L₂ ⊣ R₂) (adj₃ : L₃ ⊣ R₃) (α : L₂ ⟶ L₁) (β : TwoSquare G L₂ L₃ H) :
     (mateEquiv adj₁ adj₃) (β.whiskerLeft α) =
       (mateEquiv adj₂ adj₃ β).whiskerTop (conjugateEquiv adj₁ adj₂ α) := by
   ext b
@@ -511,15 +468,10 @@ theorem conjugateEquiv_mateEquiv_vcomp (α : L₂ ⟶ L₁) (β : TwoSquare G L�
   unfold vComp hComp at vcomp
   unfold TwoSquare.whiskerLeft TwoSquare.whiskerTop conjugateEquiv
   have vcompb := congr_app vcomp b
-  simp at vcompb
-  unfold mateEquiv
-  simp only [comp_obj, Equiv.coe_fn_mk, whiskerLeft_comp, whiskerLeft_twice, whiskerRight_comp,
-    assoc, comp_app, whiskerLeft_app, whiskerRight_app, id_obj, Functor.comp_map, Iso.homCongr_symm,
-    Equiv.instTrans_trans, Equiv.trans_apply, Iso.homCongr_apply, Iso.symm_inv, Iso.symm_hom,
-    rightUnitor_inv_app, leftUnitor_hom_app, map_id, Functor.id_map, comp_id, id_comp]
-  erw [Iso.homCongr_apply]
-  simpa
-
-end conjugateEquivmateEquivVComp
+  simp only [comp_obj, id_obj, whiskerRight_comp, assoc, mateEquiv_apply, whiskerLeft_comp,
+    whiskerLeft_twice, comp_app, whiskerLeft_app, whiskerRight_app, associator_hom_app, map_id,
+    associator_inv_app, leftUnitor_hom_app, rightUnitor_inv_app, Functor.comp_map, Functor.id_map,
+    id_comp, whiskerRight_twice, comp_id] at vcompb
+  simpa [mateEquiv]
 
 end CategoryTheory

--- a/Mathlib/CategoryTheory/Closed/Functor.lean
+++ b/Mathlib/CategoryTheory/Closed/Functor.lean
@@ -61,8 +61,9 @@ Frobenius morphism is an isomorphism.
 -/
 instance frobeniusMorphism_iso_of_preserves_binary_products (h : L ⊣ F) (A : C)
     [Limits.PreservesLimitsOfShape (Discrete Limits.WalkingPair) L] [F.Full] [F.Faithful] :
-    IsIso (frobeniusMorphism F h A).out :=
-  suffices ∀ (X : D), IsIso ((frobeniusMorphism F h A).out.app X) from NatIso.isIso_of_isIso_app _
+    IsIso (frobeniusMorphism F h A).natTrans :=
+  suffices ∀ (X : D), IsIso ((frobeniusMorphism F h A).natTrans.app X) from
+    NatIso.isIso_of_isIso_app _
   fun B ↦ by dsimp [frobeniusMorphism]; infer_instance
 
 variable [CartesianClosed C] [CartesianClosed D]
@@ -75,7 +76,7 @@ def expComparison (A : C) : TwoSquare (exp A) F F (exp (F.obj A)) :=
   mateEquiv (exp.adjunction A) (exp.adjunction (F.obj A)) (prodComparisonNatIso F A).inv
 
 theorem expComparison_ev (A B : C) :
-    F.obj A ◁ ((expComparison F A).out.app B) ≫ (exp.ev (F.obj A)).app (F.obj B) =
+    F.obj A ◁ ((expComparison F A).natTrans.app B) ≫ (exp.ev (F.obj A)).app (F.obj B) =
       inv (prodComparison F _ _) ≫ F.map ((exp.ev _).app _) := by
   convert mateEquiv_counit _ _ (prodComparisonNatIso F A).inv B using 2
   apply IsIso.inv_eq_of_hom_inv_id -- Porting note: was `ext`
@@ -83,7 +84,7 @@ theorem expComparison_ev (A B : C) :
     IsIso.hom_inv_id]
 
 theorem coev_expComparison (A B : C) :
-    F.map ((exp.coev A).app B) ≫ (expComparison F A).out.app (A ⊗ B) =
+    F.map ((exp.coev A).app B) ≫ (expComparison F A).natTrans.app (A ⊗ B) =
       (exp.coev _).app (F.obj B) ≫ (exp (F.obj A)).map (inv (prodComparison F A B)) := by
   convert unit_mateEquiv _ _ (prodComparisonNatIso F A).inv B using 3
   apply IsIso.inv_eq_of_hom_inv_id -- Porting note (https://github.com/leanprover-community/mathlib4/issues/11041): was `ext`
@@ -91,14 +92,14 @@ theorem coev_expComparison (A B : C) :
   simp
 
 theorem uncurry_expComparison (A B : C) :
-    CartesianClosed.uncurry ((expComparison F A).out.app B) =
+    CartesianClosed.uncurry ((expComparison F A).natTrans.app B) =
       inv (prodComparison F _ _) ≫ F.map ((exp.ev _).app _) := by
   rw [uncurry_eq, expComparison_ev]
 
 /-- The exponential comparison map is natural in `A`. -/
 theorem expComparison_whiskerLeft {A A' : C} (f : A' ⟶ A) :
-    (expComparison F A).out ≫ whiskerLeft _ (pre (F.map f)) =
-      whiskerRight (pre f) _ ≫ (expComparison F A').out := by
+    (expComparison F A).whiskerBottom (pre (F.map f)) =
+      (expComparison F A').whiskerTop (pre f) := by
   unfold expComparison pre
   have vcomp1 := mateEquiv_conjugateEquiv_vcomp
     (exp.adjunction A) (exp.adjunction (F.obj A)) (exp.adjunction (F.obj A'))
@@ -106,9 +107,9 @@ theorem expComparison_whiskerLeft {A A' : C} (f : A' ⟶ A) :
   have vcomp2 := conjugateEquiv_mateEquiv_vcomp
     (exp.adjunction A) (exp.adjunction A') (exp.adjunction (F.obj A'))
     (((curriedTensor C).map f)) ((prodComparisonNatIso F A').inv)
-  unfold TwoSquare.whiskerRight TwoSquare.whiskerBottom at vcomp1
-  unfold TwoSquare.whiskerLeft TwoSquare.whiskerTop at vcomp2
   rw [← vcomp1, ← vcomp2]
+  unfold TwoSquare.whiskerLeft TwoSquare.whiskerRight
+  congr 1
   apply congr_arg
   ext B
   simp only [Functor.comp_obj, tensorLeft_obj, prodComparisonNatIso_inv, asIso_inv,
@@ -121,13 +122,13 @@ theorem expComparison_whiskerLeft {A A' : C} (f : A' ⟶ A) :
 `exp_comparison F A` is an isomorphism
 -/
 class CartesianClosedFunctor : Prop where
-  comparison_iso : ∀ A, IsIso (expComparison F A).out
+  comparison_iso : ∀ A, IsIso (expComparison F A).natTrans
 
 attribute [instance] CartesianClosedFunctor.comparison_iso
 
 theorem frobeniusMorphism_mate (h : L ⊣ F) (A : C) :
     conjugateEquiv (h.comp (exp.adjunction A)) ((exp.adjunction (F.obj A)).comp h)
-        (frobeniusMorphism F h A).out = (expComparison F A).out := by
+        (frobeniusMorphism F h A).natTrans = (expComparison F A).natTrans := by
   unfold expComparison frobeniusMorphism
   have conjeq := iterated_mateEquiv_conjugateEquiv h h
     (exp.adjunction (F.obj A)) (exp.adjunction A)
@@ -162,7 +163,7 @@ If the exponential comparison transformation (at `A`) is an isomorphism, then th
 at `A` is an isomorphism.
 -/
 theorem frobeniusMorphism_iso_of_expComparison_iso (h : L ⊣ F) (A : C)
-    [i : IsIso (expComparison F A).out] : IsIso (frobeniusMorphism F h A).out := by
+    [i : IsIso (expComparison F A).natTrans] : IsIso (frobeniusMorphism F h A).natTrans := by
   rw [← frobeniusMorphism_mate F h] at i
   exact @conjugateEquiv_of_iso _ _ _ _ _ _ _ _ _ _ _ i
 
@@ -171,7 +172,7 @@ If the Frobenius morphism at `A` is an isomorphism, then the exponential compari
 (at `A`) is an isomorphism.
 -/
 theorem expComparison_iso_of_frobeniusMorphism_iso (h : L ⊣ F) (A : C)
-    [i : IsIso (frobeniusMorphism F h A)] : IsIso (expComparison F A).out := by
+    [i : IsIso (frobeniusMorphism F h A)] : IsIso (expComparison F A).natTrans := by
   rw [← frobeniusMorphism_mate F h]; infer_instance
 
 open Limits in

--- a/Mathlib/CategoryTheory/Functor/TwoSquare.lean
+++ b/Mathlib/CategoryTheory/Functor/TwoSquare.lean
@@ -49,6 +49,16 @@ namespace TwoSquare
 /-- Constructor for `TwoSquare`. -/
 abbrev mk (α : T ⋙ R ⟶ L ⋙ B) : TwoSquare T L R B := α
 
+variable {T} {L} {R} {B} in
+abbrev out (w : TwoSquare T L R B) : T ⋙ R ⟶ L ⋙ B := w
+
+@[simps]
+def equivNatTrans : TwoSquare T L R B ≃ (T ⋙ R ⟶ L ⋙ B) where
+  toFun := out
+  invFun := mk T L R B
+  left_inv := fun _ => rfl
+  right_inv := fun _ => rfl
+
 variable {T L R B}
 
 @[ext]

--- a/Mathlib/CategoryTheory/Functor/TwoSquare.lean
+++ b/Mathlib/CategoryTheory/Functor/TwoSquare.lean
@@ -71,6 +71,29 @@ def vId (T : C₁ ⥤ C₂) : TwoSquare T (𝟭 _) (𝟭 _) T :=
 /-- Notation for the vertical identity 2-square. -/
 scoped notation "𝟙ᵥ" => vId  -- type as \b1\_v
 
+/-- Whiskering a 2-square with a natural transformation at the top. -/
+@[simps!]
+protected def whiskerTop {T' : C₁ ⥤ C₂} (α : T ⟶ T') (w : TwoSquare T' L R B) : TwoSquare T L R B :=
+  whiskerRight α R ≫ w
+
+/-- Whiskering a 2-square with a natural transformation at the left side. -/
+@[simps!]
+protected def whiskerLeft {L' : C₁ ⥤ C₃} (α : L ⟶ L') (w : TwoSquare T L R B) :
+    TwoSquare T L' R B :=
+  w ≫ whiskerRight α B
+
+/-- Whiskering a 2-square with a natural transformation at the right side. -/
+@[simps!]
+protected def whiskerRight {R' : C₂ ⥤ C₄} (α : R ⟶ R') (w : TwoSquare T L R' B) :
+    TwoSquare T L R B :=
+  whiskerLeft T α ≫ w
+
+/-- Whiskering a 2-square with a natural transformation at the bottom. -/
+@[simps!]
+protected def whiskerBottom {B' : C₃ ⥤ C₄} (α : B ⟶ B') (w : TwoSquare T L R B) :
+    TwoSquare T L R B' :=
+  w ≫ whiskerLeft L α
+
 variable {C₅ : Type u₅} {C₆ : Type u₆} {C₇ : Type u₇} {C₈ : Type u₈}
   [Category.{v₅} C₅] [Category.{v₆} C₆] [Category.{v₇} C₇] [Category.{v₈} C₈]
   {T' : C₂ ⥤ C₅} {R' : C₅ ⥤ C₆} {B' : C₄ ⥤ C₆} {L' : C₃ ⥤ C₇} {R'' : C₄ ⥤ C₈} {B'' : C₇ ⥤ C₈}

--- a/Mathlib/CategoryTheory/Functor/TwoSquare.lean
+++ b/Mathlib/CategoryTheory/Functor/TwoSquare.lean
@@ -51,21 +51,22 @@ abbrev mk (α : T ⋙ R ⟶ L ⋙ B) : TwoSquare T L R B := α
 
 variable {T} {L} {R} {B} in
 /-- The natural transfomration associated to a 2-square. -/
-abbrev out (w : TwoSquare T L R B) : T ⋙ R ⟶ L ⋙ B := w
+abbrev natTrans (w : TwoSquare T L R B) : T ⋙ R ⟶ L ⋙ B := w
 
 /-- The type of 2-squares on functors `T`, `L`, `R`, and `B` is trivially equivalent to
 the type of natural transformations `T ⋙ R ⟶ L ⋙ B`. -/
 @[simps]
 def equivNatTrans : TwoSquare T L R B ≃ (T ⋙ R ⟶ L ⋙ B) where
-  toFun := out
+  toFun := natTrans
   invFun := mk T L R B
-  left_inv := fun _ => rfl
-  right_inv := fun _ => rfl
+  left_inv _ := rfl
+  right_inv _ := rfl
 
 variable {T L R B}
 
 @[ext]
-lemma ext (w w' : TwoSquare T L R B) (h : ∀ (X : C₁), w.app X = w'.app X) : w = w' :=
+lemma ext (w w' : TwoSquare T L R B) (h : ∀ (X : C₁), w.natTrans.app X = w'.natTrans.app X) :
+    w = w' :=
   NatTrans.ext (funext h)
 
 /-- The hoizontal identity 2-square. -/
@@ -86,26 +87,26 @@ scoped notation "𝟙ᵥ" => vId  -- type as \b1\_v
 
 /-- Whiskering a 2-square with a natural transformation at the top. -/
 @[simps!]
-protected def whiskerTop {T' : C₁ ⥤ C₂} (α : T ⟶ T') (w : TwoSquare T' L R B) : TwoSquare T L R B :=
-  whiskerRight α R ≫ w
+protected def whiskerTop {T' : C₁ ⥤ C₂} (w : TwoSquare T' L R B) (α : T ⟶ T') : TwoSquare T L R B :=
+  .mk _ _ _ _ <| whiskerRight α R ≫ w.natTrans
 
 /-- Whiskering a 2-square with a natural transformation at the left side. -/
 @[simps!]
-protected def whiskerLeft {L' : C₁ ⥤ C₃} (α : L ⟶ L') (w : TwoSquare T L R B) :
+protected def whiskerLeft {L' : C₁ ⥤ C₃} (w : TwoSquare T L R B) (α : L ⟶ L') :
     TwoSquare T L' R B :=
-  w ≫ whiskerRight α B
+  .mk _ _ _ _ <| w.natTrans ≫ whiskerRight α B
 
 /-- Whiskering a 2-square with a natural transformation at the right side. -/
 @[simps!]
-protected def whiskerRight {R' : C₂ ⥤ C₄} (α : R ⟶ R') (w : TwoSquare T L R' B) :
+protected def whiskerRight {R' : C₂ ⥤ C₄} (w : TwoSquare T L R' B) (α : R ⟶ R') :
     TwoSquare T L R B :=
-  whiskerLeft T α ≫ w
+  .mk _ _ _ _ <| whiskerLeft T α ≫ w.natTrans
 
 /-- Whiskering a 2-square with a natural transformation at the bottom. -/
 @[simps!]
-protected def whiskerBottom {B' : C₃ ⥤ C₄} (α : B ⟶ B') (w : TwoSquare T L R B) :
+protected def whiskerBottom {B' : C₃ ⥤ C₄} (w : TwoSquare T L R B) (α : B ⟶ B') :
     TwoSquare T L R B' :=
-  w ≫ whiskerLeft L α
+  .mk _ _ _ _ <| w.natTrans ≫ whiskerLeft L α
 
 variable {C₅ : Type u₅} {C₆ : Type u₆} {C₇ : Type u₇} {C₈ : Type u₈}
   [Category.{v₅} C₅] [Category.{v₆} C₆] [Category.{v₇} C₇] [Category.{v₈} C₈]
@@ -115,8 +116,8 @@ variable {C₅ : Type u₅} {C₆ : Type u₆} {C₇ : Type u₇} {C₈ : Type u
 @[simps!]
 def hComp (w : TwoSquare T L R B) (w' : TwoSquare T' R R' B') :
     TwoSquare (T ⋙ T') L R' (B ⋙ B') :=
-  (Functor.associator _ _ _).hom ≫ (whiskerLeft T w') ≫
-  (Functor.associator _ _ _).inv ≫ (whiskerRight w B') ≫ (Functor.associator _ _ _).hom
+  .mk _ _ _ _ <| (Functor.associator _ _ _).hom ≫ (whiskerLeft T w'.natTrans) ≫
+    (Functor.associator _ _ _).inv ≫ (whiskerRight w.natTrans B') ≫ (Functor.associator _ _ _).hom
 
 /-- Notation for the horizontal composition of 2-squares. -/
 scoped infixr:80 " ≫ₕ " => hComp -- type as \gg\_h
@@ -125,8 +126,8 @@ scoped infixr:80 " ≫ₕ " => hComp -- type as \gg\_h
 @[simps!]
 def vComp (w : TwoSquare T L R B) (w' : TwoSquare B L' R'' B'') :
     TwoSquare T (L ⋙ L') (R ⋙ R'') B'' :=
-  (Functor.associator _ _ _).hom ≫ (whiskerRight w R'') ≫
-  (Functor.associator _ _ _).inv ≫ (whiskerLeft L w') ≫ (Functor.associator _ _ _).hom
+  .mk _ _ _ _ <| (Functor.associator _ _ _).hom ≫ (whiskerRight w.natTrans R'') ≫
+    (Functor.associator _ _ _).inv ≫ (whiskerLeft L w'.natTrans) ≫ (Functor.associator _ _ _).hom
 
 /-- Notation for the vertical composition of 2-squares. -/
 scoped infixr:80 " ≫ᵥ " => vComp -- type as \gg\_v
@@ -140,14 +141,13 @@ same result as composing vertically first. -/
 lemma hCompVCompHComp (w₁ : TwoSquare T L R B) (w₂ : TwoSquare T' R R' B')
     (w₃ : TwoSquare B L' R'' B'') (w₄ : TwoSquare B' R'' R₃ B₃) :
     (w₁ ≫ₕ w₂) ≫ᵥ (w₃ ≫ₕ w₄) = (w₁ ≫ᵥ w₃) ≫ₕ (w₂ ≫ᵥ w₄) := by
-  unfold hComp vComp
-  unfold whiskerLeft whiskerRight
+  unfold hComp vComp whiskerLeft whiskerRight
   ext c
   simp only [Functor.comp_obj, NatTrans.comp_app, Functor.associator_hom_app,
     Functor.associator_inv_app, comp_id, id_comp, Functor.map_comp, assoc]
   slice_rhs 2 3 =>
     rw [← Functor.comp_map _ B₃, ← w₄.naturality]
-  simp only [Functor.comp_obj, Functor.comp_map, assoc]
+  simp
 
 end Interchange
 

--- a/Mathlib/CategoryTheory/Functor/TwoSquare.lean
+++ b/Mathlib/CategoryTheory/Functor/TwoSquare.lean
@@ -55,6 +55,7 @@ lemma ext (w w' : TwoSquare T L R B) (h : ∀ (X : C₁), w.app X = w'.app X) :
   NatTrans.ext (funext h)
 
 /-- The hoizontal identity 2-square. -/
+@[simps!]
 def hId (L : C₁ ⥤ C₃) : TwoSquare (𝟭 _) L L (𝟭 _) :=
   𝟙 _
 
@@ -62,6 +63,7 @@ def hId (L : C₁ ⥤ C₃) : TwoSquare (𝟭 _) L L (𝟭 _) :=
 scoped notation "𝟙ₕ" => hId  -- type as \b1\_h
 
 /-- The vertical identity 2-square. -/
+@[simps!]
 def vId (T : C₁ ⥤ C₂) : TwoSquare T (𝟭 _) (𝟭 _) T :=
   𝟙 _
 
@@ -73,6 +75,7 @@ variable {C₅ : Type u₅} {C₆ : Type u₆} {C₇ : Type u₇} {C₈ : Type u
   {T' : C₂ ⥤ C₅} {R' : C₅ ⥤ C₆} {B' : C₄ ⥤ C₆} {L' : C₃ ⥤ C₇} {R'' : C₄ ⥤ C₈} {B'' : C₇ ⥤ C₈}
 
 /-- The horizontal composition of 2-squares. -/
+@[simps!]
 def hComp (w : TwoSquare T L R B) (w' : TwoSquare T' R R' B') :
     TwoSquare (T ⋙ T') L R' (B ⋙ B') :=
   (whiskerLeft T w') ≫ (whiskerRight w B')
@@ -81,6 +84,7 @@ def hComp (w : TwoSquare T L R B) (w' : TwoSquare T' R R' B') :
 scoped infixr:80 " ≫ₕ " => hComp -- type as \gg\_h
 
 /-- The vertical composition of 2-squares. -/
+@[simps!]
 def vComp (w : TwoSquare T L R B) (w' : TwoSquare B L' R'' B'') :
     TwoSquare T (L ⋙ L') (R ⋙ R'') B'' :=
   (whiskerRight w R'') ≫ (whiskerLeft L w')

--- a/Mathlib/CategoryTheory/Functor/TwoSquare.lean
+++ b/Mathlib/CategoryTheory/Functor/TwoSquare.lean
@@ -79,7 +79,8 @@ variable {C₅ : Type u₅} {C₆ : Type u₆} {C₇ : Type u₇} {C₈ : Type u
 @[simps!]
 def hComp (w : TwoSquare T L R B) (w' : TwoSquare T' R R' B') :
     TwoSquare (T ⋙ T') L R' (B ⋙ B') :=
-  (whiskerLeft T w') ≫ (whiskerRight w B')
+  (Functor.associator _ _ _).hom ≫ (whiskerLeft T w') ≫
+  (Functor.associator _ _ _).inv ≫ (whiskerRight w B') ≫ (Functor.associator _ _ _).hom
 
 /-- Notation for the horizontal composition of 2-squares. -/
 scoped infixr:80 " ≫ₕ " => hComp -- type as \gg\_h
@@ -88,7 +89,8 @@ scoped infixr:80 " ≫ₕ " => hComp -- type as \gg\_h
 @[simps!]
 def vComp (w : TwoSquare T L R B) (w' : TwoSquare B L' R'' B'') :
     TwoSquare T (L ⋙ L') (R ⋙ R'') B'' :=
-  (whiskerRight w R'') ≫ (whiskerLeft L w')
+  (Functor.associator _ _ _).hom ≫ (whiskerRight w R'') ≫
+  (Functor.associator _ _ _).inv ≫ (whiskerLeft L w') ≫ (Functor.associator _ _ _).hom
 
 /-- Notation for the vertical composition of 2-squares. -/
 scoped infixr:80 " ≫ᵥ " => vComp -- type as \gg\_v
@@ -105,7 +107,8 @@ lemma hCompVCompHComp (w₁ : TwoSquare T L R B) (w₂ : TwoSquare T' R R' B')
   unfold hComp vComp
   unfold whiskerLeft whiskerRight
   ext c
-  simp only [Functor.comp_obj, NatTrans.comp_app, Functor.map_comp, assoc]
+  simp only [Functor.comp_obj, NatTrans.comp_app, Functor.associator_hom_app,
+    Functor.associator_inv_app, comp_id, id_comp, Functor.map_comp, assoc]
   slice_rhs 2 3 =>
     rw [← Functor.comp_map _ B₃, ← w₄.naturality]
   simp only [Functor.comp_obj, Functor.comp_map, assoc]

--- a/Mathlib/CategoryTheory/Functor/TwoSquare.lean
+++ b/Mathlib/CategoryTheory/Functor/TwoSquare.lean
@@ -94,7 +94,7 @@ variable {C₉ : Type u₉} [Category.{v₉} C₉] {R₃ : C₆ ⥤ C₉} {B₃ 
 
 /-- When composing 2-squares which form a diagram of grid, compositing horionzall first yields the
 same result as composing vertically first. -/
-lemma hCompVComphComp (w₁ : TwoSquare T L R B) (w₂ : TwoSquare T' R R' B')
+lemma hCompVCompHComp (w₁ : TwoSquare T L R B) (w₂ : TwoSquare T' R R' B')
     (w₃ : TwoSquare B L' R'' B'') (w₄ : TwoSquare B' R'' R₃ B₃) :
     (w₁ ≫ₕ w₂) ≫ᵥ (w₃ ≫ₕ w₄) = (w₁ ≫ᵥ w₃) ≫ₕ (w₂ ≫ᵥ w₄) := by
   unfold hComp vComp

--- a/Mathlib/CategoryTheory/Functor/TwoSquare.lean
+++ b/Mathlib/CategoryTheory/Functor/TwoSquare.lean
@@ -50,8 +50,11 @@ namespace TwoSquare
 abbrev mk (α : T ⋙ R ⟶ L ⋙ B) : TwoSquare T L R B := α
 
 variable {T} {L} {R} {B} in
+/-- The natural transfomration associated to a 2-square. -/
 abbrev out (w : TwoSquare T L R B) : T ⋙ R ⟶ L ⋙ B := w
 
+/-- The type of 2-squares on functors `T`, `L`, `R`, and `B` is trivially equivalent to
+the type of natural transformations `T ⋙ R ⟶ L ⋙ B`. -/
 @[simps]
 def equivNatTrans : TwoSquare T L R B ≃ (T ⋙ R ⟶ L ⋙ B) where
   toFun := out

--- a/Mathlib/CategoryTheory/Functor/TwoSquare.lean
+++ b/Mathlib/CategoryTheory/Functor/TwoSquare.lean
@@ -1,0 +1,112 @@
+/-
+Copyright (c) 2025 Jakob von Raumer. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joël Riou, Jakob von Raumer
+-/
+import Mathlib.CategoryTheory.Equivalence
+/-!
+# 2-squares of functors
+
+Given four functors `T`, `L`, `R` and `B`, a 2-square `TwoSquare T L R B` consists of
+a natural transformation `w : T ⋙ R ⟶ L ⋙ B`:
+```
+     T
+  C₁ ⥤ C₂
+L |     | R
+  v     v
+  C₃ ⥤ C₄
+     B
+```
+
+We define operations to paste such squares horizontally and vertically and prove the interchange
+law of those two operations.
+
+## TODO
+
+Generalize all of this to double categories.
+
+-/
+
+universe v₁ v₂ v₃ v₄ v₅ v₆ v₇ v₈ v₉ u₁ u₂ u₃ u₄ u₅ u₆ u₇ u₈ u₉
+
+namespace CategoryTheory
+
+open Category
+
+variable {C₁ : Type u₁} {C₂ : Type u₂} {C₃ : Type u₃} {C₄ : Type u₄}
+  [Category.{v₁} C₁] [Category.{v₂} C₂] [Category.{v₃} C₃] [Category.{v₄} C₄]
+  (T : C₁ ⥤ C₂) (L : C₁ ⥤ C₃) (R : C₂ ⥤ C₄) (B : C₃ ⥤ C₄)
+
+/-- A `2`-square consists of a natural transformation `T ⋙ R ⟶ L ⋙ B`
+involving fours functors `T`, `L`, `R`, `B` that are on the
+top/left/right/bottom sides of a square of categories. -/
+def TwoSquare := T ⋙ R ⟶ L ⋙ B
+
+namespace TwoSquare
+
+/-- Constructor for `TwoSquare`. -/
+abbrev mk (α : T ⋙ R ⟶ L ⋙ B) : TwoSquare T L R B := α
+
+variable {T L R B}
+
+@[ext]
+lemma ext (w w' : TwoSquare T L R B) (h : ∀ (X : C₁), w.app X = w'.app X) :
+    w = w' :=
+  NatTrans.ext (funext h)
+
+/-- The hoizontal identity 2-square. -/
+def hId (L : C₁ ⥤ C₃) : TwoSquare (𝟭 _) L L (𝟭 _) :=
+  𝟙 _
+
+/-- Notation for the horizontal identity 2-square. -/
+scoped notation "𝟙ₕ" => hId  -- type as \b1\_h
+
+/-- The vertical identity 2-square. -/
+def vId (T : C₁ ⥤ C₂) : TwoSquare T (𝟭 _) (𝟭 _) T :=
+  𝟙 _
+
+/-- Notation for the vertical identity 2-square. -/
+scoped notation "𝟙ᵥ" => vId  -- type as \b1\_v
+
+variable {C₅ : Type u₅} {C₆ : Type u₆} {C₇ : Type u₇} {C₈ : Type u₈}
+  [Category.{v₅} C₅] [Category.{v₆} C₆] [Category.{v₇} C₇] [Category.{v₈} C₈]
+  {T' : C₂ ⥤ C₅} {R' : C₅ ⥤ C₆} {B' : C₄ ⥤ C₆} {L' : C₃ ⥤ C₇} {R'' : C₄ ⥤ C₈} {B'' : C₇ ⥤ C₈}
+
+/-- The horizontal composition of 2-squares. -/
+def hComp (w : TwoSquare T L R B) (w' : TwoSquare T' R R' B') :
+    TwoSquare (T ⋙ T') L R' (B ⋙ B') :=
+  (whiskerLeft T w') ≫ (whiskerRight w B')
+
+/-- Notation for the horizontal composition of 2-squares. -/
+scoped infixr:80 " ≫ₕ " => hComp -- type as \gg\_h
+
+/-- The vertical composition of 2-squares. -/
+def vComp (w : TwoSquare T L R B) (w' : TwoSquare B L' R'' B'') :
+    TwoSquare T (L ⋙ L') (R ⋙ R'') B'' :=
+  (whiskerRight w R'') ≫ (whiskerLeft L w')
+
+/-- Notation for the vertical composition of 2-squares. -/
+scoped infixr:80 " ≫ᵥ " => vComp -- type as \gg\_v
+
+section Interchange
+
+variable {C₉ : Type u₉} [Category.{v₉} C₉] {R₃ : C₆ ⥤ C₉} {B₃ : C₈ ⥤ C₉}
+
+/-- When composing 2-squares which form a diagram of grid, compositing horionzall first yields the
+same result as composing vertically first. -/
+lemma hCompVComphComp (w₁ : TwoSquare T L R B) (w₂ : TwoSquare T' R R' B')
+    (w₃ : TwoSquare B L' R'' B'') (w₄ : TwoSquare B' R'' R₃ B₃) :
+    (w₁ ≫ₕ w₂) ≫ᵥ (w₃ ≫ₕ w₄) = (w₁ ≫ᵥ w₃) ≫ₕ (w₂ ≫ᵥ w₄) := by
+  unfold hComp vComp
+  unfold whiskerLeft whiskerRight
+  ext c
+  simp only [Functor.comp_obj, NatTrans.comp_app, Functor.map_comp, assoc]
+  slice_rhs 2 3 =>
+    rw [← Functor.comp_map _ B₃, ← w₄.naturality]
+  simp only [Functor.comp_obj, Functor.comp_map, assoc]
+
+end Interchange
+
+end TwoSquare
+
+end CategoryTheory

--- a/Mathlib/CategoryTheory/Functor/TwoSquare.lean
+++ b/Mathlib/CategoryTheory/Functor/TwoSquare.lean
@@ -3,7 +3,9 @@ Copyright (c) 2025 Jakob von Raumer. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Joël Riou, Jakob von Raumer
 -/
-import Mathlib.CategoryTheory.Equivalence
+import Mathlib.CategoryTheory.Whiskering
+import Mathlib.Tactic.CategoryTheory.Slice
+
 /-!
 # 2-squares of functors
 
@@ -50,8 +52,7 @@ abbrev mk (α : T ⋙ R ⟶ L ⋙ B) : TwoSquare T L R B := α
 variable {T L R B}
 
 @[ext]
-lemma ext (w w' : TwoSquare T L R B) (h : ∀ (X : C₁), w.app X = w'.app X) :
-    w = w' :=
+lemma ext (w w' : TwoSquare T L R B) (h : ∀ (X : C₁), w.app X = w'.app X) : w = w' :=
   NatTrans.ext (funext h)
 
 /-- The hoizontal identity 2-square. -/

--- a/Mathlib/CategoryTheory/GuitartExact/Basic.lean
+++ b/Mathlib/CategoryTheory/GuitartExact/Basic.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Joël Riou
 -/
 import Mathlib.CategoryTheory.Limits.Final
+import Mathlib.CategoryTheory.Functor.TwoSquare
 
 /-!
 # Guitart exact squares
@@ -55,24 +56,9 @@ variable {C₁ : Type u₁} {C₂ : Type u₂} {C₃ : Type u₃} {C₄ : Type u
   [Category.{v₁} C₁] [Category.{v₂} C₂] [Category.{v₃} C₃] [Category.{v₄} C₄]
   (T : C₁ ⥤ C₂) (L : C₁ ⥤ C₃) (R : C₂ ⥤ C₄) (B : C₃ ⥤ C₄)
 
-/-- A `2`-square consists of a natural transformation `T ⋙ R ⟶ L ⋙ B`
-involving fours functors `T`, `L`, `R`, `B` that are on the
-top/left/right/bottom sides of a square of categories. -/
-def TwoSquare := T ⋙ R ⟶ L ⋙ B
-
 namespace TwoSquare
 
-/-- Constructor for `TwoSquare`. -/
-abbrev mk (α : T ⋙ R ⟶ L ⋙ B) : TwoSquare T L R B := α
-
-variable {T L R B}
-
-@[ext]
-lemma ext (w w' : TwoSquare T L R B) (h : ∀ (X : C₁), w.app X = w'.app X) :
-    w = w' :=
-  NatTrans.ext (funext h)
-
-variable (w : TwoSquare T L R B)
+variable {T L R B} (w : TwoSquare T L R B)
 
 /-- Given `w : TwoSquare T L R B` and `X₃ : C₃`, this is the obvious functor
 `CostructuredArrow L X₃ ⥤ CostructuredArrow R (B.obj X₃)`. -/

--- a/Mathlib/CategoryTheory/GuitartExact/VerticalComposition.lean
+++ b/Mathlib/CategoryTheory/GuitartExact/VerticalComposition.lean
@@ -84,18 +84,12 @@ variable {H₁ : C₁ ⥤ D₁} {L₁ : C₁ ⥤ C₂} {R₁ : D₁ ⥤ D₂} {H
   {L₂ : C₂ ⥤ C₃} {R₂ : D₂ ⥤ D₃} {H₃ : C₃ ⥤ D₃}
   (w' : TwoSquare H₂ L₂ R₂ H₃)
 
-/-- The vertical composition of 2-squares. -/
-@[simps!]
-def vComp : TwoSquare H₁ (L₁ ⋙ L₂) (R₁ ⋙ R₂) H₃ :=
-  (Functor.associator _ _ _).inv ≫ whiskerRight w R₂ ≫
-    (Functor.associator _ _ _).hom ≫ whiskerLeft L₁ w' ≫ (Functor.associator _ _ _).inv
-
 /-- The canonical isomorphism between
 `w.structuredArrowDownwards Y₁ ⋙ w'.structuredArrowDownwards (R₁.obj Y₁)` and
 `(w.vComp w').structuredArrowDownwards Y₁.` -/
 def structuredArrowDownwardsComp (Y₁ : D₁) :
     w.structuredArrowDownwards Y₁ ⋙ w'.structuredArrowDownwards (R₁.obj Y₁) ≅
-      (w.vComp w').structuredArrowDownwards Y₁ :=
+      (w ≫ᵥ w').structuredArrowDownwards Y₁ :=
   NatIso.ofComponents (fun _ => StructuredArrow.isoMk (Iso.refl _))
 
 /-- The vertical composition of 2-squares. (Variant where we allow the replacement of
@@ -122,7 +116,7 @@ instance vComp' [GuitartExact w] [GuitartExact w'] {L₁₂ : C₁ ⥤ C₃}
 
 lemma vComp_iff_of_equivalences (eL : C₂ ≌ C₃) (eR : D₂ ≌ D₃)
     (w' : H₂ ⋙ eR.functor ≅ eL.functor ⋙ H₃) :
-    (w.vComp w'.hom).GuitartExact ↔ w.GuitartExact := by
+    (w ≫ᵥ w'.hom).GuitartExact ↔ w.GuitartExact := by
   constructor
   · intro hww'
     letI : CatCommSq H₂ eL.functor eR.functor H₃ := ⟨w'⟩
@@ -133,7 +127,7 @@ lemma vComp_iff_of_equivalences (eL : C₂ ≌ C₃) (eR : D₂ ≌ D₃)
       Functor.associator _ _ _ ≪≫ isoWhiskerLeft L₁ eL.unitIso.symm ≪≫ L₁.rightUnitor
     let β : (R₁ ⋙ eR.functor) ⋙ eR.inverse ≅ R₁ :=
       Functor.associator _ _ _ ≪≫ isoWhiskerLeft R₁ eR.unitIso.symm ≪≫ R₁.rightUnitor
-    have : w = (w.vComp w'.hom).vComp' w''.hom α β := by
+    have : w = (w ≫ᵥ w'.hom).vComp' w''.hom α β := by
       ext X₁
       dsimp
       simp? [w'', β, α] says

--- a/Mathlib/CategoryTheory/GuitartExact/VerticalComposition.lean
+++ b/Mathlib/CategoryTheory/GuitartExact/VerticalComposition.lean
@@ -33,7 +33,7 @@ provide natural transformations `α : L ⟶ L'` and `β : R' ⟶ R`. -/
 @[simps!]
 def whiskerVertical (α : L ⟶ L') (β : R' ⟶ R) :
     TwoSquare T L' R' B :=
-  whiskerLeft _ β ≫ w ≫ whiskerRight α _
+  (w.whiskerLeft α).whiskerRight β
 
 namespace GuitartExact
 
@@ -59,8 +59,7 @@ lemma whiskerVertical_iff (α : L ≅ L') (β : R ≅ R') :
     (w.whiskerVertical α.hom β.inv).GuitartExact ↔ w.GuitartExact := by
   constructor
   · intro h
-    have : w = TwoSquare.whiskerVertical
-        (TwoSquare.whiskerVertical w α.hom β.inv) α.inv β.hom := by
+    have : w = (w.whiskerVertical α.hom β.inv).whiskerVertical α.inv β.hom := by
       ext X₁
       simp only [Functor.comp_obj, whiskerVertical_app, assoc, Iso.hom_inv_id_app_assoc,
         ← B.map_comp, Iso.hom_inv_id_app, B.map_id, comp_id]
@@ -86,7 +85,7 @@ variable {H₁ : C₁ ⥤ D₁} {L₁ : C₁ ⥤ C₂} {R₁ : D₁ ⥤ D₂} {H
 
 /-- The canonical isomorphism between
 `w.structuredArrowDownwards Y₁ ⋙ w'.structuredArrowDownwards (R₁.obj Y₁)` and
-`(w.vComp w').structuredArrowDownwards Y₁.` -/
+`(w ≫ᵥ w').structuredArrowDownwards Y₁.` -/
 def structuredArrowDownwardsComp (Y₁ : D₁) :
     w.structuredArrowDownwards Y₁ ⋙ w'.structuredArrowDownwards (R₁.obj Y₁) ≅
       (w ≫ᵥ w').structuredArrowDownwards Y₁ :=
@@ -97,12 +96,12 @@ the vertical compositions by isomorphic functors.) -/
 @[simps!]
 def vComp' {L₁₂ : C₁ ⥤ C₃} {R₁₂ : D₁ ⥤ D₃} (eL : L₁ ⋙ L₂ ≅ L₁₂)
     (eR : R₁ ⋙ R₂ ≅ R₁₂) : TwoSquare H₁ L₁₂ R₁₂ H₃ :=
-  (w.vComp w').whiskerVertical eL.hom eR.inv
+  (w ≫ᵥ w').whiskerVertical eL.hom eR.inv
 
 namespace GuitartExact
 
 instance vComp [hw : w.GuitartExact] [hw' : w'.GuitartExact] :
-    (w.vComp w').GuitartExact := by
+    (w ≫ᵥ w').GuitartExact := by
   simp only [TwoSquare.guitartExact_iff_initial]
   intro Y₁
   rw [← Functor.initial_natIso_iff (structuredArrowDownwardsComp w w' Y₁)]

--- a/Mathlib/CategoryTheory/GuitartExact/VerticalComposition.lean
+++ b/Mathlib/CategoryTheory/GuitartExact/VerticalComposition.lean
@@ -130,15 +130,14 @@ lemma vComp_iff_of_equivalences (eL : C₂ ≌ C₃) (eR : D₂ ≌ D₃)
     have : w = (w ≫ᵥ w'.hom).vComp' w''.hom α β := by
       ext X₁
       dsimp
-      simp? [w'', β, α] says
-        simp only [vComp'_app, Functor.comp_obj, Iso.trans_inv, isoWhiskerLeft_inv, Iso.symm_inv,
-          assoc, NatTrans.comp_app, Functor.id_obj, Functor.rightUnitor_inv_app, whiskerLeft_app,
-          Functor.associator_inv_app, comp_id, id_comp, vComp_app, Functor.map_comp,
-          Equivalence.inv_fun_map, Iso.trans_hom, isoWhiskerLeft_hom, Iso.symm_hom,
-          Functor.associator_hom_app, Functor.rightUnitor_hom_app, Iso.hom_inv_id_app_assoc,
-          w'', α, β]
+      simp? [w'', α, β] says simp only [vComp'_app, Functor.comp_obj, Iso.trans_inv,
+        isoWhiskerLeft_inv, Iso.symm_inv, assoc, NatTrans.comp_app, Functor.id_obj,
+        Functor.rightUnitor_inv_app, Functor.associator_inv_app, comp_id, id_comp, vComp_app,
+        Functor.map_comp, Equivalence.inv_fun_map, Iso.trans_hom, isoWhiskerLeft_hom, Iso.symm_hom,
+        Functor.associator_hom_app, Functor.rightUnitor_hom_app, w'', α, β]
       erw [CatCommSq.vInv_iso'_hom_app]
-      simp only [hw', assoc, ← eR.inverse.map_comp_assoc]
+      simp only [CategoryTheory.whiskerLeft_app, Iso.hom_inv_id_app_assoc,
+        hw', assoc, ← eR.inverse.map_comp_assoc]
       rw [Equivalence.counitInv_app_functor]
       erw [← NatTrans.naturality_assoc]
       simp [← H₂.map_comp]

--- a/Mathlib/CategoryTheory/GuitartExact/VerticalComposition.lean
+++ b/Mathlib/CategoryTheory/GuitartExact/VerticalComposition.lean
@@ -130,11 +130,13 @@ lemma vComp_iff_of_equivalences (eL : C₂ ≌ C₃) (eR : D₂ ≌ D₃)
     have : w = (w ≫ᵥ w'.hom).vComp' w''.hom α β := by
       ext X₁
       dsimp
-      simp? [w'', α, β] says simp only [vComp'_app, Functor.comp_obj, Iso.trans_inv,
-        isoWhiskerLeft_inv, Iso.symm_inv, assoc, NatTrans.comp_app, Functor.id_obj,
-        Functor.rightUnitor_inv_app, Functor.associator_inv_app, comp_id, id_comp, vComp_app,
-        Functor.map_comp, Equivalence.inv_fun_map, Iso.trans_hom, isoWhiskerLeft_hom, Iso.symm_hom,
-        Functor.associator_hom_app, Functor.rightUnitor_hom_app, w'', α, β]
+      simp? [w'', α, β] says
+        simp only [vComp'_app, Functor.comp_obj, Iso.trans_inv, isoWhiskerLeft_inv, Iso.symm_inv,
+          assoc, NatTrans.comp_app, Functor.id_obj, Functor.rightUnitor_inv_app,
+          CategoryTheory.whiskerLeft_app, Functor.associator_inv_app, comp_id, id_comp, vComp_app,
+          Functor.map_comp, Equivalence.inv_fun_map, Iso.trans_hom, isoWhiskerLeft_hom,
+          Iso.symm_hom, Functor.associator_hom_app, Functor.rightUnitor_hom_app,
+          Iso.hom_inv_id_app_assoc, w'', α, β]
       erw [CatCommSq.vInv_iso'_hom_app]
       simp only [CategoryTheory.whiskerLeft_app, Iso.hom_inv_id_app_assoc,
         hw', assoc, ← eR.inverse.map_comp_assoc]


### PR DESCRIPTION
Adds a type `TwoSquare T L B R` of natural transformation across the diagonal of a commutative square of functors, including operations for whiskering on the sides of the square and for pasting squares vertically and horizontally. We use this type to refactor the notion of Guitart exactness and of adjoint mates.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
