### PR TITLE
[Merged by Bors] - feat(CategoryTheory): inclusion morphism into products in categories with 0-morphisms

### DIFF
--- a/Mathlib/CategoryTheory/Limits/Shapes/ZeroMorphisms.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/ZeroMorphisms.lean
@@ -618,8 +618,6 @@ end
 
 section PiIota
 
-open Classical
-
 variable [HasZeroMorphisms C] {β : Type w} [DecidableEq β] (f : β → C) [HasProduct f]
 
 /-- In the presence of 0-morphism we can define an inclusion morphism into any product. -/

--- a/Mathlib/CategoryTheory/Limits/Shapes/ZeroMorphisms.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/ZeroMorphisms.lean
@@ -28,9 +28,7 @@ zero object provides zero morphisms, as the unique morphisms factoring through t
 
 noncomputable section
 
-universe v u
-
-universe v' u'
+universe w v v' u u'
 
 open CategoryTheory
 
@@ -617,5 +615,137 @@ lemma IsInitial.isZero {X : C} (hX : IsInitial X) : IsZero X := by
   apply hX.hom_ext
 
 end
+
+section PiIota
+
+open Classical
+
+variable [HasZeroMorphisms C] {β : Type w} [DecidableEq β] (f : β → C) [HasProduct f]
+
+/-- In the presence of 0-morphism we can define an inclusion morphism into any product. -/
+def Pi.ι (b : β) : f b ⟶ ∏ᶜ f :=
+  Pi.lift (Function.update (fun _ ↦ 0) b (𝟙 _))
+
+@[reassoc (attr := simp)]
+lemma Pi.ι_π_eq_id (b : β) : Pi.ι f b ≫ Pi.π f b = 𝟙 _ := by
+  simp [Pi.ι]
+
+lemma Pi.ι_π_of_ne {b c : β} (h : b ≠ c) : Pi.ι f b ≫ Pi.π f c = 0 := by
+  simp [Pi.ι, Function.update_of_ne h.symm]
+
+@[reassoc]
+lemma Pi.ι_π (b c : β) :
+    Pi.ι f b ≫ Pi.π f c = if h : b = c then eqToHom (congrArg f h) else 0 := by
+  split_ifs with h
+  · subst h; simp
+  · simp [Pi.ι_π_of_ne f h]
+
+instance (b : β) : Mono (Pi.ι f b) where
+  right_cancellation _ _ e := by simpa using congrArg (· ≫ Pi.π f b) e
+
+end PiIota
+
+section SigmaPi
+
+variable [HasZeroMorphisms C] {β : Type w} [DecidableEq β] (f : β → C) [HasCoproduct f]
+
+/-- In the presence of 0-morphisms we can define a projection morphism from any coproduct. -/
+def Sigma.π (b : β) : ∐ f ⟶ f b :=
+  Limits.Sigma.desc (Function.update (fun _ ↦ 0) b (𝟙 _))
+
+@[reassoc (attr := simp)]
+lemma Sigma.ι_π_eq_id (b : β) : Sigma.ι f b ≫ Sigma.π f b = 𝟙 _ := by
+  simp [Sigma.π]
+
+lemma Sigma.ι_π_of_ne {b c : β} (h : b ≠ c) : Sigma.ι f b ≫ Sigma.π f c = 0 := by
+  simp [Sigma.π, Function.update_of_ne h]
+
+@[reassoc]
+theorem Sigma.ι_π (b c : β) :
+    Sigma.ι f b ≫ Sigma.π f c = if h : b = c then eqToHom (congrArg f h) else 0 := by
+  split_ifs with h
+  · subst h; simp
+  · simp [Sigma.ι_π_of_ne f h]
+
+instance (b : β) : Epi (Sigma.π f b) where
+  left_cancellation _ _ e := by simpa using congrArg (Sigma.ι f b ≫ ·) e
+
+end SigmaPi
+
+section ProdInlInr
+
+variable [HasZeroMorphisms C] (X Y : C) [HasBinaryProduct X Y]
+
+/-- If a category `C` has 0-morphisms, there is a canonical inclusion from the first component `X`
+into any product of objects `X ⨯ Y`. -/
+def prod.inl : X ⟶ X ⨯ Y :=
+  prod.lift (𝟙 _) 0
+
+/-- If a category `C` has 0-morphisms, there is a canonical inclusion from the second component `Y`
+into any product of objects `X ⨯ Y`. -/
+def prod.inr : Y ⟶ X ⨯ Y :=
+  prod.lift 0 (𝟙 _)
+
+@[reassoc (attr := simp)]
+lemma prod.inl_fst : prod.inl X Y ≫ prod.fst = 𝟙 X := by
+  simp [prod.inl]
+
+@[reassoc (attr := simp)]
+lemma prod.inl_snd : prod.inl X Y ≫ prod.snd = 0 := by
+  simp [prod.inl]
+
+@[reassoc (attr := simp)]
+lemma prod.inr_fst : prod.inr X Y ≫ prod.fst = 0 := by
+  simp [prod.inr]
+
+@[reassoc (attr := simp)]
+lemma prod.inr_snd : prod.inr X Y ≫ prod.snd = 𝟙 Y := by
+  simp [prod.inr]
+
+instance : Mono (prod.inl X Y) where
+  right_cancellation _ _ e := by simpa using congrArg (· ≫ prod.fst) e
+
+instance : Mono (prod.inr X Y) where
+  right_cancellation _ _ e := by simpa using congrArg (· ≫ prod.snd) e
+
+end ProdInlInr
+
+section CoprodFstSnd
+
+variable [HasZeroMorphisms C] (X Y : C) [HasBinaryCoproduct X Y]
+
+/-- If a category `C` has 0-morphisms, there is a canonical projection from a coproduct `X ⨿ Y` to
+its first component `X`. -/
+def coprod.fst : X ⨿ Y ⟶ X :=
+  coprod.desc (𝟙 _) 0
+
+/-- If a category `C` has 0-morphisms, there is a canonical projection from a coproduct `X ⨿ Y` to
+its second component `Y`. -/
+def coprod.snd : X ⨿ Y ⟶ Y :=
+  coprod.desc 0 (𝟙 _)
+
+@[reassoc (attr := simp)]
+lemma coprod.inl_fst : coprod.inl ≫ coprod.fst X Y = 𝟙 X := by
+  simp [coprod.fst]
+
+@[reassoc (attr := simp)]
+lemma coprod.inr_fst : coprod.inr ≫ coprod.fst X Y = 0 := by
+  simp [coprod.fst]
+
+@[reassoc (attr := simp)]
+lemma coprod.inl_snd : coprod.inl ≫ coprod.snd X Y = 0 := by
+  simp [coprod.snd]
+
+@[reassoc (attr := simp)]
+lemma coprod.inr_snd : coprod.inr ≫ coprod.snd X Y = 𝟙 Y := by
+  simp [coprod.snd]
+
+instance : Epi (coprod.fst X Y) where
+  left_cancellation _ _ e := by simpa using congrArg (coprod.inl ≫ ·) e
+
+instance : Epi (coprod.snd X Y) where
+  left_cancellation _ _ e := by simpa using congrArg (coprod.inr ≫ ·) e
+
+end CoprodFstSnd
 
 end CategoryTheory.Limits


### PR DESCRIPTION
Fixes TwoFx/cats#26

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
