### PR TITLE
doc(Topology/Defs/Induced): fix comments on three functions related to RestrictGenTopology

### DIFF
--- a/Mathlib/Topology/Defs/Induced.lean
+++ b/Mathlib/Topology/Defs/Induced.lean
@@ -83,15 +83,10 @@ end TopologicalSpace
 namespace Topology
 variable {X Y : Type*} [tX : TopologicalSpace X] [tY : TopologicalSpace Y]
 
-/-- We say that restrictions of the topology on `X` to sets from a family `S`
-generates the original topology,
-if either of the following equivalent conditions hold:
-
-- a set which is relatively open in each `s ∈ S` is open;
-- a set which is relatively closed in each `s ∈ S` is closed;
-- for any topological space `Y`, a function `f : X → Y` is continuous
-  provided that it is continuous on each `s ∈ S`.
--/
+/-- We say that restrictions of the topology on `X` to sets from a
+family `S` generates the original topology, if for any topological
+space `Y`, a function `f : X → Y` is continuous provided that it is
+continuous on each `s ∈ S`.  -/
 structure RestrictGenTopology (S : Set (Set X)) : Prop where
   isOpen_of_forall_induced (u : Set X) : (∀ s ∈ S, IsOpen ((↑) ⁻¹' u : Set s)) → IsOpen u
 

--- a/Mathlib/Topology/Defs/Induced.lean
+++ b/Mathlib/Topology/Defs/Induced.lean
@@ -83,10 +83,9 @@ end TopologicalSpace
 namespace Topology
 variable {X Y : Type*} [tX : TopologicalSpace X] [tY : TopologicalSpace Y]
 
-/-- We say that restrictions of the topology on `X` to sets from a
-family `S` generates the original topology, if for any topological
-space `Y`, a function `f : X → Y` is continuous provided that it is
-continuous on each `s ∈ S`.  -/
+/-- The restriction of a topology on `X` to sets from a family `S`
+generates the original topology if a set which is relatively open in
+each `s ∈ S` is open.  -/
 structure RestrictGenTopology (S : Set (Set X)) : Prop where
   isOpen_of_forall_induced (u : Set X) : (∀ s ∈ S, IsOpen ((↑) ⁻¹' u : Set s)) → IsOpen u
 

--- a/Mathlib/Topology/RestrictGen.lean
+++ b/Mathlib/Topology/RestrictGen.lean
@@ -53,6 +53,10 @@ protected theorem continuous_iff {Y : Type*} [TopologicalSpace Y] {f : X → Y}
   ⟨fun h _ _ ↦ h.continuousOn, fun h ↦ continuous_def.2 fun _u hu ↦ hS.isOpen_iff.2 fun s hs ↦
     hu.preimage <| (h s hs).restrict⟩
 
+/-- The restriction of a topology on `X` to sets from a family `S`
+generates the original topology if for any topological space `Y`, a
+function `f : X → Y` is continuous provided that it is continuous on
+each `s ∈ S`.  -/
 theorem of_continuous_prop (h : ∀ f : X → Prop, (∀ s ∈ S, ContinuousOn f s) → Continuous f) :
     RestrictGenTopology S where
   isOpen_of_forall_induced u hu := by

--- a/Mathlib/Topology/RestrictGen.lean
+++ b/Mathlib/Topology/RestrictGen.lean
@@ -63,6 +63,9 @@ theorem of_continuous_prop (h : ∀ f : X → Prop, (∀ s ∈ S, ContinuousOn f
     simp only [continuousOn_iff_continuous_restrict, continuous_Prop] at *
     exact h _ hu
 
+/-- The restriction of a topology on `X` to set from a family `S`
+generates the original topology if a set which is relatively closed in
+each `s ∈ S` is closed. -/
 theorem of_isClosed (h : ∀ t : Set X, (∀ s ∈ S, IsClosed ((↑) ⁻¹' t : Set s)) → IsClosed t) :
     RestrictGenTopology S :=
   ⟨fun _t ht ↦ isClosed_compl_iff.1 <| h _ fun s hs ↦ (ht s hs).isClosed_compl⟩

--- a/Mathlib/Topology/RestrictGen.lean
+++ b/Mathlib/Topology/RestrictGen.lean
@@ -63,7 +63,7 @@ theorem of_continuous_prop (h : ∀ f : X → Prop, (∀ s ∈ S, ContinuousOn f
     simp only [continuousOn_iff_continuous_restrict, continuous_Prop] at *
     exact h _ hu
 
-/-- The restriction of a topology on `X` to set from a family `S`
+/-- The restriction of a topology on `X` to sets from a family `S`
 generates the original topology if a set which is relatively closed in
 each `s ∈ S` is closed. -/
 theorem of_isClosed (h : ∀ t : Set X, (∀ s ∈ S, IsClosed ((↑) ⁻¹' t : Set s)) → IsClosed t) :


### PR DESCRIPTION

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
