### PR TITLE
feat(GroupTheory/FreeGroup): theory of (cyclically) reduced words

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3492,6 +3492,7 @@ import Mathlib.GroupTheory.FreeGroup.Basic
 import Mathlib.GroupTheory.FreeGroup.IsFreeGroup
 import Mathlib.GroupTheory.FreeGroup.NielsenSchreier
 import Mathlib.GroupTheory.FreeGroup.Reduce
+import Mathlib.GroupTheory.FreeGroup.ReducedWords
 import Mathlib.GroupTheory.Goursat
 import Mathlib.GroupTheory.GroupAction.Basic
 import Mathlib.GroupTheory.GroupAction.Blocks

--- a/Mathlib/GroupTheory/FreeGroup/Basic.lean
+++ b/Mathlib/GroupTheory/FreeGroup/Basic.lean
@@ -462,7 +462,7 @@ theorem invRev_empty : invRev ([] : List (α × Bool)) = [] :=
 @[to_additive (attr := simp)]
 theorem invRev_append : invRev (L₁ ++ L₂) = invRev L₂ ++ invRev L₁ := by simp [invRev]
 
-@[to_additive (attr := simp)]
+@[to_additive]
 theorem invRev_cons {a : (α × Bool)} : invRev (a :: L) = invRev L ++ invRev [a] := by
   simp [invRev]
 

--- a/Mathlib/GroupTheory/FreeGroup/Basic.lean
+++ b/Mathlib/GroupTheory/FreeGroup/Basic.lean
@@ -459,6 +459,13 @@ theorem invRev_invRev : invRev (invRev L₁) = L₁ := by
 theorem invRev_empty : invRev ([] : List (α × Bool)) = [] :=
   rfl
 
+@[to_additive (attr := simp)]
+theorem invRev_append : invRev (L₁ ++ L₂) = invRev L₂ ++ invRev L₁ := by simp [invRev]
+
+@[to_additive (attr := simp)]
+theorem invRev_cons {a : (α × Bool)} : invRev (a :: L) = invRev L ++ invRev [a] := by
+  simp [invRev]
+
 @[to_additive]
 theorem invRev_involutive : Function.Involutive (@invRev α) := fun _ => invRev_invRev
 

--- a/Mathlib/GroupTheory/FreeGroup/Reduce.lean
+++ b/Mathlib/GroupTheory/FreeGroup/Reduce.lean
@@ -214,6 +214,17 @@ theorem reduce_toWord : ∀ x : FreeGroup α, reduce (toWord x) = toWord x := by
 theorem toWord_one : (1 : FreeGroup α).toWord = [] :=
   rfl
 
+@[to_additive]
+theorem toWord_mul (x y : FreeGroup α) : toWord (x * y) = reduce (toWord x ++ toWord y) := by
+  rw [← mk_toWord (x := x), ← mk_toWord (x:= y), mul_mk]
+  simp
+
+@[to_additive]
+theorem toWord_pow (x : FreeGroup α) (n : ℕ) :
+    toWord (x^n) = reduce (List.replicate n x.toWord).flatten := by
+  rw [← mk_toWord (x := x), pow_mk]
+  simp
+
 @[to_additive (attr := simp)]
 theorem toWord_of_pow (a : α) (n : ℕ) : (of a ^ n).toWord = List.replicate n (a, true) := by
   rw [of, pow_mk, List.flatten_replicate_singleton, toWord]
