### PR TITLE
[Merged by Bors] - feat: induction principles for strongly measurable functions

### DIFF
--- a/Mathlib/Data/Set/Function.lean
+++ b/Mathlib/Data/Set/Function.lean
@@ -1399,12 +1399,6 @@ theorem piecewise_range_comp {ι : Sort*} (f : ι → α) [∀ j, Decidable (j �
     (g₁ g₂ : α → β) : (range f).piecewise g₁ g₂ ∘ f = g₁ ∘ f :=
   (piecewise_eqOn ..).comp_eq
 
-lemma piecewise_comp (f g : α → γ) (h : β → α) :
-    haveI : DecidablePred (· ∈ h ⁻¹' s) := @instDecidablePredComp _ (· ∈ s) _ h _;
-    (s.piecewise f g) ∘ h = (h⁻¹' s).piecewise (f ∘ h) (g ∘ h) := by
-  ext x
-  by_cases hx : h x ∈ s <;> simp [hx]
-
 theorem MapsTo.piecewise_ite {s s₁ s₂ : Set α} {t t₁ t₂ : Set β} {f₁ f₂ : α → β}
     [∀ i, Decidable (i ∈ s)] (h₁ : MapsTo f₁ (s₁ ∩ s) (t₁ ∩ t))
     (h₂ : MapsTo f₂ (s₂ ∩ sᶜ) (t₂ ∩ tᶜ)) :

--- a/Mathlib/Data/Set/Function.lean
+++ b/Mathlib/Data/Set/Function.lean
@@ -1399,6 +1399,12 @@ theorem piecewise_range_comp {ι : Sort*} (f : ι → α) [∀ j, Decidable (j �
     (g₁ g₂ : α → β) : (range f).piecewise g₁ g₂ ∘ f = g₁ ∘ f :=
   (piecewise_eqOn ..).comp_eq
 
+lemma piecewise_comp (f g : α → γ) (h : β → α) :
+    haveI : DecidablePred (· ∈ h ⁻¹' s) := @instDecidablePredComp _ (· ∈ s) _ h _;
+    (s.piecewise f g) ∘ h = (h⁻¹' s).piecewise (f ∘ h) (g ∘ h) := by
+  ext x
+  by_cases hx : h x ∈ s <;> simp [hx]
+
 theorem MapsTo.piecewise_ite {s s₁ s₂ : Set α} {t t₁ t₂ : Set β} {f₁ f₂ : α → β}
     [∀ i, Decidable (i ∈ s)] (h₁ : MapsTo f₁ (s₁ ∩ s) (t₁ ∩ t))
     (h₂ : MapsTo f₂ (s₂ ∩ sᶜ) (t₂ ∩ tᶜ)) :

--- a/Mathlib/MeasureTheory/Function/SimpleFunc.lean
+++ b/Mathlib/MeasureTheory/Function/SimpleFunc.lean
@@ -1135,8 +1135,10 @@ addition (of functions with disjoint support).
 
 It is possible to make the hypotheses in `h_add` a bit stronger, and such conditions can be added
 once we need them (for example it is only necessary to consider the case where `g` is a multiple
-of a characteristic function, and that this multiple doesn't appear in the image of `f`) -/
-@[elab_as_elim, induction_eliminator]
+of a characteristic function, and that this multiple doesn't appear in the image of `f`).
+
+To use in an induction proof, the syntax is `induction f using SimpleFunc.induction with`. -/
+@[elab_as_elim]
 protected theorem induction {α γ} [MeasurableSpace α] [AddZeroClass γ] {P : SimpleFunc α γ → Prop}
     (h_ind :
       ∀ (c) {s} (hs : MeasurableSet s),
@@ -1175,7 +1177,10 @@ protected theorem induction {α γ} [MeasurableSpace α] [AddZeroClass γ] {P : 
 
 /-- To prove something for an arbitrary simple function, it suffices to show
 that the property holds for constant functions and that if it holds for `f` and `g` and
-`s` is a measurable set then it holds for `f.piecewise h hs g`. -/
+`s` is a measurable set then it holds for `f.piecewise h hs g`.
+
+To use in an induction proof, the syntax is `induction f with`. -/
+@[induction_eliminator]
 protected theorem induction' {α γ} [MeasurableSpace α] [Nonempty γ] {P : SimpleFunc α γ → Prop}
     (const : ∀ (c), P (SimpleFunc.const _ c))
     (pcw : ∀ ⦃f g : SimpleFunc α γ⦄ {s} (hs : MeasurableSet s), P f → P g →

--- a/Mathlib/MeasureTheory/Function/SimpleFunc.lean
+++ b/Mathlib/MeasureTheory/Function/SimpleFunc.lean
@@ -1175,6 +1175,63 @@ protected theorem induction {α γ} [MeasurableSpace α] [AddMonoid γ] {P : Sim
     · simp [g, piecewise_eq_of_mem _ _ _ hy, -piecewise_eq_indicator]
     · simp [piecewise_eq_of_not_mem _ _ _ hy, -piecewise_eq_indicator]
 
+protected theorem induction' {α γ} [MeasurableSpace α] [Nonempty γ] {P : SimpleFunc α γ → Prop}
+    (ind : ∀ (c), P (SimpleFunc.const _ c))
+    (pcw : ∀ ⦃f g : SimpleFunc α γ⦄ {s} (hs : MeasurableSet s), P f → P g →
+      P (f.piecewise s hs g))
+    (f : SimpleFunc α γ) : P f := by
+  classical
+  generalize h : f.range = s
+  rw [← Finset.coe_inj, SimpleFunc.coe_range] at h
+  induction s using Finset.induction generalizing f with
+  | empty =>
+    rw [Finset.coe_empty, range_eq_empty_iff] at h
+    obtain (c : γ) := Classical.ofNonempty
+    have : f = SimpleFunc.const _ c := by ext x; exact (h.false x).rec
+    rw [this]
+    exact ind c
+  | @insert x s hxs ih =>
+    rw [Finset.coe_insert] at h
+    rcases s.eq_empty_or_nonempty with rfl | hs
+    · rw [Finset.coe_empty, insert_emptyc_eq] at h
+      replace h := range_subset_singleton.1 (subset_of_eq h)
+      simp only [← coe_const, DFunLike.coe_fn_eq] at h
+      rw [h]
+      exact ind x
+    obtain ⟨c, c_s⟩ := hs.exists_mem
+    have mx := f.measurableSet_preimage {x}
+    let F := SimpleFunc.piecewise (f ⁻¹' {x}) mx (SimpleFunc.const _ c) f
+    have PF : P F := by
+      apply ih F
+      simp only [coe_piecewise, coe_const, range_piecewise, Function.const_apply, F]
+      apply antisymm (union_subset _ _) _ <;> intro y
+      · simp only [mem_image, mem_singleton_iff, Finset.mem_coe, and_imp, forall_exists_index]
+        intro _ _ c_y
+        rwa [c_y.symm]
+      · simp only [mem_image, mem_compl_iff, mem_preimage, mem_singleton_iff, Finset.mem_coe,
+          forall_exists_index, and_imp, F]
+        intro z _ z_y
+        rw [← Finset.mem_coe]
+        apply mem_of_mem_insert_of_ne (a := x)
+        · rw [← h, Set.mem_range]
+          exact ⟨z, z_y⟩
+        · rwa [← z_y]
+      · refine fun y_s ↦ .inr ?_
+        have := mem_insert_of_mem x y_s
+        rw [← h, Set.mem_range] at this
+        obtain ⟨z, z_y⟩ := this
+        refine ⟨z, fun z_x ↦ hxs ?_, z_y⟩
+        rwa [← z_x, z_y]
+    have f_F : f = SimpleFunc.piecewise (f ⁻¹' {x}) mx (SimpleFunc.const _ x) F := by
+      ext y
+      rcases or_not (p := y ∈ f ⁻¹' {x}) with y_s | y_s
+      · simp only [coe_piecewise, coe_const, y_s, piecewise_eq_of_mem, Function.const_apply]
+        simp only [mem_preimage, mem_singleton_iff] at y_s
+        exact y_s
+      · simp only [coe_piecewise, coe_const, y_s, not_false_eq_true, piecewise_eq_of_not_mem, F]
+    rw [f_F]
+    exact pcw mx (ind x) PF
+
 /-- In a topological vector space, the addition of a measurable function and a simple function is
 measurable. -/
 theorem _root_.Measurable.add_simpleFunc

--- a/Mathlib/MeasureTheory/Function/SimpleFunc.lean
+++ b/Mathlib/MeasureTheory/Function/SimpleFunc.lean
@@ -1136,7 +1136,7 @@ addition (of functions with disjoint support).
 It is possible to make the hypotheses in `h_add` a bit stronger, and such conditions can be added
 once we need them (for example it is only necessary to consider the case where `g` is a multiple
 of a characteristic function, and that this multiple doesn't appear in the image of `f`) -/
-@[elab_as_elim]
+@[elab_as_elim, induction_eliminator]
 protected theorem induction {α γ} [MeasurableSpace α] [AddMonoid γ] {P : SimpleFunc α γ → Prop}
     (h_ind :
       ∀ (c) {s} (hs : MeasurableSet s),

--- a/Mathlib/MeasureTheory/Function/SimpleFunc.lean
+++ b/Mathlib/MeasureTheory/Function/SimpleFunc.lean
@@ -1137,7 +1137,7 @@ It is possible to make the hypotheses in `h_add` a bit stronger, and such condit
 once we need them (for example it is only necessary to consider the case where `g` is a multiple
 of a characteristic function, and that this multiple doesn't appear in the image of `f`) -/
 @[elab_as_elim, induction_eliminator]
-protected theorem induction {α γ} [MeasurableSpace α] [AddMonoid γ] {P : SimpleFunc α γ → Prop}
+protected theorem induction {α γ} [MeasurableSpace α] [AddZeroClass γ] {P : SimpleFunc α γ → Prop}
     (h_ind :
       ∀ (c) {s} (hs : MeasurableSet s),
         P (SimpleFunc.piecewise s hs (SimpleFunc.const _ c) (SimpleFunc.const _ 0)))

--- a/Mathlib/MeasureTheory/Function/SimpleFunc.lean
+++ b/Mathlib/MeasureTheory/Function/SimpleFunc.lean
@@ -1176,8 +1176,8 @@ protected theorem induction {α γ} [MeasurableSpace α] [AddZeroClass γ] {P : 
     by_cases hy : y ∈ f ⁻¹' {x} <;> simp [g, hy]
 
 /-- To prove something for an arbitrary simple function, it suffices to show
-that the property holds for constant functions and that if it holds for `f` and `g` and
-`s` is a measurable set then it holds for `f.piecewise h hs g`.
+that the property holds for constant functions and that it is closed under piecewise combinations
+of functions.
 
 To use in an induction proof, the syntax is `induction f with`. -/
 @[induction_eliminator]

--- a/Mathlib/MeasureTheory/Function/StronglyMeasurable/Basic.lean
+++ b/Mathlib/MeasureTheory/Function/StronglyMeasurable/Basic.lean
@@ -787,8 +787,8 @@ theorem induction [MeasurableSpace α] [AddZeroClass β] [TopologicalSpace β]
 
 open scoped Classical in
 /-- To prove that a property holds for any strongly measurable function, it is enough to show
-that it holds for constant functions, that it holds for `f` and `g` and `s` is a measurable set
-then it holds for `s.piecewise f g` and that it is closed under addition and pointwise limit.
+that it holds for constant functions and that it is closed under piecewise combination of functions
+and pointwise limits.
 
 To use in an induction proof, the syntax is `induction f, hf with`. -/
 @[induction_eliminator]

--- a/Mathlib/MeasureTheory/Function/StronglyMeasurable/Basic.lean
+++ b/Mathlib/MeasureTheory/Function/StronglyMeasurable/Basic.lean
@@ -790,8 +790,8 @@ open scoped Classical in
 that it holds for constant functions and that it is closed under piecewise combination of functions
 and pointwise limits.
 
-To use in an induction proof, the syntax is `induction f, hf with`. -/
-@[induction_eliminator]
+To use in an induction proof, the syntax is
+`induction f, hf using StronglyMeasurable.induction' with`. -/
 theorem induction' [MeasurableSpace α] [Nonempty β] [TopologicalSpace β]
     {P : (f : α → β) → StronglyMeasurable f → Prop}
     (ind : ∀ (c), P (fun _ ↦ c) stronglyMeasurable_const)

--- a/Mathlib/MeasureTheory/Function/StronglyMeasurable/Basic.lean
+++ b/Mathlib/MeasureTheory/Function/StronglyMeasurable/Basic.lean
@@ -134,24 +134,46 @@ protected theorem tendsto_approx {_ : MeasurableSpace α} (hf : StronglyMeasurab
     ∀ x, Tendsto (fun n => hf.approx n x) atTop (𝓝 (f x)) :=
   hf.choose_spec
 
-/-- To prove that a property holds for any strongly measurable functions, it is enough to show
- that it holds for constant indicator functions of measurable sets and that it is closed under
- addition and pointwise limit. -/
- theorem induction [MeasurableSpace α] [AddZeroClass β] (P : (α → β) → Prop)
-     (ind : ∀ c ⦃s : Set α⦄, MeasurableSet s → P (s.indicator fun _ ↦ c))
-     (add : ∀ ⦃f g : α → β⦄, Disjoint f.support g.support →
-       StronglyMeasurable f → StronglyMeasurable g → P f → P g → P (f + g))
-     (lim : ∀ ⦃f : ℕ → α → β⦄ ⦃g : α → β⦄,
-       (∀ n, StronglyMeasurable (f n)) → (∀ n, P (f n)) → StronglyMeasurable g →
-       (∀ x, Tendsto (f · x) atTop (𝓝 (g x))) → P g)
-     (f : α → β) (hf : StronglyMeasurable f) : P f := by
-   let s := hf.approx
-   have ms n := (s n).stronglyMeasurable
-   have hs x : Tendsto (s · x) atTop (𝓝 (f x)) := hf.tendsto_approx x
-   refine lim ms (fun n ↦ ?_) hf hs
-   induction s n with
-   | h_ind c hs => exact ind c hs
-   | @h_add f g h_supp hf hg => exact add h_supp f.stronglyMeasurable g.stronglyMeasurable hf hg
+/-- To prove that a property holds for any strongly measurable function, it is enough to show
+that it holds for constant indicator functions of measurable sets and that it is closed under
+addition and pointwise limit. -/
+theorem induction [MeasurableSpace α] [AddZeroClass β] (P : (α → β) → Prop)
+    (ind : ∀ c ⦃s : Set α⦄, MeasurableSet s → P (s.indicator fun _ ↦ c))
+    (add : ∀ ⦃f g : α → β⦄, Disjoint f.support g.support →
+      StronglyMeasurable f → StronglyMeasurable g → P f → P g → P (f + g))
+    (lim : ∀ ⦃f : ℕ → α → β⦄ ⦃g : α → β⦄,
+      (∀ n, StronglyMeasurable (f n)) → (∀ n, P (f n)) → StronglyMeasurable g →
+      (∀ x, Tendsto (f · x) atTop (𝓝 (g x))) → P g)
+    (f : α → β) (hf : StronglyMeasurable f) : P f := by
+  let s := hf.approx
+  have ms n := (s n).stronglyMeasurable
+  have hs x : Tendsto (s · x) atTop (𝓝 (f x)) := hf.tendsto_approx x
+  refine lim ms (fun n ↦ ?_) hf hs
+  induction s n with
+  | h_ind c hs => exact ind c hs
+  | @h_add f g h_supp hf hg => exact add h_supp f.stronglyMeasurable g.stronglyMeasurable hf hg
+
+open scoped Classical in
+/-- To prove that a property holds for any strongly measurable function, it is enough to show
+that it holds for constant functions, that it holds for `f` and `g` and `s` is a measurable set
+then it holds for `s.piecewise f g` and that it is closed under addition and pointwise limit. -/
+theorem induction' [MeasurableSpace α] [Nonempty β]
+    (P : (α → β) → Prop) (ind : ∀ (c), P (fun _ ↦ c))
+    (pcw : ∀ ⦃f g : α → β⦄ {s}, MeasurableSet s → StronglyMeasurable f →
+      StronglyMeasurable g → P f → P g → P (s.piecewise f g))
+    (lim : ∀ ⦃f : ℕ → α → β⦄ ⦃g : α → β⦄,
+      (∀ n, StronglyMeasurable (f n)) → (∀ n, P (f n)) → StronglyMeasurable g →
+      (∀ x, Tendsto (f · x) atTop (𝓝 (g x))) → P g)
+    (f : α → β) (hf : StronglyMeasurable f) : P f := by
+  let s := hf.approx
+  have ms n := (s n).stronglyMeasurable
+  have hs x : Tendsto (s · x) atTop (𝓝 (f x)) := hf.tendsto_approx x
+  refine lim ms (fun n ↦ ?_) hf hs
+  induction s n using SimpleFunc.induction' with
+  | const c => exact ind c
+  | @pcw f g s hs Pf Pg =>
+    rw [SimpleFunc.coe_piecewise]
+    exact pcw hs f.stronglyMeasurable g.stronglyMeasurable Pf Pg
 
 /-- Similar to `stronglyMeasurable.approx`, but enforces that the norm of every function in the
 sequence is less than `c` everywhere. If `‖f x‖ ≤ c` this sequence of simple functions verifies

--- a/Mathlib/MeasureTheory/Function/StronglyMeasurable/Basic.lean
+++ b/Mathlib/MeasureTheory/Function/StronglyMeasurable/Basic.lean
@@ -134,6 +134,25 @@ protected theorem tendsto_approx {_ : MeasurableSpace α} (hf : StronglyMeasurab
     ∀ x, Tendsto (fun n => hf.approx n x) atTop (𝓝 (f x)) :=
   hf.choose_spec
 
+/-- To prove that a property holds for any strongly measurable functions, it is enough to show
+ that it holds for constant indicator functions of measurable sets and that it is closed under
+ addition and pointwise limit. -/
+ theorem induction [MeasurableSpace α] [AddZeroClass β] (P : (α → β) → Prop)
+     (ind : ∀ c ⦃s : Set α⦄, MeasurableSet s → P (s.indicator fun _ ↦ c))
+     (add : ∀ ⦃f g : α → β⦄, Disjoint f.support g.support →
+       StronglyMeasurable f → StronglyMeasurable g → P f → P g → P (f + g))
+     (lim : ∀ ⦃f : ℕ → α → β⦄ ⦃g : α → β⦄,
+       (∀ n, StronglyMeasurable (f n)) → (∀ n, P (f n)) → StronglyMeasurable g →
+       (∀ x, Tendsto (f · x) atTop (𝓝 (g x))) → P g)
+     (f : α → β) (hf : StronglyMeasurable f) : P f := by
+   let s := hf.approx
+   have ms n := (s n).stronglyMeasurable
+   have hs x : Tendsto (s · x) atTop (𝓝 (f x)) := hf.tendsto_approx x
+   refine lim ms (fun n ↦ ?_) hf hs
+   induction s n with
+   | h_ind c hs => exact ind c hs
+   | @h_add f g h_supp hf hg => exact add h_supp f.stronglyMeasurable g.stronglyMeasurable hf hg
+
 /-- Similar to `stronglyMeasurable.approx`, but enforces that the norm of every function in the
 sequence is less than `c` everywhere. If `‖f x‖ ≤ c` this sequence of simple functions verifies
 `Tendsto (fun n => hf.approxBounded n x) atTop (𝓝 (f x))`. -/

--- a/Mathlib/MeasureTheory/Function/StronglyMeasurable/Basic.lean
+++ b/Mathlib/MeasureTheory/Function/StronglyMeasurable/Basic.lean
@@ -794,7 +794,7 @@ To use in an induction proof, the syntax is
 `induction f, hf using StronglyMeasurable.induction' with`. -/
 theorem induction' [MeasurableSpace α] [Nonempty β] [TopologicalSpace β]
     {P : (f : α → β) → StronglyMeasurable f → Prop}
-    (ind : ∀ (c), P (fun _ ↦ c) stronglyMeasurable_const)
+    (const : ∀ (c), P (fun _ ↦ c) stronglyMeasurable_const)
     (pcw : ∀ ⦃f g : α → β⦄ {s} (hf : StronglyMeasurable f) (hg : StronglyMeasurable g)
       (hs : MeasurableSet s), P f hf → P g hg → P (s.piecewise f g) (hf.piecewise hs hg))
     (lim : ∀ ⦃f : ℕ → α → β⦄ ⦃g : α → β⦄ (hf : ∀ n, StronglyMeasurable (f n))
@@ -805,7 +805,7 @@ theorem induction' [MeasurableSpace α] [Nonempty β] [TopologicalSpace β]
   refine lim (fun n ↦ (s n).stronglyMeasurable) hf (fun n ↦ ?_) hf.tendsto_approx
   change P (s n) (s n).stronglyMeasurable
   induction s n with
-  | const c => exact ind c
+  | const c => exact const c
   | @pcw f g s hs Pf Pg =>
     simp_rw [SimpleFunc.coe_piecewise]
     exact pcw f.stronglyMeasurable g.stronglyMeasurable hs Pf Pg


### PR DESCRIPTION
Introduce two induction principles for strongly measurable functions. To prove a predicate for all strongly measurable functions it is enough to show that it holds for simple functions and that it is closed under pointwise limits.
To prove a property for simple functions, we can prove that it is true for constant indicators and closed under addition if the codomain is an [AddZeroClass](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Algebra/Group/Defs.html#AddZeroClass) (this is [MeasureTheory.SimpleFunc.induction](https://leanprover-community.github.io/mathlib4_docs/Mathlib/MeasureTheory/Function/SimpleFunc.html#MeasureTheory.SimpleFunc.induction)).

If the codomain is not an `AddZeroClass`, we can prove a property on simple functions by showing that it holds for constant functions and is closed under piecewise combinations of functions. We introduce an induction principle for simple functions following this idea, as well as a corresponding version for strongly measurable functions.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

Co-authored-by: @D-Thomine

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
