### PR TITLE
[Merged by Bors] - feat: for nilpotent derivations, exponential is multiplicative

### DIFF
--- a/Mathlib/Algebra/Module/LinearMap/Rat.lean
+++ b/Mathlib/Algebra/Module/LinearMap/Rat.lean
@@ -30,3 +30,13 @@ theorem AddMonoidHom.toRatLinearMap_injective [AddCommGroup M] [Module ℚ M] [A
 theorem AddMonoidHom.coe_toRatLinearMap [AddCommGroup M] [Module ℚ M] [AddCommGroup M₂]
     [Module ℚ M₂] (f : M →+ M₂) : ⇑f.toRatLinearMap = f :=
   rfl
+
+instance {R M N : Type*} [Ring R] [AddCommGroup M] [AddCommGroup N]
+    [Module R M] [Module R N] [Module ℚ M] [Module ℚ N] :
+    MulActionHomClass (M →ₗ[R] N) ℚ M N where
+  map_smulₛₗ f q m := by
+    suffices q.den • f (q • m) = q.den • (q • f m) from
+      smul_right_injective N (c := q.den) q.den_nz <| by norm_cast
+    simp only [← map_nsmul, ← smul_assoc, nsmul_eq_mul, Rat.den_mul_eq_num]
+    norm_cast
+    rw [map_zsmul]

--- a/Mathlib/Algebra/Module/LinearMap/Rat.lean
+++ b/Mathlib/Algebra/Module/LinearMap/Rat.lean
@@ -30,13 +30,3 @@ theorem AddMonoidHom.toRatLinearMap_injective [AddCommGroup M] [Module ℚ M] [A
 theorem AddMonoidHom.coe_toRatLinearMap [AddCommGroup M] [Module ℚ M] [AddCommGroup M₂]
     [Module ℚ M₂] (f : M →+ M₂) : ⇑f.toRatLinearMap = f :=
   rfl
-
-instance {R M N : Type*} [Ring R] [AddCommGroup M] [AddCommGroup N]
-    [Module R M] [Module R N] [Module ℚ M] [Module ℚ N] :
-    MulActionHomClass (M →ₗ[R] N) ℚ M N where
-  map_smulₛₗ f q m := by
-    suffices q.den • f (q • m) = q.den • (q • f m) from
-      smul_right_injective N (c := q.den) q.den_nz <| by norm_cast
-    simp only [← map_nsmul, ← smul_assoc, nsmul_eq_mul, Rat.den_mul_eq_num]
-    norm_cast
-    rw [map_zsmul]

--- a/Mathlib/LinearAlgebra/TensorProduct/Basic.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Basic.lean
@@ -981,7 +981,9 @@ open TensorProduct
 
 attribute [local ext high] TensorProduct.ext
 
-/-- `lTensorHom M` is the natural linear map that sends a linear map `f : N →ₗ P` to `M ⊗ f`. -/
+/-- `lTensorHom M` is the natural linear map that sends a linear map `f : N →ₗ P` to `M ⊗ f`.
+
+See also `Module.End.lTensorAlgHom`. -/
 def lTensorHom : (N →ₗ[R] P) →ₗ[R] M ⊗[R] N →ₗ[R] M ⊗[R] P where
   toFun := lTensor M
   map_add' f g := by
@@ -992,7 +994,9 @@ def lTensorHom : (N →ₗ[R] P) →ₗ[R] M ⊗[R] N →ₗ[R] M ⊗[R] P where
     ext x y
     simp only [compr₂_apply, mk_apply, tmul_smul, smul_apply, lTensor_tmul]
 
-/-- `rTensorHom M` is the natural linear map that sends a linear map `f : N →ₗ P` to `f ⊗ M`. -/
+/-- `rTensorHom M` is the natural linear map that sends a linear map `f : N →ₗ P` to `f ⊗ M`.
+
+See also `Module.End.rTensorAlgHom`. -/
 def rTensorHom : (N →ₗ[R] P) →ₗ[R] N ⊗[R] M →ₗ[R] P ⊗[R] M where
   toFun f := f.rTensor M
   map_add' f g := by

--- a/Mathlib/RingTheory/Nilpotent/Exp.lean
+++ b/Mathlib/RingTheory/Nilpotent/Exp.lean
@@ -10,6 +10,7 @@ import Mathlib.Algebra.Module.Rat
 import Mathlib.Data.Nat.Cast.Field
 import Mathlib.LinearAlgebra.TensorProduct.Tower
 import Mathlib.RingTheory.Nilpotent.Basic
+import Mathlib.RingTheory.TensorProduct.Basic
 import Mathlib.Tactic.FieldSimp
 
 /-!
@@ -209,9 +210,7 @@ theorem lTensor_exp (f : Module.End R N) (hf : IsNilpotent f) :
   replace hk : (f.lTensor M) ^ kl = 0 := pow_eq_zero_of_le (by omega) hk
   replace hl : f ^ kl = 0 := pow_eq_zero_of_le (by omega) hl
   ext m n
-  have aux (i j : ℕ) : (i : ℚ)⁻¹ • m ⊗ₜ[R] (f ^ j) n = m ⊗ₜ[R] ((i : ℚ)⁻¹ • (f ^ j) n) := by
-    rw [← (TensorProduct.comm R M N).apply_eq_iff_eq, map_inv_natCast_smul _ ℚ ℚ]; rfl
-  simp [exp_eq_sum hk, exp_eq_sum hl, tmul_sum, aux]
+  simp [exp_eq_sum hk, exp_eq_sum hl, tmul_sum]
 
 theorem commute_exp_left_of_commute
     {fM : Module.End R M} {fN : Module.End R N} {g : M →ₗ[R] N}

--- a/Mathlib/RingTheory/Nilpotent/Exp.lean
+++ b/Mathlib/RingTheory/Nilpotent/Exp.lean
@@ -3,10 +3,11 @@ Copyright (c) 2025 Janos Wolosz. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Janos Wolosz
 -/
-import Mathlib.Algebra.Algebra.Defs
+import Mathlib.Algebra.Algebra.Basic
 import Mathlib.Algebra.BigOperators.GroupWithZero.Action
 import Mathlib.Data.Nat.Cast.Field
 import Mathlib.RingTheory.Nilpotent.Basic
+import Mathlib.RingTheory.TensorProduct.Basic
 import Mathlib.Tactic.FieldSimp
 
 /-!
@@ -36,7 +37,7 @@ algebra, exponential map, nilpotent
 
 namespace IsNilpotent
 
-variable {A : Type*} [Ring A] [Algebra ℚ A]
+variable {A : Type*} [Ring A] [Module ℚ A]
 
 open Finset
 open scoped Nat
@@ -46,8 +47,8 @@ It provides meaningful (non-junk) values for nilpotent elements. -/
 noncomputable def exp (a : A) : A :=
   ∑ i ∈ range (nilpotencyClass a), (i.factorial : ℚ)⁻¹ • (a ^ i)
 
-theorem exp_eq_truncated {a : A} {k : ℕ} (h : a ^ k = 0) :
-    ∑ i ∈ range k, (i.factorial : ℚ)⁻¹ • (a ^ i) = exp a := by
+theorem exp_eq_sum {a : A} {k : ℕ} (h : a ^ k = 0) :
+    exp a = ∑ i ∈ range k, (i.factorial : ℚ)⁻¹ • (a ^ i) := by
   have h₁ : ∑ i ∈ range k, (i.factorial : ℚ)⁻¹ • (a ^ i) =
       ∑ i ∈ range (nilpotencyClass a), (i.factorial : ℚ)⁻¹ • (a ^ i) +
         ∑ i ∈ Ico (nilpotencyClass a) k, (i.factorial : ℚ)⁻¹ • (a ^ i) :=
@@ -59,10 +60,11 @@ theorem exp_eq_truncated {a : A} {k : ℕ} (h : a ^ k = 0) :
     rw [pow_eq_zero_of_le (mem_Ico.1 h₂).1 (pow_nilpotencyClass ⟨k, h⟩), smul_zero]
 
 theorem exp_zero_eq_one : exp (0 : A) = 1 := by
-  have h₁ := exp_eq_truncated (pow_one (0 : A))
-  rw [range_one, sum_singleton, Nat.factorial_zero, Nat.cast_one, inv_one, pow_zero,
+  have h₁ := exp_eq_sum (pow_one (0 : A))
+  rwa [range_one, sum_singleton, Nat.factorial_zero, Nat.cast_one, inv_one, pow_zero,
     one_smul] at h₁
-  exact h₁.symm
+
+variable [SMulCommClass ℚ A A] [IsScalarTower ℚ A A]
 
 theorem exp_add_of_commute {a b : A} (h₁ : Commute a b) (h₂ : IsNilpotent a) (h₃ : IsNilpotent b) :
     exp (a + b) = exp a * exp b := by
@@ -71,9 +73,9 @@ theorem exp_add_of_commute {a b : A} (h₁ : Commute a b) (h₂ : IsNilpotent a)
   let N := n₁ ⊔ n₂
   have h₄ : a ^ (N + 1) = 0 := pow_eq_zero_of_le (by omega) hn₁
   have h₅ : b ^ (N + 1) = 0 := pow_eq_zero_of_le (by omega) hn₂
-  rw [← exp_eq_truncated (k := 2 * N + 1)
+  rw [exp_eq_sum (k := 2 * N + 1)
     (Commute.add_pow_eq_zero_of_add_le_succ_of_pow_eq_zero h₁ h₄ h₅ (by omega)),
-    ← exp_eq_truncated h₄, ← exp_eq_truncated h₅]
+    exp_eq_sum h₄, exp_eq_sum h₅]
   set R2N := range (2 * N + 1) with hR2N
   set RN := range (N + 1) with hRN
   have s₁ := by
@@ -90,7 +92,7 @@ theorem exp_add_of_commute {a b : A} (h₁ : Commute a b) (h₂ : IsNilpotent a)
       simp only [mem_range] at hi hj
       replace hj := Nat.le_of_lt_succ hj
       suffices (i ! : ℚ)⁻¹ * (i.choose j) = ((j ! : ℚ)⁻¹ * ((i - j)! : ℚ)⁻¹) by
-        rw [← Nat.cast_commute (i.choose j), ← this, ← Algebra.mul_smul_comm, ← nsmul_eq_mul,
+        rw [← Nat.cast_commute (i.choose j), ← this, ← mul_smul_comm, ← nsmul_eq_mul,
           mul_smul, ← smul_assoc, smul_comm, smul_assoc]
         norm_cast
       rw [Nat.choose_eq_factorial_div_factorial hj,
@@ -147,7 +149,7 @@ theorem exp_add_of_commute {a b : A} (h₁ : Commute a b) (h₂ : IsNilpotent a)
       _ = ∑ ij ∈ RN ×ˢ RN, ((ij.1 ! : ℚ)⁻¹ * (ij.2 ! : ℚ)⁻¹) • (a ^ ij.1 * b ^ ij.2) := ?_
     · rw [sum_mul_sum]
       refine sum_congr rfl fun _ _ ↦ sum_congr rfl fun _ _ ↦ ?_
-      rw [smul_mul_assoc, Algebra.mul_smul_comm, smul_smul]
+      rw [smul_mul_assoc, mul_smul_comm, smul_smul]
     · rw [sum_sigma']
       apply sum_bijective (fun ⟨i, j⟩ ↦ (i, j))
       · exact ⟨fun ⟨i, j⟩ ⟨i', j'⟩ h ↦ by cases h; rfl, fun ⟨i, j⟩ ↦ ⟨⟨i, j⟩, rfl⟩⟩
@@ -165,3 +167,87 @@ theorem exp_of_nilpotent_is_unit {a : A} (h : IsNilpotent a) : IsUnit (exp a) :=
   rw [← exp_add_of_commute h₁.symm h₂ h, neg_add_cancel a, exp_zero_eq_one]
 
 end IsNilpotent
+
+namespace LinearMap
+
+variable {R M N : Type*} [CommRing R]
+  [AddCommGroup M] [Module R M] [AddCommGroup N] [Module R N]
+
+variable (M) in
+theorem isNilpotent_lTensor_of_isNilpotent (f : Module.End R N) (hf : IsNilpotent f) :
+    IsNilpotent (f.lTensor M) := by
+  obtain ⟨k, hk⟩ := hf
+  exact ⟨k, by ext; simp [hk]⟩
+
+variable (N) in
+theorem isNilpotent_rTensor_of_isNilpotent (f : Module.End R M) (hf : IsNilpotent f) :
+    IsNilpotent (f.rTensor N) := by
+  obtain ⟨k, hk⟩ := hf
+  exact ⟨k, by ext; simp [hk]⟩
+
+open IsNilpotent TensorProduct
+
+variable [Algebra ℚ R] [Module ℚ M] [Module ℚ N] [IsScalarTower ℚ R M] [IsScalarTower ℚ R N]
+
+theorem commute_exp_left_of_commute
+    {fM : Module.End R M} {fN : Module.End R N} {g : M →ₗ[R] N}
+    (hfM : IsNilpotent fM)
+    (hfN : IsNilpotent fN)
+    (h : fN ∘ₗ g = g ∘ₗ fM) :
+    exp fN ∘ₗ g = g ∘ₗ exp fM := by
+  ext m
+  obtain ⟨k, hfM⟩ := hfM
+  obtain ⟨l, hfN⟩ := hfN
+  let kl := max k l
+  replace hfM : fM ^ kl = 0 := pow_eq_zero_of_le (by omega) hfM
+  replace hfN : fN ^ kl = 0 := pow_eq_zero_of_le (by omega) hfN
+  have (i : ℕ) : (fN ^ i) (g m) = g ((fM ^ i) m) := by
+    simpa using LinearMap.congr_fun (LinearMap.commute_pow_left_of_commute h i) m
+  simp [LinearMap.coe_comp, Function.comp_apply, exp_eq_sum hfM, exp_eq_sum hfN, this]
+
+variable (M) in
+theorem lTensor_exp (f : Module.End R N) (hf : IsNilpotent f) :
+    exp (f.lTensor M) = (exp f).lTensor M := by
+  obtain ⟨k, hk⟩ := isNilpotent_lTensor_of_isNilpotent M f hf
+  obtain ⟨l, hl⟩ := hf
+  let kl := max k l
+  replace hk : (f.lTensor M) ^ kl = 0 := pow_eq_zero_of_le (by omega) hk
+  replace hl : f ^ kl = 0 := pow_eq_zero_of_le (by omega) hl
+  ext m n
+  simp [exp_eq_sum hk, exp_eq_sum hl, tmul_sum]
+
+omit [Module ℚ N] [IsScalarTower ℚ R N] in
+variable (N) in
+theorem rTensor_exp (f : Module.End R M) (hf : IsNilpotent f) :
+    exp (f.rTensor N) = (exp f).rTensor N := by
+  obtain ⟨k, hk⟩ := isNilpotent_rTensor_of_isNilpotent N f hf
+  obtain ⟨l, hl⟩ := hf
+  let kl := max k l
+  replace hk : (f.rTensor N) ^ kl = 0 := pow_eq_zero_of_le (by omega) hk
+  replace hl : f ^ kl = 0 := pow_eq_zero_of_le (by omega) hl
+  ext m n
+  simp [exp_eq_sum hk, exp_eq_sum hl, sum_tmul, smul_tmul']
+
+theorem exp_mul_of_derivation (R B : Type*) [CommRing R] [NonUnitalNonAssocRing B]
+    [Module R B] [SMulCommClass R B B] [IsScalarTower R B B]
+    [Module ℚ B] [Algebra ℚ R] [IsScalarTower ℚ R B]
+    (D : B →ₗ[R] B) (h_der : ∀ x y, D (x * y) = x * D y + (D x) * y)
+    (h_nil : IsNilpotent D) (x y : B) :
+    exp D (x * y) = (exp D x) * (exp D y) := by
+  let DL : Module.End R (B ⊗[R] B) := D.lTensor B
+  let DR : Module.End R (B ⊗[R] B) := D.rTensor B
+  have h_nilL : IsNilpotent DL := isNilpotent_lTensor_of_isNilpotent B D h_nil
+  have h_nilR : IsNilpotent DR := isNilpotent_rTensor_of_isNilpotent B D h_nil
+  have h_comm : Commute DL DR := by ext; simp [DL, DR]
+  let m : B ⊗[R] B →ₗ[R] B := lift <| LinearMap.mul R B
+  have hm (x y : B) : m (x ⊗ₜ[R] y) = x * y := rfl
+  have h₁ : exp D (x * y) = m (exp (DL + DR) (x ⊗ₜ[R] y)) := by
+    suffices exp D ∘ₗ m = m ∘ₗ exp (DL + DR) by simpa using LinearMap.congr_fun this (x ⊗ₜ[R] y)
+    apply LinearMap.commute_exp_left_of_commute (h_comm.isNilpotent_add h_nilL h_nilR) h_nil
+    ext
+    simp [DL, DR, hm, h_der]
+  have h₂ : exp DL = (exp D).lTensor B := lTensor_exp B D h_nil
+  have h₃ : exp DR = (exp D).rTensor B := rTensor_exp B D h_nil
+  simp [h₁, exp_add_of_commute h_comm h_nilL h_nilR, h₂, h₃, hm]
+
+end LinearMap

--- a/Mathlib/RingTheory/Nilpotent/Exp.lean
+++ b/Mathlib/RingTheory/Nilpotent/Exp.lean
@@ -172,6 +172,11 @@ theorem map_exp {B F : Type*} [Ring B] [FunLike F A B] [RingHomClass F A B] [Mod
   have hk' : (f a) ^ k = 0 := by simp [← map_pow, hk]
   simp [exp_eq_sum hk, exp_eq_sum hk', map_rat_smul]
 
+theorem exp_smul {G : Type*} [Monoid G] [MulSemiringAction G A]
+    (g : G) {a : A} (ha : IsNilpotent a) :
+    exp (g • a) = g • exp a :=
+  (map_exp ha (MulSemiringAction.toRingHom G A g)).symm
+
 end IsNilpotent
 
 namespace Module.End

--- a/Mathlib/RingTheory/Nilpotent/Exp.lean
+++ b/Mathlib/RingTheory/Nilpotent/Exp.lean
@@ -207,8 +207,7 @@ theorem exp_mul_of_derivation (R B : Type*) [CommRing R] [NonUnitalNonAssocRing 
   have h_nilL : IsNilpotent DL := h_nil.map <| lTensorAlgHom R B B
   have h_nilR : IsNilpotent DR := h_nil.map <| rTensorAlgHom R B B
   have h_comm : Commute DL DR := by ext; simp [DL, DR]
-  let m : B ⊗[R] B →ₗ[R] B := LinearMap.mul' R B
-  have hm (x y : B) : m (x ⊗ₜ[R] y) = x * y := rfl
+  set m : B ⊗[R] B →ₗ[R] B := LinearMap.mul' R B with hm
   have h₁ : exp D (x * y) = m (exp (DL + DR) (x ⊗ₜ[R] y)) := by
     suffices exp D ∘ₗ m = m ∘ₗ exp (DL + DR) by simpa using LinearMap.congr_fun this (x ⊗ₜ[R] y)
     apply commute_exp_left_of_commute (h_comm.isNilpotent_add h_nilL h_nilR) h_nil

--- a/Mathlib/RingTheory/Nilpotent/Exp.lean
+++ b/Mathlib/RingTheory/Nilpotent/Exp.lean
@@ -174,7 +174,7 @@ theorem map_exp {B F : Type*} [Ring B] [FunLike F A B] [RingHomClass F A B] [Mod
 
 end IsNilpotent
 
-namespace LinearMap
+namespace Module.End
 
 variable {R M N : Type*} [CommRing R] [AddCommGroup M] [Module R M] [AddCommGroup N] [Module R N]
   [Module ℚ M] [Module ℚ N]
@@ -207,11 +207,11 @@ theorem exp_mul_of_derivation (R B : Type*) [CommRing R] [NonUnitalNonAssocRing 
   have h_nilL : IsNilpotent DL := h_nil.map <| lTensorAlgHom R B B
   have h_nilR : IsNilpotent DR := h_nil.map <| rTensorAlgHom R B B
   have h_comm : Commute DL DR := by ext; simp [DL, DR]
-  let m : B ⊗[R] B →ₗ[R] B := lift <| LinearMap.mul R B
+  let m : B ⊗[R] B →ₗ[R] B := LinearMap.mul' R B
   have hm (x y : B) : m (x ⊗ₜ[R] y) = x * y := rfl
   have h₁ : exp D (x * y) = m (exp (DL + DR) (x ⊗ₜ[R] y)) := by
     suffices exp D ∘ₗ m = m ∘ₗ exp (DL + DR) by simpa using LinearMap.congr_fun this (x ⊗ₜ[R] y)
-    apply LinearMap.commute_exp_left_of_commute (h_comm.isNilpotent_add h_nilL h_nilR) h_nil
+    apply commute_exp_left_of_commute (h_comm.isNilpotent_add h_nilL h_nilR) h_nil
     ext
     simp [DL, DR, hm, h_der]
   let aux := h_nil.map_exp (lTensorAlgHom R B B)
@@ -219,4 +219,4 @@ theorem exp_mul_of_derivation (R B : Type*) [CommRing R] [NonUnitalNonAssocRing 
   have h₃ : exp DR = (exp D).rTensor B := (h_nil.map_exp (rTensorAlgHom R B B)).symm
   simp [h₁, exp_add_of_commute h_comm h_nilL h_nilR, h₂, h₃, hm]
 
-end LinearMap
+end Module.End

--- a/Mathlib/RingTheory/Nilpotent/Exp.lean
+++ b/Mathlib/RingTheory/Nilpotent/Exp.lean
@@ -7,6 +7,7 @@ import Mathlib.Algebra.Algebra.Basic
 import Mathlib.Algebra.Algebra.Bilinear
 import Mathlib.Algebra.BigOperators.GroupWithZero.Action
 import Mathlib.Algebra.Module.Rat
+import Mathlib.Algebra.Module.LinearMap.Rat
 import Mathlib.Data.Nat.Cast.Field
 import Mathlib.LinearAlgebra.TensorProduct.Tower
 import Mathlib.RingTheory.Nilpotent.Basic
@@ -226,7 +227,7 @@ theorem commute_exp_left_of_commute
   replace hfN : fN ^ kl = 0 := pow_eq_zero_of_le (by omega) hfN
   have (i : ℕ) : (fN ^ i) (g m) = g ((fM ^ i) m) := by
     simpa using LinearMap.congr_fun (LinearMap.commute_pow_left_of_commute h i) m
-  simp [exp_eq_sum hfM, exp_eq_sum hfN, this, map_inv_natCast_smul _ ℚ ℚ]
+  simp [exp_eq_sum hfM, exp_eq_sum hfN, this]
 
 theorem exp_mul_of_derivation (R B : Type*) [CommRing R] [NonUnitalNonAssocRing B]
     [Module R B] [SMulCommClass R B B] [IsScalarTower R B B] [Module ℚ B]

--- a/Mathlib/RingTheory/Nilpotent/Exp.lean
+++ b/Mathlib/RingTheory/Nilpotent/Exp.lean
@@ -7,7 +7,6 @@ import Mathlib.Algebra.Algebra.Basic
 import Mathlib.Algebra.Algebra.Bilinear
 import Mathlib.Algebra.BigOperators.GroupWithZero.Action
 import Mathlib.Algebra.Module.Rat
-import Mathlib.Algebra.Module.LinearMap.Rat
 import Mathlib.Data.Nat.Cast.Field
 import Mathlib.LinearAlgebra.TensorProduct.Tower
 import Mathlib.RingTheory.Nilpotent.Basic
@@ -227,7 +226,7 @@ theorem commute_exp_left_of_commute
   replace hfN : fN ^ kl = 0 := pow_eq_zero_of_le (by omega) hfN
   have (i : ℕ) : (fN ^ i) (g m) = g ((fM ^ i) m) := by
     simpa using LinearMap.congr_fun (LinearMap.commute_pow_left_of_commute h i) m
-  simp [exp_eq_sum hfM, exp_eq_sum hfN, this]
+  simp [exp_eq_sum hfM, exp_eq_sum hfN, this, map_rat_smul]
 
 theorem exp_mul_of_derivation (R B : Type*) [CommRing R] [NonUnitalNonAssocRing B]
     [Module R B] [SMulCommClass R B B] [IsScalarTower R B B] [Module ℚ B]

--- a/Mathlib/RingTheory/Nilpotent/Exp.lean
+++ b/Mathlib/RingTheory/Nilpotent/Exp.lean
@@ -7,8 +7,9 @@ import Mathlib.Algebra.Algebra.Basic
 import Mathlib.Algebra.BigOperators.GroupWithZero.Action
 import Mathlib.Data.Nat.Cast.Field
 import Mathlib.RingTheory.Nilpotent.Basic
-import Mathlib.RingTheory.TensorProduct.Basic
 import Mathlib.Tactic.FieldSimp
+import Mathlib.Algebra.Algebra.Bilinear
+import Mathlib.LinearAlgebra.TensorProduct.Tower
 
 /-!
 # Exponential map on algebras

--- a/Mathlib/RingTheory/Nilpotent/Exp.lean
+++ b/Mathlib/RingTheory/Nilpotent/Exp.lean
@@ -214,7 +214,6 @@ theorem exp_mul_of_derivation (R B : Type*) [CommRing R] [NonUnitalNonAssocRing 
     apply commute_exp_left_of_commute (h_comm.isNilpotent_add h_nilL h_nilR) h_nil
     ext
     simp [DL, DR, hm, h_der]
-  let aux := h_nil.map_exp (lTensorAlgHom R B B)
   have h₂ : exp DL = (exp D).lTensor B := (h_nil.map_exp (lTensorAlgHom R B B)).symm
   have h₃ : exp DR = (exp D).rTensor B := (h_nil.map_exp (rTensorAlgHom R B B)).symm
   simp [h₁, exp_add_of_commute h_comm h_nilL h_nilR, h₂, h₃, hm]

--- a/Mathlib/RingTheory/TensorProduct/Basic.lean
+++ b/Mathlib/RingTheory/TensorProduct/Basic.lean
@@ -1406,3 +1406,29 @@ lemma Submodule.map_range_rTensor_subtype_lid {R Q} [CommSemiring R] [AddCommMon
   rintro _ ⟨t, rfl⟩
   exact t.induction_on (by simp) (by simp +contextual [Submodule.smul_mem_smul])
     (by simp +contextual [add_mem])
+
+section MoveMe
+
+namespace LinearMap
+
+variable (R M N : Type*) [CommRing R] [AddCommGroup M] [Module R M] [AddCommGroup N] [Module R N]
+
+/-- The map `LinearMap.lTensorHom` which sends `f ↦ 1 ⊗ f` as a morphism of algebras. -/
+noncomputable def lTensorAlgHom : Module.End R M →ₐ[R] Module.End R (N ⊗[R] M) :=
+  { lTensorHom (R := R) (M := N) (N := M) (P := M) with
+    map_one' := lTensor_id N M
+    map_mul' f g := lTensor_mul N f g
+    commutes' r := by ext; simp
+    map_zero' := lTensor_zero N }
+
+/-- The map `LinearMap.rTensorHom` which sends `f ↦ f ⊗ 1` as a morphism of algebras. -/
+noncomputable def rTensorAlgHom : Module.End R M →ₐ[R] Module.End R (M ⊗[R] N) :=
+  { rTensorHom (R := R) (M := N) (N := M) (P := M) with
+    map_one' := rTensor_id N M
+    map_mul' f g := rTensor_mul N f g
+    commutes' r := by ext; simp [smul_tmul]
+    map_zero' := rTensor_zero N }
+
+end LinearMap
+
+end MoveMe

--- a/Mathlib/RingTheory/TensorProduct/Basic.lean
+++ b/Mathlib/RingTheory/TensorProduct/Basic.lean
@@ -863,7 +863,7 @@ def lidOfCompatibleSMul : S ⊗[R] A ≃ₐ[S] A :=
 
 theorem lidOfCompatibleSMul_tmul (s a) : lidOfCompatibleSMul R S A (s ⊗ₜ[R] a) = s • a := rfl
 
-instance {R M N : Type*} [CommRing R] [AddCommGroup M] [AddCommGroup N]
+instance {R M N : Type*} [CommSemiring R] [AddCommGroup M] [AddCommGroup N]
     [Module R M] [Module R N] [Module ℚ M] [Module ℚ N] : CompatibleSMul R ℚ M N where
   smul_tmul q m n := by
     suffices q.den • ((q • m) ⊗ₜ[R] n) = q.den • (m ⊗ₜ[R] (q • n)) from

--- a/Mathlib/RingTheory/TensorProduct/Basic.lean
+++ b/Mathlib/RingTheory/TensorProduct/Basic.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kim Morrison, Johan Commelin
 -/
 import Mathlib.Algebra.Algebra.RestrictScalars
+import Mathlib.Algebra.Module.Rat
 import Mathlib.GroupTheory.MonoidLocalization.Basic
 import Mathlib.LinearAlgebra.TensorProduct.Tower
 import Mathlib.RingTheory.Adjoin.Basic
@@ -842,6 +843,15 @@ def lidOfCompatibleSMul : S ⊗[R] A ≃ₐ[S] A :=
   (equivOfCompatibleSMul R S S A).symm.trans (TensorProduct.lid _ _)
 
 theorem lidOfCompatibleSMul_tmul (s a) : lidOfCompatibleSMul R S A (s ⊗ₜ[R] a) = s • a := rfl
+
+instance {R M N : Type*} [CommRing R] [AddCommGroup M] [AddCommGroup N]
+    [Module R M] [Module R N] [Module ℚ M] [Module ℚ N] : CompatibleSMul R ℚ M N where
+  smul_tmul q m n := by
+    suffices q.den • ((q • m) ⊗ₜ[R] n) = q.den • (m ⊗ₜ[R] (q • n)) from
+      smul_right_injective (M ⊗[R] N) (c := q.den) q.den_nz <| by norm_cast
+    rw [smul_tmul', ← tmul_smul, ← smul_assoc, ← smul_assoc, nsmul_eq_mul, Rat.den_mul_eq_num]
+    norm_cast
+    rw [smul_tmul]
 
 end CompatibleSMul
 

--- a/Mathlib/RingTheory/TensorProduct/Basic.lean
+++ b/Mathlib/RingTheory/TensorProduct/Basic.lean
@@ -204,6 +204,25 @@ end liftBaseChange
 
 end LinearMap
 
+namespace Module.End
+
+open LinearMap
+
+variable (R M N : Type*)
+  [CommSemiring R] [AddCommMonoid M] [Module R M] [AddCommMonoid N] [Module R N]
+
+/-- The map `LinearMap.lTensorHom` which sends `f ↦ 1 ⊗ f` as a morphism of algebras. -/
+@[simps!]
+noncomputable def lTensorAlgHom : Module.End R M →ₐ[R] Module.End R (N ⊗[R] M) :=
+  .ofLinearMap (lTensorHom (M := N)) (lTensor_id N M) (lTensor_mul N)
+
+/-- The map `LinearMap.rTensorHom` which sends `f ↦ f ⊗ 1` as a morphism of algebras. -/
+@[simps!]
+noncomputable def rTensorAlgHom : Module.End R M →ₐ[R] Module.End R (M ⊗[R] N) :=
+  .ofLinearMap (rTensorHom (M := N)) (rTensor_id N M) (rTensor_mul N)
+
+end Module.End
+
 namespace Algebra
 
 namespace TensorProduct
@@ -1406,23 +1425,3 @@ lemma Submodule.map_range_rTensor_subtype_lid {R Q} [CommSemiring R] [AddCommMon
   rintro _ ⟨t, rfl⟩
   exact t.induction_on (by simp) (by simp +contextual [Submodule.smul_mem_smul])
     (by simp +contextual [add_mem])
-
-section MoveMe
-
-namespace LinearMap
-
-variable (R M N : Type*) [CommRing R] [AddCommGroup M] [Module R M] [AddCommGroup N] [Module R N]
-
-/-- The map `LinearMap.lTensorHom` which sends `f ↦ 1 ⊗ f` as a morphism of algebras. -/
-@[simps!]
-noncomputable def lTensorAlgHom : Module.End R M →ₐ[R] Module.End R (N ⊗[R] M) :=
-  .ofLinearMap (lTensorHom (M := N)) (lTensor_id N M) (lTensor_mul N)
-
-/-- The map `LinearMap.rTensorHom` which sends `f ↦ f ⊗ 1` as a morphism of algebras. -/
-@[simps!]
-noncomputable def rTensorAlgHom : Module.End R M →ₐ[R] Module.End R (M ⊗[R] N) :=
-  .ofLinearMap (rTensorHom (M := N)) (rTensor_id N M) (rTensor_mul N)
-
-end LinearMap
-
-end MoveMe

--- a/Mathlib/RingTheory/TensorProduct/Basic.lean
+++ b/Mathlib/RingTheory/TensorProduct/Basic.lean
@@ -1414,20 +1414,14 @@ namespace LinearMap
 variable (R M N : Type*) [CommRing R] [AddCommGroup M] [Module R M] [AddCommGroup N] [Module R N]
 
 /-- The map `LinearMap.lTensorHom` which sends `f ↦ 1 ⊗ f` as a morphism of algebras. -/
+@[simps!]
 noncomputable def lTensorAlgHom : Module.End R M →ₐ[R] Module.End R (N ⊗[R] M) :=
-  { lTensorHom (R := R) (M := N) (N := M) (P := M) with
-    map_one' := lTensor_id N M
-    map_mul' f g := lTensor_mul N f g
-    commutes' r := by ext; simp
-    map_zero' := lTensor_zero N }
+  .ofLinearMap (lTensorHom (M := N)) (lTensor_id N M) (lTensor_mul N)
 
 /-- The map `LinearMap.rTensorHom` which sends `f ↦ f ⊗ 1` as a morphism of algebras. -/
+@[simps!]
 noncomputable def rTensorAlgHom : Module.End R M →ₐ[R] Module.End R (M ⊗[R] N) :=
-  { rTensorHom (R := R) (M := N) (N := M) (P := M) with
-    map_one' := rTensor_id N M
-    map_mul' f g := rTensor_mul N f g
-    commutes' r := by ext; simp [smul_tmul]
-    map_zero' := rTensor_zero N }
+  .ofLinearMap (rTensorHom (M := N)) (rTensor_id N M) (rTensor_mul N)
 
 end LinearMap
 


### PR DESCRIPTION
We prove that if `D` is a nilpotent derivation of an algebra (not necessarily associative or unital) then `exp D (x * y) = (exp D x) * (exp D y)`.

Note that I have not added a deprecation for `IsNilpotent.exp_eq_truncated` since it is only 12 days old.

---

~~Hacked together in final moments over lunch so may need polish.~~

Intended to help with #22607

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
