### PR TITLE
[Merged by Bors] - feat: more lemmas about alternatingGroup

### DIFF
--- a/Mathlib/GroupTheory/SpecificGroups/Alternating/Centralizer.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/Alternating/Centralizer.lean
@@ -269,6 +269,13 @@ section Perfect
 
 open Subgroup Equiv.Perm
 
+theorem alternatingGroup.commutator_perm_le :
+    commutator (Perm α) ≤ alternatingGroup α := by
+  simp only [commutator_eq_closure, closure_le, Set.subset_def, mem_commutatorSet_iff,
+    SetLike.mem_coe, mem_alternatingGroup, forall_exists_index]
+  rintro _ p q rfl
+  simp [map_commutatorElement, commutatorElement_eq_one_iff_commute, Commute.all]
+
 /-- If `n ≥ 5`, then the alternating group on `n` letters is perfect -/
 theorem commutator_alternatingGroup_eq_top (h5 : 5 ≤ Fintype.card α) :
     commutator (alternatingGroup α) = ⊤ := by
@@ -279,18 +286,11 @@ theorem commutator_alternatingGroup_eq_top (h5 : 5 ≤ Fintype.card α) :
   rw [← closure_three_cycles_eq_alternating]
   exact Subgroup.closure_closure_coe_preimage
 
-/-- If `n ≥ 5`, then the alternating group on `n` letters is perfect (subgroup version)-/
+/-- If `n ≥ 5`, then the alternating group on `n` letters is perfect (subgroup version) -/
 theorem commutator_alternatingGroup_eq_self (h5 : 5 ≤ Fintype.card α) :
     ⁅alternatingGroup α, alternatingGroup α⁆ = alternatingGroup α := by
   rw [← Subgroup.map_subtype_commutator, commutator_alternatingGroup_eq_top h5,
     ← MonoidHom.range_eq_map, Subgroup.range_subtype]
-
-theorem alternatingGroup.commutator_perm_le :
-    commutator (Perm α) ≤ alternatingGroup α := by
-  simp only [commutator_eq_closure, closure_le, Set.subset_def, mem_commutatorSet_iff,
-    SetLike.mem_coe, mem_alternatingGroup, forall_exists_index]
-  rintro _ p q rfl
-  simp [map_commutatorElement, commutatorElement_eq_one_iff_commute, Commute.all]
 
 /-- The commutator subgroup of the permutation group is the alternating group -/
 theorem alternatingGroup.commutator_perm_eq (h5 : 5 ≤ Fintype.card α) :

--- a/Mathlib/GroupTheory/SpecificGroups/Alternating/Centralizer.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/Alternating/Centralizer.lean
@@ -269,7 +269,7 @@ section Perfect
 
 open Subgroup Equiv.Perm
 
-/-- If n ≥ 5, then the alternating group on n letters is perfect -/
+/-- If `n ≥ 5`, then the alternating group on `n` letters is perfect -/
 theorem commutator_alternatingGroup_eq_top (h5 : 5 ≤ Fintype.card α) :
     commutator (alternatingGroup α) = ⊤ := by
   suffices closure {b : alternatingGroup α | (b : Perm α).IsThreeCycle} = ⊤ by
@@ -279,7 +279,7 @@ theorem commutator_alternatingGroup_eq_top (h5 : 5 ≤ Fintype.card α) :
   rw [← closure_three_cycles_eq_alternating]
   exact Subgroup.closure_closure_coe_preimage
 
-/-- If n ≥ 5, then the alternating group on n letters is perfect (subgroup version)-/
+/-- If `n ≥ 5`, then the alternating group on `n` letters is perfect (subgroup version)-/
 theorem commutator_alternatingGroup_eq_self (h5 : 5 ≤ Fintype.card α) :
     ⁅alternatingGroup α, alternatingGroup α⁆ = alternatingGroup α := by
   rw [← Subgroup.map_subtype_commutator, commutator_alternatingGroup_eq_top h5,

--- a/Mathlib/GroupTheory/SpecificGroups/Alternating/Centralizer.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/Alternating/Centralizer.lean
@@ -3,6 +3,7 @@ Copyright (c) 2023 Antoine Chambert-Loir. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Antoine Chambert-Loir
 -/
+import Mathlib.GroupTheory.Abelianization
 import Mathlib.GroupTheory.Perm.Centralizer
 import Mathlib.GroupTheory.SpecificGroups.Alternating
 
@@ -244,4 +245,58 @@ theorem centralizer_le_alternating_iff :
       have := card_fixedPoints g
       exact card_support_le_one.mp <| le_trans (Finset.card_le_univ _) (by omega)
 
+namespace IsThreeCycle
+
+variable (h5 : 5 ≤ Fintype.card α) {g : alternatingGroup α} (hg : IsThreeCycle (g : Perm α))
+
+include h5 hg
+
+theorem mem_commutatorSet_alternatingGroup : g ∈ commutatorSet (alternatingGroup α) := by
+  apply mem_commutatorSet_of_isConj_sq
+  apply alternatingGroup.isThreeCycle_isConj h5 hg
+  simpa [sq] using hg.isThreeCycle_sq
+
+theorem mem_commutator_alternatingGroup : g ∈ commutator (alternatingGroup α) := by
+  rw [commutator_eq_closure]
+  apply Subgroup.subset_closure
+  exact hg.mem_commutatorSet_alternatingGroup h5
+
+end IsThreeCycle
+
 end Equiv.Perm
+
+section Perfect
+
+open Subgroup Equiv.Perm
+
+/-- If n ≥ 5, then the alternating group on n letters is perfect -/
+theorem commutator_alternatingGroup_eq_top (h5 : 5 ≤ Fintype.card α) :
+    commutator (alternatingGroup α) = ⊤ := by
+  suffices closure {b : alternatingGroup α | (b : Perm α).IsThreeCycle} = ⊤ by
+    rw [eq_top_iff, ← this, Subgroup.closure_le]
+    intro b hb
+    exact hb.mem_commutator_alternatingGroup h5
+  rw [← closure_three_cycles_eq_alternating]
+  exact Subgroup.closure_closure_coe_preimage
+
+/-- If n ≥ 5, then the alternating group on n letters is perfect (subgroup version)-/
+theorem commutator_alternatingGroup_eq_self (h5 : 5 ≤ Fintype.card α) :
+    ⁅alternatingGroup α, alternatingGroup α⁆ = alternatingGroup α := by
+  rw [← Subgroup.map_subtype_commutator, commutator_alternatingGroup_eq_top h5,
+    ← MonoidHom.range_eq_map, Subgroup.range_subtype]
+
+theorem alternatingGroup.commutator_perm_le :
+    commutator (Perm α) ≤ alternatingGroup α := by
+  simp only [commutator_eq_closure, closure_le, Set.subset_def, mem_commutatorSet_iff,
+    SetLike.mem_coe, mem_alternatingGroup, forall_exists_index]
+  rintro _ p q rfl
+  simp [map_commutatorElement, commutatorElement_eq_one_iff_commute, Commute.all]
+
+/-- The commutator subgroup of the permutation group is the alternating group -/
+theorem alternatingGroup.commutator_perm_eq (h5 : 5 ≤ Fintype.card α) :
+    commutator (Perm α) = alternatingGroup α := by
+  apply le_antisymm alternatingGroup.commutator_perm_le
+  rw [← commutator_alternatingGroup_eq_self h5]
+  exact commutator_mono le_top le_top
+
+end Perfect


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

cc @AntoineChambert-Loir (whose code this is)