### PR TITLE
[Merged by Bors] - feat(CategoryTheory/Enriched/Limits): Add conical limits for enriched ordinary categories

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1912,6 +1912,7 @@ import Mathlib.CategoryTheory.Endomorphism
 import Mathlib.CategoryTheory.Enriched.Basic
 import Mathlib.CategoryTheory.Enriched.FunctorCategory
 import Mathlib.CategoryTheory.Enriched.HomCongr
+import Mathlib.CategoryTheory.Enriched.Limits.HasConicalLimits
 import Mathlib.CategoryTheory.Enriched.Opposite
 import Mathlib.CategoryTheory.Enriched.Ordinary.Basic
 import Mathlib.CategoryTheory.EpiMono

--- a/Mathlib/CategoryTheory/Enriched/Limits/HasConicalLimits.lean
+++ b/Mathlib/CategoryTheory/Enriched/Limits/HasConicalLimits.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jon Eugster, Dagur Asgeirsson, Emily Riehl
 -/
 import Mathlib.CategoryTheory.Enriched.Ordinary.Basic
-import Mathlib.CategoryTheory.Limits.Preserves.Limits
 
 /-!
 # HasConicalLimits

--- a/Mathlib/CategoryTheory/Enriched/Limits/HasConicalLimits.lean
+++ b/Mathlib/CategoryTheory/Enriched/Limits/HasConicalLimits.lean
@@ -84,14 +84,12 @@ end Definitions
 
 section Results
 
-variable {J : Type u₁} [Category.{v₁} J]
+variable (J : Type u₁) [Category.{v₁} J]
 variable (V : Type u') [Category.{v'} V] [MonoidalCategory V]
 variable (C : Type u) [Category.{v} C] [EnrichedOrdinaryCategory V C]
 
-variable {C} in
-
 /-- ensure existence of a conical limit implies existence of a limit -/
-example {F : J ⥤ C} [HasConicalLimit V F] : HasLimit F := inferInstance
+example (F : J ⥤ C) [HasConicalLimit V F] : HasLimit F := inferInstance
 
 /-- existence of conical limits (of shape) implies existence of limits (of shape) -/
 -- TODO: errors if made an `instance`.

--- a/Mathlib/CategoryTheory/Enriched/Limits/HasConicalLimits.lean
+++ b/Mathlib/CategoryTheory/Enriched/Limits/HasConicalLimits.lean
@@ -124,7 +124,6 @@ end HasConicalLimitsOfSize
 end Results
 namespace HasConicalLimits
 
--- Note that `Category.{v, v} J` is deliberately chosen this way, see `HasConicalLimits`.
 variable (J : Type v) [SmallCategory J]
 variable (V : Type u') [Category.{v'} V] [MonoidalCategory V]
 variable (C : Type u) [Category.{v} C] [EnrichedOrdinaryCategory V C]

--- a/Mathlib/CategoryTheory/Enriched/Limits/HasConicalLimits.lean
+++ b/Mathlib/CategoryTheory/Enriched/Limits/HasConicalLimits.lean
@@ -13,15 +13,16 @@ This file contains different statements about the (non-constructive) existence o
 
 The main constructions are the following.
 
-- `HasConicalLimit`: there exists a limit `cone` with `IsConicalLimit V cone`
+- `HasConicalLimit`: there exists a conical limit for `F : J ⥤ C`.
 - `HasConicalLimitsOfShape J`: All functors `F : J ⥤ C` have conical limits.
 - `HasConicalLimitsOfSize.{v₁, u₁}`: For all small `J` all functors `F : J ⥤ C` have conical limits.
-- `HasConicalLimits `: has all (small) conical limits.
+- `HasConicalLimits `: `C` has all (small) conical limits.
 
 ## References
-* [Kelly G.M., *Basic concepts of enriched category theory*][kelly2005]
-See section 3.8 for a similar treatment, although the content of this file is not directly
-adapted from there.
+
+* [Kelly G.M., *Basic concepts of enriched category theory*][kelly2005]:
+  See section 3.8 for a similar treatment, although the content of this file is not directly
+  adapted from there.
 -/
 
 universe v₁ u₁ v₂ u₂ w v' v u u'

