### PR TITLE
[Merged by Bors] - feat: limsups in `ℝ≥0` and `ℝ` agree

### DIFF
--- a/Mathlib/Order/Filter/ENNReal.lean
+++ b/Mathlib/Order/Filter/ENNReal.lean
@@ -7,7 +7,7 @@ import Mathlib.Topology.Algebra.Order.LiminfLimsup
 import Mathlib.Topology.Metrizable.Real
 
 /-!
-# Limsup of reals
+# Limsup and liminf of reals
 
 This file compiles filter-related results about `ℝ`, `ℝ≥0` and `ℝ≥0∞`.
 -/

--- a/Mathlib/Order/Filter/ENNReal.lean
+++ b/Mathlib/Order/Filter/ENNReal.lean
@@ -7,9 +7,9 @@ import Mathlib.Topology.Algebra.Order.LiminfLimsup
 import Mathlib.Topology.Metrizable.Real
 
 /-!
-# Order properties of extended non-negative reals
+# Limsup of reals
 
-This file compiles filter-related results about `ℝ≥0∞` (see Data/Real/ENNReal.lean).
+This file compiles filter-related results about `ℝ`, `ℝ≥0` and `ℝ≥0∞`.
 -/
 
 
@@ -61,7 +61,7 @@ variable {ι : Type*} {f : Filter ι} {u : ι → ℝ≥0}
 
 @[simp, norm_cast] lemma isBoundedUnder_le_toReal :
     IsBoundedUnder (· ≤ ·) f (fun i ↦ (u i : ℝ)) ↔ IsBoundedUnder (· ≤ ·) f u := by
-  simp [IsBoundedUnder, IsBounded, ← NNReal.coe_le_coe, NNReal.forall, NNReal.exists]
+  simp only [IsBoundedUnder, IsBounded, eventually_map, ← coe_le_coe, NNReal.exists, coe_mk]
   constructor
   · rintro ⟨b, hb⟩
     exact ⟨b.toNNReal, by simp, by filter_upwards [hb]; simp +contextual⟩
@@ -70,7 +70,7 @@ variable {ι : Type*} {f : Filter ι} {u : ι → ℝ≥0}
 
 @[simp, norm_cast] lemma isBoundedUnder_ge_toReal :
     IsBoundedUnder (· ≥ ·) f (fun i ↦ (u i : ℝ)) ↔ IsBoundedUnder (· ≥ ·) f u := by
-  simp [IsBoundedUnder, IsBounded, ← NNReal.coe_le_coe, NNReal.forall, NNReal.exists]
+  simp only [IsBoundedUnder, IsBounded, eventually_map, ← coe_le_coe, NNReal.exists, coe_mk]
   constructor
   · rintro ⟨b, hb⟩
     exact ⟨b.toNNReal, by simp, by simpa⟩
@@ -79,7 +79,8 @@ variable {ι : Type*} {f : Filter ι} {u : ι → ℝ≥0}
 
 @[simp, norm_cast] lemma isCoboundedUnder_le_toReal [f.NeBot] :
     IsCoboundedUnder (· ≤ ·) f (fun i ↦ (u i : ℝ)) ↔ IsCoboundedUnder (· ≤ ·) f u := by
-  simp [IsCoboundedUnder, IsCobounded, ← NNReal.coe_le_coe, NNReal.forall, NNReal.exists]
+  simp only [IsCoboundedUnder, IsCobounded, eventually_map, ← coe_le_coe, NNReal.forall,
+    NNReal.exists]
   constructor
   · rintro ⟨b, hb⟩
     exact ⟨b.toNNReal, by simp, fun x _ ↦ by simpa [*] using hb _⟩
@@ -88,7 +89,8 @@ variable {ι : Type*} {f : Filter ι} {u : ι → ℝ≥0}
 
 @[simp, norm_cast] lemma isCoboundedUnder_ge_toReal :
     IsCoboundedUnder (· ≥ ·) f (fun i ↦ (u i : ℝ)) ↔ IsCoboundedUnder (· ≥ ·) f u := by
-  simp [IsCoboundedUnder, IsCobounded, ← NNReal.coe_le_coe, NNReal.forall, NNReal.exists]
+  simp only [IsCoboundedUnder, IsCobounded, eventually_map, ← coe_le_coe, NNReal.forall,
+    NNReal.exists]
   constructor
   · rintro ⟨b, hb⟩
     exact ⟨b, hb _ (by simp), fun x _ ↦ hb _⟩

