### PR TITLE
[Merged by Bors] - feat: lemmas about division of natural numbers

### DIFF
--- a/Mathlib/Data/Nat/Init.lean
+++ b/Mathlib/Data/Nat/Init.lean
@@ -454,9 +454,10 @@ lemma mul_add_mul_div_of_dvd (hb : b ≠ 0) (hd : d ≠ 0) (hba : b ∣ a) (hdc 
   obtain ⟨n, hn⟩ := hba
   obtain ⟨_, hm⟩ := hdc
   rw [hn, hm, Nat.mul_assoc b n d, Nat.mul_comm n d, ← Nat.mul_assoc, ← Nat.mul_assoc,
-    ← Nat.mul_add, Nat.mul_div_right _ (zero_lt_of_ne_zero hb),
+    ← Nat.mul_add,
+    Nat.mul_div_right _ (zero_lt_of_ne_zero hb),
     Nat.mul_div_right _ (zero_lt_of_ne_zero hd),
-    Nat.mul_div_right _ (Nat.mul_pos (zero_lt_of_ne_zero hb) (zero_lt_of_ne_zero hd))]
+    Nat.mul_div_right _ (zero_lt_of_ne_zero <| Nat.mul_ne_zero hb hd)]
 
 lemma mul_sub_mul_div_of_dvd (hb : b ≠ 0) (hd : d ≠ 0) (hba : b ∣ a) (hdc : d ∣ c) :
     (a * d - b * c) / (b * d)  = a / b - c / d:= by
@@ -465,10 +466,13 @@ lemma mul_sub_mul_div_of_dvd (hb : b ≠ 0) (hd : d ≠ 0) (hba : b ∣ a) (hdc 
   rw [hn, hm]
   rw [Nat.mul_assoc,Nat.mul_comm n d, ← Nat.mul_assoc,← Nat.mul_assoc, ← Nat.mul_sub_left_distrib,
     Nat.mul_div_right _ (zero_lt_of_ne_zero hb), Nat.mul_div_right _ (zero_lt_of_ne_zero hd),
-    Nat.mul_div_right _ (Nat.mul_pos (zero_lt_of_ne_zero hb) (zero_lt_of_ne_zero hd))]
+    Nat.mul_div_right _ (zero_lt_of_ne_zero <| Nat.mul_ne_zero hb hd)]
 
-lemma div_mul_assoc (hba : b ∣ a) (c : ℕ) : (a / b) * c = (a * c) / b := by
+protected lemma div_mul_right_comm (hba : b ∣ a) (c : ℕ) : a / b * c = a * c / b := by
   rw [Nat.mul_comm, ← Nat.mul_div_assoc _ hba, Nat.mul_comm]
+
+protected lemma mul_div_right_comm (hba : b ∣ a) (c : ℕ) : a * c / b = a / b * c :=
+  (Nat.div_mul_right_comm hba _).symm
 
 lemma eq_div_iff_mul_eq_left (hc : c ≠ 0) (hcb : c ∣ b) : a = b / c ↔ b = a * c := by
   rw [eq_comm, Nat.div_eq_iff_eq_mul_left (zero_lt_of_ne_zero hc) hcb]

--- a/Mathlib/Data/Nat/Init.lean
+++ b/Mathlib/Data/Nat/Init.lean
@@ -460,7 +460,7 @@ lemma mul_add_mul_div_of_dvd (hb : b ≠ 0) (hd : d ≠ 0) (hba : b ∣ a) (hdc 
     Nat.mul_div_right _ (zero_lt_of_ne_zero <| Nat.mul_ne_zero hb hd)]
 
 lemma mul_sub_mul_div_of_dvd (hb : b ≠ 0) (hd : d ≠ 0) (hba : b ∣ a) (hdc : d ∣ c) :
-    (a * d - b * c) / (b * d)  = a / b - c / d:= by
+    (a * d - b * c) / (b * d)  = a / b - c / d := by
   obtain ⟨n, hn⟩ := hba
   obtain ⟨m, hm⟩ := hdc
   rw [hn, hm]

