### PR TITLE
x feat(Topology): étalé space associated to a predicate on sections

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -6909,6 +6909,7 @@ public import Mathlib.Topology.EMetricSpace.Lipschitz
 public import Mathlib.Topology.EMetricSpace.PairReduction
 public import Mathlib.Topology.EMetricSpace.Paracompact
 public import Mathlib.Topology.EMetricSpace.Pi
+public import Mathlib.Topology.EtaleSpace
 public import Mathlib.Topology.ExtendFrom
 public import Mathlib.Topology.Exterior
 public import Mathlib.Topology.ExtremallyDisconnected

--- a/Mathlib/AlgebraicGeometry/ProjectiveSpectrum/StructureSheaf.lean
+++ b/Mathlib/AlgebraicGeometry/ProjectiveSpectrum/StructureSheaf.lean
@@ -80,7 +80,7 @@ The predicate `IsFraction` is "prelocal", in the sense that if it holds on `U` i
 subset `V` of `U`.
 -/
 def isFractionPrelocal : PrelocalPredicate fun x : ProjectiveSpectrum.top 𝒜 => at x where
-  pred f := IsFraction f
+  pred U := IsFraction
   res := by rintro V U i f ⟨j, r, s, h, w⟩; exact ⟨j, r, s, (h <| i ·), (w <| i ·)⟩
 
 /-- We will define the structure sheaf as the subsheaf of all dependent functions in

--- a/Mathlib/Data/Set/Operations.lean
+++ b/Mathlib/Data/Set/Operations.lean
@@ -302,6 +302,26 @@ abbrev RightInvOn (g : β → α) (f : α → β) (t : Set β) : Prop := LeftInv
 def InvOn (g : β → α) (f : α → β) (s : Set α) (t : Set β) : Prop :=
   LeftInvOn g f s ∧ RightInvOn g f t
 
