### PR TITLE
[Merged by Bors] - ci: put cache cleanup step after lean is installed

### DIFF
--- a/.github/build.in.yml
+++ b/.github/build.in.yml
@@ -137,7 +137,7 @@ jobs:
           # Check if size exceeds 10GB
           if [ "$DIR_SIZE" -gt "10737418240" ]; then
             echo "Cache size exceeds threshold, running lake exe cache clean"
-            lake exe cache clean
+            lake exe cache clean || echo "lake did not work"
           fi
 
       - name: build cache

--- a/.github/build.in.yml
+++ b/.github/build.in.yml
@@ -94,27 +94,6 @@ jobs:
               : # Do nothing on failure, but suppress errors
           fi
 
-      - name: cleanup .cache/mathlib
-        run: |
-          # Define the cache directory path
-          CACHE_DIR="$HOME/.cache/mathlib"
-
-          # Check if directory exists
-          if [ ! -d "$CACHE_DIR" ]; then
-            echo "::warning::Cache directory does not exist: $CACHE_DIR"
-            exit 0
-          fi
-
-          # Calculate directory size in bytes
-          DIR_SIZE=$(du -sb "$CACHE_DIR" | cut -f1)
-          printf 'Cache size (in bytes): %s\n' "$DIR_SIZE"
-
-          # Check if size exceeds 10GB
-          if [ "$DIR_SIZE" -gt "10737418240" ]; then
-            echo "Cache size exceeds threshold, running lake exe cache clean"
-            lake exe cache clean
-          fi
-
       # The Hoskinson runners may not have jq installed, so do that now.
       - name: 'Setup jq'
         uses: dcarbone/install-jq-action@v2.1.0
@@ -139,6 +118,27 @@ jobs:
         run: |
           lean --version
           lake --version
+
+      - name: cleanup .cache/mathlib
+        run: |
+          # Define the cache directory path
+          CACHE_DIR="$HOME/.cache/mathlib"
+
+          # Check if directory exists
+          if [ ! -d "$CACHE_DIR" ]; then
+            echo "::warning::Cache directory does not exist: $CACHE_DIR"
+            exit 0
+          fi
+
+          # Calculate directory size in bytes
+          DIR_SIZE=$(du -sb "$CACHE_DIR" | cut -f1)
+          printf 'Cache size (in bytes): %s\n' "$DIR_SIZE"
+
+          # Check if size exceeds 10GB
+          if [ "$DIR_SIZE" -gt "10737418240" ]; then
+            echo "Cache size exceeds threshold, running lake exe cache clean"
+            lake exe cache clean
+          fi
 
       - name: build cache
         run: |

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -147,7 +147,7 @@ jobs:
           # Check if size exceeds 10GB
           if [ "$DIR_SIZE" -gt "10737418240" ]; then
             echo "Cache size exceeds threshold, running lake exe cache clean"
-            lake exe cache clean
+            lake exe cache clean || echo "lake did not work"
           fi
 
       - name: build cache

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -104,27 +104,6 @@ jobs:
               : # Do nothing on failure, but suppress errors
           fi
 
-      - name: cleanup .cache/mathlib
-        run: |
-          # Define the cache directory path
-          CACHE_DIR="$HOME/.cache/mathlib"
-
-          # Check if directory exists
-          if [ ! -d "$CACHE_DIR" ]; then
-            echo "::warning::Cache directory does not exist: $CACHE_DIR"
-            exit 0
-          fi
-
-          # Calculate directory size in bytes
-          DIR_SIZE=$(du -sb "$CACHE_DIR" | cut -f1)
-          printf 'Cache size (in bytes): %s\n' "$DIR_SIZE"
-
-          # Check if size exceeds 10GB
-          if [ "$DIR_SIZE" -gt "10737418240" ]; then
-            echo "Cache size exceeds threshold, running lake exe cache clean"
-            lake exe cache clean
-          fi
-
       # The Hoskinson runners may not have jq installed, so do that now.
       - name: 'Setup jq'
         uses: dcarbone/install-jq-action@v2.1.0
@@ -149,6 +128,27 @@ jobs:
         run: |
           lean --version
           lake --version
+
+      - name: cleanup .cache/mathlib
+        run: |
+          # Define the cache directory path
+          CACHE_DIR="$HOME/.cache/mathlib"
+
+          # Check if directory exists
+          if [ ! -d "$CACHE_DIR" ]; then
+            echo "::warning::Cache directory does not exist: $CACHE_DIR"
+            exit 0
+          fi
+
+          # Calculate directory size in bytes
+          DIR_SIZE=$(du -sb "$CACHE_DIR" | cut -f1)
+          printf 'Cache size (in bytes): %s\n' "$DIR_SIZE"
+
+          # Check if size exceeds 10GB
+          if [ "$DIR_SIZE" -gt "10737418240" ]; then
+            echo "Cache size exceeds threshold, running lake exe cache clean"
+            lake exe cache clean
+          fi
 
       - name: build cache
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -154,7 +154,7 @@ jobs:
           # Check if size exceeds 10GB
           if [ "$DIR_SIZE" -gt "10737418240" ]; then
             echo "Cache size exceeds threshold, running lake exe cache clean"
