### PR TITLE
[Merged by Bors] - feat: a bit more LinearIndepOn api

### DIFF
--- a/Mathlib/LinearAlgebra/Dimension/Basic.lean
+++ b/Mathlib/LinearAlgebra/Dimension/Basic.lean
@@ -94,7 +94,7 @@ theorem cardinal_le_rank' {s : Set M}
 
 theorem _root_.LinearIndepOn.encard_le_toENat_rank {ι : Type*} {v : ι → M} {s : Set ι}
     (hs : LinearIndepOn R v s) : s.encard ≤ (Module.rank R M).toENat := by
-  simpa using OrderHom.mono (β := ℕ∞) Cardinal.toENat <| hs.linearIndependent.cardinal_lift_le_rank
+  simpa using OrderHom.mono (β := ℕ∞) Cardinal.toENat hs.linearIndependent.cardinal_lift_le_rank
 
 end LinearIndependent
 

--- a/Mathlib/LinearAlgebra/Dimension/Basic.lean
+++ b/Mathlib/LinearAlgebra/Dimension/Basic.lean
@@ -5,7 +5,7 @@ Authors: Mario Carneiro, Johannes Hölzl, Sander Dahmen, Kim Morrison
 -/
 import Mathlib.Algebra.Algebra.Tower
 import Mathlib.LinearAlgebra.LinearIndependent.Basic
-import Mathlib.SetTheory.Cardinal.Basic
+import Mathlib.Data.Set.Card
 
 /-!
 # Dimension of modules and vector spaces
