### PR TITLE
[Merged by Bors] - refactor(Tactic/Simproc): rewrite `reduceExistsAndEq` without Qq

### DIFF
--- a/Mathlib/Tactic/Simproc/ExistsAndEq.lean
+++ b/Mathlib/Tactic/Simproc/ExistsAndEq.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Vasilii Nesterov
 -/
 import Mathlib.Init
-import Qq
 
 /-!
 # simproc for `∃ a', ... ∧ a' = a ∧ ...`
@@ -14,12 +13,12 @@ the form `... ∧ a' = a ∧ ...` or `... ∧ a = a' ∧ ...` for the goal `∃ 
 If so, it rewrites the latter as `P a`.
 -/
 
-open Lean Meta Qq
+open Lean Meta
 
 namespace existsAndEq
 
 universe u in
-private theorem exists_of_imp_eq {α : Sort u} {p : α → Prop} {a : α} (h : ∀ b, p b → a = b) :
+private theorem exists_of_imp_eq {α : Sort u} {p : α → Prop} (a : α) (h : ∀ b, p b → a = b) :
     (∃ b, p b) = p a := by
   apply propext
   constructor
@@ -32,31 +31,32 @@ private theorem exists_of_imp_eq {α : Sort u} {p : α → Prop} {a : α} (h : �
 /-- For an expression `p` of the form `fun (x : α) ↦ (body : Prop)`, checks whether
 `body` implies `x = a` for some `a`, and constructs a proof of `(∃ x, p x) = p a` using
 `exists_of_imp_eq`. -/
-partial def findImpEqProof {u : Level} {α : Q(Sort u)} (p : Q($α → Prop)) :
-    MetaM <| Option ((a : Q($α)) × Q((∃ x, $p x) = $p $a)) := do
-  lambdaTelescope p fun xs (body : Q(Prop)) => do
-    let #[(x : Q($α))] := xs | return none
-    withLocalDeclQ .anonymous .default body fun h => withNewMCtxDepth do
+partial def findImpEqProof (p : Expr) :
+    MetaM <| Option (Expr × Expr) := do
+  lambdaTelescope p fun xs body => do
+    let #[x] := xs | return none
+    withLocalDecl .anonymous .default body fun h => withNewMCtxDepth do
       let .some ⟨res, proof⟩ ← go x h | return none
-      let pf1 : Q(∀ (b : $α), $p b → $res = b) ← mkLambdaFVars #[x, h] proof
-      return .some ⟨res, q(exists_of_imp_eq $pf1)⟩
+      let pf1 ← mkLambdaFVars #[x, h] proof
+      return .some ⟨res, ← mkAppM ``exists_of_imp_eq #[res, pf1]⟩
 where
   /-- Traverses the expression `h`, branching at each `And`, to find a proof of `x = a`
   for some `a`. -/
-  go (x : Q($α)) {e : Q(Prop)} (h : Q($e)) : MetaM <| Option ((a : Q($α)) × Q($a = $x)) := do
-    match e with
-    | ~q(@Eq.{u} $β $a $b) =>
-      let .defEq _ := ← isDefEqQ q($α) q($β) | return none
-      if let .defEq _ ← isDefEqQ x a then
-        return .some ⟨b, q(($h).symm)⟩
-      else if let .defEq _ ← isDefEqQ x (b : Q($α)) then
-        return .some ⟨a, q($h)⟩
+  go (x h : Expr) : MetaM <| Option (Expr × Expr) := do
+    match (← inferType h).getAppFnArgs with
+    | (``Eq, #[β, a, b]) =>
+      if !(← isDefEq (← inferType x) β) then
+        return none
+      if ← isDefEq x a then
+        return .some ⟨b, ← mkAppM ``Eq.symm #[h]⟩
+      if ← isDefEq x b then
+        return .some ⟨a, h⟩
       else
         return .none
-    | ~q(And $a $b) =>
-      if let .some res ← go x q(And.left $h) then
+    | (``And, #[_, _]) =>
+      if let .some res ← go x (← mkAppM ``And.left #[h]) then
         return res
-      if let .some res ← go x q(And.right $h) then
+      if let .some res ← go x (← mkAppM ``And.right #[h]) then
         return res
       return none
     | _ => return none
@@ -65,9 +65,9 @@ end existsAndEq
 
 /-- Checks whether `P a'` has the form `... ∧ a' = a ∧ ...` or `... ∧ a = a' ∧ ...` in
 the goal `∃ a', P a'`. If so, rewrites the goal as `P a`. -/
-simproc existsAndEq (Exists (fun _ => And _ _)) := .ofQ fun u α e => do
-  match u, α, e with
-  | 1, ~q(Prop), ~q(Exists $p) =>
-    let .some ⟨_, pf⟩ ← existsAndEq.findImpEqProof p | return .continue
-    return .visit <| .mk _ <| some q($pf)
-  | _, _, _ => return .continue
+simproc existsAndEq (Exists (fun _ => And _ _)) := fun e => do
+  match e.getAppFnArgs with
+  | (``Exists, #[_, p]) =>
+    let .some ⟨res, pf⟩ ← existsAndEq.findImpEqProof p | return .continue
+    return .visit {expr := mkApp p res, proof? := pf}
+  | _ => return .continue


### PR DESCRIPTION
This is a temporary PR before upstreaming the `reduceExistsAndEq` simproc to core.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
