### PR TITLE
[Merged by Bors] - feat(Topology/Instance/Rat): add missing NNRat metric space

### DIFF
--- a/Mathlib/Topology/Instances/Rat.lean
+++ b/Mathlib/Topology/Instances/Rat.lean
@@ -118,3 +118,21 @@ nonrec theorem totallyBounded_Icc (a b : ℚ) : TotallyBounded (Icc a b) := by
       (totallyBounded_Icc (a : ℝ) b)
 
 end Rat
+
+namespace NNRat
+
+instance : MetricSpace ℚ≥0 :=
+  Subtype.metricSpace
+
+instance : IsTopologicalSemiring ℚ≥0 where
+  toContinuousAdd := continuousAdd_induced Nonneg.coeRingHom
+  toContinuousMul := continuousMul_induced Nonneg.coeRingHom
+
+instance : ContinuousSub ℚ≥0 :=
+  ⟨((continuous_subtype_val.fst'.sub continuous_subtype_val.snd').max
+      continuous_const).subtype_mk _⟩
+
+instance : OrderTopology ℚ≥0 := orderTopology_of_ordConnected (t := Set.Ici 0)
+instance : HasContinuousInv₀ ℚ≥0 := inferInstance
+
+end NNRat

--- a/Mathlib/Topology/Instances/Rat.lean
+++ b/Mathlib/Topology/Instances/Rat.lean
@@ -124,6 +124,11 @@ namespace NNRat
 instance : MetricSpace ℚ≥0 :=
   Subtype.metricSpace
 
+@[simp ←, push_cast]
+lemma dist_eq (p q : ℚ≥0) : dist p q = dist (p : ℚ) (q : ℚ) := rfl
+@[simp ←, push_cast]
+lemma nndist_eq (p q : ℚ≥0) : nndist p q = nndist (p : ℚ) (q : ℚ) := rfl
+
 instance : IsTopologicalSemiring ℚ≥0 where
   toContinuousAdd := continuousAdd_induced Nonneg.coeRingHom
   toContinuousMul := continuousMul_induced Nonneg.coeRingHom


### PR DESCRIPTION
and some other instances, copied over from NNReal


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
