### PR TITLE
[Merged by Bors] - chore: move order-related code out of Data.Set.Image

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4526,6 +4526,7 @@ import Mathlib.Order.RelSeries
 import Mathlib.Order.Restriction
 import Mathlib.Order.ScottContinuity
 import Mathlib.Order.SemiconjSup
+import Mathlib.Order.Set
 import Mathlib.Order.SetIsMax
 import Mathlib.Order.SetNotation
 import Mathlib.Order.Shrink

--- a/Mathlib/Data/Multiset/Filter.lean
+++ b/Mathlib/Data/Multiset/Filter.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
 import Mathlib.Data.Multiset.MapFold
+import Mathlib.Order.Hom.Basic
 
 /-!
 # Filtering multisets by a predicate

--- a/Mathlib/Data/Set/Image.lean
+++ b/Mathlib/Data/Set/Image.lean
@@ -4,9 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Leonardo de Moura
 -/
 import Batteries.Tactic.Congr
+import Mathlib.Data.Option.Basic
 import Mathlib.Data.Set.Subsingleton
 import Mathlib.Data.Set.SymmDiff
-import Mathlib.Order.Hom.Basic
 
 /-!
 # Images and preimages of sets
@@ -29,6 +29,8 @@ import Mathlib.Order.Hom.Basic
 set, sets, image, preimage, pre-image, range
 
 -/
+
+assert_not_exists WithTop OrderIso
 
 universe u v
 
@@ -823,15 +825,6 @@ theorem image_preimage_inl_union_image_preimage_inr (s : Set (α ⊕ β)) :
   rw [image_preimage_eq_inter_range, image_preimage_eq_inter_range, ← inter_union_distrib_left,
     range_inl_union_range_inr, inter_univ]
 
-open Sum in
-/-- Sets on sum types are equivalent to pairs of sets on each summand. -/
-def sumEquiv {α β : Type*} : Set (α ⊕ β) ≃o Set α × Set β where
-  toFun s := (inl ⁻¹' s, inr ⁻¹' s)
-  invFun s := inl '' s.1 ∪ inr '' s.2
-  left_inv s := image_preimage_inl_union_image_preimage_inr s
-  right_inv s := by simp [preimage_image_eq _ inl_injective, preimage_image_eq _ inr_injective]
-  map_rel_iff' := by simp [subset_def]
-
 @[simp]
 theorem range_quot_mk (r : α → α → Prop) : range (Quot.mk r) = univ :=
   Quot.mk_surjective.range_eq
@@ -1295,14 +1288,6 @@ theorem range_eq {α β} (f : Option α → β) : range f = insert (f none) (ran
   Set.ext fun _ => Option.exists.trans <| eq_comm.or Iff.rfl
 
 end Option
-
-theorem WithBot.range_eq {α β} (f : WithBot α → β) :
-    range f = insert (f ⊥) (range (f ∘ WithBot.some : α → β)) :=
-  Option.range_eq f
-
-theorem WithTop.range_eq {α β} (f : WithTop α → β) :
-    range f = insert (f ⊤) (range (f ∘ WithBot.some : α → β)) :=
-  Option.range_eq f
 
 namespace Set
 

--- a/Mathlib/GroupTheory/Perm/ViaEmbedding.lean
+++ b/Mathlib/GroupTheory/Perm/ViaEmbedding.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leonardo de Moura, Mario Carneiro
 -/
 import Mathlib.Algebra.Group.End
+import Mathlib.Logic.Embedding.Basic
 import Mathlib.Logic.Equiv.Set
 
 /-!

--- a/Mathlib/Logic/Embedding/Set.lean
+++ b/Mathlib/Logic/Embedding/Set.lean
@@ -8,6 +8,7 @@ import Mathlib.Order.SetNotation
 import Mathlib.Logic.Embedding.Basic
 import Mathlib.Logic.Pairwise
 import Mathlib.Data.Set.Image
+import Mathlib.Order.Hom.Basic
 
 /-!
 # Interactions between embeddings and sets.

--- a/Mathlib/Order/Hom/Set.lean
+++ b/Mathlib/Order/Hom/Set.lean
@@ -19,6 +19,19 @@ open OrderDual Set
 
 variable {α β : Type*}
 
+namespace Set
+
+/-- Sets on sum types are order-equivalent to pairs of sets on each summand. -/
+def sumEquiv : Set (α ⊕ β) ≃o Set α × Set β where
+  toFun s := (Sum.inl ⁻¹' s, Sum.inr ⁻¹' s)
+  invFun s := Sum.inl '' s.1 ∪ Sum.inr '' s.2
+  left_inv s := image_preimage_inl_union_image_preimage_inr s
+  right_inv s := by
+    simp [preimage_image_eq _ Sum.inl_injective, preimage_image_eq _ Sum.inr_injective]
+  map_rel_iff' := by simp [subset_def]
+
+end Set
+
 namespace OrderIso
 
 section LE

--- a/Mathlib/Order/Set.lean
+++ b/Mathlib/Order/Set.lean
@@ -1,0 +1,22 @@
+/-
+Copyright (c) 2022 Yury Kudryashov. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yury Kudryashov
+-/
+
+import Mathlib.Data.Set.Image
+import Mathlib.Order.TypeTags
+
+/-! # `Set.range` on `WithBot` and `WithTop` -/
+
+open Set
+
+variable {α β : Type*}
+
+theorem WithBot.range_eq (f : WithBot α → β) :
+    range f = insert (f ⊥) (range (f ∘ WithBot.some : α → β)) :=
+  Option.range_eq f
+
+theorem WithTop.range_eq (f : WithTop α → β) :
+    range f = insert (f ⊤) (range (f ∘ WithBot.some : α → β)) :=
+  Option.range_eq f


### PR DESCRIPTION
As it happens, none of these declarations seem to be used in mathlib, but they could be useful.

Copyright from leanprover-community/mathlib3#17489.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
