### PR TITLE
chore: automatically deprime common `induction'` uses

### DIFF
--- a/Archive/Imo/Imo1977Q6.lean
+++ b/Archive/Imo/Imo1977Q6.lean
@@ -21,9 +21,10 @@ namespace Imo1977Q6
 theorem imo1977_q6_nat (f : ℕ → ℕ) (h : ∀ n, f (f n) < f (n + 1)) : ∀ n, f n = n := by
   have h' : ∀ k n : ℕ, k ≤ n → k ≤ f n := by
     intro k
-    induction' k with k h_ind
-    · intros; exact Nat.zero_le _
-    · intro n hk
+    induction k with
+    | zero => intros; exact Nat.zero_le _
+    | succ k h_ind =>
+      intro n hk
       apply Nat.succ_le_of_lt
       calc
         k ≤ f (f (n - 1)) := h_ind _ (h_ind (n - 1) (le_tsub_of_add_le_right hk))

--- a/Archive/Imo/Imo2006Q5.lean
+++ b/Archive/Imo/Imo2006Q5.lean
@@ -91,9 +91,10 @@ theorem Polynomial.isPeriodicPt_eval_two {P : Polynomial ℤ} {t : ℤ}
     -- The sign of P^n(t) - t is the same as P(t) - t for positive n. Proven by induction on n.
     have IH : ∀ n : ℕ, ((fun x => P.eval x)^[n + 1] t - t).sign = (P.eval t - t).sign := by
       intro n
-      induction' n with n IH
-      · rfl
-      · apply Eq.trans _ (Int.sign_add_eq_of_sign_eq IH)
+      induction n with
+      | zero => rfl
+      | succ n IH =>
+        apply Eq.trans _ (Int.sign_add_eq_of_sign_eq IH)
         have H := Heq n.succ 0
         dsimp at H ⊢
         rw [← H, sub_add_sub_cancel']

--- a/Archive/Imo/Imo2013Q1.lean
+++ b/Archive/Imo/Imo2013Q1.lean
@@ -43,8 +43,9 @@ open Imo2013Q1
 theorem imo2013_q1 (n : ℕ+) (k : ℕ) :
     ∃ m : ℕ → ℕ+, (1 : ℚ) + (2 ^ k - 1) / n = ∏ i ∈ Finset.range k, (1 + 1 / (m i : ℚ)) := by
   revert n
-  induction' k with pk hpk
-  · intro n; use fun (_ : ℕ) => (1 : ℕ+); simp
+  induction k with
+  | zero => intro n; use fun (_ : ℕ) => (1 : ℕ+); simp
+  | succ pk hpk => ?_
   -- For the base case, any m works.
   intro n
   obtain ⟨t, ht : ↑n = t + t⟩ | ⟨t, ht : ↑n = 2 * t + 1⟩ := (n : ℕ).even_or_odd

--- a/Archive/Imo/Imo2013Q5.lean
+++ b/Archive/Imo/Imo2013Q5.lean
@@ -113,8 +113,9 @@ theorem fx_gt_xm1 {f : ℚ → ℝ} {x : ℚ} (hx : 1 ≤ x)
 theorem pow_f_le_f_pow {f : ℚ → ℝ} {n : ℕ} (hn : 0 < n) {x : ℚ} (hx : 1 < x)
     (H1 : ∀ x y, 0 < x → 0 < y → f (x * y) ≤ f x * f y) (H4 : ∀ n : ℕ, 0 < n → (n : ℝ) ≤ f n) :
     f (x ^ n) ≤ f x ^ n := by
-  induction' n with pn hpn
-  · exfalso; exact Nat.lt_asymm hn hn
+  induction n with
+  | zero => exfalso; exact Nat.lt_asymm hn hn
+  | succ pn hpn => ?_
   rcases pn with - | pn
   · norm_num
   have hpn' := hpn pn.succ_pos
@@ -169,8 +170,9 @@ theorem imo2013_q5 (f : ℚ → ℝ) (H1 : ∀ x y, 0 < x → 0 < y → f (x * y
     intro x hx n hn
     rcases n with - | n
     · exact (lt_irrefl 0 hn).elim
-    induction' n with pn hpn
-    · norm_num
+    induction n with
+    | zero => norm_num
+    | succ pn hpn => ?_
     calc
       ↑(pn + 2) * f x = (↑pn + 1 + 1) * f x := by norm_cast
       _ = (↑pn + 1) * f x + f x := by ring

--- a/Archive/Imo/Imo2019Q4.lean
+++ b/Archive/Imo/Imo2019Q4.lean
@@ -61,8 +61,9 @@ theorem upper_bound {k n : ℕ} (hk : k > 0)
     _ < (∑ i ∈ range n, i)! := ?_
     _ ≤ k ! := by gcongr
   clear h h2
-  induction' n, hn using Nat.le_induction with n' hn' IH
-  · decide
+  induction n, hn using Nat.le_induction with
+  | base => decide
+  | succ n' hn' IH => ?_
   let A := ∑ i ∈ range n', i
   have le_sum : ∑ i ∈ range 6, i ≤ A := by
     apply sum_le_sum_of_subset

--- a/Archive/Imo/Imo2024Q1.lean
+++ b/Archive/Imo/Imo2024Q1.lean
@@ -98,12 +98,14 @@ lemma mem_Ico_one_of_mem_Ioo (h : α ∈ Set.Ioo 0 2) : α ∈ Set.Ico 1 2 := by
 lemma mem_Ico_n_of_mem_Ioo (h : α ∈ Set.Ioo 0 2) {n : ℕ} (hn : 0 < n) :
     α ∈ Set.Ico ((2 * n - 1) / n : ℝ) 2 := by
   suffices ∑ i ∈ Finset.Icc 1 n, ⌊i * α⌋ = n ^ 2 ∧ α ∈ Set.Ico ((2 * n - 1) / n : ℝ) 2 from this.2
-  induction' n, hn using Nat.le_induction with k kpos hk
-  · obtain ⟨h1, h2⟩ := hc.mem_Ico_one_of_mem_Ioo h
+  induction n, hn using Nat.le_induction with
+  | base =>
+    obtain ⟨h1, h2⟩ := hc.mem_Ico_one_of_mem_Ioo h
     simp only [zero_add, Finset.Icc_self, Finset.sum_singleton, Nat.cast_one, one_mul, one_pow,
                Int.floor_eq_iff, Int.cast_one, mul_one, div_one, Set.mem_Ico, tsub_le_iff_right]
     exact ⟨⟨h1, by linarith⟩, by linarith, h2⟩
-  · rcases hk with ⟨hks, hkl, hk2⟩
+  | succ k kpos hk =>
+    rcases hk with ⟨hks, hkl, hk2⟩
     have hs : (∑ i ∈ Finset.Icc 1 (k + 1), ⌊i * α⌋) =
          ⌊(k + 1 : ℕ) * α⌋ + ((k : ℕ) : ℤ) ^ 2 := by
       have hn11 : k + 1 ∉ Finset.Icc 1 k := by

--- a/Archive/MiuLanguage/DecisionSuf.lean
+++ b/Archive/MiuLanguage/DecisionSuf.lean
@@ -53,10 +53,12 @@ open MiuAtom List Nat
 where `count I w` is a power of 2.
 -/
 private theorem der_cons_replicate (n : ℕ) : Derivable (M :: replicate (2 ^ n) I) := by
-  induction' n with k hk
-  · -- base case
+  induction n with
+  | zero =>
+    -- base case
     constructor
-  · -- inductive step
+  | succ k hk =>
+    -- inductive step
     rw [pow_add, pow_one 2, mul_two, replicate_add]
     exact Derivable.r2 hk
 
@@ -84,10 +86,12 @@ to produce another `Derivable` `Miustr`.
 -/
 theorem der_of_der_append_replicate_U_even {z : Miustr} {m : ℕ}
     (h : Derivable (z ++ ↑(replicate (m * 2) U))) : Derivable z := by
-  induction' m with k hk
-  · revert h
+  induction m with
+  | zero =>
+    revert h
     rw [replicate, append_nil]; exact id
-  · apply hk
+  | succ k hk =>
+    apply hk
     simp only [succ_mul, replicate_add] at h
     rw [← append_nil ↑(z ++ ↑(replicate (k * 2) U))]
     apply Derivable.r4
@@ -109,9 +113,11 @@ theorem der_cons_replicate_I_replicate_U_append_of_der_cons_replicate_I_append (
     (hder : Derivable (↑(M :: replicate (c + 3 * k) I) ++ xs)) :
     Derivable (↑(M :: (replicate c I ++ replicate k U)) ++ xs) := by
   revert xs
-  induction' k with a ha
-  · simp only [replicate, zero_eq, mul_zero, add_zero, append_nil, forall_true_iff, imp_self]
-  · intro xs
+  induction k with
+  | zero =>
+    simp only [replicate, zero_eq, mul_zero, add_zero, append_nil, forall_true_iff, imp_self]
+  | succ a ha =>
+    intro xs
     specialize ha (U :: xs)
     intro h₂
     -- We massage the goal into a form amenable to the application of `ha`.
@@ -141,9 +147,11 @@ theorem add_mod2 (a : ℕ) : ∃ t, a + a % 2 = t * 2 := by
 
 private theorem le_pow2_and_pow2_eq_mod3' (c : ℕ) (x : ℕ) (h : c = 1 ∨ c = 2) :
     ∃ m : ℕ, c + 3 * x ≤ 2 ^ m ∧ 2 ^ m % 3 = c % 3 := by
-  induction' x with k hk
-  · use c + 1
+  induction x with
+  | zero =>
+    use c + 1
     rcases h with hc | hc <;> · rw [hc]; norm_num
+  | succ k hk => ?_
   rcases hk with ⟨g, hkg, hgmod⟩
   by_cases hp : c + 3 * (k + 1) ≤ 2 ^ g
   · use g, hp, hgmod
@@ -328,9 +336,10 @@ theorem der_of_decstr {en : Miustr} (h : Decstr en) : Derivable en := by
   have hu : ∃ n, count U en = n := exists_eq'
   obtain ⟨n, hu⟩ := hu
   revert en -- Crucially, we need the induction hypothesis to quantify over `en`
-  induction' n with k hk
-  · exact base_case_suf _
-  · intro ys hdec hus
+  induction n with
+  | zero => exact base_case_suf _
+  | succ k hk =>
+    intro ys hdec hus
     rcases ind_hyp_suf k ys hus hdec with ⟨as, bs, hyab, habuc, hdecab⟩
     have h₂ : Derivable (↑(M :: as) ++ ↑[I, I, I] ++ bs) := hk hdecab habuc
     rw [hyab]

--- a/Archive/Sensitivity.lean
+++ b/Archive/Sensitivity.lean
@@ -199,9 +199,10 @@ variable {n : ℕ}
 
 open Classical in
 theorem duality (p q : Q n) : ε p (e q) = if p = q then 1 else 0 := by
-  induction' n with n IH
-  · simp [Subsingleton.elim (α := Q 0) p q, ε, e]
-  · dsimp [ε, e]
+  induction n with
+  | zero => simp [Subsingleton.elim (α := Q 0) p q, ε, e]
+  | succ n IH =>
+    dsimp [ε, e]
     cases hp : p 0 <;> cases hq : q 0
     all_goals
       simp only [Bool.cond_true, Bool.cond_false, LinearMap.fst_apply, LinearMap.snd_apply,
@@ -210,9 +211,10 @@ theorem duality (p q : Q n) : ε p (e q) = if p = q then 1 else 0 := by
 
 /-- Any vector in `V n` annihilated by all `ε p`'s is zero. -/
 theorem epsilon_total {v : V n} (h : ∀ p : Q n, (ε p) v = 0) : v = 0 := by
-  induction' n with n ih
-  · dsimp [ε] at h; exact h fun _ => true
-  · obtain ⟨v₁, v₂⟩ := v
+  induction n with
+  | zero => dsimp [ε] at h; exact h fun _ => true
+  | succ n ih =>
+    obtain ⟨v₁, v₂⟩ := v
     ext <;> change _ = (0 : V n) <;> simp only <;> apply ih <;> intro p <;>
       [let q : Q n.succ := fun i => if h : i = 0 then true else p (i.pred h);
       let q : Q n.succ := fun i => if h : i = 0 then false else p (i.pred h)]
@@ -292,12 +294,14 @@ theorem f_squared (v : V n) : (f n) (f n v) = (n : ℝ) • v := by
 
 open Classical in
 theorem f_matrix : ∀ p q : Q n, |ε q (f n (e p))| = if p ∈ q.adjacent then 1 else 0 := by
-  induction' n with n IH
-  · intro p q
+  induction n with
+  | zero =>
+    intro p q
     dsimp [f]
     simp [Q.not_adjacent_zero]
     rfl
-  · intro p q
+  | succ n IH =>
+    intro p q
     have ite_nonneg : ite (π q = π p) (1 : ℝ) 0 ≥ 0 := by split_ifs <;> norm_num
     dsimp only [e, ε, f, V]; rw [LinearMap.prod_apply]; dsimp; cases hp : p 0 <;> cases hq : q 0
     all_goals

--- a/Archive/Wiedijk100Theorems/FriendshipGraphs.lean
+++ b/Archive/Wiedijk100Theorems/FriendshipGraphs.lean
@@ -227,8 +227,9 @@ theorem adjMatrix_pow_mod_p_of_regular {p : ℕ} (dmod : (d : ZMod p) = 1)
   match k with
   | 0 | 1 => exfalso; linarith
   | k + 2 =>
-    induction' k with k hind
-    · exact adjMatrix_sq_mod_p_of_regular hG dmod hd
+    induction k with
+    | zero => exact adjMatrix_sq_mod_p_of_regular hG dmod hd
+    | succ k hind => ?_
     rw [pow_succ', hind (Nat.le_add_left 2 k)]
     exact adjMatrix_mul_const_one_mod_p_of_regular dmod hd
 

--- a/Archive/Wiedijk100Theorems/Partition.lean
+++ b/Archive/Wiedijk100Theorems/Partition.lean
@@ -337,8 +337,9 @@ theorem same_gf [Field α] (m : ℕ) :
     (partialOddGF m * (range m).prod fun i => 1 - (X : PowerSeries α) ^ (m + i + 1)) =
       partialDistinctGF m := by
   rw [partialOddGF, partialDistinctGF]
-  induction' m with m ih
-  · simp
+  induction m with
+  | zero => simp
+  | succ m ih => ?_
   set! π₀ : PowerSeries α := ∏ i ∈ range m, (1 - X ^ (m + 1 + i + 1)) with hπ₀
   set! π₁ : PowerSeries α := ∏ i ∈ range m, (1 - X ^ (2 * i + 1))⁻¹ with hπ₁
   set! π₂ : PowerSeries α := ∏ i ∈ range m, (1 - X ^ (m + i + 1)) with hπ₂

--- a/Mathlib/Algebra/Algebra/Subalgebra/Lattice.lean
+++ b/Mathlib/Algebra/Algebra/Subalgebra/Lattice.lean
@@ -570,8 +570,9 @@ theorem adjoin_eq_span : Subalgebra.toSubmodule (adjoin R s) = span R (Submonoid
   · intro r hr
     rcases Subsemiring.mem_closure_iff_exists_list.1 hr with ⟨L, HL, rfl⟩
     clear hr
-    induction' L with hd tl ih
-    · exact zero_mem _
+    induction L with
+    | nil => exact zero_mem _
+    | cons hd tl ih => ?_
     rw [List.forall_mem_cons] at HL
     rw [List.map_cons, List.sum_cons]
     refine Submodule.add_mem _ ?_ (ih HL.2)
@@ -581,8 +582,9 @@ theorem adjoin_eq_span : Subalgebra.toSubmodule (adjoin R s) = span R (Submonoid
       rcases this with ⟨z, r, hr, hzr⟩
       rw [← hzr]
       exact smul_mem _ _ (subset_span hr)
-    induction' hd with hd tl ih
-    · exact ⟨1, 1, (Submonoid.closure s).one_mem', one_smul _ _⟩
+    induction hd with
+    | nil => exact ⟨1, 1, (Submonoid.closure s).one_mem', one_smul _ _⟩
+    | cons hd tl ih => ?_
     rw [List.forall_mem_cons] at HL
     rcases ih HL.2 with ⟨z, r, hr, hzr⟩
     rw [List.prod_cons, ← hzr]

--- a/Mathlib/Algebra/BigOperators/Group/List/Lemmas.lean
+++ b/Mathlib/Algebra/BigOperators/Group/List/Lemmas.lean
@@ -118,9 +118,9 @@ namespace List
 
 lemma length_sigma {σ : α → Type*} (l₁ : List α) (l₂ : ∀ a, List (σ a)) :
     length (l₁.sigma l₂) = (l₁.map fun a ↦ length (l₂ a)).sum := by
-  induction' l₁ with x l₁ IH
-  · rfl
-  · simp only [sigma_cons, length_append, length_map, IH, map, sum_cons]
+  induction l₁ with
+  | nil => rfl
+  | cons x l₁ IH => simp only [sigma_cons, length_append, length_map, IH, map, sum_cons]
 
 lemma ranges_flatten : ∀ (l : List ℕ), l.ranges.flatten = range l.sum
   | [] => rfl

--- a/Mathlib/Algebra/Group/Conj.lean
+++ b/Mathlib/Algebra/Group/Conj.lean
@@ -85,9 +85,9 @@ theorem conj_mul {a b c : α} : b * a * b⁻¹ * (b * c * b⁻¹) = b * (a * c) 
 
 @[simp]
 theorem conj_pow {i : ℕ} {a b : α} : (a * b * a⁻¹) ^ i = a * b ^ i * a⁻¹ := by
-  induction' i with i hi
-  · simp
-  · simp [pow_succ, hi]
+  induction i with
+  | zero => simp
+  | succ i hi => simp [pow_succ, hi]
 
 @[simp]
 theorem conj_zpow {i : ℤ} {a b : α} : (a * b * a⁻¹) ^ i = a * b ^ i * a⁻¹ := by

--- a/Mathlib/Algebra/Group/ForwardDiff.lean
+++ b/Mathlib/Algebra/Group/ForwardDiff.lean
@@ -101,9 +101,10 @@ lemma shiftₗ_apply (f : M → G) (y : M) : shiftₗ M G h f y = f (y + h) := b
     sub_add_cancel]
 
 lemma shiftₗ_pow_apply (f : M → G) (k : ℕ) (y : M) : (shiftₗ M G h ^ k) f y = f (y + k • h) := by
-  induction' k with k IH generalizing f
-  · simp only [pow_zero, LinearMap.one_apply, cast_zero, add_zero, zero_smul]
-  · simp only [pow_add, pow_one, LinearMap.mul_apply, IH (shiftₗ M G h f), shiftₗ_apply, add_assoc,
+  induction k generalizing f with
+  | zero => simp only [pow_zero, LinearMap.one_apply, cast_zero, add_zero, zero_smul]
+  | succ k IH =>
+    simp only [pow_add, pow_one, LinearMap.mul_apply, IH (shiftₗ M G h f), shiftₗ_apply, add_assoc,
       add_nsmul, one_smul]
 
 end fwdDiff_aux
@@ -120,9 +121,9 @@ open fwdDiff_aux
 
 @[simp] lemma fwdDiff_iter_const_smul {R : Type*} [Monoid R] [DistribMulAction R G]
     (r : R) (f : M → G) (n : ℕ) : Δ_[h]^[n] (r • f) = r • Δ_[h]^[n] f := by
-  induction' n with n IH generalizing f
-  · simp only [iterate_zero, id_eq]
-  · simp only [iterate_succ_apply, fwdDiff_const_smul, IH]
+  induction n generalizing f with
+  | zero => simp only [iterate_zero, id_eq]
+  | succ n IH => simp only [iterate_succ_apply, fwdDiff_const_smul, IH]
 
 @[simp] lemma fwdDiff_iter_finset_sum {α : Type*} (s : Finset α) (f : α → M → G) (n : ℕ) :
     Δ_[h]^[n] (∑ k ∈ s, f k) = ∑ k ∈ s, Δ_[h]^[n] (f k) := by
@@ -172,9 +173,10 @@ lemma fwdDiff_choose (j : ℕ) : Δ_[1] (fun x ↦ x.choose (j + 1) : ℕ → �
 
 lemma fwdDiff_iter_choose (j k : ℕ) :
     Δ_[1]^[k] (fun x ↦ x.choose (k + j) : ℕ → ℤ) = fun x ↦ x.choose j := by
-  induction' k with k IH generalizing j
-  · simp only [zero_add, iterate_zero, id_eq]
-  · simp only [Function.iterate_succ_apply', add_assoc, add_comm 1 j, IH, fwdDiff_choose]
+  induction k generalizing j with
+  | zero => simp only [zero_add, iterate_zero, id_eq]
+  | succ k IH =>
+    simp only [Function.iterate_succ_apply', add_assoc, add_comm 1 j, IH, fwdDiff_choose]
 
 lemma fwdDiff_iter_choose_zero (m n : ℕ) :
     Δ_[1]^[n] (fun x ↦ x.choose m : ℕ → ℤ) 0 = if n = m then 1 else 0 := by

--- a/Mathlib/Algebra/Group/Pointwise/Finset/Basic.lean
+++ b/Mathlib/Algebra/Group/Pointwise/Finset/Basic.lean
@@ -774,9 +774,9 @@ variable [Monoid α] {s t : Finset α} {a : α} {m n : ℕ}
 @[to_additive (attr := simp, norm_cast)]
 theorem coe_pow (s : Finset α) (n : ℕ) : ↑(s ^ n) = (s : Set α) ^ n := by
   change ↑(npowRec n s) = (s : Set α) ^ n
-  induction' n with n ih
-  · rw [npowRec, pow_zero, coe_one]
-  · rw [npowRec, pow_succ, coe_mul, ih]
+  induction n with
+  | zero => rw [npowRec, pow_zero, coe_one]
+  | succ n ih => rw [npowRec, pow_succ, coe_mul, ih]
 
 /-- `Finset α` is a `Monoid` under pointwise operations if `α` is. -/
 @[to_additive "`Finset α` is an `AddMonoid` under pointwise operations if `α` is. "]

--- a/Mathlib/Algebra/Group/Pointwise/Set/BigOperators.lean
+++ b/Mathlib/Algebra/Group/Pointwise/Set/BigOperators.lean
@@ -51,10 +51,12 @@ theorem image_finset_prod (f : F) (m : Finset ι) (s : ι → Set α) :
 theorem mem_finset_prod (t : Finset ι) (f : ι → Set α) (a : α) :
     (a ∈ ∏ i ∈ t, f i) ↔ ∃ (g : ι → α) (_ : ∀ {i}, i ∈ t → g i ∈ f i), ∏ i ∈ t, g i = a := by
   classical
-    induction' t using Finset.induction_on with i is hi ih generalizing a
-    · simp_rw [Finset.prod_empty, Set.mem_one]
+    induction t using Finset.induction_on generalizing a with
+    | empty =>
+      simp_rw [Finset.prod_empty, Set.mem_one]
       exact ⟨fun h ↦ ⟨fun _ ↦ a, fun hi ↦ False.elim (Finset.not_mem_empty _ hi), h.symm⟩,
         fun ⟨_, _, hf⟩ ↦ hf.symm⟩
+    | @insert i is hi ih => ?_
     rw [Finset.prod_insert hi, Set.mem_mul]
     simp_rw [Finset.prod_insert hi]
     simp_rw [ih]
@@ -87,9 +89,10 @@ theorem mem_fintype_prod [Fintype ι] (f : ι → Set α) (a : α) :
 @[to_additive "An n-ary version of `Set.add_mem_add`."]
 theorem list_prod_mem_list_prod (t : List ι) (f : ι → Set α) (g : ι → α) (hg : ∀ i ∈ t, g i ∈ f i) :
     (t.map g).prod ∈ (t.map f).prod := by
-  induction' t with h tl ih
-  · simp_rw [List.map_nil, List.prod_nil, Set.mem_one]
-  · simp_rw [List.map_cons, List.prod_cons]
+  induction t with
+  | nil => simp_rw [List.map_nil, List.prod_nil, Set.mem_one]
+  | cons h tl ih =>
+    simp_rw [List.map_cons, List.prod_cons]
     exact mul_mem_mul (hg h List.mem_cons_self)
       (ih fun i hi ↦ hg i <| List.mem_cons_of_mem _ hi)
 
@@ -97,9 +100,10 @@ theorem list_prod_mem_list_prod (t : List ι) (f : ι → Set α) (g : ι → α
 @[to_additive "An n-ary version of `Set.add_subset_add`."]
 theorem list_prod_subset_list_prod (t : List ι) (f₁ f₂ : ι → Set α) (hf : ∀ i ∈ t, f₁ i ⊆ f₂ i) :
     (t.map f₁).prod ⊆ (t.map f₂).prod := by
-  induction' t with h tl ih
-  · rfl
-  · simp_rw [List.map_cons, List.prod_cons]
+  induction t with
+  | nil => rfl
+  | cons h tl ih =>
+    simp_rw [List.map_cons, List.prod_cons]
     exact mul_subset_mul (hf h List.mem_cons_self)
       (ih fun i hi ↦ hf i <| List.mem_cons_of_mem _ hi)
 

--- a/Mathlib/Algebra/Group/Pointwise/Set/Finite.lean
+++ b/Mathlib/Algebra/Group/Pointwise/Set/Finite.lean
@@ -53,10 +53,12 @@ instance decidableMemMul [Fintype α] [DecidableEq α] [DecidablePred (· ∈ s)
 @[to_additive]
 instance decidableMemPow [Fintype α] [DecidableEq α] [DecidablePred (· ∈ s)] (n : ℕ) :
     DecidablePred (· ∈ s ^ n) := by
-  induction' n with n ih
-  · simp only [pow_zero, mem_one]
+  induction n with
+  | zero =>
+    simp only [pow_zero, mem_one]
     infer_instance
-  · letI := ih
+  | succ n ih =>
+    letI := ih
     rw [pow_succ]
     infer_instance
 

--- a/Mathlib/Algebra/Group/Pointwise/Set/ListOfFn.lean
+++ b/Mathlib/Algebra/Group/Pointwise/Set/ListOfFn.lean
@@ -22,9 +22,10 @@ open Pointwise
 @[to_additive]
 theorem mem_prod_list_ofFn {a : α} {s : Fin n → Set α} :
     a ∈ (List.ofFn s).prod ↔ ∃ f : ∀ i : Fin n, s i, (List.ofFn fun i ↦ (f i : α)).prod = a := by
-  induction' n with n ih generalizing a
-  · simp_rw [List.ofFn_zero, List.prod_nil, Fin.exists_fin_zero_pi, eq_comm, Set.mem_one]
-  · simp_rw [List.ofFn_succ, List.prod_cons, Fin.exists_fin_succ_pi, Fin.cons_zero, Fin.cons_succ,
+  induction n generalizing a with
+  | zero => simp_rw [List.ofFn_zero, List.prod_nil, Fin.exists_fin_zero_pi, eq_comm, Set.mem_one]
+  | succ n ih =>
+    simp_rw [List.ofFn_succ, List.prod_cons, Fin.exists_fin_succ_pi, Fin.cons_zero, Fin.cons_succ,
       mem_mul, @ih, exists_exists_eq_and, SetCoe.exists, exists_prop]
 
 @[to_additive]

--- a/Mathlib/Algebra/Lie/Solvable.lean
+++ b/Mathlib/Algebra/Lie/Solvable.lean
@@ -82,9 +82,10 @@ theorem derivedSeriesOfIdeal_add (k l : ℕ) : D (k + l) I = D k (D l I) := by
 @[gcongr, mono]
 theorem derivedSeriesOfIdeal_le {I J : LieIdeal R L} {k l : ℕ} (h₁ : I ≤ J) (h₂ : l ≤ k) :
     D k I ≤ D l J := by
-  revert l; induction' k with k ih <;> intro l h₂
-  · rw [le_zero_iff] at h₂; rw [h₂, derivedSeriesOfIdeal_zero]; exact h₁
-  · have h : l = k.succ ∨ l ≤ k := by rwa [le_iff_eq_or_lt, Nat.lt_succ_iff] at h₂
+  revert l; induction k with <;> intro l h₂
+  | zero => rw [le_zero_iff] at h₂; rw [h₂, derivedSeriesOfIdeal_zero]; exact h₁
+  | succ k ih =>
+    have h : l = k.succ ∨ l ≤ k := by rwa [le_iff_eq_or_lt, Nat.lt_succ_iff] at h₂
     rcases h with h | h
     · rw [h, derivedSeriesOfIdeal_succ, derivedSeriesOfIdeal_succ]
       exact LieSubmodule.mono_lie (ih (le_refl k)) (ih (le_refl k))

--- a/Mathlib/Algebra/Lie/Solvable.lean
+++ b/Mathlib/Algebra/Lie/Solvable.lean
@@ -82,9 +82,9 @@ theorem derivedSeriesOfIdeal_add (k l : ℕ) : D (k + l) I = D k (D l I) := by
 @[gcongr, mono]
 theorem derivedSeriesOfIdeal_le {I J : LieIdeal R L} {k l : ℕ} (h₁ : I ≤ J) (h₂ : l ≤ k) :
     D k I ≤ D l J := by
-  revert l; induction k with <;> intro l h₂
-  | zero => rw [le_zero_iff] at h₂; rw [h₂, derivedSeriesOfIdeal_zero]; exact h₁
-  | succ k ih =>
+  revert l; induction k <;> intro l h₂
+  case zero => rw [le_zero_iff] at h₂; rw [h₂, derivedSeriesOfIdeal_zero]; exact h₁
+  case succ k ih =>
     have h : l = k.succ ∨ l ≤ k := by rwa [le_iff_eq_or_lt, Nat.lt_succ_iff] at h₂
     rcases h with h | h
     · rw [h, derivedSeriesOfIdeal_succ, derivedSeriesOfIdeal_succ]

--- a/Mathlib/Algebra/Module/PID.lean
+++ b/Mathlib/Algebra/Module/PID.lean
@@ -171,14 +171,16 @@ theorem torsion_by_prime_power_decomposition (hN : Module.IsTorsion' N (Submonoi
     [h' : Module.Finite R N] :
     ∃ (d : ℕ) (k : Fin d → ℕ), Nonempty <| N ≃ₗ[R] ⨁ i : Fin d, R ⧸ R ∙ p ^ (k i : ℕ) := by
   obtain ⟨d, s, hs⟩ := @Module.Finite.exists_fin _ _ _ _ _ h'; use d; clear h'
-  induction' d with d IH generalizing N
-  · use finZeroElim
+  induction d generalizing N with
+  | zero =>
+    use finZeroElim
     rw [Set.range_eq_empty, Submodule.span_empty] at hs
     haveI : Unique N :=
       ⟨⟨0⟩, fun x => by dsimp; rw [← Submodule.mem_bot R, hs]; exact Submodule.mem_top⟩
     haveI : IsEmpty (Fin Nat.zero) := inferInstanceAs (IsEmpty (Fin 0))
     exact ⟨0⟩
-  · have : ∀ x : N, Decidable (x = 0) := fun _ => by classical infer_instance
+  | succ d IH =>
+    have : ∀ x : N, Decidable (x = 0) := fun _ => by classical infer_instance
     obtain ⟨j, hj⟩ := exists_isTorsionBy hN d.succ d.succ_ne_zero s hs
     let s' : Fin d → N ⧸ R ∙ s j := Submodule.Quotient.mk ∘ s ∘ j.succAbove
     -- Porting note(https://github.com/leanprover-community/mathlib4/issues/5732):

--- a/Mathlib/Algebra/Order/BigOperators/Group/List.lean
+++ b/Mathlib/Algebra/Order/BigOperators/Group/List.lean
@@ -67,13 +67,13 @@ lemma prod_lt_prod' [Preorder M] [MulLeftStrictMono M]
     [MulRightMono M] {l : List ι} (f g : ι → M)
     (h₁ : ∀ i ∈ l, f i ≤ g i) (h₂ : ∃ i ∈ l, f i < g i) : (l.map f).prod < (l.map g).prod := by
   induction l with
-  | nil => rcases h₂ with ⟨_, ⟨⟩, _⟩
-  | cons i l ihl => ?_
-  simp only [forall_mem_cons, map_cons, prod_cons] at h₁ ⊢
-  simp only [mem_cons, exists_eq_or_imp] at h₂
-  cases h₂
-  · exact mul_lt_mul_of_lt_of_le ‹_› (prod_le_prod' h₁.2)
-  · exact mul_lt_mul_of_le_of_lt h₁.1 <| ihl h₁.2 ‹_›
+  | nil => simp_all
+  | cons i l ihl =>
+    simp only [forall_mem_cons, map_cons, prod_cons] at h₁ ⊢
+    simp only [mem_cons, exists_eq_or_imp] at h₂
+    cases h₂
+    · exact mul_lt_mul_of_lt_of_le ‹_› (prod_le_prod' h₁.2)
+    · exact mul_lt_mul_of_le_of_lt h₁.1 <| ihl h₁.2 ‹_›
 
 @[to_additive]
 lemma prod_lt_prod_of_ne_nil [Preorder M] [MulLeftStrictMono M]

--- a/Mathlib/Algebra/Order/BigOperators/Group/List.lean
+++ b/Mathlib/Algebra/Order/BigOperators/Group/List.lean
@@ -66,8 +66,9 @@ lemma prod_lt_prod' [Preorder M] [MulLeftStrictMono M]
     [MulLeftMono M] [MulRightStrictMono M]
     [MulRightMono M] {l : List ι} (f g : ι → M)
     (h₁ : ∀ i ∈ l, f i ≤ g i) (h₂ : ∃ i ∈ l, f i < g i) : (l.map f).prod < (l.map g).prod := by
-  induction' l with i l ihl
-  · rcases h₂ with ⟨_, ⟨⟩, _⟩
+  induction l with
+  | nil => rcases h₂ with ⟨_, ⟨⟩, _⟩
+  | cons i l ihl => ?_
   simp only [forall_mem_cons, map_cons, prod_cons] at h₁ ⊢
   simp only [mem_cons, exists_eq_or_imp] at h₂
   cases h₂
@@ -114,8 +115,9 @@ lemma one_le_prod_of_one_le [Preorder M] [MulLeftMono M] {l : List M}
     (hl₁ : ∀ x ∈ l, (1 : M) ≤ x) : 1 ≤ l.prod := by
   -- We don't use `pow_card_le_prod` to avoid assumption
   -- [covariant_class M M (function.swap (*)) (≤)]
-  induction' l with hd tl ih
-  · rfl
+  induction l with
+  | nil => rfl
+  | cons hd tl ih => ?_
   rw [prod_cons]
   exact one_le_mul (hl₁ hd mem_cons_self) (ih fun x h => hl₁ x (mem_cons_of_mem hd h))
 
@@ -142,8 +144,9 @@ end Monoid
 -- TODO: develop theory of tropical rings
 lemma sum_le_foldr_max [AddZeroClass M] [Zero N] [LinearOrder N] (f : M → N) (h0 : f 0 ≤ 0)
     (hadd : ∀ x y, f (x + y) ≤ max (f x) (f y)) (l : List M) : f l.sum ≤ (l.map f).foldr max 0 := by
-  induction' l with hd tl IH
-  · simpa using h0
+  induction l with
+  | nil => simpa using h0
+  | cons hd tl IH => ?_
   simp only [List.sum_cons, List.foldr_map, List.foldr] at IH ⊢
   exact (hadd _ _).trans (max_le_max le_rfl IH)
 

--- a/Mathlib/Algebra/Order/CauSeq/BigOperators.lean
+++ b/Mathlib/Algebra/Order/CauSeq/BigOperators.lean
@@ -39,8 +39,9 @@ lemma of_abv_le (n : ℕ) (hm : ∀ m, n ≤ m → abv (f m) ≤ a m) :
   rw [hk]
   dsimp only
   clear hk ji j
-  induction' k with k' hi
-  · simp [abv_zero abv]
+  induction k with
+  | zero => simp [abv_zero abv]
+  | succ k' hi => ?_
   simp only [Nat.succ_add, Nat.succ_eq_add_one, Finset.sum_range_succ_comm]
   simp only [add_assoc, sub_eq_add_neg]
   refine le_trans (abv_add _ _ _) ?_
@@ -209,10 +210,12 @@ lemma series_ratio_test {f : ℕ → β} (n : ℕ) (r : α) (hr0 : 0 ≤ r) (hr1
     simpa [Nat.sub_add_cancel m_pos, pow_succ] using this
   generalize hk : m - n.succ = k
   replace hk : m = k + n.succ := (tsub_eq_iff_eq_add_of_le hmn).1 hk
-  induction' k with k ih generalizing m n
-  · rw [hk, Nat.zero_add, mul_right_comm, inv_pow _ _, ← div_eq_mul_inv, mul_div_cancel_right₀]
+  induction k generalizing m n with
+  | zero =>
+    rw [hk, Nat.zero_add, mul_right_comm, inv_pow _ _, ← div_eq_mul_inv, mul_div_cancel_right₀]
     positivity
-  · have kn : k + n.succ ≥ n.succ := by
+  | succ k ih =>
+    have kn : k + n.succ ≥ n.succ := by
       rw [← zero_add n.succ]; exact add_le_add (Nat.zero_le _) (by simp)
     rw [hk, Nat.succ_add, pow_succ r, ← mul_assoc]
     refine

--- a/Mathlib/Algebra/Order/Group/Multiset.lean
+++ b/Mathlib/Algebra/Order/Group/Multiset.lean
@@ -39,10 +39,12 @@ instance instAddCancelCommMonoid : AddCancelCommMonoid (Multiset α) where
   nsmul := nsmulRec
 
 lemma mem_of_mem_nsmul {a : α} {s : Multiset α} {n : ℕ} (h : a ∈ n • s) : a ∈ s := by
-  induction' n with n ih
-  · rw [zero_nsmul] at h
+  induction n with
+  | zero =>
+    rw [zero_nsmul] at h
     exact absurd h (not_mem_zero _)
-  · rw [succ_nsmul, mem_add] at h
+  | succ n ih =>
+    rw [succ_nsmul, mem_add] at h
     exact h.elim ih id
 
 @[simp]
@@ -178,9 +180,9 @@ end
 @[ext]
 lemma addHom_ext [AddZeroClass β] ⦃f g : Multiset α →+ β⦄ (h : ∀ x, f {x} = g {x}) : f = g := by
   ext s
-  induction' s using Multiset.induction_on with a s ih
-  · simp only [_root_.map_zero]
-  · simp only [← singleton_add, _root_.map_add, ih, h]
+  induction s using Multiset.induction_on with
+  | empty => simp only [_root_.map_zero]
+  | cons a s ih => simp only [← singleton_add, _root_.map_add, ih, h]
 
 open Nat
 

--- a/Mathlib/Algebra/Polynomial/BigOperators.lean
+++ b/Mathlib/Algebra/Polynomial/BigOperators.lean
@@ -84,20 +84,21 @@ theorem degree_list_sum_le (l : List S[X]) : degree l.sum ≤ (l.map natDegree).
     simp [hp]
 
 theorem natDegree_list_prod_le (l : List S[X]) : natDegree l.prod ≤ (l.map natDegree).sum := by
-  induction' l with hd tl IH
-  · simp
-  · simpa using natDegree_mul_le.trans (add_le_add_left IH _)
+  induction l with
+  | nil => simp
+  | cons hd tl IH => simpa using natDegree_mul_le.trans (add_le_add_left IH _)
 
 theorem degree_list_prod_le (l : List S[X]) : degree l.prod ≤ (l.map degree).sum := by
-  induction' l with hd tl IH
-  · simp
-  · simpa using (degree_mul_le _ _).trans (add_le_add_left IH _)
+  induction l with
+  | nil => simp
+  | cons hd tl IH => simpa using (degree_mul_le _ _).trans (add_le_add_left IH _)
 
 theorem coeff_list_prod_of_natDegree_le (l : List S[X]) (n : ℕ) (hl : ∀ p ∈ l, natDegree p ≤ n) :
     coeff (List.prod l) (l.length * n) = (l.map fun p => coeff p n).prod := by
-  induction' l with hd tl IH
-  · simp
-  · have hl' : ∀ p ∈ tl, natDegree p ≤ n := fun p hp => hl p (List.mem_cons_of_mem _ hp)
+  induction l with
+  | nil => simp
+  | cons hd tl IH =>
+    have hl' : ∀ p ∈ tl, natDegree p ≤ n := fun p hp => hl p (List.mem_cons_of_mem _ hp)
     simp only [List.prod_cons, List.map, List.length]
     rw [add_mul, one_mul, add_comm, ← IH hl', mul_comm tl.length]
     have h : natDegree tl.prod ≤ n * tl.length := by

--- a/Mathlib/Algebra/Polynomial/Degree/Lemmas.lean
+++ b/Mathlib/Algebra/Polynomial/Degree/Lemmas.lean
@@ -158,9 +158,10 @@ theorem coeff_mul_of_natDegree_le (pm : p.natDegree ≤ m) (qn : q.natDegree ≤
 
 theorem coeff_pow_of_natDegree_le (pn : p.natDegree ≤ n) :
     (p ^ m).coeff (m * n) = p.coeff n ^ m := by
-  induction' m with m hm
-  · simp
-  · rw [pow_succ, pow_succ, ← hm, Nat.succ_mul, coeff_mul_of_natDegree_le _ pn]
+  induction m with
+  | zero => simp
+  | succ m hm =>
+    rw [pow_succ, pow_succ, ← hm, Nat.succ_mul, coeff_mul_of_natDegree_le _ pn]
     refine natDegree_pow_le.trans (le_trans ?_ (le_refl _))
     exact mul_le_mul_of_nonneg_left pn m.zero_le
 
@@ -186,9 +187,10 @@ theorem degree_sum_eq_of_disjoint (f : S → R[X]) (s : Finset S)
     (h : Set.Pairwise { i | i ∈ s ∧ f i ≠ 0 } (Ne on degree ∘ f)) :
     degree (s.sum f) = s.sup fun i => degree (f i) := by
   classical
-  induction' s using Finset.induction_on with x s hx IH
-  · simp
-  · simp only [hx, Finset.sum_insert, not_false_iff, Finset.sup_insert]
+  induction s using Finset.induction_on with
+  | empty => simp
+  | @insert x s hx IH =>
+    simp only [hx, Finset.sum_insert, not_false_iff, Finset.sup_insert]
     specialize IH (h.mono fun _ => by simp +contextual)
     rcases lt_trichotomy (degree (f x)) (degree (s.sum f)) with (H | H | H)
     · rw [← IH, sup_eq_right.mpr H.le, degree_add_eq_right_of_degree_lt H]

--- a/Mathlib/Algebra/Polynomial/Derivative.lean
+++ b/Mathlib/Algebra/Polynomial/Derivative.lean
@@ -204,7 +204,8 @@ theorem derivative_ofNat (n : ℕ) [n.AtLeastTwo] :
 
 theorem iterate_derivative_eq_zero {p : R[X]} {x : ℕ} (hx : p.natDegree < x) :
     Polynomial.derivative^[x] p = 0 := by
-  induction' h : p.natDegree using Nat.strong_induction_on with _ ih generalizing p x
+  induction h : p.natDegree using Nat.strong_induction_on generalizing p x with
+  | h _ ih => ?_
   subst h
   obtain ⟨t, rfl⟩ := Nat.exists_eq_succ_of_ne_zero (pos_of_gt hx).ne'
   rw [Function.iterate_succ_apply]
@@ -282,9 +283,10 @@ theorem derivative_map [Semiring S] (p : R[X]) (f : R →+* S) :
 @[simp]
 theorem iterate_derivative_map [Semiring S] (p : R[X]) (f : R →+* S) (k : ℕ) :
     Polynomial.derivative^[k] (p.map f) = (Polynomial.derivative^[k] p).map f := by
-  induction' k with k ih generalizing p
-  · simp
-  · simp only [ih, Function.iterate_succ, Polynomial.derivative_map, Function.comp_apply]
+  induction k generalizing p with
+  | zero => simp
+  | succ k ih =>
+    simp only [ih, Function.iterate_succ, Polynomial.derivative_map, Function.comp_apply]
 
 theorem derivative_natCast_mul {n : ℕ} {f : R[X]} :
     derivative ((n : R[X]) * f) = n * derivative f := by
@@ -603,9 +605,9 @@ theorem derivative_comp_one_sub_X (p : R[X]) :
 @[simp]
 theorem iterate_derivative_comp_one_sub_X (p : R[X]) (k : ℕ) :
     derivative^[k] (p.comp (1 - X)) = (-1) ^ k * (derivative^[k] p).comp (1 - X) := by
-  induction' k with k ih generalizing p
-  · simp
-  · simp [ih (derivative p), iterate_derivative_neg, derivative_comp, pow_succ]
+  induction k generalizing p with
+  | zero => simp
+  | succ k ih => simp [ih (derivative p), iterate_derivative_neg, derivative_comp, pow_succ]
 
 theorem eval_multiset_prod_X_sub_C_derivative [DecidableEq R]
     {S : Multiset R} {r : R} (hr : r ∈ S) :

--- a/Mathlib/Algebra/Polynomial/EraseLead.lean
+++ b/Mathlib/Algebra/Polynomial/EraseLead.lean
@@ -266,11 +266,13 @@ theorem induction_with_natDegree_le (P : R[X] → Prop) (N : ℕ) (P_0 : P 0)
   intro f df
   generalize hd : #f.support = c
   revert f
-  induction' c with c hc
-  · intro f _ f0
+  induction c with
+  | zero =>
+    intro f _ f0
     convert P_0
     simpa [support_eq_empty, card_eq_zero] using f0
-  · intro f df f0
+  | succ c hc =>
+    intro f df f0
     rw [← eraseLead_add_C_mul_X_pow f]
     cases c
     · convert P_C_mul_pow f.natDegree f.leadingCoeff ?_ df using 1

--- a/Mathlib/Algebra/Polynomial/Eval/Defs.lean
+++ b/Mathlib/Algebra/Polynomial/Eval/Defs.lean
@@ -160,9 +160,10 @@ theorem eval₂_mul_C' (h : Commute (f a) x) : eval₂ f x (p * C a) = eval₂ f
 theorem eval₂_list_prod_noncomm (ps : List R[X])
     (hf : ∀ p ∈ ps, ∀ (k), Commute (f <| coeff p k) x) :
     eval₂ f x ps.prod = (ps.map (Polynomial.eval₂ f x)).prod := by
-  induction' ps using List.reverseRecOn with ps p ihp
-  · simp
-  · simp only [List.forall_mem_append, List.forall_mem_singleton] at hf
+  induction ps using List.reverseRecOn with
+  | nil => simp
+  | append_singleton ps p ihp =>
+    simp only [List.forall_mem_append, List.forall_mem_singleton] at hf
     simp [eval₂_mul_noncomm _ _ hf.2, ihp hf.1]
 
 /-- `eval₂` as a `RingHom` for noncommutative rings -/

--- a/Mathlib/Algebra/Polynomial/HasseDeriv.lean
+++ b/Mathlib/Algebra/Polynomial/HasseDeriv.lean
@@ -126,8 +126,9 @@ theorem hasseDeriv_X (hk : 1 < k) : hasseDeriv k (X : R[X]) = 0 := by
     zero_mul, monomial_zero_right]
 
 theorem factorial_smul_hasseDeriv : ⇑(k ! • @hasseDeriv R _ k) = (@derivative R _)^[k] := by
-  induction' k with k ih
-  · rw [hasseDeriv_zero, factorial_zero, iterate_zero, one_smul, LinearMap.id_coe]
+  induction k with
+  | zero => rw [hasseDeriv_zero, factorial_zero, iterate_zero, one_smul, LinearMap.id_coe]
+  | succ k ih => ?_
   ext f n : 2
   rw [iterate_succ_apply', ← ih]
   simp only [LinearMap.smul_apply, coeff_smul, LinearMap.map_smul_of_tower, coeff_derivative,

--- a/Mathlib/Algebra/Ring/Subring/Basic.lean
+++ b/Mathlib/Algebra/Ring/Subring/Basic.lean
@@ -926,8 +926,9 @@ protected theorem InClosure.recOn {C : R → Prop} {x : R} (hx : x ∈ closure s
   have h0 : C 0 := add_neg_cancel (1 : R) ▸ ha h1 hneg1
   rcases exists_list_of_mem_closure hx with ⟨L, HL, rfl⟩
   clear hx
-  induction' L with hd tl ih
-  · exact h0
+  induction L with
+  | nil => exact h0
+  | cons hd tl ih => ?_
   rw [List.forall_mem_cons] at HL
   suffices C (List.prod hd) by
     rw [List.map_cons, List.sum_cons]
@@ -938,20 +939,23 @@ protected theorem InClosure.recOn {C : R → Prop} {x : R} (hx : x ∈ closure s
     ∃ L : List R, (∀ x ∈ L, x ∈ s) ∧ (List.prod hd = List.prod L ∨ List.prod hd = -List.prod L)
   · rw [HP]
     clear HP HL hd
-    induction' L with hd tl ih
-    · exact h1
+    induction L with
+    | nil => exact h1
+    | cons hd tl ih => ?_
     rw [List.forall_mem_cons] at HL'
     rw [List.prod_cons]
     exact hs _ HL'.1 _ (ih HL'.2)
   · rw [HP]
     clear HP HL hd
-    induction' L with hd tl ih
-    · exact hneg1
+    induction L with
+    | nil => exact hneg1
+    | cons hd tl ih => ?_
     rw [List.prod_cons, neg_mul_eq_mul_neg]
     rw [List.forall_mem_cons] at HL'
     exact hs _ HL'.1 _ (ih HL'.2)
-  induction' hd with hd tl ih
-  · exact ⟨[], List.forall_mem_nil _, Or.inl rfl⟩
+  induction hd with
+  | nil => exact ⟨[], List.forall_mem_nil _, Or.inl rfl⟩
+  | cons hd tl ih => ?_
   rw [List.forall_mem_cons] at HL
   rcases ih HL.2 with ⟨L, HL', HP | HP⟩ <;> rcases HL.1 with hhd | hhd
   · exact

--- a/Mathlib/Algebra/Tropical/BigOperators.lean
+++ b/Mathlib/Algebra/Tropical/BigOperators.lean
@@ -36,9 +36,9 @@ variable {R S : Type*}
 open Tropical Finset
 
 theorem List.trop_sum [AddMonoid R] (l : List R) : trop l.sum = List.prod (l.map trop) := by
-  induction' l with hd tl IH
-  · simp
-  · simp [← IH]
+  induction l with
+  | nil => simp
+  | cons hd tl IH => simp [← IH]
 
 theorem Multiset.trop_sum [AddCommMonoid R] (s : Multiset R) :
     trop s.sum = Multiset.prod (s.map trop) :=
@@ -52,9 +52,9 @@ theorem trop_sum [AddCommMonoid R] (s : Finset S) (f : S → R) :
 
 theorem List.untrop_prod [AddMonoid R] (l : List (Tropical R)) :
     untrop l.prod = List.sum (l.map untrop) := by
-  induction' l with hd tl IH
-  · simp
-  · simp [← IH]
+  induction l with
+  | nil => simp
+  | cons hd tl IH => simp [← IH]
 
 theorem Multiset.untrop_prod [AddCommMonoid R] (s : Multiset (Tropical R)) :
     untrop s.prod = Multiset.sum (s.map untrop) :=
@@ -68,9 +68,9 @@ theorem untrop_prod [AddCommMonoid R] (s : Finset S) (f : S → Tropical R) :
 
 theorem List.trop_minimum [LinearOrder R] (l : List R) :
     trop l.minimum = List.sum (l.map (trop ∘ WithTop.some)) := by
-  induction' l with hd tl IH
-  · simp
-  · simp [List.minimum_cons, ← IH]
+  induction l with
+  | nil => simp
+  | cons hd tl IH => simp [List.minimum_cons, ← IH]
 
 theorem Multiset.trop_inf [LinearOrder R] [OrderTop R] (s : Multiset R) :
     trop s.inf = Multiset.sum (s.map trop) := by

--- a/Mathlib/AlgebraicTopology/DoldKan/Decomposition.lean
+++ b/Mathlib/AlgebraicTopology/DoldKan/Decomposition.lean
@@ -50,10 +50,12 @@ the $y_i$ are in degree $n$. -/
 theorem decomposition_Q (n q : ℕ) :
     ((Q q).f (n + 1) : X _⦋n + 1⦌ ⟶ X _⦋n + 1⦌) =
       ∑ i : Fin (n + 1) with i.val < q, (P i).f (n + 1) ≫ X.δ i.rev.succ ≫ X.σ (Fin.rev i) := by
-  induction' q with q hq
-  · simp only [Q_zero, HomologicalComplex.zero_f_apply, Nat.not_lt_zero,
+  induction q with
+  | zero =>
+    simp only [Q_zero, HomologicalComplex.zero_f_apply, Nat.not_lt_zero,
       Finset.filter_False, Finset.sum_empty]
-  · by_cases hqn : q + 1 ≤ n + 1
+  | succ q hq =>
+    by_cases hqn : q + 1 ≤ n + 1
     swap
     · rw [Q_is_eventually_constant (show n + 1 ≤ q by omega), hq]
       congr 1

--- a/Mathlib/AlgebraicTopology/DoldKan/Degeneracies.lean
+++ b/Mathlib/AlgebraicTopology/DoldKan/Degeneracies.lean
@@ -54,10 +54,12 @@ theorem HigherFacesVanish.comp_σ {Y : C} {X : SimplicialObject C} {n b q : ℕ}
 theorem σ_comp_P_eq_zero (X : SimplicialObject C) {n q : ℕ} (i : Fin (n + 1)) (hi : n + 1 ≤ i + q) :
     X.σ i ≫ (P q).f (n + 1) = 0 := by
   revert i hi
-  induction' q with q hq
-  · intro i (hi : n + 1 ≤ i)
+  induction q with
+  | zero =>
+    intro i (hi : n + 1 ≤ i)
     omega
-  · intro i (hi : n + 1 ≤ i + q + 1)
+  | succ q hq =>
+    intro i (hi : n + 1 ≤ i + q + 1)
     by_cases h : n + 1 ≤ (i : ℕ) + q
     · rw [P_succ, HomologicalComplex.comp_f, ← assoc, hq i h, zero_comp]
     · replace hi : n = i + q := by

--- a/Mathlib/AlgebraicTopology/DoldKan/Projections.lean
+++ b/Mathlib/AlgebraicTopology/DoldKan/Projections.lean
@@ -53,9 +53,10 @@ lemma P_succ (q : ℕ) : (P (q+1) : K[X] ⟶ K[X]) = P q ≫ (𝟙 _ + Hσ q) :=
 /-- All the `P q` coincide with `𝟙 _` in degree 0. -/
 @[simp]
 theorem P_f_0_eq (q : ℕ) : ((P q).f 0 : X _⦋0⦌ ⟶ X _⦋0⦌) = 𝟙 _ := by
-  induction' q with q hq
-  · rfl
-  · simp only [P_succ, HomologicalComplex.add_f_apply, HomologicalComplex.comp_f,
+  induction q with
+  | zero => rfl
+  | succ q hq =>
+    simp only [P_succ, HomologicalComplex.add_f_apply, HomologicalComplex.comp_f,
       HomologicalComplex.id_f, id_comp, hq, Hσ_eq_zero, add_zero]
 
 /-- `Q q` is the complement projection associated to `P q` -/
@@ -95,10 +96,12 @@ theorem of_P : ∀ q n : ℕ, HigherFacesVanish q ((P q).f (n + 1) : X _⦋n + 1
 @[reassoc]
 theorem comp_P_eq_self {Y : C} {n q : ℕ} {φ : Y ⟶ X _⦋n + 1⦌} (v : HigherFacesVanish q φ) :
     φ ≫ (P q).f (n + 1) = φ := by
-  induction' q with q hq
-  · simp only [P_zero]
+  induction q with
+  | zero =>
+    simp only [P_zero]
     apply comp_id
-  · simp only [P_succ, comp_add, HomologicalComplex.comp_f, HomologicalComplex.add_f_apply,
+  | succ q hq =>
+    simp only [P_succ, comp_add, HomologicalComplex.comp_f, HomologicalComplex.add_f_apply,
       comp_id, ← assoc, hq v.of_succ, add_eq_left]
     by_cases hqn : n < q
     · exact v.of_succ.comp_Hσ_eq_zero hqn
@@ -147,10 +150,12 @@ theorem Q_idem (q : ℕ) : (Q q : K[X] ⟶ K[X]) ≫ Q q = Q q := by
 def natTransP (q : ℕ) : alternatingFaceMapComplex C ⟶ alternatingFaceMapComplex C where
   app _ := P q
   naturality _ _ f := by
-    induction' q with q hq
-    · dsimp [alternatingFaceMapComplex]
+    induction q with
+    | zero =>
+      dsimp [alternatingFaceMapComplex]
       simp only [P_zero, id_comp, comp_id]
-    · simp only [P_succ, add_comp, comp_add, assoc, comp_id, hq, reassoc_of% hq]
+    | succ q hq =>
+      simp only [P_succ, add_comp, comp_add, assoc, comp_id, hq, reassoc_of% hq]
       -- `erw` is needed to see through `natTransHσ q).app = Hσ q`
       erw [(natTransHσ q).naturality f]
       rfl
@@ -176,10 +181,12 @@ def natTransQ (q : ℕ) : alternatingFaceMapComplex C ⟶ alternatingFaceMapComp
 theorem map_P {D : Type*} [Category D] [Preadditive D] (G : C ⥤ D) [G.Additive]
     (X : SimplicialObject C) (q n : ℕ) :
     G.map ((P q : K[X] ⟶ _).f n) = (P q : K[((whiskering C D).obj G).obj X] ⟶ _).f n := by
-  induction' q with q hq
-  · simp only [P_zero]
+  induction q with
+  | zero =>
+    simp only [P_zero]
     apply G.map_id
-  · simp only [P_succ, comp_add, HomologicalComplex.comp_f, HomologicalComplex.add_f_apply,
+  | succ q hq =>
+    simp only [P_succ, comp_add, HomologicalComplex.comp_f, HomologicalComplex.add_f_apply,
       comp_id, Functor.map_add, Functor.map_comp, hq, map_Hσ]
 
 theorem map_Q {D : Type*} [Category D] [Preadditive D] (G : C ⥤ D) [G.Additive]

--- a/Mathlib/Analysis/Analytic/Composition.lean
+++ b/Mathlib/Analysis/Analytic/Composition.lean
@@ -1070,9 +1070,10 @@ theorem sizeUpTo_sizeUpTo_add (a : Composition n) (b : Composition a.length) {i 
     show
       sum (take (b.blocks.take i).sum a.blocks) =
         sum (take i (map sum (splitWrtComposition a.blocks b)))
-    induction' i with i IH
-    · rfl
-    · have A : i < b.length := Nat.lt_of_succ_lt hi
+    induction i with
+    | zero => rfl
+    | succ i IH =>
+      have A : i < b.length := Nat.lt_of_succ_lt hi
       have B : i < List.length (map List.sum (splitWrtComposition a.blocks b)) := by simp [A]
       have C : 0 < blocksFun b ⟨i, A⟩ := Composition.blocks_pos' _ _ _
       rw [sum_take_succ _ _ B, ← IH A C]

--- a/Mathlib/Analysis/Analytic/Constructions.lean
+++ b/Mathlib/Analysis/Analytic/Constructions.lean
@@ -1133,10 +1133,12 @@ theorem Finset.analyticWithinAt_sum {f : α → E → F} {c : E} {s : Set E}
     (N : Finset α) (h : ∀ n ∈ N, AnalyticWithinAt 𝕜 (f n) s c) :
     AnalyticWithinAt 𝕜 (fun z ↦ ∑ n ∈ N, f n z) s c := by
   classical
-  induction' N using Finset.induction with a B aB hB
-  · simp only [Finset.sum_empty]
+  induction N using Finset.induction with
+  | empty =>
+    simp only [Finset.sum_empty]
     exact analyticWithinAt_const
-  · simp_rw [Finset.sum_insert aB]
+  | @insert a B aB hB =>
+    simp_rw [Finset.sum_insert aB]
     simp only [Finset.mem_insert] at h
     exact (h a (Or.inl rfl)).add (hB fun b m ↦ h b (Or.inr m))
 
@@ -1165,10 +1167,12 @@ theorem Finset.analyticWithinAt_prod {A : Type*} [NormedCommRing A] [NormedAlgeb
     {f : α → E → A} {c : E} {s : Set E} (N : Finset α) (h : ∀ n ∈ N, AnalyticWithinAt 𝕜 (f n) s c) :
     AnalyticWithinAt 𝕜 (fun z ↦ ∏ n ∈ N, f n z) s c := by
   classical
-  induction' N using Finset.induction with a B aB hB
-  · simp only [Finset.prod_empty]
+  induction N using Finset.induction with
+  | empty =>
+    simp only [Finset.prod_empty]
     exact analyticWithinAt_const
-  · simp_rw [Finset.prod_insert aB]
+  | @insert a B aB hB =>
+    simp_rw [Finset.prod_insert aB]
     simp only [Finset.mem_insert] at h
     exact (h a (Or.inl rfl)).mul (hB fun b m ↦ h b (Or.inr m))
 

--- a/Mathlib/Analysis/BoxIntegral/Box/SubboxInduction.lean
+++ b/Mathlib/Analysis/BoxIntegral/Box/SubboxInduction.lean
@@ -129,8 +129,9 @@ theorem subbox_induction_on' {p : Box ι → Prop} (I : Box ι)
     fun m ↦ Nat.recOn m hpI fun m ↦ by simpa only [J_succ] using hs (J m) (hJle m)
   have hJsub : ∀ m i, (J m).upper i - (J m).lower i = (I.upper i - I.lower i) / 2 ^ m := by
     intro m i
-    induction' m with m ihm
-    · simp [J]
+    induction m with
+    | zero => simp [J]
+    | succ m ihm => ?_
     simp only [pow_succ, J_succ, upper_sub_lower_splitCenterBox, ihm, div_div]
   have h0 : J 0 = I := rfl
   clear_value J

--- a/Mathlib/Analysis/BoxIntegral/Partition/Additive.lean
+++ b/Mathlib/Analysis/BoxIntegral/Partition/Additive.lean
@@ -118,8 +118,9 @@ def ofMapSplitAdd [Finite ι] (f : Box ι → M) (I₀ : WithTop (Box ι))
   refine ⟨f, ?_⟩
   replace hf : ∀ I : Box ι, ↑I ≤ I₀ → ∀ s, (∑ J ∈ (splitMany I s).boxes, f J) = f I := by
     intro I hI s
-    induction' s using Finset.induction_on with a s _ ihs
-    · simp
+    induction s using Finset.induction_on with
+    | empty => simp
+    | @insert a s _ ihs => ?_
     rw [splitMany_insert, inf_split, ← ihs, biUnion_boxes, sum_biUnion_boxes]
     refine Finset.sum_congr rfl fun J' hJ' => ?_
     by_cases h : a.2 ∈ Ioo (J'.lower a.1) (J'.upper a.1)

--- a/Mathlib/Analysis/BoxIntegral/Partition/Split.lean
+++ b/Mathlib/Analysis/BoxIntegral/Partition/Split.lean
@@ -245,9 +245,9 @@ theorem iUnion_splitMany (I : Box ι) (s : Finset (ι × ℝ)) : (splitMany I s)
 theorem inf_splitMany {I : Box ι} (π : Prepartition I) (s : Finset (ι × ℝ)) :
     π ⊓ splitMany I s = π.biUnion fun J => splitMany J s := by
   classical
-  induction' s using Finset.induction_on with p s _ ihp
-  · simp
-  · simp_rw [splitMany_insert, ← inf_assoc, ihp, inf_split, biUnion_assoc]
+  induction s using Finset.induction_on with
+  | empty => simp
+  | @insert p s _ ihp => simp_rw [splitMany_insert, ← inf_assoc, ihp, inf_split, biUnion_assoc]
 
 open scoped Classical in
 /-- Let `s : Finset (ι × ℝ)` be a set of hyperplanes `{x : ι → ℝ | x i = r}` in `ι → ℝ` encoded as

--- a/Mathlib/Analysis/CStarAlgebra/Basic.lean
+++ b/Mathlib/Analysis/CStarAlgebra/Basic.lean
@@ -240,9 +240,10 @@ end CStarRing
 
 theorem IsSelfAdjoint.nnnorm_pow_two_pow [NormedRing E] [StarRing E] [CStarRing E] {x : E}
     (hx : IsSelfAdjoint x) (n : ℕ) : ‖x ^ 2 ^ n‖₊ = ‖x‖₊ ^ 2 ^ n := by
-  induction' n with k hk
-  · simp only [pow_zero, pow_one]
-  · rw [pow_succ', pow_mul', sq]
+  induction n with
+  | zero => simp only [pow_zero, pow_one]
+  | succ k hk =>
+    rw [pow_succ', pow_mul', sq]
     nth_rw 1 [← selfAdjoint.mem_iff.mp hx]
     rw [← star_pow, CStarRing.nnnorm_star_mul_self, ← sq, hk, pow_mul']
 

--- a/Mathlib/Analysis/CStarAlgebra/Multiplier.lean
+++ b/Mathlib/Analysis/CStarAlgebra/Multiplier.lean
@@ -192,9 +192,10 @@ instance instIntCast : IntCast 𝓜(𝕜, A) where
 instance instPow : Pow 𝓜(𝕜, A) ℕ where
   pow a n :=
     ⟨a.toProd ^ n, fun x y => by
-      induction' n with k hk generalizing x y
-      · rfl
-      · rw [Prod.pow_snd, Prod.pow_fst] at hk ⊢
+      induction n generalizing x y with
+      | zero => rfl
+      | succ k hk =>
+        rw [Prod.pow_snd, Prod.pow_fst] at hk ⊢
         rw [pow_succ' a.snd, mul_apply, a.central, hk, pow_succ a.fst, mul_apply]⟩
 
 instance instInhabited : Inhabited 𝓜(𝕜, A) :=

--- a/Mathlib/Analysis/Calculus/ContDiff/Basic.lean
+++ b/Mathlib/Analysis/Calculus/ContDiff/Basic.lean
@@ -233,11 +233,13 @@ theorem ContinuousLinearEquiv.iteratedFDerivWithin_comp_left (g : F ≃L[𝕜] G
     (hs : UniqueDiffOn 𝕜 s) (hx : x ∈ s) (i : ℕ) :
     iteratedFDerivWithin 𝕜 i (g ∘ f) s x =
       (g : F →L[𝕜] G).compContinuousMultilinearMap (iteratedFDerivWithin 𝕜 i f s x) := by
-  induction' i with i IH generalizing x
-  · ext1 m
+  induction i generalizing x with
+  | zero =>
+    ext1 m
     simp only [iteratedFDerivWithin_zero_apply, comp_apply,
       ContinuousLinearMap.compContinuousMultilinearMap_coe, coe_coe]
-  · ext1 m
+  | succ i IH =>
+    ext1 m
     rw [iteratedFDerivWithin_succ_apply_left]
     have Z : fderivWithin 𝕜 (iteratedFDerivWithin 𝕜 i (g ∘ f) s) s x =
         fderivWithin 𝕜 (g.compContinuousMultilinearMapL (fun _ : Fin i => E) ∘
@@ -388,11 +390,13 @@ theorem ContinuousLinearEquiv.iteratedFDerivWithin_comp_right (g : G ≃L[𝕜] 
     (hs : UniqueDiffOn 𝕜 s) {x : G} (hx : g x ∈ s) (i : ℕ) :
     iteratedFDerivWithin 𝕜 i (f ∘ g) (g ⁻¹' s) x =
       (iteratedFDerivWithin 𝕜 i f s (g x)).compContinuousLinearMap fun _ => g := by
-  induction' i with i IH generalizing x
-  · ext1
+  induction i generalizing x with
+  | zero =>
+    ext1
     simp only [iteratedFDerivWithin_zero_apply, comp_apply,
      ContinuousMultilinearMap.compContinuousLinearMap_apply]
-  · ext1 m
+  | succ i IH =>
+    ext1 m
     simp only [ContinuousMultilinearMap.compContinuousLinearMap_apply,
       ContinuousLinearEquiv.coe_coe, iteratedFDerivWithin_succ_apply_left]
     have : fderivWithin 𝕜 (iteratedFDerivWithin 𝕜 i (f ∘ g) (g ⁻¹' s)) (g ⁻¹' s) x =
@@ -1154,11 +1158,13 @@ theorem ContDiffWithinAt.fderivWithin_right_apply
 theorem ContDiffWithinAt.iteratedFDerivWithin_right {i : ℕ} (hf : ContDiffWithinAt 𝕜 n f s x₀)
     (hs : UniqueDiffOn 𝕜 s) (hmn : m + i ≤ n) (hx₀s : x₀ ∈ s) :
     ContDiffWithinAt 𝕜 m (iteratedFDerivWithin 𝕜 i f s) s x₀ := by
-  induction' i with i hi generalizing m
-  · simp only [CharP.cast_eq_zero, add_zero] at hmn
+  induction i generalizing m with
+  | zero =>
+    simp only [CharP.cast_eq_zero, add_zero] at hmn
     exact (hf.of_le hmn).continuousLinearMap_comp
       ((continuousMultilinearCurryFin0 𝕜 E F).symm : _ →L[𝕜] E [×0]→L[𝕜] F)
-  · rw [Nat.cast_succ, add_comm _ 1, ← add_assoc] at hmn
+  | succ i hi =>
+    rw [Nat.cast_succ, add_comm _ 1, ← add_assoc] at hmn
     exact ((hi hmn).fderivWithin_right hs le_rfl hx₀s).continuousLinearMap_comp
       ((continuousMultilinearCurryLeftEquiv 𝕜 (fun _ : Fin (i+1) ↦ E) F).symm :
         _ →L[𝕜] E [×(i+1)]→L[𝕜] F)

--- a/Mathlib/Analysis/Calculus/ContDiff/Bounds.lean
+++ b/Mathlib/Analysis/Calculus/ContDiff/Bounds.lean
@@ -49,11 +49,13 @@ theorem ContinuousLinearMap.norm_iteratedFDerivWithin_le_of_bilinear_aux {Du Eu 
     the spaces of linear maps that appear in the induction should be in the same universe as the
     original spaces, which explains why we assume in the lemma that all spaces live in the same
     universe. -/
-  induction' n with n IH generalizing Eu Fu Gu
-  · simp only [norm_iteratedFDerivWithin_zero, zero_add, Finset.range_one,
+  induction n generalizing Eu Fu Gu with
+  | zero =>
+    simp only [norm_iteratedFDerivWithin_zero, zero_add, Finset.range_one,
       Finset.sum_singleton, Nat.choose_self, Nat.cast_one, one_mul, Nat.sub_zero, ← mul_assoc]
     apply B.le_opNorm₂
-  · have In : (n : WithTop ℕ∞) + 1 ≤ n.succ := by simp only [Nat.cast_succ, le_refl]
+  | succ n IH =>
+    have In : (n : WithTop ℕ∞) + 1 ≤ n.succ := by simp only [Nat.cast_succ, le_refl]
     -- Porting note: the next line is a hack allowing Lean to find the operator norm instance.
     let norm := @ContinuousLinearMap.hasOpNorm _ _ Eu ((Du →L[𝕜] Fu) →L[𝕜] Du →L[𝕜] Gu) _ _ _ _ _ _
       (RingHom.id 𝕜)
@@ -360,9 +362,11 @@ theorem norm_iteratedFDerivWithin_comp_le_aux {Fu Gu : Type u} [NormedAddCommGro
     As composition of linear maps is a bilinear map, one may use
     `ContinuousLinearMap.norm_iteratedFDeriv_le_of_bilinear_of_le_one` to get from these a bound
     on `D^n (g ' ∘ f ⬝ f')`. -/
-  induction' n using Nat.case_strong_induction_on with n IH generalizing Gu
-  · simpa [norm_iteratedFDerivWithin_zero, Nat.factorial_zero, algebraMap.coe_one, one_mul,
+  induction n using Nat.case_strong_induction_on generalizing Gu with
+  | hz =>
+    simpa [norm_iteratedFDerivWithin_zero, Nat.factorial_zero, algebraMap.coe_one, one_mul,
       pow_zero, mul_one, comp_apply] using hC 0 le_rfl
+  | hi n IH => ?_
   have M : (n : WithTop ℕ∞) < n.succ := Nat.cast_lt.2 n.lt_succ_self
   have Cnonneg : 0 ≤ C := (norm_nonneg _).trans (hC 0 bot_le)
   have Dnonneg : 0 ≤ D := by

--- a/Mathlib/Analysis/Calculus/ContDiff/FTaylorSeries.lean
+++ b/Mathlib/Analysis/Calculus/ContDiff/FTaylorSeries.lean
@@ -454,12 +454,14 @@ theorem iteratedFDerivWithin_succ_apply_right {n : ℕ} (hs : UniqueDiffOn 𝕜 
     (m : Fin (n + 1) → E) :
     (iteratedFDerivWithin 𝕜 (n + 1) f s x : (Fin (n + 1) → E) → F) m =
       iteratedFDerivWithin 𝕜 n (fun y => fderivWithin 𝕜 f s y) s x (init m) (m (last n)) := by
-  induction' n with n IH generalizing x
-  · rw [iteratedFDerivWithin_succ_eq_comp_left, iteratedFDerivWithin_zero_eq_comp,
+  induction n generalizing x with
+  | zero =>
+    rw [iteratedFDerivWithin_succ_eq_comp_left, iteratedFDerivWithin_zero_eq_comp,
       iteratedFDerivWithin_zero_apply, Function.comp_apply,
       LinearIsometryEquiv.comp_fderivWithin _ (hs x hx)]
     rfl
-  · let I := (continuousMultilinearCurryRightEquiv' 𝕜 n E F).symm
+  | succ n IH =>
+    let I := (continuousMultilinearCurryRightEquiv' 𝕜 n E F).symm
     have A : ∀ y ∈ s, iteratedFDerivWithin 𝕜 n.succ f s y =
         (I ∘ iteratedFDerivWithin 𝕜 n (fun y => fderivWithin 𝕜 f s y) s) y := fun y hy ↦ by
       ext m
@@ -615,9 +617,10 @@ with the one we have chosen in `iteratedFDerivWithin 𝕜 m f s`. -/
 theorem HasFTaylorSeriesUpToOn.eq_iteratedFDerivWithin_of_uniqueDiffOn
     (h : HasFTaylorSeriesUpToOn n f p s) {m : ℕ} (hmn : m ≤ n) (hs : UniqueDiffOn 𝕜 s)
     (hx : x ∈ s) : p x m = iteratedFDerivWithin 𝕜 m f s x := by
-  induction' m with m IH generalizing x
-  · rw [h.zero_eq' hx, iteratedFDerivWithin_zero_eq_comp, comp_apply]
-  · have A : m < n := lt_of_lt_of_le (mod_cast lt_add_one m) hmn
+  induction m generalizing x with
+  | zero => rw [h.zero_eq' hx, iteratedFDerivWithin_zero_eq_comp, comp_apply]
+  | succ m IH =>
+    have A : m < n := lt_of_lt_of_le (mod_cast lt_add_one m) hmn
     have :
       HasFDerivWithinAt (fun y : E => iteratedFDerivWithin 𝕜 m f s y)
         (ContinuousMultilinearMap.curryLeft (p x (Nat.succ m))) s x :=

--- a/Mathlib/Analysis/Calculus/ContDiff/Operations.lean
+++ b/Mathlib/Analysis/Calculus/ContDiff/Operations.lean
@@ -241,9 +241,10 @@ variable {i : ℕ}
 -- prove it from `ContinuousLinearEquiv.iteratedFDerivWithin_comp_left`
 theorem iteratedFDerivWithin_neg_apply {f : E → F} (hu : UniqueDiffOn 𝕜 s) (hx : x ∈ s) :
     iteratedFDerivWithin 𝕜 i (-f) s x = -iteratedFDerivWithin 𝕜 i f s x := by
-  induction' i with i hi generalizing x
-  · ext; simp
-  · ext h
+  induction i generalizing x with
+  | zero => ext; simp
+  | succ i hi =>
+    ext h
     calc
       iteratedFDerivWithin 𝕜 (i + 1) (-f) s x h =
           fderivWithin 𝕜 (iteratedFDerivWithin 𝕜 i (-f) s) s x (h 0) (Fin.tail h) :=
@@ -288,9 +289,10 @@ theorem ContDiffWithinAt.sum {ι : Type*} {f : ι → E → F} {s : Finset ι} {
     (h : ∀ i ∈ s, ContDiffWithinAt 𝕜 n (fun x => f i x) t x) :
     ContDiffWithinAt 𝕜 n (fun x => ∑ i ∈ s, f i x) t x := by
   classical
-    induction' s using Finset.induction_on with i s is IH
-    · simp [contDiffWithinAt_const]
-    · simp only [is, Finset.sum_insert, not_false_iff]
+    induction s using Finset.induction_on with
+    | empty => simp [contDiffWithinAt_const]
+    | @insert i s is IH =>
+      simp only [is, Finset.sum_insert, not_false_iff]
       exact (h _ (Finset.mem_insert_self i s)).add
         (IH fun j hj => h _ (Finset.mem_insert_of_mem hj))
 

--- a/Mathlib/Analysis/Calculus/Deriv/ZPow.lean
+++ b/Mathlib/Analysis/Calculus/Deriv/ZPow.lean
@@ -92,10 +92,12 @@ theorem derivWithin_zpow (hxs : UniqueDiffWithinAt 𝕜 s x) (h : x ≠ 0 ∨ 0 
 theorem iter_deriv_zpow' (m : ℤ) (k : ℕ) :
     (deriv^[k] fun x : 𝕜 => x ^ m) =
       fun x => (∏ i ∈ Finset.range k, ((m : 𝕜) - i)) * x ^ (m - k) := by
-  induction' k with k ihk
-  · simp only [one_mul, Int.ofNat_zero, id, sub_zero, Finset.prod_range_zero,
+  induction k with
+  | zero =>
+    simp only [one_mul, Int.ofNat_zero, id, sub_zero, Finset.prod_range_zero,
       Function.iterate_zero]
-  · simp only [Function.iterate_succ_apply', ihk, deriv_const_mul_field', deriv_zpow',
+  | succ k ihk =>
+    simp only [Function.iterate_succ_apply', ihk, deriv_const_mul_field', deriv_zpow',
       Finset.prod_range_succ, Int.ofNat_succ, ← sub_sub, Int.cast_sub, Int.cast_natCast, mul_assoc]
 
 theorem iter_deriv_zpow (m : ℤ) (x : 𝕜) (k : ℕ) :

--- a/Mathlib/Analysis/Calculus/IteratedDeriv/Lemmas.lean
+++ b/Mathlib/Analysis/Calculus/IteratedDeriv/Lemmas.lean
@@ -177,9 +177,10 @@ theorem iteratedDeriv_comp_const_mul {n : ℕ} {f : 𝕜 → 𝕜} (h : ContDiff
 
 lemma iteratedDeriv_comp_neg (n : ℕ) (f : 𝕜 → F) (a : 𝕜) :
     iteratedDeriv n (fun x ↦ f (-x)) a = (-1 : 𝕜) ^ n • iteratedDeriv n f (-a) := by
-  induction' n with n ih generalizing a
-  · simp only [iteratedDeriv_zero, pow_zero, one_smul]
-  · have ih' : iteratedDeriv n (fun x ↦ f (-x)) = fun x ↦ (-1 : 𝕜) ^ n • iteratedDeriv n f (-x) :=
+  induction n generalizing a with
+  | zero => simp only [iteratedDeriv_zero, pow_zero, one_smul]
+  | succ n ih =>
+    have ih' : iteratedDeriv n (fun x ↦ f (-x)) = fun x ↦ (-1 : 𝕜) ^ n • iteratedDeriv n f (-x) :=
       funext ih
     rw [iteratedDeriv_succ, iteratedDeriv_succ, ih', pow_succ', neg_mul, one_mul,
       deriv_comp_neg (f := fun x ↦ (-1 : 𝕜) ^ n • iteratedDeriv n f x), deriv_const_smul',

--- a/Mathlib/Analysis/Calculus/SmoothSeries.lean
+++ b/Mathlib/Analysis/Calculus/SmoothSeries.lean
@@ -189,11 +189,13 @@ theorem iteratedFDeriv_tsum (hf : ∀ i, ContDiff 𝕜 N (f i))
     (h'f : ∀ (k : ℕ) (i : α) (x : E), (k : ℕ∞) ≤ N → ‖iteratedFDeriv 𝕜 k (f i) x‖ ≤ v k i) {k : ℕ}
     (hk : (k : ℕ∞) ≤ N) :
     (iteratedFDeriv 𝕜 k fun y => ∑' n, f n y) = fun x => ∑' n, iteratedFDeriv 𝕜 k (f n) x := by
-  induction' k with k IH
-  · ext1 x
+  induction k with
+  | zero =>
+    ext1 x
     simp_rw [iteratedFDeriv_zero_eq_comp]
     exact (continuousMultilinearCurryFin0 𝕜 E F).symm.toContinuousLinearEquiv.map_tsum
-  · have h'k : (k : ℕ∞) < N := lt_of_lt_of_le (WithTop.coe_lt_coe.2 (Nat.lt_succ_self _)) hk
+  | succ k IH =>
+    have h'k : (k : ℕ∞) < N := lt_of_lt_of_le (WithTop.coe_lt_coe.2 (Nat.lt_succ_self _)) hk
     have A : Summable fun n => iteratedFDeriv 𝕜 k (f n) 0 :=
       .of_norm_bounded (v k) (hv k h'k.le) fun n => h'f k n 0 h'k.le
     simp_rw [iteratedFDeriv_succ_eq_comp_left, IH h'k.le]

--- a/Mathlib/Analysis/Convex/Combination.lean
+++ b/Mathlib/Analysis/Convex/Combination.lean
@@ -159,8 +159,9 @@ provided that all weights are non-negative, and the total weight is positive. -/
 theorem Convex.centerMass_mem (hs : Convex R s) :
     (∀ i ∈ t, 0 ≤ w i) → (0 < ∑ i ∈ t, w i) → (∀ i ∈ t, z i ∈ s) → t.centerMass w z ∈ s := by
   classical
-  induction' t using Finset.induction with i t hi ht
-  · simp [lt_irrefl]
+  induction t using Finset.induction with
+  | empty => simp [lt_irrefl]
+  | @insert i t hi ht => ?_
   intro h₀ hpos hmem
   have zi : z i ∈ s := hmem _ (mem_insert_self _ _)
   have hs₀ : ∀ j ∈ t, 0 ≤ w j := fun j hj => h₀ j <| mem_insert_of_mem hj

--- a/Mathlib/Analysis/Convex/Radon.lean
+++ b/Mathlib/Analysis/Convex/Radon.lean
@@ -89,8 +89,9 @@ theorem helly_theorem' {F : ι → Set E} {s : Finset ι}
   · exact helly_theorem_corner (le_of_lt h_card) h_inter
   generalize hn : #s = n
   rw [hn] at h_card
-  induction' n, h_card using Nat.le_induction with k h_card hk generalizing ι
-  · exact helly_theorem_corner (le_of_eq hn) h_inter
+  induction n, h_card using Nat.le_induction generalizing ι with
+  | base => exact helly_theorem_corner (le_of_eq hn) h_inter
+  | succ k h_card hk => ?_
   /- Construct a family of vectors indexed by `ι` such that the vector corresponding to `i : ι`
   is an arbitrary element of the intersection of all `F j` except `F i`. -/
   let a (i : s) : E := Set.Nonempty.some (s := ⋂ j ∈ s.erase i, F j) <| by

--- a/Mathlib/Analysis/InnerProductSpace/Projection.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Projection.lean
@@ -1110,8 +1110,9 @@ theorem LinearIsometryEquiv.reflections_generate_dim_aux [FiniteDimensional ℝ 
     ∃ l : List F, l.length ≤ n ∧ φ = (l.map fun v => reflection (ℝ ∙ v)ᗮ).prod := by
   -- We prove this by strong induction on `n`, the dimension of the orthogonal complement of the
   -- fixed subspace of the endomorphism `φ`
-  induction' n with n IH generalizing φ
-  · -- Base case: `n = 0`, the fixed subspace is the whole space, so `φ = id`
+  induction n generalizing φ with
+  | zero =>
+    -- Base case: `n = 0`, the fixed subspace is the whole space, so `φ = id`
     refine ⟨[], rfl.le, show φ = 1 from ?_⟩
     have : ker (ContinuousLinearMap.id ℝ F - φ) = ⊤ := by
       rwa [le_zero_iff, Submodule.finrank_eq_zero, Submodule.orthogonal_eq_bot_iff] at hn
@@ -1120,7 +1121,8 @@ theorem LinearIsometryEquiv.reflections_generate_dim_aux [FiniteDimensional ℝ 
     have := LinearMap.congr_fun (LinearMap.ker_eq_top.mp this) x
     simpa only [sub_eq_zero, ContinuousLinearMap.coe_sub, LinearMap.sub_apply,
       LinearMap.zero_apply] using this
-  · -- Inductive step.  Let `W` be the fixed subspace of `φ`.  We suppose its complement to have
+  | succ n IH =>
+    -- Inductive step.  Let `W` be the fixed subspace of `φ`.  We suppose its complement to have
     -- dimension at most n + 1.
     let W := ker (ContinuousLinearMap.id ℝ F - φ)
     have hW : ∀ w ∈ W, φ w = w := fun w hw => (sub_eq_zero.mp hw).symm

--- a/Mathlib/Analysis/Normed/Algebra/Exponential.lean
+++ b/Mathlib/Analysis/Normed/Algebra/Exponential.lean
@@ -483,8 +483,9 @@ theorem exp_sum_of_commute {ι} (s : Finset ι) (f : ι → 𝔸)
     exp 𝕂 (∑ i ∈ s, f i) =
       s.noncommProd (fun i => exp 𝕂 (f i)) fun _ hi _ hj _ => (h.of_refl hi hj).exp 𝕂 := by
   classical
-    induction' s using Finset.induction_on with a s ha ih
-    · simp
+    induction s using Finset.induction_on with
+    | empty => simp
+    | @insert a s ha ih => ?_
     rw [Finset.noncommProd_insert_of_not_mem _ _ _ _ ha, Finset.sum_insert ha, exp_add_of_commute,
       ih (h.mono <| Finset.subset_insert _ _)]
     refine Commute.sum_right _ _ _ fun i hi => ?_

--- a/Mathlib/Analysis/NormedSpace/Multilinear/Basic.lean
+++ b/Mathlib/Analysis/NormedSpace/Multilinear/Basic.lean
@@ -207,8 +207,9 @@ theorem norm_image_sub_le_of_bound' [DecidableEq ι] (f : MultilinearMap 𝕜 E 
       ‖f m₁ - f (s.piecewise m₂ m₁)‖ ≤
         C * ∑ i ∈ s, ∏ j, if j = i then ‖m₁ i - m₂ i‖ else max ‖m₁ j‖ ‖m₂ j‖ := by
     intro s
-    induction' s using Finset.induction with i s his Hrec
-    · simp
+    induction s using Finset.induction with
+    | empty => simp
+    | @insert i s his Hrec => ?_
     have I :
       ‖f (s.piecewise m₂ m₁) - f ((insert i s).piecewise m₂ m₁)‖ ≤
         C * ∏ j, if j = i then ‖m₁ i - m₂ i‖ else max ‖m₁ j‖ ‖m₂ j‖ := by

--- a/Mathlib/Analysis/SpecialFunctions/Gamma/Basic.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Gamma/Basic.lean
@@ -254,12 +254,14 @@ noncomputable def GammaAux : ℕ → ℂ → ℂ
 
 theorem GammaAux_recurrence1 (s : ℂ) (n : ℕ) (h1 : -s.re < ↑n) :
     GammaAux n s = GammaAux n (s + 1) / s := by
-  induction' n with n hn generalizing s
-  · simp only [CharP.cast_eq_zero, Left.neg_neg_iff] at h1
+  induction n generalizing s with
+  | zero =>
+    simp only [CharP.cast_eq_zero, Left.neg_neg_iff] at h1
     dsimp only [GammaAux]; rw [GammaIntegral_add_one h1]
     rw [mul_comm, mul_div_cancel_right₀]; contrapose! h1; rw [h1]
     simp
-  · dsimp only [GammaAux]
+  | succ n hn =>
+    dsimp only [GammaAux]
     have hh1 : -(s + 1).re < n := by
       rw [Nat.cast_add, Nat.cast_one] at h1
       rw [add_re, one_re]; linarith
@@ -289,9 +291,10 @@ irreducible_def Gamma (s : ℂ) : ℂ :=
 
 theorem Gamma_eq_GammaAux (s : ℂ) (n : ℕ) (h1 : -s.re < ↑n) : Gamma s = GammaAux n s := by
   have u : ∀ k : ℕ, GammaAux (⌊1 - s.re⌋₊ + k) s = Gamma s := by
-    intro k; induction' k with k hk
-    · simp [Gamma]
-    · rw [← hk, ← add_assoc]
+    intro k; induction k with
+    | zero => simp [Gamma]
+    | succ k hk =>
+      rw [← hk, ← add_assoc]
       refine (GammaAux_recurrence2 s (⌊1 - s.re⌋₊ + k) ?_).symm
       rw [Nat.cast_add]
       have i0 := Nat.sub_one_lt_floor (1 - s.re)

--- a/Mathlib/Analysis/SpecialFunctions/Gamma/Beta.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Gamma/Beta.lean
@@ -202,10 +202,12 @@ theorem betaIntegral_recurrence {u v : ℂ} (hu : 0 < re u) (hv : 0 < re v) :
 /-- Explicit formula for the Beta function when second argument is a positive integer. -/
 theorem betaIntegral_eval_nat_add_one_right {u : ℂ} (hu : 0 < re u) (n : ℕ) :
     betaIntegral u (n + 1) = n ! / ∏ j ∈ Finset.range (n + 1), (u + j) := by
-  induction' n with n IH generalizing u
-  · rw [Nat.cast_zero, zero_add, betaIntegral_eval_one_right hu, Nat.factorial_zero, Nat.cast_one]
+  induction n generalizing u with
+  | zero =>
+    rw [Nat.cast_zero, zero_add, betaIntegral_eval_one_right hu, Nat.factorial_zero, Nat.cast_one]
     simp
-  · have := betaIntegral_recurrence hu (?_ : 0 < re n.succ)
+  | succ n IH =>
+    have := betaIntegral_recurrence hu (?_ : 0 < re n.succ)
     swap; · rw [← ofReal_natCast, ofReal_re]; positivity
     rw [mul_comm u _, ← eq_div_iff] at this
     swap; · contrapose! hu; rw [hu, zero_re]
@@ -342,8 +344,9 @@ theorem GammaSeq_tendsto_Gamma (s : ℂ) : Tendsto (GammaSeq s) atTop (𝓝 <| G
     · refine (Nat.lt_floor_add_one _).trans_le ?_
       rw [sub_eq_neg_add, Nat.floor_add_one (neg_nonneg.mpr hs), Nat.cast_add_one]
   intro m
-  induction' m with m IH generalizing s
-  · -- Base case: `0 < re s`, so Gamma is given by the integral formula
+  induction m generalizing s with
+  | zero =>
+    -- Base case: `0 < re s`, so Gamma is given by the integral formula
     intro hs
     rw [Nat.cast_zero, neg_zero] at hs
     rw [← Gamma_eq_GammaAux]
@@ -351,7 +354,8 @@ theorem GammaSeq_tendsto_Gamma (s : ℂ) : Tendsto (GammaSeq s) atTop (𝓝 <| G
       refine (eventually_ne_atTop 0).mp (Eventually.of_forall fun n hn => ?_)
       exact (GammaSeq_eq_approx_Gamma_integral hs hn).symm
     · rwa [Nat.cast_zero, neg_lt_zero]
-  · -- Induction step: use recurrence formulae in `s` for Gamma and GammaSeq
+  | succ m IH =>
+    -- Induction step: use recurrence formulae in `s` for Gamma and GammaSeq
     intro hs
     rw [Nat.cast_succ, neg_add, ← sub_eq_add_neg, sub_lt_iff_lt_add, ← one_re, ← add_re] at hs
     rw [GammaAux]

--- a/Mathlib/Analysis/SpecialFunctions/Gamma/BohrMollerup.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Gamma/BohrMollerup.lean
@@ -247,10 +247,12 @@ theorem tendsto_logGammaSeq (hf_conv : ConvexOn ℝ (Ioi 0) f)
         abel
     · rw [← sub_le_iff_le_add]; exact Nat.le_ceil _
   intro m
-  induction' m with m hm generalizing x
-  · rw [Nat.cast_zero, zero_add]
+  induction m generalizing x with
+  | zero =>
+    rw [Nat.cast_zero, zero_add]
     exact fun _ hx' => tendsto_logGammaSeq_of_le_one hf_conv (@hf_feq) hx hx'
-  · intro hy hy'
+  | succ m hm =>
+    intro hy hy'
     rw [Nat.cast_succ, ← sub_le_iff_le_add] at hy'
     rw [Nat.cast_succ, ← lt_sub_iff_add_lt] at hy
     specialize hm ((Nat.cast_nonneg _).trans_lt hy) hy hy'

--- a/Mathlib/Analysis/SpecialFunctions/Gamma/Deriv.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Gamma/Deriv.lean
@@ -59,10 +59,12 @@ theorem hasDerivAt_GammaIntegral {s : ℂ} (hs : 0 < s.re) :
 
 theorem differentiableAt_GammaAux (s : ℂ) (n : ℕ) (h1 : 1 - s.re < n) (h2 : ∀ m : ℕ, s ≠ -m) :
     DifferentiableAt ℂ (GammaAux n) s := by
-  induction' n with n hn generalizing s
-  · refine (hasDerivAt_GammaIntegral ?_).differentiableAt
+  induction n generalizing s with
+  | zero =>
+    refine (hasDerivAt_GammaIntegral ?_).differentiableAt
     rw [Nat.cast_zero] at h1; linarith
-  · dsimp only [GammaAux]
+  | succ n hn =>
+    dsimp only [GammaAux]
     specialize hn (s + 1)
     have a : 1 - (s + 1).re < ↑n := by
       rw [Nat.cast_succ] at h1; rw [Complex.add_re, Complex.one_re]; linarith

--- a/Mathlib/Analysis/SpecialFunctions/Log/Base.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Log/Base.lean
@@ -474,8 +474,9 @@ theorem continuousAt_logb_iff (hb₀ : 0 < b) (hb : b ≠ 1) : ContinuousAt (log
 theorem logb_prod {α : Type*} (s : Finset α) (f : α → ℝ) (hf : ∀ x ∈ s, f x ≠ 0) :
     logb b (∏ i ∈ s, f i) = ∑ i ∈ s, logb b (f i) := by
   classical
-    induction' s using Finset.induction_on with a s ha ih
-    · simp
+    induction s using Finset.induction_on with
+    | empty => simp
+    | @insert a s ha ih => ?_
     simp only [Finset.mem_insert, forall_eq_or_imp] at hf
     simp [ha, ih hf.2, logb_mul hf.1 (Finset.prod_ne_zero_iff.2 hf.2)]
 

--- a/Mathlib/Analysis/SpecialFunctions/Pow/Deriv.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Pow/Deriv.lean
@@ -420,9 +420,10 @@ theorem contDiffAt_rpow_const_of_ne {x p : ℝ} {n : WithTop ℕ∞} (h : x ≠ 
 
 theorem contDiff_rpow_const_of_le {p : ℝ} {n : ℕ} (h : ↑n ≤ p) :
     ContDiff ℝ n fun x : ℝ => x ^ p := by
-  induction' n with n ihn generalizing p
-  · exact contDiff_zero.2 (continuous_id.rpow_const fun x => Or.inr <| by simpa using h)
-  · have h1 : 1 ≤ p := le_trans (by simp) h
+  induction n generalizing p with
+  | zero => exact contDiff_zero.2 (continuous_id.rpow_const fun x => Or.inr <| by simpa using h)
+  | succ n ihn =>
+    have h1 : 1 ≤ p := le_trans (by simp) h
     rw [Nat.cast_succ, ← le_sub_iff_add_le] at h
     rw [show ((n + 1 : ℕ) : WithTop ℕ∞) = n + 1 from rfl,
       contDiff_succ_iff_deriv, deriv_rpow_const' h1]

--- a/Mathlib/Analysis/SpecialFunctions/Trigonometric/EulerSineProd.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Trigonometric/EulerSineProd.lean
@@ -201,15 +201,17 @@ theorem sin_pi_mul_eq (z : ℂ) (n : ℕ) :
         (∫ x in (0 : ℝ)..π / 2, cos x ^ (2 * n) : ℝ) := by
   rcases eq_or_ne z 0 with (rfl | hz)
   · simp
-  induction' n with n hn
-  · simp_rw [mul_zero, pow_zero, mul_one, Finset.prod_range_zero, mul_one,
+  induction n with
+  | zero =>
+    simp_rw [mul_zero, pow_zero, mul_one, Finset.prod_range_zero, mul_one,
       integral_one, sub_zero]
     rw [integral_cos_mul_complex (mul_ne_zero two_ne_zero hz), Complex.ofReal_zero,
       mul_zero, Complex.sin_zero, zero_div, sub_zero,
       (by push_cast; field_simp; ring : 2 * z * ↑(π / 2) = π * z)]
     field_simp [Complex.ofReal_ne_zero.mpr pi_pos.ne']
     ring
-  · rw [hn, Finset.prod_range_succ]
+  | succ n hn =>
+    rw [hn, Finset.prod_range_succ]
     set A := ∏ j ∈ Finset.range n, ((1 : ℂ) - z ^ 2 / ((j : ℂ) + 1) ^ 2)
     set B := ∫ x in (0 : ℝ)..π / 2, Complex.cos (2 * z * x) * (cos x : ℂ) ^ (2 * n)
     set C := ∫ x in (0 : ℝ)..π / 2, cos x ^ (2 * n)

--- a/Mathlib/CategoryTheory/ComposableArrows.lean
+++ b/Mathlib/CategoryTheory/ComposableArrows.lean
@@ -176,12 +176,14 @@ def homMk {F G : ComposableArrows C n} (app : ∀ i, F.obj i ⟶ G.obj i)
       obtain ⟨k, hk⟩ := Nat.le.dest hij'
       exact this k i j hk (by valid)
     intro k
-    induction' k with k hk
-    · intro i j hj hj'
+    induction k with
+    | zero =>
+      intro i j hj hj'
       simp only [add_zero] at hj
       obtain rfl := hj
       rw [F.map'_self i, G.map'_self i, id_comp, comp_id]
-    · intro i j hj hj'
+    | succ k hk =>
+      intro i j hj hj'
       rw [← add_assoc] at hj
       subst hj
       rw [F.map'_comp i (i + k) (i + k + 1), G.map'_comp i (i + k) (i + k + 1), assoc,
@@ -838,10 +840,12 @@ lemma mkOfObjOfMapSucc_exists : ∃ (F : ComposableArrows C n) (e : ∀ i, F.obj
     ∀ (i : ℕ) (hi : i < n), mapSucc ⟨i, hi⟩ =
       (e ⟨i, _⟩).inv ≫ F.map' i (i + 1) ≫ (e ⟨i + 1, _⟩).hom := by
   revert obj mapSucc
-  induction' n with n hn
-  · intro obj _
+  induction n with
+  | zero =>
+    intro obj _
     exact ⟨mk₀ (obj 0), fun 0 => Iso.refl _, fun i hi => by simp at hi⟩
-  · intro obj mapSucc
+  | succ n hn =>
+    intro obj mapSucc
     obtain ⟨F, e, h⟩ := hn (fun i => obj i.succ) (fun i => mapSucc i.succ)
     refine ⟨F.precomp (mapSucc 0 ≫ (e 0).inv), fun i => match i with
       | 0 => Iso.refl _

--- a/Mathlib/CategoryTheory/Extensive.lean
+++ b/Mathlib/CategoryTheory/Extensive.lean
@@ -448,9 +448,10 @@ theorem FinitaryExtensive.isVanKampen_finiteCoproducts_Fin [FinitaryExtensive C]
     Functor.hext (fun _ ↦ rfl) (by rintro ⟨i⟩ ⟨j⟩ ⟨⟨rfl : i = j⟩⟩; simp [f])
   clear_value f
   subst this
-  induction' n with n IH
-  · exact isVanKampenColimit_of_isEmpty _ hc
-  · apply IsVanKampenColimit.of_iso _
+  induction n with
+  | zero => exact isVanKampenColimit_of_isEmpty _ hc
+  | succ n IH =>
+    apply IsVanKampenColimit.of_iso _
       ((extendCofanIsColimit f (coproductIsCoproduct _) (coprodIsCoprod _ _)).uniqueUpToIso hc)
     apply @isVanKampenColimit_extendCofan _ _ _ _ _ _ _ _ ?_
     · apply IH

--- a/Mathlib/CategoryTheory/Filtered/Basic.lean
+++ b/Mathlib/CategoryTheory/Filtered/Basic.lean
@@ -205,9 +205,10 @@ variable [IsFiltered C]
 -/
 theorem sup_objs_exists (O : Finset C) : ∃ S : C, ∀ {X}, X ∈ O → Nonempty (X ⟶ S) := by
   classical
-  induction' O using Finset.induction with X O' nm h
-  · exact ⟨Classical.choice IsFiltered.nonempty, by intro; simp⟩
-  · obtain ⟨S', w'⟩ := h
+  induction O using Finset.induction with
+  | empty => exact ⟨Classical.choice IsFiltered.nonempty, by intro; simp⟩
+  | @insert X O' nm h =>
+    obtain ⟨S', w'⟩ := h
     use max X S'
     rintro Y mY
     obtain rfl | h := eq_or_ne Y X
@@ -227,10 +228,12 @@ theorem sup_exists :
         (⟨X, Y, mX, mY, f⟩ : Σ' (X Y : C) (_ : X ∈ O) (_ : Y ∈ O), X ⟶ Y) ∈ H →
           f ≫ T mY = T mX := by
   classical
-  induction' H using Finset.induction with h' H' nmf h''
-  · obtain ⟨S, f⟩ := sup_objs_exists O
+  induction H using Finset.induction with
+  | empty =>
+    obtain ⟨S, f⟩ := sup_objs_exists O
     exact ⟨S, fun mX => (f mX).some, by rintro - - - - - ⟨⟩⟩
-  · obtain ⟨X, Y, mX, mY, f⟩ := h'
+  | @insert h' H' nmf h'' =>
+    obtain ⟨X, Y, mX, mY, f⟩ := h'
     obtain ⟨S', T', w'⟩ := h''
     refine ⟨coeq (f ≫ T' mY) (T' mX), fun mZ => T' mZ ≫ coeqHom (f ≫ T' mY) (T' mX), ?_⟩
     intro X' Y' mX' mY' f' mf'
@@ -662,9 +665,10 @@ variable [IsCofiltered C]
 -/
 theorem inf_objs_exists (O : Finset C) : ∃ S : C, ∀ {X}, X ∈ O → Nonempty (S ⟶ X) := by
   classical
-  induction' O using Finset.induction with X O' nm h
-  · exact ⟨Classical.choice IsCofiltered.nonempty, by intro; simp⟩
-  · obtain ⟨S', w'⟩ := h
+  induction O using Finset.induction with
+  | empty => exact ⟨Classical.choice IsCofiltered.nonempty, by intro; simp⟩
+  | @insert X O' nm h =>
+    obtain ⟨S', w'⟩ := h
     use min X S'
     rintro Y mY
     obtain rfl | h := eq_or_ne Y X
@@ -684,10 +688,12 @@ theorem inf_exists :
         (⟨X, Y, mX, mY, f⟩ : Σ' (X Y : C) (_ : X ∈ O) (_ : Y ∈ O), X ⟶ Y) ∈ H →
           T mX ≫ f = T mY := by
   classical
-  induction' H using Finset.induction with h' H' nmf h''
-  · obtain ⟨S, f⟩ := inf_objs_exists O
+  induction H using Finset.induction with
+  | empty =>
+    obtain ⟨S, f⟩ := inf_objs_exists O
     exact ⟨S, fun mX => (f mX).some, by rintro - - - - - ⟨⟩⟩
-  · obtain ⟨X, Y, mX, mY, f⟩ := h'
+  | @insert h' H' nmf h'' =>
+    obtain ⟨X, Y, mX, mY, f⟩ := h'
     obtain ⟨S', T', w'⟩ := h''
     refine ⟨eq (T' mX ≫ f) (T' mY), fun mZ => eqHom (T' mX ≫ f) (T' mY) ≫ T' mZ, ?_⟩
     intro X' Y' mX' mY' f' mf'

--- a/Mathlib/CategoryTheory/Limits/VanKampen.lean
+++ b/Mathlib/CategoryTheory/Limits/VanKampen.lean
@@ -633,7 +633,7 @@ theorem isUniversalColimit_extendCofan {n : ℕ} (f : Fin (n + 1) → C)
   rintro ⟨j⟩
   simp only [Discrete.functor_obj, limit.lift_π, PullbackCone.mk_pt,
     PullbackCone.mk_π_app, Category.comp_id]
-  induction' j using Fin.inductionOn
+  induction j using Fin.inductionOn
   · simp only [Fin.cases_zero]
   · simp only [Fin.cases_succ]
 

--- a/Mathlib/CategoryTheory/Triangulated/TStructure/Basic.lean
+++ b/Mathlib/CategoryTheory/Triangulated/TStructure/Basic.lean
@@ -126,9 +126,9 @@ lemma le_monotone : Monotone t.le := by
     rw [← h, Nat.cast_add, ← add_assoc]
     exact (ha n).trans (hb (n+a))
   intro a
-  induction' a with a ha
-  · exact H_zero
-  · exact H_add a 1 _ rfl ha H_one
+  induction a with
+  | zero => exact H_zero
+  | succ a ha => exact H_add a 1 _ rfl ha H_one
 
 lemma ge_antitone : Antitone t.ge := by
   let H := fun (a : ℕ) => ∀ (n : ℤ), t.ge (n + a) ≤ t.ge n
@@ -149,9 +149,9 @@ lemma ge_antitone : Antitone t.ge := by
     rw [← h, Nat.cast_add, ← add_assoc ]
     exact (hb (n + a)).trans (ha n)
   intro a
-  induction' a with a ha
-  · exact H_zero
-  · exact H_add a 1 _ rfl ha H_one
+  induction a with
+  | zero => exact H_zero
+  | succ a ha => exact H_add a 1 _ rfl ha H_one
 
 /-- Given a t-structure `t` on a pretriangulated category `C`, the property `t.IsLE X n`
 holds if `X : C` is `≤ n` for the t-structure. -/

--- a/Mathlib/Computability/Ackermann.lean
+++ b/Mathlib/Computability/Ackermann.lean
@@ -73,21 +73,22 @@ theorem ack_succ_succ (m n : ℕ) : ack (m + 1) (n + 1) = ack m (ack (m + 1) n) 
 
 @[simp]
 theorem ack_one (n : ℕ) : ack 1 n = n + 2 := by
-  induction' n with n IH
-  · simp
-  · simp [IH]
+  induction n with
+  | zero => simp
+  | succ n IH => simp [IH]
 
 @[simp]
 theorem ack_two (n : ℕ) : ack 2 n = 2 * n + 3 := by
-  induction' n with n IH
-  · simp
-  · simpa [mul_succ]
+  induction n with
+  | zero => simp
+  | succ n IH => simpa [mul_succ]
 
 @[simp]
 theorem ack_three (n : ℕ) : ack 3 n = 2 ^ (n + 3) - 3 := by
-  induction' n with n IH
-  · simp
-  · rw [ack_succ_succ, IH, ack_two, Nat.succ_add, Nat.pow_succ 2 (n + 3), mul_comm _ 2,
+  induction n with
+  | zero => simp
+  | succ n IH =>
+    rw [ack_succ_succ, IH, ack_two, Nat.succ_add, Nat.pow_succ 2 (n + 3), mul_comm _ 2,
         Nat.mul_sub_left_distrib, ← Nat.sub_add_comm, two_mul 3, Nat.add_sub_add_right]
     have H : 2 * 3 ≤ 2 * 2 ^ 3 := by norm_num
     apply H.trans
@@ -224,9 +225,10 @@ theorem ack_succ_right_le_ack_succ_left (m n : ℕ) : ack m (n + 1) ≤ ack (m +
 
 -- All the inequalities from this point onwards are specific to the main proof.
 private theorem sq_le_two_pow_add_one_minus_three (n : ℕ) : n ^ 2 ≤ 2 ^ (n + 1) - 3 := by
-  induction' n with k hk
-  · norm_num
-  · rcases k with - | k
+  induction n with
+  | zero => norm_num
+  | succ k hk =>
+    rcases k with - | k
     · norm_num
     · rw [add_sq, Nat.pow_succ 2, mul_comm _ 2, two_mul (2 ^ _),
           add_tsub_assoc_of_le, add_comm (2 ^ _), add_assoc]

--- a/Mathlib/Computability/DFA.lean
+++ b/Mathlib/Computability/DFA.lean
@@ -154,9 +154,10 @@ theorem evalFrom_of_pow {x y : List α} {s : σ} (hx : M.evalFrom s x = s)
     (hy : y ∈ ({x} : Language α)∗) : M.evalFrom s y = s := by
   rw [Language.mem_kstar] at hy
   rcases hy with ⟨S, rfl, hS⟩
-  induction' S with a S ih
-  · rfl
-  · have ha := hS a List.mem_cons_self
+  induction S with
+  | nil => rfl
+  | cons a S ih =>
+    have ha := hS a List.mem_cons_self
     rw [Set.mem_singleton_iff] at ha
     rw [List.flatten, evalFrom_of_append, ha, hx]
     apply ih

--- a/Mathlib/Computability/EpsilonNFA.lean
+++ b/Mathlib/Computability/EpsilonNFA.lean
@@ -74,7 +74,7 @@ theorem mem_εClosure_iff_exists : s ∈ M.εClosure S ↔ ∃ t ∈ S, s ∈ M.
       solve_by_elim [εClosure.step]
   mpr := by
     intro ⟨t, _, h⟩
-    induction' h <;> subst_vars <;> solve_by_elim [εClosure.step]
+    induction h <;> subst_vars <;> solve_by_elim [εClosure.step]
 
 /-- `M.stepSet S a` is the union of the ε-closure of `M.step s a` for all `s ∈ S`. -/
 def stepSet (S : Set σ) (a : α) : Set σ :=
@@ -112,15 +112,16 @@ theorem evalFrom_append_singleton (S : Set σ) (x : List α) (a : α) :
 
 @[simp]
 theorem evalFrom_empty (x : List α) : M.evalFrom ∅ x = ∅ := by
-  induction' x using List.reverseRecOn with x a ih
-  · rw [evalFrom_nil, εClosure_empty]
-  · rw [evalFrom_append_singleton, ih, stepSet_empty]
+  induction x using List.reverseRecOn with
+  | nil => rw [evalFrom_nil, εClosure_empty]
+  | append_singleton x a ih => rw [evalFrom_append_singleton, ih, stepSet_empty]
 
 theorem mem_evalFrom_iff_exists {s : σ} {S : Set σ} {x : List α} :
     s ∈ M.evalFrom S x ↔ ∃ t ∈ S, s ∈ M.evalFrom {t} x := by
-  induction' x using List.reverseRecOn with _ _ ih generalizing s
-  · apply mem_εClosure_iff_exists
-  · simp_rw [evalFrom_append_singleton, mem_stepSet_iff, ih]
+  induction x using List.reverseRecOn generalizing s with
+  | nil => apply mem_εClosure_iff_exists
+  | append_singleton _ _ ih =>
+    simp_rw [evalFrom_append_singleton, mem_stepSet_iff, ih]
     tauto
 
 /-- `M.eval x` computes all possible paths through `M` with input `x` starting at an element of
@@ -171,10 +172,12 @@ alias ⟨_, IsPath.singleton⟩ := isPath_singleton
 theorem isPath_append {x y : List (Option α)} :
     M.IsPath s u (x ++ y) ↔ ∃ t, M.IsPath s t x ∧ M.IsPath t u y where
   mp := by
-    induction' x with x a ih generalizing s
-    · rw [List.nil_append]
+    induction x generalizing s with
+    | nil =>
+      rw [List.nil_append]
       tauto
-    · rintro (_ | ⟨t, _, _, _, _, _, h⟩)
+    | cons x a ih =>
+      rintro (_ | ⟨t, _, _, _, _, _, h⟩)
       apply ih at h
       tauto
   mpr := by
@@ -206,8 +209,9 @@ theorem mem_εClosure_iff_exists_path {s₁ s₂ : σ} :
 
 theorem mem_evalFrom_iff_exists_path {s₁ s₂ : σ} {x : List α} :
     s₂ ∈ M.evalFrom {s₁} x ↔ ∃ x', x'.reduceOption = x ∧ M.IsPath s₁ s₂ x' := by
-  induction' x using List.reverseRecOn with x a ih generalizing s₂
-  · rw [evalFrom_nil, mem_εClosure_iff_exists_path]
+  induction x using List.reverseRecOn generalizing s₂ with
+  | nil =>
+    rw [evalFrom_nil, mem_εClosure_iff_exists_path]
     constructor
     · intro ⟨n, _⟩
       use List.replicate n none
@@ -216,7 +220,8 @@ theorem mem_evalFrom_iff_exists_path {s₁ s₂ : σ} {x : List α} :
     · simp_rw [List.reduceOption_eq_nil_iff]
       intro ⟨_, ⟨n, rfl⟩, h⟩
       exact ⟨n, h⟩
-  · rw [evalFrom_append_singleton, mem_stepSet_iff]
+  | append_singleton x a ih =>
+    rw [evalFrom_append_singleton, mem_stepSet_iff]
     constructor
     · intro ⟨t, ht, h⟩
       obtain ⟨x', _, _⟩ := ih.mp ht

--- a/Mathlib/Computability/Language.lean
+++ b/Mathlib/Computability/Language.lean
@@ -223,14 +223,16 @@ theorem add_iSup {ι : Sort v} [Nonempty ι] (l : ι → Language α) (m : Langu
 
 theorem mem_pow {l : Language α} {x : List α} {n : ℕ} :
     x ∈ l ^ n ↔ ∃ S : List (List α), x = S.flatten ∧ S.length = n ∧ ∀ y ∈ S, y ∈ l := by
-  induction' n with n ihn generalizing x
-  · simp only [mem_one, pow_zero, length_eq_zero_iff]
+  induction n generalizing x with
+  | zero =>
+    simp only [mem_one, pow_zero, length_eq_zero_iff]
     constructor
     · rintro rfl
       exact ⟨[], rfl, rfl, fun _ h ↦ by contradiction⟩
     · rintro ⟨_, rfl, rfl, _⟩
       rfl
-  · simp only [pow_succ', mem_mul, ihn]
+  | succ n ihn =>
+    simp only [pow_succ', mem_mul, ihn]
     constructor
     · rintro ⟨a, ha, b, ⟨S, rfl, rfl, hS⟩, rfl⟩
       exact ⟨a :: S, rfl, rfl, forall_mem_cons.2 ⟨ha, hS⟩⟩
@@ -274,8 +276,9 @@ instance : KleeneAlgebra (Language α) :=
     kstar_mul_le_self := fun l m h ↦ by
       rw [kstar_eq_iSup_pow, iSup_mul]
       refine iSup_le (fun n ↦ ?_)
-      induction' n with n ih
-      · simp
+      induction n with
+      | zero => simp
+      | succ n ih => ?_
       rw [pow_succ, mul_assoc (l^n) l m]
       exact le_trans (le_mul_congr le_rfl h) ih,
     mul_kstar_le_self := fun l m h ↦ by
@@ -292,7 +295,8 @@ theorem self_eq_mul_add_iff {l m n : Language α} (hm : [] ∉ m) : l = m * l + 
   mp h := by
     apply le_antisymm
     · intro x hx
-      induction' hlen : x.length using Nat.strong_induction_on with _ ih generalizing x
+      induction hlen : x.length using Nat.strong_induction_on generalizing x with
+      | h _ ih => ?_
       subst hlen
       rw [h] at hx
       obtain hx | hx := hx
@@ -306,10 +310,12 @@ theorem self_eq_mul_add_iff {l m n : Language α} (hm : [] ∉ m) : l = m * l + 
       · exact ⟨[], nil_mem_kstar _, _, ⟨hx, nil_append _⟩⟩
     · rw [kstar_eq_iSup_pow, iSup_mul, iSup_le_iff]
       intro i
-      induction' i with _ ih <;> rw [h]
-      · rw [pow_zero, one_mul, add_comm]
+      induction i with <;> rw [h]
+      | zero =>
+        rw [pow_zero, one_mul, add_comm]
         exact le_self_add
-      · rw [add_comm, pow_add, pow_one, mul_assoc]
+      | succ _ ih =>
+        rw [add_comm, pow_add, pow_one, mul_assoc]
         exact le_add_right (mul_le_mul_left' ih _)
   mpr h := by rw [h, add_comm, ← mul_assoc, ← one_add_mul, one_add_self_mul_kstar_eq_kstar]
 

--- a/Mathlib/Computability/Language.lean
+++ b/Mathlib/Computability/Language.lean
@@ -310,11 +310,11 @@ theorem self_eq_mul_add_iff {l m n : Language α} (hm : [] ∉ m) : l = m * l + 
       · exact ⟨[], nil_mem_kstar _, _, ⟨hx, nil_append _⟩⟩
     · rw [kstar_eq_iSup_pow, iSup_mul, iSup_le_iff]
       intro i
-      induction i with <;> rw [h]
-      | zero =>
+      induction i <;> rw [h]
+      case a.zero =>
         rw [pow_zero, one_mul, add_comm]
         exact le_self_add
-      | succ _ ih =>
+      case a.succ _ ih =>
         rw [add_comm, pow_add, pow_one, mul_assoc]
         exact le_add_right (mul_le_mul_left' ih _)
   mpr h := by rw [h, add_comm, ← mul_assoc, ← one_add_mul, one_add_self_mul_kstar_eq_kstar]

--- a/Mathlib/Computability/NFA.lean
+++ b/Mathlib/Computability/NFA.lean
@@ -130,9 +130,10 @@ namespace DFA
 theorem toNFA_evalFrom_match (M : DFA α σ) (start : σ) (s : List α) :
     M.toNFA.evalFrom {start} s = {M.evalFrom start s} := by
   change List.foldl M.toNFA.stepSet {start} s = {List.foldl M.step start s}
-  induction' s with a s ih generalizing start
-  · tauto
-  · rw [List.foldl, List.foldl,
+  induction s generalizing start with
+  | nil => tauto
+  | cons a s ih =>
+    rw [List.foldl, List.foldl,
       show M.toNFA.stepSet {start} a = {M.step start a} by simp [NFA.stepSet] ]
     tauto
 

--- a/Mathlib/Computability/Partrec.lean
+++ b/Mathlib/Computability/Partrec.lean
@@ -46,9 +46,9 @@ private def wf_lbp (H : ∃ n, true ∈ p n ∧ ∀ k < n, (p k).Dom) : WellFoun
     let ⟨n, pn⟩ := H
     suffices ∀ m k, n ≤ k + m → Acc (lbp p) k by exact fun a => this _ _ (Nat.le_add_left _ _)
     intro m k kn
-    induction' m with m IH generalizing k <;> refine ⟨_, fun y r => ?_⟩ <;> rcases r with ⟨rfl, a⟩
-    · injection mem_unique pn.1 (a _ kn)
-    · exact IH _ (by rw [Nat.add_right_comm]; exact kn)⟩
+    induction m generalizing k with <;> refine ⟨_, fun y r => ?_⟩ <;> rcases r with ⟨rfl, a⟩
+    | zero => injection mem_unique pn.1 (a _ kn)
+    | succ m IH => exact IH _ (by rw [Nat.add_right_comm]; exact kn)⟩
 
 variable (H : ∃ n, true ∈ p n ∧ ∀ k < n, (p k).Dom)
 
@@ -728,8 +728,9 @@ theorem fix_aux {α σ} (f : α →. σ ⊕ α) (a : α) (b : σ) :
   · rcases h with ⟨n, ⟨_x, h₁⟩, h₂⟩
     have : ∀ m a', Sum.inr a' ∈ F a m → b ∈ PFun.fix f a' → b ∈ PFun.fix f a := by
       intro m a' am ba
-      induction' m with m IH generalizing a' <;> simp [F] at am
-      · rwa [← am]
+      induction m generalizing a' with <;> simp [F] at am
+      | zero => rwa [← am]
+      | succ m IH => ?_
       rcases am with ⟨a₂, am₂, fa₂⟩
       exact IH _ am₂ (PFun.mem_fix_iff.2 (Or.inr ⟨_, fa₂, ba⟩))
     cases n <;> simp [F] at h₂

--- a/Mathlib/Computability/Partrec.lean
+++ b/Mathlib/Computability/Partrec.lean
@@ -46,9 +46,9 @@ private def wf_lbp (H : ∃ n, true ∈ p n ∧ ∀ k < n, (p k).Dom) : WellFoun
     let ⟨n, pn⟩ := H
     suffices ∀ m k, n ≤ k + m → Acc (lbp p) k by exact fun a => this _ _ (Nat.le_add_left _ _)
     intro m k kn
-    induction m generalizing k with <;> refine ⟨_, fun y r => ?_⟩ <;> rcases r with ⟨rfl, a⟩
-    | zero => injection mem_unique pn.1 (a _ kn)
-    | succ m IH => exact IH _ (by rw [Nat.add_right_comm]; exact kn)⟩
+    induction m generalizing k <;> refine ⟨_, fun y r => ?_⟩ <;> rcases r with ⟨rfl, a⟩
+    case zero => injection mem_unique pn.1 (a _ kn)
+    case succ m IH => exact IH _ (by rw [Nat.add_right_comm]; exact kn)⟩
 
 variable (H : ∃ n, true ∈ p n ∧ ∀ k < n, (p k).Dom)
 
@@ -728,11 +728,11 @@ theorem fix_aux {α σ} (f : α →. σ ⊕ α) (a : α) (b : σ) :
   · rcases h with ⟨n, ⟨_x, h₁⟩, h₂⟩
     have : ∀ m a', Sum.inr a' ∈ F a m → b ∈ PFun.fix f a' → b ∈ PFun.fix f a := by
       intro m a' am ba
-      induction m generalizing a' with <;> simp [F] at am
-      | zero => rwa [← am]
-      | succ m IH => ?_
-      rcases am with ⟨a₂, am₂, fa₂⟩
-      exact IH _ am₂ (PFun.mem_fix_iff.2 (Or.inr ⟨_, fa₂, ba⟩))
+      induction m generalizing a' <;> simp [F] at am
+      case zero => rwa [← am]
+      case succ m IH =>
+        rcases am with ⟨a₂, am₂, fa₂⟩
+        exact IH _ am₂ (PFun.mem_fix_iff.2 (Or.inr ⟨_, fa₂, ba⟩))
     cases n <;> simp [F] at h₂
     rcases h₂ with (h₂ | ⟨a', am', fa'⟩)
     · obtain ⟨a', h⟩ := h₁ (Nat.lt_succ_self _)

--- a/Mathlib/Computability/PartrecCode.lean
+++ b/Mathlib/Computability/PartrecCode.lean
@@ -651,9 +651,9 @@ theorem evaln_sound : ∀ {k c n x}, x ∈ evaln k c n → x ∈ eval c n
       exact ⟨_, hg _ _ eg, hf _ _ ef⟩
     case prec cf cg hf hg _ =>
       revert h
-      induction n.unpair.2 generalizing x with <;> simp [Option.bind_eq_some]
-      | zero => apply hf
-      | succ m IH =>
+      induction n.unpair.2 generalizing x <;> simp [Option.bind_eq_some]
+      case zero => apply hf
+      case succ m IH =>
         refine fun y h₁ h₂ => ⟨y, IH _ ?_, ?_⟩
         · have := evaln_mono k.le_succ h₁
           simp [evaln, Option.bind_eq_some] at this
@@ -700,12 +700,12 @@ theorem evaln_complete {c n x} : x ∈ eval c n ↔ ∃ k, x ∈ evaln k c n := 
   | prec cf cg hf hg =>
     revert h
     generalize n.unpair.1 = n₁; generalize n.unpair.2 = n₂
-    induction n₂ generalizing x n with <;> simp [Option.bind_eq_some]
-    | zero =>
+    induction n₂ generalizing x n <;> simp [Option.bind_eq_some]
+    case zero =>
       intro h
       rcases hf h with ⟨k, hk⟩
       exact ⟨_, le_max_left _ _, evaln_mono (Nat.succ_le_succ <| le_max_right _ _) hk⟩
-    | succ m IH =>
+    case succ m IH =>
       intro y hy hx
       rcases IH hy with ⟨k₁, nk₁, hk₁⟩
       rcases hg hx with ⟨k₂, hk₂⟩
@@ -725,12 +725,12 @@ theorem evaln_complete {c n x} : x ∈ eval c n ↔ ∃ k, x ∈ evaln k c n := 
     revert hy₁ hy₂
     generalize n.unpair.2 = m
     intro hy₁ hy₂
-    induction y generalizing m with <;> simp [evaln, Option.bind_eq_some]
-    | zero =>
+    induction y generalizing m <;> simp [evaln, Option.bind_eq_some]
+    case zero =>
       simp at hy₁
       rcases hf hy₁ with ⟨k, hk⟩
       exact ⟨_, Nat.le_of_lt_succ <| evaln_bound hk, _, hk, by simp⟩
-    | succ y IH =>
+    case succ y IH =>
       rcases hy₂ (Nat.succ_pos _) with ⟨a, ha, a0⟩
       rcases hf ha with ⟨k₁, hk₁⟩
       rcases IH m.succ (by simpa [Nat.succ_eq_add_one, add_comm, add_left_comm] using hy₁)

--- a/Mathlib/Computability/PartrecCode.lean
+++ b/Mathlib/Computability/PartrecCode.lean
@@ -651,9 +651,10 @@ theorem evaln_sound : ∀ {k c n x}, x ∈ evaln k c n → x ∈ eval c n
       exact ⟨_, hg _ _ eg, hf _ _ ef⟩
     case prec cf cg hf hg _ =>
       revert h
-      induction' n.unpair.2 with m IH generalizing x <;> simp [Option.bind_eq_some]
-      · apply hf
-      · refine fun y h₁ h₂ => ⟨y, IH _ ?_, ?_⟩
+      induction n.unpair.2 generalizing x with <;> simp [Option.bind_eq_some]
+      | zero => apply hf
+      | succ m IH =>
+        refine fun y h₁ h₂ => ⟨y, IH _ ?_, ?_⟩
         · have := evaln_mono k.le_succ h₁
           simp [evaln, Option.bind_eq_some] at this
           exact this.2
@@ -699,11 +700,13 @@ theorem evaln_complete {c n x} : x ∈ eval c n ↔ ∃ k, x ∈ evaln k c n := 
   | prec cf cg hf hg =>
     revert h
     generalize n.unpair.1 = n₁; generalize n.unpair.2 = n₂
-    induction' n₂ with m IH generalizing x n <;> simp [Option.bind_eq_some]
-    · intro h
+    induction n₂ generalizing x n with <;> simp [Option.bind_eq_some]
+    | zero =>
+      intro h
       rcases hf h with ⟨k, hk⟩
       exact ⟨_, le_max_left _ _, evaln_mono (Nat.succ_le_succ <| le_max_right _ _) hk⟩
-    · intro y hy hx
+    | succ m IH =>
+      intro y hy hx
       rcases IH hy with ⟨k₁, nk₁, hk₁⟩
       rcases hg hx with ⟨k₂, hk₂⟩
       refine
@@ -722,11 +725,13 @@ theorem evaln_complete {c n x} : x ∈ eval c n ↔ ∃ k, x ∈ evaln k c n := 
     revert hy₁ hy₂
     generalize n.unpair.2 = m
     intro hy₁ hy₂
-    induction' y with y IH generalizing m <;> simp [evaln, Option.bind_eq_some]
-    · simp at hy₁
+    induction y generalizing m with <;> simp [evaln, Option.bind_eq_some]
+    | zero =>
+      simp at hy₁
       rcases hf hy₁ with ⟨k, hk⟩
       exact ⟨_, Nat.le_of_lt_succ <| evaln_bound hk, _, hk, by simp⟩
-    · rcases hy₂ (Nat.succ_pos _) with ⟨a, ha, a0⟩
+    | succ y IH =>
+      rcases hy₂ (Nat.succ_pos _) with ⟨a, ha, a0⟩
       rcases hf ha with ⟨k₁, hk₁⟩
       rcases IH m.succ (by simpa [Nat.succ_eq_add_one, add_comm, add_left_comm] using hy₁)
           fun {i} hi => by

--- a/Mathlib/Computability/PostTuringMachine.lean
+++ b/Mathlib/Computability/PostTuringMachine.lean
@@ -981,9 +981,11 @@ theorem trTape'_move_left (L R : ListBlank Γ) :
       Tape.mk' L' (ListBlank.append (Vector.toList (enc a)) R') by
     simpa only [List.length_reverse, Vector.toList_length] using this (List.reverse_reverse _).symm
   intro _ _ l₁ l₂ e
-  induction' l₁ with b l₁ IH generalizing l₂
-  · cases e
+  induction l₁ generalizing l₂ with
+  | nil =>
+    cases e
     rfl
+  | cons b l₁ IH => ?_
   simp only [List.length, List.cons_append, iterate_succ_apply]
   convert IH e
   simp only [ListBlank.tail_cons, ListBlank.append, Tape.move_left_mk', ListBlank.head_cons]
@@ -995,8 +997,9 @@ theorem trTape'_move_right (L R : ListBlank Γ) :
     simp only [trTape'_move_left, ListBlank.cons_head_tail, ListBlank.head_cons,
       ListBlank.tail_cons]
   intro i _
-  induction' i with i IH
-  · rfl
+  induction i with
+  | zero => rfl
+  | succ i IH => ?_
   rw [iterate_succ_apply, iterate_succ_apply', Tape.move_left_right, IH]
 
 theorem stepAux_write (q : Stmt Bool (Λ' Γ Λ σ) σ) (v : σ) (a b : Γ) (L R : ListBlank Γ) :
@@ -1009,9 +1012,11 @@ theorem stepAux_write (q : Stmt Bool (Λ' Γ Λ σ) σ) (v : σ) (a b : Γ) (L R
     exact this [] _ _ ((enc b).2.trans (enc a).2.symm)
   clear a b L R
   intro L' R' l₁ l₂ l₂' e
-  induction' l₂ with a l₂ IH generalizing l₁ l₂'
-  · cases List.length_eq_zero_iff.1 e
+  induction l₂ generalizing l₁ l₂' with
+  | nil =>
+    cases List.length_eq_zero_iff.1 e
     rfl
+  | cons a l₂ IH => ?_
   rcases l₂' with - | ⟨b, l₂'⟩ <;>
     simp only [List.length_nil, List.length_cons, Nat.succ_inj', reduceCtorEq] at e
   rw [List.reverseAux, ← IH (a :: l₁) l₂' e]
@@ -1038,8 +1043,9 @@ theorem stepAux_read (f : Γ → Stmt Bool (Λ' Γ Λ σ) σ) (v : σ) (L R : Li
   clear f L a R
   intro i f L' R' l₁ l₂ _
   subst i
-  induction' l₂ with a l₂ IH generalizing l₁
-  · rfl
+  induction l₂ generalizing l₁ with
+  | nil => rfl
+  | cons a l₂ IH => ?_
   trans
     stepAux (readAux l₂.length fun v ↦ f (a ::ᵥ v)) v
       (Tape.mk' ((L'.append l₁).cons a) (R'.append l₂))

--- a/Mathlib/Computability/Primrec.lean
+++ b/Mathlib/Computability/Primrec.lean
@@ -1063,9 +1063,10 @@ theorem nat_omega_rec' (f : β → σ) {m : β → ℕ} {l : β → List β} {g 
         (bindList b (m b - i)).filterMap fun b' =>
           (g b' <| mapGraph (graph b i) (l b')).map (b', ·) := fun _ => rfl
       have bindList_succ : ∀ i, bindList b (i + 1) = (bindList b i).flatMap l := fun _ => rfl
-      induction' i with i ih
-      · symm; simpa [graph] using bindList_eq_nil
-      · simp only [graph_succ, ih (Nat.le_of_lt hi), Nat.succ_sub (Nat.lt_succ.mp hi),
+      induction i with
+      | zero => symm; simpa [graph] using bindList_eq_nil
+      | succ i ih =>
+        simp only [graph_succ, ih (Nat.le_of_lt hi), Nat.succ_sub (Nat.lt_succ.mp hi),
           Nat.succ_eq_add_one, bindList_succ, Nat.reduceSubDiff]
         apply List.filterMap_eq_map_iff_forall_eq_some.mpr
         intro b' ha'; simp; rw [mapGraph_graph]

--- a/Mathlib/Computability/RegularExpressions.lean
+++ b/Mathlib/Computability/RegularExpressions.lean
@@ -198,15 +198,17 @@ theorem char_rmatch_iff (a : α) (x : List α) : rmatch (char a) x ↔ x = [a] :
 
 theorem add_rmatch_iff (P Q : RegularExpression α) (x : List α) :
     (P + Q).rmatch x ↔ P.rmatch x ∨ Q.rmatch x := by
-  induction' x with _ _ ih generalizing P Q
-  · simp only [rmatch, matchEpsilon, Bool.or_eq_true_iff]
-  · rw [rmatch, deriv_add]
+  induction x generalizing P Q with
+  | nil => simp only [rmatch, matchEpsilon, Bool.or_eq_true_iff]
+  | cons _ _ ih =>
+    rw [rmatch, deriv_add]
     exact ih _ _
 
 theorem mul_rmatch_iff (P Q : RegularExpression α) (x : List α) :
     (P * Q).rmatch x ↔ ∃ t u : List α, x = t ++ u ∧ P.rmatch t ∧ Q.rmatch u := by
-  induction' x with a x ih generalizing P Q
-  · rw [rmatch]; simp only [matchEpsilon]
+  induction x generalizing P Q with
+  | nil =>
+    rw [rmatch]; simp only [matchEpsilon]
     constructor
     · intro h
       refine ⟨[], [], rfl, ?_⟩
@@ -217,7 +219,8 @@ theorem mul_rmatch_iff (P Q : RegularExpression α) (x : List α) :
       subst ht hu
       repeat rw [rmatch] at h₂
       simp [h₂]
-  · rw [rmatch]; simp only [deriv]
+  | cons a x ih =>
+    rw [rmatch]; simp only [deriv]
     split_ifs with hepsilon
     · rw [add_rmatch_iff, ih]
       constructor

--- a/Mathlib/Computability/TMConfig.lean
+++ b/Mathlib/Computability/TMConfig.lean
@@ -247,9 +247,10 @@ theorem exists_code.comp {m n} {f : List.Vector ℕ n →. ℕ} {g : Fin n → L
       ⟨cf.comp cg, fun v => by
         simp [hg, hf, map_bind, seq_bind_eq, Function.comp_def]
         rfl⟩
-  clear hf f; induction' n with n IH
-  · exact ⟨nil, fun v => by simp [Vector.mOfFn, Bind.bind]; rfl⟩
-  · obtain ⟨cg, hg₁⟩ := hg 0
+  clear hf f; induction n with
+  | zero => exact ⟨nil, fun v => by simp [Vector.mOfFn, Bind.bind]; rfl⟩
+  | succ n IH =>
+    obtain ⟨cg, hg₁⟩ := hg 0
     obtain ⟨cl, hl⟩ := IH fun i => hg i.succ
     exact
       ⟨cons cg cl, fun v => by
@@ -300,11 +301,13 @@ theorem exists_code {n} {f : List.Vector ℕ n →. ℕ} (hf : Nat.Partrec' f) :
         erw [Part.eq_some_iff.2 (this 0 n (zero_add n))]
         simp only [List.headI, Part.bind_some, List.tail_cons]
       intro a b e
-      induction' b with b IH generalizing a
-      · refine PFun.mem_fix_iff.2 (Or.inl <| Part.eq_some_iff.1 ?_)
+      induction b generalizing a with
+      | zero =>
+        refine PFun.mem_fix_iff.2 (Or.inl <| Part.eq_some_iff.1 ?_)
         simp only [hg, ← e, Part.bind_some, List.tail_cons, pure]
         rfl
-      · refine PFun.mem_fix_iff.2 (Or.inr ⟨_, ?_, IH (a + 1) (by rwa [add_right_comm])⟩)
+      | succ b IH =>
+        refine PFun.mem_fix_iff.2 (Or.inr ⟨_, ?_, IH (a + 1) (by rwa [add_right_comm])⟩)
         simp only [hg, eval, Part.bind_some, Nat.rec_add_one, List.tail_nil, List.tail_cons, pure]
         exact Part.mem_some_iff.2 rfl
   | comp g _ _ IHf IHg => exact exists_code.comp IHf IHg

--- a/Mathlib/Computability/TMToPartrec.lean
+++ b/Mathlib/Computability/TMToPartrec.lean
@@ -557,8 +557,9 @@ theorem move_ok {p k₁ k₂ q s L₁ o L₂} {S : K' → List Γ'} (h₁ : k₁
     (e : splitAtPred p (S k₁) = (L₁, o, L₂)) :
     Reaches₁ (TM2.step tr) ⟨some (Λ'.move p k₁ k₂ q), s, S⟩
       ⟨some q, o, update (update S k₁ L₂) k₂ (L₁.reverseAux (S k₂))⟩ := by
-  induction' L₁ with a L₁ IH generalizing S s
-  · rw [(_ : [].reverseAux _ = _), Function.update_eq_self]
+  induction L₁ generalizing S s with
+  | nil =>
+    rw [(_ : [].reverseAux _ = _), Function.update_eq_self]
     swap
     · rw [Function.update_of_ne h₁.symm, List.reverseAux_nil]
     refine TransGen.head' rfl ?_
@@ -571,7 +572,8 @@ theorem move_ok {p k₁ k₂ q s L₁ o L₂} {S : K' → List Γ'} (h₁ : k₁
       simp only [cond_false, cond_true, Prod.mk.injEq, true_and, false_and, reduceCtorEq] at e ⊢
     simp only [e]
     rfl
-  · refine TransGen.head rfl ?_
+  | cons a L₁ IH =>
+    refine TransGen.head rfl ?_
     rw [tr]; simp only [pop', Option.elim, TM2.stepAux, push']
     rcases e₁ : S k₁ with - | ⟨a', Sk⟩ <;> rw [e₁, splitAtPred] at e
     · cases e
@@ -614,8 +616,9 @@ theorem move₂_ok {p k₁ k₂ q s L₁ o L₂} {S : K' → List Γ'} (h₁ : k
 
 theorem clear_ok {p k q s L₁ o L₂} {S : K' → List Γ'} (e : splitAtPred p (S k) = (L₁, o, L₂)) :
     Reaches₁ (TM2.step tr) ⟨some (Λ'.clear p k q), s, S⟩ ⟨some q, o, update S k L₂⟩ := by
-  induction' L₁ with a L₁ IH generalizing S s
-  · refine TransGen.head' rfl ?_
+  induction L₁ generalizing S s with
+  | nil =>
+    refine TransGen.head' rfl ?_
     rw [tr]; simp only [pop', TM2.step, Option.mem_def, TM2.stepAux, Option.elim]
     revert e; rcases S k with - | ⟨a, Sk⟩ <;> intro e
     · cases e
@@ -625,7 +628,8 @@ theorem clear_ok {p k q s L₁ o L₂} {S : K' → List Γ'} (e : splitAtPred p 
       simp only [cond_false, cond_true, Prod.mk.injEq, true_and, false_and, reduceCtorEq] at e ⊢
     rcases e with ⟨e₁, e₂⟩
     rw [e₁, e₂]
-  · refine TransGen.head rfl ?_
+  | cons a L₁ IH =>
+    refine TransGen.head rfl ?_
     rw [tr]; simp only [pop', TM2.step, Option.mem_def, TM2.stepAux, Option.elim]
     rcases e₁ : S k with - | ⟨a', Sk⟩ <;> rw [e₁, splitAtPred] at e
     · cases e
@@ -641,9 +645,11 @@ theorem clear_ok {p k q s L₁ o L₂} {S : K' → List Γ'} (e : splitAtPred p 
 theorem copy_ok (q s a b c d) :
     Reaches₁ (TM2.step tr) ⟨some (Λ'.copy q), s, K'.elim a b c d⟩
       ⟨some q, none, K'.elim (List.reverseAux b a) [] c (List.reverseAux b d)⟩ := by
-  induction' b with x b IH generalizing a d s
-  · refine TransGen.single ?_
+  induction b generalizing a d s with
+  | nil =>
+    refine TransGen.single ?_
     simp
+  | cons x b IH => ?_
   refine TransGen.head rfl ?_
   rw [tr]
   simp only [TM2.step, Option.mem_def, TM2.stepAux, elim_rev, List.head?_cons, Option.isSome_some,

--- a/Mathlib/Computability/Tape.lean
+++ b/Mathlib/Computability/Tape.lean
@@ -262,10 +262,12 @@ def ListBlank.modifyNth {Γ} [Inhabited Γ] (f : Γ → Γ) : ℕ → ListBlank 
 
 theorem ListBlank.nth_modifyNth {Γ} [Inhabited Γ] (f : Γ → Γ) (n i) (L : ListBlank Γ) :
     (L.modifyNth f n).nth i = if i = n then f (L.nth i) else L.nth i := by
-  induction' n with n IH generalizing i L
-  · cases i <;> simp only [ListBlank.nth_zero, if_true, ListBlank.head_cons, ListBlank.modifyNth,
+  induction n generalizing i L with
+  | zero =>
+    cases i <;> simp only [ListBlank.nth_zero, if_true, ListBlank.head_cons, ListBlank.modifyNth,
       ListBlank.nth_succ, if_false, ListBlank.tail_cons, reduceCtorEq]
-  · cases i
+  | succ n IH =>
+    cases i
     · rw [if_neg (Nat.succ_ne_zero _).symm]
       simp only [ListBlank.nth_zero, ListBlank.head_cons, ListBlank.modifyNth]
     · simp only [IH, ListBlank.modifyNth, ListBlank.nth_succ, ListBlank.tail_cons, Nat.succ.injEq]
@@ -380,8 +382,9 @@ def ListBlank.flatMap {Γ Γ'} [Inhabited Γ] [Inhabited Γ'] (l : ListBlank Γ)
   apply l.liftOn (fun l ↦ ListBlank.mk (l.flatMap f))
   rintro l _ ⟨i, rfl⟩; obtain ⟨n, e⟩ := hf; refine Quotient.sound' (Or.inl ⟨i * n, ?_⟩)
   rw [List.flatMap_append, mul_comm]; congr
-  induction' i with i IH
-  · rfl
+  induction i with
+  | zero => rfl
+  | succ i IH => ?_
   simp only [IH, e, List.replicate_add, Nat.mul_succ, add_comm, List.replicate_succ,
     List.flatMap_cons]
 
@@ -588,9 +591,11 @@ theorem Tape.map_write {Γ Γ'} [Inhabited Γ] [Inhabited Γ'] (f : PointedMap �
 theorem Tape.write_move_right_n {Γ} [Inhabited Γ] (f : Γ → Γ) (L R : ListBlank Γ) (n : ℕ) :
     ((Tape.move Dir.right)^[n] (Tape.mk' L R)).write (f (R.nth n)) =
       (Tape.move Dir.right)^[n] (Tape.mk' L (R.modifyNth f n)) := by
-  induction' n with n IH generalizing L R
-  · simp only [ListBlank.nth_zero, ListBlank.modifyNth, iterate_zero_apply]
+  induction n generalizing L R with
+  | zero =>
+    simp only [ListBlank.nth_zero, ListBlank.modifyNth, iterate_zero_apply]
     rw [← Tape.write_mk', ListBlank.cons_head_tail]
+  | succ n IH => ?_
   simp only [ListBlank.head_cons, ListBlank.nth_succ, ListBlank.modifyNth, Tape.move_right_mk',
     ListBlank.tail_cons, iterate_succ_apply, IH]
 

--- a/Mathlib/Control/LawfulFix.lean
+++ b/Mathlib/Control/LawfulFix.lean
@@ -49,9 +49,11 @@ theorem approx_mono' {i : ℕ} : Fix.approx f i ≤ Fix.approx f (succ i) := by
   | succ _ i_ih => intro; apply f.monotone; apply i_ih
 
 theorem approx_mono ⦃i j : ℕ⦄ (hij : i ≤ j) : approx f i ≤ approx f j := by
-  induction' j with j ih
-  · cases hij
+  induction j with
+  | zero =>
+    cases hij
     exact le_rfl
+  | succ j ih => ?_
   cases hij; · exact le_rfl
   exact le_trans (ih ‹_›) (approx_mono' f)
 

--- a/Mathlib/Data/Complex/Exponential.lean
+++ b/Mathlib/Data/Complex/Exponential.lean
@@ -95,9 +95,10 @@ theorem exp_zero : exp 0 = 1 := by
   rcases j with - | j
   · exact absurd hj (not_le_of_gt zero_lt_one)
   · dsimp [exp']
-    induction' j with j ih
-    · dsimp [exp']; simp [show Nat.succ 0 = 1 from rfl]
-    · rw [← ih (by simp [Nat.succ_le_succ])]
+    induction j with
+    | zero => dsimp [exp']; simp [show Nat.succ 0 = 1 from rfl]
+    | succ j ih =>
+      rw [← ih (by simp [Nat.succ_le_succ])]
       simp only [sum_range_succ, pow_succ]
       simp
 

--- a/Mathlib/Data/Countable/Basic.lean
+++ b/Mathlib/Data/Countable/Basic.lean
@@ -142,9 +142,10 @@ instance [Countable α] [∀ a, Countable (π a)] : Countable (PSigma π) :=
 instance [Finite α] [∀ a, Countable (π a)] : Countable (∀ a, π a) := by
   have : ∀ n, Countable (Fin n → ℕ) := by
     intro n
-    induction' n with n ihn
-    · change Countable (Fin 0 → ℕ); infer_instance
-    · haveI := ihn
+    induction n with
+    | zero => change Countable (Fin 0 → ℕ); infer_instance
+    | succ n ihn =>
+      haveI := ihn
       exact Countable.of_equiv (ℕ × (Fin n → ℕ)) (Fin.consEquiv fun _ ↦ ℕ)
   rcases Finite.exists_equiv_fin α with ⟨n, ⟨e⟩⟩
   have f := fun a => (nonempty_embedding_nat (π a)).some

--- a/Mathlib/Data/DFinsupp/Defs.lean
+++ b/Mathlib/Data/DFinsupp/Defs.lean
@@ -741,10 +741,12 @@ protected theorem induction {p : (Π₀ i, β i) → Prop} (f : Π₀ i, β i) (
   obtain ⟨f, s⟩ := f
   induction' s using Trunc.induction_on with s
   obtain ⟨s, H⟩ := s
-  induction' s using Multiset.induction_on with i s ih generalizing f
-  · have : f = 0 := funext fun i => (H i).resolve_left (Multiset.not_mem_zero _)
+  induction s using Multiset.induction_on generalizing f with
+  | empty =>
+    have : f = 0 := funext fun i => (H i).resolve_left (Multiset.not_mem_zero _)
     subst this
     exact h0
+  | cons i s ih => ?_
   have H2 : p (erase i ⟨f, Trunc.mk ⟨i ::ₘ s, H⟩⟩) := by
     dsimp only [erase, Trunc.map, Trunc.bind, Trunc.liftOn, Trunc.lift_mk,
       Function.comp, Subtype.coe_mk]

--- a/Mathlib/Data/DFinsupp/WellFounded.lean
+++ b/Mathlib/Data/DFinsupp/WellFounded.lean
@@ -114,10 +114,12 @@ theorem Lex.acc_of_single (hbot : ∀ ⦃i a⦄, ¬s i a 0) [DecidableEq ι]
     (∀ i ∈ x.support, Acc (DFinsupp.Lex r s) <| single i (x i)) → Acc (DFinsupp.Lex r s) x := by
   generalize ht : x.support = t; revert x
   classical
-    induction' t using Finset.induction with b t hb ih
-    · intro x ht
+    induction t using Finset.induction with
+    | empty =>
+      intro x ht
       rw [support_eq_empty.1 ht]
       exact fun _ => Lex.acc_zero hbot
+    | @insert b t hb ih => ?_
     refine fun x ht h => Lex.acc_of_single_erase b (h b <| t.mem_insert_self b) ?_
     refine ih _ (by rw [support_erase, ht, Finset.erase_insert hb]) fun a ha => ?_
     rw [erase_ne (ha.ne_of_not_mem hb)]

--- a/Mathlib/Data/Fin/Tuple/Basic.lean
+++ b/Mathlib/Data/Fin/Tuple/Basic.lean
@@ -783,7 +783,7 @@ lemma exists_iff_castSucc {P : Fin (n + 1) → Prop} :
     (∃ i, P i) ↔ P (last n) ∨ ∃ i : Fin n, P i.castSucc where
   mp := by
     rintro ⟨i, hi⟩
-    induction' i using lastCases
+    induction i using lastCases
     · exact .inl hi
     · exact .inr ⟨_, hi⟩
   mpr := by rintro (h | ⟨i, hi⟩) <;> exact ⟨_, ‹_›⟩
@@ -796,7 +796,7 @@ lemma exists_iff_succAbove {P : Fin (n + 1) → Prop} (p : Fin (n + 1)) :
     (∃ i, P i) ↔ P p ∨ ∃ i, P (p.succAbove i) where
   mp := by
     rintro ⟨i, hi⟩
-    induction' i using p.succAboveCases
+    induction i using p.succAboveCases
     · exact .inl hi
     · exact .inr ⟨_, hi⟩
   mpr := by rintro (h | ⟨i, hi⟩) <;> exact ⟨_, ‹_›⟩

--- a/Mathlib/Data/Fin/Tuple/NatAntidiagonal.lean
+++ b/Mathlib/Data/Fin/Tuple/NatAntidiagonal.lean
@@ -86,17 +86,20 @@ theorem mem_antidiagonalTuple {n : ℕ} {k : ℕ} {x : Fin k → ℕ} :
 
 /-- The antidiagonal of `n` does not contain duplicate entries. -/
 theorem nodup_antidiagonalTuple (k n : ℕ) : List.Nodup (antidiagonalTuple k n) := by
-  induction' k with k ih generalizing n
-  · cases n
+  induction k generalizing n with
+  | zero =>
+    cases n
     · simp
     · simp [eq_comm]
+  | succ k ih => ?_
   simp_rw [antidiagonalTuple, List.nodup_flatMap]
   constructor
   · intro i _
     exact (ih i.snd).map (Fin.cons_right_injective (α := fun _ => ℕ) i.fst)
-  induction' n with n n_ih
-  · exact List.pairwise_singleton _ _
-  · rw [List.Nat.antidiagonal_succ]
+  induction n with
+  | zero => exact List.pairwise_singleton _ _
+  | succ n n_ih =>
+    rw [List.Nat.antidiagonal_succ]
     refine List.Pairwise.cons (fun a ha x hx₁ hx₂ => ?_) (n_ih.map _ fun a b h x hx₁ hx₂ => ?_)
     · rw [List.mem_map] at hx₁ hx₂ ha
       obtain ⟨⟨a, -, rfl⟩, ⟨x₁, -, rfl⟩, ⟨x₂, -, h⟩⟩ := ha, hx₁, hx₂
@@ -146,10 +149,12 @@ theorem antidiagonalTuple_pairwise_pi_lex :
     simp only [Fin.pi_lex_lt_cons_cons, eq_self_iff_true, true_and, lt_self_iff_false,
       false_or]
     refine ⟨fun _ _ _ => antidiagonalTuple_pairwise_pi_lex k _, ?_⟩
-    induction' n with n n_ih
-    · rw [antidiagonal_zero]
+    induction n with
+    | zero =>
+      rw [antidiagonal_zero]
       exact List.pairwise_singleton _ _
-    · rw [antidiagonal_succ, List.pairwise_cons, List.pairwise_map]
+    | succ n n_ih =>
+      rw [antidiagonal_succ, List.pairwise_cons, List.pairwise_map]
       refine ⟨fun p hp x hx y hy => ?_, ?_⟩
       · rw [List.mem_map, Prod.exists] at hp
         obtain ⟨a, b, _, rfl : (Nat.succ a, b) = p⟩ := hp

--- a/Mathlib/Data/Finmap.lean
+++ b/Mathlib/Data/Finmap.lean
@@ -460,8 +460,9 @@ theorem toFinmap_cons (a : α) (b : β a) (xs : List (Sigma β)) :
 
 theorem mem_list_toFinmap (a : α) (xs : List (Sigma β)) :
     a ∈ xs.toFinmap ↔ ∃ b : β a, Sigma.mk a b ∈ xs := by
-  induction' xs with x xs
-  · simp only [toFinmap_nil, not_mem_empty, find?, not_mem_nil, exists_false]
+  induction xs with
+  | nil => simp only [toFinmap_nil, not_mem_empty, find?, not_mem_nil, exists_false]
+  | cons x xs => ?_
   obtain ⟨fst_i, snd_i⟩ := x
   simp only [toFinmap_cons, *, exists_or, mem_cons, mem_insert, exists_and_left, Sigma.mk.inj_iff]
   refine (or_congr_left <| and_iff_left_of_imp ?_).symm

--- a/Mathlib/Data/Finset/Fold.lean
+++ b/Mathlib/Data/Finset/Fold.lean
@@ -74,9 +74,10 @@ theorem fold_op_distrib {f g : α → β} {b₁ b₂ : β} :
 theorem fold_const [hd : Decidable (s = ∅)] (c : β) (h : op c (op b c) = op b c) :
     Finset.fold op b (fun _ => c) s = if s = ∅ then b else op b c := by
   classical
-    induction' s using Finset.induction_on with x s hx IH generalizing hd
-    · simp
-    · simp only [Finset.fold_insert hx, IH, if_false, Finset.insert_ne_empty]
+    induction s using Finset.induction_on generalizing hd with
+    | empty => simp
+    | @insert x s hx IH =>
+      simp only [Finset.fold_insert hx, IH, if_false, Finset.insert_ne_empty]
       split_ifs
       · rw [hc.comm]
       · exact h
@@ -120,9 +121,10 @@ theorem fold_ite' {g : α → β} (hb : op b b = b) (p : α → Prop) [Decidable
     Finset.fold op b (fun i => ite (p i) (f i) (g i)) s =
       op (Finset.fold op b f (s.filter p)) (Finset.fold op b g (s.filter fun i => ¬p i)) := by
   classical
-    induction' s using Finset.induction_on with x s hx IH
-    · simp [hb]
-    · simp only [Finset.fold_insert hx]
+    induction s using Finset.induction_on with
+    | empty => simp [hb]
+    | @insert x s hx IH =>
+      simp only [Finset.fold_insert hx]
       split_ifs with h
       · have : x ∉ Finset.filter p s := by simp [hx]
         simp [Finset.filter_insert, h, Finset.fold_insert this, ha.assoc, IH]
@@ -141,8 +143,9 @@ theorem fold_ite [Std.IdempotentOp op] {g : α → β} (p : α → Prop) [Decida
 theorem fold_op_rel_iff_and {r : β → β → Prop} (hr : ∀ {x y z}, r x (op y z) ↔ r x y ∧ r x z)
     {c : β} : r c (s.fold op b f) ↔ r c b ∧ ∀ x ∈ s, r c (f x) := by
   classical
-    induction' s using Finset.induction_on with a s ha IH
-    · simp
+    induction s using Finset.induction_on with
+    | empty => simp
+    | @insert a s ha IH => ?_
     rw [Finset.fold_insert ha, hr, IH, ← and_assoc, @and_comm (r c (f a)), and_assoc]
     apply and_congr Iff.rfl
     constructor
@@ -158,8 +161,9 @@ theorem fold_op_rel_iff_and {r : β → β → Prop} (hr : ∀ {x y z}, r x (op 
 theorem fold_op_rel_iff_or {r : β → β → Prop} (hr : ∀ {x y z}, r x (op y z) ↔ r x y ∨ r x z)
     {c : β} : r c (s.fold op b f) ↔ r c b ∨ ∃ x ∈ s, r c (f x) := by
   classical
-    induction' s using Finset.induction_on with a s ha IH
-    · simp
+    induction s using Finset.induction_on with
+    | empty => simp
+    | @insert a s ha IH => ?_
     rw [Finset.fold_insert ha, hr, IH, ← or_assoc, @or_comm (r c (f a)), or_assoc]
     apply or_congr Iff.rfl
     constructor
@@ -173,9 +177,9 @@ theorem fold_op_rel_iff_or {r : β → β → Prop} (hr : ∀ {x y z}, r x (op y
 @[simp]
 theorem fold_union_empty_singleton [DecidableEq α] (s : Finset α) :
     Finset.fold (· ∪ ·) ∅ singleton s = s := by
-  induction' s using Finset.induction_on with a s has ih
-  · simp only [fold_empty]
-  · rw [fold_insert has, ih, insert_eq]
+  induction s using Finset.induction_on with
+  | empty => simp only [fold_empty]
+  | @insert a s has ih => rw [fold_insert has, ih, insert_eq]
 
 theorem fold_sup_bot_singleton [DecidableEq α] (s : Finset α) :
     Finset.fold (· ⊔ ·) ⊥ singleton s = s :=

--- a/Mathlib/Data/Finset/Image.lean
+++ b/Mathlib/Data/Finset/Image.lean
@@ -645,8 +645,9 @@ theorem subset_image_iff [DecidableEq β] {s : Finset α} {t : Finset β} {f : �
   simp only [← coe_subset, coe_image, subset_set_image_iff]
 
 theorem range_sdiff_zero {n : ℕ} : range (n + 1) \ {0} = (range n).image Nat.succ := by
-  induction' n with k hk
-  · simp
+  induction n with
+  | zero => simp
+  | succ k hk => ?_
   conv_rhs => rw [range_succ]
   rw [range_succ, image_insert, ← hk, insert_sdiff_of_not_mem]
   simp

--- a/Mathlib/Data/Finset/Lattice/Fold.lean
+++ b/Mathlib/Data/Finset/Lattice/Fold.lean
@@ -1118,14 +1118,14 @@ variable [DecidableEq α] {s : Finset ι} {f : ι → Finset α} {a : α}
 
 set_option linter.docPrime false in
 @[simp] lemma mem_sup' (hs) : a ∈ s.sup' hs f ↔ ∃ i ∈ s, a ∈ f i := by
-  induction' hs using Nonempty.cons_induction <;> simp [*]
+  induction hs using Nonempty.cons_induction <;> simp [*]
 
 set_option linter.docPrime false in
 @[simp] lemma mem_inf' (hs) : a ∈ s.inf' hs f ↔ ∀ i ∈ s, a ∈ f i := by
-  induction' hs using Nonempty.cons_induction <;> simp [*]
+  induction hs using Nonempty.cons_induction <;> simp [*]
 
 @[simp] lemma mem_sup : a ∈ s.sup f ↔ ∃ i ∈ s, a ∈ f i := by
-  induction' s using cons_induction <;> simp [*]
+  induction s using cons_induction <;> simp [*]
 
 @[simp]
 theorem sup_singleton'' (s : Finset β) (f : β → α) :

--- a/Mathlib/Data/Finset/Lattice/Lemmas.lean
+++ b/Mathlib/Data/Finset/Lattice/Lemmas.lean
@@ -167,8 +167,8 @@ variable [DecidableEq α] {l l' : List α}
 
 @[simp]
 theorem toFinset_append : toFinset (l ++ l') = l.toFinset ∪ l'.toFinset := by
-  induction' l with hd tl hl
-  · simp
-  · simp [hl]
+  induction l with
+  | nil => simp
+  | cons hd tl hl => simp [hl]
 
 end List

--- a/Mathlib/Data/Finset/Lattice/Pi.lean
+++ b/Mathlib/Data/Finset/Lattice/Pi.lean
@@ -24,8 +24,9 @@ variable [DistribLattice α] [BoundedOrder α] [DecidableEq ι]
 theorem inf_sup {κ : ι → Type*} (s : Finset ι) (t : ∀ i, Finset (κ i)) (f : ∀ i, κ i → α) :
     (s.inf fun i => (t i).sup (f i)) =
       (s.pi t).sup fun g => s.attach.inf fun i => f _ <| g _ i.2 := by
-  induction' s using Finset.induction with i s hi ih
-  · simp
+  induction s using Finset.induction with
+  | empty => simp
+  | @insert i s hi ih => ?_
   rw [inf_insert, ih, attach_insert, sup_inf_sup]
   refine eq_of_forall_ge_iff fun c => ?_
   simp only [Finset.sup_le_iff, mem_product, mem_pi, and_imp, Prod.forall,

--- a/Mathlib/Data/Finset/Max.lean
+++ b/Mathlib/Data/Finset/Max.lean
@@ -64,9 +64,10 @@ theorem max_eq_bot {s : Finset α} : s.max = ⊥ ↔ s = ∅ :=
     fun h ↦ h.symm ▸ max_empty⟩
 
 theorem mem_of_max {s : Finset α} : ∀ {a : α}, s.max = a → a ∈ s := by
-  induction' s using Finset.induction_on with b s _ ih
-  · intro _ H; cases H
-  · intro a h
+  induction s using Finset.induction_on with
+  | empty => intro _ H; cases H
+  | @insert b s _ ih =>
+    intro a h
     by_cases p : b = a
     · induction p
       exact mem_insert_self b s

--- a/Mathlib/Data/Finset/NAry.lean
+++ b/Mathlib/Data/Finset/NAry.lean
@@ -440,8 +440,9 @@ applications are disjoint (but not necessarily distinct!), then the size of `t` 
 theorem card_dvd_card_image₂_right (hf : ∀ a ∈ s, Injective (f a))
     (hs : ((fun a => t.image <| f a) '' s).PairwiseDisjoint id) : #t ∣ #(image₂ f s t) := by
   classical
-  induction' s using Finset.induction with a s _ ih
-  · simp
+  induction s using Finset.induction with
+  | empty => simp
+  | @insert a s _ ih => ?_
   specialize ih (forall_of_forall_insert hf)
     (hs.subset <| Set.image_subset _ <| coe_subset.2 <| subset_insert _ _)
   rw [image₂_insert_left]

--- a/Mathlib/Data/Finset/NoncommProd.lean
+++ b/Mathlib/Data/Finset/NoncommProd.lean
@@ -111,9 +111,10 @@ def noncommProd (s : Multiset α) (comm : { x | x ∈ s }.Pairwise Commute) : α
 theorem noncommProd_coe (l : List α) (comm) : noncommProd (l : Multiset α) comm = l.prod := by
   rw [noncommProd]
   simp only [noncommFold_coe]
-  induction' l with hd tl hl
-  · simp
-  · rw [List.prod_cons, List.foldr, hl]
+  induction l with
+  | nil => simp
+  | cons hd tl hl =>
+    rw [List.prod_cons, List.foldr, hl]
     intro x hx y hy
     exact comm (List.mem_cons_of_mem _ hx) (List.mem_cons_of_mem _ hy)
 
@@ -132,9 +133,10 @@ theorem noncommProd_cons' (s : Multiset α) (a : α) (comm) :
     noncommProd (a ::ₘ s) comm = noncommProd s (comm.mono fun _ => mem_cons_of_mem) * a := by
   induction' s using Quotient.inductionOn with s
   simp only [quot_mk_to_coe, cons_coe, noncommProd_coe, List.prod_cons]
-  induction' s with hd tl IH
-  · simp
-  · rw [List.prod_cons, mul_assoc, ← IH, ← mul_assoc, ← mul_assoc]
+  induction s with
+  | nil => simp
+  | cons hd tl IH =>
+    rw [List.prod_cons, mul_assoc, ← IH, ← mul_assoc, ← mul_assoc]
     · congr 1
       apply comm.of_refl <;> simp
     · intro x hx y hy

--- a/Mathlib/Data/Finset/Sym.lean
+++ b/Mathlib/Data/Finset/Sym.lean
@@ -187,10 +187,12 @@ theorem sym_succ : s.sym (n + 1) = s.sup fun a ↦ (s.sym n).image <| Sym.cons a
 
 @[simp]
 theorem mem_sym_iff {m : Sym α n} : m ∈ s.sym n ↔ ∀ a ∈ m, a ∈ s := by
-  induction' n with n ih
-  · refine mem_singleton.trans ⟨?_, fun _ ↦ Sym.eq_nil_of_card_zero _⟩
+  induction n with
+  | zero =>
+    refine mem_singleton.trans ⟨?_, fun _ ↦ Sym.eq_nil_of_card_zero _⟩
     rintro rfl
     exact fun a ha ↦ (Finset.not_mem_empty _ ha).elim
+  | succ n ih => ?_
   refine mem_sup.trans ⟨?_, fun h ↦ ?_⟩
   · rintro ⟨a, ha, he⟩ b hb
     rw [mem_image] at he

--- a/Mathlib/Data/Finsupp/BigOperators.lean
+++ b/Mathlib/Data/Finsupp/BigOperators.lean
@@ -36,9 +36,10 @@ variable {ι M : Type*} [DecidableEq ι]
 
 theorem List.support_sum_subset [AddZeroClass M] (l : List (ι →₀ M)) :
     l.sum.support ⊆ l.foldr (Finsupp.support · ⊔ ·) ∅ := by
-  induction' l with hd tl IH
-  · simp
-  · simp only [List.sum_cons, Finset.union_comm]
+  induction l with
+  | nil => simp
+  | cons hd tl IH =>
+    simp only [List.sum_cons, Finset.union_comm]
     refine Finsupp.support_add.trans (Finset.union_subset_union ?_ IH)
     rfl
 
@@ -55,9 +56,10 @@ theorem Finset.support_sum_subset [AddCommMonoid M] (s : Finset (ι →₀ M)) :
 theorem List.mem_foldr_sup_support_iff [Zero M] {l : List (ι →₀ M)} {x : ι} :
     x ∈ l.foldr (Finsupp.support · ⊔ ·) ∅ ↔ ∃ f ∈ l, x ∈ f.support := by
   simp only [Finset.sup_eq_union, List.foldr_map, Finsupp.mem_support_iff, exists_prop]
-  induction' l with hd tl IH
-  · simp
-  · simp only [foldr, Function.comp_apply, Finset.mem_union, Finsupp.mem_support_iff, ne_eq, IH,
+  induction l with
+  | nil => simp
+  | cons hd tl IH =>
+    simp only [foldr, Function.comp_apply, Finset.mem_union, Finsupp.mem_support_iff, ne_eq, IH,
       find?, mem_cons, exists_eq_or_imp]
 
 theorem Multiset.mem_sup_map_support_iff [Zero M] {s : Multiset (ι →₀ M)} {x : ι} :
@@ -75,9 +77,10 @@ open scoped Function -- required for scoped `on` notation
 theorem List.support_sum_eq [AddZeroClass M] (l : List (ι →₀ M))
     (hl : l.Pairwise (_root_.Disjoint on Finsupp.support)) :
     l.sum.support = l.foldr (Finsupp.support · ⊔ ·) ∅ := by
-  induction' l with hd tl IH
-  · simp
-  · simp only [List.pairwise_cons] at hl
+  induction l with
+  | nil => simp
+  | cons hd tl IH =>
+    simp only [List.pairwise_cons] at hl
     simp only [List.sum_cons, List.foldr_cons, Function.comp_apply]
     rw [Finsupp.support_add_eq, IH hl.right, Finset.sup_eq_union]
     suffices _root_.Disjoint hd.support (tl.foldr (fun x y ↦ (Finsupp.support x ⊔ y)) ∅) by

--- a/Mathlib/Data/Fintype/Basic.lean
+++ b/Mathlib/Data/Fintype/Basic.lean
@@ -257,7 +257,8 @@ theorem exists_seq_of_forall_finset_exists {α : Type*} (P : α → Prop) (r : �
     set f := seqOfForallFinsetExistsAux P r h' with hf
     have A : ∀ n : ℕ, P (f n) := by
       intro n
-      induction' n using Nat.strong_induction_on with n IH
+      induction n using Nat.strong_induction_on with
+      | h n IH => ?_
       have IH' : ∀ x : Fin n, P (f x) := fun n => IH n.1 n.2
       rw [hf, seqOfForallFinsetExistsAux]
       exact

--- a/Mathlib/Data/Fintype/Card.lean
+++ b/Mathlib/Data/Fintype/Card.lean
@@ -464,7 +464,8 @@ theorem Fintype.induction_subsingleton_or_nontrivial {P : ∀ (α) [Fintype α],
       (∀ (β) [Fintype β], Fintype.card β < Fintype.card α → P β) → P α) :
     P α := by
   obtain ⟨n, hn⟩ : ∃ n, Fintype.card α = n := ⟨Fintype.card α, rfl⟩
-  induction' n using Nat.strong_induction_on with n ih generalizing α
+  induction n using Nat.strong_induction_on generalizing α with
+  | h n ih => ?_
   rcases subsingleton_or_nontrivial α with hsing | hnontriv
   · apply hbase
   · apply hstep

--- a/Mathlib/Data/Fintype/EquivFin.lean
+++ b/Mathlib/Data/Fintype/EquivFin.lean
@@ -562,9 +562,10 @@ theorem exists_subset_card_eq (α : Type*) [Infinite α] (n : ℕ) : ∃ s : Fin
 `s : Finset α` for any cardinality. -/
 theorem exists_superset_card_eq [Infinite α] (s : Finset α) (n : ℕ) (hn : #s ≤ n) :
     ∃ t : Finset α, s ⊆ t ∧ #t = n := by
-  induction' n with n IH generalizing s
-  · exact ⟨s, subset_refl _, Nat.eq_zero_of_le_zero hn⟩
-  · rcases hn.eq_or_lt with hn' | hn'
+  induction n generalizing s with
+  | zero => exact ⟨s, subset_refl _, Nat.eq_zero_of_le_zero hn⟩
+  | succ n IH =>
+    rcases hn.eq_or_lt with hn' | hn'
     · exact ⟨s, subset_refl _, hn'⟩
     obtain ⟨t, hs, ht⟩ := IH _ (Nat.le_of_lt_succ hn')
     obtain ⟨x, hx⟩ := exists_not_mem_finset t

--- a/Mathlib/Data/Fintype/Fin.lean
+++ b/Mathlib/Data/Fintype/Fin.lean
@@ -63,9 +63,10 @@ theorem card_filter_univ_succ' (p : Fin (n + 1) → Prop) [DecidablePred p] :
 
 theorem card_filter_univ_eq_vector_get_eq_count [DecidableEq α] (a : α) (v : List.Vector α n) :
     #{i | v.get i = a} = v.toList.count a := by
-  induction' v with n x xs hxs
-  · simp
-  · simp_rw [card_filter_univ_succ', Vector.get_cons_zero, Vector.toList_cons, Vector.get_cons_succ,
+  induction v with
+  | zero => simp
+  | succ n x =>
+    simp_rw [card_filter_univ_succ', Vector.get_cons_zero, Vector.toList_cons, Vector.get_cons_succ,
       hxs, List.count_cons, add_comm (ite (x = a) 1 0), beq_iff_eq]
 
 end Fin

--- a/Mathlib/Data/Fintype/Fin.lean
+++ b/Mathlib/Data/Fintype/Fin.lean
@@ -64,8 +64,8 @@ theorem card_filter_univ_succ' (p : Fin (n + 1) → Prop) [DecidablePred p] :
 theorem card_filter_univ_eq_vector_get_eq_count [DecidableEq α] (a : α) (v : List.Vector α n) :
     #{i | v.get i = a} = v.toList.count a := by
   induction v with
-  | zero => simp
-  | succ n x =>
+  | nil => simp
+  | @cons n x xs hxs =>
     simp_rw [card_filter_univ_succ', Vector.get_cons_zero, Vector.toList_cons, Vector.get_cons_succ,
       hxs, List.count_cons, add_comm (ite (x = a) 1 0), beq_iff_eq]
 

--- a/Mathlib/Data/Fintype/Lattice.lean
+++ b/Mathlib/Data/Fintype/Lattice.lean
@@ -43,7 +43,7 @@ theorem fold_sup_univ [SemilatticeSup α] [OrderTop α] (a : α) :
   @fold_inf_univ αᵒᵈ _ _ _ _
 
 lemma mem_inf [DecidableEq α] {s : Finset ι} {f : ι → Finset α} {a : α} :
-    a ∈ s.inf f ↔ ∀ i ∈ s, a ∈ f i := by induction' s using Finset.cons_induction <;> simp [*]
+    a ∈ s.inf f ↔ ∀ i ∈ s, a ∈ f i := by induction s using Finset.cons_induction <;> simp [*]
 
 end Finset
 

--- a/Mathlib/Data/Fintype/Sum.lean
+++ b/Mathlib/Data/Fintype/Sum.lean
@@ -99,10 +99,12 @@ theorem Finset.exists_equiv_extend_of_card_eq [Fintype α] [DecidableEq β] {t :
     (hαt : Fintype.card α = #t) {s : Finset α} {f : α → β} (hfst : Finset.image f s ⊆ t)
     (hfs : Set.InjOn f s) : ∃ g : α ≃ t, ∀ i ∈ s, (g i : β) = f i := by
   classical
-    induction' s using Finset.induction with a s has H generalizing f
-    · obtain ⟨e⟩ : Nonempty (α ≃ ↥t) := by rwa [← Fintype.card_eq, Fintype.card_coe]
+    induction s using Finset.induction generalizing f with
+    | empty =>
+      obtain ⟨e⟩ : Nonempty (α ≃ ↥t) := by rwa [← Fintype.card_eq, Fintype.card_coe]
       use e
       simp
+    | @insert a s has H => ?_
     have hfst' : Finset.image f s ⊆ t := (Finset.image_mono _ (s.subset_insert a)).trans hfst
     have hfs' : Set.InjOn f s := hfs.mono (s.subset_insert a)
     obtain ⟨g', hg'⟩ := H hfst' hfs'

--- a/Mathlib/Data/List/Chain.lean
+++ b/Mathlib/Data/List/Chain.lean
@@ -83,16 +83,16 @@ theorem chain_map_of_chain {S : β → β → Prop} (f : α → β) (H : ∀ a b
 theorem chain_pmap_of_chain {S : β → β → Prop} {p : α → Prop} {f : ∀ a, p a → β}
     (H : ∀ a b ha hb, R a b → S (f a ha) (f b hb)) {a : α} {l : List α} (hl₁ : Chain R a l)
     (ha : p a) (hl₂ : ∀ a ∈ l, p a) : Chain S (f a ha) (List.pmap f l hl₂) := by
-  induction' l with lh lt l_ih generalizing a
-  · simp
-  · simp [H _ _ _ _ (rel_of_chain_cons hl₁), l_ih (chain_of_chain_cons hl₁)]
+  induction l generalizing a with
+  | nil => simp
+  | cons lh lt l_ih => simp [H _ _ _ _ (rel_of_chain_cons hl₁), l_ih (chain_of_chain_cons hl₁)]
 
 theorem chain_of_chain_pmap {S : β → β → Prop} {p : α → Prop} (f : ∀ a, p a → β) {l : List α}
     (hl₁ : ∀ a ∈ l, p a) {a : α} (ha : p a) (hl₂ : Chain S (f a ha) (List.pmap f l hl₁))
     (H : ∀ a b ha hb, S (f a ha) (f b hb) → R a b) : Chain R a l := by
-  induction' l with lh lt l_ih generalizing a
-  · simp
-  · simp [H _ _ _ _ (rel_of_chain_cons hl₂), l_ih _ _ (chain_of_chain_cons hl₂)]
+  induction l generalizing a with
+  | nil => simp
+  | cons lh lt l_ih => simp [H _ _ _ _ (rel_of_chain_cons hl₂), l_ih _ _ (chain_of_chain_cons hl₂)]
 
 protected theorem Chain.pairwise [IsTrans α R] :
     ∀ {a : α} {l : List α}, Chain R a l → Pairwise R (a :: l)
@@ -460,9 +460,10 @@ lemma Chain'.chain {α : Type*} {R : α → α → Prop} {l : List α} {v : α}
 lemma Chain'.iterate_eq_of_apply_eq {α : Type*} {f : α → α} {l : List α}
     (hl : l.Chain' (fun x y ↦ f x = y)) (i : ℕ) (hi : i < l.length) :
     f^[i] l[0] = l[i] := by
-  induction' i with i h
-  · rfl
-  · rw [Function.iterate_succ', Function.comp_apply, h (by omega)]
+  induction i with
+  | zero => rfl
+  | succ i h =>
+    rw [Function.iterate_succ', Function.comp_apply, h (by omega)]
     rw [List.chain'_iff_get] at hl
     apply hl
     omega

--- a/Mathlib/Data/List/Cycle.lean
+++ b/Mathlib/Data/List/Cycle.lean
@@ -55,8 +55,9 @@ theorem nextOr_cons_of_ne (xs : List α) (y x d : α) (h : x ≠ y) :
 /-- `nextOr` does not depend on the default value, if the next value appears. -/
 theorem nextOr_eq_nextOr_of_mem_of_ne (xs : List α) (x d d' : α) (x_mem : x ∈ xs)
     (x_ne : x ≠ xs.getLast (ne_nil_of_mem x_mem)) : nextOr xs x d = nextOr xs x d' := by
-  induction' xs with y ys IH
-  · cases x_mem
+  induction xs with
+  | nil => cases x_mem
+  | cons y ys IH => ?_
   rcases ys with - | ⟨z, zs⟩
   · simp at x_mem x_ne
     contradiction
@@ -67,8 +68,9 @@ theorem nextOr_eq_nextOr_of_mem_of_ne (xs : List α) (x d d' : α) (x_mem : x �
     · simpa using x_ne
 
 theorem mem_of_nextOr_ne {xs : List α} {x d : α} (h : nextOr xs x d ≠ d) : x ∈ xs := by
-  induction' xs with y ys IH
-  · simp at h
+  induction xs with
+  | nil => simp at h
+  | cons y ys IH => ?_
   rcases ys with - | ⟨z, zs⟩
   · simp at h
   · by_cases hx : x = y
@@ -77,9 +79,10 @@ theorem mem_of_nextOr_ne {xs : List α} {x d : α} (h : nextOr xs x d ≠ d) : x
       simpa [hx] using IH h
 
 theorem nextOr_concat {xs : List α} {x : α} (d : α) (h : x ∉ xs) : nextOr (xs ++ [x]) x d = d := by
-  induction' xs with z zs IH
-  · simp
-  · obtain ⟨hz, hzs⟩ := not_or.mp (mt mem_cons.2 h)
+  induction xs with
+  | nil => simp
+  | cons z zs IH =>
+    obtain ⟨hz, hzs⟩ := not_or.mp (mt mem_cons.2 h)
     rw [cons_append, nextOr_cons_of_ne _ _ _ _ hz, IH hzs]
 
 theorem nextOr_mem {xs : List α} {x d : α} (hd : d ∈ xs) : nextOr xs x d ∈ xs := by
@@ -87,8 +90,9 @@ theorem nextOr_mem {xs : List α} {x d : α} (hd : d ∈ xs) : nextOr xs x d ∈
   suffices ∀ xs' : List α, (∀ x ∈ xs, x ∈ xs') → d ∈ xs' → nextOr xs x d ∈ xs' by
     exact this xs fun _ => id
   intro xs' hxs' hd
-  induction' xs with y ys ih
-  · exact hd
+  induction xs with
+  | nil => exact hd
+  | cons y ys ih => ?_
   rcases ys with - | ⟨z, zs⟩
   · exact hd
   rw [nextOr]
@@ -223,9 +227,10 @@ theorem next_mem (h : x ∈ l) : l.next x h ∈ l :=
 theorem prev_mem (h : x ∈ l) : l.prev x h ∈ l := by
   rcases l with - | ⟨hd, tl⟩
   · simp at h
-  induction' tl with hd' tl hl generalizing hd
-  · simp
-  · by_cases hx : x = hd
+  induction tl generalizing hd with
+  | nil => simp
+  | cons hd' tl hl =>
+    by_cases hx : x = hd
     · simp only [hx, prev_cons_cons_eq]
       exact mem_cons_of_mem _ (getLast_mem _)
     · rw [prev, dif_neg hx]
@@ -797,10 +802,12 @@ nonrec def Chain (r : α → α → Prop) (c : Cycle α) : Prop :=
         contradiction
       · dsimp only
         obtain ⟨n, hn⟩ := hab
-        induction' n with d hd generalizing a b l m
-        · simp only [rotate_zero, cons.injEq] at hn
+        induction n generalizing a b l m with
+        | zero =>
+          simp only [rotate_zero, cons.injEq] at hn
           rw [hn.1, hn.2]
-        · rcases l with - | ⟨c, s⟩
+        | succ d hd =>
+          rcases l with - | ⟨c, s⟩
           · simp only [rotate_cons_succ, nil_append, rotate_singleton, cons.injEq] at hn
             rw [hn.1, hn.2]
           · rw [Nat.add_comm, ← rotate_rotate, rotate_cons_succ, rotate_zero, cons_append] at hn

--- a/Mathlib/Data/List/Destutter.lean
+++ b/Mathlib/Data/List/Destutter.lean
@@ -58,16 +58,18 @@ theorem destutter'_singleton : [b].destutter' R a = if R a b then [a, b] else [a
   split_ifs with h <;> simp! [h]
 
 theorem destutter'_sublist (a) : l.destutter' R a <+ a :: l := by
-  induction' l with b l hl generalizing a
-  · simp
+  induction l generalizing a with
+  | nil => simp
+  | cons b l hl => ?_
   rw [destutter']
   split_ifs
   · exact Sublist.cons₂ a (hl b)
   · exact (hl a).trans ((l.sublist_cons_self b).cons_cons a)
 
 theorem mem_destutter' (a) : a ∈ l.destutter' R a := by
-  induction' l with b l hl
-  · simp
+  induction l with
+  | nil => simp
+  | cons b l hl => ?_
   rw [destutter']
   split_ifs
   · simp
@@ -83,16 +85,18 @@ theorem destutter'_is_chain : ∀ l : List α, ∀ {a b}, R a b → (l.destutter
     · exact destutter'_is_chain l h
 
 theorem destutter'_is_chain' (a) : (l.destutter' R a).Chain' R := by
-  induction' l with b l hl generalizing a
-  · simp
+  induction l generalizing a with
+  | nil => simp
+  | cons b l hl => ?_
   rw [destutter']
   split_ifs with h
   · exact destutter'_is_chain R l h
   · exact hl a
 
 theorem destutter'_of_chain (h : l.Chain R a) : l.destutter' R a = a :: l := by
-  induction' l with b l hb generalizing a
-  · simp
+  induction l generalizing a with
+  | nil => simp
+  | cons b l hb => ?_
   obtain ⟨h, hc⟩ := chain_cons.mp h
   rw [l.destutter'_cons_pos h, hb hc]
 

--- a/Mathlib/Data/List/DropRight.lean
+++ b/Mathlib/Data/List/DropRight.lean
@@ -50,9 +50,10 @@ theorem rdrop_zero : rdrop l 0 = l := by simp [rdrop]
 
 theorem rdrop_eq_reverse_drop_reverse : l.rdrop n = reverse (l.reverse.drop n) := by
   rw [rdrop]
-  induction' l using List.reverseRecOn with xs x IH generalizing n
-  · simp
-  · cases n
+  induction l using List.reverseRecOn generalizing n with
+  | nil => simp
+  | append_singleton xs x IH =>
+    cases n
     · simp [take_append]
     · simp [take_append_eq_append_take, IH]
 
@@ -72,9 +73,10 @@ theorem rtake_zero : rtake l 0 = [] := by simp [rtake]
 
 theorem rtake_eq_reverse_take_reverse : l.rtake n = reverse (l.reverse.take n) := by
   rw [rtake]
-  induction' l using List.reverseRecOn with xs x IH generalizing n
-  · simp
-  · cases n
+  induction l using List.reverseRecOn generalizing n with
+  | nil => simp
+  | append_singleton xs x IH =>
+    cases n
     · exact drop_length
     · simp [drop_append_eq_append_drop, IH]
 

--- a/Mathlib/Data/List/Duplicate.lean
+++ b/Mathlib/Data/List/Duplicate.lean
@@ -98,9 +98,10 @@ theorem Duplicate.mono_sublist {l' : List α} (hx : x ∈+ l) (h : l <+ l') : x 
 
 /-- The contrapositive of `List.nodup_iff_sublist`. -/
 theorem duplicate_iff_sublist : x ∈+ l ↔ [x, x] <+ l := by
-  induction' l with y l IH
-  · simp
-  · by_cases hx : x = y
+  induction l with
+  | nil => simp
+  | cons y l IH =>
+    by_cases hx : x = y
     · simp [hx, cons_sublist_cons, singleton_sublist]
     · rw [duplicate_cons_iff_of_ne hx, IH]
       refine ⟨sublist_cons_of_sublist y, fun h => ?_⟩

--- a/Mathlib/Data/List/Flatten.lean
+++ b/Mathlib/Data/List/Flatten.lean
@@ -118,8 +118,9 @@ theorem drop_sum_flatten' (L : List (List α)) (i : ℕ) :
 left with a list of length `1` made of the `i`-th element of the original list. -/
 theorem drop_take_succ_eq_cons_getElem (L : List α) (i : Nat) (h : i < L.length) :
     (L.take (i + 1)).drop i = [L[i]] := by
-  induction' L with head tail ih generalizing i
-  · exact (Nat.not_succ_le_zero i h).elim
+  induction L generalizing i with
+  | nil => exact (Nat.not_succ_le_zero i h).elim
+  | cons head tail ih => ?_
   rcases i with _ | i
   · simp
   · simpa using ih _ (by simpa using h)

--- a/Mathlib/Data/List/Indexes.lean
+++ b/Mathlib/Data/List/Indexes.lean
@@ -49,14 +49,14 @@ theorem map_enumFrom_eq_zipWith : ∀ (l : List α) (n : ℕ) (f : ℕ → α �
   intro l
   generalize e : l.length = len
   revert l
-  induction len with <;> intros l e n f
-  | zero =>
+  induction len <;> intro l e n f
+  case zero =>
     have : l = [] := by
       cases l
       · rfl
       · contradiction
     rw [this]; rfl
-  | succ len ih =>
+  case succ len ih =>
     rcases l with - | ⟨head, tail⟩
     · contradiction
     · simp only [enumFrom_cons, map_cons, range_succ_eq_map, zipWith_cons_cons,
@@ -209,14 +209,14 @@ theorem mapIdxMGo_eq_mapIdxMAuxSpec
     mapIdxM.go f as arr = (arr.toList ++ ·) <$> mapIdxMAuxSpec f arr.size as := by
   generalize e : as.length = len
   revert as arr
-  induction len with <;> intro arr as h
-  | zero =>
+  induction len <;> intro arr as h
+  case zero =>
     have : as = [] := by
       cases as
       · rfl
       · contradiction
     simp only [this, mapIdxM.go, mapIdxMAuxSpec, enumFrom_nil, List.traverse, map_pure, append_nil]
-  | succ len ih =>
+  case succ len ih =>
     match as with
     | nil => contradiction
     | cons head tail =>
@@ -246,9 +246,9 @@ variable {m : Type u → Type v} [Monad m] [LawfulMonad m]
 theorem mapIdxMAux'_eq_mapIdxMGo {α} (f : ℕ → α → m PUnit) (as : List α) (arr : Array PUnit) :
     mapIdxMAux' f arr.size as = mapIdxM.go f as arr *> pure PUnit.unit := by
   revert arr
-  induction as with <;> intro arr
-  | nil => simp only [mapIdxMAux', mapIdxM.go, seqRight_eq, map_pure, seq_pure]
-  | cons head tail ih =>
+  induction as <;> intro arr
+  case nil => simp only [mapIdxMAux', mapIdxM.go, seqRight_eq, map_pure, seq_pure]
+  case cons head tail ih =>
     simp only [mapIdxMAux', seqRight_eq, map_eq_pure_bind, seq_eq_bind, bind_pure_unit,
       LawfulMonad.bind_assoc, pure_bind, mapIdxM.go, seq_pure]
     generalize (f (Array.size arr) head) = head

--- a/Mathlib/Data/List/Indexes.lean
+++ b/Mathlib/Data/List/Indexes.lean
@@ -49,13 +49,15 @@ theorem map_enumFrom_eq_zipWith : ∀ (l : List α) (n : ℕ) (f : ℕ → α �
   intro l
   generalize e : l.length = len
   revert l
-  induction' len with len ih <;> intros l e n f
-  · have : l = [] := by
+  induction len with <;> intros l e n f
+  | zero =>
+    have : l = [] := by
       cases l
       · rfl
       · contradiction
     rw [this]; rfl
-  · rcases l with - | ⟨head, tail⟩
+  | succ len ih =>
+    rcases l with - | ⟨head, tail⟩
     · contradiction
     · simp only [enumFrom_cons, map_cons, range_succ_eq_map, zipWith_cons_cons,
         Nat.zero_add, zipWith_map_left, true_and]
@@ -207,13 +209,15 @@ theorem mapIdxMGo_eq_mapIdxMAuxSpec
     mapIdxM.go f as arr = (arr.toList ++ ·) <$> mapIdxMAuxSpec f arr.size as := by
   generalize e : as.length = len
   revert as arr
-  induction' len with len ih <;> intro arr as h
-  · have : as = [] := by
+  induction len with <;> intro arr as h
+  | zero =>
+    have : as = [] := by
       cases as
       · rfl
       · contradiction
     simp only [this, mapIdxM.go, mapIdxMAuxSpec, enumFrom_nil, List.traverse, map_pure, append_nil]
-  · match as with
+  | succ len ih =>
+    match as with
     | nil => contradiction
     | cons head tail =>
       simp only [length_cons, Nat.succ.injEq] at h
@@ -242,9 +246,10 @@ variable {m : Type u → Type v} [Monad m] [LawfulMonad m]
 theorem mapIdxMAux'_eq_mapIdxMGo {α} (f : ℕ → α → m PUnit) (as : List α) (arr : Array PUnit) :
     mapIdxMAux' f arr.size as = mapIdxM.go f as arr *> pure PUnit.unit := by
   revert arr
-  induction' as with head tail ih <;> intro arr
-  · simp only [mapIdxMAux', mapIdxM.go, seqRight_eq, map_pure, seq_pure]
-  · simp only [mapIdxMAux', seqRight_eq, map_eq_pure_bind, seq_eq_bind, bind_pure_unit,
+  induction as with <;> intro arr
+  | nil => simp only [mapIdxMAux', mapIdxM.go, seqRight_eq, map_pure, seq_pure]
+  | cons head tail ih =>
+    simp only [mapIdxMAux', seqRight_eq, map_eq_pure_bind, seq_eq_bind, bind_pure_unit,
       LawfulMonad.bind_assoc, pure_bind, mapIdxM.go, seq_pure]
     generalize (f (Array.size arr) head) = head
     have : (arr.push ⟨⟩).size = arr.size + 1 := Array.size_push _

--- a/Mathlib/Data/List/Infix.lean
+++ b/Mathlib/Data/List/Infix.lean
@@ -225,9 +225,9 @@ theorem map_reverse_tails (l : List α) : map reverse l.tails = (reverse <| init
 
 @[simp]
 theorem length_tails (l : List α) : length (tails l) = length l + 1 := by
-  induction' l with x l IH
-  · simp
-  · simpa using IH
+  induction l with
+  | nil => simp
+  | cons x l IH => simpa using IH
 
 @[simp]
 theorem length_inits (l : List α) : length (inits l) = length l + 1 := by simp [inits_eq_tails]
@@ -259,10 +259,10 @@ theorem get_inits (l : List α) (n : Fin (length (inits l))) : (inits l).get n =
   simp
 
 lemma map_inits {β : Type*} (g : α → β) : (l.map g).inits = l.inits.map (map g) := by
-  induction' l using reverseRecOn <;> simp [*]
+  induction l using reverseRecOn <;> simp [*]
 
 lemma map_tails {β : Type*} (g : α → β) : (l.map g).tails = l.tails.map (map g) := by
-  induction' l using reverseRecOn <;> simp [*]
+  induction l using reverseRecOn <;> simp [*]
 
 lemma take_inits {n} : (l.take n).inits = l.inits.take (n + 1) := by
   apply ext_getElem <;> (simp [take_take] <;> omega)

--- a/Mathlib/Data/List/Lemmas.lean
+++ b/Mathlib/Data/List/Lemmas.lean
@@ -29,10 +29,12 @@ lemma Nat.sum_eq_listSum (l : List ℕ) : Nat.sum l = l.sum := rfl
 
 theorem injOn_insertIdx_index_of_not_mem (l : List α) (x : α) (hx : x ∉ l) :
     Set.InjOn (fun k => l.insertIdx k x) { n | n ≤ l.length } := by
-  induction' l with hd tl IH
-  · intro n hn m hm _
+  induction l with
+  | nil =>
+    intro n hn m hm _
     simp_all [Set.mem_singleton_iff, Set.setOf_eq_eq_singleton, length]
-  · intro n hn m hm h
+  | cons hd tl IH =>
+    intro n hn m hm h
     simp only [length, Set.mem_setOf_eq] at hn hm
     simp only [mem_cons, not_or] at hx
     cases n <;> cases m
@@ -51,9 +53,10 @@ alias injOn_insertNth_index_of_not_mem := injOn_insertIdx_index_of_not_mem
 theorem foldr_range_subset_of_range_subset {f : β → α → α} {g : γ → α → α}
     (hfg : Set.range f ⊆ Set.range g) (a : α) : Set.range (foldr f a) ⊆ Set.range (foldr g a) := by
   rintro _ ⟨l, rfl⟩
-  induction' l with b l H
-  · exact ⟨[], rfl⟩
-  · obtain ⟨c, hgf⟩ := hfg (Set.mem_range_self b)
+  induction l with
+  | nil => exact ⟨[], rfl⟩
+  | cons b l H =>
+    obtain ⟨c, hgf⟩ := hfg (Set.mem_range_self b)
     obtain ⟨m, hgf'⟩ := H
     rw [foldr_cons, ← hgf, ← hgf']
     exact ⟨c :: m, rfl⟩

--- a/Mathlib/Data/List/MinMax.lean
+++ b/Mathlib/Data/List/MinMax.lean
@@ -69,8 +69,9 @@ theorem argAux_self (hr₀ : Irreflexive r) (a : α) : argAux r (some a) a = a :
 
 theorem not_of_mem_foldl_argAux (hr₀ : Irreflexive r) (hr₁ : Transitive r) :
     ∀ {a m : α} {o : Option α}, a ∈ l → m ∈ foldl (argAux r) o l → ¬r a m := by
-  induction' l using List.reverseRecOn with tl a ih
-  · simp
+  induction l using List.reverseRecOn with
+  | nil => simp
+  | append_singleton tl a ih => ?_
   intro b m o hb ho
   rw [foldl_append, foldl_cons, foldl_nil, argAux] at ho
   rcases hf : foldl (argAux r) o tl with - | c
@@ -376,10 +377,10 @@ theorem minimum_eq_coe_iff : minimum l = m ↔ m ∈ l ∧ ∀ a ∈ l, m ≤ a 
   @maximum_eq_coe_iff αᵒᵈ _ _ _
 
 theorem coe_le_maximum_iff : a ≤ l.maximum ↔ ∃ b, b ∈ l ∧ a ≤ b := by
-  induction' l <;> simp [maximum_cons, *]
+  induction l <;> simp [maximum_cons, *]
 
 theorem minimum_le_coe_iff : l.minimum ≤ a ↔ ∃ b, b ∈ l ∧ b ≤ a := by
-  induction' l <;> simp [minimum_cons, *]
+  induction l <;> simp [minimum_cons, *]
 
 theorem maximum_ne_bot_of_ne_nil (h : l ≠ []) : l.maximum ≠ ⊥ :=
   match l, h with | _ :: _, _ => by simp [maximum_cons]
@@ -486,22 +487,24 @@ variable [OrderBot α] {l : List α}
 
 @[simp]
 theorem foldr_max_of_ne_nil (h : l ≠ []) : ↑(l.foldr max ⊥) = l.maximum := by
-  induction' l with hd tl IH
-  · contradiction
-  · rw [maximum_cons, foldr, WithBot.coe_max]
+  induction l with
+  | nil => contradiction
+  | cons hd tl IH =>
+    rw [maximum_cons, foldr, WithBot.coe_max]
     by_cases h : tl = []
     · simp [h]
     · simp [IH h]
 
 theorem max_le_of_forall_le (l : List α) (a : α) (h : ∀ x ∈ l, x ≤ a) : l.foldr max ⊥ ≤ a := by
-  induction' l with y l IH
-  · simp
-  · simpa [h y mem_cons_self] using IH fun x hx => h x <| mem_cons_of_mem _ hx
+  induction l with
+  | nil => simp
+  | cons y l IH => simpa [h y mem_cons_self] using IH fun x hx => h x <| mem_cons_of_mem _ hx
 
 theorem le_max_of_le {l : List α} {a x : α} (hx : x ∈ l) (h : a ≤ x) : a ≤ l.foldr max ⊥ := by
-  induction' l with y l IH
-  · exact absurd hx not_mem_nil
-  · obtain hl | hl := hx
+  induction l with
+  | nil => exact absurd hx not_mem_nil
+  | cons y l IH =>
+    obtain hl | hl := hx
     · simp only [foldr, foldr_cons]
       exact le_max_of_le_left h
     · exact le_max_of_le_right (IH (by assumption))

--- a/Mathlib/Data/List/NodupEquivFin.lean
+++ b/Mathlib/Data/List/NodupEquivFin.lean
@@ -105,8 +105,9 @@ then `Sublist l l'`.
 -/
 theorem sublist_of_orderEmbedding_getElem?_eq {l l' : List α} (f : ℕ ↪o ℕ)
     (hf : ∀ ix : ℕ, l[ix]? = l'[f ix]?) : l <+ l' := by
-  induction' l with hd tl IH generalizing l' f
-  · simp
+  induction l generalizing l' f with
+  | nil => simp
+  | cons hd tl IH => ?_
   have : some hd = l'[f 0]? := by simpa using hf 0
   rw [eq_comm, List.getElem?_eq_some_iff] at this
   obtain ⟨w, h⟩ := this

--- a/Mathlib/Data/List/OfFn.lean
+++ b/Mathlib/Data/List/OfFn.lean
@@ -48,20 +48,24 @@ theorem ofFn_congr {m n : ℕ} (h : m = n) (f : Fin m → α) :
 
 theorem ofFn_succ' {n} (f : Fin (succ n) → α) :
     ofFn f = (ofFn fun i => f (Fin.castSucc i)).concat (f (Fin.last _)) := by
-  induction' n with n IH
-  · rw [ofFn_zero, concat_nil, ofFn_succ, ofFn_zero]
+  induction n with
+  | zero =>
+    rw [ofFn_zero, concat_nil, ofFn_succ, ofFn_zero]
     rfl
-  · rw [ofFn_succ, IH, ofFn_succ, concat_cons, Fin.castSucc_zero]
+  | succ n IH =>
+    rw [ofFn_succ, IH, ofFn_succ, concat_cons, Fin.castSucc_zero]
     congr
 
 /-- Note this matches the convention of `List.ofFn_succ'`, putting the `Fin m` elements first. -/
 theorem ofFn_add {m n} (f : Fin (m + n) → α) :
     List.ofFn f =
       (List.ofFn fun i => f (Fin.castAdd n i)) ++ List.ofFn fun j => f (Fin.natAdd m j) := by
-  induction' n with n IH
-  · rw [ofFn_zero, append_nil, Fin.castAdd_zero, Fin.cast_refl]
+  induction n with
+  | zero =>
+    rw [ofFn_zero, append_nil, Fin.castAdd_zero, Fin.cast_refl]
     rfl
-  · rw [ofFn_succ', ofFn_succ', IH, append_concat]
+  | succ n IH =>
+    rw [ofFn_succ', ofFn_succ', IH, append_concat]
     rfl
 
 @[simp]
@@ -76,9 +80,10 @@ theorem ofFn_mul {m n} (f : Fin (m * n) → α) :
       ↑i * n + j < (i + 1) * n :=
         (Nat.add_lt_add_left j.prop _).trans_eq (by rw [Nat.add_mul, Nat.one_mul])
       _ ≤ _ := Nat.mul_le_mul_right _ i.prop⟩) := by
-  induction' m with m IH
-  · simp [ofFn_zero, Nat.zero_mul, ofFn_zero, flatten]
-  · simp_rw [ofFn_succ', succ_mul]
+  induction m with
+  | zero => simp [ofFn_zero, Nat.zero_mul, ofFn_zero, flatten]
+  | succ m IH =>
+    simp_rw [ofFn_succ', succ_mul]
     simp [flatten_concat, ofFn_add, IH]
     rfl
 

--- a/Mathlib/Data/List/Permutation.lean
+++ b/Mathlib/Data/List/Permutation.lean
@@ -79,17 +79,18 @@ theorem permutationsAux2_append (t : α) (ts : List α) (r : List β) (ys : List
 /-- The `ts` argument to `permutationsAux2` can be folded into the `f` argument. -/
 theorem permutationsAux2_comp_append {t : α} {ts ys : List α} {r : List β} (f : List α → β) :
     ((permutationsAux2 t [] r ys) fun x => f (x ++ ts)).2 = (permutationsAux2 t ts r ys f).2 := by
-  induction' ys with ys_hd _ ys_ih generalizing f
-  · simp
-  · simp [ys_ih fun xs => f (ys_hd :: xs)]
+  induction ys generalizing f with
+  | nil => simp
+  | cons ys_hd _ ys_ih => simp [ys_ih fun xs => f (ys_hd :: xs)]
 
 theorem map_permutationsAux2' {α' β'} (g : α → α') (g' : β → β') (t : α) (ts ys : List α)
     (r : List β) (f : List α → β) (f' : List α' → β') (H : ∀ a, g' (f a) = f' (map g a)) :
     map g' (permutationsAux2 t ts r ys f).2 =
       (permutationsAux2 (g t) (map g ts) (map g' r) (map g ys) f').2 := by
-  induction' ys with ys_hd _ ys_ih generalizing f f'
-  · simp
-  · simp only [map, permutationsAux2_snd_cons, cons_append, cons.injEq]
+  induction ys generalizing f f' with
+  | nil => simp
+  | cons ys_hd _ ys_ih =>
+    simp only [map, permutationsAux2_snd_cons, cons_append, cons.injEq]
     rw [ys_ih]
     · refine ⟨?_, rfl⟩
       simp only [← map_cons, ← map_append]; apply H
@@ -124,9 +125,10 @@ theorem map_map_permutationsAux2 {α'} (g : α → α') (t : α) (ts ys : List �
 
 theorem map_map_permutations'Aux (f : α → β) (t : α) (ts : List α) :
     map (map f) (permutations'Aux t ts) = permutations'Aux (f t) (map f ts) := by
-  induction' ts with a ts ih
-  · rfl
-  · simp only [permutations'Aux, map_cons, map_map, ← ih, cons.injEq, true_and, Function.comp_def]
+  induction ts with
+  | nil => rfl
+  | cons a ts ih =>
+    simp only [permutations'Aux, map_cons, map_map, ← ih, cons.injEq, true_and, Function.comp_def]
 
 theorem permutations'Aux_eq_permutationsAux2 (t : α) (ts : List α) :
     permutations'Aux t ts = (permutationsAux2 t [] [ts ++ [t]] ts id).2 := by
@@ -139,8 +141,9 @@ theorem permutations'Aux_eq_permutationsAux2 (t : α) (ts : List α) :
 theorem mem_permutationsAux2 {t : α} {ts : List α} {ys : List α} {l l' : List α} :
     l' ∈ (permutationsAux2 t ts [] ys (l ++ ·)).2 ↔
       ∃ l₁ l₂, l₂ ≠ [] ∧ ys = l₁ ++ l₂ ∧ l' = l ++ l₁ ++ t :: l₂ ++ ts := by
-  induction' ys with y ys ih generalizing l
-  · simp +contextual
+  induction ys generalizing l with
+  | nil => simp +contextual
+  | cons y ys ih => ?_
   rw [permutationsAux2_snd_cons,
     show (fun x : List α => l ++ y :: x) = (l ++ [y] ++ ·) by funext _; simp, mem_cons, ih]
   constructor
@@ -165,9 +168,9 @@ theorem length_permutationsAux2 (t : α) (ts : List α) (ys : List α) (f : List
 theorem foldr_permutationsAux2 (t : α) (ts : List α) (r L : List (List α)) :
     foldr (fun y r => (permutationsAux2 t ts r y id).2) r L =
       (L.flatMap fun y => (permutationsAux2 t ts [] y id).2) ++ r := by
-  induction' L with l L ih
-  · rfl
-  · simp_rw [foldr_cons, ih, flatMap_cons, append_assoc, permutationsAux2_append]
+  induction L with
+  | nil => rfl
+  | cons l L ih => simp_rw [foldr_cons, ih, flatMap_cons, append_assoc, permutationsAux2_append]
 
 theorem mem_foldr_permutationsAux2 {t : α} {ts : List α} {r L : List (List α)} {l' : List α} :
     l' ∈ foldr (fun y r => (permutationsAux2 t ts r y id).2) r L ↔
@@ -191,8 +194,9 @@ theorem length_foldr_permutationsAux2' (t : α) (ts : List α) (r L : List (List
     (H : ∀ l ∈ L, length l = n) :
     length (foldr (fun y r => (permutationsAux2 t ts r y id).2) r L) = n * length L + length r := by
   rw [length_foldr_permutationsAux2, (_ : (map length L).sum = n * length L)]
-  induction' L with l L ih
-  · simp
+  induction L with
+  | nil => simp
+  | cons l L ih => ?_
   have sum_map : (map length L).sum = n * length L := ih fun l m => H l (mem_cons_of_mem _ m)
   have length_l : length l = n := H _ mem_cons_self
   simp [sum_map, length_l, Nat.mul_add, Nat.add_comm, mul_succ]
@@ -316,8 +320,9 @@ private theorem DecEq_eq [DecidableEq α] :
 theorem perm_permutations'Aux_comm (a b : α) (l : List α) :
     (permutations'Aux a l).flatMap (permutations'Aux b) ~
       (permutations'Aux b l).flatMap (permutations'Aux a) := by
-  induction' l with c l ih
-  · exact Perm.swap [a, b] [b, a] []
+  induction l with
+  | nil => exact Perm.swap [a, b] [b, a] []
+  | cons c l ih => ?_
   simp only [permutations'Aux, flatMap_cons, map_cons, map_map, cons_append]
   apply Perm.swap'
   have :
@@ -387,10 +392,12 @@ theorem perm_permutations'_iff {s t : List α} : permutations' s ~ permutations'
 theorem getElem_permutations'Aux (s : List α) (x : α) (n : ℕ)
     (hn : n < length (permutations'Aux x s)) :
     (permutations'Aux x s)[n] = s.insertIdx n x := by
-  induction' s with y s IH generalizing n
-  · simp only [permutations'Aux, length, Nat.zero_add, lt_one_iff] at hn
+  induction s generalizing n with
+  | nil =>
+    simp only [permutations'Aux, length, Nat.zero_add, lt_one_iff] at hn
     simp [hn]
-  · cases n
+  | cons y s IH =>
+    cases n
     · simp [get]
     · simpa [get] using IH _ _
 
@@ -401,9 +408,10 @@ theorem get_permutations'Aux (s : List α) (x : α) (n : ℕ)
 
 theorem count_permutations'Aux_self [DecidableEq α] (l : List α) (x : α) :
     count (x :: l) (permutations'Aux x l) = length (takeWhile (x = ·) l) + 1 := by
-  induction' l with y l IH generalizing x
-  · simp [takeWhile, count]
-  · rw [permutations'Aux, count_cons_self]
+  induction l generalizing x with
+  | nil => simp [takeWhile, count]
+  | cons y l IH =>
+    rw [permutations'Aux, count_cons_self]
     by_cases hx : x = y
     · subst hx
       simpa [takeWhile, Nat.succ_inj', DecEq_eq] using IH _
@@ -414,9 +422,9 @@ theorem count_permutations'Aux_self [DecidableEq α] (l : List α) (x : α) :
 @[simp]
 theorem length_permutations'Aux (s : List α) (x : α) :
     length (permutations'Aux x s) = length s + 1 := by
-  induction' s with y s IH
-  · simp
-  · simpa using IH
+  induction s with
+  | nil => simp
+  | cons y s IH => simpa using IH
 
 theorem injective_permutations'Aux (x : α) : Function.Injective (permutations'Aux x) := by
   intro s t h
@@ -429,9 +437,10 @@ theorem injective_permutations'Aux (x : α) : Function.Injective (permutations'A
 
 theorem nodup_permutations'Aux_of_not_mem (s : List α) (x : α) (hx : x ∉ s) :
     Nodup (permutations'Aux x s) := by
-  induction' s with y s IH
-  · simp
-  · simp only [not_or, mem_cons] at hx
+  induction s with
+  | nil => simp
+  | cons y s IH =>
+    simp only [not_or, mem_cons] at hx
     simp only [permutations'Aux, nodup_cons, mem_map, cons.injEq, exists_eq_right_right, not_and]
     refine ⟨fun _ => Ne.symm hx.left, ?_⟩
     rw [nodup_map_iff]

--- a/Mathlib/Data/List/Pi.lean
+++ b/Mathlib/Data/List/Pi.lean
@@ -84,12 +84,14 @@ def pi : ∀ l : List ι, (∀ i, List (α i)) → List (∀ i, i ∈ l → α i
 
 lemma _root_.Multiset.pi_coe (l : List ι) (fs : ∀ i, List (α i)) :
     (l : Multiset ι).pi (fs ·) = (↑(pi l fs) : Multiset (∀ i ∈ l, α i)) := by
-  induction' l with i l ih
-  · change Multiset.pi 0 _ = _
+  induction l with
+  | nil =>
+    change Multiset.pi 0 _ = _
     simp only [Multiset.coe_singleton, Multiset.pi_zero, pi_nil, Multiset.singleton_inj]
     ext i hi
     simp at hi
-  · change Multiset.pi (i ::ₘ ↑l) _ = _
+  | cons i l ih =>
+    change Multiset.pi (i ::ₘ ↑l) _ = _
     simp [ih, Multiset.coe_bind, - Multiset.cons_coe]
 
 lemma mem_pi {l : List ι} (fs : ∀ i, List (α i)) :

--- a/Mathlib/Data/List/Prime.lean
+++ b/Mathlib/Data/List/Prime.lean
@@ -24,10 +24,12 @@ variable {M : Type*} [CommMonoidWithZero M]
 theorem Prime.dvd_prod_iff {p : M} {L : List M} (pp : Prime p) : p ∣ L.prod ↔ ∃ a ∈ L, p ∣ a := by
   constructor
   · intro h
-    induction' L with L_hd L_tl L_ih
-    · rw [prod_nil] at h
+    induction L with
+    | nil =>
+      rw [prod_nil] at h
       exact absurd h pp.not_dvd_one
-    · rw [prod_cons] at h
+    | cons L_hd L_tl L_ih =>
+      rw [prod_cons] at h
       rcases pp.dvd_or_dvd h with hd | hd
       · exact ⟨L_hd, mem_cons_self, hd⟩
       · obtain ⟨x, hx1, hx2⟩ := L_ih hd

--- a/Mathlib/Data/List/ProdSigma.lean
+++ b/Mathlib/Data/List/ProdSigma.lean
@@ -44,9 +44,10 @@ theorem mem_product {l₁ : List α} {l₂ : List β} {a : α} {b : β} :
 
 theorem length_product (l₁ : List α) (l₂ : List β) :
     length (l₁ ×ˢ l₂) = length l₁ * length l₂ := by
-  induction' l₁ with x l₁ IH
-  · exact (Nat.zero_mul _).symm
-  · simp only [length, product_cons, length_append, IH, Nat.add_mul, Nat.one_mul, length_map,
+  induction l₁ with
+  | nil => exact (Nat.zero_mul _).symm
+  | cons x l₁ IH =>
+    simp only [length, product_cons, length_append, IH, Nat.add_mul, Nat.one_mul, length_map,
       Nat.add_comm]
 
 /-! ### sigma -/
@@ -79,18 +80,19 @@ set_option linter.deprecated false in
 @[deprecated "Use `List.length_sigma`." (since := "2024-10-17")]
 theorem length_sigma' (l₁ : List α) (l₂ : ∀ a, List (σ a)) :
     length (l₁.sigma l₂) = Nat.sum (l₁.map fun a ↦ length (l₂ a)) := by
-  induction' l₁ with x l₁ IH
-  · rfl
-  · simp only [map, sigma_cons, length_append, length_map, IH, Nat.sum_cons]
+  induction l₁ with
+  | nil => rfl
+  | cons x l₁ IH => simp only [map, sigma_cons, length_append, length_map, IH, Nat.sum_cons]
 
 /-! ### Miscellaneous lemmas -/
 
 @[simp 1100]
 theorem mem_map_swap (x : α) (y : β) (xs : List (α × β)) :
     (y, x) ∈ map Prod.swap xs ↔ (x, y) ∈ xs := by
-  induction' xs with x xs xs_ih
-  · simp only [not_mem_nil, map_nil]
-  · obtain ⟨a, b⟩ := x
+  induction xs with
+  | nil => simp only [not_mem_nil, map_nil]
+  | cons x xs xs_ih =>
+    obtain ⟨a, b⟩ := x
     simp only [mem_cons, Prod.mk_inj, map, Prod.swap_prod_mk, Prod.exists, xs_ih, and_comm]
 
 end List

--- a/Mathlib/Data/List/Range.lean
+++ b/Mathlib/Data/List/Range.lean
@@ -30,9 +30,10 @@ theorem getElem_range'_1 {n m} (i) (H : i < (range' n m).length) :
 theorem chain'_range_succ (r : ℕ → ℕ → Prop) (n : ℕ) :
     Chain' r (range n.succ) ↔ ∀ m < n, r m m.succ := by
   rw [range_succ]
-  induction' n with n hn
-  · simp
-  · rw [range_succ]
+  induction n with
+  | zero => simp
+  | succ n hn =>
+    rw [range_succ]
     simp only [append_assoc, singleton_append, chain'_append_cons_cons, chain'_singleton, and_true]
     rw [hn, forall_lt_succ]
 

--- a/Mathlib/Data/List/ReduceOption.lean
+++ b/Mathlib/Data/List/ReduceOption.lean
@@ -31,9 +31,10 @@ theorem reduceOption_nil : @reduceOption α [] = [] :=
 @[simp]
 theorem reduceOption_map {l : List (Option α)} {f : α → β} :
     reduceOption (map (Option.map f) l) = map f (reduceOption l) := by
-  induction' l with hd tl hl
-  · simp only [reduceOption_nil, map_nil]
-  · cases hd <;>
+  induction l with
+  | nil => simp only [reduceOption_nil, map_nil]
+  | cons hd tl hl =>
+    cases hd <;>
       simpa [Option.map_some', map, eq_self_iff_true, reduceOption_cons_of_some] using hl
 
 theorem reduceOption_append (l l' : List (Option α)) :
@@ -96,9 +97,9 @@ theorem reduceOption_eq_concat_iff (l : List (Option α)) (l' : List α) (a : α
 
 theorem reduceOption_length_eq {l : List (Option α)} :
     l.reduceOption.length = (l.filter Option.isSome).length := by
-  induction' l with hd tl hl
-  · simp_rw [reduceOption_nil, filter_nil, length]
-  · cases hd <;> simp [hl]
+  induction l with
+  | nil => simp_rw [reduceOption_nil, filter_nil, length]
+  | cons hd tl hl => cases hd <;> simp [hl]
 
 theorem length_eq_reduceOption_length_add_filter_none {l : List (Option α)} :
     l.length = l.reduceOption.length + (l.filter Option.isNone).length := by
@@ -123,9 +124,10 @@ theorem reduceOption_singleton (x : Option α) : [x].reduceOption = x.toList := 
 
 theorem reduceOption_concat (l : List (Option α)) (x : Option α) :
     (l.concat x).reduceOption = l.reduceOption ++ x.toList := by
-  induction' l with hd tl hl generalizing x
-  · cases x <;> simp [Option.toList]
-  · simp only [concat_eq_append, reduceOption_append] at hl
+  induction l generalizing x with
+  | nil => cases x <;> simp [Option.toList]
+  | cons hd tl hl =>
+    simp only [concat_eq_append, reduceOption_append] at hl
     cases hd <;> simp [hl, reduceOption_append]
 
 theorem reduceOption_concat_of_some (l : List (Option α)) (x : α) :

--- a/Mathlib/Data/List/Rotate.lean
+++ b/Mathlib/Data/List/Rotate.lean
@@ -148,9 +148,10 @@ theorem rotate_length_mul (l : List α) (n : ℕ) : l.rotate (l.length * n) = l 
 
 theorem rotate_perm (l : List α) (n : ℕ) : l.rotate n ~ l := by
   rw [rotate_eq_rotate']
-  induction' n with n hn generalizing l
-  · simp
-  · rcases l with - | ⟨hd, tl⟩
+  induction n generalizing l with
+  | zero => simp
+  | succ n hn =>
+    rcases l with - | ⟨hd, tl⟩
     · simp
     · rw [rotate'_cons_succ]
       exact (hn _).trans (perm_append_singleton _ _)
@@ -161,9 +162,10 @@ theorem nodup_rotate {l : List α} {n : ℕ} : Nodup (l.rotate n) ↔ Nodup l :=
 
 @[simp]
 theorem rotate_eq_nil_iff {l : List α} {n : ℕ} : l.rotate n = [] ↔ l = [] := by
-  induction' n with n hn generalizing l
-  · simp
-  · rcases l with - | ⟨hd, tl⟩
+  induction n generalizing l with
+  | zero => simp
+  | succ n hn =>
+    rcases l with - | ⟨hd, tl⟩
     · simp
     · simp [rotate_cons_succ, hn]
 
@@ -300,9 +302,10 @@ theorem singleton_eq_rotate_iff {l : List α} {n : ℕ} {x : α} : [x] = l.rotat
 theorem reverse_rotate (l : List α) (n : ℕ) :
     (l.rotate n).reverse = l.reverse.rotate (l.length - n % l.length) := by
   rw [← length_reverse, ← rotate_eq_iff]
-  induction' n with n hn generalizing l
-  · simp
-  · rcases l with - | ⟨hd, tl⟩
+  induction n generalizing l with
+  | zero => simp
+  | succ n hn =>
+    rcases l with - | ⟨hd, tl⟩
     · simp
     · rw [rotate_cons_succ, ← rotate_rotate, hn]
       simp
@@ -324,9 +327,10 @@ theorem rotate_reverse (l : List α) (n : ℕ) :
 
 theorem map_rotate {β : Type*} (f : α → β) (l : List α) (n : ℕ) :
     map f (l.rotate n) = (map f l).rotate n := by
-  induction' n with n hn IH generalizing l
-  · simp
-  · rcases l with - | ⟨hd, tl⟩
+  induction n generalizing l with
+  | zero => simp
+  | succ n hn =>
+    rcases l with - | ⟨hd, tl⟩
     · simp
     · simp [hn]
 

--- a/Mathlib/Data/List/Sigma.lean
+++ b/Mathlib/Data/List/Sigma.lean
@@ -692,16 +692,16 @@ theorem Perm.kunion {l₁ l₂ l₃ l₄ : List (Sigma β)} (nd₃ : l₃.NodupK
 @[simp]
 theorem dlookup_kunion_left {a} {l₁ l₂ : List (Sigma β)} (h : a ∈ l₁.keys) :
     dlookup a (kunion l₁ l₂) = dlookup a l₁ := by
-  induction l₁ generalizing l₂ with <;> simp at h; rcases h with h | h <;> obtain ⟨a'⟩ := s
-  | nil =>
-    subst h
-    simp
-  | cons s _ ih =>
-    rw [kunion_cons]
-    by_cases h' : a = a'
-    · subst h'
+  induction l₁ generalizing l₂ <;> simp at h
+  case cons s _ ih =>
+    rcases h with h | h <;> obtain ⟨a'⟩ := s
+    · subst h
       simp
-    · simp [h', ih h]
+    · rw [kunion_cons]
+      by_cases h' : a = a'
+      · subst h'
+        simp
+      · simp [h', ih h]
 
 @[simp]
 theorem dlookup_kunion_right {a} {l₁ l₂ : List (Sigma β)} (h : a ∉ l₁.keys) :

--- a/Mathlib/Data/List/Sigma.lean
+++ b/Mathlib/Data/List/Sigma.lean
@@ -213,9 +213,10 @@ theorem lookup_ext {l₀ l₁ : List (Sigma β)} (nd₀ : l₀.NodupKeys) (nd₁
 theorem dlookup_map (l : List (Sigma β))
     {f : α → α'} (hf : Function.Injective f) (g : ∀ a, β a → β' (f a)) (a : α) :
     (l.map fun x => ⟨f x.1, g _ x.2⟩).dlookup (f a) = (l.dlookup a).map (g a) := by
-  induction' l with b l IH
-  · rw [map_nil, dlookup_nil, dlookup_nil, Option.map_none']
-  · rw [map_cons]
+  induction l with
+  | nil => rw [map_nil, dlookup_nil, dlookup_nil, Option.map_none']
+  | cons b l IH =>
+    rw [map_cons]
     obtain rfl | h := eq_or_ne a b.1
     · rw [dlookup_cons_eq, dlookup_cons_eq, Option.map_some']
     · rw [dlookup_cons_ne _ _ h, dlookup_cons_ne _ _ (fun he => h <| hf he), IH]
@@ -432,9 +433,10 @@ theorem kerase_kerase {a a'} {l : List (Sigma β)} :
     (kerase a' l).kerase a = (kerase a l).kerase a' := by
   by_cases h : a = a'
   · subst a'; rfl
-  induction' l with x xs
-  · rfl
-  · by_cases a' = x.1
+  induction l with
+  | nil => rfl
+  | cons x xs =>
+    by_cases a' = x.1
     · subst a'
       simp [kerase_cons_ne h, kerase_cons_eq rfl]
     by_cases h' : a = x.1
@@ -519,9 +521,9 @@ theorem kerase_comm (a₁ a₂) (l : List (Sigma β)) :
 theorem sizeOf_kerase [SizeOf (Sigma β)] (x : α)
     (xs : List (Sigma β)) : SizeOf.sizeOf (List.kerase x xs) ≤ SizeOf.sizeOf xs := by
   simp only [SizeOf.sizeOf, _sizeOf_1]
-  induction' xs with y ys
-  · simp
-  · by_cases x = y.1 <;> simp [*]
+  induction xs with
+  | nil => simp
+  | cons y ys => by_cases x = y.1 <;> simp [*]
 
 /-! ### `kinsert` -/
 
@@ -594,9 +596,10 @@ theorem nodupKeys_dedupKeys (l : List (Sigma β)) : NodupKeys (dedupKeys l) := b
     rw [← hl]
     apply nodup_nil
   clear hl
-  induction' l with x xs l_ih
-  · apply this
-  · cases x
+  induction l with
+  | nil => apply this
+  | cons x xs l_ih =>
+    cases x
     simp only [foldr_cons, kinsert_def, nodupKeys_cons, ne_eq, not_true]
     constructor
     · simp only [keys_kerase]
@@ -604,8 +607,9 @@ theorem nodupKeys_dedupKeys (l : List (Sigma β)) : NodupKeys (dedupKeys l) := b
     · exact l_ih.kerase _
 
 theorem dlookup_dedupKeys (a : α) (l : List (Sigma β)) : dlookup a (dedupKeys l) = dlookup a l := by
-  induction' l with l_hd _ l_ih
-  · rfl
+  induction l with
+  | nil => rfl
+  | cons l_hd _ l_ih => ?_
   obtain ⟨a', b⟩ := l_hd
   by_cases h : a = a'
   · subst a'
@@ -616,9 +620,10 @@ theorem dlookup_dedupKeys (a : α) (l : List (Sigma β)) : dlookup a (dedupKeys 
 theorem sizeOf_dedupKeys [SizeOf (Sigma β)]
     (xs : List (Sigma β)) : SizeOf.sizeOf (dedupKeys xs) ≤ SizeOf.sizeOf xs := by
   simp only [SizeOf.sizeOf, _sizeOf_1]
-  induction' xs with x xs
-  · simp [dedupKeys]
-  · simp only [dedupKeys_cons, kinsert_def, Nat.add_le_add_iff_left, Sigma.eta]
+  induction xs with
+  | nil => simp [dedupKeys]
+  | cons x xs =>
+    simp only [dedupKeys_cons, kinsert_def, Nat.add_le_add_iff_left, Sigma.eta]
     trans
     · apply sizeOf_kerase
     · assumption
@@ -687,10 +692,12 @@ theorem Perm.kunion {l₁ l₂ l₃ l₄ : List (Sigma β)} (nd₃ : l₃.NodupK
 @[simp]
 theorem dlookup_kunion_left {a} {l₁ l₂ : List (Sigma β)} (h : a ∈ l₁.keys) :
     dlookup a (kunion l₁ l₂) = dlookup a l₁ := by
-  induction' l₁ with s _ ih generalizing l₂ <;> simp at h; rcases h with h | h <;> obtain ⟨a'⟩ := s
-  · subst h
+  induction l₁ generalizing l₂ with <;> simp at h; rcases h with h | h <;> obtain ⟨a'⟩ := s
+  | nil =>
+    subst h
     simp
-  · rw [kunion_cons]
+  | cons s _ ih =>
+    rw [kunion_cons]
     by_cases h' : a = a'
     · subst h'
       simp

--- a/Mathlib/Data/List/Sublists.lean
+++ b/Mathlib/Data/List/Sublists.lean
@@ -66,9 +66,11 @@ theorem sublists'_cons (a : α) (l : List α) :
 
 @[simp]
 theorem mem_sublists' {s t : List α} : s ∈ sublists' t ↔ s <+ t := by
-  induction' t with a t IH generalizing s
-  · simp only [sublists'_nil, mem_singleton]
+  induction t generalizing s with
+  | nil =>
+    simp only [sublists'_nil, mem_singleton]
     exact ⟨fun h => by rw [h], eq_nil_of_sublist_nil⟩
+  | cons a t IH => ?_
   simp only [sublists'_cons, mem_append, IH, mem_map]
   constructor <;> intro h
   · rcases h with (h | ⟨s, h, rfl⟩)
@@ -172,8 +174,9 @@ theorem length_sublists (l : List α) : length (sublists l) = 2 ^ length l := by
   simp only [sublists_eq_sublists', length_map, length_sublists', length_reverse]
 
 theorem map_pure_sublist_sublists (l : List α) : map pure l <+ sublists l := by
-  induction' l using reverseRecOn with l a ih <;> simp only [map, map_append, sublists_concat]
-  · simp only [sublists_nil, sublist_cons_self]
+  induction l using reverseRecOn with <;> simp only [map, map_append, sublists_concat]
+  | nil => simp only [sublists_nil, sublist_cons_self]
+  | append_singleton l a ih => ?_
   exact ((append_sublist_append_left _).2 <|
               singleton_sublist.2 <| mem_map.2 ⟨[], mem_sublists.2 (nil_sublist _), by rfl⟩).trans
           ((append_sublist_append_right _).2 ih)
@@ -362,13 +365,15 @@ theorem sublists_cons_perm_append (a : α) (l : List α) :
 
 theorem revzip_sublists (l : List α) : ∀ l₁ l₂, (l₁, l₂) ∈ revzip l.sublists → l₁ ++ l₂ ~ l := by
   rw [revzip]
-  induction' l using List.reverseRecOn with l' a ih
-  · intro l₁ l₂ h
+  induction l using List.reverseRecOn with
+  | nil =>
+    intro l₁ l₂ h
     simp? at h says
       simp only [sublists_nil, reverse_cons, reverse_nil, nil_append, zip_cons_cons, zip_nil_right,
         mem_cons, Prod.mk.injEq, not_mem_nil, or_false] at h
     simp [h]
-  · intro l₁ l₂ h
+  | append_singleton l' a ih =>
+    intro l₁ l₂ h
     rw [sublists_concat, reverse_append, zip_append (by simp), ← map_reverse, zip_map_right,
       zip_map_left] at *
     simp only [Prod.mk_inj, mem_map, mem_append, Prod.map_apply, Prod.exists] at h
@@ -382,10 +387,12 @@ theorem revzip_sublists (l : List α) : ∀ l₁ l₂, (l₁, l₂) ∈ revzip l
 
 theorem revzip_sublists' (l : List α) : ∀ l₁ l₂, (l₁, l₂) ∈ revzip l.sublists' → l₁ ++ l₂ ~ l := by
   rw [revzip]
-  induction' l with a l IH <;> intro l₁ l₂ h
-  · simp_all only [sublists'_nil, reverse_cons, reverse_nil, nil_append, zip_cons_cons,
+  induction l with <;> intro l₁ l₂ h
+  | nil =>
+    simp_all only [sublists'_nil, reverse_cons, reverse_nil, nil_append, zip_cons_cons,
       zip_nil_right, mem_singleton, Prod.mk.injEq, append_nil, Perm.refl]
-  · rw [sublists'_cons, reverse_append, zip_append, ← map_reverse, zip_map_right, zip_map_left] at *
+  | cons a l IH =>
+    rw [sublists'_cons, reverse_append, zip_append, ← map_reverse, zip_map_right, zip_map_left] at *
       <;> [simp only [mem_append, mem_map, Prod.map_apply, id_eq, Prod.mk.injEq, Prod.exists,
         exists_eq_right_right] at h; simp]
     rcases h with (⟨l₁, l₂', h, rfl, rfl⟩ | ⟨l₁', h, rfl⟩)
@@ -394,9 +401,10 @@ theorem revzip_sublists' (l : List α) : ∀ l₁ l₂, (l₁, l₂) ∈ revzip 
 
 theorem range_bind_sublistsLen_perm (l : List α) :
     ((List.range (l.length + 1)).flatMap fun n => sublistsLen n l) ~ sublists' l := by
-  induction' l with h tl l_ih
-  · simp [range_succ]
-  · simp_rw [range_succ_eq_map, length, flatMap_cons, flatMap_map, sublistsLen_succ_cons,
+  induction l with
+  | nil => simp [range_succ]
+  | cons h tl l_ih =>
+    simp_rw [range_succ_eq_map, length, flatMap_cons, flatMap_map, sublistsLen_succ_cons,
       sublists'_cons, List.sublistsLen_zero, List.singleton_append]
     refine ((flatMap_append_perm (range (tl.length + 1)) _ _).symm.cons _).trans ?_
     simp_rw [← List.map_flatMap, ← cons_append]

--- a/Mathlib/Data/List/Sublists.lean
+++ b/Mathlib/Data/List/Sublists.lean
@@ -174,12 +174,12 @@ theorem length_sublists (l : List α) : length (sublists l) = 2 ^ length l := by
   simp only [sublists_eq_sublists', length_map, length_sublists', length_reverse]
 
 theorem map_pure_sublist_sublists (l : List α) : map pure l <+ sublists l := by
-  induction l using reverseRecOn with <;> simp only [map, map_append, sublists_concat]
-  | nil => simp only [sublists_nil, sublist_cons_self]
-  | append_singleton l a ih => ?_
-  exact ((append_sublist_append_left _).2 <|
-              singleton_sublist.2 <| mem_map.2 ⟨[], mem_sublists.2 (nil_sublist _), by rfl⟩).trans
-          ((append_sublist_append_right _).2 ih)
+  induction l using reverseRecOn <;> simp only [map, map_append, sublists_concat]
+  case nil => simp only [sublists_nil, sublist_cons_self]
+  case append_singleton l a ih =>
+    exact ((append_sublist_append_left _).2 <|
+      singleton_sublist.2 <| mem_map.2 ⟨[], mem_sublists.2 (nil_sublist _), by rfl⟩).trans
+        ((append_sublist_append_right _).2 ih)
 
 /-! ### sublistsLen -/
 
@@ -387,11 +387,11 @@ theorem revzip_sublists (l : List α) : ∀ l₁ l₂, (l₁, l₂) ∈ revzip l
 
 theorem revzip_sublists' (l : List α) : ∀ l₁ l₂, (l₁, l₂) ∈ revzip l.sublists' → l₁ ++ l₂ ~ l := by
   rw [revzip]
-  induction l with <;> intro l₁ l₂ h
-  | nil =>
+  induction l <;> intro l₁ l₂ h
+  case nil =>
     simp_all only [sublists'_nil, reverse_cons, reverse_nil, nil_append, zip_cons_cons,
       zip_nil_right, mem_singleton, Prod.mk.injEq, append_nil, Perm.refl]
-  | cons a l IH =>
+  case cons a l IH =>
     rw [sublists'_cons, reverse_append, zip_append, ← map_reverse, zip_map_right, zip_map_left] at *
       <;> [simp only [mem_append, mem_map, Prod.map_apply, id_eq, Prod.mk.injEq, Prod.exists,
         exists_eq_right_right] at h; simp]

--- a/Mathlib/Data/List/Zip.lean
+++ b/Mathlib/Data/List/Zip.lean
@@ -123,9 +123,10 @@ theorem revzip_swap (l : List α) : (revzip l).map Prod.swap = revzip l.reverse 
 
 theorem mem_zip_inits_tails {l : List α} {init tail : List α} :
     (init, tail) ∈ zip l.inits l.tails ↔ init ++ tail = l := by
-  induction' l with hd tl ih generalizing init tail <;> simp_rw [tails, inits, zip_cons_cons]
-  · simp
-  · constructor <;> rw [mem_cons, zip_map_left, mem_map, Prod.exists]
+  induction l generalizing init tail with <;> simp_rw [tails, inits, zip_cons_cons]
+  | nil => simp
+  | cons hd tl ih =>
+    constructor <;> rw [mem_cons, zip_map_left, mem_map, Prod.exists]
     · rintro (⟨rfl, rfl⟩ | ⟨_, _, h, rfl, rfl⟩)
       · simp
       · simp [ih.mp h]

--- a/Mathlib/Data/List/Zip.lean
+++ b/Mathlib/Data/List/Zip.lean
@@ -123,9 +123,9 @@ theorem revzip_swap (l : List α) : (revzip l).map Prod.swap = revzip l.reverse 
 
 theorem mem_zip_inits_tails {l : List α} {init tail : List α} :
     (init, tail) ∈ zip l.inits l.tails ↔ init ++ tail = l := by
-  induction l generalizing init tail with <;> simp_rw [tails, inits, zip_cons_cons]
-  | nil => simp
-  | cons hd tl ih =>
+  induction l generalizing init tail <;> simp_rw [tails, inits, zip_cons_cons]
+  case nil => simp
+  case cons hd tl ih =>
     constructor <;> rw [mem_cons, zip_map_left, mem_map, Prod.exists]
     · rintro (⟨rfl, rfl⟩ | ⟨_, _, h, rfl, rfl⟩)
       · simp

--- a/Mathlib/Data/Multiset/Antidiagonal.lean
+++ b/Mathlib/Data/Multiset/Antidiagonal.lean
@@ -77,9 +77,10 @@ theorem antidiagonal_cons (a : α) (s) :
 
 theorem antidiagonal_eq_map_powerset [DecidableEq α] (s : Multiset α) :
     s.antidiagonal = s.powerset.map fun t ↦ (s - t, t) := by
-  induction' s using Multiset.induction_on with a s hs
-  · simp only [antidiagonal_zero, powerset_zero, Multiset.zero_sub, map_singleton]
-  · simp_rw [antidiagonal_cons, powerset_cons, map_add, hs, map_map, Function.comp, Prod.map_apply,
+  induction s using Multiset.induction_on with
+  | empty => simp only [antidiagonal_zero, powerset_zero, Multiset.zero_sub, map_singleton]
+  | cons a s hs =>
+    simp_rw [antidiagonal_cons, powerset_cons, map_add, hs, map_map, Function.comp, Prod.map_apply,
       id, sub_cons, erase_cons_head]
     rw [add_comm]
     congr 1

--- a/Mathlib/Data/Multiset/Bind.lean
+++ b/Mathlib/Data/Multiset/Bind.lean
@@ -225,9 +225,9 @@ variable (op : α → α → α) [hc : Std.Commutative op] [ha : Std.Associative
 theorem fold_bind {ι : Type*} (s : Multiset ι) (t : ι → Multiset α) (b : ι → α) (b₀ : α) :
     (s.bind t).fold op ((s.map b).fold op b₀) =
     (s.map fun i => (t i).fold op (b i)).fold op b₀ := by
-  induction' s using Multiset.induction_on with a ha ih
-  · rw [zero_bind, map_zero, map_zero, fold_zero]
-  · rw [cons_bind, map_cons, map_cons, fold_cons_left, fold_cons_left, fold_add, ih]
+  induction s using Multiset.induction_on with
+  | empty => rw [zero_bind, map_zero, map_zero, fold_zero]
+  | cons a ha ih => rw [cons_bind, map_cons, map_cons, fold_cons_left, fold_cons_left, fold_add, ih]
 
 end Bind
 

--- a/Mathlib/Data/Multiset/DershowitzManna.lean
+++ b/Mathlib/Data/Multiset/DershowitzManna.lean
@@ -135,8 +135,9 @@ private lemma transGen_oneStep_of_isDershowitzMannaLT :
     IsDershowitzMannaLT M N → TransGen OneStep M N := by
   classical
   rintro ⟨X, Y, Z, hZ, hM, hN, hYZ⟩
-  induction' Z using Multiset.induction_on with z Z ih generalizing X Y M N
-  · simp at hZ
+  induction Z using Multiset.induction_on generalizing X Y M N with
+  | empty => simp at hZ
+  | cons z Z ih => ?_
   obtain rfl | hZ := eq_or_ne Z 0
   · exact .single ⟨X, Y, z, hM, hN, by simpa using hYZ⟩
   let Y' : Multiset α := Y.filter (· < z)

--- a/Mathlib/Data/Multiset/Pi.lean
+++ b/Mathlib/Data/Multiset/Pi.lean
@@ -154,10 +154,12 @@ protected theorem Nodup.pi {s : Multiset α} {t : ∀ a, Multiset (β a)} :
 theorem mem_pi (m : Multiset α) (t : ∀ a, Multiset (β a)) :
     ∀ f : ∀ a ∈ m, β a, f ∈ pi m t ↔ ∀ (a) (h : a ∈ m), f a h ∈ t a := by
   intro f
-  induction' m using Multiset.induction_on with a m ih
-  · have : f = Pi.empty β := funext (fun _ => funext fun h => (not_mem_zero _ h).elim)
+  induction m using Multiset.induction_on with
+  | empty =>
+    have : f = Pi.empty β := funext (fun _ => funext fun h => (not_mem_zero _ h).elim)
     simp only [this, pi_zero, mem_singleton, true_iff]
     intro _ h; exact (not_mem_zero _ h).elim
+  | cons a m ih => ?_
   simp_rw [pi_cons, mem_bind, mem_map, ih]
   constructor
   · rintro ⟨b, hb, f', hf', rfl⟩ a' ha'

--- a/Mathlib/Data/Multiset/Powerset.lean
+++ b/Mathlib/Data/Multiset/Powerset.lean
@@ -180,8 +180,9 @@ theorem powersetCardAux_cons (n : ℕ) (a : α) (l : List α) :
 
 theorem powersetCardAux_perm {n} {l₁ l₂ : List α} (p : l₁ ~ l₂) :
     powersetCardAux n l₁ ~ powersetCardAux n l₂ := by
-  induction' n with n IHn generalizing l₁ l₂
-  · simp
+  induction n generalizing l₁ l₂ with
+  | zero => simp
+  | succ n IHn => ?_
   induction p with
   | nil => rfl
   | cons _ p IH =>

--- a/Mathlib/Data/Nat/BitIndices.lean
+++ b/Mathlib/Data/Nat/BitIndices.lean
@@ -64,8 +64,9 @@ theorem bitIndices_bit_false (n : ℕ) :
 
 @[simp] theorem bitIndices_two_pow_mul (k n : ℕ) :
     bitIndices (2^k * n) = (bitIndices n).map (· + k) := by
-  induction' k with k ih
-  · simp
+  induction k with
+  | zero => simp
+  | succ k ih => ?_
   rw [add_comm, pow_add, pow_one, mul_assoc, bitIndices_two_mul, ih, List.map_map, comp_add_right]
   simp [add_comm (a := 1)]
 

--- a/Mathlib/Data/Nat/ChineseRemainder.lean
+++ b/Mathlib/Data/Nat/ChineseRemainder.lean
@@ -29,9 +29,10 @@ variable {ι : Type*}
 
 lemma modEq_list_prod_iff {a b} {l : List ℕ} (co : l.Pairwise Coprime) :
     a ≡ b [MOD l.prod] ↔ ∀ i, a ≡ b [MOD l.get i] := by
-  induction' l with m l ih
-  · simp [modEq_one]
-  · have : Coprime m l.prod := coprime_list_prod_right_iff.mpr (List.pairwise_cons.mp co).1
+  induction l with
+  | nil => simp [modEq_one]
+  | cons m l ih =>
+    have : Coprime m l.prod := coprime_list_prod_right_iff.mpr (List.pairwise_cons.mp co).1
     simp only [List.prod_cons, ← modEq_and_modEq_iff_modEq_mul this, ih (List.Pairwise.of_cons co),
       List.length_cons]
     constructor
@@ -41,9 +42,10 @@ lemma modEq_list_prod_iff {a b} {l : List ℕ} (co : l.Pairwise Coprime) :
 
 lemma modEq_list_prod_iff' {a b} {s : ι → ℕ} {l : List ι} (co : l.Pairwise (Coprime on s)) :
     a ≡ b [MOD (l.map s).prod] ↔ ∀ i ∈ l, a ≡ b [MOD s i] := by
-  induction' l with i l ih
-  · simp [modEq_one]
-  · have : Coprime (s i) (l.map s).prod := by
+  induction l with
+  | nil => simp [modEq_one]
+  | cons i l ih =>
+    have : Coprime (s i) (l.map s).prod := by
       simp only [coprime_list_prod_right_iff, List.mem_map, forall_exists_index, and_imp,
         forall_apply_eq_imp_iff₂]
       intro j hj
@@ -94,9 +96,10 @@ theorem chineseRemainderOfList_lt_prod (l : List ι)
 theorem chineseRemainderOfList_modEq_unique (l : List ι)
     (co : l.Pairwise (Coprime on s)) {z} (hz : ∀ i ∈ l, z ≡ a i [MOD s i]) :
     z ≡ chineseRemainderOfList a s l co [MOD (l.map s).prod] := by
-  induction' l with i l ih
-  · simp [modEq_one]
-  · simp only [List.map_cons, List.prod_cons, chineseRemainderOfList]
+  induction l with
+  | nil => simp [modEq_one]
+  | cons i l ih =>
+    simp only [List.map_cons, List.prod_cons, chineseRemainderOfList]
     have : Coprime (s i) (l.map s).prod := by
       simp only [coprime_list_prod_right_iff, List.mem_map, forall_exists_index, and_imp,
         forall_apply_eq_imp_iff₂]

--- a/Mathlib/Data/Nat/Choose/Basic.lean
+++ b/Mathlib/Data/Nat/Choose/Basic.lean
@@ -104,9 +104,10 @@ theorem triangle_succ (n : ℕ) : (n + 1) * (n + 1 - 1) / 2 = n * (n - 1) / 2 + 
 
 /-- `choose n 2` is the `n`-th triangle number. -/
 theorem choose_two_right (n : ℕ) : choose n 2 = n * (n - 1) / 2 := by
-  induction' n with n ih
-  · simp
-  · rw [triangle_succ n, choose, ih]
+  induction n with
+  | zero => simp
+  | succ n ih =>
+    rw [triangle_succ n, choose, ih]
     simp [Nat.add_comm]
 
 theorem choose_pos : ∀ {n k}, k ≤ n → 0 < choose n k
@@ -312,8 +313,9 @@ theorem choose_le_succ (a c : ℕ) : choose a c ≤ choose a.succ c := by
   cases c <;> simp [Nat.choose_succ_succ]
 
 theorem choose_le_add (a b c : ℕ) : choose a c ≤ choose (a + b) c := by
-  induction' b with b_n b_ih
-  · simp
+  induction b with
+  | zero => simp
+  | succ b_n b_ih => ?_
   exact le_trans b_ih (choose_le_succ (a + b_n) c)
 
 theorem choose_le_choose {a b : ℕ} (c : ℕ) (h : a ≤ b) : choose a c ≤ choose b c :=

--- a/Mathlib/Data/Nat/Choose/Central.lean
+++ b/Mathlib/Data/Nat/Choose/Central.lean
@@ -76,7 +76,8 @@ This bound is of interest because it appears in
 [Tochiori's refinement of Erdős's proof of Bertrand's postulate](tochiori_bertrand).
 -/
 theorem four_pow_lt_mul_centralBinom (n : ℕ) (n_big : 4 ≤ n) : 4 ^ n < n * centralBinom n := by
-  induction' n using Nat.strong_induction_on with n IH
+  induction n using Nat.strong_induction_on with
+  | h n IH => ?_
   rcases lt_trichotomy n 4 with (hn | rfl | hn)
   · clear IH; exact False.elim ((not_lt.2 n_big) hn)
   · norm_num [centralBinom, choose]

--- a/Mathlib/Data/Nat/Choose/Multinomial.lean
+++ b/Mathlib/Data/Nat/Choose/Multinomial.lean
@@ -257,8 +257,9 @@ theorem sum_pow_of_commute (x : α → R) (s : Finset α)
           k.1.1.multinomial *
             (k.1.1.map <| x).noncommProd
               (Multiset.map_set_pairwise <| hc.mono <| mem_sym_iff.1 k.2) := by
-  induction' s using Finset.induction with a s ha ih
-  · rw [sum_empty]
+  induction s using Finset.induction with
+  | empty =>
+    rw [sum_empty]
     rintro (_ | n)
     · rw [_root_.pow_zero, Fintype.sum_subsingleton]
       swap
@@ -269,6 +270,7 @@ theorem sum_pow_of_commute (x : α → R) (s : Finset α)
     · rw [_root_.pow_succ, mul_zero]
       haveI : IsEmpty (Finset.sym (∅ : Finset α) n.succ) := Finset.instIsEmpty
       apply (Fintype.sum_empty _).symm
+  | @insert a s ha ih => ?_
   intro n; specialize ih (hc.mono <| s.subset_insert a)
   rw [sum_insert ha, (Commute.sum_right s _ _ _).add_pow, sum_range]; swap
   · exact fun _ hb => hc (mem_insert_self a s) (mem_insert_of_mem hb)

--- a/Mathlib/Data/Nat/Factorial/Cast.lean
+++ b/Mathlib/Data/Nat/Factorial/Cast.lean
@@ -34,9 +34,10 @@ theorem cast_ascFactorial : a.ascFactorial b = (ascPochhammer S b).eval (a : S) 
 theorem cast_descFactorial :
     a.descFactorial b = (ascPochhammer S b).eval (a - (b - 1) : S) := by
   rw [← ascPochhammer_eval_cast, ascPochhammer_nat_eq_descFactorial]
-  induction' b with b
-  · simp
-  · simp_rw [add_succ, Nat.add_one_sub_one]
+  induction b with
+  | zero => simp
+  | succ b =>
+    simp_rw [add_succ, Nat.add_one_sub_one]
     obtain h | h := le_total a b
     · rw [descFactorial_of_lt (lt_succ_of_le h), descFactorial_of_lt (lt_succ_of_le _)]
       rw [tsub_eq_zero_iff_le.mpr h, zero_add]

--- a/Mathlib/Data/Nat/Factorial/SuperFactorial.lean
+++ b/Mathlib/Data/Nat/Factorial/SuperFactorial.lean
@@ -72,9 +72,10 @@ variable {R : Type*} [CommRing R]
 
 theorem det_vandermonde_id_eq_superFactorial (n : ℕ) :
     (Matrix.vandermonde (fun (i : Fin (n + 1)) ↦ (i : R))).det = Nat.superFactorial n := by
-  induction' n with n hn
-  · simp [Matrix.det_vandermonde]
-  · rw [Nat.superFactorial, Matrix.det_vandermonde, Fin.prod_univ_succAbove _ 0]
+  induction n with
+  | zero => simp [Matrix.det_vandermonde]
+  | succ n hn =>
+    rw [Nat.superFactorial, Matrix.det_vandermonde, Fin.prod_univ_succAbove _ 0]
     push_cast
     congr
     · simp only [Fin.val_zero, Nat.cast_zero, sub_zero]

--- a/Mathlib/Data/Nat/Factorization/Basic.lean
+++ b/Mathlib/Data/Nat/Factorization/Basic.lean
@@ -573,15 +573,17 @@ theorem prod_pow_prime_padicValNat (n : Nat) (hn : n ≠ 0) (m : Nat) (pr : n < 
 /-- Exactly `n / p` naturals in `[1, n]` are multiples of `p`.
 See `Nat.card_multiples'` for an alternative spelling of the statement. -/
 theorem card_multiples (n p : ℕ) : #{e ∈ range n | p ∣ e + 1} = n / p := by
-  induction' n with n hn
-  · simp
+  induction n with
+  | zero => simp
+  | succ n hn => ?_
   simp [Nat.succ_div, add_ite, add_zero, Finset.range_succ, filter_insert, apply_ite card,
     card_insert_of_not_mem, hn]
 
 /-- Exactly `n / p` naturals in `(0, n]` are multiples of `p`. -/
 theorem Ioc_filter_dvd_card_eq_div (n p : ℕ) : #{x ∈ Ioc 0 n | p ∣ x} = n / p := by
-  induction' n with n IH
-  · simp
+  induction n with
+  | zero => simp
+  | succ n IH => ?_
   -- TODO: Golf away `h1` after Yaël PRs a lemma asserting this
   have h1 : Ioc 0 n.succ = insert n.succ (Ioc 0 n) := by
     rcases n.eq_zero_or_pos with (rfl | hn)

--- a/Mathlib/Data/Nat/Factorization/Induction.lean
+++ b/Mathlib/Data/Nat/Factorization/Induction.lean
@@ -78,9 +78,10 @@ lemma _root_.induction_on_primes {P : ℕ → Prop} (h₀ : P 0) (h₁ : P 1)
     (h : ∀ p a : ℕ, p.Prime → P a → P (p * a)) : ∀ n, P n := by
   refine recOnPrimePow h₀ h₁ ?_
   rintro a p n hp - - ha
-  induction' n with n ih
-  · simpa using ha
-  · rw [pow_succ', mul_assoc]
+  induction n with
+  | zero => simpa using ha
+  | succ n ih =>
+    rw [pow_succ', mul_assoc]
     exact h _ _ hp ih
 
 lemma prime_composite_induction {P : ℕ → Prop} (zero : P 0) (one : P 1)

--- a/Mathlib/Data/Nat/Fib/Basic.lean
+++ b/Mathlib/Data/Nat/Fib/Basic.lean
@@ -120,10 +120,12 @@ lemma fib_lt_fib {m : ℕ} (hm : 2 ≤ m) : ∀ {n}, fib m < fib n ↔ m < n
   | n + 2 => fib_strictMonoOn.lt_iff_lt hm <| by simp
 
 theorem le_fib_self {n : ℕ} (five_le_n : 5 ≤ n) : n ≤ fib n := by
-  induction' five_le_n with n five_le_n IH
-  · -- 5 ≤ fib 5
+  induction five_le_n with
+  | zero =>
+    -- 5 ≤ fib 5
     rfl
-  · -- n + 1 ≤ fib (n + 1) for 5 ≤ n
+  | succ n five_le_n =>
+    -- n + 1 ≤ fib (n + 1) for 5 ≤ n
     rw [succ_le_iff]
     calc
       n ≤ fib n := IH
@@ -140,15 +142,16 @@ lemma le_fib_add_one : ∀ n, n ≤ fib n + 1
 /-- Subsequent Fibonacci numbers are coprime,
   see https://proofwiki.org/wiki/Consecutive_Fibonacci_Numbers_are_Coprime -/
 theorem fib_coprime_fib_succ (n : ℕ) : Nat.Coprime (fib n) (fib (n + 1)) := by
-  induction' n with n ih
-  · simp
-  · simp only [fib_add_two, coprime_add_self_right, Coprime, ih.symm]
+  induction n with
+  | zero => simp
+  | succ n ih => simp only [fib_add_two, coprime_add_self_right, Coprime, ih.symm]
 
 /-- See https://proofwiki.org/wiki/Fibonacci_Number_in_terms_of_Smaller_Fibonacci_Numbers -/
 theorem fib_add (m n : ℕ) : fib (m + n + 1) = fib m * fib n + fib (m + 1) * fib (n + 1) := by
-  induction' n with n ih generalizing m
-  · simp
-  · specialize ih (m + 1)
+  induction n generalizing m with
+  | zero => simp
+  | succ n ih =>
+    specialize ih (m + 1)
     rw [add_assoc m 1 n, add_comm 1 n] at ih
     simp only [fib_add_two, succ_eq_add_one, ih]
     ring
@@ -249,9 +252,10 @@ theorem fib_succ_eq_sum_choose :
     simp [choose_succ_succ, Finset.sum_add_distrib, add_left_comm]
 
 theorem fib_succ_eq_succ_sum (n : ℕ) : fib (n + 1) = (∑ k ∈ Finset.range n, fib k) + 1 := by
-  induction' n with n ih
-  · simp
-  · calc
+  induction n with
+  | zero => simp
+  | succ n ih =>
+    calc
       fib (n + 2) = fib n + fib (n + 1) := fib_add_two
       _ = (fib n + ∑ k ∈ Finset.range n, fib k) + 1 := by rw [ih, add_assoc]
       _ = (∑ k ∈ Finset.range (n + 1), fib k) + 1 := by simp [Finset.range_add_one]

--- a/Mathlib/Data/Nat/Fib/Basic.lean
+++ b/Mathlib/Data/Nat/Fib/Basic.lean
@@ -121,11 +121,8 @@ lemma fib_lt_fib {m : ℕ} (hm : 2 ≤ m) : ∀ {n}, fib m < fib n ↔ m < n
 
 theorem le_fib_self {n : ℕ} (five_le_n : 5 ≤ n) : n ≤ fib n := by
   induction five_le_n with
-  | zero =>
-    -- 5 ≤ fib 5
-    rfl
-  | succ n five_le_n =>
-    -- n + 1 ≤ fib (n + 1) for 5 ≤ n
+  | refl => rfl -- 5 ≤ fib 5
+  | @step n five_le_n IH => -- n + 1 ≤ fib (n + 1) for 5 ≤ n
     rw [succ_le_iff]
     calc
       n ≤ fib n := IH

--- a/Mathlib/Data/Nat/Hyperoperation.lean
+++ b/Mathlib/Data/Nat/Hyperoperation.lean
@@ -52,57 +52,67 @@ theorem hyperoperation_recursion (n m k : ℕ) :
 @[simp]
 theorem hyperoperation_one : hyperoperation 1 = (· + ·) := by
   ext m k
-  induction' k with bn bih
-  · rw [Nat.add_zero m, hyperoperation]
-  · rw [hyperoperation_recursion, bih, hyperoperation_zero]
+  induction k with
+  | zero => rw [Nat.add_zero m, hyperoperation]
+  | succ bn bih =>
+    rw [hyperoperation_recursion, bih, hyperoperation_zero]
     exact Nat.add_assoc m bn 1
 
 @[simp]
 theorem hyperoperation_two : hyperoperation 2 = (· * ·) := by
   ext m k
-  induction' k with bn bih
-  · rw [hyperoperation]
+  induction k with
+  | zero =>
+    rw [hyperoperation]
     exact (Nat.mul_zero m).symm
-  · rw [hyperoperation_recursion, hyperoperation_one, bih]
+  | succ bn bih =>
+    rw [hyperoperation_recursion, hyperoperation_one, bih]
     ring
 
 @[simp]
 theorem hyperoperation_three : hyperoperation 3 = (· ^ ·) := by
   ext m k
-  induction' k with bn bih
-  · rw [hyperoperation_ge_three_eq_one]
+  induction k with
+  | zero =>
+    rw [hyperoperation_ge_three_eq_one]
     exact (pow_zero m).symm
-  · rw [hyperoperation_recursion, hyperoperation_two, bih]
+  | succ bn bih =>
+    rw [hyperoperation_recursion, hyperoperation_two, bih]
     exact (pow_succ' m bn).symm
 
 theorem hyperoperation_ge_two_eq_self (n m : ℕ) : hyperoperation (n + 2) m 1 = m := by
-  induction' n with nn nih
-  · rw [hyperoperation_two]
+  induction n with
+  | zero =>
+    rw [hyperoperation_two]
     ring
-  · rw [hyperoperation_recursion, hyperoperation_ge_three_eq_one, nih]
+  | succ nn nih => rw [hyperoperation_recursion, hyperoperation_ge_three_eq_one, nih]
 
 theorem hyperoperation_two_two_eq_four (n : ℕ) : hyperoperation (n + 1) 2 2 = 4 := by
-  induction' n with nn nih
-  · rw [hyperoperation_one]
-  · rw [hyperoperation_recursion, hyperoperation_ge_two_eq_self, nih]
+  induction n with
+  | zero => rw [hyperoperation_one]
+  | succ nn nih => rw [hyperoperation_recursion, hyperoperation_ge_two_eq_self, nih]
 
 theorem hyperoperation_ge_three_one (n : ℕ) : ∀ k : ℕ, hyperoperation (n + 3) 1 k = 1 := by
-  induction' n with nn nih
-  · intro k
+  induction n with
+  | zero =>
+    intro k
     rw [hyperoperation_three]
     dsimp
     rw [one_pow]
-  · intro k
+  | succ nn nih =>
+    intro k
     cases k
     · rw [hyperoperation_ge_three_eq_one]
     · rw [hyperoperation_recursion, nih]
 
 theorem hyperoperation_ge_four_zero (n k : ℕ) :
     hyperoperation (n + 4) 0 k = if Even k then 1 else 0 := by
-  induction' k with kk kih
-  · rw [hyperoperation_ge_three_eq_one]
+  induction k with
+  | zero =>
+    rw [hyperoperation_ge_three_eq_one]
     simp only [Even.zero, if_true]
-  · rw [hyperoperation_recursion]
+  | succ kk kih =>
+    rw [hyperoperation_recursion]
     rw [kih]
     simp_rw [Nat.even_add_one]
     split_ifs

--- a/Mathlib/Data/Nat/Multiplicity.lean
+++ b/Mathlib/Data/Nat/Multiplicity.lean
@@ -153,9 +153,10 @@ theorem emultiplicity_factorial_mul_succ {n p : ℕ} (hp : p.Prime) :
 /-- The multiplicity of `p` in `(p * n)!` is `n` more than that of `n!`. -/
 theorem emultiplicity_factorial_mul {n p : ℕ} (hp : p.Prime) :
     emultiplicity p (p * n)! = emultiplicity p n ! + n := by
-  induction' n with n ih
-  · simp
-  · simp only [hp, emultiplicity_factorial_mul_succ, ih, factorial_succ, emultiplicity_mul,
+  induction n with
+  | zero => simp
+  | succ n ih =>
+    simp only [hp, emultiplicity_factorial_mul_succ, ih, factorial_succ, emultiplicity_mul,
     cast_add, cast_one, ← add_assoc]
     congr 1
     rw [add_comm, add_assoc]

--- a/Mathlib/Data/Nat/Nth.lean
+++ b/Mathlib/Data/Nat/Nth.lean
@@ -361,9 +361,10 @@ theorem filter_range_nth_eq_insert_of_infinite (hp : (setOf p).Infinite) (k : �
 
 theorem count_nth {n : ℕ} (hn : ∀ hf : (setOf p).Finite, n < #hf.toFinset) :
     count p (nth p n) = n := by
-  induction' n with k ihk
-  · exact count_nth_zero _
-  · rw [count_eq_card_filter_range, filter_range_nth_eq_insert hn, card_insert_of_not_mem, ←
+  induction n with
+  | zero => exact count_nth_zero _
+  | succ k ihk =>
+    rw [count_eq_card_filter_range, filter_range_nth_eq_insert hn, card_insert_of_not_mem, ←
       count_eq_card_filter_range, ihk fun hf => lt_of_succ_lt (hn hf)]
     simp
 

--- a/Mathlib/Data/Nat/PrimeFin.lean
+++ b/Mathlib/Data/Nat/PrimeFin.lean
@@ -103,9 +103,9 @@ protected lemma Coprime.disjoint_primeFactors (hab : Coprime a b) :
 lemma primeFactors_pow_succ (n k : ℕ) : (n ^ (k + 1)).primeFactors = n.primeFactors := by
   rcases eq_or_ne n 0 with (rfl | hn)
   · simp
-  induction' k with k ih
-  · simp
-  · rw [pow_succ', primeFactors_mul hn (pow_ne_zero _ hn), ih, Finset.union_idempotent]
+  induction k with
+  | zero => simp
+  | succ k ih => rw [pow_succ', primeFactors_mul hn (pow_ne_zero _ hn), ih, Finset.union_idempotent]
 
 lemma primeFactors_pow (n : ℕ) (hk : k ≠ 0) : (n ^ k).primeFactors = n.primeFactors := by
   cases k

--- a/Mathlib/Data/Nat/Totient.lean
+++ b/Mathlib/Data/Nat/Totient.lean
@@ -76,11 +76,13 @@ theorem filter_coprime_Ico_eq_totient (a n : ℕ) :
 theorem Ico_filter_coprime_le {a : ℕ} (k n : ℕ) (a_pos : 0 < a) :
     #{x ∈ Ico k (k + n) | a.Coprime x} ≤ totient a * (n / a + 1) := by
   conv_lhs => rw [← Nat.mod_add_div n a]
-  induction' n / a with i ih
-  · rw [← filter_coprime_Ico_eq_totient a k]
+  induction n / a with
+  | zero =>
+    rw [← filter_coprime_Ico_eq_totient a k]
     simp only [add_zero, mul_one, mul_zero, le_of_lt (mod_lt n a_pos), zero_add]
     gcongr
     exact le_of_lt (mod_lt n a_pos)
+  | succ i ih => ?_
   simp only [mul_succ]
   simp_rw [← add_assoc] at ih ⊢
   calc

--- a/Mathlib/Data/Num/Lemmas.lean
+++ b/Mathlib/Data/Num/Lemmas.lean
@@ -817,8 +817,9 @@ theorem castNum_shiftLeft (m : Num) (n : Nat) : ↑(m <<< n) = (m : ℕ) <<< (n 
   · symm
     apply Nat.zero_shiftLeft
   simp only [cast_pos]
-  induction' n with n IH
-  · rfl
+  induction n with
+  | zero => rfl
+  | succ n IH => ?_
   simp [PosNum.shiftl_succ_eq_bit0_shiftl, Nat.shiftLeft_succ, IH, pow_succ, ← mul_assoc, mul_comm,
         -shiftl_eq_shiftLeft, -PosNum.shiftl_eq_shiftLeft, shiftl, mul_two]
 
@@ -827,8 +828,9 @@ theorem castNum_shiftRight (m : Num) (n : Nat) : ↑(m >>> n) = (m : ℕ) >>> (n
   obtain - | m := m <;> dsimp only [← shiftr_eq_shiftRight, shiftr]
   · symm
     apply Nat.zero_shiftRight
-  induction' n with n IH generalizing m
-  · cases m <;> rfl
+  induction n generalizing m with
+  | zero => cases m <;> rfl
+  | succ n IH => ?_
   have hdiv2 : ∀ m, Nat.div2 (m + m) = m := by intro; rw [Nat.div2_val]; omega
   obtain - | m | m := m <;> dsimp only [PosNum.shiftr, ← PosNum.shiftr_eq_shiftRight]
   · rw [Nat.shiftRight_eq_div_pow]

--- a/Mathlib/Data/Num/Prime.lean
+++ b/Mathlib/Data/Num/Prime.lean
@@ -39,17 +39,17 @@ def minFacAux (n : PosNum) : ℕ → PosNum → PosNum
 
 theorem minFacAux_to_nat {fuel : ℕ} {n k : PosNum} (h : Nat.sqrt n < fuel + k.bit1) :
     (minFacAux n fuel k : ℕ) = Nat.minFacAux n k.bit1 := by
-  induction fuel generalizing k with <;> rw [minFacAux, Nat.minFacAux]
-  | zero =>
+  induction fuel generalizing k <;> rw [minFacAux, Nat.minFacAux]
+  case zero =>
     rw [Nat.zero_add, Nat.sqrt_lt] at h
     simp only [h, ite_true]
-  | succ fuel ih => ?_
-  simp_rw [← mul_to_nat]
-  simp only [cast_lt, dvd_to_nat]
-  split_ifs <;> try rfl
-  rw [ih] <;> [congr; convert Nat.lt_succ_of_lt h using 1] <;>
-    simp only [cast_bit1, cast_succ, Nat.succ_eq_add_one, add_assoc,
-      add_left_comm, ← one_add_one_eq_two]
+  case succ fuel ih =>
+    simp_rw [← mul_to_nat]
+    simp only [cast_lt, dvd_to_nat]
+    split_ifs <;> try rfl
+    rw [ih] <;> [congr; convert Nat.lt_succ_of_lt h using 1] <;>
+      simp only [cast_bit1, cast_succ, Nat.succ_eq_add_one, add_assoc,
+        add_left_comm, ← one_add_one_eq_two]
 
 /-- Returns the smallest prime factor of `n ≠ 1`. -/
 def minFac : PosNum → PosNum

--- a/Mathlib/Data/Num/Prime.lean
+++ b/Mathlib/Data/Num/Prime.lean
@@ -39,9 +39,11 @@ def minFacAux (n : PosNum) : ℕ → PosNum → PosNum
 
 theorem minFacAux_to_nat {fuel : ℕ} {n k : PosNum} (h : Nat.sqrt n < fuel + k.bit1) :
     (minFacAux n fuel k : ℕ) = Nat.minFacAux n k.bit1 := by
-  induction' fuel with fuel ih generalizing k <;> rw [minFacAux, Nat.minFacAux]
-  · rw [Nat.zero_add, Nat.sqrt_lt] at h
+  induction fuel generalizing k with <;> rw [minFacAux, Nat.minFacAux]
+  | zero =>
+    rw [Nat.zero_add, Nat.sqrt_lt] at h
     simp only [h, ite_true]
+  | succ fuel ih => ?_
   simp_rw [← mul_to_nat]
   simp only [cast_lt, dvd_to_nat]
   split_ifs <;> try rfl

--- a/Mathlib/Data/Real/Cardinality.lean
+++ b/Mathlib/Data/Real/Cardinality.lean
@@ -114,8 +114,9 @@ theorem increasing_cantorFunction (h1 : 0 < c) (h2 : c < 1 / 2) {n : ℕ} {f g :
   have h3 : c < 1 := by
     apply h2.trans
     norm_num
-  induction' n with n ih generalizing f g
-  · let f_max : ℕ → Bool := fun n => Nat.rec false (fun _ _ => true) n
+  induction n generalizing f g with
+  | zero =>
+    let f_max : ℕ → Bool := fun n => Nat.rec false (fun _ _ => true) n
     have hf_max : ∀ n, f n → f_max n := by
       intro n hn
       cases n
@@ -145,6 +146,7 @@ theorem increasing_cantorFunction (h1 : 0 < c) (h2 : c < 1 / 2) {n : ℕ} {f g :
         · contradiction
         rfl
       · exact cantorFunctionAux_zero _
+  | succ n ih => ?_
   rw [cantorFunction_succ f (le_of_lt h1) h3, cantorFunction_succ g (le_of_lt h1) h3]
   rw [hn 0 <| zero_lt_succ n]
   apply add_lt_add_left

--- a/Mathlib/Data/Real/Pi/Wallis.lean
+++ b/Mathlib/Data/Real/Pi/Wallis.lean
@@ -48,19 +48,22 @@ theorem W_succ (k : ℕ) :
   prod_range_succ _ _
 
 theorem W_pos (k : ℕ) : 0 < W k := by
-  induction' k with k hk
-  · unfold W; simp
-  · rw [W_succ]
+  induction k with
+  | zero => unfold W; simp
+  | succ k hk =>
+    rw [W_succ]
     refine mul_pos hk (mul_pos (div_pos ?_ ?_) (div_pos ?_ ?_)) <;> positivity
 
 theorem W_eq_factorial_ratio (n : ℕ) :
     W n = 2 ^ (4 * n) * n ! ^ 4 / ((2 * n)! ^ 2 * (2 * n + 1)) := by
-  induction' n with n IH
-  · simp only [W, prod_range_zero, Nat.factorial_zero, mul_zero, pow_zero,
+  induction n with
+  | zero =>
+    simp only [W, prod_range_zero, Nat.factorial_zero, mul_zero, pow_zero,
       algebraMap.coe_one, one_pow, mul_one, algebraMap.coe_zero, zero_add, div_self, Ne,
       one_ne_zero, not_false_iff]
     norm_num
-  · unfold W at IH ⊢
+  | succ n IH =>
+    unfold W at IH ⊢
     rw [prod_range_succ, IH, _root_.div_mul_div_comm, _root_.div_mul_div_comm]
     refine (div_eq_div_iff ?_ ?_).mpr ?_
     any_goals exact ne_of_gt (by positivity)

--- a/Mathlib/Data/Seq/Computation.lean
+++ b/Mathlib/Data/Seq/Computation.lean
@@ -102,10 +102,11 @@ theorem destruct_eq_pure {s : Computation α} {a : α} : destruct s = Sum.inl a 
   · contradiction
   · apply Subtype.eq
     funext n
-    induction' n with n IH
-    · injection h with h'
+    induction n with
+    | zero =>
+      injection h with h'
       rwa [h'] at f0
-    · exact s.2 IH
+    | succ n IH => exact s.2 IH
 
 theorem destruct_eq_think {s : Computation α} {s'} : destruct s = Sum.inr s' → s = think s' := by
   dsimp [destruct]
@@ -187,12 +188,14 @@ def corec (f : β → α ⊕ β) (b : β) : Computation α := by
   rw [Stream'.corec'_eq]
   change Stream'.corec' (Corec.f f) (Corec.f f (Sum.inr b)).2 n = some a'
   revert h; generalize Sum.inr b = o; revert o
-  induction' n with n IH <;> intro o
-  · change (Corec.f f o).1 = some a' → (Corec.f f (Corec.f f o).2).1 = some a'
+  induction n with <;> intro o
+  | zero =>
+    change (Corec.f f o).1 = some a' → (Corec.f f (Corec.f f o).2).1 = some a'
     rcases o with _ | b <;> intro h
     · exact h
     unfold Corec.f at *; split <;> simp_all
-  · rw [Stream'.corec'_eq (Corec.f f) (Corec.f f o).2, Stream'.corec'_eq (Corec.f f) o]
+  | succ n IH =>
+    rw [Stream'.corec'_eq (Corec.f f) (Corec.f f o).2, Stream'.corec'_eq (Corec.f f) o]
     exact IH (Corec.f f o).2
 
 /-- left map of `⊕` -/

--- a/Mathlib/Data/Seq/Computation.lean
+++ b/Mathlib/Data/Seq/Computation.lean
@@ -188,13 +188,13 @@ def corec (f : β → α ⊕ β) (b : β) : Computation α := by
   rw [Stream'.corec'_eq]
   change Stream'.corec' (Corec.f f) (Corec.f f (Sum.inr b)).2 n = some a'
   revert h; generalize Sum.inr b = o; revert o
-  induction n with <;> intro o
-  | zero =>
+  induction n <;> intro o
+  case zero =>
     change (Corec.f f o).1 = some a' → (Corec.f f (Corec.f f o).2).1 = some a'
     rcases o with _ | b <;> intro h
     · exact h
     unfold Corec.f at *; split <;> simp_all
-  | succ n IH =>
+  case succ n IH =>
     rw [Stream'.corec'_eq (Corec.f f) (Corec.f f o).2, Stream'.corec'_eq (Corec.f f) o]
     exact IH (Corec.f f o).2
 

--- a/Mathlib/Data/Seq/Parallel.lean
+++ b/Mathlib/Data/Seq/Parallel.lean
@@ -119,8 +119,9 @@ theorem terminates_parallel {S : WSeq (Computation α)} {c} (h : c ∈ S) [T : T
     from
     let ⟨n, h⟩ := h
     this n [] S c (Or.inr h) T
-  intro n; induction' n with n IH <;> intro l S c o T
-  · rcases o with a | a
+  intro n; induction n with <;> intro l S c o T
+  | zero =>
+    rcases o with a | a
     · exact terminates_parallel.aux a T
     have H : Seq.destruct S = some (some c, Seq.tail S) := by simp [Seq.destruct, (· <$> ·), ← a]
     induction' h : parallel.aux2 l with a l'
@@ -138,7 +139,8 @@ theorem terminates_parallel {S : WSeq (Computation α)} {c} (h : c ∈ S) [T : T
       refine @Computation.think_terminates _ _ ?_
       apply terminates_parallel.aux _ T
       simp
-  · rcases o with a | a
+  | succ n IH =>
+    rcases o with a | a
     · exact terminates_parallel.aux a T
     induction' h : parallel.aux2 l with a l'
     · have C : corec parallel.aux1 (l, S) = pure a := by
@@ -187,11 +189,13 @@ theorem exists_of_mem_parallel {S : WSeq (Computation α)} {a} (h : a ∈ parall
     · exact ∀ a', (∃ c ∈ l', a' ∈ c) → ∃ c ∈ l, a' ∈ c
   have lem1 : ∀ l : List (Computation α), F l (parallel.aux2 l) := by
     intro l
-    induction' l with c l IH <;> simp only [parallel.aux2, List.foldr]
-    · intro a h
+    induction l with <;> simp only [parallel.aux2, List.foldr]
+    | nil =>
+      intro a h
       rcases h with ⟨c, hn, _⟩
       exact False.elim <| List.not_mem_nil hn
-    · simp only [parallel.aux2] at IH
+    | cons c l IH =>
+      simp only [parallel.aux2] at IH
       -- Porting note: `revert IH` & `intro IH` are required.
       revert IH
       cases List.foldr (fun c o =>

--- a/Mathlib/Data/Seq/Parallel.lean
+++ b/Mathlib/Data/Seq/Parallel.lean
@@ -119,8 +119,8 @@ theorem terminates_parallel {S : WSeq (Computation α)} {c} (h : c ∈ S) [T : T
     from
     let ⟨n, h⟩ := h
     this n [] S c (Or.inr h) T
-  intro n; induction n with <;> intro l S c o T
-  | zero =>
+  intro n; induction n <;> intro l S c o T
+  case zero =>
     rcases o with a | a
     · exact terminates_parallel.aux a T
     have H : Seq.destruct S = some (some c, Seq.tail S) := by simp [Seq.destruct, (· <$> ·), ← a]
@@ -139,7 +139,7 @@ theorem terminates_parallel {S : WSeq (Computation α)} {c} (h : c ∈ S) [T : T
       refine @Computation.think_terminates _ _ ?_
       apply terminates_parallel.aux _ T
       simp
-  | succ n IH =>
+  case succ n IH =>
     rcases o with a | a
     · exact terminates_parallel.aux a T
     induction' h : parallel.aux2 l with a l'
@@ -189,12 +189,12 @@ theorem exists_of_mem_parallel {S : WSeq (Computation α)} {a} (h : a ∈ parall
     · exact ∀ a', (∃ c ∈ l', a' ∈ c) → ∃ c ∈ l, a' ∈ c
   have lem1 : ∀ l : List (Computation α), F l (parallel.aux2 l) := by
     intro l
-    induction l with <;> simp only [parallel.aux2, List.foldr]
-    | nil =>
+    induction l <;> simp only [parallel.aux2, List.foldr]
+    case nil =>
       intro a h
       rcases h with ⟨c, hn, _⟩
       exact False.elim <| List.not_mem_nil hn
-    | cons c l IH =>
+    case cons c l IH =>
       simp only [parallel.aux2] at IH
       -- Porting note: `revert IH` & `intro IH` are required.
       revert IH

--- a/Mathlib/Data/Seq/Seq.lean
+++ b/Mathlib/Data/Seq/Seq.lean
@@ -323,8 +323,8 @@ def corec (f : β → Option (α × β)) (b : β) : Seq α := by
   rw [Stream'.corec'_eq]
   change Stream'.corec' (Corec.f f) (Corec.f f (some b)).2 n = none
   revert h; generalize some b = o; revert o
-  induction n with <;> intro o
-  | zero =>
+  induction n <;> intro o
+  case zero =>
     change (Corec.f f o).1 = none → (Corec.f f (Corec.f f o).2).1 = none
     rcases o with - | b <;> intro h
     · rfl
@@ -334,7 +334,7 @@ def corec (f : β → Option (α × β)) (b : β) : Seq α := by
     · rfl
     · obtain ⟨a, b'⟩ := s
       contradiction
-  | succ n IH =>
+  case succ n IH =>
     rw [Stream'.corec'_eq (Corec.f f) (Corec.f f o).2, Stream'.corec'_eq (Corec.f f) o]
     exact IH (Corec.f f o).2
 

--- a/Mathlib/Data/Seq/Seq.lean
+++ b/Mathlib/Data/Seq/Seq.lean
@@ -181,7 +181,7 @@ def destruct (s : Seq α) : Option (Seq1 α) :=
 
 theorem destruct_eq_none {s : Seq α} : destruct s = none → s = nil := by
   dsimp [destruct]
-  induction' f0 : get? s 0 <;> intro h
+  induction f0 : get? s 0 <;> intro h
   · apply Subtype.eq
     funext n
     induction' n with n IH
@@ -291,14 +291,16 @@ theorem head_eq_none_iff {s : Seq α} : s.head = none ↔ s = nil := by
 theorem mem_rec_on {C : Seq α → Prop} {a s} (M : a ∈ s)
     (h1 : ∀ b s', a = b ∨ C s' → C (cons b s')) : C s := by
   obtain ⟨k, e⟩ := M; unfold Stream'.get at e
-  induction' k with k IH generalizing s
-  · have TH : s = cons a (tail s) := by
+  induction k generalizing s with
+  | zero =>
+    have TH : s = cons a (tail s) := by
       apply destruct_eq_cons
       unfold destruct get? Functor.map
       rw [← e]
       rfl
     rw [TH]
     apply h1 _ _ (Or.inl rfl)
+  | succ k IH => ?_
   cases s with
   | nil => injection e
   | cons b s' =>
@@ -321,8 +323,9 @@ def corec (f : β → Option (α × β)) (b : β) : Seq α := by
   rw [Stream'.corec'_eq]
   change Stream'.corec' (Corec.f f) (Corec.f f (some b)).2 n = none
   revert h; generalize some b = o; revert o
-  induction' n with n IH <;> intro o
-  · change (Corec.f f o).1 = none → (Corec.f f (Corec.f f o).2).1 = none
+  induction n with <;> intro o
+  | zero =>
+    change (Corec.f f o).1 = none → (Corec.f f (Corec.f f o).2).1 = none
     rcases o with - | b <;> intro h
     · rfl
     dsimp [Corec.f] at h
@@ -331,7 +334,8 @@ def corec (f : β → Option (α × β)) (b : β) : Seq α := by
     · rfl
     · obtain ⟨a, b'⟩ := s
       contradiction
-  · rw [Stream'.corec'_eq (Corec.f f) (Corec.f f o).2, Stream'.corec'_eq (Corec.f f) o]
+  | succ n IH =>
+    rw [Stream'.corec'_eq (Corec.f f) (Corec.f f o).2, Stream'.corec'_eq (Corec.f f) o]
     exact IH (Corec.f f o).2
 
 @[simp]

--- a/Mathlib/Data/Vector/Basic.lean
+++ b/Mathlib/Data/Vector/Basic.lean
@@ -680,10 +680,10 @@ protected theorem comp_traverse (f : β → F γ) (g : α → G β) (x : Vector 
     Vector.traverse (Comp.mk ∘ Functor.map f ∘ g) x =
       Comp.mk (Vector.traverse f <$> Vector.traverse g x) := by
   induction x with
-  | zero =>
+  | nil =>
     simp! [cast, *, functor_norm]
     rfl
-  | succ n x =>
+  | cons ih =>
     rw [Vector.traverse_def, ih]
     simp [functor_norm, Function.comp_def]
 
@@ -696,8 +696,8 @@ variable [LawfulApplicative F] (η : ApplicativeTransformation F G)
 protected theorem naturality {α β : Type u} (f : α → F β) (x : Vector α n) :
     η (x.traverse f) = x.traverse (@η _ ∘ f) := by
   induction x with
-  | zero => simp! [functor_norm, cast, η.preserves_pure]
-  | succ n x =>
+  | nil => simp! [functor_norm, cast, η.preserves_pure]
+  | cons ih =>
     rw [Vector.traverse_def, Vector.traverse_def, ← ih, η.preserves_seq, η.preserves_map]
     rfl
 

--- a/Mathlib/Data/Vector/Basic.lean
+++ b/Mathlib/Data/Vector/Basic.lean
@@ -366,10 +366,12 @@ theorem scanl_get (i : Fin n) :
     (scanl f b v).get i.succ = f ((scanl f b v).get (Fin.castSucc i)) (v.get i) := by
   rcases n with - | n
   · exact i.elim0
-  induction' n with n hn generalizing b
-  · have i0 : i = 0 := Fin.eq_zero _
+  induction n generalizing b with
+  | zero =>
+    have i0 : i = 0 := Fin.eq_zero _
     simp [scanl_singleton, i0, get_zero]; simp [get_eq_get_toList, List.get]
-  · rw [← cons_head_tail v, scanl_cons, get_cons_succ]
+  | succ n hn =>
+    rw [← cons_head_tail v, scanl_cons, get_cons_succ]
     refine Fin.cases ?_ ?_ i
     · simp only [get_zero, scanl_head, Fin.castSucc_zero, head_cons]
     · intro i'
@@ -426,10 +428,12 @@ It is used as the default induction principle for the `induction` tactic.
 @[elab_as_elim, induction_eliminator]
 def inductionOn {C : ∀ {n : ℕ}, Vector α n → Sort*} {n : ℕ} (v : Vector α n)
     (nil : C nil) (cons : ∀ {n : ℕ} {x : α} {w : Vector α n}, C w → C (x ::ᵥ w)) : C v := by
-  induction' n with n ih
-  · rcases v with ⟨_ | ⟨-, -⟩, - | -⟩
+  induction n with
+  | zero =>
+    rcases v with ⟨_ | ⟨-, -⟩, - | -⟩
     exact nil
-  · rcases v with ⟨_ | ⟨a, v⟩, v_property⟩
+  | succ n ih =>
+    rcases v with ⟨_ | ⟨a, v⟩, v_property⟩
     cases v_property
     exact cons (ih ⟨v, (add_left_inj 1).mp v_property⟩)
 
@@ -453,11 +457,13 @@ def inductionOn₂ {C : ∀ {n}, Vector α n → Vector β n → Sort*}
     (v : Vector α n) (w : Vector β n)
     (nil : C nil nil) (cons : ∀ {n a b} {x : Vector α n} {y}, C x y → C (a ::ᵥ x) (b ::ᵥ y)) :
     C v w := by
-  induction' n with n ih
-  · rcases v with ⟨_ | ⟨-, -⟩, - | -⟩
+  induction n with
+  | zero =>
+    rcases v with ⟨_ | ⟨-, -⟩, - | -⟩
     rcases w with ⟨_ | ⟨-, -⟩, - | -⟩
     exact nil
-  · rcases v with ⟨_ | ⟨a, v⟩, v_property⟩
+  | succ n ih =>
+    rcases v with ⟨_ | ⟨a, v⟩, v_property⟩
     cases v_property
     rcases w with ⟨_ | ⟨b, w⟩, w_property⟩
     cases w_property
@@ -471,12 +477,14 @@ def inductionOn₃ {C : ∀ {n}, Vector α n → Vector β n → Vector γ n →
     (u : Vector α n) (v : Vector β n) (w : Vector γ n) (nil : C nil nil nil)
     (cons : ∀ {n a b c} {x : Vector α n} {y z}, C x y z → C (a ::ᵥ x) (b ::ᵥ y) (c ::ᵥ z)) :
     C u v w := by
-  induction' n with n ih
-  · rcases u with ⟨_ | ⟨-, -⟩, - | -⟩
+  induction n with
+  | zero =>
+    rcases u with ⟨_ | ⟨-, -⟩, - | -⟩
     rcases v with ⟨_ | ⟨-, -⟩, - | -⟩
     rcases w with ⟨_ | ⟨-, -⟩, - | -⟩
     exact nil
-  · rcases u with ⟨_ | ⟨a, u⟩, u_property⟩
+  | succ n ih =>
+    rcases u with ⟨_ | ⟨a, u⟩, u_property⟩
     cases u_property
     rcases v with ⟨_ | ⟨b, v⟩, v_property⟩
     cases v_property
@@ -671,10 +679,12 @@ variable {α β γ : Type u}
 protected theorem comp_traverse (f : β → F γ) (g : α → G β) (x : Vector α n) :
     Vector.traverse (Comp.mk ∘ Functor.map f ∘ g) x =
       Comp.mk (Vector.traverse f <$> Vector.traverse g x) := by
-  induction' x with n x xs ih
-  · simp! [cast, *, functor_norm]
+  induction x with
+  | zero =>
+    simp! [cast, *, functor_norm]
     rfl
-  · rw [Vector.traverse_def, ih]
+  | succ n x =>
+    rw [Vector.traverse_def, ih]
     simp [functor_norm, Function.comp_def]
 
 protected theorem traverse_eq_map_id {α β} (f : α → β) :
@@ -685,9 +695,10 @@ variable [LawfulApplicative F] (η : ApplicativeTransformation F G)
 
 protected theorem naturality {α β : Type u} (f : α → F β) (x : Vector α n) :
     η (x.traverse f) = x.traverse (@η _ ∘ f) := by
-  induction' x with n x xs ih
-  · simp! [functor_norm, cast, η.preserves_pure]
-  · rw [Vector.traverse_def, Vector.traverse_def, ← ih, η.preserves_seq, η.preserves_map]
+  induction x with
+  | zero => simp! [functor_norm, cast, η.preserves_pure]
+  | succ n x =>
+    rw [Vector.traverse_def, Vector.traverse_def, ← ih, η.preserves_seq, η.preserves_map]
     rfl
 
 end Traverse

--- a/Mathlib/Data/W/Basic.lean
+++ b/Mathlib/Data/W/Basic.lean
@@ -95,9 +95,10 @@ theorem infinite_of_nonempty_of_isEmpty (a b : α) [ha : Nonempty (β a)] [he : 
           show WType β from Nat.recOn n ⟨b, IsEmpty.elim' he⟩ fun _ ih => ⟨a, fun _ => ih⟩)
         ?_
     intro n m h
-    induction' n with n ih generalizing m
-    · rcases m with - | m <;> simp_all
-    · rcases m with - | m
+    induction n generalizing m with
+    | zero => rcases m with - | m <;> simp_all
+    | succ n ih =>
+      rcases m with - | m
       · simp_all
       · refine congr_arg Nat.succ (ih ?_)
         simp_all [funext_iff]⟩

--- a/Mathlib/Data/WSeq/Basic.lean
+++ b/Mathlib/Data/WSeq/Basic.lean
@@ -463,15 +463,15 @@ theorem mem_of_mem_dropn {s : WSeq α} {a} : ∀ {n}, a ∈ drop s n → a ∈ s
   | n + 1, h => @mem_of_mem_dropn s a n (mem_of_mem_tail h)
 
 theorem get?_mem {s : WSeq α} {a n} : some a ∈ get? s n → a ∈ s := by
-  revert s; induction n with <;> intro s h
-  | zero =>
+  revert s; induction n <;> intro s h
+  case zero =>
     rcases Computation.exists_of_mem_map h with ⟨o, h1, h2⟩
     rcases o with - | o
     · injection h2
     injection h2 with h'
     obtain ⟨a', s'⟩ := o
     exact (eq_or_mem_iff_mem h1).2 (Or.inl h'.symm)
-  | succ n IH =>
+  case succ n IH =>
     have := @IH (tail s)
     rw [get?_tail] at this
     exact mem_of_mem_tail (this h)

--- a/Mathlib/Data/WSeq/Basic.lean
+++ b/Mathlib/Data/WSeq/Basic.lean
@@ -463,14 +463,16 @@ theorem mem_of_mem_dropn {s : WSeq α} {a} : ∀ {n}, a ∈ drop s n → a ∈ s
   | n + 1, h => @mem_of_mem_dropn s a n (mem_of_mem_tail h)
 
 theorem get?_mem {s : WSeq α} {a n} : some a ∈ get? s n → a ∈ s := by
-  revert s; induction' n with n IH <;> intro s h
-  · rcases Computation.exists_of_mem_map h with ⟨o, h1, h2⟩
+  revert s; induction n with <;> intro s h
+  | zero =>
+    rcases Computation.exists_of_mem_map h with ⟨o, h1, h2⟩
     rcases o with - | o
     · injection h2
     injection h2 with h'
     obtain ⟨a', s'⟩ := o
     exact (eq_or_mem_iff_mem h1).2 (Or.inl h'.symm)
-  · have := @IH (tail s)
+  | succ n IH =>
+    have := @IH (tail s)
     rw [get?_tail] at this
     exact mem_of_mem_tail (this h)
 
@@ -608,9 +610,9 @@ theorem toList_nil : toList (nil : WSeq α) = Computation.pure [] :=
   destruct_eq_pure rfl
 
 theorem toList_ofList (l : List α) : l ∈ toList (ofList l) := by
-  induction' l with a l IH
-  · simp [ret_mem]
-  · simpa [ret_mem] using think_mem (Computation.mem_map _ IH)
+  induction l with
+  | nil => simp [ret_mem]
+  | cons a l IH => simpa [ret_mem] using think_mem (Computation.mem_map _ IH)
 
 @[simp]
 theorem destruct_ofSeq (s : Seq α) :

--- a/Mathlib/FieldTheory/Finite/Basic.lean
+++ b/Mathlib/FieldTheory/Finite/Basic.lean
@@ -620,9 +620,10 @@ theorem Int.ModEq.pow_card_sub_one_eq_one {p : ℕ} (hp : Nat.Prime p) {n : ℤ}
   simpa [← ZMod.intCast_eq_intCast_iff] using ZMod.pow_card_sub_one_eq_one this
 
 theorem pow_pow_modEq_one (p m a : ℕ) : (1 + p * a) ^ (p ^ m) ≡ 1 [MOD p ^ m] := by
-  induction' m with m hm
-  · exact Nat.modEq_one
-  · rw [Nat.ModEq.comm, add_comm, Nat.modEq_iff_dvd' (Nat.one_le_pow' _ _)] at hm
+  induction m with
+  | zero => exact Nat.modEq_one
+  | succ m hm =>
+    rw [Nat.ModEq.comm, add_comm, Nat.modEq_iff_dvd' (Nat.one_le_pow' _ _)] at hm
     obtain ⟨d, hd⟩ := hm
     rw [tsub_eq_iff_eq_add_of_le (Nat.one_le_pow' _ _), add_comm] at hd
     rw [pow_succ, pow_mul, hd, add_pow, Finset.sum_range_succ', pow_zero, one_mul, one_pow,

--- a/Mathlib/FieldTheory/IntermediateField/Adjoin/Basic.lean
+++ b/Mathlib/FieldTheory/IntermediateField/Adjoin/Basic.lean
@@ -476,8 +476,9 @@ variable {F} in
 theorem exists_lt_finrank_of_infinite_dimensional
     [Algebra.IsAlgebraic F E] (hnfd : ¬ FiniteDimensional F E) (n : ℕ) :
     ∃ L : IntermediateField F E, FiniteDimensional F L ∧ n < finrank F L := by
-  induction' n with n ih
-  · exact ⟨⊥, Subalgebra.finite_bot, finrank_pos⟩
+  induction n with
+  | zero => exact ⟨⊥, Subalgebra.finite_bot, finrank_pos⟩
+  | succ n ih => ?_
   obtain ⟨L, fin, hn⟩ := ih
   obtain ⟨x, hx⟩ : ∃ x : E, x ∉ L := by
     contrapose! hnfd

--- a/Mathlib/FieldTheory/IntermediateField/Basic.lean
+++ b/Mathlib/FieldTheory/IntermediateField/Basic.lean
@@ -298,16 +298,16 @@ instance toField : Field S :=
 @[norm_cast]
 theorem coe_sum {ι : Type*} [Fintype ι] (f : ι → S) : (↑(∑ i, f i) : L) = ∑ i, (f i : L) := by
   classical
-    induction' (Finset.univ : Finset ι) using Finset.induction_on with i s hi H
-    · simp
-    · rw [Finset.sum_insert hi, AddMemClass.coe_add, H, Finset.sum_insert hi]
+    induction (Finset.univ : Finset ι) using Finset.induction_on with
+    | empty => simp
+    | @insert i s hi H => rw [Finset.sum_insert hi, AddMemClass.coe_add, H, Finset.sum_insert hi]
 
 @[norm_cast]
 theorem coe_prod {ι : Type*} [Fintype ι] (f : ι → S) : (↑(∏ i, f i) : L) = ∏ i, (f i : L) := by
   classical
-    induction' (Finset.univ : Finset ι) using Finset.induction_on with i s hi H
-    · simp
-    · rw [Finset.prod_insert hi, MulMemClass.coe_mul, H, Finset.prod_insert hi]
+    induction (Finset.univ : Finset ι) using Finset.induction_on with
+    | empty => simp
+    | @insert i s hi H => rw [Finset.prod_insert hi, MulMemClass.coe_mul, H, Finset.prod_insert hi]
 
 /-!
 `IntermediateField`s inherit structure from their `Subfield` coercions.

--- a/Mathlib/FieldTheory/PerfectClosure.lean
+++ b/Mathlib/FieldTheory/PerfectClosure.lean
@@ -232,8 +232,9 @@ theorem mk_zero : mk K p 0 = 0 :=
 
 @[simp]
 theorem mk_zero_right (n : ℕ) : mk K p (n, 0) = 0 := by
-  induction' n with n ih
-  · rfl
+  induction n with
+  | zero => rfl
+  | succ n ih => ?_
   rw [← ih]
   symm
   apply Quot.sound
@@ -243,8 +244,9 @@ theorem mk_zero_right (n : ℕ) : mk K p (n, 0) = 0 := by
 theorem R.sound (m n : ℕ) (x y : K) (H : (frobenius K p)^[m] x = y) :
     mk K p (n, x) = mk K p (m + n, y) := by
   subst H
-  induction' m with m ih
-  · simp only [zero_add, iterate_zero_apply]
+  induction m with
+  | zero => simp only [zero_add, iterate_zero_apply]
+  | succ m ih => ?_
   rw [ih, Nat.succ_add, iterate_succ']
   apply Quot.sound
   apply R.intro
@@ -345,11 +347,14 @@ theorem mk_pow (x : ℕ × K) (n : ℕ) : mk K p x ^ n = mk K p (x.1, x.2 ^ n) :
       ← pow_add, mul_assoc, ← pow_add]⟩
 
 theorem natCast (n x : ℕ) : (x : PerfectClosure K p) = mk K p (n, x) := by
-  induction' n with n ih
-  · induction' x with x ih
-    · simp
+  induction n with
+  | zero =>
+    induction x with
+    | zero => simp
+    | succ x ih => ?_
     rw [Nat.cast_succ, Nat.cast_succ, ih]
     rfl
+  | succ n ih => ?_
   rw [ih]; apply Quot.sound
   suffices R K p (n, (x : K)) (Nat.succ n, frobenius K p (x : K)) by
     rwa [frobenius_natCast K p x] at this
@@ -408,8 +413,9 @@ instance instPerfectRing : PerfectRing (PerfectClosure K p) p where
 @[simp]
 theorem iterate_frobenius_mk (n : ℕ) (x : K) :
     (frobenius (PerfectClosure K p) p)^[n] (mk K p ⟨n, x⟩) = of K p x := by
-  induction' n with n ih
-  · rfl
+  induction n with
+  | zero => rfl
+  | succ n ih => ?_
   rw [iterate_succ_apply, ← ih, frobenius_mk, mk_succ_pow]
 
 /-- Given a ring `K` of characteristic `p` and a perfect ring `L` of the same characteristic,

--- a/Mathlib/FieldTheory/Separable.lean
+++ b/Mathlib/FieldTheory/Separable.lean
@@ -365,7 +365,8 @@ theorem separable_or {f : F[X]} (hf : Irreducible f) :
 theorem exists_separable_of_irreducible {f : F[X]} (hf : Irreducible f) (hp : p ≠ 0) :
     ∃ (n : ℕ) (g : F[X]), g.Separable ∧ expand F (p ^ n) g = f := by
   replace hp : p.Prime := (CharP.char_is_prime_or_zero F p).resolve_right hp
-  induction' hn : f.natDegree using Nat.strong_induction_on with N ih generalizing f
+  induction hn : f.natDegree using Nat.strong_induction_on generalizing f with
+  | h N ih => ?_
   rcases separable_or p hf with (h | ⟨h1, g, hg, hgf⟩)
   · refine ⟨0, f, h, ?_⟩
     rw [pow_zero, expand_one]

--- a/Mathlib/Geometry/Euclidean/Circumcenter.lean
+++ b/Mathlib/Geometry/Euclidean/Circumcenter.lean
@@ -180,12 +180,14 @@ theorem _root_.AffineIndependent.existsUnique_dist_eq {ι : Type*} [hne : Nonemp
     {p : ι → P} (ha : AffineIndependent ℝ p) :
     ∃! cs : Sphere P, cs.center ∈ affineSpan ℝ (Set.range p) ∧ Set.range p ⊆ (cs : Set P) := by
   cases nonempty_fintype ι
-  induction' hn : Fintype.card ι with m hm generalizing ι
-  · exfalso
+  induction hn : Fintype.card ι generalizing ι with
+  | zero =>
+    exfalso
     have h := Fintype.card_pos_iff.2 hne
     rw [hn] at h
     exact lt_irrefl 0 h
-  · rcases m with - | m
+  | succ m hm =>
+    rcases m with - | m
     · rw [Fintype.card_eq_one_iff] at hn
       obtain ⟨i, hi⟩ := hn
       haveI : Unique ι := ⟨⟨i⟩, hi⟩

--- a/Mathlib/Geometry/Group/Growth/LinearLowerBound.lean
+++ b/Mathlib/Geometry/Group/Growth/LinearLowerBound.lean
@@ -31,9 +31,10 @@ lemma pow_ssubset_pow_succ_of_pow_ne_closure (hX₁ : (1 : G) ∈ X) (hX : X.Non
   wlog hn₁ : n = 1
   · simp +contextual only [pow_one] at this
     replace hXn d : X ^ (n + d) = X ^ n := by
-      induction' d with d hd
-      · rw [add_zero]
-      · rw [pow_add, pow_one] at hXn
+      induction d with
+      | zero => rw [add_zero]
+      | succ d hd =>
+        rw [pow_add, pow_one] at hXn
         rw [← add_assoc, pow_add, pow_one, hd, ← hXn]
     exact mod_cast this (one_mem_pow hX₁) (hX.pow hn) one_ne_zero
       (by simp [hXn, ← pow_mul, mul_two]) (by simp [hXn, ← pow_mul, mul_two])

--- a/Mathlib/Geometry/Manifold/Algebra/Monoid.lean
+++ b/Mathlib/Geometry/Manifold/Algebra/Monoid.lean
@@ -352,9 +352,10 @@ variable {ι 𝕜 : Type*} [NontriviallyNormedField 𝕜] {n : WithTop ℕ∞} {
 theorem ContMDiffWithinAt.prod (h : ∀ i ∈ t, ContMDiffWithinAt I' I n (f i) s x₀) :
     ContMDiffWithinAt I' I n (fun x ↦ ∏ i ∈ t, f i x) s x₀ := by
   classical
-  induction' t using Finset.induction_on with i K iK IH
-  · simp [contMDiffWithinAt_const]
-  · simp only [iK, Finset.prod_insert, not_false_iff]
+  induction t using Finset.induction_on with
+  | empty => simp [contMDiffWithinAt_const]
+  | @insert i K iK IH =>
+    simp only [iK, Finset.prod_insert, not_false_iff]
     exact (h _ (Finset.mem_insert_self i K)).mul (IH fun j hj ↦ h _ <| Finset.mem_insert_of_mem hj)
 
 @[to_additive]

--- a/Mathlib/Geometry/Manifold/VectorBundle/SmoothSection.lean
+++ b/Mathlib/Geometry/Manifold/VectorBundle/SmoothSection.lean
@@ -140,8 +140,9 @@ instance instNSMul : SMul ℕ Cₛ^n⟮I; F, V⟯ :=
 
 @[simp]
 theorem coe_nsmul (s : Cₛ^n⟮I; F, V⟯) (k : ℕ) : ⇑(k • s : Cₛ^n⟮I; F, V⟯) = k • ⇑s := by
-  induction' k with k ih
-  · simp_rw [zero_smul]; rfl
+  induction k with
+  | zero => simp_rw [zero_smul]; rfl
+  | succ k ih => ?_
   simp_rw [succ_nsmul, ← ih]; rfl
 
 instance instZSMul : SMul ℤ Cₛ^n⟮I; F, V⟯ :=

--- a/Mathlib/GroupTheory/CoprodI.lean
+++ b/Mathlib/GroupTheory/CoprodI.lean
@@ -695,9 +695,10 @@ theorem of_word (w : Word M) (h : w ≠ empty) : ∃ (i j : _) (w' : NeWord M i 
     ext
     rw [h]
   obtain ⟨l, hnot1, hchain⟩ := w
-  induction' l with x l hi
-  · contradiction
-  · rw [List.forall_mem_cons] at hnot1
+  induction l with
+  | nil => contradiction
+  | cons x l hi =>
+    rw [List.forall_mem_cons] at hnot1
     rcases l with - | ⟨y, l⟩
     · refine ⟨x.1, x.1, singleton x.2 hnot1.1, ?_⟩
       simp [toWord]

--- a/Mathlib/GroupTheory/Coxeter/Basic.lean
+++ b/Mathlib/GroupTheory/Coxeter/Basic.lean
@@ -370,9 +370,9 @@ theorem wordProd_concat (i : B) (ω : List B) : π (ω.concat i) = π ω * s i :
 theorem wordProd_append (ω ω' : List B) : π (ω ++ ω') = π ω * π ω' := by simp [wordProd]
 
 @[simp] theorem wordProd_reverse (ω : List B) : π (reverse ω) = (π ω)⁻¹ := by
-  induction' ω with x ω' ih
-  · simp
-  · simpa [wordProd_cons, wordProd_append] using ih
+  induction ω with
+  | nil => simp
+  | cons x ω' ih => simpa [wordProd_cons, wordProd_append] using ih
 
 theorem wordProd_surjective : Surjective cs.wordProd := by
   intro w
@@ -397,9 +397,10 @@ theorem alternatingWord_succ (i i' : B) (m : ℕ) :
 
 theorem alternatingWord_succ' (i i' : B) (m : ℕ) :
     alternatingWord i i' (m + 1) = (if Even m then i' else i) :: alternatingWord i i' m := by
-  induction' m with m ih generalizing i i'
-  · simp [alternatingWord]
-  · rw [alternatingWord]
+  induction m generalizing i i' with
+  | zero => simp [alternatingWord]
+  | succ m ih =>
+    rw [alternatingWord]
     nth_rw 1 [ih i' i]
     rw [alternatingWord]
     simp [Nat.even_add_one, ← Nat.not_even_iff_odd]
@@ -407,9 +408,9 @@ theorem alternatingWord_succ' (i i' : B) (m : ℕ) :
 @[simp]
 theorem length_alternatingWord (i i' : B) (m : ℕ) :
     List.length (alternatingWord i i' m) = m := by
-  induction' m with m ih generalizing i i'
-  · dsimp [alternatingWord]
-  · simpa [alternatingWord] using ih i' i
+  induction m generalizing i i' with
+  | zero => dsimp [alternatingWord]
+  | succ m ih => simpa [alternatingWord] using ih i' i
 
 lemma getElem_alternatingWord (i j : B) (p k : ℕ) (hk : k < p) :
     (alternatingWord i j p)[k]'(by simp [hk]) = (if Even (p + k) then i else j) := by
@@ -488,9 +489,10 @@ lemma listTake_succ_alternatingWord (i j : B) (p : ℕ) (k : ℕ) (h : k + 1 < 2
 
 theorem prod_alternatingWord_eq_mul_pow (i i' : B) (m : ℕ) :
     π (alternatingWord i i' m) = (if Even m then 1 else s i') * (s i * s i') ^ (m / 2) := by
-  induction' m with m ih
-  · simp [alternatingWord]
-  · rw [alternatingWord_succ', wordProd_cons, ih]
+  induction m with
+  | zero => simp [alternatingWord]
+  | succ m ih =>
+    rw [alternatingWord_succ', wordProd_cons, ih]
     by_cases hm : Even m
     · have h₁ : ¬ Even (m + 1) := by simp [hm, parity_simps]
       have h₂ : (m + 1) / 2 = m / 2 := Nat.succ_div_of_not_dvd <| by rwa [← even_iff_two_dvd]

--- a/Mathlib/GroupTheory/Coxeter/Inversion.lean
+++ b/Mathlib/GroupTheory/Coxeter/Inversion.lean
@@ -210,9 +210,10 @@ local prefix:100 "lis" => cs.leftInvSeq
 
 theorem rightInvSeq_concat (ω : List B) (i : B) :
     ris (ω.concat i) = (List.map (MulAut.conj (s i)) (ris ω)).concat (s i) := by
-  induction' ω with j ω ih
-  · simp
-  · dsimp [rightInvSeq, concat]
+  induction ω with
+  | nil => simp
+  | cons j ω ih =>
+    dsimp [rightInvSeq, concat]
     rw [ih]
     simp only [concat_eq_append, wordProd_append, wordProd_cons, wordProd_nil, mul_one, mul_inv_rev,
       inv_simple, cons_append, cons.injEq, and_true]
@@ -220,9 +221,10 @@ theorem rightInvSeq_concat (ω : List B) (i : B) :
 
 private theorem leftInvSeq_eq_reverse_rightInvSeq_reverse (ω : List B) :
     lis ω = (ris ω.reverse).reverse := by
-  induction' ω with i ω ih
-  · simp
-  · rw [leftInvSeq, reverse_cons, ← concat_eq_append, rightInvSeq_concat, ih]
+  induction ω with
+  | nil => simp
+  | cons i ω ih =>
+    rw [leftInvSeq, reverse_cons, ← concat_eq_append, rightInvSeq_concat, ih]
     simp [map_reverse]
 
 theorem leftInvSeq_concat (ω : List B) (i : B) :
@@ -238,9 +240,9 @@ theorem leftInvSeq_reverse (ω : List B) :
   simp [leftInvSeq_eq_reverse_rightInvSeq_reverse]
 
 @[simp] theorem length_rightInvSeq (ω : List B) : (ris ω).length = ω.length := by
-  induction' ω with i ω ih
-  · simp
-  · simpa [rightInvSeq]
+  induction ω with
+  | nil => simp
+  | cons i ω ih => simpa [rightInvSeq]
 
 @[simp] theorem length_leftInvSeq (ω : List B) : (lis ω).length = ω.length := by
   simp [leftInvSeq_eq_reverse_rightInvSeq_reverse]
@@ -250,9 +252,10 @@ theorem getD_rightInvSeq (ω : List B) (j : ℕ) :
       (π (ω.drop (j + 1)))⁻¹
         * (Option.map (cs.simple) ω[j]?).getD 1
         * π (ω.drop (j + 1)) := by
-  induction' ω with i ω ih generalizing j
-  · simp
-  · dsimp only [rightInvSeq]
+  induction ω generalizing j with
+  | nil => simp
+  | cons i ω ih =>
+    dsimp only [rightInvSeq]
     rcases j with _ | j'
     · simp [getD_cons_zero]
     · simp only [getD_eq_getElem?_getD] at ih
@@ -270,9 +273,10 @@ theorem getD_leftInvSeq (ω : List B) (j : ℕ) :
       π (ω.take j)
         * (Option.map (cs.simple) ω[j]?).getD 1
         * (π (ω.take j))⁻¹ := by
-  induction' ω with i ω ih generalizing j
-  · simp
-  · dsimp [leftInvSeq]
+  induction ω generalizing j with
+  | nil => simp
+  | cons i ω ih =>
+    dsimp [leftInvSeq]
     rcases j with _ | j'
     · simp [getD_cons_zero]
     · rw [getD_cons_succ]
@@ -307,11 +311,12 @@ theorem getD_leftInvSeq_mul_self (ω : List B) (j : ℕ) :
 
 theorem rightInvSeq_drop (ω : List B) (j : ℕ) :
     ris (ω.drop j) = (ris ω).drop j := by
-  induction' j with j ih₁ generalizing ω
-  · simp
-  · induction' ω with k ω _
-    · simp
-    · rw [drop_succ_cons, ih₁ ω, rightInvSeq, drop_succ_cons]
+  induction j generalizing ω with
+  | zero => simp
+  | succ j ih₁ =>
+    induction ω with
+    | nil => simp
+    | cons k ω _ => rw [drop_succ_cons, ih₁ ω, rightInvSeq, drop_succ_cons]
 
 theorem leftInvSeq_take (ω : List B) (j : ℕ) :
     lis (ω.take j) = (lis ω).take j := by
@@ -323,9 +328,10 @@ theorem leftInvSeq_take (ω : List B) (j : ℕ) :
 
 theorem isReflection_of_mem_rightInvSeq (ω : List B) {t : W} (ht : t ∈ ris ω) :
     cs.IsReflection t := by
-  induction' ω with i ω ih
-  · simp at ht
-  · dsimp [rightInvSeq] at ht
+  induction ω with
+  | nil => simp at ht
+  | cons i ω ih =>
+    dsimp [rightInvSeq] at ht
     rcases ht with _ | ⟨_, mem⟩
     · use (π ω)⁻¹, i
       group
@@ -385,9 +391,9 @@ theorem isLeftInversion_of_mem_leftInvSeq {ω : List B} (hω : cs.IsReduced ω) 
       _ = ℓ (π ω)                 := hω.symm
 
 theorem prod_rightInvSeq (ω : List B) : prod (ris ω) = (π ω)⁻¹ := by
-  induction' ω with i ω ih
-  · simp
-  · simp [rightInvSeq, ih, wordProd_cons]
+  induction ω with
+  | nil => simp
+  | cons i ω ih => simp [rightInvSeq, ih, wordProd_cons]
 
 theorem prod_leftInvSeq (ω : List B) : prod (lis ω) = (π ω)⁻¹ := by
   simp only [leftInvSeq_eq_reverse_rightInvSeq_reverse, prod_reverse_noncomm, inv_inj]

--- a/Mathlib/GroupTheory/Coxeter/Length.lean
+++ b/Mathlib/GroupTheory/Coxeter/Length.lean
@@ -244,8 +244,9 @@ theorem IsReduced.drop {cs : CoxeterSystem M W} {ω : List B} (hω : cs.IsReduce
 
 theorem not_isReduced_alternatingWord (i i' : B) {m : ℕ} (hM : M i i' ≠ 0) (hm : m > M i i') :
     ¬cs.IsReduced (alternatingWord i i' m) := by
-  induction' hm with m _ ih
-  · -- Base case; m = M i i' + 1
+  induction hm with
+  | zero =>
+    -- Base case; m = M i i' + 1
     suffices h : ℓ (π (alternatingWord i i' (M i i' + 1))) < M i i' + 1 by
       unfold IsReduced
       rw [Nat.succ_eq_add_one, length_alternatingWord]
@@ -260,7 +261,8 @@ theorem not_isReduced_alternatingWord (i i' : B) {m : ℕ} (hM : M i i' ≠ 0) (
       _ = M i i' - 1                                  := length_alternatingWord _ _ _
       _ ≤ M i i'                                      := Nat.sub_le _ _
       _ < M i i' + 1                                  := Nat.lt_succ_self _
-  · -- Inductive step
+  | succ m _ =>
+    -- Inductive step
     contrapose! ih
     rw [alternatingWord_succ'] at ih
     apply IsReduced.drop (j := 1) at ih

--- a/Mathlib/GroupTheory/Coxeter/Length.lean
+++ b/Mathlib/GroupTheory/Coxeter/Length.lean
@@ -245,8 +245,7 @@ theorem IsReduced.drop {cs : CoxeterSystem M W} {ω : List B} (hω : cs.IsReduce
 theorem not_isReduced_alternatingWord (i i' : B) {m : ℕ} (hM : M i i' ≠ 0) (hm : m > M i i') :
     ¬cs.IsReduced (alternatingWord i i' m) := by
   induction hm with
-  | zero =>
-    -- Base case; m = M i i' + 1
+  | refl => -- Base case; m = M i i' + 1
     suffices h : ℓ (π (alternatingWord i i' (M i i' + 1))) < M i i' + 1 by
       unfold IsReduced
       rw [Nat.succ_eq_add_one, length_alternatingWord]
@@ -261,8 +260,7 @@ theorem not_isReduced_alternatingWord (i i' : B) {m : ℕ} (hM : M i i' ≠ 0) (
       _ = M i i' - 1                                  := length_alternatingWord _ _ _
       _ ≤ M i i'                                      := Nat.sub_le _ _
       _ < M i i' + 1                                  := Nat.lt_succ_self _
-  | succ m _ =>
-    -- Inductive step
+  | step m ih => -- Inductive step
     contrapose! ih
     rw [alternatingWord_succ'] at ih
     apply IsReduced.drop (j := 1) at ih

--- a/Mathlib/GroupTheory/Nilpotent.lean
+++ b/Mathlib/GroupTheory/Nilpotent.lean
@@ -310,9 +310,9 @@ theorem lowerCentralSeries_succ (n : ℕ) :
   rfl
 
 instance lowerCentralSeries_normal (n : ℕ) : Normal (lowerCentralSeries G n) := by
-  induction' n with d hd
-  · exact (⊤ : Subgroup G).normal_of_characteristic
-  · exact @Subgroup.commutator_normal _ _ (lowerCentralSeries G d) ⊤ hd _
+  induction n with
+  | zero => exact (⊤ : Subgroup G).normal_of_characteristic
+  | succ d hd => exact @Subgroup.commutator_normal _ _ (lowerCentralSeries G d) ⊤ hd _
 
 theorem lowerCentralSeries_antitone : Antitone (lowerCentralSeries G) := by
   refine antitone_nat_of_succ_le fun n x hx => ?_
@@ -443,9 +443,10 @@ end Classical
 
 theorem lowerCentralSeries_map_subtype_le (H : Subgroup G) (n : ℕ) :
     (lowerCentralSeries H n).map H.subtype ≤ lowerCentralSeries G n := by
-  induction' n with d hd
-  · simp
-  · rw [lowerCentralSeries_succ, lowerCentralSeries_succ, MonoidHom.map_closure]
+  induction n with
+  | zero => simp
+  | succ d hd =>
+    rw [lowerCentralSeries_succ, lowerCentralSeries_succ, MonoidHom.map_closure]
     apply Subgroup.closure_mono
     rintro x1 ⟨x2, ⟨x3, hx3, x4, _hx4, rfl⟩, rfl⟩
     exact ⟨x3, hd (mem_map.mpr ⟨x3, hx3, rfl⟩), x4, by simp⟩
@@ -474,17 +475,19 @@ instance (priority := 100) Group.isNilpotent_of_subsingleton [Subsingleton G] : 
 
 theorem upperCentralSeries.map {H : Type*} [Group H] {f : G →* H} (h : Function.Surjective f)
     (n : ℕ) : Subgroup.map f (upperCentralSeries G n) ≤ upperCentralSeries H n := by
-  induction' n with d hd
-  · simp
-  · rintro _ ⟨x, hx : x ∈ upperCentralSeries G d.succ, rfl⟩ y'
+  induction n with
+  | zero => simp
+  | succ d hd =>
+    rintro _ ⟨x, hx : x ∈ upperCentralSeries G d.succ, rfl⟩ y'
     rcases h y' with ⟨y, rfl⟩
     simpa using hd (mem_map_of_mem f (hx y))
 
 theorem lowerCentralSeries.map {H : Type*} [Group H] (f : G →* H) (n : ℕ) :
     Subgroup.map f (lowerCentralSeries G n) ≤ lowerCentralSeries H n := by
-  induction' n with d hd
-  · simp
-  · rintro a ⟨x, hx : x ∈ lowerCentralSeries G d.succ, rfl⟩
+  induction n with
+  | zero => simp
+  | succ d hd =>
+    rintro a ⟨x, hx : x ∈ lowerCentralSeries G d.succ, rfl⟩
     refine closure_induction (hx := hx) ?_ (by simp [f.map_one, Subgroup.one_mem _])
       (fun y z _ _ hy hz => by simp [MonoidHom.map_mul, Subgroup.mul_mem _ hy hz]) (fun y _ hy => by
         rw [f.map_inv]; exact Subgroup.inv_mem _ hy)
@@ -568,10 +571,12 @@ private theorem comap_center_subst {H₁ H₂ : Subgroup G} [Normal H₁] [Norma
 
 theorem comap_upperCentralSeries_quotient_center (n : ℕ) :
     comap (mk' (center G)) (upperCentralSeries (G ⧸ center G) n) = upperCentralSeries G n.succ := by
-  induction' n with n ih
-  · simp only [upperCentralSeries_zero, MonoidHom.comap_bot, ker_mk',
+  induction n with
+  | zero =>
+    simp only [upperCentralSeries_zero, MonoidHom.comap_bot, ker_mk',
       (upperCentralSeries_one G).symm]
-  · let Hn := upperCentralSeries (G ⧸ center G) n
+  | succ n ih =>
+    let Hn := upperCentralSeries (G ⧸ center G) n
     calc
       comap (mk' (center G)) (upperCentralSeriesStep Hn) =
           comap (mk' (center G)) (comap (mk' Hn) (center ((G ⧸ center G) ⧸ Hn))) := by
@@ -633,17 +638,20 @@ theorem nilpotent_center_quotient_ind {P : ∀ (G) [Group G] [IsNilpotent G], Pr
     (hbase : ∀ (G) [Group G] [Subsingleton G], P G)
     (hstep : ∀ (G) [Group G] [IsNilpotent G], P (G ⧸ center G) → P G) : P G := by
   obtain ⟨n, h⟩ : ∃ n, Group.nilpotencyClass G = n := ⟨_, rfl⟩
-  induction' n with n ih generalizing G
-  · haveI := nilpotencyClass_zero_iff_subsingleton.mp h
+  induction n generalizing G with
+  | zero =>
+    haveI := nilpotencyClass_zero_iff_subsingleton.mp h
     exact hbase _
-  · have hn : Group.nilpotencyClass (G ⧸ center G) = n := by
+  | succ n ih =>
+    have hn : Group.nilpotencyClass (G ⧸ center G) = n := by
       simp [nilpotencyClass_quotient_center, h]
     exact hstep _ (ih _ hn)
 
 theorem derived_le_lower_central (n : ℕ) : derivedSeries G n ≤ lowerCentralSeries G n := by
-  induction' n with i ih
-  · simp
-  · apply commutator_mono ih
+  induction n with
+  | zero => simp
+  | succ i ih =>
+    apply commutator_mono ih
     simp
 
 /-- Abelian groups are nilpotent -/
@@ -670,9 +678,10 @@ variable {G₁ G₂ : Type*} [Group G₁] [Group G₂]
 
 theorem lowerCentralSeries_prod (n : ℕ) :
     lowerCentralSeries (G₁ × G₂) n = (lowerCentralSeries G₁ n).prod (lowerCentralSeries G₂ n) := by
-  induction' n with n ih
-  · simp
-  · calc
+  induction n with
+  | zero => simp
+  | succ n ih =>
+    calc
       lowerCentralSeries (G₁ × G₂) n.succ = ⁅lowerCentralSeries (G₁ × G₂) n, ⊤⁆ := rfl
       _ = ⁅(lowerCentralSeries G₁ n).prod (lowerCentralSeries G₂ n), ⊤⁆ := by rw [ih]
       _ = ⁅(lowerCentralSeries G₁ n).prod (lowerCentralSeries G₂ n), (⊤ : Subgroup G₁).prod ⊤⁆ := by
@@ -708,9 +717,10 @@ theorem lowerCentralSeries_pi_le (n : ℕ) :
     lowerCentralSeries (∀ i, Gs i) n ≤ Subgroup.pi Set.univ
       fun i => lowerCentralSeries (Gs i) n := by
   let pi := fun f : ∀ i, Subgroup (Gs i) => Subgroup.pi Set.univ f
-  induction' n with n ih
-  · simp [pi_top]
-  · calc
+  induction n with
+  | zero => simp [pi_top]
+  | succ n ih =>
+    calc
       lowerCentralSeries (∀ i, Gs i) n.succ = ⁅lowerCentralSeries (∀ i, Gs i) n, ⊤⁆ := rfl
       _ ≤ ⁅pi fun i => lowerCentralSeries (Gs i) n, ⊤⁆ := commutator_mono ih (le_refl _)
       _ = ⁅pi fun i => lowerCentralSeries (Gs i) n, pi fun i => ⊤⁆ := by simp [pi, pi_top]
@@ -739,9 +749,10 @@ theorem lowerCentralSeries_pi_of_finite [Finite η] (n : ℕ) :
     lowerCentralSeries (∀ i, Gs i) n = Subgroup.pi Set.univ
       fun i => lowerCentralSeries (Gs i) n := by
   let pi := fun f : ∀ i, Subgroup (Gs i) => Subgroup.pi Set.univ f
-  induction' n with n ih
-  · simp [pi_top]
-  · calc
+  induction n with
+  | zero => simp [pi_top]
+  | succ n ih =>
+    calc
       lowerCentralSeries (∀ i, Gs i) n.succ = ⁅lowerCentralSeries (∀ i, Gs i) n, ⊤⁆ := rfl
       _ = ⁅pi fun i => lowerCentralSeries (Gs i) n, ⊤⁆ := by rw [ih]
       _ = ⁅pi fun i => lowerCentralSeries (Gs i) n, pi fun i => ⊤⁆ := by simp [pi, pi_top]

--- a/Mathlib/GroupTheory/NoncommPiCoprod.lean
+++ b/Mathlib/GroupTheory/NoncommPiCoprod.lean
@@ -54,9 +54,10 @@ theorem eq_one_of_noncommProd_eq_one_of_iSupIndep {ι : Type*} (s : Finset ι) (
     (heq1 : s.noncommProd f comm = 1) : ∀ i ∈ s, f i = 1 := by
   classical
     revert heq1
-    induction' s using Finset.induction_on with i s hnmem ih
-    · simp
-    · have hcomm := comm.mono (Finset.coe_subset.2 <| Finset.subset_insert _ _)
+    induction s using Finset.induction_on with
+    | empty => simp
+    | @insert i s hnmem ih =>
+      have hcomm := comm.mono (Finset.coe_subset.2 <| Finset.subset_insert _ _)
       simp only [Finset.forall_mem_insert] at hmem
       have hmem_bsupr : s.noncommProd f hcomm ∈ ⨆ i ∈ (s : Set ι), K i := by
         refine Subgroup.noncommProd_mem _ _ ?_

--- a/Mathlib/GroupTheory/Perm/Cycle/Concrete.lean
+++ b/Mathlib/GroupTheory/Perm/Cycle/Concrete.lean
@@ -68,9 +68,10 @@ theorem formPerm_disjoint_iff (hl : Nodup l) (hl' : Nodup l') (hn : 2 ≤ l.leng
 theorem isCycle_formPerm (hl : Nodup l) (hn : 2 ≤ l.length) : IsCycle (formPerm l) := by
   rcases l with - | ⟨x, l⟩
   · norm_num at hn
-  induction' l with y l generalizing x
-  · norm_num at hn
-  · use x
+  induction l generalizing x with
+  | nil => norm_num at hn
+  | cons y l =>
+    use x
     constructor
     · rwa [formPerm_apply_mem_ne_self_iff _ hl _ mem_cons_self]
     · intro w hw

--- a/Mathlib/GroupTheory/Perm/Cycle/Factors.lean
+++ b/Mathlib/GroupTheory/Perm/Cycle/Factors.lean
@@ -807,9 +807,10 @@ theorem cycle_induction_on [Finite β] (P : Perm β → Prop) (σ : Perm β) (ba
       let x := σ.truncCycleFactors.out
       exact (congr_arg P x.2.1).mp (this x.1 x.2.2.1 x.2.2.2)
   intro l
-  induction' l with σ l ih
-  · exact fun _ _ => base_one
-  · intro h1 h2
+  induction l with
+  | nil => exact fun _ _ => base_one
+  | cons σ l ih =>
+    intro h1 h2
     rw [List.prod_cons]
     exact
       induction_disjoint σ l.prod (disjoint_prod_right _ (List.pairwise_cons.mp h2).1)

--- a/Mathlib/GroupTheory/Perm/Cycle/Type.lean
+++ b/Mathlib/GroupTheory/Perm/Cycle/Type.lean
@@ -167,9 +167,10 @@ theorem sign_of_cycleType' (σ : Perm α) :
 theorem sign_of_cycleType (f : Perm α) :
     sign f = (-1 : ℤˣ) ^ (f.cycleType.sum + Multiset.card f.cycleType) := by
   rw [sign_of_cycleType']
-  induction' f.cycleType using Multiset.induction_on with a s ihs
-  · rfl
-  · rw [Multiset.map_cons, Multiset.prod_cons, Multiset.sum_cons, Multiset.card_cons, ihs]
+  induction f.cycleType using Multiset.induction_on with
+  | empty => rfl
+  | cons a s ihs =>
+    rw [Multiset.map_cons, Multiset.prod_cons, Multiset.sum_cons, Multiset.card_cons, ihs]
     simp only [pow_add, pow_one, mul_neg_one, neg_mul, mul_neg, mul_assoc, mul_one]
 
 @[simp]

--- a/Mathlib/GroupTheory/Perm/List.lean
+++ b/Mathlib/GroupTheory/Perm/List.lean
@@ -103,9 +103,10 @@ theorem formPerm_apply_of_not_mem (h : x ∉ l) : formPerm l x = x :=
 theorem formPerm_apply_mem_of_mem (h : x ∈ l) : formPerm l x ∈ l := by
   rcases l with - | ⟨y, l⟩
   · simp at h
-  induction' l with z l IH generalizing x y
-  · simpa using h
-  · by_cases hx : x ∈ z :: l
+  induction l generalizing x y with
+  | nil => simpa using h
+  | cons z l IH =>
+    by_cases hx : x ∈ z :: l
     · rw [formPerm_cons_cons, mul_apply, swap_apply_def]
       split_ifs
       · simp [IH _ hx]
@@ -125,9 +126,9 @@ theorem formPerm_mem_iff_mem : l.formPerm x ∈ l ↔ x ∈ l :=
 @[simp]
 theorem formPerm_cons_concat_apply_last (x y : α) (xs : List α) :
     formPerm (x :: (xs ++ [y])) y = x := by
-  induction' xs with z xs IH generalizing x y
-  · simp
-  · simp [IH]
+  induction xs generalizing x y with
+  | nil => simp
+  | cons z xs IH => simp [IH]
 
 @[simp]
 theorem formPerm_apply_getLast (x : α) (xs : List α) :
@@ -157,9 +158,10 @@ theorem formPerm_eq_head_iff_eq_getLast (x y : α) :
 
 theorem formPerm_apply_lt_getElem (xs : List α) (h : Nodup xs) (n : ℕ) (hn : n + 1 < xs.length) :
     formPerm xs xs[n] = xs[n + 1] := by
-  induction' n with n IH generalizing xs
-  · simpa using formPerm_apply_getElem_zero _ h _
-  · rcases xs with (_ | ⟨x, _ | ⟨y, l⟩⟩)
+  induction n generalizing xs with
+  | zero => simpa using formPerm_apply_getElem_zero _ h _
+  | succ n IH =>
+    rcases xs with (_ | ⟨x, _ | ⟨y, l⟩⟩)
     · simp at hn
     · rw [formPerm_singleton, getElem_singleton, getElem_singleton, one_apply]
     · specialize IH (y :: l) h.of_cons _
@@ -284,11 +286,13 @@ theorem formPerm_ext_iff {x y x' y' : α} {l l' : List α} (hd : Nodup (x :: y :
   · rw [length_rotate, hl]
   · intro k hk hk'
     rw [getElem_rotate]
-    induction' k with k IH
-    · refine Eq.trans ?_ hx'
+    induction k with
+    | zero =>
+      refine Eq.trans ?_ hx'
       congr
       simpa using hn
-    · conv => congr <;> · arg 2; (rw [← Nat.mod_eq_of_lt hk'])
+    | succ k IH =>
+      conv => congr <;> · arg 2; (rw [← Nat.mod_eq_of_lt hk'])
       rw [← formPerm_apply_getElem _ hd' k (k.lt_succ_self.trans hk'),
         ← IH (k.lt_succ_self.trans hk), ← h, formPerm_apply_getElem _ hd]
       congr 1

--- a/Mathlib/GroupTheory/Perm/Sign.lean
+++ b/Mathlib/GroupTheory/Perm/Sign.lean
@@ -513,9 +513,11 @@ theorem prod_prodExtendRight {α : Type*} [DecidableEq α] (σ : α → Perm β)
     obtain ⟨_, prod_eq⟩ := Or.resolve_right this (not_and.mpr fun h _ => h (mem_l a))
     rw [prod_eq, prodCongrRight_apply]
   clear mem_l
-  induction' l with a' l ih
-  · refine Or.inr ⟨List.not_mem_nil, ?_⟩
+  induction l with
+  | nil =>
+    refine Or.inr ⟨List.not_mem_nil, ?_⟩
     rw [List.map_nil, List.prod_nil, one_apply]
+  | cons a' l ih => ?_
   rw [List.map_cons, List.prod_cons, mul_apply]
   rcases ih (List.nodup_cons.mp hl).2 with (⟨mem_l, prod_eq⟩ | ⟨not_mem_l, prod_eq⟩) <;>
     rw [prod_eq]

--- a/Mathlib/GroupTheory/Perm/Support.lean
+++ b/Mathlib/GroupTheory/Perm/Support.lean
@@ -113,9 +113,10 @@ theorem Disjoint.conj (H : Disjoint f g) (h : Perm α) : Disjoint (h * f * h⁻�
 
 theorem disjoint_prod_right (l : List (Perm α)) (h : ∀ g ∈ l, Disjoint f g) :
     Disjoint f l.prod := by
-  induction' l with g l ih
-  · exact disjoint_one_right _
-  · rw [List.prod_cons]
+  induction l with
+  | nil => exact disjoint_one_right _
+  | cons g l ih =>
+    rw [List.prod_cons]
     exact (h _ List.mem_cons_self).mul_right (ih fun g hg => h g (List.mem_cons_of_mem _ hg))
 
 theorem disjoint_noncommProd_right {ι : Type*} {k : ι → Perm α} {s : Finset ι}
@@ -318,9 +319,10 @@ theorem exists_mem_support_of_mem_support_prod {l : List (Perm α)} {x : α}
     (hx : x ∈ l.prod.support) : ∃ f : Perm α, f ∈ l ∧ x ∈ f.support := by
   contrapose! hx
   simp_rw [mem_support, not_not] at hx ⊢
-  induction' l with f l ih
-  · rfl
-  · rw [List.prod_cons, mul_apply, ih, hx]
+  induction l with
+  | nil => rfl
+  | cons f l ih =>
+    rw [List.prod_cons, mul_apply, ih, hx]
     · simp only [List.find?, List.mem_cons, true_or]
     intros f' hf'
     refine hx f' ?_
@@ -400,9 +402,10 @@ theorem zpow_apply_mem_support {n : ℤ} {x : α} : (f ^ n) x ∈ f.support ↔ 
 
 theorem pow_eq_on_of_mem_support (h : ∀ x ∈ f.support ∩ g.support, f x = g x) (k : ℕ) :
     ∀ x ∈ f.support ∩ g.support, (f ^ k) x = (g ^ k) x := by
-  induction' k with k hk
-  · simp
-  · intro x hx
+  induction k with
+  | zero => simp
+  | succ k hk =>
+    intro x hx
     rw [pow_succ, mul_apply, pow_succ, mul_apply, h _ hx, hk]
     rwa [mem_inter, apply_mem_support, ← h _ hx, apply_mem_support, ← mem_inter]
 
@@ -422,9 +425,10 @@ theorem Disjoint.support_mul (h : Disjoint f g) : (f * g).support = f.support �
 
 theorem support_prod_of_pairwise_disjoint (l : List (Perm α)) (h : l.Pairwise Disjoint) :
     l.prod.support = (l.map support).foldr (· ⊔ ·) ⊥ := by
-  induction' l with hd tl hl
-  · simp
-  · rw [List.pairwise_cons] at h
+  induction l with
+  | nil => simp
+  | cons hd tl hl =>
+    rw [List.pairwise_cons] at h
     have : Disjoint hd tl.prod := disjoint_prod_right _ h.left
     simp [this.support_mul, hl h.right]
 
@@ -446,9 +450,10 @@ theorem support_noncommProd {ι : Type*} {k : ι → Perm α} {s : Finset ι}
       simp only [Finset.coe_insert, Set.mem_insert_iff, Finset.mem_coe, hj, or_true, true_or]
 
 theorem support_prod_le (l : List (Perm α)) : l.prod.support ≤ (l.map support).foldr (· ⊔ ·) ⊥ := by
-  induction' l with hd tl hl
-  · simp
-  · rw [List.prod_cons, List.map_cons, List.foldr_cons]
+  induction l with
+  | nil => simp
+  | cons hd tl hl =>
+    rw [List.prod_cons, List.map_cons, List.foldr_cons]
     refine (support_mul_le hd tl.prod).trans ?_
     exact sup_le_sup le_rfl hl
 
@@ -521,9 +526,10 @@ theorem Disjoint.mem_imp (h : Disjoint f g) {x : α} (hx : x ∈ f.support) : x 
 
 theorem eq_on_support_mem_disjoint {l : List (Perm α)} (h : f ∈ l) (hl : l.Pairwise Disjoint) :
     ∀ x ∈ f.support, f x = l.prod x := by
-  induction' l with hd tl IH
-  · simp at h
-  · intro x hx
+  induction l with
+  | nil => simp at h
+  | cons hd tl IH =>
+    intro x hx
     rw [List.pairwise_cons] at hl
     rw [List.mem_cons] at h
     rcases h with (rfl | h)
@@ -641,9 +647,10 @@ theorem Disjoint.card_support_mul (h : Disjoint f g) :
 
 theorem card_support_prod_list_of_pairwise_disjoint {l : List (Perm α)} (h : l.Pairwise Disjoint) :
     #l.prod.support = (l.map (card ∘ support)).sum := by
-  induction' l with a t ih
-  · exact card_support_eq_zero.mpr rfl
-  · obtain ⟨ha, ht⟩ := List.pairwise_cons.1 h
+  induction l with
+  | nil => exact card_support_eq_zero.mpr rfl
+  | cons a t ih =>
+    obtain ⟨ha, ht⟩ := List.pairwise_cons.1 h
     rw [List.prod_cons, List.map_cons, List.sum_cons, ← ih ht]
     exact (disjoint_prod_right _ ha).card_support_mul
 

--- a/Mathlib/GroupTheory/Solvable.lean
+++ b/Mathlib/GroupTheory/Solvable.lean
@@ -116,10 +116,11 @@ theorem solvable_of_ker_le_range {G' G'' : Type*} [Group G'] [Group G''] (f : G'
   obtain ⟨m, hm⟩ := id hG'
   refine ⟨⟨n + m, le_bot_iff.mp (Subgroup.map_bot f ▸ hm ▸ ?_)⟩⟩
   clear hm
-  induction' m with m hm
-  · exact f.range_eq_map ▸ ((derivedSeries G n).map_eq_bot_iff.mp
+  induction m with
+  | zero =>
+    exact f.range_eq_map ▸ ((derivedSeries G n).map_eq_bot_iff.mp
       (le_bot_iff.mp ((map_derivedSeries_le_derivedSeries g n).trans hn.le))).trans hfg
-  · exact commutator_le_map_commutator hm hm
+  | succ m hm => exact commutator_le_map_commutator hm hm
 
 theorem solvable_of_solvable_injective (hf : Function.Injective f) [IsSolvable G'] :
     IsSolvable G :=
@@ -147,9 +148,9 @@ theorem IsSolvable.commutator_lt_top_of_nontrivial [hG : IsSolvable G] [Nontrivi
   obtain ⟨n, hn⟩ := hG
   contrapose! hn
   refine ne_of_eq_of_ne ?_ top_ne_bot
-  induction' n with n h
-  · exact derivedSeries_zero G
-  · rwa [derivedSeries_succ, h]
+  induction n with
+  | zero => exact derivedSeries_zero G
+  | succ n h => rwa [derivedSeries_succ, h]
 
 theorem IsSolvable.commutator_lt_of_ne_bot [IsSolvable G] {H : Subgroup G} (hH : H ≠ ⊥) :
     ⁅H, H⁆ < H := by
@@ -170,10 +171,11 @@ theorem isSolvable_iff_commutator_lt [WellFoundedLT (Subgroup G)] :
     rw [← (map_injective (subtype_injective _)).eq_iff, Subgroup.map_bot] at hn ⊢
     rw [← hn]
     clear hn
-    induction' n with n ih
-    · rw [derivedSeries_succ, derivedSeries_zero, derivedSeries_zero, map_commutator,
+    induction n with
+    | zero =>
+      rw [derivedSeries_succ, derivedSeries_zero, derivedSeries_zero, map_commutator,
         ← MonoidHom.range_eq_map, ← MonoidHom.range_eq_map, range_subtype, range_subtype]
-    · rw [derivedSeries_succ, map_commutator, ih, derivedSeries_succ, map_commutator]
+    | succ n ih => rw [derivedSeries_succ, map_commutator, ih, derivedSeries_succ, map_commutator]
 
 end Solvable
 

--- a/Mathlib/GroupTheory/SpecificGroups/Alternating.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/Alternating.lean
@@ -166,20 +166,18 @@ theorem closure_three_cycles_eq_alternating :
       rw [← two_mul] at hn
       exact hind n l hl hn
     intro n
-    induction n with <;> intro l hl hn
-    | zero => simp [List.length_eq_zero_iff.1 hn, one_mem]
-    | succ n ih => ?_
-    rw [Nat.mul_succ] at hn
-    obtain ⟨a, l, rfl⟩ := l.exists_of_length_succ hn
-    rw [List.length_cons, Nat.succ_inj'] at hn
-    obtain ⟨b, l, rfl⟩ := l.exists_of_length_succ hn
-    rw [List.prod_cons, List.prod_cons, ← mul_assoc]
-    rw [List.length_cons, Nat.succ_inj'] at hn
-    exact
-      mul_mem
-        (IsSwap.mul_mem_closure_three_cycles (hl a List.mem_cons_self)
-          (hl b (List.mem_cons_of_mem a List.mem_cons_self)))
-        (ih _ (fun g hg => hl g (List.mem_cons_of_mem _ (List.mem_cons_of_mem _ hg))) hn)
+    induction n <;> intro l hl hn
+    case zero => simp [List.length_eq_zero_iff.1 hn, one_mem]
+    case succ n ih =>
+      rw [Nat.mul_succ] at hn
+      obtain ⟨a, l, rfl⟩ := l.exists_of_length_succ hn
+      rw [List.length_cons, Nat.succ_inj'] at hn
+      obtain ⟨b, l, rfl⟩ := l.exists_of_length_succ hn
+      rw [List.prod_cons, List.prod_cons, ← mul_assoc]
+      rw [List.length_cons, Nat.succ_inj'] at hn
+      exact mul_mem (IsSwap.mul_mem_closure_three_cycles (hl a List.mem_cons_self)
+        (hl b (List.mem_cons_of_mem a List.mem_cons_self)))
+          (ih _ (fun g hg => hl g (List.mem_cons_of_mem _ (List.mem_cons_of_mem _ hg))) hn)
 
 /-- A key lemma to prove $A_5$ is simple. Shows that any normal subgroup of an alternating group on
   at least 5 elements is the entire alternating group if it contains a 3-cycle. -/

--- a/Mathlib/GroupTheory/SpecificGroups/Alternating.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/Alternating.lean
@@ -166,8 +166,9 @@ theorem closure_three_cycles_eq_alternating :
       rw [← two_mul] at hn
       exact hind n l hl hn
     intro n
-    induction' n with n ih <;> intro l hl hn
-    · simp [List.length_eq_zero_iff.1 hn, one_mem]
+    induction n with <;> intro l hl hn
+    | zero => simp [List.length_eq_zero_iff.1 hn, one_mem]
+    | succ n ih => ?_
     rw [Nat.mul_succ] at hn
     obtain ⟨a, l, rfl⟩ := l.exists_of_length_succ hn
     rw [List.length_cons, Nat.succ_inj'] at hn

--- a/Mathlib/GroupTheory/SpecificGroups/Quaternion.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/Quaternion.lean
@@ -166,9 +166,10 @@ theorem card [NeZero n] : Fintype.card (QuaternionGroup n) = 4 * n := by
 
 @[simp]
 theorem a_one_pow (k : ℕ) : (a 1 : QuaternionGroup n) ^ k = a k := by
-  induction' k with k IH
-  · rw [Nat.cast_zero]; rfl
-  · rw [pow_succ, IH, a_mul_a]
+  induction k with
+  | zero => rw [Nat.cast_zero]; rfl
+  | succ k IH =>
+    rw [pow_succ, IH, a_mul_a]
     congr 1
     norm_cast
 

--- a/Mathlib/MeasureTheory/Constructions/Pi.lean
+++ b/Mathlib/MeasureTheory/Constructions/Pi.lean
@@ -133,9 +133,9 @@ variable {δ : Type*} {X : δ → Type*} [∀ i, MeasurableSpace (X i)]
 -- for some reason the equation compiler doesn't like this definition
 /-- A product of measures in `tprod α l`. -/
 protected def tprod (l : List δ) (μ : ∀ i, Measure (X i)) : Measure (TProd X l) := by
-  induction' l with i l ih
-  · exact dirac PUnit.unit
-  · exact (μ i).prod (α := X i) ih
+  induction l with
+  | nil => exact dirac PUnit.unit
+  | cons i l ih => exact (μ i).prod (α := X i) ih
 
 @[simp]
 theorem tprod_nil (μ : ∀ i, Measure (X i)) : Measure.tprod [] μ = dirac PUnit.unit :=

--- a/Mathlib/MeasureTheory/Constructions/Polish/Basic.lean
+++ b/Mathlib/MeasureTheory/Constructions/Polish/Basic.lean
@@ -424,9 +424,9 @@ theorem measurablySeparable_range_of_disjoint [T2Space α] [MeasurableSpace α]
   -- check that at the `n`-th step we deal with cylinders of length `n`
   have pn_fst : ∀ n, (p n).1.1 = n := by
     intro n
-    induction' n with n IH
-    · rfl
-    · simp only [prec, hFn, IH]
+    induction n with
+    | zero => rfl
+    | succ n IH => simp only [prec, hFn, IH]
   -- check that the cylinders we construct are indeed decreasing, by checking that the coordinates
   -- are stationary.
   have Ix : ∀ m n, m + 1 ≤ n → (p n).1.2.1 m = (p (m + 1)).1.2.1 m := by

--- a/Mathlib/MeasureTheory/Covering/Besicovitch.lean
+++ b/Mathlib/MeasureTheory/Covering/Besicovitch.lean
@@ -744,11 +744,13 @@ theorem exists_disjoint_closedBall_covering_ae_of_finiteMeasure_aux (μ : Measur
     simp only [u, Function.comp_apply, Function.iterate_succ']
   have Pu : ∀ n, P (u n) := by
     intro n
-    induction' n with n IH
-    · simp only [P, u, Prod.forall, id, Function.iterate_zero]
+    induction n with
+    | zero =>
+      simp only [P, u, Prod.forall, id, Function.iterate_zero]
       simp only [Finset.not_mem_empty, IsEmpty.forall_iff, Finset.coe_empty, forall₂_true_iff,
         and_self_iff, pairwiseDisjoint_empty]
-    · rw [u_succ]
+    | succ n IH =>
+      rw [u_succ]
       exact (hF (u n) IH).2.1
   refine ⟨⋃ n, u n, countable_iUnion fun n => (u n).countable_toSet, ?_, ?_, ?_, ?_⟩
   · intro p hp
@@ -768,9 +770,11 @@ theorem exists_disjoint_closedBall_covering_ae_of_finiteMeasure_aux (μ : Measur
         ∀ n, μ (s \ ⋃ (p : α × ℝ) (_ : p ∈ u n), closedBall p.fst p.snd) ≤
           (N / (N + 1) : ℝ≥0∞) ^ n * μ s := by
       intro n
-      induction' n with n IH
-      · simp only [u, le_refl, diff_empty, one_mul, iUnion_false, iUnion_empty, pow_zero,
+      induction n with
+      | zero =>
+        simp only [u, le_refl, diff_empty, one_mul, iUnion_false, iUnion_empty, pow_zero,
           Function.iterate_zero, id, Finset.not_mem_empty]
+      | succ n IH => ?_
       calc
         μ (s \ ⋃ (p : α × ℝ) (_ : p ∈ u n.succ), closedBall p.fst p.snd) ≤
             N / (N + 1) * μ (s \ ⋃ (p : α × ℝ) (_ : p ∈ u n), closedBall p.fst p.snd) := by

--- a/Mathlib/MeasureTheory/Function/SimpleFunc.lean
+++ b/Mathlib/MeasureTheory/Function/SimpleFunc.lean
@@ -809,10 +809,12 @@ def eapproxDiff (f : α → ℝ≥0∞) : ℕ → α →ₛ ℝ≥0
 
 theorem sum_eapproxDiff (f : α → ℝ≥0∞) (n : ℕ) (a : α) :
     (∑ k ∈ Finset.range (n + 1), (eapproxDiff f k a : ℝ≥0∞)) = eapprox f n a := by
-  induction' n with n IH
-  · simp only [Nat.zero_add, Finset.sum_singleton, Finset.range_one]
+  induction n with
+  | zero =>
+    simp only [Nat.zero_add, Finset.sum_singleton, Finset.range_one]
     rfl
-  · rw [Finset.sum_range_succ, IH, eapproxDiff, coe_map, Function.comp_apply,
+  | succ n IH =>
+    rw [Finset.sum_range_succ, IH, eapproxDiff, coe_map, Function.comp_apply,
       coe_sub, Pi.sub_apply, ENNReal.coe_toNNReal,
       add_tsub_cancel_of_le (monotone_eapprox f (Nat.le_succ _) _)]
     apply (lt_of_le_of_lt _ (eapprox_lt_top f (n + 1) a)).ne

--- a/Mathlib/MeasureTheory/Function/SimpleFuncDense.lean
+++ b/Mathlib/MeasureTheory/Function/SimpleFuncDense.lean
@@ -92,9 +92,10 @@ theorem nearestPtInd_le (e : ℕ → α) (N : ℕ) (x : α) : nearestPtInd e N x
 
 theorem edist_nearestPt_le (e : ℕ → α) (x : α) {k N : ℕ} (hk : k ≤ N) :
     edist (nearestPt e N x) x ≤ edist (e k) x := by
-  induction' N with N ihN generalizing k
-  · simp [nonpos_iff_eq_zero.1 hk, le_refl]
-  · simp only [nearestPt, nearestPtInd_succ, map_apply]
+  induction N generalizing k with
+  | zero => simp [nonpos_iff_eq_zero.1 hk, le_refl]
+  | succ N ihN =>
+    simp only [nearestPt, nearestPtInd_succ, map_apply]
     split_ifs with h
     · rcases hk.eq_or_lt with (rfl | hk)
       exacts [le_rfl, (h k (Nat.lt_succ_iff.1 hk)).le]

--- a/Mathlib/MeasureTheory/Function/UnifTight.lean
+++ b/Mathlib/MeasureTheory/Function/UnifTight.lean
@@ -163,9 +163,11 @@ all sequences indexed by a finite type. -/
 private theorem unifTight_fin (hp_top : p ≠ ∞) {n : ℕ} {f : Fin n → α → β}
     (hf : ∀ i, MemLp (f i) p μ) : UnifTight f p μ := by
   revert f
-  induction' n with n h
-  · intro f hf
+  induction n with
+  | zero =>
+    intro f hf
     exact unifTight_of_subsingleton hp_top hf
+  | succ n h => ?_
   intro f hfLp ε hε
   by_cases hε_top : ε = ∞
   · exact ⟨∅, (by measurability), fun _ => hε_top.symm ▸ le_top⟩

--- a/Mathlib/MeasureTheory/Function/UniformIntegrable.lean
+++ b/Mathlib/MeasureTheory/Function/UniformIntegrable.lean
@@ -427,9 +427,11 @@ all sequences indexed by a finite type. -/
 theorem unifIntegrable_fin (hp_one : 1 ≤ p) (hp_top : p ≠ ∞) {n : ℕ} {f : Fin n → α → β}
     (hf : ∀ i, MemLp (f i) p μ) : UnifIntegrable f p μ := by
   revert f
-  induction' n with n h
-  · intro f hf
+  induction n with
+  | zero =>
+    intro f hf
     exact unifIntegrable_subsingleton hp_one hp_top hf
+  | succ n h => ?_
   intro f hfLp ε hε
   let g : Fin n → α → β := fun k => f k
   have hgLp : ∀ i, MemLp (g i) p μ := fun i => hfLp i

--- a/Mathlib/MeasureTheory/Group/Arithmetic.lean
+++ b/Mathlib/MeasureTheory/Group/Arithmetic.lean
@@ -167,9 +167,10 @@ export MeasurablePow (measurable_pow)
 instance Monoid.measurablePow (M : Type*) [Monoid M] [MeasurableSpace M] [MeasurableMul₂ M] :
     MeasurablePow M ℕ :=
   ⟨measurable_from_prod_countable fun n => by
-      induction' n with n ih
-      · simp only [pow_zero, ← Pi.one_def, measurable_one]
-      · simp only [pow_succ]
+      induction n with
+      | zero => simp only [pow_zero, ← Pi.one_def, measurable_one]
+      | succ n ih =>
+        simp only [pow_succ]
         exact ih.mul measurable_id⟩
 
 section Pow
@@ -596,9 +597,10 @@ instance AddMonoid.measurableSMul_nat₂ (M : Type*) [AddMonoid M] [MeasurableSp
   ⟨by
     suffices Measurable fun p : M × ℕ => p.2 • p.1 by apply this.comp measurable_swap
     refine measurable_from_prod_countable fun n => ?_
-    induction' n with n ih
-    · simp only [zero_smul, ← Pi.zero_def, measurable_zero]
-    · simp only [succ_nsmul]
+    induction n with
+    | zero => simp only [zero_smul, ← Pi.zero_def, measurable_zero]
+    | succ n ih =>
+      simp only [succ_nsmul]
       exact ih.add measurable_id⟩
 
 /-- `SubNegMonoid.SMulInt` is measurable. -/

--- a/Mathlib/MeasureTheory/Group/Measure.lean
+++ b/Mathlib/MeasureTheory/Group/Measure.lean
@@ -605,21 +605,24 @@ theorem measure_univ_of_isMulLeftInvariant [WeaklyLocallyCompactSpace G] [Noncom
   set L : ℕ → Set G := fun n => (fun T => T ∪ g T • K)^[n] K
   have Lcompact : ∀ n, IsCompact (L n) := by
     intro n
-    induction' n with n IH
-    · exact hK
-    · simp_rw [L, iterate_succ']
+    induction n with
+    | zero => exact hK
+    | succ n IH =>
+      simp_rw [L, iterate_succ']
       apply IsCompact.union IH (hK.smul (g (L n)))
   have Lclosed : ∀ n, IsClosed (L n) := by
     intro n
-    induction' n with n IH
-    · exact Kclosed
-    · simp_rw [L, iterate_succ']
+    induction n with
+    | zero => exact Kclosed
+    | succ n IH =>
+      simp_rw [L, iterate_succ']
       apply IsClosed.union IH (Kclosed.smul (g (L n)))
   have M : ∀ n, μ (L n) = (n + 1 : ℕ) * μ K := by
     intro n
-    induction' n with n IH
-    · simp only [L, one_mul, Nat.cast_one, iterate_zero, id, Nat.zero_add]
-    · calc
+    induction n with
+    | zero => simp only [L, one_mul, Nat.cast_one, iterate_zero, id, Nat.zero_add]
+    | succ n IH =>
+      calc
         μ (L (n + 1)) = μ (L n) + μ (g (L n) • K) := by
           simp_rw [L, iterate_succ']
           exact measure_union' (hg _ (Lcompact _)) (Lclosed _).measurableSet

--- a/Mathlib/MeasureTheory/Integral/IntervalIntegral/Periodic.lean
+++ b/Mathlib/MeasureTheory/Integral/IntervalIntegral/Periodic.lean
@@ -318,9 +318,10 @@ theorem intervalIntegral_add_zsmul_eq (hf : Periodic f T) (n : ℤ) (t : ℝ)
       this]
   -- First prove it for natural numbers
   have : ∀ m : ℕ, (∫ x in (0)..m • T, f x) = m • ∫ x in (0)..T, f x := fun m ↦ by
-    induction' m with m ih
-    · simp
-    · simp only [succ_nsmul, hf.intervalIntegral_add_eq_add 0 (m • T) h_int, ih, zero_add]
+    induction m with
+    | zero => simp
+    | succ m ih =>
+      simp only [succ_nsmul, hf.intervalIntegral_add_eq_add 0 (m • T) h_int, ih, zero_add]
   -- Then prove it for all integers
   rcases n with n | n
   · simp [← this n]

--- a/Mathlib/MeasureTheory/Integral/Lebesgue/Basic.lean
+++ b/Mathlib/MeasureTheory/Integral/Lebesgue/Basic.lean
@@ -575,9 +575,10 @@ theorem lintegral_finset_sum' (s : Finset β) {f : β → α → ℝ≥0∞}
     (hf : ∀ b ∈ s, AEMeasurable (f b) μ) :
     ∫⁻ a, ∑ b ∈ s, f b a ∂μ = ∑ b ∈ s, ∫⁻ a, f b a ∂μ := by
   classical
-  induction' s using Finset.induction_on with a s has ih
-  · simp
-  · simp only [Finset.sum_insert has]
+  induction s using Finset.induction_on with
+  | empty => simp
+  | @insert a s has ih =>
+    simp only [Finset.sum_insert has]
     rw [Finset.forall_mem_insert] at hf
     rw [lintegral_add_left' hf.1, ih hf.2]
 
@@ -977,9 +978,9 @@ theorem lintegral_iInf_ae {f : ℕ → α → ℝ≥0∞} (h_meas : ∀ n, Measu
           (have h_mono : ∀ᵐ a ∂μ, ∀ n : ℕ, f n.succ a ≤ f n a := ae_all_iff.2 h_mono
           have h_mono : ∀ n, ∀ᵐ a ∂μ, f n a ≤ f 0 a := fun n =>
             h_mono.mono fun a h => by
-              induction' n with n ih
-              · exact le_rfl
-              · exact le_trans (h n) ih
+              induction n with
+              | zero => exact le_rfl
+              | succ n ih => exact le_trans (h n) ih
           congr_arg iSup <|
             funext fun n =>
               lintegral_sub (h_meas _) (ne_top_of_le_ne_top h_fin <| lintegral_mono_ae <| h_mono n)

--- a/Mathlib/MeasureTheory/MeasurableSpace/Constructions.lean
+++ b/Mathlib/MeasureTheory/MeasurableSpace/Constructions.lean
@@ -712,9 +712,9 @@ open List
 variable {X : δ → Type*} [∀ i, MeasurableSpace (X i)]
 
 theorem measurable_tProd_mk (l : List δ) : Measurable (@TProd.mk δ X l) := by
-  induction' l with i l ih
-  · exact measurable_const
-  · exact (measurable_pi_apply i).prodMk ih
+  induction l with
+  | nil => exact measurable_const
+  | cons i l ih => exact (measurable_pi_apply i).prodMk ih
 
 theorem measurable_tProd_elim [DecidableEq δ] :
     ∀ {l : List δ} {i : δ} (hi : i ∈ l), Measurable fun v : TProd X l => v.elim hi
@@ -732,9 +732,9 @@ theorem measurable_tProd_elim' [DecidableEq δ] {l : List δ} (h : ∀ i, i ∈ 
 
 theorem MeasurableSet.tProd (l : List δ) {s : ∀ i, Set (X i)} (hs : ∀ i, MeasurableSet (s i)) :
     MeasurableSet (Set.tprod l s) := by
-  induction' l with i l ih
-  · exact MeasurableSet.univ
-  · exact (hs i).prod ih
+  induction l with
+  | nil => exact MeasurableSet.univ
+  | cons i l ih => exact (hs i).prod ih
 
 end TProd
 

--- a/Mathlib/MeasureTheory/MeasurableSpace/Embedding.lean
+++ b/Mathlib/MeasureTheory/MeasurableSpace/Embedding.lean
@@ -720,8 +720,9 @@ noncomputable def schroederBernstein {f : α → β} {g : β → α} (hf : Measu
   refine ⟨iInter X, ?_, ?_⟩
   · apply MeasurableSet.iInter
     intro n
-    induction' n with n ih
-    · exact MeasurableSet.univ
+    induction n with
+    | zero => exact MeasurableSet.univ
+    | succ n ih => ?_
     rw [Function.iterate_succ', Function.comp_apply]
     exact (hg.measurableSet_image' (hf.measurableSet_image' ih).compl).compl
   apply subset_antisymm

--- a/Mathlib/MeasureTheory/Measure/Decomposition/Lebesgue.lean
+++ b/Mathlib/MeasureTheory/Measure/Decomposition/Lebesgue.lean
@@ -792,11 +792,13 @@ theorem iSup_succ_eq_sup {α} (f : ℕ → α → ℝ≥0∞) (m : ℕ) (a : α)
 
 theorem iSup_mem_measurableLE (f : ℕ → α → ℝ≥0∞) (hf : ∀ n, f n ∈ measurableLE μ ν) (n : ℕ) :
     (fun x ↦ ⨆ (k) (_ : k ≤ n), f k x) ∈ measurableLE μ ν := by
-  induction' n with m hm
-  · constructor
+  induction n with
+  | zero =>
+    constructor
     · simp [(hf 0).1]
     · intro A hA; simp [(hf 0).2 A hA]
-  · have :
+  | succ m hm =>
+    have :
       (fun a : α ↦ ⨆ (k : ℕ) (_ : k ≤ m + 1), f k a) = fun a ↦
         f m.succ a ⊔ ⨆ (k : ℕ) (_ : k ≤ m), f k a :=
       funext fun _ ↦ iSup_succ_eq_sup _ _ _

--- a/Mathlib/MeasureTheory/Measure/Doubling.lean
+++ b/Mathlib/MeasureTheory/Measure/Doubling.lean
@@ -67,8 +67,9 @@ theorem exists_eventually_forall_measure_closedBall_le_mul (K : ℝ) :
     ∀ n : ℕ, ∀ᶠ ε in 𝓝[>] 0, ∀ x,
       μ (closedBall x ((2 : ℝ) ^ n * ε)) ≤ ↑(C ^ n) * μ (closedBall x ε) := by
     intro n
-    induction' n with n ih
-    · simp
+    induction n with
+    | zero => simp
+    | succ n ih => ?_
     replace ih := eventually_nhdsGT_zero_mul_left (two_pos : 0 < (2 : ℝ)) ih
     refine (ih.and (exists_measure_closedBall_le_mul' μ)).mono fun ε hε x => ?_
     calc

--- a/Mathlib/ModelTheory/DirectLimit.lean
+++ b/Mathlib/ModelTheory/DirectLimit.lean
@@ -57,10 +57,12 @@ theorem coe_natLERec (m n : ℕ) (h : m ≤ n) :
     (natLERec f' m n h : G' m → G' n) = Nat.leRecOn h (@fun k => f' k) := by
   obtain ⟨k, rfl⟩ := Nat.exists_eq_add_of_le h
   ext x
-  induction' k with k ih
-  · -- This used to be `rw`, but we need `erw` after https://github.com/leanprover/lean4/pull/2644
+  induction k with
+  | zero =>
+    -- This used to be `rw`, but we need `erw` after https://github.com/leanprover/lean4/pull/2644
     erw [natLERec, Nat.leRecOn_self, Embedding.refl_apply, Nat.leRecOn_self]
-  · -- This used to be `rw`, but we need `erw` after https://github.com/leanprover/lean4/pull/2644
+  | succ k ih =>
+    -- This used to be `rw`, but we need `erw` after https://github.com/leanprover/lean4/pull/2644
     erw [Nat.leRecOn_succ le_self_add, natLERec, Nat.leRecOn_succ le_self_add, ← natLERec,
       Embedding.comp_apply, ih]
 

--- a/Mathlib/ModelTheory/Encoding.lean
+++ b/Mathlib/ModelTheory/Encoding.lean
@@ -67,9 +67,9 @@ theorem listDecode_encode_list (l : List (L.Term α)) :
     listDecode (l.flatMap listEncode) = l := by
   suffices h : ∀ (t : L.Term α) (l : List (α ⊕ (Σ i, L.Functions i))),
       listDecode (t.listEncode ++ l) = t::listDecode l by
-    induction' l with t l lih
-    · rfl
-    · rw [flatMap_cons, h t (l.flatMap listEncode), lih]
+    induction l with
+    | nil => rfl
+    | cons t l lih => rw [flatMap_cons, h t (l.flatMap listEncode), lih]
   intro t l
   induction t generalizing l with
   | var => rw [listEncode, singleton_append, listDecode]
@@ -77,9 +77,9 @@ theorem listDecode_encode_list (l : List (L.Term α)) :
     rw [listEncode, cons_append, listDecode]
     have h : listDecode (((finRange n).flatMap fun i : Fin n => (ts i).listEncode) ++ l) =
         (finRange n).map ts ++ listDecode l := by
-      induction' finRange n with i l' l'ih
-      · rfl
-      · rw [flatMap_cons, List.append_assoc, ih, map_cons, l'ih, cons_append]
+      induction finRange n with
+      | nil => rfl
+      | cons i l' l'ih => rw [flatMap_cons, List.append_assoc, ih, map_cons, l'ih, cons_append]
     simp only [h, length_append, length_map, length_finRange, le_add_iff_nonneg_right,
       _root_.zero_le, ↓reduceDIte, getElem_fin, cons.injEq, func.injEq, heq_eq_eq, true_and]
     refine ⟨funext (fun i => ?_), ?_⟩
@@ -215,10 +215,11 @@ theorem listDecode_encode_list (l : List (Σ n, L.BoundedFormula α n)) :
   suffices h : ∀ (φ : Σ n, L.BoundedFormula α n)
       (l' : List ((Σk, L.Term (α ⊕ Fin k)) ⊕ ((Σ n, L.Relations n) ⊕ ℕ))),
       (listDecode (listEncode φ.2 ++ l')) = φ::(listDecode l') by
-    induction' l with φ l ih
-    · rw [List.flatMap_nil]
+    induction l with
+    | nil =>
+      rw [List.flatMap_nil]
       simp [listDecode]
-    · rw [flatMap_cons, h φ _, ih]
+    | cons φ l ih => rw [flatMap_cons, h φ _, ih]
   rintro ⟨n, φ⟩
   induction φ with
   | falsum => intro l; rw [listEncode, singleton_append, listDecode]

--- a/Mathlib/ModelTheory/Semantics.lean
+++ b/Mathlib/ModelTheory/Semantics.lean
@@ -260,9 +260,9 @@ theorem realize_inf : (φ ⊓ ψ).Realize v xs ↔ φ.Realize v xs ∧ ψ.Realiz
 @[simp]
 theorem realize_foldr_inf (l : List (L.BoundedFormula α n)) (v : α → M) (xs : Fin n → M) :
     (l.foldr (· ⊓ ·) ⊤).Realize v xs ↔ ∀ φ ∈ l, BoundedFormula.Realize φ v xs := by
-  induction' l with φ l ih
-  · simp
-  · simp [ih]
+  induction l with
+  | nil => simp
+  | cons φ l ih => simp [ih]
 
 @[simp]
 theorem realize_imp : (φ.imp ψ).Realize v xs ↔ φ.Realize v xs → ψ.Realize v xs := by
@@ -297,9 +297,10 @@ theorem realize_sup : (φ ⊔ ψ).Realize v xs ↔ φ.Realize v xs ∨ ψ.Realiz
 @[simp]
 theorem realize_foldr_sup (l : List (L.BoundedFormula α n)) (v : α → M) (xs : Fin n → M) :
     (l.foldr (· ⊔ ·) ⊥).Realize v xs ↔ ∃ φ ∈ l, BoundedFormula.Realize φ v xs := by
-  induction' l with φ l ih
-  · simp
-  · simp_rw [List.foldr_cons, realize_sup, ih, List.mem_cons, or_and_right, exists_or,
+  induction l with
+  | nil => simp
+  | cons φ l ih =>
+    simp_rw [List.foldr_cons, realize_sup, ih, List.mem_cons, or_and_right, exists_or,
       exists_eq_left]
 
 @[simp]
@@ -740,17 +741,19 @@ namespace BoundedFormula
 @[simp]
 theorem realize_alls {φ : L.BoundedFormula α n} {v : α → M} :
     φ.alls.Realize v ↔ ∀ xs : Fin n → M, φ.Realize v xs := by
-  induction' n with n ih
-  · exact Unique.forall_iff.symm
-  · simp only [alls, ih, Realize]
+  induction n with
+  | zero => exact Unique.forall_iff.symm
+  | succ n ih =>
+    simp only [alls, ih, Realize]
     exact ⟨fun h xs => Fin.snoc_init_self xs ▸ h _ _, fun h xs x => h (Fin.snoc xs x)⟩
 
 @[simp]
 theorem realize_exs {φ : L.BoundedFormula α n} {v : α → M} :
     φ.exs.Realize v ↔ ∃ xs : Fin n → M, φ.Realize v xs := by
-  induction' n with n ih
-  · exact Unique.exists_iff.symm
-  · simp only [BoundedFormula.exs, ih, realize_ex]
+  induction n with
+  | zero => exact Unique.exists_iff.symm
+  | succ n ih =>
+    simp only [BoundedFormula.exs, ih, realize_ex]
     constructor
     · rintro ⟨xs, x, h⟩
       exact ⟨_, h⟩

--- a/Mathlib/Order/Filter/Finite.lean
+++ b/Mathlib/Order/Filter/Finite.lean
@@ -218,9 +218,9 @@ theorem iInf_sets_induct {f : ι → Filter α} {s : Set α} (hs : s ∈ iInf f)
 theorem iInf_principal_finset {ι : Type w} (s : Finset ι) (f : ι → Set α) :
     ⨅ i ∈ s, 𝓟 (f i) = 𝓟 (⋂ i ∈ s, f i) := by
   classical
-  induction' s using Finset.induction_on with i s _ hs
-  · simp
-  · rw [Finset.iInf_insert, Finset.set_biInter_insert, hs, inf_principal]
+  induction s using Finset.induction_on with
+  | empty => simp
+  | @insert i s _ hs => rw [Finset.iInf_insert, Finset.set_biInter_insert, hs, inf_principal]
 
 theorem iInf_principal {ι : Sort w} [Finite ι] (f : ι → Set α) : ⨅ i, 𝓟 (f i) = 𝓟 (⋂ i, f i) := by
   cases nonempty_fintype (PLift ι)

--- a/Mathlib/Order/Fin/Basic.lean
+++ b/Mathlib/Order/Fin/Basic.lean
@@ -386,7 +386,8 @@ map. In this lemma we state that for each `i : Fin n` we have `(e i : ℕ) = (i 
 @[simp] lemma coe_orderIso_apply (e : Fin n ≃o Fin m) (i : Fin n) : (e i : ℕ) = i := by
   rcases i with ⟨i, hi⟩
   dsimp only
-  induction' i using Nat.strong_induction_on with i h
+  induction i using Nat.strong_induction_on with
+  | h i h => ?_
   refine le_antisymm (forall_lt_iff_le.1 fun j hj => ?_) (forall_lt_iff_le.1 fun j hj => ?_)
   · have := e.symm.lt_iff_lt.2 (mk_lt_of_lt_val hj)
     rw [e.symm_apply_apply] at this

--- a/Mathlib/Order/Height.lean
+++ b/Mathlib/Order/Height.lean
@@ -196,9 +196,10 @@ theorem chainHeight_image (f : α → β) (hf : ∀ {x y}, x < y ↔ f x < f y) 
       obtain ⟨l', h₁, rfl⟩ := this l hl
       exact ⟨l', h₁, length_map _⟩
     intro l
-    induction' l with x xs hx
-    · exact fun _ ↦ ⟨nil, ⟨trivial, fun x h ↦ (not_mem_nil h).elim⟩, rfl⟩
-    · intro h
+    induction l with
+    | nil => exact fun _ ↦ ⟨nil, ⟨trivial, fun x h ↦ (not_mem_nil h).elim⟩, rfl⟩
+    | cons x xs hx =>
+      intro h
       rw [cons_mem_subchain_iff] at h
       obtain ⟨⟨x, hx', rfl⟩, h₁, h₂⟩ := h
       obtain ⟨l', h₃, rfl⟩ := hx h₁

--- a/Mathlib/Order/Interval/Finset/Nat.lean
+++ b/Mathlib/Order/Interval/Finset/Nat.lean
@@ -178,11 +178,13 @@ theorem Ico_succ_left_eq_erase_Ico : Ico a.succ b = erase (Ico a b) a := by
     and_comm (a := a ≠ x), lt_iff_le_and_ne]
 
 theorem mod_injOn_Ico (n a : ℕ) : Set.InjOn (· % a) (Finset.Ico n (n + a)) := by
-  induction' n with n ih
-  · simp only [zero_add, Ico_zero_eq_range]
+  induction n with
+  | zero =>
+    simp only [zero_add, Ico_zero_eq_range]
     rintro k hk l hl (hkl : k % a = l % a)
     simp only [Finset.mem_range, Finset.mem_coe] at hk hl
     rwa [mod_eq_of_lt hk, mod_eq_of_lt hl] at hkl
+  | succ n ih => ?_
   rw [Ico_succ_left_eq_erase_Ico, succ_add, succ_eq_add_one,
     Ico_succ_right_eq_insert_Ico (by omega)]
   rintro k hk l hl (hkl : k % a = l % a)

--- a/Mathlib/Order/Irreducible.lean
+++ b/Mathlib/Order/Irreducible.lean
@@ -93,17 +93,18 @@ theorem SupPrime.ne_bot (ha : SupPrime a) : a ≠ ⊥ := by rintro rfl; exact no
 
 theorem SupIrred.finset_sup_eq (ha : SupIrred a) (h : s.sup f = a) : ∃ i ∈ s, f i = a := by
   classical
-  induction' s using Finset.induction with i s _ ih
-  · simpa [ha.ne_bot] using h.symm
+  induction s using Finset.induction with
+  | empty => simpa [ha.ne_bot] using h.symm
+  | @insert i s _ ih => ?_
   simp only [exists_prop, exists_mem_insert] at ih ⊢
   rw [sup_insert] at h
   exact (ha.2 h).imp_right ih
 
 theorem SupPrime.le_finset_sup (ha : SupPrime a) : a ≤ s.sup f ↔ ∃ i ∈ s, a ≤ f i := by
   classical
-  induction' s using Finset.induction with i s _ ih
-  · simp [ha.ne_bot]
-  · simp only [exists_prop, exists_mem_insert, sup_insert, ha.le_sup, ih]
+  induction s using Finset.induction with
+  | empty => simp [ha.ne_bot]
+  | @insert i s _ ih => simp only [exists_prop, exists_mem_insert, sup_insert, ha.le_sup, ih]
 
 variable [WellFoundedLT α]
 

--- a/Mathlib/Order/JordanHolder.lean
+++ b/Mathlib/Order/JordanHolder.lean
@@ -375,11 +375,13 @@ theorem exists_last_eq_snoc_equivalent (s : CompositionSeries X) (x : X) (hm : I
       t.head = s.head ∧ t.length + 1 = s.length ∧
       ∃ htx : t.last = x,
         Equivalent s (snoc t s.last (show IsMaximal t.last _ from htx.symm ▸ hm)) := by
-  induction' hn : s.length with n ih generalizing s x
-  · exact
+  induction hn : s.length generalizing s x with
+  | zero =>
+    exact
       (ne_of_gt (lt_of_le_of_lt hb (lt_of_isMaximal hm))
           (subsingleton_of_length_eq_zero hn s.last_mem s.head_mem)).elim
-  · have h0s : 0 < s.length := hn.symm ▸ Nat.succ_pos _
+  | succ n ih =>
+    have h0s : 0 < s.length := hn.symm ▸ Nat.succ_pos _
     by_cases hetx : s.eraseLast.last = x
     · use s.eraseLast
       simp [← hetx, hn, Equivalent.refl]
@@ -409,9 +411,10 @@ If two composition series start and finish at the same place, they are equivalen
 theorem jordan_holder (s₁ s₂ : CompositionSeries X)
     (hb : s₁.head = s₂.head) (ht : s₁.last = s₂.last) :
     Equivalent s₁ s₂ := by
-  induction' hle : s₁.length with n ih generalizing s₁ s₂
-  · rw [eq_of_head_eq_head_of_last_eq_last_of_length_eq_zero hb ht hle]
-  · have h0s₂ : 0 < s₂.length :=
+  induction hle : s₁.length generalizing s₁ s₂ with
+  | zero => rw [eq_of_head_eq_head_of_last_eq_last_of_length_eq_zero hb ht hle]
+  | succ n ih =>
+    have h0s₂ : 0 < s₂.length :=
       length_pos_of_head_eq_head_of_last_eq_last_of_length_pos hb ht (hle.symm ▸ Nat.succ_pos _)
     rcases exists_last_eq_snoc_equivalent s₁ s₂.eraseLast.last
         (ht.symm ▸ isMaximal_eraseLast_last h0s₂)

--- a/Mathlib/Order/KonigLemma.lean
+++ b/Mathlib/Order/KonigLemma.lean
@@ -81,9 +81,9 @@ theorem GradeMinOrder.exists_nat_orderEmbedding_of_forall_covby_finite
     ∃ f : ℕ ↪o α, f 0 = ⊥ ∧ (∀ i, f i ⋖ f (i+1)) ∧ ∀ i, grade ℕ (f i) = i := by
   obtain ⟨f, h0, hf⟩ := exists_orderEmbedding_covby_of_forall_covby_finite_of_bot hfin
   refine ⟨f, h0, hf, fun i ↦ ?_⟩
-  induction' i with i ih
-  · simp [h0]
-  · simpa [Order.covBy_iff_add_one_eq, ih, eq_comm] using CovBy.grade ℕ <| hf i
+  induction i with
+  | zero => simp [h0]
+  | succ i ih => simpa [Order.covBy_iff_add_one_eq, ih, eq_comm] using CovBy.grade ℕ <| hf i
 
 end Sequence
 

--- a/Mathlib/Order/OrderIsoNat.lean
+++ b/Mathlib/Order/OrderIsoNat.lean
@@ -197,9 +197,10 @@ theorem exists_increasing_or_nonincreasing_subseq (r : α → α → Prop) [IsTr
   obtain ⟨g, hr | hnr⟩ := exists_increasing_or_nonincreasing_subseq' r f
   · refine ⟨g, Or.intro_left _ fun m n mn => ?_⟩
     obtain ⟨x, rfl⟩ := Nat.exists_eq_add_of_le (Nat.succ_le_iff.2 mn)
-    induction' x with x ih
-    · apply hr
-    · apply IsTrans.trans _ _ _ _ (hr _)
+    induction x with
+    | zero => apply hr
+    | succ x ih =>
+      apply IsTrans.trans _ _ _ _ (hr _)
       exact ih (lt_of_lt_of_le m.lt_succ_self (Nat.le_add_right _ _))
   · exact ⟨g, Or.intro_right _ hnr⟩
 

--- a/Mathlib/Order/SuccPred/Archimedean.lean
+++ b/Mathlib/Order/SuccPred/Archimedean.lean
@@ -58,9 +58,10 @@ theorem exists_succ_iterate_iff_le : (∃ n, succ^[n] a = b) ↔ a ≤ b := by
 theorem Succ.rec {P : α → Prop} {m : α} (h0 : P m) (h1 : ∀ n, m ≤ n → P n → P (succ n)) ⦃n : α⦄
     (hmn : m ≤ n) : P n := by
   obtain ⟨n, rfl⟩ := hmn.exists_succ_iterate; clear hmn
-  induction' n with n ih
-  · exact h0
-  · rw [Function.iterate_succ_apply']
+  induction n with
+  | zero => exact h0
+  | succ n ih =>
+    rw [Function.iterate_succ_apply']
     exact h1 _ (id_le_iterate_of_id_le le_succ n m) ih
 
 theorem Succ.rec_iff {p : α → Prop} (hsucc : ∀ a, p a ↔ p (succ a)) {a b : α} (h : a ≤ b) :
@@ -396,8 +397,9 @@ lemma monotoneOn_of_le_succ (hs : s.OrdConnected)
   rintro a ha b hb hab
   obtain ⟨n, rfl⟩ := exists_succ_iterate_of_le hab
   clear hab
-  induction' n with n hn
-  · simp
+  induction n with
+  | zero => simp
+  | succ n hn => ?_
   rw [Function.iterate_succ_apply'] at hb ⊢
   have : succ^[n] a ∈ s := hs.1 ha hb ⟨le_succ_iterate .., le_succ _⟩
   by_cases hb' : IsMax (succ^[n] a)
@@ -416,8 +418,9 @@ lemma strictMonoOn_of_lt_succ (hs : s.OrdConnected)
   obtain _ | n := n
   · simp at hab
   apply not_isMax_of_lt at hab
-  induction' n with n hn
-  · simpa using hf _ hab ha hb
+  induction n with
+  | zero => simpa using hf _ hab ha hb
+  | succ n hn => ?_
   rw [Function.iterate_succ_apply'] at hb ⊢
   have : succ^[n + 1] a ∈ s := hs.1 ha hb ⟨le_succ_iterate .., le_succ _⟩
   by_cases hb' : IsMax (succ^[n + 1] a)
@@ -451,8 +454,9 @@ lemma monotoneOn_of_pred_le (hs : s.OrdConnected)
   rintro a ha b hb hab
   obtain ⟨n, rfl⟩ := exists_pred_iterate_of_le hab
   clear hab
-  induction' n with n hn
-  · simp
+  induction n with
+  | zero => simp
+  | succ n hn => ?_
   rw [Function.iterate_succ_apply'] at ha ⊢
   have : pred^[n] b ∈ s := hs.1 ha hb ⟨pred_le _, pred_iterate_le ..⟩
   by_cases ha' : IsMin (pred^[n] b)
@@ -471,8 +475,9 @@ lemma strictMonoOn_of_pred_lt (hs : s.OrdConnected)
   obtain _ | n := n
   · simp at hab
   apply not_isMin_of_lt at hab
-  induction' n with n hn
-  · simpa using hf _ hab hb ha
+  induction n with
+  | zero => simpa using hf _ hab hb ha
+  | succ n hn => ?_
   rw [Function.iterate_succ_apply'] at ha ⊢
   have : pred^[n + 1] b ∈ s := hs.1 ha hb ⟨pred_le _, pred_iterate_le ..⟩
   by_cases ha' : IsMin (pred^[n + 1] b)

--- a/Mathlib/Order/SuccPred/Basic.lean
+++ b/Mathlib/Order/SuccPred/Basic.lean
@@ -951,8 +951,9 @@ theorem pred_succ [NoMaxOrder α] (a : α) : pred (succ a) = a :=
 
 theorem pred_succ_iterate_of_not_isMax (i : α) (n : ℕ) (hin : ¬IsMax (succ^[n - 1] i)) :
     pred^[n] (succ^[n] i) = i := by
-  induction' n with n hn
-  · simp only [Nat.zero_eq, Function.iterate_zero, id]
+  induction n with
+  | zero => simp only [Nat.zero_eq, Function.iterate_zero, id]
+  | succ n hn => ?_
   rw [Nat.succ_sub_succ_eq_sub, Nat.sub_zero] at hin
   have h_not_max : ¬IsMax (succ^[n - 1] i) := by
     rcases n with - | n

--- a/Mathlib/Order/SuccPred/LinearLocallyFinite.lean
+++ b/Mathlib/Order/SuccPred/LinearLocallyFinite.lean
@@ -170,9 +170,10 @@ instance (priority := 100) [LocallyFiniteOrder ι] [SuccOrder ι] : IsSuccArchim
     by_contra! h
     have h_lt : ∀ n, succ^[n] i < j := by
       intro n
-      induction' n with n hn
-      · simpa only [Function.iterate_zero, id] using hij
-      · refine lt_of_le_of_ne ?_ (h _)
+      induction n with
+      | zero => simpa only [Function.iterate_zero, id] using hij
+      | succ n hn =>
+        refine lt_of_le_of_ne ?_ (h _)
         rw [Function.iterate_succ', Function.comp_apply]
         exact succ_le_of_lt hn
     have h_mem : ∀ n, succ^[n] i ∈ Finset.Icc i j :=

--- a/Mathlib/Order/WellFoundedSet.lean
+++ b/Mathlib/Order/WellFoundedSet.lean
@@ -721,9 +721,10 @@ theorem exists_min_bad_of_exists_bad (r : α → α → Prop) (rk : α → ℕ) 
         (minBadSeqOfBadSeq r rk s (n + 1) fn.1 fn.2.1).2.2⟩
   have h : ∀ m n, m ≤ n → (fs m).1 m = (fs n).1 m := fun m n mn => by
     obtain ⟨k, rfl⟩ := Nat.exists_eq_add_of_le mn; clear mn
-    induction' k with k ih
-    · rfl
-    · rw [ih, (minBadSeqOfBadSeq r rk s (m + k + 1) (fs (m + k)).1 (fs (m + k)).2.1).2.1 m
+    induction k with
+    | zero => rfl
+    | succ k ih =>
+      rw [ih, (minBadSeqOfBadSeq r rk s (m + k + 1) (fs (m + k)).1 (fs (m + k)).2.1).2.1 m
         (Nat.lt_succ_iff.2 (Nat.add_le_add_left k.zero_le m))]
       rfl
   refine ⟨fun n => (fs n).1 n, ⟨fun n => (fs n).2.1.1 n, fun m n mn => ?_⟩, fun n g hg1 hg2 => ?_⟩

--- a/Mathlib/Probability/Kernel/Defs.lean
+++ b/Mathlib/Probability/Kernel/Defs.lean
@@ -336,9 +336,10 @@ instance IsSFiniteKernel.add (κ η : Kernel α β) [IsSFiniteKernel κ] [IsSFin
 theorem IsSFiniteKernel.finset_sum {κs : ι → Kernel α β} (I : Finset ι)
     (h : ∀ i ∈ I, IsSFiniteKernel (κs i)) : IsSFiniteKernel (∑ i ∈ I, κs i) := by
   classical
-  induction' I using Finset.induction with i I hi_nmem_I h_ind h
-  · rw [Finset.sum_empty]; infer_instance
-  · rw [Finset.sum_insert hi_nmem_I]
+  induction I using Finset.induction with
+  | empty => rw [Finset.sum_empty]; infer_instance
+  | @insert i I hi_nmem_I h_ind =>
+    rw [Finset.sum_insert hi_nmem_I]
     haveI : IsSFiniteKernel (κs i) := h i (Finset.mem_insert_self _ _)
     have : IsSFiniteKernel (∑ x ∈ I, κs x) :=
       h_ind fun i hiI => h i (Finset.mem_insert_of_mem hiI)

--- a/Mathlib/Probability/Kernel/WithDensity.lean
+++ b/Mathlib/Probability/Kernel/WithDensity.lean
@@ -228,8 +228,9 @@ theorem isSFiniteKernel_withDensity_of_isFiniteKernel (κ : Kernel α β) [IsFin
       ENNReal.tsum_eq_liminf_sum_nat]
     have h_finset_sum : ∀ n, ∑ i ∈ Finset.range n, fs i a b = min (f a b) n := by
       intro n
-      induction' n with n hn
-      · simp
+      induction n with
+      | zero => simp
+      | succ n hn => ?_
       rw [Finset.sum_range_succ, hn]
       simp [fs]
     simp_rw [h_finset_sum]

--- a/Mathlib/Probability/Martingale/Basic.lean
+++ b/Mathlib/Probability/Martingale/Basic.lean
@@ -361,9 +361,9 @@ theorem submartingale_of_setIntegral_le_succ [IsFiniteMeasure μ] {f : ℕ → �
     (hf : ∀ i, ∀ s : Set Ω, MeasurableSet[𝒢 i] s → ∫ ω in s, f i ω ∂μ ≤ ∫ ω in s, f (i + 1) ω ∂μ) :
     Submartingale f 𝒢 μ := by
   refine submartingale_of_setIntegral_le hadp hint fun i j hij s hs => ?_
-  induction' hij with k hk₁ hk₂
-  · exact le_rfl
-  · exact le_trans hk₂ (hf k s (𝒢.mono hk₁ _ hs))
+  induction hij with
+  | zero => exact le_rfl
+  | succ k hk₁ => exact le_trans hk₂ (hf k s (𝒢.mono hk₁ _ hs))
 
 theorem supermartingale_of_setIntegral_succ_le [IsFiniteMeasure μ] {f : ℕ → Ω → ℝ}
     (hadp : Adapted 𝒢 f) (hint : ∀ i, Integrable (f i) μ)
@@ -441,26 +441,29 @@ alias martingale_of_condexp_sub_eq_zero_nat := martingale_of_condExp_sub_eq_zero
 theorem Submartingale.zero_le_of_predictable [Preorder E] [SigmaFiniteFiltration μ 𝒢]
     {f : ℕ → Ω → E} (hfmgle : Submartingale f 𝒢 μ) (hfadp : Adapted 𝒢 fun n => f (n + 1)) (n : ℕ) :
     f 0 ≤ᵐ[μ] f n := by
-  induction' n with k ih
-  · rfl
-  · exact ih.trans ((hfmgle.2.1 k (k + 1) k.le_succ).trans_eq <| Germ.coe_eq.mp <|
+  induction n with
+  | zero => rfl
+  | succ k ih =>
+    exact ih.trans ((hfmgle.2.1 k (k + 1) k.le_succ).trans_eq <| Germ.coe_eq.mp <|
     congr_arg Germ.ofFun <| condExp_of_stronglyMeasurable (𝒢.le _) (hfadp _) <| hfmgle.integrable _)
 
 /-- A predictable supermartingale is a.e. less equal than its initial state. -/
 theorem Supermartingale.le_zero_of_predictable [Preorder E] [SigmaFiniteFiltration μ 𝒢]
     {f : ℕ → Ω → E} (hfmgle : Supermartingale f 𝒢 μ) (hfadp : Adapted 𝒢 fun n => f (n + 1))
     (n : ℕ) : f n ≤ᵐ[μ] f 0 := by
-  induction' n with k ih
-  · rfl
-  · exact ((Germ.coe_eq.mp <| congr_arg Germ.ofFun <| condExp_of_stronglyMeasurable (𝒢.le _)
+  induction n with
+  | zero => rfl
+  | succ k ih =>
+    exact ((Germ.coe_eq.mp <| congr_arg Germ.ofFun <| condExp_of_stronglyMeasurable (𝒢.le _)
       (hfadp _) <| hfmgle.integrable _).symm.trans_le (hfmgle.2.1 k (k + 1) k.le_succ)).trans ih
 
 /-- A predictable martingale is a.e. equal to its initial state. -/
 theorem Martingale.eq_zero_of_predictable [SigmaFiniteFiltration μ 𝒢] {f : ℕ → Ω → E}
     (hfmgle : Martingale f 𝒢 μ) (hfadp : Adapted 𝒢 fun n => f (n + 1)) (n : ℕ) : f n =ᵐ[μ] f 0 := by
-  induction' n with k ih
-  · rfl
-  · exact ((Germ.coe_eq.mp (congr_arg Germ.ofFun <| condExp_of_stronglyMeasurable (𝒢.le _) (hfadp _)
+  induction n with
+  | zero => rfl
+  | succ k ih =>
+    exact ((Germ.coe_eq.mp (congr_arg Germ.ofFun <| condExp_of_stronglyMeasurable (𝒢.le _) (hfadp _)
       (hfmgle.integrable _))).symm.trans (hfmgle.2 k (k + 1) k.le_succ)).trans ih
 
 namespace Submartingale

--- a/Mathlib/Probability/Martingale/Basic.lean
+++ b/Mathlib/Probability/Martingale/Basic.lean
@@ -362,8 +362,8 @@ theorem submartingale_of_setIntegral_le_succ [IsFiniteMeasure μ] {f : ℕ → �
     Submartingale f 𝒢 μ := by
   refine submartingale_of_setIntegral_le hadp hint fun i j hij s hs => ?_
   induction hij with
-  | zero => exact le_rfl
-  | succ k hk₁ => exact le_trans hk₂ (hf k s (𝒢.mono hk₁ _ hs))
+  | refl => exact le_rfl
+  | @step k hk₁ hk₂ => exact le_trans hk₂ (hf k s (𝒢.mono hk₁ _ hs))
 
 theorem supermartingale_of_setIntegral_succ_le [IsFiniteMeasure μ] {f : ℕ → Ω → ℝ}
     (hadp : Adapted 𝒢 f) (hint : ∀ i, Integrable (f i) μ)

--- a/Mathlib/Probability/Martingale/Convergence.lean
+++ b/Mathlib/Probability/Martingale/Convergence.lean
@@ -116,9 +116,10 @@ theorem not_frequently_of_upcrossings_lt_top (hab : a < b) (hω : upcrossings a 
   refine Classical.not_not.2 hω ?_
   push_neg
   intro k
-  induction' k with k ih
-  · simp only [zero_le, exists_const]
-  · obtain ⟨N, hN⟩ := ih
+  induction k with
+  | zero => simp only [zero_le, exists_const]
+  | succ k ih =>
+    obtain ⟨N, hN⟩ := ih
     obtain ⟨N₁, hN₁, hN₁'⟩ := h₁ N
     obtain ⟨N₂, hN₂, hN₂'⟩ := h₂ N₁
     exact ⟨N₂ + 1, Nat.succ_le_of_lt <|

--- a/Mathlib/Probability/Martingale/Upcrossing.lean
+++ b/Mathlib/Probability/Martingale/Upcrossing.lean
@@ -306,10 +306,12 @@ variable {ℱ : Filtration ℕ m0}
 theorem Adapted.isStoppingTime_crossing (hf : Adapted ℱ f) :
     IsStoppingTime ℱ (upperCrossingTime a b f N n) ∧
       IsStoppingTime ℱ (lowerCrossingTime a b f N n) := by
-  induction' n with k ih
-  · refine ⟨isStoppingTime_const _ 0, ?_⟩
+  induction n with
+  | zero =>
+    refine ⟨isStoppingTime_const _ 0, ?_⟩
     simp [hitting_isStoppingTime hf measurableSet_Iic]
-  · obtain ⟨_, ih₂⟩ := ih
+  | succ k ih =>
+    obtain ⟨_, ih₂⟩ := ih
     have : IsStoppingTime ℱ (upperCrossingTime a b f N (k + 1)) := by
       intro n
       simp_rw [upperCrossingTime_succ_eq]
@@ -447,15 +449,17 @@ theorem crossing_eq_crossing_of_lowerCrossingTime_lt {M : ℕ} (hNM : N ≤ M)
       lowerCrossingTime a b f M n ω = lowerCrossingTime a b f N n ω := by
   have h' : upperCrossingTime a b f N n ω < N :=
     lt_of_le_of_lt upperCrossingTime_le_lowerCrossingTime h
-  induction' n with k ih
-  · simp only [upperCrossingTime_zero, bot_eq_zero', eq_self_iff_true,
+  induction n with
+  | zero =>
+    simp only [upperCrossingTime_zero, bot_eq_zero', eq_self_iff_true,
       lowerCrossingTime_zero, true_and, eq_comm]
     refine hitting_eq_hitting_of_exists hNM ?_
     rw [lowerCrossingTime, hitting_lt_iff] at h
     · obtain ⟨j, hj₁, hj₂⟩ := h
       exact ⟨j, ⟨hj₁.1, hj₁.2.le⟩, hj₂⟩
     · exact le_rfl
-  · specialize ih (lt_of_le_of_lt (lowerCrossingTime_mono (Nat.le_succ _)) h)
+  | succ k ih =>
+    specialize ih (lt_of_le_of_lt (lowerCrossingTime_mono (Nat.le_succ _)) h)
       (lt_of_le_of_lt (upperCrossingTime_mono (Nat.le_succ _)) h')
     have : upperCrossingTime a b f M k.succ ω = upperCrossingTime a b f N k.succ ω := by
       rw [upperCrossingTime_succ_eq, hitting_lt_iff] at h'
@@ -623,8 +627,9 @@ theorem crossing_pos_eq (hab : a < b) :
     · rw [← sub_le_sub_iff_right a] at h
       rwa [posPart_eq_self.2 (le_trans hab'.le h)]
   have hf' (ω i) : (f i ω - a)⁺ ≤ 0 ↔ f i ω ≤ a := by rw [posPart_nonpos, sub_nonpos]
-  induction' n with k ih
-  · refine ⟨rfl, ?_⟩
+  induction n with
+  | zero =>
+    refine ⟨rfl, ?_⟩
     simp (config := { unfoldPartialApp := true }) only [lowerCrossingTime_zero, hitting,
       Set.mem_Icc, Set.mem_Iic]
     ext ω
@@ -635,7 +640,8 @@ theorem crossing_pos_eq (hab : a < b) :
     · simp_rw [Set.mem_Iic, hf' _ _] at h₁
       exact False.elim (h₁ h₂)
     · rfl
-  · have : upperCrossingTime 0 (b - a) (fun n ω => (f n ω - a)⁺) N (k + 1) =
+  | succ k ih =>
+    have : upperCrossingTime 0 (b - a) (fun n ω => (f n ω - a)⁺) N (k + 1) =
         upperCrossingTime a b f N (k + 1) := by
       ext ω
       simp only [upperCrossingTime_succ_eq, ← ih.2, hitting, Set.mem_Ici, tsub_le_iff_right]

--- a/Mathlib/Probability/Moments/Basic.lean
+++ b/Mathlib/Probability/Moments/Basic.lean
@@ -307,10 +307,12 @@ theorem aestronglyMeasurable_exp_mul_sum {X : ι → Ω → ℝ} {s : Finset ι}
     (h_int : ∀ i ∈ s, AEStronglyMeasurable (fun ω => exp (t * X i ω)) μ) :
     AEStronglyMeasurable (fun ω => exp (t * (∑ i ∈ s, X i) ω)) μ := by
   classical
-  induction' s using Finset.induction_on with i s hi_notin_s h_rec h_int
-  · simp only [Pi.zero_apply, sum_apply, sum_empty, mul_zero, exp_zero]
+  induction s using Finset.induction_on with
+  | empty =>
+    simp only [Pi.zero_apply, sum_apply, sum_empty, mul_zero, exp_zero]
     exact aestronglyMeasurable_const
-  · have : ∀ i : ι, i ∈ s → AEStronglyMeasurable (fun ω : Ω => exp (t * X i ω)) μ := fun i hi =>
+  | @insert i s hi_notin_s h_rec =>
+    have : ∀ i : ι, i ∈ s → AEStronglyMeasurable (fun ω : Ω => exp (t * X i ω)) μ := fun i hi =>
       h_int i (mem_insert_of_mem hi)
     specialize h_rec this
     rw [sum_insert hi_notin_s]
@@ -328,10 +330,12 @@ theorem iIndepFun.integrable_exp_mul_sum [IsFiniteMeasure μ] {X : ι → Ω →
     {s : Finset ι} (h_int : ∀ i ∈ s, Integrable (fun ω => exp (t * X i ω)) μ) :
     Integrable (fun ω => exp (t * (∑ i ∈ s, X i) ω)) μ := by
   classical
-  induction' s using Finset.induction_on with i s hi_notin_s h_rec h_int
-  · simp only [Pi.zero_apply, sum_apply, sum_empty, mul_zero, exp_zero]
+  induction s using Finset.induction_on with
+  | empty =>
+    simp only [Pi.zero_apply, sum_apply, sum_empty, mul_zero, exp_zero]
     exact integrable_const _
-  · have : ∀ i : ι, i ∈ s → Integrable (fun ω : Ω => exp (t * X i ω)) μ := fun i hi =>
+  | @insert i s hi_notin_s h_rec =>
+    have : ∀ i : ι, i ∈ s → Integrable (fun ω : Ω => exp (t * X i ω)) μ := fun i hi =>
       h_int i (mem_insert_of_mem hi)
     specialize h_rec this
     rw [sum_insert hi_notin_s]
@@ -345,9 +349,10 @@ theorem iIndepFun.mgf_sum {X : ι → Ω → ℝ}
     (s : Finset ι) : mgf (∑ i ∈ s, X i) μ t = ∏ i ∈ s, mgf (X i) μ t := by
   have : IsProbabilityMeasure μ := h_indep.isProbabilityMeasure
   classical
-  induction' s using Finset.induction_on with i s hi_notin_s h_rec h_int
-  · simp only [sum_empty, mgf_zero_fun, measure_univ, ENNReal.toReal_one, prod_empty]
-  · have h_int' : ∀ i : ι, AEStronglyMeasurable (fun ω : Ω => exp (t * X i ω)) μ := fun i =>
+  induction s using Finset.induction_on with
+  | empty => simp only [sum_empty, mgf_zero_fun, measure_univ, ENNReal.toReal_one, prod_empty]
+  | @insert i s hi_notin_s h_rec =>
+    have h_int' : ∀ i : ι, AEStronglyMeasurable (fun ω : Ω => exp (t * X i ω)) μ := fun i =>
       ((h_meas i).const_mul t).exp.aestronglyMeasurable
     rw [sum_insert hi_notin_s,
       IndepFun.mgf_add (h_indep.indepFun_finset_sum_of_not_mem h_meas hi_notin_s).symm (h_int' i)

--- a/Mathlib/Probability/Variance.lean
+++ b/Mathlib/Probability/Variance.lean
@@ -297,8 +297,9 @@ theorem IndepFun.variance_sum [IsProbabilityMeasure μ] {ι : Type*} {X : ι →
     (h : Set.Pairwise ↑s fun i j => IndepFun (X i) (X j) μ) :
     variance (∑ i ∈ s, X i) μ = ∑ i ∈ s, variance (X i) μ := by
   classical
-  induction' s using Finset.induction_on with k s ks IH
-  · simp only [Finset.sum_empty, variance_zero]
+  induction s using Finset.induction_on with
+  | empty => simp only [Finset.sum_empty, variance_zero]
+  | @insert k s ks IH => ?_
   rw [variance_def' (memLp_finset_sum' _ hs), sum_insert ks, sum_insert ks]
   simp only [add_sq']
   calc

--- a/Mathlib/RingTheory/AdicCompletion/LocalRing.lean
+++ b/Mathlib/RingTheory/AdicCompletion/LocalRing.lean
@@ -27,10 +27,12 @@ lemma isUnit_iff_nmem_of_isAdicComplete_maximal [IsAdicComplete m R] (r : R) :
     absurd m.ne_top_iff_one.mp (Ideal.IsMaximal.ne_top hmax)
     simp [← hs, Ideal.mul_mem_left m s mem]
   · have mapu {n : ℕ} (npos : 0 < n) : IsUnit (Ideal.Quotient.mk (m ^ n) r) := by
-      induction' n with n ih
-      · absurd npos
+      induction n with
+      | zero =>
+        absurd npos
         exact Nat.not_lt_zero 0
-      · by_cases neq0 : n = 0
+      | succ n ih =>
+        by_cases neq0 : n = 0
         · let max' : (m ^ (n + 1)).IsMaximal := by simpa only [neq0, zero_add, pow_one] using hmax
           let hField : Field (R ⧸ m ^ (n + 1)) := Ideal.Quotient.field (m ^ (n + 1))
           simpa [isUnit_iff_ne_zero, ne_eq, Ideal.Quotient.eq_zero_iff_mem.not, neq0] using h

--- a/Mathlib/RingTheory/DedekindDomain/Factorization.lean
+++ b/Mathlib/RingTheory/DedekindDomain/Factorization.lean
@@ -374,9 +374,10 @@ theorem count_one : count K v (1 : FractionalIdeal R⁰ K) = 0 := by
 theorem count_prod {ι} (s : Finset ι) (I : ι → FractionalIdeal R⁰ K) (hS : ∀ i ∈ s, I i ≠ 0) :
     count K v (∏ i ∈ s, I i) = ∑ i ∈ s, count K v (I i) := by
   classical
-  induction' s using Finset.induction with i s hi hrec
-  · rw [Finset.prod_empty, Finset.sum_empty, count_one]
-  · have hS' : ∀ i ∈ s, I i ≠ 0 := fun j hj => hS j (Finset.mem_insert_of_mem hj)
+  induction s using Finset.induction with
+  | empty => rw [Finset.prod_empty, Finset.sum_empty, count_one]
+  | @insert i s hi hrec =>
+    have hS' : ∀ i ∈ s, I i ≠ 0 := fun j hj => hS j (Finset.mem_insert_of_mem hj)
     have hS0 : ∏ i ∈ s, I i ≠ 0 := Finset.prod_ne_zero_iff.mpr hS'
     have hi0 : I i ≠ 0 := hS i (Finset.mem_insert_self i s)
     rw [Finset.prod_insert hi, Finset.sum_insert hi, count_mul K v hi0 hS0, hrec hS']
@@ -384,9 +385,10 @@ theorem count_prod {ι} (s : Finset ι) (I : ι → FractionalIdeal R⁰ K) (hS 
 /-- For every `n ∈ ℕ` and every ideal `I`, `val_v(I^n) = n*val_v(I)`. -/
 theorem count_pow (n : ℕ) (I : FractionalIdeal R⁰ K) :
     count K v (I ^ n) = n * count K v I := by
-  induction' n with n h
-  · rw [pow_zero, ofNat_zero, MulZeroClass.zero_mul, count_one]
-  · classical rw [pow_succ, count_mul']
+  induction n with
+  | zero => rw [pow_zero, ofNat_zero, MulZeroClass.zero_mul, count_one]
+  | succ n h =>
+    classical rw [pow_succ, count_mul']
     by_cases hI : I = 0
     · have h_neg : ¬(I ^ n ≠ 0 ∧ I ≠ 0) := by
         rw [not_and', not_not, ne_eq]

--- a/Mathlib/RingTheory/DedekindDomain/Ideal.lean
+++ b/Mathlib/RingTheory/DedekindDomain/Ideal.lean
@@ -484,9 +484,10 @@ theorem coe_ideal_mul_inv [h : IsDedekindDomain A] (I : Ideal A) (hI0 : I ≠ �
   rw [Polynomial.aeval_eq_sum_range]
   refine Submodule.sum_mem _ fun i hi => Submodule.smul_mem _ _ ?_
   clear hi
-  induction' i with i ih
-  · rw [pow_zero]; exact one_mem_inv_coe_ideal hI0
-  · show x ^ i.succ ∈ (I⁻¹ : FractionalIdeal A⁰ K)
+  induction i with
+  | zero => rw [pow_zero]; exact one_mem_inv_coe_ideal hI0
+  | succ i ih =>
+    show x ^ i.succ ∈ (I⁻¹ : FractionalIdeal A⁰ K)
     rw [pow_succ']; exact x_mul_mem _ ih
 
 /-- Nonzero fractional ideals in a Dedekind domain are units.

--- a/Mathlib/RingTheory/Derivation/Basic.lean
+++ b/Mathlib/RingTheory/Derivation/Basic.lean
@@ -133,9 +133,10 @@ theorem map_natCast (n : ℕ) : D (n : A) = 0 := by
 
 @[simp]
 theorem leibniz_pow (n : ℕ) : D (a ^ n) = n • a ^ (n - 1) • D a := by
-  induction' n with n ihn
-  · rw [pow_zero, map_one_eq_zero, zero_smul]
-  · rcases (zero_le n).eq_or_lt with (rfl | hpos)
+  induction n with
+  | zero => rw [pow_zero, map_one_eq_zero, zero_smul]
+  | succ n ihn =>
+    rcases (zero_le n).eq_or_lt with (rfl | hpos)
     · simp
     · have : a * a ^ (n - 1) = a ^ n := by rw [← pow_succ', Nat.sub_add_cancel hpos]
       simp only [pow_succ', leibniz, ihn, smul_comm a n (_ : M), smul_smul a, add_smul, this,

--- a/Mathlib/RingTheory/Filtration.lean
+++ b/Mathlib/RingTheory/Filtration.lean
@@ -55,9 +55,10 @@ variable (F F' : I.Filtration M) {I}
 namespace Ideal.Filtration
 
 theorem pow_smul_le (i j : ℕ) : I ^ i • F.N j ≤ F.N (i + j) := by
-  induction' i with _ ih
-  · simp
-  · rw [pow_succ', mul_smul, add_assoc, add_comm 1, ← add_assoc]
+  induction i with
+  | zero => simp
+  | succ _ ih =>
+    rw [pow_succ', mul_smul, add_assoc, add_comm 1, ← add_assoc]
     exact (smul_mono_right _ ih).trans (F.smul_le _)
 
 theorem pow_smul_le_pow_smul (i j k : ℕ) : I ^ (i + k) • F.N j ≤ I ^ k • F.N (i + j) := by
@@ -185,9 +186,10 @@ theorem Stable.exists_pow_smul_eq (h : F.Stable) : ∃ n₀, ∀ k, F.N (n₀ + 
   obtain ⟨n₀, hn⟩ := h
   use n₀
   intro k
-  induction' k with _ ih
-  · simp
-  · rw [← add_assoc, ← hn, ih, add_comm, pow_add, mul_smul, pow_one]
+  induction k with
+  | zero => simp
+  | succ _ ih =>
+    rw [← add_assoc, ← hn, ih, add_comm, pow_add, mul_smul, pow_one]
     omega
 
 theorem Stable.exists_pow_smul_eq_of_ge (h : F.Stable) :
@@ -209,9 +211,10 @@ theorem Stable.exists_forall_le (h : F.Stable) (e : F.N 0 ≤ F'.N 0) :
   obtain ⟨n₀, hF⟩ := h
   use n₀
   intro n
-  induction' n with n hn
-  · refine (F.antitone ?_).trans e; simp
-  · rw [add_right_comm, ← hF]
+  induction n with
+  | zero => refine (F.antitone ?_).trans e; simp
+  | succ n hn =>
+    rw [add_right_comm, ← hF]
     · exact (smul_mono_right _ hn).trans (F'.smul_le _)
     simp
 
@@ -309,8 +312,9 @@ theorem submodule_eq_span_le_iff_stable_ge (n₀ : ℕ) :
       refine Set.Subset.trans ?_ Submodule.subset_span
       refine @Set.subset_iUnion₂ _ _ _ (fun i => fun _ => ↑((single R i) '' ((N F i) : Set M))) i ?_
       exact hi
-    induction' i with j hj
-    · exact this _ (zero_le _)
+    induction i with
+    | zero => exact this _ (zero_le _)
+    | succ j hj => ?_
     by_cases hj' : j.succ ≤ n₀
     · exact this _ hj'
     simp only [not_le, Nat.lt_succ_iff] at hj'
@@ -403,9 +407,10 @@ theorem Ideal.mem_iInf_smul_pow_eq_bot_iff [IsNoetherianRing R] [Module.Finite R
   · rintro ⟨r, eq⟩
     rw [Submodule.mem_iInf]
     intro i
-    induction' i with i hi
-    · simp
-    · rw [add_comm, pow_add, ← smul_smul, pow_one, ← eq]
+    induction i with
+    | zero => simp
+    | succ i hi =>
+      rw [add_comm, pow_add, ← smul_smul, pow_one, ← eq]
       exact Submodule.smul_mem_smul r.prop hi
 
 theorem Ideal.iInf_pow_smul_eq_bot_of_le_jacobson [IsNoetherianRing R]

--- a/Mathlib/RingTheory/FractionalIdeal/Operations.lean
+++ b/Mathlib/RingTheory/FractionalIdeal/Operations.lean
@@ -635,9 +635,9 @@ theorem spanSingleton_mul_spanSingleton (x y : P) :
 
 @[simp]
 theorem spanSingleton_pow (x : P) (n : ℕ) : spanSingleton S x ^ n = spanSingleton S (x ^ n) := by
-  induction' n with n hn
-  · rw [pow_zero, pow_zero, spanSingleton_one]
-  · rw [pow_succ, hn, spanSingleton_mul_spanSingleton, pow_succ]
+  induction n with
+  | zero => rw [pow_zero, pow_zero, spanSingleton_one]
+  | succ n hn => rw [pow_succ, hn, spanSingleton_mul_spanSingleton, pow_succ]
 
 @[simp]
 theorem coeIdeal_span_singleton (x : R) :

--- a/Mathlib/RingTheory/GradedAlgebra/HomogeneousLocalization.lean
+++ b/Mathlib/RingTheory/GradedAlgebra/HomogeneousLocalization.lean
@@ -239,9 +239,9 @@ instance : Pow (NumDenSameDeg 𝒜 x) ℕ where
   pow c n :=
     ⟨n • c.deg, @GradedMonoid.GMonoid.gnpow _ (fun i => ↥(𝒜 i)) _ _ n _ c.num,
       @GradedMonoid.GMonoid.gnpow _ (fun i => ↥(𝒜 i)) _ _ n _ c.den, by
-        induction' n with n ih
-        · simpa only [coe_gnpow, pow_zero] using Submonoid.one_mem _
-        · simpa only [pow_succ, coe_gnpow] using x.mul_mem ih c.den_mem⟩
+        induction n with
+        | zero => simpa only [coe_gnpow, pow_zero] using Submonoid.one_mem _
+        | succ n ih => simpa only [pow_succ, coe_gnpow] using x.mul_mem ih c.den_mem⟩
 
 @[simp]
 theorem deg_pow (c : NumDenSameDeg 𝒜 x) (n : ℕ) : (c ^ n).deg = n • c.deg :=

--- a/Mathlib/RingTheory/HahnSeries/Multiplication.lean
+++ b/Mathlib/RingTheory/HahnSeries/Multiplication.lean
@@ -698,8 +698,9 @@ theorem order_mul {Γ} [AddCommMonoid Γ] [LinearOrder Γ] [IsOrderedCancelAddMo
 theorem order_pow {Γ} [AddCommMonoid Γ] [LinearOrder Γ] [IsOrderedCancelAddMonoid Γ]
     [Semiring R] [NoZeroDivisors R]
     (x : HahnSeries Γ R) (n : ℕ) : (x ^ n).order = n • x.order := by
-  induction' n with h IH
-  · simp
+  induction n with
+  | zero => simp
+  | succ h IH => ?_
   rcases eq_or_ne x 0 with (rfl | hx)
   · simp
   rw [pow_succ, order_mul (pow_ne_zero _ hx) hx, succ_nsmul, IH]
@@ -729,9 +730,9 @@ variable [Semiring R]
 
 @[simp]
 theorem single_pow (a : Γ) (n : ℕ) (r : R) : single a r ^ n = single (n • a) (r ^ n) := by
-  induction' n with n IH
-  · ext; simp only [pow_zero, coeff_one, zero_smul, coeff_single]
-  · rw [pow_succ, pow_succ, IH, single_mul_single, succ_nsmul]
+  induction n with
+  | zero => ext; simp only [pow_zero, coeff_one, zero_smul, coeff_single]
+  | succ n IH => rw [pow_succ, pow_succ, IH, single_mul_single, succ_nsmul]
 
 end Semiring
 

--- a/Mathlib/RingTheory/HahnSeries/Summable.lean
+++ b/Mathlib/RingTheory/HahnSeries/Summable.lean
@@ -590,12 +590,12 @@ section powers
 theorem support_pow_subset_closure [AddCommMonoid Γ] [PartialOrder Γ] [IsOrderedCancelAddMonoid Γ]
     [Semiring R] (x : HahnSeries Γ R)
     (n : ℕ) : support (x ^ n) ⊆ AddSubmonoid.closure (support x) := by
-  induction n with <;> intro g hn
-  | zero =>
+  induction n <;> intro g hn
+  case zero =>
     simp only [pow_zero, mem_support, coeff_one, ne_eq, ite_eq_right_iff, Classical.not_imp] at hn
     simp only [hn, SetLike.mem_coe]
     exact AddSubmonoid.zero_mem _
-  | succ n ih =>
+  case succ n ih =>
     obtain ⟨i, hi, j, hj, rfl⟩ := support_mul_subset_add_support hn
     exact SetLike.mem_coe.2 (AddSubmonoid.add_mem _ (ih hi) (AddSubmonoid.subset_closure hj))
 

--- a/Mathlib/RingTheory/HahnSeries/Summable.lean
+++ b/Mathlib/RingTheory/HahnSeries/Summable.lean
@@ -590,11 +590,13 @@ section powers
 theorem support_pow_subset_closure [AddCommMonoid Γ] [PartialOrder Γ] [IsOrderedCancelAddMonoid Γ]
     [Semiring R] (x : HahnSeries Γ R)
     (n : ℕ) : support (x ^ n) ⊆ AddSubmonoid.closure (support x) := by
-  induction' n with n ih <;> intro g hn
-  · simp only [pow_zero, mem_support, coeff_one, ne_eq, ite_eq_right_iff, Classical.not_imp] at hn
+  induction n with <;> intro g hn
+  | zero =>
+    simp only [pow_zero, mem_support, coeff_one, ne_eq, ite_eq_right_iff, Classical.not_imp] at hn
     simp only [hn, SetLike.mem_coe]
     exact AddSubmonoid.zero_mem _
-  · obtain ⟨i, hi, j, hj, rfl⟩ := support_mul_subset_add_support hn
+  | succ n ih =>
+    obtain ⟨i, hi, j, hj, rfl⟩ := support_mul_subset_add_support hn
     exact SetLike.mem_coe.2 (AddSubmonoid.add_mem _ (ih hi) (AddSubmonoid.subset_closure hj))
 
 theorem isPWO_iUnion_support_powers [AddCommMonoid Γ] [LinearOrder Γ] [IsOrderedCancelAddMonoid Γ]

--- a/Mathlib/RingTheory/Henselian.lean
+++ b/Mathlib/RingTheory/Henselian.lean
@@ -183,8 +183,9 @@ instance (priority := 100) IsAdicComplete.henselianRing (R : Type*) [CommRing R]
       -- `hfcI`  : for every `n`, `f.eval (c n)` is contained in `I ^ (n+1)`
       have hc_mod : ∀ n, c n ≡ a₀ [SMOD I] := by
         intro n
-        induction' n with n ih
-        · rfl
+        induction n with
+        | zero => rfl
+        | succ n ih => ?_
         rw [hc, sub_eq_add_neg, ← add_zero a₀]
         refine ih.add ?_
         rw [SModEq.zero, Ideal.neg_mem_iff]
@@ -199,8 +200,9 @@ instance (priority := 100) IsAdicComplete.henselianRing (R : Type*) [CommRing R]
         exact SModEq.def.mp ((hc_mod n).eval _)
       have hfcI : ∀ n, f.eval (c n) ∈ I ^ (n + 1) := by
         intro n
-        induction' n with n ih
-        · simpa only [Nat.rec_zero, zero_add, pow_one] using h₁
+        induction n with
+        | zero => simpa only [Nat.rec_zero, zero_add, pow_one] using h₁
+        | succ n ih => ?_
         rw [← taylor_eval_sub (c n), hc, sub_eq_add_neg, sub_eq_add_neg,
           add_neg_cancel_comm]
         rw [eval_eq_sum, sum_over_range' _ _ _ (lt_add_of_pos_right _ zero_lt_two), ←
@@ -226,8 +228,9 @@ instance (priority := 100) IsAdicComplete.henselianRing (R : Type*) [CommRing R]
         rw [← Ideal.one_eq_top, Ideal.smul_eq_mul, mul_one]
         obtain ⟨k, rfl⟩ := Nat.exists_eq_add_of_le hmn
         clear hmn
-        induction' k with k ih
-        · rw [add_zero]
+        induction k with
+        | zero => rw [add_zero]
+        | succ k ih => ?_
         rw [← add_assoc, hc, ← add_zero (c m), sub_eq_add_neg]
         refine ih.add ?_
         symm

--- a/Mathlib/RingTheory/HopkinsLevitzki.lean
+++ b/Mathlib/RingTheory/HopkinsLevitzki.lean
@@ -56,8 +56,9 @@ variable [IsSemiprimaryRing R]
     have := (h.semilinearMap.isSemisimpleModule_iff_of_bijective Function.bijective_id).2
       inferInstance
     exact h0 _ h
-  induction' n with n ih generalizing M
-  · rw [Jac.pow_zero, Ideal.one_eq_top] at hn; exact this (le_top.trans hn)
+  induction n generalizing M with
+  | zero => rw [Jac.pow_zero, Ideal.one_eq_top] at hn; exact this (le_top.trans hn)
+  | succ n ih => ?_
   obtain _ | n := n
   · rw [Jac.pow_one] at hn; exact this hn
   refine h1 _ (ih _ ?_) (ih _ ?_)

--- a/Mathlib/RingTheory/Ideal/Basic.lean
+++ b/Mathlib/RingTheory/Ideal/Basic.lean
@@ -109,8 +109,9 @@ theorem add_pow_add_pred_mem_of_pow_mem {m n : ℕ}
 theorem pow_multiset_sum_mem_span_pow [DecidableEq α] (s : Multiset α) (n : ℕ) :
     s.sum ^ (Multiset.card s * n + 1) ∈
     span ((s.map fun (x : α) ↦ x ^ (n + 1)).toFinset : Set α) := by
-  induction' s using Multiset.induction_on with a s hs
-  · simp
+  induction s using Multiset.induction_on with
+  | empty => simp
+  | cons a s hs => ?_
   simp only [Finset.coe_insert, Multiset.map_cons, Multiset.toFinset_cons, Multiset.sum_cons,
     Multiset.card_cons, add_pow]
   refine Submodule.sum_mem _ ?_

--- a/Mathlib/RingTheory/Ideal/Maps.lean
+++ b/Mathlib/RingTheory/Ideal/Maps.lean
@@ -610,10 +610,12 @@ theorem le_comap_mul : comap f K * comap f L ≤ comap f (K * L) :=
       mul_mono (map_le_iff_le_comap.2 <| le_rfl) (map_le_iff_le_comap.2 <| le_rfl)
 
 theorem le_comap_pow (n : ℕ) : K.comap f ^ n ≤ (K ^ n).comap f := by
-  induction' n with n n_ih
-  · rw [pow_zero, pow_zero, Ideal.one_eq_top, Ideal.one_eq_top]
+  induction n with
+  | zero =>
+    rw [pow_zero, pow_zero, Ideal.one_eq_top, Ideal.one_eq_top]
     exact rfl.le
-  · rw [pow_succ, pow_succ]
+  | succ n n_ih =>
+    rw [pow_succ, pow_succ]
     exact (Ideal.mul_mono_left n_ih).trans (Ideal.le_comap_mul f)
 
 lemma disjoint_map_primeCompl_iff_comap_le {S : Type*} [Semiring S] {f : R →+* S}

--- a/Mathlib/RingTheory/Ideal/Norm/AbsNorm.lean
+++ b/Mathlib/RingTheory/Ideal/Norm/AbsNorm.lean
@@ -146,8 +146,9 @@ theorem Ideal.mul_add_mem_pow_succ_unique [IsDedekindDomain S] (hP : P ≠ ⊥)
 /-- Multiplicity of the ideal norm, for powers of prime ideals. -/
 theorem cardQuot_pow_of_prime [IsDedekindDomain S] (hP : P ≠ ⊥) {i : ℕ} :
     cardQuot (P ^ i) = cardQuot P ^ i := by
-  induction' i with i ih
-  · simp
+  induction i with
+  | zero => simp
+  | succ i ih => ?_
   have : P ^ (i + 1) < P ^ i := Ideal.pow_succ_lt_pow hP i
   suffices hquot : map (P ^ i.succ).mkQ (P ^ i) ≃ S ⧸ P by
     rw [pow_succ' (cardQuot P), ← ih, cardQuot_apply (P ^ i.succ), ←

--- a/Mathlib/RingTheory/Ideal/Operations.lean
+++ b/Mathlib/RingTheory/Ideal/Operations.lean
@@ -323,9 +323,10 @@ theorem pow_le_self {n : ℕ} (hn : n ≠ 0) : I ^ n ≤ I :=
     _ = I := Submodule.pow_one _
 
 theorem pow_right_mono (e : I ≤ J) (n : ℕ) : I ^ n ≤ J ^ n := by
-  induction' n with _ hn
-  · rw [Submodule.pow_zero, Submodule.pow_zero]
-  · rw [Submodule.pow_succ, Submodule.pow_succ]
+  induction n with
+  | zero => rw [Submodule.pow_zero, Submodule.pow_zero]
+  | succ _ hn =>
+    rw [Submodule.pow_succ, Submodule.pow_succ]
     exact Ideal.mul_mono hn e
 
 namespace IsTwoSided
@@ -963,12 +964,14 @@ theorem subset_union_prime' {R : Type u} [CommRing R] {s : Finset ι} {f : ι �
           refine Set.Subset.trans hi <| Set.Subset.trans ?_ Set.subset_union_right
           exact Set.subset_biUnion_of_mem (u := fun x ↦ (f x : Set R)) (Finset.mem_coe.2 his)⟩
   generalize hn : s.card = n; intro h
-  induction' n with n ih generalizing a b s
-  · clear hp
+  induction n generalizing a b s with
+  | zero =>
+    clear hp
     rw [Finset.card_eq_zero] at hn
     subst hn
     rw [Finset.coe_empty, Set.biUnion_empty, Set.union_empty, subset_union] at h
     simpa only [exists_prop, Finset.not_mem_empty, false_and, exists_false, or_false]
+  | succ n ih => ?_
   classical
     replace hn : ∃ (i : ι) (t : Finset ι), i ∉ t ∧ insert i t = s ∧ t.card = n :=
       Finset.card_eq_succ.1 hn

--- a/Mathlib/RingTheory/Ideal/Quotient/Nilpotent.lean
+++ b/Mathlib/RingTheory/Ideal/Quotient/Nilpotent.lean
@@ -26,7 +26,8 @@ theorem Ideal.IsNilpotent.induction_on (hI : IsNilpotent I)
       P (J.map (Ideal.Quotient.mk I)) → P J) :
     P I := by
   obtain ⟨n, hI : I ^ n = ⊥⟩ := hI
-  induction' n using Nat.strong_induction_on with n H generalizing S
+  induction n using Nat.strong_induction_on generalizing S with
+  | h n H => ?_
   by_cases hI' : I = ⊥
   · subst hI'
     apply h₁

--- a/Mathlib/RingTheory/Idempotents.lean
+++ b/Mathlib/RingTheory/Idempotents.lean
@@ -249,9 +249,10 @@ lemma OrthogonalIdempotents.lift_of_isNilpotent_ker_aux
     (h : ∀ x ∈ RingHom.ker f, IsNilpotent x)
     {n} {e : Fin n → S} (he : OrthogonalIdempotents e) (he' : ∀ i, e i ∈ f.range) :
     ∃ e' : Fin n → R, OrthogonalIdempotents e' ∧ f ∘ e' = e := by
-  induction' n with n IH
-  · refine ⟨0, ⟨finZeroElim, finZeroElim⟩, funext finZeroElim⟩
-  · obtain ⟨e', h₁, h₂⟩ := IH (he.embedding (Fin.succEmb n)) (fun i ↦ he' _)
+  induction n with
+  | zero => refine ⟨0, ⟨finZeroElim, finZeroElim⟩, funext finZeroElim⟩
+  | succ n IH =>
+    obtain ⟨e', h₁, h₂⟩ := IH (he.embedding (Fin.succEmb n)) (fun i ↦ he' _)
     have h₂' (i) : f (e' i) = e i.succ := congr_fun h₂ i
     obtain ⟨e₀, h₃, h₄, h₅, h₆⟩ :=
       exists_isIdempotentElem_mul_eq_zero_of_ker_isNilpotent f h _ (he' 0) (he.idem 0) _

--- a/Mathlib/RingTheory/Jacobson/Ring.lean
+++ b/Mathlib/RingTheory/Jacobson/Ring.lean
@@ -644,11 +644,12 @@ private theorem quotient_mk_comp_C_isIntegral_of_isJacobsonRing'
     {R : Type*} [CommRing R] [IsJacobsonRing R]
     (P : Ideal (MvPolynomial (Fin n) R)) (hP : P.IsMaximal) :
     RingHom.IsIntegral (algebraMap R (MvPolynomial (Fin n) R ⧸ P)) := by
-  induction' n with n IH
-  · apply RingHom.isIntegral_of_surjective
+  induction n with
+  | zero =>
+    apply RingHom.isIntegral_of_surjective
     apply Function.Surjective.comp Quotient.mk_surjective
     exact C_surjective (Fin 0)
-  · apply aux_IH IH (finSuccEquiv R n).symm P hP
+  | succ n IH => apply aux_IH IH (finSuccEquiv R n).symm P hP
 
 theorem quotient_mk_comp_C_isIntegral_of_isJacobsonRing {R : Type*} [CommRing R] [IsJacobsonRing R]
     (P : Ideal (MvPolynomial (Fin n) R)) [hP : P.IsMaximal] :

--- a/Mathlib/RingTheory/LaurentSeries.lean
+++ b/Mathlib/RingTheory/LaurentSeries.lean
@@ -461,9 +461,10 @@ theorem coe_X : ((X : RatFunc F) : F⸨X⸩) = single 1 1 := by
 
 theorem single_one_eq_pow {R : Type _} [Ring R] (n : ℕ) :
     single (n : ℤ) (1 : R) = single (1 : ℤ) 1 ^ n := by
-  induction' n with n h_ind
-  · simp
-  · rw [← Int.ofNat_add_one_out, pow_succ', ← h_ind, HahnSeries.single_mul_single, one_mul,
+  induction n with
+  | zero => simp
+  | succ n h_ind =>
+    rw [← Int.ofNat_add_one_out, pow_succ', ← h_ind, HahnSeries.single_mul_single, one_mul,
       add_comm]
 
 theorem single_inv (d : ℤ) {α : F} (hα : α ≠ 0) :

--- a/Mathlib/RingTheory/LittleWedderburn.lean
+++ b/Mathlib/RingTheory/LittleWedderburn.lean
@@ -138,7 +138,8 @@ end InductionHyp
 private theorem center_eq_top [Finite D] : Subring.center D = ⊤ := by
   classical
   cases nonempty_fintype D
-  induction' hn : Fintype.card D using Nat.strong_induction_on with n IH generalizing D
+  induction hn : Fintype.card D using Nat.strong_induction_on generalizing D with
+  | h n IH => ?_
   apply InductionHyp.center_eq_top
   intro R hR x y hx hy
   suffices (⟨y, hy⟩ : R) ∈ Subring.center R by

--- a/Mathlib/RingTheory/LocalRing/Module.lean
+++ b/Mathlib/RingTheory/LocalRing/Module.lean
@@ -250,9 +250,9 @@ theorem IsLocalRing.linearIndependent_of_flat [Flat R M] {ι : Type u} (v : ι �
     (h : LinearIndependent k (TensorProduct.mk R k M 1 ∘ v)) : LinearIndependent R v := by
   rw [linearIndependent_iff']; intro s f hfv
   classical
-  induction s using Finset.induction generalizing v with <;> intro i hi
-  | empty => exact (Finset.not_mem_empty _ hi).elim
-  | @insert n s hn ih => ?_
+  induction s using Finset.induction generalizing v <;> intro i hi
+  case empty => exact (Finset.not_mem_empty _ hi).elim
+  case insert n s hn ih =>
   rw [← Finset.sum_coe_sort] at hfv
   have ⟨l, a, y, hay, hfa⟩ := Flat.isTrivialRelation_of_sum_smul_eq_zero hfv
   have : v n ∉ 𝔪 • (⊤ : Submodule R M) := by

--- a/Mathlib/RingTheory/LocalRing/Module.lean
+++ b/Mathlib/RingTheory/LocalRing/Module.lean
@@ -250,8 +250,9 @@ theorem IsLocalRing.linearIndependent_of_flat [Flat R M] {ι : Type u} (v : ι �
     (h : LinearIndependent k (TensorProduct.mk R k M 1 ∘ v)) : LinearIndependent R v := by
   rw [linearIndependent_iff']; intro s f hfv
   classical
-  induction' s using Finset.induction with n s hn ih generalizing v <;> intro i hi
-  · exact (Finset.not_mem_empty _ hi).elim
+  induction s using Finset.induction generalizing v with <;> intro i hi
+  | empty => exact (Finset.not_mem_empty _ hi).elim
+  | @insert n s hn ih => ?_
   rw [← Finset.sum_coe_sort] at hfv
   have ⟨l, a, y, hay, hfa⟩ := Flat.isTrivialRelation_of_sum_smul_eq_zero hfv
   have : v n ∉ 𝔪 • (⊤ : Submodule R M) := by

--- a/Mathlib/RingTheory/Multiplicity.lean
+++ b/Mathlib/RingTheory/Multiplicity.lean
@@ -824,16 +824,17 @@ theorem emultiplicity_mul {p a b : α} (hp : Prime p) :
 
 theorem Finset.emultiplicity_prod {β : Type*} {p : α} (hp : Prime p) (s : Finset β) (f : β → α) :
     emultiplicity p (∏ x ∈ s, f x) = ∑ x ∈ s, emultiplicity p (f x) := by classical
-    induction' s using Finset.induction with a s has ih h
-    · simp only [Finset.sum_empty, Finset.prod_empty]
+    induction s using Finset.induction with
+    | empty =>
+      simp only [Finset.sum_empty, Finset.prod_empty]
       exact emultiplicity_of_one_right hp.not_unit
-    · simpa [has, ← ih] using emultiplicity_mul hp
+    | @insert a s has ih => simpa [has, ← ih] using emultiplicity_mul hp
 
 theorem emultiplicity_pow {p a : α} (hp : Prime p) {k : ℕ} :
     emultiplicity p (a ^ k) = k * emultiplicity p a := by
-  induction' k with k hk
-  · simp [emultiplicity_of_one_right hp.not_unit]
-  · simp [pow_succ, emultiplicity_mul hp, hk, add_mul]
+  induction k with
+  | zero => simp [emultiplicity_of_one_right hp.not_unit]
+  | succ k hk => simp [pow_succ, emultiplicity_mul hp, hk, add_mul]
 
 protected theorem FiniteMultiplicity.multiplicity_pow {p a : α} (hp : Prime p)
     (ha : FiniteMultiplicity p a) {k : ℕ} : multiplicity p (a ^ k) = k * multiplicity p a := by

--- a/Mathlib/RingTheory/Nilpotent/Basic.lean
+++ b/Mathlib/RingTheory/Nilpotent/Basic.lean
@@ -223,10 +223,12 @@ lemma NoZeroSMulDivisors.isReduced (R M : Type*)
     [MonoidWithZero R] [Zero M] [MulActionWithZero R M] [Nontrivial M] [NoZeroSMulDivisors R M] :
     IsReduced R := by
   refine ⟨fun x ⟨k, hk⟩ ↦ ?_⟩
-  induction' k with k ih
-  · rw [pow_zero] at hk
+  induction k with
+  | zero =>
+    rw [pow_zero] at hk
     exact eq_zero_of_zero_eq_one hk.symm x
-  · obtain ⟨m : M, hm : m ≠ 0⟩ := exists_ne (0 : M)
+  | succ k ih =>
+    obtain ⟨m : M, hm : m ≠ 0⟩ := exists_ne (0 : M)
     have : x ^ (k + 1) • m = 0 := by simp only [hk, zero_smul]
     rw [pow_succ', mul_smul] at this
     rcases eq_zero_or_eq_zero_of_smul_eq_zero this with rfl | hx

--- a/Mathlib/RingTheory/Norm/Transitivity.lean
+++ b/Mathlib/RingTheory/Norm/Transitivity.lean
@@ -152,20 +152,19 @@ theorem Matrix.det_det [Fintype m] [Fintype n] (f : S →+* Matrix n n R) :
     (f M.det).det = ((M.map f).comp m m n n R).det := by
   set l := Fintype.card m with hl
   clear_value l; revert R S m
-  induction l with <;> intro R S m _ _ M _ _ f card
-  | zero =>
-    rw [eq_comm, Fintype.card_eq_zero_iff] at card
+  induction l <;> intro R S m _ _ M _ _ f card
+  · rw [eq_comm, Fintype.card_eq_zero_iff] at card
     simp_rw [Matrix.det_isEmpty, map_one, det_one]
-  | succ l ih => ?_
-  have ⟨k⟩ := Fintype.card_pos_iff.mp (l.succ_pos.trans_eq card)
-  let f' := f.polyToMatrix
-  let M' := cornerAddX M k
-  have : (f' M'.det).det = ((M'.map f').comp m m n n R[X]).det := by
-    refine sub_eq_zero.mp <| mem_nonZeroDivisors_iff.mp
-      (pow_mem ?_ _) _ (det_det_aux k fun M ↦ ih _ _ <| by simp [← card])
-    rw [polyToMatrix_cornerAddX, ← charpoly]
-    exact (Matrix.charpoly_monic _).mem_nonZeroDivisors
-  rw [← eval_zero_det_det, congr_arg (eval 0) this, eval_zero_comp_det]
+  · rename_i l ih _ _ _ _
+    have ⟨k⟩ := Fintype.card_pos_iff.mp (l.succ_pos.trans_eq card)
+    let f' := f.polyToMatrix
+    let M' := cornerAddX M k
+    have : (f' M'.det).det = ((M'.map f').comp m m n n R[X]).det := by
+      refine sub_eq_zero.mp <| mem_nonZeroDivisors_iff.mp
+        (pow_mem ?_ _) _ (det_det_aux k fun M ↦ ih _ _ <| by simp [← card])
+      rw [polyToMatrix_cornerAddX, ← charpoly]
+      exact (Matrix.charpoly_monic _).mem_nonZeroDivisors
+    rw [← eval_zero_det_det, congr_arg (eval 0) this, eval_zero_comp_det]
 
 variable [Algebra R S] [Module.Free R S]
 

--- a/Mathlib/RingTheory/Norm/Transitivity.lean
+++ b/Mathlib/RingTheory/Norm/Transitivity.lean
@@ -152,9 +152,11 @@ theorem Matrix.det_det [Fintype m] [Fintype n] (f : S →+* Matrix n n R) :
     (f M.det).det = ((M.map f).comp m m n n R).det := by
   set l := Fintype.card m with hl
   clear_value l; revert R S m
-  induction' l with l ih <;> intro R S m _ _ M _ _ f card
-  · rw [eq_comm, Fintype.card_eq_zero_iff] at card
+  induction l with <;> intro R S m _ _ M _ _ f card
+  | zero =>
+    rw [eq_comm, Fintype.card_eq_zero_iff] at card
     simp_rw [Matrix.det_isEmpty, map_one, det_one]
+  | succ l ih => ?_
   have ⟨k⟩ := Fintype.card_pos_iff.mp (l.succ_pos.trans_eq card)
   let f' := f.polyToMatrix
   let M' := cornerAddX M k

--- a/Mathlib/RingTheory/Perfection.lean
+++ b/Mathlib/RingTheory/Perfection.lean
@@ -489,8 +489,9 @@ theorem valAux_eq {f : PreTilt O p} {n : ℕ} (hfn : coeff _ _ n f ≠ 0) :
   rw [valAux, dif_pos h]
   classical
   obtain ⟨k, rfl⟩ := Nat.exists_eq_add_of_le (Nat.find_min' h hfn)
-  induction' k with k ih
-  · rfl
+  induction k with
+  | zero => rfl
+  | succ k ih => ?_
   obtain ⟨x, hx⟩ := Ideal.Quotient.mk_surjective (coeff (ModP O p) p (Nat.find h + k + 1) f)
   have h1 : (Ideal.Quotient.mk _ x : ModP O p) ≠ 0 := hx.symm ▸ hfn
   have h2 : (Ideal.Quotient.mk _ (x ^ p) : ModP O p) ≠ 0 := by

--- a/Mathlib/RingTheory/Polynomial/Basic.lean
+++ b/Mathlib/RingTheory/Polynomial/Basic.lean
@@ -265,9 +265,10 @@ theorem geom_sum_X_comp_X_add_one_eq_sum (n : ℕ) :
         imp_true_iff]
     · simp +contextual only [Nat.lt_add_one_iff, Nat.choose_eq_zero_of_lt,
         Nat.cast_zero, Finset.mem_range, not_lt, eq_self_iff_true, if_true, imp_true_iff]
-  induction' n with n ih generalizing i
-  · dsimp; simp only [zero_comp, coeff_zero, Nat.cast_zero]
-  · simp only [geom_sum_succ', ih, add_comp, X_pow_comp, coeff_add, Nat.choose_succ_succ,
+  induction n generalizing i with
+  | zero => dsimp; simp only [zero_comp, coeff_zero, Nat.cast_zero]
+  | succ n ih =>
+    simp only [geom_sum_succ', ih, add_comp, X_pow_comp, coeff_add, Nat.choose_succ_succ,
     Nat.cast_add, coeff_X_add_one_pow]
 
 theorem Monic.geom_sum {P : R[X]} (hP : P.Monic) (hdeg : 0 < P.natDegree) {n : ℕ} (hn : n ≠ 0) :
@@ -600,10 +601,12 @@ theorem _root_.Polynomial.coeff_prod_mem_ideal_pow_tsub {ι : Type*} (s : Finset
     (I : Ideal R) (n : ι → ℕ) (h : ∀ i ∈ s, ∀ (k), (f i).coeff k ∈ I ^ (n i - k)) (k : ℕ) :
     (s.prod f).coeff k ∈ I ^ (s.sum n - k) := by
   classical
-    induction' s using Finset.induction with a s ha hs generalizing k
-    · rw [sum_empty, prod_empty, coeff_one, zero_tsub, pow_zero, Ideal.one_eq_top]
+    induction s using Finset.induction generalizing k with
+    | empty =>
+      rw [sum_empty, prod_empty, coeff_one, zero_tsub, pow_zero, Ideal.one_eq_top]
       exact Submodule.mem_top
-    · rw [sum_insert ha, prod_insert ha, coeff_mul]
+    | @insert a s ha hs =>
+      rw [sum_insert ha, prod_insert ha, coeff_mul]
       apply sum_mem
       rintro ⟨i, j⟩ e
       obtain rfl : i + j = k := mem_antidiagonal.mp e
@@ -767,9 +770,10 @@ private theorem prime_C_iff_of_fintype {R : Type u} (σ : Type v) {r : R} [CommR
   convert_to Prime (C r) ↔ _
   · congr!
     simp only [renameEquiv_apply, algHom_C, algebraMap_eq]
-  · induction' Fintype.card σ with d hd
-    · exact MulEquiv.prime_iff (isEmptyAlgEquiv R (Fin 0)).symm (p := r)
-    · convert MulEquiv.prime_iff (finSuccEquiv R d).symm (p := Polynomial.C (C r))
+  · induction Fintype.card σ with
+    | zero => exact MulEquiv.prime_iff (isEmptyAlgEquiv R (Fin 0)).symm (p := r)
+    | succ d hd =>
+      convert MulEquiv.prime_iff (finSuccEquiv R d).symm (p := Polynomial.C (C r))
       · simp [← finSuccEquiv_comp_C_eq_C]
       · simp [← hd, Polynomial.prime_C_iff]
 
@@ -848,7 +852,8 @@ protected theorem Polynomial.isNoetherianRing [inst : IsNoetherianRing R] : IsNo
         rw [this]
         intro p hp
         generalize hn : p.natDegree = k
-        induction' k using Nat.strong_induction_on with k ih generalizing p
+        induction k using Nat.strong_induction_on generalizing p with
+        | h k ih => ?_
         rcases le_or_lt k N with h | h
         · subst k
           refine hs2 ⟨Polynomial.mem_degreeLE.2

--- a/Mathlib/RingTheory/Polynomial/Bernstein.lean
+++ b/Mathlib/RingTheory/Polynomial/Bernstein.lean
@@ -137,9 +137,10 @@ theorem iterate_derivative_at_0_eq_zero_of_lt (n : ℕ) {ν k : ℕ} :
   rcases ν with - | ν
   · rintro ⟨⟩
   · rw [Nat.lt_succ_iff]
-    induction' k with k ih generalizing n ν
-    · simp [eval_at_0]
-    · simp only [derivative_succ, Int.natCast_eq_zero, mul_eq_zero, Function.comp_apply,
+    induction k generalizing n ν with
+    | zero => simp [eval_at_0]
+    | succ k ih =>
+      simp only [derivative_succ, Int.natCast_eq_zero, mul_eq_zero, Function.comp_apply,
         Function.iterate_succ, Polynomial.iterate_derivative_sub,
         Polynomial.iterate_derivative_natCast_mul, Polynomial.eval_mul, Polynomial.eval_natCast,
         Polynomial.eval_sub]
@@ -161,9 +162,10 @@ theorem iterate_derivative_at_0 (n ν : ℕ) :
     (Polynomial.derivative^[ν] (bernsteinPolynomial R n ν)).eval 0 =
       (ascPochhammer R ν).eval ((n - (ν - 1) : ℕ) : R) := by
   by_cases h : ν ≤ n
-  · induction' ν with ν ih generalizing n
-    · simp [eval_at_0]
-    · have h' : ν ≤ n - 1 := le_tsub_of_add_le_right h
+  · induction ν generalizing n with
+    | zero => simp [eval_at_0]
+    | succ ν ih =>
+      have h' : ν ≤ n - 1 := le_tsub_of_add_le_right h
       simp only [derivative_succ, ih (n - 1) h', iterate_derivative_succ_at_0_eq_zero,
         Nat.succ_sub_succ_eq_sub, tsub_zero, sub_zero, iterate_derivative_sub,
         iterate_derivative_natCast_mul, eval_one, eval_mul, eval_add, eval_sub, eval_X, eval_comp,
@@ -222,9 +224,10 @@ open Submodule
 
 theorem linearIndependent_aux (n k : ℕ) (h : k ≤ n + 1) :
     LinearIndependent ℚ fun ν : Fin k => bernsteinPolynomial ℚ n ν := by
-  induction' k with k ih
-  · apply linearIndependent_empty_type
-  · apply linearIndependent_fin_succ'.mpr
+  induction k with
+  | zero => apply linearIndependent_empty_type
+  | succ k ih =>
+    apply linearIndependent_fin_succ'.mpr
     fconstructor
     · exact ih (le_of_lt h)
     · -- The actual work!

--- a/Mathlib/RingTheory/Polynomial/Content.lean
+++ b/Mathlib/RingTheory/Polynomial/Content.lean
@@ -113,8 +113,9 @@ theorem content_X_mul {p : R[X]} : content (X * p) = content p := by
 
 @[simp]
 theorem content_X_pow {k : ℕ} : content ((X : R[X]) ^ k) = 1 := by
-  induction' k with k hi
-  · simp
+  induction k with
+  | zero => simp
+  | succ k hi => ?_
   rw [pow_succ', content_X_mul, hi]
 
 @[simp]
@@ -308,11 +309,13 @@ theorem content_mul {p q : R[X]} : (p * q).content = p.content * q.content := by
       apply h
       apply lt_of_le_of_lt degree_le_natDegree (WithBot.coe_lt_coe.2 (Nat.lt_succ_self _))
     intro n
-    induction' n with n ih
-    · intro p q hpq
+    induction n with
+    | zero =>
+      intro p q hpq
       rw [Nat.cast_zero,
         Nat.WithBot.lt_zero_iff, degree_eq_bot, mul_eq_zero] at hpq
       rcases hpq with (rfl | rfl) <;> simp
+    | succ n ih => ?_
     intro p q hpq
     by_cases p0 : p = 0
     · simp [p0]

--- a/Mathlib/RingTheory/Polynomial/Cyclotomic/Basic.lean
+++ b/Mathlib/RingTheory/Polynomial/Cyclotomic/Basic.lean
@@ -177,7 +177,8 @@ theorem int_coeff_of_cyclotomic' {K : Type*} [CommRing K] [IsDomain K] {ζ : K} 
     (h : IsPrimitiveRoot ζ n) : ∃ P : ℤ[X], map (Int.castRingHom K) P =
       cyclotomic' n K ∧ P.degree = (cyclotomic' n K).degree ∧ P.Monic := by
   refine lifts_and_degree_eq_and_monic ?_ (cyclotomic'.monic n K)
-  induction' n using Nat.strong_induction_on with k ihk generalizing ζ
+  induction n using Nat.strong_induction_on generalizing ζ with
+  | h k ihk => ?_
   rcases k.eq_zero_or_pos with (rfl | hpos)
   · use 1
     simp only [cyclotomic'_zero, coe_mapRingHom, Polynomial.map_one]
@@ -465,7 +466,8 @@ theorem X_pow_sub_one_dvd_prod_cyclotomic (R : Type*) [CommRing R] {n m : ℕ} (
 theorem cyclotomic_eq_prod_X_sub_primitiveRoots {K : Type*} [CommRing K] [IsDomain K] {ζ : K}
     {n : ℕ} (hz : IsPrimitiveRoot ζ n) : cyclotomic n K = ∏ μ ∈ primitiveRoots n K, (X - C μ) := by
   rw [← cyclotomic']
-  induction' n using Nat.strong_induction_on with k hk generalizing ζ
+  induction n using Nat.strong_induction_on generalizing ζ with
+  | h k hk => ?_
   obtain hzero | hpos := k.eq_zero_or_pos
   · simp only [hzero, cyclotomic'_zero, cyclotomic_zero]
   have h : ∀ i ∈ k.properDivisors, cyclotomic i K = cyclotomic' i K := by
@@ -505,8 +507,9 @@ theorem cyclotomic_prime_pow_eq_geom_sum {R : Type*} [CommRing R] {p n : ℕ} (h
       (pow_pos hp.pos (m + 1))
     rw [eq_comm] at this
     rw [this, Nat.prod_properDivisors_prime_pow hp]
-  induction' n with n_n n_ih
-  · haveI := Fact.mk hp; simp [cyclotomic_prime]
+  induction n with
+  | zero => haveI := Fact.mk hp; simp [cyclotomic_prime]
+  | succ n_n n_ih => ?_
   rw [((eq_cyclotomic_iff (pow_pos hp.pos (n_n + 1 + 1)) _).mpr _).symm]
   rw [Nat.prod_properDivisors_prime_pow hp, Finset.prod_range_succ, n_ih]
   rw [this] at n_ih
@@ -521,7 +524,8 @@ theorem cyclotomic_prime_pow_mul_X_pow_sub_one (R : Type*) [CommRing R] (p k : �
 /-- The constant term of `cyclotomic n R` is `1` if `2 ≤ n`. -/
 theorem cyclotomic_coeff_zero (R : Type*) [CommRing R] {n : ℕ} (hn : 1 < n) :
     (cyclotomic n R).coeff 0 = 1 := by
-  induction' n using Nat.strong_induction_on with n hi
+  induction n using Nat.strong_induction_on with
+  | h n hi => ?_
   have hprod : (∏ i ∈ Nat.properDivisors n, (Polynomial.cyclotomic i R).coeff 0) = -1 := by
     rw [← Finset.insert_erase (Nat.one_mem_properDivisors_iff_one_lt.2
       (lt_of_lt_of_le one_lt_two hn)), Finset.prod_insert (Finset.not_mem_erase 1 _),

--- a/Mathlib/RingTheory/Polynomial/Cyclotomic/Eval.lean
+++ b/Mathlib/RingTheory/Polynomial/Cyclotomic/Eval.lean
@@ -63,7 +63,8 @@ private theorem cyclotomic_neg_one_pos {n : ℕ} (hn : 2 < n) {R}
 theorem cyclotomic_pos {n : ℕ} (hn : 2 < n) {R}
     [CommRing R] [LinearOrder R] [IsStrictOrderedRing R] (x : R) :
     0 < eval x (cyclotomic n R) := by
-  induction' n using Nat.strong_induction_on with n ih
+  induction n using Nat.strong_induction_on with
+  | h n ih => ?_
   have hn' : 0 < n := pos_of_gt hn
   have hn'' : 1 < n := one_lt_two.trans hn
   have := prod_cyclotomic_eq_geom_sum hn' R

--- a/Mathlib/RingTheory/Polynomial/Cyclotomic/Expand.lean
+++ b/Mathlib/RingTheory/Polynomial/Cyclotomic/Expand.lean
@@ -99,8 +99,9 @@ theorem cyclotomic_irreducible_pow_of_irreducible_pow {p : ℕ} (hp : Nat.Prime 
   rcases m.eq_zero_or_pos with (rfl | hm)
   · simpa using irreducible_X_sub_C (1 : R)
   obtain ⟨k, rfl⟩ := Nat.exists_eq_add_of_le hmn
-  induction' k with k hk
-  · simpa using h
+  induction k with
+  | zero => simpa using h
+  | succ k hk => ?_
   have : m + k ≠ 0 := (add_pos_of_pos_of_nonneg hm k.zero_le).ne'
   rw [Nat.add_succ, pow_succ, ← cyclotomic_expand_eq_cyclotomic hp <| dvd_pow_self p this] at h
   exact hk (by omega) (of_irreducible_expand hp.ne_zero h)

--- a/Mathlib/RingTheory/Polynomial/Eisenstein/IsIntegral.lean
+++ b/Mathlib/RingTheory/Polynomial/Eisenstein/IsIntegral.lean
@@ -81,11 +81,13 @@ theorem cyclotomic_prime_pow_comp_X_add_one_isEisensteinAt [hp : Fact p.Prime] (
     refine (cyclotomic.monic _ ℤ).comp (monic_X_add_C 1) fun h => ?_
     rw [natDegree_X_add_C] at h
     exact zero_ne_one h.symm
-  · induction' n with n hn
-    · intro i hi
+  · induction n with
+    | zero =>
+      intro i hi
       rw [Nat.zero_add, pow_one] at hi ⊢
       exact (cyclotomic_comp_X_add_one_isEisensteinAt p).mem hi
-    · intro i hi
+    | succ n hn =>
+      intro i hi
       rw [Ideal.submodule_span_eq, Ideal.mem_span_singleton, ← ZMod.intCast_zmod_eq_zero_iff_dvd,
         show ↑(_ : ℤ) = Int.castRingHom (ZMod p) _ by rfl, ← coeff_map, map_comp, map_cyclotomic,
         Polynomial.map_add, map_X, Polynomial.map_one, pow_add, pow_one,
@@ -261,10 +263,12 @@ theorem mem_adjoin_of_smul_prime_smul_of_minpoly_isEisensteinAt {B : PowerBasis 
   -- It is enough to prove that all coefficients of `Q` are divisible by `p`, by induction.
   -- The base case is `dvd_coeff_zero_of_aeval_eq_prime_smul_of_minpoly_isEisensteinAt`.
   refine mem_adjoin_of_dvd_coeff_of_dvd_aeval hp.ne_zero (fun i => ?_) hQ
-  induction' i using Nat.case_strong_induction_on with j hind
-  · intro _
+  induction i using Nat.case_strong_induction_on with
+  | hz =>
+    intro _
     exact dvd_coeff_zero_of_aeval_eq_prime_smul_of_minpoly_isEisensteinAt hp hBint hQ hzint hei
-  · intro hj
+  | hi j hind =>
+    intro hj
     convert hp.dvd_of_pow_dvd_pow_mul_pow_of_square_not_dvd (n := n) _ hndiv
     -- Two technical results we will need about `P.natDegree` and `Q.natDegree`.
     have H := degree_modByMonic_lt Q₁ (minpoly.monic hBint)
@@ -372,9 +376,10 @@ theorem mem_adjoin_of_smul_prime_pow_smul_of_minpoly_isEisensteinAt {B : PowerBa
     (hp : Prime p) (hBint : IsIntegral R B.gen) {n : ℕ} {z : L} (hzint : IsIntegral R z)
     (hz : p ^ n • z ∈ adjoin R ({B.gen} : Set L)) (hei : (minpoly R B.gen).IsEisensteinAt 𝓟) :
     z ∈ adjoin R ({B.gen} : Set L) := by
-  induction' n with n hn
-  · simpa using hz
-  · rw [_root_.pow_succ', mul_smul] at hz
+  induction n with
+  | zero => simpa using hz
+  | succ n hn =>
+    rw [_root_.pow_succ', mul_smul] at hz
     exact
       hn (mem_adjoin_of_smul_prime_smul_of_minpoly_isEisensteinAt hp hBint (hzint.smul _) hz hei)
 

--- a/Mathlib/RingTheory/Polynomial/Hermite/Gaussian.lean
+++ b/Mathlib/RingTheory/Polynomial/Hermite/Gaussian.lean
@@ -39,9 +39,10 @@ theorem deriv_gaussian_eq_hermite_mul_gaussian (n : ℕ) (x : ℝ) :
     deriv^[n] (fun y => Real.exp (-(y ^ 2 / 2))) x =
     (-1 : ℝ) ^ n * aeval x (hermite n) * Real.exp (-(x ^ 2 / 2)) := by
   rw [mul_assoc]
-  induction' n with n ih generalizing x
-  · rw [Function.iterate_zero_apply, pow_zero, one_mul, hermite_zero, C_1, map_one, one_mul]
-  · replace ih : deriv^[n] _ = _ := _root_.funext ih
+  induction n generalizing x with
+  | zero => rw [Function.iterate_zero_apply, pow_zero, one_mul, hermite_zero, C_1, map_one, one_mul]
+  | succ n ih =>
+    replace ih : deriv^[n] _ = _ := _root_.funext ih
     have deriv_gaussian :
       deriv (fun y => Real.exp (-(y ^ 2 / 2))) x = -x * Real.exp (-(x ^ 2 / 2)) := by
       -- Porting note (https://github.com/leanprover-community/mathlib4/issues/10745): was `simp [mul_comm, ← neg_mul]`

--- a/Mathlib/RingTheory/Polynomial/Nilpotent.lean
+++ b/Mathlib/RingTheory/Polynomial/Nilpotent.lean
@@ -107,7 +107,8 @@ nilpotent, then `P` is a unit.
 See also `Polynomial.isUnit_iff_coeff_isUnit_isNilpotent`. -/
 theorem isUnit_of_coeff_isUnit_isNilpotent (hunit : IsUnit (P.coeff 0))
     (hnil : ∀ i, i ≠ 0 → IsNilpotent (P.coeff i)) : IsUnit P := by
-  induction' h : P.natDegree using Nat.strong_induction_on with k hind generalizing P
+  induction h : P.natDegree using Nat.strong_induction_on generalizing P with
+  | h k hind => ?_
   by_cases hdeg : P.natDegree = 0
   { rw [eq_C_of_natDegree_eq_zero hdeg]
     exact hunit.map C }

--- a/Mathlib/RingTheory/Polynomial/Pochhammer.lean
+++ b/Mathlib/RingTheory/Polynomial/Pochhammer.lean
@@ -62,9 +62,10 @@ theorem ascPochhammer_succ_left (n : ℕ) :
 
 theorem monic_ascPochhammer (n : ℕ) [Nontrivial S] [NoZeroDivisors S] :
     Monic <| ascPochhammer S n := by
-  induction' n with n hn
-  · simp
-  · have : leadingCoeff (X + 1 : S[X]) = 1 := leadingCoeff_X_add_C 1
+  induction n with
+  | zero => simp
+  | succ n hn =>
+    have : leadingCoeff (X + 1 : S[X]) = 1 := leadingCoeff_X_add_C 1
     rw [ascPochhammer_succ_left, Monic.def, leadingCoeff_mul,
       leadingCoeff_comp (ne_zero_of_eq_one <| natDegree_X_add_C 1 : natDegree (X + 1) ≠ 0), hn,
       monic_X, one_mul, one_mul, this, one_pow]
@@ -141,9 +142,10 @@ theorem ascPochhammer_succ_comp_X_add_one (n : ℕ) :
 
 theorem ascPochhammer_mul (n m : ℕ) :
     ascPochhammer S n * (ascPochhammer S m).comp (X + (n : S[X])) = ascPochhammer S (n + m) := by
-  induction' m with m ih
-  · simp
-  · rw [ascPochhammer_succ_right, Polynomial.mul_X_add_natCast_comp, ← mul_assoc, ih,
+  induction m with
+  | zero => simp
+  | succ m ih =>
+    rw [ascPochhammer_succ_right, Polynomial.mul_X_add_natCast_comp, ← mul_assoc, ih,
       ← add_assoc, ascPochhammer_succ_right, Nat.cast_add, add_assoc]
 
 theorem ascPochhammer_nat_eq_ascFactorial (n : ℕ) :
@@ -170,9 +172,10 @@ theorem ascPochhammer_nat_eq_natCast_descFactorial (S : Type*) [Semiring S] (a b
 @[simp]
 theorem ascPochhammer_natDegree (n : ℕ) [NoZeroDivisors S] [Nontrivial S] :
     (ascPochhammer S n).natDegree = n := by
-  induction' n with n hn
-  · simp
-  · have : natDegree (X + (n : S[X])) = 1 := natDegree_X_add_C (n : S)
+  induction n with
+  | zero => simp
+  | succ n hn =>
+    have : natDegree (X + (n : S[X])) = 1 := natDegree_X_add_C (n : S)
     rw [ascPochhammer_succ_right,
         natDegree_mul _ (ne_zero_of_natDegree_gt <| this.symm ▸ Nat.zero_lt_one), hn, this]
     cases n
@@ -251,9 +254,10 @@ theorem descPochhammer_succ_left (n : ℕ) :
 
 theorem monic_descPochhammer (n : ℕ) [Nontrivial R] [NoZeroDivisors R] :
     Monic <| descPochhammer R n := by
-  induction' n with n hn
-  · simp
-  · have h : leadingCoeff (X - 1 : R[X]) = 1 := leadingCoeff_X_sub_C 1
+  induction n with
+  | zero => simp
+  | succ n hn =>
+    have h : leadingCoeff (X - 1 : R[X]) = 1 := leadingCoeff_X_sub_C 1
     have : natDegree (X - (1 : R[X])) ≠ 0 := ne_zero_of_eq_one <| natDegree_X_sub_C (1 : R)
     rw [descPochhammer_succ_left, Monic.def, leadingCoeff_mul, leadingCoeff_comp this, hn, monic_X,
         one_mul, one_mul, h, one_pow]
@@ -305,9 +309,10 @@ theorem descPochhammer_succ_right (n : ℕ) :
 @[simp]
 theorem descPochhammer_natDegree (n : ℕ) [NoZeroDivisors R] [Nontrivial R] :
     (descPochhammer R n).natDegree = n := by
-  induction' n with n hn
-  · simp
-  · have : natDegree (X - (n : R[X])) = 1 := natDegree_X_sub_C (n : R)
+  induction n with
+  | zero => simp
+  | succ n hn =>
+    have : natDegree (X - (n : R[X])) = 1 := natDegree_X_sub_C (n : R)
     rw [descPochhammer_succ_right,
         natDegree_mul _ (ne_zero_of_natDegree_gt <| this.symm ▸ Nat.zero_lt_one), hn, this]
     cases n
@@ -349,9 +354,10 @@ theorem descPochhammer_eval_eq_ascPochhammer (r : R) (n : ℕ) :
 
 theorem descPochhammer_mul (n m : ℕ) :
     descPochhammer R n * (descPochhammer R m).comp (X - (n : R[X])) = descPochhammer R (n + m) := by
-  induction' m with m ih
-  · simp
-  · rw [descPochhammer_succ_right, Polynomial.mul_X_sub_intCast_comp, ← mul_assoc, ih,
+  induction m with
+  | zero => simp
+  | succ m ih =>
+    rw [descPochhammer_succ_right, Polynomial.mul_X_sub_intCast_comp, ← mul_assoc, ih,
       ← add_assoc, descPochhammer_succ_right, Nat.cast_add, sub_add_eq_sub_sub]
 
 theorem ascPochhammer_eval_neg_eq_descPochhammer (r : R) : ∀ (k : ℕ),

--- a/Mathlib/RingTheory/Polynomial/UniqueFactorization.lean
+++ b/Mathlib/RingTheory/Polynomial/UniqueFactorization.lean
@@ -112,10 +112,12 @@ variable (d : ℕ)
 private theorem uniqueFactorizationMonoid_of_fintype [Fintype σ] :
     UniqueFactorizationMonoid (MvPolynomial σ D) :=
   (renameEquiv D (Fintype.equivFin σ)).toMulEquiv.symm.uniqueFactorizationMonoid <| by
-    induction' Fintype.card σ with d hd
-    · apply (isEmptyAlgEquiv D (Fin 0)).toMulEquiv.symm.uniqueFactorizationMonoid
+    induction Fintype.card σ with
+    | zero =>
+      apply (isEmptyAlgEquiv D (Fin 0)).toMulEquiv.symm.uniqueFactorizationMonoid
       infer_instance
-    · apply (finSuccEquiv D d).toMulEquiv.symm.uniqueFactorizationMonoid
+    | succ d hd =>
+      apply (finSuccEquiv D d).toMulEquiv.symm.uniqueFactorizationMonoid
       exact Polynomial.uniqueFactorizationMonoid
 
 instance (priority := 100) uniqueFactorizationMonoid :

--- a/Mathlib/RingTheory/PowerSeries/Basic.lean
+++ b/Mathlib/RingTheory/PowerSeries/Basic.lean
@@ -694,7 +694,8 @@ theorem eq_zero_or_eq_zero_of_mul_eq_zero [NoZeroDivisors R] (φ ψ : R⟦X⟧) 
   have hm₂ : ∀ k < m, ¬coeff R k φ ≠ 0 := fun k => Nat.find_min ex
   ext n
   rw [(coeff R n).map_zero]
-  induction' n using Nat.strong_induction_on with n ih
+  induction n using Nat.strong_induction_on with
+  | h n ih => ?_
   replace h := congr_arg (coeff R (m + n)) h
   rw [LinearMap.map_zero, coeff_mul, Finset.sum_eq_single (m, n)] at h
   · replace h := NoZeroDivisors.eq_zero_or_eq_zero_of_mul_eq_zero h

--- a/Mathlib/RingTheory/PowerSeries/Order.lean
+++ b/Mathlib/RingTheory/PowerSeries/Order.lean
@@ -219,9 +219,10 @@ theorem coeff_mul_prod_one_sub_of_lt_order {R ι : Type*} [CommRing R] (k : ℕ)
     (φ : R⟦X⟧) (f : ι → R⟦X⟧) :
     (∀ i ∈ s, ↑k < (f i).order) → coeff R k (φ * ∏ i ∈ s, (1 - f i)) = coeff R k φ := by
   classical
-  induction' s using Finset.induction_on with a s ha ih t
-  · simp
-  · intro t
+  induction s using Finset.induction_on with
+  | empty => simp
+  | @insert a s ha ih =>
+    intro t
     simp only [Finset.mem_insert, forall_eq_or_imp] at t
     rw [Finset.prod_insert ha, ← mul_assoc, mul_right_comm, coeff_mul_one_sub_of_lt_order _ t.1]
     exact ih t.2

--- a/Mathlib/RingTheory/PowerSeries/WellKnown.lean
+++ b/Mathlib/RingTheory/PowerSeries/WellKnown.lean
@@ -258,10 +258,12 @@ theorem exp_mul_exp_neg_eq_one [Algebra ℚ A] : exp A * evalNegHom (exp A) = 1 
 
 /-- Shows that $(e^{X})^k = e^{kX}$. -/
 theorem exp_pow_eq_rescale_exp [Algebra ℚ A] (k : ℕ) : exp A ^ k = rescale (k : A) (exp A) := by
-  induction' k with k h
-  · simp only [rescale_zero, constantCoeff_exp, Function.comp_apply, map_one, cast_zero, zero_eq,
+  induction k with
+  | zero =>
+    simp only [rescale_zero, constantCoeff_exp, Function.comp_apply, map_one, cast_zero, zero_eq,
       pow_zero (exp A), coe_comp]
-  · simpa only [succ_eq_add_one, cast_add, ← exp_mul_exp_eq_exp_add (k : A), ← h, cast_one,
+  | succ k h =>
+    simpa only [succ_eq_add_one, cast_add, ← exp_mul_exp_eq_exp_add (k : A), ← h, cast_one,
     id_apply, rescale_one] using pow_succ (exp A) k
 
 /-- Shows that

--- a/Mathlib/RingTheory/Presentation.lean
+++ b/Mathlib/RingTheory/Presentation.lean
@@ -372,20 +372,23 @@ private lemma comp_relation_aux_map (r : Q.rels) :
   simp [Finsupp.prod_mapDomain_index_inj (Sum.inl_injective)]
 
 private lemma aux_surjective : Function.Surjective (Q.aux P) := fun p ↦ by
-  induction' p using MvPolynomial.induction_on with a p q hp hq p i h
-  · use rename Sum.inr <| P.σ a
+  induction p using MvPolynomial.induction_on with
+  | C a =>
+    use rename Sum.inr <| P.σ a
     simp only [aux, aeval_rename, Sum.elim_comp_inr]
     have (p : MvPolynomial P.vars R) :
         aeval (C ∘ P.val) p = (C (aeval P.val p) : MvPolynomial Q.vars S) := by
-      induction' p using MvPolynomial.induction_on with a p q hp hq p i h
-      · simp
-      · simp [hp, hq]
-      · simp [h]
+      induction p using MvPolynomial.induction_on with
+      | C a => simp
+      | add p q hp hq => simp [hp, hq]
+      | mul_X p i h => simp [h]
     simp [this]
-  · obtain ⟨a, rfl⟩ := hp
+  | add p q hp hq =>
+    obtain ⟨a, rfl⟩ := hp
     obtain ⟨b, rfl⟩ := hq
     exact ⟨a + b, map_add _ _ _⟩
-  · obtain ⟨a, rfl⟩ := h
+  | mul_X p i h =>
+    obtain ⟨a, rfl⟩ := h
     exact ⟨(a * X (Sum.inl i)), by simp⟩
 
 private lemma aux_image_relation :

--- a/Mathlib/RingTheory/Prime.lean
+++ b/Mathlib/RingTheory/Prime.lean
@@ -28,9 +28,10 @@ theorem mul_eq_mul_prime_prod {α : Type*} [DecidableEq α] {x y a : R} {s : Fin
     (hp : ∀ i ∈ s, Prime (p i)) (hx : x * y = a * ∏ i ∈ s, p i) :
     ∃ (t u : Finset α) (b c : R),
       t ∪ u = s ∧ Disjoint t u ∧ a = b * c ∧ (x = b * ∏ i ∈ t, p i) ∧ y = c * ∏ i ∈ u, p i := by
-  induction' s using Finset.induction with i s his ih generalizing x y a
-  · exact ⟨∅, ∅, x, y, by simp [hx]⟩
-  · rw [prod_insert his, ← mul_assoc] at hx
+  induction s using Finset.induction generalizing x y a with
+  | empty => exact ⟨∅, ∅, x, y, by simp [hx]⟩
+  | @insert i s his ih =>
+    rw [prod_insert his, ← mul_assoc] at hx
     have hpi : Prime (p i) := hp i (mem_insert_self _ _)
     rcases ih (fun i hi ↦ hp i (mem_insert_of_mem hi)) hx with
       ⟨t, u, b, c, htus, htu, hbc, rfl, rfl⟩

--- a/Mathlib/RingTheory/ReesAlgebra.lean
+++ b/Mathlib/RingTheory/ReesAlgebra.lean
@@ -74,9 +74,10 @@ theorem reesAlgebra.monomial_mem {I : Ideal R} {i : ℕ} {r : R} :
 
 theorem monomial_mem_adjoin_monomial {I : Ideal R} {n : ℕ} {r : R} (hr : r ∈ I ^ n) :
     monomial n r ∈ Algebra.adjoin R (Submodule.map (monomial 1 : R →ₗ[R] R[X]) I : Set R[X]) := by
-  induction' n with n hn generalizing r
-  · exact Subalgebra.algebraMap_mem _ _
-  · rw [pow_succ'] at hr
+  induction n generalizing r with
+  | zero => exact Subalgebra.algebraMap_mem _ _
+  | succ n hn =>
+    rw [pow_succ'] at hr
     apply Submodule.smul_induction_on
       -- Porting note: did not need help with motive previously
       (p := fun r => (monomial (Nat.succ n)) r ∈ Algebra.adjoin R (Submodule.map (monomial 1) I)) hr

--- a/Mathlib/RingTheory/Spectrum/Prime/ChevalleyComplexity.lean
+++ b/Mathlib/RingTheory/Spectrum/Prime/ChevalleyComplexity.lean
@@ -669,8 +669,9 @@ lemma chevalley_mvPolynomialC
         C.n ≤ numBound k (fun i ↦ 1 + (d.map Fin.val).count i) n ∧
       ∀ i, C.g i ∈ M ^ (degBound k (fun i ↦ 1 + (d.map Fin.val).count i) n) := by
   classical
-  induction' n with n IH generalizing k M
-  · refine ⟨(S.map (isEmptyRingEquiv _ _).toRingHom), ?_, ?_⟩
+  induction n generalizing k M with
+  | zero =>
+    refine ⟨(S.map (isEmptyRingEquiv _ _).toRingHom), ?_, ?_⟩
     · rw [ConstructibleSetData.toSet_map]
       show _ = (comapEquiv (isEmptyRingEquiv _ _)).symm ⁻¹' _
       rw [← Equiv.image_eq_preimage]
@@ -679,6 +680,7 @@ lemma chevalley_mvPolynomialC
         BasicConstructibleSetData.map, RingHom.coe_coe, isEmptyRingEquiv_eq_coeff_zero, pow_one,
         numBound_zero, degBound_zero, forall_exists_index, and_imp, forall_apply_eq_imp_iff₂]
       exact fun a haS ↦ ⟨hSn a haS, fun i ↦ (hS a haS i).1 0⟩
+  | succ n IH => ?_
   let e : MvPolynomial (Fin (n + 1)) R ≃ₐ[R] (MvPolynomial (Fin n) R)[X] := finSuccEquiv R n
   let S' := S.map e.toRingHom
   have hS' : S'.degBound ≤ k * (1 + d.count 0) := by

--- a/Mathlib/RingTheory/TensorProduct/Basic.lean
+++ b/Mathlib/RingTheory/TensorProduct/Basic.lean
@@ -396,9 +396,9 @@ instance instSemiring : Semiring (A ⊗[R] B) where
 
 @[simp]
 theorem tmul_pow (a : A) (b : B) (k : ℕ) : a ⊗ₜ[R] b ^ k = (a ^ k) ⊗ₜ[R] (b ^ k) := by
-  induction' k with k ih
-  · simp [one_def]
-  · simp [pow_succ, ih]
+  induction k with
+  | zero => simp [one_def]
+  | succ k ih => simp [pow_succ, ih]
 
 /-- The ring morphism `A →+* A ⊗[R] B` sending `a` to `a ⊗ₜ 1`. -/
 @[simps]

--- a/Mathlib/RingTheory/TensorProduct/MvPolynomial.lean
+++ b/Mathlib/RingTheory/TensorProduct/MvPolynomial.lean
@@ -239,12 +239,13 @@ lemma algebraTensorAlgEquiv_symm_monomial (m : σ →₀ ℕ) (a : A) :
 
 lemma aeval_one_tmul (f : σ → S) (p : MvPolynomial σ R) :
     (aeval fun x ↦ (1 ⊗ₜ[R] f x : N ⊗[R] S)) p = 1 ⊗ₜ[R] (aeval f) p := by
-  induction' p using MvPolynomial.induction_on with a p q hp hq p i h
-  · simp only [map_C, algHom_C, Algebra.TensorProduct.algebraMap_apply,
+  induction p using MvPolynomial.induction_on with
+  | C a =>
+    simp only [map_C, algHom_C, Algebra.TensorProduct.algebraMap_apply,
       RingHomCompTriple.comp_apply]
     rw [← mul_one ((algebraMap R N) a), ← Algebra.smul_def, smul_tmul, Algebra.smul_def, mul_one]
-  · simp [hp, hq, tmul_add]
-  · simp [h]
+  | add p q hp hq => simp [hp, hq, tmul_add]
+  | mul_X p i h => simp [h]
 
 section Pushout
 

--- a/Mathlib/RingTheory/UniqueFactorizationDomain/Basic.lean
+++ b/Mathlib/RingTheory/UniqueFactorizationDomain/Basic.lean
@@ -74,14 +74,16 @@ theorem prime_factors_unique [CancelCommMonoidWithZero α] :
       (∀ x ∈ f, Prime x) → (∀ x ∈ g, Prime x) → f.prod ~ᵤ g.prod → Multiset.Rel Associated f g := by
   classical
   intro f
-  induction' f using Multiset.induction_on with p f ih
-  · intros g _ hg h
+  induction f using Multiset.induction_on with
+  | empty =>
+    intros g _ hg h
     exact Multiset.rel_zero_left.2 <|
       Multiset.eq_zero_of_forall_not_mem fun x hx =>
         have : IsUnit g.prod := by simpa [associated_one_iff_isUnit] using h.symm
         (hg x hx).not_unit <|
           isUnit_iff_dvd_one.2 <| (Multiset.dvd_prod hx).trans (isUnit_iff_dvd_one.1 this)
-  · intros g hf hg hfg
+  | cons p f ih =>
+    intros g hf hg hfg
     let ⟨b, hbg, hb⟩ :=
       (exists_associated_mem_of_dvd_prod (hf p (by simp)) fun q hq => hg _ hq) <|
         hfg.dvd_iff_dvd_right.1 (show p ∣ (p ::ₘ f).prod by simp)

--- a/Mathlib/RingTheory/UniqueFactorizationDomain/FactorSet.lean
+++ b/Mathlib/RingTheory/UniqueFactorizationDomain/FactorSet.lean
@@ -456,10 +456,11 @@ theorem factors_one [Nontrivial α] : factors (1 : Associates α) = 0 := by
 @[simp]
 theorem pow_factors [Nontrivial α] {a : Associates α} {k : ℕ} :
     (a ^ k).factors = k • a.factors := by
-  induction' k with n h
-  · rw [zero_nsmul, pow_zero]
+  induction k with
+  | zero =>
+    rw [zero_nsmul, pow_zero]
     exact factors_one
-  · rw [pow_succ, succ_nsmul, factors_mul, h]
+  | succ n h => rw [pow_succ, succ_nsmul, factors_mul, h]
 
 section count
 
@@ -555,9 +556,10 @@ theorem dvd_count_of_dvd_count_mul {a b : Associates α} (hb : b ≠ 0)
 theorem count_pow [Nontrivial α] {a : Associates α} (ha : a ≠ 0)
     {p : Associates α} (hp : Irreducible p) (k : ℕ) :
     count p (a ^ k).factors = k * count p a.factors := by
-  induction' k with n h
-  · rw [pow_zero, factors_one, zero_mul, count_zero hp]
-  · rw [pow_succ', count_mul ha (pow_ne_zero _ ha) hp, h]
+  induction k with
+  | zero => rw [pow_zero, factors_one, zero_mul, count_zero hp]
+  | succ n h =>
+    rw [pow_succ', count_mul ha (pow_ne_zero _ ha) hp, h]
     ring
 
 theorem dvd_count_pow [Nontrivial α] {a : Associates α} (ha : a ≠ 0)

--- a/Mathlib/RingTheory/UniqueFactorizationDomain/Multiplicative.lean
+++ b/Mathlib/RingTheory/UniqueFactorizationDomain/Multiplicative.lean
@@ -55,8 +55,9 @@ theorem induction_on_prime_power {P : α → Prop} (s : Finset α) (i : α → �
     (hcp : ∀ {x y}, IsRelPrime x y → P x → P y → P (x * y)) :
     P (∏ p ∈ s, p ^ i p) := by
   letI := Classical.decEq α
-  induction' s using Finset.induction_on with p f' hpf' ih
-  · simpa using h1 isUnit_one
+  induction s using Finset.induction_on with
+  | empty => simpa using h1 isUnit_one
+  | @insert p f' hpf' ih => ?_
   rw [Finset.prod_insert hpf']
   exact
     hcp (prime_pow_coprime_prod_of_coprime_insert i p hpf' is_prime is_coprime)
@@ -94,8 +95,9 @@ theorem multiplicative_prime_power {f : α → β} (s : Finset α) (i j : α →
     (hcp : ∀ {x y}, IsRelPrime x y → f (x * y) = f x * f y) :
     f (∏ p ∈ s, p ^ (i p + j p)) = f (∏ p ∈ s, p ^ i p) * f (∏ p ∈ s, p ^ j p) := by
   letI := Classical.decEq α
-  induction' s using Finset.induction_on with p s hps ih
-  · simpa using h1 isUnit_one
+  induction s using Finset.induction_on with
+  | empty => simpa using h1 isUnit_one
+  | @insert p s hps ih => ?_
   have hpr_p := is_prime _ (Finset.mem_insert_self _ _)
   have hpr_s : ∀ p ∈ s, Prime p := fun p hp => is_prime _ (Finset.mem_insert_of_mem hp)
   have hcp_p := fun i => prime_pow_coprime_prod_of_coprime_insert i p hps is_prime is_coprime

--- a/Mathlib/RingTheory/UniqueFactorizationDomain/NormalizedFactors.lean
+++ b/Mathlib/RingTheory/UniqueFactorizationDomain/NormalizedFactors.lean
@@ -162,8 +162,9 @@ theorem normalizedFactors_mul {x y : α} (hx : x ≠ 0) (hy : y ≠ 0) :
 @[simp]
 theorem normalizedFactors_pow {x : α} (n : ℕ) :
     normalizedFactors (x ^ n) = n • normalizedFactors x := by
-  induction' n with n ih
-  · simp [zero_nsmul]
+  induction n with
+  | zero => simp [zero_nsmul]
+  | succ n ih => ?_
   by_cases h0 : x = 0
   · simp [h0, zero_pow n.succ_ne_zero, nsmul_zero]
   rw [pow_succ', succ_nsmul', normalizedFactors_mul h0 (pow_ne_zero _ h0), ih]

--- a/Mathlib/RingTheory/Unramified/Finite.lean
+++ b/Mathlib/RingTheory/Unramified/Finite.lean
@@ -243,14 +243,14 @@ def sec :
       LinearMap.flip_apply, TensorProduct.AlgebraTensorModule.mapBilinear_apply, RingHom.id_apply]
     trans (TensorProduct.AlgebraTensorModule.map (LinearMap.id (R := S) (M := S))
       ((LinearMap.flip (AlgHom.toLinearMap (lsmul R R M))) m)) ((1 ⊗ₜ r) * elem R S)
-    · induction' elem R S using TensorProduct.induction_on
+    · induction elem R S using TensorProduct.induction_on
       · simp
       · simp [smul_comm r]
       · simp only [map_add, mul_add, *]
     · have := one_tmul_sub_tmul_one_mul_elem (R := R) r
       rw [sub_mul, sub_eq_zero] at this
       rw [this]
-      induction' elem R S using TensorProduct.induction_on
+      induction elem R S using TensorProduct.induction_on
       · simp
       · simp [TensorProduct.smul_tmul']
       · simp only [map_add, smul_add, mul_add, *]

--- a/Mathlib/RingTheory/WittVector/DiscreteValuationRing.lean
+++ b/Mathlib/RingTheory/WittVector/DiscreteValuationRing.lean
@@ -57,8 +57,9 @@ Upgrade a Witt vector `A` whose first entry `A.coeff 0` is a unit to be, itself,
 def mkUnit {a : Units k} {A : 𝕎 k} (hA : A.coeff 0 = a) : Units (𝕎 k) :=
   Units.mkOfMulEqOne A (@WittVector.mk' p _ (inverseCoeff a A)) (by
     ext n
-    induction' n with n _
-    · simp [WittVector.mul_coeff_zero, inverseCoeff, hA]
+    induction n with
+    | zero => simp [WittVector.mul_coeff_zero, inverseCoeff, hA]
+    | succ n _ => ?_
     let H_coeff := A.coeff (n + 1) * ↑(a⁻¹ ^ p ^ (n + 1)) +
       nthRemainder p n (truncateFun (n + 1) A) fun i : Fin (n + 1) => inverseCoeff a A i
     have H := Units.mul_inv (a ^ p ^ (n + 1))

--- a/Mathlib/RingTheory/WittVector/Domain.lean
+++ b/Mathlib/RingTheory/WittVector/Domain.lean
@@ -71,9 +71,10 @@ theorem verschiebung_shift (x : 𝕎 R) (k : ℕ) (h : ∀ i < k + 1, x.coeff i 
 
 theorem eq_iterate_verschiebung {x : 𝕎 R} {n : ℕ} (h : ∀ i < n, x.coeff i = 0) :
     x = verschiebung^[n] (x.shift n) := by
-  induction' n with k ih
-  · cases x; simp [shift]
-  · dsimp; rw [verschiebung_shift]
+  induction n with
+  | zero => cases x; simp [shift]
+  | succ k ih =>
+    dsimp; rw [verschiebung_shift]
     · exact ih fun i hi => h _ (hi.trans (Nat.lt_succ_self _))
     · exact h
 

--- a/Mathlib/RingTheory/WittVector/Identities.lean
+++ b/Mathlib/RingTheory/WittVector/Identities.lean
@@ -51,16 +51,19 @@ theorem verschiebung_zmod (x : 𝕎 (ZMod p)) : verschiebung x = x * p := by
 variable (p R)
 
 theorem coeff_p_pow [CharP R p] (i : ℕ) : ((p : 𝕎 R) ^ i).coeff i = 1 := by
-  induction' i with i h
-  · simp only [one_coeff_zero, Ne, pow_zero]
-  · rw [pow_succ, ← frobenius_verschiebung, coeff_frobenius_charP,
+  induction i with
+  | zero => simp only [one_coeff_zero, Ne, pow_zero]
+  | succ i h =>
+    rw [pow_succ, ← frobenius_verschiebung, coeff_frobenius_charP,
       verschiebung_coeff_succ, h, one_pow]
 
 theorem coeff_p_pow_eq_zero [CharP R p] {i j : ℕ} (hj : j ≠ i) : ((p : 𝕎 R) ^ i).coeff j = 0 := by
-  induction' i with i hi generalizing j
-  · rw [pow_zero, one_coeff_eq_of_pos]
+  induction i generalizing j with
+  | zero =>
+    rw [pow_zero, one_coeff_eq_of_pos]
     exact Nat.pos_of_ne_zero hj
-  · rw [pow_succ, ← frobenius_verschiebung, coeff_frobenius_charP]
+  | succ i hi =>
+    rw [pow_succ, ← frobenius_verschiebung, coeff_frobenius_charP]
     cases j
     · rw [verschiebung_coeff_zero, zero_pow hp.out.ne_zero]
     · rw [verschiebung_coeff_succ, hi (ne_of_apply_ne _ hj), zero_pow hp.out.ne_zero]
@@ -109,9 +112,10 @@ theorem mul_charP_coeff_succ [CharP R p] (x : 𝕎 R) (i : ℕ) :
 
 theorem mul_pow_charP_coeff_zero [CharP R p] (x : 𝕎 R) {m n : ℕ} (h : m < n) :
     (x * p ^ n).coeff m = 0 := by
-  induction' n with n ih generalizing m
-  · contradiction
-  · rw [pow_succ, ← mul_assoc]
+  induction n generalizing m with
+  | zero => contradiction
+  | succ n ih =>
+    rw [pow_succ, ← mul_assoc]
     cases m with
     | zero => exact mul_charP_coeff_zero _
     | succ m' =>
@@ -120,9 +124,10 @@ theorem mul_pow_charP_coeff_zero [CharP R p] (x : 𝕎 R) {m n : ℕ} (h : m < n
 
 theorem mul_pow_charP_coeff_succ [CharP R p] (x : 𝕎 R) {m n : ℕ} :
     (x * p ^ n).coeff (m + n) = x.coeff m ^ (p ^ n) := by
-  induction' n with n ih generalizing m
-  · simp
-  · rw [pow_succ, ← mul_assoc, ← add_assoc,mul_charP_coeff_succ, pow_succ, pow_mul]
+  induction n generalizing m with
+  | zero => simp
+  | succ n ih =>
+    rw [pow_succ, ← mul_assoc, ← add_assoc,mul_charP_coeff_succ, pow_succ, pow_mul]
     congr
     exact ih
 
@@ -144,9 +149,10 @@ open Function
 
 theorem iterate_verschiebung_coeff_eq_zero (x : 𝕎 R) {n : ℕ} {m : ℕ} (h : m < n) :
     (verschiebung^[n] x).coeff m = 0 := by
-  induction' n with n ih generalizing m
-  · contradiction
-  · rw [iterate_succ_apply']
+  induction n generalizing m with
+  | zero => contradiction
+  | succ n ih =>
+    rw [iterate_succ_apply']
     cases m with
     | zero => exact verschiebung_coeff_zero _
     | succ m' =>
@@ -155,16 +161,18 @@ theorem iterate_verschiebung_coeff_eq_zero (x : 𝕎 R) {n : ℕ} {m : ℕ} (h :
 
 theorem iterate_verschiebung_coeff (x : 𝕎 R) (n k : ℕ) :
     (verschiebung^[n] x).coeff (k + n) = x.coeff k := by
-  induction' n with k ih
-  · simp
-  · rw [iterate_succ_apply', Nat.add_succ, verschiebung_coeff_succ]
+  induction n with
+  | zero => simp
+  | succ k ih =>
+    rw [iterate_succ_apply', Nat.add_succ, verschiebung_coeff_succ]
     exact ih
 
 theorem iterate_verschiebung_mul_left (x y : 𝕎 R) (i : ℕ) :
     verschiebung^[i] x * y = verschiebung^[i] (x * frobenius^[i] y) := by
-  induction' i with i ih generalizing y
-  · simp
-  · rw [iterate_succ_apply', ← verschiebung_mul_frobenius, ih, iterate_succ_apply']; rfl
+  induction i generalizing y with
+  | zero => simp
+  | succ i ih =>
+    rw [iterate_succ_apply', ← verschiebung_mul_frobenius, ih, iterate_succ_apply']; rfl
 
 section CharP
 
@@ -190,9 +198,10 @@ theorem iterate_verschiebung_mul (x y : 𝕎 R) (i j : ℕ) :
 -- Porting note: `ring_nf` doesn't handle powers yet; needed to add `Nat.pow_succ` rewrite
 theorem iterate_frobenius_coeff (x : 𝕎 R) (i k : ℕ) :
     (frobenius^[i] x).coeff k = x.coeff k ^ p ^ i := by
-  induction' i with i ih
-  · simp
-  · rw [iterate_succ_apply', coeff_frobenius_charP, ih, Nat.pow_succ]
+  induction i with
+  | zero => simp
+  | succ i ih =>
+    rw [iterate_succ_apply', coeff_frobenius_charP, ih, Nat.pow_succ]
     ring_nf
 
 /-- This is a slightly specialized form of [Hazewinkel, *Witt Vectors*][Haze09] 6.2 equation 5. -/
@@ -214,9 +223,10 @@ theorem iterate_verschiebung_iterate_frobenius (x : 𝕎 R) (n : ℕ) :
     verschiebung^[n] (frobenius^[n] x) = x * (p ^ n) := by
   rw [← comp_apply (f := verschiebung^[n]),
       ← Function.Commute.comp_iterate verschiebung_frobenius_comm]
-  induction' n with n ih
-  · simp
-  · rw [iterate_succ_apply', ih, pow_succ, comp_apply, verschiebung_frobenius, mul_assoc]
+  induction n with
+  | zero => simp
+  | succ n ih =>
+    rw [iterate_succ_apply', ih, pow_succ, comp_apply, verschiebung_frobenius, mul_assoc]
 
 end CharP
 

--- a/Mathlib/RingTheory/WittVector/MulP.lean
+++ b/Mathlib/RingTheory/WittVector/MulP.lean
@@ -43,9 +43,10 @@ noncomputable def wittMulN : ℕ → ℕ → MvPolynomial ℕ ℤ
 
 theorem mulN_coeff (n : ℕ) (x : 𝕎 R) (k : ℕ) :
     (x * n).coeff k = aeval x.coeff (wittMulN p n k) := by
-  induction' n with n ih generalizing k
-  · simp only [Nat.cast_zero, mul_zero, zero_coeff, wittMulN, Pi.zero_apply, map_zero]
-  · rw [wittMulN, Nat.cast_add, Nat.cast_one, mul_add, mul_one, aeval_bind₁, add_coeff]
+  induction n generalizing k with
+  | zero => simp only [Nat.cast_zero, mul_zero, zero_coeff, wittMulN, Pi.zero_apply, map_zero]
+  | succ n ih =>
+    rw [wittMulN, Nat.cast_add, Nat.cast_one, mul_add, mul_one, aeval_bind₁, add_coeff]
     apply eval₂Hom_congr (RingHom.ext_int _ _) _ rfl
     ext1 ⟨b, i⟩
     fin_cases b
@@ -62,9 +63,10 @@ theorem mulN_isPoly (n : ℕ) : IsPoly p fun _ _Rcr x => x * n :=
 @[simp]
 theorem bind₁_wittMulN_wittPolynomial (n k : ℕ) :
     bind₁ (wittMulN p n) (wittPolynomial p ℤ k) = n * wittPolynomial p ℤ k := by
-  induction' n with n ih
-  · simp [wittMulN, Nat.cast_zero, zero_mul, bind₁_zero_wittPolynomial]
-  · rw [wittMulN, ← bind₁_bind₁, wittAdd, wittStructureInt_prop]
+  induction n with
+  | zero => simp [wittMulN, Nat.cast_zero, zero_mul, bind₁_zero_wittPolynomial]
+  | succ n ih =>
+    rw [wittMulN, ← bind₁_bind₁, wittAdd, wittStructureInt_prop]
     simp only [map_add, Nat.cast_succ, bind₁_X_right]
     rw [add_mul, one_mul, bind₁_rename, bind₁_rename]
     simp only [ih, Function.uncurry, Function.comp_def, bind₁_X_left, AlgHom.id_apply,

--- a/Mathlib/SetTheory/Cardinal/Basic.lean
+++ b/Mathlib/SetTheory/Cardinal/Basic.lean
@@ -467,8 +467,9 @@ theorem nsmul_lt_aleph0_iff {n : ℕ} {a : Cardinal} : n • a < ℵ₀ ↔ n = 
   | zero => simpa using nat_lt_aleph0 0
   | succ n =>
       simp only [Nat.succ_ne_zero, false_or]
-      induction' n with n ih
-      · simp
+      induction n with
+      | zero => simp
+      | succ n ih => ?_
       rw [succ_nsmul, add_lt_aleph0_iff, ih, and_self_iff]
 
 /-- See also `Cardinal.nsmul_lt_aleph0_iff` for a hypothesis-free version. -/

--- a/Mathlib/SetTheory/Cardinal/Cofinality.lean
+++ b/Mathlib/SetTheory/Cardinal/Cofinality.lean
@@ -311,9 +311,9 @@ theorem nfpFamily_lt_ord_lift {ι} {f : ι → Ordinal → Ordinal} {c} (hc : �
   · rw [lift_max]
     apply max_lt _ hc'
     rwa [Cardinal.lift_aleph0]
-  · induction' l with i l H
-    · exact ha
-    · exact hf _ _ H
+  · induction l with
+    | nil => exact ha
+    | cons i l H => exact hf _ _ H
 
 theorem nfpFamily_lt_ord {ι} {f : ι → Ordinal → Ordinal} {c} (hc : ℵ₀ < cof c) (hc' : #ι < cof c)
     (hf : ∀ (i), ∀ b < c, f i b < c) {a} : a < c → nfpFamily.{u, u} f a < c :=

--- a/Mathlib/SetTheory/Descriptive/Tree.lean
+++ b/Mathlib/SetTheory/Descriptive/Tree.lean
@@ -33,9 +33,9 @@ namespace Tree
 variable {A : Type*} {S T : tree A}
 
 lemma mem_of_append {x y : List A} (h : x ++ y ∈ T) : x ∈ T := by
-  induction' y with y ys ih generalizing x
-  · simpa using h
-  · exact T.prop (ih (by simpa))
+  induction y generalizing x with
+  | nil => simpa using h
+  | cons y ys ih => exact T.prop (ih (by simpa))
 
 lemma mem_of_prefix {x y : List A} (h' : x <+: y) (h : y ∈ T) : x ∈ T := by
   obtain ⟨_, rfl⟩ := h'; exact mem_of_append h

--- a/Mathlib/SetTheory/Lists.lean
+++ b/Mathlib/SetTheory/Lists.lean
@@ -176,9 +176,9 @@ theorem mem_of_subset' {a} : ∀ {l₁ l₂ : Lists' α true} (_ : l₁ ⊆ l₂
 theorem subset_def {l₁ l₂ : Lists' α true} : l₁ ⊆ l₂ ↔ ∀ a ∈ l₁.toList, a ∈ l₂ :=
   ⟨fun H _ => mem_of_subset' H, fun H => by
     rw [← of_toList l₁]
-    revert H; induction toList l₁ with <;> intro H
-    | nil => exact Subset.nil
-    | cons h t t_ih =>
+    revert H; induction toList l₁ <;> intro H
+    case nil => exact Subset.nil
+    case cons h t t_ih =>
       simp only [ofList, List.find?, List.mem_cons, forall_eq_or_imp] at *
       exact cons_subset.2 ⟨H.1, t_ih H.2⟩⟩
 

--- a/Mathlib/SetTheory/Lists.lean
+++ b/Mathlib/SetTheory/Lists.lean
@@ -176,9 +176,10 @@ theorem mem_of_subset' {a} : ∀ {l₁ l₂ : Lists' α true} (_ : l₁ ⊆ l₂
 theorem subset_def {l₁ l₂ : Lists' α true} : l₁ ⊆ l₂ ↔ ∀ a ∈ l₁.toList, a ∈ l₂ :=
   ⟨fun H _ => mem_of_subset' H, fun H => by
     rw [← of_toList l₁]
-    revert H; induction' toList l₁ with h t t_ih <;> intro H
-    · exact Subset.nil
-    · simp only [ofList, List.find?, List.mem_cons, forall_eq_or_imp] at *
+    revert H; induction toList l₁ with <;> intro H
+    | nil => exact Subset.nil
+    | cons h t t_ih =>
+      simp only [ofList, List.find?, List.mem_cons, forall_eq_or_imp] at *
       exact cons_subset.2 ⟨H.1, t_ih H.2⟩⟩
 
 end Lists'

--- a/Mathlib/SetTheory/Ordinal/Basic.lean
+++ b/Mathlib/SetTheory/Ordinal/Basic.lean
@@ -1131,9 +1131,10 @@ theorem ord_zero : ord 0 = 0 :=
 theorem ord_nat (n : ℕ) : ord n = n :=
   (ord_le.2 (card_nat n).ge).antisymm
     (by
-      induction' n with n IH
-      · apply Ordinal.zero_le
-      · exact succ_le_of_lt (IH.trans_lt <| ord_lt_ord.2 <| Nat.cast_lt.2 (Nat.lt_succ_self n)))
+      induction n with
+      | zero => apply Ordinal.zero_le
+      | succ n IH =>
+        exact succ_le_of_lt (IH.trans_lt <| ord_lt_ord.2 <| Nat.cast_lt.2 (Nat.lt_succ_self n)))
 
 @[simp]
 theorem ord_one : ord 1 = 1 := by simpa using ord_nat 1

--- a/Mathlib/SetTheory/Ordinal/FixedPoint.lean
+++ b/Mathlib/SetTheory/Ordinal/FixedPoint.lean
@@ -99,9 +99,9 @@ theorem nfpFamily_le_fp (H : ∀ i, Monotone (f i)) {a b} (ab : a ≤ b) (h : �
     nfpFamily f a ≤ b := by
   apply Ordinal.iSup_le
   intro l
-  induction' l with i l IH generalizing a
-  · exact ab
-  · exact (H i (IH ab)).trans (h i)
+  induction l generalizing a with
+  | nil => exact ab
+  | cons i l IH => exact (H i (IH ab)).trans (h i)
 
 theorem nfpFamily_fp [Small.{u} ι] {i} (H : IsNormal (f i)) (a) :
     f i (nfpFamily f a) = nfpFamily f a := by
@@ -574,9 +574,9 @@ end
 theorem nfp_add_zero (a) : nfp (a + ·) 0 = a * ω := by
   simp_rw [← iSup_iterate_eq_nfp, ← iSup_mul_nat]
   congr; funext n
-  induction' n with n hn
-  · rw [Nat.cast_zero, mul_zero, iterate_zero_apply]
-  · rw [iterate_succ_apply', Nat.add_comm, Nat.cast_add, Nat.cast_one, mul_one_add, hn]
+  induction n with
+  | zero => rw [Nat.cast_zero, mul_zero, iterate_zero_apply]
+  | succ n hn => rw [iterate_succ_apply', Nat.add_comm, Nat.cast_add, Nat.cast_one, mul_one_add, hn]
 
 theorem nfp_add_eq_mul_omega0 {a b} (hba : b ≤ a * ω) : nfp (a + ·) b = a * ω := by
   apply le_antisymm (nfp_le_fp (isNormal_add_right a).monotone hba _)
@@ -614,9 +614,9 @@ theorem nfp_mul_one {a : Ordinal} (ha : 0 < a) : nfp (a * ·) 1 = a ^ ω := by
   rw [← iSup_iterate_eq_nfp, ← iSup_pow ha]
   congr
   funext n
-  induction' n with n hn
-  · rw [pow_zero, iterate_zero_apply]
-  · rw [iterate_succ_apply', Nat.add_comm, pow_add, pow_one, hn]
+  induction n with
+  | zero => rw [pow_zero, iterate_zero_apply]
+  | succ n hn => rw [iterate_succ_apply', Nat.add_comm, pow_add, pow_one, hn]
 
 @[simp]
 theorem nfp_mul_zero (a : Ordinal) : nfp (a * ·) 0 = 0 := by

--- a/Mathlib/SetTheory/Ordinal/NaturalOps.lean
+++ b/Mathlib/SetTheory/Ordinal/NaturalOps.lean
@@ -301,9 +301,9 @@ theorem succ_nadd : succ a ♯ b = succ (a ♯ b) := by rw [← one_nadd (a ♯ 
 
 @[simp]
 theorem nadd_nat (n : ℕ) : a ♯ n = a + n := by
-  induction' n with n hn
-  · simp
-  · rw [Nat.cast_succ, add_one_eq_succ, nadd_succ, add_succ, hn]
+  induction n with
+  | zero => simp
+  | succ n hn => rw [Nat.cast_succ, add_one_eq_succ, nadd_succ, add_succ, hn]
 
 @[simp]
 theorem nat_nadd (n : ℕ) : ↑n ♯ a = a + n := by rw [nadd_comm, nadd_nat]
@@ -364,9 +364,10 @@ instance : AddMonoidWithOne NatOrdinal :=
 
 @[simp]
 theorem toOrdinal_natCast (n : ℕ) : toOrdinal n = n := by
-  induction' n with n hn
-  · rfl
-  · change (toOrdinal n) ♯ 1 = n + 1
+  induction n with
+  | zero => rfl
+  | succ n hn =>
+    change (toOrdinal n) ♯ 1 = n + 1
     rw [hn]; exact nadd_one n
 
 instance : CharZero NatOrdinal where

--- a/Mathlib/SetTheory/Ordinal/Notation.lean
+++ b/Mathlib/SetTheory/Ordinal/Notation.lean
@@ -805,8 +805,9 @@ theorem repr_opow_aux₂ {a0 a'} [N0 : NF a0] [Na' : NF a'] (m : ℕ) (d : ω �
   intro R'
   haveI No : NF (oadd a0 n a') :=
     N0.oadd n (Na'.below_of_lt' <| lt_of_le_of_lt (le_add_right _ _) h)
-  induction' k with k IH
-  · cases m <;> simp [R', opowAux]
+  induction k with
+  | zero => cases m <;> simp [R', opowAux]
+  | succ k IH => ?_
   -- rename R => R'
   let R := repr (opowAux 0 a0 (oadd a0 n a' * ofNat m) k m)
   let ω0 := ω ^ repr a0

--- a/Mathlib/SetTheory/Ordinal/Principal.lean
+++ b/Mathlib/SetTheory/Ordinal/Principal.lean
@@ -79,9 +79,10 @@ theorem principal_one_iff : Principal op 1 ↔ op 0 0 = 0 := by
   · rwa [lt_one_iff_zero, ha, hb] at *
 
 theorem Principal.iterate_lt (hao : a < o) (ho : Principal op o) (n : ℕ) : (op a)^[n] a < o := by
-  induction' n with n hn
-  · rwa [Function.iterate_zero]
-  · rw [Function.iterate_succ']
+  induction n with
+  | zero => rwa [Function.iterate_zero]
+  | succ n hn =>
+    rw [Function.iterate_succ']
     exact ho hao hn
 
 theorem op_eq_self_of_principal (hao : a < o) (H : IsNormal (op a))
@@ -236,9 +237,9 @@ theorem principal_add_iff_zero_or_omega0_opow :
     apply not_lt_of_le
     suffices e : ω ^ log ω o * n + o = o by
       simpa only [e] using le_add_right (ω ^ log ω o * ↑n) o
-    induction' n with n IH
-    · simp [Nat.cast_zero, mul_zero, zero_add]
-    · simp only [Nat.cast_succ, mul_add_one, add_assoc, this, IH]
+    induction n with
+    | zero => simp [Nat.cast_zero, mul_zero, zero_add]
+    | succ n IH => simp only [Nat.cast_succ, mul_add_one, add_assoc, this, IH]
 
 theorem principal_add_opow_of_principal_add {a} (ha : Principal (· + ·) a) (b : Ordinal) :
     Principal (· + ·) (a ^ b) := by

--- a/Mathlib/SetTheory/Surreal/Dyadic.lean
+++ b/Mathlib/SetTheory/Surreal/Dyadic.lean
@@ -105,7 +105,8 @@ theorem zero_le_powHalf (n : ℕ) : 0 ≤ powHalf n :=
   (powHalf_pos n).le
 
 theorem add_powHalf_succ_self_eq_powHalf (n) : powHalf (n + 1) + powHalf (n + 1) ≈ powHalf n := by
-  induction' n using Nat.strong_induction_on with n hn
+  induction n using Nat.strong_induction_on with
+  | h n hn => ?_
   constructor <;> rw [le_iff_forall_lf] <;> constructor
   · rintro (⟨⟨⟩⟩ | ⟨⟨⟩⟩) <;> apply lf_of_lt
     · calc
@@ -163,17 +164,20 @@ theorem double_powHalf_succ_eq_powHalf (n : ℕ) : 2 * powHalf (n + 1) = powHalf
 
 @[simp]
 theorem nsmul_pow_two_powHalf (n : ℕ) : 2 ^ n * powHalf n = 1 := by
-  induction' n with n hn
-  · simp only [pow_zero, powHalf_zero, mul_one]
-  · rw [← hn, ← double_powHalf_succ_eq_powHalf n, ← mul_assoc (2 ^ n) 2 (powHalf (n + 1)),
+  induction n with
+  | zero => simp only [pow_zero, powHalf_zero, mul_one]
+  | succ n hn =>
+    rw [← hn, ← double_powHalf_succ_eq_powHalf n, ← mul_assoc (2 ^ n) 2 (powHalf (n + 1)),
       pow_succ', mul_comm 2 (2 ^ n)]
 
 @[simp]
 theorem nsmul_pow_two_powHalf' (n k : ℕ) : 2 ^ n * powHalf (n + k) = powHalf k := by
-  induction' k with k hk
-  · simp only [add_zero, Surreal.nsmul_pow_two_powHalf, eq_self_iff_true,
+  induction k with
+  | zero =>
+    simp only [add_zero, Surreal.nsmul_pow_two_powHalf, eq_self_iff_true,
       Surreal.powHalf_zero]
-  · rw [← double_powHalf_succ_eq_powHalf (n + k), ← double_powHalf_succ_eq_powHalf k,
+  | succ k hk =>
+    rw [← double_powHalf_succ_eq_powHalf (n + k), ← double_powHalf_succ_eq_powHalf k,
       ← mul_assoc, mul_comm (2 ^ n) 2, mul_assoc] at hk
     rw [← zsmul_eq_zsmul_iff' two_ne_zero]
     simpa only [zsmul_eq_mul, Int.cast_ofNat]

--- a/Mathlib/Topology/CWComplex/Classical/Basic.lean
+++ b/Mathlib/Topology/CWComplex/Classical/Basic.lean
@@ -416,9 +416,10 @@ lemma RelCWComplex.iUnion_openCell_eq_skeletonLT [RelCWComplex C D] (n : ℕ∞)
     refine iUnion₂_subset fun m hm ↦ iUnion_subset fun j ↦ ?_
     rw [← cellFrontier_union_openCell_eq_closedCell]
     apply union_subset
-    · induction' m using Nat.case_strong_induction_on with m hm'
-      · simp [cellFrontier_zero_eq_empty]
-      · obtain ⟨I, hI⟩ := cellFrontier_subset_base_union_finite_closedCell (m + 1) j
+    · induction m using Nat.case_strong_induction_on with
+      | hz => simp [cellFrontier_zero_eq_empty]
+      | hi m hm' =>
+        obtain ⟨I, hI⟩ := cellFrontier_subset_base_union_finite_closedCell (m + 1) j
         apply hI.trans
         apply union_subset subset_union_left
         apply iUnion₂_subset fun l hl ↦ iUnion₂_subset fun i _ ↦ ?_
@@ -569,9 +570,11 @@ lemma RelCWComplex.isClosed_of_isClosed_inter_openCell_or_isClosed_inter_closedC
   rw [closed C A hAC]
   refine ⟨?_, hDA⟩
   intro n j
-  induction' n using Nat.case_strong_induction_on with n hn
-  · rw [closedCell_zero_eq_singleton]
+  induction n using Nat.case_strong_induction_on with
+  | hz =>
+    rw [closedCell_zero_eq_singleton]
     exact isClosed_inter_singleton
+  | hi n hn => ?_
   specialize h n.succ n.zero_lt_succ j
   rcases h with h1 | h2
   · rw [← cellFrontier_union_openCell_eq_closedCell, inter_union_distrib_left]
@@ -590,9 +593,10 @@ The boundary of a cell is contained in a finite union of open cells of a lower d
 lemma RelCWComplex.cellFrontier_subset_finite_openCell [RelCWComplex C D] (n : ℕ) (i : cell C n) :
     ∃ I : Π m, Finset (cell C m),
     cellFrontier n i ⊆ D ∪ (⋃ (m < n) (j ∈ I m), openCell m j) := by
-  induction' n using Nat.case_strong_induction_on with n hn
-  · simp [cellFrontier_zero_eq_empty]
-  · -- We apply `cellFrontier_subset_base_union_finite_closedCell` once and then apply
+  induction n using Nat.case_strong_induction_on with
+  | hz => simp [cellFrontier_zero_eq_empty]
+  | hi n hn =>
+    -- We apply `cellFrontier_subset_base_union_finite_closedCell` once and then apply
     -- the induction hypothesis to the finitely many cells that
     -- `cellFrontier_subset_base_union_finite_closedCell` gives us.
     classical


### PR DESCRIPTION
Replace `induction'` with `induction` for the following targets:

```python
rep_dict = {("Nat", "~", 2): [("zero", 0), ("succ", 2)],
            ("Nat", "strong_induction_on", 1): [("h", 2)],
            ("Nat", "case_strong_induction_on", 2): [("hz", 0), ("hi", 2)],
            ("Nat", "le_induction", 2): [("base", 0), ("succ", 3)],
            ("List", "~", 2): [("nil", 0), ("cons", 3)],
            ("List", "reverseRecOn", 2): [("nil", 0), ("append_singleton", 3)],
            ("Multiset", "induction_on", 2): [("empty", 0), ("cons", 3)],
            ("Finset", "induction", 2): [("empty", 0), ("@insert", 4)],
            ("Finset", "induction_on", 2): [("empty", 0), ("@insert", 4)],
            ("MvPolynomial", "induction_on'", 2): [("monomial", 2), ("add", 4)],
            ("MvPolynomial", "induction_on", 3): [("C", 1), ("add", 4), ("mul_X", 3)]}
```

The script and the data file used can be found [here](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/The.20plan.20to.20remove.20induction'/near/508218834).