### PR TITLE
[Merged by Bors] - chore(Algebra/Group): split `iUnion`/`iInter` from long file `Pointwise/Set/Basic.lean`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -360,6 +360,7 @@ import Mathlib.Algebra.Group.Pointwise.Set.Basic
 import Mathlib.Algebra.Group.Pointwise.Set.BigOperators
 import Mathlib.Algebra.Group.Pointwise.Set.Card
 import Mathlib.Algebra.Group.Pointwise.Set.Finite
+import Mathlib.Algebra.Group.Pointwise.Set.Lattice
 import Mathlib.Algebra.Group.Pointwise.Set.ListOfFn
 import Mathlib.Algebra.Group.Prod
 import Mathlib.Algebra.Group.Semiconj.Basic

--- a/Mathlib/Algebra/Group/Action/Pointwise/Set/Basic.lean
+++ b/Mathlib/Algebra/Group/Action/Pointwise/Set/Basic.lean
@@ -7,6 +7,7 @@ import Mathlib.Algebra.Group.Action.Basic
 import Mathlib.Algebra.Group.Action.Opposite
 import Mathlib.Algebra.Group.Pointwise.Set.Basic
 import Mathlib.Algebra.Group.Units.Equiv
+import Mathlib.Data.Set.Lattice.Image
 import Mathlib.Data.Set.Pairwise.Basic
 
 /-!

--- a/Mathlib/Algebra/Group/Pointwise/Set/Basic.lean
+++ b/Mathlib/Algebra/Group/Pointwise/Set/Basic.lean
@@ -6,8 +6,7 @@ Authors: Johan Commelin, Floris van Doorn, Yaël Dillies
 import Mathlib.Algebra.Group.Equiv.Basic
 import Mathlib.Algebra.Group.Prod
 import Mathlib.Algebra.Order.Monoid.Unbundled.Pow
-import Mathlib.Data.Set.Lattice.Image
-import Mathlib.Tactic.MinImports
+import Mathlib.Data.Set.NAry
 
 /-!
 # Pointwise operations of sets
@@ -53,7 +52,7 @@ set multiplication, set addition, pointwise addition, pointwise multiplication,
 pointwise subtraction
 -/
 
-assert_not_exists MulAction MonoidWithZero OrderedAddCommMonoid
+assert_not_exists Set.iUnion MulAction MonoidWithZero OrderedAddCommMonoid
 
 library_note "pointwise nat action"/--
 Pointwise monoids (`Set`, `Finset`, `Filter`) have derived pointwise actions of the form
@@ -185,22 +184,6 @@ theorem inter_inv : (s ∩ t)⁻¹ = s⁻¹ ∩ t⁻¹ :=
 @[to_additive (attr := simp)]
 theorem union_inv : (s ∪ t)⁻¹ = s⁻¹ ∪ t⁻¹ :=
   preimage_union
-
-@[to_additive (attr := simp)]
-theorem iInter_inv (s : ι → Set α) : (⋂ i, s i)⁻¹ = ⋂ i, (s i)⁻¹ :=
-  preimage_iInter
-
-@[to_additive (attr := simp)]
-theorem sInter_inv (S : Set (Set α)) : (⋂₀ S)⁻¹ = ⋂ s ∈ S, s⁻¹ :=
-  preimage_sInter
-
-@[to_additive (attr := simp)]
-theorem iUnion_inv (s : ι → Set α) : (⋃ i, s i)⁻¹ = ⋃ i, (s i)⁻¹ :=
-  preimage_iUnion
-
-@[to_additive (attr := simp)]
-theorem sUnion_inv (S : Set (Set α)) : (⋃₀ S)⁻¹ = ⋃ s ∈ S, s⁻¹ :=
-  preimage_sUnion
 
 @[to_additive (attr := simp)]
 theorem compl_inv : sᶜ⁻¹ = s⁻¹ᶜ :=
@@ -390,66 +373,6 @@ theorem inter_mul_union_subset_union : s₁ ∩ s₂ * (t₁ ∪ t₂) ⊆ s₁ 
 theorem union_mul_inter_subset_union : (s₁ ∪ s₂) * (t₁ ∩ t₂) ⊆ s₁ * t₁ ∪ s₂ * t₂ :=
   image2_union_inter_subset_union
 
