### PR TITLE
WIP: add `mfderiv_prod` and `mfderiv_prodMap`

### DIFF
--- a/Mathlib/Geometry/Manifold/MFDeriv/SpecificFunctions.lean
+++ b/Mathlib/Geometry/Manifold/MFDeriv/SpecificFunctions.lean
@@ -292,6 +292,33 @@ theorem hasMFDerivWithinAt_snd (s : Set (M × M')) (x : M × M') :
       (ContinuousLinearMap.snd 𝕜 (TangentSpace I x.1) (TangentSpace I' x.2)) :=
   (hasMFDerivAt_snd x).hasMFDerivWithinAt
 
+section temp
+
+variable {f₁ : M → N} {f₁' : E →L[𝕜] F} {f₂ : M → N'} {f₂' : E →L[𝕜] F'} {s : Set M} {x : M}
+
+theorem hasMFDerivWithinAt_prod
+    (hf₁ : HasMFDerivWithinAt I J f₁ s x f₁') (hf₂ : HasMFDerivWithinAt I J' f₂ s x f₂') :
+    HasMFDerivWithinAt I (J.prod J') (fun x => (f₁ x, f₂ x)) s x (f₁'.prod f₂') := sorry
+
+-- use the preceding sorry
+theorem hasMFDerivAt_prod
+    (hf₁ : HasMFDerivAt I J f₁ x f₁') (hf₂ : HasMFDerivAt I J' f₂ x f₂') :
+    HasMFDerivAt I (J.prod J') (fun x => (f₁ x, f₂ x)) x (f₁'.prod f₂') := sorry
+
+-- use the preceding sorry
+lemma mfderiv_prod (hf₁ : MDifferentiableAt I J f₁ x) (hf₂ : MDifferentiableAt I J' f₂ x) :
+    mfderiv I (J.prod J') (fun x => (f₁ x, f₂ x)) x
+    = (mfderiv I J f₁ x).prod (mfderiv I J' f₂ x) := sorry
+
+-- should be similar
+lemma mfderiv_prodMap {x' : M'} {f : M → N} {g : M' → N'}
+    (hf : MDifferentiableAt I J f x) (hg : MDifferentiableAt I' J' g x') :
+    mfderiv (I.prod I') (J.prod J') (Prod.map f g) (x, x')
+    = (mfderiv I J f x).prodMap (mfderiv I' J' g x') := sorry
+
+end temp
+
+#exit
 theorem mdifferentiableAt_snd {x : M × M'} : MDifferentiableAt (I.prod I') I' Prod.snd x :=
   (hasMFDerivAt_snd x).mdifferentiableAt
 


### PR DESCRIPTION
Help with these sorries is very welcome!

Part of my bordism theory project: these will be needed for #22059.

---

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
