### PR TITLE
[Merged by Bors] - feat: register more tactics for `hint`

### DIFF
--- a/Mathlib/Tactic/Abel.lean
+++ b/Mathlib/Tactic/Abel.lean
@@ -565,3 +565,9 @@ macro (name := abelConv) "abel" : conv =>
   `(conv| first | discharge => abel1! | try_this abel_nf!)
 
 end Mathlib.Tactic.Abel
+
+/-!
+We register `abel` with the `hint` tactic.
+-/
+
+register_hint abel

--- a/Mathlib/Tactic/Bound.lean
+++ b/Mathlib/Tactic/Bound.lean
@@ -257,3 +257,9 @@ macro_rules
   | `(tactic| bound%$tk [$[$ts],*]) => do
     let haves ← ts.mapM fun (t : Term) => withRef t `(tactic| have := $t)
     `(tactic| ($haves;*; bound%$tk))
+
+/-!
+We register `bound` with the `hint` tactic.
+-/
+
+register_hint bound

--- a/Mathlib/Tactic/Group.lean
+++ b/Mathlib/Tactic/Group.lean
@@ -87,3 +87,9 @@ macro_rules
   `(tactic| repeat (fail_if_no_progress (aux_group₁ $[$loc]? <;> aux_group₂ $[$loc]?)))
 
 end Mathlib.Tactic.Group
+
+/-!
+We register `group` with the `hint` tactic.
+-/
+
+register_hint group

--- a/Mathlib/Tactic/NoncommRing.lean
+++ b/Mathlib/Tactic/NoncommRing.lean
@@ -71,3 +71,9 @@ macro_rules
     if rules.isSome then `(tactic| repeat1 ($tac;)) else `(tactic| $tac)
 
 end Mathlib.Tactic.NoncommRing
+
+/-!
+We register `noncomm_ring` with the `hint` tactic.
+-/
+
+register_hint noncomm_ring

--- a/Mathlib/Tactic/NormNum.lean
+++ b/Mathlib/Tactic/NormNum.lean
@@ -1,3 +1,9 @@
+/-
+Copyright (c) 2025. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: euprunin
+-/
+
 import Mathlib.Tactic.NormNum.Basic
 import Mathlib.Tactic.NormNum.OfScientific
 import Mathlib.Tactic.NormNum.Eq
@@ -6,3 +12,9 @@ import Mathlib.Tactic.NormNum.Pow
 import Mathlib.Tactic.NormNum.Inv
 import Mathlib.Tactic.NormNum.DivMod
 import Mathlib.Data.Rat.Cast.Order
+
+/-!
+We register `norm_num` with the `hint` tactic.
+-/
+
+register_hint norm_num

--- a/Mathlib/Tactic/Positivity/Core.lean
+++ b/Mathlib/Tactic/Positivity/Core.lean
@@ -442,3 +442,9 @@ elab (name := positivity) "positivity" : tactic => do
 end Positivity
 
 end Mathlib.Tactic
+
+/-!
+We register `positivity` with the `hint` tactic.
+-/
+
+register_hint positivity

--- a/Mathlib/Tactic/Ring.lean
+++ b/Mathlib/Tactic/Ring.lean
@@ -1,3 +1,15 @@
+/-
+Copyright (c) 2025. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: euprunin
+-/
+
 import Mathlib.Tactic.Ring.Basic
 import Mathlib.Tactic.Ring.RingNF
 import Mathlib.Tactic.Ring.PNat
+
+/-!
+We register `ring` with the `hint` tactic.
+-/
+
+register_hint ring

--- a/MathlibTest/hint.lean
+++ b/MathlibTest/hint.lean
@@ -13,6 +13,7 @@ example (h : 1 < 0) : False := by hint
 /--
 info: Try these:
 • exact f p
+• norm_num
 -/
 #guard_msgs in
 example {P Q : Prop} (p : P) (f : P → Q) : Q := by hint
@@ -20,6 +21,7 @@ example {P Q : Prop} (p : P) (f : P → Q) : Q := by hint
 /--
 info: Try these:
 • simp_all only [and_self]
+• norm_num
 -/
 #guard_msgs in
 example {P Q R : Prop} (x : P ∧ Q ∧ R ∧ R) : Q ∧ P ∧ R := by hint
@@ -33,7 +35,7 @@ example {a b : ℚ} (h : a < b) : ¬ b < a := by hint
 
 /--
 info: Try these:
-• omega
+• norm_num
 -/
 #guard_msgs in
 example : 37^2 - 35^2 = 72 * 2 := by hint
@@ -41,6 +43,7 @@ example : 37^2 - 35^2 = 72 * 2 := by hint
 /--
 info: Try these:
 • decide
+• norm_num
 -/
 #guard_msgs in
 example : Nat.Prime 37 := by hint
@@ -48,6 +51,7 @@ example : Nat.Prime 37 := by hint
 /--
 info: Try these:
 • aesop
+• norm_num
 • simp_all only [zero_le, and_true]
 -/
 #guard_msgs in
@@ -90,6 +94,7 @@ example {α} (A B C : Set α) (h1 : A ⊆ B ∪ C) : (A ∩ B) ∪ (A ∩ C) = A
 /--
 info: Try these:
 • aesop
+• norm_num
 • simp_all only [Nat.not_ofNat_le_one]
 ---
 warning: declaration uses 'sorry'


### PR DESCRIPTION
The following example shows test cases that `hint` now supports, which were unsupported prior to this PR:

```
import Mathlib