-@[to_additive]
-theorem iUnion_mul_left_image : ⋃ a ∈ s, (a * ·) '' t = s * t :=
-  iUnion_image_left _
-
-@[to_additive]
-theorem iUnion_mul_right_image : ⋃ a ∈ t, (· * a) '' s = s * t :=
-  iUnion_image_right _
-
-@[to_additive]
-theorem iUnion_mul (s : ι → Set α) (t : Set α) : (⋃ i, s i) * t = ⋃ i, s i * t :=
-  image2_iUnion_left ..
-
-@[to_additive]
-theorem mul_iUnion (s : Set α) (t : ι → Set α) : (s * ⋃ i, t i) = ⋃ i, s * t i :=
-  image2_iUnion_right ..
-
-@[to_additive]
-theorem sUnion_mul (S : Set (Set α)) (t : Set α) : ⋃₀ S * t = ⋃ s ∈ S, s * t :=
-  image2_sUnion_left ..
-
-@[to_additive]
-theorem mul_sUnion (s : Set α) (T : Set (Set α)) : s * ⋃₀ T = ⋃ t ∈ T, s * t :=
-  image2_sUnion_right ..
-
-@[to_additive]
-theorem iUnion₂_mul (s : ∀ i, κ i → Set α) (t : Set α) :
-    (⋃ (i) (j), s i j) * t = ⋃ (i) (j), s i j * t :=
-  image2_iUnion₂_left ..
-
-@[to_additive]
-theorem mul_iUnion₂ (s : Set α) (t : ∀ i, κ i → Set α) :
-    (s * ⋃ (i) (j), t i j) = ⋃ (i) (j), s * t i j :=
-  image2_iUnion₂_right ..
-
-@[to_additive]
-theorem iInter_mul_subset (s : ι → Set α) (t : Set α) : (⋂ i, s i) * t ⊆ ⋂ i, s i * t :=
-  Set.image2_iInter_subset_left ..
-
-@[to_additive]
-theorem mul_iInter_subset (s : Set α) (t : ι → Set α) : (s * ⋂ i, t i) ⊆ ⋂ i, s * t i :=
-  image2_iInter_subset_right ..
-
-@[to_additive]
-lemma mul_sInter_subset (s : Set α) (T : Set (Set α)) :
-    s * ⋂₀ T ⊆ ⋂ t ∈ T, s * t := image2_sInter_right_subset s T (fun a b => a * b)
-
-@[to_additive]
-lemma sInter_mul_subset (S : Set (Set α)) (t : Set α) :
-    ⋂₀ S * t ⊆ ⋂ s ∈ S, s * t := image2_sInter_left_subset S t (fun a b => a * b)
-
-@[to_additive]
-theorem iInter₂_mul_subset (s : ∀ i, κ i → Set α) (t : Set α) :
-    (⋂ (i) (j), s i j) * t ⊆ ⋂ (i) (j), s i j * t :=
-  image2_iInter₂_subset_left ..
-
-@[to_additive]
-theorem mul_iInter₂_subset (s : Set α) (t : ∀ i, κ i → Set α) :
-    (s * ⋂ (i) (j), t i j) ⊆ ⋂ (i) (j), s * t i j :=
-  image2_iInter₂_subset_right ..
-
 /-- The singleton operation as a `MulHom`. -/
 @[to_additive "The singleton operation as an `AddHom`."]
 noncomputable def singletonMulHom : α →ₙ* Set α where
@@ -592,66 +515,6 @@ theorem inter_div_union_subset_union : s₁ ∩ s₂ / (t₁ ∪ t₂) ⊆ s₁ 
 theorem union_div_inter_subset_union : (s₁ ∪ s₂) / (t₁ ∩ t₂) ⊆ s₁ / t₁ ∪ s₂ / t₂ :=
   image2_union_inter_subset_union
 
-@[to_additive]
-theorem iUnion_div_left_image : ⋃ a ∈ s, (a / ·) '' t = s / t :=
-  iUnion_image_left _
-
-@[to_additive]
-theorem iUnion_div_right_image : ⋃ a ∈ t, (· / a) '' s = s / t :=
-  iUnion_image_right _
-
-@[to_additive]
-theorem iUnion_div (s : ι → Set α) (t : Set α) : (⋃ i, s i) / t = ⋃ i, s i / t :=
-  image2_iUnion_left ..
-
-@[to_additive]
-theorem div_iUnion (s : Set α) (t : ι → Set α) : (s / ⋃ i, t i) = ⋃ i, s / t i :=
-  image2_iUnion_right ..
-
-@[to_additive]
-theorem sUnion_div (S : Set (Set α)) (t : Set α) : ⋃₀ S / t = ⋃ s ∈ S, s / t :=
-  image2_sUnion_left ..
-
-@[to_additive]
-theorem div_sUnion (s : Set α) (T : Set (Set α)) : s / ⋃₀ T = ⋃ t ∈ T, s / t :=
-  image2_sUnion_right ..
-
-@[to_additive]
-theorem iUnion₂_div (s : ∀ i, κ i → Set α) (t : Set α) :
-    (⋃ (i) (j), s i j) / t = ⋃ (i) (j), s i j / t :=
-  image2_iUnion₂_left ..
-
-@[to_additive]
-theorem div_iUnion₂ (s : Set α) (t : ∀ i, κ i → Set α) :
-    (s / ⋃ (i) (j), t i j) = ⋃ (i) (j), s / t i j :=
-  image2_iUnion₂_right ..
-
-@[to_additive]
-theorem iInter_div_subset (s : ι → Set α) (t : Set α) : (⋂ i, s i) / t ⊆ ⋂ i, s i / t :=
-  image2_iInter_subset_left ..
-
-@[to_additive]
-theorem div_iInter_subset (s : Set α) (t : ι → Set α) : (s / ⋂ i, t i) ⊆ ⋂ i, s / t i :=
-  image2_iInter_subset_right ..
-
-@[to_additive]
-theorem sInter_div_subset (S : Set (Set α)) (t : Set α) : ⋂₀ S / t ⊆ ⋂ s ∈ S, s / t :=
-  image2_sInter_subset_left ..
-
-@[to_additive]
-theorem div_sInter_subset (s : Set α) (T : Set (Set α)) : s / ⋂₀ T ⊆ ⋂ t ∈ T, s / t :=
-  image2_sInter_subset_right ..
-
-@[to_additive]
-theorem iInter₂_div_subset (s : ∀ i, κ i → Set α) (t : Set α) :
-    (⋂ (i) (j), s i j) / t ⊆ ⋂ (i) (j), s i j / t :=
-  image2_iInter₂_subset_left ..
-
-@[to_additive]
-theorem div_iInter₂_subset (s : Set α) (t : ∀ i, κ i → Set α) :
-    (s / ⋂ (i) (j), t i j) ⊆ ⋂ (i) (j), s / t i j :=
-  image2_iInter₂_subset_right ..
-
 end Div
 
 /-! ### Translation/scaling of sets -/
