### PR TITLE
[Merged by Bors] - chore(Topology): also split off Bornology results about reals

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -5596,6 +5596,7 @@ import Mathlib.Topology.Bornology.Basic
 import Mathlib.Topology.Bornology.BoundedOperation
 import Mathlib.Topology.Bornology.Constructions
 import Mathlib.Topology.Bornology.Hom
+import Mathlib.Topology.Bornology.Real
 import Mathlib.Topology.CWComplex.Abstract.Basic
 import Mathlib.Topology.CWComplex.Classical.Basic
 import Mathlib.Topology.Category.Born

--- a/Mathlib/MeasureTheory/OuterMeasure/Defs.lean
+++ b/Mathlib/MeasureTheory/OuterMeasure/Defs.lean
@@ -33,7 +33,7 @@ We also define a typeclass `MeasureTheory.OuterMeasureClass`.
 outer measure
 -/
 
-assert_not_exists IsTopologicalRing
+assert_not_exists IsTopologicalRing UniformSpace
 
 open scoped ENNReal
 

--- a/Mathlib/Topology/Algebra/Ring/Real.lean
+++ b/Mathlib/Topology/Algebra/Ring/Real.lean
@@ -6,6 +6,7 @@ Authors: Johannes Hölzl, Mario Carneiro
 import Mathlib.Data.NNReal.Defs
 import Mathlib.Topology.Algebra.Order.Field
 import Mathlib.Topology.Algebra.UniformGroup.Defs
+import Mathlib.Topology.Bornology.Real
 import Mathlib.Topology.Instances.Int
 import Mathlib.Topology.Order.MonotoneContinuity
 import Mathlib.Topology.Order.Real

--- a/Mathlib/Topology/Bornology/Real.lean
+++ b/Mathlib/Topology/Bornology/Real.lean
@@ -1,0 +1,53 @@
+/-
+Copyright (c) 2017 Johannes Hölzl. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Johannes Hölzl, Mario Carneiro
+-/
+import Mathlib.Topology.MetricSpace.Bounded
+import Mathlib.Topology.Order.Bornology
+
+/-!
+# The reals are equipped with their order bornology
+
+This file contains results related to the order bornology on (non-negative) real numbers.
+We
+- prove that `ℝ` and `ℝ≥0` are equipped with the order topology and bornology.
+-/
+
+assert_not_exists IsTopologicalRing UniformContinuousConstSMul UniformOnFun
+
+open Metric Set
+
+instance instIsOrderBornology : IsOrderBornology ℝ where
+  isBounded_iff_bddBelow_bddAbove s := by
+    refine ⟨fun bdd ↦ ?_, fun h ↦ isBounded_of_bddAbove_of_bddBelow h.2 h.1⟩
+    obtain ⟨r, hr⟩ : ∃ r : ℝ, s ⊆ Icc (-r) r := by
+      simpa [Real.closedBall_eq_Icc] using bdd.subset_closedBall 0
+    exact ⟨bddBelow_Icc.mono hr, bddAbove_Icc.mono hr⟩
+
+namespace NNReal
+
+/-!
+Instances for the following typeclasses are defined:
+
+* `OrderTopology ℝ≥0`
+* `IsOrderBornology ℝ≥0`
+
+Everything is inherited from the corresponding structures on the reals.
+-/
+
+instance : OrderTopology ℝ≥0 :=
+  orderTopology_of_ordConnected (t := Ici 0)
+
+-- TODO: generalize this to a broader class of subtypes
+instance : IsOrderBornology ℝ≥0 where
+  isBounded_iff_bddBelow_bddAbove s := by
+    refine ⟨fun bdd ↦ ?_, fun h ↦ isBounded_of_bddAbove_of_bddBelow h.2 h.1⟩
+    obtain ⟨r, hr⟩ : ∃ r : ℝ≥0, s ⊆ Icc 0 r := by
+      obtain ⟨rreal, hrreal⟩ := bdd.subset_closedBall 0
+      use rreal.toNNReal
+      simp only [← NNReal.closedBall_zero_eq_Icc', Real.coe_toNNReal']
+      exact subset_trans hrreal (Metric.closedBall_subset_closedBall (le_max_left rreal 0))
+    exact ⟨bddBelow_Icc.mono hr, bddAbove_Icc.mono hr⟩
+
+end NNReal

