### PR TITLE
refactor(Module.LinearMap.Defs): make `SemilinearMapClass` extend `AddMonoidHomClass` 

### DIFF
--- a/Mathlib/Algebra/Module/LinearMap/Defs.lean
+++ b/Mathlib/Algebra/Module/LinearMap/Defs.lean
@@ -104,7 +104,9 @@ is semilinear if it satisfies the two properties `f (x + y) = f x + f y` and
 class SemilinearMapClass (F : Type*) {R S : outParam Type*} [Semiring R] [Semiring S]
   (σ : outParam (R →+* S)) (M M₂ : outParam Type*) [AddCommMonoid M] [AddCommMonoid M₂]
     [Module R M] [Module S M₂] [FunLike F M M₂] : Prop
-    extends AddHomClass F M M₂, MulActionSemiHomClass F σ M M₂
+    extends AddMonoidHomClass F M M₂, MulActionSemiHomClass F σ M M₂ where
+  map_zero := fun f => by
+    rw [←zero_smul R 0, map_smulₛₗ, RingHom.map_zero, zero_smul]
 
 end
 
@@ -133,18 +135,10 @@ variable [AddCommMonoid M] [AddCommMonoid M₁] [AddCommMonoid M₂] [AddCommMon
 variable [Module R M] [Module R M₂] [Module S M₃]
 variable {σ : R →+* S}
 
-instance (priority := 100) instAddMonoidHomClass [FunLike F M M₃] [SemilinearMapClass F σ M M₃] :
-    AddMonoidHomClass F M M₃ :=
-  { SemilinearMapClass.toAddHomClass with
-    map_zero := fun f ↦
-      show f 0 = 0 by
-        rw [← zero_smul R (0 : M), map_smulₛₗ]
-        simp }
-
 instance (priority := 100) distribMulActionSemiHomClass
     [FunLike F M M₃] [SemilinearMapClass F σ M M₃] :
     DistribMulActionSemiHomClass F σ M M₃ :=
-  { SemilinearMapClass.toAddHomClass with
+  { SemilinearMapClass.toAddMonoidHomClass with
     map_smulₛₗ := fun f c x ↦ by rw [map_smulₛₗ] }
 
 variable {F} (f : F) [FunLike F M M₃] [SemilinearMapClass F σ M M₃]

--- a/Mathlib/Algebra/Module/LinearMap/Defs.lean
+++ b/Mathlib/Algebra/Module/LinearMap/Defs.lean
@@ -108,6 +108,8 @@ class SemilinearMapClass (F : Type*) {R S : outParam Type*} [Semiring R] [Semiri
   map_zero := fun f => by
     rw [←zero_smul R 0, map_smulₛₗ, RingHom.map_zero, zero_smul]
 
+attribute [instance 100] SemilinearMapClass.toAddMonoidHomClass
+
 end
 
 -- `map_smulₛₗ` should be `@[simp]` but doesn't fire due to https://github.com/leanprover/lean4/pull/3701.


### PR DESCRIPTION
Currently `SemilinearMapClass` extends `AddHomClass`. As both `SemilinearMapClass.toAddHomClass` and `AddMonoidHomClass.toAddHomClass` are projections, they have the same priority. With `SemilinearMapClass` declared later, it wins causing expensive failed searches in the algebraic hierarchy before `AddMonoidHomClass.toAddHomClass` is found.

The current instance `SemilinearMapClass.toAddMonoidHomClass` has lower priority so we may need to downgrade the priority of the projection also.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
