### PR TITLE
[Merged by Bors] - feat(Order/Cover): characterise covering in Pi types

### DIFF
--- a/Mathlib/Order/Atoms.lean
+++ b/Mathlib/Order/Atoms.lean
@@ -1127,36 +1127,11 @@ universe u
 variable {ι : Type*} {π : ι → Type u}
 
 protected theorem eq_bot_iff [∀ i, Bot (π i)] {f : ∀ i, π i} : f = ⊥ ↔ ∀ i, f i = ⊥ :=
-  ⟨(· ▸ by simp), fun h => funext fun i => by simp [h]⟩
+  funext_iff
 
 theorem isAtom_iff {f : ∀ i, π i} [∀ i, PartialOrder (π i)] [∀ i, OrderBot (π i)] :
     IsAtom f ↔ ∃ i, IsAtom (f i) ∧ ∀ j, j ≠ i → f j = ⊥ := by
-  classical
-  constructor
-  case mpr =>
-    rintro ⟨i, ⟨hfi, hlt⟩, hbot⟩
-    refine ⟨fun h => hfi ((Pi.eq_bot_iff.1 h) _), fun g hgf => Pi.eq_bot_iff.2 fun j => ?_⟩
-    have ⟨hgf, k, hgfk⟩ := Pi.lt_def.1 hgf
-    obtain rfl : i = k := of_not_not fun hki => by rw [hbot _ (Ne.symm hki)] at hgfk; simp at hgfk
-    if hij : j = i then subst hij; refine hlt _ hgfk else
-    exact eq_bot_iff.2 <| le_trans (hgf _) (eq_bot_iff.1 (hbot _ hij))
-  case mp =>
-    rintro ⟨hbot, h⟩
-    have ⟨i, hbot⟩ : ∃ i, f i ≠ ⊥ := by rw [ne_eq, Pi.eq_bot_iff, not_forall] at hbot; exact hbot
-    refine ⟨i, ⟨hbot, ?c⟩, ?d⟩
-    case c =>
-      intro b hb
-      have := h (Function.update ⊥ i b)
-      simp only [lt_def, le_def, Pi.eq_bot_iff, and_imp, forall_exists_index] at this
-      simpa using this
-        (fun j => by by_cases h : j = i; { subst h; simpa using le_of_lt hb }; simp [h])
-        i (by simpa using hb) i
-    case d =>
-      intro j hj
-      have := h (Function.update ⊥ j (f j))
-      simp only [lt_def, le_def, Pi.eq_bot_iff, and_imp, forall_exists_index] at this
-      simpa using this (fun k => by by_cases h : k = j; { subst h; simp }; simp [h]) i
-        (by rwa [Function.update_of_ne (Ne.symm hj), bot_apply, bot_lt_iff_ne_bot]) j
+  simp only [← bot_covBy_iff, Pi.covBy_iff, bot_apply, eq_comm]
 
 theorem isAtom_single {i : ι} [DecidableEq ι] [∀ i, PartialOrder (π i)] [∀ i, OrderBot (π i)]
     {a : π i} (h : IsAtom a) : IsAtom (Function.update (⊥ : ∀ i, π i) i a) :=
