### PR TITLE
fix(congrm): replace mvar names with fresh ones

### DIFF
--- a/MathlibTest/congrm.lean
+++ b/MathlibTest/congrm.lean
@@ -4,7 +4,7 @@ import Mathlib.Tactic.CongrM
 
 example (a b : ℤ) : (a - b + b) + a + b = a + (a - b + b) + (b - a + a) := by
   congrm ?h1 + ?h2
-  · congrm ?h1 + ?h2 <;> rw [Int.sub_add_cancel]
+  case H1 => congrm ?h1 + ?h2 <;> rw [Int.sub_add_cancel]
   · rw [Int.sub_add_cancel]
 
 private axiom test_sorry : ∀ {α}, α

--- a/MathlibTest/congrm.lean
+++ b/MathlibTest/congrm.lean
@@ -2,6 +2,11 @@ import Mathlib.Algebra.Ring.Nat
 import Mathlib.Data.Fintype.Card
 import Mathlib.Tactic.CongrM
 
+example (a b : ℤ) : (a - b + b) + a + b = a + (a - b + b) + (b - a + a) := by
+  congrm ?h1 + ?h2
+  · congrm ?h1 + ?h2 <;> rw [Int.sub_add_cancel]
+  · rw [Int.sub_add_cancel]
+
 private axiom test_sorry : ∀ {α}, α
 namespace Tests.Congrm
 

--- a/MathlibTest/congrm.lean
+++ b/MathlibTest/congrm.lean
@@ -4,7 +4,7 @@ import Mathlib.Tactic.CongrM
 
 example (a b : ℤ) : (a - b + b) + a + b = a + (a - b + b) + (b - a + a) := by
   congrm ?h1 + ?h2
-  case H1 => congrm ?h1 + ?h2 <;> rw [Int.sub_add_cancel]
+  case h1 => congrm ?h1 + ?h2 <;> rw [Int.sub_add_cancel]
   · rw [Int.sub_add_cancel]
 
 private axiom test_sorry : ∀ {α}, α


### PR DESCRIPTION
Reported in [Zulip](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Bug.20in.20.60congrm.60)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
