### PR TITLE
[Merged by Bors] - feat(Analysis): add improper integral of complex exp

### DIFF
--- a/Mathlib/Analysis/SpecialFunctions/ImproperIntegrals.lean
+++ b/Mathlib/Analysis/SpecialFunctions/ImproperIntegrals.lean
@@ -39,7 +39,7 @@ theorem integrableOn_exp_Iic (c : ℝ) : IntegrableOn exp (Iic c) := by
   exact (exp_pos _).le
 
 theorem integrableOn_exp_neg_Ioi (c : ℝ) : IntegrableOn (fun (x : ℝ) => exp (-x)) (Ioi c) :=
-  (integrableOn_exp_Iic (-c)).comp_neg_Ioi
+  integrableOn_Ici_iff_integrableOn_Ioi.mp (integrableOn_exp_Iic (-c)).comp_neg_Ici
 
 theorem integral_exp_Iic (c : ℝ) : ∫ x : ℝ in Iic c, exp x = exp c := by
   refine
@@ -68,7 +68,8 @@ theorem integrableOn_exp_mul_complex_Ioi {a : ℂ} (ha : a.re < 0) (c : ℝ) :
 
 theorem integrableOn_exp_mul_complex_Iic {a : ℂ} (ha : 0 < a.re) (c : ℝ) :
     IntegrableOn (fun x : ℝ => Complex.exp (a * x)) (Iic c) := by
-  simpa using (integrableOn_exp_mul_complex_Ioi (a := -a) (by simpa) (-c)).comp_neg_Iic
+  simpa using integrableOn_Iic_iff_integrableOn_Iio.mpr
+    (integrableOn_exp_mul_complex_Ioi (a := -a) (by simpa) (-c)).comp_neg_Iio
 
 theorem integral_exp_mul_complex_Ioi {a : ℂ} (ha : a.re < 0) (c : ℝ) :
     ∫ x : ℝ in Set.Ioi c, Complex.exp (a * x) = - Complex.exp (a * c) / a := by

--- a/Mathlib/Analysis/SpecialFunctions/ImproperIntegrals.lean
+++ b/Mathlib/Analysis/SpecialFunctions/ImproperIntegrals.lean
@@ -62,43 +62,28 @@ theorem integrableOn_exp_mul_complex_Ioi {a : ℂ} (ha : a.re < 0) (c : ℝ) :
   refine (integrable_norm_iff ?_).mp ?_
   · apply Continuous.aestronglyMeasurable
     fun_prop
-  · conv in (fun x => _) =>
-      ext x
-      rw [(by simp [Complex.norm_exp] : ‖Complex.exp (a * x)‖ = exp (-(-a.re * x)))]
-    have a_neg : 0 < -a.re := by simp [ha]
-    apply (integrableOn_Ioi_comp_mul_left_iff (fun x => exp (-x)) c a_neg).mpr
-    apply integrableOn_exp_neg_Ioi
+  · simpa [Complex.norm_exp] using
+      (integrableOn_Ioi_comp_mul_left_iff (fun x => exp (-x)) c (a := -a.re) (by simpa)).mpr <|
+        integrableOn_exp_neg_Ioi _
 
 theorem integrableOn_exp_mul_complex_Iic {a : ℂ} (ha : 0 < a.re) (c : ℝ) :
     IntegrableOn (fun x : ℝ => Complex.exp (a * x)) (Iic c) := by
-  conv in (fun x => _) =>
-    ext x
-    rw [(by simp : a * x = -a * (-x : ℝ))]
-  have a_neg : (-a).re < 0 := by simp [ha]
-  exact (integrableOn_exp_mul_complex_Ioi a_neg (-c)).comp_neg_Iic
+  simpa using (integrableOn_exp_mul_complex_Ioi (a := -a) (by simpa) (-c)).comp_neg_Iic
 
 theorem integral_exp_mul_complex_Ioi {a : ℂ} (ha : a.re < 0) (c : ℝ) :
     ∫ x : ℝ in Set.Ioi c, Complex.exp (a * x) = - Complex.exp (a * c) / a := by
