### PR TITLE
[Merged by Bors] - feat(Computability/TuringDegree): define oracle computability and Turing degrees

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2720,6 +2720,7 @@ import Mathlib.Computability.TMConfig
 import Mathlib.Computability.TMToPartrec
 import Mathlib.Computability.Tape
 import Mathlib.Computability.TuringMachine
+import Mathlib.Computability.TuringDegree
 import Mathlib.Condensed.AB
 import Mathlib.Condensed.Basic
 import Mathlib.Condensed.CartesianClosed

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2719,8 +2719,8 @@ import Mathlib.Computability.TMComputable
 import Mathlib.Computability.TMConfig
 import Mathlib.Computability.TMToPartrec
 import Mathlib.Computability.Tape
-import Mathlib.Computability.TuringMachine
 import Mathlib.Computability.TuringDegree
+import Mathlib.Computability.TuringMachine
 import Mathlib.Condensed.AB
 import Mathlib.Condensed.Basic
 import Mathlib.Condensed.CartesianClosed

--- a/Mathlib/Computability/TuringDegree.lean
+++ b/Mathlib/Computability/TuringDegree.lean
@@ -10,7 +10,7 @@ import Mathlib.Order.Antisymmetrization
 # Oracle Computability and Turing Degrees
 
 This file defines a model of oracle computability using partial recursive functions.
-THis file introduces Turing reducibility and equivalence, prove that Turing equivalence is an
+This file introduces Turing reducibility and equivalence, prove that Turing equivalence is an
 equivalence relation, and define Turing degrees as the quotient under this relation.
 
 ## Main Definitions
@@ -30,9 +30,9 @@ equivalence relation, and define Turing degrees as the quotient under this relat
 
 ## Implementation Notes
 
-The type of partial functions recursive in an oracle `g` is the smallest type containing
-the constant zero, the successor, projections, the oracle `g`, and is closed under
-pairing, composition, primitive recursion, and μ-recursion.
+The type of partial functions recursive in a set of oracle `O` is the smallest type containing
+the constant zero, the successor, left and right projections, each oracle `g ∈ O`,
+and is closed under pairing, composition, primitive recursion, and μ-recursion.
 
 ## References
 
@@ -50,7 +50,7 @@ open Primrec Nat.Partrec Part
 variable {f g h : ℕ →. ℕ}
 
 /--
-The type of partial functions recursive in a set of oracle `O` is the smallest type containing
+The type of partial functions recursive in a set of oracles `O` is the smallest type containing
 the constant zero, the successor, left and right projections, each oracle `g ∈ O`,
 and is closed under pairing, composition, primitive recursion, and μ-recursion.
 -/

--- a/Mathlib/Computability/TuringDegree.lean
+++ b/Mathlib/Computability/TuringDegree.lean
@@ -35,6 +35,7 @@ the constant zero, the successor, projections, the oracle `g`, and is closed und
 pairing, composition, primitive recursion, and μ-recursion.
 
 ## References
+
 * [Carneiro2018] Carneiro, Mario.
   *Formalizing Computability Theory via Partial Recursive Functions*.
   arXiv preprint arXiv:1810.08380, 2018.
@@ -45,17 +46,13 @@ pairing, composition, primitive recursion, and μ-recursion.
 * [Gu2015] Gu, Yi-Zhi. *Turing Degrees*. Institute for Advanced Study, 2015.
 
 ## Tags
+
 Computability, Oracle, Turing Degrees, Reducibility, Equivalence Relation
 -/
+
 open Primrec Nat.Partrec Part
 
 variable {f g h : ℕ →. ℕ}
-
-/-!
-This section defines a model of oracle computability and defines
-Turing reducibility and Turing equivalence. We define the Turing Degrees as the quotient under
-Turing equivalence relation
--/
 
 /--
 The type of partial functions recursive in a set of oracle `O` is the smallest type containing

