### PR TITLE
[Merged by Bors] - chore: rename `Set.dual_Ixx` to `Ixx_toDual`, and add `Set.Ixx_ofDual`

### DIFF
--- a/Mathlib/MeasureTheory/Constructions/BorelSpace/Order.lean
+++ b/Mathlib/MeasureTheory/Constructions/BorelSpace/Order.lean
@@ -317,8 +317,8 @@ theorem Dense.borel_eq_generateFrom_Ioc_mem_aux {α : Type*} [TopologicalSpace �
     using 2
   · ext s
     constructor <;> rintro ⟨l, hl, u, hu, hlt, rfl⟩
-    exacts [⟨u, hu, l, hl, hlt, dual_Ico⟩, ⟨u, hu, l, hl, hlt, dual_Ioc⟩]
-  · erw [dual_Ioo]
+    exacts [⟨u, hu, l, hl, hlt, Ico_toDual⟩, ⟨u, hu, l, hl, hlt, Ioc_toDual⟩]
+  · erw [Ioo_toDual]
     exact he
 
 theorem Dense.borel_eq_generateFrom_Ioc_mem {α : Type*} [TopologicalSpace α] [LinearOrder α]
@@ -360,7 +360,7 @@ theorem ext_of_Ioc_finite {α : Type*} [TopologicalSpace α] {m : MeasurableSpac
     [IsFiniteMeasure μ] (hμν : μ univ = ν univ) (h : ∀ ⦃a b⦄, a < b → μ (Ioc a b) = ν (Ioc a b)) :
     μ = ν := by
   refine @ext_of_Ico_finite αᵒᵈ _ _ _ _ _ ‹_› μ ν _ hμν fun a b hab => ?_
-  erw [dual_Ico (α := α)]
+  erw [Ico_toDual (α := α)]
   exact h hab
 
 /-- Two measures which are finite on closed-open intervals are equal if they agree on all
@@ -394,7 +394,7 @@ theorem ext_of_Ioc' {α : Type*} [TopologicalSpace α] {m : MeasurableSpace α}
     [SecondCountableTopology α] [LinearOrder α] [OrderTopology α] [BorelSpace α] [NoMinOrder α]
     (μ ν : Measure α) (hμ : ∀ ⦃a b⦄, a < b → μ (Ioc a b) ≠ ∞)
     (h : ∀ ⦃a b⦄, a < b → μ (Ioc a b) = ν (Ioc a b)) : μ = ν := by
-  refine @ext_of_Ico' αᵒᵈ _ _ _ _ _ ‹_› _ μ ν ?_ ?_ <;> intro a b hab <;> erw [dual_Ico (α := α)]
+  refine @ext_of_Ico' αᵒᵈ _ _ _ _ _ ‹_› _ μ ν ?_ ?_ <;> intro a b hab <;> erw [Ico_toDual (α := α)]
   exacts [hμ hab, h hab]
 
 /-- Two measures which are finite on closed-open intervals are equal if they agree on all

--- a/Mathlib/Order/Bounds/Basic.lean
+++ b/Mathlib/Order/Bounds/Basic.lean
@@ -594,13 +594,13 @@ section
 variable [SemilatticeInf γ] [DenselyOrdered γ]
 
 theorem isLUB_Ioo {a b : γ} (hab : a < b) : IsLUB (Ioo a b) b := by
-  simpa only [dual_Ioo] using isGLB_Ioo hab.dual
+  simpa only [Ioo_toDual] using isGLB_Ioo hab.dual
 
 theorem upperBounds_Ioo {a b : γ} (hab : a < b) : upperBounds (Ioo a b) = Ici b :=
   (isLUB_Ioo hab).upperBounds_eq
 
 theorem isLUB_Ico {a b : γ} (hab : a < b) : IsLUB (Ico a b) b := by
-  simpa only [dual_Ioc] using isGLB_Ioc hab.dual
+  simpa only [Ioc_toDual] using isGLB_Ioc hab.dual
 
 theorem upperBounds_Ico {a b : γ} (hab : a < b) : upperBounds (Ico a b) = Ici b :=
   (isLUB_Ico hab).upperBounds_eq

--- a/Mathlib/Order/Interval/Basic.lean
+++ b/Mathlib/Order/Interval/Basic.lean
@@ -228,7 +228,7 @@ theorem coe_top [BoundedOrder α] : ((⊤ : NonemptyInterval α) : Set α) = uni
 
 @[simp, norm_cast]
 theorem coe_dual (s : NonemptyInterval α) : (dual s : Set αᵒᵈ) = ofDual ⁻¹' s :=
-  dual_Icc
+  Icc_toDual
 
 theorem subset_coe_map (f : α →o β) (s : NonemptyInterval α) : f '' s ⊆ s.map f :=
   image_subset_iff.2 fun _ ha => ⟨f.mono ha.1, f.mono ha.2⟩

--- a/Mathlib/Order/Interval/Set/Basic.lean
+++ b/Mathlib/Order/Interval/Set/Basic.lean
@@ -9,7 +9,6 @@ import Mathlib.Order.Interval.Set.Defs
 import Mathlib.Order.MinMax
 import Mathlib.Tactic.Contrapose
 import Mathlib.Tactic.Says
-import Mathlib.Tactic.DeprecateTo
 
 /-!
 # Intervals

--- a/Mathlib/Order/Interval/Set/Basic.lean
+++ b/Mathlib/Order/Interval/Set/Basic.lean
@@ -9,6 +9,7 @@ import Mathlib.Order.Interval.Set.Defs
 import Mathlib.Order.MinMax
 import Mathlib.Tactic.Contrapose
 import Mathlib.Tactic.Says
+import Mathlib.Tactic.DeprecateTo
 
 /-!
 # Intervals
@@ -83,35 +84,91 @@ theorem right_mem_Ioc : b ∈ Ioc a b ↔ a < b := by simp [le_refl]
 theorem right_mem_Iic : a ∈ Iic a := by simp
 
 @[simp]
-theorem dual_Ici : Ici (toDual a) = ofDual ⁻¹' Iic a :=
+theorem Ici_toDual : Ici (toDual a) = ofDual ⁻¹' Iic a :=
+  rfl
+
+@[deprecated (since := "2025-03-20")]
+alias dual_Ici := Ici_toDual
+
+@[simp]
+theorem Iic_toDual : Iic (toDual a) = ofDual ⁻¹' Ici a :=
+  rfl
+
+@[deprecated (since := "2025-03-20")]
+alias dual_Iic := Iic_toDual
+
+@[simp]
+theorem Ioi_toDual : Ioi (toDual a) = ofDual ⁻¹' Iio a :=
+  rfl
+
+@[deprecated (since := "2025-03-20")]
+alias dual_Ioi := Ioi_toDual
+
+@[simp]
+theorem Iio_toDual : Iio (toDual a) = ofDual ⁻¹' Ioi a :=
+  rfl
+
+@[deprecated (since := "2025-03-20")]
+alias dual_Iio := Iio_toDual
+
+@[simp]
+theorem Icc_toDual : Icc (toDual a) (toDual b) = ofDual ⁻¹' Icc b a :=
+  Set.ext fun _ => and_comm
+
+@[deprecated (since := "2025-03-20")]
+alias dual_Icc := Icc_toDual
+
+@[simp]
+theorem Ioc_toDual : Ioc (toDual a) (toDual b) = ofDual ⁻¹' Ico b a :=
+  Set.ext fun _ => and_comm
+
+@[deprecated (since := "2025-03-20")]
+alias dual_Ioc := Ioc_toDual
+
+@[simp]
+theorem Ico_toDual : Ico (toDual a) (toDual b) = ofDual ⁻¹' Ioc b a :=
+  Set.ext fun _ => and_comm
+
+@[deprecated (since := "2025-03-20")]
+alias dual_Ico := Ico_toDual
+
+@[simp]
+theorem Ioo_toDual : Ioo (toDual a) (toDual b) = ofDual ⁻¹' Ioo b a :=
+  Set.ext fun _ => and_comm
+
+@[deprecated (since := "2025-03-20")]
+alias dual_Ioo := Ioo_toDual
+
+@[simp]
+theorem Ici_ofDual {x : αᵒᵈ} : Ici (ofDual x) = toDual ⁻¹' Iic x :=
   rfl
 
 @[simp]
-theorem dual_Iic : Iic (toDual a) = ofDual ⁻¹' Ici a :=
+theorem Iic_ofDual {x : αᵒᵈ} : Iic (ofDual x) = toDual ⁻¹' Ici x :=
   rfl
 
 @[simp]
-theorem dual_Ioi : Ioi (toDual a) = ofDual ⁻¹' Iio a :=
+theorem Ioi_ofDual {x : αᵒᵈ} : Ioi (ofDual x) = toDual ⁻¹' Iio x :=
   rfl
 
 @[simp]
-theorem dual_Iio : Iio (toDual a) = ofDual ⁻¹' Ioi a :=
+theorem Iio_ofDual {x : αᵒᵈ} : Iio (ofDual x) = toDual ⁻¹' Ioi x :=
   rfl
 
 @[simp]
-theorem dual_Icc : Icc (toDual a) (toDual b) = ofDual ⁻¹' Icc b a :=
+theorem Icc_ofDual {x y : αᵒᵈ} : Icc (ofDual y) (ofDual x) = toDual ⁻¹' Icc x y :=
   Set.ext fun _ => and_comm
 
 @[simp]
-theorem dual_Ioc : Ioc (toDual a) (toDual b) = ofDual ⁻¹' Ico b a :=
+theorem Ico_ofDual {x y : αᵒᵈ} : Ico (ofDual y) (ofDual x) = toDual ⁻¹' Ioc x y :=
   Set.ext fun _ => and_comm
 
 @[simp]
-theorem dual_Ico : Ico (toDual a) (toDual b) = ofDual ⁻¹' Ioc b a :=
+theorem Ioc_ofDual {x y : αᵒᵈ} : Ioc (ofDual y) (ofDual x) = toDual ⁻¹' Ico x y :=
   Set.ext fun _ => and_comm
 
 @[simp]
-theorem dual_Ioo : Ioo (toDual a) (toDual b) = ofDual ⁻¹' Ioo b a :=
+theorem Ioo_ofDual {x y : αᵒᵈ} : Ioo (ofDual y) (ofDual x) = toDual ⁻¹' Ioo x y :=
   Set.ext fun _ => and_comm
 
 @[simp]
@@ -650,7 +707,7 @@ theorem Ioo_union_left (hab : a < b) : Ioo a b ∪ {a} = Ico a b := by
     union_eq_self_of_subset_right (singleton_subset_iff.2 <| left_mem_Ico.2 hab)]
 
 theorem Ioo_union_right (hab : a < b) : Ioo a b ∪ {b} = Ioc a b := by
-  simpa only [dual_Ioo, dual_Ico] using Ioo_union_left hab.dual
+  simpa only [Ioo_toDual, Ico_toDual] using Ioo_union_left hab.dual
 
 theorem Ioo_union_both (h : a ≤ b) : Ioo a b ∪ {a, b} = Icc a b := by
   have : (Icc a b \ {a, b}) ∪ {a, b} = Icc a b := diff_union_of_subset fun
@@ -663,7 +720,7 @@ theorem Ioc_union_left (hab : a ≤ b) : Ioc a b ∪ {a} = Icc a b := by
     union_eq_self_of_subset_right (singleton_subset_iff.2 <| left_mem_Icc.2 hab)]
 
 theorem Ico_union_right (hab : a ≤ b) : Ico a b ∪ {b} = Icc a b := by
