### PR TITLE
chore: attempt to resolve porting note 11039

### DIFF
--- a/Mathlib/RepresentationTheory/GroupCohomology/Basic.lean
+++ b/Mathlib/RepresentationTheory/GroupCohomology/Basic.lean
@@ -115,6 +115,14 @@ def d [Monoid G] (n : ℕ) (A : Rep k G) : ((Fin n → G) → A) →ₗ[k] (Fin 
 
 variable [Group G] (n) (A : Rep k G)
 
+@[simp]
+lemma resolution_X_V : ((resolution k G).X n).V = ((Fin (n + 1) → G) →₀ k) :=
+  rfl
+
+@[simp]
+lemma diagonal_V : (diagonal k G n).V = ((Fin n → G) →₀ k) :=
+  rfl
+
 /- Porting note: linter says the statement doesn't typecheck, so we add `@[nolint checkType]` -/
 /-- The theorem that our isomorphism `Fun(Gⁿ, A) ≅ Hom(k[Gⁿ⁺¹], A)` (where the righthand side is
 morphisms in `Rep k G`) commutes with the differentials in the complex of inhomogeneous cochains
@@ -144,22 +152,25 @@ and the homogeneous `linearYonedaObjResolution`. -/
       rw [diagonalHomEquiv_symm_partialProd_succ, Fin.val_succ] -/
   -- https://github.com/leanprover-community/mathlib4/issues/5026
   -- https://github.com/leanprover-community/mathlib4/issues/5164
+  simp only [LinearEquiv.toModuleIso_inv, ModuleCat.hom_comp, LinearEquiv.toModuleIso_hom,
+    ModuleCat.hom_ofHom, LinearMap.comp_apply, ChainComplex.linearYonedaObj_d]
   change d n A f g = diagonalHomEquiv (n + 1) A
     ((resolution k G).d (n + 1) n ≫ (diagonalHomEquiv n A).symm f) g
-  rw [diagonalHomEquiv_apply, Action.comp_hom, ConcreteCategory.comp_apply, resolution.d_eq]
-  erw [resolution.d_of (Fin.partialProd g)]
-  simp only [map_sum, ← Finsupp.smul_single_one _ ((-1 : k) ^ _)]
-  -- This used to be `rw`, but we need `erw` after https://github.com/leanprover/lean4/pull/2644
-  erw [d_apply, @Fin.sum_univ_succ _ _ (n + 1), Fin.val_zero, pow_zero, one_smul,
-    Fin.succAbove_zero, diagonalHomEquiv_symm_apply f (Fin.partialProd g ∘ @Fin.succ (n + 1))]
+  suffices (d n A) f g = (ConcreteCategory.hom ((diagonalHomEquiv n A).symm f).hom)
+    ((resolution.d k G (n + 1)) (Finsupp.single (Fin.partialProd g) 1)) by
+    simpa [diagonalHomEquiv_apply, resolution.d_eq]
+  rw [resolution.d_of (Fin.partialProd g), map_sum]
+  simp only [← Finsupp.smul_single_one _ ((-1 : k) ^ _)]
+  rw [Fin.sum_univ_succ, Fin.val_zero, pow_zero, Fin.succAbove_zero, one_smul,
+    diagonalHomEquiv_symm_apply f (Fin.partialProd g ∘ Fin.succ)]
   simp_rw [Function.comp_apply, Fin.partialProd_succ, Fin.castSucc_zero,
     Fin.partialProd_zero, one_mul]
+  rw [d_apply]
   rcongr x
   · have := Fin.partialProd_right_inv g (Fin.castSucc x)
     simp only [mul_inv_rev, Fin.castSucc_fin_succ] at this ⊢
     rw [mul_assoc, ← mul_assoc _ _ (g x.succ), this, inv_mul_cancel_left]
-  · -- This used to be `rw`, but we need `erw` after https://github.com/leanprover/lean4/pull/2644
-    erw [map_smul, diagonalHomEquiv_symm_partialProd_succ, Fin.val_succ]
+  · rw [map_smul, diagonalHomEquiv_symm_partialProd_succ f g x, Fin.val_succ]
 
 end inhomogeneousCochains
 

--- a/Mathlib/RepresentationTheory/GroupCohomology/Resolution.lean
+++ b/Mathlib/RepresentationTheory/GroupCohomology/Resolution.lean
@@ -121,9 +121,14 @@ theorem actionDiagonalSucc_hom_apply {G : Type u} [Group G] {n : ℕ} (f : Fin (
         Fin.insertNth_zero']
       refine' Fin.cases (Fin.cons_zero _ _) (fun i => _) x
       · simp only [Fin.cons_succ, mul_left_inj, inv_inj, Fin.castSucc_fin_succ] -/
-    dsimp [actionDiagonalSucc]
-    erw [hn (fun (j : Fin (n + 1)) => f j.succ)]
-    exact Fin.cases rfl (fun i => rfl) x
+    dsimp only [actionDiagonalSucc, Iso.trans_hom, tensorIso_hom, comp_hom,
+      instMonoidalCategory_tensorHom_hom, types_comp_apply, tensor_apply]
+    rw [hn]
+    refine Fin.cases ?_ (fun i ↦ ?_) x
+    · -- heavy rfl
+      rfl
+    · -- heavy rfl
+      rfl
 
 theorem actionDiagonalSucc_inv_apply {G : Type u} [Group G] {n : ℕ} (g : G) (f : Fin n → G) :
     (actionDiagonalSucc G n).inv.hom (g, f) = (g • Fin.partialProd f : Fin (n + 1) → G) := by


### PR DESCRIPTION

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
