### PR TITLE
[Merged by Bors] - chore(CategoryTheory/Products/Basic): cleanup and harmonize

### DIFF
--- a/Mathlib/CategoryTheory/Products/Basic.lean
+++ b/Mathlib/CategoryTheory/Products/Basic.lean
@@ -248,7 +248,7 @@ section
 variable (C)
 
 /-- The diagonal functor. -/
-@[simps! obj obj_fst map map_fst map_snd]
+@[simps! obj obj_fst obj_snd map map_fst map_snd]
 def diag : C ⥤ C × C :=
   (𝟭 C).prod' (𝟭 C)
 

--- a/Mathlib/CategoryTheory/Products/Basic.lean
+++ b/Mathlib/CategoryTheory/Products/Basic.lean
@@ -248,7 +248,7 @@ section
 variable (C)
 
 /-- The diagonal functor. -/
-@[simps! obj obj_fst obj_snd map map_fst map_snd]
+@[simps! obj map]
 def diag : C ⥤ C × C :=
   (𝟭 C).prod' (𝟭 C)
 

--- a/Mathlib/CategoryTheory/Products/Basic.lean
+++ b/Mathlib/CategoryTheory/Products/Basic.lean
@@ -195,8 +195,7 @@ def evaluation : C ⥤ (C ⥤ D) ⥤ D where
     { obj := fun F => F.obj X
       map := fun α => α.app X }
   map {_} {_} f :=
-    { app := fun F => F.map f
-      naturality := fun {_} {_} α => Eq.symm (α.naturality f) }
+    { app := fun F => F.map f }
 
 /-- The "evaluation of `F` at `X`" functor,
 as a functor `C × (C ⥤ D) ⥤ D`.
@@ -205,11 +204,6 @@ as a functor `C × (C ⥤ D) ⥤ D`.
 def evaluationUncurried : C × (C ⥤ D) ⥤ D where
   obj p := p.2.obj p.1
   map := fun {x} {y} f => x.2.map f.1 ≫ f.2.app y.1
-  map_comp := fun {X} {Y} {Z} f g => by
-    cases g; cases f; cases Z; cases Y; cases X
-    simp only [prod_comp, NatTrans.comp_app, Functor.map_comp, Category.assoc]
-    rw [← NatTrans.comp_app, NatTrans.naturality, NatTrans.comp_app, Category.assoc,
-      NatTrans.naturality]
 
 variable {C}
 
@@ -254,16 +248,9 @@ section
 variable (C)
 
 /-- The diagonal functor. -/
+@[simps! obj obj_fst map map_fst map_snd]
 def diag : C ⥤ C × C :=
   (𝟭 C).prod' (𝟭 C)
-
-@[simp]
-theorem diag_obj (X : C) : (diag C).obj X = (X, X) :=
-  rfl
-
-@[simp]
-theorem diag_map {X Y : C} (f : X ⟶ Y) : (diag C).map f = (f, f) :=
-  rfl
 
 end
 
@@ -272,31 +259,18 @@ end Functor
 namespace NatTrans
 
 /-- The cartesian product of two natural transformations. -/
-@[simps]
+@[simps! app_fst app_snd]
 def prod {F G : A ⥤ B} {H I : C ⥤ D} (α : F ⟶ G) (β : H ⟶ I) : F.prod H ⟶ G.prod I where
   app X := (α.app X.1, β.app X.2)
-  naturality {X} {Y} f := by
-    cases X; cases Y
-    simp only [Functor.prod_map, prod_comp]
-    rw [Prod.mk.inj_iff]
-    constructor
-    repeat {rw [naturality]}
 
 /- Again, it is inadvisable in Lean 3 to setup a notation `α × β`;
    use instead `α.prod β` or `NatTrans.prod α β`. -/
 