--- a/Mathlib/Data/Nat/Init.lean
+++ b/Mathlib/Data/Nat/Init.lean
@@ -434,6 +434,37 @@ protected lemma div_left_inj (hda : d ∣ a) (hdb : d ∣ b) : a / d = b / d ↔
   refine ⟨fun h ↦ ?_, congrArg fun b ↦ b / d⟩
   rw [← Nat.mul_div_cancel' hda, ← Nat.mul_div_cancel' hdb, h]
 
+lemma div_sub_of_dvd (h1 : 0 < n) (h2 : n ∣ m) : m / n - k = (m - n * k) / n := by
+  obtain ⟨_,hx⟩ := h2
+  simp only [hx,←Nat.mul_sub_left_distrib,Nat.mul_div_right,h1]
+
+lemma sub_div_of_dvd (h1 : 0 < k) (h2 : k ∣ n) : m - n / k = (k * m - n) / k := by
+  obtain ⟨_,hx⟩ := h2
+  simp only [hx,←Nat.mul_sub_left_distrib,Nat.mul_div_right,h1]
+
+lemma div_add_div_of_dvd {l : ℕ} (hn : 0 < n) (hd : 0 < l) (h1 : n ∣ m) (h2 : l ∣ k) :
+    m / n + k / l = (m * l + n * k) / (n * l) := by
+  obtain ⟨a,ha⟩ := h1
+  obtain ⟨_,hb⟩ := h2
+  rw [ha,hb,Nat.mul_assoc n a l,Nat.mul_comm a l,← Nat.mul_assoc,← Nat.mul_assoc,
+    ← Nat.mul_add,Nat.mul_div_right _ hn, Nat.mul_div_right _ hd,
+    Nat.mul_div_right _ (Nat.mul_pos hn hd)]
+
+lemma div_sub_div_of_dvd {l : ℕ}  (hn : 0 < n) (hd : 0 < l) (h1 : n ∣ m) (h2 : l ∣ k ) :
+    m / n - k / l = (m * l - n * k) / (n * l) := by
+  obtain ⟨a,ha⟩ := h1
+  obtain ⟨b,hb⟩ := h2
+  rw [ha,hb]
+  rw [Nat.mul_assoc,Nat.mul_comm a l,←Nat.mul_assoc,←Nat.mul_assoc,←Nat.mul_sub_left_distrib,
+    Nat.mul_div_right _ hn, Nat.mul_div_right _ hd, Nat.mul_div_right _ (Nat.mul_pos hn hd )]
+
+lemma div_mul_assoc (h : k ∣ n) : (n / k) * m = (n * m) / k := by
+  rw [Nat.mul_comm,←Nat.mul_div_assoc,Nat.mul_comm]
+  exact h
+
+lemma eq_div_iff_mul_eq_left (h1 : 0 < k) (h2 : k ∣ n) : m = n / k ↔ n = m * k:= by
+  rw [eq_comm, Nat.div_eq_iff_eq_mul_left h1 h2]
+
 lemma div_mul_div_comm : b ∣ a → d ∣ c → (a / b) * (c / d) = (a * c) / (b * d) := by
   rintro ⟨x, rfl⟩ ⟨y, rfl⟩
   obtain rfl | hb := b.eq_zero_or_pos
@@ -524,6 +555,17 @@ protected lemma mul_le_of_le_div (k x y : ℕ) (h : x ≤ y / k) : x * k ≤ y :
   else
     rwa [← le_div_iff_mul_le (Nat.pos_iff_ne_zero.2 hk)]
 
