### PR TITLE
[Merged by Bors] - feat(Algebra/Group/Subgroup, GroupTheory/QuotientGroup): strengthen second isomorphism theorem for groups

### DIFF
--- a/Mathlib/Algebra/Group/Subgroup/Basic.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Basic.lean
@@ -913,16 +913,17 @@ theorem commute_of_normal_of_disjoint (H₁ H₂ : Subgroup G) (hH₁ : H₁.Nor
     apply hH₂.conj_mem _ hy
 
 @[to_additive]
-theorem subgroupOf_normal_of_le_normalizer {H N : Subgroup G}
+theorem normal_subgroupOf_of_le_normalizer {H N : Subgroup G}
     (hLE : H ≤ N.normalizer) : (N.subgroupOf H).Normal := by
   rw [normal_subgroupOf_iff_le_normalizer_inf]
   exact (le_inf hLE H.le_normalizer).trans inf_normalizer_le_normalizer_inf
 
 @[to_additive]
-theorem subgroupOf_sup_normal_of_le_normalizer {H N : Subgroup G}
+theorem normal_subgroupOf_sup_of_le_normalizer {H N : Subgroup G}
     (hLE : H ≤ N.normalizer) : (N.subgroupOf (H ⊔ N)).Normal := by
   rw [normal_subgroupOf_iff_le_normalizer le_sup_right]
   exact sup_le hLE le_normalizer
+
 end SubgroupNormal
 
 end Subgroup

--- a/Mathlib/Algebra/Group/Subgroup/Basic.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Basic.lean
@@ -416,11 +416,11 @@ theorem subset_normalizer_of_normal {S : Set G} [hH : H.Normal] : S ⊆ H.normal
 @[to_additive]
 theorem le_normalizer_of_normal' [hH : H.Normal] : K ≤ H.normalizer := subset_normalizer_of_normal
 
-@[deprecated (since := "2025-03-06")] alias le_normalizer_of_normal
-  := le_normalizer_of_normal_subgroupOf
+@[deprecated (since := "2025-03-06")] alias le_normalizer_of_normal :=
+  le_normalizer_of_normal_subgroupOf
 
-@[deprecated (since := "2025-03-06")] alias _root_.AddSubgroup.le_normalizer_of_normal
-  := AddSubgroup.le_normalizer_of_normal_addSubgroupOf
+@[deprecated (since := "2025-03-06")] alias _root_.AddSubgroup.le_normalizer_of_normal :=
+  AddSubgroup.le_normalizer_of_normal_addSubgroupOf
 
 @[to_additive]
 theorem inf_normalizer_le_normalizer_inf : H.normalizer ⊓ K.normalizer ≤ (H ⊓ K).normalizer :=

--- a/Mathlib/Algebra/Group/Subgroup/Basic.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Basic.lean
@@ -915,17 +915,14 @@ theorem commute_of_normal_of_disjoint (H₁ H₂ : Subgroup G) (hH₁ : H₁.Nor
 @[to_additive]
 theorem subgroupOf_normal_of_le_normalizer {H N : Subgroup G}
     (hLE : H ≤ N.normalizer) : (N.subgroupOf H).Normal := by
-  have : ((H ⊓ N).subgroupOf (H ⊓ N.normalizer)).Normal :=
-    inf_subgroupOf_inf_normal_of_right _ _ _
-  rwa [inf_eq_left.mpr hLE, inf_subgroupOf_left] at this
+  rw [normal_subgroupOf_iff_le_normalizer_inf]
+  exact (le_inf hLE H.le_normalizer).trans inf_normalizer_le_normalizer_inf
 
 @[to_additive]
 theorem subgroupOf_sup_normal_of_le_normalizer {H N : Subgroup G}
     (hLE : H ≤ N.normalizer) : (N.subgroupOf (H ⊔ N)).Normal := by
-  have : (((H ⊔ N) ⊓ N).subgroupOf ((H ⊔ N) ⊓ N.normalizer)).Normal :=
-    inf_subgroupOf_inf_normal_of_right _ _ _
-  rwa [inf_of_le_right (@le_sup_right _ _ H N), inf_of_le_left (sup_le hLE le_normalizer)] at this
-
+  rw [normal_subgroupOf_iff_le_normalizer le_sup_right]
+  exact sup_le hLE le_normalizer
 end SubgroupNormal
 
 end Subgroup

--- a/Mathlib/Algebra/Group/Subgroup/Basic.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Basic.lean
@@ -416,8 +416,11 @@ theorem subset_normalizer_of_normal {S : Set G} [hH : H.Normal] : S ⊆ H.normal
 @[to_additive]
 theorem le_normalizer_of_normal' [hH : H.Normal] : K ≤ H.normalizer := subset_normalizer_of_normal
 
-@[to_additive (attr := deprecated le_normalizer_of_normal_subgroupOf (since := "2025-03-06"))]
-alias le_normalizer_of_normal := le_normalizer_of_normal_subgroupOf
+@[deprecated (since := "2025-03-06")] alias le_normalizer_of_normal
+  := le_normalizer_of_normal_subgroupOf
+
+@[deprecated (since := "2025-03-06")] alias _root_.AddSubgroup.le_normalizer_of_normal
+  := AddSubgroup.le_normalizer_of_normal_addSubgroupOf
 
 @[to_additive]
 theorem inf_normalizer_le_normalizer_inf : H.normalizer ⊓ K.normalizer ≤ (H ⊓ K).normalizer :=

--- a/Mathlib/Algebra/Group/Subgroup/Basic.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Basic.lean
@@ -405,22 +405,12 @@ theorem le_normalizer_of_normal_subgroupOf [hK : (H.subgroupOf K).Normal] (HK : 
     K ≤ H.normalizer :=
   (normal_subgroupOf_iff_le_normalizer HK).mp hK
 
-
 @[to_additive]
 theorem subset_normalizer_of_normal {S : Set G} [hH : H.Normal] : S ⊆ H.normalizer :=
   (@normalizer_eq_top _ _ H hH) ▸ le_top
 
-/- TODO: rename `le_normalizer_of_normal'` to `le_normalizer_of_normal` when the current deprecation
-`le_normalizer_of_normal` -> `le_normalizer_of_normal_subgroupOf` is completed.
--/
 @[to_additive]
-theorem le_normalizer_of_normal' [hH : H.Normal] : K ≤ H.normalizer := subset_normalizer_of_normal
-
-@[deprecated (since := "2025-03-06")] alias le_normalizer_of_normal :=
-  le_normalizer_of_normal_subgroupOf
-
-@[deprecated (since := "2025-03-06")] alias _root_.AddSubgroup.le_normalizer_of_normal :=
-  AddSubgroup.le_normalizer_of_normal_addSubgroupOf
+theorem le_normalizer_of_normal [H.Normal] : K ≤ H.normalizer := subset_normalizer_of_normal
 
 @[to_additive]
 theorem inf_normalizer_le_normalizer_inf : H.normalizer ⊓ K.normalizer ≤ (H ⊓ K).normalizer :=

--- a/Mathlib/Algebra/Group/Subgroup/Basic.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Basic.lean
@@ -913,7 +913,7 @@ theorem commute_of_normal_of_disjoint (H₁ H₂ : Subgroup G) (hH₁ : H₁.Nor
     apply hH₂.conj_mem _ hy
 
 @[to_additive]
-theorem inf_subgroupOf_normal_of_le_normalizer {H N : Subgroup G}
+theorem subgroupOf_normal_of_le_normalizer {H N : Subgroup G}
     (hLE : H ≤ N.normalizer) : (N.subgroupOf H).Normal := by
   have : ((H ⊓ N).subgroupOf (H ⊓ N.normalizer)).Normal :=
     inf_subgroupOf_inf_normal_of_right _ _ _

--- a/Mathlib/Algebra/Group/Subgroup/Basic.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Basic.lean
@@ -401,8 +401,23 @@ instance (priority := 100) normal_in_normalizer : (H.subgroupOf H.normalizer).No
   (normal_subgroupOf_iff_le_normalizer H.le_normalizer).mpr le_rfl
 
 @[to_additive]
-theorem le_normalizer_of_normal [hK : (H.subgroupOf K).Normal] (HK : H ≤ K) : K ≤ H.normalizer :=
+theorem le_normalizer_of_normal_subgroupOf [hK : (H.subgroupOf K).Normal] (HK : H ≤ K) :
+    K ≤ H.normalizer :=
   (normal_subgroupOf_iff_le_normalizer HK).mp hK
+
+
+@[to_additive]
+theorem subset_normalizer_of_normal {S : Set G} [hH : H.Normal] : S ⊆ H.normalizer :=
+  (@normalizer_eq_top _ _ H hH) ▸ le_top
+
+/- TODO: rename `le_normalizer_of_normal'` to `le_normalizer_of_normal` when the current deprecation
+`le_normalizer_of_normal` -> `le_normalizer_of_normal_subgroupOf` is completed.
+-/
+@[to_additive]
+theorem le_normalizer_of_normal' [hH : H.Normal] : K ≤ H.normalizer := subset_normalizer_of_normal
+
+@[to_additive (attr := deprecated le_normalizer_of_normal_subgroupOf (since := "2025-03-06"))]
+alias le_normalizer_of_normal := le_normalizer_of_normal_subgroupOf
 
 @[to_additive]
 theorem inf_normalizer_le_normalizer_inf : H.normalizer ⊓ K.normalizer ≤ (H ⊓ K).normalizer :=
@@ -896,6 +911,20 @@ theorem commute_of_normal_of_disjoint (H₁ H₂ : Subgroup G) (hH₁ : H₁.Nor
   · show x * y * x⁻¹ * y⁻¹ ∈ H₂
     apply H₂.mul_mem _ (H₂.inv_mem hy)
     apply hH₂.conj_mem _ hy
+
+@[to_additive]
+theorem inf_subgroupOf_normal_of_le_normalizer {H N : Subgroup G}
+    (hLE : H ≤ N.normalizer) : (N.subgroupOf H).Normal := by
+  have : ((H ⊓ N).subgroupOf (H ⊓ N.normalizer)).Normal :=
+    inf_subgroupOf_inf_normal_of_right _ _ _
+  rwa [inf_eq_left.mpr hLE, inf_subgroupOf_left] at this
+
+@[to_additive]
+theorem subgroupOf_sup_normal_of_le_normalizer {H N : Subgroup G}
+    (hLE : H ≤ N.normalizer) : (N.subgroupOf (H ⊔ N)).Normal := by
+  have : (((H ⊔ N) ⊓ N).subgroupOf ((H ⊔ N) ⊓ N.normalizer)).Normal :=
+    inf_subgroupOf_inf_normal_of_right _ _ _
+  rwa [inf_of_le_right (@le_sup_right _ _ H N), inf_of_le_left (sup_le hLE le_normalizer)] at this
 
 end SubgroupNormal
 

--- a/Mathlib/Algebra/Group/Subgroup/Defs.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Defs.lean
@@ -679,13 +679,13 @@ theorem mem_normalizer_iff {g : G} : g ∈ H.normalizer ↔ ∀ h, h ∈ H ↔ g
   Iff.rfl
 
 @[to_additive]
+theorem mem_normalizer_iff'' {g : G} : g ∈ H.normalizer ↔ ∀ h : G, h ∈ H ↔ g⁻¹ * h * g ∈ H := by
+  rw [← inv_mem_iff (x := g), mem_normalizer_iff, inv_inv]
+
+@[to_additive]
 theorem mem_normalizer_iff' {g : G} : g ∈ H.normalizer ↔ ∀ n, n * g ∈ H ↔ g * n ∈ H :=
   ⟨fun h n => by rw [h, mul_assoc, mul_inv_cancel_right], fun h n => by
     rw [mul_assoc, ← h, inv_mul_cancel_right]⟩
-
-@[to_additive]
-theorem mem_normalizer_iff'' {g : G} : g ∈ H.normalizer ↔ ∀ h : G, h ∈ H ↔ g⁻¹ * h * g ∈ H := by
-  rw [← inv_mem_iff (x := g), mem_normalizer_iff, inv_inv]
 
 @[to_additive]
 theorem le_normalizer : H ≤ normalizer H := fun x xH n => by

--- a/Mathlib/Algebra/Group/Subgroup/Defs.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Defs.lean
@@ -679,13 +679,13 @@ theorem mem_normalizer_iff {g : G} : g ∈ H.normalizer ↔ ∀ h, h ∈ H ↔ g
   Iff.rfl
 
 @[to_additive]
-theorem mem_normalizer_iff'' {g : G} : g ∈ H.normalizer ↔ ∀ h : G, h ∈ H ↔ g⁻¹ * h * g ∈ H := by
-  rw [← inv_mem_iff (x := g), mem_normalizer_iff, inv_inv]
-
-@[to_additive]
 theorem mem_normalizer_iff' {g : G} : g ∈ H.normalizer ↔ ∀ n, n * g ∈ H ↔ g * n ∈ H :=
   ⟨fun h n => by rw [h, mul_assoc, mul_inv_cancel_right], fun h n => by
     rw [mul_assoc, ← h, inv_mul_cancel_right]⟩
+
+@[to_additive]
+theorem mem_normalizer_iff'' {g : G} : g ∈ H.normalizer ↔ ∀ h : G, h ∈ H ↔ g⁻¹ * h * g ∈ H := by
+  rw [← inv_mem_iff (x := g), mem_normalizer_iff, inv_inv]
 
 @[to_additive]
 theorem le_normalizer : H ≤ normalizer H := fun x xH n => by

--- a/Mathlib/Algebra/Group/Subgroup/Pointwise.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Pointwise.lean
@@ -265,7 +265,7 @@ theorem coe_mul_of_left_le_normalizer_right (H N : Subgroup G) (hLE : H ≤ N.no
 when `H` is a subgroup of the normalizer of `N` in `G`."]
 theorem coe_mul_of_right_le_normalizer_left (N H : Subgroup G) (hLE : H ≤ N.normalizer) :
     (↑(N ⊔ H) : Set G) = N * H := by
-  rw [← set_mul_normalizer_comm _ _ hLE, sup_comm, mul_le_normalizer _ _ hLE]
+  rw [← set_mul_normalizer_comm _ _ hLE, sup_comm, coe_mul_of_left_le_normalizer_right _ _ hLE]
 
 /-- The carrier of `H ⊔ N` is just `↑H * ↑N` (pointwise set product) when `N` is normal. -/
 @[to_additive "The carrier of `H ⊔ N` is just `↑H + ↑N` (pointwise set addition)

--- a/Mathlib/Algebra/Group/Subgroup/Pointwise.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Pointwise.lean
@@ -226,15 +226,23 @@ theorem sup_eq_closure_mul (H K : Subgroup G) : H ⊔ K = closure ((H : Set G) *
     ((closure_mul_le _ _).trans <| by rw [closure_eq, closure_eq])
 
 @[to_additive]
-theorem set_mul_normal_comm (s : Set G) (N : Subgroup G) [hN : N.Normal] :
-    s * (N : Set G) = (N : Set G) * s := by
+theorem set_mul_normalizer_comm (S : Set G) (N : Subgroup G) (hLE : S ⊆ N.normalizer) :
+    S * N = N * S := by
   rw [← iUnion_mul_left_image, ← iUnion_mul_right_image]
-  simp only [image_mul_left, image_mul_right, Set.preimage, SetLike.mem_coe, hN.mem_comm_iff]
+  simp only [image_mul_left, image_mul_right, Set.preimage]
+  congr! 5 with s hs x
+  exact (mem_normalizer_iff'.mp (inv_mem (hLE hs)) x).symm
 
-/-- The carrier of `H ⊔ N` is just `↑H * ↑N` (pointwise set product) when `N` is normal. -/
+@[to_additive]
+theorem set_mul_normal_comm (S : Set G) (N : Subgroup G) [hN : N.Normal] :
+    S * (N : Set G) = (N : Set G) * S := set_mul_normalizer_comm S N subset_normalizer_of_normal
+
+/-- The carrier of `H ⊔ N` is just `↑H * ↑N` (pointwise set product)
+when `H` is a subgroup of the normalizer of `N` in `G`. -/
 @[to_additive "The carrier of `H ⊔ N` is just `↑H + ↑N` (pointwise set addition)
-when `N` is normal."]
-theorem mul_normal (H N : Subgroup G) [hN : N.Normal] : (↑(H ⊔ N) : Set G) = H * N := by
+when `H` is a subgroup of the normalizer of `N` in `G`."]
+theorem mul_le_normalizer (H N : Subgroup G) (hLE : H ≤ N.normalizer) :
+    (↑(H ⊔ N) : Set G) = H * N := by
   rw [sup_eq_closure_mul]
   refine Set.Subset.antisymm (fun x hx => ?_) subset_closure
   induction hx using closure_induction'' with
@@ -243,19 +251,33 @@ theorem mul_normal (H N : Subgroup G) [hN : N.Normal] : (↑(H ⊔ N) : Set G) =
   | inv_mem x hx =>
     obtain ⟨x, hx, y, hy, rfl⟩ := hx
     simpa only [mul_inv_rev, mul_assoc, inv_inv, inv_mul_cancel_left]
-      using mul_mem_mul (inv_mem hx) (hN.conj_mem _ (inv_mem hy) x)
+      using mul_mem_mul (inv_mem hx) ((mem_normalizer_iff.mp (hLE hx) y⁻¹).mp (inv_mem hy))
   | mul x' x' _ _ hx hx' =>
     obtain ⟨x, hx, y, hy, rfl⟩ := hx
     obtain ⟨x', hx', y', hy', rfl⟩ := hx'
     refine ⟨x * x', mul_mem hx hx', x'⁻¹ * y * x' * y', mul_mem ?_ hy', ?_⟩
-    · simpa using hN.conj_mem _ hy x'⁻¹
+    · exact (mem_normalizer_iff''.mp (hLE hx') y).mp hy
     · simp only [mul_assoc, mul_inv_cancel_left]
+
+/-- The carrier of `N ⊔ H` is just `↑N * ↑H` (pointwise set product) when
+`H` is a subgroup of the normalizer of `N` in `G`. -/
+@[to_additive "The carrier of `N ⊔ H` is just `↑N + ↑H` (pointwise set addition)
+when `H` is a subgroup of the normalizer of `N` in `G`."]
+theorem le_normalizer_mul (N H : Subgroup G) (hLE : H ≤ N.normalizer) :
+    (↑(N ⊔ H) : Set G) = N * H := by
+  rw [← set_mul_normalizer_comm _ _ hLE, sup_comm, mul_le_normalizer _ _ hLE]
+
+/-- The carrier of `H ⊔ N` is just `↑H * ↑N` (pointwise set product) when `N` is normal. -/
+@[to_additive "The carrier of `H ⊔ N` is just `↑H + ↑N` (pointwise set addition)
+when `N` is normal."]
+theorem mul_normal (H N : Subgroup G) [hN : N.Normal] : (↑(H ⊔ N) : Set G) = H * N :=
+  mul_le_normalizer H N le_normalizer_of_normal'
 
 /-- The carrier of `N ⊔ H` is just `↑N * ↑H` (pointwise set product) when `N` is normal. -/
 @[to_additive "The carrier of `N ⊔ H` is just `↑N + ↑H` (pointwise set addition)
 when `N` is normal."]
-theorem normal_mul (N H : Subgroup G) [N.Normal] : (↑(N ⊔ H) : Set G) = N * H := by
-  rw [← set_mul_normal_comm, sup_comm, mul_normal]
+theorem normal_mul (N H : Subgroup G) [N.Normal] : (↑(N ⊔ H) : Set G) = N * H :=
+  le_normalizer_mul N H le_normalizer_of_normal'
 
 @[to_additive]
 theorem mul_inf_assoc (A B C : Subgroup G) (h : A ≤ C) :

--- a/Mathlib/Algebra/Group/Subgroup/Pointwise.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Pointwise.lean
@@ -277,7 +277,7 @@ theorem mul_normal (H N : Subgroup G) [hN : N.Normal] : (↑(H ⊔ N) : Set G) =
 @[to_additive "The carrier of `N ⊔ H` is just `↑N + ↑H` (pointwise set addition)
 when `N` is normal."]
 theorem normal_mul (N H : Subgroup G) [N.Normal] : (↑(N ⊔ H) : Set G) = N * H :=
-  le_normalizer_mul N H le_normalizer_of_normal
+  coe_mul_of_right_le_normalizer_left N H le_normalizer_of_normal
 
 @[to_additive]
 theorem mul_inf_assoc (A B C : Subgroup G) (h : A ≤ C) :

--- a/Mathlib/Algebra/Group/Subgroup/Pointwise.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Pointwise.lean
@@ -271,7 +271,7 @@ theorem coe_mul_of_right_le_normalizer_left (N H : Subgroup G) (hLE : H ≤ N.no
 @[to_additive "The carrier of `H ⊔ N` is just `↑H + ↑N` (pointwise set addition)
 when `N` is normal."]
 theorem mul_normal (H N : Subgroup G) [hN : N.Normal] : (↑(H ⊔ N) : Set G) = H * N :=
-  mul_le_normalizer H N le_normalizer_of_normal
+  coe_mul_of_left_le_normalizer_right H N le_normalizer_of_normal
 
 /-- The carrier of `N ⊔ H` is just `↑N * ↑H` (pointwise set product) when `N` is normal. -/
 @[to_additive "The carrier of `N ⊔ H` is just `↑N + ↑H` (pointwise set addition)

--- a/Mathlib/Algebra/Group/Subgroup/Pointwise.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Pointwise.lean
@@ -271,13 +271,13 @@ theorem le_normalizer_mul (N H : Subgroup G) (hLE : H ≤ N.normalizer) :
 @[to_additive "The carrier of `H ⊔ N` is just `↑H + ↑N` (pointwise set addition)
 when `N` is normal."]
 theorem mul_normal (H N : Subgroup G) [hN : N.Normal] : (↑(H ⊔ N) : Set G) = H * N :=
-  mul_le_normalizer H N le_normalizer_of_normal'
+  mul_le_normalizer H N le_normalizer_of_normal
 
 /-- The carrier of `N ⊔ H` is just `↑N * ↑H` (pointwise set product) when `N` is normal. -/
 @[to_additive "The carrier of `N ⊔ H` is just `↑N + ↑H` (pointwise set addition)
 when `N` is normal."]
 theorem normal_mul (N H : Subgroup G) [N.Normal] : (↑(N ⊔ H) : Set G) = N * H :=
-  le_normalizer_mul N H le_normalizer_of_normal'
+  le_normalizer_mul N H le_normalizer_of_normal
 
 @[to_additive]
 theorem mul_inf_assoc (A B C : Subgroup G) (h : A ≤ C) :

--- a/Mathlib/Algebra/Group/Subgroup/Pointwise.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Pointwise.lean
@@ -241,7 +241,7 @@ theorem set_mul_normal_comm (S : Set G) (N : Subgroup G) [hN : N.Normal] :
 when `H` is a subgroup of the normalizer of `N` in `G`. -/
 @[to_additive "The carrier of `H ⊔ N` is just `↑H + ↑N` (pointwise set addition)
 when `H` is a subgroup of the normalizer of `N` in `G`."]
-theorem mul_le_normalizer (H N : Subgroup G) (hLE : H ≤ N.normalizer) :
+theorem coe_mul_of_left_le_normalizer_right (H N : Subgroup G) (hLE : H ≤ N.normalizer) :
     (↑(H ⊔ N) : Set G) = H * N := by
   rw [sup_eq_closure_mul]
   refine Set.Subset.antisymm (fun x hx => ?_) subset_closure
@@ -263,7 +263,7 @@ theorem mul_le_normalizer (H N : Subgroup G) (hLE : H ≤ N.normalizer) :
 `H` is a subgroup of the normalizer of `N` in `G`. -/
 @[to_additive "The carrier of `N ⊔ H` is just `↑N + ↑H` (pointwise set addition)
 when `H` is a subgroup of the normalizer of `N` in `G`."]
-theorem le_normalizer_mul (N H : Subgroup G) (hLE : H ≤ N.normalizer) :
+theorem coe_mul_of_right_le_normalizer_left (N H : Subgroup G) (hLE : H ≤ N.normalizer) :
     (↑(N ⊔ H) : Set G) = N * H := by
   rw [← set_mul_normalizer_comm _ _ hLE, sup_comm, mul_le_normalizer _ _ hLE]
 

--- a/Mathlib/GroupTheory/QuotientGroup/Basic.lean
+++ b/Mathlib/GroupTheory/QuotientGroup/Basic.lean
@@ -293,7 +293,7 @@ where `N` is normal, defines an isomorphism between `H/(H ∩ N)` and `(HN)/N`. 
 @[to_additive "Noether's second isomorphism theorem: given two subgroups `H` and `N` of a group `G`,
 where `N` is normal, defines an isomorphism between `H/(H ∩ N)` and `(H + N)/N`"]
 noncomputable def quotientInfEquivProdNormalQuotient (H N : Subgroup G) [hN : N.Normal] :
-    H ⧸ N.subgroupOf H ≃* _ ⧸ N.subgroupOf (H ⊔ N) :=
+    H ⧸ N.subgroupOf H ≃* (H ⊔ N : Subgroup G) ⧸ N.subgroupOf (H ⊔ N) :=
   quotientInfEquivProdNormalizerQuotient H N le_normalizer_of_normal'
 
 end SndIsomorphismThm

--- a/Mathlib/GroupTheory/QuotientGroup/Basic.lean
+++ b/Mathlib/GroupTheory/QuotientGroup/Basic.lean
@@ -260,11 +260,11 @@ subgroup `H` of the normalizer of `N` in `G`,
 defines an isomorphism between `H/(H ∩ N)` and `(H + N)/N`"]
 noncomputable def quotientInfEquivProdNormalizerQuotient (H N : Subgroup G)
     (hLE : H ≤ N.normalizer) :
-    letI := Subgroup.subgroupOf_normal_of_le_normalizer hLE
-    letI := Subgroup.subgroupOf_sup_normal_of_le_normalizer hLE
+    letI := Subgroup.normal_subgroupOf_of_le_normalizer hLE
+    letI := Subgroup.normal_subgroupOf_sup_of_le_normalizer hLE
     H ⧸ N.subgroupOf H ≃* (H ⊔ N : Subgroup G) ⧸ N.subgroupOf (H ⊔ N) :=
-  letI := Subgroup.subgroupOf_normal_of_le_normalizer hLE
-  letI := Subgroup.subgroupOf_sup_normal_of_le_normalizer hLE
+  letI := Subgroup.normal_subgroupOf_of_le_normalizer hLE
+  letI := Subgroup.normal_subgroupOf_sup_of_le_normalizer hLE
   let
     φ :-- φ is the natural homomorphism H →* (HN)/N.
       H →*

--- a/Mathlib/GroupTheory/QuotientGroup/Basic.lean
+++ b/Mathlib/GroupTheory/QuotientGroup/Basic.lean
@@ -260,10 +260,10 @@ subgroup `H` of the normalizer of `N` in `G`,
 defines an isomorphism between `H/(H ∩ N)` and `(H + N)/N`"]
 noncomputable def quotientInfEquivProdNormalizerQuotient (H N : Subgroup G)
     (hLE : H ≤ N.normalizer) :
-    letI := Subgroup.inf_subgroupOf_normal_of_le_normalizer hLE
+    letI := Subgroup.subgroupOf_normal_of_le_normalizer hLE
     letI := Subgroup.subgroupOf_sup_normal_of_le_normalizer hLE
     H ⧸ N.subgroupOf H ≃* (H ⊔ N : Subgroup G) ⧸ N.subgroupOf (H ⊔ N) :=
-  letI := Subgroup.inf_subgroupOf_normal_of_le_normalizer hLE
+  letI := Subgroup.subgroupOf_normal_of_le_normalizer hLE
   letI := Subgroup.subgroupOf_sup_normal_of_le_normalizer hLE
   let
     φ :-- φ is the natural homomorphism H →* (HN)/N.

--- a/Mathlib/GroupTheory/QuotientGroup/Basic.lean
+++ b/Mathlib/GroupTheory/QuotientGroup/Basic.lean
@@ -294,7 +294,7 @@ where `N` is normal, defines an isomorphism between `H/(H ∩ N)` and `(HN)/N`. 
 where `N` is normal, defines an isomorphism between `H/(H ∩ N)` and `(H + N)/N`"]
 noncomputable def quotientInfEquivProdNormalQuotient (H N : Subgroup G) [hN : N.Normal] :
     H ⧸ N.subgroupOf H ≃* (H ⊔ N : Subgroup G) ⧸ N.subgroupOf (H ⊔ N) :=
-  quotientInfEquivProdNormalizerQuotient H N le_normalizer_of_normal'
+  quotientInfEquivProdNormalizerQuotient H N le_normalizer_of_normal
 
 end SndIsomorphismThm
 

--- a/Mathlib/GroupTheory/QuotientGroup/Basic.lean
+++ b/Mathlib/GroupTheory/QuotientGroup/Basic.lean
@@ -274,7 +274,7 @@ noncomputable def quotientInfEquivProdNormalizerQuotient (H N : Subgroup G)
     x.inductionOn' <| by
       rintro ⟨y, hy : y ∈ (H ⊔ N)⟩
       rw [← SetLike.mem_coe] at hy
-      rw [mul_le_normalizer H N hLE] at hy
+      rw [coe_mul_of_left_le_normalizer_right H N hLE] at hy
       rcases hy with ⟨h, hh, n, hn, rfl⟩
       use ⟨h, hh⟩
       let _ : Setoid ↑(H ⊔ N) :=

--- a/Mathlib/GroupTheory/QuotientGroup/Basic.lean
+++ b/Mathlib/GroupTheory/QuotientGroup/Basic.lean
@@ -22,9 +22,9 @@ proves Noether's first and second isomorphism theorems.
 
 * `QuotientGroup.quotientKerEquivRange`: Noether's first isomorphism theorem, an explicit
   isomorphism `G/ker φ → range φ` for every group homomorphism `φ : G →* H`.
-* `QuotientGroup.quotientInfEquivProdNormalQuotient`: Noether's second isomorphism theorem, an
-  explicit isomorphism between `H/(H ∩ N)` and `(HN)/N` given a subgroup `H` and a normal subgroup
-  `N` of a group `G`.
+* `QuotientGroup.quotientInfEquivProdNormalizerQuotient`: Noether's second isomorphism
+  theorem, an explicit isomorphism between `H/(H ∩ N)` and `(HN)/N` given a subgroup `H`
+  that lies in the normalizer `N_G(N)` of a subgroup `N` of a group `G`.
 * `QuotientGroup.quotientQuotientEquivQuotient`: Noether's third isomorphism theorem,
   the canonical isomorphism between `(G / N) / (M / N)` and `G / M`, where `N ≤ M`.
 * `QuotientGroup.comapMk'OrderIso`: The correspondence theorem, a lattice
@@ -252,12 +252,19 @@ section SndIsomorphismThm
 
 open Subgroup
 
-/-- **Noether's second isomorphism theorem**: given two subgroups `H` and `N` of a group `G`, where
-`N` is normal, defines an isomorphism between `H/(H ∩ N)` and `(HN)/N`. -/
-@[to_additive "The second isomorphism theorem: given two subgroups `H` and `N` of a group `G`, where
-`N` is normal, defines an isomorphism between `H/(H ∩ N)` and `(H + N)/N`"]
-noncomputable def quotientInfEquivProdNormalQuotient (H N : Subgroup G) [N.Normal] :
-    H ⧸ N.subgroupOf H ≃* _ ⧸ N.subgroupOf (H ⊔ N) :=
+/-- **Noether's second isomorphism theorem**: given a subgroup `N` of `G` and a
+subgroup `H` of the normalizer of `N` in `G`,
+defines an isomorphism between `H/(H ∩ N)` and `(HN)/N`. -/
+@[to_additive "Noether's second isomorphism theorem: given a subgroup `N` of `G` and a
+subgroup `H` of the normalizer of `N` in `G`,
+defines an isomorphism between `H/(H ∩ N)` and `(H + N)/N`"]
+noncomputable def quotientInfEquivProdNormalizerQuotient (H N : Subgroup G)
+    (hLE : H ≤ N.normalizer) :
+    letI := Subgroup.inf_subgroupOf_normal_of_le_normalizer hLE
+    letI := Subgroup.subgroupOf_sup_normal_of_le_normalizer hLE
+    H ⧸ N.subgroupOf H ≃* (H ⊔ N : Subgroup G) ⧸ N.subgroupOf (H ⊔ N) :=
+  letI := Subgroup.inf_subgroupOf_normal_of_le_normalizer hLE
+  letI := Subgroup.subgroupOf_sup_normal_of_le_normalizer hLE
   let
     φ :-- φ is the natural homomorphism H →* (HN)/N.
       H →*
@@ -267,7 +274,7 @@ noncomputable def quotientInfEquivProdNormalQuotient (H N : Subgroup G) [N.Norma
     x.inductionOn' <| by
       rintro ⟨y, hy : y ∈ (H ⊔ N)⟩
       rw [← SetLike.mem_coe] at hy
-      rw [mul_normal H N] at hy
+      rw [mul_le_normalizer H N hLE] at hy
       rcases hy with ⟨h, hh, n, hn, rfl⟩
       use ⟨h, hh⟩
       let _ : Setoid ↑(H ⊔ N) :=
@@ -280,6 +287,14 @@ noncomputable def quotientInfEquivProdNormalQuotient (H N : Subgroup G) [N.Norma
       rwa [← mul_assoc, inv_mul_cancel, one_mul]
   (quotientMulEquivOfEq (by simp [φ, ← comap_ker])).trans
     (quotientKerEquivOfSurjective φ φ_surjective)
+
+/-- **Noether's second isomorphism theorem**: given two subgroups `H` and `N` of a group `G`,
+where `N` is normal, defines an isomorphism between `H/(H ∩ N)` and `(HN)/N`. -/
+@[to_additive "Noether's second isomorphism theorem: given two subgroups `H` and `N` of a group `G`,
+where `N` is normal, defines an isomorphism between `H/(H ∩ N)` and `(H + N)/N`"]
+noncomputable def quotientInfEquivProdNormalQuotient (H N : Subgroup G) [hN : N.Normal] :
+    H ⧸ N.subgroupOf H ≃* _ ⧸ N.subgroupOf (H ⊔ N) :=
+  quotientInfEquivProdNormalizerQuotient H N le_normalizer_of_normal'
 
 end SndIsomorphismThm
 


### PR DESCRIPTION
The stronger statement is necessary when we wish that `H` and `H ⊔ N` in the statement `_ ⧸ N.subgroupOf H ≃* _ ⧸ N.subgroupOf (H ⊔ N)` may need to be of a type larger than whichever subgroup `H` is normal in. Furthermore, this commit adapts some basic results about Normal subgroups to be wrt subgroups of normalizers instead.

Moves:
- Subgroup.le_normalizer_of_normal -> Subgroup.le_normalizer_of_normal_subgroupOf

---

The primary reason for introducing this variation is that the existing formulation becomes a pain when quotienting subnormal groups. So suppose my ambient group is `G` and my normalizer is `T : Subgroup G`, the result I can get from the existing formulation is something like `_ ⧸ (N : T).subgroupOf (H : T) ≃* _ ⧸ (N : T).subgroupOf (H ⊔ N : T)`, and it is difficult or tedious to recover the desired statement `_ ⧸ N.subgroupOf H ≃* _ ⧸ N.subgroupOf (H ⊔ N)` from it.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
