### PR TITLE
feat(RingTheory/Finiteness/Small): tensor product of the system of small submodules

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3880,7 +3880,6 @@ import Mathlib.LinearAlgebra.TensorProduct.Associator
 import Mathlib.LinearAlgebra.TensorProduct.Basic
 import Mathlib.LinearAlgebra.TensorProduct.Basis
 import Mathlib.LinearAlgebra.TensorProduct.DirectLimit
-import Mathlib.LinearAlgebra.TensorProduct.DirectLimit/FG
 import Mathlib.LinearAlgebra.TensorProduct.Finiteness
 import Mathlib.LinearAlgebra.TensorProduct.Graded.External
 import Mathlib.LinearAlgebra.TensorProduct.Graded.Internal

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3880,6 +3880,7 @@ import Mathlib.LinearAlgebra.TensorProduct.Associator
 import Mathlib.LinearAlgebra.TensorProduct.Basic
 import Mathlib.LinearAlgebra.TensorProduct.Basis
 import Mathlib.LinearAlgebra.TensorProduct.DirectLimit
+import Mathlib.LinearAlgebra.TensorProduct.DirectLimit/FG
 import Mathlib.LinearAlgebra.TensorProduct.Finiteness
 import Mathlib.LinearAlgebra.TensorProduct.Graded.External
 import Mathlib.LinearAlgebra.TensorProduct.Graded.Internal

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4808,6 +4808,7 @@ import Mathlib.RingTheory.Finiteness.Nilpotent
 import Mathlib.RingTheory.Finiteness.Prod
 import Mathlib.RingTheory.Finiteness.Projective
 import Mathlib.RingTheory.Finiteness.Quotient
+import Mathlib.RingTheory.Finiteness.Small
 import Mathlib.RingTheory.Finiteness.Subalgebra
 import Mathlib.RingTheory.Fintype
 import Mathlib.RingTheory.Flat.Basic
@@ -5112,6 +5113,7 @@ import Mathlib.RingTheory.Support
 import Mathlib.RingTheory.SurjectiveOnStalks
 import Mathlib.RingTheory.TensorProduct.Basic
 import Mathlib.RingTheory.TensorProduct.DirectLimit.FG
+import Mathlib.RingTheory.TensorProduct.DirectLimit.Small
 import Mathlib.RingTheory.TensorProduct.Finite
 import Mathlib.RingTheory.TensorProduct.Free
 import Mathlib.RingTheory.TensorProduct.MvPolynomial

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3880,6 +3880,7 @@ import Mathlib.LinearAlgebra.TensorProduct.Associator
 import Mathlib.LinearAlgebra.TensorProduct.Basic
 import Mathlib.LinearAlgebra.TensorProduct.Basis
 import Mathlib.LinearAlgebra.TensorProduct.DirectLimit
+import Mathlib.LinearAlgebra.TensorProduct.DirectLimit.FG
 import Mathlib.LinearAlgebra.TensorProduct.Finiteness
 import Mathlib.LinearAlgebra.TensorProduct.Graded.External
 import Mathlib.LinearAlgebra.TensorProduct.Graded.Internal

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3880,7 +3880,6 @@ import Mathlib.LinearAlgebra.TensorProduct.Associator
 import Mathlib.LinearAlgebra.TensorProduct.Basic
 import Mathlib.LinearAlgebra.TensorProduct.Basis
 import Mathlib.LinearAlgebra.TensorProduct.DirectLimit
-import Mathlib.LinearAlgebra.TensorProduct.DirectLimit.FG
 import Mathlib.LinearAlgebra.TensorProduct.Finiteness
 import Mathlib.LinearAlgebra.TensorProduct.Graded.External
 import Mathlib.LinearAlgebra.TensorProduct.Graded.Internal
@@ -5112,6 +5111,7 @@ import Mathlib.RingTheory.Spectrum.Prime.Topology
 import Mathlib.RingTheory.Support
 import Mathlib.RingTheory.SurjectiveOnStalks
 import Mathlib.RingTheory.TensorProduct.Basic
+import Mathlib.RingTheory.TensorProduct.DirectLimit.FG
 import Mathlib.RingTheory.TensorProduct.Finite
 import Mathlib.RingTheory.TensorProduct.Free
 import Mathlib.RingTheory.TensorProduct.MvPolynomial

