### PR TITLE
[Merged by Bors] - chore: stop conflating WithTop and Option in WithTop.locallyFiniteOrder

### DIFF
--- a/Mathlib/Logic/Embedding/Set.lean
+++ b/Mathlib/Logic/Embedding/Set.lean
@@ -33,11 +33,6 @@ namespace Function
 
 namespace Embedding
 
-/-- Embedding into `WithTop α`. -/
-@[simps]
-def coeWithTop {α} : α ↪ WithTop α :=
-  { Embedding.some with toFun := WithTop.some }
-
 /-- Given an embedding `f : α ↪ β` and a point outside of `Set.range f`, construct an embedding
 `Option α ↪ β`. -/
 @[simps]

--- a/Mathlib/Order/Hom/Basic.lean
+++ b/Mathlib/Order/Hom/Basic.lean
@@ -1240,6 +1240,12 @@ theorem coe_toDualBotEquiv [LE α] :
     (WithTop.toDualBotEquiv : WithTop αᵒᵈ → (WithBot α)ᵒᵈ) = toDual ∘ WithTop.ofDual :=
   funext fun _ => rfl
 
+/-- Embedding into `WithTop α`. -/
+@[simps]
+def _root_.Function.Embedding.coeWithTop : α ↪ WithTop α where
+  toFun := (↑)
+  inj' := WithTop.coe_injective
+
 /-- The coercion `α → WithTop α` bundled as monotone map. -/
 @[simps]
 def coeOrderHom {α : Type*} [Preorder α] : α ↪o WithTop α where

--- a/Mathlib/Order/Interval/Finset/Defs.lean
+++ b/Mathlib/Order/Interval/Finset/Defs.lean
@@ -871,22 +871,22 @@ instance locallyFiniteOrder : LocallyFiniteOrder (WithTop α) where
     | ⊤, ⊤ => {⊤}
     | ⊤, (b : α) => ∅
     | (a : α), ⊤ => insertNone (Ici a)
-    | (a : α), (b : α) => (Icc a b).map Embedding.some
+    | (a : α), (b : α) => (Icc a b).map Function.Embedding.coeWithTop
   finsetIco a b :=
     match a, b with
     | ⊤, _ => ∅
-    | (a : α), ⊤ => (Ici a).map Embedding.some
-    | (a : α), (b : α) => (Ico a b).map Embedding.some
+    | (a : α), ⊤ => (Ici a).map Function.Embedding.coeWithTop
+    | (a : α), (b : α) => (Ico a b).map Function.Embedding.coeWithTop
   finsetIoc a b :=
     match a, b with
     | ⊤, _ => ∅
     | (a : α), ⊤ => insertNone (Ioi a)
-    | (a : α), (b : α) => (Ioc a b).map Embedding.some
+    | (a : α), (b : α) => (Ioc a b).map Function.Embedding.coeWithTop
   finsetIoo a b :=
     match a, b with
     | ⊤, _ => ∅
-    | (a : α), ⊤ => (Ioi a).map Embedding.some
-    | (a : α), (b : α) => (Ioo a b).map Embedding.some
+    | (a : α), ⊤ => (Ioi a).map Function.Embedding.coeWithTop
+    | (a : α), (b : α) => (Ioo a b).map Function.Embedding.coeWithTop
   -- Porting note: the proofs below got much worse
   finset_mem_Icc a b x :=
     match a, b, x with
@@ -897,27 +897,15 @@ instance locallyFiniteOrder : LocallyFiniteOrder (WithTop α) where
     | (a : α), ⊤, (x : α) => by
         simp only [le_eq_subset, coe_le_coe, le_top, and_true]
         rw [← some_eq_coe, some_mem_insertNone, mem_Ici]
