### PR TITLE
[Merged by Bors] - chore: use known bounds to avoid runtime array checks

### DIFF
--- a/Mathlib/Algebra/BigOperators/Group/Finset/Defs.lean
+++ b/Mathlib/Algebra/BigOperators/Group/Finset/Defs.lean
@@ -137,20 +137,20 @@ def processBigOpBinders (binders : TSyntax ``bigOpBinders) :
 def bigOpBindersPattern (processed : (Array (Term × Term))) :
     MacroM Term := do
   let ts := processed.map Prod.fst
-  if ts.size == 1 then
-    return ts[0]!
+  if h : ts.size = 1 then
+    return ts[0]
   else
     `(⟨$ts,*⟩)
 
 /-- Collect the terms into a product of sets. -/
 def bigOpBindersProd (processed : (Array (Term × Term))) :
     MacroM Term := do
-  if processed.isEmpty then
+  if h₀ : processed.size = 0 then
     `((Finset.univ : Finset Unit))
-  else if processed.size == 1 then
-    return processed[0]!.2
+  else if h₁ : processed.size = 1 then
+    return processed[0].2
   else
-    processed.foldrM (fun s p => `(SProd.sprod $(s.2) $p)) processed.back!.2
+    processed.foldrM (fun s p => `(SProd.sprod $(s.2) $p)) processed.back.2
       (start := processed.size - 1)
 
 /--

--- a/Mathlib/Data/QPF/Multivariate/Constructions/Cofix.lean
+++ b/Mathlib/Data/QPF/Multivariate/Constructions/Cofix.lean
@@ -465,8 +465,8 @@ elab_rules : tactic
             refine MvQPF.Cofix.bisim₂ $sR ?_ _ _ ⟨_, rfl, rfl⟩;
             rintro $(← idss 1) $(← idss 2) ⟨$(← idss 3), $(← idss 4), $(← idss 5)⟩)
           liftMetaTactic fun g => return [← g.clear f.fvarId!]
-    for n in [6 : ids.size] do
-      let name := ids[n]!
+    for h : n in [6 : ids.size] do
+      let name := ids[n]
       logWarningAt name m!"unused name: {name}"
 
 end Mathlib.Tactic.MvBisim

