### PR TITLE
[Merged by Bors] - feat: torsion-free *monoids*

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -395,6 +395,7 @@ import Mathlib.Algebra.Group.Subsemigroup.Defs
 import Mathlib.Algebra.Group.Subsemigroup.Membership
 import Mathlib.Algebra.Group.Subsemigroup.Operations
 import Mathlib.Algebra.Group.Support
+import Mathlib.Algebra.Group.Torsion
 import Mathlib.Algebra.Group.Translate
 import Mathlib.Algebra.Group.TypeTags.Basic
 import Mathlib.Algebra.Group.TypeTags.Finite

--- a/Mathlib/Algebra/Group/Torsion.lean
+++ b/Mathlib/Algebra/Group/Torsion.lean
@@ -62,4 +62,10 @@ lemma zpow_left_injective : ∀ {n : ℤ}, n ≠ 0 → Injective fun a : G ↦ a
 @[to_additive zsmul_right_inj]
 lemma zpow_left_inj (hn : n ≠ 0) : a ^ n = b ^ n ↔ a = b := (zpow_left_injective hn).eq_iff
 
+/-- Alias of `zpow_left_inj`, for ease of discovery alongside `zsmul_le_zsmul_iff'` and
+`zsmul_lt_zsmul_iff'`. -/
+@[to_additive "Alias of `zsmul_right_inj`, for ease of discovery alongside `zsmul_le_zsmul_iff'` and
+`zsmul_lt_zsmul_iff'`."]
+lemma zpow_eq_zpow_iff' (hn : n ≠ 0) : a ^ n = b ^ n ↔ a = b := zpow_left_inj hn
+
 end Group

--- a/Mathlib/Algebra/Group/Torsion.lean
+++ b/Mathlib/Algebra/Group/Torsion.lean
@@ -1,0 +1,65 @@
+/-
+Copyright (c) 2025 Yaël Dillies, Patrick Luo. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yaël Dillies, Patrick Luo
+-/
+import Mathlib.Algebra.Group.Basic
+import Mathlib.Tactic.Common
+
+/-!
+# Torsion-free monoids and groups
+
+This file defines torsion-free monoids as those monoids `M` for which `n • · : M → M` is injective
+for all non-zero natural number `n`.
+
+## TODO
+
+Replace `Monoid.IsTorsionFree`.
+-/
+
+open Function
+
+variable {M G : Type*}
+
+variable (M) in
+/-- A monoid is `R`-torsion-free if scalar multiplication by every non-zero element `a : R` is
+injective. -/
+@[mk_iff]
+class IsAddTorsionFree [AddMonoid M] where
+  protected nsmul_right_injective ⦃n : ℕ⦄ (hn : n ≠ 0) : Injective fun a : M ↦ n • a
+
+section Monoid
+variable [Monoid M]
+
+variable (M) in
+/-- A monoid is `R`-torsion-free if power by every non-zero element `a : R` is injective. -/
+@[to_additive, mk_iff]
+class IsMulTorsionFree where
+  protected pow_left_injective ⦃n : ℕ⦄ (hn : n ≠ 0) : Injective fun a : M ↦ a ^ n
+
+attribute [to_additive existing] isMulTorsionFree_iff
+
+variable [IsMulTorsionFree M] {n : ℕ} {a b : M}
+
+@[to_additive nsmul_right_injective]
+lemma pow_left_injective (hn : n ≠ 0) : Injective fun a : M ↦ a ^ n :=
+  IsMulTorsionFree.pow_left_injective hn
+
+@[to_additive nsmul_right_inj]
+lemma pow_left_inj (hn : n ≠ 0) : a ^ n = b ^ n ↔ a = b := (pow_left_injective hn).eq_iff
+
+end Monoid
+
+section Group
+variable [Group G] [IsMulTorsionFree G] {n : ℤ} {a b : G}
+
+@[to_additive zsmul_right_injective]
+lemma zpow_left_injective : ∀ {n : ℤ}, n ≠ 0 → Injective fun a : G ↦ a ^ n
+  | (n + 1 : ℕ), _ => by
+    simpa [← Int.natCast_one, ← Int.natCast_add] using pow_left_injective n.succ_ne_zero
+  | .negSucc n, _ => by simpa using inv_injective.comp (pow_left_injective n.succ_ne_zero)
+
+@[to_additive zsmul_right_inj]
+lemma zpow_left_inj (hn : n ≠ 0) : a ^ n = b ^ n ↔ a = b := (zpow_left_injective hn).eq_iff
+
+end Group

--- a/Mathlib/Algebra/Group/Torsion.lean
+++ b/Mathlib/Algebra/Group/Torsion.lean
@@ -4,7 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies, Patrick Luo
 -/
 import Mathlib.Algebra.Group.Basic
-import Mathlib.Tactic.Common
+import Mathlib.Tactic.MinImports
+import Mathlib.Tactic.MkIffOfInductiveProp
 
 /-!
 # Torsion-free monoids and groups

--- a/Mathlib/Algebra/Group/Torsion.lean
+++ b/Mathlib/Algebra/Group/Torsion.lean
@@ -15,7 +15,9 @@ for all non-zero natural number `n`.
 
 ## TODO
 
-Replace `Monoid.IsTorsionFree`.
+Replace `Monoid.IsTorsionFree`, which is mathematically incorrect for monoids which are not groups.
+This probably means we also want to get rid of `NoZeroSMulDivisors`, which is mathematically
+incorrect for the same reason.
 -/
 
 open Function

--- a/Mathlib/Algebra/Order/Group/Basic.lean
+++ b/Mathlib/Algebra/Order/Group/Basic.lean
@@ -3,6 +3,7 @@ Copyright (c) 2015 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Robert Y. Lewis
 -/
+import Mathlib.Algebra.Group.Torsion
 import Mathlib.Algebra.Order.Group.Defs
 import Mathlib.Algebra.Order.Monoid.Unbundled.Pow
 
@@ -117,24 +118,8 @@ lemma zpow_lt_zpow_iff_left (hn : 0 < n) : a ^ n < b ^ n ↔ a < b :=
 
 @[deprecated (since := "2024-11-13")] alias zpow_lt_zpow_iff' := zpow_lt_zpow_iff_left
 
-@[to_additive zsmul_right_injective
-"See also `smul_right_injective`. TODO: provide a `NoZeroSMulDivisors` instance. We can't do
-that here because importing that definition would create import cycles."]
-lemma zpow_left_injective (hn : n ≠ 0) : Injective ((· ^ n) : α → α) := by
-  obtain hn | hn := hn.lt_or_lt
-  · refine fun a b (hab : a ^ n = b ^ n) ↦
-      (zpow_left_strictMono _ <| Int.neg_pos_of_neg hn).injective ?_
-    rw [zpow_neg, zpow_neg, hab]
-  · exact (zpow_left_strictMono _ hn).injective
-
-@[to_additive zsmul_right_inj]
-lemma zpow_left_inj (hn : n ≠ 0) : a ^ n = b ^ n ↔ a = b := (zpow_left_injective hn).eq_iff
-
-/-- Alias of `zpow_left_inj`, for ease of discovery alongside `zsmul_le_zsmul_iff'` and
-`zsmul_lt_zsmul_iff'`. -/
-@[to_additive "Alias of `zsmul_right_inj`, for ease of discovery alongside `zsmul_le_zsmul_iff'` and
-`zsmul_lt_zsmul_iff'`."]
-lemma zpow_eq_zpow_iff' (hn : n ≠ 0) : a ^ n = b ^ n ↔ a = b := zpow_left_inj hn
+@[to_additive]
+instance : IsMulTorsionFree α where pow_left_injective _ hn := (pow_left_strictMono hn).injective
 
 variable (α) in
 /-- A nontrivial densely linear ordered commutative group can't be a cyclic group. -/

--- a/Mathlib/Algebra/Order/Ring/Basic.lean
+++ b/Mathlib/Algebra/Order/Ring/Basic.lean
@@ -157,10 +157,6 @@ lemma pow_le_pow_iff_left (ha : 0 ≤ a) (hb : 0 ≤ b) (hn : n ≠ 0) : a ^ n �
 lemma pow_lt_pow_iff_left (ha : 0 ≤ a) (hb : 0 ≤ b) (hn : n ≠ 0) : a ^ n < b ^ n ↔ a < b :=
   pow_lt_pow_iff_left₀ ha hb hn
 
-@[deprecated pow_left_inj₀ (since := "2024-11-12")]
-lemma pow_left_inj (ha : 0 ≤ a) (hb : 0 ≤ b) (hn : n ≠ 0) : a ^ n = b ^ n ↔ a = b :=
-  pow_left_inj₀ ha hb hn
-
 @[deprecated pow_right_injective₀ (since := "2024-11-12")]
 lemma pow_right_injective (ha₀ : 0 < a) (ha₁ : a ≠ 1) : Injective (a ^ ·) :=
   pow_right_injective₀ ha₀ ha₁

--- a/Mathlib/GroupTheory/Torsion.lean
+++ b/Mathlib/GroupTheory/Torsion.lean
@@ -301,8 +301,14 @@ namespace Monoid
 section Monoid
 variable (G) [Monoid G]
 
-/-- A predicate on a monoid saying that only 1 is of finite order. -/
-@[to_additive "A predicate on an additive monoid saying that only 0 is of finite order."]
+/-- A predicate on a monoid saying that only 1 is of finite order.
+
+This definition is mathematically incorrect for monoids which are not groups.
+Please use `IsMulTorsionFree` instead. -/
+@[to_additive "A predicate on an additive monoid saying that only 0 is of finite order.
+
+This definition is mathematically incorrect for monoids which are not groups.
+Please use `IsAddTorsionFree` instead. "]
 def IsTorsionFree :=
   ∀ g : G, g ≠ 1 → ¬IsOfFinOrder g
 

--- a/Mathlib/NumberTheory/Padics/MahlerBasis.lean
+++ b/Mathlib/NumberTheory/Padics/MahlerBasis.lean
@@ -68,7 +68,7 @@ lemma norm_ascPochhammer_le (k : ℕ) (x : ℤ_[p]) :
 
 /-- The p-adic integers are a binomial ring, i.e. a ring where binomial coefficients make sense. -/
 noncomputable instance instBinomialRing : BinomialRing ℤ_[p] where
-  nsmul_right_injective hn := smul_right_injective ℤ_[p] hn
+  nsmul_right_injective n := smul_right_injective ℤ_[p]
   -- We define `multichoose` as a fraction in `ℚ_[p]` together with a proof that its norm is `≤ 1`.
   multichoose x k := ⟨(ascPochhammer ℤ_[p] k).eval x / (k.factorial : ℚ_[p]), by
     rw [norm_div, div_le_one (by simpa using k.factorial_ne_zero)]

--- a/Mathlib/RingTheory/Binomial.lean
+++ b/Mathlib/RingTheory/Binomial.lean
@@ -3,6 +3,7 @@ Copyright (c) 2023 Scott Carnahan. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Carnahan
 -/
+import Mathlib.Algebra.Group.Torsion
 import Mathlib.Algebra.Polynomial.Smeval
 import Mathlib.Algebra.Ring.NegOnePow
 import Mathlib.GroupTheory.GroupAction.Ring
@@ -65,9 +66,7 @@ open Function Polynomial
 suitable factorials. We define this notion as a mixin for additive commutative monoids with natural
 number powers, but retain the ring name. We introduce `Ring.multichoose` as the uniquely defined
 quotient. -/
-class BinomialRing (R : Type*) [AddCommMonoid R] [Pow R ℕ] where
-  /-- Scalar multiplication by positive integers is injective -/
-  nsmul_right_injective {n : ℕ} (h : n ≠ 0) : Injective (n • · : R → R)
+class BinomialRing (R : Type*) [AddCommMonoid R] [Pow R ℕ] extends IsAddTorsionFree R where
   /-- A multichoose function, giving the quotient of Pochhammer evaluations by factorials. -/
   multichoose : R → ℕ → R
   /-- The `n`th ascending Pochhammer polynomial evaluated at any element is divisible by `n!` -/
@@ -78,11 +77,8 @@ namespace Ring
 
 variable {R : Type*} [AddCommMonoid R] [Pow R ℕ] [BinomialRing R]
 
-theorem nsmul_right_injective {n : ℕ} (h : n ≠ 0) :
-    Injective (n • · : R → R) := BinomialRing.nsmul_right_injective h
-
-theorem nsmul_right_inj {n : ℕ} (h : n ≠ 0) {a b : R} : n • a = n • b ↔ a = b :=
-  (nsmul_right_injective h).eq_iff
+@[deprecated (since := "2025-03-15")] protected alias nsmul_right_injective := nsmul_right_injective
+@[deprecated (since := "2025-03-15")] protected alias nsmul_right_inj := nsmul_right_inj
 
 /-- The multichoose function is the quotient of ascending Pochhammer evaluation by the corresponding
 factorial. When applied to natural numbers, `multichoose k n` describes choosing a multiset of `n`
@@ -225,7 +221,7 @@ section Basic_Instances
 open Polynomial
 
 instance Nat.instBinomialRing : BinomialRing ℕ where
-  nsmul_right_injective hn _ _ hrs := Nat.eq_of_mul_eq_mul_left (Nat.pos_of_ne_zero hn) hrs
+  nsmul_right_injective n hn _ _ := Nat.eq_of_mul_eq_mul_left (by omega)
   multichoose := Nat.multichoose
   factorial_nsmul_multichoose r n := by
     rw [smul_eq_mul, Nat.multichoose_eq r n, ← Nat.descFactorial_eq_factorial_mul_choose,
@@ -238,7 +234,7 @@ def Int.multichoose (n : ℤ) (k : ℕ) : ℤ :=
   | negSucc n => Int.negOnePow k * Nat.choose (n + 1) k
 
 instance Int.instBinomialRing : BinomialRing ℤ where
-  nsmul_right_injective hn _ _ hrs := Int.eq_of_mul_eq_mul_left (Int.ofNat_ne_zero.mpr hn) hrs
+  nsmul_right_injective n hn _ _ := Int.eq_of_mul_eq_mul_left (by omega)
   multichoose := Int.multichoose
   factorial_nsmul_multichoose r k := by
     rw [Int.multichoose.eq_def, nsmul_eq_mul]


### PR DESCRIPTION
Behind this click-baity title, there is the fact that `Monoid.IsTorsionFree` is incorrect for torsion-free monoids. Indeed, if `n ≠ 0` then `∀ a : α, n • a = 0 → a = 0` is equivalent to `∀ a b : α, n • a = n • b → a = b` only if `α` is a group. If `α` is a monoid (possibly even cancellative!), then the `∀ a : α, n • a = 0 → a = 0` condition is quite weak.

This PR introduces this new definition under the names `IsAddTorsionFree`/`IsMulTorsionFree`. Several things to note:
* It is a class, while `Monoid.IsTorsionFree` is not.
* It is outside of the `Monoid`/`AddMonoid` namespace. My thought is that people who care about torsion-free groups will prefer writing `IsAddTorsionFree G` over `Monoid.IsTorsionFree`.
* I am making a new file. This is because the existing definitions talk about order of an element, which is a much more advanced notion than the new one I am offering.
* I am not changing the existing definition in this PR. This will be done in a later PR.

The new imports just come from making `#min_imports` and `mk_iff` available earlier.

From Toric

Co-authored-by: Patrick Luo <m3hgu5t4@gmail.com>


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
