### PR TITLE
[Merged by Bors] - refactor: use a junk value for the analytic order of a non-analytic function

### DIFF
--- a/Mathlib/Analysis/Analytic/Constructions.lean
+++ b/Mathlib/Analysis/Analytic/Constructions.lean
@@ -149,6 +149,10 @@ theorem AnalyticAt.fun_neg (hf : AnalyticAt 𝕜 f x) : AnalyticAt 𝕜 (fun z �
 theorem AnalyticAt.neg (hf : AnalyticAt 𝕜 f x) : AnalyticAt 𝕜 (-f) x :=
   hf.fun_neg
 
+@[simp] lemma analyticAt_neg : AnalyticAt 𝕜 (-f) x ↔ AnalyticAt 𝕜 f x where
+  mp hf := by simpa using hf.neg
+  mpr := .neg
+
 @[deprecated (since := "2025-03-11")] alias AnalyticAt.neg' := AnalyticAt.fun_neg
 
 theorem HasFPowerSeriesWithinOnBall.sub (hf : HasFPowerSeriesWithinOnBall f pf s x r)

--- a/Mathlib/Analysis/Analytic/Order.lean
+++ b/Mathlib/Analysis/Analytic/Order.lean
@@ -11,21 +11,22 @@ import Mathlib.Analysis.Analytic.IsolatedZeros
 This file defines the order of vanishing of an analytic function `f` at a point `z₀`, as an element
 of `ℕ∞`.
 
-TODO: Uniformize API between analytic and meromorphic functions
+## TODO
+
+Uniformize API between analytic and meromorphic functions
 -/
 
 open Filter  Set
 open scoped Topology
 
-variable {𝕜 : Type*} [NontriviallyNormedField 𝕜]
-  {E : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E]
-  {f f₁ f₂ g : 𝕜 → E} {n : ℕ} {z₀ : 𝕜}
+variable {𝕜 E : Type*} [NontriviallyNormedField 𝕜] [NormedAddCommGroup E] [NormedSpace 𝕜 E]
 
 /-!
 ## Vanishing Order at a Point: Definition and Characterization
 -/
 
-namespace AnalyticAt
+section NormedSpace
+variable {f g : 𝕜 → E} {n : ℕ} {z₀ : 𝕜}
 
 open scoped Classical in
 
@@ -33,26 +34,48 @@ open scoped Classical in
 
 The order is defined to be `∞` if `f` is identically 0 on a neighbourhood of `z₀`, and otherwise the
 unique `n` such that `f` can locally be written as `f z = (z - z₀) ^ n • g z`, where `g` is analytic
-and does not vanish at `z₀`. See `AnalyticAt.order_eq_top_iff` and `AnalyticAt.order_eq_nat_iff` for
-these equivalences. -/
-noncomputable def order (hf : AnalyticAt 𝕜 f z₀) : ENat :=
-  if h : ∀ᶠ z in 𝓝 z₀, f z = 0 then ⊤
-  else ↑(hf.exists_eventuallyEq_pow_smul_nonzero_iff.mpr h).choose
+and does not vanish at `z₀`. See `AnalyticAt.eanalyticOrderAt_eq_top` and
+`AnalyticAt.eanalyticOrderAt_eq_natCast` for these equivalences. -/
+noncomputable def eanalyticOrderAt (f : 𝕜 → E) (z₀ : 𝕜) : ℕ∞ :=
+  if hf : AnalyticAt 𝕜 f z₀ then
+    if h : ∀ᶠ z in 𝓝 z₀, f z = 0 then ⊤
+    else ↑(hf.exists_eventuallyEq_pow_smul_nonzero_iff.mpr h).choose
+  else 0
+
+/-- The order of vanishing of `f` at `z₀`, as an element of `ℕ∞`.
+
+The order is defined to be `∞` if `f` is identically 0 on a neighbourhood of `z₀`, and otherwise the
+unique `n` such that `f` can locally be written as `f z = (z - z₀) ^ n • g z`, where `g` is analytic
+and does not vanish at `z₀`. See `AnalyticAt.eanalyticOrderAt_eq_top` and
+`AnalyticAt.eanalyticOrderAt_eq_natCast` for these equivalences. -/
+noncomputable def analyticOrderAt (f : 𝕜 → E) (z₀ : 𝕜) : ℕ := (eanalyticOrderAt f z₀).toNat
+
+@[simp]
+lemma eanalyticOrderAt_of_not_analyticAt (hf : ¬ AnalyticAt 𝕜 f z₀) : eanalyticOrderAt f z₀ = 0 :=
+  dif_neg hf
+
+@[simp]
+lemma analyticOrderAt_of_not_analyticAt (hf : ¬ AnalyticAt 𝕜 f z₀) : analyticOrderAt f z₀ = 0 := by
+  simp [analyticOrderAt, hf]
+
+@[simp] lemma Nat.cast_analyticOrderAt (hf : eanalyticOrderAt f z₀ ≠ ⊤) :
+    analyticOrderAt f z₀ = eanalyticOrderAt f z₀ := ENat.coe_toNat hf
+
+lemma eanalyticOrderAt_eq_top :
+    eanalyticOrderAt f z₀ = ⊤ ↔ AnalyticAt 𝕜 f z₀ ∧ ∀ᶠ z in 𝓝 z₀, f z = 0 := by
+  unfold eanalyticOrderAt; split_ifs with hf h <;> simp [*]
 
 /-- The order of an analytic function `f` at a `z₀` is infinity iff `f` vanishes locally around
 `z₀`. -/
-lemma order_eq_top_iff (hf : AnalyticAt 𝕜 f z₀) : hf.order = ⊤ ↔ ∀ᶠ z in 𝓝 z₀, f z = 0 := by
-  unfold order
-  split_ifs with h
-  · rwa [eq_self, true_iff]
-  · simpa only [ne_eq, ENat.coe_ne_top, false_iff] using h
+protected lemma AnalyticAt.eanalyticOrderAt_eq_top (hf : AnalyticAt 𝕜 f z₀) :
+    eanalyticOrderAt f z₀ = ⊤ ↔ ∀ᶠ z in 𝓝 z₀, f z = 0 := by simp [eanalyticOrderAt_eq_top, hf]
 
 /-- The order of an analytic function `f` at `z₀` equals a natural number `n` iff `f` can locally
 be written as `f z = (z - z₀) ^ n • g z`, where `g` is analytic and does not vanish at `z₀`. -/
-lemma order_eq_nat_iff {n : ℕ} (hf : AnalyticAt 𝕜 f z₀) :
-    hf.order = ↑n ↔
-    ∃ (g : 𝕜 → E), AnalyticAt 𝕜 g z₀ ∧ g z₀ ≠ 0 ∧ ∀ᶠ z in 𝓝 z₀, f z = (z - z₀) ^ n • g z := by
-  unfold order
+lemma AnalyticAt.eanalyticOrderAt_eq_natCast (hf : AnalyticAt 𝕜 f z₀) :
+    eanalyticOrderAt f z₀ = n ↔
+      ∃ (g : 𝕜 → E), AnalyticAt 𝕜 g z₀ ∧ g z₀ ≠ 0 ∧ ∀ᶠ z in 𝓝 z₀, f z = (z - z₀) ^ n • g z := by
+  unfold eanalyticOrderAt
   split_ifs with h
   · simp only [ENat.top_ne_coe, false_iff]
     contrapose! h
@@ -60,42 +83,63 @@ lemma order_eq_nat_iff {n : ℕ} (hf : AnalyticAt 𝕜 f z₀) :
     exact ⟨n, h⟩
   · rw [← hf.exists_eventuallyEq_pow_smul_nonzero_iff] at h
     refine ⟨fun hn ↦ (WithTop.coe_inj.mp hn : h.choose = n) ▸ h.choose_spec, fun h' ↦ ?_⟩
-    rw [unique_eventuallyEq_pow_smul_nonzero h.choose_spec h']
+    rw [AnalyticAt.unique_eventuallyEq_pow_smul_nonzero h.choose_spec h']
+
+/-- The order of an analytic function `f` at `z₀` equals a natural number `n` iff `f` can locally
+be written as `f z = (z - z₀) ^ n • g z`, where `g` is analytic and does not vanish at `z₀`. -/
+lemma AnalyticAt.analyticOrderAt_eq_iff (hf : AnalyticAt 𝕜 f z₀) (hf' : eanalyticOrderAt f z₀ ≠ ⊤)
+    {n : ℕ} :
+    analyticOrderAt f z₀ = n ↔
+      ∃ (g : 𝕜 → E), AnalyticAt 𝕜 g z₀ ∧ g z₀ ≠ 0 ∧ ∀ᶠ z in 𝓝 z₀, f z = (z - z₀) ^ n • g z := by
+  simp [← Nat.cast_inj (R := ℕ∞), Nat.cast_analyticOrderAt hf', hf.eanalyticOrderAt_eq_natCast]
 
 /-- The order of an analytic function `f` at `z₀` is finite iff `f` can locally be written as `f z =
-  (z - z₀) ^ order • g z`, where `g` is analytic and does not vanish at `z₀`.
+  (z - z₀) ^ analyticOrderAt f z₀ • g z`, where `g` is analytic and does not vanish at `z₀`.
 
 See `MeromorphicNFAt.order_eq_zero_iff` for an analogous statement about meromorphic functions in
 normal form.
 -/
-lemma order_ne_top_iff (hf : AnalyticAt 𝕜 f z₀) :
-    hf.order ≠ ⊤ ↔ ∃ (g : 𝕜 → E), AnalyticAt 𝕜 g z₀ ∧ g z₀ ≠ 0
-      ∧ f =ᶠ[𝓝 z₀] fun z ↦ (z - z₀) ^ (hf.order.toNat) • g z := by
-  simp only [← ENat.coe_toNat_eq_self, Eq.comm, EventuallyEq, ← hf.order_eq_nat_iff]
+lemma AnalyticAt.eanalyticOrderAt_ne_top (hf : AnalyticAt 𝕜 f z₀) :
+    eanalyticOrderAt f z₀ ≠ ⊤ ↔
+      ∃ (g : 𝕜 → E), AnalyticAt 𝕜 g z₀ ∧ g z₀ ≠ 0 ∧
+        f =ᶠ[𝓝 z₀] fun z ↦ (z - z₀) ^ analyticOrderAt f z₀ • g z := by
+  simp only [← ENat.coe_toNat_eq_self, Eq.comm, EventuallyEq, ← hf.eanalyticOrderAt_eq_natCast,
+    analyticOrderAt]
 
 @[deprecated (since := "2025-02-03")]
-alias order_neq_top_iff := order_ne_top_iff
+alias order_neq_top_iff := AnalyticAt.eanalyticOrderAt_ne_top
+
+lemma eanalyticOrderAt_eq_zero : eanalyticOrderAt f z₀ = 0 ↔ ¬ AnalyticAt 𝕜 f z₀ ∨ f z₀ ≠ 0 := by
+  by_cases hf : AnalyticAt 𝕜 f z₀
+  · rw [← ENat.coe_zero, hf.eanalyticOrderAt_eq_natCast]
+    constructor
+    · intro ⟨g, _, _, hg⟩
+      simpa [hf, hg.self_of_nhds]
+    · exact fun hz ↦ ⟨f, hf, hz.resolve_left <| not_not_intro hf, by simp⟩
+  · simp [hf]
+
+lemma eanalyticOrderAt_ne_zero : eanalyticOrderAt f z₀ ≠ 0 ↔ AnalyticAt 𝕜 f z₀ ∧ f z₀ = 0 := by
+  simp [eanalyticOrderAt_eq_zero]
 
 /-- The order of an analytic function `f` at `z₀` is zero iff `f` does not vanish at `z₀`. -/
-lemma order_eq_zero_iff (hf : AnalyticAt 𝕜 f z₀) :
-    hf.order = 0 ↔ f z₀ ≠ 0 := by
-  rw [← ENat.coe_zero, hf.order_eq_nat_iff]
-  constructor
-  · intro ⟨g, _, _, hg⟩
-    simpa [hg.self_of_nhds]
-  · exact fun hz ↦ ⟨f, hf, hz, by simp⟩
+protected lemma AnalyticAt.eanalyticOrderAt_eq_zero (hf : AnalyticAt 𝕜 f z₀) :
+    eanalyticOrderAt f z₀ = 0 ↔ f z₀ ≠ 0 := by simp [hf, eanalyticOrderAt_eq_zero]
+
+/-- The order of an analytic function `f` at `z₀` is zero iff `f` does not vanish at `z₀`. -/
+protected lemma AnalyticAt.eanalyticOrderAt_ne_zero (hf : AnalyticAt 𝕜 f z₀) :
+    eanalyticOrderAt f z₀ ≠ 0 ↔ f z₀ = 0 := hf.eanalyticOrderAt_eq_zero.not_left
 
 /-- An analytic function vanishes at a point if its order is nonzero when converted to ℕ. -/
-lemma apply_eq_zero_of_order_toNat_ne_zero (hf : AnalyticAt 𝕜 f z₀) :
-    hf.order.toNat ≠ 0 → f z₀ = 0 := by
-  simp [hf.order_eq_zero_iff]
-  tauto
+lemma apply_eq_zero_of_analyticOrderAt_ne_zero (hf : analyticOrderAt f z₀ ≠ 0) : f z₀ = 0 := by
+  by_cases hf' : AnalyticAt 𝕜 f z₀ <;> simp_all [analyticOrderAt, eanalyticOrderAt_eq_zero]
+
 
 /-- Characterization of which natural numbers are `≤ hf.order`. Useful for avoiding case splits,
 since it applies whether or not the order is `∞`. -/
-lemma natCast_le_order_iff (hf : AnalyticAt 𝕜 f z₀) {n : ℕ} :
-    n ≤ hf.order ↔ ∃ g, AnalyticAt 𝕜 g z₀ ∧ ∀ᶠ z in 𝓝 z₀, f z = (z - z₀) ^ n • g z := by
-  unfold order
+lemma natCast_le_eanalyticOrderAt (hf : AnalyticAt 𝕜 f z₀) {n : ℕ} :
+    n ≤ eanalyticOrderAt f z₀ ↔
+      ∃ g, AnalyticAt 𝕜 g z₀ ∧ ∀ᶠ z in 𝓝 z₀, f z = (z - z₀) ^ n • g z := by
+  unfold eanalyticOrderAt
   split_ifs with h
   · simpa using ⟨0, analyticAt_const .., by simpa⟩
   · let m := (hf.exists_eventuallyEq_pow_smul_nonzero_iff.mpr h).choose
@@ -115,100 +159,138 @@ lemma natCast_le_order_iff (hf : AnalyticAt 𝕜 f z₀) {n : ℕ} :
         rw [pow_sub₀ _ (sub_ne_zero_of_ne hz) (by omega), ← hf']
 
 /-- If two functions agree in a neighborhood of `z₀`, then their orders at `z₀` agree. -/
-theorem order_congr (hf₁ : AnalyticAt 𝕜 f₁ z₀) (h : f₁ =ᶠ[𝓝 z₀] f₂) :
-    (hf₁.congr h).order = hf₁.order := by
-  refine ENat.eq_of_forall_natCast_le_iff fun n ↦ ?_
-  simpa only [natCast_le_order_iff] using ⟨fun ⟨g, hg, hfg⟩ ↦ ⟨g, hg, h.trans hfg⟩,
-    fun ⟨g, hg, hfg⟩ ↦ ⟨g, hg, h.symm.trans hfg⟩⟩
+lemma eanalyticOrderAt_congr (hfg : f =ᶠ[𝓝 z₀] g) :
+    eanalyticOrderAt f z₀ = eanalyticOrderAt g z₀ := by
+  by_cases hf : AnalyticAt 𝕜 f z₀
+  · refine ENat.eq_of_forall_natCast_le_iff fun n ↦ ?_
+    simp only [natCast_le_eanalyticOrderAt, hf, hf.congr hfg]
+    congr! 3
+    exact hfg.congr_left
+  · rw [eanalyticOrderAt_of_not_analyticAt hf,
+      eanalyticOrderAt_of_not_analyticAt fun hg ↦ hf <| hg.congr hfg.symm]
+
+lemma eanalyticOrderAt_smul_eq_top_of_left {f : 𝕜 → 𝕜} (hg : AnalyticAt 𝕜 g z₀)
+    (hf : eanalyticOrderAt f z₀ = ⊤) : eanalyticOrderAt (f • g) z₀ = ⊤ := by
+  rw [eanalyticOrderAt_eq_top, eventually_nhds_iff] at *
+  obtain ⟨hf, t, h₁t, h₂t, h₃t⟩ := hf
+  exact ⟨hf.smul hg, t, fun y hy ↦ by simp [h₁t y hy], h₂t, h₃t⟩
+
+lemma eanalyticOrderAt_smul_eq_top_of_right {f : 𝕜 → 𝕜} (hf : AnalyticAt 𝕜 f z₀)
+    (hg : eanalyticOrderAt g z₀ = ⊤) : eanalyticOrderAt (f • g) z₀ = ⊤ := by
+  rw [eanalyticOrderAt_eq_top, eventually_nhds_iff] at *
+  obtain ⟨hg, t, h₁t, h₂t, h₃t⟩ := hg
+  exact ⟨hf.smul hg, t, fun y hy ↦ by simp [h₁t y hy], h₂t, h₃t⟩
+
+/-- The order is additive when scalar multiplying analytic functions. -/
+lemma eanalyticOrderAt_smul {f : 𝕜 → 𝕜} (hf : AnalyticAt 𝕜 f z₀) (hg : AnalyticAt 𝕜 g z₀) :
+    eanalyticOrderAt (f • g) z₀ = eanalyticOrderAt f z₀ + eanalyticOrderAt g z₀ := by
+  -- Trivial cases: one of the functions vanishes around z₀
+  by_cases hf' : eanalyticOrderAt f z₀ = ⊤
+  · simp [eanalyticOrderAt_smul_eq_top_of_left, *]
+  by_cases hg' : eanalyticOrderAt g z₀ = ⊤
+  · simp [eanalyticOrderAt_smul_eq_top_of_right, *]
+  -- Non-trivial case: both functions do not vanish around z₀
+  obtain ⟨f', h₁f', h₂f', h₃f'⟩ := hf.eanalyticOrderAt_ne_top.1 hf'
+  obtain ⟨g', h₁g', h₂g', h₃g'⟩ := hg.eanalyticOrderAt_ne_top.1 hg'
+  rw [← Nat.cast_analyticOrderAt hf', ← Nat.cast_analyticOrderAt hg', ← ENat.coe_add,
+      (hf.smul hg).eanalyticOrderAt_eq_natCast]
+  refine ⟨f' • g', h₁f'.smul h₁g', ?_, ?_⟩
+  · simp
+    tauto
+  · obtain ⟨t, h₁t, h₂t, h₃t⟩ := eventually_nhds_iff.1 h₃f'
+    obtain ⟨s, h₁s, h₂s, h₃s⟩ := eventually_nhds_iff.1 h₃g'
+    exact eventually_nhds_iff.2
+      ⟨t ∩ s, fun y hy ↦ (by simp [h₁t y hy.1, h₁s y hy.2]; module), h₂t.inter h₂s, h₃t, h₃s⟩
+
+end NormedSpace
 
 /-!
 ## Vanishing Order at a Point: Elementary Computations
 -/
 
-/-- Helper lemma, required to state analyticAt_order_centeredMonomial below -/
-lemma analyticAt_centeredMonomial (z₀ : 𝕜) (n : ℕ) :
-    AnalyticAt 𝕜 ((· - z₀) ^ n) z₀ := by fun_prop
-
 /-- Simplifier lemma for the order of a centered monomial -/
 @[simp]
-lemma analyticAt_order_centeredMonomial {z₀ : 𝕜} {n : ℕ} :
-    (analyticAt_centeredMonomial z₀ n).order = n := by
-  rw [AnalyticAt.order_eq_nat_iff]
-  use 1
-  simp only [Pi.one_apply, ne_eq, one_ne_zero, not_false_eq_true, Pi.pow_apply, smul_eq_mul,
-    mul_one, eventually_true, and_self, and_true]
-  exact analyticAt_const
+lemma eanalyticOrderAt_centeredMonomial {z₀ : 𝕜} {n : ℕ} :
+    eanalyticOrderAt ((· - z₀) ^ n) z₀ = n := by
+  rw [AnalyticAt.eanalyticOrderAt_eq_natCast (by fun_prop)]
+  exact ⟨1, by simp [Pi.one_def, analyticAt_const]⟩
 
-/-!
-## Vanishing Order at a Point: Behaviour under Standard Operations
+section NontriviallyNormedField
+variable {f g : 𝕜 → 𝕜} {z₀ : 𝕜}
 
-The theorems `AnalyticAt.order_mul` and `AnalyticAt.order_pow` establish additivity of the order
-under multiplication and taking powers. The theorem `AnalyticAt.order_add` establishes behavior
-under addition.
--/
+/-- Helper lemma for `eanalyticOrderAt_mul` -/
+lemma eanalyticOrderAt_mul_eq_top_of_left (hg : AnalyticAt 𝕜 g z₀)
+    (hf : eanalyticOrderAt f z₀ = ⊤) : eanalyticOrderAt (f * g) z₀ = ⊤ :=
+  eanalyticOrderAt_smul_eq_top_of_left hg hf
 
-/-- The order is additive when scalar multiplying analytic functions. -/
-theorem order_smul {f : 𝕜 → 𝕜} {g : 𝕜 → E} (hf : AnalyticAt 𝕜 f z₀) (hg : AnalyticAt 𝕜 g z₀) :
-    (hf.smul hg).order = hf.order + hg.order := by
-  -- Trivial cases: one of the functions vanishes around z₀
-  by_cases h₂f : hf.order = ⊤
-  · rw [h₂f, top_add, order_eq_top_iff]
-    filter_upwards [hf.order_eq_top_iff.mp h₂f] using by simp +contextual
-  by_cases h₂g : hg.order = ⊤
-  · rw [h₂g, add_top, order_eq_top_iff]
-    filter_upwards [hg.order_eq_top_iff.mp h₂g] using by simp +contextual
-  -- Non-trivial case: both functions do not vanish around z₀
-  obtain ⟨g₁, h₁g₁, h₂g₁, h₃g₁⟩ := hf.order_ne_top_iff.1 h₂f
-  obtain ⟨g₂, h₁g₂, h₂g₂, h₃g₂⟩ := hg.order_ne_top_iff.1 h₂g
-  rw [← ENat.coe_toNat h₂f, ← ENat.coe_toNat h₂g, ← ENat.coe_add, (hf.smul hg).order_eq_nat_iff]
-  refine ⟨_, h₁g₁.smul h₁g₂, by simp [h₂g₁, h₂g₂], ?_⟩
-  filter_upwards [h₃g₁, h₃g₂] with a h₁a h₂a
-  simp [h₁a, h₂a, ← smul_assoc, pow_add, mul_right_comm]
+/-- Helper lemma for `eanalyticOrderAt_mul` -/
+lemma eanalyticOrderAt_mul_eq_top_of_right (hf : AnalyticAt 𝕜 f z₀)
+    (hg : eanalyticOrderAt g z₀ = ⊤) : eanalyticOrderAt (f * g) z₀ = ⊤ :=
+  eanalyticOrderAt_smul_eq_top_of_right hf hg
 
 /-- The order is additive when multiplying analytic functions. -/
-theorem order_mul {f g : 𝕜 → 𝕜} (hf : AnalyticAt 𝕜 f z₀) (hg : AnalyticAt 𝕜 g z₀) :
-    (hf.mul hg).order = hf.order + hg.order :=
-  hf.order_smul hg
+theorem eanalyticOrderAt_mul (hf : AnalyticAt 𝕜 f z₀) (hg : AnalyticAt 𝕜 g z₀) :
+    eanalyticOrderAt (f * g) z₀ = eanalyticOrderAt f z₀ + eanalyticOrderAt g z₀ :=
+  eanalyticOrderAt_smul hf hg
+
+/-- The order is additive when multiplying analytic functions. -/
+theorem analyticOrderAt_mul (hf : AnalyticAt 𝕜 f z₀) (hg : AnalyticAt 𝕜 g z₀)
+    (hf' : eanalyticOrderAt f z₀ ≠ ⊤) (hg' : eanalyticOrderAt g z₀ ≠ ⊤) :
+    analyticOrderAt (f * g) z₀ = analyticOrderAt f z₀ + analyticOrderAt g z₀ := by
+  simp [analyticOrderAt, eanalyticOrderAt_mul, ENat.toNat_add, *]
 
 /-- The order multiplies by `n` when taking an analytic function to its `n`th power. -/
-theorem order_pow {f : 𝕜 → 𝕜} (hf : AnalyticAt 𝕜 f z₀) {n : ℕ} :
-    (hf.pow n).order = n • hf.order := by
-  induction n
-  case zero =>
-    simp [AnalyticAt.order_eq_zero_iff]
-  case succ n hn =>
-    simp [add_mul, pow_add, (hf.pow n).order_mul hf, hn]
+theorem eanalyticOrderAt_pow (hf : AnalyticAt 𝕜 f z₀) :
+    ∀ n, eanalyticOrderAt (f ^ n) z₀ = n • eanalyticOrderAt f z₀
+  | 0 => by simp [eanalyticOrderAt_eq_zero]
+  | n + 1 => by simp [add_mul, pow_add, eanalyticOrderAt_mul (hf.pow n), eanalyticOrderAt_pow, hf]
+
+@[simp] lemma eanalyticOrderAt_neg : eanalyticOrderAt (-f) z₀ = eanalyticOrderAt f z₀ := by
+  by_cases hf : AnalyticAt 𝕜 f z₀
+  · refine ENat.eq_of_forall_natCast_le_iff fun n ↦ ?_
+    simp only [ natCast_le_eanalyticOrderAt, hf, hf.neg]
+    exact (Equiv.neg _).exists_congr <| by simp [neg_eq_iff_eq_neg]
+  · rw [eanalyticOrderAt_of_not_analyticAt hf,
+      eanalyticOrderAt_of_not_analyticAt <| analyticAt_neg.not.2 hf]
 
 /-- The order of a sum is at least the minimum of the orders of the summands. -/
-theorem order_add (hf₁ : AnalyticAt 𝕜 f₁ z₀) (hf₂ : AnalyticAt 𝕜 f₂ z₀) :
-    min hf₁.order hf₂.order ≤ (hf₁.add hf₂).order := by
+theorem le_eanalyticOrderAt_add (hf : AnalyticAt 𝕜 f z₀) (hg : AnalyticAt 𝕜 g z₀) :
+    min (eanalyticOrderAt f z₀) (eanalyticOrderAt g z₀) ≤ eanalyticOrderAt (f + g) z₀ := by
   refine ENat.forall_natCast_le_iff_le.mp fun n ↦ ?_
-  simp only [le_min_iff, natCast_le_order_iff]
+  simp only [le_min_iff, natCast_le_eanalyticOrderAt, hf, hg, hf.add hg]
   refine fun ⟨⟨F, hF, hF'⟩, ⟨G, hG, hG'⟩⟩ ↦ ⟨F + G, hF.add hG, ?_⟩
-  filter_upwards [hF', hG'] with z using by simp +contextual
+  filter_upwards [hF', hG'] with z using by simp +contextual [mul_add]
 
-/-- Helper lemma for AnalyticAt.order_add_of_unequal_order -/
-lemma order_add_of_order_lt_order (hf₁ : AnalyticAt 𝕜 f₁ z₀) (hf₂ : AnalyticAt 𝕜 f₂ z₀)
-    (h : hf₁.order < hf₂.order) :
-    (hf₁.add hf₂).order = hf₁.order := by
-  lift hf₁.order to ℕ using h.ne_top with n₁ hn₁
-  simp only [eq_comm (a := (n₁ : ℕ∞)), order_eq_nat_iff] at hn₁ ⊢
-  obtain ⟨g₁, h₁g₁, h₂g₁, h₃g₁⟩ := hn₁
-  obtain ⟨g₂, h₁g₂, h₂g₂⟩ := hf₂.natCast_le_order_iff.mp (Order.add_one_le_of_lt h)
-  refine ⟨g₁ + (· - z₀) • g₂, by fun_prop, by simpa using h₂g₁, ?_⟩
-  filter_upwards [h₃g₁, h₂g₂] with a h₁a h₂a
-  simp [mul_smul, pow_succ, h₁a, h₂a]
+lemma le_eanalyticOrderAt_sub (hf : AnalyticAt 𝕜 f z₀) (hg : AnalyticAt 𝕜 g z₀) :
+    min (eanalyticOrderAt f z₀) (eanalyticOrderAt g z₀) ≤ eanalyticOrderAt (f - g) z₀ := by
+  simpa [sub_eq_add_neg] using le_eanalyticOrderAt_add hf hg.neg
+
+lemma eanalyticOrderAt_add_eq_left_of_lt (hf : AnalyticAt 𝕜 f z₀) (hg : AnalyticAt 𝕜 g z₀)
+    (hfg : eanalyticOrderAt f z₀ < eanalyticOrderAt g z₀) :
+    eanalyticOrderAt (f + g) z₀ = eanalyticOrderAt f z₀ :=
+  le_antisymm (by simpa [hfg.not_le] using le_eanalyticOrderAt_sub (hf.add hg) hg)
+    (by simpa [hfg.le] using le_eanalyticOrderAt_add hf hg)
+
+lemma eanalyticOrderAt_add_eq_right_of_lt (hf : AnalyticAt 𝕜 f z₀) (hg : AnalyticAt 𝕜 g z₀)
+    (hgf : eanalyticOrderAt g z₀ < eanalyticOrderAt f z₀) :
+    eanalyticOrderAt (f + g) z₀ = eanalyticOrderAt g z₀ := by
+  rw [add_comm, eanalyticOrderAt_add_eq_left_of_lt hg hf hgf]
 
 /-- If two functions have unequal orders, then the order of their sum is exactly the minimum
 of the orders of the summands. -/
-theorem order_add_of_order_ne_order (hf₁ : AnalyticAt 𝕜 f₁ z₀) (hf₂ : AnalyticAt 𝕜 f₂ z₀)
-    (h : hf₁.order ≠ hf₂.order) :
-    (hf₁.add hf₂).order = min hf₁.order hf₂.order := by
-  rcases min_cases hf₁.order hf₂.order with (⟨hm, h₁⟩ | ⟨hm, h₁⟩)
-  · simpa [hm] using hf₁.order_add_of_order_lt_order hf₂ (h₁.lt_of_ne h)
-  · simpa [hm, add_comm] using hf₂.order_add_of_order_lt_order hf₁ h₁
+theorem eanalyticOrderAt_add_of_ne (hf : AnalyticAt 𝕜 f z₀) (hg : AnalyticAt 𝕜 g z₀)
+    (hfg : eanalyticOrderAt f z₀ ≠ eanalyticOrderAt g z₀) :
+    eanalyticOrderAt (f + g) z₀ = min (eanalyticOrderAt f z₀) (eanalyticOrderAt g z₀) := by
+  obtain hfg | hgf := hfg.lt_or_lt
+  · simpa [hfg.le] using eanalyticOrderAt_add_eq_left_of_lt hf hg hfg
+  · simpa [hgf.le] using eanalyticOrderAt_add_eq_right_of_lt hf hg hgf
 
-end AnalyticAt
+/-- The order multiplies by `n` when taking an analytic function to its `n`th power. -/
+theorem analyticOrderAt_pow (hf : AnalyticAt 𝕜 f z₀) (n : ℕ) :
+    analyticOrderAt (f ^ n) z₀ = n • analyticOrderAt f z₀ := by
+  simp [analyticOrderAt, eanalyticOrderAt_pow, hf]
+
+end NontriviallyNormedField
 
 /-!
 ## Level Sets of the Order Function
@@ -216,17 +298,17 @@ end AnalyticAt
 
 namespace AnalyticOnNhd
 
-variable {U : Set 𝕜} (hf : AnalyticOnNhd 𝕜 f U)
+variable {U : Set 𝕜} {f : 𝕜 → E} (hf : AnalyticOnNhd 𝕜 f U)
+include hf
 
 /-- The set where an analytic function has infinite order is clopen in its domain of analyticity. -/
-theorem isClopen_setOf_order_eq_top :
-    IsClopen { u : U | (hf u.1 u.2).order = ⊤ } := by
+theorem isClopen_setOf_eanalyticOrderAt_eq_top : IsClopen {u : U | eanalyticOrderAt f u = ⊤} := by
   constructor
   · rw [← isOpen_compl_iff, isOpen_iff_forall_mem_open]
     intro z hz
     rcases (hf z.1 z.2).eventually_eq_zero_or_eventually_ne_zero with h | h
     · -- Case: f is locally zero in a punctured neighborhood of z
-      rw [← (hf z.1 z.2).order_eq_top_iff] at h
+      rw [← (hf z.1 z.2).eanalyticOrderAt_eq_top] at h
       tauto
     · -- Case: f is locally nonzero in a punctured neighborhood of z
       obtain ⟨t', h₁t', h₂t', h₃t'⟩ := eventually_nhds_iff.1 (eventually_nhdsWithin_iff.1 h)
@@ -236,16 +318,16 @@ theorem isClopen_setOf_order_eq_top :
         simp only [mem_compl_iff, mem_setOf_eq]
         by_cases h₁w : w = z
         · rwa [h₁w]
-        · rw [(hf _ w.2).order_eq_zero_iff.2 ((h₁t' w hw) (Subtype.coe_ne_coe.mpr h₁w))]
+        · rw [(hf _ w.2).eanalyticOrderAt_eq_zero.2 ((h₁t' w hw) (Subtype.coe_ne_coe.mpr h₁w))]
           exact ENat.zero_ne_top
       · exact ⟨isOpen_induced h₂t', h₃t'⟩
   · apply isOpen_iff_forall_mem_open.mpr
     intro z hz
     conv =>
       arg 1; intro; left; right; arg 1; intro
-      rw [AnalyticAt.order_eq_top_iff, eventually_nhds_iff]
+      rw [(hf _ <| Subtype.prop _).eanalyticOrderAt_eq_top, eventually_nhds_iff]
     simp only [mem_setOf_eq] at hz
-    rw [AnalyticAt.order_eq_top_iff, eventually_nhds_iff] at hz
+    rw [(hf _ <| Subtype.prop _).eanalyticOrderAt_eq_top, eventually_nhds_iff] at hz
     obtain ⟨t', h₁t', h₂t', h₃t'⟩ := hz
     use Subtype.val ⁻¹' t'
     simp only [mem_compl_iff, mem_singleton_iff, isOpen_induced h₂t', mem_preimage,
@@ -263,32 +345,32 @@ theorem isClopen_setOf_order_eq_top :
 
 /-- On a connected set, there exists a point where a meromorphic function `f` has finite order iff
 `f` has finite order at every point. -/
-theorem exists_order_ne_top_iff_forall (hU : IsConnected U) :
-    (∃ u : U, (hf u u.2).order ≠ ⊤) ↔ (∀ u : U, (hf u u.2).order ≠ ⊤) := by
+theorem exists_eanalyticOrderAt_ne_top_iff_forall (hU : IsConnected U) :
+    (∃ u : U, eanalyticOrderAt f u ≠ ⊤) ↔ ∀ u : U, eanalyticOrderAt f u ≠ ⊤ := by
   have : ConnectedSpace U := Subtype.connectedSpace hU
   obtain ⟨v⟩ : Nonempty U := inferInstance
-  suffices (∀ (u : U), (hf u u.2).order ≠ ⊤) ∨ ∀ (u : U), (hf u u.2).order = ⊤ by tauto
+  suffices (∀ (u : U), eanalyticOrderAt f u ≠ ⊤) ∨ ∀ (u : U), eanalyticOrderAt f u = ⊤ by tauto
   simpa [Set.eq_empty_iff_forall_not_mem, Set.eq_univ_iff_forall] using
-      isClopen_iff.1 hf.isClopen_setOf_order_eq_top
+      isClopen_iff.1 hf.isClopen_setOf_eanalyticOrderAt_eq_top
 
 /-- On a preconnected set, a meromorphic function has finite order at one point if it has finite
 order at another point. -/
-theorem order_ne_top_of_isPreconnected {x y : 𝕜} (hU : IsPreconnected U) (h₁x : x ∈ U) (hy : y ∈ U)
-    (h₂x : (hf x h₁x).order ≠ ⊤) :
-    (hf y hy).order ≠ ⊤ :=
-  (hf.exists_order_ne_top_iff_forall ⟨nonempty_of_mem h₁x, hU⟩).1 (by use ⟨x, h₁x⟩) ⟨y, hy⟩
+theorem eanalyticOrderAt_ne_top_of_isPreconnected {x y : 𝕜} (hU : IsPreconnected U) (h₁x : x ∈ U)
+    (hy : y ∈ U) (h₂x : eanalyticOrderAt f x ≠ ⊤) : eanalyticOrderAt f y ≠ ⊤ :=
+  (hf.exists_eanalyticOrderAt_ne_top_iff_forall ⟨nonempty_of_mem h₁x, hU⟩).1 (by use ⟨x, h₁x⟩)
+    ⟨y, hy⟩
 
 /-- The set where an analytic function has zero or infinite order is discrete within its domain of
 analyticity. -/
-theorem codiscrete_setOf_order_eq_zero_or_top :
-    {u : U | (hf u u.2).order = 0 ∨ (hf u u.2).order = ⊤} ∈ Filter.codiscrete U := by
+theorem codiscrete_setOf_eanalyticOrderAt_eq_zero_or_top :
+    {u : U | eanalyticOrderAt f u = 0 ∨ eanalyticOrderAt f u = ⊤} ∈ Filter.codiscrete U := by
   rw [mem_codiscrete_subtype_iff_mem_codiscreteWithin, mem_codiscreteWithin]
   intro x hx
   rw [Filter.disjoint_principal_right]
   rcases (hf x hx).eventually_eq_zero_or_eventually_ne_zero with h₁f | h₁f
   · filter_upwards [eventually_nhdsWithin_of_eventually_nhds h₁f.eventually_nhds] with a ha
-    simp +contextual [(hf a _).order_eq_top_iff, ha]
+    simp +contextual [(hf a _).eanalyticOrderAt_eq_top, ha]
   · filter_upwards [h₁f] with a ha
-    simp +contextual [(hf a _).order_eq_zero_iff, ha]
+    simp +contextual [(hf a _).eanalyticOrderAt_eq_zero, ha]
 
 end AnalyticOnNhd

--- a/Mathlib/Analysis/Analytic/Order.lean
+++ b/Mathlib/Analysis/Analytic/Order.lean
@@ -44,11 +44,11 @@ noncomputable def analyticOrderAt (f : 𝕜 → E) (z₀ : 𝕜) : ℕ∞ :=
 
 @[deprecated (since := "2025-05-02")] alias AnalyticAt.order := analyticOrderAt
 
-/-- The order of vanishing of `f` at `z₀`, as an element of `ℕ∞`.
+/-- The order of vanishing of `f` at `z₀`, as an element of `ℕ`.
 
-The order is defined to be `∞` if `f` is identically 0 on a neighbourhood of `z₀`, and otherwise the
-unique `n` such that `f` can locally be written as `f z = (z - z₀) ^ n • g z`, where `g` is analytic
-and does not vanish at `z₀`. See `AnalyticAt.analyticOrderAt_eq_top` and
+The order is defined to be `0` if `f` is identically zero on a neighbourhood of `z₀`,
+and is otherwise the unique `n` such that `f` can locally be written as `f z = (z - z₀) ^ n • g z`,
+where `g` is analyticand does not vanish at `z₀`. See `AnalyticAt.analyticOrderAt_eq_top` and
 `AnalyticAt.analyticOrderAt_eq_natCast` for these equivalences. -/
 noncomputable def analyticOrderNatAt (f : 𝕜 → E) (z₀ : 𝕜) : ℕ := (analyticOrderAt f z₀).toNat
 

--- a/Mathlib/Analysis/Analytic/Order.lean
+++ b/Mathlib/Analysis/Analytic/Order.lean
@@ -145,10 +145,9 @@ protected lemma AnalyticAt.analyticOrderAt_ne_zero (hf : AnalyticAt 𝕜 f z₀)
 /-- A function vanishes at a point if its analytic order is nonzero in `ℕ∞`. -/
 lemma apply_eq_zero_of_analyticOrderAt_ne_zero (hf : analyticOrderAt f z₀ ≠ 0) :
     f z₀ = 0 := by
-  by_cases hf' : AnalyticAt 𝕜 f z₀ <;> simp_all [analyticOrderAt_eq_zero] 
+  by_cases hf' : AnalyticAt 𝕜 f z₀ <;> simp_all [analyticOrderAt_eq_zero]
 
-/-- A function vanishes at a point if its analytic order is nonzero when converted to 
-ℕ. -/
+/-- A function vanishes at a point if its analytic order is nonzero when converted to ℕ. -/
 lemma apply_eq_zero_of_analyticOrderNatAt_ne_zero (hf : analyticOrderNatAt f z₀ ≠ 0) :
     f z₀ = 0 := by
   by_cases hf' : AnalyticAt 𝕜 f z₀ <;> simp_all [analyticOrderNatAt, analyticOrderAt_eq_zero]

--- a/Mathlib/Analysis/Analytic/Order.lean
+++ b/Mathlib/Analysis/Analytic/Order.lean
@@ -34,53 +34,53 @@ open scoped Classical in
 
 The order is defined to be `∞` if `f` is identically 0 on a neighbourhood of `z₀`, and otherwise the
 unique `n` such that `f` can locally be written as `f z = (z - z₀) ^ n • g z`, where `g` is analytic
-and does not vanish at `z₀`. See `AnalyticAt.eanalyticOrderAt_eq_top` and
-`AnalyticAt.eanalyticOrderAt_eq_natCast` for these equivalences. -/
-noncomputable def eanalyticOrderAt (f : 𝕜 → E) (z₀ : 𝕜) : ℕ∞ :=
+and does not vanish at `z₀`. See `AnalyticAt.analyticOrderAt_eq_top` and
+`AnalyticAt.analyticOrderAt_eq_natCast` for these equivalences. -/
+noncomputable def analyticOrderAt (f : 𝕜 → E) (z₀ : 𝕜) : ℕ∞ :=
   if hf : AnalyticAt 𝕜 f z₀ then
     if h : ∀ᶠ z in 𝓝 z₀, f z = 0 then ⊤
     else ↑(hf.exists_eventuallyEq_pow_smul_nonzero_iff.mpr h).choose
   else 0
 
-@[deprecated (since := "2025-05-02")] alias AnalyticAt.order := eanalyticOrderAt
+@[deprecated (since := "2025-05-02")] alias AnalyticAt.order := analyticOrderAt
 
 /-- The order of vanishing of `f` at `z₀`, as an element of `ℕ∞`.
 
 The order is defined to be `∞` if `f` is identically 0 on a neighbourhood of `z₀`, and otherwise the
 unique `n` such that `f` can locally be written as `f z = (z - z₀) ^ n • g z`, where `g` is analytic
-and does not vanish at `z₀`. See `AnalyticAt.eanalyticOrderAt_eq_top` and
-`AnalyticAt.eanalyticOrderAt_eq_natCast` for these equivalences. -/
-noncomputable def analyticOrderAt (f : 𝕜 → E) (z₀ : 𝕜) : ℕ := (eanalyticOrderAt f z₀).toNat
+and does not vanish at `z₀`. See `AnalyticAt.analyticOrderAt_eq_top` and
+`AnalyticAt.analyticOrderAt_eq_natCast` for these equivalences. -/
+noncomputable def analyticOrderNatAt (f : 𝕜 → E) (z₀ : 𝕜) : ℕ := (analyticOrderAt f z₀).toNat
 
 @[simp]
-lemma eanalyticOrderAt_of_not_analyticAt (hf : ¬ AnalyticAt 𝕜 f z₀) : eanalyticOrderAt f z₀ = 0 :=
+lemma analyticOrderAt_of_not_analyticAt (hf : ¬ AnalyticAt 𝕜 f z₀) : analyticOrderAt f z₀ = 0 :=
   dif_neg hf
 
 @[simp]
-lemma analyticOrderAt_of_not_analyticAt (hf : ¬ AnalyticAt 𝕜 f z₀) : analyticOrderAt f z₀ = 0 := by
-  simp [analyticOrderAt, hf]
+lemma analyticOrderNatAt_of_not_analyticAt (hf : ¬ AnalyticAt 𝕜 f z₀) :
+    analyticOrderNatAt f z₀ = 0 := by simp [analyticOrderNatAt, hf]
 
-@[simp] lemma Nat.cast_analyticOrderAt (hf : eanalyticOrderAt f z₀ ≠ ⊤) :
-    analyticOrderAt f z₀ = eanalyticOrderAt f z₀ := ENat.coe_toNat hf
+@[simp] lemma Nat.cast_analyticOrderNatAt (hf : analyticOrderAt f z₀ ≠ ⊤) :
+    analyticOrderNatAt f z₀ = analyticOrderAt f z₀ := ENat.coe_toNat hf
 
-lemma eanalyticOrderAt_eq_top :
-    eanalyticOrderAt f z₀ = ⊤ ↔ AnalyticAt 𝕜 f z₀ ∧ ∀ᶠ z in 𝓝 z₀, f z = 0 := by
-  unfold eanalyticOrderAt; split_ifs with hf h <;> simp [*]
+lemma analyticOrderAt_eq_top :
+    analyticOrderAt f z₀ = ⊤ ↔ AnalyticAt 𝕜 f z₀ ∧ ∀ᶠ z in 𝓝 z₀, f z = 0 := by
+  unfold analyticOrderAt; split_ifs with hf h <;> simp [*]
 
 /-- The order of an analytic function `f` at a `z₀` is infinity iff `f` vanishes locally around
 `z₀`. -/
-protected lemma AnalyticAt.eanalyticOrderAt_eq_top (hf : AnalyticAt 𝕜 f z₀) :
-    eanalyticOrderAt f z₀ = ⊤ ↔ ∀ᶠ z in 𝓝 z₀, f z = 0 := by simp [eanalyticOrderAt_eq_top, hf]
+protected lemma AnalyticAt.analyticOrderAt_eq_top (hf : AnalyticAt 𝕜 f z₀) :
+    analyticOrderAt f z₀ = ⊤ ↔ ∀ᶠ z in 𝓝 z₀, f z = 0 := by simp [analyticOrderAt_eq_top, hf]
 
 @[deprecated (since := "2025-05-03")]
-alias AnalyticAt.order_eq_top_iff := AnalyticAt.eanalyticOrderAt_eq_top
+alias AnalyticAt.order_eq_top_iff := AnalyticAt.analyticOrderAt_eq_top
 
 /-- The order of an analytic function `f` at `z₀` equals a natural number `n` iff `f` can locally
 be written as `f z = (z - z₀) ^ n • g z`, where `g` is analytic and does not vanish at `z₀`. -/
-lemma AnalyticAt.eanalyticOrderAt_eq_natCast (hf : AnalyticAt 𝕜 f z₀) :
-    eanalyticOrderAt f z₀ = n ↔
+lemma AnalyticAt.analyticOrderAt_eq_natCast (hf : AnalyticAt 𝕜 f z₀) :
+    analyticOrderAt f z₀ = n ↔
       ∃ (g : 𝕜 → E), AnalyticAt 𝕜 g z₀ ∧ g z₀ ≠ 0 ∧ ∀ᶠ z in 𝓝 z₀, f z = (z - z₀) ^ n • g z := by
-  unfold eanalyticOrderAt
+  unfold analyticOrderAt
   split_ifs with h
   · simp only [ENat.top_ne_coe, false_iff]
     contrapose! h
@@ -91,71 +91,72 @@ lemma AnalyticAt.eanalyticOrderAt_eq_natCast (hf : AnalyticAt 𝕜 f z₀) :
     rw [AnalyticAt.unique_eventuallyEq_pow_smul_nonzero h.choose_spec h']
 
 @[deprecated (since := "2025-05-03")]
-alias AnalyticAt.order_eq_nat_iff := AnalyticAt.eanalyticOrderAt_eq_natCast
+alias AnalyticAt.order_eq_nat_iff := AnalyticAt.analyticOrderAt_eq_natCast
 
 /-- The order of an analytic function `f` at `z₀` equals a natural number `n` iff `f` can locally
 be written as `f z = (z - z₀) ^ n • g z`, where `g` is analytic and does not vanish at `z₀`. -/
-lemma AnalyticAt.analyticOrderAt_eq_iff (hf : AnalyticAt 𝕜 f z₀) (hf' : eanalyticOrderAt f z₀ ≠ ⊤)
+lemma AnalyticAt.analyticOrderNatAt_eq_iff (hf : AnalyticAt 𝕜 f z₀) (hf' : analyticOrderAt f z₀ ≠ ⊤)
     {n : ℕ} :
-    analyticOrderAt f z₀ = n ↔
+    analyticOrderNatAt f z₀ = n ↔
       ∃ (g : 𝕜 → E), AnalyticAt 𝕜 g z₀ ∧ g z₀ ≠ 0 ∧ ∀ᶠ z in 𝓝 z₀, f z = (z - z₀) ^ n • g z := by
-  simp [← Nat.cast_inj (R := ℕ∞), Nat.cast_analyticOrderAt hf', hf.eanalyticOrderAt_eq_natCast]
+  simp [← Nat.cast_inj (R := ℕ∞), Nat.cast_analyticOrderNatAt hf', hf.analyticOrderAt_eq_natCast]
 
 /-- The order of an analytic function `f` at `z₀` is finite iff `f` can locally be written as `f z =
-  (z - z₀) ^ analyticOrderAt f z₀ • g z`, where `g` is analytic and does not vanish at `z₀`.
+  (z - z₀) ^ analyticOrderNatAt f z₀ • g z`, where `g` is analytic and does not vanish at `z₀`.
 
 See `MeromorphicNFAt.order_eq_zero_iff` for an analogous statement about meromorphic functions in
 normal form.
 -/
-lemma AnalyticAt.eanalyticOrderAt_ne_top (hf : AnalyticAt 𝕜 f z₀) :
-    eanalyticOrderAt f z₀ ≠ ⊤ ↔
+lemma AnalyticAt.analyticOrderAt_ne_top (hf : AnalyticAt 𝕜 f z₀) :
+    analyticOrderAt f z₀ ≠ ⊤ ↔
       ∃ (g : 𝕜 → E), AnalyticAt 𝕜 g z₀ ∧ g z₀ ≠ 0 ∧
-        f =ᶠ[𝓝 z₀] fun z ↦ (z - z₀) ^ analyticOrderAt f z₀ • g z := by
-  simp only [← ENat.coe_toNat_eq_self, Eq.comm, EventuallyEq, ← hf.eanalyticOrderAt_eq_natCast,
-    analyticOrderAt]
+        f =ᶠ[𝓝 z₀] fun z ↦ (z - z₀) ^ analyticOrderNatAt f z₀ • g z := by
+  simp only [← ENat.coe_toNat_eq_self, Eq.comm, EventuallyEq, ← hf.analyticOrderAt_eq_natCast,
+    analyticOrderNatAt]
 
 @[deprecated (since := "2025-05-03")]
-alias AnalyticAt.order_ne_top_iff := AnalyticAt.eanalyticOrderAt_ne_top
+alias AnalyticAt.order_ne_top_iff := AnalyticAt.analyticOrderAt_ne_top
 
 @[deprecated (since := "2025-02-03")]
-alias AnalyticAt.order_neq_top_iff := AnalyticAt.eanalyticOrderAt_ne_top
+alias AnalyticAt.order_neq_top_iff := AnalyticAt.analyticOrderAt_ne_top
 
-lemma eanalyticOrderAt_eq_zero : eanalyticOrderAt f z₀ = 0 ↔ ¬ AnalyticAt 𝕜 f z₀ ∨ f z₀ ≠ 0 := by
+lemma analyticOrderAt_eq_zero : analyticOrderAt f z₀ = 0 ↔ ¬ AnalyticAt 𝕜 f z₀ ∨ f z₀ ≠ 0 := by
   by_cases hf : AnalyticAt 𝕜 f z₀
-  · rw [← ENat.coe_zero, hf.eanalyticOrderAt_eq_natCast]
+  · rw [← ENat.coe_zero, hf.analyticOrderAt_eq_natCast]
     constructor
     · intro ⟨g, _, _, hg⟩
       simpa [hf, hg.self_of_nhds]
     · exact fun hz ↦ ⟨f, hf, hz.resolve_left <| not_not_intro hf, by simp⟩
   · simp [hf]
 
-lemma eanalyticOrderAt_ne_zero : eanalyticOrderAt f z₀ ≠ 0 ↔ AnalyticAt 𝕜 f z₀ ∧ f z₀ = 0 := by
-  simp [eanalyticOrderAt_eq_zero]
+lemma analyticOrderAt_ne_zero : analyticOrderAt f z₀ ≠ 0 ↔ AnalyticAt 𝕜 f z₀ ∧ f z₀ = 0 := by
+  simp [analyticOrderAt_eq_zero]
 
 /-- The order of an analytic function `f` at `z₀` is zero iff `f` does not vanish at `z₀`. -/
-protected lemma AnalyticAt.eanalyticOrderAt_eq_zero (hf : AnalyticAt 𝕜 f z₀) :
-    eanalyticOrderAt f z₀ = 0 ↔ f z₀ ≠ 0 := by simp [hf, eanalyticOrderAt_eq_zero]
+protected lemma AnalyticAt.analyticOrderAt_eq_zero (hf : AnalyticAt 𝕜 f z₀) :
+    analyticOrderAt f z₀ = 0 ↔ f z₀ ≠ 0 := by simp [hf, analyticOrderAt_eq_zero]
 
 @[deprecated (since := "2025-05-03")]
-alias AnalyticAt.order_eq_zero_iff := AnalyticAt.eanalyticOrderAt_eq_zero
+alias AnalyticAt.order_eq_zero_iff := AnalyticAt.analyticOrderAt_eq_zero
 
 /-- The order of an analytic function `f` at `z₀` is zero iff `f` does not vanish at `z₀`. -/
-protected lemma AnalyticAt.eanalyticOrderAt_ne_zero (hf : AnalyticAt 𝕜 f z₀) :
-    eanalyticOrderAt f z₀ ≠ 0 ↔ f z₀ = 0 := hf.eanalyticOrderAt_eq_zero.not_left
+protected lemma AnalyticAt.analyticOrderAt_ne_zero (hf : AnalyticAt 𝕜 f z₀) :
+    analyticOrderAt f z₀ ≠ 0 ↔ f z₀ = 0 := hf.analyticOrderAt_eq_zero.not_left
 
 /-- An analytic function vanishes at a point if its order is nonzero when converted to ℕ. -/
-lemma apply_eq_zero_of_analyticOrderAt_ne_zero (hf : analyticOrderAt f z₀ ≠ 0) : f z₀ = 0 := by
-  by_cases hf' : AnalyticAt 𝕜 f z₀ <;> simp_all [analyticOrderAt, eanalyticOrderAt_eq_zero]
+lemma apply_eq_zero_of_analyticOrderNatAt_ne_zero (hf : analyticOrderNatAt f z₀ ≠ 0) :
+    f z₀ = 0 := by
+  by_cases hf' : AnalyticAt 𝕜 f z₀ <;> simp_all [analyticOrderNatAt, analyticOrderAt_eq_zero]
 
 @[deprecated (since := "2025-05-03")]
-alias AnalyticAt.apply_eq_zero_of_order_toNat_ne_zero := apply_eq_zero_of_analyticOrderAt_ne_zero
+alias AnalyticAt.apply_eq_zero_of_order_toNat_ne_zero := apply_eq_zero_of_analyticOrderNatAt_ne_zero
 
 /-- Characterization of which natural numbers are `≤ hf.order`. Useful for avoiding case splits,
 since it applies whether or not the order is `∞`. -/
-lemma natCast_le_eanalyticOrderAt (hf : AnalyticAt 𝕜 f z₀) {n : ℕ} :
-    n ≤ eanalyticOrderAt f z₀ ↔
+lemma natCast_le_analyticOrderAt (hf : AnalyticAt 𝕜 f z₀) {n : ℕ} :
+    n ≤ analyticOrderAt f z₀ ↔
       ∃ g, AnalyticAt 𝕜 g z₀ ∧ ∀ᶠ z in 𝓝 z₀, f z = (z - z₀) ^ n • g z := by
-  unfold eanalyticOrderAt
+  unfold analyticOrderAt
   split_ifs with h
   · simpa using ⟨0, analyticAt_const .., by simpa⟩
   · let m := (hf.exists_eventuallyEq_pow_smul_nonzero_iff.mpr h).choose
@@ -174,93 +175,93 @@ lemma natCast_le_eanalyticOrderAt (hf : AnalyticAt 𝕜 f z₀) {n : ℕ} :
           ← mul_smul] at hf'
         rw [pow_sub₀ _ (sub_ne_zero_of_ne hz) (by omega), ← hf']
 
-@[deprecated (since := "2025-05-03")] alias natCast_le_order_iff := natCast_le_eanalyticOrderAt
+@[deprecated (since := "2025-05-03")] alias natCast_le_order_iff := natCast_le_analyticOrderAt
 
 /-- If two functions agree in a neighborhood of `z₀`, then their orders at `z₀` agree. -/
-lemma eanalyticOrderAt_congr (hfg : f =ᶠ[𝓝 z₀] g) :
-    eanalyticOrderAt f z₀ = eanalyticOrderAt g z₀ := by
+lemma analyticOrderAt_congr (hfg : f =ᶠ[𝓝 z₀] g) :
+    analyticOrderAt f z₀ = analyticOrderAt g z₀ := by
   by_cases hf : AnalyticAt 𝕜 f z₀
   · refine ENat.eq_of_forall_natCast_le_iff fun n ↦ ?_
-    simp only [natCast_le_eanalyticOrderAt, hf, hf.congr hfg]
+    simp only [natCast_le_analyticOrderAt, hf, hf.congr hfg]
     congr! 3
     exact hfg.congr_left
-  · rw [eanalyticOrderAt_of_not_analyticAt hf,
-      eanalyticOrderAt_of_not_analyticAt fun hg ↦ hf <| hg.congr hfg.symm]
+  · rw [analyticOrderAt_of_not_analyticAt hf,
+      analyticOrderAt_of_not_analyticAt fun hg ↦ hf <| hg.congr hfg.symm]
 
-@[deprecated (since := "2025-05-03")] alias AnalyticAt.order_congr := eanalyticOrderAt_congr
+@[deprecated (since := "2025-05-03")] alias AnalyticAt.order_congr := analyticOrderAt_congr
 
-@[simp] lemma eanalyticOrderAt_neg : eanalyticOrderAt (-f) z₀ = eanalyticOrderAt f z₀ := by
+@[simp] lemma analyticOrderAt_neg : analyticOrderAt (-f) z₀ = analyticOrderAt f z₀ := by
   by_cases hf : AnalyticAt 𝕜 f z₀
   · refine ENat.eq_of_forall_natCast_le_iff fun n ↦ ?_
-    simp only [ natCast_le_eanalyticOrderAt, hf, hf.neg]
+    simp only [ natCast_le_analyticOrderAt, hf, hf.neg]
     exact (Equiv.neg _).exists_congr <| by simp [neg_eq_iff_eq_neg]
-  · rw [eanalyticOrderAt_of_not_analyticAt hf,
-      eanalyticOrderAt_of_not_analyticAt <| analyticAt_neg.not.2 hf]
+  · rw [analyticOrderAt_of_not_analyticAt hf,
+      analyticOrderAt_of_not_analyticAt <| analyticAt_neg.not.2 hf]
 
 /-- The order of a sum is at least the minimum of the orders of the summands. -/
-theorem le_eanalyticOrderAt_add (hf : AnalyticAt 𝕜 f z₀) (hg : AnalyticAt 𝕜 g z₀) :
-    min (eanalyticOrderAt f z₀) (eanalyticOrderAt g z₀) ≤ eanalyticOrderAt (f + g) z₀ := by
+theorem le_analyticOrderAt_add (hf : AnalyticAt 𝕜 f z₀) (hg : AnalyticAt 𝕜 g z₀) :
+    min (analyticOrderAt f z₀) (analyticOrderAt g z₀) ≤ analyticOrderAt (f + g) z₀ := by
   refine ENat.forall_natCast_le_iff_le.mp fun n ↦ ?_
-  simp only [le_min_iff, natCast_le_eanalyticOrderAt, hf, hg, hf.add hg]
+  simp only [le_min_iff, natCast_le_analyticOrderAt, hf, hg, hf.add hg]
   refine fun ⟨⟨F, hF, hF'⟩, ⟨G, hG, hG'⟩⟩ ↦ ⟨F + G, hF.add hG, ?_⟩
   filter_upwards [hF', hG'] with z using by simp +contextual [mul_add]
 
-@[deprecated (since := "2025-05-03")] alias AnalyticAt.order_add := le_eanalyticOrderAt_add
+@[deprecated (since := "2025-05-03")] alias AnalyticAt.order_add := le_analyticOrderAt_add
 
-lemma le_eanalyticOrderAt_sub (hf : AnalyticAt 𝕜 f z₀) (hg : AnalyticAt 𝕜 g z₀) :
-    min (eanalyticOrderAt f z₀) (eanalyticOrderAt g z₀) ≤ eanalyticOrderAt (f - g) z₀ := by
-  simpa [sub_eq_add_neg] using le_eanalyticOrderAt_add hf hg.neg
+lemma le_analyticOrderAt_sub (hf : AnalyticAt 𝕜 f z₀) (hg : AnalyticAt 𝕜 g z₀) :
+    min (analyticOrderAt f z₀) (analyticOrderAt g z₀) ≤ analyticOrderAt (f - g) z₀ := by
+  simpa [sub_eq_add_neg] using le_analyticOrderAt_add hf hg.neg
 
-lemma eanalyticOrderAt_add_eq_left_of_lt (hf : AnalyticAt 𝕜 f z₀) (hg : AnalyticAt 𝕜 g z₀)
-    (hfg : eanalyticOrderAt f z₀ < eanalyticOrderAt g z₀) :
-    eanalyticOrderAt (f + g) z₀ = eanalyticOrderAt f z₀ :=
-  le_antisymm (by simpa [hfg.not_le] using le_eanalyticOrderAt_sub (hf.add hg) hg)
-    (by simpa [hfg.le] using le_eanalyticOrderAt_add hf hg)
+lemma analyticOrderAt_add_eq_left_of_lt (hf : AnalyticAt 𝕜 f z₀) (hg : AnalyticAt 𝕜 g z₀)
+    (hfg : analyticOrderAt f z₀ < analyticOrderAt g z₀) :
+    analyticOrderAt (f + g) z₀ = analyticOrderAt f z₀ :=
+  le_antisymm (by simpa [hfg.not_le] using le_analyticOrderAt_sub (hf.add hg) hg)
+    (by simpa [hfg.le] using le_analyticOrderAt_add hf hg)
 
-lemma eanalyticOrderAt_add_eq_right_of_lt (hf : AnalyticAt 𝕜 f z₀) (hg : AnalyticAt 𝕜 g z₀)
-    (hgf : eanalyticOrderAt g z₀ < eanalyticOrderAt f z₀) :
-    eanalyticOrderAt (f + g) z₀ = eanalyticOrderAt g z₀ := by
-  rw [add_comm, eanalyticOrderAt_add_eq_left_of_lt hg hf hgf]
+lemma analyticOrderAt_add_eq_right_of_lt (hf : AnalyticAt 𝕜 f z₀) (hg : AnalyticAt 𝕜 g z₀)
+    (hgf : analyticOrderAt g z₀ < analyticOrderAt f z₀) :
+    analyticOrderAt (f + g) z₀ = analyticOrderAt g z₀ := by
+  rw [add_comm, analyticOrderAt_add_eq_left_of_lt hg hf hgf]
 
-@[deprecated (since := "2025-05-03")] alias order_add_of_order_lt_order := le_eanalyticOrderAt_add
+@[deprecated (since := "2025-05-03")] alias order_add_of_order_lt_order := le_analyticOrderAt_add
 
 /-- If two functions have unequal orders, then the order of their sum is exactly the minimum
 of the orders of the summands. -/
-theorem eanalyticOrderAt_add_of_ne (hf : AnalyticAt 𝕜 f z₀) (hg : AnalyticAt 𝕜 g z₀)
-    (hfg : eanalyticOrderAt f z₀ ≠ eanalyticOrderAt g z₀) :
-    eanalyticOrderAt (f + g) z₀ = min (eanalyticOrderAt f z₀) (eanalyticOrderAt g z₀) := by
+theorem analyticOrderAt_add_of_ne (hf : AnalyticAt 𝕜 f z₀) (hg : AnalyticAt 𝕜 g z₀)
+    (hfg : analyticOrderAt f z₀ ≠ analyticOrderAt g z₀) :
+    analyticOrderAt (f + g) z₀ = min (analyticOrderAt f z₀) (analyticOrderAt g z₀) := by
   obtain hfg | hgf := hfg.lt_or_lt
-  · simpa [hfg.le] using eanalyticOrderAt_add_eq_left_of_lt hf hg hfg
-  · simpa [hgf.le] using eanalyticOrderAt_add_eq_right_of_lt hf hg hgf
+  · simpa [hfg.le] using analyticOrderAt_add_eq_left_of_lt hf hg hfg
+  · simpa [hgf.le] using analyticOrderAt_add_eq_right_of_lt hf hg hgf
 
 @[deprecated (since := "2025-05-03")]
-alias AnalyticAt.order_add_of_order_ne_order := eanalyticOrderAt_add_of_ne
+alias AnalyticAt.order_add_of_order_ne_order := analyticOrderAt_add_of_ne
 
-lemma eanalyticOrderAt_smul_eq_top_of_left {f : 𝕜 → 𝕜} (hg : AnalyticAt 𝕜 g z₀)
-    (hf : eanalyticOrderAt f z₀ = ⊤) : eanalyticOrderAt (f • g) z₀ = ⊤ := by
-  rw [eanalyticOrderAt_eq_top, eventually_nhds_iff] at *
+lemma analyticOrderAt_smul_eq_top_of_left {f : 𝕜 → 𝕜} (hg : AnalyticAt 𝕜 g z₀)
+    (hf : analyticOrderAt f z₀ = ⊤) : analyticOrderAt (f • g) z₀ = ⊤ := by
+  rw [analyticOrderAt_eq_top, eventually_nhds_iff] at *
   obtain ⟨hf, t, h₁t, h₂t, h₃t⟩ := hf
   exact ⟨hf.smul hg, t, fun y hy ↦ by simp [h₁t y hy], h₂t, h₃t⟩
 
-lemma eanalyticOrderAt_smul_eq_top_of_right {f : 𝕜 → 𝕜} (hf : AnalyticAt 𝕜 f z₀)
-    (hg : eanalyticOrderAt g z₀ = ⊤) : eanalyticOrderAt (f • g) z₀ = ⊤ := by
-  rw [eanalyticOrderAt_eq_top, eventually_nhds_iff] at *
+lemma analyticOrderAt_smul_eq_top_of_right {f : 𝕜 → 𝕜} (hf : AnalyticAt 𝕜 f z₀)
+    (hg : analyticOrderAt g z₀ = ⊤) : analyticOrderAt (f • g) z₀ = ⊤ := by
+  rw [analyticOrderAt_eq_top, eventually_nhds_iff] at *
   obtain ⟨hg, t, h₁t, h₂t, h₃t⟩ := hg
   exact ⟨hf.smul hg, t, fun y hy ↦ by simp [h₁t y hy], h₂t, h₃t⟩
 
 /-- The order is additive when scalar multiplying analytic functions. -/
-lemma eanalyticOrderAt_smul {f : 𝕜 → 𝕜} (hf : AnalyticAt 𝕜 f z₀) (hg : AnalyticAt 𝕜 g z₀) :
-    eanalyticOrderAt (f • g) z₀ = eanalyticOrderAt f z₀ + eanalyticOrderAt g z₀ := by
+lemma analyticOrderAt_smul {f : 𝕜 → 𝕜} (hf : AnalyticAt 𝕜 f z₀) (hg : AnalyticAt 𝕜 g z₀) :
+    analyticOrderAt (f • g) z₀ = analyticOrderAt f z₀ + analyticOrderAt g z₀ := by
   -- Trivial cases: one of the functions vanishes around z₀
-  by_cases hf' : eanalyticOrderAt f z₀ = ⊤
-  · simp [eanalyticOrderAt_smul_eq_top_of_left, *]
-  by_cases hg' : eanalyticOrderAt g z₀ = ⊤
-  · simp [eanalyticOrderAt_smul_eq_top_of_right, *]
+  by_cases hf' : analyticOrderAt f z₀ = ⊤
+  · simp [analyticOrderAt_smul_eq_top_of_left, *]
+  by_cases hg' : analyticOrderAt g z₀ = ⊤
+  · simp [analyticOrderAt_smul_eq_top_of_right, *]
   -- Non-trivial case: both functions do not vanish around z₀
-  obtain ⟨f', h₁f', h₂f', h₃f'⟩ := hf.eanalyticOrderAt_ne_top.1 hf'
-  obtain ⟨g', h₁g', h₂g', h₃g'⟩ := hg.eanalyticOrderAt_ne_top.1 hg'
-  rw [← Nat.cast_analyticOrderAt hf', ← Nat.cast_analyticOrderAt hg', ← ENat.coe_add,
-      (hf.smul hg).eanalyticOrderAt_eq_natCast]
+  obtain ⟨f', h₁f', h₂f', h₃f'⟩ := hf.analyticOrderAt_ne_top.1 hf'
+  obtain ⟨g', h₁g', h₂g', h₃g'⟩ := hg.analyticOrderAt_ne_top.1 hg'
+  rw [← Nat.cast_analyticOrderNatAt hf', ← Nat.cast_analyticOrderNatAt hg', ← ENat.coe_add,
+      (hf.smul hg).analyticOrderAt_eq_natCast]
   refine ⟨f' • g', h₁f'.smul h₁g', ?_, ?_⟩
   · simp
     tauto
@@ -277,56 +278,54 @@ end NormedSpace
 
 /-- Simplifier lemma for the order of a centered monomial -/
 @[simp]
-lemma eanalyticOrderAt_centeredMonomial {z₀ : 𝕜} {n : ℕ} :
-    eanalyticOrderAt ((· - z₀) ^ n) z₀ = n := by
-  rw [AnalyticAt.eanalyticOrderAt_eq_natCast (by fun_prop)]
+lemma analyticOrderAt_centeredMonomial {z₀ : 𝕜} {n : ℕ} :
+    analyticOrderAt ((· - z₀) ^ n) z₀ = n := by
+  rw [AnalyticAt.analyticOrderAt_eq_natCast (by fun_prop)]
   exact ⟨1, by simp [Pi.one_def, analyticAt_const]⟩
 
 @[deprecated (since := "2025-05-03")]
-alias analyticAt_order_centeredMonomial := eanalyticOrderAt_centeredMonomial
+alias analyticAt_order_centeredMonomial := analyticOrderAt_centeredMonomial
 
 section NontriviallyNormedField
 variable {f g : 𝕜 → 𝕜} {z₀ : 𝕜}
 
-/-- Helper lemma for `eanalyticOrderAt_mul` -/
-lemma eanalyticOrderAt_mul_eq_top_of_left (hg : AnalyticAt 𝕜 g z₀)
-    (hf : eanalyticOrderAt f z₀ = ⊤) : eanalyticOrderAt (f * g) z₀ = ⊤ :=
-  eanalyticOrderAt_smul_eq_top_of_left hg hf
+lemma analyticOrderAt_mul_eq_top_of_left (hg : AnalyticAt 𝕜 g z₀)
+    (hf : analyticOrderAt f z₀ = ⊤) : analyticOrderAt (f * g) z₀ = ⊤ :=
+  analyticOrderAt_smul_eq_top_of_left hg hf
 
 @[deprecated (since := "2025-05-03")]
-alias AnalyticAt.order_mul_of_order_eq_top := eanalyticOrderAt_mul_eq_top_of_left
+alias AnalyticAt.order_mul_of_order_eq_top := analyticOrderAt_mul_eq_top_of_left
 
-/-- Helper lemma for `eanalyticOrderAt_mul` -/
-lemma eanalyticOrderAt_mul_eq_top_of_right (hf : AnalyticAt 𝕜 f z₀)
-    (hg : eanalyticOrderAt g z₀ = ⊤) : eanalyticOrderAt (f * g) z₀ = ⊤ :=
-  eanalyticOrderAt_smul_eq_top_of_right hf hg
-
-/-- The order is additive when multiplying analytic functions. -/
-theorem eanalyticOrderAt_mul (hf : AnalyticAt 𝕜 f z₀) (hg : AnalyticAt 𝕜 g z₀) :
-    eanalyticOrderAt (f * g) z₀ = eanalyticOrderAt f z₀ + eanalyticOrderAt g z₀ :=
-  eanalyticOrderAt_smul hf hg
-
-@[deprecated (since := "2025-05-03")] alias AnalyticAt.order_mul := eanalyticOrderAt_mul
+/-- Helper lemma for `analyticOrderAt_mul` -/
+lemma analyticOrderAt_mul_eq_top_of_right (hf : AnalyticAt 𝕜 f z₀)
+    (hg : analyticOrderAt g z₀ = ⊤) : analyticOrderAt (f * g) z₀ = ⊤ :=
+  analyticOrderAt_smul_eq_top_of_right hf hg
 
 /-- The order is additive when multiplying analytic functions. -/
-theorem analyticOrderAt_mul (hf : AnalyticAt 𝕜 f z₀) (hg : AnalyticAt 𝕜 g z₀)
-    (hf' : eanalyticOrderAt f z₀ ≠ ⊤) (hg' : eanalyticOrderAt g z₀ ≠ ⊤) :
-    analyticOrderAt (f * g) z₀ = analyticOrderAt f z₀ + analyticOrderAt g z₀ := by
-  simp [analyticOrderAt, eanalyticOrderAt_mul, ENat.toNat_add, *]
+theorem analyticOrderAt_mul (hf : AnalyticAt 𝕜 f z₀) (hg : AnalyticAt 𝕜 g z₀) :
+    analyticOrderAt (f * g) z₀ = analyticOrderAt f z₀ + analyticOrderAt g z₀ :=
+  analyticOrderAt_smul hf hg
+
+@[deprecated (since := "2025-05-03")] alias AnalyticAt.order_mul := analyticOrderAt_mul
+
+/-- The order is additive when multiplying analytic functions. -/
+theorem analyticOrderNatAt_mul (hf : AnalyticAt 𝕜 f z₀) (hg : AnalyticAt 𝕜 g z₀)
+    (hf' : analyticOrderAt f z₀ ≠ ⊤) (hg' : analyticOrderAt g z₀ ≠ ⊤) :
+    analyticOrderNatAt (f * g) z₀ = analyticOrderNatAt f z₀ + analyticOrderNatAt g z₀ := by
+  simp [analyticOrderNatAt, analyticOrderAt_mul, ENat.toNat_add, *]
 
 /-- The order multiplies by `n` when taking an analytic function to its `n`th power. -/
-theorem eanalyticOrderAt_pow (hf : AnalyticAt 𝕜 f z₀) :
-    ∀ n, eanalyticOrderAt (f ^ n) z₀ = n • eanalyticOrderAt f z₀
-  | 0 => by simp [eanalyticOrderAt_eq_zero]
-  | n + 1 => by simp [add_mul, pow_add, eanalyticOrderAt_mul (hf.pow n), eanalyticOrderAt_pow, hf]
+theorem analyticOrderAt_pow (hf : AnalyticAt 𝕜 f z₀) :
+    ∀ n, analyticOrderAt (f ^ n) z₀ = n • analyticOrderAt f z₀
+  | 0 => by simp [analyticOrderAt_eq_zero]
+  | n + 1 => by simp [add_mul, pow_add, analyticOrderAt_mul (hf.pow n), analyticOrderAt_pow, hf]
 
-@[deprecated (since := "2025-05-03")] alias AnalyticAt.order_pow := eanalyticOrderAt_pow
+@[deprecated (since := "2025-05-03")] alias AnalyticAt.order_pow := analyticOrderAt_pow
 
 /-- The order multiplies by `n` when taking an analytic function to its `n`th power. -/
-theorem analyticOrderAt_pow (hf : AnalyticAt 𝕜 f z₀) (n : ℕ) :
-    analyticOrderAt (f ^ n) z₀ = n • analyticOrderAt f z₀ := by
-  simp [analyticOrderAt, eanalyticOrderAt_pow, hf]
-
+theorem analyticOrderNatAt_pow (hf : AnalyticAt 𝕜 f z₀) (n : ℕ) :
+    analyticOrderNatAt (f ^ n) z₀ = n • analyticOrderNatAt f z₀ := by
+  simp [analyticOrderNatAt, analyticOrderAt_pow, hf]
 
 end NontriviallyNormedField
 
@@ -340,13 +339,13 @@ variable {U : Set 𝕜} {f : 𝕜 → E} (hf : AnalyticOnNhd 𝕜 f U)
 include hf
 
 /-- The set where an analytic function has infinite order is clopen in its domain of analyticity. -/
-theorem isClopen_setOf_eanalyticOrderAt_eq_top : IsClopen {u : U | eanalyticOrderAt f u = ⊤} := by
+theorem isClopen_setOf_analyticOrderAt_eq_top : IsClopen {u : U | analyticOrderAt f u = ⊤} := by
   constructor
   · rw [← isOpen_compl_iff, isOpen_iff_forall_mem_open]
     intro z hz
     rcases (hf z.1 z.2).eventually_eq_zero_or_eventually_ne_zero with h | h
     · -- Case: f is locally zero in a punctured neighborhood of z
-      rw [← (hf z.1 z.2).eanalyticOrderAt_eq_top] at h
+      rw [← (hf z.1 z.2).analyticOrderAt_eq_top] at h
       tauto
     · -- Case: f is locally nonzero in a punctured neighborhood of z
       obtain ⟨t', h₁t', h₂t', h₃t'⟩ := eventually_nhds_iff.1 (eventually_nhdsWithin_iff.1 h)
@@ -356,16 +355,16 @@ theorem isClopen_setOf_eanalyticOrderAt_eq_top : IsClopen {u : U | eanalyticOrde
         simp only [mem_compl_iff, mem_setOf_eq]
         by_cases h₁w : w = z
         · rwa [h₁w]
-        · rw [(hf _ w.2).eanalyticOrderAt_eq_zero.2 ((h₁t' w hw) (Subtype.coe_ne_coe.mpr h₁w))]
+        · rw [(hf _ w.2).analyticOrderAt_eq_zero.2 ((h₁t' w hw) (Subtype.coe_ne_coe.mpr h₁w))]
           exact ENat.zero_ne_top
       · exact ⟨isOpen_induced h₂t', h₃t'⟩
   · apply isOpen_iff_forall_mem_open.mpr
     intro z hz
     conv =>
       arg 1; intro; left; right; arg 1; intro
-      rw [(hf _ <| Subtype.prop _).eanalyticOrderAt_eq_top, eventually_nhds_iff]
+      rw [(hf _ <| Subtype.prop _).analyticOrderAt_eq_top, eventually_nhds_iff]
     simp only [mem_setOf_eq] at hz
-    rw [(hf _ <| Subtype.prop _).eanalyticOrderAt_eq_top, eventually_nhds_iff] at hz
+    rw [(hf _ <| Subtype.prop _).analyticOrderAt_eq_top, eventually_nhds_iff] at hz
     obtain ⟨t', h₁t', h₂t', h₃t'⟩ := hz
     use Subtype.val ⁻¹' t'
     simp only [mem_compl_iff, mem_singleton_iff, isOpen_induced h₂t', mem_preimage,
@@ -383,32 +382,32 @@ theorem isClopen_setOf_eanalyticOrderAt_eq_top : IsClopen {u : U | eanalyticOrde
 
 /-- On a connected set, there exists a point where a meromorphic function `f` has finite order iff
 `f` has finite order at every point. -/
-theorem exists_eanalyticOrderAt_ne_top_iff_forall (hU : IsConnected U) :
-    (∃ u : U, eanalyticOrderAt f u ≠ ⊤) ↔ ∀ u : U, eanalyticOrderAt f u ≠ ⊤ := by
+theorem exists_analyticOrderAt_ne_top_iff_forall (hU : IsConnected U) :
+    (∃ u : U, analyticOrderAt f u ≠ ⊤) ↔ (∀ u : U, analyticOrderAt f u ≠ ⊤) := by
   have : ConnectedSpace U := Subtype.connectedSpace hU
   obtain ⟨v⟩ : Nonempty U := inferInstance
-  suffices (∀ (u : U), eanalyticOrderAt f u ≠ ⊤) ∨ ∀ (u : U), eanalyticOrderAt f u = ⊤ by tauto
+  suffices (∀ (u : U), analyticOrderAt f u ≠ ⊤) ∨ ∀ (u : U), analyticOrderAt f u = ⊤ by tauto
   simpa [Set.eq_empty_iff_forall_not_mem, Set.eq_univ_iff_forall] using
-      isClopen_iff.1 hf.isClopen_setOf_eanalyticOrderAt_eq_top
+      isClopen_iff.1 hf.isClopen_setOf_analyticOrderAt_eq_top
 
 /-- On a preconnected set, a meromorphic function has finite order at one point if it has finite
 order at another point. -/
-theorem eanalyticOrderAt_ne_top_of_isPreconnected {x y : 𝕜} (hU : IsPreconnected U) (h₁x : x ∈ U)
-    (hy : y ∈ U) (h₂x : eanalyticOrderAt f x ≠ ⊤) : eanalyticOrderAt f y ≠ ⊤ :=
-  (hf.exists_eanalyticOrderAt_ne_top_iff_forall ⟨nonempty_of_mem h₁x, hU⟩).1 (by use ⟨x, h₁x⟩)
+theorem analyticOrderAt_ne_top_of_isPreconnected {x y : 𝕜} (hU : IsPreconnected U) (h₁x : x ∈ U)
+    (hy : y ∈ U) (h₂x : analyticOrderAt f x ≠ ⊤) : analyticOrderAt f y ≠ ⊤ :=
+  (hf.exists_analyticOrderAt_ne_top_iff_forall ⟨nonempty_of_mem h₁x, hU⟩).1 (by use ⟨x, h₁x⟩)
     ⟨y, hy⟩
 
 /-- The set where an analytic function has zero or infinite order is discrete within its domain of
 analyticity. -/
-theorem codiscrete_setOf_eanalyticOrderAt_eq_zero_or_top :
-    {u : U | eanalyticOrderAt f u = 0 ∨ eanalyticOrderAt f u = ⊤} ∈ Filter.codiscrete U := by
+theorem codiscrete_setOf_analyticOrderAt_eq_zero_or_top :
+    {u : U | analyticOrderAt f u = 0 ∨ analyticOrderAt f u = ⊤} ∈ Filter.codiscrete U := by
   rw [mem_codiscrete_subtype_iff_mem_codiscreteWithin, mem_codiscreteWithin]
   intro x hx
   rw [Filter.disjoint_principal_right]
   rcases (hf x hx).eventually_eq_zero_or_eventually_ne_zero with h₁f | h₁f
   · filter_upwards [eventually_nhdsWithin_of_eventually_nhds h₁f.eventually_nhds] with a ha
-    simp +contextual [(hf a _).eanalyticOrderAt_eq_top, ha]
+    simp +contextual [(hf a _).analyticOrderAt_eq_top, ha]
   · filter_upwards [h₁f] with a ha
-    simp +contextual [(hf a _).eanalyticOrderAt_eq_zero, ha]
+    simp +contextual [(hf a _).analyticOrderAt_eq_zero, ha]
 
 end AnalyticOnNhd

--- a/Mathlib/Analysis/Analytic/Order.lean
+++ b/Mathlib/Analysis/Analytic/Order.lean
@@ -35,7 +35,9 @@ open scoped Classical in
 The order is defined to be `∞` if `f` is identically 0 on a neighbourhood of `z₀`, and otherwise the
 unique `n` such that `f` can locally be written as `f z = (z - z₀) ^ n • g z`, where `g` is analytic
 and does not vanish at `z₀`. See `AnalyticAt.analyticOrderAt_eq_top` and
-`AnalyticAt.analyticOrderAt_eq_natCast` for these equivalences. -/
+`AnalyticAt.analyticOrderAt_eq_natCast` for these equivalences.
+
+If `f` isn't analytic at `z₀`, then `analyticOrderAt f z₀` returns a junk value of `0`. -/
 noncomputable def analyticOrderAt (f : 𝕜 → E) (z₀ : 𝕜) : ℕ∞ :=
   if hf : AnalyticAt 𝕜 f z₀ then
     if h : ∀ᶠ z in 𝓝 z₀, f z = 0 then ⊤
@@ -49,7 +51,9 @@ noncomputable def analyticOrderAt (f : 𝕜 → E) (z₀ : 𝕜) : ℕ∞ :=
 The order is defined to be `0` if `f` is identically zero on a neighbourhood of `z₀`,
 and is otherwise the unique `n` such that `f` can locally be written as `f z = (z - z₀) ^ n • g z`,
 where `g` is analyticand does not vanish at `z₀`. See `AnalyticAt.analyticOrderAt_eq_top` and
-`AnalyticAt.analyticOrderAt_eq_natCast` for these equivalences. -/
+`AnalyticAt.analyticOrderAt_eq_natCast` for these equivalences.
+
+If `f` isn't analytic at `z₀`, then `analyticOrderNatAt f z₀` returns a junk value of `0`. -/
 noncomputable def analyticOrderNatAt (f : 𝕜 → E) (z₀ : 𝕜) : ℕ := (analyticOrderAt f z₀).toNat
 
 @[simp]
@@ -63,17 +67,12 @@ lemma analyticOrderNatAt_of_not_analyticAt (hf : ¬ AnalyticAt 𝕜 f z₀) :
 @[simp] lemma Nat.cast_analyticOrderNatAt (hf : analyticOrderAt f z₀ ≠ ⊤) :
     analyticOrderNatAt f z₀ = analyticOrderAt f z₀ := ENat.coe_toNat hf
 
-lemma analyticOrderAt_eq_top :
-    analyticOrderAt f z₀ = ⊤ ↔ AnalyticAt 𝕜 f z₀ ∧ ∀ᶠ z in 𝓝 z₀, f z = 0 := by
-  unfold analyticOrderAt; split_ifs with hf h <;> simp [*]
+/-- The order of a function `f` at a `z₀` is infinity iff `f` vanishes locally around `z₀`. -/
+lemma analyticOrderAt_eq_top : analyticOrderAt f z₀ = ⊤ ↔ ∀ᶠ z in 𝓝 z₀, f z = 0 where
+  mp hf := by unfold analyticOrderAt at hf; split_ifs at hf with h <;> simp [*] at *
+  mpr hf := by unfold analyticOrderAt; simp [hf, analyticAt_congr hf, analyticAt_const]
 
-/-- The order of an analytic function `f` at a `z₀` is infinity iff `f` vanishes locally around
-`z₀`. -/
-protected lemma AnalyticAt.analyticOrderAt_eq_top (hf : AnalyticAt 𝕜 f z₀) :
-    analyticOrderAt f z₀ = ⊤ ↔ ∀ᶠ z in 𝓝 z₀, f z = 0 := by simp [analyticOrderAt_eq_top, hf]
-
-@[deprecated (since := "2025-05-03")]
-alias AnalyticAt.order_eq_top_iff := AnalyticAt.analyticOrderAt_eq_top
+@[deprecated (since := "2025-05-03")] alias AnalyticAt.order_eq_top_iff := analyticOrderAt_eq_top
 
 /-- The order of an analytic function `f` at `z₀` equals a natural number `n` iff `f` can locally
 be written as `f z = (z - z₀) ^ n • g z`, where `g` is analytic and does not vanish at `z₀`. -/
@@ -199,55 +198,56 @@ lemma analyticOrderAt_congr (hfg : f =ᶠ[𝓝 z₀] g) :
       analyticOrderAt_of_not_analyticAt <| analyticAt_neg.not.2 hf]
 
 /-- The order of a sum is at least the minimum of the orders of the summands. -/
-theorem le_analyticOrderAt_add (hf : AnalyticAt 𝕜 f z₀) (hg : AnalyticAt 𝕜 g z₀) :
+theorem le_analyticOrderAt_add :
     min (analyticOrderAt f z₀) (analyticOrderAt g z₀) ≤ analyticOrderAt (f + g) z₀ := by
-  refine ENat.forall_natCast_le_iff_le.mp fun n ↦ ?_
-  simp only [le_min_iff, natCast_le_analyticOrderAt, hf, hg, hf.add hg]
-  refine fun ⟨⟨F, hF, hF'⟩, ⟨G, hG, hG'⟩⟩ ↦ ⟨F + G, hF.add hG, ?_⟩
-  filter_upwards [hF', hG'] with z using by simp +contextual [mul_add]
+  by_cases hf : AnalyticAt 𝕜 f z₀
+  · by_cases hg : AnalyticAt 𝕜 g z₀
+    · refine ENat.forall_natCast_le_iff_le.mp fun n ↦ ?_
+      simp only [le_min_iff, natCast_le_analyticOrderAt, hf, hg, hf.add hg]
+      refine fun ⟨⟨F, hF, hF'⟩, ⟨G, hG, hG'⟩⟩ ↦ ⟨F + G, hF.add hG, ?_⟩
+      filter_upwards [hF', hG'] with z using by simp +contextual [mul_add]
+    · simp [*]
+  · simp [*]
 
 @[deprecated (since := "2025-05-03")] alias AnalyticAt.order_add := le_analyticOrderAt_add
 
-lemma le_analyticOrderAt_sub (hf : AnalyticAt 𝕜 f z₀) (hg : AnalyticAt 𝕜 g z₀) :
+lemma le_analyticOrderAt_sub :
     min (analyticOrderAt f z₀) (analyticOrderAt g z₀) ≤ analyticOrderAt (f - g) z₀ := by
-  simpa [sub_eq_add_neg] using le_analyticOrderAt_add hf hg.neg
+  simpa [sub_eq_add_neg] using le_analyticOrderAt_add (f := f) (g := -g)
 
-lemma analyticOrderAt_add_eq_left_of_lt (hf : AnalyticAt 𝕜 f z₀) (hg : AnalyticAt 𝕜 g z₀)
-    (hfg : analyticOrderAt f z₀ < analyticOrderAt g z₀) :
+lemma analyticOrderAt_add_eq_left_of_lt (hfg : analyticOrderAt f z₀ < analyticOrderAt g z₀) :
     analyticOrderAt (f + g) z₀ = analyticOrderAt f z₀ :=
-  le_antisymm (by simpa [hfg.not_le] using le_analyticOrderAt_sub (hf.add hg) hg)
-    (by simpa [hfg.le] using le_analyticOrderAt_add hf hg)
+  le_antisymm (by simpa [hfg.not_le] using le_analyticOrderAt_sub (f := f + g) (g := g) (z₀ := z₀))
+    (by simpa [hfg.le] using le_analyticOrderAt_add (f := f) (g := g) (z₀ := z₀))
 
-lemma analyticOrderAt_add_eq_right_of_lt (hf : AnalyticAt 𝕜 f z₀) (hg : AnalyticAt 𝕜 g z₀)
-    (hgf : analyticOrderAt g z₀ < analyticOrderAt f z₀) :
+lemma analyticOrderAt_add_eq_right_of_lt (hgf : analyticOrderAt g z₀ < analyticOrderAt f z₀) :
     analyticOrderAt (f + g) z₀ = analyticOrderAt g z₀ := by
-  rw [add_comm, analyticOrderAt_add_eq_left_of_lt hg hf hgf]
+  rw [add_comm, analyticOrderAt_add_eq_left_of_lt hgf]
 
 @[deprecated (since := "2025-05-03")] alias order_add_of_order_lt_order := le_analyticOrderAt_add
 
 /-- If two functions have unequal orders, then the order of their sum is exactly the minimum
 of the orders of the summands. -/
-theorem analyticOrderAt_add_of_ne (hf : AnalyticAt 𝕜 f z₀) (hg : AnalyticAt 𝕜 g z₀)
-    (hfg : analyticOrderAt f z₀ ≠ analyticOrderAt g z₀) :
+lemma analyticOrderAt_add_of_ne (hfg : analyticOrderAt f z₀ ≠ analyticOrderAt g z₀) :
     analyticOrderAt (f + g) z₀ = min (analyticOrderAt f z₀) (analyticOrderAt g z₀) := by
   obtain hfg | hgf := hfg.lt_or_lt
-  · simpa [hfg.le] using analyticOrderAt_add_eq_left_of_lt hf hg hfg
-  · simpa [hgf.le] using analyticOrderAt_add_eq_right_of_lt hf hg hgf
+  · simpa [hfg.le] using analyticOrderAt_add_eq_left_of_lt hfg
+  · simpa [hgf.le] using analyticOrderAt_add_eq_right_of_lt hgf
 
 @[deprecated (since := "2025-05-03")]
 alias AnalyticAt.order_add_of_order_ne_order := analyticOrderAt_add_of_ne
 
-lemma analyticOrderAt_smul_eq_top_of_left {f : 𝕜 → 𝕜} (hg : AnalyticAt 𝕜 g z₀)
-    (hf : analyticOrderAt f z₀ = ⊤) : analyticOrderAt (f • g) z₀ = ⊤ := by
+lemma analyticOrderAt_smul_eq_top_of_left {f : 𝕜 → 𝕜} (hf : analyticOrderAt f z₀ = ⊤) :
+   analyticOrderAt (f • g) z₀ = ⊤ := by
   rw [analyticOrderAt_eq_top, eventually_nhds_iff] at *
-  obtain ⟨hf, t, h₁t, h₂t, h₃t⟩ := hf
-  exact ⟨hf.smul hg, t, fun y hy ↦ by simp [h₁t y hy], h₂t, h₃t⟩
+  obtain ⟨t, h₁t, h₂t, h₃t⟩ := hf
+  exact ⟨t, fun y hy ↦ by simp [h₁t y hy], h₂t, h₃t⟩
 
-lemma analyticOrderAt_smul_eq_top_of_right {f : 𝕜 → 𝕜} (hf : AnalyticAt 𝕜 f z₀)
-    (hg : analyticOrderAt g z₀ = ⊤) : analyticOrderAt (f • g) z₀ = ⊤ := by
+lemma analyticOrderAt_smul_eq_top_of_right {f : 𝕜 → 𝕜} (hg : analyticOrderAt g z₀ = ⊤) :
+    analyticOrderAt (f • g) z₀ = ⊤ := by
   rw [analyticOrderAt_eq_top, eventually_nhds_iff] at *
-  obtain ⟨hg, t, h₁t, h₂t, h₃t⟩ := hg
-  exact ⟨hf.smul hg, t, fun y hy ↦ by simp [h₁t y hy], h₂t, h₃t⟩
+  obtain ⟨t, h₁t, h₂t, h₃t⟩ := hg
+  exact ⟨t, fun y hy ↦ by simp [h₁t y hy], h₂t, h₃t⟩
 
 /-- The order is additive when scalar multiplying analytic functions. -/
 lemma analyticOrderAt_smul {f : 𝕜 → 𝕜} (hf : AnalyticAt 𝕜 f z₀) (hg : AnalyticAt 𝕜 g z₀) :
@@ -289,17 +289,14 @@ alias analyticAt_order_centeredMonomial := analyticOrderAt_centeredMonomial
 section NontriviallyNormedField
 variable {f g : 𝕜 → 𝕜} {z₀ : 𝕜}
 
-lemma analyticOrderAt_mul_eq_top_of_left (hg : AnalyticAt 𝕜 g z₀)
-    (hf : analyticOrderAt f z₀ = ⊤) : analyticOrderAt (f * g) z₀ = ⊤ :=
-  analyticOrderAt_smul_eq_top_of_left hg hf
+lemma analyticOrderAt_mul_eq_top_of_left (hf : analyticOrderAt f z₀ = ⊤) :
+    analyticOrderAt (f * g) z₀ = ⊤ := analyticOrderAt_smul_eq_top_of_left hf
 
 @[deprecated (since := "2025-05-03")]
 alias AnalyticAt.order_mul_of_order_eq_top := analyticOrderAt_mul_eq_top_of_left
 
-/-- Helper lemma for `analyticOrderAt_mul` -/
-lemma analyticOrderAt_mul_eq_top_of_right (hf : AnalyticAt 𝕜 f z₀)
-    (hg : analyticOrderAt g z₀ = ⊤) : analyticOrderAt (f * g) z₀ = ⊤ :=
-  analyticOrderAt_smul_eq_top_of_right hf hg
+lemma analyticOrderAt_mul_eq_top_of_right (hg : analyticOrderAt g z₀ = ⊤) :
+    analyticOrderAt (f * g) z₀ = ⊤ := analyticOrderAt_smul_eq_top_of_right hg
 
 /-- The order is additive when multiplying analytic functions. -/
 theorem analyticOrderAt_mul (hf : AnalyticAt 𝕜 f z₀) (hg : AnalyticAt 𝕜 g z₀) :
@@ -345,7 +342,7 @@ theorem isClopen_setOf_analyticOrderAt_eq_top : IsClopen {u : U | analyticOrderA
     intro z hz
     rcases (hf z.1 z.2).eventually_eq_zero_or_eventually_ne_zero with h | h
     · -- Case: f is locally zero in a punctured neighborhood of z
-      rw [← (hf z.1 z.2).analyticOrderAt_eq_top] at h
+      rw [← analyticOrderAt_eq_top] at h
       tauto
     · -- Case: f is locally nonzero in a punctured neighborhood of z
       obtain ⟨t', h₁t', h₂t', h₃t'⟩ := eventually_nhds_iff.1 (eventually_nhdsWithin_iff.1 h)
@@ -362,9 +359,9 @@ theorem isClopen_setOf_analyticOrderAt_eq_top : IsClopen {u : U | analyticOrderA
     intro z hz
     conv =>
       arg 1; intro; left; right; arg 1; intro
-      rw [(hf _ <| Subtype.prop _).analyticOrderAt_eq_top, eventually_nhds_iff]
+      rw [analyticOrderAt_eq_top, eventually_nhds_iff]
     simp only [mem_setOf_eq] at hz
-    rw [(hf _ <| Subtype.prop _).analyticOrderAt_eq_top, eventually_nhds_iff] at hz
+    rw [analyticOrderAt_eq_top, eventually_nhds_iff] at hz
     obtain ⟨t', h₁t', h₂t', h₃t'⟩ := hz
     use Subtype.val ⁻¹' t'
     simp only [mem_compl_iff, mem_singleton_iff, isOpen_induced h₂t', mem_preimage,
@@ -406,7 +403,7 @@ theorem codiscrete_setOf_analyticOrderAt_eq_zero_or_top :
   rw [Filter.disjoint_principal_right]
   rcases (hf x hx).eventually_eq_zero_or_eventually_ne_zero with h₁f | h₁f
   · filter_upwards [eventually_nhdsWithin_of_eventually_nhds h₁f.eventually_nhds] with a ha
-    simp +contextual [(hf a _).analyticOrderAt_eq_top, ha]
+    simp +contextual [analyticOrderAt_eq_top, ha]
   · filter_upwards [h₁f] with a ha
     simp +contextual [(hf a _).analyticOrderAt_eq_zero, ha]
 

--- a/Mathlib/Analysis/Analytic/Order.lean
+++ b/Mathlib/Analysis/Analytic/Order.lean
@@ -142,7 +142,13 @@ alias AnalyticAt.order_eq_zero_iff := AnalyticAt.analyticOrderAt_eq_zero
 protected lemma AnalyticAt.analyticOrderAt_ne_zero (hf : AnalyticAt 𝕜 f z₀) :
     analyticOrderAt f z₀ ≠ 0 ↔ f z₀ = 0 := hf.analyticOrderAt_eq_zero.not_left
 
-/-- An analytic function vanishes at a point if its order is nonzero when converted to ℕ. -/
+/-- A function vanishes at a point if its analytic order is nonzero in `ℕ∞`. -/
+lemma apply_eq_zero_of_analyticOrderAt_ne_zero (hf : analyticOrderAt f z₀ ≠ 0) :
+    f z₀ = 0 := by
+  by_cases hf' : AnalyticAt 𝕜 f z₀ <;> simp_all [analyticOrderAt_eq_zero] 
+
+/-- A function vanishes at a point if its analytic order is nonzero when converted to 
+ℕ. -/
 lemma apply_eq_zero_of_analyticOrderNatAt_ne_zero (hf : analyticOrderNatAt f z₀ ≠ 0) :
     f z₀ = 0 := by
   by_cases hf' : AnalyticAt 𝕜 f z₀ <;> simp_all [analyticOrderNatAt, analyticOrderAt_eq_zero]

--- a/Mathlib/Analysis/Analytic/Order.lean
+++ b/Mathlib/Analysis/Analytic/Order.lean
@@ -42,6 +42,8 @@ noncomputable def eanalyticOrderAt (f : 𝕜 → E) (z₀ : 𝕜) : ℕ∞ :=
     else ↑(hf.exists_eventuallyEq_pow_smul_nonzero_iff.mpr h).choose
   else 0
 
+@[deprecated (since := "2025-05-02")] alias AnalyticAt.order := eanalyticOrderAt
+
 /-- The order of vanishing of `f` at `z₀`, as an element of `ℕ∞`.
 
 The order is defined to be `∞` if `f` is identically 0 on a neighbourhood of `z₀`, and otherwise the
@@ -70,6 +72,9 @@ lemma eanalyticOrderAt_eq_top :
 protected lemma AnalyticAt.eanalyticOrderAt_eq_top (hf : AnalyticAt 𝕜 f z₀) :
     eanalyticOrderAt f z₀ = ⊤ ↔ ∀ᶠ z in 𝓝 z₀, f z = 0 := by simp [eanalyticOrderAt_eq_top, hf]
 
+@[deprecated (since := "2025-05-03")]
+alias AnalyticAt.order_eq_top_iff := AnalyticAt.eanalyticOrderAt_eq_top
+
 /-- The order of an analytic function `f` at `z₀` equals a natural number `n` iff `f` can locally
 be written as `f z = (z - z₀) ^ n • g z`, where `g` is analytic and does not vanish at `z₀`. -/
 lemma AnalyticAt.eanalyticOrderAt_eq_natCast (hf : AnalyticAt 𝕜 f z₀) :
@@ -84,6 +89,9 @@ lemma AnalyticAt.eanalyticOrderAt_eq_natCast (hf : AnalyticAt 𝕜 f z₀) :
   · rw [← hf.exists_eventuallyEq_pow_smul_nonzero_iff] at h
     refine ⟨fun hn ↦ (WithTop.coe_inj.mp hn : h.choose = n) ▸ h.choose_spec, fun h' ↦ ?_⟩
     rw [AnalyticAt.unique_eventuallyEq_pow_smul_nonzero h.choose_spec h']
+
+@[deprecated (since := "2025-05-03")]
+alias AnalyticAt.order_eq_nat_iff := AnalyticAt.eanalyticOrderAt_eq_natCast
 
 /-- The order of an analytic function `f` at `z₀` equals a natural number `n` iff `f` can locally
 be written as `f z = (z - z₀) ^ n • g z`, where `g` is analytic and does not vanish at `z₀`. -/
@@ -106,8 +114,11 @@ lemma AnalyticAt.eanalyticOrderAt_ne_top (hf : AnalyticAt 𝕜 f z₀) :
   simp only [← ENat.coe_toNat_eq_self, Eq.comm, EventuallyEq, ← hf.eanalyticOrderAt_eq_natCast,
     analyticOrderAt]
 
+@[deprecated (since := "2025-05-03")]
+alias AnalyticAt.order_ne_top_iff := AnalyticAt.eanalyticOrderAt_ne_top
+
 @[deprecated (since := "2025-02-03")]
-alias order_neq_top_iff := AnalyticAt.eanalyticOrderAt_ne_top
+alias AnalyticAt.order_neq_top_iff := AnalyticAt.eanalyticOrderAt_ne_top
 
 lemma eanalyticOrderAt_eq_zero : eanalyticOrderAt f z₀ = 0 ↔ ¬ AnalyticAt 𝕜 f z₀ ∨ f z₀ ≠ 0 := by
   by_cases hf : AnalyticAt 𝕜 f z₀
@@ -125,6 +136,9 @@ lemma eanalyticOrderAt_ne_zero : eanalyticOrderAt f z₀ ≠ 0 ↔ AnalyticAt �
 protected lemma AnalyticAt.eanalyticOrderAt_eq_zero (hf : AnalyticAt 𝕜 f z₀) :
     eanalyticOrderAt f z₀ = 0 ↔ f z₀ ≠ 0 := by simp [hf, eanalyticOrderAt_eq_zero]
 
+@[deprecated (since := "2025-05-03")]
+alias AnalyticAt.order_eq_zero_iff := AnalyticAt.eanalyticOrderAt_eq_zero
+
 /-- The order of an analytic function `f` at `z₀` is zero iff `f` does not vanish at `z₀`. -/
 protected lemma AnalyticAt.eanalyticOrderAt_ne_zero (hf : AnalyticAt 𝕜 f z₀) :
     eanalyticOrderAt f z₀ ≠ 0 ↔ f z₀ = 0 := hf.eanalyticOrderAt_eq_zero.not_left
@@ -133,6 +147,8 @@ protected lemma AnalyticAt.eanalyticOrderAt_ne_zero (hf : AnalyticAt 𝕜 f z₀
 lemma apply_eq_zero_of_analyticOrderAt_ne_zero (hf : analyticOrderAt f z₀ ≠ 0) : f z₀ = 0 := by
   by_cases hf' : AnalyticAt 𝕜 f z₀ <;> simp_all [analyticOrderAt, eanalyticOrderAt_eq_zero]
 
+@[deprecated (since := "2025-05-03")]
+alias AnalyticAt.apply_eq_zero_of_order_toNat_ne_zero := apply_eq_zero_of_analyticOrderAt_ne_zero
 
 /-- Characterization of which natural numbers are `≤ hf.order`. Useful for avoiding case splits,
 since it applies whether or not the order is `∞`. -/
@@ -158,6 +174,8 @@ lemma natCast_le_eanalyticOrderAt (hf : AnalyticAt 𝕜 f z₀) {n : ℕ} :
           ← mul_smul] at hf'
         rw [pow_sub₀ _ (sub_ne_zero_of_ne hz) (by omega), ← hf']
 
+@[deprecated (since := "2025-05-03")] alias natCast_le_order_iff := natCast_le_eanalyticOrderAt
+
 /-- If two functions agree in a neighborhood of `z₀`, then their orders at `z₀` agree. -/
 lemma eanalyticOrderAt_congr (hfg : f =ᶠ[𝓝 z₀] g) :
     eanalyticOrderAt f z₀ = eanalyticOrderAt g z₀ := by
@@ -168,6 +186,55 @@ lemma eanalyticOrderAt_congr (hfg : f =ᶠ[𝓝 z₀] g) :
     exact hfg.congr_left
   · rw [eanalyticOrderAt_of_not_analyticAt hf,
       eanalyticOrderAt_of_not_analyticAt fun hg ↦ hf <| hg.congr hfg.symm]
+
+@[deprecated (since := "2025-05-03")] alias AnalyticAt.order_congr := eanalyticOrderAt_congr
+
+@[simp] lemma eanalyticOrderAt_neg : eanalyticOrderAt (-f) z₀ = eanalyticOrderAt f z₀ := by
+  by_cases hf : AnalyticAt 𝕜 f z₀
+  · refine ENat.eq_of_forall_natCast_le_iff fun n ↦ ?_
+    simp only [ natCast_le_eanalyticOrderAt, hf, hf.neg]
+    exact (Equiv.neg _).exists_congr <| by simp [neg_eq_iff_eq_neg]
+  · rw [eanalyticOrderAt_of_not_analyticAt hf,
+      eanalyticOrderAt_of_not_analyticAt <| analyticAt_neg.not.2 hf]
+
+/-- The order of a sum is at least the minimum of the orders of the summands. -/
+theorem le_eanalyticOrderAt_add (hf : AnalyticAt 𝕜 f z₀) (hg : AnalyticAt 𝕜 g z₀) :
+    min (eanalyticOrderAt f z₀) (eanalyticOrderAt g z₀) ≤ eanalyticOrderAt (f + g) z₀ := by
+  refine ENat.forall_natCast_le_iff_le.mp fun n ↦ ?_
+  simp only [le_min_iff, natCast_le_eanalyticOrderAt, hf, hg, hf.add hg]
+  refine fun ⟨⟨F, hF, hF'⟩, ⟨G, hG, hG'⟩⟩ ↦ ⟨F + G, hF.add hG, ?_⟩
+  filter_upwards [hF', hG'] with z using by simp +contextual [mul_add]
+
+@[deprecated (since := "2025-05-03")] alias AnalyticAt.order_add := le_eanalyticOrderAt_add
+
+lemma le_eanalyticOrderAt_sub (hf : AnalyticAt 𝕜 f z₀) (hg : AnalyticAt 𝕜 g z₀) :
+    min (eanalyticOrderAt f z₀) (eanalyticOrderAt g z₀) ≤ eanalyticOrderAt (f - g) z₀ := by
+  simpa [sub_eq_add_neg] using le_eanalyticOrderAt_add hf hg.neg
+
+lemma eanalyticOrderAt_add_eq_left_of_lt (hf : AnalyticAt 𝕜 f z₀) (hg : AnalyticAt 𝕜 g z₀)
+    (hfg : eanalyticOrderAt f z₀ < eanalyticOrderAt g z₀) :
+    eanalyticOrderAt (f + g) z₀ = eanalyticOrderAt f z₀ :=
+  le_antisymm (by simpa [hfg.not_le] using le_eanalyticOrderAt_sub (hf.add hg) hg)
+    (by simpa [hfg.le] using le_eanalyticOrderAt_add hf hg)
+
+lemma eanalyticOrderAt_add_eq_right_of_lt (hf : AnalyticAt 𝕜 f z₀) (hg : AnalyticAt 𝕜 g z₀)
+    (hgf : eanalyticOrderAt g z₀ < eanalyticOrderAt f z₀) :
+    eanalyticOrderAt (f + g) z₀ = eanalyticOrderAt g z₀ := by
+  rw [add_comm, eanalyticOrderAt_add_eq_left_of_lt hg hf hgf]
+
+@[deprecated (since := "2025-05-03")] alias order_add_of_order_lt_order := le_eanalyticOrderAt_add
+
+/-- If two functions have unequal orders, then the order of their sum is exactly the minimum
+of the orders of the summands. -/
+theorem eanalyticOrderAt_add_of_ne (hf : AnalyticAt 𝕜 f z₀) (hg : AnalyticAt 𝕜 g z₀)
+    (hfg : eanalyticOrderAt f z₀ ≠ eanalyticOrderAt g z₀) :
+    eanalyticOrderAt (f + g) z₀ = min (eanalyticOrderAt f z₀) (eanalyticOrderAt g z₀) := by
+  obtain hfg | hgf := hfg.lt_or_lt
+  · simpa [hfg.le] using eanalyticOrderAt_add_eq_left_of_lt hf hg hfg
+  · simpa [hgf.le] using eanalyticOrderAt_add_eq_right_of_lt hf hg hgf
+
+@[deprecated (since := "2025-05-03")]
+alias AnalyticAt.order_add_of_order_ne_order := eanalyticOrderAt_add_of_ne
 
 lemma eanalyticOrderAt_smul_eq_top_of_left {f : 𝕜 → 𝕜} (hg : AnalyticAt 𝕜 g z₀)
     (hf : eanalyticOrderAt f z₀ = ⊤) : eanalyticOrderAt (f • g) z₀ = ⊤ := by
@@ -215,6 +282,9 @@ lemma eanalyticOrderAt_centeredMonomial {z₀ : 𝕜} {n : ℕ} :
   rw [AnalyticAt.eanalyticOrderAt_eq_natCast (by fun_prop)]
   exact ⟨1, by simp [Pi.one_def, analyticAt_const]⟩
 
+@[deprecated (since := "2025-05-03")]
+alias analyticAt_order_centeredMonomial := eanalyticOrderAt_centeredMonomial
+
 section NontriviallyNormedField
 variable {f g : 𝕜 → 𝕜} {z₀ : 𝕜}
 
@@ -222,6 +292,9 @@ variable {f g : 𝕜 → 𝕜} {z₀ : 𝕜}
 lemma eanalyticOrderAt_mul_eq_top_of_left (hg : AnalyticAt 𝕜 g z₀)
     (hf : eanalyticOrderAt f z₀ = ⊤) : eanalyticOrderAt (f * g) z₀ = ⊤ :=
   eanalyticOrderAt_smul_eq_top_of_left hg hf
+
+@[deprecated (since := "2025-05-03")]
+alias AnalyticAt.order_mul_of_order_eq_top := eanalyticOrderAt_mul_eq_top_of_left
 
 /-- Helper lemma for `eanalyticOrderAt_mul` -/
 lemma eanalyticOrderAt_mul_eq_top_of_right (hf : AnalyticAt 𝕜 f z₀)
@@ -232,6 +305,8 @@ lemma eanalyticOrderAt_mul_eq_top_of_right (hf : AnalyticAt 𝕜 f z₀)
 theorem eanalyticOrderAt_mul (hf : AnalyticAt 𝕜 f z₀) (hg : AnalyticAt 𝕜 g z₀) :
     eanalyticOrderAt (f * g) z₀ = eanalyticOrderAt f z₀ + eanalyticOrderAt g z₀ :=
   eanalyticOrderAt_smul hf hg
+
+@[deprecated (since := "2025-05-03")] alias AnalyticAt.order_mul := eanalyticOrderAt_mul
 
 /-- The order is additive when multiplying analytic functions. -/
 theorem analyticOrderAt_mul (hf : AnalyticAt 𝕜 f z₀) (hg : AnalyticAt 𝕜 g z₀)
@@ -245,50 +320,13 @@ theorem eanalyticOrderAt_pow (hf : AnalyticAt 𝕜 f z₀) :
   | 0 => by simp [eanalyticOrderAt_eq_zero]
   | n + 1 => by simp [add_mul, pow_add, eanalyticOrderAt_mul (hf.pow n), eanalyticOrderAt_pow, hf]
 
-@[simp] lemma eanalyticOrderAt_neg : eanalyticOrderAt (-f) z₀ = eanalyticOrderAt f z₀ := by
-  by_cases hf : AnalyticAt 𝕜 f z₀
-  · refine ENat.eq_of_forall_natCast_le_iff fun n ↦ ?_
-    simp only [ natCast_le_eanalyticOrderAt, hf, hf.neg]
-    exact (Equiv.neg _).exists_congr <| by simp [neg_eq_iff_eq_neg]
-  · rw [eanalyticOrderAt_of_not_analyticAt hf,
-      eanalyticOrderAt_of_not_analyticAt <| analyticAt_neg.not.2 hf]
-
-/-- The order of a sum is at least the minimum of the orders of the summands. -/
-theorem le_eanalyticOrderAt_add (hf : AnalyticAt 𝕜 f z₀) (hg : AnalyticAt 𝕜 g z₀) :
-    min (eanalyticOrderAt f z₀) (eanalyticOrderAt g z₀) ≤ eanalyticOrderAt (f + g) z₀ := by
-  refine ENat.forall_natCast_le_iff_le.mp fun n ↦ ?_
-  simp only [le_min_iff, natCast_le_eanalyticOrderAt, hf, hg, hf.add hg]
-  refine fun ⟨⟨F, hF, hF'⟩, ⟨G, hG, hG'⟩⟩ ↦ ⟨F + G, hF.add hG, ?_⟩
-  filter_upwards [hF', hG'] with z using by simp +contextual [mul_add]
-
-lemma le_eanalyticOrderAt_sub (hf : AnalyticAt 𝕜 f z₀) (hg : AnalyticAt 𝕜 g z₀) :
-    min (eanalyticOrderAt f z₀) (eanalyticOrderAt g z₀) ≤ eanalyticOrderAt (f - g) z₀ := by
-  simpa [sub_eq_add_neg] using le_eanalyticOrderAt_add hf hg.neg
-
-lemma eanalyticOrderAt_add_eq_left_of_lt (hf : AnalyticAt 𝕜 f z₀) (hg : AnalyticAt 𝕜 g z₀)
-    (hfg : eanalyticOrderAt f z₀ < eanalyticOrderAt g z₀) :
-    eanalyticOrderAt (f + g) z₀ = eanalyticOrderAt f z₀ :=
-  le_antisymm (by simpa [hfg.not_le] using le_eanalyticOrderAt_sub (hf.add hg) hg)
-    (by simpa [hfg.le] using le_eanalyticOrderAt_add hf hg)
-
-lemma eanalyticOrderAt_add_eq_right_of_lt (hf : AnalyticAt 𝕜 f z₀) (hg : AnalyticAt 𝕜 g z₀)
-    (hgf : eanalyticOrderAt g z₀ < eanalyticOrderAt f z₀) :
-    eanalyticOrderAt (f + g) z₀ = eanalyticOrderAt g z₀ := by
-  rw [add_comm, eanalyticOrderAt_add_eq_left_of_lt hg hf hgf]
-
-/-- If two functions have unequal orders, then the order of their sum is exactly the minimum
-of the orders of the summands. -/
-theorem eanalyticOrderAt_add_of_ne (hf : AnalyticAt 𝕜 f z₀) (hg : AnalyticAt 𝕜 g z₀)
-    (hfg : eanalyticOrderAt f z₀ ≠ eanalyticOrderAt g z₀) :
-    eanalyticOrderAt (f + g) z₀ = min (eanalyticOrderAt f z₀) (eanalyticOrderAt g z₀) := by
-  obtain hfg | hgf := hfg.lt_or_lt
-  · simpa [hfg.le] using eanalyticOrderAt_add_eq_left_of_lt hf hg hfg
-  · simpa [hgf.le] using eanalyticOrderAt_add_eq_right_of_lt hf hg hgf
+@[deprecated (since := "2025-05-03")] alias AnalyticAt.order_pow := eanalyticOrderAt_pow
 
 /-- The order multiplies by `n` when taking an analytic function to its `n`th power. -/
 theorem analyticOrderAt_pow (hf : AnalyticAt 𝕜 f z₀) (n : ℕ) :
     analyticOrderAt (f ^ n) z₀ = n • analyticOrderAt f z₀ := by
   simp [analyticOrderAt, eanalyticOrderAt_pow, hf]
+
 
 end NontriviallyNormedField
 

--- a/Mathlib/Analysis/Meromorphic/FactorizedRational.lean
+++ b/Mathlib/Analysis/Meromorphic/FactorizedRational.lean
@@ -163,7 +163,7 @@ theorem order_ne_top {z : 𝕜} (d : 𝕜 → ℤ) :
   · rw [← mulSupport] at hd
     have : AnalyticAt 𝕜 (1 : 𝕜 → 𝕜) z := analyticAt_const
     simp [finprod_of_infinite_mulSupport hd, this.meromorphicAt_order,
-      this.order_eq_zero_iff.2 (by simp)]
+      this.analyticOrderAt_eq_zero.2 (by simp)]
 
 /--
 If `D` is a divisor, then the divisor of the factorized rational function equals `D`.

--- a/Mathlib/Analysis/Meromorphic/NormalForm.lean
+++ b/Mathlib/Analysis/Meromorphic/NormalForm.lean
@@ -67,13 +67,13 @@ theorem meromorphicNFAt_iff_analyticAt_or :
         simp [this, WithTop.coe_lt_zero.2 (not_le.1 hn), h₃g.eq_of_nhds,
           zero_zpow n (ne_of_not_le hn).symm]
   · rintro (h | ⟨h₁, h₂, h₃⟩)
-    · by_cases h₂f : h.order = ⊤
-      · rw [AnalyticAt.order_eq_top_iff] at h₂f
+    · by_cases h₂f : eanalyticOrderAt f x = ⊤
+      · rw [h.eanalyticOrderAt_eq_top] at h₂f
         tauto
       · right
-        use h.order.toNat
-        have : h.order ≠ ⊤ := h₂f
-        rw [← ENat.coe_toNat_eq_self, eq_comm, AnalyticAt.order_eq_nat_iff] at this
+        use analyticOrderAt f x
+        have : eanalyticOrderAt f x ≠ ⊤ := h₂f
+        rw [← ENat.coe_toNat_eq_self, eq_comm, h.eanalyticOrderAt_eq_natCast] at this
         obtain ⟨g, h₁g, h₂g, h₃g⟩ := this
         use g, h₁g, h₂g
         simpa
@@ -143,8 +143,7 @@ theorem MeromorphicNFAt.order_eq_zero_iff (hf : MeromorphicNFAt f x) :
   constructor
   · intro h₁f
     have h₂f := hf.order_nonneg_iff_analyticAt.1 (le_of_eq h₁f.symm)
-    apply h₂f.order_eq_zero_iff.1
-    apply (ENat.map_natCast_eq_zero (α := ℤ)).1
+    rw [← h₂f.eanalyticOrderAt_eq_zero, ← ENat.map_natCast_eq_zero (α := ℤ)]
     rwa [h₂f.meromorphicAt_order] at h₁f
   · intro h
     rcases id hf with h₁ | ⟨n, g, h₁g, h₂g, h₃g⟩

--- a/Mathlib/Analysis/Meromorphic/NormalForm.lean
+++ b/Mathlib/Analysis/Meromorphic/NormalForm.lean
@@ -67,13 +67,13 @@ theorem meromorphicNFAt_iff_analyticAt_or :
         simp [this, WithTop.coe_lt_zero.2 (not_le.1 hn), h₃g.eq_of_nhds,
           zero_zpow n (ne_of_not_le hn).symm]
   · rintro (h | ⟨h₁, h₂, h₃⟩)
-    · by_cases h₂f : eanalyticOrderAt f x = ⊤
-      · rw [h.eanalyticOrderAt_eq_top] at h₂f
+    · by_cases h₂f : analyticOrderAt f x = ⊤
+      · rw [h.analyticOrderAt_eq_top] at h₂f
         tauto
       · right
-        use analyticOrderAt f x
-        have : eanalyticOrderAt f x ≠ ⊤ := h₂f
-        rw [← ENat.coe_toNat_eq_self, eq_comm, h.eanalyticOrderAt_eq_natCast] at this
+        use analyticOrderNatAt f x
+        have : analyticOrderAt f x ≠ ⊤ := h₂f
+        rw [← ENat.coe_toNat_eq_self, eq_comm, h.analyticOrderAt_eq_natCast] at this
         obtain ⟨g, h₁g, h₂g, h₃g⟩ := this
         use g, h₁g, h₂g
         simpa
@@ -143,7 +143,7 @@ theorem MeromorphicNFAt.order_eq_zero_iff (hf : MeromorphicNFAt f x) :
   constructor
   · intro h₁f
     have h₂f := hf.order_nonneg_iff_analyticAt.1 (le_of_eq h₁f.symm)
-    rw [← h₂f.eanalyticOrderAt_eq_zero, ← ENat.map_natCast_eq_zero (α := ℤ)]
+    rw [← h₂f.analyticOrderAt_eq_zero, ← ENat.map_natCast_eq_zero (α := ℤ)]
     rwa [h₂f.meromorphicAt_order] at h₁f
   · intro h
     rcases id hf with h₁ | ⟨n, g, h₁g, h₂g, h₃g⟩

--- a/Mathlib/Analysis/Meromorphic/NormalForm.lean
+++ b/Mathlib/Analysis/Meromorphic/NormalForm.lean
@@ -68,7 +68,7 @@ theorem meromorphicNFAt_iff_analyticAt_or :
           zero_zpow n (ne_of_not_le hn).symm]
   · rintro (h | ⟨h₁, h₂, h₃⟩)
     · by_cases h₂f : analyticOrderAt f x = ⊤
-      · rw [h.analyticOrderAt_eq_top] at h₂f
+      · rw [analyticOrderAt_eq_top] at h₂f
         tauto
       · right
         use analyticOrderNatAt f x

--- a/Mathlib/Analysis/Meromorphic/Order.lean
+++ b/Mathlib/Analysis/Meromorphic/Order.lean
@@ -52,13 +52,13 @@ lemma order_eq_top_iff (hf : MeromorphicAt f x) :
   · rw [h, ENat.map_top, ← WithTop.coe_natCast,
       top_sub, eq_self, true_iff, eventually_nhdsWithin_iff]
     rw [analyticOrderAt_eq_top] at h
-    filter_upwards [h.2] with z hf hz
+    filter_upwards [h] with z hf hz
     rwa [smul_eq_zero_iff_right <| pow_ne_zero _ (sub_ne_zero.mpr hz)] at hf
   · obtain ⟨m, hm⟩ := ENat.ne_top_iff_exists.mp h
     simp only [← hm, ENat.map_coe, WithTop.coe_natCast, sub_eq_top_iff, WithTop.natCast_ne_top,
       or_self, false_iff]
     contrapose! h
-    rw [hf.choose_spec.analyticOrderAt_eq_top]
+    rw [analyticOrderAt_eq_top]
     rw [← hf.choose_spec.frequently_eq_iff_eventually_eq analyticAt_const]
     apply Eventually.frequently
     filter_upwards [h] with z hfz
@@ -72,7 +72,7 @@ lemma order_eq_int_iff {n : ℤ} (hf : MeromorphicAt f x) : hf.order = n ↔
   by_cases h : analyticOrderAt (fun z ↦ (z - x) ^ hf.choose • f z) x = ⊤
   · rw [h, ENat.map_top, ← WithTop.coe_natCast, top_sub,
       eq_false_intro WithTop.top_ne_coe, false_iff]
-    rw [hf.choose_spec.analyticOrderAt_eq_top] at h
+    rw [analyticOrderAt_eq_top] at h
     refine fun ⟨g, hg_an, hg_ne, hg_eq⟩ ↦ hg_ne ?_
     apply EventuallyEq.eq_of_nhds
     rw [EventuallyEq, ← AnalyticAt.frequently_eq_iff_eventually_eq hg_an analyticAt_const]
@@ -247,7 +247,7 @@ lemma _root_.AnalyticAt.meromorphicAt_order (hf : AnalyticAt 𝕜 f x) :
     hf.meromorphicAt.order = (analyticOrderAt f x).map (↑) := by
   cases hn : analyticOrderAt f x
   · rw [ENat.map_top, order_eq_top_iff]
-    exact (hf.analyticOrderAt_eq_top.mp hn).filter_mono nhdsWithin_le_nhds
+    exact (analyticOrderAt_eq_top.mp hn).filter_mono nhdsWithin_le_nhds
   · simp_rw [ENat.map_coe, order_eq_int_iff, zpow_natCast]
     rcases hf.analyticOrderAt_eq_natCast.mp hn with ⟨g, h1, h2, h3⟩
     exact ⟨g, h1, h2, h3.filter_mono nhdsWithin_le_nhds⟩

--- a/Mathlib/Analysis/Meromorphic/Order.lean
+++ b/Mathlib/Analysis/Meromorphic/Order.lean
@@ -16,7 +16,9 @@ This file defines the order of a meromorphic function `f` at a point `z₀`, as 
 We characterize the order being `< 0`, or `= 0`, or `> 0`, as the convergence of the function
 to infinity, resp. a nonzero constant, resp. zero.
 
-TODO: Uniformize API between analytic and meromorphic functions
+## TODO
+
+Uniformize API between analytic and meromorphic functions
 -/
 
 open Filter Set WithTop.LinearOrderedAddCommGroup
@@ -39,24 +41,24 @@ unique `n` such that `f` can locally be written as `f z = (z - z₀) ^ n • g z
 and does not vanish at `z₀`. See `MeromorphicAt.order_eq_top_iff` and
 `MeromorphicAt.order_eq_int_iff` for these equivalences. -/
 noncomputable def order (hf : MeromorphicAt f x) : WithTop ℤ :=
-  (hf.choose_spec.order.map (↑· : ℕ → ℤ)) - hf.choose
+  ((eanalyticOrderAt (fun z ↦ (z - x) ^ hf.choose • f z) x).map (↑· : ℕ → ℤ)) - hf.choose
 
 /-- The order of a meromorphic function `f` at a `z₀` is infinity iff `f` vanishes locally around
 `z₀`. -/
 lemma order_eq_top_iff (hf : MeromorphicAt f x) :
     hf.order = ⊤ ↔ ∀ᶠ z in 𝓝[≠] x, f z = 0 := by
   unfold order
-  by_cases h : hf.choose_spec.order = ⊤
+  by_cases h : eanalyticOrderAt (fun z ↦ (z - x) ^ hf.choose • f z) x = ⊤
   · rw [h, ENat.map_top, ← WithTop.coe_natCast,
       top_sub, eq_self, true_iff, eventually_nhdsWithin_iff]
-    rw [AnalyticAt.order_eq_top_iff] at h
-    filter_upwards [h] with z hf hz
+    rw [eanalyticOrderAt_eq_top] at h
+    filter_upwards [h.2] with z hf hz
     rwa [smul_eq_zero_iff_right <| pow_ne_zero _ (sub_ne_zero.mpr hz)] at hf
   · obtain ⟨m, hm⟩ := ENat.ne_top_iff_exists.mp h
     simp only [← hm, ENat.map_coe, WithTop.coe_natCast, sub_eq_top_iff, WithTop.natCast_ne_top,
       or_self, false_iff]
     contrapose! h
-    rw [AnalyticAt.order_eq_top_iff]
+    rw [hf.choose_spec.eanalyticOrderAt_eq_top]
     rw [← hf.choose_spec.frequently_eq_iff_eventually_eq analyticAt_const]
     apply Eventually.frequently
     filter_upwards [h] with z hfz
@@ -67,10 +69,10 @@ written as `f z = (z - z₀) ^ n • g z`, where `g` is analytic and does not va
 lemma order_eq_int_iff {n : ℤ} (hf : MeromorphicAt f x) : hf.order = n ↔
     ∃ g : 𝕜 → E, AnalyticAt 𝕜 g x ∧ g x ≠ 0 ∧ ∀ᶠ z in 𝓝[≠] x, f z = (z - x) ^ n • g z := by
   unfold order
-  by_cases h : hf.choose_spec.order = ⊤
+  by_cases h : eanalyticOrderAt (fun z ↦ (z - x) ^ hf.choose • f z) x = ⊤
   · rw [h, ENat.map_top, ← WithTop.coe_natCast, top_sub,
       eq_false_intro WithTop.top_ne_coe, false_iff]
-    rw [AnalyticAt.order_eq_top_iff] at h
+    rw [hf.choose_spec.eanalyticOrderAt_eq_top] at h
     refine fun ⟨g, hg_an, hg_ne, hg_eq⟩ ↦ hg_ne ?_
     apply EventuallyEq.eq_of_nhds
     rw [EventuallyEq, ← AnalyticAt.frequently_eq_iff_eventually_eq hg_an analyticAt_const]
@@ -81,7 +83,7 @@ lemma order_eq_int_iff {n : ℤ} (hf : MeromorphicAt f x) : hf.order = n ↔
     exact mul_ne_zero (pow_ne_zero _ (sub_ne_zero.mpr hz)) (zpow_ne_zero _ (sub_ne_zero.mpr hz))
   · obtain ⟨m, h⟩ := ENat.ne_top_iff_exists.mp h
     rw [← h, ENat.map_coe, ← WithTop.coe_natCast, ← coe_sub, WithTop.coe_inj]
-    obtain ⟨g, hg_an, hg_ne, hg_eq⟩ := (AnalyticAt.order_eq_nat_iff _).mp h.symm
+    obtain ⟨g, hg_an, hg_ne, hg_eq⟩ := hf.choose_spec.eanalyticOrderAt_eq_natCast.mp h.symm
     replace hg_eq : ∀ᶠ (z : 𝕜) in 𝓝[≠] x, f z = (z - x) ^ (↑m - ↑hf.choose : ℤ) • g z := by
       rw [eventually_nhdsWithin_iff]
       filter_upwards [hg_eq] with z hg_eq hz
@@ -242,13 +244,12 @@ theorem order_congr (hf₁ : MeromorphicAt f₁ x)
 
 /-- Compatibility of notions of `order` for analytic and meromorphic functions. -/
 lemma _root_.AnalyticAt.meromorphicAt_order (hf : AnalyticAt 𝕜 f x) :
-    hf.meromorphicAt.order = hf.order.map (↑) := by
-  rcases eq_or_ne hf.order ⊤ with ho | ho
-  · rw [ho, ENat.map_top, order_eq_top_iff]
-    exact (hf.order_eq_top_iff.mp ho).filter_mono nhdsWithin_le_nhds
-  · obtain ⟨n, hn⟩ := ENat.ne_top_iff_exists.mp ho
-    simp_rw [← hn, ENat.map_coe, order_eq_int_iff, zpow_natCast]
-    rcases hf.order_eq_nat_iff.mp hn.symm with ⟨g, h1, h2, h3⟩
+    hf.meromorphicAt.order = (eanalyticOrderAt f x).map (↑) := by
+  cases hn : eanalyticOrderAt f x
+  · rw [ENat.map_top, order_eq_top_iff]
+    exact (hf.eanalyticOrderAt_eq_top.mp hn).filter_mono nhdsWithin_le_nhds
+  · simp_rw [ENat.map_coe, order_eq_int_iff, zpow_natCast]
+    rcases hf.eanalyticOrderAt_eq_natCast.mp hn with ⟨g, h1, h2, h3⟩
     exact ⟨g, h1, h2, h3.filter_mono nhdsWithin_le_nhds⟩
 
 /--
@@ -589,11 +590,7 @@ theorem codiscrete_setOf_order_eq_zero_or_top :
     obtain ⟨t, h₁t, h₂t, h₃t⟩ := h₁a
     use t \ {x}, fun y h₁y _ ↦ h₁t y h₁y.1 h₁y.2
     exact ⟨h₂t.sdiff isClosed_singleton, Set.mem_diff_of_mem h₃t hax⟩
-  · filter_upwards [hf.eventually_analyticAt_or_mem_compl hx, h₁f] with a h₁a h'₁a
-    simp only [mem_compl_iff, mem_diff, mem_image, mem_setOf_eq, Subtype.exists, exists_and_right,
-      exists_eq_right, not_exists, not_or, not_and, not_forall, Decidable.not_not]
-    rcases h₁a with h' | h'
-    · simp +contextual [h'.meromorphicAt_order, h'.order_eq_zero_iff.2, h'₁a]
-    · exact fun ha ↦ (h' ha).elim
+  · filter_upwards [(hf x hx).eventually_analyticAt, h₁f] with a h₁a
+    simp +contextual [h₁a.meromorphicAt_order, h₁a.eanalyticOrderAt_eq_zero.2]
 
 end MeromorphicOn

--- a/Mathlib/Analysis/Meromorphic/Order.lean
+++ b/Mathlib/Analysis/Meromorphic/Order.lean
@@ -41,24 +41,24 @@ unique `n` such that `f` can locally be written as `f z = (z - z₀) ^ n • g z
 and does not vanish at `z₀`. See `MeromorphicAt.order_eq_top_iff` and
 `MeromorphicAt.order_eq_int_iff` for these equivalences. -/
 noncomputable def order (hf : MeromorphicAt f x) : WithTop ℤ :=
-  ((eanalyticOrderAt (fun z ↦ (z - x) ^ hf.choose • f z) x).map (↑· : ℕ → ℤ)) - hf.choose
+  ((analyticOrderAt (fun z ↦ (z - x) ^ hf.choose • f z) x).map (↑· : ℕ → ℤ)) - hf.choose
 
 /-- The order of a meromorphic function `f` at a `z₀` is infinity iff `f` vanishes locally around
 `z₀`. -/
 lemma order_eq_top_iff (hf : MeromorphicAt f x) :
     hf.order = ⊤ ↔ ∀ᶠ z in 𝓝[≠] x, f z = 0 := by
   unfold order
-  by_cases h : eanalyticOrderAt (fun z ↦ (z - x) ^ hf.choose • f z) x = ⊤
+  by_cases h : analyticOrderAt (fun z ↦ (z - x) ^ hf.choose • f z) x = ⊤
   · rw [h, ENat.map_top, ← WithTop.coe_natCast,
       top_sub, eq_self, true_iff, eventually_nhdsWithin_iff]
-    rw [eanalyticOrderAt_eq_top] at h
+    rw [analyticOrderAt_eq_top] at h
     filter_upwards [h.2] with z hf hz
     rwa [smul_eq_zero_iff_right <| pow_ne_zero _ (sub_ne_zero.mpr hz)] at hf
   · obtain ⟨m, hm⟩ := ENat.ne_top_iff_exists.mp h
     simp only [← hm, ENat.map_coe, WithTop.coe_natCast, sub_eq_top_iff, WithTop.natCast_ne_top,
       or_self, false_iff]
     contrapose! h
-    rw [hf.choose_spec.eanalyticOrderAt_eq_top]
+    rw [hf.choose_spec.analyticOrderAt_eq_top]
     rw [← hf.choose_spec.frequently_eq_iff_eventually_eq analyticAt_const]
     apply Eventually.frequently
     filter_upwards [h] with z hfz
@@ -69,10 +69,10 @@ written as `f z = (z - z₀) ^ n • g z`, where `g` is analytic and does not va
 lemma order_eq_int_iff {n : ℤ} (hf : MeromorphicAt f x) : hf.order = n ↔
     ∃ g : 𝕜 → E, AnalyticAt 𝕜 g x ∧ g x ≠ 0 ∧ ∀ᶠ z in 𝓝[≠] x, f z = (z - x) ^ n • g z := by
   unfold order
-  by_cases h : eanalyticOrderAt (fun z ↦ (z - x) ^ hf.choose • f z) x = ⊤
+  by_cases h : analyticOrderAt (fun z ↦ (z - x) ^ hf.choose • f z) x = ⊤
   · rw [h, ENat.map_top, ← WithTop.coe_natCast, top_sub,
       eq_false_intro WithTop.top_ne_coe, false_iff]
-    rw [hf.choose_spec.eanalyticOrderAt_eq_top] at h
+    rw [hf.choose_spec.analyticOrderAt_eq_top] at h
     refine fun ⟨g, hg_an, hg_ne, hg_eq⟩ ↦ hg_ne ?_
     apply EventuallyEq.eq_of_nhds
     rw [EventuallyEq, ← AnalyticAt.frequently_eq_iff_eventually_eq hg_an analyticAt_const]
@@ -83,7 +83,7 @@ lemma order_eq_int_iff {n : ℤ} (hf : MeromorphicAt f x) : hf.order = n ↔
     exact mul_ne_zero (pow_ne_zero _ (sub_ne_zero.mpr hz)) (zpow_ne_zero _ (sub_ne_zero.mpr hz))
   · obtain ⟨m, h⟩ := ENat.ne_top_iff_exists.mp h
     rw [← h, ENat.map_coe, ← WithTop.coe_natCast, ← coe_sub, WithTop.coe_inj]
-    obtain ⟨g, hg_an, hg_ne, hg_eq⟩ := hf.choose_spec.eanalyticOrderAt_eq_natCast.mp h.symm
+    obtain ⟨g, hg_an, hg_ne, hg_eq⟩ := hf.choose_spec.analyticOrderAt_eq_natCast.mp h.symm
     replace hg_eq : ∀ᶠ (z : 𝕜) in 𝓝[≠] x, f z = (z - x) ^ (↑m - ↑hf.choose : ℤ) • g z := by
       rw [eventually_nhdsWithin_iff]
       filter_upwards [hg_eq] with z hg_eq hz
@@ -244,12 +244,12 @@ theorem order_congr (hf₁ : MeromorphicAt f₁ x)
 
 /-- Compatibility of notions of `order` for analytic and meromorphic functions. -/
 lemma _root_.AnalyticAt.meromorphicAt_order (hf : AnalyticAt 𝕜 f x) :
-    hf.meromorphicAt.order = (eanalyticOrderAt f x).map (↑) := by
-  cases hn : eanalyticOrderAt f x
+    hf.meromorphicAt.order = (analyticOrderAt f x).map (↑) := by
+  cases hn : analyticOrderAt f x
   · rw [ENat.map_top, order_eq_top_iff]
-    exact (hf.eanalyticOrderAt_eq_top.mp hn).filter_mono nhdsWithin_le_nhds
+    exact (hf.analyticOrderAt_eq_top.mp hn).filter_mono nhdsWithin_le_nhds
   · simp_rw [ENat.map_coe, order_eq_int_iff, zpow_natCast]
-    rcases hf.eanalyticOrderAt_eq_natCast.mp hn with ⟨g, h1, h2, h3⟩
+    rcases hf.analyticOrderAt_eq_natCast.mp hn with ⟨g, h1, h2, h3⟩
     exact ⟨g, h1, h2, h3.filter_mono nhdsWithin_le_nhds⟩
 
 /--
@@ -591,6 +591,6 @@ theorem codiscrete_setOf_order_eq_zero_or_top :
     use t \ {x}, fun y h₁y _ ↦ h₁t y h₁y.1 h₁y.2
     exact ⟨h₂t.sdiff isClosed_singleton, Set.mem_diff_of_mem h₃t hax⟩
   · filter_upwards [(hf x hx).eventually_analyticAt, h₁f] with a h₁a
-    simp +contextual [h₁a.meromorphicAt_order, h₁a.eanalyticOrderAt_eq_zero.2]
+    simp +contextual [h₁a.meromorphicAt_order, h₁a.analyticOrderAt_eq_zero.2]
 
 end MeromorphicOn

--- a/Mathlib/Analysis/Meromorphic/Order.lean
+++ b/Mathlib/Analysis/Meromorphic/Order.lean
@@ -590,7 +590,11 @@ theorem codiscrete_setOf_order_eq_zero_or_top :
     obtain ⟨t, h₁t, h₂t, h₃t⟩ := h₁a
     use t \ {x}, fun y h₁y _ ↦ h₁t y h₁y.1 h₁y.2
     exact ⟨h₂t.sdiff isClosed_singleton, Set.mem_diff_of_mem h₃t hax⟩
-  · filter_upwards [(hf x hx).eventually_analyticAt, h₁f] with a h₁a
-    simp +contextual [h₁a.meromorphicAt_order, h₁a.analyticOrderAt_eq_zero.2]
+  · filter_upwards [hf.eventually_analyticAt_or_mem_compl hx, h₁f] with a h₁a h'₁a
+    simp only [mem_compl_iff, mem_diff, mem_image, mem_setOf_eq, Subtype.exists, exists_and_right,
+      exists_eq_right, not_exists, not_or, not_and, not_forall, Decidable.not_not]
+    rcases h₁a with h' | h'
+    · simp +contextual [h'.meromorphicAt_order, h'.analyticOrderAt_eq_zero.2, h'₁a]
+    · exact fun ha ↦ (h' ha).elim
 
 end MeromorphicOn

--- a/Mathlib/Data/ENat/Basic.lean
+++ b/Mathlib/Data/ENat/Basic.lean
@@ -255,7 +255,7 @@ theorem toNat_sub {n : ℕ∞} (hn : n ≠ ⊤) (m : ℕ∞) : toNat (m - n) = t
   · rw [top_sub_coe, toNat_top, zero_tsub]
   · rw [← coe_sub, toNat_coe, toNat_coe, toNat_coe]
 
-theorem toNat_mul (a b : ℕ∞) : (a * b).toNat = a.toNat * b.toNat := by
+@[simp] theorem toNat_mul (a b : ℕ∞) : (a * b).toNat = a.toNat * b.toNat := by
   cases a <;> cases b <;> simp
   · rename_i b; cases b <;> simp
   · rename_i a; cases a <;> simp


### PR DESCRIPTION
Currently, the order of an analytic function is called `AnalyticAt.order` and has a single explicit argument `hf : AnalyticAt 𝕜 f z₀`. This means that working with analytic functions results in contexts full of `hf.order` or, worse, `⋯.order`.

This PR makes the `f` and `z₀` arguments explicit, and drops the `hf` one by introducing a junk value of `0` for non-analytic functions. The resulting function is called `analyticOrderAt` and I am also adding a `Nat`-valued version `analyticOrderNatAt` since `(analyticOrderAt f z₀).toNat` was appearing in quite a few lemmas.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->
The same change could be performed for meromorphic functions once you are convinced.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
