### PR TITLE
[Merged by Bors] - chore(LinearAlgebra/FreeModule): move instances downstream

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3714,6 +3714,7 @@ import Mathlib.LinearAlgebra.Dimension.RankNullity
 import Mathlib.LinearAlgebra.Dimension.StrongRankCondition
 import Mathlib.LinearAlgebra.Dimension.Torsion.Basic
 import Mathlib.LinearAlgebra.Dimension.Torsion.Finite
+import Mathlib.LinearAlgebra.DirectSum.Basis
 import Mathlib.LinearAlgebra.DirectSum.Finsupp
 import Mathlib.LinearAlgebra.DirectSum.TensorProduct
 import Mathlib.LinearAlgebra.Dual.Basis

--- a/Mathlib/Algebra/Algebra/Subalgebra/Centralizer.lean
+++ b/Mathlib/Algebra/Algebra/Subalgebra/Centralizer.lean
@@ -3,7 +3,7 @@ Copyright (c) 2024 Jujian Zhang. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jujian Zhang
 -/
-import Mathlib.LinearAlgebra.FreeModule.Basic
+import Mathlib.LinearAlgebra.TensorProduct.Basis
 import Mathlib.RingTheory.TensorProduct.Basic
 
 /-!

--- a/Mathlib/Algebra/Module/Presentation/Free.lean
+++ b/Mathlib/Algebra/Module/Presentation/Free.lean
@@ -5,6 +5,7 @@ Authors: Joël Riou
 -/
 
 import Mathlib.Algebra.Module.Presentation.Basic
+import Mathlib.LinearAlgebra.Finsupp.VectorSpace
 import Mathlib.LinearAlgebra.FreeModule.Basic
 import Mathlib.Logic.UnivLE
 

--- a/Mathlib/Algebra/Module/Projective.lean
+++ b/Mathlib/Algebra/Module/Projective.lean
@@ -6,6 +6,7 @@ Authors: Kevin Buzzard, Antoine Labelle
 import Mathlib.Algebra.Module.Defs
 import Mathlib.LinearAlgebra.Finsupp.SumProd
 import Mathlib.LinearAlgebra.FreeModule.Basic
+import Mathlib.LinearAlgebra.TensorProduct.Basis
 import Mathlib.LinearAlgebra.TensorProduct.Tower
 
 /-!

--- a/Mathlib/Analysis/Normed/Unbundled/FiniteExtension.lean
+++ b/Mathlib/Analysis/Normed/Unbundled/FiniteExtension.lean
@@ -7,6 +7,7 @@ import Mathlib.Analysis.Normed.Unbundled.AlgebraNorm
 import Mathlib.Analysis.Normed.Unbundled.SeminormFromBounded
 import Mathlib.Analysis.Normed.Unbundled.SmoothingSeminorm
 import Mathlib.LinearAlgebra.FiniteDimensional.Defs
+import Mathlib.LinearAlgebra.Finsupp.VectorSpace
 
 
 /-!

--- a/Mathlib/LinearAlgebra/Basis/Prod.lean
+++ b/Mathlib/LinearAlgebra/Basis/Prod.lean
@@ -6,6 +6,7 @@ Authors: Johannes Hölzl, Mario Carneiro, Alexander Bentkamp
 import Mathlib.LinearAlgebra.Prod
 import Mathlib.LinearAlgebra.Basis.Defs
 import Mathlib.LinearAlgebra.Finsupp.SumProd
+import Mathlib.LinearAlgebra.FreeModule.Basic
 
 /-!
 # Bases for the product of modules
@@ -91,5 +92,13 @@ theorem prod_apply (i) :
 end Prod
 
 end Basis
+
+namespace Free
+
+variable (R M N : Type*) [Semiring R] [AddCommMonoid M] [Module R M] [AddCommMonoid N] [Module R N]
+instance prod [Module.Free R M] [Module.Free R N] : Module.Free R (M × N) :=
+  .of_basis <| (Module.Free.chooseBasis R M).prod (Module.Free.chooseBasis R N)
+
+end Free
 
 end Module

--- a/Mathlib/LinearAlgebra/Basis/VectorSpace.lean
+++ b/Mathlib/LinearAlgebra/Basis/VectorSpace.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Mario Carneiro, Alexander Bentkamp
 -/
 import Mathlib.LinearAlgebra.FreeModule.Basic
+import Mathlib.LinearAlgebra.LinearIndependent.Lemmas
 import Mathlib.LinearAlgebra.LinearPMap
 import Mathlib.LinearAlgebra.Projection
 

