### PR TITLE
[Merged by Bors] - feat(Algebra/DirectSum): getting a map between directsums by giving the map on components

### DIFF
--- a/Mathlib/Algebra/DirectSum/Basic.lean
+++ b/Mathlib/Algebra/DirectSum/Basic.lean
@@ -396,24 +396,27 @@ theorem finite_support (A : ι → S) (x : DirectSum ι fun i => A i) :
 
 section map
 
-variable {ι : Type*} [DecidableEq ι] {α : ι → Type*} {β : ι → Type*} [∀ i, AddCommMonoid (α i)]
+variable {ι : Type*} {α : ι → Type*} {β : ι → Type*} [∀ i, AddCommMonoid (α i)]
 variable [∀ i, AddCommMonoid (β i)] (f : ∀(i : ι), α i →+ β i)
 
 /-- create a homomorphism from `⨁ i, α i` to `⨁ i, β i` by giving the component-wise map `f`. -/
-def map : (⨁ i, α i) →+ ⨁ i, β i :=
-  DirectSum.toAddMonoid (fun i : ι ↦ (of β i).comp (f i))
+def map : (⨁ i, α i) →+ ⨁ i, β i :=  DFinsupp.mapRange.addMonoidHom f
+
+variable [DecidableEq ι]
 
 @[simp] lemma map_of (i : ι) (x : α i) : (map f) (of α i x) = of β i (f i x) := by
-  simp [map]
+  show DFinsupp.mapRange.addMonoidHom f (DFinsupp.single i x) = DFinsupp.single i (f i x)
+  simp
 
 @[simp] lemma map_apply (i : ι) (x : ⨁ i, α i) : (map f) x i = f i (x i) := by
-  apply DirectSum.induction_on (C := fun x ↦ (map f) x i = f i (x i)) x
-  · simp
-  · intro j x; rw [map_of, of_apply, of_apply]
-    by_cases h : j = i
-    · simp [h]; subst h; rfl
-    · simp [h]
-  · simp +contextual
+  induction x using DirectSum.induction_on with
+  | H_zero => simp
+  | H_basic j x =>
+    rw [map_of, of_apply, of_apply]
+    obtain rfl | h := eq_or_ne j i
+    · simp
+    · simp [of_apply, h]
+  | H_plus _ _ hx hy => simp [hx, hy]
 
 @[simp] lemma map_id : (map (fun i ↦ AddMonoidHom.id (α i))) = AddMonoidHom.id (⨁ i, α i) := by
   ext i x; simp
@@ -424,17 +427,22 @@ def map : (⨁ i, α i) →+ ⨁ i, β i :=
 
 lemma map_surjective (h : ∀ i, Function.Surjective (f i)) : Function.Surjective (map f) := by
   intro x
-  apply DirectSum.induction_on (C := fun x ↦ ∃ a, (map f) a = x) x
-  · use 0; rfl
-  · intro i x; obtain ⟨y, hy⟩ := h i x; use of α i y; simp [hy]
-  · rintro x y ⟨u, hu⟩ ⟨v, hv⟩; use (u + v); simp [hu, hv]
+  induction x using DirectSum.induction_on with
+  | H_zero => exact ⟨0, by simp⟩
+  | H_basic i x =>
+    obtain ⟨y, rfl⟩ := h i x
+    exact ⟨of α i y, by simp⟩
+  | H_plus x y hx hy =>
+    obtain ⟨u, rfl⟩ := hx
+    obtain ⟨v, rfl⟩ := hy
+    exact ⟨u + v, by simp⟩
 
 lemma map_eq_iff (x y : ⨁ i, α i) : map f x = map f y ↔ ∀ i, f i (x i) = f i (y i) := by
   constructor
   · intro h i
-    have : (map f) x i = (map f) y i := by rw [h]
-    simpa using this
-  · intro h; ext i; simpa using h i
+    simpa using congr($h i)
+  · intro h; ext i
+    simpa using h i
 
 end map
 

--- a/Mathlib/Algebra/DirectSum/Basic.lean
+++ b/Mathlib/Algebra/DirectSum/Basic.lean
@@ -394,38 +394,45 @@ theorem finite_support (A : ι → S) (x : DirectSum ι fun i => A i) :
   classical
   exact (DFinsupp.support x).finite_toSet.subset (DirectSum.support_subset _ x)
 
-section map
+namespace mapRange
 
 variable {ι : Type*} {α : ι → Type*} {β : ι → Type*} [∀ i, AddCommMonoid (α i)]