-    | (a : α), (b : α), ⊤ => by
-        simp only [Embedding.some, mem_map, mem_Icc, and_false, exists_const, some, le_top,
-          top_le_iff, reduceCtorEq]
-    | (a : α), (b : α), (x : α) => by
-        simp only [le_eq_subset, Embedding.some, mem_map, mem_Icc, Embedding.coeFn_mk, coe_le_coe]
-        -- This used to be in the above `simp` before https://github.com/leanprover/lean4/pull/2644
-        erw [aux]
+    | (a : α), (b : α), ⊤ => by simp
+    | (a : α), (b : α), (x : α) => by simp
   finset_mem_Ico a b x :=
     match a, b, x with
     | ⊤, _, _ => iff_of_false (not_mem_empty _) fun h => not_top_lt <| h.1.trans_lt h.2
-    | (a : α), ⊤, ⊤ => by simp [some, Embedding.some]
-    | (a : α), ⊤, (x : α) => by
-        simp only [Embedding.some, mem_map, mem_Ici, Embedding.coeFn_mk, coe_le_coe, aux,
-          coe_lt_top, and_true]
-        -- This used to be in the above `simp` before https://github.com/leanprover/lean4/pull/2644
-        erw [aux]
-    | (a : α), (b : α), ⊤ => by simp [some, Embedding.some]
-    | (a : α), (b : α), (x : α) => by simp [some, Embedding.some, aux]
-                                      -- This used to be in the above `simp` before
-                                      -- https://github.com/leanprover/lean4/pull/2644
-                                      erw [aux]
+    | (a : α), ⊤, ⊤ => by simp
+    | (a : α), ⊤, (x : α) => by simp
+    | (a : α), (b : α), ⊤ => by simp
+    | (a : α), (b : α), (x : α) => by simp
   finset_mem_Ioc a b x :=
     match a, b, x with
     | ⊤, _, _ => iff_of_false (not_mem_empty _) fun h => not_top_lt <| h.1.trans_le h.2
@@ -926,25 +914,18 @@ instance locallyFiniteOrder : LocallyFiniteOrder (WithTop α) where
                                 -- This used to be in the above `simp` before
                                 -- https://github.com/leanprover/lean4/pull/2644
                                 erw [aux]
-    | (a : α), (b : α), ⊤ => by simp [some, Embedding.some, insertNone]
-    | (a : α), (b : α), (x : α) => by simp [some, Embedding.some, insertNone, aux]
-                                      -- This used to be in the above `simp` before
-                                      -- https://github.com/leanprover/lean4/pull/2644
-                                      erw [aux]
+    | (a : α), (b : α), ⊤ => by simp
+    | (a : α), (b : α), (x : α) => by simp
   finset_mem_Ioo a b x :=
     match a, b, x with
     | ⊤, _, _ => iff_of_false (not_mem_empty _) fun h => not_top_lt <| h.1.trans h.2
-    | (a : α), ⊤, ⊤ => by simp [some, Embedding.some, insertNone]
+    | (a : α), ⊤, ⊤ => by simp
     | (a : α), ⊤, (x : α) => by simp [some, Embedding.some, insertNone, aux, top]
                                 -- This used to be in the above `simp` before
                                 -- https://github.com/leanprover/lean4/pull/2644
                                 erw [aux]
-    | (a : α), (b : α), ⊤ => by simp [some, Embedding.some, insertNone]
-    | (a : α), (b : α), (x : α) => by
-      simp [some, Embedding.some, insertNone, aux]
-      -- This used to be in the above `simp` before
-      -- https://github.com/leanprover/lean4/pull/2644
-      erw [aux]
+    | (a : α), (b : α), ⊤ => by simp
+    | (a : α), (b : α), (x : α) => by simp
 
 variable (a b : α)
 

--- a/Mathlib/Order/Interval/Finset/Defs.lean
+++ b/Mathlib/Order/Interval/Finset/Defs.lean
@@ -884,53 +884,30 @@ instance locallyFiniteOrder : LocallyFiniteOrder (WithTop α) where
     | ⊤, ⊤ => {⊤}
     | ⊤, (b : α) => ∅
     | (a : α), ⊤ => insertTop (Ici a)
-    | (a : α), (b : α) => (Icc a b).map Function.Embedding.coeWithTop
+    | (a : α), (b : α) => (Icc a b).map Embedding.coeWithTop
   finsetIco a b :=
     match a, b with
     | ⊤, _ => ∅