-  refine
-    tendsto_nhds_unique (intervalIntegral_tendsto_integral_Ioi c
-      (integrableOn_exp_mul_complex_Ioi ha c) tendsto_id) ?_
-  have nonzero : a ≠ 0 := fun h => (Complex.zero_re ▸ h ▸ ha).false
-  simp_rw [integral_exp_mul_complex nonzero, id_eq]
-  rw [(by simp : - Complex.exp (a * c) / a = (0 - Complex.exp (a * c)) / a)]
-  refine Tendsto.div_const (Tendsto.sub_const ?_ _) _
-  apply Complex.tendsto_exp_nhds_zero_iff.mpr
-  simp only [Complex.mul_re, Complex.ofReal_re, Complex.ofReal_im, mul_zero, sub_zero]
-  exact Tendsto.neg_mul_atTop ha tendsto_const_nhds tendsto_id
+  refine tendsto_nhds_unique (intervalIntegral_tendsto_integral_Ioi c
+    (integrableOn_exp_mul_complex_Ioi ha c) tendsto_id) ?_
+  simp_rw [integral_exp_mul_complex (c := a) (by aesop), id_eq]
+  suffices Tendsto (fun x : ℝ ↦ Complex.exp (a * x)) atTop (𝓝 0) by
+    simpa using this.sub_const _ |>.div_const _
+  simpa [Complex.tendsto_exp_nhds_zero_iff] using tendsto_const_nhds.neg_mul_atTop ha tendsto_id
 
 theorem integral_exp_mul_complex_Iic {a : ℂ} (ha : 0 < a.re) (c : ℝ) :
     ∫ x : ℝ in Set.Iic c, Complex.exp (a * x) = Complex.exp (a * c) / a := by
-  conv in (fun x => _) =>
-    ext x
-    rw [(by simp : a * x = -a * (-x : ℝ))]
-  rw [integral_comp_neg_Iic c (fun x => Complex.exp (-a * x))]
-  have a_neg : (-a).re < 0 := by simp [ha]
-  rw [integral_exp_mul_complex_Ioi a_neg]
-  simp
+  simpa [neg_mul, ← mul_neg, ← Complex.ofReal_neg,
+    integral_comp_neg_Ioi (f := fun x : ℝ ↦ Complex.exp (a * x))]
+    using integral_exp_mul_complex_Ioi (a := -a) (by simpa) (-c)
 
 /-- If `0 < c`, then `(fun t : ℝ ↦ t ^ a)` is integrable on `(c, ∞)` for all `a < -1`. -/
 theorem integrableOn_Ioi_rpow_of_lt {a : ℝ} (ha : a < -1) {c : ℝ} (hc : 0 < c) :

--- a/Mathlib/MeasureTheory/Group/Integral.lean
+++ b/Mathlib/MeasureTheory/Group/Integral.lean
@@ -42,8 +42,8 @@ theorem integral_inv_eq_self (f : G → E) (μ : Measure G) [IsInvInvariant μ] 
 theorem IntegrableOn.comp_inv [IsInvInvariant μ] {f : G → F} {s : Set G} (hf : IntegrableOn f s μ) :
     IntegrableOn (fun x => f x⁻¹) s⁻¹ μ := by
   apply (integrable_map_equiv (MeasurableEquiv.inv G) f).mp
