### PR TITLE
[Merged by Bors] - feat: Fin.init and Fin.tail are continuous

### DIFF
--- a/Mathlib/Topology/Constructions.lean
+++ b/Mathlib/Topology/Constructions.lean
@@ -1588,18 +1588,29 @@ theorem Continuous.finInsertNth
 @[deprecated (since := "2025-01-02")]
 alias Continuous.fin_insertNth := Continuous.finInsertNth
 
-theorem Filter.Tendsto.finInit
-    {f : Y → ∀ j : Fin (n + 1), π j} {l : Filter Y} {x : ∀ j, π j}
-    (hg : Tendsto f l (𝓝 x)) : Tendsto (fun a => Fin.init (f a)) l (𝓝 <| Fin.init x) :=
+theorem Filter.Tendsto.finInit {f : Y → ∀ j : Fin (n + 1), π j} {l : Filter Y} {x : ∀ j, π j}
+    (hg : Tendsto f l (𝓝 x)) : Tendsto (fun a ↦ Fin.init (f a)) l (𝓝 <| Fin.init x) :=
   tendsto_pi_nhds.2 fun j ↦ apply_nhds hg j.castSucc
 
 theorem ContinuousAt.finInit {f : X → ∀ j : Fin (n + 1), π j} {x : X}
-    (hf : ContinuousAt f x) : ContinuousAt (fun a => Fin.init (f a)) x :=
+    (hf : ContinuousAt f x) : ContinuousAt (fun a ↦ Fin.init (f a)) x :=
   hf.tendsto.finInit
 
-theorem Continuous.finInit {f : X → ∀ j : Fin (n + 1), π j}
-    (hf : Continuous f) : Continuous fun a => Fin.init (f a) :=
-  continuous_iff_continuousAt.2 fun _ => hf.continuousAt.finInit
+theorem Continuous.finInit {f : X → ∀ j : Fin (n + 1), π j} (hf : Continuous f) :
+    Continuous fun a ↦ Fin.init (f a) :=
+  continuous_iff_continuousAt.2 fun _ ↦ hf.continuousAt.finInit
+
+theorem Filter.Tendsto.finTail {f : Y → ∀ j : Fin (n + 1), π j} {l : Filter Y} {x : ∀ j, π j}
+    (hg : Tendsto f l (𝓝 x)) : Tendsto (fun a ↦ Fin.tail (f a)) l (𝓝 <| Fin.tail x) :=
+  tendsto_pi_nhds.2 fun j ↦ apply_nhds hg j.succ
+
+theorem ContinuousAt.finTail {f : X → ∀ j : Fin (n + 1), π j} {x : X}
+    (hf : ContinuousAt f x) : ContinuousAt (fun a ↦ Fin.tail (f a)) x :=
+  hf.tendsto.finTail
+
+theorem Continuous.finTail {f : X → ∀ j : Fin (n + 1), π j} (hf : Continuous f) :
+    Continuous fun a ↦ Fin.tail (f a) :=
+  continuous_iff_continuousAt.2 fun _ ↦ hf.continuousAt.finTail
 
 end Fin
 

--- a/Mathlib/Topology/Constructions.lean
+++ b/Mathlib/Topology/Constructions.lean
@@ -1592,10 +1592,12 @@ theorem Filter.Tendsto.finInit {f : Y → ∀ j : Fin (n + 1), π j} {l : Filter
     (hg : Tendsto f l (𝓝 x)) : Tendsto (fun a ↦ Fin.init (f a)) l (𝓝 <| Fin.init x) :=
   tendsto_pi_nhds.2 fun j ↦ apply_nhds hg j.castSucc
 
+@[fun_prop]
 theorem ContinuousAt.finInit {f : X → ∀ j : Fin (n + 1), π j} {x : X}
     (hf : ContinuousAt f x) : ContinuousAt (fun a ↦ Fin.init (f a)) x :=
   hf.tendsto.finInit
 
+@[fun_prop]
 theorem Continuous.finInit {f : X → ∀ j : Fin (n + 1), π j} (hf : Continuous f) :
     Continuous fun a ↦ Fin.init (f a) :=
   continuous_iff_continuousAt.2 fun _ ↦ hf.continuousAt.finInit
@@ -1604,10 +1606,12 @@ theorem Filter.Tendsto.finTail {f : Y → ∀ j : Fin (n + 1), π j} {l : Filter
     (hg : Tendsto f l (𝓝 x)) : Tendsto (fun a ↦ Fin.tail (f a)) l (𝓝 <| Fin.tail x) :=
   tendsto_pi_nhds.2 fun j ↦ apply_nhds hg j.succ
 
+@[fun_prop]
 theorem ContinuousAt.finTail {f : X → ∀ j : Fin (n + 1), π j} {x : X}
     (hf : ContinuousAt f x) : ContinuousAt (fun a ↦ Fin.tail (f a)) x :=
   hf.tendsto.finTail
 
+@[fun_prop]
 theorem Continuous.finTail {f : X → ∀ j : Fin (n + 1), π j} (hf : Continuous f) :
     Continuous fun a ↦ Fin.tail (f a) :=
   continuous_iff_continuousAt.2 fun _ ↦ hf.continuousAt.finTail

--- a/Mathlib/Topology/Constructions.lean
+++ b/Mathlib/Topology/Constructions.lean
@@ -1588,6 +1588,19 @@ theorem Continuous.finInsertNth
 @[deprecated (since := "2025-01-02")]
 alias Continuous.fin_insertNth := Continuous.finInsertNth
 
+theorem Filter.Tendsto.finInit
+    {f : Y → ∀ j : Fin (n + 1), π j} {l : Filter Y} {x : ∀ j, π j}
+    (hg : Tendsto f l (𝓝 x)) : Tendsto (fun a => Fin.init (f a)) l (𝓝 <| Fin.init x) :=
+  tendsto_pi_nhds.2 fun j ↦ apply_nhds hg j.castSucc
+
+theorem ContinuousAt.finInit {f : X → ∀ j : Fin (n + 1), π j} {x : X}
+    (hf : ContinuousAt f x) : ContinuousAt (fun a => Fin.init (f a)) x :=
+  hf.tendsto.finInit
+
+theorem Continuous.finInit {f : X → ∀ j : Fin (n + 1), π j}
+    (hf : Continuous f) : Continuous fun a => Fin.init (f a) :=
+  continuous_iff_continuousAt.2 fun _ => hf.continuousAt.finInit
+
 end Fin
 
 theorem isOpen_set_pi {i : Set ι} {s : ∀ a, Set (π a)} (hi : i.Finite)


### PR DESCRIPTION

I needed the continuity of `Fin.init` for the inductive CW structure on the sphere. There the inverses of the characteristic maps are just the projections of the upper and lower hemisphere onto the obvious hyperplane. It was easiest to use `Fin.init` for this.

---

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
