### PR TITLE
[Merged by Bors] - refactor(MeasureTheory/Integral): split FundThmCalculus and fix late import

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4052,6 +4052,7 @@ import Mathlib.MeasureTheory.Integral.Gamma
 import Mathlib.MeasureTheory.Integral.Indicator
 import Mathlib.MeasureTheory.Integral.IntegrableOn
 import Mathlib.MeasureTheory.Integral.IntegralEqImproper
+import Mathlib.MeasureTheory.Integral.IntegrationByParts
 import Mathlib.MeasureTheory.Integral.IntervalAverage
 import Mathlib.MeasureTheory.Integral.IntervalIntegral
 import Mathlib.MeasureTheory.Integral.Layercake

--- a/Mathlib/Analysis/Fourier/AddCircle.lean
+++ b/Mathlib/Analysis/Fourier/AddCircle.lean
@@ -11,7 +11,7 @@ import Mathlib.MeasureTheory.Function.L2Space
 import Mathlib.MeasureTheory.Group.Integral
 import Mathlib.MeasureTheory.Integral.Periodic
 import Mathlib.Topology.ContinuousMap.StoneWeierstrass
-import Mathlib.MeasureTheory.Integral.FundThmCalculus
+import Mathlib.MeasureTheory.Integral.IntegrationByParts
 
 /-!
 

--- a/Mathlib/Analysis/SpecialFunctions/Integrals.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Integrals.lean
@@ -7,7 +7,7 @@ import Mathlib.Analysis.SpecialFunctions.Log.NegMulLog
 import Mathlib.Analysis.SpecialFunctions.NonIntegrable
 import Mathlib.Analysis.SpecialFunctions.Pow.Deriv
 import Mathlib.Analysis.SpecialFunctions.Trigonometric.ArctanDeriv
-import Mathlib.MeasureTheory.Integral.FundThmCalculus
+import Mathlib.MeasureTheory.Integral.IntegrationByParts
 
 /-!
 # Integration of specific interval integrals

--- a/Mathlib/MeasureTheory/Integral/FundThmCalculus.lean
+++ b/Mathlib/MeasureTheory/Integral/FundThmCalculus.lean
@@ -3,11 +3,9 @@ Copyright (c) 2020 Yury Kudryashov. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury Kudryashov, Patrick Massot, Sébastien Gouëzel
 -/
-import Mathlib.Analysis.Calculus.FDeriv.Measurable
-import Mathlib.Analysis.Calculus.Deriv.Comp
 import Mathlib.Analysis.Calculus.Deriv.Add
-import Mathlib.Analysis.Calculus.Deriv.Slope
-import Mathlib.Analysis.Calculus.Deriv.Mul
+import Mathlib.Analysis.Calculus.Deriv.Comp
+import Mathlib.Analysis.Calculus.FDeriv.Measurable
 import Mathlib.Analysis.Normed.Module.Dual
 import Mathlib.MeasureTheory.Integral.DominatedConvergence
 import Mathlib.MeasureTheory.Integral.VitaliCaratheodory
@@ -93,10 +91,6 @@ scheme as for the versions of FTC-1. They include:
 * `intervalIntegral.integral_deriv_eq_sub'` - version that is easiest to use when computing the
   integral of a specific function
 
-We then derive additional integration techniques from FTC-2:
-* `intervalIntegral.integral_mul_deriv_eq_deriv_mul` - integration by parts
-* `intervalIntegral.integral_comp_mul_deriv''` - integration by substitution
-
 Many applications of these theorems can be found in the file
 `Mathlib/Analysis/SpecialFunctions/Integrals.lean`.
 
