### PR TITLE
[Merged by Bors] - feat(SimpleGraph): induced containment

### DIFF
--- a/Mathlib/Combinatorics/SimpleGraph/Copy.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Copy.lean
@@ -1,42 +1,63 @@
 /-
-Copyright (c) 2025 Mitchell Horner. All rights reserved.
+Copyright (c) 2023 Yaël Dillies, Mitchell Horner. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Mitchell Horner
+Authors: Yaël Dillies, Mitchell Horner
 -/
 import Mathlib.Combinatorics.SimpleGraph.Subgraph
 
 /-!
-# Copies of Simple Graphs
+# Containment of graphs
 
 This file introduces the concept of one simple graph containing a copy of another.
 
-## Main definitions
+For two simple graph `G` and `H`, a *copy* of `G` in `H` is a (not necessarily induced) subgraph of
+`H` isomorphic to `G`.
 
+If there exists a copy of `G` in `H`, we say that `H` *contains* `G`. This is equivalent to saying
+that there is an injective graph homomorphism `G → H` them (this is **not** the same as a graph
+embedding, as we do not require the subgraph to be induced).
+
+If there exists an induced copy of `G` in `H`, we say that `H` *inducingly contains* `G`. This is
+equivalent to saying that there is a graph embedding `G ↪ H`.
+
+## Main declarations
+
+Containment:
 * `SimpleGraph.Copy A B` is the type of copies of `A` in `B`, implemented as the subtype of
   *injective* homomorphisms.
-
 * `SimpleGraph.IsContained A B`, `A ⊑ B` is the relation that `B` contains a copy of `A`, that
   is, the type of copies of `A` in `B` is nonempty. This is equivalent to the existence of an
   isomorphism from `A` to a subgraph of `B`.
-
   This is similar to `SimpleGraph.IsSubgraph` except that the simple graphs here need not have the
   same underlying vertex type.
-
 * `SimpleGraph.Free` is the predicate that `B` is `A`-free, that is, `B` does not contain a copy of
   `A`. This is the negation of `SimpleGraph.IsContained` implemented for convenience.
+
+Induced containment:
+* Induced copies of `G` inside `H` are already defined as `G ↪g H`.
+* `SimpleGraph.IsIndContained G H` : `G` is contained as an induced subgraph in `H`.
 
 ## Notation
 
 The following notation is declared in locale `SimpleGraph`:
-
 * `G ⊑ H` for `SimpleGraph.IsContained G H`.
+* `G ⊴ H` for `SimpleGraph.IsIndContained G H`.
 -/
 
 open Finset Function
+open Fintype (card)
 
 namespace SimpleGraph
 variable {V W X α β γ : Type*} {G G₁ G₂ G₃ : SimpleGraph V} {H : SimpleGraph W} {I : SimpleGraph X}
   {A : SimpleGraph α} {B : SimpleGraph β} {C : SimpleGraph γ}
+
+/-!
+### Copies
+
+Note that induced copies of `G` inside `H` are already defined as `G ↪g H`.
+
+#### Not necessarily induced copies
+-/
 
 section Copy
 
