### PR TITLE
[Merged by Bors] - feat: congruence theorems for interval/circle integrals

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4103,6 +4103,7 @@ import Mathlib.MeasureTheory.OuterMeasure.Operations
 import Mathlib.MeasureTheory.PiSystem
 import Mathlib.MeasureTheory.SetAlgebra
 import Mathlib.MeasureTheory.SetSemiring
+import Mathlib.MeasureTheory.Topology
 import Mathlib.MeasureTheory.VectorMeasure.Basic
 import Mathlib.MeasureTheory.VectorMeasure.WithDensity
 import Mathlib.ModelTheory.Algebra.Field.Basic

--- a/Mathlib/MeasureTheory/Integral/CircleIntegral.lean
+++ b/Mathlib/MeasureTheory/Integral/CircleIntegral.lean
@@ -203,7 +203,7 @@ theorem continuous_circleMap_inv {R : ℝ} {z w : ℂ} (hw : w ∈ ball z R) :
   exact Continuous.inv₀ (by fun_prop) this
 
 theorem circleMap_preimage_codiscrete {c : ℂ} {R : ℝ} (hR : R ≠ 0) :
-    map (circleMap c R) (codiscrete ℝ) ≤ (codiscreteWithin (Metric.sphere c |R|)) := by
+    map (circleMap c R) (codiscrete ℝ) ≤ codiscreteWithin (Metric.sphere c |R|) := by
   intro s hs
   apply analyticOnNhd_circleMap.preimage_mem_codiscreteWithin
   · intro x hx

