### PR TITLE
[Merged by Bors] - chore: generalise `ENat.iInf_eq_zero`

### DIFF
--- a/Mathlib/Data/ENat/Lattice.lean
+++ b/Mathlib/Data/ENat/Lattice.lean
@@ -67,7 +67,7 @@ lemma iInf_toNat : (⨅ i, (f i : ℕ∞)).toNat = ⨅ i, f i := by
   · simp
   · norm_cast
 
-@[simp] lemma iInf_eq_zero {f : ι → ℕ∞} : ⨅ i, (f i : ℕ∞) = 0 ↔ ∃ i, f i = 0 := by
+@[simp] lemma iInf_eq_zero {f : ι → ℕ∞} : ⨅ i, f i = 0 ↔ ∃ i, f i = 0 := by
   simpa [lt_one_iff_eq_zero] using iInf_lt_iff (α := ℕ∞) (a := 1)
 
 variable {f : ι → ℕ∞} {s : Set ℕ∞}

--- a/Mathlib/Data/ENat/Lattice.lean
+++ b/Mathlib/Data/ENat/Lattice.lean
@@ -67,12 +67,8 @@ lemma iInf_toNat : (⨅ i, (f i : ℕ∞)).toNat = ⨅ i, f i := by
   · simp
   · norm_cast
 
-lemma iInf_eq_zero : ⨅ i, (f i : ℕ∞) = 0 ↔ ∃ i, f i = 0 := by
-  cases isEmpty_or_nonempty ι
-  · simp
-  · norm_cast
-    rw [iInf, Nat.sInf_eq_zero]
-    exact ⟨fun h ↦ by simp_all, .inl⟩
+@[simp] lemma iInf_eq_zero {f : ι → ℕ∞} : ⨅ i, (f i : ℕ∞) = 0 ↔ ∃ i, f i = 0 := by
+  simpa [lt_one_iff_eq_zero] using iInf_lt_iff (α := ℕ∞) (a := 1)
 
 variable {f : ι → ℕ∞} {s : Set ℕ∞}
 


### PR DESCRIPTION
Previously, it had `f : ι → ℕ`. Also make it simp.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