+section Section
+
+variable {α β : Type*} {p : β → Prop} {f : α → β} {s s' : Subtype p → α}
+
+theorem injOn_range_subtype_section (hs : f ∘ s = Subtype.val) : (Set.range s).InjOn f := by
+  rintro _ ⟨b, rfl⟩ _ ⟨b', rfl⟩ eq
+  cases (hs ▸ Subtype.val_injective) eq
+  rfl
+
+theorem subtype_section_ext (hs : f ∘ s = Subtype.val) (hs' : f ∘ s' = Subtype.val)
+    (eq : Set.range s = Set.range s') : s = s' := by
+  ext a
+  obtain ⟨b, eq⟩ := eq.symm ▸ Set.mem_range_self a
+  have := congr_arg f eq
+  rw [← f.comp_apply, ← f.comp_apply, hs, hs'] at this
+  cases Subtype.ext this
+  exact eq
+
+end Section
+
 section image2
 
 /-- The image of a binary function `f : α → β → γ` as a function `Set α → Set β → Set γ`.

--- a/Mathlib/Geometry/Manifold/Sheaf/Smooth.lean
+++ b/Mathlib/Geometry/Manifold/Sheaf/Smooth.lean
@@ -106,12 +106,12 @@ lemma smoothSheaf.obj_eq (U : (Opens (TopCat.of M))ᵒᵖ) :
 /-- Canonical map from the stalk of `smoothSheaf IM I M N` at `x` to `N`, given by evaluating
 sections at `x`. -/
 def smoothSheaf.eval (x : M) : (smoothSheaf IM I M N).presheaf.stalk x → N :=
-  TopCat.stalkToFiber (StructureGroupoid.LocalInvariantProp.localPredicate M N _) x
+  TopCat.stalkToFiber (StructureGroupoid.LocalInvariantProp.localPredicate M N _).1 x
 
 /-- Canonical map from the stalk of `smoothSheaf IM I M N` at `x` to `N`, given by evaluating
 sections at `x`, considered as a morphism in the category of types. -/
 def smoothSheaf.evalHom (x : TopCat.of M) : (smoothSheaf IM I M N).presheaf.stalk x ⟶ N :=
-  TopCat.stalkToFiber (StructureGroupoid.LocalInvariantProp.localPredicate M N _) x
+  TopCat.stalkToFiber (StructureGroupoid.LocalInvariantProp.localPredicate M N _).1 x
 
 open CategoryTheory Limits
 
@@ -125,7 +125,7 @@ def smoothSheaf.evalAt (x : TopCat.of M) (U : OpenNhds x)
     colimit.ι ((OpenNhds.inclusion x).op ⋙ (smoothSheaf IM I M N).val) U ≫
     smoothSheaf.evalHom IM I N x =
     smoothSheaf.evalAt _ _ _ _ _ :=
-  colimit.ι_desc _ _
+  funext fun _ ↦ TopCat.stalkToFiber_germ ..
 
 /-- The `eval` map is surjective at `x`. -/
 lemma smoothSheaf.eval_surjective (x : M) : Function.Surjective (smoothSheaf.eval IM I N x) := by
@@ -141,7 +141,7 @@ variable {IM I N}
 @[simp] lemma smoothSheaf.eval_germ (U : Opens M) (x : M) (hx : x ∈ U)
     (f : (smoothSheaf IM I M N).presheaf.obj (op U)) :
     smoothSheaf.eval IM I N (x : M) ((smoothSheaf IM I M N).presheaf.germ U x hx f) = f ⟨x, hx⟩ :=
-  TopCat.stalkToFiber_germ ((contDiffWithinAt_localInvariantProp ∞).localPredicate M N) _ _ _ _
+  TopCat.stalkToFiber_germ ((contDiffWithinAt_localInvariantProp ∞).localPredicate M N).1 _ _ _ _
 
 lemma smoothSheaf.contMDiff_section {U : (Opens (TopCat.of M))ᵒᵖ}
     (f : (smoothSheaf IM I M N).presheaf.obj U) :

--- a/Mathlib/Logic/Equiv/Basic.lean
+++ b/Mathlib/Logic/Equiv/Basic.lean
@@ -396,19 +396,51 @@ def sigmaOptionEquivOfSome {α} (p : Option α → Type v) (h : p none → False
     · intro n
       exfalso
       exact h n
-    · intro _
-      exact rfl
+    · intro
+      rfl
   (sigmaSubtypeEquivOfSubset _ _ h').symm.trans (sigmaCongrLeft' (optionIsSomeEquiv α))
 
+section Sigma
+
+variable {α ι : Type*} {π : ι → Type*} {p : ι → Prop}
+
+/-- Functions to a `Sigma` type are in bijection with a `Sigma` type of dependent functions. -/
+def arrowSigma : (α → Σ i, π i) ≃ Σ i : α → ι, ∀ x, π (i x) where
+  toFun f := ⟨Sigma.fst ∘ f, fun x ↦ (f x).2⟩
+  invFun f a := .mk _ (f.2 a)
+
+/-- The `Sigma` type indexed by a subtype can be canonically identified with a subtype of the
+`Sigma` type indexed by the whole type. -/
+def sigmaSubtypeComm : (Σ i : Subtype p, π i) ≃ { f : Σ i, π i // p f.1 } where
+  toFun f := ⟨⟨_, f.2⟩, f.1.2⟩
+  invFun f := ⟨⟨_, f.2⟩, f.1.2⟩
+
+variable (ι π) in
 /-- The `Pi`-type `∀ i, π i` is equivalent to the type of sections `f : ι → Σ i, π i` of the
 `Sigma` type such that for all `i` we have `(f i).fst = i`. -/
-def piEquivSubtypeSigma (ι) (π : ι → Type*) :
-    (∀ i, π i) ≃ { f : ι → Σ i, π i // ∀ i, (f i).1 = i } where
-  toFun := fun f => ⟨fun i => ⟨i, f i⟩, fun _ => rfl⟩
-  invFun := fun f i => by rw [← f.2 i]; exact (f.1 i).2
-  right_inv := fun ⟨f, hf⟩ =>
-    Subtype.ext <| funext fun i =>
-      Sigma.eq (hf i).symm <| eq_of_heq <| rec_heq_of_heq _ <| by simp
+def piEquivSubtypeSigma : (∀ i, π i) ≃ { f : ι → Σ i, π i // ∀ i, (f i).1 = i } where
+  toFun f := ⟨fun i ↦ .mk _ (f i), fun _ ↦ rfl⟩
+  invFun f i := cast (congr_arg π (f.2 i)) (f.1 i).2
+  right_inv f := Subtype.ext <| funext fun i ↦ Sigma.ext (f.2 i).symm <| by simp
+
+/-- The `Pi`-type `∀ i : Subtype p, π i` indexed by a subtype is equivalent to the type of
+sections of the `Sigma` type `Σ i, π i` over the subtype. -/
+def piSubtypeEquivSubtypeSigma :
+    (∀ i : Subtype p, π i) ≃ { f : Subtype p → Σ i, π i // Sigma.fst ∘ f = (↑) } :=
+  (piEquivSubtypeSigma ..).trans <| .trans
+    (subtypeEquivOfSubtype' (arrowCongr (.refl _) sigmaSubtypeComm))
+    { toFun f := ⟨val ∘ f.1, funext (congr_arg val <| f.2 ·)⟩
+      invFun f := ⟨fun i ↦ ⟨_, by apply congr_fun f.2 i ▸ i.2⟩, (Subtype.ext <| congr_fun f.2 ·)⟩ }
+
+lemma mk_piEquivSubtypeSigma_symm {f : {f : ι → Σ i, π i // ∀ i, (f i).1 = i}} {i : ι} :
+    Sigma.mk _ ((piEquivSubtypeSigma ι π).symm f i) = f.1 i :=
+  congr_fun (congr_arg val ((piEquivSubtypeSigma ..).right_inv f)) i
+
+lemma mk_piSubtypeEquivSubtypeSigma {f : {f : Subtype p → Σ i, π i // Sigma.fst ∘ f = val}}
+    {i : Subtype p} : Sigma.mk _ (piSubtypeEquivSubtypeSigma.symm f i) = f.1 i :=
+  congr_fun (congr_arg val (piSubtypeEquivSubtypeSigma.right_inv f)) i
+
+end Sigma
 
 /-- The type of functions `f : ∀ a, β a` such that for all `a` we have `p a (f a)` is equivalent
 to the type of functions `∀ a, {b : β a // p a b}`. -/

--- a/Mathlib/Topology/EtaleSpace.lean
+++ b/Mathlib/Topology/EtaleSpace.lean
@@ -1,0 +1,386 @@
+/-
+Copyright (c) 2025 Junyan Xu. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Junyan Xu
+-/
+module
+
+public import Mathlib.Topology.Covering
+public import Mathlib.Topology.IsLocalHomeomorph
+public import Mathlib.Topology.Sheaves.LocalPredicate
+
+/-!
+# Étalé spaces of local predicates and presheaves
+
+The traditional approach to étalé spaces starts from a (pre)sheaf on a base space and
+directly constructs the associated étalé space with a local homeomorphism to the base space.
+We instead construct a local homeomorphism from an arbitrary type family (over the base space)
+with a predicate on sections (over open sets of the base space) specifying the "admissible"
+sections, provided that the type family behaves like the family of stalks of the presheaf
+of admissible sections (i.e., satisfies the conditions `IsStalkInj` and `IsStalkSurj`).
+
+The passage between (pre)sheaves and (pre)local predicates was already established during
+the development of sheafification (see `TopCat.LocalPredicate` and the file
+``Mathlib.Topology.Sheaves.Sheafify`), and we obtain the étalé space of a (pre)sheaf by
+combining both steps. But our theory can also be applied to situations where the type family
+is not (definitionally) the stalks of a presheaf: for example it can be a family of Hom types
+in the fundamental groupoid when constructing the universal cover, or a constant family
+when constructing the primitive of a holomorphic function and integrating it along a path.
+
+In this file we will adopt the sheaf-theoretic terminology and refer to the types in the type
+family as "stalks" and their elements as "germs".
+
+## Main definitions
+
+* `EtaleSpace`: The étalé space associated to a set of admissible sections given in the form of
+  a predicate. It is endowed with the strongest topology making every admissible section continuous.
+  `EtaleSpace.mk` is its constructor and `EtaleSpace.proj` is the continuous projection to the
+  base space.
+
+## Main results
+
+Some results below requires the type family satisfies the injectivity and/or surjectivity criteria
+to behave like the family of stalks of the admissible sections.
+
+* `EtaleSpace.isOpenEmbedding_restrict_proj`: the projection from the étalé space
+  to the base space is an open embedding on the range of every admissible section.
+
+* `EtaleSpace.isOpenEmbedding_section`: every admissible section is an open embedding
+  (requires injectivity criterion).
+
+* `EtaleSpace.isLocalHomeomorph_proj`: the projection from the étalé space to the base space
+  is a local homeomorphism (requires both criteria).
+
+* `EtaleSpace.isOpen_range_section_iff_of_isOpen`: the range of a section is open if and only if
+  it is the range of a continuous section over an open set (requires both criteria).
+
+* `EtaleSpace.continuous_cod_iff`: a function to the étalé space is continuous if and only if
+  it agrees with an admissible section around each point (requires both criteria).
+
+* `EtaleSpace.continuous_section_iff`: a section is continuous if and only if it is admissible
+  according to the sheafified predicate, i.e., it locally agrees with admissible sections
+  (requires both criteria and that the predicate is pre-local).
+
+* `EtaleSpace.isTopologicalBasis`: the étalé space has a basis consisting of
+  the ranges of admissible sections (with the same requirements as the above).
+
+## References
+* https://ncatlab.org/nlab/show/%C3%A9tale+space
+* https://nforum.ncatlab.org/discussion/11283/etale-space/
+-/
+
+open CategoryTheory Topology TopologicalSpace Opposite Set
+
+universe u v
+
+namespace TopCat
+
+variable {B : TopCat.{u}} {F : B → Type v} {X : Type*} [TopologicalSpace X]
+
+set_option linter.unusedVariables false in
+/-- The underlying type of the étalé space associated to a predicate on sections of a type family
+is simply the `Sigma` type. -/
+@[nolint unusedArguments]
+def EtaleSpace (P : Π ⦃U : Opens B⦄, (Π b : U, F b) → Prop) : Type _ := Σ b, F b
+
+variable {P : Π ⦃U : Opens B⦄, (Π b : U, F b) → Prop}
+
+namespace EtaleSpace
+
+/-- Constructor for points in the étalé space. -/
+@[simps] def mk {b : B} (x : F b) : EtaleSpace P := ⟨b, x⟩
+
+/-- The étalé space is endowed with the strongest topology
+making every admissible section continuous. -/
+instance : TopologicalSpace (EtaleSpace P) :=
+  ⨆ (U : Opens B) (s : Π b : U, F b) (_ : P s), coinduced (mk <| s ·) inferInstance
+
+lemma isOpen_iff {V : Set (EtaleSpace P)} :
+    IsOpen V ↔
+    ∀ (U : Opens B) (s : Π b : U, F b), P s → IsOpen ((mk <| s ·) ⁻¹' V) := by
+  simp_rw [isOpen_iSup_iff, isOpen_coinduced]
+
+lemma continuous_dom_iff {X} [TopologicalSpace X] {f : EtaleSpace P → X} :
+    Continuous f ↔
+    ∀ (U : Opens B) (s : Π b : U, F b), P s → Continuous (f <| mk <| s ·) := by
+  simp_rw [continuous_def, isOpen_iff, preimage_preimage,
+    ← forall_comm (α := Set X), ← forall_comm (α := IsOpen _)]
+
+variable (P) in
+/-- The projection from the étalé space down to the base is continuous. -/
+def proj : C(EtaleSpace P, B) where
+  toFun := Sigma.fst
+  continuous_toFun := continuous_dom_iff.mpr fun _ _ _ ↦ continuous_subtype_val
+
+section Section
+
+theorem exists_eq_mk_of_comp_eq_id (f : B → EtaleSpace P) (hf : proj P ∘ f = id) :
+    ∃! s : Π b, F b, f = (mk <| s ·) := by
+  convert ← (Equiv.piEquivSubtypeSigma ..).bijective.existsUnique ⟨f, congr_fun hf⟩
+  exact eq_comm.trans Subtype.ext_iff
+
+theorem exists_eq_mk_of_comp_eq_val {U : Set B} (f : U → EtaleSpace P) (hf : proj P ∘ f = (↑)) :
+    ∃! s : Π b : U, F b, f = (mk <| s ·) := by
+  convert ← (Equiv.piSubtypeEquivSubtypeSigma ..).bijective.existsUnique ⟨f, hf⟩
+  exact eq_comm.trans Subtype.ext_iff
+
+variable {U : Opens B} {s : Π b : U, F b} (hs : P s)
+
+section
+
+include hs
+
+lemma continuous_section : Continuous fun b ↦ (mk (s b) : EtaleSpace P) :=
+  continuous_iff_coinduced_le.mpr (le_iSup₂_of_le U s <| le_iSup_of_le hs le_rfl)
+
+/-- The domain of any section is homeomorphic to its range. -/
+def homeomorphRangeSection : U ≃ₜ range fun b ↦ (mk (s b) : EtaleSpace P) where
+  toFun b := ⟨_, b, rfl⟩
+  invFun x := ⟨proj P x, by obtain ⟨_, b, rfl⟩ := x; exact b.2⟩
+  right_inv := by rintro ⟨_, _, rfl⟩; rfl
+  continuous_toFun := (continuous_section hs).subtype_mk _
+  continuous_invFun := ((proj P).continuous.comp continuous_subtype_val).subtype_mk <| by
+    rintro ⟨_, b, rfl⟩; exact b.2
+
+theorem isOpenEmbedding_restrict_proj :
+    IsOpenEmbedding ((range (mk <| s ·)).restrict (proj P)) :=
+  U.2.isOpenEmbedding_subtypeVal.comp (homeomorphRangeSection hs).symm.isOpenEmbedding
+
+theorem isOpen_preimage_inter_range_section {U' : Opens B} (inj : ∀ b ∈ U', IsStalkInj P b) :
+    IsOpen (proj P ⁻¹' U'.1 ∩ range fun b ↦ (mk (s b) : EtaleSpace P)) :=
+  isOpen_iff.mpr fun V t ht ↦ isOpen_iff_mem_nhds.mpr fun ⟨v, hv⟩ ⟨h', ⟨u, hu⟩, he⟩ ↦ by
+    cases congr($he.1)
+    have ⟨W, iU, iV, eq⟩ := inj v h' ⟨U, hu⟩ ⟨V, hv⟩ _ _ hs ht congr($he.2)
+    exact Filter.mem_of_superset (((U'.2.inter W.1.2).preimage continuous_subtype_val).mem_nhds
+      ⟨h', W.2⟩) fun v hv ↦ ⟨hv.1, _, congr(mk $(eq ⟨v, hv.2⟩))⟩
+
+theorem isOpen_range_section (inj : ∀ b ∈ U, IsStalkInj P b) :
+    IsOpen (range fun b ↦ (mk (s b) : EtaleSpace P)) := by
+  convert isOpen_preimage_inter_range_section hs inj
+  rw [inter_eq_right.mpr (by rintro _ ⟨b, rfl⟩; exact b.2)]
+
+theorem isOpenEmbedding_section (inj : ∀ b ∈ U, IsStalkInj P b) :
+    IsOpenEmbedding fun b ↦ (mk (s b) : EtaleSpace P) := by
+  rw [isOpenEmbedding_iff, isEmbedding_iff, and_assoc]
+  exact ⟨.of_comp (continuous_section hs) (proj P).continuous .subtypeVal,
+    fun _ _ eq ↦ Subtype.ext congr(proj P $eq), isOpen_range_section hs inj⟩
+
+end
+
+theorem isLocalHomeomorphOn_proj (inj : ∀ b ∈ U, IsStalkInj P b) (surj : ∀ b ∈ U, IsStalkSurj P b) :
+    IsLocalHomeomorphOn (proj P) (proj P ⁻¹' U.1) :=
+  isLocalHomeomorphOn_iff_isOpenEmbedding_restrict.mpr fun x hx ↦
+    have ⟨_V, _s, hs, eq⟩ := surj _ hx x.2
+    have ho := isOpen_preimage_inter_range_section hs inj
+    ⟨_, ho.mem_nhds ⟨hx, _, congr(mk $eq)⟩, (isOpenEmbedding_restrict_proj hs).comp
+      (.inclusion inter_subset_right <| ho.preimage continuous_subtype_val)⟩
+
+variable (P) in
+/-- A map from a topological space `X` to an étalé space locally agrees with sections if every
+point of `X` has a neighborhood on which the map is determined by an admissible section. -/
+def LocallyEqSection (f : X → EtaleSpace P) : Prop :=
+  ∀ x, ∃ (U : OpenNhds (f x).1) (s : Π b : U.1, F b),
+    P s ∧ ∃ V ∈ 𝓝 x, ∀ x' (h' : (f x').1 ∈ U.1), x' ∈ V → s ⟨_, h'⟩ = (f x').2
+
+theorem section_locallyEqSection_iff {P : PrelocalPredicate F} :
+    LocallyEqSection P.pred (mk <| s ·) ↔ Sheafify P.pred s := by
+  constructor <;> intro h x
+  · have ⟨W, t, ht, V, hV, eq⟩ := h x
+    have ⟨V', hV', hV, hxV⟩ := mem_nhds_iff.mp hV
+    refine ⟨W.1 ⊓ ⟨_, U.2.isOpenMap_subtype_val _ hV⟩,
+      ⟨W.2, _, hxV, rfl⟩, Opens.infLERight .. ≫ image_val_subset.hom, ?_⟩
+    convert ← P.res (Opens.infLELeft ..) _ ht with ⟨_, hW, x, hxV, rfl⟩
+    exact eq _ _ (hV' hxV)
+  · have ⟨V, hV, i, hs⟩ := h x
+    exact ⟨⟨V, hV⟩, _, hs, _, (V.2.preimage continuous_subtype_val).mem_nhds hV, fun _ _ _ ↦ rfl⟩
+
+theorem continuous_cod {f : X → EtaleSpace P} (cont : Continuous (proj P ∘ f))
+    (eq : LocallyEqSection P f) : Continuous f :=
+  continuous_iff_continuousAt.mpr fun x ↦
+    have ⟨U, s, hs, V, hV, eq⟩ := eq x
+    (continuousOn_iff_continuous_restrict.mpr <| ((continuous_section hs).comp
+      (f := (⟨_, ·.2.1⟩)) <| (cont.comp continuous_subtype_val).subtype_mk _).congr
+        fun x ↦ by exact congr(mk $(eq x x.2.1 x.2.2))).continuousAt
+      (Filter.inter_mem (cont.continuousAt.preimage_mem_nhds (U.1.2.mem_nhds U.2)) hV)
+
+theorem continuous_sheafify_section (hs : Sheafify P s) :
+    Continuous (fun b ↦ (mk (s b) : EtaleSpace P)) :=
+  continuous_cod continuous_subtype_val fun x ↦
+    have ⟨V, hV, _, hs⟩ := hs x
+    ⟨⟨V, hV⟩, _, hs, _, (V.2.preimage continuous_subtype_val).mem_nhds hV, fun _ _ _ ↦ rfl⟩
+
+theorem continuous_cod_iff_of_opens {f : X → EtaleSpace P}
+    (hU : ∀ x, (f x).1 ∈ U) (inj : ∀ b ∈ U, IsStalkInj P b) (surj : ∀ x, IsStalkSurj P (f x).1) :
+    Continuous f ↔ Continuous (proj P ∘ f) ∧ LocallyEqSection P f := by
+  refine ⟨fun cont ↦ ⟨(proj P).continuous.comp cont, fun x ↦ ?_⟩, fun h ↦ continuous_cod h.1 h.2⟩
+  have ⟨U', s, hs, eq⟩ := surj _ (f x).2
+  refine ⟨U', s, hs, _, ((isOpen_preimage_inter_range_section hs inj).preimage cont).mem_nhds
+    ⟨hU x, _, congr(mk $eq)⟩, fun x hx ⟨_, b, eq⟩ ↦ ?_⟩
+  set y := f x with hy; clear_value y
+  have : s ⟨y.1, hx⟩ = y.2 := by cases eq; rfl
+  cases hy; exact this
+
+theorem continuous_cod_iff {f : X → EtaleSpace P}
+    (inj : ∀ b, IsStalkInj P b) (surj : ∀ x, IsStalkSurj P (f x).1) :
+    Continuous f ↔ Continuous (proj P ∘ f) ∧ LocallyEqSection P f :=
+  continuous_cod_iff_of_opens (fun _ ↦ Opens.mem_top _) (fun _ _ ↦ inj _) surj
+
+theorem continuous_section_iff {P : PrelocalPredicate F}
+    (inj : ∀ b ∈ U, IsStalkInj P.pred b) (surj : ∀ b ∈ U, IsStalkSurj P.pred b) :
+    Continuous (fun b ↦ (mk (s b) : EtaleSpace P.pred)) ↔ P.sheafify.pred s := by
+  rw [continuous_cod_iff_of_opens (·.2) inj fun b : U ↦ surj b b.2,
+    and_iff_right (by exact continuous_subtype_val), section_locallyEqSection_iff]
+  rfl
+
+section InjSurj
+
+variable (inj : ∀ b, IsStalkInj P b) (surj : ∀ b, IsStalkSurj P b)
+include inj surj
+
+theorem isLocalHomeomorph_proj : IsLocalHomeomorph (proj P) :=
+  isLocalHomeomorph_iff_isOpenEmbedding_restrict.mpr fun x ↦ have ⟨_U, _s, hs, eq⟩ := surj _ x.2
+    ⟨_, (isOpen_range_section hs fun _ _ ↦ inj _).mem_nhds ⟨_, congr(mk $eq)⟩,
+      isOpenEmbedding_restrict_proj hs⟩
+
+theorem isOpen_injOn_iff_exists_continuous_section {V : Set (EtaleSpace P)} :
+    IsOpen V ∧ V.InjOn (proj P) ↔ letI U := proj P '' V
+    IsOpen U ∧ ∃ s : Π b : U, F b, letI sec b : EtaleSpace P := mk (s b)
+      Continuous sec ∧ range sec = V := by
+  rw [((isLocalHomeomorph_proj inj surj).isOpen_injOn_tfae V).out 0 3 rfl]
+  refine and_congr .rfl (.trans ?_ Equiv.piSubtypeEquivSubtypeSigma.exists_congr_left.symm)
+  simp_rw [show mk = Sigma.mk _ from rfl, Equiv.mk_piSubtypeEquivSubtypeSigma]
+  exact ⟨fun ⟨s, hs, hsV⟩ ↦ ⟨⟨s, hs⟩, s.continuous, hsV⟩, fun ⟨s, hs, hsV⟩ ↦ ⟨⟨s.1, hs⟩, s.2, hsV⟩⟩
+
+theorem isOpen_range_section_iff {U : Set B} {s : Π b : U, F b} :
+    letI sec b : EtaleSpace P := mk (s b)
+    IsOpen (range sec) ↔ IsOpen U ∧ Continuous sec :=
+  (isLocalHomeomorph_proj inj surj).isOpen_range_section_iff U rfl
+
+theorem isOpen_range_section_opens_iff :
+    letI sec b : EtaleSpace P := mk (s b)
+    IsOpen (range sec) ↔ Continuous sec :=
+  (isOpen_range_section_iff inj surj).trans <| and_iff_right U.2
+
+end InjSurj
+
+theorem isTopologicalBasis {P : PrelocalPredicate F}
+    (inj : ∀ b, IsStalkInj P.pred b) (surj : ∀ b, IsStalkSurj P.pred b) :
+    IsTopologicalBasis {V : Set (EtaleSpace P.pred) |
+      ∃ (U : Opens B) (s : Π b : U, F b), P.pred s ∧ V = range (mk <| s ·)} :=
+  isTopologicalBasis_of_isOpen_of_nhds
+    (by rintro _ ⟨U, s, hs, rfl⟩; exact isOpen_range_section hs fun _ _ ↦ inj _)
+      fun ⟨b, x⟩ V hx hV ↦ by
+      have ⟨U, s, hs, eq⟩ := surj _ x
+      let W : Opens B := ⟨_, U.1.2.isOpenMap_subtype_val _ (isOpen_iff.mp hV _ s hs)⟩
+      refine ⟨_, ⟨W, _, P.res image_val_subset.hom s hs, rfl⟩,
+        ⟨⟨b, ⟨b, U.2⟩, by rwa [mem_preimage, eq], rfl⟩, congr(mk $eq)⟩, ?_⟩
+      rintro _ ⟨⟨_, b, hb, rfl⟩, rfl⟩
+      exact hb
+
+end Section
+
+theorem isSeparatedMap_proj (sep : ∀ b, IsSeparated P b) (inj : ∀ b, IsStalkInj P b) :
+    IsSeparatedMap (proj P) :=
+  fun x y eq ne ↦ by
+    have ⟨U, s, t, hs, ht, hsx, hty, ne⟩ := sep (proj P x) x.2 (eq ▸ y.2)
+      fun eq2 ↦ ne <| Sigma.ext eq (by simp [eq2])
+    refine ⟨_, _, isOpen_range_section hs fun _ _ ↦ inj _, isOpen_range_section ht fun _ _ ↦ inj _,
+      ⟨_, congr(mk $hsx)⟩, ⟨_, congr(mk $hty).trans <| Sigma.ext eq <| by simp⟩,
+      disjoint_iff_forall_ne.mpr ?_⟩
+    rintro _ ⟨b, rfl⟩ _ ⟨b', rfl⟩ eq
+    cases Subtype.ext congr(proj P $eq)
+    exact ne b congr($eq.2)
+
+/-- The adjunction between predicates on sections and topological spaces over a base space. -/
+def adjunction {X : Type*} [TopologicalSpace X] {p : X → B} :
+    {f : C(EtaleSpace P, X) // p ∘ f = proj P} ≃
+    {f : Π b, F b → p ⁻¹' {b} // P ≤ Pullback f (isContinuousSection p).pred} where
+  toFun f := ⟨fun _b x ↦ ⟨f.1 (mk x), congr_fun f.2 _⟩,
+    fun _U _s hs ↦ f.1.continuous.comp (continuous_section hs)⟩
+  invFun f := ⟨⟨fun x ↦ f.1 _ x.2, continuous_dom_iff.mpr f.2⟩, funext fun x ↦ (f.1 _ x.2).2⟩
+  left_inv _ := rfl
+  right_inv _ := rfl
+
+end EtaleSpace
+
+open EtaleSpace
+
+namespace TrivializationOn
+
+variable {U : Opens B} {ι : Type*} [TopologicalSpace ι] [DiscreteTopology ι]
+variable (t : TrivializationOn P U ι) (inj : ∀ b ∈ U, IsStalkInj P b)
+
+/-- The étalé space of a set of sections with a trivialization on `U` evenly covers `U` via
+the projection map. -/
+noncomputable def homeomorph : proj P ⁻¹' U ≃ₜ U × ι where
+  __ := t.equiv
+  continuous_toFun := (proj P).continuous.restrictPreimage.prodMk <| continuous_discrete_rng.2 <| by
+    convert fun i ↦ (isOpen_range_section (t.pred i) inj).preimage continuous_subtype_val
+    exact t.preimage_snd_comp_equiv _
+  continuous_invFun := continuous_prod_of_discrete_right.mpr
+    fun i ↦ (continuous_section (t.pred i)).subtype_mk _
+
+include t inj in
+theorem isEvenlyCovered {b : B} (hb : b ∈ U) : IsEvenlyCovered (proj P) b ι :=
+  ⟨‹_›, U, hb, U.2, U.2.preimage (proj P).continuous, t.homeomorph inj, fun _ ↦ rfl⟩
+
+include t inj in
+theorem isCoveringMapOn : IsCoveringMapOn (proj P) U :=
+  fun _b hb ↦ (t.isEvenlyCovered inj hb).to_isEvenlyCovered_preimage
+
+end TrivializationOn
+
+theorem isCoveringMapOn_of_isLocallyConstant {P : PrelocalPredicate F} {U : Opens B}
+    (h : ∀ b ∈ U, IsLocallyConstant P.pred b) : IsCoveringMapOn (proj P.pred) U := fun b hb ↦
+  have ⟨V, hVU, hV⟩ := h b hb ⟨U, hb⟩
+  let _ : TopologicalSpace (F (⟨b, V.2⟩ : V.1)) := ⊥
+  have := discreteTopology_bot
+  hV.trivializationOn ⟨b, V.2⟩ |>.isEvenlyCovered
+    (fun b hb ↦ (h b <| hVU hb).hasIdentityPrinciple.isStalkInj) V.2 |>.to_isEvenlyCovered_preimage
+
+theorem isCoveringMap_of_isLocallyConstant {P : PrelocalPredicate F}
+    (h : ∀ b, IsLocallyConstant P.pred b) : IsCoveringMap (proj P.pred) :=
+  isCoveringMap_iff_isCoveringMapOn_univ.mpr <|
+    isCoveringMapOn_of_isLocallyConstant (U := ⊤) fun _ _ ↦ h _
+
+end TopCat
+
+section ContinuousSection
+
+open TopCat
+
+variable {B : TopCat.{u}} {X : Type*} [TopologicalSpace X] {p : X → B}
+
+theorem IsLocallyInjective.isStalkInj (inj : IsLocallyInjective p) (b : B) :
+    IsStalkInj (F := (p ⁻¹' {·})) (isContinuousSection p).pred b :=
+  PrelocalPredicate.isStalkInj_iff.mpr fun U s t hs ht eq ↦ by
+    have ⟨V, hV, hsV, inj⟩ := inj (s ⟨b, U.2⟩)
+    refine ⟨⟨⟨_, U.1.2.isOpenMap_subtype_val _ ((hV.preimage hs).inter (hV.preimage ht))⟩,
+      ⟨_, ⟨hsV, by apply eq ▸ hsV⟩, rfl⟩⟩, image_val_subset.hom, ?_⟩
+    rintro ⟨_, b, h, rfl⟩
+    exact Subtype.ext (inj h.1 h.2 <| (s _).2.trans (t _).2.symm)
+
+theorem IsLocalHomeomorph.isStalkSurj (hp : IsLocalHomeomorph p) (b : B) :
+    IsStalkSurj (F := (p ⁻¹' {·})) (isContinuousSection p).pred b := by
+  rintro ⟨x, rfl⟩
+  have ⟨U, hU, s, hs, hxU, eq⟩ := hp.exists_section x
+  exact ⟨⟨⟨U, hU⟩, hxU⟩, fun b ↦ ⟨s b, congr_fun hs b⟩, s.continuous, Subtype.ext eq⟩
+
+theorem IsLocalHomeomorph.isSeparated_of_isSeparatedMap (hp : IsLocalHomeomorph p)
+    (sep : IsSeparatedMap p) (b : B) :
+    IsSeparated (F := (p ⁻¹' {·})) (isContinuousSection p).pred b := by
+  rintro ⟨x, eq⟩ ⟨y, rfl⟩ ne
+  have ⟨U, V, hU, hV, hxU, hyV, disj⟩ := sep x y eq (Subtype.coe_ne_coe.mpr ne)
+  have ⟨U', hU', s, hs, hxU', hsx⟩ := hp.exists_section x
+  have ⟨V', hV', t, ht, hxV', hty⟩ := hp.exists_section y
+  exact ⟨⟨⟨_, (hU'.isOpenMap_subtype_val _ (hU.preimage s.continuous)).inter
+      (hV'.isOpenMap_subtype_val _ (hV.preimage t.continuous))⟩,
+    ⟨_, hsx ▸ hxU, by exact eq⟩, _, hty ▸ hyV, rfl⟩,
+    fun b ↦ ⟨s ⟨b, image_val_subset b.2.1⟩, congr_fun hs _⟩,
+    fun b ↦ ⟨t ⟨b, image_val_subset b.2.2⟩, congr_fun ht _⟩,
+    s.continuous.comp (by fun_prop), t.continuous.comp (by fun_prop),
+    Subtype.ext ((congr_arg s <| Subtype.ext eq.symm).trans hsx),
+    Subtype.ext hty, fun b ↦ Subtype.coe_ne_coe.mp <| disjoint_iff_forall_ne.mp disj
+      (mem_of_mem_image_val b.2.1) (mem_of_mem_image_val b.2.2)⟩
+
+end ContinuousSection

--- a/Mathlib/Topology/IsLocalHomeomorph.lean
+++ b/Mathlib/Topology/IsLocalHomeomorph.lean
@@ -43,6 +43,12 @@ the source of some `e : OpenPartialHomeomorph X Y` with `f = e`. -/
 def IsLocalHomeomorphOn :=
   ∀ x ∈ s, ∃ e : OpenPartialHomeomorph X Y, x ∈ e.source ∧ f = e
 
+/-- A `OpenPartialHomeomorph` is a local homeomorphism on its source. -/
+lemma OpenPartialHomeomorph.isLocalHomeomorphOn (e : OpenPartialHomeomorph X Y) :
+    IsLocalHomeomorphOn e e.source :=
+  fun _ hx ↦ ⟨e, hx, rfl⟩
+
+variable {s} in
 theorem isLocalHomeomorphOn_iff_isOpenEmbedding_restrict {f : X → Y} :
     IsLocalHomeomorphOn f s ↔ ∀ x ∈ s, ∃ U ∈ 𝓝 x, IsOpenEmbedding (U.restrict f) := by
   refine ⟨fun h x hx ↦ ?_, fun h x hx ↦ ?_⟩
@@ -100,10 +106,8 @@ theorem mk (h : ∀ x ∈ s, ∃ e : OpenPartialHomeomorph X Y, x ∈ e.source �
         continuousOn_toFun := (continuousOn_congr he).mpr e.continuousOn_toFun },
       hx, rfl⟩
 
-/-- A `OpenPartialHomeomorph` is a local homeomorphism on its source. -/
-lemma OpenPartialHomeomorph.isLocalHomeomorphOn (e : OpenPartialHomeomorph X Y) :
-    IsLocalHomeomorphOn e e.source :=
-  fun _ hx ↦ ⟨e, hx, rfl⟩
+@[deprecated (since := "2025-11-05")]
+alias OpenPartialHomeomorph.isLocalHomeomorphOn := _root_.OpenPartialHomeomorph.isLocalHomeomorphOn
 
 variable {g t}
 
@@ -156,6 +160,7 @@ end IsLocalHomeomorphOn
 def IsLocalHomeomorph :=
   ∀ x : X, ∃ e : OpenPartialHomeomorph X Y, x ∈ e.source ∧ f = e
 
+/-- A homeomorphism is a local homeomorphism. -/
 theorem Homeomorph.isLocalHomeomorph (f : X ≃ₜ Y) : IsLocalHomeomorph f :=
   fun _ ↦ ⟨f.toOpenPartialHomeomorph, trivial, rfl⟩
 
@@ -205,9 +210,8 @@ theorem mk (h : ∀ x : X, ∃ e : OpenPartialHomeomorph X Y, x ∈ e.source ∧
   isLocalHomeomorph_iff_isLocalHomeomorphOn_univ.mpr
     (IsLocalHomeomorphOn.mk f Set.univ fun x _hx ↦ h x)
 
-/-- A homeomorphism is a local homeomorphism. -/
-lemma Homeomorph.isLocalHomeomorph (h : X ≃ₜ Y) : IsLocalHomeomorph h :=
-  fun _ ↦ ⟨h.toOpenPartialHomeomorph, trivial, rfl⟩
+@[deprecated (since := "2025-11-05")]
+alias Homeomorph.isLocalHomeomorph := _root_.Homeomorph.isLocalHomeomorph
 
 variable {g f}
 
@@ -251,23 +255,73 @@ theorem isOpenEmbedding_of_comp (hf : IsLocalHomeomorph g) (hgf : IsOpenEmbeddin
     (cont : Continuous f) : IsOpenEmbedding f :=
   (hgf.isLocalHomeomorph.of_comp hf cont).isOpenEmbedding_of_injective hgf.injective.of_comp
 
+variable {t} in
+theorem isOpenEmbedding_section (hf : IsLocalHomeomorph f) (ht : IsOpen t) {sec : t → X}
+    (hsec : f ∘ sec = (↑)) (cont : Continuous sec) : IsOpenEmbedding sec :=
+  hf.isOpenEmbedding_of_comp (hsec ▸ ht.isOpenEmbedding_subtypeVal) cont
+
+variable (s) in
+theorem isOpen_injOn_tfae (hf : IsLocalHomeomorph f) : List.TFAE
+    [IsOpen s ∧ s.InjOn f,
+      IsOpenEmbedding (s.restrict f),
+      IsOpen (f '' s) ∧ ∃ h : s.InjOn f, Continuous (Equiv.ofInjective _ h.injective).symm,
+      IsOpen (f '' s) ∧ ∃ sec : C(f '' s, X), f ∘ sec = (↑) ∧ Set.range sec = s,
+      ∃ U : Set Y, IsOpen U ∧ ∃ sec : C(U, X), f ∘ sec = (↑) ∧ Set.range sec = s] := by
+  tfae_have 1 → 2 := fun h ↦ isOpenEmbedding_iff_continuous_injective_isOpenMap.mpr ⟨hf.continuous
+    |>.comp continuous_subtype_val, h.2.injective, hf.isOpenMap.comp h.1.isOpenMap_subtype_val⟩
+  tfae_have 2 → 3 := fun h ↦ ⟨Set.range_restrict .. ▸ h.isOpen_range,
+    Set.injOn_iff_injective.mpr h.injective, h.toHomeomorph.symm.continuous⟩
+  tfae_have 3 → 4 := fun h ↦ ⟨h.1, by
+    refine Set.range_restrict .. ▸ ⟨⟨_, continuous_subtype_val.comp h.2.2⟩, ?_⟩
+    simp_rw [ContinuousMap.coe_mk, ← Function.comp_assoc]
+    exact ⟨(Equiv.comp_symm_eq ..).mpr rfl, by simp⟩⟩
+  tfae_have 4 → 5 := fun h ↦ ⟨_, h⟩
+  tfae_have 5 → 1 := by
+    rintro ⟨U, hU, sec, hsec, rfl⟩
+    exact ⟨(hf.isOpenEmbedding_section hU hsec sec.continuous).isOpen_range,
+      Set.injOn_range_subtype_section hsec⟩
+  tfae_finish
+
+theorem isOpen_range_section_iff (hf : IsLocalHomeomorph f) {sec : t → X} (hsec : f ∘ sec = (↑)) :
+    IsOpen (Set.range sec) ↔ IsOpen t ∧ Continuous sec := by
+  have : f '' Set.range sec = t := by rw [← Set.range_comp, hsec, Subtype.range_val]
+  convert ← (hf.isOpen_injOn_tfae (Set.range sec)).out 0 3
+  · exact and_iff_left (Set.injOn_range_subtype_section hsec)
+  refine this.symm ▸ ⟨fun ⟨⟨s, _⟩, hfs, eq⟩ ↦ ?_, fun h ↦ ⟨⟨_, h⟩, hsec, rfl⟩⟩
+  rwa [← Set.subtype_section_ext hfs hsec eq]
+
+theorem isOpenEmbedding_restrict (hf : IsLocalHomeomorph f) (hs : IsOpen s) (hsf : s.InjOn f) :
+    IsOpenEmbedding (s.restrict f) :=
+  isOpenEmbedding_iff_continuous_injective_isOpenMap.mpr ⟨hf.continuous.comp continuous_subtype_val,
+    hsf.injective, hf.isOpenMap.comp hs.isOpenMap_subtype_val⟩
+
+theorem exists_section (hf : IsLocalHomeomorph f) (x : X) :
+    ∃ U : Set Y, IsOpen U ∧ ∃ s : C(U, X), f ∘ s = (↑) ∧ ∃ h : f x ∈ U, s ⟨_, h⟩ = x := by
+  have ⟨V, hxV, hfV⟩ := isLocalHomeomorph_iff_isOpenEmbedding_restrict.mp hf x
+  obtain ⟨U, hU, s, hs, rfl⟩ := ((hf.isOpen_injOn_tfae V).out 1 4).mp hfV
+  obtain ⟨y, rfl⟩ := mem_of_mem_nhds hxV
+  rw [← f.comp_apply, hs]
+  exact ⟨U, hU, s, hs, y.2, rfl⟩
+
 open TopologicalSpace in
-/-- Ranges of continuous local sections of a local homeomorphism
-form a basis of the source space. -/
+/-- Ranges of continuous local sections of a local homeomorphism form a basis of
+the source space. See `isOpen_injOn_tfae` for more characterizations of sets in the basis. -/
 theorem isTopologicalBasis (hf : IsLocalHomeomorph f) : IsTopologicalBasis
     {U : Set X | ∃ V : Set Y, IsOpen V ∧ ∃ s : C(V,X), f ∘ s = (↑) ∧ Set.range s = U} := by
   refine isTopologicalBasis_of_isOpen_of_nhds ?_ fun x U hx hU ↦ ?_
   · rintro _ ⟨U, hU, s, hs, rfl⟩
-    refine (isOpenEmbedding_of_comp hf (hs ▸ ⟨IsEmbedding.subtypeVal, ?_⟩)
-      s.continuous).isOpen_range
-    rwa [Subtype.range_val]
-  · obtain ⟨f, hxf, rfl⟩ := hf x
-    refine ⟨f.source ∩ U, ⟨f.target ∩ f.symm ⁻¹' U, f.symm.isOpen_inter_preimage hU,
-      ⟨_, continuousOn_iff_continuous_restrict.mp (f.continuousOn_invFun.mono fun _ h ↦ h.1)⟩,
-      ?_, (Set.range_restrict _ _).trans ?_⟩, ⟨hxf, hx⟩, fun _ h ↦ h.2⟩
-    · ext y; exact f.right_inv y.2.1
-    · apply (f.symm_image_target_inter_eq _).trans
-      rw [Set.preimage_inter, ← Set.inter_assoc, Set.inter_eq_self_of_subset_left
-        f.source_preimage_target, f.source_inter_preimage_inv_preimage]
+    exact (hf.isOpenEmbedding_section hU hs s.continuous).isOpen_range
+  · have ⟨V, hV, hfV⟩ := isLocalHomeomorph_iff_isOpenEmbedding_restrict.mp hf x
+    have := ((hf.isOpen_injOn_tfae (V ∩ U)).out 1 4).mp <| hfV.comp
+      (.inclusion Set.inter_subset_left <| by simpa using hU.preimage continuous_subtype_val)
+    exact ⟨_, this, ⟨mem_of_mem_nhds hV, hx⟩, Set.inter_subset_right⟩
 
 end IsLocalHomeomorph
+
+theorem isLocalHomeomorph_iff_isLocallyInjective_continuous_isOpenMap :
+    IsLocalHomeomorph f ↔ IsLocallyInjective f ∧ Continuous f ∧ IsOpenMap f where
+  mp h := ⟨h.isLocallyInjective, h.continuous, h.isOpenMap⟩
+  mpr h := isLocalHomeomorph_iff_isOpenEmbedding_restrict.mpr fun x ↦
+    have ⟨U, hU, hxU, inj⟩ := h.1 x
+    ⟨U, hU.mem_nhds hxU, isOpenEmbedding_iff_continuous_injective_isOpenMap.mpr
+      ⟨h.2.1.comp continuous_subtype_val, Set.injOn_iff_injective.mp inj, h.2.2.restrict hU⟩⟩

--- a/Mathlib/Topology/Sheaves/LocalPredicate.lean
+++ b/Mathlib/Topology/Sheaves/LocalPredicate.lean
@@ -63,9 +63,33 @@ a `P : PrelocalPredicate T` consists of:
 -/
 structure PrelocalPredicate where
   /-- The underlying predicate of a prelocal predicate -/
-  pred : ∀ {U : Opens X}, (∀ x : U, T x) → Prop
+  pred : ∀ ⦃U : Opens X⦄, (∀ x : U, T x) → Prop
+  -- TODO: change `pred` to `Pred` according to naming convention
   /-- The underlying predicate should be invariant under restriction -/
-  res : ∀ {U V : Opens X} (i : U ⟶ V) (f : ∀ x : V, T x) (_ : pred f), pred fun x : U ↦ f (i x)
+  res : ∀ {U V : Opens X} (i : U ⟶ V) (f : ∀ x : V, T x), pred f → pred fun x : U ↦ f (i x)
+
+section Sheafify
+
+variable {T} (P : ∀ ⦃U : Opens X⦄, (∀ x : U, T x) → Prop)
+
+/-- The sheafification of a predicate. -/
+def Sheafify ⦃U : Opens X⦄ (f : ∀ x : U, T x) :=
+  ∀ x : U, ∃ (V : Opens X) (_ : x.1 ∈ V) (i : V ⟶ U), P (f <| i ·)
+
+lemma le_sheafify : P ≤ Sheafify P := fun U _f hf x ↦ ⟨U, x.2, 𝟙 U, hf⟩
+
+/-- A predicate is local if sheafification doesn't make it more general. -/
+def IsLocal := Sheafify P ≤ P
+
+lemma sheafify_eq_iff : Sheafify P = P ↔ IsLocal P := by
+  simp_rw [IsLocal, le_antisymm_iff, le_sheafify, and_true]
+
+lemma isLocal_sheafify : IsLocal (Sheafify P) := fun _U _f h x ↦
+  have ⟨_V, m, i, p⟩ := h x
+  have ⟨V, m', i', p'⟩ := p ⟨x, m⟩
+  ⟨V, m', i' ≫ i, p'⟩
+
+end Sheafify
 
 variable (X)
 
@@ -95,27 +119,227 @@ a `P : LocalPredicate T` consists of:
 structure LocalPredicate extends PrelocalPredicate T where
   /-- A local predicate must be local --- provided that it is locally satisfied, it is also globally
   satisfied -/
-  locality :
-    ∀ {U : Opens X} (f : ∀ x : U, T x)
-      (_ : ∀ x : U, ∃ (V : Opens X) (_ : x.1 ∈ V) (i : V ⟶ U),
-        pred fun x : V ↦ f (i x : U)), pred f
+  locality : IsLocal pred
+
+section Pullback
+
+variable {X T} {S : X → Type*} (F : Π x : X, T x → S x) (P : ∀ ⦃U : Opens X⦄, (∀ x : U, S x) → Prop)
+
+/-- The pullback of a predicate along a map between type families. -/
+def Pullback ⦃U : Opens X⦄ (s : ∀ x : U, T x) : Prop := P (F _ <| s ·)
+
+/-- The pullback of a prelocal predicate. -/
+def PrelocalPredicate.pullback (P : PrelocalPredicate S) : PrelocalPredicate T where
+  pred := Pullback F P.pred
+  res i f := P.res i (F _ <| f ·)
+
+/-- The pullback of a local predicate. -/
+def LocalPredicate.pullback (P : LocalPredicate S) : LocalPredicate T where
+  __ := P.toPrelocalPredicate.pullback F
+  locality U s := P.locality U (F _ <| s ·)
+
+end Pullback
+
+section Properties
+
+variable {B : TopCat} {F : B → Type*} (P : Π ⦃U : Opens B⦄, (Π b : U, F b) → Prop) (b : B)
+
+/-- The surjectivity criterion for a family of types `F` to behave like the stalks of a
+set of sections (represented as a predicate `pred`) says that every germ comes from a section. -/
+abbrev IsStalkSurj :=
+  ∀ x : F b, ∃ (U : OpenNhds b) (s : Π b : U.1, F b), P s ∧ s ⟨b, U.2⟩ = x
+
+open OpenNhds
+
+/-- The injectivity criterion for a family of types `F` to behave like stalks says that
+if two sections pass through the same germ, then they are equal on a neighborhood. -/
+abbrev IsStalkInj :=
+  ∀ (U V : OpenNhds b) (s : Π b : U.1, F b) (t : Π b : V.1, F b),
+    P s → P t → s ⟨b, U.2⟩ = t ⟨b, V.2⟩ →
+    ∃ (W : OpenNhds b) (iU : W ⟶ U) (iV : W ⟶ V), ∀ w : W.1, s (iU w) = t (iV w)
+
+/-- The injectivity criterion suitable for a prelocal predicate. -/
+abbrev IsStalkInj' :=
+  ∀ (U : OpenNhds b) (s t : Π b : U.1, F b), P s → P t → s ⟨b, U.2⟩ = t ⟨b, U.2⟩ →
+    ∃ (V : OpenNhds b) (i : V ⟶ U), ∀ b : V.1, s (i b) = t (i b)
+
+theorem IsStalkInj.isStalkInj' {b : B} (h : IsStalkInj P b) : IsStalkInj' P b :=
+  fun U s t hs ht eq ↦ have ⟨W, iU, _, h⟩ := h U U s t hs ht eq; ⟨W, iU, h⟩
+
+theorem PrelocalPredicate.isStalkInj_iff {P : PrelocalPredicate F} {b : B} :
+    IsStalkInj P.pred b ↔ IsStalkInj' P.pred b := by
+  refine ⟨(·.isStalkInj'), fun h U V s t hs ht eq ↦ ?_⟩
+  have ⟨W, i, h⟩ := h _ _ _ (P.res (infLELeft U V) s hs) (P.res (infLERight U V) t ht) eq
+  exact ⟨W, i ≫ infLELeft U V, i ≫ infLERight U V, h⟩
+
+/-- A set of sections satisfies the identity principle on an open set `U` if sections on `U`
+are determined by any germ. `AnalyticOnNhd.eqOn_of_preconnected_of_eventuallyEq` shows that
+sheaves of analytic functions satisfies the identity principle on any connected open set. -/
+abbrev HasIdentityPrincipleOn (U : Opens B) :=
+  ∀ (s t : Π b : U.1, F b) b, P s → P t → s b = t b → s = t
+
+/-- A set of sections satisfies the identity principle at a point `b` if every neighborhood of `b`
+contains a neighborhood on which the identity principle is satisfied.
+This definition is intended to be applied to a locally connected base space `B`. -/
+abbrev HasIdentityPrinciple :=
+  ∀ U : OpenNhds b, ∃ V ≤ U, HasIdentityPrincipleOn P V.1
+
+/-- A set of sections is separated at a point `b` if any two germs at `b` can be separated by
+disjoint sections. -/
+abbrev IsSeparated :=
+  ∀ x y : F b, x ≠ y → ∃ (U : OpenNhds b) (s t : Π b : U.1, F b), P s ∧ P t ∧
+    s ⟨b, U.2⟩ = x ∧ t ⟨b, U.2⟩ = y ∧ ∀ b' : U.1, s b' ≠ t b'
+
+/-- A set of sections is constant on a (connected) open set `U` if every germ on `U` can be
+extended to a section on `U` in exactly one way.
+This corresponds to the `IsEvenlyCovered` condition in the associated étale space. -/
+abbrev IsConstantOn (U : Opens B) : Prop :=
+  ∀ (b₀ : U) (x : F b₀), ∃! s : Π b : U, F b, P s ∧ s b₀ = x
+
+/-- A trivialization indexed by `ι` of a set of sections on a set `U` is a subset of sections
+indexed by `ι` which induces, for each point of `U`, a bijection between `ι` and the germs
+at that point. Together with `IsStalkInj`, this is enough to guarantee that `U` is evenly
+covered by the étalé space associated to the set of sections. -/
+structure TrivializationOn (U : Opens B) (ι : Type*) : Type _ where
+  /-- The sections indexed by `ι`. -/
+  sec : ι → Π b : U, F b
+  pred i : P (sec i)
+  bijective b : Function.Bijective (sec · b)
+
+/-- A set of sections is weakly locally constant at a point `b` if `b` has a neighborhood on which
+every germ can be extended to a section in exactly one way.
+This is weaker than `IsLocallyConstant`, and the étalé space associated to a weakly locally
+constant set of sections is not necessarily a covering space, but `IsWeaklyLocallyConstant` still
+implies `IsSeparated` and `IsStalkSurj`. -/
+abbrev IsWeaklyLocallyConstant := ∃ U : OpenNhds b, IsConstantOn P U.1
+
+/-- A set of sections is locally constant at a point `b` if every neighborhood of `b` contains
+a neighborhood on which every germ can be extended to a section in exactly one way.
+This definition is intended to be applied to a locally connected base space `B`:
+if `B` is not locally connected, locally constant sheaves on `B` may not give rise to
+locally constant sets of sections, but locally constant sets of sections do always give
+rise to covering spaces. -/
+abbrev IsLocallyConstant := ∀ U : OpenNhds b, ∃ V ≤ U, IsConstantOn P V.1
+
+variable {P}
+
+theorem isConstantOn_iff {U : Opens B} : IsConstantOn P U ↔
+    HasIdentityPrincipleOn P U ∧ ∀ (b : U) (x : F b), ∃ s : Π b : U, F b, P s ∧ s b = x where
+  mp h := ⟨fun _s t b hs ht eq ↦ (h b (t b)).unique ⟨hs, eq⟩ ⟨ht, rfl⟩,
+    fun b x ↦ (h b x).exists⟩
+  mpr := fun ⟨ip, surj⟩ b x ↦ existsUnique_of_exists_of_unique (surj b x)
+    fun s t hs ht ↦ ip s t b hs.1 ht.1 (hs.2.trans ht.2.symm)
+
+theorem IsConstantOn.hasIdentityPrincipleOn {U : Opens B} (h : IsConstantOn P U) :
+    HasIdentityPrincipleOn P U := (isConstantOn_iff.mp h).1
+
+theorem IsLocallyConstant.hasIdentityPrinciple (h : IsLocallyConstant P b) :
+    HasIdentityPrinciple P b :=
+  fun U ↦ have ⟨V, le, hV⟩ := h U; ⟨V, le, hV.hasIdentityPrincipleOn⟩
+
+theorem IsLocallyConstant.isWeaklyLocallyConstant (h : IsLocallyConstant P b) :
+    IsWeaklyLocallyConstant P b :=
+  have ⟨U, _, hU⟩ := h ⊤; ⟨U, hU⟩
+
+theorem HasIdentityPrinciple.isSeparated {P : PrelocalPredicate F}
+    (ip : HasIdentityPrinciple P.pred b) (surj : IsStalkSurj P.pred b) : IsSeparated P.pred b :=
+  fun x y ne ↦ by
+    obtain ⟨U₁, s₁, h₁, rfl⟩ := surj x
+    obtain ⟨U₂, s₂, h₂, rfl⟩ := surj y
+    have ⟨U, le, hU⟩ := ip (U₁ ⊓ U₂)
+    replace h₁ := P.res (le.hom ≫ infLELeft ..) _ h₁
+    replace h₂ := P.res (le.hom ≫ infLERight ..) _ h₂
+    exact ⟨U, _, _, h₁, h₂, rfl, rfl, fun x eq ↦ ne <| congr_fun (hU _ _ _ h₁ h₂ eq) ⟨b, U.2⟩⟩
+
+theorem IsWeaklyLocallyConstant.isStalkSurj (h : IsWeaklyLocallyConstant P b) :
+    IsStalkSurj P b :=
+  fun x ↦ have ⟨U, hU⟩ := h; have ⟨s, hs, _⟩ := hU ⟨b, U.2⟩ x; ⟨U, s, hs⟩
+
+theorem IsWeaklyLocallyConstant.isSeparated (h : IsWeaklyLocallyConstant P b) :
+    IsSeparated P b :=
+  fun x y ne ↦ by
+    have ⟨U, hU⟩ := h
+    have ⟨s, hs, hsu⟩ := hU ⟨b, U.2⟩ x
+    have ⟨t, ht, htu⟩ := hU ⟨b, U.2⟩ y
+    refine ⟨U, s, t, hs.1, ht.1, hs.2, ht.2, fun b' eq ↦ ne ?_⟩
+    rw [← hs.2, (isConstantOn_iff.mp hU).1 s t b' hs.1 ht.1 eq, ht.2]
+
+theorem HasIdentityPrinciple.isStalkInj {P : PrelocalPredicate F}
+    (h : HasIdentityPrinciple P.pred b) : IsStalkInj P.pred b :=
+  P.isStalkInj_iff.mpr fun U _s _t hs ht eq ↦ have ⟨V, le, ip⟩ := h U
+    ⟨V, le.hom, congr_fun (ip _ _ ⟨b, V.2⟩ (P.res le.hom _ hs) (P.res le.hom _ ht) eq)⟩
+
+namespace IsConstantOn
+
+variable {U : Opens B} (h : IsConstantOn P U) {b : U} (x : F b)
+
+/-- The section on `U` with given germ at `b : U` within a set of sections constant on `U`. -/
+def sec : Π b : U, F b := (h b x).choose
+
+lemma pred_sec : P (h.sec x) := (h b x).choose_spec.1.1
+
+lemma sec_apply : h.sec x b = x := (h b x).choose_spec.1.2
+
+lemma sec_eq_of_pred {s : Π b : U, F b} (hs : P s) (b : U) : h.sec (s b) = s :=
+  (isConstantOn_iff.mp h).1 _ _ b (h.pred_sec _) hs (h.sec_apply _)
+
+/-- The monodromy induced by a set of sections constant on `U`. -/
+def monodromy (b b' : U) : F b ≃ F b' where
+  toFun x := h.sec x b'
+  invFun x := h.sec x b
+  left_inv _ := by simp_rw [h.sec_eq_of_pred (h.pred_sec _), h.sec_apply]
+  right_inv _ := by simp_rw [h.sec_eq_of_pred (h.pred_sec _), h.sec_apply]
+
+include h in
+/-- The trivialization induced by a set of sections constant on `U`. -/
+def trivializationOn (b : U) : TrivializationOn P U (F b) where
+  sec := h.sec
+  pred := h.pred_sec
+  bijective _ := (h.monodromy ..).bijective
+
+end IsConstantOn
+
+namespace TrivializationOn
+
+variable {U : Opens B} {ι} (t : TrivializationOn P U ι)
+
+/-- A trivialization of a set of sections over a set `U` induces a trivialization of the `Sigma`
+type over `U`. -/
+def equiv : {f : Σ b, F b // f.1 ∈ U} ≃ U × ι :=
+  .trans (.symm (.trans (.sigmaCongrRight (.ofBijective _ <| t.bijective ·)) .sigmaSubtypeComm))
+    (.sigmaEquivProd ..)
+
+lemma symm_apply_coe (x : U × ι) : t.equiv.symm x = Sigma.mk _ (t.sec x.2 x.1) := rfl
+
+lemma preimage_snd_comp_equiv (i : ι) :
+    Prod.snd ∘ t.equiv ⁻¹' {i} = Subtype.val ⁻¹' Set.range (Sigma.mk _ <| t.sec i ·) :=
+  Set.ext fun f ↦ (Equiv.symm_apply_eq _).trans <| by
+    simp only [Equiv.sigmaSubtypeComm, Equiv.coe_fn_symm_mk,
+      Equiv.ofBijective_apply, Set.mem_preimage, Set.mem_range]
+    refine ⟨fun h ↦ ⟨⟨_, f.2⟩, congr(Sigma.mk _ $h).symm⟩, fun ⟨b, h⟩ ↦ ?_⟩
+    obtain ⟨⟨b', x⟩, hbx⟩ := f
+    cases congr($h.1)
+    exact congr($h.2).symm
+
+end TrivializationOn
+
+end Properties
 
 /-- Continuity is a "local" predicate on functions to a fixed topological space `T`.
 -/
-def continuousLocal (T) [TopologicalSpace T] : LocalPredicate fun _ : X ↦ T :=
+def continuousLocal (T : Type*) [TopologicalSpace T] : LocalPredicate fun _ : X ↦ T :=
   { continuousPrelocal X T with
     locality := fun {U} f w ↦ by
       apply continuous_iff_continuousAt.2
       intro x
-      specialize w x
-      rcases w with ⟨V, m, i, w⟩
+      rcases w x with ⟨V, m, i, w⟩
       dsimp at w
       rw [continuous_iff_continuousAt] at w
       specialize w ⟨x, m⟩
       simpa using (Opens.isOpenEmbedding_of_le i.le).continuousAt_iff.1 w }
 
 /-- Satisfying the inhabited linter. -/
-instance inhabitedLocalPredicate (T) [TopologicalSpace T] :
+instance inhabitedLocalPredicate (T : Type*) [TopologicalSpace T] :
     Inhabited (LocalPredicate fun _ : X ↦ T) :=
   ⟨continuousLocal X T⟩
 
@@ -123,44 +347,64 @@ variable {X T}
 
 /-- The conjunction of two prelocal predicates is prelocal. -/
 def PrelocalPredicate.and (P Q : PrelocalPredicate T) : PrelocalPredicate T where
-  pred f := P.pred f ∧ Q.pred f
+  pred _ f := P.pred f ∧ Q.pred f
   res i f h := ⟨P.res i f h.1, Q.res i f h.2⟩
+
+lemma IsLocal.inf {P Q : ∀ ⦃U : Opens X⦄, (∀ x : U, T x) → Prop} (hP : IsLocal P) (hQ : IsLocal Q) :
+    IsLocal (P ⊓ Q) := fun U f w ↦ by
+  refine ⟨hP U f ?_, hQ U f ?_⟩ <;> (intro x; have ⟨V, hV, i, h⟩ := w x; use V, hV, i)
+  exacts [h.1, h.2]
 
 /-- The conjunction of two prelocal predicates is prelocal. -/
 def LocalPredicate.and (P Q : LocalPredicate T) : LocalPredicate T where
   __ := P.1.and Q.1
-  locality f w := by
-    refine ⟨P.locality f ?_, Q.locality f ?_⟩ <;>
-      (intro x; have ⟨V, hV, i, h⟩ := w x; use V, hV, i)
-    exacts [h.1, h.2]
+  locality := P.locality.inf Q.locality
 
 /-- The local predicate of being a partial section of a function. -/
 def isSection {T} (p : T → X) : LocalPredicate fun _ : X ↦ T where
-  pred f := p ∘ f = (↑)
+  pred _ f := p ∘ f = (↑)
   res _ _ h := funext fun _ ↦ congr_fun h _
-  locality _ w := funext fun x ↦ have ⟨_, hV, _, h⟩ := w x; congr_fun h ⟨x, hV⟩
+  locality _ _ w := funext fun x ↦ have ⟨_, hV, _, h⟩ := w x; congr_fun h ⟨x, hV⟩
+
+/-- Continuity is a local predicate on sections of a map between topological spaces. -/
+def isContinuousSection {T} [TopologicalSpace T] (p : T → X) : LocalPredicate (p ⁻¹' {·}) where
+  pred _U f := Continuous fun x ↦ (f x).1
+  res i _f := (continuousLocal X T).res i _
+  locality U _f h := (continuousLocal X T).locality U _ h
+
+section Sheafify
+
+variable {T : X → Type*} (P : PrelocalPredicate T)
 
 /-- Given a `P : PrelocalPredicate`, we can always construct a `LocalPredicate`
 by asking that the condition from `P` holds locally near every point.
 -/
-def PrelocalPredicate.sheafify {T : X → Type*} (P : PrelocalPredicate T) : LocalPredicate T where
-  pred {U} f := ∀ x : U, ∃ (V : Opens X) (_ : x.1 ∈ V) (i : V ⟶ U), P.pred fun x : V ↦ f (i x : U)
+def PrelocalPredicate.sheafify : LocalPredicate T where
+  pred := Sheafify P.pred
   res {V U} i f w x := by
-    specialize w (i x)
-    rcases w with ⟨V', m', i', p⟩
+    rcases w (i x) with ⟨V', m', i', p⟩
     exact ⟨V ⊓ V', ⟨x.2, m'⟩, V.infLELeft _, P.res (V.infLERight V') _ p⟩
-  locality {U} f w x := by
-    specialize w x
-    rcases w with ⟨V, m, i, p⟩
-    specialize p ⟨x.1, m⟩
-    rcases p with ⟨V', m', i', p'⟩
-    exact ⟨V', m', i' ≫ i, p'⟩
+  locality := isLocal_sheafify _
+
+variable {P}
+
+theorem PrelocalPredicate.sheafifyOf {U : Opens X} {f : ∀ x : U, T x} (h : P.pred f) :
+    P.sheafify.pred f := le_sheafify _ _ _ h
+
+theorem IsStalkSurj.sheafify {x : X} (h : IsStalkSurj P.pred x) :
+    IsStalkSurj P.sheafify.pred x :=
+  fun t ↦ have ⟨U, s, hs, eq⟩ := h t; ⟨U, s, P.sheafifyOf hs, eq⟩
+
+theorem IsStalkInj.sheafify {x : X} (h : IsStalkInj P.pred x) : IsStalkInj P.sheafify.pred x :=
+  fun U V _fU _fV hU hV e ↦
+    have ⟨U', mU, iU, hU⟩ := hU ⟨x, U.2⟩
+    have ⟨V', mV, iV, hV⟩ := hV ⟨x, V.2⟩
+    have ⟨W, iU', iV', h⟩ := h ⟨U', mU⟩ ⟨V', mV⟩ _ _ hU hV e
+    ⟨W, iU' ≫ iU, iV' ≫ iV, h⟩
+
+end Sheafify
 
 namespace PrelocalPredicate
-
-theorem sheafifyOf {T : X → Type*} {P : PrelocalPredicate T} {U : Opens X}
-    {f : ∀ x : U, T x} (h : P.pred f) : P.sheafify.pred f := fun x ↦
-  ⟨U, x.2, 𝟙 _, by convert h⟩
 
 /-- For a unary operation (e.g. `x ↦ -x`) defined at each stalk, if a prelocal predicate is closed
 under the operation on each open set (possibly by refinement), then the sheafified predicate is
@@ -283,58 +527,42 @@ end subpresheafToTypes
 def subsheafToTypes (P : LocalPredicate T) : Sheaf (Type _) X :=
   ⟨subpresheafToTypes P.toPrelocalPredicate, subpresheafToTypes.isSheaf P⟩
 
-/-- There is a canonical map from the stalk to the original fiber, given by evaluating sections.
--/
-def stalkToFiber (P : LocalPredicate T) (x : X) : (subsheafToTypes P).presheaf.stalk x ⟶ T x := by
-  refine
-    colimit.desc _
-      { pt := T x
-        ι :=
-          { app := fun U f ↦ ?_
-            naturality := ?_ } }
-  · exact f.1 ⟨x, (unop U).2⟩
-  · aesop
+/-- There is a canonical map from the stalk to the original fiber, given by evaluating sections. -/
+def stalkToFiber (P : PrelocalPredicate T) (x : X) : (subpresheafToTypes P).stalk x → T x :=
+  ULift.down ∘ colimit.desc _
+    { pt := ULift (T x)
+      ι := { app := fun U f ↦ ⟨by exact f.1 ⟨x, (unop U).2⟩⟩ } }
 
-theorem stalkToFiber_germ (P : LocalPredicate T) (U : Opens X) (x : X) (hx : x ∈ U) (f) :
-    stalkToFiber P x ((subsheafToTypes P).presheaf.germ U x hx f) = f.1 ⟨x, hx⟩ := by
-  simp [Presheaf.germ, stalkToFiber]
+theorem stalkToFiber_germ (P : PrelocalPredicate T) (U : Opens X) (x : X) (hx : x ∈ U) (f) :
+    stalkToFiber P x ((subpresheafToTypes P).germ U x hx f) = f.1 ⟨x, hx⟩ := by
+  simp [stalkToFiber, Presheaf.germ, Colimit.ι_desc_apply]
 
 /-- The `stalkToFiber` map is surjective at `x` if
-every point in the fiber `T x` has an allowed section passing through it.
--/
-theorem stalkToFiber_surjective (P : LocalPredicate T) (x : X)
-    (w : ∀ t : T x, ∃ (U : OpenNhds x) (f : ∀ y : U.1, T y) (_ : P.pred f), f ⟨x, U.2⟩ = t) :
+every point in the fiber `T x` has an allowed section passing through it. -/
+-- TODO: upgrade to iff?
+theorem stalkToFiber_surjective (P : PrelocalPredicate T) (x : X) (w : IsStalkSurj P.pred x) :
     Function.Surjective (stalkToFiber P x) := fun t ↦ by
   rcases w t with ⟨U, f, h, rfl⟩
-  fconstructor
-  · exact (subsheafToTypes P).presheaf.germ _ x U.2 ⟨f, h⟩
-  · exact stalkToFiber_germ P U.1 x U.2 ⟨f, h⟩
+  exact ⟨_, stalkToFiber_germ P U.1 x U.2 ⟨f, h⟩⟩
 
 /-- The `stalkToFiber` map is injective at `x` if any two allowed sections which agree at `x`
-agree on some neighborhood of `x`.
--/
-theorem stalkToFiber_injective (P : LocalPredicate T) (x : X)
-    (w :
-      ∀ (U V : OpenNhds x) (fU : ∀ y : U.1, T y) (_ : P.pred fU) (fV : ∀ y : V.1, T y)
-        (_ : P.pred fV) (_ : fU ⟨x, U.2⟩ = fV ⟨x, V.2⟩),
-        ∃ (W : OpenNhds x) (iU : W ⟶ U) (iV : W ⟶ V), ∀ w : W.1,
-          fU (iU w : U.1) = fV (iV w : V.1)) :
+agree on some neighborhood of `x`. -/
+-- TODO: upgrade to iff?
+theorem stalkToFiber_injective (P : PrelocalPredicate T) (x : X) (w : IsStalkInj P.pred x) :
     Function.Injective (stalkToFiber P x) := fun tU tV h ↦ by
   -- We promise to provide all the ingredients of the proof later:
   let Q :
     ∃ (W : (OpenNhds x)ᵒᵖ) (s : ∀ w : (unop W).1, T w) (hW : P.pred s),
-      tU = (subsheafToTypes P).presheaf.germ _ x (unop W).2 ⟨s, hW⟩ ∧
-        tV = (subsheafToTypes P).presheaf.germ _ x (unop W).2 ⟨s, hW⟩ :=
-    ?_
+      tU = (subpresheafToTypes P).germ _ x (unop W).2 ⟨s, hW⟩ ∧
+        tV = (subpresheafToTypes P).germ _ x (unop W).2 ⟨s, hW⟩ := ?_
   · choose W s hW e using Q
     exact e.1.trans e.2.symm
   -- Then use induction to pick particular representatives of `tU tV : stalk x`
   obtain ⟨U, ⟨fU, hU⟩, rfl⟩ := jointly_surjective' tU
   obtain ⟨V, ⟨fV, hV⟩, rfl⟩ := jointly_surjective' tV
   -- Decompose everything into its constituent parts:
-  dsimp
-  simp only [stalkToFiber, Types.Colimit.ι_desc_apply] at h
-  specialize w (unop U) (unop V) fU hU fV hV h
+  simp_rw [stalkToFiber, Function.comp_apply, Colimit.ι_desc_apply] at h
+  specialize w (unop U) (unop V) fU fV hU hV h
   rcases w with ⟨W, iU, iV, w⟩
   -- and put it back together again in the correct order.
   refine ⟨op W, fun w ↦ fU (iU w : (unop U).1), P.res ?_ _ hU, ?_⟩

--- a/Mathlib/Topology/Sheaves/Sheafify.lean
+++ b/Mathlib/Topology/Sheaves/Sheafify.lean
@@ -34,13 +34,13 @@ following <https://stacks.math.columbia.edu/tag/007X>.
 assert_not_exists CommRingCat
 
 
-universe v
+universe u v
 
 noncomputable section
 
 open TopCat Opposite TopologicalSpace CategoryTheory
 
-variable {X : TopCat.{v}} (F : Presheaf (Type v) X)
+variable {X : TopCat.{u}} (F : Presheaf (Type v) X) [UnivLE.{u, v}]
 
 namespace TopCat.Presheaf
 
@@ -50,31 +50,66 @@ attribute [local instance] Types.instFunLike Types.instConcreteCategory in
 /--
 The prelocal predicate on functions into the stalks, asserting that the function is equal to a germ.
 -/
-def isGerm : PrelocalPredicate fun x => F.stalk x where
-  pred {U} f := ∃ g : F.obj (op U), ∀ x : U, f x = F.germ U x.1 x.2 g
-  res := fun i _ ⟨g, p⟩ => ⟨F.map i.op g, fun x ↦ (p (i x)).trans (F.germ_res_apply i x x.2 g).symm⟩
+def isGerm : PrelocalPredicate fun x ↦ F.stalk x where
+  pred {U} f := ∃ g : F.obj (op U), ∀ x : U, f x = germ F U x.1 x.2 g
+  res := fun i _ ⟨g, p⟩ ↦ ⟨F.map i.op g, fun x ↦ (p (i x)).trans (germ_res_apply F i x x.2 g).symm⟩
 
 /-- The local predicate on functions into the stalks,
 asserting that the function is locally equal to a germ.
 -/
-def isLocallyGerm : LocalPredicate fun x => F.stalk x :=
+def isLocallyGerm : LocalPredicate fun x ↦ F.stalk x :=
   (isGerm F).sheafify
 
+attribute [local instance] Types.instFunLike Types.instConcreteCategory
+
+theorem isStalkSurj_isGerm (x : X) : IsStalkSurj (isGerm F).pred x := fun t ↦ by
+  obtain ⟨U, m, s, rfl⟩ := F.germ_exist x t
+  exact ⟨⟨U, m⟩, fun y ↦ F.germ _ _ y.2 s, ⟨s, fun _ ↦ rfl⟩, rfl⟩
+
+theorem isStalkInj_isGerm (x : X) : IsStalkInj (isGerm F).pred x := by
+  intro U V sU sV ⟨gU, mU⟩ ⟨gV, mV⟩ e
+  have := (mU _).symm.trans (e.trans (mV _))
+  have ⟨W, mW, iU, iV, e⟩ := F.germ_eq x _ _ gU gV this
+  refine ⟨⟨W, mW⟩, iU, iV, fun w ↦ (mU _).trans (.trans ?_ <| .symm <| mV _)⟩
+  exact (congr_fun (F.germ_res iU w w.2) gU).symm.trans (congr_arg (F.germ W w w.2) e)
+    |>.trans (congr_fun (F.germ_res iV w w.2) gV)
+
 end Sheafify
+
+attribute [local instance] Types.instFunLike Types.instConcreteCategory in
+/-- The adjunction between presheaves and prelocal predicates. -/
+def adjunctionPrelocalPredicate (F : Presheaf (Type u) X) {G : X → Type u}
+    (P : PrelocalPredicate G) :
+    {f : Π x, F.stalk x → G x // (Sheafify.isGerm F).pred ≤ (P.pullback f).pred} ≃
+    (F ⟶ subpresheafToTypes P) where
+  toFun f := ⟨fun U s ↦ ⟨fun x ↦ f.1 _ (F.germ _ _ x.2 s), f.2 _ _ ⟨_, fun _ ↦ rfl⟩⟩,
+    fun U V i ↦ funext fun s ↦ Subtype.ext <| funext fun x ↦ congr_arg _ (F.germ_res_apply ..)⟩
+  invFun f := ⟨fun x ↦ stalkToFiber P x ∘ (stalkFunctor _ x).map f,
+    fun U s' ⟨s, eq⟩ ↦ by
+      simp_rw [PrelocalPredicate.pullback, Pullback, eq, Function.comp_apply]
+      convert (f.app _ s).2
+      exact (congr_arg _ (stalkFunctor_map_germ_apply _ _ _ f _)).trans (stalkToFiber_germ ..)⟩
+  left_inv f := Subtype.ext <| funext fun x ↦ funext fun g ↦ by
+    obtain ⟨U, hx, s, rfl⟩ := F.germ_exist x g
+    exact (congr_arg _ (stalkFunctor_map_germ_apply (C := Type u) ..)).trans (stalkToFiber_germ ..)
+  right_inv f := ext fun U ↦ funext fun s ↦ Subtype.ext <| funext fun x ↦
+    (congr_arg _ (stalkFunctor_map_germ_apply (C := Type u) ..)).trans (stalkToFiber_germ ..)
 
 /-- The sheafification of a `Type`-valued presheaf, defined as the functions into the stalks which
 are locally equal to germs.
 -/
-def sheafify : Sheaf (Type v) X :=
+def sheafify : Sheaf (Type _) X :=
   subsheafToTypes (Sheafify.isLocallyGerm F)
 
-attribute [local instance] Types.instFunLike Types.instConcreteCategory in
+attribute [local instance] Types.instFunLike Types.instConcreteCategory
+
 /-- The morphism from a presheaf to its sheafification,
 sending each section to its germs.
 (This forms the unit of the adjunction.)
 -/
-def toSheafify : F ⟶ F.sheafify.1 where
-  app U f := ⟨fun x => F.germ _ x x.2 f, PrelocalPredicate.sheafifyOf ⟨f, fun x => rfl⟩⟩
+def toSheafify (F : Presheaf (Type u) X) : F ⟶ F.sheafify.1 where
+  app U f := ⟨fun x ↦ germ F _ x x.2 f,
+    PrelocalPredicate.sheafifyOf ⟨f, fun x ↦ rfl⟩⟩
   naturality U U' f := by
     ext x
     apply Subtype.ext -- Porting note (https://github.com/leanprover-community/mathlib4/issues/11041): Added `apply`
@@ -84,47 +119,20 @@ def toSheafify : F ⟶ F.sheafify.1 where
 /-- The natural morphism from the stalk of the sheafification to the original stalk.
 In `sheafifyStalkIso` we show this is an isomorphism.
 -/
-def stalkToFiber (x : X) : F.sheafify.presheaf.stalk x ⟶ F.stalk x :=
-  TopCat.stalkToFiber (Sheafify.isLocallyGerm F) x
+def stalkToFiber (x : X) : F.sheafify.presheaf.stalk x → stalk F x :=
+  TopCat.stalkToFiber (Sheafify.isLocallyGerm F).1 x
 
-attribute [local instance] Types.instFunLike Types.instConcreteCategory in
-theorem stalkToFiber_surjective (x : X) : Function.Surjective (F.stalkToFiber x) := by
-  apply TopCat.stalkToFiber_surjective
-  intro t
-  obtain ⟨U, m, s, rfl⟩ := F.germ_exist _ t
-  use ⟨U, m⟩
-  fconstructor
-  · exact fun y => F.germ _ _ y.2 s
-  · exact ⟨PrelocalPredicate.sheafifyOf ⟨s, fun _ => rfl⟩, rfl⟩
+theorem stalkToFiber_surjective (x : X) : Function.Surjective (F.stalkToFiber x) :=
+  TopCat.stalkToFiber_surjective _ _ (Sheafify.isStalkSurj_isGerm F x).sheafify
 
-attribute [local instance] Types.instFunLike Types.instConcreteCategory in
-theorem stalkToFiber_injective (x : X) : Function.Injective (F.stalkToFiber x) := by
-  apply TopCat.stalkToFiber_injective
-  intro U V fU hU fV hV e
-  rcases hU ⟨x, U.2⟩ with ⟨U', mU, iU, gU, wU⟩
-  rcases hV ⟨x, V.2⟩ with ⟨V', mV, iV, gV, wV⟩
-  have wUx := wU ⟨x, mU⟩
-  dsimp at wUx; rw [wUx] at e; clear wUx
-  have wVx := wV ⟨x, mV⟩
-  dsimp at wVx; rw [wVx] at e; clear wVx
-  rcases F.germ_eq x mU mV gU gV e with ⟨W, mW, iU', iV', (e' : F.map iU'.op gU = F.map iV'.op gV)⟩
-  use ⟨W ⊓ (U' ⊓ V'), ⟨mW, mU, mV⟩⟩
-  refine ⟨?_, ?_, ?_⟩
-  · change W ⊓ (U' ⊓ V') ⟶ U.obj
-    exact Opens.infLERight _ _ ≫ Opens.infLELeft _ _ ≫ iU
-  · change W ⊓ (U' ⊓ V') ⟶ V.obj
-    exact Opens.infLERight _ _ ≫ Opens.infLERight _ _ ≫ iV
-  · intro w
-    specialize wU ⟨w.1, w.2.2.1⟩
-    specialize wV ⟨w.1, w.2.2.2⟩
-    refine wU.trans <| .trans ?_ wV.symm
-    rw [← F.germ_res iU' w w.2.1, ← F.germ_res iV' w w.2.1,
-      CategoryTheory.types_comp_apply, CategoryTheory.types_comp_apply, e']
+theorem stalkToFiber_injective (x : X) : Function.Injective (F.stalkToFiber x) :=
+  TopCat.stalkToFiber_injective _ _ (Sheafify.isStalkInj_isGerm F x).sheafify
 
 /-- The isomorphism between a stalk of the sheafification and the original stalk.
 -/
-def sheafifyStalkIso (x : X) : F.sheafify.presheaf.stalk x ≅ F.stalk x :=
-  (Equiv.ofBijective _ ⟨stalkToFiber_injective _ _, stalkToFiber_surjective _ _⟩).toIso
+def sheafifyStalkIso {X : TopCat.{u}} (F : Presheaf (Type max u v) X) (x : X) :
+    F.sheafify.presheaf.stalk x ≅ F.stalk x :=
+  (Equiv.ofBijective _ ⟨stalkToFiber_injective F x, stalkToFiber_surjective F x⟩).toIso
 
 -- PROJECT functoriality, and that sheafification is the left adjoint of the forgetful functor.
 end TopCat.Presheaf

--- a/Mathlib/Topology/Sheaves/Stalks.lean
+++ b/Mathlib/Topology/Sheaves/Stalks.lean
@@ -46,7 +46,7 @@ assert_not_exists IsOrderedMonoid
 
 noncomputable section
 
-universe v u v' u'
+universe v
 
 open CategoryTheory
 
@@ -60,8 +60,8 @@ open Opposite
 
 open scoped AlgebraicGeometry
 
-variable {C : Type u} [Category.{v} C]
-variable [HasColimits.{v} C]
+variable {C : Type*} [Category C]
+variable [HasColimitsOfSize.{v, v} C]
 variable {X Y Z : TopCat.{v}}
 
 namespace TopCat.Presheaf
@@ -381,8 +381,10 @@ end stalkSpecializes
 
 section Concrete
 
-variable {C} {CC : C → Type v} [∀ X Y, FunLike (FC X Y) (CC X) (CC Y)]
-variable [instCC : ConcreteCategory.{v} C FC]
+universe w
+
+variable {C} {CC : C → Type w} [∀ X Y, FunLike (FC X Y) (CC X) (CC Y)]
+variable [instCC : ConcreteCategory.{w} C FC]
 
 theorem germ_ext (F : X.Presheaf C) {U V : Opens X} {x : X} {hxU : x ∈ U} {hxV : x ∈ V}
     (W : Opens X) (hxW : x ∈ W) (iWU : W ⟶ U) (iWV : W ⟶ V)
@@ -392,16 +394,16 @@ theorem germ_ext (F : X.Presheaf C) {U V : Opens X} {x : X} {hxU : x ∈ U} {hxV
   rw [← F.germ_res iWU x hxW, ← F.germ_res iWV x hxW, ConcreteCategory.comp_apply,
     ConcreteCategory.comp_apply, ih]
 
-variable [PreservesFilteredColimits (forget C)]
+variable [PreservesFilteredColimitsOfSize.{v, v} (forget C)]
 
 /--
 For presheaves valued in a concrete category whose forgetful functor preserves filtered colimits,
 every element of the stalk is the germ of a section.
 -/
-theorem germ_exist (F : X.Presheaf C) (x : X) (t : ToType (stalk.{v, u} F x)) :
+theorem germ_exist (F : X.Presheaf C) (x : X) (t : ToType (stalk F x)) :
     ∃ (U : Opens X) (m : x ∈ U) (s : ToType (F.obj (op U))), F.germ _ x m s = t := by
   obtain ⟨U, s, e⟩ :=
-    Types.jointly_surjective.{v, v} _ (isColimitOfPreserves (forget C) (colimit.isColimit _)) t
+    Types.jointly_surjective _ (isColimitOfPreserves (forget C) (colimit.isColimit _)) t
   revert s e
   induction U with | op U => ?_
   obtain ⟨V, m⟩ := U
@@ -411,12 +413,11 @@ theorem germ_exist (F : X.Presheaf C) (x : X) (t : ToType (stalk.{v, u} F x)) :
 theorem germ_eq (F : X.Presheaf C) {U V : Opens X} (x : X) (mU : x ∈ U) (mV : x ∈ V)
     (s : ToType (F.obj (op U))) (t : ToType (F.obj (op V)))
     (h : F.germ U x mU s = F.germ V x mV t) :
-    ∃ (W : Opens X) (_m : x ∈ W) (iU : W ⟶ U) (iV : W ⟶ V), F.map iU.op s = F.map iV.op t := by
-  obtain ⟨W, iU, iV, e⟩ :=
-    (Types.FilteredColimit.isColimit_eq_iff.{v, v} _
-          (isColimitOfPreserves (forget C) (colimit.isColimit ((OpenNhds.inclusion x).op ⋙ F)))).mp
-        h
-  exact ⟨(unop W).1, (unop W).2, iU.unop, iV.unop, e⟩
+    ∃ (W : Opens X) (_m : x ∈ W) (iU : W ⟶ U) (iV : W ⟶ V), F.map iU.op s = F.map iV.op t :=
+  have ⟨W, iU, iV, e⟩ :=
+    (Types.FilteredColimit.isColimit_eq_iff _
+      (isColimitOfPreserves (forget C) (colimit.isColimit ((OpenNhds.inclusion x).op ⋙ F)))).mp h
+  ⟨(unop W).1, (unop W).2, iU.unop, iV.unop, e⟩
 
 theorem stalkFunctor_map_injective_of_app_injective {F G : Presheaf C X} {f : F ⟶ G}
     (h : ∀ U : Opens X, Function.Injective (f.app (op U))) (x : X) :
@@ -467,7 +468,8 @@ lemma stalkFunctor_map_injective_of_isBasis
 
 end IsBasis
 
-variable [HasLimits C] [PreservesLimits (forget C)] [(forget C).ReflectsIsomorphisms]
+variable [HasLimitsOfSize.{v, v} C] [PreservesLimitsOfSize.{v, v} (forget C)]
+  [(forget C).ReflectsIsomorphisms]
 
 /-- Let `F` be a sheaf valued in a concrete category, whose forgetful functor reflects isomorphisms,
 preserves limits and filtered colimits. Then two sections who agree on every stalk must be equal.
@@ -503,6 +505,8 @@ theorem app_injective_iff_stalkFunctor_map_injective {F : Sheaf C X} {G : Preshe
       ∀ U : Opens X, Function.Injective (f.app (op U)) :=
   ⟨fun h U => app_injective_of_stalkFunctor_map_injective f U fun x _ => h x,
     stalkFunctor_map_injective_of_app_injective⟩
+
+attribute [local instance] PreservesLimitsOfSize.preservesFiniteLimits
 
 instance stalkFunctor_preserves_mono (x : X) :
     Functor.PreservesMonomorphisms (Sheaf.forget.{v} C X ⋙ stalkFunctor C x) :=


### PR DESCRIPTION
migrated to #31925

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