-variable [∀ i, AddCommMonoid (β i)] (f : ∀(i : ι), α i →+ β i)
+variable [∀ i, AddCommMonoid (β i)]
+
+section addHom
+
+variable (f : ∀(i : ι), α i →+ β i)
 
 /-- create a homomorphism from `⨁ i, α i` to `⨁ i, β i` by giving the component-wise map `f`. -/
-def map : (⨁ i, α i) →+ ⨁ i, β i :=  DFinsupp.mapRange.addMonoidHom f
+def addHom : (⨁ i, α i) →+ ⨁ i, β i :=  DFinsupp.mapRange.addMonoidHom f
 
 variable [DecidableEq ι]
 
-@[simp] lemma map_of (i : ι) (x : α i) : (map f) (of α i x) = of β i (f i x) := by
+@[simp] lemma addHom_of (i : ι) (x : α i) : (addHom f) (of α i x) = of β i (f i x) := by
   show DFinsupp.mapRange.addMonoidHom f (DFinsupp.single i x) = DFinsupp.single i (f i x)
   simp
 
-@[simp] lemma map_apply (i : ι) (x : ⨁ i, α i) : (map f) x i = f i (x i) := by
+@[simp] lemma addHom_apply (i : ι) (x : ⨁ i, α i) : (addHom f) x i = f i (x i) := by
   induction x using DirectSum.induction_on with
   | H_zero => simp
   | H_basic j x =>
-    rw [map_of, of_apply, of_apply]
+    rw [addHom_of, of_apply, of_apply]
     obtain rfl | h := eq_or_ne j i
     · simp
     · simp [of_apply, h]
   | H_plus _ _ hx hy => simp [hx, hy]
 
-@[simp] lemma map_id : (map (fun i ↦ AddMonoidHom.id (α i))) = AddMonoidHom.id (⨁ i, α i) := by
+@[simp] lemma addHom_id :
+    (addHom (fun i ↦ AddMonoidHom.id (α i))) = AddMonoidHom.id (⨁ i, α i) := by
   ext i x; simp
 
-@[simp] lemma map_comp {γ : ι → Type*} [∀ i, AddCommMonoid (γ i)] (g : ∀ (i : ι), β i →+ γ i) :
-    (map (fun i ↦ (g i).comp (f i))) = (map g).comp (map f) := by
+@[simp] lemma addHom_comp {γ : ι → Type*} [∀ i, AddCommMonoid (γ i)]
+    (g : ∀ (i : ι), β i →+ γ i) :
+    (addHom (fun i ↦ (g i).comp (f i))) = (addHom g).comp (addHom f) := by
   ext i x; simp
 
-lemma map_surjective (h : ∀ i, Function.Surjective (f i)) : Function.Surjective (map f) := by
+lemma addHom_surjective (h : ∀ i, Function.Surjective (f i)) :
+    Function.Surjective (addHom f) := by
   intro x
   induction x using DirectSum.induction_on with
   | H_zero => exact ⟨0, by simp⟩
@@ -437,14 +444,17 @@ lemma map_surjective (h : ∀ i, Function.Surjective (f i)) : Function.Surjectiv
     obtain ⟨v, rfl⟩ := hy
     exact ⟨u + v, by simp⟩
 
-lemma map_eq_iff (x y : ⨁ i, α i) : map f x = map f y ↔ ∀ i, f i (x i) = f i (y i) := by
+lemma addHom_eq_iff (x y : ⨁ i, α i) :
+    addHom f x = addHom f y ↔ ∀ i, f i (x i) = f i (y i) := by
   constructor
   · intro h i
     simpa using congr($h i)
   · intro h; ext i
     simpa using h i
 
-end map
+end addHom
+
+end mapRange
 
 end DirectSum
 

--- a/Mathlib/Algebra/DirectSum/Basic.lean
+++ b/Mathlib/Algebra/DirectSum/Basic.lean
@@ -406,34 +406,25 @@ variable (f : ∀(i : ι), α i →+ β i)
 /-- create a homomorphism from `⨁ i, α i` to `⨁ i, β i` by giving the component-wise map `f`. -/
 def addHom : (⨁ i, α i) →+ ⨁ i, β i :=  DFinsupp.mapRange.addMonoidHom f
 
-variable [DecidableEq ι]
+@[simp] lemma addHom_of [DecidableEq ι] (i : ι) (x : α i) : addHom f (of α i x) = of β i (f i x) :=
+  DFinsupp.mapRange_single (hf := fun _ => map_zero _)
 
