### PR TITLE
[Merged by Bors] - feat(Finset): extra `toLeft`/`toRight` API

### DIFF
--- a/Mathlib/Data/Finset/Sum.lean
+++ b/Mathlib/Data/Finset/Sum.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies, Bhavik Mehta
 -/
 import Mathlib.Data.Finset.Card
-import Mathlib.Data.Finset.Fold
 import Mathlib.Data.Multiset.Sum
 
 /-!
@@ -110,8 +109,8 @@ forms a quasi-inverse to `disjSum`, in that it recovers its left input.
 
 See also `List.partitionMap`.
 -/
-def toLeft (s : Finset (α ⊕ β)) : Finset α :=
-  s.filterMap (Sum.elim some fun _ => none) (by clear x; aesop)
+def toLeft (u : Finset (α ⊕ β)) : Finset α :=
+  u.filterMap (Sum.elim some fun _ => none) (by clear x; aesop)
 
 /--
 Given a finset of elements `α ⊕ β`, extract all the elements of the form `β`. This
@@ -119,16 +118,13 @@ forms a quasi-inverse to `disjSum`, in that it recovers its right input.
 
 See also `List.partitionMap`.
 -/
-def toRight (s : Finset (α ⊕ β)) : Finset β :=
-  s.filterMap (Sum.elim (fun _ => none) some) (by clear x; aesop)
+def toRight (u : Finset (α ⊕ β)) : Finset β :=
+  u.filterMap (Sum.elim (fun _ => none) some) (by clear x; aesop)
 
-variable {u v : Finset (α ⊕ β)}
+variable {u v : Finset (α ⊕ β)} {a : α} {b : β}
 
-@[simp] lemma mem_toLeft {x : α} : x ∈ u.toLeft ↔ inl x ∈ u := by
-  simp [toLeft]
-
-@[simp] lemma mem_toRight {x : β} : x ∈ u.toRight ↔ inr x ∈ u := by
-  simp [toRight]
+@[simp] lemma mem_toLeft : a ∈ u.toLeft ↔ .inl a ∈ u := by simp [toLeft]
+@[simp] lemma mem_toRight : b ∈ u.toRight ↔ .inr b ∈ u := by simp [toRight]
 
 @[gcongr]
 lemma toLeft_subset_toLeft : u ⊆ v → u.toLeft ⊆ v.toLeft :=
@@ -144,13 +140,13 @@ lemma toRight_monotone : Monotone (@toRight α β) := fun _ _ => toRight_subset_
 lemma toLeft_disjSum_toRight : u.toLeft.disjSum u.toRight = u := by
   ext (x | x) <;> simp
 
-lemma card_toLeft_add_card_toRight : u.toLeft.card + u.toRight.card = u.card := by
+lemma card_toLeft_add_card_toRight : #u.toLeft + #u.toRight = #u := by
   rw [← card_disjSum, toLeft_disjSum_toRight]
 
-lemma card_toLeft_le : u.toLeft.card ≤ u.card :=
+lemma card_toLeft_le : #u.toLeft ≤ #u :=
   (Nat.le_add_right _ _).trans_eq card_toLeft_add_card_toRight
 
-lemma card_toRight_le : u.toRight.card ≤ u.card :=
+lemma card_toRight_le : #u.toRight ≤ #u :=
   (Nat.le_add_left _ _).trans_eq card_toLeft_add_card_toRight
 
 @[simp] lemma toLeft_disjSum : (s.disjSum t).toLeft = s := by ext x; simp

--- a/Mathlib/Data/Finset/Sum.lean
+++ b/Mathlib/Data/Finset/Sum.lean
@@ -163,18 +163,23 @@ lemma eq_disjSum_iff : u = s.disjSum t ↔ u.toLeft = s ∧ u.toRight = t :=
 lemma disjSum_subset : s.disjSum t ⊆ u ↔ s ⊆ u.toLeft ∧ t ⊆ u.toRight := by simp [subset_iff]
 lemma subset_disjSum : u ⊆ s.disjSum t ↔ u.toLeft ⊆ s ∧ u.toRight ⊆ t := by simp [subset_iff]
 
