### PR TITLE
[Merged by Bors] - chore(Algebra/Group/Pi): separate notation from the other instances

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -970,7 +970,6 @@ import Mathlib.Algebra.Ring.Hom.Defs
 import Mathlib.Algebra.Ring.Idempotent
 import Mathlib.Algebra.Ring.Identities
 import Mathlib.Algebra.Ring.InjSurj
-import Mathlib.Algebra.Ring.Int.Basic
 import Mathlib.Algebra.Ring.Int.Defs
 import Mathlib.Algebra.Ring.Int.Parity
 import Mathlib.Algebra.Ring.Int.Units

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -349,6 +349,7 @@ import Mathlib.Algebra.Group.PNatPowAssoc
 import Mathlib.Algebra.Group.PUnit
 import Mathlib.Algebra.Group.Pi.Basic
 import Mathlib.Algebra.Group.Pi.Lemmas
+import Mathlib.Algebra.Group.Pi.Notation
 import Mathlib.Algebra.Group.Pi.Units
 import Mathlib.Algebra.Group.Pointwise.Finset.Basic
 import Mathlib.Algebra.Group.Pointwise.Finset.Interval
@@ -969,6 +970,7 @@ import Mathlib.Algebra.Ring.Hom.Defs
 import Mathlib.Algebra.Ring.Idempotent
 import Mathlib.Algebra.Ring.Identities
 import Mathlib.Algebra.Ring.InjSurj
+import Mathlib.Algebra.Ring.Int.Basic
 import Mathlib.Algebra.Ring.Int.Defs
 import Mathlib.Algebra.Ring.Int.Parity
 import Mathlib.Algebra.Ring.Int.Units

--- a/Mathlib/Algebra/Group/Action/Basic.lean
+++ b/Mathlib/Algebra/Group/Action/Basic.lean
@@ -5,6 +5,7 @@ Authors: Chris Hughes
 -/
 import Mathlib.Algebra.Group.Action.Units
 import Mathlib.Algebra.Group.Invertible.Basic
+import Mathlib.Algebra.Group.Pi.Basic
 import Mathlib.Logic.Embedding.Basic
 
 /-!

--- a/Mathlib/Algebra/Group/Hom/Defs.lean
+++ b/Mathlib/Algebra/Group/Hom/Defs.lean
@@ -4,7 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Patrick Massot, Kevin Buzzard, Kim Morrison, Johan Commelin, Chris Hughes,
   Johannes Hölzl, Yury Kudryashov
 -/
-import Mathlib.Algebra.Group.Pi.Basic
+import Mathlib.Algebra.Group.Defs
+import Mathlib.Algebra.Group.Pi.Notation
 import Mathlib.Data.FunLike.Basic
 import Mathlib.Logic.Function.Iterate
 

--- a/Mathlib/Algebra/Group/Pi/Basic.lean
+++ b/Mathlib/Algebra/Group/Pi/Basic.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Simon Hudon, Patrick Massot, Eric Wieser
 -/
 import Mathlib.Algebra.Group.Defs
+import Mathlib.Algebra.Group.Pi.Notation
 import Mathlib.Data.Sum.Basic
 import Mathlib.Logic.Unique
 import Mathlib.Tactic.Spread
@@ -39,112 +40,6 @@ variable {f : I → Type v₁} {g : I → Type v₂} {h : I → Type v₃}
 variable (x y : ∀ i, f i) (i : I)
 
 namespace Pi
