### PR TITLE
[Merged by Bors] - chore: rename `induction_on'''`

### DIFF
--- a/Mathlib/Algebra/MvPolynomial/Basic.lean
+++ b/Mathlib/Algebra/MvPolynomial/Basic.lean
@@ -367,12 +367,12 @@ it suffices to show the condition is closed under taking sums,
 and it holds for monomials. -/
 @[elab_as_elim]
 theorem induction_on' {P : MvPolynomial σ R → Prop} (p : MvPolynomial σ R)
-    (h1 : ∀ (u : σ →₀ ℕ) (a : R), P (monomial u a))
-    (h2 : ∀ p q : MvPolynomial σ R, P p → P q → P (p + q)) : P p :=
+    (monomial : ∀ (u : σ →₀ ℕ) (a : R), P (monomial u a))
+    (add : ∀ p q : MvPolynomial σ R, P p → P q → P (p + q)) : P p :=
   Finsupp.induction p
-    (suffices P (monomial 0 0) by rwa [monomial_zero] at this
-    show P (monomial 0 0) from h1 0 0)
-    fun _ _ _ _ha _hb hPf => h2 _ _ (h1 _ _) hPf
+    (suffices P (MvPolynomial.monomial 0 0) by rwa [monomial_zero] at this
+    show P (MvPolynomial.monomial 0 0) from monomial 0 0)
+    fun _ _ _ _ha _hb hPf => add _ _ (monomial _ _) hPf
 
 /--
 Similar to `MvPolynomial.induction_on` but only a weak form of `h_add` is required.
@@ -386,7 +386,7 @@ theorem monomial_add_induction_on {motive : MvPolynomial σ R → Prop} (p : MvP
       ∀ (a : σ →₀ ℕ) (b : R) (f : MvPolynomial σ R),
         a ∉ f.support → b ≠ 0 → motive f → motive ((monomial a b) + f)) :
     motive p :=
-  Finsupp.induction p (C_0.rec <| C 0) monomial_add_weak
+  Finsupp.induction p (C_0.rec <| C 0) monomial_add
 
 @[deprecated (since := "2025-03-11")]
 alias induction_on''' := monomial_add_induction_on
@@ -406,7 +406,7 @@ theorem induction_on'' {motive : MvPolynomial σ R → Prop} (p : MvPolynomial �
     (mul_X : ∀ (p : MvPolynomial σ R) (n : σ), motive p → motive (p * MvPolynomial.X n)) :
     motive p :=
   monomial_add_induction_on p C fun a b f ha hb hf =>
-    monomial_add_weak a b f ha hb hf <| induction_on_monomial C mul_X a b
+    monomial_add a b f ha hb hf <| induction_on_monomial C mul_X a b
 
 /--
 Analog of `Polynomial.induction_on`.

--- a/Mathlib/Algebra/MvPolynomial/Basic.lean
+++ b/Mathlib/Algebra/MvPolynomial/Basic.lean
@@ -386,6 +386,9 @@ theorem monomial_add_induction_on {M : MvPolynomial σ R → Prop} (p : MvPolyno
     -- Porting note: I had to add the `show ... from ...` above, a type ascription was insufficient.
   Finsupp.induction p (C_0.rec <| h_C 0) h_add_weak
 
+@[deprecated (since := "2024-11-10")]
+alias induction_on''' := monomial_add_induction_on
+
 /--
 Similar to `MvPolynomial.induction_on` but only a yet weaker form of `h_add` is required.
 In particular, this version only requires us to show

--- a/Mathlib/Algebra/MvPolynomial/Basic.lean
+++ b/Mathlib/Algebra/MvPolynomial/Basic.lean
@@ -377,6 +377,7 @@ Similar to `MvPolynomial.induction_on` but only a weak form of `h_add` is requir
 In particular, this version only requires us to show
 that `M` is closed under addition of nontrivial monomials not present in the support.
 -/
