### PR TITLE
feat: Category algebras and path algebras

### DIFF
--- a/Mathlib/Algebra/Ring/Assoc.lean
+++ b/Mathlib/Algebra/Ring/Assoc.lean
@@ -1,0 +1,41 @@
+/-
+Copyright (c) 2025 Bernhard Reinke. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Bernhard Reinke
+-/
+import Mathlib.Algebra.Ring.Defs
+import Mathlib.Algebra.Group.Hom.End
+
+universe u
+
+variable (R : Type u) [NonUnitalNonAssocSemiring R]
+
+namespace AddMonoidHom
+
+def mull₃ : R →+ R →+ R →+ R where
+  toFun x := comp mul (mulLeft x)
+  map_zero' := by ext; simp
+  map_add' := fun x y => by ext; simp [add_mul]
+
+@[simp]
+theorem mull₃_apply (x y z : R) : mull₃ R x y z = (x * y) * z := by simp [mull₃]
+
+def mulr₃ : R →+ R →+ R →+ R where
+  toFun x := compr₂ mul (mulLeft x)
+  map_zero' := by ext; simp
+  map_add' := fun x y => by ext; simp [add_mul]
+
+@[simp]
+theorem mulr₃_apply (x y z : R) : mulr₃ R x y z = x * (y * z) := by simp [mulr₃]
+
+theorem associative_iff_mull₃_eq_mulr₃ : (∀ (x y z : R), (x * y) * z = x * (y * z)) ↔
+  mull₃ R = mulr₃ R := by
+  constructor
+  · intro h
+    ext x y z
+    simp [h x y z]
+  · intro h x y z
+    rw [← mull₃_apply, ← mulr₃_apply, h]
+
+
+end AddMonoidHom

--- a/Mathlib/CategoryTheory/Linear/CategoryAlgebra.lean
+++ b/Mathlib/CategoryTheory/Linear/CategoryAlgebra.lean
@@ -1,9 +1,15 @@
+/-
+Copyright (c) 2025 Bernhard Reinke. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Bernhard Reinke
+-/
 import Mathlib.Algebra.Module.BigOperators
 import Mathlib.Algebra.DirectSum.Basic
 import Mathlib.Algebra.DirectSum.Module
 import Mathlib.CategoryTheory.Linear.Basic
+import Mathlib.Algebra.Ring.Assoc
 
-universe w v u
+universe w' w v u
 
 namespace CategoryTheory.Linear
 
@@ -32,9 +38,16 @@ instance CategoryAlgebra.instModule : Module R (CategoryAlgebra R C) :=
 def CategoryAlgebra.of (a b : C) : (a ⟶ b) →+ CategoryAlgebra R C :=
   DirectSum.of (fun (p : C × C) ↦ p.1 ⟶ p.2) (a,b)
 
