### PR TITLE
[Merged by Bors] - chore: define shortcut instance for `One Nat`

### DIFF
--- a/Mathlib/Algebra/Group/Nat/Defs.lean
+++ b/Mathlib/Algebra/Group/Nat/Defs.lean
@@ -59,6 +59,7 @@ instance instCommSemigroup    : CommSemigroup ℕ    := by infer_instance
 instance instSemigroup        : Semigroup ℕ        := by infer_instance
 instance instAddCommSemigroup : AddCommSemigroup ℕ := by infer_instance
 instance instAddSemigroup     : AddSemigroup ℕ     := by infer_instance
+instance instOne : One ℕ := inferInstance
 
 /-! ### Miscellaneous lemmas -/
 

--- a/Mathlib/Algebra/Homology/Embedding/Basic.lean
+++ b/Mathlib/Algebra/Homology/Embedding/Basic.lean
@@ -5,7 +5,7 @@ Authors: Joël Riou
 -/
 import Mathlib.Algebra.Homology.ComplexShape
 import Mathlib.Algebra.Ring.Int.Defs
-import Mathlib.Algebra.Ring.Nat
+import Mathlib.Algebra.Group.Nat.Defs
 import Mathlib.Tactic.ByContra
 
 /-! # Embeddings of complex shapes
@@ -49,6 +49,8 @@ transformation `e.ιTruncLENatTrans : e.truncGEFunctor C ⟶ 𝟭 _` which is a 
 in degrees in the image of `e.f` (TODO);
 
 -/
+
+assert_not_exists Nat.instAddMonoidWithOne Nat.instMulZeroClass
 
 variable {ι ι' : Type*} (c : ComplexShape ι) (c' : ComplexShape ι')
 

--- a/Mathlib/Algebra/Tropical/Basic.lean
+++ b/Mathlib/Algebra/Tropical/Basic.lean
@@ -4,12 +4,12 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yakov Pechersky
 -/
 import Mathlib.Algebra.GroupWithZero.Action.Defs
-import Mathlib.Algebra.Order.Monoid.Unbundled.Pow
-import Mathlib.Order.Hom.Basic
-import Mathlib.Algebra.Order.Monoid.Unbundled.WithTop
 import Mathlib.Algebra.Order.AddGroupWithTop
-import Mathlib.Algebra.Ring.Nat
 import Mathlib.Algebra.Order.Monoid.Unbundled.MinMax
+import Mathlib.Algebra.Order.Monoid.Unbundled.Pow
+import Mathlib.Algebra.Order.Monoid.Unbundled.WithTop
+import Mathlib.Algebra.Ring.Defs
+import Mathlib.Order.Hom.Basic
 
 /-!
 
@@ -45,6 +45,7 @@ most references rely on `Semiring (Tropical R)` for building up the whole theory
 
 -/
 
+assert_not_exists Nat.instMulOneClass
 
 universe u v
 


### PR DESCRIPTION
Without this instance, typeclass search derives it from the AddMonoidWithOne instance, which pulls in unnecessary material.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
