### PR TITLE
[Merged by Bors] - feat(RingTheory/Finiteness/Small): smallness properties of modules and algebras

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4810,6 +4810,7 @@ import Mathlib.RingTheory.Finiteness.Nilpotent
 import Mathlib.RingTheory.Finiteness.Prod
 import Mathlib.RingTheory.Finiteness.Projective
 import Mathlib.RingTheory.Finiteness.Quotient
+import Mathlib.RingTheory.Finiteness.Small
 import Mathlib.RingTheory.Finiteness.Subalgebra
 import Mathlib.RingTheory.Fintype
 import Mathlib.RingTheory.Flat.Basic

--- a/Mathlib/Data/DFinsupp/Small.lean
+++ b/Mathlib/Data/DFinsupp/Small.lean
@@ -1,8 +1,9 @@
 /-
 Copyright (c) 2025 Sophie. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Sophie Morel
+Authors: Sophie Morel, Antoine Chambert-Loir
 -/
+import Mathlib.Data.Finsupp.ToDFinsupp
 import Mathlib.Data.DFinsupp.Defs
 import Mathlib.Logic.Small.Basic
 
@@ -12,6 +13,7 @@ import Mathlib.Logic.Small.Basic
 Let `π : ι → Type v`. If `ι` and all the `π i` are `w`-small, this provides a `Small.{w}`
 instance on `DFinsupp π`.
 
+As an application, `σ →₀ R` has a `Small.{v}` instance if `σ` and `R` have one.
 -/
 
 universe u v w
