### PR TITLE
[Merged by Bors] - chore: hint looks for error messages

### DIFF
--- a/Mathlib/Tactic/Hint.lean
+++ b/Mathlib/Tactic/Hint.lean
@@ -104,7 +104,10 @@ def hint (stx : Syntax) : TacticM Unit := withMainContext do
   let tacs := Nondet.ofList (← getHints)
   let results := tacs.filterMapM fun t : TSyntax `tactic => do
     if let some msgs ← observing? (withMessageLog (withoutInfoTrees (evalTactic t))) then
-      return some (← getGoals, ← suggestion t msgs)
+      if msgs.toList.any (fun m => m.severity == .error) then
+        return none
+      else
+        return some (← getGoals, ← suggestion t msgs)
     else
       return none
   let results ← (results.toMLList.takeUpToFirst fun r => r.1.1.isEmpty).asArray

--- a/Mathlib/Tactic/Hint.lean
+++ b/Mathlib/Tactic/Hint.lean
@@ -104,7 +104,7 @@ def hint (stx : Syntax) : TacticM Unit := withMainContext do
   let tacs := Nondet.ofList (← getHints)
   let results := tacs.filterMapM fun t : TSyntax `tactic => do
     if let some msgs ← observing? (withMessageLog (withoutInfoTrees (evalTactic t))) then
-      if msgs.toList.any (fun m => m.severity == .error) then
+      if msgs.hasErrors then
         return none
       else
         return some (← getGoals, ← suggestion t msgs)

--- a/Mathlib/Tactic/TautoSet.lean
+++ b/Mathlib/Tactic/TautoSet.lean
@@ -41,7 +41,7 @@ example {α} (A B C : Set α) (h1 : A ⊆ B ∪ C) : (A ∩ B) ∪ (A ∩ C) = A
 ```
 -/
 macro "tauto_set" : tactic => `(tactic|
-  · simp_all only [
+  · simp_all -failIfUnchanged only [
       Set.ext_iff, Set.subset_def,
       Set.mem_union, Set.mem_compl_iff, Set.mem_inter_iff,
       Set.symmDiff_def, Set.diff_eq, Set.disjoint_iff

--- a/MathlibTest/hint.lean
+++ b/MathlibTest/hint.lean
@@ -1,6 +1,7 @@
 import Mathlib.Tactic.Common
 import Mathlib.Tactic.Linarith
 import Mathlib.Data.Nat.Prime.Defs
+import Mathlib.Tactic.TautoSet
 
 /--
 info: Try these:
@@ -74,3 +75,26 @@ example : True := by
   hint
 
 end multiline_hint
+
+section tauto_set
+
+register_hint tauto_set
+
+/--
+info: Try these:
+• tauto_set
+-/
+#guard_msgs in
+example {α} (A B C : Set α) (h1 : A ⊆ B ∪ C) : (A ∩ B) ∪ (A ∩ C) = A := by hint
+
+/--
+info: Try these:
+• aesop
+• simp_all only [Nat.not_ofNat_le_one]
+---
+warning: declaration uses 'sorry'
+-/
+#guard_msgs in
+example : 2 ≤ 1 := by hint
+
+end tauto_set


### PR DESCRIPTION
This resolves a problem reported on [zulip](https://leanprover.zulipchat.com/#narrow/channel/144837-PR-reviews/topic/.2322365.20hint.20tactics/near/505113046), by not assuming that `evalTactic` succeeding is enough: it also checks that no error messages were produced.