+theorem div_le_iff_le_mul_of_dvd (h1 : 0 < n) (h2 : n ∣ m) : m / n ≤  k ↔ m ≤ k * n := by
+  obtain ⟨_,hx⟩ := h2
+  simp only [hx]
+  rw [Nat.mul_div_right _ h1,Nat.mul_comm]
+  exact ⟨mul_le_mul_right n, fun h ↦ Nat.le_of_mul_le_mul_right h h1⟩
+
+theorem lt_div_iff_mul_lt_of_dvd (h1 : 0 < k) (h2 : k ∣ n) : m < n / k ↔ m * k < n := by
+  obtain ⟨x,hx⟩ := h2
+  simp only [hx]
+  rw [Nat.mul_div_right _ h1,Nat.mul_comm]
+  exact ⟨fun h ↦ Nat.mul_lt_mul_of_pos_left h h1,(Nat.mul_lt_mul_left h1).mp⟩
 /-!
 ### `pow`
 

--- a/Mathlib/Data/Nat/Init.lean
+++ b/Mathlib/Data/Nat/Init.lean
@@ -445,33 +445,33 @@ lemma sub_mul_div' (a b c : ℕ) : (a - b * c) / b = a / b - c := by
       rw [Nat.mul_div_cancel_left _ (zero_lt_of_ne_zero hn)] at h2
       rw [Nat.sub_eq_zero_of_le h2]
 
-lemma mul_sub_div_of_dvd (a b c : ℕ) (h1 : c ≠ 0) (h2 : c ∣ b) : (c * a - b) / c = a - b / c := by
-  obtain ⟨_, hx⟩ := h2
-  simp only [hx, ← Nat.mul_sub_left_distrib, Nat.mul_div_right, zero_lt_of_ne_zero h1]
+lemma mul_sub_div_of_dvd (hc : c ≠ 0) (hcb : c ∣ b) (a : ℕ) : (c * a - b) / c = a - b / c := by
+  obtain ⟨_, hx⟩ := hcb
+  simp only [hx, ← Nat.mul_sub_left_distrib, Nat.mul_div_right, zero_lt_of_ne_zero hc]
 
-lemma mul_add_mul_div_of_dvd (hb : b ≠ 0) (hd : d ≠ 0) (h1 : b ∣ a) (h2 : d ∣ c) :
+lemma mul_add_mul_div_of_dvd (hb : b ≠ 0) (hd : d ≠ 0) (hba : b ∣ a) (hdc : d ∣ c) :
     (a * d + b * c) / (b * d) = a / b + c / d := by
-  obtain ⟨n, hn⟩ := h1
-  obtain ⟨_, hm⟩ := h2
+  obtain ⟨n, hn⟩ := hba
+  obtain ⟨_, hm⟩ := hdc
   rw [hn, hm, Nat.mul_assoc b n d, Nat.mul_comm n d, ← Nat.mul_assoc, ← Nat.mul_assoc,
     ← Nat.mul_add, Nat.mul_div_right _ (zero_lt_of_ne_zero hb),
     Nat.mul_div_right _ (zero_lt_of_ne_zero hd),
     Nat.mul_div_right _ (Nat.mul_pos (zero_lt_of_ne_zero hb) (zero_lt_of_ne_zero hd))]
 
-lemma mul_sub_mul_div_of_dvd (hb : b ≠ 0) (hd : d ≠ 0) (h1 : b ∣ a) (h2 : d ∣ c) :
+lemma mul_sub_mul_div_of_dvd (hb : b ≠ 0) (hd : d ≠ 0) (hba : b ∣ a) (hdc : d ∣ c) :
     (a * d - b * c) / (b * d)  = a / b - c / d:= by
-  obtain ⟨n, hn⟩ := h1
-  obtain ⟨m, hm⟩ := h2
+  obtain ⟨n, hn⟩ := hba
+  obtain ⟨m, hm⟩ := hdc
   rw [hn, hm]
   rw [Nat.mul_assoc,Nat.mul_comm n d, ← Nat.mul_assoc,← Nat.mul_assoc, ← Nat.mul_sub_left_distrib,
     Nat.mul_div_right _ (zero_lt_of_ne_zero hb), Nat.mul_div_right _ (zero_lt_of_ne_zero hd),
     Nat.mul_div_right _ (Nat.mul_pos (zero_lt_of_ne_zero hb) (zero_lt_of_ne_zero hd))]
 