--- a/Mathlib/LinearAlgebra/Dimension/Constructions.lean
+++ b/Mathlib/LinearAlgebra/Dimension/Constructions.lean
@@ -5,6 +5,7 @@ Authors: Mario Carneiro, Johannes Hölzl, Sander Dahmen, Kim Morrison, Chris Hug
 -/
 import Mathlib.Algebra.Algebra.Subalgebra.Lattice
 import Mathlib.LinearAlgebra.Dimension.Free
+import Mathlib.LinearAlgebra.TensorProduct.Basis
 
 /-!
 # Rank of various constructions

--- a/Mathlib/LinearAlgebra/Dimension/Constructions.lean
+++ b/Mathlib/LinearAlgebra/Dimension/Constructions.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Johannes Hölzl, Sander Dahmen, Kim Morrison, Chris Hughes, Anne Baanen
 -/
 import Mathlib.Algebra.Algebra.Subalgebra.Lattice
+import Mathlib.LinearAlgebra.Basis.Prod
 import Mathlib.LinearAlgebra.Dimension.Free
 import Mathlib.LinearAlgebra.TensorProduct.Basis
 

--- a/Mathlib/LinearAlgebra/Dimension/Free.lean
+++ b/Mathlib/LinearAlgebra/Dimension/Free.lean
@@ -3,9 +3,7 @@ Copyright (c) 2021 Riccardo Brasca. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Riccardo Brasca
 -/
-import Mathlib.LinearAlgebra.Basis.Defs
 import Mathlib.LinearAlgebra.Dimension.StrongRankCondition
-import Mathlib.LinearAlgebra.FreeModule.Basic
 import Mathlib.LinearAlgebra.FreeModule.Finite.Basic
 import Mathlib.RingTheory.AlgebraTower
 import Mathlib.SetTheory.Cardinal.Finsupp
@@ -26,7 +24,7 @@ noncomputable section
 
 universe u v v' w
 
-open Cardinal Basis Submodule Function Set DirectSum Module
+open Cardinal Basis Submodule Function Set Module
 
 section Tower
 

--- a/Mathlib/LinearAlgebra/DirectSum/Basis.lean
+++ b/Mathlib/LinearAlgebra/DirectSum/Basis.lean
@@ -3,7 +3,7 @@ Copyright (c) 2021 Riccardo Brasca. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Riccardo Brasca
 -/
-import Mathlib.LinearAlgebra.TensorProduct.Basis
+import Mathlib.Algebra.DirectSum.Module
 import Mathlib.LinearAlgebra.Finsupp.VectorSpace
 
 /-!

--- a/Mathlib/LinearAlgebra/DirectSum/Basis.lean
+++ b/Mathlib/LinearAlgebra/DirectSum/Basis.lean
@@ -1,0 +1,30 @@
+/-
+Copyright (c) 2021 Riccardo Brasca. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Riccardo Brasca
+-/
+import Mathlib.LinearAlgebra.TensorProduct.Basis
+import Mathlib.LinearAlgebra.Finsupp.VectorSpace
+
+/-!
+# Bases for direct sum of modules
+
+This file defines a `Module.Free` instance for the direct sum of modules.
+
+## Implementation notes
+
+Currently, to get a basis on `⨁ i, M i` from a basis on each `M i`, use `DFinsupp.basis`
+(using that the types are defeq).
+-/
+
+open DirectSum
+
+section Semiring
+
+variable (R : Type*) [Semiring R] {ι : Type*} (M : ι → Type*) [∀ i : ι, AddCommMonoid (M i)]
+variable [∀ i : ι, Module R (M i)]
+
+instance Module.Free.directSum [∀ i : ι, Module.Free R (M i)] : Module.Free R (⨁ i, M i) :=
+  Module.Free.dfinsupp R M
+
+end Semiring

--- a/Mathlib/LinearAlgebra/Finsupp/VectorSpace.lean
+++ b/Mathlib/LinearAlgebra/Finsupp/VectorSpace.lean
@@ -3,9 +3,10 @@ Copyright (c) 2019 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl
 -/
+import Mathlib.LinearAlgebra.Basis.Defs
 import Mathlib.LinearAlgebra.DFinsupp
 import Mathlib.LinearAlgebra.Finsupp.Span
-import Mathlib.LinearAlgebra.Basis.Defs
+import Mathlib.LinearAlgebra.FreeModule.Basic
 
 /-!
 # Linear structures on function with finite support `ι →₀ M`
