### PR TITLE
[Merged by Bors] - feat: integrating the integral of an indicator

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4590,6 +4590,7 @@ import Mathlib.Probability.Kernel.MeasurableIntegral
 import Mathlib.Probability.Kernel.MeasurableLIntegral
 import Mathlib.Probability.Kernel.Proper
 import Mathlib.Probability.Kernel.RadonNikodym
+import Mathlib.Probability.Kernel.SetIntegral
 import Mathlib.Probability.Kernel.WithDensity
 import Mathlib.Probability.Martingale.Basic
 import Mathlib.Probability.Martingale.BorelCantelli

--- a/Mathlib/MeasureTheory/Integral/Bochner.lean
+++ b/Mathlib/MeasureTheory/Integral/Bochner.lean
@@ -216,6 +216,10 @@ theorem integral_zero : ∫ _ : α, (0 : G) ∂μ = 0 := by
 theorem integral_zero' : integral μ (0 : α → G) = 0 :=
   integral_zero α G
 
+lemma integral_indicator₂ {β : Type*} (f : β → α → G) (s : Set β) (b : β) :
+    ∫ y, s.indicator (f · y) b ∂μ = s.indicator (fun x ↦ ∫ y, f x y ∂μ) b := by
+  by_cases hb : b ∈ s <;> simp [hb]
+
 variable {α G}
 
 theorem integrable_of_integral_eq_one {f : α → ℝ} (h : ∫ x, f x ∂μ = 1) : Integrable f μ :=

--- a/Mathlib/MeasureTheory/Integral/SetIntegral.lean
+++ b/Mathlib/MeasureTheory/Integral/SetIntegral.lean
@@ -60,7 +60,7 @@ variable {X Y E F : Type*}
 
 namespace MeasureTheory
 
-variable [MeasurableSpace X]
+variable {mX : MeasurableSpace X}
 
 section NormedAddCommGroup
 
@@ -183,6 +183,11 @@ theorem integral_indicator (hs : MeasurableSet s) :
       (congr_arg₂ (· + ·) (integral_congr_ae (indicator_ae_eq_restrict hs))
         (integral_congr_ae (indicator_ae_eq_restrict_compl hs)))
     _ = ∫ x in s, f x ∂μ := by simp
+
+lemma integral_integral_indicator {mY : MeasurableSpace Y} {ν : Measure Y} (f : X → Y → E)
+    {s : Set X} (hs : MeasurableSet s) :
+    ∫ x, ∫ y, s.indicator (f · y) x ∂ν ∂μ = ∫ x in s, ∫ y, f x y ∂ν ∂μ := by
+  simp_rw [← integral_indicator hs, integral_indicator₂]
 
 theorem setIntegral_indicator (ht : MeasurableSet t) :
     ∫ x in s, t.indicator f x ∂μ = ∫ x in s ∩ t, f x ∂μ := by

