### PR TITLE
[Merged by Bors] - ci: run lake exe cache clean if cache is larger than 10 GB

### DIFF
--- a/.github/build.in.yml
+++ b/.github/build.in.yml
@@ -107,10 +107,7 @@ jobs:
 
           # Calculate directory size in bytes
           DIR_SIZE=$(du -sb "$CACHE_DIR" | cut -f1)
-
-          # Convert to gigabytes for comparison and display (with decimal precision)
-          DIR_SIZE_GB=$(echo "scale=2; $DIR_SIZE / 1024 / 1024 / 1024" | bc)
-          echo "Cache directory size: ${DIR_SIZE_GB}GB"
+          printf 'Cache size (in bytes): %s\n' "$DIR_SIZE"
 
           # Check if size exceeds 10GB
           if [ "$DIR_SIZE" -gt "10737418240" ]; then

--- a/.github/build.in.yml
+++ b/.github/build.in.yml
@@ -97,7 +97,7 @@ jobs:
       - name: cleanup .cache/mathlib
         run: |
           # Define the cache directory path
-          CACHE_DIR="~/.cache/mathlib"
+          CACHE_DIR="$HOME/.cache/mathlib"
 
           # Check if directory exists
           if [ ! -d "$CACHE_DIR" ]; then

--- a/.github/build.in.yml
+++ b/.github/build.in.yml
@@ -94,6 +94,26 @@ jobs:
               : # Do nothing on failure, but suppress errors
           fi
 
+      - name: cleanup .cache/mathlib
+        run: |
+          # Define the cache directory path
+          CACHE_DIR="~/.cache/mathlib"
+
+          # Check if directory exists
+          if [ ! -d "$CACHE_DIR" ]; then
+            echo "::warning::Cache directory does not exist: $CACHE_DIR"
+            exit 0
+          fi
+
+          # Calculate directory size in bytes
+          DIR_SIZE=$(du -sb "$CACHE_DIR" | cut -f1)
+
+          # Check if size exceeds 10GB
+          if [ "$DIR_SIZE" -gt "10737418240" ]; then
+            echo "Cache size exceeds threshold, running lake exe cache clean"
+            lake exe cache clean
+          fi
+
       # The Hoskinson runners may not have jq installed, so do that now.
       - name: 'Setup jq'
         uses: dcarbone/install-jq-action@v2.1.0

--- a/.github/build.in.yml
+++ b/.github/build.in.yml
@@ -108,6 +108,10 @@ jobs:
           # Calculate directory size in bytes
           DIR_SIZE=$(du -sb "$CACHE_DIR" | cut -f1)
 
+          # Convert to gigabytes for comparison and display (with decimal precision)
+          DIR_SIZE_GB=$(echo "scale=2; $DIR_SIZE / 1024 / 1024 / 1024" | bc)
+          echo "Cache directory size: ${DIR_SIZE_GB}GB"
+
           # Check if size exceeds 10GB
           if [ "$DIR_SIZE" -gt "10737418240" ]; then
             echo "Cache size exceeds threshold, running lake exe cache clean"

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -104,6 +104,26 @@ jobs:
               : # Do nothing on failure, but suppress errors
           fi
 
+      - name: cleanup .cache/mathlib
+        run: |
+          # Define the cache directory path
+          CACHE_DIR="~/.cache/mathlib"
+
+          # Check if directory exists
+          if [ ! -d "$CACHE_DIR" ]; then
+            echo "::warning::Cache directory does not exist: $CACHE_DIR"
+            exit 0
+          fi
+
+          # Calculate directory size in bytes
+          DIR_SIZE=$(du -sb "$CACHE_DIR" | cut -f1)
+
+          # Check if size exceeds 10GB
+          if [ "$DIR_SIZE" -gt "10737418240" ]; then
+            echo "Cache size exceeds threshold, running lake exe cache clean"
+            lake exe cache clean
+          fi
+
       # The Hoskinson runners may not have jq installed, so do that now.
       - name: 'Setup jq'
         uses: dcarbone/install-jq-action@v2.1.0

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -107,7 +107,7 @@ jobs:
       - name: cleanup .cache/mathlib
         run: |
           # Define the cache directory path
-          CACHE_DIR="~/.cache/mathlib"
+          CACHE_DIR="$HOME/.cache/mathlib"
 
           # Check if directory exists
           if [ ! -d "$CACHE_DIR" ]; then

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -117,10 +117,7 @@ jobs:
 
           # Calculate directory size in bytes
           DIR_SIZE=$(du -sb "$CACHE_DIR" | cut -f1)
-
-          # Convert to gigabytes for comparison and display (with decimal precision)
-          DIR_SIZE_GB=$(echo "scale=2; $DIR_SIZE / 1024 / 1024 / 1024" | bc)
-          echo "Cache directory size: ${DIR_SIZE_GB}GB"
+          printf 'Cache size (in bytes): %s\n' "$DIR_SIZE"
 
           # Check if size exceeds 10GB
           if [ "$DIR_SIZE" -gt "10737418240" ]; then

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -118,6 +118,10 @@ jobs:
           # Calculate directory size in bytes
           DIR_SIZE=$(du -sb "$CACHE_DIR" | cut -f1)
 
+          # Convert to gigabytes for comparison and display (with decimal precision)
+          DIR_SIZE_GB=$(echo "scale=2; $DIR_SIZE / 1024 / 1024 / 1024" | bc)
+          echo "Cache directory size: ${DIR_SIZE_GB}GB"
+
           # Check if size exceeds 10GB
           if [ "$DIR_SIZE" -gt "10737418240" ]; then
             echo "Cache size exceeds threshold, running lake exe cache clean"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,10 +124,7 @@ jobs:
 
           # Calculate directory size in bytes
           DIR_SIZE=$(du -sb "$CACHE_DIR" | cut -f1)