@@ -112,7 +113,11 @@ theorem coe_basis {φ : ι → Type*} (b : ∀ i, Basis (φ i) R M) :
         -- Porting note: previously `this` not needed
         simp only [basis_repr, single_apply, h, this, if_false, LinearEquiv.map_zero, zero_apply]
 
-/-- The basis on `ι →₀ M` with basis vectors `fun i ↦ single i 1`. -/
+variable (ι R M) in
+instance _root_.Module.Free.finsupp [Module.Free R M] : Module.Free R (ι →₀ M) :=
+  .of_basis (Finsupp.basis fun _ => Module.Free.chooseBasis R M)
+
+/-- The basis on `ι →₀ R` with basis vectors `fun i ↦ single i 1`. -/
 @[simps]
 protected def basisSingleOne : Basis ι R (ι →₀ R) :=
   Basis.ofRepr (LinearEquiv.refl _ _)
@@ -136,6 +141,10 @@ noncomputable def basis {η : ι → Type*} (b : ∀ i, Basis (η i) R (M i)) :
     Basis (Σi, η i) R (Π₀ i, M i) :=
   .ofRepr
     ((mapRange.linearEquiv fun i => (b i).repr).trans (sigmaFinsuppLequivDFinsupp R).symm)
+
+variable (R M) in
+instance _root_.Module.Free.dfinsupp [∀ i : ι, Module.Free R (M i)] : Module.Free R (Π₀ i, M i) :=
+  .of_basis <| DFinsupp.basis fun i => Module.Free.chooseBasis R (M i)
 
 end DFinsupp
 

--- a/Mathlib/LinearAlgebra/FreeModule/Basic.lean
+++ b/Mathlib/LinearAlgebra/FreeModule/Basic.lean
@@ -4,10 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Riccardo Brasca
 -/
 import Mathlib.Data.Finsupp.Fintype
-import Mathlib.Data.Matrix.Defs
 import Mathlib.LinearAlgebra.Basis.Basic
 import Mathlib.LinearAlgebra.Basis.Prod
-import Mathlib.LinearAlgebra.StdBasis
 import Mathlib.Logic.Small.Basic
 
 /-!
@@ -23,6 +21,8 @@ module.
 
 * `Module.Free R M` : the class of free `R`-modules.
 -/
+
+assert_not_exists DirectSum TensorProduct
 
 universe u v w z
 
@@ -150,26 +150,7 @@ instance self : Module.Free R R :=
 instance prod [Module.Free R N] : Module.Free R (M × N) :=
   of_basis <| (chooseBasis R M).prod (chooseBasis R N)
 
-/-- The product of finitely many free modules is free. -/
-instance pi (M : ι → Type*) [Finite ι] [∀ i : ι, AddCommMonoid (M i)] [∀ i : ι, Module R (M i)]
-    [∀ i : ι, Module.Free R (M i)] : Module.Free R (∀ i, M i) :=
-  let ⟨_⟩ := nonempty_fintype ι
-  of_basis <| Pi.basis fun i => chooseBasis R (M i)
-
-/-- The module of finite matrices is free. -/
-instance matrix {m n : Type*} [Finite m] [Finite n] : Module.Free R (Matrix m n M) :=
-  Module.Free.pi R _
-
 instance ulift [Free R M] : Free R (ULift M) := of_equiv ULift.moduleEquiv.symm
-
-variable (ι)
-
-/-- The product of finitely many free modules is free (non-dependent version to help with typeclass
-search). -/
-instance function [Finite ι] : Module.Free R (ι → M) :=
-  Free.pi _ _
-
-variable {ι}
 
 instance (priority := 100) of_subsingleton [Subsingleton N] : Module.Free R N :=
   of_basis.{u,z,z} (Basis.empty N : Basis PEmpty R N)

--- a/Mathlib/LinearAlgebra/FreeModule/Basic.lean
+++ b/Mathlib/LinearAlgebra/FreeModule/Basic.lean
@@ -7,9 +7,8 @@ import Mathlib.Data.Finsupp.Fintype
 import Mathlib.Data.Matrix.Defs
 import Mathlib.LinearAlgebra.Basis.Basic
 import Mathlib.LinearAlgebra.Basis.Prod
-import Mathlib.LinearAlgebra.TensorProduct.Basis
-import Mathlib.Logic.Small.Basic
 import Mathlib.LinearAlgebra.StdBasis
+import Mathlib.Logic.Small.Basic
 
 /-!
 # Free modules
@@ -25,12 +24,9 @@ module.
 * `Module.Free R M` : the class of free `R`-modules.
 -/
 
