### PR TITLE
[Merged by Bors] - chore: improvements to (Mv)Polynomial and Algebra.IsPushout APIs

### DIFF
--- a/Mathlib/Algebra/MvPolynomial/Eval.lean
+++ b/Mathlib/Algebra/MvPolynomial/Eval.lean
@@ -399,6 +399,9 @@ theorem map_injective (hf : Function.Injective f) :
   intro m
   exact hf (h m)
 
+theorem map_injective_iff : Function.Injective (map (σ := σ) f) ↔ Function.Injective f :=
+  ⟨fun h r r' eq ↦ by simpa using h (a₁ := C r) (a₂ := C r') (by simpa), map_injective f⟩
+
 theorem map_surjective (hf : Function.Surjective f) :
     Function.Surjective (map f : MvPolynomial σ R → MvPolynomial σ S₁) := fun p => by
   induction' p using MvPolynomial.induction_on' with i fr a b ha hb
@@ -407,6 +410,10 @@ theorem map_surjective (hf : Function.Surjective f) :
   · obtain ⟨a, rfl⟩ := ha
     obtain ⟨b, rfl⟩ := hb
     exact ⟨a + b, RingHom.map_add _ _ _⟩
+
+theorem map_surjective_iff : Function.Surjective (map (σ := σ) f) ↔ Function.Surjective f :=
+  ⟨fun h s ↦ let ⟨p, h⟩ := h (C s); ⟨p.coeff 0, by simpa [coeff_map] using congr(coeff 0 $h)⟩,
+    map_surjective f⟩
 
 /-- If `f` is a left-inverse of `g` then `map f` is a left-inverse of `map g`. -/
 theorem map_leftInverse {f : R →+* S₁} {g : S₁ →+* R} (hf : Function.LeftInverse f g) :
@@ -765,5 +772,35 @@ lemma aeval_sumElim {σ τ : Type*} (p : MvPolynomial (σ ⊕ τ) R) (f : τ →
 @[deprecated (since := "2025-02-21")] alias aeval_sum_elim := aeval_sumElim
 
 end CommSemiring
+
+section Algebra
+
+variable {R S σ : Type*} [CommSemiring R] [CommSemiring S] [Algebra R S]
+
+/--
+If `S` is an `R`-algebra, then `MvPolynomial σ S` is a `MvPolynomial σ R` algebra.
+
+Warning: This produces a diamond for
+`Algebra (MvPolynomial σ R) (MvPolynomial σ (MvPolynomial σ S))`. That's why it is not a
+global instance.
+-/
+noncomputable def algebraMvPolynomial : Algebra (MvPolynomial σ R) (MvPolynomial σ S) :=
+  (MvPolynomial.map (algebraMap R S)).toAlgebra
+
+attribute [local instance] algebraMvPolynomial
+
+@[simp]
+lemma algebraMap_def :
+    algebraMap (MvPolynomial σ R) (MvPolynomial σ S) = MvPolynomial.map (algebraMap R S) :=
+  rfl
+
+instance : IsScalarTower R (MvPolynomial σ R) (MvPolynomial σ S) :=
+  IsScalarTower.of_algebraMap_eq' (by ext; simp)
+
+instance [FaithfulSMul R S] : FaithfulSMul (MvPolynomial σ R) (MvPolynomial σ S) :=
+  (faithfulSMul_iff_algebraMap_injective ..).mpr
+    (map_injective _ <| FaithfulSMul.algebraMap_injective ..)
+
+end Algebra
 
 end MvPolynomial

--- a/Mathlib/Algebra/Polynomial/Eval/Coeff.lean
+++ b/Mathlib/Algebra/Polynomial/Eval/Coeff.lean
@@ -103,15 +103,18 @@ def piEquiv {ι} [Finite ι] (R : ι → Type*) [∀ i, Semiring (R i)] :
 theorem map_injective (hf : Function.Injective f) : Function.Injective (map f) := fun p q h =>
   ext fun m => hf <| by rw [← coeff_map f, ← coeff_map f, h]
 
+theorem map_injective_iff : Function.Injective (map f) ↔ Function.Injective f :=
+  ⟨fun h r r' eq ↦ by simpa using h (a₁ := C r) (a₂ := C r') (by simpa), map_injective f⟩
+
 theorem map_surjective (hf : Function.Surjective f) : Function.Surjective (map f) := fun p =>
