### PR TITLE
[Merged by Bors] - feat: separate mappings for Ionescu-Tulcea theorem

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4627,6 +4627,7 @@ import Mathlib.Probability.Kernel.Disintegration.StandardBorel
 import Mathlib.Probability.Kernel.Disintegration.Unique
 import Mathlib.Probability.Kernel.Integral
 import Mathlib.Probability.Kernel.Invariance
+import Mathlib.Probability.Kernel.IonescuTulcea.Maps
 import Mathlib.Probability.Kernel.IonescuTulcea.PartialTraj
 import Mathlib.Probability.Kernel.MeasurableIntegral
 import Mathlib.Probability.Kernel.MeasurableLIntegral

--- a/Mathlib/Probability/Kernel/IonescuTulcea/Maps.lean
+++ b/Mathlib/Probability/Kernel/IonescuTulcea/Maps.lean
@@ -114,7 +114,7 @@ lemma coe_IicProdIoc_symm {a b : ι} (hab : a ≤ b) :
 /-- Gluing `Iic a` and `Ioi a` into `ℕ`, version as a measurable equivalence
 on dependent functions. -/
 def IicProdIoi (a : ι) :
-    ((Π i : Iic a, X i) × ((i : Set.Ioi a) → X i)) ≃ᵐ (Π n, X n) where
+    ((Π i : Iic a, X i) × (Π i : Set.Ioi a, X i)) ≃ᵐ (Π n, X n) where
   toFun := fun x i ↦ if hi : i ≤ a
     then x.1 ⟨i, mem_Iic.2 hi⟩
     else x.2 ⟨i, Set.mem_Ioi.2 (not_le.1 hi)⟩

