### PR TITLE
[Merged by Bors] - refactor(Data/Finsupp/Basic): Extract `Finsupp.curry_uncurry`

### DIFF
--- a/Mathlib/Data/Finsupp/Basic.lean
+++ b/Mathlib/Data/Finsupp/Basic.lean
@@ -1071,23 +1071,20 @@ protected def uncurry (f : α →₀ β →₀ M) : α × β →₀ M :=
 
 @[simp]
 theorem uncurry_apply (f : α →₀ β →₀ M) (x : α) (y : β) : f.uncurry (x, y) = f x y := by
-  have h_curry_apply := curry_apply (f.uncurry) x y
-  have curry_uncurry : f.uncurry.curry = f := by
-    simp only [Finsupp.curry, Finsupp.uncurry, sum_sum_index, sum_zero_index, sum_add_index,
-        sum_single_index, single_zero, single_add, eq_self_iff_true, forall_true_iff,
-        forall₃_true_iff, (single_sum _ _ _).symm, sum_single]
-  simp only [curry_uncurry] at h_curry_apply
-  rw [← h_curry_apply]
+  rw [← curry_apply (f.uncurry) x y]
+  simp only [Finsupp.curry, Finsupp.uncurry, sum_sum_index, single_zero, single_add,
+    forall_true_iff, sum_single_index, single_zero, (single_sum _ _ _).symm,
+    sum_single]
 
 @[simp]
 theorem curry_uncurry (f : α →₀ β →₀ M) : f.uncurry.curry = f := by
   ext a b
-  simp
+  simp only [curry_apply, uncurry_apply]
 
 @[simp]
 theorem uncurry_curry (f : α × β →₀ M) : f.curry.uncurry = f := by
   ext ⟨a, b⟩
-  simp
+  simp only [uncurry_apply, curry_apply]
 
 /-- `finsuppProdEquiv` defines the `Equiv` between `((α × β) →₀ M)` and `(α →₀ (β →₀ M))` given by
 currying and uncurrying. -/

--- a/Mathlib/Data/Finsupp/Basic.lean
+++ b/Mathlib/Data/Finsupp/Basic.lean
@@ -1084,7 +1084,7 @@ theorem curry_uncurry (f : α →₀ β →₀ M) : f.uncurry.curry = f := by
 @[simp]
 theorem uncurry_curry (f : α × β →₀ M) : f.curry.uncurry = f := by
   ext ⟨a, b⟩
-  simp only [Finsupp.uncurry_apply_pair, curry_apply]
+  rw [Finsupp.uncurry_apply_pair, curry_apply]
 
 /-- `finsuppProdEquiv` defines the `Equiv` between `((α × β) →₀ M)` and `(α →₀ (β →₀ M))` given by
 currying and uncurrying. -/

--- a/Mathlib/Data/Finsupp/Basic.lean
+++ b/Mathlib/Data/Finsupp/Basic.lean
@@ -1073,8 +1073,7 @@ protected def uncurry (f : α →₀ β →₀ M) : α × β →₀ M :=
 theorem uncurry_apply (f : α →₀ β →₀ M) (x : α) (y : β) : f.uncurry (x, y) = f x y := by
   rw [← curry_apply (f.uncurry) x y]
   simp only [Finsupp.curry, Finsupp.uncurry, sum_sum_index, single_zero, single_add,
-    forall_true_iff, sum_single_index, single_zero, (single_sum _ _ _).symm,
-    sum_single]
+    forall_true_iff, sum_single_index, single_zero, (single_sum _ _ _).symm, sum_single]
 
 @[simp]
 theorem curry_uncurry (f : α →₀ β →₀ M) : f.uncurry.curry = f := by

--- a/Mathlib/Data/Finsupp/Basic.lean
+++ b/Mathlib/Data/Finsupp/Basic.lean
@@ -1070,7 +1070,8 @@ protected def uncurry (f : α →₀ β →₀ M) : α × β →₀ M :=
   f.sum fun a g => g.sum fun b c => single (a, b) c
 
 @[simp]
-theorem uncurry_apply (f : α →₀ β →₀ M) (x : α) (y : β) : f.uncurry (x, y) = f x y := by
+protected theorem uncurry_apply_pair (f : α →₀ β →₀ M) (x : α) (y : β) :
+    f.uncurry (x, y) = f x y := by
   rw [← curry_apply (f.uncurry) x y]
   simp only [Finsupp.curry, Finsupp.uncurry, sum_sum_index, single_zero, single_add,
     forall_true_iff, sum_single_index, single_zero, ← single_sum, sum_single]
@@ -1078,12 +1079,12 @@ theorem uncurry_apply (f : α →₀ β →₀ M) (x : α) (y : β) : f.uncurry 
 @[simp]
 theorem curry_uncurry (f : α →₀ β →₀ M) : f.uncurry.curry = f := by
   ext a b
-  simp only [curry_apply, uncurry_apply]
+  rw [curry_apply, Finsupp.uncurry_apply_pair]
 
 @[simp]
 theorem uncurry_curry (f : α × β →₀ M) : f.curry.uncurry = f := by
   ext ⟨a, b⟩
-  simp only [uncurry_apply, curry_apply]
+  simp only [Finsupp.uncurry_apply_pair, curry_apply]
 
 /-- `finsuppProdEquiv` defines the `Equiv` between `((α × β) →₀ M)` and `(α →₀ (β →₀ M))` given by
 currying and uncurrying. -/

