### PR TITLE
feat(whitespace): do not allow indented doc-strings

### DIFF
--- a/Archive/Wiedijk100Theorems/BuffonsNeedle.lean
+++ b/Archive/Wiedijk100Theorems/BuffonsNeedle.lean
@@ -96,33 +96,33 @@ variable
   (hB : pdf.IsUniform B ((Set.Icc (-d / 2) (d / 2)) ×ˢ (Set.Icc 0 π)) ℙ)
 
 /--
-  Projection of a needle onto the x-axis. The needle's center is at x-coordinate `x`, of length
-  `l` and angle `θ`. Note, `θ` is measured relative to the y-axis, that is, a vertical needle has
-  `θ = 0`.
+Projection of a needle onto the x-axis. The needle's center is at x-coordinate `x`, of length
+`l` and angle `θ`. Note, `θ` is measured relative to the y-axis, that is, a vertical needle has
+`θ = 0`.
 -/
 def needleProjX (x θ : ℝ) : Set ℝ := Set.Icc (x - θ.sin * l / 2) (x + θ.sin * l / 2)
 
 /--
-  The indicator function of whether a needle at position `⟨x, θ⟩ : ℝ × ℝ` crosses the line `x = 0`.
+The indicator function of whether a needle at position `⟨x, θ⟩ : ℝ × ℝ` crosses the line `x = 0`.
 
-  In order to faithfully model the problem, we compose `needleCrossesIndicator` with a random
-  variable `B : Ω → ℝ × ℝ` with uniform distribution on `[-d/2, d/2] × [0, π]`. Then, by symmetry,
-  the probability that the needle crosses `x = 0`, is the same as the probability of a needle
-  crossing any of the infinitely spaced vertical lines distance `d` apart.
+In order to faithfully model the problem, we compose `needleCrossesIndicator` with a random
+variable `B : Ω → ℝ × ℝ` with uniform distribution on `[-d/2, d/2] × [0, π]`. Then, by symmetry,
+the probability that the needle crosses `x = 0`, is the same as the probability of a needle
+crossing any of the infinitely spaced vertical lines distance `d` apart.
 -/
 noncomputable def needleCrossesIndicator (p : ℝ × ℝ) : ℝ :=
   Set.indicator (needleProjX l p.1 p.2) 1 0
 
 /--
-  A random variable representing whether the needle crosses a line.
+A random variable representing whether the needle crosses a line.
 
-  The line is at `x = 0`, and therefore a needle crosses the line if its projection onto the x-axis
-  contains `0`. This random variable is `1` if the needle crosses the line, and `0` otherwise.
+The line is at `x = 0`, and therefore a needle crosses the line if its projection onto the x-axis
+contains `0`. This random variable is `1` if the needle crosses the line, and `0` otherwise.
 -/
 noncomputable def N : Ω → ℝ := needleCrossesIndicator l ∘ B
 
 /--
-  The possible x-positions and angle relative to the y-axis of a needle.
+The possible x-positions and angle relative to the y-axis of a needle.
 -/
 abbrev needleSpace : Set (ℝ × ℝ) := Set.Icc (-d / 2) (d / 2) ×ˢ Set.Icc 0 π
 
@@ -189,14 +189,14 @@ lemma integrable_needleCrossesIndicator :
 
 include hd hB hBₘ in
 /--
-  This is a common step in both the short and the long case to simplify the expectation of the
-  needle crossing a line to a double integral.
-  ```lean
-  ∫ (θ : ℝ) in Set.Icc 0 π,
-    ∫ (x : ℝ) in Set.Icc (-d / 2) (d / 2) ∩ Set.Icc (-θ.sin * l / 2) (θ.sin * l / 2), 1
-  ```
-  The domain of the inner integral is simpler in the short case, where the intersection is
-  equal to `Set.Icc (-θ.sin * l / 2) (θ.sin * l / 2)` by `short_needle_inter_eq`.
+This is a common step in both the short and the long case to simplify the expectation of the
+needle crossing a line to a double integral.
+```lean
+∫ (θ : ℝ) in Set.Icc 0 π,
+  ∫ (x : ℝ) in Set.Icc (-d / 2) (d / 2) ∩ Set.Icc (-θ.sin * l / 2) (θ.sin * l / 2), 1
+```
+The domain of the inner integral is simpler in the short case, where the intersection is
+equal to `Set.Icc (-θ.sin * l / 2) (θ.sin * l / 2)` by `short_needle_inter_eq`.
 -/
 lemma buffon_integral :
     𝔼[N l B] = (d * π) ⁻¹ *
@@ -235,14 +235,14 @@ lemma buffon_integral :
 
 include hl in
 /--
