### PR TITLE
[Merged by Bors] - chore: adapt more whitespace

### DIFF
--- a/Mathlib/Algebra/Category/ModuleCat/EnoughInjectives.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/EnoughInjectives.lean
@@ -28,7 +28,7 @@ lemma ModuleCat.enoughInjectives : EnoughInjectives (ModuleCat.{max v u} R) :=
   EnoughInjectives.of_adjunction (ModuleCat.restrictCoextendScalarsAdj.{max v u} (algebraMap ℤ R))
 
 open ModuleCat in
-instance [UnivLE.{u,v}] : EnoughInjectives (ModuleCat.{v} R) :=
+instance [UnivLE.{u, v}] : EnoughInjectives (ModuleCat.{v} R) :=
   letI := (equivShrink.{v} R).symm.ring
   letI := enoughInjectives.{v} (Shrink.{v} R)
   EnoughInjectives.of_equivalence (restrictScalars (equivShrink R).symm.ringEquiv.toRingHom)

--- a/Mathlib/Analysis/SpecialFunctions/Complex/Log.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Complex/Log.lean
@@ -254,7 +254,7 @@ end LogDeriv
 
 section tsum_tprod
 
-variable {α ι: Type*}
+variable {α ι : Type*}
 
 open Real
 

--- a/Mathlib/Condensed/Discrete/Colimit.lean
+++ b/Mathlib/Condensed/Discrete/Colimit.lean
@@ -26,11 +26,11 @@ namespace Condensed
 section LocallyConstantAsColimit
 
 variable {I : Type u} [Category.{u} I] [IsCofiltered I] {F : I ⥤ FintypeCat.{u}}
-  (c : Cone <| F ⋙ toProfinite) (X : Type (u+1))
+  (c : Cone <| F ⋙ toProfinite) (X : Type (u + 1))
 
 /-- The presheaf on `Profinite` of locally constant functions to `X`. -/
-abbrev locallyConstantPresheaf : Profinite.{u}ᵒᵖ ⥤ Type (u+1) :=
-  CompHausLike.LocallyConstant.functorToPresheaves.{u, u+1}.obj X
+abbrev locallyConstantPresheaf : Profinite.{u}ᵒᵖ ⥤ Type (u + 1) :=
+  CompHausLike.LocallyConstant.functorToPresheaves.{u, u + 1}.obj X
 
 /--
 The functor `locallyConstantPresheaf` takes cofiltered limits of finite sets with surjective
@@ -83,20 +83,20 @@ end LocallyConstantAsColimit
 Given a presheaf `F` on `Profinite`, `lanPresheaf F` is the left Kan extension of its
 restriction to finite sets along the inclusion functor of finite sets into `Profinite`.
 -/
-abbrev lanPresheaf (F : Profinite.{u}ᵒᵖ ⥤ Type (u+1)) : Profinite.{u}ᵒᵖ ⥤ Type (u+1) :=
+abbrev lanPresheaf (F : Profinite.{u}ᵒᵖ ⥤ Type (u + 1)) : Profinite.{u}ᵒᵖ ⥤ Type (u + 1) :=
   pointwiseLeftKanExtension toProfinite.op (toProfinite.op ⋙ F)
 
 /--
 To presheaves on `Profinite` whose restrictions to finite sets are isomorphic have isomorphic left
 Kan extensions.
 -/
-def lanPresheafExt {F G : Profinite.{u}ᵒᵖ ⥤ Type (u+1)}
+def lanPresheafExt {F G : Profinite.{u}ᵒᵖ ⥤ Type (u + 1)}
     (i : toProfinite.op ⋙ F ≅ toProfinite.op ⋙ G) : lanPresheaf F ≅ lanPresheaf G :=
   leftKanExtensionUniqueOfIso _ (pointwiseLeftKanExtensionUnit _ _) i _
     (pointwiseLeftKanExtensionUnit _ _)
 
 @[simp]
