### PR TITLE
[Merged by Bors] - refactor(CategoryTheory/Sums): refactor sums of categories

### DIFF
--- a/Mathlib/CategoryTheory/Sums/Associator.lean
+++ b/Mathlib/CategoryTheory/Sums/Associator.lean
@@ -26,7 +26,7 @@ variable (C : Type u₁) [Category.{v₁} C] (D : Type u₂) [Category.{v₂} D]
 /-- The associator functor `(C ⊕ D) ⊕ E ⥤ C ⊕ (D ⊕ E)` for sums of categories.
 -/
 def associator : (C ⊕ D) ⊕ E ⥤ C ⊕ (D ⊕ E) :=
-  (inl_ _ _ |>.sum' <| inl_ _ _ ⋙ inr_ _ _).sum' <| inr_ _ _ ⋙ inr_ _ _
+  (inl_ C (D ⊕ E) |>.sum' <| inl_ D E ⋙ inr_ C (D ⊕ E)).sum' <| inr_ D E ⋙ inr_ C (D ⊕ E)
 
 @[simp]
 theorem associator_obj_inl_inl (X) : (associator C D E).obj (inl (inl X)) = inl X :=
@@ -58,28 +58,30 @@ theorem associator_map_inr {X Y : E} (f : X ⟶ Y) :
 
 /-- Characterizing the composition of the associator and the left inclusion. -/
 @[simps!]
-def inlCompAssociator : (inl_ _ _) ⋙ associator C D E ≅ inl_ _ _ |>.sum' <| inl_ _ _ ⋙ inr_ _ _ :=
+def inlCompAssociator :
+    inl_ (C ⊕ D) E ⋙ associator C D E ≅ inl_ C (D ⊕ E) |>.sum' <| inl_ D E ⋙ inr_ C (D ⊕ E) :=
   (Functor.inlCompSum' _ _)
 
 /-- Characterizing the composition of the associator and the right inclusion. -/
 @[simps!]
-def inrCompAssociator : (inr_ _ _) ⋙ associator C D E ≅ inr_ _ _ ⋙ inr_ _ _ :=
+def inrCompAssociator : inr_ (C ⊕ D) E ⋙ associator C D E ≅ inr_ D E ⋙ inr_ C (D ⊕ E) :=
   (Functor.inrCompSum' _ _)
 
 /-- Further characterizing the composition of the associator and the left inclusion. -/
 @[simps!]
-def inlCompInlCompAssociator : (inl_ _ _) ⋙ (inl_ _ _) ⋙ associator C D E ≅ inl_ _ _ :=
-  isoWhiskerLeft (inl_ _ _) (inlCompAssociator C D E) ≪≫ (Functor.inlCompSum' _ _)
+def inlCompInlCompAssociator : inl_ C D ⋙ inl_ (C ⊕ D) E ⋙ associator C D E ≅ inl_ C (D ⊕ E) :=
+  isoWhiskerLeft (inl_ _ _) (inlCompAssociator C D E) ≪≫ Functor.inlCompSum' _ _
 
 /-- Further characterizing the composition of the associator and the left inclusion. -/
 @[simps!]
-def inrCompInlCompAssociator : (inr_ _ _) ⋙ (inl_ _ _) ⋙ associator C D E ≅ inl_ _ _ ⋙ inr_ _ _ :=
-  isoWhiskerLeft (inr_ _ _) (inlCompAssociator C D E) ≪≫ (Functor.inrCompSum' _ _)
+def inrCompInlCompAssociator :
+    inr_ C D ⋙ inl_ (C ⊕ D) E ⋙ associator C D E ≅ inl_ D E ⋙ inr_ C (D ⊕ E) :=
+  isoWhiskerLeft (inr_ _ _) (inlCompAssociator C D E) ≪≫ Functor.inrCompSum' _ _
 
 /-- The inverse associator functor `C ⊕ (D ⊕ E) ⥤ (C ⊕ D) ⊕ E` for sums of categories.
 -/
 def inverseAssociator : C ⊕ (D ⊕ E) ⥤ (C ⊕ D) ⊕ E :=
-  inl_ _ _ ⋙ inl_ _ _ |>.sum' <| (inr_ _ _ ⋙ inl_ _ _).sum' <| inr_ _ _
+  inl_ C D ⋙ inl_ (C ⊕ D) E |>.sum' <| (inr_ C D ⋙ inl_ (C ⊕ D) E).sum' <| inr_ (C ⊕ D) E
 
 @[simp]
 theorem inverseAssociator_obj_inl (X) : (inverseAssociator C D E).obj (inl X) = inl (inl X) :=
@@ -113,27 +115,28 @@ theorem inverseAssociator_map_inr_inr {X Y : E} (f : X ⟶ Y) :
 
 /-- Characterizing the composition of the inverse of the associator and the left inclusion. -/
 @[simps!]
-def inlCompInverseAssociator : (inl_ _ _) ⋙ inverseAssociator C D E ≅ inl_ _ _ ⋙ inl_ _ _ :=
+def inlCompInverseAssociator :
+    inl_ C (D ⊕ E) ⋙ inverseAssociator C D E ≅ inl_ C D ⋙ inl_ (C ⊕ D) E :=
   Functor.inlCompSum' _ _
 
 /-- Characterizing the composition of the inverse of the associator and the right inclusion. -/
 @[simps!]
 def inrCompInverseAssociator :
-    (inr_ _ _) ⋙ inverseAssociator C D E ≅ (inr_ _ _ ⋙ inl_ _ _).sum' <| inr_ _ _ :=
+    inr_ C (D ⊕ E) ⋙ inverseAssociator C D E ≅ (inr_ C D ⋙ inl_ (C ⊕ D) E).sum' <| inr_ (C ⊕ D) E :=
   Functor.inrCompSum' _ _
 
 /-- Further characterizing the composition of the inverse of the associator and the right
 inclusion. -/
 @[simps!]
 def inlCompInrCompInverseAssociator :
-    (inl_ _ _) ⋙ (inr_ _ _) ⋙ inverseAssociator C D E ≅ inr_ _ _ ⋙ inl_ _ _ :=
+    inl_ D E ⋙ inr_ C (D ⊕ E) ⋙ inverseAssociator C D E ≅ inr_ C D ⋙ inl_ (C ⊕ D) E :=
   isoWhiskerLeft (inl_ _ _) (inrCompInverseAssociator C D E) ≪≫ Functor.inlCompSum' _ _
 
 /-- Further characterizing the composition of the inverse of the associator and the right
 inclusion. -/
 @[simps!]
 def inrCompInrCompInverseAssociator :
-    (inr_ _ _) ⋙ (inr_ _ _) ⋙ inverseAssociator C D E ≅ inr_ _ _ :=
+    inr_ D E ⋙ inr_ C (D ⊕ E) ⋙ inverseAssociator C D E ≅ inr_ (C ⊕ D) E :=
   isoWhiskerLeft (inr_ _ _) (inrCompInverseAssociator C D E) ≪≫ Functor.inrCompSum' _ _
 
 /-- The equivalence of categories expressing associativity of sums of categories.
@@ -145,29 +148,29 @@ def associativity : (C ⊕ D) ⊕ E ≌ C ⊕ (D ⊕ E) where
   unitIso := Functor.sumIsoExt
     (Functor.sumIsoExt
       ((Functor.associator _ _ _).symm ≪≫ Functor.rightUnitor _ ≪≫
-        (isoWhiskerRight (inlCompInlCompAssociator _ _ _) (inverseAssociator _ _ _) ≪≫
-          inlCompInverseAssociator _ _ _).symm ≪≫ Functor.associator _ _ _)
+        (isoWhiskerRight (inlCompInlCompAssociator C D E) (inverseAssociator C D E) ≪≫
+          inlCompInverseAssociator C D E).symm ≪≫ Functor.associator _ _ _)
       ((Functor.associator _ _ _).symm ≪≫ Functor.rightUnitor _ ≪≫
-        (isoWhiskerRight (inrCompInlCompAssociator _ _ _) (inverseAssociator _ _ _) ≪≫
-          inlCompInrCompInverseAssociator _ _ _).symm ≪≫
+        (isoWhiskerRight (inrCompInlCompAssociator C D E) (inverseAssociator C D E) ≪≫
+          inlCompInrCompInverseAssociator C D E).symm ≪≫
         Functor.associator _ _ _ ≪≫ isoWhiskerLeft _ (Functor.associator _ _ _)))
     (Functor.rightUnitor _ ≪≫
-      (isoWhiskerRight (inrCompAssociator _ _ _) (inverseAssociator _ _ _) ≪≫
-        Functor.associator _ _ _ ≪≫ inrCompInrCompInverseAssociator _ _ _).symm ≪≫
+      (isoWhiskerRight (inrCompAssociator C D E) (inverseAssociator C D E) ≪≫
+        Functor.associator _ _ _ ≪≫ inrCompInrCompInverseAssociator C D E).symm ≪≫
       Functor.associator _ _ _)
   counitIso := Functor.sumIsoExt
     ((Functor.associator _ _ _).symm ≪≫
-      isoWhiskerRight (inlCompInverseAssociator _ _ _) (associator _ _ _) ≪≫
-      Functor.associator _ _ _ ≪≫ inlCompInlCompAssociator _ _ _ ≪≫ (Functor.rightUnitor _).symm)
+      isoWhiskerRight (inlCompInverseAssociator C D E) (associator C D E) ≪≫
+      Functor.associator _ _ _ ≪≫ inlCompInlCompAssociator C D E ≪≫ (Functor.rightUnitor _).symm)
     (Functor.sumIsoExt
       ((Functor.associator _ _ _).symm ≪≫ (Functor.associator _ _ _).symm ≪≫
         isoWhiskerRight (Functor.associator _ _ _ ≪≫
-          inlCompInrCompInverseAssociator C D E) (associator _ _ _) ≪≫
-        Functor.associator _ _ _ ≪≫ inrCompInlCompAssociator _ _ _ ≪≫ (Functor.rightUnitor _).symm)
+          inlCompInrCompInverseAssociator C D E) (associator C D E) ≪≫
+        Functor.associator _ _ _ ≪≫ inrCompInlCompAssociator C D E ≪≫ (Functor.rightUnitor _).symm)
       ((Functor.associator _ _ _).symm ≪≫ (Functor.associator _ _ _).symm ≪≫
         isoWhiskerRight (Functor.associator _ _ _ ≪≫
-          inrCompInrCompInverseAssociator _ _ _) (associator _ _ _) ≪≫
-        inrCompAssociator _ _ _ ≪≫ isoWhiskerLeft _ (Functor.rightUnitor _).symm))
+          inrCompInrCompInverseAssociator C D E) (associator C D E) ≪≫
+        inrCompAssociator C D E ≪≫ isoWhiskerLeft _ (Functor.rightUnitor _).symm))
   functor_unitIso_comp x := match x with
     | inl (inl c) => by simp [inlCompInlCompAssociator, inlCompInverseAssociator]
     | inl (inr d) => by simp [inrCompInlCompAssociator, inlCompInrCompInverseAssociator]