--- a/Mathlib/Computability/TuringDegree.lean
+++ b/Mathlib/Computability/TuringDegree.lean
@@ -1,0 +1,217 @@
+/-
+Copyright (c) 2025 Tanner Duve. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Tanner Duve, Elan Roth
+-/
+import Mathlib.Computability.Partrec
+import Mathlib.Order.Antisymmetrization
+
+/-!
+# Oracle Computability and Turing Degrees
+
+This file defines a model of oracle computability, introduces Turing reducibility and equivalence,
+proves that Turing equivalence is an equivalence relation, and defines Turing degrees as the
+quotient under this relation.
+
+## Main Definitions
+
+- `RecursiveIn O f`:
+  An inductive definition representing that a partial function `f` is partial recursive given access
+  to a set of oracles O.
+- `TuringReducible`: A relation defining Turing reducibility between partial functions.
+- `TuringEquivalent`: An equivalence relation defining Turing equivalence between partial functions.
+- `TuringDegree`: The type of Turing degrees, defined as the quotient of partial functions under
+  `TuringEquivalent`.
+
+## Notation
+
+- `f ≤ᵀ g` : `f` is Turing reducible to `g`.
+- `f ≡ᵀ g` : `f` is Turing equivalent to `g`.
+
+## Implementation Notes
+
+The type of partial functions recursive in an oracle `g` is the smallest type containing
+the constant zero, the successor, projections, the oracle `g`, and is closed under
+pairing, composition, primitive recursion, and μ-recursion.
+
+## References
+* [Carneiro2018] Carneiro, Mario.
+  *Formalizing Computability Theory via Partial Recursive Functions*.
+  arXiv preprint arXiv:1810.08380, 2018.
+* [Odifreddi1989] Odifreddi, Piergiorgio.
+  *Classical Recursion Theory: The Theory of Functions and Sets of Natural Numbers,
+  Vol. I*. Springer-Verlag, 1989.
+* [Soare1987] Soare, Robert I. *Recursively Enumerable Sets and Degrees*. Springer-Verlag, 1987.
+* [Gu2015] Gu, Yi-Zhi. *Turing Degrees*. Institute for Advanced Study, 2015.
+
+## Tags
+Computability, Oracle, Turing Degrees, Reducibility, Equivalence Relation
+-/
+open Primrec Nat.Partrec Part
+
+variable {f g h : ℕ →. ℕ}
+
+/-!
+This section defines a model of oracle computability and defines
+Turing reducibility and Turing equivalence. We define the Turing Degrees as the quotient under
+Turing equivalence relation
+-/
+
+/--
+The type of partial functions recursive in a set of oracle `O` is the smallest type containing
+the constant zero, the successor, left and right projections, each oracle `g ∈ O`,
+and is closed under pairing, composition, primitive recursion, and μ-recursion.
+-/
+inductive RecursiveIn (O : Set (ℕ →. ℕ)) : (ℕ →. ℕ) → Prop
+  | zero : RecursiveIn O fun _ => 0
+  | succ : RecursiveIn O Nat.succ
+  | left : RecursiveIn O fun n => (Nat.unpair n).1
+  | right : RecursiveIn O fun n => (Nat.unpair n).2
+  | oracle : ∀ g ∈ O, RecursiveIn O g
+  | pair {f h : ℕ →. ℕ} (hf : RecursiveIn O f) (hh : RecursiveIn O h) :
+      RecursiveIn O fun n => (Nat.pair <$> f n <*> h n)
+  | comp {f h : ℕ →. ℕ} (hf : RecursiveIn O f) (hh : RecursiveIn O h) :
+      RecursiveIn O fun n => h n >>= f
+  | prec {f h : ℕ →. ℕ} (hf : RecursiveIn O f) (hh : RecursiveIn O h) :
+      RecursiveIn O fun p =>
+        let (a, n) := Nat.unpair p
+        n.rec (f a) fun y IH => do
+          let i ← IH
+          h (Nat.pair a (Nat.pair y i))
+  | rfind {f : ℕ →. ℕ} (hf : RecursiveIn O f) :
+      RecursiveIn O fun a =>
+        Nat.rfind fun n => (fun m => m = 0) <$> f (Nat.pair a n)
+/--
+`f` is turing reducible to `g` if `f` is partial recursive given access to the oracle `g`
+-/
+abbrev TuringReducible (f g : ℕ →. ℕ) : Prop :=
+  RecursiveIn {g} f
+
+/--
+`f` is Turing equivalent to `g` if `f` is reducible to `g` and `g` is reducible to `f`.
+-/
+abbrev TuringEquivalent (f g : ℕ →. ℕ) : Prop :=
+  AntisymmRel TuringReducible f g
+
+@[inherit_doc] scoped[Computability] infix:50 " ≤ᵀ " => TuringReducible
+@[inherit_doc] scoped[Computability] infix:50 "≡ᵀ" => TuringEquivalent
+
+open scoped Computability
+
+/--
+If a function is partial recursive, then it is recursive in every partial function.
+-/
+lemma Nat.Partrec.turingReducible (pF : Nat.Partrec f) : f ≤ᵀ g := by
+  induction' pF with f' g' _ _ ih₁ ih₂ f' g' _ _ ih₁ ih₂ f' g' _ _ ih₁ ih₂ f' _ ih
+  repeat {constructor}
+  · case pair =>
+    apply RecursiveIn.pair ih₁ ih₂
+  · case comp =>
+    apply RecursiveIn.comp ih₁ ih₂
+  · case prec =>
+    apply RecursiveIn.prec ih₁ ih₂
+  · case rfind =>
+    apply RecursiveIn.rfind ih
+
+/--
+If a function is recursive in the constant zero function,
+then it is partial recursive.
+-/
+lemma TuringReducible.partrec_of_zero (fRecInZero : f ≤ᵀ fun _ => Part.some 0) : Nat.Partrec f := by
+  induction' fRecInZero with g hg g h _ _ ih₁ ih₂ g h _ _ ih₁ ih₂ g h _ _ ih₁ ih₂ g _ ih
+  repeat {constructor}
+  · rw [Set.mem_singleton_iff] at hg; rw [hg];
+    exact Nat.Partrec.zero
+  repeat {constructor; assumption; try assumption}
+
+/--
+A partial function `f` is partial recursive if and only if it is recursive in
+every partial function `g`.
+-/
+theorem partrec_iff_forall_turingReducible : Nat.Partrec f ↔ ∀ g, f ≤ᵀ g :=
+  ⟨fun hf _ ↦ hf.turingReducible, (· _ |>.partrec_of_zero)⟩
+
+protected theorem TuringReducible.refl (f : ℕ →. ℕ) : f ≤ᵀ f := .oracle _ <| by simp
+protected theorem TuringReducible.rfl : f ≤ᵀ f := .refl _
+
+instance : IsRefl (ℕ →. ℕ) TuringReducible where refl _ := .rfl
+
+theorem TuringReducible.trans (hg : f ≤ᵀ g) (hh : g ≤ᵀ h) : f ≤ᵀ h := by
+  induction' hg with g' hg g' h' _ _ ih₁ ih₂ g' h' _ _ ih₁ ih₂ g' h' _ _ ih₁ ih₂ g' _ ih
+  repeat {constructor}
+  · rw [Set.mem_singleton_iff] at hg; rw [hg]; exact hh
+  · case pair =>
+    apply RecursiveIn.pair ih₁ ih₂
+  · case comp =>
+    apply RecursiveIn.comp ih₁ ih₂
+  · case prec =>
+    apply RecursiveIn.prec ih₁ ih₂
+  · case rfind =>
+    apply RecursiveIn.rfind ih
+
+instance : IsTrans (ℕ →. ℕ) TuringReducible :=
+  ⟨@TuringReducible.trans⟩
+
+instance : IsPreorder (ℕ →. ℕ) TuringReducible where
+  refl := .refl
+
+theorem TuringEquivalent.equivalence : Equivalence TuringEquivalent :=
+  (AntisymmRel.setoid _ _).iseqv
+
+@[refl]
+protected theorem TuringEquivalent.refl (f : ℕ →. ℕ) : f ≡ᵀ f :=
+  Equivalence.refl equivalence f
+
+@[symm]
+theorem TuringEquivalent.symm {f g : ℕ →. ℕ} (h : f ≡ᵀ g) : g ≡ᵀ f :=
+  Equivalence.symm equivalence h
+
+@[trans]
+theorem TuringEquivalent.trans (f g h : ℕ →. ℕ) (h₁ : f ≡ᵀ g) (h₂ : g ≡ᵀ h) : f ≡ᵀ h :=
+  Equivalence.trans equivalence h₁ h₂
+
+/--
+Instance declaring that `RecursiveIn` is a preorder.
+-/
+instance : IsPreorder (ℕ →. ℕ) TuringReducible where
+  refl := TuringReducible.refl
+  trans := @TuringReducible.trans
+
+/--
+Turing degrees are the equivalence classes of partial functions under Turing equivalence.
+-/
+abbrev TuringDegree :=
+  Antisymmetrization _ TuringReducible
+
+private instance : Preorder (ℕ →. ℕ) where
+  le := TuringReducible
+  le_refl := .refl
+  le_trans _ _ _ := TuringReducible.trans
+
+instance TuringDegree.instPartialOrder : PartialOrder TuringDegree :=
+  instPartialOrderAntisymmetrization
+
+@[simp] lemma recursiveIn_empty_iff_partrec : RecursiveIn {} f ↔ Nat.Partrec f  where
+  mp fRecInNone := by
+    induction' fRecInNone with g hg g h _ _ ih₁ ih₂ g h _ _ ih₁ ih₂ g h _ _ ih₁ ih₂ g _ ih
+    repeat {constructor}
+    · simp at hg
+    repeat {constructor; assumption; try assumption}
+  mpr pF := by
+    induction' pF with f' g' _ _ ih₁ ih₂ f' g' _ _ ih₁ ih₂ f' g' _ _ ih₁ ih₂ f' _ ih
+    repeat {constructor}
+    · case pair =>
+      apply RecursiveIn.pair ih₁ ih₂
+    · case comp =>
+      apply RecursiveIn.comp ih₁ ih₂
+    · case prec =>
+      apply RecursiveIn.prec ih₁ ih₂
+    · case rfind =>
+      apply RecursiveIn.rfind ih
+
+/--
+An alternative definition of partial recursive in terms of oracle computability:
+A partial recursive function is a function which is recursive in the empty set
+-/
+example (f : ℕ →. ℕ) : Prop :=
+  RecursiveIn {} f