-lemma div_mul_assoc (a b c : ℕ) (h : b ∣ a) : (a / b) * c = (a * c) / b := by
-  rw [Nat.mul_comm, ← Nat.mul_div_assoc _ h, Nat.mul_comm]
+lemma div_mul_assoc (hba : b ∣ a) (c : ℕ) : (a / b) * c = (a * c) / b := by
+  rw [Nat.mul_comm, ← Nat.mul_div_assoc _ hba, Nat.mul_comm]
 
-lemma eq_div_iff_mul_eq_left (a b c : ℕ) (h1 : 0 < c) (h2 : c ∣ b) : a = b / c ↔ b = a * c := by
-  rw [eq_comm, Nat.div_eq_iff_eq_mul_left h1 h2]
+lemma eq_div_iff_mul_eq_left (hc : c ≠ 0) (hcb : c ∣ b) : a = b / c ↔ b = a * c := by
+  rw [eq_comm, Nat.div_eq_iff_eq_mul_left (zero_lt_of_ne_zero hc) hcb]
 
 lemma div_mul_div_comm : b ∣ a → d ∣ c → (a / b) * (c / d) = (a * c) / (b * d) := by
   rintro ⟨x, rfl⟩ ⟨y, rfl⟩
@@ -563,17 +563,18 @@ protected lemma mul_le_of_le_div (k x y : ℕ) (h : x ≤ y / k) : x * k ≤ y :
   else
     rwa [← le_div_iff_mul_le (Nat.pos_iff_ne_zero.2 hk)]
 
-theorem div_le_iff_le_mul_of_dvd (a b c : ℕ) (h1 : 0 < b) (h2 : b ∣ a) : a / b ≤ c ↔ a ≤ c * b := by
-  obtain ⟨_, hx⟩ := h2
+theorem div_le_iff_le_mul_of_dvd (hb : b ≠ 0) (hba : b ∣ a) : a / b ≤ c ↔ a ≤ c * b := by
+  obtain ⟨_, hx⟩ := hba
   simp only [hx]
-  rw [Nat.mul_div_right _ h1, Nat.mul_comm]
-  exact ⟨mul_le_mul_right b, fun h ↦ Nat.le_of_mul_le_mul_right h h1⟩
+  rw [Nat.mul_div_right _ (zero_lt_of_ne_zero hb), Nat.mul_comm]
+  exact ⟨mul_le_mul_right b, fun h ↦ Nat.le_of_mul_le_mul_right h (zero_lt_of_ne_zero hb)⟩
 
-theorem lt_div_iff_mul_lt_of_dvd (a b c : ℕ) (h1 : 0 < c) (h2 : c ∣ b) : a < b / c ↔ a * c < b := by
-  obtain ⟨x, hx⟩ := h2
+theorem lt_div_iff_mul_lt_of_dvd (hc : c ≠ 0) (hcb : c ∣ b) : a < b / c ↔ a * c < b := by
+  obtain ⟨x, hx⟩ := hcb
   simp only [hx]
-  rw [Nat.mul_div_right _ h1, Nat.mul_comm]
-  exact ⟨fun h ↦ Nat.mul_lt_mul_of_pos_left h h1, (Nat.mul_lt_mul_left h1).mp⟩
+  rw [Nat.mul_div_right _ (zero_lt_of_ne_zero hc), Nat.mul_comm]
+  exact ⟨fun h ↦ Nat.mul_lt_mul_of_pos_left h (zero_lt_of_ne_zero hc),
+    (Nat.mul_lt_mul_left (zero_lt_of_ne_zero hc)).mp⟩
 
 /-!
 ### `pow`

--- a/Mathlib/Data/Nat/Init.lean
+++ b/Mathlib/Data/Nat/Init.lean
@@ -435,41 +435,42 @@ protected lemma div_left_inj (hda : d ∣ a) (hdb : d ∣ b) : a / d = b / d ↔
   rw [← Nat.mul_div_cancel' hda, ← Nat.mul_div_cancel' hdb, h]
 
 /-- TODO: Replace `Nat.sub_mul_div` in core. -/