--- a/Mathlib/MeasureTheory/Integral/CircleIntegral.lean
+++ b/Mathlib/MeasureTheory/Integral/CircleIntegral.lean
@@ -362,7 +362,7 @@ theorem integral_congr {f g : ℂ → E} {c : ℂ} {R : ℝ} (hR : 0 ≤ R) (h :
 theorem circleIntegral_congr_codiscreteWithin {c : ℂ} {R : ℝ} {f₁ f₂ : ℂ → ℂ}
     (hf : f₁ =ᶠ[codiscreteWithin (Metric.sphere c |R|)] f₂) (hR : R ≠ 0) :
     (∮ z in C(c, R), f₁ z) = (∮ z in C(c, R), f₂ z) := by
-  apply intervalIntegral.integral_congr_ae_restict
+  apply intervalIntegral.integral_congr_ae_restrict
   apply ae_of_restrVol_le_codiscreteWithin measurableSet_uIoc
   simp only [deriv_circleMap, smul_eq_mul, mul_eq_mul_left_iff, mul_eq_zero,
     circleMap_eq_center_iff, hR, Complex.I_ne_zero, or_self, or_false]

--- a/Mathlib/MeasureTheory/Integral/CircleIntegral.lean
+++ b/Mathlib/MeasureTheory/Integral/CircleIntegral.lean
@@ -161,7 +161,6 @@ for multiplication in a normed algebra over the base field. -/
 theorem differentiable_circleMap (c : ℂ) (R : ℝ) : Differentiable ℝ (circleMap c R) := fun θ =>
   (hasDerivAt_circleMap c R θ).differentiableAt
 
-open Complex in
 /-- The circleMap is real analytic. -/
 theorem analyticOnNhd_circleMap {c : ℂ} {R : ℝ} :
     AnalyticOnNhd ℝ (circleMap c R) Set.univ := by
@@ -363,7 +362,7 @@ theorem circleIntegral_congr_codiscreteWithin {c : ℂ} {R : ℝ} {f₁ f₂ : �
     (hf : f₁ =ᶠ[codiscreteWithin (Metric.sphere c |R|)] f₂) (hR : R ≠ 0) :
     (∮ z in C(c, R), f₁ z) = (∮ z in C(c, R), f₂ z) := by
   apply intervalIntegral.integral_congr_ae_restrict
-  apply ae_of_restrVol_le_codiscreteWithin measurableSet_uIoc
+  apply ae_restrict_le_codiscreteWithin measurableSet_uIoc
   simp only [deriv_circleMap, smul_eq_mul, mul_eq_mul_left_iff, mul_eq_zero,
     circleMap_eq_center_iff, hR, Complex.I_ne_zero, or_self, or_false]
   exact codiscreteWithin.mono (by tauto) (circleMap_preimage_codiscrete hR hf)

--- a/Mathlib/MeasureTheory/Integral/CircleIntegral.lean
+++ b/Mathlib/MeasureTheory/Integral/CircleIntegral.lean
@@ -160,7 +160,7 @@ theorem differentiable_circleMap (c : ℂ) (R : ℝ) : Differentiable ℝ (circl
   (hasDerivAt_circleMap c R θ).differentiableAt
 
 /-- The circleMap is real analytic. -/
-theorem analyticOnNhd_circleMap {c : ℂ} {R : ℝ} :
+theorem analyticOnNhd_circleMap (c : ℂ) (R : ℝ) :
     AnalyticOnNhd ℝ (circleMap c R) Set.univ := by
   intro z hz
   apply analyticAt_const.add
@@ -171,7 +171,7 @@ theorem analyticOnNhd_circleMap {c : ℂ} {R : ℝ} :
 /-- The circleMap is continuously differentiable. -/
 theorem contDiff_circleMap (c : ℂ) (R : ℝ) {n : WithTop ℕ∞} :
     ContDiff ℝ n (circleMap c R) :=
-  (analyticOnNhd_circleMap).contDiff
+  (analyticOnNhd_circleMap c R).contDiff
 
 @[continuity, fun_prop]
 theorem continuous_circleMap (c : ℂ) (R : ℝ) : Continuous (circleMap c R) :=
@@ -207,7 +207,7 @@ theorem continuous_circleMap_inv {R : ℝ} {z w : ℂ} (hw : w ∈ ball z R) :
 theorem circleMap_preimage_codiscrete {c : ℂ} {R : ℝ} (hR : R ≠ 0) :
     map (circleMap c R) (codiscrete ℝ) ≤ codiscreteWithin (Metric.sphere c |R|) := by
   intro s hs
-  apply analyticOnNhd_circleMap.preimage_mem_codiscreteWithin
+  apply (analyticOnNhd_circleMap c R).preimage_mem_codiscreteWithin
   · intro x hx
     by_contra hCon
     obtain ⟨a, ha⟩ := eventuallyConst_iff_exists_eventuallyEq.1 hCon

--- a/Mathlib/MeasureTheory/Integral/CircleIntegral.lean
+++ b/Mathlib/MeasureTheory/Integral/CircleIntegral.lean
@@ -261,7 +261,7 @@ theorem circleIntegrable_zero_radius {f : ℂ → E} {c : ℂ} : CircleIntegrabl
   simp [CircleIntegrable]
 
 /-- Circle integrability is invariant when functions change along discrete sets. -/
-theorem CircleIntegrable.congr_of_codiscreteWithin {c : ℂ} {R : ℝ} {f₁ f₂ : ℂ → ℂ}
+theorem CircleIntegrable.congr_codiscreteWithin {c : ℂ} {R : ℝ} {f₁ f₂ : ℂ → ℂ}
     (hf : f₁ =ᶠ[codiscreteWithin (Metric.sphere c |R|)] f₂) (hf₁ : CircleIntegrable f₁ c R) :
     CircleIntegrable f₂ c R := by
   by_cases hR : R = 0

--- a/Mathlib/MeasureTheory/Integral/CircleIntegral.lean
+++ b/Mathlib/MeasureTheory/Integral/CircleIntegral.lean
@@ -275,8 +275,8 @@ theorem CircleIntegrable.congr_codiscreteWithin {c : ℂ} {R : ℝ} {f₁ f₂ :
 theorem circleIntegrable_congr_codiscreteWithin {c : ℂ} {R : ℝ} {f₁ f₂ : ℂ → ℂ}
     (hf : f₁ =ᶠ[codiscreteWithin (Metric.sphere c |R|)] f₂) :
     CircleIntegrable f₁ c R ↔ CircleIntegrable f₂ c R :=
-  ⟨(CircleIntegrable.congr_of_codiscreteWithin hf ·),
-    (CircleIntegrable.congr_of_codiscreteWithin hf.symm ·)⟩
+  ⟨(CircleIntegrable.congr_codiscreteWithin hf ·),
+    (CircleIntegrable.congr_codiscreteWithin hf.symm ·)⟩
 
 theorem circleIntegrable_iff [NormedSpace ℂ E] {f : ℂ → E} {c : ℂ} (R : ℝ) :
     CircleIntegrable f c R ↔ IntervalIntegrable (fun θ : ℝ =>

--- a/Mathlib/MeasureTheory/Integral/CircleIntegral.lean
+++ b/Mathlib/MeasureTheory/Integral/CircleIntegral.lean
@@ -261,7 +261,7 @@ theorem circleIntegrable_zero_radius {f : ℂ → E} {c : ℂ} : CircleIntegrabl
   simp [CircleIntegrable]
 
 /-- Circle integrability is invariant when functions change along discrete sets. -/
-theorem circleIntegrable_congr_codiscreteWithin {c : ℂ} {R : ℝ} {f₁ f₂ : ℂ → ℂ}
+theorem CircleIntegrable.congr_of_codiscreteWithin {c : ℂ} {R : ℝ} {f₁ f₂ : ℂ → ℂ}
     (hf : f₁ =ᶠ[codiscreteWithin (Metric.sphere c |R|)] f₂) :
     CircleIntegrable f₁ c R → CircleIntegrable f₂ c R := by
   by_cases hR : R = 0
@@ -271,6 +271,13 @@ theorem circleIntegrable_congr_codiscreteWithin {c : ℂ} {R : ℝ} {f₁ f₂ :
   rw [eventuallyEq_iff_exists_mem]
   use (circleMap c R)⁻¹' {z | f₁ z = f₂ z}, codiscreteWithin.mono
     (by simp only [Set.subset_univ]) (circleMap_preimage_codiscrete hR hf), (by tauto)
+
+/-- Circle integrability is invariant when functions change along discrete sets. -/
+theorem circleIntegrable_congr_of_codiscreteWithin {c : ℂ} {R : ℝ} {f₁ f₂ : ℂ → ℂ}
+    (hf : f₁ =ᶠ[codiscreteWithin (Metric.sphere c |R|)] f₂) :
+    CircleIntegrable f₁ c R ↔ CircleIntegrable f₂ c R :=
+  ⟨(CircleIntegrable.congr_of_codiscreteWithin hf ·),
+    (CircleIntegrable.congr_of_codiscreteWithin hf.symm ·)⟩
 
 theorem circleIntegrable_iff [NormedSpace ℂ E] {f : ℂ → E} {c : ℂ} (R : ℝ) :
     CircleIntegrable f c R ↔ IntervalIntegrable (fun θ : ℝ =>

--- a/Mathlib/MeasureTheory/Integral/CircleIntegral.lean
+++ b/Mathlib/MeasureTheory/Integral/CircleIntegral.lean
@@ -156,8 +156,6 @@ theorem hasDerivAt_circleMap (c : ℂ) (R : ℝ) (θ : ℝ) :
   simpa only [mul_assoc, one_mul, ofRealCLM_apply, circleMap, ofReal_one, zero_add]
     using (((ofRealCLM.hasDerivAt (x := θ)).mul_const I).cexp.const_mul (R : ℂ)).const_add c
 
-/- TODO: prove `ContDiff ℝ (circleMap c R)`. This needs a version of `ContDiff.mul`
-for multiplication in a normed algebra over the base field. -/
 theorem differentiable_circleMap (c : ℂ) (R : ℝ) : Differentiable ℝ (circleMap c R) := fun θ =>
   (hasDerivAt_circleMap c R θ).differentiableAt
 
@@ -169,6 +167,11 @@ theorem analyticOnNhd_circleMap {c : ℂ} {R : ℝ} :
   apply analyticAt_const.mul
   rw [(by rfl : (fun θ ↦ exp (θ * I) : ℝ → ℂ) = cexp ∘ (fun θ : ℝ ↦ (θ * I)))]
   apply analyticAt_cexp.restrictScalars.comp ((ofRealCLM.analyticAt z).mul (by fun_prop))
+
+/-- The circleMap is continuously differentiable. -/
+theorem contDiff_circleMap (c : ℂ) (R : ℝ) {n : WithTop ℕ∞} :
+    ContDiff ℝ n (circleMap c R) :=
+  (analyticOnNhd_circleMap).contDiff
 
 @[continuity, fun_prop]
 theorem continuous_circleMap (c : ℂ) (R : ℝ) : Continuous (circleMap c R) :=

--- a/Mathlib/MeasureTheory/Integral/CircleIntegral.lean
+++ b/Mathlib/MeasureTheory/Integral/CircleIntegral.lean
@@ -262,12 +262,11 @@ theorem circleIntegrable_zero_radius {f : ℂ → E} {c : ℂ} : CircleIntegrabl
 
 /-- Circle integrability is invariant when functions change along discrete sets. -/
 theorem CircleIntegrable.congr_of_codiscreteWithin {c : ℂ} {R : ℝ} {f₁ f₂ : ℂ → ℂ}
-    (hf : f₁ =ᶠ[codiscreteWithin (Metric.sphere c |R|)] f₂) :
-    CircleIntegrable f₁ c R → CircleIntegrable f₂ c R := by
+    (hf : f₁ =ᶠ[codiscreteWithin (Metric.sphere c |R|)] f₂) (hf₁ : CircleIntegrable f₁ c R) :
+    CircleIntegrable f₂ c R := by
   by_cases hR : R = 0
-  · rw [hR]
-    simp
-  apply (intervalIntegrable_congr_codiscreteWithin _).1
+  · simp [hR]
+  apply (intervalIntegrable_congr_codiscreteWithin _).1 hf₁
   rw [eventuallyEq_iff_exists_mem]
   use (circleMap c R)⁻¹' {z | f₁ z = f₂ z}, codiscreteWithin.mono
     (by simp only [Set.subset_univ]) (circleMap_preimage_codiscrete hR hf), (by tauto)

--- a/Mathlib/MeasureTheory/Integral/CircleIntegral.lean
+++ b/Mathlib/MeasureTheory/Integral/CircleIntegral.lean
@@ -358,6 +358,16 @@ theorem integral_congr {f g : ℂ → E} {c : ℂ} {R : ℝ} (hR : 0 ≤ R) (h :
     (∮ z in C(c, R), f z) = ∮ z in C(c, R), g z :=
   intervalIntegral.integral_congr fun θ _ => by simp only [h (circleMap_mem_sphere _ hR _)]
 
+/-- Circle integrals are invariant when functions change along discrete sets. -/
+theorem circleIntegral_congr_codiscreteWithin {c : ℂ} {R : ℝ} {f₁ f₂ : ℂ → ℂ}
+    (hf : f₁ =ᶠ[codiscreteWithin (Metric.sphere c |R|)] f₂) (hR : R ≠ 0) :
+    (∮ z in C(c, R), f₁ z) = (∮ z in C(c, R), f₂ z) := by
+  apply intervalIntegral.integral_congr_ae_restict
+  apply ae_of_restrVol_le_codiscreteWithin measurableSet_uIoc
+  simp only [deriv_circleMap, smul_eq_mul, mul_eq_mul_left_iff, mul_eq_zero,
+    circleMap_eq_center_iff, hR, Complex.I_ne_zero, or_self, or_false]
+  exact codiscreteWithin.mono (by tauto) (circleMap_preimage_codiscrete hR hf)
+
 theorem integral_sub_inv_smul_sub_smul (f : ℂ → E) (c w : ℂ) (R : ℝ) :
     (∮ z in C(c, R), (z - w)⁻¹ • (z - w) • f z) = ∮ z in C(c, R), f z := by
   rcases eq_or_ne R 0 with (rfl | hR); · simp only [integral_radius_zero]

--- a/Mathlib/MeasureTheory/Integral/CircleIntegral.lean
+++ b/Mathlib/MeasureTheory/Integral/CircleIntegral.lean
@@ -272,7 +272,7 @@ theorem CircleIntegrable.congr_codiscreteWithin {c : ℂ} {R : ℝ} {f₁ f₂ :
     (by simp only [Set.subset_univ]) (circleMap_preimage_codiscrete hR hf), (by tauto)
 
 /-- Circle integrability is invariant when functions change along discrete sets. -/
-theorem circleIntegrable_congr_of_codiscreteWithin {c : ℂ} {R : ℝ} {f₁ f₂ : ℂ → ℂ}
+theorem circleIntegrable_congr_codiscreteWithin {c : ℂ} {R : ℝ} {f₁ f₂ : ℂ → ℂ}
     (hf : f₁ =ᶠ[codiscreteWithin (Metric.sphere c |R|)] f₂) :
     CircleIntegrable f₁ c R ↔ CircleIntegrable f₂ c R :=
   ⟨(CircleIntegrable.congr_of_codiscreteWithin hf ·),

--- a/Mathlib/MeasureTheory/Integral/IntervalIntegral.lean
+++ b/Mathlib/MeasureTheory/Integral/IntervalIntegral.lean
@@ -6,6 +6,7 @@ Authors: Yury Kudryashov, Patrick Massot, Sébastien Gouëzel
 import Mathlib.Order.Interval.Set.Disjoint
 import Mathlib.MeasureTheory.Integral.SetIntegral
 import Mathlib.MeasureTheory.Measure.Lebesgue.Basic
+import Mathlib.MeasureTheory.Topology
 import Mathlib.Algebra.EuclideanDomain.Basic
 
 /-!
@@ -89,6 +90,23 @@ theorem IntervalIntegrable.congr {g : ℝ → E} (hf : IntervalIntegrable f μ a
     (h : f =ᵐ[μ.restrict (Ι a b)] g) :
     IntervalIntegrable g μ a b := by
   rwa [intervalIntegrable_iff, ← integrableOn_congr_fun_ae h, ← intervalIntegrable_iff]
+
+/-- Interval integrability is invariant when functions change along discrete sets. -/
+theorem intervalIntegrable_congr_codiscreteWithin {g : ℝ → E}
+    (h : f =ᶠ[codiscreteWithin (Ι a b)] g) :
+    IntervalIntegrable f volume a b ↔ IntervalIntegrable g volume a b := by
+  constructor
+  · intro hf
+    apply hf.congr
+    rw [eventuallyEq_iff_exists_mem] at *
+    obtain ⟨s, h₁s, h₂s⟩ := h
+    use s, ae_of_restrVol_le_codiscreteWithin measurableSet_Ioc h₁s, h₂s
+  · rw [eventuallyEq_comm] at h
+    intro hg
+    apply hg.congr
+    rw [eventuallyEq_iff_exists_mem] at *
+    obtain ⟨s, h₁s, h₂s⟩ := h
+    use s, ae_of_restrVol_le_codiscreteWithin measurableSet_Ioc h₁s, h₂s
 
 theorem intervalIntegrable_iff_integrableOn_Ioc_of_le (hab : a ≤ b) :
     IntervalIntegrable f μ a b ↔ IntegrableOn f (Ioc a b) μ := by

--- a/Mathlib/MeasureTheory/Integral/IntervalIntegral.lean
+++ b/Mathlib/MeasureTheory/Integral/IntervalIntegral.lean
@@ -6,6 +6,7 @@ Authors: Yury Kudryashov, Patrick Massot, Sébastien Gouëzel
 import Mathlib.Order.Interval.Set.Disjoint
 import Mathlib.MeasureTheory.Integral.SetIntegral
 import Mathlib.MeasureTheory.Measure.Lebesgue.Basic
+import Mathlib.MeasureTheory.Measure.Restrict
 import Mathlib.MeasureTheory.Topology
 import Mathlib.Algebra.EuclideanDomain.Basic
 
@@ -874,6 +875,19 @@ theorem integral_congr {a b : ℝ} (h : EqOn f g [[a, b]]) :
   rcases le_total a b with hab | hab <;>
     simpa [hab, integral_of_le, integral_of_ge] using
       setIntegral_congr_fun measurableSet_Ioc (h.mono Ioc_subset_Icc_self)
+
+/-- Integrals are invariant when functions change along sets that are almost
+everywhere for the restricted measure. -/
+theorem integral_congr_ae_restict {a b : ℝ} {f g : ℝ → E} {μ : Measure ℝ}
+    [NormedAddCommGroup E] [NormedSpace ℝ E] (h : f =ᵐ[μ.restrict (Ι a b)] g) :
+    ∫ x in a..b, f x ∂μ = ∫ x in a..b, g x ∂μ :=
+  integral_congr_ae (ae_imp_of_ae_restrict h)
+
+/-- Integrals are invariant when functions change along discrete sets. -/
+theorem integral_congr_codiscreteWithin {a b : ℝ} {f₁ f₂ : ℝ → ℝ}
+    (hf : f₁ =ᶠ[codiscreteWithin (Ι a b)] f₂) :
+    ∫ (x : ℝ) in a..b, f₁ x = ∫ (x : ℝ) in a..b, f₂ x :=
+  integral_congr_ae_restict (ae_of_restrVol_le_codiscreteWithin measurableSet_uIoc hf)
 
 theorem integral_add_adjacent_intervals_cancel (hab : IntervalIntegrable f μ a b)
     (hbc : IntervalIntegrable f μ b c) :

--- a/Mathlib/MeasureTheory/Integral/IntervalIntegral.lean
+++ b/Mathlib/MeasureTheory/Integral/IntervalIntegral.lean
@@ -984,8 +984,7 @@ theorem integral_congr_ae (h : ∀ᵐ x ∂μ, x ∈ Ι a b → f x = g x) :
     ∫ x in a..b, f x ∂μ = ∫ x in a..b, g x ∂μ :=
   integral_congr_ae' (ae_uIoc_iff.mp h).1 (ae_uIoc_iff.mp h).2
 
-/-- Integrals are invariant when functions change along sets that are almost
-everywhere for the restricted measure. -/
+/-- Integrals are equal for functions that agree almost everywhere for the restricted measure. -/
 theorem integral_congr_ae_restrict {a b : ℝ} {f g : ℝ → E} {μ : Measure ℝ}
     (h : f =ᵐ[μ.restrict (Ι a b)] g) :
     ∫ x in a..b, f x ∂μ = ∫ x in a..b, g x ∂μ :=
@@ -995,7 +994,7 @@ theorem integral_congr_ae_restrict {a b : ℝ} {f g : ℝ → E} {μ : Measure �
 theorem integral_congr_codiscreteWithin {a b : ℝ} {f₁ f₂ : ℝ → ℝ}
     (hf : f₁ =ᶠ[codiscreteWithin (Ι a b)] f₂) :
     ∫ (x : ℝ) in a..b, f₁ x = ∫ (x : ℝ) in a..b, f₂ x :=
-  integral_congr_ae_restict (ae_of_restrVol_le_codiscreteWithin measurableSet_uIoc hf)
+  integral_congr_ae_restrict (ae_of_restrVol_le_codiscreteWithin measurableSet_uIoc hf)
 
 theorem integral_zero_ae (h : ∀ᵐ x ∂μ, x ∈ Ι a b → f x = 0) : ∫ x in a..b, f x ∂μ = 0 :=
   calc

--- a/Mathlib/MeasureTheory/Integral/IntervalIntegral.lean
+++ b/Mathlib/MeasureTheory/Integral/IntervalIntegral.lean
@@ -986,7 +986,7 @@ theorem integral_congr_ae (h : ∀ᵐ x ∂μ, x ∈ Ι a b → f x = g x) :
 
 /-- Integrals are invariant when functions change along sets that are almost
 everywhere for the restricted measure. -/
-theorem integral_congr_ae_restict {a b : ℝ} {f g : ℝ → E} {μ : Measure ℝ}
+theorem integral_congr_ae_restrict {a b : ℝ} {f g : ℝ → E} {μ : Measure ℝ}
     (h : f =ᵐ[μ.restrict (Ι a b)] g) :
     ∫ x in a..b, f x ∂μ = ∫ x in a..b, g x ∂μ :=
   integral_congr_ae (ae_imp_of_ae_restrict h)

--- a/Mathlib/MeasureTheory/Integral/IntervalIntegral.lean
+++ b/Mathlib/MeasureTheory/Integral/IntervalIntegral.lean
@@ -93,21 +93,17 @@ theorem IntervalIntegrable.congr {g : ℝ → E} (hf : IntervalIntegrable f μ a
   rwa [intervalIntegrable_iff, ← integrableOn_congr_fun_ae h, ← intervalIntegrable_iff]
 
 /-- Interval integrability is invariant when functions change along discrete sets. -/
-theorem intervalIntegrable_congr_codiscreteWithin {g : ℝ → E}
+theorem IntervalIntegrable.congr_codiscreteWithin {g : ℝ → E} [NoAtoms μ]
+    (h : f =ᶠ[codiscreteWithin (Ι a b)] g) (hf : IntervalIntegrable f μ a b) :
+    IntervalIntegrable g μ a b :=
+  hf.congr (ae_restrict_le_codiscreteWithin measurableSet_Ioc h)
+
+/-- Interval integrability is invariant when functions change along discrete sets. -/
+theorem intervalIntegrable_congr_codiscreteWithin {g : ℝ → E} [NoAtoms μ]
     (h : f =ᶠ[codiscreteWithin (Ι a b)] g) :
-    IntervalIntegrable f volume a b ↔ IntervalIntegrable g volume a b := by
-  constructor
-  · intro hf
-    apply hf.congr
-    rw [eventuallyEq_iff_exists_mem] at *
-    obtain ⟨s, h₁s, h₂s⟩ := h
-    use s, ae_restrict_le_codiscreteWithin measurableSet_Ioc h₁s, h₂s
-  · rw [eventuallyEq_comm] at h
-    intro hg
-    apply hg.congr
-    rw [eventuallyEq_iff_exists_mem] at *
-    obtain ⟨s, h₁s, h₂s⟩ := h
-    use s, ae_restrict_le_codiscreteWithin measurableSet_Ioc h₁s, h₂s
+    IntervalIntegrable f μ a b ↔ IntervalIntegrable g μ a b :=
+  ⟨(IntervalIntegrable.congr_codiscreteWithin h ·),
+    (IntervalIntegrable.congr_codiscreteWithin h.symm ·)⟩
 
 theorem intervalIntegrable_iff_integrableOn_Ioc_of_le (hab : a ≤ b) :
     IntervalIntegrable f μ a b ↔ IntegrableOn f (Ioc a b) μ := by

--- a/Mathlib/MeasureTheory/Integral/IntervalIntegral.lean
+++ b/Mathlib/MeasureTheory/Integral/IntervalIntegral.lean
@@ -876,19 +876,6 @@ theorem integral_congr {a b : ℝ} (h : EqOn f g [[a, b]]) :
     simpa [hab, integral_of_le, integral_of_ge] using
       setIntegral_congr_fun measurableSet_Ioc (h.mono Ioc_subset_Icc_self)
 
-/-- Integrals are invariant when functions change along sets that are almost
-everywhere for the restricted measure. -/
-theorem integral_congr_ae_restict {a b : ℝ} {f g : ℝ → E} {μ : Measure ℝ}
-    [NormedAddCommGroup E] [NormedSpace ℝ E] (h : f =ᵐ[μ.restrict (Ι a b)] g) :
-    ∫ x in a..b, f x ∂μ = ∫ x in a..b, g x ∂μ :=
-  integral_congr_ae (ae_imp_of_ae_restrict h)
-
-/-- Integrals are invariant when functions change along discrete sets. -/
-theorem integral_congr_codiscreteWithin {a b : ℝ} {f₁ f₂ : ℝ → ℝ}
-    (hf : f₁ =ᶠ[codiscreteWithin (Ι a b)] f₂) :
-    ∫ (x : ℝ) in a..b, f₁ x = ∫ (x : ℝ) in a..b, f₂ x :=
-  integral_congr_ae_restict (ae_of_restrVol_le_codiscreteWithin measurableSet_uIoc hf)
-
 theorem integral_add_adjacent_intervals_cancel (hab : IntervalIntegrable f μ a b)
     (hbc : IntervalIntegrable f μ b c) :
     (((∫ x in a..b, f x ∂μ) + ∫ x in b..c, f x ∂μ) + ∫ x in c..a, f x ∂μ) = 0 := by
@@ -996,6 +983,19 @@ theorem integral_congr_ae' (h : ∀ᵐ x ∂μ, x ∈ Ioc a b → f x = g x)
 theorem integral_congr_ae (h : ∀ᵐ x ∂μ, x ∈ Ι a b → f x = g x) :
     ∫ x in a..b, f x ∂μ = ∫ x in a..b, g x ∂μ :=
   integral_congr_ae' (ae_uIoc_iff.mp h).1 (ae_uIoc_iff.mp h).2
+
+/-- Integrals are invariant when functions change along sets that are almost
+everywhere for the restricted measure. -/
+theorem integral_congr_ae_restict {a b : ℝ} {f g : ℝ → E} {μ : Measure ℝ}
+    (h : f =ᵐ[μ.restrict (Ι a b)] g) :
+    ∫ x in a..b, f x ∂μ = ∫ x in a..b, g x ∂μ :=
+  integral_congr_ae (ae_imp_of_ae_restrict h)
+
+/-- Integrals are invariant when functions change along discrete sets. -/
+theorem integral_congr_codiscreteWithin {a b : ℝ} {f₁ f₂ : ℝ → ℝ}
+    (hf : f₁ =ᶠ[codiscreteWithin (Ι a b)] f₂) :
+    ∫ (x : ℝ) in a..b, f₁ x = ∫ (x : ℝ) in a..b, f₂ x :=
+  integral_congr_ae_restict (ae_of_restrVol_le_codiscreteWithin measurableSet_uIoc hf)
 
 theorem integral_zero_ae (h : ∀ᵐ x ∂μ, x ∈ Ι a b → f x = 0) : ∫ x in a..b, f x ∂μ = 0 :=
   calc

--- a/Mathlib/MeasureTheory/Integral/IntervalIntegral.lean
+++ b/Mathlib/MeasureTheory/Integral/IntervalIntegral.lean
@@ -101,13 +101,13 @@ theorem intervalIntegrable_congr_codiscreteWithin {g : ℝ → E}
     apply hf.congr
     rw [eventuallyEq_iff_exists_mem] at *
     obtain ⟨s, h₁s, h₂s⟩ := h
-    use s, ae_of_restrVol_le_codiscreteWithin measurableSet_Ioc h₁s, h₂s
+    use s, ae_restrict_le_codiscreteWithin measurableSet_Ioc h₁s, h₂s
   · rw [eventuallyEq_comm] at h
     intro hg
     apply hg.congr
     rw [eventuallyEq_iff_exists_mem] at *
     obtain ⟨s, h₁s, h₂s⟩ := h
-    use s, ae_of_restrVol_le_codiscreteWithin measurableSet_Ioc h₁s, h₂s
+    use s, ae_restrict_le_codiscreteWithin measurableSet_Ioc h₁s, h₂s
 
 theorem intervalIntegrable_iff_integrableOn_Ioc_of_le (hab : a ≤ b) :
     IntervalIntegrable f μ a b ↔ IntegrableOn f (Ioc a b) μ := by
@@ -994,7 +994,7 @@ theorem integral_congr_ae_restrict {a b : ℝ} {f g : ℝ → E} {μ : Measure �
 theorem integral_congr_codiscreteWithin {a b : ℝ} {f₁ f₂ : ℝ → ℝ}
     (hf : f₁ =ᶠ[codiscreteWithin (Ι a b)] f₂) :
     ∫ (x : ℝ) in a..b, f₁ x = ∫ (x : ℝ) in a..b, f₂ x :=
-  integral_congr_ae_restrict (ae_of_restrVol_le_codiscreteWithin measurableSet_uIoc hf)
+  integral_congr_ae_restrict (ae_restrict_le_codiscreteWithin measurableSet_uIoc hf)
 
 theorem integral_zero_ae (h : ∀ᵐ x ∂μ, x ∈ Ι a b → f x = 0) : ∫ x in a..b, f x ∂μ = 0 :=
   calc

--- a/Mathlib/MeasureTheory/Topology.lean
+++ b/Mathlib/MeasureTheory/Topology.lean
@@ -1,0 +1,27 @@
+/-
+Copyright (c) 2025 Stefan Kebekus. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Stefan Kebekus
+-/
+import Mathlib.Topology.DiscreteSubset
+import Mathlib.MeasureTheory.Measure.Typeclasses
+
+/-!
+# Theorems combining measure theory and topology
+
+This file gathers theorems that combine measure theory and topology, and cannot easily be added to
+the existing files without introducing massive dependencies between the subjects.
+-/
+open Filter MeasureTheory
+
+/-- Under reasonable assumptions, sets that are codiscrete within `U` are almost
+everywhere with respect to the restricted measure. -/
+theorem ae_of_restrVol_le_codiscreteWithin
+    {α : Type*} [MeasureSpace α] [TopologicalSpace α] [SecondCountableTopology α]
+    {μ : Measure α} [NoAtoms μ] {U : Set α} (hU : MeasurableSet U) :
+    ae (μ.restrict U) ≤ codiscreteWithin U := by
+  intro s hs
+  have := discreteTopology_of_codiscreteWithin hs
+  rw [mem_ae_iff, Measure.restrict_apply' hU]
+  apply Set.Countable.measure_zero (TopologicalSpace.separableSpace_iff_countable.1
+    TopologicalSpace.SecondCountableTopology.to_separableSpace)

--- a/Mathlib/MeasureTheory/Topology.lean
+++ b/Mathlib/MeasureTheory/Topology.lean
@@ -16,7 +16,7 @@ open Filter MeasureTheory
 
 /-- Under reasonable assumptions, sets that are codiscrete within `U` are contained in the “almost
 everywhere” filter of co-null sets. -/
-theorem ae_of_restrVol_le_codiscreteWithin
+theorem ae_restrict_le_codiscreteWithin
     {α : Type*} [MeasureSpace α] [TopologicalSpace α] [SecondCountableTopology α]
     {μ : Measure α} [NoAtoms μ] {U : Set α} (hU : MeasurableSet U) :
     ae (μ.restrict U) ≤ codiscreteWithin U := by

--- a/Mathlib/MeasureTheory/Topology.lean
+++ b/Mathlib/MeasureTheory/Topology.lean
@@ -14,8 +14,8 @@ the existing files without introducing massive dependencies between the subjects
 -/
 open Filter MeasureTheory
 
-/-- Under reasonable assumptions, sets that are codiscrete within `U` are almost
-everywhere with respect to the restricted measure. -/
+/-- Under reasonable assumptions, sets that are codiscrete within `U` are contained in the “almost
+everywhere” filter of co-null sets. -/
 theorem ae_of_restrVol_le_codiscreteWithin
     {α : Type*} [MeasureSpace α] [TopologicalSpace α] [SecondCountableTopology α]
     {μ : Measure α} [NoAtoms μ] {U : Set α} (hU : MeasurableSet U) :

--- a/Mathlib/MeasureTheory/Topology.lean
+++ b/Mathlib/MeasureTheory/Topology.lean
@@ -17,7 +17,7 @@ open Filter MeasureTheory
 /-- Under reasonable assumptions, sets that are codiscrete within `U` are contained in the “almost
 everywhere” filter of co-null sets. -/
 theorem ae_restrict_le_codiscreteWithin
-    {α : Type*} [MeasureSpace α] [TopologicalSpace α] [SecondCountableTopology α]
+    {α : Type*} [MeasurableSpace α] [TopologicalSpace α] [SecondCountableTopology α]
     {μ : Measure α} [NoAtoms μ] {U : Set α} (hU : MeasurableSet U) :
     ae (μ.restrict U) ≤ codiscreteWithin U := by
   intro s hs

--- a/Mathlib/Topology/DiscreteSubset.lean
+++ b/Mathlib/Topology/DiscreteSubset.lean
@@ -123,10 +123,7 @@ lemma Filter.codiscreteWithin.mono {U₁ U : Set X} (hU : U₁ ⊆ U) :
   exact diff_subset_diff_left hU
 
 /-- If `s` is codiscrete within `U`, then `sᶜ ∩ U` has discrete topology. -/
-theorem discreteTopology_of_codiscreteWithin
-    {X : Type u_1} [TopologicalSpace X]
-    {U s : Set X}
-    (h : s ∈ Filter.codiscreteWithin U) :
+theorem discreteTopology_of_codiscreteWithin {U s : Set X} (h : s ∈ Filter.codiscreteWithin U) :
     DiscreteTopology ((sᶜ ∩ U) : Set X) := by
   rw [(by simp : ((sᶜ ∩ U) : Set X) = ((s ∪ Uᶜ)ᶜ : Set X)), discreteTopology_subtype_iff]
   simp_rw [mem_codiscreteWithin, Filter.disjoint_principal_right] at h

--- a/Mathlib/Topology/DiscreteSubset.lean
+++ b/Mathlib/Topology/DiscreteSubset.lean
@@ -126,7 +126,7 @@ lemma Filter.codiscreteWithin.mono {U₁ U : Set X} (hU : U₁ ⊆ U) :
 theorem discreteTopology_of_codiscreteWithin
     {X : Type u_1} [TopologicalSpace X]
     {U s : Set X}
-    (h: s ∈ Filter.codiscreteWithin U) :
+    (h : s ∈ Filter.codiscreteWithin U) :
   DiscreteTopology ((sᶜ ∩ U) : Set X) := by
   rw [(by simp : ((sᶜ ∩ U) : Set X) = ((s ∪ Uᶜ)ᶜ : Set X)), discreteTopology_subtype_iff]
   simp_rw [mem_codiscreteWithin, Filter.disjoint_principal_right] at h

--- a/Mathlib/Topology/DiscreteSubset.lean
+++ b/Mathlib/Topology/DiscreteSubset.lean
@@ -122,6 +122,18 @@ lemma Filter.codiscreteWithin.mono {U₁ U : Set X} (hU : U₁ ⊆ U) :
   rw [Set.compl_subset_compl]
   exact diff_subset_diff_left hU
 
+/-- If `s` is codiscrete within `U`, then `sᶜ ∩ U` has discrete topology. -/
+theorem discreteTopology_of_codiscreteWithin
+    {X : Type u_1} [TopologicalSpace X]
+    {U s : Set X}
+    (h: s ∈ Filter.codiscreteWithin U) :
+  DiscreteTopology ((sᶜ ∩ U) : Set X) := by
+  rw [(by simp : ((sᶜ ∩ U) : Set X) = ((s ∪ Uᶜ)ᶜ : Set X)), discreteTopology_subtype_iff]
+  simp_rw [mem_codiscreteWithin, Filter.disjoint_principal_right] at h
+  intro x hx
+  rw [← Filter.mem_iff_inf_principal_compl, ← Set.compl_diff]
+  simp_all only [h x, Set.compl_union, compl_compl, Set.mem_inter_iff, Set.mem_compl_iff]
+
 /-- In any topological space, the open sets with discrete complement form a filter,
 defined as the supremum of all punctured neighborhoods.
 

--- a/Mathlib/Topology/DiscreteSubset.lean
+++ b/Mathlib/Topology/DiscreteSubset.lean
@@ -127,7 +127,7 @@ theorem discreteTopology_of_codiscreteWithin
     {X : Type u_1} [TopologicalSpace X]
     {U s : Set X}
     (h : s ∈ Filter.codiscreteWithin U) :
-  DiscreteTopology ((sᶜ ∩ U) : Set X) := by
+    DiscreteTopology ((sᶜ ∩ U) : Set X) := by
   rw [(by simp : ((sᶜ ∩ U) : Set X) = ((s ∪ Uᶜ)ᶜ : Set X)), discreteTopology_subtype_iff]
   simp_rw [mem_codiscreteWithin, Filter.disjoint_principal_right] at h
   intro x hx


### PR DESCRIPTION
Prove that integrals are invariant when functions are changed along a discrete set.

This material is used in [Project VD](https://github.com/kebekus/ProjectVD), which aims to formalize Value Distribution Theory for meromorphic functions on the complex plane.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
