### PR TITLE
[Merged by Bors] - chore(Analysis/Normed/Group/IndicatorFunction): generalise to enorm

### DIFF
--- a/Mathlib/Analysis/Normed/Field/Basic.lean
+++ b/Mathlib/Analysis/Normed/Field/Basic.lean
@@ -172,7 +172,6 @@ section SeminormedAddCommGroup
 variable [SeminormedAddCommGroup G] [One G] [NormOneClass G]
 
 @[simp] lemma nnnorm_one : ‖(1 : G)‖₊ = 1 := NNReal.eq norm_one
-@[simp] lemma enorm_one : ‖(1 : G)‖ₑ = 1 := by simp [enorm]
 
 theorem NormOneClass.nontrivial : Nontrivial G :=
   nontrivial_of_ne 0 1 <| ne_of_apply_ne norm <| by simp

--- a/Mathlib/Analysis/Normed/Field/Basic.lean
+++ b/Mathlib/Analysis/Normed/Field/Basic.lean
@@ -172,6 +172,7 @@ section SeminormedAddCommGroup
 variable [SeminormedAddCommGroup G] [One G] [NormOneClass G]
 
 @[simp] lemma nnnorm_one : ‖(1 : G)‖₊ = 1 := NNReal.eq norm_one
+@[simp] lemma enorm_one : ‖(1 : G)‖ₑ = 1 := by simp [enorm]
 
 theorem NormOneClass.nontrivial : Nontrivial G :=
   nontrivial_of_ne 0 1 <| ne_of_apply_ne norm <| by simp

--- a/Mathlib/Analysis/Normed/Group/Basic.lean
+++ b/Mathlib/Analysis/Normed/Group/Basic.lean
@@ -854,7 +854,10 @@ end NNNorm
 
 section ENorm
 
-@[to_additive (attr := simp) enorm_zero] lemma enorm_one' : ‖(1 : E)‖ₑ = 0 := by simp [enorm]
+@[to_additive (attr := simp)]
+lemma enorm_one {E : Type*} [TopologicalSpace E] [ENormedMonoid E] : ‖(1 : E)‖ₑ = 0 := by
+  rw [ENormedMonoid.enorm_eq_zero]
+@[deprecated (since := "2025-03-07")] alias enorm_one' := enorm_one
 
 @[to_additive (attr := simp) enorm_neg]
 lemma enorm_inv' (a : E) : ‖a⁻¹‖ₑ = ‖a‖ₑ := by simp [enorm]

--- a/Mathlib/Analysis/Normed/Group/Basic.lean
+++ b/Mathlib/Analysis/Normed/Group/Basic.lean
@@ -854,10 +854,9 @@ end NNNorm
 
 section ENorm
 
-@[to_additive (attr := simp)]
-lemma enorm_one {E : Type*} [TopologicalSpace E] [ENormedMonoid E] : ‖(1 : E)‖ₑ = 0 := by
+@[to_additive (attr := simp) enorm_zero]
+lemma enorm_one' {E : Type*} [TopologicalSpace E] [ENormedMonoid E] : ‖(1 : E)‖ₑ = 0 := by
   rw [ENormedMonoid.enorm_eq_zero]
-@[deprecated (since := "2025-03-07")] alias enorm_one' := enorm_one
 
 @[to_additive (attr := simp) enorm_neg]
 lemma enorm_inv' (a : E) : ‖a⁻¹‖ₑ = ‖a‖ₑ := by simp [enorm]

--- a/Mathlib/Analysis/NormedSpace/IndicatorFunction.lean
+++ b/Mathlib/Analysis/NormedSpace/IndicatorFunction.lean
@@ -15,10 +15,33 @@ This file contains a few simple lemmas about `Set.indicator`, `norm` and `enorm`
 indicator, norm
 -/
 
-
-variable {α E : Type*} [SeminormedAddCommGroup E] {s t : Set α} (f : α → E) (a : α)
-
 open Set
