### PR TITLE
[Merged by Bors] - feat(GroupTheory/OrderOfElement): add `IsConj.isOfFinOrder`

### DIFF
--- a/Mathlib/Algebra/Group/Conj.lean
+++ b/Mathlib/Algebra/Group/Conj.lean
@@ -6,6 +6,7 @@ Authors: Patrick Massot, Chris Hughes, Michael Howes
 import Mathlib.Algebra.Group.End
 import Mathlib.Algebra.Group.Semiconj.Units
 
+import Mathlib.Tactic.ApplyFun
 /-!
 # Conjugacy of group elements
 
@@ -41,6 +42,9 @@ theorem isConj_comm {g h : α} : IsConj g h ↔ IsConj h g :=
 theorem IsConj.trans {a b c : α} : IsConj a b → IsConj b c → IsConj a c
   | ⟨c₁, hc₁⟩, ⟨c₂, hc₂⟩ => ⟨c₂ * c₁, hc₂.mul_left hc₁⟩
 
+theorem IsConj.pow {a b : α} (n : ℕ) : IsConj a b → IsConj (a^n) (b^n)
+  | ⟨c, hc⟩ => ⟨c, SemiconjBy.pow_right hc n⟩
+
 @[simp]
 theorem isConj_iff_eq {α : Type*} [CommMonoid α] {a b : α} : IsConj a b ↔ a = b :=
   ⟨fun ⟨c, hc⟩ => by
@@ -50,19 +54,16 @@ theorem isConj_iff_eq {α : Type*} [CommMonoid α] {a b : α} : IsConj a b ↔ a
 protected theorem MonoidHom.map_isConj (f : α →* β) {a b : α} : IsConj a b → IsConj (f a) (f b)
   | ⟨c, hc⟩ => ⟨Units.map f c, by rw [Units.coe_map, SemiconjBy, ← f.map_mul, hc.eq, f.map_mul]⟩
 
-end Monoid
-
-section CancelMonoid
-
-variable [CancelMonoid α]
-
--- These lemmas hold for `RightCancelMonoid` with the current proofs, but for the sake of
--- not duplicating code (these lemmas also hold for `LeftCancelMonoids`) we leave these
--- not generalised.
 @[simp]
