### PR TITLE
[Merged by Bors] - feat(CategoryTheory/WithTerminal): opposite categories of `WithTerminal C` and `WithInitial C`

### DIFF
--- a/Mathlib/CategoryTheory/WithTerminal.lean
+++ b/Mathlib/CategoryTheory/WithTerminal.lean
@@ -665,7 +665,7 @@ end WithInitial
 open Opposite in
 /-- The opposite category of `WithTerminal C` is equivalent to `WithInitial Cᵒᵖ`. -/
 @[simps!]
-def WithTerminal.OpEquiv : (WithTerminal C)ᵒᵖ ≌ WithInitial Cᵒᵖ where
+def WithTerminal.opEquiv : (WithTerminal C)ᵒᵖ ≌ WithInitial Cᵒᵖ where
   functor :=
     { obj := fun ⟨x⟩ ↦ match x with
       | of x => .of <| op x
@@ -727,7 +727,7 @@ def WithTerminal.OpEquiv : (WithTerminal C)ᵒᵖ ≌ WithInitial Cᵒᵖ where
 open Opposite in
 /-- The opposite category of `WithInitial C` is equivalent to `WithTerminal Cᵒᵖ`. -/
 @[simps!]
-def WithInitial.OpEquiv : (WithInitial C)ᵒᵖ ≌ WithTerminal Cᵒᵖ where
+def WithInitial.opEquiv : (WithInitial C)ᵒᵖ ≌ WithTerminal Cᵒᵖ where
   functor :=
     { obj := fun ⟨x⟩ ↦
         match x with

--- a/Mathlib/CategoryTheory/WithTerminal.lean
+++ b/Mathlib/CategoryTheory/WithTerminal.lean
@@ -662,4 +662,129 @@ instance isIso_of_to_star {X : WithInitial C} (f : X ⟶ star) : IsIso f :=
 
 end WithInitial
 
+open Opposite in
+/-- The opposite category of `WithTerminal C` is equivalent to `WithInitial Cᵒᵖ`. -/
+@[simps!]
+def WithTerminal.OpEquiv : (WithTerminal C)ᵒᵖ ≌ WithInitial Cᵒᵖ where
+  functor :=
+    { obj := fun ⟨x⟩ ↦ match x with
+      | of x => .of <| op x
+      | star => .star
+      map := fun {x y} ⟨f⟩ ↦
+        match x, y, f with
+        | op (of x), op (of y), f => (WithTerminal.down f).op
+        | op star, op (of _), _ => WithInitial.starInitial.to _
+        | op star, op star, _  => 𝟙 _
+      map_id := fun ⟨x⟩ ↦ by cases x <;> rfl
+      map_comp := fun {x y z} ⟨f⟩ ⟨g⟩ ↦
+        match x, y, z, f, g with
+        | op (of x), op (of y), op (of z), f, g => rfl
+        | _, op (of y), op star, f, g => (g : PEmpty).elim
+        | op (of x), op star, _, f, _ => (f : PEmpty).elim
+        | op star, _, _, f, g => rfl }
+  inverse :=
+    { obj := fun x ↦
+      match x with
+        | .of x => op <| .of <| x.unop
+        | .star => op .star
+      map := fun {x y} f ↦
+        match x, y, f with
+        | .of (op x), .of (op y), f => WithInitial.down f
+        | .star, .of (op _), _ => op <| WithTerminal.starTerminal.from _
+        | .star, .star, _  => 𝟙 _
+      map_id := fun x ↦ by cases x <;> rfl
+      map_comp := fun {x y z} f g ↦
+        match x, y, z, f, g with
+        | .of (op x), .of (op y), .of (op z), f, g => rfl
+        | _, .of (op y), .star, f, g => (g : PEmpty).elim
+        | .of (op x), .star, _, f, _ => (f : PEmpty).elim
+        | .star, _, _, f, g => by subsingleton }
+  unitIso :=
+    NatIso.ofComponents
+      (fun ⟨x⟩ ↦ match x with
+        | .of x => Iso.refl _
+        | .star => Iso.refl _)
+      (fun {x y} ⟨f⟩ ↦ match x, y, f with
+        | op (of x), op (of y), f => by
+            simp only [Functor.id_obj, op_unop, Functor.comp_obj,
+              Functor.id_map, Iso.refl_hom, Category.comp_id, Functor.comp_map, Category.id_comp]
+            rfl
+        | op star, op (of _), _ => rfl
+        | op star, op star, _  => rfl)
+  counitIso :=
+    NatIso.ofComponents
+      (fun x ↦ match x with
+        | .of x => Iso.refl _
+        | .star => Iso.refl _)
+  functor_unitIso_comp := fun ⟨x⟩ ↦
+    match x with
+    | .of x => by
+        simp only [op_unop, Functor.id_obj, Functor.comp_obj, NatIso.ofComponents_hom_app,
+          Iso.refl_hom, Category.comp_id]
+        rfl
+    | .star => rfl
+
+open Opposite in
+/-- The opposite category of `WithInitial C` is equivalent to `WithTerminal Cᵒᵖ`. -/
+@[simps!]
+def WithInitial.OpEquiv : (WithInitial C)ᵒᵖ ≌ WithTerminal Cᵒᵖ where
+  functor :=
+    { obj := fun ⟨x⟩ ↦
+        match x with
+        | of x => .of <| op x
+        | star => .star
+      map := fun {x y} ⟨f⟩ ↦
+        match x, y, f with
+        | op (of x), op (of y), f => (WithTerminal.down f).op
+        | op (of _), op star, _ => WithTerminal.starTerminal.from _
+        | op star, op star, _  => 𝟙 _
+      map_id := fun ⟨x⟩ ↦ by cases x <;> rfl
+      map_comp := fun {x y z} ⟨f⟩ ⟨g⟩ ↦
+        match x, y, z, f, g with
+        | op (of x), op (of y), op (of z), f, g => rfl
+        | _, op star, op (of y), f, g => (g : PEmpty).elim
+        | op star, op (of x), _, f, _ => (f : PEmpty).elim
+        | _, _, op star, f, g => by subsingleton }
+  inverse :=
+    { obj := fun x ↦
+        match x with
+        | .of x => op <| .of <| x.unop
+        | .star => op .star
+      map := fun {x y} f ↦
+        match x, y, f with
+        | .of (op x), .of (op y), f => WithInitial.down f
+        | .of (op _), .star, _ => op <| WithInitial.starInitial.to _
+        | .star, .star, _  => 𝟙 _
+      map_id := fun x ↦ by cases x <;> rfl
+      map_comp := fun {x y z} f g ↦
+        match x, y, z, f, g with
+        | .of (op x), .of (op y), .of (op z), f, g => rfl
+        | _, .star, .of (op y), f, g => (g : PEmpty).elim
+        | .star, .of (op x), _, f, _ => (f : PEmpty).elim
+        | _, _, .star, f, g => by rfl }
+  unitIso :=
+    NatIso.ofComponents
+      (fun ⟨x⟩ ↦ match x with
+        | .of x => Iso.refl _
+        | .star => Iso.refl _)
+      (fun {x y} f ↦ match x, y, f with
+        | op (of x), op (of y), f => by
+            simp only [Functor.id_obj, op_unop, Functor.comp_obj,
+              Functor.id_map, Iso.refl_hom, Category.comp_id, Functor.comp_map, Category.id_comp]
+            rfl
+        | op (of _), op star, _ => rfl
+        | _, op star, _ => rfl)
+  counitIso :=
+    NatIso.ofComponents
+      (fun x ↦ match x with
+        | .of x => Iso.refl _
+        | .star => Iso.refl _)
+  functor_unitIso_comp := fun ⟨x⟩ ↦
+    match x with
+    | .of x => by
+        simp only [op_unop, Functor.id_obj, Functor.comp_obj, NatIso.ofComponents_hom_app,
+          Iso.refl_hom, Category.comp_id]
+        rfl
+    | .star => rfl
+
 end CategoryTheory


### PR DESCRIPTION
We record the fact that there are equivalences of categories `(WithTerminal C)ᵒᵖ ≌ WithInitial Cᵒᵖ` and `(WithInitial C)ᵒᵖ ≌ WithTerminal Cᵒᵖ`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
