### PR TITLE
[Merged by Bors] - feat: corestrict an equivalence to a finset

### DIFF
--- a/Mathlib/Data/Finset/Pi.lean
+++ b/Mathlib/Data/Finset/Pi.lean
@@ -3,7 +3,8 @@ Copyright (c) 2018 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl
 -/
-import Mathlib.Data.Finset.Preimage
+import Mathlib.Data.Finset.Card
+ import Mathlib.Data.Finset.Union
 import Mathlib.Data.Multiset.Pi
 import Mathlib.Logic.Function.DependsOn
 
@@ -181,17 +182,6 @@ theorem restrict₂_comp_restrict₂ {s t u : Finset ι} (hst : s ⊆ t) (htu : 
 
 lemma dependsOn_restrict (s : Finset ι) : DependsOn (s.restrict (π := π)) s :=
   (s : Set ι).dependsOn_restrict
-
-omit [DecidableEq (ι → α)] in
-/-- Reindexing and then restricting to a `Finset` is the same as first restricting to the preimage
-of this `Finset` and then reindexing. -/
-lemma restrict_comp_piCongrLeft (s : Finset α) (e : ι ≃ α) :
-    s.restrict ∘ ⇑(e.piCongrLeft β) =
-    ⇑((e.frestrict s).piCongrLeft (fun a : s ↦ (β a))) ∘
-    (s.preimage e e.injective.injOn).restrict := by
-  ext x b
-  simp only [comp_apply, restrict, Equiv.piCongrLeft_apply_eq_cast, cast_inj]
-  rfl
 
 end Pi
 

--- a/Mathlib/Data/Finset/Pi.lean
+++ b/Mathlib/Data/Finset/Pi.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl
 -/
 import Mathlib.Data.Finset.Card
+import Mathlib.Data.Finset.Preimage
 import Mathlib.Data.Finset.Union
 import Mathlib.Data.Multiset.Pi
 import Mathlib.Logic.Function.DependsOn
@@ -182,6 +183,17 @@ theorem restrict₂_comp_restrict₂ {s t u : Finset ι} (hst : s ⊆ t) (htu : 
 
 lemma dependsOn_restrict (s : Finset ι) : DependsOn (s.restrict (π := π)) s :=
   (s : Set ι).dependsOn_restrict
+
+omit [DecidableEq (ι → α)] in
+/-- Reindexing and then restricting to a `Finset` is the same as first restricting to the preimage
+of this `Finset` and then reindexing. -/
+lemma restrict_comp_piCongrLeft (s : Finset α) (e : ι ≃ α) :
+    s.restrict ∘ ⇑(e.piCongrLeft β) =
+    ⇑((e.frestrict s).piCongrLeft (fun a : s ↦ (β a))) ∘
+    (s.preimage e e.injective.injOn).restrict := by
+  ext x b
+  simp only [comp_apply, restrict, Equiv.piCongrLeft_apply_eq_cast, cast_inj]
+  rfl
 
 end Pi
 

--- a/Mathlib/Data/Finset/Pi.lean
+++ b/Mathlib/Data/Finset/Pi.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl
 -/
 import Mathlib.Data.Finset.Card
- import Mathlib.Data.Finset.Union
+import Mathlib.Data.Finset.Union
 import Mathlib.Data.Multiset.Pi
 import Mathlib.Logic.Function.DependsOn
 

--- a/Mathlib/Data/Finset/Pi.lean
+++ b/Mathlib/Data/Finset/Pi.lean
@@ -3,9 +3,7 @@ Copyright (c) 2018 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl
 -/
-import Mathlib.Data.Finset.Card
 import Mathlib.Data.Finset.Preimage
-import Mathlib.Data.Finset.Union
 import Mathlib.Data.Multiset.Pi
 import Mathlib.Logic.Function.DependsOn
 

--- a/Mathlib/Data/Finset/Preimage.lean
+++ b/Mathlib/Data/Finset/Preimage.lean
@@ -134,3 +134,23 @@ theorem sigma_image_fst_preimage_mk {β : α → Type*} [DecidableEq α] (s : Fi
 
 end Preimage
 end Finset
+
+namespace Equiv
+
+/-- Given an equivalence `e : α ≃ β` and `s : Finset β`, restrict `e` to an equivalence
+from `e ⁻¹' s` to `s`. -/
+def frestrict (e : α ≃ β) (s : Finset β) : (s.preimage e e.injective.injOn) ≃ s where
+  toFun := fun a ↦ ⟨e a, Finset.mem_preimage.1 a.2⟩
+  invFun := fun b ↦ ⟨e.symm b, by simp⟩
+  left_inv := fun _ ↦ by simp
+  right_inv := fun _ ↦ by simp
+
+variable {e : α ≃ β} {s : Finset β}
+
+@[simp]
+lemma frestrict_apply (a : s.preimage e e.injective.injOn) : e.frestrict s a = e a := rfl
+
+@[simp]
+lemma frestrict_symm_apply (b : s) : (e.frestrict s).symm b = e.symm b := rfl
+
+end Equiv

--- a/Mathlib/Data/Finset/Preimage.lean
+++ b/Mathlib/Data/Finset/Preimage.lean
@@ -3,6 +3,7 @@ Copyright (c) 2017 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Mario Carneiro
 -/
+import Mathlib.Data.Finset.Pi
 import Mathlib.Data.Finset.Sigma
 import Mathlib.Data.Finset.Sum
 import Mathlib.Data.Set.Finite.Basic
@@ -154,3 +155,13 @@ lemma frestrict_apply (a : s.preimage e e.injective.injOn) : e.frestrict s a = e
 lemma frestrict_symm_apply (b : s) : (e.frestrict s).symm b = e.symm b := rfl
 
 end Equiv
+
+/-- Reindexing and then restricting to a `Finset` is the same as first restricting to the preimage
+of this `Finset` and then reindexing. -/
+lemma Finset.restrict_comp_piCongrLeft {π : β → Type*} (s : Finset β) (e : α ≃ β) :
+    s.restrict ∘ ⇑(e.piCongrLeft π) =
+    ⇑((e.frestrict s).piCongrLeft (fun b : s ↦ (π b))) ∘
+    (s.preimage e e.injective.injOn).restrict := by
+  ext x b
+  simp only [comp_apply, restrict, Equiv.piCongrLeft_apply_eq_cast, cast_inj]
+  rfl

--- a/Mathlib/Data/Finset/Preimage.lean
+++ b/Mathlib/Data/Finset/Preimage.lean
@@ -141,7 +141,7 @@ namespace Equiv
 /-- Given an equivalence `e : α ≃ β` and `s : Finset β`, restrict `e` to an equivalence
 from `e ⁻¹' s` to `s`. -/
 @[simps]
-def frestrictPreimage (e : α ≃ β) (s : Finset β) : (s.preimage e e.injective.injOn) ≃ s where
+def restrictPreimageFinset (e : α ≃ β) (s : Finset β) : (s.preimage e e.injective.injOn) ≃ s where
   toFun := fun a ↦ ⟨e a, Finset.mem_preimage.1 a.2⟩
   invFun := fun b ↦ ⟨e.symm b, by simp⟩
   left_inv := fun _ ↦ by simp
@@ -153,7 +153,7 @@ end Equiv
 of this `Finset` and then reindexing. -/
 lemma Finset.restrict_comp_piCongrLeft {π : β → Type*} (s : Finset β) (e : α ≃ β) :
     s.restrict ∘ ⇑(e.piCongrLeft π) =
-    ⇑((e.frestrictPreimage s).piCongrLeft (fun b : s ↦ (π b))) ∘
+    ⇑((e.restrictPreimageFinset s).piCongrLeft (fun b : s ↦ (π b))) ∘
     (s.preimage e e.injective.injOn).restrict := by
   ext x b
   simp only [comp_apply, restrict, Equiv.piCongrLeft_apply_eq_cast, cast_inj]

--- a/Mathlib/Data/Finset/Preimage.lean
+++ b/Mathlib/Data/Finset/Preimage.lean
@@ -140,19 +140,12 @@ namespace Equiv
 
 /-- Given an equivalence `e : α ≃ β` and `s : Finset β`, restrict `e` to an equivalence
 from `e ⁻¹' s` to `s`. -/
+@[simps]
 def frestrict (e : α ≃ β) (s : Finset β) : (s.preimage e e.injective.injOn) ≃ s where
   toFun := fun a ↦ ⟨e a, Finset.mem_preimage.1 a.2⟩
   invFun := fun b ↦ ⟨e.symm b, by simp⟩
   left_inv := fun _ ↦ by simp
   right_inv := fun _ ↦ by simp
-
-variable {e : α ≃ β} {s : Finset β}
-
-@[simp]
-lemma frestrict_apply (a : s.preimage e e.injective.injOn) : e.frestrict s a = e a := rfl
-
-@[simp]
-lemma frestrict_symm_apply (b : s) : (e.frestrict s).symm b = e.symm b := rfl
 
 end Equiv
 

--- a/Mathlib/Data/Finset/Preimage.lean
+++ b/Mathlib/Data/Finset/Preimage.lean
@@ -141,7 +141,7 @@ namespace Equiv
 /-- Given an equivalence `e : α ≃ β` and `s : Finset β`, restrict `e` to an equivalence
 from `e ⁻¹' s` to `s`. -/
 @[simps]
-def frestrict (e : α ≃ β) (s : Finset β) : (s.preimage e e.injective.injOn) ≃ s where
+def frestrictPreimage (e : α ≃ β) (s : Finset β) : (s.preimage e e.injective.injOn) ≃ s where
   toFun := fun a ↦ ⟨e a, Finset.mem_preimage.1 a.2⟩
   invFun := fun b ↦ ⟨e.symm b, by simp⟩
   left_inv := fun _ ↦ by simp
@@ -153,7 +153,7 @@ end Equiv
 of this `Finset` and then reindexing. -/
 lemma Finset.restrict_comp_piCongrLeft {π : β → Type*} (s : Finset β) (e : α ≃ β) :
     s.restrict ∘ ⇑(e.piCongrLeft π) =
-    ⇑((e.frestrict s).piCongrLeft (fun b : s ↦ (π b))) ∘
+    ⇑((e.frestrictPreimage s).piCongrLeft (fun b : s ↦ (π b))) ∘
     (s.preimage e e.injective.injOn).restrict := by
   ext x b
   simp only [comp_apply, restrict, Equiv.piCongrLeft_apply_eq_cast, cast_inj]


### PR DESCRIPTION
Given an equivalence `e : α ≃ β` and `s : Finset β`, restrict `e` to an equivalence from `e ⁻¹' s` to `s`.

 ---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