-section
-
-variable {F G : A ⥤ C} {H K : A ⥤ D} (α : F ⟶ G) (β : H ⟶ K)
-
-/-- The cartesian product of two natural transformations. -/
-def prod' : F.prod' H ⟶ G.prod' K where
+/-- The cartesian product of two natural transformations where both functors have the
+same source. -/
+@[simps! app_fst app_snd]
+def prod' {F G : A ⥤ B} {H K : A ⥤ C} (α : F ⟶ G) (β : H ⟶ K) : F.prod' H ⟶ G.prod' K where
   app X := (α.app X, β.app X)
-
-@[simp] lemma prod'_app_fst (X : A) : ((prod' α β).app X).1 = α.app X := rfl
-@[simp] lemma prod'_app_snd (X : A) : ((prod' α β).app X).2 = β.app X := rfl
-
-end
 
 end NatTrans
 
@@ -377,27 +351,21 @@ variable (A B C)
 @[simps]
 def prodFunctorToFunctorProd : (A ⥤ B) × (A ⥤ C) ⥤ A ⥤ B × C where
   obj F := F.1.prod' F.2
-  map f := { app := fun X => (f.1.app X, f.2.app X) }
+  map {F G} f := NatTrans.prod' f.1 f.2
 
 /-- The backward direction for `functorProdFunctorEquiv` -/
 @[simps]
 def functorProdToProdFunctor : (A ⥤ B × C) ⥤ (A ⥤ B) × (A ⥤ C) where
   obj F := ⟨F ⋙ CategoryTheory.Prod.fst B C, F ⋙ CategoryTheory.Prod.snd B C⟩
-  map α :=
-    ⟨{  app := fun X => (α.app X).1
-        naturality := fun X Y f => by
-          simp only [Functor.comp_map, Prod.fst_map, ← prod_comp_fst, α.naturality] },
-      { app := fun X => (α.app X).2
-        naturality := fun X Y f => by
-          simp only [Functor.comp_map, Prod.snd_map, ← prod_comp_snd, α.naturality] }⟩
+  map α := ⟨whiskerRight α _, whiskerRight α _⟩
 
 /-- The unit isomorphism for `functorProdFunctorEquiv` -/
 @[simps!]
 def functorProdFunctorEquivUnitIso :
     𝟭 _ ≅ prodFunctorToFunctorProd A B C ⋙ functorProdToProdFunctor A B C :=
   NatIso.ofComponents fun F =>
-    (((Functor.prod'CompFst F.fst F.snd).prod (Functor.prod'CompSnd F.fst F.snd)).trans
-      (prod.etaIso F)).symm
+    Functor.prod'CompFst F.fst F.snd |>.prod (Functor.prod'CompSnd F.fst F.snd) |>.trans
+      (prod.etaIso F) |>.symm
 
 /-- The counit isomorphism for `functorProdFunctorEquiv` -/
 @[simps!]
@@ -418,7 +386,7 @@ section Opposite
 open Opposite
 
 /-- The equivalence between the opposite of a product and the product of the opposites. -/
-@[simps]
+@[simps!]
 def prodOpEquiv : (C × D)ᵒᵖ ≌ Cᵒᵖ × Dᵒᵖ where
   functor :=
     { obj := fun X ↦ ⟨op X.unop.1, op X.unop.2⟩,
@@ -428,9 +396,6 @@ def prodOpEquiv : (C × D)ᵒᵖ ≌ Cᵒᵖ × Dᵒᵖ where
       map := fun ⟨f,g⟩ ↦ op ⟨f.unop, g.unop⟩ }
   unitIso := Iso.refl _
   counitIso := Iso.refl _
-  functor_unitIso_comp := fun ⟨X, Y⟩ => by
-    dsimp
-    ext <;> apply Category.id_comp
 
 end Opposite
 


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

Seems like quite a few proof in this file are found by aesop. Also, the generated simps lemma [prodOpEquiv_counitIso](https://leanprover-community.github.io/mathlib4_docs/Mathlib/CategoryTheory/Products/Basic.html#CategoryTheory.prodOpEquiv_counitIso) had a terrible type, changing the `simps` to a `simps!` helped.

A few `simp` lemmas have been moved inside `simps!` as well.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
