### PR TITLE
[Merged by Bors] - feat(Topology): add `ContinuousOn` union API lemmas

### DIFF
--- a/Mathlib/Topology/ContinuousOn.lean
+++ b/Mathlib/Topology/ContinuousOn.lean
@@ -1518,7 +1518,7 @@ theorem ContinuousOn.union_of_isClosed (hs : IsClosed s) (ht : IsClosed t) {f : 
   · refine if hx : x ∈ t then hft x hx else continuousWithinAt_of_not_mem_closure ?_
     rwa [ht.closure_eq]
 
-@[deprecated ContinuousOn.union_of_isClosed (since := "2025-03-09")]
+@[deprecated ContinuousOn.union_of_isClosed (since := "2025-04-10")]
 alias ContinuousOn.union_isClosed := ContinuousOn.union_of_isClosed
 
 /-- A function is continuous on two closed sets iff it is also continuous on their union. -/
@@ -1530,7 +1530,7 @@ theorem continouousOn_union_isClosed (hs : IsClosed s) (ht : IsClosed t) {f : α
 /-- If a function is continuous on two open sets, it is also continuous on their union. -/
 theorem ContinuousOn.union_of_isOpen (hs : IsOpen s) (ht : IsOpen t) {f : α → β}
     (hfs : ContinuousOn f s) (hft : ContinuousOn f t) : ContinuousOn f (s ∪ t) :=
-  union_continuousAt hs hfs fun _ hx ↦ IsOpen.continuousOn_iff ht |>.mp hft hx
+  union_continuousAt hs hfs fun _ hx ↦ ht.continuousOn_iff.mp hft hx
 
 /-- A function is continuous on two open sets iff it is also continuous on their union. -/
 theorem continouousOn_union_isOpen (hs : IsOpen s) (ht : IsOpen t) {f : α → β} :

--- a/Mathlib/Topology/ContinuousOn.lean
+++ b/Mathlib/Topology/ContinuousOn.lean
@@ -1502,8 +1502,8 @@ lemma ContinuousOn.union_continuousAt {f : α → β} (s_op : IsOpen s)
 
 open Classical in
 /-- If a function is continuous on two closed sets, it is also continuous on their union. -/
-theorem ContinuousOn.union_of_isClosed (hs : IsClosed s) (ht : IsClosed t) {f : α → β}
-    (hfs : ContinuousOn f s) (hft : ContinuousOn f t) : ContinuousOn f (s ∪ t) := by
+theorem ContinuousOn.union_of_isClosed {f : α → β} (hfs : ContinuousOn f s) (hft : ContinuousOn f t)
+    (hs : IsClosed s) (ht : IsClosed t) : ContinuousOn f (s ∪ t) := by
   refine fun x hx ↦ .union ?_ ?_
   · refine if hx : x ∈ s then hfs x hx else continuousWithinAt_of_not_mem_closure ?_
     rwa [hs.closure_eq]
@@ -1514,21 +1514,21 @@ theorem ContinuousOn.union_of_isClosed (hs : IsClosed s) (ht : IsClosed t) {f : 
 alias ContinuousOn.union_isClosed := ContinuousOn.union_of_isClosed
 
 /-- A function is continuous on two closed sets iff it is also continuous on their union. -/
-theorem continouousOn_union_isClosed (hs : IsClosed s) (ht : IsClosed t) {f : α → β} :
+theorem continouousOn_union_iff_of_isClosed {f : α → β} (hs : IsClosed s) (ht : IsClosed t) :
     ContinuousOn f (s ∪ t) ↔ ContinuousOn f s ∧ ContinuousOn f t :=
   ⟨fun h ↦ ⟨h.mono s.subset_union_left, h.mono s.subset_union_right⟩,
-   fun h ↦ h.left.union_of_isClosed hs ht h.right⟩
+   fun h ↦ h.left.union_of_isClosed h.right hs ht⟩
 
 /-- If a function is continuous on two open sets, it is also continuous on their union. -/
-theorem ContinuousOn.union_of_isOpen (hs : IsOpen s) (ht : IsOpen t) {f : α → β}
-    (hfs : ContinuousOn f s) (hft : ContinuousOn f t) : ContinuousOn f (s ∪ t) :=
+theorem ContinuousOn.union_of_isOpen {f : α → β} (hfs : ContinuousOn f s) (hft : ContinuousOn f t)
+    (hs : IsOpen s) (ht : IsOpen t) : ContinuousOn f (s ∪ t) :=
   union_continuousAt hs hfs fun _ hx ↦ ht.continuousOn_iff.mp hft hx
 
 /-- A function is continuous on two open sets iff it is also continuous on their union. -/
-theorem continouousOn_union_isOpen (hs : IsOpen s) (ht : IsOpen t) {f : α → β} :
+theorem continouousOn_union_iff_of_isOpen {f : α → β} (hs : IsOpen s) (ht : IsOpen t) :
     ContinuousOn f (s ∪ t) ↔ ContinuousOn f s ∧ ContinuousOn f t :=
   ⟨fun h ↦ ⟨h.mono s.subset_union_left, h.mono s.subset_union_right⟩,
-   fun h ↦ h.left.union_of_isOpen hs ht h.right⟩
+   fun h ↦ h.left.union_of_isOpen h.right hs ht⟩
 
 /-- If `f` is continuous on some neighbourhood `s'` of `s` and `f` maps `s` to `t`,
 the preimage of a set neighbourhood of `t` is a set neighbourhood of `s`. -/

--- a/Mathlib/Topology/ContinuousOn.lean
+++ b/Mathlib/Topology/ContinuousOn.lean
@@ -1500,6 +1500,13 @@ lemma ContinuousOn.union_continuousAt {f : α → β} (s_op : IsOpen s)
   (fun h => ContinuousWithinAt.continuousAt (continuousWithinAt hs h) <| IsOpen.mem_nhds s_op h)
   (ht _)
 
+/-- If a function is continuous on the union of two sets, it is continuous on both of them. -/
+theorem continuousOn_of_union {X Y : Type*} [TopologicalSpace X] [TopologicalSpace Y]
+    {s t : Set X} {f : X → Y} (h : ContinuousOn f (s ∪ t)) :
+    ContinuousOn f s ∧ ContinuousOn f t :=
+  ⟨fun x hx ↦ continuousWithinAt_union.mp (h x (mem_union_left t hx)) |>.1,
+   fun x hx ↦ continuousWithinAt_union.mp (h x (mem_union_right s hx)) |>.2⟩
+
 open Classical in
 /-- If a function is continuous on two closed sets, it is also continuous on their union. -/
 theorem ContinuousOn.union_isClosed (hs : IsClosed s)
@@ -1510,6 +1517,12 @@ theorem ContinuousOn.union_isClosed (hs : IsClosed s)
     rwa [hs.closure_eq]
   · refine if hx : x ∈ t then hft x hx else continuousWithinAt_of_not_mem_closure ?_
     rwa [ht.closure_eq]
+
+/-- If a function is continuous on two open sets, it is also continuous on their union. -/
+theorem ContinuousOn.union_isOpen {X Y : Type*} [TopologicalSpace X] [TopologicalSpace Y]
+    {s t : Set X} (hs : IsOpen s) (ht : IsOpen t) {f : X → Y} (hfs : ContinuousOn f s)
+    (hft : ContinuousOn f t) : ContinuousOn f (s ∪ t) :=
+  union_continuousAt hs hfs fun _ hx ↦ IsOpen.continuousOn_iff ht |>.mp hft hx
 
 /-- If `f` is continuous on some neighbourhood `s'` of `s` and `f` maps `s` to `t`,
 the preimage of a set neighbourhood of `t` is a set neighbourhood of `s`. -/

--- a/Mathlib/Topology/ContinuousOn.lean
+++ b/Mathlib/Topology/ContinuousOn.lean
@@ -1518,7 +1518,7 @@ theorem ContinuousOn.union_of_isClosed (hs : IsClosed s) (ht : IsClosed t) {f : 
   · refine if hx : x ∈ t then hft x hx else continuousWithinAt_of_not_mem_closure ?_
     rwa [ht.closure_eq]
 
-@[deprecated (since := "2025-03-09")]
+@[deprecated ContinuousOn.union_of_isClosed (since := "2025-03-09")]
 alias ContinuousOn.union_isClosed := ContinuousOn.union_of_isClosed
 
 /-- A function is continuous on two closed sets iff it is also continuous on their union. -/

--- a/Mathlib/Topology/ContinuousOn.lean
+++ b/Mathlib/Topology/ContinuousOn.lean
@@ -1500,29 +1500,43 @@ lemma ContinuousOn.union_continuousAt {f : α → β} (s_op : IsOpen s)
   (fun h => ContinuousWithinAt.continuousAt (continuousWithinAt hs h) <| IsOpen.mem_nhds s_op h)
   (ht _)
 
-/-- If a function is continuous on the union of two sets, it is continuous on both of them. -/
-theorem continuousOn_of_union {X Y : Type*} [TopologicalSpace X] [TopologicalSpace Y]
-    {s t : Set X} {f : X → Y} (h : ContinuousOn f (s ∪ t)) :
-    ContinuousOn f s ∧ ContinuousOn f t :=
-  ⟨fun x hx ↦ continuousWithinAt_union.mp (h x (mem_union_left t hx)) |>.1,
-   fun x hx ↦ continuousWithinAt_union.mp (h x (mem_union_right s hx)) |>.2⟩
+/-- If `f` is continuous on `s ∪ t`, it is continuous on `s`. -/
+theorem continuousOn_of_union_left {f : α → β} (h : ContinuousOn f (s ∪ t)) : ContinuousOn f s :=
+  fun x hx ↦ continuousWithinAt_union.mp (h x (mem_union_left t hx)) |>.1
+
+/-- If `f` is continuous on `s ∪ t`, it is continuous on `t`. -/
+theorem continuousOn_of_union_right {f : α → β} (h : ContinuousOn f (s ∪ t)) : ContinuousOn f t :=
+  fun x hx ↦ continuousWithinAt_union.mp (h x (mem_union_right s hx)) |>.2
 
 open Classical in
 /-- If a function is continuous on two closed sets, it is also continuous on their union. -/
-theorem ContinuousOn.union_isClosed (hs : IsClosed s)
-    (ht : IsClosed t) {f : α → β} (hfs : ContinuousOn f s)
-    (hft : ContinuousOn f t) : ContinuousOn f (s ∪ t) := by
+theorem ContinuousOn.union_of_isClosed (hs : IsClosed s) (ht : IsClosed t) {f : α → β}
+    (hfs : ContinuousOn f s) (hft : ContinuousOn f t) : ContinuousOn f (s ∪ t) := by
   refine fun x hx ↦ .union ?_ ?_
   · refine if hx : x ∈ s then hfs x hx else continuousWithinAt_of_not_mem_closure ?_
     rwa [hs.closure_eq]
   · refine if hx : x ∈ t then hft x hx else continuousWithinAt_of_not_mem_closure ?_
     rwa [ht.closure_eq]
 
+@[deprecated (since := "2025-03-09")]
+alias ContinuousOn.union_isClosed := ContinuousOn.union_of_isClosed
+
+/-- A function is continuous on two closed sets iff it is also continuous on their union. -/
+theorem continouousOn_union_isClosed (hs : IsClosed s) (ht : IsClosed t) {f : α → β} :
+    ContinuousOn f (s ∪ t) ↔ ContinuousOn f s ∧ ContinuousOn f t :=
+  ⟨fun h ↦ ⟨continuousOn_of_union_left h, continuousOn_of_union_right h⟩,
+   fun h ↦ ContinuousOn.union_of_isClosed hs ht h.1 h.2⟩
+
 /-- If a function is continuous on two open sets, it is also continuous on their union. -/
-theorem ContinuousOn.union_isOpen {X Y : Type*} [TopologicalSpace X] [TopologicalSpace Y]
-    {s t : Set X} (hs : IsOpen s) (ht : IsOpen t) {f : X → Y} (hfs : ContinuousOn f s)
-    (hft : ContinuousOn f t) : ContinuousOn f (s ∪ t) :=
+theorem ContinuousOn.union_of_isOpen (hs : IsOpen s) (ht : IsOpen t) {f : α → β}
+    (hfs : ContinuousOn f s) (hft : ContinuousOn f t) : ContinuousOn f (s ∪ t) :=
   union_continuousAt hs hfs fun _ hx ↦ IsOpen.continuousOn_iff ht |>.mp hft hx
+
+/-- A function is continuous on two open sets iff it is also continuous on their union. -/
+theorem continouousOn_union_isOpen (hs : IsOpen s) (ht : IsOpen t) {f : α → β} :
+    ContinuousOn f (s ∪ t) ↔ ContinuousOn f s ∧ ContinuousOn f t :=
+  ⟨fun h ↦ ⟨continuousOn_of_union_left h, continuousOn_of_union_right h⟩,
+   fun h ↦ ContinuousOn.union_of_isOpen hs ht h.1 h.2⟩
 
 /-- If `f` is continuous on some neighbourhood `s'` of `s` and `f` maps `s` to `t`,
 the preimage of a set neighbourhood of `t` is a set neighbourhood of `s`. -/

--- a/Mathlib/Topology/ContinuousOn.lean
+++ b/Mathlib/Topology/ContinuousOn.lean
@@ -1500,14 +1500,6 @@ lemma ContinuousOn.union_continuousAt {f : α → β} (s_op : IsOpen s)
   (fun h => ContinuousWithinAt.continuousAt (continuousWithinAt hs h) <| IsOpen.mem_nhds s_op h)
   (ht _)
 
-/-- If `f` is continuous on `s ∪ t`, it is continuous on `s`. -/
-theorem continuousOn_of_union_left {f : α → β} (h : ContinuousOn f (s ∪ t)) : ContinuousOn f s :=
-  fun x hx ↦ continuousWithinAt_union.mp (h x (mem_union_left t hx)) |>.1
-
-/-- If `f` is continuous on `s ∪ t`, it is continuous on `t`. -/
-theorem continuousOn_of_union_right {f : α → β} (h : ContinuousOn f (s ∪ t)) : ContinuousOn f t :=
-  fun x hx ↦ continuousWithinAt_union.mp (h x (mem_union_right s hx)) |>.2
-
 open Classical in
 /-- If a function is continuous on two closed sets, it is also continuous on their union. -/
 theorem ContinuousOn.union_of_isClosed (hs : IsClosed s) (ht : IsClosed t) {f : α → β}
@@ -1524,8 +1516,8 @@ alias ContinuousOn.union_isClosed := ContinuousOn.union_of_isClosed
 /-- A function is continuous on two closed sets iff it is also continuous on their union. -/
 theorem continouousOn_union_isClosed (hs : IsClosed s) (ht : IsClosed t) {f : α → β} :
     ContinuousOn f (s ∪ t) ↔ ContinuousOn f s ∧ ContinuousOn f t :=
-  ⟨fun h ↦ ⟨continuousOn_of_union_left h, continuousOn_of_union_right h⟩,
-   fun h ↦ ContinuousOn.union_of_isClosed hs ht h.1 h.2⟩
+  ⟨fun h ↦ ⟨h.mono s.subset_union_left, h.mono s.subset_union_right⟩,
+   fun h ↦ h.left.union_of_isClosed hs ht h.right⟩
 
 /-- If a function is continuous on two open sets, it is also continuous on their union. -/
 theorem ContinuousOn.union_of_isOpen (hs : IsOpen s) (ht : IsOpen t) {f : α → β}
@@ -1535,8 +1527,8 @@ theorem ContinuousOn.union_of_isOpen (hs : IsOpen s) (ht : IsOpen t) {f : α →
 /-- A function is continuous on two open sets iff it is also continuous on their union. -/
 theorem continouousOn_union_isOpen (hs : IsOpen s) (ht : IsOpen t) {f : α → β} :
     ContinuousOn f (s ∪ t) ↔ ContinuousOn f s ∧ ContinuousOn f t :=
-  ⟨fun h ↦ ⟨continuousOn_of_union_left h, continuousOn_of_union_right h⟩,
-   fun h ↦ ContinuousOn.union_of_isOpen hs ht h.1 h.2⟩
+  ⟨fun h ↦ ⟨h.mono s.subset_union_left, h.mono s.subset_union_right⟩,
+   fun h ↦ h.left.union_of_isOpen hs ht h.right⟩
 
 /-- If `f` is continuous on some neighbourhood `s'` of `s` and `f` maps `s` to `t`,
 the preimage of a set neighbourhood of `t` is a set neighbourhood of `s`. -/


### PR DESCRIPTION
Add lemmas to allow going from continuity on two open sets to continuity on their union. Note that there is already an existing lemma for continuity on the union of two closed sets.