--- a/Mathlib/Probability/Kernel/IonescuTulcea/Maps.lean
+++ b/Mathlib/Probability/Kernel/IonescuTulcea/Maps.lean
@@ -1,0 +1,135 @@
+/-
+Copyright (c) 2025 Etienne Marion. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Etienne Marion
+-/
+import Mathlib.MeasureTheory.MeasurableSpace.Embedding
+import Mathlib.Order.Restriction
+
+/-! # Auxiliary maps for Ionescu-Tulcea theorem
+
+This file contains auxiliary maps which are used to prove the Ionescu-Tulcea theorem.
+ -/
+
+open Finset Preorder
+
+variable {ι : Type*} [LinearOrder ι] [LocallyFiniteOrder ι] [DecidableLE ι] {X : ι → Type*}
+
+section IocProdIoc
+
+/-- Gluing `Ioc a b` and `Ioc b c` into `Ioc a c`. -/
+def IocProdIoc (a b c : ι) (x : (Π i : Ioc a b, X i) × (Π i : Ioc b c, X i)) (i : Ioc a c) : X i :=
+  if h : i ≤ b
+    then x.1 ⟨i, mem_Ioc.2 ⟨(mem_Ioc.1 i.2).1, h⟩⟩
+    else x.2 ⟨i, mem_Ioc.2 ⟨not_le.1 h, (mem_Ioc.1 i.2).2⟩⟩
+
+variable [∀ i, MeasurableSpace (X i)]
+
+@[measurability, fun_prop]
+lemma measurable_IocProdIoc {a b c : ι} : Measurable (IocProdIoc (X := X) a b c) := by
+  refine measurable_pi_lambda _ (fun i ↦ ?_)
+  by_cases h : i ≤ b
+  · simpa [IocProdIoc, h] using measurable_fst.eval
+  · simpa [IocProdIoc, h] using measurable_snd.eval
+
+end IocProdIoc
+
+section IicProdIoc
+
+variable [LocallyFiniteOrderBot ι]
+
+/-- Gluing `Iic a` and `Ioc a b` into `Iic b`. If `b < a`, this is just a projection on the first
+coordinate followed by a restriction, see `IicProdIoc_le`. -/
+def IicProdIoc (a b : ι) (x : (Π i : Iic a, X i) × (Π i : Ioc a b, X i)) (i : Iic b) : X i :=
+  if h : i ≤ a
+    then x.1 ⟨i, mem_Iic.2 h⟩
+    else x.2 ⟨i, mem_Ioc.2 ⟨not_le.1 h, mem_Iic.1 i.2⟩⟩
+
+/-- When `IicProdIoc` is only partially applied (i.e. `IicProdIoc a b x` but not
+`IicProdIoc a b x i`) `simp [IicProdIoc]` won't unfold the definition.
+This lemma allows to unfold it by writing `simp [IicProdIoc_def]`. -/
+lemma IicProdIoc_def (a b : ι) :
+    IicProdIoc (X := X) a b = fun x i ↦ if h : i.1 ≤ a then x.1 ⟨i, mem_Iic.2 h⟩
+      else x.2 ⟨i, mem_Ioc.2 ⟨not_le.1 h, mem_Iic.1 i.2⟩⟩ := rfl
+
+lemma frestrictLe₂_comp_IicProdIoc {a b : ι} (hab : a ≤ b) :
+    (frestrictLe₂ hab) ∘ (IicProdIoc (X := X) a b) = Prod.fst := by
+  ext x i
+  simp [IicProdIoc, mem_Iic.1 i.2]
+
+lemma restrict₂_comp_IicProdIoc (a b : ι) :
+    (restrict₂ Ioc_subset_Iic_self) ∘ (IicProdIoc (X := X) a b) = Prod.snd := by
+  ext x i
+  simp [IicProdIoc, not_le.2 (mem_Ioc.1 i.2).1]
+
+@[simp]
+lemma IicProdIoc_self (a : ι) : IicProdIoc (X := X) a a = Prod.fst := by
+  ext x i
+  simp [IicProdIoc, mem_Iic.1 i.2]
+
+lemma IicProdIoc_le {a b : ι} (hba : b ≤ a) :
+    IicProdIoc (X := X) a b = (frestrictLe₂ hba) ∘ Prod.fst := by
+  ext x i
+  simp [IicProdIoc, (mem_Iic.1 i.2).trans hba]
+
+lemma IicProdIoc_comp_restrict₂ {a b : ι} :
+    (restrict₂ Ioc_subset_Iic_self) ∘ (IicProdIoc (X := X) a b) = Prod.snd := by
+  ext x i
+  simp [IicProdIoc, not_le.2 (mem_Ioc.1 i.2).1]
+
+variable [∀ i, MeasurableSpace (X i)]
+
+@[measurability, fun_prop]
+lemma measurable_IicProdIoc {m n : ι} : Measurable (IicProdIoc (X := X) m n) := by
+  refine measurable_pi_lambda _ (fun i ↦ ?_)
+  by_cases h : i ≤ m
+  · simpa [IicProdIoc, h] using measurable_fst.eval
+  · simpa [IicProdIoc, h] using measurable_snd.eval
+
+namespace MeasurableEquiv
+
+/-- Gluing `Iic a` and `Ioc a b` into `Iic b`. This version requires `a ≤ b` to get a measurable
+equivalence. -/
+def IicProdIoc {a b : ι} (hab : a ≤ b) :
+    ((Π i : Iic a, X i) × (Π i : Ioc a b, X i)) ≃ᵐ Π i : Iic b, X i where
+  toFun x i := if h : i ≤ a then x.1 ⟨i, mem_Iic.2 h⟩
+    else x.2 ⟨i, mem_Ioc.2 ⟨not_le.1 h, mem_Iic.1 i.2⟩⟩
+  invFun x := ⟨fun i ↦ x ⟨i.1, Iic_subset_Iic.2 hab i.2⟩, fun i ↦ x ⟨i.1, Ioc_subset_Iic_self i.2⟩⟩
+  left_inv := fun x ↦ by
+    ext i
+    · simp [mem_Iic.1 i.2]
+    · simp [not_le.2 (mem_Ioc.1 i.2).1]
+  right_inv := fun x ↦ funext fun i ↦ by
+    by_cases hi : i.1 ≤ a <;> simp [hi]
+  measurable_toFun := by
+    refine measurable_pi_lambda _ (fun x ↦ ?_)
+    by_cases h : x ≤ a
+    · simpa [h] using measurable_fst.eval
+    · simpa [h] using measurable_snd.eval
+  measurable_invFun := by
+    refine Measurable.prod_mk ?_ ?_ <;> exact measurable_pi_lambda _ (fun a ↦ measurable_id.eval)
+
+lemma coe_IicProdIoc {a b : ι} (hab : a ≤ b) :
+    ⇑(IicProdIoc (X := X) hab) = _root_.IicProdIoc a b := rfl
+
+lemma coe_IicProdIoc_symm {a b : ι} (hab : a ≤ b) :
+    ⇑(IicProdIoc (X := X) hab).symm =
+    fun x ↦ (frestrictLe₂ hab x, restrict₂ Ioc_subset_Iic_self x) := rfl
+
+end MeasurableEquiv
+
+end IicProdIoc
+
+variable {X : ℕ → Type*} [∀ n, MeasurableSpace (X n)]
+
+/-- Identifying `{a + 1}` with `Ioc a (a + 1)`, as a measurable equiv on dependent functions. -/
+def MeasurableEquiv.piSingleton (a : ℕ) : X (a + 1) ≃ᵐ Π i : Ioc a (a + 1), X i where
+  toFun x i := (Nat.mem_Ioc_succ.1 i.2).symm ▸ x
+  invFun x := x ⟨a + 1, right_mem_Ioc.2 a.lt_succ_self⟩
+  left_inv := fun x ↦ by simp
+  right_inv := fun x ↦ funext fun i ↦ by cases Nat.mem_Ioc_succ' i; rfl
+  measurable_toFun := by
+    simp_rw [eqRec_eq_cast]
+    refine measurable_pi_lambda _ (fun i ↦ (MeasurableEquiv.cast _ ?_).measurable)
+    cases Nat.mem_Ioc_succ' i; rfl
+  measurable_invFun := measurable_pi_apply _