-theorem isConj_one_right {a : α} : IsConj 1 a ↔ a = 1 :=
-  ⟨fun ⟨_, hc⟩ => mul_right_cancel (hc.symm.trans ((mul_one _).trans (one_mul _).symm)), fun h => by
-    rw [h]⟩
+theorem isConj_one_right {a : α} : IsConj 1 a ↔ a = 1 := by
+  constructor
+  · rintro ⟨⟨w, w', val_inv⟩, h⟩
+    unfold SemiconjBy at h
+    simp only [mul_one] at h
+    apply_fun (fun x ↦ x * w') at h
+    symm
+    simpa [val_inv, mul_assoc] using h
+  · exact fun h => by rw [h]
 
 @[simp]
 theorem isConj_one_left {a : α} : IsConj a 1 ↔ a = 1 :=
@@ -70,7 +71,7 @@ theorem isConj_one_left {a : α} : IsConj a 1 ↔ a = 1 :=
     IsConj a 1 ↔ IsConj 1 a := ⟨IsConj.symm, IsConj.symm⟩
     _ ↔ a = 1 := isConj_one_right
 
-end CancelMonoid
+end Monoid
 
 section Group
 

--- a/Mathlib/Algebra/Group/Conj.lean
+++ b/Mathlib/Algebra/Group/Conj.lean
@@ -57,7 +57,7 @@ protected theorem MonoidHom.map_isConj (f : α →* β) {a b : α} : IsConj a b 
 theorem isConj_one_right {a : α} : IsConj 1 a ↔ a = 1 := by
   refine ⟨fun ⟨c, h⟩ => ?_, fun h => by rw [h]⟩
   rw [SemiconjBy, mul_one] at h
-  exact Units.mul_eq_left.mp h.symm
+  exact c.isUnit.mul_eq_left.mp h.symm
 
 @[simp]
 theorem isConj_one_left {a : α} : IsConj a 1 ↔ a = 1 :=

--- a/Mathlib/Algebra/Group/Conj.lean
+++ b/Mathlib/Algebra/Group/Conj.lean
@@ -57,7 +57,7 @@ protected theorem MonoidHom.map_isConj (f : α →* β) {a b : α} : IsConj a b 
 theorem isConj_one_right {a : α} : IsConj 1 a ↔ a = 1 := by
   refine ⟨fun ⟨c, h⟩ => ?_, fun h => by rw [h]⟩
   rw [SemiconjBy, mul_one] at h
-  exact Units.mul_left_eq_self.mp h.symm
+  exact Units.mul_eq_left.mp h.symm
 
 @[simp]
 theorem isConj_one_left {a : α} : IsConj a 1 ↔ a = 1 :=

--- a/Mathlib/Algebra/Group/Conj.lean
+++ b/Mathlib/Algebra/Group/Conj.lean
@@ -42,7 +42,7 @@ theorem IsConj.trans {a b c : α} : IsConj a b → IsConj b c → IsConj a c
   | ⟨c₁, hc₁⟩, ⟨c₂, hc₂⟩ => ⟨c₂ * c₁, hc₂.mul_left hc₁⟩
 
 theorem IsConj.pow {a b : α} (n : ℕ) : IsConj a b → IsConj (a^n) (b^n)
-  | ⟨c, hc⟩ => ⟨c, SemiconjBy.pow_right hc n⟩
+  | ⟨c, hc⟩ => ⟨c, hc.pow_right n⟩
 
 @[simp]
 theorem isConj_iff_eq {α : Type*} [CommMonoid α] {a b : α} : IsConj a b ↔ a = b :=

--- a/Mathlib/Algebra/Group/Conj.lean
+++ b/Mathlib/Algebra/Group/Conj.lean
@@ -57,7 +57,7 @@ protected theorem MonoidHom.map_isConj (f : α →* β) {a b : α} : IsConj a b 
 theorem isConj_one_right {a : α} : IsConj 1 a ↔ a = 1 := by
   refine ⟨fun ⟨c, h⟩ => ?_, fun h => by rw [h]⟩
   rw [SemiconjBy, mul_one] at h
-  exact c.isUnit.mul_eq_left.mp h.symm
+  exact c.isUnit.mul_eq_right.mp h.symm
 
 @[simp]
 theorem isConj_one_left {a : α} : IsConj a 1 ↔ a = 1 :=

--- a/Mathlib/Algebra/Group/Conj.lean
+++ b/Mathlib/Algebra/Group/Conj.lean
@@ -6,7 +6,6 @@ Authors: Patrick Massot, Chris Hughes, Michael Howes
 import Mathlib.Algebra.Group.End
 import Mathlib.Algebra.Group.Semiconj.Units
 
-import Mathlib.Tactic.ApplyFun
 /-!
 # Conjugacy of group elements
 
@@ -56,14 +55,9 @@ protected theorem MonoidHom.map_isConj (f : α →* β) {a b : α} : IsConj a b 
 
 @[simp]
 theorem isConj_one_right {a : α} : IsConj 1 a ↔ a = 1 := by
-  constructor
-  · rintro ⟨⟨w, w', val_inv⟩, h⟩
-    unfold SemiconjBy at h
-    simp only [mul_one] at h
-    apply_fun (fun x ↦ x * w') at h
-    symm
-    simpa [val_inv, mul_assoc] using h
-  · exact fun h => by rw [h]
+  refine ⟨fun ⟨c, h⟩ => ?_, fun h => by rw [h]⟩
+  rw [SemiconjBy, mul_one] at h
+  exact Units.mul_left_eq_self.mp h.symm
 
 @[simp]
 theorem isConj_one_left {a : α} : IsConj a 1 ↔ a = 1 :=

--- a/Mathlib/Algebra/Group/Units/Basic.lean
+++ b/Mathlib/Algebra/Group/Units/Basic.lean
@@ -113,6 +113,16 @@ theorem mul_eq_one_iff_inv_eq {a : α} : ↑u * a = 1 ↔ ↑u⁻¹ = a := by rw
 theorem inv_unique {u₁ u₂ : αˣ} (h : (↑u₁ : α) = ↑u₂) : (↑u₁⁻¹ : α) = ↑u₂⁻¹ :=
   Units.inv_eq_of_mul_eq_one_right <| by rw [h, u₂.mul_inv]
 
+@[to_additive]
+theorem mul_left_eq_self {a : α} {c : αˣ} : a * c = c ↔ a = 1 := calc
+  a * c = c ↔ a * c = 1 * c := by rw [one_mul]
+    _ ↔ a = 1 := by rw [Units.mul_left_inj]
+
+@[to_additive]
+theorem mul_right_eq_self {a : α} {c : αˣ} : c * a = c ↔ a = 1 := calc
+  c * a = c ↔ c * a = c * 1 := by rw [mul_one]
+    _ ↔ a = 1 := by rw [Units.mul_right_inj]
+
 end Monoid
 
 end Units

--- a/Mathlib/Algebra/Group/Units/Basic.lean
+++ b/Mathlib/Algebra/Group/Units/Basic.lean
@@ -114,12 +114,12 @@ theorem inv_unique {u₁ u₂ : αˣ} (h : (↑u₁ : α) = ↑u₂) : (↑u₁�
   Units.inv_eq_of_mul_eq_one_right <| by rw [h, u₂.mul_inv]
 
 @[to_additive]
-theorem mul_left_eq_self {a : α} {c : αˣ} : a * c = c ↔ a = 1 := calc
+theorem mul_eq_left {a : α} {c : αˣ} : a * c = c ↔ a = 1 := calc
   a * c = c ↔ a * c = 1 * c := by rw [one_mul]
     _ ↔ a = 1 := by rw [Units.mul_left_inj]
 
 @[to_additive]
-theorem mul_right_eq_self {a : α} {c : αˣ} : c * a = c ↔ a = 1 := calc
+theorem mul_eq_right {a : α} {c : αˣ} : c * a = c ↔ a = 1 := calc
   c * a = c ↔ c * a = c * 1 := by rw [mul_one]
     _ ↔ a = 1 := by rw [Units.mul_right_inj]
 

--- a/Mathlib/Algebra/Group/Units/Basic.lean
+++ b/Mathlib/Algebra/Group/Units/Basic.lean
@@ -113,16 +113,6 @@ theorem mul_eq_one_iff_inv_eq {a : α} : ↑u * a = 1 ↔ ↑u⁻¹ = a := by rw
 theorem inv_unique {u₁ u₂ : αˣ} (h : (↑u₁ : α) = ↑u₂) : (↑u₁⁻¹ : α) = ↑u₂⁻¹ :=
   Units.inv_eq_of_mul_eq_one_right <| by rw [h, u₂.mul_inv]
 
-@[to_additive]
-theorem mul_eq_left {a : α} {c : αˣ} : a * c = c ↔ a = 1 := calc
-  a * c = c ↔ a * c = 1 * c := by rw [one_mul]
-    _ ↔ a = 1 := by rw [Units.mul_left_inj]
-
-@[to_additive]
-theorem mul_eq_right {a : α} {c : αˣ} : c * a = c ↔ a = 1 := calc
-  c * a = c ↔ c * a = c * 1 := by rw [mul_one]
-    _ ↔ a = 1 := by rw [Units.mul_right_inj]
-
 end Monoid
 
 end Units
@@ -313,6 +303,16 @@ protected theorem mul_left_cancel (h : IsUnit a) : a * b = a * c → b = c :=
 @[to_additive]
 protected theorem mul_right_cancel (h : IsUnit b) : a * b = c * b → a = c :=
   h.mul_left_inj.1
+
+@[to_additive]
+theorem mul_eq_left (h : IsUnit b) : a * b = b ↔ a = 1 := calc
+  a * b = b ↔ a * b = 1 * b := by rw [one_mul]
+    _ ↔ a = 1 := by rw [h.mul_left_inj]
+
+@[to_additive]
+theorem mul_eq_right (h : IsUnit a) : a * b = a ↔ b = 1 := calc
+  a * b = a ↔ a * b = a * 1 := by rw [mul_one]
+    _ ↔ b = 1 := by rw [h.mul_right_inj]
 
 @[to_additive]
 protected theorem mul_right_injective (h : IsUnit a) : Injective (a * ·) :=

--- a/Mathlib/Algebra/Group/Units/Basic.lean
+++ b/Mathlib/Algebra/Group/Units/Basic.lean
@@ -305,12 +305,12 @@ protected theorem mul_right_cancel (h : IsUnit b) : a * b = c * b → a = c :=
   h.mul_left_inj.1
 
 @[to_additive]
-theorem mul_eq_left (h : IsUnit b) : a * b = b ↔ a = 1 := calc
+theorem mul_eq_right (h : IsUnit b) : a * b = b ↔ a = 1 := calc
   a * b = b ↔ a * b = 1 * b := by rw [one_mul]
     _ ↔ a = 1 := by rw [h.mul_left_inj]
 
 @[to_additive]
-theorem mul_eq_right (h : IsUnit a) : a * b = a ↔ b = 1 := calc
+theorem mul_eq_left (h : IsUnit a) : a * b = a ↔ b = 1 := calc
   a * b = a ↔ a * b = a * 1 := by rw [mul_one]
     _ ↔ b = 1 := by rw [h.mul_right_inj]
 

--- a/Mathlib/GroupTheory/OrderOfElement.lean
+++ b/Mathlib/GroupTheory/OrderOfElement.lean
@@ -131,7 +131,7 @@ theorem Submonoid.isOfFinOrder_coe {H : Submonoid G} {x : H} :
 theorem IsConj.isOfFinOrder (h : IsConj x y) : IsOfFinOrder x → IsOfFinOrder y := by
   simp_rw [isOfFinOrder_iff_pow_eq_one]
   rintro ⟨n, n_gt_0, eq'⟩
-  exact ⟨n, n_gt_0, by rw [← isConj_one_right, ← eq'] ; exact h.pow n⟩
+  exact ⟨n, n_gt_0, by rw [← isConj_one_right, ← eq']; exact h.pow n⟩
 
 /-- The image of an element of finite order has finite order. -/
 @[to_additive "The image of an element of finite additive order has finite additive order."]

--- a/Mathlib/GroupTheory/OrderOfElement.lean
+++ b/Mathlib/GroupTheory/OrderOfElement.lean
@@ -128,6 +128,11 @@ theorem Submonoid.isOfFinOrder_coe {H : Submonoid G} {x : H} :
   rw [isOfFinOrder_iff_pow_eq_one, isOfFinOrder_iff_pow_eq_one]
   norm_cast
 
+theorem IsConj.isOfFinOrder (h : IsConj x y) : IsOfFinOrder x → IsOfFinOrder y := by
+  simp_rw [isOfFinOrder_iff_pow_eq_one]
+  rintro ⟨n, n_gt_0, eq'⟩
+  exact ⟨n, n_gt_0, by rw [← isConj_one_right, ← eq'] ; exact h.pow n⟩
+
 /-- The image of an element of finite order has finite order. -/
 @[to_additive "The image of an element of finite additive order has finite additive order."]
 theorem MonoidHom.isOfFinOrder [Monoid H] (f : G →* H) {x : G} (h : IsOfFinOrder x) :


### PR DESCRIPTION
Upstreamed from the [EquationalTheories](https://github.com/teorth/equational_theories) project.

Adds the lemma `IsConj.isOfFinOrder` that finite order is invariant under conjugation. In order to prove this for general monoids, there are small adjustments in `Algebra/Group/Conj`: `IsConj.pow` is added and `isConj_one_right` / `isConj_one_left` are promoted from cancellative monoids to general monoids. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