-
-/-! `1`, `0`, `+`, `*`, `+ᵥ`, `•`, `^`, `-`, `⁻¹`, and `/` are defined pointwise. -/
-
-@[to_additive]
-instance instOne [∀ i, One <| f i] : One (∀ i : I, f i) :=
-  ⟨fun _ => 1⟩
-
-@[to_additive (attr := simp)]
-theorem one_apply [∀ i, One <| f i] : (1 : ∀ i, f i) i = 1 :=
-  rfl
-
-@[to_additive]
-theorem one_def [∀ i, One <| f i] : (1 : ∀ i, f i) = fun _ => 1 :=
-  rfl
-
-@[to_additive (attr := simp)] lemma _root_.Function.const_one [One β] : const α (1 : β) = 1 := rfl
-
-@[to_additive (attr := simp)]
-theorem one_comp [One γ] (x : α → β) : (1 : β → γ) ∘ x = 1 :=
-  rfl
-
-@[to_additive (attr := simp)]
-theorem comp_one [One β] (x : β → γ) : x ∘ (1 : α → β) = const α (x 1) :=
-  rfl
-
-@[to_additive]
-instance instMul [∀ i, Mul <| f i] : Mul (∀ i : I, f i) :=
-  ⟨fun f g i => f i * g i⟩
-
-@[to_additive (attr := simp)]
-theorem mul_apply [∀ i, Mul <| f i] : (x * y) i = x i * y i :=
-  rfl
-
-@[to_additive]
-theorem mul_def [∀ i, Mul <| f i] : x * y = fun i => x i * y i :=
-  rfl
-
-@[to_additive (attr := simp)]
-lemma _root_.Function.const_mul [Mul β] (a b : β) : const α a * const α b = const α (a * b) := rfl
-
-@[to_additive]
-theorem mul_comp [Mul γ] (x y : β → γ) (z : α → β) : (x * y) ∘ z = x ∘ z * y ∘ z :=
-  rfl
-
-@[to_additive]
-instance instSMul [∀ i, SMul α <| f i] : SMul α (∀ i : I, f i) :=
-  ⟨fun s x => fun i => s • x i⟩
-
-@[to_additive existing instSMul]
-instance instPow [∀ i, Pow (f i) β] : Pow (∀ i, f i) β :=
-  ⟨fun x b i => x i ^ b⟩
-
-@[to_additive (attr := simp, to_additive) (reorder := 5 6) smul_apply]
-theorem pow_apply [∀ i, Pow (f i) β] (x : ∀ i, f i) (b : β) (i : I) : (x ^ b) i = x i ^ b :=
-  rfl
-
-@[to_additive (attr := to_additive) (reorder := 5 6) smul_def]
-theorem pow_def [∀ i, Pow (f i) β] (x : ∀ i, f i) (b : β) : x ^ b = fun i => x i ^ b :=
-  rfl
-
-@[to_additive (attr := simp, to_additive) (reorder := 2 3, 5 6) smul_const]
-lemma _root_.Function.const_pow [Pow α β] (a : α) (b : β) : const I a ^ b = const I (a ^ b) := rfl
-
-@[to_additive (attr := to_additive) (reorder := 6 7) smul_comp]
-theorem pow_comp [Pow γ α] (x : β → γ) (a : α) (y : I → β) : (x ^ a) ∘ y = x ∘ y ^ a :=
-  rfl
-
--- Use `Pi.ofNat_apply` instead
-
-@[to_additive]
-instance instInv [∀ i, Inv <| f i] : Inv (∀ i : I, f i) :=
-  ⟨fun f i => (f i)⁻¹⟩
-
-@[to_additive (attr := simp)]
-theorem inv_apply [∀ i, Inv <| f i] : x⁻¹ i = (x i)⁻¹ :=
-  rfl
-
-@[to_additive]
-theorem inv_def [∀ i, Inv <| f i] : x⁻¹ = fun i => (x i)⁻¹ :=
-  rfl
-
-@[to_additive]
-lemma _root_.Function.const_inv [Inv β] (a : β) : (const α a)⁻¹ = const α a⁻¹ := rfl
-
-@[to_additive]
-theorem inv_comp [Inv γ] (x : β → γ) (y : α → β) : x⁻¹ ∘ y = (x ∘ y)⁻¹ :=
-  rfl
-
-@[to_additive]
-instance instDiv [∀ i, Div <| f i] : Div (∀ i : I, f i) :=
-  ⟨fun f g i => f i / g i⟩
-
-@[to_additive (attr := simp)]
-theorem div_apply [∀ i, Div <| f i] : (x / y) i = x i / y i :=
-  rfl
-
-@[to_additive]
-theorem div_def [∀ i, Div <| f i] : x / y = fun i => x i / y i :=
-  rfl
-
-@[to_additive]
-theorem div_comp [Div γ] (x y : β → γ) (z : α → β) : (x / y) ∘ z = x ∘ z / y ∘ z :=
-  rfl
-
-@[to_additive (attr := simp)]
-lemma _root_.Function.const_div [Div β] (a b : β) : const α a / const α b = const α (a / b) := rfl
 
 @[to_additive]
 instance semigroup [∀ i, Semigroup (f i)] : Semigroup (∀ i, f i) where

