### PR TITLE
[Merged by Bors] - feat: define exponential of nilpotent elements of a `ℚ`-algebra

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -7,6 +7,7 @@ import Mathlib.Algebra.Algebra.Basic
 import Mathlib.Algebra.Algebra.Bilinear
 import Mathlib.Algebra.Algebra.Defs
 import Mathlib.Algebra.Algebra.Equiv
+import Mathlib.Algebra.Algebra.Exp
 import Mathlib.Algebra.Algebra.Field
 import Mathlib.Algebra.Algebra.Hom
 import Mathlib.Algebra.Algebra.Hom.Rat

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -7,7 +7,6 @@ import Mathlib.Algebra.Algebra.Basic
 import Mathlib.Algebra.Algebra.Bilinear
 import Mathlib.Algebra.Algebra.Defs
 import Mathlib.Algebra.Algebra.Equiv
-import Mathlib.Algebra.Algebra.Exp
 import Mathlib.Algebra.Algebra.Field
 import Mathlib.Algebra.Algebra.Hom
 import Mathlib.Algebra.Algebra.Hom.Rat

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4851,6 +4851,7 @@ import Mathlib.RingTheory.MvPowerSeries.Trunc
 import Mathlib.RingTheory.Nakayama
 import Mathlib.RingTheory.Nilpotent.Basic
 import Mathlib.RingTheory.Nilpotent.Defs
+import Mathlib.RingTheory.Nilpotent.Exp
 import Mathlib.RingTheory.Nilpotent.Lemmas
 import Mathlib.RingTheory.NoetherNormalization
 import Mathlib.RingTheory.Noetherian.Basic

--- a/Mathlib/Algebra/Algebra/Exp.lean
+++ b/Mathlib/Algebra/Algebra/Exp.lean
@@ -7,6 +7,7 @@ import Mathlib.Algebra.Algebra.Defs
 import Mathlib.Algebra.BigOperators.GroupWithZero.Action
 import Mathlib.Data.Nat.Cast.Field
 import Mathlib.RingTheory.Nilpotent.Basic
+import Mathlib.Tactic.FieldSimp
 
 /-!
 # Exponential map on algebras
@@ -38,6 +39,7 @@ namespace Algebra
 variable {A : Type*} [Ring A] [Algebra ℚ A]
 
 open Finset
+open scoped Nat
 
 /-- The exponential map on algebras, defined in analogy with the usual exponential series.
 It provides meaningful (non-junk) values for nilpotent elements. -/

--- a/Mathlib/Algebra/Algebra/Exp.lean
+++ b/Mathlib/Algebra/Algebra/Exp.lean
@@ -1,11 +1,12 @@
 import Mathlib.Algebra.Algebra.Defs
 import Mathlib.Algebra.BigOperators.Group.Finset.Basic
+import Mathlib.Algebra.BigOperators.Intervals
 import Mathlib.Algebra.Field.Defs
 import Mathlib.RingTheory.Nilpotent.Defs
 
 namespace Algebra
 
-variable (R : Type*) [Field R] [CharZero R]
+variable (R : Type*) [Field R]
 variable (A : Type*) [Semiring A] [Algebra R A]
 
 noncomputable def exp (a : A) : A :=
@@ -13,7 +14,38 @@ noncomputable def exp (a : A) : A :=
 
 theorem exp_eq_truncated {k : ℕ} (a : A) (h : a ^ k = 0) :
     ∑ n ∈ Finset.range k, (Nat.factorial n : R)⁻¹ • (a ^ n) = exp R A a := by
-  sorry
+  have h₁ : nilpotencyClass a ≤ k := by
+    exact csInf_le' h
+  have h₂ : ∑ n ∈ Finset.range k, (Nat.factorial n : R)⁻¹ • (a ^ n) =
+      ∑ n ∈ Finset.range (nilpotencyClass a), (Nat.factorial n : R)⁻¹ • (a ^ n) +
+        ∑ n ∈ Finset.Ico (nilpotencyClass a) k, (Nat.factorial n : R)⁻¹ • (a ^ n) :=
+    (Finset.sum_range_add_sum_Ico _ h₁).symm
+  suffices h₃ : ∑ n ∈ Finset.Ico (nilpotencyClass a) k, (Nat.factorial n : R)⁻¹ • (a ^ n) = 0 by
+    dsimp [exp]
+    rw [h₂, h₃, add_zero]
+  suffices h₅ : ∀ n ∈ Finset.Ico (nilpotencyClass a) k, (Nat.factorial n : R)⁻¹ • (a ^ n) = 0 by
+    apply Finset.sum_eq_zero h₅
+  intro t ht
+  have h₆ : nilpotencyClass a ≤ t := by
+    simp_all only [Finset.mem_Ico]
+  suffices h₆ : a ^ t = 0 by
+    simp_all only [Finset.mem_Ico, true_and, smul_zero]
+  have h₈ : IsNilpotent a := by
+    use k
+  have h₉ := pow_nilpotencyClass h₈
+  have h10 : t = nilpotencyClass a + (t - nilpotencyClass a) := by
+    simp_all only [Finset.mem_Ico, true_and, add_tsub_cancel_of_le]
+  rw [h10]
+  rw [pow_add]
+  rw [h₉]
+  exact zero_mul (a ^ (t - nilpotencyClass a))
+
+variable [CharZero R]
+
+example (n : ℕ) (a : A) : (n.factorial : R) • ((n.factorial : R)⁻¹ • a) = a := by
+  have h1 : (n.factorial : R) ≠ 0 := by exact_mod_cast Nat.factorial_ne_zero n
+  simp_all only [ne_eq, Nat.cast_eq_zero, not_false_eq_true, smul_inv_smul₀]
+  --exact mul_inv_cancel₀ h1
 
 -- useful: add_pow_eq_zero_of_add_le_succ_of_pow_eq_zero
 -- useful: add_pow (h : Commute x y) (n : ℕ) : ...

--- a/Mathlib/Algebra/Algebra/Exp.lean
+++ b/Mathlib/Algebra/Algebra/Exp.lean
@@ -1,8 +1,6 @@
 import Mathlib.Algebra.Algebra.Defs
 import Mathlib.Algebra.BigOperators.Group.Finset.Basic
 import Mathlib.Algebra.Field.Defs
-import Mathlib.Data.Finset.Basic
-import Mathlib.Data.Nat.Factorial.Basic
 import Mathlib.RingTheory.Nilpotent.Defs
 
 namespace Algebra

--- a/Mathlib/Algebra/Algebra/Exp.lean
+++ b/Mathlib/Algebra/Algebra/Exp.lean
@@ -36,11 +36,11 @@ noncomputable def exp (a : A) : A :=
   ∑ n ∈ Finset.range (exponent A a), (Nat.factorial n : R)⁻¹ • (a ^ n)
 
 
-theorem wellDef {k : ℕ} (a : A) (h : a ^ k = 0) :
+theorem well_def {k : ℕ} (a : A) (h : a ^ k = 0) :
     ∑ n ∈ Finset.range k, (Nat.factorial n : R)⁻¹ • (a ^ n) = exp R A a := by
   sorry
 
-theorem mul_add (a b : A) (h : a * b = b * a) (h1 : IsNilpotent a) (h2 : IsNilpotent b) :
+theorem exp_add_mul (a b : A) (h : a * b = b * a) (h1 : IsNilpotent a) (h2 : IsNilpotent b) :
     exp R A (a + b) = exp R A a * exp R A b := by
   sorry
 

--- a/Mathlib/Algebra/Algebra/Exp.lean
+++ b/Mathlib/Algebra/Algebra/Exp.lean
@@ -23,7 +23,6 @@ This file could usefully be split further.
 
 universe u w
 
-open Function
 
 namespace Algebra
 
@@ -36,12 +35,17 @@ variable [Semiring A] [Algebra R A]
 noncomputable def exponent (a : A) : ℕ :=
     sInf {k | a ^ k = 0}
 
-noncomputable def exp (a : A) (h : IsNilpotent a) : A :=
+noncomputable def exp (a : A) [Field R]: A :=
   ∑ n ∈ Finset.range (exponent a), (Nat.factorial n : R)⁻¹ • (a ^ n)
+
+theorem wellDef {k : ℕ} (a : A) (h : a ^ k = 0) :
+    exp (R := R) a  = ∑ n ∈ Finset.range k, (Nat.factorial n : R)⁻¹ • (a ^ n) := by
+  sorry
+
+theorem mul_add (a b : A) (h : a * b = b * a) (IsNilpotent a : A) (IsNilpotent b : A) :
+    exp (R := R) (a + b) = (exp (R := R) a : A) * (exp (R := R) b) := by
+  sorry
 
 end Exp
 
-
 end Algebra
-
-open scoped Algebra

--- a/Mathlib/Algebra/Algebra/Exp.lean
+++ b/Mathlib/Algebra/Algebra/Exp.lean
@@ -33,11 +33,11 @@ variable {R : Type u} {A : Type w}
 variable [Field R] [CharZero R]
 variable [Semiring A] [Algebra R A]
 
-def exp (a : A) (h : IsNilpotent a) : A :=
-  --let k := nilpotency_class a h
-  let five_factorial : R := Nat.factorial 5
-  let inv_five_factorial : R := five_factorial⁻¹
-  ∑ n ∈ Finset.range 11, (Nat.factorial n : R)⁻¹ • a
+noncomputable def exponent (a : A) : ℕ :=
+    sInf {k | a ^ k = 0}
+
+noncomputable def exp (a : A) (h : IsNilpotent a) : A :=
+  ∑ n ∈ Finset.range (exponent a), (Nat.factorial n : R)⁻¹ • (a ^ n)
 
 end Exp
 

--- a/Mathlib/Algebra/Algebra/Exp.lean
+++ b/Mathlib/Algebra/Algebra/Exp.lean
@@ -70,101 +70,88 @@ theorem exp_add_of_commute {a b : A} (h₁ : Commute a b) (h₂ : IsNilpotent a)
   have h₄ : a ^ (N + 1) = 0 := pow_eq_zero_of_le (by omega) hn₁
   have h₅ : b ^ (N + 1) = 0 := pow_eq_zero_of_le (by omega) hn₂
   rw [← exp_eq_truncated (k := 2 * N + 1)
-  (Commute.add_pow_eq_zero_of_add_le_succ_of_pow_eq_zero h₁ h₄ h₅ (by omega)),
-  ← exp_eq_truncated h₄, ← exp_eq_truncated h₅]
-  have s₁ := calc
-    ∑ i ∈ range (2 * N + 1), (i.factorial : ℚ)⁻¹ • (a + b) ^ i =
-      ∑ i ∈ range (2 * N + 1), (i.factorial : ℚ)⁻¹ •
-        (∑ j ∈ range (i + 1), a ^ j * b ^ (i - j) * i.choose j) := by
-      apply sum_congr rfl
-      intro i _
+    (Commute.add_pow_eq_zero_of_add_le_succ_of_pow_eq_zero h₁ h₄ h₅ (by omega)),
+    ← exp_eq_truncated h₄, ← exp_eq_truncated h₅]
+  set R2N := range (2 * N + 1) with hR2N
+  set RN := range (N + 1) with hRN
+  have s₁ := by
+    calc ∑ i ∈ R2N, (i ! : ℚ)⁻¹ • (a + b) ^ i
+        = ∑ i ∈ R2N, (i ! : ℚ)⁻¹ • ∑ j ∈ range (i + 1), a ^ j * b ^ (i - j) * i.choose j := ?_
+      _ = ∑ i ∈ R2N, (∑ j ∈ range (i + 1),
+            ((j ! : ℚ)⁻¹ * ((i - j) ! : ℚ)⁻¹) • (a ^ j * b ^ (i - j))) := ?_
+      _ = ∑ ij ∈ R2N ×ˢ R2N with ij.1 + ij.2 ≤ 2 * N,
+            ((ij.1 ! : ℚ)⁻¹ * (ij.2 ! : ℚ)⁻¹) • (a ^ ij.1 * b ^ ij.2) := ?_
+    · refine sum_congr rfl fun i _ ↦ ?_
       rw [Commute.add_pow h₁ i]
-    _ = ∑ i ∈ range (2 * N + 1), (∑ j ∈ range (i + 1), ((j.factorial : ℚ)⁻¹ *
-          ((i - j).factorial : ℚ)⁻¹) • (a ^ j * b ^ (i - j))) := by
-      apply sum_congr rfl
-      intro i hi
-      rw [smul_sum]
-      apply sum_congr rfl
-      intro j hj
+    · simp_rw [smul_sum]
+      refine sum_congr rfl fun i hi ↦ sum_congr rfl fun j hj ↦ ?_
       simp only [mem_range] at hi hj
-      suffices (i.factorial : ℚ)⁻¹ * (i.choose j) =
-          ((j.factorial : ℚ)⁻¹ * ((i - j).factorial : ℚ)⁻¹) by
+      replace hj := Nat.le_of_lt_succ hj
+      suffices (i ! : ℚ)⁻¹ * (i.choose j) = ((j ! : ℚ)⁻¹ * ((i - j)! : ℚ)⁻¹) by
         rw [← Nat.cast_commute (i.choose j), ← this, ← Algebra.mul_smul_comm, ← nsmul_eq_mul,
-        mul_smul, ← smul_assoc, smul_comm, smul_assoc]
+          mul_smul, ← smul_assoc, smul_comm, smul_assoc]
         norm_cast
