### PR TITLE
[Merged by Bors] - chore(Data/(D)Finsupp): clean up porting notes

### DIFF
--- a/Mathlib/Algebra/DirectSum/Module.lean
+++ b/Mathlib/Algebra/DirectSum/Module.lean
@@ -396,8 +396,9 @@ theorem IsInternal.collectedBasis_coe (h : IsInternal A) {α : ι → Type*}
   -- convert DFinsupp.sumAddHom_single (fun i ↦ (A i).subtype.toAddMonoidHom) a.1 (v a.1 a.2)
   simp only [IsInternal.collectedBasis, coeLinearMap, Basis.coe_ofRepr, LinearEquiv.trans_symm,
     LinearEquiv.symm_symm, LinearEquiv.trans_apply, sigmaFinsuppLequivDFinsupp_apply,
-    sigmaFinsuppEquivDFinsupp_single, LinearEquiv.ofBijective_apply,
-    sigmaFinsuppAddEquivDFinsupp_apply]
+    AddEquiv.toEquiv_eq_coe, Equiv.toFun_as_coe, EquivLike.coe_coe,
+    sigmaFinsuppAddEquivDFinsupp_apply, sigmaFinsuppEquivDFinsupp_single,
+    LinearEquiv.ofBijective_apply]
   rw [DFinsupp.mapRange.linearEquiv_symm]
   -- `DFunLike.coe (β := fun x ↦ ⨁ (i : ι), ↥(A i))`
   -- appears in the goal, but the lemma is expecting