--- a/Mathlib/CategoryTheory/Enriched/Limits/HasConicalLimits.lean
+++ b/Mathlib/CategoryTheory/Enriched/Limits/HasConicalLimits.lean
@@ -125,7 +125,7 @@ end Results
 namespace HasConicalLimits
 
 -- Note that `Category.{v, v} J` is deliberately chosen this way, see `HasConicalLimits`.
-variable (J : Type v) [Category.{v, v} J]
+variable (J : Type v) [SmallCategory J]
 variable (V : Type u') [Category.{v'} V] [MonoidalCategory V]
 variable (C : Type u) [Category.{v} C] [EnrichedOrdinaryCategory V C]
 variable [HasConicalLimits V C]

--- a/Mathlib/CategoryTheory/Enriched/Limits/HasConicalLimits.lean
+++ b/Mathlib/CategoryTheory/Enriched/Limits/HasConicalLimits.lean
@@ -30,12 +30,10 @@ namespace CategoryTheory.Enriched
 
 open Limits
 
-variable {J : Type u₁} [Category.{v₁} J]
-variable {J : Type u₁} [Category.{v₁} J] {J' : Type u₂} [Category.{v₂} J']
-
 section Definitions
 
 -- note: for the classes it seems that instance inference wants `V` to be an `outParam`.
+variable {J : Type u₁} [Category.{v₁} J]
 variable (V : outParam <| Type u') [Category.{v'} V] [MonoidalCategory V]
 variable (C : Type u) [Category.{v} C] [EnrichedOrdinaryCategory V C]
 
@@ -77,5 +75,6 @@ hom-sets. -/
 abbrev HasConicalLimits : Prop := HasConicalLimitsOfSize.{v, v} V C
 
 end Definitions
+
 
 end CategoryTheory.Enriched

--- a/Mathlib/CategoryTheory/Enriched/Limits/HasConicalLimits.lean
+++ b/Mathlib/CategoryTheory/Enriched/Limits/HasConicalLimits.lean
@@ -22,6 +22,12 @@ The main constructions are the following.
 * [Kelly G.M., *Basic concepts of enriched category theory*][kelly2005]:
   See section 3.8 for a similar treatment, although the content of this file is not directly
   adapted from there.
+
+## Implementation notes
+
+It seems that instance inference would work much smoother when `V` would be made
+an `(V : outParam <| Type u')` for the `class`es below. However, this might
+cause other problems, for example maybe if different `[MonoidalCategory _]` are in scope.
 -/
 
 universe v₁ u₁ v₂ u₂ w v' v u u'
@@ -34,7 +40,7 @@ section Definitions
 
 -- note: for the classes it seems that instance inference wants `V` to be an `outParam`.
 variable {J : Type u₁} [Category.{v₁} J]
-variable (V : outParam <| Type u') [Category.{v'} V] [MonoidalCategory V]
+variable (V : Type u') [Category.{v'} V] [MonoidalCategory V]
 variable (C : Type u) [Category.{v} C] [EnrichedOrdinaryCategory V C]
 
 variable {C} in
@@ -95,7 +101,8 @@ namespace HasConicalLimitsOfShape
 variable [HasConicalLimitsOfShape J V C]
 
 /-- existence of conical limits (of shape) implies existence of limits (of shape) -/
-instance instHasLimitsOfShape : HasLimitsOfShape J C where
+-- TODO: errors if made an `instance`.
+def hasLimitsOfShape : HasLimitsOfShape J C where
   has_limit _ := inferInstance
 
 end HasConicalLimitsOfShape
@@ -105,9 +112,12 @@ namespace HasConicalLimitsOfSize
 variable [HasConicalLimitsOfSize.{v₁, u₁} V C]
 
 /-- existence of conical limits (of size) implies existence of limits (of size) -/
