### PR TITLE
[Merged by Bors] - refactor(Algebra/Group): redo a proof to avoid import bumps

### DIFF
--- a/Mathlib/Algebra/Group/Support.lean
+++ b/Mathlib/Algebra/Group/Support.lean
@@ -6,7 +6,7 @@ Authors: Yury Kudryashov
 import Mathlib.Algebra.Group.Basic
 import Mathlib.Algebra.Group.Pi.Basic
 import Mathlib.Algebra.ZeroOne.Prod
-import Mathlib.Order.Cover
+import Mathlib.Data.Set.Image
 
 /-!
 # Support of a function
@@ -15,7 +15,7 @@ In this file we define `Function.support f = {x | f x ≠ 0}` and prove its basi
 We also define `Function.mulSupport f = {x | f x ≠ 1}`.
 -/
 
-assert_not_exists MonoidWithZero
+assert_not_exists CompleteLattice MonoidWithZero
 
 open Set
 
@@ -128,8 +128,12 @@ theorem range_subset_insert_image_mulSupport (f : α → M) :
 @[to_additive]
 lemma range_eq_image_or_of_mulSupport_subset {f : α → M} {k : Set α} (h : mulSupport f ⊆ k) :
     range f = f '' k ∨ range f = insert 1 (f '' k) := by
-  apply (wcovBy_insert _ _).eq_or_eq (image_subset_range _ _)
-  exact (range_subset_insert_image_mulSupport f).trans (insert_subset_insert (image_subset f h))
+  have : range f ⊆ insert 1 (f '' k) :=
+    (range_subset_insert_image_mulSupport f).trans (insert_subset_insert (image_subset f h))
+  by_cases h1 : 1 ∈ range f
+  · exact Or.inr (subset_antisymm this (insert_subset h1 (image_subset_range _ _)))
+  refine Or.inl (subset_antisymm ?_ (image_subset_range _ _))
+  rwa [← diff_singleton_eq_self h1, diff_singleton_subset_iff]
 
 @[to_additive (attr := simp)]
 theorem mulSupport_one' : mulSupport (1 : α → M) = ∅ :=

--- a/Mathlib/Algebra/Order/Field/Basic.lean
+++ b/Mathlib/Algebra/Order/Field/Basic.lean
@@ -8,6 +8,7 @@ import Mathlib.Algebra.GroupWithZero.Units.Lemmas
 import Mathlib.Algebra.Order.Field.Defs
 import Mathlib.Algebra.Order.Ring.Abs
 import Mathlib.Algebra.Ring.CharZero
+import Mathlib.Order.Bounds.Basic
 import Mathlib.Order.Bounds.OrderIso
 import Mathlib.Tactic.Positivity.Core
 

--- a/Mathlib/Algebra/Order/Group/Pointwise/Interval.lean
+++ b/Mathlib/Algebra/Order/Group/Pointwise/Interval.lean
@@ -8,6 +8,7 @@ import Mathlib.Algebra.Group.Pointwise.Set.Basic
 import Mathlib.Algebra.Order.Field.Basic
 import Mathlib.Algebra.Order.Group.MinMax
 import Mathlib.Algebra.Order.Interval.Set.Monoid
+import Mathlib.Order.Interval.Set.UnorderedInterval
 
 /-!
 # (Pre)images of intervals

--- a/Mathlib/Algebra/Ring/CharZero.lean
+++ b/Mathlib/Algebra/Ring/CharZero.lean
@@ -7,6 +7,7 @@ import Mathlib.Algebra.Group.Support
 import Mathlib.Algebra.GroupWithZero.Units.Basic
 import Mathlib.Algebra.Ring.Units
 import Mathlib.Data.Nat.Cast.Basic
+import Mathlib.Logic.Embedding.Basic
 
 /-!
 # Characteristic zero rings

--- a/Mathlib/Data/ENNReal/Basic.lean
+++ b/Mathlib/Data/ENNReal/Basic.lean
@@ -6,6 +6,7 @@ Authors: Johannes Hölzl, Yury Kudryashov
 import Mathlib.Algebra.Order.Ring.WithTop
 import Mathlib.Algebra.Order.Sub.WithTop
 import Mathlib.Data.NNReal.Defs
+import Mathlib.Order.Interval.Set.WithBotTop
 
 /-!
 # Extended non-negative reals

--- a/Mathlib/Data/Finsupp/Defs.lean
+++ b/Mathlib/Data/Finsupp/Defs.lean
@@ -78,7 +78,7 @@ This file is a `noncomputable theory` and uses classical logic throughout.
 
 -/
 
-assert_not_exists Submonoid
+assert_not_exists CompleteLattice Submonoid
 
 noncomputable section
 


### PR DESCRIPTION
The lemma `Function.range_eq_image_or_of_mulSupport_subset` is proved using `WCovBy.eq_or_eq`, which lives in `Mathlib.Order.Cover`. That gives quite a lot of transitive imports for this low-down file (e.g. it is a dependency for `Mathlib.Data.Finsupp.Defs`). Moreover, if you unfold the proof it's doing quite a bit of work to prove `WCovBy` using `wCovBy_of_eq_or_eq`, which then immediately gets undone by `eq_or_eq`. So also from the point of not using overpowered techniques where simple ones suffice, I like this change.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
