### PR TITLE
[Merged by Bors] - feat: add `CStarRing.of_le_norm_mul_star_self`

### DIFF
--- a/Mathlib/Analysis/CStarAlgebra/Basic.lean
+++ b/Mathlib/Analysis/CStarAlgebra/Basic.lean
@@ -38,17 +38,17 @@ local postfix:max "⋆" => star
 
 /-- A normed star group is a normed group with a compatible `star` which is isometric. -/
 class NormedStarGroup (E : Type*) [SeminormedAddCommGroup E] [StarAddMonoid E] : Prop where
-  norm_star : ∀ x : E, ‖x⋆‖ = ‖x‖
-
-export NormedStarGroup (norm_star)
-
-attribute [simp] norm_star
+  norm_star_le : ∀ x : E, ‖x⋆‖ ≤ ‖x‖
 
 variable {𝕜 E α : Type*}
 
 section NormedStarGroup
 
 variable [SeminormedAddCommGroup E] [StarAddMonoid E] [NormedStarGroup E]
+
+@[simp]
+lemma norm_star (x : E) : ‖x⋆‖ = ‖x‖ :=
+  le_antisymm (NormedStarGroup.norm_star_le x) (by simpa using NormedStarGroup.norm_star_le x⋆)
 
 @[simp]
 theorem nnnorm_star (x : E) : ‖star x‖₊ = ‖x‖₊ :=
@@ -86,23 +86,27 @@ namespace CStarRing
 
 section NonUnital
 
+lemma of_le_norm_mul_star_self
+    [NonUnitalNormedRing E] [StarRing E]
+    (h : ∀ x : E, ‖x‖ * ‖x‖ ≤ ‖x * x⋆‖) : CStarRing E :=
+  have : NormedStarGroup E :=
+    { norm_star_le x := by
+        obtain (hx | hx) := eq_zero_or_norm_pos x⋆
+        · simp [hx]
+        · refine le_of_mul_le_mul_right ?_ hx
+          simpa [sq, mul_comm ‖x⋆‖] using h x⋆ |>.trans <| norm_mul_le _ _ }
+  ⟨star_involutive.surjective.forall.mpr <| by simpa⟩
+
 variable [NonUnitalNormedRing E] [StarRing E] [CStarRing E]
 
 -- see Note [lower instance priority]
 /-- In a C*-ring, star preserves the norm. -/
-instance (priority := 100) to_normedStarGroup : NormedStarGroup E :=
-  ⟨by
-    intro x
-    by_cases htriv : x = 0
-    · simp only [htriv, star_zero]
-    · have hnt : 0 < ‖x‖ := norm_pos_iff.mpr htriv
-      have h₁ : ∀ z : E, ‖z⋆ * z‖ ≤ ‖z⋆‖ * ‖z‖ := fun z => norm_mul_le z⋆ z
-      have h₂ : ∀ z : E, 0 < ‖z‖ → ‖z‖ ≤ ‖z⋆‖ := fun z hz => by
-        rw [← mul_le_mul_right hz]; exact (CStarRing.norm_mul_self_le z).trans (h₁ z)
-      have h₃ : ‖x⋆‖ ≤ ‖x‖ := by
-        conv_rhs => rw [← star_star x]
-        exact h₂ x⋆ (gt_of_ge_of_gt (h₂ x hnt) hnt)
-      exact le_antisymm h₃ (h₂ x hnt)⟩
+instance (priority := 100) to_normedStarGroup : NormedStarGroup E where
+  norm_star_le x := by
+    obtain (hx | hx) := eq_zero_or_norm_pos x⋆
+    · simp [hx]
+    · refine le_of_mul_le_mul_right ?_ hx
+      simpa using norm_mul_self_le (x := x⋆) |>.trans <| norm_mul_le _ _
 
 theorem norm_star_mul_self {x : E} : ‖x⋆ * x‖ = ‖x‖ * ‖x‖ :=
   le_antisymm ((norm_mul_le _ _).trans (by rw [norm_star])) (CStarRing.norm_mul_self_le x)

