### PR TITLE
[Merged by Bors] - feat(Algebra/Polynomial/BigOperators): Add lemma `degree_list_sum_le_of_forall_degree_le`

### DIFF
--- a/Mathlib/Algebra/Polynomial/BigOperators.lean
+++ b/Mathlib/Algebra/Polynomial/BigOperators.lean
@@ -60,19 +60,6 @@ lemma natDegree_sum_le_of_forall_le {n : ℕ} (f : ι → S[X]) (h : ∀ i ∈ s
     natDegree (∑ i ∈ s, f i) ≤ n :=
   le_trans (natDegree_sum_le s f) <| (Finset.fold_max_le n).mpr <| by simpa
 
-theorem degree_list_sum_le (l : List S[X]) : degree l.sum ≤ (l.map natDegree).maximum := by
-  by_cases h : l.sum = 0
-  · simp [h]
-  · rw [degree_eq_natDegree h]
-    suffices (l.map natDegree).maximum = ((l.map natDegree).foldr max 0 : ℕ) by
-      rw [this]
-      simpa using natDegree_list_sum_le l
-    rw [← List.foldr_max_of_ne_nil]
-    · congr
-    contrapose! h
-    rw [List.map_eq_nil_iff] at h
-    simp [h]
-
 theorem degree_list_sum_le_of_forall_degree_le (l : List S[X])
     (n : WithBot ℕ) (hl : ∀ p ∈ l, degree p ≤ n) :
     degree l.sum ≤ n := by
@@ -83,6 +70,18 @@ theorem degree_list_sum_le_of_forall_degree_le (l : List S[X])
     rcases hl with ⟨hhd, htl⟩
     rw [List.sum_cons]
     exact le_trans (degree_add_le hd tl.sum) (max_le hhd (ih htl))
+
+theorem degree_list_sum_le (l : List S[X]) : degree l.sum ≤ (l.map natDegree).maximum := by
+  apply degree_list_sum_le_of_forall_degree_le
+  intros p hp
+  by_cases h : p = 0
+  · subst h
+    simp
+  · rw [degree_eq_natDegree h]
+    apply List.le_maximum_of_mem'
+    rw [List.mem_map]
+    use p
+    simp [hp]
 
 theorem natDegree_list_prod_le (l : List S[X]) : natDegree l.prod ≤ (l.map natDegree).sum := by
   induction' l with hd tl IH

--- a/Mathlib/Algebra/Polynomial/BigOperators.lean
+++ b/Mathlib/Algebra/Polynomial/BigOperators.lean
@@ -80,9 +80,9 @@ theorem degree_list_sum_le_of_forall_degree_le (l : List S[X])
   | nil => simp
   | cons hd tl ih =>
     simp only [List.mem_cons, forall_eq_or_imp] at hl
-    rcases hl with ⟨ht, htl⟩
+    rcases hl with ⟨hhd, htl⟩
     rw [List.sum_cons]
-    exact le_trans (degree_add_le hd tl.sum) (max_le ht (ih htl))
+    exact le_trans (degree_add_le hd tl.sum) (max_le hhd (ih htl))
 
 theorem natDegree_list_prod_le (l : List S[X]) : natDegree l.prod ≤ (l.map natDegree).sum := by
   induction' l with hd tl IH

--- a/Mathlib/Algebra/Polynomial/BigOperators.lean
+++ b/Mathlib/Algebra/Polynomial/BigOperators.lean
@@ -79,12 +79,11 @@ theorem degree_list_sum_le_of_forall_degree_le (l : List S[X])
   induction l with
   | nil => simp
   | cons hd tl ih =>
-    simp
-    apply le_trans (Polynomial.degree_add_le _ _) _
-    simp at hl
+    simp only [List.mem_cons, forall_eq_or_imp] at hl
     rcases hl with ⟨ht, htl⟩
-    specialize ih htl
-    exact max_le ht ih
+    rw [List.sum_cons]
+    apply le_trans (Polynomial.degree_add_le _ _) _
+    exact max_le ht (ih htl)
 
 theorem natDegree_list_prod_le (l : List S[X]) : natDegree l.prod ≤ (l.map natDegree).sum := by
   induction' l with hd tl IH

--- a/Mathlib/Algebra/Polynomial/BigOperators.lean
+++ b/Mathlib/Algebra/Polynomial/BigOperators.lean
@@ -73,6 +73,19 @@ theorem degree_list_sum_le (l : List S[X]) : degree l.sum ≤ (l.map natDegree).
     rw [List.map_eq_nil_iff] at h
     simp [h]
 
+theorem degree_list_sum_le_of_forall_degree_le (l : List S[X])
+    (n : WithBot ℕ) (hl : ∀ p ∈ l, degree p ≤ n) :
+    degree l.sum ≤ n := by
+  induction l with
+  | nil => simp
+  | cons hd tl ih =>
+    simp
+    apply le_trans (Polynomial.degree_add_le _ _) _
+    simp at hl
+    rcases hl with ⟨ht, htl⟩
+    specialize ih htl
+    exact max_le ht ih
+
 theorem natDegree_list_prod_le (l : List S[X]) : natDegree l.prod ≤ (l.map natDegree).sum := by
   induction' l with hd tl IH
   · simp

--- a/Mathlib/Algebra/Polynomial/BigOperators.lean
+++ b/Mathlib/Algebra/Polynomial/BigOperators.lean
@@ -82,8 +82,7 @@ theorem degree_list_sum_le_of_forall_degree_le (l : List S[X])
     simp only [List.mem_cons, forall_eq_or_imp] at hl
     rcases hl with ⟨ht, htl⟩
     rw [List.sum_cons]
-    apply le_trans (Polynomial.degree_add_le _ _) _
-    exact max_le ht (ih htl)
+    exact le_trans (degree_add_le hd tl.sum) (max_le ht (ih htl))
 
 theorem natDegree_list_prod_le (l : List S[X]) : natDegree l.prod ≤ (l.map natDegree).sum := by
   induction' l with hd tl IH


### PR DESCRIPTION
Adds a lemma relating the degree of the sum of a list of polynomials to the degree of the polynomials (unlike `degree_list_sum_le`, which only relates this to the `natDegree` of the polynomials in the list).

Found while trying to contribute to [zkLib](https://github.com/Verified-zkEVM/ZKLib)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
