### PR TITLE
feat(CategoryTheory): implemented proofs for factorisation categories being equivalent to iterated comma categories in two ways

### DIFF
--- a/Mathlib/CategoryTheory/Category/Factorisation.lean
+++ b/Mathlib/CategoryTheory/Category/Factorisation.lean
@@ -146,7 +146,7 @@ def fromOverOfUndertoFact : Over (Under.mk f) ⥤ Factorisation f where
   map κ := {
     h := κ.left.right,
     ι_h := Under.w κ.left,
-    h_π := by (rw [← Under.comp_right, Over.w])
+    h_π := by rw [← Under.comp_right, Over.w]
   }
 
 /-- We aim to show `Factorisation f` ≌ `(X/C)/f`. That is to say,
@@ -171,7 +171,7 @@ def fromFactToUnderOfOver : Factorisation f ⥤ Under (Over.mk f) where
 /-- The functor turning `f/(C/Y)` into `Factorisation f` -/
 def fromUnderOfOvertoFact : Under (Over.mk f) ⥤ Factorisation f where
   obj α := { mid := α.right.left, ι := α.hom.left, π := α.right.hom}
-  map κ := {h := κ.right.left, ι_h := by (rw [← Over.comp_left, Under.w]), h_π := Over.w κ.right}
+  map κ := {h := κ.right.left, ι_h := by rw [← Over.comp_left, Under.w], h_π := Over.w κ.right}
 
 /-- proving that the two functors above are inverses of each other.
 Thus formulating the ≌ relationship. -/

--- a/Mathlib/CategoryTheory/Category/Factorisation.lean
+++ b/Mathlib/CategoryTheory/Category/Factorisation.lean
@@ -79,50 +79,6 @@ instance : Category.{max u v} (Factorisation f) where
 /- We now aim to show that `Factorisation f` is equivalent to iterated comma categories
 in two different ways.
 Namely, given `f : X ⟶ Y`, we will have `(X/C)/f` ≌ `Factorisation f` ≌ `f/(C/Y)`.
-
-To give an idea of how the proof works:
-
-Both
-1. an object in `C/Y`
-2. an object in `X/C`
-can be viewed as a morphism `f : X ⟶ Y` in Category `C`
-from the perspective of over/under categories.
-
-Let's first consider `(X/C)/f`
-
-Similarly, an object `α` in `(X/C)/f` can be viewed as a morphism `f₁ : f₀ ⟶ f` in Category `X/C`
-where `f₀` and `f` are both objects of `X/C`,
-thus morphisms of form `X ⟶ ?` in Category `C` (morphisms with domain X).
-We know `f : X ⟶ Y`. Take `f₀ : X ⟶ Z₁`.
-Then `α` is determined by the object-morphism pair of `(f₀, f₁)`.
-By definitions of Under Categories, we can know that the morphism `f₁` will satisfy:
-`f₀ ≫ f₁ = f`.
-
-Assume another similar object-morphism pair in `X/C`, `(g₀, g₁)` determines
-another object `β` in `(X / C) / f`, with `g₀ : X ⟶ Z₂`.
-
-A morphism `κ : α ⟶ β` in `(X / C) / f`, by definition of Over Categories,
-is a morphism in `X/C` making the following diagram commute:
-           κ
-    α  ---------> β
-    |             |
-f₁  |             | g₁
-    ∨             ∨
-    f      ==     f
-
-so f₁ = κ ≫ g₁.
-
-As we have discussed, `α` can be determined by the pair `(f₀, f₁)`, where the latter could be used
-to formulate objects in the factorisation category.
-
-Given `f₀ : X ⟶ Z`, and `f₀ ≫ f₁ = f`, we can see that the pair `(f₀, f₁)` can also be used to
-structure a factorisation.
-The map `κ : α ⟶ β` could thus be transferred to a map `κ' : ⟨ f₀, f₁ ⟩ ⟶ ⟨ g₀, g₁ ⟩` in `Fact f`.
-Such assignment of mapping and object would form a functor, and evidently this functor is an iso if
-we try to construct the `α`s and `β`s in the reversed direction from factorisations.
-Thus we have conceptually shown `Factorisation f` is equivalent to one iterated comma category
-`(X/C)/f` (being an over category on an under category),
-and we can show similar results for `f/(C/Y)` (an under category on an over category).
 -/
 section IteratedCommaCategories
 

--- a/Mathlib/CategoryTheory/Category/Factorisation.lean
+++ b/Mathlib/CategoryTheory/Category/Factorisation.lean
@@ -155,14 +155,8 @@ we aim to show the two functors we defined above are inverses of each other.
 def factEqOverOfUnder : Factorisation f ≌ Over (Under.mk f) where
   functor := fromFactToOverOfUnder f
   inverse := fromOverOfUndertoFact f
-  unitIso := NatIso.ofComponents (fun g => {
-    hom := 𝟙 g
-    inv := 𝟙 g
-  })
-  counitIso := NatIso.ofComponents (fun g => {
-    hom := 𝟙 (fromOverOfUndertoFact f ⋙ fromFactToOverOfUnder f).obj g
-    inv := 𝟙 (fromOverOfUndertoFact f ⋙ fromFactToOverOfUnder f).obj g
-  })
+  unitIso := Iso.refl _
+  counitIso := Iso.refl _
 
 end OverOfUnder
 
@@ -184,14 +178,8 @@ Thus formulating the ≌ relationship. -/
 def factEqUnderOfOver : Factorisation f ≌ Under (Over.mk f) where
   functor := fromFactToUnderOfOver f
   inverse := fromUnderOfOvertoFact f
-  unitIso := NatIso.ofComponents (fun g => {
-    hom := 𝟙 g
-    inv := 𝟙 g
-  })
-  counitIso := NatIso.ofComponents (fun g => {
-    hom := 𝟙 (fromUnderOfOvertoFact f ⋙ fromFactToUnderOfOver f).obj g
-    inv := 𝟙 (fromUnderOfOvertoFact f ⋙ fromFactToUnderOfOver f).obj g
-  })
+  unitIso := Iso.refl _
+  counitIso := Iso.refl _
 
 end UnderOfOver
 


### PR DESCRIPTION
Completed one of the tasks in TODOs, shown and implemented the details for `(X/C)/f ≌ Factorisation f ≌ f/(C/Y)`.


---


[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
