### PR TITLE
[Merged by Bors] - feat(Algebra/Order/Field/Power): add zpow theorems for linear ordered field similar to pow theorems in linear ordered ring

### DIFF
--- a/Mathlib/Algebra/Order/Field/Power.lean
+++ b/Mathlib/Algebra/Order/Field/Power.lean
@@ -127,7 +127,7 @@ alias ⟨_, Odd.zpow_nonpos⟩ := Odd.zpow_nonpos_iff
 theorem Even.zpow_abs {p : ℤ} (hp : Even p) (a : α) : |a| ^ p = a ^ p := by
   rcases abs_choice a with h | h <;> simp only [h, hp.neg_zpow _]
 
-lemma zpow_eq_zpow_iff_of_ne_zero (hn : n ≠ 0) : a ^ n = b ^ n ↔ a = b ∨ a = -b ∧ Even n :=
+lemma zpow_eq_zpow_iff_of_ne_zero₀ (hn : n ≠ 0) : a ^ n = b ^ n ↔ a = b ∨ a = -b ∧ Even n :=
   match n with
   | Int.ofNat m => by
     simp only [Int.ofNat_eq_coe, ne_eq, Nat.cast_eq_zero, zpow_natCast, Int.even_coe_nat] at *
@@ -138,16 +138,16 @@ lemma zpow_eq_zpow_iff_of_ne_zero (hn : n ≠ 0) : a ^ n = b ^ n ↔ a = b ∨ a
       Int.even_coe_nat] at *
     exact pow_eq_pow_iff_of_ne_zero hn
 
-lemma zpow_eq_zpow_iff_cases : a ^ n = b ^ n ↔ n = 0 ∨ a = b ∨ a = -b ∧ Even n := by
-  rcases eq_or_ne n 0 with rfl | hn <;> simp [zpow_eq_zpow_iff_of_ne_zero, *]
+lemma zpow_eq_zpow_iff_cases₀ : a ^ n = b ^ n ↔ n = 0 ∨ a = b ∨ a = -b ∧ Even n := by
+  rcases eq_or_ne n 0 with rfl | hn <;> simp [zpow_eq_zpow_iff_of_ne_zero₀, *]
 
-lemma zpow_eq_one_iff_of_ne_zero (hn : n ≠ 0) : a ^ n = 1 ↔ a = 1 ∨ a = -1 ∧ Even n := by
-  simp [← zpow_eq_zpow_iff_of_ne_zero hn]
+lemma zpow_eq_one_iff_of_ne_zero₀ (hn : n ≠ 0) : a ^ n = 1 ↔ a = 1 ∨ a = -1 ∧ Even n := by
+  simp [← zpow_eq_zpow_iff_of_ne_zero₀ hn]
 
-lemma zpow_eq_one_iff_cases : a ^ n = 1 ↔ n = 0 ∨ a = 1 ∨ a = -1 ∧ Even n := by
-  simp [← zpow_eq_zpow_iff_cases]
+lemma zpow_eq_one_iff_cases₀ : a ^ n = 1 ↔ n = 0 ∨ a = 1 ∨ a = -1 ∧ Even n := by
+  simp [← zpow_eq_zpow_iff_cases₀]
 
-lemma zpow_eq_neg_zpow_iff (hb : b ≠ 0) : a ^ n = -b ^ n ↔ a = -b ∧ Odd n :=
+lemma zpow_eq_neg_zpow_iff₀ (hb : b ≠ 0) : a ^ n = -b ^ n ↔ a = -b ∧ Odd n :=
   match n with
   | Int.ofNat m => by
     simp [pow_eq_neg_pow_iff, hb]
@@ -155,8 +155,8 @@ lemma zpow_eq_neg_zpow_iff (hb : b ≠ 0) : a ^ n = -b ^ n ↔ a = -b ∧ Odd n 
     rw [show Int.negSucc m = -↑(m + 1) by rfl]
     simp [-Nat.cast_add, -natCast_add, neg_inv, pow_eq_neg_pow_iff, hb]
 
-lemma zpow_eq_neg_one_iff : a ^ n = -1 ↔ a = -1 ∧ Odd n := by
-  simpa using zpow_eq_neg_zpow_iff (α := α) one_ne_zero
+lemma zpow_eq_neg_one_iff₀ : a ^ n = -1 ↔ a = -1 ∧ Odd n := by
+  simpa using zpow_eq_neg_zpow_iff₀ (α := α) one_ne_zero
 
 /-! ### Bernoulli's inequality -/
 

