### PR TITLE
[Merged by Bors] - chore(Data/Multiset): clean up porting notes

### DIFF
--- a/Mathlib/Data/Multiset/Antidiagonal.lean
+++ b/Mathlib/Data/Multiset/Antidiagonal.lean
@@ -35,8 +35,6 @@ theorem antidiagonal_coe (l : List α) : @antidiagonal α l = revzip (powersetAu
 theorem antidiagonal_coe' (l : List α) : @antidiagonal α l = revzip (powersetAux' l) :=
   Quot.sound revzip_powersetAux_perm_aux'
 
-/- Porting note: `simp` seemed to be applying `antidiagonal_coe'` instead of `antidiagonal_coe`
-in what used to be `simp [antidiagonal_coe]`. -/
 /-- A pair `(t₁, t₂)` of multisets is contained in `antidiagonal s`
     if and only if `t₁ + t₂ = s`. -/
 @[simp]
@@ -45,7 +43,7 @@ theorem mem_antidiagonal {s : Multiset α} {x : Multiset α × Multiset α} :
   Quotient.inductionOn s fun l ↦ by
     dsimp only [quot_mk_to_coe, antidiagonal_coe]
     refine ⟨fun h => revzip_powersetAux h, fun h ↦ ?_⟩
-    haveI := Classical.decEq α
+    have _ := Classical.decEq α
     simp only [revzip_powersetAux_lemma l revzip_powersetAux, h.symm, mem_coe,
       List.mem_map, mem_powersetAux]
     obtain ⟨x₁, x₂⟩ := x

--- a/Mathlib/Data/Multiset/Basic.lean
+++ b/Mathlib/Data/Multiset/Basic.lean
@@ -95,7 +95,6 @@ def strongDownwardInduction {p : Multiset α → Sort*} {n : ℕ}
     strongDownwardInduction H t ht
 termination_by n - card s
 decreasing_by simp_wf; have := (card_lt_card _h); omega
--- Porting note: reorderd universes
 
 theorem strongDownwardInduction_eq {p : Multiset α → Sort*} {n : ℕ}
     (H : ∀ t₁, (∀ {t₂ : Multiset α}, card t₂ ≤ n → t₁ < t₂ → p t₂) → card t₁ ≤ n → p t₁)

