### PR TITLE
[Merged by Bors] - feat: basic toolchain dashboard for downstream projects

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -14,7 +14,7 @@ to learn about it as well!
   https://leanprover-community.github.io/install/macos.html
   If these web pages are deprecated or removed, we should remove these scripts.
 
-**Tool for manual maintenance**
+**Tools for manual maintenance**
 - `fix_unused.py`
   Bulk processing of unused variable warnings, replacing them with `_`.
 - `add_deprecations.sh` is a text-based script that automatically adds deprecation statements.
@@ -71,6 +71,11 @@ to learn about it as well!
   and attempts to merge the branch `lean-pr-testing-NNNN` into `master`.
   It will resolve conflicts in `lean-toolchain`, `lakefile.lean`, and `lake-manifest.json`.
   If there are more conflicts, it will bail.
+
+**Managing downstream repos**
+- `downstream_repos.yml` contains basic information about significant downstream repositories.
+- `downstream-tags.py` is a script to check whether a given tag exists on the downstream
+  repositories listed in `downstream_repos.yml`.
 
 **Managing and tracking technical debt**
 - `technical-debt-metrics.sh`

--- a/scripts/downstream-tags.py
+++ b/scripts/downstream-tags.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+
+import yaml
+import sys
+import subprocess
+import re
+from typing import List, Dict, Optional
+
+# Unicode symbols
+TICK = "✅"   # Check mark button
+CROSS = "❌"  # Cross mark
+
+def load_repos() -> List[Dict[str, str]]:
+    """Load repository information from downstream_repos.yml"""
+    with open('scripts/downstream_repos.yml', 'r') as f:
+        return yaml.safe_load(f)
+
+def check_tag(repo: Dict[str, str], tag: str) -> bool:
+    """Check if a tag exists in a repository using GitHub CLI"""
+    github_url = repo['github']
+    repo_name = github_url.replace('https://github.com/', '')
+
+    try:
+        result = subprocess.run(
+            ['gh', 'api', f'repos/{repo_name}/git/refs/tags/{tag}'],
+            capture_output=True,
+            text=True
+        )
+        return result.returncode == 0
+    except subprocess.CalledProcessError:
+        return False
+
+def get_latest_version(repo: Dict[str, str]) -> Optional[str]:
+    """Get the latest version tag from a repository"""
+    github_url = repo['github']
+    repo_name = github_url.replace('https://github.com/', '')
+
+    try:
+        result = subprocess.run(
+            ['gh', 'api', f'repos/{repo_name}/git/refs/tags'],
+            capture_output=True,
+            text=True
+        )
+        if result.returncode != 0:
+            return None
+
+        # Parse JSON response
+        import json
+        tags = json.loads(result.stdout)
+
+        # Extract tag names and filter for version tags
+        version_pattern = re.compile(r'v4\.\d+\.\d+(?:-rc\d+)?$')
+        version_tags = []
+
+        for tag in tags:
+            ref = tag['ref']
+            tag_name = ref.replace('refs/tags/', '')
+            if version_pattern.match(tag_name):
+                version_tags.append(tag_name)
+
+        if not version_tags:
+            return None
+
+        # Sort version tags
+        def version_key(tag):
+            # Split into parts: v4.17.0-rc1 -> [4, 17, 0, 1]
+            parts = tag[1:].split('.')  # Remove 'v' prefix
+            major, minor = parts[0:2]
+            patch_rc = parts[2].split('-')
+            patch = int(patch_rc[0])
+            # RC versions should sort before final versions
+            rc = int(patch_rc[1][2:]) if len(patch_rc) > 1 else float('inf')
+            return (int(major), int(minor), patch, rc)
+
+        return max(version_tags, key=version_key)
+    except Exception as e:
+        print(f"Error fetching tags for {repo['name']}: {e}", file=sys.stderr)
+        return None
+
+def main():
+    repos = load_repos()
+
+    if len(sys.argv) == 1:
+        # No argument provided - get latest version
+        print("Finding latest version tags in downstream repositories:")
+        print("-" * 50)
+
+        latest_versions = []
+        for repo in repos:
+            latest = get_latest_version(repo)
+            status = TICK if latest else CROSS
+            version_str = latest if latest else "No matching version found"
+            print(f"{status} {repo['name']}: {version_str}")
+            if latest:
+                latest_versions.append(latest)
+
+        if latest_versions:
+            def version_key(tag):
+                # Split into parts: v4.17.0-rc1 -> [4, 17, 0, 1]
+                parts = tag[1:].split('.')  # Remove 'v' prefix
+                major, minor = parts[0:2]
+                patch_rc = parts[2].split('-')
+                patch = int(patch_rc[0])
+                # RC versions should sort before final versions
+                rc = int(patch_rc[1][2:]) if len(patch_rc) > 1 else float('inf')
+                return (int(major), int(minor), patch, rc)
+
+        sys.exit(0 if latest_versions else 1)
+
+    elif len(sys.argv) == 2:
+        # Check specific tag
+        tag = sys.argv[1]
+        print(f"Checking for tag {tag} in downstream repositories:")
+        print("-" * 50)
+
+        all_exist = True
+        for repo in repos:
+            exists = check_tag(repo, tag)
+            status = TICK if exists else CROSS
+            print(f"{status} {repo['name']}")
+            if not exists:
+                all_exist = False
+
+        sys.exit(0 if all_exist else 1)
+
+    else:
+        print("Usage: ./downstream-tags.py [tag]")
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/scripts/downstream-tags.py
+++ b/scripts/downstream-tags.py
@@ -7,10 +7,18 @@ import re
 from typing import List, Dict, Optional
 import json
 import base64