-  simpa only [dual_Ioc, dual_Icc] using Ioc_union_left hab.dual
+  simpa only [Ioc_toDual, Icc_toDual] using Ioc_union_left hab.dual
 
 @[simp]
 theorem Ico_insert_right (h : a ≤ b) : insert b (Ico a b) = Icc a b := by
@@ -879,7 +936,7 @@ theorem Ico_subset_Ico_iff (h₁ : a₁ < b₁) : Ico a₁ b₁ ⊆ Ico a₂ b�
     fun ⟨h₁, h₂⟩ => Ico_subset_Ico h₁ h₂⟩
 
 theorem Ioc_subset_Ioc_iff (h₁ : a₁ < b₁) : Ioc a₁ b₁ ⊆ Ioc a₂ b₂ ↔ b₁ ≤ b₂ ∧ a₂ ≤ a₁ := by
-  convert @Ico_subset_Ico_iff αᵒᵈ _ b₁ b₂ a₁ a₂ h₁ using 2 <;> exact (@dual_Ico α _ _ _).symm
+  convert @Ico_subset_Ico_iff αᵒᵈ _ b₁ b₂ a₁ a₂ h₁ using 2 <;> exact (@Ico_toDual α _ _ _).symm
 
 theorem Ioo_subset_Ioo_iff [DenselyOrdered α] (h₁ : a₁ < b₁) :
     Ioo a₁ b₁ ⊆ Ioo a₂ b₂ ↔ a₂ ≤ a₁ ∧ b₁ ≤ b₂ :=