--- a/Mathlib/CategoryTheory/Sums/Associator.lean
+++ b/Mathlib/CategoryTheory/Sums/Associator.lean
@@ -164,7 +164,7 @@ def associativity : (C ⊕ D) ⊕ E ≌ C ⊕ (D ⊕ E) where
       ((Functor.associator _ _ _).symm ≪≫ (Functor.associator _ _ _).symm ≪≫
         isoWhiskerRight (Functor.associator _ _ _ ≪≫
           inrCompInrCompInverseAssociator _ _ _) (associator _ _ _) ≪≫
-        inrCompAssociator _ _ _ ≪≫ isoWhiskerLeft _ ((Functor.rightUnitor _).symm)))
+        inrCompAssociator _ _ _ ≪≫ isoWhiskerLeft _ (Functor.rightUnitor _).symm))
   functor_unitIso_comp x := match x with
     | inl (inl c) => by simp [inlCompInlCompAssociator]
     | inl (inr d) => by simp [inrCompInlCompAssociator]

--- a/Mathlib/CategoryTheory/Sums/Associator.lean
+++ b/Mathlib/CategoryTheory/Sums/Associator.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2019 Kim Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Kim Morrison
+Authors: Kim Morrison, Robin Carlier
 -/
 import Mathlib.CategoryTheory.Sums.Basic
 
@@ -12,7 +12,7 @@ The associator functor `((C ⊕ D) ⊕ E) ⥤ (C ⊕ (D ⊕ E))` and its inverse
 -/
 
 
-universe v u
+universe v₁ v₂ v₃ u₁ u₂ u₃
 
 open CategoryTheory
 
@@ -20,24 +20,13 @@ open Sum
 
 namespace CategoryTheory.sum
 
-variable (C : Type u) [Category.{v} C] (D : Type u) [Category.{v} D] (E : Type u) [Category.{v} E]
+variable (C : Type u₁) [Category.{v₁} C] (D : Type u₂) [Category.{v₂} D]
+  (E : Type u₃) [Category.{v₃} E]
 
 /-- The associator functor `(C ⊕ D) ⊕ E ⥤ C ⊕ (D ⊕ E)` for sums of categories.
 -/
