### PR TITLE
[Merged by Bors] - fix: replace `AddCommGroupCat` -> `AddCommGrp` in comments

### DIFF
--- a/Mathlib/Algebra/Homology/DerivedCategory/Ext/Basic.lean
+++ b/Mathlib/Algebra/Homology/DerivedCategory/Ext/Basic.lean
@@ -24,12 +24,12 @@ However, in the development of the API for Ext-groups, it is important
 to keep a larger degree of generality for universes, as `w < v`
 may happen in certain situations. Indeed, if `X : Scheme.{u}`,
 then the underlying category of the étale site of `X` shall be a large
-category. However, the category `Sheaf X.Etale AddCommGroupCat.{u}`
+category. However, the category `Sheaf X.Etale AddCommGrp.{u}`
 shall have good properties (because there is a small category of affine
 schemes with the same category of sheaves), and even though the type of
-morphisms in `Sheaf X.Etale AddCommGroupCat.{u}` shall be
+morphisms in `Sheaf X.Etale AddCommGrp.{u}` shall be
 in `Type (u + 1)`, these types are going to be `u`-small.
-Then, for `C := Sheaf X.etale AddCommGroupCat.{u}`, we will have
+Then, for `C := Sheaf X.etale AddCommGrp.{u}`, we will have
 `Category.{u + 1} C`, but `HasExt.{u} C` will hold
 (as `C` has enough injectives). Then, the `Ext` groups between étale
 sheaves over `X` shall be in `Type u`.


### PR DESCRIPTION
Fix remaining references after the rename in commit 2e6f6dff0e3e5ea6b97bca1a10ebab73bd8131a7