### PR TITLE
[Merged by Bors] - feat: additivise `Irreducible`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -347,6 +347,8 @@ import Mathlib.Algebra.Group.Int.TypeTags
 import Mathlib.Algebra.Group.Int.Units
 import Mathlib.Algebra.Group.Invertible.Basic
 import Mathlib.Algebra.Group.Invertible.Defs
+import Mathlib.Algebra.Group.Irreducible.Defs
+import Mathlib.Algebra.Group.Irreducible.Lemmas
 import Mathlib.Algebra.Group.MinimalAxioms
 import Mathlib.Algebra.Group.Nat.Defs
 import Mathlib.Algebra.Group.Nat.Even

--- a/Mathlib/Algebra/Group/Irreducible/Defs.lean
+++ b/Mathlib/Algebra/Group/Irreducible/Defs.lean
@@ -25,7 +25,7 @@ variable {M : Type*}
 structure AddIrreducible [AddMonoid M] (p : M) : Prop where
   /-- An irreducible element is not a unit. -/
   not_isAddUnit : ¬IsAddUnit p
-  /-- If an irreducible elements factors, then one factor is a unit. -/
+  /-- If an irreducible element factors, then one factor is a unit. -/
   isAddUnit_or_isAddUnit ⦃a b⦄ : p = a + b → IsAddUnit a ∨ IsAddUnit b
 
 section Monoid
@@ -39,7 +39,7 @@ monoid allows us to reuse irreducible for associated elements. -/
 structure Irreducible (p : M) : Prop where
   /-- An irreducible element is not a unit. -/
   not_isUnit : ¬IsUnit p
-  /-- If an irreducible elements factors, then one factor is a unit. -/
+  /-- If an irreducible element factors, then one factor is a unit. -/
   isUnit_or_isUnit ⦃a b⦄ : p = a * b → IsUnit a ∨ IsUnit b
 
 namespace Irreducible

--- a/Mathlib/Algebra/Group/Irreducible/Defs.lean
+++ b/Mathlib/Algebra/Group/Irreducible/Defs.lean
@@ -1,0 +1,71 @@
+/-
+Copyright (c) 2018 Johannes Hölzl. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Johannes Hölzl, Jens Wagemaker, Yaël Dillies
+-/
+import Mathlib.Algebra.Group.Units.Defs
+import Mathlib.Logic.Basic
+
+/-!
+# Irreducible elements in a monoid
+
+This file defines irreducible elements of a monoid (`Irreducible`), as non-units that can't be
+written as the product of two non-units. This generalises irreducible elements of a ring.
+We also define the additive variant (`AddIrreducible`).
+
+In decomposition monoids (e.g., `ℕ`, `ℤ`), this predicate is equivalent to `Prime`
+(see `irreducible_iff_prime`), however this is not true in general.
+-/
+
+assert_not_exists MonoidWithZero OrderedCommMonoid Multiset
+
+variable {M : Type*}
+
+/-- `AddIrreducible p` states that `p` is non-unit and only factors into units. -/
+structure AddIrreducible [AddMonoid M] (p : M) : Prop where
+  /-- An irreducible element is not a unit. -/
+  not_isAddUnit : ¬IsAddUnit p
+  /-- If an irreducible elements factors, then one factor is a unit. -/
+  isAddUnit_or_isAddUnit ⦃a b⦄ : p = a + b → IsAddUnit a ∨ IsAddUnit b
+
+section Monoid
+variable [Monoid M] {p q x y : M}
+
+/-- `Irreducible p` states that `p` is non-unit and only factors into units.
+
+We explicitly avoid stating that `p` is non-zero, this would require a semiring. Assuming only a
+monoid allows us to reuse irreducible for associated elements. -/
+@[to_additive]
+structure Irreducible (p : M) : Prop where
+  /-- An irreducible element is not a unit. -/
+  not_isUnit : ¬IsUnit p
+  /-- If an irreducible elements factors, then one factor is a unit. -/
+  isUnit_or_isUnit ⦃a b⦄ : p = a * b → IsUnit a ∨ IsUnit b
+
+namespace Irreducible
+
+@[deprecated (since := "2025-04-09")] alias not_unit := not_isUnit
+@[deprecated (since := "2025-04-10")] alias isUnit_or_isUnit' := isUnit_or_isUnit
+
+end Irreducible
+
+@[to_additive] lemma irreducible_iff :
+    Irreducible p ↔ ¬IsUnit p ∧ ∀ ⦃a b⦄, p = a * b → IsUnit a ∨ IsUnit b where
+  mp hp := ⟨hp.not_isUnit, hp.isUnit_or_isUnit⟩
+  mpr hp := ⟨hp.1, hp.2⟩
+
+@[to_additive (attr := simp)]
+lemma not_irreducible_one : ¬Irreducible (1 : M) := by simp [irreducible_iff]
+
+@[to_additive]
+lemma Irreducible.ne_one (hp : Irreducible p) : p ≠ 1 := by rintro rfl; exact not_irreducible_one hp
+
+@[to_additive]
+lemma of_irreducible_mul : Irreducible (x * y) → IsUnit x ∨ IsUnit y | ⟨_, h⟩ => h rfl
+
+@[to_additive]
+lemma irreducible_or_factor (hp : ¬IsUnit p) :
+    Irreducible p ∨ ∃ a b, ¬IsUnit a ∧ ¬IsUnit b ∧ p = a * b := by
+  simpa [irreducible_iff, hp, and_rotate] using em (∀ a b, p = a * b → IsUnit a ∨ IsUnit b)
+
+end Monoid

