### PR TITLE
[Merged by Bors] - chore: rename round_add_int and related declarations

### DIFF
--- a/Mathlib/Algebra/Order/Round.lean
+++ b/Mathlib/Algebra/Order/Round.lean
@@ -58,53 +58,71 @@ theorem round_ofNat (n : ℕ) [n.AtLeastTwo] : round (ofNat(n) : α) = ofNat(n) 
 theorem round_intCast (n : ℤ) : round (n : α) = n := by simp [round]
 
 @[simp]
-theorem round_add_int (x : α) (y : ℤ) : round (x + y) = round x + y := by
+theorem round_add_intCast (x : α) (y : ℤ) : round (x + y) = round x + y := by
   rw [round, round, Int.fract_add_int, Int.floor_add_int, Int.ceil_add_int, ← apply_ite₂, ite_self]
+
+@[deprecated (since := "2025-03-23")]
+alias round_add_int := round_add_intCast
 
 @[simp]
 theorem round_add_one (a : α) : round (a + 1) = round a + 1 := by
-  rw [← round_add_int a 1, cast_one]
+  rw [← round_add_intCast a 1, cast_one]
 
 @[simp]
-theorem round_sub_int (x : α) (y : ℤ) : round (x - y) = round x - y := by
+theorem round_sub_intCast (x : α) (y : ℤ) : round (x - y) = round x - y := by
   rw [sub_eq_add_neg]
   norm_cast
-  rw [round_add_int, sub_eq_add_neg]
+  rw [round_add_intCast, sub_eq_add_neg]
+
+@[deprecated (since := "2025-03-23")]
+alias round_sub_int := round_sub_intCast
 
 @[simp]
 theorem round_sub_one (a : α) : round (a - 1) = round a - 1 := by
-  rw [← round_sub_int a 1, cast_one]
+  rw [← round_sub_intCast a 1, cast_one]
 
 @[simp]
-theorem round_add_nat (x : α) (y : ℕ) : round (x + y) = round x + y :=
-  mod_cast round_add_int x y
+theorem round_add_natCast (x : α) (y : ℕ) : round (x + y) = round x + y :=
+  mod_cast round_add_intCast x y
+
+@[deprecated (since := "2025-03-23")]
+alias round_add_nat := round_add_natCast
 
 @[simp]
 theorem round_add_ofNat (x : α) (n : ℕ) [n.AtLeastTwo] :
     round (x + ofNat(n)) = round x + ofNat(n) :=
-  round_add_nat x n
+  round_add_natCast x n
 
 @[simp]
-theorem round_sub_nat (x : α) (y : ℕ) : round (x - y) = round x - y :=
-  mod_cast round_sub_int x y
+theorem round_sub_natCast (x : α) (y : ℕ) : round (x - y) = round x - y :=
+  mod_cast round_sub_intCast x y
+
+@[deprecated (since := "2025-03-23")]
+alias round_sub_nat := round_sub_natCast
 
 @[simp]
 theorem round_sub_ofNat (x : α) (n : ℕ) [n.AtLeastTwo] :
     round (x - ofNat(n)) = round x - ofNat(n) :=
-  round_sub_nat x n
+  round_sub_natCast x n
 
 @[simp]
-theorem round_int_add (x : α) (y : ℤ) : round ((y : α) + x) = y + round x := by
-  rw [add_comm, round_add_int, add_comm]
+theorem round_intCast_add (x : α) (y : ℤ) : round ((y : α) + x) = y + round x := by
+  rw [add_comm, round_add_intCast, add_comm]
+
+@[deprecated (since := "2025-03-23")]
+alias round_int_add := round_intCast_add
 
 @[simp]
-theorem round_nat_add (x : α) (y : ℕ) : round ((y : α) + x) = y + round x := by
-  rw [add_comm, round_add_nat, add_comm]
+theorem round_natCast_add (x : α) (y : ℕ) : round ((y : α) + x) = y + round x := by
+  rw [add_comm, round_add_natCast, add_comm]
+
+@[deprecated (since := "2025-03-23")]
+alias round_nat_add := round_natCast_add
 
 @[simp]
 theorem round_ofNat_add (n : ℕ) [n.AtLeastTwo] (x : α) :
     round (ofNat(n) + x) = ofNat(n) + round x :=
-  round_nat_add x n
+  round_natCast_add x n
 
 theorem abs_sub_round_eq_min (x : α) : |x - round x| = min (fract x) (1 - fract x) := by
   simp_rw [round, min_def_lt, two_mul, ← lt_tsub_iff_left]


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
