### PR TITLE
[Merged by Bors] - fix: missing `simp` lemmas for bundled coercions

### DIFF
--- a/Mathlib/Algebra/Lie/Derivation/Basic.lean
+++ b/Mathlib/Algebra/Lie/Derivation/Basic.lean
@@ -259,6 +259,7 @@ instance instAddCommGroup : AddCommGroup (LieDerivation R L M) :=
   coe_injective.addCommGroup _ coe_zero coe_add coe_neg coe_sub (fun _ _ => rfl) fun _ _ => rfl
 
 /-- `coe_fn` as an `AddMonoidHom`. -/
+@[simps]
 def coeFnAddMonoidHom : LieDerivation R L M →+ L → M where
   toFun := (↑)
   map_zero' := coe_zero

--- a/Mathlib/Algebra/Lie/Derivation/Basic.lean
+++ b/Mathlib/Algebra/Lie/Derivation/Basic.lean
@@ -259,11 +259,13 @@ instance instAddCommGroup : AddCommGroup (LieDerivation R L M) :=
   coe_injective.addCommGroup _ coe_zero coe_add coe_neg coe_sub (fun _ _ => rfl) fun _ _ => rfl
 
 /-- `coe_fn` as an `AddMonoidHom`. -/
-@[simps]
 def coeFnAddMonoidHom : LieDerivation R L M →+ L → M where
   toFun := (↑)
   map_zero' := coe_zero
   map_add' := coe_add
+
+@[simp]
+lemma coeFnAddMonoidHom_apply (D : LieDerivation R L M) : coeFnAddMonoidHom D = D := rfl
 
 instance : DistribMulAction S (LieDerivation R L M) :=
   Function.Injective.distribMulAction coeFnAddMonoidHom coe_injective coe_smul