--- a/Mathlib/Algebra/Group/Irreducible/Defs.lean
+++ b/Mathlib/Algebra/Group/Irreducible/Defs.lean
@@ -21,11 +21,12 @@ assert_not_exists MonoidWithZero OrderedCommMonoid Multiset
 
 variable {M : Type*}
 
-/-- `AddIrreducible p` states that `p` is non-unit and only factors into units. -/
+/-- `AddIrreducible p` states that `p` is not an additive unit and cannot be written as a sum of
+additive non-units. -/
 structure AddIrreducible [AddMonoid M] (p : M) : Prop where
-  /-- An irreducible element is not a unit. -/
+  /-- An irreducible element is not an additive unit. -/
   not_isAddUnit : ¬IsAddUnit p
-  /-- If an irreducible element factors, then one factor is a unit. -/
+  /-- If an irreducible element can be written as a sum, then one term is an additive unit. -/
   isAddUnit_or_isAddUnit ⦃a b⦄ : p = a + b → IsAddUnit a ∨ IsAddUnit b
 
 section Monoid

--- a/Mathlib/Algebra/Group/Irreducible/Lemmas.lean
+++ b/Mathlib/Algebra/Group/Irreducible/Lemmas.lean
@@ -1,0 +1,118 @@
+/-
+Copyright (c) 2018 Johannes Hölzl. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Johannes Hölzl, Jens Wagemaker, Yaël Dillies
+-/
+import Mathlib.Algebra.Group.Commute.Units
+import Mathlib.Algebra.Group.Even
+import Mathlib.Algebra.Group.Irreducible.Defs
+import Mathlib.Algebra.Group.Units.Equiv
+
+/-!
+# More lemmas about irreducible elements
+-/
+
+assert_not_exists MonoidWithZero OrderedCommMonoid Multiset
+
+variable {F M N : Type*}
+
+section Monoid
+variable [Monoid M] [Monoid N] {f : F} {x y : M}
+
+@[to_additive]
+lemma not_irreducible_pow : ∀ {n : ℕ}, n ≠ 1 → ¬ Irreducible (x ^ n)
+  | 0, _ => by simp
+  | n + 2, _ => by
+    intro ⟨h₁, h₂⟩
+    have := h₂ (pow_succ _ _)
+    rw [isUnit_pow_iff n.succ_ne_zero, or_self] at this
+    exact h₁ (this.pow _)
+
+@[to_additive]
+lemma irreducible_units_mul (u : Mˣ) : Irreducible (u * y) ↔ Irreducible y := by
+  simp only [irreducible_iff, Units.isUnit_units_mul, and_congr_right_iff]
+  refine fun _ => ⟨fun h A B HAB => ?_, fun h A B HAB => ?_⟩
+  · rw [← u.isUnit_units_mul]
+    apply h
+    rw [mul_assoc, ← HAB]
+  · rw [← u⁻¹.isUnit_units_mul]
+    apply h
+    rw [mul_assoc, ← HAB, Units.inv_mul_cancel_left]
+
+@[to_additive]
+lemma irreducible_isUnit_mul (h : IsUnit x) : Irreducible (x * y) ↔ Irreducible y :=
+  let ⟨x, ha⟩ := h
+  ha ▸ irreducible_units_mul x
+
+@[to_additive]
+lemma irreducible_mul_units (u : Mˣ) : Irreducible (y * u) ↔ Irreducible y := by
+  simp only [irreducible_iff, Units.isUnit_mul_units, and_congr_right_iff]
+  refine fun _ => ⟨fun h A B HAB => ?_, fun h A B HAB => ?_⟩
+  · rw [← u.isUnit_mul_units B]
+    apply h
+    rw [← mul_assoc, ← HAB]
+  · rw [← u⁻¹.isUnit_mul_units B]
+    apply h
+    rw [← mul_assoc, ← HAB, Units.mul_inv_cancel_right]
+
+@[to_additive]
+lemma irreducible_mul_isUnit (h : IsUnit x) : Irreducible (y * x) ↔ Irreducible y :=
+  let ⟨x, hx⟩ := h
+  hx ▸ irreducible_mul_units x
+
+@[to_additive]
+lemma irreducible_mul_iff :
+    Irreducible (x * y) ↔ Irreducible x ∧ IsUnit y ∨ Irreducible y ∧ IsUnit x := by
+  constructor
+  · refine fun h => Or.imp (fun h' => ⟨?_, h'⟩) (fun h' => ⟨?_, h'⟩) (h.isUnit_or_isUnit rfl).symm
+    · rwa [irreducible_mul_isUnit h'] at h
+    · rwa [irreducible_isUnit_mul h'] at h
+  · rintro (⟨ha, hb⟩ | ⟨hb, ha⟩)
+    · rwa [irreducible_mul_isUnit hb]
+    · rwa [irreducible_isUnit_mul ha]
+
+section MulEquivClass
+variable [EquivLike F M N] [MulEquivClass F M N] (f : F)
+
+@[to_additive]
+lemma MulEquiv.irreducible_iff : Irreducible (f x) ↔ Irreducible x := by
+  simp [_root_.irreducible_iff, (EquivLike.surjective f).forall, ← map_mul, -isUnit_map_iff]
+
+/--
+Irreducibility is preserved by multiplicative equivalences.
+Note that surjective + local hom is not enough. Consider the additive monoids `M = ℕ ⊕ ℕ`, `N = ℕ`,
+with x surjective local (additive) hom `f : M →+ N` sending `(m, n)` to `2m + n`.
+It is local because the only add unit in `N` is `0`, with preimage `{(0, 0)}` also an add unit.
+Then `x = (1, 0)` is irreducible in `M`, but `f x = 2 = 1 + 1` is not irreducible in `N`.
+-/
+@[to_additive
+"Irreducibility is preserved by additive equivalences.
+Note that surjective + local hom is not enough. Consider the additive monoids `M = ℕ ⊕ ℕ`, `N = ℕ`,
+with x surjective local (additive) hom `f : M →+ N` sending `(m, n)` to `2m + n`.
+It is local because the only add unit in `N` is `0`, with preimage `{(0, 0)}` also an add unit.
+Then `x = (1, 0)` is irreducible in `M`, but `f x = 2 = 1 + 1` is not irreducible in `N`."]
+alias ⟨_, Irreducible.map⟩ := MulEquiv.irreducible_iff
+
+end MulEquivClass
+
+lemma Irreducible.of_map [FunLike F M N] [MonoidHomClass F M N] [IsLocalHom f]
+    (hfx : Irreducible (f x)) : Irreducible x where
+  not_isUnit hu := hfx.not_isUnit <| hu.map f
+  isUnit_or_isUnit := by
+    rintro p q rfl; exact (hfx.isUnit_or_isUnit <| map_mul f p q).imp (.of_map f _) (.of_map f _)
+
+end Monoid
+
+section CommMonoid
+variable [CommMonoid M] {x : M}
+
+@[to_additive]
+lemma Irreducible.not_square (ha : Irreducible x) : ¬IsSquare x := by
+  rw [isSquare_iff_exists_sq]
+  rintro ⟨y, rfl⟩
+  exact not_irreducible_pow (by decide) ha
+
+@[to_additive]
+lemma IsSquare.not_irreducible (ha : IsSquare x) : ¬Irreducible x := fun h => h.not_square ha
+
+end CommMonoid

--- a/Mathlib/Algebra/Group/Irreducible/Lemmas.lean
+++ b/Mathlib/Algebra/Group/Irreducible/Lemmas.lean
@@ -78,19 +78,13 @@ variable [EquivLike F M N] [MulEquivClass F M N] (f : F)
 lemma MulEquiv.irreducible_iff : Irreducible (f x) ↔ Irreducible x := by
   simp [_root_.irreducible_iff, (EquivLike.surjective f).forall, ← map_mul, -isUnit_map_iff]
 
-/--
-Irreducibility is preserved by multiplicative equivalences.
+/-- Irreducibility is preserved by multiplicative equivalences.
+
 Note that surjective + local hom is not enough. Consider the additive monoids `M = ℕ ⊕ ℕ`, `N = ℕ`,
 with x surjective local (additive) hom `f : M →+ N` sending `(m, n)` to `2m + n`.
 It is local because the only add unit in `N` is `0`, with preimage `{(0, 0)}` also an add unit.
-Then `x = (1, 0)` is irreducible in `M`, but `f x = 2 = 1 + 1` is not irreducible in `N`.
--/
-@[to_additive
-"Irreducibility is preserved by additive equivalences.
-Note that surjective + local hom is not enough. Consider the additive monoids `M = ℕ ⊕ ℕ`, `N = ℕ`,
-with x surjective local (additive) hom `f : M →+ N` sending `(m, n)` to `2m + n`.
-It is local because the only add unit in `N` is `0`, with preimage `{(0, 0)}` also an add unit.
-Then `x = (1, 0)` is irreducible in `M`, but `f x = 2 = 1 + 1` is not irreducible in `N`."]
+Then `x = (1, 0)` is irreducible in `M`, but `f x = 2 = 1 + 1` is not irreducible in `N`. -/
+@[to_additive "Irreducibility is preserved by additive equivalences."]
 alias ⟨_, Irreducible.map⟩ := MulEquiv.irreducible_iff
 
 end MulEquivClass

--- a/Mathlib/Algebra/Group/Units/Equiv.lean
+++ b/Mathlib/Algebra/Group/Units/Equiv.lean
@@ -184,10 +184,17 @@ theorem MulEquiv.inv_symm (G : Type*) [DivisionCommMonoid G] :
     (MulEquiv.inv G).symm = MulEquiv.inv G :=
   rfl
 
-@[instance]
-theorem isLocalHom_equiv [Monoid M] [Monoid N] [EquivLike F M N]
-    [MulEquivClass F M N] (f : F) : IsLocalHom f where
-  map_nonunit a ha := by
-    convert ha.map (f : M ≃* N).symm
-    rw [MulEquiv.eq_symm_apply]
-    rfl -- note to reviewers: ugly `rfl`
+section EquivLike
+variable [Monoid M] [Monoid N] [EquivLike F M N] [MulEquivClass F M N] (f : F) {x : M}
+
+-- Higher priority to take over the non-additivisable `isUnit_map_iff`
+@[to_additive (attr := simp high)]
+lemma MulEquiv.isUnit_map : IsUnit (f x) ↔ IsUnit x where
+  mp hx := by
+    simpa using hx.map <| MonoidHom.mk ⟨EquivLike.inv f, EquivLike.injective f <| by simp⟩
+      fun x y ↦ EquivLike.injective f <| by simp
+  mpr := .map f
+
+@[instance] theorem isLocalHom_equiv : IsLocalHom f where map_nonunit := by simp
+
+end EquivLike

--- a/Mathlib/Algebra/Prime/Defs.lean
+++ b/Mathlib/Algebra/Prime/Defs.lean
@@ -3,10 +3,11 @@ Copyright (c) 2018 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Jens Wagemaker
 -/
+import Mathlib.Algebra.Group.Irreducible.Defs
 import Mathlib.Algebra.GroupWithZero.Divisibility
 
 /-!
-# Prime and irreducible elements.
+# Prime elements
 
 In this file we define the predicate `Prime p`
 saying that an element of a commutative monoid with zero is prime.
@@ -17,11 +18,12 @@ In decomposition monoids (e.g., `ℕ`, `ℤ`), this predicate is equivalent to `
 (see `irreducible_iff_prime`), however this is not true in general.
 
 ## Main definitions
- * `Prime`: a prime element of a commutative monoid with zero
- * `Irreducible`: an irreducible element of a commutative monoid with zero
+
+* `Prime`: a prime element of a commutative monoid with zero
 
 ## Main results
- * `irreducible_iff_prime`: the two definitions are equivalent in a decomposition monoid.
+
+* `irreducible_iff_prime`: the two definitions are equivalent in a decomposition monoid.
 -/
 
 assert_not_exists OrderedCommMonoid Multiset
@@ -91,36 +93,8 @@ theorem not_prime_one : ¬Prime (1 : M) := fun h => h.not_unit isUnit_one
 
 end Prime
 
-/-- `Irreducible p` states that `p` is non-unit and only factors into units.
-
-We explicitly avoid stating that `p` is non-zero, this would require a semiring. Assuming only a
-monoid allows us to reuse irreducible for associated elements.
--/
-structure Irreducible [Monoid M] (p : M) : Prop where
-  /-- `p` is not a unit -/
-  not_isUnit : ¬IsUnit p
-  /-- if `p` factors then one factor is a unit -/
-  isUnit_or_isUnit ⦃a b⦄ : p = a * b → IsUnit a ∨ IsUnit b
-
-namespace Irreducible
-
-@[deprecated (since := "2025-04-09")] alias not_unit := not_isUnit
-@[deprecated (since := "2025-04-10")] alias isUnit_or_isUnit' := isUnit_or_isUnit
-
-theorem not_dvd_one [CommMonoid M] {p : M} (hp : Irreducible p) : ¬p ∣ 1 :=
+theorem Irreducible.not_dvd_one [CommMonoid M] {p : M} (hp : Irreducible p) : ¬p ∣ 1 :=
   mt (isUnit_of_dvd_one ·) hp.not_isUnit
-
-end Irreducible
-
-theorem irreducible_iff [Monoid M] {p : M} :
-    Irreducible p ↔ ¬IsUnit p ∧ ∀ ⦃a b⦄, p = a * b → IsUnit a ∨ IsUnit b :=
-  ⟨fun h => ⟨h.1, h.2⟩, fun h => ⟨h.1, h.2⟩⟩
-
-@[simp]
-theorem not_irreducible_one [Monoid M] : ¬Irreducible (1 : M) := by simp [irreducible_iff]
-
-theorem Irreducible.ne_one [Monoid M] : ∀ {p : M}, Irreducible p → p ≠ 1
-  | _, hp, rfl => not_irreducible_one hp
 
 @[simp]
 theorem not_irreducible_zero [MonoidWithZero M] : ¬Irreducible (0 : M)
@@ -130,20 +104,6 @@ theorem not_irreducible_zero [MonoidWithZero M] : ¬Irreducible (0 : M)
 
 theorem Irreducible.ne_zero [MonoidWithZero M] : ∀ {p : M}, Irreducible p → p ≠ 0
   | _, hp, rfl => not_irreducible_zero hp
-
-theorem of_irreducible_mul {M} [Monoid M] {x y : M} : Irreducible (x * y) → IsUnit x ∨ IsUnit y
-  | ⟨_, h⟩ => h rfl
-
-theorem irreducible_or_factor {M} [Monoid M] (x : M) (h : ¬IsUnit x) :
-    Irreducible x ∨ ∃ a b, ¬IsUnit a ∧ ¬IsUnit b ∧ a * b = x := by
-  haveI := Classical.dec
-  refine or_iff_not_imp_right.2 fun H => ?_
-  simp? [h, irreducible_iff] at H ⊢ says
-    simp only [exists_and_left, not_exists, not_and, irreducible_iff, h, not_false_eq_true,
-      true_and] at H ⊢
-  refine fun a b h => by_contradiction fun o => ?_
-  simp? [not_or] at o says simp only [not_or] at o
-  exact H _ o.1 _ o.2 h.symm
 
 /-- If `p` and `q` are irreducible, then `p ∣ q` implies `q ∣ p`. -/
 theorem Irreducible.dvd_symm [Monoid M] {p q : M} (hp : Irreducible p) (hq : Irreducible q) :

--- a/Mathlib/Algebra/Prime/Lemmas.lean
+++ b/Mathlib/Algebra/Prime/Lemmas.lean
@@ -4,9 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Jens Wagemaker
 -/
 import Mathlib.Algebra.Divisibility.Hom
-import Mathlib.Algebra.Group.Commute.Units
-import Mathlib.Algebra.Group.Even
-import Mathlib.Algebra.Group.Units.Equiv
+import Mathlib.Algebra.Group.Irreducible.Lemmas
 import Mathlib.Algebra.GroupWithZero.Equiv
 import Mathlib.Algebra.Prime.Defs
 import Mathlib.Order.Monotone.Defs
@@ -116,100 +114,6 @@ theorem prime_pow_succ_dvd_mul {M : Type*} [CancelCommMonoidWithZero M] {p x y :
     obtain ⟨x', rfl⟩ := (h.dvd_or_dvd (dvd_of_mul_right_dvd hxy)).resolve_right hy
     rw [mul_assoc] at hxy
     exact mul_dvd_mul_left p (ih ((mul_dvd_mul_iff_left h.ne_zero).mp hxy))
-
-theorem not_irreducible_pow {M} [Monoid M] {x : M} {n : ℕ} (hn : n ≠ 1) :
-    ¬ Irreducible (x ^ n) := by
-  cases n with
-  | zero => simp
-  | succ n =>
-    intro ⟨h₁, h₂⟩
-    have := h₂ (pow_succ _ _)
-    rw [isUnit_pow_iff (Nat.succ_ne_succ.mp hn), or_self] at this
-    exact h₁ (this.pow _)
-
-theorem Irreducible.of_map {F : Type*} [Monoid M] [Monoid N] [FunLike F M N] [MonoidHomClass F M N]
-    {f : F} [IsLocalHom f] {x} (hfx : Irreducible (f x)) : Irreducible x :=
-  ⟨fun hu ↦ hfx.not_isUnit <| hu.map f,
-   by rintro p q rfl
-      exact (hfx.isUnit_or_isUnit <| map_mul f p q).imp (.of_map f _) (.of_map f _)⟩
-
-section
-
-variable [Monoid M]
-
-theorem irreducible_units_mul (a : Mˣ) (b : M) : Irreducible (↑a * b) ↔ Irreducible b := by
-  simp only [irreducible_iff, Units.isUnit_units_mul, and_congr_right_iff]
-  refine fun _ => ⟨fun h A B HAB => ?_, fun h A B HAB => ?_⟩
-  · rw [← a.isUnit_units_mul]
-    apply h
-    rw [mul_assoc, ← HAB]
-  · rw [← a⁻¹.isUnit_units_mul]
-    apply h
-    rw [mul_assoc, ← HAB, Units.inv_mul_cancel_left]
-
-theorem irreducible_isUnit_mul {a b : M} (h : IsUnit a) : Irreducible (a * b) ↔ Irreducible b :=
-  let ⟨a, ha⟩ := h
-  ha ▸ irreducible_units_mul a b
-
-theorem irreducible_mul_units (a : Mˣ) (b : M) : Irreducible (b * ↑a) ↔ Irreducible b := by
-  simp only [irreducible_iff, Units.isUnit_mul_units, and_congr_right_iff]
-  refine fun _ => ⟨fun h A B HAB => ?_, fun h A B HAB => ?_⟩
-  · rw [← Units.isUnit_mul_units B a]
-    apply h
-    rw [← mul_assoc, ← HAB]
-  · rw [← Units.isUnit_mul_units B a⁻¹]
-    apply h
-    rw [← mul_assoc, ← HAB, Units.mul_inv_cancel_right]
-
-theorem irreducible_mul_isUnit {a b : M} (h : IsUnit a) : Irreducible (b * a) ↔ Irreducible b :=
-  let ⟨a, ha⟩ := h
-  ha ▸ irreducible_mul_units a b
-
-theorem irreducible_mul_iff {a b : M} :
-    Irreducible (a * b) ↔ Irreducible a ∧ IsUnit b ∨ Irreducible b ∧ IsUnit a := by
-  constructor
-  · refine fun h => Or.imp (fun h' => ⟨?_, h'⟩) (fun h' => ⟨?_, h'⟩) (h.isUnit_or_isUnit rfl).symm
-    · rwa [irreducible_mul_isUnit h'] at h
-    · rwa [irreducible_isUnit_mul h'] at h
-  · rintro (⟨ha, hb⟩ | ⟨hb, ha⟩)
-    · rwa [irreducible_mul_isUnit hb]
-    · rwa [irreducible_isUnit_mul ha]
-
-variable [Monoid N] {F : Type*} [EquivLike F M N] [MulEquivClass F M N] (f : F)
-
-open MulEquiv
-
-/--
-Irreducibility is preserved by multiplicative equivalences.
-Note that surjective + local hom is not enough. Consider the additive monoids `M = ℕ ⊕ ℕ`, `N = ℕ`,
-with a surjective local (additive) hom `f : M →+ N` sending `(m, n)` to `2m + n`.
-It is local because the only add unit in `N` is `0`, with preimage `{(0, 0)}` also an add unit.
-Then `x = (1, 0)` is irreducible in `M`, but `f x = 2 = 1 + 1` is not irreducible in `N`.
--/
-theorem Irreducible.map {x : M} (h : Irreducible x) : Irreducible (f x) :=
-  ⟨fun g ↦ h.not_isUnit g.of_map, fun a b g ↦
-    let f := MulEquivClass.toMulEquiv f
-    (h.isUnit_or_isUnit (symm_apply_apply f x ▸ map_mul f.symm a b ▸ congrArg f.symm g)).imp
-      (·.of_map) (·.of_map)⟩
-
-theorem MulEquiv.irreducible_iff (f : F) {a : M} :
-    Irreducible (f a) ↔ Irreducible a :=
-  ⟨Irreducible.of_map, Irreducible.map f⟩
-
-end
-
-section CommMonoid
-
-variable [CommMonoid M] {a : M}
-
-theorem Irreducible.not_square (ha : Irreducible a) : ¬IsSquare a := by
-  rw [isSquare_iff_exists_sq]
-  rintro ⟨b, rfl⟩
-  exact not_irreducible_pow (by decide) ha
-
-theorem IsSquare.not_irreducible (ha : IsSquare a) : ¬Irreducible a := fun h => h.not_square ha
-
-end CommMonoid
 
 section CancelCommMonoidWithZero
 

--- a/Mathlib/Tactic/ToAdditive/Frontend.lean
+++ b/Mathlib/Tactic/ToAdditive/Frontend.lean
@@ -996,6 +996,7 @@ def nameDict : String → List String
   | "quantale"    => ["add", "Quantale"]
   | "square"      => ["even"]
   | "mconv"       => ["conv"]
+  | "irreducible" => ["add", "Irreducible"]
   | x             => [x]
 
 /--


### PR DESCRIPTION
In the Toric project, we need to talk about (additive) irreducible elements of a lattice cone (they generate the cone). There is no definition of additive irreducible elements in mathlib, but luckily the existing definition of multiplicative irreducible elements talks about general monoids (instead of merely monoids with zero).

This PR additivises all the API, except for the parts about divisibility and monoids with zero, and moves it to a new file under `Algebra.Group`.

From Toric


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