-@[simp] lemma map_disjSum_inl_subset : s.map .inl ⊆ u ↔ s ⊆ u.toLeft := by
-  simp [← disjSum_empty, disjSum_subset]
-
-@[simp] lemma map_disjSum_inr_subset : t.map .inr ⊆ u ↔ t ⊆ u.toRight := by
-  simp [← empty_disjSum, disjSum_subset]
-
-lemma subset_map_disjSum_inl : u ⊆ s.map .inl ↔ u.toLeft ⊆ s ∧ u.toRight = ∅ := by
+lemma subset_map_inl : u ⊆ s.map .inl ↔ u.toLeft ⊆ s ∧ u.toRight = ∅ := by
   simp [← disjSum_empty, subset_disjSum]
 
-lemma subset_map_disjSum_inr : u ⊆ t.map .inr ↔ u.toLeft = ∅ ∧ u.toRight ⊆ t := by
+lemma subset_map_inr : u ⊆ t.map .inr ↔ u.toLeft = ∅ ∧ u.toRight ⊆ t := by
   simp [← empty_disjSum, subset_disjSum]
 
+lemma map_inl_subset_iff_subset_toLeft : s.map .inl ⊆ u ↔ s ⊆ u.toLeft := by
+  simp [← disjSum_empty, disjSum_subset]
+
+lemma map_inr_subset_iff_subset_toRight : t.map .inr ⊆ u ↔ t ⊆ u.toRight := by
+  simp [← empty_disjSum, disjSum_subset]
+
+lemma gc_map_inl_toLeft : GaloisConnection (·.map (.inl : α ↪ α ⊕ β)) toLeft :=
+  fun _ _ ↦ map_inl_subset_iff_subset_toLeft
+
+lemma gc_map_inr_toRight : GaloisConnection (·.map (.inr : β ↪ α ⊕ β)) toRight :=
+  fun _ _ ↦ map_inr_subset_iff_subset_toRight
 
 @[simp] lemma toLeft_map_sumComm : (u.map (Equiv.sumComm _ _).toEmbedding).toLeft = u.toRight := by
   ext x; simp

--- a/Mathlib/Data/Finset/Sum.lean
+++ b/Mathlib/Data/Finset/Sum.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies, Bhavik Mehta
 -/
 import Mathlib.Data.Finset.Card
+import Mathlib.Data.Finset.Fold
 import Mathlib.Data.Multiset.Sum
 
 /-!
@@ -34,11 +35,9 @@ def disjSum : Finset (α ⊕ β) :=
 theorem val_disjSum : (s.disjSum t).1 = s.1.disjSum t.1 :=
   rfl
 
-@[simp]
 theorem empty_disjSum : (∅ : Finset α).disjSum t = t.map Embedding.inr :=
   val_inj.1 <| Multiset.zero_disjSum _
 
-@[simp]
 theorem disjSum_empty : s.disjSum (∅ : Finset β) = s.map Embedding.inl :=
   val_inj.1 <| Multiset.disjSum_zero _
 

--- a/Mathlib/Data/Finset/Sum.lean
+++ b/Mathlib/Data/Finset/Sum.lean
@@ -158,6 +158,9 @@ lemma disjSum_eq_iff : s.disjSum t = u ↔ s = u.toLeft ∧ t = u.toRight :=
 lemma eq_disjSum_iff : u = s.disjSum t ↔ u.toLeft = s ∧ u.toRight = t :=
   ⟨fun h => by simp [h], fun h => by simp [← h, toLeft_disjSum_toRight]⟩
 
+lemma disjSum_subset : s.disjSum t ⊆ u ↔ s ⊆ u.toLeft ∧ t ⊆ u.toRight := by simp [subset_iff]
+lemma subset_disjSum : u ⊆ s.disjSum t ↔ u.toLeft ⊆ s ∧ u.toRight ⊆ t := by simp [subset_iff]
+
 @[simp] lemma toLeft_map_sumComm : (u.map (Equiv.sumComm _ _).toEmbedding).toLeft = u.toRight := by
   ext x; simp
 

--- a/Mathlib/Data/Finset/Sum.lean
+++ b/Mathlib/Data/Finset/Sum.lean
@@ -35,9 +35,11 @@ def disjSum : Finset (α ⊕ β) :=
 theorem val_disjSum : (s.disjSum t).1 = s.1.disjSum t.1 :=
   rfl
 
