### PR TITLE
[Merged by Bors] - chore: an injective bounded linear operator has closed range iff it is anti-Lipschitz

### DIFF
--- a/Mathlib/Analysis/Normed/Operator/Banach.lean
+++ b/Mathlib/Analysis/Normed/Operator/Banach.lean
@@ -377,12 +377,10 @@ lemma equivRange_symm_apply (f : E →SL[σ] F) (hinj : Injective f) (hclo : IsC
   trans f ((f.equivRange hinj hclo).symm.toLinearEquiv ⟨f x, by simp⟩)
   · rfl -- is there an API lemma for this already?
   dsimp only [equivRange_symm]
-  --apply LinearEquiv.ofInjective_symm_apply hinj
   set x' : LinearMap.range f := ⟨f x, by simp⟩
-  -- rw [LinearEquiv.ofInjective_symm_apply f (h := hinj) x']
-  -- #check LinearEquiv.ofInjective_symm_apply f (h := hinj) x'
-  -- goal state: f ((LinearEquiv.ofInjective (↑f) hinj).symm x') = f x
-  sorry
+  set f' : E →ₛₗ[σ] F := ↑f
+  change f' ((LinearEquiv.ofInjective f' hinj).symm x') = _
+  rw [LinearEquiv.ofInjective_symm_apply (f := f') (h := hinj) x']
 
 section
 

--- a/Mathlib/Analysis/Normed/Operator/Banach.lean
+++ b/Mathlib/Analysis/Normed/Operator/Banach.lean
@@ -365,7 +365,7 @@ theorem coe_equivRange (f : E →SL[σ] F) (hinj : Injective f) (hclo : IsClosed
   rfl
 
 @[simp]
-lemma equivRange_symm (f : E →SL[σ] F) (hinj : Injective f) (hclo : IsClosed (range f)) :
+lemma equivRange_symm_toLinearEquiv (f : E →SL[σ] F) (hinj : Injective f) (hclo : IsClosed (range f)) :
     (f.equivRange hinj hclo).symm.toLinearEquiv =
       (LinearEquiv.ofInjective f.toLinearMap hinj).symm := by
   rfl
@@ -404,7 +404,7 @@ lemma antilipschitz_of_injective_of_isClosed_range (f : E →L[𝕜] F)
 
 /-- An injective bounded linear operator between Banach spaces has closed range
 iff it is anti-Lipschitz. -/
-lemma isClosed_range_if_antilipschitz_of_injective (f : E →L[𝕜] F)
+lemma isClosed_range_iff_antilipschitz_of_injective (f : E →L[𝕜] F)
     (hf : Injective f) : IsClosed (Set.range f) ↔ ∃ K, AntilipschitzWith K f := by
   refine ⟨fun h ↦ f.antilipschitz_of_injective_of_isClosed_range hf h, fun h ↦ ?_⟩
   choose K hf' using h

--- a/Mathlib/Analysis/Normed/Operator/Banach.lean
+++ b/Mathlib/Analysis/Normed/Operator/Banach.lean
@@ -388,7 +388,7 @@ variable {E F : Type*}
   [NormedAddCommGroup E] [NormedSpace 𝕜 E] [NormedAddCommGroup F] [NormedSpace 𝕜 F]
   [CompleteSpace E] [CompleteSpace F]
 
--- TODO: generalise this to Fredholm operators, once these are in mathlib
+-- TODO: once mathlib has Fredholm operators, generalise the next two lemmas
 
 /-- If `f : E →L[𝕜] F` is injective with closed range (and `E` and `F` are Banach spaces),
 `f` is anti-Lipschitz. -/

--- a/Mathlib/Analysis/Normed/Operator/Banach.lean
+++ b/Mathlib/Analysis/Normed/Operator/Banach.lean
@@ -344,17 +344,15 @@ end LinearEquiv
 
 namespace ContinuousLinearMap
 
-variable [CompleteSpace E] [RingHomInvPair σ' σ]
+variable [CompleteSpace E] [RingHomInvPair σ' σ] {f : E →SL[σ] F}
 
 /-- An injective continuous linear map with a closed range defines a continuous linear equivalence
 between its domain and its range. -/
-noncomputable def equivRange {f : E →SL[σ] F} (hinj : Injective f) (hclo : IsClosed (range f)) :
+noncomputable def equivRange (hinj : Injective f) (hclo : IsClosed (range f)) :
     E ≃SL[σ] LinearMap.range f :=
   have : CompleteSpace (LinearMap.range f) := hclo.completeSpace_coe
   LinearEquiv.toContinuousLinearEquivOfContinuous (LinearEquiv.ofInjective f.toLinearMap hinj) <|
     (f.continuous.codRestrict fun x ↦ LinearMap.mem_range_self f x).congr fun _ ↦ rfl
-
-variable {f : E →SL[σ] F}
 
 @[simp]
 theorem coe_linearMap_equivRange (hinj : Injective f) (hclo : IsClosed (range f)) :
@@ -390,7 +388,7 @@ variable {E F : Type*}
   [NormedAddCommGroup E] [NormedSpace 𝕜 E] [NormedAddCommGroup F] [NormedSpace 𝕜 F]
   [CompleteSpace E] [CompleteSpace F]
 
--- TODO: once mathlib has Fredholm operators, generalise the next two lemmas
+-- TODO: once mathlib has Fredholm operators, generalise the next two lemmas accordingly
 
 /-- If `f : E →L[𝕜] F` is injective with closed range (and `E` and `F` are Banach spaces),
 `f` is anti-Lipschitz. -/

--- a/Mathlib/Analysis/Normed/Operator/Banach.lean
+++ b/Mathlib/Analysis/Normed/Operator/Banach.lean
@@ -348,30 +348,32 @@ variable [CompleteSpace E] [RingHomInvPair σ' σ]
 
 /-- An injective continuous linear map with a closed range defines a continuous linear equivalence
 between its domain and its range. -/
-noncomputable def equivRange (f : E →SL[σ] F) (hinj : Injective f) (hclo : IsClosed (range f)) :
+noncomputable def equivRange {f : E →SL[σ] F} (hinj : Injective f) (hclo : IsClosed (range f)) :
     E ≃SL[σ] LinearMap.range f :=
   have : CompleteSpace (LinearMap.range f) := hclo.completeSpace_coe
   LinearEquiv.toContinuousLinearEquivOfContinuous (LinearEquiv.ofInjective f.toLinearMap hinj) <|
     (f.continuous.codRestrict fun x ↦ LinearMap.mem_range_self f x).congr fun _ ↦ rfl
 
+variable {f : E →SL[σ] F}
+
 @[simp]
-theorem coe_linearMap_equivRange (f : E →SL[σ] F) (hinj : Injective f) (hclo : IsClosed (range f)) :
+theorem coe_linearMap_equivRange (hinj : Injective f) (hclo : IsClosed (range f)) :
     f.equivRange hinj hclo = f.rangeRestrict :=
   rfl
 
 @[simp]
-theorem coe_equivRange (f : E →SL[σ] F) (hinj : Injective f) (hclo : IsClosed (range f)) :
+theorem coe_equivRange (hinj : Injective f) (hclo : IsClosed (range f)) :
     (f.equivRange hinj hclo : E → LinearMap.range f) = f.rangeRestrict :=
   rfl
 
 @[simp]
-lemma equivRange_symm_toLinearEquiv (f : E →SL[σ] F) (hinj : Injective f) (hclo : IsClosed (range f)) :
+lemma equivRange_symm_toLinearEquiv (hinj : Injective f) (hclo : IsClosed (range f)) :
     (f.equivRange hinj hclo).symm.toLinearEquiv =
       (LinearEquiv.ofInjective f.toLinearMap hinj).symm := by
   rfl
 
 @[simp]
-lemma equivRange_symm_apply (f : E →SL[σ] F) (hinj : Injective f) (hclo : IsClosed (range f))
+lemma equivRange_symm_apply (hinj : Injective f) (hclo : IsClosed (range f))
     (x : E) : (f.equivRange hinj hclo).symm ⟨f x, by simp⟩ = x := by
   suffices f ((f.equivRange hinj hclo).symm ⟨f x, by simp⟩) = f x from hinj this
   trans f ((f.equivRange hinj hclo).symm.toLinearEquiv ⟨f x, by simp⟩)

--- a/Mathlib/Analysis/Normed/Operator/Banach.lean
+++ b/Mathlib/Analysis/Normed/Operator/Banach.lean
@@ -376,7 +376,7 @@ lemma equivRange_symm_apply (f : E →SL[σ] F) (hinj : Injective f) (hclo : IsC
   suffices f ((f.equivRange hinj hclo).symm ⟨f x, by simp⟩) = f x from hinj this
   trans f ((f.equivRange hinj hclo).symm.toLinearEquiv ⟨f x, by simp⟩)
   · rfl -- is there an API lemma for this already?
-  dsimp only [equivRange_symm]
+  dsimp only [equivRange_symm_toLinearEquiv]
   set x' : LinearMap.range f := ⟨f x, by simp⟩
   set f' : E →ₛₗ[σ] F := ↑f
   change f' ((LinearEquiv.ofInjective f' hinj).symm x') = _

--- a/Mathlib/Analysis/Normed/Operator/Banach.lean
+++ b/Mathlib/Analysis/Normed/Operator/Banach.lean
@@ -364,6 +364,56 @@ theorem coe_equivRange (f : E →SL[σ] F) (hinj : Injective f) (hclo : IsClosed
     (f.equivRange hinj hclo : E → LinearMap.range f) = f.rangeRestrict :=
   rfl
 
+@[simp]
+lemma equivRange_symm (f : E →SL[σ] F) (hinj : Injective f) (hclo : IsClosed (range f)) :
+    (f.equivRange hinj hclo).symm.toLinearEquiv =
+      (LinearEquiv.ofInjective f.toLinearMap hinj).symm := by
+  rfl
+
+@[simp]
+lemma equivRange_symm_apply (f : E →SL[σ] F) (hinj : Injective f) (hclo : IsClosed (range f))
+    (x : E) : (f.equivRange hinj hclo).symm ⟨f x, by simp⟩ = x := by
+  suffices f ((f.equivRange hinj hclo).symm ⟨f x, by simp⟩) = f x from hinj this
+  trans f ((f.equivRange hinj hclo).symm.toLinearEquiv ⟨f x, by simp⟩)
+  · rfl -- is there an API lemma for this already?
+  dsimp only [equivRange_symm]
+  --apply LinearEquiv.ofInjective_symm_apply hinj
+  set x' : LinearMap.range f := ⟨f x, by simp⟩
+  -- rw [LinearEquiv.ofInjective_symm_apply f (h := hinj) x']
+  -- #check LinearEquiv.ofInjective_symm_apply f (h := hinj) x'
+  -- goal state: f ((LinearEquiv.ofInjective (↑f) hinj).symm x') = f x
+  sorry
+
+section
+
+variable {E F : Type*}
+  [NormedAddCommGroup E] [NormedSpace 𝕜 E] [NormedAddCommGroup F] [NormedSpace 𝕜 F]
+  [CompleteSpace E] [CompleteSpace F]
+
+-- TODO: generalise this to Fredholm operators, once these are in mathlib
+
+/-- If `f : E →L[𝕜] F` is injective with closed range (and `E` and `F` are Banach spaces),
+`f` is anti-Lipschitz. -/
+lemma antilipschitz_of_injective_of_isClosed_range (f : E →L[𝕜] F)
+    (hf : Injective f) (hf' : IsClosed (Set.range f)) : ∃ K, AntilipschitzWith K f := by
+  let S : (LinearMap.range f) →L[𝕜] E := (f.equivRange hf hf').symm
+  use ⟨S.opNorm, S.opNorm_nonneg⟩
+  apply ContinuousLinearMap.antilipschitz_of_bound
+  intro x
+  calc ‖x‖
+    _ = ‖S ⟨f x, by simp⟩‖ := by simp [S]
+    _ ≤ S.opNorm * ‖f x‖ := le_opNorm S ⟨f x, by simp⟩
+
+/-- An injective bounded linear operator between Banach spaces has closed range
+iff it is anti-Lipschitz. -/
+lemma isClosed_range_if_antilipschitz_of_injective (f : E →L[𝕜] F)
+    (hf : Injective f) : IsClosed (Set.range f) ↔ ∃ K, AntilipschitzWith K f := by
+  refine ⟨fun h ↦ f.antilipschitz_of_injective_of_isClosed_range hf h, fun h ↦ ?_⟩
+  choose K hf' using h
+  exact hf'.isClosed_range f.uniformContinuous
+
+end
+
 end ContinuousLinearMap
 
 namespace ContinuousLinearEquiv


### PR DESCRIPTION
And make the argument `f` of `ContinuousLinearMap.equivRange` implicit,
as the explicit hypotheses `hf` and `hclo` mention `f`.

---

This is motivated by defining immersions between Banach manifolds: the correct condition is that the `mfderiv` is a split linear map, and proving that the composition of split linear maps is split requires this lemma.

~There is one remaining sorry, which I don't know how to do: @winstonyin as the original author of `ContinuousLinearMap.equivRange`, do you happen to have an idea?~ `RubenVandeVelde` helped me fix the sorry, but better approaches are very welcome.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
