### PR TITLE
[Merged by Bors] - chore(Algebra/Group): split off big operators from `Pointwise/Finset/Basic.lean`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -354,6 +354,7 @@ import Mathlib.Algebra.Group.Pi.Basic
 import Mathlib.Algebra.Group.Pi.Lemmas
 import Mathlib.Algebra.Group.Pi.Units
 import Mathlib.Algebra.Group.Pointwise.Finset.Basic
+import Mathlib.Algebra.Group.Pointwise.Finset.BigOperators
 import Mathlib.Algebra.Group.Pointwise.Finset.Density
 import Mathlib.Algebra.Group.Pointwise.Finset.Interval
 import Mathlib.Algebra.Group.Pointwise.Set.Basic

--- a/Mathlib/Algebra/Group/Pointwise/Finset/Basic.lean
+++ b/Mathlib/Algebra/Group/Pointwise/Finset/Basic.lean
@@ -3,10 +3,8 @@ Copyright (c) 2020 Floris van Doorn. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Floris van Doorn, Yaël Dillies
 -/
-import Mathlib.Algebra.BigOperators.Group.Finset.Basic
 import Mathlib.Algebra.Group.Pointwise.Set.Finite
 import Mathlib.Algebra.Group.Pointwise.Set.ListOfFn
-import Mathlib.Algebra.Order.Group.Nat
 import Mathlib.Algebra.Order.Monoid.Unbundled.WithTop
 import Mathlib.Data.Finset.Max
 import Mathlib.Data.Finset.NAry
@@ -54,7 +52,7 @@ finset multiplication, finset addition, pointwise addition, pointwise multiplica
 pointwise subtraction
 -/
 
-assert_not_exists Cardinal Finset.dens MonoidWithZero MulAction
+assert_not_exists Cardinal Finset.dens MonoidWithZero MulAction OrderedCommMonoid
 
 open Function MulOpposite
 
@@ -1090,11 +1088,6 @@ protected def commMonoid : CommMonoid (Finset α) :=
 
 scoped[Pointwise] attribute [instance] Finset.commMonoid Finset.addCommMonoid
 
-@[to_additive (attr := simp, norm_cast)]
-theorem coe_prod {ι : Type*} (s : Finset ι) (f : ι → Finset α) :
-    ↑(∏ i ∈ s, f i) = ∏ i ∈ s, (f i : Set α) :=
-  map_prod ((coeMonoidHom) : Finset α →* Set α) _ _
-
 end CommMonoid
 
 open Pointwise
@@ -1532,26 +1525,6 @@ theorem image_smul_comm [DecidableEq β] [DecidableEq γ] [SMul α β] [SMul α 
     (s : Finset β) : (∀ b, f (a • b) = a • f b) → (a • s).image f = a • s.image f :=
   image_comm
 
-section BigOps
-section CommMonoid
-variable [CommMonoid α] {ι : Type*} [DecidableEq ι]
-
-@[to_additive (attr := simp)] lemma prod_inv_index [InvolutiveInv ι] (s : Finset ι) (f : ι → α) :
-    ∏ i ∈ s⁻¹, f i = ∏ i ∈ s, f i⁻¹ := prod_image inv_injective.injOn
-
-@[to_additive existing, simp] lemma prod_neg_index [InvolutiveNeg ι] (s : Finset ι) (f : ι → α) :
-    ∏ i ∈ -s, f i = ∏ i ∈ s, f (-i) := prod_image neg_injective.injOn
-
-end CommMonoid
-
-section AddCommMonoid
-variable [AddCommMonoid α] {ι : Type*} [DecidableEq ι]
-
-@[to_additive existing, simp] lemma sum_inv_index [InvolutiveInv ι] (s : Finset ι) (f : ι → α) :
-    ∑ i ∈ s⁻¹, f i = ∑ i ∈ s, f i⁻¹ := sum_image inv_injective.injOn
-
-end AddCommMonoid
-end BigOps
 end Finset
 
 namespace Fintype

--- a/Mathlib/Algebra/Group/Pointwise/Finset/BigOperators.lean
+++ b/Mathlib/Algebra/Group/Pointwise/Finset/BigOperators.lean
@@ -1,0 +1,64 @@
+/-
+Copyright (c) 2020 Floris van Doorn. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Floris van Doorn, Yaël Dillies
+-/
+import Mathlib.Algebra.BigOperators.Group.Finset.Basic
+import Mathlib.Algebra.Group.Pointwise.Finset.Basic
+
+/-!
+# Pointwise big operators on finsets
+
+This file contains basic results on applying big operators (product and sum) on finsets.
+
+## Implementation notes
+
+We put all instances in the locale `Pointwise`, so that these instances are not available by
+default. Note that we do not mark them as reducible (as argued by note [reducible non-instances])
+since we expect the locale to be open whenever the instances are actually used (and making the
+instances reducible changes the behavior of `simp`.
+
+## Tags
+
+finset multiplication, finset addition, pointwise addition, pointwise multiplication,
+pointwise subtraction
+-/
+
+open scoped Pointwise
+
+variable {α ι : Type*}
+
+namespace Finset
+
+section CommMonoid
+
+variable [CommMonoid α]
+
+variable [DecidableEq α]
+
+@[to_additive (attr := simp, norm_cast)]
+theorem coe_prod  (s : Finset ι) (f : ι → Finset α) :
+    ↑(∏ i ∈ s, f i) = ∏ i ∈ s, (f i : Set α) :=
+  map_prod ((coeMonoidHom) : Finset α →* Set α) _ _
+
+omit [DecidableEq α]
+variable [DecidableEq ι]
+
+@[to_additive (attr := simp)] lemma prod_inv_index [InvolutiveInv ι] (s : Finset ι) (f : ι → α) :
+    ∏ i ∈ s⁻¹, f i = ∏ i ∈ s, f i⁻¹ := prod_image inv_injective.injOn
+
+@[to_additive existing, simp] lemma prod_neg_index [InvolutiveNeg ι] (s : Finset ι) (f : ι → α) :
+    ∏ i ∈ -s, f i = ∏ i ∈ s, f (-i) := prod_image neg_injective.injOn
+
+end CommMonoid
+
+section AddCommMonoid
+
+variable [AddCommMonoid α] [DecidableEq ι]
+
+@[to_additive existing, simp] lemma sum_inv_index [InvolutiveInv ι] (s : Finset ι) (f : ι → α) :
+    ∑ i ∈ s⁻¹, f i = ∑ i ∈ s, f i⁻¹ := sum_image inv_injective.injOn
+
+end AddCommMonoid
+
+end Finset

--- a/Mathlib/Algebra/Group/UniqueProds/Basic.lean
+++ b/Mathlib/Algebra/Group/UniqueProds/Basic.lean
@@ -4,8 +4,11 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Damiano Testa
 -/
 import Mathlib.Algebra.FreeMonoid.Basic
+import Mathlib.Algebra.Group.Equiv.Opposite
 import Mathlib.Algebra.Group.Pointwise.Finset.Basic
+import Mathlib.Algebra.Group.TypeTags.Basic
 import Mathlib.Algebra.Group.ULift
+import Mathlib.Algebra.Order.Group.Nat
 import Mathlib.Data.DFinsupp.Defs
 import Mathlib.Data.Finsupp.Defs
 


### PR DESCRIPTION
These lemmas cause a relatively big import bump and seem to be otherwise unused. The file `Pointwise/Finset/Basic.lean` is still too long but does not seem to have any other obvious splitting points.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
