### PR TITLE
[Merged by Bors] - fix: typo in reference

### DIFF
--- a/docs/references.bib
+++ b/docs/references.bib
@@ -3437,7 +3437,7 @@
   pages         = {75--91}
 }
 
-@Article{         rooij1070,
+@Article{         rooij1970,
   title         = {Non-Archimedean uniformities},
   author        = {van Rooij, A. C. M.},
   year          = {1970},


### PR DESCRIPTION
This causes one of the reference in https://leanprover-community.github.io/mathlib4_docs/Mathlib/Topology/UniformSpace/Ultra.html#IsUltraUniformity not to be linked properly.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
