### PR TITLE
[Merged by Bors] - perf: speed up `Finset.toLeft` and `Finset.toRight`

### DIFF
--- a/Mathlib/Computability/Language.lean
+++ b/Mathlib/Computability/Language.lean
@@ -5,7 +5,6 @@ Authors: Fox Thomson, Martin Dvorak
 -/
 import Mathlib.Algebra.Order.Kleene
 import Mathlib.Algebra.Ring.Hom.Defs
-import Mathlib.Data.List.Flatten
 import Mathlib.Data.Set.Lattice
 import Mathlib.Tactic.DeriveFintype
 

--- a/Mathlib/Data/Finset/Sum.lean
+++ b/Mathlib/Data/Finset/Sum.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies, Bhavik Mehta
 -/
 import Mathlib.Data.Finset.Card
+import Mathlib.Data.Finset.Fold
 import Mathlib.Data.Multiset.Sum
 
 /-!

--- a/Mathlib/Data/Finset/Sum.lean
+++ b/Mathlib/Data/Finset/Sum.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies, Bhavik Mehta
 -/
 import Mathlib.Data.Finset.Card
-import Mathlib.Data.Finset.Union
 import Mathlib.Data.Multiset.Sum
 
 /-!
@@ -111,8 +110,7 @@ forms a quasi-inverse to `disjSum`, in that it recovers its left input.
 See also `List.partitionMap`.
 -/
 def toLeft (s : Finset (α ⊕ β)) : Finset α :=
-  s.disjiUnion (Sum.elim singleton (fun _ => ∅)) <| by
-    simp [Set.PairwiseDisjoint, Set.Pairwise, Function.onFun, eq_comm]
+  s.filterMap (Sum.elim some fun _ => none) (by clear x; aesop)
 
 /--
 Given a finset of elements `α ⊕ β`, extract all the elements of the form `β`. This
@@ -121,8 +119,7 @@ forms a quasi-inverse to `disjSum`, in that it recovers its right input.
 See also `List.partitionMap`.
 -/
 def toRight (s : Finset (α ⊕ β)) : Finset β :=
-  s.disjiUnion (Sum.elim (fun _ => ∅) singleton) <| by
-    simp [Set.PairwiseDisjoint, Set.Pairwise, Function.onFun, eq_comm]
+  s.filterMap (Sum.elim (fun _ => none) some) (by clear x; aesop)
 
 variable {u v : Finset (α ⊕ β)}
 


### PR DESCRIPTION
This is about 10% faster than master, but also avoids stackoverflows:
```lean
#eval ((Finset.Icc 0 100000).map (.inl (β := ℕ))).toLeft.card
```
would previously fail.

`aesop` is somehow capturing an unused local variable here, but `clear` sets it straight.

As a bonus, this reduces the imports needed for this file.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

This is a more minimal version of #23020 that is also twice as fast.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
