### PR TITLE
[Merged by Bors] - chore: links from choose/factorial docstrings to counting lemmas

### DIFF
--- a/Mathlib/Data/Nat/Choose/Basic.lean
+++ b/Mathlib/Data/Nat/Choose/Basic.lean
@@ -11,6 +11,8 @@ import Mathlib.Order.Monotone.Defs
 
 This file defines binomial coefficients and proves simple lemmas (i.e. those not
 requiring more imports).
+For the lemma that `n.choose k` counts the `k`-element-subsets of an `n`-element set,
+see `Fintype.card_powersetCard` in `Mathlib.Data.Finset.Powerset`.
 
 ## Main definition and results
 
@@ -41,7 +43,8 @@ open Nat
 namespace Nat
 
 /-- `choose n k` is the number of `k`-element subsets in an `n`-element set. Also known as binomial
-coefficients. -/
+coefficients. For the fact that this is the number of `k`-element-subsets of an `n`-element
+set, see `Fintype.card_powersetCard`. -/
 def choose : ℕ → ℕ → ℕ
   | _, 0 => 1
   | 0, _ + 1 => 0

--- a/Mathlib/Data/Nat/Factorial/Basic.lean
+++ b/Mathlib/Data/Nat/Factorial/Basic.lean
@@ -13,7 +13,7 @@ import Mathlib.Tactic.Monotonicity.Attr
 
 This file defines the factorial, along with the ascending and descending variants.
 For the proof that the factorial of `n` counts the permutations of an `n`-element set,
-see `Fintype.card_perm` in `Mathlib.Data.Fintype.Perm`.
+see `Fintype.card_perm`.
 
 ## Main declarations
 

--- a/Mathlib/Data/Nat/Factorial/Basic.lean
+++ b/Mathlib/Data/Nat/Factorial/Basic.lean
@@ -12,6 +12,8 @@ import Mathlib.Tactic.Monotonicity.Attr
 # Factorial and variants
 
 This file defines the factorial, along with the ascending and descending variants.
+For the proof that the factorial of `n` counts the permutations of an `n`-element set,
+see `Fintype.card_perm` in `Mathlib.Data.Fintype.Perm`.
 
 ## Main declarations
 


### PR DESCRIPTION

---

Currently, a user looking at `Nat/Choose/Basic` or `Nat/Factorial/Basic` has no way of knowing where to find the statements that these count the sizes of sets of subsets/permutations, even though the docstring for `Nat.choose` asserts that this is the definition. This PR expands the function and module docstrings to indicate to the user where these lemmas are proved. 


<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
