### PR TITLE
[Merged by Bors] - feat(SeparationQuotient): add `IsTopologicalGroup` instance

### DIFF
--- a/Mathlib/Topology/Algebra/SeparationQuotient/Basic.lean
+++ b/Mathlib/Topology/Algebra/SeparationQuotient/Basic.lean
@@ -92,7 +92,6 @@ instance instMul [Mul M] [ContinuousMul M] : Mul (SeparationQuotient M) where
 @[to_additive (attr := simp)]
 theorem mk_mul [Mul M] [ContinuousMul M] (a b : M) : mk (a * b) = mk a * mk b := rfl
 
-
 @[to_additive]
 instance instContinuousMul [Mul M] [ContinuousMul M] : ContinuousMul (SeparationQuotient M) where
   continuous_mul := isQuotientMap_prodMap_mk.continuous_iff.2 <| continuous_mk.comp continuous_mul
@@ -197,9 +196,9 @@ instance instGroup [Group G] [IsTopologicalGroup G] : Group (SeparationQuotient 
 instance instCommGroup [CommGroup G] [IsTopologicalGroup G] : CommGroup (SeparationQuotient G) :=
   surjective_mk.commGroup mk mk_one mk_mul mk_inv mk_div mk_pow mk_zpow
 
-/-- Neighborhoods in the quotient are precisely the map of neighborhoods in the prequotient. -/
-theorem nhds_mk (x : G) : 𝓝 (mk x) = .map mk (𝓝 x) :=
-  le_antisymm ((SeparationQuotient.isOpenMap_mk).nhds_le x) continuous_quot_mk.continuousAt
+@[to_additive]
+instance instIsTopologicalGroup [Group G] [IsTopologicalGroup G] :
+    IsTopologicalGroup (SeparationQuotient G) where
 
 end Group
 

--- a/Mathlib/Topology/Inseparable.lean
+++ b/Mathlib/Topology/Inseparable.lean
@@ -605,7 +605,8 @@ theorem comap_mk_nhds_mk : comap mk (𝓝 (mk x)) = 𝓝 x :=
 theorem comap_mk_nhdsSet_image : comap mk (𝓝ˢ (mk '' s)) = 𝓝ˢ s :=
   (isInducing_mk.nhdsSet_eq_comap _).symm
 
-/-- Neighborhoods in the quotient are precisely the map of neighborhoods in the prequotient. -/
+/-- Push-forward of the neighborhood of a point along the projection to the separation quotient
+is the neighborhood of its equivalence class. -/
 theorem map_mk_nhds : map mk (𝓝 x) = 𝓝 (mk x) := by
   rw [← comap_mk_nhds_mk, map_comap_of_surjective surjective_mk]
 

--- a/Mathlib/Topology/Inseparable.lean
+++ b/Mathlib/Topology/Inseparable.lean
@@ -605,8 +605,12 @@ theorem comap_mk_nhds_mk : comap mk (𝓝 (mk x)) = 𝓝 x :=
 theorem comap_mk_nhdsSet_image : comap mk (𝓝ˢ (mk '' s)) = 𝓝ˢ s :=
   (isInducing_mk.nhdsSet_eq_comap _).symm
 
+/-- Neighborhoods in the quotient are precisely the map of neighborhoods in the prequotient. -/
 theorem map_mk_nhds : map mk (𝓝 x) = 𝓝 (mk x) := by
   rw [← comap_mk_nhds_mk, map_comap_of_surjective surjective_mk]
+
+@[deprecated map_mk_nhds (since := "2025-03-21")]
+theorem nhds_mk (x : X) : 𝓝 (mk x) = .map mk (𝓝 x) := .symm <| map_mk_nhds ..
 
 theorem map_mk_nhdsSet : map mk (𝓝ˢ s) = 𝓝ˢ (mk '' s) := by
   rw [← comap_mk_nhdsSet_image, map_comap_of_surjective surjective_mk]


### PR DESCRIPTION
Also move `nhds_mk` and deprecate it in favor of `map_mk_nhds`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
