### PR TITLE
[Merged by Bors] - chore: make commands start at the start of a line

### DIFF
--- a/Mathlib/Algebra/Category/BialgebraCat/Monoidal.lean
+++ b/Mathlib/Algebra/Category/BialgebraCat/Monoidal.lean
@@ -67,4 +67,4 @@ noncomputable instance : (forget₂ (BialgebraCat R) (CoalgebraCat R)).Monoidal 
     εIso := Iso.refl _
     μIso _ _ := Iso.refl _ }
 
- end BialgebraCat
+end BialgebraCat

--- a/Mathlib/Algebra/Homology/ShortComplex/HomologicalComplex.lean
+++ b/Mathlib/Algebra/Homology/ShortComplex/HomologicalComplex.lean
@@ -70,7 +70,9 @@ noncomputable abbrev isoSc' (hi : c.prev j = i) (hk : c.next j = k) :
 short complex `K.sc i` has. -/
 abbrev HasHomology := (K.sc i).HasHomology
 
-section variable [K.HasHomology i]
+section
+
+variable [K.HasHomology i]
 
 /-- The homology in degree `i` of a homological complex. -/
 noncomputable def homology := (K.sc i).homology

--- a/Mathlib/Analysis/Calculus/FirstDerivativeTest.lean
+++ b/Mathlib/Analysis/Calculus/FirstDerivativeTest.lean
@@ -38,10 +38,10 @@ derivative test, calculus
 open Set Topology
 
 
- /-- The First-Derivative Test from calculus, maxima version.
-  Suppose `a < b < c`, `f : ℝ → ℝ` is continuous at `b`,
-  the derivative `f'` is nonnegative on `(a,b)`, and
-  the derivative `f'` is nonpositive on `(b,c)`. Then `f` has a local maximum at `a`. -/
+/-- The First-Derivative Test from calculus, maxima version.
+Suppose `a < b < c`, `f : ℝ → ℝ` is continuous at `b`,
+the derivative `f'` is nonnegative on `(a,b)`, and
+the derivative `f'` is nonpositive on `(b,c)`. Then `f` has a local maximum at `a`. -/
 lemma isLocalMax_of_deriv_Ioo {f : ℝ → ℝ} {a b c : ℝ} (g₀ : a < b) (g₁ : b < c)
     (h : ContinuousAt f b)
     (hd₀ : DifferentiableOn ℝ f (Ioo a b))
@@ -71,8 +71,8 @@ lemma isLocalMin_of_deriv_Ioo {f : ℝ → ℝ} {a b c : ℝ}
     (fun x hx => deriv.neg (f := f) ▸ Left.neg_nonpos_iff.mpr <|h₁ x hx)
   exact (neg_neg f) ▸ IsLocalMax.neg this
 
- /-- The First-Derivative Test from calculus, maxima version,
- expressed in terms of left and right filters. -/
+/-- The First-Derivative Test from calculus, maxima version,
+expressed in terms of left and right filters. -/
 lemma isLocalMax_of_deriv' {f : ℝ → ℝ} {b : ℝ} (h : ContinuousAt f b)
     (hd₀ : ∀ᶠ x in 𝓝[<] b, DifferentiableAt ℝ f x) (hd₁ : ∀ᶠ x in 𝓝[>] b, DifferentiableAt ℝ f x)
     (h₀ : ∀ᶠ x in 𝓝[<] b, 0 ≤ deriv f x) (h₁ : ∀ᶠ x in 𝓝[>] b, deriv f x ≤ 0) :
@@ -84,8 +84,8 @@ lemma isLocalMax_of_deriv' {f : ℝ → ℝ} {b : ℝ} (h : ContinuousAt f b)
     (fun _ hx => (hc.2 hx).1.differentiableWithinAt)
     (fun _ hx => (ha.2 hx).2) (fun x hx => (hc.2 hx).2)
 
- /-- The First-Derivative Test from calculus, minima version,
- expressed in terms of left and right filters. -/
+/-- The First-Derivative Test from calculus, minima version,
+expressed in terms of left and right filters. -/
 lemma isLocalMin_of_deriv' {f : ℝ → ℝ} {b : ℝ} (h : ContinuousAt f b)
     (hd₀ : ∀ᶠ x in 𝓝[<] b, DifferentiableAt ℝ f x) (hd₁ : ∀ᶠ x in 𝓝[>] b, DifferentiableAt ℝ f x)
     (h₀ : ∀ᶠ x in 𝓝[<] b, deriv f x ≤ 0) (h₁ : ∀ᶠ x in 𝓝[>] b, deriv f x ≥ 0) :

--- a/Mathlib/Analysis/SpecialFunctions/MulExpNegMulSq.lean
+++ b/Mathlib/Analysis/SpecialFunctions/MulExpNegMulSq.lean
@@ -110,7 +110,7 @@ theorem nnnorm_deriv_mulExpNegMulSq_le_one (hε : 0 < ε) (x : ℝ) :
   rw [← NNReal.coe_le_coe, coe_nnnorm]
   exact norm_deriv_mulExpNegMulSq_le_one hε x
 
- /-- For fixed `ε > 0`, the mapping `mulExpNegMulSq ε` is Lipschitz with constant `1` -/
+/-- For fixed `ε > 0`, the mapping `mulExpNegMulSq ε` is Lipschitz with constant `1` -/
 theorem lipschitzWith_one_mulExpNegMulSq (hε : 0 < ε) :
     LipschitzWith 1 (mulExpNegMulSq ε) := by
   apply lipschitzWith_of_nnnorm_deriv_le differentiable_mulExpNegMulSq

