### PR TITLE
[Merged by Bors] - chore: deprecate duplicate lemma `isAlgebraic_of_isLocalization`

### DIFF
--- a/Mathlib/RingTheory/Localization/Integral.lean
+++ b/Mathlib/RingTheory/Localization/Integral.lean
@@ -429,22 +429,8 @@ theorem ideal_span_singleton_map_subset {L : Type*} [IsDomain R] [IsDomain S] [F
 
 end IsFractionRing
 
-lemma isAlgebraic_of_isLocalization {R} [CommRing R] (M : Submonoid R) (S) [CommRing S]
-    [Nontrivial R] [Algebra R S] [IsLocalization M S] : Algebra.IsAlgebraic R S := by
-  constructor
-  intro x
-  obtain ⟨x, s, rfl⟩ := IsLocalization.mk'_surjective M x
-  by_cases hs : (s : R) = 0
-  · have := IsLocalization.mk'_spec S x s
-    rw [hs, map_zero, mul_zero] at this
-    exact ⟨X, X_ne_zero, by simp [IsLocalization.mk'_eq_mul_mk'_one x, ← this]⟩
-  refine ⟨s • X - C x, ?_, ?_⟩
-  · intro e; apply hs
-    simpa only [coeff_sub, coeff_smul, coeff_X_one, coeff_C_succ, sub_zero, coeff_zero,
-      ← Algebra.algebraMap_eq_smul_one, Submonoid.smul_def,
-      Algebra.id.map_eq_id, RingHom.id_apply] using congr_arg (Polynomial.coeff · 1) e
-  · simp only [map_sub, Algebra.smul_def, Submonoid.smul_def,
-      map_mul, AlgHom.commutes, aeval_X, IsLocalization.mk'_spec', aeval_C, sub_self]
+@[deprecated (since := "2025-03-23")]
+alias isAlgebraic_of_isLocalization := IsLocalization.isAlgebraic
 
 open nonZeroDivisors in
 lemma isAlgebraic_of_isFractionRing {R S} (K L) [CommRing R] [CommRing S] [Field K] [CommRing L]


### PR DESCRIPTION
Deprecates `isAlgebraic_of_isLocalization`, which was added in 2a950180fd7e49c4a374c7595d858eed58573afc, in favor of `IsLocalization.isAlgebraic`, which was added more recently, in ea266590e7c060ee0e5a7fa6a95966304975e019.

These lemmas have the same signatures, modulo ordering of parameters.

This duplication was found by [tryAtEachStep](https://github.com/dwrensha/tryAtEachStep).