### PR TITLE
feat(Algebra/RingQuot): Some lemmas about `RingQuot.mkAlgHom` and `RingQuot.mkRingHom`

### DIFF
--- a/Mathlib/Algebra/RingQuot.lean
+++ b/Mathlib/Algebra/RingQuot.lean
@@ -391,6 +391,14 @@ irreducible_def mkRingHom (r : R → R → Prop) : R →+* RingQuot r :=
     map_zero' := by simp [← zero_quot]
     map_add' := by simp [add_quot] }
 
+theorem mkRingHom_eq_iff (r : R → R → Prop) (x y : R) :
+    mkRingHom r x = mkRingHom r y ↔ (Relation.EqvGen (Rel r)) x y := by
+  simp [mkRingHom_def, Quot.eq]
+
+theorem mkRingHom_eq_iff' (r : R → R → Prop) (x y : R) :
+    mkRingHom r x = mkRingHom r y ↔ (RingConGen.Rel r) x y := by
+  rw [← eqvGen_rel_eq]; exact mkRingHom_eq_iff r x y
+
 theorem mkRingHom_rel {r : R → R → Prop} {x y : R} (w : r x y) : mkRingHom r x = mkRingHom r y := by
   simp [mkRingHom_def, Quot.sound (Rel.of w)]
 
@@ -539,6 +547,14 @@ irreducible_def mkAlgHom (s : A → A → Prop) : A →ₐ[S] RingQuot s :=
 theorem mkAlgHom_coe (s : A → A → Prop) : (mkAlgHom S s : A →+* RingQuot s) = mkRingHom s := by
   simp_rw [mkAlgHom_def, mkRingHom_def]
   rfl
+
+theorem mkAlgHom_eq_iff (s : A → A → Prop) (x y : A) :
+    mkAlgHom S s x = mkAlgHom S s y ↔ (Relation.EqvGen (Rel s)) x y := by
+  simp [mkAlgHom_def, mkRingHom_def, Quot.eq]
+
+theorem mkAlgHom_eq_iff' (s : A → A → Prop) (x y : A) :
+    mkAlgHom S s x = mkAlgHom S s y ↔ (RingConGen.Rel s) x y := by
+  rw [← eqvGen_rel_eq]; exact mkAlgHom_eq_iff S s x y
 
 theorem mkAlgHom_rel {s : A → A → Prop} {x y : A} (w : s x y) :
     mkAlgHom S s x = mkAlgHom S s y := by

--- a/Mathlib/Algebra/RingQuot.lean
+++ b/Mathlib/Algebra/RingQuot.lean
@@ -397,7 +397,7 @@ theorem mkRingHom_eq_iff (r : R → R → Prop) (x y : R) :
 
 theorem mkRingHom_eq_iff' (r : R → R → Prop) (x y : R) :
     mkRingHom r x = mkRingHom r y ↔ (RingConGen.Rel r) x y := by
-  rw [← eqvGen_rel_eq]; exact mkRingHom_eq_iff r x y
+  rw [← eqvGen_rel_eq, mkRingHom_eq_iff]
 
 theorem mkRingHom_rel {r : R → R → Prop} {x y : R} (w : r x y) : mkRingHom r x = mkRingHom r y := by
   simp [mkRingHom_def, Quot.sound (Rel.of w)]
@@ -554,7 +554,7 @@ theorem mkAlgHom_eq_iff (s : A → A → Prop) (x y : A) :
 
 theorem mkAlgHom_eq_iff' (s : A → A → Prop) (x y : A) :
     mkAlgHom S s x = mkAlgHom S s y ↔ (RingConGen.Rel s) x y := by
-  rw [← eqvGen_rel_eq]; exact mkAlgHom_eq_iff S s x y
+  rw [← eqvGen_rel_eq, mkAlgHom_eq_iff]
 
 theorem mkAlgHom_rel {s : A → A → Prop} {x y : A} (w : s x y) :
     mkAlgHom S s x = mkAlgHom S s y := by


### PR DESCRIPTION
This PR provides a few basic lemmas about `RingQuot.mkRingHom` and `RingQuot.mkAlgHom`. These lemmas are about when are two elements mapped to the same one under these two maps, and they correspond to the lemma `Quot.eq`.

PR #22279 depends on these lemmas.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
