### PR TITLE
[Merged by Bors] - fix(CI): adapt to new olean path

### DIFF
--- a/.github/build.in.yml
+++ b/.github/build.in.yml
@@ -153,7 +153,7 @@ jobs:
 
       - name: print the sizes of the oleans
         run: |
-          du .lake/build/lib/Mathlib || echo "This code should be unreachable"
+          du .lake/build/lib/lean/Mathlib || echo "This code should be unreachable"
 
       - name: upload cache
         # We only upload the cache if the build started (whether succeeding, failing, or cancelled)

--- a/.github/build.in.yml
+++ b/.github/build.in.yml
@@ -153,7 +153,9 @@ jobs:
 
       - name: print the sizes of the oleans
         run: |
-          du .lake/build/lib/lean/Mathlib || echo "This code should be unreachable"
+          du .lake/build/lib/lean/Mathlib ||
+            # This path was the correct path before v4.18: it is here just for compatibility reasons
+            du .lake/build/lib/Mathlib || echo "This code should be unreachable"
 
       - name: upload cache
         # We only upload the cache if the build started (whether succeeding, failing, or cancelled)

--- a/.github/build.in.yml
+++ b/.github/build.in.yml
@@ -126,7 +126,9 @@ jobs:
       - name: get cache
         id: get
         run: |
-          rm -rf .lake/build/lib/lean/Mathlib .lake/build/lib/Mathlib/
+          rm -rf .lake/build/lib/lean/Mathlib
+          # useful pre v4.18: the following command is only present for compatibility reasons
+          rm -rf .lake/build/lib/Mathlib/
           # Fail quickly if the cache is completely cold, by checking for Mathlib.Init
           lake exe cache get Mathlib/Init.lean
           lake build --no-build Mathlib.Init && lake exe cache get || echo "No cache for 'Mathlib.Init' available"

--- a/.github/build.in.yml
+++ b/.github/build.in.yml
@@ -126,7 +126,7 @@ jobs:
       - name: get cache
         id: get
         run: |
-          rm -rf .lake/build/lib/Mathlib/
+          rm -rf .lake/build/lib/lean/Mathlib .lake/build/lib/Mathlib/
           # Fail quickly if the cache is completely cold, by checking for Mathlib.Init
           lake exe cache get Mathlib/Init.lean
           lake build --no-build Mathlib.Init && lake exe cache get || echo "No cache for 'Mathlib.Init' available"

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -163,7 +163,9 @@ jobs:
 
       - name: print the sizes of the oleans
         run: |
-          du .lake/build/lib/lean/Mathlib || echo "This code should be unreachable"
+          du .lake/build/lib/lean/Mathlib ||
+            # This path was the correct path before v4.18: it is here just for compatibility reasons
+            du .lake/build/lib/Mathlib || echo "This code should be unreachable"
 
       - name: upload cache
         # We only upload the cache if the build started (whether succeeding, failing, or cancelled)

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -163,7 +163,7 @@ jobs:
 
       - name: print the sizes of the oleans
         run: |
-          du .lake/build/lib/Mathlib || echo "This code should be unreachable"
+          du .lake/build/lib/lean/Mathlib || echo "This code should be unreachable"
 
       - name: upload cache
         # We only upload the cache if the build started (whether succeeding, failing, or cancelled)

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -136,7 +136,9 @@ jobs:
       - name: get cache
         id: get
         run: |
-          rm -rf .lake/build/lib/lean/Mathlib .lake/build/lib/Mathlib/
+          rm -rf .lake/build/lib/lean/Mathlib
+          # useful pre v4.18: the following command is only present for compatibility reasons
+          rm -rf .lake/build/lib/Mathlib/
           # Fail quickly if the cache is completely cold, by checking for Mathlib.Init
           lake exe cache get Mathlib/Init.lean
           lake build --no-build Mathlib.Init && lake exe cache get || echo "No cache for 'Mathlib.Init' available"

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -136,7 +136,7 @@ jobs:
       - name: get cache
         id: get
         run: |
-          rm -rf .lake/build/lib/Mathlib/
+          rm -rf .lake/build/lib/lean/Mathlib .lake/build/lib/Mathlib/
           # Fail quickly if the cache is completely cold, by checking for Mathlib.Init
           lake exe cache get Mathlib/Init.lean
           lake build --no-build Mathlib.Init && lake exe cache get || echo "No cache for 'Mathlib.Init' available"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -170,7 +170,7 @@ jobs:
 
       - name: print the sizes of the oleans
         run: |
