### PR TITLE
[Merged by Bors] - feat: local inverse of a diffeomorphism

### DIFF
--- a/Mathlib/Geometry/Manifold/LocalDiffeomorph.lean
+++ b/Mathlib/Geometry/Manifold/LocalDiffeomorph.lean
@@ -137,6 +137,89 @@ open sets `U ∋ x` and `V ∋ f x` and a diffeomorphism `Φ : U → V` such tha
 def IsLocalDiffeomorphAt (f : M → N) (x : M) : Prop :=
   ∃ Φ : PartialDiffeomorph I J M N n, x ∈ Φ.source ∧ EqOn f Φ Φ.source
 
+lemma PartialDiffeomorph.isLocalDiffeomorphAt (φ : PartialDiffeomorph I J M N n)
+    {x : M} (hx : x ∈ φ.source) : IsLocalDiffeomorphAt I J n φ x := by
+  use φ
+  exact ⟨hx, fun ⦃x⦄ ↦ congrFun rfl⟩
+
+namespace IsLocalDiffeomorphAt
+
+variable {f : M → N} {x : M}
+
+variable {I I' J n}
+
+/-- An arbitrary choice of local inverse of `f` near `x`. -/
+noncomputable def localInverse (hf : IsLocalDiffeomorphAt I J n f x) :
+    PartialDiffeomorph J I N M n := (Classical.choose hf).symm
+
+lemma localInverse_open_source (hf : IsLocalDiffeomorphAt I J n f x) :
+    IsOpen hf.localInverse.source :=
+  PartialDiffeomorph.open_source _
+
+lemma localInverse_mem_source (hf : IsLocalDiffeomorphAt I J n f x) :
+    f x ∈ hf.localInverse.source := by
+  rw [(hf.choose_spec.2 hf.choose_spec.1)]
+  exact (Classical.choose hf).map_source hf.choose_spec.1
+
+lemma localInverse_mem_target (hf : IsLocalDiffeomorphAt I J n f x) :
+    x ∈ hf.localInverse.target :=
+  hf.choose_spec.1
+
+lemma contmdiffOn_localInverse (hf : IsLocalDiffeomorphAt I J n f x) :
+    ContMDiffOn J I n hf.localInverse hf.localInverse.source :=
+  hf.localInverse.contMDiffOn_toFun
+
+lemma localInverse_right_inv (hf : IsLocalDiffeomorphAt I J n f x) {y : N}
+    (hy : y ∈ hf.localInverse.source) : f (hf.localInverse y) = y := by
+  have : hf.localInverse y ∈ hf.choose.source := by
+    rw [← hf.choose.symm_target]
+    exact hf.choose.symm.map_source hy
+  rw [hf.choose_spec.2 this]
+  exact hf.choose.right_inv hy
+
+lemma localInverse_eqOn_right (hf : IsLocalDiffeomorphAt I J n f x) :
+    EqOn (f ∘ hf.localInverse) id hf.localInverse.source :=
+  fun _y hy ↦ hf.localInverse_right_inv hy
+
+lemma localInverse_eventuallyEq_right (hf : IsLocalDiffeomorphAt I J n f x) :
+    f ∘ hf.localInverse =ᶠ[nhds (f x)] id :=
+  Filter.eventuallyEq_of_mem
+    (hf.localInverse.open_source.mem_nhds hf.localInverse_mem_source)
+    hf.localInverse_eqOn_right
+
+lemma localInverse_left_inv (hf : IsLocalDiffeomorphAt I J n f x) {x' : M}
+    (hx' : x' ∈ hf.localInverse.target) : hf.localInverse (f x') = x' := by
+  rw [hf.choose_spec.2 (hf.choose.symm_target ▸ hx')]
+  exact hf.choose.left_inv hx'
+
+lemma localInverse_eqOn_left (hf : IsLocalDiffeomorphAt I J n f x) :
+    EqOn (hf.localInverse ∘ f) id hf.localInverse.target :=
+  fun _ hx ↦ hf.localInverse_left_inv hx
+
+lemma localInverse_eventuallyEq_left (hf : IsLocalDiffeomorphAt I J n f x) :
+    hf.localInverse ∘ f =ᶠ[nhds x] id :=
+  Filter.eventuallyEq_of_mem
+    (hf.localInverse.open_target.mem_nhds hf.localInverse_mem_target) hf.localInverse_eqOn_left
+
+lemma localInverse_isLocalDiffeomorphAt (hf : IsLocalDiffeomorphAt I J n f x) :
+    IsLocalDiffeomorphAt J I n (hf.localInverse) (f x) :=
+  hf.localInverse.isLocalDiffeomorphAt _ _ _ hf.localInverse_mem_source
+
+lemma localInverse_contMDiffOn (hf : IsLocalDiffeomorphAt I J n f x) :
+    ContMDiffOn J I n hf.localInverse hf.localInverse.source :=
+  hf.localInverse.contMDiffOn_toFun
+
+lemma localInverse_contMDiffAt (hf : IsLocalDiffeomorphAt I J n f x) :
+    ContMDiffAt J I n hf.localInverse (f x) :=
+  hf.localInverse_contMDiffOn.contMDiffAt
+    (hf.localInverse.open_source.mem_nhds hf.localInverse_mem_source)
+
+lemma localInverse_mdifferentiableAt (hf : IsLocalDiffeomorphAt I J n f x) (hn : 1 ≤ n) :
+    MDifferentiableAt J I hf.localInverse (f x) :=
+  hf.localInverse_contMDiffAt.mdifferentiableAt hn
+
+end IsLocalDiffeomorphAt
+
 /-- `f : M → N` is called a **`C^n` local diffeomorphism on *s*** iff it is a local diffeomorphism
 at each `x : s`. -/
 def IsLocalDiffeomorphOn (f : M → N) (s : Set M) : Prop :=


### PR DESCRIPTION
Add IsLocalDiffeomorphAt.localInverse, a (choice of) local inverse for a local diffeomorphism at x. Prove basic API about it: if f is a local diffeomorphism at x, we prove that
- f and its local inverse near x are local inverses (in both directions),
- composing f and its local inverse is EventuallyEq to the identity near x.
- smoothness results for the local inverse.

PR #8738 will use this to prove that the differential of a local diffeomorphism is a continuous linear equivalence.

---

I wondered if adding the analogous `IsLocalDiffeomorph.localInverseAt` would be useful: if so, I'll be happy to add it.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
