### PR TITLE
[Merged by Bors] - feat(StrongRankCondition): linear combinations with bounded number of terms

### DIFF
--- a/Mathlib/LinearAlgebra/Dimension/StrongRankCondition.lean
+++ b/Mathlib/LinearAlgebra/Dimension/StrongRankCondition.lean
@@ -45,7 +45,7 @@ universe u v w w'
 variable {R : Type u} {M : Type v} [Semiring R] [AddCommMonoid M] [Module R M]
 variable {ι : Type w} {ι' : Type w'}
 
-open Cardinal Basis Submodule Function Set
+open Cardinal Basis Submodule Function Set Module
 
 attribute [local instance] nontrivial_of_invariantBasisNumber
 
@@ -479,8 +479,6 @@ protected theorem _root_.Submodule.finrank_eq_rank [Module.Finite R M] (N : Subm
 
 end Module
 
-open Module
-
 variable {M'} [AddCommMonoid M'] [Module R M']
 
 theorem LinearMap.finrank_le_finrank_of_injective [Module.Finite R M'] {f : M →ₗ[R] M'}
@@ -503,3 +501,42 @@ theorem LinearMap.finrank_le_of_isSMulRegular {S : Type*} [CommSemiring S] [Alge
 alias LinearMap.finrank_le_of_smul_regular := LinearMap.finrank_le_of_isSMulRegular
 
 end StrongRankCondition
+
+namespace Submodule
+
+variable {K M : Type*} [DivisionRing K] [AddCommGroup M] [Module K M] {s : Set M} {x : M}
+  [Module.Finite K (span K s)]
+
+variable (K s) in
+/-- This is a version of `exists_linearIndependent`
+with an upper estimate on the size of the finite set we choose. -/
+theorem exists_finset_span_eq_linearIndepOn :
+    ∃ t : Finset M, ↑t ⊆ s ∧ t.card = finrank K (span K s) ∧
+      span K t = span K s ∧ LinearIndepOn K id (t : Set M) := by
+  rcases exists_linearIndependent K s with ⟨t, ht_sub, ht_span, ht_indep⟩
+  obtain ⟨t, rfl, ht_card⟩ : ∃ u : Finset M, ↑u = t ∧ u.card = finrank K (span K s) := by
+    rw [← Cardinal.mk_set_eq_nat_iff_finset, finrank_eq_rank, ← ht_span, rank_span_set ht_indep]
+  exact ⟨t, ht_sub, ht_card, ht_span, ht_indep⟩
+
+variable (K s) in
+theorem exists_fun_fin_finrank_span_eq :
+    ∃ f : Fin (finrank K (span K s)) → M, (∀ i, f i ∈ s) ∧ span K (range f) = span K s ∧
+      LinearIndependent K f := by
+  rcases exists_finset_span_eq_linearIndepOn K s with ⟨t, hts, ht_card, ht_span, ht_indep⟩
+  set e := (Finset.equivFinOfCardEq ht_card).symm
+  exact ⟨(↑) ∘ e, fun i ↦ hts (e i).2, by simpa, ht_indep.comp _ e.injective⟩
+
+/-- This is a version of `mem_span_set` with an estimate on the number of terms in the sum. -/
+theorem mem_span_set_iff_exists_finsupp_le_finrank :
+    x ∈ span K s ↔ ∃ c : M →₀ K, c.support.card ≤ finrank K (span K s) ∧
+      ↑c.support ⊆ s ∧ c.sum (fun mi r ↦ r • mi) = x := by
+  constructor
+  · intro h
+    rcases exists_finset_span_eq_linearIndepOn K s with ⟨t, ht_sub, ht_card, ht_span, ht_indep⟩
+    rcases mem_span_set.mp (ht_span ▸ h) with ⟨c, hct, hx⟩
+    refine ⟨c, ?_, hct.trans ht_sub, hx⟩
+    exact ht_card ▸ Finset.card_mono hct
+  · rintro ⟨c, -, hcs, hx⟩
+    exact mem_span_set.mpr ⟨c, hcs, hx⟩
+
+end Submodule


### PR DESCRIPTION
We can represent an element of `Submodule.span K s`
as a linear combination
of at most `Module.finrank K (Submodule.span K s)`
elements of `s`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)