-instance instHasLimitsOfSize [HasConicalLimitsOfSize.{v₁, u₁} V C] :
+-- TODO: errors if made an `instance`.
+def hasLimitsOfSize [HasConicalLimitsOfSize.{v₁, u₁} V C] :
     HasLimitsOfSize.{v₁, u₁} C where
-  has_limits_of_shape := inferInstance
+  has_limits_of_shape _ :=
+    -- TODO: use `inferInstance` instead
+    HasConicalLimitsOfShape.hasLimitsOfShape V C
 
 end HasConicalLimitsOfSize
 
@@ -121,7 +131,10 @@ variable (C : Type u) [Category.{v} C] [EnrichedOrdinaryCategory V C]
 variable [HasConicalLimits V C]
 
 /-- ensure existence of (small) conical limits implies existence of (small) limits -/
-example : HasLimits C := inferInstance
+-- TODO: errors if made an `instance`.
+def hasLimits : HasLimits C :=
+  -- TODO: use `inferInstance` instead
+  HasConicalLimitsOfSize.hasLimitsOfSize V C
 
 end HasConicalLimits
 

--- a/Mathlib/CategoryTheory/Enriched/Limits/HasConicalLimits.lean
+++ b/Mathlib/CategoryTheory/Enriched/Limits/HasConicalLimits.lean
@@ -30,9 +30,12 @@ namespace CategoryTheory.Enriched
 
 open Limits
 
+variable {J : Type u₁} [Category.{v₁} J]
+variable {J : Type u₁} [Category.{v₁} J] {J' : Type u₂} [Category.{v₂} J']
+
 section Definitions
 
-variable {J : Type u₁} [Category.{v₁} J]
+-- note: for the classes it seems that instance inference wants `V` to be an `outParam`.
 variable (V : outParam <| Type u') [Category.{v'} V] [MonoidalCategory V]
 variable (C : Type u) [Category.{v} C] [EnrichedOrdinaryCategory V C]
 

--- a/Mathlib/CategoryTheory/Enriched/Limits/HasConicalLimits.lean
+++ b/Mathlib/CategoryTheory/Enriched/Limits/HasConicalLimits.lean
@@ -25,10 +25,11 @@ The main constructions are the following.
 
 ## Implementation notes
 
-It seems that instance inference would work much smoother when `V` would be made
-an `(V : outParam <| Type u')` for the `class`es below. However, this could maybe
-cause other problems, maybe such an example would be if
-different `[MonoidalCategory _]` are in scope.
+`V` has been made an `(V : outParam <| Type u')` in the classes below as it seems instance
+inference prefers this. Otherwise it failed with
+`cannot find synthesization order` on the instances below.
+However, it is not fully clear yet whether this could lead to potential issues, for example
+if there are multiple `MonoidalCategory _` instances in scope.
 -/
 
 universe v₁ u₁ v₂ u₂ w v' v u u'
@@ -40,7 +41,7 @@ open Limits
 section Definitions
 
 variable {J : Type u₁} [Category.{v₁} J]
-variable (V : Type u') [Category.{v'} V] [MonoidalCategory V]
+variable (V : outParam <| Type u') [Category.{v'} V] [MonoidalCategory V]
 variable (C : Type u) [Category.{v} C] [EnrichedOrdinaryCategory V C]
 
 variable {C} in
@@ -92,19 +93,17 @@ variable (C : Type u) [Category.{v} C] [EnrichedOrdinaryCategory V C]
 example (F : J ⥤ C) [HasConicalLimit V F] : HasLimit F := inferInstance
 
 /-- existence of conical limits (of shape) implies existence of limits (of shape) -/
-lemma HasConicalLimitsOfShape.hasLimitsOfShape [HasConicalLimitsOfShape J V C] :
+instance HasConicalLimitsOfShape.hasLimitsOfShape [HasConicalLimitsOfShape J V C] :
     HasLimitsOfShape J C where
   has_limit _ := inferInstance
 
 /-- existence of conical limits (of size) implies existence of limits (of size) -/
