### PR TITLE
[Merged by Bors] - feat(Finset): `Ioc a b` is disjoint from `Ioc c d` when `b ≤ c`

### DIFF
--- a/Mathlib/Analysis/BoxIntegral/Partition/Basic.lean
+++ b/Mathlib/Analysis/BoxIntegral/Partition/Basic.lean
@@ -169,7 +169,7 @@ theorem injOn_setOf_mem_Icc_setOf_lower_eq (x : ι → ℝ) :
   · have hi₂ : J₂.lower i = x i := (H _).1 hi₁
     have H₁ : x i < J₁.upper i := by simpa only [hi₁] using J₁.lower_lt_upper i
     have H₂ : x i < J₂.upper i := by simpa only [hi₂] using J₂.lower_lt_upper i
-    rw [Ioc_inter_Ioc, hi₁, hi₂, sup_idem, Set.nonempty_Ioc]
+    rw [Set.Ioc_inter_Ioc, hi₁, hi₂, sup_idem, Set.nonempty_Ioc]
     exact lt_min H₁ H₂
   · have hi₂ : J₂.lower i < x i := (hx₂.1 i).lt_of_ne (mt (H _).2 hi₁.ne)
     exact ⟨x i, ⟨hi₁, hx₁.2 i⟩, ⟨hi₂, hx₂.2 i⟩⟩

