### PR TITLE
[Merged by Bors] - chore(Algebra/Group/Pointwise/Finset): drop unnecessary import

### DIFF
--- a/Mathlib/Algebra/Group/Pointwise/Finset/Basic.lean
+++ b/Mathlib/Algebra/Group/Pointwise/Finset/Basic.lean
@@ -8,7 +8,6 @@ import Mathlib.Algebra.Group.Pointwise.Set.Finite
 import Mathlib.Algebra.Group.Pointwise.Set.ListOfFn
 import Mathlib.Algebra.Order.Group.Nat
 import Mathlib.Algebra.Order.Monoid.Unbundled.WithTop
-import Mathlib.Algebra.Ring.Nat
 import Mathlib.Data.Finset.Max
 import Mathlib.Data.Finset.NAry
 import Mathlib.Data.Finset.Preimage
@@ -55,11 +54,7 @@ finset multiplication, finset addition, pointwise addition, pointwise multiplica
 pointwise subtraction
 -/
 
--- TODO
--- assert_not_exists MonoidWithZero
-assert_not_exists Cardinal
-assert_not_exists Finset.dens
-assert_not_exists MulAction
+assert_not_exists Cardinal Finset.dens MonoidWithZero MulAction
 
 open Function MulOpposite
 

--- a/Mathlib/Combinatorics/Additive/ETransform.lean
+++ b/Mathlib/Combinatorics/Additive/ETransform.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies
 -/
 import Mathlib.Algebra.Group.Action.Pointwise.Finset
+import Mathlib.Algebra.Ring.Nat
 
 /-!
 # e-transforms


### PR DESCRIPTION
The file `Mathlib.Algebra.Group.Pointwise.Finset.Basic` imported `Mathlib.Algebra.Ring.Nat` but it seems this import is actually unneeded. We can drop it and add the commented-out `assert_not_exists MonoidWithZero`.

Spotted while looking at potential files to split.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
