### PR TITLE
[Merged by Bors] - doc(Algebra/Ring/Action/Invariant): add module docstring

### DIFF
--- a/Mathlib/Algebra/Ring/Action/Basic.lean
+++ b/Mathlib/Algebra/Ring/Action/Basic.lean
@@ -10,19 +10,25 @@ import Mathlib.Algebra.Ring.Hom.Defs
 /-!
 # Group action on rings
 
-This file defines the typeclass of monoid acting on semirings `MulSemiringAction M R`,
-and the corresponding typeclass of invariant subrings.
+This file defines the typeclass of monoid acting on semirings `MulSemiringAction M R`.
 
-Note that `Algebra` does not satisfy the axioms of `MulSemiringAction`.
+An example of a `MulSemiringAction` is the action of the Galois group `Gal(L/K)` on
+the big field `L`. Note that `Algebra` does not in general satisfy the axioms
+of `MulSemiringAction`.
 
 ## Implementation notes
 
 There is no separate typeclass for group acting on rings, group acting on fields, etc.
 They are all grouped under `MulSemiringAction`.
 
+## Note
+
+The corresponding typeclass of subrings invariant under such an action, `IsInvariantSubring`, is
+defined in `Mathlib/Algebra/Ring/Action/Invariant.lean`.
+
 ## Tags
 
-group action, invariant subring
+group action
 
 -/
 

--- a/Mathlib/Algebra/Ring/Action/Invariant.lean
+++ b/Mathlib/Algebra/Ring/Action/Invariant.lean
@@ -6,7 +6,13 @@ Authors: Eric Wieser
 import Mathlib.GroupTheory.GroupAction.Hom
 import Mathlib.Algebra.Ring.Subring.Defs
 
-/-! # Subrings invariant under an action -/
+/-! # Subrings invariant under an action
+
+If a monoid acts on a ring via a `MulSemiringAction`, then `IsInvariantSubring` is
+a predicate on subrings asserting that the subring is fixed elementwise by the
+action.
+
+-/
 
 assert_not_exists RelIso
 


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

Currently the module docstring for `Mathlib.Algebra.Ring.Action.Basic` claims that the file contains the "corresponding typeclass of invariant subrings". This has not been true since the mathlib3 PR https://github.com/leanprover-community/mathlib3/pull/17786 which moved the typeclass into its own file (now called `Mathlib.Algebra.Ring.Action.Invariant` in mathlib4). I add a brief module docstring to `Invariant.lean` and remove the incorrect claim from `Basic.lean`.
