### PR TITLE
[Merged by Bors] - feat: generalize Mathlib.Data

### DIFF
--- a/Mathlib/Data/Complex/Module.lean
+++ b/Mathlib/Data/Complex/Module.lean
@@ -490,7 +490,7 @@ lemma Complex.coe_realPart (z : ℂ) : (ℜ z : ℂ) = z.re := calc
     rw [map_add, AddSubmonoid.coe_add, mul_comm, ← smul_eq_mul, realPart_I_smul]
     simp [conj_ofReal, ← two_mul]
 
-lemma star_mul_self_add_self_mul_star {A : Type*} [NonUnitalRing A] [StarRing A]
+lemma star_mul_self_add_self_mul_star {A : Type*} [NonUnitalNonAssocRing A] [StarRing A]
     [Module ℂ A] [IsScalarTower ℂ A A] [SMulCommClass ℂ A A] [StarModule ℂ A] (a : A) :
     star a * a + a * star a = 2 • (ℜ a * ℜ a + ℑ a * ℑ a) :=
   have a_eq := (realPart_add_I_smul_imaginaryPart a).symm

--- a/Mathlib/Data/Finset/NoncommProd.lean
+++ b/Mathlib/Data/Finset/NoncommProd.lean
@@ -162,7 +162,7 @@ lemma noncommProd_induction (s : Multiset α) (comm)
 variable [FunLike F α β]
 
 @[to_additive]
-protected theorem map_noncommProd_aux [MonoidHomClass F α β] (s : Multiset α)
+protected theorem map_noncommProd_aux [MulHomClass F α β] (s : Multiset α)
     (comm : { x | x ∈ s }.Pairwise Commute) (f : F) : { x | x ∈ s.map f }.Pairwise Commute := by
   simp only [Multiset.mem_map]
   rintro _ ⟨x, hx, rfl⟩ _ ⟨y, hy, rfl⟩ _

--- a/Mathlib/Data/Finset/Pairwise.lean
+++ b/Mathlib/Data/Finset/Pairwise.lean
@@ -83,12 +83,12 @@ theorem pairwise_iff_coe_toFinset_pairwise (hn : l.Nodup) (hs : Symmetric r) :
 
 open scoped Function -- required for scoped `on` notation
 
-theorem pairwise_disjoint_of_coe_toFinset_pairwiseDisjoint {α ι} [SemilatticeInf α] [OrderBot α]
+theorem pairwise_disjoint_of_coe_toFinset_pairwiseDisjoint {α ι} [PartialOrder α] [OrderBot α]
     [DecidableEq ι] {l : List ι} {f : ι → α} (hl : (l.toFinset : Set ι).PairwiseDisjoint f)
     (hn : l.Nodup) : l.Pairwise (_root_.Disjoint on f) :=
   pairwise_of_coe_toFinset_pairwise hl hn
 
-theorem pairwiseDisjoint_iff_coe_toFinset_pairwise_disjoint {α ι} [SemilatticeInf α] [OrderBot α]
+theorem pairwiseDisjoint_iff_coe_toFinset_pairwise_disjoint {α ι} [PartialOrder α] [OrderBot α]
     [DecidableEq ι] {l : List ι} {f : ι → α} (hn : l.Nodup) :
     (l.toFinset : Set ι).PairwiseDisjoint f ↔ l.Pairwise (_root_.Disjoint on f) :=
   pairwise_iff_coe_toFinset_pairwise hn (symmetric_disjoint.comap f)

--- a/Mathlib/Data/Finset/SMulAntidiagonal.lean
+++ b/Mathlib/Data/Finset/SMulAntidiagonal.lean
@@ -27,18 +27,18 @@ open Pointwise
 namespace Set
 
 @[to_additive]
-theorem IsPWO.smul [PartialOrder G] [PartialOrder P] [SMul G P] [IsOrderedCancelSMul G P]
+theorem IsPWO.smul [Preorder G] [Preorder P] [SMul G P] [IsOrderedSMul G P]
     {s : Set G} {t : Set P} (hs : s.IsPWO) (ht : t.IsPWO) : IsPWO (s • t) := by
   rw [← @image_smul_prod]
   exact (hs.prod ht).image_of_monotone (monotone_fst.smul monotone_snd)
 
 @[to_additive]
-theorem IsWF.smul [LinearOrder G] [LinearOrder P] [SMul G P] [IsOrderedCancelSMul G P] {s : Set G}
+theorem IsWF.smul [LinearOrder G] [LinearOrder P] [SMul G P] [IsOrderedSMul G P] {s : Set G}
     {t : Set P} (hs : s.IsWF) (ht : t.IsWF) : IsWF (s • t) :=
   (hs.isPWO.smul ht.isPWO).isWF
 
 @[to_additive]