-@[simp] lemma addHom_of (i : ι) (x : α i) : (addHom f) (of α i x) = of β i (f i x) := by
-  show DFinsupp.mapRange.addMonoidHom f (DFinsupp.single i x) = DFinsupp.single i (f i x)
-  simp
-
-@[simp] lemma addHom_apply (i : ι) (x : ⨁ i, α i) : (addHom f) x i = f i (x i) := by
-  induction x using DirectSum.induction_on with
-  | H_zero => simp
-  | H_basic j x =>
-    rw [addHom_of, of_apply, of_apply]
-    obtain rfl | h := eq_or_ne j i
-    · simp
-    · simp [of_apply, h]
-  | H_plus _ _ hx hy => simp [hx, hy]
+@[simp] lemma addHom_apply (i : ι) (x : ⨁ i, α i) : addHom f x i = f i (x i) :=
+  DFinsupp.mapRange_apply (hf := fun _ => map_zero _) _ _ _
 
 @[simp] lemma addHom_id :
-    (addHom (fun i ↦ AddMonoidHom.id (α i))) = AddMonoidHom.id (⨁ i, α i) := by
-  ext i x; simp
+    (addHom (fun i ↦ AddMonoidHom.id (α i))) = AddMonoidHom.id (⨁ i, α i) :=
+  DFinsupp.mapRange.addMonoidHom_id
 
 @[simp] lemma addHom_comp {γ : ι → Type*} [∀ i, AddCommMonoid (γ i)]
     (g : ∀ (i : ι), β i →+ γ i) :
-    (addHom (fun i ↦ (g i).comp (f i))) = (addHom g).comp (addHom f) := by
-  ext i x; simp
+    (addHom (fun i ↦ (g i).comp (f i))) = (addHom g).comp (addHom f) :=
+  DFinsupp.mapRange.addMonoidHom_comp _ _
 
 lemma addHom_surjective (h : ∀ i, Function.Surjective (f i)) :
     Function.Surjective (addHom f) := by
   intro x
+  classical
   induction x using DirectSum.induction_on with
   | H_zero => exact ⟨0, by simp⟩
   | H_basic i x =>
@@ -446,11 +437,7 @@ lemma addHom_surjective (h : ∀ i, Function.Surjective (f i)) :
 
 lemma addHom_eq_iff (x y : ⨁ i, α i) :
     addHom f x = addHom f y ↔ ∀ i, f i (x i) = f i (y i) := by
-  constructor
-  · intro h i
-    simpa using congr($h i)
-  · intro h; ext i
-    simpa using h i
+  simp_rw [DirectSum.ext_iff, addHom_apply]
 
 end addHom
 

--- a/Mathlib/Algebra/DirectSum/Basic.lean
+++ b/Mathlib/Algebra/DirectSum/Basic.lean
@@ -394,54 +394,40 @@ theorem finite_support (A : ι → S) (x : DirectSum ι fun i => A i) :
   classical
   exact (DFinsupp.support x).finite_toSet.subset (DirectSum.support_subset _ x)
 
-namespace mapRange
+section map
 
 variable {ι : Type*} {α : ι → Type*} {β : ι → Type*} [∀ i, AddCommMonoid (α i)]
-variable [∀ i, AddCommMonoid (β i)]
-
-section addHom
-
-variable (f : ∀(i : ι), α i →+ β i)
+variable [∀ i, AddCommMonoid (β i)] (f : ∀(i : ι), α i →+ β i)
 
 /-- create a homomorphism from `⨁ i, α i` to `⨁ i, β i` by giving the component-wise map `f`. -/
-def addHom : (⨁ i, α i) →+ ⨁ i, β i :=  DFinsupp.mapRange.addMonoidHom f
+def map : (⨁ i, α i) →+ ⨁ i, β i :=  DFinsupp.mapRange.addMonoidHom f
 
-@[simp] lemma addHom_of [DecidableEq ι] (i : ι) (x : α i) : addHom f (of α i x) = of β i (f i x) :=
+@[simp] lemma map_of [DecidableEq ι] (i : ι) (x : α i) : map f (of α i x) = of β i (f i x) :=
   DFinsupp.mapRange_single (hf := fun _ => map_zero _)
 
-@[simp] lemma addHom_apply (i : ι) (x : ⨁ i, α i) : addHom f x i = f i (x i) :=
+@[simp] lemma map_apply (i : ι) (x : ⨁ i, α i) : map f x i = f i (x i) :=
   DFinsupp.mapRange_apply (hf := fun _ => map_zero _) _ _ _
 
-@[simp] lemma addHom_id :
-    (addHom (fun i ↦ AddMonoidHom.id (α i))) = AddMonoidHom.id (⨁ i, α i) :=
+@[simp] lemma map_id :
+    (map (fun i ↦ AddMonoidHom.id (α i))) = AddMonoidHom.id (⨁ i, α i) :=
   DFinsupp.mapRange.addMonoidHom_id
 