-  From `buffon_integral`, in both the short and the long case, we have
-  ```lean
-  𝔼[N l B] = (d * π)⁻¹ *
-    ∫ (θ : ℝ) in Set.Icc 0 π,
-      ∫ (x : ℝ) in Set.Icc (-d / 2) (d / 2) ∩ Set.Icc (-θ.sin * l / 2) (θ.sin * l / 2), 1
-  ```
-  With this lemma, in the short case, the inner integral's domain simplifies to
-  `Set.Icc (-θ.sin * l / 2) (θ.sin * l / 2)`.
+From `buffon_integral`, in both the short and the long case, we have
+```lean
+𝔼[N l B] = (d * π)⁻¹ *
+  ∫ (θ : ℝ) in Set.Icc 0 π,
+    ∫ (x : ℝ) in Set.Icc (-d / 2) (d / 2) ∩ Set.Icc (-θ.sin * l / 2) (θ.sin * l / 2), 1
+```
+With this lemma, in the short case, the inner integral's domain simplifies to
+`Set.Icc (-θ.sin * l / 2) (θ.sin * l / 2)`.
 -/
 lemma short_needle_inter_eq (h : l ≤ d) (θ : ℝ) :
     Set.Icc (-d / 2) (d / 2) ∩ Set.Icc (-θ.sin * l / 2) (θ.sin * l / 2) =
@@ -253,8 +253,8 @@ lemma short_needle_inter_eq (h : l ≤ d) (θ : ℝ) :
 
 include hd hBₘ hB hl in
 /--
-  Buffon's Needle, the short case (`l ≤ d`). The probability of the needle crossing a line
-  equals `(2 * l) / (d * π)`.
+Buffon's Needle, the short case (`l ≤ d`). The probability of the needle crossing a line
+equals `(2 * l) / (d * π)`.
 -/
 theorem buffon_short (h : l ≤ d) : ℙ[N l B] = (2 * l) * (d * π)⁻¹ := by
   simp_rw [buffon_integral d l hd B hBₘ hB, short_needle_inter_eq d l hl h _,
@@ -272,8 +272,8 @@ theorem buffon_short (h : l ≤ d) : ℙ[N l B] = (2 * l) * (d * π)⁻¹ := by
     integral_sin, Real.cos_zero, Real.cos_pi, sub_neg_eq_add, one_add_one_eq_two, true_or]
 
 /--
-  The integrand in the long case is `min d (θ.sin * l)` and its integrability is necessary for
-  the integral lemmas below.
+The integrand in the long case is `min d (θ.sin * l)` and its integrability is necessary for
+the integral lemmas below.
 -/
 lemma intervalIntegrable_min_const_sin_mul (a b : ℝ) :
     IntervalIntegrable (fun (θ : ℝ) => min d (θ.sin * l)) ℙ a b := by
@@ -281,9 +281,9 @@ lemma intervalIntegrable_min_const_sin_mul (a b : ℝ) :
   exact Continuous.min continuous_const (Continuous.mul Real.continuous_sin continuous_const)
 
 /--
-  This equality is useful since `θ.sin` is increasing in `0..π / 2` (but not in `0..π`).
-  Then, `∫ θ in (0)..π / 2, min d (θ.sin * l)` can be split into two adjacent integrals, at the
-  point where `d = θ.sin * l`, which is `θ = (d / l).arcsin`.
+This equality is useful since `θ.sin` is increasing in `0..π / 2` (but not in `0..π`).
+Then, `∫ θ in (0)..π / 2, min d (θ.sin * l)` can be split into two adjacent integrals, at the
+point where `d = θ.sin * l`, which is `θ = (d / l).arcsin`.
 -/
 lemma integral_min_eq_two_mul :
     ∫ θ in (0)..π, min d (θ.sin * l) = 2 * ∫ θ in (0)..π / 2, min d (θ.sin * l) := by
@@ -296,8 +296,8 @@ lemma integral_min_eq_two_mul :
 
 include hd hl in
 /--
-  The first of two adjacent integrals in the long case. In the range `(0)..(d / l).arcsin`, we
-  have that `θ.sin * l ≤ d`, and thus the integral is `∫ θ in (0)..(d / l).arcsin, θ.sin * l`.
+The first of two adjacent integrals in the long case. In the range `(0)..(d / l).arcsin`, we
+have that `θ.sin * l ≤ d`, and thus the integral is `∫ θ in (0)..(d / l).arcsin, θ.sin * l`.
 -/
 lemma integral_zero_to_arcsin_min :
     ∫ θ in (0)..(d / l).arcsin, min d (θ.sin * l) = (1 - √(1 - (d / l) ^ 2)) * l := by
@@ -314,8 +314,8 @@ lemma integral_zero_to_arcsin_min :
 
 include hl in
 /--
-  The second of two adjacent integrals in the long case. In the range `(d / l).arcsin..(π / 2)`, we
-  have that `d ≤ θ.sin * l`, and thus the integral is `∫ θ in (d / l).arcsin..(π / 2), d`.
+The second of two adjacent integrals in the long case. In the range `(d / l).arcsin..(π / 2)`, we
+have that `d ≤ θ.sin * l`, and thus the integral is `∫ θ in (d / l).arcsin..(π / 2), d`.
 -/
 lemma integral_arcsin_to_pi_div_two_min (h : d ≤ l) :
     ∫ θ in (d / l).arcsin..(π / 2), min d (θ.sin * l) = (π / 2 - (d / l).arcsin) * d := by
