### PR TITLE
[Merged by Bors] - feat: generalize map_div's type class

### DIFF
--- a/Mathlib/Algebra/Group/Ext.lean
+++ b/Mathlib/Algebra/Group/Ext.lean
@@ -125,7 +125,7 @@ theorem DivInvMonoid.ext {M : Type*} ⦃m₁ m₂ : DivInvMonoid M⦄
     ext a b
     exact @map_div' _ _
       (F := @MonoidHom _ _ (_) _) _ (id _) _
-      (@MonoidHom.instMonoidHomClass _ _ (_) _) f (congr_fun h_inv) a b
+      (@MonoidHom.instMonoidHomClass _ _ (_) _).toMulHomClass f (congr_fun h_inv) a b
   rcases m₁ with @⟨_, ⟨_⟩, ⟨_⟩⟩
   rcases m₂ with @⟨_, ⟨_⟩, ⟨_⟩⟩
   congr

--- a/Mathlib/Algebra/Group/Ext.lean
+++ b/Mathlib/Algebra/Group/Ext.lean
@@ -124,8 +124,7 @@ theorem DivInvMonoid.ext {M : Type*} ⦃m₁ m₂ : DivInvMonoid M⦄
   have : m₁.div = m₂.div := by
     ext a b
     exact @map_div' _ _
-      (F := @MonoidHom _ _ (_) _) _ (id _) _
-      (@MonoidHom.instMonoidHomClass _ _ (_) _).toMulHomClass f (congr_fun h_inv) a b
+      (F := @MonoidHom _ _ (_) _) _ (id _) _ inferInstance f (congr_fun h_inv) a b
   rcases m₁ with @⟨_, ⟨_⟩, ⟨_⟩⟩
   rcases m₂ with @⟨_, ⟨_⟩, ⟨_⟩⟩
   congr

--- a/Mathlib/Algebra/Group/Hom/Defs.lean
+++ b/Mathlib/Algebra/Group/Hom/Defs.lean
@@ -408,7 +408,7 @@ theorem map_mul_eq_one [MonoidHomClass F M N] (f : F) {a b : M} (h : a * b = 1) 
 variable [FunLike F G H]
 
 @[to_additive]
-theorem map_div' [DivInvMonoid G] [DivInvMonoid H] [MonoidHomClass F G H]
+theorem map_div' [DivInvMonoid G] [DivInvMonoid H] [MulHomClass F G H]
     (f : F) (hf : ∀ a, f a⁻¹ = (f a)⁻¹) (a b : G) : f (a / b) = f a / f b := by
   rw [div_eq_mul_inv, div_eq_mul_inv, map_mul, hf]
 


### PR DESCRIPTION
This generalization does not apply cleanly since a theorem that uses map_div' explicitly references an instance for this theorem. Manually fix that reference.

This is one of a series of PRs that generalizes type classes across Mathlib. These are generated using a new linter that tries to re-elaborate theorem definitions with more general type classes to see if it succeeds. It will accept the generalization if deleting the entire type class causes the theorem to fail to compile. Otherwise, the type class is not being generalized, but can simply be replaced by implicit type class synthesis (or an implicit type class in a variable block being pulled in.)