-    | (a : α), ⊤ => (Ici a).map Function.Embedding.coeWithTop
-    | (a : α), (b : α) => (Ico a b).map Function.Embedding.coeWithTop
+    | (a : α), ⊤ => (Ici a).map Embedding.coeWithTop
+    | (a : α), (b : α) => (Ico a b).map Embedding.coeWithTop
   finsetIoc a b :=
     match a, b with
     | ⊤, _ => ∅
     | (a : α), ⊤ => insertTop (Ioi a)
-    | (a : α), (b : α) => (Ioc a b).map Function.Embedding.coeWithTop
+    | (a : α), (b : α) => (Ioc a b).map Embedding.coeWithTop
   finsetIoo a b :=
     match a, b with
     | ⊤, _ => ∅
-    | (a : α), ⊤ => (Ioi a).map Function.Embedding.coeWithTop
-    | (a : α), (b : α) => (Ioo a b).map Function.Embedding.coeWithTop
-  -- Porting note: the proofs below got much worse
-  finset_mem_Icc a b x :=
-    match a, b, x with
-    | ⊤, ⊤, _ => mem_singleton.trans (le_antisymm_iff.trans and_comm)
-    | ⊤, (b : α), _ =>
-      iff_of_false (not_mem_empty _) fun h => (h.1.trans h.2).not_lt <| coe_lt_top _
-    | (a : α), ⊤, ⊤ => by simp
-    | (a : α), ⊤, (x : α) => by simp
-    | (a : α), (b : α), ⊤ => by simp
-    | (a : α), (b : α), (x : α) => by simp
-  finset_mem_Ico a b x :=
-    match a, b, x with
-    | ⊤, _, _ => iff_of_false (not_mem_empty _) fun h => not_top_lt <| h.1.trans_lt h.2
-    | (a : α), ⊤, ⊤ => by simp
-    | (a : α), ⊤, (x : α) => by simp
-    | (a : α), (b : α), ⊤ => by simp
-    | (a : α), (b : α), (x : α) => by simp
-  finset_mem_Ioc a b x :=
-    match a, b, x with
-    | ⊤, _, _ => iff_of_false (not_mem_empty _) fun h => not_top_lt <| h.1.trans_le h.2
-    | (a : α), ⊤, ⊤ => by simp [some, insertTop, top]
-    | (a : α), ⊤, (x : α) => by simp
-    | (a : α), (b : α), ⊤ => by simp
-    | (a : α), (b : α), (x : α) => by simp
-  finset_mem_Ioo a b x :=
-    match a, b, x with
-    | ⊤, _, _ => iff_of_false (not_mem_empty _) fun h => not_top_lt <| h.1.trans h.2
-    | (a : α), ⊤, ⊤ => by simp
-    | (a : α), ⊤, (x : α) => by simp
-    | (a : α), (b : α), ⊤ => by simp
-    | (a : α), (b : α), (x : α) => by simp
+    | (a : α), ⊤ => (Ioi a).map Embedding.coeWithTop
+    | (a : α), (b : α) => (Ioo a b).map Embedding.coeWithTop
+  finset_mem_Icc a b x := by
+    cases a <;> cases b <;> cases x <;> simp
+  finset_mem_Ico a b x := by
+    cases a <;> cases b <;> cases x <;> simp
+  finset_mem_Ioc a b x := by
+    cases a <;> cases b <;> cases x <;> simp
+  finset_mem_Ioo a b x := by
+    cases a <;> cases b <;> cases x <;> simp
 
 variable (a b : α)
 

--- a/Mathlib/Order/Interval/Finset/Defs.lean
+++ b/Mathlib/Order/Interval/Finset/Defs.lean
@@ -859,7 +859,6 @@ Adding a `⊥` to a locally finite `OrderBot` keeps it locally finite.
 
 namespace WithTop
 
--- TODO: where should this live?
 -- TODO: WithBot variant
 /-- Given a finset on `α`, lift it to being a finset on `WithTop α`
 using `WithTop.some` and then insert `⊤`. -/


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
