### PR TITLE
[Merged by Bors] - chore(RingTheory/Localization): add `LocalizedModule.equivTensorProduct`

### DIFF
--- a/Mathlib/RingTheory/Localization/BaseChange.lean
+++ b/Mathlib/RingTheory/Localization/BaseChange.lean
@@ -50,6 +50,32 @@ theorem isLocalizedModule_iff_isBaseChange : IsLocalizedModule S f ↔ IsBaseCha
     LinearEquiv.restrictScalars_apply, LinearEquiv.trans_apply, IsBaseChange.equiv_symm_apply,
     IsBaseChange.equiv_tmul, one_smul]
 
+open TensorProduct
+
+variable (M) in
+/-- The localization of an `R`-module `M` at a submonoid `S` is isomorphic to `S⁻¹R ⊗[R] M` as
+an `S⁻¹R`-module. -/
+noncomputable def LocalizedModule.equivTensorProduct :
+    LocalizedModule S M ≃ₗ[Localization S] Localization S ⊗[R] M :=
+  IsLocalizedModule.isBaseChange S (Localization S)
+    (LocalizedModule.mkLinearMap S M) |>.equiv.symm
+
+@[simp]
+lemma LocalizedModule.equivTensorProduct_symm_apply_tmul (x : M) (r : R)(s : S) :
+    (equivTensorProduct S M).symm (Localization.mk r s ⊗ₜ[R] x) = r • mk x s := by
+  simp [equivTensorProduct, IsBaseChange.equiv_tmul, mk_smul_mk, smul'_mk]
+
+@[simp]
+lemma LocalizedModule.equivTensorProduct_symm_apply_tmul_one (x : M) :
+    (equivTensorProduct S M).symm (1 ⊗ₜ[R] x) = mk x 1 := by
+  simp [← Localization.mk_one]
+
+@[simp]
+lemma LocalizedModule.equivTensorProduct_apply_mk (x : M) (s : S) :
+    equivTensorProduct S M (mk x s) = Localization.mk 1 s ⊗ₜ[R] x := by
+  apply (equivTensorProduct S M).symm.injective
+  simp
+
 namespace IsLocalization
 
 open TensorProduct Algebra.TensorProduct
@@ -116,8 +142,7 @@ instance (R M : Type*) [CommRing R] [AddCommGroup M] [Module R M]
     [IsLocalizedModule S f] : IsLocalizedModule S (Finsupp.mapRange.linearMap (α := α) f) := by
   classical
   let e : Localization S ⊗[R] M ≃ₗ[R] Mₛ :=
-    (IsLocalizedModule.isBaseChange S (Localization S)
-      (LocalizedModule.mkLinearMap S M)).equiv.restrictScalars R ≪≫ₗ IsLocalizedModule.iso S f
+    (LocalizedModule.equivTensorProduct S M).symm.restrictScalars R ≪≫ₗ IsLocalizedModule.iso S f
   let e' : Localization S ⊗[R] (α →₀ M) ≃ₗ[R] (α →₀ Mₛ) :=
     finsuppRight R (Localization S) M α ≪≫ₗ Finsupp.mapRange.linearEquiv e
   suffices IsLocalizedModule S (e'.symm.toLinearMap ∘ₗ Finsupp.mapRange.linearMap f) by

--- a/Mathlib/RingTheory/Localization/BaseChange.lean
+++ b/Mathlib/RingTheory/Localization/BaseChange.lean
@@ -61,7 +61,7 @@ noncomputable def LocalizedModule.equivTensorProduct :
     (LocalizedModule.mkLinearMap S M) |>.equiv.symm
 
 @[simp]
-lemma LocalizedModule.equivTensorProduct_symm_apply_tmul (x : M) (r : R)(s : S) :
+lemma LocalizedModule.equivTensorProduct_symm_apply_tmul (x : M) (r : R) (s : S) :
     (equivTensorProduct S M).symm (Localization.mk r s ⊗ₜ[R] x) = r • mk x s := by
   simp [equivTensorProduct, IsBaseChange.equiv_tmul, mk_smul_mk, smul'_mk]
 


### PR DESCRIPTION
That way this shows up when loogling for `LocalizedModule` and `TensorProduct` and it is a frequent, annoying to write out special case of `IsLocalizedModule.isBaseChange`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