-lemma HasConicalLimitsOfSize.hasLimitsOfSize [HasConicalLimitsOfSize.{v₁, u₁} V C] :
+instance HasConicalLimitsOfSize.hasLimitsOfSize [HasConicalLimitsOfSize.{v₁, u₁} V C] :
     HasLimitsOfSize.{v₁, u₁} C where
-  has_limits_of_shape J :=
-    HasConicalLimitsOfShape.hasLimitsOfShape J V C
+  has_limits_of_shape _ := inferInstance
 
 /-- ensure existence of (small) conical limits implies existence of (small) limits -/
-lemma HasConicalLimits.hasLimits [HasConicalLimits V C] : HasLimits C :=
-  HasConicalLimitsOfSize.hasLimitsOfSize V C
+example [HasConicalLimits V C] : HasLimits C := inferInstance
 
 end Results
 

--- a/Mathlib/CategoryTheory/Enriched/Limits/HasConicalLimits.lean
+++ b/Mathlib/CategoryTheory/Enriched/Limits/HasConicalLimits.lean
@@ -26,8 +26,9 @@ The main constructions are the following.
 ## Implementation notes
 
 It seems that instance inference would work much smoother when `V` would be made
-an `(V : outParam <| Type u')` for the `class`es below. However, this might
-cause other problems, for example maybe if different `[MonoidalCategory _]` are in scope.
+an `(V : outParam <| Type u')` for the `class`es below. However, this could maybe
+cause other problems, maybe such an example would be if
+different `[MonoidalCategory _]` are in scope.
 -/
 
 universe v₁ u₁ v₂ u₂ w v' v u u'
@@ -38,7 +39,6 @@ open Limits
 
 section Definitions
 
--- note: for the classes it seems that instance inference wants `V` to be an `outParam`.
 variable {J : Type u₁} [Category.{v₁} J]
 variable (V : Type u') [Category.{v'} V] [MonoidalCategory V]
 variable (C : Type u) [Category.{v} C] [EnrichedOrdinaryCategory V C]
@@ -92,23 +92,18 @@ variable (C : Type u) [Category.{v} C] [EnrichedOrdinaryCategory V C]
 example (F : J ⥤ C) [HasConicalLimit V F] : HasLimit F := inferInstance
 
 /-- existence of conical limits (of shape) implies existence of limits (of shape) -/
--- TODO: errors if made an `instance`.
 lemma HasConicalLimitsOfShape.hasLimitsOfShape [HasConicalLimitsOfShape J V C] :
     HasLimitsOfShape J C where
   has_limit _ := inferInstance
 
 /-- existence of conical limits (of size) implies existence of limits (of size) -/
--- TODO: errors if made an `instance`.
 lemma HasConicalLimitsOfSize.hasLimitsOfSize [HasConicalLimitsOfSize.{v₁, u₁} V C] :
     HasLimitsOfSize.{v₁, u₁} C where
   has_limits_of_shape J :=
-    -- TODO: use `inferInstance` instead
     HasConicalLimitsOfShape.hasLimitsOfShape J V C
 
 /-- ensure existence of (small) conical limits implies existence of (small) limits -/
--- TODO: errors if made an `instance`.
 lemma HasConicalLimits.hasLimits [HasConicalLimits V C] : HasLimits C :=
-  -- TODO: use `inferInstance` instead
   HasConicalLimitsOfSize.hasLimitsOfSize V C
 
 end Results

--- a/Mathlib/CategoryTheory/Enriched/Limits/HasConicalLimits.lean
+++ b/Mathlib/CategoryTheory/Enriched/Limits/HasConicalLimits.lean
@@ -101,9 +101,9 @@ lemma HasConicalLimitsOfShape.hasLimitsOfShape [HasConicalLimitsOfShape J V C] :
 -- TODO: errors if made an `instance`.
 lemma HasConicalLimitsOfSize.hasLimitsOfSize [HasConicalLimitsOfSize.{v₁, u₁} V C] :
     HasLimitsOfSize.{v₁, u₁} C where
-  has_limits_of_shape _ :=
+  has_limits_of_shape J :=
     -- TODO: use `inferInstance` instead
