### PR TITLE
[Merged by Bors] - style: fix some isolated where's

### DIFF
--- a/Mathlib/Algebra/Category/Grp/Limits.lean
+++ b/Mathlib/Algebra/Category/Grp/Limits.lean
@@ -323,8 +323,8 @@ instance hasLimitsOfShape [Small.{u} J] : HasLimitsOfShape J CommGrp.{u} where
 /-- The category of commutative groups has all limits. -/
 @[to_additive "The category of additive commutative groups has all limits.",
   to_additive_relevant_arg 2]
-instance hasLimitsOfSize [UnivLE.{v, u}] : HasLimitsOfSize.{w, v} CommGrp.{u}
-  where has_limits_of_shape _ _ := { }
+instance hasLimitsOfSize [UnivLE.{v, u}] : HasLimitsOfSize.{w, v} CommGrp.{u} where
+  has_limits_of_shape _ _ := { }
 
 @[to_additive]
 instance hasLimits : HasLimits CommGrp.{u} :=

--- a/Mathlib/Algebra/Module/Equiv/Basic.lean
+++ b/Mathlib/Algebra/Module/Equiv/Basic.lean
@@ -321,8 +321,7 @@ The `R`-linear equivalence between additive morphisms `A →+ B` and `ℕ`-linea
 -/
 @[simps]
 def addMonoidHomLequivNat {A B : Type*} (R : Type*) [Semiring R] [AddCommMonoid A]
-    [AddCommMonoid B] [Module R B] : (A →+ B) ≃ₗ[R] A →ₗ[ℕ] B
-    where
+    [AddCommMonoid B] [Module R B] : (A →+ B) ≃ₗ[R] A →ₗ[ℕ] B where
   toFun := AddMonoidHom.toNatLinearMap
   invFun := LinearMap.toAddMonoidHom
   map_add' _ _ := rfl
@@ -335,8 +334,7 @@ The `R`-linear equivalence between additive morphisms `A →+ B` and `ℤ`-linea
 -/
 @[simps]
 def addMonoidHomLequivInt {A B : Type*} (R : Type*) [Semiring R] [AddCommGroup A] [AddCommGroup B]
-    [Module R B] : (A →+ B) ≃ₗ[R] A →ₗ[ℤ] B
-    where
+    [Module R B] : (A →+ B) ≃ₗ[R] A →ₗ[ℤ] B where
   toFun := AddMonoidHom.toIntLinearMap
   invFun := LinearMap.toAddMonoidHom
   map_add' _ _ := rfl

--- a/Mathlib/Algebra/Star/NonUnitalSubsemiring.lean
+++ b/Mathlib/Algebra/Star/NonUnitalSubsemiring.lean
@@ -52,8 +52,8 @@ instance instSetLike : SetLike (NonUnitalStarSubsemiring R) R where
   coe {s} := s.carrier
   coe_injective' p q h := by cases p; cases q; congr; exact SetLike.coe_injective h
 
-instance instNonUnitalSubsemiringClass : NonUnitalSubsemiringClass (NonUnitalStarSubsemiring R) R
-    where
+instance instNonUnitalSubsemiringClass :
+    NonUnitalSubsemiringClass (NonUnitalStarSubsemiring R) R where
   add_mem {s} := s.add_mem'
   mul_mem {s} := s.mul_mem'
   zero_mem {s} := s.zero_mem'

--- a/Mathlib/Order/Chain.lean
+++ b/Mathlib/Order/Chain.lean
@@ -372,8 +372,7 @@ lemma mem_iff_forall_le_or_ge : a ∈ s ↔ ∀ ⦃b⦄, b ∈ s → a ≤ b ∨
         s.maxChain.2 (s.chain_le.insert fun c hc _ => hb hc) <| Set.subset_insert _ _⟩
 
 /-- Flags are preserved under order isomorphisms. -/
-def map (e : α ≃o β) : Flag α ≃ Flag β
-    where
+def map (e : α ≃o β) : Flag α ≃ Flag β where
   toFun s := ofIsMaxChain _ (s.maxChain.image e)
   invFun s := ofIsMaxChain _ (s.maxChain.image e.symm)
   left_inv s := ext <| e.symm_image_image s

--- a/Mathlib/Order/Monotone/MonovaryOrder.lean
+++ b/Mathlib/Order/Monotone/MonovaryOrder.lean
@@ -26,8 +26,7 @@ We define `i < j` if `f i < f j`, or if `f i = f j` and `g i < g j`, breaking ti
 def MonovaryOrder (i j : ι) : Prop :=
   Prod.Lex (· < ·) (Prod.Lex (· < ·) WellOrderingRel) (f i, g i, i) (f j, g j, j)
 