--- a/Mathlib/RingTheory/Adjoin/FG.lean
+++ b/Mathlib/RingTheory/Adjoin/FG.lean
@@ -164,6 +164,12 @@ theorem induction_on_adjoin [IsNoetherian R A] (P : Subalgebra R A → Prop) (ba
   rw [Finset.coe_insert]
   simpa only [Algebra.adjoin_insert_adjoin] using ih _ x h
 
+theorem fg_sup {B B' : Subalgebra R A} (hB : B.FG) (hB' : B'.FG) : (B ⊔ B').FG :=
+  let ⟨s, hs⟩ := Subalgebra.fg_def.1 hB
+  let ⟨s', hs'⟩ := Subalgebra.fg_def.1 hB'
+  Subalgebra.fg_def.2 ⟨s ∪ s', Set.Finite.union hs.1 hs'.1,
+    (by rw [Algebra.adjoin_union, hs.2, hs'.2])⟩
+
 end Subalgebra
 
 section Semiring

--- a/Mathlib/RingTheory/Adjoin/FG.lean
+++ b/Mathlib/RingTheory/Adjoin/FG.lean
@@ -164,12 +164,6 @@ theorem induction_on_adjoin [IsNoetherian R A] (P : Subalgebra R A → Prop) (ba
   rw [Finset.coe_insert]
   simpa only [Algebra.adjoin_insert_adjoin] using ih _ x h
 
-theorem fg_sup {B B' : Subalgebra R A} (hB : B.FG) (hB' : B'.FG) : (B ⊔ B').FG :=
-  let ⟨s, hs⟩ := Subalgebra.fg_def.1 hB
-  let ⟨s', hs'⟩ := Subalgebra.fg_def.1 hB'
-  Subalgebra.fg_def.2 ⟨s ∪ s', Set.Finite.union hs.1 hs'.1,
-    (by rw [Algebra.adjoin_union, hs.2, hs'.2])⟩
-
 end Subalgebra
 
 section Semiring

--- a/Mathlib/RingTheory/Adjoin/FG.lean
+++ b/Mathlib/RingTheory/Adjoin/FG.lean
@@ -127,6 +127,13 @@ theorem FG.prod {S : Subalgebra R A} {T : Subalgebra R B} (hS : S.FG) (hT : T.FG
       (Set.Finite.image _ (Set.Finite.union ht.1 (Set.finite_singleton _))),
     Algebra.adjoin_inl_union_inr_eq_prod R s t⟩
 
+theorem fg_sup {B B' : Subalgebra R A} (hB : Subalgebra.FG B) (hB' : Subalgebra.FG B') :
+    Subalgebra.FG (B ⊔ B') :=
+  let ⟨s, hs, hsB⟩ := Subalgebra.fg_def.1 hB
+  let ⟨s', hs', hsB'⟩ := Subalgebra.fg_def.1 hB'
+  Subalgebra.fg_def.2 ⟨s ∪ s', Set.Finite.union hs hs',
+    (by rw [Algebra.adjoin_union, hsB, hsB'])⟩
+
 section
 
 theorem FG.map {S : Subalgebra R A} (f : A →ₐ[R] B) (hs : S.FG) : (S.map f).FG := by

--- a/Mathlib/RingTheory/Finiteness/Basic.lean
+++ b/Mathlib/RingTheory/Finiteness/Basic.lean
@@ -52,6 +52,17 @@ theorem fg_iSup {ι : Sort*} [Finite ι] (N : ι → Submodule R M) (h : ∀ i, 
   cases nonempty_fintype (PLift ι)
   simpa [iSup_plift_down] using fg_biSup Finset.univ (N ∘ PLift.down) fun i _ => h i.down
 
+instance : SemilatticeSup {P : Submodule R M // P.FG} where
+  sup := fun P Q ↦ ⟨P.val ⊔ Q.val, Submodule.FG.sup P.property Q.property⟩
+  le_sup_left := fun P Q ↦ by rw [← Subtype.coe_le_coe]; exact le_sup_left
+  le_sup_right := fun P Q ↦ by rw [← Subtype.coe_le_coe]; exact le_sup_right
+  sup_le := fun P Q R hPR hQR ↦ by
+    rw [← Subtype.coe_le_coe] at hPR hQR ⊢
+    exact sup_le hPR hQR
+
+instance : Inhabited {P : Submodule R M // P.FG} where
+  default := ⟨⊥, fg_bot⟩
+
 section
 
 variable {S P : Type*} [Semiring S] [AddCommMonoid P] [Module S P]

--- a/Mathlib/RingTheory/Finiteness/Basic.lean
+++ b/Mathlib/RingTheory/Finiteness/Basic.lean
@@ -52,17 +52,6 @@ theorem fg_iSup {ι : Sort*} [Finite ι] (N : ι → Submodule R M) (h : ∀ i, 
   cases nonempty_fintype (PLift ι)
   simpa [iSup_plift_down] using fg_biSup Finset.univ (N ∘ PLift.down) fun i _ => h i.down
 
-instance : SemilatticeSup {P : Submodule R M // P.FG} where
-  sup := fun P Q ↦ ⟨P.val ⊔ Q.val, Submodule.FG.sup P.property Q.property⟩
-  le_sup_left := fun P Q ↦ by rw [← Subtype.coe_le_coe]; exact le_sup_left
-  le_sup_right := fun P Q ↦ by rw [← Subtype.coe_le_coe]; exact le_sup_right
-  sup_le := fun P Q R hPR hQR ↦ by
-    rw [← Subtype.coe_le_coe] at hPR hQR ⊢
-    exact sup_le hPR hQR
-
-instance : Inhabited {P : Submodule R M // P.FG} where
-  default := ⟨⊥, fg_bot⟩
-
 section
 
 variable {S P : Type*} [Semiring S] [AddCommMonoid P] [Module S P]

--- a/Mathlib/RingTheory/Finiteness/Cardinality.lean
+++ b/Mathlib/RingTheory/Finiteness/Cardinality.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johan Commelin
 -/
 import Mathlib.LinearAlgebra.Basis.Cardinality
-import Mathlib.LinearAlgebra.DFinsupp
 import Mathlib.LinearAlgebra.StdBasis
 import Mathlib.RingTheory.Finiteness.Basic
 

--- a/Mathlib/RingTheory/Finiteness/Small.lean
+++ b/Mathlib/RingTheory/Finiteness/Small.lean
@@ -1,0 +1,133 @@
+/-
+Copyright (c) 2025 Antoine Chambert-Loir, María-Inés de Frutos-Fernández. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Antoine Chambert-Loir, Maria-Inés de Frutos-Fernandez
+-/
+import Mathlib.LinearAlgebra.Finsupp.LinearCombination
+import Mathlib.RingTheory.FiniteType
+import Mathlib.LinearAlgebra.DFinsupp
+import Mathlib.Algebra.Algebra.Subalgebra.Basic
+import Mathlib.LinearAlgebra.Basis.Cardinality
+import Mathlib.LinearAlgebra.StdBasis
+import Mathlib.RingTheory.Finiteness.Basic
+
+
+/-! # Smallness properties of modules and algebras -/
+
+universe u
+
+namespace Submodule
+
+variable {R M : Type*} [Semiring R] [AddCommMonoid M] [Module R M]
+
+theorem bot_small : Small.{u} (⊥ : Submodule R M) := by
+  let f : Unit → (⊥ : Submodule R M) := fun _ ↦ 0
+  have : Small.{u} Unit := small_lift Unit
+  apply small_of_surjective (f := f)
+  rintro ⟨x, hx⟩
+  simp only [mem_bot] at hx
+  use default
+  simp [← Subtype.coe_inj, f, hx]
+
+theorem small_sup {P Q : Submodule R M} (_ : Small.{u} P) (_ : Small.{u} Q) :
+    Small.{u} (P ⊔ Q : Submodule R M) := by
+  rw [Submodule.sup_eq_range]
+  exact small_range _
+
+theorem FG.small [Small.{u} R] (P : Submodule R M) (hP : P.FG) : Small.{u} P := by
+  rw [fg_iff_exists_fin_generating_family] at hP
+  obtain ⟨n, s, rfl⟩ := hP
+  rw [← Fintype.range_linearCombination]
+  apply small_range
+
+theorem small_directSum
+    {ι : Type*} {P : ι → Submodule R M} [Small.{u} ι] [∀ i, Small.{u} (P i)] :
+    Small.{u} (Π₀ (i : ι), ↥(P i)) := by
+  classical
+  -- Define somewhere else
+  have : Small.{u} (Finset ι) := small_of_injective (f := Finset.toSet) Finset.coe_injective
+  have (s : Finset ι) : Small.{u} (Π (i : s), P i) := small_Pi _
+  let h : (Σ (s : Finset ι), (Π i : s, P i)) → Π₀ i, P i := fun sf ↦ by
+    exact {
+      toFun (i : ι) := if h : i ∈ sf.1.val then sf.2 ⟨i, h⟩ else 0
+      support' := Trunc.mk ⟨sf.1.val, fun i ↦ by
+        simp only [Finset.mem_val, dite_eq_right_iff]
+        by_cases hi : i ∈ sf.1
+        · exact Or.inl hi
+        · apply Or.inr fun h ↦ False.elim (hi h)⟩}
+  apply small_of_surjective (f := h)
+  intro m
+  use ⟨m.support, fun i ↦ m i⟩
+  ext i
+  simp only [Finset.mem_val, DFinsupp.mem_support_toFun, ne_eq, dite_eq_ite, DFinsupp.coe_mk',
+    ite_not, SetLike.coe_eq_coe, ite_eq_right_iff, h]
+  simp only [eq_comm, imp_self, h]
+
+theorem small_iSup
+    {ι : Type*} {P : ι → Submodule R M} (_ : Small.{u} ι) (_ : ∀ i, Small.{u} (P i)) :
+    Small.{u} (iSup P : Submodule R M) := by
+  classical
+  rw [iSup_eq_range_dfinsupp_lsum]
+  have : Small.{u} (Π₀ (i : ι), ↥(P i)) := Submodule.small_directSum
+  apply small_range
+
+theorem small_span [Small.{u} R] (s : Set M) [Small.{u} s] :
+    Small.{u} (span R s) := by
+  suffices span R s = iSup (fun i : s ↦ span R ({(↑i : M)} : Set M)) by
+    rw [this]
+    exact small_iSup (by trivial) fun _ ↦ FG.small _ (fg_span_singleton _)
+  apply le_antisymm
+  · rw [span_le]
+    intro i hi
+    apply mem_iSup_of_mem (⟨i, hi⟩ : s)
+    refine span_mono (s := {i}) (by simp) (mem_span_singleton_self i)
+  · apply iSup_le
+    rintro ⟨i, hi⟩
+    simp only [span_singleton_le_iff_mem]
+    apply span_mono (s := {i}) _ (mem_span_singleton_self i)
+    simp only [Set.singleton_subset_iff, hi]
+
+instance : SemilatticeSup {P : Submodule R M // Small.{u} P} where
+  sup := fun P Q ↦ ⟨P.val ⊔ Q.val, small_sup P.property Q.property⟩
+  le_sup_left := fun P Q ↦ by rw [← Subtype.coe_le_coe]; exact le_sup_left
+  le_sup_right := fun P Q ↦ by rw [← Subtype.coe_le_coe]; exact le_sup_right
+  sup_le := fun _ _ _ hPR hQR ↦ by
+    rw [← Subtype.coe_le_coe] at hPR hQR ⊢
+    exact sup_le hPR hQR
+
+instance : Inhabited {P : Submodule R M // Small.{u} P} where
+  default := ⟨⊥, bot_small⟩
+
+end Submodule
+
+variable {R S : Type*} [CommSemiring R] [CommSemiring S] [Algebra R S]
+
+namespace Algebra
+
+open MvPolynomial AlgHom
+
+theorem small_adjoin [Small.{u} R] {s : Set S} [Small.{u} s] :
+    Small.{u} (adjoin R s : Subalgebra R S) := by
+  let j' := mapEquiv (Shrink.{u} s) (Shrink.ringEquiv R)
+  have : Small.{u} (MvPolynomial (Shrink.{u} s) R) := small_of_surjective j'.surjective
+  let j : MvPolynomial (Shrink.{u} s) R →ₐ[R] S := aeval (fun i ↦ (equivShrink s).symm i)
+  have hj : adjoin R s = j.range := by
+    rw [← adjoin_range_eq_range_aeval, ← Function.comp_def]
+    simp
+  rw [hj]
+  apply small_range (f := j)
+
+theorem FiniteType.small [Small.{u} R] [Algebra.FiniteType R S] :
+    Small.{u} S := by
+  obtain ⟨s : Finset S, hs⟩ := (Algebra.FiniteType.out : (⊤ : Subalgebra R S).FG)
+  have : Small.{u} (adjoin R s : Subalgebra R S) := small_adjoin
+  apply small_of_surjective (f := (adjoin R s).subtype)
+  rw [hs]
+  exact fun x ↦ ⟨⟨x, by simp⟩, by simp⟩
+
+theorem _root_.Subalgebra.FG.small [Small.{u} R] {A : Subalgebra R S} (fgS : A.FG) :
+    Small.{u} A := by
+  have : FiniteType R A := (Subalgebra.fg_iff_finiteType A).mp fgS
+  exact FiniteType.small (R := R) (S := A)
+
+end Algebra

--- a/Mathlib/RingTheory/Spectrum/Prime/RingHom.lean
+++ b/Mathlib/RingTheory/Spectrum/Prime/RingHom.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johan Commelin, Filippo A. E. Nuccio, Andrew Yang
 -/
 import Mathlib.RingTheory.Spectrum.Prime.Basic
-
+import Mathlib.LinearAlgebra.DFinsupp
 /-!
 # Functoriality of the prime spectrum
 

--- a/Mathlib/RingTheory/Spectrum/Prime/RingHom.lean
+++ b/Mathlib/RingTheory/Spectrum/Prime/RingHom.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johan Commelin, Filippo A. E. Nuccio, Andrew Yang
 -/
 import Mathlib.RingTheory.Spectrum.Prime.Basic
-import Mathlib.LinearAlgebra.DFinsupp
+import Mathlib.Data.DFinsupp.Defs
 /-!
 # Functoriality of the prime spectrum
 

--- a/Mathlib/RingTheory/TensorProduct/Basic.lean
+++ b/Mathlib/RingTheory/TensorProduct/Basic.lean
@@ -98,6 +98,11 @@ lemma baseChange_comp (g : N →ₗ[R] P) :
     (g ∘ₗ f).baseChange A = g.baseChange A ∘ₗ f.baseChange A := by
   ext; simp
 
+theorem rTensor_comp_baseChange_comm_apply
+    (φ : A →ₗ[R] B) (t : A ⊗[R] M) (f : M →ₗ[R] N) :
+    (φ.rTensor N) (f.baseChange A t)  = (f.baseChange B) (φ.rTensor M t) := by
+  simp [LinearMap.baseChange_eq_ltensor, ← LinearMap.comp_apply, ← TensorProduct.map_comp]
+
 variable (R M) in
 @[simp]
 lemma baseChange_one : (1 : Module.End R M).baseChange A = 1 := baseChange_id

--- a/Mathlib/RingTheory/TensorProduct/Basic.lean
+++ b/Mathlib/RingTheory/TensorProduct/Basic.lean
@@ -74,6 +74,12 @@ theorem baseChange_tmul (a : A) (x : M) : f.baseChange A (a ⊗ₜ x) = a ⊗ₜ
 theorem baseChange_eq_ltensor : (f.baseChange A : A ⊗ M → A ⊗ N) = f.lTensor A :=
   rfl
 
+theorem rTensor_comp_baseChange_comm_apply
+    {S : Type*} [CommSemiring S] [Algebra R S] {S' : Type*} [CommSemiring S'] [Algebra R S']
+    (φ : S →ₗ[R] S') (t : S ⊗[R] M) (f : M →ₗ[R] N) :
+    (φ.rTensor N) (f.baseChange S t)  = (f.baseChange S') (φ.rTensor M t) := by
+  simp [baseChange_eq_ltensor, ← comp_apply, ← map_comp]
+
 @[simp]
 theorem baseChange_add : (f + g).baseChange A = f.baseChange A + g.baseChange A := by
   ext
@@ -1396,3 +1402,4 @@ lemma Submodule.map_range_rTensor_subtype_lid {R Q} [CommSemiring R] [AddCommMon
   rintro _ ⟨t, rfl⟩
   exact t.induction_on (by simp) (by simp +contextual [Submodule.smul_mem_smul])
     (by simp +contextual [add_mem])
+

--- a/Mathlib/RingTheory/TensorProduct/Basic.lean
+++ b/Mathlib/RingTheory/TensorProduct/Basic.lean
@@ -74,12 +74,6 @@ theorem baseChange_tmul (a : A) (x : M) : f.baseChange A (a ⊗ₜ x) = a ⊗ₜ
 theorem baseChange_eq_ltensor : (f.baseChange A : A ⊗ M → A ⊗ N) = f.lTensor A :=
   rfl
 
-theorem rTensor_comp_baseChange_comm_apply
-    {S : Type*} [CommSemiring S] [Algebra R S] {S' : Type*} [CommSemiring S'] [Algebra R S']
-    (φ : S →ₗ[R] S') (t : S ⊗[R] M) (f : M →ₗ[R] N) :
-    (φ.rTensor N) (f.baseChange S t)  = (f.baseChange S') (φ.rTensor M t) := by
-  simp [baseChange_eq_ltensor, ← comp_apply, ← map_comp]
-
 @[simp]
 theorem baseChange_add : (f + g).baseChange A = f.baseChange A + g.baseChange A := by
   ext
@@ -1402,4 +1396,3 @@ lemma Submodule.map_range_rTensor_subtype_lid {R Q} [CommSemiring R] [AddCommMon
   rintro _ ⟨t, rfl⟩
   exact t.induction_on (by simp) (by simp +contextual [Submodule.smul_mem_smul])
     (by simp +contextual [add_mem])
-

--- a/Mathlib/RingTheory/TensorProduct/DirectLimit/FG.lean
+++ b/Mathlib/RingTheory/TensorProduct/DirectLimit/FG.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) 2025 Antoine Chambert-Loir, María-Inés de Frutos-Fernández. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Antoine Chambert-Loir, Maria-Inés de Frutos-Fernandez
+-/
 import Mathlib.LinearAlgebra.TensorProduct.DirectLimit
 import Mathlib.LinearAlgebra.TensorProduct.Tower
 import Mathlib.RingTheory.Adjoin.FG
@@ -8,7 +13,7 @@ import Mathlib.RingTheory.Ideal.Quotient.Operations
 
 import Mathlib.Algebra.DirectSum.Internal
 
-/- # Tensor products and finitely generated submodules
+/-! # Tensor products and finitely generated submodules
 
 * `DirectedSystem.Submodule_fg`: the directed system of finitely generated submodules,
 with respect to the inclusion maps.
@@ -74,7 +79,7 @@ universe u v
 variable {R : Type u} [Semiring R] {M : Type*} [AddCommMonoid M] [Module R M]
 
 /-- The directed system of finitely generated submodules of `M` -/
-def DirectedSystem.Submodule_fg :
+theorem DirectedSystem.Submodule_fg :
     DirectedSystem (ι := {P : Submodule R M // P.FG}) (F := fun P ↦ P.val)
     (f := fun ⦃P Q⦄ (h : P ≤ Q) ↦ Submodule.inclusion h) where
   map_self := fun _ _ ↦ rfl
@@ -130,7 +135,7 @@ theorem rTensor_fg_directedSystem :
     (fun ⦃_ _⦄ h ↦ LinearMap.rTensor N (Submodule.inclusion h)) :=
   DirectedSystem.rTensor R N DirectedSystem.Submodule_fg
 
-/-- A tensor product `M ⊗[R] N` is the direct limit of the modules `P ⊗[R] N`,
+/-- The tensor product `M ⊗[R] N` is the direct limit of the modules `P ⊗[R] N`,
 where `P` ranges over all finitely generated submodules of `M`. -/
 noncomputable def rTensor_fg_equiv [DecidableEq {P : Submodule R M // P.FG}] :
     Module.DirectLimit (R := R) (ι := {P : Submodule R M // P.FG}) (fun P ↦ P.val ⊗[R] N)
@@ -182,6 +187,8 @@ theorem lTensor_fg_directedSystem :
       (fun _ _ hPQ ↦ LinearMap.lTensor M (Submodule.inclusion hPQ)) :=
   DirectedSystem.lTensor R M DirectedSystem.Submodule_fg
 
+/-- The module `M ⊗[R] N` is the direct limit of the modules `M ⊗[R] Q`,
+where `Q` runs over finitely generated submodules of `N`. -/
 noncomputable def lTensor_fgEquiv [DecidableEq {Q : Submodule R N // Q.FG}] :
     Module.DirectLimit (R := R) (ι := {Q : Submodule R N // Q.FG}) (fun Q ↦ M ⊗[R] Q.val)
       (fun _ _ hPQ ↦ (Submodule.inclusion hPQ).lTensor M) ≃ₗ[R] M ⊗[R] N :=

--- a/Mathlib/RingTheory/TensorProduct/DirectLimit/FG.lean
+++ b/Mathlib/RingTheory/TensorProduct/DirectLimit/FG.lean
@@ -6,12 +6,7 @@ Authors: Antoine Chambert-Loir, Maria-Inés de Frutos-Fernandez
 import Mathlib.LinearAlgebra.TensorProduct.DirectLimit
 import Mathlib.LinearAlgebra.TensorProduct.Tower
 import Mathlib.RingTheory.Adjoin.FG
-import Mathlib.Algebra.Equiv.TransferInstance
-import Mathlib.LinearAlgebra.TensorProduct.RightExactness
-import Mathlib.RingTheory.FiniteType
-import Mathlib.RingTheory.Ideal.Quotient.Operations
-
-import Mathlib.Algebra.DirectSum.Internal
+import Mathlib.RingTheory.TensorProduct.Basic
 
 /-! # Tensor products and finitely generated submodules
 

--- a/Mathlib/RingTheory/TensorProduct/DirectLimit/FG.lean
+++ b/Mathlib/RingTheory/TensorProduct/DirectLimit/FG.lean
@@ -1,0 +1,373 @@
+import Mathlib.LinearAlgebra.TensorProduct.DirectLimit
+import Mathlib.LinearAlgebra.TensorProduct.Tower
+import Mathlib.RingTheory.Adjoin.FG
+import Mathlib.Algebra.Equiv.TransferInstance
+import Mathlib.LinearAlgebra.TensorProduct.RightExactness
+import Mathlib.RingTheory.FiniteType
+import Mathlib.RingTheory.Ideal.Quotient.Operations
+
+import Mathlib.Algebra.DirectSum.Internal
+
+/- # Tensor products and finitely generated submodules
+
+* `DirectedSystem.Submodule_fg`: the directed system of finitely generated submodules,
+with respect to the inclusion maps.
+
+* `Submodules_fg_equiv`: a module is the direct limit
+of its finitely generated submodules, with respect to the inclusion maps
+
+* `DirectedSystem.rTensor`: given a directed system `M i`,
+the directed system of modules `M i ⊗[R] N`.
+
+* `rTensor_fgEquiv`: a tensor product `M ⊗[R] N` is the direct limit
+of the tensor products `P ⊗[R] N`, for finitely generated submodules `P` of `M`.
+
+* `DirectedSystem.lTensor`: given a directed system `N i`,
+the directed system of modules `M ⊗[R] N i`.
+
+* `lTensor_fgEquiv`: a tensor product `M ⊗[R] N` is the direct limit
+of the tensor products `M ⊗[R] Q`, for finitely generated submodules `Q` of `N`.
+
+* `TensorProduct.exists_rTensor_of_fg`: any element `t:  M ⊗[R] N`  can be lifted
+to some `P ⊗[R] N`, for fome finitely generated submodule `P` of `M`.
+
+* `TensorProduct.eq_of_fg_of_subtype_eq` ;
+given a finitely generated submodule `P` of `M` and `t, t' : P ⊗[R] N`
+which have the same image in `M ⊗[R] N`, there exists a finitely generated submodule `Q` of `M`
+which contains `P` such that `t` and `t'` have the same image in `Q ⊗[R] N`.
+
+* `TensorProduct.eq_of_fg_of_subtype_eq₂` ;
+given finitely generated submodules `P` and `P'`of `M`, `t : P ⊗[R] N` and `t' : P' ⊗[R] N`
+which have the same image in `M ⊗[R] N`, there exists a finitely generated submodule `Q` of `M`
+which contains `P` and `P'` and such that `t` and `t'` have the same image in `Q ⊗[R] N`.
+
+* `TensorProduct.Algebra.exists_of_fg`: any element `t : S ⊗[R] N` can be lifted
+to `A ⊗[R] N`, for some finitely generated subalgebra `A` of `S`.
+
+* `TensorProduct.Algebra.eq_of_fg_of_subtype_eq`:
+given a finitely generated subalgebra `A` of `S`, `t : A ⊗[R] N` and `t' : A ⊗[R] N`
+which have the same image in `S ⊗[R] N`, there exists a finitely generated subalgebra `B` of `S`
+which contains `A` and such that `t` and `t'` have the same image in `B ⊗[R] N`.
+
+* `TensorProduct.Algebra.eq_of_fg_of_subtype_eq₂`:
+given finitely generated subalgebras `A` and `A'`of `S`, `t : A ⊗[R] N` and `t' : A' ⊗[R] N`
+which have the same image in `S ⊗[R] N`, there exists a finitely generated subalgebra `B` of `S`
+which contains `A` and `A'` and such that `t` and `t'` have the same image in `B ⊗[R] N`.
+
+* `Submodule.exists_fg_of_baseChange_eq_zero`: if `t : S ⊗[R] M`
+mapst to `0` in `S ⊗[R] N`, there exists a finitely generated subalgebra `A` of `S`
+and `u : A ⊗[R] M` which maps to `t` in `S ⊗[R] M`, and to `0` in `S ⊗[R] N`.
+
+## TODO
+
+* The results are valid in the context of `AddCommMonoid M` over a `Semiring`.
+However,  tensor products in mathlib require commutativity of the scalars,
+and direct limits of modules are restricted to modules over rings.
+
+-/
+
+open Submodule LinearMap
+
+section Semiring
+
+universe u v
+variable {R : Type u} [Semiring R] {M : Type*} [AddCommMonoid M] [Module R M]
+
+/-- The directed system of finitely generated submodules of `M` -/
+def DirectedSystem.Submodule_fg :
+    DirectedSystem (ι := {P : Submodule R M // P.FG}) (F := fun P ↦ P.val)
+    (f := fun ⦃P Q⦄ (h : P ≤ Q) ↦ Submodule.inclusion h) where
+  map_self := fun _ _ ↦ rfl
+  map_map  := fun _ _ _ _ _ _ ↦ rfl
+
+variable (R M) in
+/-- Any module is the direct limit of its finitely generated submodules -/
+noncomputable def Submodules_fg_equiv [DecidableEq {P : Submodule R M // P.FG}] :
+    Module.DirectLimit (ι := {P : Submodule R M // P.FG})
+      (G := fun P ↦ P.val)
+      (fun ⦃P Q⦄ (h : P ≤ Q) ↦ Submodule.inclusion h) ≃ₗ[R] M :=
+  LinearEquiv.ofBijective
+    (Module.DirectLimit.lift _ _ _ _ (fun P ↦ P.val.subtype) (fun _ _ _ _ ↦ rfl))
+    ⟨Module.DirectLimit.lift_injective _ _ (fun P ↦ Submodule.injective_subtype P.val),
+      fun x ↦ ⟨Module.DirectLimit.of _ {P : Submodule R M // P.FG} _ _
+          ⟨Submodule.span R {x}, Submodule.fg_span_singleton x⟩
+          ⟨x, Submodule.mem_span_singleton_self x⟩,
+         by simp⟩⟩
+
+end Semiring
+
+section TensorProducts
+
+open TensorProduct
+
+universe u v
+
+variable (R : Type u) (M N : Type*)
+  [CommSemiring R]
+  [AddCommMonoid M] [Module R M]
+  [AddCommMonoid N] [Module R N]
+
+/-- Given a directed system of `R`-modules, tensor it on the right gives a directed system -/
+theorem DirectedSystem.rTensor {ι : Type*} [Preorder ι] {F : ι → Type*}
+    [∀ i, AddCommMonoid (F i)] [∀ i, Module R (F i)] {f : ⦃i j : ι⦄ → i ≤ j → F i →ₗ[R] F j}
+    (D : DirectedSystem F (fun _ _ h ↦ f h)) :
+    DirectedSystem (fun i ↦ (F i) ⊗[R] N) (fun _ _ h ↦ LinearMap.rTensor N (f h)) where
+  map_self i t := by
+    rw [← LinearMap.id_apply (R := R) t]
+    apply DFunLike.congr_fun
+    ext m n
+    simp [D.map_self]
+  map_map {i j k} h h' t := by
+    rw [← LinearMap.comp_apply, ← LinearMap.rTensor_comp]
+    apply DFunLike.congr_fun
+    ext p n
+    simp [D.map_map]
+
+/-- When `P` ranges over finitely generated submodules of `M`,
+  the modules of the form `P ⊗[R] N` form a directed system. -/
+theorem rTensor_fg_directedSystem :
+    DirectedSystem (ι := {P : Submodule R M // P.FG}) (fun P ↦ P.val ⊗[R] N)
+    (fun ⦃_ _⦄ h ↦ LinearMap.rTensor N (Submodule.inclusion h)) :=
+  DirectedSystem.rTensor R N DirectedSystem.Submodule_fg
+
+/-- A tensor product `M ⊗[R] N` is the direct limit of the modules `P ⊗[R] N`,
+where `P` ranges over all finitely generated submodules of `M`. -/
+noncomputable def rTensor_fg_equiv [DecidableEq {P : Submodule R M // P.FG}] :
+    Module.DirectLimit (R := R) (ι := {P : Submodule R M // P.FG}) (fun P ↦ P.val ⊗[R] N)
+      (fun ⦃P Q⦄ (h : P ≤ Q)  ↦ (Submodule.inclusion h).rTensor N) ≃ₗ[R] M ⊗[R] N :=
+  (TensorProduct.directLimitLeft _ N).symm.trans ((Submodules_fg_equiv R M).rTensor N)
+
+theorem rTensor_fgEquiv_of  [DecidableEq {P : Submodule R M // P.FG}]
+    {P : {P : Submodule R M // P.FG}} (u : P ⊗[R] N) :
+    (rTensor_fg_equiv R M N)
+      ((Module.DirectLimit.of R {P : Submodule R M // P.FG} (fun P ↦ P.val ⊗[R] N)
+        (fun ⦃_ _⦄ h ↦ (Submodule.inclusion h).rTensor N) P) u)
+      = (LinearMap.rTensor N (Submodule.subtype P)) u := by
+  suffices (rTensor_fg_equiv R M N).toLinearMap.comp
+      (Module.DirectLimit.of R {P : Submodule R M // P.FG} (fun P ↦ P.val ⊗[R] N)
+        (fun _ _ hPQ ↦ LinearMap.rTensor N (Submodule.inclusion hPQ)) P)
+      = LinearMap.rTensor N (Submodule.subtype P.val) by
+    exact DFunLike.congr_fun this u
+  ext p n
+  simp [rTensor_fg_equiv, Submodules_fg_equiv]
+
+theorem rTensor_fgEquiv_of' [DecidableEq {P : Submodule R M // P.FG}]
+    (P : Submodule R M) (hP : Submodule.FG P) (u : P ⊗[R] N) :
+    (rTensor_fg_equiv R M N)
+      ((Module.DirectLimit.of R {P : Submodule R M // P.FG} (fun P ↦ P.val ⊗[R] N)
+        (fun ⦃_ _⦄ h ↦ LinearMap.rTensor N (Submodule.inclusion h)) ⟨P, hP⟩) u)
+      = (LinearMap.rTensor N (Submodule.subtype P)) u :=
+  by apply rTensor_fgEquiv_of
+
+/-- Given a directed system of `R`-modules, tensor it on the left gives a directed system -/
+theorem DirectedSystem.lTensor {ι : Type*} [Preorder ι] {F : ι → Type*}
+    [∀ i, AddCommMonoid (F i)] [∀ i, Module R (F i)] {f : ⦃i j : ι⦄ → i ≤ j → F i →ₗ[R] F j}
+    (D : DirectedSystem F (fun _ _ h ↦ f h)) :
+    DirectedSystem (fun i ↦ M ⊗[R] (F i)) (fun _ _ h ↦ LinearMap.lTensor M (f h)) where
+  map_self i t := by
+    rw [← LinearMap.id_apply (R := R) t]
+    apply DFunLike.congr_fun
+    ext m n
+    simp [D.map_self]
+  map_map {i j k} h h' t := by
+    rw [← LinearMap.comp_apply, ← LinearMap.lTensor_comp]
+    apply DFunLike.congr_fun
+    ext p n
+    simp [D.map_map]
+
+/-- When `Q` ranges over finitely generated submodules of `N`,
+  the modules of the form `M ⊗[R] Q` form a directed system. -/
+theorem lTensor_fg_directedSystem :
+    DirectedSystem (ι := {Q : Submodule R N // Q.FG}) (fun Q ↦ M ⊗[R] Q.val)
+      (fun _ _ hPQ ↦ LinearMap.lTensor M (Submodule.inclusion hPQ)) :=
+  DirectedSystem.lTensor R M DirectedSystem.Submodule_fg
+
+noncomputable def lTensor_fgEquiv [DecidableEq {Q : Submodule R N // Q.FG}] :
+    Module.DirectLimit (R := R) (ι := {Q : Submodule R N // Q.FG}) (fun Q ↦ M ⊗[R] Q.val)
+      (fun _ _ hPQ ↦ (Submodule.inclusion hPQ).lTensor M) ≃ₗ[R] M ⊗[R] N :=
+  (TensorProduct.directLimitRight _ M).symm.trans ((Submodules_fg_equiv R N).lTensor M)
+
+theorem lTensor_fgEquiv_of [DecidableEq {P : Submodule R N // P.FG}]
+    (Q : {Q : Submodule R N // Q.FG}) (u : M ⊗[R] Q.val) :
+    (lTensor_fgEquiv R M N)
+      ((Module.DirectLimit.of R {Q : Submodule R N // Q.FG} (fun Q ↦ M ⊗[R] Q.val)
+        (fun _ _ hPQ ↦ (Submodule.inclusion hPQ).lTensor M) Q) u)
+      = (LinearMap.lTensor M (Submodule.subtype Q.val)) u := by
+  suffices (lTensor_fgEquiv R M N).toLinearMap.comp
+      (Module.DirectLimit.of R {Q : Submodule R N // Q.FG} (fun Q ↦ M ⊗[R] Q.val)
+        (fun _ _ hPQ ↦ LinearMap.lTensor M (Submodule.inclusion hPQ)) Q)
+      = LinearMap.lTensor M (Submodule.subtype Q.val) by
+    exact DFunLike.congr_fun this u
+  ext p n
+  simp [lTensor_fgEquiv, Submodules_fg_equiv]
+
+theorem lTensor_fgEquiv_of' [DecidableEq {Q : Submodule R N // Q.FG}]
+    (Q : Submodule R N) (hQ : Q.FG) (u : M ⊗[R] Q) :
+    (lTensor_fgEquiv R M N)
+      ((Module.DirectLimit.of R {Q : Submodule R N // Q.FG} (fun Q ↦ M ⊗[R] Q.val)
+        (fun _ _ hPQ ↦ LinearMap.lTensor M (Submodule.inclusion hPQ)) ⟨Q, hQ⟩) u)
+      = (LinearMap.lTensor M (Submodule.subtype Q)) u :=
+  lTensor_fgEquiv_of R M N ⟨Q, hQ⟩ u
+
+variable {R M N}
+
+theorem TensorProduct.exists_rTensor_of_fg [DecidableEq {P : Submodule R M // P.FG}]
+    (t : M ⊗[R] N) :
+    ∃ (P : Submodule R M), P.FG ∧ t ∈ LinearMap.range (LinearMap.rTensor N P.subtype) := by
+  let ⟨P, u, hu⟩ := Module.DirectLimit.exists_of ((rTensor_fg_equiv R M N).symm t)
+  use P.val, P.property, u
+  rw [← rTensor_fgEquiv_of, hu, LinearEquiv.apply_symm_apply]
+
+theorem TensorProduct.eq_of_fg_of_subtype_eq {P : Submodule R M} (hP : P.FG) (t t' : P ⊗[R] N)
+    (h : LinearMap.rTensor N P.subtype t = LinearMap.rTensor N P.subtype t') :
+    ∃ (Q : Submodule R M) (hPQ : P ≤ Q), Q.FG ∧
+      LinearMap.rTensor N (Submodule.inclusion hPQ) t
+        = LinearMap.rTensor N (Submodule.inclusion hPQ) t' := by
+  have := rTensor_fg_directedSystem R M N -- should this be an instance?
+  classical
+  simp only [← rTensor_fgEquiv_of' R M N P hP, EmbeddingLike.apply_eq_iff_eq] at h
+  obtain ⟨Q, hPQ, h⟩ := Module.DirectLimit.exists_eq_of_of_eq h
+  use Q.val, Subtype.coe_le_coe.mpr hPQ, Q.property
+
+theorem TensorProduct.eq_zero_of_fg_of_subtype_eq_zero
+    {P : Submodule R M} (hP : P.FG) (t : P ⊗[R] N)
+    (h : LinearMap.rTensor N P.subtype t = 0) :
+    ∃ (Q : Submodule R M) (hPQ : P ≤ Q), Q.FG ∧
+      LinearMap.rTensor N (Submodule.inclusion hPQ) t = 0 := by
+  rw [← (LinearMap.rTensor N P.subtype).map_zero] at h
+  simpa only [map_zero] using TensorProduct.eq_of_fg_of_subtype_eq hP t _ h
+
+theorem TensorProduct.eq_of_fg_of_subtype_eq₂
+    {P : Submodule R M} (hP : Submodule.FG P) (t : P ⊗[R] N)
+    {P' : Submodule R M} (hP' : Submodule.FG P') (t' : P' ⊗[R] N)
+    (h : LinearMap.rTensor N P.subtype t = LinearMap.rTensor N P'.subtype t') :
+    ∃ (Q : Submodule R M) (hPQ : P ≤ Q) (hP'Q : P' ≤ Q), Q.FG ∧
+      LinearMap.rTensor N (Submodule.inclusion hPQ) t
+        = LinearMap.rTensor N (Submodule.inclusion hP'Q) t' := by
+  simp only [← Submodule.subtype_comp_inclusion _ _ (le_sup_left : _ ≤ P ⊔ P'),
+    ← Submodule.subtype_comp_inclusion _ _ (le_sup_right : _ ≤ P ⊔ P'),
+    LinearMap.rTensor_comp, LinearMap.coe_comp, Function.comp_apply] at h
+  let ⟨Q, hQ_le, hQ, h⟩ := TensorProduct.eq_of_fg_of_subtype_eq (hP.sup hP') _ _ h
+  use Q, le_trans le_sup_left hQ_le, le_trans le_sup_right hQ_le, hQ
+  simpa [← LinearMap.comp_apply, ← LinearMap.rTensor_comp] using h
+
+end TensorProducts
+
+section Algebra
+
+open TensorProduct
+
+variable {R S N : Type*} [CommRing R] [CommRing S] [Algebra R S]
+  [AddCommGroup N] [Module R N]
+
+theorem TensorProduct.Algebra.exists_rTensor_of_fg [DecidableEq {P : Submodule R S // P.FG}]
+    (t : S ⊗[R] N) :
+    ∃ (A : Subalgebra R S), Subalgebra.FG A ∧
+      t ∈ LinearMap.range (LinearMap.rTensor N (Subalgebra.val A).toLinearMap) := by
+  obtain ⟨P, hP, ht⟩ := TensorProduct.exists_rTensor_of_fg t
+  obtain ⟨s, hs⟩ := hP
+  use Algebra.adjoin R s, Subalgebra.fg_adjoin_finset _
+  have : P ≤ Subalgebra.toSubmodule (Algebra.adjoin R (s : Set S)) := by
+    simp only [← hs, Submodule.span_le, Subalgebra.coe_toSubmodule]
+    exact Algebra.subset_adjoin
+  rw [← Submodule.subtype_comp_inclusion P _ this, LinearMap.rTensor_comp] at ht
+  exact LinearMap.range_comp_le_range _ _ ht
+
+theorem TensorProduct.Algebra.eq_of_fg_of_subtype_eq
+    {A : Subalgebra R S} (hA : Subalgebra.FG A) (t t' : A ⊗[R] N)
+    (h : LinearMap.rTensor N (Subalgebra.val A).toLinearMap t
+      = LinearMap.rTensor N (Subalgebra.val A).toLinearMap t') :
+    ∃ (B : Subalgebra R S) (hAB : A ≤ B), Subalgebra.FG B
+      ∧ LinearMap.rTensor N (Subalgebra.inclusion hAB).toLinearMap t
+        = LinearMap.rTensor N (Subalgebra.inclusion hAB).toLinearMap t' := by
+  classical
+  let ⟨P, hP, ⟨u, hu⟩⟩ := TensorProduct.exists_rTensor_of_fg t
+  let ⟨P', hP', ⟨u', hu'⟩⟩ := TensorProduct.exists_rTensor_of_fg t'
+  let P₁ := Submodule.map (Subalgebra.toSubmodule A).subtype (P ⊔ P')
+  have hP₁ : Submodule.FG P₁ := Submodule.FG.map _ (Submodule.FG.sup hP hP')
+  -- the embeddings from P and P' to P₁
+  let j : P →ₗ[R] P₁ := LinearMap.restrict (Subalgebra.toSubmodule A).subtype
+      (fun p hp ↦ by
+        simp only [Submodule.coe_subtype, Submodule.map_sup, P₁]
+        apply Submodule.mem_sup_left
+        use p; simp only [SetLike.mem_coe]; exact ⟨hp, rfl⟩)
+  let j' : P' →ₗ[R] P₁ := LinearMap.restrict (Subalgebra.toSubmodule A).subtype
+      (fun p hp ↦ by
+        simp only [Submodule.coe_subtype, Submodule.map_sup, P₁]
+        apply Submodule.mem_sup_right
+        use p; simp only [SetLike.mem_coe]; exact ⟨hp, rfl⟩)
+  -- we map u and u' to P₁ ⊗[R] N, getting u₁ and u'₁
+  set u₁ := LinearMap.rTensor N j u with hu₁
+  set u'₁ := LinearMap.rTensor N j' u' with hu'₁
+  -- u₁ and u'₁ are equal in S ⊗[R] N
+  have : LinearMap.rTensor N P₁.subtype u₁ = LinearMap.rTensor N P₁.subtype u'₁ := by
+    rw [hu₁, hu'₁]
+    simp only [← LinearMap.comp_apply, ← LinearMap.rTensor_comp]
+    have hj₁ : P₁.subtype ∘ₗ j = (Subalgebra.val A).toLinearMap ∘ₗ P.subtype := by ext; rfl
+    have hj'₁ : P₁.subtype ∘ₗ j' = (Subalgebra.val A).toLinearMap ∘ₗ P'.subtype := by ext; rfl
+    rw [hj₁, hj'₁]
+    simp only [LinearMap.rTensor_comp, LinearMap.comp_apply]
+    rw [hu, hu', h]
+  let ⟨P'₁, hP₁_le, hP'₁, h⟩ := TensorProduct.eq_of_fg_of_subtype_eq hP₁ _ _ this
+  let ⟨s, hs⟩ := hP'₁
+  let ⟨w, hw⟩ := hA
+  let B := Algebra.adjoin R ((s ∪ w : Finset S) : Set S)
+  have hBA : A ≤ B := by
+    simp only [B, ← hw]
+    apply Algebra.adjoin_mono
+    simp only [Finset.coe_union, Set.subset_union_right]
+  use B, hBA, Subalgebra.fg_adjoin_finset _
+  rw [← hu, ← hu']
+  simp only [← LinearMap.comp_apply, ← LinearMap.rTensor_comp]
+  have hP'₁_le : P'₁ ≤ Subalgebra.toSubmodule B := by
+    simp only [← hs, Finset.coe_union, Submodule.span_le, Subalgebra.coe_toSubmodule, B]
+    exact subset_trans Set.subset_union_left Algebra.subset_adjoin
+  have k : (Subalgebra.inclusion hBA).toLinearMap ∘ₗ P.subtype
+    = Submodule.inclusion hP'₁_le ∘ₗ Submodule.inclusion hP₁_le ∘ₗ j := by ext; rfl
+  have k' : (Subalgebra.inclusion hBA).toLinearMap ∘ₗ P'.subtype
+    = Submodule.inclusion hP'₁_le ∘ₗ Submodule.inclusion hP₁_le ∘ₗ j' := by ext; rfl
+  rw [k, k']
+  simp only [LinearMap.rTensor_comp, LinearMap.comp_apply]
+  rw [← hu₁, ← hu'₁, h]
+
+theorem TensorProduct.Algebra.eq_of_fg_of_subtype_eq₂
+    {A : Subalgebra R S} (hA : Subalgebra.FG A) (t : A ⊗[R] N)
+    {A' : Subalgebra R S} (hA' : Subalgebra.FG A') (t' : A' ⊗[R] N)
+    (h : LinearMap.rTensor N (Subalgebra.val A).toLinearMap t
+      = LinearMap.rTensor N (Subalgebra.val A').toLinearMap t') :
+    ∃ (B : Subalgebra R S) (hAB : A ≤ B) (hA'B : A' ≤ B), Subalgebra.FG B
+      ∧ LinearMap.rTensor N (Subalgebra.inclusion hAB).toLinearMap t
+        = LinearMap.rTensor N (Subalgebra.inclusion hA'B).toLinearMap t' := by
+  have hj : (Subalgebra.val (A ⊔ A')).comp (Subalgebra.inclusion le_sup_left)
+    = Subalgebra.val A := by ext; rfl
+  have hj' : (Subalgebra.val (A ⊔ A')).comp (Subalgebra.inclusion le_sup_right)
+    = Subalgebra.val A' := by ext; rfl
+  simp only [← hj, ← hj', AlgHom.comp_toLinearMap, LinearMap.rTensor_comp,
+    LinearMap.comp_apply] at h
+  let ⟨B, hB_le, hB, h⟩ := TensorProduct.Algebra.eq_of_fg_of_subtype_eq
+    (Subalgebra.fg_sup hA hA') _ _ h
+  use B, le_trans le_sup_left hB_le, le_trans le_sup_right hB_le, hB
+  simpa only [← LinearMap.rTensor_comp, ← LinearMap.comp_apply] using h
+
+/-- Lift an element that maps to 0 -/
+theorem Submodule.exists_fg_of_baseChange_eq_zero
+    {R S M N : Type*} [CommRing R] [CommRing S] [Algebra R S]
+    [AddCommGroup M] [AddCommGroup N] [Module R M] [Module R N]
+    (f : M →ₗ[R] N) (t : S ⊗[R] M) (ht : f.baseChange S t = 0) :
+    ∃ (A : Subalgebra R S) (_ : A.FG) (u : A ⊗[R] M),
+      f.baseChange A u = 0 ∧ A.val.toLinearMap.rTensor M u = t := by
+  classical
+  obtain ⟨A, hA, ht_memA⟩ := TensorProduct.Algebra.exists_rTensor_of_fg t
+  obtain ⟨u, hu⟩ := _root_.id ht_memA
+  have := TensorProduct.Algebra.eq_of_fg_of_subtype_eq hA (f.baseChange _ u) 0
+  simp only [map_zero, exists_and_left] at this
+  have hu' : (A.val.toLinearMap.rTensor N) (f.baseChange (↥A) u) = 0 := by
+    rw [rTensor_comp_baseChange_comm_apply, hu, ht]
+  obtain ⟨B, hB, hAB, hu'⟩ := this hu'
+  use B, hB, LinearMap.rTensor M (Subalgebra.inclusion hAB).toLinearMap u
+  constructor
+  · rw [← rTensor_comp_baseChange_comm_apply, hu']
+  · rw [← LinearMap.comp_apply, ← LinearMap.rTensor_comp, ← hu]
+    congr
+
+end Algebra

--- a/Mathlib/RingTheory/TensorProduct/DirectLimit/FG.lean
+++ b/Mathlib/RingTheory/TensorProduct/DirectLimit/FG.lean
@@ -31,12 +31,12 @@ of the tensor products `M ⊗[R] Q`, for finitely generated submodules `Q` of `
 * `TensorProduct.exists_rTensor_of_fg`: any element `t:  M ⊗[R] N`  can be lifted
 to some `P ⊗[R] N`, for fome finitely generated submodule `P` of `M`.
 
-* `TensorProduct.eq_of_fg_of_subtype_eq` ;
+* `TensorProduct.eq_of_fg_of_subtype_eq`;
 given a finitely generated submodule `P` of `M` and `t, t' : P ⊗[R] N`
 which have the same image in `M ⊗[R] N`, there exists a finitely generated submodule `Q` of `M`
 which contains `P` such that `t` and `t'` have the same image in `Q ⊗[R] N`.
 
-* `TensorProduct.eq_of_fg_of_subtype_eq₂` ;
+* `TensorProduct.eq_of_fg_of_subtype_eq₂`;
 given finitely generated submodules `P` and `P'`of `M`, `t : P ⊗[R] N` and `t' : P' ⊗[R] N`
 which have the same image in `M ⊗[R] N`, there exists a finitely generated submodule `Q` of `M`
 which contains `P` and `P'` and such that `t` and `t'` have the same image in `Q ⊗[R] N`.

--- a/Mathlib/RingTheory/TensorProduct/DirectLimit/Small.lean
+++ b/Mathlib/RingTheory/TensorProduct/DirectLimit/Small.lean
@@ -25,7 +25,7 @@ submodules `P`, with respect to the maps deduced from the inclusions
 However,  tensor products in mathlib require commutativity of the scalars,
 and direct limits of modules are restricted to modules over rings.
 
-* Provide the analogous results for `lTensor`, and both sides at the same time.
+* Provide the analogous result both sides at the same time.
 
 -/
 
@@ -37,7 +37,7 @@ universe u v
 variable {R : Type u} [Semiring R] {M : Type*} [AddCommMonoid M] [Module R M]
 
 -- The directed system of small submodules of `M`
-def DirectedSystem.Submodules_small :
+theorem DirectedSystem.Submodules_small :
     DirectedSystem (ι := {P : Submodule R M // Small.{v} P}) (F := fun P ↦ P.val)
     (f := fun ⦃P Q⦄ (h : P ≤ Q) ↦ Submodule.inclusion h) where
   map_self := fun _ _ ↦ rfl
@@ -59,8 +59,6 @@ noncomputable def Submodules_small_equiv
 
 end Semiring
 
-section TensorProducts
-
 open TensorProduct
 
 universe v
@@ -80,4 +78,12 @@ noncomputable def rTensor_small_equiv
       (fun ⦃P Q⦄ (h : P ≤ Q)  ↦ (Submodule.inclusion h).rTensor N) ≃ₗ[R] M ⊗[R] N :=
   (TensorProduct.directLimitLeft _ N).symm.trans ((Submodules_small_equiv R M).rTensor N)
 
-end TensorProducts
+/-- A tensor product `M ⊗[R] N` is the direct limit of the modules `M ⊗[R] Q`,
+where `Q` ranges over all small submodules of `N`. -/
+noncomputable def lTensor_small_equiv
+    [Small.{v} R]  [DecidableEq {Q : Submodule R N // Small.{v} Q}] :
+    Module.DirectLimit (R := R) (ι := {Q : Submodule R N // Small.{v} Q}) (fun Q ↦ M ⊗[R] Q.val)
+      (fun ⦃P Q⦄ (h : P ≤ Q)  ↦ (Submodule.inclusion h).lTensor M) ≃ₗ[R] M ⊗[R] N :=
+  (TensorProduct.directLimitRight _ M).symm.trans ((Submodules_small_equiv R N).lTensor M)
+
+end TensorProduct

--- a/Mathlib/RingTheory/TensorProduct/DirectLimit/Small.lean
+++ b/Mathlib/RingTheory/TensorProduct/DirectLimit/Small.lean
@@ -1,0 +1,83 @@
+/-
+Copyright (c) 2025 Antoine Chambert-Loir, María-Inés de Frutos-Fernández. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Antoine Chambert-Loir, Maria-Inés de Frutos-Fernandez
+-/
+import Mathlib.RingTheory.TensorProduct.DirectLimit.FG
+import Mathlib.LinearAlgebra.Finsupp.LinearCombination
+import Mathlib.RingTheory.FiniteType
+import Mathlib.RingTheory.Finiteness.Small
+
+/-! # Tensor products and small submodules
+
+* `Submodules_small_equiv` proves that a module is the direct limit
+of its finitely generated submodules, with respect to the inclusion maps
+
+* `rTensor_smallEquiv` deduces that a tensor product `M ⊗[R] N`
+is the direct limit of the modules `P ⊗[R] N`, for all finitely generated
+submodules `P`, with respect to the maps deduced from the inclusions
+
+## TODO
+
+* Fix namespaces, add docstrings
+
+* The results are valid in the context of `AddCommMonoid M` over a `Semiring`.
+However,  tensor products in mathlib require commutativity of the scalars,
+and direct limits of modules are restricted to modules over rings.
+
+* Provide the analogous results for `lTensor`, and both sides at the same time.
+
+-/
+
+open Submodule LinearMap
+
+section Semiring
+
+universe u v
+variable {R : Type u} [Semiring R] {M : Type*} [AddCommMonoid M] [Module R M]
+
+-- The directed system of small submodules of `M`
+def DirectedSystem.Submodules_small :
+    DirectedSystem (ι := {P : Submodule R M // Small.{v} P}) (F := fun P ↦ P.val)
+    (f := fun ⦃P Q⦄ (h : P ≤ Q) ↦ Submodule.inclusion h) where
+  map_self := fun _ _ ↦ rfl
+  map_map  := fun _ _ _ _ _ _ ↦ rfl
+
+variable (R M) in
+/-- Any module is the direct limit of its finitely generated submodules -/
+noncomputable def Submodules_small_equiv
+    [Small.{v} R] [DecidableEq {P : Submodule R M // Small.{v} P}] :
+    Module.DirectLimit (ι := {P : Submodule R M // Small.{v} P})
+      (G := fun P ↦ P.val)
+      (fun ⦃P Q⦄ (h : P ≤ Q) ↦ Submodule.inclusion h) ≃ₗ[R] M :=
+  LinearEquiv.ofBijective
+    (Module.DirectLimit.lift _ _ _ _ (fun P ↦ P.val.subtype) (fun _ _ _ _ ↦ rfl))
+    ⟨Module.DirectLimit.lift_injective _ _ (fun P ↦ Submodule.injective_subtype P.val),
+      fun x ↦ ⟨Module.DirectLimit.of _ {P : Submodule R M // Small.{v} P} _ _
+          ⟨Submodule.span R {x}, Submodule.FG.small _ (fg_span_singleton x)⟩
+          ⟨x, Submodule.mem_span_singleton_self x⟩, by simp⟩⟩
+
+end Semiring
+
+section TensorProducts
+
+open TensorProduct
+
+universe v
+
+variable (R : Type*) (M N : Type*)
+  [CommSemiring R]
+  [AddCommMonoid M] [Module R M]
+  [AddCommMonoid N] [Module R N]
+
+variable {R M N}
+
+/-- A tensor product `M ⊗[R] N` is the direct limit of the modules `P ⊗[R] N`,
+where `P` ranges over all small submodules of `M`. -/
+noncomputable def rTensor_small_equiv
+    [Small.{v} R]  [DecidableEq {P : Submodule R M // Small.{v} P}] :
+    Module.DirectLimit (R := R) (ι := {P : Submodule R M // Small.{v} P}) (fun P ↦ P.val ⊗[R] N)
+      (fun ⦃P Q⦄ (h : P ≤ Q)  ↦ (Submodule.inclusion h).rTensor N) ≃ₗ[R] M ⊗[R] N :=
+  (TensorProduct.directLimitLeft _ N).symm.trans ((Submodules_small_equiv R M).rTensor N)
+
+end TensorProducts

--- a/Mathlib/RingTheory/TensorProduct/DirectLimit/Small.lean
+++ b/Mathlib/RingTheory/TensorProduct/DirectLimit/Small.lean
@@ -10,20 +10,22 @@ import Mathlib.RingTheory.Finiteness.Small
 
 /-! # Tensor products and small submodules
 
+* `DirectedSystem.Submodules_small`: the directed system of small submodules of a module
+
 * `Submodules_small_equiv` proves that a module is the direct limit
 of its finitely generated submodules, with respect to the inclusion maps
 
 * `rTensor_smallEquiv` deduces that a tensor product `M ⊗[R] N`
 is the direct limit of the modules `P ⊗[R] N`, for all finitely generated
-submodules `P`, with respect to the maps deduced from the inclusions
+submodules `P` of `M`, with respect to the maps deduced from the inclusions
+
+* `lTensor_smallEquiv` deduces that a tensor product `M ⊗[R] N`
+is the direct limit of the modules `M ⊗[R] Q`, for all finitely generated
+submodules `Q` of `N`, with respect to the maps deduced from the inclusions
 
 ## TODO
 
 * Fix namespaces, add docstrings
-
-* The results are valid in the context of `AddCommMonoid M` over a `Semiring`.
-However,  tensor products in mathlib require commutativity of the scalars,
-and direct limits of modules are restricted to modules over rings.
 
 * Provide the analogous result both sides at the same time.
 
@@ -85,5 +87,3 @@ noncomputable def lTensor_small_equiv
     Module.DirectLimit (R := R) (ι := {Q : Submodule R N // Small.{v} Q}) (fun Q ↦ M ⊗[R] Q.val)
       (fun ⦃P Q⦄ (h : P ≤ Q)  ↦ (Submodule.inclusion h).lTensor M) ≃ₗ[R] M ⊗[R] N :=
   (TensorProduct.directLimitRight _ M).symm.trans ((Submodules_small_equiv R N).lTensor M)
-
-end TensorProduct

--- a/Mathlib/RingTheory/TensorProduct/DirectLimit/Small.lean
+++ b/Mathlib/RingTheory/TensorProduct/DirectLimit/Small.lean
@@ -3,8 +3,8 @@ Copyright (c) 2025 Antoine Chambert-Loir, María-Inés de Frutos-Fernández. All
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Antoine Chambert-Loir, Maria-Inés de Frutos-Fernandez
 -/
-import Mathlib.RingTheory.TensorProduct.DirectLimit.FG
 import Mathlib.LinearAlgebra.Finsupp.LinearCombination
+import Mathlib.LinearAlgebra.TensorProduct.DirectLimit
 import Mathlib.RingTheory.FiniteType
 import Mathlib.RingTheory.Finiteness.Small
 


### PR DESCRIPTION
The directed limit of a tensor product for the directed system of small submodules.

Co-authored with @mariainesdff 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

- [ ] depends on: #22898
- [x] depends on: #22911
[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