-    HasConicalLimitsOfShape.hasLimitsOfShape V C
+    HasConicalLimitsOfShape.hasLimitsOfShape J V C
 
 /-- ensure existence of (small) conical limits implies existence of (small) limits -/
 -- TODO: errors if made an `instance`.

--- a/Mathlib/CategoryTheory/Enriched/Limits/HasConicalLimits.lean
+++ b/Mathlib/CategoryTheory/Enriched/Limits/HasConicalLimits.lean
@@ -76,5 +76,53 @@ abbrev HasConicalLimits : Prop := HasConicalLimitsOfSize.{v, v} V C
 
 end Definitions
 
+section Results
+
+variable {J : Type u₁} [Category.{v₁} J] {J' : Type u₂} [Category.{v₂} J']
+variable (V : Type u') [Category.{v'} V] [MonoidalCategory V]
+variable (C : Type u) [Category.{v} C] [EnrichedOrdinaryCategory V C]
+namespace HasConicalLimit
+
+variable {C} {F G : J ⥤ C} [HasConicalLimit V F]
+
+/-- ensure existence of a conical limit implies existence of a limit -/
+example : HasLimit F := inferInstance
+
+end HasConicalLimit
+
+namespace HasConicalLimitsOfShape
+
+variable [HasConicalLimitsOfShape J V C]
+
+/-- existence of conical limits (of shape) implies existence of limits (of shape) -/
+instance : HasLimitsOfShape J C where
+  has_limit _ := inferInstance
+
+end HasConicalLimitsOfShape
+
+namespace HasConicalLimitsOfSize
+
+variable [HasConicalLimitsOfSize.{v₁, u₁} V C]
+
+/-- existence of conical limits (of size) implies existence of limits (of size) -/
+instance hasLimitsOfSize [HasConicalLimitsOfSize.{v₁, u₁} V C] :
+    HasLimitsOfSize.{v₁, u₁} C where
+  has_limits_of_shape := inferInstance
+
+end HasConicalLimitsOfSize
+
+end Results
+namespace HasConicalLimits
+
+-- Note that `Category.{v, v} J` is deliberately chosen this way, see `HasConicalLimits`.
+variable (J : Type v) [Category.{v, v} J]
+variable (V : Type u') [Category.{v'} V] [MonoidalCategory V]
+variable (C : Type u) [Category.{v} C] [EnrichedOrdinaryCategory V C]
+variable [HasConicalLimits V C]
+
+/-- ensure existence of (small) conical limits implies existence of (small) limits -/
+example : HasLimits C := inferInstance
+
+end HasConicalLimits
 
 end CategoryTheory.Enriched

--- a/Mathlib/CategoryTheory/Enriched/Limits/HasConicalLimits.lean
+++ b/Mathlib/CategoryTheory/Enriched/Limits/HasConicalLimits.lean
@@ -95,13 +95,13 @@ example {F : J ⥤ C} [HasConicalLimit V F] : HasLimit F := inferInstance
 
 /-- existence of conical limits (of shape) implies existence of limits (of shape) -/
 -- TODO: errors if made an `instance`.
-def HasConicalLimitsOfShape.hasLimitsOfShape [HasConicalLimitsOfShape J V C] :
+lemma HasConicalLimitsOfShape.hasLimitsOfShape [HasConicalLimitsOfShape J V C] :
     HasLimitsOfShape J C where
   has_limit _ := inferInstance
 
 /-- existence of conical limits (of size) implies existence of limits (of size) -/
 -- TODO: errors if made an `instance`.
-def HasConicalLimitsOfSize.hasLimitsOfSize [HasConicalLimitsOfSize.{v₁, u₁} V C] :
+lemma HasConicalLimitsOfSize.hasLimitsOfSize [HasConicalLimitsOfSize.{v₁, u₁} V C] :
     HasLimitsOfSize.{v₁, u₁} C where
   has_limits_of_shape _ :=
     -- TODO: use `inferInstance` instead
