### PR TITLE
[Merged by Bors] - feat: openness and closedness of the union of sets separated by neighbourhoods

### DIFF
--- a/Mathlib/Topology/Separation/SeparatedNhds.lean
+++ b/Mathlib/Topology/Separation/SeparatedNhds.lean
@@ -155,6 +155,37 @@ theorem union_left : SeparatedNhds s u → SeparatedNhds t u → SeparatedNhds (
 theorem union_right (ht : SeparatedNhds s t) (hu : SeparatedNhds s u) : SeparatedNhds s (t ∪ u) :=
   (ht.symm.union_left hu.symm).symm
 
+lemma isOpen_left_of_isOpen_union (hst : SeparatedNhds s t) (hst' : IsOpen (s ∪ t)) : IsOpen s := by
+  obtain ⟨u, v, hu, hv, hsu, htv, huv⟩ := hst
+  suffices s = (s ∪ t) ∩ u from this ▸ hst'.inter hu
+  rw [union_inter_distrib_right, (huv.symm.mono_left htv).inter_eq, union_empty,
+    inter_eq_left.2 hsu]
+
+lemma isOpen_right_of_isOpen_union (hst : SeparatedNhds s t) (hst' : IsOpen (s ∪ t)) : IsOpen t :=
+  hst.symm.isOpen_left_of_isOpen_union (union_comm _ _ ▸ hst')
+
+lemma isOpen_union_iff_isOpen (hst : SeparatedNhds s t) : IsOpen (s ∪ t) ↔ IsOpen s ∧ IsOpen t :=
+  ⟨fun h ↦ ⟨hst.isOpen_left_of_isOpen_union h, hst.isOpen_right_of_isOpen_union h⟩,
+    fun ⟨h1, h2⟩ ↦ h1.union h2⟩
+
+lemma isClosed_left_of_isClosed_union (hst : SeparatedNhds s t) (hst' : IsClosed (s ∪ t)) :
+    IsClosed s := by
+  obtain ⟨u, v, hu, hv, hsu, htv, huv⟩ := hst
+  rw [← isOpen_compl_iff] at hst' ⊢
+  suffices sᶜ = (s ∪ t)ᶜ ∪ v from this ▸ hst'.union hv
+  rw [← compl_inj_iff, Set.compl_union, compl_compl, compl_compl, union_inter_distrib_right,
+    (disjoint_compl_right.mono_left htv).inter_eq, union_empty, left_eq_inter, subset_compl_comm]
+  exact (huv.mono_left hsu).subset_compl_left
+
+lemma isClosed_right_of_isClosed_union (hst : SeparatedNhds s t) (hst' : IsClosed (s ∪ t)) :
+    IsClosed t :=
+  hst.symm.isClosed_left_of_isClosed_union (union_comm _ _ ▸ hst')
+
+lemma isClosed_union_iff_isClosed (hst : SeparatedNhds s t) :
+    IsClosed (s ∪ t) ↔ IsClosed s ∧ IsClosed t :=
+  ⟨fun h ↦ ⟨hst.isClosed_left_of_isClosed_union h, hst.isClosed_right_of_isClosed_union h⟩,
+    fun ⟨h1, h2⟩ ↦ h1.union h2⟩
+
 end SeparatedNhds
 
 end Separation

--- a/Mathlib/Topology/Separation/SeparatedNhds.lean
+++ b/Mathlib/Topology/Separation/SeparatedNhds.lean
@@ -164,7 +164,7 @@ lemma isOpen_left_of_isOpen_union (hst : SeparatedNhds s t) (hst' : IsOpen (s �
 lemma isOpen_right_of_isOpen_union (hst : SeparatedNhds s t) (hst' : IsOpen (s ∪ t)) : IsOpen t :=
   hst.symm.isOpen_left_of_isOpen_union (union_comm _ _ ▸ hst')
 
-lemma isOpen_union_iff_isOpen (hst : SeparatedNhds s t) : IsOpen (s ∪ t) ↔ IsOpen s ∧ IsOpen t :=
+lemma isOpen_union_iff (hst : SeparatedNhds s t) : IsOpen (s ∪ t) ↔ IsOpen s ∧ IsOpen t :=
   ⟨fun h ↦ ⟨hst.isOpen_left_of_isOpen_union h, hst.isOpen_right_of_isOpen_union h⟩,
     fun ⟨h1, h2⟩ ↦ h1.union h2⟩
 
@@ -181,8 +181,7 @@ lemma isClosed_right_of_isClosed_union (hst : SeparatedNhds s t) (hst' : IsClose
     IsClosed t :=
   hst.symm.isClosed_left_of_isClosed_union (union_comm _ _ ▸ hst')
 
-lemma isClosed_union_iff_isClosed (hst : SeparatedNhds s t) :
-    IsClosed (s ∪ t) ↔ IsClosed s ∧ IsClosed t :=
+lemma isClosed_union_iff (hst : SeparatedNhds s t) : IsClosed (s ∪ t) ↔ IsClosed s ∧ IsClosed t :=
   ⟨fun h ↦ ⟨hst.isClosed_left_of_isClosed_union h, hst.isClosed_right_of_isClosed_union h⟩,
     fun ⟨h1, h2⟩ ↦ h1.union h2⟩
 


### PR DESCRIPTION

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
