### PR TITLE
[Merged by Bors] - chore: cleanup a few `erw` in `Analysis/`

### DIFF
--- a/Mathlib/Analysis/Analytic/ChangeOrigin.lean
+++ b/Mathlib/Analysis/Analytic/ChangeOrigin.lean
@@ -285,7 +285,10 @@ theorem changeOrigin_eval (h : (‖x‖₊ + ‖y‖₊ : ℝ≥0∞) < p.radius
   refine hf.unique (changeOriginIndexEquiv.symm.hasSum_iff.1 ?_)
   refine HasSum.sigma_of_hasSum
     (p.hasSum x_add_y_mem_ball) (fun n => ?_) (changeOriginIndexEquiv.symm.summable_iff.2 hsf)
-  erw [(p n).map_add_univ (fun _ => x) fun _ => y]
+  -- We use a type ascription here to convert the sum of two constant functions into
+  -- a single constant function. Can this be done by an explicit rewrite?
+  have : (p n) (fun _ => x + y) = _ := (p n).map_add_univ (fun _ => x) fun _ => y
+  rw [this]
   simp_rw [← changeOriginSeriesTerm_changeOriginIndexEquiv_symm]
   exact hasSum_fintype (fun c => f (changeOriginIndexEquiv.symm ⟨n, c⟩))
 

--- a/Mathlib/Analysis/BoxIntegral/Box/Basic.lean
+++ b/Mathlib/Analysis/BoxIntegral/Box/Basic.lean
@@ -252,10 +252,10 @@ theorem coe_coe : ((I : WithBot (Box ι)) : Set (ι → ℝ)) = I := rfl
 
 theorem isSome_iff : ∀ {I : WithBot (Box ι)}, I.isSome ↔ (I : Set (ι → ℝ)).Nonempty
   | ⊥ => by
-    erw [Option.isSome]
+    unfold Option.isSome
     simp
   | (I : Box ι) => by
-    erw [Option.isSome]
+    unfold Option.isSome
     simp [I.nonempty_coe]
 
 theorem biUnion_coe_eq_coe (I : WithBot (Box ι)) :

--- a/Mathlib/Analysis/BoxIntegral/Partition/Measure.lean
+++ b/Mathlib/Analysis/BoxIntegral/Partition/Measure.lean
@@ -75,8 +75,10 @@ end Box
 theorem Prepartition.measure_iUnion_toReal [Finite ι] {I : Box ι} (π : Prepartition I)
     (μ : Measure (ι → ℝ)) [IsLocallyFiniteMeasure μ] :
     (μ π.iUnion).toReal = ∑ J ∈ π.boxes, (μ J).toReal := by
-  erw [← ENNReal.toReal_sum, π.iUnion_def, measure_biUnion_finset π.pairwiseDisjoint]
-  exacts [fun J _ => J.measurableSet_coe, fun J _ => (J.measure_coe_lt_top μ).ne]
+  rw [← ENNReal.toReal_sum (fun J _ => (J.measure_coe_lt_top μ).ne), π.iUnion_def]
+  simp only [← mem_boxes]
+  rw [measure_biUnion_finset π.pairwiseDisjoint]
+  exact fun J _ => J.measurableSet_coe
 
 end BoxIntegral
 

--- a/Mathlib/Analysis/Complex/Polynomial/Basic.lean
+++ b/Mathlib/Analysis/Complex/Polynomial/Basic.lean
@@ -190,7 +190,9 @@ lemma Irreducible.degree_le_two {p : ℝ[X]} (hp : Irreducible p) : degree p ≤
   cases eq_or_ne z.im 0 with
   | inl hz0 =>
     lift z to ℝ using hz0
-    erw [aeval_ofReal, RCLike.ofReal_eq_zero] at hz
+    -- I can't work out why `erw` is needed here. It looks like exactly the LHS of `aeval_ofReal`.
+    erw [aeval_ofReal] at hz
+    rw [RCLike.ofReal_eq_zero] at hz
     exact (degree_eq_one_of_irreducible_of_root hp hz).trans_le one_le_two
   | inr hz0 =>
     obtain ⟨q, rfl⟩ := p.quadratic_dvd_of_aeval_eq_zero_im_ne_zero hz hz0

--- a/Mathlib/Analysis/Convex/Caratheodory.lean
+++ b/Mathlib/Analysis/Convex/Caratheodory.lean
@@ -170,7 +170,8 @@ theorem eq_pos_convex_span_of_mem_convexHull {x : E} (hx : x ∈ convexHull 𝕜
   · exact ht₂.comp_embedding ⟨_, inclusion_injective (Finset.filter_subset (fun i => w i ≠ 0) t)⟩
   · exact fun i =>
       (hw₁ _ (Finset.mem_filter.mp i.2).1).lt_of_ne (Finset.mem_filter.mp i.property).2.symm
-  · erw [Finset.sum_attach, Finset.sum_filter_ne_zero, hw₂]
+  · simp only [univ_eq_attach, Function.comp_apply]
+    rw [Finset.sum_attach, Finset.sum_filter_ne_zero, hw₂]
   · change (∑ i ∈ t'.attach, (fun e => w e • e) ↑i) = x
     rw [Finset.sum_attach (f := fun e => w e • e), Finset.sum_filter_of_ne]
     · rw [t.centerMass_eq_of_sum_1 id hw₂] at hw₃


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
