### PR TITLE
[Merged by Bors] - feat(Algebra/Polynomial/ofFn): ofFn and APIs

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -939,6 +939,7 @@ import Mathlib.Algebra.Polynomial.Splits
 import Mathlib.Algebra.Polynomial.SumIteratedDerivative
 import Mathlib.Algebra.Polynomial.Taylor
 import Mathlib.Algebra.Polynomial.UnitTrinomial
+import Mathlib.Algebra.Polynomial.ofFn
 import Mathlib.Algebra.PresentedMonoid.Basic
 import Mathlib.Algebra.Prime.Defs
 import Mathlib.Algebra.Prime.Lemmas

--- a/Mathlib/Algebra/Polynomial/ofFn.lean
+++ b/Mathlib/Algebra/Polynomial/ofFn.lean
@@ -6,6 +6,7 @@ Authors: Fabrizio Barroero
 import Mathlib.Algebra.BigOperators.Fin
 import Mathlib.Algebra.Polynomial.Degree.Lemmas
 import Mathlib.Data.List.ToFinsupp
+import Mathlib.LinearAlgebra.Pi
 /-!
 # `Polynomial.ofFn` and `Polynomial.toFn`
 
@@ -26,14 +27,7 @@ section toFn
 variable {R : Type*} [Semiring R]
 
 /-- `toFn n f` is the vector of the first `n` coefficients of the polynomial `f`. -/
-def toFn (n : ℕ) : R[X] →ₗ[R] Fin n → R where
-  toFun p := fun i ↦ p.coeff i
-  map_add' x y := by
-    simp only [coeff_add]
-    rfl
-  map_smul' x p := by
-    simp only [coeff_smul]
-    rfl
+def toFn (n : ℕ) : R[X] →ₗ[R] Fin n → R := LinearMap.pi (fun i ↦ lcoeff R i)
 
 theorem toFn_zero (n : ℕ) : toFn n (0 : R[X]) = 0 := by simp
 
@@ -68,19 +62,19 @@ lemma ne_zero_of_ofFn_ne_zero {n : ℕ} {v : Fin n → R} (h : ofFn n v ≠ 0) :
 
 /-- If `i < n` the `i`-th coefficient of `ofFn n v` is `v i`. -/
 @[simp]
-theorem coeff_eq_val_of_lt {n i : ℕ} (v : Fin n → R) (hi : i < n) :
+theorem ofFn_coeff_eq_val_of_lt {n i : ℕ} (v : Fin n → R) (hi : i < n) :
     (ofFn n v).coeff i = v ⟨i, hi⟩ := by
   simp [ofFn, hi]
 
 /-- If `n ≤ i` the `i`-th coefficient of `ofFn n v` is `0`. -/
 @[simp]
-theorem coeff_eq_zero_of_ge {n i : ℕ} (v : Fin n → R) (hi : n ≤ i) : (ofFn n v).coeff i = 0 := by
-  simp [ofFn, hi, Nat.not_lt_of_ge hi]
+theorem ofFn_coeff_eq_zero_of_ge {n i : ℕ} (v : Fin n → R) (hi : n ≤ i) : (ofFn n v).coeff i = 0 :=
+  by simp [ofFn, hi, Nat.not_lt_of_ge hi]
 
 /-- `ofFn n v` has `natDegree` smaller than `n`. -/
 theorem ofFn_natDegree_lt {n : ℕ} (h : 1 ≤ n) (v : Fin n → R) : (ofFn n v).natDegree < n := by
   rw [Nat.lt_iff_le_pred h, natDegree_le_iff_coeff_eq_zero]
-  exact fun _ h ↦ coeff_eq_zero_of_ge _ <| Nat.le_of_pred_lt h
+  exact fun _ h ↦ ofFn_coeff_eq_zero_of_ge _ <| Nat.le_of_pred_lt h
 
 /-- `ofFn n v` has `degree` smaller than `n`. -/
 theorem ofFn_degree_lt {n : ℕ} (v : Fin n → R) : (ofFn n v).degree < n := by
@@ -100,7 +94,8 @@ theorem ofFn_eq_sum_monomial {n : ℕ} (v : Fin n → R) : ofFn n v =
     congr
     simp
 
