### PR TITLE
refactor(RingTheory/RingHom): factor out proofs for `Algebra.FinitePresentation`

### DIFF
--- a/Mathlib/RingTheory/FinitePresentation.lean
+++ b/Mathlib/RingTheory/FinitePresentation.lean
@@ -392,6 +392,12 @@ variable {A B C : Type*} [CommRing A] [CommRing B] [CommRing C]
 def FinitePresentation (f : A →+* B) : Prop :=
   @Algebra.FinitePresentation A B _ _ f.toAlgebra
 
+lemma finitePresentation_algebraMap [Algebra A B] :
+    (algebraMap A B).FinitePresentation ↔ Algebra.FinitePresentation A B := by
+  delta FinitePresentation
+  congr!
+  exact Algebra.algebra_ext _ _ fun _ ↦ rfl
+
 namespace FiniteType
 
 theorem of_finitePresentation {f : A →+* B} (hf : f.FinitePresentation) : f.FiniteType :=

--- a/Mathlib/RingTheory/FiniteType.lean
+++ b/Mathlib/RingTheory/FiniteType.lean
@@ -220,6 +220,12 @@ variable {A B C : Type*} [CommRing A] [CommRing B] [CommRing C]
 def FiniteType (f : A →+* B) : Prop :=
   @Algebra.FiniteType A B _ _ f.toAlgebra
 
+lemma finiteType_algebraMap [Algebra A B] :
+    (algebraMap A B).FiniteType ↔ Algebra.FiniteType A B := by
+  delta FiniteType
+  congr!
+  exact Algebra.algebra_ext _ _ fun _ ↦ rfl
+
 namespace Finite
 
 theorem finiteType {f : A →+* B} (hf : f.Finite) : FiniteType f :=

--- a/Mathlib/RingTheory/LocalProperties/Basic.lean
+++ b/Mathlib/RingTheory/LocalProperties/Basic.lean
@@ -200,6 +200,29 @@ theorem RingHom.ofLocalizationSpanTarget_iff_finite :
     obtain ⟨s', h₁, h₂⟩ := (Ideal.span_eq_top_iff_finite s).mp hs
     exact h s' h₂ fun x => hs' ⟨_, h₁ x.prop⟩
 
+open TensorProduct
+
+attribute [local instance] Algebra.TensorProduct.rightAlgebra in
+lemma RingHom.OfLocalizationSpan.mk (hP : RingHom.RespectsIso P)
+    (H : ∀ {R S : Type u} [CommRing R] [CommRing S] [Algebra R S] (s : Set R),
+      Ideal.span s = ⊤ →
+      (∀ r ∈ s, P (algebraMap (Localization.Away r) (Localization.Away r ⊗[R] S))) →
+      P (algebraMap R S)) :
+    OfLocalizationSpan P := by
+  introv R hs hf
+  algebraize [f]
+  let _ := fun r : R => (Localization.awayMap (algebraMap R S) r).toAlgebra
+  refine H s hs (fun r hr ↦ ?_)
+  have : algebraMap (Localization.Away r) (Localization.Away r ⊗[R] S) =
+      ((IsLocalization.Away.tensorRightEquiv S r (Localization.Away r)).symm : _ →+* _).comp
+        (algebraMap (Localization.Away r) (Localization.Away (algebraMap R S r))) := by
+    apply IsLocalization.ringHom_ext (Submonoid.powers r)
+    ext
+    simp [RingHom.algebraMap_toAlgebra, Localization.awayMap, IsLocalization.Away.map,
+      Algebra.TensorProduct.tmul_comm, RingHom.algebraMap_toAlgebra]
+  rw [this]
+  exact hP.1 _ _ (hf ⟨r, hr⟩)
+
 theorem RingHom.HoldsForLocalizationAway.of_bijective
     (H : RingHom.HoldsForLocalizationAway P) (hf : Function.Bijective f) :
     P f := by

--- a/Mathlib/RingTheory/RingHom/Finite.lean
+++ b/Mathlib/RingTheory/RingHom/Finite.lean
@@ -56,8 +56,8 @@ open scoped Pointwise
 
 universe u
 
-variable {R S : Type u} [CommRing R] [CommRing S] (M : Submonoid R) (f : R →+* S)
-variable (R' S' : Type u) [CommRing R'] [CommRing S']
+variable {R S : Type*} [CommRing R] [CommRing S] (M : Submonoid R) (f : R →+* S)
+variable (R' S' : Type*) [CommRing R'] [CommRing S']
 variable [Algebra R R'] [Algebra S S']
 
 lemma Module.Finite_of_isLocalization (R S Rₚ Sₚ) [CommSemiring R] [CommRing S] [CommRing Rₚ]
@@ -110,7 +110,9 @@ theorem RingHom.finite_localizationPreserves : RingHom.LocalizationPreserves @Ri
   have : Module.Finite R S := hf
   apply Module.Finite_of_isLocalization R S R' S' M
 