+@[simp]
 theorem empty_disjSum : (∅ : Finset α).disjSum t = t.map Embedding.inr :=
   val_inj.1 <| Multiset.zero_disjSum _
 
+@[simp]
 theorem disjSum_empty : s.disjSum (∅ : Finset β) = s.map Embedding.inl :=
   val_inj.1 <| Multiset.disjSum_zero _
 
@@ -160,6 +162,19 @@ lemma eq_disjSum_iff : u = s.disjSum t ↔ u.toLeft = s ∧ u.toRight = t :=
 
 lemma disjSum_subset : s.disjSum t ⊆ u ↔ s ⊆ u.toLeft ∧ t ⊆ u.toRight := by simp [subset_iff]
 lemma subset_disjSum : u ⊆ s.disjSum t ↔ u.toLeft ⊆ s ∧ u.toRight ⊆ t := by simp [subset_iff]
+
+@[simp] lemma map_disjSum_inl_subset : s.map .inl ⊆ u ↔ s ⊆ u.toLeft := by
+  simp [← disjSum_empty, disjSum_subset]
+
+@[simp] lemma map_disjSum_inr_subset : t.map .inr ⊆ u ↔ t ⊆ u.toRight := by
+  simp [← empty_disjSum, disjSum_subset]
+
+lemma subset_map_disjSum_inl : u ⊆ s.map .inl ↔ u.toLeft ⊆ s ∧ u.toRight = ∅ := by
+  simp [← disjSum_empty, subset_disjSum]
+
+lemma subset_map_disjSum_inr : u ⊆ t.map .inr ↔ u.toLeft = ∅ ∧ u.toRight ⊆ t := by
+  simp [← empty_disjSum, subset_disjSum]
+
 
 @[simp] lemma toLeft_map_sumComm : (u.map (Equiv.sumComm _ _).toEmbedding).toLeft = u.toRight := by
   ext x; simp