--- a/Mathlib/Algebra/Order/Field/Power.lean
+++ b/Mathlib/Algebra/Order/Field/Power.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2014 Robert Y. Lewis. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Robert Y. Lewis, Leonardo de Moura, Mario Carneiro, Floris van Doorn
+Authors: Robert Y. Lewis, Leonardo de Moura, Mario Carneiro, Floris van Doorn, Sabbir Rahman
 -/
 import Mathlib.Algebra.GroupWithZero.Commute
 import Mathlib.Algebra.Order.Field.Basic
@@ -86,7 +86,7 @@ end LinearOrderedSemifield
 
 section LinearOrderedField
 
-variable [LinearOrderedField α] {a : α} {n : ℤ}
+variable [LinearOrderedField α] {a b : α} {n : ℤ}
 
 protected theorem Even.zpow_nonneg (hn : Even n) (a : α) : 0 ≤ a ^ n := by
   obtain ⟨k, rfl⟩ := hn; rw [zpow_add' (by simp [em'])]; exact mul_self_nonneg _
@@ -126,6 +126,37 @@ alias ⟨_, Odd.zpow_nonpos⟩ := Odd.zpow_nonpos_iff
 
 theorem Even.zpow_abs {p : ℤ} (hp : Even p) (a : α) : |a| ^ p = a ^ p := by
   rcases abs_choice a with h | h <;> simp only [h, hp.neg_zpow _]
+
+lemma zpow_eq_zpow_iff_of_ne_zero (hn : n ≠ 0) : a ^ n = b ^ n ↔ a = b ∨ a = -b ∧ Even n :=
+  match n with
+  | Int.ofNat m => by
+    simp only [Int.ofNat_eq_coe, ne_eq, Nat.cast_eq_zero, zpow_natCast, Int.even_coe_nat] at *
+    exact pow_eq_pow_iff_of_ne_zero hn
+  | Int.negSucc m => by
+    rw [show Int.negSucc m = -↑(m + 1) by rfl] at *
+    simp only [ne_eq, neg_eq_zero, Nat.cast_eq_zero, zpow_neg, zpow_natCast, inv_inj, even_neg,
+      Int.even_coe_nat] at *
+    exact pow_eq_pow_iff_of_ne_zero hn
+
+lemma zpow_eq_zpow_iff_cases : a ^ n = b ^ n ↔ n = 0 ∨ a = b ∨ a = -b ∧ Even n := by
+  rcases eq_or_ne n 0 with rfl | hn <;> simp [zpow_eq_zpow_iff_of_ne_zero, *]
+
+lemma zpow_eq_one_iff_of_ne_zero (hn : n ≠ 0) : a ^ n = 1 ↔ a = 1 ∨ a = -1 ∧ Even n := by
+  simp [← zpow_eq_zpow_iff_of_ne_zero hn]
+
+lemma zpow_eq_one_iff_cases : a ^ n = 1 ↔ n = 0 ∨ a = 1 ∨ a = -1 ∧ Even n := by
+  simp [← zpow_eq_zpow_iff_cases]
+
+lemma zpow_eq_neg_zpow_iff (hb : b ≠ 0) : a ^ n = -b ^ n ↔ a = -b ∧ Odd n :=
+  match n with
+  | Int.ofNat m => by
+    simp [pow_eq_neg_pow_iff, hb]
+  | Int.negSucc m => by
+    rw [show Int.negSucc m = -↑(m + 1) by rfl]
+    simp [-Nat.cast_add, -natCast_add, neg_inv, pow_eq_neg_pow_iff, hb]
+
+lemma zpow_eq_neg_one_iff : a ^ n = -1 ↔ a = -1 ∧ Odd n := by
+  simpa using zpow_eq_neg_zpow_iff (α := α) one_ne_zero
 
 /-! ### Bernoulli's inequality -/
 


### PR DESCRIPTION
Adding Integer power theorems for linear ordered field which allow cancelling power in equations

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

The theorems are analogous to [linear ordered ring theorem for pow](https://github.com/leanprover-community/mathlib4/blob/d7c024f0292e801365f36c1ab2ba2ee2da009e32/Mathlib/Algebra/Order/Ring/Abs.lean#L206-L235). Some of the proofs are kind of same from the pow versions, but this seemed like the best way to go.


[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
