### PR TITLE
feat: enforce that Algebra.Notation imports no other files inside algebra

### DIFF
--- a/Mathlib/Tactic/Linter/Header.lean
+++ b/Mathlib/Tactic/Linter/Header.lean
@@ -291,8 +291,6 @@ def broadImportsCheck (imports : Array Syntax) (mainModule : Name) : CommandElab
         Linter.logLint linter.style.header i
           "Files inside the Algebra.Notation directory must not import Algebra files outside \
           of that directory"
-
-
 /-- Check the syntax `imports` for syntactically duplicate imports.
 The output is an array of `Syntax` atoms whose ranges are the import statements,
 and the embedded strings are the error message of the linter.

--- a/Mathlib/Tactic/Linter/Header.lean
+++ b/Mathlib/Tactic/Linter/Header.lean
@@ -256,8 +256,9 @@ register_option linter.style.header : Bool := {
 namespace Style.header
 
 /-- Check the `Syntax` `imports` for broad imports:
-`Mathlib.Tactic`, any import starting with `Lake`, `Mathlib.Tactic.{Have,Replace}`
-or anything in the `Deprecated` folder. -/
+`Mathlib.Tactic`, any import starting with `Lake`, `Mathlib.Tactic.{Have,Replace}` or
+anything in the `Deprecated` folder,
+as well as forbidden imports: `Algebra.Notation` must not import files in `Algebra.OtherDir`. -/
 def broadImportsCheck (imports : Array Syntax) (mainModule : Name) : CommandElabM Unit := do
   for i in imports do
     match i.getId with
@@ -284,6 +285,13 @@ def broadImportsCheck (imports : Array Syntax) (mainModule : Name) : CommandElab
         -- We do not complain about files in the `Deprecated` directory importing one another.
         Linter.logLint linter.style.header i
           "Files in the `Deprecated` directory are not supposed to be imported."
+      else if (`Mathlib.Algebra.Notation).isPrefixOf mainModule &&
+          (`Mathlib.Algebra).isPrefixOf modName &&
+          !(`Mathlib.Algebra.Notation).isPrefixOf modName then
+        Linter.logLint linter.style.header i
+          "Files inside the Algebra.Notation directory must not import Algebra files outside \
+          of that directory"
+
 
 /-- Check the syntax `imports` for syntactically duplicate imports.
 The output is an array of `Syntax` atoms whose ranges are the import statements,


### PR DESCRIPTION
by extending the broadImports check of the header linter accordingly.
This enforces some of the rules set in #22640.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
