### PR TITLE
[Merged by Bors] - feat(Analysis/Asymptotics): `=O[atTop]` for sequences implies `=O[l]` for any filter `l`

### DIFF
--- a/Mathlib/Analysis/Asymptotics/Lemmas.lean
+++ b/Mathlib/Analysis/Asymptotics/Lemmas.lean
@@ -603,9 +603,9 @@ theorem isBigO_one_nat_atTop_iff {f : ℕ → E''} :
   Iff.trans (isBigO_nat_atTop_iff fun _ h => (one_ne_zero h).elim) <| by
     simp only [norm_one, mul_one]
 
-theorem isBigO_nat_of_isBigO_atTop {f : ℕ → E''} {g : ℕ → F''} (hfg : f =O[atTop] g)
+theorem IsBigO.nat_of_atTop {f : ℕ → E''} {g : ℕ → F''} (hfg : f =O[atTop] g)
     {l : Filter ℕ} (h : ∀ᶠ n in l, g n = 0 → f n = 0) : f =O[l] g := by
-  obtain ⟨C, hC_pos, hC⟩ := Asymptotics.bound_of_isBigO_nat_atTop hfg
+  obtain ⟨C, hC_pos, hC⟩ := bound_of_isBigO_nat_atTop hfg
   refine isBigO_iff.mpr ⟨C, ?_⟩
   filter_upwards [h] with x h
   by_cases hf : f x = 0

--- a/Mathlib/Analysis/Asymptotics/Lemmas.lean
+++ b/Mathlib/Analysis/Asymptotics/Lemmas.lean
@@ -603,8 +603,8 @@ theorem isBigO_one_nat_atTop_iff {f : ℕ → E''} :
   Iff.trans (isBigO_nat_atTop_iff fun _ h => (one_ne_zero h).elim) <| by
     simp only [norm_one, mul_one]
 
-theorem isBigO_nat_of_isBigO_atTop {f g : ℕ → E''} (hfg : f =O[atTop] g) {l : Filter ℕ}
-    (h : ∀ᶠ n in l, g n = 0 → f n = 0) : f =O[l] g := by
+theorem isBigO_nat_of_isBigO_atTop {f : ℕ → E''} {g : ℕ → F''} (hfg : f =O[atTop] g)
+    {l : Filter ℕ} (h : ∀ᶠ n in l, g n = 0 → f n = 0) : f =O[l] g := by
   obtain ⟨C, hC_pos, hC⟩ := Asymptotics.bound_of_isBigO_nat_atTop hfg
   refine isBigO_iff.mpr ⟨C, ?_⟩
   filter_upwards [h] with x h

--- a/Mathlib/Analysis/Asymptotics/Lemmas.lean
+++ b/Mathlib/Analysis/Asymptotics/Lemmas.lean
@@ -603,6 +603,15 @@ theorem isBigO_one_nat_atTop_iff {f : ℕ → E''} :
   Iff.trans (isBigO_nat_atTop_iff fun _ h => (one_ne_zero h).elim) <| by
     simp only [norm_one, mul_one]
 
+theorem isBigO_nat_of_isBigO_atTop {f g : ℕ → E''} (hfg : f =O[atTop] g) {l : Filter ℕ}
+    (h : ∀ᶠ n in l, g n = 0 → f n = 0) : f =O[l] g := by
+  obtain ⟨C, hC_pos, hC⟩ := Asymptotics.bound_of_isBigO_nat_atTop hfg
+  refine isBigO_iff.mpr ⟨C, ?_⟩
+  filter_upwards [h] with x h
+  by_cases hf : f x = 0
+  · simp [hf, hC_pos]
+  exact hC fun a ↦ hf (h a)
+
 theorem isBigOWith_pi {ι : Type*} [Fintype ι] {E' : ι → Type*} [∀ i, NormedAddCommGroup (E' i)]
     {f : α → ∀ i, E' i} {C : ℝ} (hC : 0 ≤ C) :
     IsBigOWith C l f g' ↔ ∀ i, IsBigOWith C l (fun x => f x i) g' := by


### PR DESCRIPTION
Prove that `a =O[atTop] b` implies `a =O[l] b` for `a` and `b` natural sequences such that `b n = 0 -> a n = 0` eventually in `l`. I've found this result helpful for deducing uniform bounds from tail bounds.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
