### PR TITLE
[Merged by Bors] - feat: adjoints of nonzero root space elements are nilpotent endomorphisms in Lie algebras

### DIFF
--- a/Mathlib/Algebra/Lie/Weights/Chain.lean
+++ b/Mathlib/Algebra/Lie/Weights/Chain.lean
@@ -396,20 +396,13 @@ lemma LieModule.isNilpotent_toEnd_of_mem_rootSpace
     rw [map_add, LinearMap.pow_map_zero_of_le le_sup_left hn₁,
       LinearMap.pow_map_zero_of_le le_sup_right hn₂, add_zero]
 
-end
-
-end LieModule
-
-namespace LieAlgebra
-
-open LieModule
-
 variable {K L : Type*} [Field K] [CharZero K] [LieRing L] [LieAlgebra K L]
   (H : LieSubalgebra K L) [LieRing.IsNilpotent H]
 
-lemma root_space_ad_is_nilpotent' [IsTriangularizable K H L] [FiniteDimensional K L]
+lemma LieAlgebra.isNilpotent_ad_of_mem_rootSpace
+    [IsTriangularizable K H L] [FiniteDimensional K L]
     {x : L} {χ : H → K} (hχ : χ ≠ 0) (hx : x ∈ rootSpace H χ) :
     _root_.IsNilpotent (ad K L x) :=
-  LieModule.root_space_ad_is_nilpotent (M := L) H hχ hx
+  isNilpotent_toEnd_of_mem_rootSpace (M := L) H hχ hx
 
-end LieAlgebra
+end Field

--- a/Mathlib/Algebra/Lie/Weights/Chain.lean
+++ b/Mathlib/Algebra/Lie/Weights/Chain.lean
@@ -369,7 +369,7 @@ end LieModule
 
 section Field
 
-open LieAlgebra LieModule Submodule
+open LieAlgebra LieModule
 
 variable {K : Type*} [Field K] [CharZero K] [LieAlgebra K L]
   (H : LieSubalgebra K L) [LieRing.IsNilpotent H]

--- a/Mathlib/Algebra/Lie/Weights/Chain.lean
+++ b/Mathlib/Algebra/Lie/Weights/Chain.lean
@@ -389,9 +389,8 @@ lemma root_space_ad_is_nilpotent
   | hN χ₂ m₂ hm₂ =>
     obtain ⟨n, -, hn⟩ := exists_genWeightSpace_smul_add_eq_bot (M := M) χ χ₂ hχ
     use n
-    have h := toEnd_pow_apply_mem hx hm₂ n
-    rw [hn, LieSubmodule.mem_bot] at h
-    exact h
+    have := toEnd_pow_apply_mem hx hm₂ n
+    rwa [hn, LieSubmodule.mem_bot] at this
   | hadd m₁ m₂ hm₁ hm₂ hm₁' hm₂' =>
     obtain ⟨n₁, hn₁⟩ := hm₁'
     obtain ⟨n₂, hn₂⟩ := hm₂'

--- a/Mathlib/Algebra/Lie/Weights/Chain.lean
+++ b/Mathlib/Algebra/Lie/Weights/Chain.lean
@@ -379,7 +379,7 @@ lemma root_space_ad_is_nilpotent
     _root_.IsNilpotent (toEnd K L M x) := by
   let s : Set (Weight K H M) := univ
   have nilpotency_limit : ∀ χ₂ ∈ s, ∃ n : ℕ, ∀ v : genWeightSpace M χ₂, ∀ m ≥ n,
-      ((toEnd K L M x) ^ m) v = 0 := by
+      (toEnd K L M x ^ m) v = 0 := by
     intro χ₂ he
     obtain ⟨k, ⟨hk₁, hk₂⟩⟩ := exists_genWeightSpace_smul_add_eq_bot (M := M) χ χ₂ hχ
     use k
@@ -388,7 +388,7 @@ lemma root_space_ad_is_nilpotent
     rw [hk₂, LieSubmodule.mem_bot] at h
     exact LinearMap.pow_map_zero_of_le hm h
   have uniform_nilpotency_limit : ∃ n₀ : ℕ, ∀ χ₂ ∈ s, ∀ v : genWeightSpace M χ₂,
