### PR TITLE
[Merged by Bors] - feat: add some elementary number theory lemmas

### DIFF
--- a/Mathlib/Data/Nat/Prime/Basic.lean
+++ b/Mathlib/Data/Nat/Prime/Basic.lean
@@ -120,6 +120,13 @@ theorem Prime.not_coprime_iff_dvd {m n : ℕ} : ¬Coprime m n ↔ ∃ p, Prime p
     obtain ⟨p, hp⟩ := h
     apply Nat.not_coprime_of_dvd_of_dvd (Prime.one_lt hp.1) hp.2.1 hp.2.2
 
+/-- If `0 < m < minFac n`, then `n` and `m` have gcd equal to `1`. -/
+lemma gcd_eq_one_of_lt_minFac {n m : ℕ} (h₀ : m ≠ 0) (h : m < minFac n) : n.gcd m = 1 := by
+  rw [← coprime_iff_gcd_eq_one, ← not_not (a := n.Coprime m), Prime.not_coprime_iff_dvd]
+  push_neg
+  exact fun p hp hn hm ↦
+    ((le_of_dvd (by omega) hm).trans_lt <| h.trans_le <| minFac_le_of_dvd hp.two_le hn).false
+
 theorem Prime.not_dvd_mul {p m n : ℕ} (pp : Prime p) (Hm : ¬p ∣ m) (Hn : ¬p ∣ n) : ¬p ∣ m * n :=
   mt pp.dvd_mul.1 <| by simp [Hm, Hn]
 

--- a/Mathlib/Data/Nat/Prime/Basic.lean
+++ b/Mathlib/Data/Nat/Prime/Basic.lean
@@ -120,12 +120,16 @@ theorem Prime.not_coprime_iff_dvd {m n : ℕ} : ¬Coprime m n ↔ ∃ p, Prime p
     obtain ⟨p, hp⟩ := h
     apply Nat.not_coprime_of_dvd_of_dvd (Prime.one_lt hp.1) hp.2.1 hp.2.2
 
-/-- If `0 < m < minFac n`, then `n` and `m` have gcd equal to `1`. -/
-lemma gcd_eq_one_of_lt_minFac {n m : ℕ} (h₀ : m ≠ 0) (h : m < minFac n) : n.gcd m = 1 := by
-  rw [← coprime_iff_gcd_eq_one, ← not_not (a := n.Coprime m), Prime.not_coprime_iff_dvd]
+/-- If `0 < m < minFac n`, then `n` and `m` are coprime. -/
+lemma coprime_of_lt_minFac {n m : ℕ} (h₀ : m ≠ 0) (h : m < minFac n) : Coprime n m  := by
+  rw [← not_not (a := n.Coprime m), Prime.not_coprime_iff_dvd]
   push_neg
   exact fun p hp hn hm ↦
     ((le_of_dvd (by omega) hm).trans_lt <| h.trans_le <| minFac_le_of_dvd hp.two_le hn).false
+
+/-- If `0 < m < minFac n`, then `n` and `m` have gcd equal to `1`. -/
+lemma gcd_eq_one_of_lt_minFac {n m : ℕ} (h₀ : m ≠ 0) (h : m < minFac n) : n.gcd m = 1 :=
+  coprime_iff_gcd_eq_one.mp <| coprime_of_lt_minFac h₀ h
 
 theorem Prime.not_dvd_mul {p m n : ℕ} (pp : Prime p) (Hm : ¬p ∣ m) (Hn : ¬p ∣ n) : ¬p ∣ m * n :=
   mt pp.dvd_mul.1 <| by simp [Hm, Hn]

--- a/Mathlib/Data/ZMod/Basic.lean
+++ b/Mathlib/Data/ZMod/Basic.lean
@@ -677,6 +677,9 @@ instance nontrivial (n : ℕ) [Fact (1 < n)] : Nontrivial (ZMod n) :=
 instance nontrivial' : Nontrivial (ZMod 0) := by
   delta ZMod; infer_instance
 
+lemma one_eq_zero_iff {n : ℕ} : (1 : ZMod n) = 0 ↔ n = 1 := by
+  rw [← Nat.cast_one, natCast_zmod_eq_zero_iff_dvd, Nat.dvd_one]
+
 /-- The inversion on `ZMod n`.
 It is setup in such a way that `a * a⁻¹` is equal to `gcd a.val n`.
 In particular, if `a` is coprime to `n`, and hence a unit, `a * a⁻¹ = 1`. -/

--- a/Mathlib/RingTheory/Fintype.lean
+++ b/Mathlib/RingTheory/Fintype.lean
@@ -13,6 +13,8 @@ import Mathlib.Tactic.NormNum
 
 open Finset ZMod
 
+section Ring
+
 variable {R : Type*} [Ring R] [Fintype R] [DecidableEq R]
 
 lemma Finset.univ_of_card_le_two (h : Fintype.card R ≤ 2) :
@@ -51,7 +53,32 @@ lemma Finset.univ_of_card_le_three (h : Fintype.card R ≤ 3) :
       · exact zero_ne_one h
       · exact zero_ne_one h.symm
 
+end Ring
+
+section MonoidWithZero
+
+variable (M₀ : Type*) [MonoidWithZero M₀] [Nontrivial M₀]
+
 open scoped Classical in
-theorem card_units_lt (M₀ : Type*) [MonoidWithZero M₀] [Nontrivial M₀] [Fintype M₀] :
-    Fintype.card M₀ˣ < Fintype.card M₀ :=
+theorem card_units_lt [Fintype M₀] : Fintype.card M₀ˣ < Fintype.card M₀ :=
   Fintype.card_lt_of_injective_of_not_mem Units.val Units.ext not_isUnit_zero
+
+lemma natCard_units_lt [Finite M₀] : Nat.card M₀ˣ < Nat.card M₀ := by
+  have : Fintype M₀ := Fintype.ofFinite M₀
+  simpa only [Fintype.card_eq_nat_card] using card_units_lt M₀
+
+variable {M₀}
+
+lemma orderOf_lt_card [Finite M₀] (a : M₀) : orderOf a < Nat.card M₀ := by
+  by_cases h : IsUnit a
+  · rw [← h.unit_spec, orderOf_units]
+    exact orderOf_le_card.trans_lt <| natCard_units_lt M₀
+  · rw [orderOf_eq_zero_iff'.mpr fun n hn ha ↦ h <| IsUnit.of_pow_eq_one ha hn.ne']
+    exact Nat.card_pos
+
+end MonoidWithZero
+
+lemma ZMod.orderOf_lt {n : ℕ} (hn : 1 < n) (a : ZMod n) : orderOf a < n :=
+  have : NeZero n := ⟨Nat.ne_zero_of_lt hn⟩
+  have : Nontrivial (ZMod n) := nontrivial_iff.mpr hn.ne'
+  (orderOf_lt_card a).trans_eq <| Nat.card_zmod n


### PR DESCRIPTION
This PR adds a few elementary lemmas of a number theoretic flavor. It also improves the sectioning in `Mathlib/RingTheory/Fintype.lean`.

See [here on Zulip](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Some.20elementary.20number.20theory.20results/near/505893560).

I'm labeling this `t-number-theory` although the modified files are under `Data` and `RingTheory`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
