### PR TITLE
[Merged by Bors] - fix: prevent probability notation clashing with list notation

### DIFF
--- a/Mathlib/MeasureTheory/Function/ConditionalExpectation/Basic.lean
+++ b/Mathlib/MeasureTheory/Function/ConditionalExpectation/Basic.lean
@@ -82,8 +82,9 @@ variable [NormedAddCommGroup E] [NormedSpace ℝ E] [CompleteSpace E]
 
 open scoped Classical in
 variable (m) in
-/-- Conditional expectation of a function. It is defined as 0 if any one of the following conditions
-is true:
+/-- Conditional expectation of a function, with notation `μ[f|m]`.
+
+It is defined as 0 if any one of the following conditions is true:
 - `m` is not a sub-σ-algebra of `m₀`,
 - `μ` is not σ-finite with respect to `m`,
 - `f` is not integrable. -/
@@ -97,8 +98,20 @@ noncomputable irreducible_def condExp (μ : Measure[m₀] α) (f : α → E) : �
 
 @[deprecated (since := "2025-01-21")] alias condexp := condExp
 
--- We define notation `μ[f|m]` for the conditional expectation of `f` with respect to `m`.
-@[inherit_doc] scoped notation μ "[" f "|" m "]" => MeasureTheory.condExp m μ f
+@[inherit_doc MeasureTheory.condExp]
+scoped macro:max μ:term noWs "[" f:term "|" m:term "]" : term =>
+  `(MeasureTheory.condExp $m $μ $f)
+
+/-- Unexpander for `μ[f|m]` notation. -/
+@[app_unexpander MeasureTheory.condExp]
+def condExpUnexpander : Lean.PrettyPrinter.Unexpander
+  | `($_ $m $μ $f) => `($μ[$f|$m])
+  | _ => throw ()
+
+/-- info: μ[f|m] : α → E -/
+#guard_msgs in #check μ[f | m]
+/-- info: μ[f|m] sorry : E -/
+#guard_msgs in #check μ[f | m] (sorry : α)
 
 theorem condExp_of_not_le (hm_not : ¬m ≤ m₀) : μ[f|m] = 0 := by rw [condExp, dif_neg hm_not]
 

--- a/Mathlib/Probability/ConditionalProbability.lean
+++ b/Mathlib/Probability/ConditionalProbability.lean
@@ -70,32 +70,75 @@ and scaled by the inverse of `μ s` (to make it a probability measure):
 def cond (s : Set Ω) : Measure Ω :=
   (μ s)⁻¹ • μ.restrict s
 
-@[inherit_doc] scoped notation:max μ "[|" s "]" => ProbabilityTheory.cond μ s
-@[inherit_doc cond] scoped notation3:max μ "[" t " | " s "]" => ProbabilityTheory.cond μ s t
+@[inherit_doc ProbabilityTheory.cond]
+scoped macro:max μ:term noWs "[|" s:term "]" : term =>
+  `(ProbabilityTheory.cond $μ $s)
+@[inherit_doc cond]
+scoped macro:max μ:term noWs "[" t:term " | " s:term "]" : term =>
+  `(ProbabilityTheory.cond $μ $s $t)
+
+/-!
+We can't use `notation` or `notation3` as it does not support `noWs`, and so we have to write
+our own delaborators.
+-/
+
+section delaborators
+open Lean PrettyPrinter.Delaborator SubExpr
+
+/-- Unexpander for `μ[|s]` notation. -/
+@[app_unexpander ProbabilityTheory.cond]
+def condUnexpander : Lean.PrettyPrinter.Unexpander
+  | `($_ $μ $s) => `($μ[|$s])
+  | _ => throw ()
+
+/-- info: μ[|s] : Measure Ω -/
+#guard_msgs in #check μ[|s]
+
+/-- Delaborator for `μ[t|s]` notation. -/
+@[app_delab DFunLike.coe]
+def delabCondApplied : Delab :=
+  whenNotPPOption getPPExplicit <| whenPPOption getPPNotation <| withOverApp 6 do
+    let e ← getExpr
+    guard <| e.isAppOfArity' ``DFunLike.coe 6
+    guard <| (e.getArg!' 4).isAppOf' ``ProbabilityTheory.cond
+    let t ← withAppArg delab
+    withAppFn <| withAppArg do
+      let μ ← withNaryArg 2 delab
+      let s ← withNaryArg 3 delab
+      `($μ[$t|$s])
+
+/-- info: μ[t | s] : ℝ≥0∞ -/
+#guard_msgs in #check μ[t | s]
+/-- info: μ[t | s] : ℝ≥0∞ -/
+#guard_msgs in #check μ[|s] t
+
+end delaborators
 
 /-- The conditional probability measure of measure `μ` on `{ω | X ω ∈ s}`.
 
 It is `μ` restricted to `{ω | X ω ∈ s}` and scaled by the inverse of `μ {ω | X ω ∈ s}`
 (to make it a probability measure): `(μ {ω | X ω ∈ s})⁻¹ • μ.restrict {ω | X ω ∈ s}`. -/
