### PR TITLE
[Merged by Bors] - chore(Data/Option): replace bad simp lemma `elim_none_some`

### DIFF
--- a/Mathlib/Data/Option/Basic.lean
+++ b/Mathlib/Data/Option/Basic.lean
@@ -280,8 +280,8 @@ theorem choice_eq_none (α : Type*) [IsEmpty α] : choice α = none :=
 end
 
 @[simp]
-theorem elim_none_some (f : Option α → β) : (fun x ↦ Option.elim x (f none) (f ∘ some)) = f :=
-  funext fun o ↦ by cases o <;> rfl
+theorem elim_none_some (f : Option α → β) (i : Option α) : i.elim (f none) (f ∘ some) = f i := by
+  cases i <;> rfl
 
 theorem elim_comp (h : α → β) {f : γ → α} {x : α} {i : Option γ} :
     (i.elim (h x) fun j => h (f j)) = h (i.elim x f) := by cases i <;> rfl

--- a/Mathlib/Data/Option/Defs.lean
+++ b/Mathlib/Data/Option/Defs.lean
@@ -32,8 +32,13 @@ protected def elim' (b : β) (f : α → β) : Option α → β
 
 @[simp]
 theorem elim'_none (b : β) (f : α → β) : Option.elim' b f none = b := rfl
+
 @[simp]
 theorem elim'_some {a : α} (b : β) (f : α → β) : Option.elim' b f (some a) = f a := rfl
+
+@[simp]
+theorem elim'_none_some (f : Option α → β) : (Option.elim' (f none) (f ∘ some)) = f :=
+  funext fun o ↦ by cases o <;> rfl
 
 lemma elim'_eq_elim {α β : Type*} (b : β) (f : α → β) (a : Option α) :
     Option.elim' b f a = Option.elim a b f := by


### PR DESCRIPTION
The previous simp lemma is tried at every lambda term, which is bad.

[#mathlib4 > bad simp discrimination tree keys @ 💬](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/bad.20simp.20discrimination.20tree.20keys/near/505881050)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