@@ -109,7 +109,7 @@ def HasConicalLimitsOfSize.hasLimitsOfSize [HasConicalLimitsOfSize.{v₁, u₁} 
 
 /-- ensure existence of (small) conical limits implies existence of (small) limits -/
 -- TODO: errors if made an `instance`.
-def HasConicalLimits.hasLimits [HasConicalLimits V C] : HasLimits C :=
+lemma HasConicalLimits.hasLimits [HasConicalLimits V C] : HasLimits C :=
   -- TODO: use `inferInstance` instead
   HasConicalLimitsOfSize.hasLimitsOfSize V C
 

--- a/Mathlib/CategoryTheory/Enriched/Limits/HasConicalLimits.lean
+++ b/Mathlib/CategoryTheory/Enriched/Limits/HasConicalLimits.lean
@@ -6,7 +6,7 @@ Authors: Jon Eugster, Dagur Asgeirsson, Emily Riehl
 import Mathlib.CategoryTheory.Enriched.Ordinary.Basic
 
 /-!
-# HasConicalLimits
+# Existence of conical limits
 
 This file contains different statements about the (non-constructive) existence of conical limits.
 

--- a/Mathlib/CategoryTheory/Enriched/Limits/HasConicalLimits.lean
+++ b/Mathlib/CategoryTheory/Enriched/Limits/HasConicalLimits.lean
@@ -95,7 +95,7 @@ namespace HasConicalLimitsOfShape
 variable [HasConicalLimitsOfShape J V C]
 
 /-- existence of conical limits (of shape) implies existence of limits (of shape) -/
-instance : HasLimitsOfShape J C where
+instance instHasLimitsOfShape : HasLimitsOfShape J C where
   has_limit _ := inferInstance
 
 end HasConicalLimitsOfShape
@@ -105,7 +105,7 @@ namespace HasConicalLimitsOfSize
 variable [HasConicalLimitsOfSize.{v₁, u₁} V C]
 
 /-- existence of conical limits (of size) implies existence of limits (of size) -/
-instance hasLimitsOfSize [HasConicalLimitsOfSize.{v₁, u₁} V C] :
+instance instHasLimitsOfSize [HasConicalLimitsOfSize.{v₁, u₁} V C] :
     HasLimitsOfSize.{v₁, u₁} C where
   has_limits_of_shape := inferInstance
 

--- a/Mathlib/CategoryTheory/Enriched/Limits/HasConicalLimits.lean
+++ b/Mathlib/CategoryTheory/Enriched/Limits/HasConicalLimits.lean
@@ -1,0 +1,78 @@
+/-
+Copyright (c) 2025 Jon Eugster. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jon Eugster, Dagur Asgeirsson, Emily Riehl
+-/
+import Mathlib.CategoryTheory.Enriched.Ordinary.Basic
+import Mathlib.CategoryTheory.Limits.Preserves.Limits
+
+/-!
+# HasConicalLimits
+
+This file contains different statements about the (non-constructive) existence of conical limits.
+
+The main constructions are the following.
+
+- `HasConicalLimit`: there exists a limit `cone` with `IsConicalLimit V cone`
+- `HasConicalLimitsOfShape J`: All functors `F : J ⥤ C` have conical limits.
+- `HasConicalLimitsOfSize.{v₁, u₁}`: For all small `J` all functors `F : J ⥤ C` have conical limits.
+- `HasConicalLimits `: has all (small) conical limits.
+
+## References
+* [Kelly G.M., *Basic concepts of enriched category theory*][kelly2005]
+See section 3.8 for a similar treatment, although the content of this file is not directly
+adapted from there.
+-/
+
+universe v₁ u₁ v₂ u₂ w v' v u u'
+
+namespace CategoryTheory.Enriched
+
+open Limits
+
+section Definitions
+
+variable {J : Type u₁} [Category.{v₁} J]
+variable (V : outParam <| Type u') [Category.{v'} V] [MonoidalCategory V]
+variable (C : Type u) [Category.{v} C] [EnrichedOrdinaryCategory V C]
+
+variable {C} in
+
+/--
+`HasConicalLimit F` represents the mere existence of a conical limit for `F`.
+-/
+class HasConicalLimit (F : J ⥤ C) : Prop extends HasLimit F where
+  preservesLimit_eCoyoneda (X : C) : PreservesLimit F (eCoyoneda V X) := by infer_instance
+
+attribute [instance] HasConicalLimit.preservesLimit_eCoyoneda
+
+variable (J) in
+
+/--
+`C` has conical limits of shape `J` if there exists a conical limit for every functor `F : J ⥤ C`.
+-/
+class HasConicalLimitsOfShape : Prop where
+  /-- All functors `F : J ⥤ C` from `J` have limits. -/
+  hasConicalLimit : ∀ F : J ⥤ C, HasConicalLimit V F := by infer_instance
+
+attribute [instance] HasConicalLimitsOfShape.hasConicalLimit
+
+/--
+`C` has all conical limits of size `v₁ u₁` (`HasLimitsOfSize.{v₁ u₁} C`)
+if it has conical limits of every shape `J : Type u₁` with `[Category.{v₁} J]`.
+-/
+@[pp_with_univ]
+class HasConicalLimitsOfSize : Prop where
+  /-- All functors `F : J ⥤ C` from all small `J` have conical limits -/
+  hasConicalLimitsOfShape : ∀ (J : Type u₁) [Category.{v₁} J], HasConicalLimitsOfShape J V C := by
+    infer_instance
+
+attribute [instance] HasConicalLimitsOfSize.hasConicalLimitsOfShape
+
+/-- `C` has all (small) conical limits if it has limits of every shape that is as big as its
+hom-sets. -/
+abbrev HasConicalLimits : Prop := HasConicalLimitsOfSize.{v, v} V C
+
+end Definitions
+
+end CategoryTheory.Enriched

