### PR TITLE
[Merged by Bors] - feat(Subgroup/Lattice): add `toAddSubgroup_closure`

### DIFF
--- a/Mathlib/Algebra/Group/Subgroup/Lattice.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Lattice.lean
@@ -470,17 +470,17 @@ theorem closure_eq_top_of_mclosure_eq_top {S : Set G} (h : Submonoid.closure S =
     closure S = ⊤ :=
   (eq_top_iff' _).2 fun _ => le_closure_toSubmonoid _ <| h.symm ▸ trivial
 
-theorem closure_toAddSubgroup (S : Set G) :
+theorem toAddSubgroup_closure (S : Set G) :
     (Subgroup.closure S).toAddSubgroup =
       AddSubgroup.closure (Additive.toMul ⁻¹' S) :=
   le_antisymm (toAddSubgroup.le_symm_apply.mp <|
       (closure_le _).mpr (AddSubgroup.subset_closure (G := Additive G)))
     ((AddSubgroup.closure_le _).mpr (subset_closure (G := G)))
 
-theorem _root_.AddSubgroup.closure_toSubgroup {A : Type*} [AddGroup A] (S : Set A) :
+theorem _root_.AddSubgroup.toSubgroup_closure {A : Type*} [AddGroup A] (S : Set A) :
     (AddSubgroup.closure S).toSubgroup =
       Subgroup.closure (Multiplicative.toAdd ⁻¹' S) :=
-  Subgroup.toAddSubgroup.injective (Subgroup.closure_toAddSubgroup _).symm
+  Subgroup.toAddSubgroup.injective (Subgroup.toAddSubgroup_closure _).symm
 
 @[to_additive]
 theorem mem_iSup_of_directed {ι} [hι : Nonempty ι] {K : ι → Subgroup G} (hK : Directed (· ≤ ·) K)

--- a/Mathlib/Algebra/Group/Subgroup/Lattice.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Lattice.lean
@@ -471,16 +471,24 @@ theorem closure_eq_top_of_mclosure_eq_top {S : Set G} (h : Submonoid.closure S =
   (eq_top_iff' _).2 fun _ => le_closure_toSubmonoid _ <| h.symm ▸ trivial
 
 theorem toAddSubgroup_closure (S : Set G) :
-    (Subgroup.closure S).toAddSubgroup =
-      AddSubgroup.closure (Additive.toMul ⁻¹' S) :=
+    (Subgroup.closure S).toAddSubgroup = AddSubgroup.closure (Additive.toMul ⁻¹' S) :=
   le_antisymm (toAddSubgroup.le_symm_apply.mp <|
       (closure_le _).mpr (AddSubgroup.subset_closure (G := Additive G)))
     ((AddSubgroup.closure_le _).mpr (subset_closure (G := G)))
 
 theorem _root_.AddSubgroup.toSubgroup_closure {A : Type*} [AddGroup A] (S : Set A) :
-    (AddSubgroup.closure S).toSubgroup =
-      Subgroup.closure (Multiplicative.toAdd ⁻¹' S) :=
-  Subgroup.toAddSubgroup.injective (Subgroup.toAddSubgroup_closure _).symm
+    (AddSubgroup.closure S).toSubgroup = Subgroup.closure (Multiplicative.toAdd ⁻¹' S) :=
+  Subgroup.toAddSubgroup.injective (Subgroup.toAddSubgroup_closure _ ).symm
+
+theorem toAddSubgroup'_closure {A : Type*} [AddGroup A] (S : Set (Multiplicative A)) :
+    (closure S).toAddSubgroup' = AddSubgroup.closure (Additive.ofMul ⁻¹' S) :=
+  le_antisymm (toAddSubgroup'.to_galoisConnection.l_le <|
+      (closure_le _).mpr <| AddSubgroup.subset_closure (G := A))
+    ((AddSubgroup.closure_le _).mpr <| Subgroup.subset_closure (G := Multiplicative A))
+
+theorem _root_.AddSubgroup.toSubgroup'_closure (S : Set (Additive G)) :
+    (AddSubgroup.closure S).toSubgroup' = Subgroup.closure (Multiplicative.ofAdd ⁻¹' S) :=
+  congr_arg AddSubgroup.toSubgroup' (toAddSubgroup'_closure _).symm
 
 @[to_additive]
 theorem mem_iSup_of_directed {ι} [hι : Nonempty ι] {K : ι → Subgroup G} (hK : Directed (· ≤ ·) K)

--- a/Mathlib/Algebra/Group/Subgroup/Lattice.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Lattice.lean
@@ -470,6 +470,18 @@ theorem closure_eq_top_of_mclosure_eq_top {S : Set G} (h : Submonoid.closure S =
     closure S = ⊤ :=
   (eq_top_iff' _).2 fun _ => le_closure_toSubmonoid _ <| h.symm ▸ trivial
 
+theorem closure_toAddSubgroup (S : Set G) :
+    (Subgroup.closure S).toAddSubgroup =
+      AddSubgroup.closure (Additive.toMul ⁻¹' S) :=
+  le_antisymm (toAddSubgroup.le_symm_apply.mp <|
+      (closure_le _).mpr (AddSubgroup.subset_closure (G := Additive G)))
+    ((AddSubgroup.closure_le _).mpr (subset_closure (G := G)))
+
+theorem _root_.AddSubgroup.closure_toSubgroup {A : Type*} [AddGroup A] (S : Set A) :
+    (AddSubgroup.closure S).toSubgroup =
+      Subgroup.closure (Multiplicative.toAdd ⁻¹' S) :=
+  Subgroup.toAddSubgroup.injective (Subgroup.closure_toAddSubgroup _).symm
+
 @[to_additive]
 theorem mem_iSup_of_directed {ι} [hι : Nonempty ι] {K : ι → Subgroup G} (hK : Directed (· ≤ ·) K)
     {x : G} : x ∈ (iSup K : Subgroup G) ↔ ∃ i, x ∈ K i := by

--- a/Mathlib/Algebra/Group/Subgroup/Lattice.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Lattice.lean
@@ -481,13 +481,13 @@ theorem _root_.AddSubgroup.toSubgroup_closure {A : Type*} [AddGroup A] (S : Set 
   Subgroup.toAddSubgroup.injective (Subgroup.toAddSubgroup_closure _ ).symm
 
 theorem toAddSubgroup'_closure {A : Type*} [AddGroup A] (S : Set (Multiplicative A)) :
-    (closure S).toAddSubgroup' = AddSubgroup.closure (Additive.ofMul ⁻¹' S) :=
+    (closure S).toAddSubgroup' = AddSubgroup.closure (Multiplicative.ofAdd ⁻¹' S) :=
   le_antisymm (toAddSubgroup'.to_galoisConnection.l_le <|
       (closure_le _).mpr <| AddSubgroup.subset_closure (G := A))
     ((AddSubgroup.closure_le _).mpr <| Subgroup.subset_closure (G := Multiplicative A))
 
 theorem _root_.AddSubgroup.toSubgroup'_closure (S : Set (Additive G)) :
-    (AddSubgroup.closure S).toSubgroup' = Subgroup.closure (Multiplicative.ofAdd ⁻¹' S) :=
+    (AddSubgroup.closure S).toSubgroup' = Subgroup.closure (Additive.ofMul ⁻¹' S) :=
   congr_arg AddSubgroup.toSubgroup' (toAddSubgroup'_closure _).symm
 
 @[to_additive]

--- a/Mathlib/Algebra/Group/Submonoid/Operations.lean
+++ b/Mathlib/Algebra/Group/Submonoid/Operations.lean
@@ -106,7 +106,7 @@ theorem Submonoid.toAddSubmonoid_closure (S : Set M) :
 
 theorem AddSubmonoid.toSubmonoid'_closure (S : Set (Additive M)) :
     AddSubmonoid.toSubmonoid' (AddSubmonoid.closure S)
-      = Submonoid.closure (Multiplicative.ofAdd ⁻¹' S) :=
+      = Submonoid.closure (Additive.ofMul ⁻¹' S) :=
   le_antisymm
     (AddSubmonoid.toSubmonoid'.le_symm_apply.1 <|
       AddSubmonoid.closure_le.2 (Submonoid.subset_closure (M := M)))
@@ -148,7 +148,7 @@ theorem AddSubmonoid.toSubmonoid_closure (S : Set A) :
 
 theorem Submonoid.toAddSubmonoid'_closure (S : Set (Multiplicative A)) :
     Submonoid.toAddSubmonoid' (Submonoid.closure S)
-      = AddSubmonoid.closure (Additive.ofMul ⁻¹' S) :=
+      = AddSubmonoid.closure (Multiplicative.ofAdd ⁻¹' S) :=
   le_antisymm
     (Submonoid.toAddSubmonoid'.to_galoisConnection.l_le <|
       Submonoid.closure_le.2 <| AddSubmonoid.subset_closure (M := A))

--- a/Mathlib/GroupTheory/Finiteness.lean
+++ b/Mathlib/GroupTheory/Finiteness.lean
@@ -60,7 +60,7 @@ theorem Submonoid.fg_iff_add_fg (P : Submonoid M) : P.FG ↔ P.toAddSubmonoid.FG
     fun h =>
     let ⟨T, hT, hf⟩ := (AddSubmonoid.fg_iff _).1 h
     (Submonoid.fg_iff _).mpr
-      ⟨Multiplicative.ofAdd ⁻¹' T, by simp [← AddSubmonoid.toSubmonoid'_closure, hT], hf⟩⟩
+      ⟨Additive.ofMul ⁻¹' T, by simp [← AddSubmonoid.toSubmonoid'_closure, hT], hf⟩⟩
 
 theorem AddSubmonoid.fg_iff_mul_fg (P : AddSubmonoid N) : P.FG ↔ P.toSubmonoid.FG := by
   convert (Submonoid.fg_iff_add_fg (toSubmonoid P)).symm


### PR DESCRIPTION
See [Zulip](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Subgroup.2Eclosure_toAddSubgroup)

Also corrects some mis-typed casts in the existing `Submonoid` versions.

Co-authored-by: María Inés de Frutos-Fernández <88536493+mariainesdff@users.noreply.github.com>
Co-authored-by: Eric Wieser <[wieser.eric@gmail.com](mailto:wieser.eric@gmail.com)>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
