### PR TITLE
[Merged by Bors] - chore: generalise AE{Strongly}Measurable.enorm to ContinuousENorm

### DIFF
--- a/Mathlib/MeasureTheory/Constructions/BorelSpace/Metric.lean
+++ b/Mathlib/MeasureTheory/Constructions/BorelSpace/Metric.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Yury Kudryashov
 -/
 import Mathlib.Analysis.Normed.Group.Continuity
-import Mathlib.MeasureTheory.Constructions.BorelSpace.Real
+import Mathlib.MeasureTheory.Constructions.BorelSpace.Basic
 import Mathlib.Topology.MetricSpace.Thickening
 
 /-!

--- a/Mathlib/MeasureTheory/Constructions/BorelSpace/Metric.lean
+++ b/Mathlib/MeasureTheory/Constructions/BorelSpace/Metric.lean
@@ -12,8 +12,8 @@ import Mathlib.Topology.MetricSpace.Thickening
 
 ## Main statements
 
-* `measurable_dist`, `measurable_infEdist`, `measurable_norm`,
-  `Measurable.dist`, `Measurable.infEdist`, `Measurable.norm`:
+* `measurable_dist`, `measurable_infEdist`, `measurable_norm`, `measurable_enorm`,
+  `Measurable.dist`, `Measurable.infEdist`, `Measurable.norm`, `Measurable.enorm`:
   measurability of various metric-related notions;
 * `tendsto_measure_thickening_of_isClosed`:
   the measure of a closed set is the limit of the measure of its ε-thickenings as ε → 0.
@@ -210,6 +210,30 @@ theorem exists_opensMeasurableSpace_of_countablySeparated (α : Type*)
   rcases exists_borelSpace_of_countablyGenerated_of_separatesPoints (m := m') with ⟨τ, _, _, τm'⟩
   exact ⟨τ, ‹_›, ‹_›, @OpensMeasurableSpace.mk _ _ m (τm'.measurable_eq.symm.le.trans m'le)⟩
 
+
+section ContinuousENorm
+
+variable {ε : Type*} [MeasurableSpace ε] [TopologicalSpace ε] [ContinuousENorm ε]
+  [OpensMeasurableSpace ε] [MeasurableSpace β]
+
+@[measurability, fun_prop]
+lemma measurable_enorm : Measurable (enorm : ε → ℝ≥0∞) := continuous_enorm.measurable
+
+@[measurability, fun_prop]
+protected lemma Measurable.enorm {f : β → ε} (hf : Measurable f) : Measurable (‖f ·‖ₑ) :=
+  measurable_enorm.comp hf
+
+@[measurability, fun_prop]
+protected lemma AEMeasurable.enorm {f : β → ε} {μ : Measure β} (hf : AEMeasurable f μ) :
+    AEMeasurable (‖f ·‖ₑ) μ :=
+  measurable_enorm.comp_aemeasurable hf
+
+@[deprecated (since := "2025-01-21")] alias measurable_ennnorm := measurable_enorm
+@[deprecated (since := "2025-01-21")] alias Measurable.ennnorm := Measurable.enorm
+@[deprecated (since := "2025-01-21")] alias AEMeasurable.ennnorm := AEMeasurable.enorm
+
+end ContinuousENorm
+
 section NormedAddCommGroup
 
 variable [MeasurableSpace α] [NormedAddCommGroup α] [OpensMeasurableSpace α] [MeasurableSpace β]
@@ -239,21 +263,5 @@ protected theorem Measurable.nnnorm {f : β → α} (hf : Measurable f) : Measur
 protected lemma AEMeasurable.nnnorm {f : β → α} {μ : Measure β} (hf : AEMeasurable f μ) :
     AEMeasurable (fun a => ‖f a‖₊) μ :=
   measurable_nnnorm.comp_aemeasurable hf
-
-@[measurability]
-lemma measurable_enorm : Measurable (enorm : α → ℝ≥0∞) := continuous_enorm.measurable
-
-@[measurability, fun_prop]
-protected lemma Measurable.enorm {f : β → α} (hf : Measurable f) : Measurable (‖f ·‖ₑ) :=
-  hf.nnnorm.coe_nnreal_ennreal
-
-@[measurability, fun_prop]
-protected lemma AEMeasurable.enorm {f : β → α} {μ : Measure β} (hf : AEMeasurable f μ) :
-    AEMeasurable (‖f ·‖ₑ) μ :=
-  measurable_enorm.comp_aemeasurable hf
-
-@[deprecated (since := "2025-01-21")] alias measurable_ennnorm := measurable_enorm
-@[deprecated (since := "2025-01-21")] alias Measurable.ennnorm := Measurable.enorm
-@[deprecated (since := "2025-01-21")] alias AEMeasurable.ennnorm := AEMeasurable.enorm
 
 end NormedAddCommGroup

--- a/Mathlib/MeasureTheory/Constructions/BorelSpace/Metrizable.lean
+++ b/Mathlib/MeasureTheory/Constructions/BorelSpace/Metrizable.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Floris van Doorn
 -/
 import Mathlib.MeasureTheory.Constructions.BorelSpace.Metric
+import Mathlib.MeasureTheory.Constructions.BorelSpace.Real
 import Mathlib.Topology.Metrizable.Real
 import Mathlib.Topology.IndicatorConstPointwise
 

--- a/Mathlib/MeasureTheory/Constructions/Polish/Basic.lean
+++ b/Mathlib/MeasureTheory/Constructions/Polish/Basic.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sébastien Gouëzel, Felix Weilacher
 -/
 import Mathlib.MeasureTheory.Constructions.BorelSpace.Metric
+import Mathlib.MeasureTheory.Constructions.BorelSpace.Order
 import Mathlib.Topology.MetricSpace.Perfect
 import Mathlib.Topology.Separation.CountableSeparatingOn
 

--- a/Mathlib/MeasureTheory/Function/SpecialFunctions/Basic.lean
+++ b/Mathlib/MeasureTheory/Function/SpecialFunctions/Basic.lean
@@ -6,6 +6,7 @@ Authors: Yury Kudryashov
 import Mathlib.Analysis.SpecialFunctions.Pow.NNReal
 import Mathlib.MeasureTheory.Constructions.BorelSpace.Complex
 import Mathlib.MeasureTheory.Constructions.BorelSpace.Metric
+import Mathlib.MeasureTheory.Constructions.BorelSpace.Real
 
 /-!
 # Measurability of real and complex functions


### PR DESCRIPTION
From the Carleson project.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
