### PR TITLE
[Merged by Bors] - chore(Data/Real/EReal): Rename `EReal.rec` cases

### DIFF
--- a/Mathlib/Data/Real/EReal.lean
+++ b/Mathlib/Data/Real/EReal.lean
@@ -131,11 +131,11 @@ theorem coe_one : ((1 : ℝ) : EReal) = 1 := rfl
 
 When working in term mode, note that pattern matching can be used directly. -/
 @[elab_as_elim, induction_eliminator, cases_eliminator]
-protected def rec {C : EReal → Sort*} (h_bot : C ⊥) (h_real : ∀ a : ℝ, C a) (h_top : C ⊤) :
-    ∀ a : EReal, C a
-  | ⊥ => h_bot
-  | (a : ℝ) => h_real a
-  | ⊤ => h_top
+protected def rec {motive : EReal → Sort*}
+    (bot : motive ⊥) (coe : ∀ a : ℝ, motive a) (top : motive ⊤) : ∀ a : EReal, motive a
+  | ⊥ => bot
+  | (a : ℝ) => coe a
+  | ⊤ => top
 
 protected lemma «forall» {p : EReal → Prop} : (∀ r, p r) ↔ p ⊥ ∧ p ⊤ ∧ ∀ r : ℝ, p r where
   mp h := ⟨h _, h _, fun _ ↦ h _⟩
