### PR TITLE
[Merged by Bors] - chore(Ideal/Quotient): change `Fintype` to `Finite`

### DIFF
--- a/Mathlib/LinearAlgebra/FreeModule/Finite/Quotient.lean
+++ b/Mathlib/LinearAlgebra/FreeModule/Finite/Quotient.lean
@@ -86,19 +86,21 @@ noncomputable def quotientEquivPiZMod (N : Submodule ℤ M) (b : Basis ι ℤ M)
     AddEquiv.piCongrRight fun i => ↑(Int.quotientSpanEquivZMod (a i))
   (↑(e : (M ⧸ N) ≃ₗ[ℤ] _) : M ⧸ N ≃+ _).trans e'
 
-/-- A submodule of full rank of a free finite `ℤ`-module has a finite quotient.
-
-Can't be an instance because of the side condition and more importantly,
-because the choice of `Fintype` instance is non-canonical.
+/--
+A submodule of full rank of a free finite `ℤ`-module has a finite quotient.
+It can't be an instance because of the side condition ` Module.finrank ℤ N = Module.finrank ℤ M`.
 -/
-noncomputable def fintypeQuotientOfFreeOfRankEq [Module.Free ℤ M] [Module.Finite ℤ M]
-    (N : Submodule ℤ M) (h : Module.finrank ℤ N = Module.finrank ℤ M) : Fintype (M ⧸ N) := by
+theorem finiteQuotientOfFreeOfRankEq [Module.Free ℤ M] [Module.Finite ℤ M]
+    (N : Submodule ℤ M) (h : Module.finrank ℤ N = Module.finrank ℤ M) : Finite (M ⧸ N) := by
   let b := Module.Free.chooseBasis ℤ M
   let a := smithNormalFormCoeffs b h
   let e := N.quotientEquivPiZMod b h
-  haveI : ∀ i, NeZero (a i).natAbs := fun i =>
+  have : ∀ i, NeZero (a i).natAbs := fun i ↦
     ⟨Int.natAbs_ne_zero.mpr (smithNormalFormCoeffs_ne_zero b h i)⟩
-  classical exact Fintype.ofEquiv (∀ i, ZMod (a i).natAbs) e.symm
+  exact Finite.of_equiv (Π i, ZMod (a i).natAbs) e.symm
+
+@[deprecated (since := "2025-03-15")] alias fintypeQuotientOfFreeOfRankEq :=
+  finiteQuotientOfFreeOfRankEq
 
 variable (F : Type*) [CommRing F] [Algebra F R] [Module F M] [IsScalarTower F R M]
   (b : Basis ι R M) {N : Submodule R M}