-            lake exe cache clean
+            lake exe cache clean || echo "lake did not work"
           fi
 
       - name: build cache

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,27 +111,6 @@ jobs:
               : # Do nothing on failure, but suppress errors
           fi
 
-      - name: cleanup .cache/mathlib
-        run: |
-          # Define the cache directory path
-          CACHE_DIR="$HOME/.cache/mathlib"
-
-          # Check if directory exists
-          if [ ! -d "$CACHE_DIR" ]; then
-            echo "::warning::Cache directory does not exist: $CACHE_DIR"
-            exit 0
-          fi
-
-          # Calculate directory size in bytes
-          DIR_SIZE=$(du -sb "$CACHE_DIR" | cut -f1)
-          printf 'Cache size (in bytes): %s\n' "$DIR_SIZE"
-
-          # Check if size exceeds 10GB
-          if [ "$DIR_SIZE" -gt "10737418240" ]; then
-            echo "Cache size exceeds threshold, running lake exe cache clean"
-            lake exe cache clean
-          fi
-
       # The Hoskinson runners may not have jq installed, so do that now.
       - name: 'Setup jq'
         uses: dcarbone/install-jq-action@v2.1.0
@@ -156,6 +135,27 @@ jobs:
         run: |
           lean --version
           lake --version
+
+      - name: cleanup .cache/mathlib
+        run: |
+          # Define the cache directory path
+          CACHE_DIR="$HOME/.cache/mathlib"
+
+          # Check if directory exists
+          if [ ! -d "$CACHE_DIR" ]; then
+            echo "::warning::Cache directory does not exist: $CACHE_DIR"
+            exit 0
+          fi
+
+          # Calculate directory size in bytes
+          DIR_SIZE=$(du -sb "$CACHE_DIR" | cut -f1)
+          printf 'Cache size (in bytes): %s\n' "$DIR_SIZE"
+
+          # Check if size exceeds 10GB
+          if [ "$DIR_SIZE" -gt "10737418240" ]; then
+            echo "Cache size exceeds threshold, running lake exe cache clean"
+            lake exe cache clean
+          fi
 
       - name: build cache
         run: |

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -108,27 +108,6 @@ jobs:
               : # Do nothing on failure, but suppress errors
           fi
 
-      - name: cleanup .cache/mathlib
-        run: |
-          # Define the cache directory path
-          CACHE_DIR="$HOME/.cache/mathlib"
-
-          # Check if directory exists
-          if [ ! -d "$CACHE_DIR" ]; then
-            echo "::warning::Cache directory does not exist: $CACHE_DIR"
-            exit 0
-          fi
-
-          # Calculate directory size in bytes
-          DIR_SIZE=$(du -sb "$CACHE_DIR" | cut -f1)
-          printf 'Cache size (in bytes): %s\n' "$DIR_SIZE"
-
-          # Check if size exceeds 10GB
-          if [ "$DIR_SIZE" -gt "10737418240" ]; then
-            echo "Cache size exceeds threshold, running lake exe cache clean"
-            lake exe cache clean
-          fi
-
       # The Hoskinson runners may not have jq installed, so do that now.
       - name: 'Setup jq'
         uses: dcarbone/install-jq-action@v2.1.0
@@ -153,6 +132,27 @@ jobs:
         run: |
           lean --version
           lake --version
+
+      - name: cleanup .cache/mathlib
+        run: |
+          # Define the cache directory path
+          CACHE_DIR="$HOME/.cache/mathlib"
+
+          # Check if directory exists
+          if [ ! -d "$CACHE_DIR" ]; then
+            echo "::warning::Cache directory does not exist: $CACHE_DIR"
+            exit 0
+          fi
+
+          # Calculate directory size in bytes
+          DIR_SIZE=$(du -sb "$CACHE_DIR" | cut -f1)
+          printf 'Cache size (in bytes): %s\n' "$DIR_SIZE"
+
+          # Check if size exceeds 10GB
+          if [ "$DIR_SIZE" -gt "10737418240" ]; then
+            echo "Cache size exceeds threshold, running lake exe cache clean"
+            lake exe cache clean
+          fi
 
       - name: build cache
         run: |

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -151,7 +151,7 @@ jobs:
           # Check if size exceeds 10GB
           if [ "$DIR_SIZE" -gt "10737418240" ]; then
             echo "Cache size exceeds threshold, running lake exe cache clean"
-            lake exe cache clean
+            lake exe cache clean || echo "lake did not work"
           fi
 
       - name: build cache


### PR DESCRIPTION
Followup to #22863. The current workflow breaks builds because `lake` is not installed yet.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