-instance : IsStrictTotalOrder ι (MonovaryOrder f g)
-    where
+instance : IsStrictTotalOrder ι (MonovaryOrder f g) where
   trichotomous i j := by
     convert trichotomous_of (Prod.Lex (· < ·) <| Prod.Lex (· < ·) WellOrderingRel) _ _
     · simp only [Prod.ext_iff, ← and_assoc, imp_and, eq_iff_iff, iff_and_self]

--- a/Mathlib/RingTheory/AdicCompletion/Exactness.lean
+++ b/Mathlib/RingTheory/AdicCompletion/Exactness.lean
@@ -151,21 +151,21 @@ include hfg in
 private noncomputable def mapExactAux :
     (n : ℕ) → { a : M | f a - x (k + n) ∈ (I ^ (k + n) • ⊤ : Submodule R N) }
   | .zero =>
-      let d := (h2 0).choose
-      let y := (h2 0).choose_spec.choose
-      have hdy : f y = x (k + 0) - d := (h2 0).choose_spec.choose_spec.right
-      have hdmem := (h2 0).choose_spec.choose_spec.left
-      ⟨y, by simpa [hdy]⟩
+    let d := (h2 0).choose
+    let y := (h2 0).choose_spec.choose
+    have hdy : f y = x (k + 0) - d := (h2 0).choose_spec.choose_spec.right
+    have hdmem := (h2 0).choose_spec.choose_spec.left
+    ⟨y, by simpa [hdy]⟩
   | .succ n =>
-      let d := (h2 <| n + 1).choose
-      let y := (h2 <| n + 1).choose_spec.choose
-      have hdy : f y = x (k + (n + 1)) - d := (h2 <| n + 1).choose_spec.choose_spec.right
-      have hdmem := (h2 <| n + 1).choose_spec.choose_spec.left
-      let ⟨yₙ, (hyₙ : f yₙ - x (k + n) ∈ (I ^ (k + n) • ⊤ : Submodule R N))⟩ :=
-        mapExactAux n
-      let ⟨d, hd⟩ := mapExactAuxDelta hf hkn x hdmem hdy hyₙ
-      ⟨yₙ + d, hd⟩
- where
+    let d := (h2 <| n + 1).choose
+    let y := (h2 <| n + 1).choose_spec.choose
+    have hdy : f y = x (k + (n + 1)) - d := (h2 <| n + 1).choose_spec.choose_spec.right
+    have hdmem := (h2 <| n + 1).choose_spec.choose_spec.left
+    let ⟨yₙ, (hyₙ : f yₙ - x (k + n) ∈ (I ^ (k + n) • ⊤ : Submodule R N))⟩ :=
+      mapExactAux n
+    let ⟨d, hd⟩ := mapExactAuxDelta hf hkn x hdmem hdy hyₙ
+    ⟨yₙ + d, hd⟩
+where
   h1 (n : ℕ) : g (x (k + n)) ∈ Submodule.map g (I ^ (k + n) • ⊤ : Submodule R N) := by
     rw [map_smul'', Submodule.map_top, range_eq_top.mpr hg]
     exact hker (k + n)

--- a/Mathlib/RingTheory/MvPowerSeries/Order.lean
+++ b/Mathlib/RingTheory/MvPowerSeries/Order.lean
@@ -457,8 +457,7 @@ section HomogeneousComponent
 variable (w : σ → ℕ)
 
 /-- The weighted homogeneous components of an `MvPowerSeries f`. -/
-def weightedHomogeneousComponent (p : ℕ) : MvPowerSeries σ R →ₗ[R] MvPowerSeries σ R
-    where
+def weightedHomogeneousComponent (p : ℕ) : MvPowerSeries σ R →ₗ[R] MvPowerSeries σ R where
   toFun f d := if weight w d = p then coeff R d f else 0
   map_add' f g := by
     ext d

--- a/Mathlib/Tactic/Bound/Attribute.lean
+++ b/Mathlib/Tactic/Bound/Attribute.lean
@@ -54,7 +54,7 @@ def typePriority (decl : Lean.Name) (type : Lean.Expr) : MetaM Nat :=
   Lean.Meta.forallTelescope type fun xs t ↦ do
     checkResult t
     xs.foldlM (fun (t : Nat) x ↦ do return t + (← argPriority x)) 0
-  where
+where
   /-- Score the type of argument `x` -/
   argPriority (x : Lean.Expr) : MetaM Nat := do
     hypPriority (← Lean.Meta.inferType x)

