### PR TITLE
[Merged by Bors] - chore: tag measurability lemmas with fun_prop

### DIFF
--- a/Mathlib/MeasureTheory/Constructions/BorelSpace/Order.lean
+++ b/Mathlib/MeasureTheory/Constructions/BorelSpace/Order.lean
@@ -447,23 +447,23 @@ theorem measurableSet_uIoc : MeasurableSet (uIoc a b) :=
 
 variable [SecondCountableTopology α]
 
-@[measurability]
+@[measurability, fun_prop]
 theorem Measurable.max {f g : δ → α} (hf : Measurable f) (hg : Measurable g) :
     Measurable fun a => max (f a) (g a) := by
   simpa only [max_def'] using hf.piecewise (measurableSet_le hg hf) hg
 
-@[measurability]
+@[measurability, fun_prop]
 nonrec theorem AEMeasurable.max {f g : δ → α} {μ : Measure δ} (hf : AEMeasurable f μ)
     (hg : AEMeasurable g μ) : AEMeasurable (fun a => max (f a) (g a)) μ :=
   ⟨fun a => max (hf.mk f a) (hg.mk g a), hf.measurable_mk.max hg.measurable_mk,
     EventuallyEq.comp₂ hf.ae_eq_mk _ hg.ae_eq_mk⟩
 
-@[measurability]
+@[measurability, fun_prop]
 theorem Measurable.min {f g : δ → α} (hf : Measurable f) (hg : Measurable g) :
     Measurable fun a => min (f a) (g a) := by
   simpa only [min_def] using hf.piecewise (measurableSet_le hf hg) hg
 
-@[measurability]
+@[measurability, fun_prop]
 nonrec theorem AEMeasurable.min {f g : δ → α} {μ : Measure δ} (hf : AEMeasurable f μ)
     (hg : AEMeasurable g μ) : AEMeasurable (fun a => min (f a) (g a)) μ :=
   ⟨fun a => min (hf.mk f a) (hg.mk g a), hf.measurable_mk.min hg.measurable_mk,
@@ -725,7 +725,7 @@ end LinearOrder
 
 section ConditionallyCompleteLattice
 
-@[measurability]
+@[measurability, fun_prop]
 theorem Measurable.iSup_Prop {α} {mα : MeasurableSpace α} [ConditionallyCompleteLattice α]
     (p : Prop) {f : δ → α} (hf : Measurable f) : Measurable fun b => ⨆ _ : p, f b := by
   classical
@@ -734,7 +734,7 @@ theorem Measurable.iSup_Prop {α} {mα : MeasurableSpace α} [ConditionallyCompl
   · exact hf
   · exact measurable_const
 
-@[measurability]
+@[measurability, fun_prop]
 theorem Measurable.iInf_Prop {α} {mα : MeasurableSpace α} [ConditionallyCompleteLattice α]
     (p : Prop) {f : δ → α} (hf : Measurable f) : Measurable fun b => ⨅ _ : p, f b := by
   classical
@@ -779,7 +779,7 @@ alias measurable_iSup := Measurable.iSup
 --   simp_rw [iSup_apply]
 --   exact .iSup fun i ↦ by fun_prop
 
-@[measurability]
+@[measurability, fun_prop]
 protected theorem AEMeasurable.iSup {ι} {μ : Measure δ} [Countable ι] {f : ι → δ → α}
     (hf : ∀ i, AEMeasurable (f i) μ) : AEMeasurable (fun b => ⨆ i, f i b) μ := by
   refine ⟨fun b ↦ ⨆ i, (hf i).mk (f i) b, .iSup (fun i ↦ (hf i).measurable_mk), ?_⟩
@@ -796,7 +796,7 @@ protected theorem Measurable.iInf {ι} [Countable ι] {f : ι → δ → α} (hf
 @[deprecated (since := "2024-10-21")]
 alias measurable_iInf := Measurable.iInf
 
-@[measurability]
+@[measurability, fun_prop]
 protected theorem AEMeasurable.iInf {ι} {μ : Measure δ} [Countable ι] {f : ι → δ → α}
     (hf : ∀ i, AEMeasurable (f i) μ) : AEMeasurable (fun b => ⨅ i, f i b) μ :=
   .iSup (α := αᵒᵈ) hf
@@ -937,7 +937,7 @@ alias measurable_limsup' := Measurable.limsup'
 
 /-- `liminf` over `ℕ` is measurable. See `Measurable.liminf'` for a version with a general filter.
 -/
-@[measurability]
+@[measurability, fun_prop]
 theorem Measurable.liminf {f : ℕ → δ → α} (hf : ∀ i, Measurable (f i)) :
     Measurable fun x => liminf (fun i => f i x) atTop :=
   .liminf' hf atTop_countable_basis fun _ => to_countable _
@@ -947,7 +947,7 @@ alias measurable_liminf := Measurable.liminf
 
 /-- `limsup` over `ℕ` is measurable. See `Measurable.limsup'` for a version with a general filter.
 -/
-@[measurability]
+@[measurability, fun_prop]
 theorem Measurable.limsup {f : ℕ → δ → α} (hf : ∀ i, Measurable (f i)) :
     Measurable fun x => limsup (fun i => f i x) atTop :=
   .limsup' hf atTop_countable_basis fun _ => to_countable _

--- a/Mathlib/MeasureTheory/Function/Floor.lean
+++ b/Mathlib/MeasureTheory/Function/Floor.lean
@@ -24,7 +24,7 @@ theorem Int.measurable_floor [OpensMeasurableSpace R] : Measurable (Int.floor : 
   measurable_to_countable fun x => by
     simpa only [Int.preimage_floor_singleton] using measurableSet_Ico
 
-@[measurability]
+@[measurability, fun_prop]
 theorem Measurable.floor [OpensMeasurableSpace R] {f : α → R} (hf : Measurable f) :
     Measurable fun x => ⌊f x⌋ :=
   Int.measurable_floor.comp hf
@@ -33,7 +33,7 @@ theorem Int.measurable_ceil [OpensMeasurableSpace R] : Measurable (Int.ceil : R 
   measurable_to_countable fun x => by
     simpa only [Int.preimage_ceil_singleton] using measurableSet_Ioc
 
-@[measurability]
+@[measurability, fun_prop]
 theorem Measurable.ceil [OpensMeasurableSpace R] {f : α → R} (hf : Measurable f) :
     Measurable fun x => ⌈f x⌉ :=
   Int.measurable_ceil.comp hf
@@ -43,7 +43,7 @@ theorem measurable_fract [BorelSpace R] : Measurable (Int.fract : R → R) := by
   rw [Int.preimage_fract]
   exact MeasurableSet.iUnion fun z => measurable_id.sub_const _ (hs.inter measurableSet_Ico)
 
-@[measurability]
+@[measurability, fun_prop]
 theorem Measurable.fract [BorelSpace R] {f : α → R} (hf : Measurable f) :
     Measurable fun x => Int.fract (f x) :=
   measurable_fract.comp hf
@@ -64,7 +64,7 @@ theorem Nat.measurable_floor : Measurable (Nat.floor : R → ℕ) :=
   measurable_to_countable fun n => by
     rcases eq_or_ne ⌊n⌋₊ 0 with h | h <;> simp [h, Nat.preimage_floor_of_ne_zero, -floor_eq_zero]
 
-@[measurability]
+@[measurability, fun_prop]
 theorem Measurable.nat_floor (hf : Measurable f) : Measurable fun x => ⌊f x⌋₊ :=
   Nat.measurable_floor.comp hf
 
@@ -72,7 +72,7 @@ theorem Nat.measurable_ceil : Measurable (Nat.ceil : R → ℕ) :=
   measurable_to_countable fun n => by
     rcases eq_or_ne ⌈n⌉₊ 0 with h | h <;> simp_all [h, Nat.preimage_ceil_of_ne_zero, -ceil_eq_zero]
 
-@[measurability]
+@[measurability, fun_prop]
 theorem Measurable.nat_ceil (hf : Measurable f) : Measurable fun x => ⌈f x⌉₊ :=
   Nat.measurable_ceil.comp hf
 

--- a/Mathlib/MeasureTheory/Function/L1Space/AEEqFun.lean
+++ b/Mathlib/MeasureTheory/Function/L1Space/AEEqFun.lean
@@ -105,6 +105,7 @@ theorem hasFiniteIntegral_coeFn (f : α →₁[μ] β) : HasFiniteIntegral f μ 
 theorem stronglyMeasurable_coeFn (f : α →₁[μ] β) : StronglyMeasurable f :=
   Lp.stronglyMeasurable f
 
+@[fun_prop]
 theorem measurable_coeFn [MeasurableSpace β] [BorelSpace β] (f : α →₁[μ] β) : Measurable f :=
   (Lp.stronglyMeasurable f).measurable
 

--- a/Mathlib/MeasureTheory/Function/SpecialFunctions/Arctan.lean
+++ b/Mathlib/MeasureTheory/Function/SpecialFunctions/Arctan.lean
@@ -26,7 +26,7 @@ open Real
 
 variable {α : Type*} {m : MeasurableSpace α} {f : α → ℝ}
 
-@[measurability]
+@[measurability, fun_prop]
 theorem Measurable.arctan (hf : Measurable f) : Measurable fun x => arctan (f x) :=
   measurable_arctan.comp hf
 

--- a/Mathlib/MeasureTheory/Function/SpecialFunctions/Inner.lean
+++ b/Mathlib/MeasureTheory/Function/SpecialFunctions/Inner.lean
@@ -16,25 +16,25 @@ variable [RCLike 𝕜] [NormedAddCommGroup E] [InnerProductSpace 𝕜 E]
 
 local notation "⟪" x ", " y "⟫" => @inner 𝕜 _ _ x y
 
-@[aesop safe 20 apply (rule_sets := [Measurable])]
+@[aesop safe 20 apply (rule_sets := [Measurable]), fun_prop]
 theorem Measurable.inner {_ : MeasurableSpace α} [MeasurableSpace E] [OpensMeasurableSpace E]
     [SecondCountableTopology E] {f g : α → E} (hf : Measurable f)
     (hg : Measurable g) : Measurable fun t => ⟪f t, g t⟫ :=
   Continuous.measurable2 continuous_inner hf hg
 
-@[measurability]
+@[measurability, fun_prop]
 theorem Measurable.const_inner {_ : MeasurableSpace α} [MeasurableSpace E] [OpensMeasurableSpace E]
     [SecondCountableTopology E] {c : E} {f : α → E} (hf : Measurable f) :
     Measurable fun t => ⟪c, f t⟫ :=
   Measurable.inner measurable_const hf
 
-@[measurability]
+@[measurability, fun_prop]
 theorem Measurable.inner_const {_ : MeasurableSpace α} [MeasurableSpace E] [OpensMeasurableSpace E]
     [SecondCountableTopology E] {c : E} {f : α → E} (hf : Measurable f) :
     Measurable fun t => ⟪f t, c⟫ :=
   Measurable.inner hf measurable_const
 
-@[aesop safe 20 apply (rule_sets := [Measurable])]
+@[aesop safe 20 apply (rule_sets := [Measurable]), fun_prop]
 theorem AEMeasurable.inner {m : MeasurableSpace α} [MeasurableSpace E] [OpensMeasurableSpace E]
     [SecondCountableTopology E] {μ : MeasureTheory.Measure α} {f g : α → E}
     (hf : AEMeasurable f μ) (hg : AEMeasurable g μ) : AEMeasurable (fun x => ⟪f x, g x⟫) μ := by
@@ -43,16 +43,14 @@ theorem AEMeasurable.inner {m : MeasurableSpace α} [MeasurableSpace E] [OpensMe
   dsimp only
   congr
 
-set_option linter.unusedVariables false in
-@[measurability]
+@[measurability, fun_prop]
 theorem AEMeasurable.const_inner {m : MeasurableSpace α} [MeasurableSpace E]
     [OpensMeasurableSpace E] [SecondCountableTopology E]
     {μ : MeasureTheory.Measure α} {f : α → E} {c : E} (hf : AEMeasurable f μ) :
     AEMeasurable (fun x => ⟪c, f x⟫) μ :=
   AEMeasurable.inner aemeasurable_const hf
 
-set_option linter.unusedVariables false in
-@[measurability]
+@[measurability, fun_prop]
 theorem AEMeasurable.inner_const {m : MeasurableSpace α} [MeasurableSpace E]
     [OpensMeasurableSpace E] [SecondCountableTopology E]
     {μ : MeasureTheory.Measure α} {f : α → E} {c : E} (hf : AEMeasurable f μ) :

--- a/Mathlib/MeasureTheory/Function/SpecialFunctions/RCLike.lean
+++ b/Mathlib/MeasureTheory/Function/SpecialFunctions/RCLike.lean
@@ -35,19 +35,19 @@ section RCLikeComposition
 variable {α 𝕜 : Type*} [RCLike 𝕜] {m : MeasurableSpace α} {f : α → 𝕜}
   {μ : MeasureTheory.Measure α}
 
-@[measurability]
+@[measurability, fun_prop]
 theorem Measurable.re (hf : Measurable f) : Measurable fun x => RCLike.re (f x) :=
   RCLike.measurable_re.comp hf
 
-@[measurability]
+@[measurability, fun_prop]
 theorem AEMeasurable.re (hf : AEMeasurable f μ) : AEMeasurable (fun x => RCLike.re (f x)) μ :=
   RCLike.measurable_re.comp_aemeasurable hf
 
-@[measurability]
+@[measurability, fun_prop]
 theorem Measurable.im (hf : Measurable f) : Measurable fun x => RCLike.im (f x) :=
   RCLike.measurable_im.comp hf
 
-@[measurability]
+@[measurability, fun_prop]
 theorem AEMeasurable.im (hf : AEMeasurable f μ) : AEMeasurable (fun x => RCLike.im (f x)) μ :=
   RCLike.measurable_im.comp_aemeasurable hf
 

--- a/Mathlib/MeasureTheory/Group/Arithmetic.lean
+++ b/Mathlib/MeasureTheory/Group/Arithmetic.lean
@@ -95,17 +95,17 @@ theorem Measurable.const_mul [MeasurableMul M] (hf : Measurable f) (c : M) :
     Measurable fun x => c * f x :=
   (measurable_const_mul c).comp hf
 
-@[to_additive (attr := measurability)]
+@[to_additive (attr := fun_prop, measurability)]
 theorem AEMeasurable.const_mul [MeasurableMul M] (hf : AEMeasurable f μ) (c : M) :
     AEMeasurable (fun x => c * f x) μ :=
   (MeasurableMul.measurable_const_mul c).comp_aemeasurable hf
 
-@[to_additive (attr := measurability)]
+@[to_additive (attr := fun_prop, measurability)]
 theorem Measurable.mul_const [MeasurableMul M] (hf : Measurable f) (c : M) :
     Measurable fun x => f x * c :=
   (measurable_mul_const c).comp hf
 
-@[to_additive (attr := measurability)]
+@[to_additive (attr := fun_prop, measurability)]
 theorem AEMeasurable.mul_const [MeasurableMul M] (hf : AEMeasurable f μ) (c : M) :
     AEMeasurable (fun x => f x * c) μ :=
   (measurable_mul_const c).comp_aemeasurable hf
@@ -177,11 +177,11 @@ section Pow
 variable {β γ α : Type*} [MeasurableSpace β] [MeasurableSpace γ] [Pow β γ] [MeasurablePow β γ]
   {m : MeasurableSpace α} {μ : Measure α} {f : α → β} {g : α → γ}
 
-@[aesop safe 20 apply (rule_sets := [Measurable])]
+@[aesop safe 20 apply (rule_sets := [Measurable]), fun_prop]
 theorem Measurable.pow (hf : Measurable f) (hg : Measurable g) : Measurable fun x => f x ^ g x :=
   measurable_pow.comp (hf.prodMk hg)
 
-@[aesop safe 20 apply (rule_sets := [Measurable])]
+@[aesop safe 20 apply (rule_sets := [Measurable]), fun_prop]
 theorem AEMeasurable.pow (hf : AEMeasurable f μ) (hg : AEMeasurable g μ) :
     AEMeasurable (fun x => f x ^ g x) μ :=
   measurable_pow.comp_aemeasurable (hf.prodMk hg)
@@ -195,11 +195,11 @@ theorem AEMeasurable.pow_const (hf : AEMeasurable f μ) (c : γ) :
     AEMeasurable (fun x => f x ^ c) μ :=
   hf.pow aemeasurable_const
 
-@[measurability]
+@[fun_prop, measurability]
 theorem Measurable.const_pow (hg : Measurable g) (c : β) : Measurable fun x => c ^ g x :=
   measurable_const.pow hg
 
-@[measurability]
+@[fun_prop, measurability]
 theorem AEMeasurable.const_pow (hg : AEMeasurable g μ) (c : β) :
     AEMeasurable (fun x => c ^ g x) μ :=
   aemeasurable_const.pow hg
@@ -243,22 +243,22 @@ section Div
 variable {G α β : Type*} [MeasurableSpace G] [Div G] {m : MeasurableSpace α}
   {mβ : MeasurableSpace β} {f g : α → G} {μ : Measure α}
 
-@[to_additive (attr := measurability)]
+@[to_additive (attr := fun_prop, measurability)]
 theorem Measurable.const_div [MeasurableDiv G] (hf : Measurable f) (c : G) :
     Measurable fun x => c / f x :=
   (MeasurableDiv.measurable_const_div c).comp hf
 
-@[to_additive (attr := measurability)]
+@[to_additive (attr := fun_prop, measurability)]
 theorem AEMeasurable.const_div [MeasurableDiv G] (hf : AEMeasurable f μ) (c : G) :
     AEMeasurable (fun x => c / f x) μ :=
   (MeasurableDiv.measurable_const_div c).comp_aemeasurable hf
 
-@[to_additive (attr := measurability)]
+@[to_additive (attr := fun_prop, measurability)]
 theorem Measurable.div_const [MeasurableDiv G] (hf : Measurable f) (c : G) :
     Measurable fun x => f x / c :=
   (MeasurableDiv.measurable_div_const c).comp hf
 
-@[to_additive (attr := measurability)]
+@[to_additive (attr := fun_prop, measurability)]
 theorem AEMeasurable.div_const [MeasurableDiv G] (hf : AEMeasurable f μ) (c : G) :
     AEMeasurable (fun x => f x / c) μ :=
   (MeasurableDiv.measurable_div_const c).comp_aemeasurable hf
@@ -558,11 +558,11 @@ instance (priority := 100) MeasurableSMul₂.toMeasurableSMul [MeasurableSMul₂
 
 variable [MeasurableSMul M X] {μ : Measure α}
 
-@[to_additive (attr := measurability)]
+@[to_additive (attr := fun_prop, measurability)]
 theorem Measurable.smul_const (hf : Measurable f) (y : X) : Measurable fun x => f x • y :=
   (MeasurableSMul.measurable_smul_const y).comp hf
 
-@[to_additive (attr := measurability)]
+@[to_additive (attr := fun_prop, measurability)]
 theorem AEMeasurable.smul_const (hf : AEMeasurable f μ) (y : X) :
     AEMeasurable (fun x => f x • y) μ :=
   (MeasurableSMul.measurable_smul_const y).comp_aemeasurable hf
@@ -578,12 +578,12 @@ lemma Measurable.const_smul' {g : α → β → X} {h : α → β} (hg : Measura
     (c : M) : Measurable fun a ↦ (c • g a) (h a) :=
   (hg.comp <| measurable_id.prodMk hh).const_smul _
 
-@[to_additive (attr := measurability)]
+@[to_additive (attr := fun_prop, measurability)]
 theorem AEMeasurable.const_smul' (hg : AEMeasurable g μ) (c : M) :
     AEMeasurable (fun x => c • g x) μ :=
   (MeasurableSMul.measurable_const_smul c).comp_aemeasurable hg
 
-@[to_additive (attr := measurability)]
+@[to_additive (attr := fun_prop, measurability)]
 theorem AEMeasurable.const_smul (hf : AEMeasurable g μ) (c : M) : AEMeasurable (c • g) μ :=
   hf.const_smul' c
 


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
