### PR TITLE
perf: use `unif_hint` to unify `Generators.toExtension.Ring` with `Generators.Ring`

### DIFF
--- a/Mathlib/RingTheory/Kaehler/JacobiZariski.lean
+++ b/Mathlib/RingTheory/Kaehler/JacobiZariski.lean
@@ -37,6 +37,9 @@ variable {R : Type u} {S : Type v} [CommRing R] [CommRing S] [Algebra R S] {P : 
 variable {T : Type uT} [CommRing T] [Algebra R T] [Algebra S T] [IsScalarTower R S T]
 variable (Q : Generators.{w} S T) (P : Generators.{w'} R S)
 
+unif_hint toExtension_Ring where ⊢
+  P.toExtension.Ring ≟ P.Ring
+
 attribute [local instance] SMulCommClass.of_commMonoid
 
 namespace Generators

--- a/Mathlib/RingTheory/Kaehler/JacobiZariski.lean
+++ b/Mathlib/RingTheory/Kaehler/JacobiZariski.lean
@@ -37,6 +37,7 @@ variable {R : Type u} {S : Type v} [CommRing R] [CommRing S] [Algebra R S] {P : 
 variable {T : Type uT} [CommRing T] [Algebra R T] [Algebra S T] [IsScalarTower R S T]
 variable (Q : Generators.{w} S T) (P : Generators.{w'} R S)
 
+/-- Unify `P.toExtension.Ring` with `P.Ring`. -/
 unif_hint Ring_toExtension where ⊢
   P.toExtension.Ring ≟ P.Ring
 

--- a/Mathlib/RingTheory/Kaehler/JacobiZariski.lean
+++ b/Mathlib/RingTheory/Kaehler/JacobiZariski.lean
@@ -37,7 +37,7 @@ variable {R : Type u} {S : Type v} [CommRing R] [CommRing S] [Algebra R S] {P : 
 variable {T : Type uT} [CommRing T] [Algebra R T] [Algebra S T] [IsScalarTower R S T]
 variable (Q : Generators.{w} S T) (P : Generators.{w'} R S)
 
-unif_hint toExtension_Ring where ⊢
+unif_hint Ring_toExtension where ⊢
   P.toExtension.Ring ≟ P.Ring
 
 attribute [local instance] SMulCommClass.of_commMonoid


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