@@ -735,64 +598,8 @@ lemma inter_smul_union_subset_union : (s₁ ∩ s₂) • (t₁ ∪ t₂) ⊆ s�
 lemma union_smul_inter_subset_union : (s₁ ∪ s₂) • (t₁ ∩ t₂) ⊆ s₁ • t₁ ∪ s₂ • t₂ :=
   image2_union_inter_subset_union
 
-@[to_additive] lemma iUnion_smul_left_image : ⋃ a ∈ s, a • t = s • t := iUnion_image_left _
-
-@[to_additive]
-lemma iUnion_smul_right_image : ⋃ a ∈ t, (· • a) '' s = s • t := iUnion_image_right _
-
-@[to_additive]
-lemma iUnion_smul (s : ι → Set α) (t : Set β) : (⋃ i, s i) • t = ⋃ i, s i • t :=
-  image2_iUnion_left ..
-
-@[to_additive]
-lemma smul_iUnion (s : Set α) (t : ι → Set β) : (s • ⋃ i, t i) = ⋃ i, s • t i :=
-  image2_iUnion_right ..
-
-@[to_additive]
-lemma sUnion_smul (S : Set (Set α)) (t : Set β) : ⋃₀ S • t = ⋃ s ∈ S, s • t :=
-  image2_sUnion_left ..
-
-@[to_additive]
-lemma smul_sUnion (s : Set α) (T : Set (Set β)) : s • ⋃₀ T = ⋃ t ∈ T, s • t :=
-  image2_sUnion_right ..
-
-@[to_additive]
-lemma iUnion₂_smul (s : ∀ i, κ i → Set α) (t : Set β) :
-    (⋃ i, ⋃ j, s i j) • t = ⋃ i, ⋃ j, s i j • t := image2_iUnion₂_left ..
-
-@[to_additive]
-lemma smul_iUnion₂ (s : Set α) (t : ∀ i, κ i → Set β) :
-    (s • ⋃ i, ⋃ j, t i j) = ⋃ i, ⋃ j, s • t i j := image2_iUnion₂_right ..
-
-@[to_additive]
-lemma iInter_smul_subset (s : ι → Set α) (t : Set β) : (⋂ i, s i) • t ⊆ ⋂ i, s i • t :=
-  image2_iInter_subset_left ..
-
-@[to_additive]
-lemma smul_iInter_subset (s : Set α) (t : ι → Set β) : (s • ⋂ i, t i) ⊆ ⋂ i, s • t i :=
-  image2_iInter_subset_right ..
-
-@[to_additive]
-lemma sInter_smul_subset (S : Set (Set α)) (t : Set β) : ⋂₀ S • t ⊆ ⋂ s ∈ S, s • t :=
-  image2_sInter_left_subset S t (fun a x => a • x)
-
-@[to_additive]
-lemma smul_sInter_subset (s : Set α) (T : Set (Set β)) : s • ⋂₀ T ⊆ ⋂ t ∈ T, s • t :=
-  image2_sInter_right_subset s T (fun a x => a • x)
-
-@[to_additive]
-lemma iInter₂_smul_subset (s : ∀ i, κ i → Set α) (t : Set β) :
-    (⋂ i, ⋂ j, s i j) • t ⊆ ⋂ i, ⋂ j, s i j • t := image2_iInter₂_subset_left ..
-
-@[to_additive]
-lemma smul_iInter₂_subset (s : Set α) (t : ∀ i, κ i → Set β) :
-    (s • ⋂ i, ⋂ j, t i j) ⊆ ⋂ i, ⋂ j, s • t i j := image2_iInter₂_subset_right ..
-
 @[to_additive]
 lemma smul_set_subset_smul {s : Set α} : a ∈ s → a • t ⊆ s • t := image_subset_image2_right
-
-@[to_additive (attr := simp)]
-lemma iUnion_smul_set (s : Set α) (t : Set β) : ⋃ a ∈ s, a • t = s • t := iUnion_image_left _
 
 end SMul
 
@@ -833,30 +640,6 @@ lemma smul_set_insert (a : α) (b : β) (s : Set β) : a • insert b s = insert
 @[to_additive]
 lemma smul_set_inter_subset : a • (t₁ ∩ t₂) ⊆ a • t₁ ∩ a • t₂ :=
   image_inter_subset ..
-
-@[to_additive]
-lemma smul_set_iUnion (a : α) (s : ι → Set β) : a • ⋃ i, s i = ⋃ i, a • s i :=
-  image_iUnion
-
-@[to_additive]
-lemma smul_set_iUnion₂ (a : α) (s : ∀ i, κ i → Set β) :
-    a • ⋃ i, ⋃ j, s i j = ⋃ i, ⋃ j, a • s i j := image_iUnion₂ ..
-
-@[to_additive]
-lemma smul_set_sUnion (a : α) (S : Set (Set β)) : a • ⋃₀ S = ⋃ s ∈ S, a • s := by
-  rw [sUnion_eq_biUnion, smul_set_iUnion₂]
-
-@[to_additive]
-lemma smul_set_iInter_subset (a : α) (t : ι → Set β) : a • ⋂ i, t i ⊆ ⋂ i, a • t i :=
-  image_iInter_subset ..
-
-@[to_additive]
-lemma smul_set_sInter_subset (a : α) (S : Set (Set β)) :
-    a • ⋂₀ S ⊆ ⋂ s ∈ S, a • s := image_sInter_subset ..
-
-@[to_additive]
-lemma smul_set_iInter₂_subset (a : α) (t : ∀ i, κ i → Set β) :
-    a • ⋂ i, ⋂ j, t i j ⊆ ⋂ i, ⋂ j, a • t i j := image_iInter₂_subset ..
 
 @[to_additive] lemma Nonempty.smul_set : s.Nonempty → (a • s).Nonempty := Nonempty.image _
 