-scoped notation:max μ "[|" X " in " s "]" => μ[|X ⁻¹' s]
+scoped macro:max μ:term noWs "[|" X:term " in " s:term "]" : term => `($μ[|$X ⁻¹' $s])
 
 /-- The conditional probability measure of measure `μ` on set `{ω | X ω = x}`.
 
 It is `μ` restricted to `{ω | X ω = x}` and scaled by the inverse of `μ {ω | X ω = x}`
 (to make it a probability measure): `(μ {ω | X ω = x})⁻¹ • μ.restrict {ω | X ω = x}`. -/
-scoped notation:max μ "[" s " | "  X " in " t "]" => μ[s | X ⁻¹' t]
+scoped macro:max μ:term noWs "[" s:term " | " X:term " in " t:term "]" : term =>
+  `($μ[$s | $X ⁻¹' $t])
 
 /-- The conditional probability measure of measure `μ` on `{ω | X ω = x}`.
 
 It is `μ` restricted to `{ω | X ω = x}` and scaled by the inverse of `μ {ω | X ω = x}`
 (to make it a probability measure): `(μ {ω | X ω = x})⁻¹ • μ.restrict {ω | X ω = x}`. -/
-scoped notation:max μ "[|" X " ← " x "]" => μ[|X in {x}]
+scoped macro:max μ:term noWs "[|" X:term " ← " x:term "]" : term => `($μ[|$X in {$x:term}])
 
 /-- The conditional probability measure of measure `μ` on set `{ω | X ω = x}`.
 
 It is `μ` restricted to `{ω | X ω = x}` and scaled by the inverse of `μ {ω | X ω = x}`
 (to make it a probability measure): `(μ {ω | X ω = x})⁻¹ • μ.restrict {ω | X ω = x}`. -/
-scoped notation:max μ "[" s " | "  X " ← " x "]" => μ[s | X in {x}]
+scoped macro:max μ:term noWs "[" s:term " | " X:term " ← " x:term "]" : term =>
+  `($μ[$s | $X in {$x:term}])
 
 /-- The conditional probability measure of any measure on any set of finite positive measure
 is a probability measure. -/


### PR DESCRIPTION
[Zulip thread](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/List.20notation.20is.20broken.20by.20conditional.20probability/near/504149983).

This comes at the cost of losing the automatic delaborators, so we have to write them manually.

It follows on from #19900.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

The other notations did not have delaborators anyway, as can be seen with
```lean
import Mathlib

open MeasureTheory ProbabilityTheory

variable {Ω : Type*} {m : MeasurableSpace Ω} {μ : Measure Ω}
variable {s t : Set Ω} (o : Ω) (X : Ω → Ω)

#check μ[|s] -- notation
#check μ[t | s] -- notation
#check μ[t | X in s]
#check μ[| X in s]
#check μ[t | X ← o]
#check μ[| X ← o]
```
in the web editor
