### PR TITLE
[Merged by Bors] - chore: align Congruence.lean with Similarity.lean

### DIFF
--- a/Mathlib/Topology/MetricSpace/Congruence.lean
+++ b/Mathlib/Topology/MetricSpace/Congruence.lean
@@ -28,7 +28,7 @@ For more details see the [Zulip discussion](https://leanprover.zulipchat.com/#na
 
 variable {ι ι' : Type*} {P₁ P₂ P₃ : Type*} {v₁ : ι → P₁} {v₂ : ι → P₂} {v₃ : ι → P₃}
 
-noncomputable section
+section PseudoEMetricSpace
 
 variable [PseudoEMetricSpace P₁] [PseudoEMetricSpace P₂] [PseudoEMetricSpace P₃]
 
@@ -40,12 +40,12 @@ def Congruent (v₁ : ι → P₁) (v₂ : ι → P₂) : Prop :=
 @[inherit_doc]
 scoped[Congruent] infixl:25 " ≅ " => Congruent
 
-/-- A congruence holds if and only if all extended distances are the same. -/
+/-- Congruence holds if and only if all extended distances are the same. -/
 lemma congruent_iff_edist_eq :
     Congruent v₁ v₂ ↔ ∀ i₁ i₂, edist (v₁ i₁) (v₁ i₂) = edist (v₂ i₁) (v₂ i₂) :=
   Iff.rfl
 
-/-- A congruence holds if and only if all extended distances between points with different
+/-- Congruence holds if and only if all extended distances between points with different
 indices are the same. -/
 lemma congruent_iff_pairwise_edist_eq :
     Congruent v₁ v₂ ↔ Pairwise fun i₁ i₂ ↦ edist (v₁ i₁) (v₁ i₂) = edist (v₂ i₁) (v₂ i₂) := by
@@ -59,7 +59,7 @@ namespace Congruent
 /-- A congruence preserves extended distance. Forward direction of `congruent_iff_edist_eq`. -/
 alias ⟨edist_eq, _⟩ := congruent_iff_edist_eq
 
-/-- A congruence follows from preserved extended distance. Backward direction of
+/-- Congruence follows from preserved extended distance. Backward direction of
 `congruent_iff_edist_eq`. -/
 alias ⟨_, of_edist_eq⟩ := congruent_iff_edist_eq
 
@@ -67,7 +67,7 @@ alias ⟨_, of_edist_eq⟩ := congruent_iff_edist_eq
 `congruent_iff_pairwise_edist_eq`. -/
 alias ⟨pairwise_edist_eq, _⟩ := congruent_iff_pairwise_edist_eq
 
-/-- A congruence follows from pairwise preserved extended distance. Backward direction of
+/-- Congruence follows from pairwise preserved extended distance. Backward direction of
 `congruent_iff_pairwise_edist_eq`. -/
 alias ⟨_, of_pairwise_edist_eq⟩ := congruent_iff_pairwise_edist_eq
 
@@ -75,7 +75,7 @@ alias ⟨_, of_pairwise_edist_eq⟩ := congruent_iff_pairwise_edist_eq
 
 @[symm] protected lemma symm (h : v₁ ≅ v₂) : v₂ ≅ v₁ := fun i₁ i₂ ↦ (h i₁ i₂).symm
 
-lemma _root_.congruence_comm : v₁ ≅ v₂ ↔ v₂ ≅ v₁ :=
+lemma _root_.congruent_comm : v₁ ≅ v₂ ↔ v₂ ≅ v₁ :=
   ⟨Congruent.symm, Congruent.symm⟩
 
 @[trans] protected lemma trans (h₁₂ : v₁ ≅ v₂) (h₂₃ : v₂ ≅ v₃) : v₁ ≅ v₃ :=
@@ -94,31 +94,31 @@ lemma index_map (h : v₁ ≅ v₂) (f : ι' → ι) : (v₁ ∘ f) ≅ (v₂ �
 
 end Congruent
 
-end
+end PseudoEMetricSpace
 
 section PseudoMetricSpace
 
 variable [PseudoMetricSpace P₁] [PseudoMetricSpace P₂]
 
-/-- A congruence holds if and only if all non-negative distances are the same. -/
+/-- Congruence holds if and only if all non-negative distances are the same. -/
 lemma congruent_iff_nndist_eq :
     Congruent v₁ v₂ ↔ ∀ i₁ i₂, nndist (v₁ i₁) (v₁ i₂) = nndist (v₂ i₁) (v₂ i₂) :=
   forall₂_congr (fun _ _ ↦ by rw [edist_nndist, edist_nndist]; norm_cast)
 
-/-- A congruence holds if and only if all non-negative distances between points with different
+/-- Congruence holds if and only if all non-negative distances between points with different
 indices are the same. -/
 lemma congruent_iff_pairwise_nndist_eq :
     Congruent v₁ v₂ ↔ Pairwise fun i₁ i₂ ↦ nndist (v₁ i₁) (v₁ i₂) = nndist (v₂ i₁) (v₂ i₂) := by
   simp_rw [congruent_iff_pairwise_edist_eq, edist_nndist]
   exact_mod_cast Iff.rfl
 
-/-- A congruence holds if and only if all distances are the same. -/
+/-- Congruence holds if and only if all distances are the same. -/
 lemma congruent_iff_dist_eq :
     Congruent v₁ v₂ ↔ ∀ i₁ i₂, dist (v₁ i₁) (v₁ i₂) = dist (v₂ i₁) (v₂ i₂) :=
   congruent_iff_nndist_eq.trans
     (forall₂_congr (fun _ _ ↦ by rw [dist_nndist, dist_nndist]; norm_cast))
 
-/-- A congruence holds if and only if all non-negative distances between points with different
+/-- Congruence holds if and only if all non-negative distances between points with different
 indices are the same. -/
 lemma congruent_iff_pairwise_dist_eq :
     Congruent v₁ v₂ ↔ Pairwise fun i₁ i₂ ↦ dist (v₁ i₁) (v₁ i₂) = dist (v₂ i₁) (v₂ i₂) := by
@@ -130,21 +130,21 @@ namespace Congruent
 /-- A congruence preserves non-negative distance. Forward direction of `congruent_iff_nndist_eq`. -/
 alias ⟨nndist_eq, _⟩ := congruent_iff_nndist_eq
 
-/-- A congruence follows from preserved non-negative distance. Backward direction of
+/-- Congruence follows from preserved non-negative distance. Backward direction of
 `congruent_iff_nndist_eq`. -/
 alias ⟨_, of_nndist_eq⟩ := congruent_iff_nndist_eq
 
 /-- A congruence preserves distance. Forward direction of `congruent_iff_dist_eq`. -/
 alias ⟨dist_eq, _⟩ := congruent_iff_dist_eq
 
-/-- A congruence follows from preserved distance. Backward direction of `congruent_iff_dist_eq`. -/
+/-- Congruence follows from preserved distance. Backward direction of `congruent_iff_dist_eq`. -/
 alias ⟨_, of_dist_eq⟩ := congruent_iff_dist_eq
 
 /-- A congruence pairwise preserves non-negative distance. Forward direction of
 `congruent_iff_pairwise_nndist_eq`. -/
 alias ⟨pairwise_nndist_eq, _⟩ := congruent_iff_pairwise_nndist_eq
 
-/-- A congruence follows from pairwise preserved non-negative distance. Backward direction of
+/-- Congruence follows from pairwise preserved non-negative distance. Backward direction of
 `congruent_iff_pairwise_nndist_eq`. -/
 alias ⟨_, of_pairwise_nndist_eq⟩ := congruent_iff_pairwise_nndist_eq
 
@@ -152,7 +152,7 @@ alias ⟨_, of_pairwise_nndist_eq⟩ := congruent_iff_pairwise_nndist_eq
 `congruent_iff_pairwise_dist_eq`. -/
 alias ⟨pairwise_dist_eq, _⟩ := congruent_iff_pairwise_dist_eq
 
-/-- A congruence follows from pairwise preserved distance. Backward direction of
+/-- Congruence follows from pairwise preserved distance. Backward direction of
 `congruent_iff_pairwise_dist_eq`. -/
 alias ⟨_, of_pairwise_dist_eq⟩ := congruent_iff_pairwise_dist_eq
 


### PR DESCRIPTION
This PR applies the changes that were made in #7479, so that the files for `Congruent` and `Similar` align.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