@@ -948,45 +731,6 @@ lemma inter_vsub_union_subset_union : s₁ ∩ s₂ -ᵥ (t₁ ∪ t₂) ⊆ s�
 
 lemma union_vsub_inter_subset_union : s₁ ∪ s₂ -ᵥ t₁ ∩ t₂ ⊆ s₁ -ᵥ t₁ ∪ (s₂ -ᵥ t₂) :=
   image2_union_inter_subset_union
-
-lemma iUnion_vsub_left_image : ⋃ a ∈ s, (a -ᵥ ·) '' t = s -ᵥ t := iUnion_image_left _
-lemma iUnion_vsub_right_image : ⋃ a ∈ t, (· -ᵥ a) '' s = s -ᵥ t := iUnion_image_right _
-
-lemma iUnion_vsub (s : ι → Set β) (t : Set β) : (⋃ i, s i) -ᵥ t = ⋃ i, s i -ᵥ t :=
-  image2_iUnion_left ..
-
-lemma vsub_iUnion (s : Set β) (t : ι → Set β) : (s -ᵥ ⋃ i, t i) = ⋃ i, s -ᵥ t i :=
-  image2_iUnion_right ..
-
-lemma sUnion_vsub (S : Set (Set β)) (t : Set β) : ⋃₀ S -ᵥ t = ⋃ s ∈ S, s -ᵥ t :=
-  image2_sUnion_left ..
-
-lemma vsub_sUnion (s : Set β) (T : Set (Set β)) : s -ᵥ ⋃₀ T = ⋃ t ∈ T, s -ᵥ t :=
-  image2_sUnion_right ..
-
-lemma iUnion₂_vsub (s : ∀ i, κ i → Set β) (t : Set β) :
-    (⋃ i, ⋃ j, s i j) -ᵥ t = ⋃ i, ⋃ j, s i j -ᵥ t := image2_iUnion₂_left ..
-
-lemma vsub_iUnion₂ (s : Set β) (t : ∀ i, κ i → Set β) :
-    (s -ᵥ ⋃ i, ⋃ j, t i j) = ⋃ i, ⋃ j, s -ᵥ t i j := image2_iUnion₂_right ..
-
-lemma iInter_vsub_subset (s : ι → Set β) (t : Set β) : (⋂ i, s i) -ᵥ t ⊆ ⋂ i, s i -ᵥ t :=
-  image2_iInter_subset_left ..
-
-lemma vsub_iInter_subset (s : Set β) (t : ι → Set β) : (s -ᵥ ⋂ i, t i) ⊆ ⋂ i, s -ᵥ t i :=
-  image2_iInter_subset_right ..
-
-lemma sInter_vsub_subset (S : Set (Set β)) (t : Set β) : ⋂₀ S -ᵥ t ⊆ ⋂ s ∈ S, s -ᵥ t :=
-  image2_sInter_subset_left ..
-
-lemma vsub_sInter_subset (s : Set β) (T : Set (Set β)) : s -ᵥ ⋂₀ T ⊆ ⋂ t ∈ T, s -ᵥ t :=
-  image2_sInter_subset_right ..
-
-lemma iInter₂_vsub_subset (s : ∀ i, κ i → Set β) (t : Set β) :
-    (⋂ i, ⋂ j, s i j) -ᵥ t ⊆ ⋂ i, ⋂ j, s i j -ᵥ t := image2_iInter₂_subset_left ..
-
-lemma vsub_iInter₂_subset (s : Set β) (t : ∀ i, κ i → Set β) :
-    s -ᵥ ⋂ i, ⋂ j, t i j ⊆ ⋂ i, ⋂ j, s -ᵥ t i j := image2_iInter₂_subset_right ..
 
 end VSub
 