--- a/Mathlib/Data/Fintype/Sum.lean
+++ b/Mathlib/Data/Fintype/Sum.lean
@@ -30,16 +30,20 @@ variable {α β : Type*} {u : Finset (α ⊕ β)} {s : Finset α} {t : Finset β
 section left
 variable [Fintype α] {u : Finset (α ⊕ β)}
 
-lemma toLeft_eq_univ : u.toLeft = univ ↔ univ.disjSum ∅ ⊆ u := by simp
-lemma toRight_eq_empty : u.toRight = ∅ ↔ u ⊆ univ.disjSum ∅ := by simp [subset_map_disjSum_inl]
+lemma toLeft_eq_univ : u.toLeft = univ ↔ univ.map .inl ⊆ u := by
+  simp [map_inl_subset_iff_subset_toLeft]
+
+lemma toRight_eq_empty : u.toRight = ∅ ↔ u ⊆ univ.map .inl := by simp [subset_map_inl]
 
 end left
 
 section right
 variable [Fintype β] {u : Finset (α ⊕ β)}
 
-lemma toRight_eq_univ : u.toRight = univ ↔ disjSum ∅ univ ⊆ u := by simp
-lemma toLeft_eq_empty : u.toLeft = ∅ ↔ u ⊆ disjSum ∅ univ := by simp [subset_map_disjSum_inr]
+lemma toRight_eq_univ : u.toRight = univ ↔ univ.map .inr ⊆ u := by
+  simp [map_inr_subset_iff_subset_toRight]
+
+lemma toLeft_eq_empty : u.toLeft = ∅ ↔ u ⊆ univ.map .inr := by simp [subset_map_inr]
 
 end right
 

--- a/Mathlib/Data/Fintype/Sum.lean
+++ b/Mathlib/Data/Fintype/Sum.lean
@@ -27,9 +27,6 @@ instance (α : Type u) (β : Type v) [Fintype α] [Fintype β] : Fintype (α ⊕
 namespace Finset
 variable {α β : Type*} {u : Finset (α ⊕ β)} {s : Finset α} {t : Finset β}
 
-lemma disjSum_subset : s.disjSum t ⊆ u ↔ s ⊆ u.toLeft ∧ t ⊆ u.toRight := by simp [subset_iff]
-lemma subset_disjSum : u ⊆ s.disjSum t ↔ u.toLeft ⊆ s ∧ u.toRight ⊆ t := by simp [subset_iff]
-
 section left
 variable [Fintype α] {u : Finset (α ⊕ β)}
 

--- a/Mathlib/Data/Fintype/Sum.lean
+++ b/Mathlib/Data/Fintype/Sum.lean
@@ -30,16 +30,16 @@ variable {α β : Type*} {u : Finset (α ⊕ β)} {s : Finset α} {t : Finset β
 section left
 variable [Fintype α] {u : Finset (α ⊕ β)}
 
-lemma toLeft_eq_univ : u.toLeft = univ ↔ univ.disjSum ∅ ⊆ u := by simp [disjSum_subset]
-lemma toRight_eq_empty : u.toRight = ∅ ↔ u ⊆ univ.disjSum ∅ := by simp [subset_disjSum]
+lemma toLeft_eq_univ : u.toLeft = univ ↔ univ.disjSum ∅ ⊆ u := by simp
+lemma toRight_eq_empty : u.toRight = ∅ ↔ u ⊆ univ.disjSum ∅ := by simp [subset_map_disjSum_inl]
 
 end left
 
 section right
 variable [Fintype β] {u : Finset (α ⊕ β)}
 
-lemma toRight_eq_univ : u.toRight = univ ↔ disjSum ∅ univ ⊆ u := by simp [disjSum_subset]
-lemma toLeft_eq_empty : u.toLeft = ∅ ↔ u ⊆ disjSum ∅ univ := by simp [subset_disjSum]
+lemma toRight_eq_univ : u.toRight = univ ↔ disjSum ∅ univ ⊆ u := by simp
+lemma toLeft_eq_empty : u.toLeft = ∅ ↔ u ⊆ disjSum ∅ univ := by simp [subset_map_disjSum_inr]
 
 end right
 

--- a/Mathlib/Data/Fintype/Sum.lean
+++ b/Mathlib/Data/Fintype/Sum.lean
@@ -24,10 +24,38 @@ instance (α : Type u) (β : Type v) [Fintype α] [Fintype β] : Fintype (α ⊕
   elems := univ.disjSum univ
   complete := by rintro (_ | _) <;> simp
 
-@[simp]
-theorem Finset.univ_disjSum_univ {α β : Type*} [Fintype α] [Fintype β] :
-    univ.disjSum univ = (univ : Finset (α ⊕ β)) :=
-  rfl
+namespace Finset
+variable {α β : Type*}
+
+section left
+variable [Fintype α] {u : Finset (α ⊕ β)}
+
+@[simp] lemma toLeft_eq_univ : u.toLeft = univ ↔ univ.disjSum ∅ ⊆ u := by
+  simp [eq_univ_iff_forall, subset_iff]
+
+@[simp] lemma toRight_eq_empty : u.toRight = ∅ ↔ u ⊆ univ.disjSum ∅ := by
+  simp [eq_empty_iff_forall_not_mem, subset_iff]
+
+end left
+
+section right
+variable [Fintype β] {u : Finset (α ⊕ β)}
+
+@[simp] lemma toRight_eq_univ : u.toRight = univ ↔ disjSum ∅ univ ⊆ u := by
+  simp [eq_univ_iff_forall, subset_iff]
+
+@[simp] lemma toLeft_eq_empty : u.toLeft = ∅ ↔ u ⊆ disjSum ∅ univ := by
+  simp [eq_empty_iff_forall_not_mem, subset_iff]
+
+end right
+
+variable [Fintype α] [Fintype β]
+
+@[simp] lemma univ_disjSum_univ : univ.disjSum univ = (univ : Finset (α ⊕ β)) := rfl
+@[simp] lemma toLeft_univ : (univ : Finset (α ⊕ β)).toLeft = univ := by ext; simp
+@[simp] lemma toRight_univ : (univ : Finset (α ⊕ β)).toRight = univ := by ext; simp
+
+end Finset
 
 @[simp]
 theorem Fintype.card_sum [Fintype α] [Fintype β] :

--- a/Mathlib/Data/Fintype/Sum.lean
+++ b/Mathlib/Data/Fintype/Sum.lean
@@ -25,27 +25,24 @@ instance (α : Type u) (β : Type v) [Fintype α] [Fintype β] : Fintype (α ⊕
   complete := by rintro (_ | _) <;> simp
 
 namespace Finset
-variable {α β : Type*}
+variable {α β : Type*} {u : Finset (α ⊕ β)} {s : Finset α} {t : Finset β}
+
+lemma disjSum_subset : s.disjSum t ⊆ u ↔ s ⊆ u.toLeft ∧ t ⊆ u.toRight := by simp [subset_iff]
+lemma subset_disjSum : u ⊆ s.disjSum t ↔ u.toLeft ⊆ s ∧ u.toRight ⊆ t := by simp [subset_iff]
 
 section left
 variable [Fintype α] {u : Finset (α ⊕ β)}
 
-@[simp] lemma toLeft_eq_univ : u.toLeft = univ ↔ univ.disjSum ∅ ⊆ u := by
-  simp [eq_univ_iff_forall, subset_iff]
-
-@[simp] lemma toRight_eq_empty : u.toRight = ∅ ↔ u ⊆ univ.disjSum ∅ := by
-  simp [eq_empty_iff_forall_not_mem, subset_iff]
+lemma toLeft_eq_univ : u.toLeft = univ ↔ univ.disjSum ∅ ⊆ u := by simp [disjSum_subset]
+lemma toRight_eq_empty : u.toRight = ∅ ↔ u ⊆ univ.disjSum ∅ := by simp [subset_disjSum]
 
 end left
 
 section right
 variable [Fintype β] {u : Finset (α ⊕ β)}
 
-@[simp] lemma toRight_eq_univ : u.toRight = univ ↔ disjSum ∅ univ ⊆ u := by
-  simp [eq_univ_iff_forall, subset_iff]
-
-@[simp] lemma toLeft_eq_empty : u.toLeft = ∅ ↔ u ⊆ disjSum ∅ univ := by
-  simp [eq_empty_iff_forall_not_mem, subset_iff]
+lemma toRight_eq_univ : u.toRight = univ ↔ disjSum ∅ univ ⊆ u := by simp [disjSum_subset]
+lemma toLeft_eq_empty : u.toLeft = ∅ ↔ u ⊆ disjSum ∅ univ := by simp [subset_disjSum]
 
 end right
 

--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -373,7 +373,8 @@
   "Mathlib.Logic.Nontrivial.Defs": ["Mathlib.Init.Logic"],
   "Mathlib.Logic.Function.Defs": ["Mathlib.Tactic.AdaptationNote"],
   "Mathlib.Logic.Function.Basic": ["Batteries.Tactic.Init"],
-  "Mathlib.Logic.Equiv.Defs": ["Mathlib.Data.Bool.Basic"],
+  "Mathlib.Logic.Equiv.Defs":
+  ["Mathlib.Data.Bool.Basic", "Mathlib.Data.Subtype"],
   "Mathlib.Logic.Basic": ["Batteries.Tactic.Trans"],
   "Mathlib.LinearAlgebra.Matrix.Transvection": ["Mathlib.Data.Matrix.DMatrix"],
   "Mathlib.LinearAlgebra.DFinsupp": ["Mathlib.LinearAlgebra.Finsupp.SumProd"],

--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -373,8 +373,7 @@
   "Mathlib.Logic.Nontrivial.Defs": ["Mathlib.Init.Logic"],
   "Mathlib.Logic.Function.Defs": ["Mathlib.Tactic.AdaptationNote"],
   "Mathlib.Logic.Function.Basic": ["Batteries.Tactic.Init"],
-  "Mathlib.Logic.Equiv.Defs":
-  ["Mathlib.Data.Bool.Basic", "Mathlib.Data.Subtype"],
+  "Mathlib.Logic.Equiv.Defs": ["Mathlib.Data.Bool.Basic"],
   "Mathlib.Logic.Basic": ["Batteries.Tactic.Trans"],
   "Mathlib.LinearAlgebra.Matrix.Transvection": ["Mathlib.Data.Matrix.DMatrix"],
   "Mathlib.LinearAlgebra.DFinsupp": ["Mathlib.LinearAlgebra.Finsupp.SumProd"],


### PR DESCRIPTION
Add the API that I independently came up with in https://github.com/leanprover-community/mathlib4/pull/20433#issuecomment-2607541838.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
