### PR TITLE
[Merged by Bors] - chore(RingTheory/Localization): add `LinearEquiv.extendScalarsOfIsLocalization`

### DIFF
--- a/Mathlib/RingTheory/Localization/Module.lean
+++ b/Mathlib/RingTheory/Localization/Module.lean
@@ -201,6 +201,22 @@ def LinearMap.extendScalarsOfIsLocalizationEquiv : (M →ₗ[R] N) ≃ₗ[A] (M 
   left_inv := by intros _; ext; simp
   right_inv := by intros _; ext; simp
 
+/-- An `R`-linear isomorphism between `S⁻¹R`-modules is actually `S⁻¹R`-linear. -/
+@[simps!]
+def LinearEquiv.extendScalarsOfIsLocalization (f : M ≃ₗ[R] N) : M ≃ₗ[A] N :=
+  .ofLinear (LinearMap.extendScalarsOfIsLocalization S A f)
+    (LinearMap.extendScalarsOfIsLocalization S A f.symm)
+    (by ext; simp) (by ext; simp)
+
+/-- The `S⁻¹R`-linear isomorphisms between two `S⁻¹R`-modules are exactly the `R`-linear
+isomorphisms. -/
+@[simps]
+def LinearEquiv.extendScalarsOfIsLocalizationEquiv : (M ≃ₗ[R] N) ≃ M ≃ₗ[A] N where
+  toFun e := e.extendScalarsOfIsLocalization S A
+  invFun e := e.restrictScalars R
+  left_inv e := by ext; simp
+  right_inv e := by ext; simp
+
 end
 
 end Localization
@@ -221,6 +237,22 @@ variable [IsScalarTower R Rₛ M'] [IsScalarTower R Rₛ N'] [IsLocalization S R
 noncomputable
 def mapExtendScalars : (M →ₗ[R] N) →ₗ[R] (M' →ₗ[Rₛ] N') :=
   ((LinearMap.extendScalarsOfIsLocalizationEquiv S Rₛ).restrictScalars R).toLinearMap ∘ₗ map S f g
+
+/-- An `R`-module isomorphism `M ≃ₗ[R] N` gives an `Rₛ`-module isomorphism `Mₛ ≃ₗ[Rₛ] Nₛ`. -/
+@[simps!]
+noncomputable
+def mapEquiv (e : M ≃ₗ[R] N) : M' ≃ₗ[Rₛ] N' :=
+  LinearEquiv.ofLinear
+    (IsLocalizedModule.mapExtendScalars S f g Rₛ e)
+    (IsLocalizedModule.mapExtendScalars S g f Rₛ e.symm)
+    (by
+      apply LinearMap.restrictScalars_injective R
+      apply IsLocalizedModule.linearMap_ext S g g
+      ext; simp)
+    (by
+      apply LinearMap.restrictScalars_injective R
+      apply IsLocalizedModule.linearMap_ext S f f
+      ext; simp)
 
 end IsLocalizedModule
 

--- a/Mathlib/RingTheory/Smooth/Locus.lean
+++ b/Mathlib/RingTheory/Smooth/Locus.lean
@@ -66,8 +66,8 @@ lemma smoothLocus_eq_compl_support_inter [EssFiniteType R A] :
       exact ⟨fun _ ↦ Module.free_of_flat_of_isLocalRing, fun _ ↦ inferInstance⟩
     · have := IsLocalizedModule.iso p.asIdeal.primeCompl
         (KaehlerDifferential.map R R A (Localization.AtPrime p.asIdeal))
-      have := LinearEquiv.ofBijective (this.extendScalarsOfIsLocalization
-        p.asIdeal.primeCompl (Localization.AtPrime p.asIdeal)) this.bijective
+      have := this.extendScalarsOfIsLocalization
+        p.asIdeal.primeCompl (Localization.AtPrime p.asIdeal)
       exact ⟨fun H ↦ H.of_equiv' this.symm, fun H ↦ H.of_equiv' this⟩
 
 lemma basicOpen_subset_smoothLocus_iff [FinitePresentation R A] {f : A} :
@@ -83,8 +83,7 @@ lemma basicOpen_subset_smoothLocus_iff [FinitePresentation R A] {f : A} :
   · rw [← PrimeSpectrum.basicOpen_eq_zeroLocus_compl, Module.basicOpen_subset_freeLocus_iff]
     have := IsLocalizedModule.iso (.powers f)
         (KaehlerDifferential.map R R A (Localization.Away f))
-    have := LinearEquiv.ofBijective (this.extendScalarsOfIsLocalization
-      (.powers f) (Localization.Away f)) this.bijective
+    have := this.extendScalarsOfIsLocalization (.powers f) (Localization.Away f)
     exact ⟨fun _ ↦ .of_equiv this, fun _ ↦ .of_equiv this.symm⟩
 
 lemma basicOpen_subset_smoothLocus_iff_smooth [FinitePresentation R A] {f : A} :
@@ -129,8 +128,7 @@ lemma isOpen_smoothLocus [FinitePresentation R A] : IsOpen (smoothLocus R A) := 
   have : IsOpen (smoothLocus R Af) := by
     have := IsLocalizedModule.iso (.powers f)
       (KaehlerDifferential.map R R A (Localization.Away f))
-    have := LinearEquiv.ofBijective (this.extendScalarsOfIsLocalization
-      (.powers f) (Localization.Away f)) this.bijective
+    have := this.extendScalarsOfIsLocalization (.powers f) (Localization.Away f)
     have := Module.Projective.of_equiv this
     rw [smoothLocus_eq_compl_support_inter, Module.support_eq_zeroLocus]
     exact (isClosed_zeroLocus _).isOpen_compl.inter Module.isOpen_freeLocus


### PR DESCRIPTION
and two related definitions.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
