### PR TITLE
[Merged by Bors] - refactor(Algebra/Group/Subgroup/Basic): clean up normalizer lemmas

### DIFF
--- a/Mathlib/Algebra/Group/Subgroup/Basic.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Basic.lean
@@ -637,6 +637,13 @@ theorem comap_normalizer_eq_of_surjective (H : Subgroup G) {f : N →* G}
     (hf : Function.Surjective f) : H.normalizer.comap f = (H.comap f).normalizer :=
   comap_normalizer_eq_of_le_range fun x _ ↦ hf x
 
+@[deprecated (since := "2025-03-13")]
+alias comap_normalizer_eq_of_injective_of_le_range := comap_normalizer_eq_of_le_range
+
+@[deprecated (since := "2025-03-13")]
+alias _root_.AddSubgroup.comap_normalizer_eq_of_injective_of_le_range :=
+  AddSubgroup.comap_normalizer_eq_of_le_range
+
 /-- The image of the normalizer is equal to the normalizer of the image of an isomorphism. -/
 @[to_additive
       "The image of the normalizer is equal to the normalizer of the image of an

--- a/Mathlib/Algebra/Group/Subgroup/Basic.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Basic.lean
@@ -384,6 +384,33 @@ theorem le_normalizer_map (f : G →* N) : H.normalizer.map f ≤ (H.map f).norm
     rw [hx]
     simp [hy, hyH, mul_assoc]
 
+@[to_additive]
+theorem comap_normalizer_eq_of_le_range {f : N →* G} (h : H ≤ f.range) :
+    comap f H.normalizer = (comap f H).normalizer := by
+  apply le_antisymm (le_normalizer_comap f)
+  rw [← map_le_iff_le_comap]
+  apply (le_normalizer_map f).trans
+  rw [map_comap_eq_self h]
+
+@[to_additive]
+theorem subgroupOf_normalizer_eq {H N : Subgroup G} (h : H ≤ N) :
+    H.normalizer.subgroupOf N = (H.subgroupOf N).normalizer :=
+  comap_normalizer_eq_of_le_range (h.trans_eq N.range_subtype.symm)
+
+@[to_additive]
+theorem normal_subgroupOf_iff_le_normalizer (h : H ≤ K) :
+    (H.subgroupOf K).Normal ↔ K ≤ H.normalizer := by
+  rw [← subgroupOf_eq_top, subgroupOf_normalizer_eq h, normalizer_eq_top_iff]
+
+@[to_additive]
+theorem normal_subgroupOf_iff_le_normalizer_inf :
+    (H.subgroupOf K).Normal ↔ K ≤ (H ⊓ K).normalizer :=
+  inf_subgroupOf_right H K ▸ normal_subgroupOf_iff_le_normalizer inf_le_right
+
+@[to_additive]
+theorem inf_normalizer_le_normalizer_inf : H.normalizer ⊓ K.normalizer ≤ (H ⊓ K).normalizer :=
+  fun _ h g ↦ and_congr (h.1 g) (h.2 g)
+
 variable (G) in
 /-- Every proper subgroup `H` of `G` is a proper normal subgroup of the normalizer of `H` in `G`. -/
 def _root_.NormalizerCondition :=
@@ -611,32 +638,7 @@ variable {N : Type*} [Group N] (f : G →* N)
       a surjective function."]
 theorem comap_normalizer_eq_of_surjective (H : Subgroup G) {f : N →* G}
     (hf : Function.Surjective f) : H.normalizer.comap f = (H.comap f).normalizer :=
-  le_antisymm (le_normalizer_comap f)
-    (by
-      intro x hx
-      simp only [mem_comap, mem_normalizer_iff] at *
-      intro n
-      rcases hf n with ⟨y, rfl⟩
-      simp [hx y])
-
-@[to_additive]
-theorem comap_normalizer_eq_of_injective_of_le_range {N : Type*} [Group N] (H : Subgroup G)
-    {f : N →* G} (hf : Function.Injective f) (h : H.normalizer ≤ f.range) :
-    comap f H.normalizer = (comap f H).normalizer := by
-  apply Subgroup.map_injective hf
-  rw [map_comap_eq_self h]
-  apply le_antisymm
-  · refine le_trans (le_of_eq ?_) (map_mono (le_normalizer_comap _))
-    rw [map_comap_eq_self h]
-  · refine le_trans (le_normalizer_map f) (le_of_eq ?_)
-    rw [map_comap_eq_self (le_trans le_normalizer h)]
-
-@[to_additive]
-theorem subgroupOf_normalizer_eq {H N : Subgroup G} (h : H.normalizer ≤ N) :
-    H.normalizer.subgroupOf N = (H.subgroupOf N).normalizer := by
-  apply comap_normalizer_eq_of_injective_of_le_range
-  · exact Subtype.coe_injective
-  simpa
+  comap_normalizer_eq_of_le_range fun x _ ↦ hf x
 
 /-- The image of the normalizer is equal to the normalizer of the image of an isomorphism. -/
 @[to_additive
@@ -843,20 +845,18 @@ instance prod_normal (H : Subgroup G) (K : Subgroup N) [hH : H.Normal] [hK : K.N
 alias _root_.AddSubgroup.sum_normal := AddSubgroup.prod_normal
 
 @[to_additive]
-theorem inf_subgroupOf_inf_normal_of_right (A B' B : Subgroup G) (hB : B' ≤ B)
-    [hN : (B'.subgroupOf B).Normal] : ((A ⊓ B').subgroupOf (A ⊓ B)).Normal :=
-  { conj_mem := fun {n} hn g =>
-      ⟨mul_mem (mul_mem (mem_inf.1 g.2).1 (mem_inf.1 n.2).1) <|
-        show ↑g⁻¹ ∈ A from (inv_mem (mem_inf.1 g.2).1),
-        (normal_subgroupOf_iff hB).mp hN n g hn.2 (mem_inf.mp g.2).2⟩ }
+theorem inf_subgroupOf_inf_normal_of_right (A B' B : Subgroup G)
+    [hN : (B'.subgroupOf B).Normal] : ((A ⊓ B').subgroupOf (A ⊓ B)).Normal := by
+  rw [normal_subgroupOf_iff_le_normalizer_inf] at hN ⊢
+  rw [inf_inf_inf_comm, inf_eq_left.mpr le_rfl]
+  exact le_trans (inf_le_inf A.le_normalizer hN) (inf_normalizer_le_normalizer_inf)
 
 @[to_additive]
-theorem inf_subgroupOf_inf_normal_of_left {A' A : Subgroup G} (B : Subgroup G) (hA : A' ≤ A)
-    [hN : (A'.subgroupOf A).Normal] : ((A' ⊓ B).subgroupOf (A ⊓ B)).Normal :=
-  { conj_mem := fun n hn g =>
-      ⟨(normal_subgroupOf_iff hA).mp hN n g hn.1 (mem_inf.mp g.2).1,
-        mul_mem (mul_mem (mem_inf.1 g.2).2 (mem_inf.1 n.2).2) <|
-        show ↑g⁻¹ ∈ B from (inv_mem (mem_inf.1 g.2).2)⟩ }
+theorem inf_subgroupOf_inf_normal_of_left {A' A : Subgroup G} (B : Subgroup G)
+    [hN : (A'.subgroupOf A).Normal] : ((A' ⊓ B).subgroupOf (A ⊓ B)).Normal := by
+  rw [normal_subgroupOf_iff_le_normalizer_inf] at hN ⊢
+  rw [inf_inf_inf_comm, inf_eq_left.mpr le_rfl]
+  exact le_trans (inf_le_inf hN B.le_normalizer) (inf_normalizer_le_normalizer_inf)
 
 @[to_additive]
 instance normal_inf_normal (H K : Subgroup G) [hH : H.Normal] [hK : K.Normal] : (H ⊓ K).Normal :=

--- a/Mathlib/Algebra/Group/Subgroup/Basic.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Basic.lean
@@ -339,10 +339,6 @@ section Normalizer
 variable {H}
 
 @[to_additive]
-instance (priority := 100) normal_in_normalizer : (H.subgroupOf H.normalizer).Normal :=
-  ⟨fun x xH g => by simpa only [mem_subgroupOf] using (g.2 x.1).1 xH⟩
-
-@[to_additive]
 theorem normalizer_eq_top_iff : H.normalizer = ⊤ ↔ H.Normal :=
   eq_top_iff.trans
     ⟨fun h => ⟨fun a ha b => (h (mem_top b) a).mp ha⟩, fun h a _ha b =>
@@ -352,13 +348,6 @@ variable (H) in
 @[to_additive]
 theorem normalizer_eq_top [h : H.Normal] : H.normalizer = ⊤ :=
   normalizer_eq_top_iff.mpr h
-
-@[to_additive]
-theorem le_normalizer_of_normal [hK : (H.subgroupOf K).Normal] (HK : H ≤ K) : K ≤ H.normalizer :=
-  fun x hx y =>
-  ⟨fun yH => hK.conj_mem ⟨y, HK yH⟩ yH ⟨x, hx⟩, fun yH => by
-    simpa [mem_subgroupOf, mul_assoc] using
-      hK.conj_mem ⟨x * y * x⁻¹, HK yH⟩ yH ⟨x⁻¹, K.inv_mem hx⟩⟩
 
 variable {N : Type*} [Group N]
 
@@ -406,6 +395,14 @@ theorem normal_subgroupOf_iff_le_normalizer (h : H ≤ K) :
 theorem normal_subgroupOf_iff_le_normalizer_inf :
     (H.subgroupOf K).Normal ↔ K ≤ (H ⊓ K).normalizer :=
   inf_subgroupOf_right H K ▸ normal_subgroupOf_iff_le_normalizer inf_le_right
+
+@[to_additive]
+instance (priority := 100) normal_in_normalizer : (H.subgroupOf H.normalizer).Normal :=
+  (normal_subgroupOf_iff_le_normalizer H.le_normalizer).mpr le_rfl
+
+@[to_additive]
+theorem le_normalizer_of_normal [hK : (H.subgroupOf K).Normal] (HK : H ≤ K) : K ≤ H.normalizer :=
+  (normal_subgroupOf_iff_le_normalizer HK).mp hK
 
 @[to_additive]
 theorem inf_normalizer_le_normalizer_inf : H.normalizer ⊓ K.normalizer ≤ (H ⊓ K).normalizer :=
@@ -848,14 +845,14 @@ alias _root_.AddSubgroup.sum_normal := AddSubgroup.prod_normal
 theorem inf_subgroupOf_inf_normal_of_right (A B' B : Subgroup G)
     [hN : (B'.subgroupOf B).Normal] : ((A ⊓ B').subgroupOf (A ⊓ B)).Normal := by
   rw [normal_subgroupOf_iff_le_normalizer_inf] at hN ⊢
-  rw [inf_inf_inf_comm, inf_eq_left.mpr le_rfl]
+  rw [inf_inf_inf_comm, inf_self]
   exact le_trans (inf_le_inf A.le_normalizer hN) (inf_normalizer_le_normalizer_inf)
 
 @[to_additive]
 theorem inf_subgroupOf_inf_normal_of_left {A' A : Subgroup G} (B : Subgroup G)
     [hN : (A'.subgroupOf A).Normal] : ((A' ⊓ B).subgroupOf (A ⊓ B)).Normal := by
   rw [normal_subgroupOf_iff_le_normalizer_inf] at hN ⊢
-  rw [inf_inf_inf_comm, inf_eq_left.mpr le_rfl]
+  rw [inf_inf_inf_comm, inf_self]
   exact le_trans (inf_le_inf hN B.le_normalizer) (inf_normalizer_le_normalizer_inf)
 
 @[to_additive]

--- a/Mathlib/Algebra/Group/Subgroup/Basic.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Basic.lean
@@ -852,14 +852,14 @@ alias _root_.AddSubgroup.sum_normal := AddSubgroup.prod_normal
 theorem inf_subgroupOf_inf_normal_of_right (A B' B : Subgroup G)
     [hN : (B'.subgroupOf B).Normal] : ((A ⊓ B').subgroupOf (A ⊓ B)).Normal := by
   rw [normal_subgroupOf_iff_le_normalizer_inf] at hN ⊢
-  rw [inf_inf_inf_comm, inf_self]
+  rw [inf_inf_inf_comm, inf_idem]
   exact le_trans (inf_le_inf A.le_normalizer hN) (inf_normalizer_le_normalizer_inf)
 
 @[to_additive]
 theorem inf_subgroupOf_inf_normal_of_left {A' A : Subgroup G} (B : Subgroup G)
     [hN : (A'.subgroupOf A).Normal] : ((A' ⊓ B).subgroupOf (A ⊓ B)).Normal := by
   rw [normal_subgroupOf_iff_le_normalizer_inf] at hN ⊢
-  rw [inf_inf_inf_comm, inf_self]
+  rw [inf_inf_inf_comm, inf_idem]
   exact le_trans (inf_le_inf hN B.le_normalizer) (inf_normalizer_le_normalizer_inf)
 
 @[to_additive]

--- a/Mathlib/GroupTheory/Sylow.lean
+++ b/Mathlib/GroupTheory/Sylow.lean
@@ -750,11 +750,9 @@ theorem normal_of_normalizer_normal {p : ℕ} [Fact p.Prime] [Finite (Sylow p G)
 theorem normalizer_normalizer {p : ℕ} [Fact p.Prime] [Finite (Sylow p G)] (P : Sylow p G) :
     P.normalizer.normalizer = P.normalizer := by
   have := normal_of_normalizer_normal (P.subtype (le_normalizer.trans le_normalizer))
-  simp_rw [← normalizer_eq_top_iff, coe_subtype, ← subgroupOf_normalizer_eq le_normalizer, ←
-    subgroupOf_normalizer_eq le_rfl, subgroupOf_self] at this
-  rw [← range_subtype P.normalizer.normalizer, MonoidHom.range_eq_map,
-    ← this trivial]
-  exact map_comap_eq_self (le_normalizer.trans (ge_of_eq (range_subtype _)))
+  rw [coe_subtype, normal_subgroupOf_iff_le_normalizer (le_normalizer.trans le_normalizer),
+    ← subgroupOf_normalizer_eq (le_normalizer.trans le_normalizer)] at this
+  exact le_antisymm (this normal_in_normalizer) le_normalizer
 
 theorem normal_of_all_max_subgroups_normal [Finite G]
     (hnc : ∀ H : Subgroup G, IsCoatom H → H.Normal) {p : ℕ} [Fact p.Prime] [Finite (Sylow p G)]

--- a/Mathlib/Order/Lattice.lean
+++ b/Mathlib/Order/Lattice.lean
@@ -128,10 +128,6 @@ theorem sup_le_iff : a ⊔ b ≤ c ↔ a ≤ c ∧ b ≤ c :=
    fun ⟨h₁, h₂⟩ => sup_le h₁ h₂⟩
 
 @[simp]
-theorem sup_self : a ⊔ a = a := by
-  simp [le_antisymm_iff]
-
-@[simp]
 theorem sup_eq_left : a ⊔ b = a ↔ b ≤ a :=
   le_antisymm_iff.trans <| by simp [le_rfl]
 
@@ -329,10 +325,6 @@ theorem inf_lt_of_right_lt (h : b < c) : a ⊓ b < c :=
 @[simp]
 theorem le_inf_iff : a ≤ b ⊓ c ↔ a ≤ b ∧ a ≤ c :=
   @sup_le_iff αᵒᵈ _ _ _ _
-
-@[simp]
-theorem inf_self : a ⊓ a = a := by
-  simp [le_antisymm_iff]
 
 @[simp]
 theorem inf_eq_left : a ⊓ b = a ↔ a ≤ b :=

--- a/Mathlib/Order/Lattice.lean
+++ b/Mathlib/Order/Lattice.lean
@@ -128,6 +128,10 @@ theorem sup_le_iff : a ⊔ b ≤ c ↔ a ≤ c ∧ b ≤ c :=
    fun ⟨h₁, h₂⟩ => sup_le h₁ h₂⟩
 
 @[simp]
+theorem sup_self : a ⊔ a = a := by
+  simp [le_antisymm_iff]
+
+@[simp]
 theorem sup_eq_left : a ⊔ b = a ↔ b ≤ a :=
   le_antisymm_iff.trans <| by simp [le_rfl]
 
@@ -325,6 +329,10 @@ theorem inf_lt_of_right_lt (h : b < c) : a ⊓ b < c :=
 @[simp]
 theorem le_inf_iff : a ≤ b ⊓ c ↔ a ≤ b ∧ a ≤ c :=
   @sup_le_iff αᵒᵈ _ _ _ _
+
+@[simp]
+theorem inf_self : a ⊓ a = a := by
+  simp [le_antisymm_iff]
 
 @[simp]
 theorem inf_eq_left : a ⊓ b = a ↔ a ≤ b :=


### PR DESCRIPTION
This PR cleans up several normalizer lemmas in `Algebra/Group/Subgroup/Basic`. Several lemmas had unnecessary assumptions or unnecessarily complicated proofs.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
