### PR TITLE
[Merged by Bors] - feat: integral against the composition of kernels

### DIFF
--- a/Mathlib/Probability/Kernel/Composition/Basic.lean
+++ b/Mathlib/Probability/Kernel/Composition/Basic.lean
@@ -1401,6 +1401,15 @@ lemma snd_comp (κ : Kernel α β) (η : Kernel β (γ × δ)) : (η ∘ₖ κ).
   · rfl
   · exact measurable_snd hs
 
+lemma comp_add_left (μ κ : Kernel α β) (η : Kernel β γ) :
+    η ∘ₖ (μ + κ) = η ∘ₖ μ + η ∘ₖ κ := by ext _ _ hs; simp [comp_apply' _ _ _ hs]
+
+lemma comp_add_right (μ : Kernel α β) (κ η : Kernel β γ) :
+    (κ + η) ∘ₖ μ = κ ∘ₖ μ + η ∘ₖ μ := by
+  ext a s hs
+  simp_rw [comp_apply' _ _ _ hs, add_apply, Measure.add_apply, comp_apply' _ _ _ hs,
+    lintegral_add_left (Kernel.measurable_coe κ hs)]
+
 end Comp
 
 section Prod

--- a/Mathlib/Probability/Kernel/Composition/Basic.lean
+++ b/Mathlib/Probability/Kernel/Composition/Basic.lean
@@ -1218,6 +1218,56 @@ theorem comp_eq_snd_compProd (η : Kernel β γ) [IsSFiniteKernel η] (κ : Kern
   · exact measurable_snd hs
   simp only [Set.mem_setOf_eq, Set.setOf_mem_eq, prodMkLeft_apply' _ _ s]
 
+section Ae
+
+/-! ### `ae` filter of the composition -/
+
+variable {κ : Kernel α β} {η : Kernel β γ} {a : α} {s : Set γ}
+
+theorem ae_lt_top_of_comp_ne_top (a : α) (hs : (η ∘ₖ κ) a s ≠ ∞) : ∀ᵐ b ∂κ a, η b s < ∞ := by
+  have h : ∀ᵐ b ∂κ a, η b (toMeasurable ((η ∘ₖ κ) a) s) < ∞ := by
+    refine ae_lt_top (Kernel.measurable_coe η (measurableSet_toMeasurable ..)) ?_
+    rwa [← Kernel.comp_apply' _ _ _ (measurableSet_toMeasurable ..), measure_toMeasurable]
+  filter_upwards [h] with b hb using (measure_mono (subset_toMeasurable _ _)).trans_lt hb
+
+theorem comp_null (a : α) (hs : MeasurableSet s) :
+    (η ∘ₖ κ) a s = 0 ↔ (fun y ↦ η y s) =ᵐ[κ a] 0 := by
+  rw [comp_apply' _ _ _ hs, lintegral_eq_zero_iff (η.measurable_coe hs)]
+
+theorem ae_null_of_comp_null (h : (η ∘ₖ κ) a s = 0) : (η · s) =ᵐ[κ a] 0 := by
+  obtain ⟨t, hst, mt, ht⟩ := exists_measurable_superset_of_null h
+  simp_rw [comp_null a mt] at ht
+  rw [Filter.eventuallyLE_antisymm_iff]
+  exact ⟨Filter.EventuallyLE.trans_eq (ae_of_all _ fun _ ↦ measure_mono hst) ht,
+    ae_of_all _ fun _ ↦ zero_le _⟩
+
+variable {p : γ → Prop}
+
+theorem ae_ae_of_ae_comp (h : ∀ᵐ z ∂(η ∘ₖ κ) a, p z) :
+    ∀ᵐ y ∂κ a, ∀ᵐ z ∂η y, p z := ae_null_of_comp_null h
+
+lemma ae_comp_of_ae_ae (hp : MeasurableSet {z | p z})
+    (h : ∀ᵐ y ∂κ a, ∀ᵐ z ∂η y, p z) : ∀ᵐ z ∂(η ∘ₖ κ) a, p z := by
+  rwa [ae_iff, comp_null] at *
+  exact hp.compl
+
+lemma ae_comp_iff (hp : MeasurableSet {z | p z}) :
+    (∀ᵐ z ∂(η ∘ₖ κ) a, p z) ↔ ∀ᵐ y ∂κ a, ∀ᵐ z ∂η y, p z :=
+  ⟨ae_ae_of_ae_comp, ae_comp_of_ae_ae hp⟩
+
+end Ae
+
+section Restrict
+
+variable {κ : Kernel α β} {η : Kernel β γ}
+
+theorem comp_restrict {s : Set γ} (hs : MeasurableSet s) :
+    η.restrict hs ∘ₖ κ = (η ∘ₖ κ).restrict hs := by
+  ext a t ht
+  simp_rw [comp_apply' _ _ _ ht, restrict_apply' _ _ _ ht, comp_apply' _ _ _ (ht.inter hs)]
+
+end Restrict
+
 theorem lintegral_comp (η : Kernel β γ) (κ : Kernel α β) (a : α) {g : γ → ℝ≥0∞}
     (hg : Measurable g) : ∫⁻ c, g c ∂(η ∘ₖ κ) a = ∫⁻ b, ∫⁻ c, g c ∂η b ∂κ a := by
   rw [comp_apply, Measure.lintegral_bind (Kernel.measurable _) hg]
@@ -1312,56 +1362,6 @@ lemma snd_comp (κ : Kernel α β) (η : Kernel β (γ × δ)) : (η ∘ₖ κ).
   rw [snd_apply' _ _ hs, compProd_apply, comp_apply' _ _ _ hs]
   · rfl
   · exact measurable_snd hs
-
-section Ae
-
-/-! ### `ae` filter of the composition -/
-
-variable {κ : Kernel α β} {η : Kernel β γ} {a : α} {s : Set γ}
-
-theorem ae_lt_top_of_comp_ne_top (a : α) (hs : (η ∘ₖ κ) a s ≠ ∞) : ∀ᵐ b ∂κ a, η b s < ∞ := by
-  have h : ∀ᵐ b ∂κ a, η b (toMeasurable ((η ∘ₖ κ) a) s) < ∞ := by
-    refine ae_lt_top (Kernel.measurable_coe η (measurableSet_toMeasurable ..)) ?_
-    rwa [← Kernel.comp_apply' _ _ _ (measurableSet_toMeasurable ..), measure_toMeasurable]
-  filter_upwards [h] with b hb using (measure_mono (subset_toMeasurable _ _)).trans_lt hb
-
-theorem comp_null (a : α) (hs : MeasurableSet s) :
-    (η ∘ₖ κ) a s = 0 ↔ (fun y ↦ η y s) =ᵐ[κ a] 0 := by
-  rw [comp_apply' _ _ _ hs, lintegral_eq_zero_iff (η.measurable_coe hs)]
-
-theorem ae_null_of_comp_null (h : (η ∘ₖ κ) a s = 0) : (η · s) =ᵐ[κ a] 0 := by
-  obtain ⟨t, hst, mt, ht⟩ := exists_measurable_superset_of_null h
-  simp_rw [comp_null a mt] at ht
-  rw [Filter.eventuallyLE_antisymm_iff]
-  exact ⟨Filter.EventuallyLE.trans_eq (ae_of_all _ fun _ ↦ measure_mono hst) ht,
-    ae_of_all _ fun _ ↦ zero_le _⟩
-
-variable {p : γ → Prop}
-
-theorem ae_ae_of_ae_comp (h : ∀ᵐ z ∂(η ∘ₖ κ) a, p z) :
-    ∀ᵐ y ∂κ a, ∀ᵐ z ∂η y, p z := ae_null_of_comp_null h
-
-lemma ae_comp_of_ae_ae (hp : MeasurableSet {z | p z})
-    (h : ∀ᵐ y ∂κ a, ∀ᵐ z ∂η y, p z) : ∀ᵐ z ∂(η ∘ₖ κ) a, p z := by
-  rwa [ae_iff, comp_null] at *
-  exact hp.compl
-
-lemma ae_comp_iff (hp : MeasurableSet {z | p z}) :
-    (∀ᵐ z ∂(η ∘ₖ κ) a, p z) ↔ ∀ᵐ y ∂κ a, ∀ᵐ z ∂η y, p z :=
-  ⟨ae_ae_of_ae_comp, ae_comp_of_ae_ae hp⟩
-
-end Ae
-
-section Restrict
-
-variable {κ : Kernel α β} {η : Kernel β γ}
-
-theorem comp_restrict {s : Set γ} (hs : MeasurableSet s) :
-    η.restrict hs ∘ₖ κ = (η ∘ₖ κ).restrict hs := by
-  ext a t ht
-  simp_rw [comp_apply' _ _ _ ht, restrict_apply' _ _ _ ht, comp_apply' _ _ _ (ht.inter hs)]
-
-end Restrict
 
 end Comp
 

--- a/Mathlib/Probability/Kernel/Composition/Basic.lean
+++ b/Mathlib/Probability/Kernel/Composition/Basic.lean
@@ -1401,10 +1401,10 @@ lemma snd_comp (κ : Kernel α β) (η : Kernel β (γ × δ)) : (η ∘ₖ κ).
   · rfl
   · exact measurable_snd hs
 
-lemma comp_add_left (μ κ : Kernel α β) (η : Kernel β γ) :
+lemma comp_add_right (μ κ : Kernel α β) (η : Kernel β γ) :
     η ∘ₖ (μ + κ) = η ∘ₖ μ + η ∘ₖ κ := by ext _ _ hs; simp [comp_apply' _ _ _ hs]
 
-lemma comp_add_right (μ : Kernel α β) (κ η : Kernel β γ) :
+lemma comp_add_left (μ : Kernel α β) (κ η : Kernel β γ) :
     (κ + η) ∘ₖ μ = κ ∘ₖ μ + η ∘ₖ μ := by
   ext a s hs
   simp_rw [comp_apply' _ _ _ hs, add_apply, Measure.add_apply, comp_apply' _ _ _ hs,

--- a/Mathlib/Probability/Kernel/Composition/IntegralCompProd.lean
+++ b/Mathlib/Probability/Kernel/Composition/IntegralCompProd.lean
@@ -135,9 +135,13 @@ theorem integrable_compProd_iff ⦃f : β × γ → E⦄ (hf : AEStronglyMeasura
   simp only [Integrable, hasFiniteIntegral_compProd_iff' hf, hf.norm.integral_kernel_compProd,
     hf, hf.compProd_mk_left, eventually_and, true_and]
 
-theorem _root_.MeasureTheory.Integrable.compProd_mk_left_ae ⦃f : β × γ → E⦄
+theorem _root_.MeasureTheory.Integrable.ae_of_compProd ⦃f : β × γ → E⦄
     (hf : Integrable f ((κ ⊗ₖ η) a)) : ∀ᵐ x ∂κ a, Integrable (fun y => f (x, y)) (η (a, x)) :=
   ((integrable_compProd_iff hf.aestronglyMeasurable).mp hf).1
+
+@[deprecated (since := "2025-02-28")]
+alias _root_.MeasureTheory.Integrable.compProd_mk_left_ae :=
+  _root_.MeasureTheory.Integrable.ae_of_compProd
 
 theorem _root_.MeasureTheory.Integrable.integral_norm_compProd ⦃f : β × γ → E⦄
     (hf : Integrable f ((κ ⊗ₖ η) a)) : Integrable (fun x => ∫ y, ‖f (x, y)‖ ∂η (a, x)) (κ a) :=
@@ -163,7 +167,7 @@ theorem Kernel.integral_fn_integral_add ⦃f g : β × γ → E⦄ (F : E → E'
     ∫ x, F (∫ y, f (x, y) + g (x, y) ∂η (a, x)) ∂κ a =
       ∫ x, F (∫ y, f (x, y) ∂η (a, x) + ∫ y, g (x, y) ∂η (a, x)) ∂κ a := by
   refine integral_congr_ae ?_
-  filter_upwards [hf.compProd_mk_left_ae, hg.compProd_mk_left_ae] with _ h2f h2g
+  filter_upwards [hf.ae_of_compProd, hg.ae_of_compProd] with _ h2f h2g
   simp [integral_add h2f h2g]
 
 theorem Kernel.integral_fn_integral_sub ⦃f g : β × γ → E⦄ (F : E → E')
@@ -171,7 +175,7 @@ theorem Kernel.integral_fn_integral_sub ⦃f g : β × γ → E⦄ (F : E → E'
     ∫ x, F (∫ y, f (x, y) - g (x, y) ∂η (a, x)) ∂κ a =
       ∫ x, F (∫ y, f (x, y) ∂η (a, x) - ∫ y, g (x, y) ∂η (a, x)) ∂κ a := by
   refine integral_congr_ae ?_
-  filter_upwards [hf.compProd_mk_left_ae, hg.compProd_mk_left_ae] with _ h2f h2g
+  filter_upwards [hf.ae_of_compProd, hg.ae_of_compProd] with _ h2f h2g
   simp [integral_sub h2f h2g]
 
 theorem Kernel.lintegral_fn_integral_sub ⦃f g : β × γ → E⦄ (F : E → ℝ≥0∞)
@@ -179,7 +183,7 @@ theorem Kernel.lintegral_fn_integral_sub ⦃f g : β × γ → E⦄ (F : E → �
     ∫⁻ x, F (∫ y, f (x, y) - g (x, y) ∂η (a, x)) ∂κ a =
       ∫⁻ x, F (∫ y, f (x, y) ∂η (a, x) - ∫ y, g (x, y) ∂η (a, x)) ∂κ a := by
   refine lintegral_congr_ae ?_
-  filter_upwards [hf.compProd_mk_left_ae, hg.compProd_mk_left_ae] with _ h2f h2g
+  filter_upwards [hf.ae_of_compProd, hg.ae_of_compProd] with _ h2f h2g
   simp [integral_sub h2f h2g]
 
 theorem Kernel.integral_integral_add ⦃f g : β × γ → E⦄ (hf : Integrable f ((κ ⊗ₖ η) a))
@@ -284,29 +288,6 @@ section comp
 
 variable {κ : Kernel α β} {η : Kernel β γ}
 
-theorem _root_.MeasureTheory.StronglyMeasurable.integral_kernel [NormedSpace ℝ E] ⦃f : β → E⦄
-    (hf : StronglyMeasurable f) : StronglyMeasurable fun x ↦ ∫ y, f y ∂κ x := by
-  classical
-  by_cases hE : CompleteSpace E; swap
-  · simp [integral, hE, stronglyMeasurable_const]
-  borelize E
-  have : TopologicalSpace.SeparableSpace (range f ∪ {0} : Set E) :=
-    hf.separableSpace_range_union_singleton
-  let s : ℕ → SimpleFunc β E := SimpleFunc.approxOn _ hf.measurable (range f ∪ {0}) 0 (by simp)
-  let f' n : α → E := {x | Integrable f (κ x)}.indicator fun x ↦ (s n).integral (κ x)
-  refine stronglyMeasurable_of_tendsto (f := f') atTop (fun n ↦ ?_) ?_
-  · refine StronglyMeasurable.indicator ?_ (measurableSet_integrable hf)
-    simp_rw [SimpleFunc.integral_eq]
-    refine Finset.stronglyMeasurable_sum _ fun _ _ ↦ ?_
-    refine (Measurable.ennreal_toReal ?_).stronglyMeasurable.smul_const _
-    exact κ.measurable_coe ((s n).measurableSet_fiber _)
-  · rw [tendsto_pi_nhds]; intro x
-    by_cases hfx : Integrable f (κ x)
-    · simp only [mem_setOf_eq, hfx, indicator_of_mem, f']
-      apply tendsto_integral_approxOn_of_measurable_of_range_subset _ hfx
-      exact subset_rfl
-    · simp [f', hfx, integral_undef]
-
 theorem _root_.MeasureTheory.AEStronglyMeasurable.integral_kernel_comp [NormedSpace ℝ E]
     ⦃f : γ → E⦄ (hf : AEStronglyMeasurable f ((η ∘ₖ κ) a)) :
     AEStronglyMeasurable (fun x ↦ ∫ y, f y ∂η x) (κ a) :=
@@ -353,7 +334,7 @@ theorem integrable_comp_iff ⦃f : γ → E⦄ (hf : AEStronglyMeasurable f ((η
   simp only [Integrable, hf, hasFiniteIntegral_comp_iff' hf, true_and, eventually_and, hf.comp,
     hf.norm.integral_kernel_comp]
 
-theorem _root_.MeasureTheory.Integrable.comp ⦃f : γ → E⦄ (hf : Integrable f ((η ∘ₖ κ) a)) :
+theorem _root_.MeasureTheory.Integrable.ae_of_comp ⦃f : γ → E⦄ (hf : Integrable f ((η ∘ₖ κ) a)) :
     ∀ᵐ x ∂κ a, Integrable f (η x) := ((integrable_comp_iff hf.1).1 hf).1
 
 theorem _root_.MeasureTheory.Integrable.integral_norm_comp ⦃f : γ → E⦄
@@ -376,21 +357,21 @@ theorem integral_fn_integral_add_comp ⦃f g : γ → E⦄ (F : E → E')
     (hf : Integrable f ((η ∘ₖ κ) a)) (hg : Integrable g ((η ∘ₖ κ) a)) :
     ∫ x, F (∫ y, f y + g y ∂η x) ∂κ a = ∫ x, F (∫ y, f y ∂η x + ∫ y, g y ∂η x) ∂κ a := by
   refine integral_congr_ae ?_
-  filter_upwards [hf.comp, hg.comp] with _ h2f h2g
+  filter_upwards [hf.ae_of_comp, hg.ae_of_comp] with _ h2f h2g
   simp [integral_add h2f h2g]
 
 theorem integral_fn_integral_sub_comp ⦃f g : γ → E⦄ (F : E → E')
     (hf : Integrable f ((η ∘ₖ κ) a)) (hg : Integrable g ((η ∘ₖ κ) a)) :
     ∫ x, F (∫ y, f y - g y ∂η x) ∂κ a = ∫ x, F (∫ y, f y ∂η x - ∫ y, g y ∂η x) ∂κ a := by
   refine integral_congr_ae ?_
-  filter_upwards [hf.comp, hg.comp] with _ h2f h2g
+  filter_upwards [hf.ae_of_comp, hg.ae_of_comp] with _ h2f h2g
   simp [integral_sub h2f h2g]
 
 theorem lintegral_fn_integral_sub_comp ⦃f g : γ → E⦄ (F : E → ℝ≥0∞)
     (hf : Integrable f ((η ∘ₖ κ) a)) (hg : Integrable g ((η ∘ₖ κ) a)) :
     ∫⁻ x, F (∫ y, f y - g y ∂η x) ∂κ a = ∫⁻ x, F (∫ y, f y ∂η x - ∫ y, g y ∂η x) ∂κ a := by
   refine lintegral_congr_ae ?_
-  filter_upwards [hf.comp, hg.comp] with _ h2f h2g
+  filter_upwards [hf.ae_of_comp, hg.ae_of_comp] with _ h2f h2g
   simp [integral_sub h2f h2g]
 
 theorem integral_integral_add_comp ⦃f g : γ → E⦄ (hf : Integrable f ((η ∘ₖ κ) a))

--- a/Mathlib/Probability/Kernel/Composition/IntegralCompProd.lean
+++ b/Mathlib/Probability/Kernel/Composition/IntegralCompProd.lean
@@ -40,7 +40,7 @@ to the composition-product of two kernels.
 
 The composition of kernels can also be expressed easily with the composition-product and therefore
 the proofs about the composition are only simplified versions of the ones for the
-composition-product. However it is necessary to do all the proofs one again because the
+composition-product. However it is necessary to do all the proofs once again because the
 composition-product requires s-finiteness while the composition does not.
 -/
 

--- a/Mathlib/Probability/Kernel/Composition/IntegralCompProd.lean
+++ b/Mathlib/Probability/Kernel/Composition/IntegralCompProd.lean
@@ -7,27 +7,41 @@ import Mathlib.Probability.Kernel.Composition.Basic
 import Mathlib.Probability.Kernel.MeasurableIntegral
 
 /-!
-# Bochner integral of a function against the composition-product of two kernels
+# Bochner integral of a function against the composition and the composition-products of two kernels
 
-We prove properties of the composition-product of two kernels. If `κ` is an s-finite kernel from
-`α` to `β` and `η` is an s-finite kernel from `α × β` to `γ`, we can form their composition-product
-`κ ⊗ₖ η : Kernel α (β × γ)`. We proved in `ProbabilityTheory.Kernel.lintegral_compProd` that it
+We prove properties of the composition and the composition-product of two kernels.
+
+If `κ` is a kernel from `α` to `β` and `η` is a kernel from `β` to `γ`, we can form their
+composition `η ∘ₖ κ : Kernel α γ`. We proved in `ProbabilityTheory.Kernel.lintegral_comp` that it
+verifies `∫⁻ c, f c ∂((η ∘ₖ κ) a) = ∫⁻ b, ∫⁻ c, f c ∂(η b) ∂(κ a)`. In this file, we
+prove the same equality for the Bochner integral.
+
+If `κ` is an s-finite kernel from `α` to `β` and `η` is an s-finite kernel from `α × β` to `γ`,
+we can form their composition-product `κ ⊗ₖ η : Kernel α (β × γ)`.
+We proved in `ProbabilityTheory.Kernel.lintegral_compProd` that it
 verifies `∫⁻ bc, f bc ∂((κ ⊗ₖ η) a) = ∫⁻ b, ∫⁻ c, f (b, c) ∂(η (a, b)) ∂(κ a)`. In this file, we
 prove the same equality for the Bochner integral.
 
 ## Main statements
 
 * `ProbabilityTheory.integral_compProd`: the integral against the composition-product is
-  `∫ z, f z ∂((κ ⊗ₖ η) a) = ∫ x, ∫ y, f (x, y) ∂(η (a, x)) ∂(κ a)`
+  `∫ z, f z ∂((κ ⊗ₖ η) a) = ∫ x, ∫ y, f (x, y) ∂(η (a, x)) ∂(κ a)`.
+
+* `ProbabilityTheory.integral_comp`: the integral against the composition is
+  `∫⁻ z, f z ∂((η ∘ₖ κ) a) = ∫⁻ x, ∫⁻ y, f y ∂(η x) ∂(κ a)`.
 
 ## Implementation details
 
-This file is to a large extent a copy of part of
-`Mathlib/MeasureTheory/Constructions/Prod/Basic.lean`. The product of
-two measures is a particular case of composition-product of kernels and it turns out that once the
-measurablity of the Lebesgue integral of a kernel is proved, almost all proofs about integrals
-against products of measures extend with minimal modifications to the composition-product of two
-kernels.
+This file is to a large extent a copy of part of `Mathlib/MeasureTheory/Integral/Prod.lean`.
+The product of two measures is a particular case of composition-product of kernels and
+it turns out that once the measurablity of the Lebesgue integral of a kernel is proved,
+almost all proofs about integrals against products of measures extend with minimal modifications
+to the composition-product of two kernels.
+
+The composition of kernels can also be expressed easily with the composition-product and therefore
+the proofs about the composition are only simplified versions of the ones for the
+composition-product. However it is necessary to do all the proofs one again because the
+composition-product requires s-finiteness while the composition does not.
 -/
 
 

--- a/Mathlib/Probability/Kernel/Composition/MeasureComp.lean
+++ b/Mathlib/Probability/Kernel/Composition/MeasureComp.lean
@@ -25,6 +25,9 @@ variable {α β γ : Type*} {mα : MeasurableSpace α} {mβ : MeasurableSpace β
 lemma comp_assoc {η : Kernel β γ} : η ∘ₘ (κ ∘ₘ μ) = (η ∘ₖ κ) ∘ₘ μ :=
   Measure.bind_bind κ.measurable η.measurable
 
+lemma comp_eq_comp_const_apply : κ ∘ₘ μ = (κ ∘ₖ (Kernel.const Unit μ)) () := by
+  rw [Kernel.comp_apply, Kernel.const_apply]
+
 @[simp]
 lemma snd_compProd (μ : Measure α) [SFinite μ] (κ : Kernel α β) [IsSFiniteKernel κ] :
     (μ ⊗ₘ κ).snd = κ ∘ₘ μ := by
@@ -33,10 +36,10 @@ lemma snd_compProd (μ : Measure α) [SFinite μ] (κ : Kernel α β) [IsSFinite
   · rfl
   · exact measurable_snd hs
 
-lemma ae_ae_of_ae_comp [SFinite μ] [IsSFiniteKernel κ] {p : β → Prop} (h : ∀ᵐ ω ∂(κ ∘ₘ μ), p ω) :
+lemma ae_ae_of_ae_comp {p : β → Prop} (h : ∀ᵐ ω ∂(κ ∘ₘ μ), p ω) :
     ∀ᵐ ω' ∂μ, ∀ᵐ ω ∂(κ ω'), p ω := by
-  rw [← snd_compProd] at h
-  exact Measure.ae_ae_of_ae_compProd (ae_of_ae_map measurable_snd.aemeasurable h)
+  rw [comp_eq_comp_const_apply] at h
+  exact Kernel.ae_ae_of_ae_comp h
 
 instance [SFinite μ] [IsSFiniteKernel κ] : SFinite (κ ∘ₘ μ) := by
   rw [← snd_compProd]; infer_instance
@@ -68,9 +71,11 @@ lemma compProd_eq_comp_prod (μ : Measure α) [SFinite μ] (κ : Kernel α β) [
 lemma compProd_id_eq_copy_comp [SFinite μ] : μ ⊗ₘ Kernel.id = Kernel.copy α ∘ₘ μ := by
   rw [compProd_id, Kernel.copy, deterministic_comp_eq_map]
 
-lemma comp_compProd_comm {η : Kernel (α × β) γ}
-    [SFinite μ] [IsSFiniteKernel κ] [IsSFiniteKernel η] :
+lemma comp_compProd_comm {η : Kernel (α × β) γ} [SFinite μ] [IsSFiniteKernel η] :
     η ∘ₘ (μ ⊗ₘ κ) = ((κ ⊗ₖ η) ∘ₘ μ).snd := by
+  by_cases hκ : IsSFiniteKernel κ; swap
+  · simp [compProd_of_not_isSFiniteKernel _ _ hκ,
+      Kernel.compProd_of_not_isSFiniteKernel_left _ _ hκ]
   ext s hs
   rw [Measure.bind_apply hs η.measurable, Measure.snd_apply hs,
     Measure.bind_apply _ (Kernel.measurable _), Measure.lintegral_compProd (η.measurable_coe hs)]
@@ -84,9 +89,10 @@ end CompProd
 
 section Integrable
 
-variable {E : Type*} [NormedAddCommGroup E] {f : β → E} [SFinite μ] [IsSFiniteKernel κ]
+variable {E : Type*} [NormedAddCommGroup E] {f : β → E}
 
-lemma integrable_compProd_snd_iff (hf : AEStronglyMeasurable f (κ ∘ₘ μ)) :
+lemma integrable_compProd_snd_iff [SFinite μ] [IsSFiniteKernel κ]
+    (hf : AEStronglyMeasurable f (κ ∘ₘ μ)) :
     Integrable (fun p ↦ f p.2) (μ ⊗ₘ κ) ↔ Integrable f (κ ∘ₘ μ) := by
   rw [← snd_compProd, Measure.snd, integrable_map_measure _ measurable_snd.aemeasurable]
   · rfl
@@ -94,14 +100,12 @@ lemma integrable_compProd_snd_iff (hf : AEStronglyMeasurable f (κ ∘ₘ μ)) :
 
 lemma ae_integrable_of_integrable_comp (h_int : Integrable f (κ ∘ₘ μ)) :
     ∀ᵐ x ∂μ, Integrable f (κ x) := by
-  rw [← Measure.integrable_compProd_snd_iff h_int.1, Measure.integrable_compProd_iff h_int.1]
-    at h_int
+  rw [comp_eq_comp_const_apply, integrable_comp_iff h_int.1] at h_int
   exact h_int.1
 
 lemma integrable_integral_norm_of_integrable_comp (h_int : Integrable f (κ ∘ₘ μ)) :
     Integrable (fun x ↦ ∫ y, ‖f y‖ ∂κ x) μ := by
-  rw [← Measure.integrable_compProd_snd_iff h_int.1, Measure.integrable_compProd_iff h_int.1]
-    at h_int
+  rw [comp_eq_comp_const_apply, integrable_comp_iff h_int.1] at h_int
   exact h_int.2
 
 end Integrable
@@ -109,21 +113,16 @@ end Integrable
 section AddSMul
 
 @[simp]
-lemma comp_add [SFinite μ] [SFinite ν] [IsSFiniteKernel κ] :
-    κ ∘ₘ (μ + ν) = κ ∘ₘ μ + κ ∘ₘ ν := by
-  simp_rw [← snd_compProd, compProd_add_left]
-  simp
+lemma comp_add : κ ∘ₘ (μ + ν) = κ ∘ₘ μ + κ ∘ₘ ν := by
+  simp_rw [comp_eq_comp_const_apply, Kernel.const_add, Kernel.comp_add_left, Kernel.add_apply]
 
-lemma add_comp [SFinite μ] [IsSFiniteKernel κ] [IsSFiniteKernel η] :
-    (κ + η) ∘ₘ μ = κ ∘ₘ μ + η ∘ₘ μ := by
-  simp_rw [← snd_compProd, compProd_add_right]
-  simp
+lemma add_comp : (κ + η) ∘ₘ μ = κ ∘ₘ μ + η ∘ₘ μ := by
+  simp_rw [comp_eq_comp_const_apply, Kernel.comp_add_right, Kernel.add_apply]
 
 /-- Same as `add_comp` except that it uses `⇑κ + ⇑η` instead of `⇑(κ + η)` in order to have
 a simp-normal form on the left of the equality. -/
 @[simp]
-lemma add_comp' [SFinite μ] [IsSFiniteKernel κ] [IsSFiniteKernel η] :
-    (⇑κ + ⇑η) ∘ₘ μ = κ ∘ₘ μ + η ∘ₘ μ := by rw [← Kernel.coe_add, add_comp]
+lemma add_comp' : (⇑κ + ⇑η) ∘ₘ μ = κ ∘ₘ μ + η ∘ₘ μ := by rw [← Kernel.coe_add, add_comp]
 
 lemma comp_smul (a : ℝ≥0∞) : κ ∘ₘ (a • μ) = a • (κ ∘ₘ μ) := by
   ext s hs
@@ -133,20 +132,23 @@ end AddSMul
 
 section AbsolutelyContinuous
 
-variable [SFinite μ] [SFinite ν] [IsSFiniteKernel κ] [IsSFiniteKernel η]
+lemma AbsolutelyContinuous.comp_right (hμν : μ ≪ ν) (κ : Kernel α γ) :
+    κ ∘ₘ μ ≪ κ ∘ₘ ν := by
+  refine Measure.AbsolutelyContinuous.mk fun s hs hs_zero ↦ ?_
+  rw [Measure.bind_apply hs (Kernel.measurable _),
+    lintegral_eq_zero_iff (Kernel.measurable_coe _ hs)] at hs_zero ⊢
+  exact hμν.ae_eq hs_zero
+
+lemma AbsolutelyContinuous.comp_left (μ : Measure α) (hκη : ∀ᵐ a ∂μ, κ a ≪ η a) :
+    κ ∘ₘ μ ≪ η ∘ₘ μ := by
+  refine Measure.AbsolutelyContinuous.mk fun s hs hs_zero ↦ ?_
+  rw [Measure.bind_apply hs (Kernel.measurable _),
+    lintegral_eq_zero_iff (Kernel.measurable_coe _ hs)] at hs_zero ⊢
+  filter_upwards [hs_zero, hκη] with a ha_zero ha_ac using ha_ac ha_zero
 
 lemma AbsolutelyContinuous.comp (hμν : μ ≪ ν) (hκη : ∀ᵐ a ∂μ, κ a ≪ η a) :
-    κ ∘ₘ μ ≪ η ∘ₘ ν := by
-  simp_rw [← snd_compProd, Measure.snd]
-  exact (hμν.compProd hκη).map measurable_snd
-
-lemma AbsolutelyContinuous.comp_right (hμν : μ ≪ ν) (κ : Kernel α γ) [IsSFiniteKernel κ]  :
-    κ ∘ₘ μ ≪ κ ∘ₘ ν :=
-  hμν.comp (ae_of_all μ fun _ _ a ↦ a)
-
-lemma AbsolutelyContinuous.comp_left (μ : Measure α) [SFinite μ] (hκη : ∀ᵐ a ∂μ, κ a ≪ η a) :
-    κ ∘ₘ μ ≪ η ∘ₘ μ :=
-  μ.absolutelyContinuous_refl.comp hκη
+    κ ∘ₘ μ ≪ η ∘ₘ ν :=
+  (AbsolutelyContinuous.comp_left μ hκη).trans (hμν.comp_right η)
 
 end AbsolutelyContinuous
 

--- a/Mathlib/Probability/Kernel/Composition/MeasureComp.lean
+++ b/Mathlib/Probability/Kernel/Composition/MeasureComp.lean
@@ -116,10 +116,10 @@ section AddSMul
 
 @[simp]
 lemma comp_add : κ ∘ₘ (μ + ν) = κ ∘ₘ μ + κ ∘ₘ ν := by
-  simp_rw [comp_eq_comp_const_apply, Kernel.const_add, Kernel.comp_add_left, Kernel.add_apply]
+  simp_rw [comp_eq_comp_const_apply, Kernel.const_add, Kernel.comp_add_right, Kernel.add_apply]
 
 lemma add_comp : (κ + η) ∘ₘ μ = κ ∘ₘ μ + η ∘ₘ μ := by
-  simp_rw [comp_eq_comp_const_apply, Kernel.comp_add_right, Kernel.add_apply]
+  simp_rw [comp_eq_comp_const_apply, Kernel.comp_add_left, Kernel.add_apply]
 
 /-- Same as `add_comp` except that it uses `⇑κ + ⇑η` instead of `⇑(κ + η)` in order to have
 a simp-normal form on the left of the equality. -/

--- a/Mathlib/Probability/Kernel/Composition/MeasureComp.lean
+++ b/Mathlib/Probability/Kernel/Composition/MeasureComp.lean
@@ -25,6 +25,8 @@ variable {α β γ : Type*} {mα : MeasurableSpace α} {mβ : MeasurableSpace β
 lemma comp_assoc {η : Kernel β γ} : η ∘ₘ (κ ∘ₘ μ) = (η ∘ₖ κ) ∘ₘ μ :=
   Measure.bind_bind κ.measurable η.measurable
 
+/-- This lemma allows to rewrite the compostion of a measure and a kernel as the composition
+of two kernels, which allows to transfer properties of `∘ₖ` to `∘ₘ`. -/
 lemma comp_eq_comp_const_apply : κ ∘ₘ μ = (κ ∘ₖ (Kernel.const Unit μ)) () := by
   rw [Kernel.comp_apply, Kernel.const_apply]
 
@@ -124,6 +126,7 @@ a simp-normal form on the left of the equality. -/
 @[simp]
 lemma add_comp' : (⇑κ + ⇑η) ∘ₘ μ = κ ∘ₘ μ + η ∘ₘ μ := by rw [← Kernel.coe_add, add_comp]
 
+@[simp]
 lemma comp_smul (a : ℝ≥0∞) : κ ∘ₘ (a • μ) = a • (κ ∘ₘ μ) := by
   ext s hs
   simp only [bind_apply hs κ.measurable, lintegral_smul_measure, smul_apply, smul_eq_mul]

--- a/Mathlib/Probability/Kernel/Invariance.lean
+++ b/Mathlib/Probability/Kernel/Invariance.lean
@@ -36,20 +36,6 @@ namespace Kernel
 
 /-! ### Push-forward of measures along a kernel -/
 
-
-@[simp]
-theorem bind_add (μ ν : Measure α) (κ : Kernel α β) : (μ + ν).bind κ = μ.bind κ + ν.bind κ := by
-  ext1 s hs
-  rw [Measure.bind_apply hs (Kernel.measurable _), lintegral_add_measure, Measure.coe_add,
-    Pi.add_apply, Measure.bind_apply hs (Kernel.measurable _),
-    Measure.bind_apply hs (Kernel.measurable _)]
-
-@[simp]
-theorem bind_smul (κ : Kernel α β) (μ : Measure α) (r : ℝ≥0∞) : (r • μ).bind κ = r • μ.bind κ := by
-  ext1 s hs
-  rw [Measure.bind_apply hs (Kernel.measurable _), lintegral_smul_measure, Measure.coe_smul,
-    Pi.smul_apply, Measure.bind_apply hs (Kernel.measurable _), smul_eq_mul]
-
 theorem const_bind_eq_comp_const (κ : Kernel α β) (μ : Measure α) :
     const α (μ.bind κ) = κ ∘ₖ const α μ := by
   ext a s hs

--- a/Mathlib/Probability/Kernel/Invariance.lean
+++ b/Mathlib/Probability/Kernel/Invariance.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kexing Ying
 -/
 import Mathlib.Probability.Kernel.Composition.Basic
+import Mathlib.Probability.Kernel.Composition.MeasureComp
 
 /-!
 # Invariance of measures along a kernel
@@ -35,6 +36,12 @@ variable {α β : Type*} {mα : MeasurableSpace α} {mβ : MeasurableSpace β}
 namespace Kernel
 
 /-! ### Push-forward of measures along a kernel -/
+
+@[deprecated (since := "2025-02-28")]
+alias bind_add := MeasureTheory.Measure.comp_add
+
+@[deprecated (since := "2025-02-28")]
+alias bind_smul := MeasureTheory.Measure.comp_smul
 
 theorem const_bind_eq_comp_const (κ : Kernel α β) (μ : Measure α) :
     const α (μ.bind κ) = κ ∘ₖ const α μ := by

--- a/Mathlib/Probability/Kernel/Invariance.lean
+++ b/Mathlib/Probability/Kernel/Invariance.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kexing Ying
 -/
 import Mathlib.Probability.Kernel.Composition.Basic
-import Mathlib.Probability.Kernel.Composition.MeasureComp
 
 /-!
 # Invariance of measures along a kernel
@@ -37,11 +36,18 @@ namespace Kernel
 
 /-! ### Push-forward of measures along a kernel -/
 
-@[deprecated (since := "2025-02-28")]
-alias bind_add := MeasureTheory.Measure.comp_add
+@[deprecated "Use comp_add in Composition/MeasureComp" (since := "2025-02-28")]
+theorem bind_add (μ ν : Measure α) (κ : Kernel α β) : (μ + ν).bind κ = μ.bind κ + ν.bind κ := by
+  ext1 s hs
+  rw [Measure.bind_apply hs (Kernel.measurable _), lintegral_add_measure, Measure.coe_add,
+    Pi.add_apply, Measure.bind_apply hs (Kernel.measurable _),
+    Measure.bind_apply hs (Kernel.measurable _)]
 
-@[deprecated (since := "2025-02-28")]
-alias bind_smul := MeasureTheory.Measure.comp_smul
+@[deprecated "Use comp_smul in Composition/MeasureComp" (since := "2025-02-28")]
+theorem bind_smul (κ : Kernel α β) (μ : Measure α) (r : ℝ≥0∞) : (r • μ).bind κ = r • μ.bind κ := by
+  ext1 s hs
+  rw [Measure.bind_apply hs (Kernel.measurable _), lintegral_smul_measure, Measure.coe_smul,
+    Pi.smul_apply, Measure.bind_apply hs (Kernel.measurable _), smul_eq_mul]
 
 theorem const_bind_eq_comp_const (κ : Kernel α β) (μ : Measure α) :
     const α (μ.bind κ) = κ ∘ₖ const α μ := by

--- a/Mathlib/Probability/Kernel/MeasurableIntegral.lean
+++ b/Mathlib/Probability/Kernel/MeasurableIntegral.lean
@@ -46,6 +46,30 @@ namespace MeasureTheory
 
 variable [NormedSpace ℝ E]
 
+omit [IsSFiniteKernel κ] in
+theorem StronglyMeasurable.integral_kernel ⦃f : β → E⦄
+    (hf : StronglyMeasurable f) : StronglyMeasurable fun x ↦ ∫ y, f y ∂κ x := by
+  classical
+  by_cases hE : CompleteSpace E; swap
+  · simp [integral, hE, stronglyMeasurable_const]
+  borelize E
+  have : TopologicalSpace.SeparableSpace (range f ∪ {0} : Set E) :=
+    hf.separableSpace_range_union_singleton
+  let s : ℕ → SimpleFunc β E := SimpleFunc.approxOn _ hf.measurable (range f ∪ {0}) 0 (by simp)
+  let f' n : α → E := {x | Integrable f (κ x)}.indicator fun x ↦ (s n).integral (κ x)
+  refine stronglyMeasurable_of_tendsto (f := f') atTop (fun n ↦ ?_) ?_
+  · refine StronglyMeasurable.indicator ?_ (measurableSet_integrable hf)
+    simp_rw [SimpleFunc.integral_eq]
+    refine Finset.stronglyMeasurable_sum _ fun _ _ ↦ ?_
+    refine (Measurable.ennreal_toReal ?_).stronglyMeasurable.smul_const _
+    exact κ.measurable_coe ((s n).measurableSet_fiber _)
+  · rw [tendsto_pi_nhds]; intro x
+    by_cases hfx : Integrable f (κ x)
+    · simp only [mem_setOf_eq, hfx, indicator_of_mem, f']
+      apply tendsto_integral_approxOn_of_measurable_of_range_subset _ hfx
+      exact subset_rfl
+    · simp [f', hfx, integral_undef]
+
 theorem StronglyMeasurable.integral_kernel_prod_right ⦃f : α → β → E⦄
     (hf : StronglyMeasurable (uncurry f)) : StronglyMeasurable fun x => ∫ y, f x y ∂κ x := by
   classical

--- a/Mathlib/Probability/Kernel/MeasurableIntegral.lean
+++ b/Mathlib/Probability/Kernel/MeasurableIntegral.lean
@@ -25,8 +25,14 @@ open MeasureTheory ProbabilityTheory Function Set Filter
 open scoped MeasureTheory ENNReal Topology
 
 variable {α β γ : Type*} {mα : MeasurableSpace α} {mβ : MeasurableSpace β} {mγ : MeasurableSpace γ}
-  {κ : Kernel α β} {η : Kernel (α × β) γ} {a : α}
-  {E : Type*} [NormedAddCommGroup E] [IsSFiniteKernel κ] [IsSFiniteKernel η]
+  {κ : Kernel α β} {η : Kernel β γ} {a : α} {E : Type*} [NormedAddCommGroup E]
+
+theorem ProbabilityTheory.measurableSet_integrable ⦃f : β → E⦄ (hf : StronglyMeasurable f) :
+    MeasurableSet {a | Integrable f (κ a)} := by
+  simp_rw [Integrable, hf.aestronglyMeasurable, true_and]
+  exact measurableSet_lt hf.enorm.lintegral_kernel measurable_const
+
+variable [IsSFiniteKernel κ] {η : Kernel (α × β) γ} [IsSFiniteKernel η]
 
 theorem ProbabilityTheory.measurableSet_kernel_integrable ⦃f : α → β → E⦄
     (hf : StronglyMeasurable (uncurry f)) :


### PR DESCRIPTION
Prove the formula for the integral against the composition of kernels. This is a simplified version of the proof for the composition-product which is in the same file. However we need to do all the proofs again because the results about composition-product require s-finiteness while composition do not.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

- [x] depends on: #22362

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)