-theorem toFn_comp_ofFn_eq_id (n : ℕ) (v : Fin n → R) : toFn n (ofFn n v) = v := by simp [toFn]
+theorem toFn_comp_ofFn_eq_id (n : ℕ) (v : Fin n → R) : toFn n (ofFn n v) = v := by
+  simp [toFn, ofFn, LinearMap.pi]
 
 theorem injective_ofFn (n : ℕ) : Function.Injective (ofFn (R := R) n) :=
   Function.LeftInverse.injective <| toFn_comp_ofFn_eq_id n

--- a/Mathlib/Algebra/Polynomial/ofFn.lean
+++ b/Mathlib/Algebra/Polynomial/ofFn.lean
@@ -89,10 +89,8 @@ theorem ofFn_eq_sum_monomial {n : ℕ} (v : Fin n → R) : ofFn n v =
   by_cases h : n = 0
   · subst h
     simp [ofFn]
-  · rw [as_sum_range' (ofFn n v) n <| ofFn_natDegree_lt (Nat.one_le_iff_ne_zero.mpr h) v,
-      Finset.sum_range]
-    congr
-    simp
+  · rw [as_sum_range' (ofFn n v) n <| ofFn_natDegree_lt (Nat.one_le_iff_ne_zero.mpr h) v]
+    simp [Finset.sum_range]
 
 theorem toFn_comp_ofFn_eq_id (n : ℕ) (v : Fin n → R) : toFn n (ofFn n v) = v := by
   simp [toFn, ofFn, LinearMap.pi]
@@ -108,10 +106,8 @@ theorem ofFn_comp_toFn_eq_id_of_natDegree_lt {n : ℕ} {p : R [X]} (h_deg : p.na
   ext i
   by_cases h : i < n
   · simp [h, toFn]
-  · simp only [ofFn, toFn, LinearMap.coe_mk, AddHom.coe_mk, coeff_ofFinsupp, List.toFinsupp_apply,
-    List.getD_eq_getElem?_getD, List.getElem?_ofFn, h, ↓reduceDIte, Option.getD_none]
-    apply (coeff_eq_zero_of_natDegree_lt _).symm
-    omega
+  · have : p.coeff i = 0 := coeff_eq_zero_of_natDegree_lt <| by omega
+    simp_all
 
 end ofFn
 

--- a/Mathlib/Algebra/Polynomial/ofFn.lean
+++ b/Mathlib/Algebra/Polynomial/ofFn.lean
@@ -1,0 +1,126 @@
+/-
+Copyright (c) 2025 Fabrizio Barroero. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Fabrizio Barroero
+-/
+import Mathlib.Algebra.BigOperators.Fin
+import Mathlib.Algebra.Polynomial.Degree.Lemmas
+import Mathlib.Data.List.ToFinsupp
+/-!
+# `Polynomial.ofFn` and `Polynomial.toFn`
+
+In this file we introduce `ofFn` and `toFn`, two functions that associate a polynomial to the vector
+of its coefficients and vice versa. We prove some basic APIs for these functions.
+
+## Main definitions
+
+- `Polynomial.toFn n` associates a polynomial to the vector of its first `n` coefficients.
+- `Polynomial.ofFn n` associates a vector of lenght `n` to a polynomial that has the entries of the
+  vector as coefficients.
+-/
+
+namespace Polynomial
+
+section toFn
+
+variable {R : Type*} [Semiring R]
+
+/-- `toFn n f` is the vector of the first `n` coefficients of the polynomial `f`. -/
+def toFn (n : ℕ) : R[X] →+ Fin n → R where
+  toFun p := fun i ↦ p.coeff i
+  map_add' x y := by
+    simp only [coeff_add]
+    rfl
+  map_zero' := by
+    simp only [coeff_zero]
+    rfl
+
+@[simp]
+theorem toFn_zero (n : ℕ) : toFn n (0 : R[X]) = 0 := by simp
+
+end toFn
+section ofFn
+
+variable {R : Type*} [Semiring R] [Dec : DecidableEq R]
+
+/-- `ofFn n v` is the polynomial whose coefficients are the entries of the vector `v`. -/
+def ofFn (n : ℕ) : (Fin n → R) →+ R[X] where
+  toFun v := ⟨(List.ofFn v).toFinsupp⟩
+  map_add' x y := by
+    ext i
+    by_cases h : i < n
+    · simp [h]
+    · simp [List.getD_getElem?, h]
+  map_zero' := by
+    ext i
+    by_cases h : i < n
+    · simp [h]
+    · simp [List.getD_getElem?, h]
+
+@[simp]
+theorem ofFn_zero (n : ℕ) : ofFn n (0 : Fin n → R) = 0 := by simp
+
+@[simp]
+theorem ofFn_zero' (v : Fin 0 → R) : ofFn 0 v = 0 := rfl
+
+lemma ne_zero_of_ofFn_ne_zero {n : ℕ} {v : Fin n → R} (h : ofFn n v ≠ 0) : n ≠ 0 := by
+  contrapose! h
+  subst h
+  simp
+
+/-- If `i < n` the `i`-th coefficient of `ofFn n v` is `v i`. -/
+@[simp]
+theorem coeff_eq_val_of_lt {n i : ℕ} (v : Fin n → R) (hi : i < n) :
+    (ofFn n v).coeff i = v ⟨i, hi⟩ := by
+  simp [ofFn, hi]
+
+/-- If `n ≤ i` the `i`-th coefficient of `ofFn n v` is `0`. -/
+@[simp]
+theorem coeff_eq_zero_of_ge {n i : ℕ} (v : Fin n → R) (hi : n ≤ i) : (ofFn n v).coeff i = 0 := by
+  simp [ofFn, hi, Nat.not_lt_of_ge hi]
+
+/-- `ofFn n v` has `natDegree` smaller than `n`. -/
+theorem ofFn_natDegree_lt {n : ℕ} (h : 1 ≤ n) (v : Fin n → R) : (ofFn n v).natDegree < n := by
+  rw [Nat.lt_iff_le_pred h, natDegree_le_iff_coeff_eq_zero]
+  exact fun _ h ↦ coeff_eq_zero_of_ge _ <| Nat.le_of_pred_lt h
+
+/-- `ofFn n v` has `degree` smaller than `n`. -/
+theorem ofFn_degree_lt {n : ℕ} (v : Fin n → R) : (ofFn n v).degree < n := by
+  by_cases h : ofFn n v = 0
+  · simp only [h, degree_zero]
+    exact Batteries.compareOfLessAndEq_eq_lt.mp rfl
+  · exact (natDegree_lt_iff_degree_lt h).mp
+      <| ofFn_natDegree_lt (Nat.one_le_iff_ne_zero.mpr <| ne_zero_of_ofFn_ne_zero h) _
+
+theorem ofFn_eq_sum_monomial {n : ℕ} (v : Fin n → R) : ofFn n v =
+    ∑ i : Fin n, monomial i (v i) := by
+  by_cases h : n = 0
+  · subst h
+    simp [ofFn]
+  · rw [as_sum_range' (ofFn n v) n <| ofFn_natDegree_lt (Nat.one_le_iff_ne_zero.mpr h) v,
+      Finset.sum_range]
+    congr
+    simp
+
+theorem toFn_comp_ofFn_eq_id (n : ℕ) (v : Fin n → R) : toFn n (ofFn n v) = v := by simp [toFn]
+
+theorem injective_ofFn (n : ℕ) : Function.Injective (ofFn (R := R) n) :=
+  Function.LeftInverse.injective <| toFn_comp_ofFn_eq_id n
+
+theorem surjective_toFn (n : ℕ) : Function.Surjective (toFn (R := R) n) :=
+  Function.RightInverse.surjective <| toFn_comp_ofFn_eq_id n
+
+theorem ofFn_comp_toFn_eq_id_of_natDegree_lt {n : ℕ} {p : R [X]} (h_deg : p.natDegree < n) :
+    ofFn n (toFn n p) = p := by
+  ext i
+  by_cases h : i < n
+  · simp [h, toFn]
+  · simp only [ofFn, toFn, AddMonoidHom.coe_mk, ZeroHom.coe_mk, coeff_ofFinsupp,
+    List.toFinsupp_apply, List.getD_eq_getElem?_getD, List.getElem?_ofFn, h, ↓reduceDIte,
+    Option.getD_none]
+    apply (coeff_eq_zero_of_natDegree_lt _).symm
+    omega
+
+end ofFn
+
+end Polynomial

--- a/Mathlib/Algebra/Polynomial/ofFn.lean
+++ b/Mathlib/Algebra/Polynomial/ofFn.lean
@@ -14,8 +14,8 @@ of its coefficients and vice versa. We prove some basic APIs for these functions
 
 ## Main definitions
 
-- `Polynomial.toFn n` associates a polynomial to the vector of its first `n` coefficients.
-- `Polynomial.ofFn n` associates a vector of lenght `n` to a polynomial that has the entries of the
+- `Polynomial.toFn n` associates to a polynomial the vector of its first `n` coefficients.
+- `Polynomial.ofFn n` associates to a vector of length `n` the polynomial that has the entries of the
   vector as coefficients.
 -/
 
@@ -35,7 +35,6 @@ def toFn (n : ℕ) : R[X] →+ Fin n → R where
     simp only [coeff_zero]
     rfl
 
-@[simp]
 theorem toFn_zero (n : ℕ) : toFn n (0 : R[X]) = 0 := by simp
 
 end toFn
@@ -57,7 +56,6 @@ def ofFn (n : ℕ) : (Fin n → R) →+ R[X] where
     · simp [h]
     · simp [List.getD_getElem?, h]
 
-@[simp]
 theorem ofFn_zero (n : ℕ) : ofFn n (0 : Fin n → R) = 0 := by simp
 
 @[simp]

--- a/Mathlib/Algebra/Polynomial/ofFn.lean
+++ b/Mathlib/Algebra/Polynomial/ofFn.lean
@@ -15,8 +15,8 @@ of its coefficients and vice versa. We prove some basic APIs for these functions
 ## Main definitions
 
 - `Polynomial.toFn n` associates to a polynomial the vector of its first `n` coefficients.
-- `Polynomial.ofFn n` associates to a vector of length `n` the polynomial that has the entries of the
-  vector as coefficients.
+- `Polynomial.ofFn n` associates to a vector of length `n` the polynomial that has the entries of
+  the vector as coefficients.
 -/
 
 namespace Polynomial
@@ -26,13 +26,13 @@ section toFn
 variable {R : Type*} [Semiring R]
 
 /-- `toFn n f` is the vector of the first `n` coefficients of the polynomial `f`. -/
-def toFn (n : ℕ) : R[X] →+ Fin n → R where
+def toFn (n : ℕ) : R[X] →ₗ[R] Fin n → R where
   toFun p := fun i ↦ p.coeff i
   map_add' x y := by
     simp only [coeff_add]
     rfl
-  map_zero' := by
-    simp only [coeff_zero]
+  map_smul' x p := by
+    simp only [coeff_smul]
     rfl
 
 theorem toFn_zero (n : ℕ) : toFn n (0 : R[X]) = 0 := by simp
@@ -40,17 +40,17 @@ theorem toFn_zero (n : ℕ) : toFn n (0 : R[X]) = 0 := by simp
 end toFn
 section ofFn
 
-variable {R : Type*} [Semiring R] [Dec : DecidableEq R]
+variable {R : Type*} [Semiring R] [DecidableEq R]
 
 /-- `ofFn n v` is the polynomial whose coefficients are the entries of the vector `v`. -/
-def ofFn (n : ℕ) : (Fin n → R) →+ R[X] where
+def ofFn (n : ℕ) : (Fin n → R) →ₗ[R] R[X] where
   toFun v := ⟨(List.ofFn v).toFinsupp⟩
   map_add' x y := by
     ext i
     by_cases h : i < n
     · simp [h]
     · simp [List.getD_getElem?, h]
-  map_zero' := by
+  map_smul' x p := by
     ext i
     by_cases h : i < n
     · simp [h]
@@ -113,9 +113,8 @@ theorem ofFn_comp_toFn_eq_id_of_natDegree_lt {n : ℕ} {p : R [X]} (h_deg : p.na
   ext i
   by_cases h : i < n
   · simp [h, toFn]
-  · simp only [ofFn, toFn, AddMonoidHom.coe_mk, ZeroHom.coe_mk, coeff_ofFinsupp,
-    List.toFinsupp_apply, List.getD_eq_getElem?_getD, List.getElem?_ofFn, h, ↓reduceDIte,
-    Option.getD_none]
+  · simp only [ofFn, toFn, LinearMap.coe_mk, AddHom.coe_mk, coeff_ofFinsupp, List.toFinsupp_apply,
+    List.getD_eq_getElem?_getD, List.getElem?_ofFn, h, ↓reduceDIte, Option.getD_none]
     apply (coeff_eq_zero_of_natDegree_lt _).symm
     omega
 


### PR DESCRIPTION
In this PR we introduce `ofFn` and `toFn`, two functions that associate a polynomial to the vector
of its coefficients and vice versa. We prove some basic APIs for these functions.

## Main definitions

-`Polynomial.toFn n` associates to a polynomial the vector of its first `n` coefficients.

-`Polynomial.ofFn n` associates to a vector of length `n` the polynomial that has the entries of the
  vector as coefficients.

See [Zulip](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Construct.20a.20polynomial.20out.20of.20a.20vector) discussion

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
