### PR TITLE
feat(Complex): add `arg_{pow/zpow}_coe_angle`

### DIFF
--- a/Mathlib/Analysis/SpecialFunctions/Complex/Arg.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Complex/Arg.lean
@@ -491,6 +491,21 @@ theorem arg_div_coe_angle {x y : ℂ} (hx : x ≠ 0) (hy : y ≠ 0) :
     (arg (x / y) : Real.Angle) = arg x - arg y := by
   rw [div_eq_mul_inv, arg_mul_coe_angle hx (inv_ne_zero hy), arg_inv_coe_angle, sub_eq_add_neg]
 
+theorem arg_pow_coe_angle {x : ℂ} {n: ℕ} :
+    ((x ^ n).arg : Real.Angle) = n • (x.arg : Real.Angle) := by
+  by_cases x0: x = 0
+  · by_cases n0: n = 0
+    repeat simp [x0, n0]
+  · induction n with
+    | zero => simp [x0]
+    | succ n ih => rw [pow_succ, arg_mul_coe_angle (pow_ne_zero n x0) x0, ih]; rfl
+
+theorem arg_zpow_coe_angle {x : ℂ} {n: ℤ} :
+    ((x ^ n).arg : Real.Angle) = n • (x.arg : Real.Angle) := by
+  match n with
+  | Int.ofNat m => simp; exact arg_pow_coe_angle
+  | Int.negSucc m => simp; exact arg_pow_coe_angle
+
 @[simp]
 theorem arg_coe_angle_toReal_eq_arg (z : ℂ) : (arg z : Real.Angle).toReal = arg z := by
   rw [Real.Angle.toReal_coe_eq_self_iff_mem_Ioc]


### PR DESCRIPTION
Add `arg_pow_coe_angle` and `arg_zpow_coe_angle` that translates pow on complex to mul on arg.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
