### PR TITLE
[Merged by Bors] - feat: characterize level sets of the order for analytic/meromorphic functions

### DIFF
--- a/Mathlib/Analysis/Analytic/Order.lean
+++ b/Mathlib/Analysis/Analytic/Order.lean
@@ -140,10 +140,10 @@ end AnalyticAt
 
 namespace AnalyticOnNhd
 
-variable {U : Set 𝕜}
+variable {U : Set 𝕜} (hf : AnalyticOnNhd 𝕜 f U)
 
 /-- The set where an analytic function has infinite order is clopen in its domain of analyticity. -/
-theorem isClopen_setOf_order_eq_top (hf : AnalyticOnNhd 𝕜 f U) :
+theorem isClopen_setOf_order_eq_top :
     IsClopen { u : U | (hf u.1 u.2).order = ⊤ } := by
   constructor
   · rw [← isOpen_compl_iff, isOpen_iff_forall_mem_open]
@@ -187,7 +187,7 @@ theorem isClopen_setOf_order_eq_top (hf : AnalyticOnNhd 𝕜 f U) :
 
 /-- On a connected set, there exists a point where a meromorphic function `f` has finite order iff
 `f` has finite order at every point. -/
-theorem exists_order_ne_top_iff_forall (hf : AnalyticOnNhd 𝕜 f U) (hU : IsConnected U) :
+theorem exists_order_ne_top_iff_forall (hU : IsConnected U) :
     (∃ u : U, (hf u u.2).order ≠ ⊤) ↔ (∀ u : U, (hf u u.2).order ≠ ⊤) := by
   constructor
   · intro h₂f
