### PR TITLE
[Merged by Bors] - chore(AlgebraicTopology): clean up `erw` and porting notes

### DIFF
--- a/Mathlib/AlgebraicTopology/AlternatingFaceMapComplex.lean
+++ b/Mathlib/AlgebraicTopology/AlternatingFaceMapComplex.lean
@@ -73,7 +73,8 @@ theorem d_squared (n : ℕ) : objD X (n + 1) ≫ objD X n = 0 := by
   -- then, we decompose the index set P into a subset S and its complement Sᶜ
   let P := Fin (n + 2) × Fin (n + 3)
   let S := Finset.univ.filter fun ij : P => (ij.2 : ℕ) ≤ (ij.1 : ℕ)
-  erw [← Finset.sum_add_sum_compl S, ← eq_neg_iff_add_eq_zero, ← Finset.sum_neg_distrib]
+  rw [Finset.univ_product_univ, ← Finset.sum_add_sum_compl S, ← eq_neg_iff_add_eq_zero,
+    ← Finset.sum_neg_distrib]
   /- we are reduced to showing that two sums are equal, and this is obtained
     by constructing a bijection φ : S -> Sᶜ, which maps (i,j) to (j,i+1),
     and by comparing the terms -/

--- a/Mathlib/AlgebraicTopology/DoldKan/Compatibility.lean
+++ b/Mathlib/AlgebraicTopology/DoldKan/Compatibility.lean
@@ -198,8 +198,9 @@ theorem equivalenceCounitIso_eq (hη : τ₀ = τ₁ hF hG η) :
   dsimp [equivalence]
   simp only [comp_id, id_comp, Functor.map_comp, equivalence₂CounitIso_eq,
     equivalence₂CounitIso_hom_app, assoc, equivalenceCounitIso_hom_app]
