### PR TITLE
[Merged by Bors] - feat(Data/Nat/Find): Nat.find_mono_of_le and Nat.find_congr

### DIFF
--- a/Mathlib/Data/Nat/Find.lean
+++ b/Mathlib/Data/Nat/Find.lean
@@ -97,6 +97,11 @@ variable [DecidablePred q] in
 lemma find_mono (h : ∀ n, q n → p n) {hp : ∃ n, p n} {hq : ∃ n, q n} : Nat.find hp ≤ Nat.find hq :=
   Nat.find_min' _ (h _ (Nat.find_spec hq))
 
+variable [DecidablePred q] in
+lemma find_congr {hp : ∃ n, p n} {hq : ∃ n, q n} (hpq : ∀ {n}, p n ↔ q n) :
+    Nat.find hp = Nat.find hq :=
+  le_antisymm (find_mono fun _ ↦ hpq.mpr) (find_mono fun _ ↦ hpq.mp)
+
 lemma find_le {h : ∃ n, p n} (hn : p n) : Nat.find h ≤ n :=
   (Nat.find_le_iff _ _).2 ⟨n, le_refl _, hn⟩
 

--- a/Mathlib/Data/Nat/Find.lean
+++ b/Mathlib/Data/Nat/Find.lean
@@ -101,10 +101,10 @@ lemma find_mono_of_le [DecidablePred q] {x : ℕ} (hx : q x) (hpq : ∀ n ≤ x,
     Nat.find ⟨x, show p x from hpq _ le_rfl hx⟩ ≤ Nat.find ⟨x, hx⟩ :=
   Nat.find_min' _ (hpq _ (Nat.find_min' _ hx) (Nat.find_spec ⟨x, hx⟩))
 
-variable [DecidablePred q] in
 /-- A weak version of `Nat.find_mono_of_le`, which does not require that `q` implies `p` everywhere.
 -/
-lemma find_mono (h : ∀ n, q n → p n) {hp : ∃ n, p n} {hq : ∃ n, q n} : Nat.find hp ≤ Nat.find hq :=
+lemma find_mono [DecidablePred q] (h : ∀ n, q n → p n) {hp : ∃ n, p n} {hq : ∃ n, q n} :
+    Nat.find hp ≤ Nat.find hq :=
   find_mono_of_le hq.choose_spec fun _ _ ↦ h _
 
 /-- If a predicate `p` holds at some `x` and agrees with `q` up to that `x`, then

--- a/Mathlib/Data/Nat/Find.lean
+++ b/Mathlib/Data/Nat/Find.lean
@@ -97,7 +97,6 @@ variable [DecidablePred q] in
 lemma find_mono (h : ∀ n, q n → p n) {hp : ∃ n, p n} {hq : ∃ n, q n} : Nat.find hp ≤ Nat.find hq :=
   Nat.find_min' _ (h _ (Nat.find_spec hq))
 
-@[congr]
 lemma find_congr [DecidablePred q] {hp : ∃ n, p n} {hq : ∃ n, q n} (hpq : ∀ {n}, p n ↔ q n) :
     Nat.find hp = Nat.find hq :=
   le_antisymm (find_mono fun _ ↦ hpq.mpr) (find_mono fun _ ↦ hpq.mp)

--- a/Mathlib/Data/Nat/Find.lean
+++ b/Mathlib/Data/Nat/Find.lean
@@ -97,8 +97,8 @@ variable [DecidablePred q] in
 lemma find_mono (h : ∀ n, q n → p n) {hp : ∃ n, p n} {hq : ∃ n, q n} : Nat.find hp ≤ Nat.find hq :=
   Nat.find_min' _ (h _ (Nat.find_spec hq))
 
-variable [DecidablePred q] in
-lemma find_congr {hp : ∃ n, p n} {hq : ∃ n, q n} (hpq : ∀ {n}, p n ↔ q n) :
+@[congr]
+lemma find_congr [DecidablePred q] {hp : ∃ n, p n} {hq : ∃ n, q n} (hpq : ∀ {n}, p n ↔ q n) :
     Nat.find hp = Nat.find hq :=
   le_antisymm (find_mono fun _ ↦ hpq.mpr) (find_mono fun _ ↦ hpq.mp)
 