--- a/Mathlib/Data/Finsupp/Basic.lean
+++ b/Mathlib/Data/Finsupp/Basic.lean
@@ -1069,22 +1069,28 @@ finitely supported functions from `β` to `M`,
 protected def uncurry (f : α →₀ β →₀ M) : α × β →₀ M :=
   f.sum fun a g => g.sum fun b c => single (a, b) c
 
+@[simp]
+theorem curry_uncurry (f : α →₀ β →₀ M) : f.uncurry.curry = f := by
+  simp only [Finsupp.curry, Finsupp.uncurry, sum_sum_index, sum_zero_index, sum_add_index,
+      sum_single_index, single_zero, single_add, eq_self_iff_true, forall_true_iff,
+      forall₃_true_iff, (single_sum _ _ _).symm, sum_single]
+
+@[simp]
+theorem uncurry_curry (f : α × β →₀ M) : f.curry.uncurry = f := by
+  rw [Finsupp.uncurry, sum_curry_index]
+  · simp_rw [Prod.mk.eta, sum_single]
+  · intros
+    apply single_zero
+  · intros
+    apply single_add
+
 /-- `finsuppProdEquiv` defines the `Equiv` between `((α × β) →₀ M)` and `(α →₀ (β →₀ M))` given by
 currying and uncurrying. -/
 def finsuppProdEquiv : (α × β →₀ M) ≃ (α →₀ β →₀ M) where
   toFun := Finsupp.curry
   invFun := Finsupp.uncurry
-  left_inv f := by
-    rw [Finsupp.uncurry, sum_curry_index]
-    · simp_rw [Prod.mk.eta, sum_single]
-    · intros
-      apply single_zero
-    · intros
-      apply single_add
-  right_inv f := by
-    simp only [Finsupp.curry, Finsupp.uncurry, sum_sum_index, sum_zero_index, sum_add_index,
-      sum_single_index, single_zero, single_add, eq_self_iff_true, forall_true_iff,
-      forall₃_true_iff, (single_sum _ _ _).symm, sum_single]
+  left_inv := uncurry_curry
+  right_inv := curry_uncurry
 
 theorem filter_curry (f : α × β →₀ M) (p : α → Prop) [DecidablePred p] :
     (f.filter fun a : α × β => p a.1).curry = f.curry.filter p := by

--- a/Mathlib/Data/Finsupp/Basic.lean
+++ b/Mathlib/Data/Finsupp/Basic.lean
@@ -1070,19 +1070,24 @@ protected def uncurry (f : α →₀ β →₀ M) : α × β →₀ M :=
   f.sum fun a g => g.sum fun b c => single (a, b) c
 
 @[simp]
+theorem uncurry_apply (f : α →₀ β →₀ M) (x : α) (y : β) : f.uncurry (x, y) = f x y := by
+  have h_curry_apply := curry_apply (f.uncurry) x y
+  have curry_uncurry : f.uncurry.curry = f := by
+    simp only [Finsupp.curry, Finsupp.uncurry, sum_sum_index, sum_zero_index, sum_add_index,
+        sum_single_index, single_zero, single_add, eq_self_iff_true, forall_true_iff,
+        forall₃_true_iff, (single_sum _ _ _).symm, sum_single]
+  simp only [curry_uncurry] at h_curry_apply
+  rw [← h_curry_apply]
+
+@[simp]
 theorem curry_uncurry (f : α →₀ β →₀ M) : f.uncurry.curry = f := by
-  simp only [Finsupp.curry, Finsupp.uncurry, sum_sum_index, sum_zero_index, sum_add_index,
-      sum_single_index, single_zero, single_add, eq_self_iff_true, forall_true_iff,
-      forall₃_true_iff, (single_sum _ _ _).symm, sum_single]
+  ext a b
+  simp
 
 @[simp]
 theorem uncurry_curry (f : α × β →₀ M) : f.curry.uncurry = f := by
-  rw [Finsupp.uncurry, sum_curry_index]
-  · simp_rw [Prod.mk.eta, sum_single]
-  · intros
-    apply single_zero
-  · intros
-    apply single_add
+  ext ⟨a, b⟩
+  simp
 
 /-- `finsuppProdEquiv` defines the `Equiv` between `((α × β) →₀ M)` and `(α →₀ (β →₀ M))` given by
 currying and uncurrying. -/

--- a/Mathlib/Data/Finsupp/Basic.lean
+++ b/Mathlib/Data/Finsupp/Basic.lean
@@ -1073,7 +1073,7 @@ protected def uncurry (f : α →₀ β →₀ M) : α × β →₀ M :=
 theorem uncurry_apply (f : α →₀ β →₀ M) (x : α) (y : β) : f.uncurry (x, y) = f x y := by
   rw [← curry_apply (f.uncurry) x y]
   simp only [Finsupp.curry, Finsupp.uncurry, sum_sum_index, single_zero, single_add,
-    forall_true_iff, sum_single_index, single_zero, (single_sum _ _ _).symm, sum_single]
+    forall_true_iff, sum_single_index, single_zero, ← single_sum, sum_single]
 
 @[simp]
 theorem curry_uncurry (f : α →₀ β →₀ M) : f.uncurry.curry = f := by


### PR DESCRIPTION
Refactors the `finsuppProdEquiv` definition so that the inverse laws are now separate (simp) lemmas: `Finsupp.curry_uncurry` and `Finsupp.uncurry_curry`. Also factors out `Finsupp.uncurry_apply_pair` as a prerequisite to these.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