-theorem IsWF.min_smul [LinearOrder G] [LinearOrder P] [SMul G P] [IsOrderedCancelSMul G P]
+theorem IsWF.min_smul [LinearOrder G] [LinearOrder P] [SMul G P] [IsOrderedSMul G P]
     {s : Set G} {t : Set P} (hs : s.IsWF) (ht : t.IsWF) (hsn : s.Nonempty) (htn : t.Nonempty) :
     (hs.smul ht).min (hsn.smul htn) = hs.min hsn • ht.min htn := by
   refine le_antisymm (IsWF.min_le _ _ (mem_smul.2 ⟨_, hs.min_mem _, _, ht.min_mem _, rfl⟩)) ?_

--- a/Mathlib/Data/Int/Cast/Lemmas.lean
+++ b/Mathlib/Data/Int/Cast/Lemmas.lean
@@ -37,7 +37,7 @@ def ofNatHom : ℕ →+* ℤ :=
 section cast
 
 @[simp, norm_cast]
-theorem cast_ite [AddGroupWithOne α] (P : Prop) [Decidable P] (m n : ℤ) :
+theorem cast_ite [IntCast α] (P : Prop) [Decidable P] (m n : ℤ) :
     ((ite P m n : ℤ) : α) = ite P (m : α) (n : α) :=
   apply_ite _ _ _ _
 

--- a/Mathlib/Data/Matrix/Block.lean
+++ b/Mathlib/Data/Matrix/Block.lean
@@ -438,7 +438,7 @@ theorem blockDiagonal_pow [DecidableEq m] [Fintype o] [Fintype m] [Semiring α]
   map_pow (blockDiagonalRingHom m o α) M n
 
 @[simp]
-theorem blockDiagonal_smul {R : Type*} [Monoid R] [AddMonoid α] [DistribMulAction R α] (x : R)
+theorem blockDiagonal_smul {R : Type*} [Zero α] [SMulZeroClass R α] (x : R)
     (M : o → Matrix m n α) : blockDiagonal (x • M) = x • blockDiagonal M := by
   ext
   simp only [blockDiagonal_apply, Pi.smul_apply, smul_apply]

--- a/Mathlib/Data/Matrix/ConjTranspose.lean
+++ b/Mathlib/Data/Matrix/ConjTranspose.lean
@@ -178,18 +178,18 @@ theorem conjTranspose_ofNat [DecidableEq n] [NonAssocSemiring α] [StarRing α] 
   conjTranspose_natCast _
 
 @[simp]
-theorem conjTranspose_eq_ofNat [DecidableEq n] [Semiring α] [StarRing α]
+theorem conjTranspose_eq_ofNat [DecidableEq n] [NonAssocSemiring α] [StarRing α]
     {M : Matrix n n α} {d : ℕ} [d.AtLeastTwo] :
     Mᴴ = ofNat(d) ↔ M = OfNat.ofNat d :=
   conjTranspose_eq_natCast
 
 @[simp]
-theorem conjTranspose_intCast [DecidableEq n] [Ring α] [StarRing α] (d : ℤ) :
+theorem conjTranspose_intCast [DecidableEq n] [NonAssocRing α] [StarRing α] (d : ℤ) :
     (d : Matrix n n α)ᴴ = d := by
   simp [conjTranspose, Matrix.map_intCast, diagonal_intCast]
 
 @[simp]
-theorem conjTranspose_eq_intCast [DecidableEq n] [Ring α] [StarRing α]
+theorem conjTranspose_eq_intCast [DecidableEq n] [NonAssocRing α] [StarRing α]
     {M : Matrix n n α} {d : ℤ} :
     Mᴴ = d ↔ M = d :=
   (Function.Involutive.eq_iff conjTranspose_conjTranspose).trans <|

--- a/Mathlib/Data/Matrix/ConjTranspose.lean
+++ b/Mathlib/Data/Matrix/ConjTranspose.lean
@@ -178,18 +178,18 @@ theorem conjTranspose_ofNat [DecidableEq n] [NonAssocSemiring α] [StarRing α] 
   conjTranspose_natCast _
 
 @[simp]
-theorem conjTranspose_eq_ofNat [DecidableEq n] [NonAssocSemiring α] [StarRing α]
+theorem conjTranspose_eq_ofNat [DecidableEq n] [Semiring α] [StarRing α]
     {M : Matrix n n α} {d : ℕ} [d.AtLeastTwo] :
     Mᴴ = ofNat(d) ↔ M = OfNat.ofNat d :=
   conjTranspose_eq_natCast
 
 @[simp]
