### PR TITLE
[Merged by Bors] - feat: remove measurable assumptions in Azuma-Hoeffding inequality

### DIFF
--- a/Mathlib/InformationTheory/KullbackLeibler/KLFun.lean
+++ b/Mathlib/InformationTheory/KullbackLeibler/KLFun.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Rémy Degenne, Lorenzo Luccioli
 -/
 import Mathlib.Analysis.SpecialFunctions.Log.NegMulLog
+import Mathlib.MeasureTheory.Decomposition.IntegralRNDeriv
 import Mathlib.MeasureTheory.Measure.LogLikelihoodRatio
 
 /-!

--- a/Mathlib/MeasureTheory/Decomposition/IntegralRNDeriv.lean
+++ b/Mathlib/MeasureTheory/Decomposition/IntegralRNDeriv.lean
@@ -25,6 +25,12 @@ namespace MeasureTheory
 
 variable {α : Type*} {mα : MeasurableSpace α} {μ ν : Measure α} {f : ℝ → ℝ}
 
+@[fun_prop]
+lemma Measure.integrable_toReal_rnDeriv [IsFiniteMeasure μ] :
+    Integrable (fun x ↦ (μ.rnDeriv ν x).toReal) ν :=
+  integrable_toReal_of_lintegral_ne_top (Measure.measurable_rnDeriv _ _).aemeasurable
+    (Measure.lintegral_rnDeriv_lt_top _ _).ne
+
 /-- For a convex continuous function `f` on `[0, ∞)`, if `μ` is absolutely continuous
 with respect to a probability measure `ν`, then
 `f (μ univ).toReal ≤ ∫ x, f (μ.rnDeriv ν x).toReal ∂ν`. -/

--- a/Mathlib/MeasureTheory/Decomposition/Lebesgue.lean
+++ b/Mathlib/MeasureTheory/Decomposition/Lebesgue.lean
@@ -5,7 +5,6 @@ Authors: Kexing Ying
 -/
 import Mathlib.MeasureTheory.Decomposition.UnsignedHahn
 import Mathlib.MeasureTheory.Function.AEEqOfLIntegral
-import Mathlib.MeasureTheory.Function.L1Space.Integrable
 import Mathlib.MeasureTheory.Measure.Sub
 
 /-!
@@ -370,12 +369,6 @@ theorem lintegral_rnDeriv_lt_top (μ ν : Measure α) [IsFiniteMeasure μ] :
     ∫⁻ x, μ.rnDeriv ν x ∂ν < ∞ := by
   rw [← setLIntegral_univ]
   exact lintegral_rnDeriv_lt_top_of_measure_ne_top _ (measure_lt_top _ _).ne
-
-@[fun_prop]
-lemma integrable_toReal_rnDeriv [IsFiniteMeasure μ] :
-    Integrable (fun x ↦ (μ.rnDeriv ν x).toReal) ν :=
-  integrable_toReal_of_lintegral_ne_top (Measure.measurable_rnDeriv _ _).aemeasurable
-    (Measure.lintegral_rnDeriv_lt_top _ _).ne
 
 /-- The Radon-Nikodym derivative of a sigma-finite measure `μ` with respect to another
 measure `ν` is `ν`-almost everywhere finite. -/

--- a/Mathlib/Probability/Independence/Basic.lean
+++ b/Mathlib/Probability/Independence/Basic.lean
@@ -65,8 +65,6 @@ when defining `μ` in the example above, the measurable space used is the last o
 Part A, Chapter 4.
 -/
 
-assert_not_exists MeasureTheory.Integrable
-
 open MeasureTheory MeasurableSpace Set
 
 open scoped MeasureTheory ENNReal
@@ -722,11 +720,9 @@ lemma iIndepFun.indepFun_mul_left (hf_indep : iIndepFun f μ)
 lemma iIndepFun.indepFun_mul_left₀ (hf_indep : iIndepFun f μ)
     (hf_meas : ∀ i, AEMeasurable (f i) μ) (i j k : ι) (hik : i ≠ k) (hjk : j ≠ k) :
     IndepFun (f i * f j) (f k) μ := by
-  have : iIndepFun (fun i ↦ (hf_meas i).mk) μ :=
-    iIndepFun.congr hf_indep (fun i ↦ (hf_meas i).ae_eq_mk)
-  apply IndepFun.congr (this.indepFun_mul_left (fun i ↦ (hf_meas i).measurable_mk) i j k hik hjk)
-  · exact ((hf_meas i).ae_eq_mk.mul (hf_meas j).ae_eq_mk).symm
-  · exact ((hf_meas k).ae_eq_mk).symm
+  refine Kernel.iIndepFun.indepFun_mul_left₀ hf_indep ?_ i j k hik hjk
+  convert hf_meas
+  simp
 
 @[to_additive]
 lemma iIndepFun.indepFun_mul_right (hf_indep : iIndepFun f μ)

--- a/Mathlib/Probability/Independence/Basic.lean
+++ b/Mathlib/Probability/Independence/Basic.lean
@@ -735,6 +735,13 @@ lemma iIndepFun.indepFun_mul_right₀ (hf_indep : iIndepFun f μ)
   Kernel.iIndepFun.indepFun_mul_right₀ hf_indep (by simp [hf_meas]) i j k hij hik
 
 @[to_additive]
+lemma iIndepFun.indepFun_mul_mul (hf_indep : iIndepFun f μ)
+    (hf_meas : ∀ i, Measurable (f i))
+    (i j k l : ι) (hik : i ≠ k) (hil : i ≠ l) (hjk : j ≠ k) (hjl : j ≠ l) :
+    IndepFun (f i * f j) (f k * f l) μ :=
+  Kernel.iIndepFun.indepFun_mul_mul hf_indep hf_meas i j k l hik hil hjk hjl
+
+@[to_additive]
 lemma iIndepFun.indepFun_mul_mul₀ (hf_indep : iIndepFun f μ)
     (hf_meas : ∀ i, AEMeasurable (f i) μ)
     (i j k l : ι) (hik : i ≠ k) (hil : i ≠ l) (hjk : j ≠ k) (hjl : j ≠ l) :

--- a/Mathlib/Probability/Independence/Basic.lean
+++ b/Mathlib/Probability/Independence/Basic.lean
@@ -580,7 +580,7 @@ alias ⟨iIndepFun.measure_inter_preimage_eq_mul, _⟩ := iIndepFun_iff_measure_
 theorem iIndepFun.congr {β : ι → Type*} {mβ : ∀ i, MeasurableSpace (β i)}
     {f g : Π i, Ω → β i} (hf : iIndepFun f μ) (h : ∀ i, f i =ᵐ[μ] g i) :
     iIndepFun g μ :=
-  Kernel.iIndepFun.congr hf (by simp [h])
+  Kernel.iIndepFun.congr' hf (by simp [h])
 
 nonrec lemma iIndepFun.comp {β γ : ι → Type*} {mβ : ∀ i, MeasurableSpace (β i)}
     {mγ : ∀ i, MeasurableSpace (γ i)} {f : ∀ i, Ω → β i}
