### PR TITLE
[Merged by Bors] - chore(Topology/Category): generalize `topCat_hasLimitsOfSize` to more universes

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -5720,6 +5720,7 @@ import Mathlib.Topology.Instances.RatLemmas
 import Mathlib.Topology.Instances.Real.Defs
 import Mathlib.Topology.Instances.Real.Lemmas
 import Mathlib.Topology.Instances.RealVectorSpace
+import Mathlib.Topology.Instances.Shrink
 import Mathlib.Topology.Instances.Sign
 import Mathlib.Topology.Instances.TrivSqZeroExt
 import Mathlib.Topology.Instances.ZMod

--- a/Mathlib/Topology/Category/TopCat/Limits/Basic.lean
+++ b/Mathlib/Topology/Category/TopCat/Limits/Basic.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Patrick Massot, Kim Morrison, Mario Carneiro, Andrew Yang
 -/
 import Mathlib.Topology.Category.TopCat.Adjunctions
+import Mathlib.Topology.Instances.Shrink
 import Mathlib.CategoryTheory.Limits.Types
 import Mathlib.CategoryTheory.Adjunction.Limits
 
@@ -44,6 +45,34 @@ def limitCone (F : J ⥤ TopCat.{max v u}) : Cone F where
         ext a
         exact (a.2 f).symm }
 
+instance (F : J ⥤ TopCat.{u}) : TopologicalSpace (F ⋙ forget).sections :=
+  inferInstanceAs <|
+    TopologicalSpace { u : ∀ j : J, F.obj j | ∀ {i j : J} (f : i ⟶ j), F.map f (u i) = u j }
+
+instance (F : J ⥤ TopCat.{u}) [Small.{u} (F ⋙ forget).sections]  :
+    TopologicalSpace (Types.Small.limitCone (F ⋙ forget)).pt :=
+  inferInstanceAs <| TopologicalSpace (Shrink (F ⋙ forget).sections)
+
+/--
+Implementation: A choice of limit cone for a functor `F : J ⥤ TopCat.{u}` with `J : Type v`. This
+is `(F ⋙ forget).sections` shrinked to universe `u`.
+Use `limit.cone F` instead.
+-/
+def Small.limitCone (F : J ⥤ TopCat.{u}) [Small.{u} (F ⋙ forget).sections] : Cone F where
+  pt := TopCat.of (Types.Small.limitCone (F ⋙ forget)).pt
+  π :=
+    { app j := ofHom
+        { toFun :=
+            (fun u ↦ u.val j) ∘ (Shrink.homeomorph.{u} (F ⋙ forget).sections).symm
+          continuous_toFun := by
+            apply Continuous.comp
+            · exact Continuous.comp (continuous_apply (π := fun j ↦ F.obj j) j)
+                (continuous_subtype_val)
+            · exact (Shrink.homeomorph.{u} (F ⋙ forget).sections).symm.continuous }
+      naturality X Y f := by
+        ext a
+        exact (((Shrink.homeomorph _).symm a).2 f).symm }
+
 /-- A choice of limit cone for a functor `F : J ⥤ TopCat` whose topology is defined as an
 infimum of topologies infimum.
 Generally you should just use `limit.cone F`, unless you need the actual definition
@@ -81,6 +110,32 @@ def limitConeIsLimit (F : J ⥤ TopCat.{max v u}) : IsLimit (limitCone.{v,u} F) 
     simp [← h]
     rfl
 
+/--
+Implementation: The shrinked limit cone for `F : J ⥤ TopCat.{u}` with `J : Type v` is indeed a
+limit. Use `limit.isLimit F` instead.
+-/
+def Small.limitConeIsLimit (F : J ⥤ TopCat.{u}) [Small.{u} (F ⋙ forget).sections] :
+    IsLimit (Small.limitCone F) where
+  lift S := ofHom
+    { toFun := Shrink.homeomorph (F ⋙ forget).sections ∘ (fun x =>
+        ⟨fun _ => S.π.app _ x, fun f => by
+          dsimp
+          rw [← S.w f]
+          rfl⟩)
+      continuous_toFun :=
+        Continuous.comp (Shrink.homeomorph _).continuous <|
+        Continuous.subtype_mk (continuous_pi (π := fun j ↦ F.obj j)
+          fun j => (S.π.app j).hom.2) fun x i j f => by
+            dsimp
+            rw [← S.w f]
+            rfl }
+  fac S j := by
+    ext a
+    simp [Small.limitCone]
+  uniq S m h := by
+    ext a
+    simp [← h, Small.limitCone]
+
 /-- The chosen cone `TopCat.limitConeInfi F` for a functor `F : J ⥤ TopCat` is a limit cone.
 Generally you should just use `limit.isLimit F`, unless you need the actual definition
 (which is in terms of `Types.limitConeIsLimit`).
