### PR TITLE
[Merged by Bors] - feat(MetricSpace): covers (aka nets)

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -6885,6 +6885,7 @@ import Mathlib.Topology.MetricSpace.Closeds
 import Mathlib.Topology.MetricSpace.Completion
 import Mathlib.Topology.MetricSpace.Congruence
 import Mathlib.Topology.MetricSpace.Contracting
+import Mathlib.Topology.MetricSpace.Cover
 import Mathlib.Topology.MetricSpace.Defs
 import Mathlib.Topology.MetricSpace.Dilation
 import Mathlib.Topology.MetricSpace.DilationEquiv

--- a/Mathlib/Topology/MetricSpace/Cover.lean
+++ b/Mathlib/Topology/MetricSpace/Cover.lean
@@ -1,0 +1,145 @@
+/-
+Copyright (c) 2025 Yaël Dillies. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yaël Dillies
+-/
+import Mathlib.Data.Rel.Cover
+import Mathlib.Topology.MetricSpace.MetricSeparated
+import Mathlib.Topology.MetricSpace.Thickening
+
+/-!
+# Covers in a metric space
+
+This file defines covers, aka nets, which are a quantitative notion of compactness in a metric
+space.
+
+A `ε`-cover of a set `s` is a set `N` such that every element of `s` is at distance at most `ε` to
+some element of `N`.
+
+In a proper metric space, sets admitting a finite cover are precisely the relatively compact sets.
+
+## References
+
+[R. Vershynin, *High Dimensional Probability*][vershynin2018high], Section 4.2.
+-/
+
+open Set
+open scoped NNReal
+
+namespace Metric
+variable {X : Type*}
+
+section PseudoEMetricSpace
+variable [PseudoEMetricSpace X] {ε δ : ℝ≥0} {s t N N₁ N₂ : Set X} {x : X}
+
+instance : SetRel.IsRefl {(x, y) : X × X | edist x y ≤ ε} where refl := by simp
+instance : SetRel.IsSymm {(x, y) : X × X | edist x y ≤ ε} where symm := by simp [edist_comm]
+
+/-- A set `N` is an *`ε`-cover* of a set `s` if every point of `s` lies at distance at most `ε` of
+some point of `N`.
+
+This is also called an *`ε`-net* in the literature.
+
+[R. Vershynin, *High Dimensional Probability*][vershynin2018high], 4.2.1. -/
+def IsCover (ε : ℝ≥0) (s N : Set X) : Prop := SetRel.IsCover {(x, y) | edist x y ≤ ε} s N
+
+@[simp] protected nonrec lemma IsCover.empty : IsCover ε ∅ N := .empty
+
+@[simp] protected nonrec lemma IsCover.nonempty (hsN : IsCover ε s N) (hs : s.Nonempty) :
+    N.Nonempty := hsN.nonempty hs
+
+nonrec lemma IsCover.mono (hN : N₁ ⊆ N₂) (h₁ : IsCover ε s N₁) : IsCover ε s N₂ := h₁.mono hN
+
+nonrec lemma IsCover.anti (hst : s ⊆ t) (ht : IsCover ε t N) : IsCover ε s N := ht.anti hst
+
+lemma IsCover.mono' (hεδ : ε ≤ δ) (hε : IsCover ε s N) : IsCover δ s N :=
+  hε.mono_entourage fun xy hxy ↦ by dsimp at *; exact le_trans hxy <| mod_cast hεδ
+
+lemma isCover_iff_subset_iUnion_emetricClosedBall :
+    IsCover ε s N ↔ s ⊆ ⋃ y ∈ N, EMetric.closedBall y ε := by
+  simp [IsCover, SetRel.IsCover, subset_def]
+
+/-- A maximal `ε`-separated subset of a set `s` is an `ε`-cover of `s`.
+
+[R. Vershynin, *High Dimensional Probability*][vershynin2018high], 4.2.6. -/
+nonrec lemma IsCover.of_maximal_isSeparated (hN : Maximal (fun N ↦ N ⊆ s ∧ IsSeparated ε N) N) :
+    IsCover ε s N :=
+  .of_maximal_isSeparated <| by simpa [isSeparated_iff_setRelIsSeparated] using hN
+
+end PseudoEMetricSpace
+
+section PseudoMetricSpace
+variable [PseudoMetricSpace X] {ε : ℝ≥0} {s N : Set X}
+
+lemma isCover_iff_subset_iUnion_closedBall : IsCover ε s N ↔ s ⊆ ⋃ y ∈ N, closedBall y ε := by
+  simp [IsCover, SetRel.IsCover, subset_def]
+
+alias ⟨IsCover.subset_iUnion_closedBall, IsCover.of_subset_iUnion_closedBall⟩ :=
+  isCover_iff_subset_iUnion_closedBall
+
+/-- A relatively compact set admits a finite cover. -/
+lemma exists_finite_isCover_of_isCompact_closure (hε : ε ≠ 0) (hs : IsCompact (closure s)) :
+    ∃ N ⊆ s, N.Finite ∧ IsCover ε s N := by
+  obtain ⟨N, hNs, hN, hsN⟩ :=
+    exists_finite_cover_balls_of_isCompact_closure hs (ε := ε) (by positivity)
+  refine ⟨N, hNs, hN, .of_subset_iUnion_closedBall <| hsN.trans ?_⟩
+  gcongr
+  exact ball_subset_closedBall
+
+/-- A compact set admits a finite cover. -/
+lemma exists_finite_isCover_of_isCompact (hε : ε ≠ 0) (hs : IsCompact s) :
+    ∃ N ⊆ s, N.Finite ∧ IsCover ε s N := by
+  obtain ⟨N, hNs, hN, hsN⟩ := hs.finite_cover_balls (e := ε) (by positivity)
+  refine ⟨N, hNs, hN, .of_subset_iUnion_closedBall <| hsN.trans ?_⟩
+  gcongr
+  exact ball_subset_closedBall
+
+lemma IsCover.of_subset_cthickening_of_lt {δ : ℝ≥0} (hsN : s ⊆ cthickening ε N) (hεδ : ε < δ) :
+    IsCover δ s N :=
+  .of_subset_iUnion_closedBall <| hsN.trans (cthickening_subset_iUnion_closedBall_of_lt _
+    (NNReal.zero_le_coe.trans_lt hεδ) hεδ)
+
+variable [ProperSpace X]
+
+lemma isCover_iff_subset_cthickening (hN : IsClosed N) : IsCover ε s N ↔ s ⊆ cthickening ε N := by
+  rw [isCover_iff_subset_iUnion_closedBall, hN.cthickening_eq_biUnion_closedBall ε.zero_le_coe]
+
+alias ⟨IsCover.subset_cthickening, IsCover.of_subset_cthickening⟩ := isCover_iff_subset_cthickening
+
+@[simp] lemma isCover_closure (hN : IsClosed N) : IsCover ε (closure s) N ↔ IsCover ε s N := by
+  simpa [isCover_iff_subset_cthickening hN] using (isClosed_cthickening (E := N)).closure_subset_iff
+
+protected alias ⟨_, IsCover.closure⟩ := isCover_closure
+
+end PseudoMetricSpace
+
+section EMetricSpace
+variable [EMetricSpace X] {ε : ℝ≥0} {s N : Set X} {x : X}
+
+@[simp] lemma isCover_zero : IsCover 0 s N ↔ s ⊆ N := by
+  simp [isCover_iff_subset_iUnion_emetricClosedBall]
+
+end EMetricSpace
+
+section MetricSpace
+variable [MetricSpace X] [ProperSpace X] {ε : ℝ≥0} {s t N N₁ N₂ : Set X} {x : X}
+
+/-- A closed set in a proper metric space which admits a compact cover is compact. -/
+lemma IsCover.isCompact (hsN : IsCover ε s N) (hs : IsClosed s) (hN : IsCompact N) :
+    IsCompact s := .of_isClosed_subset hN.cthickening hs <| hsN.subset_cthickening hN.isClosed
+
+/-- A set in a proper metric space which admits a compact cover is relatively compact. -/
+lemma IsCover.isCompact_closure (hsN : IsCover ε s N) (hN : IsCompact N) :
+    IsCompact (closure s) := (hsN.closure hN.isClosed).isCompact isClosed_closure hN
+
+/-- A set in a proper metric space admits a finite cover iff it is relatively compact.
+
+[R. Vershynin, *High Dimensional Probability*][vershynin2018high], 4.2.3. Note that the print
+edition incorrectly claims that this holds without the `ProperSpace X` assumption. -/
+lemma isCompact_closure_iff_exists_finite_isCover (hε : ε ≠ 0) :
+    IsCompact (closure s) ↔ ∃ N ⊆ s, N.Finite ∧ IsCover ε s N where
+  mp := exists_finite_isCover_of_isCompact_closure hε
+  mpr := fun ⟨_N, _, hN, hsN⟩ ↦ hsN.isCompact_closure hN.isCompact
+
+end MetricSpace
+end Metric