--- a/Mathlib/Probability/Kernel/IonescuTulcea/PartialTraj.lean
+++ b/Mathlib/Probability/Kernel/IonescuTulcea/PartialTraj.lean
@@ -5,6 +5,7 @@ Authors: Etienne Marion
 -/
 import Mathlib.MeasureTheory.MeasurableSpace.PreorderRestrict
 import Mathlib.Probability.Kernel.Composition.Prod
+import Mathlib.Probability.Kernel.IonescuTulcea.Maps
 
 /-!
 # Consecutive composition of kernels
@@ -71,116 +72,7 @@ open Finset Function MeasureTheory Preorder ProbabilityTheory
 
 open scoped ENNReal
 
-variable {X : ℕ → Type*}
-
-section Maps
-
-/-! ### Auxiliary maps for the definition -/
-
-/-- Gluing `Iic a` and `Ioc a b` into `Iic b`. If `b < a`, this is just a projection on the first
-coordinate followed by a restriction, see `IicProdIoc_le`. -/
-def IicProdIoc (a b : ℕ) (x : (Π i : Iic a, X i) × (Π i : Ioc a b, X i)) (i : Iic b) : X i :=
-  if h : i ≤ a
-    then x.1 ⟨i, mem_Iic.2 h⟩
-    else x.2 ⟨i, mem_Ioc.2 ⟨not_le.1 h, mem_Iic.1 i.2⟩⟩
-
-/-- When `IicProdIoc` is only partially applied (i.e. `IicProdIoc a b x` but not
-`IicProdIoc a b x i`) `simp [IicProdIoc]` won't unfold the definition.
-This lemma allows to unfold it by writing `simp [IicProdIoc_def]`. -/
-lemma IicProdIoc_def (a b : ℕ) :
-    IicProdIoc (X := X) a b = fun x i ↦ if h : i.1 ≤ a then x.1 ⟨i, mem_Iic.2 h⟩
-      else x.2 ⟨i, mem_Ioc.2 ⟨not_le.1 h, mem_Iic.1 i.2⟩⟩ := rfl
-
-lemma frestrictLe₂_comp_IicProdIoc {a b : ℕ} (hab : a ≤ b) :
-    (frestrictLe₂ hab) ∘ (IicProdIoc (X := X) a b) = Prod.fst := by
-  ext x i
-  simp [IicProdIoc, mem_Iic.1 i.2]
-
-lemma restrict₂_comp_IicProdIoc (a b : ℕ) :
-    (restrict₂ Ioc_subset_Iic_self) ∘ (IicProdIoc (X := X) a b) = Prod.snd := by
-  ext x i
-  simp [IicProdIoc, not_le.2 (mem_Ioc.1 i.2).1]
-
-@[simp]
-lemma IicProdIoc_self (a : ℕ) : IicProdIoc (X := X) a a = Prod.fst := by
-  ext x i
-  simp [IicProdIoc, mem_Iic.1 i.2]
-
-lemma IicProdIoc_le {a b : ℕ} (hba : b ≤ a) :
-    IicProdIoc (X := X) a b = (frestrictLe₂ hba) ∘ Prod.fst := by
-  ext x i
-  simp [IicProdIoc, (mem_Iic.1 i.2).trans hba]
-
-lemma IicProdIoc_comp_restrict₂ {a b : ℕ} :
-    (restrict₂ Ioc_subset_Iic_self) ∘ (IicProdIoc (X := X) a b) = Prod.snd := by
-  ext x i
-  simp [IicProdIoc, not_le.2 (mem_Ioc.1 i.2).1]
-
-/-- Gluing `Ioc a b` and `Ioc b c` into `Ioc a c`. -/
-def IocProdIoc (a b c : ℕ) (x : (Π i : Ioc a b, X i) × (Π i : Ioc b c, X i)) (i : Ioc a c) : X i :=
-  if h : i ≤ b
-    then x.1 ⟨i, mem_Ioc.2 ⟨(mem_Ioc.1 i.2).1, h⟩⟩
-    else x.2 ⟨i, mem_Ioc.2 ⟨not_le.1 h, (mem_Ioc.1 i.2).2⟩⟩
-
-variable [∀ n, MeasurableSpace (X n)]
-
-@[measurability, fun_prop]
-lemma measurable_IicProdIoc {m n : ℕ} : Measurable (IicProdIoc (X := X) m n) := by
-  refine measurable_pi_lambda _ (fun i ↦ ?_)
-  by_cases h : i ≤ m
-  · simpa [IicProdIoc, h] using measurable_fst.eval
-  · simpa [IicProdIoc, h] using measurable_snd.eval
-
-@[measurability, fun_prop]
-lemma measurable_IocProdIoc {a b c : ℕ} : Measurable (IocProdIoc (X := X) a b c) := by
-  refine measurable_pi_lambda _ (fun i ↦ ?_)
-  by_cases h : i ≤ b
-  · simpa [IocProdIoc, h] using measurable_fst.eval
-  · simpa [IocProdIoc, h] using measurable_snd.eval
-
-/-- Identifying `{n + 1}` with `Ioc n (n + 1)`, as a measurable equiv on dependent functions. -/
-def MeasurableEquiv.piSingleton (a : ℕ) : (X (a + 1)) ≃ᵐ ((i : Ioc a (a + 1)) → X i) where
-  toFun x i := (Nat.mem_Ioc_succ.1 i.2).symm ▸ x
-  invFun x := x ⟨a + 1, right_mem_Ioc.2 a.lt_succ_self⟩
-  left_inv := fun x ↦ by simp
-  right_inv := fun x ↦ funext fun i ↦ by cases Nat.mem_Ioc_succ' i; rfl
-  measurable_toFun := by
-    simp_rw [eqRec_eq_cast]
-    refine measurable_pi_lambda _ (fun i ↦ (MeasurableEquiv.cast _ ?_).measurable)
-    cases Nat.mem_Ioc_succ' i; rfl
-  measurable_invFun := measurable_pi_apply _
-
-/-- Gluing `Iic a` and `Ioc a b` into `Iic b`. This version requires `a ≤ b` to get a measurable
-equivalence. -/
-def MeasurableEquiv.IicProdIoc {a b : ℕ} (hab : a ≤ b) :
-    ((Π i : Iic a, X i) × (Π i : Ioc a b, X i)) ≃ᵐ Π i : Iic b, X i where
-  toFun x i := if h : i ≤ a then x.1 ⟨i, mem_Iic.2 h⟩
-    else x.2 ⟨i, mem_Ioc.2 ⟨not_le.1 h, mem_Iic.1 i.2⟩⟩
-  invFun x := ⟨fun i ↦ x ⟨i.1, Iic_subset_Iic.2 hab i.2⟩, fun i ↦ x ⟨i.1, Ioc_subset_Iic_self i.2⟩⟩
-  left_inv := fun x ↦ by
-    ext i
-    · simp [mem_Iic.1 i.2]
-    · simp [not_le.2 (mem_Ioc.1 i.2).1]
-  right_inv := fun x ↦ funext fun i ↦ by
-    by_cases hi : i.1 ≤ a <;> simp [hi]
-  measurable_toFun := by
-    refine measurable_pi_lambda _ (fun x ↦ ?_)
-    by_cases h : x ≤ a
-    · simpa [h] using measurable_fst.eval
-    · simpa [h] using measurable_snd.eval
-  measurable_invFun := by
-    refine Measurable.prod_mk ?_ ?_ <;> exact measurable_pi_lambda _ (fun a ↦ measurable_id.eval)
-
-lemma MeasurableEquiv.coe_IicProdIoc {a b : ℕ} (hab : a ≤ b) :
-    ⇑(IicProdIoc (X := X) hab) = _root_.IicProdIoc a b := rfl
-
-lemma MeasurableEquiv.coe_IicProdIoc_symm {a b : ℕ} (hab : a ≤ b) :
-    ⇑(IicProdIoc (X := X) hab).symm =
-    fun x ↦ (frestrictLe₂ hab x, restrict₂ Ioc_subset_Iic_self x) := rfl
-
-end Maps
-
-variable {mX : ∀ n, MeasurableSpace (X n)} {a b c : ℕ}
+variable {X : ℕ → Type*} {mX : ∀ n, MeasurableSpace (X n)} {a b c : ℕ}
   {κ : (n : ℕ) → Kernel (Π i : Iic n, X i) (X (n + 1))}
 
 section partialTraj


### PR DESCRIPTION
We use many auxiliary maps for Ionescu-Tulcea theorem in #22471. This PR put them in their own file.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
