### PR TITLE
[Merged by Bors] - feat(Data/Nat/Prime/{Defs, Nth}): Add basic results about small prime numbers

### DIFF
--- a/Mathlib/Data/Nat/Prime/Defs.lean
+++ b/Mathlib/Data/Nat/Prime/Defs.lean
@@ -166,6 +166,10 @@ theorem prime_three : Prime 3 := by decide
 
 theorem prime_five : Prime 5 := by decide
 
+theorem prime_seven : Prime 7 := by decide
+
+theorem prime_eleven : Prime 11 := by decide
+
 theorem dvd_prime {p m : ℕ} (pp : Prime p) : m ∣ p ↔ m = 1 ∨ m = p :=
   ⟨fun d => pp.eq_one_or_self_of_dvd m d, fun h =>
     h.elim (fun e => e.symm ▸ one_dvd _) fun e => e.symm ▸ dvd_rfl⟩

--- a/Mathlib/Data/Nat/Prime/Nth.lean
+++ b/Mathlib/Data/Nat/Prime/Nth.lean
@@ -20,4 +20,13 @@ alias zeroth_prime_eq_two := nth_prime_zero_eq_two
 @[simp]
 theorem nth_prime_one_eq_three : nth Nat.Prime 1 = 3 := nth_count prime_three
 
+@[simp]
+theorem nth_prime_two_eq_five : nth Nat.Prime 2 = 5 := nth_count prime_five
+
+@[simp]
+theorem nth_prime_three_eq_seven : nth Nat.Prime 3 = 7 := nth_count prime_seven
+
+@[simp]
+theorem nth_prime_four_eq_eleven : nth Nat.Prime 4 = 11 := nth_count prime_eleven
+
 end Nat


### PR DESCRIPTION
This PR adds the computation of `Nat.nth Nat.Prime n` for some small values of `n`. 
I think it would be nice to have a `simproc` that handles this (this is part of my TODO list)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
