### PR TITLE
[Merged by Bors] - perf: delete redundant instances with weak discrimination keys

### DIFF
--- a/Mathlib/Algebra/Category/Grp/Basic.lean
+++ b/Mathlib/Algebra/Category/Grp/Basic.lean
@@ -215,7 +215,16 @@ lemma ofHom_injective {X Y : Type u} [Group X] [Group Y] :
   ext
   apply ConcreteCategory.congr_hom h
 
-@[to_additive]
+/-- This instance allows type class synthesis to "see through" `Grp.of` to
+the underlying type when attempting synthesis on `Unique (Grp.of _)`.
+
+It is scoped because its discrimination tree keys are `Unique _` allowing
+Lean to attempt it in *any* search for `Unique α`. -/
+@[to_additive "This instance allows type class synthesis to \"see through\" `AddGrp.of`
+to the underlying type when attempting synthesis on `Unique (AddGrp.of _)`.
+
+It is scoped because its discrimination tree keys are `Unique _` allowing
+Lean to attempt it in *any* search for `Unique α`." ]
 scoped instance ofUnique (G : Type*) [Group G] [i : Unique G] : Unique (Grp.of G) := i
 
 -- We verify that simp lemmas apply when coercing morphisms to functions.

--- a/Mathlib/Algebra/Category/Grp/Basic.lean
+++ b/Mathlib/Algebra/Category/Grp/Basic.lean
@@ -215,18 +215,6 @@ lemma ofHom_injective {X Y : Type u} [Group X] [Group Y] :
   ext
   apply ConcreteCategory.congr_hom h
 
-/-- This instance allows type class synthesis to "see through" `Grp.of` to
-the underlying type when attempting synthesis on `Unique (Grp.of _)`.
-
-It is scoped because its discrimination tree keys are `Unique _` allowing
-Lean to attempt it in *any* search for `Unique α`. -/
-@[to_additive "This instance allows type class synthesis to \"see through\" `AddGrp.of`
-to the underlying type when attempting synthesis on `Unique (AddGrp.of _)`.
-
-It is scoped because its discrimination tree keys are `Unique _` allowing
-Lean to attempt it in *any* search for `Unique α`." ]
-scoped instance ofUnique (G : Type*) [Group G] [i : Unique G] : Unique (Grp.of G) := i
-
 -- We verify that simp lemmas apply when coercing morphisms to functions.
 @[to_additive]
 example {R S : Grp} (i : R ⟶ S) (r : R) (h : r = 1) : i r = 1 := by simp [h]
@@ -414,19 +402,6 @@ alias coe_comp' := coe_comp
 
 @[to_additive (attr := deprecated "use `coe_id` instead" (since := "2025-01-28"))]
 alias coe_id' := coe_id
-
-/-- This instance allows type class synthesis to "see through" `CommGrp.of` to
-the underlying type when attempting synthesis on `Unique (CommGrp.of _)`.
-
-It is scoped because its discrimination tree keys are `Unique _` allowing
-Lean to attempt it in *any* search for `Unique α`. -/
-@[to_additive "This instance allows type class synthesis to \"see through\" `AddCommGrp.of`
-to the underlying type when attempting synthesis on `Unique (AddCommGrp.of _)`.
-
-It is scoped because its discrimination tree keys are `Unique _` allowing
-Lean to attempt it in *any* search for `Unique α`." ]
-scoped instance ofUnique (G : Type*) [CommGroup G] [i : Unique G] : Unique (CommGrp.of G) :=
-  i
 
 @[to_additive]
 instance hasForgetToGroup : HasForget₂ CommGrp Grp where

--- a/Mathlib/Algebra/Category/Grp/Basic.lean
+++ b/Mathlib/Algebra/Category/Grp/Basic.lean
@@ -415,7 +415,16 @@ alias coe_comp' := coe_comp
 @[to_additive (attr := deprecated "use `coe_id` instead" (since := "2025-01-28"))]
 alias coe_id' := coe_id
 
-@[to_additive]
+/-- This instance allows type class synthesis to "see through" `CommGrp.of` to
+the underlying type when attempting synthesis on `Unique (CommGrp.of _)`.
+
+It is scoped because its discrimination tree keys are `Unique _` allowing
+Lean to attempt it in *any* search for `Unique α`. -/
+@[to_additive "This instance allows type class synthesis to \"see through\" `AddCommGrp.of`
+to the underlying type when attempting synthesis on `Unique (AddCommGrp.of _)`.
+
+It is scoped because its discrimination tree keys are `Unique _` allowing
+Lean to attempt it in *any* search for `Unique α`." ]
 scoped instance ofUnique (G : Type*) [CommGroup G] [i : Unique G] : Unique (CommGrp.of G) :=
   i
 

--- a/Mathlib/Algebra/Category/Grp/Basic.lean
+++ b/Mathlib/Algebra/Category/Grp/Basic.lean
@@ -216,7 +216,7 @@ lemma ofHom_injective {X Y : Type u} [Group X] [Group Y] :
   apply ConcreteCategory.congr_hom h
 
 @[to_additive]
-instance ofUnique (G : Type*) [Group G] [i : Unique G] : Unique (Grp.of G) := i
+scoped instance ofUnique (G : Type*) [Group G] [i : Unique G] : Unique (Grp.of G) := i
 
 -- We verify that simp lemmas apply when coercing morphisms to functions.
 @[to_additive]
@@ -407,7 +407,7 @@ alias coe_comp' := coe_comp
 alias coe_id' := coe_id
 
 @[to_additive]
-instance ofUnique (G : Type*) [CommGroup G] [i : Unique G] : Unique (CommGrp.of G) :=
+scoped instance ofUnique (G : Type*) [CommGroup G] [i : Unique G] : Unique (CommGrp.of G) :=
   i
 
 @[to_additive]

--- a/Mathlib/Analysis/Normed/Group/SemiNormedGrp.lean
+++ b/Mathlib/Analysis/Normed/Group/SemiNormedGrp.lean
@@ -135,7 +135,7 @@ theorem coe_comp {M N K : SemiNormedGrp} (f : M ⟶ N) (g : N ⟶ K) :
 instance : Inhabited SemiNormedGrp :=
   ⟨of PUnit⟩
 
-instance ofUnique (V : Type u) [SeminormedAddCommGroup V] [i : Unique V] :
+scoped instance ofUnique (V : Type u) [SeminormedAddCommGroup V] [i : Unique V] :
     Unique (SemiNormedGrp.of V) :=
   i
 
@@ -362,7 +362,7 @@ theorem coe_comp {M N K : SemiNormedGrp₁} (f : M ⟶ N) (g : N ⟶ K) :
 instance : Inhabited SemiNormedGrp₁ :=
   ⟨of PUnit⟩
 
-instance ofUnique (V : Type u) [SeminormedAddCommGroup V] [i : Unique V] :
+scoped instance ofUnique (V : Type u) [SeminormedAddCommGroup V] [i : Unique V] :
     Unique (SemiNormedGrp₁.of V) :=
   i
 

--- a/Mathlib/Analysis/Normed/Group/SemiNormedGrp.lean
+++ b/Mathlib/Analysis/Normed/Group/SemiNormedGrp.lean
@@ -358,15 +358,6 @@ theorem coe_comp {M N K : SemiNormedGrp₁} (f : M ⟶ N) (g : N ⟶ K) :
 instance : Inhabited SemiNormedGrp₁ :=
   ⟨of PUnit⟩
 
-/-- This instance allows type class synthesis to "see through" `SemiNormedGrp₁.of` to
-the underlying type when attempting synthesis on `Unique (SemiNormedGrp₁.of _)`.
-
-It is scoped because its discrimination tree keys are `Unique _` allowing
-Lean to attempt it in *any* search for `Unique α`. -/
-scoped instance ofUnique (V : Type u) [SeminormedAddCommGroup V] [i : Unique V] :
-    Unique (SemiNormedGrp₁.of V) :=
-  i
-
 instance (X Y : SemiNormedGrp₁) : Zero (X ⟶ Y) where
   zero := ⟨0, NormedAddGroupHom.NormNoninc.zero⟩
 

--- a/Mathlib/Analysis/Normed/Group/SemiNormedGrp.lean
+++ b/Mathlib/Analysis/Normed/Group/SemiNormedGrp.lean
@@ -135,6 +135,11 @@ theorem coe_comp {M N K : SemiNormedGrp} (f : M ⟶ N) (g : N ⟶ K) :
 instance : Inhabited SemiNormedGrp :=
   ⟨of PUnit⟩
 
+/-- This instance allows type class synthesis to "see through" `SemiNormedGrp.of` to
+the underlying type when attempting synthesis on `Unique (SemiNormedGrp.of _)`.
+
+It is scoped because its discrimination tree keys are `Unique _` allowing
+Lean to attempt it in *any* search for `Unique α`. -/
 scoped instance ofUnique (V : Type u) [SeminormedAddCommGroup V] [i : Unique V] :
     Unique (SemiNormedGrp.of V) :=
   i
@@ -362,6 +367,11 @@ theorem coe_comp {M N K : SemiNormedGrp₁} (f : M ⟶ N) (g : N ⟶ K) :
 instance : Inhabited SemiNormedGrp₁ :=
   ⟨of PUnit⟩
 
+/-- This instance allows type class synthesis to "see through" `SemiNormedGrp₁.of` to
+the underlying type when attempting synthesis on `Unique (SemiNormedGrp₁.of _)`.
+
+It is scoped because its discrimination tree keys are `Unique _` allowing
+Lean to attempt it in *any* search for `Unique α`. -/
 scoped instance ofUnique (V : Type u) [SeminormedAddCommGroup V] [i : Unique V] :
     Unique (SemiNormedGrp₁.of V) :=
   i

--- a/Mathlib/Analysis/Normed/Group/SemiNormedGrp.lean
+++ b/Mathlib/Analysis/Normed/Group/SemiNormedGrp.lean
@@ -135,15 +135,6 @@ theorem coe_comp {M N K : SemiNormedGrp} (f : M ⟶ N) (g : N ⟶ K) :
 instance : Inhabited SemiNormedGrp :=
   ⟨of PUnit⟩
 
-/-- This instance allows type class synthesis to "see through" `SemiNormedGrp.of` to
-the underlying type when attempting synthesis on `Unique (SemiNormedGrp.of _)`.
-
-It is scoped because its discrimination tree keys are `Unique _` allowing
-Lean to attempt it in *any* search for `Unique α`. -/
-scoped instance ofUnique (V : Type u) [SeminormedAddCommGroup V] [i : Unique V] :
-    Unique (SemiNormedGrp.of V) :=
-  i
-
 instance {M N : SemiNormedGrp} : Zero (M ⟶ N) where
   zero := ofHom 0
 


### PR DESCRIPTION
As @eric-wieser pointed out, these are redundant with `X.of` being reducible now. Their weak keys cause Lean to engage  on wild goose instance synthesis paths. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
