### PR TITLE
[Merged by Bors] - feat: the left summand of `α ⊕ β` is equivalent to `α`

### DIFF
--- a/Mathlib/Logic/Equiv/Defs.lean
+++ b/Mathlib/Logic/Equiv/Defs.lean
@@ -3,9 +3,10 @@ Copyright (c) 2015 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leonardo de Moura, Mario Carneiro
 -/
+import Mathlib.Data.Bool.Basic
 import Mathlib.Data.FunLike.Equiv
 import Mathlib.Data.Quot
-import Mathlib.Data.Bool.Basic
+import Mathlib.Data.Subtype
 import Mathlib.Logic.Unique
 import Mathlib.Tactic.Conv
 import Mathlib.Tactic.Simps.Basic
@@ -858,3 +859,24 @@ def finTwoEquiv : Fin 2 ≃ Bool where
     | 0 => by simp
     | 1 => by simp
   right_inv b := by cases b <;> simp
+
+namespace Equiv
+variable {α β : Type*}
+
+/-- The left summand of `α ⊕ β` is equivalent to `α`. -/
+@[simps]
+def sumIsLeft : {x : α ⊕ β // x.isLeft} ≃ α where
+  toFun x := x.1.getLeft x.2
+  invFun a := ⟨.inl a, Sum.isLeft_inl⟩
+  left_inv | ⟨.inl _a, _⟩ => rfl
+  right_inv _a := rfl
+
+/-- The right summand of `α ⊕ β` is equivalent to `β`. -/
+@[simps]
+def sumIsRight : {x : α ⊕ β // x.isRight} ≃ β where
+  toFun x := x.1.getRight x.2
+  invFun b := ⟨.inr b, Sum.isRight_inr⟩
+  left_inv | ⟨.inr _b, _⟩ => rfl
+  right_inv _b := rfl
+
+end Equiv

--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -373,7 +373,8 @@
   "Mathlib.Logic.Nontrivial.Defs": ["Mathlib.Init.Logic"],
   "Mathlib.Logic.Function.Defs": ["Mathlib.Tactic.AdaptationNote"],
   "Mathlib.Logic.Function.Basic": ["Batteries.Tactic.Init"],
-  "Mathlib.Logic.Equiv.Defs": ["Mathlib.Data.Bool.Basic"],
+  "Mathlib.Logic.Equiv.Defs":
+  ["Mathlib.Data.Bool.Basic", "Mathlib.Data.Subtype"],
   "Mathlib.Logic.Basic": ["Batteries.Tactic.Trans"],
   "Mathlib.LinearAlgebra.Matrix.Transvection": ["Mathlib.Data.Matrix.DMatrix"],
   "Mathlib.LinearAlgebra.DFinsupp": ["Mathlib.LinearAlgebra.Finsupp.SumProd"],


### PR DESCRIPTION
This matches `Equiv.optionIsSomeEquiv`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->
This was originally needed in #23020, but not anymore.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
