### PR TITLE
[Merged by Bors] - chore(CategoryTheory): remove local truncated simplicial notation

### DIFF
--- a/Mathlib/AlgebraicTopology/SimplicialSet/NerveAdjunction.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/NerveAdjunction.lean
@@ -31,8 +31,8 @@ reflective. Since the category of simplicial sets is cocomplete, we conclude in
 
 namespace CategoryTheory
 
-open Category Functor Limits Opposite SimplexCategory Simplicial SSet Nerve Truncated
-open SimplexCategory.Truncated SimplicialObject.Truncated
+open Category Functor Limits Opposite SimplexCategory Simplicial SSet Nerve
+open SSet.Truncated SimplexCategory.Truncated SimplicialObject.Truncated
 universe v u v' u'
 
 section

--- a/Mathlib/AlgebraicTopology/SimplicialSet/NerveAdjunction.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/NerveAdjunction.lean
@@ -32,16 +32,10 @@ reflective. Since the category of simplicial sets is cocomplete, we conclude in
 namespace CategoryTheory
 
 open Category Functor Limits Opposite SimplexCategory Simplicial SSet Nerve Truncated
+open SimplexCategory.Truncated SimplicialObject.Truncated
 universe v u v' u'
 
 section
-
-set_option quotPrecheck false
-local macro:max (priority := high) "⦋" n:term "⦌₂" : term =>
-  `((⟨SimplexCategory.mk $n, by decide⟩ : SimplexCategory.Truncated 2))
-
-local macro:1000 (priority := high) X:term " _⦋" n:term "⦌₂" : term =>
-    `(($X : SSet.Truncated 2).obj (Opposite.op ⟨SimplexCategory.mk $n, by decide⟩))
 
 /-- The components of the counit of `nerve₂Adj`. -/
 @[simps!]
@@ -301,8 +295,9 @@ end
 underlying refl prefunctors. -/
 theorem toNerve₂.ext (F G : X ⟶ nerveFunctor₂.obj (Cat.of C))
     (hyp : SSet.oneTruncation₂.map F = SSet.oneTruncation₂.map G) : F = G := by
-  have eq₀ x : F.app (op ⦋0⦌₂) x = G.app (op ⦋0⦌₂) x := congr(($hyp).obj x)
-  have eq₁ x : F.app (op ⦋1⦌₂) x = G.app (op ⦋1⦌₂) x := congr((($hyp).map ⟨x, rfl, rfl⟩).1)
+  have eq₀ (x : X _⦋0⦌₂) : F.app (op ⦋0⦌₂) x = G.app (op ⦋0⦌₂) x := congr(($hyp).obj x)
+  have eq₁ (x : X _⦋1⦌₂) : F.app (op ⦋1⦌₂) x = G.app (op ⦋1⦌₂) x :=
+    congr((($hyp).map ⟨x, rfl, rfl⟩).1)
   ext ⟨⟨n, hn⟩⟩ x
   induction' n using SimplexCategory.rec with n
   match n with
@@ -412,8 +407,8 @@ nonrec def nerve₂Adj : hoFunctor₂.{u} ⊣ nerveFunctor₂ :=
       simp [reassoc_of% this]
   }
 
-instance nerveFunctor₂.faithful : nerveFunctor₂.{u, u}.Faithful := by
-  exact Functor.Faithful.of_comp_iso
+instance nerveFunctor₂.faithful : nerveFunctor₂.{u, u}.Faithful :=
+  Functor.Faithful.of_comp_iso
     (G := oneTruncation₂) (H := ReflQuiv.forget) OneTruncation₂.ofNerve₂.natIso
 
 instance nerveFunctor₂.full : nerveFunctor₂.{u, u}.Full where


### PR DESCRIPTION
This removes local notation about the truncated simplex category and truncated simplicial sets that is now available globally in mathlib.

---

I'm a bit confused about `open Truncated` which seems distinct from `open SimplexCategory.Truncated` and `open SimplicialObject.Truncated`. Otherwise I believe this change to be very minor.

UPDATE: Nick figured out that was `SSet.Truncated`.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