-@[simp] lemma addHom_comp {γ : ι → Type*} [∀ i, AddCommMonoid (γ i)]
+@[simp] lemma map_comp {γ : ι → Type*} [∀ i, AddCommMonoid (γ i)]
     (g : ∀ (i : ι), β i →+ γ i) :
-    (addHom (fun i ↦ (g i).comp (f i))) = (addHom g).comp (addHom f) :=
+    (map (fun i ↦ (g i).comp (f i))) = (map g).comp (map f) :=
   DFinsupp.mapRange.addMonoidHom_comp _ _
 
-lemma addHom_surjective (h : ∀ i, Function.Surjective (f i)) :
-    Function.Surjective (addHom f) := by
-  intro x
-  classical
-  induction x using DirectSum.induction_on with
-  | H_zero => exact ⟨0, by simp⟩
-  | H_basic i x =>
-    obtain ⟨y, rfl⟩ := h i x
-    exact ⟨of α i y, by simp⟩
-  | H_plus x y hx hy =>
-    obtain ⟨u, rfl⟩ := hx
-    obtain ⟨v, rfl⟩ := hy
-    exact ⟨u + v, by simp⟩
+lemma map_injective : Function.Injective (map f) ↔ ∀ i, Function.Injective (f i) := by
+  classical exact DFinsupp.mapRange_injective (hf := fun _ ↦ map_zero _)
 
-lemma addHom_eq_iff (x y : ⨁ i, α i) :
-    addHom f x = addHom f y ↔ ∀ i, f i (x i) = f i (y i) := by
-  simp_rw [DirectSum.ext_iff, addHom_apply]
+lemma map_surjective : Function.Surjective (map f) ↔ (∀ i, Function.Surjective (f i)) := by
+  classical exact DFinsupp.mapRange_surjective (hf := fun _ ↦ map_zero _)
 
-end addHom
+lemma map_eq_iff (x y : ⨁ i, α i) :
+    map f x = map f y ↔ ∀ i, f i (x i) = f i (y i) := by
+  simp_rw [DirectSum.ext_iff, map_apply]
 
-end mapRange
+end map
 
 end DirectSum
 

--- a/Mathlib/Algebra/DirectSum/Module.lean
+++ b/Mathlib/Algebra/DirectSum/Module.lean
@@ -241,7 +241,8 @@ lemma lmap_eq_iff (x y : ⨁ i, M i) :
     lmap f x = lmap f y ↔ ∀ i, f i (x i) = f i (y i) :=
   map_eq_iff (fun i => (f i).toAddMonoidHom) _ _
 
-lemma map_eq_lmap (x : ⨁ i, M i) : map (fun i => (f i).toAddMonoidHom) x = lmap f x :=
+lemma toAddMonoidHom_lmap :
+    (lmap f).toAddMonoidHom = map (fun i => (f i).toAddMonoidHom) :=
   ext _ fun i ↦ (by simp)
 
 end map

--- a/Mathlib/Algebra/DirectSum/Module.lean
+++ b/Mathlib/Algebra/DirectSum/Module.lean
@@ -228,7 +228,7 @@ def lmap : (⨁ i, M i) →ₗ[R] ⨁ i, N i := DFinsupp.mapRange.linearMap f
 
 @[simp] lemma lmap_comp {K : ι → Type*} [∀ i, AddCommMonoid (K i)] [∀ i, Module R (K i)]
     (g : ∀ (i : ι), N i →ₗ[R] K i) :
-    (lmap (fun i ↦ (g i).comp (f i))) = (lmap g).comp (lmap f) :=
+    (lmap (fun i ↦ (g i) ∘ₗ (f i))) = (lmap g) ∘ₗ (lmap f) :=
   DFinsupp.mapRange.linearMap_comp _ _
 
 theorem lmap_injective : Function.Injective (lmap f) ↔ ∀ i, Function.Injective (f i) := by

--- a/Mathlib/Algebra/DirectSum/Module.lean
+++ b/Mathlib/Algebra/DirectSum/Module.lean
@@ -503,51 +503,29 @@ variable (f : ∀ (i : ι), α i →ₗ[R] β i)
 /-- create a linear map from `⨁ i, α i` to `⨁ i, β i` by giving the component-wise map `f`. -/
 def linearMap : (⨁ i, α i) →ₗ[R] ⨁ i, β i :=  DFinsupp.mapRange.linearMap f
 
-variable [DecidableEq ι]
+@[simp] lemma linearMap_of [DecidableEq ι] (i : ι) (x : α i) :
+    linearMap f (of α i x) = of β i (f i x) :=
+  DFinsupp.mapRange_single (hf := fun _ => map_zero _)
 