@@ -136,16 +130,18 @@ instances could be added when needed (in that case, one also needs to add instan
 
 ## Tags
 
-integral, fundamental theorem of calculus, FTC-1, FTC-2, change of variables in integrals
+integral, fundamental theorem of calculus, FTC-1, FTC-2
 -/
+
+assert_not_exists HasDerivAt.mul -- guard against import creep
 
 noncomputable section
 
-open MeasureTheory Set Filter Function
+open MeasureTheory Set Filter Function Asymptotics
 
-open scoped Topology Filter ENNReal Interval NNReal
+open scoped Topology ENNReal Interval NNReal
 
-variable {ι 𝕜 E A : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
+variable {ι 𝕜 E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
 
 namespace intervalIntegral
 
@@ -233,8 +229,6 @@ instance nhdsUIcc {x a b : ℝ} [h : Fact (x ∈ [[a, b]])] :
 
 end FTCFilter
 
-open Asymptotics
-
 section
 
 variable {f : ℝ → E} {a b : ℝ} {c ca cb : E} {l l' la la' lb lb' : Filter ℝ} {lt : Filter ι}
@@ -312,9 +306,11 @@ theorem measure_integral_sub_linear_isLittleO_of_tendsto_ae_of_ge'
           huv).neg_left.congr_left
     fun t => by simp [integral_symm (u t), add_comm]
 
-section
+section IsLocallyFiniteMeasure
 
 variable [IsLocallyFiniteMeasure μ]
+
+variable [FTCFilter a la la'] [FTCFilter b lb lb']
 
 /-- **Fundamental theorem of calculus-1**, local version for any measure.
 
@@ -370,10 +366,6 @@ theorem measure_integral_sub_linear_isLittleO_of_tendsto_ae_of_ge
   haveI := FTCFilter.meas_gen l
   measure_integral_sub_linear_isLittleO_of_tendsto_ae_of_ge' hfm hf (FTCFilter.finiteAt_inner l) hu
     hv huv
-
-end
-
-variable [FTCFilter a la la'] [FTCFilter b lb lb'] [IsLocallyFiniteMeasure μ]
 
 /-- **Fundamental theorem of calculus-1**, strict derivative in both limits for a locally finite
 measure.
@@ -453,6 +445,8 @@ theorem measure_integral_sub_integral_sub_linear_isLittleO_of_tendsto_ae_left
     measure_integral_sub_integral_sub_linear_isLittleO_of_tendsto_ae hab hmeas
       stronglyMeasurableAt_bot hf ((tendsto_bot : Tendsto _ ⊥ (𝓝 (0 : E))).mono_left inf_le_left) hu
       hv (tendsto_const_pure : Tendsto _ _ (pure b)) tendsto_const_pure
+
+end IsLocallyFiniteMeasure
 
 end
 
@@ -953,6 +947,8 @@ semicontinuity. As  `g' t < G' t`, this gives the conclusion. One can therefore 
 this inequality to the right until the point `b`, where it gives the desired conclusion.
 -/
 
+section FTC2
+
 variable {g' g φ : ℝ → ℝ} {a b : ℝ}
 
 /-- Hard part of FTC-2 for integrable derivatives, real-valued functions: one has
@@ -1184,13 +1180,9 @@ lemma integral_unitInterval_deriv_eq_sub [RCLike 𝕜] [NormedSpace 𝕜 E] [IsS
   let γ (t : ℝ) : 𝕜 := z₀ + t • z₁
   have hint : IntervalIntegrable (z₁ • (f' ∘ γ)) MeasureTheory.volume 0 1 :=
     (ContinuousOn.const_smul hcont z₁).intervalIntegrable_of_Icc zero_le_one
-  have hderiv' : ∀ t ∈ Set.uIcc (0 : ℝ) 1, HasDerivAt (f ∘ γ) (z₁ • (f' ∘ γ) t) t := by
-    intro t ht
-    refine (hderiv t <| (Set.uIcc_of_le (α := ℝ) zero_le_one).symm ▸ ht).scomp t ?_
-    have : HasDerivAt (fun t : ℝ ↦ t • z₁) z₁ t := by
-      convert (hasDerivAt_id t).smul_const (F := 𝕜) _ using 1
-      simp only [one_smul]
-    exact this.const_add z₀
+  have hderiv' (t) (ht : t ∈ Set.uIcc (0 : ℝ) 1) : HasDerivAt (f ∘ γ) (z₁ • (f' ∘ γ) t) t := by
+    refine (hderiv t <| (Set.uIcc_of_le (α := ℝ) zero_le_one).symm ▸ ht).scomp t <| .const_add _ ?_
+    simp [hasDerivAt_iff_isLittleO, sub_smul]
   convert (integral_eq_sub_of_hasDerivAt hderiv' hint) using 1
   · simp_rw [← integral_smul, Function.comp_apply, γ]
   · simp only [γ, Function.comp_apply, one_smul, zero_smul, add_zero]
@@ -1198,7 +1190,6 @@ lemma integral_unitInterval_deriv_eq_sub [RCLike 𝕜] [NormedSpace 𝕜 E] [IsS
 /-!
 ### Automatic integrability for nonnegative derivatives
 -/
-
 
 /-- When the right derivative of a function is nonnegative, then it is automatically integrable. -/
 theorem integrableOn_deriv_right_of_nonneg (hcont : ContinuousOn g (Icc a b))
@@ -1254,306 +1245,6 @@ theorem intervalIntegrable_deriv_of_nonneg (hcont : ContinuousOn g (uIcc a b))
       integrableOn_empty, true_and] at hcont hderiv hpos ⊢
     exact integrableOn_deriv_of_nonneg hcont hderiv hpos
 
-/-!
-### Integration by parts
--/
-
-
-section Parts
-
-variable [NormedRing A] [NormedAlgebra ℝ A] [CompleteSpace A]
-
-/-- The integral of the derivative of a product of two maps.
-For improper integrals, see `MeasureTheory.integral_deriv_mul_eq_sub`,
-`MeasureTheory.integral_Ioi_deriv_mul_eq_sub`, and `MeasureTheory.integral_Iic_deriv_mul_eq_sub`. -/
-theorem integral_deriv_mul_eq_sub_of_hasDeriv_right {u v u' v' : ℝ → A}
-    (hu : ContinuousOn u [[a, b]])
-    (hv : ContinuousOn v [[a, b]])
-    (huu' : ∀ x ∈ Ioo (min a b) (max a b), HasDerivWithinAt u (u' x) (Ioi x) x)
-    (hvv' : ∀ x ∈ Ioo (min a b) (max a b), HasDerivWithinAt v (v' x) (Ioi x) x)
-    (hu' : IntervalIntegrable u' volume a b)
-    (hv' : IntervalIntegrable v' volume a b) :
-    ∫ x in a..b, u' x * v x + u x * v' x = u b * v b - u a * v a := by
-  apply integral_eq_sub_of_hasDeriv_right (hu.mul hv) fun x hx ↦ (huu' x hx).mul (hvv' x hx)
-  exact (hu'.mul_continuousOn hv).add (hv'.continuousOn_mul hu)
-
-/-- The integral of the derivative of a product of two maps.
-Special case of `integral_deriv_mul_eq_sub_of_hasDeriv_right` where the functions have a
-two-sided derivative in the interior of the interval. -/
-theorem integral_deriv_mul_eq_sub_of_hasDerivAt {u v u' v' : ℝ → A}
-    (hu : ContinuousOn u [[a, b]])
-    (hv : ContinuousOn v [[a, b]])
-    (huu' : ∀ x ∈ Ioo (min a b) (max a b), HasDerivAt u (u' x) x)
-    (hvv' : ∀ x ∈ Ioo (min a b) (max a b), HasDerivAt v (v' x) x)
-    (hu' : IntervalIntegrable u' volume a b)
-    (hv' : IntervalIntegrable v' volume a b) :
-    ∫ x in a..b, u' x * v x + u x * v' x = u b * v b - u a * v a :=
-  integral_deriv_mul_eq_sub_of_hasDeriv_right hu hv
-    (fun x hx ↦ huu' x hx |>.hasDerivWithinAt) (fun x hx ↦ hvv' x hx |>.hasDerivWithinAt) hu' hv'
-
-/-- The integral of the derivative of a product of two maps.
-Special case of `integral_deriv_mul_eq_sub_of_hasDeriv_right` where the functions have a
-  one-sided derivative at the endpoints. -/
-theorem integral_deriv_mul_eq_sub_of_hasDerivWithinAt {u v u' v' : ℝ → A}
-    (hu : ∀ x ∈ [[a, b]], HasDerivWithinAt u (u' x) [[a, b]] x)
-    (hv : ∀ x ∈ [[a, b]], HasDerivWithinAt v (v' x) [[a, b]] x)
-    (hu' : IntervalIntegrable u' volume a b)
-    (hv' : IntervalIntegrable v' volume a b) :
-    ∫ x in a..b, u' x * v x + u x * v' x = u b * v b - u a * v a :=
-  integral_deriv_mul_eq_sub_of_hasDerivAt
-    (fun x hx ↦ (hu x hx).continuousWithinAt)
-    (fun x hx ↦ (hv x hx).continuousWithinAt)
-    (fun x hx ↦ hu x (mem_Icc_of_Ioo hx) |>.hasDerivAt (Icc_mem_nhds hx.1 hx.2))
-    (fun x hx ↦ hv x (mem_Icc_of_Ioo hx) |>.hasDerivAt (Icc_mem_nhds hx.1 hx.2))
-    hu' hv'
-
-/-- Special case of `integral_deriv_mul_eq_sub_of_hasDeriv_right` where the functions have a
-  derivative at the endpoints. -/
-theorem integral_deriv_mul_eq_sub {u v u' v' : ℝ → A}
-    (hu : ∀ x ∈ [[a, b]], HasDerivAt u (u' x) x)
-    (hv : ∀ x ∈ [[a, b]], HasDerivAt v (v' x) x)
-    (hu' : IntervalIntegrable u' volume a b)
-    (hv' : IntervalIntegrable v' volume a b) :
-    ∫ x in a..b, u' x * v x + u x * v' x = u b * v b - u a * v a :=
-  integral_deriv_mul_eq_sub_of_hasDerivWithinAt
-    (fun x hx ↦ hu x hx |>.hasDerivWithinAt) (fun x hx ↦ hv x hx |>.hasDerivWithinAt) hu' hv'
-
-/-- **Integration by parts**. For improper integrals, see
-`MeasureTheory.integral_mul_deriv_eq_deriv_mul`,
-`MeasureTheory.integral_Ioi_mul_deriv_eq_deriv_mul`,
-and `MeasureTheory.integral_Iic_mul_deriv_eq_deriv_mul`. -/
-theorem integral_mul_deriv_eq_deriv_mul_of_hasDeriv_right {u v u' v' : ℝ → A}
-    (hu : ContinuousOn u [[a, b]])
-    (hv : ContinuousOn v [[a, b]])
-    (huu' : ∀ x ∈ Ioo (min a b) (max a b), HasDerivWithinAt u (u' x) (Ioi x) x)
-    (hvv' : ∀ x ∈ Ioo (min a b) (max a b), HasDerivWithinAt v (v' x) (Ioi x) x)
-    (hu' : IntervalIntegrable u' volume a b)
-    (hv' : IntervalIntegrable v' volume a b) :
-    ∫ x in a..b, u x * v' x = u b * v b - u a * v a - ∫ x in a..b, u' x * v x := by
-  rw [← integral_deriv_mul_eq_sub_of_hasDeriv_right hu hv huu' hvv' hu' hv', ← integral_sub]
-  · simp_rw [add_sub_cancel_left]
-  · exact (hu'.mul_continuousOn hv).add (hv'.continuousOn_mul hu)
-  · exact hu'.mul_continuousOn hv
-
-/-- **Integration by parts**. Special case of `integral_mul_deriv_eq_deriv_mul_of_hasDeriv_right`
-where the functions have a two-sided derivative in the interior of the interval. -/
-theorem integral_mul_deriv_eq_deriv_mul_of_hasDerivAt {u v u' v' : ℝ → A}
-    (hu : ContinuousOn u [[a, b]])
-    (hv : ContinuousOn v [[a, b]])
-    (huu' : ∀ x ∈ Ioo (min a b) (max a b), HasDerivAt u (u' x) x)
-    (hvv' : ∀ x ∈ Ioo (min a b) (max a b), HasDerivAt v (v' x) x)
-    (hu' : IntervalIntegrable u' volume a b)
-    (hv' : IntervalIntegrable v' volume a b) :
-    ∫ x in a..b, u x * v' x = u b * v b - u a * v a - ∫ x in a..b, u' x * v x :=
-  integral_mul_deriv_eq_deriv_mul_of_hasDeriv_right hu hv
-        (fun x hx ↦ (huu' x hx).hasDerivWithinAt) (fun x hx ↦ (hvv' x hx).hasDerivWithinAt) hu' hv'
-
-/-- **Integration by parts**. Special case of
-`intervalIntegrable.integral_mul_deriv_eq_deriv_mul_of_hasDeriv_right`
-where the functions have a one-sided derivative at the endpoints. -/
-theorem integral_mul_deriv_eq_deriv_mul_of_hasDerivWithinAt {u v u' v' : ℝ → A}
-    (hu : ∀ x ∈ [[a, b]], HasDerivWithinAt u (u' x) [[a, b]] x)
-    (hv : ∀ x ∈ [[a, b]], HasDerivWithinAt v (v' x) [[a, b]] x)
-    (hu' : IntervalIntegrable u' volume a b)
-    (hv' : IntervalIntegrable v' volume a b) :
-    ∫ x in a..b, u x * v' x = u b * v b - u a * v a - ∫ x in a..b, u' x * v x :=
-  integral_mul_deriv_eq_deriv_mul_of_hasDerivAt
-    (fun x hx ↦ (hu x hx).continuousWithinAt)
-    (fun x hx ↦ (hv x hx).continuousWithinAt)
-    (fun x hx ↦ hu x (mem_Icc_of_Ioo hx) |>.hasDerivAt (Icc_mem_nhds hx.1 hx.2))
-    (fun x hx ↦ hv x (mem_Icc_of_Ioo hx) |>.hasDerivAt (Icc_mem_nhds hx.1 hx.2))
-    hu' hv'
-
-/-- **Integration by parts**. Special case of
-`intervalIntegrable.integral_mul_deriv_eq_deriv_mul_of_hasDeriv_right`
-where the functions have a derivative also at the endpoints.
-For improper integrals, see
-`MeasureTheory.integral_mul_deriv_eq_deriv_mul`,
-`MeasureTheory.integral_Ioi_mul_deriv_eq_deriv_mul`,
-and `MeasureTheory.integral_Iic_mul_deriv_eq_deriv_mul`. -/
-theorem integral_mul_deriv_eq_deriv_mul {u v u' v' : ℝ → A}
-    (hu : ∀ x ∈ [[a, b]], HasDerivAt u (u' x) x)
-    (hv : ∀ x ∈ [[a, b]], HasDerivAt v (v' x) x)
-    (hu' : IntervalIntegrable u' volume a b)
-    (hv' : IntervalIntegrable v' volume a b) :
-    ∫ x in a..b, u x * v' x = u b * v b - u a * v a - ∫ x in a..b, u' x * v x :=
-  integral_mul_deriv_eq_deriv_mul_of_hasDerivWithinAt
-    (fun x hx ↦ (hu x hx).hasDerivWithinAt) (fun x hx ↦ (hv x hx).hasDerivWithinAt) hu' hv'
-
-end Parts
-
-/-!
-### Integration by substitution / Change of variables
--/
-
-section SMul
-
-variable {G : Type*} [NormedAddCommGroup G] [NormedSpace ℝ G]
-
-/-- Change of variables, general form. If `f` is continuous on `[a, b]` and has
-right-derivative `f'` in `(a, b)`, `g` is continuous on `f '' (a, b)` and integrable on
-`f '' [a, b]`, and `f' x • (g ∘ f) x` is integrable on `[a, b]`,
-then we can substitute `u = f x` to get `∫ x in a..b, f' x • (g ∘ f) x = ∫ u in f a..f b, g u`.
--/
-theorem integral_comp_smul_deriv''' {f f' : ℝ → ℝ} {g : ℝ → G} (hf : ContinuousOn f [[a, b]])
-    (hff' : ∀ x ∈ Ioo (min a b) (max a b), HasDerivWithinAt f (f' x) (Ioi x) x)
-    (hg_cont : ContinuousOn g (f '' Ioo (min a b) (max a b))) (hg1 : IntegrableOn g (f '' [[a, b]]))
-    (hg2 : IntegrableOn (fun x => f' x • (g ∘ f) x) [[a, b]]) :
-    (∫ x in a..b, f' x • (g ∘ f) x) = ∫ u in f a..f b, g u := by
-  by_cases hG : CompleteSpace G; swap
-  · simp [intervalIntegral, integral, hG]
-  rw [hf.image_uIcc, ← intervalIntegrable_iff'] at hg1
-  have h_cont : ContinuousOn (fun u => ∫ t in f a..f u, g t) [[a, b]] := by
-    refine (continuousOn_primitive_interval' hg1 ?_).comp hf ?_
-    · rw [← hf.image_uIcc]; exact mem_image_of_mem f left_mem_uIcc
-    · rw [← hf.image_uIcc]; exact mapsTo_image _ _
-  have h_der :
-    ∀ x ∈ Ioo (min a b) (max a b),
-      HasDerivWithinAt (fun u => ∫ t in f a..f u, g t) (f' x • (g ∘ f) x) (Ioi x) x := by
-    intro x hx
-    obtain ⟨c, hc⟩ := nonempty_Ioo.mpr hx.1
-    obtain ⟨d, hd⟩ := nonempty_Ioo.mpr hx.2
-    have cdsub : [[c, d]] ⊆ Ioo (min a b) (max a b) := by
-      rw [uIcc_of_le (hc.2.trans hd.1).le]
-      exact Icc_subset_Ioo hc.1 hd.2
-    replace hg_cont := hg_cont.mono (image_subset f cdsub)
-    let J := [[sInf (f '' [[c, d]]), sSup (f '' [[c, d]])]]
-    have hJ : f '' [[c, d]] = J := (hf.mono (cdsub.trans Ioo_subset_Icc_self)).image_uIcc
-    rw [hJ] at hg_cont
-    have h2x : f x ∈ J := by rw [← hJ]; exact mem_image_of_mem _ (mem_uIcc_of_le hc.2.le hd.1.le)
-    have h2g : IntervalIntegrable g volume (f a) (f x) := by
-      refine hg1.mono_set ?_
-      rw [← hf.image_uIcc]
-      exact hf.surjOn_uIcc left_mem_uIcc (Ioo_subset_Icc_self hx)
-    have h3g : StronglyMeasurableAtFilter g (𝓝[J] f x) :=
-      hg_cont.stronglyMeasurableAtFilter_nhdsWithin measurableSet_Icc (f x)
-    haveI : Fact (f x ∈ J) := ⟨h2x⟩
-    have : HasDerivWithinAt (fun u => ∫ x in f a..u, g x) (g (f x)) J (f x) :=
-      intervalIntegral.integral_hasDerivWithinAt_right h2g h3g (hg_cont (f x) h2x)
-    refine (this.scomp x ((hff' x hx).Ioo_of_Ioi hd.1) ?_).Ioi_of_Ioo hd.1
-    rw [← hJ]
-    refine (mapsTo_image _ _).mono ?_ Subset.rfl
-    exact Ioo_subset_Icc_self.trans ((Icc_subset_Icc_left hc.2.le).trans Icc_subset_uIcc)
-  rw [← intervalIntegrable_iff'] at hg2
-  simp_rw [integral_eq_sub_of_hasDeriv_right h_cont h_der hg2, integral_same, sub_zero]
-
-/-- Change of variables for continuous integrands. If `f` is continuous on `[a, b]` and has
-continuous right-derivative `f'` in `(a, b)`, and `g` is continuous on `f '' [a, b]` then we can
-substitute `u = f x` to get `∫ x in a..b, f' x • (g ∘ f) x = ∫ u in f a..f b, g u`.
--/
-theorem integral_comp_smul_deriv'' {f f' : ℝ → ℝ} {g : ℝ → G} (hf : ContinuousOn f [[a, b]])
-    (hff' : ∀ x ∈ Ioo (min a b) (max a b), HasDerivWithinAt f (f' x) (Ioi x) x)
-    (hf' : ContinuousOn f' [[a, b]]) (hg : ContinuousOn g (f '' [[a, b]])) :
-    (∫ x in a..b, f' x • (g ∘ f) x) = ∫ u in f a..f b, g u := by
-  refine
-    integral_comp_smul_deriv''' hf hff' (hg.mono <| image_subset _ Ioo_subset_Icc_self) ?_
-      (hf'.smul (hg.comp hf <| subset_preimage_image f _)).integrableOn_Icc
-  rw [hf.image_uIcc] at hg ⊢
-  exact hg.integrableOn_Icc
-
-/-- Change of variables. If `f` has continuous derivative `f'` on `[a, b]`,
-and `g` is continuous on `f '' [a, b]`, then we can substitute `u = f x` to get
-`∫ x in a..b, f' x • (g ∘ f) x = ∫ u in f a..f b, g u`.
-Compared to `intervalIntegral.integral_comp_smul_deriv` we only require that `g` is continuous on
-`f '' [a, b]`.
--/
-theorem integral_comp_smul_deriv' {f f' : ℝ → ℝ} {g : ℝ → G}
-    (h : ∀ x ∈ uIcc a b, HasDerivAt f (f' x) x) (h' : ContinuousOn f' (uIcc a b))
-    (hg : ContinuousOn g (f '' [[a, b]])) :
-    (∫ x in a..b, f' x • (g ∘ f) x) = ∫ x in f a..f b, g x :=
-  integral_comp_smul_deriv'' (fun x hx => (h x hx).continuousAt.continuousWithinAt)
-    (fun x hx => (h x <| Ioo_subset_Icc_self hx).hasDerivWithinAt) h' hg
-
-/-- Change of variables, most common version. If `f` has continuous derivative `f'` on `[a, b]`,
-and `g` is continuous, then we can substitute `u = f x` to get
-`∫ x in a..b, f' x • (g ∘ f) x = ∫ u in f a..f b, g u`.
--/
-theorem integral_comp_smul_deriv {f f' : ℝ → ℝ} {g : ℝ → G}
-    (h : ∀ x ∈ uIcc a b, HasDerivAt f (f' x) x) (h' : ContinuousOn f' (uIcc a b))
-    (hg : Continuous g) : (∫ x in a..b, f' x • (g ∘ f) x) = ∫ x in f a..f b, g x :=
-  integral_comp_smul_deriv' h h' hg.continuousOn
-
-theorem integral_deriv_comp_smul_deriv' {f f' : ℝ → ℝ} {g g' : ℝ → E} (hf : ContinuousOn f [[a, b]])
-    (hff' : ∀ x ∈ Ioo (min a b) (max a b), HasDerivWithinAt f (f' x) (Ioi x) x)
-    (hf' : ContinuousOn f' [[a, b]]) (hg : ContinuousOn g [[f a, f b]])
-    (hgg' : ∀ x ∈ Ioo (min (f a) (f b)) (max (f a) (f b)), HasDerivWithinAt g (g' x) (Ioi x) x)
-    (hg' : ContinuousOn g' (f '' [[a, b]])) :
-    (∫ x in a..b, f' x • (g' ∘ f) x) = (g ∘ f) b - (g ∘ f) a := by
-  rw [integral_comp_smul_deriv'' hf hff' hf' hg',
-    integral_eq_sub_of_hasDeriv_right hg hgg' (hg'.mono _).intervalIntegrable]
-  exacts [rfl, intermediate_value_uIcc hf]
-
-theorem integral_deriv_comp_smul_deriv {f f' : ℝ → ℝ} {g g' : ℝ → E}
-    (hf : ∀ x ∈ uIcc a b, HasDerivAt f (f' x) x)
-    (hg : ∀ x ∈ uIcc a b, HasDerivAt g (g' (f x)) (f x)) (hf' : ContinuousOn f' (uIcc a b))
-    (hg' : Continuous g') : (∫ x in a..b, f' x • (g' ∘ f) x) = (g ∘ f) b - (g ∘ f) a :=
-  integral_eq_sub_of_hasDerivAt (fun x hx => (hg x hx).scomp x <| hf x hx)
-    (hf'.smul (hg'.comp_continuousOn <| HasDerivAt.continuousOn hf)).intervalIntegrable
-
-end SMul
-
-section Mul
-
-/-- Change of variables, general form for scalar functions. If `f` is continuous on `[a, b]` and has
-continuous right-derivative `f'` in `(a, b)`, `g` is continuous on `f '' (a, b)` and integrable on
-`f '' [a, b]`, and `(g ∘ f) x * f' x` is integrable on `[a, b]`, then we can substitute `u = f x`
-to get `∫ x in a..b, (g ∘ f) x * f' x = ∫ u in f a..f b, g u`.
--/
-theorem integral_comp_mul_deriv''' {a b : ℝ} {f f' : ℝ → ℝ} {g : ℝ → ℝ}
-    (hf : ContinuousOn f [[a, b]])
-    (hff' : ∀ x ∈ Ioo (min a b) (max a b), HasDerivWithinAt f (f' x) (Ioi x) x)
-    (hg_cont : ContinuousOn g (f '' Ioo (min a b) (max a b))) (hg1 : IntegrableOn g (f '' [[a, b]]))
-    (hg2 : IntegrableOn (fun x => (g ∘ f) x * f' x) [[a, b]]) :
-    (∫ x in a..b, (g ∘ f) x * f' x) = ∫ u in f a..f b, g u := by
-  have hg2' : IntegrableOn (fun x => f' x • (g ∘ f) x) [[a, b]] := by simpa [mul_comm] using hg2
-  simpa [mul_comm] using integral_comp_smul_deriv''' hf hff' hg_cont hg1 hg2'
-
-/-- Change of variables for continuous integrands. If `f` is continuous on `[a, b]` and has
-continuous right-derivative `f'` in `(a, b)`, and `g` is continuous on `f '' [a, b]` then we can
-substitute `u = f x` to get `∫ x in a..b, (g ∘ f) x * f' x = ∫ u in f a..f b, g u`.
--/
-theorem integral_comp_mul_deriv'' {f f' g : ℝ → ℝ} (hf : ContinuousOn f [[a, b]])
-    (hff' : ∀ x ∈ Ioo (min a b) (max a b), HasDerivWithinAt f (f' x) (Ioi x) x)
-    (hf' : ContinuousOn f' [[a, b]]) (hg : ContinuousOn g (f '' [[a, b]])) :
-    (∫ x in a..b, (g ∘ f) x * f' x) = ∫ u in f a..f b, g u := by
-  simpa [mul_comm] using integral_comp_smul_deriv'' hf hff' hf' hg
-
-/-- Change of variables. If `f` has continuous derivative `f'` on `[a, b]`,
-and `g` is continuous on `f '' [a, b]`, then we can substitute `u = f x` to get
-`∫ x in a..b, (g ∘ f) x * f' x = ∫ u in f a..f b, g u`.
-Compared to `intervalIntegral.integral_comp_mul_deriv` we only require that `g` is continuous on
-`f '' [a, b]`.
--/
-theorem integral_comp_mul_deriv' {f f' g : ℝ → ℝ} (h : ∀ x ∈ uIcc a b, HasDerivAt f (f' x) x)
-    (h' : ContinuousOn f' (uIcc a b)) (hg : ContinuousOn g (f '' [[a, b]])) :
-    (∫ x in a..b, (g ∘ f) x * f' x) = ∫ x in f a..f b, g x := by
-  simpa [mul_comm] using integral_comp_smul_deriv' h h' hg
-
-/-- Change of variables, most common version. If `f` has continuous derivative `f'` on `[a, b]`,
-and `g` is continuous, then we can substitute `u = f x` to get
-`∫ x in a..b, (g ∘ f) x * f' x = ∫ u in f a..f b, g u`.
--/
-theorem integral_comp_mul_deriv {f f' g : ℝ → ℝ} (h : ∀ x ∈ uIcc a b, HasDerivAt f (f' x) x)
-    (h' : ContinuousOn f' (uIcc a b)) (hg : Continuous g) :
-    (∫ x in a..b, (g ∘ f) x * f' x) = ∫ x in f a..f b, g x :=
-  integral_comp_mul_deriv' h h' hg.continuousOn
-
-theorem integral_deriv_comp_mul_deriv' {f f' g g' : ℝ → ℝ} (hf : ContinuousOn f [[a, b]])
-    (hff' : ∀ x ∈ Ioo (min a b) (max a b), HasDerivWithinAt f (f' x) (Ioi x) x)
-    (hf' : ContinuousOn f' [[a, b]]) (hg : ContinuousOn g [[f a, f b]])
-    (hgg' : ∀ x ∈ Ioo (min (f a) (f b)) (max (f a) (f b)), HasDerivWithinAt g (g' x) (Ioi x) x)
-    (hg' : ContinuousOn g' (f '' [[a, b]])) :
-    (∫ x in a..b, (g' ∘ f) x * f' x) = (g ∘ f) b - (g ∘ f) a := by
-  simpa [mul_comm] using integral_deriv_comp_smul_deriv' hf hff' hf' hg hgg' hg'
-
-theorem integral_deriv_comp_mul_deriv {f f' g g' : ℝ → ℝ}
-    (hf : ∀ x ∈ uIcc a b, HasDerivAt f (f' x) x)
-    (hg : ∀ x ∈ uIcc a b, HasDerivAt g (g' (f x)) (f x)) (hf' : ContinuousOn f' (uIcc a b))
-    (hg' : Continuous g') : (∫ x in a..b, (g' ∘ f) x * f' x) = (g ∘ f) b - (g ∘ f) a := by
-  simpa [mul_comm] using integral_deriv_comp_smul_deriv hf hg hf' hg'
-
-end Mul
+end FTC2
 
 end intervalIntegral
-
-set_option linter.style.longFile 1700

--- a/Mathlib/MeasureTheory/Integral/IntegralEqImproper.lean
+++ b/Mathlib/MeasureTheory/Integral/IntegralEqImproper.lean
@@ -5,8 +5,8 @@ Authors: Anatole Dedecker, Bhavik Mehta
 -/
 import Mathlib.Analysis.Calculus.Deriv.Support
 import Mathlib.Analysis.SpecialFunctions.Pow.Deriv
-import Mathlib.MeasureTheory.Integral.FundThmCalculus
 import Mathlib.MeasureTheory.Function.Jacobian
+import Mathlib.MeasureTheory.Integral.IntegrationByParts
 import Mathlib.MeasureTheory.Measure.Haar.NormedSpace
 import Mathlib.MeasureTheory.Measure.Haar.Unique
 

--- a/Mathlib/MeasureTheory/Integral/IntegrationByParts.lean
+++ b/Mathlib/MeasureTheory/Integral/IntegrationByParts.lean
@@ -1,0 +1,316 @@
+/-
+Copyright (c) 2020 Yury Kudryashov. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yury Kudryashov, Patrick Massot, Sébastien Gouëzel
+-/
+import Mathlib.Analysis.Calculus.Deriv.Mul
+import Mathlib.Analysis.Calculus.Deriv.Slope
+import Mathlib.MeasureTheory.Integral.FundThmCalculus
+
+/-!
+# Integration by parts and by substitution
+
+We derive additional integration techniques from FTC-2:
+* `intervalIntegral.integral_mul_deriv_eq_deriv_mul` - integration by parts
+* `intervalIntegral.integral_comp_mul_deriv''` - integration by substitution
+
+## Tags
+
+integration by parts, change of variables in integrals
+-/
+
+open MeasureTheory Set
+
+open scoped Topology Interval
+
+namespace intervalIntegral
+
+variable {a b : ℝ}
+
+section Parts
+
+variable {A : Type*} [NormedRing A] [NormedAlgebra ℝ A] [CompleteSpace A] {u v u' v' : ℝ → A}
+
+/-- The integral of the derivative of a product of two maps.
+For improper integrals, see `MeasureTheory.integral_deriv_mul_eq_sub`,
+`MeasureTheory.integral_Ioi_deriv_mul_eq_sub`, and `MeasureTheory.integral_Iic_deriv_mul_eq_sub`. -/
+theorem integral_deriv_mul_eq_sub_of_hasDeriv_right (hu : ContinuousOn u [[a, b]])
+    (hv : ContinuousOn v [[a, b]])
+    (huu' : ∀ x ∈ Ioo (min a b) (max a b), HasDerivWithinAt u (u' x) (Ioi x) x)
+    (hvv' : ∀ x ∈ Ioo (min a b) (max a b), HasDerivWithinAt v (v' x) (Ioi x) x)
+    (hu' : IntervalIntegrable u' volume a b)
+    (hv' : IntervalIntegrable v' volume a b) :
+    ∫ x in a..b, u' x * v x + u x * v' x = u b * v b - u a * v a := by
+  apply integral_eq_sub_of_hasDeriv_right (hu.mul hv) fun x hx ↦ (huu' x hx).mul (hvv' x hx)
+  exact (hu'.mul_continuousOn hv).add (hv'.continuousOn_mul hu)
+
+/-- The integral of the derivative of a product of two maps.
+Special case of `integral_deriv_mul_eq_sub_of_hasDeriv_right` where the functions have a
+two-sided derivative in the interior of the interval. -/
+theorem integral_deriv_mul_eq_sub_of_hasDerivAt (hu : ContinuousOn u [[a, b]])
+    (hv : ContinuousOn v [[a, b]]) (huu' : ∀ x ∈ Ioo (min a b) (max a b), HasDerivAt u (u' x) x)
+    (hvv' : ∀ x ∈ Ioo (min a b) (max a b), HasDerivAt v (v' x) x)
+    (hu' : IntervalIntegrable u' volume a b)
+    (hv' : IntervalIntegrable v' volume a b) :
+    ∫ x in a..b, u' x * v x + u x * v' x = u b * v b - u a * v a :=
+  integral_deriv_mul_eq_sub_of_hasDeriv_right hu hv
+    (fun x hx ↦ huu' x hx |>.hasDerivWithinAt) (fun x hx ↦ hvv' x hx |>.hasDerivWithinAt) hu' hv'
+
+/-- The integral of the derivative of a product of two maps.
+Special case of `integral_deriv_mul_eq_sub_of_hasDeriv_right` where the functions have a
+  one-sided derivative at the endpoints. -/
+theorem integral_deriv_mul_eq_sub_of_hasDerivWithinAt
+    (hu : ∀ x ∈ [[a, b]], HasDerivWithinAt u (u' x) [[a, b]] x)
+    (hv : ∀ x ∈ [[a, b]], HasDerivWithinAt v (v' x) [[a, b]] x)
+    (hu' : IntervalIntegrable u' volume a b)
+    (hv' : IntervalIntegrable v' volume a b) :
+    ∫ x in a..b, u' x * v x + u x * v' x = u b * v b - u a * v a :=
+  integral_deriv_mul_eq_sub_of_hasDerivAt
+    (fun x hx ↦ (hu x hx).continuousWithinAt)
+    (fun x hx ↦ (hv x hx).continuousWithinAt)
+    (fun x hx ↦ hu x (mem_Icc_of_Ioo hx) |>.hasDerivAt (Icc_mem_nhds hx.1 hx.2))
+    (fun x hx ↦ hv x (mem_Icc_of_Ioo hx) |>.hasDerivAt (Icc_mem_nhds hx.1 hx.2))
+    hu' hv'
+
+/-- Special case of `integral_deriv_mul_eq_sub_of_hasDeriv_right` where the functions have a
+  derivative at the endpoints. -/
+theorem integral_deriv_mul_eq_sub
+    (hu : ∀ x ∈ [[a, b]], HasDerivAt u (u' x) x) (hv : ∀ x ∈ [[a, b]], HasDerivAt v (v' x) x)
+    (hu' : IntervalIntegrable u' volume a b) (hv' : IntervalIntegrable v' volume a b) :
+    ∫ x in a..b, u' x * v x + u x * v' x = u b * v b - u a * v a :=
+  integral_deriv_mul_eq_sub_of_hasDerivWithinAt
+    (fun x hx ↦ hu x hx |>.hasDerivWithinAt) (fun x hx ↦ hv x hx |>.hasDerivWithinAt) hu' hv'
+
+/-- **Integration by parts**. For improper integrals, see
+`MeasureTheory.integral_mul_deriv_eq_deriv_mul`,
+`MeasureTheory.integral_Ioi_mul_deriv_eq_deriv_mul`,
+and `MeasureTheory.integral_Iic_mul_deriv_eq_deriv_mul`. -/
+theorem integral_mul_deriv_eq_deriv_mul_of_hasDeriv_right
+    (hu : ContinuousOn u [[a, b]]) (hv : ContinuousOn v [[a, b]])
+    (huu' : ∀ x ∈ Ioo (min a b) (max a b), HasDerivWithinAt u (u' x) (Ioi x) x)
+    (hvv' : ∀ x ∈ Ioo (min a b) (max a b), HasDerivWithinAt v (v' x) (Ioi x) x)
+    (hu' : IntervalIntegrable u' volume a b) (hv' : IntervalIntegrable v' volume a b) :
+    ∫ x in a..b, u x * v' x = u b * v b - u a * v a - ∫ x in a..b, u' x * v x := by
+  rw [← integral_deriv_mul_eq_sub_of_hasDeriv_right hu hv huu' hvv' hu' hv', ← integral_sub]
+  · simp_rw [add_sub_cancel_left]
+  · exact (hu'.mul_continuousOn hv).add (hv'.continuousOn_mul hu)
+  · exact hu'.mul_continuousOn hv
+
+/-- **Integration by parts**. Special case of `integral_mul_deriv_eq_deriv_mul_of_hasDeriv_right`
+where the functions have a two-sided derivative in the interior of the interval. -/
+theorem integral_mul_deriv_eq_deriv_mul_of_hasDerivAt
+    (hu : ContinuousOn u [[a, b]]) (hv : ContinuousOn v [[a, b]])
+    (huu' : ∀ x ∈ Ioo (min a b) (max a b), HasDerivAt u (u' x) x)
+    (hvv' : ∀ x ∈ Ioo (min a b) (max a b), HasDerivAt v (v' x) x)
+    (hu' : IntervalIntegrable u' volume a b) (hv' : IntervalIntegrable v' volume a b) :
+    ∫ x in a..b, u x * v' x = u b * v b - u a * v a - ∫ x in a..b, u' x * v x :=
+  integral_mul_deriv_eq_deriv_mul_of_hasDeriv_right hu hv
+        (fun x hx ↦ (huu' x hx).hasDerivWithinAt) (fun x hx ↦ (hvv' x hx).hasDerivWithinAt) hu' hv'
+
+/-- **Integration by parts**. Special case of
+`intervalIntegrable.integral_mul_deriv_eq_deriv_mul_of_hasDeriv_right`
+where the functions have a one-sided derivative at the endpoints. -/
+theorem integral_mul_deriv_eq_deriv_mul_of_hasDerivWithinAt
+    (hu : ∀ x ∈ [[a, b]], HasDerivWithinAt u (u' x) [[a, b]] x)
+    (hv : ∀ x ∈ [[a, b]], HasDerivWithinAt v (v' x) [[a, b]] x)
+    (hu' : IntervalIntegrable u' volume a b) (hv' : IntervalIntegrable v' volume a b) :
+    ∫ x in a..b, u x * v' x = u b * v b - u a * v a - ∫ x in a..b, u' x * v x :=
+  integral_mul_deriv_eq_deriv_mul_of_hasDerivAt
+    (fun x hx ↦ (hu x hx).continuousWithinAt)
+    (fun x hx ↦ (hv x hx).continuousWithinAt)
+    (fun x hx ↦ hu x (mem_Icc_of_Ioo hx) |>.hasDerivAt (Icc_mem_nhds hx.1 hx.2))
+    (fun x hx ↦ hv x (mem_Icc_of_Ioo hx) |>.hasDerivAt (Icc_mem_nhds hx.1 hx.2))
+    hu' hv'
+
+/-- **Integration by parts**. Special case of
+`intervalIntegrable.integral_mul_deriv_eq_deriv_mul_of_hasDeriv_right`
+where the functions have a derivative also at the endpoints.
+For improper integrals, see
+`MeasureTheory.integral_mul_deriv_eq_deriv_mul`,
+`MeasureTheory.integral_Ioi_mul_deriv_eq_deriv_mul`,
+and `MeasureTheory.integral_Iic_mul_deriv_eq_deriv_mul`. -/
+theorem integral_mul_deriv_eq_deriv_mul
+    (hu : ∀ x ∈ [[a, b]], HasDerivAt u (u' x) x) (hv : ∀ x ∈ [[a, b]], HasDerivAt v (v' x) x)
+    (hu' : IntervalIntegrable u' volume a b) (hv' : IntervalIntegrable v' volume a b) :
+    ∫ x in a..b, u x * v' x = u b * v b - u a * v a - ∫ x in a..b, u' x * v x :=
+  integral_mul_deriv_eq_deriv_mul_of_hasDerivWithinAt
+    (fun x hx ↦ (hu x hx).hasDerivWithinAt) (fun x hx ↦ (hv x hx).hasDerivWithinAt) hu' hv'
+
+end Parts
+
+/-!
+### Integration by substitution / Change of variables
+-/
+
+section SMul
+
+variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] {f f' : ℝ → ℝ} {g g' : ℝ → E}
+
+/-- Change of variables, general form. If `f` is continuous on `[a, b]` and has
+right-derivative `f'` in `(a, b)`, `g` is continuous on `f '' (a, b)` and integrable on
+`f '' [a, b]`, and `f' x • (g ∘ f) x` is integrable on `[a, b]`,
+then we can substitute `u = f x` to get `∫ x in a..b, f' x • (g ∘ f) x = ∫ u in f a..f b, g u`.
+-/
+theorem integral_comp_smul_deriv''' (hf : ContinuousOn f [[a, b]])
+    (hff' : ∀ x ∈ Ioo (min a b) (max a b), HasDerivWithinAt f (f' x) (Ioi x) x)
+    (hg_cont : ContinuousOn g (f '' Ioo (min a b) (max a b))) (hg1 : IntegrableOn g (f '' [[a, b]]))
+    (hg2 : IntegrableOn (fun x ↦ f' x • (g ∘ f) x) [[a, b]]) :
+    (∫ x in a..b, f' x • (g ∘ f) x) = ∫ u in f a..f b, g u := by
+  by_cases hE : CompleteSpace E; swap
+  · simp [intervalIntegral, integral, hE]
+  rw [hf.image_uIcc, ← intervalIntegrable_iff'] at hg1
+  have h_cont : ContinuousOn (fun u ↦ ∫ t in f a..f u, g t) [[a, b]] := by
+    refine (continuousOn_primitive_interval' hg1 ?_).comp hf ?_
+    · rw [← hf.image_uIcc]; exact mem_image_of_mem f left_mem_uIcc
+    · rw [← hf.image_uIcc]; exact mapsTo_image _ _
+  have h_der :
+    ∀ x ∈ Ioo (min a b) (max a b),
+      HasDerivWithinAt (fun u ↦ ∫ t in f a..f u, g t) (f' x • (g ∘ f) x) (Ioi x) x := by
+    intro x hx
+    obtain ⟨c, hc⟩ := nonempty_Ioo.mpr hx.1
+    obtain ⟨d, hd⟩ := nonempty_Ioo.mpr hx.2
+    have cdsub : [[c, d]] ⊆ Ioo (min a b) (max a b) := by
+      rw [uIcc_of_le (hc.2.trans hd.1).le]
+      exact Icc_subset_Ioo hc.1 hd.2
+    replace hg_cont := hg_cont.mono (image_subset f cdsub)
+    let J := [[sInf (f '' [[c, d]]), sSup (f '' [[c, d]])]]
+    have hJ : f '' [[c, d]] = J := (hf.mono (cdsub.trans Ioo_subset_Icc_self)).image_uIcc
+    rw [hJ] at hg_cont
+    have h2x : f x ∈ J := by rw [← hJ]; exact mem_image_of_mem _ (mem_uIcc_of_le hc.2.le hd.1.le)
+    have h2g : IntervalIntegrable g volume (f a) (f x) := by
+      refine hg1.mono_set ?_
+      rw [← hf.image_uIcc]
+      exact hf.surjOn_uIcc left_mem_uIcc (Ioo_subset_Icc_self hx)
+    have h3g : StronglyMeasurableAtFilter g (𝓝[J] f x) :=
+      hg_cont.stronglyMeasurableAtFilter_nhdsWithin measurableSet_Icc (f x)
+    haveI : Fact (f x ∈ J) := ⟨h2x⟩
+    have : HasDerivWithinAt (fun u ↦ ∫ x in f a..u, g x) (g (f x)) J (f x) :=
+      intervalIntegral.integral_hasDerivWithinAt_right h2g h3g (hg_cont (f x) h2x)
+    refine (this.scomp x ((hff' x hx).Ioo_of_Ioi hd.1) ?_).Ioi_of_Ioo hd.1
+    rw [← hJ]
+    refine (mapsTo_image _ _).mono ?_ Subset.rfl
+    exact Ioo_subset_Icc_self.trans ((Icc_subset_Icc_left hc.2.le).trans Icc_subset_uIcc)
+  rw [← intervalIntegrable_iff'] at hg2
+  simp_rw [integral_eq_sub_of_hasDeriv_right h_cont h_der hg2, integral_same, sub_zero]
+
+/-- Change of variables for continuous integrands. If `f` is continuous on `[a, b]` and has
+continuous right-derivative `f'` in `(a, b)`, and `g` is continuous on `f '' [a, b]` then we can
+substitute `u = f x` to get `∫ x in a..b, f' x • (g ∘ f) x = ∫ u in f a..f b, g u`.
+-/
+theorem integral_comp_smul_deriv'' (hf : ContinuousOn f [[a, b]])
+    (hff' : ∀ x ∈ Ioo (min a b) (max a b), HasDerivWithinAt f (f' x) (Ioi x) x)
+    (hf' : ContinuousOn f' [[a, b]]) (hg : ContinuousOn g (f '' [[a, b]])) :
+    (∫ x in a..b, f' x • (g ∘ f) x) = ∫ u in f a..f b, g u := by
+  refine integral_comp_smul_deriv''' hf hff' (hg.mono <| image_subset _ Ioo_subset_Icc_self) ?_
+    (hf'.smul (hg.comp hf <| subset_preimage_image f _)).integrableOn_Icc
+  rw [hf.image_uIcc] at hg ⊢
+  exact hg.integrableOn_Icc
+
+/-- Change of variables. If `f` has continuous derivative `f'` on `[a, b]`,
+and `g` is continuous on `f '' [a, b]`, then we can substitute `u = f x` to get
+`∫ x in a..b, f' x • (g ∘ f) x = ∫ u in f a..f b, g u`.
+Compared to `intervalIntegral.integral_comp_smul_deriv` we only require that `g` is continuous on
+`f '' [a, b]`.
+-/
+theorem integral_comp_smul_deriv' (h : ∀ x ∈ uIcc a b, HasDerivAt f (f' x) x)
+    (h' : ContinuousOn f' (uIcc a b)) (hg : ContinuousOn g (f '' [[a, b]])) :
+    (∫ x in a..b, f' x • (g ∘ f) x) = ∫ x in f a..f b, g x :=
+  integral_comp_smul_deriv'' (fun x hx ↦ (h x hx).continuousAt.continuousWithinAt)
+    (fun x hx ↦ (h x <| Ioo_subset_Icc_self hx).hasDerivWithinAt) h' hg
+
+/-- Change of variables, most common version. If `f` has continuous derivative `f'` on `[a, b]`,
+and `g` is continuous, then we can substitute `u = f x` to get
+`∫ x in a..b, f' x • (g ∘ f) x = ∫ u in f a..f b, g u`.
+-/
+theorem integral_comp_smul_deriv (h : ∀ x ∈ uIcc a b, HasDerivAt f (f' x) x)
+    (h' : ContinuousOn f' (uIcc a b)) (hg : Continuous g) :
+    (∫ x in a..b, f' x • (g ∘ f) x) = ∫ x in f a..f b, g x :=
+  integral_comp_smul_deriv' h h' hg.continuousOn
+
+section CompleteSpace
+
+variable [CompleteSpace E]
+
+theorem integral_deriv_comp_smul_deriv' (hf : ContinuousOn f [[a, b]])
+    (hff' : ∀ x ∈ Ioo (min a b) (max a b), HasDerivWithinAt f (f' x) (Ioi x) x)
+    (hf' : ContinuousOn f' [[a, b]]) (hg : ContinuousOn g [[f a, f b]])
+    (hgg' : ∀ x ∈ Ioo (min (f a) (f b)) (max (f a) (f b)), HasDerivWithinAt g (g' x) (Ioi x) x)
+    (hg' : ContinuousOn g' (f '' [[a, b]])) :
+    (∫ x in a..b, f' x • (g' ∘ f) x) = (g ∘ f) b - (g ∘ f) a := by
+  rw [integral_comp_smul_deriv'' hf hff' hf' hg',
+    integral_eq_sub_of_hasDeriv_right hg hgg' (hg'.mono _).intervalIntegrable]
+  exacts [rfl, intermediate_value_uIcc hf]
+
+theorem integral_deriv_comp_smul_deriv (hf : ∀ x ∈ uIcc a b, HasDerivAt f (f' x) x)
+    (hg : ∀ x ∈ uIcc a b, HasDerivAt g (g' (f x)) (f x)) (hf' : ContinuousOn f' (uIcc a b))
+    (hg' : Continuous g') : (∫ x in a..b, f' x • (g' ∘ f) x) = (g ∘ f) b - (g ∘ f) a :=
+  integral_eq_sub_of_hasDerivAt (fun x hx ↦ (hg x hx).scomp x <| hf x hx)
+    (hf'.smul (hg'.comp_continuousOn <| HasDerivAt.continuousOn hf)).intervalIntegrable
+
+end CompleteSpace
+
+end SMul
+
+section Mul
+
+/-- Change of variables, general form for scalar functions. If `f` is continuous on `[a, b]` and has
+continuous right-derivative `f'` in `(a, b)`, `g` is continuous on `f '' (a, b)` and integrable on
+`f '' [a, b]`, and `(g ∘ f) x * f' x` is integrable on `[a, b]`, then we can substitute `u = f x`
+to get `∫ x in a..b, (g ∘ f) x * f' x = ∫ u in f a..f b, g u`.
+-/
+theorem integral_comp_mul_deriv''' {a b : ℝ} {f f' : ℝ → ℝ} {g : ℝ → ℝ}
+    (hf : ContinuousOn f [[a, b]])
+    (hff' : ∀ x ∈ Ioo (min a b) (max a b), HasDerivWithinAt f (f' x) (Ioi x) x)
+    (hg_cont : ContinuousOn g (f '' Ioo (min a b) (max a b))) (hg1 : IntegrableOn g (f '' [[a, b]]))
+    (hg2 : IntegrableOn (fun x ↦ (g ∘ f) x * f' x) [[a, b]]) :
+    (∫ x in a..b, (g ∘ f) x * f' x) = ∫ u in f a..f b, g u := by
+  have hg2' : IntegrableOn (fun x ↦ f' x • (g ∘ f) x) [[a, b]] := by simpa [mul_comm] using hg2
+  simpa [mul_comm] using integral_comp_smul_deriv''' hf hff' hg_cont hg1 hg2'
+
+/-- Change of variables for continuous integrands. If `f` is continuous on `[a, b]` and has
+continuous right-derivative `f'` in `(a, b)`, and `g` is continuous on `f '' [a, b]` then we can
+substitute `u = f x` to get `∫ x in a..b, (g ∘ f) x * f' x = ∫ u in f a..f b, g u`.
+-/
+theorem integral_comp_mul_deriv'' {f f' g : ℝ → ℝ} (hf : ContinuousOn f [[a, b]])
+    (hff' : ∀ x ∈ Ioo (min a b) (max a b), HasDerivWithinAt f (f' x) (Ioi x) x)
+    (hf' : ContinuousOn f' [[a, b]]) (hg : ContinuousOn g (f '' [[a, b]])) :
+    (∫ x in a..b, (g ∘ f) x * f' x) = ∫ u in f a..f b, g u := by
+  simpa [mul_comm] using integral_comp_smul_deriv'' hf hff' hf' hg
+
+/-- Change of variables. If `f` has continuous derivative `f'` on `[a, b]`,
+and `g` is continuous on `f '' [a, b]`, then we can substitute `u = f x` to get
+`∫ x in a..b, (g ∘ f) x * f' x = ∫ u in f a..f b, g u`.
+Compared to `intervalIntegral.integral_comp_mul_deriv` we only require that `g` is continuous on
+`f '' [a, b]`.
+-/
+theorem integral_comp_mul_deriv' {f f' g : ℝ → ℝ} (h : ∀ x ∈ uIcc a b, HasDerivAt f (f' x) x)
+    (h' : ContinuousOn f' (uIcc a b)) (hg : ContinuousOn g (f '' [[a, b]])) :
+    (∫ x in a..b, (g ∘ f) x * f' x) = ∫ x in f a..f b, g x := by
+  simpa [mul_comm] using integral_comp_smul_deriv' h h' hg
+
+/-- Change of variables, most common version. If `f` has continuous derivative `f'` on `[a, b]`,
+and `g` is continuous, then we can substitute `u = f x` to get
+`∫ x in a..b, (g ∘ f) x * f' x = ∫ u in f a..f b, g u`.
+-/
+theorem integral_comp_mul_deriv {f f' g : ℝ → ℝ} (h : ∀ x ∈ uIcc a b, HasDerivAt f (f' x) x)
+    (h' : ContinuousOn f' (uIcc a b)) (hg : Continuous g) :
+    (∫ x in a..b, (g ∘ f) x * f' x) = ∫ x in f a..f b, g x :=
+  integral_comp_mul_deriv' h h' hg.continuousOn
+
+theorem integral_deriv_comp_mul_deriv' {f f' g g' : ℝ → ℝ} (hf : ContinuousOn f [[a, b]])
+    (hff' : ∀ x ∈ Ioo (min a b) (max a b), HasDerivWithinAt f (f' x) (Ioi x) x)
+    (hf' : ContinuousOn f' [[a, b]]) (hg : ContinuousOn g [[f a, f b]])
+    (hgg' : ∀ x ∈ Ioo (min (f a) (f b)) (max (f a) (f b)), HasDerivWithinAt g (g' x) (Ioi x) x)
+    (hg' : ContinuousOn g' (f '' [[a, b]])) :
+    (∫ x in a..b, (g' ∘ f) x * f' x) = (g ∘ f) b - (g ∘ f) a := by
+  simpa [mul_comm] using integral_deriv_comp_smul_deriv' hf hff' hf' hg hgg' hg'
+
+theorem integral_deriv_comp_mul_deriv {f f' g g' : ℝ → ℝ}
+    (hf : ∀ x ∈ uIcc a b, HasDerivAt f (f' x) x)
+    (hg : ∀ x ∈ uIcc a b, HasDerivAt g (g' (f x)) (f x)) (hf' : ContinuousOn f' (uIcc a b))
+    (hg' : Continuous g') : (∫ x in a..b, (g' ∘ f) x * f' x) = (g ∘ f) b - (g ∘ f) a := by
+  simpa [mul_comm] using integral_deriv_comp_smul_deriv hf hg hf' hg'
+
+end Mul
+
+end intervalIntegral


### PR DESCRIPTION
Integration by parts and integration by substitution are moved to a new file. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
