### PR TITLE
[Merged by Bors] - feat: a reduced irreducible finite crystallographic root system has roots of at most two different lengths

### DIFF
--- a/Mathlib/Algebra/Lie/Weights/RootSystem.lean
+++ b/Mathlib/Algebra/Lie/Weights/RootSystem.lean
@@ -414,14 +414,15 @@ instance : (rootSystem H).IsCrystallographic where
   exists_value α β :=
     ⟨chainBotCoeff β.1 α.1 - chainTopCoeff β.1 α.1, by simp [apply_coroot_eq_cast β.1 α.1]⟩
 
-theorem isReduced_rootSystem : (rootSystem H).IsReduced := by
-  intro ⟨α, hα⟩ ⟨β, hβ⟩ e
-  rw [LinearIndependent.pair_iff' ((rootSystem H).ne_zero _), not_forall] at e
-  simp only [Nat.succ_eq_add_one, Nat.reduceAdd, rootSystem_root_apply, ne_eq, not_not] at e
-  obtain ⟨u, hu⟩ := e
-  obtain (h | h) :=
-    eq_neg_or_eq_of_eq_smul α β (by simpa using hβ) u (by ext x; exact DFunLike.congr_fun hu.symm x)
-  · right; ext x; simpa [neg_eq_iff_eq_neg] using DFunLike.congr_fun h.symm x
-  · left; ext x; simpa using DFunLike.congr_fun h.symm x
+instance : (rootSystem H).IsReduced where
+  eq_or_eq_neg := by
+    intro ⟨α, hα⟩ ⟨β, hβ⟩ e
+    rw [LinearIndependent.pair_iff' ((rootSystem H).ne_zero _), not_forall] at e
+    simp only [Nat.succ_eq_add_one, Nat.reduceAdd, rootSystem_root_apply, ne_eq, not_not] at e
+    obtain ⟨u, hu⟩ := e
+    obtain (h | h) := eq_neg_or_eq_of_eq_smul α β (by simpa using hβ) u
+      (by ext x; exact DFunLike.congr_fun hu.symm x)
+    · right; ext x; simpa [neg_eq_iff_eq_neg] using DFunLike.congr_fun h.symm x
+    · left; ext x; simpa using DFunLike.congr_fun h.symm x
 
 end LieAlgebra.IsKilling

--- a/Mathlib/Algebra/Module/Submodule/Ker.lean
+++ b/Mathlib/Algebra/Module/Submodule/Ker.lean
@@ -122,6 +122,7 @@ theorem ker_restrict [AddCommMonoid M₁] [Module R M₁] {p : Submodule R M} {q
 theorem ker_zero : ker (0 : M →ₛₗ[τ₁₂] M₂) = ⊤ :=
   eq_top_iff'.2 fun x => by simp
 
+@[simp]
 theorem ker_eq_top {f : M →ₛₗ[τ₁₂] M₂} : ker f = ⊤ ↔ f = 0 :=
   ⟨fun h => ext fun _ => mem_ker.1 <| h.symm ▸ trivial, fun h => h.symm ▸ ker_zero⟩
 

--- a/Mathlib/LinearAlgebra/RootSystem/Finite/CanonicalBilinear.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Finite/CanonicalBilinear.lean
@@ -5,6 +5,7 @@ Authors: Scott Carnahan
 -/
 import Mathlib.Algebra.Ring.SumsOfSquares
 import Mathlib.LinearAlgebra.RootSystem.RootPositive
+import Mathlib.LinearAlgebra.RootSystem.WeylGroup
 
 /-!
 # The canonical bilinear form on a finite root pairing
@@ -37,7 +38,6 @@ Weyl group.
  * [M. Demazure, *SGA III, Exposé XXI, Données Radicielles*][demazure1970]
 
 ## TODO (possibly in other files)
- * Weyl-invariance
  * Faithfulness of Weyl group action, and finiteness of Weyl group, for finite root systems.
 -/
 
@@ -147,6 +147,32 @@ lemma rootForm_reflection_reflection_apply (i : ι) (x y : M) :
   exact Fintype.sum_equiv (P.reflection_perm i)
     (fun j ↦ (P.coroot' (P.reflection_perm i j) x) * (P.coroot' (P.reflection_perm i j) y))
     (fun j ↦ P.coroot' j x * P.coroot' j y) (congrFun rfl)
+
+lemma rootForm_isOrthogonal_reflection (i : ι) :
+    P.RootForm.IsOrthogonal (P.reflection i) :=
+  P.rootForm_reflection_reflection_apply i
+
+lemma pairing_mul_eq_pairing_mul_swap' (i j : ι) :
+    P.pairing j i * P.RootForm (P.root i) (P.root i) =
+    P.pairing i j * P.RootForm (P.root j) (P.root j) :=
+  P.pairing_mul_eq_pairing_mul_swap P.RootForm P.rootForm_symmetric i j
+    (P.rootForm_isOrthogonal_reflection i) (P.rootForm_isOrthogonal_reflection j)
+
+@[simp]
+lemma rootForm_weylGroup_apply (g : P.weylGroup) (x y : M) :
+    P.RootForm (g • x) (g • y) = P.RootForm x y := by
+  revert x y
+  obtain ⟨g, hg⟩ := g
+  induction hg using weylGroup.induction with
+  | mem i => simp
+  | one => simp
+  | mul g₁ g₂ hg₁ hg₂ hg₁' hg₂' =>
+    intro x y
+    -- TODO Right way to avoid this `change`?
+    change P.RootForm
+      (((⟨g₁, hg₁⟩ : P.weylGroup) * (⟨g₂, hg₂⟩ : P.weylGroup)) • x)
+      (((⟨g₁, hg₁⟩ : P.weylGroup) * (⟨g₂, hg₂⟩ : P.weylGroup)) • y) = P.RootForm x y
+    rw [mul_smul, mul_smul, hg₁', hg₂']
 
 /-- This is SGA3 XXI Lemma 1.2.1 (10), key for proving nondegeneracy and positivity. -/
 lemma rootForm_self_smul_coroot (i : ι) :

--- a/Mathlib/LinearAlgebra/RootSystem/Finite/CanonicalBilinear.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Finite/CanonicalBilinear.lean
@@ -5,7 +5,6 @@ Authors: Scott Carnahan
 -/
 import Mathlib.Algebra.Ring.SumsOfSquares
 import Mathlib.LinearAlgebra.RootSystem.RootPositive
-import Mathlib.LinearAlgebra.RootSystem.WeylGroup
 
 /-!
 # The canonical bilinear form on a finite root pairing
@@ -37,8 +36,6 @@ Weyl group.
  * [N. Bourbaki, *Lie groups and Lie algebras. Chapters 4--6*][bourbaki1968]
  * [M. Demazure, *SGA III, Exposé XXI, Données Radicielles*][demazure1970]
 
-## TODO (possibly in other files)
- * Faithfulness of Weyl group action, and finiteness of Weyl group, for finite root systems.
 -/
 
 open Set Function
@@ -147,32 +144,6 @@ lemma rootForm_reflection_reflection_apply (i : ι) (x y : M) :
   exact Fintype.sum_equiv (P.reflection_perm i)
     (fun j ↦ (P.coroot' (P.reflection_perm i j) x) * (P.coroot' (P.reflection_perm i j) y))
     (fun j ↦ P.coroot' j x * P.coroot' j y) (congrFun rfl)
-
-lemma rootForm_isOrthogonal_reflection (i : ι) :
-    P.RootForm.IsOrthogonal (P.reflection i) :=
-  P.rootForm_reflection_reflection_apply i
-
-lemma pairing_mul_eq_pairing_mul_swap' (i j : ι) :
-    P.pairing j i * P.RootForm (P.root i) (P.root i) =
-    P.pairing i j * P.RootForm (P.root j) (P.root j) :=
-  P.pairing_mul_eq_pairing_mul_swap P.RootForm P.rootForm_symmetric i j
-    (P.rootForm_isOrthogonal_reflection i) (P.rootForm_isOrthogonal_reflection j)
-
-@[simp]
-lemma rootForm_weylGroup_apply (g : P.weylGroup) (x y : M) :
-    P.RootForm (g • x) (g • y) = P.RootForm x y := by
-  revert x y
-  obtain ⟨g, hg⟩ := g
-  induction hg using weylGroup.induction with
-  | mem i => simp
-  | one => simp
-  | mul g₁ g₂ hg₁ hg₂ hg₁' hg₂' =>
-    intro x y
-    -- TODO Right way to avoid this `change`?
-    change P.RootForm
-      (((⟨g₁, hg₁⟩ : P.weylGroup) * (⟨g₂, hg₂⟩ : P.weylGroup)) • x)
-      (((⟨g₁, hg₁⟩ : P.weylGroup) * (⟨g₂, hg₂⟩ : P.weylGroup)) • y) = P.RootForm x y
-    rw [mul_smul, mul_smul, hg₁', hg₂']
 
 /-- This is SGA3 XXI Lemma 1.2.1 (10), key for proving nondegeneracy and positivity. -/
 lemma rootForm_self_smul_coroot (i : ι) :
@@ -297,8 +268,9 @@ omit [Module S M] [IsScalarTower S R M] in
 lemma pairingIn_zero_iff [Finite ι] [NoZeroDivisors R] :
     P.pairingIn S i j = 0 ↔ P.pairingIn S j i = 0 := by
   let _i : Fintype ι := Fintype.ofFinite ι
+  have _i := Algebra.charZero_of_charZero S R
   simp only [← FaithfulSMul.algebraMap_eq_zero_iff S R, algebraMap_pairingIn]
-  exact pairing_zero_iff (P.posRootForm S) i j
+  exact (P.posRootForm S).toInvariantForm.pairing_zero_iff i j
 
 end IsValuedInOrdered
 

--- a/Mathlib/LinearAlgebra/RootSystem/Finite/CanonicalBilinear.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Finite/CanonicalBilinear.lean
@@ -264,14 +264,6 @@ lemma zero_lt_pairingIn_iff' [Finite ι] :
   let _i : Fintype ι := Fintype.ofFinite ι
   zero_lt_pairingIn_iff (P.posRootForm S) i j
 
-omit [Module S M] [IsScalarTower S R M] in
-lemma pairingIn_zero_iff [Finite ι] [NoZeroDivisors R] :
-    P.pairingIn S i j = 0 ↔ P.pairingIn S j i = 0 := by
-  let _i : Fintype ι := Fintype.ofFinite ι
-  have _i := Algebra.charZero_of_charZero S R
-  simp only [← FaithfulSMul.algebraMap_eq_zero_iff S R, algebraMap_pairingIn]
-  exact (P.posRootForm S).toInvariantForm.pairing_zero_iff i j
-
 end IsValuedInOrdered
 
 end RootPairing

--- a/Mathlib/LinearAlgebra/RootSystem/Finite/Lemmas.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Finite/Lemmas.lean
@@ -212,20 +212,24 @@ lemma foo (i j : ι) :
     simpa only [algebraMap_pairingIn] using B.pairing_mul_eq_pairing_mul_swap i j'
   aesop
 
--- With many thanks to Wang Jingting!
+-- With many thanks to Mario Carneiro, Johan Commelin, Bhavik Mehta, Wang Jingting.
 theorem extracted (R : Type*) [CommRing R] [CharZero R] [NoZeroDivisors R] (x y z : R)
     (hij : x = 2 * y ∨ x = 3 * y ∨ y = 2 * x ∨ y = 3 * x)
     (hik : x = 2 * z ∨ x = 3 * z ∨ z = 2 * x ∨ z = 3 * x)
     (hjk : y = 2 * z ∨ y = 3 * z ∨ z = 2 * y ∨ z = 3 * y) :
     x = 0 ∧ y = 0 ∧ z = 0 := by
-  rcases hij with (_ | _ | _ | _) <;>
-  rcases hjk with (_ | _ | _ | _) <;>
-  rcases hik with (_ | _ | _ | _) <;>
-  subst_vars <;>
-  rename_i h <;>
-  rw [← sub_eq_zero] at h <;>
-  ring_nf at h <;>
-  simpa using h
+  suffices y = 0 ∨ z = 0 by apply this.elim <;> rintro rfl <;> simp_all
+  let S : Finset (ℕ × ℕ) := {(1, 2), (1, 3), (2, 1), (3, 1)}
+  obtain ⟨⟨ab, hab, hxy⟩, ⟨cd, hcd, hxz⟩, ⟨ef, hef, hyz⟩⟩ :
+    (∃ ab ∈ S, ab.1 * x = ab.2 * y) ∧
+    (∃ cd ∈ S, cd.1 * x = cd.2 * z) ∧
+    (∃ ef ∈ S, ef.1 * y = ef.2 * z) := by
+    simp_all only [Finset.mem_insert, Finset.mem_singleton, exists_eq_or_imp, Nat.cast_one, one_mul,
+      Nat.cast_ofNat, eq_comm, exists_eq_left, and_self, S]
+  have : (ab.1 * cd.2 * ef.1 : R) ≠ ab.2 * cd.1 * ef.2 := by norm_cast; clear! R; decide +revert
+  have : (ab.1 * cd.2 * ef.1 - ab.2 * cd.1 * ef.2) * (y * z) = 0 := by
+    linear_combination z * cd.1 * ef.2 * hxy - ab.1 * ef.1 * y * hxz + ab.1 * x * cd.1 * hyz
+  simp_all only [ne_eq, mul_eq_zero, sub_eq_zero, false_or, S]
 
 -- Also worth having version of this which makes statement about just two values of
 -- `P.pairing` with no mention of root form.

--- a/Mathlib/LinearAlgebra/RootSystem/Finite/Lemmas.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Finite/Lemmas.lean
@@ -205,7 +205,7 @@ theorem exists_apply_eq_or_aux {x y z : R}
     (hik : x = 2 * z ∨ x = 3 * z ∨ z = 2 * x ∨ z = 3 * x)
     (hjk : y = 2 * z ∨ y = 3 * z ∨ z = 2 * y ∨ z = 3 * y) :
     x = 0 ∧ y = 0 ∧ z = 0 := by
-  /- The below proof (due to Mario Carneiro, Johan Commelin, Bhavik Mehta, Wang Jingting) should
+  /- The below proof (due to Mario Carneiro, Johan Commelin, Bhavik Mehta, Jingting Wang) should
      not really be necessary: we should have a tactic to crush this. -/
   suffices y = 0 ∨ z = 0 by apply this.elim <;> rintro rfl <;> simp_all
   let S : Finset (ℕ × ℕ) := {(1, 2), (1, 3), (2, 1), (3, 1)}

--- a/Mathlib/LinearAlgebra/RootSystem/Finite/Lemmas.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Finite/Lemmas.lean
@@ -98,7 +98,7 @@ lemma pairingIn_pairingIn_mem_set_of_isCrystallographic :
   refine (Int.mul_mem_zero_one_two_three_four_iff ?_).mp
     (P.coxeterWeightIn_mem_set_of_isCrystallographic i j)
   have : Fintype ι := Fintype.ofFinite ι
-  simpa [← P.algebraMap_pairingIn ℤ] using pairing_zero_iff (P.posRootForm ℤ) i j
+  simpa [← P.algebraMap_pairingIn ℤ] using (P.posRootForm ℤ).toInvariantForm.pairing_zero_iff i j
 
 lemma pairingIn_pairingIn_mem_set_of_isCrystallographic_of_isReduced
     [P.IsReduced] [NoZeroSMulDivisors R M] :
@@ -116,8 +116,8 @@ lemma coxeterWeightIn_eq_zero_iff :
   refine ⟨fun h ↦ ?_, fun h ↦ by rw [coxeterWeightIn, h, zero_mul]⟩
   have : Fintype ι := Fintype.ofFinite ι
   rwa [← (algebraMap_injective ℤ R).eq_iff, map_zero, algebraMap_coxeterWeightIn,
-    P.coxeterWeight_zero_iff_isOrthogonal (P.posRootForm ℤ), IsOrthogonal,
-    P.pairing_zero_iff (P.posRootForm ℤ) j i, and_self, ← P.algebraMap_pairingIn ℤ,
+    (P.posRootForm ℤ).toInvariantForm.coxeterWeight_zero_iff_isOrthogonal, IsOrthogonal,
+    (P.posRootForm ℤ).toInvariantForm.pairing_zero_iff j i, and_self, ← P.algebraMap_pairingIn ℤ,
     FaithfulSMul.algebraMap_eq_zero_iff] at h
 
 variable [NoZeroSMulDivisors R M] [NoZeroSMulDivisors R N]
@@ -168,28 +168,26 @@ lemma root_add_root_mem_of_pairingIn_neg (h : P.pairingIn ℤ i j < 0) (h' : α 
 
 section RootForm
 
-omit [Finite ι] [NoZeroSMulDivisors R N]
-variable [Fintype ι] [P.IsReduced] [P.IsIrreducible]
-
--- TODO Prove for any invariant form (valued in appropriate scalars) rather than just `RootForm`
+omit [NoZeroSMulDivisors R N]
+variable [P.IsReduced] [P.IsIrreducible] (B : P.InvariantForm)
 
 -- I think best to break this lemma in three:
 -- First part which assumes `P.pairingIn ℤ i j ≠ 0` (but not irreducible) and second which
 -- has assumptions as shown. With third part doing the Weyl group argument.
 open LinearMap MulAction in
 lemma foo (i j : ι) :
-    P.RootForm (P.root i) (P.root i) = P.RootForm (P.root j) (P.root j) ∨
-    P.RootForm (P.root i) (P.root i) = 2 * P.RootForm (P.root j) (P.root j) ∨
-    P.RootForm (P.root i) (P.root i) = 3 * P.RootForm (P.root j) (P.root j) ∨
-    P.RootForm (P.root j) (P.root j) = 2 * P.RootForm (P.root i) (P.root i) ∨
-    P.RootForm (P.root j) (P.root j) = 3 * P.RootForm (P.root i) (P.root i) := by
+    B.form (P.root i) (P.root i) = B.form (P.root j) (P.root j) ∨
+    B.form (P.root i) (P.root i) = 2 * B.form (P.root j) (P.root j) ∨
+    B.form (P.root i) (P.root i) = 3 * B.form (P.root j) (P.root j) ∨
+    B.form (P.root j) (P.root j) = 2 * B.form (P.root i) (P.root i) ∨
+    B.form (P.root j) (P.root j) = 3 * B.form (P.root i) (P.root i) := by
   obtain ⟨j', h₁, h₂⟩ : ∃ j',
-      P.RootForm (P.root j') (P.root j') = P.RootForm (P.root j) (P.root j) ∧
-      P.RootForm (P.root i) (P.root j') ≠ 0 := by
+      B.form (P.root j') (P.root j') = B.form (P.root j) (P.root j) ∧
+      B.form (P.root i) (P.root j') ≠ 0 := by
     -- TODO Probably break this out into its own lemma
     have := P.span_orbit_eq_top j
     contrapose! this
-    replace this : span R (orbit P.weylGroup (P.root j)) ≤ ker (P.RootForm (P.root i)) := by
+    replace this : span R (orbit P.weylGroup (P.root j)) ≤ ker (B.form (P.root i)) := by
       refine Submodule.span_le.mpr fun v hv ↦ ?_
       obtain ⟨g, rfl⟩ := mem_orbit_iff.mp hv
       rw [P.weylGroup_apply_root]
@@ -200,23 +198,51 @@ lemma foo (i j : ι) :
       suffices P.root ((g : P.Aut).indexEquiv j) = g • P.root j by simp [this]
       exact (RootPairing.Equiv.smul_root P j g).symm
     intro contra
-    replace this : P.RootForm (P.root i) (P.root i) = 0 := by
-      suffices P.RootForm (P.root i) = 0 by simp [this]
-      simpa [contra] using this
-    exact IsAnisotropic.rootForm_root_ne_zero i this
+    apply B.ne_zero i
+    suffices B.form (P.root i) = 0 by simp [this]
+    simpa [contra] using this
   replace h₂ : P.pairingIn ℤ i j' ≠ 0 := by
     contrapose! h₂
     replace h₂ : P.pairing i j' = 0 := by rw [← P.algebraMap_pairingIn ℤ, h₂, map_zero]
-    exact (P.apply_root_root_zero_iff (P.posRootForm ℤ) i j').mpr h₂
+    exact (B.apply_root_root_zero_iff i j').mpr h₂
   have h₃ := P.pairingIn_pairingIn_mem_set_of_isCrystallographic_of_isReduced i j'
-  -- have h₄ := P.qux i j'
-  have h₄ : P.pairingIn ℤ j' i * P.RootForm (P.root i) (P.root i) =
-            P.pairingIn ℤ i j' * P.RootForm (P.root j') (P.root j') := by
+  have h₄ : P.pairingIn ℤ j' i * B.form (P.root i) (P.root i) =
+            P.pairingIn ℤ i j' * B.form (P.root j') (P.root j') := by
     change (algebraMap ℤ R (P.pairingIn ℤ j' i)) * _ = (algebraMap ℤ R (P.pairingIn ℤ i j')) * _
-    simpa only [algebraMap_pairingIn] using pairing_mul_eq_pairing_mul_swap' P i j'
+    simpa only [algebraMap_pairingIn] using B.pairing_mul_eq_pairing_mul_swap i j'
   aesop
 
-instance : CancelMonoidWithZero R := by constructor -- Grr
+-- Courtesy of Bhavik and Mario
+theorem extracted (R : Type*) [CommRing R] [CharZero R] [NoZeroDivisors R] (x y z : R)
+    (hij : x = 2 * y ∨ x = 3 * y ∨ y = 2 * x ∨ y = 3 * x)
+    (hik : x = 2 * z ∨ x = 3 * z ∨ z = 2 * x ∨ z = 3 * x)
+    (hjk : y = 2 * z ∨ y = 3 * z ∨ z = 2 * y ∨ z = 3 * y) :
+    x = 0 ∧ y = 0 ∧ z = 0 := by
+  suffices y * z = 0 by
+    simp only [mul_eq_zero, or_assoc] at this
+    obtain rfl | rfl := this <;>
+    simp_all
+  obtain ⟨a, b, hab, hxy⟩ : ∃ a b, (a, b) ∈ ({(1, 2), (1, 3), (2, 1), (3, 1)} : Set (ℕ × ℕ)) ∧
+      a * x = b * y := by
+    simpa [exists_or, or_and_right, eq_comm] using hij
+  obtain ⟨c, d, hcd, hxz⟩ : ∃ c d, (c, d) ∈ ({(1, 2), (1, 3), (2, 1), (3, 1)} : Set (ℕ × ℕ)) ∧
+      c * x = d * z := by
+    simpa [exists_or, or_and_right, eq_comm] using hik
+  obtain ⟨e, f, hef, hyz⟩ : ∃ e f, (e, f) ∈ ({(1, 2), (1, 3), (2, 1), (3, 1)} : Set (ℕ × ℕ)) ∧
+      e * y = f * z := by
+    simpa [exists_or, or_and_right, eq_comm] using hjk
+  have h₁ : a * d * e ≠ b * c * f := by
+    suffices
+        ∀ ab ∈ ({(1, 2), (1, 3), (2, 1), (3, 1)} : Finset (ℕ × ℕ)),
+        ∀ cd ∈ ({(1, 2), (1, 3), (2, 1), (3, 1)} : Finset (ℕ × ℕ)),
+        ∀ ef ∈ ({(1, 2), (1, 3), (2, 1), (3, 1)} : Finset (ℕ × ℕ)),
+        ab.1 * cd.2 * ef.1 ≠ ab.2 * cd.1 * ef.2 by
+      exact this (a, b) (by simpa using hab) (c, d) (by simpa using hcd) (e, f) (by simpa using hef)
+    decide
+  have h₂ : (a * d * e : R) ≠ b * c * f := mod_cast h₁
+  have h₄ : (a * d * e - b * c * f) * (y * z) = 0 := by
+    linear_combination z * c * f * hxy - a * e * y * hxz + a * x * c * hyz
+  simpa [mul_eq_zero, sub_eq_zero, h₂, false_or] using h₄
 
 -- Also worth having version of this which makes statement about just two values of
 -- `P.pairing` with no mention of root form.
@@ -224,35 +250,21 @@ open Submodule in
 /-- A reduced irreducible finite crystallographic root system has roots of at most two different
 lengths. -/
 lemma bar [Nonempty ι] : ∃ i j, ∀ k,
-    P.RootForm (P.root k) (P.root k) = P.RootForm (P.root i) (P.root i) ∨
-    P.RootForm (P.root k) (P.root k) = P.RootForm (P.root j) (P.root j) := by
+    B.form (P.root k) (P.root k) = B.form (P.root i) (P.root i) ∨
+    B.form (P.root k) (P.root k) = B.form (P.root j) (P.root j) := by
   obtain ⟨i⟩ := inferInstanceAs (Nonempty ι)
-  by_cases h : (∀ j, P.RootForm (P.root j) (P.root j) = P.RootForm (P.root i) (P.root i))
+  by_cases h : (∀ j, B.form (P.root j) (P.root j) = B.form (P.root i) (P.root i))
   · refine ⟨i, i, fun j ↦ by simp [h j]⟩
   · push_neg at h
     obtain ⟨j, hji_ne⟩ := h
     refine ⟨i, j, fun k ↦ ?_⟩
     by_contra! hk
     obtain ⟨hki_ne, hkj_ne⟩ := hk
-    have hij := (P.foo i j).resolve_left hji_ne.symm
-    have hik := (P.foo i k).resolve_left hki_ne.symm
-    have hjk := (P.foo j k).resolve_left hkj_ne.symm
-    -- Sigh: blob of boilerplate to break through to `omega`
-    -- Probably the right thing here is for this lemma and the one above to work with
-    -- a new `lengthIn` function that is `ℤ`-valued.
-    let r (p : ι) : span ℤ (range P.root) := ⟨P.root p, subset_span (mem_range_self p)⟩
-    let l (p : ι) : ℤ := (P.posRootForm ℤ).posForm (r p) (r p)
-    have aux₀ (p : ι) : _ = P.RootForm (P.root p) (P.root p) :=
-      (P.posRootForm ℤ).algebraMap_posForm (x := r p) (y := r p)
-    have aux₁ (z : ℤ) (n : ℕ) [n.AtLeastTwo] :
-        ofNat(n) * algebraMap ℤ R z = algebraMap ℤ R (n * z) := by simp; left; rfl
-    have aux₂ : l j ≠ l i ∧ l k ≠ l i ∧ l k ≠ l j := by
-      simp only [← (FaithfulSMul.algebraMap_injective ℤ R).ne_iff,
-        RootPositiveForm.algebraMap_posForm, posRootForm, r, l]
-      tauto
-    simp only [← aux₀, aux₁, (FaithfulSMul.algebraMap_injective ℤ R).eq_iff] at hij hik hjk
-    simp only [l] at aux₂
-    omega
+    have hij := (P.foo B i j).resolve_left hji_ne.symm
+    have hik := (P.foo B i k).resolve_left hki_ne.symm
+    have hjk := (P.foo B j k).resolve_left hkj_ne.symm
+    have := extracted R _ _ _ hij hik hjk
+    aesop
 
 end RootForm
 

--- a/Mathlib/LinearAlgebra/RootSystem/Finite/Lemmas.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Finite/Lemmas.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Oliver Nash
 -/
 import Mathlib.LinearAlgebra.RootSystem.Base
-import Mathlib.LinearAlgebra.RootSystem.Finite.Nondegenerate
+import Mathlib.LinearAlgebra.RootSystem.Finite.CanonicalBilinear
 import Mathlib.LinearAlgebra.RootSystem.Reduced
 import Mathlib.LinearAlgebra.RootSystem.Irreducible
 import Mathlib.NumberTheory.Divisors

--- a/Mathlib/LinearAlgebra/RootSystem/Finite/Lemmas.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Finite/Lemmas.lean
@@ -212,37 +212,20 @@ lemma foo (i j : ι) :
     simpa only [algebraMap_pairingIn] using B.pairing_mul_eq_pairing_mul_swap i j'
   aesop
 
--- Courtesy of Bhavik and Mario
+-- With many thanks to Wang Jingting!
 theorem extracted (R : Type*) [CommRing R] [CharZero R] [NoZeroDivisors R] (x y z : R)
     (hij : x = 2 * y ∨ x = 3 * y ∨ y = 2 * x ∨ y = 3 * x)
     (hik : x = 2 * z ∨ x = 3 * z ∨ z = 2 * x ∨ z = 3 * x)
     (hjk : y = 2 * z ∨ y = 3 * z ∨ z = 2 * y ∨ z = 3 * y) :
     x = 0 ∧ y = 0 ∧ z = 0 := by
-  suffices y * z = 0 by
-    simp only [mul_eq_zero, or_assoc] at this
-    obtain rfl | rfl := this <;>
-    simp_all
-  obtain ⟨a, b, hab, hxy⟩ : ∃ a b, (a, b) ∈ ({(1, 2), (1, 3), (2, 1), (3, 1)} : Set (ℕ × ℕ)) ∧
-      a * x = b * y := by
-    simpa [exists_or, or_and_right, eq_comm] using hij
-  obtain ⟨c, d, hcd, hxz⟩ : ∃ c d, (c, d) ∈ ({(1, 2), (1, 3), (2, 1), (3, 1)} : Set (ℕ × ℕ)) ∧
-      c * x = d * z := by
-    simpa [exists_or, or_and_right, eq_comm] using hik
-  obtain ⟨e, f, hef, hyz⟩ : ∃ e f, (e, f) ∈ ({(1, 2), (1, 3), (2, 1), (3, 1)} : Set (ℕ × ℕ)) ∧
-      e * y = f * z := by
-    simpa [exists_or, or_and_right, eq_comm] using hjk
-  have h₁ : a * d * e ≠ b * c * f := by
-    suffices
-        ∀ ab ∈ ({(1, 2), (1, 3), (2, 1), (3, 1)} : Finset (ℕ × ℕ)),
-        ∀ cd ∈ ({(1, 2), (1, 3), (2, 1), (3, 1)} : Finset (ℕ × ℕ)),
-        ∀ ef ∈ ({(1, 2), (1, 3), (2, 1), (3, 1)} : Finset (ℕ × ℕ)),
-        ab.1 * cd.2 * ef.1 ≠ ab.2 * cd.1 * ef.2 by
-      exact this (a, b) (by simpa using hab) (c, d) (by simpa using hcd) (e, f) (by simpa using hef)
-    decide
-  have h₂ : (a * d * e : R) ≠ b * c * f := mod_cast h₁
-  have h₄ : (a * d * e - b * c * f) * (y * z) = 0 := by
-    linear_combination z * c * f * hxy - a * e * y * hxz + a * x * c * hyz
-  simpa [mul_eq_zero, sub_eq_zero, h₂, false_or] using h₄
+  rcases hij with (_ | _ | _ | _) <;>
+  rcases hjk with (_ | _ | _ | _) <;>
+  rcases hik with (_ | _ | _ | _) <;>
+  subst_vars <;>
+  rename_i h <;>
+  rw [← sub_eq_zero] at h <;>
+  ring_nf at h <;>
+  simpa using h
 
 -- Also worth having version of this which makes statement about just two values of
 -- `P.pairing` with no mention of root form.

--- a/Mathlib/LinearAlgebra/RootSystem/Finite/Lemmas.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Finite/Lemmas.lean
@@ -4,8 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Oliver Nash
 -/
 import Mathlib.LinearAlgebra.RootSystem.Base
-import Mathlib.LinearAlgebra.RootSystem.Finite.CanonicalBilinear
+import Mathlib.LinearAlgebra.RootSystem.Finite.Nondegenerate
 import Mathlib.LinearAlgebra.RootSystem.Reduced
+import Mathlib.LinearAlgebra.RootSystem.Irreducible
 import Mathlib.NumberTheory.Divisors
 
 /-!
@@ -99,6 +100,17 @@ lemma pairingIn_pairingIn_mem_set_of_isCrystallographic :
   have : Fintype ι := Fintype.ofFinite ι
   simpa [← P.algebraMap_pairingIn ℤ] using pairing_zero_iff (P.posRootForm ℤ) i j
 
+lemma pairingIn_pairingIn_mem_set_of_isCrystallographic_of_isReduced
+    [P.IsReduced] [NoZeroSMulDivisors R M] :
+    (P.pairingIn ℤ i j, P.pairingIn ℤ j i) ∈
+      ({(0, 0), (1, 1), (-1, -1), (1, 2), (2, 1), (-1, -2), (-2, -1), (1, 3), (3, 1), (-1, -3),
+        (-3, -1), (2, 2), (-2, -2)} : Set (ℤ × ℤ)) := by
+  rcases eq_or_ne i j with rfl | h₁; · simp
+  rcases eq_or_ne (P.root i) (-P.root j) with h₂ | h₂; · aesop
+  have aux₁ := P.pairingIn_pairingIn_mem_set_of_isCrystallographic i j
+  have aux₂ : P.pairingIn ℤ i j * P.pairingIn ℤ j i ≠ 4 := P.coxeterWeightIn_ne_four ℤ h₁ h₂
+  aesop
+
 lemma coxeterWeightIn_eq_zero_iff :
     P.coxeterWeightIn ℤ i j = 0 ↔ P.pairingIn ℤ i j = 0 := by
   refine ⟨fun h ↦ ?_, fun h ↦ by rw [coxeterWeightIn, h, zero_mul]⟩
@@ -153,6 +165,96 @@ lemma root_add_root_mem_of_pairingIn_neg (h : P.pairingIn ℤ i j < 0) (h' : α 
   replace h : 0 < P.pairingIn ℤ i (-j) := by simpa
   replace h' : i ≠ -j := by contrapose! h'; simp [h']
   simpa using P.root_sub_root_mem_of_pairingIn_pos h h'
+
+section RootForm
+
+omit [Finite ι] [NoZeroSMulDivisors R N]
+variable [Fintype ι] [P.IsReduced] [P.IsIrreducible]
+
+-- TODO Prove for any invariant form (valued in appropriate scalars) rather than just `RootForm`
+
+-- I think best to break this lemma in three:
+-- First part which assumes `P.pairingIn ℤ i j ≠ 0` (but not irreducible) and second which
+-- has assumptions as shown. With third part doing the Weyl group argument.
+open LinearMap MulAction in
+lemma foo (i j : ι) :
+    P.RootForm (P.root i) (P.root i) = P.RootForm (P.root j) (P.root j) ∨
+    P.RootForm (P.root i) (P.root i) = 2 * P.RootForm (P.root j) (P.root j) ∨
+    P.RootForm (P.root i) (P.root i) = 3 * P.RootForm (P.root j) (P.root j) ∨
+    P.RootForm (P.root j) (P.root j) = 2 * P.RootForm (P.root i) (P.root i) ∨
+    P.RootForm (P.root j) (P.root j) = 3 * P.RootForm (P.root i) (P.root i) := by
+  obtain ⟨j', h₁, h₂⟩ : ∃ j',
+      P.RootForm (P.root j') (P.root j') = P.RootForm (P.root j) (P.root j) ∧
+      P.RootForm (P.root i) (P.root j') ≠ 0 := by
+    -- TODO Probably break this out into its own lemma
+    have := P.span_orbit_eq_top j
+    contrapose! this
+    replace this : span R (orbit P.weylGroup (P.root j)) ≤ ker (P.RootForm (P.root i)) := by
+      refine Submodule.span_le.mpr fun v hv ↦ ?_
+      obtain ⟨g, rfl⟩ := mem_orbit_iff.mp hv
+      rw [P.weylGroup_apply_root]
+      simp only [MonoidHom.restrict_apply, Equiv.indexHom_apply]
+      specialize this (P.weylGroupToPerm g j)
+      simp only [MonoidHom.restrict_apply, Equiv.indexHom_apply] at this
+      apply this
+      suffices P.root ((g : P.Aut).indexEquiv j) = g • P.root j by simp [this]
+      exact (RootPairing.Equiv.smul_root P j g).symm
+    intro contra
+    replace this : P.RootForm (P.root i) (P.root i) = 0 := by
+      suffices P.RootForm (P.root i) = 0 by simp [this]
+      simpa [contra] using this
+    exact IsAnisotropic.rootForm_root_ne_zero i this
+  replace h₂ : P.pairingIn ℤ i j' ≠ 0 := by
+    contrapose! h₂
+    replace h₂ : P.pairing i j' = 0 := by rw [← P.algebraMap_pairingIn ℤ, h₂, map_zero]
+    exact (P.apply_root_root_zero_iff (P.posRootForm ℤ) i j').mpr h₂
+  have h₃ := P.pairingIn_pairingIn_mem_set_of_isCrystallographic_of_isReduced i j'
+  -- have h₄ := P.qux i j'
+  have h₄ : P.pairingIn ℤ j' i * P.RootForm (P.root i) (P.root i) =
+            P.pairingIn ℤ i j' * P.RootForm (P.root j') (P.root j') := by
+    change (algebraMap ℤ R (P.pairingIn ℤ j' i)) * _ = (algebraMap ℤ R (P.pairingIn ℤ i j')) * _
+    simpa only [algebraMap_pairingIn] using pairing_mul_eq_pairing_mul_swap' P i j'
+  aesop
+
+instance : CancelMonoidWithZero R := by constructor -- Grr
+
+-- Also worth having version of this which makes statement about just two values of
+-- `P.pairing` with no mention of root form.
+open Submodule in
+/-- A reduced irreducible finite crystallographic root system has roots of at most two different
+lengths. -/
+lemma bar [Nonempty ι] : ∃ i j, ∀ k,
+    P.RootForm (P.root k) (P.root k) = P.RootForm (P.root i) (P.root i) ∨
+    P.RootForm (P.root k) (P.root k) = P.RootForm (P.root j) (P.root j) := by
+  obtain ⟨i⟩ := inferInstanceAs (Nonempty ι)
+  by_cases h : (∀ j, P.RootForm (P.root j) (P.root j) = P.RootForm (P.root i) (P.root i))
+  · refine ⟨i, i, fun j ↦ by simp [h j]⟩
+  · push_neg at h
+    obtain ⟨j, hji_ne⟩ := h
+    refine ⟨i, j, fun k ↦ ?_⟩
+    by_contra! hk
+    obtain ⟨hki_ne, hkj_ne⟩ := hk
+    have hij := (P.foo i j).resolve_left hji_ne.symm
+    have hik := (P.foo i k).resolve_left hki_ne.symm
+    have hjk := (P.foo j k).resolve_left hkj_ne.symm
+    -- Sigh: blob of boilerplate to break through to `omega`
+    -- Probably the right thing here is for this lemma and the one above to work with
+    -- a new `lengthIn` function that is `ℤ`-valued.
+    let r (p : ι) : span ℤ (range P.root) := ⟨P.root p, subset_span (mem_range_self p)⟩
+    let l (p : ι) : ℤ := (P.posRootForm ℤ).posForm (r p) (r p)
+    have aux₀ (p : ι) : _ = P.RootForm (P.root p) (P.root p) :=
+      (P.posRootForm ℤ).algebraMap_posForm (x := r p) (y := r p)
+    have aux₁ (z : ℤ) (n : ℕ) [n.AtLeastTwo] :
+        ofNat(n) * algebraMap ℤ R z = algebraMap ℤ R (n * z) := by simp; left; rfl
+    have aux₂ : l j ≠ l i ∧ l k ≠ l i ∧ l k ≠ l j := by
+      simp only [← (FaithfulSMul.algebraMap_injective ℤ R).ne_iff,
+        RootPositiveForm.algebraMap_posForm, posRootForm, r, l]
+      tauto
+    simp only [← aux₀, aux₁, (FaithfulSMul.algebraMap_injective ℤ R).eq_iff] at hij hik hjk
+    simp only [l] at aux₂
+    omega
+
+end RootForm
 
 namespace Base
 

--- a/Mathlib/LinearAlgebra/RootSystem/Finite/Nondegenerate.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Finite/Nondegenerate.lean
@@ -90,6 +90,12 @@ instance instIsAnisotropicOfIsCrystallographic [CharZero R] [P.IsCrystallographi
   ne_zero := IsAnisotropic.rootForm_root_ne_zero
   isOrthogonal_reflection := P.rootForm_reflection_reflection_apply
 
+lemma pairingIn_zero_iff {S : Type*} [CommRing S] [Algebra S R] [FaithfulSMul S R]
+    [P.IsValuedIn S] [P.IsAnisotropic] [NoZeroDivisors R] [NeZero (2 : R)] {i j : ι} :
+    P.pairingIn S i j = 0 ↔ P.pairingIn S j i = 0 := by
+  simp only [← FaithfulSMul.algebraMap_eq_zero_iff S R, algebraMap_pairingIn,
+    P.toInvariantForm.pairing_zero_iff i j]
+
 end CommRing
 
 section IsDomain

--- a/Mathlib/LinearAlgebra/RootSystem/Finite/Nondegenerate.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Finite/Nondegenerate.lean
@@ -83,6 +83,13 @@ instance instIsAnisotropicOfIsCrystallographic [CharZero R] [P.IsCrystallographi
     IsAnisotropic P :=
   P.isAnisotropic_of_isValuedIn ℤ
 
+/-- The root form of an anisotropic pairing as an invariant form. -/
+@[simps] def toInvariantForm [P.IsAnisotropic] : P.InvariantForm where
+  form := P.RootForm
+  symm := P.rootForm_symmetric
+  ne_zero := IsAnisotropic.rootForm_root_ne_zero
+  isOrthogonal_reflection := P.rootForm_reflection_reflection_apply
+
 end CommRing
 
 section IsDomain

--- a/Mathlib/LinearAlgebra/RootSystem/Hom.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Hom.lean
@@ -653,7 +653,7 @@ instance : DistribMulAction P.Aut M where
 
 @[simp] lemma reflection_smul (i : ι) (x : M) : Equiv.reflection P i • x = P.reflection i x := rfl
 
-@[simp] lemma smul_root (i : ι) (g : P.Aut) :
+@[simp] lemma root_indexEquiv_eq_smul (i : ι) (g : P.Aut) :
     P.root (g.indexEquiv i) = g • P.root i := by
   simpa using (congr_fun g.root_weightMap i).symm
 

--- a/Mathlib/LinearAlgebra/RootSystem/Hom.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Hom.lean
@@ -651,6 +651,12 @@ instance : DistribMulAction P.Aut M where
   smul_zero w := show weightHom P w 0 = 0 by simp
   smul_add w x y := show weightHom P w (x + y) = weightHom P w x + weightHom P w y by simp
 
+@[simp] lemma reflection_smul (i : ι) (x : M) : Equiv.reflection P i • x = P.reflection i x := rfl
+
+lemma smul_root (i : ι) (g : P.Aut) :
+    g • P.root i = P.root (g.indexEquiv i) := by
+  simpa using congr_fun g.root_weightMap i
+
 open MulOpposite in
 instance : DistribMulAction P.Autᵐᵒᵖ N where
   smul w x := unop (coweightHom P (unop w)) x

--- a/Mathlib/LinearAlgebra/RootSystem/Hom.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Hom.lean
@@ -653,9 +653,9 @@ instance : DistribMulAction P.Aut M where
 
 @[simp] lemma reflection_smul (i : ι) (x : M) : Equiv.reflection P i • x = P.reflection i x := rfl
 
-lemma smul_root (i : ι) (g : P.Aut) :
-    g • P.root i = P.root (g.indexEquiv i) := by
-  simpa using congr_fun g.root_weightMap i
+@[simp] lemma smul_root (i : ι) (g : P.Aut) :
+    P.root (g.indexEquiv i) = g • P.root i := by
+  simpa using (congr_fun g.root_weightMap i).symm
 
 open MulOpposite in
 instance : DistribMulAction P.Autᵐᵒᵖ N where

--- a/Mathlib/LinearAlgebra/RootSystem/Irreducible.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Irreducible.lean
@@ -124,6 +124,6 @@ lemma exists_form_eq_form_and_form_ne_zero (B : P.InvariantForm) (i j : ι) :
   obtain ⟨g, rfl⟩ := mem_orbit_iff.mp hv
   simp only [P.weylGroup_apply_root, SetLike.mem_coe, LinearMap.mem_ker]
   apply contra
-  simp [← RootPairing.Equiv.smul_root P j g, ← Subgroup.smul_def g]
+  simp [← Subgroup.smul_def g]
 
 end RootPairing

--- a/Mathlib/LinearAlgebra/RootSystem/Irreducible.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Irreducible.lean
@@ -3,6 +3,7 @@ Copyright (c) 2025 Oliver Nash. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Oliver Nash
 -/
+import Mathlib.LinearAlgebra.RootSystem.RootPositive
 import Mathlib.LinearAlgebra.RootSystem.WeylGroup
 import Mathlib.RepresentationTheory.Submodule
 
@@ -21,7 +22,9 @@ This file contains basic definitions and results about irreducible root systems.
 -/
 
 open Function Set
-open Submodule (span)
+open Submodule (span span_le)
+open LinearMap (ker)
+open MulAction (orbit mem_orbit_self mem_orbit_iff)
 open Module.End (invtSubmodule)
 
 variable {ι R M N : Type*} [CommRing R] [AddCommGroup M] [Module R M] [AddCommGroup N] [Module R N]
@@ -102,11 +105,25 @@ lemma IsIrreducible.mk' {K : Type*} [Field K] [Module K M] [Module K N] [Nontriv
     replace ne_bot : q.dualAnnihilator ≠ ⊤ := by simpa
     simpa using h ne_bot
 
-lemma span_orbit_eq_top [NeZero (2 : R)] [P.IsIrreducible] (i : ι) :
-    span R (MulAction.orbit P.weylGroup (P.root i)) = ⊤ := by
+variable [NeZero (2 : R)] [P.IsIrreducible]
+
+lemma span_orbit_eq_top (i : ι) :
+    span R (orbit P.weylGroup (P.root i)) = ⊤ := by
   refine IsIrreducible.eq_top_of_invtSubmodule_reflection (P := P) _ (fun j ↦ ?_) ?_
   · let g : P.weylGroup := ⟨Equiv.reflection P j, P.reflection_mem_weylGroup j⟩
     exact Module.End.span_orbit_mem_invtSubmodule R (P.root i) g
-  · simpa using ⟨P.root i, MulAction.mem_orbit_self _, P.ne_zero i⟩
+  · simpa using ⟨P.root i, mem_orbit_self _, P.ne_zero i⟩
+
+lemma exists_form_eq_form_and_form_ne_zero (B : P.InvariantForm) (i j : ι) :
+    ∃ k, B.form (P.root k) (P.root k) = B.form (P.root j) (P.root j) ∧
+         B.form (P.root i) (P.root k) ≠ 0 := by
+  by_contra! contra
+  suffices span R (orbit P.weylGroup (P.root j)) ≤ ker (B.form (P.root i)) from
+    B.apply_root_ne_zero i <| by simpa [span_orbit_eq_top] using this
+  refine span_le.mpr fun v hv ↦ ?_
+  obtain ⟨g, rfl⟩ := mem_orbit_iff.mp hv
+  simp only [P.weylGroup_apply_root, SetLike.mem_coe, LinearMap.mem_ker]
+  apply contra
+  simp [← RootPairing.Equiv.smul_root P j g, ← Subgroup.smul_def g]
 
 end RootPairing

--- a/Mathlib/LinearAlgebra/RootSystem/Reduced.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Reduced.lean
@@ -39,18 +39,24 @@ namespace RootPairing
 
 /-- A root pairing is said to be reduced if any linearly dependent pair of roots is related by a
 sign. -/
-def IsReduced : Prop :=
-  ∀ i j, ¬ LinearIndependent R ![P.root i, P.root j] → (P.root i = P.root j ∨ P.root i = - P.root j)
+@[mk_iff] class IsReduced : Prop where
+  eq_or_eq_neg (i j : ι) (h : ¬ LinearIndependent R ![P.root i, P.root j]) :
+    P.root i = P.root j ∨ P.root i = - P.root j
 
-lemma isReduced_iff : P.IsReduced ↔ ∀ i j : ι, i ≠ j →
+lemma isReduced_iff' : P.IsReduced ↔ ∀ i j : ι, i ≠ j →
     ¬ LinearIndependent R ![P.root i, P.root j] → P.root i = - P.root j := by
-  rw [IsReduced]
+  rw [isReduced_iff]
   refine ⟨fun h i j hij hLin ↦ ?_, fun h i j hLin  ↦ ?_⟩
   · specialize h i j hLin
     simp_all only [ne_eq, EmbeddingLike.apply_eq_iff_eq, false_or]
   · rcases eq_or_ne i j with rfl | h'
     · tauto
     · exact Or.inr (h i j h' hLin)
+
+lemma IsReduced.linearIndependent [P.IsReduced] (h : i ≠ j) (h' : P.root i ≠ - P.root j) :
+    LinearIndependent R ![P.root i, P.root j] := by
+  have := IsReduced.eq_or_eq_neg (P := P) i j
+  aesop
 
 lemma infinite_of_linInd_coxeterWeight_four [NeZero (2 : R)] [NoZeroSMulDivisors ℤ M]
     (hl : LinearIndependent R ![P.root i, P.root j]) (hc : P.coxeterWeight i j = 4) :
@@ -196,6 +202,11 @@ lemma linearIndependent_iff_coxeterWeightIn_ne_four :
 lemma coxeterWeightIn_eq_four_iff_not_linearIndependent :
     P.coxeterWeightIn S i j = 4 ↔ ¬ LinearIndependent R ![P.root i, P.root j] := by
   rw [P.linearIndependent_iff_coxeterWeightIn_ne_four S, not_not]
+
+lemma coxeterWeightIn_ne_four [P.IsReduced] (h : i ≠ j) (h' : P.root i ≠ - P.root j) :
+    P.coxeterWeightIn S i j ≠ 4 := by
+  rw [ne_eq, coxeterWeightIn_eq_four_iff_not_linearIndependent, not_not]
+  exact IsReduced.linearIndependent P h h'
 
 variable (i j)
 

--- a/Mathlib/LinearAlgebra/RootSystem/Reduced.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Reduced.lean
@@ -58,6 +58,16 @@ lemma IsReduced.linearIndependent [P.IsReduced] (h : i ≠ j) (h' : P.root i ≠
   have := IsReduced.eq_or_eq_neg (P := P) i j
   aesop
 
+lemma IsReduced.linearIndependent_iff [Nontrivial R] [P.IsReduced] :
+    LinearIndependent R ![P.root i, P.root j] ↔ i ≠ j ∧ P.root i ≠ - P.root j := by
+  refine ⟨fun h ↦ ?_, fun ⟨h, h'⟩ ↦ linearIndependent P h h'⟩
+  rw [LinearIndependent.pair_iff] at h
+  contrapose! h
+  rcases eq_or_ne i j with rfl | h'
+  · exact ⟨1, -1, by simp⟩
+  · rw [h h']
+    exact ⟨1, 1, by simp⟩
+
 lemma infinite_of_linInd_coxeterWeight_four [NeZero (2 : R)] [NoZeroSMulDivisors ℤ M]
     (hl : LinearIndependent R ![P.root i, P.root j]) (hc : P.coxeterWeight i j = 4) :
     Infinite ι := by

--- a/Mathlib/LinearAlgebra/RootSystem/RootPositive.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/RootPositive.lean
@@ -4,9 +4,10 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Carnahan
 -/
 import Mathlib.LinearAlgebra.RootSystem.Defs
+import Mathlib.LinearAlgebra.RootSystem.WeylGroup
 
 /-!
-# Root-positive bilinear forms on root pairings
+# Invariant and root-positive bilinear forms on root pairings
 
 This file contains basic results on Weyl-invariant inner products for root systems and root data.
 Given a root pairing we define a structure which contains a bilinear form together with axioms for
@@ -19,6 +20,7 @@ positive semi-definite on weight space and positive-definite on the span of root
 
 ## Main definitions / results:
 
+ * `RootPairing.InvariantForm`: an invariant bilinear form on a root pairing.
  * `RootPairing.RootPositiveForm`: Given a root pairing this is a structure which contains a
    bilinear form together with axioms for reflection-invariance, symmetry, and strict positivity on
    all roots.
@@ -28,10 +30,6 @@ positive semi-definite on weight space and positive-definite on the span of root
  * `RootPairing.coxeterWeight_nonneg`: All pairs of roots have non-negative Coxeter weight.
  * `RootPairing.coxeterWeight_zero_iff_isOrthogonal` : A Coxeter weight vanishes iff the roots are
    orthogonal.
-
-## TODO
-
-* Invariance under the Weyl group.
 
 -/
 
@@ -44,23 +42,72 @@ variable {ι R S M N : Type*} [LinearOrderedCommRing S] [CommRing R] [Algebra S 
 
 namespace RootPairing
 
-lemma two_mul_apply_root_root_of_isOrthogonal (P : RootPairing ι R M N)
-    (B : LinearMap.BilinForm R M) (i j : ι) (h : B.IsOrthogonal (P.reflection j)) :
-    2 * B (P.root i) (P.root j) = P.pairing i j * B (P.root j) (P.root j) := by
+structure InvariantForm (P : RootPairing ι R M N) where
+  /-- The bilinear form bundled inside an `InvariantForm`. -/
+  form : LinearMap.BilinForm R M
+  symm : form.IsSymm
+  ne_zero (i : ι) : form (P.root i) (P.root i) ≠ 0
+  isOrthogonal_reflection (i : ι) : form.IsOrthogonal (P.reflection i)
+
+namespace InvariantForm
+
+variable {P : RootPairing ι R M N} (B : P.InvariantForm) (i j : ι)
+
+lemma two_mul_apply_root_root :
+    2 * B.form (P.root i) (P.root j) = P.pairing i j * B.form (P.root j) (P.root j) := by
   rw [two_mul, ← eq_sub_iff_add_eq]
-  nth_rw 1 [← h]
+  nth_rw 1 [← B.isOrthogonal_reflection j]
   rw [reflection_apply, reflection_apply_self, root_coroot'_eq_pairing, LinearMap.map_sub₂,
     LinearMap.map_smul₂, smul_eq_mul, LinearMap.map_neg, LinearMap.map_neg, mul_neg, neg_sub_neg]
 
-lemma pairing_mul_eq_pairing_mul_swap (P : RootPairing ι R M N)
-    (B : LinearMap.BilinForm R M)
-    (hB : B.IsSymm)
-    (i j : ι)
-    (hi : B.IsOrthogonal (P.reflection i))
-    (hj : B.IsOrthogonal (P.reflection j)) :
-    P.pairing j i * B (P.root i) (P.root i) = P.pairing i j * B (P.root j) (P.root j) := by
-  rw [← P.two_mul_apply_root_root_of_isOrthogonal B i j hj,
-    ← P.two_mul_apply_root_root_of_isOrthogonal B j i hi, ← hB.eq, RingHom.id_apply]
+lemma pairing_mul_eq_pairing_mul_swap :
+    P.pairing j i * B.form (P.root i) (P.root i) =
+    P.pairing i j * B.form (P.root j) (P.root j) := by
+  rw [← B.two_mul_apply_root_root i j, ← B.two_mul_apply_root_root j i, ← B.symm.eq,
+    RingHom.id_apply]
+
+@[simp]
+lemma apply_reflection_reflection (x y : M) :
+    B.form (P.reflection i x) (P.reflection i y) = B.form x y :=
+  B.isOrthogonal_reflection i x y
+
+@[simp]
+lemma rootForm_weylGroup_apply (g : P.weylGroup) (x y : M) :
+    B.form (g • x) (g • y) = B.form x y := by
+  revert x y
+  obtain ⟨g, hg⟩ := g
+  induction hg using weylGroup.induction with
+  | mem i => simp
+  | one => simp
+  | mul g₁ g₂ hg₁ hg₂ hg₁' hg₂' =>
+    intro x y
+    -- TODO Right way to avoid this `change`?
+    change B.form
+      (((⟨g₁, hg₁⟩ : P.weylGroup) * (⟨g₂, hg₂⟩ : P.weylGroup)) • x)
+      (((⟨g₁, hg₁⟩ : P.weylGroup) * (⟨g₂, hg₂⟩ : P.weylGroup)) • y) = B.form x y
+    rw [mul_smul, mul_smul, hg₁', hg₂']
+
+variable [NoZeroDivisors R] [NeZero (2 : R)]
+
+@[simp]
+lemma apply_root_root_zero_iff :
+    B.form (P.root i) (P.root j) = 0 ↔ P.pairing i j = 0 := by
+  calc B.form (P.root i) (P.root j) = 0
+      ↔ 2 * B.form (P.root i) (P.root j) = 0 := by simp [two_ne_zero]
+    _ ↔ P.pairing i j * B.form (P.root j) (P.root j) = 0 := by rw [B.two_mul_apply_root_root i j]
+    _ ↔ P.pairing i j = 0 := by simp [B.ne_zero j]
+
+include B
+
+lemma pairing_zero_iff :
+    P.pairing i j = 0 ↔ P.pairing j i = 0 := by
+  rw [← B.apply_root_root_zero_iff, ← B.apply_root_root_zero_iff, ← B.symm.eq, RingHom.id_apply]
+
+lemma coxeterWeight_zero_iff_isOrthogonal :
+    P.coxeterWeight i j = 0 ↔ P.IsOrthogonal i j := by
+  simp [coxeterWeight, IsOrthogonal, B.pairing_zero_iff i j]
+
+end InvariantForm
 
 variable (S) in
 /-- Given a root pairing, this is an invariant symmetric bilinear form satisfying a positivity
@@ -74,21 +121,26 @@ structure RootPositiveForm (P : RootPairing ι R M N) [P.IsValuedIn S] where
   exists_pos_eq (i : ι) : ∃ s > 0, algebraMap S R s = form (P.root i) (P.root i)
 
 variable {P : RootPairing ι R M N} [P.IsValuedIn S] (B : P.RootPositiveForm S) (i j : ι)
+  [FaithfulSMul S R] [Module S M] [IsScalarTower S R M]
 
-lemma RootPositiveForm.two_mul_apply_root_root :
-    2 * B.form (P.root i) (P.root j) = P.pairing i j * B.form (P.root j) (P.root j) :=
-  P.two_mul_apply_root_root_of_isOrthogonal B.form i j (B.isOrthogonal_reflection j)
+namespace RootPositiveForm
 
-variable [FaithfulSMul S R]
-
-lemma RootPositiveForm.form_apply_root_ne_zero (i : ι) :
+omit [Module S M] [IsScalarTower S R M] in
+lemma form_apply_root_ne_zero (i : ι) :
     B.form (P.root i) (P.root i) ≠ 0 := by
   obtain ⟨s, hs, hs'⟩ := B.exists_pos_eq i
   simpa [← hs'] using hs.ne'
 
-variable [Module S M] [IsScalarTower S R M]
+@[simps] def toInvariantForm : InvariantForm P where
+  form := B.form
+  symm := B.symm
+  ne_zero := B.form_apply_root_ne_zero
+  isOrthogonal_reflection := B.isOrthogonal_reflection
 
-namespace RootPositiveForm
+omit [Module S M] [IsScalarTower S R M] in
+lemma two_mul_apply_root_root :
+    2 * B.form (P.root i) (P.root j) = P.pairing i j * B.form (P.root j) (P.root j) :=
+  B.toInvariantForm.two_mul_apply_root_root i j
 
 /-- Given a root-positive form associated to a root pairing with coefficients in `R` but taking
 values in `S`, this is the associated `S`-bilinear form on the `S`-span of the roots. -/
@@ -140,7 +192,7 @@ lemma zero_lt_apply_root_root_iff
   let rj : span S (range P.root) := ⟨P.root j, hj⟩
   have : 2 * B.posForm ri rj = P.pairingIn S i j * B.posForm rj rj := by
     apply FaithfulSMul.algebraMap_injective S R
-    simpa [map_ofNat] using two_mul_apply_root_root B i j
+    simpa [map_ofNat] using B.toInvariantForm.two_mul_apply_root_root i j
   calc  0 < B.posForm ri rj
       ↔ 0 < 2 * B.posForm ri rj := by rw [mul_pos_iff_of_pos_left zero_lt_two]
     _ ↔ 0 < P.pairingIn S i j * B.posForm rj rj := by rw [this]
@@ -161,30 +213,5 @@ lemma coxeterWeight_nonneg : 0 ≤ P.coxeterWeightIn S i j := by
   · exact le_of_lt <| mul_pos h ((zero_lt_pairingIn_iff B i j).mp h)
   · have hn : P.pairingIn S j i ≤ 0 := by rwa [← not_lt, ← zero_lt_pairingIn_iff B i j, not_lt]
     exact mul_nonneg_of_nonpos_of_nonpos h hn
-
-variable [NoZeroDivisors R]
-
-omit [Module S M] [IsScalarTower S R M]
-
-@[simp]
-lemma apply_root_root_zero_iff :
-    B.form (P.root i) (P.root j) = 0 ↔ P.pairing i j = 0 := by
-  have _i := Algebra.charZero_of_charZero S R
-  calc B.form (P.root i) (P.root j) = 0
-      ↔ 2 * B.form (P.root i) (P.root j) = 0 := by simp
-    _ ↔ P.pairing i j * B.form (P.root j) (P.root j) = 0 := by rw [B.two_mul_apply_root_root i j]
-    _ ↔ P.pairing i j = 0 := by simp [B.form_apply_root_ne_zero j]
-
-lemma pairing_zero_iff :
-    P.pairing i j = 0 ↔ P.pairing j i = 0 := by
-  rw [← apply_root_root_zero_iff B, ← B.symm.eq, RingHom.id_apply, apply_root_root_zero_iff]
-
-lemma coxeterWeight_zero_iff_isOrthogonal :
-    P.coxeterWeight i j = 0 ↔ P.IsOrthogonal i j := by
-  rw [coxeterWeight, mul_eq_zero]
-  refine ⟨fun h => ?_, fun h => Or.inl h.1⟩
-  rcases h with h | h
-  · exact ⟨h, (pairing_zero_iff B i j).mp h⟩
-  · exact ⟨(pairing_zero_iff B j i).mp h, h⟩
 
 end RootPairing

--- a/Mathlib/LinearAlgebra/RootSystem/RootPositive.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/RootPositive.lean
@@ -82,11 +82,7 @@ lemma rootForm_weylGroup_apply (g : P.weylGroup) (x y : M) :
   | one => simp
   | mul g₁ g₂ hg₁ hg₂ hg₁' hg₂' =>
     intro x y
-    -- TODO Right way to avoid this `change`?
-    change B.form
-      (((⟨g₁, hg₁⟩ : P.weylGroup) * (⟨g₂, hg₂⟩ : P.weylGroup)) • x)
-      (((⟨g₁, hg₁⟩ : P.weylGroup) * (⟨g₂, hg₂⟩ : P.weylGroup)) • y) = B.form x y
-    rw [mul_smul, mul_smul, hg₁', hg₂']
+    rw [← Submonoid.mk_mul_mk _ _ _ hg₁ hg₂, mul_smul, mul_smul, hg₁', hg₂']
 
 variable [NoZeroDivisors R] [NeZero (2 : R)]
 

--- a/Mathlib/LinearAlgebra/RootSystem/RootPositive.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/RootPositive.lean
@@ -76,7 +76,7 @@ lemma apply_reflection_reflection (x y : M) :
   B.isOrthogonal_reflection i x y
 
 @[simp]
-lemma rootForm_weylGroup_apply (g : P.weylGroup) (x y : M) :
+lemma rootForm_weylGroup_smul (g : P.weylGroup) (x y : M) :
     B.form (g • x) (g • y) = B.form x y := by
   revert x y
   obtain ⟨g, hg⟩ := g

--- a/Mathlib/LinearAlgebra/RootSystem/RootPositive.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/RootPositive.lean
@@ -42,6 +42,7 @@ variable {ι R S M N : Type*} [LinearOrderedCommRing S] [CommRing R] [Algebra S 
 
 namespace RootPairing
 
+/-- Given a root pairing, this is an invariant symmetric bilinear form. -/
 structure InvariantForm (P : RootPairing ι R M N) where
   /-- The bilinear form bundled inside an `InvariantForm`. -/
   form : LinearMap.BilinForm R M
@@ -131,6 +132,8 @@ lemma form_apply_root_ne_zero (i : ι) :
   obtain ⟨s, hs, hs'⟩ := B.exists_pos_eq i
   simpa [← hs'] using hs.ne'
 
+/-- Forgetting the positivity condition, we may regard a `RootPositiveForm` as an `InvariantForm`.
+-/
 @[simps] def toInvariantForm : InvariantForm P where
   form := B.form
   symm := B.symm

--- a/Mathlib/LinearAlgebra/RootSystem/RootPositive.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/RootPositive.lean
@@ -54,6 +54,9 @@ namespace InvariantForm
 
 variable {P : RootPairing ι R M N} (B : P.InvariantForm) (i j : ι)
 
+lemma apply_root_ne_zero : B.form (P.root i) ≠ 0 :=
+  fun contra ↦ B.ne_zero i <| by simp [contra]
+
 lemma two_mul_apply_root_root :
     2 * B.form (P.root i) (P.root j) = P.pairing i j * B.form (P.root j) (P.root j) := by
   rw [two_mul, ← eq_sub_iff_add_eq]

--- a/Mathlib/LinearAlgebra/RootSystem/RootPositive.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/RootPositive.lean
@@ -52,6 +52,16 @@ lemma two_mul_apply_root_root_of_isOrthogonal (P : RootPairing ι R M N)
   rw [reflection_apply, reflection_apply_self, root_coroot'_eq_pairing, LinearMap.map_sub₂,
     LinearMap.map_smul₂, smul_eq_mul, LinearMap.map_neg, LinearMap.map_neg, mul_neg, neg_sub_neg]
 
+lemma pairing_mul_eq_pairing_mul_swap (P : RootPairing ι R M N)
+    (B : LinearMap.BilinForm R M)
+    (hB : B.IsSymm)
+    (i j : ι)
+    (hi : B.IsOrthogonal (P.reflection i))
+    (hj : B.IsOrthogonal (P.reflection j)) :
+    P.pairing j i * B (P.root i) (P.root i) = P.pairing i j * B (P.root j) (P.root j) := by
+  rw [← P.two_mul_apply_root_root_of_isOrthogonal B i j hj,
+    ← P.two_mul_apply_root_root_of_isOrthogonal B j i hi, ← hB.eq, RingHom.id_apply]
+
 variable (S) in
 /-- Given a root pairing, this is an invariant symmetric bilinear form satisfying a positivity
 condition. -/

--- a/Mathlib/LinearAlgebra/RootSystem/RootPositive.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/RootPositive.lean
@@ -76,7 +76,7 @@ lemma apply_reflection_reflection (x y : M) :
   B.isOrthogonal_reflection i x y
 
 @[simp]
-lemma rootForm_weylGroup_smul (g : P.weylGroup) (x y : M) :
+lemma apply_weylGroup_smul (g : P.weylGroup) (x y : M) :
     B.form (g • x) (g • y) = B.form x y := by
   revert x y
   obtain ⟨g, hg⟩ := g

--- a/Mathlib/LinearAlgebra/RootSystem/WeylGroup.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/WeylGroup.lean
@@ -175,4 +175,12 @@ def weylGroupRootRep : Representation R P.weylGroup M :=
 def weylGroupCorootRep : Representation R P.weylGroup.op N :=
   Representation.ofDistribMulAction R P.weylGroup.op N
 
+lemma weylGroup_apply_root (g : P.weylGroup) (i : ι) :
+    g • P.root i = P.root (P.weylGroupToPerm g i) := by
+  -- Gross proof: poor API here, needs fixing
+  obtain ⟨e, h⟩ := g
+  simp only [Subgroup.mk_smul, MonoidHom.restrict_apply, Equiv.indexHom_apply]
+  change e.weightMap (P.root i) = _
+  rw [Hom.root_weightMap_apply]
+
 end RootPairing

--- a/Mathlib/LinearAlgebra/RootSystem/WeylGroup.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/WeylGroup.lean
@@ -176,11 +176,7 @@ def weylGroupCorootRep : Representation R P.weylGroup.op N :=
   Representation.ofDistribMulAction R P.weylGroup.op N
 
 lemma weylGroup_apply_root (g : P.weylGroup) (i : ι) :
-    g • P.root i = P.root (P.weylGroupToPerm g i) := by
-  -- Gross proof: poor API here, needs fixing
-  obtain ⟨e, h⟩ := g
-  simp only [Subgroup.mk_smul, MonoidHom.restrict_apply, Equiv.indexHom_apply]
-  change e.weightMap (P.root i) = _
-  rw [Hom.root_weightMap_apply]
+    g • P.root i = P.root (P.weylGroupToPerm g i) :=
+  Hom.root_weightMap_apply _ _ _ _
 
 end RootPairing


### PR DESCRIPTION
In addition to the headline result we also include the following related changes:

- we promote `RootPairing.IsReduced` to a typeclass
- we introduce the definition `RootPairing.InvariantForm` (this allows us to drop ordering assumptions on scalars)

---


[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
