### PR TITLE
[Merged by Bors] - feat: metric-separated sets

### DIFF
--- a/Mathlib/Topology/MetricSpace/MetricSeparated.lean
+++ b/Mathlib/Topology/MetricSpace/MetricSeparated.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2021 Yury Kudryashov. All rights reserved.
+Copyright (c) 2021 Yury Kudryashov, Yaël Dillies. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Yury Kudryashov
+Authors: Yury Kudryashov, Yaël Dillies
 -/
 import Mathlib.Topology.EMetricSpace.Defs
 
@@ -36,8 +36,8 @@ In this section we define the predicate `Metric.IsSeparated` for `ε`-separated 
 other. -/
 def IsSeparated (ε : ℝ≥0∞) (s : Set X) : Prop := s.Pairwise (ε < edist · ·)
 
-@[simp] protected nonrec lemma IsSeparated.empty : IsSeparated ε (∅ : Set X) := pairwise_empty _
-@[simp] protected nonrec lemma IsSeparated.singleton : IsSeparated ε {x} := pairwise_singleton ..
+protected lemma IsSeparated.empty : IsSeparated ε (∅ : Set X) := pairwise_empty _
+protected lemma IsSeparated.singleton : IsSeparated ε {x} := pairwise_singleton ..
 
 @[simp] lemma IsSeparated.of_subsingleton (hs : s.Subsingleton) : IsSeparated ε s := hs.pairwise _
 

--- a/Mathlib/Topology/MetricSpace/MetricSeparated.lean
+++ b/Mathlib/Topology/MetricSpace/MetricSeparated.lean
@@ -58,7 +58,7 @@ lemma isSeparated_insert_of_not_mem (hx : x ∉ s) :
   pairwise_insert_of_symmetric_of_not_mem (fun _ _ ↦ by simp [edist_comm]) hx
 
 protected lemma IsSeparated.insert (hs : IsSeparated ε s) (h : ∀ y ∈ s, x ≠ y → ε < edist x y) :
-    IsSeparated ε (insert x s) := hs.insert_of_symmetric (fun _ _ ↦ by simp [edist_comm]) h
+    IsSeparated ε (insert x s) := isSeparated_insert.2 ⟨hs, h⟩
 
 /-!
 ### Metric separated pairs of sets

--- a/Mathlib/Topology/MetricSpace/MetricSeparated.lean
+++ b/Mathlib/Topology/MetricSpace/MetricSeparated.lean
@@ -6,32 +6,68 @@ Authors: Yury Kudryashov
 import Mathlib.Topology.EMetricSpace.Defs
 
 /-!
-# Metric separated pairs of sets
+# Metric separation
 
-In this file we define the predicate `Metric.AreSeparated`. We say that two sets in an (extended)
-metric space are *metric separated* if the (extended) distance between `x ∈ s` and `y ∈ t` is
-bounded from below by a positive constant.
+This file defines a few notions of separations of sets in a metric space.
 
-This notion is useful, e.g., to define metric outer measures.
+## Main declarations
+
+* `Metric.IsSeparated`: A set `s` is `ε`-separated if its elements are pairwise at distance at least
+  `ε` from each other.
+* `Metric.AreSeparated`: Two sets `s` and `t` are separated if the distance between `x ∈ s` and
+  `y ∈ t` is bounded from below by a positive constant.
 -/
 
-
 open EMetric Set
+open scoped ENNReal
 
 noncomputable section
 
 namespace Metric
