### PR TITLE
[Merged by Bors] - chore(simps): deprecate old configuration definitions

### DIFF
--- a/Mathlib/Algebra/AddConstMap/Basic.lean
+++ b/Mathlib/Algebra/AddConstMap/Basic.lean
@@ -334,13 +334,13 @@ initialize_simps_projections AddConstMap (toFun → coe, as_prefix coe)
 -/
 
 /-- The identity map as `G →+c[a, a] G`. -/
-@[simps (config := .asFn)]
+@[simps -fullyApplied]
 protected def id : G →+c[a, a] G := ⟨id, fun _ ↦ rfl⟩
 
 instance : Inhabited (G →+c[a, a] G) := ⟨.id⟩
 
 /-- Composition of two `AddConstMap`s. -/
-@[simps (config := .asFn)]
+@[simps -fullyApplied]
 def comp {K : Type*} [Add K] {c : K} (g : H →+c[b, c] K) (f : G →+c[a, b] H) :
     G →+c[a, c] K :=
   ⟨g ∘ f, by simp⟩
@@ -349,7 +349,7 @@ def comp {K : Type*} [Add K] {c : K} (g : H →+c[b, c] K) (f : G →+c[a, b] H)
 @[simp] theorem id_comp (f : G →+c[a, b] H) : .comp .id f = f := rfl
 
 /-- Change constants `a` and `b` in `(f : G →+c[a, b] H)` to improve definitional equalities. -/
-@[simps (config := .asFn)]
+@[simps -fullyApplied]
 def replaceConsts (f : G →+c[a, b] H) (a' b') (ha : a = a') (hb : b = b') :
     G →+c[a', b'] H where
   toFun := f
@@ -396,7 +396,7 @@ theorem one_def : (1 : G →+c[a, a] G) = .id := rfl
 theorem pow_apply (f : G →+c[a, a] G) (n : ℕ) (x : G) : (f ^ n) x = f^[n] x := rfl
 
 /-- Coercion to functions as a monoid homomorphism to `Function.End G`. -/
-@[simps (config := .asFn)]
+@[simps -fullyApplied]
 def toEnd : (G →+c[a, a] G) →* Function.End G where
   toFun := DFunLike.coe
   map_mul' _ _ := rfl
@@ -419,7 +419,7 @@ but we don't do this at the moment because we don't need this.
 -/
 
 /-- Pointwise scalar multiplication of `f : G →+c[a, b] H` as a map `G →+c[a, c • b] H`. -/
-@[simps (config := .asFn)]
+@[simps -fullyApplied]
 def smul [DistribSMul K H] (c : K) (f : G →+c[a, b] H) : G →+c[a, c • b] H where
   toFun := c • ⇑f
   map_add_const' x := by simp [smul_add]
@@ -432,7 +432,7 @@ variable {G : Type*} [AddMonoid G] {a : G}
 
 /-- The map that sends `c` to a translation by `c`
 as a monoid homomorphism from `Multiplicative G` to `G →+c[a, a] G`. -/
-@[simps! (config := .asFn)]
+@[simps! -fullyApplied]
 def addLeftHom : Multiplicative G →* (G →+c[a, a] G) where
   toFun c := c.toAdd +ᵥ .id
   map_one' := by ext; apply zero_add

