### PR TITLE
[Merged by Bors] - chore(Data/Fintype): process porting notes

### DIFF
--- a/Mathlib/Data/Fintype/CardEmbedding.lean
+++ b/Mathlib/Data/Fintype/CardEmbedding.lean
@@ -30,19 +30,19 @@ theorem card_embedding_eq_of_unique {α β : Type*} [Unique α] [Fintype β] [Fi
   card_congr Equiv.uniqueEmbeddingEquivResult
 
 -- Establishes the cardinality of the type of all injections between two finite types.
--- Porting note: `induction'` is broken so instead we make an ugly refine and `dsimp` a lot.
+-- Porting note: `induction α using Fintype.induction_empty_option` can't work with the `Fintype α`
+-- instance so instead we make an ugly refine and `dsimp` a lot.
 @[simp]
 theorem card_embedding_eq {α β : Type*} [Fintype α] [Fintype β] [emb : Fintype (α ↪ β)] :
     ‖α ↪ β‖ = ‖β‖.descFactorial ‖α‖ := by
   rw [Subsingleton.elim emb Embedding.fintype]
   refine Fintype.induction_empty_option (P := fun t ↦ ‖t ↪ β‖ = ‖β‖.descFactorial ‖t‖)
-        (fun α₁ α₂ h₂ e ih ↦ ?_) (?_) (fun γ h ih ↦ ?_) α <;> dsimp only <;> clear! α
+        (fun α₁ α₂ h₂ e ih ↦ ?_) (?_) (fun γ h ih ↦ ?_) α <;> dsimp only at * <;> clear! α
   · letI := Fintype.ofEquiv _ e.symm
     rw [← card_congr (Equiv.embeddingCongr e (Equiv.refl β)), ih, card_congr e]
   · rw [card_pempty, Nat.descFactorial_zero, card_eq_one_iff]
     exact ⟨Embedding.ofIsEmpty, fun x ↦ DFunLike.ext _ _ isEmptyElim⟩
   · classical
-    dsimp only at ih
     rw [card_option, Nat.descFactorial_succ, card_congr (Embedding.optionEmbeddingEquiv γ β),
         card_sigma, ← ih]
     simp only [Fintype.card_compl_set, Fintype.card_range, Finset.sum_const, Finset.card_univ,

--- a/Mathlib/Data/Fintype/EquivFin.lean
+++ b/Mathlib/Data/Fintype/EquivFin.lean
@@ -157,14 +157,11 @@ end Fintype
 In this section we prove that `α : Type*` is `Finite` if and only if `Fintype α` is nonempty.
 -/
 
-
--- @[nolint fintype_finite] -- Porting note: do we need this
 protected theorem Fintype.finite {α : Type*} (_inst : Fintype α) : Finite α :=
   ⟨Fintype.equivFin α⟩
 
 /-- For efficiency reasons, we want `Finite` instances to have higher
 priority than ones coming from `Fintype` instances. -/
--- @[nolint fintype_finite] -- Porting note: do we need this
 instance (priority := 900) Finite.of_fintype (α : Type*) [Fintype α] : Finite α :=
   Fintype.finite ‹_›
 
@@ -185,7 +182,6 @@ instance (priority := 100) Finite.of_subsingleton {α : Sort*} [Subsingleton α]
   Finite.of_injective (Function.const α ()) <| Function.injective_of_subsingleton _
 
 -- Higher priority for `Prop`s
--- Porting note (https://github.com/leanprover-community/mathlib4/issues/12096): removed @[nolint instance_priority], linter not ported yet
 instance prop (p : Prop) : Finite p :=
   Finite.of_subsingleton
 
@@ -401,7 +397,6 @@ theorem card_lt_of_surjective_not_injective [Fintype α] [Fintype β] (f : α �
 
 end Fintype
 
--- @[nolint fintype_finite] -- Porting note: do we need this?
 protected theorem Fintype.false [Infinite α] (_h : Fintype α) : False :=
   not_finite α
 

--- a/Mathlib/Data/Fintype/Inv.lean
+++ b/Mathlib/Data/Fintype/Inv.lean
@@ -125,7 +125,6 @@ def choose (hp : ∃! a, p a) : α :=
 theorem choose_spec (hp : ∃! a, p a) : p (choose p hp) :=
   (chooseX p hp).property
 
--- @[simp] Porting note: removing simp, never applies
 theorem choose_subtype_eq {α : Type*} (p : α → Prop) [Fintype { a : α // p a }] [DecidableEq α]
     (x : { a : α // p a })
     (h : ∃! a : { a // p a }, (a : α) = x :=

--- a/Mathlib/Data/Fintype/Lattice.lean
+++ b/Mathlib/Data/Fintype/Lattice.lean
@@ -33,17 +33,13 @@ theorem inf_univ_eq_iInf [CompleteLattice β] (f : α → β) : Finset.univ.inf 
 
 @[simp]
 theorem fold_inf_univ [SemilatticeInf α] [OrderBot α] (a : α) :
-    -- Porting note: added `haveI`
-    haveI : Std.Commutative (α := α) (· ⊓ ·) := inferInstance
-    (Finset.univ.fold (· ⊓ ·) a fun x => x) = ⊥ :=
+    (Finset.univ.fold min a fun x => x) = ⊥ :=
   eq_bot_iff.2 <|
     ((Finset.fold_op_rel_iff_and <| @le_inf_iff α _).1 le_rfl).2 ⊥ <| Finset.mem_univ _
 
 @[simp]
 theorem fold_sup_univ [SemilatticeSup α] [OrderTop α] (a : α) :
-    -- Porting note: added `haveI`
-    haveI : Std.Commutative (α := α) (· ⊔ ·) := inferInstance
-    (Finset.univ.fold (· ⊔ ·) a fun x => x) = ⊤ :=
+    (Finset.univ.fold max a fun x => x) = ⊤ :=
   @fold_inf_univ αᵒᵈ _ _ _ _
 
 lemma mem_inf [DecidableEq α] {s : Finset ι} {f : ι → Finset α} {a : α} :

--- a/Mathlib/Data/Fintype/Option.lean
+++ b/Mathlib/Data/Fintype/Option.lean
@@ -56,30 +56,24 @@ def truncRecEmptyOption {P : Type u → Sort v} (of_equiv : ∀ {α β}, α ≃ 
     apply Trunc.map _ (Fintype.truncEquivFin α)
     intro e
     exact of_equiv (Equiv.ulift.trans e.symm) h
-  apply ind where
-    -- Porting note: do a manual recursion, instead of `induction` tactic,
-    -- to ensure the result is computable
-    /-- Internal induction hypothesis -/
-    ind : ∀ n : ℕ, Trunc (P (ULift <| Fin n))
-    | Nat.zero => by
-          have : card PEmpty = card (ULift (Fin 0)) := by simp only [card_fin, card_pempty,
-                                                                     card_ulift]
-          apply Trunc.bind (truncEquivOfCardEq this)
-          intro e
-          apply Trunc.mk
-          exact of_equiv e h_empty
-      | Nat.succ n => by
-          have : card (Option (ULift (Fin n))) = card (ULift (Fin n.succ)) := by
-            simp only [card_fin, card_option, card_ulift]
-          apply Trunc.bind (truncEquivOfCardEq this)
-          intro e
-          apply Trunc.map _ (ind n)
-          intro ih
-          exact of_equiv e (h_option ih)
+  intro n
+  induction n
+  case zero =>
+    have : card PEmpty = card (ULift (Fin 0)) := by simp only [card_fin, card_pempty,
+                                                               card_ulift]
+    apply Trunc.bind (truncEquivOfCardEq this)
+    intro e
+    apply Trunc.mk
+    exact of_equiv e h_empty
+  case succ n ih =>
+    have : card (Option (ULift (Fin n))) = card (ULift (Fin n.succ)) := by
+      simp only [card_fin, card_option, card_ulift]
+    apply Trunc.bind (truncEquivOfCardEq this)
+    intro e
+    apply Trunc.map _ ih
+    intro ih
+    exact of_equiv e (h_option ih)
 
--- Porting note: due to instance inference issues in `SetTheory.Cardinal.Basic`
--- I had to explicitly name `h_fintype` in order to access it manually.
--- was `[Fintype α]`
 /-- An induction principle for finite types, analogous to `Nat.rec`. It effectively says
 that every `Fintype` is either `Empty` or `Option α`, up to an `Equiv`. -/
 @[elab_as_elim]

--- a/Mathlib/Data/Fintype/Option.lean
+++ b/Mathlib/Data/Fintype/Option.lean
@@ -57,15 +57,15 @@ def truncRecEmptyOption {P : Type u → Sort v} (of_equiv : ∀ {α β}, α ≃ 
     intro e
     exact of_equiv (Equiv.ulift.trans e.symm) h
   intro n
-  induction n
-  case zero =>
-    have : card PEmpty = card (ULift (Fin 0)) := by simp only [card_fin, card_pempty,
-                                                               card_ulift]
+  induction n with
+  | zero =>
+    have : card PEmpty = card (ULift (Fin 0)) := by
+      simp only [card_fin, card_pempty, card_ulift]
     apply Trunc.bind (truncEquivOfCardEq this)
     intro e
     apply Trunc.mk
     exact of_equiv e h_empty
-  case succ n ih =>
+  | succ n ih =>
     have : card (Option (ULift (Fin n))) = card (ULift (Fin n.succ)) := by
       simp only [card_fin, card_option, card_ulift]
     apply Trunc.bind (truncEquivOfCardEq this)

--- a/Mathlib/Data/Fintype/Order.lean
+++ b/Mathlib/Data/Fintype/Order.lean
@@ -66,7 +66,6 @@ abbrev toOrderBot [SemilatticeInf α] : OrderBot α where
 /-- Constructs the `⊤` of a finite nonempty `SemilatticeSup` -/
 abbrev toOrderTop [SemilatticeSup α] : OrderTop α where
   top := univ.sup' univ_nonempty id
-  -- Porting note: needed to make `id` explicit
   le_top a := le_sup' id <| mem_univ a
 
 -- See note [reducible non-instances]

--- a/Mathlib/Data/Fintype/Perm.lean
+++ b/Mathlib/Data/Fintype/Perm.lean
@@ -45,7 +45,6 @@ theorem mem_permsOfList_of_mem {l : List α} {f : Perm α} (h : ∀ x, f x ≠ x
     f ∈ permsOfList l := by
   induction l generalizing f with
   | nil =>
-    -- Porting note: applied `not_mem_nil` because it is no longer true definitionally.
     simp only [not_mem_nil] at h
     exact List.mem_singleton.2 (Equiv.ext fun x => Decidable.byContradiction <| h x)
   | cons a l IH =>
@@ -71,21 +70,19 @@ theorem mem_permsOfList_of_mem {l : List α} {f : Perm α} (h : ∀ x, f x ≠ x
   · rw [← mul_assoc, mul_def (swap a (f a)) (swap a (f a)), swap_swap, ← Perm.one_def, one_mul]
 
 theorem mem_of_mem_permsOfList :
-    -- Porting note: was `∀ {x}` but need to capture the `x`
-    ∀ {l : List α} {f : Perm α}, f ∈ permsOfList l → (x : α ) → f x ≠ x → x ∈ l
+    ∀ {l : List α} {f : Perm α}, f ∈ permsOfList l → {x : α} → f x ≠ x → x ∈ l
   | [], f, h, heq_iff_eq => by
     have : f = 1 := by simpa [permsOfList] using h
     rw [this]; simp
   | a :: l, f, h, x =>
-    (mem_append.1 h).elim (fun h hx => mem_cons_of_mem _ (mem_of_mem_permsOfList h x hx))
+    (mem_append.1 h).elim (fun h hx => mem_cons_of_mem _ (mem_of_mem_permsOfList h hx))
       fun h hx =>
       let ⟨y, hy, hy'⟩ := List.mem_flatMap.1 h
       let ⟨g, hg₁, hg₂⟩ := List.mem_map.1 hy'
-      -- Porting note: Seems like the implicit variable `x` of type `α` is needed.
       if hxa : x = a then by simp [hxa]
       else
         if hxy : x = y then mem_cons_of_mem _ <| by rwa [hxy]
-        else mem_cons_of_mem a <| mem_of_mem_permsOfList hg₁ _ <| by
+        else mem_cons_of_mem a <| mem_of_mem_permsOfList hg₁ <| by
               rw [eq_inv_mul_iff_mul_eq.2 hg₂, mul_apply, swap_inv, swap_apply_def]
               split_ifs <;> [exact Ne.symm hxy; exact Ne.symm hxa; exact hx]
 
@@ -99,7 +96,7 @@ theorem nodup_permsOfList : ∀ {l : List α}, l.Nodup → (permsOfList l).Nodup
     have hl' : l.Nodup := hl.of_cons
     have hln' : (permsOfList l).Nodup := nodup_permsOfList hl'
     have hmeml : ∀ {f : Perm α}, f ∈ permsOfList l → f a = a := fun {f} hf =>
-      not_not.1 (mt (mem_of_mem_permsOfList hf _) (nodup_cons.1 hl).1)
+      not_not.1 (mt (mem_of_mem_permsOfList hf) (nodup_cons.1 hl).1)
     rw [permsOfList, List.nodup_append, List.nodup_flatMap, pairwise_iff_getElem]
     refine ⟨?_, ⟨⟨?_,?_ ⟩, ?_⟩⟩
     · exact hln'
@@ -119,7 +116,7 @@ theorem nodup_permsOfList : ∀ {l : List α}, l.Nodup → (permsOfList l).Nodup
       have hgxa : g⁻¹ x = a := f.injective <| by rw [hmeml hf₁, ← hg.2]; simp
       have hxa : x ≠ a := fun h => (List.nodup_cons.1 hl).1 (h ▸ hx)
       exact (List.nodup_cons.1 hl).1 <|
-          hgxa ▸ mem_of_mem_permsOfList hg.1 _ (by rwa [apply_inv_self, hgxa])
+          hgxa ▸ mem_of_mem_permsOfList hg.1 (by rwa [apply_inv_self, hgxa])
 
 /-- Given a finset, produce the finset of all permutations of its elements. -/
 def permsOfFinset (s : Finset α) : Finset (Perm α) :=

--- a/Mathlib/Data/Fintype/Pi.lean
+++ b/Mathlib/Data/Fintype/Pi.lean
@@ -145,12 +145,13 @@ theorem Fintype.piFinset_univ {α : Type*} {β : α → Type*} [DecidableEq α] 
       (Finset.univ : Finset (∀ a, β a)) :=
   rfl
 
--- Porting note: this instance used to be computable in Lean3 and used `decidable_eq`, but
--- it makes things a lot harder to work with here. in some ways that was because in Lean3
--- we could make this instance irreducible when needed and in the worst case use `congr/convert`,
--- but those don't work with subsingletons in lean4 as-is so we cannot do this here.
+/-- There are finitely many embeddings between finite types.
+
+This instance used to be computable (using `DecidableEq` arguments), but
+it makes things a lot harder to work with here.
+-/
 noncomputable instance _root_.Function.Embedding.fintype {α β} [Fintype α] [Fintype β] :
-  Fintype (α ↪ β) := by
+    Fintype (α ↪ β) := by
   classical exact Fintype.ofEquiv _ (Equiv.subtypeInjectiveEquivEmbedding α β)
 
 instance RelHom.instFintype {α β} [Fintype α] [Fintype β] [DecidableEq α] {r : α → α → Prop}

--- a/Mathlib/Data/Fintype/Sets.lean
+++ b/Mathlib/Data/Fintype/Sets.lean
@@ -187,7 +187,7 @@ theorem toFinset_range [DecidableEq α] [Fintype β] (f : β → α) [Fintype (S
   ext
   simp
 
-@[simp] -- Porting note: new attribute
+@[simp]
 theorem toFinset_singleton (a : α) [Fintype ({a} : Set α)] : ({a} : Set α).toFinset = {a} := by
   ext
   simp

--- a/Mathlib/Data/Fintype/Vector.lean
+++ b/Mathlib/Data/Fintype/Vector.lean
@@ -17,11 +17,8 @@ variable {α : Type*}
 instance Vector.fintype [Fintype α] {n : ℕ} : Fintype (List.Vector α n) :=
   Fintype.ofEquiv _ (Equiv.vectorEquivFin _ _).symm
 
-instance [DecidableEq α] [Fintype α] {n : ℕ} : Fintype (Sym.Sym' α n) := by
-  refine @Quotient.fintype _ _ _ ?_
-  -- Porting note: had to build the instance manually
-  intros x y
-  apply List.decidablePerm
+instance [DecidableEq α] [Fintype α] {n : ℕ} : Fintype (Sym.Sym' α n) :=
+  Quotient.fintype _
 
 instance [DecidableEq α] [Fintype α] {n : ℕ} : Fintype (Sym α n) :=
   Fintype.ofEquiv _ Sym.symEquivSym'.symm

--- a/Mathlib/Data/Sym/Basic.lean
+++ b/Mathlib/Data/Sym/Basic.lean
@@ -60,6 +60,12 @@ abbrev List.Vector.Perm.isSetoid (α : Type*) (n : ℕ) : Setoid (Vector α n) :
 
 attribute [local instance] Vector.Perm.isSetoid
 
+-- Copy over the `DecidableRel` instance across the definition.
+-- (Although `List.Vector.Perm.isSetoid` is an `abbrev`, `List.isSetoid` is not.)
+instance {α : Type*} {n : ℕ} [DecidableEq α] :
+    DecidableRel (· ≈ · : List.Vector α n → List.Vector α n → Prop) :=
+  fun _ _ => List.decidablePerm _ _
+
 namespace Sym
 
 variable {α β : Type*} {n n' m : ℕ} {s : Sym α n} {a b : α}


### PR DESCRIPTION
One regression is that `induction using Fintype.induction_empty_option` does not work any more (presumably since we do induction on `ɑ` but also require a `Fintype ɑ` argument). Otherwise most of these are uninteresting.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