-lemma lanPresheafExt_hom {F G : Profinite.{u}ᵒᵖ ⥤ Type (u+1)} (S : Profinite.{u}ᵒᵖ)
+lemma lanPresheafExt_hom {F G : Profinite.{u}ᵒᵖ ⥤ Type (u + 1)} (S : Profinite.{u}ᵒᵖ)
     (i : toProfinite.op ⋙ F ≅ toProfinite.op ⋙ G) : (lanPresheafExt i).hom.app S =
       colimMap (whiskerLeft (CostructuredArrow.proj toProfinite.op S) i.hom) := by
   simp only [lanPresheaf, pointwiseLeftKanExtension_obj, lanPresheafExt,
@@ -105,7 +105,7 @@ lemma lanPresheafExt_hom {F G : Profinite.{u}ᵒᵖ ⥤ Type (u+1)} (S : Profini
   aesop
 
 @[simp]
-lemma lanPresheafExt_inv {F G : Profinite.{u}ᵒᵖ ⥤ Type (u+1)} (S : Profinite.{u}ᵒᵖ)
+lemma lanPresheafExt_inv {F G : Profinite.{u}ᵒᵖ ⥤ Type (u + 1)} (S : Profinite.{u}ᵒᵖ)
     (i : toProfinite.op ⋙ F ≅ toProfinite.op ⋙ G) : (lanPresheafExt i).inv.app S =
       colimMap (whiskerLeft (CostructuredArrow.proj toProfinite.op S) i.inv) := by
   simp only [lanPresheaf, pointwiseLeftKanExtension_obj, lanPresheafExt,
@@ -113,7 +113,7 @@ lemma lanPresheafExt_inv {F G : Profinite.{u}ᵒᵖ ⥤ Type (u+1)} (S : Profini
   apply colimit.hom_ext
   aesop
 
-variable {S : Profinite.{u}} {F : Profinite.{u}ᵒᵖ ⥤ Type (u+1)}
+variable {S : Profinite.{u}} {F : Profinite.{u}ᵒᵖ ⥤ Type (u + 1)}
 
 instance : Final <| Profinite.Extend.functorOp S.asLimitCone :=
   Profinite.Extend.functorOp_final S.asLimitCone S.asLimit
@@ -148,33 +148,34 @@ lemma lanPresheafNatIso_hom_app (hF : ∀ S : Profinite, IsColimit <| F.mapCocon
 /--
 `lanPresheaf (locallyConstantPresheaf X)` is a sheaf for the coherent topology on `Profinite`.
 -/
-def lanSheafProfinite (X : Type (u+1)) : Sheaf (coherentTopology Profinite.{u}) (Type (u+1)) where
+def lanSheafProfinite (X : Type (u + 1)) :
+    Sheaf (coherentTopology Profinite.{u}) (Type (u + 1)) where
   val := lanPresheaf (locallyConstantPresheaf X)
   cond := by
     rw [Presheaf.isSheaf_of_iso_iff (lanPresheafNatIso
       fun _ ↦ isColimitLocallyConstantPresheafDiagram _ _)]
-    exact ((CompHausLike.LocallyConstant.functor.{u, u+1}
+    exact ((CompHausLike.LocallyConstant.functor.{u, u + 1}
       (hs := fun _ _ _ ↦ ((Profinite.effectiveEpi_tfae _).out 0 2).mp)).obj X).cond
 
 /-- `lanPresheaf (locallyConstantPresheaf X)` as a condensed set. -/
-def lanCondensedSet (X : Type (u+1)) : CondensedSet.{u} :=
+def lanCondensedSet (X : Type (u + 1)) : CondensedSet.{u} :=
   (ProfiniteCompHaus.equivalence _).functor.obj (lanSheafProfinite X)
 
-variable (F : Profinite.{u}ᵒᵖ ⥤ Type (u+1))
+variable (F : Profinite.{u}ᵒᵖ ⥤ Type (u + 1))
 
 /--
 The functor which takes a finite set to the set of maps into `F(*)` for a presheaf `F` on
 `Profinite`.
 -/
 @[simps]
-def finYoneda : FintypeCat.{u}ᵒᵖ ⥤ Type (u+1) where
-  obj X := X.unop → F.obj (toProfinite.op.obj ⟨of PUnit.{u+1}⟩)
+def finYoneda : FintypeCat.{u}ᵒᵖ ⥤ Type (u + 1) where
+  obj X := X.unop → F.obj (toProfinite.op.obj ⟨of PUnit.{u + 1}⟩)
   map f g := g ∘ f.unop
 
 /-- `locallyConstantPresheaf` restricted to finite sets is isomorphic to `finYoneda F`. -/
 @[simps! hom_app]
 def locallyConstantIsoFinYoneda :
-    toProfinite.op ⋙ (locallyConstantPresheaf (F.obj (toProfinite.op.obj ⟨of PUnit.{u+1}⟩))) ≅
+    toProfinite.op ⋙ (locallyConstantPresheaf (F.obj (toProfinite.op.obj ⟨of PUnit.{u + 1}⟩))) ≅
     finYoneda F :=
   NatIso.ofComponents fun Y ↦ {
     hom := fun f ↦ f.1
@@ -182,7 +183,7 @@ def locallyConstantIsoFinYoneda :
 
 /-- A finite set as a coproduct cocone in `Profinite` over itself. -/
 def fintypeCatAsCofan (X : Profinite) :
-    Cofan (fun (_ : X) ↦ (Profinite.of (PUnit.{u+1}))) :=
+    Cofan (fun (_ : X) ↦ (Profinite.of (PUnit.{u + 1}))) :=
   Cofan.mk X (fun x ↦ TopCat.ofHom (ContinuousMap.const _ x))
 
 /-- A finite set is the coproduct of its points in `Profinite`. -/
@@ -204,13 +205,13 @@ noncomputable instance (X : Profinite) [Finite X] :
 
 /-- Auxiliary definition for `isoFinYoneda`. -/
 def isoFinYonedaComponents (X : Profinite.{u}) [Finite X] :
-    F.obj ⟨X⟩ ≅ (X → F.obj ⟨Profinite.of PUnit.{u+1}⟩) :=
+    F.obj ⟨X⟩ ≅ (X → F.obj ⟨Profinite.of PUnit.{u + 1}⟩) :=
   (isLimitFanMkObjOfIsLimit F _ _
     (Cofan.IsColimit.op (fintypeCatAsCofanIsColimit X))).conePointUniqueUpToIso
-      (Types.productLimitCone.{u, u+1} fun _ ↦ F.obj ⟨Profinite.of PUnit.{u+1}⟩).2
+      (Types.productLimitCone.{u, u + 1} fun _ ↦ F.obj ⟨Profinite.of PUnit.{u + 1}⟩).2
 
 lemma isoFinYonedaComponents_hom_apply (X : Profinite.{u}) [Finite X] (y : F.obj ⟨X⟩) (x : X) :
-    (isoFinYonedaComponents F X).hom y x = F.map ((Profinite.of PUnit.{u+1}).const x).op y := rfl
+    (isoFinYonedaComponents F X).hom y x = F.map ((Profinite.of PUnit.{u + 1}).const x).op y := rfl
 
 lemma isoFinYonedaComponents_inv_comp {X Y : Profinite.{u}} [Finite X] [Finite Y]
     (f : Y → F.obj ⟨Profinite.of PUnit⟩) (g : X ⟶ Y) :
@@ -241,16 +242,16 @@ colimit, is isomorphic to the presheaf `LocallyConstant - F(*)`.
 -/
 def isoLocallyConstantOfIsColimit
     (hF : ∀ S : Profinite, IsColimit <| F.mapCocone S.asLimitCone.op) :
-    F ≅ (locallyConstantPresheaf (F.obj (toProfinite.op.obj ⟨of PUnit.{u+1}⟩))) :=
+    F ≅ (locallyConstantPresheaf (F.obj (toProfinite.op.obj ⟨of PUnit.{u + 1}⟩))) :=
   (lanPresheafNatIso hF).symm ≪≫
     lanPresheafExt (isoFinYoneda F ≪≫ (locallyConstantIsoFinYoneda F).symm) ≪≫
       lanPresheafNatIso fun _ ↦ isColimitLocallyConstantPresheafDiagram _ _
 
-lemma isoLocallyConstantOfIsColimit_inv (X : Profinite.{u}ᵒᵖ ⥤ Type (u+1))
+lemma isoLocallyConstantOfIsColimit_inv (X : Profinite.{u}ᵒᵖ ⥤ Type (u + 1))
     [PreservesFiniteProducts X]
     (hX : ∀ S : Profinite.{u}, (IsColimit <| X.mapCocone S.asLimitCone.op)) :
     (isoLocallyConstantOfIsColimit X hX).inv =
-      (CompHausLike.LocallyConstant.counitApp.{u, u+1} X) := by
+      (CompHausLike.LocallyConstant.counitApp.{u, u + 1} X) := by
   dsimp [isoLocallyConstantOfIsColimit]
   simp only [Category.assoc]
   rw [Iso.inv_comp_eq]
@@ -266,23 +267,23 @@ lemma isoLocallyConstantOfIsColimit_inv (X : Profinite.{u}ᵒᵖ ⥤ Type (u+1))
       Profinite.Extend.cocone_pt, Cocones.precompose_obj_ι, Category.assoc, const_obj_obj,
       whiskerLeft_app, NatIso.ofComponents_hom_app, NatIso.ofComponents_inv_app,
       Profinite.Extend.cocone_ι_app, counitApp, colimit.ι_desc_assoc]
-  erw [(counitApp.{u, u+1} X).naturality]
+  erw [(counitApp.{u, u + 1} X).naturality]
   simp only [← Category.assoc]
   congr
   ext f
   simp only [types_comp_apply, isoFinYoneda_inv_app, counitApp_app]
-  apply presheaf_ext.{u, u+1} (X := X) (Y := X) (f := f)
+  apply presheaf_ext.{u, u + 1} (X := X) (Y := X) (f := f)
   intro x
   rw [incl_of_counitAppApp]
   simp only [counitAppAppImage, CompHausLike.coe_of]
-  letI : Fintype (fiber.{u, u+1} f x) :=
-    Fintype.ofInjective (sigmaIncl.{u, u+1} f x).1 Subtype.val_injective
-  apply injective_of_mono (isoFinYonedaComponents X (fiber.{u, u+1} f x)).hom
+  letI : Fintype (fiber.{u, u + 1} f x) :=
+    Fintype.ofInjective (sigmaIncl.{u, u + 1} f x).1 Subtype.val_injective
+  apply injective_of_mono (isoFinYonedaComponents X (fiber.{u, u + 1} f x)).hom
   ext y
   simp only [isoFinYonedaComponents_hom_apply, ← FunctorToTypes.map_comp_apply, ← op_comp]
-  rw [show (Profinite.of PUnit.{u+1}).const y ≫ IsTerminal.from _ (fiber f x) = 𝟙 _ from rfl]
+  rw [show (Profinite.of PUnit.{u + 1}).const y ≫ IsTerminal.from _ (fiber f x) = 𝟙 _ from rfl]
   simp only [op_comp, FunctorToTypes.map_comp_apply, op_id, FunctorToTypes.map_id_apply]
-  rw [← isoFinYonedaComponents_inv_comp X _ (sigmaIncl.{u, u+1} f x)]
+  rw [← isoFinYonedaComponents_inv_comp X _ (sigmaIncl.{u, u + 1} f x)]
   simpa [← isoFinYonedaComponents_hom_apply] using x.map_eq_image f y
 
 end Condensed
@@ -442,19 +443,19 @@ The functor which takes a finite set to the set of maps into `F(*)` for a preshe
 -/
 @[simps]
 def finYoneda : FintypeCat.{u}ᵒᵖ ⥤ Type u where
-  obj X := X.unop → F.obj (toLightProfinite.op.obj ⟨of PUnit.{u+1}⟩)
+  obj X := X.unop → F.obj (toLightProfinite.op.obj ⟨of PUnit.{u + 1}⟩)
   map f g := g ∘ f.unop
 
 /-- `locallyConstantPresheaf` restricted to finite sets is isomorphic to `finYoneda F`. -/
 def locallyConstantIsoFinYoneda : toLightProfinite.op ⋙
-    (locallyConstantPresheaf (F.obj (toLightProfinite.op.obj ⟨of PUnit.{u+1}⟩))) ≅ finYoneda F :=
+    (locallyConstantPresheaf (F.obj (toLightProfinite.op.obj ⟨of PUnit.{u + 1}⟩))) ≅ finYoneda F :=
   NatIso.ofComponents fun Y ↦ {
     hom := fun f ↦ f.1
     inv := fun f ↦ ⟨f, @IsLocallyConstant.of_discrete _ _ _ ⟨rfl⟩ _⟩ }
 
 /-- A finite set as a coproduct cocone in `LightProfinite` over itself. -/
 def fintypeCatAsCofan (X : LightProfinite) :
-    Cofan (fun (_ : X) ↦ (LightProfinite.of (PUnit.{u+1}))) :=
+    Cofan (fun (_ : X) ↦ (LightProfinite.of (PUnit.{u + 1}))) :=
   Cofan.mk X (fun x ↦ TopCat.ofHom (ContinuousMap.const _ x))
 
 /-- A finite set is the coproduct of its points in `LightProfinite`. -/
@@ -475,14 +476,14 @@ noncomputable instance (X : FintypeCat.{u}) : PreservesLimitsOfShape (Discrete X
 
 /-- Auxiliary definition for `isoFinYoneda`. -/
 def isoFinYonedaComponents (X : LightProfinite.{u}) [Finite X] :
-    F.obj ⟨X⟩ ≅ (X → F.obj ⟨LightProfinite.of PUnit.{u+1}⟩) :=
+    F.obj ⟨X⟩ ≅ (X → F.obj ⟨LightProfinite.of PUnit.{u + 1}⟩) :=
   (isLimitFanMkObjOfIsLimit F _ _
     (Cofan.IsColimit.op (fintypeCatAsCofanIsColimit X))).conePointUniqueUpToIso
-      (Types.productLimitCone.{u, u} fun _ ↦ F.obj ⟨LightProfinite.of PUnit.{u+1}⟩).2
+      (Types.productLimitCone.{u, u} fun _ ↦ F.obj ⟨LightProfinite.of PUnit.{u + 1}⟩).2
 
 lemma isoFinYonedaComponents_hom_apply (X : LightProfinite.{u}) [Finite X] (y : F.obj ⟨X⟩)
     (x : X) : (isoFinYonedaComponents F X).hom y x =
-      F.map ((LightProfinite.of PUnit.{u+1}).const x).op y := rfl
+      F.map ((LightProfinite.of PUnit.{u + 1}).const x).op y := rfl
 
 lemma isoFinYonedaComponents_inv_comp {X Y : LightProfinite.{u}} [Finite X] [Finite Y]
     (f : Y → F.obj ⟨LightProfinite.of PUnit⟩) (g : X ⟶ Y) :
@@ -515,7 +516,7 @@ colimit, is isomorphic to the presheaf `LocallyConstant - F(*)`.
 def isoLocallyConstantOfIsColimit (hF : ∀ S : LightProfinite, IsColimit <|
     F.mapCocone (coconeRightOpOfCone S.asLimitCone)) :
       F ≅ (locallyConstantPresheaf
-        (F.obj (toLightProfinite.op.obj ⟨of PUnit.{u+1}⟩))) :=
+        (F.obj (toLightProfinite.op.obj ⟨of PUnit.{u + 1}⟩))) :=
   (lanPresheafNatIso hF).symm ≪≫
     lanPresheafExt (isoFinYoneda F ≪≫ (locallyConstantIsoFinYoneda F).symm) ≪≫
       lanPresheafNatIso fun _ ↦ isColimitLocallyConstantPresheafDiagram _ _
@@ -554,7 +555,7 @@ lemma isoLocallyConstantOfIsColimit_inv (X : LightProfinite.{u}ᵒᵖ ⥤ Type u
   apply injective_of_mono (isoFinYonedaComponents X (fiber.{u, u} f x)).hom
   ext y
   simp only [isoFinYonedaComponents_hom_apply, ← FunctorToTypes.map_comp_apply, ← op_comp]
-  rw [show (LightProfinite.of PUnit.{u+1}).const y ≫ IsTerminal.from _ (fiber f x) = 𝟙 _ from rfl]
+  rw [show (LightProfinite.of PUnit.{u + 1}).const y ≫ IsTerminal.from _ (fiber f x) = 𝟙 _ from rfl]
   simp only [op_comp, FunctorToTypes.map_comp_apply, op_id, FunctorToTypes.map_id_apply]
   rw [← isoFinYonedaComponents_inv_comp X _ (sigmaIncl.{u, u} f x)]
   simpa [← isoFinYonedaComponents_hom_apply] using x.map_eq_image f y

--- a/Mathlib/Condensed/Discrete/Module.lean
+++ b/Mathlib/Condensed/Discrete/Module.lean
@@ -63,27 +63,27 @@ namespace CondensedMod.LocallyConstant
 
 open Condensed
 
-variable (R : Type (u+1)) [Ring R]
+variable (R : Type (u + 1)) [Ring R]
 
 /-- `functorToPresheaves` in the case of `CompHaus`. -/
-abbrev functorToPresheaves : ModuleCat.{u+1} R ⥤ (CompHaus.{u}ᵒᵖ ⥤ ModuleCat R) :=
-  CompHausLike.LocallyConstantModule.functorToPresheaves.{u+1, u} R
+abbrev functorToPresheaves : ModuleCat.{u + 1} R ⥤ (CompHaus.{u}ᵒᵖ ⥤ ModuleCat R) :=
+  CompHausLike.LocallyConstantModule.functorToPresheaves.{u + 1, u} R
 
 /-- `functorToPresheaves` as a functor to condensed modules. -/
 abbrev functor : ModuleCat R ⥤ CondensedMod.{u} R :=
-  CompHausLike.LocallyConstantModule.functor.{u+1, u} R
+  CompHausLike.LocallyConstantModule.functor.{u + 1, u} R
     (fun _ _ _ ↦ ((CompHaus.effectiveEpi_tfae _).out 0 2).mp)
 
 /-- Auxiliary definition for `functorIsoDiscrete`. -/
-noncomputable def functorIsoDiscreteAux₁ (M : ModuleCat.{u+1} R) :
-    M ≅ (ModuleCat.of R (LocallyConstant (CompHaus.of PUnit.{u+1}) M)) where
+noncomputable def functorIsoDiscreteAux₁ (M : ModuleCat.{u + 1} R) :
+    M ≅ (ModuleCat.of R (LocallyConstant (CompHaus.of PUnit.{u + 1}) M)) where
   hom := ModuleCat.ofHom (constₗ R)
   inv := ModuleCat.ofHom (evalₗ R PUnit.unit)
 
 /-- Auxiliary definition for `functorIsoDiscrete`. -/
 noncomputable def functorIsoDiscreteAux₂ (M : ModuleCat R) :
     (discrete _).obj M ≅ (discrete _).obj
-      (ModuleCat.of R (LocallyConstant (CompHaus.of PUnit.{u+1}) M)) :=
+      (ModuleCat.of R (LocallyConstant (CompHaus.of PUnit.{u + 1}) M)) :=
   (discrete _).mapIso (functorIsoDiscreteAux₁ R M)
 
 attribute [local instance] Types.instFunLike Types.instConcreteCategory in
@@ -186,14 +186,14 @@ abbrev functor : ModuleCat R ⥤ LightCondMod.{u} R :=
 
 /-- Auxiliary definition for `functorIsoDiscrete`. -/
 noncomputable def functorIsoDiscreteAux₁ (M : ModuleCat.{u} R) :
-    M ≅ (ModuleCat.of R (LocallyConstant (LightProfinite.of PUnit.{u+1}) M)) where
+    M ≅ (ModuleCat.of R (LocallyConstant (LightProfinite.of PUnit.{u + 1}) M)) where
   hom := ModuleCat.ofHom (constₗ R)
   inv := ModuleCat.ofHom (evalₗ R PUnit.unit)
 
 /-- Auxiliary definition for `functorIsoDiscrete`. -/
 noncomputable def functorIsoDiscreteAux₂ (M : ModuleCat.{u} R) :
     (discrete _).obj M ≅ (discrete _).obj
-      (ModuleCat.of R (LocallyConstant (LightProfinite.of PUnit.{u+1}) M)) :=
+      (ModuleCat.of R (LocallyConstant (LightProfinite.of PUnit.{u + 1}) M)) :=
   (discrete _).mapIso (functorIsoDiscreteAux₁ R M)
 
 -- Not stating this explicitly causes timeouts below.

--- a/Mathlib/RingTheory/Flat/Basic.lean
+++ b/Mathlib/RingTheory/Flat/Basic.lean
@@ -81,7 +81,7 @@ variable {R : Type u} {M : Type v} {N P Q : Type*} [CommSemiring R] [AddCommMono
   [AddCommMonoid N] [Module R N] [AddCommMonoid P] [Module R P] [AddCommMonoid Q] [Module R Q]
 
 theorem _root_.LinearMap.rTensor_injective_of_fg {f : N →ₗ[R] P}
-    (h :  ∀ (N' : Submodule R N) (P' : Submodule R P),
+    (h : ∀ (N' : Submodule R N) (P' : Submodule R P),
       N'.FG → P'.FG → ∀ h : N' ≤ P'.comap f, Function.Injective ((f.restrict h).rTensor M)) :
     Function.Injective (f.rTensor M) := fun x y eq ↦ by
   have ⟨N', Nfg, sub⟩ := Submodule.exists_fg_le_subset_range_rTensor_subtype {x, y} (by simp)


### PR DESCRIPTION
Found by #22760.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
