### PR TITLE
[Merged by Bors] - feat(CategoryTheory): the dual of a Guitart exact `2`-square is Guitart exact

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1960,6 +1960,7 @@ import Mathlib.CategoryTheory.Groupoid.FreeGroupoid
 import Mathlib.CategoryTheory.Groupoid.Subgroupoid
 import Mathlib.CategoryTheory.Groupoid.VertexGroup
 import Mathlib.CategoryTheory.GuitartExact.Basic
+import Mathlib.CategoryTheory.GuitartExact.Opposite
 import Mathlib.CategoryTheory.GuitartExact.VerticalComposition
 import Mathlib.CategoryTheory.HomCongr
 import Mathlib.CategoryTheory.Idempotents.Basic

--- a/Mathlib/CategoryTheory/Functor/TwoSquare.lean
+++ b/Mathlib/CategoryTheory/Functor/TwoSquare.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Joël Riou, Jakob von Raumer
 -/
 import Mathlib.CategoryTheory.Whiskering
+import Mathlib.CategoryTheory.Opposites
 import Mathlib.Tactic.CategoryTheory.Slice
 
 /-!
@@ -63,6 +64,13 @@ def equivNatTrans : TwoSquare T L R B ≃ (T ⋙ R ⟶ L ⋙ B) where
   right_inv _ := rfl
 
 variable {T L R B}
+
+/-- The opposite of a `2`-square. -/
+def op (α : TwoSquare T L R B) : TwoSquare L.op T.op B.op R.op := NatTrans.op α
+
+@[simp]
+lemma natTrans_op (α : TwoSquare T L R B) :
+    α.op.natTrans = NatTrans.op α.natTrans := rfl
 
 @[ext]
 lemma ext (w w' : TwoSquare T L R B) (h : ∀ (X : C₁), w.natTrans.app X = w'.natTrans.app X) :

--- a/Mathlib/CategoryTheory/GuitartExact/Opposite.lean
+++ b/Mathlib/CategoryTheory/GuitartExact/Opposite.lean
@@ -8,7 +8,7 @@ import Mathlib.CategoryTheory.GuitartExact.VerticalComposition
 /-!
 # The opposite of a Guitart exact square
 
-A `2`-square is Guitart exact iff the opposite (transposed) square
+A `2`-square is Guitart exact iff the opposite (transposed) `2`-square
 is Guitart exact.
 
 -/

--- a/Mathlib/CategoryTheory/GuitartExact/Opposite.lean
+++ b/Mathlib/CategoryTheory/GuitartExact/Opposite.lean
@@ -52,7 +52,7 @@ def functor :
 /-- Auxiliary definition for `structuredArrowRightwardsOpEquivalence`. -/
 def inverse :
     w.CostructuredArrowDownwards g.unop ⥤
-    (w.op.StructuredArrowRightwards g)ᵒᵖ where
+      (w.op.StructuredArrowRightwards g)ᵒᵖ where
   obj f := Opposite.op
     (StructuredArrowRightwards.mk _ _ (Opposite.op f.left.right)
       f.hom.right.op f.left.hom.op (Quiver.Hom.unop_inj (StructuredArrow.w f.hom)))

--- a/Mathlib/CategoryTheory/GuitartExact/Opposite.lean
+++ b/Mathlib/CategoryTheory/GuitartExact/Opposite.lean
@@ -21,11 +21,11 @@ open Category
 
 variable {C₁ : Type u₁} {C₂ : Type u₂} {C₃ : Type u₃} {C₄ : Type u₄}
   [Category.{v₁} C₁] [Category.{v₂} C₂] [Category.{v₃} C₃] [Category.{v₄} C₄]
-  (T : C₁ ⥤ C₂) (L : C₁ ⥤ C₃) (R : C₂ ⥤ C₄) (B : C₃ ⥤ C₄)
+  {T : C₁ ⥤ C₂} {L : C₁ ⥤ C₃} {R : C₂ ⥤ C₄} {B : C₃ ⥤ C₄}
 
 namespace TwoSquare
 
-variable {T L R B} (w : TwoSquare T L R B)
+variable (w : TwoSquare T L R B)
 
 section
 