--- a/Mathlib/Order/Interval/Set/Disjoint.lean
+++ b/Mathlib/Order/Interval/Set/Disjoint.lean
@@ -130,7 +130,7 @@ theorem Ico_disjoint_Ico : Disjoint (Ico a₁ a₂) (Ico b₁ b₂) ↔ min a₂
 @[simp]
 theorem Ioc_disjoint_Ioc : Disjoint (Ioc a₁ a₂) (Ioc b₁ b₂) ↔ min a₂ b₂ ≤ max a₁ b₁ := by
   have h : _ ↔ min (toDual a₁) (toDual b₁) ≤ max (toDual a₂) (toDual b₂) := Ico_disjoint_Ico
-  simpa only [dual_Ico] using h
+  simpa only [Ico_toDual] using h
 
 @[simp]
 theorem Ioo_disjoint_Ioo [DenselyOrdered α] :

--- a/Mathlib/Order/Interval/Set/OrdConnected.lean
+++ b/Mathlib/Order/Interval/Set/OrdConnected.lean
@@ -226,7 +226,7 @@ theorem ordConnected_range {E : Type*} [EquivLike E α β] [OrderIsoClass E α �
 
 @[simp]
 theorem dual_ordConnected_iff {s : Set α} : OrdConnected (ofDual ⁻¹' s) ↔ OrdConnected s := by
-  simp_rw [ordConnected_def, toDual.surjective.forall, dual_Icc, Subtype.forall']
+  simp_rw [ordConnected_def, toDual.surjective.forall, Icc_toDual, Subtype.forall']
   exact forall_swap
 
 @[instance]

--- a/Mathlib/Order/Interval/Set/OrdConnectedComponent.lean
+++ b/Mathlib/Order/Interval/Set/OrdConnectedComponent.lean
@@ -32,9 +32,7 @@ theorem mem_ordConnectedComponent : y ∈ ordConnectedComponent s x ↔ [[x, y]]
 
 theorem dual_ordConnectedComponent :
     ordConnectedComponent (ofDual ⁻¹' s) (toDual x) = ofDual ⁻¹' ordConnectedComponent s x :=
-  ext <| (Surjective.forall toDual.surjective).2 fun x => by
-    rw [mem_ordConnectedComponent, dual_uIcc]
-    rfl
+  ext <| (Surjective.forall toDual.surjective).2 fun x => by simp [mem_ordConnectedComponent]
 
 theorem ordConnectedComponent_subset : ordConnectedComponent s x ⊆ s := fun _ hy =>
   hy right_mem_uIcc

--- a/Mathlib/Order/Interval/Set/UnorderedInterval.lean
+++ b/Mathlib/Order/Interval/Set/UnorderedInterval.lean
@@ -57,9 +57,17 @@ scoped[Interval] notation "[[" a ", " b "]]" => Set.uIcc a b
 
 open Interval
 
-@[simp] lemma dual_uIcc (a b : α) : [[toDual a, toDual b]] = ofDual ⁻¹' [[a, b]] :=
+@[simp]
+lemma uIcc_toDual (a b : α) : [[toDual a, toDual b]] = ofDual ⁻¹' [[a, b]] :=
   -- Note: needed to hint `(α := α)` after https://github.com/leanprover-community/mathlib4/pull/8386 (elaboration order?)
-  dual_Icc (α := α)
+  Icc_toDual (α := α)
+
+@[deprecated (since := "2025-03-20")]
+alias dual_uIcc := uIcc_toDual
+
+@[simp]
+theorem uIcc_ofDual (a b : αᵒᵈ) : [[ofDual a, ofDual b]] = toDual ⁻¹' [[a, b]] :=
+  Icc_ofDual
 
 @[simp]
 lemma uIcc_of_le (h : a ≤ b) : [[a, b]] = Icc a b := by rw [uIcc, inf_eq_left.2 h, sup_eq_right.2 h]
@@ -306,8 +314,16 @@ Note that we define it more generally in a lattice as `Set.Ioo (a ⊓ b) (a ⊔ 
 `uIoo` corresponds to the bounding box of the two elements. -/
 def uIoo (a b : α) : Set α := Ioo (a ⊓ b) (a ⊔ b)
 
-@[simp] lemma dual_uIoo (a b : α) : uIoo (toDual a) (toDual b) = ofDual ⁻¹' uIoo a b :=
-  dual_Ioo (α := α)
+@[simp]
+lemma uIoo_toDual (a b : α) : uIoo (toDual a) (toDual b) = ofDual ⁻¹' uIoo a b :=
+  Ioo_toDual (α := α)
+
+@[deprecated (since := "2025-03-20")]
+alias dual_uIoo := uIoo_toDual
+
+@[simp]
+theorem uIoo_ofDual (a b : αᵒᵈ) : uIoo (ofDual a) (ofDual b) = toDual ⁻¹' uIoo a b :=
+  Ioo_ofDual
 
 @[simp] lemma uIoo_of_le (h : a ≤ b) : uIoo a b = Ioo a b := by
   rw [uIoo, inf_eq_left.2 h, sup_eq_right.2 h]

--- a/Mathlib/Order/SuccPred/IntervalSucc.lean
+++ b/Mathlib/Order/SuccPred/IntervalSucc.lean
@@ -73,19 +73,19 @@ theorem pairwise_disjoint_on_Ioo_succ [SuccOrder α] [Preorder β] {f : α → �
 the intervals `Set.Ioc (f Order.pred n) (f n)` are pairwise disjoint. -/
 theorem pairwise_disjoint_on_Ioc_pred [PredOrder α] [Preorder β] {f : α → β} (hf : Monotone f) :
     Pairwise (Disjoint on fun n => Ioc (f (pred n)) (f n)) := by
-  simpa only [(· ∘ ·), dual_Ico] using hf.dual.pairwise_disjoint_on_Ico_succ
+  simpa using hf.dual.pairwise_disjoint_on_Ico_succ
 
 /-- If `α` is a linear pred order, `β` is a preorder, and `f : α → β` is a monotone function, then
 the intervals `Set.Ico (f Order.pred n) (f n)` are pairwise disjoint. -/
 theorem pairwise_disjoint_on_Ico_pred [PredOrder α] [Preorder β] {f : α → β} (hf : Monotone f) :
     Pairwise (Disjoint on fun n => Ico (f (pred n)) (f n)) := by
-  simpa only [(· ∘ ·), dual_Ioc] using hf.dual.pairwise_disjoint_on_Ioc_succ
+  simpa using hf.dual.pairwise_disjoint_on_Ioc_succ
 
 /-- If `α` is a linear pred order, `β` is a preorder, and `f : α → β` is a monotone function, then
 the intervals `Set.Ioo (f Order.pred n) (f n)` are pairwise disjoint. -/
 theorem pairwise_disjoint_on_Ioo_pred [PredOrder α] [Preorder β] {f : α → β} (hf : Monotone f) :
     Pairwise (Disjoint on fun n => Ioo (f (pred n)) (f n)) := by
-  simpa only [(· ∘ ·), dual_Ioo] using hf.dual.pairwise_disjoint_on_Ioo_succ
+  simpa using hf.dual.pairwise_disjoint_on_Ioo_succ
 
 end Monotone
 

--- a/Mathlib/Topology/Order/Basic.lean
+++ b/Mathlib/Topology/Order/Basic.lean
@@ -286,7 +286,7 @@ theorem nhdsGE_basis_of_exists_gt [TopologicalSpace α] [LinearOrder α] [OrderT
 theorem nhdsLE_basis_of_exists_lt [TopologicalSpace α] [LinearOrder α] [OrderTopology α] {a : α}
     (ha : ∃ l, l < a) : (𝓝[≤] a).HasBasis (fun l => l < a) fun l => Ioc l a := by
   convert nhdsGE_basis_of_exists_gt (α := αᵒᵈ) ha using 2
-  exact dual_Ico.symm
+  exact Ico_toDual.symm
 
 @[deprecated (since := "2024-12-22")] alias nhdsWithin_Iic_basis' := nhdsLE_basis_of_exists_lt
 
@@ -376,7 +376,7 @@ theorem exists_Ioc_subset_of_mem_nhds' [OrderTopology α] {a : α} {s : Set α} 
 
 theorem exists_Ico_subset_of_mem_nhds' [OrderTopology α] {a : α} {s : Set α} (hs : s ∈ 𝓝 a) {u : α}
     (hu : a < u) : ∃ u' ∈ Ioc a u, Ico a u' ⊆ s := by
-  simpa only [OrderDual.exists, exists_prop, dual_Ico, dual_Ioc] using
+  simpa only [OrderDual.exists, exists_prop, Ico_toDual, Ioc_toDual] using
     exists_Ioc_subset_of_mem_nhds' (show ofDual ⁻¹' s ∈ 𝓝 (toDual a) from hs) hu.dual
 
 theorem exists_Ico_subset_of_mem_nhds [OrderTopology α] {a : α} {s : Set α} (hs : s ∈ 𝓝 a)
@@ -402,7 +402,7 @@ alias exists_Icc_mem_subset_of_mem_nhdsWithin_Ici := exists_Icc_mem_subset_of_me
 
 theorem exists_Icc_mem_subset_of_mem_nhdsLE [OrderTopology α] {a : α} {s : Set α}
     (hs : s ∈ 𝓝[≤] a) : ∃ b ≤ a, Icc b a ∈ 𝓝[≤] a ∧ Icc b a ⊆ s := by
-  simpa only [dual_Icc, toDual.surjective.exists] using
+  simpa only [Icc_toDual, toDual.surjective.exists] using
     exists_Icc_mem_subset_of_mem_nhdsGE (α := αᵒᵈ) (a := toDual a) hs
 
 @[deprecated (since := "2024-12-22")]

--- a/Mathlib/Topology/Order/Compact.lean
+++ b/Mathlib/Topology/Order/Compact.lean
@@ -67,7 +67,7 @@ instance [TopologicalSpace α] [Preorder α] [CompactIccSpace α] : CompactIccSp
   isCompact_Icc := by
     intro a b
     convert isCompact_Icc (α := α) (a := b) (b := a) using 1
-    exact dual_Icc (α := α)
+    exact Icc_toDual (α := α)
 
 /-- A closed interval in a conditionally complete linear order is compact. -/
 instance (priority := 100) ConditionallyCompleteLinearOrder.toCompactIccSpace (α : Type*)

--- a/Mathlib/Topology/Order/DenselyOrdered.lean
+++ b/Mathlib/Topology/Order/DenselyOrdered.lean
@@ -128,7 +128,8 @@ theorem Ioc_subset_closure_interior (a b : α) : Ioc a b ⊆ closure (interior (
         closure_mono (interior_maximal Ioo_subset_Ioc_self isOpen_Ioo)
 
 theorem Ico_subset_closure_interior (a b : α) : Ico a b ⊆ closure (interior (Ico a b)) := by
-  simpa only [dual_Ioc] using Ioc_subset_closure_interior (OrderDual.toDual b) (OrderDual.toDual a)
+  simpa only [Ioc_toDual] using
+    Ioc_subset_closure_interior (OrderDual.toDual b) (OrderDual.toDual a)
 
 @[simp]
 theorem frontier_Ici' {a : α} (ha : (Iio a).Nonempty) : frontier (Ici a) = {a} := by
@@ -242,7 +243,7 @@ alias comap_coe_nhdsWithin_Iio_of_Ioo_subset := comap_coe_nhdsLT_of_Ioo_subset
 theorem comap_coe_nhdsGT_of_Ioo_subset (ha : s ⊆ Ioi a) (hs : s.Nonempty → ∃ b > a, Ioo a b ⊆ s) :
     comap ((↑) : s → α) (𝓝[>] a) = atBot := by
   apply comap_coe_nhdsLT_of_Ioo_subset (show ofDual ⁻¹' s ⊆ Iio (toDual a) from ha)
-  simp only [OrderDual.exists, dual_Ioo]
+  simp only [OrderDual.exists, Ioo_toDual]
   exact hs
 
 @[deprecated (since := "2024-12-22")]
@@ -262,7 +263,7 @@ theorem map_coe_atBot_of_Ioo_subset (ha : s ⊆ Ioi a) (hs : ∀ b' > a, ∃ b >
   -- the elaborator gets stuck without `(... :)`
   refine (map_coe_atTop_of_Ioo_subset (show ofDual ⁻¹' s ⊆ Iio (toDual a) from ha)
     fun b' hb' => ?_ :)
-  simpa only [OrderDual.exists, dual_Ioo] using hs b' hb'
+  simpa using hs b' hb'
 
 /-- The `atTop` filter for an open interval `Ioo a b` comes from the left-neighbourhoods filter at
 the right endpoint in the ambient order. -/

--- a/Mathlib/Topology/Order/ExtendFrom.lean
+++ b/Mathlib/Topology/Order/ExtendFrom.lean
@@ -60,5 +60,5 @@ theorem continuousOn_Ioc_extendFrom_Ioo [TopologicalSpace α] [LinearOrder α] [
     (hab : a < b) (hf : ContinuousOn f (Ioo a b)) (hb : Tendsto f (𝓝[<] b) (𝓝 lb)) :
     ContinuousOn (extendFrom (Ioo a b) f) (Ioc a b) := by
   have := @continuousOn_Ico_extendFrom_Ioo αᵒᵈ _ _ _ _ _ _ _ f _ _ lb hab
-  erw [dual_Ico, dual_Ioi, dual_Ioo] at this
+  erw [Ico_toDual, Ioi_toDual, Ioo_toDual] at this
   exact this hf hb

--- a/Mathlib/Topology/Order/IsLUB.lean
+++ b/Mathlib/Topology/Order/IsLUB.lean
@@ -205,8 +205,7 @@ theorem IsGLB.exists_seq_antitone_tendsto {t : Set α} {x : α} [IsCountablyGene
 
 theorem exists_seq_strictAnti_tendsto' [DenselyOrdered α] [FirstCountableTopology α] {x y : α}
     (hy : x < y) : ∃ u : ℕ → α, StrictAnti u ∧ (∀ n, u n ∈ Ioo x y) ∧ Tendsto u atTop (𝓝 x) := by
-  simpa only [dual_Ioo]
-    using exists_seq_strictMono_tendsto' (α := αᵒᵈ) (OrderDual.toDual_lt_toDual.2 hy)
+  simpa using exists_seq_strictMono_tendsto' (α := αᵒᵈ) (OrderDual.toDual_lt_toDual.2 hy)
 
 theorem exists_seq_strictAnti_tendsto [DenselyOrdered α] [NoMaxOrder α] [FirstCountableTopology α]
     (x : α) : ∃ u : ℕ → α, StrictAnti u ∧ (∀ n, x < u n) ∧ Tendsto u atTop (𝓝 x) :=

--- a/Mathlib/Topology/Order/LeftRightNhds.lean
+++ b/Mathlib/Topology/Order/LeftRightNhds.lean
@@ -152,8 +152,7 @@ theorem TFAE_mem_nhdsLT {a b : α} (h : a < b) (s : Set α) :
         s ∈ 𝓝[Ioo a b] b,-- 2 : `s` is a neighborhood of `b` within `(a, b)`
         ∃ l ∈ Ico a b, Ioo l b ⊆ s,-- 3 : `s` includes `(l, b)` for some `l ∈ [a, b)`
         ∃ l ∈ Iio b, Ioo l b ⊆ s] := by-- 4 : `s` includes `(l, b)` for some `l < b`
-  simpa only [exists_prop, OrderDual.exists, dual_Ioi, dual_Ioc, dual_Ioo] using
-    TFAE_mem_nhdsGT h.dual (ofDual ⁻¹' s)
+  simpa using TFAE_mem_nhdsGT h.dual (ofDual ⁻¹' s)
 
 @[deprecated (since := "2024-12-22")]
 alias TFAE_mem_nhdsWithin_Iio := TFAE_mem_nhdsLT
@@ -189,7 +188,7 @@ with `l < a`. -/
 theorem mem_nhdsLT_iff_exists_Ico_subset [NoMinOrder α] [DenselyOrdered α] {a : α} {s : Set α} :
     s ∈ 𝓝[<] a ↔ ∃ l ∈ Iio a, Ico l a ⊆ s := by
   have : ofDual ⁻¹' s ∈ 𝓝[>] toDual a ↔ _ := mem_nhdsGT_iff_exists_Ioc_subset
-  simpa only [OrderDual.exists, exists_prop, dual_Ioc] using this
+  simpa using this
 
 @[deprecated (since := "2024-12-22")]
 alias mem_nhdsWithin_Iio_iff_exists_Ico_subset := mem_nhdsLT_iff_exists_Ico_subset
@@ -309,8 +308,7 @@ theorem TFAE_mem_nhdsLE {a b : α} (h : a < b) (s : Set α) :
       s ∈ 𝓝[Ioc a b] b,-- 2 : `s` is a neighborhood of `b` within `(a, b]`
       ∃ l ∈ Ico a b, Ioc l b ⊆ s,-- 3 : `s` includes `(l, b]` for some `l ∈ [a, b)`
       ∃ l ∈ Iio b, Ioc l b ⊆ s] := by-- 4 : `s` includes `(l, b]` for some `l < b`
-  simpa only [exists_prop, OrderDual.exists, dual_Ici, dual_Ioc, dual_Icc, dual_Ico] using
-    TFAE_mem_nhdsGE h.dual (ofDual ⁻¹' s)
+  simpa using TFAE_mem_nhdsGE h.dual (ofDual ⁻¹' s)
 
 @[deprecated (since := "2024-12-22")]
 alias TFAE_mem_nhdsWithin_Iic := TFAE_mem_nhdsLE
@@ -348,7 +346,7 @@ theorem mem_nhdsLE_iff_exists_Icc_subset [NoMinOrder α] [DenselyOrdered α] {a 
   calc s ∈ 𝓝[≤] a ↔ ofDual ⁻¹' s ∈ 𝓝[≥] (toDual a) := Iff.rfl
   _ ↔ ∃ u : α, toDual a < toDual u ∧ Icc (toDual a) (toDual u) ⊆ ofDual ⁻¹' s :=
     mem_nhdsGE_iff_exists_Icc_subset
-  _ ↔ ∃ l, l < a ∧ Icc l a ⊆ s := by simp only [dual_Icc]; rfl
+  _ ↔ ∃ l, l < a ∧ Icc l a ⊆ s := by simp
 
 @[deprecated (since := "2024-12-22")]
 alias mem_nhdsWithin_Iic_iff_exists_Icc_subset := mem_nhdsLE_iff_exists_Icc_subset


### PR DESCRIPTION
This is an excursion during the `erw`-killing quest.