-theorem conjTranspose_intCast [DecidableEq n] [NonAssocRing α] [StarRing α] (d : ℤ) :
+theorem conjTranspose_intCast [DecidableEq n] [Ring α] [StarRing α] (d : ℤ) :
     (d : Matrix n n α)ᴴ = d := by
   simp [conjTranspose, Matrix.map_intCast, diagonal_intCast]
 
 @[simp]
-theorem conjTranspose_eq_intCast [DecidableEq n] [NonAssocRing α] [StarRing α]
+theorem conjTranspose_eq_intCast [DecidableEq n] [Ring α] [StarRing α]
     {M : Matrix n n α} {d : ℤ} :
     Mᴴ = d ↔ M = d :=
   (Function.Involutive.eq_iff conjTranspose_conjTranspose).trans <|

--- a/Mathlib/Data/Matrix/Mul.lean
+++ b/Mathlib/Data/Matrix/Mul.lean
@@ -709,13 +709,13 @@ theorem add_vecMul [Fintype m] (A : Matrix m n α) (x y : m → α) :
   ext
   apply add_dotProduct
 
-theorem vecMul_smul [Fintype n] [Monoid R] [NonUnitalNonAssocSemiring S] [DistribMulAction R S]
+theorem vecMul_smul [Fintype n] [NonUnitalNonAssocSemiring S] [DistribSMul R S]
     [IsScalarTower R S S] (M : Matrix n m S) (b : R) (v : n → S) :
     (b • v) ᵥ* M = b • v ᵥ* M := by
   ext i
   simp only [vecMul, dotProduct, Finset.smul_sum, Pi.smul_apply, smul_mul_assoc]
 
-theorem mulVec_smul [Fintype n] [Monoid R] [NonUnitalNonAssocSemiring S] [DistribMulAction R S]
+theorem mulVec_smul [Fintype n] [NonUnitalNonAssocSemiring S] [DistribSMul R S]
     [SMulCommClass R S S] (M : Matrix m n S) (b : R) (v : n → S) :
     M *ᵥ (b • v) = b • M *ᵥ v := by
   ext i

--- a/Mathlib/Data/Nat/Cast/Basic.lean
+++ b/Mathlib/Data/Nat/Cast/Basic.lean
@@ -111,7 +111,7 @@ section MonoidWithZeroHomClass
 variable {A F : Type*} [MulZeroOneClass A] [FunLike F ℕ A]
 
 /-- If two `MonoidWithZeroHom`s agree on the positive naturals they are equal. -/
-theorem ext_nat'' [MonoidWithZeroHomClass F ℕ A] (f g : F) (h_pos : ∀ {n : ℕ}, 0 < n → f n = g n) :
+theorem ext_nat'' [ZeroHomClass F ℕ A] (f g : F) (h_pos : ∀ {n : ℕ}, 0 < n → f n = g n) :
     f = g := by
   apply DFunLike.ext
   rintro (_ | n)
