### PR TITLE
[Merged by Bors] - doc: provide an actual docstring to `MetricSpace`

### DIFF
--- a/Mathlib/Topology/EMetricSpace/Defs.lean
+++ b/Mathlib/Topology/EMetricSpace/Defs.lean
@@ -66,8 +66,8 @@ inequality `edist x z ≤ edist x y + edist y z`.
 Note that we do not require `edist x y = 0 → x = y`. See extended metric spaces (`EMetricSpace`) for
 the similar class with that stronger assumption.
 
-Any pseudo extended metric space is a topological space and a uniform space,
-where the topology and uniformity come from the metric.
+Any pseudo extended metric space is a topological space and a uniform space (see `TopologicalSpace`,
+`UniformSpace`), where the topology and uniformity come from the metric.
 Note that a T1 pseudo extended metric space is just an extended metric space.
 
 We make the uniformity/topology part of the data instead of deriving it from the metric. This eg
@@ -546,8 +546,8 @@ end EMetric
 See pseudo extended metric spaces (`PseudoEMetricSpace`) for the similar class with the
 `edist x y = 0 ↔ x = y` assumption weakened to `edist x x = 0`.
 
-Any extended metric space is a T1 topological space and a uniform space,
-where the topology and uniformity come from the metric.
+Any extended metric space is a T1 topological space and a uniform space (see `TopologicalSpace`,
+`T1Space`, `UniformSpace`), where the topology and uniformity come from the metric.
 
 We make the uniformity/topology part of the data instead of deriving it from the metric.
 This eg ensures that we do not get a diamond when doing

--- a/Mathlib/Topology/EMetricSpace/Defs.lean
+++ b/Mathlib/Topology/EMetricSpace/Defs.lean
@@ -73,7 +73,8 @@ Note that a T1 pseudo extended metric space is just an extended metric space.
 We make the uniformity/topology part of the data instead of deriving it from the metric. This eg
 ensures that we do not get a diamond when doing
 `[PseudoEMetricSpace α] [PseudoEMetricSpace β] : TopologicalSpace (α × β)`:
-The product metric and product topology agree, but not definitionally so. -/
+The product metric and product topology agree, but not definitionally so.
+See Note [forgetful inheritance]. -/
 class PseudoEMetricSpace (α : Type u) : Type u extends EDist α  where
   edist_self : ∀ x : α, edist x x = 0
   edist_comm : ∀ x y : α, edist x y = edist y x
@@ -542,7 +543,8 @@ end EMetric
 `edist x y = 0 ↔ x = y`, commutativity `edist x y = edist y x`, and the triangle inequality
 `edist x z ≤ edist x y + edist y z`.
 
-See `PseudoEMetricSpace` for the similar class without the  `edist x y = 0 → x = y` assumption.
+See `PseudoEMetricSpace` for the similar class with the `edist x y = 0 ↔ x = y` assumption
+weakened to `edist x x = 0`.
 
 Any extended metric space is a T1 topological space and a uniform space,
 where the topology and uniformity come from the metric.
@@ -550,7 +552,8 @@ where the topology and uniformity come from the metric.
 We make the uniformity/topology part of the data instead of deriving it from the metric.
 This eg ensures that we do not get a diamond when doing
 `[EMetricSpace α] [EMetricSpace β] : TopologicalSpace (α × β)`:
-The product metric and product topology agree, but not definitionally so. -/
+The product metric and product topology agree, but not definitionally so.
+See Note [forgetful inheritance]. -/
 class EMetricSpace (α : Type u) : Type u extends PseudoEMetricSpace α where
   eq_of_edist_eq_zero : ∀ {x y : α}, edist x y = 0 → x = y
 

