### PR TITLE
[Merged by Bors] - feat: numerals not divisible by the characteristic are invertible in rings

### DIFF
--- a/Mathlib/Algebra/CharP/Invertible.lean
+++ b/Mathlib/Algebra/CharP/Invertible.lean
@@ -25,30 +25,38 @@ variable {R K : Type*}
 section Ring
 variable [Ring R] {p : ℕ} [CharP R p]
 
-theorem CharP.intCast_mul_natCast_gcdA {n : ℕ} (hp : p.Prime) (not_dvd : ¬p ∣ n) :
+theorem CharP.intCast_mul_natCast_gcdA {n : ℕ} (h : n.Coprime p) :
     (n * n.gcdA p : R) = 1 := by
   suffices ↑(n * n.gcdA p + p * n.gcdB p : ℤ) = (1 : R) by simpa using this
-  rw [← Nat.Prime.coprime_iff_not_dvd hp, Nat.coprime_comm] at not_dvd
-  rw [← Nat.gcd_eq_gcd_ab, not_dvd, Nat.cast_one, Int.cast_one]
+  rw [← Nat.gcd_eq_gcd_ab, h, Nat.cast_one, Int.cast_one]
 
-theorem CharP.natCast_gcdA_mul_intCast {n : ℕ} (hp : p.Prime) (not_dvd : ¬p ∣ n) :
+theorem CharP.natCast_gcdA_mul_intCast {n : ℕ} (h : n.Coprime p) :
     (n.gcdA p * n : R) = 1 :=
-  Nat.commute_cast _ _ |>.eq.trans <| CharP.intCast_mul_natCast_gcdA hp not_dvd
+  Nat.commute_cast _ _ |>.eq.trans <| CharP.intCast_mul_natCast_gcdA h
 
-/-- In a ring of characteristic `p` where `p` is prime, `(n : R)` is invertible when `n` is not
-a multiple of `p`, with inverse `n.gcdA p`. -/
-def invertibleOfPrimeCharPNotDvd {n : ℕ} (hp : p.Prime) (not_dvd : ¬p ∣ n) :
+/-- In a ring of characteristic `p`, `(n : R)` is invertible when `n` is coprime with `p`, with
+inverse `n.gcdA p`. -/
+def invertibleOfCoprime {n : ℕ} (h : n.Coprime p) :
     Invertible (n : R) where
   invOf := n.gcdA p
-  invOf_mul_self := CharP.natCast_gcdA_mul_intCast hp not_dvd
-  mul_invOf_self := CharP.intCast_mul_natCast_gcdA hp not_dvd
+  invOf_mul_self := CharP.natCast_gcdA_mul_intCast h
+  mul_invOf_self := CharP.intCast_mul_natCast_gcdA h
+
+theorem invOf_eq_of_coprime {n : ℕ} [Invertible (n : R)] (h : n.Coprime p) :
+    ⅟(n : R) = n.gcdA p := by
+  letI : Invertible (n : R) := invertibleOfCoprime h
+  convert (rfl : ⅟(n : R) = _)
+
+-- TODO: are these true in terms of `Coprime` instead?
 
 theorem CharP.isUnit_natCast_iff {n : ℕ} (hp : p.Prime) : IsUnit (n : R) ↔ ¬p ∣ n where
   mp h := by
     have := CharP.nontrivial_of_char_ne_one (R := R) hp.ne_one
     rw [← CharP.cast_eq_zero_iff (R := R)]
     exact h.ne_zero
-  mpr not_dvd := letI := invertibleOfPrimeCharPNotDvd (R := R) hp not_dvd; isUnit_of_invertible _
+  mpr not_dvd :=
+    letI := invertibleOfCoprime (R := R) (hp.coprime_iff_not_dvd.2 not_dvd).symm
+    isUnit_of_invertible _
 
 theorem CharP.isUnit_ofNat_iff {n : ℕ} [n.AtLeastTwo] (hp : p.Prime) :
     IsUnit (ofNat(n) : R) ↔ ¬p ∣ ofNat(n) :=

--- a/Mathlib/Algebra/CharP/Invertible.lean
+++ b/Mathlib/Algebra/CharP/Invertible.lean
@@ -25,29 +25,27 @@ variable {R K : Type*}
 section Ring
 variable [Ring R] {p : ℕ} [CharP R p]
 
-theorem CharP.intCast_mul_natCast_gcdA {n : ℕ} (h : n.Coprime p) :
-    (n * n.gcdA p : R) = 1 := by
-  suffices ↑(n * n.gcdA p + p * n.gcdB p : ℤ) = (1 : R) by simpa using this
-  rw [← Nat.gcd_eq_gcd_ab, h, Nat.cast_one, Int.cast_one]
+theorem CharP.intCast_mul_natCast_gcdA_eq_gcd (n : ℕ) :
+    (n * n.gcdA p : R) = n.gcd p := by
+  suffices ↑(n * n.gcdA p + p * n.gcdB p : ℤ) = ((n.gcd p : ℤ) : R) by simpa using this
+  rw [← Nat.gcd_eq_gcd_ab]
 
-theorem CharP.natCast_gcdA_mul_intCast {n : ℕ} (h : n.Coprime p) :
-    (n.gcdA p * n : R) = 1 :=
-  Nat.commute_cast _ _ |>.eq.trans <| CharP.intCast_mul_natCast_gcdA h
+theorem CharP.natCast_gcdA_mul_intCast_eq_gcd (n : ℕ) :
+    (n.gcdA p * n : R) = n.gcd p :=
+  Nat.commute_cast _ _ |>.eq.trans <| CharP.intCast_mul_natCast_gcdA_eq_gcd n
 
 /-- In a ring of characteristic `p`, `(n : R)` is invertible when `n` is coprime with `p`, with
 inverse `n.gcdA p`. -/
 def invertibleOfCoprime {n : ℕ} (h : n.Coprime p) :
     Invertible (n : R) where
   invOf := n.gcdA p
-  invOf_mul_self := CharP.natCast_gcdA_mul_intCast h
-  mul_invOf_self := CharP.intCast_mul_natCast_gcdA h
+  invOf_mul_self := by rw [CharP.natCast_gcdA_mul_intCast_eq_gcd, h, Nat.cast_one]
+  mul_invOf_self := by rw [CharP.intCast_mul_natCast_gcdA_eq_gcd, h, Nat.cast_one]
 
 theorem invOf_eq_of_coprime {n : ℕ} [Invertible (n : R)] (h : n.Coprime p) :
     ⅟(n : R) = n.gcdA p := by
   letI : Invertible (n : R) := invertibleOfCoprime h
   convert (rfl : ⅟(n : R) = _)
-
--- TODO: are these true in terms of `Coprime` instead?
 
 theorem CharP.isUnit_natCast_iff {n : ℕ} (hp : p.Prime) : IsUnit (n : R) ↔ ¬p ∣ n where
   mp h := by


### PR DESCRIPTION
We previously only had this for fields

[Zulip thread](https://leanprover.zulipchat.com/#narrow/channel/217875-Is-there-code-for-X.3F/topic/IsUnit.20and.20CharP/near/503900213), which suggests follow-up work to show the reverse implication (and an `Iff`).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
