### PR TITLE
[Merged by Bors] - chore: automated `var decl var` replacements

### DIFF
--- a/Mathlib/Algebra/Category/BialgebraCat/Basic.lean
+++ b/Mathlib/Algebra/Category/BialgebraCat/Basic.lean
@@ -41,15 +41,12 @@ open Bialgebra
 instance : CoeSort (BialgebraCat.{v} R) (Type v) :=
   ⟨(·.carrier)⟩
 
-variable (R)
-
+variable (R) in
 /-- The object in the category of `R`-bialgebras associated to an `R`-bialgebra. -/
 @[simps]
 def of (X : Type v) [Ring X] [Bialgebra R X] :
     BialgebraCat R where
   carrier := X
-
-variable {R}
 
 @[simp]
 lemma of_comul {X : Type v} [Ring X] [Bialgebra R X] :

--- a/Mathlib/Algebra/Category/ModuleCat/Basic.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Basic.lean
@@ -495,8 +495,7 @@ lemma smul_naturality {M N : ModuleCat.{v} R} (f : M ⟶ N) (r : R) :
   ext x
   exact (f.hom.map_smul r x).symm
 
-variable (R)
-
+variable (R) in
 /-- The scalar multiplication on `ModuleCat R` considered as a morphism of rings
 to the endomorphisms of the forgetful functor to `AddCommGrp)`. -/
 @[simps]
@@ -508,8 +507,6 @@ def smulNatTrans : R →+* End (forget₂ (ModuleCat R) AddCommGrp) where
   map_zero' := NatTrans.ext (by aesop_cat)
   map_mul' _ _ := NatTrans.ext (by aesop_cat)
   map_add' _ _ := NatTrans.ext (by aesop_cat)
-
-variable {R}
 
 /-- Given `A : AddCommGrp` and a ring morphism `R →+* End A`, this is a type synonym
 for `A`, on which we shall define a structure of `R`-module. -/

--- a/Mathlib/Algebra/Field/Subfield/Basic.lean
+++ b/Mathlib/Algebra/Field/Subfield/Basic.lean
@@ -336,16 +336,13 @@ theorem closure_induction {s : Set K} {p : ∀ x ∈ closure s, Prop}
       inv_mem' := by rintro _ ⟨_, hx⟩; exact ⟨_, inv _ _ hx⟩ }
   ((closure_le (t := this)).2 (fun x hx ↦ ⟨_, mem x hx⟩) h).2
 
-variable (K)
-
+variable (K) in
 /-- `closure` forms a Galois insertion with the coercion to set. -/
 protected def gi : GaloisInsertion (@closure K _) (↑) where
   choice s _ := closure s
   gc _ _ := closure_le
   le_l_u _ := subset_closure
   choice_eq _ _ := rfl
-
-variable {K}
 
 /-- Closure of a subfield `S` equals `S`. -/
 @[simp]

--- a/Mathlib/Algebra/GradedMonoid.lean
+++ b/Mathlib/Algebra/GradedMonoid.lean
@@ -317,13 +317,10 @@ variable [AddMonoid ι] [GMonoid A]
 instance : NatPow (A 0) where
   pow x n := @Eq.rec ι (n • (0 : ι)) (fun a _ => A a) (GMonoid.gnpow n x) 0 (nsmul_zero n)
 
-variable {A}
-
+variable {A} in
 @[simp]
 theorem mk_zero_pow (a : A 0) (n : ℕ) : mk _ (a ^ n) = mk _ a ^ n :=
   Sigma.ext (nsmul_zero n).symm <| eqRec_heq _ _
-
-variable (A)
 
 /-- The `Monoid` structure derived from `GMonoid A`. -/
 instance GradeZero.monoid : Monoid (A 0) :=

--- a/Mathlib/Algebra/Group/Subgroup/Basic.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Basic.lean
@@ -380,13 +380,10 @@ theorem le_normalizer_map (f : G →* N) : H.normalizer.map f ≤ (H.map f).norm
     rw [hx]
     simp [hy, hyH, mul_assoc]
 
-variable (G)
-
+variable (G) in
 /-- Every proper subgroup `H` of `G` is a proper normal subgroup of the normalizer of `H` in `G`. -/
 def _root_.NormalizerCondition :=
   ∀ H : Subgroup G, H < ⊤ → H < normalizer H
-
-variable {G}
 
 /-- Alternative phrasing of the normalizer condition: Only the full group is self-normalizing.
 This may be easier to work with, as it avoids inequalities and negations. -/