-
 universe u v w z
 
 variable {ι : Type*} (R : Type u) (M : Type v) (N : Type z)
-
-open TensorProduct DirectSum
 
 section Basic
 
@@ -173,9 +169,6 @@ search). -/
 instance function [Finite ι] : Module.Free R (ι → M) :=
   Free.pi _ _
 
-instance finsupp : Module.Free R (ι →₀ M) :=
-  of_basis (Finsupp.basis fun _ => chooseBasis R M)
-
 variable {ι}
 
 instance (priority := 100) of_subsingleton [Subsingleton N] : Module.Free R N :=
@@ -185,28 +178,7 @@ instance (priority := 100) of_subsingleton' [Subsingleton R] : Module.Free R N :
   letI := Module.subsingleton R N
   Module.Free.of_subsingleton R N
 
-instance dfinsupp {ι : Type*} (M : ι → Type*) [∀ i : ι, AddCommMonoid (M i)]
-    [∀ i : ι, Module R (M i)] [∀ i : ι, Module.Free R (M i)] : Module.Free R (Π₀ i, M i) :=
-  of_basis <| DFinsupp.basis fun i => chooseBasis R (M i)
-
-instance directSum {ι : Type*} (M : ι → Type*) [∀ i : ι, AddCommMonoid (M i)]
-    [∀ i : ι, Module R (M i)] [∀ i : ι, Module.Free R (M i)] : Module.Free R (⨁ i, M i) :=
-  Module.Free.dfinsupp R M
-
 end Semiring
-
-section CommSemiring
-
-variable {S} [CommSemiring R] [Semiring S] [Algebra R S] [AddCommMonoid M] [Module R M]
-  [Module S M] [IsScalarTower R S M] [Module.Free S M]
-  [AddCommMonoid N] [Module R N] [Module.Free R N]
-
-instance tensor : Module.Free S (M ⊗[R] N) :=
-  let ⟨bM⟩ := exists_basis (R := S) (M := M)
-  let ⟨bN⟩ := exists_basis (R := R) (M := N)
-  of_basis (bM.2.tensorProduct bN.2)
-
-end CommSemiring
 
 end Module.Free
 

--- a/Mathlib/LinearAlgebra/FreeModule/Basic.lean
+++ b/Mathlib/LinearAlgebra/FreeModule/Basic.lean
@@ -3,9 +3,9 @@ Copyright (c) 2021 Riccardo Brasca. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Riccardo Brasca
 -/
+import Mathlib.Algebra.Algebra.Basic
 import Mathlib.Data.Finsupp.Fintype
 import Mathlib.LinearAlgebra.Basis.Basic
-import Mathlib.LinearAlgebra.Basis.Prod
 import Mathlib.Logic.Small.Basic
 
 /-!
@@ -22,7 +22,7 @@ module.
 * `Module.Free R M` : the class of free `R`-modules.
 -/
 
-assert_not_exists DirectSum TensorProduct
+assert_not_exists DirectSum Matrix TensorProduct
 
 universe u v w z
 
@@ -146,9 +146,6 @@ variable (R M N)
 /-- The module structure provided by `Semiring.toModule` is free. -/
 instance self : Module.Free R R :=
   of_basis (Basis.singleton Unit R)
-
-instance prod [Module.Free R N] : Module.Free R (M × N) :=
-  of_basis <| (chooseBasis R M).prod (chooseBasis R N)
 
 instance ulift [Free R M] : Free R (ULift M) := of_equiv ULift.moduleEquiv.symm
 

