### PR TITLE
[Merged by Bors] - feat: add to `WithVal` API

### DIFF
--- a/Mathlib/RingTheory/DedekindDomain/AdicValuation.lean
+++ b/Mathlib/RingTheory/DedekindDomain/AdicValuation.lean
@@ -359,6 +359,9 @@ def adicValued : Valued K ℤₘ₀ :=
 theorem adicValued_apply {x : K} : v.adicValued.v x = v.valuation K x :=
   rfl
 
+theorem adicValued_apply' {x : WithVal (v.valuation K)} : v.adicValued.v x = v.valuation K x :=
+  rfl
+
 variable (K)
 
 /-- The completion of `K` with respect to its `v`-adic valuation. -/

--- a/Mathlib/RingTheory/DedekindDomain/AdicValuation.lean
+++ b/Mathlib/RingTheory/DedekindDomain/AdicValuation.lean
@@ -359,7 +359,8 @@ def adicValued : Valued K ℤₘ₀ :=
 theorem adicValued_apply {x : K} : v.adicValued.v x = v.valuation K x :=
   rfl
 
-theorem adicValued_apply' {x : WithVal (v.valuation K)} : v.adicValued.v x = v.valuation K x :=
+@[simp]
+theorem adicValued_apply' (x : WithVal (v.valuation K)) : v.adicValued.v x = v.valuation K x :=
   rfl
 
 variable (K)

--- a/Mathlib/Topology/Algebra/Valued/WithVal.lean
+++ b/Mathlib/Topology/Algebra/Valued/WithVal.lean
@@ -62,6 +62,17 @@ instance {P S : Type*} [SMul P S] [SMul S R] [SMul P R] [IsScalarTower P S R] :
     IsScalarTower P S (WithVal v) :=
   ‹IsScalarTower P S R›
 
+instance {S : Type*} [Ring S] [CommRing R] [Algebra R S] :
+    Algebra (WithVal v) S := ‹Algebra R S›
+
+instance {S : Type*} [Ring S] [CommRing R] [Algebra R S] (w : Valuation S Γ₀) :
+    Algebra R (WithVal w) := ‹Algebra R S›
+
+instance {P S : Type*} [Ring S] [CommRing R] [Semiring P] [Module P R] [Module P S]
+    [Algebra R S] [IsScalarTower P R S] :
+    IsScalarTower P (WithVal v) S :=
+  ‹IsScalarTower P R S›
+
 instance (v : Valuation R Γ₀) : Valued (WithVal v) Γ₀ := Valued.mk' v
 
 /-- Canonical ring equivalence between `WithValuation v` and `R`. -/


### PR DESCRIPTION
Upstream fixes to errors generated in FLT following the refactor of `HeightOneSpectrum.adicCompletion` in #22055 
- add additional instances to `WithVal` API
- provide `WithVal` alternative to `adicValued_apply`

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