--- a/Mathlib/Algebra/Group/Pi/Lemmas.lean
+++ b/Mathlib/Algebra/Group/Pi/Lemmas.lean
@@ -5,6 +5,7 @@ Authors: Simon Hudon, Patrick Massot
 -/
 import Mathlib.Algebra.Group.Commute.Defs
 import Mathlib.Algebra.Group.Hom.Instances
+import Mathlib.Algebra.Group.Pi.Basic
 import Mathlib.Data.Set.Function
 import Mathlib.Logic.Pairwise
 

--- a/Mathlib/Algebra/Group/Pi/Notation.lean
+++ b/Mathlib/Algebra/Group/Pi/Notation.lean
@@ -1,0 +1,138 @@
+/-
+Copyright (c) 2020 Eric Wieser. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Simon Hudon, Patrick Massot, Eric Wieser
+-/
+import Mathlib.Algebra.Group.Operations
+import Mathlib.Data.One.Defs
+import Mathlib.Util.AssertExists
+
+/-!
+# Notation for algebraic operators on pi types
+
+This file provides only the notation for (pointwise) `0`, `1`, `+`, `*`, `•`, `^`, `⁻¹` on pi types.
+See `Mathlib.Algebra.Group.Pi.Basic` for the `Monoid` and `Group` instances.
+-/
+
+-- We enforce to only import `Algebra.Group.Defs` and basic logic
+assert_not_exists Set.range Monoid DenselyOrdered
+
+open Function
+
+universe u v₁ v₂ v₃
+
+variable {I : Type u}
+
+-- The indexing type
+variable {α β γ : Type*}
+
+-- The families of types already equipped with instances
+variable {f : I → Type v₁} (x y : ∀ i, f i) (i : I)
+
+namespace Pi
+
+/-! `1`, `0`, `+`, `*`, `+ᵥ`, `•`, `^`, `-`, `⁻¹`, and `/` are defined pointwise. -/
+
+@[to_additive]
+instance instOne [∀ i, One <| f i] : One (∀ i : I, f i) :=
+  ⟨fun _ => 1⟩
+
+@[to_additive (attr := simp)]
+theorem one_apply [∀ i, One <| f i] : (1 : ∀ i, f i) i = 1 :=
+  rfl
+
+@[to_additive]
+theorem one_def [∀ i, One <| f i] : (1 : ∀ i, f i) = fun _ => 1 :=
+  rfl
+
+@[to_additive (attr := simp)] lemma _root_.Function.const_one [One β] : const α (1 : β) = 1 := rfl
+
+@[to_additive (attr := simp)]
+theorem one_comp [One γ] (x : α → β) : (1 : β → γ) ∘ x = 1 :=
+  rfl
+
+@[to_additive (attr := simp)]
+theorem comp_one [One β] (x : β → γ) : x ∘ (1 : α → β) = const α (x 1) :=
+  rfl
+
+@[to_additive]
+instance instMul [∀ i, Mul <| f i] : Mul (∀ i : I, f i) :=
+  ⟨fun f g i => f i * g i⟩
+
+@[to_additive (attr := simp)]
+theorem mul_apply [∀ i, Mul <| f i] : (x * y) i = x i * y i :=
+  rfl
+
+@[to_additive]
+theorem mul_def [∀ i, Mul <| f i] : x * y = fun i => x i * y i :=
+  rfl
+
+@[to_additive (attr := simp)]
+lemma _root_.Function.const_mul [Mul β] (a b : β) : const α a * const α b = const α (a * b) := rfl
+
+@[to_additive]
+theorem mul_comp [Mul γ] (x y : β → γ) (z : α → β) : (x * y) ∘ z = x ∘ z * y ∘ z :=
+  rfl
+
+@[to_additive]
+instance instSMul [∀ i, SMul α <| f i] : SMul α (∀ i : I, f i) :=
+  ⟨fun s x => fun i => s • x i⟩
+
+@[to_additive existing instSMul]
+instance instPow [∀ i, Pow (f i) β] : Pow (∀ i, f i) β :=
+  ⟨fun x b i => x i ^ b⟩
+
+@[to_additive (attr := simp, to_additive) (reorder := 5 6) smul_apply]
+theorem pow_apply [∀ i, Pow (f i) β] (x : ∀ i, f i) (b : β) (i : I) : (x ^ b) i = x i ^ b :=
+  rfl
+
+@[to_additive (attr := to_additive) (reorder := 5 6) smul_def]
+theorem pow_def [∀ i, Pow (f i) β] (x : ∀ i, f i) (b : β) : x ^ b = fun i => x i ^ b :=
+  rfl
+
+@[to_additive (attr := simp, to_additive) (reorder := 2 3, 5 6) smul_const]
+lemma _root_.Function.const_pow [Pow α β] (a : α) (b : β) : const I a ^ b = const I (a ^ b) := rfl
+
+@[to_additive (attr := to_additive) (reorder := 6 7) smul_comp]
+theorem pow_comp [Pow γ α] (x : β → γ) (a : α) (y : I → β) : (x ^ a) ∘ y = x ∘ y ^ a :=
+  rfl
+
+@[to_additive]
+instance instInv [∀ i, Inv <| f i] : Inv (∀ i : I, f i) :=
+  ⟨fun f i => (f i)⁻¹⟩
+
+@[to_additive (attr := simp)]
+theorem inv_apply [∀ i, Inv <| f i] : x⁻¹ i = (x i)⁻¹ :=
+  rfl
+
+@[to_additive]
+theorem inv_def [∀ i, Inv <| f i] : x⁻¹ = fun i => (x i)⁻¹ :=
+  rfl
+
+@[to_additive]
+lemma _root_.Function.const_inv [Inv β] (a : β) : (const α a)⁻¹ = const α a⁻¹ := rfl
+
+@[to_additive]
+theorem inv_comp [Inv γ] (x : β → γ) (y : α → β) : x⁻¹ ∘ y = (x ∘ y)⁻¹ :=
+  rfl
+
+@[to_additive]
+instance instDiv [∀ i, Div <| f i] : Div (∀ i : I, f i) :=
+  ⟨fun f g i => f i / g i⟩
+
+@[to_additive (attr := simp)]
+theorem div_apply [∀ i, Div <| f i] : (x / y) i = x i / y i :=
+  rfl
+
+@[to_additive]
+theorem div_def [∀ i, Div <| f i] : x / y = fun i => x i / y i :=
+  rfl
+
+@[to_additive]
+theorem div_comp [Div γ] (x y : β → γ) (z : α → β) : (x / y) ∘ z = x ∘ z / y ∘ z :=
+  rfl
+
+@[to_additive (attr := simp)]
+lemma _root_.Function.const_div [Div β] (a b : β) : const α a / const α b = const α (a / b) := rfl
+
+end Pi

