### PR TITLE
[Merged by Bors] - feat: comaps of subgroups and submonoids agree

### DIFF
--- a/Mathlib/Algebra/Group/Subgroup/Map.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Map.lean
@@ -376,7 +376,11 @@ defined by sending subgroups to their inverse images.
 
 See also `MulEquiv.mapSubgroup` which maps subgroups to their forward images.
 -/
-@[to_additive (attr := simps)]
+@[to_additive (attr := simps)
+"An isomorphism of groups gives an order isomorphism between the lattices of subgroups,
+defined by sending subgroups to their inverse images.
+
+See also `AddEquiv.mapAddSubgroup` which maps subgroups to their forward images."]
 def comapSubgroup (f : G ≃* H) : Subgroup H ≃o Subgroup G where
   toFun := Subgroup.comap f
   invFun := Subgroup.comap f.symm
@@ -398,7 +402,11 @@ defined by sending subgroups to their forward images.
 
 See also `MulEquiv.comapSubgroup` which maps subgroups to their inverse images.
 -/
-@[to_additive (attr := simps)]
+@[to_additive (attr := simps)
+"An isomorphism of groups gives an order isomorphism between the lattices of subgroups,
+defined by sending subgroups to their forward images.
+
+See also `AddEquiv.comapAddSubgroup` which maps subgroups to their inverse images."]
 def mapSubgroup {H : Type*} [Group H] (f : G ≃* H) : Subgroup G ≃o Subgroup H where
   toFun := Subgroup.map f
   invFun := Subgroup.map f.symm

--- a/Mathlib/Algebra/Group/Subgroup/Map.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Map.lean
@@ -376,7 +376,7 @@ defined by sending subgroups to their inverse images.
 
 See also `MulEquiv.mapSubgroup` which maps subgroups to their forward images.
 -/
-@[simps]
+@[to_additive (attr := simps)]
 def comapSubgroup (f : G ≃* H) : Subgroup H ≃o Subgroup G where
   toFun := Subgroup.comap f
   invFun := Subgroup.comap f.symm
@@ -386,13 +386,19 @@ def comapSubgroup (f : G ≃* H) : Subgroup H ≃o Subgroup G where
     ⟨fun h => by simpa [Subgroup.comap_comap] using
       Subgroup.comap_mono (f := (f.symm : H →* G)) h, Subgroup.comap_mono⟩
 
+@[to_additive (attr := simp, norm_cast)]
+lemma coe_comapSubgroup (e : G ≃* H) : comapSubgroup e = Subgroup.comap e.toMonoidHom := rfl
+
+@[to_additive (attr := simp)]
+lemma symm_comapSubgroup (e : G ≃* H) : (comapSubgroup e).symm = comapSubgroup e.symm := rfl
+
 /--
 An isomorphism of groups gives an order isomorphism between the lattices of subgroups,
 defined by sending subgroups to their forward images.
 
 See also `MulEquiv.comapSubgroup` which maps subgroups to their inverse images.
 -/
-@[simps]
+@[to_additive (attr := simps)]
 def mapSubgroup {H : Type*} [Group H] (f : G ≃* H) : Subgroup G ≃o Subgroup H where
   toFun := Subgroup.map f
   invFun := Subgroup.map f.symm
@@ -402,6 +408,12 @@ def mapSubgroup {H : Type*} [Group H] (f : G ≃* H) : Subgroup G ≃o Subgroup 
     ⟨fun h => by simpa [Subgroup.map_map] using
       Subgroup.map_mono (f := (f.symm : H →* G)) h, Subgroup.map_mono⟩
 
+@[to_additive (attr := simp, norm_cast)]
+lemma coe_mapSubgroup (e : G ≃* H) : mapSubgroup e = Subgroup.map e.toMonoidHom := rfl
+
+@[to_additive (attr := simp)]
+lemma symm_mapSubgroup (e : G ≃* H) : (mapSubgroup e).symm = mapSubgroup e.symm := rfl
+
 end MulEquiv
 
 namespace Subgroup
@@ -409,6 +421,10 @@ namespace Subgroup
 open MonoidHom
 
 variable {N : Type*} [Group N] (f : G →* N)
+
+@[to_additive (attr := simp, norm_cast)]
+lemma comap_toSubmonoid (e : G ≃* N) (s : Subgroup N) :
+    (s.comap e).toSubmonoid = s.toSubmonoid.comap e.toMonoidHom := rfl
 
 @[to_additive]
 theorem map_comap_le (H : Subgroup N) : map f (comap f H) ≤ H :=


### PR DESCRIPTION
From Toric


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
