### PR TITLE
chore: Refactor tactic `ring` from `AtomM` to `CanonAtomM` 

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -5966,6 +5966,7 @@ import Mathlib.Util.AssertExists
 import Mathlib.Util.AssertExistsExt
 import Mathlib.Util.AssertNoSorry
 import Mathlib.Util.AtomM
+import Mathlib.Util.CanonAtomM
 import Mathlib.Util.CompileInductive
 import Mathlib.Util.CountHeartbeats
 import Mathlib.Util.Delaborators

--- a/Mathlib/Algebra/ContinuedFractions/Computation/Approximations.lean
+++ b/Mathlib/Algebra/ContinuedFractions/Computation/Approximations.lean
@@ -427,7 +427,7 @@ theorem abs_sub_convs_le (not_terminatedAt_n : ¬(of v).TerminatedAt n) :
       -- apply `sub_convs_eq` and simplify the result
       have tmp := sub_convs_eq stream_nth_eq
       simp only [stream_nth_fr_ne_zero, conts_eq.symm, pred_conts_eq.symm, if_false] at tmp
-      rw [tmp]
+      rw [tmp]; unfold den' conts pred_conts g
       ring
     rwa [this]
   -- derive some tedious inequalities that we need to rewrite our goal

--- a/Mathlib/Algebra/ContinuedFractions/Determinant.lean
+++ b/Mathlib/Algebra/ContinuedFractions/Determinant.lean
@@ -58,6 +58,7 @@ theorem determinant_aux (hyp : n = 0 ∨ ¬(↑s : GenContFract K).TerminatedAt 
       simp only [conts, contsAux_recurrence s_nth_eq ppred_conts_eq pred_conts_eq]
       have gp_a_eq_one : gp.a = 1 := s.property _ _ (partNum_eq_s_a s_nth_eq)
       rw [gp_a_eq_one, this.symm]
+      unfold pA pB ppA ppB pred_conts ppred_conts
       ring
     suffices pA * ppB - pB * ppA = (-1) ^ (n + 1) by calc
       pA * (ppB + gp.b * pB) - pB * (ppA + gp.b * pA) =

--- a/Mathlib/Algebra/Polynomial/Module/Basic.lean
+++ b/Mathlib/Algebra/Polynomial/Module/Basic.lean
@@ -285,7 +285,8 @@ theorem eval_map (f : M →ₗ[R] M') (q : PolynomialModule R M) (r : R) :
     simp_rw [map_add, e₁, e₂]
   · intro i m
     simp only [map_single, eval_single, f.map_smul]
-    module
+    match_scalars
+    rfl
 
 @[simp]
 theorem eval_map' (f : M →ₗ[R] M) (q : PolynomialModule R M) (r : R) :

--- a/Mathlib/AlgebraicGeometry/EllipticCurve/Affine.lean
+++ b/Mathlib/AlgebraicGeometry/EllipticCurve/Affine.lean
@@ -599,7 +599,7 @@ lemma addY_sub_negY_addY {x₁ x₂ : F} (y₁ y₂ : F) (hx : x₁ ≠ x₂) :
     y₃ - W.negY x₃ y₃ =
       ((y₂ - W.negY x₂ y₂) * (x₁ - x₃) - (y₁ - W.negY x₁ y₁) * (x₂ - x₃)) / (x₂ - x₁) := by
   simp_rw [addY, negY, eq_div_iff (sub_ne_zero.mpr hx.symm)]
-  linear_combination (norm := ring1) 2 * cyclic_sum_Y_mul_X_sub_X y₁ y₂ hx
+  linear_combination (norm := ring_nf) 2 * cyclic_sum_Y_mul_X_sub_X (W := W) y₁ y₂ hx
 
 end Field
 

--- a/Mathlib/AlgebraicGeometry/EllipticCurve/Affine.lean
+++ b/Mathlib/AlgebraicGeometry/EllipticCurve/Affine.lean
@@ -205,6 +205,7 @@ lemma equation_iff_variableChange (x y : R) :
     W'.Equation x y ↔ (W'.variableChange ⟨1, x, 0, y⟩).toAffine.Equation 0 0 := by
   rw [equation_iff', ← neg_eq_zero, equation_zero, variableChange_a₆, inv_one, Units.val_one]
   congr! 1
+  simp only [neg_sub, one_pow, one_mul]
   ring1
 
 end Equation

--- a/Mathlib/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Basic.lean
+++ b/Mathlib/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Basic.lean
@@ -120,7 +120,7 @@ noncomputable def Ψ₂Sq : R[X] :=
   C 4 * X ^ 3 + C W.b₂ * X ^ 2 + C (2 * W.b₄) * X + C W.b₆
 
 lemma C_Ψ₂Sq : C W.Ψ₂Sq = W.ψ₂ ^ 2 - 4 * W.toAffine.polynomial := by
-  rw [Ψ₂Sq, ψ₂, b₂, b₄, b₆, Affine.polynomialY, Affine.polynomial]
+  rw [Ψ₂Sq, ψ₂, b₂, b₄, b₆, Affine.polynomialY, Affine.polynomial, toAffine]
   C_simp
   ring1
 

--- a/Mathlib/AlgebraicGeometry/EllipticCurve/Jacobian/Basic.lean
+++ b/Mathlib/AlgebraicGeometry/EllipticCurve/Jacobian/Basic.lean
@@ -243,7 +243,7 @@ lemma eval_polynomial (P : Fin 3 → R) : eval P W'.polynomial =
 
 lemma eval_polynomial_of_Z_ne_zero {P : Fin 3 → F} (hPz : P z ≠ 0) : eval P W.polynomial / P z ^ 6 =
     W.toAffine.polynomial.evalEval (P x / P z ^ 2) (P y / P z ^ 3) := by
-  linear_combination (norm := (rw [eval_polynomial, Affine.evalEval_polynomial]; ring1))
+  linear_combination (norm := (rw [eval_polynomial, Affine.evalEval_polynomial, toAffine]; ring1))
     W.a₁ * P x * P y / P z ^ 5 * div_self hPz + W.a₃ * P y / P z ^ 3 * div_self (pow_ne_zero 3 hPz)
       - W.a₂ * P x ^ 2 / P z ^ 4 * div_self (pow_ne_zero 2 hPz)
       - W.a₄ * P x / P z ^ 2 * div_self (pow_ne_zero 4 hPz) - W.a₆ * div_self (pow_ne_zero 6 hPz)
@@ -307,7 +307,7 @@ lemma eval_polynomialX (P : Fin 3 → R) : eval P W'.polynomialX =
 lemma eval_polynomialX_of_Z_ne_zero {P : Fin 3 → F} (hPz : P z ≠ 0) :
     eval P W.polynomialX / P z ^ 4 =
       W.toAffine.polynomialX.evalEval (P x / P z ^ 2) (P y / P z ^ 3) := by
-  linear_combination (norm := (rw [eval_polynomialX, Affine.evalEval_polynomialX]; ring1))
+  linear_combination (norm := (rw [eval_polynomialX, Affine.evalEval_polynomialX, toAffine]; ring1))
     W.a₁ * P y / P z ^ 3 * div_self hPz - 2 * W.a₂ * P x / P z ^ 2 * div_self (pow_ne_zero 2 hPz)
       - W.a₄ * div_self (pow_ne_zero 4 hPz)
 
@@ -330,7 +330,7 @@ lemma eval_polynomialY (P : Fin 3 → R) :
 lemma eval_polynomialY_of_Z_ne_zero {P : Fin 3 → F} (hPz : P z ≠ 0) :
     eval P W.polynomialY / P z ^ 3 =
       W.toAffine.polynomialY.evalEval (P x / P z ^ 2) (P y / P z ^ 3) := by
-  linear_combination (norm := (rw [eval_polynomialY, Affine.evalEval_polynomialY]; ring1))
+  linear_combination (norm := (rw [eval_polynomialY, Affine.evalEval_polynomialY, toAffine]; ring1))
     W.a₁ * P x / P z ^ 2 * div_self hPz + W.a₃ * div_self (pow_ne_zero 3 hPz)
 
 variable (W') in
@@ -401,7 +401,7 @@ lemma nonsingular_some (X Y : R) : W'.Nonsingular ![X, Y, 1] ↔ W'.toAffine.Non
     Affine.equation_iff', and_congr_right_iff, ← not_and_or, not_iff_not, one_pow, mul_one,
     and_congr_right_iff, Iff.comm, iff_self_and]
   intro h hX hY
-  linear_combination (norm := ring1) 6 * h - 2 * X * hX - 3 * Y * hY
+  linear_combination (norm := (rw [toAffine]; ring1)) 6 * h - 2 * X * hX - 3 * Y * hY
 
 lemma nonsingular_of_Z_ne_zero {P : Fin 3 → F} (hPz : P z ≠ 0) :
     W.Nonsingular P ↔ W.toAffine.Nonsingular (P x / P z ^ 2) (P y / P z ^ 3) :=

--- a/Mathlib/AlgebraicGeometry/EllipticCurve/Jacobian/Formula.lean
+++ b/Mathlib/AlgebraicGeometry/EllipticCurve/Jacobian/Formula.lean
@@ -97,7 +97,7 @@ lemma negY_of_Z_eq_zero {P : Fin 3 → R} (hPz : P z = 0) : W'.negY P = -P y := 
 
 lemma negY_of_Z_ne_zero {P : Fin 3 → F} (hPz : P z ≠ 0) :
     W.negY P / P z ^ 3 = W.toAffine.negY (P x / P z ^ 2) (P y / P z ^ 3) := by
-  linear_combination (norm := (rw [negY, Affine.negY]; ring1))
+  linear_combination (norm := (rw [negY, Affine.negY, toAffine]; ring1))
     -W.a₁ * P x / P z ^ 2 * div_self hPz - W.a₃ * div_self (pow_ne_zero 3 hPz)
 
 lemma Y_sub_Y_mul_Y_sub_negY {P Q : Fin 3 → R} (hP : W'.Equation P) (hQ : W'.Equation Q)
@@ -136,7 +136,7 @@ lemma Y_ne_negY_of_Y_ne [NoZeroDivisors R] {P Q : Fin 3 → R} (hP : W'.Equation
   have hy' : P y * Q z ^ 3 - W'.negY Q * P z ^ 3 = 0 :=
     (mul_eq_zero.mp <| Y_sub_Y_mul_Y_sub_negY hP hQ hx).resolve_left <| sub_ne_zero_of_ne hy
   contrapose! hy
-  linear_combination (norm := ring1) Y_sub_Y_add_Y_sub_negY hx + Q z ^ 3 * hy - hy'
+  linear_combination (norm := (rw [negY]; ring1)) Y_sub_Y_add_Y_sub_negY hx + Q z ^ 3 * hy - hy'
 
 lemma Y_ne_negY_of_Y_ne' [NoZeroDivisors R] {P Q : Fin 3 → R} (hP : W'.Equation P)
     (hQ : W'.Equation Q) (hx : P x * Q z ^ 2 = Q x * P z ^ 2)
@@ -144,13 +144,13 @@ lemma Y_ne_negY_of_Y_ne' [NoZeroDivisors R] {P Q : Fin 3 → R} (hP : W'.Equatio
   have hy' : P y * Q z ^ 3 - Q y * P z ^ 3 = 0 :=
     (mul_eq_zero.mp <| Y_sub_Y_mul_Y_sub_negY hP hQ hx).resolve_right <| sub_ne_zero_of_ne hy
   contrapose! hy
-  linear_combination (norm := ring1) Y_sub_Y_add_Y_sub_negY hx + Q z ^ 3 * hy - hy'
+  linear_combination (norm := (rw [negY]; ring1)) Y_sub_Y_add_Y_sub_negY hx + Q z ^ 3 * hy - hy'
 
 lemma Y_eq_negY_of_Y_eq [NoZeroDivisors R] {P Q : Fin 3 → R} (hQz : Q z ≠ 0)
     (hx : P x * Q z ^ 2 = Q x * P z ^ 2) (hy : P y * Q z ^ 3 = Q y * P z ^ 3)
     (hy' : P y * Q z ^ 3 = W'.negY Q * P z ^ 3) : P y = W'.negY P :=
   mul_left_injective₀ (pow_ne_zero 3 hQz) <| by
-    linear_combination (norm := ring1) -Y_sub_Y_add_Y_sub_negY hx + hy + hy'
+    linear_combination (norm := (rw [negY]; ring1)) -Y_sub_Y_add_Y_sub_negY hx + hy + hy'
 
 lemma nonsingular_iff_of_Y_eq_negY {P : Fin 3 → F} (hPz : P z ≠ 0) (hy : P y = W.negY P) :
     W.Nonsingular P ↔ W.Equation P ∧ eval P W.polynomialX ≠ 0 := by
@@ -234,7 +234,7 @@ private lemma toAffine_slope_of_eq {P Q : Fin 3 → F} (hP : W.Equation P) (hQ :
   have hPy : P y - W.negY P ≠ 0 := sub_ne_zero.mpr <| Y_ne_negY_of_Y_ne' hP hQ hx hy
   simp only [X_eq_iff hPz hQz, ne_eq, Y_eq_iff' hPz hQz] at hx hy
   rw [Affine.slope_of_Y_ne hx <| negY_of_Z_ne_zero hQz ▸ hy, ← negY_of_Z_ne_zero hPz, dblU_eq, dblZ]
-  field_simp [pow_ne_zero 2 hPz]
+  field_simp [pow_ne_zero 2 hPz, toAffine]
   ring1
 
 variable (W') in
@@ -262,7 +262,7 @@ lemma dblX_of_Y_eq [NoZeroDivisors R] {P Q : Fin 3 → R} (hQz : Q z ≠ 0)
 private lemma toAffine_addX_of_eq {P : Fin 3 → F} (hPz : P z ≠ 0) {n d : F} (hd : d ≠ 0) :
     W.toAffine.addX (P x / P z ^ 2) (P x / P z ^ 2) (-n / (P z * d)) =
       (n ^ 2 - W.a₁ * n * P z * d - W.a₂ * P z ^ 2 * d ^ 2 - 2 * P x * d ^ 2) / (P z * d) ^ 2 := by
-  field_simp [mul_ne_zero hPz hd]
+  field_simp [mul_ne_zero hPz hd, toAffine]
   ring1
 
 lemma dblX_of_Z_ne_zero {P Q : Fin 3 → F} (hP : W.Equation P) (hQ : W.Equation Q) (hPz : P z ≠ 0)
@@ -518,7 +518,7 @@ private lemma toAffine_addX_of_ne {P Q : Fin 3 → F} (hPz : P z ≠ 0) (hQz : Q
     (hd : d ≠ 0) : W.toAffine.addX (P x / P z ^ 2) (Q x / Q z ^ 2) (n / (P z * Q z * d)) =
       (n ^ 2 + W.a₁ * n * P z * Q z * d - W.a₂ * P z ^ 2 * Q z ^ 2 * d ^ 2 - P x * Q z ^ 2 * d ^ 2
         - Q x * P z ^ 2 * d ^ 2) / (P z * Q z) ^ 2 / d ^ 2 := by
-  field_simp [mul_ne_zero (mul_ne_zero hPz hQz) hd]
+  field_simp [mul_ne_zero (mul_ne_zero hPz hQz) hd, toAffine]
   ring1
 
 lemma addX_of_Z_ne_zero {P Q : Fin 3 → F} (hP : W.Equation P) (hQ : W.Equation Q) (hPz : P z ≠ 0)

--- a/Mathlib/AlgebraicGeometry/EllipticCurve/Projective/Basic.lean
+++ b/Mathlib/AlgebraicGeometry/EllipticCurve/Projective/Basic.lean
@@ -234,7 +234,7 @@ lemma eval_polynomial (P : Fin 3 → R) : eval P W'.polynomial =
 
 lemma eval_polynomial_of_Z_ne_zero {P : Fin 3 → F} (hPz : P z ≠ 0) : eval P W.polynomial / P z ^ 3 =
     W.toAffine.polynomial.evalEval (P x / P z) (P y / P z) := by
-  linear_combination (norm := (rw [eval_polynomial, Affine.evalEval_polynomial]; ring1))
+  linear_combination (norm := (rw [eval_polynomial, Affine.evalEval_polynomial, toAffine]; ring1))
     P y ^ 2 / P z ^ 2 * div_self hPz + W.a₁ * P x * P y / P z ^ 2 * div_self hPz
       + W.a₃ * P y / P z * div_self (pow_ne_zero 2 hPz) - W.a₂ * P x ^ 2 / P z ^ 2 * div_self hPz
       - W.a₄ * P x / P z * div_self (pow_ne_zero 2 hPz) - W.a₆ * div_self (pow_ne_zero 3 hPz)
@@ -301,7 +301,7 @@ lemma eval_polynomialX (P : Fin 3 → R) : eval P W'.polynomialX =
 
 lemma eval_polynomialX_of_Z_ne_zero {P : Fin 3 → F} (hPz : P z ≠ 0) :
     eval P W.polynomialX / P z ^ 2 = W.toAffine.polynomialX.evalEval (P x / P z) (P y / P z) := by
-  linear_combination (norm := (rw [eval_polynomialX, Affine.evalEval_polynomialX]; ring1))
+  linear_combination (norm := (rw [eval_polynomialX, Affine.evalEval_polynomialX, toAffine]; ring1))
     W.a₁ * P y / P z * div_self hPz - 2 * W.a₂ * P x / P z * div_self hPz
       - W.a₄ * div_self (pow_ne_zero 2 hPz)
 
@@ -324,7 +324,7 @@ lemma eval_polynomialY (P : Fin 3 → R) :
 
 lemma eval_polynomialY_of_Z_ne_zero {P : Fin 3 → F} (hPz : P z ≠ 0) :
     eval P W.polynomialY / P z ^ 2 = W.toAffine.polynomialY.evalEval (P x / P z) (P y / P z) := by
-  linear_combination (norm := (rw [eval_polynomialY, Affine.evalEval_polynomialY]; ring1))
+  linear_combination (norm := (rw [eval_polynomialY, Affine.evalEval_polynomialY, toAffine]; ring1))
     2 * P y / P z * div_self hPz + W.a₁ * P x / P z * div_self hPz
       + W.a₃ * div_self (pow_ne_zero 2 hPz)
 
@@ -404,7 +404,7 @@ lemma nonsingular_some (X Y : R) : W'.Nonsingular ![X, Y, 1] ↔ W'.toAffine.Non
     Affine.equation_iff', and_congr_right_iff, ← not_and_or, not_iff_not, one_pow, mul_one,
     and_congr_right_iff, Iff.comm, iff_self_and]
   intro h hX hY
-  linear_combination (norm := ring1) 3 * h - X * hX - Y * hY
+  linear_combination (norm := (rw [toAffine]; ring1)) 3 * h - X * hX - Y * hY
 
 lemma nonsingular_of_Z_ne_zero {P : Fin 3 → F} (hPz : P z ≠ 0) :
     W.Nonsingular P ↔ W.toAffine.Nonsingular (P x / P z) (P y / P z) :=

--- a/Mathlib/AlgebraicGeometry/EllipticCurve/Projective/Formula.lean
+++ b/Mathlib/AlgebraicGeometry/EllipticCurve/Projective/Formula.lean
@@ -99,7 +99,7 @@ lemma negY_of_Z_eq_zero [NoZeroDivisors R] {P : Fin 3 → R} (hP : W'.Equation P
 
 lemma negY_of_Z_ne_zero {P : Fin 3 → F} (hPz : P z ≠ 0) :
     W.negY P / P z = W.toAffine.negY (P x / P z) (P y / P z) := by
-  linear_combination (norm := (rw [negY, Affine.negY]; ring1)) -W.a₃ * div_self hPz
+  linear_combination (norm := (rw [negY, Affine.negY, toAffine]; ring1)) -W.a₃ * div_self hPz
 
 lemma Y_sub_Y_mul_Y_sub_negY {P Q : Fin 3 → R} (hP : W'.Equation P) (hQ : W'.Equation Q)
     (hx : P x * Q z = Q x * P z) :
@@ -134,20 +134,20 @@ lemma Y_ne_negY_of_Y_ne [NoZeroDivisors R] {P Q : Fin 3 → R} (hP : W'.Equation
     (hy : P y * Q z ≠ Q y * P z) : P y ≠ W'.negY P := by
   have hy' : P y * Q z - W'.negY Q * P z = 0 := sub_eq_zero.mpr <| Y_eq_of_Y_ne hP hQ hPz hQz hx hy
   contrapose! hy
-  linear_combination (norm := ring1) Y_sub_Y_add_Y_sub_negY hx + Q z * hy - hy'
+  linear_combination (norm := (rw [negY]; ring1)) Y_sub_Y_add_Y_sub_negY hx + Q z * hy - hy'
 
 lemma Y_ne_negY_of_Y_ne' [NoZeroDivisors R] {P Q : Fin 3 → R} (hP : W'.Equation P)
     (hQ : W'.Equation Q) (hPz : P z ≠ 0) (hQz : Q z ≠ 0) (hx : P x * Q z = Q x * P z)
     (hy : P y * Q z ≠ W'.negY Q * P z) : P y ≠ W'.negY P := by
   have hy' : P y * Q z - Q y * P z = 0 := sub_eq_zero.mpr <| Y_eq_of_Y_ne' hP hQ hPz hQz hx hy
   contrapose! hy
-  linear_combination (norm := ring1) Y_sub_Y_add_Y_sub_negY hx + Q z * hy - hy'
+  linear_combination (norm := (rw [negY]; ring1)) Y_sub_Y_add_Y_sub_negY hx + Q z * hy - hy'
 
 lemma Y_eq_negY_of_Y_eq [NoZeroDivisors R] {P Q : Fin 3 → R} (hQz : Q z ≠ 0)
     (hx : P x * Q z = Q x * P z) (hy : P y * Q z = Q y * P z) (hy' : P y * Q z = W'.negY Q * P z) :
     P y = W'.negY P :=
   mul_left_injective₀ hQz <| by
-    linear_combination (norm := ring1) -Y_sub_Y_add_Y_sub_negY hx + hy + hy'
+    linear_combination (norm := (rw [negY]; ring1)) -Y_sub_Y_add_Y_sub_negY hx + hy + hy'
 
 lemma nonsingular_iff_of_Y_eq_negY {P : Fin 3 → F} (hPz : P z ≠ 0) (hy : P y = W.negY P) :
     W.Nonsingular P ↔ W.Equation P ∧ eval P W.polynomialX ≠ 0 := by
@@ -232,6 +232,7 @@ private lemma toAffine_slope_of_eq {P Q : Fin 3 → F} (hP : W.Equation P) (hQ :
   simp only [X_eq_iff hPz hQz, ne_eq, Y_eq_iff' hPz hQz] at hx hy
   rw [Affine.slope_of_Y_ne hx <| negY_of_Z_ne_zero hQz ▸ hy, ← negY_of_Z_ne_zero hPz]
   field_simp [eval_polynomialX, hPz]
+  rw [negY, toAffine]
   ring1
 
 variable (W') in
@@ -295,7 +296,7 @@ private lemma toAffine_addX_of_eq {P : Fin 3 → F} (hPz : P z ≠ 0) {n d : F} 
     W.toAffine.addX (P x / P z) (P x / P z) (-n / P z / d) =
       (n ^ 2 - W.a₁ * n * P z * d - W.a₂ * P z ^ 2 * d ^ 2 - 2 * P x * P z * d ^ 2) * d / P z
         / (P z * d ^ 3) := by
-  field_simp [mul_ne_zero hPz hd]
+  field_simp [mul_ne_zero hPz hd, toAffine]
   ring1
 
 lemma dblX_of_Z_ne_zero {P Q : Fin 3 → F} (hP : W.Equation P) (hQ : W.Equation Q) (hPz : P z ≠ 0)
@@ -612,7 +613,7 @@ private lemma toAffine_addX_of_ne {P Q : Fin 3 → F} (hPz : P z ≠ 0) (hQz : Q
     (hd : d ≠ 0) : W.toAffine.addX (P x / P z) (Q x / Q z) (n / d) =
       (n ^ 2 * P z * Q z + W.a₁ * n * P z * Q z * d - W.a₂ * P z * Q z * d ^ 2 - P x * Q z * d ^ 2
         - Q x * P z * d ^ 2) * d / (P z * Q z) ^ 2 / (d ^ 3 / (P z * Q z)) := by
-  field_simp [hd]
+  field_simp [hd, toAffine]
   ring1
 
 lemma addX_of_Z_ne_zero {P Q : Fin 3 → F} (hP : W.Equation P) (hQ : W.Equation Q) (hPz : P z ≠ 0)

--- a/Mathlib/Analysis/Calculus/FDeriv/Measurable.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Measurable.lean
@@ -835,8 +835,12 @@ lemma isOpen_A_with_param {r s : ℝ} (hf : Continuous f.uncurry) (L : E →L[�
   rintro ⟨a', x'⟩ ha'x'
   simp only [mem_prod, mem_ball] at ha'x'
   refine ⟨t', ⟨hrt', ht't.le.trans (htr'.le.trans Ir'r)⟩, fun y hy z hz ↦ ?_⟩
-  have dyx : dist y x ≤ t := by linarith [dist_triangle y x' x]
-  have dzx : dist z x ≤ t := by linarith [dist_triangle z x' x]
+  have dyx : dist y x ≤ t := by
+    rw [show (a', x').2 = x' by rfl] at hy
+    linarith [dist_triangle y x' x]
+  have dzx : dist z x ≤ t := by
+    rw [show (a', x').2 = x' by rfl] at hz
+    linarith [dist_triangle z x' x]
   calc
   ‖f a' z - f a' y - (L z - L y)‖ =
     ‖(f a' z - f a z) + (f a y - f a' y) + (f a z - f a y - (L z - L y))‖ := by congr; abel

--- a/Mathlib/Analysis/Complex/AbelLimit.lean
+++ b/Mathlib/Analysis/Complex/AbelLimit.lean
@@ -208,7 +208,10 @@ theorem tendsto_tsum_powerSeries_nhdsWithin_stolzSet
       _ ≤ ‖1 - z‖ * ∑ i ∈ range B₁, ‖l - s (i + 1)‖ := by
         gcongr; nth_rw 3 [← mul_one ‖_‖]
         gcongr; exact pow_le_one₀ (norm_nonneg _) zn.le
-      _ ≤ ‖1 - z‖ * (F + 1) := by gcongr; linarith only
+      _ ≤ ‖1 - z‖ * (F + 1) := by
+        gcongr
+        show F ≤ F + 1
+        linarith only
       _ < _ := by rwa [norm_sub_rev, lt_div_iff₀ (by positivity)] at zd
   have S₂ : ‖1 - z‖ * ∑ i ∈ Ico B₁ (max B₁ B₂), ‖l - s (i + 1)‖ * ‖z‖ ^ i < ε / 4 :=
     calc

--- a/Mathlib/Analysis/FunctionalSpaces/SobolevInequality.lean
+++ b/Mathlib/Analysis/FunctionalSpaces/SobolevInequality.lean
@@ -146,7 +146,7 @@ theorem T_insert_le_T_lmarginal_singleton [∀ i, SigmaFinite (μ i)] (hp₀ : 0
     fun {_} ↦ hf.lmarginal μ |>.comp <| measurable_update _
   have hF₀ : Measurable fun t ↦ f (X t) := hf.comp <| measurable_update _
   let k : ℝ := s.card
-  have hk' : 0 ≤ 1 - k * p := by linarith only [hp]
+  have hk' : 0 ≤ 1 - k * p := by unfold k; linarith only [hp]
   calc ∫⁻ t, f (X t) ^ (1 - k * p)
           * ∏ j ∈ insert i s, (∫⋯∫⁻_{j}, f ∂μ) (X t) ^ p ∂ (μ i)
       = ∫⁻ t, (∫⋯∫⁻_{i}, f ∂μ) (X t) ^ p * (f (X t) ^ (1 - k * p)
@@ -176,7 +176,7 @@ theorem T_insert_le_T_lmarginal_singleton [∀ i, SigmaFinite (μ i)] (hp₀ : 0
               · intros
                 exact hF₁.aemeasurable
               · simp only [sum_const, nsmul_eq_mul]
-                ring
+                unfold k; ring
               · exact hk'
               · exact fun _ _ ↦ hp₀
     _ = (∫⋯∫⁻_{i}, f ∂μ) x ^ p *
@@ -199,7 +199,7 @@ theorem T_insert_le_T_lmarginal_singleton [∀ i, SigmaFinite (μ i)] (hp₀ : 0
           ∏ j ∈ s, (∫⋯∫⁻_{j}, (∫⋯∫⁻_{i}, f ∂μ) ∂μ) x ^ p := by
               -- identify the result with the RHS integrand
               congr! 2 with j hj
-              · ring_nf
+              · unfold k; ring_nf
               · congr! 1
                 rw [← lmarginal_union μ f hf]
                 · congr
@@ -707,7 +707,8 @@ theorem eLpNorm_le_eLpNorm_fderiv_of_le [FiniteDimensional ℝ F]
           exact h2u.trans subset_closure
         rel [eLpNorm_le_eLpNorm_fderiv_of_eq μ hu h2u' hp (mod_cast (zero_le p).trans_lt h2p) hp']
     _ = eLpNormLESNormFDerivOfLeConst F μ s p q * eLpNorm (fderiv ℝ u) p μ := by
-      simp_rw [eLpNormLESNormFDerivOfLeConst, ENNReal.coe_mul]; ring
+      simp_rw [eLpNormLESNormFDerivOfLeConst, ENNReal.coe_mul]
+      unfold t C p'; ring
 
 /-- The **Gagliardo-Nirenberg-Sobolev inequality**.  Let `u` be a continuously differentiable
 function `u` supported in a bounded set `s` in a normed space `E` of finite dimension

--- a/Mathlib/Analysis/InnerProductSpace/Defs.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Defs.lean
@@ -337,8 +337,8 @@ theorem cauchy_schwarz_aux (x y : F) : normSqF (⟪x, y⟫ • x - ⟪x, x⟫ �
   simp only [inner_sub_sub_self, inner_smul_left, inner_smul_right, conj_ofReal, mul_sub, ←
     ofReal_normSq_eq_inner_self x, ← ofReal_normSq_eq_inner_self y]
   rw [← mul_assoc, mul_conj, RCLike.conj_mul, mul_left_comm, ← inner_conj_symm y, mul_conj]
-  push_cast
-  ring
+  push_cast; ring_nf
+  rw [mul_comm]
 
 /-- **Cauchy–Schwarz inequality**.
 We need this for the `PreInnerProductSpace.Core` structure to prove the triangle inequality below

--- a/Mathlib/Analysis/InnerProductSpace/NormPow.lean
+++ b/Mathlib/Analysis/InnerProductSpace/NormPow.lean
@@ -46,9 +46,7 @@ theorem hasFDerivAt_norm_rpow (x : E) {p : ℝ} (hp : 1 < p) :
   · apply HasStrictFDerivAt.hasFDerivAt
     convert (hasStrictFDerivAt_norm_sq x).rpow_const (p := p / 2) (by simp [hx]) using 0
     simp_rw [← Real.rpow_natCast_mul (norm_nonneg _), ← Nat.cast_smul_eq_nsmul ℝ, smul_smul]
-    ring_nf -- doesn't close the goal?
-    congr! 2
-    ring
+    ring_nf
 
 theorem differentiable_norm_rpow {p : ℝ} (hp : 1 < p) :
     Differentiable ℝ (fun x : E ↦ ‖x‖ ^ p) :=

--- a/Mathlib/Analysis/InnerProductSpace/OfNorm.lean
+++ b/Mathlib/Analysis/InnerProductSpace/OfNorm.lean
@@ -125,7 +125,9 @@ theorem inner_.conj_symm (x y : E) : conj (inner_ 𝕜 y x) = inner_ 𝕜 x y :=
   have h₂ : ‖(I : 𝕜) • y + x‖ = ‖(I : 𝕜) • x - y‖ := by
     convert (I_smul ((I : 𝕜) • y + x)).symm using 2
     linear_combination (norm := module) -hI' • y
-  rw [h₁, h₂]
+  rw [h₁, h₂];
+  have (x : ℝ) : (x : 𝕜) = 𝓚 x := rfl
+  simp only [this]
   ring
 
 variable [InnerProductSpaceable E]

--- a/Mathlib/Analysis/InnerProductSpace/Projection.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Projection.lean
@@ -238,6 +238,7 @@ theorem norm_eq_iInf_iff_real_inner_le_zero {K : Set F} (h : Convex ℝ K) {u : 
           2 * p ≤ θ * q := by
             exact this θ (lt_min (by norm_num) (div_pos hp q_pos)) (by norm_num [θ])
           _ ≤ p := eq₁
+      unfold p q at *
       linarith
   · intro h
     apply le_antisymm

--- a/Mathlib/Analysis/NormedSpace/HahnBanach/Separation.lean
+++ b/Mathlib/Analysis/NormedSpace/HahnBanach/Separation.lean
@@ -221,8 +221,8 @@ noncomputable def extendTo𝕜'ₗ [ContinuousConstSMul 𝕜 E]: (E →L[ℝ] �
       cont := show Continuous fun x ↦ (fr x : 𝕜) - (I : 𝕜) * (fr ((I : 𝕜) • x) : 𝕜) by fun_prop }
   have h fr x : to𝕜 fr x = ((fr x : 𝕜) - (I : 𝕜) * (fr ((I : 𝕜) • x) : 𝕜)) := rfl
   { toFun := to𝕜
-    map_add' := by intros; ext; simp [h]; ring
-    map_smul' := by intros; ext; simp [h, real_smul_eq_coe_mul]; ring }
+    map_add' := by intros; ext; simp [h, RCLike.ofReal, Algebra.cast]; ring
+    map_smul' := by intros; ext; simp [h, real_smul_eq_coe_mul, RCLike.ofReal, Algebra.cast]; ring }
 
 @[simp]
 lemma re_extendTo𝕜'ₗ [ContinuousConstSMul 𝕜 E] (g : E →L[ℝ] ℝ) (x : E) : re ((extendTo𝕜'ₗ g) x : 𝕜)

--- a/Mathlib/Analysis/SpecialFunctions/PolarCoord.lean
+++ b/Mathlib/Analysis/SpecialFunctions/PolarCoord.lean
@@ -48,7 +48,7 @@ def polarCoord : PartialHomeomorph (ℝ × ℝ) (ℝ × ℝ) where
     constructor
     · rcases hxy with hxy | hxy
       · dsimp at hxy; linarith [sq_pos_of_ne_zero hxy.ne', sq_nonneg y]
-      · linarith [sq_nonneg x, sq_pos_of_ne_zero hxy]
+      · linarith [sq_nonneg x, sq_pos_of_ne_zero (show y ≠ 0 from hxy)]
     · rcases hxy with hxy | hxy
       · exact Or.inl (le_of_lt hxy)
       · exact Or.inr hxy

--- a/Mathlib/Analysis/SpecialFunctions/Trigonometric/Arctan.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Trigonometric/Arctan.lean
@@ -273,8 +273,8 @@ theorem two_mul_arctan_inv_3_add_arctan_inv_7 : 2 * arctan 3⁻¹ + arctan 7⁻�
 
 /-- **John Machin's 1706 formula**, which he used to compute π to 100 decimal places. -/
 theorem four_mul_arctan_inv_5_sub_arctan_inv_239 : 4 * arctan 5⁻¹ - arctan 239⁻¹ = π / 4 := by
-  rw [show 4 * arctan _ = 2 * (2 * _) by ring, two_mul_arctan, two_mul_arctan, ← arctan_one,
-    sub_eq_iff_eq_add, arctan_add] <;> norm_num
+  rw [show 4 * arctan 5⁻¹ = 2 * (2 * arctan 5⁻¹) by ring, two_mul_arctan, two_mul_arctan,
+    ← arctan_one, sub_eq_iff_eq_add, arctan_add] <;> norm_num
 
 end ArctanAdd
 

--- a/Mathlib/Analysis/SpecialFunctions/Trigonometric/EulerSineProd.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Trigonometric/EulerSineProd.lean
@@ -101,7 +101,7 @@ theorem integral_sin_mul_sin_mul_cos_pow_eq (hn : 2 ≤ n) (hz : z ≠ 0) :
       · have : ((n - 1 : ℕ) : ℂ) = (n : ℂ) - 1 := by
           rw [Nat.cast_sub (one_le_two.trans hn), Nat.cast_one]
         rw [Nat.sub_sub, this]
-        ring
+        ring_nf
   convert
     integral_mul_deriv_eq_deriv_mul der1 (fun x _ => antideriv_sin_comp_const_mul hz x) _ _ using 1
   · refine integral_congr fun x _ => ?_

--- a/Mathlib/Combinatorics/SimpleGraph/Triangle/Counting.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Triangle/Counting.lean
@@ -85,7 +85,9 @@ private lemma good_vertices_triangle_card [DecidableEq α] (dst : 2 * ε ≤ G.e
   rw [card_image_of_injective _ (Prod.mk.inj_left _)]
   have := utu (filter_subset (G.Adj x) _) (filter_subset (G.Adj x) _) hY hZ
   have : ε ≤ G.edgeDensity {y ∈ t | G.Adj x y} {y ∈ u | G.Adj x y} := by
-    rw [abs_sub_lt_iff] at this; linarith
+    rw [abs_sub_lt_iff] at this;
+    set S := filter (fun y ↦ G.Adj x y)
+    linarith
   rw [edgeDensity_def] at this
   push_cast at this
   have hε := utu.pos.le

--- a/Mathlib/Data/Real/GoldenRatio.lean
+++ b/Mathlib/Data/Real/GoldenRatio.lean
@@ -220,6 +220,6 @@ theorem fib_golden_exp' (n : ℕ) : φ * Nat.fib (n + 1) + Nat.fib n = φ ^ (n +
     calc
       _ = φ * (Nat.fib n) + φ ^ 2 * (Nat.fib (n + 1)) := by
         simp only [Nat.fib_add_one (Nat.succ_ne_zero n), Nat.succ_sub_succ_eq_sub, tsub_zero,
-          Nat.cast_add, gold_sq]; ring
+          Nat.cast_add, gold_sq, Nat.succ_eq_add_one]; ring
       _ = φ * ((Nat.fib n) + φ * (Nat.fib (n + 1))) := by ring
       _ = φ ^ (n + 2) := by rw [add_comm, ih]; ring

--- a/Mathlib/Data/Real/Pi/Irrational.lean
+++ b/Mathlib/Data/Real/Pi/Irrational.lean
@@ -106,13 +106,13 @@ private lemma recursion' (n : ℕ) :
   have (x) : u₂' x = (2 * n + 1) * f x ^ n - 2 * n * f x ^ (n - 1) := by
     cases n with
     | zero => simp [u₂']
-    | succ n => ring!
+    | succ n => unfold u₂' f; rw [show (n + 1 - 1) = n from rfl]; ring
   simp_rw [this, sub_mul, mul_assoc _ _ (v₂ _)]
   have : Continuous v₂ := by fun_prop
   rw [mul_mul_mul_comm, integral_sub, mul_sub, add_sub_assoc]
   · congr 1
-    simp_rw [integral_const_mul]
-    ring!
+    simp_rw [integral_const_mul, I, v₂]
+    ring_nf!
   all_goals exact Continuous.intervalIntegrable (by fun_prop) _ _
 
 /--

--- a/Mathlib/FieldTheory/PrimitiveElement.lean
+++ b/Mathlib/FieldTheory/PrimitiveElement.lean
@@ -154,7 +154,7 @@ theorem primitive_element_inf_aux [Algebra.IsSeparable F E] : ∃ γ : E, F⟮α
     by_contra a
     apply hc
     apply (div_eq_iff (sub_ne_zero.mpr a)).mpr
-    simp only [γ, Algebra.smul_def, RingHom.map_add, RingHom.map_mul, RingHom.comp_apply]
+    simp only [γ, Algebra.smul_def, RingHom.map_add, RingHom.map_mul, RingHom.comp_apply, ιFE]
     ring
   rw [← eq_X_sub_C_of_separable_of_root_eq h_sep h_root h_splits h_roots]
   trans EuclideanDomain.gcd (?_ : E[X]) (?_ : E[X])

--- a/Mathlib/Geometry/Euclidean/Circumcenter.lean
+++ b/Mathlib/Geometry/Euclidean/Circumcenter.lean
@@ -118,7 +118,7 @@ theorem existsUnique_dist_eq_of_insert {s : AffineSubspace ℝ P}
         -- TODO(https://github.com/leanprover-community/mathlib4/issues/15486): used to be `field_simp`, but was really slow
         -- replaced by `simp only ...` to speed up. Reinstate `field_simp` once it is faster.
         simp (disch := field_simp_discharge) only [div_div, sub_div', one_mul, mul_div_assoc',
-          div_mul_eq_mul_div, add_div', eq_div_iff, div_eq_iff, ycc₂]
+          div_mul_eq_mul_div, add_div', eq_div_iff, div_eq_iff, ycc₂, x, y]
         ring
       · rw [dist_sq_eq_dist_orthogonalProjection_sq_add_dist_orthogonalProjection_sq _ (hps hp₁),
           orthogonalProjection_vadd_smul_vsub_orthogonalProjection _ _ hcc, Subtype.coe_mk,
@@ -153,6 +153,7 @@ theorem existsUnique_dist_eq_of_insert {s : AffineSubspace ℝ P}
         dist_of_mem_subset_mk_sphere hp0 hcr, dist_eq_norm_vsub V _ cc, vadd_vsub, norm_smul, ←
         dist_eq_norm_vsub V p, Real.norm_eq_abs, ← mul_assoc, mul_comm _ |t₃|, ← mul_assoc,
         abs_mul_abs_self]
+      unfold y
       ring
     replace hcr₃ := dist_of_mem_subset_mk_sphere (Set.mem_insert _ _) hcr₃
     rw [hpo, hcc₃'', hcr₃val, ← mul_self_inj_of_nonneg dist_nonneg (Real.sqrt_nonneg _),

--- a/Mathlib/LinearAlgebra/Ray.lean
+++ b/Mathlib/LinearAlgebra/Ray.lean
@@ -109,7 +109,7 @@ lemma sameRay_nonneg_smul_right (v : M) (h : 0 ≤ a) : SameRay R v (a • v) :=
   · rw [← algebraMap_smul R a v, h, zero_smul]
     exact zero_right _
   · refine Or.inr <| Or.inr ⟨algebraMap S R a, 1, h, by nontriviality R; exact zero_lt_one, ?_⟩
-    module
+    match_scalars; simp
 
 /-- A nonnegative multiple of a vector is in the same ray as that vector. -/
 lemma sameRay_nonneg_smul_left (v : M) (ha : 0 ≤ a) : SameRay R (a • v) v :=

--- a/Mathlib/MeasureTheory/Group/AddCircle.lean
+++ b/Mathlib/MeasureTheory/Group/AddCircle.lean
@@ -54,7 +54,7 @@ theorem isAddFundamentalDomain_of_ae_ball (I : Set <| AddCircle T) (u x : AddCir
   set G := AddSubgroup.zmultiples u
   set n := addOrderOf u
   set B := ball x (T / (2 * n))
-  have hn : 1 ≤ (n : ℝ) := by norm_cast; linarith [hu.addOrderOf_pos]
+  have hn : 1 ≤ (n : ℝ) := by norm_cast; exact hu.addOrderOf_pos
   refine IsAddFundamentalDomain.mk_of_measure_univ_le ?_ ?_ ?_ ?_
   · -- `NullMeasurableSet I volume`
     exact measurableSet_ball.nullMeasurableSet.congr hI.symm

--- a/Mathlib/MeasureTheory/Integral/MeanInequalities.lean
+++ b/Mathlib/MeasureTheory/Integral/MeanInequalities.lean
@@ -111,6 +111,7 @@ theorem lintegral_mul_le_Lp_mul_Lq_of_ne_zero_of_ne_top {p q : ℝ} (hpq : p.IsC
       refine lintegral_congr fun a => ?_
       rw [Pi.mul_apply, fun_eq_funMulInvSnorm_mul_eLpNorm f hf_nonzero hf_nontop,
         fun_eq_funMulInvSnorm_mul_eLpNorm g hg_nonzero hg_nontop, Pi.mul_apply]
+      unfold npf nqg
       ring
     _ ≤ npf * nqg := by
       rw [lintegral_mul_const' (npf * nqg) _

--- a/Mathlib/MeasureTheory/Integral/VitaliCaratheodory.lean
+++ b/Mathlib/MeasureTheory/Integral/VitaliCaratheodory.lean
@@ -480,7 +480,7 @@ theorem exists_lt_lowerSemicontinuous_integral_lt [SigmaFinite μ] (f : α → �
           simp only [EReal.toReal_coe_ennreal]
         _ ≤ (∫ x : α, ↑(fp x) ∂μ) + ↑δ - ((∫ x : α, ↑(fm x) ∂μ) - δ) := sub_le_sub_left gmint _
         _ = (∫ x : α, f x ∂μ) + 2 * δ := by
-          simp_rw [integral_eq_integral_pos_part_sub_integral_neg_part hf]; ring
+          simp_rw [integral_eq_integral_pos_part_sub_integral_neg_part hf, fp, fm]; ring
         _ = (∫ x : α, f x ∂μ) + ε := by congr 1; field_simp [δ, mul_comm]
   case aelt =>
     show ∀ᵐ x : α ∂μ, g x < ⊤

--- a/Mathlib/NumberTheory/ArithmeticFunction.lean
+++ b/Mathlib/NumberTheory/ArithmeticFunction.lean
@@ -669,7 +669,7 @@ theorem mul [CommSemiring R] {f g : ArithmeticFunction R} (hf : f.IsMultiplicati
     dsimp only
     rw [hf.map_mul_of_coprime cop.coprime_mul_right.coprime_mul_right_right,
       hg.map_mul_of_coprime cop.coprime_mul_left.coprime_mul_left_right]
-    ring
+    ring_nf
 
 @[arith_mult]
 theorem pmul [CommSemiring R] {f g : ArithmeticFunction R} (hf : f.IsMultiplicative)

--- a/Mathlib/NumberTheory/Bernoulli.lean
+++ b/Mathlib/NumberTheory/Bernoulli.lean
@@ -292,7 +292,7 @@ theorem sum_range_pow (n p : ℕ) :
       map_inv₀, map_natCast, coeff_mk, mul_inv_rev]
     rw [mul_comm ((n : ℚ) ^ (q - m + 1)), ← mul_assoc _ _ ((n : ℚ) ^ (q - m + 1)), ← one_div,
       mul_one_div, div_div, tsub_add_eq_add_tsub (le_of_lt_succ h), cast_div, cast_mul]
-    · ring
+    · rw [Nat.succ_eq_add_one]; ring
     · exact factorial_mul_factorial_dvd_factorial h.le
     · simp [hne, factorial_ne_zero]
   -- same as our goal except we pull out `p!` for convenience

--- a/Mathlib/NumberTheory/ClassNumber/Finite.lean
+++ b/Mathlib/NumberTheory/ClassNumber/Finite.lean
@@ -197,7 +197,7 @@ theorem exists_mem_finsetApprox (a : S) {b} (hb : b ≠ (0 : R)) :
       mul_left_comm, mul_inv_cancel₀, mul_one, rpow_natCast] <;>
       try norm_cast; omega
     · exact Iff.mpr Int.cast_nonneg this
-    · linarith
+    · exact le_of_lt hε
   set μ : Fin (cardM bS adm).succ ↪ R := distinctElems bS adm with hμ
   let s : ι →₀ R := bS.repr a
   have s_eq : ∀ i, s i = bS.repr a i := fun i => rfl

--- a/Mathlib/NumberTheory/LSeries/AbstractFuncEq.lean
+++ b/Mathlib/NumberTheory/LSeries/AbstractFuncEq.lean
@@ -452,6 +452,7 @@ theorem Λ_residue_zero :
   · exact (continuous_id.smul P.differentiable_Λ₀.continuous).tendsto _
   · refine (tendsto_const_nhds.mono_left nhdsWithin_le_nhds).congr' ?_
     refine eventually_nhdsWithin_of_forall (fun s (hs : s ≠ 0) ↦ ?_)
+    simp only
     match_scalars
     field_simp [sub_ne_zero.mpr hs.symm]
   · rw [show 𝓝 0 = 𝓝 ((0 : ℂ) • (P.ε / (P.k - 0 : ℂ)) • P.g₀) by rw [zero_smul]]

--- a/Mathlib/NumberTheory/Modular.lean
+++ b/Mathlib/NumberTheory/Modular.lean
@@ -467,9 +467,11 @@ theorem abs_c_le_one (hz : z ∈ 𝒟ᵒ) (hg : g • z ∈ 𝒟ᵒ) : |g 1 0| �
   calc
     9 * c ^ 4 < c ^ 4 * z.im ^ 2 * (g • z).im ^ 2 * 16 := by linarith
     _ = c ^ 4 * z.im ^ 4 / nsq ^ 2 * 16 := by
-      rw [im_smul_eq_div_normSq, div_pow]
+      rw [im_smul_eq_div_normSq, div_pow, show nsq = normSq (denom g z) from rfl]
       ring
-    _ ≤ 16 := by rw [← mul_pow]; linarith
+    _ ≤ 16 := by
+      rw [← mul_pow, show nsq = normSq (denom g z) from rfl]
+      linarith
 
 /-- An auxiliary result en route to `ModularGroup.eq_smul_self_of_mem_fdo_mem_fdo`. -/
 theorem c_eq_zero (hz : z ∈ 𝒟ᵒ) (hg : g • z ∈ 𝒟ᵒ) : g 1 0 = 0 := by

--- a/Mathlib/NumberTheory/Multiplicity.lean
+++ b/Mathlib/NumberTheory/Multiplicity.lean
@@ -98,7 +98,7 @@ theorem odd_sq_dvd_geom_sum₂_sub (hp : Odd p) :
       ring_nf
       simp only [← pow_add, map_add, Finset.sum_add_distrib, ← map_sum]
       congr
-      simp [pow_add a, mul_assoc]
+      simp [pow_add a, mul_assoc, mul_comm]
     _ =
         mk (span {s})
             (∑ x ∈ Finset.range p, a ^ (x - 1) * (a ^ (p - 1 - x) * (↑p * (b * ↑x)))) +

--- a/Mathlib/NumberTheory/NumberField/House.lean
+++ b/Mathlib/NumberTheory/NumberField/House.lean
@@ -197,7 +197,7 @@ private theorem ξ_mulVec_eq_0 : a *ᵥ ξ K x = 0 := by
   rw [sum_comm] at this
   rw [this]; congr 1; ext1 l
   rw [ξ, mul_sum]; congr 1; ext1 l
-  rw [← lin_1]; ring
+  rw [← lin_1]; ring_nf
 
 variable {A : ℝ} (habs : ∀ k l, (house ((algebraMap (𝓞 K) K) (a k l))) ≤ A)
 

--- a/Mathlib/Probability/Integration.lean
+++ b/Mathlib/Probability/Integration.lean
@@ -261,6 +261,7 @@ theorem IndepFun.integral_mul_of_integrable (hXY : IndepFun X Y μ) (hX : Integr
     integral_sub' hv4 hv3, hi1.integral_mul_of_nonneg hp1 hp3 hm1 hm3,
     hi2.integral_mul_of_nonneg hp2 hp3 hm2 hm3, hi3.integral_mul_of_nonneg hp1 hp4 hm1 hm4,
     hi4.integral_mul_of_nonneg hp2 hp4 hm2 hm4]
+  show _ = (integral μ Xp - integral μ Xm) * (integral μ Yp - integral μ Ym)
   ring
 
 /-- The (Bochner) integral of the product of two independent random

--- a/Mathlib/Probability/Moments/MGFAnalytic.lean
+++ b/Mathlib/Probability/Moments/MGFAnalytic.lean
@@ -210,7 +210,7 @@ lemma iteratedDeriv_two_cgf (h : v ∈ interior (integrableExpSet X μ)) :
     · rw [pow_two, div_mul_eq_div_div, mul_div_assoc, div_self, mul_one]
       exact (mgf_pos' hμ (interior_subset (s := integrableExpSet X μ) h)).ne'
     · rw [deriv_cgf h]
-      ring
+      ring_nf
   _ = (∫ ω, (X ω) ^ 2 * exp (v * X ω) ∂μ) / mgf X μ v - deriv (cgf X μ) v ^ 2 := by
     congr
     convert (hasDerivAt_integral_pow_mul_exp_real h 1).deriv using 1
@@ -229,7 +229,7 @@ lemma iteratedDeriv_two_cgf_eq_integral (h : v ∈ interior (integrableExpSet X 
     rw [add_div, sub_div, sub_add]
     congr 1
     rw [mul_div_cancel_right₀, deriv_cgf h]
-    · ring
+    · ring_nf
     · exact (mgf_pos' hμ (interior_subset (s := integrableExpSet X μ) h)).ne'
   _ = (∫ ω, ((X ω) ^ 2 - 2 * X ω * deriv (cgf X μ) v + deriv (cgf X μ) v ^ 2) * exp (v * X ω) ∂μ)
       / mgf X μ v := by

--- a/Mathlib/RingTheory/Localization/Basic.lean
+++ b/Mathlib/RingTheory/Localization/Basic.lean
@@ -330,7 +330,7 @@ lemma commutes (S₁ S₂ T : Type*) [CommSemiring S₁]
     convert_to _ = a * (algebraMap S₂ T) ((algebraMap R S₂) n) *
         (algebraMap S₁ T) (((algebraMap R S₁) m) * hunit.unit⁻¹.val)
     · rw [map_mul]
-      ring
+      ring_nf
     simp
   exists_of_eq {x y} hxy := by
     obtain ⟨r, s, d, hr, hs⟩ := IsLocalization.surj₂ M₁ S₁ x y
@@ -345,7 +345,7 @@ lemma commutes (S₁ S₂ T : Type*) [CommSemiring S₁]
     rw [mul_assoc, hr, mul_assoc, hs]
     apply (map_units S₁ ⟨c, hmc⟩).mul_right_cancel
     rw [← map_mul, ← map_mul, mul_assoc, mul_comm _ c, ha, map_mul, map_mul]
-    ring
+    ring_nf
 
 end IsLocalization
 

--- a/Mathlib/RingTheory/WittVector/DiscreteValuationRing.lean
+++ b/Mathlib/RingTheory/WittVector/DiscreteValuationRing.lean
@@ -66,8 +66,10 @@ def mkUnit {a : Units k} {A : 𝕎 k} (hA : A.coeff 0 = a) : Units (𝕎 k) :=
     have ha : (a : k) ^ p ^ (n + 1) = ↑(a ^ p ^ (n + 1)) := by norm_cast
     have ha_inv : (↑a⁻¹ : k) ^ p ^ (n + 1) = ↑(a ^ p ^ (n + 1))⁻¹ := by norm_cast
     simp only [nthRemainder_spec, inverseCoeff, succNthValUnits, hA,
-      one_coeff_eq_of_pos, Nat.succ_pos', ha_inv, ha, inv_pow]
-    ring!)
+      one_coeff_eq_of_pos, Nat.succ_pos', ha_inv, ha, inv_pow, add_comm 1 n, H_coeff]
+    set w := nthRemainder p n (truncateFun (n + 1) A) fun i ↦ inverseCoeff a A ↑i
+    ring_nf!; exact neg_add_cancel w
+    )
 
 @[simp]
 theorem coe_mkUnit {a : Units k} {A : 𝕎 k} (hA : A.coeff 0 = a) : (mkUnit hA : 𝕎 k) = A :=

--- a/Mathlib/RingTheory/WittVector/FrobeniusFractionField.lean
+++ b/Mathlib/RingTheory/WittVector/FrobeniusFractionField.lean
@@ -235,7 +235,7 @@ theorem exists_frobenius_solution_fractionRing_aux (m n : ℕ) (r' q' : 𝕎 k) 
     have H := congr_arg (fun x : 𝕎 k => x * (p : 𝕎 k) ^ m * (p : 𝕎 k) ^ n)
       (frobenius_frobeniusRotation p hr' hq')
     dsimp at H
-    refine (Eq.trans ?_ H).trans ?_ <;> ring
+    refine (Eq.trans ?_ H).trans ?_ <;> (unfold b; ring_nf)
   have hq'' : algebraMap (𝕎 k) (FractionRing (𝕎 k)) q' ≠ 0 := by
     have hq''' : q' ≠ 0 := fun h => hq' (by simp [h])
     simpa only [Ne, map_zero] using
@@ -243,7 +243,7 @@ theorem exists_frobenius_solution_fractionRing_aux (m n : ℕ) (r' q' : 𝕎 k) 
   rw [zpow_sub₀ (FractionRing.p_nonzero p k)]
   field_simp [FractionRing.p_nonzero p k]
   convert congr_arg (fun x => algebraMap (𝕎 k) (FractionRing (𝕎 k)) x) key using 1
-  · simp only [RingHom.map_mul, RingHom.map_pow, map_natCast, frobeniusEquiv_apply]
+  · simp only [RingHom.map_mul, RingHom.map_pow, map_natCast, frobeniusEquiv_apply, FractionRing]
     ring
   · simp only [RingHom.map_mul, RingHom.map_pow, map_natCast]
 

--- a/Mathlib/Tactic/LinearCombination'.lean
+++ b/Mathlib/Tactic/LinearCombination'.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Abby J. Goldberg, Mario Carneiro
 -/
 import Mathlib.Tactic.Ring
+import Mathlib.Tactic.AtomM
 
 /-!
 # linear_combination' Tactic

--- a/Mathlib/Tactic/LinearCombination'.lean
+++ b/Mathlib/Tactic/LinearCombination'.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Abby J. Goldberg, Mario Carneiro
 -/
 import Mathlib.Tactic.Ring
-import Mathlib.Tactic.AtomM
+import Mathlib.Util.AtomM
 
 /-!
 # linear_combination' Tactic

--- a/Mathlib/Tactic/LinearCombination'.lean
+++ b/Mathlib/Tactic/LinearCombination'.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Abby J. Goldberg, Mario Carneiro
 -/
 import Mathlib.Tactic.Ring
-import Mathlib.Util.AtomM
 
 /-!
 # linear_combination' Tactic

--- a/Mathlib/Tactic/LinearCombination.lean
+++ b/Mathlib/Tactic/LinearCombination.lean
@@ -7,6 +7,7 @@ import Mathlib.Tactic.LinearCombination.Lemmas
 import Mathlib.Tactic.Positivity.Core
 import Mathlib.Tactic.Ring
 import Mathlib.Tactic.Ring.Compare
+import Mathlib.Util.AtomM
 
 /-!
 # linear_combination Tactic

--- a/Mathlib/Tactic/LinearCombination.lean
+++ b/Mathlib/Tactic/LinearCombination.lean
@@ -200,7 +200,7 @@ def elabLinearCombination (tk : Syntax)
     -- for an equality task the default normalization tactic is (the internals of) `ring1` (but we
     -- use `.instances` transparency, which is arguably more robust in algebraic settings than the
     -- choice `.reducible` made in `ring1`)
-    | eq => fun g ↦ AtomM.run .instances <| Ring.proveEq g
+    | eq => fun g ↦ CanonAtomM.run .instances <| Ring.proveEq g
     | le => Ring.proveLE
     | lt => Ring.proveLT
 

--- a/Mathlib/Tactic/Module.lean
+++ b/Mathlib/Tactic/Module.lean
@@ -6,7 +6,7 @@ Authors: Heather Macbeth
 import Mathlib.Algebra.Algebra.Tower
 import Mathlib.Algebra.BigOperators.GroupWithZero.Action
 import Mathlib.Tactic.Ring
-import Mathlib.Util.AtomM
+import Mathlib.Util.CanonAtomM
 
 /-! # A tactic for normalization over modules
 
@@ -408,7 +408,7 @@ Possible TODO, if poor performance on large problems is witnessed: switch the im
 `AtomM` to `CanonM`, per the discussion
 https://github.com/leanprover-community/mathlib4/pull/16593/files#r1749623191 -/
 partial def parse (iM : Q(AddCommMonoid $M)) (x : Q($M)) :
-    AtomM (Σ u : Level, Σ R : Q(Type u), Σ iR : Q(Semiring $R), Σ _ : Q(@Module $R $M $iR $iM),
+    CanonAtomM (Σ u : Level, Σ R : Q(Type u), Σ iR : Q(Semiring $R), Σ _ : Q(@Module $R $M $iR $iM),
       Σ l : qNF R M, Q($x = NF.eval $(l.toNF))) := do
   match x with
   /- parse an addition: `x₁ + x₂` -/
@@ -464,7 +464,7 @@ partial def parse (iM : Q(AddCommMonoid $M)) (x : Q($M)) :
     pure ⟨0, q(Nat), q(Nat.instSemiring), q(AddCommGroup.toNatModule), [], q(NF.zero_eq_eval $M)⟩
   /- anything else should be treated as an atom -/
   | _ =>
-    let (k, ⟨x', _⟩) ← AtomM.addAtomQ x
+    let (k, ⟨x', _⟩) ← CanonAtomM.addAtomQ x
     pure ⟨0, q(Nat), q(Nat.instSemiring), q(AddCommGroup.toNatModule), [((q(1), x'), k)],
       q(NF.atom_eq_eval $x')⟩
 
@@ -516,7 +516,7 @@ the respective equalities of the `R`-coefficients of each atom.
 
 This is an auxiliary function which produces slightly awkward goals in `R`; they are later cleaned
 up by the function `Mathlib.Tactic.Module.postprocess`. -/
-def matchScalarsAux (g : MVarId) : AtomM (List MVarId) := do
+def matchScalarsAux (g : MVarId) : CanonAtomM (List MVarId) := do
   /- Parse the goal as an equality in a type `M` of two expressions `lhs` and `rhs`, with `M`
   carrying an `AddCommMonoid` instance. -/
   let eqData ← do
@@ -582,7 +582,7 @@ def postprocess (mvarId : MVarId) : MetaM MVarId := do
 RHS of the goal as linear combinations of `M`-atoms over some semiring `R`, and reduce the goal to
 the respective equalities of the `R`-coefficients of each atom. -/
 def matchScalars (g : MVarId) : MetaM (List MVarId) := do
-  let mvars ← AtomM.run .instances (matchScalarsAux g)
+  let mvars ← CanonAtomM.run .instances (matchScalarsAux g)
   mvars.mapM postprocess
 
 /-- Given a goal which is an equality in a type `M` (with `M` an `AddCommMonoid`), parse the LHS and
@@ -649,6 +649,6 @@ example [AddCommGroup M] [CommRing R] [Module R M] (a b μ ν : R) (x y : M) :
 -/
 elab "module" : tactic => Tactic.liftMetaFinishingTactic fun g ↦ do
   let l ← matchScalars g
-  discard <| l.mapM fun mvar ↦ AtomM.run .instances (Ring.proveEq mvar)
+  discard <| l.mapM fun mvar ↦ CanonAtomM.run .instances (Ring.proveEq mvar)
 
 end Mathlib.Tactic.Module

--- a/Mathlib/Tactic/Ring/Compare.lean
+++ b/Mathlib/Tactic/Ring/Compare.lean
@@ -210,7 +210,8 @@ def proveLE (g : MVarId) : MetaM Unit := do
   have e₁ : Q($α) := e₁; have e₂ : Q($α) := e₂
   let c ← mkCache q(cs_of_ocs $α)
   let (⟨a, va, pa⟩, ⟨b, vb, pb⟩)
-    ← AtomM.run .instances do pure (← eval q(cs_of_ocs $α) c e₁, ← eval q(cs_of_ocs $α) c e₂)
+    ← CanonAtomM.run .instances
+        do pure (← eval q(cs_of_ocs $α) c e₁, ← eval q(cs_of_ocs $α) c e₂)
   match ← evalLE sα va vb with
   | .ok p => g.assign q(le_congr $pa $p $pb)
   | .error e =>
@@ -234,7 +235,8 @@ def proveLT (g : MVarId) : MetaM Unit := do
   have e₁ : Q($α) := e₁; have e₂ : Q($α) := e₂
   let c ← mkCache q(cs_of_socs $α)
   let (⟨a, va, pa⟩, ⟨b, vb, pb⟩)
-    ← AtomM.run .instances do pure (← eval q(cs_of_socs $α) c e₁, ← eval q(cs_of_socs $α) c e₂)
+    ← CanonAtomM.run .instances
+        do pure (← eval q(cs_of_socs $α) c e₁, ← eval q(cs_of_socs $α) c e₂)
   match ← evalLT sα va vb with
   | .ok p => g.assign q(lt_congr $pa $p $pb)
   | .error e =>

--- a/Mathlib/Util/CanonAtomM.lean
+++ b/Mathlib/Util/CanonAtomM.lean
@@ -1,0 +1,64 @@
+/-
+Copyright (c) 2025 Jingting Wang. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jingting Wang
+-/
+import Mathlib.Init
+import Lean.Meta.Tactic.Simp.Types
+import Qq
+
+/-!
+# A monad for tracking and deduplicating atoms
+This monad attempts to provide the same functionality as `AtomM`, but uses the recommended faster =
+approach described in `CanonM`.
+-/
+namespace Mathlib.Tactic
+
+open Lean Meta
+
+/-- The context (read-only state) of the `CanonAtomM` monad. -/
+structure CanonAtomM.Context where
+  /-- The reducibility setting for definitional equality of atoms -/
+  red : TransparencyMode
+  /-- A simplification to apply to atomic expressions when they are encountered,
+  before interning them in the atom list. -/
+  evalAtom : Expr → MetaM Simp.Result := fun e ↦ pure { expr := e }
+  deriving Inhabited
+
+/-- The mutable state of the `AtomM` monad. -/
+structure CanonAtomM.State where
+  /-- The index for the new atom -/
+  currentIndex : Nat := 0
+  /-- A hashmap to keep track of the indices of canonicalized `Expr`s -/
+  index : Std.HashMap Expr Nat := {}
+
+/-- The monad used for collecting atoms. -/
+abbrev CanonAtomM := ReaderT CanonAtomM.Context <| StateRefT CanonAtomM.State CanonM
+
+/-- Run a computation in the `CanonAtomM` monad. -/
+def CanonAtomM.run {α : Type} (red : TransparencyMode) (m : CanonAtomM α)
+    (evalAtom : Expr → MetaM Simp.Result := fun e ↦ pure { expr := e }) :
+    MetaM α :=
+  ((m { red, evalAtom }).run' {}).run' red
+
+/-- If an atomic expression has already been encountered, get the index and the stored form of the
+atom (which will be defeq at the specified transparency, but not necessarily syntactically equal).
+If the atomic expression has *not* already been encountered, store it in the list of atoms, and
+return the new index (and the stored form of the atom, which will be the canonicalized version). -/
+def CanonAtomM.addAtom (e : Expr) : CanonAtomM (Nat × Expr) := do
+  let e' ← canon e
+  if let some es := (← get).index.get? e' then
+    return (es, e')
+  else
+    modifyGet fun c ↦ ((c.currentIndex, e'),
+      {currentIndex := c.currentIndex + 1, index := (c.index.insert e' c.currentIndex)})
+
+open Qq
+
+/-- A strongly typed version of `CanonAtomM.addAtom` using `Qq`. -/
+def CanonAtomM.addAtomQ {u : Level} {α : Q(Type u)} (e : Q($α)) :
+    CanonAtomM (Nat × {e' : Q($α) // $e =Q $e'}) := do
+  let (n, e') ← CanonAtomM.addAtom e
+  return (n, ⟨e', ⟨⟩⟩)
+
+end Mathlib.Tactic


### PR DESCRIPTION
In this PR, we test the efficiency of `ring` after refactoring it to `CanonAtomM` in #22614.

- depends on [ ]: #22614 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