-  rw [(by simp : s⁻¹ = MeasurableEquiv.inv G ⁻¹' s)]
-  rw [← MeasurableEquiv.restrict_map]
+  have : s⁻¹ = MeasurableEquiv.inv G ⁻¹' s := by simp
+  rw [this, ← MeasurableEquiv.restrict_map]
   simpa using hf
 
 end MeasurableInv

--- a/Mathlib/MeasureTheory/Group/Integral.lean
+++ b/Mathlib/MeasureTheory/Group/Integral.lean
@@ -48,6 +48,33 @@ theorem IntegrableOn.comp_inv [IsInvInvariant μ] {f : G → F} {s : Set G} (hf 
 
 end MeasurableInv
 
+section MeasurableInvOrder
+
+variable [PartialOrder G] [CommGroup G] [IsOrderedMonoid G] [MeasurableInv G]
+variable [IsInvInvariant μ]
+
+@[to_additive]
+theorem IntegrableOn.comp_inv_Iic {c : G} {f : G → F} (hf : IntegrableOn f (Set.Ici c⁻¹) μ) :
+    IntegrableOn (fun x => f x⁻¹) (Set.Iic c) μ := by
+  simpa using hf.comp_inv
+
+@[to_additive]
+theorem IntegrableOn.comp_inv_Ici {c : G} {f : G → F} (hf : IntegrableOn f (Set.Iic c⁻¹) μ) :
+    IntegrableOn (fun x => f x⁻¹) (Set.Ici c) μ := by
+  simpa using hf.comp_inv
+
+@[to_additive]
+theorem IntegrableOn.comp_inv_Iio {c : G} {f : G → F} (hf : IntegrableOn f (Set.Ioi c⁻¹) μ) :
+    IntegrableOn (fun x => f x⁻¹) (Set.Iio c) μ := by
+  simpa using hf.comp_inv
+
+@[to_additive]
+theorem IntegrableOn.comp_inv_Ioi {c : G} {f : G → F} (hf : IntegrableOn f (Set.Iio c⁻¹) μ) :
+    IntegrableOn (fun x => f x⁻¹) (Set.Ioi c) μ := by
+  simpa using hf.comp_inv
+
+end MeasurableInvOrder
+
 section MeasurableMul
 
 variable [Group G] [MeasurableMul G]

--- a/Mathlib/MeasureTheory/Group/Integral.lean
+++ b/Mathlib/MeasureTheory/Group/Integral.lean
@@ -38,6 +38,14 @@ theorem integral_inv_eq_self (f : G → E) (μ : Measure G) [IsInvInvariant μ] 
   have h : MeasurableEmbedding fun x : G => x⁻¹ := (MeasurableEquiv.inv G).measurableEmbedding
   rw [← h.integral_map, map_inv_eq_self]
 
+@[to_additive]
+theorem IntegrableOn.comp_inv [IsInvInvariant μ] {f : G → F} {s : Set G} (hf : IntegrableOn f s μ) :
+    IntegrableOn (fun x => f x⁻¹) s⁻¹ μ := by
+  apply (integrable_map_equiv (MeasurableEquiv.inv G) f).mp
+  rw [(by simp : s⁻¹ = MeasurableEquiv.inv G ⁻¹' s)]
+  rw [← MeasurableEquiv.restrict_map]
+  simpa using hf
+
 end MeasurableInv
 
 section MeasurableMul

--- a/Mathlib/MeasureTheory/Measure/Lebesgue/Integral.lean
+++ b/Mathlib/MeasureTheory/Measure/Lebesgue/Integral.lean
@@ -78,14 +78,12 @@ of finite integrals, see `intervalIntegral.integral_comp_neg`.
 theorem MeasureTheory.IntegrableOn.comp_neg_Iic {E : Type*} [NormedAddCommGroup E]
     {c : ℝ} {f : ℝ → E} (hf : IntegrableOn f (Ioi (-c))) :
     IntegrableOn (fun x => f (-x)) (Iic c) := by
-  rw [(by simp : Iic c = - (Ici (-c)))]
-  exact (integrableOn_Ici_iff_integrableOn_Ioi.mpr hf).comp_neg
+  simpa using (integrableOn_Ici_iff_integrableOn_Ioi.mpr hf).comp_neg
 
 theorem MeasureTheory.IntegrableOn.comp_neg_Ioi {E : Type*} [NormedAddCommGroup E]
     {c : ℝ} {f : ℝ → E} (hf : IntegrableOn f (Iic (-c))) :
     IntegrableOn (fun x => f (-x)) (Ioi c) := by
-  rw [(by simp : Ioi c = - (Iio (-c)))]
-  exact (integrableOn_Iic_iff_integrableOn_Iio.mp hf).comp_neg
+  simpa using (integrableOn_Iic_iff_integrableOn_Iio.mp hf).comp_neg
 
 /- @[simp] Porting note: Linter complains it does not apply to itself. Although it does apply to
 itself, it does not apply when `f` is more complicated -/

--- a/Mathlib/MeasureTheory/Measure/Lebesgue/Integral.lean
+++ b/Mathlib/MeasureTheory/Measure/Lebesgue/Integral.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Sébastien Gouëzel, Yury Kudryashov
 -/
 import Mathlib.MeasureTheory.Integral.SetIntegral
+import Mathlib.MeasureTheory.Group.Measure
 import Mathlib.MeasureTheory.Measure.Lebesgue.Basic
 import Mathlib.MeasureTheory.Measure.Haar.Unique
 
@@ -74,6 +75,17 @@ mathlib's conventions for integrals over finite intervals (see `intervalIntegral
 of finite integrals, see `intervalIntegral.integral_comp_neg`.
 -/
 
+theorem MeasureTheory.IntegrableOn.comp_neg_Iic {E : Type*} [NormedAddCommGroup E]
+    {c : ℝ} {f : ℝ → E} (hf : IntegrableOn f (Ioi (-c))) :
+    IntegrableOn (fun x => f (-x)) (Iic c) := by
+  rw [(by simp : Iic c = - (Ici (-c)))]
+  exact (integrableOn_Ici_iff_integrableOn_Ioi.mpr hf).comp_neg
+
+theorem MeasureTheory.IntegrableOn.comp_neg_Ioi {E : Type*} [NormedAddCommGroup E]
+    {c : ℝ} {f : ℝ → E} (hf : IntegrableOn f (Iic (-c))) :
+    IntegrableOn (fun x => f (-x)) (Ioi c) := by
+  rw [(by simp : Ioi c = - (Iio (-c)))]
+  exact (integrableOn_Iic_iff_integrableOn_Iio.mp hf).comp_neg
 
 /- @[simp] Porting note: Linter complains it does not apply to itself. Although it does apply to
 itself, it does not apply when `f` is more complicated -/

--- a/Mathlib/MeasureTheory/Measure/Lebesgue/Integral.lean
+++ b/Mathlib/MeasureTheory/Measure/Lebesgue/Integral.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Sébastien Gouëzel, Yury Kudryashov
 -/
 import Mathlib.MeasureTheory.Integral.SetIntegral
-import Mathlib.MeasureTheory.Group.Measure
 import Mathlib.MeasureTheory.Measure.Lebesgue.Basic
 import Mathlib.MeasureTheory.Measure.Haar.Unique
 
@@ -75,15 +74,6 @@ mathlib's conventions for integrals over finite intervals (see `intervalIntegral
 of finite integrals, see `intervalIntegral.integral_comp_neg`.
 -/
 
-theorem MeasureTheory.IntegrableOn.comp_neg_Iic {E : Type*} [NormedAddCommGroup E]
-    {c : ℝ} {f : ℝ → E} (hf : IntegrableOn f (Ioi (-c))) :
-    IntegrableOn (fun x => f (-x)) (Iic c) := by
-  simpa using (integrableOn_Ici_iff_integrableOn_Ioi.mpr hf).comp_neg
-
-theorem MeasureTheory.IntegrableOn.comp_neg_Ioi {E : Type*} [NormedAddCommGroup E]
-    {c : ℝ} {f : ℝ → E} (hf : IntegrableOn f (Iic (-c))) :
-    IntegrableOn (fun x => f (-x)) (Ioi c) := by
-  simpa using (integrableOn_Iic_iff_integrableOn_Iio.mp hf).comp_neg
 
 /- @[simp] Porting note: Linter complains it does not apply to itself. Although it does apply to
 itself, it does not apply when `f` is more complicated -/


### PR DESCRIPTION
These are the infinite version of integral_exp_mul_complex.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