@@ -428,9 +428,9 @@ theorem eq_bot_iff_forall_lt (x : EReal) : x = ⊥ ↔ ∀ y : ℝ, x < (y : ERe
 lemma exists_between_coe_real {x z : EReal} (h : x < z) : ∃ y : ℝ, x < y ∧ y < z := by
   obtain ⟨a, ha₁, ha₂⟩ := exists_between h
   induction a with
-  | h_bot => exact (not_lt_bot ha₁).elim
-  | h_real a₀ => exact ⟨a₀, ha₁, ha₂⟩
-  | h_top => exact (not_top_lt ha₂).elim
+  | bot => exact (not_lt_bot ha₁).elim
+  | coe a₀ => exact ⟨a₀, ha₁, ha₂⟩
+  | top => exact (not_top_lt ha₂).elim
 
 @[simp]
 lemma image_coe_Icc (x y : ℝ) : Real.toEReal '' Icc x y = Icc ↑x ↑y := by
@@ -875,9 +875,9 @@ theorem top_add_iff_ne_bot {x : EReal} : ⊤ + x = ⊤ ↔ x ≠ ⊥ := by
     rw [add_bot] at h
     exact bot_ne_top h
   · cases x with
-    | h_bot => contradiction
-    | h_top => rfl
-    | h_real r => exact top_add_of_ne_bot h
+    | bot => contradiction
+    | top => rfl
+    | coe r => exact top_add_of_ne_bot h
 
 /-- For any extended real number `x` which is not `⊥`, the sum of `x` and `⊤` is equal to `⊤`. -/
 @[simp]
@@ -1220,12 +1220,12 @@ lemma sub_add_cancel_left {a : EReal} {b : Real} : b - (b + a) = -a := by
 lemma le_sub_iff_add_le {a b c : EReal} (hb : b ≠ ⊥ ∨ c ≠ ⊥) (ht : b ≠ ⊤ ∨ c ≠ ⊤) :
     a ≤ c - b ↔ a + b ≤ c := by
   induction b with
-  | h_bot =>
+  | bot =>
     simp only [ne_eq, not_true_eq_false, false_or] at hb
     simp only [sub_bot hb, le_top, add_bot, bot_le]
-  | h_real b =>
+  | coe b =>
     rw [← (addLECancellable_coe b).add_le_add_iff_right, sub_add_cancel]
-  | h_top =>
+  | top =>
     simp only [ne_eq, not_true_eq_false, false_or, sub_top, le_bot_iff] at ht ⊢
     refine ⟨fun h ↦ h ▸ (bot_add ⊤).symm ▸ bot_le, fun h ↦ ?_⟩
     by_contra ha
@@ -1242,9 +1242,9 @@ protected theorem lt_sub_iff_add_lt {a b c : EReal} (h₁ : b ≠ ⊥ ∨ c ≠ 
 
 theorem sub_le_of_le_add {a b c : EReal} (h : a ≤ b + c) : a - c ≤ b := by
   induction c with
-  | h_bot => rw [add_bot, le_bot_iff] at h; simp only [h, bot_sub, bot_le]
-  | h_real c => exact (sub_le_iff_le_add (.inl (coe_ne_bot c)) (.inl (coe_ne_top c))).2 h
-  | h_top => simp only [sub_top, bot_le]
+  | bot => rw [add_bot, le_bot_iff] at h; simp only [h, bot_sub, bot_le]
+  | coe c => exact (sub_le_iff_le_add (.inl (coe_ne_bot c)) (.inl (coe_ne_top c))).2 h
+  | top => simp only [sub_top, bot_le]
 
 /-- See also `EReal.sub_le_of_le_add`. -/
 theorem sub_le_of_le_add' {a b c : EReal} (h : a ≤ b + c) : a - b ≤ c :=
@@ -1838,8 +1838,8 @@ lemma mul_inv (a b : EReal) : (a * b)⁻¹ = a⁻¹ * b⁻¹ := by
 
 lemma sign_mul_inv_abs (a : EReal) : (sign a) * (a.abs : EReal)⁻¹ = a⁻¹ := by
   induction a with
-  | h_bot | h_top => simp
-  | h_real a =>
+  | bot | top => simp
+  | coe a =>
     rcases lt_trichotomy a 0 with (a_neg | rfl | a_pos)
     · rw [sign_coe, _root_.sign_neg a_neg, coe_neg_one, neg_one_mul, ← inv_neg, abs_def a,
         coe_ennreal_ofReal, max_eq_left (abs_nonneg a), ← coe_neg |a|, abs_of_neg a_neg, neg_neg]
@@ -1851,8 +1851,8 @@ lemma sign_mul_inv_abs (a : EReal) : (sign a) * (a.abs : EReal)⁻¹ = a⁻¹ :=
 
 lemma sign_mul_inv_abs' (a : EReal) : (sign a) * ((a.abs⁻¹ : ℝ≥0∞) : EReal) = a⁻¹ := by
   induction a with
-  | h_bot | h_top  => simp
-  | h_real a =>
+  | bot | top  => simp
+  | coe a =>
     rcases lt_trichotomy a 0 with (a_neg | rfl | a_pos)
     · rw [sign_coe, _root_.sign_neg a_neg, coe_neg_one, neg_one_mul, abs_def a,
         ← ofReal_inv_of_pos (abs_pos_of_neg a_neg), coe_ennreal_ofReal,
@@ -1869,37 +1869,37 @@ lemma sign_mul_inv_abs' (a : EReal) : (sign a) * ((a.abs⁻¹ : ℝ≥0∞) : ER
 
 lemma bot_lt_inv (x : EReal) : ⊥ < x⁻¹ := by
   cases x with
-  | h_bot => exact inv_bot ▸ bot_lt_zero
-  | h_top => exact EReal.inv_top ▸ bot_lt_zero
-  | h_real x => exact (coe_inv x).symm ▸ bot_lt_coe (x⁻¹)
+  | bot => exact inv_bot ▸ bot_lt_zero
+  | top => exact EReal.inv_top ▸ bot_lt_zero
+  | coe x => exact (coe_inv x).symm ▸ bot_lt_coe (x⁻¹)
 
 lemma inv_lt_top (x : EReal) : x⁻¹ < ⊤ := by
   cases x with
-  | h_bot => exact inv_bot ▸ zero_lt_top
-  | h_top => exact EReal.inv_top ▸ zero_lt_top
-  | h_real x => exact (coe_inv x).symm ▸ coe_lt_top (x⁻¹)
+  | bot => exact inv_bot ▸ zero_lt_top
+  | top => exact EReal.inv_top ▸ zero_lt_top
+  | coe x => exact (coe_inv x).symm ▸ coe_lt_top (x⁻¹)
 
 lemma inv_nonneg_of_nonneg {a : EReal} (h : 0 ≤ a) : 0 ≤ a⁻¹ := by
   cases a with
-  | h_bot | h_top => simp
-  | h_real a => rw [← coe_inv a, EReal.coe_nonneg, inv_nonneg]; exact EReal.coe_nonneg.1 h
+  | bot | top => simp
+  | coe a => rw [← coe_inv a, EReal.coe_nonneg, inv_nonneg]; exact EReal.coe_nonneg.1 h
 
 lemma inv_nonpos_of_nonpos {a : EReal} (h : a ≤ 0) : a⁻¹ ≤ 0 := by
   cases a with
-  | h_bot | h_top => simp
-  | h_real a => rw [← coe_inv a, EReal.coe_nonpos, inv_nonpos]; exact EReal.coe_nonpos.1 h
+  | bot | top => simp
+  | coe a => rw [← coe_inv a, EReal.coe_nonpos, inv_nonpos]; exact EReal.coe_nonpos.1 h
 
 lemma inv_pos_of_pos_ne_top {a : EReal} (h : 0 < a) (h' : a ≠ ⊤) : 0 < a⁻¹ := by
   cases a with
-  | h_bot => exact (not_lt_bot h).rec
-  | h_real a =>  rw [← coe_inv a]; norm_cast at *; exact inv_pos_of_pos h
-  | h_top => exact (h' (Eq.refl ⊤)).rec
+  | bot => exact (not_lt_bot h).rec
+  | coe a =>  rw [← coe_inv a]; norm_cast at *; exact inv_pos_of_pos h
+  | top => exact (h' (Eq.refl ⊤)).rec
 
 lemma inv_neg_of_neg_ne_bot {a : EReal} (h : a < 0) (h' : a ≠ ⊥) : a⁻¹ < 0 := by
   cases a with
-  | h_bot => exact (h' (Eq.refl ⊥)).rec
-  | h_real a => rw [← coe_inv a]; norm_cast at *; exact inv_lt_zero.2 h
-  | h_top => exact (not_top_lt h).rec
+  | bot => exact (h' (Eq.refl ⊥)).rec
+  | coe a => rw [← coe_inv a]; norm_cast at *; exact inv_lt_zero.2 h
+  | top => exact (not_top_lt h).rec
 
 /-! ### Division -/
 

--- a/Mathlib/MeasureTheory/Constructions/BorelSpace/Real.lean
+++ b/Mathlib/MeasureTheory/Constructions/BorelSpace/Real.lean
@@ -511,9 +511,9 @@ private lemma measurable_const_mul (c : EReal) : Measurable fun (x : EReal) ↦ 
     refine Measurable.piecewise (measurableSet_singleton _) measurable_const ?_
     exact Measurable.piecewise measurableSet_Iio measurable_const measurable_const
   induction c with
-  | h_bot => rwa [h1]
-  | h_real c => exact (measurable_id.const_mul _).coe_real_ereal
-  | h_top =>
+  | bot => rwa [h1]
+  | coe c => exact (measurable_id.const_mul _).coe_real_ereal
+  | top =>
     simp_rw [← neg_bot, neg_mul]
     apply Measurable.neg
     rwa [h1]

--- a/Mathlib/NumberTheory/LSeries/Convergence.lean
+++ b/Mathlib/NumberTheory/LSeries/Convergence.lean
@@ -61,22 +61,22 @@ lemma LSeries.abscissaOfAbsConv_le_of_forall_lt_LSeriesSummable {f : ℕ → ℂ
   refine sInf_le_iff.mpr fun y hy ↦ le_of_forall_gt_imp_ge_of_dense fun a ↦ ?_
   replace hy : ∀ (a : ℝ), LSeriesSummable f a → y ≤ a := by simpa [mem_lowerBounds] using hy
   cases a with
-  | h_real a₀ => exact_mod_cast fun ha ↦ hy a₀ (h a₀ ha)
-  | h_bot => simp
-  | h_top => simp
+  | coe a₀ => exact_mod_cast fun ha ↦ hy a₀ (h a₀ ha)
+  | bot => simp
+  | top => simp
 
 lemma LSeries.abscissaOfAbsConv_le_of_forall_lt_LSeriesSummable' {f : ℕ → ℂ} {x : EReal}
     (h : ∀ y : ℝ, x < y → LSeriesSummable f y) :
     abscissaOfAbsConv f ≤ x := by
   cases x with
-  | h_real => exact abscissaOfAbsConv_le_of_forall_lt_LSeriesSummable <| mod_cast h
-  | h_top => exact le_top
-  | h_bot =>
+  | coe => exact abscissaOfAbsConv_le_of_forall_lt_LSeriesSummable <| mod_cast h
+  | top => exact le_top
+  | bot =>
     refine le_of_eq <| sInf_eq_bot.mpr fun y hy ↦ ?_
     cases y with
-    | h_bot => simp at hy
-    | h_real y => exact ⟨_,  ⟨_, h _ <| EReal.bot_lt_coe _, rfl⟩, mod_cast sub_one_lt y⟩
-    | h_top => exact ⟨_, ⟨_, h _ <| EReal.bot_lt_coe 0, rfl⟩, EReal.zero_lt_top⟩
+    | bot => simp at hy
+    | coe y => exact ⟨_,  ⟨_, h _ <| EReal.bot_lt_coe _, rfl⟩, mod_cast sub_one_lt y⟩
+    | top => exact ⟨_, ⟨_, h _ <| EReal.bot_lt_coe 0, rfl⟩, EReal.zero_lt_top⟩
 
 /-- If `‖f n‖` is bounded by a constant times `n^x`, then the abscissa of absolute convergence
 of `f` is bounded by `x + 1`. -/


### PR DESCRIPTION
This PR renames the cases in `EReal.rec`:
`h_bot` -> `bot`
`h_real` -> `coe`
`h_top` -> `top`

This is to improve the names `cases` and `induction` use when tagging subsequent goals.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