--- a/Mathlib/CategoryTheory/GuitartExact/Opposite.lean
+++ b/Mathlib/CategoryTheory/GuitartExact/Opposite.lean
@@ -1,0 +1,104 @@
+/-
+Copyright (c) 2025 Joël Riou. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joël Riou
+-/
+import Mathlib.CategoryTheory.GuitartExact.VerticalComposition
+
+/-!
+# The opposite of a Guitart exact square
+
+A `2`-square is Guitart exact iff the opposite (transposed) square
+is Guitart exact.
+
+-/
+
+universe v₁ v₂ v₃ v₄ u₁ u₂ u₃ u₄
+
+namespace CategoryTheory
+
+open Category
+
+variable {C₁ : Type u₁} {C₂ : Type u₂} {C₃ : Type u₃} {C₄ : Type u₄}
+  [Category.{v₁} C₁] [Category.{v₂} C₂] [Category.{v₃} C₃] [Category.{v₄} C₄]
+  (T : C₁ ⥤ C₂) (L : C₁ ⥤ C₃) (R : C₂ ⥤ C₄) (B : C₃ ⥤ C₄)
+
+namespace TwoSquare
+
+variable {T L R B} (w : TwoSquare T L R B)
+
+section
+
+variable {X₃ : C₃ᵒᵖ} {X₂ : C₂ᵒᵖ} (g : B.op.obj X₃ ⟶ R.op.obj X₂)
+
+namespace structuredArrowRightwardsOpEquivalence
+
+/-- Auxiliary definition for `structuredArrowRightwardsOpEquivalence`. -/
+@[simps!]
+def functor :
+    (w.op.StructuredArrowRightwards g)ᵒᵖ ⥤
+      w.CostructuredArrowDownwards g.unop where
+  obj f := CostructuredArrowDownwards.mk _ _ f.unop.right.left.unop
+      f.unop.right.hom.unop f.unop.hom.left.unop
+      (Quiver.Hom.op_inj (by simpa using CostructuredArrow.w f.unop.hom))
+  map {f f'} φ :=
+    CostructuredArrow.homMk
+      (StructuredArrow.homMk (φ.unop.right.left.unop)
+        (Quiver.Hom.op_inj (CostructuredArrow.w φ.unop.right))) (by
+          ext
+          exact Quiver.Hom.op_inj
+            ((CostructuredArrow.proj _ _).congr_map (StructuredArrow.w φ.unop)))
+
+/-- Auxiliary definition for `structuredArrowRightwardsOpEquivalence`. -/
+def inverse :
+    w.CostructuredArrowDownwards g.unop ⥤
+    (w.op.StructuredArrowRightwards g)ᵒᵖ where
+  obj f := Opposite.op
+    (StructuredArrowRightwards.mk _ _ (Opposite.op f.left.right)
+      f.hom.right.op f.left.hom.op (Quiver.Hom.unop_inj (StructuredArrow.w f.hom)))
+  map {f f'} φ :=
+    (StructuredArrow.homMk
+      (CostructuredArrow.homMk (φ.left.right.op)
+        (Quiver.Hom.unop_inj (by exact StructuredArrow.w φ.left)))
+          (by
+            ext
+            exact Quiver.Hom.unop_inj
+              ((StructuredArrow.proj _ _).congr_map
+              (CostructuredArrow.w φ)))).op
+
+end structuredArrowRightwardsOpEquivalence
+
+/-- If `w : TwoSquare T L R B`, and `g : B.op.obj X₃ ⟶ R.op.obj X₂`, this is
+the obvious equivalence of categories between
+`(w.op.StructuredArrowRightwards g)ᵒᵖ` and `w.CostructuredArrowDownwards g.unop`. -/
+def structuredArrowRightwardsOpEquivalence :
+    (w.op.StructuredArrowRightwards g)ᵒᵖ ≌
+      w.CostructuredArrowDownwards g.unop where
+  functor := structuredArrowRightwardsOpEquivalence.functor w g
+  inverse := structuredArrowRightwardsOpEquivalence.inverse w g
+  unitIso := Iso.refl _
+  counitIso := Iso.refl _
+
+end
+
+instance [w.GuitartExact] : w.op.GuitartExact := by
+  rw [guitartExact_iff_isConnected_rightwards]
+  intro X₃ X₂ g
+  rw [← isConnected_op_iff_isConnected,
+    isConnected_iff_of_equivalence (w.structuredArrowRightwardsOpEquivalence g)]
+  infer_instance
+
+lemma guitartExact_op_iff : w.op.GuitartExact ↔ w.GuitartExact := by
+  constructor
+  · intro
+    let w₁ : TwoSquare T (opOp C₁) (opOp C₂) T.op.op := 𝟙 _
+    let w₂ : TwoSquare B.op.op (unopUnop C₃) (unopUnop C₄) B := 𝟙 _
+    have : w = (w₁ ≫ᵥ w.op.op) ≫ᵥ w₂ := by aesop_cat
+    rw [this]
+    infer_instance
+  · intro
+    infer_instance
+
+end TwoSquare
+
+end CategoryTheory

--- a/Mathlib/CategoryTheory/GuitartExact/Opposite.lean
+++ b/Mathlib/CategoryTheory/GuitartExact/Opposite.lean
@@ -63,8 +63,7 @@ def inverse :
           (by
             ext
             exact Quiver.Hom.unop_inj
-              ((StructuredArrow.proj _ _).congr_map
-              (CostructuredArrow.w φ)))).op
+              ((StructuredArrow.proj _ _).congr_map (CostructuredArrow.w φ)))).op
 
 end structuredArrowRightwardsOpEquivalence
 

--- a/Mathlib/CategoryTheory/GuitartExact/Opposite.lean
+++ b/Mathlib/CategoryTheory/GuitartExact/Opposite.lean
@@ -70,6 +70,7 @@ end structuredArrowRightwardsOpEquivalence
 /-- If `w : TwoSquare T L R B`, and `g : B.op.obj X₃ ⟶ R.op.obj X₂`, this is
 the obvious equivalence of categories between
 `(w.op.StructuredArrowRightwards g)ᵒᵖ` and `w.CostructuredArrowDownwards g.unop`. -/
+@[simps]
 def structuredArrowRightwardsOpEquivalence :
     (w.op.StructuredArrowRightwards g)ᵒᵖ ≌
       w.CostructuredArrowDownwards g.unop where

--- a/Mathlib/CategoryTheory/Opposites.lean
+++ b/Mathlib/CategoryTheory/Opposites.lean
@@ -114,6 +114,12 @@ def opOpEquivalence : Cᵒᵖᵒᵖ ≌ C where
   unitIso := Iso.refl (𝟭 Cᵒᵖᵒᵖ)
   counitIso := Iso.refl (opOp C ⋙ unopUnop C)
 
+instance : (opOp C).IsEquivalence :=
+  (opOpEquivalence C).isEquivalence_inverse
+
+instance : (unopUnop C).IsEquivalence :=
+  (opOpEquivalence C).isEquivalence_functor
+
 end
 
 /-- If `f` is an isomorphism, so is `f.op` -/


### PR DESCRIPTION
This shall be used in order to formalize left derivability structures (dual to right derivability structures), and to construct left derived functors.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
