### PR TITLE
[Merged by Bors] -  feat(CategoryTheory/Subobject): add definition of subobjects presheaf

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2365,6 +2365,7 @@ import Mathlib.CategoryTheory.Subobject.HasCardinalLT
 import Mathlib.CategoryTheory.Subobject.Lattice
 import Mathlib.CategoryTheory.Subobject.Limits
 import Mathlib.CategoryTheory.Subobject.MonoOver
+import Mathlib.CategoryTheory.Subobject.Presheaf
 import Mathlib.CategoryTheory.Subobject.Types
 import Mathlib.CategoryTheory.Subobject.WellPowered
 import Mathlib.CategoryTheory.Subpresheaf.Basic

--- a/Mathlib/CategoryTheory/Subobject/Presheaf.lean
+++ b/Mathlib/CategoryTheory/Subobject/Presheaf.lean
@@ -1,0 +1,60 @@
+/-
+Copyright (c) 2025 Pablo Donato. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Pablo Donato
+-/
+
+import Mathlib.CategoryTheory.Subobject.Basic
+import Mathlib.CategoryTheory.Limits.Shapes.Pullback.HasPullback
+
+/-!
+# Subobjects presheaf
+
+Following Section I.3 of [Sheaves in Geometry and Logic][MM92], we define the subobjects presheaf
+`sub C` mapping any object `X` to its category of subobjects `Subobject X`.
+
+## Main definitions
+
+Let `C` refer to a category with pullbacks.
+
+* `CategoryTheory.Subobject.sub C` is the presheaf that sends every object `X : C` to its category
+  of subobjects `Subobject X`, and every morphism `f : X ⟶ Y` to the function
+  `Subobject Y → Subobject X` that maps every subobject of `Y` to its pullback along `f`.
+
+## References
+
+* [S. MacLane and I. Moerdijk, *Sheaves in geometry and logic: A first introduction to topos
+  theory*][MM92]
+
+## Tags
+
+subobject, representable functor, presheaf, topos theory
+-/
+
+open CategoryTheory Subobject
+
+universe u v
+
+variable (C : Type u) [Category.{v} C] [Limits.HasPullbacks C]
+
+/-- `sub` is the presheaf that sends every object `X : C` to its category of subobjects
+    `Subobject X`, and every morphism `f : X ⟶ Y` to the function `Subobject Y → Subobject X`
+    that maps every subobject of `Y` to its pullback along `f`. -/
+noncomputable def sub : Cᵒᵖ ⥤ Type (max u v) where
+  obj X := (@Subobject C _ X.unop)
+
+  map f := (pullback f.unop).obj
+
+  map_id := by
+    simp only
+    intro X
+    funext
+    rw [unop_id, pullback_id]
+    simp
+
+  map_comp := by
+    simp only
+    intro X Y Z f g
+    funext
+    rw [unop_comp, pullback_comp]
+    simp

--- a/Mathlib/CategoryTheory/Subobject/Presheaf.lean
+++ b/Mathlib/CategoryTheory/Subobject/Presheaf.lean
@@ -3,7 +3,6 @@ Copyright (c) 2025 Pablo Donato. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Pablo Donato
 -/
-
 import Mathlib.CategoryTheory.Subobject.Basic
 import Mathlib.CategoryTheory.Limits.Shapes.Pullback.HasPullback
 
@@ -11,13 +10,13 @@ import Mathlib.CategoryTheory.Limits.Shapes.Pullback.HasPullback
 # Subobjects presheaf
 
 Following Section I.3 of [Sheaves in Geometry and Logic][MM92], we define the subobjects presheaf
-`sub C` mapping any object `X` to its category of subobjects `Subobject X`.
+`Subobject.presheaf C` mapping any object `X` to its category of subobjects `Subobject X`.
 
 ## Main definitions
 
 Let `C` refer to a category with pullbacks.
 
-* `CategoryTheory.Subobject.sub C` is the presheaf that sends every object `X : C` to its category
+* `CategoryTheory.Subobject.presheaf C` is the presheaf that sends every object `X : C` to its category
   of subobjects `Subobject X`, and every morphism `f : X ⟶ Y` to the function
   `Subobject Y → Subobject X` that maps every subobject of `Y` to its pullback along `f`.
 