-@[simp] lemma linearMap_of (i : ι) (x : α i) : (linearMap f) (of α i x) = of β i (f i x) := by
-  show DFinsupp.mapRange.linearMap f (DFinsupp.single i x) = DFinsupp.single i (f i x)
-  simp
-
-@[simp] lemma linearMap_apply (i : ι) (x : ⨁ i, α i) : (linearMap f) x i = f i (x i) := by
-  induction x using DirectSum.induction_on with
-  | H_zero => simp
-  | H_basic j x =>
-    rw [linearMap_of, of_apply, of_apply]
-    obtain rfl | h := eq_or_ne j i
-    · simp
-    · simp [of_apply, h]
-  | H_plus _ _ hx hy => simp [hx, hy]
+@[simp] lemma linearMap_apply (i : ι) (x : ⨁ i, α i) : (linearMap f) x i = f i (x i) :=
+  DFinsupp.mapRange_apply (hf := fun _ => map_zero _) _ _ _
 
 @[simp] lemma linearMap_id :
-    (linearMap (fun i ↦ LinearMap.id (R := R) (M := α i))) = LinearMap.id := by
-  ext i x; simp
+    (linearMap (fun i ↦ LinearMap.id (R := R) (M := α i))) = LinearMap.id :=
+  DFinsupp.mapRange.linearMap_id
 
 @[simp] lemma linearMap_comp {γ : ι → Type*} [∀ i, AddCommMonoid (γ i)] [∀ i, Module R (γ i)]
     (g : ∀ (i : ι), β i →ₗ[R] γ i) :
-    (linearMap (fun i ↦ (g i).comp (f i))) = (linearMap g).comp (linearMap f) := by
-  ext i x; simp
+    (linearMap (fun i ↦ (g i).comp (f i))) = (linearMap g).comp (linearMap f) :=
+  DFinsupp.mapRange.linearMap_comp _ _
 
 lemma linearMap_surjective (h : ∀ i, Function.Surjective (f i)) :
-    Function.Surjective (linearMap f) := by
-  intro x
-  induction x using DirectSum.induction_on with
-  | H_zero => exact ⟨0, by simp⟩
-  | H_basic i x =>
-    obtain ⟨y, rfl⟩ := h i x
-    exact ⟨of α i y, by simp⟩
-  | H_plus x y hx hy =>
-    obtain ⟨u, rfl⟩ := hx
-    obtain ⟨v, rfl⟩ := hy
-    exact ⟨u + v, by simp⟩
+    Function.Surjective (linearMap f) :=
+  addHom_surjective (fun i => (f i).toAddMonoidHom) h
 
 lemma linearMap_eq_iff (x y : ⨁ i, α i) :
-    linearMap f x = linearMap f y ↔ ∀ i, f i (x i) = f i (y i) := by
-  constructor
-  · intro h i
-    simpa using congr($h i)
-  · intro h; ext i
-    simpa using h i
+    linearMap f x = linearMap f y ↔ ∀ i, f i (x i) = f i (y i) :=
+  addHom_eq_iff (fun i => (f i).toAddMonoidHom) _ _
 
 end linearMap
 

--- a/Mathlib/Algebra/DirectSum/Module.lean
+++ b/Mathlib/Algebra/DirectSum/Module.lean
@@ -490,4 +490,67 @@ end Ring
 
 end Submodule
 
