### PR TITLE
[Merged by Bors] - chore(Topology/Constructions): some fun_prop golfing and tagging

### DIFF
--- a/Mathlib/Topology/Constructions.lean
+++ b/Mathlib/Topology/Constructions.lean
@@ -376,12 +376,10 @@ theorem Continuous.prod_mk {f : Z → X} {g : Z → Y} (hf : Continuous f) (hg :
   continuous_prod_mk.2 ⟨hf, hg⟩
 
 @[continuity]
-theorem Continuous.Prod.mk (x : X) : Continuous fun y : Y => (x, y) :=
-  continuous_const.prod_mk continuous_id
+theorem Continuous.Prod.mk (x : X) : Continuous fun y : Y => (x, y) := by fun_prop
 
 @[continuity]
-theorem Continuous.Prod.mk_left (y : Y) : Continuous fun x : X => (x, y) :=
-  continuous_id.prod_mk continuous_const
+theorem Continuous.Prod.mk_left (y : Y) : Continuous fun x : X => (x, y) := by fun_prop
 
 /-- If `f x y` is continuous in `x` for all `y ∈ s`,
 then the set of `x` such that `f x` maps `s` to `t` is closed. -/
@@ -403,7 +401,7 @@ theorem Continuous.comp₄ {g : X × Y × Z × ζ → ε} (hg : Continuous g) {e
     (hl : Continuous l) : Continuous fun w => g (e w, f w, k w, l w) :=
   hg.comp₃ he hf <| hk.prod_mk hl
 
-@[continuity]
+@[continuity, fun_prop]
 theorem Continuous.prodMap {f : Z → X} {g : W → Y} (hf : Continuous f) (hg : Continuous g) :
     Continuous (Prod.map f g) :=
   hf.fst'.prod_mk hg.snd'
@@ -1894,23 +1892,23 @@ theorem ULift.isClosed_iff [TopologicalSpace X] {s : Set (ULift.{v} X)} :
     IsClosed s ↔ IsClosed (ULift.up ⁻¹' s) := by
   rw [← isOpen_compl_iff, ← isOpen_compl_iff, isOpen_iff, preimage_compl]
 
-@[continuity]
+@[continuity, fun_prop]
 theorem continuous_uliftDown [TopologicalSpace X] : Continuous (ULift.down : ULift.{v, u} X → X) :=
   continuous_induced_dom
 
-@[continuity]
+@[continuity, fun_prop]
 theorem continuous_uliftUp [TopologicalSpace X] : Continuous (ULift.up : X → ULift.{v, u} X) :=
   continuous_induced_rng.2 continuous_id
 
 @[deprecated (since := "2025-02-10")] alias continuous_uLift_down := continuous_uliftDown
 @[deprecated (since := "2025-02-10")] alias continuous_uLift_up := continuous_uliftUp
 
-@[continuity]
+@[continuity, fun_prop]
 theorem continuous_uliftMap [TopologicalSpace X] [TopologicalSpace Y]
     (f : X → Y) (hf : Continuous f) :
     Continuous (ULift.map f : ULift.{u'} X → ULift.{v'} Y) := by
   change Continuous (ULift.up ∘ f ∘ ULift.down)
-  continuity
+  fun_prop
 
 lemma Topology.IsEmbedding.uliftDown [TopologicalSpace X] :
     IsEmbedding (ULift.down : ULift.{v, u} X → X) := ⟨⟨rfl⟩, ULift.down_injective⟩


### PR DESCRIPTION
Benchmarking in #22750 indicates this a small performance boost.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
