### PR TITLE
feat: add the trace of a bilinear form

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3665,6 +3665,7 @@ import Mathlib.LinearAlgebra.BilinearForm.Hom
 import Mathlib.LinearAlgebra.BilinearForm.Orthogonal
 import Mathlib.LinearAlgebra.BilinearForm.Properties
 import Mathlib.LinearAlgebra.BilinearForm.TensorProduct
+import Mathlib.LinearAlgebra.BilinearForm.Trace
 import Mathlib.LinearAlgebra.BilinearMap
 import Mathlib.LinearAlgebra.Charpoly.BaseChange
 import Mathlib.LinearAlgebra.Charpoly.Basic

--- a/Mathlib/LinearAlgebra/BilinearForm/Trace.lean
+++ b/Mathlib/LinearAlgebra/BilinearForm/Trace.lean
@@ -75,8 +75,8 @@ def trace : BilinForm ℝ M →ₗ[ℝ] ℝ :=
   else
     0
 
-/-- Auxiliary lemma for `trace_eq_matrix_trace`. -/
-theorem trace_eq_matrix_trace_of_finset {s : Finset M} [DecidableEq M]
+/-- Auxiliary lemma for `trace_eq_matrixTrace`. -/
+theorem trace_eq_matrixTrace_of_finset {s : Finset M} [DecidableEq M]
     (b : OrthonormalBasis s ℝ M) (f : BilinForm ℝ M) :
     trace f = Matrix.trace (LinearMap.toMatrix₂ b.toBasis b.toBasis f) := by
   have : ∃ s : Finset M, Nonempty (OrthonormalBasis s ℝ M) := ⟨s, ⟨b⟩⟩
@@ -85,12 +85,12 @@ theorem trace_eq_matrix_trace_of_finset {s : Finset M} [DecidableEq M]
   convert traceAux_orthonormalBasis_congr _ _
 
 /-- Any choice of orthonormal basis can be used to expand the trace -/
-theorem trace_eq_matrix_trace (b : OrthonormalBasis ι ℝ M) (f : BilinForm ℝ M) :
+theorem trace_eq_matrixTrace (b : OrthonormalBasis ι ℝ M) (f : BilinForm ℝ M) :
     trace f = Matrix.trace (LinearMap.toMatrix₂ b.toBasis b.toBasis f) := by
   classical
   have : OrthonormalBasis (Finset.univ.image b) ℝ M :=
     b.reindex (Equiv.ofInjective b b.toBasis.injective |>.trans <| .subtypeEquivProp <| by simp)