+namespace mapRange
+
+section linearMap
+
+variable {ι : Type*} {α : ι → Type*} {β : ι → Type*} {R : Type*} [Semiring R]
+variable [∀ i, AddCommMonoid (α i)] [∀ i, AddCommMonoid (β i)]
+variable [∀ i, Module R (α i)] [∀ i, Module R (β i)]
+
+variable (f : ∀ (i : ι), α i →ₗ[R] β i)
+
+/-- create a linear map from `⨁ i, α i` to `⨁ i, β i` by giving the component-wise map `f`. -/
+def linearMap : (⨁ i, α i) →ₗ[R] ⨁ i, β i :=  DFinsupp.mapRange.linearMap f
+
+variable [DecidableEq ι]
+
+@[simp] lemma linearMap_of (i : ι) (x : α i) : (linearMap f) (of α i x) = of β i (f i x) := by
+  show DFinsupp.mapRange.linearMap f (DFinsupp.single i x) = DFinsupp.single i (f i x)
+  simp
+
+@[simp] lemma linearMap_apply (i : ι) (x : ⨁ i, α i) : (linearMap f) x i = f i (x i) := by
+  induction x using DirectSum.induction_on with
+  | H_zero => simp
+  | H_basic j x =>
+    rw [linearMap_of, of_apply, of_apply]
+    obtain rfl | h := eq_or_ne j i
+    · simp
+    · simp [of_apply, h]
+  | H_plus _ _ hx hy => simp [hx, hy]
+
+@[simp] lemma linearMap_id :
+    (linearMap (fun i ↦ LinearMap.id (R := R) (M := α i))) = LinearMap.id := by
+  ext i x; simp
+
+@[simp] lemma linearMap_comp {γ : ι → Type*} [∀ i, AddCommMonoid (γ i)] [∀ i, Module R (γ i)]
+    (g : ∀ (i : ι), β i →ₗ[R] γ i) :
+    (linearMap (fun i ↦ (g i).comp (f i))) = (linearMap g).comp (linearMap f) := by
+  ext i x; simp
+
+lemma linearMap_surjective (h : ∀ i, Function.Surjective (f i)) :
+    Function.Surjective (linearMap f) := by
+  intro x
+  induction x using DirectSum.induction_on with
+  | H_zero => exact ⟨0, by simp⟩
+  | H_basic i x =>
+    obtain ⟨y, rfl⟩ := h i x
+    exact ⟨of α i y, by simp⟩
+  | H_plus x y hx hy =>
+    obtain ⟨u, rfl⟩ := hx
+    obtain ⟨v, rfl⟩ := hy
+    exact ⟨u + v, by simp⟩
+
+lemma linearMap_eq_iff (x y : ⨁ i, α i) :
+    linearMap f x = linearMap f y ↔ ∀ i, f i (x i) = f i (y i) := by
+  constructor
+  · intro h i
+    simpa using congr($h i)
+  · intro h; ext i
+    simpa using h i
+
+end linearMap
+
+end mapRange
+
 end DirectSum

--- a/Mathlib/Algebra/DirectSum/Module.lean
+++ b/Mathlib/Algebra/DirectSum/Module.lean
@@ -245,6 +245,9 @@ lemma toAddMonoidHom_lmap :
     (lmap f).toAddMonoidHom = map (fun i => (f i).toAddMonoidHom) :=
   rfl
 
+lemma lmap_eq_map (x : ⨁ i, M i) : lmap f x = map (fun i => (f i).toAddMonoidHom) x :=
+  rfl
+
 end map
 
 section CongrLeft

--- a/Mathlib/Algebra/DirectSum/Module.lean
+++ b/Mathlib/Algebra/DirectSum/Module.lean
@@ -243,7 +243,7 @@ lemma lmap_eq_iff (x y : ⨁ i, M i) :
 
 lemma toAddMonoidHom_lmap :
     (lmap f).toAddMonoidHom = map (fun i => (f i).toAddMonoidHom) :=
-  ext _ fun i ↦ (by simp)
+  rfl
 
 end map
 

--- a/Mathlib/Algebra/DirectSum/Module.lean
+++ b/Mathlib/Algebra/DirectSum/Module.lean
@@ -214,12 +214,32 @@ def lmap : (⨁ i, M i) →ₗ[R] ⨁ i, N i := DFinsupp.mapRange.linearMap f
 
 @[simp] theorem lmap_apply (x i) : lmap f x i = f i (x i) := rfl
 
+@[simp] lemma lmap_of [DecidableEq ι] (i : ι) (x : M i) :
+    lmap f (of M i x) = of N i (f i x) :=
+  DFinsupp.mapRange_single (hf := fun _ => map_zero _)
+
 @[simp] theorem lmap_lof [DecidableEq ι] (i) (x : M i) :
     lmap f (lof R _ _ _ x) = lof R _ _ _ (f i x) :=
   DFinsupp.mapRange_single (hf := fun _ ↦ map_zero _)
 
+@[simp] lemma lmap_id :
+    (lmap (fun i ↦ LinearMap.id (R := R) (M := M i))) = LinearMap.id :=
+  DFinsupp.mapRange.linearMap_id
+
+@[simp] lemma lmap_comp {K : ι → Type*} [∀ i, AddCommMonoid (K i)] [∀ i, Module R (K i)]
+    (g : ∀ (i : ι), N i →ₗ[R] K i) :
+    (lmap (fun i ↦ (g i).comp (f i))) = (lmap g).comp (lmap f) :=
+  DFinsupp.mapRange.linearMap_comp _ _
+
 theorem lmap_injective : Function.Injective (lmap f) ↔ ∀ i, Function.Injective (f i) := by
   classical exact DFinsupp.mapRange_injective (hf := fun _ ↦ map_zero _)
+
+theorem lmap_surjective : Function.Surjective (lmap f) ↔ (∀ i, Function.Surjective (f i)) := by
+  classical exact DFinsupp.mapRange_surjective (hf := fun _ ↦ map_zero _)
+
+lemma lmap_eq_iff (x y : ⨁ i, M i) :
+    lmap f x = lmap f y ↔ ∀ i, f i (x i) = f i (y i) :=
+  map_eq_iff (fun i => (f i).toAddMonoidHom) _ _
 
 end map
 