--- a/Mathlib/Tactic/CasesM.lean
+++ b/Mathlib/Tactic/CasesM.lean
@@ -28,7 +28,7 @@ partial def casesMatching (matcher : Expr → MetaM Bool) (recursive := false) (
     throwError "no match"
   else
     return result
-  where
+where
   /-- Auxiliary for `casesMatching`. Accumulates generated subgoals in `acc`. -/
   go (g : MVarId) (acc : Array MVarId := #[]) : MetaM (Array MVarId) :=
     g.withContext do

--- a/Mathlib/Tactic/Linarith/Verification.lean
+++ b/Mathlib/Tactic/Linarith/Verification.lean
@@ -110,16 +110,16 @@ def mkLTZeroProof : List (Expr × ℕ) → MetaM Expr
       let (iq, h') ← mkSingleCompZeroOf c h
       let (_, t) ← t.foldlM (fun pr ce ↦ step pr.1 pr.2 ce.1 ce.2) (iq, h')
       return t
-  where
-    /--
-    `step c pf npf coeff` assumes that `pf` is a proof of `t1 R1 0` and `npf` is a proof
-    of `t2 R2 0`. It uses `mkSingleCompZeroOf` to prove `t1 + coeff*t2 R 0`, and returns `R`
-    along with this proof.
-    -/
-    step (c : Ineq) (pf npf : Expr) (coeff : ℕ) : MetaM (Ineq × Expr) := do
-      let (iq, h') ← mkSingleCompZeroOf coeff npf
-      let (nm, niq) := addIneq c iq
-      return (niq, ← mkAppM nm #[pf, h'])
+where
+  /--
+  `step c pf npf coeff` assumes that `pf` is a proof of `t1 R1 0` and `npf` is a proof
+  of `t2 R2 0`. It uses `mkSingleCompZeroOf` to prove `t1 + coeff*t2 R 0`, and returns `R`
+  along with this proof.
+  -/
+  step (c : Ineq) (pf npf : Expr) (coeff : ℕ) : MetaM (Ineq × Expr) := do
+    let (iq, h') ← mkSingleCompZeroOf coeff npf
+    let (nm, niq) := addIneq c iq
+    return (niq, ← mkAppM nm #[pf, h'])
 
 /-- If `prf` is a proof of `t R s`, `leftOfIneqProof prf` returns `t`. -/
 def leftOfIneqProof (prf : Expr) : MetaM Expr := do

--- a/Mathlib/Tactic/Linarith/Verification.lean
+++ b/Mathlib/Tactic/Linarith/Verification.lean
@@ -64,12 +64,12 @@ def mulExpr (n : ℕ) (e : Expr) : MetaM Expr := do
 def addExprs' {u : Level} {α : Q(Type $u)} (_inst : Q(AddMonoid $α)) : List Q($α) → Q($α)
   | []   => q(0)
   | h::t => go h t
-    where
-    /-- Inner loop for `addExprs'`. -/
-    go (p : Q($α)) : List Q($α) → Q($α)
-    | [] => p
-    | [q] => q($p + $q)
-    | q::t => go q($p + $q) t
+where
+  /-- Inner loop for `addExprs'`. -/
+  go (p : Q($α)) : List Q($α) → Q($α)
+  | [] => p
+  | [q] => q($p + $q)
+  | q::t => go q($p + $q) t
 
 /-- `addExprs L` creates an `Expr` representing the sum of the elements of `L`, associated left. -/
 def addExprs : List Expr → MetaM Expr

--- a/Mathlib/Tactic/Recover.lean
+++ b/Mathlib/Tactic/Recover.lean
@@ -27,7 +27,7 @@ which occur in the target or local context or delayed assignment (if any) of
 partial def getUnassignedGoalMVarDependencies (mvarId : MVarId) :
     MetaM (Std.HashSet MVarId) :=
   return (← go mvarId |>.run {}).snd
-  where
+where
     /-- auxiliary function for `getUnassignedGoalMVarDependencies` -/
     addMVars (e : Expr) : StateRefT (Std.HashSet MVarId) MetaM Unit := do
       let mvars ← getMVars e

--- a/Mathlib/Topology/ContinuousMap/Interval.lean
+++ b/Mathlib/Topology/ContinuousMap/Interval.lean
@@ -119,8 +119,7 @@ theorem tendsto_concat {ι : Type*} {p : Filter ι} {F : ι → C(Icc a b, E)} {
 /-- The concatenation of compatible pairs of continuous maps on adjacent intervals, defined as a
 `ContinuousMap` on a subtype of the product. -/
 noncomputable def concatCM :
-    C({fg : C(Icc a b, E) × C(Icc b c, E) // fg.1 ⊤ = fg.2 ⊥}, C(Icc a c, E))
-    where
+    C({fg : C(Icc a b, E) × C(Icc b c, E) // fg.1 ⊤ = fg.2 ⊥}, C(Icc a c, E)) where
   toFun fg := concat fg.val.1 fg.val.2
   continuous_toFun := by
     let S : Set (C(Icc a b, E) × C(Icc b c, E)) := {fg | fg.1 ⊤ = fg.2 ⊥}


### PR DESCRIPTION
Mathlib style is to have the `where` on the previous line: there is even a linter meant to enforce this.

---

(I am not sure why this slipped through the linter; a rewrite of the linter caught these instances. That rewrite might not be easy to land, but these fixes surely can.)

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
