### PR TITLE
[Merged by Bors] - feat(Data/Finset/Card): add `exists_mem_not_mem_of_card_lt_card`

### DIFF
--- a/Mathlib/Data/Finset/Card.lean
+++ b/Mathlib/Data/Finset/Card.lean
@@ -528,8 +528,7 @@ theorem sdiff_nonempty_of_card_lt_card (h : #s < #t) : (t \ s).Nonempty := by
   exact fun h' ↦ h.not_le (card_le_card h')
 
 theorem exists_mem_not_mem_of_card_lt_card (h : #s < #t) :  ∃ e, e ∈ t ∧ e ∉ s := by
-  obtain ⟨e, he⟩ := diff_nonempty_of_card_lt_card h
-  exact ⟨e, mem_sdiff.mp he⟩
+  simpa [Finset.Nonempty] using sdiff_nonempty_of_card_lt_card h
 
 @[simp]
 lemma card_sdiff_add_card_inter (s t : Finset α) :

--- a/Mathlib/Data/Finset/Card.lean
+++ b/Mathlib/Data/Finset/Card.lean
@@ -523,6 +523,14 @@ lemma card_sdiff_comm (h : #s = #t) : #(s \ t) = #(t \ s) :=
   Nat.add_right_cancel (m := #t) <| by
     simp_rw [card_sdiff_add_card, ← h, card_sdiff_add_card, union_comm]
 
+theorem diff_nonempty_of_card_lt_card (h : #s < #t) : (t \ s).Nonempty := by
+  rw [nonempty_iff_ne_empty, Ne, sdiff_eq_empty_iff_subset]
+  exact fun h' ↦ h.not_le (card_le_card h')
+
+theorem exists_mem_not_mem_of_card_lt_card (h : #s < #t) :  ∃ e, e ∈ t ∧ e ∉ s := by
+  obtain ⟨e, he⟩ := diff_nonempty_of_card_lt_card h
+  exact ⟨e, mem_sdiff.mp he⟩
+
 @[simp]
 lemma card_sdiff_add_card_inter (s t : Finset α) :
     #(s \ t) + #(s ∩ t) = #s := by

--- a/Mathlib/Data/Finset/Card.lean
+++ b/Mathlib/Data/Finset/Card.lean
@@ -523,7 +523,7 @@ lemma card_sdiff_comm (h : #s = #t) : #(s \ t) = #(t \ s) :=
   Nat.add_right_cancel (m := #t) <| by
     simp_rw [card_sdiff_add_card, ← h, card_sdiff_add_card, union_comm]
 
-theorem diff_nonempty_of_card_lt_card (h : #s < #t) : (t \ s).Nonempty := by
+theorem sdiff_nonempty_of_card_lt_card (h : #s < #t) : (t \ s).Nonempty := by
   rw [nonempty_iff_ne_empty, Ne, sdiff_eq_empty_iff_subset]
   exact fun h' ↦ h.not_le (card_le_card h')
 


### PR DESCRIPTION
add exists_mem_not_mem_of_card_lt_card

---

As per our [zulip discussion](https://leanprover.zulipchat.com/#narrow/channel/217875-Is-there-code-for-X.3F/topic/If.20S.2Ecard.20.3E.20T.2Ecard.20then.20there.20is.20an.20element.20in.20S.20that.20is.20not/with/506684107)