--- a/Mathlib/Algebra/Group/Prod.lean
+++ b/Mathlib/Algebra/Group/Prod.lean
@@ -6,6 +6,7 @@ Authors: Simon Hudon, Patrick Massot, Yury Kudryashov
 import Mathlib.Algebra.Group.Equiv.Defs
 import Mathlib.Algebra.Group.Hom.Basic
 import Mathlib.Algebra.Group.Opposite
+import Mathlib.Algebra.Group.Pi.Basic
 import Mathlib.Algebra.Group.Units.Hom
 import Mathlib.Algebra.ZeroOne.Prod
 import Mathlib.Logic.Equiv.Basic

--- a/Mathlib/Algebra/Order/Field/Pi.lean
+++ b/Mathlib/Algebra/Order/Field/Pi.lean
@@ -3,7 +3,7 @@ Copyright (c) 2023 Yaël Dillies. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies
 -/
-import Mathlib.Algebra.Group.Pi.Basic
+import Mathlib.Algebra.Group.Pi.Notation
 import Mathlib.Algebra.Order.Monoid.Defs
 import Mathlib.Algebra.Order.Monoid.Unbundled.ExistsOfLE
 import Mathlib.Data.Finset.Lattice.Fold

--- a/Mathlib/Algebra/Order/GroupWithZero/Unbundled.lean
+++ b/Mathlib/Algebra/Order/GroupWithZero/Unbundled.lean
@@ -3,7 +3,7 @@ Copyright (c) 2022 Damiano Testa. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Damiano Testa, Yuyang Zhao
 -/