--- a/Mathlib/MeasureTheory/Integral/IntervalIntegral.lean
+++ b/Mathlib/MeasureTheory/Integral/IntervalIntegral.lean
@@ -867,8 +867,7 @@ theorem integral_add_adjacent_intervals_cancel (hab : IntervalIntegrable f μ a 
     rw [Ioc_union_Ioc_union_Ioc_cycle, union_right_comm, Ioc_union_Ioc_union_Ioc_cycle,
       min_left_comm, max_left_comm]
   all_goals
-    simp [*, MeasurableSet.union, measurableSet_Ioc, Ioc_disjoint_Ioc_same,
-      Ioc_disjoint_Ioc_same.symm, hab.1, hab.2, hbc.1, hbc.2, hac.1, hac.2]
+    simp [*, hab.1, hab.2, hbc.1, hbc.2, hac.1, hac.2]
 
 theorem integral_add_adjacent_intervals (hab : IntervalIntegrable f μ a b)
     (hbc : IntervalIntegrable f μ b c) :

--- a/Mathlib/Order/Interval/Finset/Basic.lean
+++ b/Mathlib/Order/Interval/Finset/Basic.lean
@@ -237,6 +237,7 @@ theorem Icc_ssubset_Icc_right (hI : a₂ ≤ b₂) (ha : a₂ ≤ a₁) (hb : b�
   rw [← coe_ssubset, coe_Icc, coe_Icc]
   exact Set.Icc_ssubset_Icc_right hI ha hb
 
+@[simp]
 theorem Ioc_disjoint_Ioc_of_le {d : α} (hbc : b ≤ c) : Disjoint (Ioc a b) (Ioc c d) :=
   disjoint_left.2 fun _ h1 h2 ↦ not_and_of_not_left _
     ((mem_Ioc.1 h1).2.trans hbc).not_lt (mem_Ioc.1 h2)

--- a/Mathlib/Order/Interval/Finset/Basic.lean
+++ b/Mathlib/Order/Interval/Finset/Basic.lean
@@ -237,9 +237,10 @@ theorem Icc_ssubset_Icc_right (hI : a₂ ≤ b₂) (ha : a₂ ≤ a₁) (hb : b�
   rw [← coe_ssubset, coe_Icc, coe_Icc]
   exact Set.Icc_ssubset_Icc_right hI ha hb
 
-theorem Ioc_disjoint_Ioc (a b c : α) : Disjoint (Ioc a b) (Ioc b c) :=
-  disjoint_right.2 fun _ hi h ↦
-    (not_and_of_not_right _ (_root_.lt_iff_le_not_le.1 (mem_Ioc.1 hi).1).2) (mem_Ioc.1 h)
+theorem Ioc_disjoint_Ioc (a d : α) (hbc : b ≤ c) : Disjoint (Ioc a b) (Ioc c d) := by
+  refine disjoint_right.2 fun i hi ↦ ?_
+  rw [mem_Ioc, Preorder.lt_iff_le_not_le c] at *
+  exact not_and_of_not_right _ fun h ↦ hi.1.2 (h.trans hbc)
 
 variable (a)
 

--- a/Mathlib/Order/Interval/Finset/Basic.lean
+++ b/Mathlib/Order/Interval/Finset/Basic.lean
@@ -237,10 +237,9 @@ theorem Icc_ssubset_Icc_right (hI : a₂ ≤ b₂) (ha : a₂ ≤ a₁) (hb : b�
   rw [← coe_ssubset, coe_Icc, coe_Icc]
   exact Set.Icc_ssubset_Icc_right hI ha hb
 
-theorem Ioc_disjoint_Ioc (a d : α) (hbc : b ≤ c) : Disjoint (Ioc a b) (Ioc c d) := by
-  refine disjoint_right.2 fun i hi ↦ ?_
-  rw [mem_Ioc, Preorder.lt_iff_le_not_le c] at *
-  exact not_and_of_not_right _ fun h ↦ hi.1.2 (h.trans hbc)
+theorem Ioc_disjoint_Ioc (a d : α) (hbc : b ≤ c) : Disjoint (Ioc a b) (Ioc c d) :=
+  disjoint_left.2 fun _ h1 h2 ↦ not_and_of_not_left _
+    ((mem_Ioc.1 h1).2.trans hbc).not_lt (mem_Ioc.1 h2)
 
 variable (a)
 

--- a/Mathlib/Order/Interval/Finset/Basic.lean
+++ b/Mathlib/Order/Interval/Finset/Basic.lean
@@ -237,6 +237,10 @@ theorem Icc_ssubset_Icc_right (hI : a₂ ≤ b₂) (ha : a₂ ≤ a₁) (hb : b�
   rw [← coe_ssubset, coe_Icc, coe_Icc]
   exact Set.Icc_ssubset_Icc_right hI ha hb
 
+theorem Ioc_disjoint_Ioc (a b c : α) : Disjoint (Ioc a b) (Ioc b c) :=
+  disjoint_right.2 fun _ hi h ↦
+    (not_and_of_not_right _ (_root_.lt_iff_le_not_le.1 (mem_Ioc.1 hi).1).2) (mem_Ioc.1 h)
+
 variable (a)
 
 theorem Ico_self : Ico a a = ∅ :=

--- a/Mathlib/Order/Interval/Finset/Basic.lean
+++ b/Mathlib/Order/Interval/Finset/Basic.lean
@@ -237,7 +237,7 @@ theorem Icc_ssubset_Icc_right (hI : a₂ ≤ b₂) (ha : a₂ ≤ a₁) (hb : b�
   rw [← coe_ssubset, coe_Icc, coe_Icc]
   exact Set.Icc_ssubset_Icc_right hI ha hb
 
-theorem Ioc_disjoint_Ioc (a d : α) (hbc : b ≤ c) : Disjoint (Ioc a b) (Ioc c d) :=
+theorem Ioc_disjoint_Ioc {d : α} (hbc : b ≤ c) : Disjoint (Ioc a b) (Ioc c d) :=
   disjoint_left.2 fun _ h1 h2 ↦ not_and_of_not_left _
     ((mem_Ioc.1 h1).2.trans hbc).not_lt (mem_Ioc.1 h2)
 

--- a/Mathlib/Order/Interval/Finset/Basic.lean
+++ b/Mathlib/Order/Interval/Finset/Basic.lean
@@ -242,9 +242,6 @@ theorem Ioc_disjoint_Ioc_of_le {d : α} (hbc : b ≤ c) : Disjoint (Ioc a b) (Io
   disjoint_left.2 fun _ h1 h2 ↦ not_and_of_not_left _
     ((mem_Ioc.1 h1).2.trans hbc).not_lt (mem_Ioc.1 h2)
 
-theorem Ioc_disjoint_Ioc_same : Disjoint (Ioc a b) (Ioc b c) :=
-  Ioc_disjoint_Ioc_of_le le_rfl
-
 variable (a)
 
 theorem Ico_self : Ico a a = ∅ :=

--- a/Mathlib/Order/Interval/Finset/Basic.lean
+++ b/Mathlib/Order/Interval/Finset/Basic.lean
@@ -237,9 +237,8 @@ theorem Icc_ssubset_Icc_right (hI : a₂ ≤ b₂) (ha : a₂ ≤ a₁) (hb : b�
   rw [← coe_ssubset, coe_Icc, coe_Icc]
   exact Set.Icc_ssubset_Icc_right hI ha hb
 
-theorem Ioc_disjoint_Ioc_of_le {d : α} (hbc : b ≤ c) : Disjoint (Ioc a b) (Ioc c d) :=
-  disjoint_left.2 fun _ h1 h2 ↦ not_and_of_not_left _
-    ((mem_Ioc.1 h1).2.trans hbc).not_lt (mem_Ioc.1 h2)
+theorem Ioc_disjoint_Ioc_same : Disjoint (Ioc a b) (Ioc b c) :=
+  disjoint_left.2 fun _ h1 h2 ↦ not_and_of_not_left _ (mem_Ioc.1 h1).2.not_lt (mem_Ioc.1 h2)
 
 variable (a)
 

--- a/Mathlib/Order/Interval/Finset/Basic.lean
+++ b/Mathlib/Order/Interval/Finset/Basic.lean
@@ -237,7 +237,7 @@ theorem Icc_ssubset_Icc_right (hI : a₂ ≤ b₂) (ha : a₂ ≤ a₁) (hb : b�
   rw [← coe_ssubset, coe_Icc, coe_Icc]
   exact Set.Icc_ssubset_Icc_right hI ha hb
 
-theorem Ioc_disjoint_Ioc {d : α} (hbc : b ≤ c) : Disjoint (Ioc a b) (Ioc c d) :=
+theorem Ioc_disjoint_Ioc_of_le {d : α} (hbc : b ≤ c) : Disjoint (Ioc a b) (Ioc c d) :=
   disjoint_left.2 fun _ h1 h2 ↦ not_and_of_not_left _
     ((mem_Ioc.1 h1).2.trans hbc).not_lt (mem_Ioc.1 h2)
 
@@ -815,6 +815,11 @@ theorem Ico_union_Ico {a b c d : α} (h₁ : min a b ≤ max c d) (h₂ : min c 
 theorem Ico_inter_Ico {a b c d : α} : Ico a b ∩ Ico c d = Ico (max a c) (min b d) := by
   rw [← coe_inj, coe_inter, coe_Ico, coe_Ico, coe_Ico, Set.Ico_inter_Ico]
 
+theorem Ioc_inter_Ioc {a b c d : α} : Ioc a b ∩ Ioc c d = Ioc (max a c) (min b d) := by
+  rw [← coe_inj]
+  push_cast
+  exact Set.Ioc_inter_Ioc
+
 @[simp]
 theorem Ico_filter_lt (a b c : α) : {x ∈ Ico a b | x < c} = Ico a (min b c) := by
   cases le_total b c with
@@ -855,6 +860,10 @@ theorem Ico_diff_Ico_right (a b c : α) : Ico a b \ Ico c b = Ico a (min b c) :=
     ext x
     rw [mem_sdiff, mem_Ico, mem_Ico, mem_Ico, min_eq_right h, and_assoc, not_and', not_le]
     exact and_congr_right' ⟨fun hx => hx.2 hx.1, fun hx => ⟨hx.trans_le h, fun _ => hx⟩⟩
+
+@[simp]
+theorem Ioc_disjoint_Ioc : Disjoint (Ioc a₁ a₂) (Ioc b₁ b₂) ↔ min a₂ b₂ ≤ max a₁ b₁ := by
+  simp_rw [disjoint_iff_inter_eq_empty, Ioc_inter_Ioc, Ioc_eq_empty_iff, not_lt]
 
 section LocallyFiniteOrderBot
 

--- a/Mathlib/Order/Interval/Finset/Basic.lean
+++ b/Mathlib/Order/Interval/Finset/Basic.lean
@@ -237,8 +237,12 @@ theorem Icc_ssubset_Icc_right (hI : a₂ ≤ b₂) (ha : a₂ ≤ a₁) (hb : b�
   rw [← coe_ssubset, coe_Icc, coe_Icc]
   exact Set.Icc_ssubset_Icc_right hI ha hb
 
+theorem Ioc_disjoint_Ioc_of_le {d : α} (hbc : b ≤ c) : Disjoint (Ioc a b) (Ioc c d) :=
+  disjoint_left.2 fun _ h1 h2 ↦ not_and_of_not_left _
+    ((mem_Ioc.1 h1).2.trans hbc).not_lt (mem_Ioc.1 h2)
+
 theorem Ioc_disjoint_Ioc_same : Disjoint (Ioc a b) (Ioc b c) :=
-  disjoint_left.2 fun _ h1 h2 ↦ not_and_of_not_left _ (mem_Ioc.1 h1).2.not_lt (mem_Ioc.1 h2)
+  Ioc_disjoint_Ioc_of_le le_rfl
 
 variable (a)
 

--- a/Mathlib/Order/Interval/Set/Disjoint.lean
+++ b/Mathlib/Order/Interval/Set/Disjoint.lean
@@ -43,6 +43,10 @@ theorem Iic_disjoint_Ioc (h : a ≤ b) : Disjoint (Iic a) (Ioc b c) :=
   (Iic_disjoint_Ioi h).mono le_rfl Ioc_subset_Ioi_self
 
 @[simp]
+theorem Ioc_disjoint_Ioc_of_le {d : α} (h : b ≤ c) : Disjoint (Ioc a b) (Ioc c d) :=
+  (Iic_disjoint_Ioc h).mono Ioc_subset_Iic_self le_rfl
+
+@[simp]
 theorem Ioc_disjoint_Ioc_same : Disjoint (Ioc a b) (Ioc b c) :=
   (Iic_disjoint_Ioc le_rfl).mono Ioc_subset_Iic_self le_rfl
 

--- a/Mathlib/Order/Interval/Set/Disjoint.lean
+++ b/Mathlib/Order/Interval/Set/Disjoint.lean
@@ -46,7 +46,9 @@ theorem Iic_disjoint_Ioc (h : a ≤ b) : Disjoint (Iic a) (Ioc b c) :=
 theorem Ioc_disjoint_Ioc_of_le {d : α} (h : b ≤ c) : Disjoint (Ioc a b) (Ioc c d) :=
   (Iic_disjoint_Ioc h).mono Ioc_subset_Iic_self le_rfl
 
-@[deprecated (since := "2025-03-04")] alias Ioc_disjoint_Ioc_same := Ioc_disjoint_Ioc_of_le
+@[deprecated "Use Ioc_disjoint_Ioc_of_le instead." (since := "2025-03-04")]
+theorem Ioc_disjoint_Ioc_same : Disjoint (Ioc a b) (Ioc b c) :=
+  (Iic_disjoint_Ioc le_rfl).mono Ioc_subset_Iic_self le_rfl
 
 @[simp]
 theorem Ico_disjoint_Ico_same : Disjoint (Ico a b) (Ico b c) :=

--- a/Mathlib/Order/Interval/Set/Disjoint.lean
+++ b/Mathlib/Order/Interval/Set/Disjoint.lean
@@ -46,8 +46,7 @@ theorem Iic_disjoint_Ioc (h : a ≤ b) : Disjoint (Iic a) (Ioc b c) :=
 theorem Ioc_disjoint_Ioc_of_le {d : α} (h : b ≤ c) : Disjoint (Ioc a b) (Ioc c d) :=
   (Iic_disjoint_Ioc h).mono Ioc_subset_Iic_self le_rfl
 
-theorem Ioc_disjoint_Ioc_same : Disjoint (Ioc a b) (Ioc b c) :=
-  (Iic_disjoint_Ioc le_rfl).mono Ioc_subset_Iic_self le_rfl
+@[deprecated (since := "2025-03-04")] alias Ioc_disjoint_Ioc_same := Ioc_disjoint_Ioc_of_le
 
 @[simp]
 theorem Ico_disjoint_Ico_same : Disjoint (Ico a b) (Ico b c) :=

--- a/Mathlib/Order/Interval/Set/Disjoint.lean
+++ b/Mathlib/Order/Interval/Set/Disjoint.lean
@@ -46,7 +46,7 @@ theorem Iic_disjoint_Ioc (h : a ≤ b) : Disjoint (Iic a) (Ioc b c) :=
 theorem Ioc_disjoint_Ioc_of_le {d : α} (h : b ≤ c) : Disjoint (Ioc a b) (Ioc c d) :=
   (Iic_disjoint_Ioc h).mono Ioc_subset_Iic_self le_rfl
 
-@[deprecated "Use Ioc_disjoint_Ioc_of_le instead." (since := "2025-03-04")]
+@[deprecated Ioc_disjoint_Ioc_of_le (since := "2025-03-04")]
 theorem Ioc_disjoint_Ioc_same : Disjoint (Ioc a b) (Ioc b c) :=
   (Iic_disjoint_Ioc le_rfl).mono Ioc_subset_Iic_self le_rfl
 

--- a/Mathlib/Order/Interval/Set/Disjoint.lean
+++ b/Mathlib/Order/Interval/Set/Disjoint.lean
@@ -46,7 +46,6 @@ theorem Iic_disjoint_Ioc (h : a ≤ b) : Disjoint (Iic a) (Ioc b c) :=
 theorem Ioc_disjoint_Ioc_of_le {d : α} (h : b ≤ c) : Disjoint (Ioc a b) (Ioc c d) :=
   (Iic_disjoint_Ioc h).mono Ioc_subset_Iic_self le_rfl
 
-@[simp]
 theorem Ioc_disjoint_Ioc_same : Disjoint (Ioc a b) (Ioc b c) :=
   (Iic_disjoint_Ioc le_rfl).mono Ioc_subset_Iic_self le_rfl
 


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
