### PR TITLE
[Merged by Bors] - chore(AlgebraicGeometry/EllipticCurve/Affine): standardise variable names

### DIFF
--- a/Mathlib/AlgebraicGeometry/EllipticCurve/Affine.lean
+++ b/Mathlib/AlgebraicGeometry/EllipticCurve/Affine.lean
@@ -273,30 +273,19 @@ lemma nonsingular_iff_variableChange (x y : R) :
   simp only [variableChange]
   congr! 3 <;> ring1
 
-lemma equation_zero_iff_nonsingular_zero_of_Δ_ne_zero (hΔ : W'.Δ ≠ 0) :
-    W'.Equation 0 0 ↔ W'.Nonsingular 0 0 := by
-  simp only [equation_zero, nonsingular_zero, iff_self_and]
+lemma nonsingular_zero_of_Δ_ne_zero (h : W'.Equation 0 0) (hΔ : W'.Δ ≠ 0) :
+    W'.Nonsingular 0 0 := by
+  simp only [equation_zero, nonsingular_zero] at *
   contrapose! hΔ
-  simp only [b₂, b₄, b₆, b₈, Δ, hΔ]
+  simp only [b₂, b₄, b₆, b₈, Δ, h, hΔ]
   ring1
 
 /-- A Weierstrass curve is nonsingular at every point if its discriminant is non-zero. -/
-lemma equation_iff_nonsingular_of_Δ_ne_zero {x y : R} (hΔ : W'.Δ ≠ 0) :
-    W'.Equation x y ↔ W'.Nonsingular x y := by
-  rw [equation_iff_variableChange, nonsingular_iff_variableChange,
-    equation_zero_iff_nonsingular_zero_of_Δ_ne_zero <| by
-      rwa [variableChange_Δ, inv_one, Units.val_one, one_pow, one_mul]]
-
-/-- An elliptic curve is nonsingular at every point. -/
-lemma equation_iff_nonsingular [Nontrivial R] [W'.IsElliptic] {x y : R} :
-    W'.toAffine.Equation x y ↔ W'.toAffine.Nonsingular x y :=
-  W'.toAffine.equation_iff_nonsingular_of_Δ_ne_zero <| W'.coe_Δ' ▸ W'.Δ'.ne_zero
-
-@[deprecated (since := "2025-02-01")] alias nonsingular_zero_of_Δ_ne_zero :=
-  equation_zero_iff_nonsingular_zero_of_Δ_ne_zero
-@[deprecated (since := "2025-02-01")] alias nonsingular_of_Δ_ne_zero :=
-  equation_iff_nonsingular_of_Δ_ne_zero
-@[deprecated (since := "2025-02-01")] alias nonsingular := equation_iff_nonsingular
+lemma nonsingular_of_Δ_ne_zero {x y : R} (h : W'.Equation x y) (hΔ : W'.Δ ≠ 0) :
+    W'.Nonsingular x y :=
+  (nonsingular_iff_variableChange x y).mpr <|
+    nonsingular_zero_of_Δ_ne_zero ((equation_iff_variableChange x y).mp h) <| by
+      rwa [variableChange_Δ, inv_one, Units.val_one, one_pow, one_mul]
 
 end Nonsingular
 
@@ -343,23 +332,29 @@ lemma Y_eq_of_Y_ne {x₁ x₂ y₁ y₂ : F} (h₁ : W.Equation x₁ y₁) (h₂
     (hy : y₁ ≠ W.negY x₂ y₂) : y₁ = y₂ :=
   (Y_eq_of_X_eq h₁ h₂ hx).resolve_right hy
 
-/-- The negation of an affine point in `W` lies in `W`. -/
-lemma equation_neg (x y : R) : W'.Equation x (W'.negY x y) ↔ W'.Equation x y := by
+lemma equation_neg_iff (x y : R) : W'.Equation x (W'.negY x y) ↔ W'.Equation x y := by
   rw [equation_iff, equation_iff, negY]
   congr! 1
   ring1
 
-@[deprecated (since := "2025-02-01")] alias equation_neg_of := equation_neg
-@[deprecated (since := "2025-02-01")] alias equation_neg_iff := equation_neg
+lemma equation_neg_of {x y : R} (h : W'.Equation x <| W'.negY x y) : W'.Equation x y :=
+  (W'.equation_neg_iff ..).mp h
 
-/-- The negation of a nonsingular affine point in `W` is nonsingular. -/
-lemma nonsingular_neg (x y : R) : W'.Nonsingular x (W'.negY x y) ↔ W'.Nonsingular x y := by
-  rw [nonsingular_iff, equation_neg, ← negY, negY_negY, ← @ne_comm _ y, nonsingular_iff]
+/-- The negation of an affine point in `W` lies in `W`. -/
+lemma equation_neg {x y : R} (h : W'.Equation x y) : W'.Equation x <| W'.negY x y :=
+  (W'.equation_neg_iff ..).mpr h
+
+lemma nonsingular_neg_iff (x y : R) : W'.Nonsingular x (W'.negY x y) ↔ W'.Nonsingular x y := by
+  rw [nonsingular_iff, equation_neg_iff, ← negY, negY_negY, ← @ne_comm _ y, nonsingular_iff]
   exact and_congr_right' <| (iff_congr not_and_or.symm not_and_or.symm).mpr <|
     not_congr <| and_congr_left fun h => by rw [← h]
 
-@[deprecated (since := "2025-02-01")] alias nonsingular_neg_of := nonsingular_neg
-@[deprecated (since := "2025-02-01")] alias nonsingular_neg_iff := nonsingular_neg
+lemma nonsingular_neg_of {x y : R} (h : W'.Nonsingular x <| W'.negY x y) : W'.Nonsingular x y :=
+  (W'.nonsingular_neg_iff ..).mp h
+
+/-- The negation of a nonsingular affine point in `W` is nonsingular. -/
+lemma nonsingular_neg {x y : R} (h : W'.Nonsingular x y) : W'.Nonsingular x <| W'.negY x y :=
+  (W'.nonsingular_neg_iff ..).mpr h
 
 end Negation
 
@@ -548,7 +543,7 @@ lemma equation_negAdd {x₁ x₂ y₁ y₂ : F} (h₁ : W.Equation x₁ y₁) (h
 lemma equation_add {x₁ x₂ y₁ y₂ : F} (h₁ : W.Equation x₁ y₁) (h₂ : W.Equation x₂ y₂)
     (hxy : ¬(x₁ = x₂ ∧ y₁ = W.negY x₂ y₂)) :
     W.Equation (W.addX x₁ x₂ <| W.slope x₁ x₂ y₁ y₂) (W.addY x₁ x₂ y₁ <| W.slope x₁ x₂ y₁ y₂) :=
-  (equation_neg ..).mpr <| equation_negAdd h₁ h₂ hxy
+  equation_neg <| equation_negAdd h₁ h₂ hxy
 
 /-- The negated addition of two nonsingular affine points in `W` on a sloped line is nonsingular. -/
 lemma nonsingular_negAdd {x₁ x₂ y₁ y₂ : F} (h₁ : W.Nonsingular x₁ y₁) (h₂ : W.Nonsingular x₂ y₂)
@@ -572,7 +567,7 @@ lemma nonsingular_negAdd {x₁ x₂ y₁ y₂ : F} (h₁ : W.Nonsingular x₁ y�
 lemma nonsingular_add {x₁ x₂ y₁ y₂ : F} (h₁ : W.Nonsingular x₁ y₁) (h₂ : W.Nonsingular x₂ y₂)
     (hxy : ¬(x₁ = x₂ ∧ y₁ = W.negY x₂ y₂)) :
     W.Nonsingular (W.addX x₁ x₂ <| W.slope x₁ x₂ y₁ y₂) (W.addY x₁ x₂ y₁ <| W.slope x₁ x₂ y₁ y₂) :=
-  (nonsingular_neg ..).mpr <| nonsingular_negAdd h₁ h₂ hxy
+  nonsingular_neg <| nonsingular_negAdd h₁ h₂ hxy
 
 /-- The formula x(P₁ + P₂) = x(P₁ - P₂) - ψ(P₁)ψ(P₂) / (x(P₂) - x(P₁))²,
 where ψ(x,y) = 2y + a₁x + a₃. -/
@@ -636,12 +631,12 @@ lemma zero_def : 0 = (.zero : W'.Point) :=
 lemma some_ne_zero {x y : R} (h : W'.Nonsingular x y) : Point.some h ≠ 0 := by
   rintro (_ | _)
 
-/-- The negation of a nonsingular point on `W`.
+/-- The negation of a nonsingular rational point on `W`.
 
-Given a nonsingular point `P` on `W`, use `-P` instead of `neg P`. -/
+Given a nonsingular rational point `P` on `W`, use `-P` instead of `neg P`. -/
 def neg : W'.Point → W'.Point
   | 0 => 0
-  | some h => some <| (nonsingular_neg ..).mpr h
+  | some h => some <| nonsingular_neg h
 
 instance : Neg W'.Point :=
   ⟨neg⟩
@@ -654,7 +649,7 @@ lemma neg_zero : (-0 : W'.Point) = 0 :=
   rfl
 
 @[simp]
-lemma neg_some {x y : R} (h : W'.Nonsingular x y) : -some h = some ((nonsingular_neg ..).mpr h) :=
+lemma neg_some {x y : R} (h : W'.Nonsingular x y) : -some h = some (nonsingular_neg h) :=
   rfl
 
 instance : InvolutiveNeg W'.Point where
@@ -673,10 +668,10 @@ noncomputable def add : W.Point → W.Point → W.Point
   | @some _ _ _ x₁ y₁ h₁, @some _ _ _ x₂ y₂ h₂ =>
     if hxy : x₁ = x₂ ∧ y₁ = W.negY x₂ y₂ then 0 else some <| nonsingular_add h₁ h₂ hxy
 
-noncomputable instance : Add W.Point :=
+noncomputable instance instAddPoint : Add W.Point :=
   ⟨add⟩
 
-noncomputable instance : AddZeroClass W.Point :=
+noncomputable instance instAddZeroClassPoint : AddZeroClass W.Point :=
   ⟨by rintro (_ | _) <;> rfl, by rintro (_ | _) <;> rfl⟩
 
 lemma add_def (P Q : W.Point) : P + Q = P.add Q :=
@@ -888,23 +883,25 @@ variable [Algebra R S] [Algebra R F] [Algebra S F] [IsScalarTower R S F] [Algebr
   [IsScalarTower R S K] [Algebra R L] [Algebra S L] [IsScalarTower R S L] (f : F →ₐ[S] K)
   (g : K →ₐ[S] L)
 
+/-- The function from `W⟮F⟯` to `W⟮K⟯` induced by an algebra homomorphism `f : F →ₐ[S] K`,
+where `W` is defined over a subring of a ring `S`, and `F` and `K` are field extensions of `S`. -/
+def mapFun : W'⟮F⟯ → W'⟮K⟯
+  | 0 => 0
+  | some h => some <| (baseChange_nonsingular _ _ f.injective).mpr h
+
 /-- The group homomorphism from `W⟮F⟯` to `W⟮K⟯` induced by an algebra homomorphism `f : F →ₐ[S] K`,
 where `W` is defined over a subring of a ring `S`, and `F` and `K` are field extensions of `S`. -/
 def map : W'⟮F⟯ →+ W'⟮K⟯ where
-  toFun P := match P with
-    | 0 => 0
-    | some h => some <| (baseChange_nonsingular _ _ f.injective).mpr h
+  toFun := mapFun f
   map_zero' := rfl
   map_add' := by
     rintro (_ | @⟨x₁, y₁, _⟩) (_ | @⟨x₂, y₂, _⟩)
     any_goals rfl
     by_cases hxy : x₁ = x₂ ∧ y₁ = (W'.baseChange F).toAffine.negY x₂ y₂
-    · rw [add_of_Y_eq hxy.left hxy.right,
-        add_of_Y_eq (congr_arg _ hxy.left) <| by rw [hxy.right, baseChange_negY]]
-    · simp_rw [add_some hxy, ← baseChange_addX, ← baseChange_addY, ← baseChange_slope]
+    · simp only [add_of_Y_eq hxy.left hxy.right, mapFun]
+      rw [add_of_Y_eq (congr_arg _ hxy.left) <| by rw [hxy.right, baseChange_negY]]
+    · simp only [add_some hxy, mapFun, ← baseChange_addX, ← baseChange_addY, ← baseChange_slope]
       rw [add_some fun h => hxy ⟨f.injective h.1, f.injective (W'.baseChange_negY f .. ▸ h).2⟩]
-
-@[deprecated (since := "2025-02-01")] alias mapFun := map
 
 lemma map_zero : map f (0 : W'⟮F⟯) = 0 :=
   rfl
@@ -939,5 +936,17 @@ lemma map_baseChange [Algebra F K] [IsScalarTower R F K] [Algebra F L] [IsScalar
 end Point
 
 end Affine
+
+/-! ## Elliptic curves -/
+
+section EllipticCurve
+
+variable {R : Type u} [CommRing R] (E : WeierstrassCurve R) [E.IsElliptic]
+
+lemma nonsingular [Nontrivial R] {x y : R} (h : E.toAffine.Equation x y) :
+    E.toAffine.Nonsingular x y :=
+  E.toAffine.nonsingular_of_Δ_ne_zero h <| E.coe_Δ' ▸ E.Δ'.ne_zero
+
+end EllipticCurve
 
 end WeierstrassCurve

--- a/Mathlib/AlgebraicGeometry/EllipticCurve/Affine.lean
+++ b/Mathlib/AlgebraicGeometry/EllipticCurve/Affine.lean
@@ -469,22 +469,21 @@ def addY (x₁ x₂ y₁ ℓ : R) : R :=
   W'.negY (W'.addX x₁ x₂ ℓ) (W'.negAddY x₁ x₂ y₁ ℓ)
 
 lemma addPolynomial_slope {x₁ x₂ y₁ y₂ : F} (h₁ : W.Equation x₁ y₁) (h₂ : W.Equation x₂ y₂)
-    (hxy : ¬(x₁ = x₂ ∧ y₁ = W.negY x₂ y₂)) : W.addPolynomial x₁ y₁ (W.slope x₁ x₂ y₁ y₂) =
+    (hxy : x₁ = x₂ → y₁ ≠ W.negY x₂ y₂) : W.addPolynomial x₁ y₁ (W.slope x₁ x₂ y₁ y₂) =
       -((X - C x₁) * (X - C x₂) * (X - C (W.addX x₁ x₂ <| W.slope x₁ x₂ y₁ y₂))) := by
   rw [addPolynomial_eq, neg_inj, Cubic.prod_X_sub_C_eq, Cubic.toPoly_injective]
   by_cases hx : x₁ = x₂
-  · have hy : y₁ ≠ W.negY x₂ y₂ := fun h => hxy ⟨hx, h⟩
-    rcases hx, Y_eq_of_Y_ne h₁ h₂ hx hy with ⟨rfl, rfl⟩
+  · rcases hx, Y_eq_of_Y_ne h₁ h₂ hx (hxy hx) with ⟨rfl, rfl⟩
     rw [equation_iff] at h₁ h₂
-    rw [slope_of_Y_ne rfl hy]
-    rw [negY, ← sub_ne_zero] at hy
+    rw [slope_of_Y_ne rfl <| hxy rfl]
+    rw [negY, ← sub_ne_zero] at hxy
     ext
     · rfl
     · simp only [addX]
       ring1
-    · field_simp [hy]
+    · field_simp [hxy rfl]
       ring1
-    · linear_combination (norm := (field_simp [hy]; ring1)) -h₁
+    · linear_combination (norm := (field_simp [hxy rfl]; ring1)) -h₁
   · rw [equation_iff] at h₁ h₂
     rw [slope_of_X_ne hx]
     rw [← sub_eq_zero] at hx
@@ -498,13 +497,13 @@ lemma addPolynomial_slope {x₁ x₂ y₁ y₂ : F} (h₁ : W.Equation x₁ y₁
       linear_combination (norm := (field_simp [hx]; ring1)) x₂ * h₁ - x₁ * h₂
 
 lemma C_addPolynomial_slope {x₁ x₂ y₁ y₂ : F} (h₁ : W.Equation x₁ y₁) (h₂ : W.Equation x₂ y₂)
-    (hxy : ¬(x₁ = x₂ ∧ y₁ = W.negY x₂ y₂)) : C (W.addPolynomial x₁ y₁ <| W.slope x₁ x₂ y₁ y₂) =
+    (hxy : x₁ = x₂ → y₁ ≠ W.negY x₂ y₂) : C (W.addPolynomial x₁ y₁ <| W.slope x₁ x₂ y₁ y₂) =
       -(C (X - C x₁) * C (X - C x₂) * C (X - C (W.addX x₁ x₂ <| W.slope x₁ x₂ y₁ y₂))) := by
   rw [addPolynomial_slope h₁ h₂ hxy]
   map_simp
 
 lemma derivative_addPolynomial_slope {x₁ x₂ y₁ y₂ : F} (h₁ : W.Equation x₁ y₁)
-    (h₂ : W.Equation x₂ y₂) (hxy : ¬(x₁ = x₂ ∧ y₁ = W.negY x₂ y₂)) :
+    (h₂ : W.Equation x₂ y₂) (hxy : x₁ = x₂ → y₁ ≠ W.negY x₂ y₂) :
     derivative (W.addPolynomial x₁ y₁ <| W.slope x₁ x₂ y₁ y₂) =
       -((X - C x₁) * (X - C x₂) + (X - C x₁) * (X - C (W.addX x₁ x₂ <| W.slope x₁ x₂ y₁ y₂)) +
           (X - C x₂) * (X - C (W.addX x₁ x₂ <| W.slope x₁ x₂ y₁ y₂))) := by
@@ -533,7 +532,7 @@ lemma equation_add_iff (x₁ x₂ y₁ ℓ : R) : W'.Equation (W'.addX x₁ x₂
 
 /-- The negated addition of two affine points in `W` on a sloped line lies in `W`. -/
 lemma equation_negAdd {x₁ x₂ y₁ y₂ : F} (h₁ : W.Equation x₁ y₁) (h₂ : W.Equation x₂ y₂)
-    (hxy : ¬(x₁ = x₂ ∧ y₁ = W.negY x₂ y₂)) : W.Equation
+    (hxy : x₁ = x₂ → y₁ ≠ W.negY x₂ y₂) : W.Equation
       (W.addX x₁ x₂ <| W.slope x₁ x₂ y₁ y₂) (W.negAddY x₁ x₂ y₁ <| W.slope x₁ x₂ y₁ y₂) := by
   rw [equation_add_iff, addPolynomial_slope h₁ h₂ hxy]
   eval_simp
@@ -541,13 +540,13 @@ lemma equation_negAdd {x₁ x₂ y₁ y₂ : F} (h₁ : W.Equation x₁ y₁) (h
 
 /-- The addition of two affine points in `W` on a sloped line lies in `W`. -/
 lemma equation_add {x₁ x₂ y₁ y₂ : F} (h₁ : W.Equation x₁ y₁) (h₂ : W.Equation x₂ y₂)
-    (hxy : ¬(x₁ = x₂ ∧ y₁ = W.negY x₂ y₂)) :
+    (hxy : x₁ = x₂ → y₁ ≠ W.negY x₂ y₂) :
     W.Equation (W.addX x₁ x₂ <| W.slope x₁ x₂ y₁ y₂) (W.addY x₁ x₂ y₁ <| W.slope x₁ x₂ y₁ y₂) :=
   equation_neg <| equation_negAdd h₁ h₂ hxy
 
 /-- The negated addition of two nonsingular affine points in `W` on a sloped line is nonsingular. -/
 lemma nonsingular_negAdd {x₁ x₂ y₁ y₂ : F} (h₁ : W.Nonsingular x₁ y₁) (h₂ : W.Nonsingular x₂ y₂)
-    (hxy : ¬(x₁ = x₂ ∧ y₁ = W.negY x₂ y₂)) : W.Nonsingular
+    (hxy : x₁ = x₂ → y₁ ≠ W.negY x₂ y₂) : W.Nonsingular
       (W.addX x₁ x₂ <| W.slope x₁ x₂ y₁ y₂) (W.negAddY x₁ x₂ y₁ <| W.slope x₁ x₂ y₁ y₂) := by
   by_cases hx₁ : W.addX x₁ x₂ (W.slope x₁ x₂ y₁ y₂) = x₁
   · rwa [negAddY, hx₁, sub_self, mul_zero, zero_add]
@@ -565,7 +564,7 @@ lemma nonsingular_negAdd {x₁ x₂ y₁ y₂ : F} (h₁ : W.Nonsingular x₁ y�
 
 /-- The addition of two nonsingular affine points in `W` on a sloped line is nonsingular. -/
 lemma nonsingular_add {x₁ x₂ y₁ y₂ : F} (h₁ : W.Nonsingular x₁ y₁) (h₂ : W.Nonsingular x₂ y₂)
-    (hxy : ¬(x₁ = x₂ ∧ y₁ = W.negY x₂ y₂)) :
+    (hxy : x₁ = x₂ → y₁ ≠ W.negY x₂ y₂) :
     W.Nonsingular (W.addX x₁ x₂ <| W.slope x₁ x₂ y₁ y₂) (W.addY x₁ x₂ y₁ <| W.slope x₁ x₂ y₁ y₂) :=
   nonsingular_neg <| nonsingular_negAdd h₁ h₂ hxy
 
@@ -666,7 +665,8 @@ noncomputable def add : W.Point → W.Point → W.Point
   | 0, P => P
   | P, 0 => P
   | @some _ _ _ x₁ y₁ h₁, @some _ _ _ x₂ y₂ h₂ =>
-    if hxy : x₁ = x₂ ∧ y₁ = W.negY x₂ y₂ then 0 else some <| nonsingular_add h₁ h₂ hxy
+    if h : x₁ = x₂ ∧ y₁ = W.negY x₂ y₂ then 0
+    else some (nonsingular_add h₁ h₂ fun hx hy ↦ h ⟨hx, hy⟩)
 
 noncomputable instance instAddPoint : Add W.Point :=
   ⟨add⟩
@@ -676,10 +676,6 @@ noncomputable instance instAddZeroClassPoint : AddZeroClass W.Point :=
 
 lemma add_def (P Q : W.Point) : P + Q = P.add Q :=
   rfl
-
-lemma add_some {x₁ x₂ y₁ y₂ : F} (hxy : ¬(x₁ = x₂ ∧ y₁ = W.negY x₂ y₂)) {h₁ : W.Nonsingular x₁ y₁}
-    {h₂ : W.Nonsingular x₂ y₂} : some h₁ + some h₂ = some (nonsingular_add h₁ h₂ hxy) := by
-  simp only [add_def, add, dif_neg hxy]
 
 @[simp]
 lemma add_of_Y_eq {x₁ x₂ y₁ y₂ : F} {h₁ : W.Nonsingular x₁ y₁} {h₂ : W.Nonsingular x₂ y₂}
@@ -692,32 +688,37 @@ lemma add_self_of_Y_eq {x₁ y₁ : F} {h₁ : W.Nonsingular x₁ y₁} (hy : y�
   add_of_Y_eq rfl hy
 
 @[simp]
+lemma add_of_imp {x₁ x₂ y₁ y₂ : F} {h₁ : W.Nonsingular x₁ y₁} {h₂ : W.Nonsingular x₂ y₂}
+    (hxy : x₁ = x₂ → y₁ ≠ W.negY x₂ y₂) : some h₁ + some h₂ = some (nonsingular_add h₁ h₂ hxy) :=
+  dif_neg fun hn ↦ hxy hn.1 hn.2
+
+@[simp]
 lemma add_of_Y_ne {x₁ x₂ y₁ y₂ : F} {h₁ : W.Nonsingular x₁ y₁} {h₂ : W.Nonsingular x₂ y₂}
     (hy : y₁ ≠ W.negY x₂ y₂) :
-    some h₁ + some h₂ = some (nonsingular_add h₁ h₂ fun hxy => hy hxy.right) :=
-  add_some fun hxy => hy hxy.right
+    some h₁ + some h₂ = some (nonsingular_add h₁ h₂ fun _ ↦ hy) :=
+  add_of_imp fun _ ↦ hy
 
 lemma add_of_Y_ne' {x₁ x₂ y₁ y₂ : F} {h₁ : W.Nonsingular x₁ y₁} {h₂ : W.Nonsingular x₂ y₂}
     (hy : y₁ ≠ W.negY x₂ y₂) :
-    some h₁ + some h₂ = -some (nonsingular_negAdd h₁ h₂ fun hxy => hy hxy.right) :=
+    some h₁ + some h₂ = -some (nonsingular_negAdd h₁ h₂ fun _ ↦ hy) :=
   add_of_Y_ne hy
 
 @[simp]
 lemma add_self_of_Y_ne {x₁ y₁ : F} {h₁ : W.Nonsingular x₁ y₁} (hy : y₁ ≠ W.negY x₁ y₁) :
-    some h₁ + some h₁ = some (nonsingular_add h₁ h₁ fun hxy => hy hxy.right) :=
+    some h₁ + some h₁ = some (nonsingular_add h₁ h₁ fun _ => hy) :=
   add_of_Y_ne hy
 
 lemma add_self_of_Y_ne' {x₁ y₁ : F} {h₁ : W.Nonsingular x₁ y₁} (hy : y₁ ≠ W.negY x₁ y₁) :
-    some h₁ + some h₁ = -some (nonsingular_negAdd h₁ h₁ fun hxy => hy hxy.right) :=
+    some h₁ + some h₁ = -some (nonsingular_negAdd h₁ h₁ fun _ => hy) :=
   add_of_Y_ne hy
 
 @[simp]
 lemma add_of_X_ne {x₁ x₂ y₁ y₂ : F} {h₁ : W.Nonsingular x₁ y₁} {h₂ : W.Nonsingular x₂ y₂}
-    (hx : x₁ ≠ x₂) : some h₁ + some h₂ = some (nonsingular_add h₁ h₂ fun hxy => hx hxy.left) :=
-  add_some fun hxy => hx hxy.left
+    (hx : x₁ ≠ x₂) : some h₁ + some h₂ = some (nonsingular_add h₁ h₂ fun h => (hx h).elim) :=
+  add_of_imp fun h ↦ (hx h).elim
 
 lemma add_of_X_ne' {x₁ x₂ y₁ y₂ : F} {h₁ : W.Nonsingular x₁ y₁} {h₂ : W.Nonsingular x₂ y₂}
-    (hx : x₁ ≠ x₂) : some h₁ + some h₂ = -some (nonsingular_negAdd h₁ h₂ fun hxy => hx hxy.left) :=
+    (hx : x₁ ≠ x₂) : some h₁ + some h₂ = -some (nonsingular_negAdd h₁ h₂ fun h => (hx h).elim) :=
   add_of_X_ne hx
 
 end Point
@@ -897,11 +898,16 @@ def map : W'⟮F⟯ →+ W'⟮K⟯ where
   map_add' := by
     rintro (_ | @⟨x₁, y₁, _⟩) (_ | @⟨x₂, y₂, _⟩)
     any_goals rfl
-    by_cases hxy : x₁ = x₂ ∧ y₁ = (W'.baseChange F).toAffine.negY x₂ y₂
-    · simp only [add_of_Y_eq hxy.left hxy.right, mapFun]
-      rw [add_of_Y_eq (congr_arg _ hxy.left) <| by rw [hxy.right, baseChange_negY]]
-    · simp only [add_some hxy, mapFun, ← baseChange_addX, ← baseChange_addY, ← baseChange_slope]
-      rw [add_some fun h => hxy ⟨f.injective h.1, f.injective (W'.baseChange_negY f .. ▸ h).2⟩]
+    have inj : Function.Injective f := f.injective
+    by_cases h : x₁ = x₂ ∧ y₁ = negY (W'.baseChange F) x₂ y₂
+    · simp only [add_of_Y_eq h.1 h.2, mapFun]
+      rw [add_of_Y_eq congr(f $(h.1))]
+      rw [baseChange_negY, inj.eq_iff]
+      exact h.2
+    · simp only [add_of_imp fun hx hy ↦ h ⟨hx, hy⟩, mapFun]
+      rw [add_of_imp]
+      · simp only [some.injEq, ← baseChange_addX, ← baseChange_addY, ← baseChange_slope]
+      · push_neg at h; rwa [baseChange_negY, inj.eq_iff, inj.ne_iff]
 
 lemma map_zero : map f (0 : W'⟮F⟯) = 0 :=
   rfl

--- a/Mathlib/AlgebraicGeometry/EllipticCurve/Affine.lean
+++ b/Mathlib/AlgebraicGeometry/EllipticCurve/Affine.lean
@@ -100,13 +100,13 @@ local macro "map_simp" : tactic =>
     Polynomial.map_mul, Polynomial.map_pow, Polynomial.map_div, coe_mapRingHom,
     WeierstrassCurve.map])
 
-universe r s u v
+universe r s u v w
 
 /-! ## Weierstrass curves -/
 
 namespace WeierstrassCurve
 
-variable {R : Type r} {S : Type s} {A F : Type u} {B K : Type v}
+variable {R : Type r} {S : Type s} {A F : Type u} {B K : Type v} {L : Type w}
 
 variable (R) in
 /-- An abbreviation for a Weierstrass curve in affine coordinates. -/
@@ -119,8 +119,8 @@ abbrev toAffine (W : WeierstrassCurve R) : Affine R :=
 
 namespace Affine
 
-variable [CommRing R] [CommRing S] [CommRing A] [CommRing B] [Field F] [Field K] {W' : Affine R}
-  {W : Affine F}
+variable [CommRing R] [CommRing S] [CommRing A] [CommRing B] [Field F] [Field K] [Field L]
+  {W' : Affine R} {W : Affine F}
 
 section Equation
 
@@ -305,7 +305,7 @@ section Negation
 /-! ### Negation formulae -/
 
 variable (W') in
-/-- The polynomial `-Y - a₁X - a₃` associated to negation. -/
+/-- The polynomial $-Y - a_1X - a_3$ associated to negation. -/
 noncomputable def negPolynomial : R[X][Y] :=
   -(Y : R[X][Y]) - C (C W'.a₁ * X + C W'.a₃)
 
@@ -318,8 +318,9 @@ lemma Y_sub_negPolynomial : Y - W'.negPolynomial = W'.polynomialY := by
   rw [← Y_sub_polynomialY, sub_sub_cancel]
 
 variable (W') in
-/-- The `Y`-coordinate of the negation of an affine point in `W`.
-This depends on `W`, and has argument order: `x`, `y`. -/
+/-- The $Y$-coordinate of the negation of an affine point in `W`.
+
+This depends on `W`, and has argument order: $x$, $y$. -/
 @[simp]
 def negY (x y : R) : R :=
   -y - W'.a₁ * x - W'.a₃
@@ -367,20 +368,23 @@ section Slope
 /-! ### Slope formulae -/
 
 variable (W') in
-/-- The polynomial `ℓ(X - x) + y` associated to the line `Y = ℓ(X - x) + y`, with a slope of `ℓ`
-that passes through an affine point `(x, y)`.
-This does not depend on `W`, and has argument order: `x`, `y`, `ℓ`. -/
+/-- The polynomial $L(X - x) + y$ associated to the line $Y = L(X - x) + y$,
+with a slope of $L$ that passes through an affine point $(x, y)$.
+
+This does not depend on `W`, and has argument order: $x$, $y$, $L$. -/
 noncomputable def linePolynomial (x y ℓ : R) : R[X] :=
   C ℓ * (X - C x) + C y
 
 open Classical in
 variable (W) in
-/-- The slope of the line through two affine points `(x₁, y₁)` and `(x₂, y₂)` in `W`. If `x₁ ≠ x₂`,
-then this line is the secant of `W` through `(x₁, y₁)` and `(x₂, y₂)`, and has slope
-`(y₁ - y₂) / (x₁ - x₂)`. Otherwise, if `y₁ ≠ -y₁ - a₁x₁ - a₃`, then this line is the tangent of `W`
-at `(x₁, y₁) = (x₂, y₂)`, and has slope `(3x₁² + 2a₂x₁ + a₄ - a₁y₁) / (2y₁ + a₁x₁ + a₃)`.
-Otherwise, this line is vertical, in which case this function returns the value `0`.
-This depends on `W`, and has argument order: `x₁`, `x₂`, `y₁`, `y₂`. -/
+/-- The slope of the line through two affine points $(x_1, y_1)$ and $(x_2, y_2)$ in `W`.
+If $x_1 \ne x_2$, then this line is the secant of `W` through $(x_1, y_1)$ and $(x_2, y_2)$,
+and has slope $(y_1 - y_2) / (x_1 - x_2)$. Otherwise, if $y_1 \ne -y_1 - a_1x_1 - a_3$,
+then this line is the tangent of `W` at $(x_1, y_1) = (x_2, y_2)$, and has slope
+$(3x_1^2 + 2a_2x_1 + a_4 - a_1y_1) / (2y_1 + a_1x_1 + a_3)$. Otherwise, this line is vertical,
+and has undefined slope, in which case this function returns the value 0.
+
+This depends on `W`, and has argument order: $x_1$, $x_2$, $y_1$, $y_2$. -/
 noncomputable def slope (x₁ x₂ y₁ y₂ : F) : F :=
   if x₁ = x₂ then if y₁ = W.negY x₂ y₂ then 0
     else (3 * x₁ ^ 2 + 2 * W.a₂ * x₁ + W.a₄ - W.a₁ * y₁) / (y₁ - W.negY x₁ y₁)
@@ -416,11 +420,12 @@ section Addition
 /-! ### Addition formulae -/
 
 variable (W') in
-/-- The polynomial obtained by substituting the line `Y = ℓ*(X - x) + y`, with a slope of `ℓ` that
-passes through an affine point `(x, y)`, into the polynomial `W(X, Y)` associated to `W`. If such a
-line intersects `W` at another point `(x', y')`, then the roots of this polynomial are precisely
-`x`, `x'`, and the `X`-coordinate of the addition of `(x, y)` and `(x', y')`.
-This depends on `W`, and has argument order: `x`, `y`, `ℓ`. -/
+/-- The polynomial obtained by substituting the line $Y = L*(X - x) + y$, with a slope of $L$
+that passes through an affine point $(x, y)$, into the polynomial $W(X, Y)$ associated to `W`.
+If such a line intersects `W` at another point $(x', y')$, then the roots of this polynomial are
+precisely $x$, $x'$, and the $X$-coordinate of the addition of $(x, y)$ and $(x', y')$.
+
+This depends on `W`, and has argument order: $x$, $y$, $L$. -/
 noncomputable def addPolynomial (x y ℓ : R) : R[X] :=
   W'.polynomial.eval <| linePolynomial x y ℓ
 
@@ -442,25 +447,28 @@ lemma addPolynomial_eq (x y ℓ : R) : W'.addPolynomial x y ℓ = -Cubic.toPoly
   ring1
 
 variable (W') in
-/-- The `X`-coordinate of the addition of two affine points `(x₁, y₁)` and `(x₂, y₂)` in `W`, where
-the line through them is not vertical and has a slope of `ℓ`.
-This depends on `W`, and has argument order: `x₁`, `x₂`, `ℓ`. -/
+/-- The $X$-coordinate of the addition of two affine points $(x_1, y_1)$ and $(x_2, y_2)$ in `W`,
+where the line through them is not vertical and has a slope of $L$.
+
+This depends on `W`, and has argument order: $x_1$, $x_2$, $L$. -/
 @[simp]
 def addX (x₁ x₂ ℓ : R) : R :=
   ℓ ^ 2 + W'.a₁ * ℓ - W'.a₂ - x₁ - x₂
 
 variable (W') in
-/-- The `Y`-coordinate of the negated addition of two affine points `(x₁, y₁)` and `(x₂, y₂)`, where
-the line through them is not vertical and has a slope of `ℓ`.
-This depends on `W`, and has argument order: `x₁`, `x₂`, `y₁`, `ℓ`. -/
+/-- The $Y$-coordinate of the negated addition of two affine points $(x_1, y_1)$ and $(x_2, y_2)$,
+where the line through them is not vertical and has a slope of $L$.
+
+This depends on `W`, and has argument order: $x_1$, $x_2$, $y_1$, $L$. -/
 @[simp]
 def negAddY (x₁ x₂ y₁ ℓ : R) : R :=
   ℓ * (W'.addX x₁ x₂ ℓ - x₁) + y₁
 
 variable (W') in
-/-- The `Y`-coordinate of the addition of two affine points `(x₁, y₁)` and `(x₂, y₂)` in `W`, where
-the line through them is not vertical and has a slope of `ℓ`.
-This depends on `W`, and has argument order: `x₁`, `x₂`, `y₁`, `ℓ`. -/
+/-- The $Y$-coordinate of the addition of two affine points $(x_1, y_1)$ and $(x_2, y_2)$ in `W`,
+where the line through them is not vertical and has a slope of $L$.
+
+This depends on `W`, and has argument order: $x_1$, $x_2$, $y_1$, $L$. -/
 @[simp]
 def addY (x₁ x₂ y₁ ℓ : R) : R :=
   W'.negY (W'.addX x₁ x₂ ℓ) (W'.negAddY x₁ x₂ y₁ ℓ)
@@ -566,8 +574,8 @@ lemma nonsingular_add {x₁ x₂ y₁ y₂ : F} (h₁ : W.Nonsingular x₁ y₁)
     W.Nonsingular (W.addX x₁ x₂ <| W.slope x₁ x₂ y₁ y₂) (W.addY x₁ x₂ y₁ <| W.slope x₁ x₂ y₁ y₂) :=
   (nonsingular_neg ..).mpr <| nonsingular_negAdd h₁ h₂ hxy
 
-/-- The formula `x(P₁ + P₂) = x(P₁ - P₂) - ψ(P₁)ψ(P₂) / (x(P₂) - x(P₁))²`,
-where `ψ(x,y) = 2y + a₁x + a₃`. -/
+/-- The formula x(P₁ + P₂) = x(P₁ - P₂) - ψ(P₁)ψ(P₂) / (x(P₂) - x(P₁))²,
+where ψ(x,y) = 2y + a₁x + a₃. -/
 lemma addX_eq_addX_negY_sub {x₁ x₂ : F} (y₁ y₂ : F) (hx : x₁ ≠ x₂) :
     W.addX x₁ x₂ (W.slope x₁ x₂ y₁ y₂) = W.addX x₁ x₂ (W.slope x₁ x₂ y₁ <| W.negY x₂ y₂) -
       (y₁ - W.negY x₁ y₁) * (y₂ - W.negY x₂ y₂) / (x₂ - x₁) ^ 2 := by
@@ -575,8 +583,8 @@ lemma addX_eq_addX_negY_sub {x₁ x₂ : F} (y₁ y₂ : F) (hx : x₁ ≠ x₂)
   field_simp [sub_ne_zero.mpr hx]
   ring1
 
-/-- The formula `y(P₁)(x(P₂) - x(P₃)) + y(P₂)(x(P₃) - x(P₁)) + y(P₃)(x(P₁) - x(P₂)) = 0`,
-assuming that `P₁ + P₂ + P₃ = O`. -/
+/-- The formula y(P₁)(x(P₂) - x(P₃)) + y(P₂)(x(P₃) - x(P₁)) + y(P₃)(x(P₁) - x(P₂)) = 0,
+assuming that P₁ + P₂ + P₃ = O. -/
 lemma cyclic_sum_Y_mul_X_sub_X {x₁ x₂ : F} (y₁ y₂ : F) (hx : x₁ ≠ x₂) :
     let x₃ := W.addX x₁ x₂ (W.slope x₁ x₂ y₁ y₂)
     y₁ * (x₂ - x₃) + y₂ * (x₃ - x₁) + W.negAddY x₁ x₂ y₁ (W.slope x₁ x₂ y₁ y₂) * (x₁ - x₂) = 0 := by
@@ -584,8 +592,9 @@ lemma cyclic_sum_Y_mul_X_sub_X {x₁ x₂ : F} (y₁ y₂ : F) (hx : x₁ ≠ x�
   field_simp [sub_ne_zero.mpr hx]
   ring1
 
-/-- The formula `ψ(P₁ + P₂) = (ψ(P₂)(x(P₁) - x(P₃)) - ψ(P₁)(x(P₂) - x(P₃))) / (x(P₂) - x(P₁))`,
-where `ψ(x,y) = 2y + a₁x + a₃`. -/
+/-- The formula
+ψ(P₁ + P₂) = (ψ(P₂)(x(P₁) - x(P₃)) - ψ(P₁)(x(P₂) - x(P₃))) / (x(P₂) - x(P₁)),
+where ψ(x,y) = 2y + a₁x + a₃. -/
 lemma addY_sub_negY_addY {x₁ x₂ : F} (y₁ y₂ : F) (hx : x₁ ≠ x₂) :
     let x₃ := W.addX x₁ x₂ (W.slope x₁ x₂ y₁ y₂)
     let y₃ := W.addY x₁ x₂ y₁ (W.slope x₁ x₂ y₁ y₂)
@@ -601,14 +610,14 @@ section Group
 /-! ### Nonsingular points -/
 
 variable (W') in
-/-- A nonsingular point on a Weierstrass curve `W` in affine coordinates. This is either the unique
-point at infinity `WeierstrassCurve.Affine.Point.zero` or the nonsingular affine points
-`WeierstrassCurve.Affine.Point.some` `(x, y)` satisfying the Weierstrass equation of `W`. -/
+/-- A nonsingular rational point on a Weierstrass curve `W` in affine coordinates. This is either
+the unique point at infinity `WeierstrassCurve.Affine.Point.zero` or the nonsingular affine points
+`WeierstrassCurve.Affine.Point.some` $(x, y)$ satisfying the Weierstrass equation of `W`. -/
 inductive Point
   | zero
   | some {x y : R} (h : W'.Nonsingular x y)
 
-/-- For an algebraic extension `S` of `R`, the type of nonsingular `S`-points on `W`. -/
+/-- For an algebraic extension `S` of `R`, the type of nonsingular `S`-rational points on `W`. -/
 scoped notation3:max W' "⟮" S "⟯" => Affine.Point <| baseChange W' S
 
 namespace Point
@@ -628,6 +637,7 @@ lemma some_ne_zero {x y : R} (h : W'.Nonsingular x y) : Point.some h ≠ 0 := by
   rintro (_ | _)
 
 /-- The negation of a nonsingular point on `W`.
+
 Given a nonsingular point `P` on `W`, use `-P` instead of `neg P`. -/
 def neg : W'.Point → W'.Point
   | 0 => 0
@@ -655,6 +665,7 @@ instance : InvolutiveNeg W'.Point where
 
 open Classical in
 /-- The addition of two nonsingular points on `W`.
+
 Given two nonsingular points `P` and `Q` on `W`, use `P + Q` instead of `add P Q`. -/
 noncomputable def add : W.Point → W.Point → W.Point
   | 0, P => P
@@ -873,11 +884,9 @@ end BaseChange
 
 namespace Point
 
-universe w
-
-variable {L : Type w} [Field L] [Algebra R S] [Algebra R F] [Algebra S F] [IsScalarTower R S F]
-  [Algebra R K] [Algebra S K] [IsScalarTower R S K] [Algebra R L] [Algebra S L]
-  [IsScalarTower R S L] (f : F →ₐ[S] K) (g : K →ₐ[S] L)
+variable [Algebra R S] [Algebra R F] [Algebra S F] [IsScalarTower R S F] [Algebra R K] [Algebra S K]
+  [IsScalarTower R S K] [Algebra R L] [Algebra S L] [IsScalarTower R S L] (f : F →ₐ[S] K)
+  (g : K →ₐ[S] L)
 
 /-- The group homomorphism from `W⟮F⟯` to `W⟮K⟯` induced by an algebra homomorphism `f : F →ₐ[S] K`,
 where `W` is defined over a subring of a ring `S`, and `F` and `K` are field extensions of `S`. -/

--- a/Mathlib/AlgebraicGeometry/EllipticCurve/Affine.lean
+++ b/Mathlib/AlgebraicGeometry/EllipticCurve/Affine.lean
@@ -289,9 +289,9 @@ lemma nonsingular_of_Δ_ne_zero {x y : R} (h : W'.Equation x y) (hΔ : W'.Δ ≠
 
 end Nonsingular
 
-section Negation
+section Ring
 
-/-! ### Negation formulae -/
+/-! ### Group operations over a ring -/
 
 variable (W') in
 /-- The polynomial $-Y - a_1X - a_3$ associated to negation. -/
@@ -322,97 +322,12 @@ lemma eval_negPolynomial (x y : R) : W'.negPolynomial.evalEval x y = W'.negY x y
   rw [negY, sub_sub, negPolynomial]
   eval_simp
 
-lemma Y_eq_of_X_eq {x₁ x₂ y₁ y₂ : F} (h₁ : W.Equation x₁ y₁) (h₂ : W.Equation x₂ y₂)
-    (hx : x₁ = x₂) : y₁ = y₂ ∨ y₁ = W.negY x₂ y₂ := by
-  rw [equation_iff] at h₁ h₂
-  rw [← sub_eq_zero, ← sub_eq_zero (a := y₁), ← mul_eq_zero, negY]
-  linear_combination (norm := (rw [hx]; ring1)) h₁ - h₂
-
-lemma Y_eq_of_Y_ne {x₁ x₂ y₁ y₂ : F} (h₁ : W.Equation x₁ y₁) (h₂ : W.Equation x₂ y₂) (hx : x₁ = x₂)
-    (hy : y₁ ≠ W.negY x₂ y₂) : y₁ = y₂ :=
-  (Y_eq_of_X_eq h₁ h₂ hx).resolve_right hy
-
-lemma equation_neg_iff (x y : R) : W'.Equation x (W'.negY x y) ↔ W'.Equation x y := by
-  rw [equation_iff, equation_iff, negY]
-  congr! 1
-  ring1
-
-lemma equation_neg_of {x y : R} (h : W'.Equation x <| W'.negY x y) : W'.Equation x y :=
-  (W'.equation_neg_iff ..).mp h
-
-/-- The negation of an affine point in `W` lies in `W`. -/
-lemma equation_neg {x y : R} (h : W'.Equation x y) : W'.Equation x <| W'.negY x y :=
-  (W'.equation_neg_iff ..).mpr h
-
-lemma nonsingular_neg_iff (x y : R) : W'.Nonsingular x (W'.negY x y) ↔ W'.Nonsingular x y := by
-  rw [nonsingular_iff, equation_neg_iff, ← negY, negY_negY, ← @ne_comm _ y, nonsingular_iff]
-  exact and_congr_right' <| (iff_congr not_and_or.symm not_and_or.symm).mpr <|
-    not_congr <| and_congr_left fun h => by rw [← h]
-
-lemma nonsingular_neg_of {x y : R} (h : W'.Nonsingular x <| W'.negY x y) : W'.Nonsingular x y :=
-  (W'.nonsingular_neg_iff ..).mp h
-
-/-- The negation of a nonsingular affine point in `W` is nonsingular. -/
-lemma nonsingular_neg {x y : R} (h : W'.Nonsingular x y) : W'.Nonsingular x <| W'.negY x y :=
-  (W'.nonsingular_neg_iff ..).mpr h
-
-end Negation
-
-section Slope
-
-/-! ### Slope formulae -/
-
-variable (W') in
 /-- The polynomial $L(X - x) + y$ associated to the line $Y = L(X - x) + y$,
 with a slope of $L$ that passes through an affine point $(x, y)$.
 
 This does not depend on `W`, and has argument order: $x$, $y$, $L$. -/
 noncomputable def linePolynomial (x y ℓ : R) : R[X] :=
   C ℓ * (X - C x) + C y
-
-open Classical in
-variable (W) in
-/-- The slope of the line through two affine points $(x_1, y_1)$ and $(x_2, y_2)$ in `W`.
-If $x_1 \ne x_2$, then this line is the secant of `W` through $(x_1, y_1)$ and $(x_2, y_2)$,
-and has slope $(y_1 - y_2) / (x_1 - x_2)$. Otherwise, if $y_1 \ne -y_1 - a_1x_1 - a_3$,
-then this line is the tangent of `W` at $(x_1, y_1) = (x_2, y_2)$, and has slope
-$(3x_1^2 + 2a_2x_1 + a_4 - a_1y_1) / (2y_1 + a_1x_1 + a_3)$. Otherwise, this line is vertical,
-and has undefined slope, in which case this function returns the value 0.
-
-This depends on `W`, and has argument order: $x_1$, $x_2$, $y_1$, $y_2$. -/
-noncomputable def slope (x₁ x₂ y₁ y₂ : F) : F :=
-  if x₁ = x₂ then if y₁ = W.negY x₂ y₂ then 0
-    else (3 * x₁ ^ 2 + 2 * W.a₂ * x₁ + W.a₄ - W.a₁ * y₁) / (y₁ - W.negY x₁ y₁)
-  else (y₁ - y₂) / (x₁ - x₂)
-
-@[simp]
-lemma slope_of_Y_eq {x₁ x₂ y₁ y₂ : F} (hx : x₁ = x₂) (hy : y₁ = W.negY x₂ y₂) :
-    W.slope x₁ x₂ y₁ y₂ = 0 := by
-  rw [slope, if_pos hx, if_pos hy]
-
-@[simp]
-lemma slope_of_Y_ne {x₁ x₂ y₁ y₂ : F} (hx : x₁ = x₂) (hy : y₁ ≠ W.negY x₂ y₂) :
-    W.slope x₁ x₂ y₁ y₂ =
-      (3 * x₁ ^ 2 + 2 * W.a₂ * x₁ + W.a₄ - W.a₁ * y₁) / (y₁ - W.negY x₁ y₁) := by
-  rw [slope, if_pos hx, if_neg hy]
-
-@[simp]
-lemma slope_of_X_ne {x₁ x₂ y₁ y₂ : F} (hx : x₁ ≠ x₂) :
-    W.slope x₁ x₂ y₁ y₂ = (y₁ - y₂) / (x₁ - x₂) := by
-  rw [slope, if_neg hx]
-
-lemma slope_of_Y_ne_eq_eval {x₁ x₂ y₁ y₂ : F} (hx : x₁ = x₂) (hy : y₁ ≠ W.negY x₂ y₂) :
-    W.slope x₁ x₂ y₁ y₂ = -W.polynomialX.evalEval x₁ y₁ / W.polynomialY.evalEval x₁ y₁ := by
-  rw [slope_of_Y_ne hx hy, evalEval_polynomialX, neg_sub]
-  congr 1
-  rw [negY, evalEval_polynomialY]
-  ring1
-
-end Slope
-
-section Addition
-
-/-! ### Addition formulae -/
 
 variable (W') in
 /-- The polynomial obtained by substituting the line $Y = L*(X - x) + y$, with a slope of $L$
@@ -467,6 +382,84 @@ This depends on `W`, and has argument order: $x_1$, $x_2$, $y_1$, $L$. -/
 @[simp]
 def addY (x₁ x₂ y₁ ℓ : R) : R :=
   W'.negY (W'.addX x₁ x₂ ℓ) (W'.negAddY x₁ x₂ y₁ ℓ)
+
+lemma equation_neg_iff (x y : R) : W'.Equation x (W'.negY x y) ↔ W'.Equation x y := by
+  rw [equation_iff, equation_iff, negY]
+  congr! 1
+  ring1
+
+lemma equation_neg_of {x y : R} (h : W'.Equation x <| W'.negY x y) : W'.Equation x y :=
+  (W'.equation_neg_iff ..).mp h
+
+/-- The negation of an affine point in `W` lies in `W`. -/
+lemma equation_neg {x y : R} (h : W'.Equation x y) : W'.Equation x <| W'.negY x y :=
+  (W'.equation_neg_iff ..).mpr h
+
+lemma nonsingular_neg_iff (x y : R) : W'.Nonsingular x (W'.negY x y) ↔ W'.Nonsingular x y := by
+  rw [nonsingular_iff, equation_neg_iff, ← negY, negY_negY, ← @ne_comm _ y, nonsingular_iff]
+  exact and_congr_right' <| (iff_congr not_and_or.symm not_and_or.symm).mpr <|
+    not_congr <| and_congr_left fun h => by rw [← h]
+
+lemma nonsingular_neg_of {x y : R} (h : W'.Nonsingular x <| W'.negY x y) : W'.Nonsingular x y :=
+  (W'.nonsingular_neg_iff ..).mp h
+
+/-- The negation of a nonsingular affine point in `W` is nonsingular. -/
+lemma nonsingular_neg {x y : R} (h : W'.Nonsingular x y) : W'.Nonsingular x <| W'.negY x y :=
+  (W'.nonsingular_neg_iff ..).mpr h
+
+end Ring
+
+section Field
+
+/-! ### Group operations over a field -/
+
+open Classical in
+variable (W) in
+/-- The slope of the line through two affine points $(x_1, y_1)$ and $(x_2, y_2)$ in `W`.
+If $x_1 \ne x_2$, then this line is the secant of `W` through $(x_1, y_1)$ and $(x_2, y_2)$,
+and has slope $(y_1 - y_2) / (x_1 - x_2)$. Otherwise, if $y_1 \ne -y_1 - a_1x_1 - a_3$,
+then this line is the tangent of `W` at $(x_1, y_1) = (x_2, y_2)$, and has slope
+$(3x_1^2 + 2a_2x_1 + a_4 - a_1y_1) / (2y_1 + a_1x_1 + a_3)$. Otherwise, this line is vertical,
+and has undefined slope, in which case this function returns the value 0.
+
+This depends on `W`, and has argument order: $x_1$, $x_2$, $y_1$, $y_2$. -/
+noncomputable def slope (x₁ x₂ y₁ y₂ : F) : F :=
+  if x₁ = x₂ then if y₁ = W.negY x₂ y₂ then 0
+    else (3 * x₁ ^ 2 + 2 * W.a₂ * x₁ + W.a₄ - W.a₁ * y₁) / (y₁ - W.negY x₁ y₁)
+  else (y₁ - y₂) / (x₁ - x₂)
+
+@[simp]
+lemma slope_of_Y_eq {x₁ x₂ y₁ y₂ : F} (hx : x₁ = x₂) (hy : y₁ = W.negY x₂ y₂) :
+    W.slope x₁ x₂ y₁ y₂ = 0 := by
+  rw [slope, if_pos hx, if_pos hy]
+
+@[simp]
+lemma slope_of_Y_ne {x₁ x₂ y₁ y₂ : F} (hx : x₁ = x₂) (hy : y₁ ≠ W.negY x₂ y₂) :
+    W.slope x₁ x₂ y₁ y₂ =
+      (3 * x₁ ^ 2 + 2 * W.a₂ * x₁ + W.a₄ - W.a₁ * y₁) / (y₁ - W.negY x₁ y₁) := by
+  rw [slope, if_pos hx, if_neg hy]
+
+@[simp]
+lemma slope_of_X_ne {x₁ x₂ y₁ y₂ : F} (hx : x₁ ≠ x₂) :
+    W.slope x₁ x₂ y₁ y₂ = (y₁ - y₂) / (x₁ - x₂) := by
+  rw [slope, if_neg hx]
+
+lemma slope_of_Y_ne_eq_eval {x₁ x₂ y₁ y₂ : F} (hx : x₁ = x₂) (hy : y₁ ≠ W.negY x₂ y₂) :
+    W.slope x₁ x₂ y₁ y₂ = -W.polynomialX.evalEval x₁ y₁ / W.polynomialY.evalEval x₁ y₁ := by
+  rw [slope_of_Y_ne hx hy, evalEval_polynomialX, neg_sub]
+  congr 1
+  rw [negY, evalEval_polynomialY]
+  ring1
+
+lemma Y_eq_of_X_eq {x₁ x₂ y₁ y₂ : F} (h₁ : W.Equation x₁ y₁) (h₂ : W.Equation x₂ y₂)
+    (hx : x₁ = x₂) : y₁ = y₂ ∨ y₁ = W.negY x₂ y₂ := by
+  rw [equation_iff] at h₁ h₂
+  rw [← sub_eq_zero, ← sub_eq_zero (a := y₁), ← mul_eq_zero, negY]
+  linear_combination (norm := (rw [hx]; ring1)) h₁ - h₂
+
+lemma Y_eq_of_Y_ne {x₁ x₂ y₁ y₂ : F} (h₁ : W.Equation x₁ y₁) (h₂ : W.Equation x₂ y₂) (hx : x₁ = x₂)
+    (hy : y₁ ≠ W.negY x₂ y₂) : y₁ = y₂ :=
+  (Y_eq_of_X_eq h₁ h₂ hx).resolve_right hy
 
 lemma addPolynomial_slope {x₁ x₂ y₁ y₂ : F} (h₁ : W.Equation x₁ y₁) (h₂ : W.Equation x₂ y₂)
     (hxy : x₁ = x₂ → y₁ ≠ W.negY x₂ y₂) : W.addPolynomial x₁ y₁ (W.slope x₁ x₂ y₁ y₂) =
@@ -597,7 +590,7 @@ lemma addY_sub_negY_addY {x₁ x₂ : F} (y₁ y₂ : F) (hx : x₁ ≠ x₂) :
   simp_rw [addY, negY, eq_div_iff (sub_ne_zero.mpr hx.symm)]
   linear_combination (norm := ring1) 2 * cyclic_sum_Y_mul_X_sub_X y₁ y₂ hx
 
-end Addition
+end Field
 
 section Group
 

--- a/Mathlib/AlgebraicGeometry/EllipticCurve/Affine.lean
+++ b/Mathlib/AlgebraicGeometry/EllipticCurve/Affine.lean
@@ -81,6 +81,7 @@ elliptic curve, rational point, affine coordinates
 -/
 
 open Polynomial
+
 open scoped Polynomial.Bivariate
 
 local macro "C_simp" : tactic =>
@@ -99,63 +100,69 @@ local macro "map_simp" : tactic =>
     Polynomial.map_mul, Polynomial.map_pow, Polynomial.map_div, coe_mapRingHom,
     WeierstrassCurve.map])
 
-universe r s u v w
+universe r s u v
 
 /-! ## Weierstrass curves -/
 
+namespace WeierstrassCurve
+
+variable {R : Type r} {S : Type s} {A F : Type u} {B K : Type v}
+
+variable (R) in
 /-- An abbreviation for a Weierstrass curve in affine coordinates. -/
-abbrev WeierstrassCurve.Affine (R : Type u) : Type u :=
+abbrev Affine : Type r :=
   WeierstrassCurve R
 
 /-- The coercion to a Weierstrass curve in affine coordinates. -/
-abbrev WeierstrassCurve.toAffine {R : Type u} (W : WeierstrassCurve R) : Affine R :=
+abbrev toAffine (W : WeierstrassCurve R) : Affine R :=
   W
 
-namespace WeierstrassCurve.Affine
+namespace Affine
 
-variable {R : Type u} [CommRing R] (W : Affine R)
+variable [CommRing R] [CommRing S] [CommRing A] [CommRing B] [Field F] [Field K] {W' : Affine R}
+  {W : Affine F}
 
 section Equation
 
 /-! ### Weierstrass equations -/
 
+variable (W') in
 /-- The polynomial $W(X, Y) := Y^2 + a_1XY + a_3Y - (X^3 + a_2X^2 + a_4X + a_6)$ associated to a
 Weierstrass curve `W` over `R`. For ease of polynomial manipulation, this is represented as a term
 of type `R[X][X]`, where the inner variable represents $X$ and the outer variable represents $Y$.
 For clarity, the alternative notations `Y` and `R[X][Y]` are provided in the `Polynomial`
 scope to represent the outer variable and the bivariate polynomial ring `R[X][X]` respectively. -/
 noncomputable def polynomial : R[X][Y] :=
-  Y ^ 2 + C (C W.a₁ * X + C W.a₃) * Y - C (X ^ 3 + C W.a₂ * X ^ 2 + C W.a₄ * X + C W.a₆)
+  Y ^ 2 + C (C W'.a₁ * X + C W'.a₃) * Y - C (X ^ 3 + C W'.a₂ * X ^ 2 + C W'.a₄ * X + C W'.a₆)
 
-lemma polynomial_eq : W.polynomial =
-    Cubic.toPoly
-      ⟨0, 1, Cubic.toPoly ⟨0, 0, W.a₁, W.a₃⟩, Cubic.toPoly ⟨-1, -W.a₂, -W.a₄, -W.a₆⟩⟩ := by
+lemma polynomial_eq : W'.polynomial = Cubic.toPoly
+    ⟨0, 1, Cubic.toPoly ⟨0, 0, W'.a₁, W'.a₃⟩, Cubic.toPoly ⟨-1, -W'.a₂, -W'.a₄, -W'.a₆⟩⟩ := by
   simp only [polynomial, Cubic.toPoly]
   C_simp
   ring1
 
-lemma polynomial_ne_zero [Nontrivial R] : W.polynomial ≠ 0 := by
+lemma polynomial_ne_zero [Nontrivial R] : W'.polynomial ≠ 0 := by
   rw [polynomial_eq]
   exact Cubic.ne_zero_of_b_ne_zero one_ne_zero
 
 @[simp]
-lemma degree_polynomial [Nontrivial R] : W.polynomial.degree = 2 := by
+lemma degree_polynomial [Nontrivial R] : W'.polynomial.degree = 2 := by
   rw [polynomial_eq]
   exact Cubic.degree_of_b_ne_zero' one_ne_zero
 
 @[simp]
-lemma natDegree_polynomial [Nontrivial R] : W.polynomial.natDegree = 2 := by
+lemma natDegree_polynomial [Nontrivial R] : W'.polynomial.natDegree = 2 := by
   rw [polynomial_eq]
   exact Cubic.natDegree_of_b_ne_zero' one_ne_zero
 
-lemma monic_polynomial : W.polynomial.Monic := by
+lemma monic_polynomial : W'.polynomial.Monic := by
   nontriviality R
   simpa only [polynomial_eq] using Cubic.monic_of_b_eq_one'
 
-lemma irreducible_polynomial [IsDomain R] : Irreducible W.polynomial := by
+lemma irreducible_polynomial [IsDomain R] : Irreducible W'.polynomial := by
   by_contra h
-  rcases (W.monic_polynomial.not_irreducible_iff_exists_add_mul_eq_coeff W.natDegree_polynomial).mp
-    h with ⟨f, g, h0, h1⟩
+  rcases (monic_polynomial.not_irreducible_iff_exists_add_mul_eq_coeff natDegree_polynomial).mp h
+    with ⟨f, g, h0, h1⟩
   simp only [polynomial_eq, Cubic.coeff_eq_c, Cubic.coeff_eq_d] at h0 h1
   apply_fun degree at h0 h1
   rw [Cubic.degree_of_a_ne_zero' <| neg_ne_zero.mpr <| one_ne_zero' R, degree_mul] at h0
@@ -164,34 +171,35 @@ lemma irreducible_polynomial [IsDomain R] : Irreducible W.polynomial := by
   iterate 2 rw [degree_add_eq_right_of_degree_lt] <;> simp only [h] <;> decide
   iterate 2 rw [degree_add_eq_left_of_degree_lt] <;> simp only [h] <;> decide
 
-lemma evalEval_polynomial (x y : R) : W.polynomial.evalEval x y =
-    y ^ 2 + W.a₁ * x * y + W.a₃ * y - (x ^ 3 + W.a₂ * x ^ 2 + W.a₄ * x + W.a₆) := by
+lemma evalEval_polynomial (x y : R) : W'.polynomial.evalEval x y =
+    y ^ 2 + W'.a₁ * x * y + W'.a₃ * y - (x ^ 3 + W'.a₂ * x ^ 2 + W'.a₄ * x + W'.a₆) := by
   simp only [polynomial]
   eval_simp
   rw [add_mul, ← add_assoc]
 
 @[simp]
-lemma evalEval_polynomial_zero : W.polynomial.evalEval 0 0 = -W.a₆ := by
+lemma evalEval_polynomial_zero : W'.polynomial.evalEval 0 0 = -W'.a₆ := by
   simp only [evalEval_polynomial, zero_add, zero_sub, mul_zero, zero_pow <| Nat.succ_ne_zero _]
 
+variable (W') in
 /-- The proposition that an affine point $(x, y)$ lies in `W`. In other words, $W(x, y) = 0$. -/
 def Equation (x y : R) : Prop :=
-  W.polynomial.evalEval x y = 0
+  W'.polynomial.evalEval x y = 0
 
-lemma equation_iff' (x y : R) : W.Equation x y ↔
-    y ^ 2 + W.a₁ * x * y + W.a₃ * y - (x ^ 3 + W.a₂ * x ^ 2 + W.a₄ * x + W.a₆) = 0 := by
+lemma equation_iff' (x y : R) : W'.Equation x y ↔
+    y ^ 2 + W'.a₁ * x * y + W'.a₃ * y - (x ^ 3 + W'.a₂ * x ^ 2 + W'.a₄ * x + W'.a₆) = 0 := by
   rw [Equation, evalEval_polynomial]
 
-lemma equation_iff (x y : R) :
-    W.Equation x y ↔ y ^ 2 + W.a₁ * x * y + W.a₃ * y = x ^ 3 + W.a₂ * x ^ 2 + W.a₄ * x + W.a₆ := by
+lemma equation_iff (x y : R) : W'.Equation x y ↔
+    y ^ 2 + W'.a₁ * x * y + W'.a₃ * y = x ^ 3 + W'.a₂ * x ^ 2 + W'.a₄ * x + W'.a₆ := by
   rw [equation_iff', sub_eq_zero]
 
 @[simp]
-lemma equation_zero : W.Equation 0 0 ↔ W.a₆ = 0 := by
+lemma equation_zero : W'.Equation 0 0 ↔ W'.a₆ = 0 := by
   rw [Equation, evalEval_polynomial_zero, neg_eq_zero]
 
 lemma equation_iff_variableChange (x y : R) :
-    W.Equation x y ↔ (W.variableChange ⟨1, x, 0, y⟩).toAffine.Equation 0 0 := by
+    W'.Equation x y ↔ (W'.variableChange ⟨1, x, 0, y⟩).toAffine.Equation 0 0 := by
   rw [equation_iff', ← neg_eq_zero, equation_zero, variableChange_a₆, inv_one, Units.val_one]
   congr! 1
   ring1
@@ -202,234 +210,181 @@ section Nonsingular
 
 /-! ### Nonsingular Weierstrass equations -/
 
+variable (W') in
 /-- The partial derivative $W_X(X, Y)$ of $W(X, Y)$ with respect to $X$.
 
 TODO: define this in terms of `Polynomial.derivative`. -/
 noncomputable def polynomialX : R[X][Y] :=
-  C (C W.a₁) * Y - C (C 3 * X ^ 2 + C (2 * W.a₂) * X + C W.a₄)
+  C (C W'.a₁) * Y - C (C 3 * X ^ 2 + C (2 * W'.a₂) * X + C W'.a₄)
 
 lemma evalEval_polynomialX (x y : R) :
-    W.polynomialX.evalEval x y = W.a₁ * y - (3 * x ^ 2 + 2 * W.a₂ * x + W.a₄) := by
+    W'.polynomialX.evalEval x y = W'.a₁ * y - (3 * x ^ 2 + 2 * W'.a₂ * x + W'.a₄) := by
   simp only [polynomialX]
   eval_simp
 
 @[simp]
-lemma evalEval_polynomialX_zero : W.polynomialX.evalEval 0 0 = -W.a₄ := by
+lemma evalEval_polynomialX_zero : W'.polynomialX.evalEval 0 0 = -W'.a₄ := by
   simp only [evalEval_polynomialX, zero_add, zero_sub, mul_zero, zero_pow <| Nat.succ_ne_zero _]
 
+variable (W') in
 /-- The partial derivative $W_Y(X, Y)$ of $W(X, Y)$ with respect to $Y$.
 
 TODO: define this in terms of `Polynomial.derivative`. -/
 noncomputable def polynomialY : R[X][Y] :=
-  C (C 2) * Y + C (C W.a₁ * X + C W.a₃)
+  C (C 2) * Y + C (C W'.a₁ * X + C W'.a₃)
 
-lemma evalEval_polynomialY (x y : R) :
-    W.polynomialY.evalEval x y = 2 * y + W.a₁ * x + W.a₃ := by
+lemma evalEval_polynomialY (x y : R) : W'.polynomialY.evalEval x y = 2 * y + W'.a₁ * x + W'.a₃ := by
   simp only [polynomialY]
   eval_simp
   rw [← add_assoc]
 
 @[simp]
-lemma evalEval_polynomialY_zero : W.polynomialY.evalEval 0 0 = W.a₃ := by
+lemma evalEval_polynomialY_zero : W'.polynomialY.evalEval 0 0 = W'.a₃ := by
   simp only [evalEval_polynomialY, zero_add, mul_zero]
 
+variable (W') in
 /-- The proposition that an affine point $(x, y)$ in `W` is nonsingular.
 In other words, either $W_X(x, y) \ne 0$ or $W_Y(x, y) \ne 0$.
 
 Note that this definition is only mathematically accurate for fields.
 TODO: generalise this definition to be mathematically accurate for a larger class of rings. -/
 def Nonsingular (x y : R) : Prop :=
-  W.Equation x y ∧ (W.polynomialX.evalEval x y ≠ 0 ∨ W.polynomialY.evalEval x y ≠ 0)
+  W'.Equation x y ∧ (W'.polynomialX.evalEval x y ≠ 0 ∨ W'.polynomialY.evalEval x y ≠ 0)
 
-lemma nonsingular_iff' (x y : R) : W.Nonsingular x y ↔ W.Equation x y ∧
-    (W.a₁ * y - (3 * x ^ 2 + 2 * W.a₂ * x + W.a₄) ≠ 0 ∨ 2 * y + W.a₁ * x + W.a₃ ≠ 0) := by
+lemma nonsingular_iff' (x y : R) : W'.Nonsingular x y ↔ W'.Equation x y ∧
+    (W'.a₁ * y - (3 * x ^ 2 + 2 * W'.a₂ * x + W'.a₄) ≠ 0 ∨ 2 * y + W'.a₁ * x + W'.a₃ ≠ 0) := by
   rw [Nonsingular, equation_iff', evalEval_polynomialX, evalEval_polynomialY]
 
-lemma nonsingular_iff (x y : R) : W.Nonsingular x y ↔
-    W.Equation x y ∧ (W.a₁ * y ≠ 3 * x ^ 2 + 2 * W.a₂ * x + W.a₄ ∨ y ≠ -y - W.a₁ * x - W.a₃) := by
+lemma nonsingular_iff (x y : R) : W'.Nonsingular x y ↔ W'.Equation x y ∧
+    (W'.a₁ * y ≠ 3 * x ^ 2 + 2 * W'.a₂ * x + W'.a₄ ∨ y ≠ -y - W'.a₁ * x - W'.a₃) := by
   rw [nonsingular_iff', sub_ne_zero, ← sub_ne_zero (a := y)]
   congr! 3
   ring1
 
 @[simp]
-lemma nonsingular_zero : W.Nonsingular 0 0 ↔ W.a₆ = 0 ∧ (W.a₃ ≠ 0 ∨ W.a₄ ≠ 0) := by
+lemma nonsingular_zero : W'.Nonsingular 0 0 ↔ W'.a₆ = 0 ∧ (W'.a₃ ≠ 0 ∨ W'.a₄ ≠ 0) := by
   rw [Nonsingular, equation_zero, evalEval_polynomialX_zero, neg_ne_zero, evalEval_polynomialY_zero,
     or_comm]
 
 lemma nonsingular_iff_variableChange (x y : R) :
-    W.Nonsingular x y ↔ (W.variableChange ⟨1, x, 0, y⟩).toAffine.Nonsingular 0 0 := by
+    W'.Nonsingular x y ↔ (W'.variableChange ⟨1, x, 0, y⟩).toAffine.Nonsingular 0 0 := by
   rw [nonsingular_iff', equation_iff_variableChange, equation_zero, ← neg_ne_zero, or_comm,
     nonsingular_zero, variableChange_a₃, variableChange_a₄, inv_one, Units.val_one]
   simp only [variableChange]
   congr! 3 <;> ring1
 
-lemma nonsingular_zero_of_Δ_ne_zero (h : W.Equation 0 0) (hΔ : W.Δ ≠ 0) : W.Nonsingular 0 0 := by
-  simp only [equation_zero, nonsingular_zero] at *
+lemma equation_zero_iff_nonsingular_zero_of_Δ_ne_zero (hΔ : W'.Δ ≠ 0) :
+    W'.Equation 0 0 ↔ W'.Nonsingular 0 0 := by
+  simp only [equation_zero, nonsingular_zero, iff_self_and]
   contrapose! hΔ
-  simp only [b₂, b₄, b₆, b₈, Δ, h, hΔ]
+  simp only [b₂, b₄, b₆, b₈, Δ, hΔ]
   ring1
 
 /-- A Weierstrass curve is nonsingular at every point if its discriminant is non-zero. -/
-lemma nonsingular_of_Δ_ne_zero {x y : R} (h : W.Equation x y) (hΔ : W.Δ ≠ 0) : W.Nonsingular x y :=
-  (W.nonsingular_iff_variableChange x y).mpr <|
-    nonsingular_zero_of_Δ_ne_zero _ ((W.equation_iff_variableChange x y).mp h) <| by
-      rwa [variableChange_Δ, inv_one, Units.val_one, one_pow, one_mul]
+lemma equation_iff_nonsingular_of_Δ_ne_zero {x y : R} (hΔ : W'.Δ ≠ 0) :
+    W'.Equation x y ↔ W'.Nonsingular x y := by
+  rw [equation_iff_variableChange, nonsingular_iff_variableChange,
+    equation_zero_iff_nonsingular_zero_of_Δ_ne_zero <| by
+      rwa [variableChange_Δ, inv_one, Units.val_one, one_pow, one_mul]]
+
+/-- An elliptic curve is nonsingular at every point. -/
+lemma equation_iff_nonsingular [Nontrivial R] [W'.IsElliptic] {x y : R} :
+    W'.toAffine.Equation x y ↔ W'.toAffine.Nonsingular x y :=
+  W'.toAffine.equation_iff_nonsingular_of_Δ_ne_zero <| W'.coe_Δ' ▸ W'.Δ'.ne_zero
+
+@[deprecated (since := "2025-02-01")] alias nonsingular_zero_of_Δ_ne_zero :=
+  equation_zero_iff_nonsingular_zero_of_Δ_ne_zero
+@[deprecated (since := "2025-02-01")] alias nonsingular_of_Δ_ne_zero :=
+  equation_iff_nonsingular_of_Δ_ne_zero
+@[deprecated (since := "2025-02-01")] alias nonsingular := equation_iff_nonsingular
 
 end Nonsingular
 
-section Ring
+section Negation
 
-/-! ### Group operation polynomials over a ring -/
+/-! ### Negation formulae -/
 
-/-- The polynomial $-Y - a_1X - a_3$ associated to negation. -/
+variable (W') in
+/-- The polynomial `-Y - a₁X - a₃` associated to negation. -/
 noncomputable def negPolynomial : R[X][Y] :=
-  -(Y : R[X][Y]) - C (C W.a₁ * X + C W.a₃)
+  -(Y : R[X][Y]) - C (C W'.a₁ * X + C W'.a₃)
 
-lemma Y_sub_polynomialY : Y - W.polynomialY = W.negPolynomial := by
-  rw [polynomialY, negPolynomial]; C_simp; ring
+lemma Y_sub_polynomialY : Y - W'.polynomialY = W'.negPolynomial := by
+  rw [polynomialY, negPolynomial]
+  C_simp
+  ring1
 
-lemma Y_sub_negPolynomial : Y - W.negPolynomial = W.polynomialY := by
+lemma Y_sub_negPolynomial : Y - W'.negPolynomial = W'.polynomialY := by
   rw [← Y_sub_polynomialY, sub_sub_cancel]
 
-/-- The $Y$-coordinate of the negation of an affine point in `W`.
-
-This depends on `W`, and has argument order: $x$, $y$. -/
+variable (W') in
+/-- The `Y`-coordinate of the negation of an affine point in `W`.
+This depends on `W`, and has argument order: `x`, `y`. -/
 @[simp]
 def negY (x y : R) : R :=
-  -y - W.a₁ * x - W.a₃
+  -y - W'.a₁ * x - W'.a₃
 
-lemma negY_negY (x y : R) : W.negY x (W.negY x y) = y := by
+lemma negY_negY (x y : R) : W'.negY x (W'.negY x y) = y := by
   simp only [negY]
   ring1
 
-lemma eval_negPolynomial (x y : R) : W.negPolynomial.evalEval x y = W.negY x y := by
+lemma eval_negPolynomial (x y : R) : W'.negPolynomial.evalEval x y = W'.negY x y := by
   rw [negY, sub_sub, negPolynomial]
   eval_simp
 
-/-- The polynomial $L(X - x) + y$ associated to the line $Y = L(X - x) + y$,
-with a slope of $L$ that passes through an affine point $(x, y)$.
+lemma Y_eq_of_X_eq {x₁ x₂ y₁ y₂ : F} (h₁ : W.Equation x₁ y₁) (h₂ : W.Equation x₂ y₂)
+    (hx : x₁ = x₂) : y₁ = y₂ ∨ y₁ = W.negY x₂ y₂ := by
+  rw [equation_iff] at h₁ h₂
+  rw [← sub_eq_zero, ← sub_eq_zero (a := y₁), ← mul_eq_zero, negY]
+  linear_combination (norm := (rw [hx]; ring1)) h₁ - h₂
 
-This does not depend on `W`, and has argument order: $x$, $y$, $L$. -/
-noncomputable def linePolynomial (x y L : R) : R[X] :=
-  C L * (X - C x) + C y
+lemma Y_eq_of_Y_ne {x₁ x₂ y₁ y₂ : F} (h₁ : W.Equation x₁ y₁) (h₂ : W.Equation x₂ y₂) (hx : x₁ = x₂)
+    (hy : y₁ ≠ W.negY x₂ y₂) : y₁ = y₂ :=
+  (Y_eq_of_X_eq h₁ h₂ hx).resolve_right hy
 
-/-- The polynomial obtained by substituting the line $Y = L*(X - x) + y$, with a slope of $L$
-that passes through an affine point $(x, y)$, into the polynomial $W(X, Y)$ associated to `W`.
-If such a line intersects `W` at another point $(x', y')$, then the roots of this polynomial are
-precisely $x$, $x'$, and the $X$-coordinate of the addition of $(x, y)$ and $(x', y')$.
-
-This depends on `W`, and has argument order: $x$, $y$, $L$. -/
-noncomputable def addPolynomial (x y L : R) : R[X] :=
-  W.polynomial.eval <| linePolynomial x y L
-
-lemma C_addPolynomial (x y L : R) : C (W.addPolynomial x y L) =
-    (Y - C (linePolynomial x y L)) * (W.negPolynomial - C (linePolynomial x y L)) +
-      W.polynomial := by
-  rw [addPolynomial, linePolynomial, polynomial, negPolynomial]
-  eval_simp
-  C_simp
-  ring1
-
-lemma addPolynomial_eq (x y L : R) : W.addPolynomial x y L = -Cubic.toPoly
-    ⟨1, -L ^ 2 - W.a₁ * L + W.a₂,
-      2 * x * L ^ 2 + (W.a₁ * x - 2 * y - W.a₃) * L + (-W.a₁ * y + W.a₄),
-      -x ^ 2 * L ^ 2 + (2 * x * y + W.a₃ * x) * L - (y ^ 2 + W.a₃ * y - W.a₆)⟩ := by
-  rw [addPolynomial, linePolynomial, polynomial, Cubic.toPoly]
-  eval_simp
-  C_simp
-  ring1
-
-/-- The $X$-coordinate of the addition of two affine points $(x_1, y_1)$ and $(x_2, y_2)$ in `W`,
-where the line through them is not vertical and has a slope of $L$.
-
-This depends on `W`, and has argument order: $x_1$, $x_2$, $L$. -/
-@[simp]
-def addX (x₁ x₂ L : R) : R :=
-  L ^ 2 + W.a₁ * L - W.a₂ - x₁ - x₂
-
-/-- The $Y$-coordinate of the negated addition of two affine points $(x_1, y_1)$ and $(x_2, y_2)$,
-where the line through them is not vertical and has a slope of $L$.
-
-This depends on `W`, and has argument order: $x_1$, $x_2$, $y_1$, $L$. -/
-@[simp]
-def negAddY (x₁ x₂ y₁ L : R) : R :=
-  L * (W.addX x₁ x₂ L - x₁) + y₁
-
-/-- The $Y$-coordinate of the addition of two affine points $(x_1, y_1)$ and $(x_2, y_2)$ in `W`,
-where the line through them is not vertical and has a slope of $L$.
-
-This depends on `W`, and has argument order: $x_1$, $x_2$, $y_1$, $L$. -/
-@[simp]
-def addY (x₁ x₂ y₁ L : R) : R :=
-  W.negY (W.addX x₁ x₂ L) (W.negAddY x₁ x₂ y₁ L)
-
-lemma equation_neg_iff (x y : R) : W.Equation x (W.negY x y) ↔ W.Equation x y := by
+/-- The negation of an affine point in `W` lies in `W`. -/
+lemma equation_neg (x y : R) : W'.Equation x (W'.negY x y) ↔ W'.Equation x y := by
   rw [equation_iff, equation_iff, negY]
   congr! 1
   ring1
 
-lemma nonsingular_neg_iff (x y : R) : W.Nonsingular x (W.negY x y) ↔ W.Nonsingular x y := by
-  rw [nonsingular_iff, equation_neg_iff, ← negY, negY_negY, ← @ne_comm _ y, nonsingular_iff]
+@[deprecated (since := "2025-02-01")] alias equation_neg_of := equation_neg
+@[deprecated (since := "2025-02-01")] alias equation_neg_iff := equation_neg
+
+/-- The negation of a nonsingular affine point in `W` is nonsingular. -/
+lemma nonsingular_neg (x y : R) : W'.Nonsingular x (W'.negY x y) ↔ W'.Nonsingular x y := by
+  rw [nonsingular_iff, equation_neg, ← negY, negY_negY, ← @ne_comm _ y, nonsingular_iff]
   exact and_congr_right' <| (iff_congr not_and_or.symm not_and_or.symm).mpr <|
     not_congr <| and_congr_left fun h => by rw [← h]
 
-lemma equation_add_iff (x₁ x₂ y₁ L : R) :
-    W.Equation (W.addX x₁ x₂ L) (W.negAddY x₁ x₂ y₁ L) ↔
-      (W.addPolynomial x₁ y₁ L).eval (W.addX x₁ x₂ L) = 0 := by
-  rw [Equation, negAddY, addPolynomial, linePolynomial, polynomial]
-  eval_simp
+@[deprecated (since := "2025-02-01")] alias nonsingular_neg_of := nonsingular_neg
+@[deprecated (since := "2025-02-01")] alias nonsingular_neg_iff := nonsingular_neg
 
-variable {W}
+end Negation
 
-lemma equation_neg_of {x y : R} (h : W.Equation x <| W.negY x y) : W.Equation x y :=
-  (W.equation_neg_iff ..).mp h
+section Slope
 
-/-- The negation of an affine point in `W` lies in `W`. -/
-lemma equation_neg {x y : R} (h : W.Equation x y) : W.Equation x <| W.negY x y :=
-  (W.equation_neg_iff ..).mpr h
+/-! ### Slope formulae -/
 
-lemma nonsingular_neg_of {x y : R} (h : W.Nonsingular x <| W.negY x y) : W.Nonsingular x y :=
-  (W.nonsingular_neg_iff ..).mp h
-
-/-- The negation of a nonsingular affine point in `W` is nonsingular. -/
-lemma nonsingular_neg {x y : R} (h : W.Nonsingular x y) : W.Nonsingular x <| W.negY x y :=
-  (W.nonsingular_neg_iff ..).mpr h
-
-lemma nonsingular_negAdd_of_eval_derivative_ne_zero {x₁ x₂ y₁ L : R}
-    (hx' : W.Equation (W.addX x₁ x₂ L) (W.negAddY x₁ x₂ y₁ L))
-    (hx : (W.addPolynomial x₁ y₁ L).derivative.eval (W.addX x₁ x₂ L) ≠ 0) :
-    W.Nonsingular (W.addX x₁ x₂ L) (W.negAddY x₁ x₂ y₁ L) := by
-  rw [Nonsingular, and_iff_right hx', negAddY, polynomialX, polynomialY]
-  eval_simp
-  contrapose! hx
-  rw [addPolynomial, linePolynomial, polynomial]
-  eval_simp
-  derivative_simp
-  simp only [zero_add, add_zero, sub_zero, zero_mul, mul_one]
-  eval_simp
-  linear_combination (norm := (norm_num1; ring1)) hx.left + L * hx.right
-
-end Ring
-
-section Field
-
-/-! ### Group operation polynomials over a field -/
+variable (W') in
+/-- The polynomial `ℓ(X - x) + y` associated to the line `Y = ℓ(X - x) + y`, with a slope of `ℓ`
+that passes through an affine point `(x, y)`.
+This does not depend on `W`, and has argument order: `x`, `y`, `ℓ`. -/
+noncomputable def linePolynomial (x y ℓ : R) : R[X] :=
+  C ℓ * (X - C x) + C y
 
 open Classical in
-/-- The slope of the line through two affine points $(x_1, y_1)$ and $(x_2, y_2)$ in `W`.
-If $x_1 \ne x_2$, then this line is the secant of `W` through $(x_1, y_1)$ and $(x_2, y_2)$,
-and has slope $(y_1 - y_2) / (x_1 - x_2)$. Otherwise, if $y_1 \ne -y_1 - a_1x_1 - a_3$,
-then this line is the tangent of `W` at $(x_1, y_1) = (x_2, y_2)$, and has slope
-$(3x_1^2 + 2a_2x_1 + a_4 - a_1y_1) / (2y_1 + a_1x_1 + a_3)$. Otherwise, this line is vertical,
-and has undefined slope, in which case this function returns the value 0.
-
-This depends on `W`, and has argument order: $x_1$, $x_2$, $y_1$, $y_2$. -/
-noncomputable def slope {F : Type u} [Field F] (W : Affine F) (x₁ x₂ y₁ y₂ : F) : F :=
+variable (W) in
+/-- The slope of the line through two affine points `(x₁, y₁)` and `(x₂, y₂)` in `W`. If `x₁ ≠ x₂`,
+then this line is the secant of `W` through `(x₁, y₁)` and `(x₂, y₂)`, and has slope
+`(y₁ - y₂) / (x₁ - x₂)`. Otherwise, if `y₁ ≠ -y₁ - a₁x₁ - a₃`, then this line is the tangent of `W`
+at `(x₁, y₁) = (x₂, y₂)`, and has slope `(3x₁² + 2a₂x₁ + a₄ - a₁y₁) / (2y₁ + a₁x₁ + a₃)`.
+Otherwise, this line is vertical, in which case this function returns the value `0`.
+This depends on `W`, and has argument order: `x₁`, `x₂`, `y₁`, `y₂`. -/
+noncomputable def slope (x₁ x₂ y₁ y₂ : F) : F :=
   if x₁ = x₂ then if y₁ = W.negY x₂ y₂ then 0
     else (3 * x₁ ^ 2 + 2 * W.a₂ * x₁ + W.a₄ - W.a₁ * y₁) / (y₁ - W.negY x₁ y₁)
   else (y₁ - y₂) / (x₁ - x₂)
-
-variable {F : Type u} [Field F] {W : Affine F}
 
 @[simp]
 lemma slope_of_Y_eq {x₁ x₂ y₁ y₂ : F} (hx : x₁ = x₂) (hy : y₁ = W.negY x₂ y₂) :
@@ -454,32 +409,79 @@ lemma slope_of_Y_ne_eq_eval {x₁ x₂ y₁ y₂ : F} (hx : x₁ = x₂) (hy : y
   rw [negY, evalEval_polynomialY]
   ring1
 
-lemma Y_eq_of_X_eq {x₁ x₂ y₁ y₂ : F} (h₁ : W.Equation x₁ y₁) (h₂ : W.Equation x₂ y₂)
-    (hx : x₁ = x₂) : y₁ = y₂ ∨ y₁ = W.negY x₂ y₂ := by
-  rw [equation_iff] at h₁ h₂
-  rw [← sub_eq_zero, ← sub_eq_zero (a := y₁), ← mul_eq_zero, negY]
-  linear_combination (norm := (rw [hx]; ring1)) h₁ - h₂
+end Slope
 
-lemma Y_eq_of_Y_ne {x₁ x₂ y₁ y₂ : F} (h₁ : W.Equation x₁ y₁) (h₂ : W.Equation x₂ y₂) (hx : x₁ = x₂)
-    (hy : y₁ ≠ W.negY x₂ y₂) : y₁ = y₂ :=
-  (Y_eq_of_X_eq h₁ h₂ hx).resolve_right hy
+section Addition
+
+/-! ### Addition formulae -/
+
+variable (W') in
+/-- The polynomial obtained by substituting the line `Y = ℓ*(X - x) + y`, with a slope of `ℓ` that
+passes through an affine point `(x, y)`, into the polynomial `W(X, Y)` associated to `W`. If such a
+line intersects `W` at another point `(x', y')`, then the roots of this polynomial are precisely
+`x`, `x'`, and the `X`-coordinate of the addition of `(x, y)` and `(x', y')`.
+This depends on `W`, and has argument order: `x`, `y`, `ℓ`. -/
+noncomputable def addPolynomial (x y ℓ : R) : R[X] :=
+  W'.polynomial.eval <| linePolynomial x y ℓ
+
+lemma C_addPolynomial (x y ℓ : R) : C (W'.addPolynomial x y ℓ) =
+    (Y - C (linePolynomial x y ℓ)) * (W'.negPolynomial - C (linePolynomial x y ℓ)) +
+      W'.polynomial := by
+  rw [addPolynomial, linePolynomial, polynomial, negPolynomial]
+  eval_simp
+  C_simp
+  ring1
+
+lemma addPolynomial_eq (x y ℓ : R) : W'.addPolynomial x y ℓ = -Cubic.toPoly
+    ⟨1, -ℓ ^ 2 - W'.a₁ * ℓ + W'.a₂,
+      2 * x * ℓ ^ 2 + (W'.a₁ * x - 2 * y - W'.a₃) * ℓ + (-W'.a₁ * y + W'.a₄),
+      -x ^ 2 * ℓ ^ 2 + (2 * x * y + W'.a₃ * x) * ℓ - (y ^ 2 + W'.a₃ * y - W'.a₆)⟩ := by
+  rw [addPolynomial, linePolynomial, polynomial, Cubic.toPoly]
+  eval_simp
+  C_simp
+  ring1
+
+variable (W') in
+/-- The `X`-coordinate of the addition of two affine points `(x₁, y₁)` and `(x₂, y₂)` in `W`, where
+the line through them is not vertical and has a slope of `ℓ`.
+This depends on `W`, and has argument order: `x₁`, `x₂`, `ℓ`. -/
+@[simp]
+def addX (x₁ x₂ ℓ : R) : R :=
+  ℓ ^ 2 + W'.a₁ * ℓ - W'.a₂ - x₁ - x₂
+
+variable (W') in
+/-- The `Y`-coordinate of the negated addition of two affine points `(x₁, y₁)` and `(x₂, y₂)`, where
+the line through them is not vertical and has a slope of `ℓ`.
+This depends on `W`, and has argument order: `x₁`, `x₂`, `y₁`, `ℓ`. -/
+@[simp]
+def negAddY (x₁ x₂ y₁ ℓ : R) : R :=
+  ℓ * (W'.addX x₁ x₂ ℓ - x₁) + y₁
+
+variable (W') in
+/-- The `Y`-coordinate of the addition of two affine points `(x₁, y₁)` and `(x₂, y₂)` in `W`, where
+the line through them is not vertical and has a slope of `ℓ`.
+This depends on `W`, and has argument order: `x₁`, `x₂`, `y₁`, `ℓ`. -/
+@[simp]
+def addY (x₁ x₂ y₁ ℓ : R) : R :=
+  W'.negY (W'.addX x₁ x₂ ℓ) (W'.negAddY x₁ x₂ y₁ ℓ)
 
 lemma addPolynomial_slope {x₁ x₂ y₁ y₂ : F} (h₁ : W.Equation x₁ y₁) (h₂ : W.Equation x₂ y₂)
-    (hxy : x₁ = x₂ → y₁ ≠ W.negY x₂ y₂) : W.addPolynomial x₁ y₁ (W.slope x₁ x₂ y₁ y₂) =
+    (hxy : ¬(x₁ = x₂ ∧ y₁ = W.negY x₂ y₂)) : W.addPolynomial x₁ y₁ (W.slope x₁ x₂ y₁ y₂) =
       -((X - C x₁) * (X - C x₂) * (X - C (W.addX x₁ x₂ <| W.slope x₁ x₂ y₁ y₂))) := by
   rw [addPolynomial_eq, neg_inj, Cubic.prod_X_sub_C_eq, Cubic.toPoly_injective]
   by_cases hx : x₁ = x₂
-  · rcases hx, Y_eq_of_Y_ne h₁ h₂ hx (hxy hx) with ⟨rfl, rfl⟩
+  · have hy : y₁ ≠ W.negY x₂ y₂ := fun h => hxy ⟨hx, h⟩
+    rcases hx, Y_eq_of_Y_ne h₁ h₂ hx hy with ⟨rfl, rfl⟩
     rw [equation_iff] at h₁ h₂
-    rw [slope_of_Y_ne rfl <| hxy rfl]
-    rw [negY, ← sub_ne_zero] at hxy
+    rw [slope_of_Y_ne rfl hy]
+    rw [negY, ← sub_ne_zero] at hy
     ext
     · rfl
     · simp only [addX]
       ring1
-    · field_simp [hxy rfl]
+    · field_simp [hy]
       ring1
-    · linear_combination (norm := (field_simp [hxy rfl]; ring1)) -h₁
+    · linear_combination (norm := (field_simp [hy]; ring1)) -h₁
   · rw [equation_iff] at h₁ h₂
     rw [slope_of_X_ne hx]
     rw [← sub_eq_zero] at hx
@@ -492,22 +494,14 @@ lemma addPolynomial_slope {x₁ x₂ y₁ y₂ : F} (h₁ : W.Equation x₁ y₁
     · apply mul_right_injective₀ hx
       linear_combination (norm := (field_simp [hx]; ring1)) x₂ * h₁ - x₁ * h₂
 
-/-- The negated addition of two affine points in `W` on a sloped line lies in `W`. -/
-lemma equation_negAdd {x₁ x₂ y₁ y₂ : F} (h₁ : W.Equation x₁ y₁) (h₂ : W.Equation x₂ y₂)
-    (hxy : x₁ = x₂ → y₁ ≠ W.negY x₂ y₂) : W.Equation
-      (W.addX x₁ x₂ <| W.slope x₁ x₂ y₁ y₂) (W.negAddY x₁ x₂ y₁ <| W.slope x₁ x₂ y₁ y₂) := by
-  rw [equation_add_iff, addPolynomial_slope h₁ h₂ hxy]
-  eval_simp
-  rw [neg_eq_zero, sub_self, mul_zero]
-
-/-- The addition of two affine points in `W` on a sloped line lies in `W`. -/
-lemma equation_add {x₁ x₂ y₁ y₂ : F} (h₁ : W.Equation x₁ y₁) (h₂ : W.Equation x₂ y₂)
-    (hxy : x₁ = x₂ → y₁ ≠ W.negY x₂ y₂) :
-    W.Equation (W.addX x₁ x₂ <| W.slope x₁ x₂ y₁ y₂) (W.addY x₁ x₂ y₁ <| W.slope x₁ x₂ y₁ y₂) :=
-  equation_neg <| equation_negAdd h₁ h₂ hxy
+lemma C_addPolynomial_slope {x₁ x₂ y₁ y₂ : F} (h₁ : W.Equation x₁ y₁) (h₂ : W.Equation x₂ y₂)
+    (hxy : ¬(x₁ = x₂ ∧ y₁ = W.negY x₂ y₂)) : C (W.addPolynomial x₁ y₁ <| W.slope x₁ x₂ y₁ y₂) =
+      -(C (X - C x₁) * C (X - C x₂) * C (X - C (W.addX x₁ x₂ <| W.slope x₁ x₂ y₁ y₂))) := by
+  rw [addPolynomial_slope h₁ h₂ hxy]
+  map_simp
 
 lemma derivative_addPolynomial_slope {x₁ x₂ y₁ y₂ : F} (h₁ : W.Equation x₁ y₁)
-    (h₂ : W.Equation x₂ y₂) (hxy : x₁ = x₂ → y₁ ≠ W.negY x₂ y₂) :
+    (h₂ : W.Equation x₂ y₂) (hxy : ¬(x₁ = x₂ ∧ y₁ = W.negY x₂ y₂)) :
     derivative (W.addPolynomial x₁ y₁ <| W.slope x₁ x₂ y₁ y₂) =
       -((X - C x₁) * (X - C x₂) + (X - C x₁) * (X - C (W.addX x₁ x₂ <| W.slope x₁ x₂ y₁ y₂)) +
           (X - C x₂) * (X - C (W.addX x₁ x₂ <| W.slope x₁ x₂ y₁ y₂))) := by
@@ -515,9 +509,42 @@ lemma derivative_addPolynomial_slope {x₁ x₂ y₁ y₂ : F} (h₁ : W.Equatio
   derivative_simp
   ring1
 
+lemma nonsingular_negAdd_of_eval_derivative_ne_zero {x₁ x₂ y₁ ℓ : R}
+    (hx' : W'.Equation (W'.addX x₁ x₂ ℓ) (W'.negAddY x₁ x₂ y₁ ℓ))
+    (hx : (W'.addPolynomial x₁ y₁ ℓ).derivative.eval (W'.addX x₁ x₂ ℓ) ≠ 0) :
+    W'.Nonsingular (W'.addX x₁ x₂ ℓ) (W'.negAddY x₁ x₂ y₁ ℓ) := by
+  rw [Nonsingular, and_iff_right hx', negAddY, polynomialX, polynomialY]
+  eval_simp
+  contrapose! hx
+  rw [addPolynomial, linePolynomial, polynomial]
+  eval_simp
+  derivative_simp
+  simp only [zero_add, add_zero, sub_zero, zero_mul, mul_one]
+  eval_simp
+  linear_combination (norm := (norm_num1; ring1)) hx.left + ℓ * hx.right
+
+lemma equation_add_iff (x₁ x₂ y₁ ℓ : R) : W'.Equation (W'.addX x₁ x₂ ℓ) (W'.negAddY x₁ x₂ y₁ ℓ) ↔
+    (W'.addPolynomial x₁ y₁ ℓ).eval (W'.addX x₁ x₂ ℓ) = 0 := by
+  rw [Equation, negAddY, addPolynomial, linePolynomial, polynomial]
+  eval_simp
+
+/-- The negated addition of two affine points in `W` on a sloped line lies in `W`. -/
+lemma equation_negAdd {x₁ x₂ y₁ y₂ : F} (h₁ : W.Equation x₁ y₁) (h₂ : W.Equation x₂ y₂)
+    (hxy : ¬(x₁ = x₂ ∧ y₁ = W.negY x₂ y₂)) : W.Equation
+      (W.addX x₁ x₂ <| W.slope x₁ x₂ y₁ y₂) (W.negAddY x₁ x₂ y₁ <| W.slope x₁ x₂ y₁ y₂) := by
+  rw [equation_add_iff, addPolynomial_slope h₁ h₂ hxy]
+  eval_simp
+  rw [neg_eq_zero, sub_self, mul_zero]
+
+/-- The addition of two affine points in `W` on a sloped line lies in `W`. -/
+lemma equation_add {x₁ x₂ y₁ y₂ : F} (h₁ : W.Equation x₁ y₁) (h₂ : W.Equation x₂ y₂)
+    (hxy : ¬(x₁ = x₂ ∧ y₁ = W.negY x₂ y₂)) :
+    W.Equation (W.addX x₁ x₂ <| W.slope x₁ x₂ y₁ y₂) (W.addY x₁ x₂ y₁ <| W.slope x₁ x₂ y₁ y₂) :=
+  (equation_neg ..).mpr <| equation_negAdd h₁ h₂ hxy
+
 /-- The negated addition of two nonsingular affine points in `W` on a sloped line is nonsingular. -/
 lemma nonsingular_negAdd {x₁ x₂ y₁ y₂ : F} (h₁ : W.Nonsingular x₁ y₁) (h₂ : W.Nonsingular x₂ y₂)
-    (hxy : x₁ = x₂ → y₁ ≠ W.negY x₂ y₂) : W.Nonsingular
+    (hxy : ¬(x₁ = x₂ ∧ y₁ = W.negY x₂ y₂)) : W.Nonsingular
       (W.addX x₁ x₂ <| W.slope x₁ x₂ y₁ y₂) (W.negAddY x₁ x₂ y₁ <| W.slope x₁ x₂ y₁ y₂) := by
   by_cases hx₁ : W.addX x₁ x₂ (W.slope x₁ x₂ y₁ y₂) = x₁
   · rwa [negAddY, hx₁, sub_self, mul_zero, zero_add]
@@ -527,130 +554,131 @@ lemma nonsingular_negAdd {x₁ x₂ y₁ y₂ : F} (h₁ : W.Nonsingular x₁ y�
         contradiction
       · rwa [negAddY, ← neg_sub, mul_neg, hx₂, slope_of_X_ne hx,
           div_mul_cancel₀ _ <| sub_ne_zero_of_ne hx, neg_sub, sub_add_cancel]
-    · apply nonsingular_negAdd_of_eval_derivative_ne_zero <| equation_negAdd h₁.1 h₂.1 hxy
+    · apply nonsingular_negAdd_of_eval_derivative_ne_zero <| equation_negAdd h₁.left h₂.left hxy
       rw [derivative_addPolynomial_slope h₁.left h₂.left hxy]
       eval_simp
-      simpa only [neg_ne_zero, sub_self, mul_zero, add_zero] using
-        mul_ne_zero (sub_ne_zero_of_ne hx₁) (sub_ne_zero_of_ne hx₂)
+      simp only [neg_ne_zero, sub_self, mul_zero, add_zero]
+      exact mul_ne_zero (sub_ne_zero_of_ne hx₁) (sub_ne_zero_of_ne hx₂)
 
 /-- The addition of two nonsingular affine points in `W` on a sloped line is nonsingular. -/
 lemma nonsingular_add {x₁ x₂ y₁ y₂ : F} (h₁ : W.Nonsingular x₁ y₁) (h₂ : W.Nonsingular x₂ y₂)
-    (hxy : x₁ = x₂ → y₁ ≠ W.negY x₂ y₂) :
+    (hxy : ¬(x₁ = x₂ ∧ y₁ = W.negY x₂ y₂)) :
     W.Nonsingular (W.addX x₁ x₂ <| W.slope x₁ x₂ y₁ y₂) (W.addY x₁ x₂ y₁ <| W.slope x₁ x₂ y₁ y₂) :=
-  nonsingular_neg <| nonsingular_negAdd h₁ h₂ hxy
+  (nonsingular_neg ..).mpr <| nonsingular_negAdd h₁ h₂ hxy
 
-variable {x₁ x₂ : F} (y₁ y₂ : F)
-
-/-- The formula x(P₁ + P₂) = x(P₁ - P₂) - ψ(P₁)ψ(P₂) / (x(P₂) - x(P₁))²,
-where ψ(x,y) = 2y + a₁x + a₃. -/
-lemma addX_eq_addX_negY_sub (hx : x₁ ≠ x₂) :
-    W.addX x₁ x₂ (W.slope x₁ x₂ y₁ y₂) = W.addX x₁ x₂ (W.slope x₁ x₂ y₁ (W.negY x₂ y₂))
-      - (y₁ - W.negY x₁ y₁) * (y₂ - W.negY x₂ y₂) / (x₂ - x₁) ^ 2 := by
+/-- The formula `x(P₁ + P₂) = x(P₁ - P₂) - ψ(P₁)ψ(P₂) / (x(P₂) - x(P₁))²`,
+where `ψ(x,y) = 2y + a₁x + a₃`. -/
+lemma addX_eq_addX_negY_sub {x₁ x₂ : F} (y₁ y₂ : F) (hx : x₁ ≠ x₂) :
+    W.addX x₁ x₂ (W.slope x₁ x₂ y₁ y₂) = W.addX x₁ x₂ (W.slope x₁ x₂ y₁ <| W.negY x₂ y₂) -
+      (y₁ - W.negY x₁ y₁) * (y₂ - W.negY x₂ y₂) / (x₂ - x₁) ^ 2 := by
   simp_rw [slope_of_X_ne hx, addX, negY, ← neg_sub x₁, neg_sq]
   field_simp [sub_ne_zero.mpr hx]
   ring1
 
-/-- The formula y(P₁)(x(P₂) - x(P₃)) + y(P₂)(x(P₃) - x(P₁)) + y(P₃)(x(P₁) - x(P₂)) = 0,
-assuming that P₁ + P₂ + P₃ = O. -/
-lemma cyclic_sum_Y_mul_X_sub_X (hx : x₁ ≠ x₂) :
-    letI x₃ := W.addX x₁ x₂ (W.slope x₁ x₂ y₁ y₂)
+/-- The formula `y(P₁)(x(P₂) - x(P₃)) + y(P₂)(x(P₃) - x(P₁)) + y(P₃)(x(P₁) - x(P₂)) = 0`,
+assuming that `P₁ + P₂ + P₃ = O`. -/
+lemma cyclic_sum_Y_mul_X_sub_X {x₁ x₂ : F} (y₁ y₂ : F) (hx : x₁ ≠ x₂) :
+    let x₃ := W.addX x₁ x₂ (W.slope x₁ x₂ y₁ y₂)
     y₁ * (x₂ - x₃) + y₂ * (x₃ - x₁) + W.negAddY x₁ x₂ y₁ (W.slope x₁ x₂ y₁ y₂) * (x₁ - x₂) = 0 := by
   simp_rw [slope_of_X_ne hx, negAddY, addX]
   field_simp [sub_ne_zero.mpr hx]
   ring1
 
-/-- The formula
-ψ(P₁ + P₂) = (ψ(P₂)(x(P₁) - x(P₃)) - ψ(P₁)(x(P₂) - x(P₃))) / (x(P₂) - x(P₁)),
-where ψ(x,y) = 2y + a₁x + a₃. -/
-lemma addY_sub_negY_addY (hx : x₁ ≠ x₂) :
-    letI x₃ := W.addX x₁ x₂ (W.slope x₁ x₂ y₁ y₂)
-    letI y₃ := W.addY x₁ x₂ y₁ (W.slope x₁ x₂ y₁ y₂)
+/-- The formula `ψ(P₁ + P₂) = (ψ(P₂)(x(P₁) - x(P₃)) - ψ(P₁)(x(P₂) - x(P₃))) / (x(P₂) - x(P₁))`,
+where `ψ(x,y) = 2y + a₁x + a₃`. -/
+lemma addY_sub_negY_addY {x₁ x₂ : F} (y₁ y₂ : F) (hx : x₁ ≠ x₂) :
+    let x₃ := W.addX x₁ x₂ (W.slope x₁ x₂ y₁ y₂)
+    let y₃ := W.addY x₁ x₂ y₁ (W.slope x₁ x₂ y₁ y₂)
     y₃ - W.negY x₃ y₃ =
       ((y₂ - W.negY x₂ y₂) * (x₁ - x₃) - (y₁ - W.negY x₁ y₁) * (x₂ - x₃)) / (x₂ - x₁) := by
   simp_rw [addY, negY, eq_div_iff (sub_ne_zero.mpr hx.symm)]
-  linear_combination 2 * cyclic_sum_Y_mul_X_sub_X y₁ y₂ hx
+  linear_combination (norm := ring1) 2 * cyclic_sum_Y_mul_X_sub_X y₁ y₂ hx
 
-end Field
+end Addition
 
 section Group
 
-/-! ### Group operations -/
+/-! ### Nonsingular points -/
 
-/-- A nonsingular rational point on a Weierstrass curve `W` in affine coordinates. This is either
-the unique point at infinity `WeierstrassCurve.Affine.Point.zero` or the nonsingular affine points
-`WeierstrassCurve.Affine.Point.some` $(x, y)$ satisfying the Weierstrass equation of `W`. -/
+variable (W') in
+/-- A nonsingular point on a Weierstrass curve `W` in affine coordinates. This is either the unique
+point at infinity `WeierstrassCurve.Affine.Point.zero` or the nonsingular affine points
+`WeierstrassCurve.Affine.Point.some` `(x, y)` satisfying the Weierstrass equation of `W`. -/
 inductive Point
   | zero
-  | some {x y : R} (h : W.Nonsingular x y)
+  | some {x y : R} (h : W'.Nonsingular x y)
 
-/-- For an algebraic extension `S` of `R`, the type of nonsingular `S`-rational points on `W`. -/
-scoped notation3:max W "⟮" S "⟯" => Affine.Point <| baseChange W S
+/-- For an algebraic extension `S` of `R`, the type of nonsingular `S`-points on `W`. -/
+scoped notation3:max W' "⟮" S "⟯" => Affine.Point <| baseChange W' S
 
 namespace Point
 
-variable {W}
+/-! ### Group operations -/
 
-instance : Inhabited W.Point :=
-  ⟨zero⟩
+instance : Inhabited W'.Point :=
+  ⟨.zero⟩
 
-instance : Zero W.Point :=
-  ⟨zero⟩
+instance : Zero W'.Point :=
+  ⟨.zero⟩
 
-lemma zero_def : (zero : W.Point) = 0 :=
+lemma zero_def : 0 = (.zero : W'.Point) :=
   rfl
 
-lemma some_ne_zero {x y : R} (h : W.Nonsingular x y) : some h ≠ 0 := by rintro (_|_)
+lemma some_ne_zero {x y : R} (h : W'.Nonsingular x y) : Point.some h ≠ 0 := by
+  rintro (_ | _)
 
-/-- The negation of a nonsingular rational point on `W`.
-
-Given a nonsingular rational point `P` on `W`, use `-P` instead of `neg P`. -/
-def neg : W.Point → W.Point
+/-- The negation of a nonsingular point on `W`.
+Given a nonsingular point `P` on `W`, use `-P` instead of `neg P`. -/
+def neg : W'.Point → W'.Point
   | 0 => 0
-  | some h => some <| nonsingular_neg h
+  | some h => some <| (nonsingular_neg ..).mpr h
 
-instance : Neg W.Point :=
+instance : Neg W'.Point :=
   ⟨neg⟩
 
-lemma neg_def (P : W.Point) : P.neg = -P :=
+lemma neg_def (P : W'.Point) : -P = P.neg :=
   rfl
 
 @[simp]
-lemma neg_zero : (-0 : W.Point) = 0 :=
+lemma neg_zero : (-0 : W'.Point) = 0 :=
   rfl
 
 @[simp]
-lemma neg_some {x y : R} (h : W.Nonsingular x y) : -some h = some (nonsingular_neg h) :=
+lemma neg_some {x y : R} (h : W'.Nonsingular x y) : -some h = some ((nonsingular_neg ..).mpr h) :=
   rfl
 
-instance : InvolutiveNeg W.Point :=
-  ⟨by rintro (_ | _) <;> simp [zero_def]; ring1⟩
-
-variable {F : Type u} [Field F] {W : Affine F}
+instance : InvolutiveNeg W'.Point where
+  neg_neg := by
+    rintro (_ | _)
+    · rfl
+    · simp only [neg_some, negY_negY]
 
 open Classical in
-/-- The addition of two nonsingular rational points on `W`.
-
-Given two nonsingular rational points `P` and `Q` on `W`, use `P + Q` instead of `add P Q`. -/
+/-- The addition of two nonsingular points on `W`.
+Given two nonsingular points `P` and `Q` on `W`, use `P + Q` instead of `add P Q`. -/
 noncomputable def add : W.Point → W.Point → W.Point
   | 0, P => P
   | P, 0 => P
   | @some _ _ _ x₁ y₁ h₁, @some _ _ _ x₂ y₂ h₂ =>
-    if h : x₁ = x₂ ∧ y₁ = W.negY x₂ y₂ then 0
-    else some (nonsingular_add h₁ h₂ fun hx hy ↦ h ⟨hx, hy⟩)
+    if hxy : x₁ = x₂ ∧ y₁ = W.negY x₂ y₂ then 0 else some <| nonsingular_add h₁ h₂ hxy
 
-noncomputable instance instAddPoint : Add W.Point :=
+noncomputable instance : Add W.Point :=
   ⟨add⟩
 
-lemma add_def (P Q : W.Point) : P.add Q = P + Q :=
+noncomputable instance : AddZeroClass W.Point :=
+  ⟨by rintro (_ | _) <;> rfl, by rintro (_ | _) <;> rfl⟩
+
+lemma add_def (P Q : W.Point) : P + Q = P.add Q :=
   rfl
 
-noncomputable instance instAddZeroClassPoint : AddZeroClass W.Point :=
-  ⟨by rintro (_ | _) <;> rfl, by rintro (_ | _) <;> rfl⟩
+lemma add_some {x₁ x₂ y₁ y₂ : F} (hxy : ¬(x₁ = x₂ ∧ y₁ = W.negY x₂ y₂)) {h₁ : W.Nonsingular x₁ y₁}
+    {h₂ : W.Nonsingular x₂ y₂} : some h₁ + some h₂ = some (nonsingular_add h₁ h₂ hxy) := by
+  simp only [add_def, add, dif_neg hxy]
 
 @[simp]
 lemma add_of_Y_eq {x₁ x₂ y₁ y₂ : F} {h₁ : W.Nonsingular x₁ y₁} {h₂ : W.Nonsingular x₂ y₂}
     (hx : x₁ = x₂) (hy : y₁ = W.negY x₂ y₂) : some h₁ + some h₂ = 0 := by
-  simp_rw [← add_def, add]; exact dif_pos ⟨hx, hy⟩
+  simpa only [add_def, add] using dif_pos ⟨hx, hy⟩
 
 @[simp]
 lemma add_self_of_Y_eq {x₁ y₁ : F} {h₁ : W.Nonsingular x₁ y₁} (hy : y₁ = W.negY x₁ y₁) :
@@ -658,37 +686,32 @@ lemma add_self_of_Y_eq {x₁ y₁ : F} {h₁ : W.Nonsingular x₁ y₁} (hy : y�
   add_of_Y_eq rfl hy
 
 @[simp]
-lemma add_of_imp {x₁ x₂ y₁ y₂ : F} {h₁ : W.Nonsingular x₁ y₁} {h₂ : W.Nonsingular x₂ y₂}
-    (hxy : x₁ = x₂ → y₁ ≠ W.negY x₂ y₂) : some h₁ + some h₂ = some (nonsingular_add h₁ h₂ hxy) :=
-  dif_neg fun hn ↦ hxy hn.1 hn.2
-
-@[simp]
 lemma add_of_Y_ne {x₁ x₂ y₁ y₂ : F} {h₁ : W.Nonsingular x₁ y₁} {h₂ : W.Nonsingular x₂ y₂}
     (hy : y₁ ≠ W.negY x₂ y₂) :
-    some h₁ + some h₂ = some (nonsingular_add h₁ h₂ fun _ ↦ hy) :=
-  add_of_imp fun _ ↦ hy
+    some h₁ + some h₂ = some (nonsingular_add h₁ h₂ fun hxy => hy hxy.right) :=
+  add_some fun hxy => hy hxy.right
 
 lemma add_of_Y_ne' {x₁ x₂ y₁ y₂ : F} {h₁ : W.Nonsingular x₁ y₁} {h₂ : W.Nonsingular x₂ y₂}
     (hy : y₁ ≠ W.negY x₂ y₂) :
-    some h₁ + some h₂ = -some (nonsingular_negAdd h₁ h₂ fun _ ↦ hy) :=
+    some h₁ + some h₂ = -some (nonsingular_negAdd h₁ h₂ fun hxy => hy hxy.right) :=
   add_of_Y_ne hy
 
 @[simp]
 lemma add_self_of_Y_ne {x₁ y₁ : F} {h₁ : W.Nonsingular x₁ y₁} (hy : y₁ ≠ W.negY x₁ y₁) :
-    some h₁ + some h₁ = some (nonsingular_add h₁ h₁ fun _ => hy) :=
+    some h₁ + some h₁ = some (nonsingular_add h₁ h₁ fun hxy => hy hxy.right) :=
   add_of_Y_ne hy
 
 lemma add_self_of_Y_ne' {x₁ y₁ : F} {h₁ : W.Nonsingular x₁ y₁} (hy : y₁ ≠ W.negY x₁ y₁) :
-    some h₁ + some h₁ = -some (nonsingular_negAdd h₁ h₁ fun _ => hy) :=
+    some h₁ + some h₁ = -some (nonsingular_negAdd h₁ h₁ fun hxy => hy hxy.right) :=
   add_of_Y_ne hy
 
 @[simp]
 lemma add_of_X_ne {x₁ x₂ y₁ y₂ : F} {h₁ : W.Nonsingular x₁ y₁} {h₂ : W.Nonsingular x₂ y₂}
-    (hx : x₁ ≠ x₂) : some h₁ + some h₂ = some (nonsingular_add h₁ h₂ fun h => (hx h).elim) :=
-  add_of_imp fun h ↦ (hx h).elim
+    (hx : x₁ ≠ x₂) : some h₁ + some h₂ = some (nonsingular_add h₁ h₂ fun hxy => hx hxy.left) :=
+  add_some fun hxy => hx hxy.left
 
 lemma add_of_X_ne' {x₁ x₂ y₁ y₂ : F} {h₁ : W.Nonsingular x₁ y₁} {h₂ : W.Nonsingular x₂ y₂}
-    (hx : x₁ ≠ x₂) : some h₁ + some h₂ = -some (nonsingular_negAdd h₁ h₂ fun h => (hx h).elim) :=
+    (hx : x₁ ≠ x₂) : some h₁ + some h₂ = -some (nonsingular_negAdd h₁ h₂ fun hxy => hx hxy.left) :=
   add_of_X_ne hx
 
 end Point
@@ -699,80 +722,73 @@ section Map
 
 /-! ### Maps across ring homomorphisms -/
 
-variable {S : Type v} [CommRing S] (f : R →+* S)
+variable (f : R →+* S) (x y x₁ y₁ x₂ y₂ ℓ : R)
 
-lemma map_polynomial : (W.map f).toAffine.polynomial = W.polynomial.map (mapRingHom f) := by
+lemma map_polynomial : (W'.map f).toAffine.polynomial = W'.polynomial.map (mapRingHom f) := by
   simp only [polynomial]
   map_simp
 
-lemma evalEval_baseChange_polynomial_X_Y :
-    (W.baseChange R[X][Y]).toAffine.polynomial.evalEval (C X) Y = W.polynomial := by
-  rw [baseChange, toAffine, map_polynomial, evalEval, eval_map, eval_C_X_eval₂_map_C_X]
-
-variable {W} in
-lemma Equation.map {x y : R} (h : W.Equation x y) : Equation (W.map f) (f x) (f y) := by
-  rw [Equation, map_polynomial, map_mapRingHom_evalEval, ← f.map_zero]; exact congr_arg f h
+variable {x y} in
+lemma Equation.map {x y : R} (h : W'.Equation x y) : (W'.map f).toAffine.Equation (f x) (f y) := by
+  rw [Equation, map_polynomial, map_mapRingHom_evalEval, h, map_zero]
 
 variable {f} in
-lemma map_equation (hf : Function.Injective f) (x y : R) :
-    (W.map f).toAffine.Equation (f x) (f y) ↔ W.Equation x y := by
+lemma map_equation (hf : Function.Injective f) :
+    (W'.map f).toAffine.Equation (f x) (f y) ↔ W'.Equation x y := by
   simp only [Equation, map_polynomial, map_mapRingHom_evalEval, map_eq_zero_iff f hf]
 
-lemma map_polynomialX : (W.map f).toAffine.polynomialX = W.polynomialX.map (mapRingHom f) := by
+lemma map_polynomialX : (W'.map f).toAffine.polynomialX = W'.polynomialX.map (mapRingHom f) := by
   simp only [polynomialX]
   map_simp
 
-lemma map_polynomialY : (W.map f).toAffine.polynomialY = W.polynomialY.map (mapRingHom f) := by
+lemma map_polynomialY : (W'.map f).toAffine.polynomialY = W'.polynomialY.map (mapRingHom f) := by
   simp only [polynomialY]
   map_simp
 
 variable {f} in
-lemma map_nonsingular (hf : Function.Injective f) (x y : R) :
-    (W.map f).toAffine.Nonsingular (f x) (f y) ↔ W.Nonsingular x y := by
-  simp only [Nonsingular, evalEval, W.map_equation hf, map_polynomialX,
-    map_polynomialY, map_mapRingHom_evalEval, map_ne_zero_iff f hf]
+lemma map_nonsingular (hf : Function.Injective f) :
+    (W'.map f).toAffine.Nonsingular (f x) (f y) ↔ W'.Nonsingular x y := by
+  simp only [Nonsingular, evalEval, map_equation _ _ hf, map_polynomialX, map_polynomialY,
+    map_mapRingHom_evalEval, map_ne_zero_iff f hf]
 
 lemma map_negPolynomial :
-    (W.map f).toAffine.negPolynomial = W.negPolynomial.map (mapRingHom f) := by
+    (W'.map f).toAffine.negPolynomial = W'.negPolynomial.map (mapRingHom f) := by
   simp only [negPolynomial]
   map_simp
 
-lemma map_negY (x y : R) : (W.map f).toAffine.negY (f x) (f y) = f (W.negY x y) := by
+lemma map_negY : (W'.map f).toAffine.negY (f x) (f y) = f (W'.negY x y) := by
   simp only [negY]
   map_simp
 
-lemma map_linePolynomial (x y L : R) :
-    linePolynomial (f x) (f y) (f L) = (linePolynomial x y L).map f := by
+lemma map_linePolynomial : linePolynomial (f x) (f y) (f ℓ) = (linePolynomial x y ℓ).map f := by
   simp only [linePolynomial]
   map_simp
 
-lemma map_addPolynomial (x y L : R) :
-    (W.map f).toAffine.addPolynomial (f x) (f y) (f L) = (W.addPolynomial x y L).map f := by
+lemma map_addPolynomial :
+    (W'.map f).toAffine.addPolynomial (f x) (f y) (f ℓ) = (W'.addPolynomial x y ℓ).map f := by
   rw [addPolynomial, map_polynomial, eval_map, linePolynomial, addPolynomial, ← coe_mapRingHom,
     ← eval₂_hom, linePolynomial]
   map_simp
 
-lemma map_addX (x₁ x₂ L : R) :
-    (W.map f).toAffine.addX (f x₁) (f x₂) (f L) = f (W.addX x₁ x₂ L) := by
+lemma map_addX : (W'.map f).toAffine.addX (f x₁) (f x₂) (f ℓ) = f (W'.addX x₁ x₂ ℓ) := by
   simp only [addX]
   map_simp
 
-lemma map_negAddY (x₁ x₂ y₁ L : R) :
-    (W.map f).toAffine.negAddY (f x₁) (f x₂) (f y₁) (f L) = f (W.negAddY x₁ x₂ y₁ L) := by
+lemma map_negAddY :
+    (W'.map f).toAffine.negAddY (f x₁) (f x₂) (f y₁) (f ℓ) = f (W'.negAddY x₁ x₂ y₁ ℓ) := by
   simp only [negAddY, map_addX]
   map_simp
 
-lemma map_addY (x₁ x₂ y₁ L : R) :
-    (W.map f).toAffine.addY (f x₁) (f x₂) (f y₁) (f L) = f (W.toAffine.addY x₁ x₂ y₁ L) := by
+lemma map_addY :
+    (W'.map f).toAffine.addY (f x₁) (f x₂) (f y₁) (f ℓ) = f (W'.toAffine.addY x₁ x₂ y₁ ℓ) := by
   simp only [addY, map_negAddY, map_addX, map_negY]
 
-lemma map_slope {F : Type u} [Field F] (W : Affine F) {K : Type v} [Field K] (f : F →+* K)
-    (x₁ x₂ y₁ y₂ : F) : (W.map f).toAffine.slope (f x₁) (f x₂) (f y₁) (f y₂) =
-      f (W.slope x₁ x₂ y₁ y₂) := by
+lemma map_slope (f : F →+* K) (x₁ x₂ y₁ y₂ : F) :
+    (W.map f).toAffine.slope (f x₁) (f x₂) (f y₁) (f y₂) = f (W.slope x₁ x₂ y₁ y₂) := by
   by_cases hx : x₁ = x₂
   · by_cases hy : y₁ = W.negY x₂ y₂
     · rw [slope_of_Y_eq (congr_arg f hx) <| by rw [hy, map_negY], slope_of_Y_eq hx hy, map_zero]
-    · rw [slope_of_Y_ne (congr_arg f hx) <| W.map_negY f x₂ y₂ ▸ fun h => hy <| f.injective h,
+    · rw [slope_of_Y_ne (congr_arg f hx) <| map_negY f x₂ y₂ ▸ fun h => hy <| f.injective h,
         map_negY, slope_of_Y_ne hx hy]
       map_simp
   · rw [slope_of_X_ne fun h => hx <| f.injective h, slope_of_X_ne hx]
@@ -784,108 +800,117 @@ section BaseChange
 
 /-! ### Base changes across algebra homomorphisms -/
 
-variable {R : Type r} [CommRing R] (W : Affine R) {S : Type s} [CommRing S] [Algebra R S]
-  {A : Type u} [CommRing A] [Algebra R A] [Algebra S A] [IsScalarTower R S A]
-  {B : Type v} [CommRing B] [Algebra R B] [Algebra S B] [IsScalarTower R S B] (f : A →ₐ[S] B)
+variable [Algebra R S] [Algebra R A] [Algebra S A] [IsScalarTower R S A] [Algebra R B] [Algebra S B]
+  [IsScalarTower R S B] (f : A →ₐ[S] B) (x y x₁ y₁ x₂ y₂ ℓ : A)
 
-lemma baseChange_polynomial : (W.baseChange B).toAffine.polynomial =
-    (W.baseChange A).toAffine.polynomial.map (mapRingHom f) := by
+lemma baseChange_polynomial : (W'.baseChange B).toAffine.polynomial =
+    (W'.baseChange A).toAffine.polynomial.map (mapRingHom f) := by
   rw [← map_polynomial, map_baseChange]
 
-lemma baseChange_equation (hf : Function.Injective f) (x y : A) :
-    (W.baseChange B).toAffine.Equation (f x) (f y) ↔ (W.baseChange A).toAffine.Equation x y := by
-  simp [← map_equation _ hf]
+lemma eval_baseChange_polynomial :
+    (W'.baseChange R[X][Y]).toAffine.polynomial.evalEval (C X) Y = W'.polynomial := by
+  rw [map_polynomial, evalEval, eval_map, eval_C_X_eval₂_map_C_X]
 
-lemma baseChange_polynomialX : (W.baseChange B).toAffine.polynomialX =
-    (W.baseChange A).toAffine.polynomialX.map (mapRingHom f) := by
+@[deprecated (since := "2025-02-01")] alias evalEval_baseChange_polynomial_X_Y :=
+  eval_baseChange_polynomial
+
+variable {x y} in
+lemma Equation.baseChange (h : (W'.baseChange A).toAffine.Equation x y) :
+    (W'.baseChange B).toAffine.Equation (f x) (f y) := by
+  convert Equation.map f.toRingHom h using 1
+  rw [AlgHom.toRingHom_eq_coe, map_baseChange]
+
+variable {f} in
+lemma baseChange_equation (hf : Function.Injective f) :
+    (W'.baseChange B).toAffine.Equation (f x) (f y) ↔ (W'.baseChange A).toAffine.Equation x y := by
+  rw [← map_equation _ _ hf, AlgHom.toRingHom_eq_coe, map_baseChange, RingHom.coe_coe]
+
+lemma baseChange_polynomialX : (W'.baseChange B).toAffine.polynomialX =
+    (W'.baseChange A).toAffine.polynomialX.map (mapRingHom f) := by
   rw [← map_polynomialX, map_baseChange]
 
-lemma baseChange_polynomialY : (W.baseChange B).toAffine.polynomialY =
-    (W.baseChange A).toAffine.polynomialY.map (mapRingHom f) := by
+lemma baseChange_polynomialY : (W'.baseChange B).toAffine.polynomialY =
+    (W'.baseChange A).toAffine.polynomialY.map (mapRingHom f) := by
   rw [← map_polynomialY, map_baseChange]
 
 variable {f} in
-lemma baseChange_nonsingular (hf : Function.Injective f) (x y : A) :
-    (W.baseChange B).toAffine.Nonsingular (f x) (f y) ↔
-      (W.baseChange A).toAffine.Nonsingular x y := by
-  simp [← map_nonsingular _ hf]
+lemma baseChange_nonsingular (hf : Function.Injective f) :
+    (W'.baseChange B).toAffine.Nonsingular (f x) (f y) ↔
+      (W'.baseChange A).toAffine.Nonsingular x y := by
+  rw [← map_nonsingular _ _ hf, AlgHom.toRingHom_eq_coe, map_baseChange, RingHom.coe_coe]
 
-lemma baseChange_negPolynomial :
-    (W.baseChange B).toAffine.negPolynomial =
-      (W.baseChange A).toAffine.negPolynomial.map (mapRingHom f) := by
+lemma baseChange_negPolynomial : (W'.baseChange B).toAffine.negPolynomial =
+    (W'.baseChange A).toAffine.negPolynomial.map (mapRingHom f) := by
   rw [← map_negPolynomial, map_baseChange]
 
-lemma baseChange_negY (x y : A) :
-    (W.baseChange B).toAffine.negY (f x) (f y) = f ((W.baseChange A).toAffine.negY x y) := by simp
+lemma baseChange_negY :
+    (W'.baseChange B).toAffine.negY (f x) (f y) = f ((W'.baseChange A).toAffine.negY x y) := by
+  rw [← RingHom.coe_coe, ← map_negY, map_baseChange]
 
-lemma baseChange_addPolynomial (x y L : A) :
-    (W.baseChange B).toAffine.addPolynomial (f x) (f y) (f L) =
-      ((W.baseChange A).toAffine.addPolynomial x y L).map f := by
-  rw [← map_addPolynomial, map_baseChange]
-  rfl
+lemma baseChange_addPolynomial : (W'.baseChange B).toAffine.addPolynomial (f x) (f y) (f ℓ) =
+    ((W'.baseChange A).toAffine.addPolynomial x y ℓ).map f := by
+  rw [← RingHom.coe_coe, ← map_addPolynomial, map_baseChange]
 
-lemma baseChange_addX (x₁ x₂ L : A) :
-    (W.baseChange B).toAffine.addX (f x₁) (f x₂) (f L) =
-      f ((W.baseChange A).toAffine.addX x₁ x₂ L) := by simp
+lemma baseChange_addX : (W'.baseChange B).toAffine.addX (f x₁) (f x₂) (f ℓ) =
+    f ((W'.baseChange A).toAffine.addX x₁ x₂ ℓ) := by
+  rw [← RingHom.coe_coe, ← map_addX, map_baseChange]
 
-lemma baseChange_negAddY (x₁ x₂ y₁ L : A) :
-    (W.baseChange B).toAffine.negAddY (f x₁) (f x₂) (f y₁) (f L) =
-      f ((W.baseChange A).toAffine.negAddY x₁ x₂ y₁ L) := by simp
+lemma baseChange_negAddY : (W'.baseChange B).toAffine.negAddY (f x₁) (f x₂) (f y₁) (f ℓ) =
+    f ((W'.baseChange A).toAffine.negAddY x₁ x₂ y₁ ℓ) := by
+  rw [← RingHom.coe_coe, ← map_negAddY, map_baseChange]
 
-lemma baseChange_addY (x₁ x₂ y₁ L : A) :
-    (W.baseChange B).toAffine.addY (f x₁) (f x₂) (f y₁) (f L) =
-      f ((W.baseChange A).toAffine.addY x₁ x₂ y₁ L) := by simp
+lemma baseChange_addY : (W'.baseChange B).toAffine.addY (f x₁) (f x₂) (f y₁) (f ℓ) =
+    f ((W'.baseChange A).toAffine.addY x₁ x₂ y₁ ℓ) := by
+  rw [← RingHom.coe_coe, ← map_addY, map_baseChange]
 
-variable {F : Type u} [Field F] [Algebra R F] [Algebra S F] [IsScalarTower R S F]
-  {K : Type v} [Field K] [Algebra R K] [Algebra S K] [IsScalarTower R S K] (f : F →ₐ[S] K)
-  {L : Type w} [Field L] [Algebra R L] [Algebra S L] [IsScalarTower R S L] (g : K →ₐ[S] L)
+lemma baseChange_slope [Algebra R F] [Algebra S F] [IsScalarTower R S F] [Algebra R K] [Algebra S K]
+  [IsScalarTower R S K] (f : F →ₐ[S] K) (x₁ x₂ y₁ y₂ : F) :
+  (W'.baseChange K).toAffine.slope (f x₁) (f x₂) (f y₁) (f y₂) =
+    f ((W'.baseChange F).toAffine.slope x₁ x₂ y₁ y₂) := by
+  rw [← RingHom.coe_coe, ← map_slope, map_baseChange]
 
-lemma baseChange_slope (x₁ x₂ y₁ y₂ : F) :
-    (W.baseChange K).toAffine.slope (f x₁) (f x₂) (f y₁) (f y₂) =
-      f ((W.baseChange F).toAffine.slope x₁ x₂ y₁ y₂) := by
-  rw [← f.coe_toRingHom, ← map_slope, map_baseChange]
+end BaseChange
 
 namespace Point
 
-/-- The function from `W⟮F⟯` to `W⟮K⟯` induced by an algebra homomorphism `f : F →ₐ[S] K`,
-where `W` is defined over a subring of a ring `S`, and `F` and `K` are field extensions of `S`. -/
-def mapFun : W⟮F⟯ → W⟮K⟯
-  | 0 => 0
-  | some h => some <| (W.baseChange_nonsingular f.injective ..).mpr h
+universe w
+
+variable {L : Type w} [Field L] [Algebra R S] [Algebra R F] [Algebra S F] [IsScalarTower R S F]
+  [Algebra R K] [Algebra S K] [IsScalarTower R S K] [Algebra R L] [Algebra S L]
+  [IsScalarTower R S L] (f : F →ₐ[S] K) (g : K →ₐ[S] L)
 
 /-- The group homomorphism from `W⟮F⟯` to `W⟮K⟯` induced by an algebra homomorphism `f : F →ₐ[S] K`,
 where `W` is defined over a subring of a ring `S`, and `F` and `K` are field extensions of `S`. -/
-def map : W⟮F⟯ →+ W⟮K⟯ where
-  toFun := mapFun W f
+def map : W'⟮F⟯ →+ W'⟮K⟯ where
+  toFun P := match P with
+    | 0 => 0
+    | some h => some <| (baseChange_nonsingular _ _ f.injective).mpr h
   map_zero' := rfl
   map_add' := by
     rintro (_ | @⟨x₁, y₁, _⟩) (_ | @⟨x₂, y₂, _⟩)
     any_goals rfl
-    have inj : Function.Injective f := f.injective
-    by_cases h : x₁ = x₂ ∧ y₁ = negY (W.baseChange F) x₂ y₂
-    · simp only [add_of_Y_eq h.1 h.2, mapFun]
-      rw [add_of_Y_eq congr(f $(h.1))]
-      rw [baseChange_negY, inj.eq_iff]
-      exact h.2
-    · simp only [add_of_imp fun hx hy ↦ h ⟨hx, hy⟩, mapFun]
-      rw [add_of_imp]
-      · simp only [some.injEq, ← baseChange_addX, ← baseChange_addY, ← baseChange_slope]
-      · push_neg at h; rwa [baseChange_negY, inj.eq_iff, inj.ne_iff]
+    by_cases hxy : x₁ = x₂ ∧ y₁ = (W'.baseChange F).toAffine.negY x₂ y₂
+    · rw [add_of_Y_eq hxy.left hxy.right,
+        add_of_Y_eq (congr_arg _ hxy.left) <| by rw [hxy.right, baseChange_negY]]
+    · simp_rw [add_some hxy, ← baseChange_addX, ← baseChange_addY, ← baseChange_slope]
+      rw [add_some fun h => hxy ⟨f.injective h.1, f.injective (W'.baseChange_negY f .. ▸ h).2⟩]
 
-lemma map_zero : map W f (0 : W⟮F⟯) = 0 :=
+@[deprecated (since := "2025-02-01")] alias mapFun := map
+
+lemma map_zero : map f (0 : W'⟮F⟯) = 0 :=
   rfl
 
-lemma map_some {x y : F} (h : (W.baseChange F).toAffine.Nonsingular x y) :
-    map W f (some h) = some ((W.baseChange_nonsingular f.injective ..).mpr h) :=
+lemma map_some {x y : F} (h : (W'.baseChange F).toAffine.Nonsingular x y) :
+    map f (some h) = some ((W'.baseChange_nonsingular _ _ f.injective).mpr h) :=
   rfl
 
-lemma map_id (P : W⟮F⟯) : map W (Algebra.ofId F F) P = P := by
+lemma map_id (P : W'⟮F⟯) : map (Algebra.ofId F F) P = P := by
   cases P <;> rfl
 
-lemma map_map (P : W⟮F⟯) : map W g (map W f P) = map W (g.comp f) P := by
+lemma map_map (P : W'⟮F⟯) : map g (map f P) = map (g.comp f) P := by
   cases P <;> rfl
 
-lemma map_injective : Function.Injective <| map W f := by
+lemma map_injective : Function.Injective <| map (W' := W') f := by
   rintro (_ | _) (_ | _) h
   any_goals contradiction
   · rfl
@@ -894,28 +919,16 @@ lemma map_injective : Function.Injective <| map W f := by
 variable (F K) in
 /-- The group homomorphism from `W⟮F⟯` to `W⟮K⟯` induced by the base change from `F` to `K`,
 where `W` is defined over a subring of a ring `S`, and `F` and `K` are field extensions of `S`. -/
-abbrev baseChange [Algebra F K] [IsScalarTower R F K] : W⟮F⟯ →+ W⟮K⟯ :=
-  map W <| Algebra.ofId F K
+abbrev baseChange [Algebra F K] [IsScalarTower R F K] : W'⟮F⟯ →+ W'⟮K⟯ :=
+  map <| Algebra.ofId F K
 
 lemma map_baseChange [Algebra F K] [IsScalarTower R F K] [Algebra F L] [IsScalarTower R F L]
-    (f : K →ₐ[F] L) (P : W⟮F⟯) : map W f (baseChange W F K P) = baseChange W F L P := by
+    (f : K →ₐ[F] L) (P : W'⟮F⟯) : map f (baseChange F K P) = baseChange F L P := by
   have : Subsingleton (F →ₐ[F] L) := inferInstance
-  convert map_map W (Algebra.ofId F K) f P
+  convert map_map (Algebra.ofId F K) f P
 
 end Point
 
-end BaseChange
+end Affine
 
-/-! ## Elliptic curves -/
-
-section EllipticCurve
-
-variable {R : Type u} [CommRing R] (E : WeierstrassCurve R) [E.IsElliptic]
-
-lemma nonsingular [Nontrivial R] {x y : R} (h : E.toAffine.Equation x y) :
-    E.toAffine.Nonsingular x y :=
-  E.toAffine.nonsingular_of_Δ_ne_zero h <| E.coe_Δ' ▸ E.Δ'.ne_zero
-
-end EllipticCurve
-
-end WeierstrassCurve.Affine
+end WeierstrassCurve

--- a/Mathlib/AlgebraicGeometry/EllipticCurve/Group.lean
+++ b/Mathlib/AlgebraicGeometry/EllipticCurve/Group.lean
@@ -214,7 +214,7 @@ lemma map_injective (hf : Function.Injective f) : Function.Injective <| map W f 
 
 instance [IsDomain R] : IsDomain W.CoordinateRing :=
   have : IsDomain (W.map <| algebraMap R <| FractionRing R).toAffine.CoordinateRing :=
-    AdjoinRoot.isDomain_of_prime (irreducible_polynomial _).prime
+    AdjoinRoot.isDomain_of_prime irreducible_polynomial.prime
   (map_injective W <| IsFractionRing.injective R <| FractionRing R).isDomain
 
 end Algebra
@@ -291,18 +291,19 @@ section Field
 variable {F : Type u} [Field F] {W : Affine F}
 
 lemma C_addPolynomial_slope {x₁ x₂ y₁ y₂ : F} (h₁ : W.Equation x₁ y₁) (h₂ : W.Equation x₂ y₂)
-    (hxy : x₁ = x₂ → y₁ ≠ W.negY x₂ y₂) : mk W (C <| W.addPolynomial x₁ y₁ <| W.slope x₁ x₂ y₁ y₂) =
-      -(XClass W x₁ * XClass W x₂ * XClass W (W.addX x₁ x₂ <| W.slope x₁ x₂ y₁ y₂)) := by
-  simp only [addPolynomial_slope h₁ h₂ hxy, C_neg, mk, map_neg, neg_inj, _root_.map_mul]
-  rfl
+    (hxy : ¬(x₁ = x₂ ∧ y₁ = W.negY x₂ y₂)) :
+    mk W (C <| W.addPolynomial x₁ y₁ <| W.slope x₁ x₂ y₁ y₂) =
+      -(XClass W x₁ * XClass W x₂ * XClass W (W.addX x₁ x₂ <| W.slope x₁ x₂ y₁ y₂)) :=
+  congr_arg (mk W) <| W.C_addPolynomial_slope h₁ h₂ hxy
 
 lemma XYIdeal_eq₂ {x₁ x₂ y₁ y₂ : F} (h₁ : W.Equation x₁ y₁)
-    (h₂ : W.Equation x₂ y₂) (hxy : x₁ = x₂ → y₁ ≠ W.negY x₂ y₂) :
+    (h₂ : W.Equation x₂ y₂) (hxy : ¬(x₁ = x₂ ∧ y₁ = W.negY x₂ y₂)) :
     XYIdeal W x₂ (C y₂) = XYIdeal W x₂ (linePolynomial x₁ y₁ <| W.slope x₁ x₂ y₁ y₂) := by
   have hy₂ : y₂ = (linePolynomial x₁ y₁ <| W.slope x₁ x₂ y₁ y₂).eval x₂ := by
     by_cases hx : x₁ = x₂
-    · rcases hx, Y_eq_of_Y_ne h₁ h₂ hx <| hxy hx with ⟨rfl, rfl⟩
-      field_simp [linePolynomial, sub_ne_zero_of_ne <| hxy rfl]
+    · have hy : y₁ ≠ W.negY x₂ y₂ := fun h => hxy ⟨hx, h⟩
+      rcases hx, Y_eq_of_Y_ne h₁ h₂ hx hy with ⟨rfl, rfl⟩
+      field_simp [linePolynomial, sub_ne_zero_of_ne hy]
     · field_simp [linePolynomial, slope_of_X_ne hx, sub_ne_zero_of_ne hx]
       ring1
   nth_rw 1 [hy₂]
@@ -351,7 +352,7 @@ private lemma XYIdeal'_mul_inv {x y : F} (h : W.Nonsingular x y) :
     XIdeal, FractionalIdeal.coe_ideal_span_singleton_mul_inv W.FunctionField <| XClass_ne_zero W x]
 
 lemma XYIdeal_mul_XYIdeal {x₁ x₂ y₁ y₂ : F} (h₁ : W.Equation x₁ y₁) (h₂ : W.Equation x₂ y₂)
-    (hxy : x₁ = x₂ → y₁ ≠ W.negY x₂ y₂) :
+    (hxy : ¬(x₁ = x₂ ∧ y₁ = W.negY x₂ y₂)) :
     XIdeal W (W.addX x₁ x₂ <| W.slope x₁ x₂ y₁ y₂) * (XYIdeal W x₁ (C y₁) * XYIdeal W x₂ (C y₂)) =
       YIdeal W (linePolynomial x₁ y₁ <| W.slope x₁ x₂ y₁ y₂) *
         XYIdeal W (W.addX x₁ x₂ <| W.slope x₁ x₂ y₁ y₂)
@@ -374,9 +375,10 @@ lemma XYIdeal_mul_XYIdeal {x₁ x₂ y₁ y₂ : F} (h₁ : W.Equation x₁ y₁
     mem_map_iff_of_surjective _ AdjoinRoot.mk_surjective, ← span_insert, mem_span_insert',
     mem_span_singleton']
   by_cases hx : x₁ = x₂
-  · rcases hx, Y_eq_of_Y_ne h₁ h₂ hx (hxy hx) with ⟨rfl, rfl⟩
+  · have hy : y₁ ≠ W.negY x₂ y₂ := fun h => hxy ⟨hx, h⟩
+    rcases hx, Y_eq_of_Y_ne h₁ h₂ hx hy with ⟨rfl, rfl⟩
     let y := (y₁ - W.negY x₁ y₁) ^ 2
-    replace hxy := pow_ne_zero 2 <| sub_ne_zero_of_ne <| hxy rfl
+    replace hxy := pow_ne_zero 2 <| sub_ne_zero_of_ne hy
     refine ⟨1 + C (C <| y⁻¹ * 4) * W.polynomial,
       ⟨C <| C y⁻¹ * (C 4 * X ^ 2 + C (4 * x₁ + W.b₂) * X + C (4 * x₁ ^ 2 + W.b₂ * x₁ + 2 * W.b₄)),
         0, C (C y⁻¹) * (Y - W.negPolynomial), ?_⟩, by
@@ -401,21 +403,23 @@ lemma XYIdeal'_eq {x y : F} (h : W.Nonsingular x y) :
     (XYIdeal' h : FractionalIdeal W.CoordinateRing⁰ W.FunctionField) = XYIdeal W x (C y) :=
   rfl
 
-lemma mk_XYIdeal'_mul_mk_XYIdeal'_of_Yeq {x y : F} (h : W.Nonsingular x y) :
-    ClassGroup.mk (XYIdeal' <| nonsingular_neg h) * ClassGroup.mk (XYIdeal' h) = 1 := by
+lemma mk_XYIdeal'_neg_mul {x y : F} (h : W.Nonsingular x y) :
+    ClassGroup.mk (XYIdeal' <| (nonsingular_neg ..).mpr h) * ClassGroup.mk (XYIdeal' h) = 1 := by
   rw [← _root_.map_mul]
-  exact
-    (ClassGroup.mk_eq_one_of_coe_ideal <| by exact (FractionalIdeal.coeIdeal_mul ..).symm.trans <|
-      FractionalIdeal.coeIdeal_inj.mpr <| XYIdeal_neg_mul h).mpr ⟨_, XClass_ne_zero W _, rfl⟩
+  exact (ClassGroup.mk_eq_one_of_coe_ideal <| (FractionalIdeal.coeIdeal_mul ..).symm.trans <|
+    FractionalIdeal.coeIdeal_inj.mpr <| XYIdeal_neg_mul h).mpr ⟨_, XClass_ne_zero W _, rfl⟩
+
+@[deprecated (since := "2025-02-01")] alias mk_XYIdeal'_mul_mk_XYIdeal'_of_Yeq :=
+  mk_XYIdeal'_neg_mul
 
 lemma mk_XYIdeal'_mul_mk_XYIdeal' {x₁ x₂ y₁ y₂ : F} (h₁ : W.Nonsingular x₁ y₁)
-    (h₂ : W.Nonsingular x₂ y₂) (hxy : x₁ = x₂ → y₁ ≠ W.negY x₂ y₂) :
+    (h₂ : W.Nonsingular x₂ y₂) (hxy : ¬(x₁ = x₂ ∧ y₁ = W.negY x₂ y₂)) :
     ClassGroup.mk (XYIdeal' h₁) * ClassGroup.mk (XYIdeal' h₂) =
       ClassGroup.mk (XYIdeal' <| nonsingular_add h₁ h₂ hxy) := by
   rw [← _root_.map_mul]
-  exact (ClassGroup.mk_eq_mk_of_coe_ideal (by exact (FractionalIdeal.coeIdeal_mul ..).symm) <|
-      XYIdeal'_eq _).mpr
-    ⟨_, _, XClass_ne_zero W _, YClass_ne_zero W _, XYIdeal_mul_XYIdeal h₁.left h₂.left hxy⟩
+  exact
+    (ClassGroup.mk_eq_mk_of_coe_ideal (FractionalIdeal.coeIdeal_mul ..).symm <| XYIdeal'_eq _).mpr
+      ⟨_, _, XClass_ne_zero W _, YClass_ne_zero W _, XYIdeal_mul_XYIdeal h₁.left h₂.left hxy⟩
 
 end Field
 
@@ -499,28 +503,24 @@ namespace Point
 
 variable {F : Type u} [Field F] {W : Affine F}
 
-/-- The set function mapping an affine point $(x, y)$ of `W` to the class of the non-zero fractional
-ideal $\langle X - x, Y - y \rangle$ of $F(W)$ in the class group of $F[W]$. -/
-@[simp]
-noncomputable def toClassFun : W.Point → Additive (ClassGroup W.CoordinateRing)
-  | 0 => 0
-  | some h => Additive.ofMul <| ClassGroup.mk <| CoordinateRing.XYIdeal' h
-
 /-- The group homomorphism mapping an affine point $(x, y)$ of `W` to the class of the non-zero
 fractional ideal $\langle X - x, Y - y \rangle$ of $F(W)$ in the class group of $F[W]$. -/
 @[simps]
 noncomputable def toClass : W.Point →+ Additive (ClassGroup W.CoordinateRing) where
-  toFun := toClassFun
+  toFun P := match P with
+    | 0 => 0
+    | some h => Additive.ofMul <| ClassGroup.mk <| CoordinateRing.XYIdeal' h
   map_zero' := rfl
   map_add' := by
     rintro (_ | @⟨x₁, y₁, h₁⟩) (_ | @⟨x₂, y₂, h₂⟩)
-    any_goals simp only [zero_def, toClassFun, zero_add, add_zero]
-    obtain ⟨rfl, rfl⟩ | h := em (x₁ = x₂ ∧ y₁ = W.negY x₂ y₂)
-    · rw [add_of_Y_eq rfl rfl]
-      exact (CoordinateRing.mk_XYIdeal'_mul_mk_XYIdeal'_of_Yeq h₂).symm
-    · have h hx hy := h ⟨hx, hy⟩
-      rw [add_of_imp h]
-      exact (CoordinateRing.mk_XYIdeal'_mul_mk_XYIdeal' h₁ h₂ h).symm
+    any_goals simp only [← zero_def, zero_add, add_zero]
+    by_cases hxy : x₁ = x₂ ∧ y₁ = W.negY x₂ y₂
+    · simp only [hxy.left, hxy.right, add_of_Y_eq rfl rfl]
+      exact (CoordinateRing.mk_XYIdeal'_neg_mul h₂).symm
+    · simp only [add_some hxy]
+      exact (CoordinateRing.mk_XYIdeal'_mul_mk_XYIdeal' h₁ h₂ hxy).symm
+
+@[deprecated (since := "2025-02-01")] alias toClassFun := toClass
 
 lemma toClass_zero : toClass (0 : W.Point) = 0 :=
   rfl
@@ -532,11 +532,12 @@ lemma toClass_some {x y : F} (h : W.Nonsingular x y) :
 private lemma add_eq_zero (P Q : W.Point) : P + Q = 0 ↔ P = -Q := by
   rcases P, Q with ⟨_ | @⟨x₁, y₁, _⟩, _ | @⟨x₂, y₂, _⟩⟩
   any_goals rfl
-  · rw [zero_def, zero_add, ← neg_eq_iff_eq_neg, neg_zero, eq_comm]
+  · rw [← zero_def, zero_add, eq_comm (a := 0), neg_eq_iff_eq_neg, neg_zero]
   · rw [neg_some, some.injEq]
     constructor
-    · contrapose!; intro h; rw [add_of_imp h]; exact some_ne_zero _
-    · exact fun ⟨hx, hy⟩ ↦ add_of_Y_eq hx hy
+    · contrapose
+      exact fun hxy => by simpa only [add_some hxy] using some_ne_zero _
+    · exact fun ⟨hx, hy⟩ => add_of_Y_eq hx hy
 
 lemma toClass_eq_zero (P : W.Point) : toClass P = 0 ↔ P = 0 := by
   constructor
@@ -547,15 +548,14 @@ lemma toClass_eq_zero (P : W.Point) : toClass P = 0 ↔ P = 0 := by
       apply (p.natDegree_norm_ne_one _).elim
       rw [← finrank_quotient_span_eq_natDegree_norm (CoordinateRing.basis W) h0,
         ← (quotientEquivAlgOfEq F hp).toLinearEquiv.finrank_eq,
-        (CoordinateRing.quotientXYIdealEquiv W h).toLinearEquiv.finrank_eq,
-        Module.finrank_self]
+        (CoordinateRing.quotientXYIdealEquiv W h).toLinearEquiv.finrank_eq, Module.finrank_self]
   · exact congr_arg toClass
 
 lemma toClass_injective : Function.Injective <| @toClass _ _ W := by
   rintro (_ | h) _ hP
   all_goals rw [← neg_inj, ← add_eq_zero, ← toClass_eq_zero, map_add, ← hP]
   · exact zero_add 0
-  · exact CoordinateRing.mk_XYIdeal'_mul_mk_XYIdeal'_of_Yeq h
+  · exact CoordinateRing.mk_XYIdeal'_neg_mul h
 
 noncomputable instance : AddCommGroup W.Point where
   nsmul := nsmulRec
@@ -618,6 +618,6 @@ variable {R : Type*} [Nontrivial R] [CommRing R] (E : WeierstrassCurve R) [E.IsE
 
 /-- An affine point on an elliptic curve `E` over `R`. -/
 def mk {x y : R} (h : E.toAffine.Equation x y) : E.toAffine.Point :=
-  WeierstrassCurve.Affine.Point.some <| nonsingular E h
+  .some <| (equation_iff_nonsingular ..).mp h
 
 end WeierstrassCurve.Affine.Point

--- a/Mathlib/AlgebraicGeometry/EllipticCurve/Jacobian.lean
+++ b/Mathlib/AlgebraicGeometry/EllipticCurve/Jacobian.lean
@@ -1309,13 +1309,13 @@ lemma add_of_X_ne {P Q : Fin 3 → F} (hP : W.Equation P) (hQ : W.Equation Q) (h
 
 private lemma nonsingular_add_of_Z_ne_zero {P Q : Fin 3 → F} (hP : W.Nonsingular P)
     (hQ : W.Nonsingular Q) (hPz : P z ≠ 0) (hQz : Q z ≠ 0)
-    (hxy : ¬(P x * Q z ^ 2 = Q x * P z ^ 2 ∧ P y * Q z ^ 3 = W.negY Q * P z ^ 3)) : W.Nonsingular
+    (hxy : P x * Q z ^ 2 = Q x * P z ^ 2 → P y * Q z ^ 3 ≠ W.negY Q * P z ^ 3) : W.Nonsingular
       ![W.toAffine.addX (P x / P z ^ 2) (Q x / Q z ^ 2)
           (W.toAffine.slope (P x / P z ^ 2) (Q x / Q z ^ 2) (P y / P z ^ 3) (Q y / Q z ^ 3)),
         W.toAffine.addY (P x / P z ^ 2) (Q x / Q z ^ 2) (P y / P z ^ 3)
           (W.toAffine.slope (P x / P z ^ 2) (Q x / Q z ^ 2) (P y / P z ^ 3) (Q y / Q z ^ 3)), 1] :=
   (nonsingular_some ..).mpr <| Affine.nonsingular_add ((nonsingular_of_Z_ne_zero hPz).mp hP)
-    ((nonsingular_of_Z_ne_zero hQz).mp hQ) <| by rwa [← X_eq_iff hPz hQz, ← Y_eq_iff' hPz hQz]
+    ((nonsingular_of_Z_ne_zero hQz).mp hQ) (by rwa [← X_eq_iff hPz hQz, ne_eq, ← Y_eq_iff' hPz hQz])
 
 lemma nonsingular_add {P Q : Fin 3 → F} (hP : W.Nonsingular P) (hQ : W.Nonsingular Q) :
     W.Nonsingular <| W.add P Q := by
@@ -1328,18 +1328,20 @@ lemma nonsingular_add {P Q : Fin 3 → F} (hP : W.Nonsingular P) (hQ : W.Nonsing
   · by_cases hQz : Q z = 0
     · simpa only [add_of_Z_eq_zero_right hQ.left hPz hQz,
         nonsingular_smul _ ((isUnit_X_of_Z_eq_zero hQ hQz).mul <| Ne.isUnit hPz).neg]
-    · by_cases hxy : P x * Q z ^ 2 = Q x * P z ^ 2 ∧ P y * Q z ^ 3 = W.negY Q * P z ^ 3
-      · by_cases hy : P y * Q z ^ 3 = Q y * P z ^ 3
+    · by_cases hxy : P x * Q z ^ 2 = Q x * P z ^ 2 → P y * Q z ^ 3 ≠ W.negY Q * P z ^ 3
+      · by_cases hx : P x * Q z ^ 2 = Q x * P z ^ 2
+        · simp only [add_of_Y_ne' hP.left hQ.left hPz hQz hx <| hxy hx,
+            nonsingular_smul _ <| isUnit_dblZ_of_Y_ne' hP.left hQ.left hPz hx <| hxy hx,
+            nonsingular_add_of_Z_ne_zero hP hQ hPz hQz hxy]
+        · simp only [add_of_X_ne hP.left hQ.left hPz hQz hx,
+            nonsingular_smul _ <| isUnit_addZ_of_X_ne hx,
+            nonsingular_add_of_Z_ne_zero hP hQ hPz hQz hxy]
+      · rw [_root_.not_imp, not_ne_iff] at hxy
+        by_cases hy : P y * Q z ^ 3 = Q y * P z ^ 3
         · simp only [add_of_Y_eq hPz hQz hxy.left hy hxy.right, nonsingular_smul _ <|
               isUnit_dblU_of_Y_eq hP hPz hQz hxy.left hy hxy.right, nonsingular_zero]
         · simp only [add_of_Y_ne hP.left hQ.left hPz hQz hxy.left hy,
             nonsingular_smul _ <| isUnit_addU_of_Y_ne hPz hQz hy, nonsingular_zero]
-      · have := nonsingular_add_of_Z_ne_zero hP hQ hPz hQz hxy
-        by_cases hx : P x * Q z ^ 2 = Q x * P z ^ 2
-        · simpa only [add_of_Y_ne' hP.left hQ.left hPz hQz hx <| not_and.mp hxy hx,
-            nonsingular_smul _ <| isUnit_dblZ_of_Y_ne' hP.left hQ.left hPz hx <| not_and.mp hxy hx]
-        · simpa only [add_of_X_ne hP.left hQ.left hPz hQz hx,
-            nonsingular_smul _ <| isUnit_addZ_of_X_ne hx]
 
 variable (W') in
 /-- The addition of two point classes. If `P` is a point representative,
@@ -1382,7 +1384,7 @@ lemma addMap_of_Y_eq {P Q : Fin 3 → F} (hP : W.Nonsingular P) (hQ : W.Equation
       smul_eq _ <| isUnit_addU_of_Y_ne hPz hQz hy]
 
 lemma addMap_of_Z_ne_zero {P Q : Fin 3 → F} (hP : W.Equation P) (hQ : W.Equation Q) (hPz : P z ≠ 0)
-    (hQz : Q z ≠ 0) (hxy : ¬(P x * Q z ^ 2 = Q x * P z ^ 2 ∧ P y * Q z ^ 3 = W.negY Q * P z ^ 3)) :
+    (hQz : Q z ≠ 0) (hxy : P x * Q z ^ 2 = Q x * P z ^ 2 → P y * Q z ^ 3 ≠ W.negY Q * P z ^ 3) :
     W.addMap ⟦P⟧ ⟦Q⟧ =
       ⟦![W.toAffine.addX (P x / P z ^ 2) (Q x / Q z ^ 2)
           (W.toAffine.slope (P x / P z ^ 2) (Q x / Q z ^ 2) (P y / P z ^ 3) (Q y / Q z ^ 3)),
@@ -1390,8 +1392,8 @@ lemma addMap_of_Z_ne_zero {P Q : Fin 3 → F} (hP : W.Equation P) (hQ : W.Equati
           (W.toAffine.slope (P x / P z ^ 2) (Q x / Q z ^ 2) (P y / P z ^ 3) (Q y / Q z ^ 3)),
         1]⟧ := by
   by_cases hx : P x * Q z ^ 2 = Q x * P z ^ 2
-  · rw [addMap_eq, add_of_Y_ne' hP hQ hPz hQz hx <| not_and.mp hxy hx,
-      smul_eq _ <| isUnit_dblZ_of_Y_ne' hP hQ hPz hx <| not_and.mp hxy hx]
+  · rw [addMap_eq, add_of_Y_ne' hP hQ hPz hQz hx <| hxy hx,
+      smul_eq _ <| isUnit_dblZ_of_Y_ne' hP hQ hPz hx <| hxy hx]
   · rw [addMap_eq, add_of_X_ne hP hQ hPz hQz hx, smul_eq _ <| isUnit_addZ_of_X_ne hx]
 
 lemma nonsingularLift_addMap {P Q : PointClass F} (hP : W.NonsingularLift P)
@@ -1449,7 +1451,7 @@ Given a nonsingular rational point `P` on `W`, use `-P` instead of `neg P`. -/
 def neg (P : W.Point) : W.Point :=
   ⟨nonsingularLift_negMap P.nonsingular⟩
 
-noncomputable instance instNegPoint : Neg W.Point :=
+instance instNegPoint : Neg W.Point :=
   ⟨neg⟩
 
 lemma neg_def (P : W.Point) : -P = P.neg :=
@@ -1530,7 +1532,7 @@ lemma toAffine_neg {P : Fin 3 → F} (hP : W.Nonsingular P) :
 
 private lemma toAffine_add_of_Z_ne_zero {P Q : Fin 3 → F} (hP : W.Nonsingular P)
     (hQ : W.Nonsingular Q) (hPz : P z ≠ 0) (hQz : Q z ≠ 0)
-    (hxy : ¬(P x * Q z ^ 2 = Q x * P z ^ 2 ∧ P y * Q z ^ 3 = W.negY Q * P z ^ 3)) : toAffine W
+    (hxy : P x * Q z ^ 2 = Q x * P z ^ 2 → P y * Q z ^ 3 ≠ W.negY Q * P z ^ 3) : toAffine W
       ![W.toAffine.addX (P x / P z ^ 2) (Q x / Q z ^ 2)
           (W.toAffine.slope (P x / P z ^ 2) (Q x / Q z ^ 2) (P y / P z ^ 3) (Q y / Q z ^ 3)),
         W.toAffine.addY (P x / P z ^ 2) (Q x / Q z ^ 2) (P y / P z ^ 3)
@@ -1538,7 +1540,7 @@ private lemma toAffine_add_of_Z_ne_zero {P Q : Fin 3 → F} (hP : W.Nonsingular 
         1] = toAffine W P + toAffine W Q := by
   rw [toAffine_some <| nonsingular_add_of_Z_ne_zero hP hQ hPz hQz hxy, toAffine_of_Z_ne_zero hP hPz,
     toAffine_of_Z_ne_zero hQ hQz,
-    Affine.Point.add_some <| by rwa [← X_eq_iff hPz hQz, ← Y_eq_iff' hPz hQz]]
+    Affine.Point.add_of_imp <| by rwa [← X_eq_iff hPz hQz, ne_eq, ← Y_eq_iff' hPz hQz]]
 
 lemma toAffine_add {P Q : Fin 3 → F} (hP : W.Nonsingular P) (hQ : W.Nonsingular Q) :
     toAffine W (W.add P Q) = toAffine W P + toAffine W Q := by
@@ -1553,19 +1555,21 @@ lemma toAffine_add {P Q : Fin 3 → F} (hP : W.Nonsingular P) (hQ : W.Nonsingula
     · rw [add_of_Z_eq_zero_right hQ.left hPz hQz,
         toAffine_smul _ ((isUnit_X_of_Z_eq_zero hQ hQz).mul <| Ne.isUnit hPz).neg,
         toAffine_of_Z_eq_zero hQz, add_zero]
-    · by_cases hxy : P x * Q z ^ 2 = Q x * P z ^ 2 ∧ P y * Q z ^ 3 = W.negY Q * P z ^ 3
-      · rw [toAffine_of_Z_ne_zero hP hPz, toAffine_of_Z_ne_zero hQ hQz, Affine.Point.add_of_Y_eq
+    · by_cases hxy : P x * Q z ^ 2 = Q x * P z ^ 2 → P y * Q z ^ 3 ≠ W.negY Q * P z ^ 3
+      · by_cases hx : P x * Q z ^ 2 = Q x * P z ^ 2
+        · rw [add_of_Y_ne' hP.left hQ.left hPz hQz hx <| hxy hx,
+            toAffine_smul _ <| isUnit_dblZ_of_Y_ne' hP.left hQ.left hPz hx <| hxy hx,
+            toAffine_add_of_Z_ne_zero hP hQ hPz hQz hxy]
+        · rw [add_of_X_ne hP.left hQ.left hPz hQz hx, toAffine_smul _ <| isUnit_addZ_of_X_ne hx,
+            toAffine_add_of_Z_ne_zero hP hQ hPz hQz hxy]
+      · rw [_root_.not_imp, not_ne_iff] at hxy
+        rw [toAffine_of_Z_ne_zero hP hPz, toAffine_of_Z_ne_zero hQ hQz, Affine.Point.add_of_Y_eq
             ((X_eq_iff hPz hQz).mp hxy.left) ((Y_eq_iff' hPz hQz).mp hxy.right)]
         by_cases hy : P y * Q z ^ 3 = Q y * P z ^ 3
         · rw [add_of_Y_eq hPz hQz hxy.left hy hxy.right,
             toAffine_smul _ <| isUnit_dblU_of_Y_eq hP hPz hQz hxy.left hy hxy.right, toAffine_zero]
         · rw [add_of_Y_ne hP.left hQ.left hPz hQz hxy.left hy,
             toAffine_smul _ <| isUnit_addU_of_Y_ne hPz hQz hy, toAffine_zero]
-      · have := toAffine_add_of_Z_ne_zero hP hQ hPz hQz hxy
-        by_cases hx : P x * Q z ^ 2 = Q x * P z ^ 2
-        · rwa [add_of_Y_ne' hP.left hQ.left hPz hQz hx <| not_and.mp hxy hx,
-            toAffine_smul _ <| isUnit_dblZ_of_Y_ne' hP.left hQ.left hPz hx <| not_and.mp hxy hx]
-        · rwa [add_of_X_ne hP.left hQ.left hPz hQz hx, toAffine_smul _ <| isUnit_addZ_of_X_ne hx]
 
 /-- The map from a nonsingular rational point on a Weierstrass curve `W` in Jacobian coordinates
 to the corresponding nonsingular rational point on `W` in affine coordinates. -/

--- a/Mathlib/AlgebraicGeometry/EllipticCurve/Projective.lean
+++ b/Mathlib/AlgebraicGeometry/EllipticCurve/Projective.lean
@@ -87,24 +87,6 @@ local notation3 "y" => (1 : Fin 3)
 
 local notation3 "z" => (2 : Fin 3)
 
-local macro "matrix_simp" : tactic =>
-  `(tactic| simp only [Matrix.head_cons, Matrix.tail_cons, Matrix.smul_empty, Matrix.smul_cons,
-    Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.cons_val_two])
-
-universe r s u v w
-
-/-! ## Weierstrass curves -/
-
-/-- An abbreviation for a Weierstrass curve in projective coordinates. -/
-abbrev WeierstrassCurve.Projective (R : Type u) : Type u :=
-  WeierstrassCurve R
-
-/-- The coercion to a Weierstrass curve in projective coordinates. -/
-abbrev WeierstrassCurve.toProjective {R : Type u} (W : WeierstrassCurve R) : Projective R :=
-  W
-
-namespace WeierstrassCurve.Projective
-
 open MvPolynomial
 
 local macro "eval_simp" : tactic =>
@@ -114,17 +96,39 @@ local macro "map_simp" : tactic =>
   `(tactic| simp only [map_ofNat, map_C, map_X, map_neg, map_add, map_sub, map_mul, map_pow,
     map_div₀, WeierstrassCurve.map, Function.comp_apply])
 
+local macro "matrix_simp" : tactic =>
+  `(tactic| simp only [Matrix.head_cons, Matrix.tail_cons, Matrix.smul_empty, Matrix.smul_cons,
+    Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.cons_val_two])
+
 local macro "pderiv_simp" : tactic =>
   `(tactic| simp only [map_ofNat, map_neg, map_add, map_sub, map_mul, pderiv_mul, pderiv_pow,
     pderiv_C, pderiv_X_self, pderiv_X_of_ne one_ne_zero, pderiv_X_of_ne one_ne_zero.symm,
     pderiv_X_of_ne (by decide : z ≠ x), pderiv_X_of_ne (by decide : x ≠ z),
     pderiv_X_of_ne (by decide : z ≠ y), pderiv_X_of_ne (by decide : y ≠ z)])
 
-variable {R : Type u} {W' : Projective R} {F : Type v} [Field F] {W : Projective F}
+universe r s u v
 
-section Projective
+/-! ## Weierstrass curves -/
 
-/-! ### Projective coordinates -/
+namespace WeierstrassCurve
+
+variable {R : Type r} {S : Type s} {A F : Type u} {B K : Type v}
+
+variable (R) in
+/-- An abbreviation for a Weierstrass curve in projective coordinates. -/
+abbrev Projective : Type r :=
+  WeierstrassCurve R
+
+/-- The coercion to a Weierstrass curve in projective coordinates. -/
+abbrev toProjective (W : WeierstrassCurve R) : Projective R :=
+  W
+
+namespace Projective
+
+variable (W') in
+/-- The coercion to a Weierstrass curve in affine coordinates. -/
+abbrev toAffine : Affine R :=
+  W'
 
 lemma fin3_def (P : Fin 3 → R) : ![P x, P y, P z] = P := by
   ext n; fin_cases n <;> rfl
@@ -132,10 +136,15 @@ lemma fin3_def (P : Fin 3 → R) : ![P x, P y, P z] = P := by
 lemma fin3_def_ext (X Y Z : R) : ![X, Y, Z] x = X ∧ ![X, Y, Z] y = Y ∧ ![X, Y, Z] z = Z :=
   ⟨rfl, rfl, rfl⟩
 
-lemma comp_fin3 {S : Type v} (f : R → S) (X Y Z : R) : f ∘ ![X, Y, Z] = ![f X, f Y, f Z] :=
+lemma comp_fin3 (f : R → S) (X Y Z : R) : f ∘ ![X, Y, Z] = ![f X, f Y, f Z] :=
   (FinVec.map_eq ..).symm
 
-variable [CommRing R]
+variable [CommRing R] [CommRing S] [CommRing A] [CommRing B] [Field F] [Field K] {W' : Projective R}
+  {W : Projective F}
+
+section Projective
+
+/-! ### Projective coordinates -/
 
 lemma smul_fin3 (P : Fin 3 → R) (u : R) : u • P = ![u * P x, u * P y, u * P z] := by
   simp [← List.ofFn_inj]
@@ -144,17 +153,16 @@ lemma smul_fin3_ext (P : Fin 3 → R) (u : R) :
     (u • P) x = u * P x ∧ (u • P) y = u * P y ∧ (u • P) z = u * P z :=
   ⟨rfl, rfl, rfl⟩
 
-lemma comp_smul {S : Type v} [CommRing S] (f : R →+* S) (P : Fin 3 → R) (u : R) :
-    f ∘ (u • P) = f u • f ∘ P := by
+lemma comp_smul (f : R →+* S) (P : Fin 3 → R) (u : R) : f ∘ (u • P) = f u • f ∘ P := by
   ext n; fin_cases n <;> simp only [smul_fin3, comp_fin3] <;> map_simp
 
 /-- The equivalence setoid for a point representative. -/
-scoped instance instSetoidPoint : Setoid <| Fin 3 → R :=
+@[reducible] scoped instance : Setoid <| Fin 3 → R :=
   MulAction.orbitRel Rˣ <| Fin 3 → R
 
 variable (R) in
 /-- The equivalence class of a point representative. -/
-abbrev PointClass : Type u :=
+abbrev PointClass : Type r :=
   MulAction.orbitRel.Quotient Rˣ <| Fin 3 → R
 
 lemma smul_equiv (P : Fin 3 → R) {u : R} (hu : IsUnit u) : u • P ≈ P :=
@@ -166,13 +174,7 @@ lemma smul_eq (P : Fin 3 → R) {u : R} (hu : IsUnit u) : (⟦u • P⟧ : Point
 
 lemma smul_equiv_smul (P Q : Fin 3 → R) {u v : R} (hu : IsUnit u) (hv : IsUnit v) :
     u • P ≈ v • Q ↔ P ≈ Q := by
-  erw [← Quotient.eq_iff_equiv, ← Quotient.eq_iff_equiv, smul_eq P hu, smul_eq Q hv]
-  rfl
-
-variable (W') in
-/-- The coercion to a Weierstrass curve in affine coordinates. -/
-abbrev toAffine : Affine R :=
-  W'
+  rw [← Quotient.eq_iff_equiv, ← Quotient.eq_iff_equiv, smul_eq P hu, smul_eq Q hv]
 
 lemma equiv_iff_eq_of_Z_eq' {P Q : Fin 3 → R} (hz : P z = Q z) (mem : Q z ∈ nonZeroDivisors R) :
     P ≈ Q ↔ P = Q := by
@@ -232,8 +234,6 @@ lemma Y_eq_iff {P Q : Fin 3 → F} (hPz : P z ≠ 0) (hQz : Q z ≠ 0) :
 
 end Projective
 
-variable [CommRing R]
-
 section Equation
 
 /-! ### Weierstrass equations -/
@@ -274,7 +274,7 @@ lemma equation_smul (P : Fin 3 → R) {u : R} (hu : IsUnit u) : W'.Equation (u �
   have hP (u : R) {P : Fin 3 → R} (hP : W'.Equation P) : W'.Equation <| u • P := by
     rw [equation_iff] at hP ⊢
     linear_combination (norm := (simp only [smul_fin3_ext]; ring1)) u ^ 3 * hP
-  ⟨fun h => by convert hP hu.unit.inv h; erw [smul_smul, hu.val_inv_mul, one_smul], hP u⟩
+  ⟨fun h => by convert hP ↑hu.unit⁻¹ h; rw [smul_smul, hu.val_inv_mul, one_smul], hP u⟩
 
 lemma equation_of_equiv {P Q : Fin 3 → R} (h : P ≈ Q) : W'.Equation P ↔ W'.Equation Q := by
   rcases h with ⟨u, rfl⟩
@@ -453,7 +453,7 @@ lemma equiv_zero_of_Z_eq_zero {P : Fin 3 → F} (hP : W.Nonsingular P) (hPz : P 
     P ≈ ![0, 1, 0] :=
   equiv_of_Z_eq_zero hP nonsingular_zero hPz rfl
 
-lemma comp_equiv_comp {K : Type v} [Field K] (f : F →+* K) {P Q : Fin 3 → F} (hP : W.Nonsingular P)
+lemma comp_equiv_comp (f : F →+* K) {P Q : Fin 3 → F} (hP : W.Nonsingular P)
     (hQ : W.Nonsingular Q) : f ∘ P ≈ f ∘ Q ↔ P ≈ Q := by
   refine ⟨fun h => ?_, fun h => ?_⟩
   · by_cases hz : f (P z) = 0
@@ -1247,7 +1247,8 @@ lemma neg_of_Z_ne_zero {P : Fin 3 → F} (hPz : P z ≠ 0) :
 
 private lemma nonsingular_neg_of_Z_ne_zero {P : Fin 3 → F} (hP : W.Nonsingular P) (hPz : P z ≠ 0) :
     W.Nonsingular ![P x / P z, W.toAffine.negY (P x / P z) (P y / P z), 1] :=
-  (nonsingular_some ..).mpr <| Affine.nonsingular_neg <| (nonsingular_of_Z_ne_zero hPz).mp hP
+  (nonsingular_some ..).mpr <| (Affine.nonsingular_neg ..).mpr <|
+    (nonsingular_of_Z_ne_zero hPz).mp hP
 
 lemma nonsingular_neg {P : Fin 3 → F} (hP : W.Nonsingular P) : W.Nonsingular <| W.neg P := by
   by_cases hPz : P z = 0
@@ -1382,13 +1383,13 @@ lemma add_of_X_ne {P Q : Fin 3 → F} (hP : W.Equation P) (hQ : W.Equation Q) (h
 
 private lemma nonsingular_add_of_Z_ne_zero {P Q : Fin 3 → F} (hP : W.Nonsingular P)
     (hQ : W.Nonsingular Q) (hPz : P z ≠ 0) (hQz : Q z ≠ 0)
-    (hxy : P x * Q z = Q x * P z → P y * Q z ≠ W.negY Q * P z) : W.Nonsingular
+    (hxy : ¬(P x * Q z = Q x * P z ∧ P y * Q z = W.negY Q * P z)) : W.Nonsingular
       ![W.toAffine.addX (P x / P z) (Q x / Q z)
           (W.toAffine.slope (P x / P z) (Q x / Q z) (P y / P z) (Q y / Q z)),
         W.toAffine.addY (P x / P z) (Q x / Q z) (P y / P z)
           (W.toAffine.slope (P x / P z) (Q x / Q z) (P y / P z) (Q y / Q z)), 1] :=
   (nonsingular_some ..).mpr <| Affine.nonsingular_add ((nonsingular_of_Z_ne_zero hPz).mp hP)
-    ((nonsingular_of_Z_ne_zero hQz).mp hQ) (by rwa [← X_eq_iff hPz hQz, ne_eq, ← Y_eq_iff' hPz hQz])
+    ((nonsingular_of_Z_ne_zero hQz).mp hQ) <| by rwa [← X_eq_iff hPz hQz, ← Y_eq_iff' hPz hQz]
 
 lemma nonsingular_add {P Q : Fin 3 → F} (hP : W.Nonsingular P) (hQ : W.Nonsingular Q) :
     W.Nonsingular <| W.add P Q := by
@@ -1401,20 +1402,19 @@ lemma nonsingular_add {P Q : Fin 3 → F} (hP : W.Nonsingular P) (hQ : W.Nonsing
   · by_cases hQz : Q z = 0
     · simpa only [add_of_Z_eq_zero_right hQ.left hPz hQz,
         nonsingular_smul _ (((isUnit_Y_of_Z_eq_zero hQ hQz).pow 2).mul <| Ne.isUnit hPz).neg]
-    · by_cases hxy : P x * Q z = Q x * P z → P y * Q z ≠ W.negY Q * P z
-      · by_cases hx : P x * Q z = Q x * P z
-        · simp only [add_of_Y_ne' hP.left hQ.left hPz hQz hx <| hxy hx,
-            nonsingular_smul _ <| isUnit_dblZ_of_Y_ne' hP.left hQ.left hPz hQz hx <| hxy hx,
-            nonsingular_add_of_Z_ne_zero hP hQ hPz hQz hxy]
-        · simp only [add_of_X_ne hP.left hQ.left hPz hQz hx,
-            nonsingular_smul _ <| isUnit_addZ_of_X_ne hP.left hQ.left hx,
-            nonsingular_add_of_Z_ne_zero hP hQ hPz hQz hxy]
-      · rw [_root_.not_imp, not_ne_iff] at hxy
-        by_cases hy : P y * Q z = Q y * P z
+    · by_cases hxy : P x * Q z = Q x * P z ∧ P y * Q z = W.negY Q * P z
+      · by_cases hy : P y * Q z = Q y * P z
         · simp only [add_of_Y_eq hP.left hPz hQz hxy.left hy hxy.right, nonsingular_smul _ <|
               isUnit_dblU_of_Y_eq hP hPz hQz hxy.left hy hxy.right, nonsingular_zero]
         · simp only [add_of_Y_ne hP.left hQ.left hPz hQz hxy.left hy,
             nonsingular_smul _ <| isUnit_addU_of_Y_ne hPz hQz hy, nonsingular_zero]
+      · have := nonsingular_add_of_Z_ne_zero hP hQ hPz hQz hxy
+        by_cases hx : P x * Q z = Q x * P z
+        · simpa only [add_of_Y_ne' hP.left hQ.left hPz hQz hx <| not_and.mp hxy hx,
+            nonsingular_smul _ <| isUnit_dblZ_of_Y_ne' hP.left hQ.left hPz hQz hx <|
+              not_and.mp hxy hx]
+        · simpa only [add_of_X_ne hP.left hQ.left hPz hQz hx,
+            nonsingular_smul _ <| isUnit_addZ_of_X_ne hP.left hQ.left hx]
 
 variable (W') in
 /-- The addition of two point classes. If `P` is a point representative,
@@ -1457,14 +1457,15 @@ lemma addMap_of_Y_eq {P Q : Fin 3 → F} (hP : W.Nonsingular P) (hQ : W.Equation
       smul_eq _ <| isUnit_addU_of_Y_ne hPz hQz hy]
 
 lemma addMap_of_Z_ne_zero {P Q : Fin 3 → F} (hP : W.Equation P) (hQ : W.Equation Q) (hPz : P z ≠ 0)
-    (hQz : Q z ≠ 0) (hxy : P x * Q z = Q x * P z → P y * Q z ≠ W.negY Q * P z) : W.addMap ⟦P⟧ ⟦Q⟧ =
+    (hQz : Q z ≠ 0) (hxy : ¬(P x * Q z = Q x * P z ∧ P y * Q z = W.negY Q * P z)) :
+    W.addMap ⟦P⟧ ⟦Q⟧ =
       ⟦![W.toAffine.addX (P x / P z) (Q x / Q z)
           (W.toAffine.slope (P x / P z) (Q x / Q z) (P y / P z) (Q y / Q z)),
         W.toAffine.addY (P x / P z) (Q x / Q z) (P y / P z)
           (W.toAffine.slope (P x / P z) (Q x / Q z) (P y / P z) (Q y / Q z)), 1]⟧ := by
   by_cases hx : P x * Q z = Q x * P z
-  · rw [addMap_eq, add_of_Y_ne' hP hQ hPz hQz hx <| hxy hx,
-      smul_eq _ <| isUnit_dblZ_of_Y_ne' hP hQ hPz hQz hx <| hxy hx]
+  · rw [addMap_eq, add_of_Y_ne' hP hQ hPz hQz hx <| not_and.mp hxy hx,
+      smul_eq _ <| isUnit_dblZ_of_Y_ne' hP hQ hPz hQz hx <| not_and.mp hxy hx]
   · rw [addMap_eq, add_of_X_ne hP hQ hPz hQz hx, smul_eq _ <| isUnit_addZ_of_X_ne hP hQ hx]
 
 lemma nonsingularLift_addMap {P Q : PointClass F} (hP : W.NonsingularLift P)
@@ -1490,7 +1491,7 @@ namespace Point
 lemma mk_point {P : PointClass R} (h : W'.NonsingularLift P) : (mk h).point = P :=
   rfl
 
-instance instZeroPoint [Nontrivial R] : Zero W'.Point :=
+instance [Nontrivial R] : Zero W'.Point :=
   ⟨⟨nonsingularLift_zero⟩⟩
 
 lemma zero_def [Nontrivial R] : (0 : W'.Point) = ⟨nonsingularLift_zero⟩ :=
@@ -1498,6 +1499,9 @@ lemma zero_def [Nontrivial R] : (0 : W'.Point) = ⟨nonsingularLift_zero⟩ :=
 
 lemma zero_point [Nontrivial R] : (0 : W'.Point).point = ⟦![0, 1, 0]⟧ :=
   rfl
+
+lemma mk_ne_zero [Nontrivial R] {X Y : R} (h : W'.NonsingularLift ⟦![X, Y, 1]⟧) : mk h ≠ 0 :=
+  (not_equiv_of_Z_eq_zero_right one_ne_zero rfl).comp <| Quotient.eq.mp.comp Point.ext_iff.mp
 
 /-- The map from a nonsingular rational point on a Weierstrass curve `W'` in affine coordinates
 to the corresponding nonsingular rational point on `W'` in projective coordinates. -/
@@ -1512,17 +1516,16 @@ lemma fromAffine_some [Nontrivial R] {X Y : R} (h : W'.toAffine.Nonsingular X Y)
     fromAffine (.some h) = ⟨(nonsingularLift_some ..).mpr h⟩ :=
   rfl
 
-lemma fromAffine_ne_zero [Nontrivial R] {X Y : R} (h : W'.toAffine.Nonsingular X Y) :
-    fromAffine (.some h) ≠ 0 := fun h0 ↦ by
-  obtain ⟨u, eq⟩ := Quotient.eq.mp <| (Point.ext_iff ..).mp h0
-  simpa [Units.smul_def, smul_fin3] using congr_fun eq z
+lemma fromAffine_some_ne_zero [Nontrivial R] {X Y : R} (h : W'.toAffine.Nonsingular X Y) :
+    fromAffine (.some h) ≠ 0 :=
+  mk_ne_zero <| (nonsingularLift_some ..).mpr h
 
 /-- The negation of a nonsingular rational point on `W`.
 Given a nonsingular rational point `P` on `W`, use `-P` instead of `neg P`. -/
 def neg (P : W.Point) : W.Point :=
   ⟨nonsingularLift_negMap P.nonsingular⟩
 
-instance instNegPoint : Neg W.Point :=
+instance : Neg W.Point :=
   ⟨neg⟩
 
 lemma neg_def (P : W.Point) : -P = P.neg :=
@@ -1536,7 +1539,7 @@ Given two nonsingular rational points `P` and `Q` on `W`, use `P + Q` instead of
 noncomputable def add (P Q : W.Point) : W.Point :=
   ⟨nonsingularLift_addMap P.nonsingular Q.nonsingular⟩
 
-noncomputable instance instAddPoint : Add W.Point :=
+noncomputable instance : Add W.Point :=
   ⟨add⟩
 
 lemma add_def (P Q : W.Point) : P + Q = P.add Q :=
@@ -1602,7 +1605,7 @@ lemma toAffine_neg {P : Fin 3 → F} (hP : W.Nonsingular P) :
 
 private lemma toAffine_add_of_Z_ne_zero {P Q : Fin 3 → F} (hP : W.Nonsingular P)
     (hQ : W.Nonsingular Q) (hPz : P z ≠ 0) (hQz : Q z ≠ 0)
-    (hxy : P x * Q z = Q x * P z → P y * Q z ≠ W.negY Q * P z) : toAffine W
+    (hxy : ¬(P x * Q z = Q x * P z ∧ P y * Q z = W.negY Q * P z)) : toAffine W
       ![W.toAffine.addX (P x / P z) (Q x / Q z)
           (W.toAffine.slope (P x / P z) (Q x / Q z) (P y / P z) (Q y / Q z)),
         W.toAffine.addY (P x / P z) (Q x / Q z) (P y / P z)
@@ -1610,7 +1613,7 @@ private lemma toAffine_add_of_Z_ne_zero {P Q : Fin 3 → F} (hP : W.Nonsingular 
         1] = toAffine W P + toAffine W Q := by
   rw [toAffine_some <| nonsingular_add_of_Z_ne_zero hP hQ hPz hQz hxy, toAffine_of_Z_ne_zero hP hPz,
     toAffine_of_Z_ne_zero hQ hQz,
-    Affine.Point.add_of_imp <| by rwa [← X_eq_iff hPz hQz, ne_eq, ← Y_eq_iff' hPz hQz]]
+    Affine.Point.add_some <| by rwa [← X_eq_iff hPz hQz, ← Y_eq_iff' hPz hQz]]
 
 lemma toAffine_add {P Q : Fin 3 → F} (hP : W.Nonsingular P) (hQ : W.Nonsingular Q) :
     toAffine W (W.add P Q) = toAffine W P + toAffine W Q := by
@@ -1625,21 +1628,20 @@ lemma toAffine_add {P Q : Fin 3 → F} (hP : W.Nonsingular P) (hQ : W.Nonsingula
     · rw [add_of_Z_eq_zero_right hQ.left hPz hQz,
         toAffine_smul _ (((isUnit_Y_of_Z_eq_zero hQ hQz).pow 2).mul <| Ne.isUnit hPz).neg,
         toAffine_of_Z_eq_zero hQz, add_zero]
-    · by_cases hxy : P x * Q z = Q x * P z → P y * Q z ≠ W.negY Q * P z
-      · by_cases hx : P x * Q z = Q x * P z
-        · rw [add_of_Y_ne' hP.left hQ.left hPz hQz hx <| hxy hx,
-            toAffine_smul _ <| isUnit_dblZ_of_Y_ne' hP.left hQ.left hPz hQz hx <| hxy hx,
-            toAffine_add_of_Z_ne_zero hP hQ hPz hQz hxy]
-        · rw [add_of_X_ne hP.left hQ.left hPz hQz hx, toAffine_smul _ <|
-              isUnit_addZ_of_X_ne hP.left hQ.left hx, toAffine_add_of_Z_ne_zero hP hQ hPz hQz hxy]
-      · rw [_root_.not_imp, not_ne_iff] at hxy
-        rw [toAffine_of_Z_ne_zero hP hPz, toAffine_of_Z_ne_zero hQ hQz, Affine.Point.add_of_Y_eq
+    · by_cases hxy : P x * Q z = Q x * P z ∧ P y * Q z = W.negY Q * P z
+      · rw [toAffine_of_Z_ne_zero hP hPz, toAffine_of_Z_ne_zero hQ hQz, Affine.Point.add_of_Y_eq
             ((X_eq_iff hPz hQz).mp hxy.left) ((Y_eq_iff' hPz hQz).mp hxy.right)]
         by_cases hy : P y * Q z = Q y * P z
         · rw [add_of_Y_eq hP.left hPz hQz hxy.left hy hxy.right,
             toAffine_smul _ <| isUnit_dblU_of_Y_eq hP hPz hQz hxy.left hy hxy.right, toAffine_zero]
         · rw [add_of_Y_ne hP.left hQ.left hPz hQz hxy.left hy,
             toAffine_smul _ <| isUnit_addU_of_Y_ne hPz hQz hy, toAffine_zero]
+      · have := toAffine_add_of_Z_ne_zero hP hQ hPz hQz hxy
+        by_cases hx : P x * Q z = Q x * P z
+        · rwa [add_of_Y_ne' hP.left hQ.left hPz hQz hx <| not_and.mp hxy hx,
+            toAffine_smul _ <| isUnit_dblZ_of_Y_ne' hP.left hQ.left hPz hQz hx <| not_and.mp hxy hx]
+        · rwa [add_of_X_ne hP.left hQ.left hPz hQz hx,
+            toAffine_smul _ <| isUnit_addZ_of_X_ne hP.left hQ.left hx]
 
 /-- The map from a nonsingular rational point on a Weierstrass curve `W` in projective coordinates
 to the corresponding nonsingular rational point on `W` in affine coordinates. -/

--- a/Mathlib/AlgebraicGeometry/EllipticCurve/Projective.lean
+++ b/Mathlib/AlgebraicGeometry/EllipticCurve/Projective.lean
@@ -1383,13 +1383,13 @@ lemma add_of_X_ne {P Q : Fin 3 → F} (hP : W.Equation P) (hQ : W.Equation Q) (h
 
 private lemma nonsingular_add_of_Z_ne_zero {P Q : Fin 3 → F} (hP : W.Nonsingular P)
     (hQ : W.Nonsingular Q) (hPz : P z ≠ 0) (hQz : Q z ≠ 0)
-    (hxy : ¬(P x * Q z = Q x * P z ∧ P y * Q z = W.negY Q * P z)) : W.Nonsingular
+    (hxy : P x * Q z = Q x * P z → P y * Q z ≠ W.negY Q * P z) : W.Nonsingular
       ![W.toAffine.addX (P x / P z) (Q x / Q z)
           (W.toAffine.slope (P x / P z) (Q x / Q z) (P y / P z) (Q y / Q z)),
         W.toAffine.addY (P x / P z) (Q x / Q z) (P y / P z)
           (W.toAffine.slope (P x / P z) (Q x / Q z) (P y / P z) (Q y / Q z)), 1] :=
   (nonsingular_some ..).mpr <| Affine.nonsingular_add ((nonsingular_of_Z_ne_zero hPz).mp hP)
-    ((nonsingular_of_Z_ne_zero hQz).mp hQ) <| by rwa [← X_eq_iff hPz hQz, ← Y_eq_iff' hPz hQz]
+    ((nonsingular_of_Z_ne_zero hQz).mp hQ) (by rwa [← X_eq_iff hPz hQz, ne_eq, ← Y_eq_iff' hPz hQz])
 
 lemma nonsingular_add {P Q : Fin 3 → F} (hP : W.Nonsingular P) (hQ : W.Nonsingular Q) :
     W.Nonsingular <| W.add P Q := by
@@ -1402,19 +1402,20 @@ lemma nonsingular_add {P Q : Fin 3 → F} (hP : W.Nonsingular P) (hQ : W.Nonsing
   · by_cases hQz : Q z = 0
     · simpa only [add_of_Z_eq_zero_right hQ.left hPz hQz,
         nonsingular_smul _ (((isUnit_Y_of_Z_eq_zero hQ hQz).pow 2).mul <| Ne.isUnit hPz).neg]
-    · by_cases hxy : P x * Q z = Q x * P z ∧ P y * Q z = W.negY Q * P z
-      · by_cases hy : P y * Q z = Q y * P z
+    · by_cases hxy : P x * Q z = Q x * P z → P y * Q z ≠ W.negY Q * P z
+      · by_cases hx : P x * Q z = Q x * P z
+        · simp only [add_of_Y_ne' hP.left hQ.left hPz hQz hx <| hxy hx,
+            nonsingular_smul _ <| isUnit_dblZ_of_Y_ne' hP.left hQ.left hPz hQz hx <| hxy hx,
+            nonsingular_add_of_Z_ne_zero hP hQ hPz hQz hxy]
+        · simp only [add_of_X_ne hP.left hQ.left hPz hQz hx,
+            nonsingular_smul _ <| isUnit_addZ_of_X_ne hP.left hQ.left hx,
+            nonsingular_add_of_Z_ne_zero hP hQ hPz hQz hxy]
+      · rw [_root_.not_imp, not_ne_iff] at hxy
+        by_cases hy : P y * Q z = Q y * P z
         · simp only [add_of_Y_eq hP.left hPz hQz hxy.left hy hxy.right, nonsingular_smul _ <|
               isUnit_dblU_of_Y_eq hP hPz hQz hxy.left hy hxy.right, nonsingular_zero]
         · simp only [add_of_Y_ne hP.left hQ.left hPz hQz hxy.left hy,
             nonsingular_smul _ <| isUnit_addU_of_Y_ne hPz hQz hy, nonsingular_zero]
-      · have := nonsingular_add_of_Z_ne_zero hP hQ hPz hQz hxy
-        by_cases hx : P x * Q z = Q x * P z
-        · simpa only [add_of_Y_ne' hP.left hQ.left hPz hQz hx <| not_and.mp hxy hx,
-            nonsingular_smul _ <| isUnit_dblZ_of_Y_ne' hP.left hQ.left hPz hQz hx <|
-              not_and.mp hxy hx]
-        · simpa only [add_of_X_ne hP.left hQ.left hPz hQz hx,
-            nonsingular_smul _ <| isUnit_addZ_of_X_ne hP.left hQ.left hx]
 
 variable (W') in
 /-- The addition of two point classes. If `P` is a point representative,
@@ -1457,15 +1458,14 @@ lemma addMap_of_Y_eq {P Q : Fin 3 → F} (hP : W.Nonsingular P) (hQ : W.Equation
       smul_eq _ <| isUnit_addU_of_Y_ne hPz hQz hy]
 
 lemma addMap_of_Z_ne_zero {P Q : Fin 3 → F} (hP : W.Equation P) (hQ : W.Equation Q) (hPz : P z ≠ 0)
-    (hQz : Q z ≠ 0) (hxy : ¬(P x * Q z = Q x * P z ∧ P y * Q z = W.negY Q * P z)) :
-    W.addMap ⟦P⟧ ⟦Q⟧ =
+    (hQz : Q z ≠ 0) (hxy : P x * Q z = Q x * P z → P y * Q z ≠ W.negY Q * P z) : W.addMap ⟦P⟧ ⟦Q⟧ =
       ⟦![W.toAffine.addX (P x / P z) (Q x / Q z)
           (W.toAffine.slope (P x / P z) (Q x / Q z) (P y / P z) (Q y / Q z)),
         W.toAffine.addY (P x / P z) (Q x / Q z) (P y / P z)
           (W.toAffine.slope (P x / P z) (Q x / Q z) (P y / P z) (Q y / Q z)), 1]⟧ := by
   by_cases hx : P x * Q z = Q x * P z
-  · rw [addMap_eq, add_of_Y_ne' hP hQ hPz hQz hx <| not_and.mp hxy hx,
-      smul_eq _ <| isUnit_dblZ_of_Y_ne' hP hQ hPz hQz hx <| not_and.mp hxy hx]
+  · rw [addMap_eq, add_of_Y_ne' hP hQ hPz hQz hx <| hxy hx,
+      smul_eq _ <| isUnit_dblZ_of_Y_ne' hP hQ hPz hQz hx <| hxy hx]
   · rw [addMap_eq, add_of_X_ne hP hQ hPz hQz hx, smul_eq _ <| isUnit_addZ_of_X_ne hP hQ hx]
 
 lemma nonsingularLift_addMap {P Q : PointClass F} (hP : W.NonsingularLift P)
@@ -1603,7 +1603,7 @@ lemma toAffine_neg {P : Fin 3 → F} (hP : W.Nonsingular P) :
 
 private lemma toAffine_add_of_Z_ne_zero {P Q : Fin 3 → F} (hP : W.Nonsingular P)
     (hQ : W.Nonsingular Q) (hPz : P z ≠ 0) (hQz : Q z ≠ 0)
-    (hxy : ¬(P x * Q z = Q x * P z ∧ P y * Q z = W.negY Q * P z)) : toAffine W
+    (hxy : P x * Q z = Q x * P z → P y * Q z ≠ W.negY Q * P z) : toAffine W
       ![W.toAffine.addX (P x / P z) (Q x / Q z)
           (W.toAffine.slope (P x / P z) (Q x / Q z) (P y / P z) (Q y / Q z)),
         W.toAffine.addY (P x / P z) (Q x / Q z) (P y / P z)
@@ -1611,7 +1611,7 @@ private lemma toAffine_add_of_Z_ne_zero {P Q : Fin 3 → F} (hP : W.Nonsingular 
         1] = toAffine W P + toAffine W Q := by
   rw [toAffine_some <| nonsingular_add_of_Z_ne_zero hP hQ hPz hQz hxy, toAffine_of_Z_ne_zero hP hPz,
     toAffine_of_Z_ne_zero hQ hQz,
-    Affine.Point.add_some <| by rwa [← X_eq_iff hPz hQz, ← Y_eq_iff' hPz hQz]]
+    Affine.Point.add_of_imp <| by rwa [← X_eq_iff hPz hQz, ne_eq, ← Y_eq_iff' hPz hQz]]
 
 lemma toAffine_add {P Q : Fin 3 → F} (hP : W.Nonsingular P) (hQ : W.Nonsingular Q) :
     toAffine W (W.add P Q) = toAffine W P + toAffine W Q := by
@@ -1626,20 +1626,21 @@ lemma toAffine_add {P Q : Fin 3 → F} (hP : W.Nonsingular P) (hQ : W.Nonsingula
     · rw [add_of_Z_eq_zero_right hQ.left hPz hQz,
         toAffine_smul _ (((isUnit_Y_of_Z_eq_zero hQ hQz).pow 2).mul <| Ne.isUnit hPz).neg,
         toAffine_of_Z_eq_zero hQz, add_zero]
-    · by_cases hxy : P x * Q z = Q x * P z ∧ P y * Q z = W.negY Q * P z
-      · rw [toAffine_of_Z_ne_zero hP hPz, toAffine_of_Z_ne_zero hQ hQz, Affine.Point.add_of_Y_eq
+    · by_cases hxy : P x * Q z = Q x * P z → P y * Q z ≠ W.negY Q * P z
+      · by_cases hx : P x * Q z = Q x * P z
+        · rw [add_of_Y_ne' hP.left hQ.left hPz hQz hx <| hxy hx,
+            toAffine_smul _ <| isUnit_dblZ_of_Y_ne' hP.left hQ.left hPz hQz hx <| hxy hx,
+            toAffine_add_of_Z_ne_zero hP hQ hPz hQz hxy]
+        · rw [add_of_X_ne hP.left hQ.left hPz hQz hx, toAffine_smul _ <|
+              isUnit_addZ_of_X_ne hP.left hQ.left hx, toAffine_add_of_Z_ne_zero hP hQ hPz hQz hxy]
+      · rw [_root_.not_imp, not_ne_iff] at hxy
+        rw [toAffine_of_Z_ne_zero hP hPz, toAffine_of_Z_ne_zero hQ hQz, Affine.Point.add_of_Y_eq
             ((X_eq_iff hPz hQz).mp hxy.left) ((Y_eq_iff' hPz hQz).mp hxy.right)]
         by_cases hy : P y * Q z = Q y * P z
         · rw [add_of_Y_eq hP.left hPz hQz hxy.left hy hxy.right,
             toAffine_smul _ <| isUnit_dblU_of_Y_eq hP hPz hQz hxy.left hy hxy.right, toAffine_zero]
         · rw [add_of_Y_ne hP.left hQ.left hPz hQz hxy.left hy,
             toAffine_smul _ <| isUnit_addU_of_Y_ne hPz hQz hy, toAffine_zero]
-      · have := toAffine_add_of_Z_ne_zero hP hQ hPz hQz hxy
-        by_cases hx : P x * Q z = Q x * P z
-        · rwa [add_of_Y_ne' hP.left hQ.left hPz hQz hx <| not_and.mp hxy hx,
-            toAffine_smul _ <| isUnit_dblZ_of_Y_ne' hP.left hQ.left hPz hQz hx <| not_and.mp hxy hx]
-        · rwa [add_of_X_ne hP.left hQ.left hPz hQz hx,
-            toAffine_smul _ <| isUnit_addZ_of_X_ne hP.left hQ.left hx]
 
 /-- The map from a nonsingular rational point on a Weierstrass curve `W` in projective coordinates
 to the corresponding nonsingular rational point on `W` in affine coordinates. -/


### PR DESCRIPTION
Standardise the use of `W'` for a Weierstrass curve over a ring and `W` for a Weierstrass curve over a field in the affine coordinates file, analogous to those in the Jacobian and projective coordinates files, and rearrange the file sections to reflect this. This reduces the dependency of individual lemmas on global variables, which will make the file split in #21356 a lot easier.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