@@ -102,12 +157,12 @@ def limitConeInfiIsLimit (F : J ⥤ TopCat.{max v u}) : IsLimit (limitConeInfi.{
           (continuous_iff_coinduced_le.mp (s.π.app j).hom.continuous :))
   · rfl
 
-instance topCat_hasLimitsOfSize : HasLimitsOfSize.{w, v} TopCat.{max v u} where
+instance topCat_hasLimitsOfSize [UnivLE.{v, u}] : HasLimitsOfSize.{w, v} TopCat.{u} where
   has_limits_of_shape _ :=
     { has_limit := fun F =>
         HasLimit.mk
-          { cone := limitCone.{v,u} F
-            isLimit := limitConeIsLimit F } }
+          { cone := Small.limitCone.{v, u} F
+            isLimit := Small.limitConeIsLimit F } }
 
 instance topCat_hasLimits : HasLimits TopCat.{u} :=
   TopCat.topCat_hasLimitsOfSize.{u, u}
@@ -226,7 +281,7 @@ lemma hasColimit_iff_small_quot :
   · infer_instance
   · exact ⟨⟨_, isColimitCoconeOfForget _ (colimit.isColimit _)⟩⟩
 
-instance topCat_hasColimitsOfSize : HasColimitsOfSize.{w, v} TopCat.{max v u} where
+instance topCat_hasColimitsOfSize [UnivLE.{v, u}] : HasColimitsOfSize.{w, v} TopCat.{u} where
   has_colimits_of_shape _ := ⟨fun F ↦ by
     rw [hasColimit_iff_small_quot]
     infer_instance⟩

--- a/Mathlib/Topology/Category/TopCat/Limits/Basic.lean
+++ b/Mathlib/Topology/Category/TopCat/Limits/Basic.lean
@@ -71,8 +71,8 @@ section
 variable {F : J ⥤ TopCat.{u}} (c : Cone (F ⋙ forget))
 
 /-- Given a functor `F : J ⥤ TopCat` and a cone `c : Cone (F ⋙ forget)`
-of the underlying cone of types, this is the type `c.pt`
-with the infimum of the topologies that are induced by the maps `c.ι.app j`. -/
+of the underlying functor to types, this is the type `c.pt`
+with the infimum of the induced topologies by the maps `c.π.app j`. -/
 def conePtOfConeForget : Type _ := c.pt
 
 instance topologicalSpaceConePtOfConeForget :
@@ -80,10 +80,10 @@ instance topologicalSpaceConePtOfConeForget :
   (⨅ j, (F.obj j).str.induced (c.π.app j))
 
 /-- Given a functor `F : J ⥤ TopCat` and a cone `c : Cone (F ⋙ forget)`
-of the underlying cone of types, this is a cone for `F` whose point is
+of the underlying functor to types, this is a cone for `F` whose point is
 `c.pt` with the infimum of the induced topologies by the maps `c.π.app j`. -/
 @[simps pt π_app]