@@ -40,21 +39,9 @@ variable (C : Type u) [Category.{v} C] [Limits.HasPullbacks C]
 /-- `sub` is the presheaf that sends every object `X : C` to its category of subobjects
     `Subobject X`, and every morphism `f : X ⟶ Y` to the function `Subobject Y → Subobject X`
     that maps every subobject of `Y` to its pullback along `f`. -/
-noncomputable def sub : Cᵒᵖ ⥤ Type (max u v) where
-  obj X := (@Subobject C _ X.unop)
-
+@[simps]
+noncomputable def presheaf : Cᵒᵖ ⥤ Type max u v where
+  obj X := Subobject X.unop
   map f := (pullback f.unop).obj
-
-  map_id := by
-    simp only
-    intro X
-    funext
-    rw [unop_id, pullback_id]
-    simp
-
-  map_comp := by
-    simp only
-    intro X Y Z f g
-    funext
-    rw [unop_comp, pullback_comp]
-    simp
+  map_id _ := by ext : 1; simp [pullback_id]
+  map_comp _ _ := by ext : 1; simp [pullback_comp]

--- a/Mathlib/CategoryTheory/Subobject/Presheaf.lean
+++ b/Mathlib/CategoryTheory/Subobject/Presheaf.lean
@@ -38,7 +38,7 @@ universe u v
 
 variable (C : Type u) [Category.{v} C] [Limits.HasPullbacks C]
 
-/-- `sub` is the presheaf that sends every object `X : C` to its category of subobjects
+/-- This is the presheaf that sends every object `X : C` to its category of subobjects
     `Subobject X`, and every morphism `f : X ⟶ Y` to the function `Subobject Y → Subobject X`
     that maps every subobject of `Y` to its pullback along `f`. -/
 @[simps]

--- a/Mathlib/CategoryTheory/Subobject/Presheaf.lean
+++ b/Mathlib/CategoryTheory/Subobject/Presheaf.lean
@@ -10,7 +10,7 @@ import Mathlib.CategoryTheory.Limits.Shapes.Pullback.HasPullback
 # Subobjects presheaf
 
 Following Section I.3 of [Sheaves in Geometry and Logic][MM92], we define the subobjects presheaf
-`Subobject.presheaf C` mapping any object `X` to its category of subobjects `Subobject X`.
+`Subobject.presheaf C` mapping any object `X` to its type of subobjects `Subobject X`.
 
 ## Main definitions
 

--- a/Mathlib/CategoryTheory/Subobject/Presheaf.lean
+++ b/Mathlib/CategoryTheory/Subobject/Presheaf.lean
@@ -16,8 +16,8 @@ Following Section I.3 of [Sheaves in Geometry and Logic][MM92], we define the su
 
 Let `C` refer to a category with pullbacks.
 
-* `CategoryTheory.Subobject.presheaf C` is the presheaf that sends every object `X : C` to its category
-  of subobjects `Subobject X`, and every morphism `f : X ⟶ Y` to the function
+* `CategoryTheory.Subobject.presheaf C` is the presheaf that sends every object `X : C` to its
+  category of subobjects `Subobject X`, and every morphism `f : X ⟶ Y` to the function
   `Subobject Y → Subobject X` that maps every subobject of `Y` to its pullback along `f`.
 
 ## References
@@ -32,6 +32,8 @@ subobject, representable functor, presheaf, topos theory
 
 open CategoryTheory Subobject
 
+namespace Subobject
+
 universe u v
 
 variable (C : Type u) [Category.{v} C] [Limits.HasPullbacks C]
@@ -45,3 +47,5 @@ noncomputable def presheaf : Cᵒᵖ ⥤ Type max u v where
   map f := (pullback f.unop).obj
   map_id _ := by ext : 1; simp [pullback_id]
   map_comp _ _ := by ext : 1; simp [pullback_comp]
+
+end Subobject


### PR DESCRIPTION
We create a file `CategoryTheory/Subobject/Presheaf.lean` which introduces the definition `CategoryTheory.Subobject.sub` of the subobjects presheaf, following Section I.3 of Sheaves in Geometry and Logic [MM92]. This is a sub-PR of #22245.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