-  rw [trace_eq_matrix_trace_of_finset this, ← traceAux_apply, ← traceAux_apply,
+  rw [trace_eq_matrixTrace_of_finset this, ← traceAux_apply, ← traceAux_apply,
     traceAux_orthonormalBasis_congr this b]
 
 end InnerProductSpace

--- a/Mathlib/LinearAlgebra/BilinearForm/Trace.lean
+++ b/Mathlib/LinearAlgebra/BilinearForm/Trace.lean
@@ -1,0 +1,99 @@
+/-
+Copyright (c) 2024 Eric Wieser. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Eric Wieser
+-/
+
+import Mathlib.Analysis.InnerProductSpace.PiL2
+import Mathlib.LinearAlgebra.Matrix.SesquilinearForm
+
+/-!
+# The trace of a bilinear form
+-/
+
+variable {ι ι' R M N : Type*}
+
+noncomputable section
+
+namespace LinearMap
+namespace BilinMap
+open scoped Matrix
+open LinearMap (BilinMap BilinForm)
+
+section Module
+
+variable [Fintype ι] [DecidableEq ι] [Fintype ι'] [DecidableEq ι']
+variable [CommSemiring R] [AddCommMonoid M] [AddCommMonoid N]
+variable [Module R M] [Module R N]
+
+/-- The trace of a bilinear map with respect to a basis. -/
+def traceAux (b : Basis ι R M) : BilinMap R M N →ₗ[R] N :=
+  Matrix.traceLinearMap ι R N ∘ₗ LinearMap.toMatrix₂ (N₂ := N) b b
+
+theorem traceAux_apply (b : Basis ι R M) (f : BilinMap R M N) :
+    traceAux b f = Matrix.trace (toMatrix₂ b b f) :=
+  rfl
+
+/-- `traceAux` is invariant to the basis, so long as the transformation between the bases is
+orthogonal. -/
+theorem traceAux_basis_congr
+    (b : Basis ι R M) (c : Basis ι' R M) (h : c.toMatrix b * (c.toMatrix b)ᵀ = 1) :
+    traceAux b = traceAux (N := R) c :=
+  LinearMap.ext fun f =>
+    calc
+      Matrix.trace (LinearMap.toMatrix₂ b b f) =
+          Matrix.trace (LinearMap.toMatrix₂ b b (f.compl₁₂ .id .id)) := by
+        rw [LinearMap.compl₁₂_id_id]
+      _ = Matrix.trace ((c.toMatrix b)ᵀ * toMatrix₂ c c f * c.toMatrix b) := by
+        rw [LinearMap.toMatrix₂_compl₁₂ c c, toMatrix_id_eq_basis_toMatrix]
+      _ = Matrix.trace (toMatrix₂ c c f * (c.toMatrix b * (c.toMatrix b)ᵀ)) := by
+        rw [← Matrix.trace_mul_cycle, ← Matrix.mul_assoc]
+      _ = Matrix.trace (LinearMap.toMatrix₂ c c f) := by rw [h, mul_one]
+
+end Module
+
+section InnerProductSpace
+
+variable [Fintype ι] [DecidableEq ι] [Fintype ι'] [DecidableEq ι']
+variable [NormedAddCommGroup M] [InnerProductSpace ℝ M]
+variable [NormedAddCommGroup N] [InnerProductSpace ℝ N]
+
+theorem traceAux_orthonormalBasis_congr
+    (b : OrthonormalBasis ι ℝ M) (c : OrthonormalBasis ι' ℝ M) :
+    traceAux b.toBasis = traceAux (N := ℝ) c.toBasis := by
+  refine traceAux_basis_congr _ _ ?_
+  simp only [OrthonormalBasis.coe_toBasis, ← Matrix.conjTranspose_eq_transpose_of_trivial]
+  rw [c.toMatrix_orthonormalBasis_self_mul_conjTranspose b]
+
+open scoped Classical in
+/-- The trace of a bilinear form, corresponding to the trace of `LinearMap.toMatrix₂`.
+
+If no finite orthonormal basis exists, the trace is defined as zero. -/
+def trace : BilinForm ℝ M →ₗ[ℝ] ℝ :=
+  if H : ∃ s : Finset M, Nonempty (OrthonormalBasis s ℝ M) then
+    traceAux H.choose_spec.some.toBasis
+  else
+    0
+
+/-- Auxiliary lemma for `trace_eq_matrix_trace`. -/
+theorem trace_eq_matrix_trace_of_finset {s : Finset M} [DecidableEq M]
+    (b : OrthonormalBasis s ℝ M) (f : BilinForm ℝ M) :
+    trace f = Matrix.trace (LinearMap.toMatrix₂ b.toBasis b.toBasis f) := by
+  have : ∃ s : Finset M, Nonempty (OrthonormalBasis s ℝ M) := ⟨s, ⟨b⟩⟩
+  rw [trace, dif_pos this, ← traceAux_apply]
+  congr 1
+  convert traceAux_orthonormalBasis_congr _ _
+
+/-- Any choice of orthonormal basis can be used to expand the trace -/
+theorem trace_eq_matrix_trace (b : OrthonormalBasis ι ℝ M) (f : BilinForm ℝ M) :
+    trace f = Matrix.trace (LinearMap.toMatrix₂ b.toBasis b.toBasis f) := by
+  classical
+  have : OrthonormalBasis (Finset.univ.image b) ℝ M :=
+    b.reindex (Equiv.ofInjective b b.toBasis.injective |>.trans <| .subtypeEquivProp <| by simp)
+  rw [trace_eq_matrix_trace_of_finset this, ← traceAux_apply, ← traceAux_apply,
+    traceAux_orthonormalBasis_congr this b]
+
+end InnerProductSpace
+
+end BilinMap
+end LinearMap


### PR DESCRIPTION
Following the steps at [#Is there code for X? > Laplacian @ 💬](https://leanprover.zulipchat.com/#narrow/channel/217875-Is-there-code-for-X.3F/topic/Laplacian/near/450834505).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

Some questions:

* Does this generalize to multilinear maps?
* Is there an `RCLike` generalization?
* Does this generalize to `BilinMap` instead of just `BilinForm`?

Perhaps the approach in [#mathlib4 > Stating Schrodinger's equation @ 💬](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Stating.20Schrodinger's.20equation/near/500409890) of using `ContinuousLinearMap.adjoint'` is better.