--- a/Mathlib/Algebra/Algebra/Equiv.lean
+++ b/Mathlib/Algebra/Algebra/Equiv.lean
@@ -577,7 +577,7 @@ def ofRingEquiv {f : A₁ ≃+* A₂} (hf : ∀ x, f (algebraMap R A₁ x) = alg
 
 end OfRingEquiv
 
-@[simps (config := .lemmasOnly) one mul, stacks 09HR]
+@[simps -isSimp one mul, stacks 09HR]
 instance aut : Group (A₁ ≃ₐ[R] A₁) where
   mul ϕ ψ := ψ.trans ϕ
   mul_assoc _ _ _ := rfl

--- a/Mathlib/Algebra/Algebra/Hom.lean
+++ b/Mathlib/Algebra/Algebra/Hom.lean
@@ -300,7 +300,7 @@ theorem map_smul_of_tower {R'} [SMul R' A] [SMul R' B] [LinearMap.CompatibleSMul
     (x : A) : φ (r • x) = r • φ x :=
   φ.toLinearMap.map_smul_of_tower r x
 
-@[simps (config := .lemmasOnly) toSemigroup_toMul_mul toOne_one]
+@[simps -isSimp toSemigroup_toMul_mul toOne_one]
 instance End : Monoid (A →ₐ[R] A) where
   mul := comp
   mul_assoc _ _ _ := rfl

--- a/Mathlib/Algebra/Algebra/Opposite.lean
+++ b/Mathlib/Algebra/Algebra/Opposite.lean
@@ -69,7 +69,7 @@ namespace AlgHom
 /--
 An algebra homomorphism `f : A →ₐ[R] B` such that `f x` commutes with `f y` for all `x, y` defines
 an algebra homomorphism from `Aᵐᵒᵖ`. -/
-@[simps (config := .asFn)]
+@[simps -fullyApplied]
 def fromOpposite (f : A →ₐ[R] B) (hf : ∀ x y, Commute (f x) (f y)) : Aᵐᵒᵖ →ₐ[R] B :=
   { f.toRingHom.fromOpposite hf with
     toFun := f ∘ unop
@@ -88,7 +88,7 @@ theorem toRingHom_fromOpposite (f : A →ₐ[R] B) (hf : ∀ x y, Commute (f x) 
 /--
 An algebra homomorphism `f : A →ₐ[R] B` such that `f x` commutes with `f y` for all `x, y` defines
 an algebra homomorphism to `Bᵐᵒᵖ`. -/
-@[simps (config := .asFn)]
+@[simps -fullyApplied]
 def toOpposite (f : A →ₐ[R] B) (hf : ∀ x y, Commute (f x) (f y)) : A →ₐ[R] Bᵐᵒᵖ :=
   { f.toRingHom.toOpposite hf with
     toFun := op ∘ f

--- a/Mathlib/Algebra/Category/ModuleCat/Differentials/Presheaf.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Differentials/Presheaf.lean
@@ -177,7 +177,7 @@ namespace DifferentialsConstruction
 
 /-- The presheaf of relative differentials of a morphism of presheaves of
 commutative rings. -/
-@[simps (config := .lemmasOnly)]
+@[simps -isSimp]
 noncomputable def relativeDifferentials' :
     PresheafOfModules.{u} (R ⋙ forget₂ _ _) where
   obj X := CommRingCat.KaehlerDifferential (φ'.app X)

--- a/Mathlib/Algebra/Category/ModuleCat/Monoidal/Basic.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Monoidal/Basic.lean
@@ -92,7 +92,7 @@ def leftUnitor (M : ModuleCat.{u} R) : ModuleCat.of R (R ⊗[R] M) ≅ M :=
 def rightUnitor (M : ModuleCat.{u} R) : ModuleCat.of R (M ⊗[R] R) ≅ M :=
   (LinearEquiv.toModuleIso (TensorProduct.rid R M) : of R (M ⊗ R) ≅ of R M).trans (ofSelfIso M)
 
-@[simps (config := .lemmasOnly)]
+@[simps -isSimp]
 instance instMonoidalCategoryStruct : MonoidalCategoryStruct (ModuleCat.{u} R) where
   tensorObj := tensorObj
   whiskerLeft := whiskerLeft

--- a/Mathlib/Algebra/Category/ModuleCat/Presheaf/Sheafification.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Presheaf/Sheafification.lean
@@ -40,7 +40,7 @@ variable [HasWeakSheafify J AddCommGrp.{v}]
 /-- Given a locally bijective morphism `α : R₀ ⟶ R.val` where `R₀` is a presheaf of rings
 and `R` a sheaf of rings (i.e. `R` identifies to the sheafification of `R₀`), this is
 the associated sheaf of modules functor `PresheafOfModules.{v} R₀ ⥤ SheafOfModules.{v} R`. -/
-@[simps! (config := .lemmasOnly) map]
+@[simps! -isSimp map]
 noncomputable def sheafification : PresheafOfModules.{v} R₀ ⥤ SheafOfModules.{v} R where
   obj M₀ := sheafify α (CategoryTheory.toSheafify J M₀.presheaf)
   map f := sheafifyMap _ _ _ f

--- a/Mathlib/Algebra/Category/Ring/Under/Basic.lean
+++ b/Mathlib/Algebra/Category/Ring/Under/Basic.lean
@@ -51,7 +51,7 @@ lemma toAlgHom_apply {A B : Under R} (f : A ⟶ B) (a : A) :
 
 variable (R) in
 /-- Make an object of `Under R` from an `R`-algebra. -/
-@[simps! hom, simps! (config := .lemmasOnly) right]
+@[simps! hom, simps! -isSimp right]
 def mkUnder (A : Type u) [CommRing A] [Algebra R A] : Under R :=
   Under.mk (CommRingCat.ofHom <| algebraMap R A)
 

--- a/Mathlib/Algebra/Group/Equiv/Basic.lean
+++ b/Mathlib/Algebra/Group/Equiv/Basic.lean
@@ -172,7 +172,7 @@ section InvolutiveInv
 variable (G) [InvolutiveInv G]
 
 /-- Inversion on a `Group` or `GroupWithZero` is a permutation of the underlying type. -/
-@[to_additive (attr := simps! (config := .asFn) apply)
+@[to_additive (attr := simps! -fullyApplied apply)
     "Negation on an `AddGroup` is a permutation of the underlying type."]
 protected def inv : Perm G :=
   inv_involutive.toPerm _

--- a/Mathlib/Algebra/Group/Equiv/Defs.lean
+++ b/Mathlib/Algebra/Group/Equiv/Defs.lean
@@ -536,7 +536,7 @@ end MulEquiv
 `f.comp g = id`, returns a multiplicative equivalence with `toFun = f` and `invFun = g`. This
 constructor is useful if the underlying type(s) have specialized `ext` lemmas for multiplicative
 homomorphisms. -/
-@[to_additive (attr := simps (config := .asFn))
+@[to_additive (attr := simps -fullyApplied)
   "Given a pair of additive homomorphisms `f`, `g` such that `g.comp f = id` and
   `f.comp g = id`, returns an additive equivalence with `toFun = f` and `invFun = g`. This
   constructor is useful if the underlying type(s) have specialized `ext` lemmas for additive
@@ -552,7 +552,7 @@ def MulHom.toMulEquiv [Mul M] [Mul N] (f : M →ₙ* N) (g : N →ₙ* M) (h₁ 
 /-- Given a pair of monoid homomorphisms `f`, `g` such that `g.comp f = id` and `f.comp g = id`,
 returns a multiplicative equivalence with `toFun = f` and `invFun = g`.  This constructor is
 useful if the underlying type(s) have specialized `ext` lemmas for monoid homomorphisms. -/
-@[to_additive (attr := simps (config := .asFn))
+@[to_additive (attr := simps -fullyApplied)
   "Given a pair of additive monoid homomorphisms `f`, `g` such that `g.comp f = id`
   and `f.comp g = id`, returns an additive equivalence with `toFun = f` and `invFun = g`.  This
   constructor is useful if the underlying type(s) have specialized `ext` lemmas for additive

--- a/Mathlib/Algebra/Group/Equiv/Opposite.lean
+++ b/Mathlib/Algebra/Group/Equiv/Opposite.lean
@@ -48,7 +48,7 @@ def MulEquiv.inv' (G : Type*) [DivisionMonoid G] : G ≃* Gᵐᵒᵖ :=
 
 /-- A semigroup homomorphism `f : M →ₙ* N` such that `f x` commutes with `f y` for all `x, y`
 defines a semigroup homomorphism to `Nᵐᵒᵖ`. -/
-@[to_additive (attr := simps (config := .asFn))
+@[to_additive (attr := simps -fullyApplied)
 "An additive semigroup homomorphism `f : AddHom M N` such that `f x` additively
 commutes with `f y` for all `x, y` defines an additive semigroup homomorphism to `Sᵃᵒᵖ`."]
 def MulHom.toOpposite {M N : Type*} [Mul M] [Mul N] (f : M →ₙ* N)
@@ -58,7 +58,7 @@ def MulHom.toOpposite {M N : Type*} [Mul M] [Mul N] (f : M →ₙ* N)
 
 /-- A semigroup homomorphism `f : M →ₙ* N` such that `f x` commutes with `f y` for all `x, y`
 defines a semigroup homomorphism from `Mᵐᵒᵖ`. -/
-@[to_additive (attr := simps (config := .asFn))
+@[to_additive (attr := simps -fullyApplied)
 "An additive semigroup homomorphism `f : AddHom M N` such that `f x` additively
 commutes with `f y` for all `x`, `y` defines an additive semigroup homomorphism from `Mᵃᵒᵖ`."]
 def MulHom.fromOpposite {M N : Type*} [Mul M] [Mul N] (f : M →ₙ* N)
@@ -68,7 +68,7 @@ def MulHom.fromOpposite {M N : Type*} [Mul M] [Mul N] (f : M →ₙ* N)
 
 /-- A monoid homomorphism `f : M →* N` such that `f x` commutes with `f y` for all `x, y` defines
 a monoid homomorphism to `Nᵐᵒᵖ`. -/
-@[to_additive (attr := simps (config := .asFn))
+@[to_additive (attr := simps -fullyApplied)
 "An additive monoid homomorphism `f : M →+ N` such that `f x` additively commutes
 with `f y` for all `x, y` defines an additive monoid homomorphism to `Sᵃᵒᵖ`."]
 def MonoidHom.toOpposite {M N : Type*} [MulOneClass M] [MulOneClass N] (f : M →* N)
@@ -79,7 +79,7 @@ def MonoidHom.toOpposite {M N : Type*} [MulOneClass M] [MulOneClass N] (f : M �
 
 /-- A monoid homomorphism `f : M →* N` such that `f x` commutes with `f y` for all `x, y` defines
 a monoid homomorphism from `Mᵐᵒᵖ`. -/
-@[to_additive (attr := simps (config := .asFn))
+@[to_additive (attr := simps -fullyApplied)
 "An additive monoid homomorphism `f : M →+ N` such that `f x` additively commutes
 with `f y` for all `x`, `y` defines an additive monoid homomorphism from `Mᵃᵒᵖ`."]
 def MonoidHom.fromOpposite {M N : Type*} [MulOneClass M] [MulOneClass N] (f : M →* N)

--- a/Mathlib/Algebra/Group/Hom/Defs.lean
+++ b/Mathlib/Algebra/Group/Hom/Defs.lean
@@ -560,7 +560,7 @@ variable [Group G]
 variable [MulOneClass M]
 
 /-- Makes a group homomorphism from a proof that the map preserves multiplication. -/
-@[to_additive (attr := simps (config := .asFn))
+@[to_additive (attr := simps -fullyApplied)
   "Makes an additive group homomorphism from a proof that the map preserves addition."]
 def mk' (f : M → G) (map_mul : ∀ a b : M, f (a * b) = f a * f b) : M →* G where
   toFun := f

--- a/Mathlib/Algebra/Group/Invertible/Basic.lean
+++ b/Mathlib/Algebra/Group/Invertible/Basic.lean
@@ -145,7 +145,7 @@ theorem map_invOf {R : Type*} {S : Type*} {F : Type*} [MulOneClass R] [Monoid S]
   then `r : R` is invertible if `f r` is.
 
 The inverse is computed as `g (⅟(f r))` -/
-@[simps! (config := .lemmasOnly)]
+@[simps! -isSimp]
 def Invertible.ofLeftInverse {R : Type*} {S : Type*} {G : Type*} [MulOneClass R] [MulOneClass S]
     [FunLike G S R] [MonoidHomClass G S R] (f : R → S) (g : G) (r : R)
     (h : Function.LeftInverse g f) [Invertible (f r)] : Invertible r :=

--- a/Mathlib/Algebra/Group/Units/Equiv.lean
+++ b/Mathlib/Algebra/Group/Units/Equiv.lean
@@ -49,7 +49,7 @@ theorem coe_mapEquiv (h : M ≃* N) (x : Mˣ) : (mapEquiv h x : N) = h x :=
   rfl
 
 /-- Left multiplication by a unit of a monoid is a permutation of the underlying type. -/
-@[to_additive (attr := simps (config := .asFn) apply)
+@[to_additive (attr := simps -fullyApplied apply)
   "Left addition of an additive unit is a permutation of the underlying type."]
 def mulLeft (u : Mˣ) : Equiv.Perm M where
   toFun x := u * x
@@ -66,7 +66,7 @@ theorem mulLeft_bijective (a : Mˣ) : Function.Bijective ((a * ·) : M → M) :=
   (mulLeft a).bijective
 
 /-- Right multiplication by a unit of a monoid is a permutation of the underlying type. -/
-@[to_additive (attr := simps (config := .asFn) apply)
+@[to_additive (attr := simps -fullyApplied apply)
 "Right addition of an additive unit is a permutation of the underlying type."]
 def mulRight (u : Mˣ) : Equiv.Perm M where
   toFun x := x * u

--- a/Mathlib/Algebra/GroupWithZero/Units/Equiv.lean
+++ b/Mathlib/Algebra/GroupWithZero/Units/Equiv.lean
@@ -28,7 +28,7 @@ elements. -/
 
 /-- Left multiplication by a nonzero element in a `GroupWithZero` is a permutation of the
 underlying type. -/
-@[simps! (config := .asFn)]
+@[simps! -fullyApplied]
 protected def mulLeft₀ (a : G₀) (ha : a ≠ 0) : Perm G₀ :=
   (Units.mk0 a ha).mulLeft
 
@@ -37,7 +37,7 @@ theorem _root_.mulLeft_bijective₀ (a : G₀) (ha : a ≠ 0) : Function.Bijecti
 
 /-- Right multiplication by a nonzero element in a `GroupWithZero` is a permutation of the
 underlying type. -/
-@[simps! (config := .asFn)]
+@[simps! -fullyApplied]
 protected def mulRight₀ (a : G₀) (ha : a ≠ 0) : Perm G₀ :=
   (Units.mk0 a ha).mulRight
 

--- a/Mathlib/Algebra/Homology/Double.lean
+++ b/Mathlib/Algebra/Homology/Double.lean
@@ -152,7 +152,7 @@ end
 /-- Let `c : ComplexShape ι`, and `i₀` and `i₁` be distinct indices such
 that `hi₀₁ : c.Rel i₀ i₁`, then for any `X : C`, the functor which sends
 `K : HomologicalComplex C c` to `X ⟶ K.X i` is corepresentable by `double (𝟙 X) hi₀₁`. -/
-@[simps (config := .lemmasOnly)]
+@[simps -isSimp]
 noncomputable def evalCompCoyonedaCorepresentableByDoubleId (h : i₀ ≠ i₁) (X : C) :
     (eval C c i₀ ⋙ coyoneda.obj (op X)).CorepresentableBy (double (𝟙 X) hi₀₁) where
   homEquiv {K} :=
@@ -172,7 +172,7 @@ variable {ι : Type*} (c : ComplexShape ι)
 /-- If `i` has no successor for the complex shape `c`,
 then for any `X : C`, the functor which sends `K : HomologicalComplex C c`
 to `X ⟶ K.X i` is corepresentable by `(single C c i).obj X`. -/
-@[simps (config := .lemmasOnly)]
+@[simps -isSimp]
 noncomputable def evalCompCoyonedaCorepresentableBySingle (i : ι) [DecidableEq ι]
     (hi : ∀ (j : ι), ¬ c.Rel i j) (X : C) :
     (eval C c i ⋙ coyoneda.obj (op X)).CorepresentableBy ((single C c i).obj X) where

--- a/Mathlib/Algebra/Homology/TotalComplex.lean
+++ b/Mathlib/Algebra/Homology/TotalComplex.lean
@@ -246,7 +246,7 @@ lemma D₁_D₂ (i₁₂ i₁₂' i₁₂'' : I₁₂) :
     K.D₁ c₁₂ i₁₂ i₁₂' ≫ K.D₂ c₁₂ i₁₂' i₁₂'' = - K.D₂ c₁₂ i₁₂ i₁₂' ≫ K.D₁ c₁₂ i₁₂' i₁₂'' := by simp
 
 /-- The total complex of a bicomplex. -/
-@[simps (config := .lemmasOnly) d]
+@[simps -isSimp d]
 noncomputable def total : HomologicalComplex C c₁₂ where
   X := K.toGradedObject.mapObj (ComplexShape.π c₁ c₂ c₁₂)
   d i₁₂ i₁₂' := K.D₁ c₁₂ i₁₂ i₁₂' + K.D₂ c₁₂ i₁₂ i₁₂'

--- a/Mathlib/Algebra/Module/Equiv/Basic.lean
+++ b/Mathlib/Algebra/Module/Equiv/Basic.lean
@@ -733,7 +733,7 @@ def sumPiEquivProdPi (R : Type*) [Semiring R] (S T : Type*) (A : S ⊕ T → Typ
 
 This is `Equiv.piUnique` as a `LinearEquiv`.
 -/
-@[simps (config := .asFn)]
+@[simps -fullyApplied]
 def piUnique {α : Type*} [Unique α] (R : Type*) [Semiring R] (f : α → Type*)
     [∀ x, AddCommMonoid (f x)] [∀ x, Module R (f x)] : (Π t : α, f t) ≃ₗ[R] f default where
   __ := Equiv.piUnique _

--- a/Mathlib/Algebra/Module/Hom.lean
+++ b/Mathlib/Algebra/Module/Hom.lean
@@ -129,7 +129,7 @@ end AddMonoid.End
 namespace AddMonoidHom
 
 /-- Scalar multiplication on the left as an additive monoid homomorphism. -/
-@[simps! (config := .asFn)]
+@[simps! -fullyApplied]
 protected def smulLeft [Monoid M] [AddMonoid A] [DistribMulAction M A] (c : M) : A →+ A :=
   DistribMulAction.toAddMonoidHom _ c
 

--- a/Mathlib/Algebra/Module/Presentation/Basic.lean
+++ b/Mathlib/Algebra/Module/Presentation/Basic.lean
@@ -214,7 +214,7 @@ variable (π : (relations.G →₀ A) →ₗ[A] M) (hπ : ∀ (r : relations.R),
 for `relations.Solution M` for which the data is given as
 a linear map `π : (relations.G →₀ A) →ₗ[A] M`. (See also `ofπ'` for an alternate
 vanishing criterion.) -/
-@[simps (config := .lemmasOnly)]
+@[simps -isSimp]
 noncomputable def ofπ : relations.Solution M where
   var g := π (Finsupp.single g 1)
   linearCombination_var_relation r := by
@@ -233,7 +233,7 @@ variable (π : (relations.G →₀ A) →ₗ[A] M) (hπ : π.comp relations.map 
 
 /-- Variant of `ofπ` where the vanishing condition is expressed in terms
 of a composition of linear maps. -/
-@[simps! (config := .lemmasOnly)]
+@[simps! -isSimp]
 noncomputable def ofπ' : relations.Solution M :=
   ofπ π (fun r ↦ by
     simpa using DFunLike.congr_fun hπ (Finsupp.single r 1))

--- a/Mathlib/Algebra/MonoidAlgebra/ToDirectSum.lean
+++ b/Mathlib/Algebra/MonoidAlgebra/ToDirectSum.lean
@@ -228,7 +228,7 @@ section Equivs
 
 /-- `AddMonoidAlgebra.toDirectSum` and `DirectSum.toAddMonoidAlgebra` together form an
 equiv. -/
-@[simps (config := .asFn)]
+@[simps -fullyApplied]
 def addMonoidAlgebraEquivDirectSum [DecidableEq ι] [Semiring M] [∀ m : M, Decidable (m ≠ 0)] :
     AddMonoidAlgebra M ι ≃ ⨁ _ : ι, M :=
   { finsuppEquivDFinsupp with
@@ -236,7 +236,7 @@ def addMonoidAlgebraEquivDirectSum [DecidableEq ι] [Semiring M] [∀ m : M, Dec
     invFun := DirectSum.toAddMonoidAlgebra }
 
 /-- The additive version of `AddMonoidAlgebra.addMonoidAlgebraEquivDirectSum`. -/
-@[simps (config := .asFn)]
+@[simps -fullyApplied]
 def addMonoidAlgebraAddEquivDirectSum [DecidableEq ι] [Semiring M] [∀ m : M, Decidable (m ≠ 0)] :
     AddMonoidAlgebra M ι ≃+ ⨁ _ : ι, M :=
   { addMonoidAlgebraEquivDirectSum with
@@ -245,7 +245,7 @@ def addMonoidAlgebraAddEquivDirectSum [DecidableEq ι] [Semiring M] [∀ m : M, 
     map_add' := AddMonoidAlgebra.toDirectSum_add }
 
 /-- The ring version of `AddMonoidAlgebra.addMonoidAlgebraEquivDirectSum`. -/
-@[simps (config := .asFn)]
+@[simps -fullyApplied]
 def addMonoidAlgebraRingEquivDirectSum [DecidableEq ι] [AddMonoid ι] [Semiring M]
     [∀ m : M, Decidable (m ≠ 0)] : AddMonoidAlgebra M ι ≃+* ⨁ _ : ι, M :=
   { (addMonoidAlgebraAddEquivDirectSum : AddMonoidAlgebra M ι ≃+ ⨁ _ : ι, M) with
@@ -254,7 +254,7 @@ def addMonoidAlgebraRingEquivDirectSum [DecidableEq ι] [AddMonoid ι] [Semiring
     map_mul' := AddMonoidAlgebra.toDirectSum_mul }
 
 /-- The algebra version of `AddMonoidAlgebra.addMonoidAlgebraEquivDirectSum`. -/
-@[simps (config := .asFn)]
+@[simps -fullyApplied]
 def addMonoidAlgebraAlgEquivDirectSum [DecidableEq ι] [AddMonoid ι] [CommSemiring R] [Semiring A]
     [Algebra R A] [∀ m : A, Decidable (m ≠ 0)] : AddMonoidAlgebra A ι ≃ₐ[R] ⨁ _ : ι, A :=
   { (addMonoidAlgebraRingEquivDirectSum : AddMonoidAlgebra A ι ≃+* ⨁ _ : ι, A) with

--- a/Mathlib/Algebra/Opposites.lean
+++ b/Mathlib/Algebra/Opposites.lean
@@ -100,7 +100,7 @@ theorem unop_comp_op : (unop : αᵐᵒᵖ → α) ∘ op = id :=
 protected def rec' {F : αᵐᵒᵖ → Sort*} (h : ∀ X, F (op X)) : ∀ X, F X := fun X ↦ h (unop X)
 
 /-- The canonical bijection between `α` and `αᵐᵒᵖ`. -/
-@[to_additive (attr := simps (config := .asFn) apply symm_apply)
+@[to_additive (attr := simps -fullyApplied apply symm_apply)
   "The canonical bijection between `α` and `αᵃᵒᵖ`."]
 def opEquiv : α ≃ αᵐᵒᵖ :=
   ⟨op, unop, unop_op, op_unop⟩

--- a/Mathlib/Algebra/Order/Monoid/Unbundled/WithTop.lean
+++ b/Mathlib/Algebra/Order/Monoid/Unbundled/WithTop.lean
@@ -357,7 +357,7 @@ theorem zero_lt_coe [Zero α] [LT α] (a : α) : (0 : WithTop α) < a ↔ 0 < a 
   coe_lt_coe
 
 /-- A version of `WithTop.map` for `OneHom`s. -/
-@[to_additive (attr := simps (config := .asFn))
+@[to_additive (attr := simps -fullyApplied)
   "A version of `WithTop.map` for `ZeroHom`s"]
 protected def _root_.OneHom.withTopMap {M N : Type*} [One M] [One N] (f : OneHom M N) :
     OneHom (WithTop M) (WithTop N) where
@@ -365,14 +365,14 @@ protected def _root_.OneHom.withTopMap {M N : Type*} [One M] [One N] (f : OneHom
   map_one' := by rw [WithTop.map_one, map_one, coe_one]
 
 /-- A version of `WithTop.map` for `AddHom`s. -/
-@[simps (config := .asFn)]
+@[simps -fullyApplied]
 protected def _root_.AddHom.withTopMap {M N : Type*} [Add M] [Add N] (f : AddHom M N) :
     AddHom (WithTop M) (WithTop N) where
   toFun := WithTop.map f
   map_add' := WithTop.map_add f
 
 /-- A version of `WithTop.map` for `AddMonoidHom`s. -/
-@[simps (config := .asFn)]
+@[simps -fullyApplied]
 protected def _root_.AddMonoidHom.withTopMap {M N : Type*} [AddZeroClass M] [AddZeroClass N]
     (f : M →+ N) : WithTop M →+ WithTop N :=
   { ZeroHom.withTopMap f.toZeroHom, AddHom.withTopMap f.toAddHom with toFun := WithTop.map f }
@@ -646,7 +646,7 @@ instance addCommMonoidWithOne [AddCommMonoidWithOne α] : AddCommMonoidWithOne (
   WithTop.addCommMonoidWithOne
 
 /-- A version of `WithBot.map` for `OneHom`s. -/
-@[to_additive (attr := simps (config := .asFn))
+@[to_additive (attr := simps -fullyApplied)
   "A version of `WithBot.map` for `ZeroHom`s"]
 protected def _root_.OneHom.withBotMap {M N : Type*} [One M] [One N] (f : OneHom M N) :
     OneHom (WithBot M) (WithBot N) where
@@ -654,14 +654,14 @@ protected def _root_.OneHom.withBotMap {M N : Type*} [One M] [One N] (f : OneHom
   map_one' := by rw [WithBot.map_one, map_one, coe_one]
 
 /-- A version of `WithBot.map` for `AddHom`s. -/
-@[simps (config := .asFn)]
+@[simps -fullyApplied]
 protected def _root_.AddHom.withBotMap {M N : Type*} [Add M] [Add N] (f : AddHom M N) :
     AddHom (WithBot M) (WithBot N) where
   toFun := WithBot.map f
   map_add' := WithBot.map_add f
 
 /-- A version of `WithBot.map` for `AddMonoidHom`s. -/
-@[simps (config := .asFn)]
+@[simps -fullyApplied]
 protected def _root_.AddMonoidHom.withBotMap {M N : Type*} [AddZeroClass M] [AddZeroClass N]
     (f : M →+ N) : WithBot M →+ WithBot N :=
   { ZeroHom.withBotMap f.toZeroHom, AddHom.withBotMap f.toAddHom with toFun := WithBot.map f }

--- a/Mathlib/Algebra/Order/Monoid/Units.lean
+++ b/Mathlib/Algebra/Order/Monoid/Units.lean
@@ -36,7 +36,7 @@ instance [Monoid α] [LinearOrder α] : LinearOrder αˣ :=
   LinearOrder.lift' val Units.ext
 
 /-- `val : αˣ → α` as an order embedding. -/
-@[to_additive (attr := simps (config := .asFn))
+@[to_additive (attr := simps -fullyApplied)
   "`val : add_units α → α` as an order embedding."]
 def orderEmbeddingVal [Monoid α] [LinearOrder α] : αˣ ↪o α :=
   ⟨⟨val, ext⟩, Iff.rfl⟩

--- a/Mathlib/Algebra/Order/Ring/WithTop.lean
+++ b/Mathlib/Algebra/Order/Ring/WithTop.lean
@@ -103,7 +103,7 @@ instance instMulZeroOneClass [MulZeroOneClass α] [Nontrivial α] : MulZeroOneCl
     | (a : α) => by rw [← coe_one, ← coe_mul, mul_one]
 
 /-- A version of `WithTop.map` for `MonoidWithZeroHom`s. -/
-@[simps (config := .asFn)]
+@[simps -fullyApplied]
 protected def _root_.MonoidWithZeroHom.withTopMap {R S : Type*} [MulZeroOneClass R] [DecidableEq R]
     [Nontrivial R] [MulZeroOneClass S] [DecidableEq S] [Nontrivial S] (f : R →*₀ S)
     (hf : Function.Injective f) : WithTop R →*₀ WithTop S :=
@@ -210,7 +210,7 @@ instance instOrderedCommSemiring [CommSemiring α] [PartialOrder α] [Canonicall
   CanonicallyOrderedAdd.toOrderedCommSemiring
 
 /-- A version of `WithTop.map` for `RingHom`s. -/
-@[simps (config := .asFn)]
+@[simps -fullyApplied]
 protected def _root_.RingHom.withTopMap {R S : Type*}
     [NonAssocSemiring R] [PartialOrder R] [CanonicallyOrderedAdd R]
     [DecidableEq R] [Nontrivial R]

--- a/Mathlib/Algebra/Polynomial/Module/Basic.lean
+++ b/Mathlib/Algebra/Polynomial/Module/Basic.lean
@@ -245,7 +245,7 @@ theorem map_smul (f : M →ₗ[R] M') (p : R[X]) (q : PolynomialModule R M) :
       monomial_smul_single, f.map_smul, algebraMap_smul]
 
 /-- Evaluate a polynomial `p : PolynomialModule R M` at `r : R`. -/
-@[simps! (config := .lemmasOnly)]
+@[simps! -isSimp]
 def eval (r : R) : PolynomialModule R M →ₗ[R] M where
   toFun p := p.sum fun i m => r ^ i • m
   map_add' _ _ := Finsupp.sum_add_index' (fun _ => smul_zero _) fun _ _ _ => smul_add _ _ _

--- a/Mathlib/Algebra/Quaternion.lean
+++ b/Mathlib/Algebra/Quaternion.lean
@@ -1185,7 +1185,7 @@ section Field
 
 variable [LinearOrderedField R] (a b : ℍ[R])
 
-@[simps (config := .lemmasOnly)]
+@[simps -isSimp]
 instance instInv : Inv ℍ[R] :=
   ⟨fun a => (normSq a)⁻¹ • star a⟩
 

--- a/Mathlib/Algebra/Ring/Basic.lean
+++ b/Mathlib/Algebra/Ring/Basic.lean
@@ -27,13 +27,13 @@ open Function
 namespace AddHom
 
 /-- Left multiplication by an element of a type with distributive multiplication is an `AddHom`. -/
-@[simps (config := .asFn)]
+@[simps -fullyApplied]
 def mulLeft [Distrib R] (r : R) : AddHom R R where
   toFun := (r * ·)
   map_add' := mul_add r
 
 /-- Left multiplication by an element of a type with distributive multiplication is an `AddHom`. -/
-@[simps (config := .asFn)]
+@[simps -fullyApplied]
 def mulRight [Distrib R] (r : R) : AddHom R R where
   toFun a := a * r
   map_add' _ _ := add_mul _ _ r

--- a/Mathlib/Algebra/Ring/Equiv.lean
+++ b/Mathlib/Algebra/Ring/Equiv.lean
@@ -447,7 +447,7 @@ theorem ofBijective_apply [NonUnitalRingHomClass F R S] (f : F) (hf : Function.B
 
 /-- Product of a singleton family of (non-unital non-associative semi)rings is isomorphic
 to the only member of this family. -/
-@[simps! (config := .asFn)]
+@[simps! -fullyApplied]
 def piUnique {ι : Type*} (R : ι → Type*) [Unique ι] [∀ i, NonUnitalNonAssocSemiring (R i)] :
     (∀ i, R i) ≃+* R default where
   __ := Equiv.piUnique R

--- a/Mathlib/Algebra/Ring/Opposite.lean
+++ b/Mathlib/Algebra/Ring/Opposite.lean
@@ -145,7 +145,7 @@ open MulOpposite
 
 /-- A non-unital ring homomorphism `f : R →ₙ+* S` such that `f x` commutes with `f y` for all `x, y`
 defines a non-unital ring homomorphism to `Sᵐᵒᵖ`. -/
-@[simps (config := .asFn)]
+@[simps -fullyApplied]
 def NonUnitalRingHom.toOpposite {R S : Type*} [NonUnitalNonAssocSemiring R]
     [NonUnitalNonAssocSemiring S] (f : R →ₙ+* S) (hf : ∀ x y, Commute (f x) (f y)) : R →ₙ+* Sᵐᵒᵖ :=
   { ((opAddEquiv : S ≃+ Sᵐᵒᵖ).toAddMonoidHom.comp ↑f : R →+ Sᵐᵒᵖ), f.toMulHom.toOpposite hf with
@@ -153,7 +153,7 @@ def NonUnitalRingHom.toOpposite {R S : Type*} [NonUnitalNonAssocSemiring R]
 
 /-- A non-unital ring homomorphism `f : R →ₙ* S` such that `f x` commutes with `f y` for all `x, y`
 defines a non-unital ring homomorphism from `Rᵐᵒᵖ`. -/
-@[simps (config := .asFn)]
+@[simps -fullyApplied]
 def NonUnitalRingHom.fromOpposite {R S : Type*} [NonUnitalNonAssocSemiring R]
     [NonUnitalNonAssocSemiring S] (f : R →ₙ+* S) (hf : ∀ x y, Commute (f x) (f y)) : Rᵐᵒᵖ →ₙ+* S :=
   { (f.toAddMonoidHom.comp (opAddEquiv : R ≃+ Rᵐᵒᵖ).symm.toAddMonoidHom : Rᵐᵒᵖ →+ S),
@@ -178,7 +178,7 @@ def NonUnitalRingHom.unop {α β} [NonUnitalNonAssocSemiring α] [NonUnitalNonAs
 
 /-- A ring homomorphism `f : R →+* S` such that `f x` commutes with `f y` for all `x, y` defines
 a ring homomorphism to `Sᵐᵒᵖ`. -/
-@[simps (config := .asFn)]
+@[simps -fullyApplied]
 def RingHom.toOpposite {R S : Type*} [Semiring R] [Semiring S] (f : R →+* S)
     (hf : ∀ x y, Commute (f x) (f y)) : R →+* Sᵐᵒᵖ :=
   { ((opAddEquiv : S ≃+ Sᵐᵒᵖ).toAddMonoidHom.comp ↑f : R →+ Sᵐᵒᵖ), f.toMonoidHom.toOpposite hf with
@@ -186,7 +186,7 @@ def RingHom.toOpposite {R S : Type*} [Semiring R] [Semiring S] (f : R →+* S)
 
 /-- A ring homomorphism `f : R →+* S` such that `f x` commutes with `f y` for all `x, y` defines
 a ring homomorphism from `Rᵐᵒᵖ`. -/
-@[simps (config := .asFn)]
+@[simps -fullyApplied]
 def RingHom.fromOpposite {R S : Type*} [Semiring R] [Semiring S] (f : R →+* S)
     (hf : ∀ x y, Commute (f x) (f y)) : Rᵐᵒᵖ →+* S :=
   { (f.toAddMonoidHom.comp (opAddEquiv : R ≃+ Rᵐᵒᵖ).symm.toAddMonoidHom : Rᵐᵒᵖ →+ S),

--- a/Mathlib/AlgebraicGeometry/AffineScheme.lean
+++ b/Mathlib/AlgebraicGeometry/AffineScheme.lean
@@ -59,7 +59,7 @@ attribute [instance] IsAffine.affine
 instance (X : Scheme.{u}) [IsAffine X] : IsIso (ΓSpec.adjunction.unit.app X) := @IsAffine.affine X _
 
 /-- The canonical isomorphism `X ≅ Spec Γ(X)` for an affine scheme. -/
-@[simps! (config := .lemmasOnly) hom]
+@[simps! -isSimp hom]
 def Scheme.isoSpec (X : Scheme) [IsAffine X] : X ≅ Spec Γ(X, ⊤) :=
   asIso X.toSpecΓ
 
@@ -308,7 +308,7 @@ variable {X Y : Scheme.{u}} {U : X.Opens} (hU : IsAffineOpen U) (f : Γ(X, U))
 
 attribute [-simp] eqToHom_op in
 /-- The isomorphism `U ≅ Spec Γ(X, U)` for an affine `U`. -/
-@[simps! (config := .lemmasOnly) inv]
+@[simps! -isSimp inv]
 def isoSpec :
     ↑U ≅ Spec Γ(X, U) :=
   haveI : IsAffine U := hU

--- a/Mathlib/AlgebraicGeometry/AffineSpace.lean
+++ b/Mathlib/AlgebraicGeometry/AffineSpace.lean
@@ -60,7 +60,7 @@ lemma of_mvPolynomial_int_ext {R} {f g : ℤ[n] ⟶ R} (h : ∀ i, f (.X i) = g 
   · simpa using h _
 
 
-@[simps (config := .lemmasOnly)]
+@[simps -isSimp]
 instance over : 𝔸(n; S).CanonicallyOver S where
   hom := pullback.fst _ _
 
@@ -173,7 +173,7 @@ variable (n) in
 The affine space over an affine base is isomorphic to the spectrum of the polynomial ring.
 Also see `AffineSpace.SpecIso`.
 -/
-@[simps (config := .lemmasOnly) hom inv]
+@[simps -isSimp hom inv]
 def isoOfIsAffine [IsAffine S] :
     𝔸(n; S) ≅ Spec (.of (MvPolynomial n Γ(S, ⊤))) where
       hom := 𝔸(n; S).toSpecΓ ≫ Spec.map (CommRingCat.ofHom

--- a/Mathlib/AlgebraicGeometry/Cover/Over.lean
+++ b/Mathlib/AlgebraicGeometry/Cover/Over.lean
@@ -112,7 +112,7 @@ variable (hX : Q (X ↘ S)) (hW : Q (W ↘ S)) (hQ : ∀ j, Q (𝒰.obj j ↘ S)
 definitionally equal to `AlgebraicGeometry.Scheme.Cover.pullbackCover`, as here we take
 the pullback in `Q.Over ⊤ S`, whose underlying scheme is only isomorphic but not equal to the
 pullback in `Scheme`. -/
-@[simps (config := .lemmasOnly)]
+@[simps -isSimp]
 def Cover.pullbackCoverOverProp : W.Cover P where
   J := 𝒰.J
   obj x := (pullback (f.asOverProp (hX := hW) (hY := hX) S)
@@ -140,7 +140,7 @@ instance : (𝒰.pullbackCoverOverProp S f hX hW hQ).Over S where
 
 /-- A variant of `AlgebraicGeometry.Scheme.Cover.pullbackCoverOverProp` with the arguments in the
 fiber products flipped. -/
-@[simps (config := .lemmasOnly)]
+@[simps -isSimp]
 def Cover.pullbackCoverOverProp' : W.Cover P where
   J := 𝒰.J
   obj x := (pullback ((𝒰.map x).asOverProp (hX := hQ x) (hY := hX) S)

--- a/Mathlib/AlgebraicGeometry/Gluing.lean
+++ b/Mathlib/AlgebraicGeometry/Gluing.lean
@@ -238,7 +238,7 @@ theorem isOpen_iff (U : Set D.glued.carrier) : IsOpen U ↔ ∀ i, IsOpen ((D.ι
   rfl
 
 /-- The open cover of the glued space given by the glue data. -/
-@[simps (config := .lemmasOnly)]
+@[simps -isSimp]
 def openCover (D : Scheme.GlueData) : OpenCover D.glued where
   J := D.J
   obj := D.U

--- a/Mathlib/AlgebraicGeometry/OpenImmersion.lean
+++ b/Mathlib/AlgebraicGeometry/OpenImmersion.lean
@@ -323,7 +323,7 @@ section Restrict
 variable {U : TopCat.{u}} (X : Scheme.{u}) {f : U ⟶ TopCat.of X} (h : IsOpenEmbedding f)
 
 /-- The restriction of a Scheme along an open embedding. -/
-@[simps! (config := .lemmasOnly) carrier, simps! presheaf_obj]
+@[simps! -isSimp carrier, simps! presheaf_obj]
 def Scheme.restrict : Scheme :=
   { PresheafedSpace.IsOpenImmersion.toScheme X (X.toPresheafedSpace.ofRestrict h) with
     toPresheafedSpace := X.toPresheafedSpace.restrict h }
@@ -332,7 +332,7 @@ lemma Scheme.restrict_toPresheafedSpace :
     (X.restrict h).toPresheafedSpace = X.toPresheafedSpace.restrict h := rfl
 
 /-- The canonical map from the restriction to the subspace. -/
-@[simps! toLRSHom_base, simps! (config := .lemmasOnly) toLRSHom_c_app]
+@[simps! toLRSHom_base, simps! -isSimp toLRSHom_c_app]
 def Scheme.ofRestrict : X.restrict h ⟶ X :=
   ⟨X.toLocallyRingedSpace.ofRestrict h⟩
 

--- a/Mathlib/AlgebraicGeometry/ProjectiveSpectrum/Basic.lean
+++ b/Mathlib/AlgebraicGeometry/ProjectiveSpectrum/Basic.lean
@@ -112,7 +112,7 @@ variable {m} (f_deg : f ∈ 𝒜 m) (hm : 0 < m)
 
 /-- The canonical isomorphism `Proj A |_ D₊(f) ≅ Spec (A_f)₀`
 when `f` is homogeneous of positive degree. -/
-@[simps! (config := .lemmasOnly) hom]
+@[simps! -isSimp hom]
 noncomputable
 def basicOpenIsoSpec : (basicOpen 𝒜 f).toScheme ≅ Spec (.of (Away 𝒜 f)) :=
   have : IsIso (basicOpenToSpec 𝒜 f) := by
@@ -126,7 +126,7 @@ def basicOpenIsoSpec : (basicOpen 𝒜 f).toScheme ≅ Spec (.of (Away 𝒜 f)) 
 
 /-- The canonical isomorphism `(A_f)₀ ≅ Γ(Proj A, D₊(f))`
 when `f` is homogeneous of positive degree. -/
-@[simps! (config := .lemmasOnly) hom]
+@[simps! -isSimp hom]
 noncomputable
 def basicOpenIsoAway : CommRingCat.of (Away 𝒜 f) ≅ Γ(Proj 𝒜, basicOpen 𝒜 f) :=
   have : IsIso (awayToSection 𝒜 f) := by

--- a/Mathlib/AlgebraicGeometry/ProjectiveSpectrum/Scheme.lean
+++ b/Mathlib/AlgebraicGeometry/ProjectiveSpectrum/Scheme.lean
@@ -192,7 +192,7 @@ variable (f)
 /-- The function between the basic open set `D(f)` in `Proj` to the corresponding basic open set in
 `Spec A⁰_f`. This is bundled into a continuous map in `TopComponent.forward`.
 -/
-@[simps (config := .lemmasOnly)]
+@[simps -isSimp]
 def toFun (x : Proj.T| pbo f) : Spec.T A⁰_ f :=
   ⟨carrier x, isPrime_carrier x⟩
 
@@ -212,7 +212,7 @@ section
 
 /-- The continuous function from the basic open set `D(f)` in `Proj`
 to the corresponding basic open set in `Spec A⁰_f`. -/
-@[simps! (config := .lemmasOnly) hom_apply_asIdeal]
+@[simps! -isSimp hom_apply_asIdeal]
 def toSpec (f : A) : (Proj.T| pbo f) ⟶ Spec.T A⁰_ f :=
   TopCat.ofHom
   { toFun := ToSpec.toFun f

--- a/Mathlib/AlgebraicGeometry/Pullbacks.lean
+++ b/Mathlib/AlgebraicGeometry/Pullbacks.lean
@@ -191,7 +191,7 @@ theorem cocycle (i j k : 𝒰.J) : t' 𝒰 f g i j k ≫ t' 𝒰 f g j k i ≫ t
     · simp_rw [Category.assoc, cocycle_snd_snd 𝒰 f g i j k]
 
 /-- Given `Uᵢ ×[Z] Y`, this is the glued fibered product `X ×[Z] Y`. -/
-@[simps U V f t t', simps (config := .lemmasOnly) J]
+@[simps U V f t t', simps -isSimp J]
 def gluing : Scheme.GlueData.{u} where
   J := 𝒰.J
   U i := pullback (𝒰.map i ≫ f) g

--- a/Mathlib/Analysis/BoxIntegral/Partition/Additive.lean
+++ b/Mathlib/Analysis/BoxIntegral/Partition/Additive.lean
@@ -77,7 +77,7 @@ theorem sum_partition_boxes (f : ι →ᵇᵃ[I₀] M) (hI : ↑I ≤ I₀) {π 
     (h : π.IsPartition) : ∑ J ∈ π.boxes, f J = f I :=
   f.sum_partition_boxes' I hI π h
 
-@[simps (config := .asFn)]
+@[simps -fullyApplied]
 instance : Zero (ι →ᵇᵃ[I₀] M) :=
   ⟨⟨0, fun _ _ _ _ => sum_const_zero⟩⟩
 
@@ -134,7 +134,7 @@ def ofMapSplitAdd [Finite ι] (f : Box ι → M) (I₀ : WithTop (Box ι))
 
 /-- If `g : M → N` is an additive map and `f` is a box additive map, then `g ∘ f` is a box additive
 map. -/
-@[simps (config := .asFn)]
+@[simps -fullyApplied]
 def map (f : ι →ᵇᵃ[I₀] M) (g : M →+ N) : ι →ᵇᵃ[I₀] N where
   toFun := g ∘ f
   sum_partition_boxes' I hI π hπ := by simp_rw [comp, ← map_sum, f.sum_partition_boxes hI hπ]

--- a/Mathlib/Analysis/BoxIntegral/Partition/Tagged.lean
+++ b/Mathlib/Analysis/BoxIntegral/Partition/Tagged.lean
@@ -86,7 +86,7 @@ theorem isPartition_iff_iUnion_eq : IsPartition π ↔ π.iUnion = I :=
   Prepartition.isPartition_iff_iUnion_eq
 
 /-- The tagged partition made of boxes of `π` that satisfy predicate `p`. -/
-@[simps! (config := .asFn)]
+@[simps! -fullyApplied]
 def filter (p : Box ι → Prop) : TaggedPrepartition I :=
   ⟨π.1.filter p, π.2, π.3⟩
 
@@ -156,7 +156,7 @@ returns the tagged partition of `I` into all the boxes of all `πi J hJ`. The ta
 is defined to be the `π.tag` of the box of the partition `π` that includes `J`.
 
 Note that usually the result is not a Henstock partition. -/
-@[simps (config := .asFn) tag]
+@[simps -fullyApplied tag]
 def biUnionPrepartition (π : TaggedPrepartition I) (πi : ∀ J : Box ι, Prepartition J) :
     TaggedPrepartition I where
   toPrepartition := π.toPrepartition.biUnion πi
@@ -248,7 +248,7 @@ theorem IsSubordinate.diam_le [Fintype ι] {π : TaggedPrepartition I} (h : π.I
     _ ≤ 2 * r (π.tag J) := diam_closedBall (le_of_lt (r _).2)
 
 /-- Tagged prepartition with single box and prescribed tag. -/
-@[simps! (config := .asFn)]
+@[simps! -fullyApplied]
 def single (I J : Box ι) (hJ : J ≤ I) (x : ι → ℝ) (h : x ∈ Box.Icc I) : TaggedPrepartition I :=
   ⟨Prepartition.single I J hJ, fun _ => x, fun _ => h⟩
 

--- a/Mathlib/Analysis/CStarAlgebra/Module/Synonym.lean
+++ b/Mathlib/Analysis/CStarAlgebra/Module/Synonym.lean
@@ -165,7 +165,7 @@ def addEquiv [AddCommGroup E] : C⋆ᵐᵒᵈ E ≃+ E :=
     invFun := (equiv _).symm }
 
 /-- `WithCStarModule.equiv` as a linear equivalence. -/
-@[simps (config := .asFn)]
+@[simps -fullyApplied]
 def linearEquiv [Semiring R] [AddCommGroup E] [Module R E] : C⋆ᵐᵒᵈ E ≃ₗ[R] E :=
   { LinearEquiv.refl _ _ with
     toFun := equiv _

--- a/Mathlib/Analysis/Convex/Basic.lean
+++ b/Mathlib/Analysis/Convex/Basic.lean
@@ -648,7 +648,7 @@ section OrderedRing
 variable (𝕜) [OrderedRing 𝕜]
 
 /-- The standard one-dimensional simplex in `Fin 2 → 𝕜` is equivalent to the unit interval. -/
-@[simps (config := .asFn)]
+@[simps -fullyApplied]
 def stdSimplexEquivIcc : stdSimplex 𝕜 (Fin 2) ≃ Icc (0 : 𝕜) 1 where
   toFun f := ⟨f.1 0, f.2.1 _, f.2.2 ▸
     Finset.single_le_sum (fun i _ ↦ f.2.1 i) (Finset.mem_univ _)⟩

--- a/Mathlib/Analysis/Convex/Topology.lean
+++ b/Mathlib/Analysis/Convex/Topology.lean
@@ -80,7 +80,7 @@ instance stdSimplex.instCompactSpace_coe : CompactSpace ↥(stdSimplex ℝ ι) :
 
 /-- The standard one-dimensional simplex in `ℝ² = Fin 2 → ℝ`
 is homeomorphic to the unit interval. -/
-@[simps! (config := .asFn)]
+@[simps! -fullyApplied]
 def stdSimplexHomeomorphUnitInterval : stdSimplex ℝ (Fin 2) ≃ₜ unitInterval where
   toEquiv := stdSimplexEquivIcc ℝ
   continuous_toFun := .subtype_mk ((continuous_apply 0).comp continuous_subtype_val) _

--- a/Mathlib/Analysis/Normed/Lp/PiLp.lean
+++ b/Mathlib/Analysis/Normed/Lp/PiLp.lean
@@ -912,7 +912,7 @@ theorem norm_equiv_symm_one {β} [SeminormedAddCommGroup β] (hp : p ≠ ∞) [O
 variable (𝕜 p)
 
 /-- `WithLp.equiv` as a continuous linear equivalence. -/
-@[simps! (config := .asFn) apply symm_apply]
+@[simps! -fullyApplied apply symm_apply]
 protected def continuousLinearEquiv : PiLp p β ≃L[𝕜] ∀ i, β i where
   toLinearEquiv := WithLp.linearEquiv _ _ _
   continuous_toFun := continuous_equiv _ _

--- a/Mathlib/Analysis/Normed/Lp/ProdLp.lean
+++ b/Mathlib/Analysis/Normed/Lp/ProdLp.lean
@@ -495,7 +495,7 @@ variable [Semiring 𝕜] [AddCommGroup α] [AddCommGroup β]
 variable [Module 𝕜 α] [Module 𝕜 β]
 
 /-- `WithLp.equiv` as a continuous linear equivalence. -/
-@[simps! (config := .asFn) apply symm_apply]
+@[simps! -fullyApplied apply symm_apply]
 protected def prodContinuousLinearEquiv : WithLp p (α × β) ≃L[𝕜] α × β where
   toLinearEquiv := WithLp.linearEquiv _ _ _
   continuous_toFun := prod_continuous_equiv _ _ _

--- a/Mathlib/Analysis/Normed/Lp/WithLp.lean
+++ b/Mathlib/Analysis/Normed/Lp/WithLp.lean
@@ -127,7 +127,7 @@ theorem equiv_symm_smul : (WithLp.equiv p V).symm (c • x') = c • (WithLp.equ
 variable (K V)
 
 /-- `WithLp.equiv` as a linear equivalence. -/
-@[simps (config := .asFn)]
+@[simps -fullyApplied]
 protected def linearEquiv : WithLp p V ≃ₗ[K] V :=
   { LinearEquiv.refl _ _ with
     toFun := WithLp.equiv _ _

--- a/Mathlib/Analysis/NormedSpace/HomeomorphBall.lean
+++ b/Mathlib/Analysis/NormedSpace/HomeomorphBall.lean
@@ -37,7 +37,7 @@ noncomputable section
 
 /-- Local homeomorphism between a real (semi)normed space and the unit ball.
 See also `Homeomorph.unitBall`. -/
-@[simps (config := .lemmasOnly)]
+@[simps -isSimp]
 def PartialHomeomorph.univUnitBall : PartialHomeomorph E E where
   toFun x := (√(1 + ‖x‖ ^ 2))⁻¹ • x
   invFun y := (√(1 - ‖(y : E)‖ ^ 2))⁻¹ • (y : E)
@@ -87,7 +87,7 @@ In many cases the actual implementation is not important, so we don't mark the p
 
 See also `Homeomorph.contDiff_unitBall` and `PartialHomeomorph.contDiffOn_unitBall_symm`
 for smoothness properties that hold when `E` is an inner-product space. -/
-@[simps! (config := .lemmasOnly)]
+@[simps! -isSimp]
 def Homeomorph.unitBall : E ≃ₜ ball (0 : E) 1 :=
   (Homeomorph.Set.univ _).symm.trans PartialHomeomorph.univUnitBall.toHomeomorphSourceTarget
 

--- a/Mathlib/Analysis/NormedSpace/OperatorNorm/Completeness.lean
+++ b/Mathlib/Analysis/NormedSpace/OperatorNorm/Completeness.lean
@@ -36,7 +36,7 @@ variable {E' : Type*} [SeminormedAddCommGroup E'] [NormedSpace 𝕜 E'] [RingHom
 /-- Construct a bundled continuous (semi)linear map from a map `f : E → F` and a proof of the fact
 that it belongs to the closure of the image of a bounded set `s : Set (E →SL[σ₁₂] F)` under coercion
 to function. Coercion to function of the result is definitionally equal to `f`. -/
-@[simps! (config := .asFn) apply]
+@[simps! -fullyApplied apply]
 def ofMemClosureImageCoeBounded (f : E' → F) {s : Set (E' →SL[σ₁₂] F)} (hs : IsBounded s)
     (hf : f ∈ closure (((↑) : (E' →SL[σ₁₂] F) → E' → F) '' s)) : E' →SL[σ₁₂] F := by
   -- `f` is a linear map due to `linearMapOfMemClosureRangeCoe`
@@ -54,7 +54,7 @@ def ofMemClosureImageCoeBounded (f : E' → F) {s : Set (E' →SL[σ₁₂] F)} 
 /-- Let `f : E → F` be a map, let `g : α → E →SL[σ₁₂] F` be a family of continuous (semi)linear maps
 that takes values in a bounded set and converges to `f` pointwise along a nontrivial filter. Then
 `f` is a continuous (semi)linear map. -/
-@[simps! (config := .asFn) apply]
+@[simps! -fullyApplied apply]
 def ofTendstoOfBoundedRange {α : Type*} {l : Filter α} [l.NeBot] (f : E' → F)
     (g : α → E' →SL[σ₁₂] F) (hf : Tendsto (fun a x => g a x) l (𝓝 f))
     (hg : IsBounded (Set.range g)) : E' →SL[σ₁₂] F :=

--- a/Mathlib/Analysis/SpecialFunctions/Arsinh.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Arsinh.lean
@@ -98,13 +98,13 @@ def sinhEquiv : ℝ ≃ ℝ where
   right_inv := sinh_arsinh
 
 /-- `Real.sinh` as an `OrderIso`. -/
-@[simps! (config := .asFn)]
+@[simps! -fullyApplied]
 def sinhOrderIso : ℝ ≃o ℝ where
   toEquiv := sinhEquiv
   map_rel_iff' := @sinh_le_sinh
 
 /-- `Real.sinh` as a `Homeomorph`. -/
-@[simps! (config := .asFn)]
+@[simps! -fullyApplied]
 def sinhHomeomorph : ℝ ≃ₜ ℝ :=
   sinhOrderIso.toHomeomorph
 

--- a/Mathlib/Analysis/SpecialFunctions/Complex/Circle.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Complex/Circle.lean
@@ -37,7 +37,7 @@ theorem exp_arg (z : Circle) : exp (arg z) = z :=
 
 /-- `Complex.arg ∘ (↑)` and `expMapCircle` define a partial equivalence between `circle` and `ℝ`
 with `source = Set.univ` and `target = Set.Ioc (-π) π`. -/
-@[simps (config := .asFn)]
+@[simps -fullyApplied]
 noncomputable def argPartialEquiv : PartialEquiv Circle ℝ where
   toFun := arg ∘ (↑)
   invFun := exp
@@ -49,7 +49,7 @@ noncomputable def argPartialEquiv : PartialEquiv Circle ℝ where
   right_inv' _ hx := arg_exp hx.1 hx.2
 
 /-- `Complex.arg` and `expMapCircle` define an equivalence between `circle` and `(-π, π]`. -/
-@[simps (config := .asFn)]
+@[simps -fullyApplied]
 noncomputable def argEquiv : Circle ≃ Ioc (-π) π where
   toFun z := ⟨arg z, neg_pi_lt_arg _, arg_le_pi _⟩
   invFun := exp ∘ (↑)

--- a/Mathlib/CategoryTheory/Adjunction/Basic.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Basic.lean
@@ -149,7 +149,7 @@ namespace Adjunction
 attribute [reassoc (attr := simp)] left_triangle_components right_triangle_components
 
 /-- The hom set equivalence associated to an adjunction. -/
-@[simps (config := .lemmasOnly)]
+@[simps -isSimp]
 def homEquiv {F : C ⥤ D} {G : D ⥤ C} (adj : F ⊣ G) (X : C) (Y : D) :
     (F.obj X ⟶ Y) ≃ (X ⟶ G.obj Y) where
   toFun := fun f => adj.unit.app X ≫ G.map f
@@ -507,7 +507,7 @@ variable {E : Type u₃} [ℰ : Category.{v₃} E] {H : D ⥤ E} {I : E ⥤ D}
   (adj₁ : F ⊣ G) (adj₂ : H ⊣ I)
 
 /-- Composition of adjunctions. -/
-@[simps! (config := .lemmasOnly) unit counit, stacks 0DV0]
+@[simps! -isSimp unit counit, stacks 0DV0]
 def comp : F ⋙ H ⊣ I ⋙ G :=
   mk' {
     homEquiv := fun _ _ ↦ Equiv.trans (adj₂.homEquiv _ _) (adj₁.homEquiv _ _)

--- a/Mathlib/CategoryTheory/Comma/Over/OverClass.lean
+++ b/Mathlib/CategoryTheory/Comma/Over/OverClass.lean
@@ -73,7 +73,7 @@ instance : OverClass X X := ⟨𝟙 _⟩
 instance : IsIso (S ↘ S) := inferInstanceAs (IsIso (𝟙 S))
 
 -- This cannot be a simp lemma be cause it loops with `comp_over`.
-@[simps (config := .lemmasOnly)]
+@[simps -isSimp]
 instance (priority := 900) [CanonicallyOverClass X Y] [OverClass Y S] : OverClass X S :=
   ⟨X ↘ Y ≫ Y ↘ S⟩
 

--- a/Mathlib/CategoryTheory/FinCategory/AsType.lean
+++ b/Mathlib/CategoryTheory/FinCategory/AsType.lean
@@ -38,7 +38,7 @@ noncomputable def objAsTypeEquiv : ObjAsType α ≌ α :=
 abbrev AsType : Type :=
   Fin (Fintype.card α)
 
-@[simps (config := .lemmasOnly) id comp]
+@[simps -isSimp id comp]
 noncomputable instance categoryAsType : SmallCategory (AsType α) where
   Hom i j := Fin (Fintype.card (@Quiver.Hom (ObjAsType α) _ i j))
   id _ := Fintype.equivFin _ (𝟙 _)

--- a/Mathlib/CategoryTheory/Groupoid/Subgroupoid.lean
+++ b/Mathlib/CategoryTheory/Groupoid/Subgroupoid.lean
@@ -126,7 +126,7 @@ def asWideQuiver : Quiver C :=
   ⟨fun c d => Subtype <| S.arrows c d⟩
 
 /-- The coercion of a subgroupoid as a groupoid -/
-@[simps comp_coe, simps (config := .lemmasOnly) inv_coe]
+@[simps comp_coe, simps -isSimp inv_coe]
 instance coe : Groupoid S.objs where
   Hom a b := S.arrows a.val b.val
   id a := ⟨𝟙 a.val, id_mem_of_nonempty_isotropy S a.val a.prop⟩

--- a/Mathlib/CategoryTheory/Limits/Final.lean
+++ b/Mathlib/CategoryTheory/Limits/Final.lean
@@ -341,7 +341,7 @@ variable (G)
 
 /-- When `F : C ⥤ D` is final, and `G : D ⥤ E` has a colimit, then `F ⋙ G` has a colimit also and
 `colimit (F ⋙ G) ≅ colimit G`. -/
-@[simps! (config := .lemmasOnly), stacks 04E7]
+@[simps! -isSimp, stacks 04E7]
 def colimitIso [HasColimit G] : colimit (F ⋙ G) ≅ colimit G :=
   asIso (colimit.pre G F)
 
@@ -687,7 +687,7 @@ variable (G)
 
 /-- When `F : C ⥤ D` is initial, and `G : D ⥤ E` has a limit, then `F ⋙ G` has a limit also and
 `limit (F ⋙ G) ≅ limit G`. -/
-@[simps! (config := .lemmasOnly), stacks 04E7]
+@[simps! -isSimp, stacks 04E7]
 def limitIso [HasLimit G] : limit (F ⋙ G) ≅ limit G :=
   (asIso (limit.pre G F)).symm
 

--- a/Mathlib/CategoryTheory/Localization/HomEquiv.lean
+++ b/Mathlib/CategoryTheory/Localization/HomEquiv.lean
@@ -113,7 +113,7 @@ variable (W : MorphismProperty C) (L₁ : C ⥤ D₁) [L₁.IsLocalization W]
 
 /-- Bijection between types of morphisms in two localized categories
 for the same class of morphisms `W`. -/
-@[simps (config := .lemmasOnly) apply]
+@[simps -isSimp apply]
 noncomputable def homEquiv :
     (L₁.obj X ⟶ L₁.obj Y) ≃ (L₂.obj X ⟶ L₂.obj Y) where
   toFun := (LocalizerMorphism.id W).homMap L₁ L₂

--- a/Mathlib/CategoryTheory/Monoidal/Transport.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Transport.lean
@@ -129,7 +129,7 @@ instance fromInducedMonoidal [MonoidalCategoryStruct D] (F : D ⥤ C) [F.Faithfu
 
 /-- Transport a monoidal structure along an equivalence of (plain) categories.
 -/
-@[simps (config := .lemmasOnly)]
+@[simps -isSimp]
 def transportStruct (e : C ≌ D) : MonoidalCategoryStruct.{v₂} D where
   tensorObj X Y := e.functor.obj (e.inverse.obj X ⊗ e.inverse.obj Y)
   whiskerLeft X _ _ f := e.functor.map (e.inverse.obj X ◁ e.inverse.map f)

--- a/Mathlib/CategoryTheory/Shift/Opposite.lean
+++ b/Mathlib/CategoryTheory/Shift/Opposite.lean
@@ -274,7 +274,7 @@ end NatTrans
 The adjunction `adj`, seen as an adjunction between `OppositeShift.functor G`
 and `OppositeShift.functor F`.
 -/
-@[simps (config := .lemmasOnly)]
+@[simps -isSimp]
 def OppositeShift.adjunction {F} {G : D ⥤ C} (adj : F ⊣ G) :
     OppositeShift.functor A G ⊣ OppositeShift.functor A F where
   unit := (NatTrans.OppositeShift.natIsoId D A).hom ≫

--- a/Mathlib/CategoryTheory/Shift/Pullback.lean
+++ b/Mathlib/CategoryTheory/Shift/Pullback.lean
@@ -267,7 +267,7 @@ end NatTrans
 The adjunction `adj`, seen as an adjunction between `PullbackShift.functor F φ`
 and `PullbackShift.functor G φ`.
 -/
-@[simps (config := .lemmasOnly)]
+@[simps -isSimp]
 def PullbackShift.adjunction {F} {G : D ⥤ C} (adj : F ⊣ G) :
     PullbackShift.functor φ F ⊣ PullbackShift.functor φ G where
   unit := (NatTrans.PullbackShift.natIsoId C φ).hom ≫

--- a/Mathlib/CategoryTheory/Sites/LocallySurjective.lean
+++ b/Mathlib/CategoryTheory/Sites/LocallySurjective.lean
@@ -40,7 +40,7 @@ namespace Presheaf
 
 /-- Given `f : F ⟶ G`, a morphism between presieves, and `s : G.obj (op U)`, this is the sieve
 of `U` consisting of the `i : V ⟶ U` such that `s` restricted along `i` is in the image of `f`. -/
-@[simps (config := .lemmasOnly)]
+@[simps -isSimp]
 def imageSieve {F G : Cᵒᵖ ⥤ A} (f : F ⟶ G) {U : C} (s : ToType (G.obj (op U))) : Sieve U where
   arrows V i := ∃ t : ToType (F.obj (op V)), f.app _ t = G.map i.op s
   downward_closed := by

--- a/Mathlib/CategoryTheory/Subpresheaf/Equalizer.lean
+++ b/Mathlib/CategoryTheory/Subpresheaf/Equalizer.lean
@@ -27,7 +27,7 @@ namespace Subpresheaf
 
 /-- The equalizer of two morphisms of presheaves of types of the form
 `A.toPresheaf ⟶ F₂` with `A : Subpresheaf F₁`, as a subcomplex of `F₁`. -/
-@[simps (config := .lemmasOnly)]
+@[simps -isSimp]
 protected def equalizer : Subpresheaf F₁ where
   obj U := setOf (fun x ↦ ∃ (hx : x ∈ A.obj _), f.app _ ⟨x, hx⟩ = g.app _ ⟨x, hx⟩)
   map φ x := by

--- a/Mathlib/CategoryTheory/Subpresheaf/OfSection.lean
+++ b/Mathlib/CategoryTheory/Subpresheaf/OfSection.lean
@@ -29,7 +29,7 @@ variable {F : Cᵒᵖ ⥤ Type w} {X : Cᵒᵖ} (x : F.obj X)
 
 /-- The subpresheaf of `F : Cᵒᵖ ⥤ Type w` that is generated
 by a section `x : F.obj X`. -/
-@[simps (config := .lemmasOnly)]
+@[simps -isSimp]
 def ofSection : Subpresheaf F where
   obj U := setOf (fun u ↦ ∃ (f : X ⟶ U), F.map f x = u)
   map {U V} g := by

--- a/Mathlib/Data/ENat/Basic.lean
+++ b/Mathlib/Data/ENat/Basic.lean
@@ -398,7 +398,7 @@ protected theorem map_add {β F} [Add β] [FunLike F ℕ β] [AddHomClass F ℕ 
   WithTop.map_add f a b
 
 /-- A version of `ENat.map` for `OneHom`s. -/
--- @[to_additive (attr := simps (config := .asFn))
+-- @[to_additive (attr := simps -fullyApplied)
 --   "A version of `ENat.map` for `ZeroHom`s"]
 protected def _root_.OneHom.ENatMap {N : Type*} [One N] (f : OneHom ℕ N) :
     OneHom ℕ∞ (WithTop N) where
@@ -412,20 +412,20 @@ protected def _root_.ZeroHom.ENatMap {N : Type*} [Zero N] (f : ZeroHom ℕ N) :
   map_zero' := by simp
 
 /-- A version of `WithTop.map` for `AddHom`s. -/
-@[simps (config := .asFn)]
+@[simps -fullyApplied]
 protected def _root_.AddHom.ENatMap {N : Type*} [Add N] (f : AddHom ℕ N) :
     AddHom ℕ∞ (WithTop N) where
   toFun := ENat.map f
   map_add' := ENat.map_add f
 
 /-- A version of `WithTop.map` for `AddMonoidHom`s. -/
-@[simps (config := .asFn)]
+@[simps -fullyApplied]
 protected def _root_.AddMonoidHom.ENatMap {N : Type*} [AddZeroClass N]
     (f : ℕ →+ N) : ℕ∞ →+ WithTop N :=
   { ZeroHom.ENatMap f.toZeroHom, AddHom.ENatMap f.toAddHom with toFun := ENat.map f }
 
 /-- A version of `ENat.map` for `MonoidWithZeroHom`s. -/
-@[simps (config := .asFn)]
+@[simps -fullyApplied]
 protected def _root_.MonoidWithZeroHom.ENatMap {S : Type*} [MulZeroOneClass S] [DecidableEq S]
     [Nontrivial S] (f : ℕ →*₀ S)
     (hf : Function.Injective f) : ℕ∞ →*₀ WithTop S :=
@@ -447,7 +447,7 @@ protected def _root_.MonoidWithZeroHom.ENatMap {S : Type*} [MulZeroOneClass S] [
         simp only [map_coe, ← coe_mul, map_mul, WithTop.coe_mul] }
 
 /-- A version of `ENat.map` for `RingHom`s. -/
-@[simps (config := .asFn)]
+@[simps -fullyApplied]
 protected def _root_.RingHom.ENatMap {S : Type*} [OrderedCommSemiring S] [CanonicallyOrderedAdd S]
     [DecidableEq S] [Nontrivial S] (f : ℕ →+* S) (hf : Function.Injective f) : ℕ∞ →+* WithTop S :=
   {MonoidWithZeroHom.ENatMap f.toMonoidWithZeroHom hf, f.toAddMonoidHom.ENatMap with}

--- a/Mathlib/Data/Fin/Tuple/Basic.lean
+++ b/Mathlib/Data/Fin/Tuple/Basic.lean
@@ -1182,7 +1182,7 @@ end Fin
 
 /-- `Π i : Fin 2, α i` is equivalent to `α 0 × α 1`. See also `finTwoArrowEquiv` for a
 non-dependent version and `prodEquivPiFinTwo` for a version with inputs `α β : Type u`. -/
-@[simps (config := .asFn)]
+@[simps -fullyApplied]
 def piFinTwoEquiv (α : Fin 2 → Type u) : (∀ i, α i) ≃ α 0 × α 1 where
   toFun f := (f 0, f 1)
   invFun p := Fin.cons p.1 <| Fin.cons p.2 finZeroElim

--- a/Mathlib/Data/Finsupp/ToDFinsupp.lean
+++ b/Mathlib/Data/Finsupp/ToDFinsupp.lean
@@ -198,7 +198,7 @@ end Lemmas
 section Equivs
 
 /-- `Finsupp.toDFinsupp` and `DFinsupp.toFinsupp` together form an equiv. -/
-@[simps (config := .asFn)]
+@[simps -fullyApplied]
 def finsuppEquivDFinsupp [DecidableEq ι] [Zero M] [∀ m : M, Decidable (m ≠ 0)] :
     (ι →₀ M) ≃ Π₀ _ : ι, M where
   toFun := Finsupp.toDFinsupp
@@ -208,7 +208,7 @@ def finsuppEquivDFinsupp [DecidableEq ι] [Zero M] [∀ m : M, Decidable (m ≠ 
 
 /-- The additive version of `finsupp.toFinsupp`. Note that this is `noncomputable` because
 `Finsupp.add` is noncomputable. -/
-@[simps (config := .asFn)]
+@[simps -fullyApplied]
 def finsuppAddEquivDFinsupp [DecidableEq ι] [AddZeroClass M] [∀ m : M, Decidable (m ≠ 0)] :
     (ι →₀ M) ≃+ Π₀ _ : ι, M :=
   { finsuppEquivDFinsupp with

--- a/Mathlib/Data/Nat/Cast/Order/Basic.lean
+++ b/Mathlib/Data/Nat/Cast/Order/Basic.lean
@@ -69,7 +69,7 @@ theorem strictMono_cast : StrictMono (Nat.cast : ℕ → α) :=
 lemma _root_.GCongr.natCast_lt_natCast {a b : ℕ} (h : a < b) : (a : α) < b := strictMono_cast h
 
 /-- `Nat.cast : ℕ → α` as an `OrderEmbedding` -/
-@[simps! (config := .asFn)]
+@[simps! -fullyApplied]
 def castOrderEmbedding : ℕ ↪o α :=
   OrderEmbedding.ofStrictMono Nat.cast Nat.strictMono_cast
 

--- a/Mathlib/Data/Nat/Pairing.lean
+++ b/Mathlib/Data/Nat/Pairing.lean
@@ -66,7 +66,7 @@ theorem unpair_pair (a b : ℕ) : unpair (pair a b) = (a, b) := by
     simp [unpair, ae, Nat.not_lt_zero, Nat.add_assoc, Nat.add_sub_cancel_left]
 
 /-- An equivalence between `ℕ × ℕ` and `ℕ`. -/
-@[simps (config := .asFn)]
+@[simps -fullyApplied]
 def pairEquiv : ℕ × ℕ ≃ ℕ :=
   ⟨uncurry pair, unpair, fun ⟨a, b⟩ => unpair_pair a b, pair_unpair⟩
 

--- a/Mathlib/Data/PNat/Basic.lean
+++ b/Mathlib/Data/PNat/Basic.lean
@@ -127,7 +127,7 @@ instance addLeftReflectLT : AddLeftReflectLT ℕ+ :=
   Positive.addLeftReflectLT
 
 /-- The order isomorphism between ℕ and ℕ+ given by `succ`. -/
-@[simps! (config := .asFn) apply]
+@[simps! -fullyApplied apply]
 def _root_.OrderIso.pnatIsoNat : ℕ+ ≃o ℕ where
   toEquiv := Equiv.pnatEquivNat
   map_rel_iff' := natPred_le_natPred

--- a/Mathlib/Data/PNat/Equiv.lean
+++ b/Mathlib/Data/PNat/Equiv.lean
@@ -11,7 +11,7 @@ import Mathlib.Logic.Equiv.Defs
 -/
 
 /-- An equivalence between `ℕ+` and `ℕ` given by `PNat.natPred` and `Nat.succPNat`. -/
-@[simps (config := .asFn)]
+@[simps -fullyApplied]
 def _root_.Equiv.pnatEquivNat : ℕ+ ≃ ℕ where
   toFun := PNat.natPred
   invFun := Nat.succPNat

--- a/Mathlib/Data/Real/ENatENNReal.lean
+++ b/Mathlib/Data/Real/ENatENNReal.lean
@@ -32,12 +32,12 @@ theorem map_coe_nnreal : ENat.map ((↑) : ℕ → ℝ≥0) = ((↑) : ℕ∞ �
   rfl
 
 /-- Coercion `ℕ∞ → ℝ≥0∞` as an `OrderEmbedding`. -/
-@[simps! (config := .asFn)]
+@[simps! -fullyApplied]
 def toENNRealOrderEmbedding : ℕ∞ ↪o ℝ≥0∞ :=
   Nat.castOrderEmbedding.withTopMap
 
 /-- Coercion `ℕ∞ → ℝ≥0∞` as a ring homomorphism. -/
-@[simps! (config := .asFn)]
+@[simps! -fullyApplied]
 def toENNRealRingHom : ℕ∞ →+* ℝ≥0∞ :=
   .ENatMap (Nat.castRingHom ℝ≥0) Nat.cast_injective
 

--- a/Mathlib/Geometry/Manifold/IsManifold/Basic.lean
+++ b/Mathlib/Geometry/Manifold/IsManifold/Basic.lean
@@ -402,7 +402,7 @@ corners `I.prod I'` on `(E × E', ModelProd H H')`. This appears in particular f
 structure on the tangent bundle to a manifold modelled on `(E, H)`: it will be modelled on
 `(E × E, H × E)`. See note [Manifold type tags] for explanation about `ModelProd H H'`
 vs `H × H'`. -/
-@[simps (config := .lemmasOnly)]
+@[simps -isSimp]
 def ModelWithCorners.prod {𝕜 : Type u} [NontriviallyNormedField 𝕜] {E : Type v}
     [NormedAddCommGroup E] [NormedSpace 𝕜 E] {H : Type w} [TopologicalSpace H]
     (I : ModelWithCorners 𝕜 E H) {E' : Type v'} [NormedAddCommGroup E'] [NormedSpace 𝕜 E']

--- a/Mathlib/GroupTheory/Coprod/Basic.lean
+++ b/Mathlib/GroupTheory/Coprod/Basic.lean
@@ -639,7 +639,7 @@ variable {M N M' N' : Type*} [MulOneClass M] [MulOneClass N] [MulOneClass M']
 
 /-- Lift two monoid equivalences `e : M ≃* N` and `e' : M' ≃* N'` to a monoid equivalence
 `(M ∗ M') ≃* (N ∗ N')`. -/
-@[to_additive (attr := simps! (config := .asFn)) "Lift two additive monoid
+@[to_additive (attr := simps! -fullyApplied) "Lift two additive monoid
 equivalences `e : M ≃+ N` and `e' : M' ≃+ N'` to an additive monoid equivalence
 `(AddMonoid.Coprod M M') ≃+ (AddMonoid.Coprod N N')`."]
 def coprodCongr (e : M ≃* N) (e' : M' ≃* N') : (M ∗ M') ≃* (N ∗ N') :=
@@ -649,7 +649,7 @@ def coprodCongr (e : M ≃* N) (e' : M' ≃* N') : (M ∗ M') ≃* (N ∗ N') :=
 variable (M N)
 
 /-- A `MulEquiv` version of `Coprod.swap`. -/
-@[to_additive (attr := simps! (config := .asFn))
+@[to_additive (attr := simps! -fullyApplied)
   "An `AddEquiv` version of `AddMonoid.Coprod.swap`."]
 def coprodComm : M ∗ N ≃* N ∗ M :=
   (Coprod.swap _ _).toMulEquiv (Coprod.swap _ _) (Coprod.swap_comp_swap _ _)
@@ -696,12 +696,12 @@ theorem coprodAssoc_symm_apply_inr_inr (x : P) :
 variable (M)
 
 /-- Isomorphism between `M ∗ PUnit` and `M`. -/
-@[simps! (config := .asFn)]
+@[simps! -fullyApplied]
 def coprodPUnit : M ∗ PUnit ≃* M :=
   MonoidHom.toMulEquiv fst inl (hom_ext rfl <| Subsingleton.elim _ _) fst_comp_inl
 
 /-- Isomorphism between `PUnit ∗ M` and `M`. -/
-@[simps! (config := .asFn)]
+@[simps! -fullyApplied]
 def punitCoprod : PUnit ∗ M ≃* M :=
   MonoidHom.toMulEquiv snd inr (hom_ext (Subsingleton.elim _ _) rfl) snd_comp_inr
 
@@ -714,13 +714,13 @@ namespace AddEquiv
 variable {M : Type*} [AddMonoid M]
 
 /-- Isomorphism between `M ∗ PUnit` and `M`. -/
-@[simps! (config := .asFn)]
+@[simps! -fullyApplied]
 def coprodUnit : AddMonoid.Coprod M PUnit ≃+ M :=
   AddMonoidHom.toAddEquiv AddMonoid.Coprod.fst AddMonoid.Coprod.inl
     (AddMonoid.Coprod.hom_ext rfl <| Subsingleton.elim _ _) AddMonoid.Coprod.fst_comp_inl
 
 /-- Isomorphism between `PUnit ∗ M` and `M`. -/
-@[simps! (config := .asFn)]
+@[simps! -fullyApplied]
 def punitCoprod : AddMonoid.Coprod PUnit M ≃+ M :=
   AddMonoidHom.toAddEquiv AddMonoid.Coprod.snd AddMonoid.Coprod.inr
     (AddMonoid.Coprod.hom_ext (Subsingleton.elim _ _) rfl) AddMonoid.Coprod.snd_comp_inr

--- a/Mathlib/LinearAlgebra/Alternating/Basic.lean
+++ b/Mathlib/LinearAlgebra/Alternating/Basic.lean
@@ -386,7 +386,7 @@ def ofSubsingleton [Subsingleton ι] (i : ι) : (M →ₗ[R] N) ≃ (M [⋀^ι]�
 variable (ι) {N}
 
 /-- The constant map is alternating when `ι` is empty. -/
-@[simps (config := .asFn)]
+@[simps -fullyApplied]
 def constOfIsEmpty [IsEmpty ι] (m : N) : M [⋀^ι]→ₗ[R] N :=
   { MultilinearMap.constOfIsEmpty R _ m with
     toFun := Function.const _ m

--- a/Mathlib/LinearAlgebra/CliffordAlgebra/Even.lean
+++ b/Mathlib/LinearAlgebra/CliffordAlgebra/Even.lean
@@ -192,7 +192,7 @@ private theorem fFold_fFold (m : M) (x : A × S f) : fFold f m (fFold f m x) = Q
 -- `.lemmasOnly`, so that `aux_apply` isn't a simp lemma.
 /-- The final auxiliary construction for `CliffordAlgebra.even.lift`. This map is the forwards
 direction of that equivalence, but not in the fully-bundled form. -/
-@[simps! (config := .lemmasOnly) apply]
+@[simps! -isSimp apply]
 def aux (f : EvenHom Q A) : CliffordAlgebra.even Q →ₗ[R] A := by
   refine ?_ ∘ₗ (even Q).val.toLinearMap
   -- Porting note: added, can't be found otherwise

--- a/Mathlib/LinearAlgebra/CliffordAlgebra/Even.lean
+++ b/Mathlib/LinearAlgebra/CliffordAlgebra/Even.lean
@@ -189,7 +189,7 @@ private theorem fFold_fFold (m : M) (x : A × S f) : fFold f m (fFold f m x) = Q
       rw [LinearMap.smul_apply, LinearMap.smul_apply, mul_smul_comm, ihx, smul_comm]
 
 -- Porting note: In Lean 3, `aux_apply` isn't a simp lemma. I changed `{ attrs := [] }` to
--- `.lemmasOnly`, so that `aux_apply` isn't a simp lemma.
+-- `-isSimp`, so that `aux_apply` isn't a simp lemma.
 /-- The final auxiliary construction for `CliffordAlgebra.even.lift`. This map is the forwards
 direction of that equivalence, but not in the fully-bundled form. -/
 @[simps! -isSimp apply]

--- a/Mathlib/LinearAlgebra/Dual/Basis.lean
+++ b/Mathlib/LinearAlgebra/Dual/Basis.lean
@@ -287,7 +287,7 @@ theorem lc_coeffs (m : M) : DualBases.lc e (h.coeffs m) = m := by
   simp [LinearMap.map_sub, h.dual_lc, sub_eq_zero]
 
 /-- `(h : DualBases e ε).basis` shows the family of vectors `e` forms a basis. -/
-@[simps repr_apply, simps (config := .lemmasOnly) repr_symm_apply]
+@[simps repr_apply, simps -isSimp repr_symm_apply]
 def basis : Basis ι R M :=
   Basis.ofRepr
     { toFun := coeffs h

--- a/Mathlib/LinearAlgebra/ExteriorPower/Basic.lean
+++ b/Mathlib/LinearAlgebra/ExteriorPower/Basic.lean
@@ -263,7 +263,7 @@ theorem map_comp (f : M →ₗ[R] N) (g : N →ₗ[R] N') :
 
 variable (R M) in
 /-- The linear equivalence ` ⋀[R]^0 M ≃ₗ[R] R`. -/
-@[simps! (config := .lemmasOnly) symm_apply]
+@[simps! -isSimp symm_apply]
 noncomputable def zeroEquiv : ⋀[R]^0 M ≃ₗ[R] R :=
   LinearEquiv.ofLinear
     (alternatingMapLinearEquiv (AlternatingMap.constOfIsEmpty R _ _ 1))
@@ -282,7 +282,7 @@ lemma zeroEquiv_naturality (f : M →ₗ[R] N) :
 
 variable (R M) in
 /-- The linear equivalence `M ≃ₗ[R] ⋀[R]^1 M`. -/
-@[simps! (config := .lemmasOnly) symm_apply]
+@[simps! -isSimp symm_apply]
 noncomputable def oneEquiv : ⋀[R]^1 M ≃ₗ[R] M :=
   LinearEquiv.ofLinear
     (alternatingMapLinearEquiv (AlternatingMap.ofSubsingleton R M M (0 : Fin 1) .id)) (by

--- a/Mathlib/LinearAlgebra/Matrix/GeneralLinearGroup/Basic.lean
+++ b/Mathlib/LinearAlgebra/Matrix/GeneralLinearGroup/Basic.lean
@@ -18,7 +18,7 @@ section Examples
 
 /-- The matrix [a, -b; b, a] (inspired by multiplication by a complex number); it is an element of
 $GL_2(R)$ if `a ^ 2 + b ^ 2` is nonzero. -/
-@[simps! (config := .asFn) val]
+@[simps! -fullyApplied val]
 def planeConformalMatrix {R} [Field R] (a b : R) (hab : a ^ 2 + b ^ 2 ≠ 0) :
     Matrix.GeneralLinearGroup (Fin 2) R :=
   GeneralLinearGroup.mkOfDetNeZero !![a, -b; b, a] (by simpa [det_fin_two, sq] using hab)

--- a/Mathlib/LinearAlgebra/Matrix/ToLin.lean
+++ b/Mathlib/LinearAlgebra/Matrix/ToLin.lean
@@ -948,7 +948,7 @@ by finite types `ι₁` and `ι₂`,
 then `Basis.linearMap b₁ b₂` is the basis of `M₁ →ₗ[R] M₂` indexed by `ι₂ × ι₁`
 where `(i, j)` indexes the linear map that sends `b j` to `b i`
 and sends all other basis vectors to `0`. -/
-@[simps! (config := .lemmasOnly) repr_apply repr_symm_apply]
+@[simps! -isSimp repr_apply repr_symm_apply]
 noncomputable
 def linearMap (b₁ : Basis ι₁ R M₁) (b₂ : Basis ι₂ R M₂) :
     Basis (ι₂ × ι₁) R (M₁ →ₗ[R] M₂) :=
@@ -974,7 +974,7 @@ If `M` is a module with basis `b` indexed by a finite type `ι`,
 then `Basis.end b` is the basis of `Module.End R M` indexed by `ι × ι`
 where `(i, j)` indexes the linear map that sends `b j` to `b i`
 and sends all other basis vectors to `0`. -/
-@[simps! (config := .lemmasOnly) repr_apply repr_symm_apply]
+@[simps! -isSimp repr_apply repr_symm_apply]
 noncomputable
 abbrev _root_.Basis.end (b : Basis ι R M) : Basis (ι × ι) R (Module.End R M) :=
   b.linearMap b

--- a/Mathlib/LinearAlgebra/Multilinear/Basic.lean
+++ b/Mathlib/LinearAlgebra/Multilinear/Basic.lean
@@ -265,7 +265,7 @@ def ofSubsingleton [Subsingleton ι] (i : ι) :
 variable (M₁) {M₂}
 
 /-- The constant map is multilinear when `ι` is empty. -/
-@[simps (config := .asFn)]
+@[simps -fullyApplied]
 def constOfIsEmpty [IsEmpty ι] (m : M₂) : MultilinearMap R M₁ M₂ where
   toFun := Function.const _ m
   map_update_add' _ := isEmptyElim

--- a/Mathlib/LinearAlgebra/Pi.lean
+++ b/Mathlib/LinearAlgebra/Pi.lean
@@ -565,7 +565,7 @@ theorem piFinTwo_apply (M : Fin 2 → Type v)
     (piFinTwo R M : ((i : Fin 2) → M i) → M 0 × M 1) = fun f => (f 0, f 1) := rfl
 
 /-- Linear equivalence between vectors in `M² = Fin 2 → M` and `M × M`. -/
-@[simps! (config := .asFn)]
+@[simps! -fullyApplied]
 def finTwoArrow : (Fin 2 → M) ≃ₗ[R] M × M :=
   { finTwoArrowEquiv M, piFinTwo R fun _ => M with }
 

--- a/Mathlib/Logic/Embedding/Basic.lean
+++ b/Mathlib/Logic/Embedding/Basic.lean
@@ -192,12 +192,12 @@ lemma setValue_right_apply_eq {α β} (f : α ↪ β) (a c : α) [∀ a', Decida
   simp [setValue]
 
 /-- Embedding into `Option α` using `some`. -/
-@[simps (config := .asFn)]
+@[simps -fullyApplied]
 protected def some {α} : α ↪ Option α :=
   ⟨some, Option.some_injective α⟩
 
 /-- A version of `Option.map` for `Function.Embedding`s. -/
-@[simps (config := .asFn)]
+@[simps -fullyApplied]
 def optionMap {α β} (f : α ↪ β) : Option α ↪ Option β :=
   ⟨Option.map f, Option.map_injective f.injective⟩
 

--- a/Mathlib/Logic/Equiv/Basic.lean
+++ b/Mathlib/Logic/Equiv/Basic.lean
@@ -93,7 +93,7 @@ def pprodEquivProdPLift : PProd α β ≃ PLift α × PLift β :=
 /-- Product of two equivalences. If `α₁ ≃ α₂` and `β₁ ≃ β₂`, then `α₁ × β₁ ≃ α₂ × β₂`. This is
 `Prod.map` as an equivalence. -/
 -- Porting note: in Lean 3 there was also a @[congr] tag
-@[simps (config := .asFn) apply]
+@[simps -fullyApplied apply]
 def prodCongr {α₁ α₂ β₁ β₂} (e₁ : α₁ ≃ α₂) (e₂ : β₁ ≃ β₂) : α₁ × β₁ ≃ α₂ × β₂ :=
   ⟨Prod.map e₁ e₂, Prod.map e₁.symm e₂.symm, fun ⟨a, b⟩ => by simp, fun ⟨a, b⟩ => by simp⟩
 
@@ -139,7 +139,7 @@ theorem prodProdProdComm_symm (α β γ δ) :
   rfl
 
 /-- `γ`-valued functions on `α × β` are equivalent to functions `α → β → γ`. -/
-@[simps (config := .asFn)]
+@[simps -fullyApplied]
 def curry (α β γ) : (α × β → γ) ≃ (α → β → γ) where
   toFun := Function.curry
   invFun := uncurry
@@ -344,7 +344,7 @@ def boolEquivPUnitSumPUnit : Bool ≃ PUnit.{u + 1} ⊕ PUnit.{v + 1} :=
     fun b => by cases b <;> rfl, fun s => by rcases s with (⟨⟨⟩⟩ | ⟨⟨⟩⟩) <;> rfl⟩
 
 /-- Sum of types is commutative up to an equivalence. This is `Sum.swap` as an equivalence. -/
-@[simps (config := .asFn) apply]
+@[simps -fullyApplied apply]
 def sumComm (α β) : α ⊕ β ≃ β ⊕ α :=
   ⟨Sum.swap, Sum.swap, Sum.swap_swap, Sum.swap_swap⟩
 
@@ -670,7 +670,7 @@ def piCurry {α} {β : α → Type*} (γ : ∀ a, β a → Type*) :
   left_inv := Sigma.uncurry_curry
   right_inv := Sigma.curry_uncurry
 
--- `simps` overapplies these but `simps (config := .asFn)` under-applies them
+-- `simps` overapplies these but `simps -fullyApplied` under-applies them
 @[simp] theorem piCurry_apply {α} {β : α → Type*} (γ : ∀ a, β a → Type*)
     (f : ∀ x : Σ i, β i, γ x.1 x.2) :
     piCurry γ f = Sigma.curry f :=
@@ -767,7 +767,7 @@ theorem ofFiberEquiv_map {α β γ} {f : α → γ} {g : β → γ}
 /-- A variation on `Equiv.prodCongr` where the equivalence in the second component can depend
   on the first component. A typical example is a shear mapping, explaining the name of this
   declaration. -/
-@[simps (config := .asFn)]
+@[simps -fullyApplied]
 def prodShear (e₁ : α₁ ≃ α₂) (e₂ : α₁ → β₁ ≃ β₂) : α₁ × β₁ ≃ α₂ × β₂ where
   toFun := fun x : α₁ × β₁ => (e₁ x.1, e₂ x.1 x.2)
   invFun := fun y : α₂ × β₂ => (e₁.symm y.1, (e₂ <| e₁.symm y.1).symm y.2)
@@ -1608,7 +1608,7 @@ section
 
 /-- Transport dependent functions through an equivalence of the base space.
 -/
-@[simps apply, simps (config := .lemmasOnly) symm_apply]
+@[simps apply, simps -isSimp symm_apply]
 def piCongrLeft' (P : α → Sort*) (e : α ≃ β) : (∀ a, P a) ≃ ∀ b, P (e.symm b) where
   toFun f x := f (e.symm x)
   invFun f x := (e.symm_apply_apply x).ndrec (f (e x))

--- a/Mathlib/Logic/Equiv/Defs.lean
+++ b/Mathlib/Logic/Equiv/Defs.lean
@@ -407,12 +407,12 @@ def equivPUnit (α : Sort u) [Unique α] : α ≃ PUnit.{v} := ofUnique α _
 def propEquivPUnit {p : Prop} (h : p) : p ≃ PUnit.{0} := @equivPUnit p <| uniqueProp h
 
 /-- `ULift α` is equivalent to `α`. -/
-@[simps (config := .asFn) apply]
+@[simps -fullyApplied apply]
 protected def ulift {α : Type v} : ULift.{u} α ≃ α :=
   ⟨ULift.down, ULift.up, ULift.up_down, ULift.down_up.{v, u}⟩
 
 /-- `PLift α` is equivalent to `α`. -/
-@[simps (config := .asFn) apply]
+@[simps -fullyApplied apply]
 protected def plift : PLift α ≃ α := ⟨PLift.down, PLift.up, PLift.up_down, PLift.down_up⟩
 
 /-- equivalence of propositions is the same as iff -/
@@ -527,7 +527,7 @@ def arrowPUnitEquivPUnit (α : Sort*) : (α → PUnit.{v}) ≃ PUnit.{w} :=
   ⟨fun _ => .unit, fun _ _ => .unit, fun _ => rfl, fun _ => rfl⟩
 
 /-- The equivalence `(∀ i, β i) ≃ β ⋆` when the domain of `β` only contains `⋆` -/
-@[simps (config := .asFn)]
+@[simps -fullyApplied]
 def piUnique [Unique α] (β : α → Sort*) : (∀ i, β i) ≃ β default where
   toFun f := f default
   invFun := uniqueElim
@@ -535,7 +535,7 @@ def piUnique [Unique α] (β : α → Sort*) : (∀ i, β i) ≃ β default wher
   right_inv _ := rfl
 
 /-- If `α` has a unique term, then the type of function `α → β` is equivalent to `β`. -/
-@[simps! (config := .asFn) apply symm_apply]
+@[simps! -fullyApplied apply symm_apply]
 def funUnique (α β) [Unique.{u} α] : (α → β) ≃ β := piUnique _
 
 /-- The sort of maps from `PUnit` is equivalent to the codomain. -/

--- a/Mathlib/Logic/Equiv/Fin.lean
+++ b/Mathlib/Logic/Equiv/Fin.lean
@@ -37,13 +37,13 @@ theorem Fin.preimage_apply_01_prod' {α : Type u} (s t : Set α) :
 /-- A product space `α × β` is equivalent to the space `Π i : Fin 2, γ i`, where
 `γ = Fin.cons α (Fin.cons β finZeroElim)`. See also `piFinTwoEquiv` and
 `finTwoArrowEquiv`. -/
-@[simps! (config := .asFn)]
+@[simps! -fullyApplied]
 def prodEquivPiFinTwo (α β : Type u) : α × β ≃ ∀ i : Fin 2, ![α, β] i :=
   (piFinTwoEquiv (Fin.cons α (Fin.cons β finZeroElim))).symm
 
 /-- The space of functions `Fin 2 → α` is equivalent to `α × α`. See also `piFinTwoEquiv` and
 `prodEquivPiFinTwo`. -/
-@[simps (config := .asFn)]
+@[simps -fullyApplied]
 def finTwoArrowEquiv (α : Type*) : (Fin 2 → α) ≃ α × α :=
   { piFinTwoEquiv fun _ => α with invFun := fun x => ![x.1, x.2] }
 

--- a/Mathlib/Logic/Equiv/PartialEquiv.lean
+++ b/Mathlib/Logic/Equiv/PartialEquiv.lean
@@ -223,7 +223,7 @@ protected theorem surjOn : SurjOn e e.source e.target :=
 
 /-- Interpret an `Equiv` as a `PartialEquiv` by restricting it to `s` in the domain
 and to `t` in the codomain. -/
-@[simps (config := .asFn)]
+@[simps -fullyApplied]
 def _root_.Equiv.toPartialEquivOfImageEq (e : α ≃ β) (s : Set α) (t : Set β) (h : e '' s = t) :
     PartialEquiv α β where
   toFun := e
@@ -247,7 +247,7 @@ instance inhabitedOfEmpty [IsEmpty α] [IsEmpty β] : Inhabited (PartialEquiv α
   ⟨((Equiv.equivEmpty α).trans (Equiv.equivEmpty β).symm).toPartialEquiv⟩
 
 /-- Create a copy of a `PartialEquiv` providing better definitional equalities. -/
-@[simps (config := .asFn)]
+@[simps -fullyApplied]
 def copy (e : PartialEquiv α β) (f : α → β) (hf : ⇑e = f) (g : β → α) (hg : ⇑e.symm = g) (s : Set α)
     (hs : e.source = s) (t : Set β) (ht : e.target = t) :
     PartialEquiv α β where
@@ -332,7 +332,7 @@ theorem symm_mapsTo (h : e.IsImage s t) : MapsTo e.symm (e.target ∩ t) (e.sour
   h.symm.mapsTo
 
 /-- Restrict a `PartialEquiv` to a pair of corresponding sets. -/
-@[simps (config := .asFn)]
+@[simps -fullyApplied]
 def restr (h : e.IsImage s t) : PartialEquiv α β where
   toFun := e
   invFun := e.symm
@@ -806,7 +806,7 @@ end Prod
 sends `e.source ∩ s` to `e.target ∩ t` using `e` and `e'.source \ s` to `e'.target \ t` using `e'`,
 and similarly for the inverse function. The definition assumes `e.isImage s t` and
 `e'.isImage s t`. -/
-@[simps (config := .asFn)]
+@[simps -fullyApplied]
 def piecewise (e e' : PartialEquiv α β) (s : Set α) (t : Set β) [∀ x, Decidable (x ∈ s)]
     [∀ y, Decidable (y ∈ t)] (H : e.IsImage s t) (H' : e'.IsImage s t) :
     PartialEquiv α β where
@@ -827,7 +827,7 @@ theorem symm_piecewise (e e' : PartialEquiv α β) {s : Set α} {t : Set β} [�
 /-- Combine two `PartialEquiv`s with disjoint sources and disjoint targets. We reuse
 `PartialEquiv.piecewise`, then override `source` and `target` to ensure better definitional
 equalities. -/
-@[simps! (config := .asFn)]
+@[simps! -fullyApplied]
 def disjointUnion (e e' : PartialEquiv α β) (hs : Disjoint e.source e'.source)
     (ht : Disjoint e.target e'.target) [∀ x, Decidable (x ∈ e.source)]
     [∀ y, Decidable (y ∈ e.target)] : PartialEquiv α β :=
@@ -886,7 +886,7 @@ namespace Set
 -- All arguments are explicit to avoid missing information in the pretty printer output
 /-- A bijection between two sets `s : Set α` and `t : Set β` provides a partial equivalence
 between `α` and `β`. -/
-@[simps (config := .asFn)]
+@[simps -fullyApplied]
 noncomputable def BijOn.toPartialEquiv [Nonempty α] (f : α → β) (s : Set α) (t : Set β)
     (hf : BijOn f s t) : PartialEquiv α β where
   toFun := f

--- a/Mathlib/MeasureTheory/Group/MeasurableEquiv.lean
+++ b/Mathlib/MeasureTheory/Group/MeasurableEquiv.lean
@@ -43,7 +43,7 @@ variable {G G₀ α : Type*} [MeasurableSpace G] [MeasurableSpace G₀] [Measura
 
 /-- If a group `G` acts on `α` by measurable maps, then each element `c : G` defines a measurable
 automorphism of `α`. -/
-@[to_additive (attr := simps! (config := .asFn) toEquiv apply)
+@[to_additive (attr := simps! -fullyApplied toEquiv apply)
       "If an additive group `G` acts on `α` by measurable maps, then each element `c : G`
       defines a measurable automorphism of `α`." ]
 def smul (c : G) : α ≃ᵐ α where
@@ -176,7 +176,7 @@ theorem toEquiv_mulRight₀ {g : G₀} (hg : g ≠ 0) : (mulRight₀ g hg).toEqu
 end Mul
 
 /-- Inversion as a measurable automorphism of a group or group with zero. -/
-@[to_additive (attr := simps! (config := .asFn) toEquiv apply)
+@[to_additive (attr := simps! -fullyApplied toEquiv apply)
     "Negation as a measurable automorphism of an additive group."]
 def inv (G) [MeasurableSpace G] [InvolutiveInv G] [MeasurableInv G] : G ≃ᵐ G where
   toEquiv := Equiv.inv G

--- a/Mathlib/MeasureTheory/MeasurableSpace/Embedding.lean
+++ b/Mathlib/MeasureTheory/MeasurableSpace/Embedding.lean
@@ -523,7 +523,7 @@ def arrowCongr' {α₁ β₁ α₂ β₂ : Type*} [MeasurableSpace β₁] [Measu
       measurable_pi_iff.mpr fun _ ↦ hβ.symm.measurable.comp' (measurable_pi_apply _)
 
 /-- Pi-types are measurably equivalent to iterated products. -/
-@[simps! (config := .asFn)]
+@[simps! -fullyApplied]
 def piMeasurableEquivTProd [DecidableEq δ'] {l : List δ'} (hnd : l.Nodup) (h : ∀ i, i ∈ l) :
     (∀ i, π i) ≃ᵐ List.TProd π l where
   toEquiv := List.TProd.piEquivTProd hnd h
@@ -532,26 +532,26 @@ def piMeasurableEquivTProd [DecidableEq δ'] {l : List δ'} (hnd : l.Nodup) (h :
 
 variable (π) in
 /-- The measurable equivalence `(∀ i, π i) ≃ᵐ π ⋆` when the domain of `π` only contains `⋆` -/
-@[simps! (config := .asFn)]
+@[simps! -fullyApplied]
 def piUnique [Unique δ'] : (∀ i, π i) ≃ᵐ π default where
   toEquiv := Equiv.piUnique π
   measurable_toFun := measurable_pi_apply _
   measurable_invFun := measurable_uniqueElim
 
 /-- If `α` has a unique term, then the type of function `α → β` is measurably equivalent to `β`. -/
-@[simps! (config := .asFn)]
+@[simps! -fullyApplied]
 def funUnique (α β : Type*) [Unique α] [MeasurableSpace β] : (α → β) ≃ᵐ β :=
   MeasurableEquiv.piUnique _
 
 /-- The space `Π i : Fin 2, α i` is measurably equivalent to `α 0 × α 1`. -/
-@[simps! (config := .asFn)]
+@[simps! -fullyApplied]
 def piFinTwo (α : Fin 2 → Type*) [∀ i, MeasurableSpace (α i)] : (∀ i, α i) ≃ᵐ α 0 × α 1 where
   toEquiv := piFinTwoEquiv α
   measurable_toFun := Measurable.prod (measurable_pi_apply _) (measurable_pi_apply _)
   measurable_invFun := measurable_pi_iff.2 <| Fin.forall_fin_two.2 ⟨measurable_fst, measurable_snd⟩
 
 /-- The space `Fin 2 → α` is measurably equivalent to `α × α`. -/
-@[simps! (config := .asFn)]
+@[simps! -fullyApplied]
 def finTwoArrow : (Fin 2 → α) ≃ᵐ α × α :=
   piFinTwo fun _ => α
 
@@ -559,7 +559,7 @@ def finTwoArrow : (Fin 2 → α) ≃ᵐ α × α :=
 `α i × Π j : Fin n, α (Fin.succAbove i j)`.
 
 Measurable version of `Fin.insertNthEquiv`. -/
-@[simps! (config := .asFn)]
+@[simps! -fullyApplied]
 def piFinSuccAbove {n : ℕ} (α : Fin (n + 1) → Type*) [∀ i, MeasurableSpace (α i)]
     (i : Fin (n + 1)) : (∀ j, α j) ≃ᵐ α i × ∀ j, α (i.succAbove j) where
   toEquiv := (Fin.insertNthEquiv α i).symm
@@ -572,7 +572,7 @@ variable (π)
 
 /-- Measurable equivalence between (dependent) functions on a type and pairs of functions on
 `{i // p i}` and `{i // ¬p i}`. See also `Equiv.piEquivPiSubtypeProd`. -/
-@[simps! (config := .asFn)]
+@[simps! -fullyApplied]
 def piEquivPiSubtypeProd (p : δ' → Prop) [DecidablePred p] :
     (∀ i, π i) ≃ᵐ (∀ i : Subtype p, π i) × ∀ i : { i // ¬p i }, π i where
   toEquiv := .piEquivPiSubtypeProd p π

--- a/Mathlib/NumberTheory/ModularForms/SlashInvariantForms.lean
+++ b/Mathlib/NumberTheory/ModularForms/SlashInvariantForms.lean
@@ -175,7 +175,7 @@ instance : Module ℂ (SlashInvariantForm Γ k) :=
   coeHom_injective.module ℂ coeHom fun _ _ => rfl
 
 /-- The `SlashInvariantForm` corresponding to `Function.const _ x`. -/
-@[simps (config := .asFn)]
+@[simps -fullyApplied]
 def const (x : ℂ) : SlashInvariantForm Γ 0 where
   toFun := Function.const _ x
   slash_action_eq' A _ := ModularForm.is_invariant_const A x

--- a/Mathlib/Order/Category/PartOrd.lean
+++ b/Mathlib/Order/Category/PartOrd.lean
@@ -195,7 +195,7 @@ def preordToPartOrdForgetAdjunction :
 -- The `simpNF` linter would complain as `Functor.comp_obj`, `Preord.dual_obj` both apply to LHS
 -- of `preordToPartOrdCompToDualIsoToDualCompPreordToPartOrd_hom_app_coe`
 /-- `PreordToPartOrd` and `OrderDual` commute. -/
-@[simps! inv_app_hom_coe, simps! (config := .lemmasOnly) hom_app_hom_coe]
+@[simps! inv_app_hom_coe, simps! -isSimp hom_app_hom_coe]
 def preordToPartOrdCompToDualIsoToDualCompPreordToPartOrd :
     preordToPartOrd.{u} ⋙ PartOrd.dual ≅ Preord.dual ⋙ preordToPartOrd :=
   NatIso.ofComponents (fun _ => PartOrd.Iso.mk <| OrderIso.dualAntisymmetrization _)

--- a/Mathlib/Order/Hom/Basic.lean
+++ b/Mathlib/Order/Hom/Basic.lean
@@ -267,7 +267,7 @@ theorem copy_eq (f : α →o β) (f' : α → β) (h : f' = f) : f.copy f' h = f
   DFunLike.ext' h
 
 /-- The identity function as bundled monotone function. -/
-@[simps (config := .asFn)]
+@[simps -fullyApplied]
 def id : α →o α :=
   ⟨_root_.id, monotone_id⟩
 
@@ -314,7 +314,7 @@ theorem curry_symm_apply (f : α →o β →o γ) (x : α × β) : curry.symm f 
   rfl
 
 /-- The composition of two bundled monotone functions. -/
-@[simps (config := .asFn)]
+@[simps -fullyApplied]
 def comp (g : β →o γ) (f : α →o β) : α →o γ :=
   ⟨g ∘ f, g.mono.comp f.mono⟩
 
@@ -326,7 +326,7 @@ theorem comp_mono ⦃g₁ g₂ : β →o γ⦄ (hg : g₁ ≤ g₂) ⦃f₁ f₂
     comp ⟨g, hg⟩ ⟨f, hf⟩ = ⟨g ∘ f, hg.comp hf⟩ := rfl
 
 /-- The composition of two bundled monotone functions, a fully bundled version. -/
-@[simps! (config := .asFn)]
+@[simps! -fullyApplied]
 def compₘ : (β →o γ) →o (α →o β) →o α →o γ :=
   curry ⟨fun f : (β →o γ) × (α →o β) => f.1.comp f.2, fun _ _ h => comp_mono h.1 h.2⟩
 
@@ -341,7 +341,7 @@ theorem id_comp (f : α →o β) : comp id f = f := by
   rfl
 
 /-- Constant function bundled as an `OrderHom`. -/
-@[simps (config := .asFn)]
+@[simps -fullyApplied]
 def const (α : Type*) [Preorder α] {β : Type*} [Preorder β] : β →o α →o β where
   toFun b := ⟨Function.const α b, fun _ _ _ => le_rfl⟩
   monotone' _ _ h _ := h
@@ -426,20 +426,20 @@ def prodMap (f : α →o β) (g : γ →o δ) : α × γ →o β × δ :=
 variable {ι : Type*} {π : ι → Type*} [∀ i, Preorder (π i)]
 
 /-- Evaluation of an unbundled function at a point (`Function.eval`) as an `OrderHom`. -/
-@[simps (config := .asFn)]
+@[simps -fullyApplied]
 def _root_.Pi.evalOrderHom (i : ι) : (∀ j, π j) →o π i :=
   ⟨Function.eval i, Function.monotone_eval i⟩
 
 /-- The "forgetful functor" from `α →o β` to `α → β` that takes the underlying function,
 is monotone. -/
-@[simps (config := .asFn)]
+@[simps -fullyApplied]
 def coeFnHom : (α →o β) →o α → β where
   toFun f := f
   monotone' _ _ h := h
 
 /-- Function application `fun f => f a` (for fixed `a`) is a monotone function from the
 monotone function space `α →o β` to `β`. See also `Pi.evalOrderHom`. -/
-@[simps! (config := .asFn)]
+@[simps! -fullyApplied]
 def apply (x : α) : (α →o β) →o β :=
   (Pi.evalOrderHom x).comp coeFnHom
 
@@ -460,7 +460,7 @@ def piIso : (α →o ∀ i, π i) ≃o ∀ i, α →o π i where
   map_rel_iff' := forall_swap
 
 /-- `Subtype.val` as a bundled monotone function. -/
-@[simps (config := .asFn)]
+@[simps -fullyApplied]
 def Subtype.val (p : α → Prop) : Subtype p →o α :=
   ⟨_root_.Subtype.val, fun _ _ h => h⟩
 
@@ -512,12 +512,12 @@ def dualIso (α β : Type*) [Preorder α] [Preorder β] : (α →o β) ≃o (α�
   map_rel_iff' := Iff.rfl
 
 /-- Lift an order homomorphism `f : α →o β` to an order homomorphism `WithBot α →o WithBot β`. -/
-@[simps (config := .asFn)]
+@[simps -fullyApplied]
 protected def withBotMap (f : α →o β) : WithBot α →o WithBot β :=
   ⟨WithBot.map f, f.mono.withBot_map⟩
 
 /-- Lift an order homomorphism `f : α →o β` to an order homomorphism `WithTop α →o WithTop β`. -/
-@[simps (config := .asFn)]
+@[simps -fullyApplied]
 protected def withTopMap (f : α →o β) : WithTop α →o WithTop β :=
   ⟨WithTop.map f, f.mono.withTop_map⟩
 
@@ -600,25 +600,25 @@ protected theorem wellFoundedGT [WellFoundedGT β] (f : α ↪o β) : WellFounde
   @OrderEmbedding.wellFoundedLT αᵒᵈ _ _ _ _ f.dual
 
 /-- A version of `WithBot.map` for order embeddings. -/
-@[simps! (config := .asFn)]
+@[simps! -fullyApplied]
 protected def withBotMap (f : α ↪o β) : WithBot α ↪o WithBot β where
   __ := f.toEmbedding.optionMap
   map_rel_iff' := WithBot.map_le_iff f f.map_rel_iff
 
 /-- A version of `WithTop.map` for order embeddings. -/
-@[simps (config := .asFn)]
+@[simps -fullyApplied]
 protected def withTopMap (f : α ↪o β) : WithTop α ↪o WithTop β :=
   { f.dual.withBotMap.dual with toFun := WithTop.map f }
 
 /-- Coercion `α → WithBot α` as an `OrderEmbedding`. -/
-@[simps (config := .asFn)]
+@[simps -fullyApplied]
 protected def withBotCoe : α ↪o WithBot α where
   toFun := .some
   inj' := Option.some_injective _
   map_rel_iff' := WithBot.coe_le_coe
 
 /-- Coercion `α → WithTop α` as an `OrderEmbedding`. -/
-@[simps (config := .asFn)]
+@[simps -fullyApplied]
 protected def withTopCoe : α ↪o WithTop α :=
   { (OrderEmbedding.withBotCoe (α := αᵒᵈ)).dual with toFun := .some }
 
@@ -659,7 +659,7 @@ theorem coe_subtype (p : α → Prop) : ⇑(subtype p) = Subtype.val :=
   rfl
 
 /-- Convert an `OrderEmbedding` to an `OrderHom`. -/
-@[simps (config := .asFn)]
+@[simps -fullyApplied]
 def toOrderHom {X Y : Type*} [Preorder X] [Preorder Y] (f : X ↪o Y) : X →o Y where
   toFun := f
   monotone' := f.monotone
@@ -713,7 +713,7 @@ variable (f : ((· < ·) : α → α → Prop) →r ((· < ·) : β → β → P
 
 /-- A bundled expression of the fact that a map between partial orders that is strictly monotone
 is weakly monotone. -/
-@[simps (config := .asFn)]
+@[simps -fullyApplied]
 def toOrderHom : α →o β where
   toFun := f
   monotone' := StrictMono.monotone fun _ _ => f.map_rel
@@ -1086,7 +1086,7 @@ variable [LinearOrder α] [Preorder β]
 variable (f : α → β) (h_mono : StrictMono f)
 
 /-- A strictly monotone function with a right inverse is an order isomorphism. -/
-@[simps (config := .asFn)]
+@[simps -fullyApplied]
 def orderIsoOfRightInverse (g : β → α) (hg : Function.RightInverse g f) : α ≃o β :=
   { OrderEmbedding.ofStrictMono f h_mono with
     toFun := f,

--- a/Mathlib/Order/OmegaCompletePartialOrder.lean
+++ b/Mathlib/Order/OmegaCompletePartialOrder.lean
@@ -90,7 +90,7 @@ lemma directed : Directed (· ≤ ·) c := directedOn_range.2 c.isChain_range.di
 
 /-- `map` function for `Chain` -/
 -- Porting note: `simps` doesn't work with type synonyms
--- @[simps! (config := .asFn)]
+-- @[simps! -fullyApplied]
 def map : Chain β :=
   f.comp c
 

--- a/Mathlib/Order/Partition/Finpartition.lean
+++ b/Mathlib/Order/Partition/Finpartition.lean
@@ -604,7 +604,7 @@ variable [Fintype α]
 
 /-- A setoid over a finite type induces a finpartition of the type's elements,
 where the parts are the setoid's equivalence classes. -/
-@[simps (config := .lemmasOnly)]
+@[simps -isSimp]
 def ofSetoid (s : Setoid α) [DecidableRel s.r] : Finpartition (univ : Finset α) where
   parts := univ.image fun a ↦ ({b | s.r a b} : Finset α)
   supIndep := by

--- a/Mathlib/RepresentationTheory/GroupCohomology/Functoriality.lean
+++ b/Mathlib/RepresentationTheory/GroupCohomology/Functoriality.lean
@@ -33,7 +33,7 @@ variable {k G H : Type u} [CommRing k] [Group G] [Group H]
 
 /-- Given a group homomorphism `f : G →* H` and a representation morphism `φ : Res(f)(A) ⟶ B`,
 this is the chain map sending `x : Hⁿ → A` to `(g : Gⁿ) ↦ φ (x (f ∘ g))`. -/
-@[simps! (config := .lemmasOnly) f f_hom]
+@[simps! -isSimp f f_hom]
 noncomputable def cochainsMap :
     inhomogeneousCochains A ⟶ inhomogeneousCochains B where
   f i := ModuleCat.ofHom <|

--- a/Mathlib/RingTheory/AdjoinRoot.lean
+++ b/Mathlib/RingTheory/AdjoinRoot.lean
@@ -578,7 +578,7 @@ such that `pb.gen` has a minimal polynomial `g`, then `S` is isomorphic to `Adjo
 Compare `PowerBasis.equivOfRoot`, which would require
 `h₂ : aeval pb.gen (minpoly R (root g)) = 0`; that minimal polynomial is not
 guaranteed to be identical to `g`. -/
-@[simps (config := .asFn)]
+@[simps -fullyApplied]
 def equiv' (h₁ : aeval (root g) (minpoly R pb.gen) = 0) (h₂ : aeval pb.gen g = 0) :
     AdjoinRoot g ≃ₐ[R] S :=
   { AdjoinRoot.liftHom g pb.gen h₂ with

--- a/Mathlib/RingTheory/Bialgebra/Hom.lean
+++ b/Mathlib/RingTheory/Bialgebra/Hom.lean
@@ -272,7 +272,7 @@ theorem map_smul_of_tower {R'} [SMul R' A] [SMul R' B] [LinearMap.CompatibleSMul
     (x : A) : φ (r • x) = r • φ x :=
   φ.toLinearMap.map_smul_of_tower r x
 
-@[simps (config := .lemmasOnly) toSemigroup_toMul_mul toOne_one]
+@[simps -isSimp toSemigroup_toMul_mul toOne_one]
 instance End : Monoid (A →ₐc[R] A) where
   mul := comp
   mul_assoc _ _ _ := rfl

--- a/Mathlib/RingTheory/Coalgebra/Hom.lean
+++ b/Mathlib/RingTheory/Coalgebra/Hom.lean
@@ -238,7 +238,7 @@ theorem map_smul_of_tower {R'} [SMul R' A] [SMul R' B] [LinearMap.CompatibleSMul
     (x : A) : φ (r • x) = r • φ x :=
   φ.toLinearMap.map_smul_of_tower r x
 
-@[simps (config := .lemmasOnly) toSemigroup_toMul_mul toOne_one]
+@[simps -isSimp toSemigroup_toMul_mul toOne_one]
 instance End : Monoid (A →ₗc[R] A) where
   mul := comp
   mul_assoc _ _ _ := rfl

--- a/Mathlib/RingTheory/Derivation/ToSquareZero.lean
+++ b/Mathlib/RingTheory/Derivation/ToSquareZero.lean
@@ -75,7 +75,7 @@ theorem derivationToSquareZeroOfLift_apply [IsScalarTower R A B] (f : A →ₐ[R
 
 /-- Given a tower of algebras `R → A → B`, and a square-zero `I : Ideal B`, each `R`-derivation
 from `A` to `I` corresponds to a lift `A →ₐ[R] B` of the canonical map `A →ₐ[R] B ⧸ I`. -/
-@[simps (config := .lemmasOnly)]
+@[simps -isSimp]
 def liftOfDerivationToSquareZero [IsScalarTower R A B]  (hI : I ^ 2 = ⊥) (f : Derivation R A I) :
     A →ₐ[R] B :=
   { ((I.restrictScalars R).subtype.comp f.toLinearMap + (IsScalarTower.toAlgHom R A B).toLinearMap :

--- a/Mathlib/RingTheory/Extension.lean
+++ b/Mathlib/RingTheory/Extension.lean
@@ -92,7 +92,7 @@ lemma algebraMap_surjective : Function.Surjective (algebraMap P.Ring S) := (⟨_
 section Construction
 
 /-- Construct `Extension` from a surjective algebra homomorphism. -/
-@[simps (config := .lemmasOnly) Ring σ]
+@[simps -isSimp Ring σ]
 noncomputable
 def ofSurjective {P : Type w} [CommRing P] [Algebra R P] (f : P →ₐ[R] S)
     (h : Function.Surjective f) : Extension.{w} R S where
@@ -104,7 +104,7 @@ def ofSurjective {P : Type w} [CommRing P] [Algebra R P] (f : P →ₐ[R] S)
 
 variable (R S) in
 /-- The trivial extension of `S`. -/
-@[simps (config := .lemmasOnly) Ring σ]
+@[simps -isSimp Ring σ]
 noncomputable
 def self : Extension R S where
   Ring := S

--- a/Mathlib/RingTheory/Generators.lean
+++ b/Mathlib/RingTheory/Generators.lean
@@ -112,7 +112,7 @@ lemma algebraMap_surjective : Function.Surjective (algebraMap P.Ring S) :=
 section Construction
 
 /-- Construct `Generators` from an assignment `I → S` such that `R[X] → S` is surjective. -/
-@[simps val, simps (config := .lemmasOnly) vars]
+@[simps val, simps -isSimp vars]
 noncomputable
 def ofSurjective {vars} (val : vars → S) (h : Function.Surjective (aeval (R := R) val)) :
     Generators R S where
@@ -170,7 +170,7 @@ variable (r : R) [IsLocalization.Away r S]
 
 /-- If `S` is the localization of `R` away from `r`, we obtain a canonical generator mapping
 to the inverse of `r`. -/
-@[simps val, simps (config := .lemmasOnly) vars σ]
+@[simps val, simps -isSimp vars σ]
 noncomputable
 def localizationAway : Generators R S where
   vars := Unit
@@ -193,7 +193,7 @@ variable {T} [CommRing T] [Algebra R T] [Algebra S T] [IsScalarTower R S T]
 
 /-- Given two families of generators `S[X] → T` and `R[Y] → S`,
 we may construct the family of generators `R[X, Y] → T`. -/
-@[simps val, simps (config := .lemmasOnly) vars σ]
+@[simps val, simps -isSimp vars σ]
 noncomputable
 def comp (Q : Generators S T) (P : Generators R S) : Generators R T where
   vars := Q.vars ⊕ P.vars
@@ -210,7 +210,7 @@ def comp (Q : Generators S T) (P : Generators R S) : Generators R T where
 variable (S) in
 /-- If `R → S → T` is a tower of algebras, a family of generators `R[X] → T`
 gives a family of generators `S[X] → T`. -/
-@[simps val, simps (config := .lemmasOnly) vars]
+@[simps val, simps -isSimp vars]
 noncomputable
 def extendScalars (P : Generators R T) : Generators S T where
   vars := P.vars
@@ -220,7 +220,7 @@ def extendScalars (P : Generators R T) : Generators S T where
 
 /-- If `P` is a family of generators of `S` over `R` and `T` is an `R`-algebra, we
 obtain a natural family of generators of `T ⊗[R] S` over `T`. -/
-@[simps! val, simps! (config := .lemmasOnly) vars]
+@[simps! val, simps! -isSimp vars]
 noncomputable
 def baseChange {T} [CommRing T] [Algebra R T] (P : Generators R S) : Generators T (T ⊗[R] S) := by
   apply Generators.ofSurjective (fun x ↦ 1 ⊗ₜ[R] P.val x)

--- a/Mathlib/RingTheory/HahnSeries/Addition.lean
+++ b/Mathlib/RingTheory/HahnSeries/Addition.lean
@@ -86,7 +86,7 @@ protected lemma map_add [AddMonoid S] (f : R →+ S) {x y : HahnSeries Γ R} :
 Hahn series over `Γ` with coefficients in the opposite additive monoid `Rᵃᵒᵖ`
 and the additive opposite of Hahn series over `Γ` with coefficients `R`.
 -/
-@[simps (config := .lemmasOnly)]
+@[simps -isSimp]
 def addOppositeEquiv : HahnSeries Γ (Rᵃᵒᵖ) ≃+ (HahnSeries Γ R)ᵃᵒᵖ where
   toFun x := .op ⟨fun a ↦ (x.coeff a).unop, by convert x.isPWO_support; ext; simp⟩
   invFun x := ⟨fun a ↦ .op (x.unop.coeff a), by convert x.unop.isPWO_support; ext; simp⟩

--- a/Mathlib/RingTheory/Ideal/Cotangent.lean
+++ b/Mathlib/RingTheory/Ideal/Cotangent.lean
@@ -52,7 +52,7 @@ instance [IsNoetherian R I] : IsNoetherian R I.Cotangent :=
   inferInstanceAs (IsNoetherian R (I ⧸ (I • ⊤ : Submodule R I)))
 
 /-- The quotient map from `I` to `I ⧸ I ^ 2`. -/
-@[simps! (config := .lemmasOnly) apply]
+@[simps! -isSimp apply]
 def toCotangent : I →ₗ[R] I.Cotangent := Submodule.mkQ _
 
 theorem map_toCotangent_ker : I.toCotangent.ker.map I.subtype = I ^ 2 := by

--- a/Mathlib/RingTheory/IsTensorProduct.lean
+++ b/Mathlib/RingTheory/IsTensorProduct.lean
@@ -476,7 +476,7 @@ lemma Algebra.IsPushout.equiv_symm_algebraMap_right [Algebra.IsPushout R S R' S'
 /-- If `S' = S ⊗[R] R'`, then any pair of `R`-algebra homomorphisms `f : S → A` and `g : R' → A`
 such that `f x` and `g y` commutes for all `x, y` descends to a (unique) homomorphism `S' → A`.
 -/
-@[simps! (config := .lemmasOnly) apply]
+@[simps! -isSimp apply]
 noncomputable def Algebra.pushoutDesc [H : Algebra.IsPushout R S R' S'] {A : Type*} [Semiring A]
     [Algebra R A] (f : S →ₐ[R] A) (g : R' →ₐ[R] A) (hf : ∀ x y, f x * g y = g y * f x) :
     S' →ₐ[R] A :=

--- a/Mathlib/RingTheory/PowerBasis.lean
+++ b/Mathlib/RingTheory/PowerBasis.lean
@@ -311,7 +311,7 @@ noncomputable def liftEquiv (pb : PowerBasis A S) :
 
 /-- `pb.liftEquiv'` states that elements of the root set of the minimal
 polynomial of `pb.gen` correspond to maps sending `pb.gen` to that root. -/
-@[simps! (config := .asFn)]
+@[simps! -fullyApplied]
 noncomputable def liftEquiv' [IsDomain B] (pb : PowerBasis A S) :
     (S →ₐ[A] B) ≃ { y : B // y ∈ (minpoly A pb.gen).aroots B } :=
   pb.liftEquiv.trans ((Equiv.refl _).subtypeEquiv fun x => by
@@ -331,7 +331,7 @@ where "the same" means that `pb` is a root of `pb'`s minimal polynomial and vice
 See also `PowerBasis.equivOfMinpoly` which takes the hypothesis that the
 minimal polynomials are identical.
 -/
-@[simps! (config := .lemmasOnly) apply]
+@[simps! -isSimp apply]
 noncomputable def equivOfRoot (pb : PowerBasis A S) (pb' : PowerBasis A S')
     (h₁ : aeval pb.gen (minpoly A pb'.gen) = 0) (h₂ : aeval pb'.gen (minpoly A pb.gen) = 0) :
     S ≃ₐ[A] S' :=
@@ -369,7 +369,7 @@ where "the same" means that they have identical minimal polynomials.
 See also `PowerBasis.equivOfRoot` which takes the hypothesis that each generator is a root of the
 other basis' minimal polynomial; `PowerBasis.equivOfRoot` is more general if `A` is not a field.
 -/
-@[simps! (config := .lemmasOnly) apply]
+@[simps! -isSimp apply]
 noncomputable def equivOfMinpoly (pb : PowerBasis A S) (pb' : PowerBasis A S')
     (h : minpoly A pb.gen = minpoly A pb'.gen) : S ≃ₐ[A] S' :=
   pb.equivOfRoot pb' (h ▸ minpoly.aeval _ _) (h.symm ▸ minpoly.aeval _ _)

--- a/Mathlib/RingTheory/Presentation.lean
+++ b/Mathlib/RingTheory/Presentation.lean
@@ -209,7 +209,7 @@ lemma _root_.Algebra.Generators.ker_localizationAway :
 variable (S) in
 /-- If `S` is the localization of `R` away from `r`, we can construct a natural
 presentation of `S` as `R`-algebra with a single generator `X` and the relation `r * X - 1 = 0`. -/
-@[simps relation, simps (config := .lemmasOnly) rels]
+@[simps relation, simps -isSimp rels]
 noncomputable def localizationAway : Presentation R S where
   toGenerators := Generators.localizationAway r
   rels := Unit
@@ -286,7 +286,7 @@ private lemma span_range_relation_eq_ker_baseChange :
 
 /-- If `P` is a presentation of `S` over `R` and `T` is an `R`-algebra, we
 obtain a natural presentation of `T ⊗[R] S` over `T`. -/
-@[simps relation, simps (config := .lemmasOnly) rels]
+@[simps relation, simps -isSimp rels]
 noncomputable
 def baseChange : Presentation T (T ⊗[R] S) where
   __ := Generators.baseChange P.toGenerators
@@ -431,7 +431,7 @@ private lemma span_range_relation_eq_ker_comp : Ideal.span
 
 /-- Given presentations of `T` over `S` and of `S` over `R`,
 we may construct a presentation of `T` over `R`. -/
-@[simps rels, simps (config := .lemmasOnly) relation]
+@[simps rels, simps -isSimp relation]
 noncomputable def comp : Presentation R T where
   toGenerators := Q.toGenerators.comp P.toGenerators
   rels := Q.rels ⊕ P.rels

--- a/Mathlib/RingTheory/RootsOfUnity/PrimitiveRoots.lean
+++ b/Mathlib/RingTheory/RootsOfUnity/PrimitiveRoots.lean
@@ -501,7 +501,7 @@ lemma map_rootsOfUnity {S F} [CommRing S] [IsDomain S] [FunLike F R S] [MonoidHo
 /-- If `R` contains an `n`-th primitive root, and `S/R` is a ring extension,
 then the `n`-th roots of unity in `R` and `S` are isomorphic.
 Also see `IsPrimitiveRoot.map_rootsOfUnity` for the equality as `Subgroup Sˣ`. -/
-@[simps! (config := .lemmasOnly) apply_coe_val apply_coe_inv_val]
+@[simps! -isSimp apply_coe_val apply_coe_inv_val]
 noncomputable
 def _root_.rootsOfUnityEquivOfPrimitiveRoots {S F} [CommRing S] [IsDomain S]
     [FunLike F R S] [MonoidHomClass F R S]

--- a/Mathlib/RingTheory/WittVector/Frobenius.lean
+++ b/Mathlib/RingTheory/WittVector/Frobenius.lean
@@ -290,7 +290,7 @@ theorem frobenius_zmodp (x : 𝕎 (ZMod p)) : frobenius x = x := by
 variable (R)
 
 /-- `WittVector.frobenius` as an equiv. -/
-@[simps (config := .asFn)]
+@[simps -fullyApplied]
 def frobeniusEquiv [PerfectRing R p] : WittVector p R ≃+* WittVector p R :=
   { (WittVector.frobenius : WittVector p R →+* WittVector p R) with
     toFun := WittVector.frobenius

--- a/Mathlib/SetTheory/Ordinal/Basic.lean
+++ b/Mathlib/SetTheory/Ordinal/Basic.lean
@@ -525,7 +525,7 @@ theorem relIso_enum {α β : Type u} {r : α → α → Prop} {s : β → β →
   relIso_enum' _ _ _ _
 
 /-- The order isomorphism between ordinals less than `o` and `o.toType`. -/
-@[simps! (config := .lemmasOnly)]
+@[simps! -isSimp]
 noncomputable def enumIsoToType (o : Ordinal) : Set.Iio o ≃o o.toType where
   toFun x := enum (α := o.toType) (· < ·) ⟨x.1, type_toType _ ▸ x.2⟩
   invFun x := ⟨typein (α := o.toType) (· < ·) x, typein_lt_self x⟩

--- a/Mathlib/Tactic/Simps/Basic.lean
+++ b/Mathlib/Tactic/Simps/Basic.lean
@@ -315,15 +315,15 @@ Some common uses:
   This will generate `foo_apply` lemmas for each declaration `foo`.
 * If you prefer `coe_foo` lemmas that state equalities between functions, use
   `initialize_simps_projections MulHom (toFun → coe, as_prefix coe)`
-  In this case you have to use `@[simps (config := .asFn)]` whenever you call `@[simps]`.
+  In this case you have to use `@[simps -fullyApplied]` whenever you call `@[simps]`.
 * You can also initialize to use both, in which case you have to choose which one to use by default,
   by using either of the following
   ```
     initialize_simps_projections MulHom (toFun → apply, toFun → coe, as_prefix coe, -coe)
     initialize_simps_projections MulHom (toFun → apply, toFun → coe, as_prefix coe, -apply)
   ```
-  In the first case, you can get both lemmas using `@[simps, simps (config := .asFn) coe]` and in
-  the second case you can get both lemmas using `@[simps (config := .asFn), simps apply]`.
+  In the first case, you can get both lemmas using `@[simps, simps -fullyApplied coe]` and in
+  the second case you can get both lemmas using `@[simps -fullyApplied, simps apply]`.
 * If you declare a new homomorphism-like structure (like `RelEmbedding`),
   then `initialize_simps_projections` will automatically find any `DFunLike` coercions
   that will be used as the default projection for the `toFun` field.
@@ -877,12 +877,14 @@ structure Config where
 declare_command_config_elab elabSimpsConfig Config
 
 /-- A common configuration for `@[simps]`: generate equalities between functions instead equalities
-between fully applied Expressions. Use this using `@[simps (config := .asFn)]`. -/
+between fully applied Expressions. Replaced by `@[simps -fullyApplied]`. -/
+@[deprecated "use `-fullyApplied` instead" (since := "2025-03-10")]
 def Config.asFn : Simps.Config where
   fullyApplied := false
 
 /-- A common configuration for `@[simps]`: don't tag the generated lemmas with `@[simp]`.
-Use this using `@[simps (config := .lemmasOnly)]`. -/
+Replaced by `@[simps -isSimp]`. -/
+@[deprecated "use `-isSimp` instead" (since := "2025-03-10")]
 def Config.lemmasOnly : Config where
   isSimp := false
 

--- a/Mathlib/Topology/Algebra/ConstMulAction.lean
+++ b/Mathlib/Topology/Algebra/ConstMulAction.lean
@@ -302,7 +302,7 @@ theorem continuous_const_smul_iff₀ (hc : c ≠ 0) : (Continuous fun x => c •
 
 /-- Scalar multiplication by a non-zero element of a group with zero acting on `α` is a
 homeomorphism from `α` onto itself. -/
-@[simps! (config := .asFn) apply]
+@[simps! -fullyApplied apply]
 protected def Homeomorph.smulOfNeZero (c : G₀) (hc : c ≠ 0) : α ≃ₜ α :=
   Homeomorph.smul (Units.mk0 c hc)
 

--- a/Mathlib/Topology/Algebra/Module/Alternating/Basic.lean
+++ b/Mathlib/Topology/Algebra/Module/Alternating/Basic.lean
@@ -546,7 +546,7 @@ def toContinuousMultilinearMapLinear :
 
 /-- Linear map version of the map `toAlternatingMap`
 associating to a continuous alternating map the corresponding alternating map. -/
-@[simps (config := .asFn) apply]
+@[simps -fullyApplied apply]
 def toAlternatingMapLinear : (M [⋀^ι]→L[A] N) →ₗ[R] (M [⋀^ι]→ₗ[A] N) where
   toFun := toAlternatingMap
   map_add' := by simp
@@ -611,7 +611,7 @@ variable {R M N ι : Type*} [Semiring R] [AddCommMonoid M] [Module R M] [Topolog
   [DecidableEq ι] (f : ContinuousMultilinearMap R (fun _ : ι => M) N)
 
 /-- Alternatization of a continuous multilinear map. -/
-@[simps (config := .lemmasOnly) apply_toContinuousMultilinearMap]
+@[simps -isSimp apply_toContinuousMultilinearMap]
 def alternatization : ContinuousMultilinearMap R (fun _ : ι => M) N →+ M [⋀^ι]→L[R] N where
   toFun f :=
     { toContinuousMultilinearMap := ∑ σ : Equiv.Perm ι, Equiv.Perm.sign σ • f.domDomCongr σ

--- a/Mathlib/Topology/Algebra/Module/Alternating/Topology.lean
+++ b/Mathlib/Topology/Algebra/Module/Alternating/Topology.lean
@@ -220,7 +220,7 @@ theorem continuous_restrictScalars :
 
 variable (𝕜') in
 /-- `ContinuousMultilinearMap.restrictScalars` as a `ContinuousLinearMap`. -/
-@[simps (config := .asFn) apply]
+@[simps -fullyApplied apply]
 def restrictScalarsCLM [ContinuousConstSMul 𝕜' F] :
     E [⋀^ι]→L[𝕜] F →L[𝕜'] E [⋀^ι]→L[𝕜'] F where
   toFun := restrictScalars 𝕜'

--- a/Mathlib/Topology/Algebra/Module/Basic.lean
+++ b/Mathlib/Topology/Algebra/Module/Basic.lean
@@ -218,7 +218,7 @@ variable [ContinuousAdd M₂] {σ : R →+* S} {l : Filter α}
 
 /-- Constructs a bundled linear map from a function and a proof that this function belongs to the
 closure of the set of linear maps. -/
-@[simps (config := .asFn)]
+@[simps -fullyApplied]
 def linearMapOfMemClosureRangeCoe (f : M₁ → M₂)
     (hf : f ∈ closure (Set.range ((↑) : (M₁ →ₛₗ[σ] M₂) → M₁ → M₂))) : M₁ →ₛₗ[σ] M₂ :=
   { addMonoidHomOfMemClosureRangeCoe f hf with
@@ -226,7 +226,7 @@ def linearMapOfMemClosureRangeCoe (f : M₁ → M₂)
       (Set.range_subset_iff.2 LinearMap.map_smulₛₗ) hf }
 
 /-- Construct a bundled linear map from a pointwise limit of linear maps -/
-@[simps! (config := .asFn)]
+@[simps! -fullyApplied]
 def linearMapOfTendsto (f : M₁ → M₂) (g : α → M₁ →ₛₗ[σ] M₂) [l.NeBot]
     (h : Tendsto (fun a x => g a x) l (𝓝 f)) : M₁ →ₛₗ[σ] M₂ :=
   linearMapOfMemClosureRangeCoe f <|

--- a/Mathlib/Topology/Algebra/Module/Equiv.lean
+++ b/Mathlib/Topology/Algebra/Module/Equiv.lean
@@ -599,7 +599,7 @@ def sumPiEquivProdPi (R : Type*) [Semiring R] (S T : Type*)
 
 This is `Equiv.piUnique` as a `ContinuousLinearEquiv`.
 -/
-@[simps! (config := .asFn)]
+@[simps! -fullyApplied]
 def piUnique {α : Type*} [Unique α] (R : Type*) [Semiring R] (f : α → Type*)
     [∀ x, AddCommMonoid (f x)] [∀ x, Module R (f x)] [∀ x, TopologicalSpace (f x)] :
     (Π t, f t) ≃L[R] f default where
@@ -845,13 +845,13 @@ variable (R M)
 
 /-- Continuous linear equivalence between dependent functions `(i : Fin 2) → M i` and `M 0 × M 1`.
 -/
-@[simps! (config := .asFn) apply symm_apply]
+@[simps! -fullyApplied apply symm_apply]
 def piFinTwo (M : Fin 2 → Type*) [∀ i, AddCommMonoid (M i)] [∀ i, Module R (M i)]
     [∀ i, TopologicalSpace (M i)] : ((i : _) → M i) ≃L[R] M 0 × M 1 :=
   { Homeomorph.piFinTwo M with toLinearEquiv := LinearEquiv.piFinTwo R M }
 
 /-- Continuous linear equivalence between vectors in `M² = Fin 2 → M` and `M × M`. -/
-@[simps! (config := .asFn) apply symm_apply]
+@[simps! -fullyApplied apply symm_apply]
 def finTwoArrow : (Fin 2 → M) ≃L[R] M × M :=
   { piFinTwo R fun _ => M with toLinearEquiv := LinearEquiv.finTwoArrow R M }
 

--- a/Mathlib/Topology/Algebra/Module/Multilinear/Basic.lean
+++ b/Mathlib/Topology/Algebra/Module/Multilinear/Basic.lean
@@ -300,7 +300,7 @@ theorem _root_.ContinuousLinearMap.compContinuousMultilinearMap_coe (g : M₂ �
   rfl
 
 /-- `ContinuousMultilinearMap.prod` as an `Equiv`. -/
-@[simps apply symm_apply_fst symm_apply_snd, simps (config := .lemmasOnly) symm_apply]
+@[simps apply symm_apply_fst symm_apply_snd, simps -isSimp symm_apply]
 def prodEquiv :
     (ContinuousMultilinearMap R M₁ M₂ × ContinuousMultilinearMap R M₁ M₃) ≃
       ContinuousMultilinearMap R M₁ (M₂ × M₃) where

--- a/Mathlib/Topology/Algebra/Module/Multilinear/Topology.lean
+++ b/Mathlib/Topology/Algebra/Module/Multilinear/Topology.lean
@@ -256,7 +256,7 @@ theorem continuous_restrictScalars :
 
 variable (𝕜') in
 /-- `ContinuousMultilinearMap.restrictScalars` as a `ContinuousLinearMap`. -/
-@[simps (config := .asFn) apply]
+@[simps -fullyApplied apply]
 def restrictScalarsLinear [ContinuousConstSMul 𝕜' F] :
     ContinuousMultilinearMap 𝕜 E F →L[𝕜'] ContinuousMultilinearMap 𝕜' E F where
   toFun := restrictScalars 𝕜'

--- a/Mathlib/Topology/Algebra/Monoid.lean
+++ b/Mathlib/Topology/Algebra/Monoid.lean
@@ -312,7 +312,7 @@ variable {M₁ M₂} [Mul M₁] [Mul M₂] [ContinuousMul M₂]
 /-- Construct a bundled semigroup homomorphism `M₁ →ₙ* M₂` from a function `f` and a proof that it
 belongs to the closure of the range of the coercion from `M₁ →ₙ* M₂` (or another type of bundled
 homomorphisms that has a `MulHomClass` instance) to `M₁ → M₂`. -/
-@[to_additive (attr := simps (config := .asFn))
+@[to_additive (attr := simps -fullyApplied)
   "Construct a bundled additive semigroup homomorphism `M₁ →ₙ+ M₂` from a function `f`
 and a proof that it belongs to the closure of the range of the coercion from `M₁ →ₙ+ M₂` (or another
 type of bundled homomorphisms that has an `AddHomClass` instance) to `M₁ → M₂`."]
@@ -322,7 +322,7 @@ def mulHomOfMemClosureRangeCoe (f : M₁ → M₂)
   map_mul' := (isClosed_setOf_map_mul M₁ M₂).closure_subset_iff.2 (range_subset_iff.2 map_mul) hf
 
 /-- Construct a bundled semigroup homomorphism from a pointwise limit of semigroup homomorphisms. -/
-@[to_additive (attr := simps! (config := .asFn))
+@[to_additive (attr := simps! -fullyApplied)
   "Construct a bundled additive semigroup homomorphism from a pointwise limit of additive
 semigroup homomorphisms"]
 def mulHomOfTendsto (f : M₁ → M₂) (g : α → F) [l.NeBot]
@@ -346,7 +346,7 @@ variable {M₁ M₂} [MulOneClass M₁] [MulOneClass M₂] [ContinuousMul M₂]
 /-- Construct a bundled monoid homomorphism `M₁ →* M₂` from a function `f` and a proof that it
 belongs to the closure of the range of the coercion from `M₁ →* M₂` (or another type of bundled
 homomorphisms that has a `MonoidHomClass` instance) to `M₁ → M₂`. -/
-@[to_additive (attr := simps (config := .asFn))
+@[to_additive (attr := simps -fullyApplied)
   "Construct a bundled additive monoid homomorphism `M₁ →+ M₂` from a function `f`
 and a proof that it belongs to the closure of the range of the coercion from `M₁ →+ M₂` (or another
 type of bundled homomorphisms that has an `AddMonoidHomClass` instance) to `M₁ → M₂`."]
@@ -357,7 +357,7 @@ def monoidHomOfMemClosureRangeCoe (f : M₁ → M₂)
   map_mul' := (isClosed_setOf_map_mul M₁ M₂).closure_subset_iff.2 (range_subset_iff.2 map_mul) hf
 
 /-- Construct a bundled monoid homomorphism from a pointwise limit of monoid homomorphisms. -/
-@[to_additive (attr := simps! (config := .asFn))
+@[to_additive (attr := simps! -fullyApplied)
   "Construct a bundled additive monoid homomorphism from a pointwise limit of additive
 monoid homomorphisms"]
 def monoidHomOfTendsto (f : M₁ → M₂) (g : α → F) [l.NeBot]

--- a/Mathlib/Topology/Category/TopCat/Opens.lean
+++ b/Mathlib/Topology/Category/TopCat/Opens.lean
@@ -121,7 +121,7 @@ theorem toTopCat_map (X : TopCat.{u}) {U V : Opens X} {f : U ⟶ V} {x} {h} :
 
 /-- The inclusion map from an open subset to the whole space, as a morphism in `TopCat`.
 -/
-@[simps! (config := .asFn)]
+@[simps! -fullyApplied]
 def inclusion' {X : TopCat.{u}} (U : Opens X) : (toTopCat X).obj U ⟶ X :=
   TopCat.ofHom
   { toFun := _

--- a/Mathlib/Topology/CompactOpen.lean
+++ b/Mathlib/Topology/CompactOpen.lean
@@ -333,7 +333,7 @@ variable (X Y)
 
 /-- The coevaluation map `Y → C(X, Y × X)` sending a point `x : Y` to the continuous function
 on `X` sending `y` to `(x, y)`. -/
-@[simps (config := .asFn)]
+@[simps -fullyApplied]
 def coev (b : Y) : C(X, Y × X) :=
   { toFun := Prod.mk b }
 

--- a/Mathlib/Topology/ContinuousMap/Basic.lean
+++ b/Mathlib/Topology/ContinuousMap/Basic.lean
@@ -84,7 +84,7 @@ theorem coe_const (b : β) : ⇑(const α b) = Function.const α b :=
   rfl
 
 /-- `Function.const α b` as a bundled continuous function of `b`. -/
-@[simps (config := .asFn)]
+@[simps -fullyApplied]
 def constPi : C(β, α → β) where
   toFun b := Function.const α b
 
@@ -154,12 +154,12 @@ variable {α₁ α₂ β₁ β₂ : Type*} [TopologicalSpace α₁] [Topological
   [TopologicalSpace β₂]
 
 /-- `Prod.fst : (x, y) ↦ x` as a bundled continuous map. -/
-@[simps (config := .asFn)]
+@[simps -fullyApplied]
 def fst : C(α × β, α) where
   toFun := Prod.fst
 
 /-- `Prod.snd : (x, y) ↦ y` as a bundled continuous map. -/
-@[simps (config := .asFn)]
+@[simps -fullyApplied]
 def snd : C(α × β, β) where
   toFun := Prod.snd
 
@@ -227,7 +227,7 @@ theorem pi_eval (f : ∀ i, C(A, X i)) (a : A) : (pi f) a = fun i : I => (f i) a
   rfl
 
 /-- Evaluation at point as a bundled continuous map. -/
-@[simps (config := .asFn)]
+@[simps -fullyApplied]
 def eval (i : I) : C(∀ j, X j, X i) where
   toFun := Function.eval i
 

--- a/Mathlib/Topology/ContinuousMap/Bounded/Basic.lean
+++ b/Mathlib/Topology/ContinuousMap/Bounded/Basic.lean
@@ -261,7 +261,7 @@ alias embedding_coeFn := isEmbedding_coeFn
 
 variable (α) in
 /-- Constant as a continuous bounded function. -/
-@[simps! (config := .asFn)]
+@[simps! -fullyApplied]
 def const (b : β) : α →ᵇ β :=
   ⟨ContinuousMap.const α b, 0, by simp⟩
 

--- a/Mathlib/Topology/ContinuousMap/Compact.lean
+++ b/Mathlib/Topology/ContinuousMap/Compact.lean
@@ -40,7 +40,7 @@ variable (α β)
 /-- When `α` is compact, the bounded continuous maps `α →ᵇ β` are
 equivalent to `C(α, β)`.
 -/
-@[simps (config := .asFn)]
+@[simps -fullyApplied]
 def equivBoundedOfCompact : C(α, β) ≃ (α →ᵇ β) :=
   ⟨mkOfCompact, BoundedContinuousFunction.toContinuousMap, fun f => by
     ext
@@ -73,7 +73,7 @@ alias uniformEmbedding_equivBoundedOfCompact := isUniformEmbedding_equivBoundedO
 /-- When `α` is compact, the bounded continuous maps `α →ᵇ 𝕜` are
 additively equivalent to `C(α, 𝕜)`.
 -/
-@[simps! (config := .asFn) apply symm_apply]
+@[simps! -fullyApplied apply symm_apply]
 def addEquivBoundedOfCompact [AddMonoid β] [LipschitzAdd β] : C(α, β) ≃+ (α →ᵇ β) :=
   ({ toContinuousMapAddHom α β, (equivBoundedOfCompact α β).symm with } : (α →ᵇ β) ≃+ C(α, β)).symm
 
@@ -88,7 +88,7 @@ instance instMetricSpace {β : Type*} [MetricSpace β] :
 /-- When `α` is compact, and `β` is a metric space, the bounded continuous maps `α →ᵇ β` are
 isometric to `C(α, β)`.
 -/
-@[simps! (config := .asFn) toEquiv apply symm_apply]
+@[simps! -fullyApplied toEquiv apply symm_apply]
 def isometryEquivBoundedOfCompact : C(α, β) ≃ᵢ (α →ᵇ β) where
   isometry_toFun _ _ := rfl
   toEquiv := equivBoundedOfCompact α β

--- a/Mathlib/Topology/Homeomorph.lean
+++ b/Mathlib/Topology/Homeomorph.lean
@@ -98,7 +98,7 @@ theorem ext {h h' : X ≃ₜ Y} (H : ∀ x, h x = h' x) : h = h' :=
   DFunLike.ext _ _ H
 
 /-- Identity map as a homeomorphism. -/
-@[simps! (config := .asFn) apply]
+@[simps! -fullyApplied apply]
 protected def refl (X : Type*) [TopologicalSpace X] : X ≃ₜ X where
   continuous_toFun := continuous_id
   continuous_invFun := continuous_id
@@ -605,7 +605,7 @@ lemma sumSumSumComm_toEquiv : (sumSumSumComm X Y W Z).toEquiv = (Equiv.sumSumSum
 lemma sumSumSumComm_symm : (sumSumSumComm X Y W Z).symm = (sumSumSumComm X W Y Z) := rfl
 
 /-- The sum of `X` with any empty topological space is homeomorphic to `X`. -/
-@[simps! (config := .asFn) apply]
+@[simps! -fullyApplied apply]
 def sumEmpty [IsEmpty Y] : X ⊕ Y ≃ₜ X where
   toEquiv := Equiv.sumEmpty X Y
   continuous_toFun := Continuous.sumElim continuous_id (by fun_prop)
@@ -663,7 +663,7 @@ theorem prodProdProdComm_symm : (prodProdProdComm X Y W Z).symm = prodProdProdCo
   rfl
 
 /-- `X × {*}` is homeomorphic to `X`. -/
-@[simps! (config := .asFn) apply]
+@[simps! -fullyApplied apply]
 def prodPUnit : X × PUnit ≃ₜ X where
   toEquiv := Equiv.prodPUnit X
   continuous_toFun := continuous_fst
@@ -699,7 +699,7 @@ space `f ⬝` when `α` only contains `⬝`.
 
 This is `Equiv.piUnique` as a `Homeomorph`.
 -/
-@[simps! (config := .asFn)]
+@[simps! -fullyApplied]
 def piUnique {α : Type*} [Unique α] (f : α → Type*) [∀ x, TopologicalSpace (f x)] :
     (Π t, f t) ≃ₜ f default :=
   homeomorphOfContinuousOpen (Equiv.piUnique f) (continuous_apply default) (isOpenMap_eval _)
@@ -818,21 +818,21 @@ def sigmaProdDistrib : (Σ i, X i) × Y ≃ₜ Σ i, X i × Y :=
 end Distrib
 
 /-- If `ι` has a unique element, then `ι → X` is homeomorphic to `X`. -/
-@[simps! (config := .asFn)]
+@[simps! -fullyApplied]
 def funUnique (ι X : Type*) [Unique ι] [TopologicalSpace X] : (ι → X) ≃ₜ X where
   toEquiv := Equiv.funUnique ι X
   continuous_toFun := continuous_apply _
   continuous_invFun := continuous_pi fun _ => continuous_id
 
 /-- Homeomorphism between dependent functions `Π i : Fin 2, X i` and `X 0 × X 1`. -/
-@[simps! (config := .asFn)]
+@[simps! -fullyApplied]
 def piFinTwo.{u} (X : Fin 2 → Type u) [∀ i, TopologicalSpace (X i)] : (∀ i, X i) ≃ₜ X 0 × X 1 where
   toEquiv := piFinTwoEquiv X
   continuous_toFun := (continuous_apply 0).prod_mk (continuous_apply 1)
   continuous_invFun := continuous_pi <| Fin.forall_fin_two.2 ⟨continuous_fst, continuous_snd⟩
 
 /-- Homeomorphism between `X² = Fin 2 → X` and `X × X`. -/
-@[simps! (config := .asFn)]
+@[simps! -fullyApplied]
 def finTwoArrow : (Fin 2 → X) ≃ₜ X × X :=
   { piFinTwo fun _ => X with toEquiv := finTwoArrowEquiv X }
 
@@ -846,7 +846,7 @@ def image (e : X ≃ₜ Y) (s : Set X) : s ≃ₜ e '' s where
   toEquiv := e.toEquiv.image s
 
 /-- `Set.univ X` is homeomorphic to `X`. -/
-@[simps! (config := .asFn)]
+@[simps! -fullyApplied]
 def Set.univ (X : Type*) [TopologicalSpace X] : (univ : Set X) ≃ₜ X where
   toEquiv := Equiv.Set.univ X
   continuous_toFun := continuous_subtype_val

--- a/Mathlib/Topology/Instances/NNReal/Lemmas.lean
+++ b/Mathlib/Topology/Instances/NNReal/Lemmas.lean
@@ -52,7 +52,7 @@ theorem _root_.continuous_real_toNNReal : Continuous Real.toNNReal :=
   (continuous_id.max continuous_const).subtype_mk _
 
 /-- `Real.toNNReal` bundled as a continuous map for convenience. -/
-@[simps (config := .asFn)]
+@[simps -fullyApplied]
 noncomputable def _root_.ContinuousMap.realToNNReal : C(ℝ, ℝ≥0) :=
   .mk Real.toNNReal continuous_real_toNNReal
 

--- a/Mathlib/Topology/MetricSpace/Dilation.lean
+++ b/Mathlib/Topology/MetricSpace/Dilation.lean
@@ -111,7 +111,7 @@ theorem mk_coe (f : α →ᵈ β) (h) : Dilation.mk f h = f :=
 
 /-- Copy of a `Dilation` with a new `toFun` equal to the old one. Useful to fix definitional
 equalities. -/
-@[simps (config := .asFn)]
+@[simps -fullyApplied]
 protected def copy (f : α →ᵈ β) (f' : α → β) (h : f' = ⇑f) : α →ᵈ β where
   toFun := f'
   edist_eq' := h.symm ▸ f.edist_eq'

--- a/Mathlib/Topology/MetricSpace/DilationEquiv.lean
+++ b/Mathlib/Topology/MetricSpace/DilationEquiv.lean
@@ -91,7 +91,7 @@ initialize_simps_projections DilationEquiv (toFun → apply, invFun → symm_app
 lemma ratio_toDilation (e : X ≃ᵈ Y) : ratio e.toDilation = ratio e := rfl
 
 /-- Identity map as a `DilationEquiv`. -/
-@[simps! (config := .asFn) apply]
+@[simps! -fullyApplied apply]
 def refl (X : Type*) [PseudoEMetricSpace X] : X ≃ᵈ X where
   toEquiv := .refl X
   edist_eq' := ⟨1, one_ne_zero, fun _ _ ↦ by simp⟩
@@ -100,7 +100,7 @@ def refl (X : Type*) [PseudoEMetricSpace X] : X ≃ᵈ X where
 @[simp] theorem ratio_refl : ratio (refl X) = 1 := Dilation.ratio_id
 
 /-- Composition of `DilationEquiv`s. -/
-@[simps! (config := .asFn) apply]
+@[simps! -fullyApplied apply]
 def trans (e₁ : X ≃ᵈ Y) (e₂ : Y ≃ᵈ Z) : X ≃ᵈ Z where
   toEquiv := e₁.1.trans e₂.1
   __ := e₂.toDilation.comp e₁.toDilation

--- a/Mathlib/Topology/PartialHomeomorph.lean
+++ b/Mathlib/Topology/PartialHomeomorph.lean
@@ -187,8 +187,8 @@ end Basic
 
 /-- Interpret a `Homeomorph` as a `PartialHomeomorph` by restricting it
 to an open set `s` in the domain and to `t` in the codomain. -/
-@[simps! (config := .asFn) apply symm_apply toPartialEquiv,
-  simps! (config := .lemmasOnly) source target]
+@[simps! -fullyApplied apply symm_apply toPartialEquiv,
+  simps! -isSimp source target]
 def _root_.Homeomorph.toPartialHomeomorphOfImageEq (e : X ≃ₜ Y) (s : Set X) (hs : IsOpen s)
     (t : Set Y) (h : e '' s = t) : PartialHomeomorph X Y where
   toPartialEquiv := e.toPartialEquivOfImageEq s t h
@@ -616,7 +616,7 @@ theorem restrOpen_source (s : Set X) (hs : IsOpen s) : (e.restrOpen s hs).source
 sure that the restriction is well defined whatever the set s, since partial homeomorphisms are by
 definition defined on open sets. In applications where `s` is open, this coincides with the
 restriction of partial equivalences -/
-@[simps! (config := mfld_cfg) apply symm_apply, simps! (config := .lemmasOnly) source target]
+@[simps! (config := mfld_cfg) apply symm_apply, simps! -isSimp source target]
 protected def restr (s : Set X) : PartialHomeomorph X Y :=
   e.restrOpen (interior s) isOpen_interior
 
@@ -646,7 +646,7 @@ theorem restr_source_inter (s : Set X) : e.restr (e.source ∩ s) = e.restr s :=
   simp [e.open_source.interior_eq, ← inter_assoc]
 
 /-- The identity on the whole space as a partial homeomorphism. -/
-@[simps! (config := mfld_cfg) apply, simps! (config := .lemmasOnly) source target]
+@[simps! (config := mfld_cfg) apply, simps! -isSimp source target]
 protected def refl (X : Type*) [TopologicalSpace X] : PartialHomeomorph X X :=
   (Homeomorph.refl X).toPartialHomeomorph
 
@@ -691,7 +691,7 @@ section ofSet
 variable {s : Set X} (hs : IsOpen s)
 
 /-- The identity partial equivalence on a set `s` -/
-@[simps! (config := mfld_cfg) apply, simps! (config := .lemmasOnly) source target]
+@[simps! (config := mfld_cfg) apply, simps! -isSimp source target]
 def ofSet (s : Set X) (hs : IsOpen s) : PartialHomeomorph X X where
   toPartialEquiv := PartialEquiv.ofSet s
   open_source := hs
@@ -719,7 +719,7 @@ variable (e' : PartialHomeomorph Y Z)
 
 /-- Composition of two partial homeomorphisms when the target of the first and the source of
 the second coincide. -/
-@[simps! apply symm_apply toPartialEquiv, simps! (config := .lemmasOnly) source target]
+@[simps! apply symm_apply toPartialEquiv, simps! -isSimp source target]
 protected def trans' (h : e.target = e'.source) : PartialHomeomorph X Z where
   toPartialEquiv := PartialEquiv.trans' e.toPartialEquiv e'.toPartialEquiv h
   open_source := e.open_source
@@ -895,7 +895,7 @@ section Prod
 
 /-- The product of two partial homeomorphisms, as a partial homeomorphism on the product space. -/
 @[simps! (config := mfld_cfg) toPartialEquiv apply,
-  simps! (config := .lemmasOnly) source target symm_apply]
+  simps! -isSimp source target symm_apply]
 def prod (eX : PartialHomeomorph X X') (eY : PartialHomeomorph Y Y') :
     PartialHomeomorph (X × Y) (X' × Y') where
   open_source := eX.open_source.prod eY.open_source
@@ -968,7 +968,7 @@ To ensure the maps `toFun` and `invFun` are inverse of each other on the new `so
 the definition assumes that the sets `s` and `t` are related both by `e.is_image` and `e'.is_image`.
 To ensure that the new maps are continuous on `source`/`target`, it also assumes that `e.source` and
 `e'.source` meet `frontier s` on the same set and `e x = e' x` on this intersection. -/
-@[simps! (config := .asFn) toPartialEquiv apply]
+@[simps! -fullyApplied toPartialEquiv apply]
 def piecewise (e e' : PartialHomeomorph X Y) (s : Set X) (t : Set Y) [∀ x, Decidable (x ∈ s)]
     [∀ y, Decidable (y ∈ t)] (H : e.IsImage s t) (H' : e'.IsImage s t)
     (Hs : e.source ∩ frontier s = e'.source ∩ frontier s)
@@ -1173,7 +1173,7 @@ theorem trans_toPartialHomeomorph :
 
 /-- Precompose a partial homeomorphism with a homeomorphism.
 We modify the source and target to have better definitional behavior. -/
-@[simps! (config := .asFn)]
+@[simps! -fullyApplied]
 def transPartialHomeomorph (e : X ≃ₜ Y) (f' : PartialHomeomorph Y Z) : PartialHomeomorph X Z where
   toPartialEquiv := e.toEquiv.transPartialEquiv f'.toPartialEquiv
   open_source := f'.open_source.preimage e.continuous
@@ -1260,7 +1260,7 @@ section transHomeomorph
 
 /-- Postcompose a partial homeomorphism with a homeomorphism.
 We modify the source and target to have better definitional behavior. -/
-@[simps! (config := .asFn)]
+@[simps! -fullyApplied]
 def transHomeomorph (e : PartialHomeomorph X Y) (f' : Y ≃ₜ Z) : PartialHomeomorph X Z where
   toPartialEquiv := e.toPartialEquiv.transEquiv f'.toEquiv
   open_source := e.open_source

--- a/Mathlib/Topology/Sets/Opens.lean
+++ b/Mathlib/Topology/Sets/Opens.lean
@@ -384,7 +384,7 @@ theorem comap_injective [T0Space β] : Injective (comap : C(α, β) → FrameHom
         show a ∈ f ⁻¹' s ↔ a ∈ g ⁻¹' s from Set.ext_iff.1 (coe_inj.2 this) a
 
 /-- A homeomorphism induces an order-preserving equivalence on open sets, by taking comaps. -/
-@[simps (config := .asFn) apply]
+@[simps -fullyApplied apply]
 def _root_.Homeomorph.opensCongr (f : α ≃ₜ β) : Opens α ≃o Opens β where
   toFun := Opens.comap (f.symm : C(β, α))
   invFun := Opens.comap (f : C(α, β))

--- a/Mathlib/Topology/UniformSpace/Equiv.lean
+++ b/Mathlib/Topology/UniformSpace/Equiv.lean
@@ -88,7 +88,7 @@ theorem ext {h h' : α ≃ᵤ β} (H : ∀ x, h x = h' x) : h = h' :=
   toEquiv_injective <| Equiv.ext H
 
 /-- Identity map as a uniform isomorphism. -/
-@[simps! (config := .asFn) apply]
+@[simps! -fullyApplied apply]
 protected def refl (α : Type*) [UniformSpace α] : α ≃ᵤ α where
   uniformContinuous_toFun := uniformContinuous_id
   uniformContinuous_invFun := uniformContinuous_id
@@ -276,7 +276,7 @@ def prodAssoc : (α × β) × γ ≃ᵤ α × β × γ where
   toEquiv := Equiv.prodAssoc α β γ
 
 /-- `α × {*}` is uniformly isomorphic to `α`. -/
-@[simps! (config := .asFn) apply]
+@[simps! -fullyApplied apply]
 def prodPunit : α × PUnit ≃ᵤ α where
   toEquiv := Equiv.prodPUnit α
   uniformContinuous_toFun := uniformContinuous_fst
@@ -337,14 +337,14 @@ def ulift : ULift.{v, u} α ≃ᵤ α :=
 end
 
 /-- If `ι` has a unique element, then `ι → α` is uniformly isomorphic to `α`. -/
-@[simps! (config := .asFn)]
+@[simps! -fullyApplied]
 def funUnique (ι α : Type*) [Unique ι] [UniformSpace α] : (ι → α) ≃ᵤ α where
   toEquiv := Equiv.funUnique ι α
   uniformContinuous_toFun := Pi.uniformContinuous_proj _ _
   uniformContinuous_invFun := uniformContinuous_pi.mpr fun _ => uniformContinuous_id
 
 /-- Uniform isomorphism between dependent functions `Π i : Fin 2, α i` and `α 0 × α 1`. -/
-@[simps! (config := .asFn)]
+@[simps! -fullyApplied]
 def piFinTwo (α : Fin 2 → Type u) [∀ i, UniformSpace (α i)] : (∀ i, α i) ≃ᵤ α 0 × α 1 where
   toEquiv := piFinTwoEquiv α
   uniformContinuous_toFun := (Pi.uniformContinuous_proj _ 0).prod_mk (Pi.uniformContinuous_proj _ 1)
@@ -353,7 +353,7 @@ def piFinTwo (α : Fin 2 → Type u) [∀ i, UniformSpace (α i)] : (∀ i, α i
 
 /-- Uniform isomorphism between `α² = Fin 2 → α` and `α × α`. -/
 -- Porting note: made `α` explicit
-@[simps! (config := .asFn)]
+@[simps! -fullyApplied]
 def finTwoArrow (α : Type*) [UniformSpace α] : (Fin 2 → α) ≃ᵤ α × α :=
   { piFinTwo fun _ => α with toEquiv := finTwoArrowEquiv α }
 

--- a/Mathlib/Topology/UniformSpace/Real.lean
+++ b/Mathlib/Topology/UniformSpace/Real.lean
@@ -47,7 +47,7 @@ theorem continuous_coe : Continuous ((↑) : ℝ≥0 → ℝ) :=
   continuous_subtype_val
 
 /-- Embedding of `ℝ≥0` to `ℝ` as a bundled continuous map. -/
-@[simps (config := .asFn)]
+@[simps -fullyApplied]
 def _root_.ContinuousMap.coeNNRealReal : C(ℝ≥0, ℝ) :=
   ⟨(↑), continuous_coe⟩
 

--- a/Mathlib/Topology/VectorBundle/Basic.lean
+++ b/Mathlib/Topology/VectorBundle/Basic.lean
@@ -92,7 +92,7 @@ protected def symmₗ (e : Pretrivialization F (π F E)) [e.IsLinear R] (b : B) 
 
 /-- A pretrivialization for a vector bundle defines linear equivalences between the
 fibers and the model space. -/
-@[simps (config := .asFn)]
+@[simps -fullyApplied]
 def linearEquivAt (e : Pretrivialization F (π F E)) [e.IsLinear R] (b : B) (hb : b ∈ e.baseSet) :
     E b ≃ₗ[R] F where
   toFun y := (e ⟨b, y⟩).2
@@ -365,7 +365,7 @@ namespace Trivialization
 
 /-- Forward map of `Trivialization.continuousLinearEquivAt` (only propositionally equal),
   defined everywhere (`0` outside domain). -/
-@[simps (config := .asFn) apply]
+@[simps -fullyApplied apply]
 def continuousLinearMapAt (e : Trivialization F (π F E)) [e.IsLinear R] (b : B) : E b →L[R] F :=
   { e.linearMapAt R b with
     toFun := e.linearMapAt R b -- given explicitly to help `simps`
@@ -378,7 +378,7 @@ def continuousLinearMapAt (e : Trivialization F (π F E)) [e.IsLinear R] (b : B)
         fun x => e.mem_source.mpr hb).snd }
 
 /-- Backwards map of `Trivialization.continuousLinearEquivAt`, defined everywhere. -/
-@[simps (config := .asFn) apply]
+@[simps -fullyApplied apply]
 def symmL (e : Trivialization F (π F E)) [e.IsLinear R] (b : B) : F →L[R] E b :=
   { e.symmₗ R b with
     toFun := e.symm b -- given explicitly to help `simps`
@@ -402,7 +402,7 @@ theorem continuousLinearMapAt_symmL (e : Trivialization F (π F E)) [e.IsLinear 
 variable (R) in
 /-- In a vector bundle, a trivialization in the fiber (which is a priori only linear)
 is in fact a continuous linear equiv between the fibers and the model fiber. -/
-@[simps (config := .asFn) apply symm_apply]
+@[simps -fullyApplied apply symm_apply]
 def continuousLinearEquivAt (e : Trivialization F (π F E)) [e.IsLinear R] (b : B)
     (hb : b ∈ e.baseSet) : E b ≃L[R] F :=
   { e.toPretrivialization.linearEquivAt R b hb with

--- a/MathlibTest/Simps.lean
+++ b/MathlibTest/Simps.lean
@@ -175,7 +175,7 @@ example {α} (x : α) : rfl2.toFun x = x ∧ rfl2.invFun x = x := by
 
 /- test `fullyApplied` option -/
 
-@[simps (config := .asFn)]
+@[simps -fullyApplied]
 def rfl3 {α} : α ≃ α := ⟨id, fun x ↦ x, fun _ ↦ rfl, fun _ ↦ rfl⟩
 
 end foo
@@ -193,7 +193,7 @@ namespace CountNested
 def nested1 : MyProd ℕ <| MyProd ℤ ℕ :=
   ⟨2, -1, 1⟩
 
-@[simps (config := .lemmasOnly)]
+@[simps -isSimp]
 def nested2 : ℕ × MyProd ℕ ℕ :=
   ⟨2, MyProd.map Nat.succ Nat.pred ⟨1, 2⟩⟩
 
@@ -213,7 +213,7 @@ run_cmd liftTermElabM <| do
   -- todo: test that another attribute can be added (not working yet)
   guard <| hasSimpAttribute env `CountNested.nested1_fst -- simp attribute is global
   guard <| not <| hasSimpAttribute env `CountNested.nested2_fst
-    -- `lemmasOnly` doesn't add simp lemma
+    -- `- isSimp` doesn't add simp lemma
   -- todo: maybe test that there are no other lemmas generated
   -- guard <| 7 = env.fold 0
   --   (fun d n ↦ n + if d.to_name.components.init.ilast = `CountNested then 1 else 0)
@@ -528,7 +528,7 @@ example {α} (x x' : α) (h : x = x') : coercing.rfl2.invFun x = x' := by simp; 
 @[simps] protected def Equiv2.symm2 {α β} (f : Equiv2 α β) : Equiv2 β α :=
   ⟨f.invFun, f.toFun, f.right_inv, f.left_inv⟩
 
-@[simps (config := .asFn)] protected def Equiv2.symm3 {α β} (f : Equiv2 α β) : Equiv2 β α :=
+@[simps -fullyApplied] protected def Equiv2.symm3 {α β} (f : Equiv2 α β) : Equiv2 β α :=
   ⟨f.invFun, f, f.right_inv, f.left_inv⟩
 
 example {α β} (f : Equiv2 α β) (y : β) {x} (h : f.invFun y = x) : f.symm y = x := by simp; rw [h]


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
