### PR TITLE
[Merged by Bors] - chore: rename `measureEquiv` to `measurableEquiv`

### DIFF
--- a/Mathlib/MeasureTheory/Measure/Haar/InnerProductSpace.lean
+++ b/Mathlib/MeasureTheory/Measure/Haar/InnerProductSpace.lean
@@ -29,14 +29,14 @@ namespace LinearIsometryEquiv
 variable (f : E ≃ₗᵢ[ℝ] F)
 
 /-- Every linear isometry equivalence is a measurable equivalence. -/
-def toMeasureEquiv : E ≃ᵐ F where
+def toMeasurableEquiv : E ≃ᵐ F where
   toEquiv := f
   measurable_toFun := f.continuous.measurable
   measurable_invFun := f.symm.continuous.measurable
 
-@[simp] theorem coe_toMeasureEquiv : (f.toMeasureEquiv : E → F) = f := rfl
+@[simp] theorem coe_toMeasurableEquiv : (f.toMeasurableEquiv : E → F) = f := rfl
 
-theorem toMeasureEquiv_symm : f.toMeasureEquiv.symm = f.symm.toMeasureEquiv := rfl
+theorem toMeasurableEquiv_symm : f.toMeasurableEquiv.symm = f.symm.toMeasurableEquiv := rfl
 
 end LinearIsometryEquiv
 

--- a/Mathlib/MeasureTheory/Measure/Haar/InnerProductSpace.lean
+++ b/Mathlib/MeasureTheory/Measure/Haar/InnerProductSpace.lean
@@ -34,9 +34,15 @@ def toMeasurableEquiv : E ≃ᵐ F where
   measurable_toFun := f.continuous.measurable
   measurable_invFun := f.symm.continuous.measurable
 
+@[deprecated (since := "2025-03-22")] alias toMeasureEquiv := toMeasurableEquiv
+
 @[simp] theorem coe_toMeasurableEquiv : (f.toMeasurableEquiv : E → F) = f := rfl
 
+@[deprecated (since := "2025-03-22")] alias coe_toMeasureEquiv := coe_toMeasurableEquiv
+
 theorem toMeasurableEquiv_symm : f.toMeasurableEquiv.symm = f.symm.toMeasurableEquiv := rfl
+
+@[deprecated (since := "2025-03-22")] alias toMeasureEquiv_symm := toMeasurableEquiv_symm
 
 end LinearIsometryEquiv
 

--- a/Mathlib/MeasureTheory/Measure/Haar/NormedSpace.lean
+++ b/Mathlib/MeasureTheory/Measure/Haar/NormedSpace.lean
@@ -225,10 +225,10 @@ variable (f : E' ≃ₗᵢ[ℝ] F')
 variable [NormedAddCommGroup A]
 
 theorem integrable_comp (g : F' → A) : Integrable (g ∘ f) ↔ Integrable g :=
-  f.measurePreserving.integrable_comp_emb f.toMeasureEquiv.measurableEmbedding
+  f.measurePreserving.integrable_comp_emb f.toMeasurableEquiv.measurableEmbedding
 
 theorem integral_comp [NormedSpace ℝ A] (g : F' → A) : ∫ (x : E'), g (f x) = ∫ (y : F'), g y :=
-  f.measurePreserving.integral_comp' (f := f.toMeasureEquiv) g
+  f.measurePreserving.integral_comp' (f := f.toMeasurableEquiv) g
 
 end InnerProductSpace
 


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

There were three variables defined in `Mathlib.MeasureTheory.Measure.Haar.InnerProductSpace` which used name `measureEquiv`.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
