### PR TITLE
[Merged by Bors] - feat(CategoryTheory/Products/Associator): compatibility of `associator`

### DIFF
--- a/Mathlib/CategoryTheory/Products/Associator.lean
+++ b/Mathlib/CategoryTheory/Products/Associator.lean
@@ -10,7 +10,7 @@ The associator functor `((C × D) × E) ⥤ (C × (D × E))` and its inverse for
 -/
 
 
-universe v₁ v₂ v₃ u₁ u₂ u₃
+universe v₁ v₂ v₃ v₄ u₁ u₂ u₃ u₄
 
 open CategoryTheory
 
@@ -49,4 +49,25 @@ instance inverseAssociatorIsEquivalence : (inverseAssociator C D E).IsEquivalenc
   (by infer_instance : (associativity C D E).inverse.IsEquivalence)
 
 -- TODO pentagon natural transformation? ...satisfying?
+
+variable (A : Type u₄) [Category.{v₄} A]
+
+/-- The associator isomorphism is compatible with `prodFunctorToFunctorProd`. -/
+@[simps!]
+def prodFunctorToFunctorProdAssociator :
+    (associativity _ _ _).functor ⋙ ((𝟭 _).prod (prodFunctorToFunctorProd A D E) ⋙
+      (prodFunctorToFunctorProd A C (D × E))) ≅
+        (prodFunctorToFunctorProd A C D).prod (𝟭 _) ⋙ (prodFunctorToFunctorProd A (C × D) E) ⋙
+          (associativity C D E).congrRight.functor :=
+  Iso.refl _
+
+/-- The associator isomorphism is compatible with `functorProdToProdFunctor`. -/
+@[simps!]
+def functorProdToProdFunctorAssociator :
+    (associativity _ _ _).congrRight.functor ⋙ functorProdToProdFunctor A C (D × E) ⋙
+      (𝟭 _).prod (functorProdToProdFunctor A D E) ≅
+        functorProdToProdFunctor A (C × D) E ⋙ (functorProdToProdFunctor A C D).prod (𝟭 _) ⋙
+          (associativity _ _ _).functor :=
+  Iso.refl _
+
 end CategoryTheory.prod


### PR DESCRIPTION
We show that the `associator` isomorphism for product in categories is compatible with the construction on functor categories provided by `functorProdToProdFunctor` and `prodFunctorToFunctorProd`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