-      ((toEnd K L M x) ^ n₀) v = 0 := by
+      (toEnd K L M x ^ n₀) v = 0 := by
     choose fn₁ hn using nilpotency_limit
     simp only [Subtype.forall] at hn ⊢
     let n₀ := s.toFinset.sup fun χ₂ => fn₁ χ₂ (mem_univ χ₂)

--- a/Mathlib/Algebra/Lie/Weights/Chain.lean
+++ b/Mathlib/Algebra/Lie/Weights/Chain.lean
@@ -367,6 +367,7 @@ end
 section
 
 open LieAlgebra
+open Submodule
 
 variable {K L M : Type*} [Field K] [CharZero K] [LieRing L] [LieAlgebra K L]
   (H : LieSubalgebra K L) [LieRing.IsNilpotent H]
@@ -400,41 +401,26 @@ lemma root_space_ad_is_nilpotent
     exact hn hv n₀ this
   obtain ⟨n₀, hn₀⟩ := uniform_nilpotency_limit
   let A := (toEnd K L M x) ^ n₀
-  have s₁ : ∀ χ₂ ∈ s, genWeightSpace M χ₂ ≤
-      Submodule.span K (⋃ χᵢ ∈ s, (genWeightSpace M χᵢ).carrier) := by
-    intro χ₂ a m hm
-    have h₁ : Submodule.span K (genWeightSpace M χ₂).carrier ≤
-        Submodule.span K (⋃ χᵢ ∈ s, (genWeightSpace M χᵢ).carrier) := by
-      apply Submodule.span_mono
-      exact fun _ hx => Set.mem_biUnion a hx
-    have h₂ : genWeightSpace M χ₂ ≤ Submodule.span K (genWeightSpace M χ₂).carrier := by
-      intro m hm p hp
-      obtain ⟨pr, ⟨_, _⟩⟩ := hp
-      simp only [mem_setOf_eq, mem_iInter, SetLike.mem_coe]
-      exact fun p => p hm
-    exact h₁ (h₂ hm)
-  have s₂ : ⨆ χᵢ ∈ s, genWeightSpace M χᵢ ≤
-      Submodule.span K (⋃ χᵢ ∈ s, (genWeightSpace M χᵢ).carrier) := by
+  have s₁ : ⨆ χᵢ ∈ s, genWeightSpace M χᵢ ≤ span K (⋃ χᵢ ∈ s, (genWeightSpace M χᵢ).carrier) := by
     apply sSup_le
     intro n hn
-    simp only [mem_univ, iSup_pos, mem_range, exists_exists_eq_and, s] at s₁ hn ⊢
+    simp only [mem_univ, iSup_pos, mem_range, exists_exists_eq_and, s] at hn ⊢
     obtain ⟨χ₂, hχ₂⟩ := hn
     subst hχ₂
