### PR TITLE
[Merged by Bors] - feat(Analysis/SpecialFunctions/Pow): add continuity of constant^x for real x

### DIFF
--- a/Mathlib/Analysis/SpecialFunctions/Pow/Continuity.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Pow/Continuity.lean
@@ -225,6 +225,11 @@ theorem continuousAt_rpow_const (x : ℝ) (q : ℝ) (h : x ≠ 0 ∨ 0 ≤ q) :
 @[fun_prop]
 theorem continuous_rpow_const {q : ℝ} (h : 0 ≤ q) : Continuous (fun x : ℝ => x ^ q) :=
   continuous_iff_continuousAt.mpr fun x ↦ continuousAt_rpow_const x q (.inr h)
+
+@[fun_prop]
+lemma continuous_const_rpow {a : ℝ} (h: a ≠ 0) : Continuous fun x : ℝ ↦ a ^ x :=
+  continuous_iff_continuousAt.mpr fun _ ↦ continuousAt_const_rpow h
+
 end Real
 
 section

--- a/Mathlib/Analysis/SpecialFunctions/Pow/Continuity.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Pow/Continuity.lean
@@ -227,7 +227,7 @@ theorem continuous_rpow_const {q : ℝ} (h : 0 ≤ q) : Continuous (fun x : ℝ 
   continuous_iff_continuousAt.mpr fun x ↦ continuousAt_rpow_const x q (.inr h)
 
 @[fun_prop]
-lemma continuous_const_rpow {a : ℝ} (h: a ≠ 0) : Continuous fun x : ℝ ↦ a ^ x :=
+lemma continuous_const_rpow {a : ℝ} (h : a ≠ 0) : Continuous (fun x : ℝ ↦ a ^ x) :=
   continuous_iff_continuousAt.mpr fun _ ↦ continuousAt_const_rpow h
 
 end Real


### PR DESCRIPTION
Add the lemma `continuous_const_rpow`

Motivation: There is lemma `continuous_const_cpow` to prove constant^x is continuous for complex x, but no analogue lemma for real exists. This also causes difficulty to prove such facts using `fun_prop`. 

See [minor discussion on Zulip](https://leanprover.zulipchat.com/#narrow/channel/113489-new-members/topic/proving.202.5Ex.20is.20continous).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