@@ -489,46 +509,5 @@ alias IsInternal.addSubgroup_independent := IsInternal.addSubgroup_iSupIndep
 end Ring
 
 end Submodule
-
-namespace mapRange
-
-section linearMap
-
-variable {ι : Type*} {α : ι → Type*} {β : ι → Type*} {R : Type*} [Semiring R]
-variable [∀ i, AddCommMonoid (α i)] [∀ i, AddCommMonoid (β i)]
-variable [∀ i, Module R (α i)] [∀ i, Module R (β i)]
-
-variable (f : ∀ (i : ι), α i →ₗ[R] β i)
-
-/-- create a linear map from `⨁ i, α i` to `⨁ i, β i` by giving the component-wise map `f`. -/
-def linearMap : (⨁ i, α i) →ₗ[R] ⨁ i, β i :=  DFinsupp.mapRange.linearMap f
-
-@[simp] lemma linearMap_of [DecidableEq ι] (i : ι) (x : α i) :
-    linearMap f (of α i x) = of β i (f i x) :=
-  DFinsupp.mapRange_single (hf := fun _ => map_zero _)
-
-@[simp] lemma linearMap_apply (i : ι) (x : ⨁ i, α i) : (linearMap f) x i = f i (x i) :=
-  DFinsupp.mapRange_apply (hf := fun _ => map_zero _) _ _ _
-
-@[simp] lemma linearMap_id :
-    (linearMap (fun i ↦ LinearMap.id (R := R) (M := α i))) = LinearMap.id :=
-  DFinsupp.mapRange.linearMap_id
-
-@[simp] lemma linearMap_comp {γ : ι → Type*} [∀ i, AddCommMonoid (γ i)] [∀ i, Module R (γ i)]
-    (g : ∀ (i : ι), β i →ₗ[R] γ i) :
-    (linearMap (fun i ↦ (g i).comp (f i))) = (linearMap g).comp (linearMap f) :=
-  DFinsupp.mapRange.linearMap_comp _ _
-
-lemma linearMap_surjective (h : ∀ i, Function.Surjective (f i)) :
-    Function.Surjective (linearMap f) :=
-  addHom_surjective (fun i => (f i).toAddMonoidHom) h
-
-lemma linearMap_eq_iff (x y : ⨁ i, α i) :
-    linearMap f x = linearMap f y ↔ ∀ i, f i (x i) = f i (y i) :=
-  addHom_eq_iff (fun i => (f i).toAddMonoidHom) _ _
-
-end linearMap
-
-end mapRange
 
 end DirectSum

--- a/Mathlib/Algebra/DirectSum/Module.lean
+++ b/Mathlib/Algebra/DirectSum/Module.lean
@@ -241,6 +241,9 @@ lemma lmap_eq_iff (x y : ⨁ i, M i) :
     lmap f x = lmap f y ↔ ∀ i, f i (x i) = f i (y i) :=
   map_eq_iff (fun i => (f i).toAddMonoidHom) _ _
 
+lemma map_eq_lmap (x : ⨁ i, M i) : map (fun i => (f i).toAddMonoidHom) x = lmap f x :=
+  ext _ fun i ↦ (by simp)
+
 end map
 
 section CongrLeft

--- a/Mathlib/Data/DFinsupp/Defs.lean
+++ b/Mathlib/Data/DFinsupp/Defs.lean
@@ -928,23 +928,21 @@ theorem mapRange_injective (f : ∀ i, β₁ i → β₂ i) (hf : ∀ i, f i 0 =
     simpa using congr_arg _ eq), fun h _ _ eq ↦ DFinsupp.ext fun i ↦ h i congr($eq i)⟩
 
 theorem mapRange_surjective (f : ∀ i, β₁ i → β₂ i) (hf : ∀ i, f i 0 = 0) :