--- a/Mathlib/Algebra/Group/Subgroup/Lattice.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Lattice.lean
@@ -386,8 +386,7 @@ theorem closure_closure_coe_preimage {k : Set G} : closure (((↑) : closure k �
     closure_induction (fun _ h ↦ subset_closure h) (one_mem _) (fun _ _ _ _ ↦ mul_mem)
       (fun _ _ ↦ inv_mem) hx'
 
-variable (G)
-
+variable (G) in
 /-- `closure` forms a Galois insertion with the coercion to set. -/
 @[to_additive "`closure` forms a Galois insertion with the coercion to set."]
 protected def gi : GaloisInsertion (@closure G _) (↑) where
@@ -395,8 +394,6 @@ protected def gi : GaloisInsertion (@closure G _) (↑) where
   gc s t := @closure_le _ _ t s
   le_l_u _s := subset_closure
   choice_eq _s _h := rfl
-
-variable {G}
 
 /-- Subgroup closure of a set is monotone in its argument: if `h ⊆ k`,
 then `closure h ≤ closure k`. -/

--- a/Mathlib/Algebra/Homology/HomotopyCategory/Pretriangulated.lean
+++ b/Mathlib/Algebra/Homology/HomotopyCategory/Pretriangulated.lean
@@ -79,13 +79,10 @@ a morphism `φ : K ⟶ L` in the category `CochainComplex C ℤ`. -/
 noncomputable abbrev triangleh : Triangle (HomotopyCategory C (ComplexShape.up ℤ)) :=
   (HomotopyCategory.quotient _ _).mapTriangle.obj (triangle φ)
 
-variable (K)
-
+variable (K) in
 /-- The mapping cone of the identity is contractible. -/
 noncomputable def homotopyToZeroOfId : Homotopy (𝟙 (mappingCone (𝟙 K))) 0 :=
   descHomotopy (𝟙 K) _ _ 0 (inl _) (by simp) (by simp)
-
-variable {K}
 
 section mapOfHomotopy
 

--- a/Mathlib/Algebra/Module/LocalizedModule/Basic.lean
+++ b/Mathlib/Algebra/Module/LocalizedModule/Basic.lean
@@ -978,15 +978,12 @@ theorem mk'_add_mk' (m₁ m₂ : M) (s₁ s₂ : S) :
 @[simp]
 theorem mk'_zero (s : S) : mk' f 0 s = 0 := by rw [← zero_smul R (0 : M), mk'_smul, zero_smul]
 
-variable (S)
-
+variable (S) in
 @[simp]
 theorem mk'_one (m : M) : mk' f m (1 : S) = f m := by
   delta mk'
   rw [fromLocalizedModule_mk, Module.End_algebraMap_isUnit_inv_apply_eq_iff, Submonoid.coe_one,
     one_smul]
-
-variable {S}
 
 @[simp]
 theorem mk'_cancel (m : M) (s : S) : mk' f (s • m) s = f m := by

--- a/Mathlib/Algebra/Module/NatInt.lean
+++ b/Mathlib/Algebra/Module/NatInt.lean
@@ -62,8 +62,7 @@ instance AddCommGroup.toIntModule : Module ℤ M where
 
 end AddCommGroup
 
-variable (R)
-
+variable (R) in
 /-- An `AddCommMonoid` that is a `Module` over a `Ring` carries a natural `AddCommGroup`
 structure.
 See note [reducible non-instances]. -/
@@ -79,8 +78,6 @@ abbrev Module.addCommMonoidToAddCommGroup
     zsmul_zero' := fun a => by simpa only [Int.cast_zero] using zero_smul R a
     zsmul_succ' := fun z a => by simp [add_comm, add_smul]
     zsmul_neg' := fun z a => by simp [← smul_assoc, neg_one_smul] }
-
-variable {R}
 
 section AddCommMonoid
 

--- a/Mathlib/Algebra/Module/Submodule/Bilinear.lean
+++ b/Mathlib/Algebra/Module/Submodule/Bilinear.lean
@@ -50,7 +50,7 @@ theorem map₂_le {f : M →ₗ[R] N →ₗ[R] P} {p : Submodule R M} {q : Submo
   ⟨fun H _m hm _n hn => H <| apply_mem_map₂ _ hm hn, fun H =>
     iSup_le fun ⟨m, hm⟩ => map_le_iff_le_comap.2 fun n hn => H m hm n hn⟩
 
-variable (R)
+variable (R) in
 theorem map₂_span_span (f : M →ₗ[R] N →ₗ[R] P) (s : Set M) (t : Set N) :
     map₂ f (span R s) (span R t) = span R (Set.image2 (fun m n => f m n) s t) := by
   apply le_antisymm
@@ -68,8 +68,6 @@ theorem map₂_span_span (f : M →ₗ[R] N →ₗ[R] P) (s : Set M) (t : Set N)
   · rw [span_le, image2_subset_iff]
     intro a ha b hb
     exact apply_mem_map₂ _ (subset_span ha) (subset_span hb)
-variable {R}
-
 @[simp]
 theorem map₂_bot_right (f : M →ₗ[R] N →ₗ[R] P) (p : Submodule R M) : map₂ f p ⊥ = ⊥ :=
   eq_bot_iff.2 <|

--- a/Mathlib/Algebra/Module/Submodule/Ker.lean
+++ b/Mathlib/Algebra/Module/Submodule/Ker.lean
@@ -172,12 +172,9 @@ theorem injOn_of_disjoint_ker {p : Submodule R M} {s : Set M} (h : s ⊆ p)
     (hd : Disjoint p (ker f)) : Set.InjOn f s := fun _ hx _ hy =>
   disjoint_ker'.1 hd _ (h hx) _ (h hy)
 
-variable (F)
-
+variable (F) in
 theorem _root_.LinearMapClass.ker_eq_bot : ker f = ⊥ ↔ Injective f := by
   simpa [disjoint_iff_inf_le] using disjoint_ker' (f := f) (p := ⊤)
-
-variable {F}
 
 theorem ker_eq_bot {f : M →ₛₗ[τ₁₂] M₂} : ker f = ⊥ ↔ Injective f :=
   LinearMapClass.ker_eq_bot _

--- a/Mathlib/Algebra/Module/ZLattice/Basic.lean
+++ b/Mathlib/Algebra/Module/ZLattice/Basic.lean
@@ -178,13 +178,10 @@ theorem fract_zSpan_add (m : E) {v : E} (h : v ∈ span ℤ (Set.range b)) :
 theorem fract_add_ZSpan (m : E) {v : E} (h : v ∈ span ℤ (Set.range b)) :
     fract b (m + v) = fract b m := by rw [add_comm, fract_zSpan_add b m h]
 
-variable {b}
-
+variable {b} in
 theorem fract_eq_self {x : E} : fract b x = x ↔ x ∈ fundamentalDomain b := by
   classical simp only [Basis.ext_elem_iff b, repr_fract_apply, Int.fract_eq_self,
     mem_fundamentalDomain, Set.mem_Ico]
-
-variable (b)
 
 theorem fract_mem_fundamentalDomain (x : E) : fract b x ∈ fundamentalDomain b :=
   fract_eq_self.mp (fract_fract b _)

--- a/Mathlib/Algebra/MvPolynomial/Basic.lean
+++ b/Mathlib/Algebra/MvPolynomial/Basic.lean
@@ -828,7 +828,6 @@ theorem constantCoeff_C (r : R) : constantCoeff (C r : MvPolynomial σ R) = r :=
   classical simp [constantCoeff_eq]
 
 variable (R) in
-
 @[simp]
 theorem constantCoeff_X (i : σ) : constantCoeff (X i : MvPolynomial σ R) = 0 := by
   simp [constantCoeff_eq]

--- a/Mathlib/Algebra/MvPolynomial/Basic.lean
+++ b/Mathlib/Algebra/MvPolynomial/Basic.lean
@@ -822,20 +822,16 @@ def constantCoeff : MvPolynomial σ R →+* R where
 theorem constantCoeff_eq : (constantCoeff : MvPolynomial σ R → R) = coeff 0 :=
   rfl
 
-variable (σ)
-
+variable (σ) in
 @[simp]
 theorem constantCoeff_C (r : R) : constantCoeff (C r : MvPolynomial σ R) = r := by
   classical simp [constantCoeff_eq]
 
-variable {σ}
-variable (R)
+variable (R) in
 
 @[simp]
 theorem constantCoeff_X (i : σ) : constantCoeff (X i : MvPolynomial σ R) = 0 := by
   simp [constantCoeff_eq]
-
-variable {R}
 
 @[simp]
 theorem constantCoeff_smul {R : Type*} [SMulZeroClass R S₁] (a : R) (f : MvPolynomial σ S₁) :

--- a/Mathlib/Algebra/MvPolynomial/Supported.lean
+++ b/Mathlib/Algebra/MvPolynomial/Supported.lean
@@ -30,13 +30,11 @@ variable {σ : Type*} {R : Type u}
 section CommSemiring
 
 variable [CommSemiring R] {p : MvPolynomial σ R}
-variable (R)
 
+variable (R) in
 /-- The set of polynomials whose variables are contained in `s` as a `Subalgebra` over `R`. -/
 noncomputable def supported (s : Set σ) : Subalgebra R (MvPolynomial σ R) :=
   Algebra.adjoin R (X '' s)
-
-variable {R}
 
 open Algebra
 

--- a/Mathlib/Algebra/NoZeroSMulDivisors/Basic.lean
+++ b/Mathlib/Algebra/NoZeroSMulDivisors/Basic.lean
@@ -55,13 +55,10 @@ variable [Semiring R] [AddCommGroup M] [Module R M]
 
 section SMulInjective
 
-variable (M)
-
+variable (M) in
 theorem smul_right_injective [NoZeroSMulDivisors R M] {c : R} (hc : c ≠ 0) :
     Function.Injective (c • · : M → M) :=
   (injective_iff_map_eq_zero (smulAddHom R M c)).2 fun _ ha => (smul_eq_zero.mp ha).resolve_left hc
-
-variable {M}
 
 theorem smul_right_inj [NoZeroSMulDivisors R M] {c : R} (hc : c ≠ 0) {x y : M} :
     c • x = c • y ↔ x = y :=

--- a/Mathlib/Algebra/Polynomial/GroupRingAction.lean
+++ b/Mathlib/Algebra/Polynomial/GroupRingAction.lean
@@ -25,7 +25,6 @@ namespace Polynomial
 variable (R : Type*) [Semiring R]
 
 variable {M} in
-
 -- In this statement, we use `HSMul.hSMul m` as LHS instead of `(m • ·)`
 -- to avoid a spurious lambda-expression that complicates rewriting with this lemma.
 theorem smul_eq_map [MulSemiringAction M R] (m : M) :

--- a/Mathlib/Algebra/Polynomial/GroupRingAction.lean
+++ b/Mathlib/Algebra/Polynomial/GroupRingAction.lean
@@ -23,7 +23,8 @@ open Polynomial
 namespace Polynomial
 
 variable (R : Type*) [Semiring R]
-variable {M}
+
+variable {M} in
 
 -- In this statement, we use `HSMul.hSMul m` as LHS instead of `(m • ·)`
 -- to avoid a spurious lambda-expression that complicates rewriting with this lemma.
@@ -36,8 +37,6 @@ theorem smul_eq_map [MulSemiringAction M R] (m : M) :
   ext n r : 2
   change m • monomial n r = map (MulSemiringAction.toRingHom M R m) (monomial n r)
   rw [Polynomial.map_monomial, Polynomial.smul_monomial, MulSemiringAction.toRingHom_apply]
-
-variable (M)
 
 noncomputable instance [MulSemiringAction M R] : MulSemiringAction M R[X] :=
   { Polynomial.distribMulAction with

--- a/Mathlib/Algebra/QuaternionBasis.lean
+++ b/Mathlib/Algebra/QuaternionBasis.lean
@@ -54,8 +54,7 @@ protected theorem ext ⦃q₁ q₂ : Basis A c₁ c₂ c₃⦄ (hi : q₁.i = q�
   rw [← q₁_i_mul_j, ← q₂_i_mul_j]
   congr
 
-variable (R)
-
+variable (R) in
 /-- There is a natural quaternionic basis for the `QuaternionAlgebra`. -/
 @[simps i j k]
 protected def self : Basis ℍ[R,c₁,c₂,c₃] c₁ c₂ c₃ where
@@ -66,8 +65,6 @@ protected def self : Basis ℍ[R,c₁,c₂,c₃] c₁ c₂ c₃ where
   k := ⟨0, 0, 0, 1⟩
   i_mul_j := by ext <;> simp
   j_mul_i := by ext <;> simp
-
-variable {R}
 
 instance : Inhabited (Basis ℍ[R,c₁,c₂,c₃] c₁ c₂ c₃) :=
   ⟨Basis.self R⟩

--- a/Mathlib/Algebra/Ring/Subsemiring/Basic.lean
+++ b/Mathlib/Algebra/Ring/Subsemiring/Basic.lean
@@ -533,16 +533,13 @@ theorem mem_closure_iff_exists_list {R} [Semiring R] {s : Set R} {x} :
         let ⟨t, ht1, ht2⟩ := List.mem_map.1 hr
         ht2 ▸ list_prod_mem _ fun y hy => subset_closure <| HL1 t ht1 y hy
 
-variable (R)
-
+variable (R) in
 /-- `closure` forms a Galois insertion with the coercion to set. -/
 protected def gi : GaloisInsertion (@closure R _) (↑) where
   choice s _ := closure s
   gc _ _ := closure_le
   le_l_u _ := subset_closure
   choice_eq _ _ := rfl
-
-variable {R}
 
 /-- Closure of a subsemiring `S` equals `S`. -/
 @[simp]

--- a/Mathlib/Algebra/Star/Basic.lean
+++ b/Mathlib/Algebra/Star/Basic.lean
@@ -170,13 +170,10 @@ def starMulAut [CommSemigroup R] [StarMul R] : MulAut R :=
     toFun := star
     map_mul' := star_mul' }
 
-variable (R)
-
+variable (R) in
 @[simp]
 theorem star_one [MulOneClass R] [StarMul R] : star (1 : R) = 1 :=
   op_injective <| (starMulEquiv : R ≃* Rᵐᵒᵖ).map_one.trans op_one.symm
-
-variable {R}
 
 @[simp]
 theorem star_pow [Monoid R] [StarMul R] (x : R) (n : ℕ) : star (x ^ n) = star x ^ n :=
@@ -233,13 +230,10 @@ def starAddEquiv [AddMonoid R] [StarAddMonoid R] : R ≃+ R :=
     toFun := star
     map_add' := star_add }
 
-variable (R)
-
+variable (R) in
 @[simp]
 theorem star_zero [AddMonoid R] [StarAddMonoid R] : star (0 : R) = 0 :=
   (starAddEquiv : R ≃+ R).map_zero
-
-variable {R}
 
 @[simp]
 theorem star_eq_zero [AddMonoid R] [StarAddMonoid R] {x : R} : star x = 0 ↔ x = 0 :=
@@ -299,14 +293,14 @@ theorem star_intCast [Ring R] [StarRing R] (z : ℤ) : star (z : R) = z :=
 end
 
 section CommSemiring
+
 variable [CommSemiring R] [StarRing R]
 
 /-- `star` as a ring automorphism, for commutative `R`. -/
 @[simps apply]
 def starRingAut : RingAut R := { starAddEquiv, starMulAut (R := R) with toFun := star }
 
-variable (R)
-
+variable (R) in
 /-- `star` as a ring endomorphism, for commutative `R`. This is used to denote complex
 conjugation, and is available under the notation `conj` in the locale `ComplexConjugate`.
 
@@ -315,8 +309,6 @@ because the notation `E →ₗ⋆[R] F` for an `R`-conjugate-linear map (short f
 `E →ₛₗ[starRingEnd R] F`) does not pretty-print if there is a coercion involved, as would be the
 case for `(↑starRingAut : R →* R)`. -/
 def starRingEnd : R →+* R := @starRingAut R _ _
-
-variable {R}
 
 @[inherit_doc]
 scoped[ComplexConjugate] notation "conj" => starRingEnd _

--- a/Mathlib/Algebra/Star/SelfAdjoint.lean
+++ b/Mathlib/Algebra/Star/SelfAdjoint.lean
@@ -111,7 +111,6 @@ section AddMonoid
 variable [AddMonoid R] [StarAddMonoid R]
 
 variable (R) in
-
 @[simp] protected theorem zero : IsSelfAdjoint (0 : R) := star_zero R
 
 @[aesop 90% apply]

--- a/Mathlib/Algebra/Star/SelfAdjoint.lean
+++ b/Mathlib/Algebra/Star/SelfAdjoint.lean
@@ -109,11 +109,10 @@ theorem _root_.isSelfAdjoint_map {F R S : Type*} [Star R] [Star S] [FunLike F R 
 section AddMonoid
 
 variable [AddMonoid R] [StarAddMonoid R]
-variable (R)
+
+variable (R) in
 
 @[simp] protected theorem zero : IsSelfAdjoint (0 : R) := star_zero R
-
-variable {R}
 
 @[aesop 90% apply]
 theorem add {x y : R} (hx : IsSelfAdjoint x) (hy : IsSelfAdjoint y) : IsSelfAdjoint (x + y) := by

--- a/Mathlib/AlgebraicGeometry/EllipticCurve/VariableChange.lean
+++ b/Mathlib/AlgebraicGeometry/EllipticCurve/VariableChange.lean
@@ -247,13 +247,10 @@ variable (C : VariableChange R)
 def map : VariableChange A :=
   ⟨Units.map φ C.u, φ C.r, φ C.s, φ C.t⟩
 
-variable (A)
-
+variable (A) in
 /-- The change of variables base changed to an algebra `A` over `R`. -/
 abbrev baseChange [Algebra R A] : VariableChange A :=
   C.map <| algebraMap R A
-
-variable {A}
 
 @[simp]
 lemma map_id : C.map (RingHom.id R) = C :=

--- a/Mathlib/AlgebraicGeometry/EllipticCurve/Weierstrass.lean
+++ b/Mathlib/AlgebraicGeometry/EllipticCurve/Weierstrass.lean
@@ -230,13 +230,10 @@ variable {A : Type v} [CommRing A] (φ : R →+* A)
 def map : WeierstrassCurve A :=
   ⟨φ W.a₁, φ W.a₂, φ W.a₃, φ W.a₄, φ W.a₆⟩
 
-variable (A)
-
+variable (A) in
 /-- The Weierstrass curve base changed to an algebra `A` over `R`. -/
 abbrev baseChange [Algebra R A] : WeierstrassCurve A :=
   W.map <| algebraMap R A
-
-variable {A}
 
 @[simp]
 lemma map_b₂ : (W.map φ).b₂ = φ W.b₂ := by

--- a/Mathlib/AlgebraicGeometry/ProjectiveSpectrum/StructureSheaf.lean
+++ b/Mathlib/AlgebraicGeometry/ProjectiveSpectrum/StructureSheaf.lean
@@ -64,16 +64,13 @@ local notation3 "at " x =>
 
 namespace ProjectiveSpectrum.StructureSheaf
 
-variable {𝒜}
-
+variable {𝒜} in
 /-- The predicate saying that a dependent function on an open `U` is realised as a fixed fraction
 `r / s` of *same grading* in each of the stalks (which are localizations at various prime ideals).
 -/
 def IsFraction {U : Opens (ProjectiveSpectrum.top 𝒜)} (f : ∀ x : U, at x.1) : Prop :=
   ∃ (i : ℕ) (r s : 𝒜 i) (s_nin : ∀ x : U, s.1 ∉ x.1.asHomogeneousIdeal),
     ∀ x : U, f x = .mk ⟨i, r, s, s_nin x⟩
-variable (𝒜)
-
 /--
 The predicate `IsFraction` is "prelocal", in the sense that if it holds on `U` it holds on any open
 subset `V` of `U`.

--- a/Mathlib/AlgebraicTopology/DoldKan/FunctorGamma.lean
+++ b/Mathlib/AlgebraicTopology/DoldKan/FunctorGamma.lean
@@ -92,13 +92,10 @@ def mapMono (K : ChainComplex C ℕ) {Δ' Δ : SimplexCategory} (i : Δ' ⟶ Δ)
     · exact K.d Δ.len Δ'.len
     · exact 0
 
-variable (Δ)
-
+variable (Δ) in
 theorem mapMono_id : mapMono K (𝟙 Δ) = 𝟙 _ := by
   unfold mapMono
   simp only [eq_self_iff_true, eqToHom_refl, dite_eq_ite, if_true]
-
-variable {Δ}
 
 theorem mapMono_δ₀' (i : Δ' ⟶ Δ) [Mono i] (hi : Isδ₀ i) : mapMono K i = K.d Δ.len Δ'.len := by
   unfold mapMono

--- a/Mathlib/Analysis/CStarAlgebra/Basic.lean
+++ b/Mathlib/Analysis/CStarAlgebra/Basic.lean
@@ -246,15 +246,14 @@ section starₗᵢ
 variable [CommSemiring 𝕜] [StarRing 𝕜]
 variable [SeminormedAddCommGroup E] [StarAddMonoid E] [NormedStarGroup E]
 variable [Module 𝕜 E] [StarModule 𝕜 E]
-variable (𝕜)
+
+variable (𝕜) in
 
 /-- `star` bundled as a linear isometric equivalence -/
 def starₗᵢ : E ≃ₗᵢ⋆[𝕜] E :=
   { starAddEquiv with
     map_smul' := star_smul
     norm_map' := norm_star }
-
-variable {𝕜}
 
 @[simp]
 theorem coe_starₗᵢ : (starₗᵢ 𝕜 : E → E) = star :=

--- a/Mathlib/Analysis/CStarAlgebra/Basic.lean
+++ b/Mathlib/Analysis/CStarAlgebra/Basic.lean
@@ -248,7 +248,6 @@ variable [SeminormedAddCommGroup E] [StarAddMonoid E] [NormedStarGroup E]
 variable [Module 𝕜 E] [StarModule 𝕜 E]
 
 variable (𝕜) in
-
 /-- `star` bundled as a linear isometric equivalence -/
 def starₗᵢ : E ≃ₗᵢ⋆[𝕜] E :=
   { starAddEquiv with

--- a/Mathlib/Analysis/CStarAlgebra/GelfandDuality.lean
+++ b/Mathlib/Analysis/CStarAlgebra/GelfandDuality.lean
@@ -212,15 +212,12 @@ noncomputable def compContinuousMap (ψ : A →⋆ₐ[𝕜] B) :
     Continuous.subtype_mk
       (continuous_of_continuous_eval fun a => map_continuous <| gelfandTransform 𝕜 B (ψ a)) _
 
-variable (A)
-
+variable (A) in
 /-- `WeakDual.CharacterSpace.compContinuousMap` sends the identity to the identity. -/
 @[simp]
 theorem compContinuousMap_id :
     compContinuousMap (StarAlgHom.id 𝕜 A) = ContinuousMap.id (characterSpace 𝕜 A) :=
   ContinuousMap.ext fun _a => ext fun _x => rfl
-
-variable {A}
 
 /-- `WeakDual.CharacterSpace.compContinuousMap` is functorial. -/
 @[simp]

--- a/Mathlib/Analysis/CStarAlgebra/Multiplier.lean
+++ b/Mathlib/Analysis/CStarAlgebra/Multiplier.lean
@@ -423,8 +423,7 @@ end Star
 ### Coercion from an algebra into its multiplier algebra
 -/
 
-variable (𝕜)
-
+variable (𝕜) in
 /-- The natural coercion of `A` into `𝓜(𝕜, A)` given by sending `a : A` to the pair of linear
 maps `Lₐ Rₐ : A →L[𝕜] A` given by left- and right-multiplication by `a`, respectively.
 
@@ -437,8 +436,6 @@ protected noncomputable def coe (a : A) : 𝓜(𝕜, A) :=
   { fst := ContinuousLinearMap.mul 𝕜 A a
     snd := (ContinuousLinearMap.mul 𝕜 A).flip a
     central := fun _x _y => mul_assoc _ _ _ }
-
-variable {𝕜}
 
 /-- The natural coercion of `A` into `𝓜(𝕜, A)` given by sending `a : A` to the pair of linear
 maps `Lₐ Rₐ : A →L[𝕜] A` given by left- and right-multiplication by `a`, respectively.

--- a/Mathlib/Analysis/Calculus/BumpFunction/FiniteDimension.lean
+++ b/Mathlib/Analysis/Calculus/BumpFunction/FiniteDimension.lean
@@ -236,14 +236,11 @@ theorem u_exists :
       simp only [I1, I2, add_zero, zero_div]
   · intro x; simp only [add_comm, neg_neg]
 
-variable {E}
-
+variable {E} in
 /-- An auxiliary function to construct partitions of unity on finite-dimensional real vector spaces,
 which is smooth, symmetric, and with support equal to the unit ball. -/
 def u (x : E) : ℝ :=
   Classical.choose (u_exists E) x
-
-variable (E)
 
 theorem u_smooth : ContDiff ℝ ∞ (u : E → ℝ) :=
   (Classical.choose_spec (u_exists E)).1
@@ -273,15 +270,11 @@ variable [MeasurableSpace E] [BorelSpace E]
 
 local notation "μ" => MeasureTheory.Measure.addHaar
 
-variable (E)
-
+variable (E) in
 theorem u_int_pos : 0 < ∫ x : E, u x ∂μ := by
   refine (integral_pos_iff_support_of_nonneg u_nonneg ?_).mpr ?_
   · exact (u_continuous E).integrable_of_hasCompactSupport (u_compact_support E)
   · rw [u_support]; exact measure_ball_pos _ _ zero_lt_one
-
-variable {E}
-
 
 /-- An auxiliary function to construct partitions of unity on finite-dimensional real vector spaces,
 which is smooth, symmetric, with support equal to the ball of radius `D` and integral `1`. -/

--- a/Mathlib/Analysis/Convex/Between.lean
+++ b/Mathlib/Analysis/Convex/Between.lean
@@ -62,15 +62,12 @@ theorem affineSegment_same (x : P) : affineSegment R x x = {x} := by
   simp_rw [affineSegment, lineMap_same, AffineMap.coe_const, Function.const,
     (Set.nonempty_Icc.mpr zero_le_one).image_const]
 
-variable {R}
-
+variable {R} in
 @[simp]
 theorem affineSegment_image (f : P →ᵃ[R] P') (x y : P) :
     f '' affineSegment R x y = affineSegment R (f x) (f y) := by
   rw [affineSegment, affineSegment, Set.image_image, ← comp_lineMap]
   rfl
-
-variable (R)
 
 @[simp]
 theorem affineSegment_const_vadd_image (x y : P) (v : V) :

--- a/Mathlib/Analysis/Convex/Exposed.lean
+++ b/Mathlib/Analysis/Convex/Exposed.lean
@@ -170,14 +170,11 @@ protected theorem isCompact [OrderClosedTopology 𝕜] [T2Space E] {A B : Set E}
 
 end IsExposed
 
-variable (𝕜)
-
+variable (𝕜) in
 /-- A point is exposed with respect to `A` iff there exists a hyperplane whose intersection with
 `A` is exactly that point. -/
 def Set.exposedPoints (A : Set E) : Set E :=
   { x ∈ A | ∃ l : E →L[𝕜] 𝕜, ∀ y ∈ A, l y ≤ l x ∧ (l x ≤ l y → y = x) }
-
-variable {𝕜}
 
 theorem exposed_point_def :
     x ∈ A.exposedPoints 𝕜 ↔ x ∈ A ∧ ∃ l : E →L[𝕜] 𝕜, ∀ y ∈ A, l y ≤ l x ∧ (l x ≤ l y → y = x) :=

--- a/Mathlib/Analysis/Convex/Topology.lean
+++ b/Mathlib/Analysis/Convex/Topology.lean
@@ -302,14 +302,11 @@ theorem convex_closed_sInter {S : Set (Set E)} (h : ∀ s ∈ S, Convex 𝕜 s �
   ⟨fun _ hx => starConvex_sInter fun _ hs => (h _ hs).1 <| hx _ hs,
     isClosed_sInter fun _ hs => (h _ hs).2⟩
 
-variable (𝕜)
-
+variable (𝕜) in
 /-- The convex closed hull of a set `s` is the minimal convex closed set that includes `s`. -/
 @[simps! isClosed]
 def closedConvexHull : ClosureOperator (Set E) := .ofCompletePred (fun s => Convex 𝕜 s ∧ IsClosed s)
   fun _ ↦ convex_closed_sInter
-
-variable {𝕜}
 
 theorem convex_closedConvexHull {s : Set E} :
     Convex 𝕜 (closedConvexHull 𝕜 s) := ((closedConvexHull 𝕜).isClosed_closure s).1

--- a/Mathlib/Analysis/InnerProductSpace/Projection.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Projection.lean
@@ -744,14 +744,11 @@ theorem Submodule.sup_orthogonal_inf_of_completeSpace {K₁ K₂ : Submodule �
     exact K₂.add_mem (h hy) hz.2
   · exact fun hx => ⟨v, v.prop, x - v, ⟨hvm, K₂.sub_mem hx (h v.prop)⟩, add_sub_cancel _ _⟩
 
-variable {K}
-
+variable {K} in
 /-- If `K` is complete, `K` and `Kᗮ` span the whole space. -/
 theorem Submodule.sup_orthogonal_of_completeSpace [HasOrthogonalProjection K] : K ⊔ Kᗮ = ⊤ := by
   convert Submodule.sup_orthogonal_inf_of_completeSpace (le_top : K ≤ ⊤) using 2
   simp
-
-variable (K)
 
 /-- If `K` is complete, any `v` in `E` can be expressed as a sum of elements of `K` and `Kᗮ`. -/
 theorem Submodule.exists_add_mem_mem_orthogonal [HasOrthogonalProjection K] (v : E) :

--- a/Mathlib/Analysis/LocallyConvex/AbsConvex.lean
+++ b/Mathlib/Analysis/LocallyConvex/AbsConvex.lean
@@ -150,15 +150,12 @@ theorem absConvex_closed_sInter {S : Set (Set E)} (h : ∀ s ∈ S, AbsConvex �
     AbsConvex 𝕜 (⋂₀ S) ∧ IsClosed (⋂₀ S) :=
   ⟨AbsConvex.sInter (fun s hs => (h s hs).1), isClosed_sInter fun _ hs => (h _ hs).2⟩
 
-variable (𝕜)
-
+variable (𝕜) in
 /-- The absolutely convex closed hull of a set `s` is the minimal absolutely convex closed set that
 includes `s`. -/
 @[simps! isClosed]
 def closedAbsConvexHull : ClosureOperator (Set E) :=
   .ofCompletePred (fun s => AbsConvex 𝕜 s ∧ IsClosed s) fun _ ↦ absConvex_closed_sInter
-
-variable {𝕜}
 
 theorem absConvex_convexClosedHull {s : Set E} :
     AbsConvex 𝕜 (closedAbsConvexHull 𝕜 s) := ((closedAbsConvexHull 𝕜).isClosed_closure s).1

--- a/Mathlib/Analysis/LocallyConvex/BalancedCoreHull.lean
+++ b/Mathlib/Analysis/LocallyConvex/BalancedCoreHull.lean
@@ -127,12 +127,9 @@ theorem balancedCore_nonempty_iff : (balancedCore 𝕜 s).Nonempty ↔ (0 : E) �
       balancedCore_subset _,
     fun h => ⟨0, balancedCore_zero_mem h⟩⟩
 
-variable (𝕜)
-
+variable (𝕜) in
 theorem subset_balancedHull [NormOneClass 𝕜] {s : Set E} : s ⊆ balancedHull 𝕜 s := fun _ hx =>
   mem_balancedHull_iff.2 ⟨1, norm_one.le, _, hx, one_smul _ _⟩
-
-variable {𝕜}
 
 theorem balancedHull.balanced (s : Set E) : Balanced 𝕜 (balancedHull 𝕜 s) := by
   intro a ha

--- a/Mathlib/Analysis/LocallyConvex/Basic.lean
+++ b/Mathlib/Analysis/LocallyConvex/Basic.lean
@@ -51,13 +51,12 @@ variable [SeminormedRing 𝕜]
 section SMul
 
 variable [SMul 𝕜 E] {s A B : Set E}
-variable (𝕜)
+
+variable (𝕜) in
 
 /-- A set `A` is balanced if `a • A` is contained in `A` whenever `a` has norm at most `1`. -/
 def Balanced (A : Set E) :=
   ∀ a : 𝕜, ‖a‖ ≤ 1 → a • A ⊆ A
-
-variable {𝕜}
 
 lemma absorbs_iff_norm : Absorbs 𝕜 A B ↔ ∃ r, ∀ c : 𝕜, r ≤ ‖c‖ → B ⊆ c • A :=
   Filter.atTop_basis.cobounded_of_norm.eventually_iff.trans <| by simp only [true_and]; rfl

--- a/Mathlib/Analysis/LocallyConvex/Basic.lean
+++ b/Mathlib/Analysis/LocallyConvex/Basic.lean
@@ -53,7 +53,6 @@ section SMul
 variable [SMul 𝕜 E] {s A B : Set E}
 
 variable (𝕜) in
-
 /-- A set `A` is balanced if `a • A` is contained in `A` whenever `a` has norm at most `1`. -/
 def Balanced (A : Set E) :=
   ∀ a : 𝕜, ‖a‖ ≤ 1 → a • A ⊆ A

--- a/Mathlib/Analysis/Normed/Affine/Isometry.lean
+++ b/Mathlib/Analysis/Normed/Affine/Isometry.lean
@@ -613,13 +613,10 @@ lemma ofEq_symm (h : s₁ = s₂) : (ofEq s₁ s₂ h).symm = ofEq s₂ s₁ h.s
 lemma ofEq_rfl : ofEq s₁ s₁ rfl = refl 𝕜 s₁ :=
   rfl
 
-variable (𝕜)
-
+variable (𝕜) in
 /-- The map `v ↦ v +ᵥ p` as an affine isometric equivalence between `V` and `P`. -/
 def vaddConst (p : P) : V ≃ᵃⁱ[𝕜] P :=
   { AffineEquiv.vaddConst 𝕜 p with norm_map := fun _ => rfl }
-
-variable {𝕜}
 
 @[simp]
 theorem coe_vaddConst (p : P) : ⇑(vaddConst 𝕜 p) = fun v => v +ᵥ p :=
@@ -638,13 +635,10 @@ theorem vaddConst_toAffineEquiv (p : P) :
     (vaddConst 𝕜 p).toAffineEquiv = AffineEquiv.vaddConst 𝕜 p :=
   rfl
 
-variable (𝕜)
-
+variable (𝕜) in
 /-- `p' ↦ p -ᵥ p'` as an affine isometric equivalence. -/
 def constVSub (p : P) : P ≃ᵃⁱ[𝕜] V :=
   { AffineEquiv.constVSub 𝕜 p with norm_map := norm_neg }
-
-variable {𝕜}
 
 @[simp]
 theorem coe_constVSub (p : P) : ⇑(constVSub 𝕜 p) = (p -ᵥ ·) :=
@@ -657,14 +651,11 @@ theorem symm_constVSub (p : P) :
   ext
   rfl
 
-variable (𝕜 P)
-
+variable (𝕜 P) in
 /-- Translation by `v` (that is, the map `p ↦ v +ᵥ p`) as an affine isometric automorphism of `P`.
 -/
 def constVAdd (v : V) : P ≃ᵃⁱ[𝕜] P :=
   { AffineEquiv.constVAdd 𝕜 P v with norm_map := fun _ => rfl }
-
-variable {𝕜 P}
 
 @[simp]
 theorem coe_constVAdd (v : V) : ⇑(constVAdd 𝕜 P v : P ≃ᵃⁱ[𝕜] P) = (v +ᵥ ·) :=
@@ -682,13 +673,10 @@ theorem vadd_vsub {f : P → P₂} (hf : Isometry f) {p : P} {g : V → V₂}
   convert (vaddConst 𝕜 (f p)).symm.isometry.comp (hf.comp (vaddConst 𝕜 p).isometry)
   exact funext hg
 
-variable (𝕜)
-
+variable (𝕜) in
 /-- Point reflection in `x` as an affine isometric automorphism. -/
 def pointReflection (x : P) : P ≃ᵃⁱ[𝕜] P :=
   (constVSub 𝕜 x).trans (vaddConst 𝕜 x)
-
-variable {𝕜}
 
 theorem pointReflection_apply (x y : P) : (pointReflection 𝕜 x) y = (x -ᵥ y) +ᵥ x :=
   rfl

--- a/Mathlib/Analysis/Normed/Algebra/Spectrum.lean
+++ b/Mathlib/Analysis/Normed/Algebra/Spectrum.lean
@@ -280,7 +280,6 @@ open scoped NNReal ENNReal
 variable [NontriviallyNormedField 𝕜] [NormedRing A] [NormedAlgebra 𝕜 A]
 
 variable (𝕜) in
-
 /-- In a Banach algebra `A` over a nontrivially normed field `𝕜`, for any `a : A` the
 power series with coefficients `a ^ n` represents the function `(1 - z • a)⁻¹` in a disk of
 radius `‖a‖₊⁻¹`. -/

--- a/Mathlib/Analysis/Normed/Algebra/Spectrum.lean
+++ b/Mathlib/Analysis/Normed/Algebra/Spectrum.lean
@@ -278,7 +278,8 @@ open ContinuousMultilinearMap ENNReal FormalMultilinearSeries
 open scoped NNReal ENNReal
 
 variable [NontriviallyNormedField 𝕜] [NormedRing A] [NormedAlgebra 𝕜 A]
-variable (𝕜)
+
+variable (𝕜) in
 
 /-- In a Banach algebra `A` over a nontrivially normed field `𝕜`, for any `a : A` the
 power series with coefficients `a ^ n` represents the function `(1 - z • a)⁻¹` in a disk of
@@ -310,8 +311,6 @@ theorem hasFPowerSeriesOnBall_inverse_one_sub_smul [HasSummableGeomSeries A] (a 
             ← NNReal.lt_inv_iff_mul_lt h]
       simpa [← smul_pow, (summable_geometric_of_norm_lt_one norm_lt).hasSum_iff] using
         (NormedRing.inverse_one_sub _ norm_lt).symm }
-
-variable {𝕜}
 
 theorem isUnit_one_sub_smul_of_lt_inv_radius {a : A} {z : 𝕜} (h : ↑‖z‖₊ < (spectralRadius 𝕜 a)⁻¹) :
     IsUnit (1 - z • a) := by

--- a/Mathlib/Analysis/Normed/Lp/lpSpace.lean
+++ b/Mathlib/Analysis/Normed/Lp/lpSpace.lean
@@ -789,8 +789,7 @@ variable [∀ i, NormOneClass (B i)]
 theorem _root_.one_memℓp_infty : Memℓp (1 : ∀ i, B i) ∞ :=
   ⟨1, by rintro i ⟨i, rfl⟩; exact norm_one.le⟩
 
-variable (B)
-
+variable (B) in
 /-- The `𝕜`-subring of elements of `∀ i : α, B i` whose `lp` norm is finite. This is `lp E ∞`,
 with extra structure. -/
 def _root_.lpInftySubring : Subring (PreLp B) :=
@@ -798,8 +797,6 @@ def _root_.lpInftySubring : Subring (PreLp B) :=
     carrier := { f | Memℓp f ∞ }
     one_mem' := one_memℓp_infty
     mul_mem' := Memℓp.infty_mul }
-
-variable {B}
 
 instance inftyRing : Ring (lp B ∞) :=
   (lpInftySubring B).toRing

--- a/Mathlib/Analysis/Normed/Operator/BoundedLinearMaps.lean
+++ b/Mathlib/Analysis/Normed/Operator/BoundedLinearMaps.lean
@@ -270,8 +270,7 @@ theorem map_smul₂ (f : E →L[𝕜] F →L[𝕜] G) (c : 𝕜) (x : E) (y : F)
 
 end ContinuousLinearMap
 
-variable (𝕜)
-
+variable (𝕜) in
 /-- A map `f : E × F → G` satisfies `IsBoundedBilinearMap 𝕜 f` if it is bilinear and
 continuous. -/
 structure IsBoundedBilinearMap (f : E × F → G) : Prop where
@@ -281,7 +280,6 @@ structure IsBoundedBilinearMap (f : E × F → G) : Prop where
   smul_right : ∀ (c : 𝕜) (x : E) (y : F), f (x, c • y) = c • f (x, y)
   bound : ∃ C > 0, ∀ (x : E) (y : F), ‖f (x, y)‖ ≤ C * ‖x‖ * ‖y‖
 
-variable {𝕜}
 variable {f : E × F → G}
 
 theorem ContinuousLinearMap.isBoundedBilinearMap (f : E →L[𝕜] F →L[𝕜] G) :
@@ -423,16 +421,13 @@ theorem IsBoundedBilinearMap.deriv_apply (h : IsBoundedBilinearMap 𝕜 f) (p q 
     h.deriv p q = f (p.1, q.2) + f (q.1, p.2) :=
   rfl
 
-variable (𝕜)
-
+variable (𝕜) in
 /-- The function `ContinuousLinearMap.mulLeftRight : 𝕜' × 𝕜' → (𝕜' →L[𝕜] 𝕜')` is a bounded
 bilinear map. -/
 theorem ContinuousLinearMap.mulLeftRight_isBoundedBilinear (𝕜' : Type*) [SeminormedRing 𝕜']
     [NormedAlgebra 𝕜 𝕜'] :
     IsBoundedBilinearMap 𝕜 fun p : 𝕜' × 𝕜' => ContinuousLinearMap.mulLeftRight 𝕜 𝕜' p.1 p.2 :=
   (ContinuousLinearMap.mulLeftRight 𝕜 𝕜').isBoundedBilinearMap
-
-variable {𝕜}
 
 /-- Given a bounded bilinear map `f`, the map associating to a point `p` the derivative of `f` at
 `p` is itself a bounded linear map. -/

--- a/Mathlib/Analysis/Normed/Operator/LinearIsometry.lean
+++ b/Mathlib/Analysis/Normed/Operator/LinearIsometry.lean
@@ -931,13 +931,10 @@ theorem coe_ofLinearIsometry_symm (f : E →ₛₗᵢ[σ₁₂] E₂) (g : E₂ 
     ((ofLinearIsometry f g h₁ h₂).symm : E₂ → E) = (g : E₂ → E) :=
   rfl
 
-variable (R)
-
+variable (R) in
 /-- The negation operation on a normed space `E`, considered as a linear isometry equivalence. -/
 def neg : E ≃ₗᵢ[R] E :=
   { LinearEquiv.neg R with norm_map' := norm_neg }
-
-variable {R}
 
 @[simp]
 theorem coe_neg : (neg R : E → E) = fun x => -x :=

--- a/Mathlib/Analysis/NormedSpace/OperatorNorm/NormedSpace.lean
+++ b/Mathlib/Analysis/NormedSpace/OperatorNorm/NormedSpace.lean
@@ -125,8 +125,7 @@ instance toNormedAddCommGroup [RingHomIsometric σ₁₂] : NormedAddCommGroup (
 instance toNormedRing : NormedRing (E →L[𝕜] E) :=
   { ContinuousLinearMap.toNormedAddCommGroup, ContinuousLinearMap.toSemiNormedRing with }
 
-variable {f}
-
+variable {f} in
 theorem homothety_norm [RingHomIsometric σ₁₂] [Nontrivial E] (f : E →SL[σ₁₂] F) {a : ℝ}
     (hf : ∀ x, ‖f x‖ = a * ‖x‖) : ‖f‖ = a := by
   obtain ⟨x, hx⟩ : ∃ x : E, x ≠ 0 := exists_ne 0
@@ -134,8 +133,6 @@ theorem homothety_norm [RingHomIsometric σ₁₂] [Nontrivial E] (f : E →SL[�
   have ha : 0 ≤ a := by simpa only [hf, hx, mul_nonneg_iff_of_pos_right] using norm_nonneg (f x)
   apply le_antisymm (f.opNorm_le_bound ha fun y => le_of_eq (hf y))
   simpa only [hf, hx, mul_le_mul_right] using f.le_opNorm x
-
-variable (f)
 
 /-- If a continuous linear map is a topology embedding, then it is expands the distances
 by a positive factor. -/

--- a/Mathlib/CategoryTheory/CommSq.lean
+++ b/Mathlib/CategoryTheory/CommSq.lean
@@ -225,12 +225,9 @@ class HasLift : Prop where
 
 namespace HasLift
 
-variable {sq}
-
+variable {sq} in
 theorem mk' (l : sq.LiftStruct) : HasLift sq :=
   ⟨Nonempty.intro l⟩
-
-variable (sq)
 
 theorem iff : HasLift sq ↔ Nonempty sq.LiftStruct := by
   constructor

--- a/Mathlib/CategoryTheory/Idempotents/Basic.lean
+++ b/Mathlib/CategoryTheory/Idempotents/Basic.lean
@@ -88,15 +88,12 @@ theorem isIdempotentComplete_iff_hasEqualizer_of_id_and_idempotent :
       Fork.ofι_π_app, id_comp]
     rw [← equalizer.condition, comp_id]
 
-variable {C}
-
+variable {C} in
 /-- In a preadditive category, when `p : X ⟶ X` is idempotent,
 then `𝟙 X - p` is also idempotent. -/
 theorem idem_of_id_sub_idem [Preadditive C] {X : C} (p : X ⟶ X) (hp : p ≫ p = p) :
     (𝟙 _ - p) ≫ (𝟙 _ - p) = 𝟙 _ - p := by
   simp only [comp_sub, sub_comp, id_comp, comp_id, hp, sub_self, sub_zero]
-
-variable (C)
 
 /-- A preadditive category is pseudoabelian iff all idempotent endomorphisms have a kernel. -/
 theorem isIdempotentComplete_iff_idempotents_have_kernels [Preadditive C] :

--- a/Mathlib/CategoryTheory/Limits/Constructions/BinaryProducts.lean
+++ b/Mathlib/CategoryTheory/Limits/Constructions/BinaryProducts.lean
@@ -82,15 +82,12 @@ noncomputable def limitConeOfTerminalAndPullbacks [HasTerminal C] [HasPullbacks 
   isLimit :=
     isBinaryProductOfIsTerminalIsPullback F _ terminalIsTerminal _ _ (pullbackIsPullback _ _)
 
-variable (C)
-
+variable (C) in
 -- This is not an instance, as it is not always how one wants to construct binary products!
 /-- Any category with pullbacks and terminal object has binary products. -/
 theorem hasBinaryProducts_of_hasTerminal_and_pullbacks [HasTerminal C] [HasPullbacks C] :
     HasBinaryProducts C :=
   { has_limit := fun F => HasLimit.mk (limitConeOfTerminalAndPullbacks F) }
-
-variable {C}
 
 /-- A functor that preserves terminal objects and pullbacks preserves binary products. -/
 lemma preservesBinaryProducts_of_preservesTerminal_and_pullbacks [HasTerminal C]
@@ -188,15 +185,12 @@ noncomputable def colimitCoconeOfInitialAndPushouts [HasInitial C] [HasPushouts 
           Discrete.casesOn x fun x => WalkingPair.casesOn x (pushout.inl _ _) (pushout.inr _ _) }
   isColimit := isBinaryCoproductOfIsInitialIsPushout F _ initialIsInitial _ _ (pushoutIsPushout _ _)
 
-variable (C)
-
+variable (C) in
 -- This is not an instance, as it is not always how one wants to construct binary coproducts!
 /-- Any category with pushouts and initial object has binary coproducts. -/
 theorem hasBinaryCoproducts_of_hasInitial_and_pushouts [HasInitial C] [HasPushouts C] :
     HasBinaryCoproducts C :=
   { has_colimit := fun F => HasColimit.mk (colimitCoconeOfInitialAndPushouts F) }
-
-variable {C}
 
 /-- A functor that preserves initial objects and pushouts preserves binary coproducts. -/
 lemma preservesBinaryCoproducts_of_preservesInitial_and_pushouts [HasInitial C]

--- a/Mathlib/CategoryTheory/Localization/CalculusOfFractions.lean
+++ b/Mathlib/CategoryTheory/Localization/CalculusOfFractions.lean
@@ -302,14 +302,11 @@ lemma comp₀_rel [W.HasLeftCalculusOfFractions]
   · simp only [comp₀, assoc, ← reassoc_of% fac]
     exact W.comp_mem _ _ z₂.hs (W.comp_mem _ _ z₃'.hs (W.comp_mem _ _ z₄.hs ht))
 
-variable (W)
-
+variable (W) in
 /-- The morphisms in the constructed localized category for a morphism property `W`
 that has left calculus of fractions are equivalence classes of left fractions. -/
 def Localization.Hom (X Y : C) :=
   Quot (LeftFractionRel : W.LeftFraction X Y → W.LeftFraction X Y → Prop)
-
-variable {W}
 
 /-- The morphism in the constructed localized category that is induced by a left fraction. -/
 def Localization.Hom.mk {X Y : C} (z : W.LeftFraction X Y) : Localization.Hom W X Y :=
@@ -469,8 +466,7 @@ noncomputable instance : Category (Localization W) where
         (by dsimp; rw [assoc, ← reassoc_of% fac₁₂, fac])]
     simp
 
-variable (W)
-
+variable (W) in
 /-- The localization functor to the constructed localized category for a morphism property
 that has left calculus of fractions. -/
 @[simps obj]
@@ -482,8 +478,6 @@ def Q : C ⥤ Localization W where
     change _ = Hom.comp _ _
     rw [Hom.comp_eq, comp_eq (ofHom W f) (ofHom W g) (ofHom W g) (by simp)]
     simp only [ofHom, comp₀, comp_id]
-
-variable {W}
 
 /-- The morphism on `Localization W` that is induced by a left fraction. -/
 abbrev homMk {X Y : C} (f : W.LeftFraction X Y) : (Q W).obj X ⟶ (Q W).obj Y := Hom.mk f

--- a/Mathlib/CategoryTheory/Localization/Construction.lean
+++ b/Mathlib/CategoryTheory/Localization/Construction.lean
@@ -123,12 +123,10 @@ def wIso {X Y : C} (w : X ⟶ Y) (hw : W w) : Iso (W.Q.obj X) (W.Q.obj Y) where
 abbrev wInv {X Y : C} (w : X ⟶ Y) (hw : W w) :=
   (wIso w hw).inv
 
-variable (W)
-
+variable (W) in
 theorem _root_.CategoryTheory.MorphismProperty.Q_inverts : W.IsInvertedBy W.Q := fun _ _ w hw =>
   (Localization.Construction.wIso w hw).isIso_hom
 
-variable {W}
 variable (G : C ⥤ D) (hG : W.IsInvertedBy G)
 
 /-- The lifting of a functor to the path category of `LocQuiver W` -/
@@ -187,8 +185,7 @@ theorem uniq (G₁ G₂ : W.Localization ⥤ D) (h : W.Q ⋙ G₁ = W.Q ⋙ G₂
       refine Functor.congr_inv_of_congr_hom _ _ _ ?_ ?_ hw'
       all_goals apply Functor.congr_obj h
 
-variable (W)
-
+variable (W) in
 /-- The canonical bijection between objects in a category and its
 localization with respect to a morphism_property `W` -/
 @[simps]
@@ -199,8 +196,6 @@ def objEquiv : C ≃ W.Localization where
   right_inv := by
     rintro ⟨⟨X⟩⟩
     rfl
-
-variable {W}
 
 /-- A `MorphismProperty` in `W.Localization` is satisfied by all
 morphisms in the localized category if it contains the image of the

--- a/Mathlib/CategoryTheory/Monad/EquivMon.lean
+++ b/Mathlib/CategoryTheory/Monad/EquivMon.lean
@@ -43,15 +43,12 @@ def toMon (M : Monad C) : Mon_ (C ⥤ C) where
   mul := M.μ
   mul_assoc := by ext; simp [M.assoc]
 
-variable (C)
-
+variable (C) in
 /-- Passing from `Monad C` to `Mon_ (C ⥤ C)` is functorial. -/
 @[simps]
 def monadToMon : Monad C ⥤ Mon_ (C ⥤ C) where
   obj := toMon
   map f := { hom := f.toNatTrans }
-
-variable {C}
 
 /-- To every monoid object in `C ⥤ C` we associate a `Monad C`. -/
 @[simps η μ]

--- a/Mathlib/CategoryTheory/Shift/ShiftSequence.lean
+++ b/Mathlib/CategoryTheory/Shift/ShiftSequence.lean
@@ -97,12 +97,9 @@ lemma shiftIso_inv_naturality {X Y : C} (n a a' : M) (ha' : n + a = a') (f : X �
       (shiftIso F n a a' ha').inv.app X ≫ (shift F a).map (f⟦n⟧') := by
   simp
 
-variable (M)
-
+variable (M) in
 /-- The canonical isomorphism `F.shift 0 ≅ F`. -/
 def isoShiftZero : F.shift (0 : M) ≅ F := ShiftSequence.isoZero
-
-variable {M}
 
 /-- The canonical isomorphism `shiftFunctor C n ⋙ F ≅ F.shift n`. -/
 def isoShift (n : M) : shiftFunctor C n ⋙ F ≅ F.shift n :=

--- a/Mathlib/CategoryTheory/Sites/DenseSubsite/Basic.lean
+++ b/Mathlib/CategoryTheory/Sites/DenseSubsite/Basic.lean
@@ -400,8 +400,7 @@ theorem sheafHom_restrict_eq (α : G.op ⋙ ℱ ⟶ G.op ⋙ ℱ'.val) :
     (whiskerRight α (coyoneda.obj _)) hf.some.map (𝟙 _)
   simpa using this
 
-variable (G)
-
+variable (G) in
 /--
 If the pullback map is obtained via whiskering,
 then the result `sheaf_hom (whisker_left G.op α)` is equal to `α`.
@@ -420,8 +419,6 @@ theorem sheafHom_eq (α : ℱ ⟶ ℱ'.val) : sheafHom (whiskerLeft G.op α) = �
   conv_lhs => rw [← hf.some.fac]
   dsimp
   simp
-
-variable {G}
 
 /--
 A locally-full and cover-dense functor `G` induces an equivalence between morphisms into a sheaf and

--- a/Mathlib/CategoryTheory/Sites/Plus.lean
+++ b/Mathlib/CategoryTheory/Sites/Plus.lean
@@ -83,15 +83,13 @@ theorem diagramNatTrans_comp {P Q R : Cᵒᵖ ⥤ D} (η : P ⟶ Q) (γ : Q ⟶ 
   refine Multiequalizer.hom_ext _ _ _ (fun i => ?_)
   simp
 
-variable (D)
-
+variable (D) in
 /-- `J.diagram P`, as a functor in `P`. -/
 @[simps]
 def diagramFunctor (X : C) : (Cᵒᵖ ⥤ D) ⥤ (J.Cover X)ᵒᵖ ⥤ D where
   obj P := J.diagram P X
   map η := J.diagramNatTrans η X
 
-variable {D}
 variable [∀ X : C, HasColimitsOfShape (J.Cover X)ᵒᵖ D]
 
 /-- The plus construction, associating a presheaf to any presheaf.
@@ -168,15 +166,12 @@ theorem plusMap_comp {P Q R : Cᵒᵖ ⥤ D} (η : P ⟶ Q) (γ : Q ⟶ R) :
   refine colimit.hom_ext (fun S => ?_)
   simp [plusMap, J.diagramNatTrans_comp]
 
-variable (D)
-
+variable (D) in
 /-- The plus construction, a functor sending `P` to `J.plusObj P`. -/
 @[simps]
 def plusFunctor : (Cᵒᵖ ⥤ D) ⥤ Cᵒᵖ ⥤ D where
   obj P := J.plusObj P
   map η := J.plusMap η
-
-variable {D}
 
 /-- The canonical map from `P` to `J.plusObj P`.
 See `toPlusNatTrans` for a functorial version. -/
@@ -207,14 +202,11 @@ theorem toPlus_naturality {P Q : Cᵒᵖ ⥤ D} (η : P ⟶ Q) :
   congr 1
   exact Multiequalizer.hom_ext _ _ _ (fun I => by dsimp; simp)
 
-variable (D)
-
+variable (D) in
 /-- The natural transformation from the identity functor to `plus`. -/
 @[simps]
 def toPlusNatTrans : 𝟭 (Cᵒᵖ ⥤ D) ⟶ J.plusFunctor D where
   app P := J.toPlus P
-
-variable {D}
 
 /-- `(P ⟶ P⁺)⁺ = P⁺ ⟶ P⁺⁺` -/
 @[simp]

--- a/Mathlib/CategoryTheory/Sites/Subsheaf.lean
+++ b/Mathlib/CategoryTheory/Sites/Subsheaf.lean
@@ -190,15 +190,12 @@ theorem Subpresheaf.sheafify_le (h : G ≤ G') (hF : Presieve.IsSheaf J F)
 
 section Image
 
-variable (J)
-
+variable (J) in
 /-- A morphism factors through the sheafification of the image presheaf. -/
 @[simps!]
 def Subpresheaf.toRangeSheafify (f : F' ⟶ F) : F' ⟶ ((Subpresheaf.range f).sheafify J).toPresheaf :=
   toRange f ≫ Subpresheaf.homOfLe ((range f).le_sheafify J)
 
-
-variable {J}
 
 /-- The image sheaf of a morphism between sheaves, defined to be the sheafification of
 `image_presheaf`. -/

--- a/Mathlib/CategoryTheory/Subobject/MonoOver.lean
+++ b/Mathlib/CategoryTheory/Subobject/MonoOver.lean
@@ -231,13 +231,10 @@ def map (f : X ⟶ Y) [Mono f] : MonoOver X ⥤ MonoOver Y :=
 def mapComp (f : X ⟶ Y) (g : Y ⟶ Z) [Mono f] [Mono g] : map (f ≫ g) ≅ map f ⋙ map g :=
   liftIso _ _ (Over.mapComp _ _) ≪≫ (liftComp _ _ _ _).symm
 
-variable (X)
-
+variable (X) in
 /-- `MonoOver.map` preserves the identity (up to a natural isomorphism). -/
 def mapId : map (𝟙 X) ≅ 𝟭 _ :=
   liftIso _ _ (Over.mapId X) ≪≫ liftId
-
-variable {X}
 
 @[simp]
 theorem map_obj_left (f : X ⟶ Y) [Mono f] (g : MonoOver X) : ((map f).obj g : C) = g.obj.left :=

--- a/Mathlib/CategoryTheory/Triangulated/Rotate.lean
+++ b/Mathlib/CategoryTheory/Triangulated/Rotate.lean
@@ -122,8 +122,7 @@ def invRotCompRot : invRotate C ⋙ rotate C ≅ 𝟭 (Triangle C) :=
   NatIso.ofComponents fun T => Triangle.isoMk _ _ (Iso.refl _) (Iso.refl _)
     ((shiftEquiv C (1 : ℤ)).counitIso.app T.obj₃)
 
-variable (C)
-
+variable (C) in
 /-- Rotating triangles gives an auto-equivalence on the category of triangles in `C`.
 -/
 @[simps]
@@ -132,8 +131,6 @@ def triangleRotation : Equivalence (Triangle C) (Triangle C) where
   inverse := invRotate C
   unitIso := rotCompInvRot
   counitIso := invRotCompRot
-
-variable {C}
 
 instance : (rotate C).IsEquivalence := by
   change (triangleRotation C).functor.IsEquivalence

--- a/Mathlib/Combinatorics/SimpleGraph/AdjMatrix.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/AdjMatrix.lean
@@ -136,7 +136,6 @@ namespace SimpleGraph
 variable (G : SimpleGraph V) [DecidableRel G.Adj]
 
 variable (α) in
-
 /-- `adjMatrix G α` is the matrix `A` such that `A i j = (1 : α)` if `i` and `j` are
   adjacent in the simple graph `G`, and otherwise `A i j = 0`. -/
 def adjMatrix [Zero α] [One α] : Matrix V V α :=

--- a/Mathlib/Combinatorics/SimpleGraph/AdjMatrix.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/AdjMatrix.lean
@@ -134,14 +134,13 @@ open Matrix
 namespace SimpleGraph
 
 variable (G : SimpleGraph V) [DecidableRel G.Adj]
-variable (α)
+
+variable (α) in
 
 /-- `adjMatrix G α` is the matrix `A` such that `A i j = (1 : α)` if `i` and `j` are
   adjacent in the simple graph `G`, and otherwise `A i j = 0`. -/
 def adjMatrix [Zero α] [One α] : Matrix V V α :=
   of fun i j => if G.Adj i j then (1 : α) else 0
-
-variable {α}
 
 -- TODO: set as an equation lemma for `adjMatrix`, see https://github.com/leanprover-community/mathlib4/pull/3024
 @[simp]
@@ -218,13 +217,10 @@ theorem mul_adjMatrix_apply [NonAssocSemiring α] (M : Matrix V V α) (v w : V) 
     (M * G.adjMatrix α) v w = ∑ u ∈ G.neighborFinset w, M v u := by
   simp [mul_apply, neighborFinset_eq_filter, sum_filter, adj_comm]
 
-variable (α)
-
+variable (α) in
 @[simp]
 theorem trace_adjMatrix [AddCommMonoid α] [One α] : Matrix.trace (G.adjMatrix α) = 0 := by
   simp [Matrix.trace]
-
-variable {α}
 
 theorem adjMatrix_mul_self_apply_self [NonAssocSemiring α] (i : V) :
     (G.adjMatrix α * G.adjMatrix α) i i = degree G i := by simp [filter_true_of_mem]

--- a/Mathlib/Combinatorics/SimpleGraph/Connectivity/WalkCounting.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Connectivity/WalkCounting.lean
@@ -110,13 +110,10 @@ theorem coe_finsetWalkLength_eq (n : ℕ) (u v : V) :
     simp only [Finset.mem_coe, Set.mem_setOf_eq] at this
     rw [← this]
 
-variable {G}
-
+variable {G} in
 theorem mem_finsetWalkLength_iff {n : ℕ} {u v : V} {p : G.Walk u v} :
     p ∈ G.finsetWalkLength n u v ↔ p.length = n :=
   Set.ext_iff.mp (G.coe_finsetWalkLength_eq n u v) p
-
-variable (G)
 
 /-- The `Finset` of walks from `u` to `v` with length less than `n`. See `finsetWalkLength` for
 context. In particular, we use this definition for `SimpleGraph.Path.instFintype`. -/
@@ -134,13 +131,10 @@ theorem coe_finsetWalkLengthLT_eq (n : ℕ) (u v : V) :
   ext p
   simp [finsetWalkLengthLT, mem_coe, mem_disjiUnion, mem_finsetWalkLength_iff]
 
-variable {G}
-
+variable {G} in
 theorem mem_finsetWalkLengthLT_iff {n : ℕ} {u v : V} {p : G.Walk u v} :
     p ∈ G.finsetWalkLengthLT n u v ↔ p.length < n :=
   Set.ext_iff.mp (G.coe_finsetWalkLengthLT_eq n u v) p
-
-variable (G)
 
 instance fintypeSetWalkLength (u v : V) (n : ℕ) : Fintype {p : G.Walk u v | p.length = n} :=
   Fintype.ofFinset (G.finsetWalkLength n u v) fun p => by

--- a/Mathlib/Combinatorics/SimpleGraph/DegreeSum.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/DegreeSum.lean
@@ -69,13 +69,10 @@ theorem dart_card_eq_sum_degrees : Fintype.card G.Dart = ∑ v, G.degree v := by
   simp only [← card_univ, ← dart_fst_fiber_card_eq_degree]
   exact card_eq_sum_card_fiberwise (by simp)
 
-variable {G}
-
+variable {G} in
 theorem Dart.edge_fiber [DecidableEq V] (d : G.Dart) :
     ({d' : G.Dart | d'.edge = d.edge} : Finset _) = {d, d.symm} :=
   Finset.ext fun d' => by simpa using dart_edge_eq_iff d' d
-
-variable (G)
 
 theorem dart_edge_fiber_card [DecidableEq V] (e : Sym2 V) (h : e ∈ G.edgeSet) :
     #{d : G.Dart | d.edge = e} = 2 := by

--- a/Mathlib/Control/Functor/Multivariate.lean
+++ b/Mathlib/Control/Functor/Multivariate.lean
@@ -104,8 +104,7 @@ theorem map_map (g : α ⟹ β) (h : β ⟹ γ) (x : F α) : h <$$> g <$$> x = (
 
 section LiftP'
 
-variable (F)
-
+variable (F) in
 theorem exists_iff_exists_of_mono {P : F α → Prop} {q : F β → Prop}
     (f : α ⟹ β) (g : β ⟹ α)
     (h₀ : f ⊚ g = TypeVec.id)
@@ -117,8 +116,6 @@ theorem exists_iff_exists_of_mono {P : F α → Prop} {q : F β → Prop}
   · refine ⟨g <$$> u, ?_⟩
     rw [h₁]
     simp only [MvFunctor.map_map, h₀, LawfulMvFunctor.id_map, h₂]
-
-variable {F}
 
 theorem LiftP_def (x : F α) : LiftP' P x ↔ ∃ u : F (Subtype_ P), subtypeVal P <$$> u = x :=
   exists_iff_exists_of_mono F _ _ (toSubtype_of_subtype P) (by simp [MvFunctor.map_map])

--- a/Mathlib/Data/DFinsupp/Defs.lean
+++ b/Mathlib/Data/DFinsupp/Defs.lean
@@ -46,7 +46,6 @@ universe u u₁ u₂ v v₁ v₂ v₃ w x y l
 variable {ι : Type u} {γ : Type w} {β : ι → Type v} {β₁ : ι → Type v₁} {β₂ : ι → Type v₂}
 
 variable (β) in
-
 /-- A dependent function `Π i, β i` with finite support, with notation `Π₀ i, β i`.
 
 Note that `DFinsupp.support` is the preferred API for accessing the support of the function,

--- a/Mathlib/Data/DFinsupp/Defs.lean
+++ b/Mathlib/Data/DFinsupp/Defs.lean
@@ -44,7 +44,8 @@ assert_not_exists Finset.prod Submonoid
 universe u u₁ u₂ v v₁ v₂ v₃ w x y l
 
 variable {ι : Type u} {γ : Type w} {β : ι → Type v} {β₁ : ι → Type v₁} {β₂ : ι → Type v₂}
-variable (β)
+
+variable (β) in
 
 /-- A dependent function `Π i, β i` with finite support, with notation `Π₀ i, β i`.
 
@@ -56,8 +57,6 @@ structure DFinsupp [∀ i, Zero (β i)] : Type max u v where mk' ::
   toFun : ∀ i, β i
   /-- The support of a dependent function with finite support (aka `DFinsupp`). -/
   support' : Trunc { s : Multiset ι // ∀ i, i ∈ s ∨ toFun i = 0 }
-
-variable {β}
 
 /-- `Π₀ i, β i` denotes the type of dependent functions with finite support `DFinsupp β`. -/
 notation3 "Π₀ "(...)", "r:(scoped f => DFinsupp f) => r

--- a/Mathlib/Data/DFinsupp/Order.lean
+++ b/Mathlib/Data/DFinsupp/Order.lean
@@ -213,12 +213,9 @@ lemma support_monotone : Monotone (support (ι := ι) (β := α)) :=
 
 lemma support_mono (hfg : f ≤ g) : f.support ⊆ g.support := support_monotone hfg
 
-variable (α)
-
+variable (α) in
 instance decidableLE [∀ i, DecidableRel (@LE.le (α i) _)] : DecidableRel (@LE.le (Π₀ i, α i) _) :=
   fun _ _ ↦ decidable_of_iff _ le_iff.symm
-
-variable {α}
 
 end
 

--- a/Mathlib/Data/Nat/Nth.lean
+++ b/Mathlib/Data/Nat/Nth.lean
@@ -400,16 +400,13 @@ theorem le_nth_of_count_le {n k : ℕ} (h : n ≤ nth p k) : count p n ≤ k :=
 protected theorem count_eq_zero (h : ∃ n, p n) {n : ℕ} : count p n = 0 ↔ n ≤ nth p 0 := by
   rw [nth_zero_of_exists h, le_find_iff h, Nat.count_iff_forall_not]
 
-variable (p)
-
+variable (p) in
 theorem nth_count_eq_sInf (n : ℕ) : nth p (count p n) = sInf {i : ℕ | p i ∧ n ≤ i} := by
   refine (nth_eq_sInf _ _).trans (congr_arg sInf ?_)
   refine Set.ext fun a => and_congr_right fun hpa => ?_
   refine ⟨fun h => not_lt.1 fun ha => ?_, fun hn k hk => lt_of_lt_of_le (nth_lt_of_lt_count hk) hn⟩
   have hn : nth p (count p a) < a := h _ (count_strict_mono hpa ha)
   rwa [nth_count hpa, lt_self_iff_false] at hn
-
-variable {p}
 
 theorem le_nth_count' {n : ℕ} (hpn : ∃ k, p k ∧ n ≤ k) : n ≤ nth p (count p n) :=
   (le_csInf hpn fun _ => And.right).trans (nth_count_eq_sInf p n).ge

--- a/Mathlib/Data/Prod/TProd.lean
+++ b/Mathlib/Data/Prod/TProd.lean
@@ -39,13 +39,10 @@ variable {ι : Type u} {α : ι → Type v} {i j : ι} {l : List ι}
 
 namespace List
 
-variable (α)
-
+variable (α) in
 /-- The product of a family of types over a list. -/
 abbrev TProd (l : List ι) : Type v :=
   l.foldr (fun i β => α i × β) PUnit
-
-variable {α}
 
 namespace TProd
 

--- a/Mathlib/Data/Setoid/Partition.lean
+++ b/Mathlib/Data/Setoid/Partition.lean
@@ -248,8 +248,7 @@ instance Partition.partialOrder : PartialOrder (Subtype (@IsPartition α)) where
     let h := @le_antisymm (Setoid α) _ _ _ hx hy
     rw [Subtype.ext_iff_val, ← classes_mkClasses x.1 x.2, ← classes_mkClasses y.1 y.2, h]
 
-variable (α)
-
+variable (α) in
 /-- The order-preserving bijection between equivalence relations on a type `α`, and
   partitions of `α` into subsets. -/
 protected def Partition.orderIso : Setoid α ≃o { C : Set (Set α) // IsPartition C } where
@@ -260,8 +259,6 @@ protected def Partition.orderIso : Setoid α ≃o { C : Set (Set α) // IsPartit
   map_rel_iff' {r s} := by
     conv_rhs => rw [← mkClasses_classes r, ← mkClasses_classes s]
     rfl
-
-variable {α}
 
 /-- A complete lattice instance for partitions; there is more infrastructure for the
     equivalent complete lattice on equivalence relations. -/

--- a/Mathlib/Data/W/Basic.lean
+++ b/Mathlib/Data/W/Basic.lean
@@ -59,8 +59,7 @@ theorem ofSigma_toSigma : ∀ w : WType β, ofSigma (toSigma w) = w
 theorem toSigma_ofSigma : ∀ s : Σa : α, β a → WType β, toSigma (ofSigma s) = s
   | ⟨_, _⟩ => rfl
 
-variable (β)
-
+variable (β) in
 /-- The canonical bijection with the sigma type, showing that `WType` is a fixed point of
   the polynomial functor `X ↦ Σ a : α, β a → X`. -/
 @[simps]
@@ -69,8 +68,6 @@ def equivSigma : WType β ≃ Σa : α, β a → WType β where
   invFun := ofSigma
   left_inv := ofSigma_toSigma
   right_inv := toSigma_ofSigma
-
-variable {β}
 
 -- Porting note: Universes have a different order than mathlib3 definition
 /-- The canonical map from `WType β` into any type `γ` given a map `(Σ a : α, β a → γ) → γ`. -/


### PR DESCRIPTION
Found by #22389.

The motivation comes from [this Zulip discussion](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/style.20proposal.3A.20avoid.20.60variable.20.7BX.7D.20.2E.2E.2E.20variable.20.28X.29.60).

Summarising, updating a variable binder for a single declaration can be confusing.

This is a further batch with the changes in the dirs `Mathlib/[A-D]*`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
