### PR TITLE
[Merged by Bors] - feat: WithBot.insertBot

### DIFF
--- a/Mathlib/Order/Hom/Basic.lean
+++ b/Mathlib/Order/Hom/Basic.lean
@@ -1202,6 +1202,12 @@ theorem coe_toDualTopEquiv_eq [LE α] :
     (WithBot.toDualTopEquiv : WithBot αᵒᵈ → (WithTop α)ᵒᵈ) = toDual ∘ WithBot.ofDual :=
   funext fun _ => rfl
 
+/-- Embedding into `WithBot α`. -/
+@[simps]
+def _root_.Function.Embedding.coeWithBot : α ↪ WithBot α where
+  toFun := (↑)
+  inj' := WithBot.coe_injective
+
 /-- The coercion `α → WithBot α` bundled as monotone map. -/
 @[simps]
 def coeOrderHom {α : Type*} [Preorder α] : α ↪o WithBot α where

--- a/Mathlib/Order/Interval/Finset/Defs.lean
+++ b/Mathlib/Order/Interval/Finset/Defs.lean
@@ -949,7 +949,7 @@ theorem some_mem_insertBot {s : Finset α} {a : α} : ↑a ∈ insertBot s ↔ a
   simp [insertBot]
 
 @[simp]
-theorem top_mem_insertTop {s : Finset α} : ⊥ ∈ insertBot s := by
+theorem bot_mem_insertBot {s : Finset α} : ⊥ ∈ insertBot s := by
   simp [insertBot]
 
 variable (α) [PartialOrder α] [OrderBot α] [LocallyFiniteOrder α]

--- a/Mathlib/Order/Interval/Finset/Defs.lean
+++ b/Mathlib/Order/Interval/Finset/Defs.lean
@@ -859,7 +859,6 @@ Adding a `⊥` to a locally finite `OrderBot` keeps it locally finite.
 
 namespace WithTop
 
--- TODO: WithBot variant
 /-- Given a finset on `α`, lift it to being a finset on `WithTop α`
 using `WithTop.some` and then insert `⊤`. -/
 def insertTop : Finset α ↪o Finset (WithTop α) :=
@@ -937,6 +936,21 @@ theorem Ioo_coe_coe : Ioo (a : WithTop α) b = (Ioo a b).map Embedding.some :=
 end WithTop
 
 namespace WithBot
+
+/-- Given a finset on `α`, lift it to being a finset on `WithBot α`
+using `WithBot.some` and then insert `⊥`. -/
+def insertBot : Finset α ↪o Finset (WithBot α) :=
+  OrderEmbedding.ofMapLEIff
+    (fun s => cons ⊥ (s.map Embedding.coeWithBot) <| by simp)
+    (fun s t => by rw [le_iff_subset, cons_subset_cons, map_subset_map, le_iff_subset])
+
+@[simp]
+theorem some_mem_insertBot {s : Finset α} {a : α} : ↑a ∈ insertBot s ↔ a ∈ s := by
+  simp [insertBot]
+
+@[simp]
+theorem top_mem_insertTop {s : Finset α} : ⊥ ∈ insertBot s := by
+  simp [insertBot]
 
 variable (α) [PartialOrder α] [OrderBot α] [LocallyFiniteOrder α]
 


### PR DESCRIPTION
This PR adds `WithBot.insertBot`, which was not added in #22477.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
