### PR TITLE
[Merged by Bors] - feat(LinearAlgebra/FreeModule/CardQuotient): compute indices of subgroups via determinant

### DIFF
--- a/Mathlib/LinearAlgebra/Basis/Basic.lean
+++ b/Mathlib/LinearAlgebra/Basis/Basic.lean
@@ -595,6 +595,6 @@ theorem Basis.addSubgroupOfClosure_repr_apply (h : A = .closure (Set.range b)) (
       (b.addSubgroupOfClosure A h).repr.toLinearMap =
         ((b.repr : M →ₗ[R] ι →₀ R).restrictScalars ℤ).domRestrict A.toIntSubmodule by
     exact DFunLike.congr_fun (LinearMap.congr_fun this x) i
-  refine (b.addSubgroupOfClosure A h).ext fun _ ↦ by simp
+  exact (b.addSubgroupOfClosure A h).ext fun _ ↦ by simp
 
 end AddSubgroup

--- a/Mathlib/LinearAlgebra/Basis/Basic.lean
+++ b/Mathlib/LinearAlgebra/Basis/Basic.lean
@@ -567,3 +567,34 @@ theorem Basis.mem_span_iff_repr_mem (m : M) :
   exact smul_mem _ _ (subset_span (Set.mem_range_self i))
 
 end RestrictScalars
+
+section AddSubgroup
+
+variable {M R : Type*} [Ring R] [Nontrivial R] [NoZeroSMulDivisors ℤ R]
+  [AddCommGroup M] [Module R M] (A : AddSubgroup M) {ι : Type*} (b : Basis ι R M)
+
+/--
+Let `A` be an subgroup of an additive commutative group `M` that is also an `R`-module.
+Construct a basis of `A` as a `ℤ`-basis from a `R`-basis of `E` that generates `A`.
+-/
+noncomputable def Basis.addSubgroupOfClosure (h : A = .closure (Set.range b)) :
+    Basis ι ℤ A.toIntSubmodule :=
+  (b.restrictScalars ℤ).map <|
+    LinearEquiv.ofEq _ _
+      (by rw [h, ← Submodule.span_int_eq_addSubgroup_closure, toAddSubgroup_toIntSubmodule])
+
+@[simp]
+theorem Basis.addSubgroupOfClosure_apply (h : A = .closure (Set.range b)) (i : ι) :
+    b.addSubgroupOfClosure A h i = b i := by
+  simp [addSubgroupOfClosure]
+
+@[simp]
+theorem Basis.addSubgroupOfClosure_repr_apply (h : A = .closure (Set.range b)) (x : A) (i : ι) :
+    (b.addSubgroupOfClosure A h).repr x i = b.repr x i := by
+  suffices Finsupp.mapRange.linearMap (Algebra.linearMap ℤ R) ∘ₗ
+      (b.addSubgroupOfClosure A h).repr.toLinearMap =
+        ((b.repr : M →ₗ[R] ι →₀ R).restrictScalars ℤ).domRestrict A.toIntSubmodule by
+    exact DFunLike.congr_fun (LinearMap.congr_fun this x) i
+  refine (b.addSubgroupOfClosure A h).ext fun _ ↦ by simp
+
+end AddSubgroup

--- a/Mathlib/LinearAlgebra/FreeModule/Finite/CardQuotient.lean
+++ b/Mathlib/LinearAlgebra/FreeModule/Finite/CardQuotient.lean
@@ -119,4 +119,3 @@ theorem AddSubgroup.relindex_eq_abs_det {E : Type*} [AddCommGroup E] [Module ℚ
   simp [Basis.toMatrix_apply]
 
 end AddSubgroup
-

--- a/Mathlib/LinearAlgebra/FreeModule/Finite/CardQuotient.lean
+++ b/Mathlib/LinearAlgebra/FreeModule/Finite/CardQuotient.lean
@@ -93,11 +93,30 @@ end Submodule
 
 section AddSubgroup
 
-theorem AddSubgroup.natAbs_det_basis_change {E : Type*} [AddCommGroup E] {ι : Type*}
+theorem AddSubgroup.index_eq_natAbs_det {E : Type*} [AddCommGroup E] {ι : Type*}
     [DecidableEq ι] [Fintype ι] (bE : Basis ι ℤ E) (N : AddSubgroup E) (bN : Basis ι ℤ N) :
-    (bE.det (bN ·)).natAbs = N.index :=
+    N.index = (bE.det (bN ·)).natAbs :=
   have : Module.Free ℤ E := Module.Free.of_basis bE
   have : Module.Finite ℤ E := Module.Finite.of_basis bE
-  Submodule.natAbs_det_basis_change bE N.toIntSubmodule bN
+  (Submodule.natAbs_det_basis_change bE N.toIntSubmodule bN).symm
+
+theorem AddSubgroup.relindex_eq_natAbs_det {E : Type*} [AddCommGroup E]
+    (L₁ L₂ : AddSubgroup E) (H : L₁ ≤ L₂) {ι : Type*} [DecidableEq ι] [Fintype ι]
+    (b₁ : Basis ι ℤ L₁.toIntSubmodule) (b₂ : Basis ι ℤ L₂.toIntSubmodule) :
+    L₁.relindex L₂ = (b₂.det (fun i ↦ ⟨b₁ i, (H (SetLike.coe_mem _))⟩)).natAbs := by
+  rw [relindex, index_eq_natAbs_det b₂ _ (b₁.map (addSubgroupOfEquivOfLe H).toIntLinearEquiv.symm)]
+  rfl
+
+theorem AddSubgroup.relindex_eq_abs_det {E : Type*} [AddCommGroup E] [Module ℚ E]
+    (L₁ L₂ : AddSubgroup E) (H : L₁ ≤ L₂) {ι : Type*} [DecidableEq ι] [Fintype ι]
+    (b₁ b₂ : Basis ι ℚ E) (h₁ : L₁ = .closure (Set.range b₁)) (h₂ : L₂ = .closure (Set.range b₂)) :
+    L₁.relindex L₂ = |b₂.det b₁| := by
+  rw [AddSubgroup.relindex_eq_natAbs_det L₁ L₂ H (b₁.addSubgroupOfClosure L₁ h₁)
+    (b₂.addSubgroupOfClosure L₂ h₂), Nat.cast_natAbs, Int.cast_abs]
+  change |algebraMap ℤ ℚ _| = _
+  rw [Basis.det_apply, Basis.det_apply, RingHom.map_det]
+  congr; ext
+  simp [Basis.toMatrix_apply]
 
 end AddSubgroup
+


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
