### PR TITLE
[Merged by Bors] - chore(Topology/UniformSpace): place SymmetricRel -> IsSymmetricRel deprecations

### DIFF
--- a/Mathlib/Dynamics/TopologicalEntropy/DynamicalEntourage.lean
+++ b/Mathlib/Dynamics/TopologicalEntropy/DynamicalEntourage.lean
@@ -76,6 +76,9 @@ lemma _root_.IsSymmetricRel.dynEntourage (T : X → X) {U : Set (X × X)}
   refine forall₂_congr fun k _ ↦ ?_
   exact map_apply' _ _ _ ▸ IsSymmetricRel.mk_mem_comm h
 
+@[deprecated (since := "2025-03-05")]
+alias _root_.SymmetricRel.dynEntourage := _root_.IsSymmetricRel.dynEntourage
+
 lemma dynEntourage_comp_subset (T : X → X) (U V : Set (X × X)) (n : ℕ) :
     (dynEntourage T U n) ○ (dynEntourage T V n) ⊆ dynEntourage T (U ○ V) n := by
   simp only [dynEntourage, map_iterate, subset_iInter_iff]

--- a/Mathlib/Topology/UniformSpace/Defs.lean
+++ b/Mathlib/Topology/UniformSpace/Defs.lean
@@ -208,6 +208,9 @@ theorem subset_iterate_compRel {s t : Set (α × α)} (h : idRel ⊆ s) (n : ℕ
 def IsSymmetricRel (V : Set (α × α)) : Prop :=
   Prod.swap ⁻¹' V = V
 
+@[deprecated (since := "2025-03-05")]
+alias SymmetricRel := IsSymmetricRel
+
 /-- The maximal symmetric relation contained in a given relation. -/
 def symmetrizeRel (V : Set (α × α)) : Set (α × α) :=
   V ∩ Prod.swap ⁻¹' V
@@ -226,11 +229,20 @@ theorem IsSymmetricRel.mk_mem_comm {V : Set (α × α)} (hV : IsSymmetricRel V) 
     (x, y) ∈ V ↔ (y, x) ∈ V :=
   Set.ext_iff.1 hV (y, x)
 
+@[deprecated (since := "2025-03-05")]
+alias SymmetricRel.mk_mem_comm := IsSymmetricRel.mk_mem_comm
+
 theorem IsSymmetricRel.eq {U : Set (α × α)} (hU : IsSymmetricRel U) : Prod.swap ⁻¹' U = U :=
   hU
 
+@[deprecated (since := "2025-03-05")]
+alias SymmetricRel.eq := IsSymmetricRel.eq
+
 theorem IsSymmetricRel.inter {U V : Set (α × α)} (hU : IsSymmetricRel U) (hV : IsSymmetricRel V) :
     IsSymmetricRel (U ∩ V) := by rw [IsSymmetricRel, preimage_inter, hU.eq, hV.eq]
+
+@[deprecated (since := "2025-03-05")]
+alias SymmetricRel.inter := IsSymmetricRel.inter
 
 /-- This core description of a uniform space is outside of the type class hierarchy. It is useful
   for constructions of uniform spaces, when the topology is derived from the uniform space. -/


### PR DESCRIPTION
follow up to #22594 -- in the previous PR, `SymmetricRel` was renamed to `IsSymmetricRel`, but was merged before deprecations could be added


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