-import Mathlib.Algebra.Group.Pi.Basic
+import Mathlib.Algebra.Group.Pi.Notation
 import Mathlib.Algebra.GroupWithZero.Units.Basic
 import Mathlib.Algebra.Order.Monoid.Unbundled.Defs
 import Mathlib.Algebra.Order.ZeroLEOne

--- a/Mathlib/Algebra/Order/GroupWithZero/Unbundled/Lemmas.lean
+++ b/Mathlib/Algebra/Order/GroupWithZero/Unbundled/Lemmas.lean
@@ -3,7 +3,6 @@ Copyright (c) 2021 Eric Wieser. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Eric Wieser
 -/
-import Mathlib.Algebra.Group.Pi.Basic
 import Mathlib.Algebra.Order.GroupWithZero.Unbundled
 import Mathlib.Algebra.GroupWithZero.Units.Equiv
 import Mathlib.Order.Hom.Basic

--- a/Mathlib/Algebra/Order/Ring/Unbundled/Basic.lean
+++ b/Mathlib/Algebra/Order/Ring/Unbundled/Basic.lean
@@ -3,7 +3,6 @@ Copyright (c) 2016 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Leonardo de Moura, Mario Carneiro, Yaël Dillies
 -/
-import Mathlib.Algebra.Group.Pi.Basic
 import Mathlib.Algebra.Group.Units.Basic
 import Mathlib.Algebra.GroupWithZero.NeZero
 import Mathlib.Algebra.Order.Group.Unbundled.Basic

--- a/Mathlib/Algebra/Order/Sum.lean
+++ b/Mathlib/Algebra/Order/Sum.lean
@@ -3,8 +3,8 @@ Copyright (c) 2024 Martin Dvorak. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Martin Dvorak
 -/
+import Mathlib.Algebra.Group.Pi.Notation
 import Mathlib.Order.Basic
-import Mathlib.Algebra.Group.Pi.Basic
 
 /-!
 # Interaction between `Sum.elim`, `≤`, and `0` or `1`

--- a/Mathlib/Algebra/Ring/Hom/Defs.lean
+++ b/Mathlib/Algebra/Ring/Hom/Defs.lean
@@ -3,7 +3,6 @@ Copyright (c) 2019 Amelia Livingston. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Amelia Livingston, Jireh Loreaux
 -/
-import Mathlib.Algebra.Group.Pi.Basic
 import Mathlib.Algebra.GroupWithZero.Hom
 import Mathlib.Algebra.Ring.Defs
 import Mathlib.Algebra.Ring.Basic

--- a/Mathlib/Algebra/SMulWithZero.lean
+++ b/Mathlib/Algebra/SMulWithZero.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Damiano Testa
 -/
 import Mathlib.Algebra.Group.Action.Opposite
