### PR TITLE
[Merged by Bors] - chore (Analysis/Normed): rename `norm_mul` to `norm_mul_le`

### DIFF
--- a/Mathlib/Analysis/CStarAlgebra/CStarMatrix.lean
+++ b/Mathlib/Analysis/CStarAlgebra/CStarMatrix.lean
@@ -596,8 +596,9 @@ instance instNormedSpace : NormedSpace ℂ (CStarMatrix m n A) :=
 
 noncomputable instance instNonUnitalNormedRing :
     NonUnitalNormedRing (CStarMatrix n n A) where
-  dist_eq _ _ := rfl
-  norm_mul _ _ := by simpa only [norm_def', map_mul] using norm_mul_le _ _
+  __ : NormedAddCommGroup (CStarMatrix n n A) := inferInstance
+  __ : NonUnitalRing (CStarMatrix n n A) := inferInstance
+  norm_mul_le _ _ := by simpa only [norm_def', map_mul] using norm_mul_le _ _
 
 open ContinuousLinearMap CStarModule in
 /-- Matrices with entries in a C⋆-algebra form a C⋆-algebra. -/
@@ -649,7 +650,7 @@ variable {n : Type*} [Fintype n] [DecidableEq n]
 
 noncomputable instance instNormedRing : NormedRing (CStarMatrix n n A) where
   dist_eq _ _ := rfl
-  norm_mul := norm_mul_le
+  norm_mul_le := norm_mul_le
 
 noncomputable instance instNormedAlgebra : NormedAlgebra ℂ (CStarMatrix n n A) where
   norm_smul_le r M := by simpa only [norm_def, map_smul] using (toCLM M).opNorm_smul_le r

--- a/Mathlib/Analysis/CStarAlgebra/Matrix.lean
+++ b/Mathlib/Analysis/CStarAlgebra/Matrix.lean
@@ -225,7 +225,7 @@ scoped[Matrix.L2OpNorm] attribute [instance] Matrix.instL2OpNormedSpace
 identification with (continuous) linear endmorphisms of `EuclideanSpace 𝕜 n`. -/
 def instL2OpNormedRing : NormedRing (Matrix n n 𝕜) where
   dist_eq := l2OpNormedRingAux.dist_eq
-  norm_mul := l2OpNormedRingAux.norm_mul
+  norm_mul_le := l2OpNormedRingAux.norm_mul_le
 
 scoped[Matrix.L2OpNorm] attribute [instance] Matrix.instL2OpNormedRing
 

--- a/Mathlib/Analysis/CStarAlgebra/lpSpace.lean
+++ b/Mathlib/Analysis/CStarAlgebra/lpSpace.lean
@@ -27,7 +27,7 @@ instance [∀ i, NonUnitalCommCStarAlgebra (A i)] : NonUnitalCommCStarAlgebra (l
 -- aside from `∀ i, NormOneClass (A i)`, this holds automatically for C⋆-algebras though.
 instance [∀ i, Nontrivial (A i)] [∀ i, CStarAlgebra (A i)] : NormedRing (lp A ∞) where
   dist_eq := dist_eq_norm
-  norm_mul := norm_mul_le
+  norm_mul_le := norm_mul_le
 
 instance [∀ i, Nontrivial (A i)] [∀ i, CommCStarAlgebra (A i)] : CommCStarAlgebra (lp A ∞) where
   mul_comm := mul_comm

--- a/Mathlib/Analysis/Complex/Basic.lean
+++ b/Mathlib/Analysis/Complex/Basic.lean
@@ -50,7 +50,7 @@ open ComplexConjugate Topology Filter
 
 instance : NormedField ℂ where
   dist_eq _ _ := rfl
-  norm_mul' := Complex.norm_mul
+  norm_mul := Complex.norm_mul
 
 instance : DenselyNormedField ℂ where
   lt_norm_lt r₁ r₂ h₀ hr :=

--- a/Mathlib/Analysis/LocallyConvex/BalancedCoreHull.lean
+++ b/Mathlib/Analysis/LocallyConvex/BalancedCoreHull.lean
@@ -136,7 +136,7 @@ theorem balancedHull.balanced (s : Set E) : Balanced 𝕜 (balancedHull 𝕜 s) 
   simp_rw [balancedHull, smul_set_iUnion₂, subset_def, mem_iUnion₂]
   rintro x ⟨r, hr, hx⟩
   rw [← smul_assoc] at hx
-  exact ⟨a • r, (SeminormedRing.norm_mul _ _).trans (mul_le_one₀ ha (norm_nonneg r) hr), hx⟩
+  exact ⟨a • r, (norm_mul_le _ _).trans (mul_le_one₀ ha (norm_nonneg r) hr), hx⟩
 
 open Balanced in
 theorem balancedHull_add_subset [NormOneClass 𝕜] {t : Set E} :

--- a/Mathlib/Analysis/Matrix.lean
+++ b/Mathlib/Analysis/Matrix.lean
@@ -325,7 +325,7 @@ the norm of a matrix. -/
 protected def linftyOpNonUnitalSemiNormedRing [NonUnitalSeminormedRing α] :
     NonUnitalSeminormedRing (Matrix n n α) :=
   { Matrix.linftyOpSeminormedAddCommGroup, Matrix.instNonUnitalRing with
-    norm_mul := linfty_opNorm_mul }
+    norm_mul_le := linfty_opNorm_mul }
 
 /-- The `L₁-L∞` norm preserves one on non-empty matrices. Note this is safe as an instance, as it
 carries no data. -/
@@ -597,7 +597,7 @@ matrix. -/
 def frobeniusNormedRing [DecidableEq m] : NormedRing (Matrix m m α) :=
   { Matrix.frobeniusSeminormedAddCommGroup, Matrix.instRing with
     norm := Norm.norm
-    norm_mul := frobenius_norm_mul
+    norm_mul_le := frobenius_norm_mul
     eq_of_dist_eq_zero := eq_of_dist_eq_zero }
 
 /-- Normed algebra instance (using frobenius norm) for matrices over `ℝ` or `ℂ`.  Not

--- a/Mathlib/Analysis/Normed/Algebra/Spectrum.lean
+++ b/Mathlib/Analysis/Normed/Algebra/Spectrum.lean
@@ -446,7 +446,7 @@ theorem algebraMap_eq_of_mem {a : A} {z : ℂ} (h : z ∈ σ a) : algebraMap ℂ
 is an algebra isomorphism whose inverse is given by selecting the (unique) element of
 `spectrum ℂ a`. In addition, `algebraMap_isometry` guarantees this map is an isometry.
 
-Note: because `NormedDivisionRing` requires the field `norm_mul' : ∀ a b, ‖a * b‖ = ‖a‖ * ‖b‖`, we
+Note: because `NormedDivisionRing` requires the field `norm_mul : ∀ a b, ‖a * b‖ = ‖a‖ * ‖b‖`, we
 don't use this type class and instead opt for a `NormedRing` in which the nonzero elements are
 precisely the units. This allows for the application of this isomorphism in broader contexts, e.g.,
 to the quotient of a complex Banach algebra by a maximal ideal. In the case when `A` is actually a

--- a/Mathlib/Analysis/Normed/Algebra/TrivSqZeroExt.lean
+++ b/Mathlib/Analysis/Normed/Algebra/TrivSqZeroExt.lean
@@ -220,20 +220,19 @@ variable [Module R M] [IsBoundedSMul R M] [Module Rᵐᵒᵖ M] [IsBoundedSMul R
   [SMulCommClass R Rᵐᵒᵖ M]
 
 instance instL1SeminormedRing : SeminormedRing (tsze R M) where
-  norm_mul
+  norm_mul_le
   | ⟨r₁, m₁⟩, ⟨r₂, m₂⟩ => by
-    dsimp
-    rw [norm_def, norm_def, norm_def, add_mul, mul_add, mul_add, snd_mul, fst_mul]
-    dsimp [fst, snd]
-    rw [add_assoc]
-    gcongr
-    · exact norm_mul_le _ _
-    refine (norm_add_le _ _).trans ?_
-    gcongr
-    · exact norm_smul_le _ _
-    refine (_root_.norm_smul_le _ _).trans ?_
-    rw [mul_comm, MulOpposite.norm_op]
-    exact le_add_of_nonneg_right <| by positivity
+    simp_rw [norm_def]
+    calc ‖r₁ * r₂‖ + ‖r₁ • m₂ + MulOpposite.op r₂ • m₁‖
+    _ ≤ ‖r₁‖ * ‖r₂‖ + (‖r₁‖ * ‖m₂‖ + ‖r₂‖ * ‖m₁‖) := by
+      gcongr
+      · apply norm_mul_le
+      · refine norm_add_le_of_le ?_ ?_ <;>
+        apply norm_smul_le
+    _ ≤ ‖r₁‖ * ‖r₂‖ + (‖r₁‖ * ‖m₂‖ + ‖r₂‖ * ‖m₁‖) + (‖m₁‖ * ‖m₂‖) := by
+      apply le_add_of_nonneg_right
+      positivity
+    _ = (‖r₁‖ + ‖m₁‖) * (‖r₂‖ + ‖m₂‖) := by ring
   __ : SeminormedAddCommGroup (tsze R M) := inferInstance
   __ : Ring (tsze R M) := inferInstance
 

--- a/Mathlib/Analysis/Normed/Algebra/Unitization.lean
+++ b/Mathlib/Analysis/Normed/Algebra/Unitization.lean
@@ -232,7 +232,7 @@ noncomputable instance instMetricSpace : MetricSpace (Unitization 𝕜 A) :=
 algebra homomorphism `Unitization.splitMul 𝕜 A`. -/
 noncomputable instance instNormedRing : NormedRing (Unitization 𝕜 A) where
   dist_eq := normedRingAux.dist_eq
-  norm_mul := normedRingAux.norm_mul
+  norm_mul_le := normedRingAux.norm_mul_le
   norm := normedRingAux.norm
 
 /-- Pull back the normed algebra structure from `𝕜 × (A →L[𝕜] A)` to `Unitization 𝕜 A` using the

--- a/Mathlib/Analysis/Normed/Algebra/UnitizationL1.lean
+++ b/Mathlib/Analysis/Normed/Algebra/UnitizationL1.lean
@@ -110,7 +110,7 @@ def unitizationAlgEquiv (R : Type*) [CommSemiring R] [Algebra R 𝕜] [DistribMu
 
 noncomputable instance instUnitizationNormedRing : NormedRing (WithLp 1 (Unitization 𝕜 A)) where
   dist_eq := dist_eq_norm
-  norm_mul x y := by
+  norm_mul_le x y := by
     simp_rw [unitization_norm_def, add_mul, mul_add, unitization_mul, fst_mul, snd_mul]
     rw [add_assoc, add_assoc]
     gcongr

--- a/Mathlib/Analysis/Normed/Field/Basic.lean
+++ b/Mathlib/Analysis/Normed/Field/Basic.lean
@@ -5,7 +5,6 @@ Authors: Patrick Massot, Johannes Hölzl
 -/
 import Mathlib.Algebra.Field.Subfield.Defs
 import Mathlib.Algebra.Order.Group.Pointwise.Interval
-import Mathlib.Algebra.Ring.Regular
 import Mathlib.Analysis.Normed.Ring.Basic
 
 /-!
@@ -38,21 +37,20 @@ class NormedDivisionRing (α : Type*) extends Norm α, DivisionRing α, MetricSp
   /-- The distance is induced by the norm. -/
   dist_eq : ∀ x y, dist x y = norm (x - y)
   /-- The norm is multiplicative. -/
-  norm_mul' : ∀ a b, norm (a * b) = norm a * norm b
+  protected norm_mul : ∀ a b, norm (a * b) = norm a * norm b
 
 -- see Note [lower instance priority]
 /-- A normed division ring is a normed ring. -/
 instance (priority := 100) NormedDivisionRing.toNormedRing [β : NormedDivisionRing α] :
     NormedRing α :=
-  { β with norm_mul := fun a b => (NormedDivisionRing.norm_mul' a b).le }
+  { β with norm_mul_le a b := (NormedDivisionRing.norm_mul a b).le }
 
 section NormedDivisionRing
 
 variable [NormedDivisionRing α] {a b : α}
 
 @[simp]
-theorem norm_mul (a b : α) : ‖a * b‖ = ‖a‖ * ‖b‖ :=
-  NormedDivisionRing.norm_mul' a b
+theorem norm_mul (a b : α) : ‖a * b‖ = ‖a‖ * ‖b‖ := NormedDivisionRing.norm_mul a b
 
 instance (priority := 900) NormedDivisionRing.to_normOneClass : NormOneClass α :=
   ⟨mul_left_cancel₀ (mt norm_eq_zero.1 (one_ne_zero' α)) <| by rw [← norm_mul, mul_one, mul_one]⟩
@@ -192,7 +190,7 @@ class NormedField (α : Type*) extends Norm α, Field α, MetricSpace α where
   /-- The distance is induced by the norm. -/
   dist_eq : ∀ x y, dist x y = norm (x - y)
   /-- The norm is multiplicative. -/
-  norm_mul' : ∀ a b, norm (a * b) = norm a * norm b
+  protected norm_mul : ∀ a b, norm (a * b) = norm a * norm b
 
 /-- A nontrivially normed field is a normed field in which there is an element of norm different
 from `0` and `1`. This makes it possible to bring any element arbitrarily close to `0` by
@@ -226,7 +224,7 @@ instance (priority := 100) NormedField.toNormedDivisionRing : NormedDivisionRing
 
 -- see Note [lower instance priority]
 instance (priority := 100) NormedField.toNormedCommRing : NormedCommRing α :=
-  { ‹NormedField α› with norm_mul := fun a b => (norm_mul a b).le }
+  { ‹NormedField α› with norm_mul_le a b := (norm_mul a b).le }
 
 @[simp]
 theorem norm_prod (s : Finset β) (f : β → α) : ‖∏ b ∈ s, f b‖ = ∏ b ∈ s, ‖f b‖ :=
@@ -319,7 +317,7 @@ def NontriviallyNormedField.ofNormNeOne {𝕜 : Type*} [h' : NormedField 𝕜]
 
 noncomputable instance Real.normedField : NormedField ℝ :=
   { Real.normedAddCommGroup, Real.field with
-    norm_mul' := abs_mul }
+    norm_mul := abs_mul }
 
 noncomputable instance Real.denselyNormedField : DenselyNormedField ℝ where
   lt_norm_lt _ _ h₀ hr :=
@@ -351,9 +349,7 @@ See note [reducible non-instances] -/
 abbrev NormedDivisionRing.induced [DivisionRing R] [NormedDivisionRing S]
     [NonUnitalRingHomClass F R S] (f : F) (hf : Function.Injective f) : NormedDivisionRing R :=
   { NormedAddCommGroup.induced R S f hf, ‹DivisionRing R› with
-    norm_mul' := fun x y => by
-      show ‖f (x * y)‖ = ‖f x‖ * ‖f y‖
-      exact (map_mul f x y).symm ▸ norm_mul (f x) (f y) }
+    norm_mul x y := show ‖f _‖ = _ from (map_mul f x y).symm ▸ norm_mul (f x) (f y) }
 
 /-- An injective non-unital ring homomorphism from a `Field` to a `NormedRing` induces a
 `NormedField` structure on the domain.
@@ -385,6 +381,6 @@ namespace AbsoluteValue
 noncomputable def toNormedField {K : Type*} [Field K] (v : AbsoluteValue K ℝ) : NormedField K where
   toField := inferInstanceAs (Field K)
   __ := v.toNormedRing
-  norm_mul' := v.map_mul
+  norm_mul := v.map_mul
 
 end AbsoluteValue

--- a/Mathlib/Analysis/Normed/Field/Lemmas.lean
+++ b/Mathlib/Analysis/Normed/Field/Lemmas.lean
@@ -226,7 +226,7 @@ end NormedField
 instance Rat.instNormedField : NormedField ℚ where
   __ := instField
   __ := instNormedAddCommGroup
-  norm_mul' a b := by simp only [norm, Rat.cast_mul, abs_mul]
+  norm_mul a b := by simp only [norm, Rat.cast_mul, abs_mul]
 
 instance Rat.instDenselyNormedField : DenselyNormedField ℚ where
   lt_norm_lt r₁ r₂ h₀ hr :=

--- a/Mathlib/Analysis/Normed/Group/Quotient.lean
+++ b/Mathlib/Analysis/Normed/Group/Quotient.lean
@@ -454,7 +454,7 @@ theorem Ideal.Quotient.norm_mk_le (r : R) : ‖Ideal.Quotient.mk I r‖ ≤ ‖r
 instance Ideal.Quotient.semiNormedCommRing : SeminormedCommRing (R ⧸ I) where
   dist_eq := dist_eq_norm
   mul_comm := _root_.mul_comm
-  norm_mul x y := le_of_forall_pos_le_add fun ε hε => by
+  norm_mul_le x y := le_of_forall_pos_le_add fun ε hε => by
     have := ((nhds_basis_ball.prod_nhds nhds_basis_ball).tendsto_iff nhds_basis_ball).mp
       (continuous_mul.tendsto (‖x‖, ‖y‖)) ε hε
     simp only [Set.mem_prod, mem_ball, and_imp, Prod.forall, exists_prop, Prod.exists] at this

--- a/Mathlib/Analysis/Normed/Lp/lpSpace.lean
+++ b/Mathlib/Analysis/Normed/Lp/lpSpace.lean
@@ -737,13 +737,10 @@ instance nonUnitalRing : NonUnitalRing (lp B ∞) :=
 
 instance nonUnitalNormedRing : NonUnitalNormedRing (lp B ∞) :=
   { lp.normedAddCommGroup, lp.nonUnitalRing with
-    norm_mul := fun f g =>
-      lp.norm_le_of_forall_le (mul_nonneg (norm_nonneg f) (norm_nonneg g)) fun i =>
-        calc
-          ‖(f * g) i‖ ≤ ‖f i‖ * ‖g i‖ := norm_mul_le _ _
-          _ ≤ ‖f‖ * ‖g‖ :=
-            mul_le_mul (lp.norm_apply_le_norm ENNReal.top_ne_zero f i)
-              (lp.norm_apply_le_norm ENNReal.top_ne_zero g i) (norm_nonneg _) (norm_nonneg _) }
+    norm_mul_le f g := lp.norm_le_of_forall_le (by positivity) fun i ↦ calc
+      ‖(f * g) i‖ ≤ ‖f i‖ * ‖g i‖ := norm_mul_le _ _
+      _ ≤ ‖f‖ * ‖g‖ := mul_le_mul (lp.norm_apply_le_norm ENNReal.top_ne_zero f i)
+        (lp.norm_apply_le_norm ENNReal.top_ne_zero g i) (norm_nonneg _) (norm_nonneg _) }
 
 instance nonUnitalNormedCommRing {B : I → Type*} [∀ i, NonUnitalNormedCommRing (B i)] :
     NonUnitalNormedCommRing (lp B ∞) where

--- a/Mathlib/Analysis/Normed/Module/Basic.lean
+++ b/Mathlib/Analysis/Normed/Module/Basic.lean
@@ -42,7 +42,7 @@ typeclass can be used for "semi normed spaces" too, just as `Module` can be used
 "semi modules". -/
 class NormedSpace (𝕜 : Type*) (E : Type*) [NormedField 𝕜] [SeminormedAddCommGroup E]
     extends Module 𝕜 E where
-  norm_smul_le : ∀ (a : 𝕜) (b : E), ‖a • b‖ ≤ ‖a‖ * ‖b‖
+  protected norm_smul_le : ∀ (a : 𝕜) (b : E), ‖a • b‖ ≤ ‖a‖ * ‖b‖
 
 attribute [inherit_doc NormedSpace] NormedSpace.norm_smul_le
 

--- a/Mathlib/Analysis/Normed/Module/Completion.lean
+++ b/Mathlib/Analysis/Normed/Module/Completion.lean
@@ -71,13 +71,10 @@ variable (A : Type*)
 instance [SeminormedRing A] : NormedRing (Completion A) where
   __ : NormedAddCommGroup (Completion A) := inferInstance
   __ : Ring (Completion A) := inferInstance
-  norm_mul x y := by
+  norm_mul_le x y := by
     induction x, y using induction_on₂ with
-    | hp =>
-      apply isClosed_le <;> fun_prop
-    | ih x y =>
-      simp only [← coe_mul, norm_coe]
-      exact norm_mul_le x y
+    | hp => apply isClosed_le <;> fun_prop
+    | ih x y => simpa only [← coe_mul, norm_coe] using norm_mul_le x y
 
 instance [SeminormedCommRing A] : NormedCommRing (Completion A) where
   __ : CommRing (Completion A) := inferInstance
@@ -91,7 +88,7 @@ instance [NormedField A] [CompletableTopField A] :
     NormedField (UniformSpace.Completion A) where
   __ : NormedCommRing (Completion A) := inferInstance
   __ : Field (Completion A) := inferInstance
-  norm_mul' x y := induction_on₂ x y (isClosed_eq (by fun_prop) (by fun_prop)) (by simp [← coe_mul])
+  norm_mul x y := induction_on₂ x y (isClosed_eq (by fun_prop) (by fun_prop)) (by simp [← coe_mul])
 
 end Algebra
 

--- a/Mathlib/Analysis/Normed/Order/Basic.lean
+++ b/Mathlib/Analysis/Normed/Order/Basic.lean
@@ -59,7 +59,7 @@ class NormedLinearOrderedField (α : Type*) extends LinearOrderedField α, Norm 
   /-- The distance function is induced by the norm. -/
   dist_eq : ∀ x y, dist x y = ‖x - y‖ := by aesop
   /-- The norm is multiplicative. -/
-  norm_mul' : ∀ x y : α, ‖x * y‖ = ‖x‖ * ‖y‖
+  norm_mul : ∀ x y : α, ‖x * y‖ = ‖x‖ * ‖y‖
 
 @[to_additive]
 instance (priority := 100) NormedOrderedGroup.toNormedCommGroup [NormedOrderedGroup α] :
@@ -74,7 +74,7 @@ instance (priority := 100) NormedLinearOrderedGroup.toNormedOrderedGroup
 instance (priority := 100) NormedLinearOrderedField.toNormedField (α : Type*)
     [NormedLinearOrderedField α] : NormedField α where
   dist_eq := NormedLinearOrderedField.dist_eq
-  norm_mul' := NormedLinearOrderedField.norm_mul'
+  norm_mul := NormedLinearOrderedField.norm_mul
 
 instance Rat.normedLinearOrderedField : NormedLinearOrderedField ℚ :=
   ⟨dist_eq_norm, norm_mul⟩

--- a/Mathlib/Analysis/Normed/Ring/Basic.lean
+++ b/Mathlib/Analysis/Normed/Ring/Basic.lean
@@ -34,7 +34,7 @@ class NonUnitalSeminormedRing (α : Type*) extends Norm α, NonUnitalRing α,
   /-- The distance is induced by the norm. -/
   dist_eq : ∀ x y, dist x y = norm (x - y)
   /-- The norm is submultiplicative. -/
-  norm_mul : ∀ a b, norm (a * b) ≤ norm a * norm b
+  protected norm_mul_le : ∀ a b, norm (a * b) ≤ norm a * norm b
 
 /-- A seminormed ring is a ring endowed with a seminorm which satisfies the inequality
 `‖x y‖ ≤ ‖x‖ ‖y‖`. -/
@@ -42,7 +42,7 @@ class SeminormedRing (α : Type*) extends Norm α, Ring α, PseudoMetricSpace α
   /-- The distance is induced by the norm. -/
   dist_eq : ∀ x y, dist x y = norm (x - y)
   /-- The norm is submultiplicative. -/
-  norm_mul : ∀ a b, norm (a * b) ≤ norm a * norm b
+  norm_mul_le : ∀ a b, norm (a * b) ≤ norm a * norm b
 
 -- see Note [lower instance priority]
 /-- A seminormed ring is a non-unital seminormed ring. -/
@@ -56,7 +56,7 @@ class NonUnitalNormedRing (α : Type*) extends Norm α, NonUnitalRing α, Metric
   /-- The distance is induced by the norm. -/
   dist_eq : ∀ x y, dist x y = norm (x - y)
   /-- The norm is submultiplicative. -/
-  norm_mul : ∀ a b, norm (a * b) ≤ norm a * norm b
+  norm_mul_le : ∀ a b, norm (a * b) ≤ norm a * norm b
 
 -- see Note [lower instance priority]
 /-- A non-unital normed ring is a non-unital seminormed ring. -/
@@ -69,7 +69,7 @@ class NormedRing (α : Type*) extends Norm α, Ring α, MetricSpace α where
   /-- The distance is induced by the norm. -/
   dist_eq : ∀ x y, dist x y = norm (x - y)
   /-- The norm is submultiplicative. -/
-  norm_mul : ∀ a b, norm (a * b) ≤ norm a * norm b
+  norm_mul_le : ∀ a b, norm (a * b) ≤ norm a * norm b
 
 -- see Note [lower instance priority]
 /-- A normed ring is a seminormed ring. -/
@@ -132,7 +132,9 @@ instance (priority := 100) NormedCommRing.toSeminormedCommRing [β : NormedCommR
 
 instance PUnit.normedCommRing : NormedCommRing PUnit :=
   { PUnit.normedAddCommGroup, PUnit.commRing with
-    norm_mul := fun _ _ => by simp }
+    norm_mul_le _ _ := by simp }
+
+section NormOneClass
 
 /-- A mixin class with the axiom `‖1‖ = 1`. Many `NormedRing`s and all `NormedField`s satisfy this
 axiom. -/
@@ -154,6 +156,8 @@ theorem NormOneClass.nontrivial : Nontrivial G :=
   nontrivial_of_ne 0 1 <| ne_of_apply_ne norm <| by simp
 
 end SeminormedAddCommGroup
+
+end NormOneClass
 
 -- see Note [lower instance priority]
 instance (priority := 100) NonUnitalSeminormedCommRing.toNonUnitalCommRing
@@ -195,12 +199,11 @@ section NonUnitalSeminormedRing
 
 variable [NonUnitalSeminormedRing α] {a a₁ a₂ b c : α}
 
+/-- The norm is submultiplicative. -/
 theorem norm_mul_le (a b : α) : ‖a * b‖ ≤ ‖a‖ * ‖b‖ :=
-  NonUnitalSeminormedRing.norm_mul _ _
+  NonUnitalSeminormedRing.norm_mul_le a b
 
-theorem nnnorm_mul_le (a b : α) : ‖a * b‖₊ ≤ ‖a‖₊ * ‖b‖₊ := by
-  simpa only [← norm_toNNReal, ← Real.toNNReal_mul (norm_nonneg _)] using
-    Real.toNNReal_mono (norm_mul_le _ _)
+theorem nnnorm_mul_le (a b : α) : ‖a * b‖₊ ≤ ‖a‖₊ * ‖b‖₊ := norm_mul_le a b
 
 lemma norm_mul_le_of_le {r₁ r₂ : ℝ} (h₁ : ‖a₁‖ ≤ r₁) (h₂ : ‖a₂‖ ≤ r₂) : ‖a₁ * a₂‖ ≤ r₁ * r₂ :=
   (norm_mul_le ..).trans <| mul_le_mul h₁ h₂ (norm_nonneg _) ((norm_nonneg _).trans h₁)
@@ -235,7 +238,7 @@ instance NonUnitalSubalgebra.nonUnitalSeminormedRing {𝕜 : Type*} [CommRing �
     [NonUnitalSeminormedRing E] [Module 𝕜 E] (s : NonUnitalSubalgebra 𝕜 E) :
     NonUnitalSeminormedRing s :=
   { s.toSubmodule.seminormedAddCommGroup, s.toNonUnitalRing with
-    norm_mul := fun a b => norm_mul_le a.1 b.1 }
+    norm_mul_le a b := norm_mul_le a.1 b.1 }
 
 /-- A non-unital subalgebra of a non-unital seminormed ring is also a non-unital seminormed ring,
 with the restriction of the norm. -/
@@ -246,7 +249,7 @@ instance (priority := 75) NonUnitalSubalgebraClass.nonUnitalSeminormedRing {S �
     [SMulMemClass S 𝕜 E] (s : S) :
     NonUnitalSeminormedRing s :=
   { AddSubgroupClass.seminormedAddCommGroup s, NonUnitalSubringClass.toNonUnitalRing s with
-    norm_mul := fun a b => norm_mul_le a.1 b.1 }
+    norm_mul_le a b := norm_mul_le a.1 b.1 }
 
 /-- A non-unital subalgebra of a non-unital normed ring is also a non-unital normed ring, with the
 restriction of the norm. -/
@@ -266,30 +269,28 @@ instance (priority := 75) NonUnitalSubalgebraClass.nonUnitalNormedRing {S 𝕜 E
 
 instance ULift.nonUnitalSeminormedRing : NonUnitalSeminormedRing (ULift α) :=
   { ULift.seminormedAddCommGroup, ULift.nonUnitalRing with
-    norm_mul := fun x y => (norm_mul_le x.down y.down :) }
+    norm_mul_le x y := norm_mul_le x.down y.down }
 
 /-- Non-unital seminormed ring structure on the product of two non-unital seminormed rings,
   using the sup norm. -/
 instance Prod.nonUnitalSeminormedRing [NonUnitalSeminormedRing β] :
     NonUnitalSeminormedRing (α × β) :=
   { seminormedAddCommGroup, instNonUnitalRing with
-    norm_mul := fun x y =>
-      calc
-        ‖x * y‖ = ‖(x.1 * y.1, x.2 * y.2)‖ := rfl
-        _ = max ‖x.1 * y.1‖ ‖x.2 * y.2‖ := rfl
-        _ ≤ max (‖x.1‖ * ‖y.1‖) (‖x.2‖ * ‖y.2‖) :=
-          (max_le_max (norm_mul_le x.1 y.1) (norm_mul_le x.2 y.2))
-        _ = max (‖x.1‖ * ‖y.1‖) (‖y.2‖ * ‖x.2‖) := by simp [mul_comm]
-        _ ≤ max ‖x.1‖ ‖x.2‖ * max ‖y.2‖ ‖y.1‖ := by
-          apply max_mul_mul_le_max_mul_max <;> simp [norm_nonneg]
-        _ = max ‖x.1‖ ‖x.2‖ * max ‖y.1‖ ‖y.2‖ := by simp [max_comm]
-        _ = ‖x‖ * ‖y‖ := rfl
-         }
+    norm_mul_le x y := calc
+      ‖x * y‖ = ‖(x.1 * y.1, x.2 * y.2)‖ := rfl
+      _ = max ‖x.1 * y.1‖ ‖x.2 * y.2‖ := rfl
+      _ ≤ max (‖x.1‖ * ‖y.1‖) (‖x.2‖ * ‖y.2‖) :=
+        (max_le_max (norm_mul_le x.1 y.1) (norm_mul_le x.2 y.2))
+      _ = max (‖x.1‖ * ‖y.1‖) (‖y.2‖ * ‖x.2‖) := by simp [mul_comm]
+      _ ≤ max ‖x.1‖ ‖x.2‖ * max ‖y.2‖ ‖y.1‖ := by
+        apply max_mul_mul_le_max_mul_max <;> simp [norm_nonneg]
+      _ = max ‖x.1‖ ‖x.2‖ * max ‖y.1‖ ‖y.2‖ := by simp [max_comm]
+      _ = ‖x‖ * ‖y‖ := rfl }
 
 instance MulOpposite.instNonUnitalSeminormedRing : NonUnitalSeminormedRing αᵐᵒᵖ where
   __ := instNonUnitalRing
   __ := instSeminormedAddCommGroup
-  norm_mul := MulOpposite.rec' fun x ↦ MulOpposite.rec' fun y ↦
+  norm_mul_le := MulOpposite.rec' fun x ↦ MulOpposite.rec' fun y ↦
     (norm_mul_le y x).trans_eq (mul_comm _ _)
 
 end NonUnitalSeminormedRing
@@ -303,7 +304,7 @@ norm. -/
 instance Subalgebra.seminormedRing {𝕜 : Type*} [CommRing 𝕜] {E : Type*} [SeminormedRing E]
     [Algebra 𝕜 E] (s : Subalgebra 𝕜 E) : SeminormedRing s :=
   { s.toSubmodule.seminormedAddCommGroup, s.toRing with
-    norm_mul := fun a b => norm_mul_le a.1 b.1 }
+    norm_mul_le a b := norm_mul_le a.1 b.1 }
 
 /-- A subalgebra of a seminormed ring is also a seminormed ring, with the restriction of the
 norm. -/
@@ -313,7 +314,7 @@ instance (priority := 75) SubalgebraClass.seminormedRing {S 𝕜 E : Type*} [Com
     [SeminormedRing E] [Algebra 𝕜 E] [SetLike S E] [SubringClass S E] [SMulMemClass S 𝕜 E]
     (s : S) : SeminormedRing s :=
   { AddSubgroupClass.seminormedAddCommGroup s, SubringClass.toRing s with
-    norm_mul := fun a b => norm_mul_le a.1 b.1 }
+    norm_mul_le a b := norm_mul_le a.1 b.1 }
 
 /-- A subalgebra of a normed ring is also a normed ring, with the restriction of the norm. -/
 instance Subalgebra.normedRing {𝕜 : Type*} [CommRing 𝕜] {E : Type*} [NormedRing E]
@@ -602,7 +603,7 @@ instance MulOpposite.instNormedCommRing : NormedCommRing αᵐᵒᵖ where
   __ := instSeminormedCommRing
 
 /-- The restriction of a power-multiplicative function to a subalgebra is power-multiplicative. -/
-theorem IsPowMul.restriction {R S : Type*} [NormedCommRing R] [CommRing S] [Algebra R S]
+theorem IsPowMul.restriction {R S : Type*} [CommRing R] [Ring S] [Algebra R S]
     (A : Subalgebra R S) {f : S → ℝ} (hf_pm : IsPowMul f) :
     IsPowMul fun x : A => f x.val := fun x n hn => by
   simpa [SubsemiringClass.coe_pow] using hf_pm (↑x) hn
@@ -610,7 +611,7 @@ theorem IsPowMul.restriction {R S : Type*} [NormedCommRing R] [CommRing S] [Alge
 end NormedCommRing
 
 instance Real.normedCommRing : NormedCommRing ℝ :=
-  { Real.normedAddCommGroup, Real.commRing with norm_mul := fun x y => (abs_mul x y).le }
+  { Real.normedAddCommGroup, Real.commRing with norm_mul_le x y := (abs_mul x y).le }
 
 namespace NNReal
 
@@ -670,9 +671,7 @@ See note [reducible non-instances] -/
 abbrev NonUnitalSeminormedRing.induced [NonUnitalRing R] [NonUnitalSeminormedRing S]
     [NonUnitalRingHomClass F R S] (f : F) : NonUnitalSeminormedRing R :=
   { SeminormedAddCommGroup.induced R S f, ‹NonUnitalRing R› with
-    norm_mul := fun x y => by
-      show ‖f (x * y)‖ ≤ ‖f x‖ * ‖f y‖
-      exact (map_mul f x y).symm ▸ norm_mul_le (f x) (f y) }
+    norm_mul_le x y := show ‖f _‖ ≤ _ from (map_mul f x y).symm ▸ norm_mul_le (f x) (f y) }
 
 /-- An injective non-unital ring homomorphism from a `NonUnitalRing` to a
 `NonUnitalNormedRing` induces a `NonUnitalNormedRing` structure on the domain.
@@ -773,7 +772,7 @@ noncomputable def toNormedRing {R : Type*} [Ring R] (v : AbsoluteValue R ℝ) : 
   dist_comm := v.map_sub
   dist_triangle := v.sub_le
   edist_dist x y := rfl
-  norm_mul x y := (v.map_mul x y).le
+  norm_mul_le x y := (v.map_mul x y).le
   eq_of_dist_eq_zero := by simp only [MulHom.toFun_eq_coe, AbsoluteValue.coe_toMulHom,
     AbsoluteValue.map_sub_eq_zero_iff, imp_self, implies_true]
 

--- a/Mathlib/Analysis/Normed/Ring/Lemmas.lean
+++ b/Mathlib/Analysis/Normed/Ring/Lemmas.lean
@@ -38,20 +38,17 @@ theorem Filter.isBoundedUnder_le_mul_tendsto_zero {f g : ι → α} {l : Filter 
   hg.op_zero_isBoundedUnder_le hf (flip (· * ·)) fun x y =>
     (norm_mul_le y x).trans_eq (mul_comm _ _)
 
+open Finset in
 /-- Non-unital seminormed ring structure on the product of finitely many non-unital seminormed
 rings, using the sup norm. -/
 instance Pi.nonUnitalSeminormedRing {π : ι → Type*} [Fintype ι]
     [∀ i, NonUnitalSeminormedRing (π i)] : NonUnitalSeminormedRing (∀ i, π i) :=
-  { Pi.seminormedAddCommGroup, Pi.nonUnitalRing with
-    norm_mul := fun x y =>
-      NNReal.coe_mono <|
-        calc
-          (Finset.univ.sup fun i => ‖x i * y i‖₊) ≤
-              Finset.univ.sup ((fun i => ‖x i‖₊) * fun i => ‖y i‖₊) :=
-            Finset.sup_mono_fun fun _ _ => norm_mul_le _ _
-          _ ≤ (Finset.univ.sup fun i => ‖x i‖₊) * Finset.univ.sup fun i => ‖y i‖₊ :=
-            Finset.sup_mul_le_mul_sup_of_nonneg (fun _ _ => zero_le _) fun _ _ => zero_le _
-           }
+  { seminormedAddCommGroup, nonUnitalRing with
+    norm_mul_le x y := NNReal.coe_mono <| calc
+      (univ.sup fun i ↦ ‖x i * y i‖₊) ≤ univ.sup ((‖x ·‖₊) * (‖y ·‖₊)) :=
+        sup_mono_fun fun _ _ ↦ nnnorm_mul_le _ _
+      _ ≤ (univ.sup (‖x ·‖₊)) * univ.sup (‖y ·‖₊) :=
+        sup_mul_le_mul_sup_of_nonneg (fun _ _ ↦ zero_le _) fun _ _ ↦ zero_le _}
 
 end NonUnitalSeminormedRing
 
@@ -172,22 +169,22 @@ namespace SeparationQuotient
 instance [NonUnitalSeminormedRing α] : NonUnitalNormedRing (SeparationQuotient α) where
   __ : NonUnitalRing (SeparationQuotient α) := inferInstance
   __ : NormedAddCommGroup (SeparationQuotient α) := inferInstance
-  norm_mul := Quotient.ind₂ norm_mul_le
+  norm_mul_le := Quotient.ind₂ norm_mul_le
 
 instance [NonUnitalSeminormedCommRing α] : NonUnitalNormedCommRing (SeparationQuotient α) where
   __ : NonUnitalCommRing (SeparationQuotient α) := inferInstance
   __ : NormedAddCommGroup (SeparationQuotient α) := inferInstance
-  norm_mul := Quotient.ind₂ norm_mul_le
+  norm_mul_le := Quotient.ind₂ norm_mul_le
 
 instance [SeminormedRing α] : NormedRing (SeparationQuotient α) where
   __ : Ring (SeparationQuotient α) := inferInstance
   __ : NormedAddCommGroup (SeparationQuotient α) := inferInstance
-  norm_mul := Quotient.ind₂ norm_mul_le
+  norm_mul_le := Quotient.ind₂ norm_mul_le
 
 instance [SeminormedCommRing α] : NormedCommRing (SeparationQuotient α) where
   __ : CommRing (SeparationQuotient α) := inferInstance
   __ : NormedAddCommGroup (SeparationQuotient α) := inferInstance
-  norm_mul := Quotient.ind₂ norm_mul_le
+  norm_mul_le := Quotient.ind₂ norm_mul_le
 
 instance [SeminormedAddCommGroup α] [One α] [NormOneClass α] :
     NormOneClass (SeparationQuotient α) where
@@ -210,7 +207,7 @@ end NNReal
 instance Int.instNormedCommRing : NormedCommRing ℤ where
   __ := instCommRing
   __ := instNormedAddCommGroup
-  norm_mul m n := by simp only [norm, Int.cast_mul, abs_mul, le_rfl]
+  norm_mul_le m n := by simp only [norm, Int.cast_mul, abs_mul, le_rfl]
 
 instance Int.instNormOneClass : NormOneClass ℤ :=
   ⟨by simp [← Int.norm_cast_real]⟩

--- a/Mathlib/Analysis/NormedSpace/OperatorNorm/Basic.lean
+++ b/Mathlib/Analysis/NormedSpace/OperatorNorm/Basic.lean
@@ -316,7 +316,6 @@ instance toPseudoMetricSpace : PseudoMetricSpace (E →SL[σ₁₂] F) := .repla
 /-- Continuous linear maps themselves form a seminormed space with respect to
     the operator norm. -/
 instance toSeminormedAddCommGroup : SeminormedAddCommGroup (E →SL[σ₁₂] F) where
-  dist_eq _ _ := rfl
 
 instance toNormedSpace {𝕜' : Type*} [NormedField 𝕜'] [NormedSpace 𝕜' F] [SMulCommClass 𝕜₂ 𝕜' F] :
     NormedSpace 𝕜' (E →SL[σ₁₂] F) :=
@@ -329,19 +328,13 @@ theorem opNorm_comp_le (f : E →SL[σ₁₂] F) : ‖h.comp f‖ ≤ ‖h‖ * 
       rw [mul_assoc]
       exact h.le_opNorm_of_le (f.le_opNorm x)⟩
 
-
 /-- Continuous linear maps form a seminormed ring with respect to the operator norm. -/
-instance toSemiNormedRing : SeminormedRing (E →L[𝕜] E) :=
-  { ContinuousLinearMap.toSeminormedAddCommGroup, ContinuousLinearMap.ring with
-    norm_mul := fun f g => opNorm_comp_le f g }
+instance toSeminormedRing : SeminormedRing (E →L[𝕜] E) :=
+  { toSeminormedAddCommGroup, ring with norm_mul_le := opNorm_comp_le }
 
 /-- For a normed space `E`, continuous linear endomorphisms form a normed algebra with
 respect to the operator norm. -/
-instance toNormedAlgebra : NormedAlgebra 𝕜 (E →L[𝕜] E) :=
-  { algebra with
-    norm_smul_le := by
-      intro c f
-      apply opNorm_smul_le c f}
+instance toNormedAlgebra : NormedAlgebra 𝕜 (E →L[𝕜] E) := { toNormedSpace, algebra with }
 
 end
 

--- a/Mathlib/Analysis/NormedSpace/OperatorNorm/NormedSpace.lean
+++ b/Mathlib/Analysis/NormedSpace/OperatorNorm/NormedSpace.lean
@@ -122,8 +122,9 @@ instance toNormedAddCommGroup [RingHomIsometric σ₁₂] : NormedAddCommGroup (
   NormedAddCommGroup.ofSeparation fun f => (opNorm_zero_iff f).mp
 
 /-- Continuous linear maps form a normed ring with respect to the operator norm. -/
-instance toNormedRing : NormedRing (E →L[𝕜] E) :=
-  { ContinuousLinearMap.toNormedAddCommGroup, ContinuousLinearMap.toSemiNormedRing with }
+instance toNormedRing : NormedRing (E →L[𝕜] E) where
+  __ := toNormedAddCommGroup
+  __ := toSeminormedRing
 
 variable {f} in
 theorem homothety_norm [RingHomIsometric σ₁₂] [Nontrivial E] (f : E →SL[σ₁₂] F) {a : ℝ}

--- a/Mathlib/Analysis/Quaternion.lean
+++ b/Mathlib/Analysis/Quaternion.lean
@@ -86,9 +86,7 @@ theorem nnnorm_star (a : ℍ) : ‖star a‖₊ = ‖a‖₊ :=
 
 noncomputable instance : NormedDivisionRing ℍ where
   dist_eq _ _ := rfl
-  norm_mul' a b := by
-    simp only [norm_eq_sqrt_real_inner, inner_self, normSq.map_mul]
-    exact Real.sqrt_mul normSq_nonneg _
+  norm_mul _ _ := by simp [norm_eq_sqrt_real_inner, inner_self]
 
 noncomputable instance : NormedAlgebra ℝ ℍ where
   norm_smul_le := norm_smul_le

--- a/Mathlib/NumberTheory/Padics/PadicIntegers.lean
+++ b/Mathlib/NumberTheory/Padics/PadicIntegers.lean
@@ -192,11 +192,10 @@ instance : Norm ℤ_[p] := ⟨fun z => ‖(z : ℚ_[p])‖⟩
 variable {p} in
 theorem norm_def {z : ℤ_[p]} : ‖z‖ = ‖(z : ℚ_[p])‖ := rfl
 
-instance : NormedCommRing ℤ_[p] :=
-  { PadicInt.instCommRing with
-    dist_eq := fun ⟨_, _⟩ ⟨_, _⟩ => rfl
-    norm_mul := by simp [norm_def]
-    norm := norm }
+instance : NormedCommRing ℤ_[p] where
+  __ := instCommRing
+  dist_eq := fun ⟨_, _⟩ ⟨_, _⟩ ↦ rfl
+  norm_mul_le := by simp [norm_def]
 
 instance : NormOneClass ℤ_[p] :=
   ⟨norm_def.trans norm_one⟩

--- a/Mathlib/NumberTheory/Padics/PadicNumbers.lean
+++ b/Mathlib/NumberTheory/Padics/PadicNumbers.lean
@@ -724,7 +724,7 @@ instance normedField : NormedField ℚ_[p] :=
   { Padic.field,
     Padic.metricSpace p with
     dist_eq := fun _ _ ↦ rfl
-    norm_mul' := by simp [Norm.norm, map_mul]
+    norm_mul := by simp [Norm.norm, map_mul]
     norm := norm }
 
 instance isAbsoluteValue : IsAbsoluteValue fun a : ℚ_[p] ↦ ‖a‖ where

--- a/Mathlib/Topology/Algebra/Valued/NormedValued.lean
+++ b/Mathlib/Topology/Algebra/Valued/NormedValued.lean
@@ -104,7 +104,7 @@ def toNormedField : NormedField L :=
         (max_le_add_of_nonneg (norm_nonneg _) (norm_nonneg _))
     eq_of_dist_eq_zero := fun hxy => eq_of_sub_eq_zero (norm_eq_zero hxy)
     dist_eq := fun x y => rfl
-    norm_mul' := fun x y => by simp only [norm, ← NNReal.coe_mul, _root_.map_mul]
+    norm_mul := fun x y => by simp only [norm, ← NNReal.coe_mul, _root_.map_mul]
     toUniformSpace := Valued.toUniformSpace
     uniformity_dist := by
       haveI : Nonempty { ε : ℝ // ε > 0 } := nonempty_Ioi_subtype

--- a/Mathlib/Topology/ContinuousMap/Bounded/Basic.lean
+++ b/Mathlib/Topology/ContinuousMap/Bounded/Basic.lean
@@ -1168,13 +1168,12 @@ instance instNonUnitalRing : NonUnitalRing (α →ᵇ R) :=
   DFunLike.coe_injective.nonUnitalRing _ coe_zero coe_add coe_mul coe_neg coe_sub
     (fun _ _ => coe_nsmul _ _) fun _ _ => coe_zsmul _ _
 
-instance instNonUnitalSeminormedRing : NonUnitalSeminormedRing (α →ᵇ R) :=
-  { instSeminormedAddCommGroup with
-    norm_mul := fun f g =>
-      norm_ofNormedAddCommGroup_le _ (mul_nonneg (norm_nonneg _) (norm_nonneg _))
-        (fun x ↦ (norm_mul_le _ _).trans <|
-          mul_le_mul (norm_coe_le_norm f x) (norm_coe_le_norm g x) (norm_nonneg _) (norm_nonneg _))
-    left_distrib, right_distrib, zero_mul, mul_zero, mul_assoc }
+instance instNonUnitalSeminormedRing : NonUnitalSeminormedRing (α →ᵇ R) where
+  __ := instSeminormedAddCommGroup
+  __ := instNonUnitalRing
+  norm_mul_le f g := norm_ofNormedAddCommGroup_le _ (by positivity)
+    (fun x ↦ (norm_mul_le _ _).trans <| mul_le_mul
+      (norm_coe_le_norm f x) (norm_coe_le_norm g x) (norm_nonneg _) (norm_nonneg _))
 
 end Seminormed
 
@@ -1249,7 +1248,6 @@ In this section, if `R` is a normed commutative ring, then we show that the spac
 continuous functions from `α` to `R` inherits a normed commutative ring structure, by using
 pointwise operations and checking that they are compatible with the uniform distance. -/
 
-
 variable [TopologicalSpace α] {R : Type*}
 
 instance instCommRing [SeminormedCommRing R] : CommRing (α →ᵇ R) where
@@ -1257,13 +1255,11 @@ instance instCommRing [SeminormedCommRing R] : CommRing (α →ᵇ R) where
 
 instance instSeminormedCommRing [SeminormedCommRing R] : SeminormedCommRing (α →ᵇ R) where
   __ := instCommRing
-  __ := instSeminormedAddCommGroup
-  norm_mul := norm_mul_le
+  __ := instNonUnitalSeminormedRing
 
 instance instNormedCommRing [NormedCommRing R] : NormedCommRing (α →ᵇ R) where
-  __ := instCommRing
+  __ := instSeminormedCommRing
   __ := instNormedAddCommGroup
-  norm_mul := norm_mul_le
 
 end NormedCommRing
 

--- a/Mathlib/Topology/ContinuousMap/Compact.lean
+++ b/Mathlib/Topology/ContinuousMap/Compact.lean
@@ -234,7 +234,7 @@ variable {R : Type*}
 instance [NonUnitalSeminormedRing R] : NonUnitalSeminormedRing C(α, R) where
   __ : SeminormedAddCommGroup C(α, R) := inferInstance
   __ : NonUnitalRing C(α, R) := inferInstance
-  norm_mul f g := norm_mul_le (mkOfCompact f) (mkOfCompact g)
+  norm_mul_le f g := norm_mul_le (mkOfCompact f) (mkOfCompact g)
 
 instance [NonUnitalSeminormedCommRing R] : NonUnitalSeminormedCommRing C(α, R) where
   __ : NonUnitalSeminormedRing C(α, R) := inferInstance

--- a/Mathlib/Topology/ContinuousMap/ContinuousMapZero.lean
+++ b/Mathlib/Topology/ContinuousMap/ContinuousMapZero.lean
@@ -372,7 +372,7 @@ lemma norm_def [NormedAddCommGroup R] (f : C(α, R)₀) : ‖f‖ = ‖(f : C(α
 
 noncomputable instance [NormedCommRing R] : NonUnitalNormedCommRing C(α, R)₀ where
   dist_eq f g := NormedAddGroup.dist_eq (f : C(α, R)) g
-  norm_mul f g := NormedRing.norm_mul (f : C(α, R)) g
+  norm_mul_le f g := norm_mul_le (f : C(α, R)) g
   mul_comm f g := mul_comm f g
 
 instance [NormedField 𝕜] [NormedCommRing R] [NormedAlgebra 𝕜 R] : NormedSpace 𝕜 C(α, R)₀ where

--- a/Mathlib/Topology/ContinuousMap/ZeroAtInfty.lean
+++ b/Mathlib/Topology/ContinuousMap/ZeroAtInfty.lean
@@ -466,7 +466,8 @@ variable [SeminormedAddCommGroup β] {𝕜 : Type*} [NormedField 𝕜] [NormedSp
 theorem norm_toBCF_eq_norm {f : C₀(α, β)} : ‖f.toBCF‖ = ‖f‖ :=
   rfl
 
-instance : NormedSpace 𝕜 C₀(α, β) where norm_smul_le k f := (norm_smul_le k f.toBCF :)
+instance : NormedSpace 𝕜 C₀(α, β) where
+  norm_smul_le k f := norm_smul_le k f.toBCF
 
 end NormedSpace
 
@@ -475,12 +476,11 @@ section NormedRing
 noncomputable instance instNonUnitalSeminormedRing [NonUnitalSeminormedRing β] :
     NonUnitalSeminormedRing C₀(α, β) :=
   { instNonUnitalRing, instSeminormedAddCommGroup with
-    norm_mul := fun f g => norm_mul_le f.toBCF g.toBCF }
+    norm_mul_le f g := norm_mul_le f.toBCF g.toBCF }
 
 noncomputable instance instNonUnitalNormedRing [NonUnitalNormedRing β] :
     NonUnitalNormedRing C₀(α, β) :=
-  { instNonUnitalRing, instNormedAddCommGroup with
-    norm_mul := fun f g => norm_mul_le f.toBCF g.toBCF }
+  { instNonUnitalSeminormedRing, instNormedAddCommGroup with }
 
 noncomputable instance instNonUnitalSeminormedCommRing [NonUnitalSeminormedCommRing β] :
     NonUnitalSeminormedCommRing C₀(α, β) :=


### PR DESCRIPTION
Rename `norm_mul` of NormedRing and cousins to `norm_mul_le`, and `norm_mul'` of `NormedDivisionRing` to `norm_mul`. Split off from #22842.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