--- a/Mathlib/Data/Multiset/Bind.lean
+++ b/Mathlib/Data/Multiset/Bind.lean
@@ -193,7 +193,7 @@ theorem le_bind {α β : Type*} {f : α → Multiset β} (S : Multiset α) {x : 
   rw [count_bind, hm', sum_cons]
   exact Nat.le_add_right _ _
 
--- Porting note (https://github.com/leanprover-community/mathlib4/issues/11119): @[simp] removed because not in normal form
+@[simp]
 theorem attach_bind_coe (s : Multiset α) (f : α → Multiset β) :
     (s.attach.bind fun i => f i) = s.bind f :=
   congr_arg join <| attach_map_val' _ _
@@ -217,7 +217,7 @@ lemma dedup_bind_dedup [DecidableEq α] [DecidableEq β] (s : Multiset α) (f : 
   ext x
   -- Porting note: was `simp_rw [count_dedup, mem_bind, mem_dedup]`
   simp_rw [count_dedup]
-  refine if_congr ?_ rfl rfl
+  congr 1
   simp
 
 variable (op : α → α → α) [hc : Std.Commutative op] [ha : Std.Associative op]

--- a/Mathlib/Data/Multiset/Count.lean
+++ b/Mathlib/Data/Multiset/Count.lean
@@ -76,16 +76,9 @@ theorem countP_True {s : Multiset α} : countP (fun _ => True) s = card s :=
 theorem countP_False {s : Multiset α} : countP (fun _ => False) s = 0 :=
   Quot.inductionOn s fun _l => congrFun List.countP_false _
 
--- Porting note: `Lean.Internal.coeM` forces us to type-ascript `{a // a ∈ s}`
 lemma countP_attach (s : Multiset α) : s.attach.countP (fun a : {a // a ∈ s} ↦ p a) = s.countP p :=
   Quotient.inductionOn s fun l => by
-    simp only [quot_mk_to_coe, coe_countP]
-    -- Porting note: was
-    -- rw [quot_mk_to_coe, coe_attach, coe_countP]
-    -- exact List.countP_attach _ _
-    rw [coe_attach]
-    refine (coe_countP _ _).trans ?_
-    convert List.countP_attach _ _
+    simp only [quot_mk_to_coe, coe_countP, coe_attach, coe_countP, ← List.countP_attach l]
     rfl
 
 variable {p}

--- a/Mathlib/Data/Multiset/Defs.lean
+++ b/Mathlib/Data/Multiset/Defs.lean
@@ -97,15 +97,14 @@ theorem lift_coe {α β : Type*} (x : List α) (f : List α → β)
 theorem coe_eq_coe {l₁ l₂ : List α} : (l₁ : Multiset α) = l₂ ↔ l₁ ~ l₂ :=
   Quotient.eq
 
--- Porting note: new instance;
 -- Porting note (https://github.com/leanprover-community/mathlib4/issues/11215): TODO: move to better place
+-- (upstream to Batteries?)
 instance [DecidableEq α] (l₁ l₂ : List α) : Decidable (l₁ ≈ l₂) :=
   inferInstanceAs (Decidable (l₁ ~ l₂))
 
 instance [DecidableEq α] (l₁ l₂ : List α) : Decidable (isSetoid α l₁ l₂) :=
   inferInstanceAs (Decidable (l₁ ~ l₂))
 
--- Porting note: `Quotient.recOnSubsingleton₂ s₁ s₂` was in parens which broke elaboration
 instance decidableEq [DecidableEq α] : DecidableEq (Multiset α)
   | s₁, s₂ => Quotient.recOnSubsingleton₂ s₁ s₂ fun _ _ => decidable_of_iff' _ Quotient.eq_iff_equiv
 

--- a/Mathlib/Data/Multiset/FinsetOps.lean
+++ b/Mathlib/Data/Multiset/FinsetOps.lean
@@ -128,7 +128,7 @@ def ndunion (s t : Multiset α) : Multiset α :=
 theorem coe_ndunion (l₁ l₂ : List α) : @ndunion α _ l₁ l₂ = (l₁ ∪ l₂ : List α) :=
   rfl
 
--- Porting note: removed @[simp], original porting note incorrectly claimed that simp can prove it
+-- `simp` can prove this once we have `ndunion_eq_union`.
 theorem zero_ndunion (s : Multiset α) : ndunion 0 s = s :=
   Quot.inductionOn s fun _ => rfl
 

--- a/Mathlib/Data/Multiset/Fintype.lean
+++ b/Mathlib/Data/Multiset/Fintype.lean
@@ -48,8 +48,6 @@ instance : CoeSort (Multiset α) (Type _) := ⟨Multiset.ToType⟩
 
 example : DecidableEq m := inferInstanceAs <| DecidableEq ((x : α) × Fin (m.count x))
 
--- Porting note: syntactic equality
-
 /-- Constructor for terms of the coercion of `m` to a type.
 This helps Lean pick up the correct instances. -/
 @[reducible, match_pattern]
@@ -61,11 +59,6 @@ component. -/
 instance instCoeSortMultisetType.instCoeOutToType : CoeOut m α :=
   ⟨fun x ↦ x.1⟩
 
--- Porting note: syntactic equality
-
--- Syntactic equality
-
--- @[simp] -- Porting note (https://github.com/leanprover-community/mathlib4/issues/10685): dsimp can prove this
 theorem coe_mk {x : α} {i : Fin (m.count x)} : ↑(m.mkToType x i) = x :=
   rfl
 

--- a/Mathlib/Data/Multiset/Lattice.lean
+++ b/Mathlib/Data/Multiset/Lattice.lean
@@ -78,8 +78,6 @@ theorem sup_ndinsert (a : α) (s : Multiset α) : (ndinsert a s).sup = a ⊔ s.s
 
 theorem nodup_sup_iff {α : Type*} [DecidableEq α] {m : Multiset (Multiset α)} :
     m.sup.Nodup ↔ ∀ a : Multiset α, a ∈ m → a.Nodup := by
-  -- Porting note: this was originally `apply m.induction_on`, which failed due to
-  -- `failed to elaborate eliminator, expected type is not available`
   induction m using Multiset.induction_on with
   | empty => simp
   | cons _ _ h => simp [h]

--- a/Mathlib/Data/Multiset/MapFold.lean
+++ b/Mathlib/Data/Multiset/MapFold.lean
@@ -153,11 +153,10 @@ theorem map_id (s : Multiset α) : map id s = s :=
 theorem map_id' (s : Multiset α) : map (fun x => x) s = s :=
   map_id s
 
--- Porting note: was a `simp` lemma in mathlib3
+-- `simp`-normal form lemma is `map_const'`
 theorem map_const (s : Multiset α) (b : β) : map (const α b) s = replicate (card s) b :=
   Quot.inductionOn s fun _ => congr_arg _ <| List.map_const' _ _
 
--- Porting note: was not a `simp` lemma in mathlib3 because `Function.const` was reducible
 @[simp] theorem map_const' (s : Multiset α) (b : β) : map (fun _ ↦ b) s = replicate (card s) b :=
   map_const _ _
 
@@ -327,7 +326,7 @@ theorem pmap_eq_map_attach {p : α → Prop} (f : ∀ a, p a → β) (s) :
     ∀ H, pmap f s H = s.attach.map fun x => f x.1 (H _ x.2) :=
   Quot.inductionOn s fun l H => congr_arg _ <| List.pmap_eq_map_attach f l H
 
--- @[simp] -- Porting note: Left hand does not simplify
+@[simp]
 theorem attach_map_val' (s : Multiset α) (f : α → β) : (s.attach.map fun i => f i.val) = s.map f :=
   Quot.inductionOn s fun l => congr_arg _ <| List.attach_map_val l f
 

--- a/Mathlib/Data/Multiset/Replicate.lean
+++ b/Mathlib/Data/Multiset/Replicate.lean
@@ -69,7 +69,6 @@ theorem replicate_right_injective {n : ℕ} (hn : n ≠ 0) : Injective (@replica
   (replicate_right_injective h).eq_iff
 
 theorem replicate_left_injective (a : α) : Injective (replicate · a) :=
-  -- Porting note: was `fun m n h => by rw [← (eq_replicate.1 h).1, card_replicate]`
   LeftInverse.injective (card_replicate · a)
 
 theorem replicate_subset_singleton (n : ℕ) (a : α) : replicate n a ⊆ {a} :=

--- a/Mathlib/Data/Multiset/Sum.lean
+++ b/Mathlib/Data/Multiset/Sum.lean
@@ -47,7 +47,6 @@ theorem mem_disjSum : x ∈ s.disjSum t ↔ (∃ a, a ∈ s ∧ inl a = x) ∨ �
 @[simp]
 theorem inl_mem_disjSum : inl a ∈ s.disjSum t ↔ a ∈ s := by
   rw [mem_disjSum, or_iff_left]
-  -- Porting note: Previous code for L62 was: simp only [exists_eq_right]
   · simp only [inl.injEq, exists_eq_right]
   rintro ⟨b, _, hb⟩
   exact inr_ne_inl hb
@@ -55,7 +54,6 @@ theorem inl_mem_disjSum : inl a ∈ s.disjSum t ↔ a ∈ s := by
 @[simp]
 theorem inr_mem_disjSum : inr b ∈ s.disjSum t ↔ b ∈ t := by
   rw [mem_disjSum, or_iff_right]
-  -- Porting note: Previous code for L72 was: simp only [exists_eq_right]
   · simp only [inr.injEq, exists_eq_right]
   rintro ⟨a, _, ha⟩
   exact inl_ne_inr ha


### PR DESCRIPTION
A lot of porting notes are about definitions working slightly differently in Lean 4. We seem to be happy with the current setup so just drop these.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
