### PR TITLE
feat: CanonAtomM

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -5966,6 +5966,7 @@ import Mathlib.Util.AssertExists
 import Mathlib.Util.AssertExistsExt
 import Mathlib.Util.AssertNoSorry
 import Mathlib.Util.AtomM
+import Mathlib.Util.CanonAtomM
 import Mathlib.Util.CompileInductive
 import Mathlib.Util.CountHeartbeats
 import Mathlib.Util.Delaborators

--- a/Mathlib/Util/CanonAtomM.lean
+++ b/Mathlib/Util/CanonAtomM.lean
@@ -1,0 +1,64 @@
+/-
+Copyright (c) 2025 Jingting Wang. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jingting Wang
+-/
+import Mathlib.Init
+import Lean.Meta.Tactic.Simp.Types
+import Qq
+
+/-!
+# A monad for tracking and deduplicating atoms
+This monad attempts to provide the same functionality as `AtomM`, but uses the recommended faster =
+approach described in `CanonM`.
+-/
+namespace Mathlib.Tactic
+
+open Lean Meta
+
+/-- The context (read-only state) of the `CanonAtomM` monad. -/
+structure CanonAtomM.Context where
+  /-- The reducibility setting for definitional equality of atoms -/
+  red : TransparencyMode
+  /-- A simplification to apply to atomic expressions when they are encountered,
+  before interning them in the atom list. -/
+  evalAtom : Expr → MetaM Simp.Result := fun e ↦ pure { expr := e }
+  deriving Inhabited
+
+/-- The mutable state of the `AtomM` monad. -/
+structure CanonAtomM.State where
+  /-- The index for the new atom -/
+  currentIndex : Nat := 0
+  /-- A hashmap to keep track of the indices of canonicalized `Expr`s -/
+  index : Std.HashMap Expr Nat := {}
+
+/-- The monad used for collecting atoms. -/
+abbrev CanonAtomM := ReaderT CanonAtomM.Context <| StateRefT CanonAtomM.State CanonM
+
+/-- Run a computation in the `CanonAtomM` monad. -/
+def CanonAtomM.run {α : Type} (red : TransparencyMode) (m : CanonAtomM α)
+    (evalAtom : Expr → MetaM Simp.Result := fun e ↦ pure { expr := e }) :
+    MetaM α :=
+  ((m { red, evalAtom }).run' {}).run' red
+
+/-- If an atomic expression has already been encountered, get the index and the stored form of the
+atom (which will be defeq at the specified transparency, but not necessarily syntactically equal).
+If the atomic expression has *not* already been encountered, store it in the list of atoms, and
+return the new index (and the stored form of the atom, which will be the canonicalized version). -/
+def CanonAtomM.addAtom (e : Expr) : CanonAtomM (Nat × Expr) := do
+  let e' ← canon e
+  if let some es := (← get).index.get? e' then
+    return (es, e')
+  else
+    modifyGet fun c ↦ ((c.currentIndex, e'),
+      {currentIndex := c.currentIndex + 1, index := (c.index.insert e' c.currentIndex)})
+
+open Qq
+
+/-- A strongly typed version of `CanonAtomM.addAtom` using `Qq`. -/
+def CanonAtomM.addAtomQ {u : Level} {α : Q(Type u)} (e : Q($α)) :
+    CanonAtomM (Nat × {e' : Q($α) // $e =Q $e'}) := do
+  let (n, e') ← CanonAtomM.addAtom e
+  return (n, ⟨e', ⟨⟩⟩)
+
+end Mathlib.Tactic


### PR DESCRIPTION
In this PR, we implemented CanonAtomM which does almost the same thing as AtomM with the same APIs (though the number of parameters of the state has some difference). We did this because we noticed that in the docstring part of AtomM, it is recommended to use CanonM instead, but they have different APIs, so we decided to build something on top of that which has the same API and functionality so that future usage could be easier.

#22196 depends on this (but it can also work on `AtomM`)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