-@[simps]
-def comp' (X Y Z W : C) (h : Y = Z) : (X ⟶ Y) →+ (Z ⟶ W) →+ (CategoryAlgebra R C) where
-  toFun f := AddMonoidHom.comp (CategoryAlgebra.of X W) (compHom (f ≫ eqToHom h))
+theorem CategoryAlgebra.addHom_ext {γ : Type w'} [AddZeroClass γ] ⦃f g : CategoryAlgebra R C →+ γ⦄
+    (H : ∀ (X Y : C) (y : X ⟶ Y), f (CategoryAlgebra.of X Y y) = g (CategoryAlgebra.of X Y y)) :
+    f = g := DFinsupp.addHom_ext (fun p => H p.1 p.2)
+
+theorem CategoryAlgebra.of_eq_single (a b : C) (f : a ⟶ b) :
+    (CategoryAlgebra.of a b f : CategoryAlgebra R C) =
+    DFinsupp.single (a,b) f := by rfl
+
+def compEq (X Y Z W : C) (h : Y = Z) : (X ⟶ Y) →+ (Z ⟶ W) →+ (X ⟶ W) where
+  toFun f := compHom (f ≫ eqToHom h)
   map_add' := by
     intros
     ext
@@ -43,25 +56,86 @@ def comp' (X Y Z W : C) (h : Y = Z) : (X ⟶ Y) →+ (Z ⟶ W) →+ (CategoryAlg
     ext
     simp
 
-def comp'' (X Y Z W : C) : (X ⟶ Y) →+ (Z ⟶ W) →+ (CategoryAlgebra R C) :=
-  if h : Y = Z then comp' X Y Z W h else 0
+def comp₀ (X Y Z W : C): (X ⟶ Y) →+ (Z ⟶ W) →+ (X ⟶ W) :=
+  if h : Y = Z then compEq X Y Z W h else 0
 
-@[irreducible] def mul' (f g : CategoryAlgebra R C) : CategoryAlgebra R C :=
-  DFinsupp.sumAddHom (fun p ↦ DFinsupp.sumAddHom (fun q ↦ comp'' q.1 q.2 p.1 p.2) g) f
+theorem comp₀_assoc (X₁ Y₁ X₂ Y₂ X₃ Y₃ : C) (f : X₁ ⟶ Y₁) (g : X₂ ⟶ Y₂) (h : X₃ ⟶ Y₃) :
+    ((comp₀ X₁ Y₂ X₃ Y₃) (((comp₀ X₁ Y₁ X₂ Y₂) f) g)) h =
+    ((comp₀ X₁ Y₁ X₂ Y₃) f) (((comp₀ X₂ Y₂ X₃ Y₃) g) h)
+    := by
+  by_cases h₁₂ : Y₁ = X₂ <;> by_cases h₂₃ : Y₂ = X₃ <;>
+  simp [comp₀, compEq, h₁₂, h₂₃, compHom, Preadditive.leftComp]
 
-instance instMul : Mul (CategoryAlgebra R C) := ⟨mul'⟩
+@[irreducible] def mul' : CategoryAlgebra R C →+ CategoryAlgebra R C →+ CategoryAlgebra R C :=
+  DFinsupp.sumAddHom₂ (fun q p ↦ AddMonoidHom.compr₂
+    (comp₀ q.1 q.2 p.1 p.2) (CategoryAlgebra.of q.1 p.2))
+
+instance instMul : Mul (CategoryAlgebra R C) := ⟨fun f g => mul' f g⟩
 
 theorem mul_def (f g : CategoryAlgebra R C) :
-  f * g = DFinsupp.sumAddHom (fun p ↦ DFinsupp.sumAddHom (fun q ↦ comp'' q.1 q.2 p.1 p.2) g) f := by
+    f * g = DFinsupp.sumAddHom₂ (fun q p ↦ AddMonoidHom.compr₂
+    (comp₀ q.1 q.2 p.1 p.2) (CategoryAlgebra.of q.1 p.2)) f g := by
   with_unfolding_all rfl
 
-instance : NonUnitalSemiring (CategoryAlgebra R C) where
-  mul := mul'
+instance : NonUnitalNonAssocSemiring (CategoryAlgebra R C) where
   left_distrib := fun a b c => by simp [mul_def]
   right_distrib := fun a b c => by simp [mul_def]
   zero_mul := fun a => by simp [mul_def]
   mul_zero := fun a => by simp [mul_def]
-  mul_assoc := fun a b c => by sorry
 
+theorem mul_of (X₁ Y₁ X₂ Y₂ : C) (f : X₁ ⟶ Y₁) (g : X₂ ⟶ Y₂) :
+    (CategoryAlgebra.of X₁ Y₁ f) * (CategoryAlgebra.of X₂ Y₂ g : (CategoryAlgebra R C)) =
+    CategoryAlgebra.of X₁ Y₂ (comp₀ X₁ Y₁ X₂ Y₂ f g) := by
+  simp [mul_def, CategoryAlgebra.of_eq_single, DFinsupp.sumAddHom₂_single]
 
+instance : NonUnitalSemiring (CategoryAlgebra R C) where
+  mul_assoc := by
+    rw [AddMonoidHom.associative_iff_mull₃_eq_mulr₃]
+    apply CategoryAlgebra.addHom_ext
+    rintro X₁ Y₁ f
+    apply CategoryAlgebra.addHom_ext
+    rintro X₂ Y₂ g
+    apply CategoryAlgebra.addHom_ext
+    rintro X₃ Y₃ h
+    simp only [AddMonoidHom.mull₃, AddMonoidHom.mul, AddMonoidHom.mulLeft, AddMonoidHom.coe_mk,
+      ZeroHom.coe_mk, AddMonoidHom.coe_comp, Function.comp_apply, mul_of, AddMonoidHom.mulr₃,
+      AddMonoidHom.compr₂, AddMonoidHom.compHom_apply_apply]
+    apply congrArg
+    apply comp₀_assoc
+
+section Unital
+
+variable [Fintype C]
+
+def one' : CategoryAlgebra R C :=  ∑ i : C, (CategoryAlgebra.of i i (𝟙 i))
+
+instance : One (CategoryAlgebra R C) := ⟨one'⟩
+
+theorem one_def : (1 : CategoryAlgebra R C) = ∑ i : C, (CategoryAlgebra.of i i (𝟙 i)) := rfl
+
+instance [Fintype C] : Semiring (CategoryAlgebra R C) where
+  one_mul := by
+    have H : (AddMonoidHom.mulLeft (1 : (CategoryAlgebra R C)) = (AddMonoidHom.id _)) := by
+      apply CategoryAlgebra.addHom_ext
+      rintro X₁ Y₁ f
+      simp only [AddMonoidHom.mulLeft, one_def, Finset.sum_mul, AddMonoidHom.coe_mk, ZeroHom.coe_mk,
+        mul_of, AddMonoidHom.id_apply]
+      rw [Finset.sum_eq_single_of_mem X₁ (Finset.mem_univ _)]
+      · simp [comp₀, compEq, compHom, Preadditive.leftComp]
+      · intro b _ h
+        simp [comp₀, h]
+    apply DFunLike.congr_fun (h₁ := H)
+  mul_one := by
+    have H : (AddMonoidHom.mulRight (1 : (CategoryAlgebra R C)) = (AddMonoidHom.id _)) := by
+      apply CategoryAlgebra.addHom_ext
+      rintro X₁ Y₁ f
+      simp only [AddMonoidHom.mulRight, one_def, Finset.mul_sum, AddMonoidHom.coe_mk,
+        ZeroHom.coe_mk, mul_of, AddMonoidHom.id_apply]
+      rw [Finset.sum_eq_single_of_mem Y₁ (Finset.mem_univ _)]
+      · simp [comp₀, compEq, compHom, Preadditive.leftComp]
+      · intro b _ h
+        simp [comp₀, h.symm]
+    apply DFunLike.congr_fun (h₁ := H)
+
+end Unital
 end CategoryTheory.Linear

--- a/Mathlib/CategoryTheory/Linear/CategoryAlgebra.lean
+++ b/Mathlib/CategoryTheory/Linear/CategoryAlgebra.lean
@@ -1,0 +1,67 @@
+import Mathlib.Algebra.Module.BigOperators
+import Mathlib.Algebra.DirectSum.Basic
+import Mathlib.Algebra.DirectSum.Module
+import Mathlib.CategoryTheory.Linear.Basic
+
+universe w v u
+
+namespace CategoryTheory.Linear
+
+open DirectSum
+open CategoryTheory.Preadditive
+
+def CategoryAlgebra (R : Type w) [CommSemiring R] (C : Type u) [Category.{v} C] [Preadditive C]
+  [Linear R C] := ⨁ (p : C × C), p.1 ⟶ p.2
+
+variable {R : Type w} [CommSemiring R] {C : Type u} [Category.{v} C] [Preadditive C]
+  [Linear R C] [DecidableEq C]
+
+
+instance CategoryAlgebra.inhabited : Inhabited (CategoryAlgebra R C) :=
+  inferInstanceAs (Inhabited (⨁ (p : C × C), p.1 ⟶ p.2))
+
+instance CategoryAlgebra.addCommMonoid : AddCommMonoid (CategoryAlgebra R C) :=
+  inferInstanceAs (AddCommMonoid (⨁ (p : C × C), p.1 ⟶ p.2))
+
+instance CategoryAlgebra.instIsCancelAdd [IsCancelAdd R] : IsCancelAdd (CategoryAlgebra R C) :=
+  inferInstanceAs (IsCancelAdd (⨁ (p : C × C), p.1 ⟶ p.2))
+
+instance CategoryAlgebra.instModule : Module R (CategoryAlgebra R C) :=
+  inferInstanceAs (Module R (⨁ (p : C × C), p.1 ⟶ p.2))
+
+def CategoryAlgebra.of (a b : C) : (a ⟶ b) →+ CategoryAlgebra R C :=
+  DirectSum.of (fun (p : C × C) ↦ p.1 ⟶ p.2) (a,b)
+
+@[simps]
+def comp' (X Y Z W : C) (h : Y = Z) : (X ⟶ Y) →+ (Z ⟶ W) →+ (CategoryAlgebra R C) where
+  toFun f := AddMonoidHom.comp (CategoryAlgebra.of X W) (compHom (f ≫ eqToHom h))
+  map_add' := by
+    intros
+    ext
+    simp
+  map_zero' := by
+    ext
+    simp
+
+def comp'' (X Y Z W : C) : (X ⟶ Y) →+ (Z ⟶ W) →+ (CategoryAlgebra R C) :=
+  if h : Y = Z then comp' X Y Z W h else 0
+
+@[irreducible] def mul' (f g : CategoryAlgebra R C) : CategoryAlgebra R C :=
+  DFinsupp.sumAddHom (fun p ↦ DFinsupp.sumAddHom (fun q ↦ comp'' q.1 q.2 p.1 p.2) g) f
+
+instance instMul : Mul (CategoryAlgebra R C) := ⟨mul'⟩
+
+theorem mul_def (f g : CategoryAlgebra R C) :
+  f * g = DFinsupp.sumAddHom (fun p ↦ DFinsupp.sumAddHom (fun q ↦ comp'' q.1 q.2 p.1 p.2) g) f := by
+  with_unfolding_all rfl
+
+instance : NonUnitalSemiring (CategoryAlgebra R C) where
+  mul := mul'
+  left_distrib := fun a b c => by simp [mul_def]
+  right_distrib := fun a b c => by simp [mul_def]
+  zero_mul := fun a => by simp [mul_def]
+  mul_zero := fun a => by simp [mul_def]
+  mul_assoc := fun a b c => by sorry
+
+
+end CategoryTheory.Linear

--- a/Mathlib/Combinatorics/Quiver/PathAlgebra.lean
+++ b/Mathlib/Combinatorics/Quiver/PathAlgebra.lean
@@ -1,44 +1,24 @@
-import Mathlib.Combinatorics.Quiver.Path
+import Mathlib.Algebra.Category.ModuleCat.Adjunctions
 import Mathlib.Algebra.Group.WithOne.Defs
 import Mathlib.Algebra.GroupWithZero.Defs
-import Mathlib.Combinatorics.Quiver.Cast
+import Mathlib.CategoryTheory.Linear.CategoryAlgebra
 import Mathlib.CategoryTheory.PathCategory.Basic
-universe v u
+import Mathlib.Combinatorics.Quiver.Path
+import Mathlib.Combinatorics.Quiver.Cast
+universe w v u
 
 namespace Quiver
 
-namespace Path
+open CategoryTheory.Linear
 
-def hnil {V : Type u} [Quiver.{v} V] {a b : V} (h : a = b) : Path a b :
-
-end Path
-
-namespace PathAlgebra
-
-inductive TotalPath (V : Type u) [Quiver.{v} V] : Type max (u + 1) v
-  | mk : ∀ (a b : V), Path a b → TotalPath V
+/- TODO: does not work, why? -/
+--  def PathAlgebra (R : Type w) [CommRing R] {V : Type u} [Quiver.{v} V] :=
+--    CategoryAlgebra R (CategoryTheory.Free R (CategoryTheory.Paths V))
 
 
-instance {V : Type u} [Quiver.{v} V] [DecidableEq V] : Mul (WithZero (TotalPath V)) where
-  mul := fun p q ↦ match p, q with
-  | 0, _ => 0
-  | _, 0 => 0
-  | some (.mk a b p), some (.mk c d q) =>
-    if h : (b = c) then some (TotalPath.mk a d (p.comp (h ▸ q))) else 0
-
-instance {V : Type u} [Quiver.{v} V] [DecidableEq V] : SemigroupWithZero (WithZero (TotalPath V)) where
-  zero_mul := fun p => by cases p <;> rfl
-  mul_zero := fun p => by cases p <;> rfl
-  mul_assoc := fun p q r => by
-    cases p <;> cases q <;> cases r <;> try rfl
-    next p q => cases ((p : WithZero (TotalPath V)) * q) <;> rfl
-    next p q => cases ((p : WithZero (TotalPath V)) * q) <;> rfl
-    next p q r =>
-      cases p
-      cases q
-      cases r
+def PathAlgebra (R : Type w) [CommRing R] {V : Type u} [Quiver.{v} V] :=
+  @CategoryAlgebra R inferInstance (CategoryTheory.Free R (CategoryTheory.Paths V))
 
 
-end PathAlgebra
 
 end Quiver

--- a/Mathlib/Combinatorics/Quiver/PathAlgebra.lean
+++ b/Mathlib/Combinatorics/Quiver/PathAlgebra.lean
@@ -1,0 +1,44 @@
+import Mathlib.Combinatorics.Quiver.Path
+import Mathlib.Algebra.Group.WithOne.Defs
+import Mathlib.Algebra.GroupWithZero.Defs
+import Mathlib.Combinatorics.Quiver.Cast
+import Mathlib.CategoryTheory.PathCategory.Basic
+universe v u
+
+namespace Quiver
+
+namespace Path
+
+def hnil {V : Type u} [Quiver.{v} V] {a b : V} (h : a = b) : Path a b :
+
+end Path
+
+namespace PathAlgebra
+
+inductive TotalPath (V : Type u) [Quiver.{v} V] : Type max (u + 1) v
+  | mk : ∀ (a b : V), Path a b → TotalPath V
+
+
+instance {V : Type u} [Quiver.{v} V] [DecidableEq V] : Mul (WithZero (TotalPath V)) where
+  mul := fun p q ↦ match p, q with
+  | 0, _ => 0
+  | _, 0 => 0
+  | some (.mk a b p), some (.mk c d q) =>
+    if h : (b = c) then some (TotalPath.mk a d (p.comp (h ▸ q))) else 0
+
+instance {V : Type u} [Quiver.{v} V] [DecidableEq V] : SemigroupWithZero (WithZero (TotalPath V)) where
+  zero_mul := fun p => by cases p <;> rfl
+  mul_zero := fun p => by cases p <;> rfl
+  mul_assoc := fun p q r => by
+    cases p <;> cases q <;> cases r <;> try rfl
+    next p q => cases ((p : WithZero (TotalPath V)) * q) <;> rfl
+    next p q => cases ((p : WithZero (TotalPath V)) * q) <;> rfl
+    next p q r =>
+      cases p
+      cases q
+      cases r
+
+
+end PathAlgebra
+
+end Quiver

--- a/Mathlib/Data/DFinsupp/BigOperators.lean
+++ b/Mathlib/Data/DFinsupp/BigOperators.lean
@@ -293,6 +293,18 @@ theorem sumAddHom_comm {ι₁ ι₂ : Sort _} {β₁ : ι₁ → Type*} {β₂ :
     AddMonoidHom.flip_apply, Trunc.lift, toFun_eq_coe, ZeroHom.coe_mk, coe_mk']
   exact Finset.sum_comm
 
+def sumAddHom₂ {ι₁ ι₂ : Sort _} {β₁ : ι₁ → Type*} {β₂ : ι₂ → Type*} {γ : Type*}
+    [DecidableEq ι₁] [DecidableEq ι₂] [∀ i, AddZeroClass (β₁ i)] [∀ i, AddZeroClass (β₂ i)]
+    [AddCommMonoid γ] (h : ∀ i j, β₁ i →+ β₂ j →+ γ) : (Π₀ i, β₁ i) →+ (Π₀ j, β₂ j) →+ γ :=
+  sumAddHom (fun i₁ ↦ AddMonoidHom.flip (sumAddHom (fun i₂ ↦ (h i₁ i₂).flip)))
+
+@[simp]
+theorem sumAddHom₂_single {ι₁ ι₂ : Sort _} {β₁ : ι₁ → Type*} {β₂ : ι₂ → Type*} {γ : Type*}
+    [DecidableEq ι₁] [DecidableEq ι₂] [∀ i, AddZeroClass (β₁ i)] [∀ i, AddZeroClass (β₂ i)]
+    [AddCommMonoid γ] (h : ∀ i j, β₁ i →+ β₂ j →+ γ) (i₁ i₂) (x : β₁ i₁) (y : β₂ i₂) :
+    sumAddHom₂ h (single i₁ x) (single i₂ y) = h i₁ i₂ x y := by
+  simp [sumAddHom₂]
+
 /-- The `DFinsupp` version of `Finsupp.liftAddHom` -/
 @[simps apply symm_apply]
 def liftAddHom [∀ i, AddZeroClass (β i)] [AddCommMonoid γ] :


### PR DESCRIPTION
This PR defines the category algebra of a linear category and path algebras of quivers.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