+import Mathlib.Algebra.Group.Pi.Basic
 import Mathlib.Algebra.GroupWithZero.Action.Defs
 import Mathlib.Algebra.GroupWithZero.Hom
 import Mathlib.Algebra.GroupWithZero.Opposite

--- a/Mathlib/Data/Matrix/DMatrix.lean
+++ b/Mathlib/Data/Matrix/DMatrix.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kim Morrison
 -/
 import Mathlib.Algebra.Group.Hom.Defs
+import Mathlib.Algebra.Group.Pi.Basic
 
 /-!
 # Dependent-typed matrices

--- a/Mathlib/Lean/Meta/RefinedDiscrTree/Pi.lean
+++ b/Mathlib/Lean/Meta/RefinedDiscrTree/Pi.lean
@@ -4,11 +4,15 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jovan Gerbscheid
 -/
 import Mathlib.Init
-import Mathlib.Algebra.Group.Pi.Basic
+import Mathlib.Algebra.Group.Pi.Notation
 
 /-!
 # Reducing Pi instances for indexing in the RefinedDiscrTree
 -/
+
+-- This file is only concerned with notation, and should avoid importing the actual algebraic
+-- hierarchy.
+assert_not_exists Monoid
 
 namespace Lean.Meta.RefinedDiscrTree
 

--- a/Mathlib/Order/Filter/Basic.lean
+++ b/Mathlib/Order/Filter/Basic.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Jeremy Avigad
 -/
 import Mathlib.Algebra.Group.Basic
-import Mathlib.Algebra.Group.Pi.Basic
+import Mathlib.Algebra.Group.Pi.Notation
 import Mathlib.Data.Set.Lattice
 import Mathlib.Order.Filter.Defs
 

--- a/Mathlib/Order/Filter/Map.lean
+++ b/Mathlib/Order/Filter/Map.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Jeremy Avigad
 -/
 import Mathlib.Algebra.Group.Basic
-import Mathlib.Algebra.Group.Pi.Basic
 import Mathlib.Control.Basic
 import Mathlib.Data.Set.Lattice
 import Mathlib.Order.Filter.Basic

--- a/Mathlib/Topology/Defs/Basic.lean
+++ b/Mathlib/Topology/Defs/Basic.lean
@@ -6,6 +6,7 @@ Authors: Johannes Hölzl, Mario Carneiro, Jeremy Avigad
 import Mathlib.Order.SetNotation
 import Mathlib.Tactic.Continuity
 import Mathlib.Tactic.FunProp
+import Mathlib.Tactic.MkIffOfInductiveProp
 /-!
 # Basic definitions about topological spaces
 
@@ -52,6 +53,8 @@ other than `Mathlib.Data.Set.Lattice`.
 We introduce notation `IsOpen[t]`, `IsClosed[t]`, `closure[t]`, `Continuous[t₁, t₂]`
 that allow passing custom topologies to these predicates and functions without using `@`.
 -/
+
+assert_not_exists Monoid
 
 universe u v
 open Set

--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -383,7 +383,7 @@
   ["Mathlib.LinearAlgebra.AffineSpace.Defs"],
   "Mathlib.LinearAlgebra.AffineSpace.AffineMap":
   ["Mathlib.LinearAlgebra.AffineSpace.Defs"],
-  "Mathlib.Lean.Meta.RefinedDiscrTree.Pi": ["Mathlib.Algebra.Group.Pi.Basic"],
+  "Mathlib.Lean.Meta.RefinedDiscrTree.Pi": ["Mathlib.Algebra.Group.Pi.Notation"],
   "Mathlib.Lean.Meta": ["Batteries.Logic"],
   "Mathlib.Lean.Expr.ExtraRecognizers": ["Mathlib.Data.Set.Operations"],
   "Mathlib.Lean.Expr.Basic": ["Batteries.Logic"],


### PR DESCRIPTION
We want to be able to recognize pointwise group operations in `RefinedDiscrTree`, but we don't actually need to define a full-on group structure in order to do so. So split up the notation for pi types from monoid/group/etc instances.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