+variable {X : Type*} [PseudoEMetricSpace X] {s t : Set X} {ε δ : ℝ≥0∞} {x : X}
+
+/-!
+### Metric-separated sets
+
+In this section we define the predicate `Metric.IsSeparated` for `ε`-separated sets.
+-/
+
+/-- A set `s` is `ε`-separated if its elements are pairwise at distance at least `ε` from each
+other. -/
+def IsSeparated (ε : ℝ≥0∞) (s : Set X) : Prop := s.Pairwise (ε < edist · ·)
+
+@[simp] protected nonrec lemma IsSeparated.empty : IsSeparated ε (∅ : Set X) := pairwise_empty _
+@[simp] protected nonrec lemma IsSeparated.singleton : IsSeparated ε {x} := pairwise_singleton ..
+
+@[simp] lemma IsSeparated.of_subsingleton (hs : s.Subsingleton) : IsSeparated ε s := hs.pairwise _
+
+alias _root_.Set.Subsingleton.isSeparated := IsSeparated.of_subsingleton
+
+nonrec lemma IsSeparated.anti (hεδ : ε ≤ δ) (hs : IsSeparated δ s) : IsSeparated ε s :=
+  hs.mono' fun _ _ ↦ hεδ.trans_lt
+
+lemma IsSeparated.subset (hst : s ⊆ t) (hs : IsSeparated ε t) : IsSeparated ε s := hs.mono hst
+
+protected lemma IsSeparated.insert (hs : IsSeparated ε s) (h : ∀ y ∈ s, x ≠ y → ε < edist x y) :
+    IsSeparated ε (insert x s) := hs.insert_of_symmetric (fun _ _ ↦ by simp [edist_comm]) h
+
+/-!
+### Metric separated pairs of sets
+
+In this section we define the predicate `Metric.AreSeparated`. We say that two sets in an
+(extended) metric space are *metric separated* if the (extended) distance between `x ∈ s` and
+`y ∈ t` is bounded from below by a positive constant.
+
+This notion is useful, e.g., to define metric outer measures.
+-/
 
 /-- Two sets in an (extended) metric space are called *metric separated* if the (extended) distance
 between `x ∈ s` and `y ∈ t` is bounded from below by a positive constant. -/
-def AreSeparated {X : Type*} [EMetricSpace X] (s t : Set X) :=
-  ∃ r, r ≠ 0 ∧ ∀ x ∈ s, ∀ y ∈ t, r ≤ edist x y
+def AreSeparated (s t : Set X) := ∃ r, r ≠ 0 ∧ ∀ x ∈ s, ∀ y ∈ t, r ≤ edist x y
 
 @[deprecated (since := "2025-01-21")] alias IsMetricSeparated := AreSeparated
 
 namespace AreSeparated
-
-variable {X : Type*} [EMetricSpace X] {s t : Set X}
 
 @[symm]
 theorem symm (h : AreSeparated s t) : AreSeparated t s :=

--- a/Mathlib/Topology/MetricSpace/MetricSeparated.lean
+++ b/Mathlib/Topology/MetricSpace/MetricSeparated.lean
@@ -10,12 +10,13 @@ import Mathlib.Topology.EMetricSpace.Defs
 
 This file defines a few notions of separations of sets in a metric space.
 
-## Main declarations
 
-* `Metric.IsSeparated`: A set `s` is `ε`-separated if its elements are pairwise at distance at least
-  `ε` from each other.
-* `Metric.AreSeparated`: Two sets `s` and `t` are separated if the distance between `x ∈ s` and
-  `y ∈ t` is bounded from below by a positive constant.
+The first notion (`Metric.IsSeparated`) is quantitative and about a single set: A set `s` is
+`ε`-separated if its elements are pairwise at distance at least `ε` from each other.
+
+The second notion ( `Metric.AreSeparated`) is qualitative and about two sets: Two sets `s` and `t`
+are separated if the distance between `x ∈ s` and `y ∈ t` is bounded from below by a positive
+constant.
 -/
 
 open EMetric Set

--- a/Mathlib/Topology/MetricSpace/MetricSeparated.lean
+++ b/Mathlib/Topology/MetricSpace/MetricSeparated.lean
@@ -49,6 +49,14 @@ nonrec lemma IsSeparated.anti (hεδ : ε ≤ δ) (hs : IsSeparated δ s) : IsSe
 
 lemma IsSeparated.subset (hst : s ⊆ t) (hs : IsSeparated ε t) : IsSeparated ε s := hs.mono hst
 
+lemma isSeparated_insert :
+    IsSeparated ε (insert x s) ↔ IsSeparated ε s ∧ ∀ y ∈ s, x ≠ y → ε < edist x y :=
+  pairwise_insert_of_symmetric fun _ _ ↦ by simp [edist_comm]
+
+lemma isSeparated_insert_of_not_mem (hx : x ∉ s) :
+    IsSeparated ε (insert x s) ↔ IsSeparated ε s ∧ ∀ y ∈ s, ε < edist x y :=
+  pairwise_insert_of_symmetric_of_not_mem (fun _ _ ↦ by simp [edist_comm]) hx
+
 protected lemma IsSeparated.insert (hs : IsSeparated ε s) (h : ∀ y ∈ s, x ≠ y → ε < edist x y) :
     IsSeparated ε (insert x s) := hs.insert_of_symmetric (fun _ _ ↦ by simp [edist_comm]) h
 


### PR DESCRIPTION
For `ε : ℝ≥0∞`, define `ε`-separated sets as those sets `s` for which the distance between any two points of `s` is at least `ε`.

From my PhD (MiscYD)


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
