### PR TITLE
[Merged by Bors] - doc(NumberTheory/SelbergSieve): add missing references

### DIFF
--- a/docs/references.bib
+++ b/docs/references.bib
@@ -2120,7 +2120,7 @@
   eprint        = {math/0209360},
   archivePrefix = {arXiv},
   primaryClass  = {math.NT},
-  url           = {https://arxiv.org/abs/math/0209360},
+  url           = {https://arxiv.org/abs/math/0209360}
 }
 
 @Article{         Higman52,
@@ -3147,7 +3147,7 @@
   mrnumber      = {3971232},
   mrreviewer    = {Y.-F.\ S.\ P\'etermann},
   doi           = {10.1090/gsm/203},
-  url           = {https://doi.org/10.1090/gsm/203},
+  url           = {https://doi.org/10.1090/gsm/203}
 }
 
 @Article{         MR399081,

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -2113,6 +2113,16 @@
   pages         = {319–472}
 }
 
+@Misc{            heathbrown2002lecturessieves,
+  title         = {Lectures on sieves},
+  author        = {D. R. Heath-Brown},
+  year          = {2002},
+  eprint        = {math/0209360},
+  archivePrefix = {arXiv},
+  primaryClass  = {math.NT},
+  url           = {https://arxiv.org/abs/math/0209360},
+}
+
 @Article{         Higman52,
   author        = {Higman, Graham},
   title         = {Ordering by Divisibility in Abstract Algebras},
@@ -3122,6 +3132,22 @@
   mrnumber      = {3790629},
   doi           = {10.1103/PhysicsPhysiqueFizika.1.195},
   url           = {https://doi.org/10.1103/PhysicsPhysiqueFizika.1.195}
+}
+
+@Book{            MR3971232,
+  author        = {Koukoulopoulos, Dimitris},
+  title         = {The distribution of prime numbers},
+  series        = {Graduate Studies in Mathematics},
+  volume        = {203},
+  publisher     = {American Mathematical Society, Providence, RI},
+  year          = {[2019] \copyright 2019},
+  pages         = {xii + 356},
+  isbn          = {978-1-4704-4754-0; 978-1-4704-6285-7},
+  mrclass       = {11N05 (11-01 11M06 11N35 11N60)},
+  mrnumber      = {3971232},
+  mrreviewer    = {Y.-F.\ S.\ P\'etermann},
+  doi           = {10.1090/gsm/203},
+  url           = {https://doi.org/10.1090/gsm/203},
 }
 
 @Article{         MR399081,

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -2118,8 +2118,8 @@
   author        = {D. R. Heath-Brown},
   year          = {2002},
   eprint        = {math/0209360},
-  archivePrefix = {arXiv},
-  primaryClass  = {math.NT},
+  archiveprefix = {arXiv},
+  primaryclass  = {math.NT},
   url           = {https://arxiv.org/abs/math/0209360}
 }
 


### PR DESCRIPTION
I had forgotten to add these references in a previous PR.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

They are cited [here](https://github.com/leanprover-community/mathlib4/blob/c441f7b6964d8337ba5a736403f696aa24afe072/Mathlib/NumberTheory/SelbergSieve.lean#L39).

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