+@[elab_as_elim]
 theorem monomial_add_induction_on {M : MvPolynomial σ R → Prop} (p : MvPolynomial σ R)
     (h_C : ∀ a, M (C a))
     (h_add_weak :

--- a/Mathlib/Algebra/MvPolynomial/Basic.lean
+++ b/Mathlib/Algebra/MvPolynomial/Basic.lean
@@ -372,27 +372,42 @@ theorem induction_on' {P : MvPolynomial σ R → Prop} (p : MvPolynomial σ R)
     show P (monomial 0 0) from h1 0 0)
     fun _ _ _ _ha _hb hPf => h2 _ _ (h1 _ _) hPf
 
-/-- Similar to `MvPolynomial.induction_on` but only a weak form of `h_add` is required. -/
-theorem induction_on''' {M : MvPolynomial σ R → Prop} (p : MvPolynomial σ R) (h_C : ∀ a, M (C a))
+/--
+Similar to `MvPolynomial.induction_on` but only a weak form of `h_add` is required.
+In particular, this version only requires us to show
+that `M` is closed under addition of nontrivial monomials not present in the support.
+-/
+theorem monomial_add_induction_on {M : MvPolynomial σ R → Prop} (p : MvPolynomial σ R)
+    (h_C : ∀ a, M (C a))
     (h_add_weak :
-      ∀ (a : σ →₀ ℕ) (b : R) (f : (σ →₀ ℕ) →₀ R),
-        a ∉ f.support → b ≠ 0 → M f → M ((show (σ →₀ ℕ) →₀ R from monomial a b) + f)) :
+      ∀ (a : σ →₀ ℕ) (b : R) (f : MvPolynomial σ R),
+        a ∉ f.support → b ≠ 0 → M f → M ((monomial a b) + f)) :
     M p :=
     -- Porting note: I had to add the `show ... from ...` above, a type ascription was insufficient.
   Finsupp.induction p (C_0.rec <| h_C 0) h_add_weak
 
-/-- Similar to `MvPolynomial.induction_on` but only a yet weaker form of `h_add` is required. -/
+/--
+Similar to `MvPolynomial.induction_on` but only a yet weaker form of `h_add` is required.
+In particular, this version only requires us to show
+that `M` is closed under addition of monomials not present in the support
+and for which `M` is already known to hold.
+-/
 theorem induction_on'' {M : MvPolynomial σ R → Prop} (p : MvPolynomial σ R) (h_C : ∀ a, M (C a))
     (h_add_weak :
-      ∀ (a : σ →₀ ℕ) (b : R) (f : (σ →₀ ℕ) →₀ R),
+      ∀ (a : σ →₀ ℕ) (b : R) (f : MvPolynomial σ R),
         a ∉ f.support → b ≠ 0 → M f → M (monomial a b) →
-          M ((show (σ →₀ ℕ) →₀ R from monomial a b) + f))
+          M ((monomial a b) + f))
     (h_X : ∀ (p : MvPolynomial σ R) (n : σ), M p → M (p * MvPolynomial.X n)) : M p :=
     -- Porting note: I had to add the `show ... from ...` above, a type ascription was insufficient.
-  induction_on''' p h_C fun a b f ha hb hf =>
+  monomial_add_induction_on p h_C fun a b f ha hb hf =>
     h_add_weak a b f ha hb hf <| induction_on_monomial h_C h_X a b
 
-/-- Analog of `Polynomial.induction_on`. -/
+/--
+Analog of `Polynomial.induction_on`.
+If a property holds for any constant polynomial
+and is preserved under addition and multiplication by variables
+then it holds for all multivariate polynomials.
+-/
 @[recursor 5]
 theorem induction_on {M : MvPolynomial σ R → Prop} (p : MvPolynomial σ R) (h_C : ∀ a, M (C a))
     (h_add : ∀ p q, M p → M q → M (p + q)) (h_X : ∀ p n, M p → M (p * X n)) : M p :=

--- a/Mathlib/Algebra/MvPolynomial/Basic.lean
+++ b/Mathlib/Algebra/MvPolynomial/Basic.lean
@@ -383,7 +383,6 @@ theorem monomial_add_induction_on {M : MvPolynomial σ R → Prop} (p : MvPolyno
       ∀ (a : σ →₀ ℕ) (b : R) (f : MvPolynomial σ R),
         a ∉ f.support → b ≠ 0 → M f → M ((monomial a b) + f)) :
     M p :=