--- a/Mathlib/CategoryTheory/ChosenFiniteProducts.lean
+++ b/Mathlib/CategoryTheory/ChosenFiniteProducts.lean
@@ -526,7 +526,7 @@ lemma preservesLimit_pair_of_isIso_prodComparison (A B : C)
  · dsimp only [BinaryFan.snd]
    simp [pairComp, prodComparison, lift, snd]
 
-  /-- If `prodComparison F A B` is an isomorphism for all `A B` then `F` preserves limits of shape
+/-- If `prodComparison F A B` is an isomorphism for all `A B` then `F` preserves limits of shape
 `Discrete (WalkingPair)`. -/
 lemma preservesLimitsOfShape_discrete_walkingPair_of_isIso_prodComparison
     [∀ A B, IsIso (prodComparison F A B)] : PreservesLimitsOfShape (Discrete WalkingPair) F := by

--- a/Mathlib/Dynamics/Ergodic/Action/OfMinimal.lean
+++ b/Mathlib/Dynamics/Ergodic/Action/OfMinimal.lean
@@ -137,7 +137,7 @@ theorem ergodic_smul_of_denseRange_zpow {g : G} (hg : DenseRange (g ^ · : ℤ �
   rw [← Subgroup.coe_zpowers, SetLike.coe_subset_coe, ← Subgroup.zpowers_inv, Subgroup.zpowers_le,
     MulAction.mem_aestabilizer, ← preimage_smul, hs]
 
- end MulActionGroup
+end MulActionGroup
 
 section IsTopologicalGroup
 

--- a/Mathlib/NumberTheory/NumberField/FinitePlaces.lean
+++ b/Mathlib/NumberTheory/NumberField/FinitePlaces.lean
@@ -166,7 +166,7 @@ theorem RingOfIntegers.HeightOneSpectrum.adicAbv_add_le_max (x y : K) :
     adicAbv v (x + y) ≤ (adicAbv v x) ⊔ (adicAbv v y) := by
   simp [← FinitePlace.norm_def]
 
- @[deprecated (since := "2025-02-28")] alias vadicAbv_add_le_max :=
+@[deprecated (since := "2025-02-28")] alias vadicAbv_add_le_max :=
   RingOfIntegers.HeightOneSpectrum.adicAbv_add_le_max
 
 /-- The `v`-adic absolute value of a natural number is `≤ 1`. -/

--- a/Mathlib/RingTheory/Ideal/Maps.lean
+++ b/Mathlib/RingTheory/Ideal/Maps.lean
@@ -267,7 +267,9 @@ theorem restrictScalars_mul {R S : Type*} [Semiring R] [Semiring S] [Module R S]
 
 section Surjective
 
-section variable (hf : Function.Surjective f)
+section
+
+variable (hf : Function.Surjective f)
 include hf
 
 open Function

--- a/Mathlib/RingTheory/Invariant.lean
+++ b/Mathlib/RingTheory/Invariant.lean
@@ -169,7 +169,8 @@ open FaithfulSMul IsScalarTower Polynomial
 variable {A B : Type*} [CommRing A] [CommRing B] [Algebra A B]
   (G : Type*) [Group G] [Finite G] [MulSemiringAction G B] [SMulCommClass G A B]
   (P : Ideal A) (Q : Ideal B) [Q.IsPrime] [Q.LiesOver P]
-  variable (K L : Type*) [Field K] [Field L]
+
+variable (K L : Type*) [Field K] [Field L]
   [Algebra (A ⧸ P) K] [Algebra (B ⧸ Q) L]
   [Algebra (A ⧸ P) L] [IsScalarTower (A ⧸ P) (B ⧸ Q) L]
   [Algebra K L] [IsScalarTower (A ⧸ P) K L]

--- a/Mathlib/RingTheory/Polynomial/Chebyshev.lean
+++ b/Mathlib/RingTheory/Polynomial/Chebyshev.lean
@@ -454,7 +454,7 @@ theorem S_neg (n : ℤ) : S R (-n) = -S R (n - 2) := by simpa [sub_sub] using S_
 theorem S_neg_sub_two (n : ℤ) : S R (-n - 2) = -S R n := by
   simpa [sub_eq_add_neg, add_comm] using S_neg R (n + 2)
 
-  @[simp]
+@[simp]
 theorem S_eval_two (n : ℤ) : (S R n).eval 2 = n + 1 := by
   induction n using Polynomial.Chebyshev.induct with
   | zero => simp

--- a/Mathlib/Topology/Algebra/Category/ProfiniteGrp/Basic.lean
+++ b/Mathlib/Topology/Algebra/Category/ProfiniteGrp/Basic.lean
@@ -112,7 +112,7 @@ instance : ConcreteCategory ProfiniteGrp (fun X Y => ContinuousMonoidHom X Y) wh
   hom f := f.hom'
   ofHom f := ⟨f⟩
 
-  /-- The underlying `ContinuousMonoidHom`. -/
+/-- The underlying `ContinuousMonoidHom`. -/
 @[to_additive "The underlying `ContinuousAddMonoidHom`."]
 abbrev ProfiniteGrp.Hom.hom {M N : ProfiniteGrp.{u}} (f : ProfiniteGrp.Hom M N) :
     ContinuousMonoidHom M N :=


### PR DESCRIPTION
Just some whitespace changes: both to commands in the wrong column, and unnecessary indents in docstrings.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