+import shutil
 
 # Unicode symbols
 TICK = "✅"   # Check mark button
 CROSS = "❌"  # Cross mark
+
+def check_gh_installed():
+    """Check if GitHub CLI (gh) is installed and accessible"""
+    if not shutil.which('gh'):
+        print("Error: GitHub CLI (gh) is not installed or not in PATH", file=sys.stderr)
+        print("Please install it from https://cli.github.com/", file=sys.stderr)
+        sys.exit(1)
 
 def load_repos() -> List[Dict[str, str]]:
     """Load repository information from downstream_repos.yml"""
@@ -133,6 +141,9 @@ def get_current_toolchain(repo: Dict[str, str]) -> Optional[str]:
         return None
 
 def main():
+    # Add gh check at the start of main
+    check_gh_installed()
+
     repos = load_repos()
 
     if len(sys.argv) == 1:

--- a/scripts/downstream_repos.yml
+++ b/scripts/downstream_repos.yml
@@ -1,0 +1,22 @@
+# This file contains basic information about significant downstream repositories.
+# It is used by the `downstream-tags.py` script to check whether a given tag exists on the
+# downstream repositories.
+
+- github: https://github.com/ImperialCollegeLondon/FLT
+  default_branch: main
+  name: Fermat's Last Theorem
+- github: https://github.com/fpvandoorn/carleson
+  default_branch: master
+  name: Carleson operators on doubling metric measure spaces
+- github: https://github.com/emilyriehl/infinity-cosmos
+  default_branch: main
+  name: ∞-Cosmos
+- github: https://github.com/teorth/pfr
+  default_branch: master
+  name: The Polynomial Freiman-Ruzsa Conjecture
+- github: https://github.com/AlexKontorovich/PrimeNumberTheoremAnd
+  default_branch: main
+  name: Prime Number Theorem and ...
+- github: https://github.com/leanprover-community/sphere-eversion
+  default_branch: master
+  name: The sphere eversion project