-theorem RingHom.localization_away_map_finite (r : R) [IsLocalization.Away r R']
+theorem RingHom.localization_away_map_finite (R S R' S' : Type u) [CommRing R] [CommRing S]
+    [Algebra R S] [CommRing R'] [CommRing S'] [Algebra R R'] (f : R →+* S) [Algebra S S']
+    (r : R) [IsLocalization.Away r R']
     [IsLocalization.Away (f r) S'] (hf : f.Finite) : (IsLocalization.Away.map R' S' f r).Finite :=
   finite_localizationPreserves.away f r _ _ hf
 

--- a/Mathlib/RingTheory/RingHom/Finite.lean
+++ b/Mathlib/RingTheory/RingHom/Finite.lean
@@ -111,7 +111,7 @@ theorem RingHom.finite_localizationPreserves : RingHom.LocalizationPreserves @Ri
   apply Module.Finite_of_isLocalization R S R' S' M
 
 theorem RingHom.localization_away_map_finite (R S R' S' : Type u) [CommRing R] [CommRing S]
-    [Algebra R S] [CommRing R'] [CommRing S'] [Algebra R R'] (f : R →+* S) [Algebra S S']
+    [CommRing R'] [CommRing S'] [Algebra R R'] (f : R →+* S) [Algebra S S']
     (r : R) [IsLocalization.Away r R']
     [IsLocalization.Away (f r) S'] (hf : f.Finite) : (IsLocalization.Away.map R' S' f r).Finite :=
   finite_localizationPreserves.away f r _ _ hf

--- a/Mathlib/RingTheory/RingHom/FinitePresentation.lean
+++ b/Mathlib/RingTheory/RingHom/FinitePresentation.lean
@@ -18,49 +18,9 @@ The main result is `RingHom.finitePresentation_isLocal`.
 
 open scoped Pointwise TensorProduct
 
-namespace RingHom
+namespace Algebra.FinitePresentation
 
-attribute [local instance] MvPolynomial.algebraMvPolynomial
-
-/-- Being finitely-presented is preserved by localizations. -/
-theorem finitePresentation_localizationPreserves : LocalizationPreserves @FinitePresentation := by
-  introv R hf
-  letI := f.toAlgebra
-  letI := ((algebraMap S S').comp f).toAlgebra
-  let f' : R' →+* S' := IsLocalization.map S' f M.le_comap_map
-  letI := f'.toAlgebra
-  haveI : IsScalarTower R R' S' :=
-    IsScalarTower.of_algebraMap_eq' (IsLocalization.map_comp M.le_comap_map).symm
-  obtain ⟨n, g, hgsurj, hgker⟩ := hf
-  let MX : Submonoid (MvPolynomial (Fin n) R) :=
-    Algebra.algebraMapSubmonoid (MvPolynomial (Fin n) R) M
-  haveI : IsLocalization MX (MvPolynomial (Fin n) R') :=
-    inferInstanceAs <| IsLocalization (M.map MvPolynomial.C) (MvPolynomial (Fin n) R')
-  haveI : IsScalarTower R S S' := IsScalarTower.of_algebraMap_eq' rfl
-  haveI : IsLocalization (Algebra.algebraMapSubmonoid S M) S' :=
-    inferInstanceAs <| IsLocalization (M.map f) S'
-  let g' : MvPolynomial (Fin n) R' →ₐ[R'] S' := IsLocalization.mapₐ M R' _ S' g
-  let k : RingHom.ker g →ₗ[MvPolynomial (Fin n) R] RingHom.ker g' :=
-    AlgHom.toKerIsLocalization M R' _ S' g
-  have : IsLocalizedModule MX k := AlgHom.toKerIsLocalization_isLocalizedModule M _ _ _ g
-  have : Module.Finite (MvPolynomial (Fin n) R) (ker g) := Module.Finite.iff_fg.mpr hgker
-  exact ⟨n, g', IsLocalization.mapₐ_surjective_of_surjective M R' _ S' g hgsurj,
-    Module.Finite.iff_fg.mp (Module.Finite.of_isLocalizedModule MX k)⟩
-
-/-- Being finitely-presented is stable under composition. -/
-theorem finitePresentation_stableUnderComposition : StableUnderComposition @FinitePresentation := by
-  introv R hf hg
-  exact hg.comp hf
-
-/-- If `R` is a ring, then `Rᵣ` is `R`-finitely-presented for any `r : R`. -/
-theorem finitePresentation_holdsForLocalizationAway :
-    HoldsForLocalizationAway @FinitePresentation := by
-  introv R _
-  suffices Algebra.FinitePresentation R S by
-    rw [RingHom.FinitePresentation]
-    convert this; ext
-    rw [Algebra.smul_def]; rfl
-  exact IsLocalization.Away.finitePresentation r
+variable {R S : Type*} [CommRing R] [CommRing S] [Algebra R S]
 
 /--
 If `S` is an `R`-algebra with a surjection from a finitely-presented `R`-algebra `A`, such that
@@ -70,14 +30,13 @@ This is almost `finitePresentation_ofLocalizationSpanTarget`. The difference is,
 that here the set `t` generates the unit ideal of `A`, while in the general version,
 it only generates a quotient of `A`.
 -/
-lemma finitePresentation_ofLocalizationSpanTarget_aux
-    {R S A : Type*} [CommRing R] [CommRing S] [CommRing A] [Algebra R S] [Algebra R A]
+lemma of_span_eq_top_target_aux {A : Type*} [CommRing A] [Algebra R A]
     [Algebra.FinitePresentation R A] (f : A →ₐ[R] S) (hf : Function.Surjective f)
     (t : Finset A) (ht : Ideal.span (t : Set A) = ⊤)
     (H : ∀ g : t, Algebra.FinitePresentation R (Localization.Away (f g))) :
     Algebra.FinitePresentation R S := by
   apply Algebra.FinitePresentation.of_surjective hf
-  apply ker_fg_of_localizationSpan t ht
+  apply RingHom.ker_fg_of_localizationSpan t ht
   intro g
   let f' : Localization.Away g.val →ₐ[R] Localization.Away (f g) :=
     Localization.awayMapₐ f g.val
@@ -88,16 +47,15 @@ lemma finitePresentation_ofLocalizationSpanTarget_aux
   apply Algebra.FinitePresentation.ker_fG_of_surjective f'
   exact IsLocalization.Away.mapₐ_surjective_of_surjective _ hf
 
+universe u
+
 /-- Finite-presentation can be checked on a standard covering of the target. -/
-theorem finitePresentation_ofLocalizationSpanTarget :
-    OfLocalizationSpanTarget @FinitePresentation := by
-  rw [ofLocalizationSpanTarget_iff_finite]
-  introv R hs H
+lemma of_span_eq_top_target (s : Set S) (hs : Ideal.span (s : Set S) = ⊤)
+    (h : ∀ i ∈ s, Algebra.FinitePresentation R (Localization.Away i)) :
+    Algebra.FinitePresentation R S := by
+  obtain ⟨s, h₁, hs⟩ := (Ideal.span_eq_top_iff_finite s).mp hs
+  replace h (i : s) : Algebra.FinitePresentation R (Localization.Away i.val) := h i (h₁ i.property)
   classical
-  letI := f.toAlgebra
-  replace H : ∀ r : s, Algebra.FinitePresentation R (Localization.Away (r : S)) := by
-    intro r; simp_rw [RingHom.FinitePresentation] at H
-    convert H r; ext; simp_rw [Algebra.smul_def]; rfl
   /-
   We already know that `S` is of finite type over `R`, so we have a surjection
   `MvPolynomial (Fin n) R →ₐ[R] S`. To reason about the kernel, we want to check it on the stalks
@@ -105,13 +63,10 @@ theorem finitePresentation_ofLocalizationSpanTarget :
   we quotient out by an ideal and apply `finitePresentation_ofLocalizationSpanTarget_aux`.
   -/
   have hfintype : Algebra.FiniteType R S := by
-    apply finiteType_ofLocalizationSpanTarget f s hs
-    intro r
-    convert_to Algebra.FiniteType R (Localization.Away r.val)
-    · rw [RingHom.FiniteType]
-      constructor <;> intro h <;> convert h <;> ext <;> simp_rw [Algebra.smul_def] <;> rfl
-    · infer_instance
-  rw [RingHom.FinitePresentation]
+    apply Algebra.FiniteType.of_span_eq_top_target s hs
+    intro x hx
+    have := h ⟨x, hx⟩
+    infer_instance
   obtain ⟨n, f, hf⟩ := Algebra.FiniteType.iff_quotient_mvPolynomial''.mp hfintype
   obtain ⟨l, hl⟩ := (Finsupp.mem_span_iff_linearCombination S (s : Set S) 1).mp
       (show (1 : S) ∈ Ideal.span (s : Set S) by rw [hs]; trivial)
@@ -155,10 +110,59 @@ theorem finitePresentation_ofLocalizationSpanTarget :
     obtain ⟨r, hr, hrr⟩ := this
     simp only [f']
     rw [← hrr, Ideal.Quotient.liftₐ_apply, Ideal.Quotient.lift_mk]
-    simp_rw [coe_coe]
+    simp_rw [RingHom.coe_coe]
     rw [hg']
-    apply H
-  exact finitePresentation_ofLocalizationSpanTarget_aux f' hf' t ht Ht
+    apply h
+  exact of_span_eq_top_target_aux f' hf' t ht Ht
+
+end Algebra.FinitePresentation
+
+namespace RingHom
+
+attribute [local instance] MvPolynomial.algebraMvPolynomial
+
+/-- Being finitely-presented is stable under composition. -/
+theorem finitePresentation_stableUnderComposition : StableUnderComposition @FinitePresentation := by
+  introv R hf hg
+  exact hg.comp hf
+
+/-- Being finitely-presented respects isomorphisms. -/
+theorem finitePresentation_respectsIso : RingHom.RespectsIso @RingHom.FinitePresentation := by
+  refine finitePresentation_stableUnderComposition.respectsIso (fun {R S} _ _ e ↦ ?_)
+  algebraize [e.toRingHom]
+  apply Algebra.FinitePresentation.equiv <| .ofRingEquiv (congrFun rfl)
+
+/-- Being finitely-presented is stable under base change. -/
+theorem finitePresentation_isStableUnderBaseChange :
+    IsStableUnderBaseChange @FinitePresentation := by
+  apply IsStableUnderBaseChange.mk
+  · exact finitePresentation_respectsIso
+  · introv h
+    rw [finitePresentation_algebraMap] at h
+    suffices Algebra.FinitePresentation S (S ⊗[R] T) by
+      rw [RingHom.FinitePresentation]; convert this; ext; simp_rw [Algebra.smul_def]; rfl
+    infer_instance
+
+/-- Being finitely-presented is preserved by localizations. -/
+theorem finitePresentation_localizationPreserves : LocalizationPreserves @FinitePresentation :=
+  finitePresentation_isStableUnderBaseChange.localizationPreserves
+
+/-- If `R` is a ring, then `Rᵣ` is `R`-finitely-presented for any `r : R`. -/
+theorem finitePresentation_holdsForLocalizationAway :
+    HoldsForLocalizationAway @FinitePresentation := by
+  introv R _
+  rw [finitePresentation_algebraMap]
+  exact IsLocalization.Away.finitePresentation r
+
+/-- Finite-presentation can be checked on a standard covering of the target. -/
+theorem finitePresentation_ofLocalizationSpanTarget :
+    OfLocalizationSpanTarget @FinitePresentation := by
+  introv R hs H
+  algebraize [f]
+  replace H : ∀ r ∈ s, Algebra.FinitePresentation R (Localization.Away (r : S)) := by
+    intro r hr; simp_rw [RingHom.FinitePresentation] at H; convert H ⟨r, hr⟩; ext
+    simp_rw [Algebra.smul_def]; rfl
+  exact Algebra.FinitePresentation.of_span_eq_top_target s hs H
 
 /-- Being finitely-presented is a local property of rings. -/
 theorem finitePresentation_isLocal : PropertyIsLocal @FinitePresentation :=
@@ -169,21 +173,5 @@ theorem finitePresentation_isLocal : PropertyIsLocal @FinitePresentation :=
         finitePresentation_holdsForLocalizationAway).left,
     (finitePresentation_stableUnderComposition.stableUnderCompositionWithLocalizationAway
       finitePresentation_holdsForLocalizationAway).right⟩
-
-/-- Being finitely-presented respects isomorphisms. -/
-theorem finitePresentation_respectsIso : RingHom.RespectsIso @RingHom.FinitePresentation :=
-  RingHom.finitePresentation_isLocal.respectsIso
-
-/-- Being finitely-presented is stable under base change. -/
-theorem finitePresentation_isStableUnderBaseChange :
-    IsStableUnderBaseChange @FinitePresentation := by
-  apply IsStableUnderBaseChange.mk
-  · exact finitePresentation_respectsIso
-  · introv h
-    replace h : Algebra.FinitePresentation R T := by
-      rw [RingHom.FinitePresentation] at h; convert h; ext; simp_rw [Algebra.smul_def]; rfl
-    suffices Algebra.FinitePresentation S (S ⊗[R] T) by
-      rw [RingHom.FinitePresentation]; convert this; ext; simp_rw [Algebra.smul_def]; rfl
-    infer_instance
 
 end RingHom

--- a/Mathlib/RingTheory/RingHom/FinitePresentation.lean
+++ b/Mathlib/RingTheory/RingHom/FinitePresentation.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Christian Merten
 -/
 import Mathlib.RingTheory.Localization.Finiteness
-import Mathlib.RingTheory.MvPolynomial.Localization
 import Mathlib.RingTheory.RingHom.FiniteType
 import Mathlib.RingTheory.Localization.Away.AdjoinRoot
 
@@ -118,8 +117,6 @@ lemma of_span_eq_top_target (s : Set S) (hs : Ideal.span (s : Set S) = ⊤)
 end Algebra.FinitePresentation
 
 namespace RingHom
-
-attribute [local instance] MvPolynomial.algebraMvPolynomial
 
 /-- Being finitely-presented is stable under composition. -/
 theorem finitePresentation_stableUnderComposition : StableUnderComposition @FinitePresentation := by

--- a/Mathlib/RingTheory/RingHom/FiniteType.lean
+++ b/Mathlib/RingTheory/RingHom/FiniteType.lean
@@ -198,7 +198,7 @@ theorem finiteType_localizationPreserves : RingHom.LocalizationPreserves @RingHo
   finiteType_isStableUnderBaseChange.localizationPreserves
 
 theorem localization_away_map_finiteType (R S R' S' : Type u) [CommRing R] [CommRing S]
-    [Algebra R S] [CommRing R'] [CommRing S'] [Algebra R R'] (f : R →+* S) [Algebra S S']
+    [CommRing R'] [CommRing S'] [Algebra R R'] (f : R →+* S) [Algebra S S']
     (r : R) [IsLocalization.Away r R']
     [IsLocalization.Away (f r) S'] (hf : f.FiniteType) :
     (IsLocalization.Away.map R' S' f r).FiniteType :=

--- a/Mathlib/RingTheory/RingHom/FiniteType.lean
+++ b/Mathlib/RingTheory/RingHom/FiniteType.lean
@@ -23,66 +23,22 @@ Let `R` be a commutative ring, `S` is an `R`-algebra, `M` be a submonoid of `R`.
 
 -/
 
-
-namespace RingHom
+section Algebra
 
 open scoped Pointwise TensorProduct
 
-universe u
-
-variable {R S : Type u} [CommRing R] [CommRing S] (M : Submonoid R) (f : R →+* S)
-variable (R' S' : Type u) [CommRing R'] [CommRing S']
+variable {R S : Type*} [CommRing R] [CommRing S] [Algebra R S] (M : Submonoid R)
+variable (R' S' : Type*) [CommRing R'] [CommRing S']
 variable [Algebra R R'] [Algebra S S']
 
-theorem finiteType_stableUnderComposition : StableUnderComposition @FiniteType := by
-  introv R hf hg
-  exact hg.comp hf
-
-/-- If `S` is a finite type `R`-algebra, then `S' = M⁻¹S` is a finite type `R' = M⁻¹R`-algebra. -/
-theorem finiteType_localizationPreserves : RingHom.LocalizationPreserves @RingHom.FiniteType := by
-  classical
-  introv R hf
-  -- mirrors the proof of `localization_map_finite`
-  letI := f.toAlgebra
-  letI := ((algebraMap S S').comp f).toAlgebra
-  let f' : R' →+* S' := IsLocalization.map S' f (Submonoid.le_comap_map M)
-  letI := f'.toAlgebra
-  haveI : IsScalarTower R R' S' :=
-    IsScalarTower.of_algebraMap_eq' (IsLocalization.map_comp M.le_comap_map).symm
-  let fₐ : S →ₐ[R] S' := AlgHom.mk' (algebraMap S S') fun c x => RingHom.map_mul _ _ _
-  obtain ⟨T, hT⟩ := hf
-  use T.image (algebraMap S S')
-  rw [eq_top_iff]
-  rintro x -
-  obtain ⟨y, ⟨_, ⟨r, hr, rfl⟩⟩, rfl⟩ := IsLocalization.mk'_surjective (M.map f) x
-  rw [IsLocalization.mk'_eq_mul_mk'_one, mul_comm, Finset.coe_image]
-  have hy : y ∈ Algebra.adjoin R (T : Set S) := by rw [hT]; trivial
-  replace hy : algebraMap S S' y ∈ (Algebra.adjoin R (T : Set S)).map fₐ :=
-    Subalgebra.mem_map.mpr ⟨_, hy, rfl⟩
-  rw [fₐ.map_adjoin T] at hy
-  have H : Algebra.adjoin R (algebraMap S S' '' T) ≤
-      (Algebra.adjoin R' (algebraMap S S' '' T)).restrictScalars R := by
-    rw [Algebra.adjoin_le_iff]; exact Algebra.subset_adjoin
-  convert (Algebra.adjoin R' (algebraMap S S' '' T)).smul_mem (H hy)
-    (IsLocalization.mk' R' (1 : R) ⟨r, hr⟩) using 1
-  rw [Algebra.smul_def]
-  erw [IsLocalization.map_mk' M.le_comap_map]
-  rw [map_one]
-
-theorem localization_away_map_finiteType (r : R) [IsLocalization.Away r R']
-    [IsLocalization.Away (f r) S'] (hf : f.FiniteType) :
-    (IsLocalization.Away.map R' S' f r).FiniteType :=
-  finiteType_localizationPreserves.away _ r _ _ hf
-
-variable {S'}
-
+variable {S'} in
 open scoped Classical in
 /-- Let `S` be an `R`-algebra, `M` a submonoid of `S`, `S' = M⁻¹S`.
 Suppose the image of some `x : S` falls in the adjoin of some finite `s ⊆ S'` over `R`,
 and `A` is an `R`-subalgebra of `S` containing both `M` and the numerators of `s`.
 Then, there exists some `m : M` such that `m • x` falls in `A`.
 -/
-theorem IsLocalization.exists_smul_mem_of_mem_adjoin [Algebra R S] [Algebra R S']
+theorem IsLocalization.exists_smul_mem_of_mem_adjoin [Algebra R S']
     [IsScalarTower R S S'] (M : Submonoid S) [IsLocalization M S'] (x : S) (s : Finset S')
     (A : Subalgebra R S) (hA₁ : (IsLocalization.finsetIntegerMultiple M s : Set S) ⊆ A)
     (hA₂ : M ≤ A.toSubmonoid) (hx : algebraMap S S' x ∈ Algebra.adjoin R (s : Set S')) :
@@ -102,13 +58,14 @@ theorem IsLocalization.exists_smul_mem_of_mem_adjoin [Algebra R S] [Algebra R S'
   rw [Submonoid.smul_def, smul_eq_mul, Submonoid.coe_mul, SubmonoidClass.coe_pow, mul_assoc, ← ha₂,
     mul_comm]
 
+variable {S'} in
 open scoped Classical in
 /-- Let `S` be an `R`-algebra, `M` a submonoid of `R`, and `S' = M⁻¹S`.
 If the image of some `x : S` falls in the adjoin of some finite `s ⊆ S'` over `R`,
 then there exists some `m : M` such that `m • x` falls in the
 adjoin of `IsLocalization.finsetIntegerMultiple _ s` over `R`.
 -/
-theorem IsLocalization.lift_mem_adjoin_finsetIntegerMultiple [Algebra R S] [Algebra R S']
+theorem IsLocalization.lift_mem_adjoin_finsetIntegerMultiple [Algebra R S']
     [IsScalarTower R S S'] [IsLocalization (M.map (algebraMap R S)) S'] (x : S) (s : Finset S')
     (hx : algebraMap S S' x ∈ Algebra.adjoin R (s : Set S')) :
     ∃ m : M, m • x ∈
@@ -120,70 +77,24 @@ theorem IsLocalization.lift_mem_adjoin_finsetIntegerMultiple [Algebra R S] [Alge
   refine ⟨⟨a, ha⟩, ?_⟩
   simpa only [Submonoid.smul_def, algebraMap_smul] using e
 
-theorem finiteType_ofLocalizationSpan : RingHom.OfLocalizationSpan @RingHom.FiniteType := by
+/-- Finite-type can be checked on a standard covering of the target. -/
+lemma Algebra.FiniteType.of_span_eq_top_target (s : Set S) (hs : Ideal.span (s : Set S) = ⊤)
+    (h : ∀ x ∈ s, Algebra.FiniteType R (Localization.Away x)) :
+    Algebra.FiniteType R S := by
+  obtain ⟨s, h₁, hs⟩ := (Ideal.span_eq_top_iff_finite s).mp hs
+  replace h (i : s) : Algebra.FiniteType R (Localization.Away i.val) := h i (h₁ i.property)
   classical
-  rw [RingHom.ofLocalizationSpan_iff_finite]
-  introv R hs H
-  -- mirrors the proof of `finite_ofLocalizationSpan`
-  letI := f.toAlgebra
-  letI := fun r : s => (Localization.awayMap f r).toAlgebra
-  have : ∀ r : s,
-      IsLocalization ((Submonoid.powers (r : R)).map (algebraMap R S)) (Localization.Away (f r)) :=
-    by intro r; rw [Submonoid.map_powers]; exact Localization.isLocalization
-  haveI : ∀ r : s, IsScalarTower R (Localization.Away (r : R)) (Localization.Away (f r)) :=
-    fun r => IsScalarTower.of_algebraMap_eq'
-      (IsLocalization.map_comp (Submonoid.powers (r : R)).le_comap_map).symm
-  constructor
-  replace H := fun r => (H r).1
-  choose s₁ s₂ using H
-  let sf := fun x : s => IsLocalization.finsetIntegerMultiple (Submonoid.powers (f x)) (s₁ x)
-  use s.attach.biUnion sf
-  convert (Algebra.adjoin_attach_biUnion (R := R) sf).trans _
-  rw [eq_top_iff]
-  rintro x -
-  apply (⨆ x : s, Algebra.adjoin R (sf x : Set S)).toSubmodule.mem_of_span_eq_top_of_smul_pow_mem
-    _ hs _ _
-  intro r
-  obtain ⟨⟨_, n₁, rfl⟩, hn₁⟩ :=
-    multiple_mem_adjoin_of_mem_localization_adjoin (Submonoid.powers (r : R))
-      (Localization.Away (r : R)) (s₁ r : Set (Localization.Away (f r)))
-      (algebraMap S (Localization.Away (f r)) x) (by rw [s₂ r]; trivial)
-  rw [Submonoid.smul_def, Algebra.smul_def, IsScalarTower.algebraMap_apply R S, ← map_mul] at hn₁
-  obtain ⟨⟨_, n₂, rfl⟩, hn₂⟩ :=
-    IsLocalization.lift_mem_adjoin_finsetIntegerMultiple (Submonoid.powers (r : R)) _ (s₁ r) hn₁
-  rw [Submonoid.smul_def, ← Algebra.smul_def, smul_smul, ← pow_add] at hn₂
-  simp_rw [Submonoid.map_powers] at hn₂
-  use n₂ + n₁
-  exact le_iSup (fun x : s => Algebra.adjoin R (sf x : Set S)) r hn₂
-
-theorem finiteType_holdsForLocalizationAway : HoldsForLocalizationAway @FiniteType := by
-  introv R _
-  suffices Algebra.FiniteType R S by
-    rw [RingHom.FiniteType]
-    convert this; ext
-    rw [Algebra.smul_def]; rfl
-  exact IsLocalization.finiteType_of_monoid_fg (Submonoid.powers r) S
-
-theorem finiteType_ofLocalizationSpanTarget : OfLocalizationSpanTarget @FiniteType := by
-  -- Setup algebra instances.
-  rw [ofLocalizationSpanTarget_iff_finite]
-  introv R hs H
-  classical
-  letI := f.toAlgebra
-  replace H : ∀ r : s, Algebra.FiniteType R (Localization.Away (r : S)) := by
-    intro r; simp_rw [RingHom.FiniteType] at H; convert H r; ext; simp_rw [Algebra.smul_def]; rfl
-  replace H := fun r => (H r).1
-  constructor
   -- Suppose `s : Finset S` spans `S`, and each `Sᵣ` is finitely generated as an `R`-algebra.
   -- Say `t r : Finset Sᵣ` generates `Sᵣ`. By assumption, we may find `lᵢ` such that
   -- `∑ lᵢ * sᵢ = 1`. I claim that all `s` and `l` and the numerators of `t` and generates `S`.
-  choose t ht using H
+  replace h := fun r => (h r).1
+  choose t ht using h
   obtain ⟨l, hl⟩ :=
     (Finsupp.mem_span_iff_linearCombination S (s : Set S) 1).mp
       (show (1 : S) ∈ Ideal.span (s : Set S) by rw [hs]; trivial)
   let sf := fun x : s => IsLocalization.finsetIntegerMultiple (Submonoid.powers (x : S)) (t x)
   use s.attach.biUnion sf ∪ s ∪ l.support.image l
-  rw [eq_top_iff]
+  rw [_root_.eq_top_iff]
   -- We need to show that every `x` falls in the subalgebra generated by those elements.
   -- Since all `s` and `l` are in the subalgebra, it suffices to check that `sᵢ ^ nᵢ • x` falls in
   -- the algebra for each `sᵢ` and some `nᵢ`.
@@ -219,6 +130,98 @@ theorem finiteType_ofLocalizationSpanTarget : OfLocalizationSpanTarget @FiniteTy
       exact Or.inl (Or.inr r.2)
     · rw [ht]; trivial
 
+attribute [local instance] Algebra.TensorProduct.rightAlgebra in
+lemma Algebra.FiniteType.of_span_eq_top_source (s : Set R) (hs : Ideal.span (s : Set R) = ⊤)
+    (h : ∀ i ∈ s, Algebra.FiniteType (Localization.Away i) (Localization.Away i ⊗[R] S)) :
+    Algebra.FiniteType R S := by
+  obtain ⟨s, h₁, hs⟩ := (Ideal.span_eq_top_iff_finite s).mp hs
+  replace h (i : s) := h i.val (h₁ i.property)
+  classical
+  letI := fun r : s => (Localization.awayMap (algebraMap R S) r).toAlgebra
+  set f := algebraMap R S
+  constructor
+  replace H := fun r => (h r).1
+  choose s₁ s₂ using H
+  let sf := fun x : s => IsLocalization.finsetIntegerMultiple (Submonoid.powers (f x)) (s₁ x)
+  use s.attach.biUnion sf
+  convert (Algebra.adjoin_attach_biUnion (R := R) sf).trans _
+  rw [eq_top_iff]
+  rintro x -
+  apply (⨆ x : s, Algebra.adjoin R (sf x : Set S)).toSubmodule.mem_of_span_eq_top_of_smul_pow_mem
+    _ hs _ _
+  intro r
+  obtain ⟨⟨_, n₁, rfl⟩, hn₁⟩ :=
+    multiple_mem_adjoin_of_mem_localization_adjoin (Submonoid.powers (r : R))
+      (Localization.Away (r : R)) (s₁ r : Set (Localization.Away r.val ⊗[R] S))
+      (algebraMap S _ x) (by rw [s₂ r]; trivial)
+  rw [Submonoid.smul_def, Algebra.smul_def, IsScalarTower.algebraMap_apply R S, ← map_mul] at hn₁
+  obtain ⟨⟨_, n₂, rfl⟩, hn₂⟩ :=
+    IsLocalization.lift_mem_adjoin_finsetIntegerMultiple (Submonoid.powers (r : R)) _ (s₁ r) hn₁
+  rw [Submonoid.smul_def, ← Algebra.smul_def, smul_smul, ← pow_add] at hn₂
+  simp_rw [Submonoid.map_powers] at hn₂
+  use n₂ + n₁
+  exact le_iSup (fun x : s => Algebra.adjoin R (sf x : Set S)) r hn₂
+
+end Algebra
+
+namespace RingHom
+
+open scoped Pointwise TensorProduct
+
+universe u
+
+variable {R S : Type*} [CommRing R] [CommRing S] (M : Submonoid R) (f : R →+* S)
+variable (R' S' : Type*) [CommRing R'] [CommRing S']
+variable [Algebra R R'] [Algebra S S']
+
+theorem finiteType_stableUnderComposition : StableUnderComposition @FiniteType := by
+  introv R hf hg
+  exact hg.comp hf
+
+theorem finiteType_respectsIso : RingHom.RespectsIso @RingHom.FiniteType := by
+  refine finiteType_stableUnderComposition.respectsIso (fun {R S} _ _ e ↦ ?_)
+  algebraize [e.toRingHom]
+  apply Algebra.FiniteType.equiv (inferInstanceAs <| Algebra.FiniteType R R) <|
+    .ofRingEquiv (congrFun rfl)
+
+theorem finiteType_isStableUnderBaseChange : IsStableUnderBaseChange @FiniteType := by
+  apply IsStableUnderBaseChange.mk
+  · exact finiteType_respectsIso
+  · introv h
+    rw [finiteType_algebraMap] at h
+    suffices Algebra.FiniteType S (S ⊗[R] T) by
+      rw [RingHom.FiniteType]; convert this; ext; simp_rw [Algebra.smul_def]; rfl
+    infer_instance
+
+/-- If `S` is a finite type `R`-algebra, then `S' = M⁻¹S` is a finite type `R' = M⁻¹R`-algebra. -/
+theorem finiteType_localizationPreserves : RingHom.LocalizationPreserves @RingHom.FiniteType :=
+  finiteType_isStableUnderBaseChange.localizationPreserves
+
+theorem localization_away_map_finiteType (R S R' S' : Type u) [CommRing R] [CommRing S]
+    [Algebra R S] [CommRing R'] [CommRing S'] [Algebra R R'] (f : R →+* S) [Algebra S S']
+    (r : R) [IsLocalization.Away r R']
+    [IsLocalization.Away (f r) S'] (hf : f.FiniteType) :
+    (IsLocalization.Away.map R' S' f r).FiniteType :=
+  finiteType_localizationPreserves.away _ r _ _ hf
+
+theorem finiteType_ofLocalizationSpan : RingHom.OfLocalizationSpan @RingHom.FiniteType := by
+  refine OfLocalizationSpan.mk _ finiteType_respectsIso (fun s hs h ↦ ?_)
+  simp_rw [finiteType_algebraMap] at h ⊢
+  exact Algebra.FiniteType.of_span_eq_top_source s hs h
+
+theorem finiteType_holdsForLocalizationAway : HoldsForLocalizationAway @FiniteType := by
+  introv R _
+  rw [finiteType_algebraMap]
+  exact IsLocalization.finiteType_of_monoid_fg (Submonoid.powers r) S
+
+theorem finiteType_ofLocalizationSpanTarget : OfLocalizationSpanTarget @FiniteType := by
+  introv R hs H
+  algebraize [f]
+  replace H : ∀ r ∈ s, Algebra.FiniteType R (Localization.Away (r : S)) := by
+    intro r hr; simp_rw [RingHom.FiniteType] at H; convert H ⟨r, hr⟩; ext
+    simp_rw [Algebra.smul_def]; rfl
+  exact Algebra.FiniteType.of_span_eq_top_target s hs H
+
 theorem finiteType_isLocal : PropertyIsLocal @FiniteType :=
   ⟨finiteType_localizationPreserves.away,
     finiteType_ofLocalizationSpanTarget,
@@ -231,17 +234,12 @@ theorem finiteType_isLocal : PropertyIsLocal @FiniteType :=
 @[deprecated (since := "2025-03-01")]
 alias finiteType_is_local := finiteType_isLocal
 
-theorem finiteType_respectsIso : RingHom.RespectsIso @RingHom.FiniteType :=
-  RingHom.finiteType_isLocal.respectsIso
-
-theorem finiteType_isStableUnderBaseChange : IsStableUnderBaseChange @FiniteType := by
-  apply IsStableUnderBaseChange.mk
-  · exact finiteType_respectsIso
-  · introv h
-    replace h : Algebra.FiniteType R T := by
-      rw [RingHom.FiniteType] at h; convert h; ext; simp_rw [Algebra.smul_def]; rfl
-    suffices Algebra.FiniteType S (S ⊗[R] T) by
-      rw [RingHom.FiniteType]; convert this; ext; simp_rw [Algebra.smul_def]; rfl
-    infer_instance
-
 end RingHom
+
+@[deprecated (since := "2025-03-14")]
+alias RingHom.IsLocalization.lift_mem_adjoin_finsetIntegerMultiple :=
+  IsLocalization.lift_mem_adjoin_finsetIntegerMultiple
+
+@[deprecated (since := "2025-03-14")]
+alias RingHom.IsLocalization.exists_smul_mem_of_mem_adjoin :=
+  IsLocalization.exists_smul_mem_of_mem_adjoin

--- a/Mathlib/RingTheory/TensorProduct/Basic.lean
+++ b/Mathlib/RingTheory/TensorProduct/Basic.lean
@@ -885,6 +885,9 @@ lemma comm_comp_includeRight :
 theorem adjoin_tmul_eq_top : adjoin R { t : A ⊗[R] B | ∃ a b, a ⊗ₜ[R] b = t } = ⊤ :=
   top_le_iff.mp <| (top_le_iff.mpr <| span_tmul_eq_top R A B).trans (span_le_adjoin R _)
 
+lemma tmul_comm(r : R) : algebraMap R A r ⊗ₜ[R] 1 = 1 ⊗ₜ algebraMap R B r := by
+  rw [algebraMap_eq_smul_one, algebraMap_eq_smul_one, smul_tmul]
+
 end
 
 section


### PR DESCRIPTION
The current way to use locality of a given property of algebras is to convert everything into the language of `RingHom`s and then for example the `RingHom.OfLocalizationSpanTarget` API. This has two disadvantages:

1. The ring hom property API fixes the universes of source and target to be the same, hence we unnecessarily lose out on some universe generality.
2. The results for `RingHom`s are proven by translating everything in terms of `Algebra`, so we duplicate the translation steps.

This PR refactors `RingHom.FinitePresentation` to do all locality proofs in the language of `Algebra`s and translate it into the corresponding `RingHom.OfLocalizationSpan{Target}` in the last step. We also streamline some of the translation proofs by unifying the API.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->
- [x] depends on: #22931 

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
