### PR TITLE
[Merged by Bors] - feat: API for continuous extension of meromorphic functions

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1516,6 +1516,7 @@ import Mathlib.Analysis.MellinInversion
 import Mathlib.Analysis.MellinTransform
 import Mathlib.Analysis.Meromorphic.Basic
 import Mathlib.Analysis.Meromorphic.Divisor.Basic
+import Mathlib.Analysis.Meromorphic.NormalFormAt
 import Mathlib.Analysis.Meromorphic.Order
 import Mathlib.Analysis.Normed.Affine.AddTorsor
 import Mathlib.Analysis.Normed.Affine.AddTorsorBases

--- a/Mathlib/Analysis/Analytic/IsolatedZeros.lean
+++ b/Mathlib/Analysis/Analytic/IsolatedZeros.lean
@@ -135,7 +135,7 @@ theorem eventually_eq_or_eventually_ne (hf : AnalyticAt 𝕜 f z₀) (hg : Analy
 
 /-- Two analytic functions agree on a punctured neighborhood iff they agree on a neighborhood. -/
 theorem eventuallyEq_nhdNE_iff_eventuallyEq_nhd (hf : AnalyticAt 𝕜 f z₀) (hg : AnalyticAt 𝕜 g z₀) :
-  f =ᶠ[𝓝[≠] z₀] g ↔ f =ᶠ[𝓝 z₀] g := by
+    f =ᶠ[𝓝[≠] z₀] g ↔ f =ᶠ[𝓝 z₀] g := by
   constructor <;> intro hfg
   · rcases ((hf.sub hg).eventually_eq_zero_or_eventually_ne_zero) with h | h
     · exact Filter.eventuallyEq_iff_sub.2 h

--- a/Mathlib/Analysis/Analytic/IsolatedZeros.lean
+++ b/Mathlib/Analysis/Analytic/IsolatedZeros.lean
@@ -133,6 +133,15 @@ theorem eventually_eq_or_eventually_ne (hf : AnalyticAt 𝕜 f z₀) (hg : Analy
     (∀ᶠ z in 𝓝 z₀, f z = g z) ∨ ∀ᶠ z in 𝓝[≠] z₀, f z ≠ g z := by
   simpa [sub_eq_zero] using (hf.sub hg).eventually_eq_zero_or_eventually_ne_zero
 
+/-- Two analytic functions agree on a punctured neighborhood iff they agree on a neighborhood. -/
+theorem eventuallyEq_nhd_iff_eventuallyEq_nhdNE (hf : AnalyticAt 𝕜 f z₀) (hg : AnalyticAt 𝕜 g z₀) :
+  f =ᶠ[𝓝[≠] z₀] g ↔ f =ᶠ[𝓝 z₀] g := by
+  constructor <;> intro hfg
+  · rcases ((hf.sub hg).eventually_eq_zero_or_eventually_ne_zero) with h | h
+    · exact Filter.eventuallyEq_iff_sub.2 h
+    · simpa using (Filter.eventually_and.2 ⟨Filter.eventuallyEq_iff_sub.mp hfg, h⟩).exists
+  · exact hfg.filter_mono nhdsWithin_le_nhds
+
 theorem frequently_zero_iff_eventually_zero {f : 𝕜 → E} {w : 𝕜} (hf : AnalyticAt 𝕜 f w) :
     (∃ᶠ z in 𝓝[≠] w, f z = 0) ↔ ∀ᶠ z in 𝓝 w, f z = 0 :=
   ⟨hf.eventually_eq_zero_or_eventually_ne_zero.resolve_right, fun h =>

--- a/Mathlib/Analysis/Analytic/IsolatedZeros.lean
+++ b/Mathlib/Analysis/Analytic/IsolatedZeros.lean
@@ -134,7 +134,7 @@ theorem eventually_eq_or_eventually_ne (hf : AnalyticAt 𝕜 f z₀) (hg : Analy
   simpa [sub_eq_zero] using (hf.sub hg).eventually_eq_zero_or_eventually_ne_zero
 
 /-- Two analytic functions agree on a punctured neighborhood iff they agree on a neighborhood. -/
-theorem eventuallyEq_nhd_iff_eventuallyEq_nhdNE (hf : AnalyticAt 𝕜 f z₀) (hg : AnalyticAt 𝕜 g z₀) :
+theorem eventuallyEq_nhdNE_iff_eventuallyEq_nhd (hf : AnalyticAt 𝕜 f z₀) (hg : AnalyticAt 𝕜 g z₀) :
   f =ᶠ[𝓝[≠] z₀] g ↔ f =ᶠ[𝓝 z₀] g := by
   constructor <;> intro hfg
   · rcases ((hf.sub hg).eventually_eq_zero_or_eventually_ne_zero) with h | h

--- a/Mathlib/Analysis/Analytic/IsolatedZeros.lean
+++ b/Mathlib/Analysis/Analytic/IsolatedZeros.lean
@@ -133,15 +133,6 @@ theorem eventually_eq_or_eventually_ne (hf : AnalyticAt 𝕜 f z₀) (hg : Analy
     (∀ᶠ z in 𝓝 z₀, f z = g z) ∨ ∀ᶠ z in 𝓝[≠] z₀, f z ≠ g z := by
   simpa [sub_eq_zero] using (hf.sub hg).eventually_eq_zero_or_eventually_ne_zero
 
-/-- Two analytic functions agree on a punctured neighborhood iff they agree on a neighborhood. -/
-theorem eventuallyEq_nhdNE_iff_eventuallyEq_nhd (hf : AnalyticAt 𝕜 f z₀) (hg : AnalyticAt 𝕜 g z₀) :
-    f =ᶠ[𝓝[≠] z₀] g ↔ f =ᶠ[𝓝 z₀] g := by
-  constructor <;> intro hfg
-  · rcases ((hf.sub hg).eventually_eq_zero_or_eventually_ne_zero) with h | h
-    · exact Filter.eventuallyEq_iff_sub.2 h
-    · simpa using (Filter.eventually_and.2 ⟨Filter.eventuallyEq_iff_sub.mp hfg, h⟩).exists
-  · exact hfg.filter_mono nhdsWithin_le_nhds
-
 theorem frequently_zero_iff_eventually_zero {f : 𝕜 → E} {w : 𝕜} (hf : AnalyticAt 𝕜 f w) :
     (∃ᶠ z in 𝓝[≠] w, f z = 0) ↔ ∀ᶠ z in 𝓝 w, f z = 0 :=
   ⟨hf.eventually_eq_zero_or_eventually_ne_zero.resolve_right, fun h =>

--- a/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
+++ b/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
@@ -140,7 +140,8 @@ theorem AnalyticAt.MeromorphicNFAt (hf : AnalyticAt 𝕜 f x) :
 -/
 
 variable (f) (x) in
-/-- Convert a meromorphic function to normal form at `x` by changing its value at `x`. -/
+/-- If `f` is meromorphic at `x`, convert `f` to normal form at `x` by changing its value at `x`.
+Otherwise, returns the 0 function. -/
 noncomputable def Function.toMeromorphicNFAt :
     𝕜 → E := by
   by_cases hf : MeromorphicAt f x

--- a/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
+++ b/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
@@ -53,7 +53,7 @@ theorem meromorphicNFAt_def :
 /-- A meromorphic function has normal form at `x` iff it is either analytic
 there, or if it has a pole at `x` and takes the default value `0`. -/
 theorem MeromorphicAt.meromorphicNFAt_iff (hf : MeromorphicAt f x) :
-    MeromorphicNFAt f x ↔ (AnalyticAt 𝕜 f x) ∨ (hf.order < 0 ∧ f x = 0) := by
+    MeromorphicNFAt f x ↔ AnalyticAt 𝕜 f x ∨ hf.order < 0 ∧ f x = 0 := by
   constructor
   · intro h₁f
     rcases h₁f with h | h

--- a/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
+++ b/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
@@ -136,13 +136,12 @@ order, then it is analytic -/
 theorem MeromorphicNFAt.analyticAt (h₁f : MeromorphicNFAt f x)
     (h₂f : 0 ≤ h₁f.meromorphicAt.order) :
     AnalyticAt 𝕜 f x := by
-  have h₃f := h₁f.meromorphicAt
   rw [MeromorphicAt.meromorphicNFAt_iff] at h₁f
   rcases h₁f with h | h
   · exact h
   · by_contra h'
-    obtain ⟨h₄f, h₅f, h₆f⟩ := h
-    exact lt_irrefl 0 (lt_of_le_of_lt h₂f h₅f)
+    obtain ⟨h₃f, h₄f, h₅f⟩ := h
+    exact lt_irrefl 0 (lt_of_le_of_lt h₂f h₄f)
 
 /-- Analytic functions are meromorphic in normal form. -/
 theorem AnalyticAt.MeromorphicNFAt (hf : AnalyticAt 𝕜 f x) :

--- a/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
+++ b/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
@@ -202,9 +202,8 @@ theorem meromorphicNFAt_toMeromorphicNFAt :
 
 /-- If `f` has normal form at `x`, then `f` equals `f.toNF`. -/
 theorem meromorphicNFAt_iff_toNF_eq_id :
-    MeromorphicNFAt f x ↔ f = toMeromorphicNFAt f x := by
-  constructor
-  · intro hf
+    MeromorphicNFAt f x ↔ f = toMeromorphicNFAt f x where
+  mp hf := by
     funext z
     by_cases hz : z = x
     · rw [hz]
@@ -243,6 +242,6 @@ theorem meromorphicNFAt_iff_toNF_eq_id :
           rw [hn] at this
           tauto
     · exact hf.meromorphicAt.eqOn_compl_singleton_toMermomorphicNFAt hz
-  · intro hf
+  mpr hf := by
     rw [hf]
     exact meromorphicNFAt_toMeromorphicNFAt

--- a/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
+++ b/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
@@ -177,7 +177,7 @@ theorem MeromorphicAt.meromorphicNFAt_toNF (hf : MeromorphicAt f x) :
   by_cases h₂f : hf.order = ⊤
   · have : toMeromorphicNFAt f x =ᶠ[𝓝 x] 0 := by
       apply eventuallyEq_nhds_of_eventuallyEq_nhdsNE
-      · exact hf.toNF_id_on_nhdNE.symm.trans (hf.order_eq_top_iff.1 h₂f)
+      · exact hf.eq_nhdNE_toMeromorphicNFAt.symm.trans (hf.order_eq_top_iff.1 h₂f)
       · simp [h₂f, toMeromorphicNFAt, hf]
     apply AnalyticAt.MeromorphicNFAt
     rw [analyticAt_congr this]
@@ -186,7 +186,7 @@ theorem MeromorphicAt.meromorphicNFAt_toNF (hf : MeromorphicAt f x) :
     obtain ⟨g, h₁g, h₂g, h₃g⟩ := (hf.order_eq_int_iff n).1 hn.symm
     right
     use n, g, h₁g, h₂g
-    apply eventuallyEq_nhds_of_eventuallyEq_nhdsNE (hf.toNF_id_on_nhdNE.symm.trans h₃g)
+    apply eventuallyEq_nhds_of_eventuallyEq_nhdsNE (hf.eq_nhdNE_toMeromorphicNFAt.symm.trans h₃g)
     simp only [toMeromorphicNFAt, hf, ↓reduceDIte, ← hn, WithTop.coe_zero,
       WithTop.coe_eq_zero, ne_eq, Function.update_self, sub_self]
     split_ifs with h₃f

--- a/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
+++ b/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
@@ -98,11 +98,11 @@ theorem meromorphicNFAt_congr {g : 𝕜 → E} (hfg : f =ᶠ[𝓝 x] g) :
     MeromorphicNFAt f x ↔ MeromorphicNFAt g x := by
   constructor
   · rintro (h | ⟨n, h, h₁h, h₂h, h₃h⟩)
-    · exact Or.inl (hfg.symm.trans h)
-    · exact Or.inr ⟨n, h, h₁h, h₂h, hfg.symm.trans h₃h⟩
+    · exact .inl (hfg.symm.trans h)
+    · exact .inr ⟨n, h, h₁h, h₂h, hfg.symm.trans h₃h⟩
   · rintro (h | ⟨n, h, h₁h, h₂h, h₃h⟩)
-    · exact Or.inl (hfg.trans h)
-    · exact Or.inr ⟨n, h, h₁h, h₂h, hfg.trans h₃h⟩
+    · exact .inl (hfg.trans h)
+    · exact .inr ⟨n, h, h₁h, h₂h, hfg.trans h₃h⟩
 
 /-!
 ## Relation to other properties of functions

--- a/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
+++ b/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
@@ -199,9 +199,8 @@ theorem MeromorphicNFAt.toNF_eq_id (hf : MeromorphicNFAt f x) :
     simp only [WithTop.coe_zero, ne_eq, Function.update_self]
     have h₀f := hf
     rcases hf with h₁f | h₁f
-    · simp only [(h₀f.meromorphicAt.order_eq_top_iff).2 (h₁f.filter_mono nhdsWithin_le_nhds),
-        LinearOrderedAddCommGroupWithTop.top_ne_zero, ↓reduceDIte]
-      exact Filter.EventuallyEq.eq_of_nhds h₁f
+    · simpa [(h₀f.meromorphicAt.order_eq_top_iff).2 (h₁f.filter_mono nhdsWithin_le_nhds)] 
+        using h₁f.eq_of_nhds
     · obtain ⟨n, g, h₁g, h₂g, h₃g⟩ := h₁f
       rw [Filter.EventuallyEq.eq_of_nhds h₃g]
       have : h₀f.meromorphicAt.order = n := by

--- a/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
+++ b/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
@@ -128,7 +128,7 @@ theorem MeromorphicNFAt.meromorphicAt (hf : MeromorphicNFAt f x) :
     apply MeromorphicAt.congr _ (Filter.EventuallyEq.filter_mono h₃g nhdsWithin_le_nhds).symm
     fun_prop
 
-/- If a function is meromorphic in normal form at `x` and has non-negative
+/-- If a function is meromorphic in normal form at `x` and has non-negative
 order, then it is analytic -/
 theorem MeromorphicNFAt.analyticAt (h₁f : MeromorphicNFAt f x)
     (h₂f : 0 ≤ h₁f.meromorphicAt.order) :
@@ -149,7 +149,7 @@ theorem AnalyticAt.MeromorphicNFAt (hf : AnalyticAt 𝕜 f x) :
 ## Continuous extension and conversion to normal form
 -/
 
-/- Convert a meromorphic function to normal form at `x` by changing its value. -/
+/-- Convert a meromorphic function to normal form at `x` by changing its value at `x`. -/
 noncomputable def MeromorphicAt.toNF (hf : MeromorphicAt f x) :
     𝕜 → E := by
   classical -- do not complain about decidability issues in Function.update
@@ -159,17 +159,17 @@ noncomputable def MeromorphicAt.toNF (hf : MeromorphicAt f x) :
     exact (Classical.choose h₁f) x
   · exact 0
 
-/- Conversion to normal form at `x` by changes the value only at x. -/
+/-- Conversion to normal form at `x` by changes the value only at x. -/
 lemma MeromorphicAt.toNF_id_on_complement (hf : MeromorphicAt f x) :
     Set.EqOn f hf.toNF {x}ᶜ :=
   fun _ _ ↦ by simp_all [MeromorphicAt.toNF]
 
-/- Conversion to normal form at `x` by changes the value only at x. -/
+/-- Conversion to normal form at `x` changes the value only at x. -/
 lemma MeromorphicAt.toNF_id_on_nhdNE (hf : MeromorphicAt f x) :
     f =ᶠ[𝓝[≠] x] hf.toNF :=
   eventually_nhdsWithin_of_forall (fun _ hz ↦ hf.toNF_id_on_complement hz)
 
-/- After conversion to normal form at `x`, the function has normal form. -/
+/-- After conversion to normal form at `x`, the function has normal form. -/
 theorem MeromorphicAt.MeromorphicNFAt_of_toNF (hf : MeromorphicAt f x) :
     MeromorphicNFAt hf.toNF x := by
   by_cases h₂f : hf.order = ⊤
@@ -200,7 +200,7 @@ theorem MeromorphicAt.MeromorphicNFAt_of_toNF (hf : MeromorphicAt f x) :
       · simp_rw [← hn, WithTop.coe_zero, WithTop.coe_eq_zero] at *
         simp [h₃f, zero_zpow n h₃f]
 
-/- If `f` has normal form at `x`, then `f` equals `f.toNF`. -/
+/-- If `f` has normal form at `x`, then `f` equals `f.toNF`. -/
 theorem MeromorphicNFAt.toNF_eq_id (hf : MeromorphicNFAt f x) :
     f = hf.meromorphicAt.toNF := by
   funext z

--- a/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
+++ b/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
@@ -41,8 +41,8 @@ variable
 or if it can locally be written as `fun z ↦ (z - x) ^ n • g` where `g` is
 analytic and does not vanish at `x`. -/
 def MeromorphicNFAt (f : 𝕜 → E) (x : 𝕜) :=
-  (f =ᶠ[𝓝 x] 0) ∨ (∃ (n : ℤ), ∃ g : 𝕜 → E, (AnalyticAt 𝕜 g x) ∧ (g x ≠ 0) ∧
-    (f =ᶠ[𝓝 x] (· - x) ^ n • g ))
+  f =ᶠ[𝓝 x] 0 ∨
+    ∃ (n : ℤ) (g : 𝕜 → E), AnalyticAt 𝕜 g x ∧ g x ≠ 0 ∧ f =ᶠ[𝓝 x] (· - x) ^ n • g
 
 /-- Reformulation of the definition for convenience -/
 theorem meromorphicNFAt_def :

--- a/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
+++ b/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
@@ -150,14 +150,14 @@ noncomputable def MeromorphicAt.toNF (hf : MeromorphicAt f x) :
   · exact 0
 
 /-- Conversion to normal form at `x` by changes the value only at x. -/
-lemma MeromorphicAt.toNF_id_on_complement (hf : MeromorphicAt f x) :
+lemma MeromorphicAt.eqOn_compl_singleton_toNF (hf : MeromorphicAt f x) :
     Set.EqOn f hf.toNF {x}ᶜ :=
   fun _ _ ↦ by simp_all [MeromorphicAt.toNF]
 
 /-- Conversion to normal form at `x` changes the value only at x. -/
 lemma MeromorphicAt.toNF_id_on_nhdNE (hf : MeromorphicAt f x) :
     f =ᶠ[𝓝[≠] x] hf.toNF :=
-  eventually_nhdsWithin_of_forall (fun _ hz ↦ hf.toNF_id_on_complement hz)
+  eventually_nhdsWithin_of_forall (fun _ hz ↦ hf.eqOn_compl_singleton_toNF hz)
 
 -- Two analytic functions agree on a punctured neighborhood iff they agree on a neighborhood.
 private lemma AnalyticAt.eventuallyEq_nhdNE_iff_eventuallyEq_nhd {g : 𝕜 → E} {z₀ : 𝕜}
@@ -231,4 +231,4 @@ theorem MeromorphicNFAt.toNF_eq_id (hf : MeromorphicNFAt f x) :
         by_contra hn
         rw [hn] at this
         tauto
-  · exact (MeromorphicNFAt.meromorphicAt hf).toNF_id_on_complement hz
+  · exact hf.meromorphicAt.eqOn_compl_singleton_toNF hz

--- a/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
+++ b/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
@@ -154,14 +154,14 @@ noncomputable def toMeromorphicNFAt :
   · exact 0
 
 /-- Conversion to normal form at `x` by changes the value only at x. -/
-lemma MeromorphicAt.eqOn_compl_singleton_toNF (hf : MeromorphicAt f x) :
+lemma MeromorphicAt.eqOn_compl_singleton_toMermomorphicNFAt (hf : MeromorphicAt f x) :
     Set.EqOn f (toMeromorphicNFAt f x) {x}ᶜ :=
   fun _ _ ↦ by simp_all [toMeromorphicNFAt]
 
 /-- Conversion to normal form at `x` changes the value only at x. -/
 lemma MeromorphicAt.eq_nhdNE_toMeromorphicNFAt (hf : MeromorphicAt f x) :
     f =ᶠ[𝓝[≠] x] toMeromorphicNFAt f x :=
-  eventually_nhdsWithin_of_forall (fun _ hz ↦ hf.eqOn_compl_singleton_toNF hz)
+  eventually_nhdsWithin_of_forall (fun _ hz ↦ hf.eqOn_compl_singleton_toMermomorphicNFAt hz)
 
 /-- Two analytic functions agree on a punctured neighborhood iff they agree on a neighborhood. -/
 private lemma AnalyticAt.eventuallyEq_nhdNE_iff_eventuallyEq_nhd {g : 𝕜 → E} {z₀ : 𝕜}
@@ -172,69 +172,77 @@ private lemma AnalyticAt.eventuallyEq_nhdNE_iff_eventuallyEq_nhd {g : 𝕜 → E
   · simpa using (Filter.eventually_and.2 ⟨Filter.eventuallyEq_iff_sub.mp hfg, h⟩).exists
 
 /-- After conversion to normal form at `x`, the function has normal form. -/
-theorem MeromorphicAt.meromorphicNFAt_toNF (hf : MeromorphicAt f x) :
+theorem meromorphicNFAt_toMeromorphicNFAt :
     MeromorphicNFAt (toMeromorphicNFAt f x) x := by
-  by_cases h₂f : hf.order = ⊤
-  · have : toMeromorphicNFAt f x =ᶠ[𝓝 x] 0 := by
-      apply eventuallyEq_nhds_of_eventuallyEq_nhdsNE
-      · exact hf.eq_nhdNE_toMeromorphicNFAt.symm.trans (hf.order_eq_top_iff.1 h₂f)
-      · simp [h₂f, toMeromorphicNFAt, hf]
-    apply AnalyticAt.MeromorphicNFAt
-    rw [analyticAt_congr this]
-    exact analyticAt_const
-  · lift hf.order to ℤ using h₂f with n hn
-    obtain ⟨g, h₁g, h₂g, h₃g⟩ := (hf.order_eq_int_iff n).1 hn.symm
-    right
-    use n, g, h₁g, h₂g
-    apply eventuallyEq_nhds_of_eventuallyEq_nhdsNE (hf.eq_nhdNE_toMeromorphicNFAt.symm.trans h₃g)
-    simp only [toMeromorphicNFAt, hf, ↓reduceDIte, ← hn, WithTop.coe_zero,
-      WithTop.coe_eq_zero, ne_eq, Function.update_self, sub_self]
-    split_ifs with h₃f
-    · obtain ⟨h₁G, _, h₃G⟩ := Classical.choose_spec ((hf.order_eq_int_iff 0).1 (h₃f ▸ hn.symm))
-      apply Filter.EventuallyEq.eq_of_nhds
-      apply h₁G.eventuallyEq_nhdNE_iff_eventuallyEq_nhd (by fun_prop)
-      filter_upwards [h₃g, h₃G]
-      simp_all
-    · simp [h₃f, zero_zpow]
+  by_cases hf : MeromorphicAt f x
+  · by_cases h₂f : hf.order = ⊤
+    · have : toMeromorphicNFAt f x =ᶠ[𝓝 x] 0 := by
+        apply eventuallyEq_nhds_of_eventuallyEq_nhdsNE
+        · exact hf.eq_nhdNE_toMeromorphicNFAt.symm.trans (hf.order_eq_top_iff.1 h₂f)
+        · simp [h₂f, toMeromorphicNFAt, hf]
+      apply AnalyticAt.MeromorphicNFAt
+      rw [analyticAt_congr this]
+      exact analyticAt_const
+    · lift hf.order to ℤ using h₂f with n hn
+      obtain ⟨g, h₁g, h₂g, h₃g⟩ := (hf.order_eq_int_iff n).1 hn.symm
+      right
+      use n, g, h₁g, h₂g
+      apply eventuallyEq_nhds_of_eventuallyEq_nhdsNE (hf.eq_nhdNE_toMeromorphicNFAt.symm.trans h₃g)
+      simp only [toMeromorphicNFAt, hf, ↓reduceDIte, ← hn, WithTop.coe_zero,
+        WithTop.coe_eq_zero, ne_eq, Function.update_self, sub_self]
+      split_ifs with h₃f
+      · obtain ⟨h₁G, _, h₃G⟩ := Classical.choose_spec ((hf.order_eq_int_iff 0).1 (h₃f ▸ hn.symm))
+        apply Filter.EventuallyEq.eq_of_nhds
+        apply h₁G.eventuallyEq_nhdNE_iff_eventuallyEq_nhd (by fun_prop)
+        filter_upwards [h₃g, h₃G]
+        simp_all
+      · simp [h₃f, zero_zpow]
+  · simp only [toMeromorphicNFAt, hf, ↓reduceDIte]
+    exact analyticAt_const.MeromorphicNFAt
 
 /-- If `f` has normal form at `x`, then `f` equals `f.toNF`. -/
-theorem MeromorphicNFAt.toNF_eq_id (hf : MeromorphicNFAt f x) :
-    f = toMeromorphicNFAt f x := by
-  funext z
-  by_cases hz : z = x
-  · rw [hz]
-    simp only [toMeromorphicNFAt, hf.meromorphicAt, WithTop.coe_zero, ne_eq, Function.update_self]
-    have h₀f := hf
-    rcases hf with h₁f | h₁f
-    · simpa [(h₀f.meromorphicAt.order_eq_top_iff).2 (h₁f.filter_mono nhdsWithin_le_nhds)]
-        using h₁f.eq_of_nhds
-    · obtain ⟨n, g, h₁g, h₂g, h₃g⟩ := h₁f
-      rw [Filter.EventuallyEq.eq_of_nhds h₃g]
-      have : h₀f.meromorphicAt.order = n := by
-        rw [MeromorphicAt.order_eq_int_iff (MeromorphicNFAt.meromorphicAt h₀f) n]
-        use g, h₁g, h₂g
-        exact eventually_nhdsWithin_of_eventually_nhds h₃g
-      by_cases h₃f : h₀f.meromorphicAt.order = 0
-      · simp only [Pi.smul_apply', Pi.pow_apply, sub_self, h₃f, ↓reduceDIte]
-        have hn : n = (0 : ℤ) := by
-          rw [h₃f] at this
-          exact WithTop.coe_eq_zero.mp this.symm
-        simp_rw [hn]
-        simp only [zpow_zero, one_smul]
-        have : g =ᶠ[𝓝 x] (Classical.choose ((h₀f.meromorphicAt.order_eq_int_iff 0).1 h₃f)) := by
-          obtain ⟨h₀, h₁, h₂⟩ := Classical.choose_spec
-            ((h₀f.meromorphicAt.order_eq_int_iff 0).1 h₃f)
-          apply h₁g.eventuallyEq_nhdNE_iff_eventuallyEq_nhd h₀
-          rw [hn] at h₃g
-          simp only [zpow_zero, one_smul, ne_eq] at h₃g h₂
-          exact (h₃g.filter_mono nhdsWithin_le_nhds).symm.trans h₂
-        simp only [Function.update_self]
-        exact Filter.EventuallyEq.eq_of_nhds this
-      · simp only [Pi.smul_apply', Pi.pow_apply, sub_self, h₃f, ↓reduceDIte, smul_eq_zero,
-          Function.update_self, smul_eq_zero]
-        left
-        apply zero_zpow n
-        by_contra hn
-        rw [hn] at this
-        tauto
-  · exact hf.meromorphicAt.eqOn_compl_singleton_toNF hz
+theorem meromorphicNFAt_iff_toNF_eq_id :
+    MeromorphicNFAt f x ↔ f = toMeromorphicNFAt f x := by
+  constructor
+  · intro hf
+    funext z
+    by_cases hz : z = x
+    · rw [hz]
+      simp only [toMeromorphicNFAt, hf.meromorphicAt, WithTop.coe_zero, ne_eq, Function.update_self]
+      have h₀f := hf
+      rcases hf with h₁f | h₁f
+      · simpa [(h₀f.meromorphicAt.order_eq_top_iff).2 (h₁f.filter_mono nhdsWithin_le_nhds)]
+          using h₁f.eq_of_nhds
+      · obtain ⟨n, g, h₁g, h₂g, h₃g⟩ := h₁f
+        rw [Filter.EventuallyEq.eq_of_nhds h₃g]
+        have : h₀f.meromorphicAt.order = n := by
+          rw [MeromorphicAt.order_eq_int_iff (MeromorphicNFAt.meromorphicAt h₀f) n]
+          use g, h₁g, h₂g
+          exact eventually_nhdsWithin_of_eventually_nhds h₃g
+        by_cases h₃f : h₀f.meromorphicAt.order = 0
+        · simp only [Pi.smul_apply', Pi.pow_apply, sub_self, h₃f, ↓reduceDIte]
+          have hn : n = (0 : ℤ) := by
+            rw [h₃f] at this
+            exact WithTop.coe_eq_zero.mp this.symm
+          simp_rw [hn]
+          simp only [zpow_zero, one_smul]
+          have : g =ᶠ[𝓝 x] (Classical.choose ((h₀f.meromorphicAt.order_eq_int_iff 0).1 h₃f)) := by
+            obtain ⟨h₀, h₁, h₂⟩ := Classical.choose_spec
+              ((h₀f.meromorphicAt.order_eq_int_iff 0).1 h₃f)
+            apply h₁g.eventuallyEq_nhdNE_iff_eventuallyEq_nhd h₀
+            rw [hn] at h₃g
+            simp only [zpow_zero, one_smul, ne_eq] at h₃g h₂
+            exact (h₃g.filter_mono nhdsWithin_le_nhds).symm.trans h₂
+          simp only [Function.update_self]
+          exact Filter.EventuallyEq.eq_of_nhds this
+        · simp only [Pi.smul_apply', Pi.pow_apply, sub_self, h₃f, ↓reduceDIte, smul_eq_zero,
+            Function.update_self, smul_eq_zero]
+          left
+          apply zero_zpow n
+          by_contra hn
+          rw [hn] at this
+          tauto
+    · exact hf.meromorphicAt.eqOn_compl_singleton_toMermomorphicNFAt hz
+  · intro hf
+    rw [hf]
+    exact meromorphicNFAt_toMeromorphicNFAt

--- a/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
+++ b/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
@@ -19,7 +19,9 @@ means that the representative can locally near any point `x` be written 'in
 normal form', as `f =ᶠ[𝓝 x] fun z ↦ (z - x) ^ n • g` where `g` is analytic and
 does not vanish at `x`.
 
-TODO: Establish further properties of meromorphic functions in normal form, such
+## TODO
+
+Establish further properties of meromorphic functions in normal form, such
 as a local identity theorem. Establish the analogous notion `MeromorphicNFOn`.
 -/
 

--- a/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
+++ b/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
@@ -139,7 +139,7 @@ theorem AnalyticAt.MeromorphicNFAt (hf : AnalyticAt 𝕜 f x) :
 ## Continuous extension and conversion to normal form
 -/
 
-variable (f) (x) in
+variable (f x) in
 /-- If `f` is meromorphic at `x`, convert `f` to normal form at `x` by changing its value at `x`.
 Otherwise, returns the 0 function. -/
 noncomputable def toMeromorphicNFAt :

--- a/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
+++ b/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
@@ -158,6 +158,11 @@ lemma MeromorphicAt.eqOn_compl_singleton_toMermomorphicNFAt (hf : MeromorphicAt 
     Set.EqOn f (toMeromorphicNFAt f x) {x}ᶜ :=
   fun _ _ ↦ by simp_all [toMeromorphicNFAt]
 
+/-- If `f` is not meromorphic, conversion to normal form at `x` maps the function to `0`. -/
+@[simp] lemma toMeromorphicNFAt_of_not_meromorphicAt (hf : ¬MeromorphicAt f x) :
+    toMeromorphicNFAt f x = 0 := by
+  simp [toMeromorphicNFAt, hf]
+
 /-- Conversion to normal form at `x` changes the value only at x. -/
 lemma MeromorphicAt.eq_nhdNE_toMeromorphicNFAt (hf : MeromorphicAt f x) :
     f =ᶠ[𝓝[≠] x] toMeromorphicNFAt f x :=

--- a/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
+++ b/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
@@ -131,7 +131,7 @@ theorem MeromorphicNFAt.order_nonneg_iff_analyticAt (hf : MeromorphicNFAt f x) :
     simp
 
 /-- Analytic functions are meromorphic in normal form. -/
-theorem AnalyticAt.MeromorphicNFAt (hf : AnalyticAt 𝕜 f x) :
+theorem AnalyticAt.meromorphicNFAt (hf : AnalyticAt 𝕜 f x) :
     MeromorphicNFAt f x := by
   simp [meromorphicNFAt_iff_analyticAt_or, hf]
 

--- a/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
+++ b/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
@@ -119,7 +119,7 @@ theorem MeromorphicNFAt.meromorphicAt (hf : MeromorphicNFAt f x) :
 
 /-- If a function is meromorphic in normal form at `x`, then it has non-negative order iff it is
 analytic. -/
-theorem MeromorphicNFAt.nonneg_order_iff_analyticAt (hf : MeromorphicNFAt f x) :
+theorem MeromorphicNFAt.order_nonneg_iff_analyticAt (hf : MeromorphicNFAt f x) :
     0 ≤ hf.meromorphicAt.order ↔ AnalyticAt 𝕜 f x := by
   constructor <;> intro h₂f
   · rw [meromorphicNFAt_iff_analyticAt_or] at hf

--- a/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
+++ b/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
@@ -153,7 +153,7 @@ noncomputable def toMeromorphicNFAt :
     · exact 0
   · exact 0
 
-/-- Conversion to normal form at `x` by changes the value only at x. -/
+/-- Conversion to normal form at `x` changes the value only at x. -/
 lemma MeromorphicAt.eqOn_compl_singleton_toMermomorphicNFAt (hf : MeromorphicAt f x) :
     Set.EqOn f (toMeromorphicNFAt f x) {x}ᶜ :=
   fun _ _ ↦ by simp_all [toMeromorphicNFAt]

--- a/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
+++ b/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
@@ -132,7 +132,7 @@ theorem MeromorphicNFAt.meromorphicAt (hf : MeromorphicNFAt f x) :
     exact hf
 
 /-- If a function is meromorphic in normal form at `x` and has non-negative
-order, then it is analytic -/
+order, then it is analytic. -/
 theorem MeromorphicNFAt.analyticAt (h₁f : MeromorphicNFAt f x)
     (h₂f : 0 ≤ h₁f.meromorphicAt.order) :
     AnalyticAt 𝕜 f x := by

--- a/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
+++ b/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
@@ -192,8 +192,7 @@ theorem MeromorphicNFAt.toNF_eq_id (hf : MeromorphicNFAt f x) :
   funext z
   by_cases hz : z = x
   · rw [hz]
-    unfold MeromorphicAt.toNF
-    simp only [WithTop.coe_zero, ne_eq, Function.update_self]
+    simp only [MeromorphicAt.toNF, WithTop.coe_zero, ne_eq, Function.update_self]
     have h₀f := hf
     rcases hf with h₁f | h₁f
     · simpa [(h₀f.meromorphicAt.order_eq_top_iff).2 (h₁f.filter_mono nhdsWithin_le_nhds)]

--- a/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
+++ b/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
@@ -185,7 +185,7 @@ theorem meromorphicNFAt_toMeromorphicNFAt :
         apply eventuallyEq_nhds_of_eventuallyEq_nhdsNE
         · exact hf.eq_nhdNE_toMeromorphicNFAt.symm.trans (hf.order_eq_top_iff.1 h₂f)
         · simp [h₂f, toMeromorphicNFAt, hf]
-      apply AnalyticAt.MeromorphicNFAt
+      apply AnalyticAt.meromorphicNFAt
       rw [analyticAt_congr this]
       exact analyticAt_const
     · lift hf.order to ℤ using h₂f with n hn
@@ -203,7 +203,7 @@ theorem meromorphicNFAt_toMeromorphicNFAt :
         simp_all
       · simp [h₃f, zero_zpow]
   · simp only [toMeromorphicNFAt, hf, ↓reduceDIte]
-    exact analyticAt_const.MeromorphicNFAt
+    exact analyticAt_const.meromorphicNFAt
 
 /-- If `f` has normal form at `x`, then `f` equals `f.toNF`. -/
 @[simp] theorem toMeromorphicNFAt_eq_self :

--- a/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
+++ b/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
@@ -50,10 +50,7 @@ theorem MeromorphicAt.meromorphicNFAt_iff :
     MeromorphicNFAt f x ↔ AnalyticAt 𝕜 f x ∨ ∃ hf : MeromorphicAt f x, hf.order < 0 ∧ f x = 0 := by
   constructor
   · rintro (h | ⟨n, g, h₁g, h₂g, h₃g⟩)
-    · have hf : MeromorphicAt f x := by
-        have : f =ᶠ[𝓝[≠] x] 0 := Filter.EventuallyEq.filter_mono h nhdsWithin_le_nhds
-        exact analyticAt_const.meromorphicAt.congr this.symm
-      simp [(analyticAt_congr h).2 analyticAt_const]
+    · simp [(analyticAt_congr h).2 analyticAt_const]
     · have hf : MeromorphicAt f x := by
         apply MeromorphicAt.congr _ (h₃g.filter_mono nhdsWithin_le_nhds).symm
         fun_prop

--- a/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
+++ b/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
@@ -178,21 +178,16 @@ theorem MeromorphicAt.MeromorphicNFAt_of_toNF (hf : MeromorphicAt f x) :
     obtain ⟨g, h₁g, h₂g, h₃g⟩ := (hf.order_eq_int_iff n).1 hn.symm
     right
     use n, g, h₁g, h₂g
-    apply eventuallyEq_nhds_of_eventuallyEq_nhdsNE
-    · exact hf.toNF_id_on_nhdNE.symm.trans h₃g
-    · unfold MeromorphicAt.toNF
-      simp only [WithTop.coe_zero, ne_eq, Function.update_self, Pi.smul_apply', Pi.pow_apply,
-        sub_self]
-      by_cases h₃f : hf.order = (0 : ℤ)
-      · simp only [h₃f, WithTop.coe_zero, ↓reduceDIte, WithTop.untopD_zero, zpow_zero, one_smul]
-        obtain ⟨h₁G, h₂G, h₃G⟩  := Classical.choose_spec ((hf.order_eq_int_iff 0).1 h₃f)
-        simp only [zpow_zero, ne_eq, one_smul] at h₃G
-        apply Filter.EventuallyEq.eq_of_nhds
-        apply (AnalyticAt.eventuallyEq_nhdNE_iff_eventuallyEq_nhd h₁G (by fun_prop)).1
-        filter_upwards [h₃g, h₃G]
-        simp_all
-      · simp_rw [← hn, WithTop.coe_zero, WithTop.coe_eq_zero] at *
-        simp [h₃f, zero_zpow n h₃f]
+    apply eventuallyEq_nhds_of_eventuallyEq_nhdsNE (hf.toNF_id_on_nhdNE.symm.trans h₃g)
+    simp only [MeromorphicAt.toNF, ne_eq, Function.update_self, Pi.smul_apply',
+      Pi.pow_apply, sub_self, ← hn, WithTop.coe_eq_coe]
+    split_ifs with h₃f
+    · obtain ⟨h₁G, _, h₃G⟩ := Classical.choose_spec ((hf.order_eq_int_iff 0).1 (h₃f ▸ hn.symm))
+      apply Filter.EventuallyEq.eq_of_nhds
+      rw [← h₁G.eventuallyEq_nhdNE_iff_eventuallyEq_nhd (by fun_prop)]
+      filter_upwards [h₃g, h₃G]
+      simp_all
+    · simp [h₃f, zero_zpow]
 
 /-- If `f` has normal form at `x`, then `f` equals `f.toNF`. -/
 theorem MeromorphicNFAt.toNF_eq_id (hf : MeromorphicNFAt f x) :

--- a/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
+++ b/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
@@ -10,7 +10,7 @@ import Mathlib.Analysis.Meromorphic.Order
 
 If a function `f` is meromorphic on `U` and if `g` differs from `f` only along a
 set that is codiscrete within `U`, then `g` is likewise meromorphic. The set of
-meromorphic functions is therefore huge, and `=ᶠ[codiscreteWithinU]` defines an
+meromorphic functions is therefore huge, and `=ᶠ[codiscreteWithin U]` defines an
 equivalence relation.
 
 This file implements continuous extension to provide an API that allows picking

--- a/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
+++ b/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
@@ -48,7 +48,7 @@ def MeromorphicNFAt (f : 𝕜 → E) (x : 𝕜) :=
 
 /-- A meromorphic function has normal form at `x` iff it is either analytic
 there, or if it has a pole at `x` and takes the default value `0`. -/
-theorem MeromorphicAt.meromorphicNFAt_iff :
+theorem meromorphicNFAt_iff_analyticAt_or :
     MeromorphicNFAt f x ↔ AnalyticAt 𝕜 f x ∨ ∃ hf : MeromorphicAt f x, hf.order < 0 ∧ f x = 0 := by
   constructor
   · rintro (h | ⟨n, g, h₁g, h₂g, h₃g⟩)

--- a/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
+++ b/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
@@ -51,7 +51,7 @@ theorem meromorphicNFAt_def :
   .rfl
 
 /-- A meromorphic function has normal form at `x` iff it is either analytic
-there, or if has a pole `x` and take the default value `0`. -/
+there, or if it has a pole at `x` and takes the default value `0`. -/
 theorem MeromorphicAt.meromorphicNFAt_iff (hf : MeromorphicAt f x) :
     MeromorphicNFAt f x ↔ (AnalyticAt 𝕜 f x) ∨ (hf.order < 0 ∧ f x = 0) := by
   constructor

--- a/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
+++ b/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
@@ -168,7 +168,7 @@ private lemma AnalyticAt.eventuallyEq_nhdNE_iff_eventuallyEq_nhd {g : 𝕜 → E
   · simpa using (Filter.eventually_and.2 ⟨Filter.eventuallyEq_iff_sub.mp hfg, h⟩).exists
 
 /-- After conversion to normal form at `x`, the function has normal form. -/
-theorem MeromorphicAt.MeromorphicNFAt_toNF (hf : MeromorphicAt f x) :
+theorem MeromorphicAt.meromorphicNFAt_toNF (hf : MeromorphicAt f x) :
     MeromorphicNFAt hf.toNF x := by
   by_cases h₂f : hf.order = ⊤
   · have : hf.toNF =ᶠ[𝓝 x] 0 := by

--- a/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
+++ b/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
@@ -159,7 +159,7 @@ lemma MeromorphicAt.eqOn_compl_singleton_toNF (hf : MeromorphicAt f x) :
   fun _ _ ↦ by simp_all [toMeromorphicNFAt]
 
 /-- Conversion to normal form at `x` changes the value only at x. -/
-lemma MeromorphicAt.toNF_id_on_nhdNE (hf : MeromorphicAt f x) :
+lemma MeromorphicAt.eq_nhdNE_toMeromorphicNFAt (hf : MeromorphicAt f x) :
     f =ᶠ[𝓝[≠] x] toMeromorphicNFAt f x :=
   eventually_nhdsWithin_of_forall (fun _ hz ↦ hf.eqOn_compl_singleton_toNF hz)
 

--- a/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
+++ b/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
@@ -38,7 +38,7 @@ variable
 -/
 
 /-- A function is 'meromorphic in normal form' at `x` if it vanishes around `x`
-or if can locally be written as `fun z ↦ (z - x) ^ n • g` where `g` is
+or if it can locally be written as `fun z ↦ (z - x) ^ n • g` where `g` is
 analytic and does not vanish at `x`. -/
 def MeromorphicNFAt (f : 𝕜 → E) (x : 𝕜) :=
   (f =ᶠ[𝓝 x] 0) ∨ (∃ (n : ℤ), ∃ g : 𝕜 → E, (AnalyticAt 𝕜 g x) ∧ (g x ≠ 0) ∧

--- a/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
+++ b/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
@@ -142,7 +142,7 @@ theorem AnalyticAt.MeromorphicNFAt (hf : AnalyticAt 𝕜 f x) :
 variable (f) (x) in
 /-- If `f` is meromorphic at `x`, convert `f` to normal form at `x` by changing its value at `x`.
 Otherwise, returns the 0 function. -/
-noncomputable def Function.toMeromorphicNFAt :
+noncomputable def toMeromorphicNFAt :
     𝕜 → E := by
   by_cases hf : MeromorphicAt f x
   · classical -- do not complain about decidability issues in Function.update
@@ -155,12 +155,12 @@ noncomputable def Function.toMeromorphicNFAt :
 
 /-- Conversion to normal form at `x` by changes the value only at x. -/
 lemma MeromorphicAt.eqOn_compl_singleton_toNF (hf : MeromorphicAt f x) :
-    Set.EqOn f (f.toMeromorphicNFAt x) {x}ᶜ :=
-  fun _ _ ↦ by simp_all [Function.toMeromorphicNFAt]
+    Set.EqOn f (toMeromorphicNFAt f x) {x}ᶜ :=
+  fun _ _ ↦ by simp_all [toMeromorphicNFAt]
 
 /-- Conversion to normal form at `x` changes the value only at x. -/
 lemma MeromorphicAt.toNF_id_on_nhdNE (hf : MeromorphicAt f x) :
-    f =ᶠ[𝓝[≠] x] f.toMeromorphicNFAt x :=
+    f =ᶠ[𝓝[≠] x] toMeromorphicNFAt f x :=
   eventually_nhdsWithin_of_forall (fun _ hz ↦ hf.eqOn_compl_singleton_toNF hz)
 
 -- Two analytic functions agree on a punctured neighborhood iff they agree on a neighborhood.
@@ -173,12 +173,12 @@ private lemma AnalyticAt.eventuallyEq_nhdNE_iff_eventuallyEq_nhd {g : 𝕜 → E
 
 /-- After conversion to normal form at `x`, the function has normal form. -/
 theorem MeromorphicAt.meromorphicNFAt_toNF (hf : MeromorphicAt f x) :
-    MeromorphicNFAt (f.toMeromorphicNFAt x) x := by
+    MeromorphicNFAt (toMeromorphicNFAt f x) x := by
   by_cases h₂f : hf.order = ⊤
-  · have : f.toMeromorphicNFAt x =ᶠ[𝓝 x] 0 := by
+  · have : toMeromorphicNFAt f x =ᶠ[𝓝 x] 0 := by
       apply eventuallyEq_nhds_of_eventuallyEq_nhdsNE
       · exact hf.toNF_id_on_nhdNE.symm.trans (hf.order_eq_top_iff.1 h₂f)
-      · simp [h₂f, Function.toMeromorphicNFAt, hf]
+      · simp [h₂f, toMeromorphicNFAt, hf]
     apply AnalyticAt.MeromorphicNFAt
     rw [analyticAt_congr this]
     exact analyticAt_const
@@ -187,7 +187,7 @@ theorem MeromorphicAt.meromorphicNFAt_toNF (hf : MeromorphicAt f x) :
     right
     use n, g, h₁g, h₂g
     apply eventuallyEq_nhds_of_eventuallyEq_nhdsNE (hf.toNF_id_on_nhdNE.symm.trans h₃g)
-    simp only [Function.toMeromorphicNFAt, hf, ↓reduceDIte, ← hn, WithTop.coe_zero,
+    simp only [toMeromorphicNFAt, hf, ↓reduceDIte, ← hn, WithTop.coe_zero,
       WithTop.coe_eq_zero, ne_eq, Function.update_self, sub_self]
     split_ifs with h₃f
     · obtain ⟨h₁G, _, h₃G⟩ := Classical.choose_spec ((hf.order_eq_int_iff 0).1 (h₃f ▸ hn.symm))
@@ -199,12 +199,11 @@ theorem MeromorphicAt.meromorphicNFAt_toNF (hf : MeromorphicAt f x) :
 
 /-- If `f` has normal form at `x`, then `f` equals `f.toNF`. -/
 theorem MeromorphicNFAt.toNF_eq_id (hf : MeromorphicNFAt f x) :
-    f = f.toMeromorphicNFAt x := by
+    f = toMeromorphicNFAt f x := by
   funext z
   by_cases hz : z = x
   · rw [hz]
-    simp only [Function.toMeromorphicNFAt, hf.meromorphicAt, WithTop.coe_zero, ne_eq,
-      Function.update_self]
+    simp only [toMeromorphicNFAt, hf.meromorphicAt, WithTop.coe_zero, ne_eq, Function.update_self]
     have h₀f := hf
     rcases hf with h₁f | h₁f
     · simpa [(h₀f.meromorphicAt.order_eq_top_iff).2 (h₁f.filter_mono nhdsWithin_le_nhds)]

--- a/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
+++ b/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
@@ -49,17 +49,14 @@ there, or if it has a pole at `x` and takes the default value `0`. -/
 theorem MeromorphicAt.meromorphicNFAt_iff :
     MeromorphicNFAt f x ↔ AnalyticAt 𝕜 f x ∨ ∃ hf : MeromorphicAt f x, hf.order < 0 ∧ f x = 0 := by
   constructor
-  · intro h₁f
-    have hf : MeromorphicAt f x := by
-      rcases h₁f with h | h
-      · have : f =ᶠ[𝓝[≠] x] 0 := Filter.EventuallyEq.filter_mono h nhdsWithin_le_nhds
+  · rintro (h | ⟨n, g, h₁g, h₂g, h₃g⟩)
+    · have hf : MeromorphicAt f x := by
+        have : f =ᶠ[𝓝[≠] x] 0 := Filter.EventuallyEq.filter_mono h nhdsWithin_le_nhds
         exact analyticAt_const.meromorphicAt.congr this.symm
-      · obtain ⟨n, g, h₁g, _, h₃g⟩ := h
-        apply MeromorphicAt.congr _ (Filter.EventuallyEq.filter_mono h₃g nhdsWithin_le_nhds).symm
+      simp [(analyticAt_congr h).2 analyticAt_const]
+    · have hf : MeromorphicAt f x := by
+        apply MeromorphicAt.congr _ (h₃g.filter_mono nhdsWithin_le_nhds).symm
         fun_prop
-    rcases h₁f with h | h
-    · simp [(analyticAt_congr h).2 analyticAt_const]
-    · obtain ⟨n, g, h₁g, h₂g, h₃g⟩ := h
       have : hf.order = n := by
         rw [hf.order_eq_int_iff]
         use g, h₁g, h₂g
@@ -72,8 +69,7 @@ theorem MeromorphicAt.meromorphicNFAt_iff :
         use hf
         simp [this, WithTop.coe_lt_zero.2 (not_le.1 hn), h₃g.eq_of_nhds,
           zero_zpow n (ne_of_not_le hn).symm]
-  · intro h₁f
-    rcases h₁f with h | ⟨h₁, h₂, h₃⟩
+  · rintro (h | ⟨h₁, h₂, h₃⟩)
     · by_cases h₂f : h.order = ⊤
       · rw [AnalyticAt.order_eq_top_iff] at h₂f
         tauto
@@ -199,7 +195,7 @@ theorem MeromorphicNFAt.toNF_eq_id (hf : MeromorphicNFAt f x) :
     simp only [WithTop.coe_zero, ne_eq, Function.update_self]
     have h₀f := hf
     rcases hf with h₁f | h₁f
-    · simpa [(h₀f.meromorphicAt.order_eq_top_iff).2 (h₁f.filter_mono nhdsWithin_le_nhds)] 
+    · simpa [(h₀f.meromorphicAt.order_eq_top_iff).2 (h₁f.filter_mono nhdsWithin_le_nhds)]
         using h₁f.eq_of_nhds
     · obtain ⟨n, g, h₁g, h₂g, h₃g⟩ := h₁f
       rw [Filter.EventuallyEq.eq_of_nhds h₃g]

--- a/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
+++ b/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
@@ -47,8 +47,8 @@ def MeromorphicNFAt (f : 𝕜 → E) (x : 𝕜) :=
 /-- Reformulation of the definition for convenience -/
 theorem meromorphicNFAt_def :
     MeromorphicNFAt f x ↔ (f =ᶠ[𝓝 x] 0) ∨
-    (∃ (n : ℤ), ∃ g : 𝕜 → E, (AnalyticAt 𝕜 g x) ∧ (g x ≠ 0) ∧ (f =ᶠ[𝓝 x] (· - x) ^ n • g )) := by
-  rfl
+    (∃ (n : ℤ), ∃ g : 𝕜 → E, (AnalyticAt 𝕜 g x) ∧ (g x ≠ 0) ∧ (f =ᶠ[𝓝 x] (· - x) ^ n • g)) :=
+  .rfl
 
 /-- A meromorphic function has normal form at `x` iff it is either analytic
 there, or if has a pole `x` and take the default value `0`. -/

--- a/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
+++ b/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
@@ -118,17 +118,18 @@ theorem MeromorphicNFAt.meromorphicAt (hf : MeromorphicNFAt f x) :
   · obtain ⟨hf, _⟩ := h
     exact hf
 
-/-- If a function is meromorphic in normal form at `x` and has non-negative
-order, then it is analytic. -/
-theorem MeromorphicNFAt.analyticAt (h₁f : MeromorphicNFAt f x)
-    (h₂f : 0 ≤ h₁f.meromorphicAt.order) :
-    AnalyticAt 𝕜 f x := by
-  rw [MeromorphicAt.meromorphicNFAt_iff] at h₁f
-  rcases h₁f with h | h
-  · exact h
-  · by_contra h'
-    obtain ⟨h₃f, h₄f, h₅f⟩ := h
-    exact lt_irrefl 0 (lt_of_le_of_lt h₂f h₄f)
+/-- If a function is meromorphic in normal form at `x`, then it has non-negative order iff it is
+analytic. -/
+theorem MeromorphicNFAt.nonneg_order_iff_analyticAt (hf : MeromorphicNFAt f x) :
+    0 ≤ hf.meromorphicAt.order ↔ AnalyticAt 𝕜 f x := by
+  constructor <;> intro h₂f
+  · rw [MeromorphicAt.meromorphicNFAt_iff] at hf
+    rcases hf with h | ⟨_, h₃f, _⟩
+    · exact h
+    · by_contra h'
+      exact lt_irrefl 0 (lt_of_le_of_lt h₂f h₃f)
+  · rw [h₂f.meromorphicAt_order]
+    simp
 
 /-- Analytic functions are meromorphic in normal form. -/
 theorem AnalyticAt.MeromorphicNFAt (hf : AnalyticAt 𝕜 f x) :

--- a/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
+++ b/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
@@ -194,7 +194,7 @@ theorem MeromorphicAt.MeromorphicNFAt_of_toNF (hf : MeromorphicAt f x) :
         obtain ⟨h₁G, h₂G, h₃G⟩  := Classical.choose_spec ((hf.order_eq_int_iff 0).1 h₃f)
         simp only [zpow_zero, ne_eq, one_smul] at h₃G
         apply Filter.EventuallyEq.eq_of_nhds
-        apply (AnalyticAt.eventuallyEq_nhd_iff_eventuallyEq_nhdNE h₁G (by fun_prop)).1
+        apply (AnalyticAt.eventuallyEq_nhdNE_iff_eventuallyEq_nhd h₁G (by fun_prop)).1
         filter_upwards [h₃g, h₃G]
         simp_all
       · simp_rw [← hn, WithTop.coe_zero, WithTop.coe_eq_zero] at *
@@ -229,7 +229,7 @@ theorem MeromorphicNFAt.toNF_eq_id (hf : MeromorphicNFAt f x) :
         have : g =ᶠ[𝓝 x] (Classical.choose ((h₀f.meromorphicAt.order_eq_int_iff 0).1 h₃f)) := by
           obtain ⟨h₀, h₁, h₂⟩ := Classical.choose_spec
             ((h₀f.meromorphicAt.order_eq_int_iff 0).1 h₃f)
-          apply (h₁g.eventuallyEq_nhd_iff_eventuallyEq_nhdNE h₀).1
+          apply (h₁g.eventuallyEq_nhdNE_iff_eventuallyEq_nhd h₀).1
           rw [hn] at h₃g
           simp only [zpow_zero, one_smul, ne_eq] at h₃g h₂
           exact (h₃g.filter_mono nhdsWithin_le_nhds).symm.trans h₂

--- a/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
+++ b/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
@@ -101,22 +101,13 @@ theorem MeromorphicAt.meromorphicNFAt_iff :
 /-- Meromorphicity in normal form is a local property. -/
 theorem meromorphicNFAt_congr {g : 𝕜 → E} (hfg : f =ᶠ[𝓝 x] g) :
     MeromorphicNFAt f x ↔ MeromorphicNFAt g x := by
-  unfold MeromorphicNFAt
   constructor
-  · intro h
-    rcases h with h | h
-    · left
-      exact hfg.symm.trans h
-    · obtain ⟨n, h, h₁h, h₂h, h₃h⟩ := h
-      right
-      use n, h, h₁h, h₂h, hfg.symm.trans h₃h
-  · intro h
-    rcases h with h | h
-    · left
-      exact hfg.trans h
-    · obtain ⟨n, h, h₁h, h₂h, h₃h⟩ := h
-      right
-      use n, h, h₁h, h₂h, hfg.trans h₃h
+  · rintro (h | ⟨n, h, h₁h, h₂h, h₃h⟩)
+    · exact Or.inl (hfg.symm.trans h)
+    · exact Or.inr ⟨n, h, h₁h, h₂h, hfg.symm.trans h₃h⟩
+  · rintro (h | ⟨n, h, h₁h, h₂h, h₃h⟩)
+    · exact Or.inl (hfg.trans h)
+    · exact Or.inr ⟨n, h, h₁h, h₂h, hfg.trans h₃h⟩
 
 /-!
 ## Relation to other properties of functions

--- a/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
+++ b/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
@@ -111,7 +111,7 @@ theorem meromorphicNFAt_congr {g : 𝕜 → E} (hfg : f =ᶠ[𝓝 x] g) :
 /-- If a function is meromorphic in normal form at `x`, then it is meromorphic at `x`. -/
 theorem MeromorphicNFAt.meromorphicAt (hf : MeromorphicNFAt f x) :
     MeromorphicAt f x := by
-  rw [MeromorphicAt.meromorphicNFAt_iff] at hf
+  rw [meromorphicNFAt_iff_analyticAt_or] at hf
   rcases hf with h | h
   · exact h.meromorphicAt
   · obtain ⟨hf, _⟩ := h
@@ -122,7 +122,7 @@ analytic. -/
 theorem MeromorphicNFAt.nonneg_order_iff_analyticAt (hf : MeromorphicNFAt f x) :
     0 ≤ hf.meromorphicAt.order ↔ AnalyticAt 𝕜 f x := by
   constructor <;> intro h₂f
-  · rw [MeromorphicAt.meromorphicNFAt_iff] at hf
+  · rw [meromorphicNFAt_iff_analyticAt_or] at hf
     rcases hf with h | ⟨_, h₃f, _⟩
     · exact h
     · by_contra h'
@@ -133,7 +133,7 @@ theorem MeromorphicNFAt.nonneg_order_iff_analyticAt (hf : MeromorphicNFAt f x) :
 /-- Analytic functions are meromorphic in normal form. -/
 theorem AnalyticAt.MeromorphicNFAt (hf : AnalyticAt 𝕜 f x) :
     MeromorphicNFAt f x := by
-  simp [MeromorphicAt.meromorphicNFAt_iff, hf]
+  simp [meromorphicNFAt_iff_analyticAt_or, hf]
 
 /-!
 ## Continuous extension and conversion to normal form

--- a/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
+++ b/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
@@ -44,12 +44,6 @@ def MeromorphicNFAt (f : 𝕜 → E) (x : 𝕜) :=
   f =ᶠ[𝓝 x] 0 ∨
     ∃ (n : ℤ) (g : 𝕜 → E), AnalyticAt 𝕜 g x ∧ g x ≠ 0 ∧ f =ᶠ[𝓝 x] (· - x) ^ n • g
 
-/-- Reformulation of the definition for convenience -/
-theorem meromorphicNFAt_def :
-    MeromorphicNFAt f x ↔ (f =ᶠ[𝓝 x] 0) ∨
-    (∃ (n : ℤ), ∃ g : 𝕜 → E, (AnalyticAt 𝕜 g x) ∧ (g x ≠ 0) ∧ (f =ᶠ[𝓝 x] (· - x) ^ n • g)) :=
-  .rfl
-
 /-- A meromorphic function has normal form at `x` iff it is either analytic
 there, or if it has a pole at `x` and takes the default value `0`. -/
 theorem MeromorphicAt.meromorphicNFAt_iff (hf : MeromorphicAt f x) :

--- a/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
+++ b/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
@@ -139,24 +139,27 @@ theorem AnalyticAt.MeromorphicNFAt (hf : AnalyticAt 𝕜 f x) :
 ## Continuous extension and conversion to normal form
 -/
 
+variable (f) (x) in
 /-- Convert a meromorphic function to normal form at `x` by changing its value at `x`. -/
-noncomputable def MeromorphicAt.toNF (hf : MeromorphicAt f x) :
+noncomputable def Function.toMeromorphicNFAt :
     𝕜 → E := by
-  classical -- do not complain about decidability issues in Function.update
-  apply Function.update f x
-  by_cases h₁f : hf.order = (0 : ℤ)
-  · rw [hf.order_eq_int_iff] at h₁f
-    exact (Classical.choose h₁f) x
+  by_cases hf : MeromorphicAt f x
+  · classical -- do not complain about decidability issues in Function.update
+    apply Function.update f x
+    by_cases h₁f : hf.order = (0 : ℤ)
+    · rw [hf.order_eq_int_iff] at h₁f
+      exact (Classical.choose h₁f) x
+    · exact 0
   · exact 0
 
 /-- Conversion to normal form at `x` by changes the value only at x. -/
 lemma MeromorphicAt.eqOn_compl_singleton_toNF (hf : MeromorphicAt f x) :
-    Set.EqOn f hf.toNF {x}ᶜ :=
-  fun _ _ ↦ by simp_all [MeromorphicAt.toNF]
+    Set.EqOn f (f.toMeromorphicNFAt x) {x}ᶜ :=
+  fun _ _ ↦ by simp_all [Function.toMeromorphicNFAt]
 
 /-- Conversion to normal form at `x` changes the value only at x. -/
 lemma MeromorphicAt.toNF_id_on_nhdNE (hf : MeromorphicAt f x) :
-    f =ᶠ[𝓝[≠] x] hf.toNF :=
+    f =ᶠ[𝓝[≠] x] f.toMeromorphicNFAt x :=
   eventually_nhdsWithin_of_forall (fun _ hz ↦ hf.eqOn_compl_singleton_toNF hz)
 
 -- Two analytic functions agree on a punctured neighborhood iff they agree on a neighborhood.
@@ -169,12 +172,12 @@ private lemma AnalyticAt.eventuallyEq_nhdNE_iff_eventuallyEq_nhd {g : 𝕜 → E
 
 /-- After conversion to normal form at `x`, the function has normal form. -/
 theorem MeromorphicAt.MeromorphicNFAt_toNF (hf : MeromorphicAt f x) :
-    MeromorphicNFAt hf.toNF x := by
+    MeromorphicNFAt (f.toMeromorphicNFAt x) x := by
   by_cases h₂f : hf.order = ⊤
-  · have : hf.toNF =ᶠ[𝓝 x] 0 := by
+  · have : f.toMeromorphicNFAt x =ᶠ[𝓝 x] 0 := by
       apply eventuallyEq_nhds_of_eventuallyEq_nhdsNE
       · exact hf.toNF_id_on_nhdNE.symm.trans (hf.order_eq_top_iff.1 h₂f)
-      · simp [h₂f, MeromorphicAt.toNF]
+      · simp [h₂f, Function.toMeromorphicNFAt, hf]
     apply AnalyticAt.MeromorphicNFAt
     rw [analyticAt_congr this]
     exact analyticAt_const
@@ -183,8 +186,8 @@ theorem MeromorphicAt.MeromorphicNFAt_toNF (hf : MeromorphicAt f x) :
     right
     use n, g, h₁g, h₂g
     apply eventuallyEq_nhds_of_eventuallyEq_nhdsNE (hf.toNF_id_on_nhdNE.symm.trans h₃g)
-    simp only [MeromorphicAt.toNF, ne_eq, Function.update_self, Pi.smul_apply',
-      Pi.pow_apply, sub_self, ← hn, WithTop.coe_eq_coe]
+    simp only [Function.toMeromorphicNFAt, hf, ↓reduceDIte, ← hn, WithTop.coe_zero,
+      WithTop.coe_eq_zero, ne_eq, Function.update_self, sub_self]
     split_ifs with h₃f
     · obtain ⟨h₁G, _, h₃G⟩ := Classical.choose_spec ((hf.order_eq_int_iff 0).1 (h₃f ▸ hn.symm))
       apply Filter.EventuallyEq.eq_of_nhds
@@ -195,11 +198,12 @@ theorem MeromorphicAt.MeromorphicNFAt_toNF (hf : MeromorphicAt f x) :
 
 /-- If `f` has normal form at `x`, then `f` equals `f.toNF`. -/
 theorem MeromorphicNFAt.toNF_eq_id (hf : MeromorphicNFAt f x) :
-    f = hf.meromorphicAt.toNF := by
+    f = f.toMeromorphicNFAt x := by
   funext z
   by_cases hz : z = x
   · rw [hz]
-    simp only [MeromorphicAt.toNF, WithTop.coe_zero, ne_eq, Function.update_self]
+    simp only [Function.toMeromorphicNFAt, hf.meromorphicAt, WithTop.coe_zero, ne_eq,
+      Function.update_self]
     have h₀f := hf
     rcases hf with h₁f | h₁f
     · simpa [(h₀f.meromorphicAt.order_eq_top_iff).2 (h₁f.filter_mono nhdsWithin_le_nhds)]
@@ -224,8 +228,10 @@ theorem MeromorphicNFAt.toNF_eq_id (hf : MeromorphicNFAt f x) :
           rw [hn] at h₃g
           simp only [zpow_zero, one_smul, ne_eq] at h₃g h₂
           exact (h₃g.filter_mono nhdsWithin_le_nhds).symm.trans h₂
+        simp only [Function.update_self]
         exact Filter.EventuallyEq.eq_of_nhds this
-      · simp only [Pi.smul_apply', Pi.pow_apply, sub_self, h₃f, ↓reduceDIte, smul_eq_zero]
+      · simp only [Pi.smul_apply', Pi.pow_apply, sub_self, h₃f, ↓reduceDIte, smul_eq_zero,
+          Function.update_self, smul_eq_zero]
         left
         apply zero_zpow n
         by_contra hn

--- a/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
+++ b/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
@@ -163,7 +163,7 @@ lemma MeromorphicAt.toNF_id_on_nhdNE (hf : MeromorphicAt f x) :
     f =ᶠ[𝓝[≠] x] toMeromorphicNFAt f x :=
   eventually_nhdsWithin_of_forall (fun _ hz ↦ hf.eqOn_compl_singleton_toNF hz)
 
--- Two analytic functions agree on a punctured neighborhood iff they agree on a neighborhood.
+/-- Two analytic functions agree on a punctured neighborhood iff they agree on a neighborhood. -/
 private lemma AnalyticAt.eventuallyEq_nhdNE_iff_eventuallyEq_nhd {g : 𝕜 → E} {z₀ : 𝕜}
   (hf : AnalyticAt 𝕜 f z₀) (hg : AnalyticAt 𝕜 g z₀) (hfg : f =ᶠ[𝓝[≠] z₀] g) :
     f =ᶠ[𝓝 z₀] g := by

--- a/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
+++ b/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
@@ -1,0 +1,243 @@
+/-
+Copyright (c) 2025 Stefan Kebekus. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Stefan Kebekus
+-/
+import Mathlib.Analysis.Meromorphic.Order
+
+/-!
+# Normal form of meromorphic functions and continuous extension
+
+If a function `f` is meromorphic on `U` and if `g` differs from `f` only along a
+set that is codiscrete within `U`, then `g` is likewise meromorphic. The set of
+meromorphic functions is therefore huge, and `=ᶠ[codiscreteWithinU]` defines an
+equivalence relation.
+
+This file implements continuous extension to provide an API that allows picking
+the 'unique best' representative of any given equivalence class, where 'best'
+means that the representative can locally near any point `x` be written 'in
+normal form', as `f =ᶠ[𝓝 x] fun z ↦ (z - x) ^ n • g` where `g` is analytic and
+does not vanish at `x`.
+
+TODO: Establish further properties of meromorphic functions in normal form, such
+as a local identity theorem. Establish the analogous notion `MeromorphicNFOn`.
+-/
+
+open Topology
+
+variable
+  {𝕜 : Type*} [NontriviallyNormedField 𝕜]
+  {E : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E]
+  {f : 𝕜 → E}
+  {x : 𝕜}
+
+/-!
+# Normal form of meromorphic functions at a given point
+
+## Definition and characterizations
+-/
+
+/-- A function is 'meromorphic in normal form' at `x` if it vanishes around `x`
+or if can locally be written as `fun z ↦ (z - x) ^ n • g` where `g` is
+analytic and does not vanish at `x`. -/
+def MeromorphicNFAt (f : 𝕜 → E) (x : 𝕜) :=
+  (f =ᶠ[𝓝 x] 0) ∨ (∃ (n : ℤ), ∃ g : 𝕜 → E, (AnalyticAt 𝕜 g x) ∧ (g x ≠ 0) ∧
+    (f =ᶠ[𝓝 x] (· - x) ^ n • g ))
+
+/-- Reformulation of the definition for convenience -/
+theorem meromorphicNFAt_def :
+    MeromorphicNFAt f x ↔ (f =ᶠ[𝓝 x] 0) ∨
+    (∃ (n : ℤ), ∃ g : 𝕜 → E, (AnalyticAt 𝕜 g x) ∧ (g x ≠ 0) ∧ (f =ᶠ[𝓝 x] (· - x) ^ n • g )) := by
+  rfl
+
+/-- A meromorphic function has normal form at `x` iff it is either analytic
+there, or if has a pole `x` and take the default value `0`. -/
+theorem MeromorphicAt.meromorphicNFAt_iff (hf : MeromorphicAt f x) :
+    MeromorphicNFAt f x ↔ (AnalyticAt 𝕜 f x) ∨ (hf.order < 0 ∧ f x = 0) := by
+  constructor
+  · intro h₁f
+    rcases h₁f with h | h
+    · simp [(analyticAt_congr h).2 analyticAt_const]
+    · obtain ⟨n, g, h₁g, h₂g, h₃g⟩ := h
+      have : hf.order = n := by
+        rw [hf.order_eq_int_iff]
+        use g, h₁g, h₂g
+        exact eventually_nhdsWithin_of_eventually_nhds h₃g
+      by_cases hn : 0 ≤ n
+      · left
+        rw [analyticAt_congr h₃g]
+        apply (AnalyticAt.zpow_nonneg (by fun_prop) hn).smul h₁g
+      · simp [this, WithTop.coe_lt_zero.2 (not_le.1 hn), h₃g.eq_of_nhds,
+          zero_zpow n (ne_of_not_le hn).symm]
+  · intro h₁f
+    rcases h₁f with h | ⟨h₁, h₂⟩
+    · by_cases h₂f : h.order = ⊤
+      · rw [AnalyticAt.order_eq_top_iff] at h₂f
+        tauto
+      · right
+        use h.order.toNat
+        have : h.order ≠ ⊤ := h₂f
+        rw [← ENat.coe_toNat_eq_self, eq_comm, AnalyticAt.order_eq_nat_iff] at this
+        obtain ⟨g, h₁g, h₂g, h₃g⟩ := this
+        use g, h₁g, h₂g
+        simpa
+    · right
+      lift hf.order to ℤ using LT.lt.ne_top h₁ with n hn
+      obtain ⟨g, h₁g, h₂g, h₃g⟩ := (hf.order_eq_int_iff n).1 hn.symm
+      use n, g, h₁g, h₂g
+      filter_upwards [eventually_nhdsWithin_iff.1 h₃g]
+      intro z hz
+      by_cases h₁z : z = x
+      · simp only [h₁z, h₂, Pi.smul_apply', Pi.pow_apply, sub_self]
+        apply (smul_eq_zero_of_left (zero_zpow n _) (g x)).symm
+        by_contra hCon
+        simp [hCon] at h₁
+      · exact hz h₁z
+
+/-- Meromorphicity in normal form is a local property. -/
+theorem meromorphicNFAt_congr {g : 𝕜 → E} (hfg : f =ᶠ[𝓝 x] g) :
+    MeromorphicNFAt f x ↔ MeromorphicNFAt g x := by
+  unfold MeromorphicNFAt
+  constructor
+  · intro h
+    rcases h with h | h
+    · left
+      exact hfg.symm.trans h
+    · obtain ⟨n, h, h₁h, h₂h, h₃h⟩ := h
+      right
+      use n, h, h₁h, h₂h, hfg.symm.trans h₃h
+  · intro h
+    rcases h with h | h
+    · left
+      exact hfg.trans h
+    · obtain ⟨n, h, h₁h, h₂h, h₃h⟩ := h
+      right
+      use n, h, h₁h, h₂h, hfg.trans h₃h
+
+/-!
+## Relation to other properties of functions
+-/
+
+/-- If a function is meromorphic in normal form at `x`, then it is meromorphic at `x`. -/
+theorem MeromorphicNFAt.meromorphicAt (hf : MeromorphicNFAt f x) :
+    MeromorphicAt f x := by
+  rcases hf with h | h
+  · have : f =ᶠ[𝓝[≠] x] 0 := Filter.EventuallyEq.filter_mono h nhdsWithin_le_nhds
+    exact analyticAt_const.meromorphicAt.congr this.symm
+  · obtain ⟨n, g, h₁g, _, h₃g⟩ := h
+    apply MeromorphicAt.congr _ (Filter.EventuallyEq.filter_mono h₃g nhdsWithin_le_nhds).symm
+    fun_prop
+
+/- If a function is meromorphic in normal form at `x` and has non-negative
+order, then it is analytic -/
+theorem MeromorphicNFAt.analyticAt (h₁f : MeromorphicNFAt f x)
+    (h₂f : 0 ≤ h₁f.meromorphicAt.order) :
+    AnalyticAt 𝕜 f x := by
+  have h₃f := h₁f.meromorphicAt
+  rw [h₃f.meromorphicNFAt_iff] at h₁f
+  rcases h₁f with h | h
+  · exact h
+  · by_contra h'
+    exact lt_irrefl 0 (lt_of_le_of_lt h₂f h.1)
+
+/-- Analytic functions are meromorphic in normal form. -/
+theorem AnalyticAt.MeromorphicNFAt (hf : AnalyticAt 𝕜 f x) :
+    MeromorphicNFAt f x := by
+  simp [hf.meromorphicAt.meromorphicNFAt_iff, hf]
+
+/-!
+## Continuous extension and conversion to normal form
+-/
+
+/- Convert a meromorphic function to normal form at `x` by changing its value. -/
+noncomputable def MeromorphicAt.toNF (hf : MeromorphicAt f x) :
+    𝕜 → E := by
+  classical -- do not complain about decidability issues in Function.update
+  apply Function.update f x
+  by_cases h₁f : hf.order = (0 : ℤ)
+  · rw [hf.order_eq_int_iff] at h₁f
+    exact (Classical.choose h₁f) x
+  · exact 0
+
+/- Conversion to normal form at `x` by changes the value only at x. -/
+lemma MeromorphicAt.toNF_id_on_complement (hf : MeromorphicAt f x) :
+    Set.EqOn f hf.toNF {x}ᶜ :=
+  fun _ _ ↦ by simp_all [MeromorphicAt.toNF]
+
+/- Conversion to normal form at `x` by changes the value only at x. -/
+lemma MeromorphicAt.toNF_id_on_nhdNE (hf : MeromorphicAt f x) :
+    f =ᶠ[𝓝[≠] x] hf.toNF :=
+  eventually_nhdsWithin_of_forall (fun _ hz ↦ hf.toNF_id_on_complement hz)
+
+/- After conversion to normal form at `x`, the function has normal form. -/
+theorem MeromorphicAt.MeromorphicNFAt_of_toNF (hf : MeromorphicAt f x) :
+    MeromorphicNFAt hf.toNF x := by
+  by_cases h₂f : hf.order = ⊤
+  · have : hf.toNF =ᶠ[𝓝 x] 0 := by
+      apply eventuallyEq_nhds_of_eventuallyEq_nhdsNE
+      · exact hf.toNF_id_on_nhdNE.symm.trans (hf.order_eq_top_iff.1 h₂f)
+      · simp [h₂f, MeromorphicAt.toNF]
+    apply AnalyticAt.MeromorphicNFAt
+    rw [analyticAt_congr this]
+    exact analyticAt_const
+  · lift hf.order to ℤ using h₂f with n hn
+    obtain ⟨g, h₁g, h₂g, h₃g⟩ := (hf.order_eq_int_iff n).1 hn.symm
+    right
+    use n, g, h₁g, h₂g
+    apply eventuallyEq_nhds_of_eventuallyEq_nhdsNE
+    · exact hf.toNF_id_on_nhdNE.symm.trans h₃g
+    · unfold MeromorphicAt.toNF
+      simp only [WithTop.coe_zero, ne_eq, Function.update_self, Pi.smul_apply', Pi.pow_apply,
+        sub_self]
+      by_cases h₃f : hf.order = (0 : ℤ)
+      · simp only [h₃f, WithTop.coe_zero, ↓reduceDIte, WithTop.untopD_zero, zpow_zero, one_smul]
+        obtain ⟨h₁G, h₂G, h₃G⟩  := Classical.choose_spec ((hf.order_eq_int_iff 0).1 h₃f)
+        simp only [zpow_zero, ne_eq, one_smul] at h₃G
+        apply Filter.EventuallyEq.eq_of_nhds
+        apply (AnalyticAt.eventuallyEq_nhd_iff_eventuallyEq_nhdNE h₁G (by fun_prop)).1
+        filter_upwards [h₃g, h₃G]
+        simp_all
+      · simp_rw [← hn, WithTop.coe_zero, WithTop.coe_eq_zero] at *
+        simp [h₃f, zero_zpow n h₃f]
+
+/- If `f` has normal form at `x`, then `f` equals `f.toNF`. -/
+theorem MeromorphicNFAt.toNF_eq_id (hf : MeromorphicNFAt f x) :
+    f = hf.meromorphicAt.toNF := by
+  funext z
+  by_cases hz : z = x
+  · rw [hz]
+    unfold MeromorphicAt.toNF
+    simp only [WithTop.coe_zero, ne_eq, Function.update_self]
+    have h₀f := hf
+    rcases hf with h₁f | h₁f
+    · simp only [(h₀f.meromorphicAt.order_eq_top_iff).2 (h₁f.filter_mono nhdsWithin_le_nhds),
+        LinearOrderedAddCommGroupWithTop.top_ne_zero, ↓reduceDIte]
+      exact Filter.EventuallyEq.eq_of_nhds h₁f
+    · obtain ⟨n, g, h₁g, h₂g, h₃g⟩ := h₁f
+      rw [Filter.EventuallyEq.eq_of_nhds h₃g]
+      have : h₀f.meromorphicAt.order = n := by
+        rw [MeromorphicAt.order_eq_int_iff (MeromorphicNFAt.meromorphicAt h₀f) n]
+        use g, h₁g, h₂g
+        exact eventually_nhdsWithin_of_eventually_nhds h₃g
+      by_cases h₃f : h₀f.meromorphicAt.order = 0
+      · simp only [Pi.smul_apply', Pi.pow_apply, sub_self, h₃f, ↓reduceDIte]
+        have hn : n = (0 : ℤ) := by
+          rw [h₃f] at this
+          exact WithTop.coe_eq_zero.mp this.symm
+        simp_rw [hn]
+        simp only [zpow_zero, one_smul]
+        have : g =ᶠ[𝓝 x] (Classical.choose ((h₀f.meromorphicAt.order_eq_int_iff 0).1 h₃f)) := by
+          obtain ⟨h₀, h₁, h₂⟩ := Classical.choose_spec
+            ((h₀f.meromorphicAt.order_eq_int_iff 0).1 h₃f)
+          apply (h₁g.eventuallyEq_nhd_iff_eventuallyEq_nhdNE h₀).1
+          rw [hn] at h₃g
+          simp only [zpow_zero, one_smul, ne_eq] at h₃g h₂
+          exact (h₃g.filter_mono nhdsWithin_le_nhds).symm.trans h₂
+        exact Filter.EventuallyEq.eq_of_nhds this
+      · simp only [Pi.smul_apply', Pi.pow_apply, sub_self, h₃f, ↓reduceDIte, smul_eq_zero]
+        left
+        apply zero_zpow n
+        by_contra hn
+        rw [hn] at this
+        tauto
+  · exact (MeromorphicNFAt.meromorphicAt hf).toNF_id_on_complement hz

--- a/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
+++ b/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
@@ -201,8 +201,8 @@ theorem meromorphicNFAt_toMeromorphicNFAt :
     exact analyticAt_const.MeromorphicNFAt
 
 /-- If `f` has normal form at `x`, then `f` equals `f.toNF`. -/
-theorem meromorphicNFAt_iff_toNF_eq_id :
-    MeromorphicNFAt f x ↔ f = toMeromorphicNFAt f x := by
+@[simp] theorem toMeromorphicNFAt_eq_self :
+    toMeromorphicNFAt f x = f ↔ MeromorphicNFAt f x := by
   constructor
   · intro hf
     funext z

--- a/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
+++ b/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
@@ -160,8 +160,16 @@ lemma MeromorphicAt.toNF_id_on_nhdNE (hf : MeromorphicAt f x) :
     f =ᶠ[𝓝[≠] x] hf.toNF :=
   eventually_nhdsWithin_of_forall (fun _ hz ↦ hf.toNF_id_on_complement hz)
 
+-- Two analytic functions agree on a punctured neighborhood iff they agree on a neighborhood.
+private lemma AnalyticAt.eventuallyEq_nhdNE_iff_eventuallyEq_nhd {g : 𝕜 → E} {z₀ : 𝕜}
+  (hf : AnalyticAt 𝕜 f z₀) (hg : AnalyticAt 𝕜 g z₀) (hfg : f =ᶠ[𝓝[≠] z₀] g) :
+    f =ᶠ[𝓝 z₀] g := by
+  rcases ((hf.sub hg).eventually_eq_zero_or_eventually_ne_zero) with h | h
+  · exact Filter.eventuallyEq_iff_sub.2 h
+  · simpa using (Filter.eventually_and.2 ⟨Filter.eventuallyEq_iff_sub.mp hfg, h⟩).exists
+
 /-- After conversion to normal form at `x`, the function has normal form. -/
-theorem MeromorphicAt.MeromorphicNFAt_of_toNF (hf : MeromorphicAt f x) :
+theorem MeromorphicAt.MeromorphicNFAt_toNF (hf : MeromorphicAt f x) :
     MeromorphicNFAt hf.toNF x := by
   by_cases h₂f : hf.order = ⊤
   · have : hf.toNF =ᶠ[𝓝 x] 0 := by
@@ -181,7 +189,7 @@ theorem MeromorphicAt.MeromorphicNFAt_of_toNF (hf : MeromorphicAt f x) :
     split_ifs with h₃f
     · obtain ⟨h₁G, _, h₃G⟩ := Classical.choose_spec ((hf.order_eq_int_iff 0).1 (h₃f ▸ hn.symm))
       apply Filter.EventuallyEq.eq_of_nhds
-      rw [← h₁G.eventuallyEq_nhdNE_iff_eventuallyEq_nhd (by fun_prop)]
+      apply h₁G.eventuallyEq_nhdNE_iff_eventuallyEq_nhd (by fun_prop)
       filter_upwards [h₃g, h₃G]
       simp_all
     · simp [h₃f, zero_zpow]
@@ -214,7 +222,7 @@ theorem MeromorphicNFAt.toNF_eq_id (hf : MeromorphicNFAt f x) :
         have : g =ᶠ[𝓝 x] (Classical.choose ((h₀f.meromorphicAt.order_eq_int_iff 0).1 h₃f)) := by
           obtain ⟨h₀, h₁, h₂⟩ := Classical.choose_spec
             ((h₀f.meromorphicAt.order_eq_int_iff 0).1 h₃f)
-          apply (h₁g.eventuallyEq_nhdNE_iff_eventuallyEq_nhd h₀).1
+          apply h₁g.eventuallyEq_nhdNE_iff_eventuallyEq_nhd h₀
           rw [hn] at h₃g
           simp only [zpow_zero, one_smul, ne_eq] at h₃g h₂
           exact (h₃g.filter_mono nhdsWithin_le_nhds).symm.trans h₂

--- a/Mathlib/Topology/ContinuousOn.lean
+++ b/Mathlib/Topology/ContinuousOn.lean
@@ -420,6 +420,17 @@ theorem eventuallyEq_nhdsWithin_iff {f g : α → β} {s : Set α} {a : α} :
     f =ᶠ[𝓝[s] a] g ↔ ∀ᶠ x in 𝓝 a, x ∈ s → f x = g x :=
   mem_inf_principal
 
+/-- The functions agree on a neighborhood of `x` if they agree at `x` and in a punctured
+neighborhood. -/
+theorem eventuallyEq_nhds_of_eventuallyEq_nhdsNE {f g : α → β} {a : α} (h₁ : f =ᶠ[𝓝[≠] a] g)
+    (h₂ : f a = g a) :
+    f =ᶠ[𝓝 a] g := by
+  filter_upwards [eventually_nhdsWithin_iff.1 h₁]
+  intro x hx
+  by_cases h₂x : x = a
+  · simp [h₂x, h₂]
+  · tauto
+
 theorem eventuallyEq_nhdsWithin_of_eqOn {f g : α → β} {s : Set α} {a : α} (h : EqOn f g s) :
     f =ᶠ[𝓝[s] a] g :=
   mem_inf_of_right h

--- a/Mathlib/Topology/ContinuousOn.lean
+++ b/Mathlib/Topology/ContinuousOn.lean
@@ -420,7 +420,7 @@ theorem eventuallyEq_nhdsWithin_iff {f g : α → β} {s : Set α} {a : α} :
     f =ᶠ[𝓝[s] a] g ↔ ∀ᶠ x in 𝓝 a, x ∈ s → f x = g x :=
   mem_inf_principal
 
-/-- The functions agree on a neighborhood of `x` if they agree at `x` and in a punctured
+/-- Two functions agree on a neighborhood of `x` if they agree at `x` and in a punctured
 neighborhood. -/
 theorem eventuallyEq_nhds_of_eventuallyEq_nhdsNE {f g : α → β} {a : α} (h₁ : f =ᶠ[𝓝[≠] a] g)
     (h₂ : f a = g a) :


### PR DESCRIPTION
Defines the normal form of meromorphic functions and provides API for continuous extension, as discussed [on Zulip](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/API.20for.20continuous.20extension.20of.20meromorphic.20functions). More material will be provided in upcoming PRs.

This material is used in [Project VD](https://github.com/kebekus/ProjectVD), which aims to formalize Value Distribution Theory for meromorphic functions on the complex plane.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
