### PR TITLE
[Merged by Bors] - doc(scripts): specify that `update_PR_comment` takes a file input

### DIFF
--- a/scripts/update_PR_comment.sh
+++ b/scripts/update_PR_comment.sh
@@ -23,7 +23,7 @@ comment_init="${2:-}"
 # But we do complain if the PR number is missing.
 PR="${3:-}"
 if [[ -z $PR ]]; then
-  echo "Usage: <new_message_file> <beginning_of_old_message> <pr_number>"
+  printf $'Please enter a valid PR number.\nUsage: <new_message_file> <beginning_of_old_message> <pr_number>'
   exit 1
 fi
 

--- a/scripts/update_PR_comment.sh
+++ b/scripts/update_PR_comment.sh
@@ -17,7 +17,7 @@ BASH_DOC_MODULE
 # If the first two arguments are missing, use the empty string as default value.
 
 # the file containing the text of the message that will replace the current one
-message="${1:-}"
+messageFile="${1:-}"
 # the start of the message to locate it among all messages in the PR
 comment_init="${2:-}"
 # But we do complain if the PR number is missing.
@@ -30,7 +30,7 @@ fi
 baseURL="https://api.github.com/repos/${GITHUB_REPOSITORY}/issues"
 printf 'Base url: %s\n' "${baseURL}"
 method="POST"
-if [[ -f "$message" ]]; then
+if [[ -f "$messageFile" ]]; then
     url="${baseURL}/${PR}/comments"
     printf 'Base url: %s\n' "${url}"
     headers="Authorization: token ${GITHUB_TOKEN}"
@@ -41,6 +41,6 @@ if [[ -f "$message" ]]; then
         url="${baseURL}/comments/${comment_id}"
         method="PATCH"
     fi
-    jq -Rs -n -c '{"body": inputs}' "${message}" > "${message}.json"
-    curl -s -S -H "Content-Type: application/json" -H "$headers" -X "$method" -d @"${message}.json" "$url"
+    jq -Rs -n -c '{"body": inputs}' "${messageFile}" > "${messageFile}.json"
+    curl -s -S -H "Content-Type: application/json" -H "$headers" -X "$method" -d @"${messageFile}.json" "$url"
 fi

--- a/scripts/update_PR_comment.sh
+++ b/scripts/update_PR_comment.sh
@@ -9,7 +9,7 @@ IFS=$'\n\t'
 This script takes care of maintaining and updating the first message that starts with a given string in a PR.
 It takes 3 inputs:
 
-1. the new message;
+1. the path of a file containing the new message;
 2. the beginning of the message, to identify whether to create a new or update an existing message;
 3. the PR number.
 BASH_DOC_MODULE


### PR DESCRIPTION
The `update_PR_comment` script changed from taking a `string` input to taking a `file_path` input, but the docs did not entirely align with the change.

This PR rectifies the situation.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
