### PR TITLE
[Merged by Bors] - chore: use `to_additive` for `BoundedAdd`

### DIFF
--- a/Mathlib/Topology/Bornology/BoundedOperation.lean
+++ b/Mathlib/Topology/Bornology/BoundedOperation.lean
@@ -25,53 +25,6 @@ we can equip bounded continuous functions with the corresponding operations.
 
 open scoped NNReal
 
-section bounded_add
-/-!
-### Bounded addition
--/
-
-open Pointwise
-
-/-- A typeclass saying that `(p : R × R) ↦ p.1 + p.2` maps any product of bounded sets to a bounded
-set. This property follows from `LipschitzAdd`, and thus automatically holds, e.g., for seminormed
-additive groups. -/
-class BoundedAdd (R : Type*) [Bornology R] [Add R] : Prop where
-  isBounded_add : ∀ {s t : Set R},
-    Bornology.IsBounded s → Bornology.IsBounded t → Bornology.IsBounded (s + t)
-
-variable {R : Type*}
-
-lemma isBounded_add [Bornology R] [Add R] [BoundedAdd R] {s t : Set R}
-    (hs : Bornology.IsBounded s) (ht : Bornology.IsBounded t) :
-    Bornology.IsBounded (s + t) := BoundedAdd.isBounded_add hs ht
-
-lemma add_bounded_of_bounded_of_bounded {X : Type*} [PseudoMetricSpace R] [Add R] [BoundedAdd R]
-    {f g : X → R} (f_bdd : ∃ C, ∀ x y, dist (f x) (f y) ≤ C)
-    (g_bdd : ∃ C, ∀ x y, dist (g x) (g y) ≤ C) :
-    ∃ C, ∀ x y, dist ((f + g) x) ((f + g) y) ≤ C := by
-  obtain ⟨C, hC⟩ := Metric.isBounded_iff.mp <|
-    isBounded_add (Metric.isBounded_range_iff.mpr f_bdd) (Metric.isBounded_range_iff.mpr g_bdd)
-  use C
-  intro x y
-  exact hC (Set.add_mem_add (Set.mem_range_self (f := f) x) (Set.mem_range_self (f := g) x))
-           (Set.add_mem_add (Set.mem_range_self (f := f) y) (Set.mem_range_self (f := g) y))
-
-instance [PseudoMetricSpace R] [AddMonoid R] [LipschitzAdd R] : BoundedAdd R where
-  isBounded_add {s t} s_bdd t_bdd := by
-    have bdd : Bornology.IsBounded (s ×ˢ t) := Bornology.IsBounded.prod s_bdd t_bdd
-    obtain ⟨C, add_lip⟩ := ‹LipschitzAdd R›.lipschitz_add
-    convert add_lip.isBounded_image bdd
-    ext p
-    simp only [Set.mem_image, Set.mem_prod, Prod.exists]
-    constructor
-    · intro ⟨a, a_in_s, b, b_in_t, eq_p⟩
-      exact ⟨a, b, ⟨a_in_s, b_in_t⟩, eq_p⟩
-    · intro ⟨a, b, ⟨a_in_s, b_in_t⟩, eq_p⟩
-      simpa [← eq_p] using Set.add_mem_add a_in_s b_in_t
-
-end bounded_add
-
-
 section bounded_sub
 /-!
 ### Bounded subtraction
@@ -122,20 +75,29 @@ end bounded_sub
 
 section bounded_mul
 /-!
-### Bounded multiplication
+### Bounded multiplication and addition
 -/
 
 open Pointwise Set
 
+/-- A typeclass saying that `(p : R × R) ↦ p.1 + p.2` maps any product of bounded sets to a bounded
+set. This property follows from `LipschitzAdd`, and thus automatically holds, e.g., for seminormed
+additive groups. -/
+class BoundedAdd (R : Type*) [Bornology R] [Add R] : Prop where
+  isBounded_add : ∀ {s t : Set R},
+    Bornology.IsBounded s → Bornology.IsBounded t → Bornology.IsBounded (s + t)
+
 /-- A typeclass saying that `(p : R × R) ↦ p.1 * p.2` maps any product of bounded sets to a bounded
 set. This property automatically holds for non-unital seminormed rings, but it also holds, e.g.,
 for `ℝ≥0`. -/