--- a/Mathlib/Analysis/Matrix.lean
+++ b/Mathlib/Analysis/Matrix.lean
@@ -128,7 +128,7 @@ theorem norm_conjTranspose [StarAddMonoid α] [NormedStarGroup α] (A : Matrix m
   congr_arg ((↑) : ℝ≥0 → ℝ) <| nnnorm_conjTranspose A
 
 instance [StarAddMonoid α] [NormedStarGroup α] : NormedStarGroup (Matrix m m α) :=
-  ⟨norm_conjTranspose⟩
+  ⟨(le_of_eq <| norm_conjTranspose ·)⟩
 
 @[simp]
 theorem nnnorm_col (v : m → α) : ‖col ι v‖₊ = ‖v‖₊ := by
@@ -520,7 +520,7 @@ theorem frobenius_norm_conjTranspose [StarAddMonoid α] [NormedStarGroup α] (A 
 
 instance frobenius_normedStarGroup [StarAddMonoid α] [NormedStarGroup α] :
     NormedStarGroup (Matrix m m α) :=
-  ⟨frobenius_norm_conjTranspose⟩
+  ⟨(le_of_eq <| frobenius_norm_conjTranspose ·)⟩
 
 @[simp]
 theorem frobenius_norm_row (v : m → α) : ‖row ι v‖ = ‖(WithLp.equiv 2 _).symm v‖ := by

--- a/Mathlib/Analysis/Normed/Lp/lpSpace.lean
+++ b/Mathlib/Analysis/Normed/Lp/lpSpace.lean
@@ -690,7 +690,7 @@ instance instStarAddMonoid : StarAddMonoid (lp E p) where
   star_add _f _g := ext <| star_add (R := ∀ i, E i) _ _
 
 instance [hp : Fact (1 ≤ p)] : NormedStarGroup (lp E p) where
-  norm_star f := by
+  norm_star_le f := le_of_eq <| by
     rcases p.trichotomy with (rfl | rfl | h)
     · exfalso
       have := ENNReal.toReal_mono ENNReal.zero_ne_top hp.elim

--- a/Mathlib/Topology/ContinuousMap/Bounded/Star.lean
+++ b/Mathlib/Topology/ContinuousMap/Bounded/Star.lean
@@ -62,7 +62,7 @@ theorem coe_star (f : α →ᵇ β) : ⇑(star f) = star (⇑f) := rfl
 theorem star_apply (f : α →ᵇ β) (x : α) : star f x = star (f x) := rfl
 
 instance instNormedStarGroup : NormedStarGroup (α →ᵇ β) where
-  norm_star f := by simp only [norm_eq, star_apply, norm_star]
+  norm_star_le f := by simp only [norm_eq, star_apply, norm_star, le_of_eq]
 
 instance instStarModule : StarModule 𝕜 (α →ᵇ β) where
   star_smul k f := ext fun x => star_smul k (f x)

--- a/Mathlib/Topology/ContinuousMap/Compact.lean
+++ b/Mathlib/Topology/ContinuousMap/Compact.lean
@@ -459,7 +459,7 @@ theorem _root_.BoundedContinuousFunction.mkOfCompact_star [CompactSpace α] (f :
   rfl
 
 instance [CompactSpace α] : NormedStarGroup C(α, β) where
-  norm_star f := by
+  norm_star_le f := by
     rw [← BoundedContinuousFunction.norm_mkOfCompact, BoundedContinuousFunction.mkOfCompact_star,
       norm_star, BoundedContinuousFunction.norm_mkOfCompact]
 

--- a/Mathlib/Topology/ContinuousMap/ZeroAtInfty.lean
+++ b/Mathlib/Topology/ContinuousMap/ZeroAtInfty.lean
@@ -534,7 +534,7 @@ section NormedStar
 variable [NormedAddCommGroup β] [StarAddMonoid β] [NormedStarGroup β]
 
 instance instNormedStarGroup : NormedStarGroup C₀(α, β) where
-  norm_star f := (norm_star f.toBCF :)
+  norm_star_le f := (norm_star f.toBCF :).le
 
 end NormedStar
 


### PR DESCRIPTION
This adds another constructor for `CStarRing` which allows the user to prove `‖x‖ * ‖x‖ ≤ ‖x * star x‖` instead of `‖x‖ * ‖x‖ ≤ ‖star x * x‖`, which is occasionally useful.

Along the way we also refactor `NormedStarGroup` so that the user only has to supply a proof that `star` is contractive instead of that it is an isometry.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
