### PR TITLE
[Merged by Bors] - chore: drop Algebra.Order.Ring.Nat import from Data.Nat.Count

### DIFF
--- a/Archive/Imo/Imo2024Q3.lean
+++ b/Archive/Imo/Imo2024Q3.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Joseph Myers
 -/
 import Mathlib.Algebra.Order.Sub.Basic
+import Mathlib.Algebra.Ring.Parity
 import Mathlib.Data.Fintype.Pigeonhole
 import Mathlib.Data.Nat.Nth
 import Mathlib.Tactic.ApplyFun

--- a/Mathlib/Data/Nat/Count.lean
+++ b/Mathlib/Data/Nat/Count.lean
@@ -16,7 +16,8 @@ objects, and helping to evaluate it for specific `k`.
 
 -/
 
-assert_not_imported Mathlib.Dynamics.FixedPoints.Basic Mathlib.Algebra.Order.Ring.Nat
+assert_not_imported Mathlib.Dynamics.FixedPoints.Basic
+assert_not_exists Ring
 
 open Finset
 

--- a/Mathlib/Data/Nat/Count.lean
+++ b/Mathlib/Data/Nat/Count.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies, Vladimir Goryachev, Kyle Miller, Kim Morrison, Eric Rodriguez
 -/
 import Mathlib.Algebra.Group.Nat.Range
-import Mathlib.Algebra.Order.Ring.Nat
 import Mathlib.Data.Set.Finite.Basic
 
 /-!
@@ -17,7 +16,7 @@ objects, and helping to evaluate it for specific `k`.
 
 -/
 
-assert_not_imported Mathlib.Dynamics.FixedPoints.Basic
+assert_not_imported Mathlib.Dynamics.FixedPoints.Basic Mathlib.Algebra.Order.Ring.Nat
 
 open Finset
 
@@ -74,7 +73,7 @@ theorem count_add (a b : ℕ) : count p (a + b) = count p a + count (fun k ↦ p
     rw [Finset.disjoint_left]
     simp_rw [mem_map, mem_range, addLeftEmbedding_apply]
     rintro x hx ⟨c, _, rfl⟩
-    exact (self_le_add_right _ _).not_lt hx
+    exact (Nat.le_add_right _ _).not_lt hx
   simp_rw [count_eq_card_filter_range, range_add, filter_union, card_union_of_disjoint this,
     filter_map, addLeftEmbedding, card_map]
   rfl


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
