### PR TITLE
[Merged by Bors] - feat: interval averages are invariant when functions change along discrete sets

### DIFF
--- a/Mathlib/MeasureTheory/Integral/IntervalAverage.lean
+++ b/Mathlib/MeasureTheory/Integral/IntervalAverage.lean
@@ -49,3 +49,10 @@ theorem interval_average_eq (f : ℝ → E) (a b : ℝ) :
 theorem interval_average_eq_div (f : ℝ → ℝ) (a b : ℝ) :
     (⨍ x in a..b, f x) = (∫ x in a..b, f x) / (b - a) := by
   rw [interval_average_eq, smul_eq_mul, div_eq_inv_mul]
+
+/-- Interval averages are invariant when functions change along discrete sets. -/
+theorem intervalAverage_congr_codiscreteWithin {a b : ℝ} {f₁ f₂ : ℝ → ℝ}
+    (hf : f₁ =ᶠ[Filter.codiscreteWithin (Ι a b)] f₂) :
+    ⨍ (x : ℝ) in a..b, f₁ x = ⨍ (x : ℝ) in a..b, f₂ x := by
+  rw [interval_average_eq, intervalIntegral.integral_congr_codiscreteWithin hf,
+    ← interval_average_eq]


### PR DESCRIPTION
Establish that interval averages are invariant when functions change on discrete sets.

-------
This is a trivial PR that should have been part of #22372. I apologize for forgetting to include this the first time round.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
