### PR TITLE
[Merged by Bors] - feat(MeasureTheory): a.e. equality on product space from equality of integrals

### DIFF
--- a/Mathlib/MeasureTheory/Function/AEEqOfLIntegral.lean
+++ b/Mathlib/MeasureTheory/Function/AEEqOfLIntegral.lean
@@ -195,9 +195,7 @@ theorem lintegral_eq_lintegral_of_isPiSystem
       _ ≤ ∫⁻ x, f x ∂μ := setLIntegral_le_lintegral t _
       _ < ∞ := hf_int.lt_top
   · intro f hfd hfm h
-    simp_rw [lintegral_iUnion hfm hfd]
-    congr with i
-    exact h i
+    simp_rw [lintegral_iUnion hfm hfd, h]
 
 lemma lintegral_eq_lintegral_of_isPiSystem_of_univ_mem
     (h_eq : m0 = MeasurableSpace.generateFrom s) (h_inter : IsPiSystem s) (h_univ : Set.univ ∈ s)
@@ -206,7 +204,7 @@ lemma lintegral_eq_lintegral_of_isPiSystem_of_univ_mem
     {t : Set α} (ht : MeasurableSet t) :
     ∫⁻ x in t, f x ∂μ = ∫⁻ x in t, g x ∂μ := by
   refine lintegral_eq_lintegral_of_isPiSystem h_eq h_inter basic ?_ hf_int hg_int t ht
-  rw [← setLIntegral_univ, ← setLIntegral_univ (f := g)]
+  rw [← setLIntegral_univ, ← setLIntegral_univ g]
   exact basic _ h_univ
 
 /-- If two a.e.-measurable functions `α × β → ℝ≥0∞` with finite integrals have the same integral
@@ -215,14 +213,13 @@ lemma ae_eq_of_setLIntegral_prod_eq₀ {β : Type*} {mβ : MeasurableSpace β}
     {μ : Measure (α × β)} {f g : α × β → ℝ≥0∞}
     (hf : AEMeasurable f μ) (hg : AEMeasurable g μ)
     (hf_int : ∫⁻ x, f x ∂μ ≠ ∞) (hg_int : ∫⁻ x, g x ∂μ ≠ ∞)
