### PR TITLE
feat: tag Fermat's little theorem (`ZMod.pow_card_sub_one_eq_one`) as `simp`

### DIFF
--- a/Mathlib/FieldTheory/Finite/Basic.lean
+++ b/Mathlib/FieldTheory/Finite/Basic.lean
@@ -584,6 +584,7 @@ theorem units_pow_card_sub_one_eq_one (p : ℕ) [Fact p.Prime] (a : (ZMod p)ˣ) 
   rw [← card_units p, pow_card_eq_one]
 
 /-- **Fermat's Little Theorem**: for all nonzero `a : ZMod p`, we have `a ^ (p - 1) = 1`. -/
+@[simp]
 theorem pow_card_sub_one_eq_one {a : ZMod p} (ha : a ≠ 0) :
     a ^ (p - 1) = 1 := by
     have h := FiniteField.pow_card_sub_one_eq_one a ha


### PR DESCRIPTION
I apologize in advance if there is a valid reason this shouldn’t be tagged `@[simp]`. From my point of view, it looks like an obvious simplification, though I might be overlooking something.