-    Function.Surjective (mapRange f hf) ↔ ∀ i, Function.Surjective (f i) := ⟨
-      fun h i u ↦ by
-        obtain ⟨x, hx⟩ := h (single i u)
-        exact ⟨x i, by simpa using congr($hx i)⟩,
-      fun h x ↦ by
-        obtain ⟨x, ⟨s, hs⟩⟩ := x
-        have : ∀ i : ι, ∃ u : β₁ i, (f i u = x i) ∧ ((x i = 0) → (u = 0)) := fun i ↦
-          Or.elim (eq_or_ne (x i) 0)
-            (fun h ↦ ⟨0, ⟨(hf i).trans h.symm, fun _ ↦ rfl⟩⟩)
-            (fun h' ↦ by
-              obtain ⟨u, hu⟩ := h i (x i)
-              exact ⟨u, ⟨hu, fun h'' ↦ False.elim (h' h'')⟩⟩)
-        choose y hy using this
-        refine ⟨⟨y, Trunc.mk ⟨s, fun i ↦ ?_⟩⟩, ext fun i ↦ ?_⟩
-        · exact Or.elim (hs i) (fun h ↦ Or.inl h) (fun h ↦ Or.inr ((hy i).2 h))
-        · simp [(hy i).1]
-    ⟩
+    Function.Surjective (mapRange f hf) ↔ ∀ i, Function.Surjective (f i) := by
+  refine ⟨fun h i u ↦ ?_, fun h x ↦ ?_⟩
+  · obtain ⟨x, hx⟩ := h (single i u)
+    exact ⟨x i, by simpa using congr($hx i)⟩
+  · obtain ⟨x, s, hs⟩ := x
+    have (i : ι) : ∃ u : β₁ i, f i u = x i ∧ (x i = 0 → u = 0) :=
+      (eq_or_ne (x i) 0).elim
+        (fun h ↦ ⟨0, (hf i).trans h.symm, fun _ ↦ rfl⟩)
+        (fun h' ↦ by
+          obtain ⟨u, hu⟩ := h i (x i)
+          exact ⟨u, hu, fun h'' ↦ (h' h'').elim⟩)
+    choose y hy using this
+    refine ⟨⟨y, Trunc.mk ⟨s, fun i ↦ ?_⟩⟩, ext fun i ↦ ?_⟩
+    · exact (hs i).imp_right (hy i).2
+    · simp [(hy i).1]
 
 variable [∀ (i) (x : β₁ i), Decidable (x ≠ 0)] [∀ (i) (x : β₂ i), Decidable (x ≠ 0)]
 

--- a/Mathlib/Data/DFinsupp/Defs.lean
+++ b/Mathlib/Data/DFinsupp/Defs.lean
@@ -927,6 +927,25 @@ theorem mapRange_injective (f : ∀ i, β₁ i → β₂ i) (hf : ∀ i, f i 0 =
   ⟨fun h i x y eq ↦ single_injective (@h (single i x) (single i y) <| by
     simpa using congr_arg _ eq), fun h _ _ eq ↦ DFinsupp.ext fun i ↦ h i congr($eq i)⟩
 
+theorem mapRange_surjective (f : ∀ i, β₁ i → β₂ i) (hf : ∀ i, f i 0 = 0) :
+    Function.Surjective (mapRange f hf) ↔ ∀ i, Function.Surjective (f i) := ⟨
+      fun h i u ↦ by
+        obtain ⟨x, hx⟩ := h (single i u)
+        exact ⟨x i, by simpa using congr($hx i)⟩,
+      fun h x ↦ by
+        obtain ⟨x, ⟨s, hs⟩⟩ := x
+        have : ∀ i : ι, ∃ u : β₁ i, (f i u = x i) ∧ ((x i = 0) → (u = 0)) := fun i ↦
+          Or.elim (eq_or_ne (x i) 0)
+            (fun h ↦ ⟨0, ⟨(hf i).trans h.symm, fun _ ↦ rfl⟩⟩)
+            (fun h' ↦ by
+              obtain ⟨u, hu⟩ := h i (x i)
+              exact ⟨u, ⟨hu, fun h'' ↦ False.elim (h' h'')⟩⟩)
+        choose y hy using this
+        refine ⟨⟨y, Trunc.mk ⟨s, fun i ↦ ?_⟩⟩, ext fun i ↦ ?_⟩
+        · exact Or.elim (hs i) (fun h ↦ Or.inl h) (fun h ↦ Or.inr ((hy i).2 h))
+        · simp [(hy i).1]
+    ⟩
+
 variable [∀ (i) (x : β₁ i), Decidable (x ≠ 0)] [∀ (i) (x : β₂ i), Decidable (x ≠ 0)]
 
 theorem support_mapRange {f : ∀ i, β₁ i → β₂ i} {hf : ∀ i, f i 0 = 0} {g : Π₀ i, β₁ i} :


### PR DESCRIPTION
This PR defines the map obtained between `DirectSum`s by giving the component-wise mapping. More specifically, it creates a homomorphism `DirectSum.map f : (⨁ i, α i) →+ ⨁ i, β i` from the component-wise map `f : ∀(i : ι), α i →+ β i`. We also proved some basic properties of this function. This construction is expected to be used in things related to graded rings.

The linear version of this map was added already in #20265.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)


#22279 depends on this PR.