--- a/Mathlib/Computability/TuringDegree.lean
+++ b/Mathlib/Computability/TuringDegree.lean
@@ -9,9 +9,9 @@ import Mathlib.Order.Antisymmetrization
 /-!
 # Oracle Computability and Turing Degrees
 
-This file defines a model of oracle computability, introduces Turing reducibility and equivalence,
-proves that Turing equivalence is an equivalence relation, and defines Turing degrees as the
-quotient under this relation.
+This file defines a model of oracle computability using partial recursive functions.
+THis file introduces Turing reducibility and equivalence, prove that Turing equivalence is an
+equivalence relation, and define Turing degrees as the quotient under this relation.
 
 ## Main Definitions
 
@@ -36,14 +36,9 @@ pairing, composition, primitive recursion, and μ-recursion.
 
 ## References
 
-* [Carneiro2018] Carneiro, Mario.
-  *Formalizing Computability Theory via Partial Recursive Functions*.
-  arXiv preprint arXiv:1810.08380, 2018.
 * [Odifreddi1989] Odifreddi, Piergiorgio.
   *Classical Recursion Theory: The Theory of Functions and Sets of Natural Numbers,
   Vol. I*. Springer-Verlag, 1989.
-* [Soare1987] Soare, Robert I. *Recursively Enumerable Sets and Degrees*. Springer-Verlag, 1987.
-* [Gu2015] Gu, Yi-Zhi. *Turing Degrees*. Institute for Advanced Study, 2015.
 
 ## Tags
 