@@ -616,7 +616,7 @@ nonrec theorem IndepFun.symm {_ : MeasurableSpace β} {_ : MeasurableSpace β'}
 theorem IndepFun.congr {mβ : MeasurableSpace β} {mβ' : MeasurableSpace β'}
     {f' : Ω → β} {g' : Ω → β'} (hfg : IndepFun f g μ)
     (hf : f =ᵐ[μ] f') (hg : g =ᵐ[μ] g') : IndepFun f' g' μ := by
-  refine Kernel.IndepFun.congr hfg ?_ ?_ <;>
+  refine Kernel.IndepFun.congr' hfg ?_ ?_ <;>
     simp only [ae_dirac_eq, Filter.eventually_pure, Kernel.const_apply]
   exacts [hf, hg]
 

--- a/Mathlib/Probability/Independence/Basic.lean
+++ b/Mathlib/Probability/Independence/Basic.lean
@@ -579,12 +579,8 @@ alias ⟨iIndepFun.measure_inter_preimage_eq_mul, _⟩ := iIndepFun_iff_measure_
 
 theorem iIndepFun.ae_eq {β : ι → Type*} {mβ : ∀ i, MeasurableSpace (β i)}
     {f g : Π i, Ω → β i} (hf : iIndepFun f μ) (h : ∀ i, f i =ᵐ[μ] g i) :
-    iIndepFun g μ := by
-  apply Kernel.iIndepFun.ae_eq
-  sorry
-
-#exit
-
+    iIndepFun g μ :=
+  Kernel.iIndepFun.ae_eq hf (by simp [h])
 
 nonrec lemma iIndepFun.comp {β γ : ι → Type*} {mβ : ∀ i, MeasurableSpace (β i)}
     {mγ : ∀ i, MeasurableSpace (γ i)} {f : ∀ i, Ω → β i}
@@ -721,17 +717,42 @@ lemma iIndepFun.indepFun_mul_left (hf_indep : iIndepFun f μ)
   Kernel.iIndepFun.indepFun_mul_left hf_indep hf_meas i j k hik hjk
 
 @[to_additive]
+lemma iIndepFun.indepFun_mul_left₀ (hf_indep : iIndepFun f μ)
+    (hf_meas : ∀ i, AEMeasurable (f i) μ) (i j k : ι) (hik : i ≠ k) (hjk : j ≠ k) :
+    IndepFun (f i * f j) (f k) μ := by
+  have : iIndepFun (fun i ↦ (hf_meas i).mk) μ :=
+    iIndepFun.ae_eq hf_indep (fun i ↦ (hf_meas i).ae_eq_mk)
+  apply IndepFun.ae_eq (this.indepFun_mul_left (fun i ↦ (hf_meas i).measurable_mk) i j k hik hjk)
+  · exact ((hf_meas i).ae_eq_mk.mul (hf_meas j).ae_eq_mk).symm
+  · exact ((hf_meas k).ae_eq_mk).symm
+
+@[to_additive]
 lemma iIndepFun.indepFun_mul_right (hf_indep : iIndepFun f μ)
     (hf_meas : ∀ i, Measurable (f i)) (i j k : ι) (hij : i ≠ j) (hik : i ≠ k) :
     IndepFun (f i) (f j * f k) μ :=
   Kernel.iIndepFun.indepFun_mul_right hf_indep hf_meas i j k hij hik
 
 @[to_additive]
-lemma iIndepFun.indepFun_mul_mul (hf_indep : iIndepFun f μ)
-    (hf_meas : ∀ i, Measurable (f i))
+lemma iIndepFun.indepFun_mul_right₀ (hf_indep : iIndepFun f μ)
+    (hf_meas : ∀ i, AEMeasurable (f i) μ) (i j k : ι) (hij : i ≠ j) (hik : i ≠ k) :
+    IndepFun (f i) (f j * f k) μ := by
+  have : iIndepFun (fun i ↦ (hf_meas i).mk) μ :=
+    iIndepFun.ae_eq hf_indep (fun i ↦ (hf_meas i).ae_eq_mk)
+  apply IndepFun.ae_eq (this.indepFun_mul_right (fun i ↦ (hf_meas i).measurable_mk) i j k hij hik)
+  · exact ((hf_meas i).ae_eq_mk).symm
+  · exact ((hf_meas j).ae_eq_mk.mul (hf_meas k).ae_eq_mk).symm
+
+@[to_additive]
+lemma iIndepFun.indepFun_mul_mul₀ (hf_indep : iIndepFun f μ)
+    (hf_meas : ∀ i, AEMeasurable (f i) μ)
     (i j k l : ι) (hik : i ≠ k) (hil : i ≠ l) (hjk : j ≠ k) (hjl : j ≠ l) :
-    IndepFun (f i * f j) (f k * f l) μ :=
-  Kernel.iIndepFun.indepFun_mul_mul hf_indep hf_meas i j k l hik hil hjk hjl
+    IndepFun (f i * f j) (f k * f l) μ := by
+  have : iIndepFun (fun i ↦ (hf_meas i).mk) μ :=
+    iIndepFun.ae_eq hf_indep (fun i ↦ (hf_meas i).ae_eq_mk)
+  apply IndepFun.ae_eq (this.indepFun_mul_mul (fun i ↦ (hf_meas i).measurable_mk) i j k l
+    hik hil hjk hjl)
+  · exact (((hf_meas i).ae_eq_mk).mul (hf_meas j).ae_eq_mk).symm
+  · exact ((hf_meas k).ae_eq_mk.mul (hf_meas l).ae_eq_mk).symm
 
 end Mul
 
@@ -745,10 +766,30 @@ lemma iIndepFun.indepFun_div_left (hf_indep : iIndepFun f μ)
   Kernel.iIndepFun.indepFun_div_left hf_indep hf_meas i j k hik hjk
 
 @[to_additive]
+lemma iIndepFun.indepFun_div_left₀ (hf_indep : iIndepFun f μ)
+    (hf_meas : ∀ i, AEMeasurable (f i) μ) (i j k : ι) (hik : i ≠ k) (hjk : j ≠ k) :
+    IndepFun (f i / f j) (f k) μ := by
+  have : iIndepFun (fun i ↦ (hf_meas i).mk) μ :=
+    iIndepFun.ae_eq hf_indep (fun i ↦ (hf_meas i).ae_eq_mk)
+  apply IndepFun.ae_eq (this.indepFun_div_left (fun i ↦ (hf_meas i).measurable_mk) i j k hik hjk)
+  · exact ((hf_meas i).ae_eq_mk.div (hf_meas j).ae_eq_mk).symm
+  · exact ((hf_meas k).ae_eq_mk).symm
+
+@[to_additive]
 lemma iIndepFun.indepFun_div_right (hf_indep : iIndepFun f μ)
     (hf_meas : ∀ i, Measurable (f i)) (i j k : ι) (hij : i ≠ j) (hik : i ≠ k) :
     IndepFun (f i) (f j / f k) μ :=
   Kernel.iIndepFun.indepFun_div_right hf_indep hf_meas i j k hij hik
+
+@[to_additive]
+lemma iIndepFun.indepFun_div_right₀ (hf_indep : iIndepFun f μ)
+    (hf_meas : ∀ i, AEMeasurable (f i) μ) (i j k : ι) (hij : i ≠ j) (hik : i ≠ k) :
+    IndepFun (f i) (f j / f k) μ := by
+  have : iIndepFun (fun i ↦ (hf_meas i).mk) μ :=
+    iIndepFun.ae_eq hf_indep (fun i ↦ (hf_meas i).ae_eq_mk)
+  apply IndepFun.ae_eq (this.indepFun_div_right (fun i ↦ (hf_meas i).measurable_mk) i j k hij hik)
+  · exact ((hf_meas i).ae_eq_mk).symm
+  · exact ((hf_meas j).ae_eq_mk.div (hf_meas k).ae_eq_mk).symm
 
 @[to_additive]
 lemma iIndepFun.indepFun_div_div (hf_indep : iIndepFun f μ)
@@ -756,6 +797,18 @@ lemma iIndepFun.indepFun_div_div (hf_indep : iIndepFun f μ)
     (i j k l : ι) (hik : i ≠ k) (hil : i ≠ l) (hjk : j ≠ k) (hjl : j ≠ l) :
     IndepFun (f i / f j) (f k / f l) μ :=
   Kernel.iIndepFun.indepFun_div_div hf_indep hf_meas i j k l hik hil hjk hjl
+
+@[to_additive]
+lemma iIndepFun.indepFun_div_div₀ (hf_indep : iIndepFun f μ)
+    (hf_meas : ∀ i, AEMeasurable (f i) μ)
+    (i j k l : ι) (hik : i ≠ k) (hil : i ≠ l) (hjk : j ≠ k) (hjl : j ≠ l) :
+    IndepFun (f i / f j) (f k / f l) μ := by
+  have : iIndepFun (fun i ↦ (hf_meas i).mk) μ :=
+    iIndepFun.ae_eq hf_indep (fun i ↦ (hf_meas i).ae_eq_mk)
+  apply IndepFun.ae_eq (this.indepFun_div_div (fun i ↦ (hf_meas i).measurable_mk) i j k l
+    hik hil hjk hjl)
+  · exact (((hf_meas i).ae_eq_mk).div (hf_meas j).ae_eq_mk).symm
+  · exact ((hf_meas k).ae_eq_mk.div (hf_meas l).ae_eq_mk).symm
 
 end Div
 
@@ -769,9 +822,26 @@ lemma iIndepFun.indepFun_finset_prod_of_not_mem (hf_Indep : iIndepFun f μ)
   Kernel.iIndepFun.indepFun_finset_prod_of_not_mem hf_Indep hf_meas hi
 
 @[to_additive]
+lemma iIndepFun.indepFun_finset_prod_of_not_mem₀ (hf_Indep : iIndepFun f μ)
+    (hf_meas : ∀ i, AEMeasurable (f i) μ) {s : Finset ι} {i : ι} (hi : i ∉ s) :
+    IndepFun (∏ j ∈ s, f j) (f i) μ := by
+  have : iIndepFun (fun i ↦ (hf_meas i).mk) μ :=
+    iIndepFun.ae_eq hf_Indep (fun i ↦ (hf_meas i).ae_eq_mk)
+  apply IndepFun.ae_eq (this.indepFun_finset_prod_of_not_mem (fun i ↦ (hf_meas i).measurable_mk)
+    hi)
+  · apply eventuallyEq_prod (fun i hi ↦ (hf_meas i).ae_eq_mk.symm)
+  · exact (hf_meas i).ae_eq_mk.symm
+
+@[to_additive]
 lemma iIndepFun.indepFun_prod_range_succ {f : ℕ → Ω → β} (hf_Indep : iIndepFun f μ)
     (hf_meas : ∀ i, Measurable (f i)) (n : ℕ) : IndepFun (∏ j ∈ Finset.range n, f j) (f n) μ :=
   Kernel.iIndepFun.indepFun_prod_range_succ hf_Indep hf_meas n
+
+@[to_additive]
+lemma iIndepFun.indepFun_prod_range_succ₀ {f : ℕ → Ω → β} (hf_Indep : iIndepFun f μ)
+    (hf_meas : ∀ i, AEMeasurable (f i) μ) (n : ℕ) :
+    IndepFun (∏ j ∈ Finset.range n, f j) (f n) μ :=
+  hf_Indep.indepFun_finset_prod_of_not_mem₀ hf_meas (by simp)
 
 end CommMonoid
 

--- a/Mathlib/Probability/Independence/Basic.lean
+++ b/Mathlib/Probability/Independence/Basic.lean
@@ -577,6 +577,15 @@ theorem iIndepFun_iff_measure_inter_preimage_eq_mul {ι : Type*} {β : ι → Ty
 
 alias ⟨iIndepFun.measure_inter_preimage_eq_mul, _⟩ := iIndepFun_iff_measure_inter_preimage_eq_mul
 
+theorem iIndepFun.ae_eq {β : ι → Type*} {mβ : ∀ i, MeasurableSpace (β i)}
+    {f g : Π i, Ω → β i} (hf : iIndepFun f μ) (h : ∀ i, f i =ᵐ[μ] g i) :
+    iIndepFun g μ := by
+  apply Kernel.iIndepFun.ae_eq
+  sorry
+
+#exit
+
+
 nonrec lemma iIndepFun.comp {β γ : ι → Type*} {mβ : ∀ i, MeasurableSpace (β i)}
     {mγ : ∀ i, MeasurableSpace (γ i)} {f : ∀ i, Ω → β i}
     (h : iIndepFun f μ) (g : ∀ i, β i → γ i) (hg : ∀ i, Measurable (g i)) :

--- a/Mathlib/Probability/Independence/Basic.lean
+++ b/Mathlib/Probability/Independence/Basic.lean
@@ -682,7 +682,6 @@ lemma iIndepFun.indepFun_prodMk₀ (hf_Indep : iIndepFun f μ) (hf_meas : ∀ i,
     IndepFun (fun a => (f i a, f j a)) (f k) μ :=
   Kernel.iIndepFun.indepFun_prodMk₀ hf_Indep (by simp [hf_meas]) i j k hik hjk
 
-open Finset in
 lemma iIndepFun.indepFun_prodMk_prodMk (h_indep : iIndepFun f μ) (hf : ∀ i, Measurable (f i))
     (i j k l : ι) (hik : i ≠ k) (hil : i ≠ l) (hjk : j ≠ k) (hjl : j ≠ l) :
     IndepFun (fun a ↦ (f i a, f j a)) (fun a ↦ (f k a, f l a)) μ :=
@@ -691,7 +690,6 @@ lemma iIndepFun.indepFun_prodMk_prodMk (h_indep : iIndepFun f μ) (hf : ∀ i, M
 @[deprecated (since := "2025-03-05")]
 alias iIndepFun.indepFun_prod_mk_prod_mk := iIndepFun.indepFun_prodMk_prodMk
 
-open Finset in
 lemma iIndepFun.indepFun_prodMk_prodMk₀ (h_indep : iIndepFun f μ) (hf : ∀ i, AEMeasurable (f i) μ)
     (i j k l : ι) (hik : i ≠ k) (hil : i ≠ l) (hjk : j ≠ k) (hjl : j ≠ l) :
     IndepFun (fun a ↦ (f i a, f j a)) (fun a ↦ (f k a, f l a)) μ :=

--- a/Mathlib/Probability/Independence/Basic.lean
+++ b/Mathlib/Probability/Independence/Basic.lean
@@ -65,6 +65,8 @@ when defining `μ` in the example above, the measurable space used is the last o
 Part A, Chapter 4.
 -/
 
+assert_not_exists MeasureTheory.Integrable
+
 open MeasureTheory MeasurableSpace Set
 
 open scoped MeasureTheory ENNReal

--- a/Mathlib/Probability/Independence/Basic.lean
+++ b/Mathlib/Probability/Independence/Basic.lean
@@ -719,10 +719,8 @@ lemma iIndepFun.indepFun_mul_left (hf_indep : iIndepFun f μ)
 @[to_additive]
 lemma iIndepFun.indepFun_mul_left₀ (hf_indep : iIndepFun f μ)
     (hf_meas : ∀ i, AEMeasurable (f i) μ) (i j k : ι) (hik : i ≠ k) (hjk : j ≠ k) :
-    IndepFun (f i * f j) (f k) μ := by
-  refine Kernel.iIndepFun.indepFun_mul_left₀ hf_indep ?_ i j k hik hjk
-  convert hf_meas
-  simp
+    IndepFun (f i * f j) (f k) μ :=
+  Kernel.iIndepFun.indepFun_mul_left₀ hf_indep (by simp [hf_meas]) i j k hik hjk
 
 @[to_additive]
 lemma iIndepFun.indepFun_mul_right (hf_indep : iIndepFun f μ)
@@ -733,24 +731,15 @@ lemma iIndepFun.indepFun_mul_right (hf_indep : iIndepFun f μ)
 @[to_additive]
 lemma iIndepFun.indepFun_mul_right₀ (hf_indep : iIndepFun f μ)
     (hf_meas : ∀ i, AEMeasurable (f i) μ) (i j k : ι) (hij : i ≠ j) (hik : i ≠ k) :
-    IndepFun (f i) (f j * f k) μ := by
-  have : iIndepFun (fun i ↦ (hf_meas i).mk) μ :=
-    iIndepFun.congr hf_indep (fun i ↦ (hf_meas i).ae_eq_mk)
-  apply IndepFun.congr (this.indepFun_mul_right (fun i ↦ (hf_meas i).measurable_mk) i j k hij hik)
-  · exact ((hf_meas i).ae_eq_mk).symm
-  · exact ((hf_meas j).ae_eq_mk.mul (hf_meas k).ae_eq_mk).symm
+    IndepFun (f i) (f j * f k) μ :=
+  Kernel.iIndepFun.indepFun_mul_right₀ hf_indep (by simp [hf_meas]) i j k hij hik
 
 @[to_additive]
 lemma iIndepFun.indepFun_mul_mul₀ (hf_indep : iIndepFun f μ)
     (hf_meas : ∀ i, AEMeasurable (f i) μ)
     (i j k l : ι) (hik : i ≠ k) (hil : i ≠ l) (hjk : j ≠ k) (hjl : j ≠ l) :
-    IndepFun (f i * f j) (f k * f l) μ := by
-  have : iIndepFun (fun i ↦ (hf_meas i).mk) μ :=
-    iIndepFun.congr hf_indep (fun i ↦ (hf_meas i).ae_eq_mk)
-  apply IndepFun.congr (this.indepFun_mul_mul (fun i ↦ (hf_meas i).measurable_mk) i j k l
-    hik hil hjk hjl)
-  · exact (((hf_meas i).ae_eq_mk).mul (hf_meas j).ae_eq_mk).symm
-  · exact ((hf_meas k).ae_eq_mk.mul (hf_meas l).ae_eq_mk).symm
+    IndepFun (f i * f j) (f k * f l) μ :=
+  Kernel.iIndepFun.indepFun_mul_mul₀ hf_indep (by simp [hf_meas]) i j k l hik hil hjk hjl
 
 end Mul
 

--- a/Mathlib/Probability/Independence/Basic.lean
+++ b/Mathlib/Probability/Independence/Basic.lean
@@ -764,12 +764,8 @@ lemma iIndepFun.indepFun_div_left (hf_indep : iIndepFun f μ)
 @[to_additive]
 lemma iIndepFun.indepFun_div_left₀ (hf_indep : iIndepFun f μ)
     (hf_meas : ∀ i, AEMeasurable (f i) μ) (i j k : ι) (hik : i ≠ k) (hjk : j ≠ k) :
-    IndepFun (f i / f j) (f k) μ := by
-  have : iIndepFun (fun i ↦ (hf_meas i).mk) μ :=
-    iIndepFun.congr hf_indep (fun i ↦ (hf_meas i).ae_eq_mk)
-  apply IndepFun.congr (this.indepFun_div_left (fun i ↦ (hf_meas i).measurable_mk) i j k hik hjk)
-  · exact ((hf_meas i).ae_eq_mk.div (hf_meas j).ae_eq_mk).symm
-  · exact ((hf_meas k).ae_eq_mk).symm
+    IndepFun (f i / f j) (f k) μ :=
+  Kernel.iIndepFun.indepFun_div_left₀ hf_indep (by simp [hf_meas]) i j k hik hjk
 
 @[to_additive]
 lemma iIndepFun.indepFun_div_right (hf_indep : iIndepFun f μ)
@@ -780,12 +776,8 @@ lemma iIndepFun.indepFun_div_right (hf_indep : iIndepFun f μ)
 @[to_additive]
 lemma iIndepFun.indepFun_div_right₀ (hf_indep : iIndepFun f μ)
     (hf_meas : ∀ i, AEMeasurable (f i) μ) (i j k : ι) (hij : i ≠ j) (hik : i ≠ k) :
-    IndepFun (f i) (f j / f k) μ := by
-  have : iIndepFun (fun i ↦ (hf_meas i).mk) μ :=
-    iIndepFun.congr hf_indep (fun i ↦ (hf_meas i).ae_eq_mk)
-  apply IndepFun.congr (this.indepFun_div_right (fun i ↦ (hf_meas i).measurable_mk) i j k hij hik)
-  · exact ((hf_meas i).ae_eq_mk).symm
-  · exact ((hf_meas j).ae_eq_mk.div (hf_meas k).ae_eq_mk).symm
+    IndepFun (f i) (f j / f k) μ :=
+  Kernel.iIndepFun.indepFun_div_right₀ hf_indep (by simp [hf_meas]) i j k hij hik
 
 @[to_additive]
 lemma iIndepFun.indepFun_div_div (hf_indep : iIndepFun f μ)
@@ -798,13 +790,8 @@ lemma iIndepFun.indepFun_div_div (hf_indep : iIndepFun f μ)
 lemma iIndepFun.indepFun_div_div₀ (hf_indep : iIndepFun f μ)
     (hf_meas : ∀ i, AEMeasurable (f i) μ)
     (i j k l : ι) (hik : i ≠ k) (hil : i ≠ l) (hjk : j ≠ k) (hjl : j ≠ l) :
-    IndepFun (f i / f j) (f k / f l) μ := by
-  have : iIndepFun (fun i ↦ (hf_meas i).mk) μ :=
-    iIndepFun.congr hf_indep (fun i ↦ (hf_meas i).ae_eq_mk)
-  apply IndepFun.congr (this.indepFun_div_div (fun i ↦ (hf_meas i).measurable_mk) i j k l
-    hik hil hjk hjl)
-  · exact (((hf_meas i).ae_eq_mk).div (hf_meas j).ae_eq_mk).symm
-  · exact ((hf_meas k).ae_eq_mk.div (hf_meas l).ae_eq_mk).symm
+    IndepFun (f i / f j) (f k / f l) μ :=
+  Kernel.iIndepFun.indepFun_div_div₀ hf_indep (by simp [hf_meas]) i j k l hik hil hjk hjl
 
 end Div
 
@@ -820,13 +807,8 @@ lemma iIndepFun.indepFun_finset_prod_of_not_mem (hf_Indep : iIndepFun f μ)
 @[to_additive]
 lemma iIndepFun.indepFun_finset_prod_of_not_mem₀ (hf_Indep : iIndepFun f μ)
     (hf_meas : ∀ i, AEMeasurable (f i) μ) {s : Finset ι} {i : ι} (hi : i ∉ s) :
-    IndepFun (∏ j ∈ s, f j) (f i) μ := by
-  have : iIndepFun (fun i ↦ (hf_meas i).mk) μ :=
-    iIndepFun.congr hf_Indep (fun i ↦ (hf_meas i).ae_eq_mk)
-  apply IndepFun.congr (this.indepFun_finset_prod_of_not_mem (fun i ↦ (hf_meas i).measurable_mk)
-    hi)
-  · apply eventuallyEq_prod (fun i hi ↦ (hf_meas i).ae_eq_mk.symm)
-  · exact (hf_meas i).ae_eq_mk.symm
+    IndepFun (∏ j ∈ s, f j) (f i) μ :=
+  Kernel.iIndepFun.indepFun_finset_prod_of_not_mem₀ hf_Indep (by simp [hf_meas]) hi
 
 @[to_additive]
 lemma iIndepFun.indepFun_prod_range_succ {f : ℕ → Ω → β} (hf_Indep : iIndepFun f μ)

--- a/Mathlib/Probability/Independence/Basic.lean
+++ b/Mathlib/Probability/Independence/Basic.lean
@@ -616,9 +616,7 @@ nonrec theorem IndepFun.symm {_ : MeasurableSpace β} {_ : MeasurableSpace β'}
 theorem IndepFun.congr {mβ : MeasurableSpace β} {mβ' : MeasurableSpace β'}
     {f' : Ω → β} {g' : Ω → β'} (hfg : IndepFun f g μ)
     (hf : f =ᵐ[μ] f') (hg : g =ᵐ[μ] g') : IndepFun f' g' μ := by
-  refine Kernel.IndepFun.congr' hfg ?_ ?_ <;>
-    simp only [ae_dirac_eq, Filter.eventually_pure, Kernel.const_apply]
-  exacts [hf, hg]
+  refine Kernel.IndepFun.congr' hfg ?_ ?_ <;> simpa
 
 @[deprecated (since := "2025-03-18")] alias IndepFun.ae_eq := IndepFun.congr
 

--- a/Mathlib/Probability/Independence/Basic.lean
+++ b/Mathlib/Probability/Independence/Basic.lean
@@ -577,10 +577,10 @@ theorem iIndepFun_iff_measure_inter_preimage_eq_mul {ι : Type*} {β : ι → Ty
 
 alias ⟨iIndepFun.measure_inter_preimage_eq_mul, _⟩ := iIndepFun_iff_measure_inter_preimage_eq_mul
 
-theorem iIndepFun.ae_eq {β : ι → Type*} {mβ : ∀ i, MeasurableSpace (β i)}
+theorem iIndepFun.congr {β : ι → Type*} {mβ : ∀ i, MeasurableSpace (β i)}
     {f g : Π i, Ω → β i} (hf : iIndepFun f μ) (h : ∀ i, f i =ᵐ[μ] g i) :
     iIndepFun g μ :=
-  Kernel.iIndepFun.ae_eq hf (by simp [h])
+  Kernel.iIndepFun.congr hf (by simp [h])
 
 nonrec lemma iIndepFun.comp {β γ : ι → Type*} {mβ : ∀ i, MeasurableSpace (β i)}
     {mγ : ∀ i, MeasurableSpace (γ i)} {f : ∀ i, Ω → β i}
@@ -613,12 +613,14 @@ theorem indepFun_iff_map_prod_eq_prod_map_map {mβ : MeasurableSpace β} {mβ' :
 nonrec theorem IndepFun.symm {_ : MeasurableSpace β} {_ : MeasurableSpace β'}
     (hfg : IndepFun f g μ) : IndepFun g f μ := hfg.symm
 
-theorem IndepFun.ae_eq {mβ : MeasurableSpace β} {mβ' : MeasurableSpace β'}
+theorem IndepFun.congr {mβ : MeasurableSpace β} {mβ' : MeasurableSpace β'}
     {f' : Ω → β} {g' : Ω → β'} (hfg : IndepFun f g μ)
     (hf : f =ᵐ[μ] f') (hg : g =ᵐ[μ] g') : IndepFun f' g' μ := by
-  refine Kernel.IndepFun.ae_eq hfg ?_ ?_ <;>
+  refine Kernel.IndepFun.congr hfg ?_ ?_ <;>
     simp only [ae_dirac_eq, Filter.eventually_pure, Kernel.const_apply]
   exacts [hf, hg]
+
+@[deprecated (since := "2025-03-18")] alias IndepFun.ae_eq := IndepFun.congr
 
 theorem IndepFun.comp {_mβ : MeasurableSpace β} {_mβ' : MeasurableSpace β'}
     {_mγ : MeasurableSpace γ} {_mγ' : MeasurableSpace γ'} {φ : β → γ} {ψ : β' → γ'}
@@ -721,8 +723,8 @@ lemma iIndepFun.indepFun_mul_left₀ (hf_indep : iIndepFun f μ)
     (hf_meas : ∀ i, AEMeasurable (f i) μ) (i j k : ι) (hik : i ≠ k) (hjk : j ≠ k) :
     IndepFun (f i * f j) (f k) μ := by
   have : iIndepFun (fun i ↦ (hf_meas i).mk) μ :=
-    iIndepFun.ae_eq hf_indep (fun i ↦ (hf_meas i).ae_eq_mk)
-  apply IndepFun.ae_eq (this.indepFun_mul_left (fun i ↦ (hf_meas i).measurable_mk) i j k hik hjk)
+    iIndepFun.congr hf_indep (fun i ↦ (hf_meas i).ae_eq_mk)
+  apply IndepFun.congr (this.indepFun_mul_left (fun i ↦ (hf_meas i).measurable_mk) i j k hik hjk)
   · exact ((hf_meas i).ae_eq_mk.mul (hf_meas j).ae_eq_mk).symm
   · exact ((hf_meas k).ae_eq_mk).symm
 
@@ -737,8 +739,8 @@ lemma iIndepFun.indepFun_mul_right₀ (hf_indep : iIndepFun f μ)
     (hf_meas : ∀ i, AEMeasurable (f i) μ) (i j k : ι) (hij : i ≠ j) (hik : i ≠ k) :
     IndepFun (f i) (f j * f k) μ := by
   have : iIndepFun (fun i ↦ (hf_meas i).mk) μ :=
-    iIndepFun.ae_eq hf_indep (fun i ↦ (hf_meas i).ae_eq_mk)
-  apply IndepFun.ae_eq (this.indepFun_mul_right (fun i ↦ (hf_meas i).measurable_mk) i j k hij hik)
+    iIndepFun.congr hf_indep (fun i ↦ (hf_meas i).ae_eq_mk)
+  apply IndepFun.congr (this.indepFun_mul_right (fun i ↦ (hf_meas i).measurable_mk) i j k hij hik)
   · exact ((hf_meas i).ae_eq_mk).symm
   · exact ((hf_meas j).ae_eq_mk.mul (hf_meas k).ae_eq_mk).symm
 
@@ -748,8 +750,8 @@ lemma iIndepFun.indepFun_mul_mul₀ (hf_indep : iIndepFun f μ)
     (i j k l : ι) (hik : i ≠ k) (hil : i ≠ l) (hjk : j ≠ k) (hjl : j ≠ l) :
     IndepFun (f i * f j) (f k * f l) μ := by
   have : iIndepFun (fun i ↦ (hf_meas i).mk) μ :=
-    iIndepFun.ae_eq hf_indep (fun i ↦ (hf_meas i).ae_eq_mk)
-  apply IndepFun.ae_eq (this.indepFun_mul_mul (fun i ↦ (hf_meas i).measurable_mk) i j k l
+    iIndepFun.congr hf_indep (fun i ↦ (hf_meas i).ae_eq_mk)
+  apply IndepFun.congr (this.indepFun_mul_mul (fun i ↦ (hf_meas i).measurable_mk) i j k l
     hik hil hjk hjl)
   · exact (((hf_meas i).ae_eq_mk).mul (hf_meas j).ae_eq_mk).symm
   · exact ((hf_meas k).ae_eq_mk.mul (hf_meas l).ae_eq_mk).symm
@@ -770,8 +772,8 @@ lemma iIndepFun.indepFun_div_left₀ (hf_indep : iIndepFun f μ)
     (hf_meas : ∀ i, AEMeasurable (f i) μ) (i j k : ι) (hik : i ≠ k) (hjk : j ≠ k) :
     IndepFun (f i / f j) (f k) μ := by
   have : iIndepFun (fun i ↦ (hf_meas i).mk) μ :=
-    iIndepFun.ae_eq hf_indep (fun i ↦ (hf_meas i).ae_eq_mk)
-  apply IndepFun.ae_eq (this.indepFun_div_left (fun i ↦ (hf_meas i).measurable_mk) i j k hik hjk)
+    iIndepFun.congr hf_indep (fun i ↦ (hf_meas i).ae_eq_mk)
+  apply IndepFun.congr (this.indepFun_div_left (fun i ↦ (hf_meas i).measurable_mk) i j k hik hjk)
   · exact ((hf_meas i).ae_eq_mk.div (hf_meas j).ae_eq_mk).symm
   · exact ((hf_meas k).ae_eq_mk).symm
 
@@ -786,8 +788,8 @@ lemma iIndepFun.indepFun_div_right₀ (hf_indep : iIndepFun f μ)
     (hf_meas : ∀ i, AEMeasurable (f i) μ) (i j k : ι) (hij : i ≠ j) (hik : i ≠ k) :
     IndepFun (f i) (f j / f k) μ := by
   have : iIndepFun (fun i ↦ (hf_meas i).mk) μ :=
-    iIndepFun.ae_eq hf_indep (fun i ↦ (hf_meas i).ae_eq_mk)
-  apply IndepFun.ae_eq (this.indepFun_div_right (fun i ↦ (hf_meas i).measurable_mk) i j k hij hik)
+    iIndepFun.congr hf_indep (fun i ↦ (hf_meas i).ae_eq_mk)
+  apply IndepFun.congr (this.indepFun_div_right (fun i ↦ (hf_meas i).measurable_mk) i j k hij hik)
   · exact ((hf_meas i).ae_eq_mk).symm
   · exact ((hf_meas j).ae_eq_mk.div (hf_meas k).ae_eq_mk).symm
 
@@ -804,8 +806,8 @@ lemma iIndepFun.indepFun_div_div₀ (hf_indep : iIndepFun f μ)
     (i j k l : ι) (hik : i ≠ k) (hil : i ≠ l) (hjk : j ≠ k) (hjl : j ≠ l) :
     IndepFun (f i / f j) (f k / f l) μ := by
   have : iIndepFun (fun i ↦ (hf_meas i).mk) μ :=
-    iIndepFun.ae_eq hf_indep (fun i ↦ (hf_meas i).ae_eq_mk)
-  apply IndepFun.ae_eq (this.indepFun_div_div (fun i ↦ (hf_meas i).measurable_mk) i j k l
+    iIndepFun.congr hf_indep (fun i ↦ (hf_meas i).ae_eq_mk)
+  apply IndepFun.congr (this.indepFun_div_div (fun i ↦ (hf_meas i).measurable_mk) i j k l
     hik hil hjk hjl)
   · exact (((hf_meas i).ae_eq_mk).div (hf_meas j).ae_eq_mk).symm
   · exact ((hf_meas k).ae_eq_mk.div (hf_meas l).ae_eq_mk).symm
@@ -826,8 +828,8 @@ lemma iIndepFun.indepFun_finset_prod_of_not_mem₀ (hf_Indep : iIndepFun f μ)
     (hf_meas : ∀ i, AEMeasurable (f i) μ) {s : Finset ι} {i : ι} (hi : i ∉ s) :
     IndepFun (∏ j ∈ s, f j) (f i) μ := by
   have : iIndepFun (fun i ↦ (hf_meas i).mk) μ :=
-    iIndepFun.ae_eq hf_Indep (fun i ↦ (hf_meas i).ae_eq_mk)
-  apply IndepFun.ae_eq (this.indepFun_finset_prod_of_not_mem (fun i ↦ (hf_meas i).measurable_mk)
+    iIndepFun.congr hf_Indep (fun i ↦ (hf_meas i).ae_eq_mk)
+  apply IndepFun.congr (this.indepFun_finset_prod_of_not_mem (fun i ↦ (hf_meas i).measurable_mk)
     hi)
   · apply eventuallyEq_prod (fun i hi ↦ (hf_meas i).ae_eq_mk.symm)
   · exact (hf_meas i).ae_eq_mk.symm

--- a/Mathlib/Probability/Independence/Kernel.lean
+++ b/Mathlib/Probability/Independence/Kernel.lean
@@ -1315,10 +1315,40 @@ lemma iIndepFun.indepFun_div_left (hf_indep : iIndepFun f κ μ)
   simpa using this.comp (measurable_fst.div measurable_snd) measurable_id
 
 @[to_additive]
+lemma iIndepFun.indepFun_div_left₀ (hf_indep : iIndepFun f κ μ)
+    (hf_meas : ∀ i, AEMeasurable (f i) (κ ∘ₘ μ)) (i j k : ι) (hik : i ≠ k) (hjk : j ≠ k) :
+    IndepFun (f i / f j) (f k) κ μ := by
+  have h : IndepFun ((hf_meas i).mk (f i) / (hf_meas j).mk (f j)) ((hf_meas k).mk (f k)) κ μ := by
+    refine iIndepFun.indepFun_div_left ?_ (fun i ↦ (hf_meas i).measurable_mk) _ _ _ hik hjk
+    exact iIndepFun.congr' hf_indep fun i ↦ Measure.ae_ae_of_ae_comp (hf_meas i).ae_eq_mk
+  refine IndepFun.congr' h ?_ ?_
+  · filter_upwards [Measure.ae_ae_of_ae_comp (hf_meas i).ae_eq_mk,
+      Measure.ae_ae_of_ae_comp (hf_meas j).ae_eq_mk] with a hi hj
+    filter_upwards [hi, hj] with ω hωi hωj
+    simp [hωi, hωj]
+  · filter_upwards [Measure.ae_ae_of_ae_comp (hf_meas k).ae_eq_mk] with a hk
+    filter_upwards [hk] with ω hωk using by rw [hωk]
+
+@[to_additive]
 lemma iIndepFun.indepFun_div_right (hf_indep : iIndepFun f κ μ)
     (hf_meas : ∀ i, Measurable (f i)) (i j k : ι) (hij : i ≠ j) (hik : i ≠ k) :
     IndepFun (f i) (f j / f k) κ μ :=
   (hf_indep.indepFun_div_left hf_meas _ _ _ hij.symm hik.symm).symm
+
+@[to_additive]
+lemma iIndepFun.indepFun_div_right₀ (hf_indep : iIndepFun f κ μ)
+    (hf_meas : ∀ i, AEMeasurable (f i) (κ ∘ₘ μ)) (i j k : ι) (hij : i ≠ j) (hik : i ≠ k) :
+    IndepFun (f i) (f j / f k) κ μ := by
+  have h : IndepFun ((hf_meas i).mk (f i)) ((hf_meas j).mk (f j) / (hf_meas k).mk (f k)) κ μ := by
+    refine iIndepFun.indepFun_div_right ?_ (fun i ↦ (hf_meas i).measurable_mk) _ _ _ hij hik
+    exact iIndepFun.congr' hf_indep fun i ↦ Measure.ae_ae_of_ae_comp (hf_meas i).ae_eq_mk
+  refine IndepFun.congr' h ?_ ?_
+  · filter_upwards [Measure.ae_ae_of_ae_comp (hf_meas i).ae_eq_mk] with a hi
+    filter_upwards [hi] with ω hω using by rw [hω]
+  · filter_upwards [Measure.ae_ae_of_ae_comp (hf_meas j).ae_eq_mk,
+      Measure.ae_ae_of_ae_comp (hf_meas k).ae_eq_mk] with a hj hk
+    filter_upwards [hj, hk] with ω hωj hωk
+    simp [hωj, hωk]
 
 @[to_additive]
 lemma iIndepFun.indepFun_div_div (hf_indep : iIndepFun f κ μ)
@@ -1327,6 +1357,25 @@ lemma iIndepFun.indepFun_div_div (hf_indep : iIndepFun f κ μ)
     IndepFun (f i / f j) (f k / f l) κ μ :=
   (hf_indep.indepFun_prodMk_prodMk hf_meas i j k l hik hil hjk hjl).comp
     measurable_div measurable_div
+
+@[to_additive]
+lemma iIndepFun.indepFun_div_div₀ (hf_indep : iIndepFun f κ μ)
+    (hf_meas : ∀ i, AEMeasurable (f i) (κ ∘ₘ μ))
+    (i j k l : ι) (hik : i ≠ k) (hil : i ≠ l) (hjk : j ≠ k) (hjl : j ≠ l) :
+    IndepFun (f i / f j) (f k / f l) κ μ := by
+  have h : IndepFun ((hf_meas i).mk (f i) / (hf_meas j).mk (f j))
+      ((hf_meas k).mk (f k) / (hf_meas l).mk (f l)) κ μ := by
+    refine iIndepFun.indepFun_div_div ?_ (fun i ↦ (hf_meas i).measurable_mk) _ _ _ _ hik hil hjk hjl
+    exact iIndepFun.congr' hf_indep fun i ↦ Measure.ae_ae_of_ae_comp (hf_meas i).ae_eq_mk
+  refine IndepFun.congr' h ?_ ?_
+  · filter_upwards [Measure.ae_ae_of_ae_comp (hf_meas i).ae_eq_mk,
+      Measure.ae_ae_of_ae_comp (hf_meas j).ae_eq_mk] with a hi hj
+    filter_upwards [hi, hj] with ω hωi hωj
+    simp [hωi, hωj]
+  · filter_upwards [Measure.ae_ae_of_ae_comp (hf_meas k).ae_eq_mk,
+      Measure.ae_ae_of_ae_comp (hf_meas l).ae_eq_mk] with a hk hl
+    filter_upwards [hk, hl] with ω hωk hωl
+    simp [hωk, hωl]
 
 end Div
 

--- a/Mathlib/Probability/Independence/Kernel.lean
+++ b/Mathlib/Probability/Independence/Kernel.lean
@@ -912,7 +912,7 @@ theorem iIndepFun_iff_measure_inter_preimage_eq_mul {ι : Type*} {β : ι → Ty
 
 alias ⟨iIndepFun.measure_inter_preimage_eq_mul, _⟩ := iIndepFun_iff_measure_inter_preimage_eq_mul
 
-theorem iIndepFun.ae_eq {β : ι → Type*} {mβ : ∀ i, MeasurableSpace (β i)}
+theorem iIndepFun.congr {β : ι → Type*} {mβ : ∀ i, MeasurableSpace (β i)}
     {f g : Π i, Ω → β i} (hf : iIndepFun f κ μ)
     (h : ∀ i, ∀ᵐ a ∂μ, f i =ᵐ[κ a] g i) :
     iIndepFun g κ μ := by
@@ -959,7 +959,7 @@ theorem indepFun_iff_indepSet_preimage {mβ : MeasurableSpace β} {mβ' : Measur
 nonrec theorem IndepFun.symm {_ : MeasurableSpace β} {_ : MeasurableSpace β'}
     (hfg : IndepFun f g κ μ) : IndepFun g f κ μ := hfg.symm
 
-theorem IndepFun.ae_eq {mβ : MeasurableSpace β} {mβ' : MeasurableSpace β'}
+theorem IndepFun.congr {mβ : MeasurableSpace β} {mβ' : MeasurableSpace β'}
     {f' : Ω → β} {g' : Ω → β'} (hfg : IndepFun f g κ μ)
     (hf : ∀ᵐ a ∂μ, f =ᵐ[κ a] f') (hg : ∀ᵐ a ∂μ, g =ᵐ[κ a] g') :
     IndepFun f' g' κ μ := by
@@ -968,6 +968,8 @@ theorem IndepFun.ae_eq {mβ : MeasurableSpace β} {mβ' : MeasurableSpace β'}
   have h1 : f ⁻¹' A =ᵐ[κ a] f' ⁻¹' A := hf'.fun_comp A
   have h2 : g ⁻¹' B =ᵐ[κ a] g' ⁻¹' B := hg'.fun_comp B
   rwa [← measure_congr h1, ← measure_congr h2, ← measure_congr (h1.inter h2)]
+
+@[deprecated (since := "2025-03-18")] alias IndepFun.ae_eq := IndepFun.congr
 
 theorem IndepFun.comp {mβ : MeasurableSpace β} {mβ' : MeasurableSpace β'}
     {mγ : MeasurableSpace γ} {mγ' : MeasurableSpace γ'} {φ : β → γ} {ψ : β' → γ'}

--- a/Mathlib/Probability/Independence/Kernel.lean
+++ b/Mathlib/Probability/Independence/Kernel.lean
@@ -953,10 +953,8 @@ lemma iIndepFun.comp₀ {β γ : ι → Type*} {mβ : ∀ i, MeasurableSpace (β
     iIndepFun (fun i ↦ g i ∘ f i) κ μ := by
   have h : iIndepFun (fun i ↦ ((hg i).mk (g i)) ∘ f i) κ μ :=
     iIndepFun.comp h (fun i ↦ (hg i).mk (g i)) fun i ↦ (hg i).measurable_mk
-  have h_ae i := ae_of_ae_map (hf i) (hg i).ae_eq_mk
-  refine iIndepFun.congr' h fun i ↦ ?_
-  filter_upwards [Measure.ae_ae_of_ae_comp (h_ae i)] with a ha
-  filter_upwards [ha] with ω hω using hω.symm
+  have h_ae i := ae_of_ae_map (hf i) (hg i).ae_eq_mk.symm
+  exact iIndepFun.congr' h fun i ↦ Measure.ae_ae_of_ae_comp (h_ae i)
 
 theorem indepFun_iff_indepSet_preimage {mβ : MeasurableSpace β} {mβ' : MeasurableSpace β'}
     [IsZeroOrMarkovKernel κ] (hf : Measurable f) (hg : Measurable g) :
@@ -1188,8 +1186,7 @@ theorem iIndepFun.indepFun_prodMk₀ (hf_Indep : iIndepFun f κ μ)
       Measure.ae_ae_of_ae_comp (hf_meas j).ae_eq_mk] with a hi hj
     filter_upwards [hi, hj] with ω hωi hωj
     rw [← hωi, ← hωj]
-  · filter_upwards [Measure.ae_ae_of_ae_comp (hf_meas k).ae_eq_mk] with a hk
-    filter_upwards [hk] with ω hωk using by rw [hωk]
+  · exact Measure.ae_ae_of_ae_comp (hf_meas k).ae_eq_mk.symm
 
 open Finset in
 lemma iIndepFun.indepFun_prodMk_prodMk (hf_indep : iIndepFun f κ μ)
@@ -1364,10 +1361,8 @@ theorem iIndepFun.indepFun_finset_prod_of_not_mem₀ (hf_Indep : iIndepFun f κ 
     filter_upwards [this] with a ha
     filter_upwards [ae_all_iff.2 ha] with ω hω
     simp only [Finset.prod_apply]
-    refine Finset.prod_congr rfl fun i hi ↦ ?_
-    exact (hω ⟨i, hi⟩).symm
-  · filter_upwards [Measure.ae_ae_of_ae_comp (hf_meas i).ae_eq_mk] with a hi
-    filter_upwards [hi] with ω hω using by rw [hω]
+    exact Finset.prod_congr rfl fun i hi ↦ (hω ⟨i, hi⟩).symm
+  · exact Measure.ae_ae_of_ae_comp (hf_meas i).ae_eq_mk.symm
 
 @[to_additive]
 theorem iIndepFun.indepFun_prod_range_succ {f : ℕ → Ω → β}

--- a/Mathlib/Probability/Independence/Kernel.lean
+++ b/Mathlib/Probability/Independence/Kernel.lean
@@ -1222,12 +1222,49 @@ lemma iIndepFun.indepFun_mul_right (hf_indep : iIndepFun f κ μ)
   (hf_indep.indepFun_mul_left hf_meas _ _ _ hij.symm hik.symm).symm
 
 @[to_additive]
+lemma iIndepFun.indepFun_mul_right₀ (hf_indep : iIndepFun f κ μ)
+    (hf_meas : ∀ i, AEMeasurable (f i) (κ ∘ₘ μ)) (i j k : ι) (hij : i ≠ j) (hik : i ≠ k) :
+    IndepFun (f i) (f j * f k) κ μ := by
+  have h : IndepFun ((hf_meas i).mk (f i)) ((hf_meas j).mk (f j) * (hf_meas k).mk (f k)) κ μ := by
+    refine iIndepFun.indepFun_mul_right ?_ (fun i ↦ (hf_meas i).measurable_mk) _ _ _ hij hik
+    exact iIndepFun.congr' hf_indep fun i ↦ Measure.ae_ae_of_ae_comp (hf_meas i).ae_eq_mk
+  refine IndepFun.congr' h ?_ ?_
+  · filter_upwards [Measure.ae_ae_of_ae_comp (hf_meas i).ae_eq_mk] with a hi
+    filter_upwards [hi] with ω hω using by rw [hω]
+  · filter_upwards [Measure.ae_ae_of_ae_comp (hf_meas j).ae_eq_mk,
+      Measure.ae_ae_of_ae_comp (hf_meas k).ae_eq_mk] with a hj hk
+    filter_upwards [hj, hk] with ω hωj hωk
+    simp only [Pi.mul_apply]
+    rw [← hωj, ← hωk]
+
+@[to_additive]
 lemma iIndepFun.indepFun_mul_mul (hf_indep : iIndepFun f κ μ)
     (hf_meas : ∀ i, Measurable (f i))
     (i j k l : ι) (hik : i ≠ k) (hil : i ≠ l) (hjk : j ≠ k) (hjl : j ≠ l) :
     IndepFun (f i * f j) (f k * f l) κ μ :=
   (hf_indep.indepFun_prodMk_prodMk hf_meas i j k l hik hil hjk hjl).comp
     measurable_mul measurable_mul
+
+@[to_additive]
+lemma iIndepFun.indepFun_mul_mul₀ (hf_indep : iIndepFun f κ μ)
+    (hf_meas : ∀ i, AEMeasurable (f i) (κ ∘ₘ μ))
+    (i j k l : ι) (hik : i ≠ k) (hil : i ≠ l) (hjk : j ≠ k) (hjl : j ≠ l) :
+    IndepFun (f i * f j) (f k * f l) κ μ := by
+  have h : IndepFun ((hf_meas i).mk (f i) * (hf_meas j).mk (f j))
+      ((hf_meas k).mk (f k) * (hf_meas l).mk (f l)) κ μ := by
+    refine iIndepFun.indepFun_mul_mul ?_ (fun i ↦ (hf_meas i).measurable_mk) _ _ _ _ hik hil hjk hjl
+    exact iIndepFun.congr' hf_indep fun i ↦ Measure.ae_ae_of_ae_comp (hf_meas i).ae_eq_mk
+  refine IndepFun.congr' h ?_ ?_
+  · filter_upwards [Measure.ae_ae_of_ae_comp (hf_meas i).ae_eq_mk,
+      Measure.ae_ae_of_ae_comp (hf_meas j).ae_eq_mk] with a hi hj
+    filter_upwards [hi, hj] with ω hωi hωj
+    simp only [Pi.mul_apply]
+    rw [← hωi, ← hωj]
+  · filter_upwards [Measure.ae_ae_of_ae_comp (hf_meas k).ae_eq_mk,
+      Measure.ae_ae_of_ae_comp (hf_meas l).ae_eq_mk] with a hk hl
+    filter_upwards [hk, hl] with ω hωk hωl
+    simp only [Pi.mul_apply]
+    rw [← hωk, ← hωl]
 
 end Mul
 

--- a/Mathlib/Probability/Independence/Kernel.lean
+++ b/Mathlib/Probability/Independence/Kernel.lean
@@ -1182,6 +1182,21 @@ theorem iIndepFun.indepFun_prodMk (hf_Indep : iIndepFun f κ μ)
 @[deprecated (since := "2025-03-05")]
 alias ProbabilityTheory.Kernel.iIndepFun.indepFun_prod_mk := iIndepFun.indepFun_prodMk
 
+theorem iIndepFun.indepFun_prodMk₀ (hf_Indep : iIndepFun f κ μ)
+    (hf_meas : ∀ i, AEMeasurable (f i) (κ ∘ₘ μ)) (i j k : ι) (hik : i ≠ k) (hjk : j ≠ k) :
+    IndepFun (fun a ↦ (f i a, f j a)) (f k) κ μ := by
+  have h : IndepFun (fun a ↦ ((hf_meas i).mk (f i) a, (hf_meas j).mk (f j) a))
+      ((hf_meas k).mk (f k)) κ μ := by
+    refine iIndepFun.indepFun_prodMk ?_ (fun i ↦ (hf_meas i).measurable_mk) _ _ _ hik hjk
+    exact iIndepFun.congr' hf_Indep fun i ↦ Measure.ae_ae_of_ae_comp (hf_meas i).ae_eq_mk
+  refine IndepFun.congr' h ?_ ?_
+  · filter_upwards [Measure.ae_ae_of_ae_comp (hf_meas i).ae_eq_mk,
+      Measure.ae_ae_of_ae_comp (hf_meas j).ae_eq_mk] with a hi hj
+    filter_upwards [hi, hj] with ω hωi hωj
+    rw [← hωi, ← hωj]
+  · filter_upwards [Measure.ae_ae_of_ae_comp (hf_meas k).ae_eq_mk] with a hk
+    filter_upwards [hk] with ω hωk using by rw [hωk]
+
 open Finset in
 lemma iIndepFun.indepFun_prodMk_prodMk (hf_indep : iIndepFun f κ μ)
     (hf_meas : ∀ i, Measurable (f i))
@@ -1196,6 +1211,25 @@ lemma iIndepFun.indepFun_prodMk_prodMk (hf_indep : iIndepFun f κ μ)
 @[deprecated (since := "2025-03-05")]
 alias ProbabilityTheory.Kernel.iIndepFun.indepFun_prod_mk_prod_mk :=
   iIndepFun.indepFun_prodMk_prodMk
+
+theorem iIndepFun.indepFun_prodMk_prodMk₀ (hf_indep : iIndepFun f κ μ)
+    (hf_meas : ∀ i, AEMeasurable (f i) (κ ∘ₘ μ))
+    (i j k l : ι) (hik : i ≠ k) (hil : i ≠ l) (hjk : j ≠ k) (hjl : j ≠ l) :
+    IndepFun (fun a ↦ (f i a, f j a)) (fun a ↦ (f k a, f l a)) κ μ := by
+  have h : IndepFun (fun a ↦ ((hf_meas i).mk (f i) a, (hf_meas j).mk (f j) a))
+      (fun a ↦ ((hf_meas k).mk (f k) a, (hf_meas l).mk (f l) a)) κ μ := by
+    refine iIndepFun.indepFun_prodMk_prodMk ?_ (fun i ↦ (hf_meas i).measurable_mk) _ _ _ _ hik hil
+      hjk hjl
+    exact iIndepFun.congr' hf_indep fun i ↦ Measure.ae_ae_of_ae_comp (hf_meas i).ae_eq_mk
+  refine IndepFun.congr' h ?_ ?_
+  · filter_upwards [Measure.ae_ae_of_ae_comp (hf_meas i).ae_eq_mk,
+      Measure.ae_ae_of_ae_comp (hf_meas j).ae_eq_mk] with a hi hj
+    filter_upwards [hi, hj] with ω hωi hωj
+    rw [← hωi, ← hωj]
+  · filter_upwards [Measure.ae_ae_of_ae_comp (hf_meas k).ae_eq_mk,
+      Measure.ae_ae_of_ae_comp (hf_meas l).ae_eq_mk] with a hk hl
+    filter_upwards [hk, hl] with ω hωk hωl
+    rw [← hωk, ← hωl]
 
 end iIndepFun
 

--- a/Mathlib/Probability/Independence/Kernel.lean
+++ b/Mathlib/Probability/Independence/Kernel.lean
@@ -922,10 +922,10 @@ theorem iIndepFun.congr' {β : ι → Type*} {mβ : ∀ i, MeasurableSpace (β i
   have : ∀ᵐ a ∂μ, ∀ i ∈ S, f i =ᵐ[κ a] g i :=
     (ae_ball_iff (Finset.countable_toSet S)).2 (fun i hi ↦ h i)
   filter_upwards [this, hf S hmeas] with a ha h'a
-  have A i (hi : i ∈ S) : (κ a) (f i ⁻¹' sets i) = (κ a) (g i ⁻¹' sets i) := by
+  have A i (hi : i ∈ S) : (κ a) (g i ⁻¹' sets i) = (κ a) (f i ⁻¹' sets i) := by
     apply measure_congr
     filter_upwards [ha i hi] with ω hω
-    change (f i ω ∈ sets i) = (g i ω ∈ sets i)
+    change (g i ω ∈ sets i) = (f i ω ∈ sets i)
     simp [hω]
   have B : (κ a) (⋂ i ∈ S, g i ⁻¹' sets i) = (κ a) (⋂ i ∈ S, f i ⁻¹' sets i) := by
     apply measure_congr
@@ -933,7 +933,7 @@ theorem iIndepFun.congr' {β : ι → Type*} {mβ : ∀ i, MeasurableSpace (β i
     change (ω ∈ ⋂ i ∈ S, g i ⁻¹' sets i) = (ω ∈ ⋂ i ∈ S, f i ⁻¹' sets i)
     simp +contextual [hω]
   convert h'a using 2 with i hi
-  exact (A i hi).symm
+  exact A i hi
 
 lemma iIndepFun.comp {β γ : ι → Type*} {mβ : ∀ i, MeasurableSpace (β i)}
     {mγ : ∀ i, MeasurableSpace (γ i)} {f : ∀ i, Ω → β i}
@@ -1135,8 +1135,20 @@ theorem iIndepFun.indepFun_finset₀ (S T : Finset ι) (hST : Disjoint S T)
     refine iIndepFun.indepFun_finset S T hST ?_ fun i ↦ (hf_meas i).measurable_mk
     exact iIndepFun.congr' hf_Indep fun i ↦ Measure.ae_ae_of_ae_comp (hf_meas i).ae_eq_mk
   refine IndepFun.congr' h ?_ ?_
-  · sorry
-  · sorry
+  · have : ∀ᵐ (a : α) ∂μ, ∀ (i : S), f i =ᵐ[κ a] (hf_meas i).mk  := by
+      rw [ae_all_iff]
+      exact fun i ↦ Measure.ae_ae_of_ae_comp (hf_meas i).ae_eq_mk
+    filter_upwards [this] with a ha
+    filter_upwards [ae_all_iff.2 ha] with b hb
+    ext i
+    exact (hb i).symm
+  · have : ∀ᵐ (a : α) ∂μ, ∀ (i : T), f i =ᵐ[κ a] (hf_meas i).mk  := by
+      rw [ae_all_iff]
+      exact fun i ↦ Measure.ae_ae_of_ae_comp (hf_meas i).ae_eq_mk
+    filter_upwards [this] with a ha
+    filter_upwards [ae_all_iff.2 ha] with b hb
+    ext i
+    exact (hb i).symm
 
 theorem iIndepFun.indepFun_prodMk (hf_Indep : iIndepFun f κ μ)
     (hf_meas : ∀ i, Measurable (f i)) (i j k : ι) (hik : i ≠ k) (hjk : j ≠ k) :

--- a/Mathlib/Probability/Independence/Kernel.lean
+++ b/Mathlib/Probability/Independence/Kernel.lean
@@ -912,6 +912,29 @@ theorem iIndepFun_iff_measure_inter_preimage_eq_mul {ι : Type*} {β : ι → Ty
 
 alias ⟨iIndepFun.measure_inter_preimage_eq_mul, _⟩ := iIndepFun_iff_measure_inter_preimage_eq_mul
 
+theorem iIndepFun.ae_eq {β : ι → Type*} {mβ : ∀ i, MeasurableSpace (β i)}
+    {f g : Π i, Ω → β i} (hf : iIndepFun f κ μ)
+    (h : ∀ i, ∀ᵐ a ∂μ, f i =ᵐ[κ a] g i) :
+    iIndepFun g κ μ := by
+  rw [iIndepFun_iff_measure_inter_preimage_eq_mul] at hf ⊢
+  intro S sets hmeas
+  have : ∀ᵐ a ∂μ, ∀ i ∈ S, f i =ᵐ[κ a] g i :=
+    (ae_ball_iff (Finset.countable_toSet S)).2 (fun i hi ↦ h i)
+  filter_upwards [this, hf S hmeas] with a ha h'a
+  have A i (hi : i ∈ S) : (κ a) (f i ⁻¹' sets i) = (κ a) (g i ⁻¹' sets i) := by
+    apply measure_congr
+    filter_upwards [ha i hi] with ω hω
+    change (f i ω ∈ sets i) = (g i ω ∈ sets i)
+    simp [hω]
+  have B : (κ a) (⋂ i ∈ S, g i ⁻¹' sets i) = (κ a) (⋂ i ∈ S, f i ⁻¹' sets i) := by
+    apply measure_congr
+    filter_upwards [(ae_ball_iff (Finset.countable_toSet S)).2 ha] with ω hω
+    change (ω ∈ ⋂ i ∈ S, g i ⁻¹' sets i) = (ω ∈ ⋂ i ∈ S, f i ⁻¹' sets i)
+    simp only [Finset.mem_coe] at hω
+    simp +contextual [hω]
+  convert h'a using 2 with i hi
+  exact (A i hi).symm
+
 lemma iIndepFun.comp {β γ : ι → Type*} {mβ : ∀ i, MeasurableSpace (β i)}
     {mγ : ∀ i, MeasurableSpace (γ i)} {f : ∀ i, Ω → β i}
     (h : iIndepFun f κ μ) (g : ∀ i, β i → γ i) (hg : ∀ i, Measurable (g i)) :

--- a/Mathlib/Probability/Independence/Kernel.lean
+++ b/Mathlib/Probability/Independence/Kernel.lean
@@ -1375,6 +1375,12 @@ theorem iIndepFun.indepFun_prod_range_succ {f : ℕ → Ω → β}
     IndepFun (∏ j ∈ Finset.range n, f j) (f n) κ μ :=
   hf_Indep.indepFun_finset_prod_of_not_mem hf_meas Finset.not_mem_range_self
 
+@[to_additive]
+theorem iIndepFun.indepFun_prod_range_succ₀ {f : ℕ → Ω → β}
+    (hf_Indep : iIndepFun f κ μ) (hf_meas : ∀ i, AEMeasurable (f i) (κ ∘ₘ μ)) (n : ℕ) :
+    IndepFun (∏ j ∈ Finset.range n, f j) (f n) κ μ :=
+  hf_Indep.indepFun_finset_prod_of_not_mem₀ hf_meas Finset.not_mem_range_self
+
 end CommMonoid
 
 theorem iIndepSet.iIndepFun_indicator [Zero β] [One β] {m : MeasurableSpace β} {s : ι → Set Ω}

--- a/Mathlib/Probability/Independence/Kernel.lean
+++ b/Mathlib/Probability/Independence/Kernel.lean
@@ -1242,16 +1242,9 @@ lemma iIndepFun.indepFun_mul_left (hf_indep : iIndepFun f κ μ)
 lemma iIndepFun.indepFun_mul_left₀ (hf_indep : iIndepFun f κ μ)
     (hf_meas : ∀ i, AEMeasurable (f i) (κ ∘ₘ μ)) (i j k : ι) (hik : i ≠ k) (hjk : j ≠ k) :
     IndepFun (f i * f j) (f k) κ μ := by
-  have h : IndepFun ((hf_meas i).mk (f i) * (hf_meas j).mk (f j)) ((hf_meas k).mk (f k)) κ μ := by
-    refine iIndepFun.indepFun_mul_left ?_ (fun i ↦ (hf_meas i).measurable_mk) _ _ _ hik hjk
-    exact iIndepFun.congr' hf_indep fun i ↦ Measure.ae_ae_of_ae_comp (hf_meas i).ae_eq_mk
-  refine IndepFun.congr' h ?_ ?_
-  · filter_upwards [Measure.ae_ae_of_ae_comp (hf_meas i).ae_eq_mk,
-      Measure.ae_ae_of_ae_comp (hf_meas j).ae_eq_mk] with a hi hj
-    filter_upwards [hi, hj] with ω hωi hωj
-    simp [hωi, hωj]
-  · filter_upwards [Measure.ae_ae_of_ae_comp (hf_meas k).ae_eq_mk] with a hk
-    filter_upwards [hk] with ω hωk using by rw [hωk]
+  have : IndepFun (fun ω => (f i ω, f j ω)) (f k) κ μ :=
+    hf_indep.indepFun_prodMk₀ hf_meas i j k hik hjk
+  simpa using this.comp (measurable_fst.mul measurable_snd) measurable_id
 
 @[to_additive]
 lemma iIndepFun.indepFun_mul_right (hf_indep : iIndepFun f κ μ)
@@ -1262,17 +1255,8 @@ lemma iIndepFun.indepFun_mul_right (hf_indep : iIndepFun f κ μ)
 @[to_additive]
 lemma iIndepFun.indepFun_mul_right₀ (hf_indep : iIndepFun f κ μ)
     (hf_meas : ∀ i, AEMeasurable (f i) (κ ∘ₘ μ)) (i j k : ι) (hij : i ≠ j) (hik : i ≠ k) :
-    IndepFun (f i) (f j * f k) κ μ := by
-  have h : IndepFun ((hf_meas i).mk (f i)) ((hf_meas j).mk (f j) * (hf_meas k).mk (f k)) κ μ := by
-    refine iIndepFun.indepFun_mul_right ?_ (fun i ↦ (hf_meas i).measurable_mk) _ _ _ hij hik
-    exact iIndepFun.congr' hf_indep fun i ↦ Measure.ae_ae_of_ae_comp (hf_meas i).ae_eq_mk
-  refine IndepFun.congr' h ?_ ?_
-  · filter_upwards [Measure.ae_ae_of_ae_comp (hf_meas i).ae_eq_mk] with a hi
-    filter_upwards [hi] with ω hω using by rw [hω]
-  · filter_upwards [Measure.ae_ae_of_ae_comp (hf_meas j).ae_eq_mk,
-      Measure.ae_ae_of_ae_comp (hf_meas k).ae_eq_mk] with a hj hk
-    filter_upwards [hj, hk] with ω hωj hωk
-    simp [hωj, hωk]
+    IndepFun (f i) (f j * f k) κ μ :=
+  (hf_indep.indepFun_mul_left₀ hf_meas _ _ _ hij.symm hik.symm).symm
 
 @[to_additive]
 lemma iIndepFun.indepFun_mul_mul (hf_indep : iIndepFun f κ μ)
@@ -1286,20 +1270,9 @@ lemma iIndepFun.indepFun_mul_mul (hf_indep : iIndepFun f κ μ)
 lemma iIndepFun.indepFun_mul_mul₀ (hf_indep : iIndepFun f κ μ)
     (hf_meas : ∀ i, AEMeasurable (f i) (κ ∘ₘ μ))
     (i j k l : ι) (hik : i ≠ k) (hil : i ≠ l) (hjk : j ≠ k) (hjl : j ≠ l) :
-    IndepFun (f i * f j) (f k * f l) κ μ := by
-  have h : IndepFun ((hf_meas i).mk (f i) * (hf_meas j).mk (f j))
-      ((hf_meas k).mk (f k) * (hf_meas l).mk (f l)) κ μ := by
-    refine iIndepFun.indepFun_mul_mul ?_ (fun i ↦ (hf_meas i).measurable_mk) _ _ _ _ hik hil hjk hjl
-    exact iIndepFun.congr' hf_indep fun i ↦ Measure.ae_ae_of_ae_comp (hf_meas i).ae_eq_mk
-  refine IndepFun.congr' h ?_ ?_
-  · filter_upwards [Measure.ae_ae_of_ae_comp (hf_meas i).ae_eq_mk,
-      Measure.ae_ae_of_ae_comp (hf_meas j).ae_eq_mk] with a hi hj
-    filter_upwards [hi, hj] with ω hωi hωj
-    simp [hωi, hωj]
-  · filter_upwards [Measure.ae_ae_of_ae_comp (hf_meas k).ae_eq_mk,
-      Measure.ae_ae_of_ae_comp (hf_meas l).ae_eq_mk] with a hk hl
-    filter_upwards [hk, hl] with ω hωk hωl
-    simp [hωk, hωl]
+    IndepFun (f i * f j) (f k * f l) κ μ :=
+  (hf_indep.indepFun_prodMk_prodMk₀ hf_meas i j k l hik hil hjk hjl).comp
+    measurable_mul measurable_mul
 
 end Mul
 
@@ -1318,16 +1291,9 @@ lemma iIndepFun.indepFun_div_left (hf_indep : iIndepFun f κ μ)
 lemma iIndepFun.indepFun_div_left₀ (hf_indep : iIndepFun f κ μ)
     (hf_meas : ∀ i, AEMeasurable (f i) (κ ∘ₘ μ)) (i j k : ι) (hik : i ≠ k) (hjk : j ≠ k) :
     IndepFun (f i / f j) (f k) κ μ := by
-  have h : IndepFun ((hf_meas i).mk (f i) / (hf_meas j).mk (f j)) ((hf_meas k).mk (f k)) κ μ := by
-    refine iIndepFun.indepFun_div_left ?_ (fun i ↦ (hf_meas i).measurable_mk) _ _ _ hik hjk
-    exact iIndepFun.congr' hf_indep fun i ↦ Measure.ae_ae_of_ae_comp (hf_meas i).ae_eq_mk
-  refine IndepFun.congr' h ?_ ?_
-  · filter_upwards [Measure.ae_ae_of_ae_comp (hf_meas i).ae_eq_mk,
-      Measure.ae_ae_of_ae_comp (hf_meas j).ae_eq_mk] with a hi hj
-    filter_upwards [hi, hj] with ω hωi hωj
-    simp [hωi, hωj]
-  · filter_upwards [Measure.ae_ae_of_ae_comp (hf_meas k).ae_eq_mk] with a hk
-    filter_upwards [hk] with ω hωk using by rw [hωk]
+  have : IndepFun (fun ω => (f i ω, f j ω)) (f k) κ μ :=
+    hf_indep.indepFun_prodMk₀ hf_meas i j k hik hjk
+  simpa using this.comp (measurable_fst.div measurable_snd) measurable_id
 
 @[to_additive]
 lemma iIndepFun.indepFun_div_right (hf_indep : iIndepFun f κ μ)
@@ -1338,17 +1304,8 @@ lemma iIndepFun.indepFun_div_right (hf_indep : iIndepFun f κ μ)
 @[to_additive]
 lemma iIndepFun.indepFun_div_right₀ (hf_indep : iIndepFun f κ μ)
     (hf_meas : ∀ i, AEMeasurable (f i) (κ ∘ₘ μ)) (i j k : ι) (hij : i ≠ j) (hik : i ≠ k) :
-    IndepFun (f i) (f j / f k) κ μ := by
-  have h : IndepFun ((hf_meas i).mk (f i)) ((hf_meas j).mk (f j) / (hf_meas k).mk (f k)) κ μ := by
-    refine iIndepFun.indepFun_div_right ?_ (fun i ↦ (hf_meas i).measurable_mk) _ _ _ hij hik
-    exact iIndepFun.congr' hf_indep fun i ↦ Measure.ae_ae_of_ae_comp (hf_meas i).ae_eq_mk
-  refine IndepFun.congr' h ?_ ?_
-  · filter_upwards [Measure.ae_ae_of_ae_comp (hf_meas i).ae_eq_mk] with a hi
-    filter_upwards [hi] with ω hω using by rw [hω]
-  · filter_upwards [Measure.ae_ae_of_ae_comp (hf_meas j).ae_eq_mk,
-      Measure.ae_ae_of_ae_comp (hf_meas k).ae_eq_mk] with a hj hk
-    filter_upwards [hj, hk] with ω hωj hωk
-    simp [hωj, hωk]
+    IndepFun (f i) (f j / f k) κ μ :=
+  (hf_indep.indepFun_div_left₀ hf_meas _ _ _ hij.symm hik.symm).symm
 
 @[to_additive]
 lemma iIndepFun.indepFun_div_div (hf_indep : iIndepFun f κ μ)
@@ -1362,20 +1319,9 @@ lemma iIndepFun.indepFun_div_div (hf_indep : iIndepFun f κ μ)
 lemma iIndepFun.indepFun_div_div₀ (hf_indep : iIndepFun f κ μ)
     (hf_meas : ∀ i, AEMeasurable (f i) (κ ∘ₘ μ))
     (i j k l : ι) (hik : i ≠ k) (hil : i ≠ l) (hjk : j ≠ k) (hjl : j ≠ l) :
-    IndepFun (f i / f j) (f k / f l) κ μ := by
-  have h : IndepFun ((hf_meas i).mk (f i) / (hf_meas j).mk (f j))
-      ((hf_meas k).mk (f k) / (hf_meas l).mk (f l)) κ μ := by
-    refine iIndepFun.indepFun_div_div ?_ (fun i ↦ (hf_meas i).measurable_mk) _ _ _ _ hik hil hjk hjl
-    exact iIndepFun.congr' hf_indep fun i ↦ Measure.ae_ae_of_ae_comp (hf_meas i).ae_eq_mk
-  refine IndepFun.congr' h ?_ ?_
-  · filter_upwards [Measure.ae_ae_of_ae_comp (hf_meas i).ae_eq_mk,
-      Measure.ae_ae_of_ae_comp (hf_meas j).ae_eq_mk] with a hi hj
-    filter_upwards [hi, hj] with ω hωi hωj
-    simp [hωi, hωj]
-  · filter_upwards [Measure.ae_ae_of_ae_comp (hf_meas k).ae_eq_mk,
-      Measure.ae_ae_of_ae_comp (hf_meas l).ae_eq_mk] with a hk hl
-    filter_upwards [hk, hl] with ω hωk hωl
-    simp [hωk, hωl]
+    IndepFun (f i / f j) (f k / f l) κ μ :=
+  (hf_indep.indepFun_prodMk_prodMk₀ hf_meas i j k l hik hil hjk hjl).comp
+    measurable_div measurable_div
 
 end Div
 
@@ -1403,6 +1349,25 @@ theorem iIndepFun.indepFun_finset_prod_of_not_mem (hf_Indep : iIndepFun f κ μ)
   exact
     (hf_Indep.indepFun_finset s {i} (Finset.disjoint_singleton_left.mpr hi).symm hf_meas).comp
       h_meas_left h_meas_right
+
+@[to_additive]
+theorem iIndepFun.indepFun_finset_prod_of_not_mem₀ (hf_Indep : iIndepFun f κ μ)
+    (hf_meas : ∀ i, AEMeasurable (f i) (κ ∘ₘ μ)) {s : Finset ι} {i : ι} (hi : i ∉ s) :
+    IndepFun (∏ j ∈ s, f j) (f i) κ μ := by
+  have h : IndepFun (∏ j ∈ s, (hf_meas j).mk (f j)) ((hf_meas i).mk (f i)) κ μ := by
+    refine iIndepFun.indepFun_finset_prod_of_not_mem ?_ (fun i ↦ (hf_meas i).measurable_mk) hi
+    exact iIndepFun.congr' hf_Indep fun i ↦ Measure.ae_ae_of_ae_comp (hf_meas i).ae_eq_mk
+  refine IndepFun.congr' h ?_ ?_
+  · have : ∀ᵐ a ∂μ, ∀ (i : s), f i =ᵐ[κ a] (hf_meas i).mk := by
+      rw [ae_all_iff]
+      exact fun i ↦ Measure.ae_ae_of_ae_comp (hf_meas i).ae_eq_mk
+    filter_upwards [this] with a ha
+    filter_upwards [ae_all_iff.2 ha] with ω hω
+    simp only [Finset.prod_apply]
+    refine Finset.prod_congr rfl fun i hi ↦ ?_
+    exact (hω ⟨i, hi⟩).symm
+  · filter_upwards [Measure.ae_ae_of_ae_comp (hf_meas i).ae_eq_mk] with a hi
+    filter_upwards [hi] with ω hω using by rw [hω]
 
 @[to_additive]
 theorem iIndepFun.indepFun_prod_range_succ {f : ℕ → Ω → β}

--- a/Mathlib/Probability/Independence/Kernel.lean
+++ b/Mathlib/Probability/Independence/Kernel.lean
@@ -956,8 +956,7 @@ lemma iIndepFun.comp₀ {β γ : ι → Type*} {mβ : ∀ i, MeasurableSpace (β
   have h_ae i := ae_of_ae_map (hf i) (hg i).ae_eq_mk
   refine iIndepFun.congr' h fun i ↦ ?_
   filter_upwards [Measure.ae_ae_of_ae_comp (h_ae i)] with a ha
-  filter_upwards [ha] with ω hω
-  simpa [Function.comp_apply] using hω.symm
+  filter_upwards [ha] with ω hω using hω.symm
 
 theorem indepFun_iff_indepSet_preimage {mβ : MeasurableSpace β} {mβ' : MeasurableSpace β'}
     [IsZeroOrMarkovKernel κ] (hf : Measurable f) (hg : Measurable g) :
@@ -998,23 +997,17 @@ theorem IndepFun.comp₀ {mβ : MeasurableSpace β} {mβ' : MeasurableSpace β'}
     (hfg : IndepFun f g κ μ)
     (hf : AEMeasurable f (κ ∘ₘ μ)) (hg : AEMeasurable g (κ ∘ₘ μ))
     (hφ : AEMeasurable φ ((κ ∘ₘ μ).map f)) (hψ : AEMeasurable ψ ((κ ∘ₘ μ).map g)) :
-    IndepFun (φ ∘ f) (ψ ∘ g) κ μ := by
-  have h : IndepFun ((hφ.mk φ) ∘ (hf.mk f)) ((hψ.mk ψ) ∘ (hg.mk g)) κ μ := by
-    refine IndepFun.comp ?_ hφ.measurable_mk hψ.measurable_mk
-    exact hfg.congr' (Measure.ae_ae_of_ae_comp hf.ae_eq_mk) (Measure.ae_ae_of_ae_comp hg.ae_eq_mk)
+  have h : IndepFun ((hφ.mk φ) ∘ f) ((hψ.mk ψ) ∘ g) κ μ := by
+    refine IndepFun.comp hfg hφ.measurable_mk hψ.measurable_mk
   have hφ_ae := ae_of_ae_map hf hφ.ae_eq_mk
   have hψ_ae := ae_of_ae_map hg hψ.ae_eq_mk
   refine IndepFun.congr' h ?_ ?_
-  · filter_upwards [Measure.ae_ae_of_ae_comp (hφ_ae), Measure.ae_ae_of_ae_comp hf.ae_eq_mk]
-      with a haφ haf
-    filter_upwards [haφ, haf] with ω hωφ hωf
-    simp only [Function.comp_apply]
-    rw [← hωf, ← hωφ]
-  · filter_upwards [Measure.ae_ae_of_ae_comp (hψ_ae), Measure.ae_ae_of_ae_comp hg.ae_eq_mk]
-      with a haψ hag
-    filter_upwards [haψ, hag] with ω hωψ hωg
-    simp only [Function.comp_apply]
-    rw [← hωg, ← hωψ]
+  · filter_upwards [Measure.ae_ae_of_ae_comp (hφ_ae)] with a haφ
+    filter_upwards [haφ] with ω hωφ
+    simp [hωφ]
+  · filter_upwards [Measure.ae_ae_of_ae_comp (hψ_ae)] with a haψ
+    filter_upwards [haψ] with ω hωψ
+    simp [hωψ]
 
 theorem IndepFun.neg_right {_mβ : MeasurableSpace β} {_mβ' : MeasurableSpace β'} [Neg β']
     [MeasurableNeg β'] (hfg : IndepFun f g κ μ) :
@@ -1135,14 +1128,14 @@ theorem iIndepFun.indepFun_finset₀ (S T : Finset ι) (hST : Disjoint S T)
     refine iIndepFun.indepFun_finset S T hST ?_ fun i ↦ (hf_meas i).measurable_mk
     exact iIndepFun.congr' hf_Indep fun i ↦ Measure.ae_ae_of_ae_comp (hf_meas i).ae_eq_mk
   refine IndepFun.congr' h ?_ ?_
-  · have : ∀ᵐ (a : α) ∂μ, ∀ (i : S), f i =ᵐ[κ a] (hf_meas i).mk  := by
+  · have : ∀ᵐ (a : α) ∂μ, ∀ (i : S), f i =ᵐ[κ a] (hf_meas i).mk := by
       rw [ae_all_iff]
       exact fun i ↦ Measure.ae_ae_of_ae_comp (hf_meas i).ae_eq_mk
     filter_upwards [this] with a ha
     filter_upwards [ae_all_iff.2 ha] with b hb
     ext i
     exact (hb i).symm
-  · have : ∀ᵐ (a : α) ∂μ, ∀ (i : T), f i =ᵐ[κ a] (hf_meas i).mk  := by
+  · have : ∀ᵐ (a : α) ∂μ, ∀ (i : T), f i =ᵐ[κ a] (hf_meas i).mk := by
       rw [ae_all_iff]
       exact fun i ↦ Measure.ae_ae_of_ae_comp (hf_meas i).ae_eq_mk
     filter_upwards [this] with a ha
@@ -1255,8 +1248,7 @@ lemma iIndepFun.indepFun_mul_left₀ (hf_indep : iIndepFun f κ μ)
   · filter_upwards [Measure.ae_ae_of_ae_comp (hf_meas i).ae_eq_mk,
       Measure.ae_ae_of_ae_comp (hf_meas j).ae_eq_mk] with a hi hj
     filter_upwards [hi, hj] with ω hωi hωj
-    simp only [Pi.mul_apply]
-    rw [← hωi, ← hωj]
+    simp [hωi, hωj]
   · filter_upwards [Measure.ae_ae_of_ae_comp (hf_meas k).ae_eq_mk] with a hk
     filter_upwards [hk] with ω hωk using by rw [hωk]
 
@@ -1279,8 +1271,7 @@ lemma iIndepFun.indepFun_mul_right₀ (hf_indep : iIndepFun f κ μ)
   · filter_upwards [Measure.ae_ae_of_ae_comp (hf_meas j).ae_eq_mk,
       Measure.ae_ae_of_ae_comp (hf_meas k).ae_eq_mk] with a hj hk
     filter_upwards [hj, hk] with ω hωj hωk
-    simp only [Pi.mul_apply]
-    rw [← hωj, ← hωk]
+    simp [hωj, hωk]
 
 @[to_additive]
 lemma iIndepFun.indepFun_mul_mul (hf_indep : iIndepFun f κ μ)
@@ -1303,13 +1294,11 @@ lemma iIndepFun.indepFun_mul_mul₀ (hf_indep : iIndepFun f κ μ)
   · filter_upwards [Measure.ae_ae_of_ae_comp (hf_meas i).ae_eq_mk,
       Measure.ae_ae_of_ae_comp (hf_meas j).ae_eq_mk] with a hi hj
     filter_upwards [hi, hj] with ω hωi hωj
-    simp only [Pi.mul_apply]
-    rw [← hωi, ← hωj]
+    simp [hωi, hωj]
   · filter_upwards [Measure.ae_ae_of_ae_comp (hf_meas k).ae_eq_mk,
       Measure.ae_ae_of_ae_comp (hf_meas l).ae_eq_mk] with a hk hl
     filter_upwards [hk, hl] with ω hωk hωl
-    simp only [Pi.mul_apply]
-    rw [← hωk, ← hωl]
+    simp [hωk, hωl]
 
 end Mul
 

--- a/Mathlib/Probability/Independence/Kernel.lean
+++ b/Mathlib/Probability/Independence/Kernel.lean
@@ -997,6 +997,7 @@ theorem IndepFun.comp₀ {mβ : MeasurableSpace β} {mβ' : MeasurableSpace β'}
     (hfg : IndepFun f g κ μ)
     (hf : AEMeasurable f (κ ∘ₘ μ)) (hg : AEMeasurable g (κ ∘ₘ μ))
     (hφ : AEMeasurable φ ((κ ∘ₘ μ).map f)) (hψ : AEMeasurable ψ ((κ ∘ₘ μ).map g)) :
+    IndepFun (φ ∘ f) (ψ ∘ g) κ μ := by
   have h : IndepFun ((hφ.mk φ) ∘ f) ((hψ.mk ψ) ∘ g) κ μ := by
     refine IndepFun.comp hfg hφ.measurable_mk hψ.measurable_mk
   have hφ_ae := ae_of_ae_map hf hφ.ae_eq_mk

--- a/Mathlib/Probability/Independence/Kernel.lean
+++ b/Mathlib/Probability/Independence/Kernel.lean
@@ -912,7 +912,7 @@ theorem iIndepFun_iff_measure_inter_preimage_eq_mul {ι : Type*} {β : ι → Ty
 
 alias ⟨iIndepFun.measure_inter_preimage_eq_mul, _⟩ := iIndepFun_iff_measure_inter_preimage_eq_mul
 
-theorem iIndepFun.congr {β : ι → Type*} {mβ : ∀ i, MeasurableSpace (β i)}
+theorem iIndepFun.congr' {β : ι → Type*} {mβ : ∀ i, MeasurableSpace (β i)}
     {f g : Π i, Ω → β i} (hf : iIndepFun f κ μ)
     (h : ∀ i, ∀ᵐ a ∂μ, f i =ᵐ[κ a] g i) :
     iIndepFun g κ μ := by
@@ -959,7 +959,7 @@ theorem indepFun_iff_indepSet_preimage {mβ : MeasurableSpace β} {mβ' : Measur
 nonrec theorem IndepFun.symm {_ : MeasurableSpace β} {_ : MeasurableSpace β'}
     (hfg : IndepFun f g κ μ) : IndepFun g f κ μ := hfg.symm
 
-theorem IndepFun.congr {mβ : MeasurableSpace β} {mβ' : MeasurableSpace β'}
+theorem IndepFun.congr' {mβ : MeasurableSpace β} {mβ' : MeasurableSpace β'}
     {f' : Ω → β} {g' : Ω → β'} (hfg : IndepFun f g κ μ)
     (hf : ∀ᵐ a ∂μ, f =ᵐ[κ a] f') (hg : ∀ᵐ a ∂μ, g =ᵐ[κ a] g') :
     IndepFun f' g' κ μ := by
@@ -969,7 +969,7 @@ theorem IndepFun.congr {mβ : MeasurableSpace β} {mβ' : MeasurableSpace β'}
   have h2 : g ⁻¹' B =ᵐ[κ a] g' ⁻¹' B := hg'.fun_comp B
   rwa [← measure_congr h1, ← measure_congr h2, ← measure_congr (h1.inter h2)]
 
-@[deprecated (since := "2025-03-18")] alias IndepFun.ae_eq := IndepFun.congr
+@[deprecated (since := "2025-03-18")] alias IndepFun.ae_eq := IndepFun.congr'
 
 theorem IndepFun.comp {mβ : MeasurableSpace β} {mβ' : MeasurableSpace β'}
     {mγ : MeasurableSpace γ} {mγ' : MeasurableSpace γ'} {φ : β → γ} {ψ : β' → γ'}

--- a/Mathlib/Probability/Independence/Kernel.lean
+++ b/Mathlib/Probability/Independence/Kernel.lean
@@ -931,7 +931,6 @@ theorem iIndepFun.congr' {β : ι → Type*} {mβ : ∀ i, MeasurableSpace (β i
     apply measure_congr
     filter_upwards [(ae_ball_iff (Finset.countable_toSet S)).2 ha] with ω hω
     change (ω ∈ ⋂ i ∈ S, g i ⁻¹' sets i) = (ω ∈ ⋂ i ∈ S, f i ⁻¹' sets i)
-    simp only [Finset.mem_coe] at hω
     simp +contextual [hω]
   convert h'a using 2 with i hi
   exact (A i hi).symm

--- a/Mathlib/Probability/Integration.lean
+++ b/Mathlib/Probability/Integration.lean
@@ -120,7 +120,7 @@ theorem lintegral_mul_eq_lintegral_mul_lintegral_of_indepFun' (h_meas_f : AEMeas
     lintegral_congr_ae fg_ae]
   apply lintegral_mul_eq_lintegral_mul_lintegral_of_indepFun h_meas_f.measurable_mk
       h_meas_g.measurable_mk
-  exact h_indep_fun.ae_eq h_meas_f.ae_eq_mk h_meas_g.ae_eq_mk
+  exact h_indep_fun.congr h_meas_f.ae_eq_mk h_meas_g.ae_eq_mk
 
 theorem lintegral_mul_eq_lintegral_mul_lintegral_of_indepFun'' (h_meas_f : AEMeasurable f μ)
     (h_meas_g : AEMeasurable g μ) (h_indep_fun : IndepFun f g μ) :

--- a/Mathlib/Probability/Kernel/Composition/IntegralCompProd.lean
+++ b/Mathlib/Probability/Kernel/Composition/IntegralCompProd.lean
@@ -3,10 +3,7 @@ Copyright (c) 2023 Rémy Degenne. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Rémy Degenne, Etienne Marion
 -/
-import Mathlib.Probability.Kernel.Composition.Comp
-import Mathlib.Probability.Kernel.Composition.CompProd
 import Mathlib.Probability.Kernel.Composition.MeasureComp
-import Mathlib.Probability.Kernel.Composition.MeasureCompProd
 import Mathlib.Probability.Kernel.MeasurableIntegral
 
 /-!

--- a/Mathlib/Probability/Kernel/Composition/IntegralCompProd.lean
+++ b/Mathlib/Probability/Kernel/Composition/IntegralCompProd.lean
@@ -3,8 +3,10 @@ Copyright (c) 2023 Rémy Degenne. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Rémy Degenne, Etienne Marion
 -/
-import Mathlib.Probability.Kernel.Composition.CompProd
 import Mathlib.Probability.Kernel.Composition.Comp
+import Mathlib.Probability.Kernel.Composition.CompProd
+import Mathlib.Probability.Kernel.Composition.MeasureComp
+import Mathlib.Probability.Kernel.Composition.MeasureCompProd
 import Mathlib.Probability.Kernel.MeasurableIntegral
 
 /-!
@@ -447,3 +449,68 @@ end Kernel
 end comp
 
 end ProbabilityTheory
+
+namespace MeasureTheory
+
+namespace Measure
+
+variable {α β E : Type*} {mα : MeasurableSpace α} {mβ : MeasurableSpace β}
+  [NormedAddCommGroup E] {a : α} {κ : Kernel α β} {μ : Measure α} {f : β → E}
+
+section Integral
+
+lemma _root_.MeasureTheory.AEStronglyMeasurable.ae_of_compProd [SFinite μ] [IsSFiniteKernel κ]
+    {E : Type*} [NormedAddCommGroup E] {f : α → β → E}
+    (hf : AEStronglyMeasurable f.uncurry (μ ⊗ₘ κ)) :
+    ∀ᵐ x ∂μ, AEStronglyMeasurable (f x) (κ x) := by
+  simpa using hf.compProd_mk_left
+
+lemma integrable_compProd_iff [SFinite μ] [IsSFiniteKernel κ] {E : Type*} [NormedAddCommGroup E]
+    {f : α × β → E} (hf : AEStronglyMeasurable f (μ ⊗ₘ κ)) :
+    Integrable f (μ ⊗ₘ κ) ↔
+      (∀ᵐ x ∂μ, Integrable (fun y => f (x, y)) (κ x)) ∧
+        Integrable (fun x => ∫ y, ‖f (x, y)‖ ∂(κ x)) μ := by
+  simp_rw [Measure.compProd, ProbabilityTheory.integrable_compProd_iff hf, Kernel.prodMkLeft_apply,
+    Kernel.const_apply]
+
+lemma integral_compProd [SFinite μ] [IsSFiniteKernel κ] {E : Type*}
+    [NormedAddCommGroup E] [NormedSpace ℝ E]
+    {f : α × β → E} (hf : Integrable f (μ ⊗ₘ κ)) :
+    ∫ x, f x ∂(μ ⊗ₘ κ) = ∫ a, ∫ b, f (a, b) ∂(κ a) ∂μ := by
+  rw [Measure.compProd, ProbabilityTheory.integral_compProd hf]
+  simp
+
+lemma setIntegral_compProd [SFinite μ] [IsSFiniteKernel κ] {E : Type*}
+    [NormedAddCommGroup E] [NormedSpace ℝ E]
+    {s : Set α} (hs : MeasurableSet s) {t : Set β} (ht : MeasurableSet t)
+    {f : α × β → E} (hf : IntegrableOn f (s ×ˢ t) (μ ⊗ₘ κ))  :
+    ∫ x in s ×ˢ t, f x ∂(μ ⊗ₘ κ) = ∫ a in s, ∫ b in t, f (a, b) ∂(κ a) ∂μ := by
+  rw [Measure.compProd, ProbabilityTheory.setIntegral_compProd hs ht hf]
+  simp
+
+end Integral
+
+section Integrable
+
+lemma integrable_compProd_snd_iff [SFinite μ] [IsSFiniteKernel κ]
+    (hf : AEStronglyMeasurable f (κ ∘ₘ μ)) :
+    Integrable (fun p ↦ f p.2) (μ ⊗ₘ κ) ↔ Integrable f (κ ∘ₘ μ) := by
+  rw [← Measure.snd_compProd, Measure.snd, integrable_map_measure _ measurable_snd.aemeasurable,
+    Function.comp_def]
+  rwa [← Measure.snd, Measure.snd_compProd]
+
+lemma ae_integrable_of_integrable_comp (h_int : Integrable f (κ ∘ₘ μ)) :
+    ∀ᵐ x ∂μ, Integrable f (κ x) := by
+  rw [Measure.comp_eq_comp_const_apply, integrable_comp_iff h_int.1] at h_int
+  exact h_int.1
+
+lemma integrable_integral_norm_of_integrable_comp (h_int : Integrable f (κ ∘ₘ μ)) :
+    Integrable (fun x ↦ ∫ y, ‖f y‖ ∂κ x) μ := by
+  rw [Measure.comp_eq_comp_const_apply, integrable_comp_iff h_int.1] at h_int
+  exact h_int.2
+
+end Integrable
+
+end Measure
+
+end MeasureTheory

--- a/Mathlib/Probability/Kernel/Composition/MeasureComp.lean
+++ b/Mathlib/Probability/Kernel/Composition/MeasureComp.lean
@@ -102,29 +102,6 @@ lemma prodMkLeft_comp_compProd {η : Kernel β γ} [SFinite μ] [IsSFiniteKernel
 
 end CompProd
 
-section Integrable
-
-variable {E : Type*} [NormedAddCommGroup E] {f : β → E}
-
-lemma integrable_compProd_snd_iff [SFinite μ] [IsSFiniteKernel κ]
-    (hf : AEStronglyMeasurable f (κ ∘ₘ μ)) :
-    Integrable (fun p ↦ f p.2) (μ ⊗ₘ κ) ↔ Integrable f (κ ∘ₘ μ) := by
-  rw [← snd_compProd, Measure.snd, integrable_map_measure _ measurable_snd.aemeasurable,
-    Function.comp_def]
-  rwa [← Measure.snd, snd_compProd]
-
-lemma ae_integrable_of_integrable_comp (h_int : Integrable f (κ ∘ₘ μ)) :
-    ∀ᵐ x ∂μ, Integrable f (κ x) := by
-  rw [comp_eq_comp_const_apply, integrable_comp_iff h_int.1] at h_int
-  exact h_int.1
-
-lemma integrable_integral_norm_of_integrable_comp (h_int : Integrable f (κ ∘ₘ μ)) :
-    Integrable (fun x ↦ ∫ y, ‖f y‖ ∂κ x) μ := by
-  rw [comp_eq_comp_const_apply, integrable_comp_iff h_int.1] at h_int
-  exact h_int.2
-
-end Integrable
-
 section AddSMul
 
 @[simp]

--- a/Mathlib/Probability/Kernel/Composition/MeasureCompProd.lean
+++ b/Mathlib/Probability/Kernel/Composition/MeasureCompProd.lean
@@ -4,7 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Rémy Degenne
 -/
 import Mathlib.MeasureTheory.Decomposition.Lebesgue
-import Mathlib.Probability.Kernel.Composition.IntegralCompProd
+import Mathlib.Probability.Kernel.Composition.CompProd
+import Mathlib.MeasureTheory.Measure.Prod
 
 /-!
 # Composition-Product of a measure and a kernel
@@ -176,35 +177,6 @@ lemma setLIntegral_compProd [SFinite μ] [IsSFiniteKernel κ]
     {s : Set α} (hs : MeasurableSet s) {t : Set β} (ht : MeasurableSet t) :
     ∫⁻ x in s ×ˢ t, f x ∂(μ ⊗ₘ κ) = ∫⁻ a in s, ∫⁻ b in t, f (a, b) ∂(κ a) ∂μ := by
   rw [compProd, Kernel.setLIntegral_compProd _ _ _ hf hs ht]
-  simp
-
-lemma _root_.MeasureTheory.AEStronglyMeasurable.ae_of_compProd [SFinite μ] [IsSFiniteKernel κ]
-    {E : Type*} [NormedAddCommGroup E] {f : α → β → E}
-    (hf : AEStronglyMeasurable f.uncurry (μ ⊗ₘ κ)) :
-    ∀ᵐ x ∂μ, AEStronglyMeasurable (f x) (κ x) := by
-  simpa using hf.compProd_mk_left
-
-lemma integrable_compProd_iff [SFinite μ] [IsSFiniteKernel κ] {E : Type*} [NormedAddCommGroup E]
-    {f : α × β → E} (hf : AEStronglyMeasurable f (μ ⊗ₘ κ)) :
-    Integrable f (μ ⊗ₘ κ) ↔
-      (∀ᵐ x ∂μ, Integrable (fun y => f (x, y)) (κ x)) ∧
-        Integrable (fun x => ∫ y, ‖f (x, y)‖ ∂(κ x)) μ := by
-  simp_rw [Measure.compProd, ProbabilityTheory.integrable_compProd_iff hf, Kernel.prodMkLeft_apply,
-    Kernel.const_apply]
-
-lemma integral_compProd [SFinite μ] [IsSFiniteKernel κ] {E : Type*}
-    [NormedAddCommGroup E] [NormedSpace ℝ E]
-    {f : α × β → E} (hf : Integrable f (μ ⊗ₘ κ)) :
-    ∫ x, f x ∂(μ ⊗ₘ κ) = ∫ a, ∫ b, f (a, b) ∂(κ a) ∂μ := by
-  rw [compProd, ProbabilityTheory.integral_compProd hf]
-  simp
-
-lemma setIntegral_compProd [SFinite μ] [IsSFiniteKernel κ] {E : Type*}
-    [NormedAddCommGroup E] [NormedSpace ℝ E]
-    {s : Set α} (hs : MeasurableSet s) {t : Set β} (ht : MeasurableSet t)
-    {f : α × β → E} (hf : IntegrableOn f (s ×ˢ t) (μ ⊗ₘ κ))  :
-    ∫ x in s ×ˢ t, f x ∂(μ ⊗ₘ κ) = ∫ a in s, ∫ b in t, f (a, b) ∂(κ a) ∂μ := by
-  rw [compProd, ProbabilityTheory.setIntegral_compProd hs ht hf]
   simp
 
 end Integral

--- a/Mathlib/Probability/Kernel/Composition/MeasureCompProd.lean
+++ b/Mathlib/Probability/Kernel/Composition/MeasureCompProd.lean
@@ -4,8 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Rémy Degenne
 -/
 import Mathlib.MeasureTheory.Decomposition.Lebesgue
-import Mathlib.Probability.Kernel.Composition.CompProd
 import Mathlib.MeasureTheory.Measure.Prod
+import Mathlib.Probability.Kernel.Composition.CompProd
 
 /-!
 # Composition-Product of a measure and a kernel

--- a/Mathlib/Probability/Kernel/Disintegration/Integral.lean
+++ b/Mathlib/Probability/Kernel/Disintegration/Integral.lean
@@ -3,6 +3,7 @@ Copyright (c) 2024 Rémy Degenne. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Rémy Degenne
 -/
+import Mathlib.Probability.Kernel.Composition.IntegralCompProd
 import Mathlib.Probability.Kernel.Disintegration.StandardBorel
 
 /-!
@@ -194,7 +195,7 @@ lemma integral_condKernel (hf : Integrable f ρ) :
     ∫ b, ∫ ω, f (b, ω) ∂(ρ.condKernel b) ∂ρ.fst = ∫ x, f x ∂ρ := by
   conv_rhs => rw [← ρ.disintegrate ρ.condKernel]
   rw [← ρ.disintegrate ρ.condKernel] at hf
-  rw [integral_compProd hf]
+  rw [ MeasureTheory.Measure.integrable_compProd_iff hf]
 
 lemma setIntegral_condKernel {s : Set β} (hs : MeasurableSet s)
     {t : Set Ω} (ht : MeasurableSet t) (hf : IntegrableOn f (s ×ˢ t) ρ) :

--- a/Mathlib/Probability/Kernel/Disintegration/Integral.lean
+++ b/Mathlib/Probability/Kernel/Disintegration/Integral.lean
@@ -195,7 +195,7 @@ lemma integral_condKernel (hf : Integrable f ρ) :
     ∫ b, ∫ ω, f (b, ω) ∂(ρ.condKernel b) ∂ρ.fst = ∫ x, f x ∂ρ := by
   conv_rhs => rw [← ρ.disintegrate ρ.condKernel]
   rw [← ρ.disintegrate ρ.condKernel] at hf
-  rw [ MeasureTheory.Measure.integrable_compProd_iff hf]
+  rw [integral_compProd hf]
 
 lemma setIntegral_condKernel {s : Set β} (hs : MeasurableSet s)
     {t : Set Ω} (ht : MeasurableSet t) (hf : IntegrableOn f (s ×ˢ t) ρ) :

--- a/Mathlib/Probability/Kernel/IonescuTulcea/Traj.lean
+++ b/Mathlib/Probability/Kernel/IonescuTulcea/Traj.lean
@@ -8,7 +8,6 @@ import Mathlib.MeasureTheory.Function.FactorsThrough
 import Mathlib.MeasureTheory.Measure.ProbabilityMeasure
 import Mathlib.MeasureTheory.OuterMeasure.OfAddContent
 import Mathlib.Probability.Kernel.Composition.IntegralCompProd
-import Mathlib.Probability.Kernel.Composition.MeasureComp
 import Mathlib.Probability.Kernel.IonescuTulcea.PartialTraj
 import Mathlib.Probability.Kernel.SetIntegral
 

--- a/Mathlib/Probability/Kernel/IonescuTulcea/Traj.lean
+++ b/Mathlib/Probability/Kernel/IonescuTulcea/Traj.lean
@@ -7,6 +7,7 @@ import Mathlib.MeasureTheory.Constructions.ProjectiveFamilyContent
 import Mathlib.MeasureTheory.Function.FactorsThrough
 import Mathlib.MeasureTheory.Measure.ProbabilityMeasure
 import Mathlib.MeasureTheory.OuterMeasure.OfAddContent
+import Mathlib.Probability.Kernel.Composition.IntegralCompProd
 import Mathlib.Probability.Kernel.Composition.MeasureComp
 import Mathlib.Probability.Kernel.IonescuTulcea.PartialTraj
 import Mathlib.Probability.Kernel.SetIntegral

--- a/Mathlib/Probability/Moments/SubGaussian.lean
+++ b/Mathlib/Probability/Moments/SubGaussian.lean
@@ -565,15 +565,13 @@ private lemma sum_of_iIndepFun_of_forall_aemeasurable
 lemma sum_of_iIndepFun {ι : Type*} {X : ι → Ω → ℝ} (h_indep : iIndepFun X μ) {c : ι → ℝ≥0}
     {s : Finset ι} (h_subG : ∀ i ∈ s, HasSubgaussianMGF (X i) (c i) μ) :
     HasSubgaussianMGF (fun ω ↦ ∑ i ∈ s, X i ω) (∑ i ∈ s, c i) μ := by
-  have A (i : s) : AEMeasurable (X i) μ := (h_subG i i.2).aemeasurable
   have : HasSubgaussianMGF (fun ω ↦ ∑ (i : s), X i ω) (∑ (i : s), c i) μ := by
     apply sum_of_iIndepFun_of_forall_aemeasurable
     · exact h_indep.precomp Subtype.val_injective
-    · exact fun i ↦ (A i)
+    · exact fun i ↦ (h_subG i i.2).aemeasurable
     · exact fun i _ ↦ h_subG i i.2
   rw [Finset.sum_coe_sort] at this
-  apply this.congr (ae_of_all _ fun ω ↦ ?_)
-  exact Finset.sum_attach s (fun i ↦ X i ω)
+  exact this.congr (ae_of_all _ fun ω ↦ Finset.sum_attach s (fun i ↦ X i ω))
 
 /-- **Hoeffding inequality** for sub-Gaussian random variables. -/
 lemma measure_sum_ge_le_of_iIndepFun {ι : Type*} {X : ι → Ω → ℝ} (h_indep : iIndepFun X μ)

--- a/Mathlib/Probability/Moments/SubGaussian.lean
+++ b/Mathlib/Probability/Moments/SubGaussian.lean
@@ -573,7 +573,7 @@ lemma sum_of_iIndepFun
   have A (i : s) : AEMeasurable (X i) μ := (h_subG i i.2).aemeasurable
   have : HasSubgaussianMGF (fun ω ↦ ∑ (i : s), (A i).mk _ ω) (∑ (i : s), c i) μ := by
     apply sum_of_iIndepFun_of_measurable
-    · exact iIndepFun.ae_eq
+    · exact iIndepFun.congr
         (iIndepFun.precomp (g := Subtype.val) Subtype.val_injective h_indep)
         (fun i ↦ AEMeasurable.ae_eq_mk (A i))
     · exact fun i ↦ AEMeasurable.measurable_mk (A i)

--- a/Mathlib/Probability/Moments/SubGaussian.lean
+++ b/Mathlib/Probability/Moments/SubGaussian.lean
@@ -474,11 +474,9 @@ lemma aemeasurable (h : HasSubgaussianMGF X c μ) : AEMeasurable X μ :=
 
 lemma congr (h : HasSubgaussianMGF X c μ) {Y : Ω → ℝ} (h' : X =ᵐ[μ] Y) :
     HasSubgaussianMGF Y c μ := by
-  refine ⟨fun t ↦ ?_, fun t ↦ ?_⟩
-  · apply (h.integrable_exp_mul t).congr
-    filter_upwards [h'] with ω hω using by simp [hω]
-  · apply (le_of_eq _).trans (h.mgf_le t)
-    exact mgf_congr h'.symm
+  rw [HasSubgaussianMGF_iff_kernel] at h ⊢
+  apply h.congr
+  simpa
 
 lemma memLp_exp_mul (h : HasSubgaussianMGF X c μ) (t : ℝ) (p : ℝ≥0) :
     MemLp (fun ω ↦ exp (t * X ω)) p μ := by
@@ -571,17 +569,15 @@ lemma sum_of_iIndepFun
   have A (i : s) : AEMeasurable (X i) μ := (h_subG i i.2).aemeasurable
   have : HasSubgaussianMGF (fun ω ↦ ∑ (i : s), (A i).mk _ ω) (∑ (i : s), c i) μ := by
     apply sum_of_iIndepFun_of_measurable
-    · exact iIndepFun.congr
-        (iIndepFun.precomp (g := Subtype.val) Subtype.val_injective h_indep)
-        (fun i ↦ AEMeasurable.ae_eq_mk (A i))
-    · exact fun i ↦ AEMeasurable.measurable_mk (A i)
+    · exact (h_indep.precomp Subtype.val_injective).congr (fun i ↦ (A i).ae_eq_mk)
+    · exact fun i ↦ (A i).measurable_mk
     · exact fun i hi ↦ (h_subG i i.2).congr (A i).ae_eq_mk
   rw [Finset.sum_coe_sort] at this
   apply this.congr
   have : ∀ᵐ ω ∂μ, ∀ (i : s), X i ω = (A i).mk _ ω :=
     ae_all_iff.2 fun i ↦ AEMeasurable.ae_eq_mk (A i)
   filter_upwards [this] with ω hω
-  conv_rhs => rw [← Finset.sum_coe_sort]
+  nth_rw 2 [← Finset.sum_coe_sort]
   simp [hω]
 
 /-- **Hoeffding inequality** for sub-Gaussian random variables. -/

--- a/Mathlib/Probability/Moments/SubGaussian.lean
+++ b/Mathlib/Probability/Moments/SubGaussian.lean
@@ -568,8 +568,6 @@ lemma sum_of_iIndepFun
     {ι : Type*} {X : ι → Ω → ℝ} (h_indep : iIndepFun X μ) {c : ι → ℝ≥0}
     {s : Finset ι} (h_subG : ∀ i ∈ s, HasSubgaussianMGF (X i) (c i) μ) :
     HasSubgaussianMGF (fun ω ↦ ∑ i ∈ s, X i ω) (∑ i ∈ s, c i) μ := by
-  have : iIndepFun (fun (i : s) ↦ X i) μ :=
-    iIndepFun.precomp (g := Subtype.val) Subtype.val_injective h_indep
   have A (i : s) : AEMeasurable (X i) μ := (h_subG i i.2).aemeasurable
   have : HasSubgaussianMGF (fun ω ↦ ∑ (i : s), (A i).mk _ ω) (∑ (i : s), c i) μ := by
     apply sum_of_iIndepFun_of_measurable
@@ -577,8 +575,7 @@ lemma sum_of_iIndepFun
         (iIndepFun.precomp (g := Subtype.val) Subtype.val_injective h_indep)
         (fun i ↦ AEMeasurable.ae_eq_mk (A i))
     · exact fun i ↦ AEMeasurable.measurable_mk (A i)
-    · intro i hi
-      apply (h_subG i i.2).congr (A i).ae_eq_mk
+    · exact fun i hi ↦ (h_subG i i.2).congr (A i).ae_eq_mk
   rw [Finset.sum_coe_sort] at this
   apply this.congr
   have : ∀ᵐ ω ∂μ, ∀ (i : s), X i ω = (A i).mk _ ω :=

--- a/Mathlib/Probability/StrongLaw.lean
+++ b/Mathlib/Probability/StrongLaw.lean
@@ -818,7 +818,7 @@ theorem strong_law_ae (X : ℕ → Ω → E) (hint : Integrable (X 0) μ)
   have C : ∀ᵐ ω ∂μ,
       Tendsto (fun n : ℕ ↦ (n : ℝ) ⁻¹ • (∑ i ∈ range n, Y i ω)) atTop (𝓝 μ[Y 0]) := by
     apply strong_law_ae_of_measurable Y Yint ((A 0).1.stronglyMeasurable_mk)
-      (fun i j hij ↦ IndepFun.ae_eq (hindep hij) (A i).1.ae_eq_mk (A j).1.ae_eq_mk)
+      (fun i j hij ↦ IndepFun.congr (hindep hij) (A i).1.ae_eq_mk (A j).1.ae_eq_mk)
       (fun i ↦ ((A i).1.identDistrib_mk.symm.trans (hident i)).trans (A 0).1.identDistrib_mk)
   filter_upwards [B, C] with ω h₁ h₂
   have : μ[X 0] = μ[Y 0] := integral_congr_ae (AEStronglyMeasurable.ae_eq_mk (A 0).1)


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
