### PR TITLE
[Merged by Bors] - feat: Prove r_zpow

### DIFF
--- a/Mathlib/GroupTheory/SpecificGroups/Dihedral.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/Dihedral.lean
@@ -112,9 +112,7 @@ theorem r_pow (i : ZMod n) (k : ℕ) : (r i)^k = r (i * k : ZMod n) := by
   induction k with
   | zero => simp only [pow_zero, Nat.cast_zero, mul_zero, r_zero]
   | succ k IH =>
-  rw [show (r i)^(k+1) = (r i)^k * (r i) by rfl, IH]
-  simp only [r_mul_r, Nat.cast_add, Nat.cast_one, r.injEq]
-  ring
+    rw [pow_add, pow_one, IH, r_mul_r, Nat.cast_add, Nat.cast_one, r.injEq, mul_add, mul_one]
 
 @[simp]
 theorem r_zpow (i : ZMod n) (k : ℤ) : (r i)^k = r (i * k : ZMod n) := by

--- a/Mathlib/GroupTheory/SpecificGroups/Dihedral.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/Dihedral.lean
@@ -107,6 +107,22 @@ theorem r_zero : r 0 = (1 : DihedralGroup n) :=
 theorem one_def : (1 : DihedralGroup n) = r 0 :=
   rfl
 
+@[simp]
+theorem r_pow (i : ZMod n) (k : ℕ) : (r i)^k = r (i * k : ZMod n) := by
+  induction k with
+  | zero => simp only [pow_zero, Nat.cast_zero, mul_zero, r_zero]
+  | succ k IH =>
+  rw [show (r i)^(k+1) = (r i)^k * (r i) by rfl, IH]
+  simp only [r_mul_r, Nat.cast_add, Nat.cast_one, r.injEq]
+  ring
+
+@[simp]
+theorem r_zpow (i : ZMod n) (k : ℤ) : (r i)^k = r (i * k : ZMod n) := by
+  cases k
+  · simp [r_pow]
+  · simp [r_pow]
+    ring
+
 private def fintypeHelper : (ZMod n) ⊕ (ZMod n) ≃ DihedralGroup n where
   invFun
     | r j => .inl j
@@ -140,13 +156,7 @@ theorem nat_card : Nat.card (DihedralGroup n) = 2 * n := by
 
 @[simp]
 theorem r_one_pow (k : ℕ) : (r 1 : DihedralGroup n) ^ k = r k := by
-  induction' k with k IH
-  · rw [Nat.cast_zero]
-    rfl
-  · rw [pow_succ', IH, r_mul_r]
-    congr 1
-    norm_cast
-    rw [Nat.one_add]
+  simp [r_pow (1 : ZMod n) k]
 
 @[simp]
 theorem r_one_zpow (k : ℤ) : (r 1 : DihedralGroup n) ^ k = r k := by

--- a/Mathlib/GroupTheory/SpecificGroups/Dihedral.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/Dihedral.lean
@@ -154,13 +154,11 @@ theorem nat_card : Nat.card (DihedralGroup n) = 2 * n := by
   · rw [Nat.card_eq_zero_of_infinite]
   · rw [Nat.card_eq_fintype_card, card]
 
-@[simp]
 theorem r_one_pow (k : ℕ) : (r 1 : DihedralGroup n) ^ k = r k := by
-  simp [r_pow (1 : ZMod n) k]
+  simp only [r_pow, one_mul]
 
-@[simp]
 theorem r_one_zpow (k : ℤ) : (r 1 : DihedralGroup n) ^ k = r k := by
-  cases k <;> simp
+  simp only [r_zpow, one_mul]
 
 theorem r_one_pow_n : r (1 : ZMod n) ^ n = 1 := by
   simp

--- a/Mathlib/GroupTheory/SpecificGroups/Dihedral.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/Dihedral.lean
@@ -118,10 +118,7 @@ theorem r_pow (i : ZMod n) (k : ℕ) : (r i)^k = r (i * k : ZMod n) := by
 
 @[simp]
 theorem r_zpow (i : ZMod n) (k : ℤ) : (r i)^k = r (i * k : ZMod n) := by
-  cases k
-  · simp [r_pow]
-  · simp [r_pow]
-    ring
+  cases k <;> simp [r_pow, neg_mul_eq_mul_neg]
 
 private def fintypeHelper : (ZMod n) ⊕ (ZMod n) ≃ DihedralGroup n where
   invFun


### PR DESCRIPTION
Prove formulas for `(r i)^k` in a dihedral group, as requested [here](https://github.com/leanprover-community/mathlib4/pull/20338#discussion_r1899657779)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