--- a/Mathlib/CategoryTheory/Enriched/Limits/HasConicalLimits.lean
+++ b/Mathlib/CategoryTheory/Enriched/Limits/HasConicalLimits.lean
@@ -84,57 +84,35 @@ end Definitions
 
 section Results
 
-variable {J : Type u₁} [Category.{v₁} J] {J' : Type u₂} [Category.{v₂} J']
+variable {J : Type u₁} [Category.{v₁} J]
 variable (V : Type u') [Category.{v'} V] [MonoidalCategory V]
 variable (C : Type u) [Category.{v} C] [EnrichedOrdinaryCategory V C]
-namespace HasConicalLimit
 
-variable {C} {F G : J ⥤ C} [HasConicalLimit V F]
+variable {C} in
 
 /-- ensure existence of a conical limit implies existence of a limit -/
-example : HasLimit F := inferInstance
-
-end HasConicalLimit
-
-namespace HasConicalLimitsOfShape
-
-variable [HasConicalLimitsOfShape J V C]
+example {F : J ⥤ C} [HasConicalLimit V F] : HasLimit F := inferInstance
 
 /-- existence of conical limits (of shape) implies existence of limits (of shape) -/
 -- TODO: errors if made an `instance`.
-def hasLimitsOfShape : HasLimitsOfShape J C where
+def HasConicalLimitsOfShape.hasLimitsOfShape [HasConicalLimitsOfShape J V C] :
+    HasLimitsOfShape J C where
   has_limit _ := inferInstance
-
-end HasConicalLimitsOfShape
-
-namespace HasConicalLimitsOfSize
-
-variable [HasConicalLimitsOfSize.{v₁, u₁} V C]
 
 /-- existence of conical limits (of size) implies existence of limits (of size) -/
 -- TODO: errors if made an `instance`.
-def hasLimitsOfSize [HasConicalLimitsOfSize.{v₁, u₁} V C] :
+def HasConicalLimitsOfSize.hasLimitsOfSize [HasConicalLimitsOfSize.{v₁, u₁} V C] :
     HasLimitsOfSize.{v₁, u₁} C where
   has_limits_of_shape _ :=
     -- TODO: use `inferInstance` instead
     HasConicalLimitsOfShape.hasLimitsOfShape V C
 