-    exact s₁ χ₂ trivial
-  have s₃ : Submodule.span K (⋃ χᵢ ∈ s, (genWeightSpace M χᵢ).carrier) = ⊤ := by
-    simp only [mem_univ, iSup_pos, iUnion_true, s] at s₂ ⊢
-    rw [iSup_genWeightSpace_eq_top' K H M] at s₂
-    apply top_le_iff.1 s₂
-  have s₄ (χ₂ : Weight K H M) (m : M) (m : genWeightSpace M χ₂) : A m = 0 :=
-    (hn₀ χ₂) (mem_univ χ₂) m
-  have s₅ : A = 0 := by
+    intro m hm
+    exact (span_mono (fun _ hx => Set.mem_biUnion (mem_univ χ₂) hx)) (subset_span hm)
+  have s₂ : span K (⋃ χᵢ ∈ s, (genWeightSpace M χᵢ).carrier) = ⊤ := by
+    simp only [mem_univ, iSup_pos, iUnion_true, s] at s₁ ⊢
+    rw [iSup_genWeightSpace_eq_top' K H M] at s₁
+    apply top_le_iff.1 s₁
+  have s₃ : A = 0 := by
     haveI := [Module K M]
-    apply (Submodule.linearMap_eq_zero_iff_of_span_eq_top (A : M →ₗ[K] M) s₃).2
+    apply (linearMap_eq_zero_iff_of_span_eq_top (A : M →ₗ[K] M) s₂).2
     intro h₀
     obtain ⟨m, ⟨_, ⟨⟨χ₂, ⟨_, _⟩⟩, h₁⟩⟩⟩ := h₀
     rw [mem_iUnion] at h₁
     obtain ⟨_, h₂⟩ := h₁
-    have h₃ := s₄ χ₂ m
+    have h₃ := (hn₀ χ₂) (mem_univ χ₂)
     rw [Subtype.forall] at h₃
     exact h₃ m h₂
   use n₀
@@ -450,7 +436,7 @@ open LieModule
 variable {K L : Type*} [Field K] [CharZero K] [LieRing L] [LieAlgebra K L]
   (H : LieSubalgebra K L) [LieRing.IsNilpotent H]
 
-lemma root_space_ad_is_nilpotent [IsTriangularizable K H L] [FiniteDimensional K L]
+lemma root_space_ad_is_nilpotent' [IsTriangularizable K H L] [FiniteDimensional K L]
     {x : L} {χ : H → K} (hχ : χ ≠ 0) (hx : x ∈ rootSpace H χ) :
     _root_.IsNilpotent (ad K L x) :=
   LieModule.root_space_ad_is_nilpotent (M := L) H hχ hx

--- a/Mathlib/Algebra/Lie/Weights/Chain.lean
+++ b/Mathlib/Algebra/Lie/Weights/Chain.lean
@@ -376,13 +376,10 @@ variable {K L M : Type*} [Field K] [CharZero K] [LieRing L] [LieAlgebra K L]
 lemma root_space_ad_is_nilpotent
     {x : L} {χ : H → K} (hχ : χ ≠ 0) (hx : x ∈ rootSpace H χ) :
     _root_.IsNilpotent (toEnd K L M x) := by
-  have partition := iSup_genWeightSpace_eq_top' K H M
-  set s : Set (Weight K H M) := by
+  let s : Set (Weight K H M) := by
     exact univ
-  have Mm : Finite s := by
-    exact Subtype.finite
 
-  have helpMe : ∀ χ₂ ∈ s, ∃ n : ℕ, ∀ v : genWeightSpace M χ₂, ∀ m ≥ n,
+  have nilpotency_limit : ∀ χ₂ ∈ s, ∃ n : ℕ, ∀ v : genWeightSpace M χ₂, ∀ m ≥ n,
       ((toEnd K L M x) ^ m) v = 0 := by
     intro χ₂ he
     obtain ⟨k, ⟨hk₁, hk₂⟩⟩ := exists_genWeightSpace_smul_add_eq_bot (M := M) χ χ₂ hχ
@@ -392,9 +389,9 @@ lemma root_space_ad_is_nilpotent
     rw [hk₂, LieSubmodule.mem_bot] at h
     exact LinearMap.pow_map_zero_of_le hm h
 
-  have exists_uniform_n₀ : ∃ n₀ : ℕ, ∀ χ₂ ∈ s, ∀ v : genWeightSpace M χ₂,
+  have uniform_nilpotency_limit : ∃ n₀ : ℕ, ∀ χ₂ ∈ s, ∀ v : genWeightSpace M χ₂,
       ((toEnd K L M x) ^ n₀) v = 0 := by
-    choose fn₁ hn using helpMe
+    choose fn₁ hn using nilpotency_limit
     simp only [Subtype.forall] at hn ⊢
     let fn₂ : (χ₂ : Weight K H M) → ℕ := fun χ₂ => fn₁ χ₂ (mem_univ χ₂)
     let n₀ := s.toFinset.sup fn₂
@@ -406,7 +403,7 @@ lemma root_space_ad_is_nilpotent
       apply Finset.le_sup (mem_toFinset.2 hχ₂)
     exact hn hv n₀ this
 
-  obtain ⟨n₀, hn₀⟩ := exists_uniform_n₀
+  obtain ⟨n₀, hn₀⟩ := uniform_nilpotency_limit
   let A := (toEnd K L M x) ^ n₀
 
   have s₁ : ∀ χ₂ ∈ s, genWeightSpace M χ₂ ≤
@@ -437,22 +434,22 @@ lemma root_space_ad_is_nilpotent
   have s₃ : Submodule.span K (⋃ χ ∈ s, (genWeightSpace M χ).carrier) = ⊤ := by
     simp only [mem_univ, iSup_pos, iUnion_true, s] at s₂
     simp only [mem_univ, iUnion_true, s]
-    rw [partition] at s₂
+    rw [iSup_genWeightSpace_eq_top' K H M] at s₂
     apply top_le_iff.1 s₂
 
-  have s₄ (χ₂ : Weight K H M) (n : M) (n : genWeightSpace M χ₂) : A n = 0 :=
-    (hn₀ χ₂) (mem_univ χ₂) n
+  have s₄ (χ₂ : Weight K H M) (m : M) (m : genWeightSpace M χ₂) : A m = 0 :=
+    (hn₀ χ₂) (mem_univ χ₂) m
 
   have s₅ : A = 0 := by
     haveI := [Module K M]
     apply (Submodule.linearMap_eq_zero_iff_of_span_eq_top (A : M →ₗ[K] M) s₃).2
-    intro s1
-    obtain ⟨a, ⟨b, ⟨⟨e, ⟨f, g⟩⟩, d⟩⟩⟩ := s1
-    rw [mem_iUnion] at d
-    obtain ⟨d1, d2⟩ := d
-    have h := s₄ e a
+    intro h₀
+    obtain ⟨m, ⟨_, ⟨⟨χ₂, ⟨_, _⟩⟩, h⟩⟩⟩ := h₀
+    rw [mem_iUnion] at h
+    obtain ⟨h₁, h₂⟩ := h
+    have h := s₄ χ₂ m
     rw [Subtype.forall] at h
-    exact h a d2
+    exact h m h₂
   use n₀
 
 end

--- a/Mathlib/Algebra/Lie/Weights/Chain.lean
+++ b/Mathlib/Algebra/Lie/Weights/Chain.lean
@@ -385,7 +385,7 @@ lemma LieModule.isNilpotent_toEnd_of_mem_rootSpace
   induction hm using LieSubmodule.iSup_induction' with
   | h0 => exact ⟨0, map_zero _⟩
   | hN χ₂ m₂ hm₂ =>
-    obtain ⟨n, -, hn⟩ := exists_genWeightSpace_smul_add_eq_bot (M := M) χ χ₂ hχ
+    obtain ⟨n, -, hn⟩ := exists_genWeightSpace_smul_add_eq_bot M χ χ₂ hχ
     use n
     have := toEnd_pow_apply_mem hx hm₂ n
     rwa [hn, LieSubmodule.mem_bot] at this

--- a/Mathlib/Algebra/Lie/Weights/Chain.lean
+++ b/Mathlib/Algebra/Lie/Weights/Chain.lean
@@ -368,14 +368,23 @@ section
 
 open LieAlgebra
 
-variable {K L : Type*} [Field K] [IsAlgClosed K] [NoZeroSMulDivisors ℤ K] [LieRing L]
-[LieAlgebra K L] (H : LieSubalgebra K L) [LieRing.IsNilpotent H]
+variable {K L M : Type*} [Field K] [CharZero K] [LieRing L] [LieAlgebra K L]
+  (H : LieSubalgebra K L) [LieRing.IsNilpotent H]
+  [AddCommGroup M] [Module K M] [LieRingModule L M] [LieModule K L M]
+  [IsTriangularizable K H M] [FiniteDimensional K M]
 
-variable {M : Type*} [AddCommGroup M] [Module K M] [FiniteDimensional K M] [NoZeroSMulDivisors K M]
-[LieRingModule L M] [LieModule K L M]
+lemma root_space_ad_is_nilpotent
+    {x : L} {χ : H → K} (hχ : χ ≠ 0) (hx : x ∈ rootSpace H χ) :
+    _root_.IsNilpotent (toEnd K L M x) := by
+  have := iSup_genWeightSpace_eq_top K H M
+  have := exists_genWeightSpace_smul_add_eq_bot (R := K) (L := H) (M := M) χ (by sorry) hχ
+  sorry
 
-lemma root_space_ad_is_nilpotent {x : L} {χ : H → K} (hχ : χ ≠ 0) (hx : x ∈ rootSpace H χ) :
-  _root_.IsNilpotent (toEnd K L M x) := sorry
+-- This is what we really want
+example [IsTriangularizable K H L] [FiniteDimensional K L]
+    {x : L} {χ : H → K} (hχ : χ ≠ 0) (hx : x ∈ rootSpace H χ) :
+    _root_.IsNilpotent (ad K L x) :=
+  root_space_ad_is_nilpotent (M := L) H hχ hx
 
 end
 

--- a/Mathlib/Algebra/Lie/Weights/Chain.lean
+++ b/Mathlib/Algebra/Lie/Weights/Chain.lean
@@ -431,12 +431,12 @@ lemma root_space_ad_is_nilpotent
     haveI := [Module K M]
     apply (Submodule.linearMap_eq_zero_iff_of_span_eq_top (A : M →ₗ[K] M) s₃).2
     intro h₀
-    obtain ⟨m, ⟨_, ⟨⟨χ₂, ⟨_, _⟩⟩, h⟩⟩⟩ := h₀
-    rw [mem_iUnion] at h
-    obtain ⟨h₁, h₂⟩ := h
-    have h := s₄ χ₂ m
-    rw [Subtype.forall] at h
-    exact h m h₂
+    obtain ⟨m, ⟨_, ⟨⟨χ₂, ⟨_, _⟩⟩, h₁⟩⟩⟩ := h₀
+    rw [mem_iUnion] at h₁
+    obtain ⟨_, h₂⟩ := h₁
+    have h₃ := s₄ χ₂ m
+    rw [Subtype.forall] at h₃
+    exact h₃ m h₂
   use n₀
 
 end

--- a/Mathlib/Algebra/Lie/Weights/Chain.lean
+++ b/Mathlib/Algebra/Lie/Weights/Chain.lean
@@ -365,14 +365,15 @@ lemma chainTop_isNonZero (α β : Weight R L M) (hα : α.IsNonZero) :
 
 end
 
-section
+end LieModule
 
-open LieAlgebra
-open Submodule
+section Field
 
-variable {K L M : Type*} [Field K] [CharZero K] [LieRing L] [LieAlgebra K L]
+open LieAlgebra LieModule Submodule
+
+variable {K : Type*} [Field K] [CharZero K] [LieAlgebra K L]
   (H : LieSubalgebra K L) [LieRing.IsNilpotent H]
-  [AddCommGroup M] [Module K M] [LieRingModule L M] [LieModule K L M]
+  [Module K M] [LieModule K L M]
   [IsTriangularizable K H M] [FiniteDimensional K M]
 
 lemma root_space_ad_is_nilpotent

--- a/Mathlib/Algebra/Lie/Weights/Chain.lean
+++ b/Mathlib/Algebra/Lie/Weights/Chain.lean
@@ -376,7 +376,7 @@ variable {K : Type*} [Field K] [CharZero K] [LieAlgebra K L]
   [Module K M] [LieModule K L M]
   [IsTriangularizable K H M] [FiniteDimensional K M]
 
-lemma root_space_ad_is_nilpotent
+lemma LieModule.isNilpotent_toEnd_of_mem_rootSpace
     {x : L} {χ : H → K} (hχ : χ ≠ 0) (hx : x ∈ rootSpace H χ) :
     _root_.IsNilpotent (toEnd K L M x) := by
   refine Module.Finite.Module.End.isNilpotent_iff_of_finite.mpr fun m ↦ ?_

--- a/Mathlib/Algebra/Lie/Weights/Chain.lean
+++ b/Mathlib/Algebra/Lie/Weights/Chain.lean
@@ -376,9 +376,7 @@ variable {K L M : Type*} [Field K] [CharZero K] [LieRing L] [LieAlgebra K L]
 lemma root_space_ad_is_nilpotent
     {x : L} {χ : H → K} (hχ : χ ≠ 0) (hx : x ∈ rootSpace H χ) :
     _root_.IsNilpotent (toEnd K L M x) := by
-  let s : Set (Weight K H M) := by
-    exact univ
-
+  let s : Set (Weight K H M) := univ
   have nilpotency_limit : ∀ χ₂ ∈ s, ∃ n : ℕ, ∀ v : genWeightSpace M χ₂, ∀ m ≥ n,
       ((toEnd K L M x) ^ m) v = 0 := by
     intro χ₂ he
@@ -388,13 +386,11 @@ lemma root_space_ad_is_nilpotent
     have h := toEnd_pow_apply_mem hx v.mem k
     rw [hk₂, LieSubmodule.mem_bot] at h
     exact LinearMap.pow_map_zero_of_le hm h
-
   have uniform_nilpotency_limit : ∃ n₀ : ℕ, ∀ χ₂ ∈ s, ∀ v : genWeightSpace M χ₂,
       ((toEnd K L M x) ^ n₀) v = 0 := by
     choose fn₁ hn using nilpotency_limit
     simp only [Subtype.forall] at hn ⊢
-    let fn₂ : (χ₂ : Weight K H M) → ℕ := fun χ₂ => fn₁ χ₂ (mem_univ χ₂)
-    let n₀ := s.toFinset.sup fn₂
+    let n₀ := s.toFinset.sup fun χ₂ => fn₁ χ₂ (mem_univ χ₂)
     use n₀
     intro χ₂ hχ₂ v
     specialize hn χ₂ hχ₂ v
@@ -402,15 +398,13 @@ lemma root_space_ad_is_nilpotent
     have : fn₁ χ₂ hχ₂ ≤ n₀ := by
       apply Finset.le_sup (mem_toFinset.2 hχ₂)
     exact hn hv n₀ this
-
   obtain ⟨n₀, hn₀⟩ := uniform_nilpotency_limit
   let A := (toEnd K L M x) ^ n₀
-
   have s₁ : ∀ χ₂ ∈ s, genWeightSpace M χ₂ ≤
-      Submodule.span K (⋃ i ∈ s, (genWeightSpace M i).carrier) := by
+      Submodule.span K (⋃ χᵢ ∈ s, (genWeightSpace M χᵢ).carrier) := by
     intro χ₂ a m hm
     have h₁ : Submodule.span K (genWeightSpace M χ₂).carrier ≤
-        Submodule.span K (⋃ χ ∈ s, (genWeightSpace M χ).carrier) := by
+        Submodule.span K (⋃ χᵢ ∈ s, (genWeightSpace M χᵢ).carrier) := by
       apply Submodule.span_mono
       exact fun _ hx => Set.mem_biUnion a hx
     have h₂ : genWeightSpace M χ₂ ≤ Submodule.span K (genWeightSpace M χ₂).carrier := by
@@ -419,27 +413,20 @@ lemma root_space_ad_is_nilpotent
       simp only [mem_setOf_eq, mem_iInter, SetLike.mem_coe]
       exact fun p => p hm
     exact h₁ (h₂ hm)
-
-  have s₂ : ⨆ χ ∈ s, genWeightSpace M χ ≤
-      Submodule.span K (⋃ χ ∈ s, (genWeightSpace M χ).carrier) := by
+  have s₂ : ⨆ χᵢ ∈ s, genWeightSpace M χᵢ ≤
+      Submodule.span K (⋃ χᵢ ∈ s, (genWeightSpace M χᵢ).carrier) := by
     apply sSup_le
-    intro x hf
-    simp only [mem_univ, iUnion_true, mem_range, s] at s₁
-    simp only [mem_univ, iSup_pos, mem_range, exists_exists_eq_and, s] at hf
-    simp only [mem_univ, iSup_pos, iUnion_true, s]
-    obtain ⟨w₁, h₁⟩ := hf
-    subst h₁
-    exact s₁ w₁ trivial
-
-  have s₃ : Submodule.span K (⋃ χ ∈ s, (genWeightSpace M χ).carrier) = ⊤ := by
-    simp only [mem_univ, iSup_pos, iUnion_true, s] at s₂
-    simp only [mem_univ, iUnion_true, s]
+    intro n hn
+    simp only [mem_univ, iSup_pos, mem_range, exists_exists_eq_and, s] at s₁ hn ⊢
+    obtain ⟨χ₂, hχ₂⟩ := hn
+    subst hχ₂
+    exact s₁ χ₂ trivial
+  have s₃ : Submodule.span K (⋃ χᵢ ∈ s, (genWeightSpace M χᵢ).carrier) = ⊤ := by
+    simp only [mem_univ, iSup_pos, iUnion_true, s] at s₂ ⊢
     rw [iSup_genWeightSpace_eq_top' K H M] at s₂
     apply top_le_iff.1 s₂
-
   have s₄ (χ₂ : Weight K H M) (m : M) (m : genWeightSpace M χ₂) : A m = 0 :=
     (hn₀ χ₂) (mem_univ χ₂) m
-
   have s₅ : A = 0 := by
     haveI := [Module K M]
     apply (Submodule.linearMap_eq_zero_iff_of_span_eq_top (A : M →ₗ[K] M) s₃).2

--- a/Mathlib/Algebra/Lie/Weights/Chain.lean
+++ b/Mathlib/Algebra/Lie/Weights/Chain.lean
@@ -394,7 +394,7 @@ lemma root_space_ad_is_nilpotent
     obtain ⟨n₂, hn₂⟩ := hm₂'
     refine ⟨max n₁ n₂, ?_⟩
     rw [map_add, LinearMap.pow_map_zero_of_le le_sup_left hn₁,
-    LinearMap.pow_map_zero_of_le le_sup_right hn₂, add_zero]
+      LinearMap.pow_map_zero_of_le le_sup_right hn₂, add_zero]
 
 end
 

--- a/Mathlib/Algebra/Lie/Weights/Chain.lean
+++ b/Mathlib/Algebra/Lie/Weights/Chain.lean
@@ -396,9 +396,6 @@ lemma LieModule.isNilpotent_toEnd_of_mem_rootSpace
     rw [map_add, LinearMap.pow_map_zero_of_le le_sup_left hn₁,
       LinearMap.pow_map_zero_of_le le_sup_right hn₂, add_zero]
 
-variable {K L : Type*} [Field K] [CharZero K] [LieRing L] [LieAlgebra K L]
-  (H : LieSubalgebra K L) [LieRing.IsNilpotent H]
-
 lemma LieAlgebra.isNilpotent_ad_of_mem_rootSpace
     [IsTriangularizable K H L] [FiniteDimensional K L]
     {x : L} {χ : H → K} (hχ : χ ≠ 0) (hx : x ∈ rootSpace H χ) :

--- a/Mathlib/Algebra/Lie/Weights/Chain.lean
+++ b/Mathlib/Algebra/Lie/Weights/Chain.lean
@@ -383,10 +383,7 @@ lemma root_space_ad_is_nilpotent
   have hm : m ∈ ⨆ χ : LieModule.Weight K H M, genWeightSpace M χ := by
     simp [iSup_genWeightSpace_eq_top' K H M]
   induction hm using LieSubmodule.iSup_induction' with
-  | h0 =>
-      obtain ⟨n, -, hn⟩ := exists_genWeightSpace_smul_add_eq_bot (M := M) χ χ hχ
-      use 0
-      apply map_zero
+  | h0 => exact ⟨0, map_zero _⟩
   | hN χ₂ m₂ hm₂ =>
     obtain ⟨n, -, hn⟩ := exists_genWeightSpace_smul_add_eq_bot (M := M) χ χ₂ hχ
     use n

--- a/Mathlib/Algebra/Lie/Weights/Chain.lean
+++ b/Mathlib/Algebra/Lie/Weights/Chain.lean
@@ -364,4 +364,19 @@ lemma chainTop_isNonZero (α β : Weight R L M) (hα : α.IsNonZero) :
 
 end
 
+section
+
+open LieAlgebra
+
+variable {K L : Type*} [Field K] [IsAlgClosed K] [NoZeroSMulDivisors ℤ K] [LieRing L]
+[LieAlgebra K L] (H : LieSubalgebra K L) [LieRing.IsNilpotent H]
+
+variable {M : Type*} [AddCommGroup M] [Module K M] [FiniteDimensional K M] [NoZeroSMulDivisors K M]
+[LieRingModule L M] [LieModule K L M]
+
+lemma root_space_ad_is_nilpotent {x : L} {χ : H → K} (hχ : χ ≠ 0) (hx : x ∈ rootSpace H χ) :
+  _root_.IsNilpotent (toEnd K L M x) := sorry
+
+end
+
 end LieModule


### PR DESCRIPTION
The adjoints of nonzero root space elements are nilpotent endomorphisms in Lie algebras.
---
This PR proves that the adjoints of nonzero root space elements are nilpotent endomorphisms in Lie algebras satisfying the following conditions:
- The base field has characteristic zero.
- The Lie algebra (with nilpotent subalgebra H) is triangularizable.
- The Lie algebra has finite dimension.

This work is part of the framework:
https://github.com/orgs/leanprover-community/projects/17
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
