### PR TITLE
chore(Data/Nat): can we drop a porting note using `fast_instance%`?

### DIFF
--- a/Mathlib/Data/Nat/Lattice.lean
+++ b/Mathlib/Data/Nat/Lattice.lean
@@ -6,6 +6,7 @@ Authors: Johannes Hölzl, Floris van Doorn, Gabriel Ebner, Yury Kudryashov
 import Mathlib.Data.Set.Accumulate
 import Mathlib.Order.ConditionallyCompleteLattice.Finset
 import Mathlib.Order.Interval.Finset.Nat
+import Mathlib.Tactic.FastInstance
 
 /-!
 # Conditionally complete linear order structure on `ℕ`
@@ -118,11 +119,9 @@ instance : Lattice ℕ :=
   LinearOrder.toLattice
 
 open scoped Classical in
-noncomputable instance : ConditionallyCompleteLinearOrderBot ℕ :=
+noncomputable instance : ConditionallyCompleteLinearOrderBot ℕ := fast_instance%
   { (inferInstance : OrderBot ℕ), (LinearOrder.toLattice : Lattice ℕ),
     (inferInstance : LinearOrder ℕ) with
-    -- sup := sSup -- Porting note: removed, unnecessary?
-    -- inf := sInf -- Porting note: removed, unnecessary?
     le_csSup := fun s a hb ha ↦ by rw [sSup_def hb]; revert a ha; exact @Nat.find_spec _ _ hb
     csSup_le := fun s a _ ha ↦ by rw [sSup_def ⟨a, ha⟩]; exact Nat.find_min' _ ha
     le_csInf := fun s a hs hb ↦ by


### PR DESCRIPTION
There's a porting note asking if these fields are unnecessary. I think with the `fast_instance%` elaborator we might be able to achieve the goals of the pre-port code. If the benchmark says no difference, we should probably just drop the unused fields altogether.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