-lemma sub_mul_div' : (a - b * c) / b = a / b - c  := by
-  by_cases h : b * c ≤ a
+lemma sub_mul_div' (a b c : ℕ) : (a - b * c) / b = a / b - c := by
+  obtain h | h := Nat.le_total (b * c) a
   · rw [Nat.sub_mul_div _ _ _ h]
-  · simp only [Nat.not_le] at h
-    rw [ Nat.sub_eq_zero_of_le (Nat.le_of_lt h),Nat.zero_div]
+  · rw [Nat.sub_eq_zero_of_le h, Nat.zero_div]
     by_cases hn : b = 0
     · simp only [hn, Nat.div_zero, zero_le, Nat.sub_eq_zero_of_le]
-    · have h2 : a / b ≤ (b * c) / b := Nat.div_le_div_right (Nat.le_of_lt h)
+    · have h2 : a / b ≤ (b * c) / b := Nat.div_le_div_right h
       rw [Nat.mul_div_cancel_left _ (zero_lt_of_ne_zero hn)] at h2
       rw [Nat.sub_eq_zero_of_le h2]
 
-lemma mul_sub_div_of_dvd (h1 : 0 < c) (h2 : c ∣ b) :  (c * a - b) / c = a - b / c := by
-  obtain ⟨_,hx⟩ := h2
-  simp only [hx,←Nat.mul_sub_left_distrib,Nat.mul_div_right,h1]
+lemma mul_sub_div_of_dvd (a b c : ℕ) (h1 : c ≠ 0) (h2 : c ∣ b) : (c * a - b) / c = a - b / c := by
+  obtain ⟨_, hx⟩ := h2
+  simp only [hx, ← Nat.mul_sub_left_distrib, Nat.mul_div_right, zero_lt_of_ne_zero h1]
 
-lemma mul_add_mul_div_of_dvd  (hb : 0 < b) (hd : 0 < d) (h1 : b ∣ a) (h2 : d ∣ c) :
+lemma mul_add_mul_div_of_dvd (hb : b ≠ 0) (hd : d ≠ 0) (h1 : b ∣ a) (h2 : d ∣ c) :
     (a * d + b * c) / (b * d) = a / b + c / d := by
-  obtain ⟨n,hn⟩ := h1
-  obtain ⟨_,hm⟩ := h2
-  rw [hn,hm,Nat.mul_assoc b n d,Nat.mul_comm n d,← Nat.mul_assoc,← Nat.mul_assoc,
-    ← Nat.mul_add,Nat.mul_div_right _ hb, Nat.mul_div_right _ hd,
-    Nat.mul_div_right _ (Nat.mul_pos hb hd)]
+  obtain ⟨n, hn⟩ := h1
+  obtain ⟨_, hm⟩ := h2
+  rw [hn, hm, Nat.mul_assoc b n d, Nat.mul_comm n d, ← Nat.mul_assoc, ← Nat.mul_assoc,
+    ← Nat.mul_add, Nat.mul_div_right _ (zero_lt_of_ne_zero hb),
+    Nat.mul_div_right _ (zero_lt_of_ne_zero hd),
+    Nat.mul_div_right _ (Nat.mul_pos (zero_lt_of_ne_zero hb) (zero_lt_of_ne_zero hd))]
 
-lemma mul_sub_mul_div_of_dvd (hb : 0 < b) (hd : 0 < d) (h1 : b ∣ a) (h2 : d ∣ c) :
+lemma mul_sub_mul_div_of_dvd (hb : b ≠ 0) (hd : d ≠ 0) (h1 : b ∣ a) (h2 : d ∣ c) :
     (a * d - b * c) / (b * d)  = a / b - c / d:= by
