### PR TITLE
[Merged by Bors] - feat: a σ-additive content on a set ring is σ-subadditive

### DIFF
--- a/Mathlib/MeasureTheory/Measure/AddContent.lean
+++ b/Mathlib/MeasureTheory/Measure/AddContent.lean
@@ -405,33 +405,14 @@ theorem tendsto_atTop_addContent_iUnion_of_addContent_iUnion_eq_tsum (hC : IsSet
       (_hf_disj : Pairwise (Disjoint on f)), m (⋃ i, f i) = ∑' i, m (f i))
     ⦃f : ℕ → Set α⦄ (hf_mono : Monotone f) (hf : ∀ i, f i ∈ C) (hf_Union : ⋃ i, f i ∈ C) :
     Tendsto (fun n ↦ m (f n)) atTop (𝓝 (m (⋃ i, f i))) := by
-  let g := disjointed f
-  have hg_Union : (⋃ i, g i) = ⋃ i, f i := iUnion_disjointed
-  simp_rw [← hg_Union,
-    m_iUnion g (hC.disjointed_mem hf) (by rwa [hg_Union]) (disjoint_disjointed f)]
-  have h : ∀ n, m (f n) = ∑ i ∈ range (n + 1), m (g i) := by
-    intro n
-    classical
-    have h1 : f n = ⋃₀ image g (range (n + 1)) := by
-      rw [← Monotone.partialSups_eq hf_mono, ← partialSups_disjointed, ←
-        partialSups_eq_sUnion_image g]
-    rw [h1, addContent_sUnion]
-    · rw [sum_image_of_disjoint addContent_empty ((disjoint_disjointed f).pairwiseDisjoint _)]
-    · intro s
-      rw [mem_coe, Finset.mem_image]
-      rintro ⟨i, _, rfl⟩
-      exact hC.disjointed_mem hf i
-    · intro s hs t ht hst
-      rw [mem_coe, Finset.mem_image] at hs ht
-      obtain ⟨i, _, rfl⟩ := hs
-      obtain ⟨j, _, rfl⟩ := ht
-      have hij : i ≠ j := fun h_eq ↦ hst (h_eq ▸ rfl)
-      exact disjoint_disjointed f hij
-    · rw [← h1]
-      exact hf n
+  rw [← iUnion_disjointed, m_iUnion _ (hC.disjointed_mem hf) (by rwa [iUnion_disjointed])
+      (disjoint_disjointed f)]
+  have h n : m (f n) = ∑ i ∈ range (n + 1), m (disjointed f i) := by
+    nth_rw 1 [← addContent_accumulate _ hC (disjoint_disjointed f) (hC.disjointed_mem hf),
+    ← hf_mono.partialSups_eq, ← partialSups_disjointed, partialSups_eq_biSup, Accumulate]
+    rfl
   simp_rw [h]
-  change Tendsto (fun n ↦ (fun k ↦ ∑ i ∈ range k, m (g i)) (n + 1)) atTop (𝓝 (∑' i, m (g i)))
-  rw [tendsto_add_atTop_iff_nat (f := (fun k ↦ ∑ i ∈ range k, m (g i))) 1]
+  refine (tendsto_add_atTop_iff_nat (f := (fun k ↦ ∑ i ∈ range k, m (disjointed f i))) 1).2 ?_
   exact ENNReal.tendsto_nat_tsum _
 
 /-- If an additive content is σ-additive on a set ring, then it is σ-subadditive. -/
@@ -448,17 +429,9 @@ theorem isSigmaSubadditive_of_addContent_iUnion_eq_tsum (hC : IsSetRing C)
   have h_tendsto' : Tendsto (fun n ↦ ∑ i ∈ range (n + 1), m (f i)) atTop (𝓝 (∑' i, m (f i))) := by
     rw [tendsto_add_atTop_iff_nat (f := (fun k ↦ ∑ i ∈ range k, m (f i))) 1]
     exact ENNReal.tendsto_nat_tsum _
-  refine le_of_tendsto_of_tendsto' h_tendsto h_tendsto' fun n ↦ ?_
-  classical
-  rw [partialSups_eq_sUnion_image]
-  refine (addContent_le_sum_of_subset_sUnion hC.isSetSemiring
-    (J := (range (n + 1)).image f) (fun s ↦ ?_) ?_ subset_rfl).trans ?_
-  · rw [mem_coe, Finset.mem_image]
-    rintro ⟨i, _, rfl⟩
-    exact hf i
-  · rw [← partialSups_eq_sUnion_image]
-    exact hC.partialSups_mem hf n
-  · exact sum_image_le_of_nonneg fun _ _ ↦ zero_le _
+  refine le_of_tendsto_of_tendsto' h_tendsto h_tendsto' fun _ ↦ ?_
+  rw [partialSups_eq_biUnion_range]
+  exact addContent_biUnion_le hC (fun _ _ ↦ hf _)
 
 end IsSetRing
 

--- a/Mathlib/MeasureTheory/Measure/AddContent.lean
+++ b/Mathlib/MeasureTheory/Measure/AddContent.lean
@@ -437,7 +437,7 @@ theorem tendsto_atTop_addContent_iUnion_of_addContent_iUnion_eq_tsum (hC : IsSet
 /-- If an additive content is σ-additive on a set ring, then it is σ-subadditive. -/
 theorem addContent_iUnion_le_of_addContent_iUnion_eq_tsum (hC : IsSetRing C)
     (m_iUnion : ∀ (f : ℕ → Set α) (_ : ∀ i, f i ∈ C) (_ : (⋃ i, f i) ∈ C)
-      (_hf_disj : Pairwise (Function.onFun Disjoint f)), m (⋃ i, f i) = ∑' i, m (f i)) :
+      (_hf_disj : Pairwise (Disjoint on f)), m (⋃ i, f i) = ∑' i, m (f i)) :
     m.IsSigmaSubadditive := by
   intro f hf hf_Union
   have h_tendsto : Tendsto (fun n ↦ m (partialSups f n)) atTop (𝓝 (m (⋃ i, f i))) := by

--- a/Mathlib/MeasureTheory/Measure/AddContent.lean
+++ b/Mathlib/MeasureTheory/Measure/AddContent.lean
@@ -398,6 +398,68 @@ theorem addContent_iUnion_eq_sum_of_tendsto_zero (hC : IsSetRing C) (m : AddCont
   exact addContent_mono hC.isSetSemiring (hC.accumulate_mem hf n) hUf
     (Set.accumulate_subset_iUnion _)
 
+/-- If an additive content is σ-additive on a set ring, then the content of a monotone sequence of
+sets tends to the content of the union. -/
+theorem tendsto_atTop_addContent_iUnion_of_addContent_iUnion_eq_tsum (hC : IsSetRing C)
+    (m_iUnion : ∀ (f : ℕ → Set α) (_ : ∀ i, f i ∈ C) (_ : (⋃ i, f i) ∈ C)
+      (_hf_disj : Pairwise (Disjoint on f)), m (⋃ i, f i) = ∑' i, m (f i))
+    ⦃f : ℕ → Set α⦄ (hf_mono : Monotone f) (hf : ∀ i, f i ∈ C) (hf_Union : ⋃ i, f i ∈ C) :
+    Tendsto (fun n ↦ m (f n)) atTop (𝓝 (m (⋃ i, f i))) := by
+  let g := disjointed f
+  have hg_Union : (⋃ i, g i) = ⋃ i, f i := iUnion_disjointed
+  simp_rw [← hg_Union,
+    m_iUnion g (hC.disjointed_mem hf) (by rwa [hg_Union]) (disjoint_disjointed f)]
+  have h : ∀ n, m (f n) = ∑ i ∈ range (n + 1), m (g i) := by
+    intro n
+    classical
+    have h1 : f n = ⋃₀ image g (range (n + 1)) := by
+      rw [← Monotone.partialSups_eq hf_mono, ← partialSups_disjointed, ←
+        partialSups_eq_sUnion_image g]
+    rw [h1, addContent_sUnion]
+    · rw [sum_image_of_disjoint addContent_empty ((disjoint_disjointed f).pairwiseDisjoint _)]
+    · intro s
+      rw [mem_coe, Finset.mem_image]
+      rintro ⟨i, _, rfl⟩
+      exact hC.disjointed_mem hf i
+    · intro s hs t ht hst
+      rw [mem_coe, Finset.mem_image] at hs ht
+      obtain ⟨i, _, rfl⟩ := hs
+      obtain ⟨j, _, rfl⟩ := ht
+      have hij : i ≠ j := fun h_eq ↦ hst (h_eq ▸ rfl)
+      exact disjoint_disjointed f hij
+    · rw [← h1]
+      exact hf n
+  simp_rw [h]
+  change Tendsto (fun n ↦ (fun k ↦ ∑ i ∈ range k, m (g i)) (n + 1)) atTop (𝓝 (∑' i, m (g i)))
+  rw [tendsto_add_atTop_iff_nat (f := (fun k ↦ ∑ i ∈ range k, m (g i))) 1]
+  exact ENNReal.tendsto_nat_tsum _
+
+/-- If an additive content is σ-additive on a set ring, then it is σ-subadditive. -/
+theorem addContent_iUnion_le_of_addContent_iUnion_eq_tsum (hC : IsSetRing C)
+    (m_iUnion : ∀ (f : ℕ → Set α) (_ : ∀ i, f i ∈ C) (_ : (⋃ i, f i) ∈ C)
+      (_hf_disj : Pairwise (Function.onFun Disjoint f)), m (⋃ i, f i) = ∑' i, m (f i)) :
+    m.IsSigmaSubadditive := by
+  intro f hf hf_Union
+  have h_tendsto : Tendsto (fun n ↦ m (partialSups f n)) atTop (𝓝 (m (⋃ i, f i))) := by
+    rw [← iSup_eq_iUnion, ← iSup_partialSups_eq]
+    refine tendsto_atTop_addContent_iUnion_of_addContent_iUnion_eq_tsum hC m_iUnion
+      (partialSups_monotone f) (hC.partialSups_mem hf) ?_
+    rwa [← iSup_eq_iUnion, iSup_partialSups_eq]
+  have h_tendsto' : Tendsto (fun n ↦ ∑ i ∈ range (n + 1), m (f i)) atTop (𝓝 (∑' i, m (f i))) := by
+    rw [tendsto_add_atTop_iff_nat (f := (fun k ↦ ∑ i ∈ range k, m (f i))) 1]
+    exact ENNReal.tendsto_nat_tsum _
+  refine le_of_tendsto_of_tendsto' h_tendsto h_tendsto' fun n ↦ ?_
+  classical
+  rw [partialSups_eq_sUnion_image]
+  refine (addContent_le_sum_of_subset_sUnion hC.isSetSemiring
+    (J := (range (n + 1)).image f) (fun s ↦ ?_) ?_ subset_rfl).trans ?_
+  · rw [mem_coe, Finset.mem_image]
+    rintro ⟨i, _, rfl⟩
+    exact hf i
+  · rw [← partialSups_eq_sUnion_image]
+    exact hC.partialSups_mem hf n
+  · exact sum_image_le_of_nonneg fun _ _ ↦ zero_le _
+
 end IsSetRing
 
 end MeasureTheory

--- a/Mathlib/MeasureTheory/Measure/AddContent.lean
+++ b/Mathlib/MeasureTheory/Measure/AddContent.lean
@@ -46,7 +46,7 @@ If `C` is a set ring (`MeasureTheory.IsSetRing C`), we have
 disjoint sets defines an additive content
 * `addContent_iUnion_eq_sum_of_tendsto_zero`: if an additive content is continuous at `∅`, then
 its value on a countable disjoint union is the sum of the values
-* `MeasureTheory.addContent_iUnion_le_of_addContent_iUnion_eq_tsum`: if an `AddContent` is
+* `MeasureTheory.isSigmaSubadditive_of_addContent_iUnion_eq_tsum`: if an `AddContent` is
   σ-additive on a set ring, then it is σ-subadditive.
 
 -/
@@ -435,7 +435,7 @@ theorem tendsto_atTop_addContent_iUnion_of_addContent_iUnion_eq_tsum (hC : IsSet
   exact ENNReal.tendsto_nat_tsum _
 
 /-- If an additive content is σ-additive on a set ring, then it is σ-subadditive. -/
-theorem addContent_iUnion_le_of_addContent_iUnion_eq_tsum (hC : IsSetRing C)
+theorem isSigmaSubadditive_of_addContent_iUnion_eq_tsum (hC : IsSetRing C)
     (m_iUnion : ∀ (f : ℕ → Set α) (_ : ∀ i, f i ∈ C) (_ : (⋃ i, f i) ∈ C)
       (_hf_disj : Pairwise (Disjoint on f)), m (⋃ i, f i) = ∑' i, m (f i)) :
     m.IsSigmaSubadditive := by


### PR DESCRIPTION
The result was already mentioned in the file docstring, but was not there.

Part of the formalization of Kolmogorov's extension theorem.
Co-authored-by: Peter Pfaffelhuber

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
