### PR TITLE
[Merged by Bors] - chore(Data/Set): split long file `Function.lean`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3238,6 +3238,7 @@ import Mathlib.Data.Set.Pairwise.Basic
 import Mathlib.Data.Set.Pairwise.Lattice
 import Mathlib.Data.Set.Pointwise.Support
 import Mathlib.Data.Set.Prod
+import Mathlib.Data.Set.Restrict
 import Mathlib.Data.Set.SMulAntidiagonal
 import Mathlib.Data.Set.Semiring
 import Mathlib.Data.Set.Sigma

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3236,6 +3236,7 @@ import Mathlib.Data.Set.Opposite
 import Mathlib.Data.Set.Order
 import Mathlib.Data.Set.Pairwise.Basic
 import Mathlib.Data.Set.Pairwise.Lattice
+import Mathlib.Data.Set.Piecewise
 import Mathlib.Data.Set.Pointwise.Support
 import Mathlib.Data.Set.Prod
 import Mathlib.Data.Set.Restrict

--- a/Mathlib/Algebra/Group/Action/Pi.lean
+++ b/Mathlib/Algebra/Group/Action/Pi.lean
@@ -5,7 +5,7 @@ Authors: Simon Hudon, Patrick Massot
 -/
 import Mathlib.Algebra.Group.Action.Faithful
 import Mathlib.Algebra.Group.Pi.Basic
-import Mathlib.Data.Set.Function
+import Mathlib.Data.Set.Piecewise
 
 /-!
 # Pi instances for multiplicative actions

--- a/Mathlib/Algebra/Group/Pi/Lemmas.lean
+++ b/Mathlib/Algebra/Group/Pi/Lemmas.lean
@@ -6,7 +6,7 @@ Authors: Simon Hudon, Patrick Massot
 import Mathlib.Algebra.Group.Commute.Defs
 import Mathlib.Algebra.Group.Hom.Instances
 import Mathlib.Algebra.Group.Pi.Basic
-import Mathlib.Data.Set.Function
+import Mathlib.Data.Set.Piecewise
 import Mathlib.Logic.Pairwise
 
 /-!

--- a/Mathlib/Data/Finset/Piecewise.lean
+++ b/Mathlib/Data/Finset/Piecewise.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sébastien Gouëzel
 -/
 import Mathlib.Data.Finset.BooleanAlgebra
+import Mathlib.Data.Set.Piecewise
 import Mathlib.Order.Interval.Set.Basic
 
 /-!

--- a/Mathlib/Data/Set/Function.lean
+++ b/Mathlib/Data/Set/Function.lean
@@ -4,14 +4,13 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Andrew Zipperer, Haitao Zhang, Minchao Wu, Yury Kudryashov
 -/
 import Mathlib.Data.Set.Prod
+import Mathlib.Data.Set.Restrict
 import Mathlib.Logic.Function.Conjugate
 
 /-!
 # Functions over sets
 
-## Main definitions
-
-### Predicate
+This file contains basic results on the following predicates of functions and sets:
 
 * `Set.EqOn f₁ f₂ s` : functions `f₁` and `f₂` are equal at every point of `s`;
 * `Set.MapsTo f s t` : `f` sends every point of `s` to a point of `t`;
@@ -22,13 +21,6 @@ import Mathlib.Logic.Function.Conjugate
 * `Set.RightInvOn f' f t` : for every `y ∈ t` we have `f (f' y) = y`;
 * `Set.InvOn f' f s t` : `f'` is a two-side inverse of `f` on `s` and `t`, i.e.
   we have `Set.LeftInvOn f' f s` and `Set.RightInvOn f' f t`.
-
-### Functions
-
-* `Set.restrict f s` : restrict the domain of `f` to the set `s`;
-* `Set.codRestrict f s h` : given `h : ∀ x, f x ∈ s`, restrict the codomain of `f` to the set `s`;
-* `Set.MapsTo.restrict f s t h`: given `h : MapsTo f s t`, restrict the domain of `f` to `s`
-  and the codomain to `t`.
 -/
 
 variable {α β γ δ : Type*} {ι : Sort*} {π : α → Type*}
@@ -36,132 +28,6 @@ variable {α β γ δ : Type*} {ι : Sort*} {π : α → Type*}
 open Equiv Equiv.Perm Function
 
 namespace Set
