### PR TITLE
[Merged by Bors] - feat: add versions of the Lebesgue number lemma

### DIFF
--- a/Mathlib/Topology/Compactness/Compact.lean
+++ b/Mathlib/Topology/Compactness/Compact.lean
@@ -202,6 +202,13 @@ theorem IsCompact.elim_nhds_subcover (hs : IsCompact s) (U : X → Set X) (hU : 
     ∃ t : Finset X, (∀ x ∈ t, x ∈ s) ∧ s ⊆ ⋃ x ∈ t, U x :=
   (hs.elim_nhds_subcover_nhdsSet hU).imp fun _ h ↦ h.imp_right subset_of_mem_nhdsSet
 
+theorem IsCompact.elim_nhdsWithin_subcover (hs : IsCompact s) (U : X → Set X)
+    (hU : ∀ x ∈ s, U x ∈ 𝓝[s] x) : ∃ t : Finset X, (∀ x ∈ t, x ∈ s) ∧ s ⊆ ⋃ x ∈ t, U x := by
+  choose! V V_nhds hV using fun x hx => mem_nhdsWithin_iff_exists_mem_nhds_inter.1 (hU x hx)
+  rcases hs.elim_nhds_subcover V V_nhds with ⟨t, t_sub_s, ht⟩
+  refine ⟨t, t_sub_s, subset_trans ?_ (biUnion_mono (fun _ => id) fun x hx => hV x (t_sub_s x hx))⟩
+  simpa [← iUnion_inter]
+
 /-- The neighborhood filter of a compact set is disjoint with a filter `l` if and only if the
 neighborhood filter of each point of this set is disjoint with `l`. -/
 theorem IsCompact.disjoint_nhdsSet_left {l : Filter X} (hs : IsCompact s) :

--- a/Mathlib/Topology/Compactness/Compact.lean
+++ b/Mathlib/Topology/Compactness/Compact.lean
@@ -202,6 +202,13 @@ theorem IsCompact.elim_nhds_subcover (hs : IsCompact s) (U : X → Set X) (hU : 
     ∃ t : Finset X, (∀ x ∈ t, x ∈ s) ∧ s ⊆ ⋃ x ∈ t, U x :=
   (hs.elim_nhds_subcover_nhdsSet hU).imp fun _ h ↦ h.imp_right subset_of_mem_nhdsSet
 
+theorem IsCompact.elim_nhdsWithin_subcover' (hs : IsCompact s) (U : ∀ x ∈ s, Set X)
+    (hU : ∀ x (hx : x ∈ s), U x hx ∈ 𝓝[s] x) : ∃ t : Finset s, s ⊆ ⋃ x ∈ t, U x x.2 := by
+  choose V V_nhds hV using fun x hx => mem_nhdsWithin_iff_exists_mem_nhds_inter.1 (hU x hx)
+  rcases hs.elim_nhds_subcover' V V_nhds with ⟨t, ht⟩
+  refine ⟨t, subset_trans ?_ (biUnion_mono (fun _ => id) fun x _ => hV x x.2)⟩
+  simpa [← iUnion_inter, ← iUnion_coe_set]
+
 theorem IsCompact.elim_nhdsWithin_subcover (hs : IsCompact s) (U : X → Set X)
     (hU : ∀ x ∈ s, U x ∈ 𝓝[s] x) : ∃ t : Finset X, (∀ x ∈ t, x ∈ s) ∧ s ⊆ ⋃ x ∈ t, U x := by
   choose! V V_nhds hV using fun x hx => mem_nhdsWithin_iff_exists_mem_nhds_inter.1 (hU x hx)

--- a/Mathlib/Topology/Compactness/Compact.lean
+++ b/Mathlib/Topology/Compactness/Compact.lean
@@ -202,20 +202,6 @@ theorem IsCompact.elim_nhds_subcover (hs : IsCompact s) (U : X → Set X) (hU : 
     ∃ t : Finset X, (∀ x ∈ t, x ∈ s) ∧ s ⊆ ⋃ x ∈ t, U x :=
   (hs.elim_nhds_subcover_nhdsSet hU).imp fun _ h ↦ h.imp_right subset_of_mem_nhdsSet
 
-theorem IsCompact.elim_nhdsWithin_subcover' (hs : IsCompact s) (U : ∀ x ∈ s, Set X)
-    (hU : ∀ x (hx : x ∈ s), U x hx ∈ 𝓝[s] x) : ∃ t : Finset s, s ⊆ ⋃ x ∈ t, U x x.2 := by
-  choose V V_nhds hV using fun x hx => mem_nhdsWithin_iff_exists_mem_nhds_inter.1 (hU x hx)
-  rcases hs.elim_nhds_subcover' V V_nhds with ⟨t, ht⟩
-  refine ⟨t, subset_trans ?_ (biUnion_mono (fun _ => id) fun x _ => hV x x.2)⟩
-  simpa [← iUnion_inter, ← iUnion_coe_set]
-
-theorem IsCompact.elim_nhdsWithin_subcover (hs : IsCompact s) (U : X → Set X)
-    (hU : ∀ x ∈ s, U x ∈ 𝓝[s] x) : ∃ t : Finset X, (∀ x ∈ t, x ∈ s) ∧ s ⊆ ⋃ x ∈ t, U x := by
-  choose! V V_nhds hV using fun x hx => mem_nhdsWithin_iff_exists_mem_nhds_inter.1 (hU x hx)
-  rcases hs.elim_nhds_subcover V V_nhds with ⟨t, t_sub_s, ht⟩
-  refine ⟨t, t_sub_s, subset_trans ?_ (biUnion_mono (fun _ => id) fun x hx => hV x (t_sub_s x hx))⟩
-  simpa [← iUnion_inter]
-
 /-- The neighborhood filter of a compact set is disjoint with a filter `l` if and only if the
 neighborhood filter of each point of this set is disjoint with `l`. -/
 theorem IsCompact.disjoint_nhdsSet_left {l : Filter X} (hs : IsCompact s) :

--- a/Mathlib/Topology/EMetricSpace/Basic.lean
+++ b/Mathlib/Topology/EMetricSpace/Basic.lean
@@ -6,6 +6,7 @@ Authors: Jeremy Avigad, Robert Y. Lewis, Johannes Hölzl, Mario Carneiro, Sébas
 import Mathlib.Algebra.Order.BigOperators.Group.Finset
 import Mathlib.Order.Interval.Finset.Nat
 import Mathlib.Topology.EMetricSpace.Defs
+import Mathlib.Topology.UniformSpace.Compact
 import Mathlib.Topology.UniformSpace.UniformConvergence
 import Mathlib.Topology.UniformSpace.UniformEmbedding
 
@@ -328,3 +329,12 @@ theorem IsSeparable.separableSpace {s : Set α} (hs : IsSeparable s) :
 end Compact
 
 end TopologicalSpace
+
+theorem lebesgue_number_lemma_of_emetric {s : Set α} {ι : Sort*} {c : ι → Set α} (hs : IsCompact s)
+    (hc₁ : ∀ i, IsOpen (c i)) (hc₂ : s ⊆ ⋃ i, c i) : ∃ δ > 0, ∀ x ∈ s, ∃ i, ball x δ ⊆ c i := by
+  simpa only [ball, UniformSpace.ball, preimage_setOf_eq, edist_comm]
+    using uniformity_basis_edist.lebesgue_number_lemma hs hc₁ hc₂
+
+theorem lebesgue_number_lemma_of_emetric_sUnion {s : Set α} {c : Set (Set α)} (hs : IsCompact s)
+    (hc₁ : ∀ t ∈ c, IsOpen t) (hc₂ : s ⊆ ⋃₀ c) : ∃ δ > 0, ∀ x ∈ s, ∃ t ∈ c, ball x δ ⊆ t := by
+  rw [sUnion_eq_iUnion] at hc₂; simpa using lebesgue_number_lemma_of_emetric hs (by simpa) hc₂

--- a/Mathlib/Topology/EMetricSpace/Basic.lean
+++ b/Mathlib/Topology/EMetricSpace/Basic.lean
@@ -339,23 +339,23 @@ theorem lebesgue_number_lemma_of_emetric {ι : Sort*} {c : ι → Set α} (hs : 
   simpa only [ball, UniformSpace.ball, preimage_setOf_eq, edist_comm]
     using uniformity_basis_edist.lebesgue_number_lemma hs hc₁ hc₂
 
-theorem lebesgue_number_lemma_nhds_of_emetric' {c : (x : α) → x ∈ s → Set α} (hs : IsCompact s)
+theorem lebesgue_number_lemma_of_emetric_nhds' {c : (x : α) → x ∈ s → Set α} (hs : IsCompact s)
     (hc : ∀ x hx, c x hx ∈ 𝓝 x) : ∃ δ > 0, ∀ x ∈ s, ∃ y : s, ball x δ ⊆ c y y.2 := by
   simpa only [ball, UniformSpace.ball, preimage_setOf_eq, edist_comm]
     using uniformity_basis_edist.lebesgue_number_lemma_nhds' hs hc
 
-theorem lebesgue_number_lemma_nhds_of_emetric {c : α → Set α} (hs : IsCompact s)
+theorem lebesgue_number_lemma_of_emetric_nhds {c : α → Set α} (hs : IsCompact s)
   (hc : ∀ x ∈ s, c x ∈ 𝓝 x) : ∃ δ > 0, ∀ x ∈ s, ∃ y, ball x δ ⊆ c y := by
   simpa only [ball, UniformSpace.ball, preimage_setOf_eq, edist_comm]
     using uniformity_basis_edist.lebesgue_number_lemma_nhds hs hc
 
-theorem lebesgue_number_lemma_nhdsWithin_of_emetric' {c : (x : α) → x ∈ s → Set α}
+theorem lebesgue_number_lemma_of_emetric_nhdsWithin' {c : (x : α) → x ∈ s → Set α}
     (hs : IsCompact s) (hc : ∀ x hx, c x hx ∈ 𝓝[s] x) :
     ∃ δ > 0, ∀ x ∈ s, ∃ y : s, ball x δ ∩ s ⊆ c y y.2 := by
   simpa only [ball, UniformSpace.ball, preimage_setOf_eq, edist_comm]
     using uniformity_basis_edist.lebesgue_number_lemma_nhdsWithin' hs hc
 
-theorem lebesgue_number_lemma_nhdsWithin_of_emetric {c : α → Set α} (hs : IsCompact s)
+theorem lebesgue_number_lemma_of_emetric_nhdsWithin {c : α → Set α} (hs : IsCompact s)
     (hc : ∀ x ∈ s, c x ∈ 𝓝[s] x) : ∃ δ > 0, ∀ x ∈ s, ∃ y, ball x δ ∩ s ⊆ c y := by
   simpa only [ball, UniformSpace.ball, preimage_setOf_eq, edist_comm]
     using uniformity_basis_edist.lebesgue_number_lemma_nhdsWithin hs hc

--- a/Mathlib/Topology/EMetricSpace/Basic.lean
+++ b/Mathlib/Topology/EMetricSpace/Basic.lean
@@ -330,33 +330,38 @@ end Compact
 
 end TopologicalSpace
 
-theorem lebesgue_number_lemma_of_emetric {s : Set α} {ι : Sort*} {c : ι → Set α} (hs : IsCompact s)
+section LebesgueNumberLemma
+
+variable {s : Set α}
+
+theorem lebesgue_number_lemma_of_emetric {ι : Sort*} {c : ι → Set α} (hs : IsCompact s)
     (hc₁ : ∀ i, IsOpen (c i)) (hc₂ : s ⊆ ⋃ i, c i) : ∃ δ > 0, ∀ x ∈ s, ∃ i, ball x δ ⊆ c i := by
   simpa only [ball, UniformSpace.ball, preimage_setOf_eq, edist_comm]
     using uniformity_basis_edist.lebesgue_number_lemma hs hc₁ hc₂
 
-theorem lebesgue_number_lemma_nhds_of_emetric' {s : Set α} {c : (x : α) → x ∈ s → Set α}
-    (hs : IsCompact s) (hc : ∀ x hx, c x hx ∈ 𝓝 x) :
-    ∃ δ > 0, ∀ x ∈ s, ∃ y : s, ball x δ ⊆ c y y.2 := by
+theorem lebesgue_number_lemma_nhds_of_emetric' {c : (x : α) → x ∈ s → Set α} (hs : IsCompact s)
+    (hc : ∀ x hx, c x hx ∈ 𝓝 x) : ∃ δ > 0, ∀ x ∈ s, ∃ y : s, ball x δ ⊆ c y y.2 := by
   simpa only [ball, UniformSpace.ball, preimage_setOf_eq, edist_comm]
     using uniformity_basis_edist.lebesgue_number_lemma_nhds' hs hc
 
-theorem lebesgue_number_lemma_nhds_of_emetric {s : Set α} {c : α → Set α} (hs : IsCompact s)
-    (hc : ∀ x ∈ s, c x ∈ 𝓝 x) : ∃ δ > 0, ∀ x ∈ s, ∃ y, ball x δ ⊆ c y := by
+theorem lebesgue_number_lemma_nhds_of_emetric {c : α → Set α} (hs : IsCompact s)
+  (hc : ∀ x ∈ s, c x ∈ 𝓝 x) : ∃ δ > 0, ∀ x ∈ s, ∃ y, ball x δ ⊆ c y := by
   simpa only [ball, UniformSpace.ball, preimage_setOf_eq, edist_comm]
     using uniformity_basis_edist.lebesgue_number_lemma_nhds hs hc
 
-theorem lebesgue_number_lemma_nhdsWithin_of_emetric' {s : Set α} {c : (x : α) → x ∈ s → Set α}
+theorem lebesgue_number_lemma_nhdsWithin_of_emetric' {c : (x : α) → x ∈ s → Set α}
     (hs : IsCompact s) (hc : ∀ x hx, c x hx ∈ 𝓝[s] x) :
     ∃ δ > 0, ∀ x ∈ s, ∃ y : s, ball x δ ∩ s ⊆ c y y.2 := by
   simpa only [ball, UniformSpace.ball, preimage_setOf_eq, edist_comm]
     using uniformity_basis_edist.lebesgue_number_lemma_nhdsWithin' hs hc
 
-theorem lebesgue_number_lemma_nhdsWithin_of_emetric {s : Set α} {c : α → Set α} (hs : IsCompact s)
+theorem lebesgue_number_lemma_nhdsWithin_of_emetric {c : α → Set α} (hs : IsCompact s)
     (hc : ∀ x ∈ s, c x ∈ 𝓝[s] x) : ∃ δ > 0, ∀ x ∈ s, ∃ y, ball x δ ∩ s ⊆ c y := by
   simpa only [ball, UniformSpace.ball, preimage_setOf_eq, edist_comm]
     using uniformity_basis_edist.lebesgue_number_lemma_nhdsWithin hs hc
 
-theorem lebesgue_number_lemma_of_emetric_sUnion {s : Set α} {c : Set (Set α)} (hs : IsCompact s)
+theorem lebesgue_number_lemma_of_emetric_sUnion {c : Set (Set α)} (hs : IsCompact s)
     (hc₁ : ∀ t ∈ c, IsOpen t) (hc₂ : s ⊆ ⋃₀ c) : ∃ δ > 0, ∀ x ∈ s, ∃ t ∈ c, ball x δ ⊆ t := by
   rw [sUnion_eq_iUnion] at hc₂; simpa using lebesgue_number_lemma_of_emetric hs (by simpa) hc₂
+
+end LebesgueNumberLemma

--- a/Mathlib/Topology/EMetricSpace/Basic.lean
+++ b/Mathlib/Topology/EMetricSpace/Basic.lean
@@ -346,10 +346,6 @@ theorem lebesgue_number_lemma_nhds_of_emetric {s : Set α} {c : α → Set α} (
   simpa only [ball, UniformSpace.ball, preimage_setOf_eq, edist_comm]
     using uniformity_basis_edist.lebesgue_number_lemma_nhds hs hc
 
-theorem lebesgue_number_lemma_of_emetric_sUnion {s : Set α} {c : Set (Set α)} (hs : IsCompact s)
-    (hc₁ : ∀ t ∈ c, IsOpen t) (hc₂ : s ⊆ ⋃₀ c) : ∃ δ > 0, ∀ x ∈ s, ∃ t ∈ c, ball x δ ⊆ t := by
-  rw [sUnion_eq_iUnion] at hc₂; simpa using lebesgue_number_lemma_of_emetric hs (by simpa) hc₂
-
 theorem lebesgue_number_lemma_nhdsWithin_of_emetric' {s : Set α} {c : (x : α) → x ∈ s → Set α}
     (hs : IsCompact s) (hc : ∀ x hx, c x hx ∈ 𝓝[s] x) :
     ∃ δ > 0, ∀ x ∈ s, ∃ y : s, ball x δ ∩ s ⊆ c y y.2 := by
@@ -360,3 +356,7 @@ theorem lebesgue_number_lemma_nhdsWithin_of_emetric {s : Set α} {c : α → Set
     (hc : ∀ x ∈ s, c x ∈ 𝓝[s] x) : ∃ δ > 0, ∀ x ∈ s, ∃ y, ball x δ ∩ s ⊆ c y := by
   simpa only [ball, UniformSpace.ball, preimage_setOf_eq, edist_comm]
     using uniformity_basis_edist.lebesgue_number_lemma_nhdsWithin hs hc
+
+theorem lebesgue_number_lemma_of_emetric_sUnion {s : Set α} {c : Set (Set α)} (hs : IsCompact s)
+    (hc₁ : ∀ t ∈ c, IsOpen t) (hc₂ : s ⊆ ⋃₀ c) : ∃ δ > 0, ∀ x ∈ s, ∃ t ∈ c, ball x δ ⊆ t := by
+  rw [sUnion_eq_iUnion] at hc₂; simpa using lebesgue_number_lemma_of_emetric hs (by simpa) hc₂

--- a/Mathlib/Topology/EMetricSpace/Basic.lean
+++ b/Mathlib/Topology/EMetricSpace/Basic.lean
@@ -335,6 +335,17 @@ theorem lebesgue_number_lemma_of_emetric {s : Set α} {ι : Sort*} {c : ι → S
   simpa only [ball, UniformSpace.ball, preimage_setOf_eq, edist_comm]
     using uniformity_basis_edist.lebesgue_number_lemma hs hc₁ hc₂
 
+theorem lebesgue_number_lemma_nhds_of_emetric' {s : Set α} {c : (x : α) → x ∈ s → Set α}
+    (hs : IsCompact s) (hc : ∀ x hx, c x hx ∈ 𝓝 x) :
+    ∃ δ > 0, ∀ x ∈ s, ∃ y : s, ball x δ ⊆ c y y.2 := by
+  simpa only [ball, UniformSpace.ball, preimage_setOf_eq, edist_comm]
+    using uniformity_basis_edist.lebesgue_number_lemma_nhds' hs hc
+
+theorem lebesgue_number_lemma_nhds_of_emetric {s : Set α} {c : α → Set α} (hs : IsCompact s)
+    (hc : ∀ x ∈ s, c x ∈ 𝓝 x) : ∃ δ > 0, ∀ x ∈ s, ∃ y, ball x δ ⊆ c y := by
+  simpa only [ball, UniformSpace.ball, preimage_setOf_eq, edist_comm]
+    using uniformity_basis_edist.lebesgue_number_lemma_nhds hs hc
+
 theorem lebesgue_number_lemma_of_emetric_sUnion {s : Set α} {c : Set (Set α)} (hs : IsCompact s)
     (hc₁ : ∀ t ∈ c, IsOpen t) (hc₂ : s ⊆ ⋃₀ c) : ∃ δ > 0, ∀ x ∈ s, ∃ t ∈ c, ball x δ ⊆ t := by
   rw [sUnion_eq_iUnion] at hc₂; simpa using lebesgue_number_lemma_of_emetric hs (by simpa) hc₂

--- a/Mathlib/Topology/EMetricSpace/Basic.lean
+++ b/Mathlib/Topology/EMetricSpace/Basic.lean
@@ -349,3 +349,14 @@ theorem lebesgue_number_lemma_nhds_of_emetric {s : Set α} {c : α → Set α} (
 theorem lebesgue_number_lemma_of_emetric_sUnion {s : Set α} {c : Set (Set α)} (hs : IsCompact s)
     (hc₁ : ∀ t ∈ c, IsOpen t) (hc₂ : s ⊆ ⋃₀ c) : ∃ δ > 0, ∀ x ∈ s, ∃ t ∈ c, ball x δ ⊆ t := by
   rw [sUnion_eq_iUnion] at hc₂; simpa using lebesgue_number_lemma_of_emetric hs (by simpa) hc₂
+
+theorem lebesgue_number_lemma_nhdsWithin_of_emetric' {s : Set α} {c : (x : α) → x ∈ s → Set α}
+    (hs : IsCompact s) (hc : ∀ x hx, c x hx ∈ 𝓝[s] x) :
+    ∃ δ > 0, ∀ x ∈ s, ∃ y : s, ball x δ ∩ s ⊆ c y y.2 := by
+  simpa only [ball, UniformSpace.ball, preimage_setOf_eq, edist_comm]
+    using uniformity_basis_edist.lebesgue_number_lemma_nhdsWithin' hs hc
+
+theorem lebesgue_number_lemma_nhdsWithin_of_emetric {s : Set α} {c : α → Set α} (hs : IsCompact s)
+    (hc : ∀ x ∈ s, c x ∈ 𝓝[s] x) : ∃ δ > 0, ∀ x ∈ s, ∃ y, ball x δ ∩ s ⊆ c y := by
+  simpa only [ball, UniformSpace.ball, preimage_setOf_eq, edist_comm]
+    using uniformity_basis_edist.lebesgue_number_lemma_nhdsWithin hs hc

--- a/Mathlib/Topology/EMetricSpace/Basic.lean
+++ b/Mathlib/Topology/EMetricSpace/Basic.lean
@@ -345,7 +345,7 @@ theorem lebesgue_number_lemma_of_emetric_nhds' {c : (x : α) → x ∈ s → Set
     using uniformity_basis_edist.lebesgue_number_lemma_nhds' hs hc
 
 theorem lebesgue_number_lemma_of_emetric_nhds {c : α → Set α} (hs : IsCompact s)
-  (hc : ∀ x ∈ s, c x ∈ 𝓝 x) : ∃ δ > 0, ∀ x ∈ s, ∃ y, ball x δ ⊆ c y := by
+    (hc : ∀ x ∈ s, c x ∈ 𝓝 x) : ∃ δ > 0, ∀ x ∈ s, ∃ y, ball x δ ⊆ c y := by
   simpa only [ball, UniformSpace.ball, preimage_setOf_eq, edist_comm]
     using uniformity_basis_edist.lebesgue_number_lemma_nhds hs hc
 

--- a/Mathlib/Topology/UniformSpace/Compact.lean
+++ b/Mathlib/Topology/UniformSpace/Compact.lean
@@ -54,14 +54,14 @@ theorem lebesgue_number_lemma_nhds {U : α → Set α} (hK : IsCompact K) (hU : 
     fun _ ⟨V_uni, hV⟩ => ⟨V_uni, fun x hx => (hV x hx).imp fun _ hy => hy.trans interior_subset⟩
 
 theorem lebesgue_number_lemma_nhdsWithin' {U : (x : α) → x ∈ K → Set α} (hK : IsCompact K)
-    (hU : ∀ x hx, U x hx ∈ 𝓝[K] x) : ∃ V ∈ 𝓤 α, ∀ x ∈ K, ∃ y : K, ball x V ∩ K ⊆ U y y.2 := by
-  refine (lebesgue_number_lemma_nhds' hK (fun x hx => Filter.mem_inf_principal'.1 (hU x hx))).imp
-    fun V ⟨V_uni, hV⟩ => ⟨V_uni, fun x hx => (hV x hx).imp fun _ hy => (inter_subset _ _ _).2 hy⟩
+    (hU : ∀ x hx, U x hx ∈ 𝓝[K] x) : ∃ V ∈ 𝓤 α, ∀ x ∈ K, ∃ y : K, ball x V ∩ K ⊆ U y y.2 :=
+  (lebesgue_number_lemma_nhds' hK (fun x hx => Filter.mem_inf_principal'.1 (hU x hx))).imp
+    fun _ ⟨V_uni, hV⟩ => ⟨V_uni, fun x hx => (hV x hx).imp fun _ hy => (inter_subset _ _ _).2 hy⟩
 
 theorem lebesgue_number_lemma_nhdsWithin {U : α → Set α} (hK : IsCompact K)
-    (hU : ∀ x ∈ K, U x ∈ 𝓝[K] x) : ∃ V ∈ 𝓤 α, ∀ x ∈ K, ∃ y, ball x V ∩ K ⊆ U y := by
-  refine (lebesgue_number_lemma_nhds hK (fun x hx => Filter.mem_inf_principal'.1 (hU x hx))).imp
-    fun V ⟨V_uni, hV⟩ => ⟨V_uni, fun x hx => (hV x hx).imp fun _ hy => (inter_subset _ _ _).2 hy⟩
+    (hU : ∀ x ∈ K, U x ∈ 𝓝[K] x) : ∃ V ∈ 𝓤 α, ∀ x ∈ K, ∃ y, ball x V ∩ K ⊆ U y :=
+  (lebesgue_number_lemma_nhds hK (fun x hx => Filter.mem_inf_principal'.1 (hU x hx))).imp
+    fun _ ⟨V_uni, hV⟩ => ⟨V_uni, fun x hx => (hV x hx).imp fun _ hy => (inter_subset _ _ _).2 hy⟩
 
 /-- Let `U : ι → Set α` be an open cover of a compact set `K`.
 Then there exists an entourage `V`

--- a/Mathlib/Topology/UniformSpace/Compact.lean
+++ b/Mathlib/Topology/UniformSpace/Compact.lean
@@ -42,18 +42,16 @@ theorem lebesgue_number_lemma {ι : Sort*} {U : ι → Set α} (hK : IsCompact K
   exact ⟨ind y y.2, fun z hz ↦ hWU _ _ ⟨x, hxy, mem_iInter₂.1 hz _ hyt⟩⟩
 
 theorem lebesgue_number_lemma_nhds' {U : (x : α) → x ∈ K → Set α} (hK : IsCompact K)
-    (hU : ∀ x hx, U x hx ∈ 𝓝 x) : ∃ V ∈ 𝓤 α, ∀ x ∈ K, ∃ y, ∃ hy, ball x V ⊆ U y hy := by
+    (hU : ∀ x hx, U x hx ∈ 𝓝 x) : ∃ V ∈ 𝓤 α, ∀ x ∈ K, ∃ y : K, ball x V ⊆ U y y.2 := by
   rcases lebesgue_number_lemma (U := fun x : K => interior (U x x.2)) hK (fun _ => isOpen_interior)
     (fun x hx => mem_iUnion.2 ⟨⟨x, hx⟩, mem_interior_iff_mem_nhds.2 (hU x hx)⟩) with ⟨V, V_unif, hV⟩
-  refine ⟨V, V_unif, fun x hx => ?_⟩
-  rcases hV x hx with ⟨y, hy⟩
-  exact ⟨y, y.2, hy.trans interior_subset⟩
+  exact ⟨V, V_unif, fun x hx => (hV x hx).imp fun y hy => hy.trans interior_subset⟩
 
 theorem lebesgue_number_lemma_nhds {U : α → Set α} (hK : IsCompact K) (hU : ∀ x ∈ K, U x ∈ 𝓝 x) :
     ∃ V ∈ 𝓤 α, ∀ x ∈ K, ∃ y, ball x V ⊆ U y := by
   rcases lebesgue_number_lemma_nhds' hK hU with ⟨V, V_unif, hV⟩
   refine ⟨V, V_unif, fun x hx => ?_⟩
-  rcases hV x hx with ⟨y, _, hy⟩
+  rcases hV x hx with ⟨y, hy⟩
   exact ⟨y, hy⟩
 
 /-- Let `U : ι → Set α` be an open cover of a compact set `K`.
@@ -67,6 +65,19 @@ protected theorem Filter.HasBasis.lebesgue_number_lemma {ι' ι : Sort*} {p : ι
     ∃ i, p i ∧ ∀ x ∈ K, ∃ j, ball x (V i) ⊆ U j := by
   refine (hbasis.exists_iff ?_).1 (lebesgue_number_lemma hK hopen hcover)
   exact fun s t hst ht x hx ↦ (ht x hx).imp fun i hi ↦ Subset.trans (ball_mono hst _) hi
+
+protected theorem Filter.HasBasis.lebesgue_number_lemma_nhds' {ι' : Sort*} {p : ι' → Prop}
+    {V : ι' → Set (α × α)} {U : (x : α) → x ∈ K → Set α} (hbasis : (𝓤 α).HasBasis p V)
+    (hK : IsCompact K) (hU : ∀ x hx, U x hx ∈ 𝓝 x) :
+    ∃ i, p i ∧ ∀ x ∈ K, ∃ y : K, ball x (V i) ⊆ U y y.2 := by
+  refine (hbasis.exists_iff ?_).1 (lebesgue_number_lemma_nhds' hK hU)
+  exact fun s t hst ht x hx ↦ (ht x hx).imp fun y hy ↦  Subset.trans (ball_mono hst _) hy
+
+protected theorem Filter.HasBasis.lebesgue_number_lemma_nhds {ι' : Sort*} {p : ι' → Prop}
+    {V : ι' → Set (α × α)} {U : α → Set α} (hbasis : (𝓤 α).HasBasis p V) (hK : IsCompact K)
+    (hU : ∀ x ∈ K, U x ∈ 𝓝 x) : ∃ i, p i ∧ ∀ x ∈ K, ∃ y, ball x (V i) ⊆ U y := by
+  refine (hbasis.exists_iff ?_).1 (lebesgue_number_lemma_nhds hK hU)
+  exact fun s t hst ht x hx ↦ (ht x hx).imp fun y hy ↦  Subset.trans (ball_mono hst _) hy
 
 /-- Let `c : Set (Set α)` be an open cover of a compact set `s`. Then there exists an entourage
 `n` such that for each `x ∈ s` its `n`-neighborhood is contained in some `t ∈ c`. -/

--- a/Mathlib/Topology/UniformSpace/Compact.lean
+++ b/Mathlib/Topology/UniformSpace/Compact.lean
@@ -42,28 +42,26 @@ theorem lebesgue_number_lemma {ι : Sort*} {U : ι → Set α} (hK : IsCompact K
   exact ⟨ind y y.2, fun z hz ↦ hWU _ _ ⟨x, hxy, mem_iInter₂.1 hz _ hyt⟩⟩
 
 theorem lebesgue_number_lemma_nhds' {U : (x : α) → x ∈ K → Set α} (hK : IsCompact K)
-    (hU : ∀ x hx, U x hx ∈ 𝓝 x) : ∃ V ∈ 𝓤 α, ∀ x ∈ K, ∃ y : K, ball x V ⊆ U y y.2 := by
-  rcases lebesgue_number_lemma (U := fun x : K => interior (U x x.2)) hK (fun _ => isOpen_interior)
-    (fun x hx => mem_iUnion.2 ⟨⟨x, hx⟩, mem_interior_iff_mem_nhds.2 (hU x hx)⟩) with ⟨V, V_uni, hV⟩
-  exact ⟨V, V_uni, fun x hx => (hV x hx).imp fun y hy => hy.trans interior_subset⟩
+    (hU : ∀ x hx, U x hx ∈ 𝓝 x) : ∃ V ∈ 𝓤 α, ∀ x ∈ K, ∃ y : K, ball x V ⊆ U y y.2 :=
+  (lebesgue_number_lemma (U := fun x : K => interior (U x x.2)) hK (fun _ => isOpen_interior)
+    (fun x hx => mem_iUnion.2 ⟨⟨x, hx⟩, mem_interior_iff_mem_nhds.2 (hU x hx)⟩)).imp
+    fun _ ⟨V_uni, hV⟩ => ⟨V_uni, fun x hx => (hV x hx).imp fun _ hy => hy.trans interior_subset⟩
 
 theorem lebesgue_number_lemma_nhds {U : α → Set α} (hK : IsCompact K) (hU : ∀ x ∈ K, U x ∈ 𝓝 x) :
-    ∃ V ∈ 𝓤 α, ∀ x ∈ K, ∃ y, ball x V ⊆ U y := by
-  refine (lebesgue_number_lemma_nhds' hK hU).imp fun V ⟨V_uni, hV⟩ => ⟨V_uni, fun x hx => ?_⟩
-  rcases hV x hx with ⟨y, hy⟩
-  exact ⟨y, hy⟩
+    ∃ V ∈ 𝓤 α, ∀ x ∈ K, ∃ y, ball x V ⊆ U y :=
+  (lebesgue_number_lemma (U := fun x => interior (U x)) hK (fun _ => isOpen_interior)
+    (fun x hx => mem_iUnion.2 ⟨x, mem_interior_iff_mem_nhds.2 (hU x hx)⟩)).imp
+    fun _ ⟨V_uni, hV⟩ => ⟨V_uni, fun x hx => (hV x hx).imp fun _ hy => hy.trans interior_subset⟩
 
 theorem lebesgue_number_lemma_nhdsWithin' {U : (x : α) → x ∈ K → Set α} (hK : IsCompact K)
     (hU : ∀ x hx, U x hx ∈ 𝓝[K] x) : ∃ V ∈ 𝓤 α, ∀ x ∈ K, ∃ y : K, ball x V ∩ K ⊆ U y y.2 := by
-  choose U' U'_nhds hU' using fun x hx => mem_nhdsWithin_iff_exists_mem_nhds_inter.1 (hU x hx)
-  exact (lebesgue_number_lemma_nhds' hK U'_nhds).imp fun V ⟨V_nhds, hV⟩ => ⟨V_nhds, fun x hx =>
-    (hV x hx).imp fun y hy => (Set.inter_subset_inter_left K hy).trans (hU' y y.2)⟩
+  refine (lebesgue_number_lemma_nhds' hK (fun x hx => Filter.mem_inf_principal'.1 (hU x hx))).imp
+    fun V ⟨V_uni, hV⟩ => ⟨V_uni, fun x hx => (hV x hx).imp fun _ hy => (inter_subset _ _ _).2 hy⟩
 
 theorem lebesgue_number_lemma_nhdsWithin {U : α → Set α} (hK : IsCompact K)
     (hU : ∀ x ∈ K, U x ∈ 𝓝[K] x) : ∃ V ∈ 𝓤 α, ∀ x ∈ K, ∃ y, ball x V ∩ K ⊆ U y := by
-  refine (lebesgue_number_lemma_nhdsWithin' hK hU).imp fun V ⟨V_uni, hV⟩ => ⟨V_uni, fun x hx => ?_⟩
-  rcases hV x hx with ⟨y, hy⟩
-  exact ⟨y, hy⟩
+  refine (lebesgue_number_lemma_nhds hK (fun x hx => Filter.mem_inf_principal'.1 (hU x hx))).imp
+    fun V ⟨V_uni, hV⟩ => ⟨V_uni, fun x hx => (hV x hx).imp fun _ hy => (inter_subset _ _ _).2 hy⟩
 
 /-- Let `U : ι → Set α` be an open cover of a compact set `K`.
 Then there exists an entourage `V`

--- a/Mathlib/Topology/UniformSpace/Compact.lean
+++ b/Mathlib/Topology/UniformSpace/Compact.lean
@@ -44,13 +44,24 @@ theorem lebesgue_number_lemma {ι : Sort*} {U : ι → Set α} (hK : IsCompact K
 theorem lebesgue_number_lemma_nhds' {U : (x : α) → x ∈ K → Set α} (hK : IsCompact K)
     (hU : ∀ x hx, U x hx ∈ 𝓝 x) : ∃ V ∈ 𝓤 α, ∀ x ∈ K, ∃ y : K, ball x V ⊆ U y y.2 := by
   rcases lebesgue_number_lemma (U := fun x : K => interior (U x x.2)) hK (fun _ => isOpen_interior)
-    (fun x hx => mem_iUnion.2 ⟨⟨x, hx⟩, mem_interior_iff_mem_nhds.2 (hU x hx)⟩) with ⟨V, V_unif, hV⟩
-  exact ⟨V, V_unif, fun x hx => (hV x hx).imp fun y hy => hy.trans interior_subset⟩
+    (fun x hx => mem_iUnion.2 ⟨⟨x, hx⟩, mem_interior_iff_mem_nhds.2 (hU x hx)⟩) with ⟨V, V_uni, hV⟩
+  exact ⟨V, V_uni, fun x hx => (hV x hx).imp fun y hy => hy.trans interior_subset⟩
 
 theorem lebesgue_number_lemma_nhds {U : α → Set α} (hK : IsCompact K) (hU : ∀ x ∈ K, U x ∈ 𝓝 x) :
     ∃ V ∈ 𝓤 α, ∀ x ∈ K, ∃ y, ball x V ⊆ U y := by
-  rcases lebesgue_number_lemma_nhds' hK hU with ⟨V, V_unif, hV⟩
-  refine ⟨V, V_unif, fun x hx => ?_⟩
+  refine (lebesgue_number_lemma_nhds' hK hU).imp fun V ⟨V_uni, hV⟩ => ⟨V_uni, fun x hx => ?_⟩
+  rcases hV x hx with ⟨y, hy⟩
+  exact ⟨y, hy⟩
+
+theorem lebesgue_number_lemma_nhdsWithin' {U : (x : α) → x ∈ K → Set α} (hK : IsCompact K)
+    (hU : ∀ x hx, U x hx ∈ 𝓝[K] x) : ∃ V ∈ 𝓤 α, ∀ x ∈ K, ∃ y : K, ball x V ∩ K ⊆ U y y.2 := by
+  choose U' U'_nhds hU' using fun x hx => mem_nhdsWithin_iff_exists_mem_nhds_inter.1 (hU x hx)
+  exact (lebesgue_number_lemma_nhds' hK U'_nhds).imp fun V ⟨V_nhds, hV⟩ => ⟨V_nhds, fun x hx =>
+    (hV x hx).imp fun y hy => (Set.inter_subset_inter_left K hy).trans (hU' y y.2)⟩
+
+theorem lebesgue_number_lemma_nhdsWithin {U : α → Set α} (hK : IsCompact K)
+    (hU : ∀ x ∈ K, U x ∈ 𝓝[K] x) : ∃ V ∈ 𝓤 α, ∀ x ∈ K, ∃ y, ball x V ∩ K ⊆ U y := by
+  refine (lebesgue_number_lemma_nhdsWithin' hK hU).imp fun V ⟨V_uni, hV⟩ => ⟨V_uni, fun x hx => ?_⟩
   rcases hV x hx with ⟨y, hy⟩
   exact ⟨y, hy⟩
 

--- a/Mathlib/Topology/UniformSpace/Compact.lean
+++ b/Mathlib/Topology/UniformSpace/Compact.lean
@@ -82,13 +82,28 @@ protected theorem Filter.HasBasis.lebesgue_number_lemma_nhds' {ι' : Sort*} {p :
     (hK : IsCompact K) (hU : ∀ x hx, U x hx ∈ 𝓝 x) :
     ∃ i, p i ∧ ∀ x ∈ K, ∃ y : K, ball x (V i) ⊆ U y y.2 := by
   refine (hbasis.exists_iff ?_).1 (lebesgue_number_lemma_nhds' hK hU)
-  exact fun s t hst ht x hx ↦ (ht x hx).imp fun y hy ↦  Subset.trans (ball_mono hst _) hy
+  exact fun s t hst ht x hx ↦ (ht x hx).imp fun y hy ↦ Subset.trans (ball_mono hst _) hy
 
 protected theorem Filter.HasBasis.lebesgue_number_lemma_nhds {ι' : Sort*} {p : ι' → Prop}
     {V : ι' → Set (α × α)} {U : α → Set α} (hbasis : (𝓤 α).HasBasis p V) (hK : IsCompact K)
     (hU : ∀ x ∈ K, U x ∈ 𝓝 x) : ∃ i, p i ∧ ∀ x ∈ K, ∃ y, ball x (V i) ⊆ U y := by
   refine (hbasis.exists_iff ?_).1 (lebesgue_number_lemma_nhds hK hU)
-  exact fun s t hst ht x hx ↦ (ht x hx).imp fun y hy ↦  Subset.trans (ball_mono hst _) hy
+  exact fun s t hst ht x hx ↦ (ht x hx).imp fun y hy ↦ Subset.trans (ball_mono hst _) hy
+
+protected theorem Filter.HasBasis.lebesgue_number_lemma_nhdsWithin' {ι' : Sort*} {p : ι' → Prop}
+    {V : ι' → Set (α × α)} {U : (x : α) → x ∈ K → Set α} (hbasis : (𝓤 α).HasBasis p V)
+    (hK : IsCompact K) (hU : ∀ x hx, U x hx ∈ 𝓝[K] x) :
+    ∃ i, p i ∧ ∀ x ∈ K, ∃ y : K, ball x (V i) ∩ K ⊆ U y y.2 := by
+  refine (hbasis.exists_iff ?_).1 (lebesgue_number_lemma_nhdsWithin' hK hU)
+  exact fun s t hst ht x hx ↦ (ht x hx).imp
+    fun y hy ↦ Subset.trans (Set.inter_subset_inter_left K (ball_mono hst _)) hy
+
+protected theorem Filter.HasBasis.lebesgue_number_lemma_nhdsWithin {ι' : Sort*} {p : ι' → Prop}
+    {V : ι' → Set (α × α)} {U : α → Set α} (hbasis : (𝓤 α).HasBasis p V) (hK : IsCompact K)
+    (hU : ∀ x ∈ K, U x ∈ 𝓝[K] x) : ∃ i, p i ∧ ∀ x ∈ K, ∃ y, ball x (V i) ∩ K ⊆ U y := by
+  refine (hbasis.exists_iff ?_).1 (lebesgue_number_lemma_nhdsWithin hK hU)
+  exact fun s t hst ht x hx ↦ (ht x hx).imp
+    fun y hy ↦ Subset.trans (Set.inter_subset_inter_left K (ball_mono hst _)) hy
 
 /-- Let `c : Set (Set α)` be an open cover of a compact set `s`. Then there exists an entourage
 `n` such that for each `x ∈ s` its `n`-neighborhood is contained in some `t ∈ c`. -/

--- a/Mathlib/Topology/UniformSpace/Compact.lean
+++ b/Mathlib/Topology/UniformSpace/Compact.lean
@@ -41,6 +41,21 @@ theorem lebesgue_number_lemma {ι : Sort*} {U : ι → Set α} (hK : IsCompact K
   rcases mem_iUnion₂.1 (ht hx) with ⟨y, hyt, hxy⟩
   exact ⟨ind y y.2, fun z hz ↦ hWU _ _ ⟨x, hxy, mem_iInter₂.1 hz _ hyt⟩⟩
 
+theorem lebesgue_number_lemma_nhds' {U : (x : α) → x ∈ K → Set α} (hK : IsCompact K)
+    (hU : ∀ x hx, U x hx ∈ 𝓝 x) : ∃ V ∈ 𝓤 α, ∀ x ∈ K, ∃ y, ∃ hy, ball x V ⊆ U y hy := by
+  rcases lebesgue_number_lemma (U := fun x : K => interior (U x x.2)) hK (fun _ => isOpen_interior)
+    (fun x hx => mem_iUnion.2 ⟨⟨x, hx⟩, mem_interior_iff_mem_nhds.2 (hU x hx)⟩) with ⟨V, V_unif, hV⟩
+  refine ⟨V, V_unif, fun x hx => ?_⟩
+  rcases hV x hx with ⟨y, hy⟩
+  exact ⟨y, y.2, hy.trans interior_subset⟩
+
+theorem lebesgue_number_lemma_nhds {U : α → Set α} (hK : IsCompact K) (hU : ∀ x ∈ K, U x ∈ 𝓝 x) :
+    ∃ V ∈ 𝓤 α, ∀ x ∈ K, ∃ y, ball x V ⊆ U y := by
+  rcases lebesgue_number_lemma_nhds' hK hU with ⟨V, V_unif, hV⟩
+  refine ⟨V, V_unif, fun x hx => ?_⟩
+  rcases hV x hx with ⟨y, _, hy⟩
+  exact ⟨y, hy⟩
+
 /-- Let `U : ι → Set α` be an open cover of a compact set `K`.
 Then there exists an entourage `V`
 such that for each `x ∈ K` its `V`-neighborhood is included in some `U i`.

--- a/Mathlib/Topology/UniformSpace/Compact.lean
+++ b/Mathlib/Topology/UniformSpace/Compact.lean
@@ -42,16 +42,16 @@ theorem lebesgue_number_lemma {ι : Sort*} {U : ι → Set α} (hK : IsCompact K
   exact ⟨ind y y.2, fun z hz ↦ hWU _ _ ⟨x, hxy, mem_iInter₂.1 hz _ hyt⟩⟩
 
 theorem lebesgue_number_lemma_nhds' {U : (x : α) → x ∈ K → Set α} (hK : IsCompact K)
-    (hU : ∀ x hx, U x hx ∈ 𝓝 x) : ∃ V ∈ 𝓤 α, ∀ x ∈ K, ∃ y : K, ball x V ⊆ U y y.2 :=
-  (lebesgue_number_lemma (U := fun x : K => interior (U x x.2)) hK (fun _ => isOpen_interior)
-    (fun x hx => mem_iUnion.2 ⟨⟨x, hx⟩, mem_interior_iff_mem_nhds.2 (hU x hx)⟩)).imp
-    fun _ ⟨V_uni, hV⟩ => ⟨V_uni, fun x hx => (hV x hx).imp fun _ hy => hy.trans interior_subset⟩
+    (hU : ∀ x hx, U x hx ∈ 𝓝 x) : ∃ V ∈ 𝓤 α, ∀ x ∈ K, ∃ y : K, ball x V ⊆ U y y.2 := by
+  rcases lebesgue_number_lemma (U := fun x : K => interior (U x x.2)) hK (fun _ => isOpen_interior)
+    (fun x hx => mem_iUnion.2 ⟨⟨x, hx⟩, mem_interior_iff_mem_nhds.2 (hU x hx)⟩) with ⟨V, V_uni, hV⟩
+  exact ⟨V, V_uni, fun x hx => (hV x hx).imp fun _ hy => hy.trans interior_subset⟩
 
 theorem lebesgue_number_lemma_nhds {U : α → Set α} (hK : IsCompact K) (hU : ∀ x ∈ K, U x ∈ 𝓝 x) :
-    ∃ V ∈ 𝓤 α, ∀ x ∈ K, ∃ y, ball x V ⊆ U y :=
-  (lebesgue_number_lemma (U := fun x => interior (U x)) hK (fun _ => isOpen_interior)
-    (fun x hx => mem_iUnion.2 ⟨x, mem_interior_iff_mem_nhds.2 (hU x hx)⟩)).imp
-    fun _ ⟨V_uni, hV⟩ => ⟨V_uni, fun x hx => (hV x hx).imp fun _ hy => hy.trans interior_subset⟩
+    ∃ V ∈ 𝓤 α, ∀ x ∈ K, ∃ y, ball x V ⊆ U y := by
+  rcases lebesgue_number_lemma (U := fun x => interior (U x)) hK (fun _ => isOpen_interior)
+    (fun x hx => mem_iUnion.2 ⟨x, mem_interior_iff_mem_nhds.2 (hU x hx)⟩) with ⟨V, V_uni, hV⟩
+  exact ⟨V, V_uni, fun x hx => (hV x hx).imp fun _ hy => hy.trans interior_subset⟩
 
 theorem lebesgue_number_lemma_nhdsWithin' {U : (x : α) → x ∈ K → Set α} (hK : IsCompact K)
     (hU : ∀ x hx, U x hx ∈ 𝓝[K] x) : ∃ V ∈ 𝓤 α, ∀ x ∈ K, ∃ y : K, ball x V ∩ K ⊆ U y y.2 :=


### PR DESCRIPTION
Add versions of the Lebesgue number lemma, for coverings by neighborhoods rather than by open subsets (in `Topology/UniformSpace/Compact.lean`).
Add specializations of the Lebesgue number lemma for extended metric spaces (in `Topology/EMetricSpace/Basic.lean`).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