-  Polynomial.induction_on' p
-    (fun p q hp hq =>
-      let ⟨p', hp'⟩ := hp
-      let ⟨q', hq'⟩ := hq
-      ⟨p' + q', by rw [Polynomial.map_add f, hp', hq']⟩)
-    fun n s =>
+  p.induction_on'
+    (by rintro _ _ ⟨p, rfl⟩ ⟨q, rfl⟩; exact ⟨p + q, Polynomial.map_add f⟩)
+    fun n s ↦
     let ⟨r, hr⟩ := hf s
     ⟨monomial n r, by rw [map_monomial f, hr]⟩
+
+theorem map_surjective_iff : Function.Surjective (map f) ↔ Function.Surjective f :=
+  ⟨fun h s ↦ let ⟨p, h⟩ := h (C s); ⟨p.coeff 0, by simpa using congr(coeff $h 0)⟩, map_surjective f⟩
 
 variable {f}
 

--- a/Mathlib/RingTheory/Algebraic/Defs.lean
+++ b/Mathlib/RingTheory/Algebraic/Defs.lean
@@ -55,8 +55,7 @@ theorem transcendental_iff {x : A} :
   congr! 1; tauto
 
 /-- A subalgebra is algebraic if all its elements are algebraic. -/
-nonrec
-def Subalgebra.IsAlgebraic (S : Subalgebra R A) : Prop :=
+protected def Subalgebra.IsAlgebraic (S : Subalgebra R A) : Prop :=
   ∀ x ∈ S, IsAlgebraic R x
 
 variable (R A)

