### PR TITLE
[Merged by Bors] - doc(Algebra/Module/SnakeLemma): correct the subscript values

### DIFF
--- a/Mathlib/Algebra/Module/SnakeLemma.lean
+++ b/Mathlib/Algebra/Module/SnakeLemma.lean
@@ -142,7 +142,7 @@ C₁
 
 ```
 such that `f₂` is surjective with a (set-theoretic) section `σ`, `g₁` is injective with a
-(set-theoretic) retraction `ρ`, and `ι₃` is injective, then `K₂ -F→ K₂ -δ→ C₁` is exact.
+(set-theoretic) retraction `ρ`, and `ι₃` is injective, then `K₂ -F→ K₃ -δ→ C₁` is exact.
 -/
 lemma SnakeLemma.exact_δ_right (F : K₂ →ₗ[R] K₃) (hF : f₂.comp ι₂ = ι₃.comp F)
     (h : Injective ι₃) :
@@ -181,7 +181,7 @@ C₁ -G-→ C₂
 
 ```
 such that `f₂` is surjective with a (set-theoretic) section `σ`, `g₁` is injective with a
-(set-theoretic) retraction `ρ`, and `π₁` is surjective, then `K₂ -δ→ C₁ -G→ C₂` is exact.
+(set-theoretic) retraction `ρ`, and `π₁` is surjective, then `K₃ -δ→ C₁ -G→ C₂` is exact.
 -/
 lemma SnakeLemma.exact_δ_left (G : C₁ →ₗ[R] C₂) (hF : G.comp π₁ = π₂.comp g₁) (h : Surjective π₁) :
     Exact (δ i₁ i₂ i₃ f₁ f₂ hf g₁ g₂ hg h₁ h₂ σ hσ ρ hρ ι₃ hι₃ π₁ hπ₁) G := by
@@ -250,7 +250,7 @@ C₁
 
 ```
 such that `f₂` is surjective, `g₁` is injective, and `ι₃` is injective,
-then `K₂ -F→ K₂ -δ→ C₁` is exact.
+then `K₂ -F→ K₃ -δ→ C₁` is exact.
 -/
 lemma SnakeLemma.exact_δ'_right (hf₂ : Surjective f₂) (hg₁ : Injective g₁)
     (F : K₂ →ₗ[R] K₃) (hF : f₂.comp ι₂ = ι₃.comp F) (h : Injective ι₃) :
@@ -277,7 +277,7 @@ C₁ -G-→ C₂
 
 ```
 such that `f₂` is surjective, `g₁` is injective, and `π₁` is surjective,
-then `K₂ -δ→ C₁ -G→ C₂` is exact.
+then `K₃ -δ→ C₁ -G→ C₂` is exact.
 -/
 lemma SnakeLemma.exact_δ'_left (hf₂ : Surjective f₂) (hg₁ : Injective g₁)
     (G : C₁ →ₗ[R] C₂) (hF : G.comp π₁ = π₂.comp g₁) (h : Surjective π₁) :


### PR DESCRIPTION
I happened to notice these weren't correct.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
