### PR TITLE
[Merged by Bors] - feat(Sign): permutation sign is a product

### DIFF
--- a/Mathlib/GroupTheory/Perm/Fin.lean
+++ b/Mathlib/GroupTheory/Perm/Fin.lean
@@ -281,3 +281,58 @@ theorem isThreeCycle_cycleRange_two {n : ℕ} : IsThreeCycle (cycleRange 2 : Per
 end Fin
 
 end CycleRange
+
+section Sign
+
+variable {n : ℕ}
+
+theorem Equiv.Perm.sign_eq_prod_prod_Iio (σ : Equiv.Perm (Fin n)) :
+    σ.sign = ∏ j, ∏ i ∈ Finset.Iio j, (if σ i < σ j then 1 else -1) := by
+  suffices h : σ.sign = σ.signAux by
+    rw [h, Finset.prod_sigma', Equiv.Perm.signAux]
+    convert rfl using 2 with x hx
+    · simp [Finset.ext_iff, Equiv.Perm.mem_finPairsLT]
+    simp [not_lt, ← ite_not (p := _ ≤ _)]
+  refine σ.swap_induction_on (by simp) fun π i j hne h_eq ↦ ?_
+  rw [Equiv.Perm.signAux_mul, Equiv.Perm.sign_mul, h_eq, Equiv.Perm.sign_swap hne,
+    Equiv.Perm.signAux_swap hne]
+
+theorem Equiv.Perm.sign_eq_prod_prod_Ioi (σ : Equiv.Perm (Fin n)) :
+    σ.sign = ∏ i, ∏ j ∈ Finset.Ioi i, (if σ i < σ j then 1 else -1) := by
+  rw [σ.sign_eq_prod_prod_Iio]
+  apply Finset.prod_comm' (by simp)
+
+theorem prod_Iio_comp_eq_sign_mul_prod {R : Type*} [CommRing R] {f : Fin n → Fin n → R}
+    (hf : ∀ i j, f i j = - f j i) (σ : Equiv.Perm (Fin n)) :
+    ∏ j, ∏ i ∈ Finset.Iio j, f (σ i) (σ j) = σ.sign * ∏ j, ∏ i ∈ Finset.Iio j, f i j := by
+  rw [← σ.sign_inv, Equiv.Perm.sign_eq_prod_prod_Iio, Finset.prod_sigma', Finset.prod_sigma',
+    Finset.prod_sigma']
+  simp only [Units.coe_prod, Int.cast_prod, ← Finset.prod_mul_distrib]
+  set D := (Finset.univ : Finset (Fin n)).sigma Finset.Iio with hD
+  have hφD : D.image (fun x ↦ ⟨σ x.1 ⊔ σ x.2, σ x.1 ⊓ σ x.2⟩) = D := by
+    ext ⟨x1, x2⟩
+    suffices (∃ a, ∃ b < a, σ a ⊔ σ b = x1 ∧ σ a ⊓ σ b = x2) ↔ x2 < x1 by simpa [hD]
+    refine ⟨?_, fun hlt ↦ ?_⟩
+    · rintro ⟨i, j, hij, rfl, rfl⟩
+      exact inf_le_sup.lt_of_ne <| by simp [hij.ne.symm]
+    obtain hlt' | hle := lt_or_le (σ.symm x1) (σ.symm x2)
+    · exact ⟨_, _, hlt', by simp [hlt.le]⟩
+    exact ⟨_, _, hle.lt_of_ne (by simp [hlt.ne]), by simp [hlt.le]⟩
+  have hinj := Finset.injOn_of_card_image_eq (s := D) (by rw [hφD])
+  nth_rw 2 [← hφD]
+  rw [Finset.prod_image (fun x hx y hy hxy ↦ hinj hx hy hxy)]
+  refine Finset.prod_congr rfl fun ⟨x₁, x₂⟩ hx ↦ ?_
+  replace hx : x₂ < x₁ := by simpa [hD] using hx
+  obtain hlt | hle := lt_or_le (σ x₁) (σ x₂)
+  · simp [inf_eq_left.2 hlt.le, sup_eq_right.2 hlt.le, hx.not_lt, ← hf]
+  simp [inf_eq_right.2 hle, sup_eq_left.2 hle, hx]
+
+theorem prod_Ioi_comp_eq_sign_mul_prod {R : Type*} [CommRing R] {f : Fin n → Fin n → R}
+    (hf : ∀ i j, f i j = - f j i) (σ : Equiv.Perm (Fin n)) :
+    ∏ i, ∏ j ∈ Finset.Ioi i, f (σ i) (σ j) = σ.sign * ∏ i, ∏ j ∈ Finset.Ioi i, f i j := by
+  convert prod_Iio_comp_eq_sign_mul_prod hf σ using 1
+  · apply Finset.prod_comm' (by simp)
+  convert rfl using 2
+  apply Finset.prod_comm' (by simp)
+
+end Sign

--- a/Mathlib/GroupTheory/Perm/Fin.lean
+++ b/Mathlib/GroupTheory/Perm/Fin.lean
@@ -305,9 +305,8 @@ theorem Equiv.Perm.sign_eq_prod_prod_Ioi (σ : Equiv.Perm (Fin n)) :
 theorem Equiv.Perm.prod_Iio_comp_eq_sign_mul_prod {R : Type*} [CommRing R]
     (σ : Equiv.Perm (Fin n)) {f : Fin n → Fin n → R} (hf : ∀ i j, f i j = - f j i) :
     ∏ j, ∏ i ∈ Finset.Iio j, f (σ i) (σ j) = σ.sign * ∏ j, ∏ i ∈ Finset.Iio j, f i j := by
-  rw [← σ.sign_inv, Equiv.Perm.sign_eq_prod_prod_Iio, Finset.prod_sigma', Finset.prod_sigma',
-    Finset.prod_sigma']
-  simp only [Units.coe_prod, Int.cast_prod, ← Finset.prod_mul_distrib]
+  simp_rw [← σ.sign_inv, Equiv.Perm.sign_eq_prod_prod_Iio, Finset.prod_sigma', Units.coe_prod,
+    Int.cast_prod, ← Finset.prod_mul_distrib]
   set D := (Finset.univ : Finset (Fin n)).sigma Finset.Iio with hD
   have hφD : D.image (fun x ↦ ⟨σ x.1 ⊔ σ x.2, σ x.1 ⊓ σ x.2⟩) = D := by
     ext ⟨x1, x2⟩
@@ -318,9 +317,8 @@ theorem Equiv.Perm.prod_Iio_comp_eq_sign_mul_prod {R : Type*} [CommRing R]
     obtain hlt' | hle := lt_or_le (σ.symm x1) (σ.symm x2)
     · exact ⟨_, _, hlt', by simp [hlt.le]⟩
     exact ⟨_, _, hle.lt_of_ne (by simp [hlt.ne]), by simp [hlt.le]⟩
-  have hinj := Finset.injOn_of_card_image_eq (s := D) (by rw [hφD])
   nth_rw 2 [← hφD]
-  rw [Finset.prod_image (fun x hx y hy hxy ↦ hinj hx hy hxy)]
+  rw [Finset.prod_image fun x hx y hy ↦ Finset.injOn_of_card_image_eq (by rw [hφD]) hx hy]
   refine Finset.prod_congr rfl fun ⟨x₁, x₂⟩ hx ↦ ?_
   replace hx : x₂ < x₁ := by simpa [hD] using hx
   obtain hlt | hle := lt_or_le (σ x₁) (σ x₂)

--- a/Mathlib/GroupTheory/Perm/Fin.lean
+++ b/Mathlib/GroupTheory/Perm/Fin.lean
@@ -302,8 +302,8 @@ theorem Equiv.Perm.sign_eq_prod_prod_Ioi (σ : Equiv.Perm (Fin n)) :
   rw [σ.sign_eq_prod_prod_Iio]
   apply Finset.prod_comm' (by simp)
 
-theorem prod_Iio_comp_eq_sign_mul_prod {R : Type*} [CommRing R] {f : Fin n → Fin n → R}
-    (hf : ∀ i j, f i j = - f j i) (σ : Equiv.Perm (Fin n)) :
+theorem Equiv.Perm.prod_Iio_comp_eq_sign_mul_prod {R : Type*} [CommRing R]
+    (σ : Equiv.Perm (Fin n)) {f : Fin n → Fin n → R} (hf : ∀ i j, f i j = - f j i) :
     ∏ j, ∏ i ∈ Finset.Iio j, f (σ i) (σ j) = σ.sign * ∏ j, ∏ i ∈ Finset.Iio j, f i j := by
   rw [← σ.sign_inv, Equiv.Perm.sign_eq_prod_prod_Iio, Finset.prod_sigma', Finset.prod_sigma',
     Finset.prod_sigma']
@@ -327,10 +327,10 @@ theorem prod_Iio_comp_eq_sign_mul_prod {R : Type*} [CommRing R] {f : Fin n → F
   · simp [inf_eq_left.2 hlt.le, sup_eq_right.2 hlt.le, hx.not_lt, ← hf]
   simp [inf_eq_right.2 hle, sup_eq_left.2 hle, hx]
 
-theorem prod_Ioi_comp_eq_sign_mul_prod {R : Type*} [CommRing R] {f : Fin n → Fin n → R}
-    (hf : ∀ i j, f i j = - f j i) (σ : Equiv.Perm (Fin n)) :
+theorem Equiv.Perm.prod_Ioi_comp_eq_sign_mul_prod {R : Type*} [CommRing R]
+    (σ : Equiv.Perm (Fin n)) {f : Fin n → Fin n → R} (hf : ∀ i j, f i j = - f j i) :
     ∏ i, ∏ j ∈ Finset.Ioi i, f (σ i) (σ j) = σ.sign * ∏ i, ∏ j ∈ Finset.Ioi i, f i j := by
-  convert prod_Iio_comp_eq_sign_mul_prod hf σ using 1
+  convert σ.prod_Iio_comp_eq_sign_mul_prod hf using 1
   · apply Finset.prod_comm' (by simp)
   convert rfl using 2
   apply Finset.prod_comm' (by simp)

--- a/Mathlib/GroupTheory/Perm/Fin.lean
+++ b/Mathlib/GroupTheory/Perm/Fin.lean
@@ -305,7 +305,7 @@ theorem Equiv.Perm.sign_eq_prod_prod_Ioi (σ : Equiv.Perm (Fin n)) :
 theorem Equiv.Perm.prod_Iio_comp_eq_sign_mul_prod {R : Type*} [CommRing R]
     (σ : Equiv.Perm (Fin n)) {f : Fin n → Fin n → R} (hf : ∀ i j, f i j = - f j i) :
     ∏ j, ∏ i ∈ Finset.Iio j, f (σ i) (σ j) = σ.sign * ∏ j, ∏ i ∈ Finset.Iio j, f i j := by
-  simp_rw [← σ.sign_inv, Equiv.Perm.sign_eq_prod_prod_Iio, Finset.prod_sigma', Units.coe_prod,
+  simp_rw [← σ.sign_inv, σ⁻¹.sign_eq_prod_prod_Iio, Finset.prod_sigma', Units.coe_prod,
     Int.cast_prod, ← Finset.prod_mul_distrib]
   set D := (Finset.univ : Finset (Fin n)).sigma Finset.Iio with hD
   have hφD : D.image (fun x ↦ ⟨σ x.1 ⊔ σ x.2, σ x.1 ⊓ σ x.2⟩) = D := by

--- a/Mathlib/GroupTheory/Perm/Sign.lean
+++ b/Mathlib/GroupTheory/Perm/Sign.lean
@@ -3,8 +3,6 @@ Copyright (c) 2018 Chris Hughes. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes
 -/
-import Mathlib.Algebra.BigOperators.Group.Finset.Sigma
-import Mathlib.Algebra.BigOperators.Ring.Finset
 import Mathlib.Algebra.Group.Conj
 import Mathlib.Algebra.Group.Subgroup.Lattice
 import Mathlib.Algebra.Group.Submonoid.BigOperators
@@ -18,7 +16,6 @@ import Mathlib.GroupTheory.Perm.Support
 import Mathlib.Logic.Equiv.Fin
 import Mathlib.Tactic.NormNum.Ineq
 import Mathlib.Data.Finset.Sigma
-import Mathlib.Order.Interval.Finset.Fin
 
 /-!
 # Sign of a permutation
@@ -619,60 +616,5 @@ lemma ofSign_disjUnion :
   simp_rw [mem_disjUnion, mem_ofSign, Int.units_eq_one_or, mem_univ]
 
 end Finset
-
-section Fin
-
-variable {n : ℕ}
-
-theorem sign_eq_prod_prod_Iio (σ : Equiv.Perm (Fin n)) :
-    σ.sign = ∏ j, ∏ i ∈ Finset.Iio j, (if σ i < σ j then 1 else -1) := by
-  suffices h : σ.sign = σ.signAux by
-    rw [h, Finset.prod_sigma', Equiv.Perm.signAux]
-    convert rfl using 2 with x hx
-    · simp [Finset.ext_iff, Equiv.Perm.mem_finPairsLT]
-    simp [not_lt, ← ite_not (p := _ ≤ _)]
-  refine σ.swap_induction_on (by simp) fun π i j hne h_eq ↦ ?_
-  rw [Equiv.Perm.signAux_mul, Equiv.Perm.sign_mul, h_eq, Equiv.Perm.sign_swap hne,
-    Equiv.Perm.signAux_swap hne]
-
-theorem Equiv.Perm.sign_eq_prod_prod_Ioi (σ : Equiv.Perm (Fin n)) :
-    σ.sign = ∏ i, ∏ j ∈ Finset.Ioi i, (if σ i < σ j then 1 else -1) := by
-  rw [σ.sign_eq_prod_prod_Iio]
-  apply Finset.prod_comm' (by simp)
-
-theorem prod_Iio_comp_eq_sign_mul_prod {R : Type*} [CommRing R] {f : Fin n → Fin n → R}
-    (hf : ∀ i j, f i j = - f j i) (σ : Equiv.Perm (Fin n)) :
-    ∏ j, ∏ i ∈ Finset.Iio j, f (σ i) (σ j) = σ.sign * ∏ j, ∏ i ∈ Finset.Iio j, f i j := by
-  rw [← σ.sign_inv, Equiv.Perm.sign_eq_prod_prod_Iio, Finset.prod_sigma', Finset.prod_sigma',
-    Finset.prod_sigma']
-  simp only [Units.coe_prod, Int.cast_prod, ← Finset.prod_mul_distrib]
-  set D := (Finset.univ : Finset (Fin n)).sigma Finset.Iio with hD
-  have hφD : D.image (fun x ↦ ⟨σ x.1 ⊔ σ x.2, σ x.1 ⊓ σ x.2⟩) = D := by
-    ext ⟨x1, x2⟩
-    suffices (∃ a, ∃ b < a, σ a ⊔ σ b = x1 ∧ σ a ⊓ σ b = x2) ↔ x2 < x1 by simpa [hD]
-    refine ⟨?_, fun hlt ↦ ?_⟩
-    · rintro ⟨i, j, hij, rfl, rfl⟩
-      exact inf_le_sup.lt_of_ne <| by simp [hij.ne.symm]
-    obtain hlt' | hle := lt_or_le (σ.symm x1) (σ.symm x2)
-    · exact ⟨_, _, hlt', by simp [hlt.le]⟩
-    exact ⟨_, _, hle.lt_of_ne (by simp [hlt.ne]), by simp [hlt.le]⟩
-  have hinj := Finset.injOn_of_card_image_eq (s := D) (by rw [hφD])
-  nth_rw 2 [← hφD]
-  rw [Finset.prod_image (fun x hx y hy hxy ↦ hinj hx hy hxy)]
-  refine Finset.prod_congr rfl fun ⟨x₁, x₂⟩ hx ↦ ?_
-  replace hx : x₂ < x₁ := by simpa [hD] using hx
-  obtain hlt | hle := lt_or_le (σ x₁) (σ x₂)
-  · simp [inf_eq_left.2 hlt.le, sup_eq_right.2 hlt.le, hx.not_lt, ← hf]
-  simp [inf_eq_right.2 hle, sup_eq_left.2 hle, hx]
-
-theorem prod_Ioi_comp_eq_sign_mul_prod {R : Type*} [CommRing R] {f : Fin n → Fin n → R}
-    (hf : ∀ i j, f i j = - f j i) (σ : Equiv.Perm (Fin n)) :
-    ∏ i, ∏ j ∈ Finset.Ioi i, f (σ i) (σ j) = σ.sign * ∏ i, ∏ j ∈ Finset.Ioi i, f i j := by
-  convert prod_Iio_comp_eq_sign_mul_prod hf σ using 1
-  · apply Finset.prod_comm' (by simp)
-  convert rfl using 2
-  apply Finset.prod_comm' (by simp)
-
-end Fin
 
 end Equiv.Perm

--- a/Mathlib/GroupTheory/Perm/Sign.lean
+++ b/Mathlib/GroupTheory/Perm/Sign.lean
@@ -3,6 +3,8 @@ Copyright (c) 2018 Chris Hughes. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes
 -/
+import Mathlib.Algebra.BigOperators.Group.Finset.Sigma
+import Mathlib.Algebra.BigOperators.Ring.Finset
 import Mathlib.Algebra.Group.Conj
 import Mathlib.Algebra.Group.Subgroup.Lattice
 import Mathlib.Algebra.Group.Submonoid.BigOperators
@@ -16,6 +18,7 @@ import Mathlib.GroupTheory.Perm.Support
 import Mathlib.Logic.Equiv.Fin
 import Mathlib.Tactic.NormNum.Ineq
 import Mathlib.Data.Finset.Sigma
+import Mathlib.Order.Interval.Finset.Fin
 
 /-!
 # Sign of a permutation
@@ -616,5 +619,60 @@ lemma ofSign_disjUnion :
   simp_rw [mem_disjUnion, mem_ofSign, Int.units_eq_one_or, mem_univ]
 
 end Finset
+
+section Fin
+
+variable {n : ℕ}
+
+theorem sign_eq_prod_prod_Iio (σ : Equiv.Perm (Fin n)) :
+    σ.sign = ∏ j, ∏ i ∈ Finset.Iio j, (if σ i < σ j then 1 else -1) := by
+  suffices h : σ.sign = σ.signAux by
+    rw [h, Finset.prod_sigma', Equiv.Perm.signAux]
+    convert rfl using 2 with x hx
+    · simp [Finset.ext_iff, Equiv.Perm.mem_finPairsLT]
+    simp [not_lt, ← ite_not (p := _ ≤ _)]
+  refine σ.swap_induction_on (by simp) fun π i j hne h_eq ↦ ?_
+  rw [Equiv.Perm.signAux_mul, Equiv.Perm.sign_mul, h_eq, Equiv.Perm.sign_swap hne,
+    Equiv.Perm.signAux_swap hne]
+
+theorem Equiv.Perm.sign_eq_prod_prod_Ioi (σ : Equiv.Perm (Fin n)) :
+    σ.sign = ∏ i, ∏ j ∈ Finset.Ioi i, (if σ i < σ j then 1 else -1) := by
+  rw [σ.sign_eq_prod_prod_Iio]
+  apply Finset.prod_comm' (by simp)
+
+theorem prod_Iio_comp_eq_sign_mul_prod {R : Type*} [CommRing R] {f : Fin n → Fin n → R}
+    (hf : ∀ i j, f i j = - f j i) (σ : Equiv.Perm (Fin n)) :
+    ∏ j, ∏ i ∈ Finset.Iio j, f (σ i) (σ j) = σ.sign * ∏ j, ∏ i ∈ Finset.Iio j, f i j := by
+  rw [← σ.sign_inv, Equiv.Perm.sign_eq_prod_prod_Iio, Finset.prod_sigma', Finset.prod_sigma',
+    Finset.prod_sigma']
+  simp only [Units.coe_prod, Int.cast_prod, ← Finset.prod_mul_distrib]
+  set D := (Finset.univ : Finset (Fin n)).sigma Finset.Iio with hD
+  have hφD : D.image (fun x ↦ ⟨σ x.1 ⊔ σ x.2, σ x.1 ⊓ σ x.2⟩) = D := by
+    ext ⟨x1, x2⟩
+    suffices (∃ a, ∃ b < a, σ a ⊔ σ b = x1 ∧ σ a ⊓ σ b = x2) ↔ x2 < x1 by simpa [hD]
+    refine ⟨?_, fun hlt ↦ ?_⟩
+    · rintro ⟨i, j, hij, rfl, rfl⟩
+      exact inf_le_sup.lt_of_ne <| by simp [hij.ne.symm]
+    obtain hlt' | hle := lt_or_le (σ.symm x1) (σ.symm x2)
+    · exact ⟨_, _, hlt', by simp [hlt.le]⟩
+    exact ⟨_, _, hle.lt_of_ne (by simp [hlt.ne]), by simp [hlt.le]⟩
+  have hinj := Finset.injOn_of_card_image_eq (s := D) (by rw [hφD])
+  nth_rw 2 [← hφD]
+  rw [Finset.prod_image (fun x hx y hy hxy ↦ hinj hx hy hxy)]
+  refine Finset.prod_congr rfl fun ⟨x₁, x₂⟩ hx ↦ ?_
+  replace hx : x₂ < x₁ := by simpa [hD] using hx
+  obtain hlt | hle := lt_or_le (σ x₁) (σ x₂)
+  · simp [inf_eq_left.2 hlt.le, sup_eq_right.2 hlt.le, hx.not_lt, ← hf]
+  simp [inf_eq_right.2 hle, sup_eq_left.2 hle, hx]
+
+theorem prod_Ioi_comp_eq_sign_mul_prod {R : Type*} [CommRing R] {f : Fin n → Fin n → R}
+    (hf : ∀ i j, f i j = - f j i) (σ : Equiv.Perm (Fin n)) :
+    ∏ i, ∏ j ∈ Finset.Ioi i, f (σ i) (σ j) = σ.sign * ∏ i, ∏ j ∈ Finset.Ioi i, f i j := by
+  convert prod_Iio_comp_eq_sign_mul_prod hf σ using 1
+  · apply Finset.prod_comm' (by simp)
+  convert rfl using 2
+  apply Finset.prod_comm' (by simp)
+
+end Fin
 
 end Equiv.Perm


### PR DESCRIPTION
We prove that a permutation sign is a product of +/- terms over a lower triangle  in `Fin n`, and a related lemma about the product over a lower triangle of the composition of an antisymmetric function `f : Fin n -> Fin n -> R` with a permutation. 

The first lemma is essentially already proved in the `aux` API that is used to define `Perm.sign` in the first place, but it wasn't previously user-facing in a reasonable way. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
