### PR TITLE
[Merged by Bors] - refactor(CategoryTheory/ConcreteCategory): concreteify `NatTrans.naturality_apply`

### DIFF
--- a/Mathlib/Algebra/Category/ModuleCat/Presheaf/Free.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Presheaf/Free.lean
@@ -57,6 +57,7 @@ variable {R}
 
 variable {F : Cᵒᵖ ⥤ Type u} {G : PresheafOfModules.{u} R}
 
+attribute [local instance] Types.instFunLike Types.instConcreteCategory in
 /-- The morphism of presheaves of modules `freeObj F ⟶ G` corresponding to
 a morphism `F ⟶ G.presheaf ⋙ forget _` of presheaves of types. -/
 @[simps]

--- a/Mathlib/Algebra/Category/ModuleCat/Presheaf/Sheafify.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Presheaf/Sheafify.lean
@@ -65,9 +65,7 @@ lemma _root_.PresheafOfModules.Sheafify.app_eq_of_isLocallyInjective
     · exact Presheaf.equalizerSieve_mem J α _ _ hr₀
     · exact Presheaf.equalizerSieve_mem J φ _ _ hm₀
   · intro Z g hg
-    -- Manually apply `elementwise_of%` to generate ConcreteCategory lemmas.
-    rw [← elementwise_of% NatTrans.naturality (D := Ab),
-      ← elementwise_of% NatTrans.naturality (D := Ab)]
+    rw [← NatTrans.naturality_apply (D := Ab), ← NatTrans.naturality_apply (D := Ab)]
     erw [M₀.map_smul, M₀.map_smul, hg.1, hg.2]
     rfl
 