--- a/Mathlib/Probability/Kernel/Integral.lean
+++ b/Mathlib/Probability/Kernel/Integral.lean
@@ -41,6 +41,10 @@ lemma integral_congr_ae₂ {f g : α → β → E} {μ : Measure α} (h : ∀ᵐ
   apply integral_congr_ae
   filter_upwards [ha] with _ hb using hb
 
+lemma integral_indicator₂ (f : α → β → E) (s : Set α) (a : α) :
+    ∫ y, s.indicator (f · y) a ∂κ a = s.indicator (fun x ↦ ∫ y, f x y ∂κ x) a := by
+  by_cases ha : a ∈ s <;> simp [ha]
+
 section Deterministic
 
 variable [CompleteSpace E] {g : α → β}

--- a/Mathlib/Probability/Kernel/Integral.lean
+++ b/Mathlib/Probability/Kernel/Integral.lean
@@ -3,7 +3,7 @@ Copyright (c) 2022 Rémy Degenne. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Rémy Degenne
 -/
-import Mathlib.MeasureTheory.Integral.Bochner
+import Mathlib.MeasureTheory.Integral.SetIntegral
 import Mathlib.Probability.Kernel.Basic
 
 /-!
@@ -44,6 +44,11 @@ lemma integral_congr_ae₂ {f g : α → β → E} {μ : Measure α} (h : ∀ᵐ
 lemma integral_indicator₂ (f : α → β → E) (s : Set α) (a : α) :
     ∫ y, s.indicator (f · y) a ∂κ a = s.indicator (fun x ↦ ∫ y, f x y ∂κ x) a := by
   by_cases ha : a ∈ s <;> simp [ha]
+
+lemma integral_integral_indicator {μ : Measure α} (f : α → β → E)
+    {s : Set α} (hs : MeasurableSet s) :
+    ∫ x, ∫ y, s.indicator (f · y) x ∂κ x ∂μ = ∫ x in s, ∫ y, f x y ∂κ x ∂μ := by
+  simp_rw [← integral_indicator hs, integral_indicator₂]
 
 section Deterministic
 

--- a/Mathlib/Probability/Kernel/Integral.lean
+++ b/Mathlib/Probability/Kernel/Integral.lean
@@ -3,7 +3,7 @@ Copyright (c) 2022 Rémy Degenne. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Rémy Degenne
 -/
-import Mathlib.MeasureTheory.Integral.SetIntegral
+import Mathlib.MeasureTheory.Integral.Bochner
 import Mathlib.Probability.Kernel.Basic
 
 /-!
@@ -44,11 +44,6 @@ lemma integral_congr_ae₂ {f g : α → β → E} {μ : Measure α} (h : ∀ᵐ
 lemma integral_indicator₂ (f : α → β → E) (s : Set α) (a : α) :
     ∫ y, s.indicator (f · y) a ∂κ a = s.indicator (fun x ↦ ∫ y, f x y ∂κ x) a := by
   by_cases ha : a ∈ s <;> simp [ha]
-
-lemma integral_integral_indicator {μ : Measure α} (f : α → β → E)
-    {s : Set α} (hs : MeasurableSet s) :
-    ∫ x, ∫ y, s.indicator (f · y) x ∂κ x ∂μ = ∫ x in s, ∫ y, f x y ∂κ x ∂μ := by
-  simp_rw [← integral_indicator hs, integral_indicator₂]
 
 section Deterministic
 

--- a/Mathlib/Probability/Kernel/SetIntegral.lean
+++ b/Mathlib/Probability/Kernel/SetIntegral.lean
@@ -14,6 +14,8 @@ This file contains lemmas about the integral against a kernel and over a set.
 
 open MeasureTheory ProbabilityTheory
 
+namespace ProbabilityTheory.Kernel
+
 variable {X Y E : Type*} {mX : MeasurableSpace X} {mY : MeasurableSpace Y}
   [NormedAddCommGroup E] [NormedSpace ℝ E] (κ : Kernel X Y)
 
@@ -21,3 +23,5 @@ lemma integral_integral_indicator (μ : Measure X) (f : X → Y → E) {s : Set 
     (hs : MeasurableSet s) :
     ∫ x, ∫ y, s.indicator (f · y) x ∂κ x ∂μ = ∫ x in s, ∫ y, f x y ∂κ x ∂μ := by
   simp_rw [← integral_indicator hs, Kernel.integral_indicator₂]
+
+end ProbabilityTheory.Kernel

--- a/Mathlib/Probability/Kernel/SetIntegral.lean
+++ b/Mathlib/Probability/Kernel/SetIntegral.lean
@@ -1,0 +1,23 @@
+/-
+Copyright (c) 2025 Etienne Marion. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Etienne Marion
+-/
+import Mathlib.MeasureTheory.Integral.SetIntegral
+import Mathlib.Probability.Kernel.Integral
+
+/-! # Integral against a kernel over a set
+
+This file contains lemmas about the integral against a kernel and over a set.
+
+-/
+
+open MeasureTheory ProbabilityTheory
+
+variable {X Y E : Type*} {mX : MeasurableSpace X} {mY : MeasurableSpace Y}
+  [NormedAddCommGroup E] [NormedSpace ℝ E] (κ : Kernel X Y)
+
+lemma integral_integral_indicator (μ : Measure X) (f : X → Y → E) {s : Set X}
+    (hs : MeasurableSet s) :
+    ∫ x, ∫ y, s.indicator (f · y) x ∂κ x ∂μ = ∫ x in s, ∫ y, f x y ∂κ x ∂μ := by
+  simp_rw [← integral_indicator hs, Kernel.integral_indicator₂]


### PR DESCRIPTION
Prove that `∫ x, ∫ y, s.indicator (f · y) x ∂ν ∂μ = ∫ x in s, ∫ y, f x y ∂ν ∂μ`, as well as a version for kernels. Create a new file for lemmas about the `setIntegral` against kernels to avoid large imports.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