-- The tactics registered in this PR
register_hint abel
register_hint bound
register_hint group
register_hint noncomm_ring
register_hint norm_num
register_hint positivity
register_hint ring

-- "hint" now correctly suggests "abel" which closes the goal (no closing tactic suggested prior to this PR)
example {α} [AddCommMonoid α] (a b c d: α) : a + b + c + d + 0 = d + (c + b) + (0 + 0 + a) := by hint

-- "hint" now correctly suggests "bound" which closes the goal (no closing tactic suggested prior to this PR)
example (a b : ℝ) (h1 : ‖a‖ ≤ ‖b‖) (h2 : 3 ≤ ‖b‖) : ‖b ^ 2 + a‖ ≥ ‖b ^ 2‖ - ‖a‖ ∧ ‖b ^ 2‖ - ‖a‖ ≥ ‖b ^ 2‖ - ‖b‖ ∧ (‖b‖ - 1) * ‖b‖ ≥ 2 * ‖b‖ := by hint

-- "hint" now correctly suggests "group" which closes the goal (no closing tactic suggested prior to this PR)
example (G : Type) (a b c : G) [Group G] : c⁻¹ * (b * c⁻¹) * c * (a * b) * (b⁻¹ * a⁻¹ * b⁻¹) * c = 1 := by hint

-- "hint" now correctly suggests "noncomm_ring" which closes the goal (no closing tactic suggested prior to this PR)
example (R : Type) (a b : R) [Ring R] : (a + b) ^ 3 = a ^ 3 + a ^ 2 * b + a * b * a + a * b ^ 2 + b * a ^ 2 + b * a * b + b ^ 2 * a + b ^ 3 := by hint

-- "hint" now correctly suggests "norm_num" which closes the goal (no closing tactic suggested prior to this PR)
example : (2 : ℝ) < 5 / 2 ∧ 5 / 2 < 3 := by hint

-- "hint" now correctly suggests "positivity" which closes the goal (no closing tactic suggested prior to this PR)
example (a : ℤ) : 0 < |a| + 3 := by hint

-- "hint" now correctly suggests "ring" which closes the goal (no closing tactic suggested prior to this PR)
example (α : Type) (a b c : α) [LinearOrderedField α] : a * (-c / b) * (-c / b) + -c + c = a * (c / b * (c / b)) := by hint
```