@@ -79,7 +74,7 @@ inductive RecursiveIn (O : Set (ℕ →. ℕ)) : (ℕ →. ℕ) → Prop
       RecursiveIn O fun a =>
         Nat.rfind fun n => (fun m => m = 0) <$> f (Nat.pair a n)
 /--
-`f` is turing reducible to `g` if `f` is partial recursive given access to the oracle `g`
+`f` is Turing reducible to `g` if `f` is partial recursive given access to the oracle `g`
 -/
 abbrev TuringReducible (f g : ℕ →. ℕ) : Prop :=
   RecursiveIn {g} f
@@ -205,10 +200,3 @@ instance TuringDegree.instPartialOrder : PartialOrder TuringDegree :=
       apply RecursiveIn.prec ih₁ ih₂
     · case rfind =>
       apply RecursiveIn.rfind ih
-
-/--
-An alternative definition of partial recursive in terms of oracle computability:
-A partial recursive function is a function which is recursive in the empty set
--/
-example (f : ℕ →. ℕ) : Prop :=
-  RecursiveIn {} f

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -3298,6 +3298,17 @@
   doi           = {10.1112/jlms/s1-29.2.236}
 }
 
+@Book{            odifreddi1989,
+  author        = {Piergiorgio Odifreddi},
+  title         = {Classical Recursion Theory: The Theory of Functions and Sets of Natural Numbers},
+  publisher     = {Elsevier Science Publishing Co., Inc.},
+  address       = {New York, N.Y., USA},
+  year          = {1989},
+  isbn          = {9780444872951},
+  note          = {Studies in Logic and the Foundations of Mathematics, Vol. 125},
+  doi           = {10.2307/2274492}
+}
+
 @Book{            Okninski1991,
   place         = {New York},
   title         = {Semigroup algebras},

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -3300,12 +3300,14 @@
 
 @Book{            odifreddi1989,
   author        = {Piergiorgio Odifreddi},
-  title         = {Classical Recursion Theory: The Theory of Functions and Sets of Natural Numbers},
+  title         = {Classical Recursion Theory: The Theory of Functions and
+                  Sets of Natural Numbers},
   publisher     = {Elsevier Science Publishing Co., Inc.},
   address       = {New York, N.Y., USA},
   year          = {1989},
   isbn          = {9780444872951},
-  note          = {Studies in Logic and the Foundations of Mathematics, Vol. 125},
+  note          = {Studies in Logic and the Foundations of Mathematics, Vol.
+                  125},
   doi           = {10.2307/2274492}
 }
 


### PR DESCRIPTION
Define a model of **oracle computability**, introducing Turing reducibility (`≤ᵀ`), Turing equivalence (`≡ᵀ`), and Turing degrees as the quotient under Turing equivalence.

- `RecursiveIn O f`: A function `f` is recursive in a set of oracles `O` if it can be computed using `O` via basic operations (zero, successor, pairing, composition, primitive recursion, and μ-recursion).
- `TuringReducible`: The relation that `f` is recursive in `{g}`, i.e., `f ≤ᵀ g`.
- `TuringEquivalent`: A relation defining Turing equivalence between partial functions.
- `TuringDegree`: The set of equivalence classes under `TuringEquivalent`, forming a **partially ordered structure**.

Additionally:
- Prove that `TuringReducible` is a **preorder** (reflexive, transitive).
- Show that `TuringEquivalent` is an **equivalence relation**.
- Establish that **partial recursive functions** correspond to functions recursive in the empty oracle set.

This formalization follows classical recursion theory (Odifreddi, Soare) and extends previous work by Carneiro.

Co-authored-by: Elan Roth

---

### Breaking Changes
None.

### Dependencies
None.