### PR TITLE
[Merged by Bors] - feat(Probability): add `condExp_ae_eq_trim_integral_condExpKernel`

### DIFF
--- a/Mathlib/MeasureTheory/Function/ConditionalExpectation/Basic.lean
+++ b/Mathlib/MeasureTheory/Function/ConditionalExpectation/Basic.lean
@@ -203,6 +203,11 @@ theorem condExp_congr_ae (h : f =ᵐ[μ] g) : μ[f|m] =ᵐ[μ] μ[g|m] := by
 
 @[deprecated (since := "2025-01-21")] alias condexp_congr_ae := condExp_congr_ae
 
+lemma condExp_congr_ae_trim (hm : m ≤ m₀) (hfg : f =ᵐ[μ] g) :
+    μ[f|m] =ᵐ[μ.trim hm] μ[g|m] :=
+  StronglyMeasurable.ae_eq_trim_of_stronglyMeasurable hm
+    stronglyMeasurable_condExp stronglyMeasurable_condExp (condExp_congr_ae hfg)
+
 theorem condExp_of_aestronglyMeasurable' (hm : m ≤ m₀) [hμm : SigmaFinite (μ.trim hm)] {f : α → E}
     (hf : AEStronglyMeasurable[m] f μ) (hfi : Integrable f μ) : μ[f|m] =ᵐ[μ] f := by
   refine ((condExp_congr_ae hf.ae_eq_mk).trans ?_).trans hf.ae_eq_mk.symm

--- a/Mathlib/Probability/Kernel/Condexp.lean
+++ b/Mathlib/Probability/Kernel/Condexp.lean
@@ -178,6 +178,12 @@ alias aestronglyMeasurable'_integral_condExpKernel := aestronglyMeasurable_integ
 @[deprecated (since := "2025-01-21")]
 alias aestronglyMeasurable'_integral_condexpKernel := aestronglyMeasurable_integral_condExpKernel
 
+lemma aestronglyMeasurable_trim_condExpKernel (hm : m ≤ mΩ) (hf : AEStronglyMeasurable f μ) :
+    ∀ᵐ ω ∂(μ.trim hm), f =ᵐ[condExpKernel μ m ω] hf.mk f := by
+  refine Measure.ae_ae_of_ae_comp ?_
+  rw [condExpKernel_comp_trim hm]
+  exact hf.ae_eq_mk
+
 end Measurability
 
 section Integrability
@@ -300,6 +306,28 @@ theorem condExp_ae_eq_integral_condExpKernel [NormedAddCommGroup F] {f : Ω → 
 
 @[deprecated (since := "2025-01-21")]
 alias condexp_ae_eq_integral_condexpKernel := condExp_ae_eq_integral_condExpKernel
+
+/-- Auxiliary lemma for `condExp_ae_eq_trim_integral_condExpKernel`. -/
+theorem condExp_ae_eq_trim_integral_condExpKernel_of_stronglyMeasurable
+    [NormedAddCommGroup F] {f : Ω → F} [NormedSpace ℝ F] [CompleteSpace F]
+    (hm : m ≤ mΩ) (hf : StronglyMeasurable f) (hf_int : Integrable f μ) :
+    μ[f|m] =ᵐ[μ.trim hm] fun ω ↦ ∫ y, f y ∂condExpKernel μ m ω := by
+ refine StronglyMeasurable.ae_eq_trim_of_stronglyMeasurable hm ?_ ?_ ?_
+ · exact stronglyMeasurable_condExp
+ · exact hf.integral_condExpKernel
+ · exact condExp_ae_eq_integral_condExpKernel hm hf_int
+
+/-- The conditional expectation of `f` with respect to a σ-algebra `m` is
+(`μ.trim hm`)-almost everywhere equal to the integral `∫ y, f y ∂(condExpKernel μ m ω)`. -/
+theorem condExp_ae_eq_trim_integral_condExpKernel [NormedAddCommGroup F] {f : Ω → F}
+    [NormedSpace ℝ F] [CompleteSpace F] (hm : m ≤ mΩ) (hf_int : Integrable f μ) :
+    μ[f|m] =ᵐ[μ.trim hm] fun ω ↦ ∫ y, f y ∂condExpKernel μ m ω := by
+  refine (condExp_congr_ae_trim hm hf_int.1.ae_eq_mk).trans ?_
+  refine (condExp_ae_eq_trim_integral_condExpKernel_of_stronglyMeasurable hm
+    hf_int.1.stronglyMeasurable_mk ?_).trans ?_
+  · rwa [integrable_congr hf_int.1.ae_eq_mk.symm]
+  filter_upwards [aestronglyMeasurable_trim_condExpKernel hm hf_int.1] with ω hω
+  rw [integral_congr_ae hω]
 
 section Cond
 


### PR DESCRIPTION
This lemma is a stronger version of `condExp_ae_eq_integral_condExpKernel` (from a.e. equality to a.e. equality with respect to the trimmed measure).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
