### PR TITLE
[Merged by Bors] - fea(Algebra/**/Sub*): Subfoo.subtype_injective

### DIFF
--- a/Mathlib/Algebra/Algebra/NonUnitalSubalgebra.lean
+++ b/Mathlib/Algebra/Algebra/NonUnitalSubalgebra.lean
@@ -32,6 +32,14 @@ namespace NonUnitalSubalgebraClass
 def subtype (s : S) : s →ₙₐ[R] A :=
   { NonUnitalSubsemiringClass.subtype s, SMulMemClass.subtype s with toFun := (↑) }
 
+variable {s} in
+@[simp]
+lemma subtype_apply (x : s) : subtype s x = x := rfl
+
+lemma subtype_injective :
+    Function.Injective (subtype s) :=
+  Subtype.coe_injective
+
 @[simp]
 theorem coe_subtype : (subtype s : s → A) = ((↑) : s → A) :=
   rfl

--- a/Mathlib/Algebra/Field/Subfield/Defs.lean
+++ b/Mathlib/Algebra/Field/Subfield/Defs.lean
@@ -322,6 +322,14 @@ def subtype (s : Subfield K) : s →+* K :=
   { s.toSubmonoid.subtype, s.toAddSubgroup.subtype with toFun := (↑) }
 
 @[simp]
+lemma subtype_apply {s : Subfield K} (x : s) :
+    s.subtype x = x := rfl
+
+lemma subtype_injective (s : Subfield K) :
+    Function.Injective s.subtype :=
+  Subtype.coe_injective
+
+@[simp]
 theorem coe_subtype : ⇑(s.subtype) = ((↑) : s → K) :=
   rfl
 