@@ -1526,5 +1270,3 @@ lemma MapsTo.div [DivisionCommMonoid β] {A : Set α} {B₁ B₂ : Set β} {f₁
 end Pointwise
 
 end Set
-
-set_option linter.style.longFile 1700

--- a/Mathlib/Algebra/Group/Pointwise/Set/Lattice.lean
+++ b/Mathlib/Algebra/Group/Pointwise/Set/Lattice.lean
@@ -1,0 +1,336 @@
+/-
+Copyright (c) 2019 Johan Commelin. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Johan Commelin, Floris van Doorn, Yaël Dillies
+-/
+import Mathlib.Algebra.Group.Pointwise.Set.Basic
+import Mathlib.Data.Set.Lattice.Image
+
+/-!
+# Indexed unions and intersections of pointwise operations of sets
+
+This file contains lemmas on taking the union and intersection over pointwise algebraic operations
+on sets.
+
+## Tags
+
+set multiplication, set addition, pointwise addition, pointwise multiplication,
+pointwise subtraction
+-/
+
+assert_not_exists MulAction MonoidWithZero OrderedAddCommMonoid
+
+open Function MulOpposite
+
+variable {F α β γ : Type*}
+
+namespace Set
+
+/-! ### Set negation/inversion -/
+
+
+section Inv
+
+open Pointwise
+
+variable {ι : Sort*} [Inv α]
+
+@[to_additive (attr := simp)]
+theorem iInter_inv (s : ι → Set α) : (⋂ i, s i)⁻¹ = ⋂ i, (s i)⁻¹ :=
+  preimage_iInter
+
+@[to_additive (attr := simp)]
+theorem sInter_inv (S : Set (Set α)) : (⋂₀ S)⁻¹ = ⋂ s ∈ S, s⁻¹ :=
+  preimage_sInter
+
+@[to_additive (attr := simp)]
+theorem iUnion_inv (s : ι → Set α) : (⋃ i, s i)⁻¹ = ⋃ i, (s i)⁻¹ :=
+  preimage_iUnion
+
+@[to_additive (attr := simp)]
+theorem sUnion_inv (S : Set (Set α)) : (⋃₀ S)⁻¹ = ⋃ s ∈ S, s⁻¹ :=
+  preimage_sUnion
+
+end Inv
+
+open Pointwise
+
+/-! ### Set addition/multiplication -/
+
+
+section Mul
+
+variable {ι : Sort*} {κ : ι → Sort*} [Mul α] {s s₁ s₂ t t₁ t₂ u : Set α} {a b : α}
+
+@[to_additive]
+theorem iUnion_mul_left_image : ⋃ a ∈ s, (a * ·) '' t = s * t :=
+  iUnion_image_left _
+
+@[to_additive]
+theorem iUnion_mul_right_image : ⋃ a ∈ t, (· * a) '' s = s * t :=
+  iUnion_image_right _
+
+@[to_additive]
+theorem iUnion_mul (s : ι → Set α) (t : Set α) : (⋃ i, s i) * t = ⋃ i, s i * t :=
+  image2_iUnion_left ..
+
+@[to_additive]
+theorem mul_iUnion (s : Set α) (t : ι → Set α) : (s * ⋃ i, t i) = ⋃ i, s * t i :=
+  image2_iUnion_right ..
+
+@[to_additive]
+theorem sUnion_mul (S : Set (Set α)) (t : Set α) : ⋃₀ S * t = ⋃ s ∈ S, s * t :=
+  image2_sUnion_left ..
+
+@[to_additive]
+theorem mul_sUnion (s : Set α) (T : Set (Set α)) : s * ⋃₀ T = ⋃ t ∈ T, s * t :=
+  image2_sUnion_right ..
+
+@[to_additive]
+theorem iUnion₂_mul (s : ∀ i, κ i → Set α) (t : Set α) :
+    (⋃ (i) (j), s i j) * t = ⋃ (i) (j), s i j * t :=
+  image2_iUnion₂_left ..
+
+@[to_additive]
+theorem mul_iUnion₂ (s : Set α) (t : ∀ i, κ i → Set α) :
+    (s * ⋃ (i) (j), t i j) = ⋃ (i) (j), s * t i j :=
+  image2_iUnion₂_right ..
+
+@[to_additive]
+theorem iInter_mul_subset (s : ι → Set α) (t : Set α) : (⋂ i, s i) * t ⊆ ⋂ i, s i * t :=
+  Set.image2_iInter_subset_left ..
+
+@[to_additive]
+theorem mul_iInter_subset (s : Set α) (t : ι → Set α) : (s * ⋂ i, t i) ⊆ ⋂ i, s * t i :=
+  image2_iInter_subset_right ..
+
+@[to_additive]
+lemma mul_sInter_subset (s : Set α) (T : Set (Set α)) :
+    s * ⋂₀ T ⊆ ⋂ t ∈ T, s * t := image2_sInter_right_subset s T (fun a b => a * b)
+
+@[to_additive]
+lemma sInter_mul_subset (S : Set (Set α)) (t : Set α) :
+    ⋂₀ S * t ⊆ ⋂ s ∈ S, s * t := image2_sInter_left_subset S t (fun a b => a * b)
+
+@[to_additive]
+theorem iInter₂_mul_subset (s : ∀ i, κ i → Set α) (t : Set α) :
+    (⋂ (i) (j), s i j) * t ⊆ ⋂ (i) (j), s i j * t :=
+  image2_iInter₂_subset_left ..
+
+@[to_additive]
+theorem mul_iInter₂_subset (s : Set α) (t : ∀ i, κ i → Set α) :
+    (s * ⋂ (i) (j), t i j) ⊆ ⋂ (i) (j), s * t i j :=
+  image2_iInter₂_subset_right ..
+
+end Mul
+
+/-! ### Set subtraction/division -/
+
+
+section Div
+
+variable {ι : Sort*} {κ : ι → Sort*} [Div α] {s s₁ s₂ t t₁ t₂ u : Set α} {a b : α}
+
+@[to_additive]
+theorem iUnion_div_left_image : ⋃ a ∈ s, (a / ·) '' t = s / t :=
+  iUnion_image_left _
+
+@[to_additive]
+theorem iUnion_div_right_image : ⋃ a ∈ t, (· / a) '' s = s / t :=
+  iUnion_image_right _
+
+@[to_additive]
+theorem iUnion_div (s : ι → Set α) (t : Set α) : (⋃ i, s i) / t = ⋃ i, s i / t :=
+  image2_iUnion_left ..
+
+@[to_additive]
+theorem div_iUnion (s : Set α) (t : ι → Set α) : (s / ⋃ i, t i) = ⋃ i, s / t i :=
+  image2_iUnion_right ..
+
+@[to_additive]
+theorem sUnion_div (S : Set (Set α)) (t : Set α) : ⋃₀ S / t = ⋃ s ∈ S, s / t :=
+  image2_sUnion_left ..
+
+@[to_additive]
+theorem div_sUnion (s : Set α) (T : Set (Set α)) : s / ⋃₀ T = ⋃ t ∈ T, s / t :=
+  image2_sUnion_right ..
+
+@[to_additive]
+theorem iUnion₂_div (s : ∀ i, κ i → Set α) (t : Set α) :
+    (⋃ (i) (j), s i j) / t = ⋃ (i) (j), s i j / t :=
+  image2_iUnion₂_left ..
+
+@[to_additive]
+theorem div_iUnion₂ (s : Set α) (t : ∀ i, κ i → Set α) :
+    (s / ⋃ (i) (j), t i j) = ⋃ (i) (j), s / t i j :=
+  image2_iUnion₂_right ..
+
+@[to_additive]
+theorem iInter_div_subset (s : ι → Set α) (t : Set α) : (⋂ i, s i) / t ⊆ ⋂ i, s i / t :=
+  image2_iInter_subset_left ..
+
+@[to_additive]
+theorem div_iInter_subset (s : Set α) (t : ι → Set α) : (s / ⋂ i, t i) ⊆ ⋂ i, s / t i :=
+  image2_iInter_subset_right ..
+
+@[to_additive]
+theorem sInter_div_subset (S : Set (Set α)) (t : Set α) : ⋂₀ S / t ⊆ ⋂ s ∈ S, s / t :=
+  image2_sInter_subset_left ..
+
+@[to_additive]
+theorem div_sInter_subset (s : Set α) (T : Set (Set α)) : s / ⋂₀ T ⊆ ⋂ t ∈ T, s / t :=
+  image2_sInter_subset_right ..
+
+@[to_additive]
+theorem iInter₂_div_subset (s : ∀ i, κ i → Set α) (t : Set α) :
+    (⋂ (i) (j), s i j) / t ⊆ ⋂ (i) (j), s i j / t :=
+  image2_iInter₂_subset_left ..
+
+@[to_additive]
+theorem div_iInter₂_subset (s : Set α) (t : ∀ i, κ i → Set α) :
+    (s / ⋂ (i) (j), t i j) ⊆ ⋂ (i) (j), s / t i j :=
+  image2_iInter₂_subset_right ..
+
+end Div
+
+/-! ### Translation/scaling of sets -/
+
+section SMul
+
+variable {ι : Sort*} {κ : ι → Sort*} [SMul α β] {s s₁ s₂ : Set α} {t t₁ t₂ u : Set β} {a : α}
+  {b : β}
+
+@[to_additive] lemma iUnion_smul_left_image : ⋃ a ∈ s, a • t = s • t := iUnion_image_left _
+
+@[to_additive]
+lemma iUnion_smul_right_image : ⋃ a ∈ t, (· • a) '' s = s • t := iUnion_image_right _
+
+@[to_additive]
+lemma iUnion_smul (s : ι → Set α) (t : Set β) : (⋃ i, s i) • t = ⋃ i, s i • t :=
+  image2_iUnion_left ..
+
+@[to_additive]
+lemma smul_iUnion (s : Set α) (t : ι → Set β) : (s • ⋃ i, t i) = ⋃ i, s • t i :=
+  image2_iUnion_right ..
+
+@[to_additive]
+lemma sUnion_smul (S : Set (Set α)) (t : Set β) : ⋃₀ S • t = ⋃ s ∈ S, s • t :=
+  image2_sUnion_left ..
+
+@[to_additive]
+lemma smul_sUnion (s : Set α) (T : Set (Set β)) : s • ⋃₀ T = ⋃ t ∈ T, s • t :=
+  image2_sUnion_right ..
+
+@[to_additive]
+lemma iUnion₂_smul (s : ∀ i, κ i → Set α) (t : Set β) :
+    (⋃ i, ⋃ j, s i j) • t = ⋃ i, ⋃ j, s i j • t := image2_iUnion₂_left ..
+
+@[to_additive]
+lemma smul_iUnion₂ (s : Set α) (t : ∀ i, κ i → Set β) :
+    (s • ⋃ i, ⋃ j, t i j) = ⋃ i, ⋃ j, s • t i j := image2_iUnion₂_right ..
+
+@[to_additive]
+lemma iInter_smul_subset (s : ι → Set α) (t : Set β) : (⋂ i, s i) • t ⊆ ⋂ i, s i • t :=
+  image2_iInter_subset_left ..
+
+@[to_additive]
+lemma smul_iInter_subset (s : Set α) (t : ι → Set β) : (s • ⋂ i, t i) ⊆ ⋂ i, s • t i :=
+  image2_iInter_subset_right ..
+
+@[to_additive]
+lemma sInter_smul_subset (S : Set (Set α)) (t : Set β) : ⋂₀ S • t ⊆ ⋂ s ∈ S, s • t :=
+  image2_sInter_left_subset S t (fun a x => a • x)
+
+@[to_additive]
+lemma smul_sInter_subset (s : Set α) (T : Set (Set β)) : s • ⋂₀ T ⊆ ⋂ t ∈ T, s • t :=
+  image2_sInter_right_subset s T (fun a x => a • x)
+
+@[to_additive]
+lemma iInter₂_smul_subset (s : ∀ i, κ i → Set α) (t : Set β) :
+    (⋂ i, ⋂ j, s i j) • t ⊆ ⋂ i, ⋂ j, s i j • t := image2_iInter₂_subset_left ..
+
+@[to_additive]
+lemma smul_iInter₂_subset (s : Set α) (t : ∀ i, κ i → Set β) :
+    (s • ⋂ i, ⋂ j, t i j) ⊆ ⋂ i, ⋂ j, s • t i j := image2_iInter₂_subset_right ..
+
+@[to_additive (attr := simp)]
+lemma iUnion_smul_set (s : Set α) (t : Set β) : ⋃ a ∈ s, a • t = s • t := iUnion_image_left _
+
+end SMul
+
+section SMulSet
+variable {ι : Sort*} {κ : ι → Sort*} [SMul α β] {s t t₁ t₂ : Set β} {a : α} {b : β} {x y : β}
+
+@[to_additive]
+lemma smul_set_iUnion (a : α) (s : ι → Set β) : a • ⋃ i, s i = ⋃ i, a • s i :=
+  image_iUnion
+
+@[to_additive]
+lemma smul_set_iUnion₂ (a : α) (s : ∀ i, κ i → Set β) :
+    a • ⋃ i, ⋃ j, s i j = ⋃ i, ⋃ j, a • s i j := image_iUnion₂ ..
+
+@[to_additive]
+lemma smul_set_sUnion (a : α) (S : Set (Set β)) : a • ⋃₀ S = ⋃ s ∈ S, a • s := by
+  rw [sUnion_eq_biUnion, smul_set_iUnion₂]
+
+@[to_additive]
+lemma smul_set_iInter_subset (a : α) (t : ι → Set β) : a • ⋂ i, t i ⊆ ⋂ i, a • t i :=
+  image_iInter_subset ..
+
+@[to_additive]
+lemma smul_set_sInter_subset (a : α) (S : Set (Set β)) :
+    a • ⋂₀ S ⊆ ⋂ s ∈ S, a • s := image_sInter_subset ..
+
+@[to_additive]
+lemma smul_set_iInter₂_subset (a : α) (t : ∀ i, κ i → Set β) :
+    a • ⋂ i, ⋂ j, t i j ⊆ ⋂ i, ⋂ j, a • t i j := image_iInter₂_subset ..
+
+end SMulSet
+variable {s : Set α} {t : Set β} {a : α} {b : β}
+
+section VSub
+variable {ι : Sort*} {κ : ι → Sort*} [VSub α β] {s s₁ s₂ t t₁ t₂ : Set β} {u : Set α} {a : α}
+  {b c : β}
+
+lemma iUnion_vsub_left_image : ⋃ a ∈ s, (a -ᵥ ·) '' t = s -ᵥ t := iUnion_image_left _
+lemma iUnion_vsub_right_image : ⋃ a ∈ t, (· -ᵥ a) '' s = s -ᵥ t := iUnion_image_right _
+
+lemma iUnion_vsub (s : ι → Set β) (t : Set β) : (⋃ i, s i) -ᵥ t = ⋃ i, s i -ᵥ t :=
+  image2_iUnion_left ..
+
+lemma vsub_iUnion (s : Set β) (t : ι → Set β) : (s -ᵥ ⋃ i, t i) = ⋃ i, s -ᵥ t i :=
+  image2_iUnion_right ..
+
+lemma sUnion_vsub (S : Set (Set β)) (t : Set β) : ⋃₀ S -ᵥ t = ⋃ s ∈ S, s -ᵥ t :=
+  image2_sUnion_left ..
+
+lemma vsub_sUnion (s : Set β) (T : Set (Set β)) : s -ᵥ ⋃₀ T = ⋃ t ∈ T, s -ᵥ t :=
+  image2_sUnion_right ..
+
+lemma iUnion₂_vsub (s : ∀ i, κ i → Set β) (t : Set β) :
+    (⋃ i, ⋃ j, s i j) -ᵥ t = ⋃ i, ⋃ j, s i j -ᵥ t := image2_iUnion₂_left ..
+
+lemma vsub_iUnion₂ (s : Set β) (t : ∀ i, κ i → Set β) :
+    (s -ᵥ ⋃ i, ⋃ j, t i j) = ⋃ i, ⋃ j, s -ᵥ t i j := image2_iUnion₂_right ..
+
+lemma iInter_vsub_subset (s : ι → Set β) (t : Set β) : (⋂ i, s i) -ᵥ t ⊆ ⋂ i, s i -ᵥ t :=
+  image2_iInter_subset_left ..
+
+lemma vsub_iInter_subset (s : Set β) (t : ι → Set β) : (s -ᵥ ⋂ i, t i) ⊆ ⋂ i, s -ᵥ t i :=
+  image2_iInter_subset_right ..
+
+lemma sInter_vsub_subset (S : Set (Set β)) (t : Set β) : ⋂₀ S -ᵥ t ⊆ ⋂ s ∈ S, s -ᵥ t :=
+  image2_sInter_subset_left ..
+
+lemma vsub_sInter_subset (s : Set β) (T : Set (Set β)) : s -ᵥ ⋂₀ T ⊆ ⋂ t ∈ T, s -ᵥ t :=
+  image2_sInter_subset_right ..
+
+lemma iInter₂_vsub_subset (s : ∀ i, κ i → Set β) (t : Set β) :
+    (⋂ i, ⋂ j, s i j) -ᵥ t ⊆ ⋂ i, ⋂ j, s i j -ᵥ t := image2_iInter₂_subset_left ..
+
+lemma vsub_iInter₂_subset (s : Set β) (t : ∀ i, κ i → Set β) :
+    s -ᵥ ⋂ i, ⋂ j, t i j ⊆ ⋂ i, ⋂ j, s -ᵥ t i j := image2_iInter₂_subset_right ..
+
+end VSub
+
+end Set

--- a/Mathlib/Algebra/Group/Subgroup/Pointwise.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Pointwise.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Eric Wieser
 -/
 import Mathlib.Algebra.Group.Action.End
+import Mathlib.Algebra.Group.Pointwise.Set.Lattice
 import Mathlib.Algebra.Group.Subgroup.MulOppositeLemmas
 import Mathlib.Algebra.Group.Submonoid.Pointwise
 import Mathlib.GroupTheory.GroupAction.ConjAct

--- a/Mathlib/Algebra/Order/Group/Pointwise/Bounds.lean
+++ b/Mathlib/Algebra/Order/Group/Pointwise/Bounds.lean
@@ -7,6 +7,7 @@ import Mathlib.Algebra.Group.Pointwise.Set.Basic
 import Mathlib.Algebra.Order.Group.OrderIso
 import Mathlib.Algebra.Order.Monoid.Unbundled.OrderDual
 import Mathlib.Order.Bounds.OrderIso
+import Mathlib.Order.GaloisConnection.Basic
 
 /-!
 # Upper/lower bounds in ordered monoids and groups

--- a/Mathlib/Algebra/Order/Module/Pointwise.lean
+++ b/Mathlib/Algebra/Order/Module/Pointwise.lean
@@ -6,6 +6,7 @@ Authors: Yaël Dillies
 import Mathlib.Algebra.Group.Pointwise.Set.Basic
 import Mathlib.Algebra.Order.Module.Defs
 import Mathlib.Order.Bounds.OrderIso
+import Mathlib.Order.GaloisConnection.Basic
 
 /-!
 # Bounds on scalar multiplication of set

--- a/Mathlib/Algebra/Order/UpperLower.lean
+++ b/Mathlib/Algebra/Order/UpperLower.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies
 -/
 import Mathlib.Algebra.Group.Action.Pointwise.Set.Basic
+import Mathlib.Algebra.Group.Pointwise.Set.Lattice
 import Mathlib.Algebra.Order.Group.Instances
 import Mathlib.Algebra.Order.Group.OrderIso
 import Mathlib.Order.UpperLower.Basic

--- a/Mathlib/Algebra/Star/Pointwise.lean
+++ b/Mathlib/Algebra/Star/Pointwise.lean
@@ -3,10 +3,11 @@ Copyright (c) 2022 Jireh Loreaux. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jireh Loreaux
 -/
+import Mathlib.Algebra.Field.Defs
 import Mathlib.Algebra.Group.Pointwise.Set.Basic
 import Mathlib.Algebra.Star.Basic
 import Mathlib.Data.Set.Finite.Basic
-import Mathlib.Algebra.Field.Defs
+import Mathlib.Data.Set.Lattice.Image
 
 /-!
 # Pointwise star operation on sets

--- a/Mathlib/Data/Set/Semiring.lean
+++ b/Mathlib/Data/Set/Semiring.lean
@@ -6,6 +6,7 @@ Authors: Floris van Doorn
 import Mathlib.Algebra.Group.Pointwise.Set.Basic
 import Mathlib.Algebra.Order.Kleene
 import Mathlib.Algebra.Order.Ring.Canonical
+import Mathlib.Data.Set.BooleanAlgebra
 
 /-!
 # Sets as a semiring under union

--- a/Mathlib/GroupTheory/GroupAction/Defs.lean
+++ b/Mathlib/GroupTheory/GroupAction/Defs.lean
@@ -7,6 +7,7 @@ import Mathlib.Algebra.Group.Action.Basic
 import Mathlib.Algebra.Group.Pointwise.Set.Basic
 import Mathlib.Algebra.Group.Subgroup.Defs
 import Mathlib.Algebra.Group.Submonoid.MulAction
+import Mathlib.Data.Set.BooleanAlgebra
 
 /-!
 # Definition of `orbit`, `fixedPoints` and `stabilizer`

--- a/Mathlib/GroupTheory/GroupAction/Pointwise.lean
+++ b/Mathlib/GroupTheory/GroupAction/Pointwise.lean
@@ -5,6 +5,7 @@ Authors: Nathaniel Thomas, Jeremy Avigad, Johannes Hölzl, Mario Carneiro, Anne 
   Frédéric Dupuis, Heather Macbeth, Antoine Chambert-Loir
 -/
 import Mathlib.Algebra.Group.Pointwise.Set.Basic
+import Mathlib.Data.Set.Function
 import Mathlib.GroupTheory.GroupAction.Hom
 
 /-!

--- a/Mathlib/Topology/Algebra/ConstMulAction.lean
+++ b/Mathlib/Topology/Algebra/ConstMulAction.lean
@@ -3,6 +3,7 @@ Copyright (c) 2021 Alex Kontorovich, Heather Macbeth. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Alex Kontorovich, Heather Macbeth
 -/
+import Mathlib.Algebra.Group.Pointwise.Set.Lattice
 import Mathlib.Algebra.GroupWithZero.Action.Pointwise.Set
 import Mathlib.Algebra.Module.ULift
 import Mathlib.Algebra.Order.Group.Synonym


### PR DESCRIPTION
This PR splits up the long file `Algebra.Group.Pointwise.Set.Basic` by taking out all results involving the complete lattice structure on Set: these now live in `Pointwise.Set.Lattice`. We get a surprising reduction in downstream imports, since apparently we don't care much about order theory in that area of the library!


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
