### PR TITLE
[Merged by Bors] - feat: biSup and biInf for monotone and antitone functions

### DIFF
--- a/Mathlib/Order/CompleteLattice.lean
+++ b/Mathlib/Order/CompleteLattice.lean
@@ -1122,6 +1122,23 @@ lemma biInf_gt_eq_iInf {ι : Type*} [LT ι] [NoMinOrder ι] {f : ι → α} :
 lemma biInf_ge_eq_iInf {ι : Type*} [Preorder ι] {f : ι → α} : ⨅ (i) (j ≥ i), f j = ⨅ i, f i :=
   biInf_le_eq_iInf (ι := ιᵒᵈ)
 
+lemma biSup_le_eq_of_monotone [Preorder β] {f : β → α} (hf : Monotone f) (b : β) :
+    ⨆ (b' ≤ b), f b' = f b :=
+  le_antisymm (iSup₂_le_iff.2 (fun _ hji ↦ hf hji))
+    (le_iSup_of_le b (le_of_eq (Eq.symm (iSup_pos (Preorder.le_refl b)))))
+
+lemma biInf_le_eq_of_antitone [Preorder β] {f : β → α} (hf : Antitone f) (b : β) :
+    ⨅ (b' ≤ b), f b' = f b :=
+  biSup_le_eq_of_monotone (α := αᵒᵈ) hf.dual_right b
+
+lemma biSup_ge_eq_of_antitone [Preorder β] {f : β → α} (hf : Antitone f) (b : β) :
+    ⨆ (b' ≥ b), f b' = f b :=
+  biSup_le_eq_of_monotone (β := βᵒᵈ) hf.dual_left b
+
+lemma biInf_ge_of_monotone [Preorder β] {f : β → α} (hf : Monotone f) (b : β) :
+    ⨅ (b' ≥ b), f b' = f b :=
+  biInf_le_eq_of_antitone (β := βᵒᵈ) hf.dual_left b
+
 /-! ### `iSup` and `iInf` under `Prop` -/
 
 

--- a/Mathlib/Order/CompleteLattice.lean
+++ b/Mathlib/Order/CompleteLattice.lean
@@ -1135,7 +1135,7 @@ lemma biSup_ge_eq_of_antitone [Preorder β] {f : β → α} (hf : Antitone f) (b
     ⨆ (b' ≥ b), f b' = f b :=
   biSup_le_eq_of_monotone (β := βᵒᵈ) hf.dual_left b
 
-lemma biInf_ge_of_monotone [Preorder β] {f : β → α} (hf : Monotone f) (b : β) :
+lemma biInf_ge_eq_of_monotone [Preorder β] {f : β → α} (hf : Monotone f) (b : β) :
     ⨅ (b' ≥ b), f b' = f b :=
   biInf_le_eq_of_antitone (β := βᵒᵈ) hf.dual_left b
 


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
