### PR TITLE
[Merged by Bors] - chore(Data): fix performance regressions of #22907

### DIFF
--- a/Mathlib/Data/PFun.lean
+++ b/Mathlib/Data/PFun.lean
@@ -584,7 +584,10 @@ theorem prodMap_id_id : (PFun.id α).prodMap (PFun.id β) = PFun.id _ := by
 
 @[simp]
 theorem prodMap_comp_comp (f₁ : α →. β) (f₂ : β →. γ) (g₁ : δ →. ε) (g₂ : ε →. ι) :
-    (f₂.comp f₁).prodMap (g₂.comp g₁) = (f₂.prodMap g₂).comp (f₁.prodMap g₁) := by
-  aesop
+    (f₂.comp f₁).prodMap (g₂.comp g₁) = (f₂.prodMap g₂).comp (f₁.prodMap g₁) :=
+  -- `aesop` can prove this but takes over a second, so we do it manually
+  ext <| fun ⟨_, _⟩ ⟨_, _⟩ ↦
+  ⟨fun ⟨⟨⟨h1l1, h1l2⟩, ⟨h1r1, h1r2⟩⟩, h2⟩ ↦ ⟨⟨⟨h1l1, h1r1⟩, ⟨h1l2, h1r2⟩⟩, h2⟩,
+   fun ⟨⟨⟨h1l1, h1r1⟩, ⟨h1l2, h1r2⟩⟩, h2⟩ ↦ ⟨⟨⟨h1l1, h1l2⟩, ⟨h1r1, h1r2⟩⟩, h2⟩⟩
 
 end PFun

--- a/Mathlib/Data/Sign.lean
+++ b/Mathlib/Data/Sign.lean
@@ -212,7 +212,11 @@ def cast : SignType → α
   | pos => 1
   | neg => -1
 
-/-- This is a `CoeTail` since the type on the right (trivially) determines the type on the left. -/
+/-- This is a `CoeTail` since the type on the right (trivially) determines the type on the left.
+
+`outParam`-wise it could be a `Coe`, but we don't want to try applying this instance for a
+coercion to any `α`.
+-/
 instance : CoeTail SignType α :=
   ⟨cast⟩
 

--- a/Mathlib/Data/Sign.lean
+++ b/Mathlib/Data/Sign.lean
@@ -212,8 +212,8 @@ def cast : SignType → α
   | pos => 1
   | neg => -1
 
-/-- This is a `Coe` since the type on the right (trivially) determines the type on the left. -/
-instance : Coe SignType α :=
+/-- This is a `CoeTail` since the type on the right (trivially) determines the type on the left. -/
+instance : CoeTail SignType α :=
   ⟨cast⟩
 
 /-- Casting out of `SignType` respects composition with functions preserving `0, 1, -1`. -/


### PR DESCRIPTION
This fixes two major [performance regressions](https://speed.lean-lang.org/mathlib4/run-detail/e7b27246-a3e6-496a-b552-ff4b45c7236e/f033aca78f32c0bef4d264d5576a083d0534330d) I accidentally introduced in #22907: (Thanks to @Kha for spotting them!)

* in `Data.PFun`, `aesop` was very slow to prove a goal, restore manual proof
* in `Data.Sign`, I turned a `CoeTC SignType ɑ` instance into `Coe SignType ɑ` (since `CoeTC` is an implementation detail), but this would mean that for any coercion to `ɑ` we'd try `SignType` as an intermediate step. Instead make it a `CoeTail` so it would only be applied as a fallback.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