@@ -82,8 +80,7 @@ lemma isCompatible_map_smul_aux {Y Z : C} (f : Y ⟶ X) (g : Z ⟶ Y)
   · rw [hr₀', R.map_comp, RingCat.comp_apply, ← hr₀, ← RingCat.comp_apply, NatTrans.naturality,
       RingCat.comp_apply]
   · rw [hm₀', A.map_comp, AddCommGrp.coe_comp, Function.comp_apply, ← hm₀]
-    -- Manually apply `elementwise_of%` to generate ConcreteCategory lemmas.
-    erw [elementwise_of% NatTrans.naturality φ]
+    erw [NatTrans.naturality_apply φ]
 
 variable (hr₀ : (r₀.map (whiskerRight α (forget _))).IsAmalgamation r)
   (hm₀ : (m₀.map (whiskerRight φ (forget _))).IsAmalgamation m)
@@ -107,8 +104,7 @@ lemma isCompatible_map_smul : ((r₀.smul m₀).map (whiskerRight φ (forget _))
       RingCat.comp_apply]
   have hb₀ : (φ.app (Opposite.op Z)) b₀ = (A.map (f₁.op ≫ g₁.op)) m := by
     dsimp [b₀]
-    -- Manually apply `elementwise_of%` to generate ConcreteCategory lemmas.
-    erw [elementwise_of% NatTrans.naturality φ, hb₁, Functor.map_comp, ConcreteCategory.comp_apply]
+    erw [NatTrans.naturality_apply φ, hb₁, Functor.map_comp, ConcreteCategory.comp_apply]
   have ha₀' : (α.app (Opposite.op Z)) a₀ = (R.map (f₂.op ≫ g₂.op)) r := by
     rw [ha₀, ← op_comp, fac, op_comp]
   have hb₀' : (φ.app (Opposite.op Z)) b₀ = (A.map (f₂.op ≫ g₂.op)) m := by
@@ -163,8 +159,7 @@ def SMulCandidate.mk' (S : Sieve X.unop) (hS : S ∈ J X.unop)
     apply A.isSeparated _ _ (J.pullback_stable f.unop hS)
     rintro Z g hg
     dsimp at hg
-    rw [← ConcreteCategory.comp_apply, ← A.val.map_comp,
-      ← elementwise_of% NatTrans.naturality (D := Ab)]
+    rw [← ConcreteCategory.comp_apply, ← A.val.map_comp, ← NatTrans.naturality_apply (D := Ab)]
     erw [M₀.map_smul] -- Mismatch between `M₀.map` and `M₀.presheaf.map`
     refine (ha _ hg).trans (app_eq_of_isLocallyInjective α φ A.isSeparated _ _ _ _ ?_ ?_)
     · rw [← RingCat.comp_apply, NatTrans.naturality, RingCat.comp_apply, ha₀]

--- a/Mathlib/CategoryTheory/ConcreteCategory/Basic.lean
+++ b/Mathlib/CategoryTheory/ConcreteCategory/Basic.lean
@@ -232,12 +232,6 @@ def hasForgetToType (C : Type u) [Category.{v} C] [HasForget.{w} C] :
   forget₂ := forget C
   forget_comp := Functor.comp_id _
 
-@[simp]
-lemma NatTrans.naturality_apply {C D : Type*} [Category C] [Category D] [HasForget D]
-    {F G : C ⥤ D} (φ : F ⟶ G) {X Y : C} (f : X ⟶ Y) (x : F.obj X) :
-    φ.app Y (F.map f x) = G.map f (φ.app X x) := by
-  simpa only [Functor.map_comp] using congr_fun ((forget D).congr_map (φ.naturality f)) x
-
 section ConcreteCategory
 
 /-- A concrete category is a category `C` where objects correspond to types and morphisms to
@@ -374,6 +368,13 @@ lemma ConcreteCategory.forget₂_comp_apply {C : Type u} {D : Type u'} [Category
 instance hom_isIso {X Y : C} (f : X ⟶ Y) [IsIso f] :
     IsIso (C := Type _) ⇑(ConcreteCategory.hom f) :=
   ((forget C).mapIso (asIso f)).isIso_hom
+
+@[simp]
+lemma NatTrans.naturality_apply {C D : Type*} [Category C] [Category D] {FD : D → D → Type*}
+    {CD : D → Type*} [∀ X Y, FunLike (FD X Y) (CD X) (CD Y)] [ConcreteCategory D FD]
+    {F G : C ⥤ D} (φ : F ⟶ G) {X Y : C} (f : X ⟶ Y) (x : ToType (F.obj X)) :
+    φ.app Y (F.map f x) = G.map f (φ.app X x) := by
+  simpa only [Functor.map_comp] using congr_fun ((forget D).congr_map (φ.naturality f)) x
 
 section
 

--- a/Mathlib/CategoryTheory/Sites/Coherent/LocallySurjective.lean
+++ b/Mathlib/CategoryTheory/Sites/Coherent/LocallySurjective.lean
@@ -77,9 +77,7 @@ lemma extensiveTopology.surjective_of_isLocallySurjective_sheaf_of_types [Finita
     Functor.mapCone_pt, Cone.whisker_pt, Cocone.op_pt, Cofan.mk_pt, Functor.const_obj_obj,
     Functor.mapCone_π_app, Cone.whisker_π, Cocone.op_π, whiskerLeft_app, NatTrans.op_app,
     Cofan.mk_ι_app]
-  have : f.app ⟨Y a⟩ (y a) = G.map (π a).op x := (h' a).choose_spec
-  change _ = G.map (π a).op x
-  rw [← this]
+  rw [← (h' a).choose_spec]
   erw [← NatTrans.naturality_apply (φ := f)]
   change f.app _ ((i.hom ≫ F.map (π a).op) y) = _
   erw [IsLimit.map_π]
@@ -130,11 +128,7 @@ lemma regularTopology.isLocallySurjective_sheaf_of_types [Preregular C] [Finitar
     simp only [Functor.comp_obj, Functor.op_obj, Discrete.functor_obj, Functor.mapCone_pt,
       Cocone.op_pt, Cofan.mk_pt, Functor.const_obj_obj, Functor.mapCone_π_app, Cocone.op_π,
       NatTrans.op_app, Cofan.mk_ι_app, Functor.mapIso_symm, Iso.symm_hom, Iso.trans_hom,
-      Functor.mapIso_inv, types_comp_apply, i']
-    -- Work around a `ConcreteCategory`/`HasForget` mismatch:
-    -- (the `simp only` used to be part of the `simp` above)
-    show G.map _ (f.app _ _) = _
-    simp only [← elementwise_of% NatTrans.naturality f (Sigma.ι Z a).op]
+      Functor.mapIso_inv, types_comp_apply, i', ← NatTrans.naturality_apply f (Sigma.ι Z a).op]
     have : f.app ⟨Z a⟩ (x a) = G.map (π a).op y := (h' a).choose_spec
     convert this
     · change F.map _ (F.map _ _) = _

--- a/Mathlib/CategoryTheory/Sites/LocallyInjective.lean
+++ b/Mathlib/CategoryTheory/Sites/LocallyInjective.lean
@@ -80,9 +80,7 @@ lemma isLocallyInjective_of_injective (hφ : ∀ (X : Cᵒᵖ), Function.Injecti
     ext Y f
     simp only [equalizerSieve_apply, op_unop, Sieve.top_apply, iff_true]
     apply hφ
-    -- Invoke `elementwise_of%` manually to get a `ConcreteCategory`-based result, instead of the
-    -- `HasForget`-based result.
-    simp [h, elementwise_of% NatTrans.naturality (D := D)]
+    simp [h]
 
 instance [IsIso φ] : IsLocallyInjective J φ :=
   isLocallyInjective_of_injective J φ (fun X => Function.Bijective.injective (by
@@ -118,10 +116,7 @@ lemma isLocallyInjective_iff_equalizerSieve_mem_imp :
     · intro Y f hf
       refine J.superset_covering (Sieve.le_pullback_bind S.1 T _ hf)
         (equalizerSieve_mem J φ _ _ ?_)
-      -- Invoke `elementwise_of%` manually to get a `ConcreteCategory`-based result, instead of the
-      -- `HasForget`-based result.
-      rw [elementwise_of% NatTrans.naturality (D := D),
-        elementwise_of% NatTrans.naturality (D := D)]
+      rw [NatTrans.naturality_apply, NatTrans.naturality_apply]
       exact hf
   · intro hφ
     exact ⟨fun {X} x y h => hφ x y (by simp [h])⟩

--- a/Mathlib/CategoryTheory/Sites/LocallySurjective.lean
+++ b/Mathlib/CategoryTheory/Sites/LocallySurjective.lean
@@ -46,7 +46,7 @@ def imageSieve {F G : Cᵒᵖ ⥤ A} (f : F ⟶ G) {U : C} (s : ToType (G.obj (o
   downward_closed := by
     rintro V W i ⟨t, ht⟩ j
     refine ⟨F.map j.op t, ?_⟩
-    rw [op_comp, G.map_comp, ConcreteCategory.comp_apply, ← ht, elementwise_of% f.naturality]
+    rw [op_comp, G.map_comp, ConcreteCategory.comp_apply, ← ht, NatTrans.naturality_apply f]
 
 theorem imageSieve_eq_sieveOfSection {F G : Cᵒᵖ ⥤ A} (f : F ⟶ G) {U : C}
     (s : ToType (G.obj (op U))) :
@@ -62,8 +62,7 @@ theorem imageSieve_app {F G : Cᵒᵖ ⥤ A} (f : F ⟶ G) {U : C} (s : ToType (
     imageSieve f (f.app _ s) = ⊤ := by
   ext V i
   simp only [Sieve.top_apply, iff_true, imageSieve_apply]
-  have := elementwise_of% (f.naturality i.op)
-  exact ⟨F.map i.op s, this s⟩
+  exact ⟨F.map i.op s, NatTrans.naturality_apply f i.op s⟩
 
 /-- If a morphism `g : V ⟶ U.unop` belongs to the sieve `imageSieve f s g`, then
 this is choice of a preimage of `G.map g.op s` in `F.obj (op V)`, see
@@ -142,7 +141,7 @@ instance isLocallySurjective_comp {F₁ F₂ F₃ : Cᵒᵖ ⥤ A} (f₁ : F₁ 
       rintro V i ⟨W, i, j, H, ⟨t', ht'⟩, rfl⟩
       refine ⟨t', ?_⟩
       rw [op_comp, F₃.map_comp, NatTrans.comp_app, ConcreteCategory.comp_apply,
-        ConcreteCategory.comp_apply, ht', elementwise_of% f₂.naturality, H.choose_spec]
+        ConcreteCategory.comp_apply, ht', NatTrans.naturality_apply, H.choose_spec]
     apply J.superset_covering this
     apply J.bind_covering
     · apply imageSieve_mem
@@ -199,17 +198,13 @@ lemma isLocallyInjective_of_isLocallyInjective_of_isLocallySurjective
       equalizerSieve (localPreimage f₁ x₁ f hf.1) (localPreimage f₁ x₂ f hf.2)
     refine J.superset_covering ?_ (J.transitive hS (Sieve.bind S.1 T) ?_)
     · rintro Y f ⟨Z, a, g, hg, ha, rfl⟩
-      -- Manually invoke `elementwise_of%` to obtain a `ConcreteCategory result
-      simpa [elementwise_of% NatTrans.naturality (D := A)] using congr_arg (f₁.app _) ha
+      simpa using congr_arg (f₁.app _) ha
     · intro Y f hf
       apply J.superset_covering (Sieve.le_pullback_bind _ _ _ hf)
       apply equalizerSieve_mem J (f₁ ≫ f₂)
       dsimp
       rw [ConcreteCategory.comp_apply, ConcreteCategory.comp_apply, app_localPreimage,
-        app_localPreimage,
-        -- Manually invoke `elementwise_of%` to obtain a `ConcreteCategory result
-        elementwise_of% NatTrans.naturality (D := A), elementwise_of% NatTrans.naturality (D := A),
-        h]
+        app_localPreimage, NatTrans.naturality_apply, NatTrans.naturality_apply, h]
 
 lemma isLocallyInjective_of_isLocallyInjective_of_isLocallySurjective_fac
     {F₁ F₂ F₃ : Cᵒᵖ ⥤ A} {f₁ : F₁ ⟶ F₂} {f₂ : F₂ ⟶ F₃} (f₃ : F₁ ⟶ F₃) (fac : f₁ ≫ f₂ = f₃)
@@ -229,13 +224,11 @@ lemma isLocallySurjective_of_isLocallySurjective_of_isLocallyInjective
     refine J.superset_covering ?_ (J.transitive (imageSieve_mem J (f₁ ≫ f₂) (f₂.app _ x))
       (Sieve.bind S.1 T) ?_)
     · rintro Y _ ⟨Z, a, g, hg, ha, rfl⟩
-      exact ⟨F₁.map a.op (localPreimage (f₁ ≫ f₂) _ _ hg), by
-        -- Manually invoke `elementwise_of%` to obtain a `ConcreteCategory result
-        simpa [elementwise_of% NatTrans.naturality (D := A)] using ha⟩
+      exact ⟨F₁.map a.op (localPreimage (f₁ ≫ f₂) _ _ hg), by simpa using ha⟩
     · intro Y f hf
       apply J.superset_covering (Sieve.le_pullback_bind _ _ _ hf)
       apply equalizerSieve_mem J f₂
-      rw [elementwise_of% NatTrans.naturality (D := A), ← app_localPreimage (f₁ ≫ f₂) _ _ hf,
+      rw [NatTrans.naturality_apply, ← app_localPreimage (f₁ ≫ f₂) _ _ hf,
         NatTrans.comp_app, ConcreteCategory.comp_apply]
 
 lemma isLocallySurjective_of_isLocallySurjective_of_isLocallyInjective_fac

--- a/Mathlib/CategoryTheory/Sites/PreservesLocallyBijective.lean
+++ b/Mathlib/CategoryTheory/Sites/PreservesLocallyBijective.lean
@@ -46,10 +46,7 @@ lemma isLocallyInjective_of_whisker (hH : CoverPreserving J K H)
     · intro W q hq
       simpa using hq
     · simp only [comp_obj, op_obj, whiskerLeft_app, Opposite.op_unop]
-      rw [
-        -- Manually insert `elementwise_of%` to generate a `ConcreteCategory` lemma
-        elementwise_of% NatTrans.naturality (D := A), elementwise_of% NatTrans.naturality (D := A),
-        h]
+      rw [NatTrans.naturality_apply, NatTrans.naturality_apply, h]
 
 lemma isLocallyInjective_whisker_iff (hH : CoverPreserving J K H) [H.IsCocontinuous J K]
     [H.IsCoverDense K] : IsLocallyInjective J (whiskerLeft H.op f) ↔ IsLocallyInjective K f :=

--- a/Mathlib/Condensed/Basic.lean
+++ b/Mathlib/Condensed/Basic.lean
@@ -73,6 +73,7 @@ end Condensed
 
 namespace CondensedSet
 
+attribute [local instance] Types.instFunLike Types.instConcreteCategory in
 -- Note: `simp` can prove this when stated for `Condensed C` for a concrete category `C`.
 -- However, it doesn't seem to see through the abbreviation `CondensedSet`
 @[simp]

--- a/Mathlib/Condensed/Light/Basic.lean
+++ b/Mathlib/Condensed/Light/Basic.lean
@@ -57,6 +57,7 @@ end LightCondensed
 
 namespace LightCondSet
 
+attribute [local instance] Types.instFunLike Types.instConcreteCategory in
 -- Note: `simp` can prove this when stated for `LightCondensed C` for a concrete category `C`.
 -- However, it doesn't seem to see through the abbreviation `LightCondSet`
 @[simp]

--- a/Mathlib/Condensed/Light/Module.lean
+++ b/Mathlib/Condensed/Light/Module.lean
@@ -65,9 +65,6 @@ noncomputable example : Abelian LightCondAb := inferInstance
 
 namespace LightCondMod
 
--- Note: `simp` can prove this when stated for `LightCondensed C` for a concrete category `C`.
--- However, it doesn't seem to see through the abbreviation `LightCondMod`
-@[simp]
 lemma hom_naturality_apply {X Y : LightCondMod.{u} R} (f : X ⟶ Y) {S T : LightProfiniteᵒᵖ}
     (g : S ⟶ T) (x : X.val.obj S) : f.val.app T (X.val.map g x) = Y.val.map g (f.val.app S x) :=
   NatTrans.naturality_apply f.val g x

--- a/Mathlib/Condensed/Light/TopCatAdjunction.lean
+++ b/Mathlib/Condensed/Light/TopCatAdjunction.lean
@@ -51,6 +51,7 @@ lemma continuous_coinducingCoprod {S : LightProfinite.{u}} (x : X.val.obj ⟨S�
 
 variable {X} {Y : LightCondSet} (f : X ⟶ Y)
 
+attribute [local instance] Types.instFunLike Types.instConcreteCategory in
 /-- The map part of the functor `LightCondSet ⥤ TopCat` -/
 @[simps!]
 def toTopCatMap : X.toTopCat ⟶ Y.toTopCat :=

--- a/Mathlib/Condensed/Module.lean
+++ b/Mathlib/Condensed/Module.lean
@@ -71,9 +71,6 @@ noncomputable abbrev Condensed.setAbAdjunction : freeAb ⊣ abForget := freeForg
 
 namespace CondensedMod
 
--- Note: `simp` can prove this when stated for `Condensed C` for a concrete category `C`.
--- However, it doesn't seem to see through the abbreviation `CondensedMod`
-@[simp]
 lemma hom_naturality_apply {X Y : CondensedMod.{u} R} (f : X ⟶ Y) {S T : CompHausᵒᵖ} (g : S ⟶ T)
     (x : X.val.obj S) : f.val.app T (X.val.map g x) = Y.val.map g (f.val.app S x) :=
   NatTrans.naturality_apply f.val g x

--- a/Mathlib/Condensed/TopCatAdjunction.lean
+++ b/Mathlib/Condensed/TopCatAdjunction.lean
@@ -48,6 +48,7 @@ lemma continuous_coinducingCoprod {S : CompHaus.{u}} (x : X.val.obj ⟨S⟩) :
 
 variable {X} {Y : CondensedSet} (f : X ⟶ Y)
 
+attribute [local instance] Types.instFunLike Types.instConcreteCategory in
 /-- The map part of the functor `CondensedSet ⥤ TopCat`  -/
 @[simps!]
 def toTopCatMap : X.toTopCat ⟶ Y.toTopCat :=


### PR DESCRIPTION
This lemma was still stated using `HasForget`, we can turn it into taking `ConcreteCategory` for some nice downstream cleanup.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