--- a/Mathlib/LinearAlgebra/FreeModule/IdealQuotient.lean
+++ b/Mathlib/LinearAlgebra/FreeModule/IdealQuotient.lean
@@ -33,15 +33,17 @@ noncomputable def quotientEquivPiZMod (I : Ideal S) (b : Basis ι ℤ S) (hI : I
     S ⧸ I ≃+ ∀ i, ZMod (I.smithCoeffs b hI i).natAbs :=
   Submodule.quotientEquivPiZMod (I.restrictScalars ℤ) b <| finrank_eq_finrank b I hI
 
-/-- A nonzero ideal over a free finite extension of `ℤ` has a finite quotient.
-
-Can't be an instance because of the side condition `I ≠ ⊥`, and more importantly,
-because the choice of `Fintype` instance is non-canonical.
+/--
+A nonzero ideal over a free finite extension of `ℤ` has a finite quotient.
+It can't be an instance because of the side condition `I ≠ ⊥`.
 -/
-noncomputable def fintypeQuotientOfFreeOfNeBot [Module.Free ℤ S] [Module.Finite ℤ S]
-    (I : Ideal S) (hI : I ≠ ⊥) : Fintype (S ⧸ I) :=
+theorem finiteQuotientOfFreeOfNeBot [Module.Free ℤ S] [Module.Finite ℤ S]
+    (I : Ideal S) (hI : I ≠ ⊥) : Finite (S ⧸ I) :=
   let b := Module.Free.chooseBasis ℤ S
-  Submodule.fintypeQuotientOfFreeOfRankEq (I.restrictScalars ℤ) <| finrank_eq_finrank b I hI
+  Submodule.finiteQuotientOfFreeOfRankEq (I.restrictScalars ℤ) <| finrank_eq_finrank b I hI
+
+@[deprecated (since := "2025-03-15")] alias fintypeQuotientOfFreeOfNeBot :=
+  finiteQuotientOfFreeOfNeBot
 
 variable (F : Type*) [CommRing F] [Algebra F R] [Algebra F S] [IsScalarTower F R S]
   (b : Basis ι R S) {I : Ideal S} (hI : I ≠ ⊥)

--- a/Mathlib/NumberTheory/Cyclotomic/Rat.lean
+++ b/Mathlib/NumberTheory/Cyclotomic/Rat.lean
@@ -179,8 +179,7 @@ lemma coe_toInteger {k : ℕ+} (hζ : IsPrimitiveRoot ζ k) : hζ.toInteger.1 = 
 /-- `𝓞 K ⧸ Ideal.span {ζ - 1}` is finite. -/
 lemma finite_quotient_toInteger_sub_one [NumberField K] {k : ℕ+} (hk : 1 < k)
     (hζ : IsPrimitiveRoot ζ k) : Finite (𝓞 K ⧸ Ideal.span {hζ.toInteger - 1}) := by
-  refine (finite_iff_nonempty_fintype _).2 ⟨?_⟩
-  refine Ideal.fintypeQuotientOfFreeOfNeBot _ (fun h ↦ ?_)
+  refine Ideal.finiteQuotientOfFreeOfNeBot _ (fun h ↦ ?_)
   simp only [Ideal.span_singleton_eq_bot, sub_eq_zero, ← Subtype.coe_inj] at h
   exact hζ.ne_one hk (RingOfIntegers.ext_iff.1 h)
 
@@ -192,7 +191,6 @@ lemma card_quotient_toInteger_sub_one [NumberField K] {k : ℕ+} (hk : 1 < k)
     Nat.card (𝓞 K ⧸ Ideal.span {hζ.toInteger - 1}) =
       (Algebra.norm ℤ (hζ.toInteger - 1)).natAbs := by
   have := hζ.finite_quotient_toInteger_sub_one hk
-  let _ := Fintype.ofFinite (𝓞 K ⧸ Ideal.span {hζ.toInteger - 1})
   rw [← Submodule.cardQuot_apply, ← Ideal.absNorm_apply, Ideal.absNorm_span_singleton]
 
 lemma toInteger_isPrimitiveRoot {k : ℕ+} (hζ : IsPrimitiveRoot ζ k) :
@@ -498,7 +496,7 @@ theorem finite_quotient_span_sub_one [hcycl : IsCyclotomicExtension {p ^ (k + 1)
     (hζ : IsPrimitiveRoot ζ ↑(p ^ (k + 1))) :
     Finite (𝓞 K ⧸ Ideal.span {hζ.toInteger - 1}) := by
   have : NumberField K := IsCyclotomicExtension.numberField {p ^ (k + 1)} ℚ K
-  refine Fintype.finite <| Ideal.fintypeQuotientOfFreeOfNeBot _ (fun h ↦ ?_)
+  refine Ideal.finiteQuotientOfFreeOfNeBot _ (fun h ↦ ?_)
   simp only [Ideal.span_singleton_eq_bot, sub_eq_zero, ← Subtype.coe_inj] at h
   exact hζ.ne_one (one_lt_pow₀ hp.1.one_lt (Nat.zero_ne_add_one k).symm)
     (RingOfIntegers.ext_iff.1 h)

--- a/Mathlib/NumberTheory/Cyclotomic/Rat.lean
+++ b/Mathlib/NumberTheory/Cyclotomic/Rat.lean
@@ -186,11 +186,9 @@ lemma finite_quotient_toInteger_sub_one [NumberField K] {k : ℕ+} (hk : 1 < k)
 /-- We have that `𝓞 K ⧸ Ideal.span {ζ - 1}` has cardinality equal to the norm of `ζ - 1`.
 
 See the results below to compute this norm in various cases. -/
-lemma card_quotient_toInteger_sub_one [NumberField K] {k : ℕ+} (hk : 1 < k)
-    (hζ : IsPrimitiveRoot ζ k) :
+lemma card_quotient_toInteger_sub_one [NumberField K] {k : ℕ+} (hζ : IsPrimitiveRoot ζ k) :
     Nat.card (𝓞 K ⧸ Ideal.span {hζ.toInteger - 1}) =
       (Algebra.norm ℤ (hζ.toInteger - 1)).natAbs := by
-  have := hζ.finite_quotient_toInteger_sub_one hk
   rw [← Submodule.cardQuot_apply, ← Ideal.absNorm_apply, Ideal.absNorm_span_singleton]
 
 lemma toInteger_isPrimitiveRoot {k : ℕ+} (hζ : IsPrimitiveRoot ζ k) :

--- a/Mathlib/NumberTheory/Cyclotomic/Three.lean
+++ b/Mathlib/NumberTheory/Cyclotomic/Three.lean
@@ -131,7 +131,7 @@ lemma lambda_dvd_or_dvd_sub_one_or_dvd_add_one [NumberField K] [IsCyclotomicExte
   let _ : AddGroup (𝓞 K ⧸ Ideal.span {λ}) := AddGroupWithOne.toAddGroup -- ditto
   have := Finset.mem_univ (Ideal.Quotient.mk (Ideal.span {λ}) x)
   have h3 : Fintype.card (𝓞 K ⧸ Ideal.span {λ}) = 3 := by
-    rw [← Nat.card_eq_fintype_card, hζ.card_quotient_toInteger_sub_one (by decide),
+    rw [← Nat.card_eq_fintype_card, hζ.card_quotient_toInteger_sub_one,
       hζ.norm_toInteger_sub_one_of_prime_ne_two' (by decide)]
     simp only [PNat.val_ofNat, Nat.cast_ofNat, Int.reduceAbs]
   rw [Finset.univ_of_card_le_three h3.le] at this

--- a/Mathlib/NumberTheory/NumberField/FinitePlaces.lean
+++ b/Mathlib/NumberTheory/NumberField/FinitePlaces.lean
@@ -49,7 +49,7 @@ lemma one_lt_absNorm : 1 < absNorm v.asIdeal := by
   rw [← absNorm_eq_one_iff]
   have : 0 < absNorm v.asIdeal := by
     rw [Nat.pos_iff_ne_zero, absNorm_ne_zero_iff]
-    exact (v.asIdeal.fintypeQuotientOfFreeOfNeBot v.ne_bot).finite
+    exact v.asIdeal.finiteQuotientOfFreeOfNeBot v.ne_bot
   omega
 
 @[deprecated (since := "2025-02-28")] alias one_lt_norm := one_lt_absNorm

--- a/Mathlib/RingTheory/Ideal/Norm/AbsNorm.lean
+++ b/Mathlib/RingTheory/Ideal/Norm/AbsNorm.lean
@@ -295,7 +295,7 @@ theorem absNorm_span_singleton (r : S) :
   by_cases hr : r = 0
   · simp only [hr, Ideal.span_zero, Algebra.coe_lmul_eq_mul, eq_self_iff_true, Ideal.absNorm_bot,
       LinearMap.det_zero'', Set.singleton_zero, _root_.map_zero, Int.natAbs_zero]
-  letI := Ideal.fintypeQuotientOfFreeOfNeBot (span {r}) (mt span_singleton_eq_bot.mp hr)
+  letI := Ideal.finiteQuotientOfFreeOfNeBot (span {r}) (mt span_singleton_eq_bot.mp hr)
   let b := Module.Free.chooseBasis ℤ S
   rw [← natAbs_det_equiv _ (b.equiv (basisSpanSingleton b hr) (Equiv.refl _))]
   congr


### PR DESCRIPTION
As discussed [here](https://github.com/leanprover-community/mathlib4/pull/22902#discussion_r1995329397)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
