### PR TITLE
[Merged by Bors] - feat(Fintype/BigOperators): add `prod_eq_mul_prod_subtype_ne`

### DIFF
--- a/Mathlib/Data/Fintype/BigOperators.lean
+++ b/Mathlib/Data/Fintype/BigOperators.lean
@@ -96,9 +96,8 @@ variable {M : Type*} [Fintype α] [CommMonoid M]
 theorem Fintype.prod_option (f : Option α → M) : ∏ i, f i = f none * ∏ i, f (some i) :=
   Finset.prod_insertNone f univ
 
-open Classical in
 @[to_additive]
-theorem Fintype.prod_eq_mul_prod_subtype_ne (f : α → M) (a : α) :
+theorem Fintype.prod_eq_mul_prod_subtype_ne [DecidableEq α] (f : α → M) (a : α) :
     ∏ i, f i = f a * ∏ i : {i // i ≠ a}, f i.1 := by
   simp_rw [← (Equiv.optionSubtypeNe a).prod_comp, prod_option, Equiv.optionSubtypeNe_none,
     Equiv.optionSubtypeNe_some]

--- a/Mathlib/Data/Fintype/BigOperators.lean
+++ b/Mathlib/Data/Fintype/BigOperators.lean
@@ -96,6 +96,13 @@ variable {M : Type*} [Fintype α] [CommMonoid M]
 theorem Fintype.prod_option (f : Option α → M) : ∏ i, f i = f none * ∏ i, f (some i) :=
   Finset.prod_insertNone f univ
 
+open Classical in
+@[to_additive]
+theorem Fintype.prod_eq_mul_prod_subtype_ne (f : α → M) (a : α) :
+    ∏ i, f i = f a * ∏ i : {i // i ≠ a}, f i.1 := by
+  simp_rw [← (Equiv.optionSubtypeNe a).prod_comp, prod_option, Equiv.optionSubtypeNe_none,
+    Equiv.optionSubtypeNe_some]
+
 end
 
 open Finset


### PR DESCRIPTION
Add
```lean
theorem Fintype.prod_eq_mul_prod_subtype_ne (f : α → M) (a : α) :
    ∏ i, f i = f a * ∏ i : {i // i ≠ a}, f i.1
```

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