-    -- Porting note: I had to add the `show ... from ...` above, a type ascription was insufficient.
   Finsupp.induction p (C_0.rec <| h_C 0) h_add_weak
 
 @[deprecated (since := "2024-11-10")]
@@ -401,7 +400,6 @@ theorem induction_on'' {M : MvPolynomial σ R → Prop} (p : MvPolynomial σ R) 
         a ∉ f.support → b ≠ 0 → M f → M (monomial a b) →
           M ((monomial a b) + f))
     (h_X : ∀ (p : MvPolynomial σ R) (n : σ), M p → M (p * MvPolynomial.X n)) : M p :=
-    -- Porting note: I had to add the `show ... from ...` above, a type ascription was insufficient.
   monomial_add_induction_on p h_C fun a b f ha hb hf =>
     h_add_weak a b f ha hb hf <| induction_on_monomial h_C h_X a b
 

--- a/Mathlib/Algebra/MvPolynomial/Basic.lean
+++ b/Mathlib/Algebra/MvPolynomial/Basic.lean
@@ -399,7 +399,7 @@ for which `motive` is already known to hold.
 -/
 theorem induction_on'' {motive : MvPolynomial σ R → Prop} (p : MvPolynomial σ R)
     (C : ∀ a, motive (C a))
-    (monomial_add_weak :
+    (monomial_add :
       ∀ (a : σ →₀ ℕ) (b : R) (f : MvPolynomial σ R),
         a ∉ f.support → b ≠ 0 → motive f → motive (monomial a b) →
           motive ((monomial a b) + f))

--- a/Mathlib/Algebra/MvPolynomial/Basic.lean
+++ b/Mathlib/Algebra/MvPolynomial/Basic.lean
@@ -382,7 +382,7 @@ that `motive` is closed under addition of nontrivial monomials not present in th
 @[elab_as_elim]
 theorem monomial_add_induction_on {motive : MvPolynomial σ R → Prop} (p : MvPolynomial σ R)
     (C : ∀ a, motive (C a))
-    (monomial_add_weak :
+    (monomial_add :
       ∀ (a : σ →₀ ℕ) (b : R) (f : MvPolynomial σ R),
         a ∉ f.support → b ≠ 0 → motive f → motive ((monomial a b) + f)) :
     motive p :=

--- a/Mathlib/Algebra/MvPolynomial/Basic.lean
+++ b/Mathlib/Algebra/MvPolynomial/Basic.lean
@@ -385,14 +385,14 @@ theorem monomial_add_induction_on {M : MvPolynomial σ R → Prop} (p : MvPolyno
     M p :=
   Finsupp.induction p (C_0.rec <| h_C 0) h_add_weak
 
-@[deprecated (since := "2024-11-10")]
+@[deprecated (since := "2025-03-11")]
 alias induction_on''' := monomial_add_induction_on
 
 /--
 Similar to `MvPolynomial.induction_on` but only a yet weaker form of `h_add` is required.
 In particular, this version only requires us to show
 that `M` is closed under addition of monomials not present in the support
-and for which `M` is already known to hold.
+for which `M` is already known to hold.
 -/
 theorem induction_on'' {M : MvPolynomial σ R → Prop} (p : MvPolynomial σ R) (h_C : ∀ a, M (C a))
     (h_add_weak :

--- a/Mathlib/Algebra/MvPolynomial/Basic.lean
+++ b/Mathlib/Algebra/MvPolynomial/Basic.lean
@@ -346,15 +346,15 @@ lemma prod_X_pow_eq_monomial : ∏ x ∈ s.support, X x ^ s x = monomial s (1 : 
   simp only [monomial_eq, map_one, one_mul, Finsupp.prod]
 
 @[elab_as_elim]
-theorem induction_on_monomial {M : MvPolynomial σ R → Prop}
-    (C : ∀ a, M (C a))
-    (mul_X : ∀ p n, M p → M (p * X n)) : ∀ s a, M (monomial s a) := by
+theorem induction_on_monomial {motive : MvPolynomial σ R → Prop}
+    (C : ∀ a, motive (C a))
+    (mul_X : ∀ p n, motive p → motive (p * X n)) : ∀ s a, motive (monomial s a) := by
   intro s a
   apply @Finsupp.induction σ ℕ _ _ s
-  · show M (monomial 0 a)
+  · show motive (monomial 0 a)
     exact C a
   · intro n e p _hpn _he ih
-    have : ∀ e : ℕ, M (monomial p a * X n ^ e) := by
+    have : ∀ e : ℕ, motive (monomial p a * X n ^ e) := by
       intro e
       induction e with
       | zero => simp [ih]
@@ -377,15 +377,15 @@ theorem induction_on' {P : MvPolynomial σ R → Prop} (p : MvPolynomial σ R)
 /--
 Similar to `MvPolynomial.induction_on` but only a weak form of `h_add` is required.
 In particular, this version only requires us to show
-that `M` is closed under addition of nontrivial monomials not present in the support.
+that `motive` is closed under addition of nontrivial monomials not present in the support.
 -/
 @[elab_as_elim]
-theorem monomial_add_induction_on {M : MvPolynomial σ R → Prop} (p : MvPolynomial σ R)
-    (C : ∀ a, M (C a))
+theorem monomial_add_induction_on {motive : MvPolynomial σ R → Prop} (p : MvPolynomial σ R)
+    (C : ∀ a, motive (C a))
     (monomial_add_weak :
       ∀ (a : σ →₀ ℕ) (b : R) (f : MvPolynomial σ R),
-        a ∉ f.support → b ≠ 0 → M f → M ((monomial a b) + f)) :
-    M p :=
+        a ∉ f.support → b ≠ 0 → motive f → motive ((monomial a b) + f)) :
+    motive p :=
   Finsupp.induction p (C_0.rec <| C 0) monomial_add_weak
 
 @[deprecated (since := "2025-03-11")]
@@ -394,16 +394,17 @@ alias induction_on''' := monomial_add_induction_on
 /--
 Similar to `MvPolynomial.induction_on` but only a yet weaker form of `h_add` is required.
 In particular, this version only requires us to show
-that `M` is closed under addition of monomials not present in the support
-for which `M` is already known to hold.
+that `motive` is closed under addition of monomials not present in the support
+for which `motive` is already known to hold.
 -/
-theorem induction_on'' {M : MvPolynomial σ R → Prop} (p : MvPolynomial σ R)
-    (C : ∀ a, M (C a))
+theorem induction_on'' {motive : MvPolynomial σ R → Prop} (p : MvPolynomial σ R)
+    (C : ∀ a, motive (C a))
     (monomial_add_weak :
       ∀ (a : σ →₀ ℕ) (b : R) (f : MvPolynomial σ R),
-        a ∉ f.support → b ≠ 0 → M f → M (monomial a b) →
-          M ((monomial a b) + f))
-    (mul_X : ∀ (p : MvPolynomial σ R) (n : σ), M p → M (p * MvPolynomial.X n)) : M p :=
+        a ∉ f.support → b ≠ 0 → motive f → motive (monomial a b) →
+          motive ((monomial a b) + f))
+    (mul_X : ∀ (p : MvPolynomial σ R) (n : σ), motive p → motive (p * MvPolynomial.X n)) :
+    motive p :=
   monomial_add_induction_on p C fun a b f ha hb hf =>
     monomial_add_weak a b f ha hb hf <| induction_on_monomial C mul_X a b
 
@@ -414,10 +415,10 @@ and is preserved under addition and multiplication by variables
 then it holds for all multivariate polynomials.
 -/
 @[recursor 5]
-theorem induction_on {M : MvPolynomial σ R → Prop} (p : MvPolynomial σ R)
-    (C : ∀ a, M (C a))
-    (add : ∀ p q, M p → M q → M (p + q))
-    (mul_X : ∀ p n, M p → M (p * X n)) : M p :=
+theorem induction_on {motive : MvPolynomial σ R → Prop} (p : MvPolynomial σ R)
+    (C : ∀ a, motive (C a))
+    (add : ∀ p q, motive p → motive q → motive (p + q))
+    (mul_X : ∀ p n, motive p → motive (p * X n)) : motive p :=
   induction_on'' p C (fun a b f _ha _hb hf hm => add (monomial a b) f hm hf) mul_X
 
 theorem ringHom_ext {A : Type*} [Semiring A] {f g : MvPolynomial σ R →+* A}

--- a/Mathlib/Algebra/MvPolynomial/Basic.lean
+++ b/Mathlib/Algebra/MvPolynomial/Basic.lean
@@ -345,6 +345,7 @@ theorem monomial_eq : monomial s a = C a * (s.prod fun n e => X n ^ e : MvPolyno
 lemma prod_X_pow_eq_monomial : ∏ x ∈ s.support, X x ^ s x = monomial s (1 : R) := by
   simp only [monomial_eq, map_one, one_mul, Finsupp.prod]
 
+@[elab_as_elim]
 theorem induction_on_monomial {M : MvPolynomial σ R → Prop}
     (C : ∀ a, M (C a))
     (mul_X : ∀ p n, M p → M (p * X n)) : ∀ s a, M (monomial s a) := by

--- a/Mathlib/Algebra/MvPolynomial/Derivation.lean
+++ b/Mathlib/Algebra/MvPolynomial/Derivation.lean
@@ -92,10 +92,10 @@ theorem leibniz_iff_X (D : MvPolynomial σ R →ₗ[R] A) (h₁ : D 1 = 0) :
     · rw [add_mul, map_add, map_add, hp, hq, add_smul, smul_add, add_add_add_comm]
   intro p q
   induction q using MvPolynomial.induction_on with
-  | h_C c =>
+  | C c =>
     rw [mul_comm, C_mul', hC, smul_zero, zero_add, D.map_smul, C_eq_smul_one, smul_one_smul]
-  | h_add q₁ q₂ h₁ h₂ => simp only [mul_add, map_add, h₁, h₂, smul_add, add_smul]; abel
-  | h_X q i hq =>
+  | add q₁ q₂ h₁ h₂ => simp only [mul_add, map_add, h₁, h₂, smul_add, add_smul]; abel
+  | mul_X q i hq =>
     simp only [this, ← mul_assoc, hq, mul_smul, smul_add, add_assoc]
     rw [smul_comm (X i), smul_comm (X i)]
 

--- a/Mathlib/Algebra/MvPolynomial/Eval.lean
+++ b/Mathlib/Algebra/MvPolynomial/Eval.lean
@@ -728,7 +728,7 @@ theorem eval₂_mem {f : R →+* S} {p : MvPolynomial σ R} {s : subS}
     · exact hs i hi
     · rw [MvPolynomial.not_mem_support_iff.1 hi, f.map_zero]
       exact zero_mem s
-  induction' p using MvPolynomial.induction_on''' with a a b f ha _ ih
+  induction' p using MvPolynomial.monomial_add_induction_on with a a b f ha _ ih
   · simpa using hs 0
   rw [eval₂_add, eval₂_monomial]
   refine add_mem (mul_mem ?_ <| prod_mem fun i _ => pow_mem (hv _) _) (ih fun i => ?_)

--- a/Mathlib/Algebra/MvPolynomial/Eval.lean
+++ b/Mathlib/Algebra/MvPolynomial/Eval.lean
@@ -731,7 +731,7 @@ theorem eval₂_mem {f : R →+* S} {p : MvPolynomial σ R} {s : subS}
   induction p using MvPolynomial.monomial_add_induction_on with
   | C a =>
     simpa using hs 0
-  | monomial_add_weak a b f ha _ ih =>
+  | monomial_add a b f ha _ ih =>
     rw [eval₂_add, eval₂_monomial]
     refine add_mem (mul_mem ?_ <| prod_mem fun i _ => pow_mem (hv _) _) (ih fun i => ?_)
     · have := hs a -- Porting note: was `simpa only [...]`

--- a/Mathlib/Algebra/MvPolynomial/Eval.lean
+++ b/Mathlib/Algebra/MvPolynomial/Eval.lean
@@ -728,20 +728,22 @@ theorem eval₂_mem {f : R →+* S} {p : MvPolynomial σ R} {s : subS}
     · exact hs i hi
     · rw [MvPolynomial.not_mem_support_iff.1 hi, f.map_zero]
       exact zero_mem s
-  induction' p using MvPolynomial.monomial_add_induction_on with a a b f ha _ ih
-  · simpa using hs 0
-  rw [eval₂_add, eval₂_monomial]
-  refine add_mem (mul_mem ?_ <| prod_mem fun i _ => pow_mem (hv _) _) (ih fun i => ?_)
-  · have := hs a -- Porting note: was `simpa only [...]`
-    rwa [coeff_add, MvPolynomial.not_mem_support_iff.1 ha, add_zero, coeff_monomial,
-      if_pos rfl] at this
-  have := hs i
-  rw [coeff_add, coeff_monomial] at this
-  split_ifs at this with h
-  · subst h
-    rw [MvPolynomial.not_mem_support_iff.1 ha, map_zero]
-    exact zero_mem _
-  · rwa [zero_add] at this
+  induction p using MvPolynomial.monomial_add_induction_on with
+  | C a =>
+    simpa using hs 0
+  | monomial_add_weak a b f ha _ ih =>
+    rw [eval₂_add, eval₂_monomial]
+    refine add_mem (mul_mem ?_ <| prod_mem fun i _ => pow_mem (hv _) _) (ih fun i => ?_)
+    · have := hs a -- Porting note: was `simpa only [...]`
+      rwa [coeff_add, MvPolynomial.not_mem_support_iff.1 ha, add_zero, coeff_monomial,
+        if_pos rfl] at this
+    have := hs i
+    rw [coeff_add, coeff_monomial] at this
+    split_ifs at this with h
+    · subst h
+      rw [MvPolynomial.not_mem_support_iff.1 ha, map_zero]
+      exact zero_mem _
+    · rwa [zero_add] at this
 
 theorem eval_mem {p : MvPolynomial σ S} {s : subS} (hs : ∀ i ∈ p.support, p.coeff i ∈ s) {v : σ → S}
     (hv : ∀ i, v i ∈ s) : MvPolynomial.eval v p ∈ s :=

--- a/Mathlib/FieldTheory/IsAlgClosed/AlgebraicClosure.lean
+++ b/Mathlib/FieldTheory/IsAlgClosed/AlgebraicClosure.lean
@@ -170,9 +170,9 @@ instance isAlgebraic : Algebra.IsAlgebraic k (AlgebraicClosure k) :=
       let ⟨p, hp⟩ := Ideal.Quotient.mk_surjective z
       rw [← hp]
       induction p using MvPolynomial.induction_on generalizing z with
-        | h_C => exact isIntegral_algebraMap
-        | h_add _ _ ha hb => exact (ha _ rfl).add (hb _ rfl)
-        | h_X p fi ih =>
+        | C => exact isIntegral_algebraMap
+        | add _ _ ha hb => exact (ha _ rfl).add (hb _ rfl)
+        | mul_X p fi ih =>
           rw [map_mul]
           refine (ih _ rfl).mul ⟨_, fi.1.2, ?_⟩
           simp_rw [← eval_map, Monics.map_eq_prod, eval_prod, Polynomial.map_sub, eval_sub]

--- a/Mathlib/RingTheory/Generators.lean
+++ b/Mathlib/RingTheory/Generators.lean
@@ -235,11 +235,11 @@ def baseChange {T} [CommRing T] [Algebra R T] (P : Generators R S) : Generators 
       aeval (fun x ↦ (1 ⊗ₜ[R] P.val x : T ⊗[R] S)) y = 1 ⊗ₜ aeval (fun x ↦ P.val x) y := by
       intro y
       induction y using MvPolynomial.induction_on with
-      | h_C a =>
+      | C a =>
         rw [aeval_C, aeval_C, TensorProduct.algebraMap_apply, algebraMap_eq_smul_one, smul_tmul,
           algebraMap_eq_smul_one]
-      | h_add p q hp hq => simp [map_add, tmul_add, hp, hq]
-      | h_X p i hp => simp [hp]
+      | add p q hp hq => simp [map_add, tmul_add, hp, hq]
+      | mul_X p i hp => simp [hp]
     rw [this, P.aeval_val_σ, smul_tmul', smul_eq_mul, mul_one]
   | add x y ex ey =>
     obtain ⟨a, ha⟩ := ex
@@ -343,9 +343,9 @@ noncomputable def Hom.comp [IsScalarTower R' R'' S''] [IsScalarTower R' S' S'']
     simp only
     rw [IsScalarTower.algebraMap_apply S S' S'', ← g.aeval_val]
     induction g.val x using MvPolynomial.induction_on with
-    | h_C r => simp [← IsScalarTower.algebraMap_apply]
-    | h_add x y hx hy => simp only [map_add, hx, hy]
-    | h_X p i hp => simp only [map_mul, hp, aeval_X, aeval_val]
+    | C r => simp [← IsScalarTower.algebraMap_apply]
+    | add x y hx hy => simp only [map_add, hx, hy]
+    | mul_X p i hp => simp only [map_mul, hp, aeval_X, aeval_val]
 
 @[simp]
 lemma Hom.comp_id [Algebra R S'] [IsScalarTower R R' S'] [IsScalarTower R S S'] (f : Hom P P') :
@@ -367,9 +367,9 @@ lemma Hom.toAlgHom_comp_apply
     (f : Hom P P') (g : Hom P' P'') (x) :
     (g.comp f).toAlgHom x = g.toAlgHom (f.toAlgHom x) := by
   induction x using MvPolynomial.induction_on with
-  | h_C r => simp only [← MvPolynomial.algebraMap_eq, AlgHom.map_algebraMap]
-  | h_add x y hx hy => simp only [map_add, hx, hy]
-  | h_X p i hp => simp only [map_mul, hp, toAlgHom_X, comp_val]; rfl
+  | C r => simp only [← MvPolynomial.algebraMap_eq, AlgHom.map_algebraMap]
+  | add x y hx hy => simp only [map_add, hx, hy]
+  | mul_X p i hp => simp only [map_mul, hp, toAlgHom_X, comp_val]; rfl
 
 variable {T} [CommRing T] [Algebra R T] [Algebra S T] [IsScalarTower R S T]
 
@@ -421,19 +421,19 @@ lemma toAlgHom_ofComp_surjective (Q : Generators S T) (P : Generators R S) :
     Function.Surjective (Q.ofComp P).toAlgHom := by
   intro p
   induction p using MvPolynomial.induction_on with
-  | h_C a =>
+  | C a =>
       use MvPolynomial.rename Sum.inr (P.σ a)
       simp only [Hom.toAlgHom, ofComp, Generators.comp, MvPolynomial.aeval_rename,
         Sum.elim_comp_inr]
       simp_rw [Function.comp_def, ← MvPolynomial.algebraMap_eq, ← IsScalarTower.toAlgHom_apply R,
         ← MvPolynomial.comp_aeval]
       simp
-  | h_add p q hp hq =>
+  | add p q hp hq =>
       obtain ⟨p, rfl⟩ := hp
       obtain ⟨q, rfl⟩ := hq
       use p + q
       simp
-  | h_X p i hp =>
+  | mul_X p i hp =>
       obtain ⟨(p : MvPolynomial (Q.vars ⊕ P.vars) R), rfl⟩ := hp
       use p * MvPolynomial.X (R := R) (Sum.inl i)
       simp [Algebra.Generators.ofComp, Algebra.Generators.Hom.toAlgHom]

--- a/Mathlib/RingTheory/Generators.lean
+++ b/Mathlib/RingTheory/Generators.lean
@@ -523,7 +523,7 @@ lemma map_toComp_ker (Q : Generators S T) (P : Generators R S) :
         simp_all
       rw [Finset.sum_filter, ← finsum_eq_sum_of_support_subset _ (this x)]
       induction x using MvPolynomial.induction_on' with
-      | h1 v a =>
+      | monomial v a =>
         rw [finsum_eq_sum_of_support_subset _ (this _), ← Finset.sum_filter]
         obtain ⟨v, rfl⟩ := e.symm.surjective v
         erw [ofComp_toAlgHom_monomial_sumElim]
@@ -536,7 +536,7 @@ lemma map_toComp_ker (Q : Generators S T) (P : Generators R S) :
         split
         · simp only [zero_smul, coeff_zero, *, map_zero, ite_self]
         · congr
-      | h2 p q hp hq =>
+      | add p q hp hq =>
         simp only [coeff_add, map_add, ite_add_zero]
         rw [finsum_add_distrib, hp, hq]
         · refine (((support p).map e).finite_toSet.subset ?_)

--- a/Mathlib/RingTheory/MvPolynomial/Symmetric/FundamentalTheorem.lean
+++ b/Mathlib/RingTheory/MvPolynomial/Symmetric/FundamentalTheorem.lean
@@ -316,9 +316,9 @@ lemma esymmAlgHom_fin_surjective (h : m ≤ n) :
   obtain ⟨q, rfl⟩ := (esymmAlgHom_fin_bijective R m).2 p
   rw [← AlgHom.mem_range]
   induction q using MvPolynomial.induction_on with
-  | h_C r => rw [← algebraMap_eq, AlgHom.commutes]; apply Subalgebra.algebraMap_mem
-  | h_add p q hp hq => rw [map_add]; exact Subalgebra.add_mem _ hp hq
-  | h_X p i hp =>
+  | C r => rw [← algebraMap_eq, AlgHom.commutes]; apply Subalgebra.algebraMap_mem
+  | add p q hp hq => rw [map_add]; exact Subalgebra.add_mem _ hp hq
+  | mul_X p i hp =>
     rw [map_mul]
     apply Subalgebra.mul_mem _ hp
     rw [AlgHom.mem_range]

--- a/Mathlib/RingTheory/Presentation.lean
+++ b/Mathlib/RingTheory/Presentation.lean
@@ -260,7 +260,7 @@ private lemma span_range_relation_eq_ker_baseChange :
       rw [RingHom.mem_ker, ← hx]
       clear hx
       induction x using MvPolynomial.induction_on with
-      | h_C a =>
+      | C a =>
         simp only [Generators.algebraMap_apply, algHom_C, TensorProduct.algebraMap_apply,
           id.map_eq_id, RingHom.id_apply, e]
         rw [← MvPolynomial.algebraMap_eq, AlgEquiv.commutes]
@@ -268,8 +268,8 @@ private lemma span_range_relation_eq_ker_baseChange :
           TensorProduct.map_tmul, AlgHom.coe_id, id_eq, map_one, algebraMap_eq]
         erw [aeval_C]
         simp
-      | h_add p q hp hq => simp only [map_add, hp, hq]
-      | h_X p i hp =>
+      | add p q hp hq => simp only [map_add, hp, hq]
+      | mul_X p i hp =>
         simp only [map_mul, algebraTensorAlgEquiv_symm_X, hp, TensorProduct.map_tmul, map_one,
           IsScalarTower.coe_toAlgHom', Generators.algebraMap_apply, aeval_X, e]
         congr


### PR DESCRIPTION
This PR addresses a few things:

* It renames `MvPolynomial.induction_on'''` (three primes!) to `MvPolynomial.monomial_add_induction_on`, addressing a particularly egregious instance of the docPrime linter.
* It improves the docstrings of this and nearby induction principles to be a bit more clear.
* It changes the type of a component of the argument of some of these from `(σ →₀ ℕ) →₀ R` to `MvPolynomial σ R`, making the theorems more readable and addressing two porting notes.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
