### PR TITLE
[Merged by Bors] - feat(CategoryTheory): reversing the `liftToFinset` construction

### DIFF
--- a/Mathlib/CategoryTheory/Limits/Constructions/Filtered.lean
+++ b/Mathlib/CategoryTheory/Limits/Constructions/Filtered.lean
@@ -24,7 +24,7 @@ universe w v u
 
 noncomputable section
 
-open CategoryTheory
+open CategoryTheory Opposite
 
 variable {C : Type u} [Category.{v} C] {α : Type w}
 
@@ -52,7 +52,7 @@ def liftToFinsetColimitCocone [HasColimitsOfShape (Finset (Discrete α)) C]
     { pt := colimit (liftToFinsetObj F)
       ι :=
         Discrete.natTrans fun j =>
-          @Sigma.ι _ _ _ (fun x : ({j} : Finset (Discrete α)) => F.obj x) _ ⟨j, by simp⟩ ≫
+          Sigma.ι (fun x : ({j} : Finset (Discrete α)) => F.obj x) ⟨j, by simp⟩ ≫
             colimit.ι (liftToFinsetObj F) {j} }
   isColimit :=
     { desc := fun s =>
@@ -70,14 +70,37 @@ def liftToFinsetColimitCocone [HasColimitsOfShape (Finset (Discrete α)) C]
           rfl
         · simp }
 
-variable (C) (α)
-
+variable (C) (α) in
 /-- The functor taking a functor `Discrete α ⥤ C` to a functor `Finset (Discrete α) ⥤ C` by taking
 coproducts. -/
 @[simps!]
 def liftToFinset : (Discrete α ⥤ C) ⥤ (Finset (Discrete α) ⥤ C) where
   obj := liftToFinsetObj
   map := fun β => { app := fun _ => Sigma.map (fun x => β.app x.val) }
+
+/-- The converse of the construction in `liftToFinsetColimitCocone`: we can form a cocone on the
+coproduct of `f` whose legs are the coproducts over the finite subsets of `α`. -/
+@[simps!]
+def finiteSubcoproductsCocone (f : α → C) [HasCoproduct f] :
+    Cocone (liftToFinsetObj (Discrete.functor f)) where
+  pt := ∐ f
+  ι := { app S := Sigma.desc fun s => Sigma.ι f _ }
+
+/-- The cocone `finiteSubcoproductsCocone` is a colimit cocone. -/
+def isColimitFiniteSubproductsCocone (f : α → C) [HasColimitsOfShape (Finset (Discrete α)) C]
+    [HasCoproduct f] : IsColimit (finiteSubcoproductsCocone f) :=
+  IsColimit.ofIsoColimit (colimit.isColimit _)
+    (Cocones.ext (IsColimit.coconePointUniqueUpToIso
+      (liftToFinsetColimitCocone (Discrete.functor f)).isColimit (colimit.isColimit _) :) (by
+    intro S
+    simp only [liftToFinsetObj_obj, Discrete.functor_obj_eq_as, finiteSubcoproductsCocone_pt,
+      colimit.cocone_x, Functor.const_obj_obj, colimit.cocone_ι, finiteSubcoproductsCocone_ι_app]
+    ext j
+    rw [← Category.assoc]
+    convert IsColimit.comp_coconePointUniqueUpToIso_hom
+      (liftToFinsetColimitCocone (Discrete.functor f)).isColimit (colimit.isColimit _) j
+    · simp [← colimit.w (liftToFinsetObj _) (homOfLE (x := {j.1}) (y := S) (by simp))]
+    · simp))
 
 end CoproductsFromFiniteFiltered
 
@@ -181,6 +204,30 @@ def liftToFinsetLimitCone [HasLimitsOfShape (Finset (Discrete α))ᵒᵖ C]
         · simp [← limit.w (liftToFinsetObj F) ⟨⟨⟨Finset.singleton_subset_iff.2 hj⟩⟩⟩]
           rfl
         · simp }
+
+/-- The converse of the construction in `liftToFinsetLimitCone`: we can form a cone on the
+product of `f` whose legs are the products over the finite subsets of `α`. -/
+@[simps!]
+def finiteSubproductsCone (f : α → C) [HasProduct f] :
+    Cone (liftToFinsetObj (Discrete.functor f)) where
+  pt := ∏ᶜ f
+  π := { app S := Pi.lift fun s => Pi.π f _ }
+
+/-- The cone `finiteSubproductsCone` is a limit cone. -/
+def isLimitFiniteSubproductsCone (f : α → C) [HasLimitsOfShape (Finset (Discrete α))ᵒᵖ C]
+    [HasProduct f] : IsLimit (finiteSubproductsCone f) :=
+  IsLimit.ofIsoLimit (limit.isLimit _)
+    (Cones.ext (IsLimit.conePointUniqueUpToIso
+      (liftToFinsetLimitCone (Discrete.functor f)).isLimit (limit.isLimit _) :) (by
+    intro S
+    simp only [limit.cone_x, Functor.const_obj_obj, liftToFinsetObj_obj, Discrete.functor_obj_eq_as,
+      limit.cone_π, finiteSubproductsCone_pt, finiteSubproductsCone_π_app]
+    ext j
+    simp only [Discrete.functor_obj_eq_as, Category.assoc, limit.lift_π, Fan.mk_pt, Fan.mk_π_app,
+      limit.conePointUniqueUpToIso_hom_comp, liftToFinsetLimitCone_cone_pt, Discrete.mk_as,
+      liftToFinsetLimitCone_cone_π_app]
+    simp [← limit.w (liftToFinsetObj _)
+      (Quiver.Hom.op (homOfLE (x := {j.1}) (y := S.unop) (by simp)))]))
 
 variable (C) (α)
 


### PR DESCRIPTION
---



<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
