### PR TITLE
feat(ENat): some ENat API

### DIFF
--- a/Mathlib/Data/ENat/BigOperators.lean
+++ b/Mathlib/Data/ENat/BigOperators.lean
@@ -28,4 +28,12 @@ lemma sum_iSup_of_monotone {α ι : Type*} [Preorder ι] [IsDirected ι (· ≤ 
     {f : α → ι → ℕ∞} (hf : ∀ a, Monotone (f a)) : (∑ a ∈ s, iSup (f a)) = ⨆ n, ∑ a ∈ s, f a n :=
   sum_iSup fun i j ↦ (exists_ge_ge i j).imp fun _k ⟨hi, hj⟩ a ↦ ⟨hf a hi, hf a hj⟩
 
+@[simp]
+lemma toNat_prod {ι : Type*} (s : Finset ι) (f : ι → ℕ∞) :
+    (∏ i ∈ s, f i).toNat = ∏ i ∈ s, (f i).toNat := by
+  classical
+  induction s using Finset.induction_on with
+  | empty => simp
+  | @insert x s hxs ih => rw [Finset.prod_insert hxs, ENat.toNat_mul, Finset.prod_insert hxs, ih]
+
 end ENat

--- a/Mathlib/Data/ENat/Lattice.lean
+++ b/Mathlib/Data/ENat/Lattice.lean
@@ -3,9 +3,9 @@ Copyright (c) 2022 Yury Kudryashov. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury Kudryashov
 -/
+import Mathlib.Algebra.Group.Action.Defs
 import Mathlib.Data.Nat.Lattice
 import Mathlib.Data.ENat.Basic
-import Mathlib.Algebra.Group.Action.Defs
 
 /-!
 # Extended natural numbers form a complete linear order
@@ -59,6 +59,18 @@ lemma coe_iSup : BddAbove (range f) → ↑(⨆ i, f i) = ⨆ i, (f i : ℕ∞) 
 @[simp]
 lemma iInf_eq_top_of_isEmpty [IsEmpty ι] : ⨅ i, (f i : ℕ∞) = ⊤ :=
   iInf_coe_eq_top.mpr ‹_›
+
+lemma iSup_eq_top_iff {f : ι → ℕ∞} : ⨆ i, f i = ⊤ ↔ ∀ n : ℕ, ∃ i, n ≤ f i := by
+  refine (iSup_eq_top _).trans ⟨fun h n ↦ ?_, fun h n hn ↦ ?_⟩
+  · obtain ⟨a, ha⟩ := h n (by simp)
+    exact ⟨_, ha.le⟩
+  lift n to ℕ using hn.ne
+  obtain ⟨a, ha⟩ := h (n+1)
+  simp only [Nat.cast_add, Nat.cast_one, ← natCast_lt_iff] at ha
+  exact ⟨_, ha⟩
+
+lemma sSup_eq_top_iff {s : Set ℕ∞} : sSup s = ⊤ ↔ ∀ n : ℕ, ∃ x ∈ s, n ≤ x := by
+  simp [sSup_eq_iSup', iSup_eq_top_iff]
 
 lemma iInf_toNat : (⨅ i, (f i : ℕ∞)).toNat = ⨅ i, f i := by
   cases isEmpty_or_nonempty ι


### PR DESCRIPTION
WIP for the 'card without cardinal' refactor in #22615

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