-          du .lake/build/lib/Mathlib || echo "This code should be unreachable"
+          du .lake/build/lib/lean/Mathlib || echo "This code should be unreachable"
 
       - name: upload cache
         # We only upload the cache if the build started (whether succeeding, failing, or cancelled)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -143,7 +143,9 @@ jobs:
       - name: get cache
         id: get
         run: |
-          rm -rf .lake/build/lib/lean/Mathlib .lake/build/lib/Mathlib/
+          rm -rf .lake/build/lib/lean/Mathlib
+          # useful pre v4.18: the following command is only present for compatibility reasons
+          rm -rf .lake/build/lib/Mathlib/
           # Fail quickly if the cache is completely cold, by checking for Mathlib.Init
           lake exe cache get Mathlib/Init.lean
           lake build --no-build Mathlib.Init && lake exe cache get || echo "No cache for 'Mathlib.Init' available"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -170,7 +170,9 @@ jobs:
 
       - name: print the sizes of the oleans
         run: |
-          du .lake/build/lib/lean/Mathlib || echo "This code should be unreachable"
+          du .lake/build/lib/lean/Mathlib ||
+            # This path was the correct path before v4.18: it is here just for compatibility reasons
+            du .lake/build/lib/Mathlib || echo "This code should be unreachable"
 
       - name: upload cache
         # We only upload the cache if the build started (whether succeeding, failing, or cancelled)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -143,7 +143,7 @@ jobs:
       - name: get cache
         id: get
         run: |
-          rm -rf .lake/build/lib/Mathlib/
+          rm -rf .lake/build/lib/lean/Mathlib .lake/build/lib/Mathlib/
           # Fail quickly if the cache is completely cold, by checking for Mathlib.Init
           lake exe cache get Mathlib/Init.lean
           lake build --no-build Mathlib.Init && lake exe cache get || echo "No cache for 'Mathlib.Init' available"

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -140,7 +140,9 @@ jobs:
       - name: get cache
         id: get
         run: |
-          rm -rf .lake/build/lib/lean/Mathlib .lake/build/lib/Mathlib/
+          rm -rf .lake/build/lib/lean/Mathlib
+          # useful pre v4.18: the following command is only present for compatibility reasons
+          rm -rf .lake/build/lib/Mathlib/
           # Fail quickly if the cache is completely cold, by checking for Mathlib.Init
           lake exe cache get Mathlib/Init.lean
           lake build --no-build Mathlib.Init && lake exe cache get || echo "No cache for 'Mathlib.Init' available"

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -140,7 +140,7 @@ jobs:
       - name: get cache
         id: get
         run: |
-          rm -rf .lake/build/lib/Mathlib/
+          rm -rf .lake/build/lib/lean/Mathlib .lake/build/lib/Mathlib/
           # Fail quickly if the cache is completely cold, by checking for Mathlib.Init
           lake exe cache get Mathlib/Init.lean
           lake build --no-build Mathlib.Init && lake exe cache get || echo "No cache for 'Mathlib.Init' available"

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -167,7 +167,9 @@ jobs:
 
       - name: print the sizes of the oleans
         run: |
-          du .lake/build/lib/lean/Mathlib || echo "This code should be unreachable"
+          du .lake/build/lib/lean/Mathlib ||
+            # This path was the correct path before v4.18: it is here just for compatibility reasons
+            du .lake/build/lib/Mathlib || echo "This code should be unreachable"
 
       - name: upload cache
         # We only upload the cache if the build started (whether succeeding, failing, or cancelled)

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -167,7 +167,7 @@ jobs:
 
       - name: print the sizes of the oleans
         run: |
-          du .lake/build/lib/Mathlib || echo "This code should be unreachable"
+          du .lake/build/lib/lean/Mathlib || echo "This code should be unreachable"
 
       - name: upload cache
         # We only upload the cache if the build started (whether succeeding, failing, or cancelled)


### PR DESCRIPTION
The path where the oleans are stored appears to be contained inside an extra `lean` layer.

Reported on [Zulip](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Error.20in.20CI.20step.20.22print.20sizes.20of.20oleans.22)

As mentioned below, this is a consequence of [lean4#7001](https://github.com/leanprover/lean4/pull/7001).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