@@ -23,5 +25,11 @@ section Small
 instance DFinsupp.small [Small.{w} ι] [∀ (i : ι), Small.{w} (π i)] :
     Small.{w} (DFinsupp π) :=
   small_of_injective (f := fun x j ↦ x j) (fun f f' eq ↦ by ext j; exact congr_fun eq j)
+
+instance Finsupp.small {σ : Type*} {R : Type*} [Zero R]
+    [Small.{u} R] [Small.{u} σ] :
+    Small.{u} (σ →₀ R) := by
+  classical
+  exact small_map finsuppEquivDFinsupp
 
 end Small

--- a/Mathlib/RingTheory/Finiteness/Cardinality.lean
+++ b/Mathlib/RingTheory/Finiteness/Cardinality.lean
@@ -37,10 +37,6 @@ lemma exists_fin' [Module.Finite R M] : ∃ (n : ℕ) (f : (Fin n → R) →ₗ[
   refine ⟨n, Basis.constr (Pi.basisFun R _) ℕ s, ?_⟩
   rw [← LinearMap.range_eq_top, Basis.constr_range, hs]
 
-lemma small' [Module.Finite R M] [Small.{v} R] : Small.{v} M :=
-  have ⟨_, _, h⟩ := exists_fin' R M
-  small_of_surjective h
-
 variable {M}
 
 lemma _root_.Module.finite_of_finite [Finite R] [Module.Finite R M] : Finite M := by

--- a/Mathlib/RingTheory/Finiteness/Cardinality.lean
+++ b/Mathlib/RingTheory/Finiteness/Cardinality.lean
@@ -37,7 +37,7 @@ lemma exists_fin' [Module.Finite R M] : ∃ (n : ℕ) (f : (Fin n → R) →ₗ[
   refine ⟨n, Basis.constr (Pi.basisFun R _) ℕ s, ?_⟩
   rw [← LinearMap.range_eq_top, Basis.constr_range, hs]
 
-lemma small [Module.Finite R M] [Small.{v} R] : Small.{v} M :=
+lemma small' [Module.Finite R M] [Small.{v} R] : Small.{v} M :=
   have ⟨_, _, h⟩ := exists_fin' R M
   small_of_surjective h
 

--- a/Mathlib/RingTheory/Finiteness/Small.lean
+++ b/Mathlib/RingTheory/Finiteness/Small.lean
@@ -79,17 +79,15 @@ instance small_adjoin [Small.{u} R] {s : Set S} [Small.{u} s] :
   rw [Algebra.adjoin_eq_range]
   apply small_range
 
-theorem FiniteType.small [Small.{u} R] [Algebra.FiniteType R S] :
-    Small.{u} S := by
-  obtain ⟨s : Finset S, hs⟩ := (Algebra.FiniteType.out : (⊤ : Subalgebra R S).FG)
-  have : Small.{u} (adjoin R s : Subalgebra R S) := small_adjoin
-  apply small_of_surjective (f := (adjoin R s).subtype)
-  rw [hs]
-  exact fun x ↦ ⟨⟨x, by simp⟩, by simp⟩
-
 theorem _root_.Subalgebra.FG.small [Small.{u} R] {A : Subalgebra R S} (fgS : A.FG) :
     Small.{u} A := by
-  have : FiniteType R A := (Subalgebra.fg_iff_finiteType A).mp fgS
-  exact FiniteType.small (R := R) (S := A)
+  obtain ⟨s, hs, rfl⟩ := fgS
+  exact small_adjoin
+
+theorem FiniteType.small [Small.{u} R] [Algebra.FiniteType R S] :
+    Small.{u} S := by
+  have : Small.{u} (⊤ : Subalgebra R S) :=
+    Subalgebra.FG.small Algebra.FiniteType.out
+  rwa [← small_univ_iff]
 
 end Algebra

--- a/Mathlib/RingTheory/Finiteness/Small.lean
+++ b/Mathlib/RingTheory/Finiteness/Small.lean
@@ -50,6 +50,7 @@ theorem FG.small [Small.{u} R] (P : Submodule R M) (hP : P.FG) : Small.{u} P := 
   rw [← Fintype.range_linearCombination]
   apply small_range
 
+variable (R M) in
 theorem _root_.Module.Finite.small [Small.{u} R] [Module.Finite R M] : Small.{u} M := by
   have : Small.{u} (⊤ : Submodule R M) :=
     FG.small _ (Module.finite_def.mp inferInstance)

--- a/Mathlib/RingTheory/Finiteness/Small.lean
+++ b/Mathlib/RingTheory/Finiteness/Small.lean
@@ -10,6 +10,7 @@ import Mathlib.Algebra.Algebra.Subalgebra.Basic
 import Mathlib.LinearAlgebra.Basis.Cardinality
 import Mathlib.LinearAlgebra.StdBasis
 import Mathlib.RingTheory.Finiteness.Basic
+import Mathlib.RingTheory.MvPolynomial.Basic
 import Mathlib.Data.DFinsupp.Small
 
 /-! # Smallness properties of modules and algebras -/
@@ -41,7 +42,6 @@ instance small_iSup
     Small.{u} (iSup P : Submodule R M) := by
   classical
   rw [iSup_eq_range_dfinsupp_lsum]
-  have : Small.{u} (Π₀ (i : ι), ↥(P i)) := inferInstance
   apply small_range
 
 theorem FG.small [Small.{u} R] (P : Submodule R M) (hP : P.FG) : Small.{u} P := by
@@ -50,12 +50,10 @@ theorem FG.small [Small.{u} R] (P : Submodule R M) (hP : P.FG) : Small.{u} P := 
   rw [← Fintype.range_linearCombination]
   apply small_range
 
-theorem Finite.small [Small.{u} R] [Module.Finite R M] : Small.{u} M := by
+theorem _root_.Module.Finite.small [Small.{u} R] [Module.Finite R M] : Small.{u} M := by
   have : Small.{u} (⊤ : Submodule R M) :=
     FG.small _ (Module.finite_def.mp inferInstance)
-  apply small_of_surjective (f := Submodule.subtype (⊤ : Submodule R M))
-  intro m
-  exact ⟨⟨m, mem_top⟩, rfl⟩
+  rwa [← small_univ_iff]
 
 instance small_span_singleton [Small.{u} R] (m : M) :
     Small.{u} (span R {m}) := FG.small _ (fg_span_singleton _)
@@ -77,14 +75,8 @@ open MvPolynomial AlgHom
 
 instance small_adjoin [Small.{u} R] {s : Set S} [Small.{u} s] :
     Small.{u} (adjoin R s : Subalgebra R S) := by
-  let j' := mapEquiv (Shrink.{u} s) (Shrink.ringEquiv R)
-  have : Small.{u} (MvPolynomial (Shrink.{u} s) R) := small_of_surjective j'.surjective
-  let j : MvPolynomial (Shrink.{u} s) R →ₐ[R] S := aeval (fun i ↦ (equivShrink s).symm i)
-  have hj : adjoin R s = j.range := by
-    rw [← adjoin_range_eq_range_aeval, ← Function.comp_def]
-    simp
-  rw [hj]
-  apply small_range (f := j)
+  rw [Algebra.adjoin_eq_range]
+  apply small_range
 
 theorem FiniteType.small [Small.{u} R] [Algebra.FiniteType R S] :
     Small.{u} S := by

--- a/Mathlib/RingTheory/Finiteness/Small.lean
+++ b/Mathlib/RingTheory/Finiteness/Small.lean
@@ -1,0 +1,132 @@
+/-
+Copyright (c) 2025 Antoine Chambert-Loir, María-Inés de Frutos-Fernández. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Antoine Chambert-Loir, Maria-Inés de Frutos-Fernandez
+-/
+import Mathlib.LinearAlgebra.Finsupp.LinearCombination
+import Mathlib.RingTheory.FiniteType
+import Mathlib.LinearAlgebra.DFinsupp
+import Mathlib.Algebra.Algebra.Subalgebra.Basic
+import Mathlib.LinearAlgebra.Basis.Cardinality
+import Mathlib.LinearAlgebra.StdBasis
+import Mathlib.RingTheory.Finiteness.Basic
+
+/-! # Smallness properties of modules and algebras -/
+
+universe u
+
+namespace Submodule
+
+variable {R M : Type*} [Semiring R] [AddCommMonoid M] [Module R M]
+
+theorem bot_small : Small.{u} (⊥ : Submodule R M) := by
+  let f : Unit → (⊥ : Submodule R M) := fun _ ↦ 0
+  have : Small.{u} Unit := small_lift Unit
+  apply small_of_surjective (f := f)
+  rintro ⟨x, hx⟩
+  simp only [mem_bot] at hx
+  use default
+  simp [← Subtype.coe_inj, f, hx]
+
+theorem small_sup {P Q : Submodule R M} (_ : Small.{u} P) (_ : Small.{u} Q) :
+    Small.{u} (P ⊔ Q : Submodule R M) := by
+  rw [Submodule.sup_eq_range]
+  exact small_range _
+
+theorem FG.small [Small.{u} R] (P : Submodule R M) (hP : P.FG) : Small.{u} P := by
+  rw [fg_iff_exists_fin_generating_family] at hP
+  obtain ⟨n, s, rfl⟩ := hP
+  rw [← Fintype.range_linearCombination]
+  apply small_range
+
+theorem small_directSum
+    {ι : Type*} {P : ι → Submodule R M} [Small.{u} ι] [∀ i, Small.{u} (P i)] :
+    Small.{u} (Π₀ (i : ι), ↥(P i)) := by
+  classical
+  -- Define somewhere else
+  have : Small.{u} (Finset ι) := small_of_injective (f := Finset.toSet) Finset.coe_injective
+  have (s : Finset ι) : Small.{u} (Π (i : s), P i) := small_Pi _
+  let h : (Σ (s : Finset ι), (Π i : s, P i)) → Π₀ i, P i := fun sf ↦ by
+    exact {
+      toFun (i : ι) := if h : i ∈ sf.1.val then sf.2 ⟨i, h⟩ else 0
+      support' := Trunc.mk ⟨sf.1.val, fun i ↦ by
+        simp only [Finset.mem_val, dite_eq_right_iff]
+        by_cases hi : i ∈ sf.1
+        · exact Or.inl hi
+        · apply Or.inr fun h ↦ False.elim (hi h)⟩}
+  apply small_of_surjective (f := h)
+  intro m
+  use ⟨m.support, fun i ↦ m i⟩
+  ext i
+  simp only [Finset.mem_val, DFinsupp.mem_support_toFun, ne_eq, dite_eq_ite, DFinsupp.coe_mk',
+    ite_not, SetLike.coe_eq_coe, ite_eq_right_iff, h]
+  simp only [eq_comm, imp_self, h]
+
+theorem small_iSup
+    {ι : Type*} {P : ι → Submodule R M} (_ : Small.{u} ι) (_ : ∀ i, Small.{u} (P i)) :
+    Small.{u} (iSup P : Submodule R M) := by
+  classical
+  rw [iSup_eq_range_dfinsupp_lsum]
+  have : Small.{u} (Π₀ (i : ι), ↥(P i)) := Submodule.small_directSum
+  apply small_range
+
+theorem small_span [Small.{u} R] (s : Set M) [Small.{u} s] :
+    Small.{u} (span R s) := by
+  suffices span R s = iSup (fun i : s ↦ span R ({(↑i : M)} : Set M)) by
+    rw [this]
+    exact small_iSup (by trivial) fun _ ↦ FG.small _ (fg_span_singleton _)
+  apply le_antisymm
+  · rw [span_le]
+    intro i hi
+    apply mem_iSup_of_mem (⟨i, hi⟩ : s)
+    refine span_mono (s := {i}) (by simp) (mem_span_singleton_self i)
+  · apply iSup_le
+    rintro ⟨i, hi⟩
+    simp only [span_singleton_le_iff_mem]
+    apply span_mono (s := {i}) _ (mem_span_singleton_self i)
+    simp only [Set.singleton_subset_iff, hi]
+
+instance : SemilatticeSup {P : Submodule R M // Small.{u} P} where
+  sup := fun P Q ↦ ⟨P.val ⊔ Q.val, small_sup P.property Q.property⟩
+  le_sup_left := fun P Q ↦ by rw [← Subtype.coe_le_coe]; exact le_sup_left
+  le_sup_right := fun P Q ↦ by rw [← Subtype.coe_le_coe]; exact le_sup_right
+  sup_le := fun _ _ _ hPR hQR ↦ by
+    rw [← Subtype.coe_le_coe] at hPR hQR ⊢
+    exact sup_le hPR hQR
+
+instance : Inhabited {P : Submodule R M // Small.{u} P} where
+  default := ⟨⊥, bot_small⟩
+
+end Submodule
+
+variable {R S : Type*} [CommSemiring R] [CommSemiring S] [Algebra R S]
+
+namespace Algebra
+
+open MvPolynomial AlgHom
+
+theorem small_adjoin [Small.{u} R] {s : Set S} [Small.{u} s] :
+    Small.{u} (adjoin R s : Subalgebra R S) := by
+  let j' := mapEquiv (Shrink.{u} s) (Shrink.ringEquiv R)
+  have : Small.{u} (MvPolynomial (Shrink.{u} s) R) := small_of_surjective j'.surjective
+  let j : MvPolynomial (Shrink.{u} s) R →ₐ[R] S := aeval (fun i ↦ (equivShrink s).symm i)
+  have hj : adjoin R s = j.range := by
+    rw [← adjoin_range_eq_range_aeval, ← Function.comp_def]
+    simp
+  rw [hj]
+  apply small_range (f := j)
+
+theorem FiniteType.small [Small.{u} R] [Algebra.FiniteType R S] :
+    Small.{u} S := by
+  obtain ⟨s : Finset S, hs⟩ := (Algebra.FiniteType.out : (⊤ : Subalgebra R S).FG)
+  have : Small.{u} (adjoin R s : Subalgebra R S) := small_adjoin
+  apply small_of_surjective (f := (adjoin R s).subtype)
+  rw [hs]
+  exact fun x ↦ ⟨⟨x, by simp⟩, by simp⟩
+
+theorem _root_.Subalgebra.FG.small [Small.{u} R] {A : Subalgebra R S} (fgS : A.FG) :
+    Small.{u} A := by
+  have : FiniteType R A := (Subalgebra.fg_iff_finiteType A).mp fgS
+  exact FiniteType.small (R := R) (S := A)
+
+end Algebra

--- a/Mathlib/RingTheory/Flat/Basic.lean
+++ b/Mathlib/RingTheory/Flat/Basic.lean
@@ -13,7 +13,7 @@ import Mathlib.Algebra.Module.Projective
 import Mathlib.LinearAlgebra.DirectSum.TensorProduct
 import Mathlib.LinearAlgebra.FreeModule.Basic
 import Mathlib.LinearAlgebra.TensorProduct.RightExactness
-import Mathlib.RingTheory.Finiteness.Cardinality
+import Mathlib.RingTheory.Finiteness.Small
 import Mathlib.RingTheory.TensorProduct.Finite
 
 /-!

--- a/Mathlib/RingTheory/MvPolynomial/Basic.lean
+++ b/Mathlib/RingTheory/MvPolynomial/Basic.lean
@@ -5,6 +5,7 @@ Authors: Johannes Hölzl
 -/
 import Mathlib.Algebra.CharP.Defs
 import Mathlib.Algebra.MvPolynomial.Degrees
+import Mathlib.Data.DFinsupp.SMall
 import Mathlib.Data.Fintype.Pi
 import Mathlib.LinearAlgebra.Finsupp.VectorSpace
 import Mathlib.LinearAlgebra.FreeModule.Finite.Basic
@@ -44,6 +45,11 @@ universe u v
 variable (σ : Type u) (R : Type v) [CommSemiring R] (p m : ℕ)
 
 namespace MvPolynomial
+
+instance {σ : Type*} {R : Type*} [CommSemiring R]
+    [Small.{u} R] [Small.{u} σ] :
+    Small.{u} (MvPolynomial σ R) :=
+  inferInstanceAs (Small.{u} ((σ →₀ ℕ) →₀ R))
 
 section CharP
 

--- a/Mathlib/RingTheory/MvPolynomial/Basic.lean
+++ b/Mathlib/RingTheory/MvPolynomial/Basic.lean
@@ -5,7 +5,7 @@ Authors: Johannes Hölzl
 -/
 import Mathlib.Algebra.CharP.Defs
 import Mathlib.Algebra.MvPolynomial.Degrees
-import Mathlib.Data.DFinsupp.SMall
+import Mathlib.Data.DFinsupp.Small
 import Mathlib.Data.Fintype.Pi
 import Mathlib.LinearAlgebra.Finsupp.VectorSpace
 import Mathlib.LinearAlgebra.FreeModule.Finite.Basic


### PR DESCRIPTION
Basic smallness properties (with respect to universe) for modules and algebras.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
