### PR TITLE
[Merged by Bors] - chore: more on rank of localized module

### DIFF
--- a/Mathlib/Algebra/GroupWithZero/NonZeroDivisors.lean
+++ b/Mathlib/Algebra/GroupWithZero/NonZeroDivisors.lean
@@ -114,6 +114,11 @@ open nonZeroDivisors
 section MonoidWithZero
 variable {F M₀ M₀' : Type*} [MonoidWithZero M₀] [MonoidWithZero M₀'] {r x y : M₀}
 
+lemma nonZeroDivisorsLeft_eq_nonZeroDivisors : nonZeroDivisorsLeft M₀ = nonZeroDivisors M₀ := rfl
+
+lemma nonZeroDivisorsRight_eq_nonZeroSMulDivisors :
+    nonZeroDivisorsRight M₀ = nonZeroSMulDivisors M₀ M₀ := rfl
+
 theorem mem_nonZeroDivisors_iff : r ∈ M₀⁰ ↔ ∀ x, x * r = 0 → x = 0 := Iff.rfl
 
 lemma nmem_nonZeroDivisors_iff : r ∉ M₀⁰ ↔ {s | s * r = 0 ∧ s ≠ 0}.Nonempty := by

--- a/Mathlib/Algebra/GroupWithZero/NonZeroDivisors.lean
+++ b/Mathlib/Algebra/GroupWithZero/NonZeroDivisors.lean
@@ -114,6 +114,7 @@ open nonZeroDivisors
 section MonoidWithZero
 variable {F M₀ M₀' : Type*} [MonoidWithZero M₀] [MonoidWithZero M₀'] {r x y : M₀}
 
+-- this lemma reflects symmetry-breaking in the definition of `nonZeroDivisors`
 lemma nonZeroDivisorsLeft_eq_nonZeroDivisors : nonZeroDivisorsLeft M₀ = nonZeroDivisors M₀ := rfl
 
 lemma nonZeroDivisorsRight_eq_nonZeroSMulDivisors :

--- a/Mathlib/Algebra/Module/LocalizedModule/Basic.lean
+++ b/Mathlib/Algebra/Module/LocalizedModule/Basic.lean
@@ -553,6 +553,10 @@ lemma IsLocalizedModule.eq_iff_exists [IsLocalizedModule S f] {x₁ x₂} :
     simp_rw [f.map_smul_of_tower, Submonoid.smul_def, ← Module.algebraMap_end_apply R R] at h
     exact ((Module.End_isUnit_iff _).mp <| map_units f c).1 h
 
