### PR TITLE
[Merged by Bors] - chore: add `coe` attribute to `ContinuousAffineMap.toAffineMap`

### DIFF
--- a/Mathlib/Analysis/Normed/Affine/ContinuousAffineMap.lean
+++ b/Mathlib/Analysis/Normed/Affine/ContinuousAffineMap.lean
@@ -98,7 +98,7 @@ theorem contLinear_eq_zero_iff_exists_const (f : P →ᴬ[R] Q) :
     intro q
     refine ⟨fun h => ?_, fun h => ?_⟩ <;> ext
     · rw [h]; rfl
-    · rw [← coe_to_affineMap, h]; rfl
+    · rw [← coe_toAffineMap, h]; rfl
   simp_rw [h₁, h₂]
   exact (f : P →ᵃ[R] Q).linear_eq_zero_iff_exists_const
 

--- a/Mathlib/Topology/Algebra/ContinuousAffineMap.lean
+++ b/Mathlib/Topology/Algebra/ContinuousAffineMap.lean
@@ -46,7 +46,9 @@ variable [AddCommGroup W] [Module R W] [TopologicalSpace Q] [AddTorsor W Q]
 instance : Coe (P →ᴬ[R] Q) (P →ᵃ[R] Q) :=
   ⟨toAffineMap⟩
 
-theorem to_affineMap_injective {f g : P →ᴬ[R] Q} (h : (f : P →ᵃ[R] Q) = (g : P →ᵃ[R] Q)) :
+attribute [coe] ContinuousAffineMap.toAffineMap
+
+theorem toAffineMap_injective {f g : P →ᴬ[R] Q} (h : (f : P →ᵃ[R] Q) = (g : P →ᵃ[R] Q)) :
     f = g := by
   cases f
   cases g
@@ -54,7 +56,7 @@ theorem to_affineMap_injective {f g : P →ᴬ[R] Q} (h : (f : P →ᵃ[R] Q) = 
 
 instance : FunLike (P →ᴬ[R] Q) P Q where
   coe f := f.toAffineMap
-  coe_injective' _ _ h := to_affineMap_injective <| DFunLike.coe_injective h
+  coe_injective' _ _ h := toAffineMap_injective <| DFunLike.coe_injective h
 
 instance : ContinuousMapClass (P →ᴬ[R] Q) P Q where
   map_continuous := cont
@@ -82,10 +84,10 @@ instance : CoeHead (P →ᴬ[R] Q) C(P, Q) :=
 @[simp]
 theorem toContinuousMap_coe (f : P →ᴬ[R] Q) : f.toContinuousMap = ↑f := rfl
 
-@[simp] -- Porting note: removed `norm_cast`
-theorem coe_to_affineMap (f : P →ᴬ[R] Q) : ((f : P →ᵃ[R] Q) : P → Q) = f := rfl
+@[simp, norm_cast]
+theorem coe_toAffineMap (f : P →ᴬ[R] Q) : ((f : P →ᵃ[R] Q) : P → Q) = f := rfl
 
--- Porting note: removed `norm_cast` and `simp` since proof is `simp only [ContinuousMap.coe_mk]`
+@[simp, norm_cast]
 theorem coe_to_continuousMap (f : P →ᴬ[R] Q) : ((f : C(P, Q)) : P → Q) = f := rfl
 
 theorem to_continuousMap_injective {f g : P →ᴬ[R] Q} (h : (f : C(P, Q)) = (g : C(P, Q))) :
@@ -93,8 +95,8 @@ theorem to_continuousMap_injective {f g : P →ᴬ[R] Q} (h : (f : C(P, Q)) = (g
   ext a
   exact ContinuousMap.congr_fun h a
 
--- Porting note: removed `norm_cast`
-theorem coe_affineMap_mk (f : P →ᵃ[R] Q) (h) : ((⟨f, h⟩ : P →ᴬ[R] Q) : P →ᵃ[R] Q) = f := rfl
+@[norm_cast]
+theorem coe_toAffineMap_mk (f : P →ᵃ[R] Q) (h) : ((⟨f, h⟩ : P →ᴬ[R] Q) : P →ᵃ[R] Q) = f := rfl
 
 @[norm_cast]
 theorem coe_continuousMap_mk (f : P →ᵃ[R] Q) (h) : ((⟨f, h⟩ : P →ᴬ[R] Q) : C(P, Q)) = ⟨f, h⟩ := rfl


### PR DESCRIPTION
There is already an instance, it's just that the attribute was missing. Resolves a few porting notes because now the lemmas can be marked `norm_cast`.

Also fixes some minor issues regarding naming. `to_affineMap` → `toAffineMap` in names referencing this function.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
