### PR TITLE
[Merged by Bors] - feat: product using `Function.extend`

### DIFF
--- a/Mathlib/Algebra/BigOperators/Group/Finset/Basic.lean
+++ b/Mathlib/Algebra/BigOperators/Group/Finset/Basic.lean
@@ -560,6 +560,12 @@ theorem prod_extend_by_one [DecidableEq α] (s : Finset α) (f : α → β) :
     ∏ i ∈ s, (if i ∈ s then f i else 1) = ∏ i ∈ s, f i :=
   (prod_congr rfl) fun _i hi => if_pos hi
 
+@[to_additive]
+theorem prod_eq_prod_extend (f : s → β) : ∏ x, f x = ∏ x ∈ s, Subtype.val.extend f 1 x := by
+  rw [univ_eq_attach, ← Finset.prod_attach s]
+  congr with ⟨x, hx⟩
+  rw [Subtype.val_injective.extend_apply]
+
 @[to_additive (attr := simp)]
 theorem prod_ite_mem [DecidableEq α] (s t : Finset α) (f : α → β) :
     ∏ i ∈ s, (if i ∈ t then f i else 1) = ∏ i ∈ s ∩ t, f i := by

--- a/Mathlib/Data/Subtype.lean
+++ b/Mathlib/Data/Subtype.lean
@@ -109,6 +109,10 @@ theorem _root_.exists_subtype_mk_eq_iff {a : Subtype p} {b : α} :
     (∃ h : p b, Subtype.mk b h = a) ↔ b = a := by
   simp only [@eq_comm _ b, exists_eq_subtype_mk_iff, @eq_comm _ _ a]
 
+theorem _root_.Function.extend_val_apply {p : β → Prop} {g : {x // p x} → γ} {j : β → γ}
+    (b : β) (hb : p b) : val.extend g j b = g ⟨b, hb⟩ :=
+  val_injective.extend_apply g j ⟨b, hb⟩
+
 /-- Restrict a (dependent) function to a subtype -/
 def restrict {α} {β : α → Type*} (p : α → Prop) (f : ∀ x, β x) (x : Subtype p) : β x.1 :=
   f x

--- a/Mathlib/Data/Subtype.lean
+++ b/Mathlib/Data/Subtype.lean
@@ -110,7 +110,7 @@ theorem _root_.exists_subtype_mk_eq_iff {a : Subtype p} {b : α} :
   simp only [@eq_comm _ b, exists_eq_subtype_mk_iff, @eq_comm _ _ a]
 
 theorem _root_.Function.extend_val_apply {p : β → Prop} {g : {x // p x} → γ} {j : β → γ}
-    (b : β) (hb : p b) : val.extend g j b = g ⟨b, hb⟩ :=
+    {b : β} (hb : p b) : val.extend g j b = g ⟨b, hb⟩ :=
   val_injective.extend_apply g j ⟨b, hb⟩
 
 /-- Restrict a (dependent) function to a subtype -/

--- a/Mathlib/Order/Interval/Finset/Basic.lean
+++ b/Mathlib/Order/Interval/Finset/Basic.lean
@@ -237,6 +237,10 @@ theorem Icc_ssubset_Icc_right (hI : a₂ ≤ b₂) (ha : a₂ ≤ a₁) (hb : b�
   rw [← coe_ssubset, coe_Icc, coe_Icc]
   exact Set.Icc_ssubset_Icc_right hI ha hb
 
+theorem Ioc_disjoint_Ioc (a b c : α) : Disjoint (Ioc a b) (Ioc b c) :=
+  disjoint_right.2 fun _ hi h ↦
+    (not_and_of_not_right _ (_root_.lt_iff_le_not_le.1 (mem_Ioc.1 hi).1).2) (mem_Ioc.1 h)
+
 variable (a)
 
 theorem Ico_self : Ico a a = ∅ :=

--- a/Mathlib/Order/Interval/Finset/Basic.lean
+++ b/Mathlib/Order/Interval/Finset/Basic.lean
@@ -237,10 +237,6 @@ theorem Icc_ssubset_Icc_right (hI : a₂ ≤ b₂) (ha : a₂ ≤ a₁) (hb : b�
   rw [← coe_ssubset, coe_Icc, coe_Icc]
   exact Set.Icc_ssubset_Icc_right hI ha hb
 
-theorem Ioc_disjoint_Ioc (a b c : α) : Disjoint (Ioc a b) (Ioc b c) :=
-  disjoint_right.2 fun _ hi h ↦
-    (not_and_of_not_right _ (_root_.lt_iff_le_not_le.1 (mem_Ioc.1 hi).1).2) (mem_Ioc.1 h)
-
 variable (a)
 
 theorem Ico_self : Ico a a = ∅ :=


### PR DESCRIPTION
Given `s : Finset α` and `f : s → β` we have `∏ x, f x = ∏ x ∈ s, Subtype.val.extend f 1 x`.
Specialize `Function.extend_apply` to the case where `f = Subtype.val`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
