### PR TITLE
feat: `not_le_of_le_of_not_le`

### DIFF
--- a/Mathlib/Order/Basic.lean
+++ b/Mathlib/Order/Basic.lean
@@ -82,6 +82,12 @@ theorem lt_of_lt_of_le' : b < c → a ≤ b → a < c :=
 theorem not_lt_iff_not_le_or_ge : ¬a < b ↔ ¬a ≤ b ∨ b ≤ a := by
   rw [lt_iff_le_not_le, Classical.not_and_iff_or_not_not, Classical.not_not]
 
+theorem not_le_of_le_of_not_le (h₁ : a ≤ b) (h₂ : ¬ c ≤ b) : ¬ c ≤ a :=
+  fun h ↦ h₂ (le_trans h h₁)
+
+theorem not_le_of_not_le_of_le (h₁ : ¬ b ≤ a) (h₂ : b ≤ c) : ¬ c ≤ a :=
+  fun h ↦ h₁ (le_trans h₂ h)
+
 end Preorder
 
 section PartialOrder

--- a/Mathlib/Order/Basic.lean
+++ b/Mathlib/Order/Basic.lean
@@ -83,7 +83,7 @@ theorem not_lt_iff_not_le_or_ge : ¬a < b ↔ ¬a ≤ b ∨ b ≤ a := by
   rw [lt_iff_le_not_le, Classical.not_and_iff_or_not_not, Classical.not_not]
 
 theorem not_le_of_le_of_not_le (h₁ : a ≤ b) (h₂ : ¬ c ≤ b) : ¬ c ≤ a :=
-  fun h ↦ h₂ (le_trans h h₁)
+  mt h₁.trans'
 
 theorem not_le_of_not_le_of_le (h₁ : ¬ b ≤ a) (h₂ : b ≤ c) : ¬ c ≤ a :=
   fun h ↦ h₁ (le_trans h₂ h)

--- a/Mathlib/Order/Basic.lean
+++ b/Mathlib/Order/Basic.lean
@@ -86,7 +86,7 @@ theorem not_le_of_le_of_not_le (h₁ : a ≤ b) (h₂ : ¬ c ≤ b) : ¬ c ≤ a
   mt h₁.trans'
 
 theorem not_le_of_not_le_of_le (h₁ : ¬ b ≤ a) (h₂ : b ≤ c) : ¬ c ≤ a :=
-  fun h ↦ h₁ (le_trans h₂ h)
+  mt h₁.trans
 
 end Preorder
 

--- a/Mathlib/Order/Basic.lean
+++ b/Mathlib/Order/Basic.lean
@@ -83,10 +83,10 @@ theorem not_lt_iff_not_le_or_ge : ¬a < b ↔ ¬a ≤ b ∨ b ≤ a := by
   rw [lt_iff_le_not_le, Classical.not_and_iff_or_not_not, Classical.not_not]
 
 theorem not_le_of_le_of_not_le (h₁ : a ≤ b) (h₂ : ¬ c ≤ b) : ¬ c ≤ a :=
-  mt h₁.trans'
+  fun h ↦ h₂ (le_trans h h₁)
 
 theorem not_le_of_not_le_of_le (h₁ : ¬ b ≤ a) (h₂ : b ≤ c) : ¬ c ≤ a :=
-  mt h₁.trans
+  fun h ↦ h₁ (le_trans h₂ h)
 
 end Preorder
 


### PR DESCRIPTION
Used within the CGT repo.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