--- a/Mathlib/Topology/EMetricSpace/Defs.lean
+++ b/Mathlib/Topology/EMetricSpace/Defs.lean
@@ -59,21 +59,17 @@ def uniformSpaceOfEDist (edist : α → α → ℝ≥0∞) (edist_self : ∀ x :
     ⟨ε / 2, ENNReal.half_pos ε0.ne', fun _ h₁ _ h₂ =>
       (ENNReal.add_lt_add h₁ h₂).trans_eq (ENNReal.add_halves _)⟩
 
--- the uniform structure is embedded in the emetric space structure
--- to avoid instance diamond issues. See Note [forgetful inheritance].
-/-- Extended (pseudo) metric spaces, with an extended distance `edist` possibly taking the
-value ∞
+/-- An extended pseudo metric space is a topological space and uniform space equipped with an
+extended metric `edist`, possibly taking the value `∞`, such that the topology comes from metric.
 
-Each pseudo_emetric space induces a canonical `UniformSpace` and hence a canonical
-`TopologicalSpace`.
-This is enforced in the type class definition, by extending the `UniformSpace` structure. When
-instantiating a `PseudoEMetricSpace` structure, the uniformity fields are not necessary, they
+We make the uniformity/topology part of the data instead of deriving it from the metric. This eg
+ensures that we do not get a diamond when doing
+`[PseudoEMetricSpace α] [PseudoEMetricSpace β] : TopologicalSpace (α × β)`: The product metric and
+product topology agree, but not definitionally so.
+
+When instantiating `PseudoEMetricSpace`, the uniformity fields are not necessary, they
 will be filled in by default. There is a default value for the uniformity, that can be substituted
-in cases of interest, for instance when instantiating a `PseudoEMetricSpace` structure
-on a product.
-
-Continuity of `edist` is proved in `Topology.Instances.ENNReal`
--/
+in cases of interest, for instance when giving an `EMetricSpace` instance on a product. -/
 class PseudoEMetricSpace (α : Type u) : Type u extends EDist α  where
   edist_self : ∀ x : α, edist x x = 0
   edist_comm : ∀ x y : α, edist x y = edist y x
@@ -538,8 +534,17 @@ end Compact
 
 end EMetric
 
---namespace
-/-- We now define `EMetricSpace`, extending `PseudoEMetricSpace`. -/
+/-- An extended metric space is a T1 topological space and uniform space equipped with an extended
+metric `edist`, possibly taking the value `∞`, such that the topology comes from metric.
+
+We make the uniformity/topology part of the data instead of deriving it from the metric. This eg
+ensures that we do not get a diamond when doing
+`[EMetricSpace α] [EMetricSpace β] : TopologicalSpace (α × β)`: The product metric and product
+topology agree, but not definitionally so.
+
+When instantiating `EMetricSpace`, the uniformity fields are not necessary, they
+will be filled in by default. There is a default value for the uniformity, that can be substituted
+in cases of interest, for instance when giving an `EMetricSpace` instance on a product. -/
 class EMetricSpace (α : Type u) : Type u extends PseudoEMetricSpace α where
   eq_of_edist_eq_zero : ∀ {x y : α}, edist x y = 0 → x = y
 

--- a/Mathlib/Topology/EMetricSpace/Defs.lean
+++ b/Mathlib/Topology/EMetricSpace/Defs.lean
@@ -59,17 +59,20 @@ def uniformSpaceOfEDist (edist : α → α → ℝ≥0∞) (edist_self : ∀ x :
     ⟨ε / 2, ENNReal.half_pos ε0.ne', fun _ h₁ _ h₂ =>
       (ENNReal.add_lt_add h₁ h₂).trans_eq (ENNReal.add_halves _)⟩
 
-/-- An extended pseudo metric space is a topological space and uniform space equipped with an
-extended metric `edist`, possibly taking the value `∞`, such that the topology comes from metric.
+/-- A pseudo extended metric space is a type endowed with a `ℝ≥0∞`-valued distance `edist`
+satisfying the triangle inequality.
+
+Note that we do not require `edist x y = 0 → x = y`. See `EMetricSpace` for the analogous class with
+that stronger assumption.
+
+Any pseudo extended metric space is a topological space and a uniform space,
+where the topology and uniformity come from the metric.
+Note that a T1 pseudo extended metric space is just an extended metric space.
 
 We make the uniformity/topology part of the data instead of deriving it from the metric. This eg
 ensures that we do not get a diamond when doing
-`[PseudoEMetricSpace α] [PseudoEMetricSpace β] : TopologicalSpace (α × β)`: The product metric and
-product topology agree, but not definitionally so.
-
-When instantiating `PseudoEMetricSpace`, the uniformity fields are not necessary, they
-will be filled in by default. There is a default value for the uniformity, that can be substituted
-in cases of interest, for instance when giving an `EMetricSpace` instance on a product. -/
+`[PseudoEMetricSpace α] [PseudoEMetricSpace β] : TopologicalSpace (α × β)`:
+The product metric and product topology agree, but not definitionally so. -/
 class PseudoEMetricSpace (α : Type u) : Type u extends EDist α  where
   edist_self : ∀ x : α, edist x x = 0
   edist_comm : ∀ x y : α, edist x y = edist y x
@@ -534,17 +537,18 @@ end Compact
 
 end EMetric
 
-/-- An extended metric space is a T1 topological space and uniform space equipped with an extended
-metric `edist`, possibly taking the value `∞`, such that the topology comes from metric.
+/-- An extended metric space is a type endowed with a `ℝ≥0∞`-valued distance `edist` satisfying the
+triangle inequality and `edist x y = 0 → x = y`.
 
-We make the uniformity/topology part of the data instead of deriving it from the metric. This eg
-ensures that we do not get a diamond when doing
-`[EMetricSpace α] [EMetricSpace β] : TopologicalSpace (α × β)`: The product metric and product
-topology agree, but not definitionally so.
+See `PseudoEMetricSpace` for the similar class without the  `edist x y = 0 → x = y` assumption.
 
-When instantiating `EMetricSpace`, the uniformity fields are not necessary, they
-will be filled in by default. There is a default value for the uniformity, that can be substituted
-in cases of interest, for instance when giving an `EMetricSpace` instance on a product. -/
+Any extended metric space is a T1 topological space and a uniform space,
+where the topology and uniformity come from the metric.
+
+We make the uniformity/topology part of the data instead of deriving it from the metric.
+This eg ensures that we do not get a diamond when doing
+`[EMetricSpace α] [EMetricSpace β] : TopologicalSpace (α × β)`:
+The product metric and product topology agree, but not definitionally so. -/
 class EMetricSpace (α : Type u) : Type u extends PseudoEMetricSpace α where
   eq_of_edist_eq_zero : ∀ {x y : α}, edist x y = 0 → x = y
 

--- a/Mathlib/Topology/EMetricSpace/Defs.lean
+++ b/Mathlib/Topology/EMetricSpace/Defs.lean
@@ -63,8 +63,8 @@ def uniformSpaceOfEDist (edist : α → α → ℝ≥0∞) (edist_self : ∀ x :
 satisfying reflexivity `edist x x = 0`, commutativity `edist x y = edist y x`, and the triangle
 inequality `edist x z ≤ edist x y + edist y z`.
 
-Note that we do not require `edist x y = 0 → x = y`. See `EMetricSpace` for the analogous class with
-that stronger assumption.
+Note that we do not require `edist x y = 0 → x = y`. See extended metric spaces (`EMetricSpace`) for
+the similar class with that stronger assumption.
 
 Any pseudo extended metric space is a topological space and a uniform space,
 where the topology and uniformity come from the metric.
@@ -543,8 +543,8 @@ end EMetric
 `edist x y = 0 ↔ x = y`, commutativity `edist x y = edist y x`, and the triangle inequality
 `edist x z ≤ edist x y + edist y z`.
 
-See `PseudoEMetricSpace` for the similar class with the `edist x y = 0 ↔ x = y` assumption
-weakened to `edist x x = 0`.
+See pseudo extended metric spaces (`PseudoEMetricSpace`) for the similar class with the
+`edist x y = 0 ↔ x = y` assumption weakened to `edist x x = 0`.
 
 Any extended metric space is a T1 topological space and a uniform space,
 where the topology and uniformity come from the metric.

--- a/Mathlib/Topology/EMetricSpace/Defs.lean
+++ b/Mathlib/Topology/EMetricSpace/Defs.lean
@@ -60,7 +60,8 @@ def uniformSpaceOfEDist (edist : α → α → ℝ≥0∞) (edist_self : ∀ x :
       (ENNReal.add_lt_add h₁ h₂).trans_eq (ENNReal.add_halves _)⟩
 
 /-- A pseudo extended metric space is a type endowed with a `ℝ≥0∞`-valued distance `edist`
-satisfying the triangle inequality.
+satisfying reflexivity `edist x x = 0`, commutativity `edist x y = edist y x`, and the triangle
+inequality `edist x z ≤ edist x y + edist y z`.
 
 Note that we do not require `edist x y = 0 → x = y`. See `EMetricSpace` for the analogous class with
 that stronger assumption.
@@ -537,8 +538,9 @@ end Compact
 
 end EMetric
 
-/-- An extended metric space is a type endowed with a `ℝ≥0∞`-valued distance `edist` satisfying the
-triangle inequality and `edist x y = 0 → x = y`.
+/-- An extended metric space is a type endowed with a `ℝ≥0∞`-valued distance `edist` satisfying
+`edist x y = 0 ↔ x = y`, commutativity `edist x y = edist y x`, and the triangle inequality
+`edist x z ≤ edist x y + edist y z`.
 
 See `PseudoEMetricSpace` for the similar class without the  `edist x y = 0 → x = y` assumption.
 

--- a/Mathlib/Topology/MetricSpace/Defs.lean
+++ b/Mathlib/Topology/MetricSpace/Defs.lean
@@ -42,8 +42,8 @@ variable [PseudoMetricSpace α]
 See pseudometric spaces (`PseudoMetricSpace`) for the similar class with the `dist x y = 0 ↔ x = y`
 assumption weakened to `dist x x = 0`.
 
-Any metric space is a T1 topological space and a uniform space,
-where the topology and uniformity come from the metric.
+Any metric space is a T1 topological space and a uniform space (see `TopologicalSpace`, `T1Space`,
+`UniformSpace`), where the topology and uniformity come from the metric.
 
 We make the uniformity/topology part of the data instead of deriving it from the metric.
 This eg ensures that we do not get a diamond when doing

--- a/Mathlib/Topology/MetricSpace/Defs.lean
+++ b/Mathlib/Topology/MetricSpace/Defs.lean
@@ -35,17 +35,18 @@ universe u v w
 variable {α : Type u} {β : Type v} {X ι : Type*}
 variable [PseudoMetricSpace α]
 
-/-- A metric space is a T1 topological space and uniform space equipped with a metric `dist`,
-such that the topology comes from metric.
+/-- A metric space is a type endowed with a `ℝ`-valued distance `dist` satisfying the triangle
+inequality and `dist x y = 0 → x = y`.
 
-We make the uniformity/topology part of the data instead of deriving it from the metric. This eg
-ensures that we do not get a diamond when doing
-`[MetricSpace α] [MetricSpace β] : TopologicalSpace (α × β)`: The product metric and product
-topology agree, but not definitionally so.
+See `PseudoMetricSpace` for the similar class without the  `dist x y = 0 → x = y` assumption.
 
-When instantiating `MetricSpace`, the uniformity fields are not necessary, they
-will be filled in by default. There is a default value for the uniformity, that can be substituted
-in cases of interest, for instance when giving a `EMetricSpace` instance on a product. -/
+Any metric space is a T1 topological space and a uniform space,
+where the topology and uniformity come from the metric.
+
+We make the uniformity/topology part of the data instead of deriving it from the metric.
+This eg ensures that we do not get a diamond when doing
+`[MetricSpace α] [MetricSpace β] : TopologicalSpace (α × β)`:
+The product metric and product topology agree, but not definitionally so. -/
 class MetricSpace (α : Type u) : Type u extends PseudoMetricSpace α where
   eq_of_dist_eq_zero : ∀ {x y : α}, dist x y = 0 → x = y
 

--- a/Mathlib/Topology/MetricSpace/Defs.lean
+++ b/Mathlib/Topology/MetricSpace/Defs.lean
@@ -39,8 +39,8 @@ variable [PseudoMetricSpace α]
 `dist x y = 0 ↔ x = y`, commutativity `dist x y = dist y x`, and the triangle inequality
 `dist x z ≤ dist x y + dist y z`.
 
-See `PseudoMetricSpace` for the similar class with the `dist x y = 0 ↔ x = y` assumption
-weakened to `dist x x = 0`.
+See pseudometric spaces (`PseudoMetricSpace`) for the similar class with the `dist x y = 0 ↔ x = y`
+assumption weakened to `dist x x = 0`.
 
 Any metric space is a T1 topological space and a uniform space,
 where the topology and uniformity come from the metric.

--- a/Mathlib/Topology/MetricSpace/Defs.lean
+++ b/Mathlib/Topology/MetricSpace/Defs.lean
@@ -35,8 +35,9 @@ universe u v w
 variable {α : Type u} {β : Type v} {X ι : Type*}
 variable [PseudoMetricSpace α]
 
-/-- A metric space is a type endowed with a `ℝ`-valued distance `dist` satisfying the triangle
-inequality and `dist x y = 0 → x = y`.
+/-- A metric space is a type endowed with a `ℝ`-valued distance `dist` satisfying
+`dist x y = 0 ↔ x = y`, commutativity `dist x y = dist y x`, and the triangle inequality
+`dist x z ≤ dist x y + dist y z`.
 
 See `PseudoMetricSpace` for the similar class without the  `dist x y = 0 → x = y` assumption.
 

--- a/Mathlib/Topology/MetricSpace/Defs.lean
+++ b/Mathlib/Topology/MetricSpace/Defs.lean
@@ -35,7 +35,17 @@ universe u v w
 variable {α : Type u} {β : Type v} {X ι : Type*}
 variable [PseudoMetricSpace α]
 
-/-- We now define `MetricSpace`, extending `PseudoMetricSpace`. -/
+/-- A metric space is a T1 topological space and uniform space equipped with a metric `dist`,
+such that the topology comes from metric.
+
+We make the uniformity/topology part of the data instead of deriving it from the metric. This eg
+ensures that we do not get a diamond when doing
+`[MetricSpace α] [MetricSpace β] : TopologicalSpace (α × β)`: The product metric and product
+topology agree, but not definitionally so.
+
+When instantiating `MetricSpace`, the uniformity fields are not necessary, they
+will be filled in by default. There is a default value for the uniformity, that can be substituted
+in cases of interest, for instance when giving a `EMetricSpace` instance on a product. -/
 class MetricSpace (α : Type u) : Type u extends PseudoMetricSpace α where
   eq_of_dist_eq_zero : ∀ {x y : α}, dist x y = 0 → x = y
 

--- a/Mathlib/Topology/MetricSpace/Defs.lean
+++ b/Mathlib/Topology/MetricSpace/Defs.lean
@@ -39,7 +39,8 @@ variable [PseudoMetricSpace α]
 `dist x y = 0 ↔ x = y`, commutativity `dist x y = dist y x`, and the triangle inequality
 `dist x z ≤ dist x y + dist y z`.
 
-See `PseudoMetricSpace` for the similar class without the  `dist x y = 0 → x = y` assumption.
+See `PseudoMetricSpace` for the similar class with the `dist x y = 0 ↔ x = y` assumption
+weakened to `dist x x = 0`.
 
 Any metric space is a T1 topological space and a uniform space,
 where the topology and uniformity come from the metric.
@@ -47,7 +48,8 @@ where the topology and uniformity come from the metric.
 We make the uniformity/topology part of the data instead of deriving it from the metric.
 This eg ensures that we do not get a diamond when doing
 `[MetricSpace α] [MetricSpace β] : TopologicalSpace (α × β)`:
-The product metric and product topology agree, but not definitionally so. -/
+The product metric and product topology agree, but not definitionally so.
+See Note [forgetful inheritance]. -/
 class MetricSpace (α : Type u) : Type u extends PseudoMetricSpace α where
   eq_of_dist_eq_zero : ∀ {x y : α}, dist x y = 0 → x = y
 

--- a/Mathlib/Topology/MetricSpace/Pseudo/Defs.lean
+++ b/Mathlib/Topology/MetricSpace/Pseudo/Defs.lean
@@ -99,8 +99,9 @@ private theorem dist_nonneg' {α} {x y : α} (dist : α → α → ℝ)
     _ = 2 * dist x y := by rw [two_mul, dist_comm]
   nonneg_of_mul_nonneg_right this two_pos
 
-/-- A pseudo metric space is a type endowed with a `ℝ`-valued distance `dist` satisfying the
-triangle inequality.
+/-- A pseudo metric space is a type endowed with a `ℝ`-valued distance `dist` satisfying
+reflexivity `dist x x = 0`, commutativity `dist x y = dist y x`, and the triangle inequality
+`dist x z ≤ dist x y + dist y z`.
 
 Note that we do not require `dist x y = 0 → x = y`. See `MetricSpace` for the analogous class with
 that stronger assumption.

--- a/Mathlib/Topology/MetricSpace/Pseudo/Defs.lean
+++ b/Mathlib/Topology/MetricSpace/Pseudo/Defs.lean
@@ -99,16 +99,16 @@ private theorem dist_nonneg' {α} {x y : α} (dist : α → α → ℝ)
     _ = 2 * dist x y := by rw [two_mul, dist_comm]
   nonneg_of_mul_nonneg_right this two_pos
 
-/-- A pseudo metric space is a type endowed with a `ℝ`-valued distance `dist` satisfying
+/-- A pseudometric space is a type endowed with a `ℝ`-valued distance `dist` satisfying
 reflexivity `dist x x = 0`, commutativity `dist x y = dist y x`, and the triangle inequality
 `dist x z ≤ dist x y + dist y z`.
 
 Note that we do not require `dist x y = 0 → x = y`. See `MetricSpace` for the analogous class with
 that stronger assumption.
 
-Any pseudo metric space is a topological space and a uniform space,
+Any pseudometric space is a topological space and a uniform space,
 where the topology and uniformity come from the metric.
-Note that a T1 pseudo metric space is just a metric space.
+Note that a T1 pseudometric space is just a metric space.
 
 We make the uniformity/topology part of the data instead of deriving it from the metric. This eg
 ensures that we do not get a diamond when doing

--- a/Mathlib/Topology/MetricSpace/Pseudo/Defs.lean
+++ b/Mathlib/Topology/MetricSpace/Pseudo/Defs.lean
@@ -103,8 +103,8 @@ private theorem dist_nonneg' {α} {x y : α} (dist : α → α → ℝ)
 reflexivity `dist x x = 0`, commutativity `dist x y = dist y x`, and the triangle inequality
 `dist x z ≤ dist x y + dist y z`.
 
-Note that we do not require `dist x y = 0 → x = y`. See `MetricSpace` for the analogous class with
-that stronger assumption.
+Note that we do not require `dist x y = 0 → x = y`. See metric spaces (`MetricSpace`) for the
+similar class with that stronger assumption.
 
 Any pseudometric space is a topological space and a uniform space,
 where the topology and uniformity come from the metric.

--- a/Mathlib/Topology/MetricSpace/Pseudo/Defs.lean
+++ b/Mathlib/Topology/MetricSpace/Pseudo/Defs.lean
@@ -113,7 +113,8 @@ Note that a T1 pseudo metric space is just a metric space.
 We make the uniformity/topology part of the data instead of deriving it from the metric. This eg
 ensures that we do not get a diamond when doing
 `[PseudoMetricSpace α] [PseudoMetricSpace β] : TopologicalSpace (α × β)`:
-The product metric and product topology agree, but not definitionally so. -/
+The product metric and product topology agree, but not definitionally so.
+See Note [forgetful inheritance]. -/
 class PseudoMetricSpace (α : Type u) : Type u extends Dist α where
   dist_self : ∀ x : α, dist x x = 0
   dist_comm : ∀ x y : α, dist x y = dist y x

--- a/Mathlib/Topology/MetricSpace/Pseudo/Defs.lean
+++ b/Mathlib/Topology/MetricSpace/Pseudo/Defs.lean
@@ -106,8 +106,8 @@ reflexivity `dist x x = 0`, commutativity `dist x y = dist y x`, and the triangl
 Note that we do not require `dist x y = 0 → x = y`. See metric spaces (`MetricSpace`) for the
 similar class with that stronger assumption.
 
-Any pseudometric space is a topological space and a uniform space,
-where the topology and uniformity come from the metric.
+Any pseudometric space is a topological space and a uniform space (see `TopologicalSpace`,
+`UniformSpace`), where the topology and uniformity come from the metric.
 Note that a T1 pseudometric space is just a metric space.
 
 We make the uniformity/topology part of the data instead of deriving it from the metric. This eg

--- a/Mathlib/Topology/MetricSpace/Pseudo/Defs.lean
+++ b/Mathlib/Topology/MetricSpace/Pseudo/Defs.lean
@@ -99,17 +99,20 @@ private theorem dist_nonneg' {α} {x y : α} (dist : α → α → ℝ)
     _ = 2 * dist x y := by rw [two_mul, dist_comm]
   nonneg_of_mul_nonneg_right this two_pos
 
-/-- A pseudo metric space is a topological space and uniform space equipped with a metric `dist`,
-such that the topology comes from metric.
+/-- A pseudo metric space is a type endowed with a `ℝ`-valued distance `dist` satisfying the
+triangle inequality.
+
+Note that we do not require `dist x y = 0 → x = y`. See `MetricSpace` for the analogous class with
+that stronger assumption.
+
+Any pseudo metric space is a topological space and a uniform space,
+where the topology and uniformity come from the metric.
+Note that a T1 pseudo metric space is just a metric space.
 
 We make the uniformity/topology part of the data instead of deriving it from the metric. This eg
 ensures that we do not get a diamond when doing
-`[PseudoMetricSpace α] [PseudoMetricSpace β] : TopologicalSpace (α × β)`: The product metric and
-product topology agree, but not definitionally so.
-
-When instantiating `PseudoMetricSpace`, the uniformity fields are not necessary, they
-will be filled in by default. There is a default value for the uniformity, that can be substituted
-in cases of interest, for instance when giving a `PseudoMetricSpace` instance on a product. -/
+`[PseudoMetricSpace α] [PseudoMetricSpace β] : TopologicalSpace (α × β)`:
+The product metric and product topology agree, but not definitionally so. -/
 class PseudoMetricSpace (α : Type u) : Type u extends Dist α where
   dist_self : ∀ x : α, dist x x = 0
   dist_comm : ∀ x y : α, dist x y = dist y x

--- a/Mathlib/Topology/MetricSpace/Pseudo/Defs.lean
+++ b/Mathlib/Topology/MetricSpace/Pseudo/Defs.lean
@@ -99,16 +99,17 @@ private theorem dist_nonneg' {α} {x y : α} (dist : α → α → ℝ)
     _ = 2 * dist x y := by rw [two_mul, dist_comm]
   nonneg_of_mul_nonneg_right this two_pos
 
-/-- Pseudo metric and Metric spaces
+/-- A pseudo metric space is a topological space and uniform space equipped with a metric `dist`,
+such that the topology comes from metric.
 
-A pseudo metric space is endowed with a distance for which the requirement `d(x,y)=0 → x = y` might
-not hold. A metric space is a pseudo metric space such that `d(x,y)=0 → x = y`.
-Each pseudo metric space induces a canonical `UniformSpace` and hence a canonical
-`TopologicalSpace` This is enforced in the type class definition, by extending the `UniformSpace`
-structure. When instantiating a `PseudoMetricSpace` structure, the uniformity fields are not
-necessary, they will be filled in by default. In the same way, each (pseudo) metric space induces a
-(pseudo) emetric space structure. It is included in the structure, but filled in by default.
--/
+We make the uniformity/topology part of the data instead of deriving it from the metric. This eg
+ensures that we do not get a diamond when doing
+`[PseudoMetricSpace α] [PseudoMetricSpace β] : TopologicalSpace (α × β)`: The product metric and
+product topology agree, but not definitionally so.
+
+When instantiating `PseudoMetricSpace`, the uniformity fields are not necessary, they
+will be filled in by default. There is a default value for the uniformity, that can be substituted
+in cases of interest, for instance when giving a `PseudoMetricSpace` instance on a product. -/
 class PseudoMetricSpace (α : Type u) : Type u extends Dist α where
   dist_self : ∀ x : α, dist x x = 0
   dist_comm : ∀ x y : α, dist x y = dist y x


### PR DESCRIPTION
Docstrings which assume you are reading them from the file they are defined in are completely useless on hover.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
