### PR TITLE
[Merged by Bors] - feat: add rewriting lemmas for euclidean domains

### DIFF
--- a/Mathlib/Algebra/EuclideanDomain/Basic.lean
+++ b/Mathlib/Algebra/EuclideanDomain/Basic.lean
@@ -388,7 +388,7 @@ theorem div_eq_iff_eq_mul_of_dvd (x y z : R) (h1 : y ≠ 0) (h2 : y ∣ x) :
 
 theorem eq_div_iff_mul_eq_of_dvd (x y z : R) (h1 : z ≠ 0) (h2 : z ∣ y) :
     x = y / z ↔ z * x = y := by
-  rw [eq_comm,div_eq_iff_eq_mul_of_dvd _ _ _ h1 h2, eq_comm]
+  rw [eq_comm, div_eq_iff_eq_mul_of_dvd _ _ _ h1 h2, eq_comm]
 
 theorem div_eq_div_iff_mul_eq_mul_of_dvd {x y z t : R} (h1 : y ≠ 0) (h2 : t ≠ 0)
     (h3 : y ∣ x) (h4 : t ∣ z) : x / y = z / t ↔ t * x = y * z := by

--- a/Mathlib/Algebra/EuclideanDomain/Basic.lean
+++ b/Mathlib/Algebra/EuclideanDomain/Basic.lean
@@ -324,18 +324,15 @@ theorem div_add_of_dvd (x y z : R) (h1 : y ≠ 0) (h2 : y ∣ x) : x / y + z = (
 
 theorem div_sub_of_dvd (x y z : R) (h1 : y ≠ 0) (h2 : y ∣ x) : x / y - z = (x - y * z) / y := by
   apply eq_div_of_mul_eq_right h1
-  rw [mul_sub]
-  rw [EuclideanDomain.mul_div_cancel' h1 h2]
+  rw [mul_sub, EuclideanDomain.mul_div_cancel' h1 h2]
 
 theorem add_div_of_dvd (x y z : R) (h1 : z ≠ 0) (h2 : z ∣ y) : x + y / z = (z * x + y) / z := by
   apply eq_div_of_mul_eq_right h1
-  rw [mul_add]
-  rw [EuclideanDomain.mul_div_cancel' h1 h2]
+  rw [mul_add, EuclideanDomain.mul_div_cancel' h1 h2]
 
 theorem sub_div_of_dvd (x y z : R) (h1 : z ≠ 0) (h2 : z ∣ y) : x - y / z = (z * x - y) / z := by
   apply eq_div_of_mul_eq_right h1
-  rw [mul_sub]
-  rw [EuclideanDomain.mul_div_cancel' h1 h2]
+  rw [mul_sub, EuclideanDomain.mul_div_cancel' h1 h2]
 
 theorem div_mul {x y z : R} (h1 : y ∣ x) (h2 : y * z ∣ x) :
     x / (y * z) = x / y / z := by
@@ -364,13 +361,13 @@ theorem div_sub_div_of_dvd {x y z t : R} (h1 : y ≠ 0) (h2 : t ≠ 0) (h3 : y �
     mul_assoc, EuclideanDomain.mul_div_cancel' h2 h4]
 
 theorem div_eq_iff_eq_mul_of_dvd (x y z : R) (h1 : y ≠ 0) (h2 : y ∣ x) :
-    x / y = z  ↔ x = y * z := by
+    x / y = z ↔ x = y * z := by
   obtain ⟨a, ha⟩ := h2
   rw [ha, mul_div_cancel_left₀ _ h1]
   simp only [mul_eq_mul_left_iff, mul_eq_zero, h1, or_self, or_false]
 
 theorem eq_div_iff_mul_eq_of_dvd (x y z : R) (h1 : z ≠ 0) (h2 : z ∣ y) :
-    x = y / z  ↔ z * x = y := by
+    x = y / z ↔ z * x = y := by
   rw [eq_comm,div_eq_iff_eq_mul_of_dvd _ _ _ h1 h2, eq_comm]
 
 theorem div_eq_div_iff_mul_eq_mul_of_dvd {x y z t : R} (h1 : y ≠ 0) (h2 : t ≠ 0)

--- a/Mathlib/Algebra/EuclideanDomain/Basic.lean
+++ b/Mathlib/Algebra/EuclideanDomain/Basic.lean
@@ -318,21 +318,41 @@ theorem mul_div_mul_comm_of_dvd_dvd {a b c d : R} (hac : c ∣ a) (hbd : d ∣ b
   rw [mul_div_cancel_left₀ _ hc0, mul_div_cancel_left₀ _ hd0, mul_mul_mul_comm,
     mul_div_cancel_left₀ _ (mul_ne_zero hc0 hd0)]
 
-theorem div_add_of_dvd (x y z : R) (h1 : y ≠ 0) (h2 : y ∣ x) : x / y + z = (x + y * z) / y := by
+theorem add_mul_div_left (x y z : R) (h1 : y ≠ 0) (h2 : y ∣ x) : (x + y * z) / y = x / y + z := by
+  rw [eq_comm]
   apply eq_div_of_mul_eq_right h1
   rw [mul_add, EuclideanDomain.mul_div_cancel' h1 h2]
 
-theorem div_sub_of_dvd (x y z : R) (h1 : y ≠ 0) (h2 : y ∣ x) : x / y - z = (x - y * z) / y := by
+theorem add_mul_div_right (x y z : R) (h1 : y ≠ 0) (h2 : y ∣ x) : (x + z * y) / y = x / y + z := by
+  rw [mul_comm z y]
+  exact add_mul_div_left _ _ _ h1 h2
+
+theorem sub_mul_div_left (x y z : R) (h1 : y ≠ 0) (h2 : y ∣ x) : (x - y * z) / y = x / y - z := by
+  rw [eq_comm]
   apply eq_div_of_mul_eq_right h1
   rw [mul_sub, EuclideanDomain.mul_div_cancel' h1 h2]
 
-theorem add_div_of_dvd (x y z : R) (h1 : z ≠ 0) (h2 : z ∣ y) : x + y / z = (z * x + y) / z := by
+theorem sub_mul_div_right (x y z : R) (h1 : y ≠ 0) (h2 : y ∣ x) : (x - z * y) / y = x / y - z := by
+  rw [mul_comm z y]
+  exact sub_mul_div_left _ _ _ h1 h2
+
+theorem mul_add_div_left (x y z : R) (h1 : z ≠ 0) (h2 : z ∣ y) : (z * x + y) / z = x + y / z  := by
+  rw [eq_comm]
   apply eq_div_of_mul_eq_right h1
   rw [mul_add, EuclideanDomain.mul_div_cancel' h1 h2]
 
-theorem sub_div_of_dvd (x y z : R) (h1 : z ≠ 0) (h2 : z ∣ y) : x - y / z = (z * x - y) / z := by
+theorem mul_add_div_right (x y z : R) (h1 : z ≠ 0) (h2 : z ∣ y) : (x * z + y) / z = x + y / z := by
+  rw [mul_comm x z]
+  exact mul_add_div_left _  _  _  h1 h2
+
+theorem mul_sub_div_left (x y z : R) (h1 : z ≠ 0) (h2 : z ∣ y) : (z * x - y) / z = x - y / z := by
+  rw [eq_comm]
   apply eq_div_of_mul_eq_right h1
   rw [mul_sub, EuclideanDomain.mul_div_cancel' h1 h2]
+
+theorem mul_sub_div_right (x y z : R) (h1 : z ≠ 0) (h2 : z ∣ y) : (x * z - y) / z = x - y / z := by
+  rw [mul_comm x z]
+  exact mul_sub_div_left _ _ _ h1 h2
 
 theorem div_mul {x y z : R} (h1 : y ∣ x) (h2 : y * z ∣ x) :
     x / (y * z) = x / y / z := by
@@ -374,9 +394,9 @@ theorem div_eq_div_iff_mul_eq_mul_of_dvd {x y z t : R} (h1 : y ≠ 0) (h2 : t �
     (h3 : y ∣ x) (h4 : t ∣ z) : x / y = z / t ↔ t * x = y * z := by
   rw [div_eq_iff_eq_mul_of_dvd _  _ _ h1 h3, ← mul_div_assoc _ h4,
     eq_div_iff_mul_eq_of_dvd _ _ _ h2]
-  · obtain ⟨a, ha⟩ := h4
-    use y * a
-    rw [ha, mul_comm, mul_assoc, mul_comm y a]
+  obtain ⟨a, ha⟩ := h4
+  use y * a
+  rw [ha, mul_comm, mul_assoc, mul_comm y a]
 
 end Div
 

--- a/Mathlib/Algebra/EuclideanDomain/Basic.lean
+++ b/Mathlib/Algebra/EuclideanDomain/Basic.lean
@@ -320,8 +320,7 @@ theorem mul_div_mul_comm_of_dvd_dvd {a b c d : R} (hac : c ∣ a) (hbd : d ∣ b
 
 theorem div_add_of_dvd {x y z : R} (h1 : y ≠ 0) (h2 : y ∣ x) : x / y + z = (x + y * z) / y := by
   apply eq_div_of_mul_eq_right h1
-  rw [mul_add]
-  rw [EuclideanDomain.mul_div_cancel' h1 h2]
+  rw [mul_add, EuclideanDomain.mul_div_cancel' h1 h2]
 
 theorem div_sub_of_dvd {x y z : R} (h1 : y ≠ 0) (h2 : y ∣ x) : x / y - z = (x - y * z) / y := by
   apply eq_div_of_mul_eq_right h1

--- a/Mathlib/Algebra/EuclideanDomain/Basic.lean
+++ b/Mathlib/Algebra/EuclideanDomain/Basic.lean
@@ -318,79 +318,68 @@ theorem mul_div_mul_comm_of_dvd_dvd {a b c d : R} (hac : c ∣ a) (hbd : d ∣ b
   rw [mul_div_cancel_left₀ _ hc0, mul_div_cancel_left₀ _ hd0, mul_mul_mul_comm,
     mul_div_cancel_left₀ _ (mul_ne_zero hc0 hd0)]
 
-theorem div_add_of_dvd {x y z : R} (h1 : y ≠ 0) (h2 : y ∣ x) : x / y + z = (x + y * z) / y := by
+theorem div_add_of_dvd (x y z : R) (h1 : y ≠ 0) (h2 : y ∣ x) : x / y + z = (x + y * z) / y := by
   apply eq_div_of_mul_eq_right h1
   rw [mul_add, EuclideanDomain.mul_div_cancel' h1 h2]
 
-theorem div_sub_of_dvd {x y z : R} (h1 : y ≠ 0) (h2 : y ∣ x) : x / y - z = (x - y * z) / y := by
+theorem div_sub_of_dvd (x y z : R) (h1 : y ≠ 0) (h2 : y ∣ x) : x / y - z = (x - y * z) / y := by
   apply eq_div_of_mul_eq_right h1
   rw [mul_sub]
   rw [EuclideanDomain.mul_div_cancel' h1 h2]
 
-theorem add_div_of_dvd {x y z : R} (h1 : z ≠ 0) (h2 : z ∣ y) : x + y / z = (z * x + y) / z := by
+theorem add_div_of_dvd (x y z : R) (h1 : z ≠ 0) (h2 : z ∣ y) : x + y / z = (z * x + y) / z := by
   apply eq_div_of_mul_eq_right h1
   rw [mul_add]
   rw [EuclideanDomain.mul_div_cancel' h1 h2]
 
-theorem sub_div_of_dvd {x y z : R} (h1 : z ≠ 0) (h2 : z ∣ y) : x - y / z = (z * x - y) / z:= by
+theorem sub_div_of_dvd (x y z : R) (h1 : z ≠ 0) (h2 : z ∣ y) : x - y / z = (z * x - y) / z := by
   apply eq_div_of_mul_eq_right h1
   rw [mul_sub]
   rw [EuclideanDomain.mul_div_cancel' h1 h2]
 
+theorem div_mul {x y z : R} (h1 : y ∣ x) (h2 : y * z ∣ x) :
+    x / (y * z) = x / y / z := by
+  rcases eq_or_ne z 0 with rfl | hz
+  · simp only [mul_zero, div_zero]
+  apply eq_div_of_mul_eq_right hz
+  rw [← EuclideanDomain.mul_div_assoc z h2, mul_comm y z, mul_div_mul_cancel hz h1]
+
 theorem div_div {x y z : R} (h1 : y ∣ x) (h2 : z ∣ (x / y)) :
     x / y / z = x / (y * z) := by
-  by_cases h3 : y = 0
-  · rw [h3]
-    simp only [div_zero, zero_div, zero_mul]
-  by_cases h4 : z = 0
-  · rw [h4]
-    simp only [div_zero, mul_zero]
-  obtain ⟨a,ha⟩ := h1
-  obtain ⟨n,hb⟩ := h2
-  rw [hb,mul_comm,MulDivCancelClass.mul_div_cancel _ _ h4]
-  rw [ha,mul_comm y a,MulDivCancelClass.mul_div_cancel a y h3] at hb
-  rw [ha,hb,mul_div_mul_cancel h3, mul_div_cancel_left₀ _ h4]
-  use n
+  rcases eq_or_ne y 0 with rfl | hy
+  · simp only [div_zero, zero_div, zero_mul]
+  rw [← mul_dvd_mul_iff_left hy, EuclideanDomain.mul_div_cancel' hy h1] at h2
+  exact (div_mul h1 h2).symm
 
 theorem div_add_div_of_dvd {x y z t : R} (h1 : y ≠ 0) (h2 : t ≠ 0) (h3 : y ∣ x) (h4 : t ∣ z) :
     x / y + z / t = (t * x + y * z) / (t * y):= by
-  obtain ⟨r,hr⟩ := h3
-  obtain ⟨s,hs⟩ := h4
-  rw [hr,hs]
-  simp only [ne_eq, h1, not_false_eq_true, mul_div_cancel_left₀, h2]
-  rw [← mul_assoc,← mul_assoc y t s,mul_comm y t,← mul_add,mul_div_cancel_left₀]
-  rw [ne_eq, mul_eq_zero]
-  push_neg
-  exact ⟨h2,h1⟩
+  apply eq_div_of_mul_eq_right (mul_ne_zero h2 h1)
+  rw [mul_add, mul_assoc, EuclideanDomain.mul_div_cancel' h1 h3, mul_comm t y,
+    mul_assoc, EuclideanDomain.mul_div_cancel' h2 h4]
 
 theorem div_sub_div_of_dvd {x y z t : R} (h1 : y ≠ 0) (h2 : t ≠ 0) (h3 : y ∣ x) (h4 : t ∣ z) :
     x / y - z / t = (t * x - y * z) / (t * y):= by
-  obtain ⟨r,hr⟩ := h3
-  obtain ⟨s,hs⟩ := h4
-  simp [hr,hs]
-  simp only [ne_eq, h1, not_false_eq_true, mul_div_cancel_left₀, h2]
-  rw [← mul_assoc,← mul_assoc y t s,mul_comm y t,← mul_sub,mul_div_cancel_left₀]
-  simp only [ne_eq, mul_eq_zero]
-  push_neg
-  exact ⟨h2,h1⟩
+  apply eq_div_of_mul_eq_right (mul_ne_zero h2 h1)
+  rw [mul_sub, mul_assoc, EuclideanDomain.mul_div_cancel' h1 h3, mul_comm t y,
+    mul_assoc, EuclideanDomain.mul_div_cancel' h2 h4]
 
-theorem div_eq_iff_eq_mul_of_dvd {x y z : R} (h1 : y ≠ 0) (h2 : y ∣ x) :
+theorem div_eq_iff_eq_mul_of_dvd (x y z : R) (h1 : y ≠ 0) (h2 : y ∣ x) :
     x / y = z  ↔ x = y * z := by
-  obtain ⟨a,ha⟩ := h2
-  rw [ha,mul_div_cancel_left₀ _ h1]
+  obtain ⟨a, ha⟩ := h2
+  rw [ha, mul_div_cancel_left₀ _ h1]
   simp only [mul_eq_mul_left_iff, mul_eq_zero, h1, or_self, or_false]
 
-theorem eq_div_iff_mul_eq_of_dvd {x y z : R} (h1 : z ≠ 0) (h2 : z ∣ y) :
-    x = y / z  ↔ z * x = y  := by
-  rw [eq_comm,div_eq_iff_eq_mul_of_dvd h1 h2,eq_comm]
+theorem eq_div_iff_mul_eq_of_dvd (x y z : R) (h1 : z ≠ 0) (h2 : z ∣ y) :
+    x = y / z  ↔ z * x = y := by
+  rw [eq_comm,div_eq_iff_eq_mul_of_dvd _ _ _ h1 h2, eq_comm]
 
 theorem div_eq_div_iff_mul_eq_mul_of_dvd {x y z t : R} (h1 : y ≠ 0) (h2 : t ≠ 0)
     (h3 : y ∣ x) (h4 : t ∣ z) : x / y = z / t ↔ t * x = y * z := by
-  rw [div_eq_iff_eq_mul_of_dvd h1 h3,← mul_div_assoc _ h4]
-  rw [eq_div_iff_mul_eq_of_dvd h2]
-  · obtain ⟨a,ha⟩ := h4
+  rw [div_eq_iff_eq_mul_of_dvd _  _ _ h1 h3, ← mul_div_assoc _ h4,
+    eq_div_iff_mul_eq_of_dvd _ _ _ h2]
+  · obtain ⟨a, ha⟩ := h4
     use y * a
-    rw [ha,mul_comm,mul_assoc,mul_comm y a]
+    rw [ha, mul_comm, mul_assoc, mul_comm y a]
 
 end Div
 

--- a/Mathlib/Algebra/EuclideanDomain/Basic.lean
+++ b/Mathlib/Algebra/EuclideanDomain/Basic.lean
@@ -318,6 +318,76 @@ theorem mul_div_mul_comm_of_dvd_dvd {a b c d : R} (hac : c ∣ a) (hbd : d ∣ b
   rw [mul_div_cancel_left₀ _ hc0, mul_div_cancel_left₀ _ hd0, mul_mul_mul_comm,
     mul_div_cancel_left₀ _ (mul_ne_zero hc0 hd0)]
 
+
+theorem div_add_of_dvd {x y z : R} (h1 : y ≠ 0) (h2 : y ∣ x) : x / y + z = (x + y * z) / y := by
+  apply eq_div_of_mul_eq_right h1
+  rw [mul_add]
+  rw [EuclideanDomain.mul_div_cancel' h1 h2]
+
+theorem div_sub_of_dvd {x y z : R} (h1 : y ≠ 0) (h2 : y ∣ x) : x / y - z = (x - y * z) / y := by
+  apply eq_div_of_mul_eq_right h1
+  rw [mul_sub]
+  rw [EuclideanDomain.mul_div_cancel' h1 h2]
+
+theorem add_div_of_dvd {x y z : R} (h1 : z ≠ 0) (h2 : z ∣ y) : x + y / z = (z * x + y) / z := by
+  apply eq_div_of_mul_eq_right h1
+  rw [mul_add]
+  rw [EuclideanDomain.mul_div_cancel' h1 h2]
+
+theorem sub_div_of_dvd {x y z : R} (h1 : z ≠ 0) (h2 : z ∣ y) : x - y / z = (z * x - y) / z:= by
+  apply eq_div_of_mul_eq_right h1
+  rw [mul_sub]
+  rw [EuclideanDomain.mul_div_cancel' h1 h2]
+
+theorem div_div {x y z : R} (h1 : y ≠ 0) (h2 : z ≠ 0) (h3 : y ∣ x) (h4 : z ∣ (x / y)) :
+    x / y / z = x / (y * z) := by
+  obtain ⟨a,ha⟩ := h3
+  obtain ⟨n,hb⟩ := h4
+  rw [hb,mul_comm,MulDivCancelClass.mul_div_cancel _ _ h2]
+  rw [ha,mul_comm y a,MulDivCancelClass.mul_div_cancel a y h1] at hb
+  rw [ha,hb,EuclideanDomain.mul_div_mul_cancel h1, mul_div_cancel_left₀ _ h2]
+  use n
+
+theorem div_add_div_of_dvd {x y z t : R} (h1 : y ≠ 0) (h2 : t ≠ 0) (h3 : y ∣ x) (h4 : t ∣ z) :
+    x / y + z / t = (t * x + y * z) / (t * y):= by
+  obtain ⟨r,hr⟩ := h3
+  obtain ⟨s,hs⟩ := h4
+  rw [hr,hs]
+  simp only [ne_eq, h1, not_false_eq_true, mul_div_cancel_left₀, h2]
+  rw [← mul_assoc,← mul_assoc y t s,mul_comm y t,← mul_add,mul_div_cancel_left₀]
+  rw [ne_eq, mul_eq_zero]
+  push_neg
+  exact ⟨h2,h1⟩
+
+theorem div_sub_div_of_dvd {x y z t : R} (h1 : y ≠ 0) (h2 : t ≠ 0) (h3 : y ∣ x) (h4 : t ∣ z) :
+    x / y - z / t = (t * x - y * z) / (t * y):= by
+  obtain ⟨r,hr⟩ := h3
+  obtain ⟨s,hs⟩ := h4
+  simp [hr,hs]
+  simp only [ne_eq, h1, not_false_eq_true, mul_div_cancel_left₀, h2]
+  rw [← mul_assoc,← mul_assoc y t s,mul_comm y t,← mul_sub,mul_div_cancel_left₀]
+  simp only [ne_eq, mul_eq_zero]
+  push_neg
+  exact ⟨h2,h1⟩
+
+theorem div_eq_iff_eq_mul_of_dvd {x y z : R} (h1 : y ≠ 0) (h2 : y ∣ x) :
+    x / y = z  ↔ x = y * z := by
+  obtain ⟨a,ha⟩ := h2
+  rw [ha,mul_div_cancel_left₀ _ h1]
+  simp only [mul_eq_mul_left_iff, mul_eq_zero, h1, or_self, or_false]
+
+theorem eq_div_iff_mul_eq_of_dvd {x y z : R} (h1 : z ≠ 0) (h2 : z ∣ y) :
+    x = y / z  ↔ z * x = y  := by
+  rw [eq_comm,EuclideanDomain.div_eq_iff_eq_mul_of_dvd h1 h2,eq_comm]
+
+theorem div_eq_div_iff_mul_eq_mul_of_dvd {x y z t : R} (h1 : y ≠ 0) (h2 : t ≠ 0)
+    (h3 : y ∣ x) (h4 : t ∣ z): x / y = z / t ↔ t * x = y * z := by
+  rw [EuclideanDomain.div_eq_iff_eq_mul_of_dvd h1 h3,← EuclideanDomain.mul_div_assoc _ h4]
+  rw [EuclideanDomain.eq_div_iff_mul_eq_of_dvd h2]
+  · obtain ⟨a,ha⟩ := h4
+    use y * a
+    rw [ha,mul_comm,mul_assoc,mul_comm y a]
+
 end Div
 
 end EuclideanDomain

--- a/Mathlib/Algebra/EuclideanDomain/Basic.lean
+++ b/Mathlib/Algebra/EuclideanDomain/Basic.lean
@@ -337,7 +337,7 @@ theorem sub_div_of_dvd {x y z : R} (h1 : z ≠ 0) (h2 : z ∣ y) : x - y / z = (
   rw [mul_sub]
   rw [EuclideanDomain.mul_div_cancel' h1 h2]
 
-theorem div_div {x y z : R}  (h1 : y ∣ x) (h2 : z ∣ (x / y)) :
+theorem div_div {x y z : R} (h1 : y ∣ x) (h2 : z ∣ (x / y)) :
     x / y / z = x / (y * z) := by
   by_cases h3 : y = 0
   · rw [h3]

--- a/Mathlib/Algebra/EuclideanDomain/Basic.lean
+++ b/Mathlib/Algebra/EuclideanDomain/Basic.lean
@@ -318,7 +318,6 @@ theorem mul_div_mul_comm_of_dvd_dvd {a b c d : R} (hac : c ∣ a) (hbd : d ∣ b
   rw [mul_div_cancel_left₀ _ hc0, mul_div_cancel_left₀ _ hd0, mul_mul_mul_comm,
     mul_div_cancel_left₀ _ (mul_ne_zero hc0 hd0)]
 
-
 theorem div_add_of_dvd {x y z : R} (h1 : y ≠ 0) (h2 : y ∣ x) : x / y + z = (x + y * z) / y := by
   apply eq_div_of_mul_eq_right h1
   rw [mul_add]
@@ -345,7 +344,7 @@ theorem div_div {x y z : R} (h1 : y ≠ 0) (h2 : z ≠ 0) (h3 : y ∣ x) (h4 : z
   obtain ⟨n,hb⟩ := h4
   rw [hb,mul_comm,MulDivCancelClass.mul_div_cancel _ _ h2]
   rw [ha,mul_comm y a,MulDivCancelClass.mul_div_cancel a y h1] at hb
-  rw [ha,hb,EuclideanDomain.mul_div_mul_cancel h1, mul_div_cancel_left₀ _ h2]
+  rw [ha,hb,mul_div_mul_cancel h1, mul_div_cancel_left₀ _ h2]
   use n
 
 theorem div_add_div_of_dvd {x y z t : R} (h1 : y ≠ 0) (h2 : t ≠ 0) (h3 : y ∣ x) (h4 : t ∣ z) :
@@ -378,12 +377,12 @@ theorem div_eq_iff_eq_mul_of_dvd {x y z : R} (h1 : y ≠ 0) (h2 : y ∣ x) :
 
 theorem eq_div_iff_mul_eq_of_dvd {x y z : R} (h1 : z ≠ 0) (h2 : z ∣ y) :
     x = y / z  ↔ z * x = y  := by
-  rw [eq_comm,EuclideanDomain.div_eq_iff_eq_mul_of_dvd h1 h2,eq_comm]
+  rw [eq_comm,div_eq_iff_eq_mul_of_dvd h1 h2,eq_comm]
 
 theorem div_eq_div_iff_mul_eq_mul_of_dvd {x y z t : R} (h1 : y ≠ 0) (h2 : t ≠ 0)
     (h3 : y ∣ x) (h4 : t ∣ z): x / y = z / t ↔ t * x = y * z := by
-  rw [EuclideanDomain.div_eq_iff_eq_mul_of_dvd h1 h3,← EuclideanDomain.mul_div_assoc _ h4]
-  rw [EuclideanDomain.eq_div_iff_mul_eq_of_dvd h2]
+  rw [div_eq_iff_eq_mul_of_dvd h1 h3,← mul_div_assoc _ h4]
+  rw [eq_div_iff_mul_eq_of_dvd h2]
   · obtain ⟨a,ha⟩ := h4
     use y * a
     rw [ha,mul_comm,mul_assoc,mul_comm y a]

--- a/Mathlib/Algebra/EuclideanDomain/Basic.lean
+++ b/Mathlib/Algebra/EuclideanDomain/Basic.lean
@@ -338,13 +338,19 @@ theorem sub_div_of_dvd {x y z : R} (h1 : z ≠ 0) (h2 : z ∣ y) : x - y / z = (
   rw [mul_sub]
   rw [EuclideanDomain.mul_div_cancel' h1 h2]
 
-theorem div_div {x y z : R} (h1 : y ≠ 0) (h2 : z ≠ 0) (h3 : y ∣ x) (h4 : z ∣ (x / y)) :
+theorem div_div {x y z : R}  (h1 : y ∣ x) (h2 : z ∣ (x / y)) :
     x / y / z = x / (y * z) := by
-  obtain ⟨a,ha⟩ := h3
-  obtain ⟨n,hb⟩ := h4
-  rw [hb,mul_comm,MulDivCancelClass.mul_div_cancel _ _ h2]
-  rw [ha,mul_comm y a,MulDivCancelClass.mul_div_cancel a y h1] at hb
-  rw [ha,hb,mul_div_mul_cancel h1, mul_div_cancel_left₀ _ h2]
+  by_cases h3 : y = 0
+  · rw [h3]
+    simp only [div_zero, zero_div, zero_mul]
+  by_cases h4 : z = 0
+  · rw [h4]
+    simp only [div_zero, mul_zero]
+  obtain ⟨a,ha⟩ := h1
+  obtain ⟨n,hb⟩ := h2
+  rw [hb,mul_comm,MulDivCancelClass.mul_div_cancel _ _ h4]
+  rw [ha,mul_comm y a,MulDivCancelClass.mul_div_cancel a y h3] at hb
+  rw [ha,hb,mul_div_mul_cancel h3, mul_div_cancel_left₀ _ h4]
   use n
 
 theorem div_add_div_of_dvd {x y z t : R} (h1 : y ≠ 0) (h2 : t ≠ 0) (h3 : y ∣ x) (h4 : t ∣ z) :

--- a/Mathlib/Algebra/EuclideanDomain/Basic.lean
+++ b/Mathlib/Algebra/EuclideanDomain/Basic.lean
@@ -385,7 +385,7 @@ theorem eq_div_iff_mul_eq_of_dvd {x y z : R} (h1 : z ≠ 0) (h2 : z ∣ y) :
   rw [eq_comm,div_eq_iff_eq_mul_of_dvd h1 h2,eq_comm]
 
 theorem div_eq_div_iff_mul_eq_mul_of_dvd {x y z t : R} (h1 : y ≠ 0) (h2 : t ≠ 0)
-    (h3 : y ∣ x) (h4 : t ∣ z): x / y = z / t ↔ t * x = y * z := by
+    (h3 : y ∣ x) (h4 : t ∣ z) : x / y = z / t ↔ t * x = y * z := by
   rw [div_eq_iff_eq_mul_of_dvd h1 h3,← mul_div_assoc _ h4]
   rw [eq_div_iff_mul_eq_of_dvd h2]
   · obtain ⟨a,ha⟩ := h4


### PR DESCRIPTION

This PR includes some equalities and equivalences about expressions in euclidean domains.

They can be useful as rewriting lemmas to simplify expressions.

---

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
