### PR TITLE
[Merged by Bors] - chore(RingTheory/LocalRing/ResidueField/Ideal): increase `simp` prio, analogous to #22215

### DIFF
--- a/Mathlib/RingTheory/LocalRing/ResidueField/Ideal.lean
+++ b/Mathlib/RingTheory/LocalRing/ResidueField/Ideal.lean
@@ -49,14 +49,14 @@ def Ideal.ResidueField.mapₐ (I : Ideal R) [I.IsPrime] (J : Ideal A) [J.IsPrime
     Ideal.ResidueField.mapₐ I J hf x = Ideal.ResidueField.map I J _ hf x := rfl
 
 variable {I} in
-@[simp]
+@[simp high] -- marked `high` to override the more general `FaithfulSMul.algebraMap_eq_zero_iff`
 lemma Ideal.algebraMap_residueField_eq_zero {x} :
     algebraMap R I.ResidueField x = 0 ↔ x ∈ I := by
   rw [IsScalarTower.algebraMap_apply R (Localization.AtPrime I),
     IsLocalRing.ResidueField.algebraMap_eq, IsLocalRing.residue_eq_zero_iff]
   exact IsLocalization.AtPrime.to_map_mem_maximal_iff _ _ _
 
-@[simp high] -- marked high to override the more general `FaithfulSMul.ker_algebraMap_eq_bot`
+@[simp high] -- marked `high` to override the more general `FaithfulSMul.ker_algebraMap_eq_bot`
 lemma Ideal.ker_algebraMap_residueField :
     RingHom.ker (algebraMap R I.ResidueField) = I :=
   Ideal.ext fun _ ↦ Ideal.algebraMap_residueField_eq_zero


### PR DESCRIPTION
This PR increases the `simp` priority of a lemma to avoid a `simpNF` timeout. It is analogous to #22215. It is needed to fix the nightly-with-mathlib build.

Edit: this has been cherry-picked to the nightly-testing branch.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