-def coneOfConeForget  : Cone F where
+def coneOfConeForget : Cone F where
   pt := of (conePtOfConeForget c)
   π :=
     { app j := ofHom (ContinuousMap.mk (c.π.app j) (by
@@ -94,8 +94,8 @@ def coneOfConeForget  : Cone F where
         apply congr_fun (c.π.naturality φ) }
 
 /-- Given a functor `F : J ⥤ TopCat` and a cone `c : Cone (F ⋙ forget)`
-of the underlying cone of types, the limit of `F` is `c.pt` equipped
-with the supremum of the induced topologies by the maps `c.π.app j`. -/
+of the underlying functor to types, the limit of `F` is `c.pt` equipped
+with the infimum of the induced topologies by the maps `c.π.app j`. -/
 def isLimitConeOfForget (c : Cone (F ⋙ forget)) (hc : IsLimit c) :
     IsLimit (coneOfConeForget c) := by
   refine IsLimit.ofFaithful forget (ht := hc)

--- a/Mathlib/Topology/Category/TopCat/Limits/Basic.lean
+++ b/Mathlib/Topology/Category/TopCat/Limits/Basic.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Patrick Massot, Kim Morrison, Mario Carneiro, Andrew Yang
 -/
 import Mathlib.Topology.Category.TopCat.Adjunctions
-import Mathlib.Topology.Instances.Shrink
 import Mathlib.CategoryTheory.Limits.Types
 import Mathlib.CategoryTheory.Adjunction.Limits
 

--- a/Mathlib/Topology/Category/TopCat/Limits/Cofiltered.lean
+++ b/Mathlib/Topology/Category/TopCat/Limits/Cofiltered.lean
@@ -42,25 +42,8 @@ theorem isTopologicalBasis_cofiltered_limit (hC : IsLimit C) (T : ∀ j, Set (Se
     IsTopologicalBasis
       {U : Set C.pt | ∃ (j : _) (V : Set (F.obj j)), V ∈ T j ∧ U = C.π.app j ⁻¹' V} := by
   classical
-  -- The limit cone for `F` whose topology is defined as an infimum.
-  let D := limitConeInfi F
-  -- The isomorphism between the cone point of `C` and the cone point of `D`.
-  let E : C.pt ≅ D.pt := hC.conePointUniqueUpToIso (limitConeInfiIsLimit _)
-  have hE : IsInducing E.hom := (TopCat.homeoOfIso E).isInducing
-  -- Reduce to the assertion of the theorem with `D` instead of `C`.
-  suffices
-    IsTopologicalBasis
-      {U : Set D.pt | ∃ (j : _) (V : Set (F.obj j)), V ∈ T j ∧ U = D.π.app j ⁻¹' V} by
-    convert this.isInducing hE
-    ext U0
-    constructor
-    · rintro ⟨j, V, hV, rfl⟩
-      exact ⟨D.π.app j ⁻¹' V, ⟨j, V, hV, rfl⟩, rfl⟩
-    · rintro ⟨W, ⟨j, V, hV, rfl⟩, rfl⟩
-      exact ⟨j, V, hV, rfl⟩
-  -- Using `D`, we can apply the characterization of the topological basis of a
-  -- topology defined as an infimum...
-  convert IsTopologicalBasis.iInf_induced hT fun j (x : D.pt) => D.π.app j x using 1
+  convert IsTopologicalBasis.iInf_induced hT fun j (x : C.pt) => C.π.app j x using 1
+  · exact induced_of_isLimit C hC
   ext U0
   constructor
   · rintro ⟨j, V, hV, rfl⟩
@@ -100,7 +83,7 @@ theorem isTopologicalBasis_cofiltered_limit (hC : IsLimit C) (T : ∀ j, Set (Se
       exact compat j e (g e he) (U e) (h1 e he)
     · -- conclude...
       rw [h2]
-      change _ = (D.π.app j)⁻¹' ⋂ (e : J) (_ : e ∈ G), Vs e
+      change _ = (C.π.app j)⁻¹' ⋂ (e : J) (_ : e ∈ G), Vs e
       rw [Set.preimage_iInter]
       apply congrArg
       ext1 e
@@ -108,12 +91,12 @@ theorem isTopologicalBasis_cofiltered_limit (hC : IsLimit C) (T : ∀ j, Set (Se
       apply congrArg
       ext1 he
       -- Porting note: needed more hand holding here
-      change (D.π.app e)⁻¹' U e =
-        (D.π.app j) ⁻¹' if h : e ∈ G then F.map (g e h) ⁻¹' U e else Set.univ
+      change (C.π.app e)⁻¹' U e =
+        (C.π.app j) ⁻¹' if h : e ∈ G then F.map (g e h) ⁻¹' U e else Set.univ
       rw [dif_pos he, ← Set.preimage_comp]
       apply congrFun
       apply congrArg
-      rw [← coe_comp, D.w]
+      rw [← coe_comp, C.w]
       rfl
 
 end CofilteredLimit

--- a/Mathlib/Topology/Category/TopCat/Limits/Products.lean
+++ b/Mathlib/Topology/Category/TopCat/Limits/Products.lean
@@ -112,18 +112,6 @@ theorem sigmaIsoSigma_inv_apply {ι : Type v} (α : ι → TopCat.{max v u}) (i 
   rw [← sigmaIsoSigma_hom_ι_apply, ← comp_app, ← comp_app, Iso.hom_inv_id,
     Category.comp_id]
 
-theorem induced_of_isLimit {F : J ⥤ TopCat.{max v u}} (C : Cone F) (hC : IsLimit C) :
-    C.pt.str = ⨅ j, (F.obj j).str.induced (C.π.app j) := by
-  let homeo := homeoOfIso (hC.conePointUniqueUpToIso (limitConeInfiIsLimit F))
-  refine homeo.isInducing.eq_induced.trans ?_
-  change induced homeo (⨅ j : J, _) = _
-  simp [induced_iInf, induced_compose]
-  rfl
-
-theorem limit_topology (F : J ⥤ TopCat.{max v u}) :
-    (limit F).str = ⨅ j, (F.obj j).str.induced (limit.π F j) :=
-  induced_of_isLimit _ (limit.isLimit F)
-
 section Prod
 
 -- Porting note: why is autoParam not firing?

--- a/Mathlib/Topology/Instances/Shrink.lean
+++ b/Mathlib/Topology/Instances/Shrink.lean
@@ -1,0 +1,32 @@
+/-
+Copyright (c) 2025 Christian Merten. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Christian Merten
+-/
+import Mathlib.Logic.Small.Defs
+import Mathlib.Topology.Defs.Induced
+import Mathlib.Topology.Homeomorph
+
+/-!
+# Topological space structure on `Shrink X`
+-/
+
+universe v u
+
+namespace Shrink
+
+instance (X : Type u) [TopologicalSpace X] [Small.{v} X] : TopologicalSpace (Shrink.{v} X) :=
+  .coinduced (equivShrink X) inferInstance
+
+/-- `equivShrink` as a homeomorphism. -/
+@[simps toEquiv]
+noncomputable def homeomorph (X : Type u) [TopologicalSpace X] [Small.{v} X] :
+    X ≃ₜ Shrink.{v} X where
+  __ := equivShrink X
+  continuous_toFun := continuous_coinduced_rng
+  continuous_invFun := by
+    convert continuous_induced_dom
+    simp only [Equiv.invFun_as_coe, Equiv.induced_symm]
+    rfl
+
+end Shrink


### PR DESCRIPTION
And the same for `topCat_hasColimitsOfSize`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