+@[to_additive]
 class BoundedMul (R : Type*) [Bornology R] [Mul R] : Prop where
   isBounded_mul : ∀ {s t : Set R},
     Bornology.IsBounded s → Bornology.IsBounded t → Bornology.IsBounded (s * t)
 
 variable {R : Type*}
 
+@[to_additive]
 lemma isBounded_mul [Bornology R] [Mul R] [BoundedMul R] {s t : Set R}
     (hs : Bornology.IsBounded s) (ht : Bornology.IsBounded t) :
     Bornology.IsBounded (s * t) := BoundedMul.isBounded_mul hs ht
@@ -159,6 +121,7 @@ lemma isBounded_pow {R : Type*} [Bornology R] [Monoid R] [BoundedMul R] {s : Set
       use y
     exact (isBounded_mul hn s_bdd).subset obs
 
+@[to_additive]
 lemma mul_bounded_of_bounded_of_bounded {X : Type*} [PseudoMetricSpace R] [Mul R] [BoundedMul R]
     {f g : X → R} (f_bdd : ∃ C, ∀ x y, dist (f x) (f y) ≤ C)
     (g_bdd : ∃ C, ∀ x y, dist (g x) (g y) ≤ C) :
@@ -169,6 +132,20 @@ lemma mul_bounded_of_bounded_of_bounded {X : Type*} [PseudoMetricSpace R] [Mul R
   intro x y
   exact hC (Set.mul_mem_mul (Set.mem_range_self (f := f) x) (Set.mem_range_self (f := g) x))
            (Set.mul_mem_mul (Set.mem_range_self (f := f) y) (Set.mem_range_self (f := g) y))
+
+@[to_additive]
+instance [PseudoMetricSpace R] [Monoid R] [LipschitzMul R] : BoundedMul R where
+  isBounded_mul {s t} s_bdd t_bdd := by
+    have bdd : Bornology.IsBounded (s ×ˢ t) := Bornology.IsBounded.prod s_bdd t_bdd
+    obtain ⟨C, mul_lip⟩ := ‹LipschitzMul R›.lipschitz_mul
+    convert mul_lip.isBounded_image bdd
+    ext p
+    simp only [Set.mem_image, Set.mem_prod, Prod.exists]
+    constructor
+    · intro ⟨a, a_in_s, b, b_in_t, eq_p⟩
+      exact ⟨a, b, ⟨a_in_s, b_in_t⟩, eq_p⟩
+    · intro ⟨a, b, ⟨a_in_s, b_in_t⟩, eq_p⟩
+      simpa [← eq_p] using Set.mul_mem_mul a_in_s b_in_t
 
 end bounded_mul
 

--- a/Mathlib/Topology/Bornology/BoundedOperation.lean
+++ b/Mathlib/Topology/Bornology/BoundedOperation.lean
@@ -102,6 +102,7 @@ lemma isBounded_mul [Bornology R] [Mul R] [BoundedMul R] {s t : Set R}
     (hs : Bornology.IsBounded s) (ht : Bornology.IsBounded t) :
     Bornology.IsBounded (s * t) := BoundedMul.isBounded_mul hs ht
 
+@[to_additive]
 lemma isBounded_pow {R : Type*} [Bornology R] [Monoid R] [BoundedMul R] {s : Set R}
     (s_bdd : Bornology.IsBounded s) (n : ℕ) :
     Bornology.IsBounded ((fun x ↦ x ^ n) '' s) := by


### PR DESCRIPTION
`BoundedAdd` and `BoundedMul` results were in separate section of the file that defines them, with very similar proofs.
This PR uses `to_additive` to generate the `Add` results from the `Mul` results, and also adds an instance for the `Mul` case, that was present only for `Add`.

Co-authored-by: Jakob Stiefel

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

The need for this PR arose in #19782

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
