### PR TITLE
[Merged by Bors] - chore: fix factual inaccuracy in the `Data.Set.Basic` module doc

### DIFF
--- a/Mathlib/Data/Set/Basic.lean
+++ b/Mathlib/Data/Set/Basic.lean
@@ -16,10 +16,10 @@ import Mathlib.Tactic.Lift
 
 Sets in Lean are homogeneous; all their elements have the same type. Sets whose elements
 have type `X` are thus defined as `Set X := X → Prop`. Note that this function need not
-be decidable. The definition is in the core library.
+be decidable. The definition is in the module `Mathlib.Data.Set.Defs`.
 
-This file provides some basic definitions related to sets and functions not present in the core
-library, as well as extra lemmas for functions in the core library (empty set, univ, union,
+This file provides some basic definitions related to sets and functions not present in the
+definitions file, as well as extra lemmas for functions in the core library (empty set, univ, union,
 intersection, insert, singleton, set-theoretic difference, complement, and powerset).
 
 Note that a set is a term, not a type. There is a coercion from `Set α` to `Type*` sending

--- a/Mathlib/Data/Set/Basic.lean
+++ b/Mathlib/Data/Set/Basic.lean
@@ -19,8 +19,9 @@ have type `X` are thus defined as `Set X := X → Prop`. Note that this function
 be decidable. The definition is in the module `Mathlib.Data.Set.Defs`.
 
 This file provides some basic definitions related to sets and functions not present in the
-definitions file, as well as extra lemmas for functions in the core library (empty set, univ, union,
-intersection, insert, singleton, set-theoretic difference, complement, and powerset).
+definitions file, as well as extra lemmas for functions defined in the definitions file and
+`Mathlib.Data.Set.Operations` (empty set, univ, union, intersection, insert, singleton,
+set-theoretic difference, complement, and powerset).
 
 Note that a set is a term, not a type. There is a coercion from `Set α` to `Type*` sending
 `s` to the corresponding subtype `↥s`.


### PR DESCRIPTION
The definition of `Set` is in mathlib, not in core.