@@ -148,7 +148,7 @@ theorem map_ofNat [FunLike F R S] [RingHomClass F R S] (f : F) (n : ℕ) [Nat.At
 theorem ext_nat [FunLike F ℕ R] [RingHomClass F ℕ R] (f g : F) : f = g :=
   ext_nat' f g <| by simp
 
-theorem NeZero.nat_of_neZero {R S} [Semiring R] [Semiring S]
+theorem NeZero.nat_of_neZero {R S} [NonAssocSemiring R] [NonAssocSemiring S]
     {F} [FunLike F R S] [RingHomClass F R S] (f : F)
     {n : ℕ} [hn : NeZero (n : S)] : NeZero (n : R) :=
   .of_map (f := f) (neZero := by simp only [map_natCast, hn])

--- a/Mathlib/Data/Nat/Cast/Defs.lean
+++ b/Mathlib/Data/Nat/Cast/Defs.lean
@@ -169,11 +169,11 @@ theorem binCast_eq [AddMonoidWithOne R] (n : ℕ) :
         rw [h1, Nat.add_comm 1, Nat.succ_mul, Nat.one_mul]
         simp only [Nat.cast_add, Nat.cast_one]
 
-theorem cast_two [AddMonoidWithOne R] : ((2 : ℕ) : R) = (2 : R) := rfl
+theorem cast_two [NatCast R] : ((2 : ℕ) : R) = (2 : R) := rfl
 
-theorem cast_three [AddMonoidWithOne R] : ((3 : ℕ) : R) = (3 : R) := rfl
+theorem cast_three [NatCast R] : ((3 : ℕ) : R) = (3 : R) := rfl
 
-theorem cast_four [AddMonoidWithOne R] : ((4 : ℕ) : R) = (4 : R) := rfl
+theorem cast_four [NatCast R] : ((4 : ℕ) : R) = (4 : R) := rfl
 
 attribute [simp, norm_cast] Int.natAbs_ofNat
 

--- a/Mathlib/Data/Set/MulAntidiagonal.lean
+++ b/Mathlib/Data/Set/MulAntidiagonal.lean
@@ -40,12 +40,12 @@ end Mul
 
 -- The left hand side is not in simp normal form, see variant below.
 @[to_additive]
-theorem swap_mem_mulAntidiagonal [CommSemigroup α] {s t : Set α} {a : α} {x : α × α} :
+theorem swap_mem_mulAntidiagonal [CommMagma α] {s t : Set α} {a : α} {x : α × α} :
     x.swap ∈ Set.mulAntidiagonal s t a ↔ x ∈ Set.mulAntidiagonal t s a := by
   simp [mul_comm, and_left_comm]
 
 @[to_additive (attr := simp)]
-theorem swap_mem_mulAntidiagonal_aux [CommSemigroup α] {s t : Set α} {a : α} {x : α × α} :
+theorem swap_mem_mulAntidiagonal_aux [CommMagma α] {s t : Set α} {a : α} {x : α × α} :
     x.snd ∈ s ∧ x.fst ∈ t ∧ x.snd * x.fst = a
       ↔ x ∈ Set.mulAntidiagonal t s a := by
   simp [mul_comm, and_left_comm]

--- a/Mathlib/Data/ZMod/Basic.lean
+++ b/Mathlib/Data/ZMod/Basic.lean
@@ -1058,7 +1058,7 @@ theorem natAbs_min_of_le_div_two (n : ℕ) (x y : ℤ) (he : (x : ZMod n) = y) (
 
 end ZMod
 
-theorem RingHom.ext_zmod {n : ℕ} {R : Type*} [Semiring R] (f g : ZMod n →+* R) : f = g := by
+theorem RingHom.ext_zmod {n : ℕ} {R : Type*} [NonAssocSemiring R] (f g : ZMod n →+* R) : f = g := by
   ext a
   obtain ⟨k, rfl⟩ := ZMod.intCast_surjective a
   let φ : ℤ →+* R := f.comp (Int.castRingHom (ZMod n))
@@ -1079,19 +1079,19 @@ instance subsingleton_ringEquiv [Semiring R] : Subsingleton (ZMod n ≃+* R) :=
     apply RingHom.ext_zmod _ _⟩
 
 @[simp]
-theorem ringHom_map_cast [Ring R] (f : R →+* ZMod n) (k : ZMod n) : f (cast k) = k := by
+theorem ringHom_map_cast [NonAssocRing R] (f : R →+* ZMod n) (k : ZMod n) : f (cast k) = k := by
   cases n
   · dsimp [ZMod, ZMod.cast] at f k ⊢; simp
   · dsimp [ZMod.cast]
     rw [map_natCast, natCast_zmod_val]
 
 /-- Any ring homomorphism into `ZMod n` has a right inverse. -/
-theorem ringHom_rightInverse [Ring R] (f : R →+* ZMod n) :
+theorem ringHom_rightInverse [NonAssocRing R] (f : R →+* ZMod n) :
     Function.RightInverse (cast : ZMod n → R) f :=
   ringHom_map_cast f
 
 /-- Any ring homomorphism into `ZMod n` is surjective. -/
-theorem ringHom_surjective [Ring R] (f : R →+* ZMod n) : Function.Surjective f :=
+theorem ringHom_surjective [NonAssocRing R] (f : R →+* ZMod n) : Function.Surjective f :=
   (ringHom_rightInverse f).surjective
 
 @[simp]


### PR DESCRIPTION
This is one of a series of PRs that generalizes type classes across
Mathlib. These are generated using a new linter that tries to
re-elaborate theorem definitions with more general type classes to see
if it succeeds. It will accept the generalization if deleting the entire
type class causes the theorem to fail to compile, and the old type class
can not simply be re-synthesized with the new declaration. Otherwise, the
generalization is rejected as the type class is not being generalized,
but can simply be replaced by implicit type class synthesis or an
implicit type class in a variable block being pulled in.

The linter currently output debug statements indicating source file
positions where type classes should be generalized, and a script then
makes those edits. This file contains a subset of those generalizations.
The linter and the script performing re-writes is available in commit
5e2b7040be0f73821c1dcb360ffecd61235d87af.

Also see discussions on Zulip here:
* https://leanprover.zulipchat.com/#narrow/channel/270676-lean4/topic/Elab.20to.20generalize.20type.20classes.20for.20theorems/near/498862988
* https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Elab.20to.20generalize.20type.20classes.20for.20theorems/near/501288855