### PR TITLE
[Merged by Bors] - chore({Order,Topology}/Category): clean up `erw` and porting notes

### DIFF
--- a/Mathlib/Order/Category/OmegaCompletePartialOrder.lean
+++ b/Mathlib/Order/Category/OmegaCompletePartialOrder.lean
@@ -118,7 +118,7 @@ def isEqualizer {X Y : ωCPO.{v}} (f g : X ⟶ Y) : IsLimit (equalizer f g) :=
         monotone' := fun _ _ h => s.ι.monotone h
         map_ωSup' := fun x => Subtype.ext (s.ι.continuous x)
       }, by ext; rfl, fun hm => by
-      apply ContinuousHom.ext _ _ fun x => Subtype.ext ?_ -- Porting note (https://github.com/leanprover-community/mathlib4/issues/11041): Originally `ext`
+      ext x : 2; apply Subtype.ext ?_ -- Porting note (https://github.com/leanprover-community/mathlib4/issues/11041): Originally `ext`
       apply ContinuousHom.congr_fun hm⟩
 
 end HasEqualizers

--- a/Mathlib/Topology/Category/CompHaus/Basic.lean
+++ b/Mathlib/Topology/Category/CompHaus/Basic.lean
@@ -65,10 +65,8 @@ abbrev of : CompHaus := CompHausLike.of _ X
 end CompHaus
 
 /-- The fully faithful embedding of `CompHaus` in `TopCat`. -/
--- Porting note: `semireducible` -> `.default`.
 abbrev compHausToTop : CompHaus.{u} ⥤ TopCat.{u} :=
   CompHausLike.compHausLikeToTop _
-  -- deriving Full, Faithful -- Porting note: deriving fails, adding manually.
 
 /-- (Implementation) The object part of the compactification functor from topological spaces to
 compact Hausdorff spaces.

--- a/Mathlib/Topology/Category/Profinite/AsLimit.lean
+++ b/Mathlib/Topology/Category/Profinite/AsLimit.lean
@@ -45,7 +45,7 @@ def fintypeDiagram : DiscreteQuotient X ⥤ FintypeCat where
   map f := DiscreteQuotient.ofLE f.le
   -- Porting note: `map_comp` used to be proved by default by `aesop_cat`.
   -- once `aesop_cat` can prove this again, remove the entire `map_comp` here.
-  map_comp _ _ := by ext; simp
+  map_comp _ _ := by ext; aesop_cat
 
 /-- An abbreviation for `X.fintypeDiagram ⋙ FintypeCat.toProfinite`. -/
 abbrev diagram : DiscreteQuotient X ⥤ Profinite :=

--- a/Mathlib/Topology/Category/Profinite/Basic.lean
+++ b/Mathlib/Topology/Category/Profinite/Basic.lean
@@ -71,7 +71,6 @@ abbrev profiniteToCompHaus : Profinite ⥤ CompHaus :=
 -- Porting note: deriving fails, adding manually.
 -- deriving Full, Faithful
 
--- Porting note: added, as it is not found otherwise.
 instance {X : Profinite} : TotallyDisconnectedSpace (profiniteToCompHaus.obj X) :=
   X.prop
 
@@ -209,8 +208,7 @@ instance forget_preservesLimits : Limits.PreservesLimits (forget Profinite) := b
 
 theorem epi_iff_surjective {X Y : Profinite.{u}} (f : X ⟶ Y) : Epi f ↔ Function.Surjective f := by
   constructor
-  · -- Porting note: in mathlib3 `contrapose` saw through `Function.Surjective`.
-    dsimp [Function.Surjective]
+  · dsimp [Function.Surjective]
     contrapose!
     rintro ⟨y, hy⟩ hf
     let C := Set.range f

--- a/Mathlib/Topology/Category/Profinite/CofilteredLimit.lean
+++ b/Mathlib/Topology/Category/Profinite/CofilteredLimit.lean
@@ -114,8 +114,7 @@ theorem exists_locallyConstant_fin_two (hC : IsLimit C) (f : LocallyConstant C.p
   apply LocallyConstant.locallyConstant_eq_of_fiber_zero_eq
   simp only [Fin.isValue, Functor.const_obj_obj, LocallyConstant.coe_comap, Set.preimage_comp,
     LocallyConstant.ofIsClopen_fiber_zero]
-  -- This used to be `rw`, but we need `erw` after https://github.com/leanprover/lean4/pull/2644
-  erw [← h]
+  exact h
 
 open Classical in
 theorem exists_locallyConstant_finite_aux {α : Type*} [Finite α] (hC : IsLimit C)
@@ -169,8 +168,9 @@ theorem exists_locallyConstant_finite_nonempty {α : Type*} [Finite α] [Nonempt
     rw [h]
     rfl
   have h2 : ∃ a : α, ι a = gg (C.π.app j x) := ⟨f x, h1⟩
-  -- This used to be `rw`, but we need `erw` after https://github.com/leanprover/lean4/pull/2644
-  erw [dif_pos h2]
+  rw [dif_pos]
+  swap
+  · assumption
   apply_fun ι
   · rw [h2.choose_spec]
     exact h1

--- a/Mathlib/Topology/Category/TopCat/Limits/Cofiltered.lean
+++ b/Mathlib/Topology/Category/TopCat/Limits/Cofiltered.lean
@@ -93,11 +93,7 @@ theorem isTopologicalBasis_cofiltered_limit (hC : IsLimit C) (T : ∀ j, Set (Se
       -- Porting note: needed more hand holding here
       change (C.π.app e)⁻¹' U e =
         (C.π.app j) ⁻¹' if h : e ∈ G then F.map (g e h) ⁻¹' U e else Set.univ
-      rw [dif_pos he, ← Set.preimage_comp]
-      apply congrFun
-      apply congrArg
-      rw [← coe_comp, C.w]
-      rfl
+      simp [he, ← Set.preimage_comp, ← coe_comp]
 
 end CofilteredLimit
 

--- a/Mathlib/Topology/Category/TopCat/Limits/Konig.lean
+++ b/Mathlib/Topology/Category/TopCat/Limits/Konig.lean
@@ -33,7 +33,6 @@ open CategoryTheory
 
 open CategoryTheory.Limits
 
--- Porting note: changed universe order as `v` is usually passed explicitly
 universe v u w
 
 noncomputable section
@@ -44,7 +43,6 @@ section TopologicalKonig
 
 variable {J : Type u} [SmallCategory J]
 
--- Porting note: generalized `F` to land in `v` not `u`
 variable (F : J ⥤ TopCat.{v})
 
 private abbrev FiniteDiagramArrow {J : Type u} [SmallCategory J] (G : Finset J) :=
@@ -56,7 +54,6 @@ private abbrev FiniteDiagram (J : Type u) [SmallCategory J] :=
 /-- Partial sections of a cofiltered limit are sections when restricted to
 a finite subset of objects and morphisms of `J`.
 -/
--- Porting note: generalized `F` to land in `v` not `u`
 def partialSections {J : Type u} [SmallCategory J] (F : J ⥤ TopCat.{v}) {G : Finset J}
     (H : Finset (FiniteDiagramArrow G)) : Set (∀ j, F.obj j) :=
   {u | ∀ {f : FiniteDiagramArrow G} (_ : f ∈ H), F.map f.2.2.2.2 (u f.1) = u f.2.1}
@@ -111,7 +108,6 @@ theorem partialSections.closed [∀ j : J, T2Space (F.obj j)] {G : Finset J}
 
 /-- Cofiltered limits of nonempty compact Hausdorff spaces are nonempty topological spaces.
 -/
--- Porting note: generalized from `TopCat.{u}` to `TopCat.{max v u}`
 theorem nonempty_limitCone_of_compact_t2_cofiltered_system (F : J ⥤ TopCat.{max v u})
     [IsCofilteredOrEmpty J]
     [∀ j : J, Nonempty (F.obj j)] [∀ j : J, CompactSpace (F.obj j)] [∀ j : J, T2Space (F.obj j)] :

--- a/Mathlib/Topology/Category/TopCat/Limits/Products.lean
+++ b/Mathlib/Topology/Category/TopCat/Limits/Products.lean
@@ -203,11 +203,11 @@ theorem range_prod_map {W X Y Z : TopCat.{u}} (f : W ⟶ Y) (g : X ⟶ Z) :
     rintro ⟨⟨⟩⟩
     · rw [← ConcreteCategory.comp_apply]
       erw [Limits.prod.map_fst]
-      rw [← ConcreteCategory.comp_apply, TopCat.prodIsoProd_inv_fst_assoc, TopCat.comp_app]
+      rw [ConcreteCategory.comp_apply, TopCat.prodIsoProd_inv_fst_apply]
       exact hx₁
     · rw [← ConcreteCategory.comp_apply]
       erw [Limits.prod.map_snd]
-      rw [← ConcreteCategory.comp_apply, TopCat.prodIsoProd_inv_snd_assoc, TopCat.comp_app]
+      rw [ConcreteCategory.comp_apply, TopCat.prodIsoProd_inv_snd_apply]
       exact hx₂
 
 theorem isInducing_prodMap {W X Y Z : TopCat.{u}} {f : W ⟶ X} {g : Y ⟶ Z} (hf : IsInducing f)
@@ -265,8 +265,9 @@ theorem binaryCofan_isColimit_iff {X Y : TopCat} (c : BinaryCofan X Y) :
         (binaryCofanIsColimit X Y)).symm.isOpenEmbedding.comp .inl,
           (homeoOfIso <| h.coconePointUniqueUpToIso
             (binaryCofanIsColimit X Y)).symm.isOpenEmbedding.comp .inr, ?_⟩
-      erw [Set.range_comp, ← eq_compl_iff_isCompl, Set.range_comp _ Sum.inr,
-        ← Set.image_compl_eq (homeoOfIso <| h.coconePointUniqueUpToIso
+      rw [Set.range_comp, ← eq_compl_iff_isCompl]
+      conv_rhs => rw [Set.range_comp]
+      erw [← Set.image_compl_eq (homeoOfIso <| h.coconePointUniqueUpToIso
             (binaryCofanIsColimit X Y)).symm.bijective, Set.compl_range_inr, Set.image_comp]
     · rintro ⟨h₁, h₂, h₃⟩
       have : ∀ x, x ∈ Set.range c.inl ∨ x ∈ Set.range c.inr := by

--- a/Mathlib/Topology/Category/TopCat/OpenNhds.lean
+++ b/Mathlib/Topology/Category/TopCat/OpenNhds.lean
@@ -109,7 +109,6 @@ def map (x : X) : OpenNhds (f x) ⥤ OpenNhds x where
   obj U := ⟨(Opens.map f).obj U.1, U.2⟩
   map i := (Opens.map f).map i
 
--- Porting note: Changed `⟨(Opens.map f).obj U, by tidy⟩` to `⟨(Opens.map f).obj U, q⟩`
 @[simp]
 theorem map_obj (x : X) (U) (q) : (map f x).obj ⟨U, q⟩ = ⟨(Opens.map f).obj U, q⟩ :=
   rfl


### PR DESCRIPTION
I searched for `erw` and `porting note` and did my best to fix them. No big things that I wanted to remark upon.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
