### PR TITLE
[Merged by Bors] - perf: reorder arguments in instance `IsEmpty (∀ x, p x)`

### DIFF
--- a/Mathlib/Logic/IsEmpty.lean
+++ b/Mathlib/Logic/IsEmpty.lean
@@ -43,7 +43,9 @@ protected theorem Function.isEmpty [IsEmpty β] (f : α → β) : IsEmpty α :=
 theorem Function.Surjective.isEmpty [IsEmpty α] {f : α → β} (hf : f.Surjective) : IsEmpty β :=
   ⟨fun y ↦ let ⟨x, _⟩ := hf y; IsEmpty.false x⟩
 
-instance {p : α → Sort*} [h : Nonempty α] [∀ x, IsEmpty (p x)] : IsEmpty (∀ x, p x) :=
+-- Note on type class argument order:
+-- We want type class search to look for `IsEmpty (p x)` instances before `Nonempty α` instances.
+instance {p : α → Sort*} [∀ x, IsEmpty (p x)] [h : Nonempty α] : IsEmpty (∀ x, p x) :=
   h.elim fun x ↦ Function.isEmpty <| Function.eval x
 
 instance PProd.isEmpty_left [IsEmpty α] : IsEmpty (PProd α β) :=


### PR DESCRIPTION
When trying to synthesize `IsEmpty` for a forall where the body is obviously nonempty, type class search can spend a lot of time trying to show that the domain is nonempty. Reordering the arguments changes the order in which type class search attempts to synthesize the arguments. This should speedup failing type class searches.

Following from a [Zulip conversation](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/instances.20that.20match.20unconditionally/near/505787203)[#mathlib4 > instances that match unconditionally @ 💬](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/instances.20that.20match.20unconditionally/near/505787203)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