-end HasConicalLimitsOfSize
-
-end Results
-namespace HasConicalLimits
-
-variable (J : Type v) [SmallCategory J]
-variable (V : Type u') [Category.{v'} V] [MonoidalCategory V]
-variable (C : Type u) [Category.{v} C] [EnrichedOrdinaryCategory V C]
-variable [HasConicalLimits V C]
-
 /-- ensure existence of (small) conical limits implies existence of (small) limits -/
 -- TODO: errors if made an `instance`.
-def hasLimits : HasLimits C :=
+def HasConicalLimits.hasLimits [HasConicalLimits V C] : HasLimits C :=
   -- TODO: use `inferInstance` instead
   HasConicalLimitsOfSize.hasLimitsOfSize V C
 
-end HasConicalLimits
+end Results
 
 end CategoryTheory.Enriched

--- a/Mathlib/CategoryTheory/Enriched/Ordinary/Basic.lean
+++ b/Mathlib/CategoryTheory/Enriched/Ordinary/Basic.lean
@@ -26,7 +26,7 @@ using an abbreviation for `EnrichedOrdinaryCategory SSet C`.
 
 universe v' v u u'
 
-open CategoryTheory Category MonoidalCategory
+open CategoryTheory Category MonoidalCategory Opposite
 
 namespace CategoryTheory
 
@@ -172,5 +172,8 @@ instance ForgetEnrichment.EnrichedOrdinaryCategory {D : Type*} [EnrichedCategory
   homEquiv := Equiv.refl _
   homEquiv_id _ := Category.id_comp _
   homEquiv_comp _ _ := Category.assoc _ _ _
+
+/-- enriched coyoneda functor `(X ⟶[V] _) : C ⥤ V`. -/
+abbrev eCoyoneda (X : C) := (eHomFunctor V C).obj (op X)
 
 end CategoryTheory

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -2594,6 +2594,16 @@
   url           = {https://doi.org/10.1007/978-1-4612-4190-4}
 }
 
+@Article{         kelly2005,
+  author        = {Kelly, G. M.},
+  title         = {Basic concepts of enriched category theory},
+  journal       = {Repr. Theory Appl. Categ.},
+  volume        = {10},
+  pages         = {vi+137 pp.},
+  year          = {2005},
+  language      = {English}
+}
+
 @Article{         kelleyVaught1953,
   author        = {Kelley, J. L. and Vaught, R. L.},
   title         = {The positive cone in {Banach} algebras},

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -2594,16 +2594,6 @@
   url           = {https://doi.org/10.1007/978-1-4612-4190-4}
 }
 
-@Article{         kelly2005,
-  author        = {Kelly, G. M.},
-  title         = {Basic concepts of enriched category theory},
-  journal       = {Repr. Theory Appl. Categ.},
-  volume        = {10},
-  pages         = {vi+137 pp.},
-  year          = {2005},
-  language      = {English}
-}
-
 @Article{         kelleyVaught1953,
   author        = {Kelley, J. L. and Vaught, R. L.},
   title         = {The positive cone in {Banach} algebras},
@@ -2614,6 +2604,16 @@
   year          = {1953},
   language      = {English},
   doi           = {10.2307/1990847}
+}
+
+@Article{         kelly2005,
+  author        = {Kelly, G. M.},
+  title         = {Basic concepts of enriched category theory},
+  journal       = {Repr. Theory Appl. Categ.},
+  volume        = {10},
+  pages         = {vi+137 pp.},
+  year          = {2005},
+  language      = {English}
 }
 
 @Article{         kleiman1979,


### PR DESCRIPTION
Co-authored-by: Emily Riehl [eriehl@jhu.edu](mailto:eriehl@jhu.edu)
Co-authored-by: Dagur Asgeirsson [dagurtomas@gmail.com](mailto:dagurtomas@gmail.com)

---

More API to follow in PR #22921.

Rewrite to replace PR-stack under #20967

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
