### PR TITLE
[Merged by Bors] - feat(Algebra/BigOperators): weaken `prod_map_neg` assumption

### DIFF
--- a/Mathlib/Algebra/BigOperators/Ring/List.lean
+++ b/Mathlib/Algebra/BigOperators/Ring/List.lean
@@ -37,7 +37,7 @@ end Commute
 
 namespace List
 section HasDistribNeg
-variable [CommMonoid M] [HasDistribNeg M]
+variable [Monoid M] [HasDistribNeg M]
 
 @[simp]
 lemma prod_map_neg (l : List M) :


### PR DESCRIPTION
Replace `CommMonoid M` assumption with `Monoid M` in `prod_map_neg`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