-
-          # Convert to gigabytes for comparison and display (with decimal precision)
-          DIR_SIZE_GB=$(echo "scale=2; $DIR_SIZE / 1024 / 1024 / 1024" | bc)
-          echo "Cache directory size: ${DIR_SIZE_GB}GB"
+          printf 'Cache size (in bytes): %s\n' "$DIR_SIZE"
 
           # Check if size exceeds 10GB
           if [ "$DIR_SIZE" -gt "10737418240" ]; then

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,7 +114,7 @@ jobs:
       - name: cleanup .cache/mathlib
         run: |
           # Define the cache directory path
-          CACHE_DIR="~/.cache/mathlib"
+          CACHE_DIR="$HOME/.cache/mathlib"
 
           # Check if directory exists
           if [ ! -d "$CACHE_DIR" ]; then

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,6 +111,26 @@ jobs:
               : # Do nothing on failure, but suppress errors
           fi
 
+      - name: cleanup .cache/mathlib
+        run: |
+          # Define the cache directory path
+          CACHE_DIR="~/.cache/mathlib"
+
+          # Check if directory exists
+          if [ ! -d "$CACHE_DIR" ]; then
+            echo "::warning::Cache directory does not exist: $CACHE_DIR"
+            exit 0
+          fi
+
+          # Calculate directory size in bytes
+          DIR_SIZE=$(du -sb "$CACHE_DIR" | cut -f1)
+
+          # Check if size exceeds 10GB
+          if [ "$DIR_SIZE" -gt "10737418240" ]; then
+            echo "Cache size exceeds threshold, running lake exe cache clean"
+            lake exe cache clean
+          fi
+
       # The Hoskinson runners may not have jq installed, so do that now.
       - name: 'Setup jq'
         uses: dcarbone/install-jq-action@v2.1.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -125,6 +125,10 @@ jobs:
           # Calculate directory size in bytes
           DIR_SIZE=$(du -sb "$CACHE_DIR" | cut -f1)
 
+          # Convert to gigabytes for comparison and display (with decimal precision)
+          DIR_SIZE_GB=$(echo "scale=2; $DIR_SIZE / 1024 / 1024 / 1024" | bc)
+          echo "Cache directory size: ${DIR_SIZE_GB}GB"
+
           # Check if size exceeds 10GB
           if [ "$DIR_SIZE" -gt "10737418240" ]; then
             echo "Cache size exceeds threshold, running lake exe cache clean"

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -111,7 +111,7 @@ jobs:
       - name: cleanup .cache/mathlib
         run: |
           # Define the cache directory path
-          CACHE_DIR="~/.cache/mathlib"
+          CACHE_DIR="$HOME/.cache/mathlib"
 
           # Check if directory exists
           if [ ! -d "$CACHE_DIR" ]; then

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -108,6 +108,26 @@ jobs:
               : # Do nothing on failure, but suppress errors
           fi
 
+      - name: cleanup .cache/mathlib
+        run: |
+          # Define the cache directory path
+          CACHE_DIR="~/.cache/mathlib"
+
+          # Check if directory exists
+          if [ ! -d "$CACHE_DIR" ]; then
+            echo "::warning::Cache directory does not exist: $CACHE_DIR"
+            exit 0
+          fi
+
+          # Calculate directory size in bytes
+          DIR_SIZE=$(du -sb "$CACHE_DIR" | cut -f1)
+
+          # Check if size exceeds 10GB
+          if [ "$DIR_SIZE" -gt "10737418240" ]; then
+            echo "Cache size exceeds threshold, running lake exe cache clean"
+            lake exe cache clean
+          fi
+
       # The Hoskinson runners may not have jq installed, so do that now.
       - name: 'Setup jq'
         uses: dcarbone/install-jq-action@v2.1.0

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -121,10 +121,7 @@ jobs:
 
           # Calculate directory size in bytes
           DIR_SIZE=$(du -sb "$CACHE_DIR" | cut -f1)
-
-          # Convert to gigabytes for comparison and display (with decimal precision)
-          DIR_SIZE_GB=$(echo "scale=2; $DIR_SIZE / 1024 / 1024 / 1024" | bc)
-          echo "Cache directory size: ${DIR_SIZE_GB}GB"
+          printf 'Cache size (in bytes): %s\n' "$DIR_SIZE"
 
           # Check if size exceeds 10GB
           if [ "$DIR_SIZE" -gt "10737418240" ]; then

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -122,6 +122,10 @@ jobs:
           # Calculate directory size in bytes
           DIR_SIZE=$(du -sb "$CACHE_DIR" | cut -f1)
 
+          # Convert to gigabytes for comparison and display (with decimal precision)
+          DIR_SIZE_GB=$(echo "scale=2; $DIR_SIZE / 1024 / 1024 / 1024" | bc)
+          echo "Cache directory size: ${DIR_SIZE_GB}GB"
+
           # Check if size exceeds 10GB
           if [ "$DIR_SIZE" -gt "10737418240" ]; then
             echo "Cache size exceeds threshold, running lake exe cache clean"


### PR DESCRIPTION
Our hoskinson runners have been going down periodically due to the .cache directory getting too large. This adds a step to the build which should keep it within a reasonable size.

cf. [Zulip](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Error.3A.20No.20space.20left.20on.20device)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