--- a/Mathlib/Data/DFinsupp/BigOperators.lean
+++ b/Mathlib/Data/DFinsupp/BigOperators.lean
@@ -192,7 +192,6 @@ theorem prod_add_index [∀ i, AddCommMonoid (β i)] [∀ (i) (x : β i), Decida
 
 @[to_additive (attr := simp)]
 theorem prod_eq_prod_fintype [Fintype ι] [∀ i, Zero (β i)] [∀ (i : ι) (x : β i), Decidable (x ≠ 0)]
-    -- Porting note: `f` was a typeclass argument
     [CommMonoid γ] (v : Π₀ i, β i) {f : ∀ i, β i → γ} (hf : ∀ i, f i 0 = 1) :
     v.prod f = ∏ i, f i (DFinsupp.equivFunOnFintype v i) := by
   suffices (∏ i ∈ v.support, f i (v i)) = ∏ i, f i (v i) by simp [DFinsupp.prod, this]
@@ -303,39 +302,36 @@ def liftAddHom [∀ i, AddZeroClass (β i)] [AddCommMonoid γ] :
   right_inv ψ := by ext; simp
   map_add' F G := by ext; simp
 
--- Porting note: The elaborator is struggling with `liftAddHom`. Passing it `β` explicitly helps.
--- This applies to roughly the remainder of the file.
-
 /-- The `DFinsupp` version of `Finsupp.liftAddHom_singleAddHom` -/
 theorem liftAddHom_singleAddHom [∀ i, AddCommMonoid (β i)] :
-    liftAddHom (β := β) (singleAddHom β) = AddMonoidHom.id (Π₀ i, β i) :=
-  (liftAddHom (β := β)).toEquiv.apply_eq_iff_eq_symm_apply.2 rfl
+    liftAddHom (singleAddHom β) = AddMonoidHom.id (Π₀ i, β i) :=
+  liftAddHom.toEquiv.apply_eq_iff_eq_symm_apply.2 rfl
 
 /-- The `DFinsupp` version of `Finsupp.liftAddHom_apply_single` -/
 theorem liftAddHom_apply_single [∀ i, AddZeroClass (β i)] [AddCommMonoid γ] (f : ∀ i, β i →+ γ)
-    (i : ι) (x : β i) : liftAddHom (β := β) f (single i x) = f i x := by simp
+    (i : ι) (x : β i) : liftAddHom f (single i x) = f i x := by simp
 
 /-- The `DFinsupp` version of `Finsupp.liftAddHom_comp_single` -/
 theorem liftAddHom_comp_single [∀ i, AddZeroClass (β i)] [AddCommMonoid γ] (f : ∀ i, β i →+ γ)
-    (i : ι) : (liftAddHom (β := β) f).comp (singleAddHom β i) = f i := by simp
+    (i : ι) : (liftAddHom f).comp (singleAddHom β i) = f i := by simp
 
 /-- The `DFinsupp` version of `Finsupp.comp_liftAddHom` -/
 theorem comp_liftAddHom {δ : Type*} [∀ i, AddZeroClass (β i)] [AddCommMonoid γ] [AddCommMonoid δ]
     (g : γ →+ δ) (f : ∀ i, β i →+ γ) :
-    g.comp (liftAddHom (β := β) f) = liftAddHom (β := β) fun a => g.comp (f a) :=
-  (liftAddHom (β := β)).symm_apply_eq.1 <|
+    g.comp (liftAddHom f) = liftAddHom fun a => g.comp (f a) :=
+  liftAddHom.symm_apply_eq.1 <|
     funext fun a => by
       rw [liftAddHom_symm_apply, AddMonoidHom.comp_assoc, liftAddHom_comp_single]
 
 @[simp]
 theorem sumAddHom_zero [∀ i, AddZeroClass (β i)] [AddCommMonoid γ] :
     (sumAddHom fun i => (0 : β i →+ γ)) = 0 :=
-  map_zero (liftAddHom (β := β))
+  map_zero liftAddHom
 
 @[simp]
 theorem sumAddHom_add [∀ i, AddZeroClass (β i)] [AddCommMonoid γ] (g : ∀ i, β i →+ γ)
     (h : ∀ i, β i →+ γ) : (sumAddHom fun i => g i + h i) = sumAddHom g + sumAddHom h :=
-  map_add (liftAddHom (β := β)) _ _
+  map_add liftAddHom _ _
 
 @[simp]
 theorem sumAddHom_singleAddHom [∀ i, AddCommMonoid (β i)] :
@@ -349,7 +345,7 @@ theorem comp_sumAddHom {δ : Type*} [∀ i, AddZeroClass (β i)] [AddCommMonoid 
 theorem sum_sub_index [∀ i, AddGroup (β i)] [∀ (i) (x : β i), Decidable (x ≠ 0)] [AddCommGroup γ]
     {f g : Π₀ i, β i} {h : ∀ i, β i → γ} (h_sub : ∀ i b₁ b₂, h i (b₁ - b₂) = h i b₁ - h i b₂) :
     (f - g).sum h = f.sum h - g.sum h := by
-  have := (liftAddHom (β := β) fun a => AddMonoidHom.ofMapSub (h a) (h_sub a)).map_sub f g
+  have := (liftAddHom fun a => AddMonoidHom.ofMapSub (h a) (h_sub a)).map_sub f g
   rw [liftAddHom_apply, sumAddHom_apply, sumAddHom_apply, sumAddHom_apply] at this
   exact this
 

--- a/Mathlib/Data/DFinsupp/Defs.lean
+++ b/Mathlib/Data/DFinsupp/Defs.lean
@@ -565,8 +565,7 @@ theorem erase_same {i : ι} {f : Π₀ i, β i} : (f.erase i) i = 0 := by simp
 
 theorem erase_ne {i i' : ι} {f : Π₀ i, β i} (h : i' ≠ i) : (f.erase i) i' = f i' := by simp [h]
 
-theorem piecewise_single_erase (x : Π₀ i, β i) (i : ι)
-    [∀ i' : ι, Decidable <| (i' ∈ ({i} : Set ι))] : -- Porting note: added Decidable hypothesis
+theorem piecewise_single_erase (x : Π₀ i, β i) (i : ι) :
     (single i (x i)).piecewise (x.erase i) {i} = x := by
   ext j; rw [piecewise_apply]; split_ifs with h
   · rw [(id h : j = i), single_eq_same]
@@ -1137,18 +1136,14 @@ section SigmaCurry
 
 variable {α : ι → Type*} {δ : ∀ i, α i → Type v}
 
--- lean can't find these instances -- Porting note: but Lean 4 can!!!
 instance hasAdd₂ [∀ i j, AddZeroClass (δ i j)] : Add (Π₀ (i : ι) (j : α i), δ i j) :=
   inferInstance
-  -- @DFinsupp.hasAdd ι (fun i => Π₀ j, δ i j) _
 
 instance addZeroClass₂ [∀ i j, AddZeroClass (δ i j)] : AddZeroClass (Π₀ (i : ι) (j : α i), δ i j) :=
   inferInstance
-  -- @DFinsupp.addZeroClass ι (fun i => Π₀ j, δ i j) _
 
 instance addMonoid₂ [∀ i j, AddMonoid (δ i j)] : AddMonoid (Π₀ (i : ι) (j : α i), δ i j) :=
   inferInstance
-  -- @DFinsupp.addMonoid ι (fun i => Π₀ j, δ i j) _
 
 end SigmaCurry
 

--- a/Mathlib/Data/DFinsupp/Interval.lean
+++ b/Mathlib/Data/DFinsupp/Interval.lean
@@ -44,7 +44,7 @@ variable [∀ i, DecidableEq (α i)]
 theorem mem_dfinsupp_iff : f ∈ s.dfinsupp t ↔ f.support ⊆ s ∧ ∀ i ∈ s, f i ∈ t i := by
   refine mem_map.trans ⟨?_, ?_⟩
   · rintro ⟨f, hf, rfl⟩
-    rw [Function.Embedding.coeFn_mk] -- Porting note: added to avoid heartbeat timeout
+    rw [Function.Embedding.coeFn_mk]
     refine ⟨support_mk_subset, fun i hi => ?_⟩
     convert mem_pi.1 hf i hi
     exact mk_of_mem hi

--- a/Mathlib/Data/DFinsupp/Lex.lean
+++ b/Mathlib/Data/DFinsupp/Lex.lean
@@ -30,12 +30,10 @@ The type synonym `Lex (Π₀ i, α i)` has an order given by `DFinsupp.Lex (· <
 protected def Lex (r : ι → ι → Prop) (s : ∀ i, α i → α i → Prop) (x y : Π₀ i, α i) : Prop :=
   Pi.Lex r (s _) x y
 
--- Porting note: Added `_root_` to match more closely with Lean 3. Also updated `s`'s type.
 theorem _root_.Pi.lex_eq_dfinsupp_lex {r : ι → ι → Prop} {s : ∀ i, α i → α i → Prop}
     (a b : Π₀ i, α i) : Pi.Lex r (s _) (a : ∀ i, α i) b = DFinsupp.Lex r s a b :=
   rfl
 
--- Porting note: Updated `s`'s type.
 theorem lex_def {r : ι → ι → Prop} {s : ∀ i, α i → α i → Prop} {a b : Π₀ i, α i} :
     DFinsupp.Lex r s a b ↔ ∃ j, (∀ d, r d j → a d = b d) ∧ s j (a j) (b j) :=
   Iff.rfl
@@ -99,11 +97,6 @@ irreducible_def Lex.decidableLE : DecidableRel (α := Lex (Π₀ i, α i)) (· �
 /-- The less-than relation for the lexicographic ordering is decidable. -/
 irreducible_def Lex.decidableLT : DecidableRel (α := Lex (Π₀ i, α i)) (· < ·) :=
   lt_trichotomy_rec (fun h ↦ isTrue h) (fun h ↦ isFalse h.not_lt) fun h ↦ isFalse h.asymm
-
--- Porting note: Added `DecidableEq` for `LinearOrder`.
-instance : DecidableEq (Lex (Π₀ i, α i)) :=
-  lt_trichotomy_rec (fun h ↦ isFalse fun h' ↦ h'.not_lt h) isTrue
-    fun h ↦ isFalse fun h' ↦ h'.symm.not_lt h
 
 /-- The linear order on `DFinsupp`s obtained by the lexicographic ordering. -/
 instance Lex.linearOrder : LinearOrder (Lex (Π₀ i, α i)) where

--- a/Mathlib/Data/DFinsupp/Order.lean
+++ b/Mathlib/Data/DFinsupp/Order.lean
@@ -49,9 +49,8 @@ def orderEmbeddingToFun : (Π₀ i, α i) ↪o ∀ i, α i where
 @[simp, norm_cast]
 lemma coe_orderEmbeddingToFun : ⇑(orderEmbeddingToFun (α := α)) = DFunLike.coe := rfl
 
--- Porting note: we added implicit arguments here in https://github.com/leanprover-community/mathlib4/pull/3414.
 theorem orderEmbeddingToFun_apply {f : Π₀ i, α i} {i : ι} :
-    (@orderEmbeddingToFun ι α _ _ f) i = f i :=
+    orderEmbeddingToFun f i = f i :=
   rfl
 
 end LE
@@ -176,9 +175,7 @@ end Module
 
 section PartialOrder
 
--- Porting note: Split into 2 lines to satisfy the unusedVariables linter.
-variable (α)
-variable [∀ i, AddCommMonoid (α i)] [∀ i, PartialOrder (α i)] [∀ i, CanonicallyOrderedAdd (α i)]
+variable (α) [∀ i, AddCommMonoid (α i)] [∀ i, PartialOrder (α i)] [∀ i, CanonicallyOrderedAdd (α i)]
 
 instance : OrderBot (Π₀ i, α i) where
   bot := 0
@@ -226,9 +223,7 @@ theorem single_le_iff {f : Π₀ i, α i} {i : ι} {a : α i} :
 
 end LE
 
--- Porting note: Split into 2 lines to satisfy the unusedVariables linter.
-variable (α)
-variable [∀ i, Sub (α i)] [∀ i, OrderedSub (α i)] {f g : Π₀ i, α i} {i : ι} {a b : α i}
+variable (α) [∀ i, Sub (α i)] [∀ i, OrderedSub (α i)] {f g : Π₀ i, α i} {i : ι} {a b : α i}
 
 /-- This is called `tsub` for truncated subtraction, to distinguish it with subtraction in an
 additive group. -/

--- a/Mathlib/Data/Finsupp/Defs.lean
+++ b/Mathlib/Data/Finsupp/Defs.lean
@@ -37,9 +37,8 @@ Most of the theory assumes that the range is a commutative additive monoid. This
 sum operator as a powerful way to construct `Finsupp` elements, which is defined in
 `Mathlib.Algebra.BigOperators.Finsupp.Basic`.
 
--- Porting note: the semireducibility remark no longer applies in Lean 4, afaict.
-Many constructions based on `α →₀ M` use `semireducible` type tags to avoid reusing unwanted type
-instances. E.g., `MonoidAlgebra`, `AddMonoidAlgebra`, and types based on these two have
+Many constructions based on `α →₀ M` are `def`s rather than `abbrev`s to avoid reusing unwanted type
+class instances. E.g., `MonoidAlgebra`, `AddMonoidAlgebra`, and types based on these two have
 non-pointwise multiplication.
 
 ## Main declarations

--- a/Mathlib/Data/Finsupp/Interval.lean
+++ b/Mathlib/Data/Finsupp/Interval.lean
@@ -58,15 +58,11 @@ open scoped Classical in
 @[simps toFun]
 def rangeIcc (f g : ι →₀ α) : ι →₀ Finset α where
   toFun i := Icc (f i) (g i)
-  support :=
-    -- Porting note: Not needed (due to open scoped Classical), in mathlib3 too
-    -- haveI := Classical.decEq ι
-    f.support ∪ g.support
+  support := f.support ∪ g.support
   mem_support_toFun i := by
     rw [mem_union, ← not_iff_not, not_or, not_mem_support_iff, not_mem_support_iff, not_ne_iff]
     exact Icc_eq_singleton_iff.symm
 
--- Porting note: Added as alternative to rangeIcc_toFun to be used in proof of card_Icc
 lemma coe_rangeIcc (f g : ι →₀ α) : rangeIcc f g i = Icc (f i) (g i) := rfl
 
 open scoped Classical in
@@ -84,9 +80,6 @@ variable [PartialOrder α] [Zero α] [LocallyFiniteOrder α] (f g : ι →₀ α
 
 open scoped Classical in
 instance instLocallyFiniteOrder : LocallyFiniteOrder (ι →₀ α) :=
-  -- Porting note: Not needed (due to open scoped Classical), in mathlib3 too
-  -- haveI := Classical.decEq ι
-  -- haveI := Classical.decEq α
   LocallyFiniteOrder.ofIcc (ι →₀ α) (fun f g => (f.support ∪ g.support).finsupp <| f.rangeIcc g)
     fun f g x => by
       refine
@@ -98,22 +91,18 @@ open scoped Classical in
 theorem Icc_eq : Icc f g = (f.support ∪ g.support).finsupp (f.rangeIcc g) := rfl
 
 open scoped Classical in
--- Porting note: removed [DecidableEq ι]
 theorem card_Icc : #(Icc f g) = ∏ i ∈ f.support ∪ g.support, #(Icc (f i) (g i)):= by
   simp_rw [Icc_eq, card_finsupp, coe_rangeIcc]
 
 open scoped Classical in
--- Porting note: removed [DecidableEq ι]
 theorem card_Ico : #(Ico f g) = ∏ i ∈ f.support ∪ g.support, #(Icc (f i) (g i)) - 1 := by
   rw [card_Ico_eq_card_Icc_sub_one, card_Icc]
 
 open scoped Classical in
--- Porting note: removed [DecidableEq ι]
 theorem card_Ioc : #(Ioc f g) = ∏ i ∈ f.support ∪ g.support, #(Icc (f i) (g i)) - 1 := by
   rw [card_Ioc_eq_card_Icc_sub_one, card_Icc]
 
 open scoped Classical in
--- Porting note: removed [DecidableEq ι]
 theorem card_Ioo : #(Ioo f g) = ∏ i ∈ f.support ∪ g.support, #(Icc (f i) (g i)) - 2 := by
   rw [card_Ioo_eq_card_Icc_sub_two, card_Icc]
 
@@ -123,7 +112,6 @@ section Lattice
 variable [Lattice α] [Zero α] [LocallyFiniteOrder α] (f g : ι →₀ α)
 
 open scoped Classical in
--- Porting note: removed [DecidableEq ι]
 theorem card_uIcc :
     #(uIcc f g) = ∏ i ∈ f.support ∪ g.support, #(uIcc (f i) (g i)) := by
   rw [← support_inf_union_support_sup]; exact card_Icc (_ : ι →₀ α) _

--- a/Mathlib/Data/Finsupp/Lex.lean
+++ b/Mathlib/Data/Finsupp/Lex.lean
@@ -30,7 +30,6 @@ The type synonym `Lex (α →₀ N)` has an order given by `Finsupp.Lex (· < ·
 protected def Lex (r : α → α → Prop) (s : N → N → Prop) (x y : α →₀ N) : Prop :=
   Pi.Lex r s x y
 
--- Porting note: Added `_root_` to better align with Lean 3.
 theorem _root_.Pi.lex_eq_finsupp_lex {r : α → α → Prop} {s : N → N → Prop} (a b : α →₀ N) :
     Pi.Lex r s a b = Finsupp.Lex r s a b :=
   rfl

--- a/Mathlib/Data/Finsupp/Multiset.lean
+++ b/Mathlib/Data/Finsupp/Multiset.lean
@@ -30,8 +30,9 @@ Under the additional assumption of `[DecidableEq α]`, this is available as
 is only needed for one direction. -/
 def toMultiset : (α →₀ ℕ) →+ Multiset α where
   toFun f := Finsupp.sum f fun a n => n • {a}
-  -- Porting note: times out if h is not specified
-  map_add' _f _g := sum_add_index' (h := fun a n => n • ({a} : Multiset α))
+  -- Porting note: have to specify `h` or add a `dsimp only` before `sum_add_index'`.
+  -- see also: https://github.com/leanprover-community/mathlib4/issues/12129
+  map_add' _f _g := sum_add_index' (h := fun _ n => n • _)
     (fun _ ↦ zero_nsmul _) (fun _ ↦ add_nsmul _)
   map_zero' := sum_zero_index
 

--- a/Mathlib/Data/Finsupp/SMul.lean
+++ b/Mathlib/Data/Finsupp/SMul.lean
@@ -194,12 +194,7 @@ variable [Monoid R] [AddMonoid M] [AddMonoid N] [DistribMulAction R M] [DistribM
 See also `Finsupp.lsingle` for the version as a linear map. -/
 def DistribMulActionHom.single (a : α) : M →+[R] α →₀ M :=
   { singleAddHom a with
-    map_smul' := fun k m => by
-      simp only
-      show singleAddHom a (k • m) = k • singleAddHom a m
-      change Finsupp.single a (k • m) = k • (Finsupp.single a m)
-      -- Porting note: because `singleAddHom_apply` is missing
-      simp only [smul_single] }
+    map_smul' := fun k m => by simp }
 
 theorem distribMulActionHom_ext {f g : (α →₀ M) →+[R] N}
     (h : ∀ (a : α) (m : M), f (single a m) = g (single a m)) : f = g :=

--- a/Mathlib/Data/Finsupp/ToDFinsupp.lean
+++ b/Mathlib/Data/Finsupp/ToDFinsupp.lean
@@ -239,11 +239,9 @@ theorem finsuppLequivDFinsupp_symm_apply [DecidableEq ι] [Semiring R] [AddCommM
     ↑(LinearEquiv.symm (finsuppLequivDFinsupp (ι := ι) (M := M) R)) = DFinsupp.toFinsupp :=
   rfl
 
--- Porting note: moved noncomputable declaration into section begin
 noncomputable section Sigma
 
 /-! ### Stronger versions of `Finsupp.split` -/
---noncomputable section
 
 variable {η : ι → Type*} {N : Type*} [Semiring R]
 
@@ -332,13 +330,7 @@ attribute [-instance] Finsupp.instAddMonoid
 @[simps]
 def sigmaFinsuppLequivDFinsupp [AddCommMonoid N] [Module R N] :
     ((Σ i, η i) →₀ N) ≃ₗ[R] Π₀ i, η i →₀ N :=
-    -- Porting note: was
-    -- sigmaFinsuppAddEquivDFinsupp with map_smul' := sigmaFinsuppEquivDFinsupp_smul
-    -- but times out
-  { sigmaFinsuppEquivDFinsupp with
-    toFun := sigmaFinsuppEquivDFinsupp
-    invFun := sigmaFinsuppEquivDFinsupp.symm
-    map_add' := sigmaFinsuppEquivDFinsupp_add
+  { sigmaFinsuppAddEquivDFinsupp with
     map_smul' := sigmaFinsuppEquivDFinsupp_smul }
 
 end Sigma


### PR DESCRIPTION
The main issue that remains is #12129: when defining structure fields, the constructor of the parent structure is not reduced away. So we need to first run `dsimp`/`beta_reduce` or add type ascriptions.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
