### PR TITLE
[Merged by Bors] - chore(CategoryTheory/WithTerminal): `WithTerminal` has a terminal object

### DIFF
--- a/Mathlib/CategoryTheory/WithTerminal.lean
+++ b/Mathlib/CategoryTheory/WithTerminal.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Joseph Tooby-Smith, Adam Topaz
 -/
 import Mathlib.CategoryTheory.Limits.Shapes.IsTerminal
+import Mathlib.CategoryTheory.Limits.Shapes.Terminal
 import Mathlib.CategoryTheory.Bicategory.Functor.Pseudofunctor
 
 /-!
@@ -273,6 +274,13 @@ instance {X : WithTerminal C} : Unique (X ⟶ star) where
 /-- `WithTerminal.star` is terminal. -/
 def starTerminal : Limits.IsTerminal (star : WithTerminal C) :=
   Limits.IsTerminal.ofUnique _
+
+instance : Limits.HasTerminal (WithTerminal C) := Limits.hasTerminal_of_unique star
+
+/-- The isomorphism between star and an abstract terminal object of `WithTerminal C` -/
+@[simps!]
+noncomputable def starIsoTerminal : star ≅ ⊤_ (WithTerminal C) :=
+    starTerminal.uniqueUpToIso (Limits.terminalIsTerminal)
 
 /-- Lift a functor `F : C ⥤ D` to `WithTerminal C ⥤ D`. -/
 @[simps]
@@ -570,6 +578,13 @@ instance {X : WithInitial C} : Unique (star ⟶ X) where
 /-- `WithInitial.star` is initial. -/
 def starInitial : Limits.IsInitial (star : WithInitial C) :=
   Limits.IsInitial.ofUnique _
+
+instance : Limits.HasInitial (WithInitial C) := Limits.hasInitial_of_unique star
+
+/-- The isomorphism between star and an abstract terminal object of `WithTerminal C` -/
+@[simps!]
+noncomputable def starIsoInitial : star ≅ ⊥_ (WithInitial C) :=
+    starInitial.uniqueUpToIso (Limits.initialIsInitial)
 
 /-- Lift a functor `F : C ⥤ D` to `WithInitial C ⥤ D`. -/
 @[simps]

--- a/Mathlib/CategoryTheory/WithTerminal.lean
+++ b/Mathlib/CategoryTheory/WithTerminal.lean
@@ -581,7 +581,7 @@ def starInitial : Limits.IsInitial (star : WithInitial C) :=
 
 instance : Limits.HasInitial (WithInitial C) := Limits.hasInitial_of_unique star
 
-/-- The isomorphism between star and an abstract terminal object of `WithTerminal C` -/
+/-- The isomorphism between star and an abstract initial object of `WithInitial C` -/
 @[simps!]
 noncomputable def starIsoInitial : star ≅ ⊥_ (WithInitial C) :=
     starInitial.uniqueUpToIso (Limits.initialIsInitial)


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

Somehow, no `HasTerminal` instance was present on `WithTerminal C`, which feels wrong. This comes at the cost of an extra import, though.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
