### PR TITLE
[Merged by Bors] - chore(MeasureTheory): rename pi family from π to X

### DIFF
--- a/Mathlib/MeasureTheory/Constructions/BorelSpace/Basic.lean
+++ b/Mathlib/MeasureTheory/Constructions/BorelSpace/Basic.lean
@@ -345,19 +345,19 @@ instance (priority := 100) OpensMeasurableSpace.toMeasurableSingletonClass [T1Sp
     MeasurableSingletonClass α :=
   ⟨fun _ => isClosed_singleton.measurableSet⟩
 
-instance Pi.opensMeasurableSpace {ι : Type*} {π : ι → Type*} [Countable ι]
-    [t' : ∀ i, TopologicalSpace (π i)] [∀ i, MeasurableSpace (π i)]
-    [∀ i, SecondCountableTopology (π i)] [∀ i, OpensMeasurableSpace (π i)] :
-    OpensMeasurableSpace (∀ i, π i) := by
+instance Pi.opensMeasurableSpace {ι : Type*} {X : ι → Type*} [Countable ι]
+    [t' : ∀ i, TopologicalSpace (X i)] [∀ i, MeasurableSpace (X i)]
+    [∀ i, SecondCountableTopology (X i)] [∀ i, OpensMeasurableSpace (X i)] :
+    OpensMeasurableSpace (∀ i, X i) := by
   constructor
-  have : Pi.topologicalSpace = .generateFrom { t | ∃ (s : ∀ a, Set (π a)) (i : Finset ι),
-      (∀ a ∈ i, s a ∈ countableBasis (π a)) ∧ t = pi (↑i) s } := by
-    simp only [funext fun a => @eq_generateFrom_countableBasis (π a) _ _, pi_generateFrom_eq]
+  have : Pi.topologicalSpace = .generateFrom { t | ∃ (s : ∀ a, Set (X a)) (i : Finset ι),
+      (∀ a ∈ i, s a ∈ countableBasis (X a)) ∧ t = pi (↑i) s } := by
+    simp only [funext fun a => @eq_generateFrom_countableBasis (X a) _ _, pi_generateFrom_eq]
   rw [borel_eq_generateFrom_of_subbasis this]
   apply generateFrom_le
   rintro _ ⟨s, i, hi, rfl⟩
   refine MeasurableSet.pi i.countable_toSet fun a ha => IsOpen.measurableSet ?_
-  rw [eq_generateFrom_countableBasis (π a)]
+  rw [eq_generateFrom_countableBasis (X a)]
   exact .basic _ (hi a ha)
 
 /-- The typeclass `SecondCountableTopologyEither α β` registers the fact that at least one of
@@ -589,10 +589,10 @@ variable [TopologicalSpace α] [MeasurableSpace α] [BorelSpace α] [Topological
   [MeasurableSpace β] [BorelSpace β] [TopologicalSpace γ] [MeasurableSpace γ] [BorelSpace γ]
   [MeasurableSpace δ]
 
-theorem pi_le_borel_pi {ι : Type*} {π : ι → Type*} [∀ i, TopologicalSpace (π i)]
-    [∀ i, MeasurableSpace (π i)] [∀ i, BorelSpace (π i)] :
-      MeasurableSpace.pi ≤ borel (∀ i, π i) := by
-  have : ‹∀ i, MeasurableSpace (π i)› = fun i => borel (π i) :=
+theorem pi_le_borel_pi {ι : Type*} {X : ι → Type*} [∀ i, TopologicalSpace (X i)]
+    [∀ i, MeasurableSpace (X i)] [∀ i, BorelSpace (X i)] :
+      MeasurableSpace.pi ≤ borel (∀ i, X i) := by
+  have : ‹∀ i, MeasurableSpace (X i)› = fun i => borel (X i) :=
     funext fun i => BorelSpace.measurable_eq
   rw [this]
   exact iSup_le fun i => comap_le_iff_le_map.2 <| (continuous_apply i).borel_measurable
@@ -603,9 +603,9 @@ theorem prod_le_borel_prod : Prod.instMeasurableSpace ≤ borel (α × β) := by
   · exact comap_le_iff_le_map.mpr continuous_fst.borel_measurable
   · exact comap_le_iff_le_map.mpr continuous_snd.borel_measurable
 
-instance Pi.borelSpace {ι : Type*} {π : ι → Type*} [Countable ι] [∀ i, TopologicalSpace (π i)]
-    [∀ i, MeasurableSpace (π i)] [∀ i, SecondCountableTopology (π i)] [∀ i, BorelSpace (π i)] :
-    BorelSpace (∀ i, π i) :=
+instance Pi.borelSpace {ι : Type*} {X : ι → Type*} [Countable ι] [∀ i, TopologicalSpace (X i)]
+    [∀ i, MeasurableSpace (X i)] [∀ i, SecondCountableTopology (X i)] [∀ i, BorelSpace (X i)] :
+    BorelSpace (∀ i, X i) :=
   ⟨le_antisymm pi_le_borel_pi OpensMeasurableSpace.borel_le⟩
 
 instance Prod.borelSpace [SecondCountableTopologyEither α β] :

--- a/Mathlib/MeasureTheory/Constructions/Cylinders.lean
+++ b/Mathlib/MeasureTheory/Constructions/Cylinders.lean
@@ -8,14 +8,14 @@ import Mathlib.Topology.Constructions
 import Mathlib.MeasureTheory.MeasurableSpace.Basic
 
 /-!
-# π-systems of cylinders and square cylinders
+# X-systems of cylinders and square cylinders
 
 The instance `MeasurableSpace.pi` on `∀ i, α i`, where each `α i` has a `MeasurableSpace` `m i`,
 is defined as `⨆ i, (m i).comap (fun a => a i)`.
 That is, a function `g : β → ∀ i, α i` is measurable iff for all `i`, the function `b ↦ g b i`
 is measurable.
 
-We define two π-systems generating `MeasurableSpace.pi`, cylinders and square cylinders.
+We define two X-systems generating `MeasurableSpace.pi`, cylinders and square cylinders.
 
 ## Main definitions
 
@@ -366,47 +366,47 @@ end cylinders
 
 section cylinderEvents
 
-variable {α ι : Type*} {π : ι → Type*} {mα : MeasurableSpace α} [m : ∀ i, MeasurableSpace (π i)]
+variable {α ι : Type*} {X : ι → Type*} {mα : MeasurableSpace α} [m : ∀ i, MeasurableSpace (X i)]
   {Δ Δ₁ Δ₂ : Set ι} {i : ι}
 
 /-- The σ-algebra of cylinder events on `Δ`. It is the smallest σ-algebra making the projections
 on the `i`-th coordinate continuous for all `i ∈ Δ`. -/
-def cylinderEvents (Δ : Set ι) : MeasurableSpace (∀ i, π i) := ⨆ i ∈ Δ, (m i).comap fun σ ↦ σ i
+def cylinderEvents (Δ : Set ι) : MeasurableSpace (∀ i, X i) := ⨆ i ∈ Δ, (m i).comap fun σ ↦ σ i
 
-@[simp] lemma cylinderEvents_univ : cylinderEvents (π := π) univ = MeasurableSpace.pi := by
+@[simp] lemma cylinderEvents_univ : cylinderEvents (X := X) univ = MeasurableSpace.pi := by
   simp [cylinderEvents, MeasurableSpace.pi]
 
 @[gcongr]
-lemma cylinderEvents_mono (h : Δ₁ ⊆ Δ₂) : cylinderEvents (π := π) Δ₁ ≤ cylinderEvents Δ₂ :=
+lemma cylinderEvents_mono (h : Δ₁ ⊆ Δ₂) : cylinderEvents (X := X) Δ₁ ≤ cylinderEvents Δ₂ :=
   biSup_mono h
 
-lemma cylinderEvents_le_pi : cylinderEvents (π := π) Δ ≤ MeasurableSpace.pi := by
+lemma cylinderEvents_le_pi : cylinderEvents (X := X) Δ ≤ MeasurableSpace.pi := by
   simpa using cylinderEvents_mono (subset_univ _)
 
-lemma measurable_cylinderEvents_iff {g : α → ∀ i, π i} :
+lemma measurable_cylinderEvents_iff {g : α → ∀ i, X i} :
     @Measurable _ _ _ (cylinderEvents Δ) g ↔ ∀ ⦃i⦄, i ∈ Δ → Measurable fun a ↦ g a i := by
   simp_rw [measurable_iff_comap_le, cylinderEvents, MeasurableSpace.comap_iSup,
     MeasurableSpace.comap_comp, Function.comp_def, iSup_le_iff]
 
 @[fun_prop, aesop safe 100 apply (rule_sets := [Measurable])]
 lemma measurable_cylinderEvent_apply (hi : i ∈ Δ) :
-    Measurable[cylinderEvents Δ] fun f : ∀ i, π i => f i :=
+    Measurable[cylinderEvents Δ] fun f : ∀ i, X i => f i :=
   measurable_cylinderEvents_iff.1 measurable_id hi
 
 @[aesop safe 100 apply (rule_sets := [Measurable])]
-lemma Measurable.eval_cylinderEvents {g : α → ∀ i, π i} (hi : i ∈ Δ)
+lemma Measurable.eval_cylinderEvents {g : α → ∀ i, X i} (hi : i ∈ Δ)
     (hg : @Measurable _ _ _ (cylinderEvents Δ) g) : Measurable fun a ↦ g a i :=
   (measurable_cylinderEvent_apply hi).comp hg
 
 @[fun_prop, aesop safe 100 apply (rule_sets := [Measurable])]
-lemma measurable_cylinderEvents_lambda (f : α → ∀ i, π i) (hf : ∀ i, Measurable fun a ↦ f a i) :
+lemma measurable_cylinderEvents_lambda (f : α → ∀ i, X i) (hf : ∀ i, Measurable fun a ↦ f a i) :
     Measurable f :=
   measurable_pi_iff.mpr hf
 
-/-- The function `(f, x) ↦ update f a x : (Π a, π a) × π a → Π a, π a` is measurable. -/
+/-- The function `(f, x) ↦ update f a x : (Π a, X a) × X a → Π a, X a` is measurable. -/
 lemma measurable_update_cylinderEvents' [DecidableEq ι] :
     @Measurable _ _ (.prod (cylinderEvents Δ) (m i)) (cylinderEvents Δ)
-      (fun p : (∀ i, π i) × π i ↦ update p.1 i p.2) := by
+      (fun p : (∀ i, X i) × X i ↦ update p.1 i p.2) := by
   rw [measurable_cylinderEvents_iff]
   intro j hj
   dsimp [update]
@@ -417,23 +417,23 @@ lemma measurable_update_cylinderEvents' [DecidableEq ι] :
   · exact measurable_cylinderEvents_iff.1 measurable_fst hj
 
 lemma measurable_uniqueElim_cylinderEvents [Unique ι] :
-    Measurable (uniqueElim : π (default : ι) → ∀ i, π i) := by
+    Measurable (uniqueElim : X (default : ι) → ∀ i, X i) := by
   simp_rw [measurable_pi_iff, Unique.forall_iff, uniqueElim_default]; exact measurable_id
 
-/-- The function `update f a : π a → Π a, π a` is always measurable.
+/-- The function `update f a : X a → Π a, X a` is always measurable.
 This doesn't require `f` to be measurable.
 This should not be confused with the statement that `update f a x` is measurable. -/
 @[measurability]
-lemma measurable_update_cylinderEvents (f : ∀ a : ι, π a) {a : ι} [DecidableEq ι] :
+lemma measurable_update_cylinderEvents (f : ∀ a : ι, X a) {a : ι} [DecidableEq ι] :
     @Measurable _ _ _ (cylinderEvents Δ) (update f a) :=
   measurable_update_cylinderEvents'.comp measurable_prod_mk_left
 
-lemma measurable_update_cylinderEvents_left {a : ι} [DecidableEq ι] {x : π a} :
+lemma measurable_update_cylinderEvents_left {a : ι} [DecidableEq ι] {x : X a} :
     @Measurable _ _ (cylinderEvents Δ) (cylinderEvents Δ) (update · a x) :=
   measurable_update_cylinderEvents'.comp measurable_prod_mk_right
 
 lemma measurable_restrict_cylinderEvents (Δ : Set ι) :
-    Measurable[cylinderEvents (π := π) Δ] (restrict Δ) := by
+    Measurable[cylinderEvents (X := X) Δ] (restrict Δ) := by
   rw [@measurable_pi_iff]; exact fun i ↦ measurable_cylinderEvent_apply i.2
 
 end cylinderEvents

--- a/Mathlib/MeasureTheory/Constructions/Cylinders.lean
+++ b/Mathlib/MeasureTheory/Constructions/Cylinders.lean
@@ -8,14 +8,14 @@ import Mathlib.Topology.Constructions
 import Mathlib.MeasureTheory.MeasurableSpace.Basic
 
 /-!
-# X-systems of cylinders and square cylinders
+# π-systems of cylinders and square cylinders
 
 The instance `MeasurableSpace.pi` on `∀ i, α i`, where each `α i` has a `MeasurableSpace` `m i`,
 is defined as `⨆ i, (m i).comap (fun a => a i)`.
 That is, a function `g : β → ∀ i, α i` is measurable iff for all `i`, the function `b ↦ g b i`
 is measurable.
 
-We define two X-systems generating `MeasurableSpace.pi`, cylinders and square cylinders.
+We define two π-systems generating `MeasurableSpace.pi`, cylinders and square cylinders.
 
 ## Main definitions
 

--- a/Mathlib/MeasureTheory/Constructions/Pi.lean
+++ b/Mathlib/MeasureTheory/Constructions/Pi.lean
@@ -127,7 +127,7 @@ section Tprod
 
 open List
 
-variable {δ : Type*} {X : δ → Type*} [∀ x, MeasurableSpace (X x)]
+variable {δ : Type*} {X : δ → Type*} [∀ i, MeasurableSpace (X i)]
 
 -- for some reason the equation compiler doesn't like this definition
 /-- A product of measures in `tprod α l`. -/

--- a/Mathlib/MeasureTheory/Constructions/Pi.lean
+++ b/Mathlib/MeasureTheory/Constructions/Pi.lean
@@ -127,32 +127,32 @@ section Tprod
 
 open List
 
-variable {δ : Type*} {π : δ → Type*} [∀ x, MeasurableSpace (π x)]
+variable {δ : Type*} {X : δ → Type*} [∀ x, MeasurableSpace (X x)]
 
 -- for some reason the equation compiler doesn't like this definition
 /-- A product of measures in `tprod α l`. -/
-protected def tprod (l : List δ) (μ : ∀ i, Measure (π i)) : Measure (TProd π l) := by
+protected def tprod (l : List δ) (μ : ∀ i, Measure (X i)) : Measure (TProd X l) := by
   induction' l with i l ih
   · exact dirac PUnit.unit
-  · exact (μ i).prod (α := π i) ih
+  · exact (μ i).prod (α := X i) ih
 
 @[simp]
-theorem tprod_nil (μ : ∀ i, Measure (π i)) : Measure.tprod [] μ = dirac PUnit.unit :=
+theorem tprod_nil (μ : ∀ i, Measure (X i)) : Measure.tprod [] μ = dirac PUnit.unit :=
   rfl
 
 @[simp]
-theorem tprod_cons (i : δ) (l : List δ) (μ : ∀ i, Measure (π i)) :
+theorem tprod_cons (i : δ) (l : List δ) (μ : ∀ i, Measure (X i)) :
     Measure.tprod (i :: l) μ = (μ i).prod (Measure.tprod l μ) :=
   rfl
 
-instance sigmaFinite_tprod (l : List δ) (μ : ∀ i, Measure (π i)) [∀ i, SigmaFinite (μ i)] :
+instance sigmaFinite_tprod (l : List δ) (μ : ∀ i, Measure (X i)) [∀ i, SigmaFinite (μ i)] :
     SigmaFinite (Measure.tprod l μ) := by
   induction l with
   | nil => rw [tprod_nil]; infer_instance
   | cons i l ih => rw [tprod_cons]; exact @prod.instSigmaFinite _ _ _ _ _ _ _ ih
 
-theorem tprod_tprod (l : List δ) (μ : ∀ i, Measure (π i)) [∀ i, SigmaFinite (μ i)]
-    (s : ∀ i, Set (π i)) :
+theorem tprod_tprod (l : List δ) (μ : ∀ i, Measure (X i)) [∀ i, SigmaFinite (μ i)]
+    (s : ∀ i, Set (X i)) :
     Measure.tprod l μ (Set.tprod l s) = (l.map fun i => (μ i) (s i)).prod := by
   induction l with
   | nil => simp
@@ -705,31 +705,31 @@ theorem volume_measurePreserving_arrowProdEquivProdArrow (α β γ : Type*) [Mea
     MeasurePreserving (MeasurableEquiv.arrowProdEquivProdArrow α β γ) :=
   measurePreserving_arrowProdEquivProdArrow α β γ (fun _ ↦ volume) (fun _ ↦ volume)
 
-theorem measurePreserving_sumPiEquivProdPi_symm {π : ι ⊕ ι' → Type*}
-    {m : ∀ i, MeasurableSpace (π i)} (μ : ∀ i, Measure (π i)) [∀ i, SigmaFinite (μ i)] :
-    MeasurePreserving (MeasurableEquiv.sumPiEquivProdPi π).symm
+theorem measurePreserving_sumPiEquivProdPi_symm {X : ι ⊕ ι' → Type*}
+    {m : ∀ i, MeasurableSpace (X i)} (μ : ∀ i, Measure (X i)) [∀ i, SigmaFinite (μ i)] :
+    MeasurePreserving (MeasurableEquiv.sumPiEquivProdPi X).symm
       ((Measure.pi fun i => μ (.inl i)).prod (Measure.pi fun i => μ (.inr i))) (Measure.pi μ) where
-  measurable := (MeasurableEquiv.sumPiEquivProdPi π).symm.measurable
+  measurable := (MeasurableEquiv.sumPiEquivProdPi X).symm.measurable
   map_eq := by
     refine (pi_eq fun s _ => ?_).symm
     simp_rw [MeasurableEquiv.map_apply, MeasurableEquiv.coe_sumPiEquivProdPi_symm,
       Equiv.sumPiEquivProdPi_symm_preimage_univ_pi, Measure.prod_prod, Measure.pi_pi,
       Fintype.prod_sum_type]
 
-theorem volume_measurePreserving_sumPiEquivProdPi_symm (π : ι ⊕ ι' → Type*)
-    [∀ i, MeasureSpace (π i)] [∀ i, SigmaFinite (volume : Measure (π i))] :
-    MeasurePreserving (MeasurableEquiv.sumPiEquivProdPi π).symm volume volume :=
+theorem volume_measurePreserving_sumPiEquivProdPi_symm (X : ι ⊕ ι' → Type*)
+    [∀ i, MeasureSpace (X i)] [∀ i, SigmaFinite (volume : Measure (X i))] :
+    MeasurePreserving (MeasurableEquiv.sumPiEquivProdPi X).symm volume volume :=
   measurePreserving_sumPiEquivProdPi_symm (fun _ ↦ volume)
 
-theorem measurePreserving_sumPiEquivProdPi {π : ι ⊕ ι' → Type*} {_m : ∀ i, MeasurableSpace (π i)}
-    (μ : ∀ i, Measure (π i)) [∀ i, SigmaFinite (μ i)] :
-    MeasurePreserving (MeasurableEquiv.sumPiEquivProdPi π)
+theorem measurePreserving_sumPiEquivProdPi {X : ι ⊕ ι' → Type*} {_m : ∀ i, MeasurableSpace (X i)}
+    (μ : ∀ i, Measure (X i)) [∀ i, SigmaFinite (μ i)] :
+    MeasurePreserving (MeasurableEquiv.sumPiEquivProdPi X)
       (Measure.pi μ) ((Measure.pi fun i => μ (.inl i)).prod (Measure.pi fun i => μ (.inr i))) :=
   measurePreserving_sumPiEquivProdPi_symm μ |>.symm
 
-theorem volume_measurePreserving_sumPiEquivProdPi (π : ι ⊕ ι' → Type*)
-    [∀ i, MeasureSpace (π i)] [∀ i, SigmaFinite (volume : Measure (π i))] :
-    MeasurePreserving (MeasurableEquiv.sumPiEquivProdPi π) volume volume :=
+theorem volume_measurePreserving_sumPiEquivProdPi (X : ι ⊕ ι' → Type*)
+    [∀ i, MeasureSpace (X i)] [∀ i, SigmaFinite (volume : Measure (X i))] :
+    MeasurePreserving (MeasurableEquiv.sumPiEquivProdPi X) volume volume :=
   measurePreserving_sumPiEquivProdPi (fun _ ↦ volume)
 
 theorem measurePreserving_piFinSuccAbove {n : ℕ} {α : Fin (n + 1) → Type u}
@@ -749,12 +749,12 @@ theorem volume_preserving_piFinSuccAbove {n : ℕ} (α : Fin (n + 1) → Type u)
     MeasurePreserving (MeasurableEquiv.piFinSuccAbove α i) :=
   measurePreserving_piFinSuccAbove (fun _ => volume) i
 
-theorem measurePreserving_piUnique {π : ι → Type*} [Unique ι] {m : ∀ i, MeasurableSpace (π i)}
-    (μ : ∀ i, Measure (π i)) :
-    MeasurePreserving (MeasurableEquiv.piUnique π) (Measure.pi μ) (μ default) where
-  measurable := (MeasurableEquiv.piUnique π).measurable
+theorem measurePreserving_piUnique {X : ι → Type*} [Unique ι] {m : ∀ i, MeasurableSpace (X i)}
+    (μ : ∀ i, Measure (X i)) :
+    MeasurePreserving (MeasurableEquiv.piUnique X) (Measure.pi μ) (μ default) where
+  measurable := (MeasurableEquiv.piUnique X).measurable
   map_eq := by
-    set e := MeasurableEquiv.piUnique π
+    set e := MeasurableEquiv.piUnique X
     have : (piPremeasure fun i => (μ i).toOuterMeasure) = Measure.map e.symm (μ default) := by
       ext1 s
       rw [piPremeasure, Fintype.prod_unique, e.symm.map_apply, coe_toOuterMeasure]
@@ -762,8 +762,8 @@ theorem measurePreserving_piUnique {π : ι → Type*} [Unique ι] {m : ∀ i, M
     simp_rw [Measure.pi, OuterMeasure.pi, this, ← coe_toOuterMeasure, boundedBy_eq_self,
       toOuterMeasure_toMeasure, MeasurableEquiv.map_map_symm]
 
-theorem volume_preserving_piUnique (π : ι → Type*) [Unique ι] [∀ i, MeasureSpace (π i)] :
-    MeasurePreserving (MeasurableEquiv.piUnique π) volume volume :=
+theorem volume_preserving_piUnique (X : ι → Type*) [Unique ι] [∀ i, MeasureSpace (X i)] :
+    MeasurePreserving (MeasurableEquiv.piUnique X) volume volume :=
   measurePreserving_piUnique _
 
 theorem measurePreserving_funUnique {β : Type u} {_m : MeasurableSpace β} (μ : Measure β)

--- a/Mathlib/MeasureTheory/Integral/Marginal.lean
+++ b/Mathlib/MeasureTheory/Integral/Marginal.lean
@@ -19,8 +19,8 @@ space (e.g. `((ι ⊕ ι') → ℝ) ≃ (ι → ℝ) × (ι' → ℝ)`).
 
 ## Main Definitions
 
-* Assume that `∀ i : ι, π i` is a product of measurable spaces with measures `μ i` on `π i`,
-  `f : (∀ i, π i) → ℝ≥0∞` is a function and `s : Finset ι`.
+* Assume that `∀ i : ι, X i` is a product of measurable spaces with measures `μ i` on `X i`,
+  `f : (∀ i, X i) → ℝ≥0∞` is a function and `s : Finset ι`.
   Then `lmarginal μ s f` or `∫⋯∫⁻_s, f ∂μ` is the function that integrates `f`
   over all variables in `s`. It returns a function that still takes the same variables as `f`,
   but is constant in the variables in `s`. Mathematically, if `s = {i₁, ..., iₖ}`,
@@ -64,17 +64,17 @@ namespace MeasureTheory
 
 section LMarginal
 
-variable {δ δ' : Type*} {π : δ → Type*} [∀ x, MeasurableSpace (π x)]
-variable {μ : ∀ i, Measure (π i)} [DecidableEq δ]
-variable {s t : Finset δ} {f : (∀ i, π i) → ℝ≥0∞} {x : ∀ i, π i}
+variable {δ δ' : Type*} {X : δ → Type*} [∀ x, MeasurableSpace (X x)]
+variable {μ : ∀ i, Measure (X i)} [DecidableEq δ]
+variable {s t : Finset δ} {f : (∀ i, X i) → ℝ≥0∞} {x : ∀ i, X i}
 
 /-- Integrate `f(x₁,…,xₙ)` over all variables `xᵢ` where `i ∈ s`. Return a function in the
   remaining variables (it will be constant in the `xᵢ` for `i ∈ s`).
   This is the marginal distribution of all variables not in `s` when the considered measure
   is the product measure. -/
-def lmarginal (μ : ∀ i, Measure (π i)) (s : Finset δ) (f : (∀ i, π i) → ℝ≥0∞)
-    (x : ∀ i, π i) : ℝ≥0∞ :=
-  ∫⁻ y : ∀ i : s, π i, f (updateFinset x s y) ∂Measure.pi fun i : s => μ i
+def lmarginal (μ : ∀ i, Measure (X i)) (s : Finset δ) (f : (∀ i, X i) → ℝ≥0∞)
+    (x : ∀ i, X i) : ℝ≥0∞ :=
+  ∫⁻ y : ∀ i : s, X i, f (updateFinset x s y) ∂Measure.pi fun i : s => μ i
 
 -- Note: this notation is not a binder. This is more convenient since it returns a function.
 @[inherit_doc]
@@ -94,20 +94,20 @@ theorem _root_.Measurable.lmarginal [∀ i, SigmaFinite (μ i)] (hf : Measurable
   · simpa [hi, updateFinset] using measurable_pi_iff.1 measurable_snd _
   · simpa [hi, updateFinset] using measurable_pi_iff.1 measurable_fst _
 
-@[simp] theorem lmarginal_empty (f : (∀ i, π i) → ℝ≥0∞) : ∫⋯∫⁻_∅, f ∂μ = f := by
+@[simp] theorem lmarginal_empty (f : (∀ i, X i) → ℝ≥0∞) : ∫⋯∫⁻_∅, f ∂μ = f := by
   ext1 x
   simp_rw [lmarginal, Measure.pi_of_empty fun i : (∅ : Finset δ) => μ i]
   apply lintegral_dirac'
   exact Subsingleton.measurable
 
 /-- The marginal distribution is independent of the variables in `s`. -/
-theorem lmarginal_congr {x y : ∀ i, π i} (f : (∀ i, π i) → ℝ≥0∞)
+theorem lmarginal_congr {x y : ∀ i, X i} (f : (∀ i, X i) → ℝ≥0∞)
     (h : ∀ i ∉ s, x i = y i) :
     (∫⋯∫⁻_s, f ∂μ) x = (∫⋯∫⁻_s, f ∂μ) y := by
   dsimp [lmarginal, updateFinset_def]; rcongr; exact h _ ‹_›
 
 theorem lmarginal_update_of_mem {i : δ} (hi : i ∈ s)
-    (f : (∀ i, π i) → ℝ≥0∞) (x : ∀ i, π i) (y : π i) :
+    (f : (∀ i, X i) → ℝ≥0∞) (x : ∀ i, X i) (y : X i) :
     (∫⋯∫⁻_s, f ∂μ) (Function.update x i y) = (∫⋯∫⁻_s, f ∂μ) x := by
   apply lmarginal_congr
   intro j hj
@@ -115,13 +115,13 @@ theorem lmarginal_update_of_mem {i : δ} (hi : i ∈ s)
   apply update_of_ne this
 
 variable {μ} in
-theorem lmarginal_singleton (f : (∀ i, π i) → ℝ≥0∞) (i : δ) :
+theorem lmarginal_singleton (f : (∀ i, X i) → ℝ≥0∞) (i : δ) :
     ∫⋯∫⁻_{i}, f ∂μ = fun x => ∫⁻ xᵢ, f (Function.update x i xᵢ) ∂μ i := by
   let α : Type _ := ({i} : Finset δ)
-  let e := (MeasurableEquiv.piUnique fun j : α ↦ π j).symm
+  let e := (MeasurableEquiv.piUnique fun j : α ↦ X j).symm
   ext1 x
   calc (∫⋯∫⁻_{i}, f ∂μ) x
-      = ∫⁻ (y : π (default : α)), f (updateFinset x {i} (e y)) ∂μ (default : α) := by
+      = ∫⁻ (y : X (default : α)), f (updateFinset x {i} (e y)) ∂μ (default : α) := by
         simp_rw [lmarginal,
           measurePreserving_piUnique (fun j : ({i} : Finset δ) ↦ μ j) |>.symm _
             |>.lintegral_map_equiv, e, α]
@@ -129,22 +129,22 @@ theorem lmarginal_singleton (f : (∀ i, π i) → ℝ≥0∞) (i : δ) :
 
 variable {μ} in
 @[gcongr]
-theorem lmarginal_mono {f g : (∀ i, π i) → ℝ≥0∞} (hfg : f ≤ g) : ∫⋯∫⁻_s, f ∂μ ≤ ∫⋯∫⁻_s, g ∂μ :=
+theorem lmarginal_mono {f g : (∀ i, X i) → ℝ≥0∞} (hfg : f ≤ g) : ∫⋯∫⁻_s, f ∂μ ≤ ∫⋯∫⁻_s, g ∂μ :=
   fun _ => lintegral_mono fun _ => hfg _
 
 variable [∀ i, SigmaFinite (μ i)]
 
-theorem lmarginal_union (f : (∀ i, π i) → ℝ≥0∞) (hf : Measurable f)
+theorem lmarginal_union (f : (∀ i, X i) → ℝ≥0∞) (hf : Measurable f)
     (hst : Disjoint s t) : ∫⋯∫⁻_s ∪ t, f ∂μ = ∫⋯∫⁻_s, ∫⋯∫⁻_t, f ∂μ ∂μ := by
   ext1 x
-  let e := MeasurableEquiv.piFinsetUnion π hst
+  let e := MeasurableEquiv.piFinsetUnion X hst
   calc (∫⋯∫⁻_s ∪ t, f ∂μ) x
-      = ∫⁻ (y : (i : ↥(s ∪ t)) → π i), f (updateFinset x (s ∪ t) y)
+      = ∫⁻ (y : (i : ↥(s ∪ t)) → X i), f (updateFinset x (s ∪ t) y)
           ∂.pi fun i' : ↥(s ∪ t) ↦ μ i' := rfl
-    _ = ∫⁻ (y : ((i : s) → π i) × ((j : t) → π j)), f (updateFinset x (s ∪ t) _)
+    _ = ∫⁻ (y : ((i : s) → X i) × ((j : t) → X j)), f (updateFinset x (s ∪ t) _)
           ∂(Measure.pi fun i : s ↦ μ i).prod (.pi fun j : t ↦ μ j) := by
         rw [measurePreserving_piFinsetUnion hst μ |>.lintegral_map_equiv]
-    _ = ∫⁻ (y : (i : s) → π i), ∫⁻ (z : (j : t) → π j), f (updateFinset x (s ∪ t) (e (y, z)))
+    _ = ∫⁻ (y : (i : s) → X i), ∫⁻ (z : (j : t) → X j), f (updateFinset x (s ∪ t) (e (y, z)))
           ∂.pi fun j : t ↦ μ j ∂.pi fun i : s ↦ μ i := by
         apply lintegral_prod
         apply Measurable.aemeasurable
@@ -153,7 +153,7 @@ theorem lmarginal_union (f : (∀ i, π i) → ℝ≥0∞) (hf : Measurable f)
         simp_rw [lmarginal, updateFinset_updateFinset hst]
         rfl
 
-theorem lmarginal_union' (f : (∀ i, π i) → ℝ≥0∞) (hf : Measurable f) {s t : Finset δ}
+theorem lmarginal_union' (f : (∀ i, X i) → ℝ≥0∞) (hf : Measurable f) {s t : Finset δ}
     (hst : Disjoint s t) : ∫⋯∫⁻_s ∪ t, f ∂μ = ∫⋯∫⁻_t, ∫⋯∫⁻_s, f ∂μ ∂μ := by
   rw [Finset.union_comm, lmarginal_union μ f hf hst.symm]
 
@@ -161,22 +161,22 @@ variable {μ}
 
 /-- Peel off a single integral from a `lmarginal` integral at the beginning (compare with
 `lmarginal_insert'`, which peels off an integral at the end). -/
-theorem lmarginal_insert (f : (∀ i, π i) → ℝ≥0∞) (hf : Measurable f) {i : δ}
-    (hi : i ∉ s) (x : ∀ i, π i) :
+theorem lmarginal_insert (f : (∀ i, X i) → ℝ≥0∞) (hf : Measurable f) {i : δ}
+    (hi : i ∉ s) (x : ∀ i, X i) :
     (∫⋯∫⁻_insert i s, f ∂μ) x = ∫⁻ xᵢ, (∫⋯∫⁻_s, f ∂μ) (Function.update x i xᵢ) ∂μ i := by
   rw [Finset.insert_eq, lmarginal_union μ f hf (Finset.disjoint_singleton_left.mpr hi),
     lmarginal_singleton]
 
 /-- Peel off a single integral from a `lmarginal` integral at the beginning (compare with
 `lmarginal_erase'`, which peels off an integral at the end). -/
-theorem lmarginal_erase (f : (∀ i, π i) → ℝ≥0∞) (hf : Measurable f) {i : δ}
-    (hi : i ∈ s) (x : ∀ i, π i) :
+theorem lmarginal_erase (f : (∀ i, X i) → ℝ≥0∞) (hf : Measurable f) {i : δ}
+    (hi : i ∈ s) (x : ∀ i, X i) :
     (∫⋯∫⁻_s, f ∂μ) x = ∫⁻ xᵢ, (∫⋯∫⁻_(erase s i), f ∂μ) (Function.update x i xᵢ) ∂μ i := by
   simpa [insert_erase hi] using lmarginal_insert _ hf (not_mem_erase i s) x
 
 /-- Peel off a single integral from a `lmarginal` integral at the end (compare with
 `lmarginal_insert`, which peels off an integral at the beginning). -/
-theorem lmarginal_insert' (f : (∀ i, π i) → ℝ≥0∞) (hf : Measurable f) {i : δ}
+theorem lmarginal_insert' (f : (∀ i, X i) → ℝ≥0∞) (hf : Measurable f) {i : δ}
     (hi : i ∉ s) :
     ∫⋯∫⁻_insert i s, f ∂μ = ∫⋯∫⁻_s, (fun x ↦ ∫⁻ xᵢ, f (Function.update x i xᵢ) ∂μ i) ∂μ := by
   rw [Finset.insert_eq, Finset.union_comm,
@@ -184,12 +184,12 @@ theorem lmarginal_insert' (f : (∀ i, π i) → ℝ≥0∞) (hf : Measurable f)
 
 /-- Peel off a single integral from a `lmarginal` integral at the end (compare with
 `lmarginal_erase`, which peels off an integral at the beginning). -/
-theorem lmarginal_erase' (f : (∀ i, π i) → ℝ≥0∞) (hf : Measurable f) {i : δ}
+theorem lmarginal_erase' (f : (∀ i, X i) → ℝ≥0∞) (hf : Measurable f) {i : δ}
     (hi : i ∈ s) :
     ∫⋯∫⁻_s, f ∂μ = ∫⋯∫⁻_(erase s i), (fun x ↦ ∫⁻ xᵢ, f (Function.update x i xᵢ) ∂μ i) ∂μ := by
   simpa [insert_erase hi] using lmarginal_insert' _ hf (not_mem_erase i s)
 
-@[simp] theorem lmarginal_univ [Fintype δ] {f : (∀ i, π i) → ℝ≥0∞} :
+@[simp] theorem lmarginal_univ [Fintype δ] {f : (∀ i, X i) → ℝ≥0∞} :
     ∫⋯∫⁻_univ, f ∂μ = fun _ => ∫⁻ x, f x ∂Measure.pi μ := by
   let e : { j // j ∈ Finset.univ } ≃ δ := Equiv.subtypeUnivEquiv mem_univ
   ext1 x
@@ -197,13 +197,13 @@ theorem lmarginal_erase' (f : (∀ i, π i) → ℝ≥0∞) (hf : Measurable f) 
   simp
   rfl
 
-theorem lintegral_eq_lmarginal_univ [Fintype δ] {f : (∀ i, π i) → ℝ≥0∞} (x : ∀ i, π i) :
+theorem lintegral_eq_lmarginal_univ [Fintype δ] {f : (∀ i, X i) → ℝ≥0∞} (x : ∀ i, X i) :
     ∫⁻ x, f x ∂Measure.pi μ = (∫⋯∫⁻_univ, f ∂μ) x := by simp
 
 theorem lmarginal_image [DecidableEq δ'] {e : δ' → δ} (he : Injective e) (s : Finset δ')
-    {f : (∀ i, π (e i)) → ℝ≥0∞} (hf : Measurable f) (x : ∀ i, π i) :
+    {f : (∀ i, X (e i)) → ℝ≥0∞} (hf : Measurable f) (x : ∀ i, X i) :
       (∫⋯∫⁻_s.image e, f ∘ (· ∘' e) ∂μ) x = (∫⋯∫⁻_s, f ∂μ ∘' e) (x ∘' e) := by
-  have h : Measurable ((· ∘' e) : (∀ i, π i) → _) :=
+  have h : Measurable ((· ∘' e) : (∀ i, X i) → _) :=
     measurable_pi_iff.mpr <| fun i ↦ measurable_pi_apply (e i)
   induction s using Finset.induction generalizing x with
   | empty => simp
@@ -213,7 +213,7 @@ theorem lmarginal_image [DecidableEq δ'] {e : δ' → δ} (he : Injective e) (s
     simp_rw [ih, ← update_comp_eq_of_injective' x he]
 
 theorem lmarginal_update_of_not_mem {i : δ}
-    {f : (∀ i, π i) → ℝ≥0∞} (hf : Measurable f) (hi : i ∉ s) (x : ∀ i, π i) (y : π i) :
+    {f : (∀ i, X i) → ℝ≥0∞} (hf : Measurable f) (hi : i ∉ s) (x : ∀ i, X i) (y : X i) :
     (∫⋯∫⁻_s, f ∂μ) (Function.update x i y) = (∫⋯∫⁻_s, f ∘ (Function.update · i y) ∂μ) x := by
   induction s using Finset.induction generalizing x with
   | empty => simp
@@ -222,30 +222,30 @@ theorem lmarginal_update_of_not_mem {i : δ}
     have hii' : i ≠ i' := mt (by rintro rfl; exact mem_insert_self i s) hi
     simp_rw [update_comm hii', ih (mt Finset.mem_insert_of_mem hi)]
 
-theorem lmarginal_eq_of_subset {f g : (∀ i, π i) → ℝ≥0∞} (hst : s ⊆ t)
+theorem lmarginal_eq_of_subset {f g : (∀ i, X i) → ℝ≥0∞} (hst : s ⊆ t)
     (hf : Measurable f) (hg : Measurable g) (hfg : ∫⋯∫⁻_s, f ∂μ = ∫⋯∫⁻_s, g ∂μ) :
     ∫⋯∫⁻_t, f ∂μ = ∫⋯∫⁻_t, g ∂μ := by
   rw [← union_sdiff_of_subset hst, lmarginal_union' μ f hf disjoint_sdiff,
     lmarginal_union' μ g hg disjoint_sdiff, hfg]
 
-theorem lmarginal_le_of_subset {f g : (∀ i, π i) → ℝ≥0∞} (hst : s ⊆ t)
+theorem lmarginal_le_of_subset {f g : (∀ i, X i) → ℝ≥0∞} (hst : s ⊆ t)
     (hf : Measurable f) (hg : Measurable g) (hfg : ∫⋯∫⁻_s, f ∂μ ≤ ∫⋯∫⁻_s, g ∂μ) :
     ∫⋯∫⁻_t, f ∂μ ≤ ∫⋯∫⁻_t, g ∂μ := by
   rw [← union_sdiff_of_subset hst, lmarginal_union' μ f hf disjoint_sdiff,
     lmarginal_union' μ g hg disjoint_sdiff]
   exact lmarginal_mono hfg
 
-theorem lintegral_eq_of_lmarginal_eq [Fintype δ] (s : Finset δ) {f g : (∀ i, π i) → ℝ≥0∞}
+theorem lintegral_eq_of_lmarginal_eq [Fintype δ] (s : Finset δ) {f g : (∀ i, X i) → ℝ≥0∞}
     (hf : Measurable f) (hg : Measurable g) (hfg : ∫⋯∫⁻_s, f ∂μ = ∫⋯∫⁻_s, g ∂μ) :
     ∫⁻ x, f x ∂Measure.pi μ = ∫⁻ x, g x ∂Measure.pi μ := by
-  rcases isEmpty_or_nonempty (∀ i, π i) with h|⟨⟨x⟩⟩
+  rcases isEmpty_or_nonempty (∀ i, X i) with h|⟨⟨x⟩⟩
   · simp_rw [lintegral_of_isEmpty]
   simp_rw [lintegral_eq_lmarginal_univ x, lmarginal_eq_of_subset (Finset.subset_univ s) hf hg hfg]
 
-theorem lintegral_le_of_lmarginal_le [Fintype δ] (s : Finset δ) {f g : (∀ i, π i) → ℝ≥0∞}
+theorem lintegral_le_of_lmarginal_le [Fintype δ] (s : Finset δ) {f g : (∀ i, X i) → ℝ≥0∞}
     (hf : Measurable f) (hg : Measurable g) (hfg : ∫⋯∫⁻_s, f ∂μ ≤ ∫⋯∫⁻_s, g ∂μ) :
     ∫⁻ x, f x ∂Measure.pi μ ≤ ∫⁻ x, g x ∂Measure.pi μ := by
-  rcases isEmpty_or_nonempty (∀ i, π i) with h|⟨⟨x⟩⟩
+  rcases isEmpty_or_nonempty (∀ i, X i) with h|⟨⟨x⟩⟩
   · simp_rw [lintegral_of_isEmpty, le_rfl]
   simp_rw [lintegral_eq_lmarginal_univ x, lmarginal_le_of_subset (Finset.subset_univ s) hf hg hfg x]
 

--- a/Mathlib/MeasureTheory/Integral/Marginal.lean
+++ b/Mathlib/MeasureTheory/Integral/Marginal.lean
@@ -64,7 +64,7 @@ namespace MeasureTheory
 
 section LMarginal
 
-variable {δ δ' : Type*} {X : δ → Type*} [∀ x, MeasurableSpace (X x)]
+variable {δ δ' : Type*} {X : δ → Type*} [∀ i, MeasurableSpace (X i)]
 variable {μ : ∀ i, Measure (X i)} [DecidableEq δ]
 variable {s t : Finset δ} {f : (∀ i, X i) → ℝ≥0∞} {x : ∀ i, X i}
 

--- a/Mathlib/MeasureTheory/MeasurableSpace/Basic.lean
+++ b/Mathlib/MeasureTheory/MeasurableSpace/Basic.lean
@@ -51,7 +51,7 @@ defined in terms of the Galois connection induced by f.
 
 ## Tags
 
-measurable space, σ-algebra, measurable function, dynkin system, X-λ theorem, X-system
+measurable space, σ-algebra, measurable function, dynkin system, π-λ theorem, π-system
 -/
 
 open Set Encodable Function Equiv Filter MeasureTheory

--- a/Mathlib/MeasureTheory/MeasurableSpace/Basic.lean
+++ b/Mathlib/MeasureTheory/MeasurableSpace/Basic.lean
@@ -51,7 +51,7 @@ defined in terms of the Galois connection induced by f.
 
 ## Tags
 
-measurable space, σ-algebra, measurable function, dynkin system, π-λ theorem, π-system
+measurable space, σ-algebra, measurable function, dynkin system, X-λ theorem, X-system
 -/
 
 open Set Encodable Function Equiv Filter MeasureTheory
@@ -827,35 +827,35 @@ end Prod
 
 section Pi
 
-variable {π : δ → Type*} [MeasurableSpace α]
+variable {X : δ → Type*} [MeasurableSpace α]
 
-instance MeasurableSpace.pi [m : ∀ a, MeasurableSpace (π a)] : MeasurableSpace (∀ a, π a) :=
+instance MeasurableSpace.pi [m : ∀ a, MeasurableSpace (X a)] : MeasurableSpace (∀ a, X a) :=
   ⨆ a, (m a).comap fun b => b a
 
-variable [∀ a, MeasurableSpace (π a)] [MeasurableSpace γ]
+variable [∀ a, MeasurableSpace (X a)] [MeasurableSpace γ]
 
-theorem measurable_pi_iff {g : α → ∀ a, π a} : Measurable g ↔ ∀ a, Measurable fun x => g x a := by
+theorem measurable_pi_iff {g : α → ∀ a, X a} : Measurable g ↔ ∀ a, Measurable fun x => g x a := by
   simp_rw [measurable_iff_comap_le, MeasurableSpace.pi, MeasurableSpace.comap_iSup,
     MeasurableSpace.comap_comp, Function.comp_def, iSup_le_iff]
 
 @[fun_prop, aesop safe 100 apply (rule_sets := [Measurable])]
-theorem measurable_pi_apply (a : δ) : Measurable fun f : ∀ a, π a => f a :=
+theorem measurable_pi_apply (a : δ) : Measurable fun f : ∀ a, X a => f a :=
   measurable_pi_iff.1 measurable_id a
 
 @[aesop safe 100 apply (rule_sets := [Measurable])]
-theorem Measurable.eval {a : δ} {g : α → ∀ a, π a} (hg : Measurable g) :
+theorem Measurable.eval {a : δ} {g : α → ∀ a, X a} (hg : Measurable g) :
     Measurable fun x => g x a :=
   (measurable_pi_apply a).comp hg
 
 @[fun_prop, aesop safe 100 apply (rule_sets := [Measurable])]
-theorem measurable_pi_lambda (f : α → ∀ a, π a) (hf : ∀ a, Measurable fun c => f c a) :
+theorem measurable_pi_lambda (f : α → ∀ a, X a) (hf : ∀ a, Measurable fun c => f c a) :
     Measurable f :=
   measurable_pi_iff.mpr hf
 
-/-- The function `(f, x) ↦ update f a x : (Π a, π a) × π a → Π a, π a` is measurable. -/
+/-- The function `(f, x) ↦ update f a x : (Π a, X a) × X a → Π a, X a` is measurable. -/
 @[measurability, fun_prop]
 theorem measurable_update'  {a : δ} [DecidableEq δ] :
-    Measurable (fun p : (∀ i, π i) × π a ↦ update p.1 a p.2) := by
+    Measurable (fun p : (∀ i, X i) × X a ↦ update p.1 a p.2) := by
   rw [measurable_pi_iff]
   intro j
   dsimp [update]
@@ -867,54 +867,54 @@ theorem measurable_update'  {a : δ} [DecidableEq δ] :
 
 @[measurability, fun_prop]
 theorem measurable_uniqueElim [Unique δ] :
-    Measurable (uniqueElim : π (default : δ) → ∀ i, π i) := by
+    Measurable (uniqueElim : X (default : δ) → ∀ i, X i) := by
   simp_rw [measurable_pi_iff, Unique.forall_iff, uniqueElim_default]; exact measurable_id
 
 @[measurability, fun_prop]
 theorem measurable_updateFinset' [DecidableEq δ] {s : Finset δ} :
-    Measurable (fun p : (Π i, π i) × (Π i : s, π i) ↦ updateFinset p.1 s p.2) := by
+    Measurable (fun p : (Π i, X i) × (Π i : s, X i) ↦ updateFinset p.1 s p.2) := by
   simp only [updateFinset, measurable_pi_iff]
   intro i
   by_cases h : i ∈ s <;> simp [h, Measurable.eval, measurable_fst, measurable_snd]
 
 @[measurability, fun_prop]
-theorem measurable_updateFinset [DecidableEq δ] {s : Finset δ} {x : Π i, π i} :
+theorem measurable_updateFinset [DecidableEq δ] {s : Finset δ} {x : Π i, X i} :
     Measurable (updateFinset x s) :=
   measurable_updateFinset'.comp measurable_prod_mk_left
 
 @[measurability, fun_prop]
-theorem measurable_updateFinset_left [DecidableEq δ] {s : Finset δ} {x : Π i : s, π i} :
+theorem measurable_updateFinset_left [DecidableEq δ] {s : Finset δ} {x : Π i : s, X i} :
     Measurable (updateFinset · s x) :=
   measurable_updateFinset'.comp measurable_prod_mk_right
 
-/-- The function `update f a : π a → Π a, π a` is always measurable.
+/-- The function `update f a : X a → Π a, X a` is always measurable.
   This doesn't require `f` to be measurable.
   This should not be confused with the statement that `update f a x` is measurable. -/
 @[measurability, fun_prop]
-theorem measurable_update (f : ∀ a : δ, π a) {a : δ} [DecidableEq δ] : Measurable (update f a) :=
+theorem measurable_update (f : ∀ a : δ, X a) {a : δ} [DecidableEq δ] : Measurable (update f a) :=
   measurable_update'.comp measurable_prod_mk_left
 
 @[measurability, fun_prop]
-theorem measurable_update_left {a : δ} [DecidableEq δ] {x : π a} :
+theorem measurable_update_left {a : δ} [DecidableEq δ] {x : X a} :
     Measurable (update · a x) :=
   measurable_update'.comp measurable_prod_mk_right
 
 @[measurability, fun_prop]
-theorem Set.measurable_restrict (s : Set δ) : Measurable (s.restrict (π := π)) :=
+theorem Set.measurable_restrict (s : Set δ) : Measurable (s.restrict (π := X)) :=
   measurable_pi_lambda _ fun _ ↦ measurable_pi_apply _
 
 @[measurability, fun_prop]
 theorem Set.measurable_restrict₂ {s t : Set δ} (hst : s ⊆ t) :
-    Measurable (restrict₂ (π := π) hst) :=
+    Measurable (restrict₂ (π := X) hst) :=
   measurable_pi_lambda _ fun _ ↦ measurable_pi_apply _
 
 @[measurability, fun_prop]
-theorem Finset.measurable_restrict (s : Finset δ) : Measurable (s.restrict (π := π)) :=
+theorem Finset.measurable_restrict (s : Finset δ) : Measurable (s.restrict (π := X)) :=
   measurable_pi_lambda _ fun _ ↦ measurable_pi_apply _
 
 @[measurability, fun_prop]
 theorem Finset.measurable_restrict₂ {s t : Finset δ} (hst : s ⊆ t) :
-    Measurable (Finset.restrict₂ (π := π) hst) :=
+    Measurable (Finset.restrict₂ (π := X) hst) :=
   measurable_pi_lambda _ fun _ ↦ measurable_pi_apply _
 
 @[measurability, fun_prop]
@@ -935,36 +935,36 @@ theorem Finset.measurable_restrict₂_apply {s t : Finset α} (hst : s ⊆ t)
     {f : t → γ} (hf : Measurable f) :
     Measurable (restrict₂ (π := fun _ ↦ γ) hst f) := hf.comp (measurable_inclusion hst)
 
-variable (π) in
-theorem measurable_eq_mp {i i' : δ} (h : i = i') : Measurable (congr_arg π h).mp := by
+variable (X) in
+theorem measurable_eq_mp {i i' : δ} (h : i = i') : Measurable (congr_arg X h).mp := by
   cases h
   exact measurable_id
 
-variable (π) in
-theorem Measurable.eq_mp {β} [MeasurableSpace β] {i i' : δ} (h : i = i') {f : β → π i}
-    (hf : Measurable f) : Measurable fun x => (congr_arg π h).mp (f x) :=
-  (measurable_eq_mp π h).comp hf
+variable (X) in
+theorem Measurable.eq_mp {β} [MeasurableSpace β] {i i' : δ} (h : i = i') {f : β → X i}
+    (hf : Measurable f) : Measurable fun x => (congr_arg X h).mp (f x) :=
+  (measurable_eq_mp X h).comp hf
 
 @[measurability, fun_prop]
-theorem measurable_piCongrLeft (f : δ' ≃ δ) : Measurable (piCongrLeft π f) := by
+theorem measurable_piCongrLeft (f : δ' ≃ δ) : Measurable (piCongrLeft X f) := by
   rw [measurable_pi_iff]
   intro i
   simp_rw [piCongrLeft_apply_eq_cast]
-  exact Measurable.eq_mp π (f.apply_symm_apply i) <| measurable_pi_apply <| f.symm i
+  exact Measurable.eq_mp X (f.apply_symm_apply i) <| measurable_pi_apply <| f.symm i
 
 /- Even though we cannot use projection notation, we still keep a dot to be consistent with similar
   lemmas, like `MeasurableSet.prod`. -/
 @[measurability]
-protected theorem MeasurableSet.pi {s : Set δ} {t : ∀ i : δ, Set (π i)} (hs : s.Countable)
+protected theorem MeasurableSet.pi {s : Set δ} {t : ∀ i : δ, Set (X i)} (hs : s.Countable)
     (ht : ∀ i ∈ s, MeasurableSet (t i)) : MeasurableSet (s.pi t) := by
   rw [pi_def]
   exact MeasurableSet.biInter hs fun i hi => measurable_pi_apply _ (ht i hi)
 
-protected theorem MeasurableSet.univ_pi [Countable δ] {t : ∀ i : δ, Set (π i)}
+protected theorem MeasurableSet.univ_pi [Countable δ] {t : ∀ i : δ, Set (X i)}
     (ht : ∀ i, MeasurableSet (t i)) : MeasurableSet (pi univ t) :=
   MeasurableSet.pi (to_countable _) fun i _ => ht i
 
-theorem measurableSet_pi_of_nonempty {s : Set δ} {t : ∀ i, Set (π i)} (hs : s.Countable)
+theorem measurableSet_pi_of_nonempty {s : Set δ} {t : ∀ i, Set (X i)} (hs : s.Countable)
     (h : (pi s t).Nonempty) : MeasurableSet (pi s t) ↔ ∀ i ∈ s, MeasurableSet (t i) := by
   classical
     rcases h with ⟨f, hf⟩
@@ -973,58 +973,58 @@ theorem measurableSet_pi_of_nonempty {s : Set δ} {t : ∀ i, Set (π i)} (hs : 
     rw [update_preimage_pi hi]
     exact fun j hj _ => hf j hj
 
-theorem measurableSet_pi {s : Set δ} {t : ∀ i, Set (π i)} (hs : s.Countable) :
+theorem measurableSet_pi {s : Set δ} {t : ∀ i, Set (X i)} (hs : s.Countable) :
     MeasurableSet (pi s t) ↔ (∀ i ∈ s, MeasurableSet (t i)) ∨ pi s t = ∅ := by
   rcases (pi s t).eq_empty_or_nonempty with h | h
   · simp [h]
   · simp [measurableSet_pi_of_nonempty hs, h, ← not_nonempty_iff_eq_empty]
 
-instance Pi.instMeasurableSingletonClass [Countable δ] [∀ a, MeasurableSingletonClass (π a)] :
-    MeasurableSingletonClass (∀ a, π a) :=
+instance Pi.instMeasurableSingletonClass [Countable δ] [∀ a, MeasurableSingletonClass (X a)] :
+    MeasurableSingletonClass (∀ a, X a) :=
   ⟨fun f => univ_pi_singleton f ▸ MeasurableSet.univ_pi fun t => measurableSet_singleton (f t)⟩
 
-variable (π)
+variable (X)
 
 @[measurability]
 theorem measurable_piEquivPiSubtypeProd_symm (p : δ → Prop) [DecidablePred p] :
-    Measurable (Equiv.piEquivPiSubtypeProd p π).symm := by
+    Measurable (Equiv.piEquivPiSubtypeProd p X).symm := by
   refine measurable_pi_iff.2 fun j => ?_
   by_cases hj : p j
   · simp only [hj, dif_pos, Equiv.piEquivPiSubtypeProd_symm_apply]
-    have : Measurable fun (f : ∀ i : { x // p x }, π i.1) => f ⟨j, hj⟩ :=
-      measurable_pi_apply (π := fun i : {x // p x} => π i.1) ⟨j, hj⟩
+    have : Measurable fun (f : ∀ i : { x // p x }, X i.1) => f ⟨j, hj⟩ :=
+      measurable_pi_apply (X := fun i : {x // p x} => X i.1) ⟨j, hj⟩
     exact Measurable.comp this measurable_fst
   · simp only [hj, Equiv.piEquivPiSubtypeProd_symm_apply, dif_neg, not_false_iff]
-    have : Measurable fun (f : ∀ i : { x // ¬p x }, π i.1) => f ⟨j, hj⟩ :=
-      measurable_pi_apply (π := fun i : {x // ¬p x} => π i.1) ⟨j, hj⟩
+    have : Measurable fun (f : ∀ i : { x // ¬p x }, X i.1) => f ⟨j, hj⟩ :=
+      measurable_pi_apply (X := fun i : {x // ¬p x} => X i.1) ⟨j, hj⟩
     exact Measurable.comp this measurable_snd
 
 @[measurability]
 theorem measurable_piEquivPiSubtypeProd (p : δ → Prop) [DecidablePred p] :
-    Measurable (Equiv.piEquivPiSubtypeProd p π) :=
+    Measurable (Equiv.piEquivPiSubtypeProd p X) :=
   (measurable_pi_iff.2 fun _ => measurable_pi_apply _).prod_mk
     (measurable_pi_iff.2 fun _ => measurable_pi_apply _)
 
 end Pi
 
-instance TProd.instMeasurableSpace (π : δ → Type*) [∀ x, MeasurableSpace (π x)] :
-    ∀ l : List δ, MeasurableSpace (List.TProd π l)
+instance TProd.instMeasurableSpace (X : δ → Type*) [∀ x, MeasurableSpace (X x)] :
+    ∀ l : List δ, MeasurableSpace (List.TProd X l)
   | [] => PUnit.instMeasurableSpace
-  | _::is => @Prod.instMeasurableSpace _ _ _ (TProd.instMeasurableSpace π is)
+  | _::is => @Prod.instMeasurableSpace _ _ _ (TProd.instMeasurableSpace X is)
 
 section TProd
 
 open List
 
-variable {π : δ → Type*} [∀ x, MeasurableSpace (π x)]
+variable {X : δ → Type*} [∀ x, MeasurableSpace (X x)]
 
-theorem measurable_tProd_mk (l : List δ) : Measurable (@TProd.mk δ π l) := by
+theorem measurable_tProd_mk (l : List δ) : Measurable (@TProd.mk δ X l) := by
   induction' l with i l ih
   · exact measurable_const
   · exact (measurable_pi_apply i).prod_mk ih
 
 theorem measurable_tProd_elim [DecidableEq δ] :
-    ∀ {l : List δ} {i : δ} (hi : i ∈ l), Measurable fun v : TProd π l => v.elim hi
+    ∀ {l : List δ} {i : δ} (hi : i ∈ l), Measurable fun v : TProd X l => v.elim hi
   | i::is, j, hj => by
     by_cases hji : j = i
     · subst hji
@@ -1034,10 +1034,10 @@ theorem measurable_tProd_elim [DecidableEq δ] :
       exact (measurable_tProd_elim (hj.resolve_left hji)).comp measurable_snd
 
 theorem measurable_tProd_elim' [DecidableEq δ] {l : List δ} (h : ∀ i, i ∈ l) :
-    Measurable (TProd.elim' h : TProd π l → ∀ i, π i) :=
+    Measurable (TProd.elim' h : TProd X l → ∀ i, X i) :=
   measurable_pi_lambda _ fun i => measurable_tProd_elim (h i)
 
-theorem MeasurableSet.tProd (l : List δ) {s : ∀ i, Set (π i)} (hs : ∀ i, MeasurableSet (s i)) :
+theorem MeasurableSet.tProd (l : List δ) {s : ∀ i, Set (X i)} (hs : ∀ i, MeasurableSet (s i)) :
     MeasurableSet (Set.tprod l s) := by
   induction' l with i l ih
   · exact MeasurableSet.univ

--- a/Mathlib/MeasureTheory/MeasurableSpace/Basic.lean
+++ b/Mathlib/MeasureTheory/MeasurableSpace/Basic.lean
@@ -1007,7 +1007,7 @@ theorem measurable_piEquivPiSubtypeProd (p : δ → Prop) [DecidablePred p] :
 
 end Pi
 
-instance TProd.instMeasurableSpace (X : δ → Type*) [∀ x, MeasurableSpace (X x)] :
+instance TProd.instMeasurableSpace (X : δ → Type*) [∀ i, MeasurableSpace (X i)] :
     ∀ l : List δ, MeasurableSpace (List.TProd X l)
   | [] => PUnit.instMeasurableSpace
   | _::is => @Prod.instMeasurableSpace _ _ _ (TProd.instMeasurableSpace X is)
@@ -1016,7 +1016,7 @@ section TProd
 
 open List
 
-variable {X : δ → Type*} [∀ x, MeasurableSpace (X x)]
+variable {X : δ → Type*} [∀ i, MeasurableSpace (X i)]
 
 theorem measurable_tProd_mk (l : List δ) : Measurable (@TProd.mk δ X l) := by
   induction' l with i l ih

--- a/Mathlib/Probability/Process/Filtration.lean
+++ b/Mathlib/Probability/Process/Filtration.lean
@@ -371,7 +371,7 @@ end piLE
 variable {α : Type*}
 
 /-- The exterior σ-algebras of finite sets of `α` form a cofiltration indexed by `Finset α`. -/
-def cylinderEventsCompl : Filtration (Finset α)ᵒᵈ (.pi (π := fun _ : α ↦ Ω)) where
+def cylinderEventsCompl : Filtration (Finset α)ᵒᵈ (.pi (X := fun _ : α ↦ Ω)) where
   seq Λ := cylinderEvents (↑(OrderDual.ofDual Λ))ᶜ
   mono' _ _ h := cylinderEvents_mono <| Set.compl_subset_compl_of_subset h
   le' _  := cylinderEvents_le_pi


### PR DESCRIPTION
Only in files that mentioned such a family, via a script:
```
git grep -e "π : . → Type" --name-only | rg "Measure" | xargs -I{} sed -i -e 's/π/X/g' {}
```


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
