### PR TITLE
[Merged by Bors] - perf(GroupTheory/SpecificGroups/KleinFour): scope the Finite instance

### DIFF
--- a/Mathlib/GroupTheory/SpecificGroups/KleinFour.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/KleinFour.lean
@@ -74,6 +74,8 @@ instance {G : Type*} [AddGroup G] [IsAddKleinFour G] : IsKleinFour (Multiplicati
 
 namespace IsKleinFour
 
+/-- This instance is scoped, because it always applies (which makes linting and typeclass inference
+potentially *a lot* slower). -/
 @[to_additive]
 scoped instance instFinite {G : Type*} [Group G] [IsKleinFour G] : Finite G :=
   Nat.finite_of_card_ne_zero <| by norm_num [IsKleinFour.card_four]

--- a/Mathlib/GroupTheory/SpecificGroups/KleinFour.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/KleinFour.lean
@@ -64,20 +64,18 @@ instance : IsKleinFour (DihedralGroup 2) where
   card_four := by simp only [Nat.card_eq_fintype_card]; rfl
   exponent_two := by simp [DihedralGroup.exponent]
 
-instance {G : Type*} [Group G] [IsKleinFour G] :
-    IsAddKleinFour (Additive G) where
+instance {G : Type*} [Group G] [IsKleinFour G] : IsAddKleinFour (Additive G) where
   card_four := by rw [← IsKleinFour.card_four (G := G)]; congr!
   exponent_two := by simp
 
-instance {G : Type*} [AddGroup G] [IsAddKleinFour G] :
-    IsKleinFour (Multiplicative G) where
+instance {G : Type*} [AddGroup G] [IsAddKleinFour G] : IsKleinFour (Multiplicative G) where
   card_four := by rw [← IsAddKleinFour.card_four (G := G)]; congr!
   exponent_two := by simp
 
 namespace IsKleinFour
 
 @[to_additive]
-instance instFinite {G : Type*} [Group G] [IsKleinFour G] : Finite G :=
+scoped instance instFinite {G : Type*} [Group G] [IsKleinFour G] : Finite G :=
   Nat.finite_of_card_ne_zero <| by norm_num [IsKleinFour.card_four]
 
 @[to_additive (attr := simp)]


### PR DESCRIPTION
This instance always applies, meaning searches for a Finite instance will try inferring an Is(Add)KleinFour instance. This is not helpful outside of very specific settings.
Make this instance scoped to the Is(Add)KleinFour namespace.

[Zulip discussion](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/instances.20that.20match.20unconditionally/with/505843540)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
