### PR TITLE
feat: PartialEquiv on closed sets restricts to closed map

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -5953,6 +5953,7 @@ import Mathlib.Topology.Order.ScottTopology
 import Mathlib.Topology.Order.T5
 import Mathlib.Topology.Order.UpperLowerSetTopology
 import Mathlib.Topology.Partial
+import Mathlib.Topology.PartialEquiv
 import Mathlib.Topology.PartialHomeomorph
 import Mathlib.Topology.PartitionOfUnity
 import Mathlib.Topology.Path

--- a/Mathlib/Topology/PartialEquiv.lean
+++ b/Mathlib/Topology/PartialEquiv.lean
@@ -1,0 +1,52 @@
+/-
+Copyright (c) 2025 Hannah Scholz. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Hannah Scholz
+-/
+import Mathlib.Logic.Equiv.PartialEquiv
+import Mathlib.Topology.ContinuousOn
+
+/-!
+# Topological properties of partial equivalences
+
+-/
+
+open Set
+
+namespace PartialEquiv
+
+/-- A partial equivalence that is continuous on the source and the target restricts to a
+homeomorphism. -/
+@[simps]
+def toHomeomorph {α β : Type*} [TopologicalSpace α] [TopologicalSpace β] (e : PartialEquiv α β)
+    (he1 : ContinuousOn e e.source) (he2 : ContinuousOn e.symm e.target) :
+    e.source ≃ₜ e.target where
+  toFun := e.toEquiv
+  invFun := e.toEquiv.symm
+  left_inv := e.toEquiv.symm_apply_apply
+  right_inv := e.toEquiv.apply_symm_apply
+  continuous_toFun := by
+    apply Continuous.subtype_mk
+    change Continuous (e.source.restrict e)
+    rw [← continuousOn_iff_continuous_restrict]
+    exact he1
+  continuous_invFun := by
+    apply Continuous.subtype_mk
+    change Continuous (e.target.restrict e.symm)
+    rw [← continuousOn_iff_continuous_restrict]
+    exact he2
+
+/-- A partial equivalence that is continuous on both source and target and where the source and the
+target are closed is a closed map when restricting to the source. -/
+lemma isClosed_of_isClosed_preimage {X Y : Type*} [TopologicalSpace X] [TopologicalSpace Y]
+    (e : PartialEquiv X Y) (h1 : ContinuousOn e e.source) (h2 : ContinuousOn e.symm e.target)
+    (he1 : IsClosed e.target) (he2 : IsClosed e.source) (A : Set Y) (hAe : A ⊆ e.target)
+    (hA : IsClosed (e.source ∩ e ⁻¹' A)) : IsClosed A := by
+  rw [← inter_eq_right.2 hAe, ← he1.inter_preimage_val_iff,
+    ← (e.toHomeomorph h1 h2).isClosed_preimage,
+    he2.isClosedEmbedding_subtypeVal.isClosed_iff_image_isClosed]
+  convert hA
+  ext
+  simp [PartialEquiv.toEquiv, and_comm]
+
+end PartialEquiv


### PR DESCRIPTION
This PR shows that a PartialEquiv that is continuous on both source and target restricts to a homeomorphism. It then uses that to show that a PartialEquiv with closed source and target and which is continuous on both the source and target restricts to a closed map. 

---

See [this Zulip discussion](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Generalizing.20.60PartialHomeomorph.60.3F) that will probably mean that I close this PR.

I need the latter statement to prove that one can transport a CW complex along a PartialEquiv. I had trouble finding a good spot for these statements; I hope this solution works. 

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
