### PR TITLE
[Merged by Bors] - feat: grading a flag

### DIFF
--- a/Mathlib/Order/Grade.lean
+++ b/Mathlib/Order/Grade.lean
@@ -198,6 +198,7 @@ end PartialOrder
 
 /-! ### Instances -/
 
+section Preorder
 variable [Preorder 𝕆] [Preorder ℙ] [Preorder α] [Preorder β]
 
 instance Preorder.toGradeBoundedOrder : GradeBoundedOrder α α where
@@ -326,3 +327,60 @@ instance [GradeOrder ℕ α] : WellFoundedLT α :=
 
 instance [GradeOrder ℕᵒᵈ α] : WellFoundedGT α :=
   GradeOrder.wellFoundedGT ℕᵒᵈ
+
+end Preorder
+
+/-!
+### Grading a flag
+
+A flag inherits the grading of its ambient order.
+-/
+
+namespace Flag
+variable [PartialOrder α] {s : Flag α}
+
+@[simp]
+lemma coe_covby_coe {a b : s} : (a : α) ⋖ b ↔ a ⋖ b := by
+  refine and_congr_right' ⟨fun h c hac ↦ h hac, fun h c hac hcb ↦
+    @h ⟨c, mem_iff_forall_le_or_ge.2 fun d hd ↦ ?_⟩ hac hcb⟩
+  classical
+  obtain hda | had := le_or_lt (⟨d, hd⟩ : s) a
+  · exact .inr ((Subtype.coe_le_coe.2 hda).trans hac.le)
+  obtain hbd | hdb := le_or_lt b ⟨d, hd⟩
+  · exact .inl (hcb.le.trans hbd)
+  · cases h had hdb
+
+@[simp]
+lemma isMax_coe {a : s} : IsMax (a : α) ↔ IsMax a where
+  mp h b hab := h hab
+  mpr h b hab := by
+    refine @h ⟨b, mem_iff_forall_le_or_ge.2 fun c hc ↦ ?_⟩ hab
+    classical
+    exact .inr <| hab.trans' <| h.isTop ⟨c, hc⟩
+
+@[simp]
+lemma isMin_coe {a : s} : IsMin (a : α) ↔ IsMin a where
+  mp h b hba := h hba
+  mpr h b hba := by
+    refine @h ⟨b, mem_iff_forall_le_or_ge.2 fun c hc ↦ ?_⟩ hba
+    classical
+    exact .inl <| hba.trans <| h.isBot ⟨c, hc⟩
+
+variable [Preorder 𝕆]
+
+instance [GradeOrder 𝕆 α] (s : Flag α) : GradeOrder 𝕆 s :=
+  .liftRight _ (Subtype.strictMono_coe _) fun _ _ ↦ coe_covby_coe.2
+
+instance [GradeMinOrder 𝕆 α] (s : Flag α) : GradeMinOrder 𝕆 s :=
+  .liftRight _ (Subtype.strictMono_coe _) (fun _ _ ↦ coe_covby_coe.2) fun _ ↦ isMin_coe.2
+
+instance [GradeMaxOrder 𝕆 α] (s : Flag α) : GradeMaxOrder 𝕆 s :=
+  .liftRight _ (Subtype.strictMono_coe _) (fun _ _ ↦ coe_covby_coe.2) fun _ ↦ isMax_coe.2
+
+instance [GradeBoundedOrder 𝕆 α] (s : Flag α) : GradeBoundedOrder 𝕆 s :=
+  .liftRight _ (Subtype.strictMono_coe _) (fun _ _ ↦ coe_covby_coe.2) (fun _ ↦ isMin_coe.2)
+    fun _ ↦ isMax_coe.2
+
+@[simp, norm_cast] lemma grade_coe [GradeOrder 𝕆 α] (a : s) : grade 𝕆 (a : α) = grade 𝕆 a := rfl
+
+end Flag

--- a/Mathlib/Order/Grade.lean
+++ b/Mathlib/Order/Grade.lean
@@ -337,10 +337,21 @@ A flag inherits the grading of its ambient order.
 -/
 
 namespace Flag
-variable [PartialOrder α] {s : Flag α}
+variable [PartialOrder α] {s : Flag α} {a b : s}
 
-@[simp]
-lemma coe_covby_coe {a b : s} : (a : α) ⋖ b ↔ a ⋖ b := by
+@[simp, norm_cast]
+lemma coe_wcovBy_coe : (a : α) ⩿ b ↔ a ⩿ b := by
+  refine and_congr_right' ⟨fun h c hac ↦ h hac, fun h c hac hcb ↦
+    @h ⟨c, mem_iff_forall_le_or_ge.2 fun d hd ↦ ?_⟩ hac hcb⟩
+  classical
+  obtain hda | had := le_or_lt (⟨d, hd⟩ : s) a
+  · exact .inr ((Subtype.coe_le_coe.2 hda).trans hac.le)
+  obtain hbd | hdb := le_or_lt b ⟨d, hd⟩
+  · exact .inl (hcb.le.trans hbd)
+  · cases h had hdb
+
+@[simp, norm_cast]
+lemma coe_covBy_coe : (a : α) ⋖ b ↔ a ⋖ b := by
   refine and_congr_right' ⟨fun h c hac ↦ h hac, fun h c hac hcb ↦
     @h ⟨c, mem_iff_forall_le_or_ge.2 fun d hd ↦ ?_⟩ hac hcb⟩
   classical
