### PR TITLE
[Merged by Bors] - chore(Data): go through remaining porting notes

### DIFF
--- a/Mathlib/Data/Analysis/Filter.lean
+++ b/Mathlib/Data/Analysis/Filter.lean
@@ -20,7 +20,7 @@ This file provides infrastructure to compute with filters.
 
 open Set Filter
 
--- Porting note (https://github.com/leanprover-community/mathlib4/issues/11215): TODO write doc strings
+-- TODO write doc strings
 /-- A `CFilter α σ` is a realization of a filter (base) on `α`,
   represented by a type `σ` together with operations for the top element and
   the binary `inf` operation. -/
@@ -46,13 +46,13 @@ section
 
 variable [PartialOrder α] (F : CFilter α σ)
 
+/-
+A DFunLike instance would not be mathematically meaningful here, since the coercion to f cannot b
+injective.
+-/
 instance : CoeFun (CFilter α σ) fun _ ↦ σ → α :=
   ⟨CFilter.f⟩
 
-/- Porting note: Due to the CoeFun instance, the lhs of this lemma has a variable (f) as its head
-symbol (simpnf linter problem). Replacing it with a DFunLike instance would not be mathematically
-meaningful here, since the coercion to f cannot be injective, hence need to remove @[simp]. -/
--- @[simp]
 theorem coe_mk (f pt inf h₁ h₂ a) : (@CFilter.mk α σ _ f pt inf h₁ h₂) a = f a :=
   rfl
 
@@ -86,7 +86,7 @@ theorem mem_toFilter_sets (F : CFilter (Set α) σ) {a : Set α} : a ∈ F.toFil
 
 end CFilter
 
--- Porting note (https://github.com/leanprover-community/mathlib4/issues/11215): TODO write doc strings
+-- TODO write doc strings
 /-- A realizer for filter `f` is a cfilter which generates `f`. -/
 structure Filter.Realizer (f : Filter α) where
   σ : Type*

--- a/Mathlib/Data/Analysis/Topology.lean
+++ b/Mathlib/Data/Analysis/Topology.lean
@@ -57,7 +57,6 @@ variable (F : Ctop α σ)
 instance : CoeFun (Ctop α σ) fun _ ↦ σ → Set α :=
   ⟨Ctop.f⟩
 
--- @[simp] -- Porting note (https://github.com/leanprover-community/mathlib4/issues/10685): dsimp can prove this
 theorem coe_mk (f T h₁ I h₂ h₃ a) : (@Ctop.mk α σ f T h₁ I h₂ h₃) a = f a := rfl
 
 /-- Map a Ctop to an equivalent representation type. -/

--- a/Mathlib/Data/Bool/Basic.lean
+++ b/Mathlib/Data/Bool/Basic.lean
@@ -126,7 +126,7 @@ lemma self_ne_not : ∀ b : Bool, b ≠ !b := by decide
 
 lemma eq_or_eq_not : ∀ a b, a = b ∨ a = !b := by decide
 
--- Porting note: naming issue again: these two `not` are different.
+-- TODO naming issue: these two `not` are different.
 theorem not_iff_not : ∀ {b : Bool}, !b ↔ ¬b := by simp
 
 theorem eq_true_of_not_eq_false' {a : Bool} : !a = false → a = true := by

--- a/Mathlib/Data/Bool/Count.lean
+++ b/Mathlib/Data/Bool/Count.lean
@@ -20,11 +20,8 @@ namespace List
 
 @[simp]
 theorem count_not_add_count (l : List Bool) (b : Bool) : count (!b) l + count b l = length l := by
-  -- Porting note: Proof re-written
-  -- Old proof: simp only [length_eq_countP_add_countP (Eq (!b)), Bool.not_not_eq, count]
-  simp only [length_eq_countP_add_countP (· == !b), count, add_right_inj]
-  suffices (fun x => x == b) = (fun a => decide ¬(a == !b) = true) by rw [this]
-  ext x; cases x <;> cases b <;> rfl
+  have := length_eq_countP_add_countP (· == !b)
+  aesop (add simp this)
 
 @[simp]
 theorem count_add_count_not (l : List Bool) (b : Bool) : count b l + count (!b) l = length l := by
@@ -56,11 +53,7 @@ theorem count_not_eq_count (hl : Chain' (· ≠ ·) l) (h2 : Even (length l)) (b
   · rfl
   rw [length_cons, Nat.even_add_one, Nat.not_even_iff] at h2
   suffices count (!x) (x :: l) = count x (x :: l) by
-    -- Porting note: old proof is
-    -- cases b <;> cases x <;> try exact this;
-    cases b <;> cases x <;>
-    revert this <;> simp only [Bool.not_false, Bool.not_true] <;> intro this <;>
-    (try exact this) <;> exact this.symm
+    cases b <;> cases x <;> (try exact this) <;> exact this.symm
   rw [count_cons_of_ne x.not_ne_self, hl.count_not, h2, count_cons_self]
 
 theorem count_false_eq_count_true (hl : Chain' (· ≠ ·) l) (h2 : Even (length l)) :

--- a/Mathlib/Data/Bundle.lean
+++ b/Mathlib/Data/Bundle.lean
@@ -141,6 +141,4 @@ theorem Pullback.lift_mk (f : B' → B) (x : B') (y : E (f x)) :
 
 end Pullback
 
--- Porting note: not needed since Lean unfolds coercion
-
 end Bundle

--- a/Mathlib/Data/Complex/Basic.lean
+++ b/Mathlib/Data/Complex/Basic.lean
@@ -74,7 +74,6 @@ theorem range_re : range re = univ :=
 theorem range_im : range im = univ :=
   im_surjective.range_eq
 
--- Porting note: refactored instance to allow `norm_cast` to work
 /-- The natural inclusion of the real numbers into the complex numbers. -/
 @[coe]
 def ofReal (r : ℝ) : ℂ :=
@@ -99,10 +98,8 @@ theorem ofReal_def (r : ℝ) : (r : ℂ) = ⟨r, 0⟩ :=
 theorem ofReal_inj {z w : ℝ} : (z : ℂ) = w ↔ z = w :=
   ⟨congrArg re, by apply congrArg⟩
 
--- Porting note: made coercion explicit
 theorem ofReal_injective : Function.Injective ((↑) : ℝ → ℂ) := fun _ _ => congrArg re
 
--- Porting note: made coercion explicit
 instance canLift : CanLift ℂ ℝ (↑) fun z => z.im = 0 where
   prf z hz := ⟨z.re, ext rfl hz.symm⟩
 
@@ -289,7 +286,6 @@ defined in `Data.Complex.Module`. -/
 instance : Nontrivial ℂ :=
   domain_nontrivial re rfl rfl
 
--- Porting note: moved from `Module/Data/Complex/Basic.lean`
 namespace SMul
 
 -- The useless `0` multiplication in `smul` is to make sure that
@@ -320,7 +316,6 @@ theorem real_smul {x : ℝ} {z : ℂ} : x • z = x * z :=
 
 end SMul
 
--- Porting note: proof needed modifications and rewritten fields
 instance addCommGroup : AddCommGroup ℂ :=
   { zero := (0 : ℂ)
     add := (· + ·)
@@ -330,17 +325,13 @@ instance addCommGroup : AddCommGroup ℂ :=
     zsmul := fun n z => n • z
     zsmul_zero' := by intros; ext <;> simp [smul_re, smul_im]
     nsmul_zero := by intros; ext <;> simp [smul_re, smul_im]
-    nsmul_succ := by
-      intros; ext <;> simp [AddMonoid.nsmul_succ, add_mul, add_comm,
-        smul_re, smul_im]
-    zsmul_succ' := by
-      intros; ext <;> simp [add_mul, smul_re, smul_im]
-    zsmul_neg' := by
-      intros; ext <;> simp [zsmul_neg', add_mul, smul_re, smul_im]
-    add_assoc := by intros; ext <;> simp [add_assoc]
+    nsmul_succ := by intros; ext <;> simp [smul_re, smul_im] <;> ring
+    zsmul_succ' := by intros; ext <;> simp [smul_re, smul_im] <;> ring
+    zsmul_neg' := by intros; ext <;> simp [smul_re, smul_im] <;> ring
+    add_assoc := by intros; ext <;> simp <;> ring
     zero_add := by intros; ext <;> simp
     add_zero := by intros; ext <;> simp
-    add_comm := by intros; ext <;> simp [add_comm]
+    add_comm := by intros; ext <;> simp <;> ring
     neg_add_cancel := by intros; ext <;> simp }
 
 
@@ -362,22 +353,19 @@ instance addGroupWithOne : AddGroupWithOne ℂ :=
         rfl
     one := 1 }
 
--- Porting note: proof needed modifications and rewritten fields
 instance commRing : CommRing ℂ :=
   { addGroupWithOne with
     mul := (· * ·)
     npow := @npowRec _ ⟨(1 : ℂ)⟩ ⟨(· * ·)⟩
-    add_comm := by intros; ext <;> simp [add_comm]
-    left_distrib := by
-      intros; ext <;> simp [mul_re, mul_im] <;> ring
-    right_distrib := by
-      intros; ext <;> simp [mul_re, mul_im] <;> ring
-    zero_mul := by intros; ext <;> simp [zero_mul]
-    mul_zero := by intros; ext <;> simp [mul_zero]
-    mul_assoc := by intros; ext <;> simp [mul_assoc] <;> ring
-    one_mul := by intros; ext <;> simp [one_mul]
-    mul_one := by intros; ext <;> simp [mul_one]
-    mul_comm := by intros; ext <;> simp [mul_comm]; ring }
+    add_comm := by intros; ext <;> simp <;> ring
+    left_distrib := by intros; ext <;> simp [mul_re, mul_im] <;> ring
+    right_distrib := by intros; ext <;> simp [mul_re, mul_im] <;> ring
+    zero_mul := by intros; ext <;> simp
+    mul_zero := by intros; ext <;> simp
+    mul_assoc := by intros; ext <;> simp <;> ring
+    one_mul := by intros; ext <;> simp
+    mul_one := by intros; ext <;> simp
+    mul_comm := by intros; ext <;> simp <;> ring }
 
 /-- This shortcut instance ensures we do not find `Ring` via the noncomputable `Complex.field`
 instance. -/
@@ -388,7 +376,6 @@ instance : Ring ℂ := by infer_instance
 instance : CommSemiring ℂ :=
   inferInstance
 
--- Porting note: added due to changes in typeclass search order
 /-- This shortcut instance ensures we do not find `Semiring` via the noncomputable
 `Complex.field` instance. -/
 instance : Semiring ℂ :=
@@ -485,12 +472,7 @@ theorem conj_natCast (n : ℕ) : conj (n : ℂ) = n := map_natCast _ _
 theorem conj_ofNat (n : ℕ) [n.AtLeastTwo] : conj (ofNat(n) : ℂ) = ofNat(n) :=
   map_ofNat _ _
 
--- @[simp]
-/- Porting note (https://github.com/leanprover-community/mathlib4/issues/11119): `simp` attribute removed as the result could be proved
-by `simp only [@map_neg, Complex.conj_i, @neg_neg]`
--/
-theorem conj_neg_I : conj (-I) = I :=
-  Complex.ext_iff.2 <| by simp
+theorem conj_neg_I : conj (-I) = I := by simp
 
 theorem conj_eq_iff_real {z : ℂ} : conj z = z ↔ ∃ r : ℝ, z = r :=
   ⟨fun h => ⟨z.re, ext rfl <| eq_zero_of_neg_eq (congr_arg im h)⟩, fun ⟨h, e⟩ => by
@@ -503,9 +485,6 @@ theorem conj_eq_iff_im {z : ℂ} : conj z = z ↔ z.im = 0 :=
   ⟨fun h => add_self_eq_zero.mp (neg_eq_iff_add_eq_zero.mp (congr_arg im h)), fun h =>
     ext rfl (neg_eq_iff_add_eq_zero.mpr (add_self_eq_zero.mpr h))⟩
 
--- `simpNF` complains about this being provable by `RCLike.star_def` even
--- though it's not imported by this file.
--- Porting note: linter `simpNF` not found
 @[simp]
 theorem star_def : (Star.star : ℂ → ℂ) = conj :=
   rfl
@@ -554,17 +533,9 @@ theorem normSq_add_mul_I (x y : ℝ) : normSq (x + y * I) = x ^ 2 + y ^ 2 := by
 theorem normSq_eq_conj_mul_self {z : ℂ} : (normSq z : ℂ) = conj z * z := by
   ext <;> simp [normSq, mul_comm, ofReal]
 
--- @[simp]
-/- Porting note (https://github.com/leanprover-community/mathlib4/issues/11119): `simp` attribute removed as linter reports this can be proved
-by `simp only [@map_zero]` -/
-theorem normSq_zero : normSq 0 = 0 :=
-  normSq.map_zero
+theorem normSq_zero : normSq 0 = 0 := by simp
 
--- @[simp]
-/- Porting note (https://github.com/leanprover-community/mathlib4/issues/11119): `simp` attribute removed as linter reports this can be proved
-by `simp only [@map_one]` -/
-theorem normSq_one : normSq 1 = 1 :=
-  normSq.map_one
+theorem normSq_one : normSq 1 = 1 := by simp
 
 @[simp]
 theorem normSq_I : normSq I = 1 := by simp [normSq]
@@ -738,17 +709,9 @@ theorem div_I (z : ℂ) : z / I = -(z * I) :=
 theorem inv_I : I⁻¹ = -I := by
   rw [inv_eq_one_div, div_I, one_mul]
 
--- @[simp]
-/- Porting note (https://github.com/leanprover-community/mathlib4/issues/11119): `simp` attribute removed as linter reports this can be proved
-by `simp only [@map_inv₀]` -/
-theorem normSq_inv (z : ℂ) : normSq z⁻¹ = (normSq z)⁻¹ :=
-  map_inv₀ normSq z
+theorem normSq_inv (z : ℂ) : normSq z⁻¹ = (normSq z)⁻¹ := by simp
 
--- @[simp]
-/- Porting note (https://github.com/leanprover-community/mathlib4/issues/11119): `simp` attribute removed as linter reports this can be proved
-by `simp only [@map_div₀]` -/
-theorem normSq_div (z w : ℂ) : normSq (z / w) = normSq z / normSq w :=
-  map_div₀ normSq z w
+theorem normSq_div (z w : ℂ) : normSq (z / w) = normSq z / normSq w := by simp
 
 lemma div_ofReal (z : ℂ) (x : ℝ) : z / x = ⟨z.re / x, z.im / x⟩ := by
   simp_rw [div_eq_inv_mul, ← ofReal_inv, ofReal_mul']

--- a/Mathlib/Data/Complex/Cardinality.lean
+++ b/Mathlib/Data/Complex/Cardinality.lean
@@ -11,8 +11,6 @@ import Mathlib.Data.Real.Cardinality
 
 This file shows that the complex numbers have cardinality continuum, i.e. `#ℂ = 𝔠`.
 -/
--- Porting note: the lemmas `mk_complex` and `mk_univ_complex` should be in the namespace `Cardinal`
--- like their real counterparts.
 
 open Cardinal Set
 
@@ -20,13 +18,18 @@ open Cardinal
 
 /-- The cardinality of the complex numbers, as a type. -/
 @[simp]
-theorem mk_complex : #ℂ = 𝔠 := by
+theorem Cardinal.mk_complex : #ℂ = 𝔠 := by
   rw [mk_congr Complex.equivRealProd, mk_prod, lift_id, mk_real, continuum_mul_self]
 
+@[deprecated Cardinal.mk_complex (since := "2025-03-13")] alias mk_complex := Cardinal.mk_complex
+
 /-- The cardinality of the complex numbers, as a set. -/
-theorem mk_univ_complex : #(Set.univ : Set ℂ) = 𝔠 := by rw [mk_univ, mk_complex]
+theorem Cardinal.mk_univ_complex : #(Set.univ : Set ℂ) = 𝔠 := by rw [mk_univ, mk_complex]
+
+@[deprecated Cardinal.mk_univ_complex (since := "2025-03-13")]
+alias mk_univ_complex := Cardinal.mk_univ_complex
 
 /-- The complex numbers are not countable. -/
 theorem not_countable_complex : ¬(Set.univ : Set ℂ).Countable := by
-  rw [← le_aleph0_iff_set_countable, not_le, mk_univ_complex]
+  rw [← le_aleph0_iff_set_countable, not_le, Cardinal.mk_univ_complex]
   apply cantor

--- a/Mathlib/Data/Complex/Exponential.lean
+++ b/Mathlib/Data/Complex/Exponential.lean
@@ -85,7 +85,7 @@ variable (x y : ℂ)
 theorem exp_zero : exp 0 = 1 := by
   rw [exp]
   refine lim_eq_of_equiv_const fun ε ε0 => ⟨1, fun j hj => ?_⟩
-  convert (config := .unfoldSameFun) ε0 -- Porting note: ε0 : ε > 0 but goal is _ < ε
+  convert (config := .unfoldSameFun) ε0 -- ε0 : ε > 0 but goal is _ < ε
   rcases j with - | j
   · exact absurd hj (not_le_of_gt zero_lt_one)
   · dsimp [exp']
@@ -116,7 +116,6 @@ theorem exp_add : exp (x + y) = exp x * exp y := by
   simp only [hj]
   exact cauchy_product (isCauSeq_norm_exp x) (isCauSeq_exp y)
 
--- Porting note (https://github.com/leanprover-community/mathlib4/issues/11445): new definition
 /-- the exponential function as a monoid hom from `Multiplicative ℂ` to `ℂ` -/
 @[simps]
 noncomputable def expMonoidHom : MonoidHom (Multiplicative ℂ) ℂ :=
@@ -193,7 +192,6 @@ theorem exp_zero : exp 0 = 1 := by simp [Real.exp]
 
 nonrec theorem exp_add : exp (x + y) = exp x * exp y := by simp [exp_add, exp]
 
--- Porting note (https://github.com/leanprover-community/mathlib4/issues/11445): new definition
 /-- the exponential function as a monoid hom from `Multiplicative ℝ` to `ℝ` -/
 @[simps]
 noncomputable def expMonoidHom : MonoidHom (Multiplicative ℝ) ℝ :=
@@ -612,7 +610,7 @@ theorem exp_bound_div_one_sub_of_interval' {x : ℝ} (h1 : 0 < x) (h2 : x < 1) :
       -- Porting note: was `norm_num [Finset.sum] <;> nlinarith`
       -- This proof should be restored after the norm_num plugin for big operators is ported.
       -- (It may also need the positivity extensions in https://github.com/leanprover-community/mathlib4/pull/3907.)
-      erw [Finset.sum_range_succ]
+      rw [show 3 = 1 + 1 + 1 from rfl]
       repeat rw [Finset.sum_range_succ]
       norm_num [Nat.factorial]
       nlinarith

--- a/Mathlib/Data/Complex/FiniteDimensional.lean
+++ b/Mathlib/Data/Complex/FiniteDimensional.lean
@@ -66,7 +66,7 @@ lemma Real.rank_rat_real : Module.rank ℚ ℝ = continuum := by
 /-- `C` has an uncountable basis over `ℚ`. -/
 @[simp, stacks 09G0]
 lemma Complex.rank_rat_complex : Module.rank ℚ ℂ = continuum := by
-  refine (Free.rank_eq_mk_of_infinite_lt ℚ ℂ ?_).trans mk_complex
+  refine (Free.rank_eq_mk_of_infinite_lt ℚ ℂ ?_).trans Cardinal.mk_complex
   simpa using aleph0_lt_continuum
 
 /-- `ℂ` and `ℝ` are isomorphic as vector spaces over `ℚ`, or equivalently,

--- a/Mathlib/Data/Complex/Module.lean
+++ b/Mathlib/Data/Complex/Module.lean
@@ -146,11 +146,7 @@ theorem coe_basisOneI : ⇑basisOneI = ![1, I] :=
   funext fun i =>
     Basis.apply_eq_iff.mpr <|
       Finsupp.ext fun j => by
-        fin_cases i <;> fin_cases j <;>
-          -- Porting note: removed `only`, consider squeezing again
-          simp [coe_basisOneI_repr, Finsupp.single_eq_of_ne, Matrix.cons_val_zero,
-            Matrix.cons_val_one, Matrix.head_cons, Fin.one_eq_zero_iff, Ne, not_false_iff, I_re,
-            Nat.succ_succ_ne_one, one_im, I_im, one_re, Finsupp.single_eq_same, Fin.zero_eq_one_iff]
+        fin_cases i <;> fin_cases j <;> simp
 
 end Complex
 
@@ -253,7 +249,6 @@ theorem conjAe_coe : ⇑conjAe = conj :=
 theorem toMatrix_conjAe :
     LinearMap.toMatrix basisOneI basisOneI conjAe.toLinearMap = !![1, 0; 0, -1] := by
   ext i j
-  -- Porting note: replaced non-terminal `simp [LinearMap.toMatrix_apply]`
   fin_cases i <;> fin_cases j <;> simp [LinearMap.toMatrix_apply]
 
 /-- The identity and the complex conjugation are the only two `ℝ`-algebra homomorphisms of `ℂ`. -/
@@ -267,8 +262,7 @@ theorem real_algHom_eq_id_or_conj (f : ℂ →ₐ[ℝ] ℂ) : f = AlgHom.id ℝ 
 @[simps! (config := { simpRhs := true }) apply symm_apply_re symm_apply_im]
 def equivRealProdLm : ℂ ≃ₗ[ℝ] ℝ × ℝ :=
   { equivRealProdAddHom with
-    -- Porting note: `simp` has issues with `Prod.smul_def`
-    map_smul' := fun r c => by simp [equivRealProdAddHom, Prod.smul_def, smul_eq_mul] }
+    map_smul' := fun r c => by simp }
 
 theorem equivRealProdLm_symm_apply (p : ℝ × ℝ) :
     Complex.equivRealProdLm.symm p = p.1 + p.2 * Complex.I := Complex.equivRealProd_symm_apply p
@@ -290,11 +284,10 @@ def liftAux (I' : A) (hf : I' * I' = -1) : ℂ →ₐ[ℝ] A :=
       rw [add_mul, mul_add, mul_add, add_comm _ (y₁ • I' * y₂ • I'), add_add_add_comm]
       congr 1
       -- equate "real" and "imaginary" parts
-      · let inst : SMulCommClass ℝ A A := by infer_instance  -- Porting note: added
-        rw [smul_mul_smul_comm, hf, smul_neg, ← Algebra.algebraMap_eq_smul_one, ← sub_eq_add_neg, ←
-          RingHom.map_mul, ← RingHom.map_sub]
-      · rw [Algebra.smul_def, Algebra.smul_def, Algebra.smul_def, ← Algebra.right_comm _ x₂, ←
-          mul_assoc, ← add_mul, ← RingHom.map_mul, ← RingHom.map_mul, ← RingHom.map_add]
+      · rw [smul_mul_smul_comm, hf, smul_neg, ← Algebra.algebraMap_eq_smul_one, ← sub_eq_add_neg,
+          ← RingHom.map_mul, ← RingHom.map_sub]
+      · rw [Algebra.smul_def, Algebra.smul_def, Algebra.smul_def, ← Algebra.right_comm _ x₂,
+          ← mul_assoc, ← add_mul, ← RingHom.map_mul, ← RingHom.map_mul, ← RingHom.map_add]
 
 @[simp]
 theorem liftAux_apply (I' : A) (hI') (z : ℂ) : liftAux I' hI' z = algebraMap ℝ A z.re + z.im • I' :=
@@ -396,18 +389,12 @@ theorem realPart_add_I_smul_imaginaryPart (a : A) : (ℜ a : A) + I • (ℑ a :
 @[simp]
 theorem realPart_I_smul (a : A) : ℜ (I • a) = -ℑ a := by
   ext
-  -- Porting note: was
-  -- simp [smul_comm I, smul_sub, sub_eq_add_neg, add_comm]
-  rw [realPart_apply_coe, NegMemClass.coe_neg, imaginaryPart_apply_coe, neg_smul, neg_neg,
-    smul_comm I, star_smul, star_def, conj_I, smul_sub, neg_smul, sub_eq_add_neg]
+  simp [realPart_apply_coe, imaginaryPart_apply_coe, smul_comm I, sub_eq_add_neg, add_comm]
 
 @[simp]
 theorem imaginaryPart_I_smul (a : A) : ℑ (I • a) = ℜ a := by
   ext
-  -- Porting note: was
-  -- simp [smul_comm I, smul_smul I]
-  rw [realPart_apply_coe, imaginaryPart_apply_coe, smul_comm]
-  simp [← smul_assoc]
+  simp [realPart_apply_coe, imaginaryPart_apply_coe, smul_comm I (2⁻¹ : ℝ), smul_smul I]
 
 theorem realPart_smul (z : ℂ) (a : A) : ℜ (z • a) = z.re • ℜ a - z.im • ℑ a := by
   have := by congrm (ℜ ($((re_add_im z).symm) • a))

--- a/Mathlib/Data/Complex/Order.lean
+++ b/Mathlib/Data/Complex/Order.lean
@@ -44,7 +44,6 @@ protected def partialOrder : PartialOrder ℂ where
 
 namespace _root_.ComplexOrder
 
--- Porting note: made section into namespace to allow scoping
 scoped[ComplexOrder] attribute [instance] Complex.partialOrder
 
 end _root_.ComplexOrder

--- a/Mathlib/Data/Complex/Trigonometric.lean
+++ b/Mathlib/Data/Complex/Trigonometric.lean
@@ -150,9 +150,7 @@ theorem cosh_sub : cosh (x - y) = cosh x * cosh y - sinh x * sinh y := by
   simp [sub_eq_add_neg, cosh_add, sinh_neg, cosh_neg]
 
 theorem sinh_conj : sinh (conj x) = conj (sinh x) := by
-  rw [sinh, ← RingHom.map_neg, exp_conj, exp_conj, ← RingHom.map_sub, sinh, map_div₀]
-  -- Porting note: not nice
-  simp [← one_add_one_eq_two]
+  rw [sinh, ← RingHom.map_neg, exp_conj, exp_conj, ← RingHom.map_sub, sinh, map_div₀, map_ofNat]
 
 @[simp]
 theorem ofReal_sinh_ofReal_re (x : ℝ) : ((sinh x).re : ℂ) = sinh x :=
@@ -169,9 +167,7 @@ theorem sinh_ofReal_re (x : ℝ) : (sinh x).re = Real.sinh x :=
   rfl
 
 theorem cosh_conj : cosh (conj x) = conj (cosh x) := by
-  rw [cosh, ← RingHom.map_neg, exp_conj, exp_conj, ← RingHom.map_add, cosh, map_div₀]
-  -- Porting note: not nice
-  simp [← one_add_one_eq_two]
+  rw [cosh, ← RingHom.map_neg, exp_conj, exp_conj, ← RingHom.map_add, cosh, map_div₀, map_ofNat]
 
 theorem ofReal_cosh_ofReal_re (x : ℝ) : ((cosh x).re : ℂ) = cosh x :=
   conj_eq_iff_re.1 <| by rw [← cosh_conj, conj_ofReal]

--- a/Mathlib/Data/ENat/Basic.lean
+++ b/Mathlib/Data/ENat/Basic.lean
@@ -42,8 +42,8 @@ deriving instance Zero, OrderedCommSemiring, Nontrivial,
 -- instances should be constructed by a deriving handler.
 -- https://github.com/leanprover-community/mathlib4/issues/380
 
--- Porting Note: In `Data.Nat.ENatPart` proofs timed out when having
--- the `deriving AddCommMonoidWithOne`, and it seems to work without.
+-- In `Mathlib.Data.Nat.PartENat` proofs timed out when we included `deriving AddCommMonoidWithOne`,
+-- and it seems to work without.
 
 namespace ENat
 
@@ -458,8 +458,7 @@ protected def _root_.MonoidWithZeroHom.ENatMap {S : Type*} [MulZeroOneClass S] [
       induction' y with y
       · have : (f x : WithTop S) ≠ 0 := by simpa [hf.eq_iff' (_root_.map_zero f)] using hx
         simp [mul_top hx, WithTop.mul_top this]
-      · -- Porting note (https://github.com/leanprover-community/mathlib4/issues/11215): TODO: `simp [← coe_mul]` times out
-        simp only [map_coe, ← coe_mul, map_mul, WithTop.coe_mul] }
+      · simp [← Nat.cast_mul, ← coe_mul] }
 
 /-- A version of `ENat.map` for `RingHom`s. -/
 @[simps -fullyApplied]

--- a/Mathlib/Data/ENat/Defs.lean
+++ b/Mathlib/Data/ENat/Defs.lean
@@ -18,7 +18,6 @@ namespace ENat
 
 instance instNatCast : NatCast ℕ∞ := ⟨WithTop.some⟩
 
--- Porting note (https://github.com/leanprover-community/mathlib4/issues/11445): new definition copied from `WithTop`
 /-- Recursor for `ENat` using the preferred forms `⊤` and `↑a`. -/
 @[elab_as_elim, induction_eliminator, cases_eliminator]
 def recTopCoe {C : ℕ∞ → Sort*} (top : C ⊤) (coe : ∀ a : ℕ, C a) : ∀ n : ℕ∞, C n

--- a/Mathlib/Data/ENat/Lattice.lean
+++ b/Mathlib/Data/ENat/Lattice.lean
@@ -30,7 +30,7 @@ open Set
 -- The `CompleteLinearOrder` instance should be constructed by a deriving handler.
 -- https://github.com/leanprover-community/mathlib4/issues/380
 
--- Porting note: `noncomputable` through 'Nat.instConditionallyCompleteLinearOrderBotNat'
+-- `noncomputable` through 'Nat.instConditionallyCompleteLinearOrderBotNat'
 noncomputable instance : CompleteLinearOrder ENat :=
   inferInstanceAs (CompleteLinearOrder (WithTop ℕ))
 

--- a/Mathlib/Data/Erased.lean
+++ b/Mathlib/Data/Erased.lean
@@ -68,8 +68,6 @@ instance (α : Type u) : Repr (Erased α) :=
 instance (α : Type u) : ToString (Erased α) :=
   ⟨fun _ => "Erased"⟩
 
--- Porting note: Deleted `has_to_format`
-
 /-- Computably produce an erased value from a proof of nonemptiness. -/
 def choice {α} (h : Nonempty α) : Erased α :=
   mk (Classical.choice h)
@@ -129,7 +127,6 @@ theorem bind_def {α β} : ((· >>= ·) : Erased α → (α → Erased β) → E
 theorem map_def {α β} : ((· <$> ·) : (α → β) → Erased α → Erased β) = @map _ _ :=
   rfl
 
--- Porting note: Old proof `by refine' { .. } <;> intros <;> ext <;> simp`
 protected instance instLawfulMonad : LawfulMonad Erased :=
   { id_map := by intros; ext; simp
     map_const := by intros; ext; simp [Functor.mapConst]

--- a/Mathlib/Data/FP/Basic.lean
+++ b/Mathlib/Data/FP/Basic.lean
@@ -15,7 +15,7 @@ import Mathlib.Algebra.Order.Group.Unbundled.Basic
 # Implementation of floating-point numbers (experimental).
 -/
 
--- Porting note (https://github.com/leanprover-community/mathlib4/issues/11215): TODO add docs and remove `@[nolint docBlame]`
+-- TODO add docs and remove `@[nolint docBlame]`
 
 @[nolint docBlame]
 def Int.shift2 (a b : ℕ) : ℤ → ℕ × ℕ

--- a/Mathlib/Data/Fin/Tuple/Basic.lean
+++ b/Mathlib/Data/Fin/Tuple/Basic.lean
@@ -635,9 +635,7 @@ theorem cons_snoc_eq_snoc_cons {β : Sort*} (a : β) (q : Fin n → β) (b : β)
     @cons n.succ (fun _ ↦ β) a (snoc q b) = snoc (cons a q) b := by
   ext i
   by_cases h : i = 0
-  · rw [h]
-    -- Porting note: `refl` finished it here in Lean 3, but I had to add more.
-    simp [snoc, castLT]
+  · simp [h, snoc, castLT]
   set j := pred i h with ji
   have : i = j.succ := by rw [ji, succ_pred]
   rw [this, cons_succ]

--- a/Mathlib/Data/Fin/Tuple/Reflection.lean
+++ b/Mathlib/Data/Fin/Tuple/Reflection.lean
@@ -130,7 +130,6 @@ example (P : (Fin 2 → α) → Prop) : (∃ f, P f) ↔ ∃ a₀ a₁, P ![a₀
 def sum [Add α] [Zero α] : ∀ {m} (_ : Fin m → α), α
   | 0, _ => 0
   | 1, v => v 0
-  -- Porting note: inline `∘` since it is no longer reducible
   | _ + 2, v => sum (fun i => v (Fin.castSucc i)) + v (Fin.last _)
 
 /-- This can be used to prove

--- a/Mathlib/Data/Fin/Tuple/Sort.lean
+++ b/Mathlib/Data/Fin/Tuple/Sort.lean
@@ -48,7 +48,6 @@ theorem graph.card (f : Fin n → α) : (graph f).card = n := by
   · exact Finset.card_fin _
   · intro _ _
     -- Porting note: proof was `simp`
-    dsimp only
     rw [Prod.ext_iff]
     simp
 

--- a/Mathlib/Data/Fin/VecNotation.lean
+++ b/Mathlib/Data/Fin/VecNotation.lean
@@ -254,9 +254,6 @@ theorem vecAppend_eq_ite {α : Type*} {o : ℕ} (ho : o = m + n) (u : Fin m → 
   simp only [eq_rec_constant]
   rfl
 
--- Porting note: proof was `rfl`, so this is no longer a `dsimp`-lemma
--- Could become one again with change to `Nat.ble`:
--- https://github.com/leanprover-community/mathlib4/pull/1741/files/#r1083902351
 @[simp]
 theorem vecAppend_apply_zero {α : Type*} {o : ℕ} (ho : o + 1 = m + 1 + n) (u : Fin (m + 1) → α)
     (v : Fin n → α) : vecAppend ho u v 0 = u 0 :=

--- a/Mathlib/Data/FunLike/Basic.lean
+++ b/Mathlib/Data/FunLike/Basic.lean
@@ -126,12 +126,6 @@ does **not** have a `FunLike` instance by checking the discrimination tree once 
 the entire `extends` hierarchy.
 -/
 
--- This instance should have low priority, to ensure we follow the chain
--- `DFunLike → CoeFun`
--- Porting note: this is an elaboration detail from Lean 3, we are going to disable it
--- until it is clearer what the Lean 4 elaborator needs.
--- attribute [instance, priority 10] coe_fn_trans
-
 /-- The class `DFunLike F α β` expresses that terms of type `F` have an
 injective coercion to (dependent) functions from `α` to `β`.
 
@@ -175,7 +169,6 @@ run_cmd Lean.Elab.Command.liftTermElabM do
   Lean.Meta.registerCoercion ``DFunLike.coe
     (some { numArgs := 5, coercee := 4, type := .coeFun })
 
--- @[simp] -- Porting note: this loops in lean 4
 theorem coe_eq_coe_fn : (DFunLike.coe (F := F)) = (fun f => ↑f) := rfl
 
 theorem coe_injective : Function.Injective (fun f : F ↦ (f : ∀ a : α, β a)) :=

--- a/Mathlib/Data/FunLike/Fintype.lean
+++ b/Mathlib/Data/FunLike/Fintype.lean
@@ -26,7 +26,7 @@ You can use these to produce instances for specific `DFunLike` types.
 They can't be instances themselves since they can cause loops.
 -/
 
--- Porting note: `Type` is a reserved word, switched to `Type'`
+-- `Type` is a reserved word, switched to `Type'`
 section Type'
 
 variable (F G : Type*) {α γ : Type*} {β : α → Type*} [DFunLike F α β] [FunLike G α γ]
@@ -50,7 +50,7 @@ noncomputable def FunLike.fintype [DecidableEq α] [Fintype α] [Fintype γ] : F
 
 end Type'
 
--- Porting note: `Sort` is a reserved word, switched to `Sort'`
+-- `Sort` is a reserved word, switched to `Sort'`
 section Sort'
 
 variable (F G : Sort*) {α γ : Sort*} {β : α → Sort*} [DFunLike F α β] [FunLike G α γ]

--- a/Mathlib/Data/Holor.lean
+++ b/Mathlib/Data/Holor.lean
@@ -263,12 +263,11 @@ theorem cprankMax_add [Monoid α] [AddMonoid α] :
     match hx with
     | CPRankMax.zero => simp only [zero_add, hy]
   | m + 1, n, _, y, CPRankMax.succ _ x₁ x₂ hx₁ hx₂, hy => by
-    simp only [add_comm, add_assoc]
+    suffices CPRankMax (m + n + 1) (x₁ + (x₂ + y)) by
+      simpa only [add_comm, add_assoc, add_left_comm] using this
     apply CPRankMax.succ
     · assumption
-    · -- Porting note: Single line is added.
-      simp only [Nat.add_eq, add_zero, add_comm n m]
-      exact cprankMax_add hx₂ hy
+    · exact cprankMax_add hx₂ hy
 
 theorem cprankMax_mul [Ring α] :
     ∀ (n : ℕ) (x : Holor α [d]) (y : Holor α ds), CPRankMax n y → CPRankMax n (x ⊗ y)

--- a/Mathlib/Data/Int/Range.lean
+++ b/Mathlib/Data/Int/Range.lean
@@ -16,7 +16,6 @@ less than `n`.
 This could be unified with `Data.List.Intervals`. See the TODOs there.
 -/
 
--- Porting note: Many unfolds about `Lean.Internal.coeM`
 namespace Int
 
 /-- List enumerating `[m, n)`. This is the ℤ variant of `List.Ico`. -/

--- a/Mathlib/Data/Matrix/Auto.lean
+++ b/Mathlib/Data/Matrix/Auto.lean
@@ -19,6 +19,7 @@ example {α} [AddCommMonoid α] [Mul α] (a₁₁ a₁₂ a₂₁ a₂₂ b₁�
   rw [of_mul_of_fin]
 ```
 
-Porting note: these magic lemmas have been skipped for now, though the plumbing lemmas in
-`Mathlib.Data.Matrix.Reflection` are still available
+TODO: These magic lemmas have been skipped for now, though the plumbing lemmas in
+`Mathlib.Data.Matrix.Reflection` are still available.
+They should probably be implemented as simprocs.
 -/

--- a/Mathlib/Data/Matrix/Basic.lean
+++ b/Mathlib/Data/Matrix/Basic.lean
@@ -37,7 +37,6 @@ variable {R : Type*} {S : Type*} {α : Type v} {β : Type w} {γ : Type*}
 
 namespace Matrix
 
--- Porting note: new, Lean3 found this automatically
 instance decidableEq [DecidableEq α] [Fintype m] [Fintype n] : DecidableEq (Matrix m n α) :=
   Fintype.decidablePiFintype
 
@@ -235,15 +234,7 @@ theorem map_algebraMap (r : R) (f : α → β) (hf : f 0 = 0)
     (hf₂ : f (algebraMap R α r) = algebraMap R β r) :
     (algebraMap R (Matrix n n α) r).map f = algebraMap R (Matrix n n β) r := by
   rw [algebraMap_eq_diagonal, algebraMap_eq_diagonal, diagonal_map hf]
-  -- Porting note: (congr) the remaining proof was
-  -- ```
-  -- congr 1
-  -- simp only [hf₂, Pi.algebraMap_apply]
-  -- ```
-  -- But some `congr 1` doesn't quite work.
-  simp only [Pi.algebraMap_apply, diagonal_eq_diagonal_iff]
-  intro
-  rw [hf₂]
+  simp [hf₂]
 
 variable (R)
 

--- a/Mathlib/Data/Matrix/Basis.lean
+++ b/Mathlib/Data/Matrix/Basis.lean
@@ -91,7 +91,6 @@ theorem matrix_eq_sum_stdBasisMatrix [AddCommMonoid α] [Fintype m] [Fintype n] 
 theorem stdBasisMatrix_eq_single_vecMulVec_single [MulZeroOneClass α] (i : m) (j : n) :
     stdBasisMatrix i j (1 : α) = vecMulVec (Pi.single i 1) (Pi.single j 1) := by
   ext i' j'
-  -- Porting note: lean3 didn't apply `mul_ite`.
   simp [-mul_ite, stdBasisMatrix, vecMulVec, ite_and, Pi.single_apply, eq_comm]
 
 -- todo: the old proof used fintypes, I don't know `Finsupp` but this feels generalizable
@@ -240,14 +239,8 @@ theorem mul_of_ne (i : l) (j k : m) {l : n} (h : j ≠ k) (d : α) :
   ext a b
   simp only [mul_apply, boole_mul, stdBasisMatrix, of_apply]
   by_cases h₁ : i = a
-  -- Porting note (https://github.com/leanprover-community/mathlib4/issues/10745): was `simp [h₁, h, h.symm]`
-  · simp only [h₁, true_and, mul_ite, ite_mul, zero_mul, mul_zero, ← ite_and, zero_apply]
-    refine Finset.sum_eq_zero (fun x _ => ?_)
-    apply if_neg
-    rintro ⟨⟨rfl, rfl⟩, h⟩
-    contradiction
-  · simp only [h₁, false_and, ite_false, mul_ite, zero_mul, mul_zero, ite_self,
-      Finset.sum_const_zero, zero_apply]
+  · simp [h₁, h, Finset.sum_eq_zero]
+  · simp [h₁]
 
 end mul
 

--- a/Mathlib/Data/Matrix/Block.lean
+++ b/Mathlib/Data/Matrix/Block.lean
@@ -174,7 +174,6 @@ def toSquareBlockProp (M : Matrix m m α) (p : m → Prop) : Matrix { a // p a }
   toBlock M _ _
 
 theorem toSquareBlockProp_def (M : Matrix m m α) (p : m → Prop) :
-    -- Porting note: added missing `of`
     toSquareBlockProp M p = of (fun i j : { a // p a } => M ↑i ↑j) :=
   rfl
 
@@ -185,7 +184,6 @@ def toSquareBlock (M : Matrix m m α) (b : m → β) (k : β) :
   toSquareBlockProp M _
 
 theorem toSquareBlock_def (M : Matrix m m α) (b : m → β) (k : β) :
-    -- Porting note: added missing `of`
     toSquareBlock M b k = of (fun i j : { a // b a = k } => M ↑i ↑j) :=
   rfl
 
@@ -675,7 +673,7 @@ theorem blockDiagonal'_mul [NonUnitalNonAssocSemiring α] [∀ i, Fintype (n' i)
   ext ⟨k, i⟩ ⟨k', j⟩
   simp only [blockDiagonal'_apply, mul_apply, ← Finset.univ_sigma_univ, Finset.sum_sigma]
   rw [Fintype.sum_eq_single k]
-  · simp only [if_pos, dif_pos] -- Porting note: added
+  · simp only [if_pos, dif_pos]
     split_ifs <;> simp
   · intro j' hj'
     exact Finset.sum_eq_zero fun _ _ => by rw [dif_neg hj'.symm, zero_mul]

--- a/Mathlib/Data/Matrix/Defs.lean
+++ b/Mathlib/Data/Matrix/Defs.lean
@@ -74,10 +74,6 @@ which performs elementwise multiplication, vs `Matrix.mul`).
 If you are defining a matrix, in terms of its entries, use `of (fun i j ↦ _)`. The
 purpose of this approach is to ensure that terms of the form `(fun i j ↦ _) * (fun i j ↦ _)` do not
 appear, as the type of `*` can be misleading.
-
-Porting note: In Lean 3, it is also safe to use pattern matching in a definition as `| i j := _`,
-which can only be unfolded when fully-applied. https://github.com/leanprover/lean4/issues/2042 means this does not
-(currently) work in Lean 4.
 -/
 def of : (m → n → α) ≃ Matrix m n α :=
   Equiv.refl _

--- a/Mathlib/Data/Matrix/Diagonal.lean
+++ b/Mathlib/Data/Matrix/Diagonal.lean
@@ -190,7 +190,6 @@ theorem map_one [Zero β] [One β] (f : α → β) (h₀ : f 0 = 0) (h₁ : f 1 
   simp only [one_apply, map_apply]
   split_ifs <;> simp [h₀, h₁]
 
--- Porting note: added implicit argument `(f := fun_ => α)`, why is that needed?
 theorem one_eq_pi_single {i j} : (1 : Matrix n n α) i j = Pi.single (f := fun _ => α) i 1 j := by
   simp only [one_apply, Pi.single_apply, eq_comm]
 
@@ -334,8 +333,7 @@ theorem submatrix_diagonal [Zero α] [DecidableEq m] [DecidableEq l] (d : m → 
   ext fun i j => by
     rw [submatrix_apply]
     by_cases h : i = j
-    · rw [h, diagonal_apply_eq, diagonal_apply_eq]
-      simp only [Function.comp_apply] -- Porting note: (simp) added this
+    · rw [h, diagonal_apply_eq, diagonal_apply_eq, Function.comp_apply]
     · rw [diagonal_apply_ne _ h, diagonal_apply_ne _ (he.ne h)]
 
 theorem submatrix_one [Zero α] [One α] [DecidableEq m] [DecidableEq l] (e : l → m)

--- a/Mathlib/Data/Matrix/Kronecker.lean
+++ b/Mathlib/Data/Matrix/Kronecker.lean
@@ -359,7 +359,7 @@ theorem mul_kronecker_mul [Fintype m] [Fintype m'] [CommSemiring α] (A : Matrix
     (A * B) ⊗ₖ (A' * B') = A ⊗ₖ A' * B ⊗ₖ B' :=
   kroneckerMapBilinear_mul_mul (Algebra.lmul ℕ α).toLinearMap mul_mul_mul_comm A B A' B'
 
--- @[simp] -- Porting note: simp-normal form is `kronecker_assoc'`
+-- simp-normal form is `kronecker_assoc'`
 theorem kronecker_assoc [Semigroup α] (A : Matrix l m α) (B : Matrix n p α) (C : Matrix q r α) :
     reindex (Equiv.prodAssoc l n q) (Equiv.prodAssoc m p r) (A ⊗ₖ B ⊗ₖ C) = A ⊗ₖ (B ⊗ₖ C) :=
   kroneckerMap_assoc₁ _ _ _ _ A B C mul_assoc
@@ -503,7 +503,7 @@ theorem diagonal_kroneckerTMul [DecidableEq l] (a : l → α) (B : Matrix m n α
         (blockDiagonal fun i => B.map fun b => a i ⊗ₜ[R] b) :=
   kroneckerMap_diagonal_left _ (zero_tmul _) _ _
 
--- @[simp] -- Porting note: simp-normal form is `kroneckerTMul_assoc'`
+-- simp-normal form is `kroneckerTMul_assoc'`
 theorem kroneckerTMul_assoc (A : Matrix l m α) (B : Matrix n p β) (C : Matrix q r γ) :
     reindex (Equiv.prodAssoc l n q) (Equiv.prodAssoc m p r)
         (((A ⊗ₖₜ[R] B) ⊗ₖₜ[R] C).map (TensorProduct.assoc R α β γ)) =

--- a/Mathlib/Data/Matrix/Mul.lean
+++ b/Mathlib/Data/Matrix/Mul.lean
@@ -168,8 +168,7 @@ protected alias Matrix.dotProduct_comp_equiv_symm := dotProduct_comp_equiv_symm
 /-- Permuting vectors on both sides of a dot product is a no-op. -/
 @[simp]
 theorem comp_equiv_dotProduct_comp_equiv (e : m ≃ n) : x ∘ e ⬝ᵥ y ∘ e = x ⬝ᵥ y := by
-  -- Porting note: was `simp only` with all three lemmas
-  rw [← dotProduct_comp_equiv_symm]; simp only [Function.comp_def, Equiv.apply_symm_apply]
+  simp [← dotProduct_comp_equiv_symm, Function.comp_def _ e.symm]
 
 @[deprecated (since := "2024-12-12")]
 protected alias Matrix.comp_equiv_dotProduct_comp_equiv := comp_equiv_dotProduct_comp_equiv

--- a/Mathlib/Data/Matrix/RowCol.lean
+++ b/Mathlib/Data/Matrix/RowCol.lean
@@ -180,25 +180,21 @@ variable {M : Matrix m n α} {i : m} {j : n} {b : n → α} {c : m → α}
 
 @[simp]
 theorem updateRow_self [DecidableEq m] : updateRow M i b i = b :=
-  -- Porting note: (implicit arg) added `(β := _)`
   Function.update_self (β := fun _ => (n → α)) i b M
 
 @[simp]
 theorem updateCol_self [DecidableEq n] : updateCol M j c i j = c i :=
-  -- Porting note: (implicit arg) added `(β := _)`
   Function.update_self (β := fun _ => α) j (c i) (M i)
 
 @[deprecated (since := "2024-12-11")] alias updateColumn_self := updateCol_self
 
 @[simp]
 theorem updateRow_ne [DecidableEq m] {i' : m} (i_ne : i' ≠ i) : updateRow M i b i' = M i' :=
-  -- Porting note: (implicit arg) added `(β := _)`
   Function.update_of_ne (β := fun _ => (n → α)) i_ne b M
 
 @[simp]
 theorem updateCol_ne [DecidableEq n] {j' : n} (j_ne : j' ≠ j) :
     updateCol M j c i j' = M i j' :=
-  -- Porting note: (implicit arg) added `(β := _)`
   Function.update_of_ne (β := fun _ => α) j_ne (c i) (M i)
 
 @[deprecated (since := "2024-12-11")] alias updateColumn_ne := updateCol_ne

--- a/Mathlib/Data/Num/Bitwise.lean
+++ b/Mathlib/Data/Num/Bitwise.lean
@@ -109,9 +109,7 @@ instance : HShiftLeft PosNum Nat PosNum where hShiftLeft := PosNum.shiftl
 
 @[simp] lemma shiftl_eq_shiftLeft (p : PosNum) (n : Nat) : p.shiftl n = p <<< n := rfl
 
-
--- Porting note: `PosNum.shiftl` is defined as tail-recursive in Lean4.
---               This theorem ensures the definition is same to one in Lean3.
+-- This shows that the tail-recursive definition is the same as the more naïve recursion.
 theorem shiftl_succ_eq_bit0_shiftl : ∀ (p : PosNum) (n : Nat), p <<< n.succ = bit0 (p <<< n)
   | _, 0       => rfl
   | p, .succ n => shiftl_succ_eq_bit0_shiftl p.bit0 n
@@ -311,7 +309,7 @@ def not : SNum → SNum
   | zero z => zero (Not z)
   | nz p => ~p
 
--- Porting note: Defined `priority` so that `~1 : SNum` is unambiguous.
+-- Higher `priority` so that `~1 : SNum` is unambiguous.
 @[inherit_doc]
 scoped prefix:100 (priority := default + 1) "~" => not
 

--- a/Mathlib/Data/Num/Lemmas.lean
+++ b/Mathlib/Data/Num/Lemmas.lean
@@ -14,7 +14,6 @@ import Mathlib.Data.Num.Bitwise
 # Properties of the binary representation of integers
 -/
 
--- Porting note: Required for the notation `-[n+1]`.
 open Int Function
 
 attribute [local simp] add_assoc
@@ -423,7 +422,7 @@ theorem of_natCast {α} [AddMonoidWithOne α] (n : ℕ) : ((n : Num) : α) = n :
 theorem of_nat_inj {m n : ℕ} : (m : Num) = n ↔ m = n :=
   ⟨fun h => Function.LeftInverse.injective to_of_nat h, congr_arg _⟩
 
--- Porting note: The priority should be `high`er than `cast_to_nat`.
+-- The priority should be `high`er than `cast_to_nat`.
 @[simp high, norm_cast]
 theorem of_to_nat : ∀ n : Num, ((n : ℕ) : Num) = n :=
   of_to_nat'
@@ -440,7 +439,7 @@ variable {α : Type*}
 
 open Num
 
--- Porting note: The priority should be `high`er than `cast_to_nat`.
+-- The priority should be `high`er than `cast_to_nat`.
 @[simp high, norm_cast]
 theorem of_to_nat : ∀ n : PosNum, ((n : ℕ) : Num) = Num.pos n :=
   of_to_nat'
@@ -790,10 +789,8 @@ theorem castNum_eq_bitwise {f : Num → Num → Num} {g : Bool → Bool → Bool
 
 @[simp, norm_cast]
 theorem castNum_or : ∀ m n : Num, ↑(m ||| n) = (↑m ||| ↑n : ℕ) := by
-  -- Porting note: A name of an implicit local hypothesis is not available so
-  --               `cases_type*` is used.
   apply castNum_eq_bitwise fun x y => pos (PosNum.lor x y) <;>
-   intros <;> (try cases_type* Bool) <;> rfl
+   (try rintro (_ | _)) <;> (try rintro (_ | _)) <;> intros <;> rfl
 
 @[simp, norm_cast]
 theorem castNum_and : ∀ m n : Num, ↑(m &&& n) = (↑m &&& ↑n : ℕ) := by
@@ -846,7 +843,6 @@ theorem castNum_shiftRight (m : Num) (n : Nat) : ↑(m >>> n) = (m : ℕ) >>> (n
 
 @[simp]
 theorem castNum_testBit (m n) : testBit m n = Nat.testBit m n := by
-  -- Porting note: `unfold` → `dsimp only`
   cases m with dsimp only [testBit]
   | zero =>
     rw [show (Num.zero : Nat) = 0 from rfl, Nat.zero_testBit]
@@ -961,7 +957,6 @@ theorem cast_bit1 [AddGroupWithOne α] : ∀ n : ZNum, (n.bit1 : α) = ((n : α)
     · conv at ep => change p = 1
       subst p
       simp
-    -- Porting note: `rw [Num.succ']` yields a `match` pattern.
     · dsimp only [Num.succ'] at ep
       subst p
       have : (↑(-↑a : ℤ) : α) = -1 + ↑(-↑a + 1 : ℤ) := by simp [add_comm (- ↑a : ℤ) 1]
@@ -1060,8 +1055,6 @@ theorem pred_succ : ∀ n : ZNum, n.pred.succ = n
   | ZNum.neg p => show toZNumNeg (pos p).succ'.pred' = _ by rw [PosNum.pred'_succ']; rfl
   | ZNum.pos p => by rw [ZNum.pred, ← toZNum_succ, Num.succ, PosNum.succ'_pred', toZNum]
 
--- Porting note: `erw [ZNum.ofInt', ZNum.ofInt']` yields `match` so
---               `change` & `dsimp` are required.
 theorem succ_ofInt' : ∀ n, ZNum.ofInt' (n + 1) = ZNum.ofInt' n + 1
   | (n : ℕ) => by
     change ZNum.ofInt' (n + 1 : ℕ) = ZNum.ofInt' (n : ℕ) + 1
@@ -1157,7 +1150,6 @@ theorem ofInt'_neg : ∀ n : ℤ, ofInt' (-n) = -ofInt' n
   | 0 => show Num.toZNum (Num.ofNat' 0) = -Num.toZNum (Num.ofNat' 0) by rw [Num.ofNat'_zero]; rfl
   | (n + 1 : ℕ) => show Num.toZNumNeg _ = -Num.toZNum _ by rw [Num.zneg_toZNum]
 
--- Porting note: `erw [ofInt']` yields `match` so `dsimp` is required.
 theorem of_to_int' : ∀ n : ZNum, ZNum.ofInt' n = n
   | 0 => by dsimp [ofInt', cast_zero]; erw [Num.ofNat'_zero, Num.toZNum]
   | pos a => by rw [cast_pos, ← PosNum.cast_to_nat, ← Num.ofInt'_toZNum, PosNum.of_to_nat]; rfl
@@ -1278,7 +1270,7 @@ instance addMonoidWithOne : AddMonoidWithOne ZNum :=
       show (Num.ofNat' (n + 1)).toZNum = (Num.ofNat' n).toZNum + 1 by
         rw [Num.ofNat'_succ, Num.add_one, Num.toZNum_succ, ZNum.add_one] }
 
--- Porting note: These theorems should be declared out of the instance, otherwise timeouts.
+-- The next theorems are declared outside of the instance to prevent timeouts.
 
 private theorem mul_comm : ∀ (a b : ZNum), a * b = b * a := by transfer
 
@@ -1333,7 +1325,7 @@ theorem ofInt'_eq : ∀ n : ℤ, ZNum.ofInt' n = n
 theorem of_nat_toZNum (n : ℕ) : Num.toZNum n = n :=
   rfl
 
--- Porting note: The priority should be `high`er than `cast_to_int`.
+-- The priority should be `high`er than `cast_to_int`.
 @[simp high, norm_cast]
 theorem of_to_int (n : ZNum) : ((n : ℤ) : ZNum) = n := by rw [← ofInt'_eq, of_to_int']
 

--- a/Mathlib/Data/Opposite.lean
+++ b/Mathlib/Data/Opposite.lean
@@ -21,10 +21,6 @@ universe v u
 -- morphism levels before object levels. See note [CategoryTheory universes].
 variable (α : Sort u)
 
--- Porting note: in mathlib, `opposite α` was a type synonym for `α`, but if we did
--- the same in Lean4, one could write problematic definitions like:
--- example (X : C) : Cᵒᵖ := X
--- example {X Y : C} (f : X ⟶ Y): op Y ⟶ op X := f
 /-- The type of objects of the opposite of `α`; used to define the opposite category.
 
 Now that Lean 4 supports definitional eta equality for records,

--- a/Mathlib/Data/Option/Basic.lean
+++ b/Mathlib/Data/Option/Basic.lean
@@ -132,8 +132,7 @@ section pmap
 
 variable {p : α → Prop} (f : ∀ a : α, p a → β) (x : Option α)
 
--- Porting note: Can't simp tag this anymore because `pbind` simplifies
--- @[simp]
+@[simp]
 theorem pbind_eq_bind (f : α → Option β) (x : Option α) : (x.pbind fun a _ ↦ f a) = x.bind f := by
   cases x <;> simp only [pbind, none_bind', some_bind']
 
@@ -177,10 +176,15 @@ theorem pbind_eq_some {f : ∀ a : α, a ∈ x → Option β} {y : β} :
     simp only [mem_def, Option.some_inj] at H
     simpa [H] using hz
 
--- Porting note: Can't simp tag this anymore because `join` and `pmap` simplify
--- @[simp]
 theorem join_pmap_eq_pmap_join {f : ∀ a, p a → β} {x : Option (Option α)} (H) :
     (pmap (pmap f) x H).join = pmap f x.join fun a h ↦ H (some a) (mem_of_mem_join h) _ rfl := by
+  rcases x with (_ | _ | x) <;> simp
+
+/-- `simp`-normal form of `join_pmap_eq_pmap_join` -/
+@[simp]
+theorem pmap_bind_id_eq_pmap_join {f : ∀ a, p a → β} {x : Option (Option α)} (H) :
+    ((pmap (pmap f) x H).bind fun a ↦ a) =
+      pmap f x.join fun a h ↦ H (some a) (mem_of_mem_join h) _ rfl := by
   rcases x with (_ | _ | x) <;> simp
 
 end pmap
@@ -241,23 +245,18 @@ theorem casesOn'_some (x : β) (f : α → β) (a : α) : casesOn' (some a) x f 
 theorem casesOn'_coe (x : β) (f : α → β) (a : α) : casesOn' (a : Option α) x f = f a :=
   rfl
 
--- Porting note: Left-hand side does not simplify.
--- @[simp]
+@[simp]
 theorem casesOn'_none_coe (f : Option α → β) (o : Option α) :
     casesOn' o (f none) (f ∘ (fun a ↦ ↑a)) = f o := by cases o <;> rfl
 
 lemma casesOn'_eq_elim (b : β) (f : α → β) (a : Option α) :
     Option.casesOn' a b f = Option.elim a b f := by cases a <;> rfl
 
--- porting note: workaround for https://github.com/leanprover/lean4/issues/2049
-compile_inductive% Option
-
 theorem orElse_eq_some (o o' : Option α) (x : α) :
     (o <|> o') = some x ↔ o = some x ∨ o = none ∧ o' = some x := by
   cases o
   · simp only [true_and, false_or, eq_self_iff_true, none_orElse, reduceCtorEq]
   · simp only [some_orElse, or_false, false_and, reduceCtorEq]
-
 
 theorem orElse_eq_some' (o o' : Option α) (x : α) :
     o.orElse (fun _ ↦ o') = some x ↔ o = some x ∨ o = none ∧ o' = some x :=
@@ -280,8 +279,7 @@ theorem choice_eq_none (α : Type*) [IsEmpty α] : choice α = none :=
 
 end
 
--- Porting note: Can't simp tag this anymore because `elim` simplifies
--- @[simp]
+@[simp]
 theorem elim_none_some (f : Option α → β) : (fun x ↦ Option.elim x (f none) (f ∘ some)) = f :=
   funext fun o ↦ by cases o <;> rfl
 

--- a/Mathlib/Data/Option/Defs.lean
+++ b/Mathlib/Data/Option/Defs.lean
@@ -25,9 +25,6 @@ protected def traverse.{u, v}
 
 variable {α : Type*} {β : Type*}
 
--- Porting note: Would need to add the attribute directly in `Init.Prelude`.
--- attribute [inline] Option.isSome Option.isNone
-
 /-- An elimination principle for `Option`. It is a nondependent version of `Option.rec`. -/
 protected def elim' (b : β) (f : α → β) : Option α → β
   | some a => f a
@@ -38,8 +35,6 @@ theorem elim'_none (b : β) (f : α → β) : Option.elim' b f none = b := rfl
 @[simp]
 theorem elim'_some {a : α} (b : β) (f : α → β) : Option.elim' b f (some a) = f a := rfl
 
--- Porting note: this lemma was introduced because it is necessary
--- in `CategoryTheory.Category.PartialFun`
 lemma elim'_eq_elim {α β : Type*} (b : β) (f : α → β) (a : Option α) :
     Option.elim' b f a = Option.elim a b f := by
   cases a <;> rfl

--- a/Mathlib/Data/Option/NAry.lean
+++ b/Mathlib/Data/Option/NAry.lean
@@ -20,7 +20,6 @@ on intervals.
 
 This file is very similar to the n-ary section of `Mathlib.Data.Set.Basic`, to
 `Mathlib.Data.Finset.NAry` and to `Mathlib.Order.Filter.NAry`. Please keep them in sync.
-(porting note - only some of these may exist right now!)
 
 We do not define `Option.map₃` as its only purpose so far would be to prove properties of
 `Option.map₂` and casing already fulfills this task.
@@ -65,8 +64,13 @@ theorem map₂_coe_left (f : α → β → γ) (a : α) (b : Option β) : map₂
 theorem map₂_coe_right (f : α → β → γ) (a : Option α) (b : β) :
     map₂ f a b = a.map fun a => f a b := by cases a <;> rfl
 
--- Porting note: Removed the `@[simp]` tag as membership of an `Option` is no-longer simp-normal.
 theorem mem_map₂_iff {c : γ} : c ∈ map₂ f a b ↔ ∃ a' b', a' ∈ a ∧ b' ∈ b ∧ f a' b' = c := by
+  simp [map₂, bind_eq_some]
+
+/-- `simp`-normal form of `mem_map₂_iff`. -/
+@[simp]
+theorem map₂_eq_some_iff {c : γ} :
+    map₂ f a b = some c ↔ ∃ a' b', a' ∈ a ∧ b' ∈ b ∧ f a' b' = c := by
   simp [map₂, bind_eq_some]
 
 @[simp]

--- a/Mathlib/Data/Ordering/Basic.lean
+++ b/Mathlib/Data/Ordering/Basic.lean
@@ -23,8 +23,6 @@ variable {α : Type*}
 
 /-- `Compares o a b` means that `a` and `b` have the ordering relation `o` between them, assuming
 that the relation `a < b` is defined. -/
--- Porting note: we have removed `@[simp]` here in favour of separate simp lemmas,
--- otherwise this definition will unfold to a match.
 def Compares [LT α] : Ordering → α → α → Prop
   | lt, a, b => a < b
   | eq, a, b => a = b

--- a/Mathlib/Data/Ordmap/Ordnode.lean
+++ b/Mathlib/Data/Ordmap/Ordnode.lean
@@ -69,8 +69,6 @@ universe u
 inductive Ordnode (α : Type u) : Type u
   | nil : Ordnode α
   | node (size : ℕ) (l : Ordnode α) (x : α) (r : Ordnode α) : Ordnode α
-
--- Porting note: `Nat.Partrec.Code.recOn` is noncomputable in Lean4, so we make it computable.
 compile_inductive% Ordnode
 
 namespace Ordnode
@@ -126,9 +124,6 @@ def size : Ordnode α → ℕ
   | nil => 0
   | node sz _ _ _ => sz
 
--- Porting note (https://github.com/leanprover-community/mathlib4/issues/11647): during the port we marked these lemmas with `@[eqns]`
--- to emulate the old Lean 3 behaviour.
-
 @[simp] theorem size_nil : size (nil : Ordnode α) = 0 :=
   rfl
 @[simp] theorem size_node (sz : ℕ) (l : Ordnode α) (x : α) (r : Ordnode α) :
@@ -182,7 +177,6 @@ instance {α} [Repr α] : Repr (Ordnode α) :=
 O(1). Rebalance a tree which was previously balanced but has had its left
 side grow by 1, or its right side shrink by 1. -/
 def balanceL (l : Ordnode α) (x : α) (r : Ordnode α) : Ordnode α := by
-  -- Porting note: removed `clean`
   rcases id r with _ | rs
   · rcases id l with _ | ⟨ls, ll, lx, lr⟩
     · exact ι x
@@ -217,7 +211,6 @@ def balanceL (l : Ordnode α) (x : α) (r : Ordnode α) : Ordnode α := by
 O(1). Rebalance a tree which was previously balanced but has had its right
 side grow by 1, or its left side shrink by 1. -/
 def balanceR (l : Ordnode α) (x : α) (r : Ordnode α) : Ordnode α := by
-  -- Porting note: removed `clean`
   rcases id l with _ | ls
   · rcases id r with _ | ⟨rs, rl, rx, rr⟩
     · exact ι x
@@ -252,7 +245,6 @@ def balanceR (l : Ordnode α) (x : α) (r : Ordnode α) : Ordnode α := by
 O(1). Rebalance a tree which was previously balanced but has had one side change
 by at most 1. -/
 def balance (l : Ordnode α) (x : α) (r : Ordnode α) : Ordnode α := by
-  -- Porting note: removed `clean`
   rcases id l with _ | ⟨ls, ll, lx, lr⟩
   · rcases id r with _ | ⟨rs, rl, rx, rr⟩
     · exact ι x
@@ -356,9 +348,9 @@ of the tree.
 
 To see the difference with `Emem`, we need a preorder that is not a partial order.
 For example, suppose we compare pairs of numbers using only their first coordinate. Then:
--- Porting note: Verify below example
-    emem (0, 1) {(0, 0), (1, 2)} = false
-    amem (0, 1) {(0, 0), (1, 2)} = true
+-- TODO: Verify below example
+    Emem (0, 1) {(0, 0), (1, 2)} = false
+    Amem (0, 1) {(0, 0), (1, 2)} = true
     (0, 1) ∈ {(0, 0), (1, 2)} = true
 
 The `∈` relation is equivalent to `Amem` as long as the `Ordnode` is well formed,
@@ -506,13 +498,6 @@ assumption on the relative sizes.
     link {1, 2} 4 {5, 6} = {1, 2, 4, 5, 6}
     link {1, 3} 2 {5} = precondition violation -/
 def link (l : Ordnode α) (x : α) : Ordnode α → Ordnode α :=
-  -- Porting note: Previous code was:
-  -- (Ordnode.recOn l (insertMin x)) fun ls ll lx lr IHll IHlr r =>
-  --   (Ordnode.recOn r (insertMax l x)) fun rs rl rx rr IHrl IHrr =>
-  --     if delta * ls < rs then balanceL IHrl rx rr
-  --     else if delta * rs < ls then balanceR ll lx (IHlr r) else node' l x r
-  --
-  -- failed to elaborate eliminator, expected type is not available.
   match l with
   | nil => insertMin x
   | node ls ll lx lr => fun r ↦
@@ -593,7 +578,6 @@ def toRevList (t : Ordnode α) : List α :=
 instance [ToString α] : ToString (Ordnode α) :=
   ⟨fun t => "{" ++ String.intercalate ", " (t.toList.map toString) ++ "}"⟩
 
--- Porting note removed unsafe
 instance [Std.ToFormat α] : Std.ToFormat (Ordnode α) where
   format := fun t => Std.Format.joinSep (t.toList.map Std.ToFormat.format) (Std.Format.text ", ")
 
@@ -1088,7 +1072,6 @@ def findGeAux (x : α) : Ordnode α → α → α
     | Ordering.eq => y
     | Ordering.gt => findGeAux x r best
 
--- Porting note: find_le → findGe
 /-- O(log n). Get the smallest element in the tree that is `≥ x`.
 
      findGe 2 {1, 2, 4} = some 2

--- a/Mathlib/Data/Ordmap/Ordset.lean
+++ b/Mathlib/Data/Ordmap/Ordset.lean
@@ -225,9 +225,6 @@ def rotateL : Ordnode α → α → Ordnode α → Ordnode α
   | l, x, node _ m y r => if size m < ratio * size r then node3L l x m y r else node4L l x m y r
   | l, x, nil => node' l x nil
 
--- Porting note (https://github.com/leanprover-community/mathlib4/pull/11467): during the port we marked these lemmas with `@[eqns]`
--- to emulate the old Lean 3 behaviour.
-
 theorem rotateL_node (l : Ordnode α) (x : α) (sz : ℕ) (m : Ordnode α) (y : α) (r : Ordnode α) :
     rotateL l x (node sz m y r) =
       if size m < ratio * size r then node3L l x m y r else node4L l x m y r :=
@@ -242,9 +239,6 @@ if balance is upset. -/
 def rotateR : Ordnode α → α → Ordnode α → Ordnode α
   | node _ l x m, y, r => if size m < ratio * size l then node3R l x m y r else node4R l x m y r
   | nil, y, r => node' nil y r
-
--- Porting note (https://github.com/leanprover-community/mathlib4/pull/11467): during the port we marked these lemmas with `@[eqns]`
--- to emulate the old Lean 3 behaviour.
 
 theorem rotateR_node (sz : ℕ) (l : Ordnode α) (x : α) (m : Ordnode α) (y : α) (r : Ordnode α) :
     rotateR (node sz l x m) y r =

--- a/Mathlib/Data/PFun.lean
+++ b/Mathlib/Data/PFun.lean
@@ -99,6 +99,7 @@ theorem ext' {f g : α →. β} (H1 : ∀ a, a ∈ Dom f ↔ a ∈ Dom g) (H2 : 
     f = g :=
   funext fun a => Part.ext' (H1 a) (H2 a)
 
+@[ext]
 theorem ext {f g : α →. β} (H : ∀ a b, b ∈ f a ↔ b ∈ g a) : f = g :=
   funext fun a => Part.ext (H a)
 
@@ -318,7 +319,7 @@ theorem fixInduction'_stop {C : α → Sort*} {f : α →. β ⊕ α} {b : β} {
     @fixInduction' _ _ C _ _ _ h hbase hind = hbase a fa := by
   unfold fixInduction'
   rw [fixInduction_spec]
-  -- Porting note: the explicit motive required because `simp` behaves differently
+  -- Porting note: the explicit motive required because `simp` does not apply `Part.get_eq_of_mem`
   refine Eq.rec (motive := fun x e ↦
       Sum.casesOn x ?_ ?_ (Eq.trans (Part.get_eq_of_mem fa (dom_of_mem_fix h)) e) = hbase a fa) ?_
     (Part.get_eq_of_mem fa (dom_of_mem_fix h)).symm
@@ -331,7 +332,7 @@ theorem fixInduction'_fwd {C : α → Sort*} {f : α →. β ⊕ α} {b : β} {a
     @fixInduction' _ _ C _ _ _ h hbase hind = hind a a' h' fa (fixInduction' h' hbase hind) := by
   unfold fixInduction'
   rw [fixInduction_spec]
-  -- Porting note: the explicit motive required because `simp` behaves differently
+  -- Porting note: the explicit motive required because `simp` does not apply `Part.get_eq_of_mem`
   refine Eq.rec (motive := fun x e =>
       Sum.casesOn (motive := fun y => (f a).get (dom_of_mem_fix h) = y → C a) x ?_ ?_
       (Eq.trans (Part.get_eq_of_mem fa (dom_of_mem_fix h)) e) = _) ?_
@@ -544,7 +545,6 @@ theorem mem_prodLift {f : α →. β} {g : α →. γ} {x : α} {y : β × γ} :
     y ∈ f.prodLift g x ↔ y.1 ∈ f x ∧ y.2 ∈ g x := by
   trans ∃ hp hq, (f x).get hp = y.1 ∧ (g x).get hq = y.2
   · simp only [prodLift, Part.mem_mk_iff, And.exists, Prod.ext_iff]
-  -- Porting note: was just `[exists_and_left, exists_and_right]`
   · simp only [exists_and_left, exists_and_right, Membership.mem, Part.Mem]
 
 /-- Product of partial functions. -/
@@ -575,19 +575,16 @@ theorem mem_prodMap {f : α →. γ} {g : β →. δ} {x : α × β} {y : γ × 
 theorem prodLift_fst_comp_snd_comp (f : α →. γ) (g : β →. δ) :
     prodLift (f.comp ((Prod.fst : α × β → α) : α × β →. α))
         (g.comp ((Prod.snd : α × β → β) : α × β →. β)) =
-      prodMap f g :=
-  ext fun a => by simp
+      prodMap f g := by
+  aesop
 
 @[simp]
-theorem prodMap_id_id : (PFun.id α).prodMap (PFun.id β) = PFun.id _ :=
-  ext fun _ _ ↦ by simp [eq_comm]
+theorem prodMap_id_id : (PFun.id α).prodMap (PFun.id β) = PFun.id _ := by
+  aesop
 
 @[simp]
 theorem prodMap_comp_comp (f₁ : α →. β) (f₂ : β →. γ) (g₁ : δ →. ε) (g₂ : ε →. ι) :
-    (f₂.comp f₁).prodMap (g₂.comp g₁) = (f₂.prodMap g₂).comp (f₁.prodMap g₁) := -- by
-  -- Porting note: was `by tidy`, below is a golfed version of the `tidy?` proof
-  ext <| fun ⟨_, _⟩ ⟨_, _⟩ ↦
-  ⟨fun ⟨⟨⟨h1l1, h1l2⟩, ⟨h1r1, h1r2⟩⟩, h2⟩ ↦ ⟨⟨⟨h1l1, h1r1⟩, ⟨h1l2, h1r2⟩⟩, h2⟩,
-   fun ⟨⟨⟨h1l1, h1r1⟩, ⟨h1l2, h1r2⟩⟩, h2⟩ ↦ ⟨⟨⟨h1l1, h1l2⟩, ⟨h1r1, h1r2⟩⟩, h2⟩⟩
+    (f₂.comp f₁).prodMap (g₂.comp g₁) = (f₂.prodMap g₂).comp (f₁.prodMap g₁) := by
+  aesop
 
 end PFun

--- a/Mathlib/Data/PFunctor/Univariate/M.lean
+++ b/Mathlib/Data/PFunctor/Univariate/M.lean
@@ -21,9 +21,6 @@ open List
 
 variable (F : PFunctor.{u})
 
--- Porting note: the ♯ tactic is never used
--- local prefix:0 "♯" => cast (by first |simp [*]|cc|solve_by_elim)
-
 namespace PFunctor
 
 namespace Approx

--- a/Mathlib/Data/PNat/Basic.lean
+++ b/Mathlib/Data/PNat/Basic.lean
@@ -313,8 +313,6 @@ theorem mod_le (m k : ℕ+) : mod m k ≤ m ∧ mod m k ≤ k := by
     · rw [h₁, mul_zero] at hm
       exact (lt_irrefl _ hm).elim
     · let h₂ : (k : ℕ) * 1 ≤ k * (m / k) :=
-        -- Porting note: Specified type of `h₂` explicitly because `rw` could not unify
-        -- `succ 0` with `1`.
         Nat.mul_le_mul_left (k : ℕ) (Nat.succ_le_of_lt (Nat.pos_of_ne_zero h₁))
       rw [mul_one] at h₂
       exact ⟨h₂, le_refl (k : ℕ)⟩

--- a/Mathlib/Data/PNat/Defs.lean
+++ b/Mathlib/Data/PNat/Defs.lean
@@ -92,13 +92,9 @@ open Nat
  obvious way, but there are a few things to be said about
  subtraction, division and powers.
 -/
--- Porting note: no `simp`  because simp can prove it
-theorem mk_le_mk (n k : ℕ) (hn : 0 < n) (hk : 0 < k) : (⟨n, hn⟩ : ℕ+) ≤ ⟨k, hk⟩ ↔ n ≤ k :=
-  Iff.rfl
+theorem mk_le_mk (n k : ℕ) (hn : 0 < n) (hk : 0 < k) : (⟨n, hn⟩ : ℕ+) ≤ ⟨k, hk⟩ ↔ n ≤ k := by simp
 
--- Porting note: no `simp`  because simp can prove it
-theorem mk_lt_mk (n k : ℕ) (hn : 0 < n) (hk : 0 < k) : (⟨n, hn⟩ : ℕ+) < ⟨k, hk⟩ ↔ n < k :=
-  Iff.rfl
+theorem mk_lt_mk (n k : ℕ) (hn : 0 < n) (hk : 0 < k) : (⟨n, hn⟩ : ℕ+) < ⟨k, hk⟩ ↔ n < k := by simp
 
 @[simp, norm_cast]
 theorem coe_le_coe (n k : ℕ+) : (n : ℕ) ≤ k ↔ n ≤ k :=

--- a/Mathlib/Data/PNat/Find.lean
+++ b/Mathlib/Data/PNat/Find.lean
@@ -88,9 +88,7 @@ theorem lt_find_iff (n : ℕ+) : n < PNat.find h ↔ ∀ m ≤ n, ¬p m := by
 @[simp]
 theorem find_eq_one : PNat.find h = 1 ↔ p 1 := by simp [find_eq_iff]
 
--- Porting note: deleted `@[simp]` to satisfy the linter because `le_find_iff` is more general
-theorem one_le_find : 1 < PNat.find h ↔ ¬p 1 :=
-  not_iff_not.mp <| by simp
+theorem one_le_find : 1 < PNat.find h ↔ ¬p 1 := by simp
 
 theorem find_mono (h : ∀ n, q n → p n) {hp : ∃ n, p n} {hq : ∃ n, q n} :
     PNat.find hp ≤ PNat.find hq :=

--- a/Mathlib/Data/PNat/Prime.lean
+++ b/Mathlib/Data/PNat/Prime.lean
@@ -16,7 +16,6 @@ This file extends the theory of `ℕ+` with `gcd`, `lcm` and `Prime` functions, 
 
 namespace Nat.Primes
 
--- Porting note (https://github.com/leanprover-community/mathlib4/issues/11445): new definition
 /-- The canonical map from `Nat.Primes` to `ℕ+` -/
 @[coe] def toPNat : Nat.Primes → ℕ+ :=
   fun p => ⟨(p : ℕ), p.property.pos⟩

--- a/Mathlib/Data/PNat/Xgcd.lean
+++ b/Mathlib/Data/PNat/Xgcd.lean
@@ -137,7 +137,6 @@ theorem isSpecial_iff : u.IsSpecial ↔ u.IsSpecial' := by
     simp only [← coe_inj, mul_coe, mk_coe] at *
   · simp_all [← h]; ring
   · simp [Nat.mul_add, Nat.add_mul, ← Nat.add_assoc] at h; rw [← h]; ring
-  -- Porting note: Old code has been removed as it was much more longer.
 
 /-- `IsReduced` holds if the two entries in the vector are the
  same.  The reduction algorithm will produce a system with this
@@ -287,7 +286,6 @@ theorem step_v (hr : u.r ≠ 0) : u.step.v = u.v.swap := by
     rw [← ha, hr]
     ring
 
--- Porting note: removed 'have' and added decreasing_by to avoid lint errors
 /-- We can now define the full reduction function, which applies
  step as long as possible, and then applies finish. Note that the
  "have" statement puts a fact in the local context, and the

--- a/Mathlib/Data/Part.lean
+++ b/Mathlib/Data/Part.lean
@@ -239,7 +239,7 @@ theorem getOrElse_none (d : α) [Decidable (none : Part α).Dom] : getOrElse non
 theorem getOrElse_some (a : α) (d : α) [Decidable (some a).Dom] : getOrElse (some a) d = a :=
   (some a).getOrElse_of_dom (some_dom a) d
 
--- Porting note: removed `simp`
+-- `simp`-normal form is `toOption_eq_some_iff`.
 theorem mem_toOption {o : Part α} [Decidable o.Dom] {a : α} : a ∈ toOption o ↔ a ∈ o := by
   unfold toOption
   by_cases h : o.Dom <;> simp [h]
@@ -257,8 +257,7 @@ protected theorem Dom.toOption {o : Part α} [Decidable o.Dom] (h : o.Dom) : o.t
 theorem toOption_eq_none_iff {a : Part α} [Decidable a.Dom] : a.toOption = Option.none ↔ ¬a.Dom :=
   Ne.dite_eq_right_iff fun _ => Option.some_ne_none _
 
-/- Porting TODO: Removed `simp`. Maybe add `@[simp]` later if `@[simp]` is taken off definition of
-`Option.elim` -/
+@[simp]
 theorem elim_toOption {α β : Type*} (a : Part α) [Decidable a.Dom] (b : β) (f : α → β) :
     a.toOption.elim b f = if h : a.Dom then f (a.get h) else b := by
   split_ifs with h
@@ -528,7 +527,7 @@ theorem bind_le {α} (x : Part α) (f : α → Part β) (y : Part β) :
     rcases h' with ⟨a, h₀, h₁⟩
     apply h _ h₀ _ h₁
 
--- Porting note: No MonadFail in Lean4 yet
+-- TODO: if `MonadFail` is defined, define the below instance.
 -- instance : MonadFail Part :=
 --   { Part.monad with fail := fun _ _ => none }
 

--- a/Mathlib/Data/Prod/Basic.lean
+++ b/Mathlib/Data/Prod/Basic.lean
@@ -58,10 +58,7 @@ theorem map_fst' (f : α → γ) (g : β → δ) : Prod.fst ∘ map f g = f ∘ 
 theorem map_snd' (f : α → γ) (g : β → δ) : Prod.snd ∘ map f g = g ∘ Prod.snd :=
   funext <| map_snd f g
 
--- Porting note: `@[simp]` tag removed because auto-generated `mk.injEq` simplifies LHS
--- @[simp]
-theorem mk_inj {a₁ a₂ : α} {b₁ b₂ : β} : (a₁, b₁) = (a₂, b₂) ↔ a₁ = a₂ ∧ b₁ = b₂ :=
-  Iff.of_eq (mk.injEq _ _ _ _)
+theorem mk_inj {a₁ a₂ : α} {b₁ b₂ : β} : (a₁, b₁) = (a₂, b₂) ↔ a₁ = a₂ ∧ b₁ = b₂ := by simp
 
 @[deprecated (since := "2025-03-06")] alias mk.inj_iff := mk_inj
 

--- a/Mathlib/Data/Quot.lean
+++ b/Mathlib/Data/Quot.lean
@@ -94,7 +94,6 @@ theorem factor_mk_eq {α : Type*} (r s : α → α → Prop) (h : ∀ x y, r x y
 
 variable {γ : Sort*} {r : α → α → Prop} {s : β → β → Prop}
 
--- Porting note: used to be an Alias of `Quot.lift_mk`.
 theorem lift_mk (f : α → γ) (h : ∀ a₁ a₂, r a₁ a₂ → f a₁ = f a₂) (a : α) :
     Quot.lift f h (Quot.mk r a) = f a :=
   rfl
@@ -196,7 +195,7 @@ namespace Quotient
 variable {sa : Setoid α} {sb : Setoid β}
 variable {φ : Quotient sa → Quotient sb → Sort*}
 
--- Porting note: in mathlib3 this notation took the Setoid as an instance-implicit argument,
+-- TODO: in mathlib3 this notation took the Setoid as an instance-implicit argument,
 -- now it's explicit but left as a metavariable.
 -- We have not yet decided which one works best, since the setoid instance can't always be
 -- reliably found but it can't always be inferred from the expected type either.
@@ -355,7 +354,7 @@ noncomputable def Quot.out {r : α → α → Prop} (q : Quot r) : α :=
 /-- Unwrap the VM representation of a quotient to obtain an element of the equivalence class.
   Computable but unsound. -/
 unsafe def Quot.unquot {r : α → α → Prop} : Quot r → α :=
-  cast lcProof -- Porting note: was `unchecked_cast` before, which unfolds to `cast undefined`
+  cast lcProof
 
 @[simp]
 theorem Quot.out_eq {r : α → α → Prop} (q : Quot r) : Quot.mk r q.out = q :=
@@ -514,7 +513,6 @@ instance : LawfulMonad Trunc where
   id_map _ := Trunc.eq _ _
   pure_bind _ _ := rfl
   bind_assoc _ _ _ := Trunc.eq _ _
-  -- Porting note: the fields below are new in Lean 4
   map_const := rfl
   seqLeft_eq _ _ := Trunc.eq _ _
   seqRight_eq _ _ := Trunc.eq _ _
@@ -569,7 +567,6 @@ several different quotient relations on a type, for example quotient groups, rin
 
 -- TODO: this whole section can probably be replaced `Quotient.mk`, with explicit parameter
 
--- Porting note: Quotient.mk' is the equivalent of Lean 3's `Quotient.mk`
 /-- A version of `Quotient.mk` taking `{s : Setoid α}` as an implicit argument instead of an
 instance argument. -/
 protected abbrev mk'' (a : α) : Quotient s₁ :=

--- a/Mathlib/Data/Rat/Cast/Lemmas.lean
+++ b/Mathlib/Data/Rat/Cast/Lemmas.lean
@@ -21,12 +21,12 @@ namespace Rat
 
 variable {α : Type*} [DivisionRing α]
 
+-- Note that this is more general than `(Rat.castHom α).map_pow`.
 @[simp, norm_cast]
 lemma cast_pow (p : ℚ) (n : ℕ) : ↑(p ^ n) = (p ^ n : α) := by
   rw [cast_def, cast_def, den_pow, num_pow, Nat.cast_pow, Int.cast_pow, div_eq_mul_inv, ← inv_pow,
     ← (Int.cast_commute _ _).mul_pow, ← div_eq_mul_inv]
 
--- Porting note: rewrote proof
 @[simp]
 theorem cast_inv_nat (n : ℕ) : ((n⁻¹ : ℚ) : α) = (n : α)⁻¹ := by
   rcases n with - | n
@@ -34,7 +34,6 @@ theorem cast_inv_nat (n : ℕ) : ((n⁻¹ : ℚ) : α) = (n : α)⁻¹ := by
   rw [cast_def, inv_natCast_num, inv_natCast_den, if_neg n.succ_ne_zero,
     Int.sign_eq_one_of_pos (Int.ofNat_succ_pos n), Int.cast_one, one_div]
 
--- Porting note: proof got a lot easier - is this still the intended statement?
 @[simp]
 theorem cast_inv_int (n : ℤ) : ((n⁻¹ : ℚ) : α) = (n : α)⁻¹ := by
   rcases n with n | n

--- a/Mathlib/Data/Rat/Defs.lean
+++ b/Mathlib/Data/Rat/Defs.lean
@@ -39,7 +39,6 @@ open Function
 namespace Rat
 variable {q : ℚ}
 
--- Porting note: the definition of `ℚ` has changed; in mathlib3 this was a field.
 theorem pos (a : ℚ) : 0 < a.den := Nat.pos_of_ne_zero a.den_nz
 
 lemma mk'_num_den (q : ℚ) : mk' q.num q.den q.den_nz q.reduced = q := rfl
@@ -73,8 +72,6 @@ lemma natCast_injective : Injective (Nat.cast : ℕ → ℚ) :=
 @[simp, nolint simpNF, norm_cast] lemma intCast_eq_one {n : ℤ} : (n : ℚ) = 1 ↔ n = 1 := intCast_inj
 @[simp, nolint simpNF, norm_cast] lemma natCast_eq_one {n : ℕ} : (n : ℚ) = 1 ↔ n = 1 := natCast_inj
 
--- Porting note (https://github.com/leanprover-community/mathlib4/issues/11215): TODO Should this be namespaced?
-
 lemma mkRat_eq_divInt (n d) : mkRat n d = n /. d := rfl
 
 @[simp] lemma mk'_zero (d) (h : d ≠ 0) (w) : mk' 0 d h w = 0 := by congr; simp_all
@@ -101,7 +98,7 @@ theorem divInt_eq_zero {a b : ℤ} (b0 : b ≠ 0) : a /. b = 0 ↔ a = 0 := by
 theorem divInt_ne_zero {a b : ℤ} (b0 : b ≠ 0) : a /. b ≠ 0 ↔ a ≠ 0 :=
   (divInt_eq_zero b0).not
 
--- Porting note: this can move to Batteries
+-- TODO: this can move to Batteries
 theorem normalize_eq_mk' (n : Int) (d : Nat) (h : d ≠ 0) (c : Nat.gcd (Int.natAbs n) d = 1) :
     normalize n d h = mk' n d h c := (mk_eq_normalize ..).symm
 
@@ -139,8 +136,6 @@ numbers of the form `mk' n d` with `d ≠ 0`. -/
 def numDenCasesOn''.{u} {C : ℚ → Sort u} (a : ℚ)
     (H : ∀ (n : ℤ) (d : ℕ) (nz red), C (mk' n d nz red)) : C a :=
   numDenCasesOn a fun n d h h' ↦ by rw [← mk_eq_divInt _ _ h.ne' h']; exact H n d h.ne' _
-
--- Porting note: there's already an instance for `Add ℚ` is in Batteries.
 
 theorem lift_binop_eq (f : ℚ → ℚ → ℚ) (f₁ : ℤ → ℤ → ℤ → ℤ → ℤ) (f₂ : ℤ → ℤ → ℤ → ℤ → ℤ)
     (fv :
@@ -284,8 +279,6 @@ protected theorem mul_inv_cancel : a ≠ 0 → a * a⁻¹ = 1 :=
 
 protected theorem inv_mul_cancel (h : a ≠ 0) : a⁻¹ * a = 1 :=
   Eq.trans (Rat.mul_comm _ _) (Rat.mul_inv_cancel _ h)
-
--- Porting note: we already have a `DecidableEq ℚ`.
 
 -- Extra instances to short-circuit type class resolution
 -- TODO(Mario): this instance slows down Mathlib.Data.Real.Basic

--- a/Mathlib/Data/Rat/Lemmas.lean
+++ b/Mathlib/Data/Rat/Lemmas.lean
@@ -183,15 +183,15 @@ protected theorem inv_neg (q : ℚ) : (-q)⁻¹ = -q⁻¹ := by
 
 theorem num_div_eq_of_coprime {a b : ℤ} (hb0 : 0 < b) (h : Nat.Coprime a.natAbs b.natAbs) :
     (a / b : ℚ).num = a := by
-  -- Porting note: was `lift b to ℕ using le_of_lt hb0`
-  rw [← Int.natAbs_of_nonneg hb0.le, ← Rat.divInt_eq_div,
-    ← mk_eq_divInt _ _ (Int.natAbs_ne_zero.mpr hb0.ne') h]
+  lift b to ℕ using hb0.le
+  simp only [Int.natAbs_ofNat, Int.ofNat_pos] at h hb0
+  rw [← Rat.divInt_eq_div, ← mk_eq_divInt _ _ hb0.ne' h]
 
 theorem den_div_eq_of_coprime {a b : ℤ} (hb0 : 0 < b) (h : Nat.Coprime a.natAbs b.natAbs) :
     ((a / b : ℚ).den : ℤ) = b := by
-  -- Porting note: was `lift b to ℕ using le_of_lt hb0`
-  rw [← Int.natAbs_of_nonneg hb0.le, ← Rat.divInt_eq_div,
-    ← mk_eq_divInt _ _ (Int.natAbs_ne_zero.mpr hb0.ne') h]
+  lift b to ℕ using hb0.le
+  simp only [Int.natAbs_ofNat, Int.ofNat_pos] at h hb0
+  rw [← Rat.divInt_eq_div, ← mk_eq_divInt _ _ hb0.ne' h]
 
 theorem div_int_inj {a b c d : ℤ} (hb0 : 0 < b) (hd0 : 0 < d) (h1 : Nat.Coprime a.natAbs b.natAbs)
     (h2 : Nat.Coprime c.natAbs d.natAbs) (h : (a : ℚ) / b = (c : ℚ) / d) : a = c ∧ b = d := by

--- a/Mathlib/Data/Rel.lean
+++ b/Mathlib/Data/Rel.lean
@@ -52,7 +52,6 @@ namespace Rel
 
 variable (r : Rel α β)
 
--- Porting note: required for later theorems.
 @[ext] theorem ext {r s : Rel α β} : (∀ a, r a = s a) → r = s := funext
 
 /-- The inverse relation : `r.inv x y ↔ r y x`. Note that this is *not* a groupoid inverse. -/
@@ -85,8 +84,8 @@ theorem dom_inv : r.inv.dom = r.codom := by
 /-- Composition of relation; note that it follows the `CategoryTheory/` order of arguments. -/
 def comp (r : Rel α β) (s : Rel β γ) : Rel α γ := fun x z => ∃ y, r x y ∧ s y z
 
--- Porting note: the original `∘` syntax can't be overloaded here, lean considers it ambiguous.
 /-- Local syntax for composition of relations. -/
+-- TODO: this could be replaced with `local infixr:90 " ∘ " => Rel.comp`.
 local infixr:90 " • " => Rel.comp
 
 theorem comp_assoc {δ : Type*} (r : Rel α β) (s : Rel β γ) (t : Rel γ δ) :

--- a/Mathlib/Data/Seq/Computation.lean
+++ b/Mathlib/Data/Seq/Computation.lean
@@ -207,11 +207,6 @@ def rmap (f : β → γ) : α ⊕ β → α ⊕ γ
 
 attribute [simp] lmap rmap
 
--- Porting note: this was far less painful in mathlib3. There seem to be two issues;
--- firstly, in mathlib3 we have `corec.F._match_1` and it's the obvious map α ⊕ β → option α.
--- In mathlib4 we have `Corec.f.match_1` and it's something completely different.
--- Secondly, the proof that `Stream'.corec' (Corec.f f) (Sum.inr b) 0` is this function
--- evaluated at `f b`, used to be `rfl` and now is `cases, rfl`.
 @[simp]
 theorem corec_eq (f : β → α ⊕ β) (b : β) : destruct (corec f b) = rmap (corec f) (f b) := by
   dsimp [corec, destruct]
@@ -900,12 +895,7 @@ theorem LiftRel.trans (R : α → α → Prop) (H : Transitive R) : Transitive (
     ⟨a, a1, H ab bc⟩⟩
 
 theorem LiftRel.equiv (R : α → α → Prop) : Equivalence R → Equivalence (LiftRel R)
-  | ⟨refl, symm, trans⟩ => ⟨LiftRel.refl R refl, by apply LiftRel.symm; apply symm,
-    by apply LiftRel.trans; apply trans⟩
-  -- Porting note: The code above was:
-  -- | ⟨refl, symm, trans⟩ => ⟨LiftRel.refl R refl, LiftRel.symm R symm, LiftRel.trans R trans⟩
-  --
-  -- The code fails to identify `symm` as being symmetric.
+  | ⟨refl, symm, trans⟩ => ⟨LiftRel.refl R refl, @LiftRel.symm _ R @symm, @LiftRel.trans _ R @trans⟩
 
 theorem LiftRel.imp {R S : α → β → Prop} (H : ∀ {a b}, R a b → S a b) (s t) :
     LiftRel R s t → LiftRel S s t

--- a/Mathlib/Data/Seq/Parallel.lean
+++ b/Mathlib/Data/Seq/Parallel.lean
@@ -81,7 +81,7 @@ theorem terminates_parallel.aux :
       induction' l with c l IH' <;> intro l' e' <;> simp at m
       rcases m with e | m <;> simp [parallel.aux2] at e'
       · rw [← e] at e'
-        -- Porting note: `revert e'` & `intro e'` are required.
+        -- Porting note: `revert e'` is required.
         revert e'
         split
         · simp
@@ -217,7 +217,7 @@ theorem exists_of_mem_parallel {S : WSeq (Computation α)} {a} (h : a ∈ parall
             obtain ⟨dm, ad⟩ := dm
             exact ⟨d, List.Mem.tail _ dm, ad⟩
   intro C aC
-  -- Porting note: `revert e'` & `intro e'` are required.
+  -- Porting note: `revert this e'` & `intro this e'` are required.
   apply memRecOn aC <;> [skip; intro C' IH] <;> intro l S e <;> have e' := congr_arg destruct e <;>
     have := lem1 l <;> simp only [parallel.aux1, corec_eq, destruct_pure, destruct_think] at e' <;>
     revert this e' <;> rcases parallel.aux2 l with a' | l' <;> intro this e' <;>

--- a/Mathlib/Data/Seq/Seq.lean
+++ b/Mathlib/Data/Seq/Seq.lean
@@ -299,7 +299,6 @@ theorem mem_rec_on {C : Seq α → Prop} {a s} (M : a ∈ s)
       rfl
     rw [TH]
     apply h1 _ _ (Or.inl rfl)
-  -- Porting note: had to reshuffle `intro`
   cases s with
   | nil => injection e
   | cons b s' =>
@@ -339,9 +338,7 @@ def corec (f : β → Option (α × β)) (b : β) : Seq α := by
 theorem corec_eq (f : β → Option (α × β)) (b : β) :
     destruct (corec f b) = omap (corec f) (f b) := by
   dsimp [corec, destruct, get]
-  -- Porting note: next two lines were `change`...`with`...
-  have h : Stream'.corec' (Corec.f f) (some b) 0 = (Corec.f f (some b)).1 := rfl
-  rw [h]
+  rw [show Stream'.corec' (Corec.f f) (some b) 0 = (Corec.f f (some b)).1 from rfl]
   dsimp [Corec.f]
   induction' h : f b with s; · rfl
   obtain ⟨a, b'⟩ := s; dsimp [Corec.f]
@@ -1319,8 +1316,6 @@ theorem bind_assoc (s : Seq1 α) (f : α → Seq1 β) (g : β → Seq1 γ) :
   rw [map_comp _ join]
   generalize Seq.map (map g ∘ f) s = SS
   rcases map g (f a) with ⟨⟨a, s⟩, S⟩
-  -- Porting note: Instead of `apply recOn s <;> intros`, `induction'` are used to
-  --   give names to variables.
   induction' s using recOn with x s_1 <;> induction' S using recOn with x_1 s_2 <;> simp
   · obtain ⟨x, t⟩ := x_1
     cases t <;> simp

--- a/Mathlib/Data/Seq/WSeq.lean
+++ b/Mathlib/Data/Seq/WSeq.lean
@@ -1437,8 +1437,8 @@ theorem liftRel_join (R : α → β → Prop) {S : WSeq (WSeq α)} {T : WSeq (WS
       | some (a, s), some (b, t), ⟨h1, h2⟩ => by
         simpa using ⟨h1, s, t, S, rfl, T, rfl, h2, ST⟩
       | none, none, _ => by
-        -- Porting note: `LiftRelO` should be excluded.
-        dsimp [destruct_append.aux, Computation.LiftRel, -LiftRelO]; constructor
+        -- We do not `dsimp` with `LiftRelO` since `liftRel_join.lem` uses `LiftRelO`.
+        dsimp only [destruct_append.aux, Computation.LiftRel]; constructor
         · intro
           apply liftRel_join.lem _ ST fun _ _ => id
         · intro b mb

--- a/Mathlib/Data/Set/Pairwise/Lattice.lean
+++ b/Mathlib/Data/Set/Pairwise/Lattice.lean
@@ -72,7 +72,6 @@ theorem PairwiseDisjoint.biUnion {s : Set ι'} {g : ι' → Set ι} {f : ι → 
   obtain ⟨d, hd, hb⟩ := hb
   obtain hcd | hcd := eq_or_ne (g c) (g d)
   · exact hg d hd (hcd ▸ ha) hb hab
-  -- Porting note: the elaborator couldn't figure out `f` here.
   · exact (hs hc hd <| ne_of_apply_ne _ hcd).mono
       (le_iSup₂ (f := fun i _ => f i) a ha)
       (le_iSup₂ (f := fun i _ => f i) b hb)

--- a/Mathlib/Data/Sigma/Basic.lean
+++ b/Mathlib/Data/Sigma/Basic.lean
@@ -193,8 +193,6 @@ theorem Prod.snd_toSigma {α β} (x : α × β) : (Prod.toSigma x).snd = x.snd :
 theorem Prod.toSigma_mk {α β} (x : α) (y : β) : (x, y).toSigma = ⟨x, y⟩ :=
   rfl
 
--- Porting note: the meta instance `has_reflect (Σa, β a)` was removed here.
-
 end Sigma
 
 namespace PSigma

--- a/Mathlib/Data/Sign.lean
+++ b/Mathlib/Data/Sign.lean
@@ -205,16 +205,15 @@ section cast
 
 variable {α : Type*} [Zero α] [One α] [Neg α]
 
-/-- Turn a `SignType` into zero, one, or minus one. This is a coercion instance, but note it is
-only a `CoeTC` instance: see note [use has_coe_t]. -/
+/-- Turn a `SignType` into zero, one, or minus one. This is a coercion instance. -/
 @[coe]
 def cast : SignType → α
   | zero => 0
   | pos => 1
   | neg => -1
 
--- Porting note: Translated has_coe_t to CoeTC
-instance : CoeTC SignType α :=
+/-- This is a `Coe` since the type on the right (trivially) determines the type on the left. -/
+instance : Coe SignType α :=
   ⟨cast⟩
 
 /-- Casting out of `SignType` respects composition with functions preserving `0, 1, -1`. -/

--- a/Mathlib/Data/Stream/Defs.lean
+++ b/Mathlib/Data/Stream/Defs.lean
@@ -146,8 +146,7 @@ def pure (a : α) : Stream' α :=
 /-- Given a stream of functions and a stream of values, apply `n`-th function to `n`-th value. -/
 def apply (f : Stream' (α → β)) (s : Stream' α) : Stream' β := fun n => (get f n) (get s n)
 
-@[inherit_doc] infixl:75 " ⊛ " => apply
--- Porting note: "input as \o*" was here but doesn't work for the above notation
+@[inherit_doc] infixl:75 " ⊛ " => apply -- input as `\circledast`
 
 /-- The stream of natural numbers: `Stream'.get n Stream'.nats = n`. -/
 def nats : Stream' ℕ := fun n => n

--- a/Mathlib/Data/Subtype.lean
+++ b/Mathlib/Data/Subtype.lean
@@ -73,8 +73,7 @@ theorem coe_eta (a : { a // p a }) (h : p a) : mk (↑a) h = a :=
 theorem coe_mk (a h) : (@mk α p a h : α) = a :=
   rfl
 
--- Porting note: not clear if "built-in reduction doesn't always work" is still relevant
--- built-in reduction doesn't always work
+/-- Restatement of `subtype.mk.injEq` as an iff. -/
 theorem mk_eq_mk {a h a' h'} : @mk α p a h = @mk α p a' h' ↔ a = a' := by simp
 
 theorem coe_eq_of_eq_mk {a : { a // p a }} {b : α} (h : ↑a = b) : a = ⟨b, h ▸ a.2⟩ :=

--- a/Mathlib/Data/Sum/Interval.lean
+++ b/Mathlib/Data/Sum/Interval.lean
@@ -191,10 +191,7 @@ lemma sumLexLift_nonempty :
       (∃ a₁ b₁, a = inl a₁ ∧ b = inl b₁ ∧ (f₁ a₁ b₁).Nonempty) ∨
         (∃ a₁ b₂, a = inl a₁ ∧ b = inr b₂ ∧ ((g₁ a₁ b₂).Nonempty ∨ (g₂ a₁ b₂).Nonempty)) ∨
           ∃ a₂ b₂, a = inr a₂ ∧ b = inr b₂ ∧ (f₂ a₂ b₂).Nonempty := by
-  -- Porting note (https://github.com/leanprover-community/mathlib4/issues/10745): was `simp [nonempty_iff_ne_empty, sumLexLift_eq_empty, not_and_or]`.
-  -- Could add `-exists_and_left, -not_and, -exists_and_right` but easier to squeeze.
-  simp only [nonempty_iff_ne_empty, Ne, sumLexLift_eq_empty, not_and_or, exists_prop,
-    not_forall]
+  simp only [nonempty_iff_ne_empty, Ne, sumLexLift_eq_empty, not_and_or, exists_prop, not_forall]
 
 end SumLexLift
 end Finset
@@ -292,16 +289,7 @@ variable [Preorder α] [Preorder β] [OrderTop α] [OrderBot β] [LocallyFiniteO
 local elab "simp_lex" : tactic => do
   Lean.Elab.Tactic.evalTactic <| ← `(tactic|
     refine toLex.surjective.forall₃.2 ?_;
-    rintro (a | a) (b | b) (c | c) <;> simp only
-      [sumLexLift_inl_inl, sumLexLift_inl_inr, sumLexLift_inr_inl, sumLexLift_inr_inr,
-        inl_le_inl_iff, inl_le_inr, not_inr_le_inl, inr_le_inr_iff, inl_lt_inl_iff, inl_lt_inr,
-        not_inr_lt_inl, inr_lt_inr_iff, mem_Icc, mem_Ico, mem_Ioc, mem_Ioo, mem_Ici, mem_Ioi,
-        mem_Iic, mem_Iio, Equiv.coe_toEmbedding, toLex_inj, exists_false, and_false, false_and,
-        map_empty, not_mem_empty, true_and, inl_mem_disjSum, inr_mem_disjSum, and_true, ofLex_toLex,
-        mem_map, Embedding.coeFn_mk, exists_prop, exists_eq_right, Embedding.inl_apply,
-        -- Porting note: added
-        inl.injEq, inr.injEq, reduceCtorEq]
-  )
+    rintro (a | a) (b | b) (c | c) <;> simp)
 
 instance locallyFiniteOrder : LocallyFiniteOrder (α ⊕ₗ β) where
   finsetIcc a b :=

--- a/Mathlib/Data/Sym/Basic.lean
+++ b/Mathlib/Data/Sym/Basic.lean
@@ -86,7 +86,7 @@ theorem val_eq_coe (s : Sym α n) : s.1 = ↑s :=
 
 /-- Construct an element of the `n`th symmetric power from a multiset of cardinality `n`.
 -/
-@[match_pattern] -- Porting note: removed `@[simps]`, generated bad lemma
+@[match_pattern]
 abbrev mk (m : Multiset α) (h : Multiset.card m = n) : Sym α n :=
   ⟨m, h⟩
 
@@ -589,7 +589,6 @@ theorem encode_of_not_none_mem [DecidableEq α] (s : Sym (Option α) n.succ) (h 
   dif_neg h
 
 /-- Inverse of `Sym_option_succ_equiv.decode`. -/
--- @[simp] Porting note: not a nice simp lemma, applies too often in Lean4
 def decode : Sym (Option α) n ⊕ Sym α n.succ → Sym (Option α) n.succ
   | Sum.inl s => none ::ₛ s
   | Sum.inr s => s.map Embedding.some

--- a/Mathlib/Data/Sym/Card.lean
+++ b/Mathlib/Data/Sym/Card.lean
@@ -87,7 +87,6 @@ protected def e2 {n k : ℕ} : { s : Sym (Fin n.succ.succ) k // ↑0 ∉ s } ≃
   right_inv s := by
     simp only [map_map, comp_apply, ← Fin.castSucc_zero, Fin.predAbove_succAbove, map_id']
 
--- Porting note: use eqn compiler instead of `pincerRecursion` to make cases more readable
 theorem card_sym_fin_eq_multichoose : ∀ n k : ℕ, card (Sym (Fin n) k) = multichoose n k
   | n, 0 => by simp
   | 0, k + 1 => by rw [multichoose_zero_succ]; exact card_eq_zero
@@ -103,9 +102,7 @@ theorem card_sym_fin_eq_multichoose : ∀ n k : ℕ, card (Sym (Fin n) k) = mult
 theorem card_sym_eq_multichoose (α : Type*) (k : ℕ) [Fintype α] [Fintype (Sym α k)] :
     card (Sym α k) = multichoose (card α) k := by
   rw [← card_sym_fin_eq_multichoose]
-  -- FIXME: Without the `Fintype` namespace, why does it complain about `Finset.card_congr` being
-  -- deprecated?
-  exact Fintype.card_congr (equivCongr (equivFin α))
+  exact card_congr (equivCongr (equivFin α))
 
 /-- The *stars and bars* lemma: the cardinality of `Sym α k` is equal to
 `Nat.choose (card α + k - 1) k`. -/

--- a/Mathlib/Data/Tree/Basic.lean
+++ b/Mathlib/Data/Tree/Basic.lean
@@ -29,6 +29,7 @@ inductive Tree.{u} (α : Type u) : Type u
   | nil : Tree α
   | node : α → Tree α → Tree α → Tree α
   deriving DecidableEq, Repr
+compile_inductive% Tree
 
 namespace Tree
 
@@ -117,9 +118,6 @@ def right : Tree α → Tree α
 
 /-- A node with `Unit` data -/
 scoped infixr:65 " △ " => Tree.node ()
-
--- Porting note: workaround for https://github.com/leanprover/lean4/issues/2049
-compile_inductive% Tree
 
 /-- Induction principle for `Tree Unit`s -/
 @[elab_as_elim]

--- a/Mathlib/Data/TypeVec.lean
+++ b/Mathlib/Data/TypeVec.lean
@@ -246,9 +246,9 @@ theorem appendFun_id_id {α : TypeVec n} {β : Type*} :
   eq_of_drop_last_eq rfl rfl
 
 instance subsingleton0 : Subsingleton (TypeVec 0) :=
-  ⟨fun a b => funext fun a => by apply Fin2.elim0 a⟩ -- Porting note: `by apply` necessary?
+  ⟨fun _ _ => funext Fin2.elim0⟩
 
--- Porting note: `simp` attribute `TypeVec` moved to file `Tactic/Attr/Register.lean`
+-- See `Mathlib.Tactic.Attr.Register` for `register_simp_attr typevec`
 
 /-- cases distinction for 0-length type vector -/
 protected def casesNil {β : TypeVec 0 → Sort*} (f : β Fin2.elim0) : ∀ v, β v :=
@@ -345,7 +345,6 @@ def prod : ∀ {n}, TypeVec.{u} n → TypeVec.{u} n → TypeVec n
 
 @[inherit_doc] scoped[MvFunctor] infixl:45 " ⊗ " => TypeVec.prod
 
-/- porting note: the order of universes in `const` is reversed w.r.t. mathlib3 -/
 /-- `const x α` is an arrow that ignores its source and constructs a `TypeVec` that
 contains nothing but `x` -/
 protected def const {β} (x : β) : ∀ {n} (α : TypeVec n), α ⟹ «repeat» _ β

--- a/Mathlib/Data/Vector/Basic.lean
+++ b/Mathlib/Data/Vector/Basic.lean
@@ -426,7 +426,6 @@ It is used as the default induction principle for the `induction` tactic.
 @[elab_as_elim, induction_eliminator]
 def inductionOn {C : ∀ {n : ℕ}, Vector α n → Sort*} {n : ℕ} (v : Vector α n)
     (nil : C nil) (cons : ∀ {n : ℕ} {x : α} {w : Vector α n}, C w → C (x ::ᵥ w)) : C v := by
-  -- Porting note: removed `generalizing`: already generalized
   induction' n with n ih
   · rcases v with ⟨_ | ⟨-, -⟩, - | -⟩
     exact nil
@@ -454,7 +453,6 @@ def inductionOn₂ {C : ∀ {n}, Vector α n → Vector β n → Sort*}
     (v : Vector α n) (w : Vector β n)
     (nil : C nil nil) (cons : ∀ {n a b} {x : Vector α n} {y}, C x y → C (a ::ᵥ x) (b ::ᵥ y)) :
     C v w := by
-  -- Porting note: removed `generalizing`: already generalized
   induction' n with n ih
   · rcases v with ⟨_ | ⟨-, -⟩, - | -⟩
     rcases w with ⟨_ | ⟨-, -⟩, - | -⟩
@@ -473,7 +471,6 @@ def inductionOn₃ {C : ∀ {n}, Vector α n → Vector β n → Vector γ n →
     (u : Vector α n) (v : Vector β n) (w : Vector γ n) (nil : C nil nil nil)
     (cons : ∀ {n a b c} {x : Vector α n} {y z}, C x y z → C (a ::ᵥ x) (b ::ᵥ y) (c ::ᵥ z)) :
     C u v w := by
-  -- Porting note: removed `generalizing`: already generalized
   induction' n with n ih
   · rcases u with ⟨_ | ⟨-, -⟩, - | -⟩
     rcases v with ⟨_ | ⟨-, -⟩, - | -⟩
@@ -582,7 +579,6 @@ theorem insertIdx_comm (a b : α) (i j : Fin (n + 1)) (h : i ≤ j) :
 
 end InsertIdx
 
--- Porting note: renamed to `set` from `updateNth` to align with `List`
 section Set
 
 /-- `set v n a` replaces the `n`th element of `v` with `a`. -/

--- a/Mathlib/Data/Vector3.lean
+++ b/Mathlib/Data/Vector3.lean
@@ -46,8 +46,6 @@ def cons (a : α) (v : Vector3 α n) : Vector3 α (n + 1) := fun i => by
 section
 open Lean
 
--- Porting note: was
--- scoped notation3 "["(l", "* => foldr (h t => cons h t) nil)"]" => l
 scoped macro_rules | `([$l,*]) => `(expand_foldr% (h t => cons h t) nil [$(.ofElems l),*])
 
 -- this is copied from `src/Init/NotationExtra.lean`
@@ -98,12 +96,12 @@ theorem cons_head_tail (v : Vector3 α (n + 1)) : (head v :: tail v) = v :=
   funext fun i => Fin2.cases' rfl (fun _ => rfl) i
 
 /-- Eliminator for an empty vector. -/
-@[elab_as_elim]  -- Porting note: add `elab_as_elim`
+@[elab_as_elim]
 def nilElim {C : Vector3 α 0 → Sort u} (H : C []) (v : Vector3 α 0) : C v := by
   rw [eq_nil v]; apply H
 
 /-- Recursion principle for a nonempty vector. -/
-@[elab_as_elim]  -- Porting note: add `elab_as_elim`
+@[elab_as_elim]
 def consElim {C : Vector3 α (n + 1) → Sort u} (H : ∀ (a : α) (t : Vector3 α n), C (a :: t))
     (v : Vector3 α (n + 1)) : C v := by rw [← cons_head_tail v]; apply H
 

--- a/Mathlib/Data/W/Basic.lean
+++ b/Mathlib/Data/W/Basic.lean
@@ -70,7 +70,6 @@ def equivSigma : WType β ≃ Σa : α, β a → WType β where
   left_inv := ofSigma_toSigma
   right_inv := toSigma_ofSigma
 
--- Porting note: Universes have a different order than mathlib3 definition
 /-- The canonical map from `WType β` into any type `γ` given a map `(Σ a : α, β a → γ) → γ`. -/
 def elim (γ : Type*) (fγ : (Σa : α, β a → γ) → γ) : WType β → γ
   | ⟨a, f⟩ => fγ ⟨a, fun b => elim γ fγ (f b)⟩

--- a/Mathlib/Data/ZMod/Basic.lean
+++ b/Mathlib/Data/ZMod/Basic.lean
@@ -588,9 +588,6 @@ theorem cast_zmod_eq_zero_iff_of_le {m n : ℕ} [NeZero m] (h : m ≤ n) (a : ZM
   rw [← ZMod.cast_zero (n := m)]
   exact Injective.eq_iff' (cast_injective_of_le h) rfl
 
--- Porting note: commented
--- unseal Int.NonNeg
-
 @[simp]
 theorem natCast_toNat (p : ℕ) : ∀ {z : ℤ} (_h : 0 ≤ z), (z.toNat : ZMod p) = z
   | (n : ℕ), _h => by simp only [Int.cast_natCast, Int.toNat_natCast]
@@ -1102,7 +1099,6 @@ section lift
 variable (n) {A : Type*} [AddGroup A]
 
 /-- The map from `ZMod n` induced by `f : ℤ →+ A` that maps `n` to `0`. -/
---@[simps] -- Porting note: removed, simplified LHS of `lift_coe` to something worse.
 def lift : { f : ℤ →+ A // f n = 0 } ≃ (ZMod n →+ A) :=
   (Equiv.subtypeEquivRight <| by
         intro f

--- a/Mathlib/Data/ZMod/Defs.lean
+++ b/Mathlib/Data/ZMod/Defs.lean
@@ -73,8 +73,6 @@ instance instCommRing (n : ℕ) [NeZero n] : CommRing (Fin n) :=
   { Fin.instAddMonoidWithOne n, Fin.addCommGroup n, Fin.instCommSemigroup n, Fin.instDistrib n with
     one_mul := Fin.one_mul'
     mul_one := Fin.mul_one',
-    -- Porting note: new, see
-    -- https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/ring.20vs.20Ring/near/322876462
     zero_mul := Fin.zero_mul'
     mul_zero := Fin.mul_zero' }
 
@@ -147,7 +145,6 @@ instance commRing (n : ℕ) : CommRing (ZMod n) where
   nsmul_succ := Nat.casesOn n
     (inferInstanceAs (CommRing ℤ)).nsmul_succ
     fun n => (inferInstanceAs (CommRing (Fin n.succ))).nsmul_succ
-  -- Porting note: `match` didn't work here
   neg_add_cancel := Nat.casesOn n (@neg_add_cancel Int _) fun n => @neg_add_cancel (Fin n.succ) _
   add_comm := Nat.casesOn n (@add_comm Int _) fun n => @add_comm (Fin n.succ) _
   mul := Nat.casesOn n (@Mul.mul Int _) fun n => @Mul.mul (Fin n.succ) _
@@ -166,8 +163,6 @@ instance commRing (n : ℕ) : CommRing (ZMod n) where
   right_distrib :=
     Nat.casesOn n (@right_distrib Int _ _ _) fun n => @right_distrib (Fin n.succ) _ _ _
   mul_comm := Nat.casesOn n (@mul_comm Int _) fun n => @mul_comm (Fin n.succ) _
-  -- Porting note: new, see
-  -- https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/ring.20vs.20Ring/near/322876462
   zero_mul := Nat.casesOn n (@zero_mul Int _) fun n => @zero_mul (Fin n.succ) _
   mul_zero := Nat.casesOn n (@mul_zero Int _) fun n => @mul_zero (Fin n.succ) _
   npow := Nat.casesOn n

--- a/Mathlib/Data/ZMod/QuotientGroup.lean
+++ b/Mathlib/Data/ZMod/QuotientGroup.lean
@@ -123,8 +123,8 @@ theorem _root_.AddAction.orbitZMultiplesEquiv_symm_apply' {α β : Type*} [AddGr
     (AddAction.orbitZMultiplesEquiv a b).symm k =
       k • (⟨a, mem_zmultiples a⟩ : zmultiples a) +ᵥ ⟨b, AddAction.mem_orbit_self b⟩ := by
   rw [AddAction.orbitZMultiplesEquiv_symm_apply, ZMod.coe_intCast]
-  -- Porting note: times out without `a b` explicit
-  exact Subtype.ext (zsmul_vadd_mod_minimalPeriod a b k)
+  -- Making `a` explicit turns this from ~190000 heartbeats to ~700.
+  exact Subtype.ext (zsmul_vadd_mod_minimalPeriod a _ k)
 
 attribute [to_additive existing]
   orbitZPowersEquiv_symm_apply'
@@ -132,8 +132,7 @@ attribute [to_additive existing]
 @[to_additive]
 theorem minimalPeriod_eq_card [Fintype (orbit (zpowers a) b)] :
     minimalPeriod (a • ·) b = Fintype.card (orbit (zpowers a) b) := by
-  -- Porting note: added `(_)` to find `Fintype` by unification
-  rw [← Fintype.ofEquiv_card (orbitZPowersEquiv a b), @ZMod.card _ (_)]
+  rw [← Fintype.ofEquiv_card (orbitZPowersEquiv a b), ZMod.card]
 
 @[to_additive]
 instance minimalPeriod_pos [Finite <| orbit (zpowers a) b] :

--- a/Mathlib/Util/CompileInductive.lean
+++ b/Mathlib/Util/CompileInductive.lean
@@ -242,6 +242,7 @@ compile_inductive% False
 compile_inductive% Empty
 compile_inductive% Bool
 compile_inductive% Sigma
+compile_inductive% Option
 
 -- In addition to the manual implementation below, we also have to override the `Float.val` and
 -- `Float.mk` functions because these also have no implementation in core lean.


### PR DESCRIPTION
This PR goes through all porting notes in `Mathlib/Data` and reviews them. Most of the notes can simply be applied or dropped.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