+
+section ENormedAddMonoid
+
+variable {α ε : Type*} [TopologicalSpace ε] [ENormedAddMonoid ε] {s t : Set α} (f : α → ε) (a : α)
+
+lemma enorm_indicator_eq_indicator_enorm :
+    ‖indicator s f a‖ₑ = indicator s (fun a => ‖f a‖ₑ) a :=
+  flip congr_fun a (indicator_comp_of_zero (enorm_zero (E := ε))).symm
+
+theorem enorm_indicator_le_of_subset (h : s ⊆ t) (f : α → ε) (a : α) :
+    ‖indicator s f a‖ₑ ≤ ‖indicator t f a‖ₑ := by
+  simp only [enorm_indicator_eq_indicator_enorm]
+  apply indicator_le_indicator_of_subset ‹_› (zero_le _)
+
+theorem indicator_enorm_le_enorm_self : indicator s (fun a => ‖f a‖ₑ) a ≤ ‖f a‖ₑ :=
+  indicator_le_self' (fun _ _ ↦ zero_le _) a
+
+theorem enorm_indicator_le_enorm_self : ‖indicator s f a‖ₑ ≤ ‖f a‖ₑ := by
+  rw [enorm_indicator_eq_indicator_enorm]
+  apply indicator_enorm_le_enorm_self
+
+end ENormedAddMonoid
+
+section SeminormedAddGroup
+
+variable {α E : Type*} [SeminormedAddGroup E] {s t : Set α} (f : α → E) (a : α)
 
 theorem norm_indicator_eq_indicator_norm : ‖indicator s f a‖ = indicator s (fun a => ‖f a‖) a :=
   flip congr_fun a (indicator_comp_of_zero norm_zero).symm
@@ -27,30 +50,16 @@ theorem nnnorm_indicator_eq_indicator_nnnorm :
     ‖indicator s f a‖₊ = indicator s (fun a => ‖f a‖₊) a :=
   flip congr_fun a (indicator_comp_of_zero nnnorm_zero).symm
 
-lemma enorm_indicator_eq_indicator_enorm :
-    ‖indicator s f a‖ₑ = indicator s (fun a => ‖f a‖ₑ) a :=
-  flip congr_fun a (indicator_comp_of_zero enorm_zero).symm
-
 theorem norm_indicator_le_of_subset (h : s ⊆ t) (f : α → E) (a : α) :
     ‖indicator s f a‖ ≤ ‖indicator t f a‖ := by
   simp only [norm_indicator_eq_indicator_norm]
   exact indicator_le_indicator_of_subset ‹_› (fun _ => norm_nonneg _) _
 
-theorem enorm_indicator_le_of_subset (h : s ⊆ t) (f : α → E) (a : α) :
-    ‖indicator s f a‖ₑ ≤ ‖indicator t f a‖ₑ := by
-  simp only [enorm_indicator_eq_indicator_enorm]
-  apply indicator_le_indicator_of_subset ‹_› (zero_le _)
-
 theorem indicator_norm_le_norm_self : indicator s (fun a => ‖f a‖) a ≤ ‖f a‖ :=
   indicator_le_self' (fun _ _ => norm_nonneg _) a
-
-theorem indicator_enorm_le_enorm_self : indicator s (fun a => ‖f a‖ₑ) a ≤ ‖f a‖ₑ :=
-  indicator_le_self' (fun _ _ ↦ zero_le _) a
 
 theorem norm_indicator_le_norm_self : ‖indicator s f a‖ ≤ ‖f a‖ := by
   rw [norm_indicator_eq_indicator_norm]
   apply indicator_norm_le_norm_self
 
-theorem enorm_indicator_le_enorm_self : ‖indicator s f a‖ₑ ≤ ‖f a‖ₑ := by
-  rw [enorm_indicator_eq_indicator_enorm]
-  apply indicator_enorm_le_enorm_self
+end SeminormedAddGroup


### PR DESCRIPTION
and generalise `enorm_{zero,one}` to any ENormed{Add}Monoid. Cherry-picked from #21712.

Done as part of the Carleson project.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