--- a/Mathlib/LinearAlgebra/Matrix/StdBasis.lean
+++ b/Mathlib/LinearAlgebra/Matrix/StdBasis.lean
@@ -50,3 +50,13 @@ theorem stdBasis_eq_stdBasisMatrix (i : m) (j : n) [DecidableEq m] [DecidableEq 
   simp [stdBasis, stdBasisMatrix_eq_of_single_single]
 
 end Matrix
+
+namespace Module.Free
+
+variable (R M : Type*) [Semiring R] [AddCommMonoid M] [Module R M] [Module.Free R M]
+
+/-- The module of finite matrices is free. -/
+instance matrix {m n : Type*} [Finite m] [Finite n] : Module.Free R (Matrix m n M) :=
+  Module.Free.pi R _
+
+end Module.Free

--- a/Mathlib/LinearAlgebra/StdBasis.lean
+++ b/Mathlib/LinearAlgebra/StdBasis.lean
@@ -3,8 +3,8 @@ Copyright (c) 2017 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl
 -/
-import Mathlib.LinearAlgebra.Basis.Defs
 import Mathlib.LinearAlgebra.Finsupp.SumProd
+import Mathlib.LinearAlgebra.FreeModule.Basic
 import Mathlib.LinearAlgebra.LinearIndependent.Lemmas
 import Mathlib.LinearAlgebra.Pi
 
@@ -174,3 +174,21 @@ lemma piEquiv_apply_apply (ι R M : Type*) [Fintype ι] [CommSemiring R]
   rw [← LinearMap.range_eq_top, range_piEquiv]
 
 end Module
+
+namespace Module.Free
+
+variable {ι : Type*} (R : Type*) (M : Type*) [Semiring R] [AddCommMonoid M] [Module R M]
+
+/-- The product of finitely many free modules is free. -/
+instance _root_.Module.Free.pi (M : ι → Type*) [Finite ι] [∀ i : ι, AddCommMonoid (M i)]
+    [∀ i : ι, Module R (M i)] [∀ i : ι, Module.Free R (M i)] : Module.Free R (∀ i, M i) :=
+  let ⟨_⟩ := nonempty_fintype ι
+  .of_basis <| Pi.basis fun i => Module.Free.chooseBasis R (M i)
+
+variable (ι) in
+/-- The product of finitely many free modules is free (non-dependent version to help with typeclass
+search). -/
+instance _root_.Module.Free.function [Finite ι] [Module.Free R M] : Module.Free R (ι → M) :=
+  Free.pi _ _
+
+end Module.Free

--- a/Mathlib/LinearAlgebra/TensorProduct/Basis.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Basis.lean
@@ -6,12 +6,13 @@ Authors: Jakob von Raumer
 import Mathlib.LinearAlgebra.Basis.Basic
 import Mathlib.LinearAlgebra.DirectSum.Finsupp
 import Mathlib.LinearAlgebra.Finsupp.VectorSpace
+import Mathlib.LinearAlgebra.FreeModule.Basic
 
 /-!
 # Bases and dimensionality of tensor products of modules
 
-These can not go into `LinearAlgebra.TensorProduct` since they depend on
-`LinearAlgebra.FinsuppVectorSpace` which in turn imports `LinearAlgebra.TensorProduct`.
+This file defines various bases on the tensor product of modules,
+and shows that the tensor product of free modules is again free.
 -/
 
 
@@ -172,6 +173,14 @@ lemma TensorProduct.sum_tmul_basis_left_eq_zero
   (TensorProduct.equivFinsuppOfBasisLeft ℬ).symm.injective (a₂ := 0) <| by simpa
 
 end
+
+variable {S} [CommSemiring R] [Semiring S] [Algebra R S] [AddCommMonoid M] [Module R M]
+  [Module S M] [IsScalarTower R S M] [Module.Free S M]
+  [AddCommMonoid N] [Module R N] [Module.Free R N]
+instance Module.Free.tensor : Module.Free S (M ⊗[R] N) :=
+  let ⟨bM⟩ := exists_basis (R := S) (M := M)
+  let ⟨bN⟩ := exists_basis (R := R) (M := N)
+  of_basis (bM.2.tensorProduct bN.2)
 
 end CommSemiring
 

--- a/Mathlib/RingTheory/TensorProduct/Free.lean
+++ b/Mathlib/RingTheory/TensorProduct/Free.lean
@@ -3,16 +3,17 @@ Copyright (c) 2020 Kim Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kim Morrison, Johan Commelin
 -/
+import Mathlib.LinearAlgebra.DirectSum.Finsupp
+import Mathlib.LinearAlgebra.Finsupp.Pi
 import Mathlib.LinearAlgebra.FreeModule.Basic
 import Mathlib.LinearAlgebra.Matrix.ToLin
 import Mathlib.RingTheory.TensorProduct.Basic
-import Mathlib.LinearAlgebra.Finsupp.Pi
 
 /-!
 # Results on bases of tensor products
 
 In the file we construct a basis for the base change of a module to an algebra,
-and deducde that `Module.Free` is stable under base change.
+and deduce that `Module.Free` is stable under base change.
 
 ## Main declarations
 


### PR DESCRIPTION
I would like that `Module.Free` is as primitive as `Basis` itself. So let's reorder the import direction so specific vector spaces import `FreeModule.Basic` alongside `Basis.Defs`. This leads to small bumps in the files, but a lot of downstream improvement too.

---

- [x] depends on: #22066

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
