### PR TITLE
[Merged by Bors] - chore(Data/Set): some more porting notes

### DIFF
--- a/Mathlib/Data/Set/Basic.lean
+++ b/Mathlib/Data/Set/Basic.lean
@@ -690,7 +690,6 @@ theorem subset_union_of_subset_left {s t : Set α} (h : s ⊆ t) (u : Set α) : 
 theorem subset_union_of_subset_right {s u : Set α} (h : s ⊆ u) (t : Set α) : s ⊆ t ∪ u :=
   h.trans subset_union_right
 
--- Porting note: replaced `⊔` in RHS
 theorem union_congr_left (ht : t ⊆ s ∪ u) (hu : u ⊆ s ∪ t) : s ∪ t = s ∪ u :=
   sup_congr_left ht hu
 

--- a/Mathlib/Data/Set/CoeSort.lean
+++ b/Mathlib/Data/Set/CoeSort.lean
@@ -23,13 +23,13 @@ universe u v w
 
 variable {α : Type u} {β : Type v} {γ : Type w}
 
--- Porting note: I've introduced this abbreviation, with the `@[coe]` attribute,
--- so that `norm_cast` has something to index on.
--- It is currently an abbreviation so that instance coming from `Subtype` are available.
--- If you're interested in making it a `def`, as it probably should be,
--- you'll then need to create additional instances (and possibly prove lemmas about them).
--- The first error should appear below at `monotoneOn_iff_monotone`.
-/-- Given the set `s`, `Elem s` is the `Type` of element of `s`. -/
+/-- Given the set `s`, `Elem s` is the `Type` of element of `s`.
+
+It is currently an abbreviation so that instance coming from `Subtype` are available.
+If you're interested in making it a `def`, as it probably should be,
+you'll then need to create additional instances (and possibly prove lemmas about them).
+See e.g. `Mathlib.Data.Set.Order`.
+-/
 @[coe, reducible] def Elem (s : Set α) : Type u := {x // x ∈ s}
 
 /-- Coercion from a set to the corresponding subtype. -/

--- a/Mathlib/Data/Set/Defs.lean
+++ b/Mathlib/Data/Set/Defs.lean
@@ -66,7 +66,7 @@ Note that you should **not** use this definition directly, but instead write `s 
 protected def Subset (s₁ s₂ : Set α) :=
   ∀ ⦃a⦄, a ∈ s₁ → a ∈ s₂
 
-/-- Porting note: we introduce `≤` before `⊆` to help the unifier when applying lattice theorems
+/-- We introduce `≤` before `⊆` to help the unifier when applying lattice theorems
 to subset hypotheses. -/
 instance : LE (Set α) :=
   ⟨Set.Subset⟩

--- a/Mathlib/Data/Set/Finite/Basic.lean
+++ b/Mathlib/Data/Set/Finite/Basic.lean
@@ -74,10 +74,7 @@ protected noncomputable def Finite.toFinset {s : Set α} (h : s.Finite) : Finset
 
 theorem Finite.toFinset_eq_toFinset {s : Set α} [Fintype s] (h : s.Finite) :
     h.toFinset = s.toFinset := by
-  -- Porting note: was `rw [Finite.toFinset]; congr`
-  -- in Lean 4, a goal is left after `congr`
-  have : h.fintype = ‹_› := Subsingleton.elim _ _
-  rw [Finite.toFinset, this]
+  rw [Finite.toFinset, Subsingleton.elim h.fintype]
 
 @[simp]
 theorem toFinite_toFinset (s : Set α) [Fintype s] : s.toFinite.toFinset = s.toFinset :=
@@ -639,7 +636,7 @@ theorem finite_image_iff {s : Set α} {f : α → β} (hi : InjOn f s) : (f '' s
 theorem univ_finite_iff_nonempty_fintype : (univ : Set α).Finite ↔ Nonempty (Fintype α) :=
   ⟨fun h => ⟨fintypeOfFiniteUniv h⟩, fun ⟨_i⟩ => finite_univ⟩
 
--- Porting note: moved `@[simp]` to `Set.toFinset_singleton` because `simp` can now simplify LHS
+-- `simp`-normal form is `Set.toFinset_singleton`.
 theorem Finite.toFinset_singleton {a : α} (ha : ({a} : Set α).Finite := finite_singleton _) :
     ha.toFinset = {a} :=
   Set.toFinite_toFinset _

--- a/Mathlib/Data/Set/Function.lean
+++ b/Mathlib/Data/Set/Function.lean
@@ -553,8 +553,7 @@ theorem exists_injOn_iff_injective [Nonempty β] :
     exact ⟨f, injOn_iff_injective.2 hf⟩⟩
 
 theorem injOn_preimage {B : Set (Set β)} (hB : B ⊆ 𝒫 range f) : InjOn (preimage f) B :=
-  fun s hs t ht hst => (preimage_eq_preimage' (@hB s hs) (@hB t ht)).1 hst
--- Porting note: is there a semi-implicit variable problem with `⊆`?
+  fun _ hs _ ht hst => (preimage_eq_preimage' (hB hs) (hB ht)).1 hst
 
 theorem InjOn.mem_of_mem_image {x} (hf : InjOn f s) (hs : s₁ ⊆ s) (h : x ∈ s) (h₁ : f x ∈ f '' s₁) :
     x ∈ s₁ :=
@@ -760,8 +759,7 @@ theorem SurjOn.inter (h₁ : SurjOn f s₁ t) (h₂ : SurjOn f s₂ t) (h : InjO
     SurjOn f (s₁ ∩ s₂) t :=
   inter_self t ▸ h₁.inter_inter h₂ h
 
--- Porting note: Why does `simp` not call `refl` by itself?
-lemma surjOn_id (s : Set α) : SurjOn id s s := by simp [SurjOn, subset_rfl]
+lemma surjOn_id (s : Set α) : SurjOn id s s := by simp [SurjOn]
 
 theorem SurjOn.comp (hg : SurjOn g t p) (hf : SurjOn f s t) : SurjOn (g ∘ f) s p :=
   Subset.trans hg <| Subset.trans (image_subset g hf) <| image_comp g f s ▸ Subset.refl _

--- a/Mathlib/Data/Set/Image.lean
+++ b/Mathlib/Data/Set/Image.lean
@@ -185,8 +185,6 @@ section Image
 
 variable {f : α → β} {s t : Set α}
 
--- Porting note: `Set.image` is already defined in `Data.Set.Defs`
-
 theorem image_eta (f : α → β) : f '' s = (fun x => f x) '' s :=
   rfl
 
@@ -204,11 +202,9 @@ theorem forall_mem_image {f : α → β} {s : Set α} {p : β → Prop} :
 theorem exists_mem_image {f : α → β} {s : Set α} {p : β → Prop} :
     (∃ y ∈ f '' s, p y) ↔ ∃ x ∈ s, p (f x) := by simp
 
--- Porting note: used to be `safe`
 @[congr]
 theorem image_congr {f g : α → β} {s : Set α} (h : ∀ a ∈ s, f a = g a) : f '' s = g '' s := by
-  ext x
-  exact exists_congr fun a ↦ and_congr_right fun ha ↦ by rw [h a ha]
+  aesop
 
 /-- A common special case of `image_congr` -/
 theorem image_congr' {f g : α → β} {s : Set α} (h : ∀ x : α, f x = g x) : f '' s = g '' s :=
@@ -292,7 +288,6 @@ theorem image_eq_empty {α β} {f : α → β} {s : Set α} : f '' s = ∅ ↔ s
   simp only [eq_empty_iff_forall_not_mem]
   exact ⟨fun H a ha => H _ ⟨_, ha, rfl⟩, fun H b ⟨_, ha, _⟩ => H _ ha⟩
 
--- Porting note: `compl` is already defined in `Data.Set.Defs`
 theorem preimage_compl_eq_image_compl [BooleanAlgebra α] (S : Set α) :
     HasCompl.compl ⁻¹' S = HasCompl.compl '' S :=
   Set.ext fun x =>
@@ -735,13 +730,11 @@ theorem preimage_eq_preimage' {s t : Set α} {f : β → α} (hs : s ⊆ range f
     · rw [← preimage_subset_preimage_iff ht, h]
   rintro rfl; rfl
 
--- Porting note:
--- @[simp] `simp` can prove this
+-- Not `@[simp]` since `simp` can prove this.
 theorem preimage_inter_range {f : α → β} {s : Set β} : f ⁻¹' (s ∩ range f) = f ⁻¹' s :=
   Set.ext fun x => and_iff_left ⟨x, rfl⟩
 
--- Porting note:
--- @[simp] `simp` can prove this
+-- Not `@[simp]` since `simp` can prove this.
 theorem preimage_range_inter {f : α → β} {s : Set β} : f ⁻¹' (range f ∩ s) = f ⁻¹' s := by
   rw [inter_comm, preimage_inter_range]
 
@@ -987,8 +980,7 @@ theorem compl_range_some (α : Type*) : (range (some : α → Option α))ᶜ = {
 theorem range_some_inter_none (α : Type*) : range (some : α → Option α) ∩ {none} = ∅ :=
   (isCompl_range_some_none α).inf_eq_bot
 
--- Porting note:
--- @[simp] `simp` can prove this
+-- Not `@[simp]` since `simp` can prove this.
 theorem range_some_union_none (α : Type*) : range (some : α → Option α) ∪ {none} = univ :=
   (isCompl_range_some_none α).sup_eq_top
 
@@ -1225,8 +1217,7 @@ theorem preimage_coe_self_inter (s t : Set α) :
     ((↑) : s → α) ⁻¹' (s ∩ t) = ((↑) : s → α) ⁻¹' t := by
   rw [preimage_coe_eq_preimage_coe_iff, ← inter_assoc, inter_self]
 
--- Porting note:
--- @[simp] `simp` can prove this
+-- Not `@[simp]` since `simp` can prove this.
 theorem preimage_coe_inter_self (s t : Set α) :
     ((↑) : s → α) ⁻¹' (t ∩ s) = ((↑) : s → α) ⁻¹' t := by
   rw [inter_comm, preimage_coe_self_inter]
@@ -1258,8 +1249,7 @@ theorem preimage_coe_nonempty {s t : Set α} :
 theorem preimage_coe_eq_empty {s t : Set α} : ((↑) : s → α) ⁻¹' t = ∅ ↔ s ∩ t = ∅ := by
   simp [← not_nonempty_iff_eq_empty, preimage_coe_nonempty]
 
--- Porting note:
--- @[simp] `simp` can prove this
+-- Not `@[simp]` since `simp` can prove this.
 theorem preimage_coe_compl (s : Set α) : ((↑) : s → α) ⁻¹' sᶜ = ∅ :=
   preimage_coe_eq_empty.2 (inter_compl_self s)
 

--- a/Mathlib/Data/Set/Insert.lean
+++ b/Mathlib/Data/Set/Insert.lean
@@ -184,7 +184,7 @@ theorem setOf_eq_eq_singleton' {a : α} : { x | a = x } = {a} :=
   ext fun _ => eq_comm
 
 -- TODO: again, annotation needed
---Porting note (https://github.com/leanprover-community/mathlib4/issues/11119): removed `simp` attribute
+-- Not `@[simp]` since `mem_singleton_iff` proves it.
 theorem mem_singleton (a : α) : a ∈ ({a} : Set α) :=
   @rfl _ _
 

--- a/Mathlib/Data/Set/Lattice.lean
+++ b/Mathlib/Data/Set/Lattice.lean
@@ -691,8 +691,7 @@ theorem mem_biInter {s : Set α} {t : α → Set β} {y : β} (h : ∀ x ∈ s, 
 /-- A specialization of `subset_iUnion₂`. -/
 theorem subset_biUnion_of_mem {s : Set α} {u : α → Set β} {x : α} (xs : x ∈ s) :
     u x ⊆ ⋃ x ∈ s, u x :=
--- Porting note: Why is this not just `subset_iUnion₂ x xs`?
-  @subset_iUnion₂ β α (· ∈ s) (fun i _ => u i) x xs
+  subset_iUnion₂ (s := fun i _ => u i) x xs
 
 /-- A specialization of `iInter₂_subset`. -/
 theorem biInter_subset_of_mem {s : Set α} {t : α → Set β} {x : α} (xs : x ∈ s) :
@@ -1209,10 +1208,7 @@ end le
 
 section Function
 
-/-! ### Lemmas about `Set.MapsTo`
-
-Porting note: some lemmas in this section were upgraded from implications to `iff`s.
--/
+/-! ### Lemmas about `Set.MapsTo` -/
 
 @[simp]
 theorem mapsTo_sUnion {S : Set (Set α)} {t : Set β} {f : α → β} :
@@ -1414,9 +1410,7 @@ section Image
 
 theorem image_iUnion {f : α → β} {s : ι → Set α} : (f '' ⋃ i, s i) = ⋃ i, f '' s i := by
   ext1 x
-  simp only [mem_image, mem_iUnion, ← exists_and_right, ← exists_and_left]
-  -- Porting note: `exists_swap` causes a `simp` loop in Lean4 so we use `rw` instead.
-  rw [exists_swap]
+  simp only [mem_image, mem_iUnion, ← exists_and_right, ← exists_and_left, exists_swap (α := α)]
 
 theorem image_iUnion₂ (f : α → β) (s : ∀ i, κ i → Set α) :
     (f '' ⋃ (i) (j), s i j) = ⋃ (i) (j), f '' s i j := by simp_rw [image_iUnion]
@@ -1920,9 +1914,7 @@ theorem _root_.Antitone.iInter_nat_add {f : ℕ → Set α} (hf : Antitone f) (k
     ⋂ n, f (n + k) = ⋂ n, f n :=
   hf.iInf_nat_add k
 
-/- Porting note: removing `simp`. LHS does not simplify. Possible linter bug. Zulip discussion:
-https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/complete_lattice.20and.20has_sup/near/316497982
--/
+@[simp]
 theorem iUnion_iInter_ge_nat_add (f : ℕ → Set α) (k : ℕ) :
     ⋃ n, ⋂ i ≥ n, f (i + k) = ⋃ n, ⋂ i ≥ n, f i :=
   iSup_iInf_ge_nat_add f k

--- a/Mathlib/Data/Set/MulAntidiagonal.lean
+++ b/Mathlib/Data/Set/MulAntidiagonal.lean
@@ -57,7 +57,8 @@ section CancelCommMonoid
 
 variable [CancelCommMonoid α] {s t : Set α} {a : α} {x y : mulAntidiagonal s t a}
 
--- Porting note: to_additive cannot translate the "Mul" in "MulAntidiagonal" by itself here
+-- We have to translate the names manually because the namespace name `MulAntidiagonal`
+-- does not match the declaration `mulAntidiagonal` that has the `to_additive` attribute.
 @[to_additive Set.AddAntidiagonal.fst_eq_fst_iff_snd_eq_snd]
 theorem fst_eq_fst_iff_snd_eq_snd : (x : α × α).1 = (y : α × α).1 ↔ (x : α × α).2 = (y : α × α).2 :=
   ⟨fun h =>

--- a/Mathlib/Data/Set/NAry.lean
+++ b/Mathlib/Data/Set/NAry.lean
@@ -69,7 +69,7 @@ theorem image2_subset_iff_right : image2 f s t ⊆ u ↔ ∀ b ∈ t, (fun a => 
 
 variable (f)
 
--- Porting note: Removing `simp` - LHS does not simplify
+@[simp]
 lemma image_prod : (fun x : α × β ↦ f x.1 x.2) '' s ×ˢ t = image2 f s t :=
   ext fun _ ↦ by simp [and_assoc]
 
@@ -78,7 +78,7 @@ lemma image_prod : (fun x : α × β ↦ f x.1 x.2) '' s ×ˢ t = image2 f s t :
 
 @[simp] lemma image2_mk_eq_prod : image2 Prod.mk s t = s ×ˢ t := ext <| by simp
 
--- Porting note: Removing `simp` - LHS does not simplify
+@[simp]
 lemma image2_curry (f : α × β → γ) (s : Set α) (t : Set β) :
     image2 (fun a b ↦ f (a, b)) s t = f '' s ×ˢ t := by
   simp [← image_uncurry_prod, uncurry]

--- a/Mathlib/Data/Set/Order.lean
+++ b/Mathlib/Data/Set/Order.lean
@@ -21,11 +21,6 @@ section Preorder
 
 variable [Preorder α] [Preorder β] {f : α → β}
 
--- Porting note:
--- If we decide we want `Elem` to semireducible rather than reducible, we will need:
---   instance : Preorder (↑s) := Subtype.instPreorderSubtype _
--- here, along with appropriate lemmas.
-
 theorem monotoneOn_iff_monotone : MonotoneOn f s ↔
     Monotone fun a : s => f a := by
   simp [Monotone, MonotoneOn]

--- a/Mathlib/Data/Set/Semiring.lean
+++ b/Mathlib/Data/Set/Semiring.lean
@@ -22,20 +22,19 @@ open Pointwise
 
 variable {α β : Type*}
 
--- Porting note: mathlib3 uses `deriving Inhabited, PartialOrder, OrderBot`
 /-- An alias for `Set α`, which has a semiring structure given by `∪` as "addition" and pointwise
   multiplication `*` as "multiplication". -/
 def SetSemiring (α : Type*) : Type _ :=
   Set α
 
 noncomputable instance (α : Type*) : Inhabited (SetSemiring α) :=
-  (inferInstance : Inhabited (Set _))
+  inferInstanceAs <| Inhabited (Set _)
 
 instance (α : Type*) : PartialOrder (SetSemiring α) :=
-  (inferInstance : PartialOrder (Set _))
+  inferInstanceAs <| PartialOrder (Set _)
 
 instance (α : Type*) : OrderBot (SetSemiring α) :=
-  (inferInstance : OrderBot (Set _))
+  inferInstanceAs <| OrderBot (Set _)
 
 /-- The identity function `Set α → SetSemiring α`. -/
 protected def Set.up : Set α ≃ SetSemiring α :=
@@ -47,44 +46,36 @@ namespace SetSemiring
 protected def down : SetSemiring α ≃ Set α :=
   Equiv.refl _
 
--- Porting note: new, since dot notation doesn't work
 open SetSemiring (down)
 open Set (up)
 
--- Porting note (https://github.com/leanprover-community/mathlib4/issues/11036): dot notation no longer works
 @[simp]
-protected theorem down_up (s : Set α) : SetSemiring.down (Set.up s) = s :=
+protected theorem down_up (s : Set α) : s.up.down = s :=
   rfl
 
--- Porting note (https://github.com/leanprover-community/mathlib4/issues/11036): dot notation no longer works
 @[simp]
-protected theorem up_down (s : SetSemiring α) : Set.up (SetSemiring.down s) = s :=
+protected theorem up_down (s : SetSemiring α) : s.down.up = s :=
   rfl
 
 -- TODO: These lemmas are not tagged `simp` because `Set.le_eq_subset` simplifies the LHS
--- Porting note (https://github.com/leanprover-community/mathlib4/issues/11036): dot notation no longer works
-theorem up_le_up {s t : Set α} : Set.up s ≤ Set.up t ↔ s ⊆ t :=
+theorem up_le_up {s t : Set α} : s.up ≤ t.up ↔ s ⊆ t :=
   Iff.rfl
 
--- Porting note (https://github.com/leanprover-community/mathlib4/issues/11036): dot notation no longer works
-theorem up_lt_up {s t : Set α} : Set.up s < Set.up t ↔ s ⊂ t :=
+theorem up_lt_up {s t : Set α} : s.up < t.up ↔ s ⊂ t :=
   Iff.rfl
 
--- Porting note (https://github.com/leanprover-community/mathlib4/issues/11036): dot notation no longer works
 @[simp]
-theorem down_subset_down {s t : SetSemiring α} : SetSemiring.down s ⊆ SetSemiring.down t ↔ s ≤ t :=
+theorem down_subset_down {s t : SetSemiring α} : s.down ⊆ t.down ↔ s ≤ t :=
   Iff.rfl
 
--- Porting note (https://github.com/leanprover-community/mathlib4/issues/11036): dot notation no longer works
 @[simp]
-theorem down_ssubset_down {s t : SetSemiring α} : SetSemiring.down s ⊂ SetSemiring.down t ↔ s < t :=
+theorem down_ssubset_down {s t : SetSemiring α} : s.down ⊂ t.down ↔ s < t :=
   Iff.rfl
 
-instance : Zero (SetSemiring α) where zero := Set.up (∅ : Set α)
+instance : Zero (SetSemiring α) where zero := (∅ : Set α).up
 
-instance : Add (SetSemiring α) where add s t := Set.up (SetSemiring.down s ∪ SetSemiring.down t)
+instance : Add (SetSemiring α) where add s t := (s.down ∪ t.down).up
 
--- Porting note (https://github.com/leanprover-community/mathlib4/issues/11036): dot notation no longer works
 instance : AddCommMonoid (SetSemiring α) where
   add_assoc := union_assoc
   zero_add := empty_union
@@ -96,22 +87,22 @@ theorem zero_def : (0 : SetSemiring α) = Set.up ∅ :=
   rfl
 
 @[simp]
-theorem down_zero : down (0 : SetSemiring α) = ∅ :=
+theorem down_zero : (0 : SetSemiring α).down = ∅ :=
   rfl
 
 @[simp]
-theorem _root_.Set.up_empty : Set.up (∅ : Set α) = 0 :=
+theorem _root_.Set.up_empty : (∅ : Set α).up = 0 :=
   rfl
 
-theorem add_def (s t : SetSemiring α) : s + t = up (down s ∪ down t) :=
-  rfl
-
-@[simp]
-theorem down_add (s t : SetSemiring α) : down (s + t) = down s ∪ down t :=
+theorem add_def (s t : SetSemiring α) : s + t = (s.down ∪ t.down).up :=
   rfl
 
 @[simp]
-theorem _root_.Set.up_union (s t : Set α) : up (s ∪ t) = up s + up t :=
+theorem down_add (s t : SetSemiring α) : (s + t).down = s.down ∪ t.down :=
+  rfl
+
+@[simp]
+theorem _root_.Set.up_union (s t : Set α) : (s ∪ t).up = s.up + t.up :=
   rfl
 
 /- Since addition on `SetSemiring` is commutative (it is set union), there is no need
@@ -123,25 +114,23 @@ section Mul
 
 variable [Mul α]
 
--- Porting note (https://github.com/leanprover-community/mathlib4/issues/11036): dot notation no longer works
 instance : NonUnitalNonAssocSemiring (SetSemiring α) :=
   { (inferInstance : AddCommMonoid (SetSemiring α)) with
-    mul := fun s t => Set.up (image2 (· * ·) (SetSemiring.down s) (SetSemiring.down t))
+    mul := fun s t => (image2 (· * ·) s.down t.down).up
     zero_mul := fun _ => empty_mul
     mul_zero := fun _ => mul_empty
     left_distrib := fun _ _ _ => mul_union
     right_distrib := fun _ _ _ => union_mul }
 
--- TODO: port
-theorem mul_def (s t : SetSemiring α) : s * t = up (down s * down t) :=
+theorem mul_def (s t : SetSemiring α) : s * t = (s.down * t.down).up :=
   rfl
 
 @[simp]
-theorem down_mul (s t : SetSemiring α) : down (s * t) = down s * down t :=
+theorem down_mul (s t : SetSemiring α) : (s * t).down = s.down * t.down :=
   rfl
 
 @[simp]
-theorem _root_.Set.up_mul (s t : Set α) : up (s * t) = up s * up t :=
+theorem _root_.Set.up_mul (s t : Set α) : (s * t).up = s.up * t.up :=
   rfl
 
 instance : NoZeroDivisors (SetSemiring α) :=
@@ -163,17 +152,17 @@ section One
 
 variable [One α]
 
-instance : One (SetSemiring α) where one := Set.up (1 : Set α)
+instance : One (SetSemiring α) where one := (1 : Set α).up
 
 theorem one_def : (1 : SetSemiring α) = Set.up 1 :=
   rfl
 
 @[simp]
-theorem down_one : down (1 : SetSemiring α) = 1 :=
+theorem down_one : (1 : SetSemiring α).down = 1 :=
   rfl
 
 @[simp]
-theorem _root_.Set.up_one : up (1 : Set α) = 1 :=
+theorem _root_.Set.up_one : (1 : Set α).up = 1 :=
   rfl
 
 end One
@@ -210,26 +199,26 @@ instance [CommMonoid α] : OrderedCommSemiring (SetSemiring α) :=
 /-- The image of a set under a multiplicative homomorphism is a ring homomorphism
 with respect to the pointwise operations on sets. -/
 def imageHom [MulOneClass α] [MulOneClass β] (f : α →* β) : SetSemiring α →+* SetSemiring β where
-  toFun s := up (image f (down s))
+  toFun s := (image f s.down).up
   map_zero' := image_empty _
   map_one' := by
-    dsimp only  -- Porting note: structures do not do this automatically any more
+    dsimp only
     rw [down_one, image_one, map_one, singleton_one, up_one]
   map_add' := image_union _
   map_mul' _ _ := image_mul f
 
 lemma imageHom_def [MulOneClass α] [MulOneClass β] (f : α →* β) (s : SetSemiring α) :
-    imageHom f s = up (image f (down s)) :=
+    imageHom f s = (image f s.down).up :=
   rfl
 
 @[simp]
 lemma down_imageHom [MulOneClass α] [MulOneClass β] (f : α →* β) (s : SetSemiring α) :
-    down (imageHom f s) = f '' down s :=
+    (imageHom f s).down = f '' s.down :=
   rfl
 
 @[simp]
 lemma _root_.Set.up_image [MulOneClass α] [MulOneClass β] (f : α →* β) (s : Set α) :
-    up (f '' s) = imageHom f (up s) :=
+    (f '' s).up = imageHom f s.up :=
   rfl
 
 end SetSemiring

--- a/Mathlib/Data/Set/Semiring.lean
+++ b/Mathlib/Data/Set/Semiring.lean
@@ -22,6 +22,9 @@ open Pointwise
 
 variable {α β : Type*}
 
+-- The following instances should be constructed by a deriving handler.
+-- https://github.com/leanprover-community/mathlib4/issues/380
+
 /-- An alias for `Set α`, which has a semiring structure given by `∪` as "addition" and pointwise
   multiplication `*` as "multiplication". -/
 def SetSemiring (α : Type*) : Type _ :=

--- a/Mathlib/Data/Set/Subsingleton.lean
+++ b/Mathlib/Data/Set/Subsingleton.lean
@@ -127,8 +127,6 @@ protected def Nontrivial (s : Set α) : Prop :=
 theorem nontrivial_of_mem_mem_ne {x y} (hx : x ∈ s) (hy : y ∈ s) (hxy : x ≠ y) : s.Nontrivial :=
   ⟨x, hx, y, hy, hxy⟩
 
--- Porting note: following the pattern for `Exists`, we have renamed `some` to `choose`.
-
 /-- Extract witnesses from s.nontrivial. This function might be used instead of case analysis on the
 argument. Note that it makes a proof depend on the classical.choice axiom. -/
 protected noncomputable def Nontrivial.choose (hs : s.Nontrivial) : α × α :=

--- a/Mathlib/Data/Set/Sups.lean
+++ b/Mathlib/Data/Set/Sups.lean
@@ -62,8 +62,7 @@ protected def hasSups : HasSups (Set α) :=
   ⟨image2 (· ⊔ ·)⟩
 
 scoped[SetFamily] attribute [instance] Set.hasSups
--- Porting note: opening SetFamily, because otherwise the Set.hasSups does not seem to be an
--- instance
+
 open SetFamily
 
 variable {s s₁ s₂ t t₁ t₂ u} {a b c : α}
@@ -192,8 +191,7 @@ protected def hasInfs : HasInfs (Set α) :=
   ⟨image2 (· ⊓ ·)⟩
 
 scoped[SetFamily] attribute [instance] Set.hasInfs
--- Porting note: opening SetFamily, because otherwise the Set.hasSups does not seem to be an
--- instance
+
 open SetFamily
 
 variable {s s₁ s₂ t t₁ t₂ u} {a b c : α}


### PR DESCRIPTION
This builds on #22765 and gets rid of a few more porting notes.


---

- [ ] depends on: #22765 (soft dependency)

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