@@ -123,6 +144,34 @@ def induce (G : SimpleGraph V) (s : Set V) : Copy (G.induce s) G := (Embedding.i
 /-- The copy of `⊥` in any simple graph that can embed its vertices. -/
 protected def bot (f : α ↪ β) : Copy (⊥ : SimpleGraph α) B := ⟨⟨f, False.elim⟩, f.injective⟩
 
+/-- The isomorphism from a subgraph of `A` to its map under a copy `f : Copy A B`. -/
+noncomputable def isoSubgraphMap (f : Copy A B) (A' : A.Subgraph) :
+    A'.coe ≃g (A'.map f.toHom).coe := by
+  use Equiv.Set.image f.toHom _ f.injective
+  simp_rw [Subgraph.map_verts, Equiv.Set.image_apply, Subgraph.coe_adj, Subgraph.map_adj,
+    Relation.map_apply, f.injective.eq_iff, exists_eq_right_right, exists_eq_right, forall_true_iff]
+
+/-- The subgraph of `B` corresponding to a copy of `A` inside `B`. -/
+abbrev toSubgraph (f : Copy A B) : B.Subgraph := .map f.toHom ⊤
+
+/-- The isomorphism from `A` to its copy under `f : Copy A B`. -/
+noncomputable def isoToSubgraph (f : Copy A B) : A ≃g f.toSubgraph.coe :=
+  (f.isoSubgraphMap ⊤).comp Subgraph.topIso.symm
+
+@[simp] lemma range_toSubgraph :
+    .range (toSubgraph (A := A)) = {B' : B.Subgraph | Nonempty (A ≃g B'.coe)} := by
+  ext H'
+  constructor
+  · rintro ⟨f, hf, rfl⟩
+    simpa [toSubgraph] using ⟨f.isoToSubgraph⟩
+  · rintro ⟨e⟩
+    refine ⟨⟨H'.hom.comp e.toHom, Subgraph.hom_injective.comp e.injective⟩, ?_⟩
+    simp [toSubgraph, Subgraph.map_comp]
+
+lemma toSubgraph_surjOn :
+    Set.SurjOn (toSubgraph (A := A)) .univ {B' : B.Subgraph | Nonempty (A ≃g B'.coe)} :=
+  fun H' hH' ↦ by simpa
+
 instance [Subsingleton (V → W)] : Subsingleton (G.Copy H) := DFunLike.coe_injective.subsingleton
 
 instance [Fintype {f : G →g H // Injective f}] : Fintype (G.Copy H) :=
@@ -139,6 +188,12 @@ end Copy
 def Subgraph.coeCopy (G' : G.Subgraph) : Copy G'.coe G := G'.hom.toCopy hom_injective
 
 end Copy
+
+/-!
+### Containment
+
+#### Not necessarily induced containment
+-/
 
 section IsContained
 
@@ -192,18 +247,11 @@ protected alias IsContained.bot := bot_isContained_iff_card_le
 /-- A simple graph `G` contains all `Subgraph G` coercions. -/
 lemma Subgraph.coe_isContained (G' : G.Subgraph) : G'.coe ⊑ G := ⟨G'.coeCopy⟩
 
-/-- The isomorphism from `Subgraph A` to its map under a copy `Copy A B`. -/
-noncomputable def Subgraph.Copy.map (f : Copy A B) (A' : A.Subgraph) :
-    A'.coe ≃g (A'.map f.toHom).coe := by
-  use Equiv.Set.image f.toHom _ f.injective
-  simp_rw [map_verts, Equiv.Set.image_apply, coe_adj, map_adj, Relation.map_apply,
-    Function.Injective.eq_iff f.injective, exists_eq_right_right, exists_eq_right, forall_true_iff]
-
 /-- `B` contains `A` if and only if `B` has a subgraph `B'` and `B'` is isomorphic to `A`. -/
 theorem isContained_iff_exists_iso_subgraph :
-    A ⊑ B ↔ ∃ B' : B.Subgraph, Nonempty (A ≃g B'.coe) :=
-  ⟨fun ⟨f⟩ ↦ ⟨Subgraph.map f.toHom ⊤, ⟨(Subgraph.Copy.map f ⊤).comp Subgraph.topIso.symm⟩⟩,
-    fun ⟨B', ⟨e⟩⟩ ↦ B'.coe_isContained.trans' ⟨e.toCopy⟩⟩
+    A ⊑ B ↔ ∃ B' : B.Subgraph, Nonempty (A ≃g B'.coe) where
+  mp := fun ⟨f⟩ ↦ ⟨.map f.toHom ⊤, ⟨f.isoToSubgraph⟩⟩
+  mpr := fun ⟨B', ⟨e⟩⟩ ↦ B'.coe_isContained.trans' ⟨e.toCopy⟩
 
 alias ⟨IsContained.exists_iso_subgraph, IsContained.of_exists_iso_subgraph⟩ :=
   isContained_iff_exists_iso_subgraph
@@ -228,5 +276,52 @@ lemma free_bot (h : A ≠ ⊥) : A.Free (⊥ : SimpleGraph β) := by
   exact Set.not_mem_empty (h.choose.map f)
 
 end Free
+
+/-!
+#### Induced containment
+
+A graph `H` *inducingly contains* a graph `G` if there is some graph embedding `G ↪ H`. This amounts
+to `H` having an induced subgraph isomorphic to `G`.
+
+We denote "`G` is contained in `H`" by `G ⊴ H` (`\triangle_left_eq`).
+-/
+
+/-- A simple graph `G` is contained in a simple graph `H` if there exists an induced subgraph of `H`
+isomorphic to `G`. This is denoted by `G ⊴ H`. -/
+def IsIndContained (G : SimpleGraph V) (H : SimpleGraph β) : Prop := Nonempty (G ↪g H)
+
+@[inherit_doc] scoped infixl:50 " ⊴ " => SimpleGraph.IsIndContained
+
+protected lemma IsIndContained.isContained : G₁ ⊴ G₂ → G₁ ⊑ G₂ := fun ⟨f⟩ ↦ ⟨f, f.injective⟩
+protected lemma Iso.isIndContained (e : G ≃g H) : G ⊴ H := ⟨e⟩
+protected lemma Iso.isIndContained' (e : G ≃g H) : H ⊴ G := e.symm.isIndContained
+
+protected lemma Subgraph.IsInduced.isIndContained {G' : G.Subgraph} (hG' : G'.IsInduced) :
+    G'.coe ⊴ G :=
+  ⟨{  toFun := (↑)
+      inj' := Subtype.coe_injective
+      map_rel_iff' := hG'.adj.symm }⟩
+
+@[refl] lemma IsIndContained.refl (G : SimpleGraph V) : G ⊴ G := ⟨Embedding.refl⟩
+lemma IsIndContained.rfl : G ⊴ G := .refl _
+lemma IsIndContained.trans : G ⊴ H → H ⊴ I → G ⊴ I := fun ⟨f⟩ ⟨g⟩ ↦ ⟨g.comp f⟩
+
+lemma IsIndContained.of_isEmpty [IsEmpty V] : G ⊴ H :=
+  ⟨{  toFun := isEmptyElim
+      inj' := isEmptyElim
+      map_rel_iff' := fun {a} ↦ isEmptyElim a }⟩
+
+lemma isIndContained_iff_exists_iso_subgraph :
+    G ⊴ H ↔ ∃ (H' : H.Subgraph) (_e : G ≃g H'.coe), H'.IsInduced := by
+  constructor
+  · rintro ⟨f⟩
+    refine ⟨Subgraph.map f.toHom ⊤, f.toCopy.isoToSubgraph, ?_⟩
+    rintro _ ⟨a, -, rfl⟩ _ ⟨b, -, rfl⟩
+    simp [Relation.map_apply_apply, f.injective]
+  · rintro ⟨H', e, hH'⟩
+    exact e.isIndContained.trans hH'.isIndContained
+
+alias ⟨IsIndContained.exists_iso_subgraph, IsIndContained.of_exists_iso_subgraph⟩ :=
+  isIndContained_iff_exists_iso_subgraph
 
 end SimpleGraph

--- a/Mathlib/Combinatorics/SimpleGraph/Copy.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Copy.lean
@@ -193,6 +193,11 @@ end Copy
 ### Containment
 
 #### Not necessarily induced containment
+
+A graph `H` *contains* a graph `G` if there is some copy `f : Copy G H` of `G` inside `H`. This
+amounts to `H` having a subgraph isomorphic to `G`.
+
+We denote "`G` is contained in `H`" by `G ⊑ H` (`\squb`).
 -/
 
 section IsContained
@@ -285,7 +290,7 @@ end Free
 A graph `H` *inducingly contains* a graph `G` if there is some graph embedding `G ↪ H`. This amounts
 to `H` having an induced subgraph isomorphic to `G`.
 
-We denote "`G` is contained in `H`" by `G ⊴ H` (`\triangle_left_eq`).
+We denote "`G` is inducingly contained in `H`" by `G ⊴ H` (`\trianglelefteq`).
 -/
 
 /-- A simple graph `G` is inducingly contained in a simple graph `H` if there exists an induced
@@ -310,13 +315,12 @@ protected lemma Subgraph.IsInduced.isIndContained {G' : G.Subgraph} (hG' : G'.Is
 
 @[refl] lemma IsIndContained.refl (G : SimpleGraph V) : G ⊴ G := ⟨Embedding.refl⟩
 lemma IsIndContained.rfl : G ⊴ G := .refl _
-lemma IsIndContained.trans : G ⊴ H → H ⊴ I → G ⊴ I := fun ⟨f⟩ ⟨g⟩ ↦ ⟨g.comp f⟩
+@[trans] lemma IsIndContained.trans : G ⊴ H → H ⊴ I → G ⊴ I := fun ⟨f⟩ ⟨g⟩ ↦ ⟨g.comp f⟩
 
 lemma IsIndContained.of_isEmpty [IsEmpty V] : G ⊴ H :=
   ⟨{ toFun := isEmptyElim
      inj' := isEmptyElim
      map_rel_iff' := fun {a} ↦ isEmptyElim a }⟩
-
 
 lemma isIndContained_iff_exists_iso_subgraph :
     G ⊴ H ↔ ∃ (H' : H.Subgraph) (_e : G ≃g H'.coe), H'.IsInduced := by

--- a/Mathlib/Combinatorics/SimpleGraph/Copy.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Copy.lean
@@ -59,9 +59,12 @@ variable {V W X α β γ : Type*} {G G₁ G₂ G₃ : SimpleGraph V} {H : Simple
 /-!
 ### Copies
 
-Note that induced copies of `G` inside `H` are already defined as `G ↪g H`.
-
 #### Not necessarily induced copies
+
+A copy of a subgraph `G` inside a subgraph `H` is an embedding of the vertices of `G` into the
+vertices of `H`, such that adjacency in `G` implies adjacency in `H`.
+
+We capture this concept by injective graph homomorphisms.
 -/
 
 section Copy
@@ -195,6 +198,13 @@ def Subgraph.coeCopy (G' : G.Subgraph) : Copy G'.coe G := G'.hom.toCopy hom_inje
 end Copy
 
 /-!
+#### Induced copies
+
+An induced copy of a graph `G` inside a graph `H` is an embedding from the vertices of
+`G` into the vertices of `H` which preserves the adjacency relation.
+
+This is already captured by the notion of graph embeddings, defined as `G ↪g H`.
+
 ### Containment
 
 #### Not necessarily induced containment

--- a/Mathlib/Combinatorics/SimpleGraph/Copy.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Copy.lean
@@ -247,6 +247,8 @@ protected alias IsContained.bot := bot_isContained_iff_card_le
 /-- A simple graph `G` contains all `Subgraph G` coercions. -/
 lemma Subgraph.coe_isContained (G' : G.Subgraph) : G'.coe ⊑ G := ⟨G'.coeCopy⟩
 
+@[deprecated (since := "2025-03-19")] alias Subgraph.Copy.map := Copy.isoSubgraphMap
+
 /-- `B` contains `A` if and only if `B` has a subgraph `B'` and `B'` is isomorphic to `A`. -/
 theorem isContained_iff_exists_iso_subgraph :
     A ⊑ B ↔ ∃ B' : B.Subgraph, Nonempty (A ≃g B'.coe) where

--- a/Mathlib/Combinatorics/SimpleGraph/Copy.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Copy.lean
@@ -46,7 +46,6 @@ The following notation is declared in locale `SimpleGraph`:
 ## TODO
 
 Relate `⊤ ⊑ H`/`⊥ ⊑ H` to there being a clique/independent set in `H`.
-Relate `⊤ ⊑ H` to there being an independent set in `H`.
 -/
 
 open Finset Function

--- a/Mathlib/Combinatorics/SimpleGraph/Copy.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Copy.lean
@@ -42,6 +42,11 @@ Induced containment:
 The following notation is declared in locale `SimpleGraph`:
 * `G ⊑ H` for `SimpleGraph.IsContained G H`.
 * `G ⊴ H` for `SimpleGraph.IsIndContained G H`.
+
+## TODO
+
+Relate `⊤ ⊑ H`/`⊥ ⊑ H` to there being a clique/independent set in `H`.
+Relate `⊤ ⊑ H` to there being an independent set in `H`.
 -/
 
 open Finset Function
@@ -338,5 +343,10 @@ alias ⟨IsIndContained.exists_iso_subgraph, IsIndContained.of_exists_iso_subgra
     (⊤ : SimpleGraph V) ⊴ H ↔ (⊤ : SimpleGraph V) ⊑ H where
   mp h := h.isContained
   mpr := fun ⟨f⟩ ↦ ⟨f.toEmbedding, fun {v w} ↦ ⟨fun h ↦ by simpa using h.ne, f.toHom.map_adj⟩⟩
+
+@[simp] lemma compl_isIndContained_compl : Gᶜ ⊴ Hᶜ ↔ G ⊴ H :=
+  Embedding.complEquiv.symm.nonempty_congr
+
+protected alias ⟨IsIndContained.of_compl, IsIndContained.compl⟩ := compl_isIndContained_compl
 
 end SimpleGraph

--- a/Mathlib/Combinatorics/SimpleGraph/Maps.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Maps.lean
@@ -406,6 +406,16 @@ abbrev comp (f' : G' ↪g G'') (f : G ↪g G') : G ↪g G'' :=
 theorem coe_comp (f' : G' ↪g G'') (f : G ↪g G') : ⇑(f'.comp f) = f' ∘ f :=
   rfl
 
+/-- Graph embeddings from `G` to `H` are the same thing as graph embeddings from `Gᶜ` to `Hᶜ`. -/
+def complEquiv : G ↪g H ≃ Gᶜ ↪g Hᶜ where
+  toFun f := ⟨f.toEmbedding, by simp⟩
+  invFun f := ⟨f.toEmbedding, fun {v w} ↦ by
+    obtain rfl | hvw := eq_or_ne v w
+    · simp
+    · simpa [hvw, not_iff_not] using f.map_adj_iff (v := v) (w := w)⟩
+  left_inv f := rfl
+  right_inv f := rfl
+
 end Embedding
 
 section induceHom


### PR DESCRIPTION
Define induced containment of simple graphs.

From ExtrProbCombi (LeanCamCombi)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->
- [x] depends on: #23090

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
