### PR TITLE
[Merged by Bors] - feat(Algebra/Order): injectivity of `zpow` in its left argument

### DIFF
--- a/Mathlib/Algebra/Order/GroupWithZero/Unbundled/Basic.lean
+++ b/Mathlib/Algebra/Order/GroupWithZero/Unbundled/Basic.lean
@@ -13,6 +13,8 @@ public import Mathlib.Order.Monotone.Basic
 public import Mathlib.Tactic.Bound.Attribute
 public import Mathlib.Tactic.Monotonicity.Attr
 
+import Mathlib.Data.Set.Function
+
 /-!
 # Lemmas on the monotone multiplication typeclasses
 
@@ -1352,6 +1354,18 @@ lemma zpow_lt_zpow_iff_left₀ (ha : 0 ≤ a) (hb : 0 ≤ b) (hn : 0 < n) : a ^ 
 
 end MulPosMono
 
+section PosMulStrictMono
+variable [PosMulStrictMono G₀] [MulPosMono G₀]
+
+lemma zpow_left_injOn₀ : ∀ {n : ℤ}, n ≠ 0 → {a | 0 ≤ a}.InjOn fun a : G₀ ↦ a ^ n
+  | (n + 1 : ℕ), _ => by simpa using mod_cast (pow_left_strictMonoOn₀ n.succ_ne_zero).injOn
+  | .negSucc n, _ => by
+    simpa using inv_injective.comp_injOn (pow_left_strictMonoOn₀ n.succ_ne_zero).injOn
+
+lemma zpow_left_inj₀ (ha : 0 ≤ a) (hb : 0 ≤ b) (hn : n ≠ 0) :
+    a ^ n = b ^ n ↔ a = b := (zpow_left_injOn₀ hn).eq_iff ha hb
+
+end PosMulStrictMono
 end GroupWithZero.LinearOrder
 
 section CommGroupWithZero

--- a/MathlibTest/nontriviality.lean
+++ b/MathlibTest/nontriviality.lean
@@ -53,11 +53,11 @@ test_sorry
 theorem Subsingleton.set_empty_or_univ' {α} [Subsingleton α] (s : Set α) : EmptyOrUniv s :=
   Subsingleton.set_empty_or_univ s
 
-theorem Set.empty_union (a : Set α) : ∅ ∪ a = a := test_sorry
+theorem MySet.empty_union (a : Set α) : ∅ ∪ a = a := test_sorry
 
 example {α : Type _} (s : Set α) (hs : s = ∅ ∪ Set.univ) : EmptyOrUniv s := by
   fail_if_success nontriviality α
-  rw [Set.empty_union] at hs
+  rw [MySet.empty_union] at hs
   exact Or.inr hs
 
 section
@@ -67,7 +67,7 @@ attribute [local nontriviality] Subsingleton.set_empty_or_univ
 example {α : Type _} (s : Set α) (hs : s = ∅ ∪ Set.univ) : EmptyOrUniv s := by
   fail_if_success nontriviality α
   nontriviality α using Subsingleton.set_empty_or_univ'
-  rw [Set.empty_union] at hs
+  rw [MySet.empty_union] at hs
   exact Or.inr hs
 
 end


### PR DESCRIPTION
Co-authored-by: María Inés de Frutos Fernández <midff@math.uni-bonn.de>

---

- [x] depends on: #26665
- [x] depends on: #26724
- [x] depends on: #26761
- [x] depends on: #26762
- [x] depends on: #26763