@@ -351,7 +362,7 @@ lemma coe_covby_coe {a b : s} : (a : α) ⋖ b ↔ a ⋖ b := by
   · cases h had hdb
 
 @[simp]
-lemma isMax_coe {a : s} : IsMax (a : α) ↔ IsMax a where
+lemma isMax_coe : IsMax (a : α) ↔ IsMax a where
   mp h b hab := h hab
   mpr h b hab := by
     refine @h ⟨b, mem_iff_forall_le_or_ge.2 fun c hc ↦ ?_⟩ hab
@@ -359,7 +370,7 @@ lemma isMax_coe {a : s} : IsMax (a : α) ↔ IsMax a where
     exact .inr <| hab.trans' <| h.isTop ⟨c, hc⟩
 
 @[simp]
-lemma isMin_coe {a : s} : IsMin (a : α) ↔ IsMin a where
+lemma isMin_coe : IsMin (a : α) ↔ IsMin a where
   mp h b hba := h hba
   mpr h b hba := by
     refine @h ⟨b, mem_iff_forall_le_or_ge.2 fun c hc ↦ ?_⟩ hba
@@ -369,16 +380,16 @@ lemma isMin_coe {a : s} : IsMin (a : α) ↔ IsMin a where
 variable [Preorder 𝕆]
 
 instance [GradeOrder 𝕆 α] (s : Flag α) : GradeOrder 𝕆 s :=
-  .liftRight _ (Subtype.strictMono_coe _) fun _ _ ↦ coe_covby_coe.2
+  .liftRight _ (Subtype.strictMono_coe _) fun _ _ ↦ coe_covBy_coe.2
 
 instance [GradeMinOrder 𝕆 α] (s : Flag α) : GradeMinOrder 𝕆 s :=
-  .liftRight _ (Subtype.strictMono_coe _) (fun _ _ ↦ coe_covby_coe.2) fun _ ↦ isMin_coe.2
+  .liftRight _ (Subtype.strictMono_coe _) (fun _ _ ↦ coe_covBy_coe.2) fun _ ↦ isMin_coe.2
 
 instance [GradeMaxOrder 𝕆 α] (s : Flag α) : GradeMaxOrder 𝕆 s :=
-  .liftRight _ (Subtype.strictMono_coe _) (fun _ _ ↦ coe_covby_coe.2) fun _ ↦ isMax_coe.2
+  .liftRight _ (Subtype.strictMono_coe _) (fun _ _ ↦ coe_covBy_coe.2) fun _ ↦ isMax_coe.2
 
 instance [GradeBoundedOrder 𝕆 α] (s : Flag α) : GradeBoundedOrder 𝕆 s :=
-  .liftRight _ (Subtype.strictMono_coe _) (fun _ _ ↦ coe_covby_coe.2) (fun _ ↦ isMin_coe.2)
+  .liftRight _ (Subtype.strictMono_coe _) (fun _ _ ↦ coe_covBy_coe.2) (fun _ ↦ isMin_coe.2)
     fun _ ↦ isMax_coe.2
 
 @[simp, norm_cast] lemma grade_coe [GradeOrder 𝕆 α] (a : s) : grade 𝕆 (a : α) = grade 𝕆 a := rfl

--- a/Mathlib/Order/Grade.lean
+++ b/Mathlib/Order/Grade.lean
@@ -351,15 +351,7 @@ lemma coe_wcovBy_coe : (a : α) ⩿ b ↔ a ⩿ b := by
   · cases h had hdb
 
 @[simp, norm_cast]
-lemma coe_covBy_coe : (a : α) ⋖ b ↔ a ⋖ b := by
-  refine and_congr_right' ⟨fun h c hac ↦ h hac, fun h c hac hcb ↦
-    @h ⟨c, mem_iff_forall_le_or_ge.2 fun d hd ↦ ?_⟩ hac hcb⟩
-  classical
-  obtain hda | had := le_or_lt (⟨d, hd⟩ : s) a
-  · exact .inr ((Subtype.coe_le_coe.2 hda).trans hac.le)
-  obtain hbd | hdb := le_or_lt b ⟨d, hd⟩
-  · exact .inl (hcb.le.trans hbd)
-  · cases h had hdb
+lemma coe_covBy_coe : (a : α) ⋖ b ↔ a ⋖ b := by simp [covBy_iff_wcovBy_and_not_le]
 
 @[simp]
 lemma isMax_coe : IsMax (a : α) ↔ IsMax a where


### PR DESCRIPTION
A flag inherits the grading of its ambient order.

From MiscYD


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
