### PR TITLE
[Merged by Bors] - chore(Dimension/Finrank): golf, reuse `variable`s

### DIFF
--- a/Mathlib/LinearAlgebra/Dimension/Finrank.lean
+++ b/Mathlib/LinearAlgebra/Dimension/Finrank.lean
@@ -57,9 +57,7 @@ noncomputable def finrank (R M : Type*) [Semiring R] [AddCommMonoid M] [Module R
 @[deprecated (since := "2024-10-01")] protected alias _root_.FiniteDimensional.finrank := finrank
 
 theorem finrank_eq_of_rank_eq {n : ℕ} (h : Module.rank R M = ↑n) : finrank R M = n := by
-  apply_fun toNat at h
-  rw [toNat_natCast] at h
-  exact mod_cast h
+  simp [finrank, h]
 
 lemma rank_eq_one_iff_finrank_eq_one : Module.rank R M = 1 ↔ finrank R M = 1 :=
   Cardinal.toNat_eq_one.symm
@@ -102,17 +100,14 @@ open Module
 
 namespace LinearEquiv
 
-variable {R M M₂ : Type*} [Semiring R] [AddCommMonoid M] [AddCommMonoid M₂]
-variable [Module R M] [Module R M₂]
-
 /-- The dimension of a finite dimensional space is preserved under linear equivalence. -/
-theorem finrank_eq (f : M ≃ₗ[R] M₂) : finrank R M = finrank R M₂ := by
+theorem finrank_eq (f : M ≃ₗ[R] N) : finrank R M = finrank R N := by
   unfold finrank
   rw [← Cardinal.toNat_lift, f.lift_rank_eq, Cardinal.toNat_lift]
 
 /-- Pushforwards of finite-dimensional submodules along a `LinearEquiv` have the same finrank. -/
-theorem finrank_map_eq (f : M ≃ₗ[R] M₂) (p : Submodule R M) :
-    finrank R (p.map (f : M →ₗ[R] M₂)) = finrank R p :=
+theorem finrank_map_eq (f : M ≃ₗ[R] N) (p : Submodule R M) :
+    finrank R (p.map (f : M →ₗ[R] N)) = finrank R p :=
   (f.submoduleMap p).finrank_eq.symm
 
 end LinearEquiv
@@ -131,4 +126,4 @@ variable (R M)
 @[simp]
 theorem finrank_top : finrank R (⊤ : Submodule R M) = finrank R M := by
   unfold finrank
-  simp [rank_top]
+  simp

--- a/Mathlib/LinearAlgebra/Dual/Lemmas.lean
+++ b/Mathlib/LinearAlgebra/Dual/Lemmas.lean
@@ -526,8 +526,7 @@ open Module
 
 theorem finrank_add_finrank_dualAnnihilator_eq (W : Subspace K V) :
     finrank K W + finrank K W.dualAnnihilator = finrank K V := by
-  rw [← W.quotEquivAnnihilator.finrank_eq (M₂ := dualAnnihilator W),
-    add_comm, Submodule.finrank_quotient_add_finrank]
+  rw [← W.quotEquivAnnihilator.finrank_eq, add_comm, Submodule.finrank_quotient_add_finrank]
 
 @[simp]
 theorem finrank_dualCoannihilator_eq {Φ : Subspace K (Module.Dual K V)} :


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)