@@ -332,9 +332,7 @@ lemma integral_arcsin_to_pi_div_two_min (h : d ≤ l) :
   rw [intervalIntegral.integral_congr this, intervalIntegral.integral_const, smul_eq_mul]
 
 include hd hBₘ hB hl in
-/--
-  Buffon's Needle, the long case (`d ≤ l`).
--/
+/-- Buffon's Needle, the long case (`d ≤ l`) -/
 theorem buffon_long (h : d ≤ l) :
     ℙ[N l B] = (2 * l) / (d * π) - 2 / (d * π) * (√(l^2 - d^2) + d * (d / l).arcsin) + 1 := by
   simp only [

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -5290,6 +5290,7 @@ import Mathlib.Tactic.LinearCombination.Lemmas
 import Mathlib.Tactic.Linter
 import Mathlib.Tactic.Linter.AdmitLinter
 import Mathlib.Tactic.Linter.DocPrime
+import Mathlib.Tactic.Linter.DocString
 import Mathlib.Tactic.Linter.FlexibleLinter
 import Mathlib.Tactic.Linter.GlobalAttributeIn
 import Mathlib.Tactic.Linter.HashCommandLinter

--- a/Mathlib/Algebra/Module/SpanRank.lean
+++ b/Mathlib/Algebra/Module/SpanRank.lean
@@ -118,7 +118,8 @@ lemma spanRank_finite_iff_fg {p : Submodule R M} : p.spanRank < aleph0 ↔ p.FG 
   · rintro ⟨s, ⟨hs₁, hs₂⟩⟩
     exact lt_of_le_of_lt (ciInf_le' _ ⟨s, hs₂⟩) (by simpa)
 
-/-- A submodule is finitely generated if and only if its `spanRank` is equal to its `spanFinrank`.-/
+/-- A submodule is finitely generated if and only if its `spanRank` is equal to its `spanFinrank`.
+-/
 lemma fg_iff_spanRank_eq_spanFinrank {p : Submodule R M} : p.spanRank = p.spanFinrank ↔ p.FG := by
   rw [spanFinrank, ← spanRank_finite_iff_fg, eq_comm]
   exact cast_toNat_eq_iff_lt_aleph0

--- a/Mathlib/AlgebraicTopology/SimplicialSet/NerveAdjunction.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/NerveAdjunction.lean
@@ -106,7 +106,7 @@ def toNerve₂.mk.app (n : SimplexCategory.Truncated 2) :
     mk.app F ⦋2⦌₂ φ = .mk₂ (F.map (ev01₂ φ)) (F.map (ev12₂ φ)) := rfl
 
 /-- This is similar to one of the famous Segal maps, except valued in a product rather than a
-pullback.-/
+pullback. -/
 noncomputable def nerve₂.seagull (C : Type u) [Category C] :
     (nerveFunctor₂.obj (Cat.of C)).obj (op ⦋2⦌₂) ⟶
     (nerveFunctor₂.obj (Cat.of C)).obj (op ⦋1⦌₂) ⨯ (nerveFunctor₂.obj (Cat.of C)).obj (op ⦋1⦌₂) :=

--- a/Mathlib/Analysis/Asymptotics/ExpGrowth.lean
+++ b/Mathlib/Analysis/Asymptotics/ExpGrowth.lean
@@ -29,10 +29,10 @@ open ENNReal EReal Filter Function
 
 /-! ### Definition -/
 
-/-- Lower exponential growth of a sequence of extended nonnegative real numbers.-/
+/-- Lower exponential growth of a sequence of extended nonnegative real numbers -/
 noncomputable def expGrowthInf (u : ℕ → ℝ≥0∞) : EReal := atTop.liminf fun n ↦ log (u n) / n
 
-/-- Upper exponential growth of a sequence of extended nonnegative real numbers.-/
+/-- Upper exponential growth of a sequence of extended nonnegative real numbers -/
 noncomputable def expGrowthSup (u : ℕ → ℝ≥0∞) : EReal := atTop.limsup fun n ↦ log (u n) / n
 
 /-! ### Basic properties -/
@@ -148,27 +148,27 @@ lemma le_expGrowthInf_mul {u v : ℕ → ℝ≥0∞} :
   refine le_liminf_add.trans_eq (liminf_congr (Eventually.of_forall fun n ↦ ?_))
   rw [Pi.add_apply, Pi.mul_apply, ← add_div_of_nonneg_right n.cast_nonneg', log_mul_add]
 
-/-- See `expGrowthInf_mul_le'` for a version with swapped argument `u` and `v`.-/
+/-- See `expGrowthInf_mul_le'` for a version with swapped argument `u` and `v`. -/
 lemma expGrowthInf_mul_le {u v : ℕ → ℝ≥0∞} (h : expGrowthSup u ≠ ⊥ ∨ expGrowthInf v ≠ ⊤)
     (h' : expGrowthSup u ≠ ⊤ ∨ expGrowthInf v ≠ ⊥) :
     expGrowthInf (u * v) ≤ expGrowthSup u + expGrowthInf v := by
   refine (liminf_add_le h h').trans_eq' (liminf_congr (Eventually.of_forall fun n ↦ ?_))
   rw [Pi.add_apply, Pi.mul_apply, ← add_div_of_nonneg_right n.cast_nonneg', log_mul_add]
 
-/-- See `expGrowthInf_mul_le` for a version with swapped argument `u` and `v`.-/
+/-- See `expGrowthInf_mul_le` for a version with swapped argument `u` and `v`. -/
 lemma expGrowthInf_mul_le' {u v : ℕ → ℝ≥0∞} (h : expGrowthInf u ≠ ⊥ ∨ expGrowthSup v ≠ ⊤)
     (h' : expGrowthInf u ≠ ⊤ ∨ expGrowthSup v ≠ ⊥) :
     expGrowthInf (u * v) ≤ expGrowthInf u + expGrowthSup v := by
   rw [mul_comm, add_comm]
   exact expGrowthInf_mul_le h'.symm h.symm
 
-/-- See `le_expGrowthSup_mul'` for a version with swapped argument `u` and `v`.-/
+/-- See `le_expGrowthSup_mul'` for a version with swapped argument `u` and `v`. -/
 lemma le_expGrowthSup_mul {u v : ℕ → ℝ≥0∞} :
     expGrowthSup u + expGrowthInf v ≤ expGrowthSup (u * v) := by
   refine le_limsup_add.trans_eq (limsup_congr (Eventually.of_forall fun n ↦ ?_))
   rw [Pi.add_apply, Pi.mul_apply, log_mul_add, add_div_of_nonneg_right n.cast_nonneg']
 
-/-- See `le_expGrowthSup_mul` for a version with swapped argument `u` and `v`.-/
+/-- See `le_expGrowthSup_mul` for a version with swapped argument `u` and `v`. -/
 lemma le_expGrowthSup_mul' {u v : ℕ → ℝ≥0∞} :
     expGrowthInf u + expGrowthSup v ≤ expGrowthSup (u * v) := by
   rw [mul_comm, add_comm]
@@ -246,7 +246,7 @@ lemma expGrowthInf_inf {u v : ℕ → ℝ≥0∞} :
   rw [Pi.inf_apply, log_monotone.map_min]
   exact (monotone_div_right_of_nonneg n.cast_nonneg').map_min
 
-/-- Lower exponential growth as an `InfTopHom`.-/
+/-- Lower exponential growth as an `InfTopHom` -/
 noncomputable def expGrowthInfTopHom : InfTopHom (ℕ → ℝ≥0∞) EReal where
   toFun := expGrowthInf
   map_inf' := fun u v ↦ @expGrowthInf_inf u v
@@ -269,7 +269,7 @@ lemma expGrowthSup_sup {u v : ℕ → ℝ≥0∞} :
   rw [Pi.sup_apply, log_monotone.map_max]
   exact (monotone_div_right_of_nonneg n.cast_nonneg').map_max
 
-/-- Upper exponential growth as a `SupBotHom`.-/
+/-- Upper exponential growth as a `SupBotHom` -/
 noncomputable def expGrowthSupBotHom : SupBotHom (ℕ → ℝ≥0∞) EReal where
   toFun := expGrowthSup
   map_sup' := fun u v ↦ @expGrowthSup_sup u v

--- a/Mathlib/Data/Matroid/Circuit.lean
+++ b/Mathlib/Data/Matroid/Circuit.lean
@@ -581,7 +581,7 @@ lemma isCocircuit_iff_minimal_compl_nonspanning :
     not_disjoint_iff_nonempty_inter, ← and_imp, and_iff_left_of_imp IsBase.subset_ground,
       inter_comm K]
 
-/-- For an element `e` of a base `B`, the complement of the closure of `B \ {e}` is a cocircuit.-/
+/-- For an element `e` of a base `B`, the complement of the closure of `B \ {e}` is a cocircuit. -/
 lemma IsBase.compl_closure_diff_singleton_isCocircuit (hB : M.IsBase B) (he : e ∈ B) :
     M.IsCocircuit (M.E \ M.closure (B \ {e})) := by
   rw [isCocircuit_iff_minimal_compl_nonspanning, minimal_subset_iff,
@@ -653,7 +653,7 @@ lemma rankPos_iff_exists_isCocircuit : M.RankPos ↔ ∃ K, M.IsCocircuit K := b
 /-- The fundamental cocircuit for `B` and `e`:
 that is, the unique cocircuit `K` of `M` for which `K ∩ B = {e}`.
 Should be used when `B` is a base and `e ∈ B`.
-Has the junk value `{e}` if `e ∉ B` or `e ∉ M.E`.-/
+Has the junk value `{e}` if `e ∉ B` or `e ∉ M.E`. -/
 def fundCocircuit (M : Matroid α) (e : α) (B : Set α) := M✶.fundCircuit e (M✶.E \ B)
 
 lemma fundCocircuit_isCocircuit (he : e ∈ B) (hB : M.IsBase B) :
@@ -688,7 +688,7 @@ lemma fundCocircuit_eq_of_not_mem (M : Matroid α) (heX : e ∉ X) : M.fundCocir
   rw [fundCocircuit_eq_of_not_mem_ground _ he]
 
 /-- For every element `e` of an independent set `I`,
-there is a cocircuit whose intersection with `I` is `{e}`.-/
+there is a cocircuit whose intersection with `I` is `{e}`. -/
 lemma Indep.exists_isCocircuit_inter_eq_mem (hI : M.Indep I) (heI : e ∈ I) :
     ∃ K, M.IsCocircuit K ∧ K ∩ I = {e} := by
   obtain ⟨B, hB, hIB⟩ := hI.exists_isBase_superset

--- a/Mathlib/Init.lean
+++ b/Mathlib/Init.lean
@@ -1,4 +1,5 @@
 import Mathlib.Tactic.Linter.DocPrime
+import Mathlib.Tactic.Linter.DocString
 import Mathlib.Tactic.Linter.GlobalAttributeIn
 import Mathlib.Tactic.Linter.HashCommandLinter
 import Mathlib.Tactic.Linter.Header

--- a/Mathlib/Lean/Meta/RefinedDiscrTree/Encode.lean
+++ b/Mathlib/Lean/Meta/RefinedDiscrTree/Encode.lean
@@ -480,6 +480,7 @@ partial def mkDTExprsAux (original : Expr) (root : Bool) : M DTExpr := do
 
 end MkDTExpr
 
+set_option linter.style.docString false in
 /-- -/
 def DTExpr.isSpecific : DTExpr → Bool
   | .star _

--- a/Mathlib/LinearAlgebra/Dimension/StrongRankCondition.lean
+++ b/Mathlib/LinearAlgebra/Dimension/StrongRankCondition.lean
@@ -263,8 +263,8 @@ theorem linearIndependent_le_basis {ι : Type w} (b : Basis ι R M) {κ : Type w
     exact linearIndependent_le_infinite_basis b v i
 
 /-- `StrongRankCondition` implies that if there is an injective linear map `(α →₀ R) →ₗ[R] β →₀ R`,
-  then the cardinal of `α` is smaller than or equal to the cardinal of `β`.
- -/
+then the cardinal of `α` is smaller than or equal to the cardinal of `β`.
+-/
 theorem card_le_of_injective'' {α : Type v} {β : Type v} (f : (α →₀ R) →ₗ[R] β →₀ R)
     (i : Injective f) : #α ≤ #β := by
   let b : Basis β R (β →₀ R) := ⟨1⟩

--- a/Mathlib/LinearAlgebra/LinearIndependent/Basic.lean
+++ b/Mathlib/LinearAlgebra/LinearIndependent/Basic.lean
@@ -64,7 +64,7 @@ independent over a subring `R` of `K`.
 See also `LinearIndependent.restrict_scalars'` for a verison with more convenient typeclass
 assumptions.
 
-TODO : `LinearIndepOn` version.  -/
+TODO : `LinearIndepOn` version. -/
 theorem LinearIndependent.restrict_scalars [Semiring K] [SMulWithZero R K] [Module K M]
     [IsScalarTower R K M] (hinj : Injective fun r : R ↦ r • (1 : K))
     (li : LinearIndependent K v) : LinearIndependent R v := by
@@ -91,7 +91,7 @@ such that they are both injective, and compatible with the scalar
 multiplications on `M` and `M'`, then `j` sends linearly independent families of vectors to
 linearly independent families of vectors. As a special case, taking `R = R'`
 it is `LinearIndependent.map_injOn`.
-TODO : `LinearIndepOn` version.  -/
+TODO : `LinearIndepOn` version. -/
 theorem LinearIndependent.map_of_injective_injectiveₛ {R' M' : Type*}
     [Semiring R'] [AddCommMonoid M'] [Module R' M'] (hv : LinearIndependent R v)
     (i : R' → R) (j : M →+ M') (hi : Injective i) (hj : Injective j)
@@ -106,7 +106,7 @@ and `j : M →+ M'` is an injective monoid map, such that the scalar multiplicat
 on `M` and `M'` are compatible, then `j` sends linearly independent families
 of vectors to linearly independent families of vectors. As a special case, taking `R = R'`
 it is `LinearIndependent.map_injOn`.
-TODO : `LinearIndepOn` version.  -/
+TODO : `LinearIndepOn` version. -/
 theorem LinearIndependent.map_of_surjective_injectiveₛ {R' M' : Type*}
     [Semiring R'] [AddCommMonoid M'] [Module R' M'] (hv : LinearIndependent R v)
     (i : R → R') (j : M →+ M') (hi : Surjective i) (hj : Injective j)

--- a/Mathlib/LinearAlgebra/LinearIndependent/Defs.lean
+++ b/Mathlib/LinearAlgebra/LinearIndependent/Defs.lean
@@ -344,7 +344,8 @@ theorem LinearIndependent.linearIndepOn_id (i : LinearIndependent R v) :
 @[deprecated (since := "2025-02-14")] alias
   LinearIndependent.coe_range := LinearIndependent.linearIndepOn_id
 
-/-- A version of `LinearIndependent.linearIndepOn_id` with the set range equality as a hypothesis.-/
+/-- A version of `LinearIndependent.linearIndepOn_id` with the set range equality as a hypothesis.
+-/
 theorem LinearIndependent.linearIndepOn_id' (hv : LinearIndependent R v) {t : Set M}
     (ht : Set.range v = t) : LinearIndepOn R id t :=
   ht ▸ hv.linearIndepOn_id

--- a/Mathlib/Tactic.lean
+++ b/Mathlib/Tactic.lean
@@ -144,6 +144,7 @@ import Mathlib.Tactic.LinearCombination.Lemmas
 import Mathlib.Tactic.Linter
 import Mathlib.Tactic.Linter.AdmitLinter
 import Mathlib.Tactic.Linter.DocPrime
+import Mathlib.Tactic.Linter.DocString
 import Mathlib.Tactic.Linter.FlexibleLinter
 import Mathlib.Tactic.Linter.GlobalAttributeIn
 import Mathlib.Tactic.Linter.HashCommandLinter

--- a/Mathlib/Tactic/FunProp/Decl.lean
+++ b/Mathlib/Tactic/FunProp/Decl.lean
@@ -36,6 +36,7 @@ structure FunPropDecls where
   decls : DiscrTree FunPropDecl := {}
   deriving Inhabited
 
+set_option linter.style.docString false in
 /-- -/
 abbrev FunPropDeclsExt := SimpleScopedEnvExtension FunPropDecl FunPropDecls
 

--- a/Mathlib/Tactic/FunProp/Theorems.lean
+++ b/Mathlib/Tactic/FunProp/Theorems.lean
@@ -168,6 +168,7 @@ structure FunctionTheorem where
 
 private local instance : Ord Name := ⟨Name.quickCmp⟩
 
+set_option linter.style.docString false in
 /-- -/
 structure FunctionTheorems where
   /-- map: function name → function property → function theorem -/
@@ -182,7 +183,7 @@ def FunctionTheorem.getProof (thm : FunctionTheorem) : MetaM Expr := do
   | .decl name => mkConstWithFreshMVarLevels name
   | .fvar id => return .fvar id
 
-
+set_option linter.style.docString false in
 /-- -/
 abbrev FunctionTheoremsExt := SimpleScopedEnvExtension FunctionTheorem FunctionTheorems
 
@@ -201,6 +202,7 @@ initialize functionTheoremsExt : FunctionTheoremsExt ←
               thms.push e}
   }
 
+set_option linter.style.docString false in
 /-- -/
 def getTheoremsForFunction (funName : Name) (funPropName : Name) :
     CoreM (Array FunctionTheorem) := do

--- a/Mathlib/Tactic/Linter.lean
+++ b/Mathlib/Tactic/Linter.lean
@@ -8,6 +8,7 @@ This file is ignored by `shake`:
 * it is in `ignoreImport`, meaning that where it is imported, it is considered necessary.
 -/
 
+import Mathlib.Tactic.Linter.DocString
 import Mathlib.Tactic.Linter.FlexibleLinter
 import Mathlib.Tactic.Linter.HaveLetLinter
 import Mathlib.Tactic.Linter.MinImports

--- a/Mathlib/Tactic/Linter/DocString.lean
+++ b/Mathlib/Tactic/Linter/DocString.lean
@@ -61,6 +61,10 @@ def docStringLinter : Linter where run := withSetOptionIn fun stx ↦ do
   if tail + 1 != docString.length then
     Linter.logLint linter.style.docString (endRg 3)
       s!"error: doc-strings should end with a single space or newline"
+  let fromFirstLineBreak := docString.dropWhile (· != '\n')
+  if fromFirstLineBreak.get ⟨1⟩ == ' ' then
+    Linter.logLint linter.style.docString (endRg (fromFirstLineBreak.length + 1))
+      s!"error: doc-strings should not be indented"
 
 initialize addLinter docStringLinter
 

--- a/Mathlib/Tactic/Linter/DocString.lean
+++ b/Mathlib/Tactic/Linter/DocString.lean
@@ -1,0 +1,69 @@
+/-
+Copyright (c) 2025 Damiano Testa. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Michael Rothgang, Damiano Testa
+-/
+
+import Mathlib.Tactic.Linter.Header
+
+/-!
+#  The "DocString" style linter
+
+The "DocString" linter validates style conventions regarding doc-string formatting.
+-/
+
+open Lean Elab
+
+namespace Mathlib.Linter
+
+/--
+The "DocString" linter validates style conventions regarding doc-string formatting.
+-/
+register_option linter.style.docString : Bool := {
+  defValue := false
+  descr := "enable the style.docString linter"
+}
+
+namespace Style
+
+@[inherit_doc Mathlib.Linter.linter.style.docString]
+def docStringLinter : Linter where run := withSetOptionIn fun stx ↦ do
+  unless Linter.getLinterValue linter.style.docString (← getOptions) do
+    return
+  if (← get).messages.hasErrors then
+    return
+  let some declMods := stx.find? (·.isOfKind ``Lean.Parser.Command.declModifiers) | return
+  -- `docStx` extracts the `Lean.Parser.Command.docComment` node from the declaration modifiers.
+  -- In particular, this ignores parsing `#adaptation_note`s.
+  let docStx := declMods[0][0]
+  if docStx.isMissing then return
+  -- `docString` contains e.g. trailing spaces before the `-/`, but does not contain
+  -- any leading whitespace before the actual string starts.
+  let docString ← try getDocStringText ⟨docStx⟩ catch _ => return
+  -- `startSubstring` is the whitespace between `/--` and the actual doc-string text
+  let startSubstring := match docStx with
+    | .node _ _ #[(.atom si ..), _] => si.getTrailing?.getD default
+    | _ => default
+  let start := startSubstring.toString
+  if !#["\n", " "].contains start then
+    let startRg := {start := startSubstring.startPos, stop := startSubstring.stopPos}
+    Linter.logLint linter.style.docString (.ofRange startRg)
+      s!"error: doc-strings should start with a single space or newline"
+  let docTrim := docString.trimRight
+  let tail := docTrim.length
+  let tailSubstr : Substring :=
+    {str := docString, startPos := ⟨tail⟩, stopPos := ⟨docString.length⟩}
+  let endRg (n : Nat) : Syntax := .ofRange
+    {start := docStx.getTailPos?.getD 0 - ⟨n⟩, stop := docStx.getTailPos?.getD 0 - ⟨n⟩}
+  if docTrim.takeRight 1 == "," then
+    Linter.logLint linter.style.docString (endRg (docString.length - tail + 3))
+      s!"error: doc-strings should not end with a comma"
+  if tail + 1 != docString.length then
+    Linter.logLint linter.style.docString (endRg 3)
+      s!"error: doc-strings should end with a single space or newline"
+
+initialize addLinter docStringLinter
+
+end Style
+
+end Mathlib.Linter

--- a/Mathlib/Topology/Path.lean
+++ b/Mathlib/Topology/Path.lean
@@ -518,8 +518,8 @@ protected theorem mul_apply [Mul X] [ContinuousMul X] {a₁ b₁ a₂ b₂ : X} 
 /-! #### Truncating a path -/
 
 
-/-- `γ.truncate t₀ t₁` is the path which follows the path `γ` on the
-  time interval `[t₀, t₁]` and stays still otherwise. -/
+/-- `γ.truncate t₀ t₁` is the path which follows the path `γ` on the time interval `[t₀, t₁]`
+and stays still otherwise. -/
 def truncate {X : Type*} [TopologicalSpace X] {a b : X} (γ : Path a b) (t₀ t₁ : ℝ) :
     Path (γ.extend <| min t₀ t₁) (γ.extend t₁) where
   toFun s := γ.extend (min (max s t₀) t₁)
@@ -544,7 +544,7 @@ def truncate {X : Type*} [TopologicalSpace X] {a b : X} (γ : Path a b) (t₀ t�
     · rfl
 
 /-- `γ.truncateOfLE t₀ t₁ h`, where `h : t₀ ≤ t₁` is `γ.truncate t₀ t₁`
-  casted as a path from `γ.extend t₀` to `γ.extend t₁`. -/
+casted as a path from `γ.extend t₀` to `γ.extend t₁`. -/
 def truncateOfLE {X : Type*} [TopologicalSpace X] {a b : X} (γ : Path a b) {t₀ t₁ : ℝ}
     (h : t₀ ≤ t₁) : Path (γ.extend t₀) (γ.extend t₁) :=
   (γ.truncate t₀ t₁).cast (by rw [min_eq_left h]) rfl
@@ -556,8 +556,8 @@ theorem truncate_range {a b : X} (γ : Path a b) {t₀ t₁ : ℝ} :
   intro x _hx
   simp only [DFunLike.coe, Path.truncate, mem_range_self]
 
-/-- For a path `γ`, `γ.truncate` gives a "continuous family of paths", by which we
-  mean the uncurried function which maps `(t₀, t₁, s)` to `γ.truncate t₀ t₁ s` is continuous. -/
+/-- For a path `γ`, `γ.truncate` gives a "continuous family of paths", by which we mean
+the uncurried function which maps `(t₀, t₁, s)` to `γ.truncate t₀ t₁ s` is continuous. -/
 @[continuity]
 theorem truncate_continuous_family {a b : X} (γ : Path a b) :
     Continuous (fun x => γ.truncate x.1 x.2.1 x.2.2 : ℝ × ℝ × I → X) :=

--- a/Mathlib/Topology/UnitInterval.lean
+++ b/Mathlib/Topology/UnitInterval.lean
@@ -252,7 +252,7 @@ lemma _root_.Set.abs_projIcc_sub_projIcc : (|projIcc a b h c - projIcc a b h d| 
   · exact (abs_eq_self.mpr hdc).le
 
 /-- When `h : a ≤ b` and `δ > 0`, `addNSMul h δ` is a sequence of points in the closed interval
-  `[a,b]`, which is initially equally spaced but eventually stays at the right endpoint `b`. -/
+`[a,b]`, which is initially equally spaced but eventually stays at the right endpoint `b`. -/
 def addNSMul (δ : α) (n : ℕ) : Icc a b := projIcc a b h (a + n • δ)
 
 lemma addNSMul_zero : addNSMul h δ 0 = a := by
@@ -284,8 +284,8 @@ end Set.Icc
 
 open scoped unitInterval
 
-/-- Any open cover `c` of a closed interval `[a, b]` in ℝ can be refined to
-  a finite partition into subintervals. -/
+/-- Any open cover `c` of a closed interval `[a, b]` in ℝ
+can be refined to a finite partition into subintervals. -/
 lemma exists_monotone_Icc_subset_open_cover_Icc {ι} {a b : ℝ} (h : a ≤ b) {c : ι → Set (Icc a b)}
     (hc₁ : ∀ i, IsOpen (c i)) (hc₂ : univ ⊆ ⋃ i, c i) : ∃ t : ℕ → Icc a b, t 0 = a ∧
       Monotone t ∧ (∃ m, ∀ n ≥ m, t n = b) ∧ ∀ n, ∃ i, Icc (t n) (t (n + 1)) ⊆ c i := by

--- a/MathlibTest/LintDocstring.lean
+++ b/MathlibTest/LintDocstring.lean
@@ -58,3 +58,13 @@ def foo : Bool := by
 
 -/
 example : Nat := 1
+
+/--
+warning: error: doc-strings should not be indented
+note: this linter can be disabled with `set_option linter.style.docString false`
+-/
+#guard_msgs in
+/-- Let's give an example.
+  sorry
+-/
+example : Nat := 1

--- a/MathlibTest/LintDocstring.lean
+++ b/MathlibTest/LintDocstring.lean
@@ -1,0 +1,60 @@
+import Mathlib.Tactic.AdaptationNote
+import Mathlib.Tactic.Linter.DocString
+
+/-! Tests for the `docstring` linter -/
+
+set_option linter.style.docString true
+
+#adaptation_note /--This comment is not inspected by the `docString` linter.-/
+
+example : True := by
+  #adaptation_note /--   This comment is not inspected by the `docString` linter.
+  -/
+  trivial
+
+/--
+warning: error: doc-strings should start with a single space or newline
+note: this linter can be disabled with `set_option linter.style.docString false`
+-/
+#guard_msgs in
+/--Missing space -/
+example : Nat := 1
+
+/--
+warning: error: doc-strings should end with a single space or newline
+note: this linter can be disabled with `set_option linter.style.docString false`
+-/
+#guard_msgs in
+/-- Missing ending space-/
+example : Nat := 1
+
+/--
+warning: error: doc-strings should start with a single space or newline
+note: this linter can be disabled with `set_option linter.style.docString false`
+-/
+#guard_msgs in
+/--  Two starting spaces -/
+example : Nat := 1
+
+/--
+warning: error: doc-strings should end with a single space or newline
+note: this linter can be disabled with `set_option linter.style.docString false`
+-/
+#guard_msgs in
+/--
+Two ending spaces  -/
+example : Nat := 1
+
+/--
+warning: error: doc-strings should end with a single space or newline
+note: this linter can be disabled with `set_option linter.style.docString false`
+-/
+#guard_msgs in
+/-- Let's give an example.
+```lean4
+def foo : Bool := by
+  sorry
+```
+
+-/
+example : Nat := 1

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -34,6 +34,7 @@ abbrev mathlibOnlyLinters : Array LeanOption := #[
   ⟨`linter.oldObtain, true,⟩,
   ⟨`linter.refine, true⟩,
   ⟨`linter.style.cdot, true⟩,
+  ⟨`linter.style.docString, true⟩,
   ⟨`linter.style.dollarSyntax, true⟩,
   ⟨`linter.style.header, true⟩,
   ⟨`linter.style.lambdaSyntax, true⟩,


### PR DESCRIPTION
In a doc-string, Do not allow the first character after the first line break to be a space.

---

There are approximately 2.5k exceptions. I think that they should be unindented, judging from the sample that I looked at, but won't act on it, unless there is a clear plan to fix and merge this modification!

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
