### PR TITLE
[Merged by Bors] - chore(Analysis/Meromorphic/Divisor/MeromorphicFunction): style tweaks…

### DIFF
--- a/Mathlib/Analysis/Meromorphic/Divisor/MeromorphicFunction.lean
+++ b/Mathlib/Analysis/Meromorphic/Divisor/MeromorphicFunction.lean
@@ -3,9 +3,8 @@ Copyright (c) 2025 Stefan Kebekus. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Stefan Kebekus
 -/
-
-import Mathlib.Analysis.Meromorphic.Order
 import Mathlib.Analysis.Meromorphic.Divisor.Basic
+import Mathlib.Analysis.Meromorphic.Order
 
 /-!
 # The Divisor of a Meromorphic Function
@@ -21,12 +20,7 @@ basic lemmas about those divisors.
 - Congruence lemmas for `codiscreteWithin`
 -/
 
-open Classical
-
-variable
-  {𝕜 : Type*} [NontriviallyNormedField 𝕜]
-  {U : Set 𝕜}
-  {z : 𝕜}
+variable {𝕜 : Type*} [NontriviallyNormedField 𝕜] {U : Set 𝕜} {z : 𝕜}
   {E : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E] [CompleteSpace E]
 
 namespace MeromorphicOn
@@ -35,6 +29,7 @@ namespace MeromorphicOn
 ## Definition of the Divisor
 -/
 
+open Classical in
 /-- The divisor of a meromorphic function `f`, mapping a point `z` to the order
   of `f` at `z`, and to zero if the order is infinite. -/
 noncomputable def divisor (f : 𝕜 → E) (U : Set 𝕜) :
@@ -54,12 +49,13 @@ noncomputable def divisor (f : 𝕜 → E) (U : Set 𝕜) :
     · simp only [hf, false_and, ↓reduceDIte]
       exact (Eq.eventuallyEq rfl)
 
-/-- Definition of the divisor. -/
+open Classical in
+/-- Definition of the divisor -/
 theorem divisor_def (f : 𝕜 → E) (U : Set 𝕜) :
     divisor f U z = if h : MeromorphicOn f U ∧ z ∈ U then ((h.1 z h.2).order.untopD 0) else 0 :=
   rfl
 
-/-- Simplifier lemma: On `U`, the divisor of a function `f` that is meromorphic on `U` evaluates to
+/-- Simplifier lemma: on `U`, the divisor of a function `f` that is meromorphic on `U` evaluates to
   `order.untopD`. -/
 @[simp]
 lemma divisor_apply {f : 𝕜 → E} (hf : MeromorphicOn f U) (hz : z ∈ U) :
@@ -69,12 +65,13 @@ lemma divisor_apply {f : 𝕜 → E} (hf : MeromorphicOn f U) (hz : z ∈ U) :
 ## Behavior under Standard Operations
 -/
 
-/-- If orders are finite, the divisor of the scalar product of two meromorphic
-  functions is the sum of the divisors.
+/--
+If orders are finite, the divisor of the scalar product of two meromorphic
+functions is the sum of the divisors.
 
-  See `MeromorphicOn.exists_order_ne_top_iff_forall` and
-  `MeromorphicOn.order_ne_top_of_isPreconnected` for two convenient criteria to
-  guarantee conditions `h₂f₁` and `h₂f₂`.
+See `MeromorphicOn.exists_order_ne_top_iff_forall` and
+`MeromorphicOn.order_ne_top_of_isPreconnected` for two convenient criteria to
+guarantee conditions `h₂f₁` and `h₂f₂`.
 -/
 theorem divisor_smul [CompleteSpace 𝕜] {f₁ : 𝕜 → 𝕜} {f₂ : 𝕜 → E} (h₁f₁ : MeromorphicOn f₁ U)
     (h₁f₂ : MeromorphicOn f₂ U) (h₂f₁ : ∀ z, (hz : z ∈ U) → (h₁f₁ z hz).order ≠ ⊤)
@@ -88,12 +85,13 @@ theorem divisor_smul [CompleteSpace 𝕜] {f₁ : 𝕜 → 𝕜} {f₂ : 𝕜 �
       ← WithTop.coe_add]
   · simp [hz]
 
-/-- If orders are finite, the divisor of the product of two meromorphic
-  functions is the sum of the divisors.
+/--
+If orders are finite, the divisor of the product of two meromorphic
+functions is the sum of the divisors.
 
-  See `MeromorphicOn.exists_order_ne_top_iff_forall` and
-  `MeromorphicOn.order_ne_top_of_isPreconnected` for two convenient criteria to
-  guarantee conditions `h₂f₁` and `h₂f₂`.
+See `MeromorphicOn.exists_order_ne_top_iff_forall` and
+`MeromorphicOn.order_ne_top_of_isPreconnected` for two convenient criteria to
+guarantee conditions `h₂f₁` and `h₂f₂`.
 -/
 theorem divisor_mul [CompleteSpace 𝕜] {f₁ f₂ : 𝕜 → 𝕜} (h₁f₁ : MeromorphicOn f₁ U)
     (h₁f₂ : MeromorphicOn f₂ U) (h₂f₁ : ∀ z, (hz : z ∈ U) → (h₁f₁ z hz).order ≠ ⊤)


### PR DESCRIPTION
…; remove open Classical

Apply a few style tweaks which have in-progress linters against them:
- remove bare open Classical; scope this to the two definitions which use it
- remove indentation in doc-strings
- alphabetise imports, while we're there


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