@@ -235,6 +246,19 @@ theorem reduce_invRev {w : List (α × Bool)} : reduce (invRev w) = invRev (redu
 theorem toWord_inv (x : FreeGroup α) : x⁻¹.toWord = invRev x.toWord := by
   rcases x with ⟨L⟩
   rw [quot_mk_eq_mk, inv_mk, toWord_mk, toWord_mk, reduce_invRev]
+
+@[to_additive]
+theorem reduce_append : (reduce (L₁ ++ L₂)) = reduce (reduce L₁ ++ reduce L₂) := by
+rw [← toWord_mk, ← mul_mk, toWord_mul, toWord_mk, toWord_mk]
+
+@[to_additive]
+theorem reduce_cons (a : α × Bool) (w : List (α × Bool)) :
+    FreeGroup.reduce (a :: w) = FreeGroup.reduce (a :: FreeGroup.reduce w) := by
+  simp only [FreeGroup.reduce.cons, FreeGroup.reduce.idem]
+
+@[to_additive]
+theorem reduce_invRev_left_cancel (L : List (α × Bool)) : reduce (invRev L ++ L) = [] := by
+  simp [←toWord_mk, ←mul_mk, ←inv_mk]
 
 open List -- for <+ notation
 

--- a/Mathlib/GroupTheory/FreeGroup/ReducedWords.lean
+++ b/Mathlib/GroupTheory/FreeGroup/ReducedWords.lean
@@ -3,13 +3,11 @@ Copyright (c) 2025 Bernhard Reinke. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Amir Livne Bar-on, Bernhard Reinke
 -/
-
-import Mathlib.GroupTheory.FreeGroup.Reduce
-import Mathlib.Tactic.Linarith
-
 import Mathlib.Data.List.Chain
 import Mathlib.Data.List.Lemmas
+import Mathlib.GroupTheory.FreeGroup.Reduce
 import Mathlib.GroupTheory.OrderOfElement
+import Mathlib.Tactic.Linarith
 
 /-!
 This file defines some extra lemmas for free groups, in particular about (cyclically) reduced words.

--- a/Mathlib/GroupTheory/FreeGroup/ReducedWords.lean
+++ b/Mathlib/GroupTheory/FreeGroup/ReducedWords.lean
@@ -1,0 +1,386 @@
+/-
+Copyright (c) 2025 Bernhard Reinke. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Amir Livne Bar-on, Bernhard Reinke
+-/
+
+import Mathlib.GroupTheory.FreeGroup.Reduce
+import Mathlib.Tactic.Linarith
+
+import Mathlib.Data.List.Chain
+import Mathlib.Data.List.Lemmas
+import Mathlib.GroupTheory.OrderOfElement
+
+/-!
+This file defines some extra lemmas for free groups, in particular about (cyclically) reduced words.
+
+## Main declarations
+
+* `FreeGroup.Red.reduced`: the predicate for reduced words
+* `FreeGroup.Red.cyclicallyReduced`: the predicate for cyclically reduced words
+
+## Main statements
+* `FreeGroup.infinite_order`: : nontrivial elements of a free group have infinite order
+* `FreeGroup.zpow_left_injective`: taking n-th powers is an injective function on the free group
+
+-/
+open List
+
+universe u
+
+variable {α : Type u}
+namespace FreeGroup
+
+variable {L L₁ L₂ : List (α × Bool)}
+
+
+namespace Red
+
+@[to_additive]
+def reduced (L : List (α × Bool)) : Prop := List.Chain' (fun a b => ¬(a.1 = b.1 ∧ (!a.2) = b.2)) L
+
+@[to_additive (attr := simp)]
+theorem reduced_nil : reduced ([] : List (α × Bool)) := List.chain'_nil
+
+@[to_additive (attr := simp)]
+theorem reduced_singleton {a : (α × Bool)} : reduced [a] := List.chain'_singleton a
+
+@[to_additive (attr := simp)]
+theorem reduced_cons {a b: (α × Bool)} :
+    reduced (a :: b :: L) ↔ ¬(a.1 = b.1 ∧ (!a.2) = b.2) ∧ reduced (b :: L) :=
+  List.chain'_cons
+
+@[to_additive]
+theorem not_step_reduced : reduced L₁ → ¬ Step L₁ L₂
+| red, step => by induction step; simp [reduced] at red
+
+@[to_additive]
+theorem not_step_reduced_iff : reduced L₁ ↔ ∀ L₂, ¬ Step L₁ L₂ where
+  mp h _ := not_step_reduced h
+  mpr hL := by
+    induction L₁ with
+    | nil => exact reduced_nil
+    | cons x l ih =>
+      cases l with
+      | nil => exact reduced_singleton
+      | cons y l' =>
+        rw [reduced_cons]
+        constructor
+        · intro ⟨eq1, eq2⟩
+          obtain ⟨x1, x2⟩ := x
+          obtain ⟨y1, y2⟩ := y
+          simp only at eq1 eq2
+          apply hL l'
+          rw [eq1, ← eq2]
+          apply Step.cons_not
+        · apply ih
+          intro L₂ step
+          apply hL (x :: L₂)
+          exact Step.cons step
+
+@[to_additive]
+theorem reduced_infix : reduced L₂ → L₁ <:+: L₂ → reduced L₁ := Chain'.infix
+
+@[to_additive]
+theorem reduced_min (h : reduced L₁) : Red L₁ L₂ ↔ L₂ = L₁ :=
+  Relation.reflTransGen_iff_eq fun _ => not_step_reduced h
+
+@[to_additive]
+theorem reduced_cons_append_chain {x : α × Bool} {L₁ L₂ : List (α × Bool)} (h : L₁ ≠ []) :
+    reduced (x :: L₁) → reduced (L₁ ++ L₂) → reduced (x :: L₁ ++ L₂) := by
+  intro h1 h2
+  induction L₁
+  · contradiction
+  · apply reduced_cons.mp at h1
+    apply reduced_cons.mpr
+    tauto
+
+@[to_additive]
+theorem reduced_append_chain {L₁ L₂ L₃ : List (α × Bool)} (h : L₂ ≠ []) :
+    reduced (L₁ ++ L₂) → reduced (L₂ ++ L₃) → reduced (L₁ ++ L₂ ++ L₃) := by
+  intro h1 h2
+  induction L₁
+  case nil => simp [h2]
+  case cons head tail ih =>
+    refine reduced_cons_append_chain (by simp [h]) h1 (ih (reduced_infix h1 ⟨[head], [], by simp⟩))
+
+@[to_additive]
+def cyclicallyReduced (L : List (α × Bool)) : Prop :=
+  reduced L ∧ ∀ a ∈ L.getLast?, ∀ b ∈ L.head?, ¬(a.1 = b.1 ∧ (!a.2) = b.2)
+
+@[to_additive (attr := simp)]
+theorem cyclicallyReduced_nil : cyclicallyReduced ([] : List (α × Bool)) := by
+  simp [cyclicallyReduced]
+
+@[to_additive (attr := simp)]
+theorem cyclicallyReduced_singleton {x : (α × Bool )} : cyclicallyReduced [x] := by
+  simp [cyclicallyReduced]
+
+@[to_additive]
+theorem cyclicallyReduced_iff : cyclicallyReduced L ↔ reduced L ∧ ∀ a ∈ L.getLast?, ∀ b ∈ L.head?,
+¬(a.1 = b.1 ∧ (!a.2) = b.2) := by rfl
+
+@[to_additive]
+theorem cyclicallyReduced_cons_append {a b : α × Bool} :
+    cyclicallyReduced (b :: L ++ [a]) ↔
+    reduced (b :: L ++ [a]) ∧ ¬(a.1 = b.1 ∧ (!a.2) = b.2) := by
+  rw [cyclicallyReduced_iff,List.getLast?_concat]
+  simp
+
+@[to_additive]
+theorem reduced_of_cyclicallyReduced (L : List (α × Bool)) : cyclicallyReduced L → reduced L :=
+  fun h => h.1
+
+@[to_additive]
+theorem cyclicallyReduced_flatten_replicate (n : ℕ) (L : List (α × Bool))
+    (h : cyclicallyReduced L) : cyclicallyReduced (List.replicate n L).flatten := by match n, L with
+  | 0, _ => simp
+  | n + 1, [] => simp
+  | n + 1, (head::tail) =>
+    unfold cyclicallyReduced at *
+    unfold reduced at *
+    rw [List.chain'_flatten (by simp)]
+    constructor
+    · constructor
+      · simp only [List.mem_replicate, ne_eq, AddLeftCancelMonoid.add_eq_zero, one_ne_zero,
+        and_false, not_false_eq_true, true_and, Bool.not_eq_eq_eq_not, not_and, Bool.not_eq_not,
+        forall_eq] at *
+        apply h.1
+      · apply List.chain'_replicate_of_rel _ h.2
+    · intro a ha b hb
+      simp only [Option.mem_def] at ha hb
+      rw [List.getLast?_flatten_replicate (h := by simp +arith)] at ha
+      rw [List.head?_flatten_replicate (h := by simp +arith)] at hb
+      apply h.2 _ ha _ hb
+
+variable [DecidableEq α]
+
+@[to_additive]
+theorem reduced_iff_eq_reduce : reduced L ↔ reduce L = L := by
+  constructor
+  · intro h
+    rw [← reduced_min h]
+    exact reduce.red
+  · intro h
+    unfold reduced
+    rw [List.chain'_iff_forall_rel_of_append_cons_cons]
+    intro ⟨x₁, x₂⟩ ⟨y₁, y₂⟩ l₁ l₂ hl hx
+    simp only at hl hx
+    rw [hx.1, ← hx.2] at hl
+    nth_rw 2 [hl] at h
+    apply reduce.not h
+
+end Red
+
+variable [DecidableEq α]
+
+@[to_additive]
+theorem reduced_toWord {x : FreeGroup α} : Red.reduced (x.toWord) := by
+  rw [Red.reduced_iff_eq_reduce]
+  simp
+
+@[to_additive]
+def reduceCyclically : List (α × Bool) → List (α × Bool) :=
+  List.bidirectionalRec
+    (nil := [])
+    (singleton := fun x => [x])
+    (cons_append := fun a l b rC => if (b.1 = a.1 ∧ (!b.2) = a.2) then rC else (a :: l ++ [b]))
+
+@[to_additive]
+def reduceCyclicallyConjugator : List (α × Bool) → List (α × Bool) := List.bidirectionalRec
+  (nil := [])
+  (singleton := fun _ => [])
+  (cons_append := fun a _ b rCC => if (b.1 = a.1 ∧ (!b.2) = a.2) then a :: rCC else [] )
+
+@[to_additive (attr := simp)]
+theorem reduceCyclically_nil : reduceCyclically ([] : List (α × Bool)) = [] :=
+  by simp [reduceCyclically]
+
+@[to_additive (attr := simp)]
+theorem reduceCyclically_singleton {a : α × Bool} : reduceCyclically [a] = [a] :=
+  by simp [reduceCyclically]
+
+@[to_additive (attr := simp)]
+theorem reduceCyclicallyConjugator_nil : reduceCyclicallyConjugator ([] : List (α × Bool)) = [] :=
+  by simp [reduceCyclicallyConjugator]
+
+@[to_additive (attr := simp)]
+theorem reduceCyclicallyConjugator_singleton {a : α × Bool} : reduceCyclicallyConjugator [a] = [] :=
+  by simp [reduceCyclicallyConjugator]
+
+@[to_additive]
+theorem reduceCyclically_cons_append {a b : α × Bool} (l : List (α × Bool)) :
+    reduceCyclically (a :: (l ++ [b])) =
+    if (b.1 = a.1 ∧ (!b.2) = a.2) then reduceCyclically l else (a :: l ++ [b]) := by
+  simp [reduceCyclically]
+
+@[to_additive]
+theorem reduceCyclicallyConjugator_cons_append {a b : α × Bool} (l : List (α × Bool)) :
+    reduceCyclicallyConjugator (a :: (l ++ [b])) =
+    if (b.1 = a.1 ∧ (!b.2) = a.2) then a :: reduceCyclicallyConjugator l else [] := by
+  simp [reduceCyclicallyConjugator]
+
+@[to_additive]
+theorem reduceCyclically_conjugation (w : List (α × Bool)) : w = reduceCyclicallyConjugator w ++
+    reduceCyclically w ++ invRev (reduceCyclicallyConjugator w) := by
+  induction w using List.bidirectionalRec
+  case nil => simp
+  case singleton => simp
+  case cons_append a l b eq =>
+    rw [reduceCyclically_cons_append, reduceCyclicallyConjugator_cons_append]
+    split
+    case isTrue h =>
+      nth_rw 1 [eq]
+      simp [invRev, h.1.symm, h.2.symm]
+    case isFalse => simp
+
+@[to_additive]
+theorem reduceCyclically_sound (w : List (α × Bool)) :
+    Red.reduced w → Red.cyclicallyReduced (reduceCyclically w) := by
+  induction w using List.bidirectionalRec
+  case nil => simp
+  case singleton => simp
+  case cons_append a l b ih =>
+    intro h
+    rw [reduceCyclically_cons_append]
+    split
+    case isTrue =>
+      apply ih
+      apply Red.reduced_infix h
+      exists [a], [b]
+    case isFalse h =>
+      rw [Red.cyclicallyReduced_cons_append]
+      trivial
+
+@[to_additive]
+theorem reduced_flatten_replicate (n : ℕ) (hn : n ≠ 0) (L₁ L₂ L₃ : List (α × Bool))
+    (h1 : Red.cyclicallyReduced L₂) (h2 : Red.reduced (L₁ ++ L₂ ++ L₃))
+    : Red.reduced (L₁ ++ (List.replicate n L₂).flatten ++ L₃) := by
+  match n with
+  | 0 => contradiction
+  | n + 1 =>
+    if h : L₂ = [] then simp_all else
+    have h' : (replicate (n + 1) L₂).flatten ≠ [] := by simp [h]
+    apply Red.reduced_append_chain h'
+    · rw [replicate_succ, flatten_cons, ←append_assoc]
+      apply Red.reduced_append_chain h
+      · exact Red.reduced_infix h2 ⟨[], L₃, by simp⟩
+      · rw [←flatten_cons, ←replicate_succ]
+        apply Red.reduced_of_cyclicallyReduced
+        apply Red.cyclicallyReduced_flatten_replicate _ _ h1
+    · rw [replicate_succ', flatten_concat]
+      apply Red.reduced_append_chain h
+      · rw [←flatten_concat, ←replicate_succ']
+        apply Red.reduced_of_cyclicallyReduced
+        apply Red.cyclicallyReduced_flatten_replicate _ _ h1
+      · exact Red.reduced_infix h2 ⟨L₁, [], by simp⟩
+
+@[to_additive]
+theorem reduce_flatten_replicate' (n : ℕ) (L : List (α × Bool)) (h : Red.reduced L) :
+    reduce (List.replicate (n + 1) L).flatten = reduceCyclicallyConjugator L ++ (List.replicate
+    (n + 1) (reduceCyclically L)).flatten ++ invRev (reduceCyclicallyConjugator L) := by
+  induction n
+  case zero =>
+    simpa [←append_assoc, ←reduceCyclically_conjugation, ←Red.reduced_iff_eq_reduce]
+  case succ n ih =>
+    rw [replicate_succ, flatten_cons, reduce_append, ih, Red.reduced_iff_eq_reduce.mp h]
+    nth_rewrite 1 [reduceCyclically_conjugation L]
+    have {L₁ L₂ L₃ L₄ L₅ : List (α × Bool)} : reduce (L₁ ++ L₂ ++ invRev L₃ ++ (L₃ ++ L₄ ++ L₅)) =
+        reduce (L₁ ++ (L₂ ++ L₄) ++ L₅) := by
+      nth_rewrite 1 [append_assoc]
+      nth_rewrite 2 [←append_assoc, ←append_assoc]
+      nth_rewrite 1 [reduce_append]
+      nth_rewrite 3 [reduce_append]
+      nth_rewrite 4 [reduce_append]
+      simp [reduce_invRev_left_cancel, ←reduce_append]
+    rw [this, ←flatten_cons, ←replicate_succ, ←Red.reduced_iff_eq_reduce]
+    apply reduced_flatten_replicate _ (by simp) ..
+    · apply reduceCyclically_sound _ h
+    · rwa [←reduceCyclically_conjugation]
+
+@[to_additive]
+theorem reduce_flatten_replicate {n : ℕ} {L : List (α × Bool)} (hn : n ≠ 0) (h : Red.reduced L) :
+    reduce (List.replicate n L).flatten = reduceCyclicallyConjugator L ++
+    (List.replicate n (reduceCyclically L)).flatten ++ invRev (reduceCyclicallyConjugator L) :=
+  match n with
+  | 0 => by contradiction
+  | n + 1 => reduce_flatten_replicate' n L h
+
+@[to_additive FreeAdditiveGroup.nsmul_right_inj]
+theorem pow_left_inj {x y : FreeGroup α} {n : ℕ} (hn : n ≠ 0) : x ^ n = y ^ n ↔ x = y := by
+  refine ⟨fun heq => ?_, congr_arg (· ^ n)⟩
+
+  have heq2 : x ^ (2 * n) = y ^ (2 * n) := by
+    apply_fun (· ^ 2) at heq
+    rwa [mul_comm, pow_mul, pow_mul]
+  have hn2 : 2 * n ≠ 0 := by simp [hn]
+
+  apply_fun toWord at heq heq2
+  rw [toWord_pow, toWord_pow] at heq heq2
+  rw [reduce_flatten_replicate hn x.reduced_toWord, reduce_flatten_replicate hn y.reduced_toWord]
+    at heq
+  rw [reduce_flatten_replicate hn2 x.reduced_toWord, reduce_flatten_replicate hn2 y.reduced_toWord]
+    at heq2
+
+  have leq := congr_arg List.length heq
+  have leq2 := congr_arg List.length heq2
+  simp [length_append] at leq leq2
+
+  have hm : (reduceCyclically x.toWord).length = (reduceCyclically y.toWord).length := by
+    apply Nat.mul_left_cancel (Nat.ne_zero_iff_zero_lt.mp hn)
+    linarith
+
+  have hc : reduceCyclicallyConjugator x.toWord = reduceCyclicallyConjugator y.toWord := by
+    have : (reduceCyclicallyConjugator x.toWord).length =
+      (reduceCyclicallyConjugator y.toWord).length :=
+      by linarith
+    apply_fun (·.take (reduceCyclicallyConjugator x.toWord).length) at heq
+    rwa [append_assoc, take_left' rfl, this, append_assoc, take_left' rfl] at heq
+
+  have hm : reduceCyclically x.toWord = reduceCyclically y.toWord := by
+    simp [hc] at heq
+    apply_fun (·.take (reduceCyclically x.toWord).length) at heq
+    match n with
+    | 0 => contradiction
+    | n + 1 =>
+      rw [replicate_succ, flatten_cons, take_left' rfl] at heq
+      rwa [replicate_succ, flatten_cons, hm, take_left' rfl] at heq
+
+  have := congr_arg mk <| reduceCyclically_conjugation x.toWord
+  rwa [hc, hm, ←reduceCyclically_conjugation, mk_toWord, mk_toWord] at this
+
+@[to_additive FreeAdditiveGroup.nsmul_right_injective]
+theorem pow_left_injective {n : ℕ} (hn : n ≠ 0) :
+    Function.Injective ((· ^ n) : FreeGroup α → FreeGroup α) := fun _ _ => (pow_left_inj hn).mp
+
+@[to_additive FreeAdditiveGroup.zsmul_right_inj]
+theorem zpow_left_inj {x y : FreeGroup α} {n : ℤ} (hn : n ≠ 0) : x ^ n = y ^ n ↔ x = y := by
+  nth_rw 2 [← pow_left_inj (Int.natAbs_ne_zero.mpr hn)]
+  rcases Int.natAbs_eq n with h | h
+  · rw [h, Int.natAbs_ofNat, zpow_natCast, zpow_natCast]
+  · rw [h, Int.natAbs_neg, Int.natAbs_ofNat, zpow_neg, zpow_neg, inv_inj, zpow_natCast,
+    zpow_natCast]
+
+@[to_additive FreeAdditiveGroup.zsmul_right_injective]
+theorem zpow_left_injective {n : ℤ} (hn : n ≠ 0) :
+    Function.Injective ((· ^ n) : FreeGroup α → FreeGroup α) := fun _ _ => (zpow_left_inj hn).mp
+
+@[to_additive]
+theorem infinite_order (x : FreeGroup α) (hx : x ≠ 1) : ¬IsOfFinOrder x := by
+  rw [isOfFinOrder_iff_pow_eq_one]
+  rintro ⟨n, hn, eq⟩
+  rw [← one_pow n, pow_left_inj (by omega)] at eq
+  exact hx eq
+
+@[to_additive]
+theorem ne_inv_of_ne_one {x : FreeGroup α} (hx : x ≠ 1) : x ≠ x⁻¹ := by
+  apply_fun (fun r => x*r)
+  simp only [mul_inv_cancel, ne_eq]
+  intro eq
+  apply infinite_order x hx
+  rw [isOfFinOrder_iff_pow_eq_one]
+  use 2, (by decide)
+  rw [← eq]
+  exact pow_two x
+
+end FreeGroup

--- a/Mathlib/GroupTheory/FreeGroup/ReducedWords.lean
+++ b/Mathlib/GroupTheory/FreeGroup/ReducedWords.lean
@@ -20,7 +20,7 @@ This file defines some extra lemmas for free groups, in particular about (cyclic
 * `FreeGroup.Red.cyclicallyReduced`: the predicate for cyclically reduced words
 
 ## Main statements
-* `FreeGroup.infinite_order`: : nontrivial elements of a free group have infinite order
+* `FreeGroup.infinite_order`: nontrivial elements of a free group have infinite order
 * `FreeGroup.zpow_left_injective`: taking n-th powers is an injective function on the free group
 
 -/

--- a/Mathlib/GroupTheory/FreeGroup/ReducedWords.lean
+++ b/Mathlib/GroupTheory/FreeGroup/ReducedWords.lean
@@ -34,7 +34,10 @@ variable {L L₁ L₂ : List (α × Bool)}
 
 namespace Red
 
-@[to_additive]
+/-- Predicate asserting that the word `L` admits no reduction steps, i.e., no two neighboring
+  elements of the word cancel. -/
+@[to_additive "Predicate asserting the word `L` admits no reduction steps, i.e., no two neighboring
+elements of the word cancel."]
 def reduced (L : List (α × Bool)) : Prop := List.Chain' (fun a b => ¬(a.1 = b.1 ∧ (!a.2) = b.2)) L
 
 @[to_additive (attr := simp)]
@@ -102,7 +105,12 @@ theorem reduced_append_chain {L₁ L₂ L₃ : List (α × Bool)} (h : L₂ ≠ 
   case cons head tail ih =>
     refine reduced_cons_append_chain (by simp [h]) h1 (ih (reduced_infix h1 ⟨[head], [], by simp⟩))
 
-@[to_additive]
+/-- Predicate asserting that the word `L` is cyclically reduced, i.e., it is reduced and furthermore
+the first and the last letter of the word do not cancel. The empty word is by convention also
+cyclically reduced.-/
+@[to_additive "Predicate asserting that the word `L` is cyclically reduced, i.e., it is reduced and
+furthermore the first and the last letter of the word do not cancel. The empty word is by convention
+also cyclically reduced."]
 def cyclicallyReduced (L : List (α × Bool)) : Prop :=
   reduced L ∧ ∀ a ∈ L.getLast?, ∀ b ∈ L.head?, ¬(a.1 = b.1 ∧ (!a.2) = b.2)
 
@@ -177,14 +185,19 @@ theorem reduced_toWord {x : FreeGroup α} : Red.reduced (x.toWord) := by
   rw [Red.reduced_iff_eq_reduce]
   simp
 
-@[to_additive]
+/-- This function produces a subword of a word `w` by cancelling the first and last letters of `w`
+as long as possible. If `w` is reduced, the resulting word will be cyclically reduced. -/
+@[to_additive "This function produces a subword of a word `w` by cancelling the first and last
+letters of `w` as long as possible. If `w` is reduced, the resulting word will be cyclically
+reduced."]
 def reduceCyclically : List (α × Bool) → List (α × Bool) :=
   List.bidirectionalRec
     (nil := [])
     (singleton := fun x => [x])
     (cons_append := fun a l b rC => if (b.1 = a.1 ∧ (!b.2) = a.2) then rC else (a :: l ++ [b]))
 
-@[to_additive]
+/-- Partner function to `reduceCyclically`. See `reduceCyclically_conjugation`. -/
+@[to_additive "Partner function to `reduceCyclically`. See `reduceCyclically_conjugation`."]
 def reduceCyclicallyConjugator : List (α × Bool) → List (α × Bool) := List.bidirectionalRec
   (nil := [])
   (singleton := fun _ => [])


### PR DESCRIPTION
Upstreamed from the [EquationalTheories](https://github.com/teorth/equational_theories) project.

This PR defines in the new file `Mathlib/GroupTheory/FreeGroup/ReducedWords.lean` some extra lemmas for free groups, in particular about (cyclically) reduced words.

## Main declarations

* `FreeGroup.Red.reduced`: the predicate for reduced words
* `FreeGroup.Red.cyclicallyReduced`: the predicate for cyclically reduced words

## Main statements
* `FreeGroup.infinite_order`: nontrivial elements of a free group have infinite order
* `FreeGroup.zpow_left_injective`: taking n-th powers is an injective function on the free group

Co-authored-by: Amir Livne Bar-on

---

- [x] depends on: #23366
- [x] depends on: #23367
- [ ] depends on: #25966
- [ ] depends on: #27672
- [ ] depends on: #27673

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
