### PR TITLE
[Merged by Bors] - feat(LinearIndependent): more API for linearIndepOn

### DIFF
--- a/Mathlib/LinearAlgebra/Dimension/Constructions.lean
+++ b/Mathlib/LinearAlgebra/Dimension/Constructions.lean
@@ -63,14 +63,12 @@ theorem LinearIndepOn.union_of_quotient {s t : Set ι} {f : ι → M} (hs : Line
   · simp
   aesop
 
--- TODO : change the statement to use `MkQ`, and the proof to use `LinearIndepOn.union_of_quotient`.
 theorem LinearIndepOn.union_id_of_quotient {M' : Submodule R M}
     {s : Set M} (hs : s ⊆ M') (hs' : LinearIndepOn R id s) {t : Set M}
-    (ht : LinearIndepOn R (Submodule.Quotient.mk (p := M')) t) : LinearIndepOn R id (s ∪ t) :=
-  have h := (LinearIndependent.sumElim_of_quotient (f := Set.embeddingOfSubset s M' hs)
-    (LinearIndependent.of_comp M'.subtype (by simpa using hs')) Subtype.val ht)
-  h.linearIndepOn_id' <| by
-    simp only [embeddingOfSubset_apply_coe, Sum.elim_range, Subtype.range_val]
+    (ht : LinearIndepOn R (mkQ M') t) : LinearIndepOn R id (s ∪ t) :=
+  hs'.union_of_quotient <| by
+    rw [image_id]
+    exact ht.of_comp ((span R s).mapQ M' (LinearMap.id) (span_le.2 hs))
 
 @[deprecated (since := "2025-02-16")] alias LinearIndependent.union_of_quotient :=
   LinearIndepOn.union_id_of_quotient

--- a/Mathlib/LinearAlgebra/Dimension/Constructions.lean
+++ b/Mathlib/LinearAlgebra/Dimension/Constructions.lean
@@ -56,7 +56,15 @@ theorem LinearIndependent.sumElim_of_quotient
 @[deprecated (since := "2025-02-21")]
 alias LinearIndependent.sum_elim_of_quotient := LinearIndependent.sumElim_of_quotient
 
-theorem LinearIndepOn.union_of_quotient {M' : Submodule R M}
+theorem LinearIndepOn.union_of_quotient {s t : Set ι} {f : ι → M} (hs : LinearIndepOn R f s)
+    (ht : LinearIndepOn R (mkQ (span R (f '' s)) ∘ f) t) : LinearIndepOn R f (s ∪ t) := by
+  apply hs.union ht.of_comp
+  convert (Submodule.range_ker_disjoint ht).symm
+  · simp
+  aesop
+
+-- TODO : change the statement to use `MkQ`, and the proof to use `LinearIndepOn.union_of_quotient`.
+theorem LinearIndepOn.union_id_of_quotient {M' : Submodule R M}
     {s : Set M} (hs : s ⊆ M') (hs' : LinearIndepOn R id s) {t : Set M}
     (ht : LinearIndepOn R (Submodule.Quotient.mk (p := M')) t) : LinearIndepOn R id (s ∪ t) :=
   have h := (LinearIndependent.sumElim_of_quotient (f := Set.embeddingOfSubset s M' hs)
@@ -65,7 +73,20 @@ theorem LinearIndepOn.union_of_quotient {M' : Submodule R M}
     simp only [embeddingOfSubset_apply_coe, Sum.elim_range, Subtype.range_val]
 
 @[deprecated (since := "2025-02-16")] alias LinearIndependent.union_of_quotient :=
-  LinearIndepOn.union_of_quotient
+  LinearIndepOn.union_id_of_quotient
+
+theorem linearIndepOn_union_iff_quotient {s t : Set ι} {f : ι → M} (hst : Disjoint s t) :
+    LinearIndepOn R f (s ∪ t) ↔
+    LinearIndepOn R f s ∧ LinearIndepOn R (mkQ (span R (f '' s)) ∘ f) t := by
+  refine ⟨fun h ↦ ⟨?_, ?_⟩, fun h ↦ h.1.union_of_quotient h.2⟩
+  · exact h.mono subset_union_left
+  apply (h.mono subset_union_right).map
+  simpa [← image_eq_range] using ((linearIndepOn_union_iff hst).1 h).2.2.symm
+
+theorem LinearIndepOn.quotient_iff_union {s t : Set ι} {f : ι → M} (hs : LinearIndepOn R f s)
+    (hst : Disjoint s t) :
+    LinearIndepOn R (mkQ (span R (f '' s)) ∘ f) t ↔ LinearIndepOn R f (s ∪ t) := by
+  rw [linearIndepOn_union_iff_quotient hst, and_iff_right hs]
 
 theorem rank_quotient_add_rank_le [Nontrivial R] (M' : Submodule R M) :
     Module.rank R (M ⧸ M') + Module.rank R M' ≤ Module.rank R M := by

--- a/Mathlib/LinearAlgebra/Dimension/RankNullity.lean
+++ b/Mathlib/LinearAlgebra/Dimension/RankNullity.lean
@@ -104,7 +104,7 @@ theorem exists_linearIndepOn_of_lt_rank [StrongRankCondition R]
   · rw [Cardinal.mk_union_of_disjoint hst, Cardinal.mk_image_eq, ht,
       ← rank_quotient_add_rank (Submodule.span R s), add_comm, rank_span_set hs]
     exact HasLeftInverse.injective ⟨Submodule.Quotient.mk, hsec⟩
-  · apply LinearIndepOn.union_of_quotient Submodule.subset_span hs
+  · apply LinearIndepOn.union_id_of_quotient Submodule.subset_span hs
     rwa [linearIndepOn_iff_image (hsec'.symm ▸ injective_id).injOn.image_of_comp,
       ← image_comp, hsec', image_id]
 

--- a/Mathlib/LinearAlgebra/Dimension/RankNullity.lean
+++ b/Mathlib/LinearAlgebra/Dimension/RankNullity.lean
@@ -92,13 +92,13 @@ theorem exists_linearIndepOn_of_lt_rank [StrongRankCondition R]
     {s : Set M} (hs : LinearIndepOn R id s) :
     ∃ t, s ⊆ t ∧ #t = Module.rank R M ∧ LinearIndepOn R id t := by
   obtain ⟨t, ht, ht'⟩ := exists_set_linearIndependent R (M ⧸ Submodule.span R s)
-  choose sec hsec using Submodule.Quotient.mk_surjective (Submodule.span R s)
-  have hsec' : Submodule.Quotient.mk ∘ sec = _root_.id := funext hsec
+  choose sec hsec using Submodule.mkQ_surjective (Submodule.span R s)
+  have hsec' : (Submodule.mkQ _) ∘ sec = _root_.id := funext hsec
   have hst : Disjoint s (sec '' t) := by
     rw [Set.disjoint_iff]
     rintro _ ⟨hxs, ⟨x, hxt, rfl⟩⟩
     apply ht'.ne_zero ⟨x, hxt⟩
-    rw [Subtype.coe_mk, ← hsec x, Submodule.Quotient.mk_eq_zero]
+    rw [Subtype.coe_mk, ← hsec x,mkQ_apply, Quotient.mk_eq_zero]
     exact Submodule.subset_span hxs
   refine ⟨s ∪ sec '' t, subset_union_left, ?_, ?_⟩
   · rw [Cardinal.mk_union_of_disjoint hst, Cardinal.mk_image_eq, ht,

--- a/Mathlib/LinearAlgebra/LinearIndependent/Basic.lean
+++ b/Mathlib/LinearAlgebra/LinearIndependent/Basic.lean
@@ -151,6 +151,21 @@ theorem LinearIndepOn.id_image (hs : LinearIndepOn R v s) : LinearIndepOn R id (
 @[deprecated (since := "2025-02-14")] alias
   LinearIndependent.image := LinearIndepOn.id_image
 
+theorem LinearIndepOn_iff_linearIndepOn_image_injOn [Nontrivial R] :
+    LinearIndepOn R v s ↔ LinearIndepOn R id (v '' s) ∧ InjOn v s :=
+  ⟨fun h ↦ ⟨h.id_image, h.injOn⟩, fun h ↦ (linearIndepOn_iff_image h.2).2 h.1⟩
+
+theorem linearIndepOn_congr {w : ι → M} (h : EqOn v w s) :
+    LinearIndepOn R v s ↔ LinearIndepOn R w s := by
+  rw [LinearIndepOn, LinearIndepOn]
+  convert Iff.rfl using 2
+  ext x
+  exact h.symm x.2
+
+theorem LinearIndepOn.congr {w : ι → M} (hli : LinearIndepOn R v s) (h : EqOn v w s) :
+    LinearIndepOn R w s :=
+  (linearIndepOn_congr h).1 hli
+
 theorem LinearIndependent.group_smul {G : Type*} [hG : Group G] [DistribMulAction G R]
     [DistribMulAction G M] [IsScalarTower G R M] [SMulCommClass G R M] {v : ι → M}
     (hv : LinearIndependent R v) (w : ι → G) : LinearIndependent R (w • v) := by
@@ -455,14 +470,28 @@ theorem LinearIndependent.sum_type {v' : ι' → M} (hv : LinearIndependent R v)
     LinearIndependent R (Sum.elim v v') :=
   linearIndependent_sum.2 ⟨hv, hv', h⟩
 
--- TODO - generalize this to non-identity functions
-theorem LinearIndepOn.id_union {s t : Set M} (hs : LinearIndepOn R id s)
-    (ht : LinearIndepOn R id t) (hst : Disjoint (span R s) (span R t)) :
-    LinearIndepOn R id (s ∪ t) := by
-  have h := hs.linearIndependent.sum_type ht.linearIndependent (by simpa)
-  simpa [id_eq] using h.linearIndepOn_id
+theorem LinearIndepOn.union [Nontrivial R] {t : Set ι} (hs : LinearIndepOn R v s)
+    (ht : LinearIndepOn R v t) (hdj : Disjoint (span R (v '' s)) (span R (v '' t))) :
+    LinearIndepOn R v (s ∪ t) := by
+  classical
+  have hli := LinearIndependent.sum_type hs ht (by rwa [← image_eq_range, ← image_eq_range])
+  have hdj := (Submodule.disjoint_of_disjoint_span₀ hdj hs.zero_not_mem_image).of_image
+  rw [LinearIndepOn]
+  convert (hli.comp _ (Equiv.Set.union hdj).injective) with ⟨x, hx | hx⟩
+  · rw [comp_apply, Equiv.Set.union_apply_left _ hx, Sum.elim_inl]
+  rw [comp_apply, Equiv.Set.union_apply_right _ hx, Sum.elim_inr]
 
-@[deprecated (since := "2025-02-14")] alias LinearIndependent.union := LinearIndepOn.id_union
+theorem linearIndepOn_union_iff [Nontrivial R] {t : Set ι} (hdj : Disjoint s t) :
+    LinearIndepOn R v (s ∪ t) ↔
+    LinearIndepOn R v s ∧ LinearIndepOn R v t ∧ Disjoint (span R (v '' s)) (span R (v '' t)) := by
+  refine ⟨fun h ↦ ⟨h.mono subset_union_left, h.mono subset_union_right, ?_⟩,
+    fun h ↦ h.1.union h.2.1 h.2.2⟩
+  convert h.disjoint_span_image (s := (↑) ⁻¹' s) (t := (↑) ⁻¹' t) (hdj.preimage _) <;>
+  aesop
+
+@[deprecated (since := "2025-02-14")] alias LinearIndependent.union := LinearIndepOn.union
+
+@[deprecated (since := "2025-02-27")] alias LinearIndepOn.id_union := LinearIndepOn.union
 
 open LinearMap
 
@@ -585,8 +614,12 @@ theorem linearIndependent_unique_iff (v : ι → M) [Unique ι] :
 
 alias ⟨_, linearIndependent_unique⟩ := linearIndependent_unique_iff
 
-theorem LinearIndepOn.singleton {v : ι → M} {i : ι} (hi : v i ≠ 0) : LinearIndepOn R v {i} :=
-  linearIndependent_unique _ hi
+variable (R) in
+@[simp]
+theorem linearIndepOn_singleton_iff  {i : ι} {v : ι → M} : LinearIndepOn R v {i} ↔ v i ≠ 0 :=
+  ⟨fun h ↦ h.ne_zero rfl, fun h ↦ linearIndependent_unique _ h⟩
+
+alias ⟨_, LinearIndepOn.singleton⟩ := linearIndepOn_singleton_iff
 
 variable (R) in
 theorem LinearIndepOn.id_singleton {x : M} (hx : x ≠ 0) : LinearIndepOn R id {x} :=

--- a/Mathlib/LinearAlgebra/LinearIndependent/Basic.lean
+++ b/Mathlib/LinearAlgebra/LinearIndependent/Basic.lean
@@ -470,9 +470,9 @@ theorem LinearIndependent.sum_type {v' : ι' → M} (hv : LinearIndependent R v)
     LinearIndependent R (Sum.elim v v') :=
   linearIndependent_sum.2 ⟨hv, hv', h⟩
 
-theorem LinearIndepOn.union [Nontrivial R] {t : Set ι} (hs : LinearIndepOn R v s)
-    (ht : LinearIndepOn R v t) (hdj : Disjoint (span R (v '' s)) (span R (v '' t))) :
-    LinearIndepOn R v (s ∪ t) := by
+theorem LinearIndepOn.union {t : Set ι} (hs : LinearIndepOn R v s) (ht : LinearIndepOn R v t)
+    (hdj : Disjoint (span R (v '' s)) (span R (v '' t))) : LinearIndepOn R v (s ∪ t) := by
+  nontriviality R
   classical
   have hli := LinearIndependent.sum_type hs ht (by rwa [← image_eq_range, ← image_eq_range])
   have hdj := (Submodule.disjoint_of_disjoint_span₀ hdj hs.zero_not_mem_image).of_image
@@ -481,7 +481,11 @@ theorem LinearIndepOn.union [Nontrivial R] {t : Set ι} (hs : LinearIndepOn R v 
   · rw [comp_apply, Equiv.Set.union_apply_left _ hx, Sum.elim_inl]
   rw [comp_apply, Equiv.Set.union_apply_right _ hx, Sum.elim_inr]
 
-theorem linearIndepOn_union_iff [Nontrivial R] {t : Set ι} (hdj : Disjoint s t) :
+theorem LinearIndepOn.id_union {s t : Set M} (hs : LinearIndepOn R id s) (ht : LinearIndepOn R id t)
+    (hdj : Disjoint (span R s) (span R t)) : LinearIndepOn R id (s ∪ t) :=
+  hs.union ht (by simpa)
+
+theorem linearIndepOn_union_iff {t : Set ι} (hdj : Disjoint s t) :
     LinearIndepOn R v (s ∪ t) ↔
     LinearIndepOn R v s ∧ LinearIndepOn R v t ∧ Disjoint (span R (v '' s)) (span R (v '' t)) := by
   refine ⟨fun h ↦ ⟨h.mono subset_union_left, h.mono subset_union_right, ?_⟩,
@@ -489,9 +493,12 @@ theorem linearIndepOn_union_iff [Nontrivial R] {t : Set ι} (hdj : Disjoint s t)
   convert h.disjoint_span_image (s := (↑) ⁻¹' s) (t := (↑) ⁻¹' t) (hdj.preimage _) <;>
   aesop
 
-@[deprecated (since := "2025-02-14")] alias LinearIndependent.union := LinearIndepOn.union
+theorem linearIndepOn_id_union_iff {s t : Set M} (hdj : Disjoint s t) :
+    LinearIndepOn R id (s ∪ t) ↔
+    LinearIndepOn R id s ∧ LinearIndepOn R id t ∧ Disjoint (span R s) (span R t) := by
+  rw [linearIndepOn_union_iff hdj, image_id, image_id]
 
-@[deprecated (since := "2025-02-27")] alias LinearIndepOn.id_union := LinearIndepOn.union
+@[deprecated (since := "2025-02-14")] alias LinearIndependent.union := LinearIndepOn.union
 
 open LinearMap
 
@@ -616,7 +623,7 @@ alias ⟨_, linearIndependent_unique⟩ := linearIndependent_unique_iff
 
 variable (R) in
 @[simp]
-theorem linearIndepOn_singleton_iff  {i : ι} {v : ι → M} : LinearIndepOn R v {i} ↔ v i ≠ 0 :=
+theorem linearIndepOn_singleton_iff {i : ι} {v : ι → M} : LinearIndepOn R v {i} ↔ v i ≠ 0 :=
   ⟨fun h ↦ h.ne_zero rfl, fun h ↦ linearIndependent_unique _ h⟩
 
 alias ⟨_, LinearIndepOn.singleton⟩ := linearIndepOn_singleton_iff

--- a/Mathlib/LinearAlgebra/LinearIndependent/Basic.lean
+++ b/Mathlib/LinearAlgebra/LinearIndependent/Basic.lean
@@ -475,7 +475,7 @@ theorem LinearIndepOn.union {t : Set ι} (hs : LinearIndepOn R v s) (ht : Linear
   nontriviality R
   classical
   have hli := LinearIndependent.sum_type hs ht (by rwa [← image_eq_range, ← image_eq_range])
-  have hdj := (Submodule.disjoint_of_disjoint_span₀ hdj hs.zero_not_mem_image).of_image
+  have hdj := (hdj.of_span₀ hs.zero_not_mem_image).of_image
   rw [LinearIndepOn]
   convert (hli.comp _ (Equiv.Set.union hdj).injective) with ⟨x, hx | hx⟩
   · rw [comp_apply, Equiv.Set.union_apply_left _ hx, Sum.elim_inl]

--- a/Mathlib/LinearAlgebra/LinearIndependent/Defs.lean
+++ b/Mathlib/LinearAlgebra/LinearIndependent/Defs.lean
@@ -141,6 +141,11 @@ theorem LinearIndepOn.ne_zero [Nontrivial R] {i : ι} (hv : LinearIndepOn R v s)
     v i ≠ 0 :=
   LinearIndependent.ne_zero ⟨i, hi⟩ hv
 
+theorem LinearIndepOn.zero_not_mem_image [Nontrivial R] (hs : LinearIndepOn R v s) : 0 ∉ v '' s :=
+  fun ⟨_, hi, h0⟩ ↦ hs.ne_zero hi h0
+
+-- done
+
 theorem linearIndependent_empty_type [IsEmpty ι] : LinearIndependent R v :=
   injective_of_subsingleton _
 
@@ -148,6 +153,10 @@ theorem linearIndependent_empty_type [IsEmpty ι] : LinearIndependent R v :=
 theorem linearIndependent_zero_iff [Nontrivial R] : LinearIndependent R (0 : ι → M) ↔ IsEmpty ι :=
   ⟨fun h ↦ not_nonempty_iff.1 fun ⟨i⟩ ↦ (h.ne_zero i rfl).elim,
     fun _ ↦ linearIndependent_empty_type⟩
+
+@[simp]
+theorem linearIndepOn_zero_iff [Nontrivial R] : LinearIndepOn R (0 : ι → M) s ↔ s = ∅ :=
+  linearIndependent_zero_iff.trans isEmpty_coe_sort
 
 variable (R M) in
 theorem linearIndependent_empty : LinearIndependent R (fun x => x : (∅ : Set M) → M) :=

--- a/Mathlib/LinearAlgebra/LinearIndependent/Defs.lean
+++ b/Mathlib/LinearAlgebra/LinearIndependent/Defs.lean
@@ -144,8 +144,6 @@ theorem LinearIndepOn.ne_zero [Nontrivial R] {i : ι} (hv : LinearIndepOn R v s)
 theorem LinearIndepOn.zero_not_mem_image [Nontrivial R] (hs : LinearIndepOn R v s) : 0 ∉ v '' s :=
   fun ⟨_, hi, h0⟩ ↦ hs.ne_zero hi h0
 
--- done
-
 theorem linearIndependent_empty_type [IsEmpty ι] : LinearIndependent R v :=
   injective_of_subsingleton _
 

--- a/Mathlib/LinearAlgebra/LinearIndependent/Lemmas.lean
+++ b/Mathlib/LinearAlgebra/LinearIndependent/Lemmas.lean
@@ -458,6 +458,35 @@ theorem linearIndepOn_id_insert (hxs : x ∉ s) :
 
 @[deprecated (since := "2025-02-15")] alias linearIndependent_insert := linearIndepOn_insert
 
+theorem linearIndepOn_insert_iff {s : Set ι} {a : ι} {f : ι → V} :
+    LinearIndepOn K f (insert a s) ↔ LinearIndepOn K f s ∧ (f a ∈ span K (f '' s) → a ∈ s) := by
+  by_cases has : a ∈ s
+  · simp [insert_eq_of_mem has, has]
+  simp [linearIndepOn_insert has, has]
+
+theorem linearIndepOn_id_insert_iff {a : V} {s : Set V} :
+    LinearIndepOn K id (insert a s) ↔ LinearIndepOn K id s ∧ (a ∈ span K s → a ∈ s) := by
+  simpa using linearIndepOn_insert_iff (a := a) (f := id)
+
+theorem LinearIndepOn.mem_span_iff {s : Set ι} {a : ι} {f : ι → V} (h : LinearIndepOn K f s) :
+    f a ∈ Submodule.span K (f '' s) ↔ (LinearIndepOn K f (insert a s) → a ∈ s) := by
+  by_cases has : a ∈ s
+  · exact iff_of_true (subset_span <| mem_image_of_mem f has) fun _ ↦ has
+  simp [linearIndepOn_insert_iff, h, has]
+
+/-- A shortcut to a convenient form for the negation in `LinearIndepOn.mem_span_iff`. -/
+theorem LinearIndepOn.not_mem_span_iff {s : Set ι} {a : ι} {f : ι → V} (h : LinearIndepOn K f s) :
+    f a ∉ Submodule.span K (f '' s) ↔ LinearIndepOn K f (insert a s) ∧ a ∉ s := by
+  rw [h.mem_span_iff, _root_.not_imp]
+
+theorem LinearIndepOn.mem_span_iff_id {s : Set V} {a : V} (h : LinearIndepOn K id s) :
+    a ∈ Submodule.span K s ↔ (LinearIndepOn K id (insert a s) → a ∈ s) := by
+  simpa using h.mem_span_iff (a := a)
+
+theorem LinearIndepOn.not_mem_span_iff_id {s : Set V} {a : V} (h : LinearIndepOn K id s) :
+    a ∉ Submodule.span K s ↔ LinearIndepOn K id (insert a s) ∧ a ∉ s := by
+  rw [h.mem_span_iff_id, _root_.not_imp]
+
 theorem linearIndepOn_id_pair {x y : V} (hx : x ≠ 0) (hy : ∀ a : K, a • x ≠ y) :
     LinearIndepOn K id {x, y} :=
   pair_comm y x ▸ (LinearIndepOn.id_singleton K hx).insert (x := y) <|

--- a/Mathlib/LinearAlgebra/LinearIndependent/Lemmas.lean
+++ b/Mathlib/LinearAlgebra/LinearIndependent/Lemmas.lean
@@ -415,7 +415,7 @@ protected theorem LinearIndepOn.insert (hs : LinearIndepOn K id s) (hx : x ∉ s
     LinearIndepOn K id (insert x s) := by
   rw [← union_singleton]
   have x0 : x ≠ 0 := mt (by rintro rfl; apply zero_mem (span K s)) hx
-  apply hs.id_union (LinearIndepOn.singleton x0)
+  apply hs.id_union (LinearIndepOn.id_singleton _ x0)
   rwa [disjoint_span_singleton' x0]
 
 @[deprecated (since := "2025-02-15")] alias LinearIndependent.insert := LinearIndepOn.insert
@@ -493,6 +493,12 @@ theorem linearIndepOn_id_pair {x y : V} (hx : x ≠ 0) (hy : ∀ a : K, a • x 
     mt mem_span_singleton.1 <| not_exists.2 hy
 
 @[deprecated (since := "2025-02-15")] alias linearIndependent_pair := linearIndepOn_id_pair
+
+theorem linearIndepOn_pair_iff {i j : ι} (v : ι → V) (hij : i ≠ j) (hi : v i ≠ 0):
+    LinearIndepOn K v {i, j} ↔ ∀ (c : K), c • v i ≠ v j := by
+  rw [pair_comm]
+  convert linearIndepOn_insert (s := {i}) (a := j) hij.symm
+  simp [hi, mem_span_singleton, linearIndependent_unique_iff]
 
 /-- Also see `LinearIndependent.pair_iff` for the version over arbitrary rings. -/
 theorem LinearIndependent.pair_iff' {x y : V} (hx : x ≠ 0) :

--- a/Mathlib/LinearAlgebra/Span/Basic.lean
+++ b/Mathlib/LinearAlgebra/Span/Basic.lean
@@ -393,6 +393,17 @@ lemma _root_.LinearMap.BilinMap.apply_apply_mem_of_mem_span {R M N P : Type*} [C
   | smul_left t u v hu hv huv => simpa using Submodule.smul_mem _ _ huv
   | smul_right t u v hu hv huv => simpa using Submodule.smul_mem _ _ huv
 
+theorem disjoint_of_disjoint_span (hst : Disjoint (span R s) (span R t)) :
+    Disjoint (s \ {0}) t := by
+  rw [disjoint_iff_forall_ne]
+  rintro v ⟨hvs, hv0 : v ≠ 0⟩ _ hvt rfl
+  exact hv0 <| (disjoint_def.1 hst) v (subset_span hvs) (subset_span hvt)
+
+theorem disjoint_of_disjoint_span₀ (hst : Disjoint (span R s) (span R t)) (h0s : 0 ∉ s) :
+    Disjoint s t := by
+  rw [← diff_singleton_eq_self h0s]
+  exact disjoint_of_disjoint_span hst
+
 end AddCommMonoid
 
 section AddCommGroup

--- a/Mathlib/LinearAlgebra/Span/Basic.lean
+++ b/Mathlib/LinearAlgebra/Span/Basic.lean
@@ -393,17 +393,6 @@ lemma _root_.LinearMap.BilinMap.apply_apply_mem_of_mem_span {R M N P : Type*} [C
   | smul_left t u v hu hv huv => simpa using Submodule.smul_mem _ _ huv
   | smul_right t u v hu hv huv => simpa using Submodule.smul_mem _ _ huv
 
-theorem disjoint_of_disjoint_span (hst : Disjoint (span R s) (span R t)) :
-    Disjoint (s \ {0}) t := by
-  rw [disjoint_iff_forall_ne]
-  rintro v ⟨hvs, hv0 : v ≠ 0⟩ _ hvt rfl
-  exact hv0 <| (disjoint_def.1 hst) v (subset_span hvs) (subset_span hvt)
-
-theorem disjoint_of_disjoint_span₀ (hst : Disjoint (span R s) (span R t)) (h0s : 0 ∉ s) :
-    Disjoint s t := by
-  rw [← diff_singleton_eq_self h0s]
-  exact disjoint_of_disjoint_span hst
-
 end AddCommMonoid
 
 section AddCommGroup

--- a/Mathlib/LinearAlgebra/Span/Defs.lean
+++ b/Mathlib/LinearAlgebra/Span/Defs.lean
@@ -228,16 +228,16 @@ theorem span_int_eq_addSubgroup_closure {M : Type*} [AddCommGroup M] (s : Set M)
 theorem span_int_eq {M : Type*} [AddCommGroup M] (s : AddSubgroup M) :
     (span ℤ (s : Set M)).toAddSubgroup = s := by rw [span_int_eq_addSubgroup_closure, s.closure_eq]
 
-theorem disjoint_of_disjoint_span (hst : Disjoint (span R s) (span R t)) :
+theorem _root_.Disjoint.of_span (hst : Disjoint (span R s) (span R t)) :
     Disjoint (s \ {0}) t := by
   rw [disjoint_iff_forall_ne]
   rintro v ⟨hvs, hv0 : v ≠ 0⟩ _ hvt rfl
   exact hv0 <| (disjoint_def.1 hst) v (subset_span hvs) (subset_span hvt)
 
-theorem disjoint_of_disjoint_span₀ (hst : Disjoint (span R s) (span R t)) (h0s : 0 ∉ s) :
+theorem _root_.Disjoint.of_span₀ (hst : Disjoint (span R s) (span R t)) (h0s : 0 ∉ s) :
     Disjoint s t := by
   rw [← diff_singleton_eq_self h0s]
-  exact disjoint_of_disjoint_span hst
+  exact hst.of_span
 
 section
 

--- a/Mathlib/LinearAlgebra/Span/Defs.lean
+++ b/Mathlib/LinearAlgebra/Span/Defs.lean
@@ -228,6 +228,17 @@ theorem span_int_eq_addSubgroup_closure {M : Type*} [AddCommGroup M] (s : Set M)
 theorem span_int_eq {M : Type*} [AddCommGroup M] (s : AddSubgroup M) :
     (span ℤ (s : Set M)).toAddSubgroup = s := by rw [span_int_eq_addSubgroup_closure, s.closure_eq]
 
+theorem disjoint_of_disjoint_span (hst : Disjoint (span R s) (span R t)) :
+    Disjoint (s \ {0}) t := by
+  rw [disjoint_iff_forall_ne]
+  rintro v ⟨hvs, hv0 : v ≠ 0⟩ _ hvt rfl
+  exact hv0 <| (disjoint_def.1 hst) v (subset_span hvs) (subset_span hvt)
+
+theorem disjoint_of_disjoint_span₀ (hst : Disjoint (span R s) (span R t)) (h0s : 0 ∉ s) :
+    Disjoint s t := by
+  rw [← diff_singleton_eq_self h0s]
+  exact disjoint_of_disjoint_span hst
+
 section
 
 variable (R M)


### PR DESCRIPTION
We add a few more API lemmas for `linearIndepOn`, in many cases generalizing `id` versions of existing lemmas to arbitrary functions. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
