### PR TITLE
[Merged by Bors] - feat(Data/Real): (NN)Real.exists_nat_pos_inv_lt

### DIFF
--- a/Mathlib/Data/NNReal/Defs.lean
+++ b/Mathlib/Data/NNReal/Defs.lean
@@ -797,6 +797,10 @@ protected theorem zpow_pos {x : ℝ≥0} (hx : x ≠ 0) (n : ℤ) : 0 < x ^ n :=
 theorem inv_lt_inv {x y : ℝ≥0} (hx : x ≠ 0) (h : x < y) : y⁻¹ < x⁻¹ :=
   inv_strictAnti₀ hx.bot_lt h
 
+lemma exists_nat_pos_inv_lt {b : ℝ≥0} (hb : 0 < b) :
+    ∃ (n : ℕ), 0 < n ∧ (n : ℝ≥0)⁻¹ < b :=
+  b.toReal.exists_nat_pos_inv_lt hb
+
 end Inv
 
 @[simp]

--- a/Mathlib/Data/Real/Archimedean.lean
+++ b/Mathlib/Data/Real/Archimedean.lean
@@ -385,4 +385,11 @@ lemma exists_natCast_add_one_lt_pow_of_one_lt (ha : 1 < a) : ∃ m : ℕ, (m + 1
     _ = (1 / k + 1 : ℝ) ^ (2 * k ^ 2) := by rw [← pow_mul, mul_left_comm, sq]
     _ < a ^ (2 * k ^ 2) := by gcongr
 
+lemma exists_nat_pos_inv_lt {b : ℝ} (hb : 0 < b) :
+    ∃ (n : ℕ), 0 < n ∧ (n : ℝ)⁻¹ < b := by
+  refine (exists_nat_gt b⁻¹).imp fun k hk ↦ ?_
+  have := (inv_pos_of_pos hb).trans hk
+  refine ⟨Nat.cast_pos.mp this, ?_⟩
+  rwa [inv_lt_comm₀ this hb]
+
 end Real

--- a/Mathlib/Data/Real/StarOrdered.lean
+++ b/Mathlib/Data/Real/StarOrdered.lean
@@ -30,14 +30,3 @@ instance NNReal.instStarOrderedRing : StarOrderedRing ℝ≥0 := by
     simp only [star_trivial, mul_self_sqrt]
   · rintro ⟨p, -, rfl⟩
     exact le_self_add
-
-lemma Real.exists_nat_pos_inv_lt {b : ℝ} (hb : 0 < b) :
-    ∃ (n : ℕ), 0 < n ∧ (n : ℝ)⁻¹ < b := by
-  refine (exists_nat_gt b⁻¹).imp fun k hk ↦ ?_
-  have := (inv_pos_of_pos hb).trans hk
-  refine ⟨Nat.cast_pos.mp this, ?_⟩
-  rwa [inv_lt_comm₀ this hb]
-
-lemma NNReal.exists_nat_pos_inv_lt {b : ℝ≥0} (hb : 0 < b) :
-    ∃ (n : ℕ), 0 < n ∧ (n : ℝ≥0)⁻¹ < b :=
-  b.toReal.exists_nat_pos_inv_lt hb

--- a/Mathlib/Data/Real/StarOrdered.lean
+++ b/Mathlib/Data/Real/StarOrdered.lean
@@ -30,3 +30,14 @@ instance NNReal.instStarOrderedRing : StarOrderedRing ℝ≥0 := by
     simp only [star_trivial, mul_self_sqrt]
   · rintro ⟨p, -, rfl⟩
     exact le_self_add
+
+lemma Real.exists_nat_pos_inv_lt {b : ℝ} (hb : 0 < b) :
+    ∃ (n : ℕ), 0 < n ∧ (n : ℝ)⁻¹ < b := by
+  refine (exists_nat_gt b⁻¹).imp fun k hk ↦ ?_
+  have := (inv_pos_of_pos hb).trans hk
+  refine ⟨Nat.cast_pos.mp this, ?_⟩
+  rwa [inv_lt_comm₀ this hb]
+
+lemma NNReal.exists_nat_pos_inv_lt {b : ℝ≥0} (hb : 0 < b) :
+    ∃ (n : ℕ), 0 < n ∧ (n : ℝ≥0)⁻¹ < b :=
+  b.toReal.exists_nat_pos_inv_lt hb


### PR DESCRIPTION
The ENNReal version already exists as
ENNReal.exists_nat_pos_inv_mul_lt


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