--- a/Mathlib/Topology/MetricSpace/Cover.lean
+++ b/Mathlib/Topology/MetricSpace/Cover.lean
@@ -45,8 +45,8 @@ def IsCover (ε : ℝ≥0) (s N : Set X) : Prop := SetRel.IsCover {(x, y) | edis
 
 @[simp] protected nonrec lemma IsCover.empty : IsCover ε ∅ N := .empty
 
-@[simp] protected nonrec lemma IsCover.nonempty (hsN : IsCover ε s N) (hs : s.Nonempty) :
-    N.Nonempty := hsN.nonempty hs
+protected nonrec lemma IsCover.nonempty (hsN : IsCover ε s N) (hs : s.Nonempty) : N.Nonempty :=
+  hsN.nonempty hs
 
 nonrec lemma IsCover.mono (hN : N₁ ⊆ N₂) (h₁ : IsCover ε s N₁) : IsCover ε s N₂ := h₁.mono hN
 

--- a/Mathlib/Topology/MetricSpace/Cover.lean
+++ b/Mathlib/Topology/MetricSpace/Cover.lean
@@ -52,7 +52,7 @@ nonrec lemma IsCover.mono (hN : N₁ ⊆ N₂) (h₁ : IsCover ε s N₁) : IsCo
 
 nonrec lemma IsCover.anti (hst : s ⊆ t) (ht : IsCover ε t N) : IsCover ε s N := ht.anti hst
 
-lemma IsCover.mono' (hεδ : ε ≤ δ) (hε : IsCover ε s N) : IsCover δ s N :=
+lemma IsCover.mono_radius (hεδ : ε ≤ δ) (hε : IsCover ε s N) : IsCover δ s N :=
   hε.mono_entourage fun xy hxy ↦ by dsimp at *; exact le_trans hxy <| mod_cast hεδ
 
 lemma isCover_iff_subset_iUnion_emetricClosedBall :

--- a/Mathlib/Topology/MetricSpace/MetricSeparated.lean
+++ b/Mathlib/Topology/MetricSpace/MetricSeparated.lean
@@ -3,6 +3,7 @@ Copyright (c) 2021 Yury Kudryashov, Yaël Dillies. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury Kudryashov, Yaël Dillies
 -/
+import Mathlib.Data.Rel.Separated
 import Mathlib.Topology.EMetricSpace.Defs
 
 /-!
@@ -36,6 +37,10 @@ In this section we define the predicate `Metric.IsSeparated` for `ε`-separated 
 /-- A set `s` is `ε`-separated if its elements are pairwise at distance at least `ε` from each
 other. -/
 def IsSeparated (ε : ℝ≥0∞) (s : Set X) : Prop := s.Pairwise (ε < edist · ·)
+
+lemma isSeparated_iff_setRelIsSeparated :
+    IsSeparated ε s ↔ SetRel.IsSeparated {(x, y) | edist x y ≤ ε} s := by
+  simp [IsSeparated, SetRel.IsSeparated]
 
 protected lemma IsSeparated.empty : IsSeparated ε (∅ : Set X) := pairwise_empty _
 protected lemma IsSeparated.singleton : IsSeparated ε {x} := pairwise_singleton ..


### PR DESCRIPTION
Define covers (aka nets), which are a quantitative notion of compactness in a metric space.

From my PhD (MiscYD)


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->
- [x] depends on: #23180
- [x] depends on: #23181
- [x] depends on: #23920
- [x] depends on: #31104

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