-def associator : (C ⊕ D) ⊕ E ⥤ C ⊕ (D ⊕ E) where
-  obj X :=
-    match X with
-    | inl (inl X) => inl X
-    | inl (inr X) => inr (inl X)
-    | inr X => inr (inr X)
-  map {X Y} f :=
-    match X, Y, f with
-    | inl (inl _), inl (inl _), f => f
-    | inl (inr _), inl (inr _), f => f
-    | inr _, inr _, f => f
-  map_id := by rintro ((_|_)|_) <;> rfl
-  map_comp := by
-    rintro ((_|_)|_) ((_|_)|_) ((_|_)|_) f g <;> first | cases f | cases g | aesop_cat
+def associator : (C ⊕ D) ⊕ E ⥤ C ⊕ (D ⊕ E) :=
+  (inl_ _ _ |>.sum' <| inl_ _ _ ⋙ inr_ _ _).sum' <| inr_ _ _ ⋙ inr_ _ _
 
 @[simp]
 theorem associator_obj_inl_inl (X) : (associator C D E).obj (inl (inl X)) = inl X :=
@@ -53,34 +42,39 @@ theorem associator_obj_inr (X) : (associator C D E).obj (inr X) = inr (inr X) :=
 
 @[simp]
 theorem associator_map_inl_inl {X Y : C} (f : inl (inl X) ⟶ inl (inl Y)) :
-    (associator C D E).map f = f :=
+    (associator C D E).map f = (inl_ _ _).map f.down.down :=
   rfl
 
 @[simp]
 theorem associator_map_inl_inr {X Y : D} (f : inl (inr X) ⟶ inl (inr Y)) :
-    (associator C D E).map f = f :=
+    (associator C D E).map f = (inr_ _ _).map ((inl_ _ _).map f.down.down) :=
   rfl
 
 @[simp]
-theorem associator_map_inr {X Y : E} (f : inr X ⟶ inr Y) : (associator C D E).map f = f :=
+theorem associator_map_inr {X Y : E} (f : inr X ⟶ inr Y) :
+    (associator C D E).map f = (inr_ _ _).map ((inr_ _ _).map f.down) :=
   rfl
+
+@[simps!]
+def inlCompAssociator : (inl_ _ _) ⋙ associator C D E ≅ inl_ _ _ |>.sum' <| inl_ _ _ ⋙ inr_ _ _ :=
+  (Functor.inlCompSum' _ _)
+
+@[simps!]
+def inrCompAssociator : (inr_ _ _) ⋙ associator C D E ≅ inr_ _ _ ⋙ inr_ _ _ :=
+  (Functor.inrCompSum' _ _)
+
+@[simps!]
+def inlCompInlCompAssociator : (inl_ _ _) ⋙ (inl_ _ _) ⋙ associator C D E ≅ inl_ _ _ :=
+  isoWhiskerLeft (inl_ _ _) (inlCompAssociator C D E) ≪≫ (Functor.inlCompSum' _ _)
+
+@[simps!]
+def inrCompInlCompAssociator : (inr_ _ _) ⋙ (inl_ _ _) ⋙ associator C D E ≅ inl_ _ _ ⋙ inr_ _ _ :=
+  isoWhiskerLeft (inr_ _ _) (inlCompAssociator C D E) ≪≫ (Functor.inrCompSum' _ _)
 
 /-- The inverse associator functor `C ⊕ (D ⊕ E) ⥤ (C ⊕ D) ⊕ E` for sums of categories.
 -/
-def inverseAssociator : C ⊕ (D ⊕ E) ⥤ (C ⊕ D) ⊕ E where
-  obj X :=
-    match X with
-    | inl X => inl (inl X)
-    | inr (inl X) => inl (inr X)
-    | inr (inr X) => inr X
-  map {X Y} f :=
-    match X, Y, f with
-    | inl _, inl _, f => f
-    | inr (inl _), inr (inl _), f => f
-    | inr (inr _), inr (inr _), f => f
-  map_id := by rintro (_|(_|_)) <;> rfl
-  map_comp := by
-    rintro (_|(_|_)) (_|(_|_)) (_|(_|_)) f g <;> first | cases f | cases g | aesop_cat
+def inverseAssociator : C ⊕ (D ⊕ E) ⥤ (C ⊕ D) ⊕ E :=
+  inl_ _ _ ⋙ inl_ _ _ |>.sum' <| (inr_ _ _ ⋙ inl_ _ _).sum' <| inr_ _ _
 
 @[simp]
 theorem inverseAssociator_obj_inl (X) : (inverseAssociator C D E).obj (inl X) = inl (inl X) :=
@@ -97,18 +91,37 @@ theorem inverseAssociator_obj_inr_inr (X) : (inverseAssociator C D E).obj (inr (
 
 @[simp]
 theorem inverseAssociator_map_inl {X Y : C} (f : inl X ⟶ inl Y) :
-    (inverseAssociator C D E).map f = f :=
+    (inverseAssociator C D E).map f = (inl_ _ _).map ((inl_ _ _).map f.down) :=
   rfl
 
 @[simp]
 theorem inverseAssociator_map_inr_inl {X Y : D} (f : inr (inl X) ⟶ inr (inl Y)) :
-    (inverseAssociator C D E).map f = f :=
+    (inverseAssociator C D E).map f = (inl_ _ _).map ((inr_ _ _).map f.down.down) :=
   rfl
 
 @[simp]
 theorem inverseAssociator_map_inr_inr {X Y : E} (f : inr (inr X) ⟶ inr (inr Y)) :
-    (inverseAssociator C D E).map f = f :=
+    (inverseAssociator C D E).map f = (inr_ _ _).map f.down.down :=
   rfl
+
+@[simps!]
+def inlCompInverseAssociator : (inl_ _ _) ⋙ inverseAssociator C D E ≅ inl_ _ _ ⋙ inl_ _ _ :=
+  Functor.inlCompSum' _ _
+
+@[simps!]
+def inrCompInverseAssociator :
+    (inr_ _ _) ⋙ inverseAssociator C D E ≅ (inr_ _ _ ⋙ inl_ _ _).sum' <| inr_ _ _ :=
+  Functor.inrCompSum' _ _
+
+@[simps!]
+def inlCompInrCompInverseAssociator :
+    (inl_ _ _) ⋙ (inr_ _ _) ⋙ inverseAssociator C D E ≅ inr_ _ _ ⋙ inl_ _ _ :=
+  isoWhiskerLeft (inl_ _ _) (inrCompInverseAssociator C D E) ≪≫ Functor.inlCompSum' _ _
+
+@[simps!]
+def inrCompInrCompInverseAssociator :
+    (inr_ _ _) ⋙ (inr_ _ _) ⋙ inverseAssociator C D E ≅ inr_ _ _ :=
+  isoWhiskerLeft (inr_ _ _) (inrCompInverseAssociator C D E) ≪≫ Functor.inrCompSum' _ _
 
 /-- The equivalence of categories expressing associativity of sums of categories.
 -/
@@ -116,10 +129,36 @@ theorem inverseAssociator_map_inr_inr {X Y : E} (f : inr (inr X) ⟶ inr (inr Y)
 def associativity : (C ⊕ D) ⊕ E ≌ C ⊕ (D ⊕ E) where
   functor := associator C D E
   inverse := inverseAssociator C D E
-  unitIso := NatIso.ofComponents (by rintro ((_ | _) | _) <;> exact Iso.refl _) (by
-    rintro ((_ | _) | _) ((_ | _) | _) f <;> first | cases f | aesop_cat)
-  counitIso := NatIso.ofComponents (by rintro (_ | (_ | _)) <;> exact Iso.refl _) (by
-    rintro (_ | (_ | _)) (_ | (_ | _)) f <;> first | cases f | aesop_cat)
+  unitIso := Functor.sumIsoExt
+    (Functor.sumIsoExt
+      ((Functor.associator _ _ _).symm ≪≫ Functor.rightUnitor _ ≪≫
+        (isoWhiskerRight (inlCompInlCompAssociator _ _ _) (inverseAssociator _ _ _) ≪≫
+          inlCompInverseAssociator _ _ _).symm ≪≫ Functor.associator _ _ _)
+      ((Functor.associator _ _ _).symm ≪≫ Functor.rightUnitor _ ≪≫
+        (isoWhiskerRight (inrCompInlCompAssociator _ _ _) (inverseAssociator _ _ _) ≪≫
+          inlCompInrCompInverseAssociator _ _ _).symm ≪≫
+        Functor.associator _ _ _ ≪≫ isoWhiskerLeft _ (Functor.associator _ _ _)))
+    (Functor.rightUnitor _ ≪≫
+      (isoWhiskerRight (inrCompAssociator _ _ _) (inverseAssociator _ _ _) ≪≫
+        Functor.associator _ _ _ ≪≫ inrCompInrCompInverseAssociator _ _ _).symm ≪≫
+      Functor.associator _ _ _)
+  counitIso := Functor.sumIsoExt
+    ((Functor.associator _ _ _).symm ≪≫
+      isoWhiskerRight (inlCompInverseAssociator _ _ _) (associator _ _ _) ≪≫
+      Functor.associator _ _ _ ≪≫ inlCompInlCompAssociator _ _ _ ≪≫ (Functor.rightUnitor _).symm)
+    (Functor.sumIsoExt
+      ((Functor.associator _ _ _).symm ≪≫ (Functor.associator _ _ _).symm ≪≫
+        isoWhiskerRight (Functor.associator _ _ _ ≪≫
+          inlCompInrCompInverseAssociator C D E) (associator _ _ _) ≪≫
+        Functor.associator _ _ _ ≪≫ inrCompInlCompAssociator _ _ _ ≪≫ (Functor.rightUnitor _).symm)
+      ((Functor.associator _ _ _).symm ≪≫ (Functor.associator _ _ _).symm ≪≫
+        isoWhiskerRight (Functor.associator _ _ _ ≪≫
+          inrCompInrCompInverseAssociator _ _ _) (associator _ _ _) ≪≫
+        inrCompAssociator _ _ _ ≪≫ isoWhiskerLeft _ ((Functor.rightUnitor _).symm)))
+  functor_unitIso_comp x := match x with
+    | inl (inl c) => by simp [inlCompInlCompAssociator]
+    | inl (inr d) => by simp [inrCompInlCompAssociator]
+    | inr e => by simp [inrCompAssociator]
 
 instance associatorIsEquivalence : (associator C D E).IsEquivalence :=
   (by infer_instance : (associativity C D E).functor.IsEquivalence)

--- a/Mathlib/CategoryTheory/Sums/Associator.lean
+++ b/Mathlib/CategoryTheory/Sums/Associator.lean
@@ -41,18 +41,19 @@ theorem associator_obj_inr (X) : (associator C D E).obj (inr X) = inr (inr X) :=
   rfl
 
 @[simp]
-theorem associator_map_inl_inl {X Y : C} (f : inl (inl X) ⟶ inl (inl Y)) :
-    (associator C D E).map f = (inl_ _ _).map f.down.down :=
+theorem associator_map_inl_inl {X Y : C} (f : X ⟶ Y) :
+    (associator C D E).map ((inl_ _ _).map ((inl_ _ _).map f)) = (inl_ _ _).map f :=
   rfl
 
 @[simp]
-theorem associator_map_inl_inr {X Y : D} (f : inl (inr X) ⟶ inl (inr Y)) :
-    (associator C D E).map f = (inr_ _ _).map ((inl_ _ _).map f.down.down) :=
+theorem associator_map_inl_inr {X Y : D} (f : X ⟶ Y) :
+    (associator C D E).map ((inl_ _ _).map ((inr_ _ _).map f)) =
+    (inr_ _ _).map ((inl_ _ _).map f) :=
   rfl
 
 @[simp]
-theorem associator_map_inr {X Y : E} (f : inr X ⟶ inr Y) :
-    (associator C D E).map f = (inr_ _ _).map ((inr_ _ _).map f.down) :=
+theorem associator_map_inr {X Y : E} (f : X ⟶ Y) :
+    (associator C D E).map ((inr_ _ _).map f) = (inr_ _ _).map ((inr_ _ _).map f) :=
   rfl
 
 /-- Characterizing the composition of the associator and the left inclusion. -/
@@ -94,18 +95,20 @@ theorem inverseAssociator_obj_inr_inr (X) : (inverseAssociator C D E).obj (inr (
   rfl
 
 @[simp]
-theorem inverseAssociator_map_inl {X Y : C} (f : inl X ⟶ inl Y) :
-    (inverseAssociator C D E).map f = (inl_ _ _).map ((inl_ _ _).map f.down) :=
+theorem inverseAssociator_map_inl {X Y : C} (f : X ⟶ Y) :
+    (inverseAssociator C D E).map ((inl_ _ _).map f) = (inl_ _ _).map ((inl_ _ _).map f) :=
   rfl
 
 @[simp]
-theorem inverseAssociator_map_inr_inl {X Y : D} (f : inr (inl X) ⟶ inr (inl Y)) :
-    (inverseAssociator C D E).map f = (inl_ _ _).map ((inr_ _ _).map f.down.down) :=
+theorem inverseAssociator_map_inr_inl {X Y : D} (f : X ⟶ Y) :
+    (inverseAssociator C D E).map ((inr_ _ _).map ((inl_ _ _).map f)) =
+    (inl_ _ _).map ((inr_ _ _).map f) :=
   rfl
 
 @[simp]
-theorem inverseAssociator_map_inr_inr {X Y : E} (f : inr (inr X) ⟶ inr (inr Y)) :
-    (inverseAssociator C D E).map f = (inr_ _ _).map f.down.down :=
+theorem inverseAssociator_map_inr_inr {X Y : E} (f : X ⟶ Y) :
+    (inverseAssociator C D E).map ((inr_ _ _).map ((inr_ _ _).map f)) =
+    (inr_ _ _).map f :=
   rfl
 
 /-- Characterizing the composition of the inverse of the associator and the left inclusion. -/
@@ -166,9 +169,9 @@ def associativity : (C ⊕ D) ⊕ E ≌ C ⊕ (D ⊕ E) where
           inrCompInrCompInverseAssociator _ _ _) (associator _ _ _) ≪≫
         inrCompAssociator _ _ _ ≪≫ isoWhiskerLeft _ (Functor.rightUnitor _).symm))
   functor_unitIso_comp x := match x with
-    | inl (inl c) => by simp [inlCompInlCompAssociator]
-    | inl (inr d) => by simp [inrCompInlCompAssociator]
-    | inr e => by simp [inrCompAssociator]
+    | inl (inl c) => by simp [inlCompInlCompAssociator, inlCompInverseAssociator]
+    | inl (inr d) => by simp [inrCompInlCompAssociator, inlCompInrCompInverseAssociator]
+    | inr e => by simp [inrCompAssociator, inrCompInrCompInverseAssociator]
 
 instance associatorIsEquivalence : (associator C D E).IsEquivalence :=
   (by infer_instance : (associativity C D E).functor.IsEquivalence)

--- a/Mathlib/CategoryTheory/Sums/Associator.lean
+++ b/Mathlib/CategoryTheory/Sums/Associator.lean
@@ -55,18 +55,22 @@ theorem associator_map_inr {X Y : E} (f : inr X ⟶ inr Y) :
     (associator C D E).map f = (inr_ _ _).map ((inr_ _ _).map f.down) :=
   rfl
 
+/-- Characterizing the composition of the associator and the left inclusion. -/
 @[simps!]
 def inlCompAssociator : (inl_ _ _) ⋙ associator C D E ≅ inl_ _ _ |>.sum' <| inl_ _ _ ⋙ inr_ _ _ :=
   (Functor.inlCompSum' _ _)
 
+/-- Characterizing the composition of the associator and the right inclusion. -/
 @[simps!]
 def inrCompAssociator : (inr_ _ _) ⋙ associator C D E ≅ inr_ _ _ ⋙ inr_ _ _ :=
   (Functor.inrCompSum' _ _)
 
+/-- Further characterizing the composition of the associator and the left inclusion. -/
 @[simps!]
 def inlCompInlCompAssociator : (inl_ _ _) ⋙ (inl_ _ _) ⋙ associator C D E ≅ inl_ _ _ :=
   isoWhiskerLeft (inl_ _ _) (inlCompAssociator C D E) ≪≫ (Functor.inlCompSum' _ _)
 
+/-- Further characterizing the composition of the associator and the left inclusion. -/
 @[simps!]
 def inrCompInlCompAssociator : (inr_ _ _) ⋙ (inl_ _ _) ⋙ associator C D E ≅ inl_ _ _ ⋙ inr_ _ _ :=
   isoWhiskerLeft (inr_ _ _) (inlCompAssociator C D E) ≪≫ (Functor.inrCompSum' _ _)
@@ -104,20 +108,26 @@ theorem inverseAssociator_map_inr_inr {X Y : E} (f : inr (inr X) ⟶ inr (inr Y)
     (inverseAssociator C D E).map f = (inr_ _ _).map f.down.down :=
   rfl
 
+/-- Characterizing the composition of the inverse of the associator and the left inclusion. -/
 @[simps!]
 def inlCompInverseAssociator : (inl_ _ _) ⋙ inverseAssociator C D E ≅ inl_ _ _ ⋙ inl_ _ _ :=
   Functor.inlCompSum' _ _
 
+/-- Characterizing the composition of the inverse of the associator and the right inclusion. -/
 @[simps!]
 def inrCompInverseAssociator :
     (inr_ _ _) ⋙ inverseAssociator C D E ≅ (inr_ _ _ ⋙ inl_ _ _).sum' <| inr_ _ _ :=
   Functor.inrCompSum' _ _
 
+/-- Further characterizing the composition of the inverse of the associator and the right
+inclusion. -/
 @[simps!]
 def inlCompInrCompInverseAssociator :
     (inl_ _ _) ⋙ (inr_ _ _) ⋙ inverseAssociator C D E ≅ inr_ _ _ ⋙ inl_ _ _ :=
   isoWhiskerLeft (inl_ _ _) (inrCompInverseAssociator C D E) ≪≫ Functor.inlCompSum' _ _
 
+/-- Further characterizing the composition of the inverse of the associator and the right
+inclusion. -/
 @[simps!]
 def inrCompInrCompInverseAssociator :
     (inr_ _ _) ⋙ (inr_ _ _) ⋙ inverseAssociator C D E ≅ inr_ _ _ :=

--- a/Mathlib/CategoryTheory/Sums/Basic.lean
+++ b/Mathlib/CategoryTheory/Sums/Basic.lean
@@ -16,10 +16,13 @@ We define:
 * `swap`      : the functor `C ⊕ D ⥤ D ⊕ C`
     (and the fact this is an equivalence)
 
-The sum of two functors `F : A ⥤ C` and `G : B ⥤ C` is a functor `A ⊕ B ⥤ C`, written `F.sum' G`.
-This construction should be preffered when defining functors out of a sum.
+We provide an induction principle `Sum.homInduction` to reason and work with morphisms in this
+category.
 
-We provides natural isomorphisms `inlCompSum' : inl_ ⋙ F.sum' G ≅ F` and
+The sum of two functors `F : A ⥤ C` and `G : B ⥤ C` is a functor `A ⊕ B ⥤ C`, written `F.sum' G`.
+This construction should be prefered when defining functors out of a sum.
+
+We provide natural isomorphisms `inlCompSum' : inl_ ⋙ F.sum' G ≅ F` and
 `inrCompSum' : inl_ ⋙ F.sum' G ≅ G`.
 
 Furthermore, we provide `Functor.sumIsoExt`, which
@@ -74,32 +77,6 @@ theorem hom_inl_inr_false {X : C} {Y : D} (f : Sum.inl X ⟶ Sum.inr Y) : False 
 theorem hom_inr_inl_false {X : C} {Y : D} (f : Sum.inr X ⟶ Sum.inl Y) : False := by
   cases f
 
-@[simp, reassoc]
-theorem sum_comp_inl_down {P Q R : C} (f : (inl P : C ⊕ D) ⟶ inl Q) (g : (inl Q : C ⊕ D) ⟶ inl R) :
-    (f ≫ g).down = f.down ≫ g.down :=
-  rfl
-
-@[simp, reassoc]
-theorem sum_comp_inr_down {P Q R : D} (f : (inr P : C ⊕ D) ⟶ inr Q) (g : (inr Q : C ⊕ D) ⟶ inr R) :
-    (f ≫ g).down = f.down ≫ g.down :=
-  rfl
-
-@[reassoc (attr := simp)]
-theorem sum_comp_inl {P Q R : C} (f : (inl P : C ⊕ D) ⟶ inl Q) (g : (inl Q : C ⊕ D) ⟶ inl R) :
-    (f ≫ g) = (ULift.up (f.down ≫ g.down) : inl P ⟶ inl R) :=
-  rfl
-
-@[reassoc (attr := simp)]
-theorem sum_comp_inr {P Q R : D} (f : (inr P : C ⊕ D) ⟶ inr Q) (g : (inr Q : C ⊕ D) ⟶ inr R) :
-    f ≫ g = (ULift.up (f.down ≫ g.down) : inr P ⟶ inr R) :=
-  rfl
-
-@[simp]
-lemma id_down_left {P : C} : (𝟙 (inl P) : (_ : C ⊕ D) ⟶ _ ).down = 𝟙 P := rfl
-
-@[simp]
-lemma id_down_right {P : D} : (𝟙 (inr P) : (_ : C ⊕ D) ⟶ _ ).down = 𝟙 P := rfl
-
 end
 
 namespace Sum
@@ -113,23 +90,36 @@ def inl_ : C ⥤ C ⊕ D where
   obj X := inl X
   map {_ _} f := ULift.up f
 
-@[simp]
-lemma inl_map_down {c c' : C} (f : c ⟶ c') : ((inl_ C D).map f).down = f := rfl
-
-@[simp]
-lemma inl_map_down' {c c' : C} (f : (inl c : C ⊕ D) ⟶ inl c') : (inl_ C D).map f.down = f := rfl
-
 /-- `inr_` is the functor `X ↦ inr X`. -/
 @[simps! obj]
 def inr_ : D ⥤ C ⊕ D where
   obj X := inr X
   map {_ _} f := ULift.up f
 
-@[simp]
-lemma inr_map_down {d d' : D} (f : d ⟶ d') : ((inr_ C D).map f).down = f := rfl
+variable {C D}
+
+@[elab_as_elim, cases_eliminator, induction_eliminator]
+def homInduction {P : {x y : C ⊕ D} → (x ⟶ y) → Sort*}
+    (inl : ∀ x y : C, (f : x ⟶ y) → P ((inl_ C D).map f))
+    (inr : ∀ x y : D, (f : x ⟶ y) → P ((inr_ C D).map f))
+    {x y : C ⊕ D} (f : x ⟶ y) : P f :=
+  match x, y, f with
+  | .inl x, .inl y, f => inl x y f.down
+  | .inr x, .inr y, f => inr x y f.down
 
 @[simp]
-lemma inr_map_down' {d d' : D} (f : (inr d : C ⊕ D) ⟶ inr d') : (inr_ C D).map f.down = f := rfl
+def homInduction_left {P : {x y : C ⊕ D} → (x ⟶ y) → Sort*}
+    (inl : ∀ x y : C, (f : x ⟶ y) → P ((inl_ C D).map f))
+    (inr : ∀ x y : D, (f : x ⟶ y) → P ((inr_ C D).map f))
+    {x y : C} (f : x ⟶ y) : homInduction (P := P) inl inr ((inl_ C D).map f) = inl x y f :=
+  rfl
+
+@[simp]
+def homInduction_right {P : {x y : C ⊕ D} → (x ⟶ y) → Sort*}
+    (inl : ∀ x y : C, (f : x ⟶ y) → P ((inl_ C D).map f))
+    (inr : ∀ x y : D, (f : x ⟶ y) → P ((inr_ C D).map f))
+    {x y : D} (f : x ⟶ y) : homInduction (P := P) inl inr ((inr_ C D).map f) = inr x y f :=
+  rfl
 
 end Sum
 
@@ -145,13 +135,22 @@ variable (F : A ⥤ C) (G : B ⥤ C)
 /-- The sum of two functors that land in a given category `C`. -/
 def sum' : A ⊕ B ⥤ C where
   obj X :=
-    match X with
-    | inl X => F.obj X
-    | inr X => G.obj X
+  match X with
+  | inl X => F.obj X
+  | inr X => G.obj X
   map {X Y} f :=
-    match X, Y, f with
-    | inl _, inl _, f => F.map f.down
-    | inr _, inr _, f => G.map f.down
+    Sum.homInduction
+      (inl := fun _ _ f ↦ F.map f)
+      (inr := fun _ _ g ↦ G.map g)
+      f
+  map_comp {x y z} f g := by
+    cases f <;> cases g <;> simp [← Functor.map_comp]
+  map_id x := by
+    cases x
+    · simp only [← map_id]
+      rfl
+    · simp only [← map_id]
+      rfl
 
 /-- The sum `F.sum' G` precomposed with the left inclusion functor is isomorphic to `F` -/
 @[simps!]
@@ -172,13 +171,13 @@ theorem sum'_obj_inr (b : B) : (F.sum' G).obj (inr b) = (G.obj b) :=
   rfl
 
 @[simp]
-theorem sum'_map_inl {a a' : A} (f : inl a ⟶ inl a') :
-    (F.sum' G).map f = (F.map f.down) :=
+theorem sum'_map_inl {a a' : A} (f : a ⟶ a') :
+    (F.sum' G).map ((Sum.inl_ _ _).map f) = F.map f :=
   rfl
 
 @[simp]
-theorem sum'_map_inr {b b' : B} (f : inr b ⟶ inr b') :
-    (F.sum' G).map f = (G.map f.down) :=
+theorem sum'_map_inr {b b' : B} (f : b ⟶ b') :
+    (F.sum' G).map ((Sum.inr_ _ _).map f) = G.map f :=
   rfl
 
 end Sum'
@@ -195,13 +194,13 @@ theorem sum_obj_inr (F : A ⥤ B) (G : C ⥤ D) (c : C) : (F.sum G).obj (inr c) 
   rfl
 
 @[simp]
-theorem sum_map_inl (F : A ⥤ B) (G : C ⥤ D) {a a' : A} (f : inl a ⟶ inl a') :
-    (F.sum G).map f = (Sum.inl_ _ _).map (F.map f.down) :=
+theorem sum_map_inl (F : A ⥤ B) (G : C ⥤ D) {a a' : A} (f : a ⟶ a') :
+    (F.sum G).map ((Sum.inl_ _ _).map f) = (Sum.inl_ _ _).map (F.map f) :=
   rfl
 
 @[simp]
-theorem sum_map_inr (F : A ⥤ B) (G : C ⥤ D) {c c' : C} (f : inr c ⟶ inr c') :
-    (F.sum G).map f = (Sum.inr_ _ _).map (G.map f.down) :=
+theorem sum_map_inr (F : A ⥤ B) (G : C ⥤ D) {c c' : C} (f : c ⟶ c') :
+    (F.sum G).map ((Sum.inr_ _ _).map f) = (Sum.inr_ _ _).map (G.map f) :=
   rfl
 
 section
@@ -217,10 +216,10 @@ def sumIsoExt : F ≅ G :=
     match x with
     | inl x => e₁.app x
     | inr x => e₂.app x)
-    (fun {x y} f ↦
-      match x, y, f with
-      | inl x, inl y, f => by simpa using e₁.hom.naturality f.down
-      | inr x, inr y, f => by simpa using e₂.hom.naturality f.down)
+    (fun {x y} f ↦ by
+      cases f
+      · simpa using e₁.hom.naturality _
+      · simpa using e₂.hom.naturality _)
 
 @[simp]
 lemma sumIsoExt_hom_app_inl (a : A) : (sumIsoExt e₁ e₂).hom.app (inl a) = e₁.hom.app a := rfl
@@ -269,9 +268,7 @@ def sum {F G : A ⥤ B} {H I : C ⥤ D} (α : F ⟶ G) (β : H ⟶ I) : F.sum H 
     | inl X => (Sum.inl_ _ _).map (α.app X)
     | inr X => (Sum.inr_ _ _).map (β.app X)
   naturality X Y f :=
-    match X, Y, f with
-    | inl X, inl Y, f => by simp [← Functor.map_comp]
-    | inr X, inr Y, f => by simp [← Functor.map_comp]
+    by cases f <;> simp [← Functor.map_comp]
 
 @[simp]
 theorem sum_app_inl {F G : A ⥤ B} {H I : C ⥤ D} (α : F ⟶ G) (β : H ⟶ I) (a : A) :
@@ -309,11 +306,11 @@ theorem swap_map_inr {X Y : D} {f : inr X ⟶ inr Y} : (swap C D).map f = f :=
   rfl
 
 /-- Precomposing `swap` with the left inclusion gives the right inclusion. -/
-@[simps!]
+@[simps! hom_app inv_app]
 def swapCompInl : inl_ _ _ ⋙ swap C D ≅ inr_ _ _ := (Functor.inlCompSum' (inr_ _ _) (inl_ _ _)).symm
 
 /-- Precomposing `swap` with the rightt inclusion gives the leftt inclusion. -/
-@[simps!]
+@[simps! hom_app inv_app]
 def swapCompInr : inr_ _ _ ⋙ swap C D ≅ inl_ _ _ := (Functor.inrCompSum' (inr_ _ _) (inl_ _ _)).symm
 
 namespace Swap

--- a/Mathlib/CategoryTheory/Sums/Basic.lean
+++ b/Mathlib/CategoryTheory/Sums/Basic.lean
@@ -88,13 +88,13 @@ variable (C : Type u₁) [Category.{v₁} C] (D : Type u₂) [Category.{v₂} D]
 @[simps! obj]
 def inl_ : C ⥤ C ⊕ D where
   obj X := inl X
-  map {_ _} f := ULift.up f
+  map f := ULift.up f
 
 /-- `inr_` is the functor `X ↦ inr X`. -/
 @[simps! obj]
 def inr_ : D ⥤ C ⊕ D where
   obj X := inr X
-  map {_ _} f := ULift.up f
+  map f := ULift.up f
 
 variable {C D}
 
@@ -113,14 +113,14 @@ def homInduction {P : {x y : C ⊕ D} → (x ⟶ y) → Sort*}
 lemma homInduction_left {P : {x y : C ⊕ D} → (x ⟶ y) → Sort*}
     (inl : ∀ x y : C, (f : x ⟶ y) → P ((inl_ C D).map f))
     (inr : ∀ x y : D, (f : x ⟶ y) → P ((inr_ C D).map f))
-    {x y : C} (f : x ⟶ y) : homInduction (P := P) inl inr ((inl_ C D).map f) = inl x y f :=
+    {x y : C} (f : x ⟶ y) : homInduction inl inr ((inl_ C D).map f) = inl x y f :=
   rfl
 
 @[simp]
 lemma homInduction_right {P : {x y : C ⊕ D} → (x ⟶ y) → Sort*}
     (inl : ∀ x y : C, (f : x ⟶ y) → P ((inl_ C D).map f))
     (inr : ∀ x y : D, (f : x ⟶ y) → P ((inr_ C D).map f))
-    {x y : D} (f : x ⟶ y) : homInduction (P := P) inl inr ((inr_ C D).map f) = inr x y f :=
+    {x y : D} (f : x ⟶ y) : homInduction inl inr ((inr_ C D).map f) = inr x y f :=
   rfl
 
 end Sum
@@ -140,19 +140,11 @@ def sum' : A ⊕ B ⥤ C where
   match X with
   | inl X => F.obj X
   | inr X => G.obj X
-  map {X Y} f :=
-    Sum.homInduction
-      (inl := fun _ _ f ↦ F.map f)
-      (inr := fun _ _ g ↦ G.map g)
-      f
+  map {X Y} f := Sum.homInduction (inl := fun _ _ f ↦ F.map f) (inr := fun _ _ g ↦ G.map g) f
   map_comp {x y z} f g := by
     cases f <;> cases g <;> simp [← Functor.map_comp]
   map_id x := by
-    cases x
-    · simp only [← map_id]
-      rfl
-    · simp only [← map_id]
-      rfl
+    cases x <;> (simp only [← map_id]; rfl)
 
 /-- The sum `F.sum' G` precomposed with the left inclusion functor is isomorphic to `F` -/
 @[simps!]
@@ -208,8 +200,8 @@ theorem sum_map_inr (F : A ⥤ B) (G : C ⥤ D) {c c' : C} (f : c ⟶ c') :
 section
 
 variable {F G: A ⊕ B ⥤ C}
-  (e₁ : Sum.inl_ _ _ ⋙ F ≅ Sum.inl_ _ _ ⋙ G)
-  (e₂ : Sum.inr_ _ _ ⋙ F ≅ Sum.inr_ _ _ ⋙ G)
+  (e₁ : Sum.inl_ A B ⋙ F ≅ Sum.inl_ A B ⋙ G)
+  (e₂ : Sum.inr_ A B ⋙ F ≅ Sum.inr_ A B ⋙ G)
 
 /-- A functor out of a sum is uniquely characterized by its precompositions with `inl_` and `inr_`.
 -/
@@ -239,11 +231,13 @@ end
 
 section
 
-variable (F : A ⊕ B ⥤ C) (a : A) (b : B)
+variable (F : A ⊕ B ⥤ C)
 
 /-- Any functor out of a sum is the sum of its precomposition with the inclusions. -/
-def isoSum : F ≅ (Sum.inl_ _ _ ⋙ F).sum' (Sum.inr_ _ _ ⋙ F) :=
+def isoSum : F ≅ (Sum.inl_ A B ⋙ F).sum' (Sum.inr_ A B ⋙ F) :=
     sumIsoExt (Iso.refl _) (Iso.refl _)
+
+variable (a : A) (b : B)
 
 @[simp]
 lemma isoSum_hom_app_inl : (isoSum F).hom.app (inl a) = 𝟙 (F.obj (inl a)) := rfl
@@ -267,8 +261,8 @@ namespace NatTrans
 def sum {F G : A ⥤ B} {H I : C ⥤ D} (α : F ⟶ G) (β : H ⟶ I) : F.sum H ⟶ G.sum I where
   app X :=
     match X with
-    | inl X => (Sum.inl_ _ _).map (α.app X)
-    | inr X => (Sum.inr_ _ _).map (β.app X)
+    | inl X => (Sum.inl_ B D).map (α.app X)
+    | inr X => (Sum.inr_ B D).map (β.app X)
   naturality X Y f :=
     by cases f <;> simp [← Functor.map_comp]
 
@@ -289,7 +283,7 @@ namespace Sum
 variable (C : Type u₁) [Category.{v₁} C] (D : Type u₂) [Category.{v₂} D]
 
 /-- The functor exchanging two direct summand categories. -/
-def swap : C ⊕ D ⥤ D ⊕ C := (inr_ _ _).sum' (inl_ _ _)
+def swap : C ⊕ D ⥤ D ⊕ C := (inr_ D C).sum' (inl_ D C)
 
 @[simp]
 theorem swap_obj_inl (X : C) : (swap C D).obj (inl X) = inr X :=
@@ -309,11 +303,11 @@ theorem swap_map_inr {X Y : D} {f : inr X ⟶ inr Y} : (swap C D).map f = f :=
 
 /-- Precomposing `swap` with the left inclusion gives the right inclusion. -/
 @[simps! hom_app inv_app]
-def swapCompInl : inl_ _ _ ⋙ swap C D ≅ inr_ _ _ := (Functor.inlCompSum' (inr_ _ _) (inl_ _ _)).symm
+def swapCompInl : inl_ C D ⋙ swap C D ≅ inr_ D C := (Functor.inlCompSum' (inr_ _ _) (inl_ _ _)).symm
 
 /-- Precomposing `swap` with the rightt inclusion gives the leftt inclusion. -/
 @[simps! hom_app inv_app]
-def swapCompInr : inr_ _ _ ⋙ swap C D ≅ inl_ _ _ := (Functor.inrCompSum' (inr_ _ _) (inl_ _ _)).symm
+def swapCompInr : inr_ C D ⋙ swap C D ≅ inl_ D C := (Functor.inrCompSum' (inr_ _ _) (inl_ _ _)).symm
 
 namespace Swap
 

--- a/Mathlib/CategoryTheory/Sums/Basic.lean
+++ b/Mathlib/CategoryTheory/Sums/Basic.lean
@@ -142,7 +142,7 @@ section Sum'
 
 variable (F : A ⥤ C) (G : B ⥤ C)
 
-/-- The sum of two functors that lands in a given category `C`. -/
+/-- The sum of two functors that land in a given category `C`. -/
 def sum' : A ⊕ B ⥤ C where
   obj X :=
     match X with

--- a/Mathlib/CategoryTheory/Sums/Basic.lean
+++ b/Mathlib/CategoryTheory/Sums/Basic.lean
@@ -98,6 +98,8 @@ def inr_ : D ⥤ C ⊕ D where
 
 variable {C D}
 
+/-- An induction principle for morphisms in a sum of category: a morphism is either of the form
+`(inl_ _ _).map _` or of the form `(inr_ _ _).map _)`. -/
 @[elab_as_elim, cases_eliminator, induction_eliminator]
 def homInduction {P : {x y : C ⊕ D} → (x ⟶ y) → Sort*}
     (inl : ∀ x y : C, (f : x ⟶ y) → P ((inl_ C D).map f))
@@ -108,14 +110,14 @@ def homInduction {P : {x y : C ⊕ D} → (x ⟶ y) → Sort*}
   | .inr x, .inr y, f => inr x y f.down
 
 @[simp]
-def homInduction_left {P : {x y : C ⊕ D} → (x ⟶ y) → Sort*}
+lemma homInduction_left {P : {x y : C ⊕ D} → (x ⟶ y) → Sort*}
     (inl : ∀ x y : C, (f : x ⟶ y) → P ((inl_ C D).map f))
     (inr : ∀ x y : D, (f : x ⟶ y) → P ((inr_ C D).map f))
     {x y : C} (f : x ⟶ y) : homInduction (P := P) inl inr ((inl_ C D).map f) = inl x y f :=
   rfl
 
 @[simp]
-def homInduction_right {P : {x y : C ⊕ D} → (x ⟶ y) → Sort*}
+lemma homInduction_right {P : {x y : C ⊕ D} → (x ⟶ y) → Sort*}
     (inl : ∀ x y : C, (f : x ⟶ y) → P ((inl_ C D).map f))
     (inr : ∀ x y : D, (f : x ⟶ y) → P ((inr_ C D).map f))
     {x y : D} (f : x ⟶ y) : homInduction (P := P) inl inr ((inr_ C D).map f) = inr x y f :=

--- a/Mathlib/CategoryTheory/Sums/Basic.lean
+++ b/Mathlib/CategoryTheory/Sums/Basic.lean
@@ -74,12 +74,12 @@ theorem hom_inl_inr_false {X : C} {Y : D} (f : Sum.inl X ⟶ Sum.inr Y) : False 
 theorem hom_inr_inl_false {X : C} {Y : D} (f : Sum.inr X ⟶ Sum.inl Y) : False := by
   cases f
 
-@[reassoc (attr := simp)]
+@[simp, reassoc]
 theorem sum_comp_inl_down {P Q R : C} (f : (inl P : C ⊕ D) ⟶ inl Q) (g : (inl Q : C ⊕ D) ⟶ inl R) :
     (f ≫ g).down = f.down ≫ g.down :=
   rfl
 
-@[reassoc (attr := simp)]
+@[simp, reassoc]
 theorem sum_comp_inr_down {P Q R : D} (f : (inr P : C ⊕ D) ⟶ inr Q) (g : (inr Q : C ⊕ D) ⟶ inr R) :
     (f ≫ g).down = f.down ≫ g.down :=
   rfl


### PR DESCRIPTION
We refactor the category instance on sums of types so that it is defined even for types living in a different universes.

Consequently, we change the order of things related to sums of categories:
  - We remove `simp` instance on `Sum.inl_.map` and `Sum.inr_.map`: the inclusions for maps should be considered primitives.
  - We make `Sum.sum'` the first definition about functors out of a sum.
  - We add an extensionality (up to isomorphism) theorem for functors out of sums in terms of their precomposition with `inl_`and `inr_`.
  - We redefine `Sum.swap`, `Sum.associator` (as well as its inverse), `Functor.sum` to use only `Sum.sum'`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

This refactor follows discussions in #22278 and #22281 and is rather opinionated: the universal property of sums of categories should be the only way one should work with sums and should be the only way one defines functors out of sums.

The proof of the associativity equivalence of categories becomes a bit longer, but I believe it is the morally right one.

This was an occasion to clean up erw's as well.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
