### PR TITLE
[Merged by Bors] - feat(MeasureTheory): cylinders with closed compact bases

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3932,6 +3932,7 @@ import Mathlib.MeasureTheory.Constructions.BorelSpace.Metric
 import Mathlib.MeasureTheory.Constructions.BorelSpace.Metrizable
 import Mathlib.MeasureTheory.Constructions.BorelSpace.Order
 import Mathlib.MeasureTheory.Constructions.BorelSpace.Real
+import Mathlib.MeasureTheory.Constructions.ClosedCompactCylinders
 import Mathlib.MeasureTheory.Constructions.Cylinders
 import Mathlib.MeasureTheory.Constructions.HaarToSphere
 import Mathlib.MeasureTheory.Constructions.Pi

--- a/Mathlib/MeasureTheory/Constructions/ClosedCompactCylinders.lean
+++ b/Mathlib/MeasureTheory/Constructions/ClosedCompactCylinders.lean
@@ -1,0 +1,85 @@
+/-
+Copyright (c) 2025 Rémy Degenne. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Rémy Degenne, Peter Pfaffelhuber
+-/
+import Mathlib.MeasureTheory.Constructions.BorelSpace.Basic
+import Mathlib.MeasureTheory.Constructions.Cylinders
+
+/-! # Cylinders with closed compact bases
+
+We define the set of all cylinders with closed compact bases. Those sets play a role in the
+proof of Kolmogorov's extension theorem.
+
+## Main definitions
+
+* `closedCompactCylinders α`: the set of all cylinders based on closed compact sets.
+
+## Main statements
+
+* `mem_measurableCylinders_of_mem_closedCompactCylinders`: in a topological space with second
+  countable topology and measurable open sets, a set in `closedCompactCylinders α` is a measurable
+  cylinder.
+
+-/
+
+open Set
+
+namespace MeasureTheory
+
+variable {ι : Type*} {α : ι → Type*} [∀ i, TopologicalSpace (α i)] {t : Set (Π i, α i)}
+
+variable (α) in
+/-- The set of all cylinders based on closed compact sets. Note that such a set is closed, but
+not compact in general (for instance, the whole space is always a closed compact cylinder). -/
+def closedCompactCylinders : Set (Set (Π i, α i)) :=
+  ⋃ (s) (S) (_ : IsClosed S) (_ : IsCompact S), {cylinder s S}
+
+variable (α) in
+theorem empty_mem_closedCompactCylinders : ∅ ∈ closedCompactCylinders α := by
+  simp_rw [closedCompactCylinders, mem_iUnion, mem_singleton_iff]
+  exact ⟨∅, ∅, isClosed_empty, isCompact_empty, (cylinder_empty _).symm⟩
+
+theorem mem_closedCompactCylinders (t : Set (Π i, α i)) :
+    t ∈ closedCompactCylinders α
+      ↔ ∃ (s S : _), IsClosed S ∧ IsCompact S ∧ t = cylinder s S := by
+  simp_rw [closedCompactCylinders, mem_iUnion, mem_singleton_iff, exists_prop]
+
+/-- A finset `s` such that `t = cylinder s S`. `S` is given by `closedCompactCylinders.set`. -/
+noncomputable def closedCompactCylinders.finset (ht : t ∈ closedCompactCylinders α) :
+    Finset ι :=
+  ((mem_closedCompactCylinders t).mp ht).choose
+
+/-- A set `S` such that `t = cylinder s S`. `s` is given by `closedCompactCylinders.finset`. -/
+def closedCompactCylinders.set (ht : t ∈ closedCompactCylinders α) :
+    Set (∀ i : closedCompactCylinders.finset ht, α i) :=
+  ((mem_closedCompactCylinders t).mp ht).choose_spec.choose
+
+theorem closedCompactCylinders.isClosed (ht : t ∈ closedCompactCylinders α) :
+    IsClosed (closedCompactCylinders.set ht) :=
+  ((mem_closedCompactCylinders t).mp ht).choose_spec.choose_spec.1
+
+theorem closedCompactCylinders.isCompact (ht : t ∈ closedCompactCylinders α) :
+    IsCompact (closedCompactCylinders.set ht) :=
+  ((mem_closedCompactCylinders t).mp ht).choose_spec.choose_spec.2.1
+
+theorem closedCompactCylinders.eq_cylinder (ht : t ∈ closedCompactCylinders α) :
+    t = cylinder (closedCompactCylinders.finset ht) (closedCompactCylinders.set ht) :=
+  ((mem_closedCompactCylinders t).mp ht).choose_spec.choose_spec.2.2
+
+theorem cylinder_mem_closedCompactCylinders (s : Finset ι) (S : Set (∀ i : s, α i))
+    (hS_closed : IsClosed S) (hS_compact : IsCompact S) :
+    cylinder s S ∈ closedCompactCylinders α := by
+  rw [mem_closedCompactCylinders]
+  exact ⟨s, S, hS_closed, hS_compact, rfl⟩
+
+theorem mem_measurableCylinders_of_mem_closedCompactCylinders [∀ i, MeasurableSpace (α i)]
+    [∀ i, SecondCountableTopology (α i)] [∀ i, OpensMeasurableSpace (α i)]
+    (ht : t ∈ closedCompactCylinders α) :
+    t ∈ measurableCylinders α := by
+  rw [mem_measurableCylinders]
+  refine ⟨closedCompactCylinders.finset ht, closedCompactCylinders.set ht, ?_, ?_⟩
+  · exact (closedCompactCylinders.isClosed ht).measurableSet
+  · exact closedCompactCylinders.eq_cylinder ht
+
+end MeasureTheory