+lemma IsLocalizedModule.injective_iff_isRegular [IsLocalizedModule S f] :
+    Function.Injective f ↔ ∀ c : S, IsSMulRegular M c := by
+  simp_rw [IsSMulRegular, Function.Injective, eq_iff_exists S, exists_imp, forall_comm (α := S)]
+
 instance IsLocalizedModule.of_linearEquiv (e : M' ≃ₗ[R] M'') [hf : IsLocalizedModule S f] :
     IsLocalizedModule S (e ∘ₗ f : M →ₗ[R] M'') where
   map_units s := by
@@ -958,6 +962,14 @@ theorem smul_injective (s : S) : Function.Injective fun m : M' => s • m :=
 include f in
 theorem smul_inj (s : S) (m₁ m₂ : M') : s • m₁ = s • m₂ ↔ m₁ = m₂ :=
   (smul_injective f s).eq_iff
+
+include f in
+lemma isRegular_of_smul_left_injective {m : M'} (inj : Function.Injective fun r : R ↦ r • m)
+    (s : S) : IsRegular (s : R) :=
+  (Commute.isRegular_iff (Commute.all _)).mpr fun r r' eq ↦ by
+    have := congr_arg (· • m) eq
+    simp_rw [mul_smul, ← Submonoid.smul_def, smul_inj f] at this
+    exact inj this
 
 /-- `mk' f m s` is the fraction `m/s` with respect to the localization map `f`. -/
 noncomputable def mk' (m : M) (s : S) : M' :=

--- a/Mathlib/Algebra/Ring/NonZeroDivisors.lean
+++ b/Mathlib/Algebra/Ring/NonZeroDivisors.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yakov Pechersky
 -/
 import Mathlib.Algebra.GroupWithZero.NonZeroDivisors
+import Mathlib.Algebra.Regular.Basic
 import Mathlib.Algebra.Ring.Defs
 
 /-!
@@ -23,6 +24,24 @@ lemma mul_cancel_right_mem_nonZeroDivisors (hr : r ∈ R⁰) : x * r = y * r ↔
 
 lemma mul_cancel_right_coe_nonZeroDivisors {c : R⁰} : x * c = y * c ↔ x = y :=
   mul_cancel_right_mem_nonZeroDivisors c.prop
+
+lemma isLeftRegular_iff_mem_nonZeroDivisorsRight : IsLeftRegular r ↔ r ∈ nonZeroDivisorsRight R :=
+  ⟨fun h r' eq ↦ h (by simp_rw [eq, mul_zero]),
+    fun h r₁ r₂ eq ↦ sub_eq_zero.mp <| h _ <| by simp_rw [mul_sub, eq, sub_self]⟩
+
+lemma isRightRegular_iff_mem_nonZeroDivisorsLeft : IsRightRegular r ↔ r ∈ nonZeroDivisorsLeft R :=
+  ⟨fun h r' eq ↦ h (by simp_rw [eq, zero_mul]),
+    fun h r₁ r₂ eq ↦ sub_eq_zero.mp <| h _ <| by simp_rw [sub_mul, eq, sub_self]⟩
+
+lemma le_nonZeroDivisors_iff_isRightRegular {S : Submonoid R} :
+    S ≤ R⁰ ↔ ∀ s : S, IsRightRegular (s : R) := by
+  simp_rw [SetLike.le_def, isRightRegular_iff_mem_nonZeroDivisorsLeft, Subtype.forall,
+    nonZeroDivisorsLeft_eq_nonZeroDivisors]
+
+lemma le_nonZeroDivisors_iff_isRegular {R} [CommRing R] {S : Submonoid R} :
+    S ≤ R⁰ ↔ ∀ s : S, IsRegular (s : R) := by
+  simp_rw [le_nonZeroDivisors_iff_isRightRegular,
+    Commute.isRightRegular_iff (Commute.all _), Commute.isRegular_iff (Commute.all _)]
 
 /-- In a finite ring, an element is a unit iff it is a non-zero-divisor. -/
 lemma isUnit_iff_mem_nonZeroDivisors_of_finite [Finite R] : IsUnit a ↔ a ∈ nonZeroDivisors R := by

--- a/Mathlib/LinearAlgebra/Dimension/Localization.lean
+++ b/Mathlib/LinearAlgebra/Dimension/Localization.lean
@@ -5,6 +5,8 @@ Authors: Andrew Yang
 -/
 import Mathlib.Algebra.Module.LocalizedModule.Submodule
 import Mathlib.LinearAlgebra.Dimension.DivisionRing
+import Mathlib.RingTheory.IsTensorProduct
+import Mathlib.RingTheory.Localization.BaseChange
 import Mathlib.RingTheory.Localization.FractionRing
 import Mathlib.RingTheory.OreLocalization.OreSet
 
@@ -21,9 +23,9 @@ open Cardinal Module nonZeroDivisors
 
 section CommRing
 
-universe u u' v v'
+universe uR uS uT uM uN uP
 
-variable {R : Type u} (S : Type u') {M : Type v} {N : Type v'}
+variable {R : Type uR} (S : Type uS) {M : Type uM} {N : Type uN}
 variable [CommRing R] [CommRing S] [AddCommGroup M] [AddCommGroup N]
 variable [Module R M] [Module R N] [Algebra R S] [Module S N] [IsScalarTower R S N]
 variable (p : Submonoid R) [IsLocalization p S] (f : M →ₗ[R] N) [IsLocalizedModule p f]
@@ -35,57 +37,36 @@ include hp
 section
 include f
 
-variable {S} in
-lemma IsLocalizedModule.linearIndependent_lift {ι} {v : ι → N} (hf : LinearIndependent S v) :
-    ∃ w : ι → M, LinearIndependent R w := by
-  choose sec hsec using IsLocalizedModule.surj p f
-  use fun i ↦ (sec (v i)).1
-  rw [linearIndependent_iff'] at hf ⊢
-  intro t g hg i hit
-  apply hp (sec (v i)).2.prop
-  apply IsLocalization.injective S hp
-  rw [map_zero]
-  refine hf t (fun i ↦ algebraMap R S (g i * (sec (v i)).2)) ?_ _ hit
-  simp only [map_mul, mul_smul, algebraMap_smul, ← Submonoid.smul_def,
-    hsec, ← map_smul, ← map_sum, hg, map_zero]
-
 lemma IsLocalizedModule.lift_rank_eq :
-    Cardinal.lift.{v} (Module.rank S N) = Cardinal.lift.{v'} (Module.rank R M) := by
+    Cardinal.lift.{uM} (Module.rank R N) = Cardinal.lift.{uN} (Module.rank R M) := by
   cases subsingleton_or_nontrivial R
-  · have := (algebraMap R S).codomain_trivial; simp only [rank_subsingleton, lift_one]
-  have := (IsLocalization.injective S hp).nontrivial
+  · simp only [rank_subsingleton, lift_one]
   apply le_antisymm <;>
     rw [Module.rank_def, lift_iSup (bddAbove_range _)] <;>
     apply ciSup_le' <;>
     intro ⟨s, hs⟩
-  · exact (IsLocalizedModule.linearIndependent_lift p f hp hs).choose_spec.cardinal_lift_le_rank
-  · choose sec hsec using IsLocalization.surj p (S := S)
-    refine LinearIndependent.cardinal_lift_le_rank (ι := s) (v := fun i ↦ f i) ?_
-    rw [LinearIndepOn] at hs
-    rw [linearIndependent_iff'] at hs ⊢
-    intro t g hg i hit
-    apply (IsLocalization.map_units S (sec (g i)).2).mul_left_injective
-    classical
-    let u := fun (i : s) ↦ (t.erase i).prod (fun j ↦ (sec (g j)).2)
-    have : f (t.sum fun i ↦ u i • (sec (g i)).1 • i) = f 0 := by
-      convert congr_arg (t.prod (fun j ↦ (sec (g j)).2) • ·) hg
-      · simp only [map_sum, map_smul, Submonoid.smul_def, Finset.smul_sum]
-        apply Finset.sum_congr rfl
-        intro j hj
-        simp only [u, ← @IsScalarTower.algebraMap_smul R S N, Submonoid.coe_finset_prod, map_prod]
-        rw [← hsec, mul_comm (g j), mul_smul, ← mul_smul, Finset.prod_erase_mul (h := hj)]
-      rw [map_zero, smul_zero]
-    obtain ⟨c, hc⟩ := IsLocalizedModule.exists_of_eq (S := p) this
-    simp_rw [smul_zero, Finset.smul_sum, ← mul_smul, Submonoid.smul_def, ← mul_smul, mul_comm] at hc
-    simp only [hsec, zero_mul, map_eq_zero_iff (algebraMap R S) (IsLocalization.injective S hp)]
-    apply hp (c * u i).prop
-    exact hs t _ hc _ hit
+  exacts [(IsLocalizedModule.linearIndependent_lift p f hs).choose_spec.cardinal_lift_le_rank,
+    hs.of_isLocalizedModule_of_isRegular p f (le_nonZeroDivisors_iff_isRegular.mp hp)
+      |>.cardinal_lift_le_rank]
+
+lemma IsLocalizedModule.finrank_eq : finrank R N = finrank R M := by
+  simpa using congr_arg toNat (lift_rank_eq p f hp)
 
 end
 
-lemma IsLocalizedModule.rank_eq {N : Type v} [AddCommGroup N]
-    [Module R N] [Module S N] [IsScalarTower R S N] (f : M →ₗ[R] N) [IsLocalizedModule p f] :
-    Module.rank S N = Module.rank R M := by simpa using IsLocalizedModule.lift_rank_eq S p f hp
+lemma IsLocalizedModule.rank_eq {N : Type uM} [AddCommGroup N] [Module R N] (f : M →ₗ[R] N)
+    [IsLocalizedModule p f] : Module.rank R N = Module.rank R M := by
+  simpa using lift_rank_eq p f hp
+
+lemma IsLocalization.rank_eq : Module.rank S N = Module.rank R N := by
+  cases subsingleton_or_nontrivial R
+  · have := (algebraMap R S).codomain_trivial; simp only [rank_subsingleton, lift_one]
+  have inj := IsLocalization.injective S hp
+  apply le_antisymm <;> (rw [Module.rank]; apply ciSup_le'; intro ⟨s, hs⟩)
+  · have := (faithfulSMul_iff_algebraMap_injective R S).mpr inj
+    exact (hs.restrict_scalars' R).cardinal_le_rank
+  · have := inj.nontrivial
+    exact (hs.localization S p).cardinal_le_rank
 
 end
 
@@ -93,26 +74,112 @@ variable (R M) in
 theorem exists_set_linearIndependent_of_isDomain [IsDomain R] :
     ∃ s : Set M, #s = Module.rank R M ∧ LinearIndepOn R id s := by
   obtain ⟨w, hw⟩ :=
-    IsLocalizedModule.linearIndependent_lift R⁰ (LocalizedModule.mkLinearMap R⁰ M) le_rfl
-      (Module.Free.chooseBasis (FractionRing R) (LocalizedModule R⁰ M)).linearIndependent
+    IsLocalizedModule.linearIndependent_lift R⁰ (LocalizedModule.mkLinearMap R⁰ M) <|
+      Module.Free.chooseBasis (FractionRing R) (LocalizedModule R⁰ M)
+        |>.linearIndependent.restrict_scalars' _
   refine ⟨Set.range w, ?_, (linearIndepOn_id_range_iff hw.injective).mpr hw⟩
-  apply Cardinal.lift_injective.{max u v}
+  apply Cardinal.lift_injective.{max uR uM}
   rw [Cardinal.mk_range_eq_of_injective hw.injective, ← Module.Free.rank_eq_card_chooseBasisIndex,
-  IsLocalizedModule.lift_rank_eq (FractionRing R) R⁰ (LocalizedModule.mkLinearMap R⁰ M) le_rfl]
+    IsLocalization.rank_eq (FractionRing R) R⁰ le_rfl,
+    IsLocalizedModule.lift_rank_eq R⁰ (LocalizedModule.mkLinearMap R⁰ M) le_rfl]
 
 /-- The **rank-nullity theorem** for commutative domains. Also see `rank_quotient_add_rank`. -/
 theorem rank_quotient_add_rank_of_isDomain [IsDomain R] (M' : Submodule R M) :
     Module.rank R (M ⧸ M') + Module.rank R M' = Module.rank R M := by
-  apply lift_injective.{max u v}
-  rw [lift_add, ← IsLocalizedModule.lift_rank_eq (FractionRing R) R⁰ (M'.toLocalized R⁰) le_rfl,
-    ← IsLocalizedModule.lift_rank_eq (FractionRing R) R⁰ (LocalizedModule.mkLinearMap R⁰ M) le_rfl,
-    ← IsLocalizedModule.lift_rank_eq (FractionRing R) R⁰ (M'.toLocalizedQuotient R⁰) le_rfl,
+  apply lift_injective.{max uR uM}
+  simp_rw [lift_add, ← IsLocalizedModule.lift_rank_eq R⁰ (M'.toLocalized R⁰) le_rfl,
+    ← IsLocalizedModule.lift_rank_eq R⁰ (LocalizedModule.mkLinearMap R⁰ M) le_rfl,
+    ← IsLocalizedModule.lift_rank_eq R⁰ (M'.toLocalizedQuotient R⁰) le_rfl,
+    ← IsLocalization.rank_eq (FractionRing R) R⁰ le_rfl,
     ← lift_add, rank_quotient_add_rank_of_divisionRing]
 
 universe w in
 instance IsDomain.hasRankNullity [IsDomain R] : HasRankNullity.{w} R where
   rank_quotient_add_rank := rank_quotient_add_rank_of_isDomain
   exists_set_linearIndependent M := exists_set_linearIndependent_of_isDomain R M
+
+namespace IsBaseChange
+
+open Cardinal TensorProduct
+
+section
+
+variable {p} [Free S N] [StrongRankCondition S] {T : Type uT} [CommRing T] [Algebra R T]
+  (hpT : Algebra.algebraMapSubmonoid T p ≤ T⁰) [StrongRankCondition (S ⊗[R] T)]
+  {P : Type uP} [AddCommGroup P] [Module R P] [Module T P] [IsScalarTower R T P]
+  {g : M →ₗ[R] P} (bc : IsBaseChange T g)
+
+include S hp hpT f bc
+
+theorem lift_rank_eq_of_le_nonZeroDivisors :
+    Cardinal.lift.{uM} (Module.rank T P) = Cardinal.lift.{uP} (Module.rank R M) := by
+  rw [← lift_inj.{_, max uS uT uN}, lift_lift, lift_lift]
+  let ST := S ⊗[R] T
+  conv_rhs => rw [← lift_lift.{uN, max uS uT uP}, ← IsLocalizedModule.lift_rank_eq p f hp,
+    ← IsLocalization.rank_eq S p hp, lift_lift, ← lift_lift.{max uS uT, max uM uP},
+    ← rank_baseChange (R := ST), ← lift_id'.{max uS uT, max uS uT uN} (Module.rank ..),
+    lift_lift, ← lift_lift.{max uS uT uP, uM}]
+  let _ : Algebra T ST := Algebra.TensorProduct.rightAlgebra
+  set pT := Algebra.algebraMapSubmonoid T p
+  have : IsLocalization pT ST := isLocalizedModule_iff_isLocalization.mp
+    (IsLocalization.tensorProduct_isLocalizedModule ..)
+  rw [← lift_lift.{max uS uT, max uM uN}, ← lift_umax.{uP},
+    ← IsLocalizedModule.lift_rank_eq pT (mk T ST P 1) hpT,
+    ← IsLocalization.rank_eq ST pT hpT, lift_id'.{uP, max uS uT},
+    ← lift_id'.{max uS uT, max uS uT uP} (Module.rank ..), lift_lift,
+    ← lift_lift.{max uS uT uN, uM}, lift_inj]
+  exact LinearEquiv.lift_rank_eq <| AlgebraTensorModule.congr (.refl ST ST) bc.equiv.symm ≪≫ₗ
+    AlgebraTensorModule.cancelBaseChange .. ≪≫ₗ (AlgebraTensorModule.cancelBaseChange ..).symm ≪≫ₗ
+    AlgebraTensorModule.congr (.refl ..) ((isLocalizedModule_iff_isBaseChange p S f).mp ‹_›).equiv
+
+theorem finrank_eq_of_le_nonZeroDivisors : finrank T P = finrank R M := by
+  simpa using congr_arg toNat (lift_rank_eq_of_le_nonZeroDivisors S f hp hpT bc)
+
+omit bc
+theorem rank_eq_of_le_nonZeroDivisors {P : Type uM} [AddCommGroup P] [Module R P] [Module T P]
+    [IsScalarTower R T P] {g : M →ₗ[R] P} (bc : IsBaseChange T g) :
+    Module.rank T P = Module.rank R M := by
+  simpa using lift_rank_eq_of_le_nonZeroDivisors S f hp hpT bc
+
+end
+
+variable {p} {T : Type uT} [CommRing T] [NoZeroDivisors T] [Algebra R T] [FaithfulSMul R T]
+  {P : Type uP} [AddCommGroup P] [Module R P] [Module T P] [IsScalarTower R T P]
+  {g : M →ₗ[R] P} (bc : IsBaseChange T g)
+
+include bc
+theorem lift_rank_eq :
+    Cardinal.lift.{uM} (Module.rank T P) = Cardinal.lift.{uP} (Module.rank R M) := by
+  have inj := FaithfulSMul.algebraMap_injective R T
+  have := inj.noZeroDivisors _ (map_zero _) (map_mul _)
+  cases subsingleton_or_nontrivial R
+  · have := (algebraMap R T).codomain_trivial; simp only [rank_subsingleton, lift_one]
+  have := (isDomain_iff_noZeroDivisors_and_nontrivial T).mpr
+    ⟨‹_›, (FaithfulSMul.algebraMap_injective R T).nontrivial⟩
+  let FR := FractionRing R
+  let FT := FractionRing T
+  replace inj : Function.Injective (algebraMap R FT) := (IsFractionRing.injective T _).comp inj
+  let g := TensorProduct.mk T FT P 1
+  have : IsLocalizedModule R⁰ (TensorProduct.mk R FR FT 1) := inferInstance
+  let _ : Algebra FT (FR ⊗[R] FT) := Algebra.TensorProduct.rightAlgebra
+  let _ := isLocalizedModule_iff_isLocalization.mp this |>.atUnits _ _ ?_ |>.symm.isField
+    _ (Field.toIsField FT) |>.toField
+  on_goal 2 => rintro _ ⟨_, mem, rfl⟩; exact (map_ne_zero_of_mem_nonZeroDivisors _ inj mem).isUnit
+  have := bc.comp_iff.2 ((isLocalizedModule_iff_isBaseChange T⁰ FT g).1 inferInstance)
+  rw [← lift_inj.{_, max uT uP}, lift_lift, lift_lift, ← lift_lift.{max uT uP, uM},
+    ← IsLocalizedModule.lift_rank_eq T⁰ g le_rfl, lift_lift, ← lift_lift.{uM},
+    ← IsLocalization.rank_eq FT T⁰ le_rfl,
+    lift_rank_eq_of_le_nonZeroDivisors FR (LocalizedModule.mkLinearMap R⁰ M) le_rfl
+      (map_le_nonZeroDivisors_of_injective _ inj le_rfl) this, lift_lift]
+
+theorem finrank_eq : finrank T P = finrank R M := by simpa using congr_arg toNat bc.lift_rank_eq
+
+omit bc
+theorem rank_eq {P : Type uM} [AddCommGroup P] [Module R P] [Module T P] [IsScalarTower R T P]
+    {g : M →ₗ[R] P} (bc : IsBaseChange T g) : Module.rank T P = Module.rank R M := by
+  simpa using bc.lift_rank_eq
+
+end IsBaseChange
 
 end CommRing
 

--- a/Mathlib/LinearAlgebra/LinearIndependent/Defs.lean
+++ b/Mathlib/LinearAlgebra/LinearIndependent/Defs.lean
@@ -132,6 +132,9 @@ theorem LinearIndependent.injective [Nontrivial R] (hv : LinearIndependent R v) 
 theorem LinearIndepOn.injOn [Nontrivial R] (hv : LinearIndepOn R v s) : InjOn v s :=
   injOn_iff_injective.2 <| LinearIndependent.injective hv
 
+theorem LinearIndependent.smul_left_injective (hv : LinearIndependent R v) (i : ι) :
+    Injective fun r : R ↦ r • v i := by convert hv.comp (Finsupp.single_injective i); simp
+
 theorem LinearIndependent.ne_zero [Nontrivial R] (i : ι) (hv : LinearIndependent R v) :
     v i ≠ 0 := by
   intro h

--- a/Mathlib/RingTheory/ClassGroup.lean
+++ b/Mathlib/RingTheory/ClassGroup.lean
@@ -118,7 +118,7 @@ theorem ClassGroup.mk_eq_mk_of_coe_ideal {I J : (FractionalIdeal R⁰ <| Fractio
   · rintro ⟨x, rfl⟩
     rw [Units.val_mul, hI, coe_toPrincipalIdeal, mul_comm,
       spanSingleton_mul_coeIdeal_eq_coeIdeal] at hJ
-    exact ⟨_, _, sec_fst_ne_zero (R := R) le_rfl x.ne_zero,
+    exact ⟨_, _, sec_fst_ne_zero x.ne_zero,
       sec_snd_ne_zero (R := R) le_rfl (x : FractionRing R), hJ⟩
   · rintro ⟨x, y, hx, hy, h⟩
     have : IsUnit (mk' (FractionRing R) x ⟨y, mem_nonZeroDivisors_of_ne_zero hy⟩) := by

--- a/Mathlib/RingTheory/DedekindDomain/SelmerGroup.lean
+++ b/Mathlib/RingTheory/DedekindDomain/SelmerGroup.lean
@@ -96,7 +96,7 @@ theorem valuationOfNeZeroToFun_eq (x : Kˣ) :
   rw [Units.val_inv_eq_inv_val]
   change _ = ite _ _ _ * (ite _ _ _)⁻¹
   simp_rw [IsLocalization.toLocalizationMap_sec, SubmonoidClass.coe_subtype,
-    if_neg <| IsLocalization.sec_fst_ne_zero le_rfl x.ne_zero,
+    if_neg <| IsLocalization.sec_fst_ne_zero x.ne_zero,
     if_neg (nonZeroDivisors.coe_ne_zero _),
     valuationOfNeZeroToFun, ofAdd_sub, ofAdd_neg, div_inv_eq_mul, WithZero.coe_mul,
     WithZero.coe_inv, inv_inv]

--- a/Mathlib/RingTheory/Ideal/Norm/RelNorm.lean
+++ b/Mathlib/RingTheory/Ideal/Norm/RelNorm.lean
@@ -225,8 +225,6 @@ theorem spanNorm_mul (I J : Ideal S) : spanNorm R (I * J) = spanNorm R I * spanN
       AlgEquiv.commutes, IsScalarTower.algebraMap_apply R S L,
       IsScalarTower.algebraMap_apply S Sₚ L, AlgEquiv.coe_ringEquiv, AlgEquiv.commutes]
     simp only [← IsScalarTower.algebraMap_apply]
-    rw [IsScalarTower.algebraMap_apply R Rₚ (FractionRing Rₚ),
-      ← IsScalarTower.algebraMap_apply Rₚ, ← IsScalarTower.algebraMap_apply]
   simp only [Ideal.map_mul, ← spanIntNorm_localization (R := R) (S := S)
     (Rₘ := Localization.AtPrime P) (Sₘ := Localization P') _ _ P.primeCompl_le_nonZeroDivisors]
   rw [← (I.map _).span_singleton_generator, ← (J.map _).span_singleton_generator,

--- a/Mathlib/RingTheory/IntegralClosure/Algebra/Basic.lean
+++ b/Mathlib/RingTheory/IntegralClosure/Algebra/Basic.lean
@@ -3,9 +3,9 @@ Copyright (c) 2019 Kenny Lau. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kenny Lau
 -/
+import Mathlib.LinearAlgebra.Matrix.Charpoly.LinearMap
 import Mathlib.RingTheory.IntegralClosure.Algebra.Defs
 import Mathlib.RingTheory.IntegralClosure.IsIntegral.Basic
-import Mathlib.LinearAlgebra.Matrix.Charpoly.LinearMap
 
 /-!
 # Integral closure of a subring.

--- a/Mathlib/RingTheory/Localization/Defs.lean
+++ b/Mathlib/RingTheory/Localization/Defs.lean
@@ -128,6 +128,10 @@ theorem eq_iff_exists {x y} : algebraMap R S x = algebraMap R S y ↔ ∃ c : M,
     rw [map_mul, map_mul] at h
     exact (IsLocalization.map_units S c).mul_right_inj.mp h
 
+theorem injective_iff_isRegular : Injective (algebraMap R S) ↔ ∀ c : M, IsRegular (c : R) := by
+  simp_rw [Commute.isRegular_iff (Commute.all _), IsLeftRegular,
+    Injective, eq_iff_exists M, exists_imp, forall_comm (α := M)]
+
 theorem of_le (N : Submonoid R) (h₁ : M ≤ N) (h₂ : ∀ r ∈ N, IsUnit (algebraMap R S r)) :
     IsLocalization N S where
   map_units' r := h₂ r r.2
@@ -323,6 +327,23 @@ theorem mk'_zero (s : M) : IsLocalization.mk' S 0 s = 0 := by
 theorem ne_zero_of_mk'_ne_zero {x : R} {y : M} (hxy : IsLocalization.mk' S x y ≠ 0) : x ≠ 0 := by
   rintro rfl
   exact hxy (IsLocalization.mk'_zero _)
+
+include M in
+variable (M) in
+/-- Any localization of a commutative semiring without zero-divisors also has no zero-divisors. -/
+theorem noZeroDivisors [NoZeroDivisors R] : NoZeroDivisors S where
+  eq_zero_or_eq_zero_of_mul_eq_zero {x y} eq := by
+    nontriviality S
+    obtain ⟨x, s, rfl⟩ := mk'_surjective M x
+    obtain ⟨y, t, rfl⟩ := mk'_surjective M y
+    rw [← mk'_mul, mk'_eq_zero_iff] at eq
+    have ⟨m, eq⟩ := eq
+    obtain eq | eq := eq_zero_or_eq_zero_of_mul_eq_zero eq
+    · exact absurd (subsingleton (eq ▸ m.2)) (not_subsingleton S)
+    obtain rfl | rfl := eq_zero_or_eq_zero_of_mul_eq_zero eq <;> simp
+
+theorem sec_fst_ne_zero {x : S} (hx : x ≠ 0) : (sec M x).fst ≠ 0 :=
+  mt (fun h ↦ by rw [← mk'_sec (M := M) S x, h, mk'_zero]) hx
 
 section Ext
 
@@ -536,7 +557,7 @@ theorem lift_injective_iff :
 
 variable (M) in
 include M in
-lemma injective_iff_map_algebraMap_eq {T} [CommRing T] (f : S →+* T) :
+lemma injective_iff_map_algebraMap_eq {T} [CommSemiring T] (f : S →+* T) :
     Function.Injective f ↔ ∀ x y,
       algebraMap R S x = algebraMap R S y ↔ f (algebraMap R S x) = f (algebraMap R S y) := by
   rw [← IsLocalization.lift_of_comp (M := M) f, IsLocalization.lift_injective_iff]
@@ -798,6 +819,8 @@ instance isLocalization : IsLocalization M (Localization M) where
   surj' := (Localization.monoidOf M).surj
   exists_of_eq := (Localization.monoidOf M).eq_iff_exists.mp
 
+instance [NoZeroDivisors R] : NoZeroDivisors (Localization M) := IsLocalization.noZeroDivisors M
+
 end
 
 @[simp]
@@ -887,32 +910,10 @@ theorem sec_snd_ne_zero [Nontrivial R] (hM : M ≤ nonZeroDivisors R) (x : S) :
     ((sec M x).snd : R) ≠ 0 :=
   nonZeroDivisors.coe_ne_zero ⟨(sec M x).snd.val, hM (sec M x).snd.property⟩
 
-theorem sec_fst_ne_zero [Nontrivial R] [NoZeroDivisors S] (hM : M ≤ nonZeroDivisors R) {x : S}
-    (hx : x ≠ 0) : (sec M x).fst ≠ 0 := by
-  have hsec := sec_spec M x
-  intro hfst
-  rw [hfst, map_zero, mul_eq_zero, _root_.map_eq_zero_iff] at hsec
-  · exact Or.elim hsec hx (sec_snd_ne_zero hM x)
-  · exact IsLocalization.injective S hM
-
 variable {Q : Type*} [CommRing Q] {g : R →+* P} [Algebra P Q]
 variable (A : Type*) [CommRing A] [IsDomain A]
 
-/-- A `CommRing` `S` which is the localization of a ring `R` without zero divisors at a subset of
-non-zero elements does not have zero divisors. -/
-theorem noZeroDivisors_of_le_nonZeroDivisors [Algebra A S] {M : Submonoid A} [IsLocalization M S]
-    (hM : M ≤ nonZeroDivisors A) : NoZeroDivisors S :=
-  { eq_zero_or_eq_zero_of_mul_eq_zero := by
-      intro z w h
-      obtain ⟨x, hx⟩ := surj M z
-      obtain ⟨y, hy⟩ := surj M w
-      have :
-        z * w * algebraMap A S y.2 * algebraMap A S x.2 = algebraMap A S x.1 * algebraMap A S y.1 :=
-        by rw [mul_assoc z, hy, ← hx]; ring
-      rw [h, zero_mul, zero_mul, ← (algebraMap A S).map_mul] at this
-      rcases eq_zero_or_eq_zero_of_mul_eq_zero ((to_map_eq_zero_iff S hM).mp this.symm) with H | H
-      · exact Or.inl (eq_zero_of_fst_eq_zero hx H)
-      · exact Or.inr (eq_zero_of_fst_eq_zero hy H) }
+@[deprecated (since := "2025-03-18")] alias noZeroDivisors_of_le_nonZeroDivisors := noZeroDivisors
 
 /-- A `CommRing` `S` which is the localization of an integral domain `R` at a subset of
 non-zero elements is an integral domain. -/
@@ -922,7 +923,7 @@ theorem isDomain_of_le_nonZeroDivisors [Algebra A S] {M : Submonoid A} [IsLocali
   · exact
       ⟨⟨(algebraMap A S) 0, (algebraMap A S) 1, fun h =>
           zero_ne_one (IsLocalization.injective S hM h)⟩⟩
-  · exact noZeroDivisors_of_le_nonZeroDivisors _ hM
+  · exact noZeroDivisors M
 
 variable {A}
 

--- a/Mathlib/RingTheory/Localization/FractionRing.lean
+++ b/Mathlib/RingTheory/Localization/FractionRing.lean
@@ -509,19 +509,37 @@ theorem mk_eq_div {r s} :
       (algebraMap _ _ r / algebraMap A _ s : FractionRing A) := by
   rw [Localization.mk_eq_mk', IsFractionRing.mk'_eq_div]
 
+section liftAlgebra
+
+variable [Field K] [Algebra R K] [FaithfulSMul R K]
+
 /-- This is not an instance because it creates a diamond when `K = FractionRing R`.
 Should usually be introduced locally along with `isScalarTower_liftAlgebra`
 See note [reducible non-instances]. -/
-noncomputable abbrev liftAlgebra [IsDomain R] [Field K] [Algebra R K]
-    [FaithfulSMul R K] : Algebra (FractionRing R) K :=
-  RingHom.toAlgebra (IsFractionRing.lift (FaithfulSMul.algebraMap_injective R _))
+noncomputable abbrev liftAlgebra : Algebra (FractionRing R) K :=
+  have := (FaithfulSMul.algebraMap_injective R K).isDomain
+  RingHom.toAlgebra (IsFractionRing.lift (FaithfulSMul.algebraMap_injective R K))
+
+attribute [local instance] liftAlgebra
 
 -- Porting note: had to fill in the `_` by hand for this instance
-instance isScalarTower_liftAlgebra [IsDomain R] [Field K] [Algebra R K] [FaithfulSMul R K] :
-    by letI := liftAlgebra R K; exact IsScalarTower R (FractionRing R) K := by
-  letI := liftAlgebra R K
-  exact IsScalarTower.of_algebraMap_eq fun x =>
+instance isScalarTower_liftAlgebra : IsScalarTower R (FractionRing R) K :=
+  have := (FaithfulSMul.algebraMap_injective R K).isDomain
+  .of_algebraMap_eq fun x ↦
     (IsFractionRing.lift_algebraMap (FaithfulSMul.algebraMap_injective R K) x).symm
+
+lemma algebraMap_liftAlgebra :
+    have := (FaithfulSMul.algebraMap_injective R K).isDomain
+    algebraMap (FractionRing R) K = IsFractionRing.lift (FaithfulSMul.algebraMap_injective R _) :=
+  rfl
+
+instance {R₀} [SMul R₀ R] [IsScalarTower R₀ R R] [SMul R₀ K] [IsScalarTower R₀ R K] :
+    IsScalarTower R₀ (FractionRing R) K where
+  smul_assoc r₀ r k := r.ind fun ⟨r, s⟩ ↦ by
+    simp_rw [Localization.smul_mk, Algebra.smul_def, Localization.mk_eq_mk',
+      algebraMap_liftAlgebra, IsFractionRing.lift_mk', mul_comm_div, ← Algebra.smul_def, smul_assoc]
+
+end liftAlgebra
 
 /-- Given a ring `A` and a localization map to a fraction ring
 `f : A →+* K`, we get an `A`-isomorphism between the fraction ring of `A` as a quotient

--- a/Mathlib/RingTheory/Localization/Module.lean
+++ b/Mathlib/RingTheory/Localization/Module.lean
@@ -67,11 +67,35 @@ theorem LinearIndependent.of_isLocalizedModule {ι : Type*} {v : ι → M}
   simpa only [map_mul, (IsLocalization.map_units Rₛ s).mul_right_inj, hfg.1 ⟨i, hi⟩, hfg.2 ⟨i, hi⟩,
     Algebra.smul_def, (IsLocalization.map_units Rₛ a).mul_right_inj] using this
 
+theorem LinearIndependent.of_isLocalizedModule_of_isRegular {ι : Type*} {v : ι → M}
+    (hv : LinearIndependent R v) (h : ∀ s : S, IsRegular (s : R)) : LinearIndependent R (f ∘ v) :=
+  hv.map_injOn _ <| by
+    rw [← Finsupp.range_linearCombination]
+    rintro _ ⟨_, r, rfl⟩ _ ⟨_, r', rfl⟩ eq
+    congr; ext i
+    have ⟨s, eq⟩ := IsLocalizedModule.exists_of_eq (S := S) eq
+    simp_rw [Submonoid.smul_def, ← map_smul] at eq
+    exact (h s).1 (DFunLike.congr_fun (hv eq) i)
+
 theorem LinearIndependent.localization [Module Rₛ M] [IsScalarTower R Rₛ M]
     {ι : Type*} {b : ι → M} (hli : LinearIndependent R b) :
     LinearIndependent Rₛ b := by
   have := isLocalizedModule_id S M Rₛ
   exact hli.of_isLocalizedModule Rₛ S .id
+
+include f in
+lemma IsLocalizedModule.linearIndependent_lift {ι} {v : ι → Mₛ} (hf : LinearIndependent R v) :
+    ∃ w : ι → M, LinearIndependent R w := by
+  cases isEmpty_or_nonempty ι
+  · exact ⟨isEmptyElim, linearIndependent_empty_type⟩
+  have inj := hf.smul_left_injective (Classical.arbitrary ι)
+  choose sec hsec using surj S f
+  use fun i ↦ (sec (v i)).1
+  rw [linearIndependent_iff'ₛ] at hf ⊢
+  intro t g g' eq i hit
+  refine (isRegular_of_smul_left_injective f inj (sec (v i)).2).2 <|
+    hf t (fun i ↦ _ * (sec (v i)).2) (fun i ↦ _ * (sec (v i)).2) ?_ i hit
+  simp_rw [mul_smul, ← Submonoid.smul_def, hsec, ← map_smul, ← map_sum, eq]
 
 section Basis
 
@@ -123,7 +147,7 @@ open Submodule
 include S
 
 theorem LinearIndependent.localization_localization {ι : Type*} {v : ι → A}
-    (hv : LinearIndependent R v) : LinearIndependent Rₛ ((algebraMap A Aₛ) ∘ v) :=
+    (hv : LinearIndependent R v) : LinearIndependent Rₛ (algebraMap A Aₛ ∘ v) :=
   hv.of_isLocalizedModule Rₛ S (IsScalarTower.toAlgHom R A Aₛ).toLinearMap
 
 theorem span_eq_top_localization_localization {v : Set A} (hv : span R v = ⊤) :
@@ -156,13 +180,13 @@ end LocalizationLocalization
 
 section FractionRing
 
-variable (R K : Type*) [CommRing R] [Field K] [Algebra R K] [IsFractionRing R K]
+variable (R K : Type*) [CommRing R] [CommRing K] [Algebra R K] [IsFractionRing R K]
 variable {V : Type*} [AddCommGroup V] [Module R V] [Module K V] [IsScalarTower R K V]
 
 theorem LinearIndependent.iff_fractionRing {ι : Type*} {b : ι → V} :
     LinearIndependent R b ↔ LinearIndependent K b :=
-  ⟨LinearIndependent.localization K R⁰,
-    LinearIndependent.restrict_scalars (smul_left_injective R one_ne_zero)⟩
+  ⟨.localization K R⁰,
+    .restrict_scalars <| (faithfulSMul_iff_injective_smul_one ..).mp inferInstance⟩
 
 end FractionRing
 


### PR DESCRIPTION
+ Prove `IsBaseChange.(lift_)rank_eq`: base change along an injective map of domains preserves rank.
+ Split results including `IsLocalizedModule.linearIndependent_lift` and `IsLocalizedModule.(lift_)rank_eq` into two: one changes the module, and the other changes the ring.
+ Add some results connecting nonZeroDivisors and injectivity of localization to regular elements, towards the resolution of issue #22997.
+ Improve `FractionRing.liftAlgebra` API: remove the redundant `[IsDomain R]` assumption and add a missing `IsScalarTower` instance.
+ Show that any localization of a CommSemiring without zero-divisors has no zero-divisors, and deprecate `noZeroDivisors_of_le_nonZeroDivisors`. Golf and remove extraneous conditions from `sec_fst_ne_zero`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