--- a/Mathlib/Topology/Bornology/Real.lean
+++ b/Mathlib/Topology/Bornology/Real.lean
@@ -10,8 +10,7 @@ import Mathlib.Topology.Order.Bornology
 # The reals are equipped with their order bornology
 
 This file contains results related to the order bornology on (non-negative) real numbers.
-We
-- prove that `ℝ` and `ℝ≥0` are equipped with the order topology and bornology.
+We prove that `ℝ` and `ℝ≥0` are equipped with the order topology and bornology.
 -/
 
 assert_not_exists IsTopologicalRing UniformContinuousConstSMul UniformOnFun
@@ -28,12 +27,7 @@ instance instIsOrderBornology : IsOrderBornology ℝ where
 namespace NNReal
 
 /-!
-Instances for the following typeclasses are defined:
-
-* `OrderTopology ℝ≥0`
-* `IsOrderBornology ℝ≥0`
-
-Everything is inherited from the corresponding structures on the reals.
+Every instance is inherited from the corresponding structures on the reals.
 -/
 
 instance : OrderTopology ℝ≥0 :=

--- a/Mathlib/Topology/Order/Real.lean
+++ b/Mathlib/Topology/Order/Real.lean
@@ -4,8 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Mario Carneiro
 -/
 import Mathlib.Data.Real.EReal
-import Mathlib.Topology.MetricSpace.Bounded
-import Mathlib.Topology.Order.Bornology
 import Mathlib.Topology.Order.T5
 
 /-!
@@ -18,16 +16,9 @@ We
 - define the topology `ℝ≥0∞` (which is the order topology, *not* the `EMetricSpace` topology)
 -/
 
-assert_not_exists IsTopologicalRing UniformContinuousConstSMul UniformOnFun
+assert_not_exists IsTopologicalRing UniformSpace
 
-open Metric Set
-
-instance instIsOrderBornology : IsOrderBornology ℝ where
-  isBounded_iff_bddBelow_bddAbove s := by
-    refine ⟨fun bdd ↦ ?_, fun h ↦ isBounded_of_bddAbove_of_bddBelow h.2 h.1⟩
-    obtain ⟨r, hr⟩ : ∃ r : ℝ, s ⊆ Icc (-r) r := by
-      simpa [Real.closedBall_eq_Icc] using bdd.subset_closedBall 0
-    exact ⟨bddBelow_Icc.mono hr, bddAbove_Icc.mono hr⟩
+open Set
 
 namespace EReal
 
@@ -65,30 +56,3 @@ instance : T5Space ℝ≥0∞ := inferInstance
 instance : T4Space ℝ≥0∞ := inferInstance
 
 end ENNReal
-
-namespace NNReal
-
-/-!
-Instances for the following typeclasses are defined:
-
-* `OrderTopology ℝ≥0`
-* `IsOrderBornology ℝ≥0`
-
-Everything is inherited from the corresponding structures on the reals.
--/
-
-instance : OrderTopology ℝ≥0 :=
-  orderTopology_of_ordConnected (t := Ici 0)
-
--- TODO: generalize this to a broader class of subtypes
-instance : IsOrderBornology ℝ≥0 where
-  isBounded_iff_bddBelow_bddAbove s := by
-    refine ⟨fun bdd ↦ ?_, fun h ↦ isBounded_of_bddAbove_of_bddBelow h.2 h.1⟩
-    obtain ⟨r, hr⟩ : ∃ r : ℝ≥0, s ⊆ Icc 0 r := by
-      obtain ⟨rreal, hrreal⟩ := bdd.subset_closedBall 0
-      use rreal.toNNReal
-      simp only [← NNReal.closedBall_zero_eq_Icc', Real.coe_toNNReal']
-      exact subset_trans hrreal (Metric.closedBall_subset_closedBall (le_max_left rreal 0))
-    exact ⟨bddBelow_Icc.mono hr, bddAbove_Icc.mono hr⟩
-
-end NNReal


### PR DESCRIPTION
This is motivated by avoiding an import of `UniformSpace` in `OuterMeasure/Defs.lean`. There don't seem to be many downstream advantages, so I'm not going to push this PR very hard.

---

- [ ] depends on: #22562

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
