### PR TITLE
[Merged by Bors] - refactor(Logic/Equiv/List): split

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3926,9 +3926,11 @@ import Mathlib.Logic.Equiv.Defs
 import Mathlib.Logic.Equiv.Embedding
 import Mathlib.Logic.Equiv.Fin.Basic
 import Mathlib.Logic.Equiv.Fin.Rotate
+import Mathlib.Logic.Equiv.Finset
 import Mathlib.Logic.Equiv.Fintype
 import Mathlib.Logic.Equiv.Functor
 import Mathlib.Logic.Equiv.List
+import Mathlib.Logic.Equiv.Multiset
 import Mathlib.Logic.Equiv.Nat
 import Mathlib.Logic.Equiv.Option
 import Mathlib.Logic.Equiv.Pairwise

--- a/Mathlib/Data/Set/Countable.lean
+++ b/Mathlib/Data/Set/Countable.lean
@@ -22,7 +22,7 @@ For a noncomputable conversion to `Encodable s`, use `Set.Countable.nonempty_enc
 sets, countable set
 -/
 
-assert_not_exists Monoid
+assert_not_exists Monoid Multiset.sort
 
 noncomputable section
 

--- a/Mathlib/Logic/Encodable/Pi.lean
+++ b/Mathlib/Logic/Encodable/Pi.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
 import Mathlib.Data.Vector.Basic
-import Mathlib.Logic.Equiv.List
+import Mathlib.Logic.Equiv.Finset
 
 /-!
 # Encodability of Pi types

--- a/Mathlib/Logic/Equiv/Finset.lean
+++ b/Mathlib/Logic/Equiv/Finset.lean
@@ -3,8 +3,8 @@ Copyright (c) 2018 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
-import Mathlib.Logic.Equiv.Multiset
 import Mathlib.Data.Finset.Sort
+import Mathlib.Logic.Equiv.Multiset
 
 /-!
 # `Encodable` and `Denumerable` instances for `Finset`

--- a/Mathlib/Logic/Equiv/Finset.lean
+++ b/Mathlib/Logic/Equiv/Finset.lean
@@ -1,0 +1,109 @@
+/-
+Copyright (c) 2018 Mario Carneiro. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mario Carneiro
+-/
+import Mathlib.Logic.Equiv.Multiset
+import Mathlib.Data.Finset.Sort
+
+/-!
+# `Encodable` and `Denumerable` instances for `Finset`
+-/
+
+variable {α}
+
+open Encodable
+
+/-- If `α` is encodable, then so is `Finset α`. -/
+instance Finset.encodable [Encodable α] : Encodable (Finset α) :=
+  haveI := decidableEqOfEncodable α
+  ofEquiv { s : Multiset α // s.Nodup }
+    ⟨fun ⟨a, b⟩ => ⟨a, b⟩, fun ⟨a, b⟩ => ⟨a, b⟩, fun ⟨_, _⟩ => rfl, fun ⟨_, _⟩ => rfl⟩
+
+namespace Encodable
+
+/-- The elements of a `Fintype` as a sorted list. -/
+def sortedUniv (α) [Fintype α] [Encodable α] : List α :=
+  Finset.univ.sort (Encodable.encode' α ⁻¹'o (· ≤ ·))
+
+@[simp]
+theorem mem_sortedUniv {α} [Fintype α] [Encodable α] (x : α) : x ∈ sortedUniv α :=
+  (Finset.mem_sort _).2 (Finset.mem_univ _)
+
+@[simp]
+theorem length_sortedUniv (α) [Fintype α] [Encodable α] : (sortedUniv α).length = Fintype.card α :=
+  Finset.length_sort _
+
+@[simp]
+theorem sortedUniv_nodup (α) [Fintype α] [Encodable α] : (sortedUniv α).Nodup :=
+  Finset.sort_nodup _ _
+
+@[simp]
+theorem sortedUniv_toFinset (α) [Fintype α] [Encodable α] [DecidableEq α] :
+    (sortedUniv α).toFinset = Finset.univ :=
+  Finset.sort_toFinset _ _
+
+/-- An encodable `Fintype` is equivalent to the same size `Fin`. -/
+def fintypeEquivFin {α} [Fintype α] [Encodable α] : α ≃ Fin (Fintype.card α) :=
+  haveI : DecidableEq α := Encodable.decidableEqOfEncodable _
+  ((sortedUniv_nodup α).getEquivOfForallMemList _ mem_sortedUniv).symm.trans <|
+    Equiv.cast (congr_arg _ (length_sortedUniv α))
+
+end Encodable
+
+
+namespace Denumerable
+variable [Denumerable α]
+
+/-- Outputs the list of differences minus one of the input list, that is
+`lower' [a₁, a₂, a₃, ...] n = [a₁ - n, a₂ - a₁ - 1, a₃ - a₂ - 1, ...]`. -/
+def lower' : List ℕ → ℕ → List ℕ
+  | [], _ => []
+  | m :: l, n => (m - n) :: lower' l (m + 1)
+
+/-- Outputs the list of partial sums plus one of the input list, that is
+`raise [a₁, a₂, a₃, ...] n = [n + a₁, n + a₁ + a₂ + 1, n + a₁ + a₂ + a₃ + 2, ...]`. Adding one each
+time ensures the elements are distinct. -/
+def raise' : List ℕ → ℕ → List ℕ
+  | [], _ => []
+  | m :: l, n => (m + n) :: raise' l (m + n + 1)
+
+theorem lower_raise' : ∀ l n, lower' (raise' l n) n = l
+  | [], _ => rfl
+  | m :: l, n => by simp [raise', lower', Nat.add_sub_cancel_right, lower_raise']
+
+theorem raise_lower' : ∀ {l n}, (∀ m ∈ l, n ≤ m) → List.Sorted (· < ·) l → raise' (lower' l n) n = l
+  | [], _, _, _ => rfl
+  | m :: l, n, h₁, h₂ => by
+    have : n ≤ m := h₁ _ (l.mem_cons_self _)
+    simp [raise', lower', Nat.sub_add_cancel this,
+      raise_lower' (List.rel_of_sorted_cons h₂ : ∀ a ∈ l, m < a) h₂.of_cons]
+
+theorem raise'_chain : ∀ (l) {m n}, m < n → List.Chain (· < ·) m (raise' l n)
+  | [], _, _, _ => List.Chain.nil
+  | _ :: _, _, _, h =>
+    List.Chain.cons (lt_of_lt_of_le h (Nat.le_add_left _ _)) (raise'_chain _ (Nat.lt_succ_self _))
+
+/-- `raise' l n` is a strictly increasing sequence. -/
+theorem raise'_sorted : ∀ l n, List.Sorted (· < ·) (raise' l n)
+  | [], _ => List.sorted_nil
+  | _ :: _, _ => List.chain_iff_pairwise.1 (raise'_chain _ (Nat.lt_succ_self _))
+
+/-- Makes `raise' l n` into a finset. Elements are distinct thanks to `raise'_sorted`. -/
+def raise'Finset (l : List ℕ) (n : ℕ) : Finset ℕ :=
+  ⟨raise' l n, (raise'_sorted _ _).imp (@ne_of_lt _ _)⟩
+
+/-- If `α` is denumerable, then so is `Finset α`. Warning: this is *not* the same encoding as used
+in `Finset.encodable`. -/
+instance finset : Denumerable (Finset α) :=
+  mk'
+    ⟨fun s : Finset α => encode <| lower' ((s.map (eqv α).toEmbedding).sort (· ≤ ·)) 0, fun n =>
+      Finset.map (eqv α).symm.toEmbedding (raise'Finset (ofNat (List ℕ) n) 0), fun s =>
+      Finset.eq_of_veq <| by
+        simp [-Multiset.map_coe, raise'Finset,
+          raise_lower' (fun n _ => Nat.zero_le n) (Finset.sort_sorted_lt _)],
+      fun n => by
+      simp [-Multiset.map_coe, Finset.map, raise'Finset, Finset.sort,
+        List.mergeSort_eq_self _ (raise'_sorted _ _).le_of_lt, lower_raise']⟩
+
+end Denumerable

--- a/Mathlib/Logic/Equiv/List.lean
+++ b/Mathlib/Logic/Equiv/List.lean
@@ -81,11 +81,11 @@ end List
 require `Finset.sort`. -/
 
 /-- If `α` is countable, then so is `Multiset α`. -/
-instance _root_.Multiset.countable {α : Type*} [Countable α] : Countable (Multiset α) :=
+instance _root_.Multiset.countable [Countable α] : Countable (Multiset α) :=
   Quotient.countable
 
 /-- If `α` is countable, then so is `Finset α`. -/
-instance Finset.countable [Countable α] : Countable (Finset α) :=
+instance _root_.Finset.countable [Countable α] : Countable (Finset α) :=
   Finset.val_injective.countable
 
 /-- A listable type with decidable equality is encodable. -/

--- a/Mathlib/Logic/Equiv/List.lean
+++ b/Mathlib/Logic/Equiv/List.lean
@@ -3,7 +3,6 @@ Copyright (c) 2018 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
-import Mathlib.Data.List.Chain
 import Mathlib.Logic.Denumerable
 
 /-!

--- a/Mathlib/Logic/Equiv/List.lean
+++ b/Mathlib/Logic/Equiv/List.lean
@@ -3,7 +3,6 @@ Copyright (c) 2018 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
-import Mathlib.Data.Finset.Sort
 import Mathlib.Data.List.Chain
 import Mathlib.Logic.Denumerable
 
@@ -14,7 +13,7 @@ This file defines some additional constructive equivalences using `Encodable` an
 function on `ℕ`.
 -/
 
-assert_not_exists Monoid
+assert_not_exists Monoid Multiset.sort
 
 open List
 open Nat List
@@ -78,39 +77,16 @@ theorem length_le_encode : ∀ l : List α, length l ≤ encode l
 
 end List
 
-section Finset
-
-variable [Encodable α]
-
-private def enle : α → α → Prop :=
-  encode ⁻¹'o (· ≤ ·)
-
-private theorem enle.isLinearOrder : IsLinearOrder α enle :=
-  (RelEmbedding.preimage ⟨encode, encode_injective⟩ (· ≤ ·)).isLinearOrder
-
-private def decidable_enle (a b : α) : Decidable (enle a b) := by
-  unfold enle Order.Preimage
-  infer_instance
-
-attribute [local instance] enle.isLinearOrder decidable_enle
-
-/-- Explicit encoding function for `Multiset α` -/
-def encodeMultiset (s : Multiset α) : ℕ :=
-  encode (s.sort enle)
-
-/-- Explicit decoding function for `Multiset α` -/
-def decodeMultiset (n : ℕ) : Option (Multiset α) :=
-  ((↑) : List α → Multiset α) <$> decode (α := List α) n
-
-/-- If `α` is encodable, then so is `Multiset α`. -/
-instance _root_.Multiset.encodable : Encodable (Multiset α) :=
-  ⟨encodeMultiset, decodeMultiset, fun s => by simp [encodeMultiset, decodeMultiset, encodek]⟩
+/-! These two lemmas are not about lists, but are convenient to keep here and don't
+require `Finset.sort`. -/
 
 /-- If `α` is countable, then so is `Multiset α`. -/
 instance _root_.Multiset.countable {α : Type*} [Countable α] : Countable (Multiset α) :=
   Quotient.countable
 
-end Finset
+/-- If `α` is countable, then so is `Finset α`. -/
+instance Finset.countable [Countable α] : Countable (Finset α) :=
+  Finset.val_injective.countable
 
 /-- A listable type with decidable equality is encodable. -/
 def encodableOfList [DecidableEq α] (l : List α) (H : ∀ x, x ∈ l) : Encodable α :=
@@ -127,43 +103,6 @@ It is not made into a global instance, since it involves an arbitrary choice.
 This can be locally made into an instance with `attribute [local instance] Fintype.toEncodable`. -/
 noncomputable def _root_.Fintype.toEncodable (α : Type*) [Fintype α] : Encodable α := by
   classical exact (Fintype.truncEncodable α).out
-
-/-- If `α` is encodable, then so is `Finset α`. -/
-instance _root_.Finset.encodable [Encodable α] : Encodable (Finset α) :=
-  haveI := decidableEqOfEncodable α
-  ofEquiv { s : Multiset α // s.Nodup }
-    ⟨fun ⟨a, b⟩ => ⟨a, b⟩, fun ⟨a, b⟩ => ⟨a, b⟩, fun ⟨_, _⟩ => rfl, fun ⟨_, _⟩ => rfl⟩
-
-/-- If `α` is countable, then so is `Finset α`. -/
-instance _root_.Finset.countable [Countable α] : Countable (Finset α) :=
-  Finset.val_injective.countable
-
-/-- The elements of a `Fintype` as a sorted list. -/
-def sortedUniv (α) [Fintype α] [Encodable α] : List α :=
-  Finset.univ.sort (Encodable.encode' α ⁻¹'o (· ≤ ·))
-
-@[simp]
-theorem mem_sortedUniv {α} [Fintype α] [Encodable α] (x : α) : x ∈ sortedUniv α :=
-  (Finset.mem_sort _).2 (Finset.mem_univ _)
-
-@[simp]
-theorem length_sortedUniv (α) [Fintype α] [Encodable α] : (sortedUniv α).length = Fintype.card α :=
-  Finset.length_sort _
-
-@[simp]
-theorem sortedUniv_nodup (α) [Fintype α] [Encodable α] : (sortedUniv α).Nodup :=
-  Finset.sort_nodup _ _
-
-@[simp]
-theorem sortedUniv_toFinset (α) [Fintype α] [Encodable α] [DecidableEq α] :
-    (sortedUniv α).toFinset = Finset.univ :=
-  Finset.sort_toFinset _ _
-
-/-- An encodable `Fintype` is equivalent to the same size `Fin`. -/
-def fintypeEquivFin {α} [Fintype α] [Encodable α] : α ≃ Fin (Fintype.card α) :=
-  haveI : DecidableEq α := Encodable.decidableEqOfEncodable _
-  ((sortedUniv_nodup α).getEquivOfForallMemList _ mem_sortedUniv).symm.trans <|
-    Equiv.cast (congr_arg _ (length_sortedUniv α))
 
 end Encodable
 
@@ -207,109 +146,6 @@ theorem list_ofNat_succ (v : ℕ) :
 
 end List
 
-section Multiset
-
-/-- Outputs the list of differences of the input list, that is
-`lower [a₁, a₂, ...] n = [a₁ - n, a₂ - a₁, ...]` -/
-def lower : List ℕ → ℕ → List ℕ
-  | [], _ => []
-  | m :: l, n => (m - n) :: lower l m
-
-/-- Outputs the list of partial sums of the input list, that is
-`raise [a₁, a₂, ...] n = [n + a₁, n + a₁ + a₂, ...]` -/
-def raise : List ℕ → ℕ → List ℕ
-  | [], _ => []
-  | m :: l, n => (m + n) :: raise l (m + n)
-
-theorem lower_raise : ∀ l n, lower (raise l n) n = l
-  | [], _ => rfl
-  | m :: l, n => by rw [raise, lower, Nat.add_sub_cancel_right, lower_raise l]
-
-theorem raise_lower : ∀ {l n}, List.Sorted (· ≤ ·) (n :: l) → raise (lower l n) n = l
-  | [], _, _ => rfl
-  | m :: l, n, h => by
-    have : n ≤ m := List.rel_of_sorted_cons h _ (l.mem_cons_self _)
-    simp [raise, lower, Nat.sub_add_cancel this, raise_lower h.of_cons]
-
-theorem raise_chain : ∀ l n, List.Chain (· ≤ ·) n (raise l n)
-  | [], _ => List.Chain.nil
-  | _ :: _, _ => List.Chain.cons (Nat.le_add_left _ _) (raise_chain _ _)
-
-/-- `raise l n` is a non-decreasing sequence. -/
-theorem raise_sorted : ∀ l n, List.Sorted (· ≤ ·) (raise l n)
-  | [], _ => List.sorted_nil
-  | _ :: _, _ => List.chain_iff_pairwise.1 (raise_chain _ _)
-
-/-- If `α` is denumerable, then so is `Multiset α`. Warning: this is *not* the same encoding as used
-in `Multiset.encodable`. -/
-instance multiset : Denumerable (Multiset α) :=
-  mk'
-    ⟨fun s : Multiset α => encode <| lower ((s.map encode).sort (· ≤ ·)) 0,
-     fun n =>
-      Multiset.map (ofNat α) (raise (ofNat (List ℕ) n) 0),
-     fun s => by
-      have :=
-        raise_lower (List.sorted_cons.2 ⟨fun n _ => Nat.zero_le n, (s.map encode).sort_sorted _⟩)
-      simp [-Multiset.map_coe, this],
-     fun n => by
-      simp [-Multiset.map_coe, List.mergeSort_eq_self _ (raise_sorted _ _), lower_raise]⟩
-
-end Multiset
-
-section Finset
-
-/-- Outputs the list of differences minus one of the input list, that is
-`lower' [a₁, a₂, a₃, ...] n = [a₁ - n, a₂ - a₁ - 1, a₃ - a₂ - 1, ...]`. -/
-def lower' : List ℕ → ℕ → List ℕ
-  | [], _ => []
-  | m :: l, n => (m - n) :: lower' l (m + 1)
-
-/-- Outputs the list of partial sums plus one of the input list, that is
-`raise [a₁, a₂, a₃, ...] n = [n + a₁, n + a₁ + a₂ + 1, n + a₁ + a₂ + a₃ + 2, ...]`. Adding one each
-time ensures the elements are distinct. -/
-def raise' : List ℕ → ℕ → List ℕ
-  | [], _ => []
-  | m :: l, n => (m + n) :: raise' l (m + n + 1)
-
-theorem lower_raise' : ∀ l n, lower' (raise' l n) n = l
-  | [], _ => rfl
-  | m :: l, n => by simp [raise', lower', Nat.add_sub_cancel_right, lower_raise']
-
-theorem raise_lower' : ∀ {l n}, (∀ m ∈ l, n ≤ m) → List.Sorted (· < ·) l → raise' (lower' l n) n = l
-  | [], _, _, _ => rfl
-  | m :: l, n, h₁, h₂ => by
-    have : n ≤ m := h₁ _ (l.mem_cons_self _)
-    simp [raise', lower', Nat.sub_add_cancel this,
-      raise_lower' (List.rel_of_sorted_cons h₂ : ∀ a ∈ l, m < a) h₂.of_cons]
-
-theorem raise'_chain : ∀ (l) {m n}, m < n → List.Chain (· < ·) m (raise' l n)
-  | [], _, _, _ => List.Chain.nil
-  | _ :: _, _, _, h =>
-    List.Chain.cons (lt_of_lt_of_le h (Nat.le_add_left _ _)) (raise'_chain _ (lt_succ_self _))
-
-/-- `raise' l n` is a strictly increasing sequence. -/
-theorem raise'_sorted : ∀ l n, List.Sorted (· < ·) (raise' l n)
-  | [], _ => List.sorted_nil
-  | _ :: _, _ => List.chain_iff_pairwise.1 (raise'_chain _ (lt_succ_self _))
-
-/-- Makes `raise' l n` into a finset. Elements are distinct thanks to `raise'_sorted`. -/
-def raise'Finset (l : List ℕ) (n : ℕ) : Finset ℕ :=
-  ⟨raise' l n, (raise'_sorted _ _).imp (@ne_of_lt _ _)⟩
-
-/-- If `α` is denumerable, then so is `Finset α`. Warning: this is *not* the same encoding as used
-in `Finset.encodable`. -/
-instance finset : Denumerable (Finset α) :=
-  mk'
-    ⟨fun s : Finset α => encode <| lower' ((s.map (eqv α).toEmbedding).sort (· ≤ ·)) 0, fun n =>
-      Finset.map (eqv α).symm.toEmbedding (raise'Finset (ofNat (List ℕ) n) 0), fun s =>
-      Finset.eq_of_veq <| by
-        simp [-Multiset.map_coe, raise'Finset,
-          raise_lower' (fun n _ => Nat.zero_le n) (Finset.sort_sorted_lt _)],
-      fun n => by
-      simp [-Multiset.map_coe, Finset.map, raise'Finset, Finset.sort,
-        List.mergeSort_eq_self _ (raise'_sorted _ _).le_of_lt, lower_raise']⟩
-
-end Finset
 
 end Denumerable
 

--- a/Mathlib/Logic/Equiv/Multiset.lean
+++ b/Mathlib/Logic/Equiv/Multiset.lean
@@ -3,8 +3,9 @@ Copyright (c) 2018 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
-import Mathlib.Logic.Equiv.List
+import Mathlib.Data.List.Chain
 import Mathlib.Data.Multiset.Sort
+import Mathlib.Logic.Equiv.List
 
 /-!
 # `Encodable` and `Denumerable` instances for `Multiset`

--- a/Mathlib/Logic/Equiv/Multiset.lean
+++ b/Mathlib/Logic/Equiv/Multiset.lean
@@ -1,0 +1,99 @@
+/-
+Copyright (c) 2018 Mario Carneiro. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mario Carneiro
+-/
+import Mathlib.Logic.Equiv.List
+import Mathlib.Data.Multiset.Sort
+
+/-!
+# `Encodable` and `Denumerable` instances for `Multiset`
+-/
+
+variable {α : Type*}
+
+open Encodable
+
+section Finset
+
+variable [Encodable α]
+
+private def enle : α → α → Prop :=
+  encode ⁻¹'o (· ≤ ·)
+
+private theorem enle.isLinearOrder : IsLinearOrder α enle :=
+  (RelEmbedding.preimage ⟨encode, encode_injective⟩ (· ≤ ·)).isLinearOrder
+
+private def decidable_enle (a b : α) : Decidable (enle a b) := by
+  unfold enle Order.Preimage
+  infer_instance
+
+attribute [local instance] enle.isLinearOrder decidable_enle
+
+/-- Explicit encoding function for `Multiset α` -/
+def encodeMultiset (s : Multiset α) : ℕ :=
+  encode (s.sort enle)
+
+/-- Explicit decoding function for `Multiset α` -/
+def decodeMultiset (n : ℕ) : Option (Multiset α) :=
+  ((↑) : List α → Multiset α) <$> decode (α := List α) n
+
+/-- If `α` is encodable, then so is `Multiset α`. -/
+instance _root_.Multiset.encodable : Encodable (Multiset α) :=
+  ⟨encodeMultiset, decodeMultiset, fun s => by simp [encodeMultiset, decodeMultiset, encodek]⟩
+
+end Finset
+
+namespace Denumerable
+variable [Denumerable α]
+
+section Multiset
+
+/-- Outputs the list of differences of the input list, that is
+`lower [a₁, a₂, ...] n = [a₁ - n, a₂ - a₁, ...]` -/
+def lower : List ℕ → ℕ → List ℕ
+  | [], _ => []
+  | m :: l, n => (m - n) :: lower l m
+
+/-- Outputs the list of partial sums of the input list, that is
+`raise [a₁, a₂, ...] n = [n + a₁, n + a₁ + a₂, ...]` -/
+def raise : List ℕ → ℕ → List ℕ
+  | [], _ => []
+  | m :: l, n => (m + n) :: raise l (m + n)
+
+theorem lower_raise : ∀ l n, lower (raise l n) n = l
+  | [], _ => rfl
+  | m :: l, n => by rw [raise, lower, Nat.add_sub_cancel_right, lower_raise l]
+
+theorem raise_lower : ∀ {l n}, List.Sorted (· ≤ ·) (n :: l) → raise (lower l n) n = l
+  | [], _, _ => rfl
+  | m :: l, n, h => by
+    have : n ≤ m := List.rel_of_sorted_cons h _ (l.mem_cons_self _)
+    simp [raise, lower, Nat.sub_add_cancel this, raise_lower h.of_cons]
+
+theorem raise_chain : ∀ l n, List.Chain (· ≤ ·) n (raise l n)
+  | [], _ => List.Chain.nil
+  | _ :: _, _ => List.Chain.cons (Nat.le_add_left _ _) (raise_chain _ _)
+
+/-- `raise l n` is a non-decreasing sequence. -/
+theorem raise_sorted : ∀ l n, List.Sorted (· ≤ ·) (raise l n)
+  | [], _ => List.sorted_nil
+  | _ :: _, _ => List.chain_iff_pairwise.1 (raise_chain _ _)
+
+/-- If `α` is denumerable, then so is `Multiset α`. Warning: this is *not* the same encoding as used
+in `Multiset.encodable`. -/
+instance multiset : Denumerable (Multiset α) :=
+  mk'
+    ⟨fun s : Multiset α => encode <| lower ((s.map encode).sort (· ≤ ·)) 0,
+     fun n =>
+      Multiset.map (ofNat α) (raise (ofNat (List ℕ) n) 0),
+     fun s => by
+      have :=
+        raise_lower (List.sorted_cons.2 ⟨fun n _ => Nat.zero_le n, (s.map encode).sort_sorted _⟩)
+      simp [-Multiset.map_coe, this],
+     fun n => by
+      simp [-Multiset.map_coe, List.mergeSort_eq_self _ (raise_sorted _ _), lower_raise]⟩
+
+end Multiset
+
+end Denumerable

--- a/Mathlib/ModelTheory/Order.lean
+++ b/Mathlib/ModelTheory/Order.lean
@@ -5,6 +5,7 @@ Authors: Aaron Anderson
 -/
 import Mathlib.Algebra.CharZero.Infinite
 import Mathlib.Data.Rat.Encodable
+import Mathlib.Data.Finset.Sort
 import Mathlib.ModelTheory.Complexity
 import Mathlib.ModelTheory.Fraisse
 import Mathlib.Order.CountableDenseLinearOrder

--- a/Mathlib/Topology/Category/Profinite/Nobeling.lean
+++ b/Mathlib/Topology/Category/Profinite/Nobeling.lean
@@ -9,6 +9,7 @@ import Mathlib.Topology.Category.Profinite.Product
 import Mathlib.Topology.LocallyConstant.Algebra
 import Mathlib.Topology.Separation.Profinite
 import Mathlib.Data.Bool.Basic
+import Mathlib.Data.Finset.Sort
 
 /-!
 


### PR DESCRIPTION
The motivation here is to delay the import of sorting.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