--- a/Mathlib/FieldTheory/IntermediateField/Adjoin/Defs.lean
+++ b/Mathlib/FieldTheory/IntermediateField/Adjoin/Defs.lean
@@ -524,10 +524,10 @@ open Lean in
 private partial def mkInsertTerm {m : Type → Type} [Monad m] [MonadQuotation m]
     (xs : TSyntaxArray `term) : m Term := run 0 where
   run (i : Nat) : m Term := do
-    if i + 1 == xs.size then
-      ``(singleton $(xs[i]!))
-    else if i < xs.size then
-      ``(insert $(xs[i]!) $(← run (i + 1)))
+    if h : i + 1 = xs.size then
+      ``(singleton $(xs[i]))
+    else if h : i < xs.size then
+      ``(insert $(xs[i]) $(← run (i + 1)))
     else
       ``(EmptyCollection.emptyCollection)
 

--- a/Mathlib/Lean/Meta/RefinedDiscrTree.lean
+++ b/Mathlib/Lean/Meta/RefinedDiscrTree.lean
@@ -141,9 +141,9 @@ partial def insertInTrie [BEq α] (keys : Array Key) (v : α) (i : Nat) : Trie �
   | .values vs =>
       .values (insertInArray vs v)
   | .path ks c => Id.run do
-    for n in [:ks.size] do
+    for h : n in [:ks.size] do
       let k1 := keys[i+n]!
-      let k2 := ks[n]!
+      let k2 := ks[n]
       if k1 != k2 then
         let shared := ks[:n]
         let rest := ks[n+1:]

--- a/Mathlib/Lean/Meta/RefinedDiscrTree/Encode.lean
+++ b/Mathlib/Lean/Meta/RefinedDiscrTree/Encode.lean
@@ -245,13 +245,13 @@ def getIgnores (fn : Expr) (args : Array Expr) : MetaM (Array Bool) := do
   let mut fnType ← inferType fn
   let mut result := Array.mkEmpty args.size
   let mut j := 0
-  for i in [:args.size] do
+  for h : i in [:args.size] do
     unless fnType matches .forallE .. do
       fnType ← whnfD (fnType.instantiateRevRange j i args)
       j := i
     let .forallE _ d b bi := fnType | throwError m! "expected function type {indentExpr fnType}"
     fnType := b
-    result := result.push (← isIgnoredArg args[i]! d bi)
+    result := result.push (← isIgnoredArg args[i] d bi)
   return result
 where
   /-- Return whether the argument should be ignored. -/

--- a/Mathlib/Tactic/CC/Addition.lean
+++ b/Mathlib/Tactic/CC/Addition.lean
@@ -275,9 +275,9 @@ def insertEraseROccs (e lhs : ACApps) (inLHS isInsert : Bool) : CCM Unit := do
   match e with
   | .apps _ args =>
     insertEraseROcc args[0]! lhs inLHS isInsert
-    for i in [1:args.size] do
-      if args[i]! != args[i - 1]! then
-        insertEraseROcc args[i]! lhs inLHS isInsert
+    for h : i in [1:args.size] do
+      if args[i] != args[i - 1]! then
+        insertEraseROcc args[i] lhs inLHS isInsert
   | .ofExpr e => insertEraseROcc e lhs inLHS isInsert
 
 /-- Insert `lhs` to the occurrences of arguments of `e` on an equality in `acR`. -/

--- a/Mathlib/Tactic/CC/Datatypes.lean
+++ b/Mathlib/Tactic/CC/Datatypes.lean
@@ -173,11 +173,11 @@ def ACApps.isSubset : (e₁ e₂ : ACApps) → Bool
       if args₁.size ≤ args₂.size then Id.run do
         let mut i₁ := 0
         let mut i₂ := 0
-        while i₁ < args₁.size ∧ i₂ < args₂.size do
-          if args₁[i₁]! == args₂[i₂]! then
+        while h : i₁ < args₁.size ∧ i₂ < args₂.size do
+          if args₁[i₁] == args₂[i₂] then
             i₁ := i₁ + 1
             i₂ := i₂ + 1
-          else if Expr.lt args₂[i₂]! args₁[i₁]! then
+          else if Expr.lt args₂[i₂] args₁[i₁] then
             i₂ := i₂ + 1
           else return false
         return i₁ == args₁.size
@@ -197,20 +197,20 @@ def ACApps.diff (e₁ e₂ : ACApps) (r : Array Expr := #[]) : Array Expr :=
     | .apps op₂ args₂ =>
       if op₁ == op₂ then
         let mut i₂ := 0
-        for i₁ in [:args₁.size] do
+        for h : i₁ in [:args₁.size] do
           if i₂ == args₂.size then
-            r := r.push args₁[i₁]!
-          else if args₁[i₁]! == args₂[i₂]! then
+            r := r.push args₁[i₁]
+          else if args₁[i₁] == args₂[i₂]! then
             i₂ := i₂ + 1
           else
-            r := r.push args₁[i₁]!
+            r := r.push args₁[i₁]
     | .ofExpr e₂ =>
       let mut found := false
-      for i in [:args₁.size] do
-        if !found && args₁[i]! == e₂ then
+      for h : i in [:args₁.size] do
+        if !found && args₁[i] == e₂ then
           found := true
         else
-          r := r.push args₁[i]!
+          r := r.push args₁[i]
     return r
   | .ofExpr e => if e₂ == e then r else r.push e
 
@@ -229,12 +229,12 @@ def ACApps.intersection (e₁ e₂ : ACApps) (r : Array Expr := #[]) : Array Exp
     let mut r := r
     let mut i₁ := 0
     let mut i₂ := 0
-    while i₁ < args₁.size ∧ i₂ < args₂.size do
-      if args₁[i₁]! == args₂[i₂]! then
-        r := r.push args₁[i₁]!
+    while h : i₁ < args₁.size ∧ i₂ < args₂.size do
+      if args₁[i₁] == args₂[i₂] then
+        r := r.push args₁[i₁]
         i₁ := i₁ + 1
         i₂ := i₂ + 1
-      else if Expr.lt args₂[i₂]! args₁[i₁]! then
+      else if Expr.lt args₂[i₂] args₁[i₁] then
         i₂ := i₂ + 1
       else
         i₁ := i₁ + 1

--- a/Mathlib/Tactic/CC/MkProof.lean
+++ b/Mathlib/Tactic/CC/MkProof.lean
@@ -473,9 +473,9 @@ partial def getEqProofCore (e₁ e₂ : Expr) (asHEq : Bool) : CCM (Option Expr)
   -- 4. Build transitivity proof
   let mut pr? : Option Expr := none
   let mut lhs := e₁
-  for i in [:path₁.size] do
-    pr? ← some <$> mkTransOpt pr? (← mkProof lhs path₁[i]! Hs₁[i]! heqProofs) heqProofs
-    lhs := path₁[i]!
+  for h : i in [:path₁.size] do
+    pr? ← some <$> mkTransOpt pr? (← mkProof lhs path₁[i] Hs₁[i]! heqProofs) heqProofs
+    lhs := path₁[i]
   let mut i := Hs₂.size
   while i > 0 do
     i := i - 1

--- a/Mathlib/Tactic/CategoryTheory/ToApp.lean
+++ b/Mathlib/Tactic/CategoryTheory/ToApp.lean
@@ -73,8 +73,8 @@ def toCatExpr (e : Expr) : MetaM Expr := do
   /-- Recursive function which applies `mkLambdaFVars` stepwise
   (so that each step can have different binderinfos) -/
     apprec (i : Nat) (e : Expr) : MetaM Expr := do
-      if i < args.size then
-        let arg := args[i]!
+      if h : i < args.size then
+        let arg := args[i]
         let bi := binderInfos[i]!
         let e' ← apprec (i + 1) e
         unless arg != B && arg != inst do return e'

--- a/Mathlib/Tactic/DeriveFintype.lean
+++ b/Mathlib/Tactic/DeriveFintype.lean
@@ -178,9 +178,10 @@ def mkFintypeEnum (declName : Name) : CommandElabM Unit := do
   elabCommand cmd
 
 def mkFintypeInstanceHandler (declNames : Array Name) : CommandElabM Bool := do
-  if declNames.size != 1 then
+  if h : declNames.size ≠ 1 then
     return false -- mutually inductive types are not supported
-  let declName := declNames[0]!
+  else
+  let declName := declNames[0]
   if ← isEnumType declName then
     mkFintypeEnum declName
     return true

--- a/Mathlib/Tactic/DeriveFintype.lean
+++ b/Mathlib/Tactic/DeriveFintype.lean
@@ -181,12 +181,12 @@ def mkFintypeInstanceHandler (declNames : Array Name) : CommandElabM Bool := do
   if h : declNames.size ≠ 1 then
     return false -- mutually inductive types are not supported
   else
-  let declName := declNames[0]
-  if ← isEnumType declName then
-    mkFintypeEnum declName
-    return true
-  else
-    mkFintype declName
+    let declName := declNames[0]
+    if ← isEnumType declName then
+      mkFintypeEnum declName
+      return true
+    else
+      mkFintype declName
 
 initialize
   registerDerivingHandler ``Fintype mkFintypeInstanceHandler

--- a/Mathlib/Tactic/FunProp/Core.lean
+++ b/Mathlib/Tactic/FunProp/Core.lean
@@ -365,11 +365,10 @@ def removeArgRule (funPropDecl : FunPropDecl) (e : Expr) (fData : FunctionData)
     (funProp : Expr → FunPropM (Option Result)) :
     FunPropM (Option Result) := do
 
-  match fData.args.size with
+  match h : fData.args.size with
   | 0 => throwError "fun_prop bug: invalid use of remove arg case {←ppExpr e}"
-  | _ =>
-    let n := fData.args.size
-    let arg := fData.args[n-1]!
+  | n + 1 =>
+    let arg := fData.args[n]
 
     if arg.coe.isSome then
       -- if have to apply morphisms rules if we deal with morphims

--- a/Mathlib/Tactic/FunProp/Decl.lean
+++ b/Mathlib/Tactic/FunProp/Decl.lean
@@ -94,16 +94,15 @@ def getFunProp? (e : Expr) : MetaM (Option (FunPropDecl × Expr)) := do
   if h : decls.size = 0 then
     return none
   else
-  if decls.size > 1 then
-    throwError "\
-fun_prop bug: expression {← ppExpr e} matches multiple function properties
-{decls.map (fun d => d.funPropName)}"
+    if decls.size > 1 then
+      throwError "fun_prop bug: expression {← ppExpr e} matches multiple function properties\n\
+        {decls.map (fun d => d.funPropName)}"
 
-  let decl := decls[0]
-  unless decl.funArgId < e.getAppNumArgs do return none
-  let f := e.getArg! decl.funArgId
+    let decl := decls[0]
+    unless decl.funArgId < e.getAppNumArgs do return none
+    let f := e.getArg! decl.funArgId
 
-  return (decl,f)
+    return (decl,f)
 
 /-- Is `e` a function property statement? -/
 def isFunProp (e : Expr) : MetaM Bool := do return (← getFunProp? e).isSome

--- a/Mathlib/Tactic/FunProp/Decl.lean
+++ b/Mathlib/Tactic/FunProp/Decl.lean
@@ -91,15 +91,15 @@ def getFunProp? (e : Expr) : MetaM (Option (FunPropDecl × Expr)) := do
 
   let decls ← ext.decls.getMatch e (← read)
 
-  if decls.size = 0 then
+  if h : decls.size = 0 then
     return none
-
+  else
   if decls.size > 1 then
     throwError "\
 fun_prop bug: expression {← ppExpr e} matches multiple function properties
 {decls.map (fun d => d.funPropName)}"
 
-  let decl := decls[0]!
+  let decl := decls[0]
   unless decl.funArgId < e.getAppNumArgs do return none
   let f := e.getArg! decl.funArgId
 

--- a/Mathlib/Tactic/FunProp/FunctionData.lean
+++ b/Mathlib/Tactic/FunProp/FunctionData.lean
@@ -169,11 +169,10 @@ def FunctionData.isMorApplication (f : FunctionData) : MetaM MorApplication := d
       | .eq => return .exact
       | .lt => return .overApplied
       | .gt => return .underApplied
-  match f.args.size with
+  match h : f.args.size with
   | 0 => return .none
-  | _ =>
-    let n := f.args.size
-    if f.args[n-1]!.coe.isSome then
+  | n + 1 =>
+    if f.args[n].coe.isSome then
       return .exact
     else if f.args.any (fun a => a.coe.isSome) then
       return .overApplied

--- a/Mathlib/Tactic/FunProp/ToBatteries.lean
+++ b/Mathlib/Tactic/FunProp/ToBatteries.lean
@@ -71,7 +71,7 @@ def mkProdElem (xs : Array Expr) : MetaM Expr := do
   match h : xs.size with
   | 0 => return default
   | 1 => return xs[0]
-  | n+1 =>
+  | n + 1 =>
     xs[0:n].foldrM (init := xs[n]) fun x p => mkAppM ``Prod.mk #[x,p]
 
 /--

--- a/Mathlib/Tactic/FunProp/ToBatteries.lean
+++ b/Mathlib/Tactic/FunProp/ToBatteries.lean
@@ -20,11 +20,11 @@ def isOrderedSubsetOf {α} [Inhabited α] [DecidableEq α] (a b : Array α) : Bo
   if a.size > b.size then
     return false
   let mut i := 0
-  for j in [0:b.size] do
+  for h' : j in [0:b.size] do
     if i = a.size then
       break
 
-    if a[i]! = b[j]! then
+    if a[i]! = b[j] then
       i := i+1
 
   if i = a.size then
@@ -68,12 +68,11 @@ def _root_.Lean.Expr.swapBVars (e : Expr) (i j : Nat) : Expr :=
 For `#[x₁, .., xₙ]` create `(x₁, .., xₙ)`.
 -/
 def mkProdElem (xs : Array Expr) : MetaM Expr := do
-  match xs.size with
+  match h : xs.size with
   | 0 => return default
-  | 1 => return xs[0]!
-  | _ =>
-    let n := xs.size
-    xs[0:n-1].foldrM (init := xs[n-1]!) fun x p => mkAppM ``Prod.mk #[x,p]
+  | 1 => return xs[0]
+  | n+1 =>
+    xs[0:n].foldrM (init := xs[n]) fun x p => mkAppM ``Prod.mk #[x,p]
 
 /--
 For `(x₀, .., xₙ₋₁)` return `xᵢ` but as a product projection.

--- a/Mathlib/Tactic/GeneralizeProofs.lean
+++ b/Mathlib/Tactic/GeneralizeProofs.lean
@@ -161,13 +161,13 @@ where
     let mut fty ← inferType f
     -- Whether we have already unified the type `ty?` with `fty` (once `margs` is filled)
     let mut unifiedFTy := false
-    for i in [0 : args.size] do
+    for h : i in [0 : args.size] do
       unless i < margs.size do
         let (margs', _, fty') ← forallMetaBoundedTelescope fty (args.size - i)
         if margs'.isEmpty then throwError "could not make progress at argument {i}"
         fty := fty'
         margs := margs ++ margs'
-      let arg := args[i]!
+      let arg := args[i]
       let marg := margs[i]!
       if !unifiedFTy && margs.size == args.size then
         if let some ty := ty? then

--- a/Mathlib/Tactic/Linarith/Oracle/SimplexAlgorithm/PositiveVector.lean
+++ b/Mathlib/Tactic/Linarith/Oracle/SimplexAlgorithm/PositiveVector.lean
@@ -73,8 +73,8 @@ def stateLP {n m : Nat} (A : matType n m) (strictIndexes : List Nat) : matType (
 /-- Extracts target vector from the tableau, putting auxiliary variables aside (see `stateLP`). -/
 def extractSolution (tableau : Tableau matType) : Array Rat := Id.run do
   let mut ans : Array Rat := Array.mkArray (tableau.basic.size + tableau.free.size - 3) 0
-  for i in [1:tableau.basic.size] do
-    ans := ans.set! (tableau.basic[i]! - 2) <| tableau.mat[(i, tableau.free.size - 1)]!
+  for h : i in [1:tableau.basic.size] do
+    ans := ans.set! (tableau.basic[i] - 2) <| tableau.mat[(i, tableau.free.size - 1)]!
   return ans
 
 /--

--- a/Mathlib/Tactic/Linter/TextBased.lean
+++ b/Mathlib/Tactic/Linter/TextBased.lean
@@ -208,13 +208,13 @@ def adaptationNoteLinter : TextbasedLinter := fun lines ↦ Id.run do
 /-- Lint a collection of input strings if one of them contains trailing whitespace. -/
 def trailingWhitespaceLinter : TextbasedLinter := fun lines ↦ Id.run do
   let mut errors := Array.mkEmpty 0
-  let mut fixedLines := lines
+  let mut fixedLines : Vector String lines.size := lines.toVector
   for h : idx in [:lines.size] do
     let line := lines[idx]
     if line.back == ' ' then
       errors := errors.push (StyleError.trailingWhitespace, idx + 1)
-      fixedLines := fixedLines.set! idx line.trimRight
-  return (errors, if errors.size > 0 then some fixedLines else none)
+      fixedLines := fixedLines.set idx line.trimRight
+  return (errors, if errors.size > 0 then some fixedLines.toArray else none)
 
 
 /-- Lint a collection of input strings for a semicolon preceded by a space. -/

--- a/Mathlib/Tactic/Order.lean
+++ b/Mathlib/Tactic/Order.lean
@@ -160,18 +160,18 @@ graph. We repeat adding edges using this until no more edges can be added. -/
 def updateGraphWithNlt (g : Graph) (idxToAtom : Std.HashMap Nat Expr)
     (facts : Array AtomicFact) : MetaM Graph := do
   let nltFacts := facts.filter fun fact => match fact with | .nlt _ _ _ => true | _ => false
-  let mut usedNltFacts : Array Bool := mkArray nltFacts.size false
+  let mut usedNltFacts : Vector Bool _ := .mkVector nltFacts.size false
   let mut g := g
   while true do
     let mut changed : Bool := false
-    for i in [:nltFacts.size] do
-      if usedNltFacts[i]! then
+    for h : i in [:nltFacts.size] do
+      if usedNltFacts[i] then
         continue
-      let .nlt lhs rhs proof := nltFacts[i]! | throwError "Bug: Non-nlt fact in nltFacts."
+      let .nlt lhs rhs proof := nltFacts[i] | throwError "Bug: Non-nlt fact in nltFacts."
       let .some pf ← g.buildTransitiveLeProof idxToAtom lhs rhs | continue
       g := g.addEdge ⟨rhs, lhs, ← mkAppM ``le_of_not_lt_le #[proof, pf]⟩
       changed := true
-      usedNltFacts := usedNltFacts.set! i true
+      usedNltFacts := usedNltFacts.set i true
     if !changed then
       break
   return g

--- a/Mathlib/Tactic/ProxyType.lean
+++ b/Mathlib/Tactic/ProxyType.lean
@@ -106,8 +106,8 @@ def defaultMkProxyType (ctors : Array (Name × Expr × Term))
     TermElabM (Expr × Array Term × TSyntax `tactic) := do
   let mut types := #[]
   let mut patts := #[]
-  for i in [0:ctors.size] do
-    let (_ctorName, ty, patt) := ctors[i]!
+  for h : i in [0:ctors.size] do
+    let (_ctorName, ty, patt) := ctors[i]
     types := types.push ty
     patts := patts.push <| ← wrapSumAccess i ctors.size patt
   let (type, pf) ← mkCType types.toList

--- a/Mathlib/Tactic/Simps/NotationClass.lean
+++ b/Mathlib/Tactic/Simps/NotationClass.lean
@@ -50,8 +50,8 @@ def defaultfindArgs : findArgType := fun _ className args ↦ do
   let arity := classExpr.type.getNumHeadForalls
   if arity == args.size then
     return args.map some
-  else if args.size == 1 then
-    return mkArray arity args[0]!
+  else if h : args.size = 1 then
+    return mkArray arity args[0]
   else
     throwError "initialize_simps_projections cannot automatically find arguments for class \
       {className}"

--- a/Mathlib/Tactic/ToAdditive/Frontend.lean
+++ b/Mathlib/Tactic/ToAdditive/Frontend.lean
@@ -599,9 +599,9 @@ where /-- Implementation of `applyReplacementFun`. -/
           /- Test if the head should not be replaced. -/
           let relevantArgId := relevantArg nm
           let gfAdditive :=
-            if relevantArgId < gAllArgs.size && gf.isConst then
+            if h : relevantArgId < gAllArgs.size ∧ gf.isConst then
               if let some fxd :=
-                additiveTest env gAllArgs[relevantArgId]! then
+                additiveTest env gAllArgs[relevantArgId] then
                 Id.run <| do
                   if trace then
                     dbg_trace s!"The application of {nm} contains the fixed type \

--- a/Mathlib/Tactic/Variable.lean
+++ b/Mathlib/Tactic/Variable.lean
@@ -160,7 +160,7 @@ partial def completeBinders' (maxSteps : Nat) (gas : Nat)
     (toOmit : Array Bool) (i : Nat) :
     TermElabM (TSyntaxArray ``bracketedBinder × Array Bool) := do
   if h : 0 < gas ∧ i < binders.size then
-    let binder := binders[i]!
+    let binder := binders[i]
     trace[«variable?»] "\
       Have {(← getLCtx).getFVarIds.size} fvars and {(← getLocalInstances).size} local instances. \
       Looking at{indentD binder}"
@@ -213,9 +213,9 @@ partial def completeBinders' (maxSteps : Nat) (gas : Nat)
           | _ => return (binders, toOmit.push false)
         completeBinders' maxSteps gas checkRedundant binders toOmit (i + 1)
   else
-    if gas == 0 && i < binders.size then
+    if h : gas = 0 ∧ i < binders.size then
       let binders' := binders.extract 0 i
-      logErrorAt binders[i]! m!"Maximum recursion depth for variables! reached. This might be a \
+      logErrorAt binders[i] m!"Maximum recursion depth for variables! reached. This might be a \
         bug, or you can try adjusting `set_option variable?.maxSteps {maxSteps}`\n\n\
         Current variable command:{indentD (← `(command| variable $binders'*))}"
     return (binders, toOmit)

--- a/Mathlib/Util/AssertExists.lean
+++ b/Mathlib/Util/AssertExists.lean
@@ -111,7 +111,7 @@ elab "assert_not_exists " ns:ident+ : command => do
         | pure m!"Declaration {c} is defined in this file."
       let mut msg := m!"Declaration {c} is not allowed to be imported by this file.\n\
         It is defined in {modNames[idx.toNat]!},"
-      for h : i in [idx.toNat+1:modData.size] do
+      for h : i in [idx.toNat + 1:modData.size] do
         if modData[i].imports.any (·.module == modNames[idx.toNat]!) then
           idx := i
           msg := msg ++ m!"\n  which is imported by {modNames[i]!},"

--- a/Mathlib/Util/AssertExists.lean
+++ b/Mathlib/Util/AssertExists.lean
@@ -99,7 +99,6 @@ elab "assert_not_exists " ns:ident+ : command => do
   let env ← getEnv
   let modNames := env.header.moduleNames
   let modData := env.header.moduleData
-  let modDataSize := modData.size
   for n in ns do
     let decl ←
       try liftCoreM <| realizeGlobalConstNoOverloadWithInfo n
@@ -112,8 +111,8 @@ elab "assert_not_exists " ns:ident+ : command => do
         | pure m!"Declaration {c} is defined in this file."
       let mut msg := m!"Declaration {c} is not allowed to be imported by this file.\n\
         It is defined in {modNames[idx.toNat]!},"
-      for i in [idx.toNat+1:modDataSize] do
-        if modData[i]!.imports.any (·.module == modNames[idx.toNat]!) then
+      for h : i in [idx.toNat+1:modData.size] do
+        if modData[i].imports.any (·.module == modNames[idx.toNat]!) then
           idx := i
           msg := msg ++ m!"\n  which is imported by {modNames[i]!},"
       pure <| msg ++ m!"\n  which is imported by this file.")


### PR DESCRIPTION
Avoid runtime array checks, if the bounds are already easily known from context.