--- a/Mathlib/Algebra/Order/Nonneg/Basic.lean
+++ b/Mathlib/Algebra/Order/Nonneg/Basic.lean
@@ -128,6 +128,7 @@ instance addMonoid : AddMonoid { x : α // 0 ≤ x } :=
   Subtype.coe_injective.addMonoid _ Nonneg.coe_zero (fun _ _ => rfl) fun _ _ => rfl
 
 /-- Coercion `{x : α // 0 ≤ x} → α` as an `AddMonoidHom`. -/
+@[simps]
 def coeAddMonoidHom : { x : α // 0 ≤ x } →+ α :=
   { toFun := ((↑) : { x : α // 0 ≤ x } → α)
     map_zero' := Nonneg.coe_zero

--- a/Mathlib/Analysis/Normed/Lp/lpSpace.lean
+++ b/Mathlib/Analysis/Normed/Lp/lpSpace.lean
@@ -339,6 +339,7 @@ theorem coeFn_add (f g : lp E p) : ⇑(f + g) = f + g :=
 
 variable (p E) in
 /-- Coercion to function as an `AddMonoidHom`. -/
+@[simps]
 def coeFnAddMonoidHom : lp E p →+ (∀ i, E i) where
   toFun := (⇑)
   __ := AddSubgroup.subtype _

--- a/Mathlib/Analysis/Normed/Lp/lpSpace.lean
+++ b/Mathlib/Analysis/Normed/Lp/lpSpace.lean
@@ -339,7 +339,6 @@ theorem coeFn_add (f g : lp E p) : ⇑(f + g) = f + g :=
 
 variable (p E) in
 /-- Coercion to function as an `AddMonoidHom`. -/
-@[simps]
 def coeFnAddMonoidHom : lp E p →+ (∀ i, E i) where
   toFun := (⇑)
   __ := AddSubgroup.subtype _

--- a/Mathlib/Data/DFinsupp/Defs.lean
+++ b/Mathlib/Data/DFinsupp/Defs.lean
@@ -226,11 +226,14 @@ instance [∀ i, AddMonoid (β i)] : AddMonoid (Π₀ i, β i) :=
   DFunLike.coe_injective.addMonoid _ coe_zero coe_add fun _ _ => coe_nsmul _ _
 
 /-- Coercion from a `DFinsupp` to a pi type is an `AddMonoidHom`. -/
-@[simps]
 def coeFnAddMonoidHom [∀ i, AddZeroClass (β i)] : (Π₀ i, β i) →+ ∀ i, β i where
   toFun := (⇑)
   map_zero' := coe_zero
   map_add' := coe_add
+
+@[simp]
+lemma coeFnAddMonoidHom_apply [∀ i, AddZeroClass (β i)] (v : Π₀ i, β i) : coeFnAddMonoidHom v = v :=
+  rfl
 
 instance addCommMonoid [∀ i, AddCommMonoid (β i)] : AddCommMonoid (Π₀ i, β i) :=
   DFunLike.coe_injective.addCommMonoid _ coe_zero coe_add fun _ _ => coe_nsmul _ _

--- a/Mathlib/Data/DFinsupp/Defs.lean
+++ b/Mathlib/Data/DFinsupp/Defs.lean
@@ -226,6 +226,7 @@ instance [∀ i, AddMonoid (β i)] : AddMonoid (Π₀ i, β i) :=
   DFunLike.coe_injective.addMonoid _ coe_zero coe_add fun _ _ => coe_nsmul _ _
 
 /-- Coercion from a `DFinsupp` to a pi type is an `AddMonoidHom`. -/
+@[simps]
 def coeFnAddMonoidHom [∀ i, AddZeroClass (β i)] : (Π₀ i, β i) →+ ∀ i, β i where
   toFun := (⇑)
   map_zero' := coe_zero

--- a/Mathlib/Data/PNat/Basic.lean
+++ b/Mathlib/Data/PNat/Basic.lean
@@ -110,8 +110,9 @@ theorem add_coe (m n : ℕ+) : ((m + n : ℕ+) : ℕ) = m + n :=
   rfl
 
 /-- `coe` promoted to an `AddHom`, that is, a morphism which preserves addition. -/
+@[simps]
 def coeAddHom : AddHom ℕ+ ℕ where
-  toFun := Coe.coe
+  toFun := (↑)
   map_add' := add_coe
 
 instance addLeftMono : AddLeftMono ℕ+ :=

--- a/Mathlib/Geometry/Manifold/VectorBundle/SmoothSection.lean
+++ b/Mathlib/Geometry/Manifold/VectorBundle/SmoothSection.lean
@@ -181,6 +181,9 @@ def coeAddHom : Cₛ^n⟮I; F, V⟯ →+ ∀ x, V x where
   map_zero' := coe_zero
   map_add' := coe_add
 
+@[simp]
+theorem coeAddHom_apply (s : Cₛ^n⟮I; F, V⟯) : coeAddHom s = s := rfl
+
 instance instModule : Module 𝕜 Cₛ^n⟮I; F, V⟯ :=
   coe_injective.module 𝕜 (coeAddHom I F n V) coe_smul
 

--- a/Mathlib/Geometry/Manifold/VectorBundle/SmoothSection.lean
+++ b/Mathlib/Geometry/Manifold/VectorBundle/SmoothSection.lean
@@ -175,6 +175,7 @@ theorem coe_smul (r : 𝕜) (s : Cₛ^n⟮I; F, V⟯) : ⇑(r • s : Cₛ^n⟮I
 
 variable (I F V n) in
 /-- The additive morphism from `C^n` sections to dependent maps. -/
+@[simps]
 def coeAddHom : Cₛ^n⟮I; F, V⟯ →+ ∀ x, V x where
   toFun := (↑)
   map_zero' := coe_zero

--- a/Mathlib/Geometry/Manifold/VectorBundle/SmoothSection.lean
+++ b/Mathlib/Geometry/Manifold/VectorBundle/SmoothSection.lean
@@ -175,7 +175,6 @@ theorem coe_smul (r : 𝕜) (s : Cₛ^n⟮I; F, V⟯) : ⇑(r • s : Cₛ^n⟮I
 
 variable (I F V n) in
 /-- The additive morphism from `C^n` sections to dependent maps. -/
-@[simps]
 def coeAddHom : Cₛ^n⟮I; F, V⟯ →+ ∀ x, V x where
   toFun := (↑)
   map_zero' := coe_zero

--- a/Mathlib/Geometry/Manifold/VectorBundle/SmoothSection.lean
+++ b/Mathlib/Geometry/Manifold/VectorBundle/SmoothSection.lean
@@ -181,7 +181,7 @@ def coeAddHom : Cₛ^n⟮I; F, V⟯ →+ ∀ x, V x where
   map_add' := coe_add
 
 @[simp]
-theorem coeAddHom_apply (s : Cₛ^n⟮I; F, V⟯) : coeAddHom s = s := rfl
+theorem coeAddHom_apply (s : Cₛ^n⟮I; F, V⟯) : coeAddHom I F n V s = s := rfl
 
 instance instModule : Module 𝕜 Cₛ^n⟮I; F, V⟯ :=
   coe_injective.module 𝕜 (coeAddHom I F n V) coe_smul

--- a/Mathlib/LinearAlgebra/BilinearForm/Basic.lean
+++ b/Mathlib/LinearAlgebra/BilinearForm/Basic.lean
@@ -116,6 +116,7 @@ theorem sub_apply (x y : M₁) : (B₁ - D₁) x y = B₁ x y - D₁ x y :=
   rfl
 
 /-- `coeFn` as an `AddMonoidHom` -/
+@[simps]
 def coeFnAddMonoidHom : BilinForm R M →+ M → M → R where
   toFun := fun B x y => B x y
   map_zero' := rfl

--- a/Mathlib/MeasureTheory/Measure/MeasureSpace.lean
+++ b/Mathlib/MeasureTheory/Measure/MeasureSpace.lean
@@ -855,11 +855,13 @@ instance instAddCommMonoid {_ : MeasurableSpace α} : AddCommMonoid (Measure α)
     fun _ _ => smul_toOuterMeasure _ _
 
 /-- Coercion to function as an additive monoid homomorphism. -/
-@[simps]
 def coeAddHom {_ : MeasurableSpace α} : Measure α →+ Set α → ℝ≥0∞ where
   toFun := (⇑)
   map_zero' := coe_zero
   map_add' := coe_add
+
+@[simp]
+theorem coeAddHom_apply {_ : MeasurableSpace α} (μ : Measure α) : coeAddHom μ = ⇑μ := rfl
 
 @[simp]
 theorem coe_finset_sum {_m : MeasurableSpace α} (I : Finset ι) (μ : ι → Measure α) :

--- a/Mathlib/MeasureTheory/Measure/MeasureSpace.lean
+++ b/Mathlib/MeasureTheory/Measure/MeasureSpace.lean
@@ -855,6 +855,7 @@ instance instAddCommMonoid {_ : MeasurableSpace α} : AddCommMonoid (Measure α)
     fun _ _ => smul_toOuterMeasure _ _
 
 /-- Coercion to function as an additive monoid homomorphism. -/
+@[simps]
 def coeAddHom {_ : MeasurableSpace α} : Measure α →+ Set α → ℝ≥0∞ where
   toFun := (⇑)
   map_zero' := coe_zero

--- a/Mathlib/Probability/Kernel/Defs.lean
+++ b/Mathlib/Probability/Kernel/Defs.lean
@@ -117,7 +117,7 @@ def coeAddHom (α β : Type*) [MeasurableSpace α] [MeasurableSpace β] :
 
 @[simp]
 theorem coeAddHom_apply (α β : Type*) [MeasurableSpace α] [MeasurableSpace β] (κ : Kernel α β) :
-    coeAddHom κ = ⇑κ := rfl
+    coeAddHom α β κ = ⇑κ := rfl
 
 @[simp]
 theorem coe_finset_sum (I : Finset ι) (κ : ι → Kernel α β) : ⇑(∑ i ∈ I, κ i) = ∑ i ∈ I, ⇑(κ i) :=

--- a/Mathlib/Probability/Kernel/Defs.lean
+++ b/Mathlib/Probability/Kernel/Defs.lean
@@ -116,8 +116,8 @@ def coeAddHom (α β : Type*) [MeasurableSpace α] [MeasurableSpace β] :
   map_add' := coe_add
 
 @[simp]
-theorem coeAddHom_apply(α β : Type*) [MeasurableSpace α] [MeasurableSpace β] (κ : Kernel α β) :
-    coeAddHom μ = ⇑μ := rfl
+theorem coeAddHom_apply (α β : Type*) [MeasurableSpace α] [MeasurableSpace β] (κ : Kernel α β) :
+    coeAddHom κ = ⇑κ := rfl
 
 @[simp]
 theorem coe_finset_sum (I : Finset ι) (κ : ι → Kernel α β) : ⇑(∑ i ∈ I, κ i) = ∑ i ∈ I, ⇑(κ i) :=

--- a/Mathlib/Probability/Kernel/Defs.lean
+++ b/Mathlib/Probability/Kernel/Defs.lean
@@ -109,6 +109,7 @@ instance instOrderBot {α β : Type*} [MeasurableSpace α] [MeasurableSpace β] 
   bot_le κ a := by simp only [coe_zero, Pi.zero_apply, Measure.zero_le]
 
 /-- Coercion to a function as an additive monoid homomorphism. -/
+@[simps]
 def coeAddHom (α β : Type*) [MeasurableSpace α] [MeasurableSpace β] :
     Kernel α β →+ α → Measure β where
   toFun := (⇑)

--- a/Mathlib/Probability/Kernel/Defs.lean
+++ b/Mathlib/Probability/Kernel/Defs.lean
@@ -109,12 +109,15 @@ instance instOrderBot {α β : Type*} [MeasurableSpace α] [MeasurableSpace β] 
   bot_le κ a := by simp only [coe_zero, Pi.zero_apply, Measure.zero_le]
 
 /-- Coercion to a function as an additive monoid homomorphism. -/
-@[simps]
 def coeAddHom (α β : Type*) [MeasurableSpace α] [MeasurableSpace β] :
     Kernel α β →+ α → Measure β where
   toFun := (⇑)
   map_zero' := coe_zero
   map_add' := coe_add
+
+@[simp]
+theorem coeAddHom_apply(α β : Type*) [MeasurableSpace α] [MeasurableSpace β] (κ : Kernel α β) :
+    coeAddHom μ = ⇑μ := rfl
 
 @[simp]
 theorem coe_finset_sum (I : Finset ι) (κ : ι → Kernel α β) : ⇑(∑ i ∈ I, κ i) = ∑ i ∈ I, ⇑(κ i) :=

--- a/Mathlib/RingTheory/Derivation/Basic.lean
+++ b/Mathlib/RingTheory/Derivation/Basic.lean
@@ -227,6 +227,7 @@ instance : AddCommMonoid (Derivation R A M) :=
   coe_injective.addCommMonoid _ coe_zero coe_add fun _ _ => rfl
 
 /-- `coe_fn` as an `AddMonoidHom`. -/
+@[simps]
 def coeFnAddMonoidHom : Derivation R A M →+ A → M where
   toFun := (↑)
   map_zero' := coe_zero

--- a/Mathlib/RingTheory/Derivation/Basic.lean
+++ b/Mathlib/RingTheory/Derivation/Basic.lean
@@ -226,12 +226,14 @@ theorem smul_apply (r : S) (D : Derivation R A M) : (r • D) a = r • D a :=
 instance : AddCommMonoid (Derivation R A M) :=
   coe_injective.addCommMonoid _ coe_zero coe_add fun _ _ => rfl
 
-/-- `coe_fn` as an `AddMonoidHom`. -/
-@[simps]
+/-- `coeFn` as an `AddMonoidHom`. -/
 def coeFnAddMonoidHom : Derivation R A M →+ A → M where
-  toFun := (↑)
+  toFun := (⇑)
   map_zero' := coe_zero
   map_add' := coe_add
+
+@[simp]
+lemma coeFnAddMonoidHom_apply (D : Derivation R A M) : coeFnAddMonoidHom D = D := rfl
 
 instance : DistribMulAction S (Derivation R A M) :=
   Function.Injective.distribMulAction coeFnAddMonoidHom coe_injective coe_smul

--- a/Mathlib/RingTheory/TwoSidedIdeal/Basic.lean
+++ b/Mathlib/RingTheory/TwoSidedIdeal/Basic.lean
@@ -192,7 +192,7 @@ instance addCommGroup : AddCommGroup I :=
     rfl (fun _ _ ↦ rfl) (fun _ ↦ rfl) (fun _ _ ↦ rfl) (fun _ _ ↦ rfl) (fun _ _ ↦ rfl)
 
 /-- The coercion into the ring as a `AddMonoidHom` -/
-@[simp]
+@[simps]
 def coeAddMonoidHom : I →+ R where
   toFun := (↑)
   map_zero' := rfl

--- a/Mathlib/Topology/ContinuousMap/ContinuousMapZero.lean
+++ b/Mathlib/Topology/ContinuousMap/ContinuousMapZero.lean
@@ -239,11 +239,13 @@ lemma evalCLM_apply {𝕜 : Type*} [Semiring 𝕜] [Module 𝕜 R] [ContinuousCo
     (x : X) (f : C(X, R)₀) : evalCLM 𝕜 x f = f x := rfl
 
 /-- Coercion to a function as an `AddMonoidHom`. Similar to `ContinuousMap.coeFnAddMonoidHom`. -/
-@[simps]
 def coeFnAddMonoidHom : C(X, R)₀ →+ X → R where
   toFun f := f
   map_zero' := coe_zero
   map_add' f g := by simp
+
+@[simp]
+lemma coeFnAddMonoidHom_apply (f : C(X, R)₀) : coeFnAddMonoidHom f = f := rfl
 
 @[simp] lemma coe_sum {ι : Type*} (s : Finset ι)
     (f : ι → C(X, R)₀) : ⇑(s.sum f) = s.sum (fun i => ⇑(f i)) :=

--- a/Mathlib/Topology/ContinuousMap/ContinuousMapZero.lean
+++ b/Mathlib/Topology/ContinuousMap/ContinuousMapZero.lean
@@ -239,6 +239,7 @@ lemma evalCLM_apply {𝕜 : Type*} [Semiring 𝕜] [Module 𝕜 R] [ContinuousCo
     (x : X) (f : C(X, R)₀) : evalCLM 𝕜 x f = f x := rfl
 
 /-- Coercion to a function as an `AddMonoidHom`. Similar to `ContinuousMap.coeFnAddMonoidHom`. -/
+@[simps]
 def coeFnAddMonoidHom : C(X, R)₀ →+ X → R where
   toFun f := f
   map_zero' := coe_zero


### PR DESCRIPTION
Most of the time `simps` does too much here but `simps -fullyApplied` does too little, so we have to write them manually.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
