### PR TITLE
[Merged by Bors] - refactor(GroupTheory): fix `(z)powersEquiv(Z)Powers` not being in simpNF

### DIFF
--- a/Mathlib/GroupTheory/OrderOfElement.lean
+++ b/Mathlib/GroupTheory/OrderOfElement.lean
@@ -684,7 +684,7 @@ lemma IsOfFinOrder.mem_zpowers_iff_mem_range_orderOf [DecidableEq G] (hx : IsOfF
 @[to_additive "The equivalence between `Fin (addOrderOf a)` and
 `Subgroup.zmultiples a`, sending `i` to `i • a`."]
 noncomputable def finEquivZPowers (hx : IsOfFinOrder x) :
-    Fin (orderOf x) ≃ (zpowers x : Set G) :=
+    Fin (orderOf x) ≃ zpowers x :=
   (finEquivPowers hx).trans <| Equiv.setCongr hx.powers_eq_zpowers
 
 @[to_additive]
@@ -842,13 +842,11 @@ lemma mem_zpowers_iff_mem_range_orderOf [DecidableEq G] :
   "The equivalence between `Subgroup.zmultiples` of two elements `a, b` of the same additive order,
   mapping `i • a` to `i • b`."]
 noncomputable def zpowersEquivZPowers (h : orderOf x = orderOf y) :
-    (Subgroup.zpowers x : Set G) ≃ (Subgroup.zpowers y : Set G) :=
+    Subgroup.zpowers x ≃ Subgroup.zpowers y :=
   (finEquivZPowers <| isOfFinOrder_of_finite _).symm.trans <| (finCongr h).trans <|
     finEquivZPowers <| isOfFinOrder_of_finite _
 
--- Porting note: the simpNF linter complains that simp can change the LHS to something
--- that looks the same as the current LHS even with `pp.explicit`
-@[to_additive (attr := simp, nolint simpNF) zmultiples_equiv_zmultiples_apply]
+@[to_additive (attr := simp) zmultiples_equiv_zmultiples_apply]
 theorem zpowersEquivZPowers_apply (h : orderOf x = orderOf y) (n : ℕ) :
     zpowersEquivZPowers h ⟨x ^ n, n, zpow_natCast x n⟩ = ⟨y ^ n, n, zpow_natCast y n⟩ := by
   rw [zpowersEquivZPowers, Equiv.trans_apply, Equiv.trans_apply, finEquivZPowers_symm_apply, ←


### PR DESCRIPTION
The definition of the equivalences `powersEquivPowers` and `zpowersEquivZPowers` casts `powers x` and `zpowers x` to a Set before casting to a type, while the `simp`-normal form has them use the `CoeSort` instance for `SetLike`s. Changing their type means that the rewrite and `simp` lemmas should now fire correctly.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