@@ -68,7 +68,6 @@ lemma nonempty_linearIndependent_set : Nonempty {s : Set M // LinearIndepOn R id
 
 end
 
-
 namespace LinearIndependent
 variable [Semiring R] [AddCommMonoid M] [Module R M]
 
@@ -92,6 +91,10 @@ theorem cardinal_le_rank {ι : Type v} {v : ι → M}
 theorem cardinal_le_rank' {s : Set M}
     (hs : LinearIndependent R (fun x => x : s → M)) : #s ≤ Module.rank R M :=
   hs.cardinal_le_rank
+
+theorem _root_.LinearIndepOn.encard_le_toENat_rank {ι : Type*} {v : ι → M} {s : Set ι}
+    (hs : LinearIndepOn R v s) : s.encard ≤ (Module.rank R M).toENat := by
+  simpa using OrderHom.mono (β := ℕ∞) Cardinal.toENat <| hs.linearIndependent.cardinal_lift_le_rank
 
 end LinearIndependent
 

--- a/Mathlib/LinearAlgebra/Dimension/StrongRankCondition.lean
+++ b/Mathlib/LinearAlgebra/Dimension/StrongRankCondition.lean
@@ -371,8 +371,8 @@ theorem rank_span_set {s : Set M} (hs : LinearIndepOn R id s) : Module.rank R �
   rw [← @setOf_mem_eq _ s, ← Subtype.range_coe_subtype]
   exact rank_span hs
 
-theorem toENat_rank_span_set {ι : Type*} {v : ι → M} {s : Set ι}
-    (hs : LinearIndepOn R v s) : (Module.rank R ↑(span R (v '' s))).toENat = s.encard := by
+theorem toENat_rank_span_set {v : ι → M} {s : Set ι} (hs : LinearIndepOn R v s) :
+    (Module.rank R <| span R <| v '' s).toENat = s.encard := by
   rw [image_eq_range, ← hs.injOn.encard_image, ← toENat_cardinalMk, image_eq_range,
     ← rank_span hs.linearIndependent]
 

--- a/Mathlib/LinearAlgebra/Dimension/StrongRankCondition.lean
+++ b/Mathlib/LinearAlgebra/Dimension/StrongRankCondition.lean
@@ -371,6 +371,11 @@ theorem rank_span_set {s : Set M} (hs : LinearIndepOn R id s) : Module.rank R �
   rw [← @setOf_mem_eq _ s, ← Subtype.range_coe_subtype]
   exact rank_span hs
 
+theorem toENat_rank_span_set {ι : Type*} {v : ι → M} {s : Set ι}
+    (hs : LinearIndepOn R v s) : (Module.rank R ↑(span R (v '' s))).toENat = s.encard := by
+  rw [image_eq_range, ← hs.injOn.encard_image, ← toENat_cardinalMk, image_eq_range,
+    ← rank_span hs.linearIndependent]
+
 /-- An induction (and recursion) principle for proving results about all submodules of a fixed
 finite free module `M`. A property is true for all submodules of `M` if it satisfies the following
 "inductive step": the property is true for a submodule `N` if it's true for all submodules `N'`

--- a/Mathlib/LinearAlgebra/LinearIndependent/Defs.lean
+++ b/Mathlib/LinearAlgebra/LinearIndependent/Defs.lean
@@ -553,6 +553,7 @@ theorem linearIndependent_iff :
     LinearIndependent R v ↔ ∀ l, Finsupp.linearCombination R v l = 0 → l = 0 := by
   simp [linearIndependent_iff_ker, LinearMap.ker_eq_bot']
 
+/-- A version of `linearIndependent_iff` where the linear combination is a `Finset` sum. -/
 theorem linearIndependent_iff' :
     LinearIndependent R v ↔
       ∀ s : Finset ι, ∀ g : ι → R, ∑ i ∈ s, g i • v i = 0 → ∀ i ∈ s, g i = 0 := by
@@ -562,6 +563,8 @@ theorem linearIndependent_iff' :
   · rw [← sub_eq_zero, ← Finset.sum_sub_distrib]
     convert h s (f - g) using 3 <;> simp only [Pi.sub_apply, sub_smul, sub_eq_zero]
 
+/-- A version of `linearIndependent_iff` where the linear combination is a `Finset` sum
+of a function with support contained in the `Finset`. -/
 theorem linearIndependent_iff'' :
     LinearIndependent R v ↔
       ∀ (s : Finset ι) (g : ι → R), (∀ i ∉ s, g i = 0) → ∑ i ∈ s, g i • v i = 0 → ∀ i, g i = 0 := by
@@ -650,6 +653,28 @@ theorem linearIndepOn_iff_linearCombinationOn :
 
 @[deprecated (since := "2025-02-15")] alias linearIndependent_iff_linearCombinationOn :=
   linearIndepOn_iff_linearCombinationOn
+
+/-- A version of `linearIndepOn_iff` where the linear combination is a `Finset` sum. -/
+lemma linearIndepOn_iff' : LinearIndepOn R v s ↔ ∀ (t : Finset ι) (g : ι → R), (t : Set ι) ⊆ s →
+    ∑ i ∈ t, g i • v i = 0 → ∀ i ∈ t, g i = 0 := by
+  classical
+  rw [LinearIndepOn, linearIndependent_iff']
+  refine ⟨fun h t g hts h0 i hit ↦ ?_, fun h t g h0 i hit ↦ ?_⟩
+  · refine h (t.preimage _ Subtype.val_injective.injOn) (fun i ↦ g i) ?_ ⟨i, hts hit⟩ (by simpa)
+    rwa [t.sum_preimage ((↑) : s → ι) Subtype.val_injective.injOn (fun i ↦ g i • v i)]
+    simp only [Subtype.range_coe_subtype, setOf_mem_eq, smul_eq_zero]
+    exact fun x hxt hxs ↦ (hxs (hts hxt)) |>.elim
+  replace h : ∀ i (hi : i ∈ s), ⟨i, hi⟩ ∈ t → ∀ (h : i ∈ s), g ⟨i, h⟩ = 0 := by
+    simpa [h0] using h (t.image (↑)) (fun i ↦ if hi : i ∈ s then g ⟨i, hi⟩ else 0)
+  apply h _ _ hit
+
+/-- A version of `linearIndepOn_iff` where the linear combination is a `Finset` sum
+of a function with support contained in the `Finset`. -/
+lemma linearIndepOn_iff'' : LinearIndepOn R v s ↔ ∀ (t : Finset ι) (g : ι → R), (t : Set ι) ⊆ s →
+    (∀ i ∉ t, g i = 0) → ∑ i ∈ t, g i • v i = 0 → ∀ i ∈ t, g i = 0 := by
+  classical
+  exact linearIndepOn_iff'.trans ⟨fun h t g hts htg h0 ↦ h _ _ hts h0, fun h t g hts h0 ↦
+    by simpa +contextual [h0] using h t (fun i ↦ if i ∈ t then g i else 0) hts⟩
 
 end LinearIndepOn
 

--- a/Mathlib/LinearAlgebra/LinearIndependent/Lemmas.lean
+++ b/Mathlib/LinearAlgebra/LinearIndependent/Lemmas.lean
@@ -233,16 +233,26 @@ theorem Fintype.linearIndependent_iff' [Fintype ι] [DecidableEq ι] :
       LinearMap.ker (LinearMap.lsum R (fun _ ↦ R) ℕ fun i ↦ LinearMap.id.smulRight (v i)) = ⊥ := by
   simp [Fintype.linearIndependent_iff, LinearMap.ker_eq_bot', funext_iff]
 
+/-- `linearIndepOn_pair_iff` is a simpler version over fields. -/
+lemma LinearIndepOn.pair_iff {i j : ι} (f : ι → M) (hij : i ≠ j) :
+    LinearIndepOn R f {i,j} ↔ ∀ c d : R, c • f i + d • f j = 0 → c = 0 ∧ d = 0 := by
+  classical
+  rw [linearIndepOn_iff'']
+  refine ⟨fun h c d hcd ↦ ?_, fun h t g ht hg0 h0 ↦ ?_⟩
+  · specialize h {i, j} (Pi.single i c + Pi.single j d)
+    simpa +contextual [Finset.sum_pair, Pi.single_apply, hij, hij.symm, hcd] using h
+  have ht' : t ⊆ {i, j} := by simpa [← Finset.coe_subset]
+  rw [Finset.sum_subset ht', Finset.sum_pair hij] at h0
+  · obtain ⟨hi0, hj0⟩ := h _ _ h0
+    exact fun k hkt ↦ Or.elim (ht hkt) (fun h ↦ h ▸ hi0) (fun h ↦ h ▸ hj0)
+  simp +contextual [hg0]
+
 /-- Also see `LinearIndependent.pair_iff'` for a simpler version over fields. -/
 lemma LinearIndependent.pair_iff {x y : M} :
     LinearIndependent R ![x, y] ↔ ∀ (s t : R), s • x + t • y = 0 → s = 0 ∧ t = 0 := by
-  refine ⟨fun h s t hst ↦ h.eq_zero_of_pair hst, fun h ↦ ?_⟩
-  apply Fintype.linearIndependent_iff.2
-  intro g hg
-  simp only [Fin.sum_univ_two, Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons] at hg
-  intro i
-  fin_cases i
-  exacts [(h _ _ hg).1, (h _ _ hg).2]
+  rw [← linearIndepOn_univ, ← Finset.coe_univ, show @Finset.univ (Fin 2) _ = {0,1} from rfl,
+    Finset.coe_insert, Finset.coe_singleton, LinearIndepOn.pair_iff _ (by trivial)]
+  simp
 
 lemma LinearIndependent.pair_symm_iff {x y : M} :
     LinearIndependent R ![x, y] ↔ LinearIndependent R ![y, x] := by
@@ -494,6 +504,7 @@ theorem linearIndepOn_id_pair {x y : V} (hx : x ≠ 0) (hy : ∀ a : K, a • x 
 
 @[deprecated (since := "2025-02-15")] alias linearIndependent_pair := linearIndepOn_id_pair
 
+/-- `LinearIndepOn.pair_iff` is a version that works over arbitrary rings. -/
 theorem linearIndepOn_pair_iff {i j : ι} (v : ι → V) (hij : i ≠ j) (hi : v i ≠ 0):
     LinearIndepOn K v {i, j} ↔ ∀ (c : K), c • v i ≠ v j := by
   rw [pair_comm]
@@ -503,17 +514,9 @@ theorem linearIndepOn_pair_iff {i j : ι} (v : ι → V) (hij : i ≠ j) (hi : v
 /-- Also see `LinearIndependent.pair_iff` for the version over arbitrary rings. -/
 theorem LinearIndependent.pair_iff' {x y : V} (hx : x ≠ 0) :
     LinearIndependent K ![x, y] ↔ ∀ a : K, a • x ≠ y := by
-  rw [LinearIndependent.pair_iff]
-  constructor
-  · intro H a ha
-    have := (H a (-1) (by simpa [← sub_eq_add_neg, sub_eq_zero])).2
-    simp only [neg_eq_zero, one_ne_zero] at this
-  · intro H s t hst
-    by_cases ht : t = 0
-    · exact ⟨by simpa [ht, hx] using hst, ht⟩
-    apply_fun (t⁻¹ • ·) at hst
-    simp only [smul_add, smul_smul, inv_mul_cancel₀ ht] at hst
-    cases H (-(t⁻¹ * s)) <| by linear_combination (norm := match_scalars <;> noncomm_ring) -hst
+  rw [← linearIndepOn_univ, ← Finset.coe_univ, show @Finset.univ (Fin 2) _ = {0,1} from rfl,
+    Finset.coe_insert, Finset.coe_singleton, linearIndepOn_pair_iff _ (by simp) (by simpa)]
+  simp
 
 theorem linearIndependent_fin_cons {n} {v : Fin n → V} :
     LinearIndependent K (Fin.cons x v : Fin (n + 1) → V) ↔


### PR DESCRIPTION
We add some more API for `LinearIndepOn`.


The large import is so a lemma about dimension can be stated with `Set.encard` - it is unclear where such a lemma belongs if not where it is. 

---

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
