### PR TITLE
chore: fix benchmark script for precompilation

### DIFF
--- a/scripts/bench/run
+++ b/scripts/bench/run
@@ -2,6 +2,8 @@
 
 set -euxo pipefail
 
+ln -s $(lean --print-prefix)/{lib,include} ./scripts/bench/fake-root
+
 temci exec --config ./scripts/bench/temci-config.yml >2
 temci report --reporter codespeed2 |\
   sed 's/instructions:u/instructions/g' |\


### PR DESCRIPTION
The benchmarking script used to fail when precompilation was enabled anywhere in the dependency graph.

---
Fix courtesy of @Kha.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
