### PR TITLE
feat: register `trivial` for `hint`

### DIFF
--- a/Mathlib/Tactic/Common.lean
+++ b/Mathlib/Tactic/Common.lean
@@ -128,11 +128,12 @@ import hierarchy.
 -/
 
 /-!
-# Register tactics with `hint`.
+# Register tactics with `hint`. Tactics are tried in reverse registration order.
 -/
 
 section Hint
 
+register_hint trivial
 register_hint split
 register_hint intro
 register_hint aesop


### PR DESCRIPTION
Example:

```
import Mathlib

register_hint trivial

example (m : Nat) (h : m ≠ 1) : True ∧ m ≠ 1 ∧ ∀ n < 100, n^2 < 10000 := by hint
```

---

- [ ] depends on: #22063 

I know it doesn't strictly depend on that PR, but it will acquire a merge conflict when that PR is merged, so I'm avoiding making a `bors` batch fail.