--- a/Mathlib/MeasureTheory/Constructions/ClosedCompactCylinders.lean
+++ b/Mathlib/MeasureTheory/Constructions/ClosedCompactCylinders.lean
@@ -52,7 +52,7 @@ noncomputable def closedCompactCylinders.finset (ht : t ∈ closedCompactCylinde
 
 /-- A set `S` such that `t = cylinder s S`. `s` is given by `closedCompactCylinders.finset`. -/
 def closedCompactCylinders.set (ht : t ∈ closedCompactCylinders α) :
-    Set (∀ i : closedCompactCylinders.finset ht, α i) :=
+    Set (Π i : closedCompactCylinders.finset ht, α i) :=
   ((mem_closedCompactCylinders t).mp ht).choose_spec.choose
 
 theorem closedCompactCylinders.isClosed (ht : t ∈ closedCompactCylinders α) :
@@ -67,7 +67,7 @@ theorem closedCompactCylinders.eq_cylinder (ht : t ∈ closedCompactCylinders α
     t = cylinder (closedCompactCylinders.finset ht) (closedCompactCylinders.set ht) :=
   ((mem_closedCompactCylinders t).mp ht).choose_spec.choose_spec.2.2
 
-theorem cylinder_mem_closedCompactCylinders (s : Finset ι) (S : Set (∀ i : s, α i))
+theorem cylinder_mem_closedCompactCylinders (s : Finset ι) (S : Set (Π i : s, α i))
     (hS_closed : IsClosed S) (hS_compact : IsCompact S) :
     cylinder s S ∈ closedCompactCylinders α := by
   rw [mem_closedCompactCylinders]

--- a/Mathlib/MeasureTheory/Constructions/ClosedCompactCylinders.lean
+++ b/Mathlib/MeasureTheory/Constructions/ClosedCompactCylinders.lean
@@ -13,12 +13,12 @@ proof of Kolmogorov's extension theorem.
 
 ## Main definitions
 
-* `closedCompactCylinders α`: the set of all cylinders based on closed compact sets.
+* `closedCompactCylinders X`: the set of all cylinders of `Π i, X i` based on closed compact sets.
 
 ## Main statements
 
 * `mem_measurableCylinders_of_mem_closedCompactCylinders`: in a topological space with second
-  countable topology and measurable open sets, a set in `closedCompactCylinders α` is a measurable
+  countable topology and measurable open sets, a set in `closedCompactCylinders X` is a measurable
   cylinder.
 
 -/
@@ -27,56 +27,56 @@ open Set
 
 namespace MeasureTheory
 
-variable {ι : Type*} {α : ι → Type*} [∀ i, TopologicalSpace (α i)] {t : Set (Π i, α i)}
+variable {ι : Type*} {X : ι → Type*} [∀ i, TopologicalSpace (X i)] {t : Set (Π i, X i)}
 
-variable (α) in
+variable (X) in
 /-- The set of all cylinders based on closed compact sets. Note that such a set is closed, but
 not compact in general (for instance, the whole space is always a closed compact cylinder). -/
-def closedCompactCylinders : Set (Set (Π i, α i)) :=
+def closedCompactCylinders : Set (Set (Π i, X i)) :=
   ⋃ (s) (S) (_ : IsClosed S) (_ : IsCompact S), {cylinder s S}
 
-variable (α) in
-theorem empty_mem_closedCompactCylinders : ∅ ∈ closedCompactCylinders α := by
+variable (X) in
+theorem empty_mem_closedCompactCylinders : ∅ ∈ closedCompactCylinders X := by
   simp_rw [closedCompactCylinders, mem_iUnion, mem_singleton_iff]
   exact ⟨∅, ∅, isClosed_empty, isCompact_empty, (cylinder_empty _).symm⟩
 
-theorem mem_closedCompactCylinders (t : Set (Π i, α i)) :
-    t ∈ closedCompactCylinders α
+theorem mem_closedCompactCylinders (t : Set (Π i, X i)) :
+    t ∈ closedCompactCylinders X
       ↔ ∃ (s S : _), IsClosed S ∧ IsCompact S ∧ t = cylinder s S := by
   simp_rw [closedCompactCylinders, mem_iUnion, mem_singleton_iff, exists_prop]
 
 /-- A finset `s` such that `t = cylinder s S`. `S` is given by `closedCompactCylinders.set`. -/
-noncomputable def closedCompactCylinders.finset (ht : t ∈ closedCompactCylinders α) :
+noncomputable def closedCompactCylinders.finset (ht : t ∈ closedCompactCylinders X) :
     Finset ι :=
   ((mem_closedCompactCylinders t).mp ht).choose
 
 /-- A set `S` such that `t = cylinder s S`. `s` is given by `closedCompactCylinders.finset`. -/
-def closedCompactCylinders.set (ht : t ∈ closedCompactCylinders α) :
-    Set (Π i : closedCompactCylinders.finset ht, α i) :=
+def closedCompactCylinders.set (ht : t ∈ closedCompactCylinders X) :
+    Set (Π i : closedCompactCylinders.finset ht, X i) :=
   ((mem_closedCompactCylinders t).mp ht).choose_spec.choose
 
-theorem closedCompactCylinders.isClosed (ht : t ∈ closedCompactCylinders α) :
+theorem closedCompactCylinders.isClosed (ht : t ∈ closedCompactCylinders X) :
     IsClosed (closedCompactCylinders.set ht) :=
   ((mem_closedCompactCylinders t).mp ht).choose_spec.choose_spec.1
 
-theorem closedCompactCylinders.isCompact (ht : t ∈ closedCompactCylinders α) :
+theorem closedCompactCylinders.isCompact (ht : t ∈ closedCompactCylinders X) :
     IsCompact (closedCompactCylinders.set ht) :=
   ((mem_closedCompactCylinders t).mp ht).choose_spec.choose_spec.2.1
 
-theorem closedCompactCylinders.eq_cylinder (ht : t ∈ closedCompactCylinders α) :
+theorem closedCompactCylinders.eq_cylinder (ht : t ∈ closedCompactCylinders X) :
     t = cylinder (closedCompactCylinders.finset ht) (closedCompactCylinders.set ht) :=
   ((mem_closedCompactCylinders t).mp ht).choose_spec.choose_spec.2.2
 
-theorem cylinder_mem_closedCompactCylinders (s : Finset ι) (S : Set (Π i : s, α i))
+theorem cylinder_mem_closedCompactCylinders (s : Finset ι) (S : Set (Π i : s, X i))
     (hS_closed : IsClosed S) (hS_compact : IsCompact S) :
-    cylinder s S ∈ closedCompactCylinders α := by
+    cylinder s S ∈ closedCompactCylinders X := by
   rw [mem_closedCompactCylinders]
   exact ⟨s, S, hS_closed, hS_compact, rfl⟩
 
-theorem mem_measurableCylinders_of_mem_closedCompactCylinders [∀ i, MeasurableSpace (α i)]
-    [∀ i, SecondCountableTopology (α i)] [∀ i, OpensMeasurableSpace (α i)]
-    (ht : t ∈ closedCompactCylinders α) :
-    t ∈ measurableCylinders α := by
+theorem mem_measurableCylinders_of_mem_closedCompactCylinders [∀ i, MeasurableSpace (X i)]
+    [∀ i, SecondCountableTopology (X i)] [∀ i, OpensMeasurableSpace (X i)]
+    (ht : t ∈ closedCompactCylinders X) :
+    t ∈ measurableCylinders X := by
   rw [mem_measurableCylinders]
   refine ⟨closedCompactCylinders.finset ht, closedCompactCylinders.set ht, ?_, ?_⟩
   · exact (closedCompactCylinders.isClosed ht).measurableSet


### PR DESCRIPTION
Part of the formalization of Kolmogorov's extension theorem.
Co-authored-by: Peter Pfaffelhuber

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

See [this repository](https://github.com/RemyDegenne/kolmogorov_extension4/) for the whole proof of Kolmogorov's extension theorem.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
