### PR TITLE
[Merged by Bors] - chore: move the group of relation automorphisms under `Algebra.Order`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -753,6 +753,7 @@ import Mathlib.Algebra.Order.Group.CompleteLattice
 import Mathlib.Algebra.Order.Group.Cone
 import Mathlib.Algebra.Order.Group.Defs
 import Mathlib.Algebra.Order.Group.DenselyOrdered
+import Mathlib.Algebra.Order.Group.End
 import Mathlib.Algebra.Order.Group.Finset
 import Mathlib.Algebra.Order.Group.Indicator
 import Mathlib.Algebra.Order.Group.InjSurj
@@ -4547,7 +4548,6 @@ import Mathlib.Order.Radical
 import Mathlib.Order.Rel.GaloisConnection
 import Mathlib.Order.RelClasses
 import Mathlib.Order.RelIso.Basic
-import Mathlib.Order.RelIso.Group
 import Mathlib.Order.RelIso.Set
 import Mathlib.Order.RelSeries
 import Mathlib.Order.Restriction

--- a/Mathlib/Algebra/Order/Group/End.lean
+++ b/Mathlib/Algebra/Order/Group/End.lean
@@ -10,6 +10,7 @@ import Mathlib.Order.RelIso.Basic
 # Relation isomorphisms form a group
 -/
 
+assert_not_exists MulAction MonoidWithZero
 
 variable {α : Type*} {r : α → α → Prop}
 

--- a/Mathlib/Order/RelIso/Basic.lean
+++ b/Mathlib/Order/RelIso/Basic.lean
@@ -614,6 +614,41 @@ instance (r : α → α → Prop) : Inhabited (r ≃r r) :=
 theorem default_def (r : α → α → Prop) : default = RelIso.refl r :=
   rfl
 
+@[simp] lemma apply_symm_apply (e : r ≃r s) (x : β) : e (e.symm x) = x := e.right_inv x
+@[simp] lemma symm_apply_apply (e : r ≃r s) (x : α) : e.symm (e x) = x := e.left_inv x
+
+@[simp] lemma symm_comp_self (e : r ≃r s) : e.symm ∘ e = id := funext e.symm_apply_apply
+@[simp] lemma self_comp_symm (e : r ≃r s) : e ∘ e.symm = id := funext e.apply_symm_apply
+
+@[simp] lemma symm_trans_apply (f : r ≃r s) (g : s ≃r t) (a : γ) :
+    (f.trans g).symm a = f.symm (g.symm a) := rfl
+
+lemma symm_symm_apply (f : r ≃r s) (b : α) : f.symm.symm b = f b := rfl
+
+lemma apply_eq_iff_eq (f : r ≃r s) {x y : α} : f x = f y ↔ x = y := EquivLike.apply_eq_iff_eq f
+
+lemma apply_eq_iff_eq_symm_apply {x : α} {y : β} (f : r ≃r s) : f x = y ↔ x = f.symm y := by
+  conv_lhs => rw [← apply_symm_apply f y]
+  rw [apply_eq_iff_eq]
+
+lemma symm_apply_eq (e : r ≃r s) {x y} : e.symm x = y ↔ x = e y := e.toEquiv.symm_apply_eq
+lemma eq_symm_apply (e : r ≃r s) {x y} : y = e.symm x ↔ e y = x := e.toEquiv.eq_symm_apply
+
+@[simp] lemma symm_symm (e : r ≃r s) : e.symm.symm = e := rfl
+
+lemma symm_bijective : Bijective (.symm : (r ≃r s) → s ≃r r) :=
+  bijective_iff_has_inverse.mpr ⟨_, symm_symm, symm_symm⟩
+
+@[simp] lemma refl_symm : (RelIso.refl r).symm = .refl _ := rfl
+@[simp] lemma trans_refl (e : r ≃r s) : e.trans (.refl _) = e := rfl
+@[simp] lemma refl_trans (e : r ≃r s) : .trans (.refl _) e = e := rfl
+
+@[simp] lemma symm_trans_self (e : r ≃r s) : e.symm.trans e = .refl _ := ext <| by simp
+@[simp] lemma self_trans_symm (e : r ≃r s) : e.trans e.symm = .refl _ := ext <| by simp
+
+lemma trans_assoc {δ : Type*} {u : δ → δ → Prop} (ab : r ≃r s) (bc : s ≃r t) (cd : t ≃r u) :
+    (ab.trans bc).trans cd = ab.trans (bc.trans cd) := rfl
+
 /-- A relation isomorphism between equal relations on equal types. -/
 @[simps! toEquiv apply]
 protected def cast {α β : Type u} {r : α → α → Prop} {s : β → β → Prop} (h₁ : α = β)
@@ -652,27 +687,11 @@ protected def compl (f : r ≃r s) : rᶜ ≃r sᶜ :=
 theorem coe_fn_symm_mk (f o) : ((@RelIso.mk _ _ r s f @o).symm : β → α) = f.symm :=
   rfl
 
-@[simp]
-theorem apply_symm_apply (e : r ≃r s) (x : β) : e (e.symm x) = x :=
-  e.toEquiv.apply_symm_apply x
-
-@[simp]
-theorem symm_apply_apply (e : r ≃r s) (x : α) : e.symm (e x) = x :=
-  e.toEquiv.symm_apply_apply x
-
 theorem rel_symm_apply (e : r ≃r s) {x y} : r x (e.symm y) ↔ s (e x) y := by
   rw [← e.map_rel_iff, e.apply_symm_apply]
 
 theorem symm_apply_rel (e : r ≃r s) {x y} : r (e.symm x) y ↔ s x (e y) := by
   rw [← e.map_rel_iff, e.apply_symm_apply]
-
-@[simp]
-theorem self_trans_symm (e : r ≃r s) : e.trans e.symm = RelIso.refl r :=
-  ext e.symm_apply_apply
-
-@[simp]
-theorem symm_trans_self (e : r ≃r s) : e.symm.trans e = RelIso.refl s :=
-  ext e.apply_symm_apply
 
 protected theorem bijective (e : r ≃r s) : Bijective e :=
   e.toEquiv.bijective

--- a/Mathlib/Order/SemiconjSup.lean
+++ b/Mathlib/Order/SemiconjSup.lean
@@ -4,10 +4,10 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury Kudryashov
 -/
 import Mathlib.Algebra.Group.Units.Equiv
+import Mathlib.Algebra.Order.Group.End
 import Mathlib.Logic.Function.Conjugate
 import Mathlib.Order.Bounds.OrderIso
 import Mathlib.Order.OrdContinuous
-import Mathlib.Order.RelIso.Group
 
 /-!
 # Semiconjugate by `sSup`


### PR DESCRIPTION
`Order.RelIso.Group` imports algebra, hence should be under `Algebra`


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