@@ -1165,23 +1140,14 @@ theorem isAtom_single {i : ι} [DecidableEq ι] [∀ i, PartialOrder (π i)] [�
 theorem isAtom_iff_eq_single [DecidableEq ι] [∀ i, PartialOrder (π i)]
     [∀ i, OrderBot (π i)] {f : ∀ i, π i} :
     IsAtom f ↔ ∃ i a, IsAtom a ∧ f = Function.update ⊥ i a := by
-  constructor
-  case mp =>
-    intro h
-    have ⟨i, h, hbot⟩ := isAtom_iff.1 h
-    refine ⟨_, _, h, funext fun j => if hij : j = i then hij ▸ by simp else ?_⟩
-    rw [Function.update_of_ne hij, hbot _ hij, bot_apply]
-  case mpr =>
-    rintro ⟨i, a, h, rfl⟩
-    exact isAtom_single h
+  simp [← bot_covBy_iff, covBy_iff_exists_right_eq]
 
 instance isAtomic [∀ i, PartialOrder (π i)] [∀ i, OrderBot (π i)] [∀ i, IsAtomic (π i)] :
     IsAtomic (∀ i, π i) where
   eq_bot_or_exists_atom_le b := or_iff_not_imp_left.2 fun h =>
     have ⟨i, hi⟩ : ∃ i, b i ≠ ⊥ := not_forall.1 (h.imp Pi.eq_bot_iff.2)
     have ⟨a, ha, hab⟩ := (eq_bot_or_exists_atom_le (b i)).resolve_left hi
-    have : DecidableEq ι := open scoped Classical in inferInstance
-    ⟨Function.update ⊥ i a, isAtom_single ha, update_le_iff.2 ⟨hab, by simp⟩⟩
+    by classical exact ⟨Function.update ⊥ i a, isAtom_single ha, update_le_iff.2 ⟨hab, by simp⟩⟩
 
 instance isCoatomic [∀ i, PartialOrder (π i)] [∀ i, OrderTop (π i)] [∀ i, IsCoatomic (π i)] :
     IsCoatomic (∀ i, π i) :=
@@ -1200,8 +1166,7 @@ instance isAtomistic [∀ i, PartialOrder (π i)] [∀ i, OrderBot (π i)] [∀ 
     · rintro _ ⟨_, ⟨⟨_, _, _, rfl⟩, hs⟩, rfl⟩
       exact hs i
     · refine fun j hj ↦ (isLUB_atoms_le (s i)).2 fun x ⟨hx₁, hx₂⟩ ↦ ?_
-      refine hj ⟨Function.update ⊥ i x, ⟨⟨_, x, hx₁, rfl⟩, fun j ↦ ?_⟩, by simp⟩
-      obtain rfl | hij := eq_or_ne j i <;> simp [*]
+      exact hj ⟨Function.update ⊥ i x, ⟨⟨_, x, hx₁, rfl⟩, by simp [update_le_iff, hx₂]⟩, by simp⟩
 
 instance isCoatomistic [∀ i, CompleteLattice (π i)] [∀ i, IsCoatomistic (π i)] :
     IsCoatomistic (∀ i, π i) :=

--- a/Mathlib/Order/Cover.lean
+++ b/Mathlib/Order/Cover.lean
@@ -685,7 +685,7 @@ lemma wcovBy_iff_exists_left_eq [Nonempty ι] [DecidableEq ι] :
   · rintro ⟨i, x, h, rfl⟩
     exact ⟨i, by simpa +contextual⟩
 
-lemma covBy_iff_exists_left_eq [Nonempty ι] [DecidableEq ι] :
+lemma covBy_iff_exists_left_eq [DecidableEq ι] :
     a ⋖ b ↔ ∃ i x, x ⋖ b i ∧ a = Function.update b i x := by
   rw [covBy_iff]
   constructor

--- a/Mathlib/Order/Cover.lean
+++ b/Mathlib/Order/Cover.lean
@@ -603,7 +603,7 @@ lemma exists_forall_antisymmRel_of_wcovBy [Nonempty ι] (h : a ⩿ b) :
 A characterisation of the `WCovBy` relation in products of preorders. See `Pi.wcovBy_iff` for the
 (more common) version in products of partial orders.
 -/
-lemma wcovBy_iff' [Nonempty ι] :
+lemma wcovBy_iff_antisymmRel [Nonempty ι] :
     a ⩿ b ↔ ∃ i, a i ⩿ b i ∧ ∀ j ≠ i, AntisymmRel (· ≤ ·) (a j) (b j) := by
   constructor
   · intro h
@@ -625,7 +625,8 @@ lemma wcovBy_iff' [Nonempty ι] :
 A characterisation of the `CovBy` relation in products of preorders. See `Pi.covBy_iff` for the
 (more common) version in products of partial orders.
 -/
-lemma covBy_iff' : a ⋖ b ↔ ∃ i, a i ⋖ b i ∧ ∀ j ≠ i, AntisymmRel (· ≤ ·) (a j) (b j) := by
+lemma covBy_iff_antisymmRel :
+    a ⋖ b ↔ ∃ i, a i ⋖ b i ∧ ∀ j ≠ i, AntisymmRel (· ≤ ·) (a j) (b j) := by
   constructor
   · intro h
     obtain ⟨j, hj⟩ := (Pi.lt_def.1 h.1).2
@@ -635,7 +636,7 @@ lemma covBy_iff' : a ⋖ b ↔ ∃ i, a i ⋖ b i ∧ ∀ j ≠ i, AntisymmRel (
     exact ⟨i, covBy_iff_wcovBy_and_lt.2 ⟨h.wcovBy.eval i, hj⟩, hi⟩
   rintro ⟨i, hi, h⟩
   have : Nonempty ι := ⟨i⟩
-  refine covBy_iff_wcovBy_and_lt.2 ⟨wcovBy_iff'.2 ⟨i, hi.wcovBy, h⟩, ?_⟩
+  refine covBy_iff_wcovBy_and_lt.2 ⟨wcovBy_iff_antisymmRel.2 ⟨i, hi.wcovBy, h⟩, ?_⟩
   exact Pi.lt_def.2 ⟨fun j ↦ (eq_or_ne j i).elim (· ▸ hi.1.le) (h j · |>.1), i, hi.1⟩
 
 end Preorder
@@ -653,10 +654,10 @@ lemma exists_forall_eq_of_wcovBy [Nonempty ι] (h : a ⩿ b) : ∃ i, ∀ j ≠ 
   exact ⟨i, fun j hj ↦ AntisymmRel.eq (hi _ hj)⟩
 
 lemma wcovBy_iff [Nonempty ι] : a ⩿ b ↔ ∃ i, a i ⩿ b i ∧ ∀ j ≠ i, a j = b j := by
-  simp [wcovBy_iff']
+  simp [wcovBy_iff_antisymmRel]
 
 lemma covBy_iff : a ⋖ b ↔ ∃ i, a i ⋖ b i ∧ ∀ j ≠ i, a j = b j := by
-  simp [covBy_iff']
+  simp [covBy_iff_antisymmRel]
 
 lemma wcovBy_iff_exists_right_eq [Nonempty ι] [DecidableEq ι] :
     a ⩿ b ↔ ∃ i x, a i ⩿ x ∧ b = Function.update a i x := by


### PR DESCRIPTION
Characterise the covering relation in products of partial orders.
Generalise this characterisation to products of preorders.
Use the characterisation to significantly simplify the characterisation of atoms in products of partial orders.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
