### PR TITLE
[Merged by Bors] - chore(Data/Int): address porting notes

### DIFF
--- a/Mathlib/Data/Int/Bitwise.lean
+++ b/Mathlib/Data/Int/Bitwise.lean
@@ -66,7 +66,6 @@ def land : ℤ → ℤ → ℤ
   | -[m +1], (n : ℕ) => Nat.ldiff n m
   | -[m +1], -[n +1] => -[m ||| n +1]
 
--- Porting note: I don't know why `Nat.ldiff` got the prime, but I'm matching this change here
 /-- `ldiff a b` performs bitwise set difference. For each corresponding
   pair of bits taken as booleans, say `aᵢ` and `bᵢ`, it applies the
   boolean operation `aᵢ ∧ bᵢ` to obtain the `iᵗʰ` bit of the result. -/
@@ -76,7 +75,6 @@ def ldiff : ℤ → ℤ → ℤ
   | -[m +1], (n : ℕ) => -[m ||| n +1]
   | -[m +1], -[n +1] => Nat.ldiff n m
 
--- Porting note: I don't know why `Nat.xor'` got the prime, but I'm matching this change here
 /-- `xor` computes the bitwise `xor` of two natural numbers -/
 protected def xor : ℤ → ℤ → ℤ
   | (m : ℕ), (n : ℕ) => (m ^^^ n)
@@ -129,38 +127,22 @@ theorem bodd_negOfNat (n : ℕ) : bodd (negOfNat n) = n.bodd := by
 
 @[simp]
 theorem bodd_neg (n : ℤ) : bodd (-n) = bodd n := by
-  cases n with
-  | ofNat =>
-    rw [← negOfNat_eq, bodd_negOfNat]
-    simp
-  | negSucc n =>
-    rw [neg_negSucc, bodd_coe, Nat.bodd_succ]
-    change (!Nat.bodd n) = !(bodd n)
-    rw [bodd_coe]
--- Porting note: Heavily refactored proof, used to work all with `simp`:
--- `cases n <;> simp [Neg.neg, Int.natCast_eq_ofNat, Int.neg, bodd, -of_nat_eq_coe]`
+  cases n <;> simp only [← negOfNat_eq, bodd_negOfNat, neg_negSucc] <;> simp [bodd]
 
 @[simp]
 theorem bodd_add (m n : ℤ) : bodd (m + n) = xor (bodd m) (bodd n) := by
   rcases m with m | m <;>
   rcases n with n | n <;>
   simp only [ofNat_eq_coe, ofNat_add_negSucc, negSucc_add_ofNat,
-             negSucc_add_negSucc, bodd_subNatNat] <;>
-  simp only [negSucc_coe, bodd_neg, bodd_coe, ← Nat.bodd_add, Bool.xor_comm, ← Nat.cast_add]
-  rw [← Nat.succ_add, add_assoc]
--- Porting note: Heavily refactored proof, used to work all with `simp`:
--- `by cases m with m m; cases n with n n; unfold has_add.add;`
--- `simp [int.add, -of_nat_eq_coe, bool.xor_comm]`
+             negSucc_add_negSucc, bodd_subNatNat, ← Nat.cast_add] <;>
+  simp [bodd, Bool.xor_comm]
 
 @[simp]
 theorem bodd_mul (m n : ℤ) : bodd (m * n) = (bodd m && bodd n) := by
   rcases m with m | m <;> rcases n with n | n <;>
   simp only [ofNat_eq_coe, ofNat_mul_negSucc, negSucc_mul_ofNat, ofNat_mul_ofNat,
              negSucc_mul_negSucc] <;>
-  simp only [negSucc_coe, bodd_neg, bodd_coe, ← Nat.bodd_mul]
--- Porting note: Heavily refactored proof, used to be:
--- `by cases m with m m; cases n with n n;`
--- `simp [← int.mul_def, int.mul, -of_nat_eq_coe, bool.xor_comm]`
+  simp only [negSucc_coe, bodd_neg, bodd_coe, Nat.bodd_mul]
 
 theorem bodd_add_div2 : ∀ n, cond (bodd n) 1 0 + 2 * div2 n = n
   | (n : ℕ) => by
@@ -368,14 +350,15 @@ theorem shiftLeft_neg (m n : ℤ) : m <<< (-n) = m >>> n :=
 @[simp]
 theorem shiftRight_neg (m n : ℤ) : m >>> (-n) = m <<< n := by rw [← shiftLeft_neg, neg_neg]
 
--- Porting note: what's the correct new name?
 @[simp]
-theorem shiftLeft_coe_nat (m n : ℕ) : (m : ℤ) <<< (n : ℤ) = ↑(m <<< n) := by
+theorem shiftLeft_natCast (m n : ℕ) : (m : ℤ) <<< (n : ℤ) = ↑(m <<< n) := by
   unfold_projs; simp
 
--- Porting note: what's the correct new name?
 @[simp]
-theorem shiftRight_coe_nat (m n : ℕ) : (m : ℤ) >>> (n : ℤ) = m >>> n := by cases n <;> rfl
+theorem shiftRight_natCast (m n : ℕ) : (m : ℤ) >>> (n : ℤ) = m >>> n := by cases n <;> rfl
+
+@[deprecated (since := "2025-03-10")] alias shiftLeft_coe_nat := shiftLeft_natCast
+@[deprecated (since := "2025-03-10")] alias shiftRight_coe_nat := shiftRight_natCast
 
 @[simp]
 theorem shiftLeft_negSucc (m n : ℕ) : -[m+1] <<< (n : ℤ) = -[Nat.shiftLeft' true m n+1] :=
@@ -387,7 +370,7 @@ theorem shiftRight_negSucc (m n : ℕ) : -[m+1] >>> (n : ℤ) = -[m >>> n+1] := 
 /-- Compare with `Int.shiftRight_add`, which doesn't have the coercions `ℕ → ℤ`. -/
 theorem shiftRight_add' : ∀ (m : ℤ) (n k : ℕ), m >>> (n + k : ℤ) = (m >>> (n : ℤ)) >>> (k : ℤ)
   | (m : ℕ), n, k => by
-    rw [shiftRight_coe_nat, shiftRight_coe_nat, ← Int.ofNat_add, shiftRight_coe_nat,
+    rw [shiftRight_natCast, shiftRight_natCast, ← Int.ofNat_add, shiftRight_natCast,
       Nat.shiftRight_add]
   | -[m+1], n, k => by
     rw [shiftRight_negSucc, shiftRight_negSucc, ← Int.ofNat_add, shiftRight_negSucc,
@@ -406,7 +389,7 @@ theorem shiftLeft_add : ∀ (m : ℤ) (n : ℕ) (k : ℤ), m <<< (n + k) = (m <<
       fun i n => by
         dsimp
         simp_rw [negSucc_eq, shiftLeft_neg, Nat.shiftLeft'_false, Nat.shiftRight_add,
-          ← Nat.shiftLeft_sub _ le_rfl, Nat.sub_self, Nat.shiftLeft_zero, ← shiftRight_coe_nat,
+          ← Nat.shiftLeft_sub _ le_rfl, Nat.sub_self, Nat.shiftLeft_zero, ← shiftRight_natCast,
           ← shiftRight_add', Nat.cast_one]
   | -[m+1], n, -[k+1] =>
     subNatNat_elim n k.succ

--- a/Mathlib/Data/Int/ConditionallyCompleteOrder.lean
+++ b/Mathlib/Data/Int/ConditionallyCompleteOrder.lean
@@ -32,34 +32,29 @@ instance instConditionallyCompleteLinearOrder : ConditionallyCompleteLinearOrder
     else 0
   le_csSup s n hs hns := by
     have : s.Nonempty ∧ BddAbove s := ⟨⟨n, hns⟩, hs⟩
-    -- Porting note: this was `rw [dif_pos this]`
-    simp only [this, and_self, dite_true]
+    simp only [dif_pos this]
     exact (greatestOfBdd _ _ _).2.2 n hns
   csSup_le s n hs hns := by
     have : s.Nonempty ∧ BddAbove s := ⟨hs, ⟨n, hns⟩⟩
-    -- Porting note: this was `rw [dif_pos this]`
-    simp only [this, and_self, dite_true]
+    simp only [dif_pos this]
     exact hns (greatestOfBdd _ (Classical.choose_spec this.2) _).2.1
   csInf_le s n hs hns := by
     have : s.Nonempty ∧ BddBelow s := ⟨⟨n, hns⟩, hs⟩
-    -- Porting note: this was `rw [dif_pos this]`
-    simp only [this, and_self, dite_true]
+    simp only [dif_pos this]
     exact (leastOfBdd _ _ _).2.2 n hns
   le_csInf s n hs hns := by
     have : s.Nonempty ∧ BddBelow s := ⟨hs, ⟨n, hns⟩⟩
-    -- Porting note: this was `rw [dif_pos this]`
-    simp only [this, and_self, dite_true]
+    simp only [dif_pos this]
     exact hns (leastOfBdd _ (Classical.choose_spec this.2) _).2.1
   csSup_of_not_bddAbove := fun s hs ↦ by simp [hs]
   csInf_of_not_bddBelow := fun s hs ↦ by simp [hs]
 
 namespace Int
 
--- Porting note: mathlib3 proof uses `convert dif_pos _ using 1`
 theorem csSup_eq_greatest_of_bdd {s : Set ℤ} [DecidablePred (· ∈ s)] (b : ℤ) (Hb : ∀ z ∈ s, z ≤ b)
     (Hinh : ∃ z : ℤ, z ∈ s) : sSup s = greatestOfBdd b Hb Hinh := by
   have : s.Nonempty ∧ BddAbove s := ⟨Hinh, b, Hb⟩
-  simp only [sSup, this, and_self, dite_true]
+  simp only [sSup, dif_pos this]
   convert (coe_greatestOfBdd_eq Hb (Classical.choose_spec (⟨b, Hb⟩ : BddAbove s)) Hinh).symm
 
 @[simp]
@@ -69,11 +64,10 @@ theorem csSup_empty : sSup (∅ : Set ℤ) = 0 :=
 theorem csSup_of_not_bdd_above {s : Set ℤ} (h : ¬BddAbove s) : sSup s = 0 :=
   dif_neg (by simp [h])
 
--- Porting note: mathlib3 proof uses `convert dif_pos _ using 1`
 theorem csInf_eq_least_of_bdd {s : Set ℤ} [DecidablePred (· ∈ s)] (b : ℤ) (Hb : ∀ z ∈ s, b ≤ z)
     (Hinh : ∃ z : ℤ, z ∈ s) : sInf s = leastOfBdd b Hb Hinh := by
   have : s.Nonempty ∧ BddBelow s := ⟨Hinh, b, Hb⟩
-  simp only [sInf, this, and_self, dite_true]
+  simp only [sInf, dif_pos this]
   convert (coe_leastOfBdd_eq Hb (Classical.choose_spec (⟨b, Hb⟩ : BddBelow s)) Hinh).symm
 
 @[simp]

--- a/Mathlib/Data/Int/Init.lean
+++ b/Mathlib/Data/Int/Init.lean
@@ -500,7 +500,7 @@ lemma natMod_lt {n : ℕ} (hn : n ≠ 0) : m.natMod n < n :=
 
 attribute [simp] natCast_pow
 
--- Porting note: this was added in an ad hoc port for use in `Tactic/NormNum/Basic`
+/-- For use in `Mathlib.Tactic.NormNum.Pow` -/
 @[simp] lemma pow_eq (m : ℤ) (n : ℕ) : m.pow n = m ^ n := rfl
 
 end Int

--- a/Mathlib/Data/Int/Log.lean
+++ b/Mathlib/Data/Int/Log.lean
@@ -131,8 +131,7 @@ theorem log_one_left (r : R) : log 1 r = 0 := by
   · simp_all only [log, ↓reduceIte, Nat.log_one_left, Nat.cast_zero]
   · simp only [log, Nat.log_one_left, Nat.cast_zero, Nat.clog_one_left, neg_zero, ite_self]
 
--- Porting note: needed to replace b ^ z with (b : R) ^ z in the below
-theorem log_zpow {b : ℕ} (hb : 1 < b) (z : ℤ) : log b ((b : R) ^ z : R) = z := by
+theorem log_zpow {b : ℕ} (hb : 1 < b) (z : ℤ) : log b (b ^ z : R) = z := by
   obtain ⟨n, rfl | rfl⟩ := Int.eq_nat_or_neg z
   · rw [log_of_one_le_right _ (one_le_zpow₀ (mod_cast hb.le) <| Int.natCast_nonneg _), zpow_natCast,
       ← Nat.cast_pow, Nat.floor_natCast, Nat.log_pow hb]
@@ -257,8 +256,7 @@ theorem clog_zero_left (r : R) : clog 0 r = 0 := by
 theorem clog_one_left (r : R) : clog 1 r = 0 := by
   simp only [clog, Nat.log_one_left, Nat.cast_zero, Nat.clog_one_left, neg_zero, ite_self]
 
--- Porting note: needed to replace b ^ z with (b : R) ^ z in the below
-theorem clog_zpow {b : ℕ} (hb : 1 < b) (z : ℤ) : clog b ((b : R) ^ z : R) = z := by
+theorem clog_zpow {b : ℕ} (hb : 1 < b) (z : ℤ) : clog b (b ^ z : R) = z := by
   rw [← neg_log_inv_eq_clog, ← zpow_neg, log_zpow hb, neg_neg]
 
 @[mono]

--- a/Mathlib/Data/Int/ModEq.lean
+++ b/Mathlib/Data/Int/ModEq.lean
@@ -31,7 +31,6 @@ notation:50 a " ≡ " b " [ZMOD " n "]" => ModEq n a b
 
 variable {m n a b c d : ℤ}
 
--- Porting note: This instance should be derivable automatically
 instance : Decidable (ModEq n a b) := decEq (a % n) (b % n)
 
 namespace ModEq
@@ -178,7 +177,6 @@ theorem cancel_right_div_gcd (hm : 0 < m) (h : a * c ≡ b * c [ZMOD m]) :
     a ≡ b [ZMOD m / gcd m c] := by
   letI d := gcd m c
   rw [modEq_iff_dvd] at h ⊢
-  -- Porting note: removed `show` due to https://github.com/leanprover-community/mathlib4/issues/3305
   refine Int.dvd_of_dvd_mul_right_of_gcd_one (?_ : m / d ∣ c / d * (b - a)) ?_
   · rw [mul_comm, ← Int.mul_ediv_assoc (b - a) gcd_dvd_right, Int.sub_mul]
     exact Int.ediv_dvd_ediv gcd_dvd_left h

--- a/Mathlib/Data/Int/Range.lean
+++ b/Mathlib/Data/Int/Range.lean
@@ -33,18 +33,10 @@ instance decidableLELT (P : Int → Prop) [DecidablePred P] (m n : ℤ) :
   decidable_of_iff (∀ r ∈ range m n, P r) <| by simp only [mem_range_iff, and_imp]
 
 instance decidableLELE (P : Int → Prop) [DecidablePred P] (m n : ℤ) :
-    Decidable (∀ r, m ≤ r → r ≤ n → P r) := by
-  -- Porting note: The previous code was:
-  -- decidable_of_iff (∀ r ∈ range m (n + 1), P r) <| by
-  --   simp only [mem_range_iff, and_imp, lt_add_one_iff]
-  --
-  -- This fails to synthesize an instance
-  -- `Decidable (∀ (r : ℤ), r ∈ range m (n + 1) → P r)`
-    apply decidable_of_iff (∀ r ∈ range m (n + 1), P r)
-    apply Iff.intro <;> intros h _ _
-    · intro _; apply h
-      simp_all only [mem_range_iff, and_imp, and_self, lt_add_one_iff]
-    · simp_all only [mem_range_iff, and_imp, lt_add_one_iff]
+    Decidable (∀ r, m ≤ r → r ≤ n → P r) :=
+  -- Add empty type ascription, otherwise it fails to find `Decidable` instance.
+  decidable_of_iff (∀ r ∈ range m (n + 1), P r :) <| by
+    simp only [mem_range_iff, and_imp, lt_add_one_iff]
 
 instance decidableLTLT (P : Int → Prop) [DecidablePred P] (m n : ℤ) :
     Decidable (∀ r, m < r → r < n → P r) :=


### PR DESCRIPTION
Addresses most porting notes in `Data/Int` except for those talking about tactics.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