-  simp only [← eB.inverse.map_comp_assoc, ← τ₀_hom_app, hη, τ₁_hom_app]
-  erw [hF.inv.naturality_assoc, hF.inv.naturality_assoc]
+  simp only [← eB.inverse.map_comp_assoc, ← τ₀_hom_app, hη, τ₁_hom_app, equivalence₂_inverse,
+    Functor.comp_obj]
+  rw [hF.inv.naturality_assoc, hF.inv.naturality_assoc]
   dsimp
   congr 2
   simp only [← e'.functor.map_comp_assoc, Equivalence.fun_inv_map, assoc,
@@ -243,9 +244,8 @@ theorem equivalenceUnitIso_eq (hε : υ hF = ε) :
     (equivalence hF hG).unitIso = equivalenceUnitIso hG ε := by
   ext1; apply NatTrans.ext; ext X
   dsimp [equivalence]
-  simp only [assoc, comp_id, equivalenceUnitIso_hom_app]
-  erw [id_comp]
-  simp only [equivalence₂UnitIso_eq eB hF, equivalence₂UnitIso_hom_app,
+  simp only [assoc, comp_id, equivalenceUnitIso_hom_app, equivalence₂_inverse, Functor.comp_obj,
+    id_comp, equivalence₂UnitIso_eq eB hF, equivalence₂UnitIso_hom_app,
     ← eA.inverse.map_comp_assoc, assoc, ← hε, υ_hom_app]
 
 end Compatibility

--- a/Mathlib/AlgebraicTopology/DoldKan/Degeneracies.lean
+++ b/Mathlib/AlgebraicTopology/DoldKan/Degeneracies.lean
@@ -74,25 +74,32 @@ theorem σ_comp_P_eq_zero (X : SimplicialObject C) {n q : ℕ} (i : Fin (n + 1))
           HomologicalComplex.id_f, AlternatingFaceMapComplex.obj_d_eq, Hσ,
           HomologicalComplex.comp_f, Homotopy.nullHomotopicMap'_f (c_mk 2 1 rfl) (c_mk 1 0 rfl),
           comp_id]
-        erw [hσ'_eq' (zero_add 0).symm, hσ'_eq' (add_zero 1).symm, comp_id, Fin.sum_univ_two,
+        rw [hσ'_eq' (zero_add 0).symm, hσ'_eq' (add_zero 1).symm]
+        dsimp [P_zero]
+        rw [comp_id, Fin.sum_univ_two,
           Fin.sum_univ_succ, Fin.sum_univ_two]
         simp only [Fin.val_zero, pow_zero, pow_one, pow_add, one_smul, neg_smul, Fin.mk_one,
-          Fin.val_succ, Fin.val_one, Fin.succ_one_eq_two, P_zero, HomologicalComplex.id_f,
+          Fin.val_succ, Fin.val_one, P_zero, HomologicalComplex.id_f,
           Fin.val_two, pow_two, mul_neg, one_mul, neg_mul, neg_neg, id_comp, add_comp,
           comp_add, Fin.mk_zero, neg_comp, comp_neg, Fin.succ_zero_eq_one]
-        erw [SimplicialObject.δ_comp_σ_self, SimplicialObject.δ_comp_σ_self_assoc,
-          SimplicialObject.δ_comp_σ_succ, comp_id,
+        rw [← Fin.castSucc_one, SimplicialObject.δ_comp_σ_self, ← Fin.castSucc_zero,
+          SimplicialObject.δ_comp_σ_self_assoc,
+          SimplicialObject.δ_comp_σ_succ, comp_id, ← Fin.castSucc_zero, ← Fin.succ_zero_eq_one,
           SimplicialObject.δ_comp_σ_of_le X
             (show (0 : Fin 2) ≤ Fin.castSucc 0 by rw [Fin.castSucc_zero]),
-          SimplicialObject.δ_comp_σ_self_assoc, SimplicialObject.δ_comp_σ_succ_assoc]
+          ← Fin.castSucc_zero, SimplicialObject.δ_comp_σ_self_assoc,
+          SimplicialObject.δ_comp_σ_succ_assoc]
         simp only [add_neg_cancel, add_zero, zero_add]
       · rw [← id_comp (X.σ i), ← (P_add_Q_f q n.succ : _ = 𝟙 (X.obj _)), add_comp, add_comp,
           P_succ]
         have v : HigherFacesVanish q ((P q).f n.succ ≫ X.σ i) :=
           (HigherFacesVanish.of_P q n).comp_σ hi
-        erw [← assoc, v.comp_P_eq_self, HomologicalComplex.add_f_apply, Preadditive.comp_add,
-          comp_id, v.comp_Hσ_eq hi, assoc, SimplicialObject.δ_comp_σ_succ_assoc, Fin.eta,
-          decomposition_Q n q, sum_comp, sum_comp, Finset.sum_eq_zero, add_zero, add_neg_eq_zero]
+        dsimp only [AlternatingFaceMapComplex.obj_X, Nat.succ_eq_add_one, HomologicalComplex.comp_f,
+          HomologicalComplex.add_f_apply, HomologicalComplex.id_f]
+        rw [← assoc, v.comp_P_eq_self, Preadditive.comp_add,
+          comp_id, v.comp_Hσ_eq hi, assoc, ← Fin.succ_mk, SimplicialObject.δ_comp_σ_succ_assoc,
+          Fin.eta, decomposition_Q n q, sum_comp, sum_comp, Finset.sum_eq_zero, add_zero,
+          add_neg_eq_zero]
         intro j hj
         simp only [Finset.mem_univ, Finset.mem_filter] at hj
         obtain ⟨k, hk⟩ := Nat.le.dest (Nat.lt_succ_iff.mp (Fin.is_lt j))
@@ -103,7 +110,7 @@ theorem σ_comp_P_eq_zero (X : SimplicialObject C) {n q : ℕ} (i : Fin (n + 1))
         have eq := hq j.rev.succ (by
           simp only [← hk, Fin.rev_eq j hk.symm, Nat.succ_eq_add_one, Fin.succ_mk, Fin.val_mk]
           omega)
-        rw [HomologicalComplex.comp_f, assoc, assoc, assoc, hi',
+        rw [assoc, assoc, assoc, hi',
           SimplicialObject.σ_comp_σ_assoc, reassoc_of% eq, zero_comp, comp_zero, comp_zero,
           comp_zero]
         simp only [Fin.rev_eq j hk.symm, Fin.le_iff_val_le_val, Fin.val_mk]

--- a/Mathlib/AlgebraicTopology/DoldKan/EquivalencePseudoabelian.lean
+++ b/Mathlib/AlgebraicTopology/DoldKan/EquivalencePseudoabelian.lean
@@ -125,14 +125,13 @@ theorem hε :
   ext1
   rw [← cancel_epi Γ₂N₁.inv, Iso.inv_hom_id]
   ext X : 2
-  rw [NatTrans.comp_app]
-  erw [compatibility_Γ₂N₁_Γ₂N₂_natTrans X]
-  rw [Compatibility.υ_hom_app, Preadditive.DoldKan.equivalence_unitIso, Iso.app_inv, assoc]
-  erw [← NatTrans.comp_app_assoc, IsIso.hom_inv_id]
-  rw [NatTrans.id_app, id_comp, NatTrans.id_app, Γ₂N₂ToKaroubiIso_inv_app]
-  dsimp only [Preadditive.DoldKan.equivalence_inverse, Preadditive.DoldKan.Γ]
-  rw [← Γ₂.map_comp, Iso.inv_hom_id_app, Γ₂.map_id]
-  rfl
+  rw [NatTrans.comp_app, Γ₂N₁_inv, compatibility_Γ₂N₁_Γ₂N₂_natTrans X, Compatibility.υ_hom_app,
+    Preadditive.DoldKan.equivalence_unitIso, Iso.app_inv, assoc]
+  dsimp only [Functor.comp_obj, Preadditive.DoldKan.equivalence_inverse, Preadditive.DoldKan.Γ.eq_1,
+    toKaroubiEquivalence, Functor.asEquivalence_functor, Preadditive.DoldKan.N.eq_1,
+    NatTrans.id_app]
+  rw [← NatTrans.comp_app_assoc, ← Γ₂N₂_inv, Iso.inv_hom_id, NatTrans.id_app, id_comp,
+    Γ₂N₂ToKaroubiIso_inv_app, ← Γ₂.map_comp, Iso.inv_hom_id_app, Γ₂.map_id]
 
 /-- The unit isomorphism induced by `Γ₂N₁`. -/
 def ε : 𝟭 (SimplicialObject C) ≅ N ⋙ Γ :=

--- a/Mathlib/AlgebraicTopology/DoldKan/Faces.lean
+++ b/Mathlib/AlgebraicTopology/DoldKan/Faces.lean
@@ -128,7 +128,8 @@ theorem comp_Hσ_eq {Y : C} {n a q : ℕ} {φ : Y ⟶ X _⦋n + 1⦌} (v : Highe
       rw [Fin.le_iff_val_le_val]
       dsimp
       omega
-    erw [δ_comp_σ_of_le X hia, add_eq_zero_iff_eq_neg, ← neg_zsmul]
+    rw [← Fin.succ_mk, ← Fin.castSucc_mk _ i, δ_comp_σ_of_le X hia, add_eq_zero_iff_eq_neg,
+      ← neg_zsmul]
     congr 2
     ring
 
@@ -146,7 +147,8 @@ theorem comp_Hσ_eq_zero {Y : C} {n q : ℕ} {φ : Y ⟶ X _⦋n + 1⦌} (v : Hi
         Fin.cast_mk, Fin.castSucc_mk]
       simp only [Fin.mk_zero, Fin.val_zero, pow_zero, one_zsmul, Fin.mk_one, Fin.val_one, pow_one,
         neg_smul, comp_neg]
-      erw [δ_comp_σ_self, δ_comp_σ_succ, add_neg_cancel]
+      rw [← Fin.castSucc_zero (n := n + 1), δ_comp_σ_self, ← Fin.succ_zero_eq_one, δ_comp_σ_succ,
+        add_neg_cancel]
     · intro j
       dsimp [Fin.cast, Fin.castLE, Fin.castLT]
       rw [comp_zsmul, comp_zsmul, δ_comp_σ_of_gt', v.comp_δ_eq_zero_assoc, zero_comp, zsmul_zero]

--- a/Mathlib/AlgebraicTopology/DoldKan/FunctorGamma.lean
+++ b/Mathlib/AlgebraicTopology/DoldKan/FunctorGamma.lean
@@ -201,7 +201,9 @@ def obj (K : ChainComplex C ℕ) : SimplicialObject C where
   map_id Δ := colimit.hom_ext (fun ⟨A⟩ => by
     dsimp
     have fac : A.e ≫ 𝟙 A.1.unop = (𝟙 Δ).unop ≫ A.e := by rw [unop_id, comp_id, id_comp]
-    erw [Obj.map_on_summand₀ K A fac, Obj.Termwise.mapMono_id, id_comp, comp_id]
+    rw [Obj.map_on_summand₀ K A fac, Obj.Termwise.mapMono_id, id_comp]
+    dsimp only [Obj.obj₂]
+    rw [comp_id]
     rfl)
   map_comp {Δ'' Δ' Δ} θ' θ := colimit.hom_ext (fun ⟨A⟩ => by
     have fac : θ.unop ≫ θ'.unop ≫ A.e = (θ' ≫ θ).unop ≫ A.e := by rw [unop_comp, assoc]
@@ -234,10 +236,14 @@ theorem Obj.map_on_summand {Δ Δ' : SimplexCategoryᵒᵖ} (A : Splitting.Index
   change (_ ≫ (Γ₀.obj K).map A.e.op) ≫ (Γ₀.obj K).map θ = _
   rw [assoc, ← Functor.map_comp]
   dsimp [splitting]
-  erw [Γ₀.Obj.map_on_summand₀ K (Splitting.IndexSet.id A.1)
-    (show e ≫ i = ((Splitting.IndexSet.e A).op ≫ θ).unop ≫ 𝟙 _ by rw [comp_id, fac]; rfl),
-    Γ₀.Obj.map_on_summand₀ K (Splitting.IndexSet.id (op Δ''))
-      (show e ≫ 𝟙 Δ'' = e.op.unop ≫ 𝟙 _ by simp), Termwise.mapMono_id, id_comp]
+  rw [Γ₀.Obj.map_on_summand₀ K (Splitting.IndexSet.id A.1)
+    (show e ≫ i = ((Splitting.IndexSet.e A).op ≫ θ).unop ≫ 𝟙 _ by rw [comp_id, fac]; rfl)]
+  dsimp only [Splitting.IndexSet.id_fst, Splitting.IndexSet.mk, op_unop, Splitting.IndexSet.e]
+  rw [Γ₀.Obj.map_on_summand₀ K (Splitting.IndexSet.id (op Δ''))
+      (show e ≫ 𝟙 Δ'' = e.op.unop ≫ 𝟙 _ by simp), Termwise.mapMono_id]
+  dsimp only [Splitting.IndexSet.id_fst]
+  rw [id_comp]
+  rfl
 
 @[reassoc]
 theorem Obj.map_on_summand' {Δ Δ' : SimplexCategoryᵒᵖ} (A : Splitting.IndexSet Δ) (θ : Δ ⟶ Δ') :

--- a/Mathlib/AlgebraicTopology/DoldKan/GammaCompN.lean
+++ b/Mathlib/AlgebraicTopology/DoldKan/GammaCompN.lean
@@ -42,12 +42,14 @@ def Γ₀NondegComplexIso (K : ChainComplex C ℕ) : (Γ₀.splitting K).nondegC
         Preadditive.comp_sum]
       rw [Fintype.sum_eq_single (0 : Fin (n + 2))]
       · simp only [Fin.val_zero, pow_zero, one_zsmul]
-        erw [Γ₀.Obj.mapMono_on_summand_id_assoc, Γ₀.Obj.Termwise.mapMono_δ₀,
-          Splitting.cofan_inj_πSummand_eq_id, comp_id]
+        rw [δ, Γ₀.Obj.mapMono_on_summand_id_assoc, Γ₀.Obj.Termwise.mapMono_δ₀,
+          Splitting.cofan_inj_πSummand_eq_id]
+        dsimp only [Γ₀.splitting, Splitting.summand.eq_1, Splitting.IndexSet.id_fst]
+        rw [comp_id]
       · intro i hi
         dsimp
         simp only [Preadditive.zsmul_comp, Preadditive.comp_zsmul, assoc]
-        erw [Γ₀.Obj.mapMono_on_summand_id_assoc, Γ₀.Obj.Termwise.mapMono_eq_zero, zero_comp,
+        rw [δ, Γ₀.Obj.mapMono_on_summand_id_assoc, Γ₀.Obj.Termwise.mapMono_eq_zero, zero_comp,
           zsmul_zero]
         · intro h
           replace h := congr_arg SimplexCategory.len h
@@ -160,7 +162,6 @@ theorem N₂Γ₂_inv_app_f_f (X : Karoubi (ChainComplex C ℕ)) (n : ℕ) :
     Splitting.ι_desc]
   apply Karoubi.HomologicalComplex.p_idem_assoc
 
--- Porting note: added to ease the proof of `N₂Γ₂_compatible_with_N₁Γ₀`
 lemma whiskerLeft_toKaroubi_N₂Γ₂_hom :
     whiskerLeft (toKaroubi (ChainComplex C ℕ)) N₂Γ₂.hom = N₂Γ₂ToKaroubiIso.hom ≫ N₁Γ₀.hom := by
   let e : _ ≅ toKaroubi (ChainComplex C ℕ) ⋙ 𝟭 _ := N₂Γ₂ToKaroubiIso ≪≫ N₁Γ₀

--- a/Mathlib/AlgebraicTopology/DoldKan/Homotopies.lean
+++ b/Mathlib/AlgebraicTopology/DoldKan/Homotopies.lean
@@ -130,10 +130,11 @@ theorem Hσ_eq_zero (q : ℕ) : (Hσ q : K[X] ⟶ K[X]).f 0 = 0 := by
   rcases q with (_|q)
   · rw [hσ'_eq (show 0 = 0 + 0 by rfl) (c_mk 1 0 rfl)]
     simp only [pow_zero, Fin.mk_zero, one_zsmul, eqToHom_refl, Category.comp_id]
+    -- This `erw` is needed to show `0 + 1 = 1`.
     erw [ChainComplex.of_d]
     rw [AlternatingFaceMapComplex.objD, Fin.sum_univ_two, Fin.val_zero, Fin.val_one, pow_zero,
-      pow_one, one_smul, neg_smul, one_smul, comp_add, comp_neg, add_neg_eq_zero]
-    erw [δ_comp_σ_self, δ_comp_σ_succ]
+      pow_one, one_smul, neg_smul, one_smul, comp_add, comp_neg, add_neg_eq_zero,
+      ← Fin.castSucc_zero, ← Fin.succ_zero_eq_one, δ_comp_σ_self, δ_comp_σ_succ]
   · rw [hσ'_eq_zero (Nat.succ_pos q) (c_mk 1 0 rfl), zero_comp]
 
 /-- The maps `hσ' q n m hnm` are natural on the simplicial object -/

--- a/Mathlib/AlgebraicTopology/DoldKan/HomotopyEquivalence.lean
+++ b/Mathlib/AlgebraicTopology/DoldKan/HomotopyEquivalence.lean
@@ -61,16 +61,12 @@ def homotopyPInftyToId : Homotopy (PInfty : K[X] ⟶ _) (𝟙 _) where
     rcases n with _|n
     · simpa only [Homotopy.dNext_zero_chainComplex, Homotopy.prevD_chainComplex,
         PInfty_f, P_f_0_eq, zero_add] using (homotopyPToId X 2).comm 0
-    · simp only [Homotopy.dNext_succ_chainComplex, Homotopy.prevD_chainComplex,
-        HomologicalComplex.id_f, PInfty_f, ← P_is_eventually_constant (le_refl <| n + 1)]
-      -- Porting note(lean4/2146): remaining proof was
-      -- `simpa only [homotopyPToId_eventually_constant X (lt_add_one (Nat.succ n))]
-      -- using (homotopyPToId X (n + 2)).comm (n + 1)`;
-      -- fails since leanprover/lean4:nightly-2023-05-16; `erw` below clunkily works around this.
-      erw [homotopyPToId_eventually_constant X (lt_add_one (Nat.succ n))]
-      have := (homotopyPToId X (n + 2)).comm (n + 1)
-      rw [Homotopy.dNext_succ_chainComplex, Homotopy.prevD_chainComplex] at this
-      exact this
+    · simpa only [Homotopy.dNext_succ_chainComplex, Homotopy.prevD_chainComplex,
+          HomologicalComplex.id_f, PInfty_f, ← P_is_eventually_constant (le_refl <| n + 1),
+          homotopyPToId_eventually_constant X (Nat.lt_add_one (Nat.succ n)),
+          Homotopy.dNext_succ_chainComplex, Homotopy.prevD_chainComplex]
+        using (homotopyPToId X (n + 2)).comm (n + 1)
+
 
 /-- The inclusion of the Moore complex in the alternating face map complex
 is a homotopy equivalence -/

--- a/Mathlib/AlgebraicTopology/DoldKan/NCompGamma.lean
+++ b/Mathlib/AlgebraicTopology/DoldKan/NCompGamma.lean
@@ -100,8 +100,8 @@ theorem Γ₀_obj_termwise_mapMono_comp_PInfty (X : SimplicialObject C) {Δ Δ' 
     rw [Finset.sum_eq_single (0 : Fin (n + 2))]
     rotate_left
     · intro b _ hb
-      rw [Preadditive.comp_zsmul]
-      erw [PInfty_comp_map_mono_eq_zero X (SimplexCategory.δ b) h
+      rw [Preadditive.comp_zsmul, SimplicialObject.δ,
+        PInfty_comp_map_mono_eq_zero X (SimplexCategory.δ b) h
           (by
             rw [Isδ₀.iff]
             exact hb),
@@ -207,11 +207,7 @@ theorem identity_N₂_objectwise (P : Karoubi (SimplicialObject C)) :
     rw [Γ₂N₂ToKaroubiIso_hom_app, assoc, Splitting.ι_desc_assoc, assoc, assoc]
     dsimp [toKaroubi]
     rw [Splitting.ι_desc_assoc]
-    dsimp
-    simp only [assoc, Splitting.ι_desc_assoc, unop_op, Splitting.IndexSet.id_fst,
-      len_mk, NatTrans.naturality, PInfty_f_idem_assoc,
-      PInfty_f_naturality_assoc, app_idem_assoc]
-    erw [P.X.map_id, comp_id]
+    simp [Splitting.IndexSet.e]
   simp only [Karoubi.comp_f, HomologicalComplex.comp_f, Karoubi.id_f, N₂_obj_p_f, assoc,
     eq₁, eq₂, PInfty_f_naturality_assoc, app_idem, PInfty_f_idem_assoc]
 
@@ -228,7 +224,8 @@ instance : IsIso (Γ₂N₂.natTrans : (N₂ : Karoubi (SimplicialObject C) ⥤ 
     intro P
     have : IsIso (N₂.map (Γ₂N₂.natTrans.app P)) := by
       have h := identity_N₂_objectwise P
-      erw [hom_comp_eq_id] at h
+      dsimp only [Functor.id_obj, Functor.comp_obj] at h
+      rw [hom_comp_eq_id] at h
       rw [h]
       infer_instance
     exact isIso_of_reflects_iso _ N₂

--- a/Mathlib/AlgebraicTopology/DoldKan/NReflectsIso.lean
+++ b/Mathlib/AlgebraicTopology/DoldKan/NReflectsIso.lean
@@ -113,7 +113,7 @@ instance : (N₂ : Karoubi (SimplicialObject C) ⥤ Karoubi (ChainComplex C ℕ)
     haveI : ((KaroubiKaroubi.equivalence C).inverse).ReflectsIsomorphisms :=
       reflectsIsomorphisms_of_full_and_faithful _
     have : IsIso (F.map f) := by
-      simp only [F]
+      simp only [F, F₁]
       rw [← compatibility_N₂_N₁_karoubi, Functor.comp_map]
       apply Functor.map_isIso
     exact isIso_of_reflects_iso f F⟩

--- a/Mathlib/AlgebraicTopology/DoldKan/Projections.lean
+++ b/Mathlib/AlgebraicTopology/DoldKan/Projections.lean
@@ -151,6 +151,7 @@ def natTransP (q : ℕ) : alternatingFaceMapComplex C ⟶ alternatingFaceMapComp
     · dsimp [alternatingFaceMapComplex]
       simp only [P_zero, id_comp, comp_id]
     · simp only [P_succ, add_comp, comp_add, assoc, comp_id, hq, reassoc_of% hq]
+      -- `erw` is needed to see through `natTransHσ q).app = Hσ q`
       erw [(natTransHσ q).naturality f]
       rfl
 

--- a/Mathlib/AlgebraicTopology/DoldKan/SplitSimplicialObject.lean
+++ b/Mathlib/AlgebraicTopology/DoldKan/SplitSimplicialObject.lean
@@ -125,7 +125,8 @@ theorem πSummand_comp_cofan_inj_id_comp_PInfty_eq_PInfty (n : ℕ) :
     s.πSummand (IndexSet.id (op ⦋n⦌)) ≫ (s.cofan _).inj (IndexSet.id (op ⦋n⦌)) ≫ PInfty.f n =
       PInfty.f n := by
   conv_rhs => rw [← id_comp (PInfty.f n)]
-  erw [s.decomposition_id, Preadditive.sum_comp]
+  dsimp only [AlternatingFaceMapComplex.obj_X]
+  rw [s.decomposition_id, Preadditive.sum_comp]
   rw [Fintype.sum_eq_single (IndexSet.id (op ⦋n⦌)), assoc]
   rintro A (hA : ¬A.EqId)
   rw [assoc, s.cofan_inj_comp_PInfty_eq_zero A hA, comp_zero]
@@ -188,8 +189,9 @@ noncomputable def toKaroubiNondegComplexIsoN₁ :
           comm' := fun i j _ => by
             dsimp
             slice_rhs 1 1 => rw [← id_comp (K[X].d i j)]
-            erw [s.decomposition_id]
-            rw [sum_comp, sum_comp, Finset.sum_eq_single (IndexSet.id (op ⦋i⦌)), assoc, assoc]
+            dsimp only [AlternatingFaceMapComplex.obj_X]
+            rw [s.decomposition_id, sum_comp, sum_comp, Finset.sum_eq_single (IndexSet.id (op ⦋i⦌)),
+                assoc, assoc]
             · intro A _ hA
               simp only [assoc, s.ιSummand_comp_d_comp_πSummand_eq_zero _ _ _ hA, comp_zero]
             · simp only [Finset.mem_univ, not_true, IsEmpty.forall_iff] }

--- a/Mathlib/AlgebraicTopology/ExtraDegeneracy.lean
+++ b/Mathlib/AlgebraicTopology/ExtraDegeneracy.lean
@@ -84,20 +84,30 @@ def map {D : Type*} [Category D] {X : SimplicialObject.Augmented C} (ed : ExtraD
   s n := F.map (ed.s n)
   s'_comp_ε := by
     dsimp
-    erw [comp_id, ← F.map_comp, ed.s'_comp_ε, F.map_id]
+    rw [comp_id, ← F.map_comp, ed.s'_comp_ε]
+    dsimp only [point_obj]
+    rw [F.map_id]
   s₀_comp_δ₁ := by
     dsimp
-    erw [comp_id, ← F.map_comp, ← F.map_comp, ed.s₀_comp_δ₁]
+    rw [comp_id, ← F.map_comp]
+    dsimp [SimplicialObject.whiskering, SimplicialObject.δ]
+    rw [← F.map_comp]
+    erw [ed.s₀_comp_δ₁]
   s_comp_δ₀ n := by
+    dsimp [SimplicialObject.δ]
+    rw [← F.map_comp]
+    erw [ed.s_comp_δ₀]
     dsimp
-    erw [← F.map_comp, ed.s_comp_δ₀, F.map_id]
+    rw [F.map_id]
   s_comp_δ n i := by
-    dsimp
-    erw [← F.map_comp, ← F.map_comp, ed.s_comp_δ]
+    dsimp [SimplicialObject.δ]
+    rw [← F.map_comp, ← F.map_comp]
+    erw [ed.s_comp_δ]
     rfl
   s_comp_σ n i := by
-    dsimp
-    erw [← F.map_comp, ← F.map_comp, ed.s_comp_σ]
+    dsimp [SimplicialObject.whiskering, SimplicialObject.σ]
+    rw [← F.map_comp, ← F.map_comp]
+    erw [ed.s_comp_σ]
     rfl
 
 /-- If `X` and `Y` are isomorphic augmented simplicial objects, then an extra
@@ -270,6 +280,8 @@ noncomputable def ExtraDegeneracy.s (n : ℕ) :
       · simp only [WidePullback.π_arrow]
 
 -- Porting note (https://github.com/leanprover-community/mathlib4/issues/11119): @[simp] removed as the linter complains the LHS is not in normal form
+-- The problem is that the type of `ExtraDegeneracy.s` is not in normal form, this causes the `erw`
+-- in the proofs below.
 theorem ExtraDegeneracy.s_comp_π_0 (n : ℕ) :
     ExtraDegeneracy.s f S n ≫ WidePullback.π _ 0 =
       @WidePullback.base _ _ _ f.right (fun _ : Fin (n + 1) => f.left) (fun _ => f.hom) _ ≫
@@ -314,12 +326,13 @@ noncomputable def extraDegeneracy :
     · simpa only [assoc, WidePullback.lift_π, id_comp] using ExtraDegeneracy.s_comp_π_succ f S n j
     · simpa only [assoc, WidePullback.lift_base, id_comp] using ExtraDegeneracy.s_comp_base f S n
   s_comp_δ n i := by
-    dsimp [cechNerve, SimplicialObject.δ, SimplexCategory.δ]
+    dsimp [SimplicialObject.δ, SimplexCategory.δ]
     ext j
     · simp only [assoc, WidePullback.lift_π]
       by_cases h : j = 0
       · subst h
-        erw [Fin.succ_succAbove_zero, ExtraDegeneracy.s_comp_π_0, ExtraDegeneracy.s_comp_π_0]
+        rw [Fin.succ_succAbove_zero]
+        erw [ExtraDegeneracy.s_comp_π_0, ExtraDegeneracy.s_comp_π_0]
         dsimp
         simp only [WidePullback.lift_base_assoc]
       · obtain ⟨k, hk⟩ := Fin.eq_succ_of_ne_zero h

--- a/Mathlib/AlgebraicTopology/FundamentalGroupoid/FundamentalGroup.lean
+++ b/Mathlib/AlgebraicTopology/FundamentalGroupoid/FundamentalGroup.lean
@@ -43,9 +43,6 @@ namespace FundamentalGroup
 
 attribute [local instance] Path.Homotopic.setoid
 
--- Porting note: removed this attribute
---attribute [local reducible] FundamentalGroupoid
-
 /-- Get an isomorphism between the fundamental groups at two points given a path -/
 def fundamentalGroupMulEquivOfPath (p : Path x₀ x₁) :
     FundamentalGroup X x₀ ≃* FundamentalGroup X x₁ :=

--- a/Mathlib/AlgebraicTopology/MooreComplex.lean
+++ b/Mathlib/AlgebraicTopology/MooreComplex.lean
@@ -82,7 +82,7 @@ def objD : ∀ n : ℕ, (objX X (n + 1) : C) ⟶ (objX X n : C)
     apply kernelSubobject_factors
     dsimp [objX]
     -- Use a simplicial identity
-    erw [Category.assoc, ← X.δ_comp_δ (Fin.zero_le i.succ)]
+    rw [Category.assoc, ← Fin.castSucc_zero, ← X.δ_comp_δ (Fin.zero_le i.succ)]
     -- We can rewrite the arrow out of the intersection of all the kernels as a composition
     -- of a morphism we don't care about with the arrow out of the kernel of `X.δ i.succ.succ`.
     rw [← factorThru_arrow _ _ (finset_inf_arrow_factors Finset.univ _ i.succ (by simp)),
@@ -90,13 +90,14 @@ def objD : ∀ n : ℕ, (objX X (n + 1) : C) ⟶ (objX X n : C)
 
 theorem d_squared (n : ℕ) : objD X (n + 1) ≫ objD X n = 0 := by
   -- It's a pity we need to do a case split here;
-    -- after the first erw the proofs are almost identical
+    -- after the first rw the proofs are almost identical
   rcases n with _ | n <;> dsimp [objD]
-  · erw [Subobject.factorThru_arrow_assoc, Category.assoc,
+  · rw [Subobject.factorThru_arrow_assoc, Category.assoc, ← Fin.castSucc_zero,
       ← X.δ_comp_δ_assoc (Fin.zero_le (0 : Fin 2)),
       ← factorThru_arrow _ _ (finset_inf_arrow_factors Finset.univ _ (0 : Fin 2) (by simp)),
       Category.assoc, kernelSubobject_arrow_comp_assoc, zero_comp, comp_zero]
-  · erw [factorThru_right, factorThru_eq_zero, factorThru_arrow_assoc, Category.assoc,
+  · rw [factorThru_right, factorThru_eq_zero, factorThru_arrow_assoc, Category.assoc,
+      ← Fin.castSucc_zero,
       ← X.δ_comp_δ (Fin.zero_le (0 : Fin (n + 3))),
       ← factorThru_arrow _ _ (finset_inf_arrow_factors Finset.univ _ (0 : Fin (n + 3)) (by simp)),
       Category.assoc, kernelSubobject_arrow_comp_assoc, zero_comp, comp_zero]
@@ -120,9 +121,11 @@ def map (f : X ⟶ Y) : obj X ⟶ obj Y :=
       cases n <;> dsimp
       · apply top_factors
       · refine (finset_inf_factors _).mpr fun i _ => kernelSubobject_factors _ _ ?_
-        erw [Category.assoc, ← f.naturality,
+        rw [Category.assoc, SimplicialObject.δ, ← f.naturality,
           ← factorThru_arrow _ _ (finset_inf_arrow_factors Finset.univ _ i (by simp)),
-          Category.assoc, kernelSubobject_arrow_comp_assoc, zero_comp, comp_zero]))
+          Category.assoc]
+        erw [kernelSubobject_arrow_comp_assoc]
+        rw [zero_comp, comp_zero]))
     fun n => by
     cases n <;> dsimp [objD, objX] <;> aesop_cat
 

--- a/Mathlib/AlgebraicTopology/SimplexCategory/Basic.lean
+++ b/Mathlib/AlgebraicTopology/SimplexCategory/Basic.lean
@@ -810,8 +810,8 @@ theorem eq_comp_δ_of_not_surjective' {n : ℕ} {Δ : SimplexCategory} (θ : Δ 
     ext x : 3
     dsimp [δ, σ]
     simp_rw [Fin.succAbove_last, Fin.predAbove_last_apply]
-    erw [dif_neg (hi x)]
-    rw [Fin.castSucc_castPred]
+    rw [dif_neg, Fin.castSucc_castPred]
+    · exact hi x
 
 theorem eq_comp_δ_of_not_surjective {n : ℕ} {Δ : SimplexCategory} (θ : Δ ⟶ mk (n + 1))
     (hθ : ¬Function.Surjective θ.toOrderHom) :

--- a/Mathlib/AlgebraicTopology/SimplexCategory/Basic.lean
+++ b/Mathlib/AlgebraicTopology/SimplexCategory/Basic.lean
@@ -810,8 +810,7 @@ theorem eq_comp_δ_of_not_surjective' {n : ℕ} {Δ : SimplexCategory} (θ : Δ 
     ext x : 3
     dsimp [δ, σ]
     simp_rw [Fin.succAbove_last, Fin.predAbove_last_apply]
-    rw [dif_neg, Fin.castSucc_castPred]
-    · exact hi x
+    rw [dif_neg (by simpa using hi x), Fin.castSucc_castPred]
 
 theorem eq_comp_δ_of_not_surjective {n : ℕ} {Δ : SimplexCategory} (θ : Δ ⟶ mk (n + 1))
     (hθ : ¬Function.Surjective θ.toOrderHom) :

--- a/Mathlib/AlgebraicTopology/SimplexCategory/Defs.lean
+++ b/Mathlib/AlgebraicTopology/SimplexCategory/Defs.lean
@@ -40,7 +40,7 @@ def SimplexCategory :=
 
 namespace SimplexCategory
 
--- Porting note: the definition of `SimplexCategory` is made irreducible below
+-- The definition of `SimplexCategory` is made irreducible below.
 /-- Interpret a natural number as an object of the simplex category. -/
 def mk (n : ℕ) : SimplexCategory :=
   n

--- a/Mathlib/AlgebraicTopology/SimplicialObject/Basic.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialObject/Basic.lean
@@ -74,7 +74,6 @@ instance [HasColimits C] : HasColimits (SimplicialObject C) :=
 
 variable {C}
 
--- Porting note (https://github.com/leanprover-community/mathlib4/issues/10688): added to ease automation
 @[ext]
 lemma hom_ext {X Y : SimplicialObject C} (f g : X ⟶ Y)
     (h : ∀ (n : SimplexCategoryᵒᵖ), f.app n = g.app n) : f = g :=
@@ -371,7 +370,6 @@ variable {C}
 
 namespace Augmented
 
--- Porting note (https://github.com/leanprover-community/mathlib4/issues/10688): added to ease automation
 @[ext]
 lemma hom_ext {X Y : Augmented C} (f g : X ⟶ Y) (h₁ : f.left = g.left) (h₂ : f.right = g.right) :
     f = g :=
@@ -474,6 +472,7 @@ def augment (X : SimplicialObject C) (X₀ : C) (f : X _⦋0⦌ ⟶ X₀)
         rw [← g.op_unop]
         simpa only [← X.map_comp, ← Category.assoc, Category.comp_id, ← op_comp] using w _ _ _ }
 
+-- Not `@[simp]` since `simp` can prove this.
 theorem augment_hom_zero (X : SimplicialObject C) (X₀ : C) (f : X _⦋0⦌ ⟶ X₀) (w) :
     (X.augment X₀ f w).hom.app (op ⦋0⦌) = f := by simp
 
@@ -513,7 +512,6 @@ instance [HasColimits C] : HasColimits (CosimplicialObject C) :=
 
 variable {C}
 
--- Porting note (https://github.com/leanprover-community/mathlib4/issues/10688): added to ease automation
 @[ext]
 lemma hom_ext {X Y : CosimplicialObject C} (f g : X ⟶ Y)
     (h : ∀ (n : SimplexCategory), f.app n = g.app n) : f = g :=
@@ -709,7 +707,6 @@ variable {C}
 
 namespace Augmented
 
--- Porting note (https://github.com/leanprover-community/mathlib4/issues/10688): added to ease automation
 @[ext]
 lemma hom_ext {X Y : Augmented C} (f g : X ⟶ Y) (h₁ : f.left = g.left) (h₂ : f.right = g.right) :
     f = g :=
@@ -805,6 +802,7 @@ def augment (X : CosimplicialObject C) (X₀ : C) (f : X₀ ⟶ X.obj ⦋0⦌)
         dsimp
         rw [Category.id_comp, Category.assoc, ← X.map_comp, w] }
 
+-- Not `@[simp]` since `simp` can prove this.
 theorem augment_hom_zero (X : CosimplicialObject C) (X₀ : C) (f : X₀ ⟶ X.obj ⦋0⦌) (w) :
     (X.augment X₀ f w).hom.app ⦋0⦌ = f := by simp
 

--- a/Mathlib/AlgebraicTopology/SimplicialObject/Split.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialObject/Split.lean
@@ -227,8 +227,7 @@ theorem cofan_inj_eq {Δ : SimplexCategoryᵒᵖ} (A : IndexSet Δ) :
     (s.cofan Δ).inj  A = s.ι A.1.unop.len ≫ X.map A.e.op := rfl
 
 theorem cofan_inj_id (n : ℕ) : (s.cofan _).inj (IndexSet.id (op ⦋n⦌)) = s.ι n := by
-  erw [cofan_inj_eq, X.map_id, comp_id]
-  rfl
+  simp [IndexSet.id, IndexSet.e, cofan_inj_eq]
 
 /-- As it is stated in `Splitting.hom_ext`, a morphism `f : X ⟶ Y` from a split
 simplicial object to any simplicial object is determined by its restrictions

--- a/Mathlib/AlgebraicTopology/SimplicialSet/StdSimplex.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/StdSimplex.lean
@@ -133,8 +133,6 @@ end Examples
 
 namespace Augmented
 
--- Porting note: an instance of `Subsingleton (⊤_ (Type u))` was added in
--- `CategoryTheory.Limits.Types` to ease the automation in this definition
 /-- The functor which sends `⦋n⦌` to the simplicial set `Δ[n]` equipped by
 the obvious augmentation towards the terminal object of the category of sets. -/
 @[simps]


### PR DESCRIPTION
I searched for `erw` and `porting note` and did my best to fix them. One issue that might be tackled for some profit further down is that `ExtraDegeneracy.s` has a type which is not in `simp`-normal form, and so we need a lot of `erw`s downstream. The obvious replacement of the type with the `simpNF`'d type does not typecheck, unfortunately, so this is something to think about more carefully.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