@@ -207,14 +207,14 @@ theorem exists_order_ne_top_iff_forall (hf : AnalyticOnNhd 𝕜 f U) (hU : IsCon
 
 /-- On a preconnected set, a meromorphic function has finite order at one point if it has finite
 order at another point. -/
-theorem order_ne_top_of_isPreconnected {x y : 𝕜} (hf : AnalyticOnNhd 𝕜 f U) (hU : IsPreconnected U)
-    (h₁x : x ∈ U) (hy : y ∈ U) (h₂x : (hf x h₁x).order ≠ ⊤) :
+theorem order_ne_top_of_isPreconnected {x y : 𝕜} (hU : IsPreconnected U) (h₁x : x ∈ U) (hy : y ∈ U)
+    (h₂x : (hf x h₁x).order ≠ ⊤) :
     (hf y hy).order ≠ ⊤ :=
   (hf.exists_order_ne_top_iff_forall ⟨nonempty_of_mem h₁x, hU⟩).1 (by use ⟨x, h₁x⟩) ⟨y, hy⟩
 
 /-- The set where an analytic function has zero or infinite order is discrete within its domain of
 analyticity. -/
-theorem codiscrete_setOf_order_eq_zero_or_top (hf : AnalyticOnNhd 𝕜 f U) :
+theorem codiscrete_setOf_order_eq_zero_or_top :
     {u : U | (hf u u.2).order = 0 ∨ (hf u u.2).order = ⊤} ∈ Filter.codiscrete U := by
   rw [mem_codiscrete_subtype_iff_mem_codiscreteWithin, mem_codiscreteWithin]
   intro x hx

--- a/Mathlib/Analysis/Analytic/Order.lean
+++ b/Mathlib/Analysis/Analytic/Order.lean
@@ -136,13 +136,6 @@ end AnalyticAt
 
 /-!
 ## Level Sets of the Order Function
-
-TODO:
-
-- Draw conclusions about behaviour of the order function on connected domains of analyticity.
-
-- Prove that the set where an analytic function has order in [1,∞) is discrete within its domain of
-  analyticity.
 -/
 
 namespace AnalyticOnNhd
@@ -150,14 +143,14 @@ namespace AnalyticOnNhd
 variable {U : Set 𝕜}
 
 /-- The set where an analytic function has infinite order is clopen in its domain of analyticity. -/
-theorem isClopen_setOf_order_eq_top (h₁f : AnalyticOnNhd 𝕜 f U) :
-    IsClopen { u : U | (h₁f u.1 u.2).order = ⊤ } := by
+theorem isClopen_setOf_order_eq_top (hf : AnalyticOnNhd 𝕜 f U) :
+    IsClopen { u : U | (hf u.1 u.2).order = ⊤ } := by
   constructor
   · rw [← isOpen_compl_iff, isOpen_iff_forall_mem_open]
     intro z hz
-    rcases (h₁f z.1 z.2).eventually_eq_zero_or_eventually_ne_zero with h | h
+    rcases (hf z.1 z.2).eventually_eq_zero_or_eventually_ne_zero with h | h
     · -- Case: f is locally zero in a punctured neighborhood of z
-      rw [← (h₁f z.1 z.2).order_eq_top_iff] at h
+      rw [← (hf z.1 z.2).order_eq_top_iff] at h
       tauto
     · -- Case: f is locally nonzero in a punctured neighborhood of z
       obtain ⟨t', h₁t', h₂t', h₃t'⟩ := eventually_nhds_iff.1 (eventually_nhdsWithin_iff.1 h)
@@ -167,7 +160,7 @@ theorem isClopen_setOf_order_eq_top (h₁f : AnalyticOnNhd 𝕜 f U) :
         simp only [mem_compl_iff, mem_setOf_eq]
         by_cases h₁w : w = z
         · rwa [h₁w]
-        · rw [(h₁f _ w.2).order_eq_zero_iff.2 ((h₁t' w hw) (Subtype.coe_ne_coe.mpr h₁w))]
+        · rw [(hf _ w.2).order_eq_zero_iff.2 ((h₁t' w hw) (Subtype.coe_ne_coe.mpr h₁w))]
           exact ENat.zero_ne_top
       · exact ⟨isOpen_induced h₂t', h₃t'⟩
   · apply isOpen_iff_forall_mem_open.mpr
@@ -191,5 +184,61 @@ theorem isClopen_setOf_order_eq_top (h₁f : AnalyticOnNhd 𝕜 f U) :
     use t' \ {z.1}, fun y h₁y ↦ h₁t' y h₁y.1, h₂t'.sdiff isClosed_singleton
     apply (mem_diff w).1
     exact ⟨hw, mem_singleton_iff.not.1 (Subtype.coe_ne_coe.2 h₁w)⟩
+
+/-- On a connected set, there exists a point where a meromorphic function `f` has finite order iff
+`f` has finite order at every point. -/
+theorem exists_order_ne_top_iff_forall (hf : AnalyticOnNhd 𝕜 f U) (hU : IsConnected U) :
+    (∃ u : U, (hf u u.2).order ≠ ⊤) ↔ (∀ u : U, (hf u u.2).order ≠ ⊤) := by
+  constructor
+  · intro h₂f
+    have := isPreconnected_iff_preconnectedSpace.1 hU.isPreconnected
+    rcases isClopen_iff.1 hf.isClopen_setOf_order_eq_top with h | h
+    · intro u
+      have : u ∉ (∅ : Set U) := by exact fun a => a
+      rw [← h] at this
+      tauto
+    · obtain ⟨u, hU⟩ := h₂f
+      have : u ∈ univ := by trivial
+      rw [← h] at this
+      tauto
+  · intro h₂f
+    obtain ⟨v, hv⟩ := hU.nonempty
+    use ⟨v, hv⟩, h₂f ⟨v, hv⟩
+
+/-- On a preconnected set, a meromorphic function has finite order at one point if it has finite
+order at another point. -/
+theorem order_ne_top_of_isPreconnected {x y : 𝕜} (hf : AnalyticOnNhd 𝕜 f U) (hU : IsPreconnected U)
+    (h₁x : x ∈ U) (hy : y ∈ U) (h₂x : (hf x h₁x).order ≠ ⊤) :
+    (hf y hy).order ≠ ⊤ :=
+  (hf.exists_order_ne_top_iff_forall ⟨nonempty_of_mem h₁x, hU⟩).1 (by use ⟨x, h₁x⟩) ⟨y, hy⟩
+
+/-- The set where an analytic function has zero or infinite order is discrete within its domain of
+analyticity. -/
+theorem codiscrete_setOf_order_eq_zero_or_top (hf : AnalyticOnNhd 𝕜 f U) :
+    {u : U | (hf u u.2).order = 0 ∨ (hf u u.2).order = ⊤} ∈ Filter.codiscrete U := by
+  rw [mem_codiscrete_subtype_iff_mem_codiscreteWithin, mem_codiscreteWithin]
+  intro x hx
+  rw [Filter.disjoint_principal_right]
+  rcases (hf x hx).eventually_eq_zero_or_eventually_ne_zero with h₁f | h₁f
+  · filter_upwards [eventually_nhdsWithin_of_eventually_nhds
+      (Filter.Eventually.eventually_nhds h₁f)]
+    simp only [Set.mem_compl_iff, Set.mem_diff, Set.mem_image, Set.mem_setOf_eq, Subtype.exists,
+      exists_and_right, exists_eq_right, not_exists, not_or, not_and, not_forall, Decidable.not_not]
+    intro a _ h₁a
+    use h₁a
+    by_cases h₂a : a = x
+    · rw [← (hf x hx).order_eq_top_iff] at h₁f
+      simp_rw [h₂a]
+      tauto
+    · have : (hf a h₁a).order = ⊤ := by rwa [(hf a h₁a).order_eq_top_iff]
+      tauto
+  · filter_upwards [h₁f]
+    intro a h₁a
+    simp only [Set.mem_compl_iff, Set.mem_diff, Set.mem_image, Set.mem_setOf_eq, Subtype.exists,
+      exists_and_right, exists_eq_right, not_exists, not_or, not_and, not_forall, Decidable.not_not]
+    intro h₂a
+    use h₂a
+    rw [(hf a h₂a).order_eq_zero_iff.2 h₁a]
+    tauto
 
 end AnalyticOnNhd

--- a/Mathlib/Analysis/Analytic/Order.lean
+++ b/Mathlib/Analysis/Analytic/Order.lean
@@ -210,25 +210,9 @@ theorem codiscrete_setOf_order_eq_zero_or_top :
   intro x hx
   rw [Filter.disjoint_principal_right]
   rcases (hf x hx).eventually_eq_zero_or_eventually_ne_zero with h₁f | h₁f
-  · filter_upwards [eventually_nhdsWithin_of_eventually_nhds
-      (Filter.Eventually.eventually_nhds h₁f)]
-    simp only [Set.mem_compl_iff, Set.mem_diff, Set.mem_image, Set.mem_setOf_eq, Subtype.exists,
-      exists_and_right, exists_eq_right, not_exists, not_or, not_and, not_forall, Decidable.not_not]
-    intro a _ h₁a
-    use h₁a
-    by_cases h₂a : a = x
-    · rw [← (hf x hx).order_eq_top_iff] at h₁f
-      simp_rw [h₂a]
-      tauto
-    · have : (hf a h₁a).order = ⊤ := by rwa [(hf a h₁a).order_eq_top_iff]
-      tauto
-  · filter_upwards [h₁f]
-    intro a h₁a
-    simp only [Set.mem_compl_iff, Set.mem_diff, Set.mem_image, Set.mem_setOf_eq, Subtype.exists,
-      exists_and_right, exists_eq_right, not_exists, not_or, not_and, not_forall, Decidable.not_not]
-    intro h₂a
-    use h₂a
-    rw [(hf a h₂a).order_eq_zero_iff.2 h₁a]
-    tauto
+  · filter_upwards [eventually_nhdsWithin_of_eventually_nhds h₁f.eventually_nhds] with a ha
+    simp +contextual [(hf a _).order_eq_top_iff, ha]
+  · filter_upwards [h₁f] with a ha
+    simp +contextual [(hf a _).order_eq_zero_iff, ha]
 
 end AnalyticOnNhd

--- a/Mathlib/Analysis/Analytic/Order.lean
+++ b/Mathlib/Analysis/Analytic/Order.lean
@@ -189,21 +189,11 @@ theorem isClopen_setOf_order_eq_top :
 `f` has finite order at every point. -/
 theorem exists_order_ne_top_iff_forall (hU : IsConnected U) :
     (∃ u : U, (hf u u.2).order ≠ ⊤) ↔ (∀ u : U, (hf u u.2).order ≠ ⊤) := by
-  constructor
-  · intro h₂f
-    have := isPreconnected_iff_preconnectedSpace.1 hU.isPreconnected
-    rcases isClopen_iff.1 hf.isClopen_setOf_order_eq_top with h | h
-    · intro u
-      have : u ∉ (∅ : Set U) := by exact fun a => a
-      rw [← h] at this
-      tauto
-    · obtain ⟨u, hU⟩ := h₂f
-      have : u ∈ univ := by trivial
-      rw [← h] at this
-      tauto
-  · intro h₂f
-    obtain ⟨v, hv⟩ := hU.nonempty
-    use ⟨v, hv⟩, h₂f ⟨v, hv⟩
+  have : ConnectedSpace U := Subtype.connectedSpace hU
+  obtain ⟨v⟩ : Nonempty U := inferInstance
+  suffices (∀ (u : U), (hf u u.2).order ≠ ⊤) ∨ ∀ (u : U), (hf u u.2).order = ⊤ by tauto
+  simpa [Set.eq_empty_iff_forall_not_mem, Set.eq_univ_iff_forall] using
+      isClopen_iff.1 hf.isClopen_setOf_order_eq_top
 
 /-- On a preconnected set, a meromorphic function has finite order at one point if it has finite
 order at another point. -/

--- a/Mathlib/Analysis/Meromorphic/Order.lean
+++ b/Mathlib/Analysis/Meromorphic/Order.lean
@@ -23,15 +23,6 @@ variable {𝕜 : Type*} [NontriviallyNormedField 𝕜]
 
 /-!
 ## Order at a Point: Definition and Characterization
-
-This file defines the order of a meromorphic analytic function `f` at a point `z₀`, as an element of
-`ℤ ∪ {∞}`.
-
-TODO: Uniformize API between analytic and meromorphic functions
--/
-
-/-!
-## Order at a Point: Definition and Characterization
 -/
 
 namespace MeromorphicAt
@@ -146,8 +137,8 @@ end MeromorphicAt
 /-!
 ## Level Sets of the Order Function
 
-TODO: Prove that the set where an analytic function has order in [1,∞) is discrete within its domain
-of meromorphy.
+TODO: investigate whether `codiscrete_setOf_order_eq_zero_or_top` really needs a completeness
+hypothesis.
 -/
 
 namespace MeromorphicOn
@@ -228,5 +219,38 @@ theorem order_ne_top_of_isPreconnected {x y : 𝕜} (hU : IsPreconnected U) (h�
     (h₂x : (hf x h₁x).order ≠ ⊤) :
     (hf y hy).order ≠ ⊤ :=
   (hf.exists_order_ne_top_iff_forall ⟨nonempty_of_mem h₁x, hU⟩).1 (by use ⟨x, h₁x⟩) ⟨y, hy⟩
+
+/-- If the target is a complete space, then the set where a mermorphic function has zero or infinite
+order is discrete within its domain of meromorphicity. -/
+theorem codiscrete_setOf_order_eq_zero_or_top [CompleteSpace E] :
+    {u : U | (hf u u.2).order = 0 ∨ (hf u u.2).order = ⊤} ∈ Filter.codiscrete U := by
+  rw [mem_codiscrete_subtype_iff_mem_codiscreteWithin, mem_codiscreteWithin]
+  intro x hx
+  rw [Filter.disjoint_principal_right]
+  rcases (hf x hx).eventually_eq_zero_or_eventually_ne_zero with h₁f | h₁f
+  · filter_upwards [eventually_eventually_nhdsWithin.2 h₁f]
+    simp only [Set.mem_compl_iff, Set.mem_diff, Set.mem_image, Set.mem_setOf_eq, Subtype.exists,
+      exists_and_right, exists_eq_right, not_exists, not_or, not_and, not_forall, Decidable.not_not]
+    intro a h₁a h₂a
+    use h₂a
+    by_cases h₃a : a = x
+    · rw [← (hf x hx).order_eq_top_iff] at h₁f
+      simp_rw [h₃a]
+      tauto
+    · have : (hf a h₂a).order = ⊤ := by
+        rw [(hf a h₂a).order_eq_top_iff]
+        rw [eventually_nhdsWithin_iff, eventually_nhds_iff] at h₁a ⊢
+        obtain ⟨t, h₁t, h₂t, h₃t⟩ := h₁a
+        use t \ {x}, fun y h₁y _ ↦ h₁t y h₁y.1 h₁y.2
+        exact ⟨h₂t.sdiff isClosed_singleton, Set.mem_diff_of_mem h₃t h₃a⟩
+      tauto
+  · filter_upwards [(hf x hx).eventually_analyticAt, h₁f]
+    intro a h₁a h₂a
+    simp only [Set.mem_compl_iff, Set.mem_diff, Set.mem_image, Set.mem_setOf_eq, Subtype.exists,
+      exists_and_right, exists_eq_right, not_exists, not_or, not_and, not_forall, Decidable.not_not]
+    intro h₃a
+    use h₃a
+    rw [h₁a.meromorphicAt_order, h₁a.order_eq_zero_iff.2 h₂a]
+    tauto
 
 end MeromorphicOn

--- a/Mathlib/Analysis/Meromorphic/Order.lean
+++ b/Mathlib/Analysis/Meromorphic/Order.lean
@@ -228,29 +228,16 @@ theorem codiscrete_setOf_order_eq_zero_or_top [CompleteSpace E] :
   intro x hx
   rw [Filter.disjoint_principal_right]
   rcases (hf x hx).eventually_eq_zero_or_eventually_ne_zero with h₁f | h₁f
-  · filter_upwards [eventually_eventually_nhdsWithin.2 h₁f]
-    simp only [Set.mem_compl_iff, Set.mem_diff, Set.mem_image, Set.mem_setOf_eq, Subtype.exists,
-      exists_and_right, exists_eq_right, not_exists, not_or, not_and, not_forall, Decidable.not_not]
-    intro a h₁a h₂a
-    use h₂a
-    by_cases h₃a : a = x
-    · rw [← (hf x hx).order_eq_top_iff] at h₁f
-      simp_rw [h₃a]
-      tauto
-    · have : (hf a h₂a).order = ⊤ := by
-        rw [(hf a h₂a).order_eq_top_iff]
-        rw [eventually_nhdsWithin_iff, eventually_nhds_iff] at h₁a ⊢
-        obtain ⟨t, h₁t, h₂t, h₃t⟩ := h₁a
-        use t \ {x}, fun y h₁y _ ↦ h₁t y h₁y.1 h₁y.2
-        exact ⟨h₂t.sdiff isClosed_singleton, Set.mem_diff_of_mem h₃t h₃a⟩
-      tauto
-  · filter_upwards [(hf x hx).eventually_analyticAt, h₁f]
-    intro a h₁a h₂a
-    simp only [Set.mem_compl_iff, Set.mem_diff, Set.mem_image, Set.mem_setOf_eq, Subtype.exists,
-      exists_and_right, exists_eq_right, not_exists, not_or, not_and, not_forall, Decidable.not_not]
-    intro h₃a
-    use h₃a
-    rw [h₁a.meromorphicAt_order, h₁a.order_eq_zero_iff.2 h₂a]
-    tauto
+  · filter_upwards [eventually_eventually_nhdsWithin.2 h₁f] with a h₁a
+    suffices ∀ᶠ (z : 𝕜) in 𝓝[≠] a, f z = 0 by
+      simp +contextual [(hf a _).order_eq_top_iff, h₁a, this]
+    obtain rfl | hax := eq_or_ne a x
+    · exact h₁a
+    rw [eventually_nhdsWithin_iff, eventually_nhds_iff] at h₁a ⊢
+    obtain ⟨t, h₁t, h₂t, h₃t⟩ := h₁a
+    use t \ {x}, fun y h₁y _ ↦ h₁t y h₁y.1 h₁y.2
+    exact ⟨h₂t.sdiff isClosed_singleton, Set.mem_diff_of_mem h₃t hax⟩
+  · filter_upwards [(hf x hx).eventually_analyticAt, h₁f] with a h₁a
+    simp +contextual [h₁a.meromorphicAt_order, h₁a.order_eq_zero_iff.2]
 
 end MeromorphicOn


### PR DESCRIPTION
Establish that sets where the order of analytic/meromorphic function takes values other than infinity and zero are codiscrete within the domains of analyticity/meromorphicity. Uniformize API between analytic and meromorphic functions. Fix typo in docstrings.

This material is used in [Project VD](https://github.com/kebekus/ProjectVD), which aims to formalize Value Distribution Theory for meromorphic functions on the complex plane. It will be used in the definition of a divisor attached to a meromorphic function.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
