### PR TITLE
feat(CategoryTheory/IsPullback): add helper lemmas based on of_iso

### DIFF
--- a/Mathlib/CategoryTheory/Limits/Shapes/Pullback/CommSq.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Pullback/CommSq.lean
@@ -370,6 +370,35 @@ lemma of_iso (h : IsPullback fst snd f g)
               rw [← reassoc_of% commfst, e₂.hom_inv_id, Category.comp_id]
             · change snd = e₁.hom ≫ snd' ≫ e₃.inv
               rw [← reassoc_of% commsnd, e₃.hom_inv_id, Category.comp_id]))⟩
+
+lemma of_iso1 {P P' X Y Z : C}
+    {f : X ⟶ Z} {g : Y ⟶ Z} {fst : P ⟶ X} {snd : P ⟶ Y}
+    {fst' : P' ⟶ X} {snd' : P' ⟶ Y}
+    (h : IsPullback fst snd f g) (i₁ : P ≅ P')
+    (commfst : fst = i₁.hom ≫ fst')
+    (commsnd : snd = i₁.hom ≫ snd') :
+    IsPullback fst' snd' f g := by
+  apply IsPullback.of_iso h i₁ (Iso.refl _) (Iso.refl _) (Iso.refl _) <;> aesop_cat
+
+lemma of_iso2 {P X X' Y Z : C}
+    {f : X ⟶ Z} {g : Y ⟶ Z} {fst : P ⟶ X} {snd : P ⟶ Y}
+    {f' : X' ⟶ Z} {fst' : P ⟶ X'}
+    (h : IsPullback fst snd f g) (i₂ : X ≅ X')
+    (commfst : fst ≫ i₂.hom = fst')
+    (commf : f = i₂.hom ≫ f') :
+    IsPullback fst' snd f' g := by
+  apply IsPullback.of_iso h (Iso.refl _) i₂ (Iso.refl _) (Iso.refl _) <;> aesop_cat
+
+lemma of_iso12 {P P' X X' Y Z : C}
+    {f : X ⟶ Z} {g : Y ⟶ Z} {fst : P ⟶ X} {snd : P ⟶ Y}
+    {f' : X' ⟶ Z} {fst' : P' ⟶ X'} {snd' : P' ⟶ Y}
+    (h : IsPullback fst snd f g) (i₁ : P ≅ P') (i₂ : X ≅ X')
+    (commfst : fst ≫ i₂.hom = i₁.hom ≫ fst')
+    (commsnd : snd = i₁.hom ≫ snd')
+    (commf : f = i₂.hom ≫ f') :
+    IsPullback fst' snd' f' g := by
+  apply IsPullback.of_iso h i₁ i₂ (Iso.refl _) (Iso.refl _) <;> aesop_cat
+
 section
 
 variable {P X Y : C} {fst : P ⟶ X} {snd : P ⟶ X} {f : X ⟶ Y} [Mono f]


### PR DESCRIPTION
Add helper lemmas that are specific instances of `CategoryTheory.IsPullback.of_iso` with identities.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