--- a/Mathlib/Order/Filter/ENNReal.lean
+++ b/Mathlib/Order/Filter/ENNReal.lean
@@ -15,6 +15,134 @@ This file compiles filter-related results about `ℝ≥0∞` (see Data/Real/ENNR
 
 open Filter ENNReal
 
+namespace Real
+variable {ι : Type*} {f : Filter ι} {u : ι → ℝ}
+
+@[simp]
+lemma limsSup_of_not_isCobounded {f : Filter ℝ} (hf : ¬ f.IsCobounded (· ≤ ·)) :
+    limsSup f = 0 := by rwa [limsSup, sInf_of_not_bddBelow]
+
+@[simp]
+lemma limsSup_of_not_isBounded {f : Filter ℝ} (hf : ¬ f.IsBounded (· ≤ ·)) : limsSup f = 0 := by
+  rw [limsSup]
+  convert sInf_empty
+  simpa [Set.eq_empty_iff_forall_not_mem, IsBounded] using hf
+
+@[simp]
+lemma limsInf_of_not_isCobounded {f : Filter ℝ} (hf : ¬ f.IsCobounded (· ≥ ·)) :
+    limsInf f = 0 := by rwa [limsInf, sSup_of_not_bddAbove]
+
+@[simp]
+lemma limsInf_of_not_isBounded {f : Filter ℝ} (hf : ¬ f.IsBounded (· ≥ ·)) : limsInf f = 0 := by
+  rw [limsInf]
+  convert sSup_empty
+  simpa [Set.eq_empty_iff_forall_not_mem, IsBounded] using hf
+
+@[simp]
+lemma limsup_of_not_isCoboundedUnder (hf : ¬ f.IsCoboundedUnder (· ≤ ·) u) : limsup u f = 0 :=
+  limsSup_of_not_isCobounded hf
+
+@[simp]
+lemma limsup_of_not_isBoundedUnder (hf : ¬ f.IsBoundedUnder (· ≤ ·) u) : limsup u f = 0 :=
+  limsSup_of_not_isBounded hf
+
+@[simp]
+lemma liminf_of_not_isCoboundedUnder (hf : ¬ f.IsCoboundedUnder (· ≥ ·) u) : liminf u f = 0 :=
+  limsInf_of_not_isCobounded hf
+
+@[simp]
+lemma liminf_of_not_isBoundedUnder (hf : ¬ f.IsBoundedUnder (· ≥ ·) u) : liminf u f = 0 :=
+  limsInf_of_not_isBounded hf
+
+end Real
+
+namespace NNReal
+variable {ι : Type*} {f : Filter ι} {u : ι → ℝ≥0}
+
+@[simp, norm_cast] lemma isBoundedUnder_le_toReal :
+    IsBoundedUnder (· ≤ ·) f (fun i ↦ (u i : ℝ)) ↔ IsBoundedUnder (· ≤ ·) f u := by
+  simp [IsBoundedUnder, IsBounded, ← NNReal.coe_le_coe, NNReal.forall, NNReal.exists]
+  constructor
+  · rintro ⟨b, hb⟩
+    exact ⟨b.toNNReal, by simp, by filter_upwards [hb]; simp +contextual⟩
+  · rintro ⟨b, -, hb⟩
+    exact ⟨b, hb⟩
+
+@[simp, norm_cast] lemma isBoundedUnder_ge_toReal :
+    IsBoundedUnder (· ≥ ·) f (fun i ↦ (u i : ℝ)) ↔ IsBoundedUnder (· ≥ ·) f u := by
+  simp [IsBoundedUnder, IsBounded, ← NNReal.coe_le_coe, NNReal.forall, NNReal.exists]
+  constructor
+  · rintro ⟨b, hb⟩
+    exact ⟨b.toNNReal, by simp, by simpa⟩
+  · rintro ⟨b, -, hb⟩
+    exact ⟨b, hb⟩
+
+@[simp, norm_cast] lemma isCoboundedUnder_le_toReal [f.NeBot] :
+    IsCoboundedUnder (· ≤ ·) f (fun i ↦ (u i : ℝ)) ↔ IsCoboundedUnder (· ≤ ·) f u := by
+  simp [IsCoboundedUnder, IsCobounded, ← NNReal.coe_le_coe, NNReal.forall, NNReal.exists]
+  constructor
+  · rintro ⟨b, hb⟩
+    exact ⟨b.toNNReal, by simp, fun x _ ↦ by simpa [*] using hb _⟩
+  · rintro ⟨b, hb₀, hb⟩
+    exact ⟨b, fun x hx ↦ hb _ (hx.exists.choose_spec.trans' (by simp)) hx⟩
+
+@[simp, norm_cast] lemma isCoboundedUnder_ge_toReal :
+    IsCoboundedUnder (· ≥ ·) f (fun i ↦ (u i : ℝ)) ↔ IsCoboundedUnder (· ≥ ·) f u := by
+  simp [IsCoboundedUnder, IsCobounded, ← NNReal.coe_le_coe, NNReal.forall, NNReal.exists]
+  constructor
+  · rintro ⟨b, hb⟩
+    exact ⟨b, hb _ (by simp), fun x _ ↦ hb _⟩
+  · rintro ⟨b, hb₀, hb⟩
+    refine ⟨b, fun x hx ↦ ?_⟩
+    obtain hx₀ | hx₀ := le_total x 0
+    · exact hx₀.trans hb₀
+    · exact hb _ hx₀ hx
+
+@[simp]
+lemma limsSup_of_not_isBounded {f : Filter ℝ≥0} (hf : ¬ f.IsBounded (· ≤ ·)) : limsSup f = 0 := by
+  rw [limsSup, ← bot_eq_zero]
+  convert sInf_empty
+  simpa [Set.eq_empty_iff_forall_not_mem, IsBounded] using hf
+
+@[simp]
+lemma limsInf_of_not_isCobounded {f : Filter ℝ≥0} (hf : ¬ f.IsCobounded (· ≥ ·)) :
+    limsInf f = 0 := by rwa [limsInf, sSup_of_not_bddAbove]
+
+@[simp]
+lemma limsup_of_not_isBoundedUnder (hf : ¬ f.IsBoundedUnder (· ≤ ·) u) : limsup u f = 0 :=
+  limsSup_of_not_isBounded hf
+
+@[simp]
+lemma liminf_of_not_isCoboundedUnder (hf : ¬ f.IsCoboundedUnder (· ≥ ·) u) : liminf u f = 0 :=
+  limsInf_of_not_isCobounded hf
+
+@[simp, norm_cast]
+lemma toReal_liminf : liminf (fun i ↦ (u i : ℝ)) f = liminf u f := by
+  by_cases hf : f.IsCoboundedUnder (· ≥ ·) u; swap
+  · simp [*]
+  refine eq_of_forall_le_iff fun c ↦ ?_
+  rw [← Real.toNNReal_le_iff_le_coe, le_liminf_iff (by simpa) ⟨0, by simp⟩, le_liminf_iff]
+  simp only [← coe_lt_coe, Real.coe_toNNReal', lt_sup_iff, or_imp, isEmpty_Prop, not_lt,
+    zero_le_coe, IsEmpty.forall_iff, and_true, NNReal.forall, coe_mk, forall_swap (α := _ ≤ _)]
+  refine forall₂_congr fun r hr ↦ ?_
+  simpa using (le_or_lt 0 r).imp_right fun hr ↦ .of_forall fun i ↦ hr.trans_le (by simp)
+
+@[simp, norm_cast]
+lemma toReal_limsup : limsup (fun i ↦ (u i : ℝ)) f = limsup u f := by
+  obtain rfl | hf := f.eq_or_neBot
+  · simp [limsup, limsSup, Real.sInf_of_not_bddBelow]
+  by_cases hf : f.IsBoundedUnder (· ≤ ·) u; swap
+  · simp [*]
+  have : f.IsCoboundedUnder (· ≤ ·) u := by isBoundedDefault
+  refine eq_of_forall_le_iff fun c ↦ ?_
+  rw [← Real.toNNReal_le_iff_le_coe, le_limsup_iff (by simpa) (by simpa), le_limsup_iff ‹_›]
+  simp only [← coe_lt_coe, Real.coe_toNNReal', lt_sup_iff, or_imp, isEmpty_Prop, not_lt,
+    zero_le_coe, IsEmpty.forall_iff, and_true, NNReal.forall, coe_mk, forall_swap (α := _ ≤ _)]
+  refine forall₂_congr fun r hr ↦ ?_
+  simpa using (le_or_lt 0 r).imp_right fun hr ↦ .of_forall fun i ↦ hr.trans_le (by simp)
+
+end NNReal
+
 namespace ENNReal
 
 variable {α : Type*} {f : Filter α}


### PR DESCRIPTION

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
