### PR TITLE
feat: abstract tactic

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -5117,6 +5117,7 @@ import Mathlib.SetTheory.ZFC.Rank
 import Mathlib.Std.Data.HashMap
 import Mathlib.Tactic
 import Mathlib.Tactic.Abel
+import Mathlib.Tactic.Abstract
 import Mathlib.Tactic.AdaptationNote
 import Mathlib.Tactic.Algebraize
 import Mathlib.Tactic.ApplyAt

--- a/Mathlib/Tactic.lean
+++ b/Mathlib/Tactic.lean
@@ -1,4 +1,5 @@
 import Mathlib.Tactic.Abel
+import Mathlib.Tactic.Abstract
 import Mathlib.Tactic.AdaptationNote
 import Mathlib.Tactic.Algebraize
 import Mathlib.Tactic.ApplyAt

--- a/Mathlib/Tactic/Abstract.lean
+++ b/Mathlib/Tactic/Abstract.lean
@@ -28,8 +28,10 @@ elab "abstract" tacs:ppDedent(tacticSeq) : tactic => do
   setGoals [newGoal.mvarId!]
   evalTactic tacs
   let newGoal ← instantiateMVars newGoal
-  if newGoal.hasMVar then
-    goal.assign newGoal -- makes sure we get the correct error message
+  -- `mkAuxTheorem` works when there are universe metavariables,
+  -- so we only check for expression metavariabes.
+  if newGoal.hasExprMVar then
+    throwError m! "tactic `abstract` failed with unsolved goals\n{goalsToMessageData (← getGoals)}"
   else
     setGoals [goal]
     let auxName ← mkAuxName ((← getDeclName?).getD .anonymous ++ `abstract) 1

--- a/Mathlib/Tactic/Abstract.lean
+++ b/Mathlib/Tactic/Abstract.lean
@@ -27,6 +27,13 @@ elab "abstract" tacs:ppDedent(tacticSeq) : tactic => do
   let newGoal ← mkFreshExprMVar target
   setGoals [newGoal.mvarId!]
   evalTactic tacs
-  setGoals [goal]
-  let auxName := (← getDeclName?).get! ++ `abstract ++ (← mkFreshId)
-  goal.assign <| ← mkAuxTheorem auxName target newGoal
+  let newGoal ← instantiateMVars newGoal
+  if newGoal.hasMVar then
+    let newMVars ← getMVars newGoal
+    _ ← goal.assign newGoal
+    setGoals newMVars.toList
+    return
+  else
+    setGoals [goal]
+    let auxName ← mkAuxName ((← getDeclName?).getD .anonymous ++ `abstract) 1
+    goal.assign <| ← mkAuxTheorem auxName target newGoal

--- a/Mathlib/Tactic/Abstract.lean
+++ b/Mathlib/Tactic/Abstract.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Floris van Doorn, Sven Manthe
 -/
 import Mathlib.Init
-import Lean.Elab.Tactic.Simp
+import Lean.Meta.Closure
 
 /-! # The `abstract` tactic -/
 

--- a/Mathlib/Tactic/Abstract.lean
+++ b/Mathlib/Tactic/Abstract.lean
@@ -3,6 +3,7 @@ Copyright (c) 2025 Floris van Doorn. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Floris van Doorn, Sven Manthe
 -/
+import Mathlib.Init
 import Lean.Elab.Tactic.Simp
 
 /-! # The `abstract` tactic -/

--- a/Mathlib/Tactic/Abstract.lean
+++ b/Mathlib/Tactic/Abstract.lean
@@ -1,0 +1,31 @@
+/-
+Copyright (c) 2025 Floris van Doorn. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Floris van Doorn, Sven Manthe
+-/
+import Lean.Elab.Tactic.Simp
+
+/-! # The `abstract` tactic -/
+
+open Lean Meta Elab Tactic Term
+
+/--
+Usage: `abstract <tacticSeq>`.
+
+The abstract tactic executes the provided tactic sequence, and "hides" its proof behind a new
+auxiliary lemma. This is mostly useful to hide long proofs in the statement of a theorem, since
+certain tactics can be slow if the goal contains a large proof as subterm.
+-/
+elab "abstract" tacs:ppDedent(tacticSeq) : tactic => do
+  if (← getGoals).length ≠ 1 then
+    throwError "Abstract failed. There are {(← getGoals).length} goals. Expected exactly 1 goal."
+  let target ← getMainTarget
+  if !(← isProp target) then
+    throwError "Abstract failed. The current goal is not propositional."
+  let goal ← getMainGoal
+  let newGoal ← mkFreshExprMVar target
+  setGoals [newGoal.mvarId!]
+  evalTactic tacs
+  setGoals [goal]
+  let auxName := (← getDeclName?).get! ++ `abstract ++ (← mkFreshId)
+  goal.assign <| ← mkAuxTheorem auxName target newGoal

--- a/Mathlib/Tactic/Abstract.lean
+++ b/Mathlib/Tactic/Abstract.lean
@@ -29,10 +29,7 @@ elab "abstract" tacs:ppDedent(tacticSeq) : tactic => do
   evalTactic tacs
   let newGoal ← instantiateMVars newGoal
   if newGoal.hasMVar then
-    let newMVars ← getMVars newGoal
-    _ ← goal.assign newGoal
-    setGoals newMVars.toList
-    return
+    goal.assign newGoal -- makes sure we get the correct error message
   else
     setGoals [goal]
     let auxName ← mkAuxName ((← getDeclName?).getD .anonymous ++ `abstract) 1

--- a/MathlibTest/Abstract.lean
+++ b/MathlibTest/Abstract.lean
@@ -6,12 +6,12 @@ open Lean
 
 theorem foo (x : Fin 1) : x = ⟨0, by abstract omega⟩ := Subsingleton.elim ..
 
--- We don't test the precise type of `foo`, since I don't know how robust
--- the generated unique number is (currently 87)
-run_cmd do
-  let some t := (← getEnv).find? `foo | unreachable!
-  if !t.type.foldConsts false (fun n b ↦ b || n matches .num _ _) then
-    throwError "no aux-lemma in the type of foo"
+/--
+info: theorem foo : ∀ (x : Fin 1), x = ⟨0, foo.abstract_1⟩ :=
+fun x => Subsingleton.elim x ⟨0, foo.abstract_1⟩
+-/
+#guard_msgs in
+#print foo
 
 /-- error: Abstract failed. The current goal is not propositional. -/
 #guard_msgs in
@@ -21,3 +21,17 @@ example (n : Nat) : n = by abstract exact 0 := sorry
 #guard_msgs in
 example (f : True ∧ True → Nat) (n : Nat) :
   n = f (by constructor; abstract trivial; trivial) := sorry
+
+/-- error: unsolved goals
+case left
+f : True ∧ True → Nat
+n : Nat
+⊢ True
+
+case right
+f : True ∧ True → Nat
+n : Nat
+⊢ True -/
+#guard_msgs in
+example (f : True ∧ True → Nat) (n : Nat) :
+  n = f (by abstract constructor) := sorry

--- a/MathlibTest/Abstract.lean
+++ b/MathlibTest/Abstract.lean
@@ -13,7 +13,7 @@ fun x => Subsingleton.elim x ⟨0, foo.abstract_1⟩
 #guard_msgs in
 #print foo
 
-/-- error: Abstract failed. The current goal is not propositional. -/
+/-- error: Abstract failed. The current goal is not a proposition. -/
 #guard_msgs in
 example (n : Nat) : n = by abstract exact 0 := sorry
 
@@ -22,7 +22,7 @@ example (n : Nat) : n = by abstract exact 0 := sorry
 example (f : True ∧ True → Nat) (n : Nat) :
   n = f (by constructor; abstract trivial; trivial) := sorry
 
-/-- error: tactic `abstract` failed with unsolved goals
+/-- error: Abstract failed. There are unsolved goals
 case left
 f : True ∧ True → Nat
 n : Nat

--- a/MathlibTest/Abstract.lean
+++ b/MathlibTest/Abstract.lean
@@ -22,7 +22,7 @@ example (n : Nat) : n = by abstract exact 0 := sorry
 example (f : True ∧ True → Nat) (n : Nat) :
   n = f (by constructor; abstract trivial; trivial) := sorry
 
-/-- error: unsolved goals
+/-- error: tactic `abstract` failed with unsolved goals
 case left
 f : True ∧ True → Nat
 n : Nat
@@ -35,3 +35,22 @@ n : Nat
 #guard_msgs in
 example (f : True ∧ True → Nat) (n : Nat) :
   n = f (by abstract constructor) := sorry
+
+
+def bar : Function.const (∀ α : Type _, ∀ a : α, a = a) 1 (by abstract simp) = 1 := rfl
+
+/--
+info: def bar.{u_1} : Function.const (∀ (α : Type u_1) (a : α), a = a) 1 bar.abstract_1 = 1 :=
+rfl
+-/
+#guard_msgs in
+#print bar
+
+def baz : Function.const (∀ α : Type u, ∀ a : α, a = a) 1 (by abstract simp) = 1 := rfl
+
+/--
+info: def baz.{u} : Function.const (∀ (α : Type u) (a : α), a = a) 1 baz.abstract_1 = 1 :=
+rfl
+-/
+#guard_msgs in
+#print baz

--- a/MathlibTest/Abstract.lean
+++ b/MathlibTest/Abstract.lean
@@ -1,0 +1,23 @@
+import Mathlib.Tactic.Abstract
+import Mathlib.Tactic.Core
+import Mathlib.Lean.Name
+
+open Lean
+
+theorem foo (x : Fin 1) : x = ⟨0, by abstract omega⟩ := Subsingleton.elim ..
+
+-- We don't test the precise type of `foo`, since I don't know how robust
+-- the generated unique number is (currently 87)
+run_cmd do
+  let some t := (← getEnv).find? `foo | unreachable!
+  if !t.type.foldConsts false (fun n b ↦ b || n matches .num _ _) then
+    throwError "no aux-lemma in the type of foo"
+
+/-- error: Abstract failed. The current goal is not propositional. -/
+#guard_msgs in
+example (n : Nat) : n = by abstract exact 0 := sorry
+
+/-- error: Abstract failed. There are 2 goals. Expected exactly 1 goal. -/
+#guard_msgs in
+example (f : True ∧ True → Nat) (n : Nat) :
+  n = f (by constructor; abstract trivial; trivial) := sorry

--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -57,6 +57,7 @@
   "Mathlib.Mathport.Rename",
   "Mathlib.Probability.Notation",
   "Mathlib.Tactic.Abel",
+  "Mathlib.Tactic.Abstract",
   "Mathlib.Tactic.ApplyCongr",
   "Mathlib.Tactic.ApplyFun",
   "Mathlib.Tactic.ApplyWith",


### PR DESCRIPTION
This can be used to hide long proofs in the statement of a theorem behind an auxiliary lemma.

Co-authored-by: Sven Manthe sven.manthe@uni-bonn.de

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