-    (h : ∀ {s : Set α} (_ : MeasurableSet s) {t : Set β} (_ : MeasurableSet t),
+    (h : ∀ ⦃s : Set α⦄ (_ : MeasurableSet s) ⦃t : Set β⦄ (_ : MeasurableSet t),
       ∫⁻ x in s ×ˢ t, f x ∂μ = ∫⁻ x in s ×ˢ t, g x ∂μ) :
     f =ᵐ[μ] g := by
   refine AEMeasurable.ae_eq_of_forall_setLIntegral_eq hf hg hf_int hg_int fun s hs _ ↦ ?_
   refine lintegral_eq_lintegral_of_isPiSystem_of_univ_mem generateFrom_prod.symm isPiSystem_prod
     ?_ ?_ hf_int hg_int hs
-  · simp only [Set.mem_image2, Set.mem_setOf_eq]
-    exact ⟨Set.univ, .univ, Set.univ, .univ, Set.univ_prod_univ⟩
+  · exact ⟨Set.univ, .univ, Set.univ, .univ, Set.univ_prod_univ⟩
   · rintro _ ⟨s, hs, t, ht, rfl⟩
     exact h hs ht
 

--- a/Mathlib/MeasureTheory/Function/AEEqOfLIntegral.lean
+++ b/Mathlib/MeasureTheory/Function/AEEqOfLIntegral.lean
@@ -172,6 +172,72 @@ theorem AEMeasurable.ae_eq_of_forall_setLIntegral_eq {f g : α → ℝ≥0∞} (
   rw [Measure.restrict_apply hu] at huμ
   exact hfg (hu.inter (hf'.measurableSet.union hg'.measurableSet)) huμ
 
+section PiSystem
+
+variable {s : Set (Set α)} {f g : α → ℝ≥0∞}
+
+theorem lintegral_eq_lintegral_of_isPiSystem
+    (h_eq : m0 = MeasurableSpace.generateFrom s) (h_inter : IsPiSystem s)
+    (basic : ∀ t ∈ s, ∫⁻ x in t, f x ∂μ = ∫⁻ x in t, g x ∂μ)
+    (h_univ : ∫⁻ x, f x ∂μ = ∫⁻ x, g x ∂μ)
+    (hf_int : ∫⁻ x, f x ∂μ ≠ ∞) (hg_int : ∫⁻ x, g x ∂μ ≠ ∞) :
+    ∀ t (_ : MeasurableSet t), ∫⁻ x in t, f x ∂μ = ∫⁻ x in t, g x ∂μ := by
+  refine MeasurableSpace.induction_on_inter h_eq h_inter ?_ basic ?_ ?_
+  · simp
+  · intro t ht h_eq
+    rw [setLintegral_compl ht, setLintegral_compl ht, h_eq, h_univ]
+    · refine ne_of_lt ?_
+      calc ∫⁻ x in t, g x ∂μ
+      _ ≤ ∫⁻ x, g x ∂μ := setLIntegral_le_lintegral t _
+      _ < ∞ := hg_int.lt_top
+    · refine ne_of_lt ?_
+      calc ∫⁻ x in t, f x ∂μ
+      _ ≤ ∫⁻ x, f x ∂μ := setLIntegral_le_lintegral t _
+      _ < ∞ := hf_int.lt_top
+  · intro f hfd hfm h
+    simp_rw [lintegral_iUnion hfm hfd]
+    congr with i
+    exact h i
+
+lemma lintegral_eq_lintegral_of_isPiSystem_of_univ_mem
+    (h_eq : m0 = MeasurableSpace.generateFrom s) (h_inter : IsPiSystem s) (h_univ : Set.univ ∈ s)
+    (basic : ∀ t ∈ s, ∫⁻ x in t, f x ∂μ = ∫⁻ x in t, g x ∂μ)
+    (hf_int : ∫⁻ x, f x ∂μ ≠ ∞) (hg_int : ∫⁻ x, g x ∂μ ≠ ∞)
+    {t : Set α} (ht : MeasurableSet t) :
+    ∫⁻ x in t, f x ∂μ = ∫⁻ x in t, g x ∂μ := by
+  refine lintegral_eq_lintegral_of_isPiSystem h_eq h_inter basic ?_ hf_int hg_int t ht
+  rw [← setLIntegral_univ, ← setLIntegral_univ (f := g)]
+  exact basic _ h_univ
+
+/-- If two a.e.-measurable functions `α × β → ℝ≥0∞` with finite integrals have the same integral
+on every rectangle, then they are almost everywhere equal. -/
+lemma ae_eq_of_setLIntegral_prod_eq₀ {β : Type*} {mβ : MeasurableSpace β}
+    {μ : Measure (α × β)} {f g : α × β → ℝ≥0∞}
+    (hf : AEMeasurable f μ) (hg : AEMeasurable g μ)
+    (hf_int : ∫⁻ x, f x ∂μ ≠ ∞) (hg_int : ∫⁻ x, g x ∂μ ≠ ∞)
+    (h : ∀ {s : Set α} (_ : MeasurableSet s) {t : Set β} (_ : MeasurableSet t),
+      ∫⁻ x in s ×ˢ t, f x ∂μ = ∫⁻ x in s ×ˢ t, g x ∂μ) :
+    f =ᵐ[μ] g := by
+  refine AEMeasurable.ae_eq_of_forall_setLIntegral_eq hf hg hf_int hg_int fun s hs _ ↦ ?_
+  refine lintegral_eq_lintegral_of_isPiSystem_of_univ_mem generateFrom_prod.symm isPiSystem_prod
+    ?_ ?_ hf_int hg_int hs
+  · simp only [Set.mem_image2, Set.mem_setOf_eq]
+    exact ⟨Set.univ, .univ, Set.univ, .univ, Set.univ_prod_univ⟩
+  · rintro _ ⟨s, hs, t, ht, rfl⟩
+    exact h hs ht
+
+/-- If two measurable functions `α × β → ℝ≥0∞` with finite integrals have the same integral
+on every rectangle, then they are almost everywhere equal. -/
+lemma ae_eq_of_setLIntegral_prod_eq {β : Type*} {mβ : MeasurableSpace β}
+    {μ : Measure (α × β)} {f g : α × β → ℝ≥0∞}
+    (hf : Measurable f) (hg : Measurable g) (hf_int : ∫⁻ x, f x ∂μ ≠ ∞) (hg_int : ∫⁻ x, g x ∂μ ≠ ∞)
+    (h : ∀ {s : Set α} (_ : MeasurableSet s) {t : Set β} (_ : MeasurableSet t),
+      ∫⁻ x in s ×ˢ t, f x ∂μ = ∫⁻ x in s ×ˢ t, g x ∂μ) :
+    f =ᵐ[μ] g :=
+  ae_eq_of_setLIntegral_prod_eq₀ hf.aemeasurable hg.aemeasurable hf_int hg_int h
+
+end PiSystem
+
 section WithDensity
 
 variable {m : MeasurableSpace α} {μ : Measure α}

--- a/Mathlib/MeasureTheory/Function/AEEqOfLIntegral.lean
+++ b/Mathlib/MeasureTheory/Function/AEEqOfLIntegral.lean
@@ -179,8 +179,7 @@ variable {s : Set (Set α)} {f g : α → ℝ≥0∞}
 theorem lintegral_eq_lintegral_of_isPiSystem
     (h_eq : m0 = MeasurableSpace.generateFrom s) (h_inter : IsPiSystem s)
     (basic : ∀ t ∈ s, ∫⁻ x in t, f x ∂μ = ∫⁻ x in t, g x ∂μ)
-    (h_univ : ∫⁻ x, f x ∂μ = ∫⁻ x, g x ∂μ)
-    (hf_int : ∫⁻ x, f x ∂μ ≠ ∞) (hg_int : ∫⁻ x, g x ∂μ ≠ ∞) :
+    (h_univ : ∫⁻ x, f x ∂μ = ∫⁻ x, g x ∂μ) (hf_int : ∫⁻ x, f x ∂μ ≠ ∞) :
     ∀ t (_ : MeasurableSet t), ∫⁻ x in t, f x ∂μ = ∫⁻ x in t, g x ∂μ := by
   refine MeasurableSpace.induction_on_inter h_eq h_inter ?_ basic ?_ ?_
   · simp
@@ -189,7 +188,7 @@ theorem lintegral_eq_lintegral_of_isPiSystem
     · refine ne_of_lt ?_
       calc ∫⁻ x in t, g x ∂μ
       _ ≤ ∫⁻ x, g x ∂μ := setLIntegral_le_lintegral t _
-      _ < ∞ := hg_int.lt_top
+      _ < ∞ := by rw [← h_univ]; exact hf_int.lt_top
     · refine ne_of_lt ?_
       calc ∫⁻ x in t, f x ∂μ
       _ ≤ ∫⁻ x, f x ∂μ := setLIntegral_le_lintegral t _
@@ -200,10 +199,9 @@ theorem lintegral_eq_lintegral_of_isPiSystem
 lemma lintegral_eq_lintegral_of_isPiSystem_of_univ_mem
     (h_eq : m0 = MeasurableSpace.generateFrom s) (h_inter : IsPiSystem s) (h_univ : Set.univ ∈ s)
     (basic : ∀ t ∈ s, ∫⁻ x in t, f x ∂μ = ∫⁻ x in t, g x ∂μ)
-    (hf_int : ∫⁻ x, f x ∂μ ≠ ∞) (hg_int : ∫⁻ x, g x ∂μ ≠ ∞)
-    {t : Set α} (ht : MeasurableSet t) :
+    (hf_int : ∫⁻ x, f x ∂μ ≠ ∞) {t : Set α} (ht : MeasurableSet t) :
     ∫⁻ x in t, f x ∂μ = ∫⁻ x in t, g x ∂μ := by
-  refine lintegral_eq_lintegral_of_isPiSystem h_eq h_inter basic ?_ hf_int hg_int t ht
+  refine lintegral_eq_lintegral_of_isPiSystem h_eq h_inter basic ?_ hf_int t ht
   rw [← setLIntegral_univ, ← setLIntegral_univ g]
   exact basic _ h_univ
 
@@ -211,14 +209,16 @@ lemma lintegral_eq_lintegral_of_isPiSystem_of_univ_mem
 on every rectangle, then they are almost everywhere equal. -/
 lemma ae_eq_of_setLIntegral_prod_eq {β : Type*} {mβ : MeasurableSpace β}
     {μ : Measure (α × β)} {f g : α × β → ℝ≥0∞}
-    (hf : AEMeasurable f μ) (hg : AEMeasurable g μ)
-    (hf_int : ∫⁻ x, f x ∂μ ≠ ∞) (hg_int : ∫⁻ x, g x ∂μ ≠ ∞)
+    (hf : AEMeasurable f μ) (hg : AEMeasurable g μ) (hf_int : ∫⁻ x, f x ∂μ ≠ ∞)
     (h : ∀ ⦃s : Set α⦄ (_ : MeasurableSet s) ⦃t : Set β⦄ (_ : MeasurableSet t),
       ∫⁻ x in s ×ˢ t, f x ∂μ = ∫⁻ x in s ×ˢ t, g x ∂μ) :
     f =ᵐ[μ] g := by
+  have hg_int : ∫⁻ x, g x ∂μ ≠ ∞ := by
+    rwa [← setLIntegral_univ, ← Set.univ_prod_univ, ← h .univ .univ, Set.univ_prod_univ,
+      setLIntegral_univ]
   refine AEMeasurable.ae_eq_of_forall_setLIntegral_eq hf hg hf_int hg_int fun s hs _ ↦ ?_
   refine lintegral_eq_lintegral_of_isPiSystem_of_univ_mem generateFrom_prod.symm isPiSystem_prod
-    ?_ ?_ hf_int hg_int hs
+    ?_ ?_ hf_int hs
   · exact ⟨Set.univ, .univ, Set.univ, .univ, Set.univ_prod_univ⟩
   · rintro _ ⟨s, hs, t, ht, rfl⟩
     exact h hs ht

--- a/Mathlib/MeasureTheory/Function/AEEqOfLIntegral.lean
+++ b/Mathlib/MeasureTheory/Function/AEEqOfLIntegral.lean
@@ -209,7 +209,7 @@ lemma lintegral_eq_lintegral_of_isPiSystem_of_univ_mem
 
 /-- If two a.e.-measurable functions `α × β → ℝ≥0∞` with finite integrals have the same integral
 on every rectangle, then they are almost everywhere equal. -/
-lemma ae_eq_of_setLIntegral_prod_eq₀ {β : Type*} {mβ : MeasurableSpace β}
+lemma ae_eq_of_setLIntegral_prod_eq {β : Type*} {mβ : MeasurableSpace β}
     {μ : Measure (α × β)} {f g : α × β → ℝ≥0∞}
     (hf : AEMeasurable f μ) (hg : AEMeasurable g μ)
     (hf_int : ∫⁻ x, f x ∂μ ≠ ∞) (hg_int : ∫⁻ x, g x ∂μ ≠ ∞)
@@ -222,16 +222,6 @@ lemma ae_eq_of_setLIntegral_prod_eq₀ {β : Type*} {mβ : MeasurableSpace β}
   · exact ⟨Set.univ, .univ, Set.univ, .univ, Set.univ_prod_univ⟩
   · rintro _ ⟨s, hs, t, ht, rfl⟩
     exact h hs ht
-
-/-- If two measurable functions `α × β → ℝ≥0∞` with finite integrals have the same integral
-on every rectangle, then they are almost everywhere equal. -/
-lemma ae_eq_of_setLIntegral_prod_eq {β : Type*} {mβ : MeasurableSpace β}
-    {μ : Measure (α × β)} {f g : α × β → ℝ≥0∞}
-    (hf : Measurable f) (hg : Measurable g) (hf_int : ∫⁻ x, f x ∂μ ≠ ∞) (hg_int : ∫⁻ x, g x ∂μ ≠ ∞)
-    (h : ∀ {s : Set α} (_ : MeasurableSet s) {t : Set β} (_ : MeasurableSet t),
-      ∫⁻ x in s ×ˢ t, f x ∂μ = ∫⁻ x in s ×ˢ t, g x ∂μ) :
-    f =ᵐ[μ] g :=
-  ae_eq_of_setLIntegral_prod_eq₀ hf.aemeasurable hg.aemeasurable hf_int hg_int h
 
 end PiSystem
 

--- a/Mathlib/MeasureTheory/Function/AEEqOfLIntegral.lean
+++ b/Mathlib/MeasureTheory/Function/AEEqOfLIntegral.lean
@@ -194,8 +194,8 @@ theorem lintegral_eq_lintegral_of_isPiSystem
       calc ∫⁻ x in t, f x ∂μ
       _ ≤ ∫⁻ x, f x ∂μ := setLIntegral_le_lintegral t _
       _ < ∞ := hf_int.lt_top
-  · intro f hfd hfm h
-    simp_rw [lintegral_iUnion hfm hfd, h]
+  · intro t htd htm h
+    simp_rw [lintegral_iUnion htm htd, h]
 
 lemma lintegral_eq_lintegral_of_isPiSystem_of_univ_mem
     (h_eq : m0 = MeasurableSpace.generateFrom s) (h_inter : IsPiSystem s) (h_univ : Set.univ ∈ s)


### PR DESCRIPTION
If two a.e.-measurable functions `α × β → ℝ≥0∞` with finite integrals have the same integral on every rectangle, then they are almost everywhere equal.
The new result puts together the fact that a.e.-equality can be proven from equality of integrals, and induction over the pi-system of rectangles.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
