### PR TITLE
[Merged by Bors] - chore: more whitespace fixes

### DIFF
--- a/Mathlib/Data/DFinsupp/BigOperators.lean
+++ b/Mathlib/Data/DFinsupp/BigOperators.lean
@@ -391,7 +391,7 @@ theorem subtypeDomain_sum {ι} {β : ι → Type v} [∀ i, AddCommMonoid (β i)
   map_sum (subtypeDomainAddMonoidHom β p) _ s
 
 theorem subtypeDomain_finsupp_sum {ι} {β : ι → Type v} {δ : γ → Type x} [DecidableEq γ]
-    [∀ c, Zero (δ c)]  [∀ (c) (x : δ c), Decidable (x ≠ 0)]
+    [∀ c, Zero (δ c)] [∀ (c) (x : δ c), Decidable (x ≠ 0)]
     [∀ i, AddCommMonoid (β i)] {p : ι → Prop} [DecidablePred p]
     {s : Π₀ c, δ c} {h : ∀ c, δ c → Π₀ i, β i} :
     (s.sum h).subtypeDomain p = s.sum fun c d => (h c d).subtypeDomain p :=

--- a/Mathlib/Data/Finset/Preimage.lean
+++ b/Mathlib/Data/Finset/Preimage.lean
@@ -108,18 +108,18 @@ theorem subset_map_iff {f : α ↪ β} {s : Finset β} {t : Finset α} :
   classical
   simp_rw [map_eq_image, subset_image_iff, eq_comm]
 
-theorem sigma_preimage_mk {β : α → Type*} [DecidableEq α] (s : Finset (Σa, β a)) (t : Finset α) :
+theorem sigma_preimage_mk {β : α → Type*} [DecidableEq α] (s : Finset (Σ a, β a)) (t : Finset α) :
     (t.sigma fun a => s.preimage (Sigma.mk a) sigma_mk_injective.injOn) =
       s.filter fun a => a.1 ∈ t := by
   ext x
   simp [and_comm]
 
-theorem sigma_preimage_mk_of_subset {β : α → Type*} [DecidableEq α] (s : Finset (Σa, β a))
+theorem sigma_preimage_mk_of_subset {β : α → Type*} [DecidableEq α] (s : Finset (Σ a, β a))
     {t : Finset α} (ht : s.image Sigma.fst ⊆ t) :
     (t.sigma fun a => s.preimage (Sigma.mk a) sigma_mk_injective.injOn) = s := by
   rw [sigma_preimage_mk, filter_true_of_mem <| image_subset_iff.1 ht]
 
-theorem sigma_image_fst_preimage_mk {β : α → Type*} [DecidableEq α] (s : Finset (Σa, β a)) :
+theorem sigma_image_fst_preimage_mk {β : α → Type*} [DecidableEq α] (s : Finset (Σ a, β a)) :
     ((s.image Sigma.fst).sigma fun a => s.preimage (Sigma.mk a) sigma_mk_injective.injOn) =
       s :=
   s.sigma_preimage_mk_of_subset (Subset.refl _)

--- a/Mathlib/Data/Finset/Sigma.lean
+++ b/Mathlib/Data/Finset/Sigma.lean
@@ -38,13 +38,13 @@ section Sigma
 variable {α : ι → Type*} {β : Type*} (s s₁ s₂ : Finset ι) (t t₁ t₂ : ∀ i, Finset (α i))
 
 /-- `s.sigma t` is the finset of dependent pairs `⟨i, a⟩` such that `i ∈ s` and `a ∈ t i`. -/
-protected def sigma : Finset (Σi, α i) :=
+protected def sigma : Finset (Σ i, α i) :=
   ⟨_, s.nodup.sigma fun i => (t i).nodup⟩
 
 variable {s s₁ s₂ t t₁ t₂}
 
 @[simp]
-theorem mem_sigma {a : Σi, α i} : a ∈ s.sigma t ↔ a.1 ∈ s ∧ a.2 ∈ t a.1 :=
+theorem mem_sigma {a : Σ i, α i} : a ∈ s.sigma t ↔ a.1 ∈ s ∧ a.2 ∈ t a.1 :=
   Multiset.mem_sigma
 
 @[simp, norm_cast]
@@ -82,12 +82,12 @@ theorem disjiUnion_map_sigma_mk :
       s.sigma t :=
   rfl
 
-theorem sigma_eq_biUnion [DecidableEq (Σi, α i)] (s : Finset ι) (t : ∀ i, Finset (α i)) :
+theorem sigma_eq_biUnion [DecidableEq (Σ i, α i)] (s : Finset ι) (t : ∀ i, Finset (α i)) :
     s.sigma t = s.biUnion fun i => (t i).map <| Embedding.sigmaMk i := by
   ext ⟨x, y⟩
   simp [and_left_comm]
 
-variable (s t) (f : (Σi, α i) → β)
+variable (s t) (f : (Σ i, α i) → β)
 
 theorem sup_sigma [SemilatticeSup β] [OrderBot β] :
     (s.sigma t).sup f = s.sup fun i => (t i).sup fun b => f ⟨i, b⟩ := by
@@ -179,7 +179,7 @@ theorem not_mem_sigmaLift_of_ne_right (f : ∀ ⦃i⦄, α i → β i → Finset
   rw [mem_sigmaLift]
   exact fun H => h H.snd.fst
 
-variable {f g : ∀ ⦃i⦄, α i → β i → Finset (γ i)} {a : Σi, α i} {b : Σi, β i}
+variable {f g : ∀ ⦃i⦄, α i → β i → Finset (γ i)} {a : Σ i, α i} {b : Σ i, β i}
 
 theorem sigmaLift_nonempty :
     (sigmaLift f a b).Nonempty ↔ ∃ h : a.1 = b.1, (f (h ▸ a.2) b.2).Nonempty := by
@@ -192,7 +192,8 @@ theorem sigmaLift_eq_empty : sigmaLift f a b = ∅ ↔ ∀ h : a.1 = b.1, f (h �
   · simp [h, forall_prop_of_true h]
   · simp [h, forall_prop_of_false h]
 
-theorem sigmaLift_mono (h : ∀ ⦃i⦄ ⦃a : α i⦄ ⦃b : β i⦄, f a b ⊆ g a b) (a : Σi, α i) (b : Σi, β i) :
+theorem sigmaLift_mono
+    (h : ∀ ⦃i⦄ ⦃a : α i⦄ ⦃b : β i⦄, f a b ⊆ g a b) (a : Σ i, α i) (b : Σ i, β i) :
     sigmaLift f a b ⊆ sigmaLift g a b := by
   rintro x hx
   rw [mem_sigmaLift] at hx ⊢

--- a/Mathlib/Data/Set/Constructions.lean
+++ b/Mathlib/Data/Set/Constructions.lean
@@ -79,7 +79,7 @@ theorem finiteInterClosure_insert {A : Set α} (cond : FiniteInter S) (P)
 
 open Set
 
-theorem mk₂ (h: ∀ ⦃s⦄, s ∈ S → ∀ ⦃t⦄, t ∈ S → s ∩ t ∈ S) :
+theorem mk₂ (h : ∀ ⦃s⦄, s ∈ S → ∀ ⦃t⦄, t ∈ S → s ∩ t ∈ S) :
     FiniteInter (insert (univ : Set α) S) where
   univ_mem := Set.mem_insert Set.univ S
   inter_mem s hs t ht := by aesop

--- a/Mathlib/Data/Sym/Basic.lean
+++ b/Mathlib/Data/Sym/Basic.lean
@@ -494,7 +494,7 @@ open Multiset
 
 /-- Remove every `a` from a given `Sym α n`.
 Yields the number of copies `i` and a term of `Sym α (n - i)`. -/
-def filterNe [DecidableEq α] (a : α) (m : Sym α n) : Σi : Fin (n + 1), Sym α (n - i) :=
+def filterNe [DecidableEq α] (a : α) (m : Sym α n) : Σ i : Fin (n + 1), Sym α (n - i) :=
   ⟨⟨m.1.count a, (count_le_card _ _).trans_lt <| by rw [m.2, Nat.lt_succ_iff]⟩,
     m.1.filter (a ≠ ·),
     Nat.eq_sub_of_add_eq <|
@@ -505,7 +505,7 @@ def filterNe [DecidableEq α] (a : α) (m : Sym α n) : Σi : Fin (n + 1), Sym �
           rw [← card_eq_countP_add_countP _ _])
         m.2⟩
 
-theorem sigma_sub_ext {m₁ m₂ : Σi : Fin (n + 1), Sym α (n - i)} (h : (m₁.2 : Multiset α) = m₂.2) :
+theorem sigma_sub_ext {m₁ m₂ : Σ i : Fin (n + 1), Sym α (n - i)} (h : (m₁.2 : Multiset α) = m₂.2) :
     m₁ = m₂ :=
   Sigma.subtype_ext
     (Fin.ext <| by
@@ -524,7 +524,8 @@ theorem fill_filterNe [DecidableEq α] (a : α) (m : Sym α n) :
       · rw [if_pos rfl, if_neg (not_not.2 rfl), zero_add]
       · rw [if_pos h, if_neg h, add_zero])
 
-theorem filter_ne_fill [DecidableEq α] (a : α) (m : Σi : Fin (n + 1), Sym α (n - i)) (h : a ∉ m.2) :
+theorem filter_ne_fill
+    [DecidableEq α] (a : α) (m : Σ i : Fin (n + 1), Sym α (n - i)) (h : a ∉ m.2) :
     (m.2.fill a m.1).filterNe a = m :=
   sigma_sub_ext
     (by

--- a/Mathlib/Data/W/Basic.lean
+++ b/Mathlib/Data/W/Basic.lean
@@ -75,7 +75,7 @@ def equivSigma : WType β ≃ Σa : α, β a → WType β where
 def elim (γ : Type*) (fγ : (Σa : α, β a → γ) → γ) : WType β → γ
   | ⟨a, f⟩ => fγ ⟨a, fun b => elim γ fγ (f b)⟩
 
-theorem elim_injective (γ : Type*) (fγ : (Σa : α, β a → γ) → γ)
+theorem elim_injective (γ : Type*) (fγ : (Σ a : α, β a → γ) → γ)
     (fγ_injective : Function.Injective fγ) : Function.Injective (elim γ fγ)
   | ⟨a₁, f₁⟩, ⟨a₂, f₂⟩, h => by
     obtain ⟨rfl, h⟩ := Sigma.mk.inj_iff.mp (fγ_injective h)

--- a/Mathlib/GroupTheory/Perm/Sign.lean
+++ b/Mathlib/GroupTheory/Perm/Sign.lean
@@ -161,7 +161,7 @@ theorem isConj_swap {w x y z : α} (hwx : w ≠ x) (hyz : y ≠ z) : IsConj (swa
 def finPairsLT (n : ℕ) : Finset (Σ_ : Fin n, Fin n) :=
   (univ : Finset (Fin n)).sigma fun a => (range a).attachFin fun _ hm => (mem_range.1 hm).trans a.2
 
-theorem mem_finPairsLT {n : ℕ} {a : Σ_ : Fin n, Fin n} : a ∈ finPairsLT n ↔ a.2 < a.1 := by
+theorem mem_finPairsLT {n : ℕ} {a : Σ _ : Fin n, Fin n} : a ∈ finPairsLT n ↔ a.2 < a.1 := by
   simp only [finPairsLT, Fin.lt_iff_val_lt_val, true_and, mem_attachFin, mem_range, mem_univ,
     mem_sigma]
 

--- a/Mathlib/RingTheory/NonUnitalSubsemiring/Basic.lean
+++ b/Mathlib/RingTheory/NonUnitalSubsemiring/Basic.lean
@@ -711,7 +711,7 @@ namespace RingEquiv
 open NonUnitalRingHom NonUnitalSubsemiringClass
 
 variable {s t : NonUnitalSubsemiring R}
-variable [NonUnitalNonAssocSemiring S]  {F : Type*} [FunLike F R S] [NonUnitalRingHomClass F R S]
+variable [NonUnitalNonAssocSemiring S] {F : Type*} [FunLike F R S] [NonUnitalRingHomClass F R S]
 
 /-- Makes the identity isomorphism from a proof two non-unital subsemirings of a multiplicative
 monoid are equal. -/

--- a/Mathlib/SetTheory/Ordinal/Basic.lean
+++ b/Mathlib/SetTheory/Ordinal/Basic.lean
@@ -408,7 +408,7 @@ def typein (r : α → α → Prop) [IsWellOrder α r] : @PrincipalSeg α Ordina
 alias typein.principalSeg := typein
 
 set_option linter.deprecated false in
-@[deprecated "No deprecation message was provided."  (since := "2024-10-09")]
+@[deprecated "No deprecation message was provided." (since := "2024-10-09")]
 theorem typein.principalSeg_coe (r : α → α → Prop) [IsWellOrder α r] :
     (typein.principalSeg r : α → Ordinal) = typein r :=
   rfl
@@ -763,7 +763,7 @@ theorem mem_range_lift_of_le {a : Ordinal.{u}} {b : Ordinal.{max u v}} (h : b �
   liftInitialSeg.mem_range_of_le h
 
 @[deprecated mem_range_lift_of_le (since := "2024-10-07")]
-theorem lift_down {a : Ordinal.{u}} {b : Ordinal.{max u v}} (h : b ≤ lift.{v,u} a) :
+theorem lift_down {a : Ordinal.{u}} {b : Ordinal.{max u v}} (h : b ≤ lift.{v, u} a) :
     ∃ a', lift.{v,u} a' = b :=
   mem_range_lift_of_le h
 

--- a/Mathlib/Tactic/CategoryTheory/Monoidal/Datatypes.lean
+++ b/Mathlib/Tactic/CategoryTheory/Monoidal/Datatypes.lean
@@ -116,12 +116,12 @@ theorem StructuralOfExpr_monoidalComp {f g h i : C} [MonoidalCoherence g h]
 variable [MonoidalCategory C]
 
 theorem structuralIsoOfExpr_whiskerLeft (f : C) {g h : C}
-    (η : g ⟶ h) (η' : g ≅ h) (ih_η : η'.hom = η)  :
+    (η : g ⟶ h) (η' : g ≅ h) (ih_η : η'.hom = η) :
     (whiskerLeftIso f η').hom = f ◁ η := by
   simp [ih_η]
 
 theorem structuralIsoOfExpr_whiskerRight {f g : C} (h : C)
-    (η : f ⟶ g) (η' : f ≅ g) (ih_η : η'.hom = η)  :
+    (η : f ⟶ g) (η' : f ≅ g) (ih_η : η'.hom = η) :
     (whiskerRightIso η' h).hom = η ▷ h := by
   simp [ih_η]
 

--- a/Mathlib/Tactic/IntervalCases.lean
+++ b/Mathlib/Tactic/IntervalCases.lean
@@ -121,14 +121,14 @@ structure Methods where
 
 variable {α : Type*} {a b a' b' : α}
 
-theorem of_not_lt_left [LinearOrder α] (h : ¬(a:α) < b) (eq : a = a') : b ≤ a' := eq ▸ not_lt.1 h
-theorem of_not_lt_right [LinearOrder α] (h : ¬(a:α) < b) (eq : b = b') : b' ≤ a := eq ▸ not_lt.1 h
-theorem of_not_le_left [LE α] (h : ¬(a:α) ≤ b) (eq : a = a') : ¬a' ≤ b := eq ▸ h
-theorem of_not_le_right [LE α] (h : ¬(a:α) ≤ b) (eq : b = b') : ¬a ≤ b' := eq ▸ h
-theorem of_lt_left [LinearOrder α] (h : (a:α) < b) (eq : a = a') : ¬b ≤ a' := eq ▸ not_le.2 h
-theorem of_lt_right [LinearOrder α] (h : (a:α) < b) (eq : b = b') : ¬b' ≤ a := eq ▸ not_le.2 h
-theorem of_le_left [LE α] (h : (a:α) ≤ b) (eq : a = a') : a' ≤ b := eq ▸ h
-theorem of_le_right [LE α] (h : (a:α) ≤ b) (eq : b = b') : a ≤ b' := eq ▸ h
+theorem of_not_lt_left [LinearOrder α] (h : ¬(a : α) < b) (eq : a = a') : b ≤ a' := eq ▸ not_lt.1 h
+theorem of_not_lt_right [LinearOrder α] (h : ¬(a : α) < b) (eq : b = b') : b' ≤ a := eq ▸ not_lt.1 h
+theorem of_not_le_left [LE α] (h : ¬(a : α) ≤ b) (eq : a = a') : ¬a' ≤ b := eq ▸ h
+theorem of_not_le_right [LE α] (h : ¬(a : α) ≤ b) (eq : b = b') : ¬a ≤ b' := eq ▸ h
+theorem of_lt_left [LinearOrder α] (h : (a : α) < b) (eq : a = a') : ¬b ≤ a' := eq ▸ not_le.2 h
+theorem of_lt_right [LinearOrder α] (h : (a : α) < b) (eq : b = b') : ¬b' ≤ a := eq ▸ not_le.2 h
+theorem of_le_left [LE α] (h : (a : α) ≤ b) (eq : a = a') : a' ≤ b := eq ▸ h
+theorem of_le_right [LE α] (h : (a : α) ≤ b) (eq : b = b') : a ≤ b' := eq ▸ h
 
 /--
 Given a proof `pf`, attempts to parse it as an upper (`lb = false`) or lower (`lb = true`)

--- a/Mathlib/Tactic/LinearCombination/Lemmas.lean
+++ b/Mathlib/Tactic/LinearCombination/Lemmas.lean
@@ -22,18 +22,18 @@ variable {K : Type*} {t s : K}
 
 /-! ### Addition -/
 
-theorem add_eq_eq [Add α] (p₁ : (a₁:α) = b₁) (p₂ : a₂ = b₂) : a₁ + a₂ = b₁ + b₂ := p₁ ▸ p₂ ▸ rfl
+theorem add_eq_eq [Add α] (p₁ : (a₁ : α) = b₁) (p₂ : a₂ = b₂) : a₁ + a₂ = b₁ + b₂ := p₁ ▸ p₂ ▸ rfl
 
 theorem add_le_eq [OrderedAddCommMonoid α]
-    (p₁ : (a₁:α) ≤ b₁) (p₂ : a₂ = b₂) : a₁ + a₂ ≤ b₁ + b₂ :=
+    (p₁ : (a₁ : α) ≤ b₁) (p₂ : a₂ = b₂) : a₁ + a₂ ≤ b₁ + b₂ :=
   p₂ ▸ add_le_add_right p₁ b₂
 
 theorem add_eq_le [OrderedAddCommMonoid α]
-    (p₁ : (a₁:α) = b₁) (p₂ : a₂ ≤ b₂) : a₁ + a₂ ≤ b₁ + b₂ :=
+    (p₁ : (a₁ : α) = b₁) (p₂ : a₂ ≤ b₂) : a₁ + a₂ ≤ b₁ + b₂ :=
   p₁ ▸ add_le_add_left p₂ b₁
 
 theorem add_lt_eq [OrderedCancelAddCommMonoid α]
-    (p₁ : (a₁:α) < b₁) (p₂ : a₂ = b₂) : a₁ + a₂ < b₁ + b₂ :=
+    (p₁ : (a₁ : α) < b₁) (p₂ : a₂ = b₂) : a₁ + a₂ < b₁ + b₂ :=
   p₂ ▸ add_lt_add_right p₁ b₂
 
 theorem add_eq_lt [OrderedCancelAddCommMonoid α] {a₁ b₁ a₂ b₂ : α}
@@ -122,35 +122,36 @@ theorem div_lt_const_weak [LinearOrderedSemifield α] (p : b < c) {a : α} (ha :
 
 /-! ### Lemmas constructing the reduction of a goal to a specified built-up hypothesis -/
 
-theorem eq_of_eq [Add α] [IsRightCancelAdd α] (p : (a:α) = b) (H : a' + b = b' + a) : a' = b' := by
+theorem eq_of_eq [Add α] [IsRightCancelAdd α] (p : (a : α) = b) (H : a' + b = b' + a) :
+    a' = b' := by
   rw [p] at H
   exact add_right_cancel H
 
-theorem le_of_le [OrderedCancelAddCommMonoid α] (p : (a:α) ≤ b) (H : a' + b ≤ b' + a) :
+theorem le_of_le [OrderedCancelAddCommMonoid α] (p : (a : α) ≤ b) (H : a' + b ≤ b' + a) :
     a' ≤ b' := by
   rw [← add_le_add_iff_right b]
   apply H.trans
   apply add_le_add_left p
 
-theorem le_of_eq [OrderedCancelAddCommMonoid α] (p : (a:α) = b) (H : a' + b ≤ b' + a) :
+theorem le_of_eq [OrderedCancelAddCommMonoid α] (p : (a : α) = b) (H : a' + b ≤ b' + a) :
     a' ≤ b' := by
   rwa [p, add_le_add_iff_right] at H
 
-theorem le_of_lt [OrderedCancelAddCommMonoid α] (p : (a:α) < b) (H : a' + b ≤ b' + a) :
+theorem le_of_lt [OrderedCancelAddCommMonoid α] (p : (a : α) < b) (H : a' + b ≤ b' + a) :
     a' ≤ b' :=
   le_of_le p.le H
 
-theorem lt_of_le [OrderedCancelAddCommMonoid α] (p : (a:α) ≤ b) (H : a' + b < b' + a) :
+theorem lt_of_le [OrderedCancelAddCommMonoid α] (p : (a : α) ≤ b) (H : a' + b < b' + a) :
     a' < b' := by
   rw [← add_lt_add_iff_right b]
   apply H.trans_le
   apply add_le_add_left p
 
-theorem lt_of_eq [OrderedCancelAddCommMonoid α] (p : (a:α) = b) (H : a' + b < b' + a) :
+theorem lt_of_eq [OrderedCancelAddCommMonoid α] (p : (a : α) = b) (H : a' + b < b' + a) :
     a' < b' := by
   rwa [p, add_lt_add_iff_right] at H
 
-theorem lt_of_lt [OrderedCancelAddCommMonoid α] (p : (a:α) < b) (H : a' + b ≤ b' + a) :
+theorem lt_of_lt [OrderedCancelAddCommMonoid α] (p : (a : α) < b) (H : a' + b ≤ b' + a) :
     a' < b' := by
   rw [← add_lt_add_iff_right b]
   apply H.trans_lt
@@ -164,8 +165,8 @@ theorem le_rearrange {α : Type*} [OrderedAddCommGroup α] {a b : α} (h : a - b
 theorem lt_rearrange {α : Type*} [OrderedAddCommGroup α] {a b : α} (h : a - b < 0) : a < b :=
   sub_neg.mp h
 
-theorem eq_of_add_pow [Ring α] [NoZeroDivisors α] (n : ℕ) (p : (a:α) = b)
-    (H : (a' - b')^n - (a - b) = 0) : a' = b' := by
+theorem eq_of_add_pow [Ring α] [NoZeroDivisors α] (n : ℕ) (p : (a : α) = b)
+    (H : (a' - b') ^ n - (a - b) = 0) : a' = b' := by
   rw [← sub_eq_zero] at p ⊢; apply pow_eq_zero (n := n); rwa [sub_eq_zero, p] at H
 
 end Tactic.LinearCombination


### PR DESCRIPTION
Found by #22760.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