--- a/scripts/downstream_repos.yml
+++ b/scripts/downstream_repos.yml
@@ -20,3 +20,12 @@
 - github: https://github.com/leanprover-community/sphere-eversion
   default_branch: master
   name: The sphere eversion project
+- github: https://github.com/YaelDillies/LeanCamCombi
+  default_branch: master
+  name: Cambridge Combinatorics in Lean
+- github: https://github.com/YaelDillies/add-combi
+  default_branch: master
+  name: add-combi
+- github: https://github.com/vihdzp/combinatorial-games
+  default_branch: master
+  name: Combinatorial Games in Lean


### PR DESCRIPTION
The Mathlib ecosystem is growing up, and we will increasingly need tools to track and manage compatibility between projects. Here's a start:

```
% scripts/downstream-tags.py
Finding latest version tags in downstream repositories:
--------------------------------------------------
✅ Fermat's Last Theorem: v4.17.0-rc1
✅ Carleson operators on doubling metric measure spaces: v4.17.0-rc1
✅ ∞-Cosmos: v4.18.0-rc1
❌ The Polynomial Freiman-Ruzsa Conjecture: no toolchain tags found (master branch is on v4.17.0-rc1)
❌ Prime Number Theorem and ...: no toolchain tags found (main branch is on v4.16.0)
❌ The sphere eversion project: no toolchain tags found (master branch is on v4.17.0-rc1)
❌ Cambridge Combinatorics in Lean: no toolchain tags found (master branch is on v4.17.0-rc1)
❌ add-combi: no toolchain tags found (master branch is on v4.17.0-rc1)
❌ Combinatorial Games in Lean: no toolchain tags found (master branch is on v4.17.0-rc1)
```
You can also enquire about a particular toolchain:
```
% scripts/downstream-tags.py v4.17.0-rc1          
Checking for tag v4.17.0-rc1 in downstream repositories:
--------------------------------------------------
✅ Fermat's Last Theorem
✅ Carleson operators on doubling metric measure spaces
✅ ∞-Cosmos
❌ The Polynomial Freiman-Ruzsa Conjecture
    - There is a commit which uses this toolchain. You can tag it using:
    gh api repos/teorth/pfr/git/refs -X POST -F ref=refs/tags/v4.17.0-rc1 -F sha=09e1451c0bc4c687c04f81880443741c89d0c9ed
❌ Prime Number Theorem and ...
    - No matching toolchain found in history
❌ The sphere eversion project
    - There is a commit which uses this toolchain. You can tag it using:
    gh api repos/leanprover-community/sphere-eversion/git/refs -X POST -F ref=refs/tags/v4.17.0-rc1 -F sha=93e3595509c1b82b4419df2917645c035559965c
❌ Cambridge Combinatorics in Lean
    - There is a commit which uses this toolchain. You can tag it using:
    gh api repos/YaelDillies/LeanCamCombi/git/refs -X POST -F ref=refs/tags/v4.17.0-rc1 -F sha=d140052407e5e4aa956626f8be0cd70898815991
❌ add-combi
    - There is a commit which uses this toolchain. You can tag it using:
    gh api repos/YaelDillies/add-combi/git/refs -X POST -F ref=refs/tags/v4.17.0-rc1 -F sha=45d91581017ed82bc3a85cf50ca1f15b1a48d964
❌ Combinatorial Games in Lean
    - There is a commit which uses this toolchain. You can tag it using:
    gh api repos/vihdzp/combinatorial-games/git/refs -X POST -F ref=refs/tags/v4.17.0-rc1 -F sha=951a3dc866a2a25ac78da17aac0316b313deaf05
```

This is based on a `scripts/downstream_repos.yml` file to choose which repositories to look at. I appreciate that it is unclear that this information should be stored within Mathlib itself, and am open to other suggestions! I'm inclined to start here, iterate a bit, and then move out to a separate repo (and ideally stick a webpage around it).

(This is premature, but inclusion in this list should just be "active enough to promise to keep updating".)
