### PR TITLE
[Merged by Bors] - chore: remove unused set_options

### DIFF
--- a/Mathlib/Algebra/Category/BialgebraCat/Monoidal.lean
+++ b/Mathlib/Algebra/Category/BialgebraCat/Monoidal.lean
@@ -61,6 +61,8 @@ noncomputable instance instMonoidalCategory : MonoidalCategory (BialgebraCat R) 
 /-- `forget₂ (BialgebraCat R) (AlgebraCat R)` as a monoidal functor. -/
 noncomputable instance : (forget₂ (BialgebraCat R) (AlgebraCat R)).Monoidal where
 
+#adaptation_note /-- nightly-2025-02-18: added `maxHeartbeats` --/
+set_option maxHeartbeats 400000 in
 /-- `forget₂ (BialgebraCat R) (CoalgebraCat R)` as a monoidal functor. -/
 noncomputable instance : (forget₂ (BialgebraCat R) (CoalgebraCat R)).Monoidal :=
   Functor.CoreMonoidal.toMonoidal {

--- a/Mathlib/Algebra/Category/BialgebraCat/Monoidal.lean
+++ b/Mathlib/Algebra/Category/BialgebraCat/Monoidal.lean
@@ -61,8 +61,6 @@ noncomputable instance instMonoidalCategory : MonoidalCategory (BialgebraCat R) 
 /-- `forget₂ (BialgebraCat R) (AlgebraCat R)` as a monoidal functor. -/
 noncomputable instance : (forget₂ (BialgebraCat R) (AlgebraCat R)).Monoidal where
 
-#adaptation_note /-- nightly-2025-02-18: added `maxHeartbeats` --/
-set_option maxHeartbeats 400000 in
 /-- `forget₂ (BialgebraCat R) (CoalgebraCat R)` as a monoidal functor. -/
 noncomputable instance : (forget₂ (BialgebraCat R) (CoalgebraCat R)).Monoidal :=
   Functor.CoreMonoidal.toMonoidal {

--- a/Mathlib/Algebra/Category/Ring/Adjunctions.lean
+++ b/Mathlib/Algebra/Category/Ring/Adjunctions.lean
@@ -91,9 +91,6 @@ instance : HasForget₂ CommRingCat CommMonCat where
   forget₂ := { obj M := .of M, map f := CommMonCat.ofHom f.hom }
   forget_comp := rfl
 
-#adaptation_note /-- nightly-2025-02-12
-This apparently became slower. (Possibly due to changes in `simp +arith`?) -/
-set_option maxHeartbeats 400000 in
 /-- The adjunction `G ↦ R[G]` and `S ↦ S` between `CommGrp` and `R-Alg`. -/
 def monoidAlgebraAdj (R : CommRingCat.{u}) :
     monoidAlgebra R ⊣ Under.forget R ⋙ forget₂ _ _ where

--- a/Mathlib/Analysis/InnerProductSpace/PiL2.lean
+++ b/Mathlib/Analysis/InnerProductSpace/PiL2.lean
@@ -118,7 +118,6 @@ macro_rules | `(!$p:subscript[$e:term,*]) => do
   let n := e.getElems.size
   `((WithLp.equiv $p <| ∀ _ : Fin $(quote n), _).symm ![$e,*])
 
-set_option trace.debug true in
 /-- Unexpander for the `!₂[x, y, ...]` notation. -/
 @[app_delab DFunLike.coe]
 def EuclideanSpace.delabVecNotation : Delab :=

--- a/Mathlib/Analysis/SpecialFunctions/BinaryEntropy.lean
+++ b/Mathlib/Analysis/SpecialFunctions/BinaryEntropy.lean
@@ -168,7 +168,6 @@ This is due to definition of `Real.log` for negative numbers. -/
   simp only [log_inv, mul_neg]
   fun_prop (disch := assumption)
 
-set_option push_neg.use_distrib true in
 lemma differentiableAt_binEntropy_iff_ne_zero_one :
     DifferentiableAt ℝ binEntropy p ↔ p ≠ 0 ∧ p ≠ 1 := by
   refine ⟨fun h ↦ ⟨?_, ?_⟩, fun h ↦ differentiableAt_binEntropy h.1 h.2⟩

--- a/Mathlib/NumberTheory/FactorisationProperties.lean
+++ b/Mathlib/NumberTheory/FactorisationProperties.lean
@@ -78,7 +78,6 @@ theorem abundant_twelve : Abundant 12 := by
   rw [Abundant, show properDivisors 12 = {1,2,3,4,6} by rfl]
   norm_num
 
-set_option maxRecDepth 1730 in
 theorem weird_seventy : Weird 70 := by
   rw [Weird, Abundant, not_pseudoperfect_iff_forall]
   have h : properDivisors 70 = {1, 2, 5, 7, 10, 14, 35} := by rfl

--- a/Mathlib/Order/Category/BoolAlg.lean
+++ b/Mathlib/Order/Category/BoolAlg.lean
@@ -176,9 +176,6 @@ def dual : BoolAlg ⥤ BoolAlg where
   obj X := of Xᵒᵈ
   map f := ofHom f.hom.dual
 
-#adaptation_note /-- nightly-2025-02-12
-This apparently became slower. (Possibly due to changes in `simp +arith`?) -/
-set_option maxHeartbeats 400000 in
 /-- The equivalence between `BoolAlg` and itself induced by `OrderDual` both ways. -/
 @[simps functor inverse]
 def dualEquiv : BoolAlg ≌ BoolAlg where

--- a/Mathlib/Order/Category/FinBddDistLat.lean
+++ b/Mathlib/Order/Category/FinBddDistLat.lean
@@ -173,9 +173,6 @@ def dual : FinBddDistLat ⥤ FinBddDistLat where
   obj X := of Xᵒᵈ
   map f := ofHom f.hom.dual
 
-#adaptation_note /-- nightly-2025-02-12
-This apparently became slower. (Possibly due to changes in `simp +arith`?) -/
-set_option maxHeartbeats 400000 in
 /-- The equivalence between `FinBddDistLat` and itself induced by `OrderDual` both ways. -/
 @[simps functor inverse]
 def dualEquiv : FinBddDistLat ≌ FinBddDistLat where

--- a/Mathlib/Order/Category/FinBoolAlg.lean
+++ b/Mathlib/Order/Category/FinBoolAlg.lean
@@ -97,10 +97,6 @@ def dual : FinBoolAlg ⥤ FinBoolAlg where
   obj X := of Xᵒᵈ
   map f := BoolAlg.ofHom f.hom.dual
 
-#adaptation_note /--
-sThis apparently became slower in nightly-2025-02-12. (Possibly due to changes in `simp +arith`?)
--/
-set_option maxHeartbeats 400000 in
 /-- The equivalence between `FinBoolAlg` and itself induced by `OrderDual` both ways. -/
 @[simps functor inverse]
 def dualEquiv : FinBoolAlg ≌ FinBoolAlg where

--- a/Mathlib/RingTheory/TensorProduct/Basic.lean
+++ b/Mathlib/RingTheory/TensorProduct/Basic.lean
@@ -1062,7 +1062,6 @@ theorem tensorTensorTensorComm_tmul (m : A) (n : B) (p : C) (q : D) :
     tensorTensorTensorComm R S A B C D (m ⊗ₜ n ⊗ₜ (p ⊗ₜ q)) = m ⊗ₜ p ⊗ₜ (n ⊗ₜ q) :=
   rfl
 
-set_option maxSynthPendingDepth 2 in
 @[simp]
 theorem tensorTensorTensorComm_symm_tmul (m : A) (n : C) (p : B) (q : D) :
     (tensorTensorTensorComm R S A B C D).symm (m ⊗ₜ n ⊗ₜ (p ⊗ₜ q)) = m ⊗ₜ p ⊗ₜ (n ⊗ₜ q) :=
@@ -1072,7 +1071,6 @@ theorem tensorTensorTensorComm_symm :
     (tensorTensorTensorComm R R A B C D).symm = tensorTensorTensorComm R R A C B D := by
   ext; rfl
 
-set_option maxSynthPendingDepth 2 in
 theorem tensorTensorTensorComm_toLinearEquiv :
     (tensorTensorTensorComm R S A B C D).toLinearEquiv =
       TensorProduct.AlgebraTensorModule.tensorTensorTensorComm R S A B C D := rfl

--- a/Mathlib/Topology/Separation/Regular.lean
+++ b/Mathlib/Topology/Separation/Regular.lean
@@ -449,7 +449,6 @@ instance (priority := 100) NormalSpace.of_compactSpace_r1Space [CompactSpace X] 
     NormalSpace X where
   normal _s _t hs ht := .of_isCompact_isCompact_isClosed hs.isCompact ht.isCompact ht
 
-set_option pp.universes true in
 /-- A regular topological space with a Lindelöf topology is a normal space. A consequence of e.g.
 Corollaries 20.8 and 20.10 of [Willard's *General Topology*][zbMATH02107988] (without the
 assumption of Hausdorff). -/


### PR DESCRIPTION
Found by #13653.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