--- a/Mathlib/RingTheory/IsTensorProduct.lean
+++ b/Mathlib/RingTheory/IsTensorProduct.lean
@@ -383,8 +383,7 @@ variable {R' S' : Type*} [CommSemiring R'] [CommSemiring S']
 variable [Algebra R R'] [Algebra S S'] [Algebra R' S'] [Algebra R S']
 variable [IsScalarTower R R' S'] [IsScalarTower R S S']
 
-open IsScalarTower (toAlgHom)
-open IsScalarTower (algebraMap_apply)
+open IsScalarTower (toAlgHom algebraMap_apply)
 
 variable (R S R' S')
 
@@ -398,53 +397,6 @@ is a pushout diagram (i.e. `S' = S ⊗[R] R'`)
 class Algebra.IsPushout : Prop where
   out : IsBaseChange S (toAlgHom R R' S').toLinearMap
 
-variable {R S R' S'}
-
-@[symm]
-theorem Algebra.IsPushout.symm (h : Algebra.IsPushout R S R' S') : Algebra.IsPushout R R' S S' := by
-  let _ := (Algebra.TensorProduct.includeRight : R' →ₐ[R] S ⊗ R').toRingHom.toAlgebra
-  let e : R' ⊗[R] S ≃ₗ[R'] S' := by
-    refine { (_root_.TensorProduct.comm R R' S).trans <|
-      h.1.equiv.restrictScalars R with map_smul' := ?_ }
-    intro r x
-    change
-      h.1.equiv (TensorProduct.comm R R' S (r • x)) = r • h.1.equiv (TensorProduct.comm R R' S x)
-    refine TensorProduct.induction_on x ?_ ?_ ?_
-    · simp only [smul_zero, map_zero]
-    · intro x y
-      simp only [smul_tmul', smul_eq_mul, TensorProduct.comm_tmul, smul_def,
-        TensorProduct.algebraMap_apply, id.map_eq_id, RingHom.id_apply, TensorProduct.tmul_mul_tmul,
-        one_mul, h.1.equiv_tmul, AlgHom.toLinearMap_apply, map_mul, IsScalarTower.coe_toAlgHom']
-      ring
-    · intro x y hx hy
-      rw [map_add, map_add, smul_add, map_add, map_add, hx, hy, smul_add]
-  have :
-    (toAlgHom R S S').toLinearMap =
-      (e.toLinearMap.restrictScalars R).comp (TensorProduct.mk R R' S 1) := by
-    ext
-    simp [e, h.1.equiv_tmul, Algebra.smul_def]
-  constructor
-  rw [this]
-  exact (TensorProduct.isBaseChange R S R').comp (IsBaseChange.ofEquiv e)
-
-variable (R S R' S')
-
-theorem Algebra.IsPushout.comm : Algebra.IsPushout R S R' S' ↔ Algebra.IsPushout R R' S S' :=
-  ⟨Algebra.IsPushout.symm, Algebra.IsPushout.symm⟩
-
-variable {R S R'}
-
-attribute [local instance] Algebra.TensorProduct.rightAlgebra
-
-instance TensorProduct.isPushout {R S T : Type*} [CommRing R] [CommRing S] [CommRing T]
-    [Algebra R S] [Algebra R T] : Algebra.IsPushout R S T (TensorProduct R S T) :=
-  ⟨TensorProduct.isBaseChange R T S⟩
-
-instance TensorProduct.isPushout' {R S T : Type*} [CommRing R] [CommRing S] [CommRing T]
-    [Algebra R S] [Algebra R T] : Algebra.IsPushout R T S (TensorProduct R S T) :=
-  Algebra.IsPushout.symm inferInstance
-
-variable (R S R') in
 /-- The isomorphism `S' ≃ S ⊗[R] R` given `Algebra.IsPushout R S R' S'`. -/
 noncomputable
 def Algebra.IsPushout.equiv [h : Algebra.IsPushout R S R' S'] : S ⊗[R] R' ≃ₐ[S] S' where
@@ -472,6 +424,38 @@ lemma Algebra.IsPushout.equiv_symm_algebraMap_left [Algebra.IsPushout R S R' S']
 lemma Algebra.IsPushout.equiv_symm_algebraMap_right [Algebra.IsPushout R S R' S'] (a : R') :
     (equiv R S R' S').symm (algebraMap R' S' a) = 1 ⊗ₜ a := by
   rw [(equiv R S R' S').symm_apply_eq, equiv_tmul, map_one, one_mul]
+
+variable {R S R' S'}
+
+@[symm]
+theorem Algebra.IsPushout.symm (h : Algebra.IsPushout R S R' S') : Algebra.IsPushout R R' S S' where
+  out := .of_equiv
+    { __ := (TensorProduct.comm R ..).toAddEquiv.trans (equiv R S R' S').toAddEquiv,
+      map_smul' _ x := x.induction_on (by simp) (fun _ _ ↦ by
+        simp [smul_tmul', equiv_tmul, Algebra.smul_def, mul_left_comm]) (by simp+contextual) }
+    fun _ ↦ by simp [equiv_tmul]
+
+variable (R S R' S')
+
+theorem Algebra.IsPushout.comm : Algebra.IsPushout R S R' S' ↔ Algebra.IsPushout R R' S S' :=
+  ⟨Algebra.IsPushout.symm, Algebra.IsPushout.symm⟩
+
+instance : Algebra.IsPushout R R S S where
+  out := .of_equiv (TensorProduct.lid R S) fun _ ↦ by simp
+
+instance : Algebra.IsPushout R S R S := .symm inferInstance
+
+variable {R S R'}
+
+attribute [local instance] Algebra.TensorProduct.rightAlgebra
+
+instance TensorProduct.isPushout {R S T : Type*} [CommSemiring R] [CommSemiring S] [CommSemiring T]
+    [Algebra R S] [Algebra R T] : Algebra.IsPushout R S T (S ⊗[R] T) :=
+  ⟨TensorProduct.isBaseChange R T S⟩
+
+instance TensorProduct.isPushout' {R S T : Type*} [CommSemiring R] [CommSemiring S] [CommSemiring T]
+    [Algebra R S] [Algebra R T] : Algebra.IsPushout R T S (S ⊗[R] T) :=
+  Algebra.IsPushout.symm inferInstance
 
 /-- If `S' = S ⊗[R] R'`, then any pair of `R`-algebra homomorphisms `f : S → A` and `g : R' → A`
 such that `f x` and `g y` commutes for all `x, y` descends to a (unique) homomorphism `S' → A`.
@@ -520,6 +504,7 @@ theorem Algebra.IsPushout.algHom_ext [H : Algebra.IsPushout R S R' S'] {A : Type
   · intro s₁ s₂ e₁ e₂
     rw [map_add, map_add, e₁, e₂]
 
+variable (R S R')
 /--
 Let the following be a commutative diagram of rings
 ```
@@ -533,14 +518,14 @@ where the left-hand square is a pushout. Then the following are equivalent:
 
 Note that this is essentially the isomorphism `T ⊗[S] (S ⊗[R] R') ≃ₐ[T] T ⊗[R] R'`.
 -/
-lemma Algebra.IsPushout.comp_iff {T' : Type*} [CommRing T'] [Algebra R T']
+lemma Algebra.IsPushout.comp_iff {T' : Type*} [CommSemiring T'] [Algebra R T']
     [Algebra S' T'] [Algebra S T'] [Algebra T T'] [Algebra R' T']
     [IsScalarTower R T T'] [IsScalarTower S T T'] [IsScalarTower S S' T']
     [IsScalarTower R R' T'] [IsScalarTower R S' T'] [IsScalarTower R' S' T']
     [Algebra.IsPushout R S R' S'] :
     Algebra.IsPushout R T R' T' ↔ Algebra.IsPushout S T S' T' := by
   let f : R' →ₗ[R] S' := (IsScalarTower.toAlgHom R R' S').toLinearMap
-  haveI : IsScalarTower R S T' := IsScalarTower.of_algebraMap_eq <| fun x ↦ by
+  haveI : IsScalarTower R S T' := .of_algebraMap_eq fun x ↦ by
     rw [algebraMap_apply R S' T', algebraMap_apply R S S', ← algebraMap_apply S S' T']
   have heq : (toAlgHom S S' T').toLinearMap.restrictScalars R ∘ₗ f =
       (toAlgHom R R' T').toLinearMap := by

--- a/Mathlib/RingTheory/Localization/Algebra.lean
+++ b/Mathlib/RingTheory/Localization/Algebra.lean
@@ -153,12 +153,10 @@ namespace Polynomial
 See also `MvPolynomial.isLocalization` for the multivariate case. -/
 lemma isLocalization {R} [CommRing R] (S : Submonoid R) (A) [CommRing A] [Algebra R A]
     [IsLocalization S A] : letI := (mapRingHom (algebraMap R A)).toAlgebra
-    IsLocalization (S.map C) A[X] := by
+    IsLocalization (S.map C) A[X] :=
   letI := (mapRingHom (algebraMap R A)).toAlgebra
   have : IsScalarTower R R[X] A[X] := .of_algebraMap_eq fun _ ↦ (map_C _).symm
-  apply isLocalizedModule_iff_isLocalization.mp <| (isLocalizedModule_iff_isBaseChange S A _).mpr <|
-    .of_equiv (polyEquivTensor' R A).symm.toLinearEquiv fun _ ↦ ?_
-  show _ = eval₂ ..
-  simp [eval₂, ← C_mul_X_pow_eq_monomial]
+  isLocalizedModule_iff_isLocalization.mp <| (isLocalizedModule_iff_isBaseChange S A _).mpr <|
+    .of_equiv (polyEquivTensor' R A).symm.toLinearEquiv fun _ ↦ by simp
 
 end Polynomial

--- a/Mathlib/RingTheory/MvPolynomial/Basic.lean
+++ b/Mathlib/RingTheory/MvPolynomial/Basic.lean
@@ -155,30 +155,4 @@ instance [Finite σ] (N : ℕ) : Module.Finite R (restrictTotalDegree σ R N) :=
 
 end Degree
 
-section Algebra
-
-variable {R S σ : Type*} [CommSemiring R] [CommSemiring S] [Algebra R S]
-
-/--
-If `S` is an `R`-algebra, then `MvPolynomial σ S` is a `MvPolynomial σ R` algebra.
-
-Warning: This produces a diamond for
-`Algebra (MvPolynomial σ R) (MvPolynomial σ (MvPolynomial σ S))`. That's why it is not a
-global instance.
--/
-noncomputable def algebraMvPolynomial : Algebra (MvPolynomial σ R) (MvPolynomial σ S) :=
-  (MvPolynomial.map (algebraMap R S)).toAlgebra
-
-attribute [local instance] algebraMvPolynomial
-
-@[simp]
-lemma algebraMap_def :
-    algebraMap (MvPolynomial σ R) (MvPolynomial σ S) = MvPolynomial.map (algebraMap R S) :=
-  rfl
-
-instance : IsScalarTower R (MvPolynomial σ R) (MvPolynomial σ S) :=
-  IsScalarTower.of_algebraMap_eq' (by ext; simp)
-
-end Algebra
-
 end MvPolynomial

--- a/Mathlib/RingTheory/MvPolynomial/Localization.lean
+++ b/Mathlib/RingTheory/MvPolynomial/Localization.lean
@@ -8,7 +8,6 @@ import Mathlib.Algebra.MvPolynomial.CommRing
 import Mathlib.RingTheory.Ideal.Quotient.Operations
 import Mathlib.RingTheory.Localization.Away.Basic
 import Mathlib.RingTheory.Localization.BaseChange
-import Mathlib.RingTheory.MvPolynomial.Basic
 import Mathlib.RingTheory.TensorProduct.MvPolynomial
 
 /-!

--- a/Mathlib/RingTheory/RingHom/Locally.lean
+++ b/Mathlib/RingTheory/RingHom/Locally.lean
@@ -290,7 +290,7 @@ lemma locally_isStableUnderBaseChange (hPi : RespectsIso P) (hPb : IsStableUnder
     simp [RingHom.algebraMap_toAlgebra]
   haveI (a : s) : Algebra.IsPushout T (Localization.Away a.val) (S ⊗[R] T)
       (S ⊗[R] Localization.Away a.val) := by
-    rw [← Algebra.IsPushout.comp_iff (R := R) (R' := S)]
+    rw [← Algebra.IsPushout.comp_iff R _ S]
     infer_instance
   refine ⟨s, fun a ↦ Algebra.TensorProduct.includeRight a.val, ?_,
       fun a ↦ (S ⊗[R] Localization.Away a.val), inferInstance, inferInstance, ?_, ?_⟩

--- a/Mathlib/RingTheory/TensorProduct/MvPolynomial.lean
+++ b/Mathlib/RingTheory/TensorProduct/MvPolynomial.lean
@@ -8,6 +8,8 @@ import Mathlib.LinearAlgebra.DirectSum.Finsupp
 import Mathlib.Algebra.MvPolynomial.Eval
 import Mathlib.RingTheory.TensorProduct.Basic
 import Mathlib.Algebra.MvPolynomial.Equiv
+import Mathlib.RingTheory.IsTensorProduct
+
 /-!
 
 # Tensor Product of (multivariate) polynomial rings
@@ -243,6 +245,17 @@ lemma aeval_one_tmul (f : σ → S) (p : MvPolynomial σ R) :
     rw [← mul_one ((algebraMap R N) a), ← Algebra.smul_def, smul_tmul, Algebra.smul_def, mul_one]
   · simp [hp, hq, tmul_add]
   · simp [h]
+
+section Pushout
+
+attribute [local instance] algebraMvPolynomial
+
+instance : Algebra.IsPushout R S (MvPolynomial σ R) (MvPolynomial σ S) where
+  out := .of_equiv (algebraTensorAlgEquiv R S).toLinearEquiv fun _ ↦ by simp
+
+instance : Algebra.IsPushout R (MvPolynomial σ R) S (MvPolynomial σ S) := .symm inferInstance
+
+end Pushout
 
 end Algebra
 


### PR DESCRIPTION
+ Introduce better simp lemma `toFunBilinear_apply_eq_smul` to replace `toFunBilinear_apply_apply`. Closes #20332.

+ `(Mv)Polynomial.map_in/surjective_iff`: R → S is in/surjective iff the induced R[X] → S[X] is in/surjective.

+ Move `algebraMvPolynomial` from MvPolynomial/Basic.lean to MvPolynomial/Eval.lean. Saves 39 transitive imports from MvPolynomial/Localization.lean.

+ Golf the proof of `Algebra.IsPushout.symm`.

+ Protect `Subalgebra.IsAlgebraic`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
