### PR TITLE
[Merged by Bors] - feat: adds `Real.nnreal_dichotomy` for principled case splits into nonnegative and nonpositive options

### DIFF
--- a/Mathlib/Data/NNReal/Defs.lean
+++ b/Mathlib/Data/NNReal/Defs.lean
@@ -914,13 +914,10 @@ lemma nnreal_dichotomy (r : ℝ) : ∃ x : ℝ≥0, r = x ∨ r = -x := by
     aesop
 
 /-- Every real number is either zero, positive or negative, phrased using `ℝ≥0`. -/
-lemma nnreal_trichotomy (r : ℝ) : r = 0 ∨ ∃ x : ℝ≥0, 0 < x ∧ (r = x  ∨ r = -x) := by
-  obtain (hr | rfl | hr) : 0 < r ∨ 0 = r ∨ 0 < -r := by simpa using lt_trichotomy 0 r
-  case inr.inl => exact .inl rfl
-  all_goals
-    rw [← neg_neg r]
-    lift (_ : ℝ) to ℝ≥0 using hr.le with r
-    aesop
+lemma nnreal_trichotomy (r : ℝ) : r = 0 ∨ ∃ x : ℝ≥0, 0 < x ∧ (r = x ∨ r = -x) := by
+  obtain ⟨x, hx⟩ := nnreal_dichotomy r
+  rw [or_iff_not_imp_left]
+  aesop (add simp pos_iff_ne_zero)
 
 /-- To prove a property holds for real numbers it suffices to show that it holds for `x : ℝ≥0`,
 and if it holds for `x : ℝ≥0`, then it does also for `(-↑x : ℝ)`. -/

--- a/Mathlib/Data/NNReal/Defs.lean
+++ b/Mathlib/Data/NNReal/Defs.lean
@@ -905,6 +905,39 @@ theorem cast_natAbs_eq_nnabs_cast (n : ℤ) : (n.natAbs : ℝ≥0) = nnabs n := 
   ext
   rw [NNReal.coe_natCast, Int.cast_natAbs, Real.coe_nnabs, Int.cast_abs]
 
+/-- Every real number nonnegative or nonpositive, phrased using `ℝ≥0`. -/
+lemma nnreal_dichotomy (r : ℝ) : ∃ x : ℝ≥0, r = x ∨ r = -x := by
+  obtain (hr | hr) : 0 ≤ r ∨ 0 ≤ -r := by simpa using le_total ..
+  all_goals
+    rw [← neg_neg r]
+    lift (_ : ℝ) to ℝ≥0 using hr with r
+    aesop
+
+/-- Every real number is either zero, positive or negative, phrased using `ℝ≥0`. -/
+lemma nnreal_trichotomy (r : ℝ) : r = 0 ∨ ∃ x : ℝ≥0, 0 < x ∧ (r = x  ∨ r = -x) := by
+  obtain (hr | rfl | hr) : 0 < r ∨ 0 = r ∨ 0 < -r := by simpa using lt_trichotomy 0 r
+  case inr.inl => exact .inl rfl
+  all_goals
+    rw [← neg_neg r]
+    lift (_ : ℝ) to ℝ≥0 using hr.le with r
+    aesop
+
+/-- To prove a property holds for real numbers it suffices to show that it holds for `x : ℝ≥0`,
+and if it holds for `x : ℝ≥0`, then it does also for `(-↑x : ℝ)`. -/
+@[elab_as_elim]
+lemma nnreal_induction_on {motive : ℝ → Prop} (nonneg : ∀ x : ℝ≥0, motive x)
+    (nonpos : ∀ x : ℝ≥0, motive x → motive (-x)) (r : ℝ) : motive r := by
+  obtain ⟨r, (rfl | rfl)⟩ := r.nnreal_dichotomy
+  all_goals simp_all
+
+/-- A version of `nnreal_induction_on` which splits into three cases (zero, positive and negative)
+instead of two. -/
+@[elab_as_elim]
+lemma nnreal_induction_on' {motive : ℝ → Prop} (zero : motive 0) (pos : ∀ x : ℝ≥0, 0 < x → motive x)
+    (neg : ∀ x : ℝ≥0, 0 < x → motive x → motive (-x)) (r : ℝ) : motive r := by
+  obtain rfl | ⟨r, hr, (rfl | rfl)⟩ := r.nnreal_trichotomy
+  all_goals simp_all
+
 end Real
 
 section StrictMono


### PR DESCRIPTION

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
