### PR TITLE
[Merged by Bors] - feat: improve definition of `AffineSubspace.mk'`, and use it in `perpBisector`

### DIFF
--- a/Mathlib/Geometry/Euclidean/PerpBisector.lean
+++ b/Mathlib/Geometry/Euclidean/PerpBisector.lean
@@ -33,8 +33,7 @@ variable {c p₁ p₂ : P}
 
 /-- Perpendicular bisector of a segment in a Euclidean affine space. -/
 def perpBisector (p₁ p₂ : P) : AffineSubspace ℝ P :=
-  .comap ((AffineEquiv.vaddConst ℝ (midpoint ℝ p₁ p₂)).symm : P →ᵃ[ℝ] V) <|
-    (LinearMap.ker (innerₛₗ ℝ (p₂ -ᵥ p₁))).toAffineSubspace
+  mk' (midpoint ℝ p₁ p₂) (LinearMap.ker (innerₛₗ ℝ (p₂ -ᵥ p₁)))
 
 /-- A point `c` belongs the perpendicular bisector of `[p₁, p₂] iff `p₂ -ᵥ p₁` is orthogonal to
 `c -ᵥ midpoint ℝ p₁ p₂`. -/
@@ -70,8 +69,7 @@ theorem perpBisector_nonempty : (perpBisector p₁ p₂ : Set P).Nonempty :=
 @[simp]
 theorem direction_perpBisector (p₁ p₂ : P) :
     (perpBisector p₁ p₂).direction = (ℝ ∙ (p₂ -ᵥ p₁))ᗮ := by
-  erw [perpBisector, comap_symm, map_direction, Submodule.map_id,
-    Submodule.toAffineSubspace_direction]
+  rw [perpBisector, direction_mk']
   ext x
   exact Submodule.mem_orthogonal_singleton_iff_inner_right.symm
 

--- a/Mathlib/LinearAlgebra/AffineSpace/AffineSubspace/Defs.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/AffineSubspace/Defs.lean
@@ -322,23 +322,24 @@ theorem eq_iff_direction_eq_of_mem {s₁ s₂ : AffineSubspace k P} {p : P} (h�
 
 /-- Construct an affine subspace from a point and a direction. -/
 def mk' (p : P) (direction : Submodule k V) : AffineSubspace k P where
-  carrier := { q | ∃ v ∈ direction, q = v +ᵥ p }
+  carrier := { q | q -ᵥ p ∈ direction }
   smul_vsub_vadd_mem c p₁ p₂ p₃ hp₁ hp₂ hp₃ := by
-    rcases hp₁ with ⟨v₁, hv₁, hp₁⟩
-    rcases hp₂ with ⟨v₂, hv₂, hp₂⟩
-    rcases hp₃ with ⟨v₃, hv₃, hp₃⟩
-    use c • (v₁ - v₂) + v₃, direction.add_mem (direction.smul_mem c (direction.sub_mem hv₁ hv₂)) hv₃
-    simp [hp₁, hp₂, hp₃, vadd_vadd]
+    simpa [vadd_vsub_assoc] using
+      direction.add_mem (direction.smul_mem c (direction.sub_mem hp₁ hp₂)) hp₃
+
+@[simp]
+theorem mem_mk' (p q : P) (direction : Submodule k V) : q ∈ mk' p direction ↔ q -ᵥ p ∈ direction :=
+  Iff.rfl
 
 /-- An affine subspace constructed from a point and a direction contains that point. -/
-theorem self_mem_mk' (p : P) (direction : Submodule k V) : p ∈ mk' p direction :=
-  ⟨0, ⟨direction.zero_mem, (zero_vadd _ _).symm⟩⟩
+theorem self_mem_mk' (p : P) (direction : Submodule k V) : p ∈ mk' p direction := by
+  simp
 
 /-- An affine subspace constructed from a point and a direction contains the result of adding a
 vector in that direction to that point. -/
 theorem vadd_mem_mk' {v : V} (p : P) {direction : Submodule k V} (hv : v ∈ direction) :
-    v +ᵥ p ∈ mk' p direction :=
-  ⟨v, hv, rfl⟩
+    v +ᵥ p ∈ mk' p direction := by
+  simpa
 
 /-- An affine subspace constructed from a point and a direction is nonempty. -/
 theorem mk'_nonempty (p : P) (direction : Submodule k V) : (mk' p direction : Set P).Nonempty :=
@@ -351,9 +352,8 @@ theorem direction_mk' (p : P) (direction : Submodule k V) :
   ext v
   rw [mem_direction_iff_eq_vsub (mk'_nonempty _ _)]
   constructor
-  · rintro ⟨p₁, ⟨v₁, hv₁, hp₁⟩, p₂, ⟨v₂, hv₂, hp₂⟩, hv⟩
-    rw [hv, hp₁, hp₂, vadd_vsub_vadd_cancel_right]
-    exact direction.sub_mem hv₁ hv₂
+  · rintro ⟨p₁, hp₁, p₂, hp₂, rfl⟩
+    simpa using direction.sub_mem hp₁ hp₂
   · exact fun hv => ⟨v +ᵥ p, vadd_mem_mk' _ hv, p, self_mem_mk' _ _, (vadd_vsub _ _).symm⟩
 
 /-- A point lies in an affine subspace constructed from another point and a direction if and only


### PR DESCRIPTION
I replaced `{ q | ∃ v ∈ direction, q = v +ᵥ p }` by `{ q | q -ᵥ p ∈ direction }`. This definition is shorter and nicer to work with.

I then use this to define `perpBisector` more conveniently. (And this removes one `erw`)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