-
-/-! ### Restrict -/
-section restrict
-
-/-- Restrict domain of a function `f` to a set `s`. Same as `Subtype.restrict` but this version
-takes an argument `↥s` instead of `Subtype s`. -/
-def restrict (s : Set α) (f : ∀ a : α, π a) : ∀ a : s, π a := fun x => f x
-
-theorem restrict_def (s : Set α) : s.restrict (π := π) = fun f x ↦ f x := rfl
-
-theorem restrict_eq (f : α → β) (s : Set α) : s.restrict f = f ∘ Subtype.val :=
-  rfl
-
-@[simp]
-theorem restrict_apply (f : (a : α) → π a) (s : Set α) (x : s) : s.restrict f x = f x :=
-  rfl
-
-theorem restrict_eq_iff {f : ∀ a, π a} {s : Set α} {g : ∀ a : s, π a} :
-    restrict s f = g ↔ ∀ (a) (ha : a ∈ s), f a = g ⟨a, ha⟩ :=
-  funext_iff.trans Subtype.forall
-
-theorem eq_restrict_iff {s : Set α} {f : ∀ a : s, π a} {g : ∀ a, π a} :
-    f = restrict s g ↔ ∀ (a) (ha : a ∈ s), f ⟨a, ha⟩ = g a :=
-  funext_iff.trans Subtype.forall
-
-@[simp]
-theorem range_restrict (f : α → β) (s : Set α) : Set.range (s.restrict f) = f '' s :=
-  (range_comp _ _).trans <| congr_arg (f '' ·) Subtype.range_coe
-
-theorem image_restrict (f : α → β) (s t : Set α) :
-    s.restrict f '' (Subtype.val ⁻¹' t) = f '' (t ∩ s) := by
-  rw [restrict_eq, image_comp, image_preimage_eq_inter_range, Subtype.range_coe]
-
-@[simp]
-theorem restrict_dite {s : Set α} [∀ x, Decidable (x ∈ s)] (f : ∀ a ∈ s, β)
-    (g : ∀ a ∉ s, β) :
-    (s.restrict fun a => if h : a ∈ s then f a h else g a h) = (fun a : s => f a a.2) :=
-  funext fun a => dif_pos a.2
-
-@[simp]
-theorem restrict_dite_compl {s : Set α} [∀ x, Decidable (x ∈ s)] (f : ∀ a ∈ s, β)
-    (g : ∀ a ∉ s, β) :
-    (sᶜ.restrict fun a => if h : a ∈ s then f a h else g a h) = (fun a : (sᶜ : Set α) => g a a.2) :=
-  funext fun a => dif_neg a.2
-
-@[simp]
-theorem restrict_ite (f g : α → β) (s : Set α) [∀ x, Decidable (x ∈ s)] :
-    (s.restrict fun a => if a ∈ s then f a else g a) = s.restrict f :=
-  restrict_dite _ _
-
-@[simp]
-theorem restrict_ite_compl (f g : α → β) (s : Set α) [∀ x, Decidable (x ∈ s)] :
-    (sᶜ.restrict fun a => if a ∈ s then f a else g a) = sᶜ.restrict g :=
-  restrict_dite_compl _ _
-
-@[simp]
-theorem restrict_piecewise (f g : α → β) (s : Set α) [∀ x, Decidable (x ∈ s)] :
-    s.restrict (piecewise s f g) = s.restrict f :=
-  restrict_ite _ _ _
-
-@[simp]
-theorem restrict_piecewise_compl (f g : α → β) (s : Set α) [∀ x, Decidable (x ∈ s)] :
-    sᶜ.restrict (piecewise s f g) = sᶜ.restrict g :=
-  restrict_ite_compl _ _ _
-
-theorem restrict_extend_range (f : α → β) (g : α → γ) (g' : β → γ) :
-    (range f).restrict (extend f g g') = fun x => g x.coe_prop.choose := by
-  classical
-  exact restrict_dite _ _
-
-@[simp]
-theorem restrict_extend_compl_range (f : α → β) (g : α → γ) (g' : β → γ) :
-    (range f)ᶜ.restrict (extend f g g') = g' ∘ Subtype.val := by
-  classical
-  exact restrict_dite_compl _ _
-
-/-- If a function `f` is restricted to a set `t`, and `s ⊆ t`, this is the restriction to `s`. -/
-@[simp]
-def restrict₂ {s t : Set α} (hst : s ⊆ t) (f : ∀ a : t, π a) : ∀ a : s, π a :=
-  fun x => f ⟨x.1, hst x.2⟩
-
-theorem restrict₂_def {s t : Set α} (hst : s ⊆ t) :
-    restrict₂ (π := π) hst = fun f x ↦ f ⟨x.1, hst x.2⟩ := rfl
-
-theorem restrict₂_comp_restrict {s t : Set α} (hst : s ⊆ t) :
-    (restrict₂ (π := π) hst) ∘ t.restrict = s.restrict := rfl
-
-theorem restrict₂_comp_restrict₂ {s t u : Set α} (hst : s ⊆ t) (htu : t ⊆ u) :
-    (restrict₂ (π := π) hst) ∘ (restrict₂ htu) = restrict₂ (hst.trans htu) := rfl
-
-theorem range_extend_subset (f : α → β) (g : α → γ) (g' : β → γ) :
-    range (extend f g g') ⊆ range g ∪ g' '' (range f)ᶜ := by
-  classical
-  rintro _ ⟨y, rfl⟩
-  rw [extend_def]
-  split_ifs with h
-  exacts [Or.inl (mem_range_self _), Or.inr (mem_image_of_mem _ h)]
-
-theorem range_extend {f : α → β} (hf : Injective f) (g : α → γ) (g' : β → γ) :
-    range (extend f g g') = range g ∪ g' '' (range f)ᶜ := by
-  refine (range_extend_subset _ _ _).antisymm ?_
-  rintro z (⟨x, rfl⟩ | ⟨y, hy, rfl⟩)
-  exacts [⟨f x, hf.extend_apply _ _ _⟩, ⟨y, extend_apply' _ _ _ hy⟩]
-
-/-- Restrict codomain of a function `f` to a set `s`. Same as `Subtype.coind` but this version
-has codomain `↥s` instead of `Subtype s`. -/
-def codRestrict (f : ι → α) (s : Set α) (h : ∀ x, f x ∈ s) : ι → s := fun x => ⟨f x, h x⟩
-
-@[simp]
-theorem val_codRestrict_apply (f : ι → α) (s : Set α) (h : ∀ x, f x ∈ s) (x : ι) :
-    (codRestrict f s h x : α) = f x :=
-  rfl
-
-@[simp]
-theorem restrict_comp_codRestrict {f : ι → α} {g : α → β} {b : Set α} (h : ∀ x, f x ∈ b) :
-    b.restrict g ∘ b.codRestrict f h = g ∘ f :=
-  rfl
-
-@[simp]
-theorem injective_codRestrict {f : ι → α} {s : Set α} (h : ∀ x, f x ∈ s) :
-    Injective (codRestrict f s h) ↔ Injective f := by
-  simp only [Injective, Subtype.ext_iff, val_codRestrict_apply]
-
-alias ⟨_, _root_.Function.Injective.codRestrict⟩ := injective_codRestrict
-
-end restrict
 
 /-! ### Equality on a set -/
 section equality
@@ -178,10 +44,6 @@ theorem eqOn_singleton : Set.EqOn f₁ f₂ {a} ↔ f₁ a = f₂ a := by
 @[simp]
 theorem eqOn_univ (f₁ f₂ : α → β) : EqOn f₁ f₂ univ ↔ f₁ = f₂ := by
   simp [EqOn, funext_iff]
-
-@[simp]
-theorem restrict_eq_restrict_iff : restrict s f₁ = restrict s f₂ ↔ EqOn f₁ f₂ s :=
-  restrict_eq_iff
 
 @[symm]
 theorem EqOn.symm (h : EqOn f₁ f₂ s) : EqOn f₂ f₁ s := fun _ hx => (h hx).symm
@@ -236,44 +98,6 @@ variable {s s₁ s₂ : Set α} {t t₁ t₂ : Set β} {p : Set γ} {f f₁ f₂
   {f' f₁' f₂' : β → α} {g' : γ → β} {a : α} {b : β}
 
 section MapsTo
-
-theorem MapsTo.restrict_commutes (f : α → β) (s : Set α) (t : Set β) (h : MapsTo f s t) :
-    Subtype.val ∘ h.restrict f s t = f ∘ Subtype.val :=
-  rfl
-
-@[simp]
-theorem MapsTo.val_restrict_apply (h : MapsTo f s t) (x : s) : (h.restrict f s t x : β) = f x :=
-  rfl
-
-theorem MapsTo.coe_iterate_restrict {f : α → α} (h : MapsTo f s s) (x : s) (k : ℕ) :
-    h.restrict^[k] x = f^[k] x := by
-  induction k with
-  | zero => simp
-  | succ k ih => simp only [iterate_succ', comp_apply, val_restrict_apply, ih]
-
-/-- Restricting the domain and then the codomain is the same as `MapsTo.restrict`. -/
-@[simp]
-theorem codRestrict_restrict (h : ∀ x : s, f x ∈ t) :
-    codRestrict (s.restrict f) t h = MapsTo.restrict f s t fun x hx => h ⟨x, hx⟩ :=
-  rfl
-
-/-- Reverse of `Set.codRestrict_restrict`. -/
-theorem MapsTo.restrict_eq_codRestrict (h : MapsTo f s t) :
-    h.restrict f s t = codRestrict (s.restrict f) t fun x => h x.2 :=
-  rfl
-
-theorem MapsTo.coe_restrict (h : Set.MapsTo f s t) :
-    Subtype.val ∘ h.restrict f s t = s.restrict f :=
-  rfl
-
-theorem MapsTo.range_restrict (f : α → β) (s : Set α) (t : Set β) (h : MapsTo f s t) :
-    range (h.restrict f s t) = Subtype.val ⁻¹' (f '' s) :=
-  Set.range_subtype_map f h
-
-theorem mapsTo_iff_exists_map_subtype : MapsTo f s t ↔ ∃ g : s → t, ∀ x : s, f x = g x :=
-  ⟨fun h => ⟨h.restrict f s t, fun _ => rfl⟩, fun ⟨g, hg⟩ x hx => by
-    rw [hg ⟨x, hx⟩]
-    apply Subtype.coe_prop⟩
 
 theorem mapsTo' : MapsTo f s t ↔ f '' s ⊆ t :=
   image_subset_iff.symm
@@ -398,58 +222,10 @@ lemma mapsTo_univ_iff : MapsTo f univ t ↔ ∀ x, f x ∈ t :=
 lemma mapsTo_range_iff {g : ι → α} : MapsTo f (range g) t ↔ ∀ i, f (g i) ∈ t :=
   forall_mem_range
 
-theorem surjective_mapsTo_image_restrict (f : α → β) (s : Set α) :
-    Surjective ((mapsTo_image f s).restrict f s (f '' s)) := fun ⟨_, x, hs, hxy⟩ =>
-  ⟨⟨x, hs⟩, Subtype.ext hxy⟩
-
 theorem MapsTo.mem_iff (h : MapsTo f s t) (hc : MapsTo f sᶜ tᶜ) {x} : f x ∈ t ↔ x ∈ s :=
   ⟨fun ht => by_contra fun hs => hc hs ht, fun hx => h hx⟩
 
 end MapsTo
-
-/-! ### Restriction onto preimage -/
-section
-
-variable (t)
-
-variable (f s) in
-theorem image_restrictPreimage :
-    t.restrictPreimage f '' (Subtype.val ⁻¹' s) = Subtype.val ⁻¹' (f '' s) := by
-  delta Set.restrictPreimage
-  rw [← (Subtype.coe_injective).image_injective.eq_iff, ← image_comp, MapsTo.restrict_commutes,
-    image_comp, Subtype.image_preimage_coe, Subtype.image_preimage_coe, image_preimage_inter]
-
-variable (f) in
-theorem range_restrictPreimage : range (t.restrictPreimage f) = Subtype.val ⁻¹' range f := by
-  simp only [← image_univ, ← image_restrictPreimage, preimage_univ]
-
-@[simp]
-theorem restrictPreimage_mk (h : a ∈ f ⁻¹' t) : t.restrictPreimage f ⟨a, h⟩ = ⟨f a, h⟩ := rfl
-
-theorem image_val_preimage_restrictPreimage {u : Set t} :
-    Subtype.val '' (t.restrictPreimage f ⁻¹' u) = f ⁻¹' (Subtype.val '' u) := by
-  ext
-  simp
-
-theorem preimage_restrictPreimage {u : Set t} :
-    t.restrictPreimage f ⁻¹' u = (fun a : f ⁻¹' t ↦ f a) ⁻¹' (Subtype.val '' u) := by
-  rw [← preimage_preimage (g := f) (f := Subtype.val), ← image_val_preimage_restrictPreimage,
-    preimage_image_eq _ Subtype.val_injective]
-
-lemma restrictPreimage_injective (hf : Injective f) : Injective (t.restrictPreimage f) :=
-  fun _ _ e => Subtype.coe_injective <| hf <| Subtype.mk.inj e
-
-lemma restrictPreimage_surjective (hf : Surjective f) : Surjective (t.restrictPreimage f) :=
-  fun x => ⟨⟨_, ((hf x).choose_spec.symm ▸ x.2 : _ ∈ t)⟩, Subtype.ext (hf x).choose_spec⟩
-
-lemma restrictPreimage_bijective (hf : Bijective f) : Bijective (t.restrictPreimage f) :=
-  ⟨t.restrictPreimage_injective hf.1, t.restrictPreimage_surjective hf.2⟩
-
-alias _root_.Function.Injective.restrictPreimage := Set.restrictPreimage_injective
-alias _root_.Function.Surjective.restrictPreimage := Set.restrictPreimage_surjective
-alias _root_.Function.Bijective.restrictPreimage := Set.restrictPreimage_bijective
-
-end
 
 /-! ### Injectivity on a set -/
 section injOn
@@ -535,15 +311,6 @@ theorem _root_.Function.Injective.injOn_range (h : Injective (g ∘ f)) : InjOn 
 theorem _root_.Set.InjOn.injective_iff (s : Set β) (h : InjOn g s) (hs : range f ⊆ s) :
     Injective (g ∘ f) ↔ Injective f :=
   ⟨(·.of_comp), fun h _ ↦ by aesop⟩
-
-theorem injOn_iff_injective : InjOn f s ↔ Injective (s.restrict f) :=
-  ⟨fun H a b h => Subtype.eq <| H a.2 b.2 h, fun H a as b bs h =>
-    congr_arg Subtype.val <| @H ⟨a, as⟩ ⟨b, bs⟩ h⟩
-
-alias ⟨InjOn.injective, _⟩ := Set.injOn_iff_injective
-
-theorem MapsTo.restrict_inj (h : MapsTo f s t) : Injective (h.restrict f s t) ↔ InjOn f s := by
-  rw [h.restrict_eq_codRestrict, injective_codRestrict, injOn_iff_injective]
 
 theorem exists_injOn_iff_injective [Nonempty β] :
     (∃ f : α → β, InjOn f s) ↔ ∃ f : s → β, Injective f :=
@@ -789,25 +556,6 @@ lemma surjOn_of_subsingleton [Subsingleton α] (f : α → α) (s : Set α) : Su
 
 theorem surjective_iff_surjOn_univ : Surjective f ↔ SurjOn f univ univ := by
   simp [Surjective, SurjOn, subset_def]
-
-theorem surjOn_iff_surjective : SurjOn f s univ ↔ Surjective (s.restrict f) :=
-  ⟨fun H b =>
-    let ⟨a, as, e⟩ := @H b trivial
-    ⟨⟨a, as⟩, e⟩,
-    fun H b _ =>
-    let ⟨⟨a, as⟩, e⟩ := H b
-    ⟨a, as, e⟩⟩
-
-@[simp]
-theorem MapsTo.restrict_surjective_iff (h : MapsTo f s t) :
-    Surjective (MapsTo.restrict _ _ _ h) ↔ SurjOn f s t := by
-  refine ⟨fun h' b hb ↦ ?_, fun h' ⟨b, hb⟩ ↦ ?_⟩
-  · obtain ⟨⟨a, ha⟩, ha'⟩ := h' ⟨b, hb⟩
-    replace ha' : f a = b := by simpa [Subtype.ext_iff] using ha'
-    rw [← ha']
-    exact mem_image_of_mem f ha
-  · obtain ⟨a, ha, rfl⟩ := h' hb
-    exact ⟨⟨a, ha⟩, rfl⟩
 
 theorem SurjOn.image_eq_of_mapsTo (h₁ : SurjOn f s t) (h₂ : MapsTo f s t) : f '' s = t :=
   eq_of_subset_of_subset h₂.image_subset h₁
@@ -1730,5 +1478,3 @@ lemma exists_eq_mgraphOn_univ {s : Set (β × γ)}
     fun a b h ↦ congr_arg (Prod.snd ∘ (Subtype.val : s → β × γ)) (hs₁.injective h)
 
 end Set
-
-set_option linter.style.longFile 1800

--- a/Mathlib/Data/Set/Piecewise.lean
+++ b/Mathlib/Data/Set/Piecewise.lean
@@ -1,0 +1,178 @@
+/-
+Copyright (c) 2014 Jeremy Avigad. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jeremy Avigad, Andrew Zipperer, Haitao Zhang, Minchao Wu, Yury Kudryashov
+-/
+import Mathlib.Data.Set.Function
+
+/-!
+# Piecewise functions
+
+This file contains basic results on piecewise defined functions.
+-/
+
+variable {α β γ δ : Type*} {ι : Sort*} {π : α → Type*}
+
+open Equiv Equiv.Perm Function
+
+namespace Set
+
+variable {δ : α → Sort*} (s : Set α) (f g : ∀ i, δ i)
+
+@[simp]
+theorem piecewise_empty [∀ i : α, Decidable (i ∈ (∅ : Set α))] : piecewise ∅ f g = g := by
+  ext i
+  simp [piecewise]
+
+@[simp]
+theorem piecewise_univ [∀ i : α, Decidable (i ∈ (Set.univ : Set α))] :
+    piecewise Set.univ f g = f := by
+  ext i
+  simp [piecewise]
+
+theorem piecewise_insert_self {j : α} [∀ i, Decidable (i ∈ insert j s)] :
+    (insert j s).piecewise f g j = f j := by simp [piecewise]
+
+variable [∀ j, Decidable (j ∈ s)]
+
+theorem piecewise_insert [DecidableEq α] (j : α) [∀ i, Decidable (i ∈ insert j s)] :
+    (insert j s).piecewise f g = Function.update (s.piecewise f g) j (f j) := by
+  simp (config := { unfoldPartialApp := true }) only [piecewise, mem_insert_iff]
+  ext i
+  by_cases h : i = j
+  · rw [h]
+    simp
+  · by_cases h' : i ∈ s <;> simp [h, h']
+
+@[simp]
+theorem piecewise_eq_of_mem {i : α} (hi : i ∈ s) : s.piecewise f g i = f i :=
+  if_pos hi
+
+@[simp]
+theorem piecewise_eq_of_not_mem {i : α} (hi : i ∉ s) : s.piecewise f g i = g i :=
+  if_neg hi
+
+theorem piecewise_singleton (x : α) [∀ y, Decidable (y ∈ ({x} : Set α))] [DecidableEq α]
+    (f g : α → β) : piecewise {x} f g = Function.update g x (f x) := by
+  ext y
+  by_cases hy : y = x
+  · subst y
+    simp
+  · simp [hy]
+
+theorem piecewise_eqOn (f g : α → β) : EqOn (s.piecewise f g) f s := fun _ =>
+  piecewise_eq_of_mem _ _ _
+
+theorem piecewise_eqOn_compl (f g : α → β) : EqOn (s.piecewise f g) g sᶜ := fun _ =>
+  piecewise_eq_of_not_mem _ _ _
+
+theorem piecewise_le {δ : α → Type*} [∀ i, Preorder (δ i)] {s : Set α} [∀ j, Decidable (j ∈ s)]
+    {f₁ f₂ g : ∀ i, δ i} (h₁ : ∀ i ∈ s, f₁ i ≤ g i) (h₂ : ∀ i ∉ s, f₂ i ≤ g i) :
+    s.piecewise f₁ f₂ ≤ g := fun i => if h : i ∈ s then by simp [*] else by simp [*]
+
+theorem le_piecewise {δ : α → Type*} [∀ i, Preorder (δ i)] {s : Set α} [∀ j, Decidable (j ∈ s)]
+    {f₁ f₂ g : ∀ i, δ i} (h₁ : ∀ i ∈ s, g i ≤ f₁ i) (h₂ : ∀ i ∉ s, g i ≤ f₂ i) :
+    g ≤ s.piecewise f₁ f₂ :=
+  @piecewise_le α (fun i => (δ i)ᵒᵈ) _ s _ _ _ _ h₁ h₂
+
+@[gcongr]
+theorem piecewise_mono {δ : α → Type*} [∀ i, Preorder (δ i)] {s : Set α}
+    [∀ j, Decidable (j ∈ s)] {f₁ f₂ g₁ g₂ : ∀ i, δ i} (h₁ : ∀ i ∈ s, f₁ i ≤ g₁ i)
+    (h₂ : ∀ i ∉ s, f₂ i ≤ g₂ i) : s.piecewise f₁ f₂ ≤ s.piecewise g₁ g₂ := by
+  apply piecewise_le <;> intros <;> simp [*]
+
+@[deprecated (since := "2024-10-06")] alias piecewise_le_piecewise := piecewise_mono
+
+@[simp]
+theorem piecewise_insert_of_ne {i j : α} (h : i ≠ j) [∀ i, Decidable (i ∈ insert j s)] :
+    (insert j s).piecewise f g i = s.piecewise f g i := by simp [piecewise, h]
+
+@[simp]
+theorem piecewise_compl [∀ i, Decidable (i ∈ sᶜ)] : sᶜ.piecewise f g = s.piecewise g f :=
+  funext fun x => if hx : x ∈ s then by simp [hx] else by simp [hx]
+
+@[simp]
+theorem piecewise_range_comp {ι : Sort*} (f : ι → α) [∀ j, Decidable (j ∈ range f)]
+    (g₁ g₂ : α → β) : (range f).piecewise g₁ g₂ ∘ f = g₁ ∘ f :=
+  (piecewise_eqOn ..).comp_eq
+
+theorem MapsTo.piecewise_ite {s s₁ s₂ : Set α} {t t₁ t₂ : Set β} {f₁ f₂ : α → β}
+    [∀ i, Decidable (i ∈ s)] (h₁ : MapsTo f₁ (s₁ ∩ s) (t₁ ∩ t))
+    (h₂ : MapsTo f₂ (s₂ ∩ sᶜ) (t₂ ∩ tᶜ)) :
+    MapsTo (s.piecewise f₁ f₂) (s.ite s₁ s₂) (t.ite t₁ t₂) := by
+  refine (h₁.congr ?_).union_union (h₂.congr ?_)
+  exacts [(piecewise_eqOn s f₁ f₂).symm.mono inter_subset_right,
+    (piecewise_eqOn_compl s f₁ f₂).symm.mono inter_subset_right]
+
+theorem eqOn_piecewise {f f' g : α → β} {t} :
+    EqOn (s.piecewise f f') g t ↔ EqOn f g (t ∩ s) ∧ EqOn f' g (t ∩ sᶜ) := by
+  simp only [EqOn, ← forall_and]
+  refine forall_congr' fun a => ?_; by_cases a ∈ s <;> simp [*]
+
+theorem EqOn.piecewise_ite' {f f' g : α → β} {t t'} (h : EqOn f g (t ∩ s))
+    (h' : EqOn f' g (t' ∩ sᶜ)) : EqOn (s.piecewise f f') g (s.ite t t') := by
+  simp [eqOn_piecewise, *]
+
+theorem EqOn.piecewise_ite {f f' g : α → β} {t t'} (h : EqOn f g t) (h' : EqOn f' g t') :
+    EqOn (s.piecewise f f') g (s.ite t t') :=
+  (h.mono inter_subset_left).piecewise_ite' s (h'.mono inter_subset_left)
+
+theorem piecewise_preimage (f g : α → β) (t) : s.piecewise f g ⁻¹' t = s.ite (f ⁻¹' t) (g ⁻¹' t) :=
+  ext fun x => by by_cases x ∈ s <;> simp [*, Set.ite]
+
+theorem apply_piecewise {δ' : α → Sort*} (h : ∀ i, δ i → δ' i) {x : α} :
+    h x (s.piecewise f g x) = s.piecewise (fun x => h x (f x)) (fun x => h x (g x)) x := by
+  by_cases hx : x ∈ s <;> simp [hx]
+
+theorem apply_piecewise₂ {δ' δ'' : α → Sort*} (f' g' : ∀ i, δ' i) (h : ∀ i, δ i → δ' i → δ'' i)
+    {x : α} :
+    h x (s.piecewise f g x) (s.piecewise f' g' x) =
+      s.piecewise (fun x => h x (f x) (f' x)) (fun x => h x (g x) (g' x)) x := by
+  by_cases hx : x ∈ s <;> simp [hx]
+
+theorem piecewise_op {δ' : α → Sort*} (h : ∀ i, δ i → δ' i) :
+    (s.piecewise (fun x => h x (f x)) fun x => h x (g x)) = fun x => h x (s.piecewise f g x) :=
+  funext fun _ => (apply_piecewise _ _ _ _).symm
+
+theorem piecewise_op₂ {δ' δ'' : α → Sort*} (f' g' : ∀ i, δ' i) (h : ∀ i, δ i → δ' i → δ'' i) :
+    (s.piecewise (fun x => h x (f x) (f' x)) fun x => h x (g x) (g' x)) = fun x =>
+      h x (s.piecewise f g x) (s.piecewise f' g' x) :=
+  funext fun _ => (apply_piecewise₂ _ _ _ _ _ _).symm
+
+@[simp]
+theorem piecewise_same : s.piecewise f f = f := by
+  ext x
+  by_cases hx : x ∈ s <;> simp [hx]
+
+theorem range_piecewise (f g : α → β) : range (s.piecewise f g) = f '' s ∪ g '' sᶜ := by
+  ext y; constructor
+  · rintro ⟨x, rfl⟩
+    by_cases h : x ∈ s <;> [left; right] <;> use x <;> simp [h]
+  · rintro (⟨x, hx, rfl⟩ | ⟨x, hx, rfl⟩) <;> use x <;> simp_all
+
+theorem injective_piecewise_iff {f g : α → β} :
+    Injective (s.piecewise f g) ↔
+      InjOn f s ∧ InjOn g sᶜ ∧ ∀ x ∈ s, ∀ y ∉ s, f x ≠ g y := by
+  rw [injective_iff_injOn_univ, ← union_compl_self s, injOn_union (@disjoint_compl_right _ _ s),
+    (piecewise_eqOn s f g).injOn_iff, (piecewise_eqOn_compl s f g).injOn_iff]
+  refine and_congr Iff.rfl (and_congr Iff.rfl <| forall₄_congr fun x hx y hy => ?_)
+  rw [piecewise_eq_of_mem s f g hx, piecewise_eq_of_not_mem s f g hy]
+
+theorem piecewise_mem_pi {δ : α → Type*} {t : Set α} {t' : ∀ i, Set (δ i)} {f g} (hf : f ∈ pi t t')
+    (hg : g ∈ pi t t') : s.piecewise f g ∈ pi t t' := by
+  intro i ht
+  by_cases hs : i ∈ s <;> simp [hf i ht, hg i ht, hs]
+
+@[simp]
+theorem pi_piecewise {ι : Type*} {α : ι → Type*} (s s' : Set ι) (t t' : ∀ i, Set (α i))
+    [∀ x, Decidable (x ∈ s')] : pi s (s'.piecewise t t') = pi (s ∩ s') t ∩ pi (s \ s') t' :=
+  pi_if _ _ _
+
+theorem univ_pi_piecewise {ι : Type*} {α : ι → Type*} (s : Set ι) (t t' : ∀ i, Set (α i))
+    [∀ x, Decidable (x ∈ s)] : pi univ (s.piecewise t t') = pi s t ∩ pi sᶜ t' := by
+  simp [compl_eq_univ_diff]
+
+theorem univ_pi_piecewise_univ {ι : Type*} {α : ι → Type*} (s : Set ι) (t : ∀ i, Set (α i))
+    [∀ x, Decidable (x ∈ s)] : pi univ (s.piecewise t fun _ => univ) = pi s t := by simp
+
+end Set

--- a/Mathlib/Data/Set/Restrict.lean
+++ b/Mathlib/Data/Set/Restrict.lean
@@ -1,0 +1,287 @@
+/-
+Copyright (c) 2014 Jeremy Avigad. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jeremy Avigad, Andrew Zipperer, Haitao Zhang, Minchao Wu, Yury Kudryashov
+-/
+import Mathlib.Data.Set.Prod
+import Mathlib.Logic.Function.Conjugate
+
+/-!
+# Restrict the domain of a function to a set
+
+## Main definitions
+
+* `Set.restrict f s` : restrict the domain of `f` to the set `s`;
+* `Set.codRestrict f s h` : given `h : ∀ x, f x ∈ s`, restrict the codomain of `f` to the set `s`;
+-/
+
+variable {α β γ δ : Type*} {ι : Sort*} {π : α → Type*}
+
+open Equiv Equiv.Perm Function
+
+namespace Set
+
+/-! ### Restrict -/
+section restrict
+
+/-- Restrict domain of a function `f` to a set `s`. Same as `Subtype.restrict` but this version
+takes an argument `↥s` instead of `Subtype s`. -/
+def restrict (s : Set α) (f : ∀ a : α, π a) : ∀ a : s, π a := fun x => f x
+
+theorem restrict_def (s : Set α) : s.restrict (π := π) = fun f x ↦ f x := rfl
+
+theorem restrict_eq (f : α → β) (s : Set α) : s.restrict f = f ∘ Subtype.val :=
+  rfl
+
+@[simp]
+theorem restrict_apply (f : (a : α) → π a) (s : Set α) (x : s) : s.restrict f x = f x :=
+  rfl
+
+theorem restrict_eq_iff {f : ∀ a, π a} {s : Set α} {g : ∀ a : s, π a} :
+    restrict s f = g ↔ ∀ (a) (ha : a ∈ s), f a = g ⟨a, ha⟩ :=
+  funext_iff.trans Subtype.forall
+
+theorem eq_restrict_iff {s : Set α} {f : ∀ a : s, π a} {g : ∀ a, π a} :
+    f = restrict s g ↔ ∀ (a) (ha : a ∈ s), f ⟨a, ha⟩ = g a :=
+  funext_iff.trans Subtype.forall
+
+@[simp]
+theorem range_restrict (f : α → β) (s : Set α) : Set.range (s.restrict f) = f '' s :=
+  (range_comp _ _).trans <| congr_arg (f '' ·) Subtype.range_coe
+
+theorem image_restrict (f : α → β) (s t : Set α) :
+    s.restrict f '' (Subtype.val ⁻¹' t) = f '' (t ∩ s) := by
+  rw [restrict_eq, image_comp, image_preimage_eq_inter_range, Subtype.range_coe]
+
+@[simp]
+theorem restrict_dite {s : Set α} [∀ x, Decidable (x ∈ s)] (f : ∀ a ∈ s, β)
+    (g : ∀ a ∉ s, β) :
+    (s.restrict fun a => if h : a ∈ s then f a h else g a h) = (fun a : s => f a a.2) :=
+  funext fun a => dif_pos a.2
+
+@[simp]
+theorem restrict_dite_compl {s : Set α} [∀ x, Decidable (x ∈ s)] (f : ∀ a ∈ s, β)
+    (g : ∀ a ∉ s, β) :
+    (sᶜ.restrict fun a => if h : a ∈ s then f a h else g a h) = (fun a : (sᶜ : Set α) => g a a.2) :=
+  funext fun a => dif_neg a.2
+
+@[simp]
+theorem restrict_ite (f g : α → β) (s : Set α) [∀ x, Decidable (x ∈ s)] :
+    (s.restrict fun a => if a ∈ s then f a else g a) = s.restrict f :=
+  restrict_dite _ _
+
+@[simp]
+theorem restrict_ite_compl (f g : α → β) (s : Set α) [∀ x, Decidable (x ∈ s)] :
+    (sᶜ.restrict fun a => if a ∈ s then f a else g a) = sᶜ.restrict g :=
+  restrict_dite_compl _ _
+
+@[simp]
+theorem restrict_piecewise (f g : α → β) (s : Set α) [∀ x, Decidable (x ∈ s)] :
+    s.restrict (piecewise s f g) = s.restrict f :=
+  restrict_ite _ _ _
+
+@[simp]
+theorem restrict_piecewise_compl (f g : α → β) (s : Set α) [∀ x, Decidable (x ∈ s)] :
+    sᶜ.restrict (piecewise s f g) = sᶜ.restrict g :=
+  restrict_ite_compl _ _ _
+
+theorem restrict_extend_range (f : α → β) (g : α → γ) (g' : β → γ) :
+    (range f).restrict (extend f g g') = fun x => g x.coe_prop.choose := by
+  classical
+  exact restrict_dite _ _
+
+@[simp]
+theorem restrict_extend_compl_range (f : α → β) (g : α → γ) (g' : β → γ) :
+    (range f)ᶜ.restrict (extend f g g') = g' ∘ Subtype.val := by
+  classical
+  exact restrict_dite_compl _ _
+
+/-- If a function `f` is restricted to a set `t`, and `s ⊆ t`, this is the restriction to `s`. -/
+@[simp]
+def restrict₂ {s t : Set α} (hst : s ⊆ t) (f : ∀ a : t, π a) : ∀ a : s, π a :=
+  fun x => f ⟨x.1, hst x.2⟩
+
+theorem restrict₂_def {s t : Set α} (hst : s ⊆ t) :
+    restrict₂ (π := π) hst = fun f x ↦ f ⟨x.1, hst x.2⟩ := rfl
+
+theorem restrict₂_comp_restrict {s t : Set α} (hst : s ⊆ t) :
+    (restrict₂ (π := π) hst) ∘ t.restrict = s.restrict := rfl
+
+theorem restrict₂_comp_restrict₂ {s t u : Set α} (hst : s ⊆ t) (htu : t ⊆ u) :
+    (restrict₂ (π := π) hst) ∘ (restrict₂ htu) = restrict₂ (hst.trans htu) := rfl
+
+theorem range_extend_subset (f : α → β) (g : α → γ) (g' : β → γ) :
+    range (extend f g g') ⊆ range g ∪ g' '' (range f)ᶜ := by
+  classical
+  rintro _ ⟨y, rfl⟩
+  rw [extend_def]
+  split_ifs with h
+  exacts [Or.inl (mem_range_self _), Or.inr (mem_image_of_mem _ h)]
+
+theorem range_extend {f : α → β} (hf : Injective f) (g : α → γ) (g' : β → γ) :
+    range (extend f g g') = range g ∪ g' '' (range f)ᶜ := by
+  refine (range_extend_subset _ _ _).antisymm ?_
+  rintro z (⟨x, rfl⟩ | ⟨y, hy, rfl⟩)
+  exacts [⟨f x, hf.extend_apply _ _ _⟩, ⟨y, extend_apply' _ _ _ hy⟩]
+
+/-- Restrict codomain of a function `f` to a set `s`. Same as `Subtype.coind` but this version
+has codomain `↥s` instead of `Subtype s`. -/
+def codRestrict (f : ι → α) (s : Set α) (h : ∀ x, f x ∈ s) : ι → s := fun x => ⟨f x, h x⟩
+
+@[simp]
+theorem val_codRestrict_apply (f : ι → α) (s : Set α) (h : ∀ x, f x ∈ s) (x : ι) :
+    (codRestrict f s h x : α) = f x :=
+  rfl
+
+@[simp]
+theorem restrict_comp_codRestrict {f : ι → α} {g : α → β} {b : Set α} (h : ∀ x, f x ∈ b) :
+    b.restrict g ∘ b.codRestrict f h = g ∘ f :=
+  rfl
+
+@[simp]
+theorem injective_codRestrict {f : ι → α} {s : Set α} (h : ∀ x, f x ∈ s) :
+    Injective (codRestrict f s h) ↔ Injective f := by
+  simp only [Injective, Subtype.ext_iff, val_codRestrict_apply]
+
+alias ⟨_, _root_.Function.Injective.codRestrict⟩ := injective_codRestrict
+
+variable {s : Set α} {f₁ f₂ : α → β}
+
+@[simp]
+theorem restrict_eq_restrict_iff : restrict s f₁ = restrict s f₂ ↔ EqOn f₁ f₂ s :=
+  restrict_eq_iff
+
+end restrict
+
+variable {s s₁ s₂ : Set α} {t t₁ t₂ : Set β} {p : Set γ} {f f₁ f₂ : α → β} {g g₁ g₂ : β → γ}
+  {f' f₁' f₂' : β → α} {g' : γ → β} {a : α} {b : β}
+
+section MapsTo
+
+theorem MapsTo.restrict_commutes (f : α → β) (s : Set α) (t : Set β) (h : MapsTo f s t) :
+    Subtype.val ∘ h.restrict f s t = f ∘ Subtype.val :=
+  rfl
+
+@[simp]
+theorem MapsTo.val_restrict_apply (h : MapsTo f s t) (x : s) : (h.restrict f s t x : β) = f x :=
+  rfl
+
+theorem MapsTo.coe_iterate_restrict {f : α → α} (h : MapsTo f s s) (x : s) (k : ℕ) :
+    h.restrict^[k] x = f^[k] x := by
+  induction k with
+  | zero => simp
+  | succ k ih => simp only [iterate_succ', comp_apply, val_restrict_apply, ih]
+
+/-- Restricting the domain and then the codomain is the same as `MapsTo.restrict`. -/
+@[simp]
+theorem codRestrict_restrict (h : ∀ x : s, f x ∈ t) :
+    codRestrict (s.restrict f) t h = MapsTo.restrict f s t fun x hx => h ⟨x, hx⟩ :=
+  rfl
+
+/-- Reverse of `Set.codRestrict_restrict`. -/
+theorem MapsTo.restrict_eq_codRestrict (h : MapsTo f s t) :
+    h.restrict f s t = codRestrict (s.restrict f) t fun x => h x.2 :=
+  rfl
+
+theorem MapsTo.coe_restrict (h : Set.MapsTo f s t) :
+    Subtype.val ∘ h.restrict f s t = s.restrict f :=
+  rfl
+
+theorem MapsTo.range_restrict (f : α → β) (s : Set α) (t : Set β) (h : MapsTo f s t) :
+    range (h.restrict f s t) = Subtype.val ⁻¹' (f '' s) :=
+  Set.range_subtype_map f h
+
+theorem mapsTo_iff_exists_map_subtype : MapsTo f s t ↔ ∃ g : s → t, ∀ x : s, f x = g x :=
+  ⟨fun h => ⟨h.restrict f s t, fun _ => rfl⟩, fun ⟨g, hg⟩ x hx => by
+    rw [hg ⟨x, hx⟩]
+    apply Subtype.coe_prop⟩
+
+theorem surjective_mapsTo_image_restrict (f : α → β) (s : Set α) :
+    Surjective ((mapsTo_image f s).restrict f s (f '' s)) := fun ⟨_, x, hs, hxy⟩ =>
+  ⟨⟨x, hs⟩, Subtype.ext hxy⟩
+
+end MapsTo
+
+/-! ### Restriction onto preimage -/
+section
+
+variable (t)
+
+variable (f s) in
+theorem image_restrictPreimage :
+    t.restrictPreimage f '' (Subtype.val ⁻¹' s) = Subtype.val ⁻¹' (f '' s) := by
+  delta Set.restrictPreimage
+  rw [← (Subtype.coe_injective).image_injective.eq_iff, ← image_comp, MapsTo.restrict_commutes,
+    image_comp, Subtype.image_preimage_coe, Subtype.image_preimage_coe, image_preimage_inter]
+
+variable (f) in
+theorem range_restrictPreimage : range (t.restrictPreimage f) = Subtype.val ⁻¹' range f := by
+  simp only [← image_univ, ← image_restrictPreimage, preimage_univ]
+
+@[simp]
+theorem restrictPreimage_mk (h : a ∈ f ⁻¹' t) : t.restrictPreimage f ⟨a, h⟩ = ⟨f a, h⟩ := rfl
+
+theorem image_val_preimage_restrictPreimage {u : Set t} :
+    Subtype.val '' (t.restrictPreimage f ⁻¹' u) = f ⁻¹' (Subtype.val '' u) := by
+  ext
+  simp
+
+theorem preimage_restrictPreimage {u : Set t} :
+    t.restrictPreimage f ⁻¹' u = (fun a : f ⁻¹' t ↦ f a) ⁻¹' (Subtype.val '' u) := by
+  rw [← preimage_preimage (g := f) (f := Subtype.val), ← image_val_preimage_restrictPreimage,
+    preimage_image_eq _ Subtype.val_injective]
+
+lemma restrictPreimage_injective (hf : Injective f) : Injective (t.restrictPreimage f) :=
+  fun _ _ e => Subtype.coe_injective <| hf <| Subtype.mk.inj e
+
+lemma restrictPreimage_surjective (hf : Surjective f) : Surjective (t.restrictPreimage f) :=
+  fun x => ⟨⟨_, ((hf x).choose_spec.symm ▸ x.2 : _ ∈ t)⟩, Subtype.ext (hf x).choose_spec⟩
+
+lemma restrictPreimage_bijective (hf : Bijective f) : Bijective (t.restrictPreimage f) :=
+  ⟨t.restrictPreimage_injective hf.1, t.restrictPreimage_surjective hf.2⟩
+
+alias _root_.Function.Injective.restrictPreimage := Set.restrictPreimage_injective
+alias _root_.Function.Surjective.restrictPreimage := Set.restrictPreimage_surjective
+alias _root_.Function.Bijective.restrictPreimage := Set.restrictPreimage_bijective
+
+end
+
+/-! ### Injectivity on a set -/
+section injOn
+
+theorem injOn_iff_injective : InjOn f s ↔ Injective (s.restrict f) :=
+  ⟨fun H a b h => Subtype.eq <| H a.2 b.2 h, fun H a as b bs h =>
+    congr_arg Subtype.val <| @H ⟨a, as⟩ ⟨b, bs⟩ h⟩
+
+alias ⟨InjOn.injective, _⟩ := Set.injOn_iff_injective
+
+theorem MapsTo.restrict_inj (h : MapsTo f s t) : Injective (h.restrict f s t) ↔ InjOn f s := by
+  rw [h.restrict_eq_codRestrict, injective_codRestrict, injOn_iff_injective]
+
+end injOn
+
+/-! ### Surjectivity on a set -/
+section surjOn
+
+theorem surjOn_iff_surjective : SurjOn f s univ ↔ Surjective (s.restrict f) :=
+  ⟨fun H b =>
+    let ⟨a, as, e⟩ := @H b trivial
+    ⟨⟨a, as⟩, e⟩,
+    fun H b _ =>
+    let ⟨⟨a, as⟩, e⟩ := H b
+    ⟨a, as, e⟩⟩
+
+@[simp]
+theorem MapsTo.restrict_surjective_iff (h : MapsTo f s t) :
+    Surjective (MapsTo.restrict _ _ _ h) ↔ SurjOn f s t := by
+  refine ⟨fun h' b hb ↦ ?_, fun h' ⟨b, hb⟩ ↦ ?_⟩
+  · obtain ⟨⟨a, ha⟩, ha'⟩ := h' ⟨b, hb⟩
+    replace ha' : f a = b := by simpa [Subtype.ext_iff] using ha'
+    rw [← ha']
+    exact mem_image_of_mem f ha
+  · obtain ⟨a, ha, rfl⟩ := h' hb
+    exact ⟨⟨a, ha⟩, rfl⟩
+
+end surjOn
+
+end Set

--- a/Mathlib/Data/Set/Restrict.lean
+++ b/Mathlib/Data/Set/Restrict.lean
@@ -3,8 +3,7 @@ Copyright (c) 2014 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Andrew Zipperer, Haitao Zhang, Minchao Wu, Yury Kudryashov
 -/
-import Mathlib.Data.Set.Prod
-import Mathlib.Logic.Function.Conjugate
+import Mathlib.Data.Set.Image
 
 /-!
 # Restrict the domain of a function to a set

--- a/Mathlib/Logic/Equiv/PartialEquiv.lean
+++ b/Mathlib/Logic/Equiv/PartialEquiv.lean
@@ -3,7 +3,7 @@ Copyright (c) 2019 Sébastien Gouëzel. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sébastien Gouëzel
 -/
-import Mathlib.Data.Set.Function
+import Mathlib.Data.Set.Piecewise
 import Mathlib.Logic.Equiv.Defs
 import Mathlib.Tactic.Core
 import Mathlib.Tactic.Attr.Core

--- a/Mathlib/Logic/Function/DependsOn.lean
+++ b/Mathlib/Logic/Function/DependsOn.lean
@@ -3,7 +3,7 @@ Copyright (c) 2024 Etienne Marion. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Etienne Marion
 -/
-import Mathlib.Data.Set.Function
+import Mathlib.Data.Set.Restrict
 
 /-!
 # Functions depending only on some variables

--- a/Mathlib/Order/Filter/AtTopBot/Defs.lean
+++ b/Mathlib/Order/Filter/AtTopBot/Defs.lean
@@ -3,6 +3,7 @@ Copyright (c) 2017 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Jeremy Avigad, Yury Kudryashov, Patrick Massot
 -/
+import Mathlib.Data.Set.Piecewise
 import Mathlib.Order.Filter.Basic
 
 /-!

--- a/Mathlib/Order/Filter/Pi.lean
+++ b/Mathlib/Order/Filter/Pi.lean
@@ -3,6 +3,7 @@ Copyright (c) 2021 Yury Kudryashov. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury Kudryashov, Alex Kontorovich
 -/
+import Mathlib.Data.Set.Piecewise
 import Mathlib.Order.Filter.Tendsto
 import Mathlib.Order.Filter.Bases.Finite
 

--- a/Mathlib/Order/Interval/Set/Pi.lean
+++ b/Mathlib/Order/Interval/Set/Pi.lean
@@ -5,6 +5,7 @@ Authors: Yury Kudryashov
 -/
 import Mathlib.Algebra.Group.Pi.Basic
 import Mathlib.Data.Set.BooleanAlgebra
+import Mathlib.Data.Set.Piecewise
 import Mathlib.Order.Interval.Set.Basic
 import Mathlib.Order.Interval.Set.UnorderedInterval
 

--- a/Mathlib/SetTheory/Cardinal/SchroederBernstein.lean
+++ b/Mathlib/SetTheory/Cardinal/SchroederBernstein.lean
@@ -3,6 +3,7 @@ Copyright (c) 2017 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Mario Carneiro
 -/
+import Mathlib.Data.Set.Piecewise
 import Mathlib.Order.FixedPoints
 import Mathlib.Order.Zorn
 


### PR DESCRIPTION
This PR splits the long file `Data.Set.Function` into a few chunks:

* `Data.Set.Function` now focusses on lemmas for predicates such as `EqOn`, `InjOn`, `MapsTo`, ...
* `Data.Set.Piecewise` is a new file for results on the definiton `Set.piecewise`.
* `Data.Set.Prod` received some upstreamed results on `graphOn` and the vertical line test.
* `Data.Set.Restrict` is a new file for the definition of `Set.restrict` and some basic results.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