--- a/Mathlib/Data/Nat/Find.lean
+++ b/Mathlib/Data/Nat/Find.lean
@@ -101,7 +101,7 @@ lemma find_mono_of_le [DecidablePred q] {x : ℕ} (hx : q x) (hpq : ∀ n ≤ x,
     Nat.find ⟨x, show p x from hpq _ le_rfl hx⟩ ≤ Nat.find ⟨x, hx⟩ :=
   Nat.find_min' _ (hpq _ (Nat.find_min' _ hx) (Nat.find_spec ⟨x, hx⟩))
 
-/-- A weak version of `Nat.find_mono_of_le`, which does not require that `q` implies `p` everywhere.
+/-- A weak version of `Nat.find_mono_of_le`, requiring `q` implies `p` everywhere.
 -/
 lemma find_mono [DecidablePred q] (h : ∀ n, q n → p n) {hp : ∃ n, p n} {hq : ∃ n, q n} :
     Nat.find hp ≤ Nat.find hq :=
@@ -118,7 +118,7 @@ lemma find_congr [DecidablePred q] {x : ℕ} (hx : p x) (hpq : ∀ n ≤ x, p n 
   le_antisymm (find_mono_of_le (hpq _ le_rfl |>.1 hx) fun _ h ↦ (hpq _ h).mpr)
     (find_mono_of_le hx fun _ h ↦ (hpq _ h).mp)
 
-/-- A weak version of `Nat.find_congr`, which does not require `p = q` everywhere. -/
+/-- A weak version of `Nat.find_congr`, requiring `p = q` everywhere. -/
 lemma find_congr' [DecidablePred q] {hp : ∃ n, p n} {hq : ∃ n, q n} (hpq : ∀ {n}, p n ↔ q n) :
     Nat.find hp = Nat.find hq :=
   let ⟨_, hp⟩ := hp; find_congr hp fun _ _ ↦ hpq

--- a/Mathlib/Data/Nat/Find.lean
+++ b/Mathlib/Data/Nat/Find.lean
@@ -105,7 +105,7 @@ lemma find_mono_of_le [DecidablePred q] {x : ℕ} (hx : q x) (hpq : ∀ n ≤ x,
 -/
 lemma find_mono [DecidablePred q] (h : ∀ n, q n → p n) {hp : ∃ n, p n} {hq : ∃ n, q n} :
     Nat.find hp ≤ Nat.find hq :=
-  find_mono_of_le hq.choose_spec fun _ _ ↦ h _
+  let ⟨_, hq⟩ := hq; find_mono_of_le hq fun _ _ ↦ h _
 
 /-- If a predicate `p` holds at some `x` and agrees with `q` up to that `x`, then
 their `Nat.find` agree. The stronger version of `Nat.find_congr'`, since this one needs
@@ -121,7 +121,7 @@ lemma find_congr [DecidablePred q] {x : ℕ} (hx : p x) (hpq : ∀ n ≤ x, p n 
 /-- A weak version of `Nat.find_congr`, which does not require `p = q` everywhere. -/
 lemma find_congr' [DecidablePred q] {hp : ∃ n, p n} {hq : ∃ n, q n} (hpq : ∀ {n}, p n ↔ q n) :
     Nat.find hp = Nat.find hq :=
-  find_congr hp.choose_spec fun _ _ ↦ hpq
+  let ⟨_, hp⟩ := hp; find_congr hp fun _ _ ↦ hpq
 
 lemma find_le {h : ∃ n, p n} (hn : p n) : Nat.find h ≤ n :=
   (Nat.find_le_iff _ _).2 ⟨n, le_refl _, hn⟩


### PR DESCRIPTION
Both strong versions (p and q agree below some x) and weak (p and q agree everywhere)

helper for not juggling generalize_proofs


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
