### PR TITLE
[Merged by Bors] - chore(CategoryTheory/ChosenFiniteProducts/FunctorCategory): remove `noncomputable`

### DIFF
--- a/Mathlib/CategoryTheory/ChosenFiniteProducts/FunctorCategory.lean
+++ b/Mathlib/CategoryTheory/ChosenFiniteProducts/FunctorCategory.lean
@@ -53,7 +53,7 @@ def snd : chosenProd F₁ F₂ ⟶ F₂ where
   app _ := ChosenFiniteProducts.snd _ _
 
 /-- `Functor.chosenProd F₁ F₂` is a binary product of `F₁` and `F₂`. -/
-noncomputable def isLimit : IsLimit (BinaryFan.mk (fst F₁ F₂) (snd F₁ F₂)) :=
+def isLimit : IsLimit (BinaryFan.mk (fst F₁ F₂) (snd F₁ F₂)) :=
   evaluationJointlyReflectsLimits _ (fun j =>
     (IsLimit.postcomposeHomEquiv (mapPairIso (by exact Iso.refl _) (by exact Iso.refl _)) _).1
       (IsLimit.ofIsoLimit (ChosenFiniteProducts.product (X := F₁.obj j) (Y := F₂.obj j)).2
@@ -63,7 +63,7 @@ end chosenProd
 
 end
 
-noncomputable instance chosenFiniteProducts :
+instance chosenFiniteProducts :
     ChosenFiniteProducts (J ⥤ C) where
   terminal := ⟨_, chosenTerminalIsTerminal J C⟩
   product F₁ F₂ := ⟨_, chosenProd.isLimit F₁ F₂⟩
@@ -151,7 +151,7 @@ lemma associator_inv_app (F₁ F₂ F₃ : J ⥤ C) (j : J) :
     (α_ F₁ F₂ F₃).inv.app j = (α_ _ _ _).inv := by
   rw [← cancel_mono ((α_ _ _ _).hom), Iso.inv_hom_id, ← associator_hom_app, Iso.inv_hom_id_app]
 
-noncomputable instance {K : Type*} [Category K] [HasColimitsOfShape K C]
+instance {K : Type*} [Category K] [HasColimitsOfShape K C]
     [∀ X : C, PreservesColimitsOfShape K (tensorLeft X)] {F : J ⥤ C} :
     PreservesColimitsOfShape K (tensorLeft F) := by
   apply preservesColimitsOfShape_of_evaluation


### PR DESCRIPTION

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

Looks like all of the noncomputable defs in this file are in fact computable.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
