### PR TITLE
[Merged by Bors] - chore(GroupWithZero.Hom): split off `Equiv`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -431,6 +431,7 @@ import Mathlib.Algebra.GroupWithZero.Commute
 import Mathlib.Algebra.GroupWithZero.Conj
 import Mathlib.Algebra.GroupWithZero.Defs
 import Mathlib.Algebra.GroupWithZero.Divisibility
+import Mathlib.Algebra.GroupWithZero.Equiv
 import Mathlib.Algebra.GroupWithZero.Hom
 import Mathlib.Algebra.GroupWithZero.Idempotent
 import Mathlib.Algebra.GroupWithZero.Indicator

--- a/Mathlib/Algebra/Field/Equiv.lean
+++ b/Mathlib/Algebra/Field/Equiv.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Junyan Xu
 -/
 import Mathlib.Algebra.Field.IsField
-import Mathlib.Algebra.GroupWithZero.Hom
+import Mathlib.Algebra.GroupWithZero.Equiv
 
 /-!
 # If a semiring is a field, any isomorphic semiring is also a field.

--- a/Mathlib/Algebra/GroupWithZero/Equiv.lean
+++ b/Mathlib/Algebra/GroupWithZero/Equiv.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2024 Yaël Dillies. All rights reserved.
+Copyright (c) 2022 Yaël Dillies. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies
 -/

--- a/Mathlib/Algebra/GroupWithZero/Equiv.lean
+++ b/Mathlib/Algebra/GroupWithZero/Equiv.lean
@@ -1,0 +1,28 @@
+/-
+Copyright (c) 2024 Yaël Dillies. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yaël Dillies
+-/
+import Mathlib.Algebra.Group.Equiv.Defs
+import Mathlib.Algebra.GroupWithZero.Hom
+
+/-! ### Equivalences -/
+
+namespace MulEquivClass
+variable {F α β : Type*} [EquivLike F α β]
+
+-- See note [lower instance priority]
+instance (priority := 100) toZeroHomClass [MulZeroClass α] [MulZeroClass β] [MulEquivClass F α β] :
+    ZeroHomClass F α β where
+  map_zero f :=
+    calc
+      f 0 = f 0 * f (EquivLike.inv f 0) := by rw [← map_mul, zero_mul]
+        _ = 0 := by simp
+
+-- See note [lower instance priority]
+instance (priority := 100) toMonoidWithZeroHomClass
+    [MulZeroOneClass α] [MulZeroOneClass β] [MulEquivClass F α β] :
+    MonoidWithZeroHomClass F α β :=
+  { MulEquivClass.instMonoidHomClass F, MulEquivClass.toZeroHomClass with }
+
+end MulEquivClass

--- a/Mathlib/Algebra/GroupWithZero/Equiv.lean
+++ b/Mathlib/Algebra/GroupWithZero/Equiv.lean
@@ -6,7 +6,7 @@ Authors: Yaël Dillies
 import Mathlib.Algebra.Group.Equiv.Defs
 import Mathlib.Algebra.GroupWithZero.Hom
 
-/-! ### Equivalences -/
+/-! # Isomorphisms of monoids with zero -/
 
 namespace MulEquivClass
 variable {F α β : Type*} [EquivLike F α β]

--- a/Mathlib/Algebra/GroupWithZero/Hom.lean
+++ b/Mathlib/Algebra/GroupWithZero/Hom.lean
@@ -3,10 +3,8 @@ Copyright (c) 2020 Patrick Massot. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Eric Wieser
 -/
-import Mathlib.Algebra.Group.Equiv.Defs
 import Mathlib.Algebra.Group.Hom.Basic
 import Mathlib.Algebra.GroupWithZero.Basic
-import Mathlib.Algebra.NeZero
 
 /-!
 # Monoid with zero and group with zero homomorphisms
@@ -218,24 +216,3 @@ def powMonoidWithZeroHom : M₀ →*₀ M₀ :=
 @[simp] lemma powMonoidWithZeroHom_apply (a : M₀) : powMonoidWithZeroHom hn a = a ^ n := rfl
 
 end CommMonoidWithZero
-
-/-! ### Equivalences -/
-
-namespace MulEquivClass
-variable {F α β : Type*} [EquivLike F α β]
-
--- See note [lower instance priority]
-instance (priority := 100) toZeroHomClass [MulZeroClass α] [MulZeroClass β] [MulEquivClass F α β] :
-    ZeroHomClass F α β where
-  map_zero f :=
-    calc
-      f 0 = f 0 * f (EquivLike.inv f 0) := by rw [← map_mul, zero_mul]
-        _ = 0 := by simp
-
--- See note [lower instance priority]
-instance (priority := 100) toMonoidWithZeroHomClass
-    [MulZeroOneClass α] [MulZeroOneClass β] [MulEquivClass F α β] :
-    MonoidWithZeroHomClass F α β :=
-  { MulEquivClass.instMonoidHomClass F, MulEquivClass.toZeroHomClass with }
-
-end MulEquivClass

--- a/Mathlib/Algebra/GroupWithZero/WithZero.lean
+++ b/Mathlib/Algebra/GroupWithZero/WithZero.lean
@@ -3,8 +3,9 @@ Copyright (c) 2018 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Johan Commelin
 -/
+import Mathlib.Algebra.Group.Equiv.Defs
 import Mathlib.Algebra.Group.WithOne.Defs
-import Mathlib.Algebra.GroupWithZero.Hom
+import Mathlib.Algebra.GroupWithZero.Equiv
 import Mathlib.Algebra.GroupWithZero.Units.Basic
 import Mathlib.Data.Nat.Cast.Defs
 import Mathlib.Data.Option.Basic

--- a/Mathlib/Algebra/Prime/Lemmas.lean
+++ b/Mathlib/Algebra/Prime/Lemmas.lean
@@ -7,7 +7,7 @@ import Mathlib.Algebra.Divisibility.Hom
 import Mathlib.Algebra.Group.Commute.Units
 import Mathlib.Algebra.Group.Even
 import Mathlib.Algebra.Group.Units.Equiv
-import Mathlib.Algebra.GroupWithZero.Hom
+import Mathlib.Algebra.GroupWithZero.Equiv
 import Mathlib.Algebra.Prime.Defs
 import Mathlib.Order.Monotone.Defs
 

--- a/Mathlib/Algebra/Ring/Equiv.lean
+++ b/Mathlib/Algebra/Ring/Equiv.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Callum Sutton, Yury Kudryashov
 -/
 import Mathlib.Algebra.Group.Equiv.Opposite
+import Mathlib.Algebra.GroupWithZero.Equiv
 import Mathlib.Algebra.GroupWithZero.InjSurj
 import Mathlib.Algebra.Ring.Hom.Defs
 import Mathlib.Logic.Equiv.Set


### PR DESCRIPTION
Generally, we separate `X.Hom` and `X.Equiv`. This PR does this for `GroupWithZero`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
