### PR TITLE
[Merged by Bors] - doc: library note about argument order in instances

### DIFF
--- a/Mathlib/Algebra/HierarchyDesign.lean
+++ b/Mathlib/Algebra/HierarchyDesign.lean
@@ -247,5 +247,5 @@ for example in
 instance {G : Type*} [Group G] [IsKleinFour G] : IsAddKleinFour (Additive G)
 ```
 where the `Group G` instance appears in `IsKleinFour G`. Future work may be done to improve the
-type class syntesis order in this situation.
+type class synthesis order in this situation.
 -/

--- a/Mathlib/Algebra/HierarchyDesign.lean
+++ b/Mathlib/Algebra/HierarchyDesign.lean
@@ -229,3 +229,23 @@ See also [mathlib#1561](https://github.com/leanprover-community/mathlib/issues/1
 Therefore, if we create an instance that always applies, we set the priority of these instances to
 100 (or something similar, which is below the default value of 1000).
 -/
+
+library_note "instance argument order"/--
+When type class inference applies an instance, it attempts to solve the sub-goals from left to
+right (it used to be from right to left in lean 3). For example in
+```
+instance {p : α → Sort*} [∀ x, IsEmpty (p x)] [Nonempty α] : IsEmpty (∀ x, p x)
+```
+we make sure to write `[∀ x, IsEmpty (p x)]` on the left of `[Nonempty α]` to avoid an expensive
+search for `Nonempty α` when there is no instance for `∀ x, IsEmpty (p x)`.
+
+This helps to speed up failing type class searches, for example those triggered by `simp` lemmas.
+
+In some situations, we can't reorder type class assumptions because one depends on the other,
+for example in
+```
+instance {G : Type*} [Group G] [IsKleinFour G] : IsAddKleinFour (Additive G)
+```
+where the `Group G` instance appears in `IsKleinFour G`. Future work may be done to improve the
+type class syntesis order in this situation.
+-/

--- a/Mathlib/CategoryTheory/Limits/Shapes/Countable.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Countable.lean
@@ -92,6 +92,7 @@ instance (priority := 100) hasCountableColimits_of_hasColimits [HasColimits C] :
     HasCountableColimits C where
   out := inferInstance
 
+-- See note [instance argument order]
 universe v in
 instance [HasCountableColimits C] (J : Type*) [Category.{v} J] [CountableCategory J] :
     HasColimitsOfShape J C :=
@@ -108,6 +109,7 @@ instance (priority := 100) hasCountableCoproducts_of_hasCoproducts [HasCoproduct
     have : HasCoproducts.{0} C := has_smallest_coproducts_of_hasCoproducts
     inferInstance
 
+-- See note [instance argument order]
 instance [HasCountableCoproducts C] (J : Type*) [Countable J] : HasCoproductsOfShape J C :=
   have : Countable (Shrink.{0} J) := Countable.of_equiv _ (equivShrink.{0} J)
   have : HasColimitsOfShape (Discrete (Shrink.{0} J)) C := HasCountableCoproducts.out _

--- a/Mathlib/CategoryTheory/Limits/Shapes/FiniteLimits.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/FiniteLimits.lean
@@ -88,6 +88,7 @@ class HasFiniteColimits : Prop where
   and which has `Fintype` objects and morphisms -/
   out (J : Type) [𝒥 : SmallCategory J] [@FinCategory J 𝒥] : @HasColimitsOfShape J 𝒥 C _
 
+-- See note [instance argument order]
 instance (priority := 100) hasColimitsOfShape_of_hasFiniteColimits [HasFiniteColimits C]
     (J : Type w) [SmallCategory J] [FinCategory J] : HasColimitsOfShape J C := by
   refine @hasColimitsOfShape_of_equivalence _ _ _ _ _ _ (FinCategory.equivAsType J) ?_

--- a/Mathlib/Logic/IsEmpty.lean
+++ b/Mathlib/Logic/IsEmpty.lean
@@ -43,8 +43,7 @@ protected theorem Function.isEmpty [IsEmpty β] (f : α → β) : IsEmpty α :=
 theorem Function.Surjective.isEmpty [IsEmpty α] {f : α → β} (hf : f.Surjective) : IsEmpty β :=
   ⟨fun y ↦ let ⟨x, _⟩ := hf y; IsEmpty.false x⟩
 
--- Note on type class argument order:
--- We want type class search to look for `IsEmpty (p x)` instances before `Nonempty α` instances.
+-- See note [instance argument order]
 instance {p : α → Sort*} [∀ x, IsEmpty (p x)] [h : Nonempty α] : IsEmpty (∀ x, p x) :=
   h.elim fun x ↦ Function.isEmpty <| Function.eval x
 


### PR DESCRIPTION
This is a follow up on #22953 and #22968.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