-      rw [Nat.choose_eq_factorial_div_factorial (Nat.le_of_lt_succ hj), Nat.cast_div, mul_div]
-      · rw [inv_mul_cancel₀ (mod_cast Nat.factorial_ne_zero i), Nat.cast_mul, one_div,
-        mul_inv_rev, mul_comm]
-      · exact Nat.factorial_mul_factorial_dvd_factorial (Nat.le_of_lt_succ hj)
-      rw [Nat.cast_mul]
-      apply mul_ne_zero <;> exact_mod_cast Nat.factorial_ne_zero _
-    _ = ∑ ij ∈ (range (2 * N + 1)).product (range (2 * N + 1)) with ij.1 + ij.2 <= 2 * N,
-          ((ij.1.factorial : ℚ)⁻¹ * (ij.2.factorial : ℚ)⁻¹) • (a ^ ij.1 * b ^ ij.2) := by
-      rw [sum_sigma']
-      apply sum_bij (fun ⟨i, j⟩ _ => (j, i - j))
-      · simp only [mem_sigma, mem_range, product_eq_sprod, mem_filter, mem_product, and_imp]
-        (intro _ _ _; omega)
+      rw [Nat.choose_eq_factorial_div_factorial hj,
+        Nat.cast_div (Nat.factorial_mul_factorial_dvd_factorial hj) (by field_simp)]
+      field_simp
+    · rw [hR2N, sum_sigma']
+      apply sum_bij (fun ⟨i, j⟩ _ ↦ (j, i - j))
+      · simp only [mem_sigma, mem_range, mem_filter, mem_product, and_imp]
+        omega
       · simp only [mem_sigma, mem_range, Prod.mk.injEq, and_imp]
-        (intro _ _ _ _ _ _ h _; exact Sigma.ext (by omega) (heq_of_eq h))
-      · simp only [product_eq_sprod, mem_filter, mem_product, mem_range, mem_sigma, exists_prop,
-          Sigma.exists, and_imp, Prod.forall, Prod.mk.injEq]
-        (intro h₁ h₂ _ _ _; use h₁ + h₂, h₁; omega)
-      simp only [mem_sigma, mem_range, implies_true]
-  have z₁ : ∑ ij ∈ ((range (2 * N + 1)).product (range (2 * N + 1))) with ¬ ij.1 + ij.2 ≤ 2 * N,
-      ((ij.1.factorial : ℚ)⁻¹ * (ij.2.factorial : ℚ)⁻¹) • (a ^ ij.1 * b ^ ij.2) = 0 :=
+        rintro ⟨x₁, y₁⟩ - h₁ ⟨x₂, y₂⟩ - h₂ h₃ h₄
+        simp_all
+        omega
+      · simp only [mem_filter, mem_product, mem_range, mem_sigma, exists_prop, Sigma.exists,
+          and_imp, Prod.forall, Prod.mk.injEq]
+        exact fun x y _ _ _ ↦ ⟨x + y, x, by omega⟩
+      · simp only [mem_sigma, mem_range, implies_true]
+  have z₁ : ∑ ij ∈ R2N ×ˢ R2N with ¬ ij.1 + ij.2 ≤ 2 * N,
+      ((ij.1 ! : ℚ)⁻¹ * (ij.2 ! : ℚ)⁻¹) • (a ^ ij.1 * b ^ ij.2) = 0 :=
     sum_eq_zero fun i hi ↦ by
       rw [mem_filter] at hi
       cases le_or_lt (N + 1) i.1 with
         | inl h => rw [pow_eq_zero_of_le h h₄, zero_mul, smul_zero]
         | inr _ => rw [pow_eq_zero_of_le (by linarith) h₅, mul_zero, smul_zero]
-  have split₁ := sum_filter_add_sum_filter_not ((range (2 * N + 1)).product (range (2 * N + 1)))
-    (fun ij => ij.1 + ij.2 ≤ 2 * N)
-    (fun ij => ((ij.1.factorial : ℚ)⁻¹ * (ij.2.factorial : ℚ)⁻¹) • (a ^ ij.1 * b ^ ij.2))
-  rw [z₁, product_eq_sprod, add_zero] at split₁
-  rw [product_eq_sprod, split₁] at s₁
-  have z₂ : ∑ ij ∈ ((range (2 * N + 1)).product (range (2 * N + 1))) with ¬ (ij.1 ≤ N ∧ ij.2 ≤ N),
-      ((ij.1.factorial : ℚ)⁻¹ * (ij.2.factorial : ℚ)⁻¹) • (a ^ ij.1 * b ^ ij.2) = 0 :=
+  have split₁ := sum_filter_add_sum_filter_not (R2N ×ˢ R2N)
+    (fun ij ↦ ij.1 + ij.2 ≤ 2 * N)
+    (fun ij ↦ ((ij.1 ! : ℚ)⁻¹ * (ij.2 ! : ℚ)⁻¹) • (a ^ ij.1 * b ^ ij.2))
+  rw [z₁, add_zero] at split₁
+  rw [split₁] at s₁
+  have z₂ : ∑ ij ∈ R2N ×ˢ R2N with ¬ (ij.1 ≤ N ∧ ij.2 ≤ N),
+      ((ij.1 ! : ℚ)⁻¹ * (ij.2 ! : ℚ)⁻¹) • (a ^ ij.1 * b ^ ij.2) = 0 :=
     sum_eq_zero fun i hi ↦ by
     simp only [not_and, not_le, mem_filter] at hi
     cases le_or_lt (N + 1) i.1 with
       | inl h => rw [pow_eq_zero_of_le h h₄, zero_mul, smul_zero]
       | inr h => rw [pow_eq_zero_of_le (hi.2 (Nat.le_of_lt_succ h)) h₅, mul_zero, smul_zero]
-  have split₂ := sum_filter_add_sum_filter_not ((range (2 * N + 1)).product (range (2 * N + 1)))
-    (fun ij => ij.1 ≤ N ∧ ij.2 ≤ N)
-    (fun ij => ((ij.1.factorial : ℚ)⁻¹ * (ij.2.factorial : ℚ)⁻¹) • (a ^ ij.1 * b ^ ij.2))
-  rw [z₂, product_eq_sprod, add_zero] at split₂
+  have split₂ := sum_filter_add_sum_filter_not (R2N ×ˢ R2N)
+    (fun ij ↦ ij.1 ≤ N ∧ ij.2 ≤ N)
+    (fun ij ↦ ((ij.1 ! : ℚ)⁻¹ * (ij.2 ! : ℚ)⁻¹) • (a ^ ij.1 * b ^ ij.2))
+  rw [z₂, add_zero] at split₂
   rw [← split₂] at s₁
-  have restrict: ∑ ij ∈ (range (2 * N + 1)).product (range (2 * N + 1)) with ij.1 ≤ N ∧ ij.2 ≤ N,
-      ((ij.1.factorial : ℚ)⁻¹ * (ij.2.factorial : ℚ)⁻¹) • (a ^ ij.1 * b ^ ij.2) =
-        ∑ ij ∈ (range (N + 1)).product (range (N + 1)), ((ij.1.factorial : ℚ)⁻¹ *
-      (ij.2.factorial : ℚ)⁻¹) • (a ^ ij.1 * b ^ ij.2) := by
+  have restrict: ∑ ij ∈ R2N ×ˢ R2N with ij.1 ≤ N ∧ ij.2 ≤ N,
+      ((ij.1 ! : ℚ)⁻¹ * (ij.2 ! : ℚ)⁻¹) • (a ^ ij.1 * b ^ ij.2) =
+        ∑ ij ∈ RN ×ˢ RN, ((ij.1 ! : ℚ)⁻¹ * (ij.2 ! : ℚ)⁻¹) • (a ^ ij.1 * b ^ ij.2) := by
     apply sum_congr
     · ext x
-      simp only [product_eq_sprod, mem_filter, mem_product, mem_range]
-      constructor <;> omega
-    · (intro _ _; rfl)
-  simp only [product_eq_sprod] at restrict
+      simp only [mem_filter, mem_product, mem_range, hR2N, hRN]
+      omega
+    · tauto
   rw [restrict] at s₁
-  have s₂ := calc
-    (∑ i ∈ range (N + 1), (i.factorial : ℚ)⁻¹ • a ^ i) * ∑ i ∈ range (N + 1),
-      (i.factorial : ℚ)⁻¹ • b ^ i = ∑ i ∈ range (N + 1), ∑ j ∈ range (N + 1),
-        ((i.factorial : ℚ)⁻¹ * (j.factorial : ℚ)⁻¹) • (a ^ i * b ^ j) := by
-      rw [sum_mul_sum]
-      apply sum_congr rfl
-      intro _ _
-      apply sum_congr rfl
-      intro _ _
+  have s₂ := by
+    calc (∑ i ∈ RN, (i ! : ℚ)⁻¹ • a ^ i) * ∑ i ∈ RN, (i ! : ℚ)⁻¹ • b ^ i
+        = ∑ i ∈ RN, ∑ j ∈ RN, ((i ! : ℚ)⁻¹ * (j ! : ℚ)⁻¹) • (a ^ i * b ^ j) := ?_
+      _ = ∑ ij ∈ RN ×ˢ RN, ((ij.1 ! : ℚ)⁻¹ * (ij.2 ! : ℚ)⁻¹) • (a ^ ij.1 * b ^ ij.2) := ?_
+    · rw [sum_mul_sum]
+      refine sum_congr rfl fun _ _ ↦ sum_congr rfl fun _ _ ↦ ?_
       rw [smul_mul_assoc, Algebra.mul_smul_comm, smul_smul]
-    _ = ∑ ij ∈ (range (N + 1)).product (range (N + 1)), ((ij.1.factorial : ℚ)⁻¹ *
-          (ij.2.factorial : ℚ)⁻¹) • (a ^ ij.1 * b ^ ij.2) := by
-      rw [sum_sigma']
-      apply sum_bijective (fun ⟨i, j⟩ => (i, j))
-      exact ⟨fun ⟨i, j⟩ ⟨i', j'⟩ h => by cases h; rfl, fun ⟨i, j⟩ => ⟨⟨i, j⟩, rfl⟩⟩
-      · simp only [mem_sigma, product_eq_sprod, mem_product, implies_true]
-      simp only [implies_true]
-  simp only [product_eq_sprod] at s₂
-  rw [s₂.symm] at s₁
-  exact s₁
+    · rw [sum_sigma']
+      apply sum_bijective (fun ⟨i, j⟩ ↦ (i, j))
+      · exact ⟨fun ⟨i, j⟩ ⟨i', j'⟩ h ↦ by cases h; rfl, fun ⟨i, j⟩ ↦ ⟨⟨i, j⟩, rfl⟩⟩
+      · simp only [mem_sigma, mem_product, implies_true]
+      · simp only [implies_true]
+  rwa [s₂.symm] at s₁
 
 theorem exp_of_nilpotent_is_unit {a : A} (h : IsNilpotent a) : IsUnit (exp a) := by
   have h₁ : Commute a (-a) := Commute.neg_right rfl

--- a/Mathlib/Algebra/Algebra/Exp.lean
+++ b/Mathlib/Algebra/Algebra/Exp.lean
@@ -1,25 +1,10 @@
-/-
-Copyright (c) 2018 Kenny Lau. All rights reserved.
-Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Kenny Lau, Yury Kudryashov
--/
 import Mathlib.Algebra.Algebra.Defs
-import Mathlib.Algebra.Module.Equiv.Basic
-import Mathlib.Algebra.Module.Submodule.Ker
-import Mathlib.Algebra.Module.Submodule.RestrictScalars
-import Mathlib.Algebra.Module.ULift
-import Mathlib.Algebra.Ring.CharZero
-import Mathlib.Algebra.Ring.Subring.Basic
-import Mathlib.Data.Nat.Cast.Order.Basic
-import Mathlib.Data.Int.CharZero
-import Mathlib.RingTheory.Nilpotent.Defs
+import Mathlib.Algebra.BigOperators.Group.Finset.Basic
+import Mathlib.Algebra.Field.Defs
+import Mathlib.Data.Finset.Basic
 import Mathlib.Data.Nat.Factorial.Basic
+import Mathlib.RingTheory.Nilpotent.Defs
 
-/-!
-# Further basic results about `Algebra`.
-
-This file could usefully be split further.
--/
 namespace Algebra
 
 section Exp
@@ -34,7 +19,9 @@ theorem well_def {k : ℕ} (a : A) (h : a ^ k = 0) :
     ∑ n ∈ Finset.range k, (Nat.factorial n : R)⁻¹ • (a ^ n) = exp R A a := by
   sorry
 
--- theorem add_pow (h : Commute x y) (n : ℕ) :
+-- useful: add_pow_eq_zero_of_add_le_succ_of_pow_eq_zero
+-- useful: add_pow (h : Commute x y) (n : ℕ) : ...
+-- useful: isNilpotent_add (h_comm : Commute x y) ...
 theorem exp_add_mul (a b : A) (h₁ : Commute a b) (h₂ : IsNilpotent a) (h₃ : IsNilpotent b) :
     exp R A (a + b) = exp R A a * exp R A b := by
   sorry

--- a/Mathlib/Algebra/Algebra/Exp.lean
+++ b/Mathlib/Algebra/Algebra/Exp.lean
@@ -1,0 +1,44 @@
+/-
+Copyright (c) 2018 Kenny Lau. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kenny Lau, Yury Kudryashov
+-/
+import Mathlib.Algebra.Algebra.Defs
+import Mathlib.Algebra.Module.Equiv.Basic
+import Mathlib.Algebra.Module.Submodule.Ker
+import Mathlib.Algebra.Module.Submodule.RestrictScalars
+import Mathlib.Algebra.Module.ULift
+import Mathlib.Algebra.Ring.CharZero
+import Mathlib.Algebra.Ring.Subring.Basic
+import Mathlib.Data.Nat.Cast.Order.Basic
+import Mathlib.Data.Int.CharZero
+import Mathlib.RingTheory.Nilpotent.Defs
+
+/-!
+# Further basic results about `Algebra`.
+
+This file could usefully be split further.
+-/
+
+universe u v w u₁ v₁
+
+open Function
+
+namespace Algebra
+
+section Exp
+
+variable {R : Type u} {A : Type w}
+variable [Field R] [CharZero R]
+variable [Semiring A] [Algebra R A]
+
+noncomputable def exp (a : A) (h : IsNilpotent a) : A :=
+  a
+  --∑ n in finset.range (nat.find hx + 1), (x^n) / (n! : R)
+
+end Exp
+
+
+end Algebra
+
+open scoped Algebra

--- a/Mathlib/Algebra/Algebra/Exp.lean
+++ b/Mathlib/Algebra/Algebra/Exp.lean
@@ -4,14 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Janos Wolosz
 -/
 import Mathlib.Algebra.Algebra.Defs
-import Mathlib.Algebra.BigOperators.Group.Finset.Basic
 import Mathlib.Algebra.BigOperators.GroupWithZero.Action
-import Mathlib.Algebra.BigOperators.Intervals
-import Mathlib.Algebra.Field.Defs
-import Mathlib.Algebra.Group.Basic
-import Mathlib.RingTheory.Nilpotent.Basic
 import Mathlib.Data.Nat.Cast.Field
-import Mathlib.Data.Sigma.Basic
+import Mathlib.RingTheory.Nilpotent.Basic
 
 /-!
 # Exponential map on algebras
@@ -79,71 +74,64 @@ theorem exp_add_of_commute (a b : A) (h₁ : Commute a b) (h₂ : IsNilpotent a)
   obtain ⟨n₁, hn₁⟩ := h₂
   obtain ⟨n₂, hn₂⟩ := h₃
   let N := n₁ ⊔ n₂
-  have le₁ : n₁ ≤ N + 1 := by omega
-  have le₂ : n₂ ≤ N + 1 := by omega
-  have h₄ : a ^ (N + 1) = 0 := pow_eq_zero_of_le le₁ hn₁
-  have h₅ : b ^ (N + 1) = 0 := pow_eq_zero_of_le le₂ hn₂
-  have le₃ : (N + 1) + (N + 1) ≤ (2 * N + 1) + 1 := by omega
-  have h₆ : (a + b) ^ (2 * N + 1) = 0 :=
-    Commute.add_pow_eq_zero_of_add_le_succ_of_pow_eq_zero h₁ h₄ h₅ le₃
-  rw [← exp_eq_truncated R A (a + b) h₆, ← exp_eq_truncated R A a h₄, ← exp_eq_truncated R A b h₅]
-  have s₁ :=
-    calc
-      ∑ i ∈ range (2 * N + 1), (i.factorial : R)⁻¹ • (a + b) ^ i
-          = ∑ i ∈ range (2 * N + 1), (i.factorial : R)⁻¹ •
-            (∑ j ∈ range (i + 1), a ^ j * b ^ (i - j) * i.choose j) := by
-        apply sum_congr rfl
-        intros n hn
-        rw [Commute.add_pow h₁ n]
-      _ = ∑ i ∈ range (2 * N + 1), (∑ j ∈ range (i + 1), ((j.factorial : R)⁻¹ *
-            ((i - j).factorial : R)⁻¹) • (a ^ j * b ^ (i - j))) := by
-        apply sum_congr rfl
-        intro i hi
-        rw [smul_sum]
-        apply sum_congr rfl
-        intro j hj
-        simp only [mem_range] at hi hj
-        suffices (i.factorial : R)⁻¹ * (i.choose j) =
-            ((j.factorial : R)⁻¹ * ((i - j).factorial : R)⁻¹) by
-          rw [← Nat.cast_commute (i.choose j), ← this, ← Algebra.mul_smul_comm, ← nsmul_eq_mul,
-          mul_smul, ← smul_assoc, smul_comm, smul_assoc]
-          norm_cast
-        rw [Nat.choose_eq_factorial_div_factorial (Nat.le_of_lt_succ hj), Nat.cast_div, mul_div]
-        · rw [inv_mul_cancel₀ (mod_cast Nat.factorial_ne_zero i), Nat.cast_mul, one_div,
-          mul_inv_rev, mul_comm]
-        · exact Nat.factorial_mul_factorial_dvd_factorial (Nat.le_of_lt_succ hj)
-        rw [Nat.cast_mul]
-        apply mul_ne_zero <;> exact_mod_cast Nat.factorial_ne_zero _
-      _ = ∑ ij ∈ (range (2 * N + 1)).product (range (2 * N + 1)) with ij.1 + ij.2 <= 2 * N,
-            ((ij.1.factorial : R)⁻¹ * (ij.2.factorial : R)⁻¹) • (a ^ ij.1 * b ^ ij.2) := by
-        rw [sum_sigma']
-        apply sum_bij (fun ⟨i, j⟩ _ => (j, i - j))
-        · simp only [mem_sigma, mem_range, product_eq_sprod, mem_filter, mem_product, and_imp]
-          intro _ _ _
-          omega
-        · simp only [mem_sigma, mem_range, Prod.mk.injEq, and_imp]
-          (intro _ _ _ _ _ _ h _; exact Sigma.ext (by omega) (heq_of_eq h))
-        · simp only [product_eq_sprod, mem_filter, mem_product, mem_range, mem_sigma, exists_prop,
-            Sigma.exists, and_imp, Prod.forall, Prod.mk.injEq]
-          (intro h₁ h₂ _ _ _; use h₁ + h₂, h₁; omega)
-        simp only [mem_sigma, mem_range, implies_true]
+  have h₄ : a ^ (N + 1) = 0 := pow_eq_zero_of_le (by omega) hn₁
+  have h₅ : b ^ (N + 1) = 0 := pow_eq_zero_of_le (by omega) hn₂
+  rw [← exp_eq_truncated R A (k := 2 * N + 1) (a + b)
+  (Commute.add_pow_eq_zero_of_add_le_succ_of_pow_eq_zero h₁ h₄ h₅ (by omega)),
+  ← exp_eq_truncated R A a h₄, ← exp_eq_truncated R A b h₅]
+  have s₁ := calc
+    ∑ i ∈ range (2 * N + 1), (i.factorial : R)⁻¹ • (a + b) ^ i =
+      ∑ i ∈ range (2 * N + 1), (i.factorial : R)⁻¹ •
+        (∑ j ∈ range (i + 1), a ^ j * b ^ (i - j) * i.choose j) := by
+      apply sum_congr rfl
+      intro i _
+      rw [Commute.add_pow h₁ i]
+    _ = ∑ i ∈ range (2 * N + 1), (∑ j ∈ range (i + 1), ((j.factorial : R)⁻¹ *
+          ((i - j).factorial : R)⁻¹) • (a ^ j * b ^ (i - j))) := by
+      apply sum_congr rfl
+      intro i hi
+      rw [smul_sum]
+      apply sum_congr rfl
+      intro j hj
+      simp only [mem_range] at hi hj
+      suffices (i.factorial : R)⁻¹ * (i.choose j) =
+          ((j.factorial : R)⁻¹ * ((i - j).factorial : R)⁻¹) by
+        rw [← Nat.cast_commute (i.choose j), ← this, ← Algebra.mul_smul_comm, ← nsmul_eq_mul,
+        mul_smul, ← smul_assoc, smul_comm, smul_assoc]
+        norm_cast
+      rw [Nat.choose_eq_factorial_div_factorial (Nat.le_of_lt_succ hj), Nat.cast_div, mul_div]
+      · rw [inv_mul_cancel₀ (mod_cast Nat.factorial_ne_zero i), Nat.cast_mul, one_div,
+        mul_inv_rev, mul_comm]
+      · exact Nat.factorial_mul_factorial_dvd_factorial (Nat.le_of_lt_succ hj)
+      rw [Nat.cast_mul]
+      apply mul_ne_zero <;> exact_mod_cast Nat.factorial_ne_zero _
+    _ = ∑ ij ∈ (range (2 * N + 1)).product (range (2 * N + 1)) with ij.1 + ij.2 <= 2 * N,
+          ((ij.1.factorial : R)⁻¹ * (ij.2.factorial : R)⁻¹) • (a ^ ij.1 * b ^ ij.2) := by
+      rw [sum_sigma']
+      apply sum_bij (fun ⟨i, j⟩ _ => (j, i - j))
+      · simp only [mem_sigma, mem_range, product_eq_sprod, mem_filter, mem_product, and_imp]
+        (intro _ _ _; omega)
+      · simp only [mem_sigma, mem_range, Prod.mk.injEq, and_imp]
+        (intro _ _ _ _ _ _ h _; exact Sigma.ext (by omega) (heq_of_eq h))
+      · simp only [product_eq_sprod, mem_filter, mem_product, mem_range, mem_sigma, exists_prop,
+          Sigma.exists, and_imp, Prod.forall, Prod.mk.injEq]
+        (intro h₁ h₂ _ _ _; use h₁ + h₂, h₁; omega)
+      simp only [mem_sigma, mem_range, implies_true]
   have z₁ : ∑ ij ∈ ((range (2 * N + 1)).product (range (2 * N + 1))) with ¬ ij.1 + ij.2 ≤ 2 * N,
-      ((ij.1.factorial : R)⁻¹ * (ij.2.factorial : R)⁻¹) • (a ^ ij.1 * b ^ ij.2) = 0 := by
-    apply sum_eq_zero
-    intro i hi
-    rw [mem_filter] at hi
-    cases le_or_lt (N + 1) i.1 with
-      | inl h => rw [pow_eq_zero_of_le h h₄, zero_mul, smul_zero]
-      | inr _ => rw [pow_eq_zero_of_le (by linarith) h₅, mul_zero, smul_zero]
+      ((ij.1.factorial : R)⁻¹ * (ij.2.factorial : R)⁻¹) • (a ^ ij.1 * b ^ ij.2) = 0 :=
+    sum_eq_zero fun i hi ↦ by
+      rw [mem_filter] at hi
+      cases le_or_lt (N + 1) i.1 with
+        | inl h => rw [pow_eq_zero_of_le h h₄, zero_mul, smul_zero]
+        | inr _ => rw [pow_eq_zero_of_le (by linarith) h₅, mul_zero, smul_zero]
   have split₁ := sum_filter_add_sum_filter_not ((range (2 * N + 1)).product (range (2 * N + 1)))
     (fun ij => ij.1 + ij.2 ≤ 2 * N)
     (fun ij => ((ij.1.factorial : R)⁻¹ * (ij.2.factorial : R)⁻¹) • (a ^ ij.1 * b ^ ij.2))
   rw [z₁, product_eq_sprod, add_zero] at split₁
   rw [product_eq_sprod, split₁] at s₁
   have z₂ : ∑ ij ∈ ((range (2 * N + 1)).product (range (2 * N + 1))) with ¬ (ij.1 ≤ N ∧ ij.2 ≤ N),
-      ((ij.1.factorial : R)⁻¹ * (ij.2.factorial : R)⁻¹) • (a ^ ij.1 * b ^ ij.2) = 0 := by
-    apply sum_eq_zero
-    intro i hi
+      ((ij.1.factorial : R)⁻¹ * (ij.2.factorial : R)⁻¹) • (a ^ ij.1 * b ^ ij.2) = 0 :=
+    sum_eq_zero fun i hi ↦ by
     simp only [not_and, not_le, mem_filter] at hi
     cases le_or_lt (N + 1) i.1 with
       | inl h => rw [pow_eq_zero_of_le h h₄, zero_mul, smul_zero]
@@ -161,35 +149,26 @@ theorem exp_add_of_commute (a b : A) (h₁ : Commute a b) (h₂ : IsNilpotent a)
     · ext x
       simp only [product_eq_sprod, mem_filter, mem_product, mem_range]
       constructor <;> omega
-    · intro x hx
-      rfl
+    · (intro _ _; rfl)
   simp only [product_eq_sprod] at restrict
   rw [restrict] at s₁
-  have s₂ :=
-    calc
-      (∑ i ∈ range (N + 1), (i.factorial : R)⁻¹ • a ^ i) * ∑ i ∈ range (N + 1),
-        (i.factorial : R)⁻¹ • b ^ i =
-      ∑ i ∈ range (N + 1), ∑ j ∈ range (N + 1), ((i.factorial : R)⁻¹ * (j.factorial : R)⁻¹) •
-        (a ^ i * b ^ j) := by
-        rw [sum_mul_sum]
-        apply sum_congr rfl
-        intro n hn
-        apply sum_congr rfl
-        intro m hm
-        rw [smul_mul_assoc, Algebra.mul_smul_comm, smul_smul]
-      _ = ∑ ij ∈ (range (N + 1)).product (range (N + 1)), ((ij.1.factorial : R)⁻¹ *
+  have s₂ := calc
+    (∑ i ∈ range (N + 1), (i.factorial : R)⁻¹ • a ^ i) * ∑ i ∈ range (N + 1),
+      (i.factorial : R)⁻¹ • b ^ i = ∑ i ∈ range (N + 1), ∑ j ∈ range (N + 1),
+        ((i.factorial : R)⁻¹ * (j.factorial : R)⁻¹) • (a ^ i * b ^ j) := by
+      rw [sum_mul_sum]
+      apply sum_congr rfl
+      intro _ _
+      apply sum_congr rfl
+      intro _ _
+      rw [smul_mul_assoc, Algebra.mul_smul_comm, smul_smul]
+    _ = ∑ ij ∈ (range (N + 1)).product (range (N + 1)), ((ij.1.factorial : R)⁻¹ *
           (ij.2.factorial : R)⁻¹) • (a ^ ij.1 * b ^ ij.2) := by
-        rw [sum_sigma']
-        apply sum_bij (fun ⟨i, j⟩ _ => (i, j))
-        · simp only [mem_sigma, product_eq_sprod, mem_product, imp_self, implies_true]
-        · simp only [mem_sigma, Prod.mk.injEq, and_imp]
-          intro _ _ _ _ _ _ h₁ h₂
-          exact Sigma.ext h₁ (heq_of_eq h₂)
-        · simp only [product_eq_sprod, mem_product, mem_range, mem_sigma, exists_prop,
-          Sigma.exists, and_imp, Prod.forall, Prod.mk.injEq, exists_eq_right_right, exists_eq_right]
-          intro _ _ h₁ h₂
-          exact ⟨h₁, h₂⟩
-        simp only [implies_true]
+      rw [sum_sigma']
+      apply sum_bijective (fun ⟨i, j⟩ => (i, j))
+      exact ⟨fun ⟨i, j⟩ ⟨i', j'⟩ h => by cases h; rfl, fun ⟨i, j⟩ => ⟨⟨i, j⟩, rfl⟩⟩
+      · simp only [mem_sigma, product_eq_sprod, mem_product, implies_true]
+      simp only [implies_true]
   simp only [product_eq_sprod] at s₂
   rw [s₂.symm] at s₁
   exact s₁

--- a/Mathlib/Algebra/Algebra/Exp.lean
+++ b/Mathlib/Algebra/Algebra/Exp.lean
@@ -37,7 +37,7 @@ noncomputable def exp (a : A) : A :=
 
 
 theorem wellDef {k : ℕ} (a : A) (h : a ^ k = 0) :
-    exp R A a  = ∑ n ∈ Finset.range k, (Nat.factorial n : R)⁻¹ • (a ^ n) := by
+    ∑ n ∈ Finset.range k, (Nat.factorial n : R)⁻¹ • (a ^ n) = exp R A a := by
   sorry
 
 theorem mul_add (a b : A) (h : a * b = b * a) (IsNilpotent a : A) (IsNilpotent b : A) :

--- a/Mathlib/Algebra/Algebra/Exp.lean
+++ b/Mathlib/Algebra/Algebra/Exp.lean
@@ -12,7 +12,6 @@ import Mathlib.Algebra.Group.Basic
 import Mathlib.RingTheory.Nilpotent.Basic
 import Mathlib.Data.Nat.Cast.Field
 import Mathlib.Data.Sigma.Basic
-import LeanCopilot
 
 /-!
 # Exponential map on algebras

--- a/Mathlib/Algebra/Algebra/Exp.lean
+++ b/Mathlib/Algebra/Algebra/Exp.lean
@@ -49,7 +49,7 @@ It provides meaningful (non-junk) values for nilpotent elements. -/
 noncomputable def exp (a : A) : A :=
   ∑ i ∈ range (nilpotencyClass a), (i.factorial : R)⁻¹ • (a ^ i)
 
-theorem exp_eq_truncated {k : ℕ} (a : A) (h : a ^ k = 0) :
+theorem exp_eq_truncated {a : A} {k : ℕ}  (h : a ^ k = 0) :
     ∑ i ∈ range k, (i.factorial : R)⁻¹ • (a ^ i) = exp R A a := by
   have h₁ : ∑ i ∈ range k, (i.factorial : R)⁻¹ • (a ^ i) =
       ∑ i ∈ range (nilpotencyClass a), (i.factorial : R)⁻¹ • (a ^ i) +
@@ -62,23 +62,23 @@ theorem exp_eq_truncated {k : ℕ} (a : A) (h : a ^ k = 0) :
     rw [pow_eq_zero_of_le (mem_Ico.1 h₂).1 (pow_nilpotencyClass ⟨k, h⟩), smul_zero]
 
 theorem exp_zero_eq_one : exp R A 0 = 1 := by
-  have h₁ := exp_eq_truncated R A (0 : A) (pow_one 0)
+  have h₁ := exp_eq_truncated R A (pow_one 0)
   rw [range_one, sum_singleton, Nat.factorial_zero, Nat.cast_one, inv_one, pow_zero,
     one_smul] at h₁
   exact h₁.symm
 
 variable [CharZero R]
 
-theorem exp_add_of_commute (a b : A) (h₁ : Commute a b) (h₂ : IsNilpotent a) (h₃ : IsNilpotent b) :
+theorem exp_add_of_commute {a b : A} (h₁ : Commute a b) (h₂ : IsNilpotent a) (h₃ : IsNilpotent b) :
     exp R A (a + b) = exp R A a * exp R A b := by
   obtain ⟨n₁, hn₁⟩ := h₂
   obtain ⟨n₂, hn₂⟩ := h₃
   let N := n₁ ⊔ n₂
   have h₄ : a ^ (N + 1) = 0 := pow_eq_zero_of_le (by omega) hn₁
   have h₅ : b ^ (N + 1) = 0 := pow_eq_zero_of_le (by omega) hn₂
-  rw [← exp_eq_truncated R A (k := 2 * N + 1) (a + b)
+  rw [← exp_eq_truncated R A (k := 2 * N + 1)
   (Commute.add_pow_eq_zero_of_add_le_succ_of_pow_eq_zero h₁ h₄ h₅ (by omega)),
-  ← exp_eq_truncated R A a h₄, ← exp_eq_truncated R A b h₅]
+  ← exp_eq_truncated R A h₄, ← exp_eq_truncated R A h₅]
   have s₁ := calc
     ∑ i ∈ range (2 * N + 1), (i.factorial : R)⁻¹ • (a + b) ^ i =
       ∑ i ∈ range (2 * N + 1), (i.factorial : R)⁻¹ •
@@ -180,14 +180,14 @@ section RingAlgebras
 variable [CharZero R]
 variable [Ring A] [Algebra R A]
 
-theorem exp_of_nilpotent_is_unit (a : A) (h : IsNilpotent a) : IsUnit (exp R A a) := by
+theorem exp_of_nilpotent_is_unit {a : A} (h : IsNilpotent a) : IsUnit (exp R A a) := by
   have h₁ : Commute a (-a) := Commute.neg_right rfl
   have h₂ : IsNilpotent (-a) := IsNilpotent.neg h
-  have h₃ := exp_add_of_commute R A a (-a) h₁ h h₂
+  have h₃ := exp_add_of_commute R A h₁ h h₂
   rw [add_neg_cancel a, exp_zero_eq_one] at h₃
   apply isUnit_iff_exists.2
   refine ⟨exp R A (-a), h₃.symm, ?_⟩
-  rw [← exp_add_of_commute R A (-a) a h₁.symm h₂ h, neg_add_cancel a, exp_zero_eq_one]
+  rw [← exp_add_of_commute R A h₁.symm h₂ h, neg_add_cancel a, exp_zero_eq_one]
 
 end RingAlgebras
 

--- a/Mathlib/Algebra/Algebra/Exp.lean
+++ b/Mathlib/Algebra/Algebra/Exp.lean
@@ -40,11 +40,11 @@ theorem wellDef {k : ℕ} (a : A) (h : a ^ k = 0) :
     ∑ n ∈ Finset.range k, (Nat.factorial n : R)⁻¹ • (a ^ n) = exp R A a := by
   sorry
 
-theorem mul_add (a b : A) (h : a * b = b * a) (IsNilpotent a : A) (IsNilpotent b : A) :
+theorem mul_add (a b : A) (h : a * b = b * a) (h1 : IsNilpotent a) (h2 : IsNilpotent b) :
     exp R A (a + b) = exp R A a * exp R A b := by
   sorry
 
-theorem exp_inv (a : A) (IsNilpotent a : A) : IsUnit (exp R A a) := by
+theorem exp_inv (a : A) (h : IsNilpotent a) : IsUnit (exp R A a) := by
   sorry
 
 end Exp

--- a/Mathlib/Algebra/Algebra/Exp.lean
+++ b/Mathlib/Algebra/Algebra/Exp.lean
@@ -31,71 +31,62 @@ Furthermore, in case `A` is a ring (rather than a general semiring) and `a` is n
 algebra, exponential map, nilpotent
 -/
 
-universe u v
-
 namespace Algebra
 
-variable (R : Type u) [Field R]
-variable (A : Type v)
+variable {A : Type*} [Ring A] [Algebra ℚ A]
 
 open Finset
-
-section SemiringAlgebras
-
-variable [Semiring A] [Algebra R A]
 
 /-- The exponential map on algebras, defined in analogy with the usual exponential series.
 It provides meaningful (non-junk) values for nilpotent elements. -/
 noncomputable def exp (a : A) : A :=
-  ∑ i ∈ range (nilpotencyClass a), (i.factorial : R)⁻¹ • (a ^ i)
+  ∑ i ∈ range (nilpotencyClass a), (i.factorial : ℚ)⁻¹ • (a ^ i)
 
 theorem exp_eq_truncated {a : A} {k : ℕ}  (h : a ^ k = 0) :
-    ∑ i ∈ range k, (i.factorial : R)⁻¹ • (a ^ i) = exp R A a := by
-  have h₁ : ∑ i ∈ range k, (i.factorial : R)⁻¹ • (a ^ i) =
-      ∑ i ∈ range (nilpotencyClass a), (i.factorial : R)⁻¹ • (a ^ i) +
-        ∑ i ∈ Ico (nilpotencyClass a) k, (i.factorial : R)⁻¹ • (a ^ i) :=
+    ∑ i ∈ range k, (i.factorial : ℚ)⁻¹ • (a ^ i) = exp a := by
+  have h₁ : ∑ i ∈ range k, (i.factorial : ℚ)⁻¹ • (a ^ i) =
+      ∑ i ∈ range (nilpotencyClass a), (i.factorial : ℚ)⁻¹ • (a ^ i) +
+        ∑ i ∈ Ico (nilpotencyClass a) k, (i.factorial : ℚ)⁻¹ • (a ^ i) :=
     (sum_range_add_sum_Ico _ (csInf_le' h)).symm
-  suffices ∑ i ∈ Ico (nilpotencyClass a) k, (i.factorial : R)⁻¹ • (a ^ i) = 0 by
+  suffices ∑ i ∈ Ico (nilpotencyClass a) k, (i.factorial : ℚ)⁻¹ • (a ^ i) = 0 by
     dsimp [exp]
     rw [h₁, this, add_zero]
   exact sum_eq_zero fun _ h₂ => by
     rw [pow_eq_zero_of_le (mem_Ico.1 h₂).1 (pow_nilpotencyClass ⟨k, h⟩), smul_zero]
 
-theorem exp_zero_eq_one : exp R A 0 = 1 := by
-  have h₁ := exp_eq_truncated R A (pow_one 0)
+theorem exp_zero_eq_one : exp (0 : A) = 1 := by
+  have h₁ := exp_eq_truncated (pow_one (0 : A))
   rw [range_one, sum_singleton, Nat.factorial_zero, Nat.cast_one, inv_one, pow_zero,
     one_smul] at h₁
   exact h₁.symm
 
-variable [CharZero R]
-
 theorem exp_add_of_commute {a b : A} (h₁ : Commute a b) (h₂ : IsNilpotent a) (h₃ : IsNilpotent b) :
-    exp R A (a + b) = exp R A a * exp R A b := by
+    exp (a + b) = exp a * exp b := by
   obtain ⟨n₁, hn₁⟩ := h₂
   obtain ⟨n₂, hn₂⟩ := h₃
   let N := n₁ ⊔ n₂
   have h₄ : a ^ (N + 1) = 0 := pow_eq_zero_of_le (by omega) hn₁
   have h₅ : b ^ (N + 1) = 0 := pow_eq_zero_of_le (by omega) hn₂
-  rw [← exp_eq_truncated R A (k := 2 * N + 1)
+  rw [← exp_eq_truncated (k := 2 * N + 1)
   (Commute.add_pow_eq_zero_of_add_le_succ_of_pow_eq_zero h₁ h₄ h₅ (by omega)),
-  ← exp_eq_truncated R A h₄, ← exp_eq_truncated R A h₅]
+  ← exp_eq_truncated h₄, ← exp_eq_truncated h₅]
   have s₁ := calc
-    ∑ i ∈ range (2 * N + 1), (i.factorial : R)⁻¹ • (a + b) ^ i =
-      ∑ i ∈ range (2 * N + 1), (i.factorial : R)⁻¹ •
+    ∑ i ∈ range (2 * N + 1), (i.factorial : ℚ)⁻¹ • (a + b) ^ i =
+      ∑ i ∈ range (2 * N + 1), (i.factorial : ℚ)⁻¹ •
         (∑ j ∈ range (i + 1), a ^ j * b ^ (i - j) * i.choose j) := by
       apply sum_congr rfl
       intro i _
       rw [Commute.add_pow h₁ i]
-    _ = ∑ i ∈ range (2 * N + 1), (∑ j ∈ range (i + 1), ((j.factorial : R)⁻¹ *
-          ((i - j).factorial : R)⁻¹) • (a ^ j * b ^ (i - j))) := by
+    _ = ∑ i ∈ range (2 * N + 1), (∑ j ∈ range (i + 1), ((j.factorial : ℚ)⁻¹ *
+          ((i - j).factorial : ℚ)⁻¹) • (a ^ j * b ^ (i - j))) := by
       apply sum_congr rfl
       intro i hi
       rw [smul_sum]
       apply sum_congr rfl
       intro j hj
       simp only [mem_range] at hi hj
-      suffices (i.factorial : R)⁻¹ * (i.choose j) =
-          ((j.factorial : R)⁻¹ * ((i - j).factorial : R)⁻¹) by
+      suffices (i.factorial : ℚ)⁻¹ * (i.choose j) =
+          ((j.factorial : ℚ)⁻¹ * ((i - j).factorial : ℚ)⁻¹) by
         rw [← Nat.cast_commute (i.choose j), ← this, ← Algebra.mul_smul_comm, ← nsmul_eq_mul,
         mul_smul, ← smul_assoc, smul_comm, smul_assoc]
         norm_cast
@@ -106,7 +97,7 @@ theorem exp_add_of_commute {a b : A} (h₁ : Commute a b) (h₂ : IsNilpotent a)
       rw [Nat.cast_mul]
       apply mul_ne_zero <;> exact_mod_cast Nat.factorial_ne_zero _
     _ = ∑ ij ∈ (range (2 * N + 1)).product (range (2 * N + 1)) with ij.1 + ij.2 <= 2 * N,
-          ((ij.1.factorial : R)⁻¹ * (ij.2.factorial : R)⁻¹) • (a ^ ij.1 * b ^ ij.2) := by
+          ((ij.1.factorial : ℚ)⁻¹ * (ij.2.factorial : ℚ)⁻¹) • (a ^ ij.1 * b ^ ij.2) := by
       rw [sum_sigma']
       apply sum_bij (fun ⟨i, j⟩ _ => (j, i - j))
       · simp only [mem_sigma, mem_range, product_eq_sprod, mem_filter, mem_product, and_imp]
@@ -118,7 +109,7 @@ theorem exp_add_of_commute {a b : A} (h₁ : Commute a b) (h₂ : IsNilpotent a)
         (intro h₁ h₂ _ _ _; use h₁ + h₂, h₁; omega)
       simp only [mem_sigma, mem_range, implies_true]
   have z₁ : ∑ ij ∈ ((range (2 * N + 1)).product (range (2 * N + 1))) with ¬ ij.1 + ij.2 ≤ 2 * N,
-      ((ij.1.factorial : R)⁻¹ * (ij.2.factorial : R)⁻¹) • (a ^ ij.1 * b ^ ij.2) = 0 :=
+      ((ij.1.factorial : ℚ)⁻¹ * (ij.2.factorial : ℚ)⁻¹) • (a ^ ij.1 * b ^ ij.2) = 0 :=
     sum_eq_zero fun i hi ↦ by
       rw [mem_filter] at hi
       cases le_or_lt (N + 1) i.1 with
@@ -126,11 +117,11 @@ theorem exp_add_of_commute {a b : A} (h₁ : Commute a b) (h₂ : IsNilpotent a)
         | inr _ => rw [pow_eq_zero_of_le (by linarith) h₅, mul_zero, smul_zero]
   have split₁ := sum_filter_add_sum_filter_not ((range (2 * N + 1)).product (range (2 * N + 1)))
     (fun ij => ij.1 + ij.2 ≤ 2 * N)
-    (fun ij => ((ij.1.factorial : R)⁻¹ * (ij.2.factorial : R)⁻¹) • (a ^ ij.1 * b ^ ij.2))
+    (fun ij => ((ij.1.factorial : ℚ)⁻¹ * (ij.2.factorial : ℚ)⁻¹) • (a ^ ij.1 * b ^ ij.2))
   rw [z₁, product_eq_sprod, add_zero] at split₁
   rw [product_eq_sprod, split₁] at s₁
   have z₂ : ∑ ij ∈ ((range (2 * N + 1)).product (range (2 * N + 1))) with ¬ (ij.1 ≤ N ∧ ij.2 ≤ N),
-      ((ij.1.factorial : R)⁻¹ * (ij.2.factorial : R)⁻¹) • (a ^ ij.1 * b ^ ij.2) = 0 :=
+      ((ij.1.factorial : ℚ)⁻¹ * (ij.2.factorial : ℚ)⁻¹) • (a ^ ij.1 * b ^ ij.2) = 0 :=
     sum_eq_zero fun i hi ↦ by
     simp only [not_and, not_le, mem_filter] at hi
     cases le_or_lt (N + 1) i.1 with
@@ -138,13 +129,13 @@ theorem exp_add_of_commute {a b : A} (h₁ : Commute a b) (h₂ : IsNilpotent a)
       | inr h => rw [pow_eq_zero_of_le (hi.2 (Nat.le_of_lt_succ h)) h₅, mul_zero, smul_zero]
   have split₂ := sum_filter_add_sum_filter_not ((range (2 * N + 1)).product (range (2 * N + 1)))
     (fun ij => ij.1 ≤ N ∧ ij.2 ≤ N)
-    (fun ij => ((ij.1.factorial : R)⁻¹ * (ij.2.factorial : R)⁻¹) • (a ^ ij.1 * b ^ ij.2))
+    (fun ij => ((ij.1.factorial : ℚ)⁻¹ * (ij.2.factorial : ℚ)⁻¹) • (a ^ ij.1 * b ^ ij.2))
   rw [z₂, product_eq_sprod, add_zero] at split₂
   rw [← split₂] at s₁
   have restrict: ∑ ij ∈ (range (2 * N + 1)).product (range (2 * N + 1)) with ij.1 ≤ N ∧ ij.2 ≤ N,
-      ((ij.1.factorial : R)⁻¹ * (ij.2.factorial : R)⁻¹) • (a ^ ij.1 * b ^ ij.2) =
-        ∑ ij ∈ (range (N + 1)).product (range (N + 1)), ((ij.1.factorial : R)⁻¹ *
-      (ij.2.factorial : R)⁻¹) • (a ^ ij.1 * b ^ ij.2) := by
+      ((ij.1.factorial : ℚ)⁻¹ * (ij.2.factorial : ℚ)⁻¹) • (a ^ ij.1 * b ^ ij.2) =
+        ∑ ij ∈ (range (N + 1)).product (range (N + 1)), ((ij.1.factorial : ℚ)⁻¹ *
+      (ij.2.factorial : ℚ)⁻¹) • (a ^ ij.1 * b ^ ij.2) := by
     apply sum_congr
     · ext x
       simp only [product_eq_sprod, mem_filter, mem_product, mem_range]
@@ -153,17 +144,17 @@ theorem exp_add_of_commute {a b : A} (h₁ : Commute a b) (h₂ : IsNilpotent a)
   simp only [product_eq_sprod] at restrict
   rw [restrict] at s₁
   have s₂ := calc
-    (∑ i ∈ range (N + 1), (i.factorial : R)⁻¹ • a ^ i) * ∑ i ∈ range (N + 1),
-      (i.factorial : R)⁻¹ • b ^ i = ∑ i ∈ range (N + 1), ∑ j ∈ range (N + 1),
-        ((i.factorial : R)⁻¹ * (j.factorial : R)⁻¹) • (a ^ i * b ^ j) := by
+    (∑ i ∈ range (N + 1), (i.factorial : ℚ)⁻¹ • a ^ i) * ∑ i ∈ range (N + 1),
+      (i.factorial : ℚ)⁻¹ • b ^ i = ∑ i ∈ range (N + 1), ∑ j ∈ range (N + 1),
+        ((i.factorial : ℚ)⁻¹ * (j.factorial : ℚ)⁻¹) • (a ^ i * b ^ j) := by
       rw [sum_mul_sum]
       apply sum_congr rfl
       intro _ _
       apply sum_congr rfl
       intro _ _
       rw [smul_mul_assoc, Algebra.mul_smul_comm, smul_smul]
-    _ = ∑ ij ∈ (range (N + 1)).product (range (N + 1)), ((ij.1.factorial : R)⁻¹ *
-          (ij.2.factorial : R)⁻¹) • (a ^ ij.1 * b ^ ij.2) := by
+    _ = ∑ ij ∈ (range (N + 1)).product (range (N + 1)), ((ij.1.factorial : ℚ)⁻¹ *
+          (ij.2.factorial : ℚ)⁻¹) • (a ^ ij.1 * b ^ ij.2) := by
       rw [sum_sigma']
       apply sum_bijective (fun ⟨i, j⟩ => (i, j))
       exact ⟨fun ⟨i, j⟩ ⟨i', j'⟩ h => by cases h; rfl, fun ⟨i, j⟩ => ⟨⟨i, j⟩, rfl⟩⟩
@@ -173,22 +164,13 @@ theorem exp_add_of_commute {a b : A} (h₁ : Commute a b) (h₂ : IsNilpotent a)
   rw [s₂.symm] at s₁
   exact s₁
 
-end SemiringAlgebras
-
-section RingAlgebras
-
-variable [CharZero R]
-variable [Ring A] [Algebra R A]
-
-theorem exp_of_nilpotent_is_unit {a : A} (h : IsNilpotent a) : IsUnit (exp R A a) := by
+theorem exp_of_nilpotent_is_unit {a : A} (h : IsNilpotent a) : IsUnit (exp a) := by
   have h₁ : Commute a (-a) := Commute.neg_right rfl
   have h₂ : IsNilpotent (-a) := IsNilpotent.neg h
-  have h₃ := exp_add_of_commute R A h₁ h h₂
+  have h₃ := exp_add_of_commute h₁ h h₂
   rw [add_neg_cancel a, exp_zero_eq_one] at h₃
   apply isUnit_iff_exists.2
-  refine ⟨exp R A (-a), h₃.symm, ?_⟩
-  rw [← exp_add_of_commute R A h₁.symm h₂ h, neg_add_cancel a, exp_zero_eq_one]
-
-end RingAlgebras
+  refine ⟨exp (-a), h₃.symm, ?_⟩
+  rw [← exp_add_of_commute h₁.symm h₂ h, neg_add_cancel a, exp_zero_eq_one]
 
 end Algebra

--- a/Mathlib/Algebra/Algebra/Exp.lean
+++ b/Mathlib/Algebra/Algebra/Exp.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) 2025 Janos Wolosz. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Janos Wolosz
+-/
 import Mathlib.Algebra.Algebra.Defs
 import Mathlib.Algebra.BigOperators.Group.Finset.Basic
 import Mathlib.Algebra.BigOperators.GroupWithZero.Action
@@ -7,371 +12,222 @@ import Mathlib.Algebra.Group.Basic
 import Mathlib.RingTheory.Nilpotent.Basic
 import Mathlib.Data.Nat.Cast.Field
 import Mathlib.Data.Sigma.Basic
+import LeanCopilot
+
+/-!
+# Exponential map on algebras
+
+This file defines the exponential map `Algebra.exp` on algebras. The definition of `Algebra.exp a`
+applies to any `R`-algebra `A` and any element `a`, though it yields meaningful (non-junk)
+values only when `a` is nilpotent.
+
+When `R` is a characteristic zero field, the theorem `Algebra.exp_add_of_commute` establishes
+the expected connection between the additive and multiplicative structures of `A` for commuting
+nilpotent elements.
+
+Furthermore, in case `A` is a ring (rather than a general semiring) and `a` is nilpotent,
+`Algebra.exp_of_nilpotent_is_unit` shows that `Algebra.exp a` is a unit in `A`.
+
+## Main definitions
+
+  * `Algebra.exp`
+
+## Tags
+
+algebra, exponential map, nilpotent
+-/
+
+universe u v
 
 namespace Algebra
 
-variable (R : Type*) [Field R]
-variable (A : Type*)
+variable (R : Type u) [Field R]
+variable (A : Type v)
 
-section Semi
+open Finset
+
+section SemiringAlgebras
 
 variable [Semiring A] [Algebra R A]
 
-theorem reorder (N : ℕ) {f : ℕ → ℕ → A} : ∑ j ∈ Finset.range (2 * N + 1), ∑ i ∈ Finset.range (j + 1), f i j = ∑ ij ∈ (Finset.range (2 * N + 1)).product (Finset.range (2 * N + 1)) |>.filter (fun ij => ij.1 ≤ ij.2), f ij.1 ij.2 := by
-  rw [Finset.sum_sigma']
-  apply Finset.sum_bij
-    (fun ⟨j, i⟩ _ => (i, j))
-  simp
-  intro h1
-  intro h2
-  intro h3
-  constructor
-  constructor
-  · exact Nat.lt_of_lt_of_le h3 h2
-  · exact h2
-  · exact Nat.le_of_lt_succ h3
-  simp
-  intro h4
-  intro h5
-  intro h6
-  intro h7
-  intro h8
-  intro h9
-  intro h10
-  intro h11
-  · refine Sigma.ext h11 ?_
-    exact heq_of_eq h10
-  simp
-  intro h1
-  intro h2
-  intro h3
-  intro h4
-  intro h5
-  use h2, h1
-  constructor
-  constructor
-  exact h4
-  exact Nat.lt_add_one_of_le h5
-  exact Prod.mk.inj_iff.mp rfl
-  simp
-
+/-- The exponential map on algebras, defined in analogy with the usual exponential series.
+It provides meaningful (non-junk) values for nilpotent elements. -/
 noncomputable def exp (a : A) : A :=
-  ∑ n ∈ Finset.range (nilpotencyClass a), (n.factorial : R)⁻¹ • (a ^ n)
+  ∑ i ∈ range (nilpotencyClass a), (i.factorial : R)⁻¹ • (a ^ i)
 
 theorem exp_eq_truncated {k : ℕ} (a : A) (h : a ^ k = 0) :
-    ∑ n ∈ Finset.range k, (Nat.factorial n : R)⁻¹ • (a ^ n) = exp R A a := by
-  have h₁ : nilpotencyClass a ≤ k := by
-    exact csInf_le' h
-  have h₂ : ∑ n ∈ Finset.range k, (Nat.factorial n : R)⁻¹ • (a ^ n) =
-      ∑ n ∈ Finset.range (nilpotencyClass a), (Nat.factorial n : R)⁻¹ • (a ^ n) +
-        ∑ n ∈ Finset.Ico (nilpotencyClass a) k, (Nat.factorial n : R)⁻¹ • (a ^ n) :=
-    (Finset.sum_range_add_sum_Ico _ h₁).symm
-  suffices h₃ : ∑ n ∈ Finset.Ico (nilpotencyClass a) k, (Nat.factorial n : R)⁻¹ • (a ^ n) = 0 by
+    ∑ i ∈ range k, (i.factorial : R)⁻¹ • (a ^ i) = exp R A a := by
+  have h₁ : ∑ i ∈ range k, (i.factorial : R)⁻¹ • (a ^ i) =
+      ∑ i ∈ range (nilpotencyClass a), (i.factorial : R)⁻¹ • (a ^ i) +
+        ∑ i ∈ Ico (nilpotencyClass a) k, (i.factorial : R)⁻¹ • (a ^ i) :=
+    (sum_range_add_sum_Ico _ (csInf_le' h)).symm
+  suffices ∑ i ∈ Ico (nilpotencyClass a) k, (i.factorial : R)⁻¹ • (a ^ i) = 0 by
     dsimp [exp]
-    rw [h₂, h₃, add_zero]
-  suffices h₅ : ∀ n ∈ Finset.Ico (nilpotencyClass a) k, (Nat.factorial n : R)⁻¹ • (a ^ n) = 0 by
-    apply Finset.sum_eq_zero h₅
-  intro t _
-  have h₆ : nilpotencyClass a ≤ t := by
-    simp_all only [Finset.mem_Ico]
-  suffices h₆ : a ^ t = 0 by
-    simp_all only [Finset.mem_Ico, true_and, smul_zero]
-  have h₈ : IsNilpotent a := by
-    use k
-  have h₉ := pow_nilpotencyClass h₈
-  have h10 : t = nilpotencyClass a + (t - nilpotencyClass a) := by
-    simp_all only [Finset.mem_Ico, true_and, add_tsub_cancel_of_le]
-  rw [h10]
-  rw [pow_add]
-  rw [h₉]
-  exact zero_mul (a ^ (t - nilpotencyClass a))
+    rw [h₁, this, add_zero]
+  exact sum_eq_zero fun _ h₂ => by
+    rw [pow_eq_zero_of_le (mem_Ico.1 h₂).1 (pow_nilpotencyClass ⟨k, h⟩), smul_zero]
 
 theorem exp_zero_eq_one : exp R A 0 = 1 := by
-  have h : (0 : A) ^ 1 = 0 := by
-    exact pow_one 0
-  have h1 := exp_eq_truncated R A (0 : A) h
-  simp at h1
-  apply h1.symm
-
-
-theorem zero_ev {k l : ℕ} {a : A} (h₁ : a ^ k = 0) (h₂ : k ≤ l) : a ^ l = 0 := by
-  obtain ⟨m, rfl⟩ := Nat.exists_eq_add_of_le h₂
-  rw [pow_add, h₁, zero_mul]
+  have h₁ := exp_eq_truncated R A (0 : A) (pow_one 0)
+  rw [range_one, sum_singleton, Nat.factorial_zero, Nat.cast_one, inv_one, pow_zero,
+    one_smul] at h₁
+  exact h₁.symm
 
 variable [CharZero R]
-
-theorem ttttt (n : ℕ) : (n.factorial : R)⁻¹  * (n.factorial : R) = 1 := by
-  have h1 : (n.factorial : R) ≠ 0 := by exact_mod_cast Nat.factorial_ne_zero n
-  simp_all only [ne_eq, Nat.cast_eq_zero, not_false_eq_true, inv_mul_cancel₀]
 
 theorem exp_add_of_commute (a b : A) (h₁ : Commute a b) (h₂ : IsNilpotent a) (h₃ : IsNilpotent b) :
     exp R A (a + b) = exp R A a * exp R A b := by
   obtain ⟨n₁, hn₁⟩ := h₂
   obtain ⟨n₂, hn₂⟩ := h₃
-  let N :=  n₁ ⊔ n₂
-  have huh₁ : n₁ ≤ N + 1 := by
-    refine Nat.le_add_right_of_le ?_
-    simp_all only [le_sup_left, N]
-  have huh₂ : n₂ ≤ N + 1 := by
-    refine Nat.le_add_right_of_le ?_
-    simp_all only [le_sup_right, N]
-  have h₃ : a ^ (N + 1) = 0 := zero_ev A hn₁ huh₁
-  have h₄ : b ^ (N + 1) = 0 := zero_ev A hn₂ huh₂
-  have help : (N + 1) + (N + 1) <= (2 * N + 1) + 1 := by
-    calc (N + 1) + (N + 1) = 2 * (N + 1) := by rw [← Nat.two_mul (N + 1)]
-    _ = 2 * N + 2 := by rw [Nat.mul_add_one]
-    _ = (2 * N + 1) + 1 := by rw [Nat.add_assoc]
-    _ ≤ (2 * N + 1) + 1 := by exact le_refl (2 * N + 2)
-  have h₅ : (a + b) ^ (2 * N + 1) = 0 :=
-    Commute.add_pow_eq_zero_of_add_le_succ_of_pow_eq_zero h₁ h₃ h₄ help
-  rw [← exp_eq_truncated R A (a + b) h₅, ← exp_eq_truncated R A a h₃, ← exp_eq_truncated R A b h₄]
-
- -- have  hh (n : ℕ) (a : A) : n * a = (n : R) • a := by
-  --  norm_cast
-  --  simp_all only [nsmul_eq_mul, N]
-
-  have e₁ :=
+  let N := n₁ ⊔ n₂
+  have le₁ : n₁ ≤ N + 1 := by omega
+  have le₂ : n₂ ≤ N + 1 := by omega
+  have h₄ : a ^ (N + 1) = 0 := pow_eq_zero_of_le le₁ hn₁
+  have h₅ : b ^ (N + 1) = 0 := pow_eq_zero_of_le le₂ hn₂
+  have le₃ : (N + 1) + (N + 1) ≤ (2 * N + 1) + 1 := by omega
+  have h₆ : (a + b) ^ (2 * N + 1) = 0 :=
+    Commute.add_pow_eq_zero_of_add_le_succ_of_pow_eq_zero h₁ h₄ h₅ le₃
+  rw [← exp_eq_truncated R A (a + b) h₆, ← exp_eq_truncated R A a h₄, ← exp_eq_truncated R A b h₅]
+  have s₁ :=
     calc
-      ∑ n ∈ Finset.range (2 * N + 1), (n.factorial : R)⁻¹ • (a + b) ^ n = ∑ n ∈ Finset.range (2 * N + 1), (n.factorial : R)⁻¹ • (a + b) ^ n := rfl
-      _ = ∑ n ∈ Finset.range (2 * N + 1), (n.factorial : R)⁻¹ • (a + b) ^ n := rfl
-      _ = ∑ n ∈ Finset.range (2 * N + 1), (n.factorial : R)⁻¹ • (∑ m ∈ Finset.range (n + 1), a ^ m * b ^ (n - m) * n.choose m) := by
-        apply Finset.sum_congr rfl
+      ∑ i ∈ range (2 * N + 1), (i.factorial : R)⁻¹ • (a + b) ^ i
+          = ∑ i ∈ range (2 * N + 1), (i.factorial : R)⁻¹ •
+            (∑ j ∈ range (i + 1), a ^ j * b ^ (i - j) * i.choose j) := by
+        apply sum_congr rfl
         intros n hn
         rw [Commute.add_pow h₁ n]
-      _ = ∑ n ∈ Finset.range (2 * N + 1), (∑ m ∈ Finset.range (n + 1), (n.factorial : R)⁻¹ • (a ^ m * b ^ (n - m) * n.choose m)) := by
-        apply Finset.sum_congr rfl
+      _ = ∑ i ∈ range (2 * N + 1), (∑ j ∈ range (i + 1), ((j.factorial : R)⁻¹ *
+            ((i - j).factorial : R)⁻¹) • (a ^ j * b ^ (i - j))) := by
+        apply sum_congr rfl
         intro n hn
-        rw [Finset.smul_sum]
-      _ = ∑ n ∈ Finset.range (2 * N + 1), (∑ m ∈ Finset.range (n + 1), ((m.factorial : R)⁻¹ * ((n - m).factorial : R)⁻¹) • (a ^ m * b ^ (n - m))) := by
-        apply Finset.sum_congr rfl
-        intro n hn
-        apply Finset.sum_congr rfl
+        rw [smul_sum]
+        apply sum_congr rfl
         intro m hm
-        have hhh0 : a ^ m * b ^ (n - m) * (n.choose m) = (n.choose m) * (a ^ m * b ^ (n - m)) := by
-          rw [Nat.cast_commute (n.choose m)]
-
-        have  hh (n : ℕ) (a : A) : n * a = (n : R) • a := by
-          norm_cast
-          simp
-        have hhh : (n.factorial : R)⁻¹ • (a ^ m * b ^ (n - m) * (n.choose m)) = ((n.factorial : R)⁻¹ * (n.choose m)) • (a ^ m * b ^ (n - m)) := by
-          rw [hhh0]
-          rw [hh (n.choose m)]
-          rw [← smul_assoc]
-          norm_cast
-        rw [hhh]
-        suffices h11 : (n.factorial : R)⁻¹ * (n.choose m) = ((m.factorial : R)⁻¹ * ((n - m).factorial : R)⁻¹) by
-          simp_all only [Finset.mem_range, N]
-        have t : m ≤ n := by
-          simp_all only [Finset.mem_range, N]
-          omega
-        rw [Nat.choose_eq_factorial_div_factorial t]
-        rw [Nat.cast_div]
-        rw [mul_div]
-        have qqq := ttttt R n
-        rw [qqq]
-        simp
-        rw [mul_comm]
-        apply Nat.factorial_mul_factorial_dvd_factorial
-        apply t
+        simp_all only [mem_range]
+        suffices (n.factorial : R)⁻¹ * (n.choose m) =
+            ((m.factorial : R)⁻¹ * ((n - m).factorial : R)⁻¹) by
+          have help : (n.factorial : R)⁻¹ • (a ^ m * b ^ (n - m) * (n.choose m)) =
+              ((n.factorial : R)⁻¹ * (n.choose m)) • (a ^ m * b ^ (n - m)) := by
+            rw [← Nat.cast_commute (n.choose m), mul_smul]
+            norm_cast
+            rw [nsmul_eq_mul]
+          simp_all only [mem_range]
+        have le₄ : m ≤ n := Nat.le_of_lt_succ hm
+        rw [Nat.choose_eq_factorial_div_factorial le₄, Nat.cast_div, mul_div]
+        · have inv : (n.factorial : R)⁻¹  * (n.factorial : R) = 1 := by
+            have : (n.factorial : R) ≠ 0 := by exact_mod_cast Nat.factorial_ne_zero n
+            simp_all only [ne_eq, Nat.cast_eq_zero, not_false_eq_true, inv_mul_cancel₀]
+          rw [inv, Nat.cast_mul, one_div, mul_inv_rev, mul_comm]
+        · exact Nat.factorial_mul_factorial_dvd_factorial le₄
         rw [Nat.cast_mul]
-        apply mul_ne_zero
-        have h1 : (m.factorial : R) ≠ 0 := by exact_mod_cast Nat.factorial_ne_zero m
-        apply h1
-        have h2 : ((n - m).factorial : R) ≠ 0 := by exact_mod_cast Nat.factorial_ne_zero (n - m)
-        apply h2
-      _ = ∑ ij ∈ (Finset.range (2 * N + 1)).product (Finset.range (2 * N + 1)) |>.filter (fun ij => ij.1 ≤ ij.2), ((ij.1.factorial : R)⁻¹ * ((ij.2 - ij.1).factorial : R)⁻¹) • (a ^ ij.1 * b ^ (ij.2 - ij.1)) := by rw [reorder]
-      _ = ∑ ij ∈ (Finset.range (2 * N + 1)).product (Finset.range (2 * N + 1)) |>.filter (fun ij => ij.1 + ij.2 <= 2 * N), ((ij.1.factorial : R)⁻¹ * (ij.2.factorial : R)⁻¹) • (a ^ ij.1 * b ^ ij.2) := by
-        apply Finset.sum_bij
-          (fun ⟨i, j⟩ _ => (i, j - i))
-        simp
-        intro h1 h2 h3 h4 h5
-        constructor
-        constructor
-        apply h3
-        exact tsub_lt_of_lt h4
-        rw [Nat.add_sub_of_le h5]
-        exact Nat.le_of_lt_succ h4
-        simp
-        intro h1 h2 h3 h4 h5 h6 h7 h8 h9 h10 h11 h12
-        constructor
-        apply h11
-        rw [h11] at h12
-        omega
-        simp
-        intro h1 h2 h3 h4 h5
-        use h1, h1 + h2
-        constructor
-        constructor
-        constructor
-        apply h3
-        exact Nat.lt_add_one_of_le h5
-        exact Nat.le_add_right h1 h2
-        constructor
-        rfl
-        omega
-        simp
-  have e2 :=
+        apply mul_ne_zero <;> exact_mod_cast Nat.factorial_ne_zero _
+      _ = ∑ ij ∈ (range (2 * N + 1)).product (range (2 * N + 1)) with ij.1 + ij.2 <= 2 * N,
+            ((ij.1.factorial : R)⁻¹ * (ij.2.factorial : R)⁻¹) • (a ^ ij.1 * b ^ ij.2) := by
+        rw [sum_sigma']
+        apply sum_bij (fun ⟨i, j⟩ _ => (j, i - j))
+        · simp only [mem_sigma, mem_range, product_eq_sprod, mem_filter, mem_product, and_imp]
+          intro _ _ _
+          omega
+        · simp only [mem_sigma, mem_range, Prod.mk.injEq, and_imp]
+          (intro h1 h2 h3 h4 h5 h6 h7 h8; exact Sigma.ext (by omega) (heq_of_eq h7))
+        · simp only [product_eq_sprod, mem_filter, mem_product, mem_range, mem_sigma, exists_prop,
+            Sigma.exists, and_imp, Prod.forall, Prod.mk.injEq]
+          (intro h1 h2 h3 h4 h5; use h1 + h2, h1; omega)
+        simp only [mem_sigma, mem_range, implies_true]
+  have z₁ : ∑ ij ∈ ((range (2 * N + 1)).product (range (2 * N + 1))) with ¬ ij.1 + ij.2 ≤ 2 * N,
+      ((ij.1.factorial : R)⁻¹ * (ij.2.factorial : R)⁻¹) • (a ^ ij.1 * b ^ ij.2) = 0 := by
+    apply sum_eq_zero
+    intro i hi
+    simp only [mem_filter] at hi
+    cases le_or_lt (N + 1) i.1 with
+      | inl h => rw [pow_eq_zero_of_le h h₄, zero_mul, smul_zero]
+      | inr _ => rw [pow_eq_zero_of_le (by linarith) h₅, mul_zero, smul_zero]
+  have split₁ : ∑ ij ∈ (range (2 * N + 1)).product (range (2 * N + 1)), ((ij.1.factorial : R)⁻¹ *
+      (ij.2.factorial : R)⁻¹) • (a ^ ij.1 * b ^ ij.2) =
+        ∑ ij ∈ ((range (2 * N + 1)).product (range (2 * N + 1))) with ij.1 + ij.2 ≤ 2 * N,
+          ((ij.1.factorial : R)⁻¹ * (ij.2.factorial : R)⁻¹) • (a ^ ij.1 * b ^ ij.2) +
+        ∑ ij ∈ ((range (2 * N + 1)).product (range (2 * N + 1))) with ¬ ij.1 + ij.2 ≤ 2 * N,
+          ((ij.1.factorial : R)⁻¹ * (ij.2.factorial : R)⁻¹) • (a ^ ij.1 * b ^ ij.2) := by
+      rw [sum_filter_add_sum_filter_not]
+  rw [z₁] at split₁
+  simp only [product_eq_sprod, add_zero] at split₁
+  simp only [product_eq_sprod] at s₁
+  rw [← split₁] at s₁
+  have z₂ : ∑ ij ∈ ((range (2 * N + 1)).product (range (2 * N + 1))) with ¬ (ij.1 ≤ N ∧ ij.2 ≤ N),
+      ((ij.1.factorial : R)⁻¹ * (ij.2.factorial : R)⁻¹) • (a ^ ij.1 * b ^ ij.2) = 0 := by
+    apply sum_eq_zero
+    intro i hi
+    simp only [not_and, not_le, mem_filter] at hi
+    cases le_or_lt (N + 1) i.1 with
+      | inl h => rw [pow_eq_zero_of_le h h₄, zero_mul, smul_zero]
+      | inr h => rw [pow_eq_zero_of_le (hi.2 (Nat.le_of_lt_succ h)) h₅, mul_zero, smul_zero]
+  have split₂ : ∑ ij ∈ (range (2 * N + 1)).product (range (2 * N + 1)),
+      ((ij.1.factorial : R)⁻¹ * (ij.2.factorial : R)⁻¹) • (a ^ ij.1 * b ^ ij.2) =
+          ∑ ij ∈ ((range (2 * N + 1)).product (range (2 * N + 1))) with ij.1 ≤ N ∧ ij.2 ≤ N,
+            ((ij.1.factorial : R)⁻¹ * (ij.2.factorial : R)⁻¹) • (a ^ ij.1 * b ^ ij.2) +
+          ∑ ij ∈ ((range (2 * N + 1)).product (range (2 * N + 1))) with ¬ (ij.1 ≤ N ∧ ij.2 ≤ N),
+            ((ij.1.factorial : R)⁻¹ * (ij.2.factorial : R)⁻¹) • (a ^ ij.1 * b ^ ij.2) := by
+      rw [sum_filter_add_sum_filter_not]
+  rw [z₂] at split₂
+  simp only [product_eq_sprod, add_zero] at split₂
+  rw [split₂] at s₁
+  have split₃: ∑ ij ∈ (range (2 * N + 1)).product (range (2 * N + 1)) with ij.1 ≤ N ∧ ij.2 ≤ N,
+      ((ij.1.factorial : R)⁻¹ * (ij.2.factorial : R)⁻¹) • (a ^ ij.1 * b ^ ij.2) =
+        ∑ ij ∈ (range (N + 1)).product (range (N + 1)), ((ij.1.factorial : R)⁻¹ *
+      (ij.2.factorial : R)⁻¹) • (a ^ ij.1 * b ^ ij.2) := by
+    apply sum_congr
+    · ext x
+      simp only [product_eq_sprod, mem_filter, mem_product, mem_range]
+      constructor <;> omega
+    · intro x hx
+      rfl
+  simp only [product_eq_sprod] at split₃
+  rw [split₃] at s₁
+  have s₂ :=
     calc
-      (∑ n ∈ Finset.range (N + 1), (n.factorial : R)⁻¹ • a ^ n) * ∑ n ∈ Finset.range (N + 1), (n.factorial : R)⁻¹ • b ^ n = (∑ n ∈ Finset.range (N + 1), (n.factorial : R)⁻¹ • a ^ n) * ∑ n ∈ Finset.range (N + 1), (n.factorial : R)⁻¹ • b ^ n := by rfl
-      _ = ∑ i ∈ Finset.range (N + 1), ∑ j ∈ Finset.range (N + 1), (i.factorial : R)⁻¹ • a ^ i * (j.factorial : R)⁻¹ • b ^ j := by rw [Finset.sum_mul_sum]
-      _ = ∑ i ∈ Finset.range (N + 1), ∑ j ∈ Finset.range (N + 1), ((i.factorial : R)⁻¹ * (j.factorial : R)⁻¹) • (a ^ i * b ^ j) := by
-       apply Finset.sum_congr rfl
-       intro n hn
-       apply Finset.sum_congr rfl
-       intro m hm
-       rw [smul_mul_assoc]
-       have ppp : a ^ n * (m.factorial : R)⁻¹ • b ^ m = (m.factorial : R)⁻¹ • (a ^ n *  b ^ m) := by
-         simp_all only [Finset.product_eq_sprod, Finset.mem_range, Algebra.mul_smul_comm, N]
-       rw [ppp]
-       rw [smul_smul]
-      _ = ∑ ij ∈ (Finset.range (N + 1)).product (Finset.range (N + 1)), ((ij.1.factorial : R)⁻¹ * (ij.2.factorial : R)⁻¹) • (a ^ ij.1 * b ^ ij.2) := by
-        rw [Finset.sum_sigma']
-        apply Finset.sum_bij
-          (fun ⟨i, j⟩ _ => (i, j))
-        simp
-        simp
-        intro h1 h2 h3 h4 h5 h6 h7 h8
-        refine Sigma.ext h7 ?_
-        exact heq_of_eq h8
-        simp
-        intro h1 h2 h3 h4
-        constructor
-        apply h3
-        apply h4
-        simp
+      (∑ i ∈ range (N + 1), (i.factorial : R)⁻¹ • a ^ i) * ∑ i ∈ range (N + 1),
+        (i.factorial : R)⁻¹ • b ^ i =
+      ∑ i ∈ range (N + 1), ∑ j ∈ range (N + 1), ((i.factorial : R)⁻¹ * (j.factorial : R)⁻¹) •
+        (a ^ i * b ^ j) := by
+        rw [sum_mul_sum]
+        apply sum_congr rfl
+        intro n hn
+        apply sum_congr rfl
+        intro m hm
+        rw [smul_mul_assoc, Algebra.mul_smul_comm, smul_smul]
+      _ = ∑ ij ∈ (range (N + 1)).product (range (N + 1)), ((ij.1.factorial : R)⁻¹ *
+          (ij.2.factorial : R)⁻¹) • (a ^ ij.1 * b ^ ij.2) := by
+        rw [sum_sigma']
+        apply sum_bij (fun ⟨i, j⟩ _ => (i, j))
+        · simp only [mem_sigma, product_eq_sprod, mem_product, imp_self, implies_true]
+        · simp only [mem_sigma, Prod.mk.injEq, and_imp]
+          intro _ _ _ _ _ _ h₁ h₂
+          exact Sigma.ext h₁ (heq_of_eq h₂)
+        · simp only [product_eq_sprod, mem_product, mem_range, mem_sigma, exists_prop,
+          Sigma.exists, and_imp, Prod.forall, Prod.mk.injEq, exists_eq_right_right, exists_eq_right]
+          intro _ _ h₁ h₂
+          exact ⟨h₁, h₂⟩
+        simp only [implies_true]
+  simp only [product_eq_sprod] at s₂
+  rw [s₂.symm] at s₁
+  exact s₁
 
-  have e4 : ∑ ij ∈ (Finset.range (2 * N + 1)).product (Finset.range (2 * N + 1)), ((ij.1.factorial : R)⁻¹ * (ij.2.factorial : R)⁻¹) • (a ^ ij.1 * b ^ ij.2) =
-    ∑ ij ∈ ((Finset.range (2 * N + 1)).product (Finset.range (2 * N + 1))) with ij.1 + ij.2 ≤ 2 * N, ((ij.1.factorial : R)⁻¹ * (ij.2.factorial : R)⁻¹) • (a ^ ij.1 * b ^ ij.2) +
-    ∑ ij ∈ ((Finset.range (2 * N + 1)).product (Finset.range (2 * N + 1))) with ¬ ij.1 + ij.2 ≤ 2 * N, ((ij.1.factorial : R)⁻¹ * (ij.2.factorial : R)⁻¹) • (a ^ ij.1 * b ^ ij.2) := by
-      rw [Finset.sum_filter_add_sum_filter_not]
+end SemiringAlgebras
 
-  have e5 : ∑ ij ∈ ((Finset.range (2 * N + 1)).product (Finset.range (2 * N + 1))) with ¬ ij.1 + ij.2 ≤ 2 * N, ((ij.1.factorial : R)⁻¹ * (ij.2.factorial : R)⁻¹) • (a ^ ij.1 * b ^ ij.2) = 0 := by
-    apply Finset.sum_eq_zero
-    intro i hi
-    simp at hi
-    obtain ⟨hi1, hi2⟩ := hi
-    have help : N + 1 ≤ i.1 ∨ N + 1 ≤ i.2 := by
-      by_contra h
-      simp at h
-      obtain ⟨hi11, hi21⟩ := h
-      linarith
-    cases help with
-    | inl h1 =>
-      have qqq : a ^ (i.1) = 0 := zero_ev A h₃ h1
-      rw [qqq]
-      simp
-    | inr h1 =>
-      have qqq : b ^ (i.2) = 0 := zero_ev A h₄ h1
-      rw [qqq]
-      simp
-  rw [e5] at e4
-  simp at e4
-  simp at e₁
-  rw [← e4] at e₁
-  simp at e2
-  have e5 : ∑ ij ∈ (Finset.range (2 * N + 1)).product (Finset.range (2 * N + 1)), ((ij.1.factorial : R)⁻¹ * (ij.2.factorial : R)⁻¹) • (a ^ ij.1 * b ^ ij.2) =
-    ∑ ij ∈ ((Finset.range (2 * N + 1)).product (Finset.range (2 * N + 1))) with ij.1 ≤ N ∧ ij.2 ≤ N, ((ij.1.factorial : R)⁻¹ * (ij.2.factorial : R)⁻¹) • (a ^ ij.1 * b ^ ij.2) +
-    ∑ ij ∈ ((Finset.range (2 * N + 1)).product (Finset.range (2 * N + 1))) with ¬ (ij.1 ≤ N ∧ ij.2 ≤ N), ((ij.1.factorial : R)⁻¹ * (ij.2.factorial : R)⁻¹) • (a ^ ij.1 * b ^ ij.2) := by
-      rw [Finset.sum_filter_add_sum_filter_not]
-
-  have e6 : ∑ ij ∈ ((Finset.range (2 * N + 1)).product (Finset.range (2 * N + 1))) with ¬ (ij.1 ≤ N ∧ ij.2 ≤ N), ((ij.1.factorial : R)⁻¹ * (ij.2.factorial : R)⁻¹) • (a ^ ij.1 * b ^ ij.2) = 0 := by
-    apply Finset.sum_eq_zero
-    intro i hi
-    push_neg at hi
-    simp at hi
-    obtain ⟨aa, ba⟩ := hi
-    have rrr : N + 1 ≤ i.1 ∨ N + 1 ≤ i.2 := by
-      by_contra hh
-      push_neg at hh
-      have h₁1 : i.1 < N + 1 := hh.1
-      have h₂1 : i.2 < N + 1 := hh.2
-      have h₃1 : i.1 ≤ N := by
-        exact Nat.le_of_lt_succ h₁1
-      have ttt := ba h₃1
-      linarith
-    cases rrr with
-    | inl h1 =>
-      have qqq : a ^ (i.1) = 0 := zero_ev A h₃ h1
-      rw [qqq]
-      simp
-    | inr h1 =>
-      have qqq : b ^ (i.2) = 0 := zero_ev A h₄ h1
-      rw [qqq]
-      simp
-  rw [e6] at e5
-  simp at e5
-  have lll: ∑ ij ∈ (Finset.range (2 * N + 1)).product (Finset.range (2 * N + 1)) with ij.1 ≤ N ∧ ij.2 ≤ N, ((ij.1.factorial : R)⁻¹ * (ij.2.factorial : R)⁻¹) • (a ^ ij.1 * b ^ ij.2) = ∑ ij ∈ (Finset.range (N + 1)).product (Finset.range (N + 1)), ((ij.1.factorial : R)⁻¹ * (ij.2.factorial : R)⁻¹) • (a ^ ij.1 * b ^ ij.2) := by
-    let aaaaa := ((Finset.range (2 * N + 1)).product (Finset.range (2 * N + 1))).filter (fun ij => ij.1 ≤ N ∧ ij.2 ≤ N)
-    let bbbbb := (Finset.range (N + 1)).product (Finset.range (N + 1))
-    have key : aaaaa = bbbbb := by
-      dsimp [aaaaa, bbbbb]
-      ext x
-      constructor
-      intro hhh
-      simp at hhh
-      obtain ⟨hhh1, hhh2⟩ := hhh
-      obtain ⟨hhh1a, hhh1b⟩ := hhh1
-      obtain ⟨hhh2a, hhh2b⟩ := hhh2
-      simp
-      constructor
-      exact Nat.lt_add_one_of_le hhh2a
-      exact Nat.lt_add_one_of_le hhh2b
-      intro hhh
-      simp at hhh
-      obtain ⟨hhh1, hhh2⟩ := hhh
-      simp
-      constructor
-      constructor
-      linarith [hhh1]
-      linarith [hhh2]
-      constructor
-      exact Nat.le_of_lt_succ hhh1
-      exact Nat.le_of_lt_succ hhh2
-
-
-    apply Finset.sum_congr
-    simp at key
-    simp
-    apply key
-    intro x hx
-    rfl
-  rw [e5] at e₁
-  simp at lll
-  rw [lll] at e₁
-  rw [e2.symm] at e₁
-  apply e₁
-
-end Semi
-
-section Full
+section RingAlgebras
 
 variable [CharZero R]
 variable [Ring A] [Algebra R A]
 
 theorem exp_of_nilpotent_is_unit (a : A) (h : IsNilpotent a) : IsUnit (exp R A a) := by
-  have h₀ : a + (-a) = 0 := by
-    exact add_neg_cancel a
-  have h0 : (-a) + a = 0 := by
-    exact neg_add_cancel a
-  have h₁ : Commute a (-a) := by
-    simp_all only [Commute.neg_right_iff, Commute.refl]
-  have h1 : Commute (-a) a := by
-    simp_all only [add_neg_cancel, Commute.neg_right_iff, Commute.refl, Commute.neg_left_iff]
-  have h₃ : IsNilpotent (-a) := IsNilpotent.neg h
-  have h₄ := exp_add_of_commute R A a (-a) h₁ h h₃
-  rw [h₀] at h₄
-  rw [exp_zero_eq_one R A] at h₄
-  dsimp [IsUnit]
+  have h₁ : Commute a (-a) := Commute.neg_right rfl
+  have h₂ : IsNilpotent (-a) := IsNilpotent.neg h
+  have h₃ := exp_add_of_commute R A a (-a) h₁ h h₂
+  rw [add_neg_cancel a, exp_zero_eq_one] at h₃
   apply isUnit_iff_exists.2
-  use exp R A (-a)
-  constructor
-  · apply h₄.symm
-  have h₅ := exp_add_of_commute R A (-a) a h1 h₃ h
-  rw [h0] at h₅
-  rw [exp_zero_eq_one R A] at h₅
-  apply h₅.symm
+  refine ⟨exp R A (-a), h₃.symm, ?_⟩
+  rw [← exp_add_of_commute R A (-a) a h₁.symm h₂ h, neg_add_cancel a, exp_zero_eq_one]
 
-
-end Full
+end RingAlgebras
 
 end Algebra

--- a/Mathlib/Algebra/Algebra/Exp.lean
+++ b/Mathlib/Algebra/Algebra/Exp.lean
@@ -9,7 +9,7 @@ variable (R : Type*) [Field R] [CharZero R]
 variable (A : Type*) [Semiring A] [Algebra R A]
 
 noncomputable def exp (a : A) : A :=
-  ∑ n ∈ Finset.range (nilpotencyClass a), (Nat.factorial n : R)⁻¹ • (a ^ n)
+  ∑ n ∈ Finset.range (nilpotencyClass a), (n.factorial : R)⁻¹ • (a ^ n)
 
 theorem exp_eq_truncated {k : ℕ} (a : A) (h : a ^ k = 0) :
     ∑ n ∈ Finset.range k, (Nat.factorial n : R)⁻¹ • (a ^ n) = exp R A a := by

--- a/Mathlib/Algebra/Algebra/Exp.lean
+++ b/Mathlib/Algebra/Algebra/Exp.lean
@@ -21,7 +21,7 @@ import Mathlib.Data.Nat.Factorial.Basic
 This file could usefully be split further.
 -/
 
-universe u v w u₁ v₁
+universe u w
 
 open Function
 
@@ -34,9 +34,10 @@ variable [Field R] [CharZero R]
 variable [Semiring A] [Algebra R A]
 
 def exp (a : A) (h : IsNilpotent a) : A :=
+  --let k := nilpotency_class a h
   let five_factorial : R := Nat.factorial 5
   let inv_five_factorial : R := five_factorial⁻¹
-  inv_five_factorial • a
+  ∑ n ∈ Finset.range 11, (Nat.factorial n : R)⁻¹ • a
 
 end Exp
 

--- a/Mathlib/Algebra/Algebra/Exp.lean
+++ b/Mathlib/Algebra/Algebra/Exp.lean
@@ -27,20 +27,17 @@ section Exp
 variable (R : Type*) [Field R] [CharZero R]
 variable (A : Type*) [Semiring A] [Algebra R A]
 
--- Exponent of a nilpotent element
 noncomputable def exponent (a : A) : ℕ :=
   sInf {k | a ^ k = 0}
 
--- Exponential of a nilpotent element
 noncomputable def exp (a : A) : A :=
   ∑ n ∈ Finset.range (exponent A a), (Nat.factorial n : R)⁻¹ • (a ^ n)
-
 
 theorem well_def {k : ℕ} (a : A) (h : a ^ k = 0) :
     ∑ n ∈ Finset.range k, (Nat.factorial n : R)⁻¹ • (a ^ n) = exp R A a := by
   sorry
 
-theorem exp_add_mul (a b : A) (h : a * b = b * a) (h1 : IsNilpotent a) (h2 : IsNilpotent b) :
+theorem exp_add_mul (a b : A) (h₁ : Commute a b) (h₂ : IsNilpotent a) (h₃ : IsNilpotent b) :
     exp R A (a + b) = exp R A a * exp R A b := by
   sorry
 

--- a/Mathlib/Algebra/Algebra/Exp.lean
+++ b/Mathlib/Algebra/Algebra/Exp.lean
@@ -5,28 +5,24 @@ import Mathlib.RingTheory.Nilpotent.Defs
 
 namespace Algebra
 
-section Exp
-
 variable (R : Type*) [Field R] [CharZero R]
 variable (A : Type*) [Semiring A] [Algebra R A]
 
 noncomputable def exp (a : A) : A :=
   ∑ n ∈ Finset.range (nilpotencyClass a), (Nat.factorial n : R)⁻¹ • (a ^ n)
 
-theorem well_def {k : ℕ} (a : A) (h : a ^ k = 0) :
+theorem exp_eq_truncated {k : ℕ} (a : A) (h : a ^ k = 0) :
     ∑ n ∈ Finset.range k, (Nat.factorial n : R)⁻¹ • (a ^ n) = exp R A a := by
   sorry
 
 -- useful: add_pow_eq_zero_of_add_le_succ_of_pow_eq_zero
 -- useful: add_pow (h : Commute x y) (n : ℕ) : ...
 -- useful: isNilpotent_add (h_comm : Commute x y) ...
-theorem exp_add_mul (a b : A) (h₁ : Commute a b) (h₂ : IsNilpotent a) (h₃ : IsNilpotent b) :
+theorem exp_add_of_commute (a b : A) (h₁ : Commute a b) (h₂ : IsNilpotent a) (h₃ : IsNilpotent b) :
     exp R A (a + b) = exp R A a * exp R A b := by
   sorry
 
-theorem exp_inv (a : A) (h : IsNilpotent a) : IsUnit (exp R A a) := by
+theorem exp_is_unit_of_nilpotent (a : A) (h : IsNilpotent a) : IsUnit (exp R A a) := by
   sorry
-
-end Exp
 
 end Algebra

--- a/Mathlib/Algebra/Algebra/Exp.lean
+++ b/Mathlib/Algebra/Algebra/Exp.lean
@@ -13,6 +13,7 @@ import Mathlib.Algebra.Ring.Subring.Basic
 import Mathlib.Data.Nat.Cast.Order.Basic
 import Mathlib.Data.Int.CharZero
 import Mathlib.RingTheory.Nilpotent.Defs
+import Mathlib.Data.Nat.Factorial.Basic
 
 /-!
 # Further basic results about `Algebra`.
@@ -32,9 +33,10 @@ variable {R : Type u} {A : Type w}
 variable [Field R] [CharZero R]
 variable [Semiring A] [Algebra R A]
 
-noncomputable def exp (a : A) (h : IsNilpotent a) : A :=
-  a
-  --∑ n in finset.range (nat.find hx + 1), (x^n) / (n! : R)
+def exp (a : A) (h : IsNilpotent a) : A :=
+  let five_factorial : R := Nat.factorial 5
+  let inv_five_factorial : R := five_factorial⁻¹
+  inv_five_factorial • a
 
 end Exp
 

--- a/Mathlib/Algebra/Algebra/Exp.lean
+++ b/Mathlib/Algebra/Algebra/Exp.lean
@@ -11,16 +11,18 @@ import Mathlib.RingTheory.Nilpotent.Basic
 /-!
 # Exponential map on algebras
 
-This file defines the exponential map `Algebra.exp` on algebras. The definition of `Algebra.exp a`
-applies to any `R`-algebra `A` and any element `a`, though it yields meaningful (non-junk)
-values only when `a` is nilpotent.
+This file defines the exponential map `Algebra.exp` on `ℚ`-algebras. The definition of
+`Algebra.exp a` applies to any element `a` in an algebra over `ℚ`, though it yields meaningful
+(non-junk) values only when `a` is nilpotent.
 
-When `R` is a characteristic zero field, the theorem `Algebra.exp_add_of_commute` establishes
-the expected connection between the additive and multiplicative structures of `A` for commuting
-nilpotent elements.
+The main result is `Algebra.exp_add_of_commute`, which establishes the expected connection between
+the additive and multiplicative structures of `A` for commuting nilpotent elements.
 
-Furthermore, in case `A` is a ring (rather than a general semiring) and `a` is nilpotent,
-`Algebra.exp_of_nilpotent_is_unit` shows that `Algebra.exp a` is a unit in `A`.
+Furthermore, in case `A` is a ring and `a` is nilpotent, `Algebra.exp_of_nilpotent_is_unit` shows
+that `Algebra.exp a` is a unit in `A`.
+
+Note: Although the definition works with `ℚ`-algebras, the results apply to any algebra over a
+characteristic zero field.
 
 ## Main definitions
 

--- a/Mathlib/Algebra/Algebra/Exp.lean
+++ b/Mathlib/Algebra/Algebra/Exp.lean
@@ -21,8 +21,8 @@ the additive and multiplicative structures of `A` for commuting nilpotent elemen
 Furthermore, in case `A` is a ring and `a` is nilpotent, `Algebra.exp_of_nilpotent_is_unit` shows
 that `Algebra.exp a` is a unit in `A`.
 
-Note: Although the definition works with `ℚ`-algebras, the results apply to any algebra over a
-characteristic zero field.
+Note: Although the definition works with `ℚ`-algebras, the results can be applied to any algebra
+over a characteristic zero field.
 
 ## Main definitions
 

--- a/Mathlib/Algebra/Algebra/Exp.lean
+++ b/Mathlib/Algebra/Algebra/Exp.lean
@@ -27,16 +27,14 @@ section Exp
 variable (R : Type*) [Field R] [CharZero R]
 variable (A : Type*) [Semiring A] [Algebra R A]
 
-noncomputable def exponent (a : A) : ℕ :=
-  sInf {k | a ^ k = 0}
-
 noncomputable def exp (a : A) : A :=
-  ∑ n ∈ Finset.range (exponent A a), (Nat.factorial n : R)⁻¹ • (a ^ n)
+  ∑ n ∈ Finset.range (nilpotencyClass a), (Nat.factorial n : R)⁻¹ • (a ^ n)
 
 theorem well_def {k : ℕ} (a : A) (h : a ^ k = 0) :
     ∑ n ∈ Finset.range k, (Nat.factorial n : R)⁻¹ • (a ^ n) = exp R A a := by
   sorry
 
+-- theorem add_pow (h : Commute x y) (n : ℕ) :
 theorem exp_add_mul (a b : A) (h₁ : Commute a b) (h₂ : IsNilpotent a) (h₃ : IsNilpotent b) :
     exp R A (a + b) = exp R A a * exp R A b := by
   sorry

--- a/Mathlib/Algebra/Algebra/Exp.lean
+++ b/Mathlib/Algebra/Algebra/Exp.lean
@@ -1,17 +1,66 @@
 import Mathlib.Algebra.Algebra.Defs
 import Mathlib.Algebra.BigOperators.Group.Finset.Basic
+import Mathlib.Algebra.BigOperators.GroupWithZero.Action
 import Mathlib.Algebra.BigOperators.Intervals
 import Mathlib.Algebra.Field.Defs
+import Mathlib.Algebra.Group.Basic
 import Mathlib.RingTheory.Nilpotent.Basic
+import Mathlib.Data.Nat.Cast.Field
+import Mathlib.Data.Sigma.Basic
+import LeanCopilot
+
+
+
+
 
 namespace Algebra
 
 variable (R : Type*) [Field R]
 variable (A : Type*)
 
+
 section Semi
 
 variable [Semiring A] [Algebra R A]
+
+
+theorem reorder (N : ℕ) {f : ℕ → ℕ → A} : ∑ j ∈ Finset.range (2 * N + 1), ∑ i ∈ Finset.range (j + 1), f i j = ∑ ij ∈ (Finset.range (2 * N + 1)).product (Finset.range (2 * N + 1)) |>.filter (fun ij => ij.1 ≤ ij.2), f ij.1 ij.2 := by
+  rw [Finset.sum_sigma']
+  apply Finset.sum_bij
+    (fun ⟨j, i⟩ _ => (i, j))
+  simp
+  intro h1
+  intro h2
+  intro h3
+  constructor
+  constructor
+  · exact Nat.lt_of_lt_of_le h3 h2
+  · exact h2
+  · exact Nat.le_of_lt_succ h3
+  simp
+  intro h4
+  intro h5
+  intro h6
+  intro h7
+  intro h8
+  intro h9
+  intro h10
+  intro h11
+  · refine Sigma.ext h11 ?_
+    exact heq_of_eq h10
+  simp
+  intro h1
+  intro h2
+  intro h3
+  intro h4
+  intro h5
+  use h2, h1
+  constructor
+  constructor
+  exact h4
+  exact Nat.lt_add_one_of_le h5
+  exact Prod.mk.inj_iff.mp rfl
+  simp
 
 noncomputable def exp (a : A) : A :=
   ∑ n ∈ Finset.range (nilpotencyClass a), (n.factorial : R)⁻¹ • (a ^ n)
@@ -51,20 +100,264 @@ theorem exp_zero_eq_one : exp R A 0 = 1 := by
   simp at h1
   apply h1.symm
 
+
+theorem zero_ev {k l : ℕ} {a : A} (h₁ : a ^ k = 0) (h₂ : k ≤ l) : a ^ l = 0 := by
+  obtain ⟨m, rfl⟩ := Nat.exists_eq_add_of_le h₂
+  rw [pow_add, h₁, zero_mul]
+
 --example (n : ℕ) (a : A) : (n.factorial : R) • ((n.factorial : R)⁻¹ • a) = a := by
 --have h1 : (n.factorial : R) ≠ 0 := by exact_mod_cast Nat.factorial_ne_zero n
 --simp_all only [ne_eq, Nat.cast_eq_zero, not_false_eq_true, smul_inv_smul₀]
   --exact mul_inv_cancel₀ h1
+
 
 -- useful: add_pow_eq_zero_of_add_le_succ_of_pow_eq_zero
 -- useful: add_pow (h : Commute x y) (n : ℕ) : ...
 -- useful: isNilpotent_add (h_comm : Commute x y) ...
 
 variable [CharZero R]
+
+theorem ttttt (n : ℕ) : (n.factorial : R)⁻¹  * (n.factorial : R) = 1 := by
+  have h1 : (n.factorial : R) ≠ 0 := by exact_mod_cast Nat.factorial_ne_zero n
+  simp_all only [ne_eq, Nat.cast_eq_zero, not_false_eq_true, inv_mul_cancel₀]
+
+
 theorem exp_add_of_commute (a b : A) (h₁ : Commute a b) (h₂ : IsNilpotent a) (h₃ : IsNilpotent b) :
     exp R A (a + b) = exp R A a * exp R A b := by
-  have h : a * b = b * a := h₁
-  sorry
+  obtain ⟨n₁, hn₁⟩ := h₂
+  obtain ⟨n₂, hn₂⟩ := h₃
+  let N :=  n₁ ⊔ n₂
+  have huh₁ : n₁ ≤ N + 1 := by
+    refine Nat.le_add_right_of_le ?_
+    simp_all only [le_sup_left, N]
+  have huh₂ : n₂ ≤ N + 1 := by
+    refine Nat.le_add_right_of_le ?_
+    simp_all only [le_sup_right, N]
+  have h₃ : a ^ (N + 1) = 0 := zero_ev A hn₁ huh₁
+  have h₄ : b ^ (N + 1) = 0 := zero_ev A hn₂ huh₂
+  have help : (N + 1) + (N + 1) <= (2 * N + 1) + 1 := by
+    calc (N + 1) + (N + 1) = 2 * (N + 1) := by rw [← Nat.two_mul (N + 1)]
+    _ = 2 * N + 2 := by rw [Nat.mul_add_one]
+    _ = (2 * N + 1) + 1 := by rw [Nat.add_assoc]
+    _ ≤ (2 * N + 1) + 1 := by exact le_refl (2 * N + 2)
+  have h₅ : (a + b) ^ (2 * N + 1) = 0 :=
+    Commute.add_pow_eq_zero_of_add_le_succ_of_pow_eq_zero h₁ h₃ h₄ help
+  rw [← exp_eq_truncated R A (a + b) h₅, ← exp_eq_truncated R A a h₃, ← exp_eq_truncated R A b h₄]
+
+ -- have  hh (n : ℕ) (a : A) : n * a = (n : R) • a := by
+  --  norm_cast
+  --  simp_all only [nsmul_eq_mul, N]
+
+  have e₁ :=
+    calc
+      ∑ n ∈ Finset.range (2 * N + 1), (n.factorial : R)⁻¹ • (a + b) ^ n = ∑ n ∈ Finset.range (2 * N + 1), (n.factorial : R)⁻¹ • (a + b) ^ n := rfl
+      _ = ∑ n ∈ Finset.range (2 * N + 1), (n.factorial : R)⁻¹ • (a + b) ^ n := rfl
+      _ = ∑ n ∈ Finset.range (2 * N + 1), (n.factorial : R)⁻¹ • (∑ m ∈ Finset.range (n + 1), a ^ m * b ^ (n - m) * n.choose m) := by
+        apply Finset.sum_congr rfl
+        intros n hn
+        rw [Commute.add_pow h₁ n]
+      _ = ∑ n ∈ Finset.range (2 * N + 1), (∑ m ∈ Finset.range (n + 1), (n.factorial : R)⁻¹ • (a ^ m * b ^ (n - m) * n.choose m)) := by
+        apply Finset.sum_congr rfl
+        intro n hn
+        rw [Finset.smul_sum]
+      _ = ∑ n ∈ Finset.range (2 * N + 1), (∑ m ∈ Finset.range (n + 1), ((m.factorial : R)⁻¹ * ((n - m).factorial : R)⁻¹) • (a ^ m * b ^ (n - m))) := by
+        apply Finset.sum_congr rfl
+        intro n hn
+        apply Finset.sum_congr rfl
+        intro m hm
+        have hhh0 : a ^ m * b ^ (n - m) * (n.choose m) = (n.choose m) * (a ^ m * b ^ (n - m)) := by
+          rw [Nat.cast_commute (n.choose m)]
+
+        have  hh (n : ℕ) (a : A) : n * a = (n : R) • a := by
+          norm_cast
+          simp
+        have hhh : (n.factorial : R)⁻¹ • (a ^ m * b ^ (n - m) * (n.choose m)) = ((n.factorial : R)⁻¹ * (n.choose m)) • (a ^ m * b ^ (n - m)) := by
+          rw [hhh0]
+          rw [hh (n.choose m)]
+          rw [← smul_assoc]
+          norm_cast
+        rw [hhh]
+        suffices h11 : (n.factorial : R)⁻¹ * (n.choose m) = ((m.factorial : R)⁻¹ * ((n - m).factorial : R)⁻¹) by
+          simp_all only [Finset.mem_range, N]
+        have t : m ≤ n := by
+          simp_all only [Finset.mem_range, N]
+          omega
+        rw [Nat.choose_eq_factorial_div_factorial t]
+        rw [Nat.cast_div]
+        rw [mul_div]
+        have qqq := ttttt R n
+        rw [qqq]
+        simp
+        rw [mul_comm]
+        apply Nat.factorial_mul_factorial_dvd_factorial
+        apply t
+        rw [Nat.cast_mul]
+        apply mul_ne_zero
+        have h1 : (m.factorial : R) ≠ 0 := by exact_mod_cast Nat.factorial_ne_zero m
+        apply h1
+        have h2 : ((n - m).factorial : R) ≠ 0 := by exact_mod_cast Nat.factorial_ne_zero (n - m)
+        apply h2
+      _ = ∑ ij ∈ (Finset.range (2 * N + 1)).product (Finset.range (2 * N + 1)) |>.filter (fun ij => ij.1 ≤ ij.2), ((ij.1.factorial : R)⁻¹ * ((ij.2 - ij.1).factorial : R)⁻¹) • (a ^ ij.1 * b ^ (ij.2 - ij.1)) := by rw [reorder]
+      _ = ∑ ij ∈ (Finset.range (2 * N + 1)).product (Finset.range (2 * N + 1)) |>.filter (fun ij => ij.1 + ij.2 <= 2 * N), ((ij.1.factorial : R)⁻¹ * (ij.2.factorial : R)⁻¹) • (a ^ ij.1 * b ^ ij.2) := by
+        apply Finset.sum_bij
+          (fun ⟨i, j⟩ _ => (i, j - i))
+        simp
+        intro h1 h2 h3 h4 h5
+        constructor
+        constructor
+        apply h3
+        exact tsub_lt_of_lt h4
+        rw [Nat.add_sub_of_le h5]
+        exact Nat.le_of_lt_succ h4
+        simp
+        intro h1 h2 h3 h4 h5 h6 h7 h8 h9 h10 h11 h12
+        constructor
+        apply h11
+        rw [h11] at h12
+        omega
+        simp
+        intro h1 h2 h3 h4 h5
+        use h1, h1 + h2
+        constructor
+        constructor
+        constructor
+        apply h3
+        exact Nat.lt_add_one_of_le h5
+        exact Nat.le_add_right h1 h2
+        constructor
+        rfl
+        omega
+        simp
+  have e2 :=
+    calc
+      (∑ n ∈ Finset.range (N + 1), (n.factorial : R)⁻¹ • a ^ n) * ∑ n ∈ Finset.range (N + 1), (n.factorial : R)⁻¹ • b ^ n = (∑ n ∈ Finset.range (N + 1), (n.factorial : R)⁻¹ • a ^ n) * ∑ n ∈ Finset.range (N + 1), (n.factorial : R)⁻¹ • b ^ n := by rfl
+      _ = ∑ i ∈ Finset.range (N + 1), ∑ j ∈ Finset.range (N + 1), (i.factorial : R)⁻¹ • a ^ i * (j.factorial : R)⁻¹ • b ^ j := by rw [Finset.sum_mul_sum]
+      _ = ∑ i ∈ Finset.range (N + 1), ∑ j ∈ Finset.range (N + 1), ((i.factorial : R)⁻¹ * (j.factorial : R)⁻¹) • (a ^ i * b ^ j) := by
+       apply Finset.sum_congr rfl
+       intro n hn
+       apply Finset.sum_congr rfl
+       intro m hm
+       rw [smul_mul_assoc]
+       have ppp : a ^ n * (m.factorial : R)⁻¹ • b ^ m = (m.factorial : R)⁻¹ • (a ^ n *  b ^ m) := by
+         simp_all only [Finset.product_eq_sprod, Finset.mem_range, Algebra.mul_smul_comm, N]
+       rw [ppp]
+       rw [smul_smul]
+      _ = ∑ ij ∈ (Finset.range (N + 1)).product (Finset.range (N + 1)), ((ij.1.factorial : R)⁻¹ * (ij.2.factorial : R)⁻¹) • (a ^ ij.1 * b ^ ij.2) := by
+        rw [Finset.sum_sigma']
+        apply Finset.sum_bij
+          (fun ⟨i, j⟩ _ => (i, j))
+        simp
+        simp
+        intro h1 h2 h3 h4 h5 h6 h7 h8
+        refine Sigma.ext h7 ?_
+        exact heq_of_eq h8
+        simp
+        intro h1 h2 h3 h4
+        constructor
+        apply h3
+        apply h4
+        simp
+
+  have e4 : ∑ ij ∈ (Finset.range (2 * N + 1)).product (Finset.range (2 * N + 1)), ((ij.1.factorial : R)⁻¹ * (ij.2.factorial : R)⁻¹) • (a ^ ij.1 * b ^ ij.2) =
+    ∑ ij ∈ ((Finset.range (2 * N + 1)).product (Finset.range (2 * N + 1))) with ij.1 + ij.2 ≤ 2 * N, ((ij.1.factorial : R)⁻¹ * (ij.2.factorial : R)⁻¹) • (a ^ ij.1 * b ^ ij.2) +
+    ∑ ij ∈ ((Finset.range (2 * N + 1)).product (Finset.range (2 * N + 1))) with ¬ ij.1 + ij.2 ≤ 2 * N, ((ij.1.factorial : R)⁻¹ * (ij.2.factorial : R)⁻¹) • (a ^ ij.1 * b ^ ij.2) := by
+      rw [Finset.sum_filter_add_sum_filter_not]
+
+  have e5 : ∑ ij ∈ ((Finset.range (2 * N + 1)).product (Finset.range (2 * N + 1))) with ¬ ij.1 + ij.2 ≤ 2 * N, ((ij.1.factorial : R)⁻¹ * (ij.2.factorial : R)⁻¹) • (a ^ ij.1 * b ^ ij.2) = 0 := by
+    apply Finset.sum_eq_zero
+    intro i hi
+    simp at hi
+    obtain ⟨hi1, hi2⟩ := hi
+    have help : N + 1 ≤ i.1 ∨ N + 1 ≤ i.2 := by
+      by_contra h
+      simp at h
+      obtain ⟨hi11, hi21⟩ := h
+      linarith
+    cases help with
+    | inl h1 =>
+      have qqq : a ^ (i.1) = 0 := zero_ev A h₃ h1
+      rw [qqq]
+      simp
+    | inr h1 =>
+      have qqq : b ^ (i.2) = 0 := zero_ev A h₄ h1
+      rw [qqq]
+      simp
+  rw [e5] at e4
+  simp at e4
+  simp at e₁
+  rw [← e4] at e₁
+  simp at e2
+  have e5 : ∑ ij ∈ (Finset.range (2 * N + 1)).product (Finset.range (2 * N + 1)), ((ij.1.factorial : R)⁻¹ * (ij.2.factorial : R)⁻¹) • (a ^ ij.1 * b ^ ij.2) =
+    ∑ ij ∈ ((Finset.range (2 * N + 1)).product (Finset.range (2 * N + 1))) with ij.1 ≤ N ∧ ij.2 ≤ N, ((ij.1.factorial : R)⁻¹ * (ij.2.factorial : R)⁻¹) • (a ^ ij.1 * b ^ ij.2) +
+    ∑ ij ∈ ((Finset.range (2 * N + 1)).product (Finset.range (2 * N + 1))) with ¬ (ij.1 ≤ N ∧ ij.2 ≤ N), ((ij.1.factorial : R)⁻¹ * (ij.2.factorial : R)⁻¹) • (a ^ ij.1 * b ^ ij.2) := by
+      rw [Finset.sum_filter_add_sum_filter_not]
+
+  have e6 : ∑ ij ∈ ((Finset.range (2 * N + 1)).product (Finset.range (2 * N + 1))) with ¬ (ij.1 ≤ N ∧ ij.2 ≤ N), ((ij.1.factorial : R)⁻¹ * (ij.2.factorial : R)⁻¹) • (a ^ ij.1 * b ^ ij.2) = 0 := by
+    apply Finset.sum_eq_zero
+    intro i hi
+    push_neg at hi
+    simp at hi
+    obtain ⟨aa, ba⟩ := hi
+    have rrr : N + 1 ≤ i.1 ∨ N + 1 ≤ i.2 := by
+      by_contra hh
+      push_neg at hh
+      have h₁1 : i.1 < N + 1 := hh.1
+      have h₂1 : i.2 < N + 1 := hh.2
+      have h₃1 : i.1 ≤ N := by
+        exact Nat.le_of_lt_succ h₁1
+      have ttt := ba h₃1
+      linarith
+    cases rrr with
+    | inl h1 =>
+      have qqq : a ^ (i.1) = 0 := zero_ev A h₃ h1
+      rw [qqq]
+      simp
+    | inr h1 =>
+      have qqq : b ^ (i.2) = 0 := zero_ev A h₄ h1
+      rw [qqq]
+      simp
+  rw [e6] at e5
+  simp at e5
+  have lll: ∑ ij ∈ (Finset.range (2 * N + 1)).product (Finset.range (2 * N + 1)) with ij.1 ≤ N ∧ ij.2 ≤ N, ((ij.1.factorial : R)⁻¹ * (ij.2.factorial : R)⁻¹) • (a ^ ij.1 * b ^ ij.2) = ∑ ij ∈ (Finset.range (N + 1)).product (Finset.range (N + 1)), ((ij.1.factorial : R)⁻¹ * (ij.2.factorial : R)⁻¹) • (a ^ ij.1 * b ^ ij.2) := by
+    let aaaaa := ((Finset.range (2 * N + 1)).product (Finset.range (2 * N + 1))).filter (fun ij => ij.1 ≤ N ∧ ij.2 ≤ N)
+    let bbbbb := (Finset.range (N + 1)).product (Finset.range (N + 1))
+    have key : aaaaa = bbbbb := by
+      dsimp [aaaaa, bbbbb]
+      ext x
+      constructor
+      intro hhh
+      simp at hhh
+      obtain ⟨hhh1, hhh2⟩ := hhh
+      obtain ⟨hhh1a, hhh1b⟩ := hhh1
+      obtain ⟨hhh2a, hhh2b⟩ := hhh2
+      simp
+      constructor
+      exact Nat.lt_add_one_of_le hhh2a
+      exact Nat.lt_add_one_of_le hhh2b
+      intro hhh
+      simp at hhh
+      obtain ⟨hhh1, hhh2⟩ := hhh
+      simp
+      constructor
+      constructor
+      linarith [hhh1]
+      linarith [hhh2]
+      constructor
+      exact Nat.le_of_lt_succ hhh1
+      exact Nat.le_of_lt_succ hhh2
+
+
+    apply Finset.sum_congr
+    simp at key
+    simp
+    apply key
+    intro x hx
+    rfl
+  rw [e5] at e₁
+  simp at lll
+  rw [lll] at e₁
+  rw [e2.symm] at e₁
+  apply e₁
 
 
 

--- a/Mathlib/Algebra/Algebra/Exp.lean
+++ b/Mathlib/Algebra/Algebra/Exp.lean
@@ -7,22 +7,15 @@ import Mathlib.Algebra.Group.Basic
 import Mathlib.RingTheory.Nilpotent.Basic
 import Mathlib.Data.Nat.Cast.Field
 import Mathlib.Data.Sigma.Basic
-import LeanCopilot
-
-
-
-
 
 namespace Algebra
 
 variable (R : Type*) [Field R]
 variable (A : Type*)
 
-
 section Semi
 
 variable [Semiring A] [Algebra R A]
-
 
 theorem reorder (N : ℕ) {f : ℕ → ℕ → A} : ∑ j ∈ Finset.range (2 * N + 1), ∑ i ∈ Finset.range (j + 1), f i j = ∑ ij ∈ (Finset.range (2 * N + 1)).product (Finset.range (2 * N + 1)) |>.filter (fun ij => ij.1 ≤ ij.2), f ij.1 ij.2 := by
   rw [Finset.sum_sigma']
@@ -105,22 +98,11 @@ theorem zero_ev {k l : ℕ} {a : A} (h₁ : a ^ k = 0) (h₂ : k ≤ l) : a ^ l 
   obtain ⟨m, rfl⟩ := Nat.exists_eq_add_of_le h₂
   rw [pow_add, h₁, zero_mul]
 
---example (n : ℕ) (a : A) : (n.factorial : R) • ((n.factorial : R)⁻¹ • a) = a := by
---have h1 : (n.factorial : R) ≠ 0 := by exact_mod_cast Nat.factorial_ne_zero n
---simp_all only [ne_eq, Nat.cast_eq_zero, not_false_eq_true, smul_inv_smul₀]
-  --exact mul_inv_cancel₀ h1
-
-
--- useful: add_pow_eq_zero_of_add_le_succ_of_pow_eq_zero
--- useful: add_pow (h : Commute x y) (n : ℕ) : ...
--- useful: isNilpotent_add (h_comm : Commute x y) ...
-
 variable [CharZero R]
 
 theorem ttttt (n : ℕ) : (n.factorial : R)⁻¹  * (n.factorial : R) = 1 := by
   have h1 : (n.factorial : R) ≠ 0 := by exact_mod_cast Nat.factorial_ne_zero n
   simp_all only [ne_eq, Nat.cast_eq_zero, not_false_eq_true, inv_mul_cancel₀]
-
 
 theorem exp_add_of_commute (a b : A) (h₁ : Commute a b) (h₂ : IsNilpotent a) (h₃ : IsNilpotent b) :
     exp R A (a + b) = exp R A a * exp R A b := by
@@ -358,8 +340,6 @@ theorem exp_add_of_commute (a b : A) (h₁ : Commute a b) (h₂ : IsNilpotent a)
   rw [lll] at e₁
   rw [e2.symm] at e₁
   apply e₁
-
-
 
 end Semi
 

--- a/Mathlib/Algebra/Algebra/Exp.lean
+++ b/Mathlib/Algebra/Algebra/Exp.lean
@@ -20,30 +20,31 @@ import Mathlib.Data.Nat.Factorial.Basic
 
 This file could usefully be split further.
 -/
-
-universe u w
-
-
 namespace Algebra
 
 section Exp
 
-variable {R : Type u} {A : Type w}
-variable [Field R] [CharZero R]
-variable [Semiring A] [Algebra R A]
+variable (R : Type*) [Field R] [CharZero R]
+variable (A : Type*) [Semiring A] [Algebra R A]
 
+-- Exponent of a nilpotent element
 noncomputable def exponent (a : A) : ℕ :=
-    sInf {k | a ^ k = 0}
+  sInf {k | a ^ k = 0}
 
-noncomputable def exp (a : A) [Field R]: A :=
-  ∑ n ∈ Finset.range (exponent a), (Nat.factorial n : R)⁻¹ • (a ^ n)
+-- Exponential of a nilpotent element
+noncomputable def exp (a : A) : A :=
+  ∑ n ∈ Finset.range (exponent A a), (Nat.factorial n : R)⁻¹ • (a ^ n)
+
 
 theorem wellDef {k : ℕ} (a : A) (h : a ^ k = 0) :
-    exp (R := R) a  = ∑ n ∈ Finset.range k, (Nat.factorial n : R)⁻¹ • (a ^ n) := by
+    exp R A a  = ∑ n ∈ Finset.range k, (Nat.factorial n : R)⁻¹ • (a ^ n) := by
   sorry
 
 theorem mul_add (a b : A) (h : a * b = b * a) (IsNilpotent a : A) (IsNilpotent b : A) :
-    exp (R := R) (a + b) = (exp (R := R) a : A) * (exp (R := R) b) := by
+    exp R A (a + b) = exp R A a * exp R A b := by
+  sorry
+
+theorem exp_inv (a : A) (IsNilpotent a : A) : IsUnit (exp R A a) := by
   sorry
 
 end Exp

--- a/Mathlib/Algebra/Algebra/Exp.lean
+++ b/Mathlib/Algebra/Algebra/Exp.lean
@@ -22,7 +22,7 @@ theorem exp_add_of_commute (a b : A) (h₁ : Commute a b) (h₂ : IsNilpotent a)
     exp R A (a + b) = exp R A a * exp R A b := by
   sorry
 
-theorem exp_is_unit_of_nilpotent (a : A) (h : IsNilpotent a) : IsUnit (exp R A a) := by
+theorem exp_of_nilpotent_is_unit (a : A) (h : IsNilpotent a) : IsUnit (exp R A a) := by
   sorry
 
 end Algebra

--- a/Mathlib/RingTheory/Nilpotent/Exp.lean
+++ b/Mathlib/RingTheory/Nilpotent/Exp.lean
@@ -12,29 +12,29 @@ import Mathlib.Tactic.FieldSimp
 /-!
 # Exponential map on algebras
 
-This file defines the exponential map `Algebra.exp` on `ℚ`-algebras. The definition of
-`Algebra.exp a` applies to any element `a` in an algebra over `ℚ`, though it yields meaningful
+This file defines the exponential map `IsNilpotent.exp` on `ℚ`-algebras. The definition of
+`IsNilpotent.exp a` applies to any element `a` in an algebra over `ℚ`, though it yields meaningful
 (non-junk) values only when `a` is nilpotent.
 
-The main result is `Algebra.exp_add_of_commute`, which establishes the expected connection between
-the additive and multiplicative structures of `A` for commuting nilpotent elements.
+The main result is `IsNilpotent.exp_add_of_commute`, which establishes the expected connection
+between the additive and multiplicative structures of `A` for commuting nilpotent elements.
 
-Furthermore, in case `A` is a ring and `a` is nilpotent, `Algebra.exp_of_nilpotent_is_unit` shows
-that `Algebra.exp a` is a unit in `A`.
+Additionally, `IsNilpotent.exp_of_nilpotent_is_unit` shows that if `a` is nilpotent in `A`, then
+`IsNilpotent.exp a` is a unit in `A`.
 
 Note: Although the definition works with `ℚ`-algebras, the results can be applied to any algebra
 over a characteristic zero field.
 
 ## Main definitions
 
-  * `Algebra.exp`
+  * `IsNilpotent.exp`
 
 ## Tags
 
 algebra, exponential map, nilpotent
 -/
 
-namespace Algebra
+namespace IsNilpotent
 
 variable {A : Type*} [Ring A] [Algebra ℚ A]
 
@@ -164,4 +164,4 @@ theorem exp_of_nilpotent_is_unit {a : A} (h : IsNilpotent a) : IsUnit (exp a) :=
   refine ⟨exp (-a), h₃.symm, ?_⟩
   rw [← exp_add_of_commute h₁.symm h₂ h, neg_add_cancel a, exp_zero_eq_one]
 
-end Algebra
+end IsNilpotent


### PR DESCRIPTION
Define exponential map for algebras
---
This PR defines the exponential map for algebras. The given definition is in analogy with the usual exponential series and provides meaningful values for nilpotent elements of algebras.

This work is part of the framework:
https://github.com/orgs/leanprover-community/projects/17
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