-  obtain ⟨n,hn⟩ := h1
-  obtain ⟨m,hm⟩ := h2
-  rw [hn,hm]
-  rw [Nat.mul_assoc,Nat.mul_comm n d,←Nat.mul_assoc,←Nat.mul_assoc,←Nat.mul_sub_left_distrib,
-    Nat.mul_div_right _ hb, Nat.mul_div_right _ hd, Nat.mul_div_right _ (Nat.mul_pos hb hd )]
+  obtain ⟨n, hn⟩ := h1
+  obtain ⟨m, hm⟩ := h2
+  rw [hn, hm]
+  rw [Nat.mul_assoc,Nat.mul_comm n d, ← Nat.mul_assoc,← Nat.mul_assoc, ← Nat.mul_sub_left_distrib,
+    Nat.mul_div_right _ (zero_lt_of_ne_zero hb), Nat.mul_div_right _ (zero_lt_of_ne_zero hd),
+    Nat.mul_div_right _ (Nat.mul_pos (zero_lt_of_ne_zero hb) (zero_lt_of_ne_zero hd))]
 
-lemma div_mul_assoc (h : b ∣ a) : (a / b) * c = (a * c) / b := by
-  rw [Nat.mul_comm,←Nat.mul_div_assoc _ h,Nat.mul_comm]
+lemma div_mul_assoc (a b c : ℕ) (h : b ∣ a) : (a / b) * c = (a * c) / b := by
+  rw [Nat.mul_comm, ← Nat.mul_div_assoc _ h, Nat.mul_comm]
 
-lemma eq_div_iff_mul_eq_left (h1 : 0 < c) (h2 : c ∣ b) : a = b / c ↔ b = a * c:= by
+lemma eq_div_iff_mul_eq_left (a b c : ℕ) (h1 : 0 < c) (h2 : c ∣ b) : a = b / c ↔ b = a * c := by
   rw [eq_comm, Nat.div_eq_iff_eq_mul_left h1 h2]
 
 lemma div_mul_div_comm : b ∣ a → d ∣ c → (a / b) * (c / d) = (a * c) / (b * d) := by
@@ -562,17 +563,18 @@ protected lemma mul_le_of_le_div (k x y : ℕ) (h : x ≤ y / k) : x * k ≤ y :
   else
     rwa [← le_div_iff_mul_le (Nat.pos_iff_ne_zero.2 hk)]
 
-theorem div_le_iff_le_mul_of_dvd (h1 : 0 < b) (h2 : b ∣ a) : a / b ≤ c ↔ a ≤ c * b := by
-  obtain ⟨_,hx⟩ := h2
+theorem div_le_iff_le_mul_of_dvd (a b c : ℕ) (h1 : 0 < b) (h2 : b ∣ a) : a / b ≤ c ↔ a ≤ c * b := by
+  obtain ⟨_, hx⟩ := h2
   simp only [hx]
-  rw [Nat.mul_div_right _ h1,Nat.mul_comm]
+  rw [Nat.mul_div_right _ h1, Nat.mul_comm]
   exact ⟨mul_le_mul_right b, fun h ↦ Nat.le_of_mul_le_mul_right h h1⟩
 
-theorem lt_div_iff_mul_lt_of_dvd (h1 : 0 < c) (h2 : c ∣ b) : a < b / c ↔ a * c < b := by
-  obtain ⟨x,hx⟩ := h2
+theorem lt_div_iff_mul_lt_of_dvd (a b c : ℕ) (h1 : 0 < c) (h2 : c ∣ b) : a < b / c ↔ a * c < b := by
+  obtain ⟨x, hx⟩ := h2
   simp only [hx]
-  rw [Nat.mul_div_right _ h1,Nat.mul_comm]
-  exact ⟨fun h ↦ Nat.mul_lt_mul_of_pos_left h h1,(Nat.mul_lt_mul_left h1).mp⟩
+  rw [Nat.mul_div_right _ h1, Nat.mul_comm]
+  exact ⟨fun h ↦ Nat.mul_lt_mul_of_pos_left h h1, (Nat.mul_lt_mul_left h1).mp⟩
+
 /-!
 ### `pow`
 


### PR DESCRIPTION
This PR includes some equalities and equivalences about expressions with natural numbers.

They can be useful as rewriting lemmas to simplify expressions.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
