### PR TITLE
[Merged by Bors] - chore: fix typo-ed name `Continous.ereal_toENNReal`

### DIFF
--- a/Mathlib/Topology/Instances/EReal/Lemmas.lean
+++ b/Mathlib/Topology/Instances/EReal/Lemmas.lean
@@ -203,10 +203,13 @@ lemma continuous_toENNReal : Continuous EReal.toENNReal := by
   simp_all only [mem_compl_iff, mem_singleton_iff, mem_insert_iff, or_self, not_false_eq_true]
 
 @[fun_prop]
-lemma _root_.Continous.ereal_toENNReal {α : Type*} [TopologicalSpace α] {f : α → EReal}
+lemma _root_.Continuous.ereal_toENNReal {α : Type*} [TopologicalSpace α] {f : α → EReal}
     (hf : Continuous f) :
     Continuous fun x => (f x).toENNReal :=
   continuous_toENNReal.comp hf
+
+@[deprecated (since := "2025-03-05")] alias _root_.Continous.ereal_toENNReal :=
+  _root_.Continuous.ereal_toENNReal
 
 @[fun_prop]
 lemma _root_.ContinuousOn.ereal_toENNReal {α : Type*} [TopologicalSpace α] {s : Set α}


### PR DESCRIPTION
It should read `Continuous.ereal_toENNReal`, of course.