### PR TITLE
[Merged by Bors] - feat(Mathlib/Dynamics/PeriodicPts/Lemmas): Added lemmas about `periodicPts` on `Fintype`

### DIFF
--- a/Mathlib/Dynamics/PeriodicPts/Defs.lean
+++ b/Mathlib/Dynamics/PeriodicPts/Defs.lean
@@ -199,6 +199,12 @@ theorem mk_mem_periodicPts (hn : 0 < n) (hx : IsPeriodicPt f n x) : x ∈ period
 theorem mem_periodicPts : x ∈ periodicPts f ↔ ∃ n > 0, IsPeriodicPt f n x :=
   Iff.rfl
 
+theorem periodicPts_subset_image : periodicPts f ⊆ range f := by
+  intro x h; rw [mem_periodicPts] at h; rcases h with ⟨n, h₁, h₂⟩
+  use f^[n - 1] x; nth_rw 1 [← iterate_one f]
+  rw [← iterate_add_apply, Nat.add_sub_cancel' (by omega)]
+  exact h₂
+
 theorem isPeriodicPt_of_mem_periodicPts_of_isPeriodicPt_iterate (hx : x ∈ periodicPts f)
     (hm : IsPeriodicPt f m (f^[n] x)) : IsPeriodicPt f m x := by
   rcases hx with ⟨r, hr, hr'⟩

--- a/Mathlib/Dynamics/PeriodicPts/Defs.lean
+++ b/Mathlib/Dynamics/PeriodicPts/Defs.lean
@@ -200,10 +200,13 @@ theorem mem_periodicPts : x ∈ periodicPts f ↔ ∃ n > 0, IsPeriodicPt f n x 
   Iff.rfl
 
 theorem periodicPts_subset_image : periodicPts f ⊆ range f := by
-  intro x h; rw [mem_periodicPts] at h; rcases h with ⟨n, h₁, h₂⟩
-  use f^[n - 1] x; nth_rw 1 [← iterate_one f]
+  intro x h
+  rw [mem_periodicPts] at h
+  rcases h with ⟨n, _, h⟩
+  use f^[n - 1] x
+  nth_rw 1 [← iterate_one f]
   rw [← iterate_add_apply, Nat.add_sub_cancel' (by omega)]
-  exact h₂
+  exact h
 
 theorem isPeriodicPt_of_mem_periodicPts_of_isPeriodicPt_iterate (hx : x ∈ periodicPts f)
     (hm : IsPeriodicPt f m (f^[n] x)) : IsPeriodicPt f m x := by

--- a/Mathlib/Dynamics/PeriodicPts/Lemmas.lean
+++ b/Mathlib/Dynamics/PeriodicPts/Lemmas.lean
@@ -81,35 +81,34 @@ theorem isPeriodicPt_factorial_card_of_mem_periodicPts (h : x ∈ periodicPts f)
     (Nat.dvd_factorial (minimalPeriod_pos_of_mem_periodicPts h) minimalPeriod_le_card)
 
 theorem mem_periodicPts_iff_isPeriodicPt_factorial_card :
-    x ∈ periodicPts f ↔ IsPeriodicPt f (card α)! x :=
-  ⟨isPeriodicPt_factorial_card_of_mem_periodicPts, fun h ↦
-   minimalPeriod_pos_iff_mem_periodicPts.mp
-    (IsPeriodicPt.minimalPeriod_pos (Nat.factorial_pos _) h)⟩
+    x ∈ periodicPts f ↔ IsPeriodicPt f (card α)! x where
+  mp := isPeriodicPt_factorial_card_of_mem_periodicPts
+  mpr h := minimalPeriod_pos_iff_mem_periodicPts.mp
+    (IsPeriodicPt.minimalPeriod_pos (Nat.factorial_pos _) h)
 
 open Finset in
 theorem mem_periodicPts_of_injective (h : Injective f) : x ∈ periodicPts f := by
-  have h₁ : ∀ a ∈ (range (card α).succ), f^[a] x ∈ Finset.univ := fun _ _ ↦ mem_univ _
+  have h₁ (a) (ha : a ∈ range (card α).succ) : f^[a] x ∈ Finset.univ := mem_univ _
   rcases exists_ne_map_eq_of_card_lt_of_maps_to (by simp) h₁ with ⟨_, _, _, _, h₂, h₃⟩
   rcases lt_or_gt_of_ne h₂ with h₂ | h₂
   · exact mk_mem_periodicPts (by omega) (iterate_cancel h h₃.symm)
   · exact mk_mem_periodicPts (by omega) (iterate_cancel h h₃)
 
-theorem forall_mem_periodicPts_iff_injective :
-    (∀ x, x ∈ periodicPts f) ↔ Injective f :=
-  ⟨fun h ↦ ((bijective_iff_injective_and_card f).mp
-    ((bijective_iff_surjective_and_card f).mpr ⟨Set.range_eq_univ.mp
-      (ext fun _ ↦ ⟨fun _ ↦ mem_univ _, fun _ ↦ periodicPts_subset_image (h _)⟩), rfl⟩)).1,
-   fun h _ ↦ mem_periodicPts_of_injective h⟩
+theorem injective_iff_forall_mem_periodicPts : Injective f ↔ periodicPts f = univ := by
+  constructor <;> intro h
+  · ext; simp only [mem_univ, mem_periodicPts_of_injective h]
+  · exact ((bijective_iff_injective_and_card f).mp
+      ((bijective_iff_surjective_and_card f).mpr ⟨Set.range_eq_univ.mp
+        (Subset.antisymm (subset_univ _) (h ▸ periodicPts_subset_image)), rfl⟩)).1
 
 theorem injective_iff_iterate_factorial_card_eq_id :
     Injective f ↔ f^[(card α)!] = id := by
+  rw [injective_iff_forall_mem_periodicPts]
   constructor <;> intro h
-  · simp_rw [← forall_isFixedPt_iff]; intro
-    rw [← forall_mem_periodicPts_iff_injective] at h
-    exact mem_periodicPts_iff_isPeriodicPt_factorial_card.mp (h _)
-  · rw [← forall_mem_periodicPts_iff_injective]; intro
-    rw [mem_periodicPts_iff_isPeriodicPt_factorial_card]
-    simp only [IsPeriodicPt, isFixedPt_id, h]
+  · simp_rw [← forall_isFixedPt_iff]
+    exact fun _ ↦ mem_periodicPts_iff_isPeriodicPt_factorial_card.mp (h ▸ mem_univ _)
+  · ext; simp only [mem_univ, iff_true, mem_periodicPts_iff_isPeriodicPt_factorial_card,
+      IsPeriodicPt, isFixedPt_id, h]
 
 end Fintype
 

--- a/Mathlib/Dynamics/PeriodicPts/Lemmas.lean
+++ b/Mathlib/Dynamics/PeriodicPts/Lemmas.lean
@@ -75,10 +75,6 @@ theorem minimalPeriod_le_card : minimalPeriod f x ≤ card α := by
   rw [← periodicOrbit_length]
   exact List.Nodup.length_le_card nodup_periodicOrbit
 
-theorem minimalPeriod_dvd_factorial_card_of_mem_periodicPts (h : x ∈ periodicPts f) :
-    minimalPeriod f x ∣ (card α)! :=
-  Nat.dvd_factorial (minimalPeriod_pos_of_mem_periodicPts h) minimalPeriod_le_card
-
 theorem isPeriodicPt_factorial_card_of_mem_periodicPts (h : x ∈ periodicPts f) :
     IsPeriodicPt f (card α)! x :=
   isPeriodicPt_iff_minimalPeriod_dvd.mpr

--- a/Mathlib/Dynamics/PeriodicPts/Lemmas.lean
+++ b/Mathlib/Dynamics/PeriodicPts/Lemmas.lean
@@ -3,6 +3,8 @@ Copyright (c) 2020 Yury Kudryashov. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury Kudryashov
 -/
+import Mathlib.Data.Fintype.Card
+import Mathlib.Data.Fintype.EquivFin
 import Mathlib.Data.Nat.GCD.Basic
 import Mathlib.Data.Nat.Prime.Basic
 import Mathlib.Data.PNat.Basic
@@ -62,6 +64,58 @@ theorem Commute.minimalPeriod_of_comp_eq_mul_of_coprime {g : α → α} (h : Com
   refine hco.dvd_of_dvd_mul_left (IsPeriodicPt.left_of_comp h ?_ ?_).minimalPeriod_dvd
   · exact (isPeriodicPt_minimalPeriod _ _).const_mul _
   · exact (isPeriodicPt_minimalPeriod _ _).mul_const _
+
+section Fintype
+
+variable [Fintype α]
+
+open Fintype
+
+theorem minimalPeriod_le_card : minimalPeriod f x ≤ card α := by
+  rw [← periodicOrbit_length]
+  exact List.Nodup.length_le_card nodup_periodicOrbit
+
+theorem minimalPeriod_dvd_factorial_card_of_mem_periodicPts (h : x ∈ periodicPts f) :
+    minimalPeriod f x ∣ (card α)! :=
+  Nat.dvd_factorial (minimalPeriod_pos_of_mem_periodicPts h) minimalPeriod_le_card
+
+theorem isPeriodicPt_factorial_card_of_mem_periodicPts (h : x ∈ periodicPts f) :
+    IsPeriodicPt f (card α)! x :=
+  isPeriodicPt_iff_minimalPeriod_dvd.mpr
+    (Nat.dvd_factorial (minimalPeriod_pos_of_mem_periodicPts h) minimalPeriod_le_card)
+
+theorem mem_periodicPts_iff_isPeriodicPt_factorial_card :
+    x ∈ periodicPts f ↔ IsPeriodicPt f (card α)! x :=
+  ⟨isPeriodicPt_factorial_card_of_mem_periodicPts, fun h ↦
+   minimalPeriod_pos_iff_mem_periodicPts.mp
+    (IsPeriodicPt.minimalPeriod_pos (Nat.factorial_pos _) h)⟩
+
+open Finset in
+theorem mem_periodicPts_of_injective (h : Injective f) : x ∈ periodicPts f := by
+  have h₁ : ∀ a ∈ (range (card α).succ), f^[a] x ∈ Finset.univ := fun _ _ ↦ mem_univ _
+  rcases exists_ne_map_eq_of_card_lt_of_maps_to (by simp) h₁ with ⟨_, _, _, _, h₂, h₃⟩
+  rcases lt_or_gt_of_ne h₂ with h₂ | h₂
+  · exact mk_mem_periodicPts (by omega) (iterate_cancel h h₃.symm)
+  · exact mk_mem_periodicPts (by omega) (iterate_cancel h h₃)
+
+theorem forall_mem_periodicPts_iff_injective :
+    (∀ x, x ∈ periodicPts f) ↔ Injective f :=
+  ⟨fun h ↦ ((bijective_iff_injective_and_card f).mp
+    ((bijective_iff_surjective_and_card f).mpr ⟨Set.range_eq_univ.mp
+      (ext fun _ ↦ ⟨fun _ ↦ mem_univ _, fun _ ↦ periodicPts_subset_image (h _)⟩), rfl⟩)).1,
+   fun h _ ↦ mem_periodicPts_of_injective h⟩
+
+theorem injective_iff_iterate_factorial_card_eq_id :
+    Injective f ↔ f^[(card α)!] = id := by
+  constructor <;> intro h
+  · simp_rw [← forall_isFixedPt_iff]; intro
+    rw [← forall_mem_periodicPts_iff_injective] at h
+    exact mem_periodicPts_iff_isPeriodicPt_factorial_card.mp (h _)
+  · rw [← forall_mem_periodicPts_iff_injective]; intro
+    rw [mem_periodicPts_iff_isPeriodicPt_factorial_card]
+    simp only [IsPeriodicPt, isFixedPt_id, h]
+
+end Fintype
 
 end Function
 


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

There is one auxiliary lemma added in `Mathlib/Dynamics/PeriodicPts/Basic`, which is `periodicPts_subset_image`.
All other lemmas are placed in `Mathlib/Dynamics/PeriodicPts/Lemmas`.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