--- a/Mathlib/Algebra/Group/Subgroup/Defs.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Defs.lean
@@ -194,6 +194,16 @@ instance (priority := 75) toCommGroup {G : Type*} [CommGroup G] [SetLike S G] [S
 protected def subtype : H →* G where
   toFun := ((↑) : H → G); map_one' := rfl; map_mul' := fun _ _ => rfl
 
+variable {H} in
+@[to_additive (attr := simp)]
+lemma subtype_apply (x : H) :
+    SubgroupClass.subtype H x = x := rfl
+
+@[to_additive]
+lemma subtype_injective :
+    Function.Injective (SubgroupClass.subtype H) :=
+  Subtype.coe_injective
+
 @[to_additive (attr := simp)]
 theorem coe_subtype : (SubgroupClass.subtype H : H → G) = ((↑) : H → G) := by
   rfl
@@ -522,6 +532,15 @@ protected def subtype : H →* G where
   toFun := ((↑) : H → G); map_one' := rfl; map_mul' _ _ := rfl
 
 @[to_additive (attr := simp)]
+lemma subtype_apply {s : Subgroup G} (x : s) :
+    s.subtype x = x := rfl
+
+@[to_additive]
+lemma subtype_injective (s : Subgroup G) :
+    Function.Injective s.subtype :=
+  Subtype.coe_injective
+
+@[to_additive (attr := simp)]
 theorem coe_subtype : ⇑ H.subtype = ((↑) : H → G) :=
   rfl
 
@@ -529,10 +548,6 @@ theorem coe_subtype : ⇑ H.subtype = ((↑) : H → G) :=
 alias coeSubtype := coe_subtype
 @[deprecated (since := "2025-02-18")]
 alias _root_.AddSubgroup.coeSubtype := AddSubgroup.coe_subtype
-
-@[to_additive]
-theorem subtype_injective : Function.Injective (Subgroup.subtype H) :=
-  Subtype.coe_injective
 
 /-- The inclusion homomorphism from a subgroup `H` contained in `K` to `K`. -/
 @[to_additive "The inclusion homomorphism from an additive subgroup `H` contained in `K` to `K`."]

--- a/Mathlib/Algebra/Group/Submonoid/Defs.lean
+++ b/Mathlib/Algebra/Group/Submonoid/Defs.lean
@@ -454,7 +454,6 @@ lemma subtype_injective (s : Submonoid M) :
     Function.Injective s.subtype := fun _ ↦ by
   simp
 
-@[to_additive (attr := simp)]
 lemma subtype_inj {s : Submonoid M} {x y : s} :
     s.subtype x = s.subtype y ↔ x = y :=
   s.subtype_injective.eq_iff

--- a/Mathlib/Algebra/Group/Submonoid/Defs.lean
+++ b/Mathlib/Algebra/Group/Submonoid/Defs.lean
@@ -446,6 +446,20 @@ def subtype : S →* M where
   toFun := Subtype.val; map_one' := rfl; map_mul' _ _ := by simp
 
 @[to_additive (attr := simp)]
+lemma subtype_apply {s : Submonoid M} (x : s) :
+    s.subtype x = x := rfl
+
+@[to_additive]
+lemma subtype_injective (s : Submonoid M) :
+    Function.Injective s.subtype := fun _ ↦ by
+  simp
+
+@[to_additive (attr := simp)]
+lemma subtype_inj {s : Submonoid M} {x y : s} :
+    s.subtype x = s.subtype y ↔ x = y :=
+  s.subtype_injective.eq_iff
+
+@[to_additive (attr := simp)]
 theorem coe_subtype : ⇑S.subtype = Subtype.val :=
   rfl
 

--- a/Mathlib/Algebra/Group/Submonoid/Defs.lean
+++ b/Mathlib/Algebra/Group/Submonoid/Defs.lean
@@ -374,6 +374,16 @@ instance (priority := 75) toCommMonoid {M} [CommMonoid M] {A : Type*} [SetLike A
 def subtype : S' →* M where
   toFun := Subtype.val; map_one' := rfl; map_mul' _ _ := by simp
 
+variable {S'} in
+@[to_additive (attr := simp)]
+lemma subtype_apply (x : S') :
+    SubmonoidClass.subtype S' x = x := rfl
+
+@[to_additive]
+lemma subtype_injective :
+    Function.Injective (SubmonoidClass.subtype S') :=
+  Subtype.coe_injective
+
 @[to_additive (attr := simp)]
 theorem coe_subtype : (SubmonoidClass.subtype S' : S' → M) = Subtype.val :=
   rfl
@@ -451,12 +461,8 @@ lemma subtype_apply {s : Submonoid M} (x : s) :
 
 @[to_additive]
 lemma subtype_injective (s : Submonoid M) :
-    Function.Injective s.subtype := fun _ ↦ by
-  simp
-
-lemma subtype_inj {s : Submonoid M} {x y : s} :
-    s.subtype x = s.subtype y ↔ x = y :=
-  s.subtype_injective.eq_iff
+    Function.Injective s.subtype :=
+  Subtype.coe_injective
 
 @[to_additive (attr := simp)]
 theorem coe_subtype : ⇑S.subtype = Subtype.val :=

--- a/Mathlib/Algebra/Group/Subsemigroup/Defs.lean
+++ b/Mathlib/Algebra/Group/Subsemigroup/Defs.lean
@@ -270,6 +270,16 @@ instance toCommSemigroup {M} [CommSemigroup M] {A : Type*} [SetLike A M] [MulMem
 def subtype : S' →ₙ* M where
   toFun := Subtype.val; map_mul' := fun _ _ => rfl
 
+variable {S'} in
+@[to_additive (attr := simp)]
+lemma subtype_apply (x : S') :
+    MulMemClass.subtype S' x = x := rfl
+
+@[to_additive]
+lemma subtype_injective :
+    Function.Injective (MulMemClass.subtype S') :=
+  Subtype.coe_injective
+
 @[to_additive (attr := simp)]
 theorem coe_subtype : (MulMemClass.subtype S' : S' → M) = Subtype.val :=
   rfl

--- a/Mathlib/Algebra/Module/Submodule/LinearMap.lean
+++ b/Mathlib/Algebra/Module/Submodule/LinearMap.lean
@@ -47,6 +47,15 @@ protected def subtype : S' →ₗ[R] M where
   map_add' _ _ := rfl
   map_smul' _ _ := rfl
 
+variable {S'} in
+@[simp]
+lemma subtype_apply (x : S') :
+    SMulMemClass.subtype S' x = x := rfl
+
+lemma subtype_injective :
+    Function.Injective (SMulMemClass.subtype S') :=
+  Subtype.coe_injective
+
 @[simp]
 protected theorem coe_subtype : (SMulMemClass.subtype S' : S' → M) = Subtype.val :=
   rfl
@@ -75,8 +84,14 @@ protected def subtype : p →ₗ[R] M where
   map_add' := by simp [coe_smul]
   map_smul' := by simp [coe_smul]
 
+variable {p} in
+@[simp]
 theorem subtype_apply (x : p) : p.subtype x = x :=
   rfl
+
+lemma subtype_injective :
+    Function.Injective p.subtype :=
+  Subtype.coe_injective
 
 @[simp]
 theorem coe_subtype : (Submodule.subtype p : p → M) = Subtype.val :=

--- a/Mathlib/Algebra/Ring/Subring/Defs.lean
+++ b/Mathlib/Algebra/Ring/Subring/Defs.lean
@@ -338,7 +338,6 @@ lemma subtype_injective (s : Subring R) :
     Function.Injective s.subtype :=
   s.toSubmonoid.subtype_injective
 
-@[simp]
 lemma subtype_inj {s : Subring R} {x y : s} :
     s.subtype x = s.subtype y ↔ x = y :=
   s.subtype_injective.eq_iff

--- a/Mathlib/Algebra/Ring/Subring/Defs.lean
+++ b/Mathlib/Algebra/Ring/Subring/Defs.lean
@@ -116,6 +116,15 @@ def subtype (s : S) : s →+* R :=
   { SubmonoidClass.subtype s, AddSubgroupClass.subtype s with
     toFun := (↑) }
 
+variable {s} in
+@[simp]
+lemma subtype_apply (x : s) :
+    SubringClass.subtype s x = x := rfl
+
+lemma subtype_injective :
+    Function.Injective (subtype s) :=
+  Subtype.coe_injective
+
 @[simp]
 theorem coe_subtype : (subtype s : s → R) = ((↑) : s → R) :=
   rfl
@@ -327,10 +336,6 @@ def subtype (s : Subring R) : s →+* R :=
   { s.toSubmonoid.subtype, s.toAddSubgroup.subtype with toFun := (↑) }
 
 @[simp]
-theorem coe_subtype : ⇑s.subtype = ((↑) : s → R) :=
-  rfl
-
-@[simp]
 lemma subtype_apply {s : Subring R} (x : s) :
     s.subtype x = x := rfl
 
@@ -338,9 +343,9 @@ lemma subtype_injective (s : Subring R) :
     Function.Injective s.subtype :=
   s.toSubmonoid.subtype_injective
 
-lemma subtype_inj {s : Subring R} {x y : s} :
-    s.subtype x = s.subtype y ↔ x = y :=
-  s.subtype_injective.eq_iff
+@[simp]
+theorem coe_subtype : ⇑s.subtype = ((↑) : s → R) :=
+  rfl
 
 @[deprecated (since := "2025-02-18")]
 alias coeSubtype := coe_subtype

--- a/Mathlib/Algebra/Ring/Subring/Defs.lean
+++ b/Mathlib/Algebra/Ring/Subring/Defs.lean
@@ -330,6 +330,19 @@ def subtype (s : Subring R) : s →+* R :=
 theorem coe_subtype : ⇑s.subtype = ((↑) : s → R) :=
   rfl
 
+@[simp]
+lemma subtype_apply {s : Subring R} (x : s) :
+    s.subtype x = x := rfl
+
+lemma subtype_injective (s : Subring R) :
+    Function.Injective s.subtype :=
+  s.toSubmonoid.subtype_injective
+
+@[simp]
+lemma subtype_inj {s : Subring R} {x y : s} :
+    s.subtype x = s.subtype y ↔ x = y :=
+  s.subtype_injective.eq_iff
+
 @[deprecated (since := "2025-02-18")]
 alias coeSubtype := coe_subtype
 

--- a/Mathlib/Algebra/Ring/Subsemiring/Defs.lean
+++ b/Mathlib/Algebra/Ring/Subsemiring/Defs.lean
@@ -88,6 +88,15 @@ def subtype : s →+* R :=
 theorem coe_subtype : (subtype s : s → R) = ((↑) : s → R) :=
   rfl
 
+variable {s} in
+@[simp]
+lemma subtype_apply (x : s) :
+    SubsemiringClass.subtype s x = x := rfl
+
+lemma subtype_injective :
+    Function.Injective (SubsemiringClass.subtype s) := fun _ ↦ by
+  simp
+
 -- Prefer subclasses of `Semiring` over subclasses of `SubsemiringClass`.
 /-- A subsemiring of a `Semiring` is a `Semiring`. -/
 instance (priority := 75) toSemiring {R} [Semiring R] [SetLike S R] [SubsemiringClass S R] :
@@ -287,11 +296,18 @@ instance toCommSemiring {R} [CommSemiring R] (s : Subsemiring R) : CommSemiring 
 def subtype : s →+* R :=
   { s.toSubmonoid.subtype, s.toAddSubmonoid.subtype with toFun := (↑) }
 
+variable {s} in
+@[simp]
+lemma subtype_apply (x : s) :
+    s.subtype x = x := rfl
+
+lemma subtype_injective :
+    Function.Injective s.subtype :=
+  Subtype.coe_injective
+
 @[simp]
 theorem coe_subtype : ⇑s.subtype = ((↑) : s → R) :=
   rfl
-
-theorem subtype_injective : Function.Injective s.subtype := Subtype.coe_injective
 
 protected theorem nsmul_mem {x : R} (hx : x ∈ s) (n : ℕ) : n • x ∈ s :=
   nsmul_mem hx n

--- a/Mathlib/Algebra/Star/NonUnitalSubalgebra.lean
+++ b/Mathlib/Algebra/Star/NonUnitalSubalgebra.lean
@@ -75,6 +75,14 @@ def subtype (s : S) : s →⋆ₙₐ[R] A :=
     toFun := Subtype.val
     map_star' := fun _ => rfl }
 
+variable {s} in
+@[simp]
+lemma subtype_apply (x : s) : subtype s x = x := rfl
+
+lemma subtype_injective :
+    Function.Injective (subtype s) :=
+  Subtype.coe_injective
+
 @[simp]
 theorem coe_subtype : (subtype s : s → A) = Subtype.val :=
   rfl

--- a/Mathlib/Data/Finset/Sort.lean
+++ b/Mathlib/Data/Finset/Sort.lean
@@ -188,7 +188,7 @@ theorem range_orderEmbOfFin (s : Finset α) {k : ℕ} (h : s.card = k) :
     Set.range (s.orderEmbOfFin h) = s := by
   simp only [orderEmbOfFin, Set.range_comp ((↑) : _ → α) (s.orderIsoOfFin h),
   RelEmbedding.coe_trans, Set.image_univ, Finset.orderEmbOfFin, RelIso.range_eq,
-    OrderEmbedding.subtype_apply, OrderIso.coe_toOrderEmbedding, eq_self_iff_true,
+    OrderEmbedding.coe_subtype, OrderIso.coe_toOrderEmbedding, eq_self_iff_true,
     Subtype.range_coe_subtype, Finset.setOf_mem, Finset.coe_inj]
 
 /-- The bijection `orderEmbOfFin s h` sends `0` to the minimum of `s`. -/

--- a/Mathlib/GroupTheory/GroupAction/SubMulAction.lean
+++ b/Mathlib/GroupTheory/GroupAction/SubMulAction.lean
@@ -247,9 +247,14 @@ protected def subtype : p →[R] M where
   toFun := Subtype.val
   map_smul' := by simp [val_smul]
 
+variable {p} in
 @[to_additive (attr := simp)]
 theorem subtype_apply (x : p) : p.subtype x = x :=
   rfl
+
+lemma subtype_injective :
+    Function.Injective p.subtype :=
+  Subtype.coe_injective
 
 @[to_additive]
 theorem subtype_eq_val : (SubMulAction.subtype p : p → M) = Subtype.val :=
@@ -272,6 +277,15 @@ instance (priority := 75) toMulAction : MulAction R S' :=
 @[to_additive "The natural `AddActionHom` over `R` from a `SubAddAction` of `M` to `M`."]
 protected def subtype : S' →[R] M where
   toFun := Subtype.val; map_smul' _ _ := rfl
+
+variable {S'} in
+@[simp]
+lemma subtype_apply (x : S') :
+    SMulMemClass.subtype S' x = x := rfl
+
+lemma subtype_injective :
+    Function.Injective (SMulMemClass.subtype S') :=
+  Subtype.coe_injective
 
 @[to_additive (attr := simp)]
 protected theorem coe_subtype : (SMulMemClass.subtype S' : S' → M) = Subtype.val :=

--- a/Mathlib/LinearAlgebra/AffineSpace/AffineSubspace.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/AffineSubspace.lean
@@ -374,8 +374,12 @@ protected def subtype (s : AffineSubspace k P) [Nonempty s] : s →ᵃ[k] P wher
 theorem subtype_linear (s : AffineSubspace k P) [Nonempty s] :
     s.subtype.linear = s.direction.subtype := rfl
 
-theorem subtype_apply (s : AffineSubspace k P) [Nonempty s] (p : s) : s.subtype p = p :=
+@[simp]
+theorem subtype_apply {s : AffineSubspace k P} [Nonempty s] (p : s) : s.subtype p = p :=
   rfl
+
+theorem subtype_injective (s : AffineSubspace k P) [Nonempty s] : Function.Injective s.subtype :=
+  Subtype.coe_injective
 
 @[simp]
 theorem coe_subtype (s : AffineSubspace k P) [Nonempty s] : (s.subtype : s → P) = ((↑) : s → P) :=
@@ -383,9 +387,6 @@ theorem coe_subtype (s : AffineSubspace k P) [Nonempty s] : (s.subtype : s → P
 
 @[deprecated (since := "2025-02-18")]
 alias coeSubtype := coe_subtype
-
-theorem injective_subtype (s : AffineSubspace k P) [Nonempty s] : Function.Injective s.subtype :=
-  Subtype.coe_injective
 
 /-- Two affine subspaces with nonempty intersection are equal if and only if their directions are
 equal. -/

--- a/Mathlib/Logic/Embedding/Basic.lean
+++ b/Mathlib/Logic/Embedding/Basic.lean
@@ -206,6 +206,13 @@ def subtype {α} (p : α → Prop) : Subtype p ↪ α :=
   ⟨Subtype.val, fun _ _ => Subtype.ext⟩
 
 @[simp]
+theorem subtype_apply {α} {p : α → Prop} (x : Subtype p) : subtype p x = x :=
+  rfl
+
+theorem subtype_injective {α} (p : α → Prop) : Function.Injective (subtype p) :=
+  Subtype.coe_injective
+
+@[simp]
 theorem coe_subtype {α} (p : α → Prop) : ↑(subtype p) = Subtype.val :=
   rfl
 

--- a/Mathlib/ModelTheory/ElementarySubstructures.lean
+++ b/Mathlib/ModelTheory/ElementarySubstructures.lean
@@ -70,7 +70,14 @@ def subtype (S : L.ElementarySubstructure M) : S ↪ₑ[L] M where
   map_formula' := S.isElementary
 
 @[simp]
-theorem coe_subtype {S : L.ElementarySubstructure M} : ⇑S.subtype = ((↑) : S → M) :=
+theorem subtype_apply {S : L.ElementarySubstructure M} {x : S} : subtype S x = x :=
+  rfl
+
+theorem subtype_injective (S : L.ElementarySubstructure M): Function.Injective (subtype S) :=
+  Subtype.coe_injective
+
+@[simp]
+theorem coe_subtype (S : L.ElementarySubstructure M) : ⇑S.subtype = Subtype.val :=
   rfl
 
 @[deprecated (since := "2025-02-18")]

--- a/Mathlib/ModelTheory/Substructures.lean
+++ b/Mathlib/ModelTheory/Substructures.lean
@@ -628,6 +628,13 @@ def subtype (S : L.Substructure M) : S ↪[L] M where
   inj' := Subtype.coe_injective
 
 @[simp]
+theorem subtype_apply {S : L.Substructure M} {x : S} : subtype S x = x :=
+  rfl
+
+theorem subtype_injective (S : L.Substructure M): Function.Injective (subtype S) :=
+  Subtype.coe_injective
+
+@[simp]
 theorem coe_subtype : ⇑S.subtype = ((↑) : S → M) :=
   rfl
 

--- a/Mathlib/Order/Atoms.lean
+++ b/Mathlib/Order/Atoms.lean
@@ -233,13 +233,13 @@ variable [PartialOrder α] {a b : α}
 theorem Set.Ici.isAtom_iff {b : Set.Ici a} : IsAtom b ↔ a ⋖ b := by
   rw [← bot_covBy_iff]
   refine (Set.OrdConnected.apply_covBy_apply_iff (OrderEmbedding.subtype fun c => a ≤ c) ?_).symm
-  simpa only [OrderEmbedding.subtype_apply, Subtype.range_coe_subtype] using Set.ordConnected_Ici
+  simpa only [OrderEmbedding.coe_subtype, Subtype.range_coe_subtype] using Set.ordConnected_Ici
 
 @[simp]
 theorem Set.Iic.isCoatom_iff {a : Set.Iic b} : IsCoatom a ↔ ↑a ⋖ b := by
   rw [← covBy_top_iff]
   refine (Set.OrdConnected.apply_covBy_apply_iff (OrderEmbedding.subtype fun c => c ≤ b) ?_).symm
-  simpa only [OrderEmbedding.subtype_apply, Subtype.range_coe_subtype] using Set.ordConnected_Iic
+  simpa only [OrderEmbedding.coe_subtype, Subtype.range_coe_subtype] using Set.ordConnected_Iic
 
 theorem covBy_iff_atom_Ici (h : a ≤ b) : a ⋖ b ↔ IsAtom (⟨b, h⟩ : Set.Ici a) := by simp
 

--- a/Mathlib/Order/Hom/Basic.lean
+++ b/Mathlib/Order/Hom/Basic.lean
@@ -644,9 +644,19 @@ theorem coe_ofStrictMono {α β} [LinearOrder α] [Preorder β] {f : α → β} 
   rfl
 
 /-- Embedding of a subtype into the ambient type as an `OrderEmbedding`. -/
-@[simps! (config := .asFn)]
 def subtype (p : α → Prop) : Subtype p ↪o α :=
   ⟨Function.Embedding.subtype p, Iff.rfl⟩
+
+@[simp]
+theorem subtype_apply {p : α → Prop} (x : Subtype p) : subtype p x = x :=
+  rfl
+
+theorem subtype_injective (p : α → Prop) : Function.Injective (subtype p) :=
+  Subtype.coe_injective
+
+@[simp]
+theorem coe_subtype (p : α → Prop) : ⇑(subtype p) = Subtype.val :=
+  rfl
 
 /-- Convert an `OrderEmbedding` to an `OrderHom`. -/
 @[simps (config := .asFn)]

--- a/Mathlib/RingTheory/NonUnitalSubring/Defs.lean
+++ b/Mathlib/RingTheory/NonUnitalSubring/Defs.lean
@@ -86,6 +86,14 @@ def subtype (s : S) : s →ₙ+* R :=
     AddSubgroupClass.subtype s with
     toFun := Subtype.val }
 
+variable {s} in
+@[simp]
+theorem subtype_apply (x : s) : subtype s x = x :=
+  rfl
+
+theorem subtype_injective : Function.Injective (subtype s) :=
+  Subtype.coe_injective
+
 @[simp]
 theorem coe_subtype : (subtype s : s → R) = Subtype.val :=
   rfl

--- a/Mathlib/RingTheory/NonUnitalSubsemiring/Defs.lean
+++ b/Mathlib/RingTheory/NonUnitalSubsemiring/Defs.lean
@@ -56,6 +56,14 @@ instance noZeroDivisors [NoZeroDivisors R] : NoZeroDivisors s :=
 def subtype : s →ₙ+* R :=
   { AddSubmonoidClass.subtype s, MulMemClass.subtype s with toFun := (↑) }
 
+variable {s} in
+@[simp]
+theorem subtype_apply (x : s) : subtype s x = x :=
+  rfl
+
+theorem subtype_injective : Function.Injective (subtype s) :=
+  Subtype.coe_injective
+
 @[simp]
 theorem coe_subtype : (subtype s : s → R) = ((↑) : s → R) :=
   rfl

--- a/Mathlib/RingTheory/TwoSidedIdeal/Operations.lean
+++ b/Mathlib/RingTheory/TwoSidedIdeal/Operations.lean
@@ -257,6 +257,13 @@ def subtype : I →ₗ[R] R where
   map_add' _ _ := rfl
   map_smul' _ _ := rfl
 
+theorem subtype_injective : Function.Injective (subtype I) :=
+  Subtype.coe_injective
+
+@[simp]
+theorem coe_subtype : ⇑(subtype I) = Subtype.val :=
+  rfl
+
 /--
 For any `RingCon R`, when we view it as an ideal in `Rᵒᵖ`, `subtype` is the injective `Rᵐᵒᵖ`-linear
 map `I → Rᵐᵒᵖ`.
@@ -266,6 +273,9 @@ def subtypeMop : I →ₗ[Rᵐᵒᵖ] Rᵐᵒᵖ where
   toFun x := MulOpposite.op x.1
   map_add' _ _ := rfl
   map_smul' _ _ := rfl
+
+theorem subtypeMop_injective : Function.Injective (subtypeMop I) :=
+  MulOpposite.op_injective.comp Subtype.coe_injective
 
 /-- Given an ideal `I`, `span I` is the smallest two-sided ideal containing `I`. -/
 def fromIdeal : Ideal R →o TwoSidedIdeal R where

--- a/Mathlib/RingTheory/Valuation/ValuationSubring.lean
+++ b/Mathlib/RingTheory/Valuation/ValuationSubring.lean
@@ -226,6 +226,18 @@ def inclusion (R S : ValuationSubring K) (h : R ≤ S) : R →+* S :=
 def subtype (R : ValuationSubring K) : R →+* K :=
   Subring.subtype R.toSubring
 
+@[simp]
+lemma subtype_apply {R : ValuationSubring K} (x : R) :
+    R.subtype x = x := rfl
+
+lemma subtype_injective (R : ValuationSubring K) :
+    Function.Injective R.subtype :=
+  R.toSubring.subtype_injective
+
+lemma subtype_inj {R : ValuationSubring K} {x y : R} :
+    R.subtype x = R.subtype y ↔ x = y :=
+  R.subtype_injective.eq_iff
+
 /-- The canonical map on value groups induced by a coarsening of valuation rings. -/
 def mapOfLE (R S : ValuationSubring K) (h : R ≤ S) : R.ValueGroup →*₀ S.ValueGroup where
   toFun := Quotient.map' id fun _ _ ⟨u, hu⟩ => ⟨Units.map (R.inclusion S h).toMonoidHom u, hu⟩

--- a/Mathlib/RingTheory/Valuation/ValuationSubring.lean
+++ b/Mathlib/RingTheory/Valuation/ValuationSubring.lean
@@ -234,9 +234,9 @@ lemma subtype_injective (R : ValuationSubring K) :
     Function.Injective R.subtype :=
   R.toSubring.subtype_injective
 
-lemma subtype_inj {R : ValuationSubring K} {x y : R} :
-    R.subtype x = R.subtype y ↔ x = y :=
-  R.subtype_injective.eq_iff
+@[simp]
+theorem coe_subtype (R : ValuationSubring K) : ⇑(subtype R) = Subtype.val :=
+  rfl
 
 /-- The canonical map on value groups induced by a coarsening of valuation rings. -/
 def mapOfLE (R S : ValuationSubring K) (h : R ≤ S) : R.ValueGroup →*₀ S.ValueGroup where


### PR DESCRIPTION
For all subFoo that I could find that defined a `FooHom` from the subfoo to the ambient foo, define
`subtype_apply` and `subtype_injective`.

Do no clean up of ones that are protected vs not:
there is some discrepancy of how that's handled in `SubFooClass` variants.

From FLT


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
