### PR TITLE
[Merged by Bors] - feat(Combinatorics/SimpleGraph/Diam): add basic (e)diam facts

### DIFF
--- a/Mathlib/Combinatorics/SimpleGraph/Diam.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Diam.lean
@@ -217,7 +217,7 @@ lemma diam_eq_zero : G.diam = 0 ↔ G.ediam = ⊤ ∨ Subsingleton α := by
 lemma diam_eq_one [Nontrivial α] : G.diam = 1 ↔ G = ⊤ := by
   rw [diam, ENat.toNat_eq_iff one_ne_zero, Nat.cast_one, ediam_eq_one]
 
-lemma diam_zero_iff_ediam_top [Nontrivial α] : G.diam = 0 ↔ G.ediam = ⊤ := by
+lemma diam_eq_zero_iff_ediam_top [Nontrivial α] : G.diam = 0 ↔ G.ediam = ⊤ := by
   rw [← not_iff_not]
   exact ⟨ediam_ne_top_of_diam_ne_zero, diam_ne_zero_of_ediam_ne_top⟩
 

--- a/Mathlib/Combinatorics/SimpleGraph/Diam.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Diam.lean
@@ -188,9 +188,10 @@ lemma exists_dist_eq_diam [Nonempty α] :
     use u, v
     rw [diam, dist, congrArg ENat.toNat huv]
 
-lemma diam_pos_of_ediam_ne_top [Nontrivial α] (h : G.ediam ≠ ⊤) : 0 < G.diam  :=
+lemma diam_ne_zero_of_ediam_ne_top [Nontrivial α] (h : G.ediam ≠ ⊤) : G.diam ≠ 0 :=
   have ⟨_, _, hne⟩ := exists_pair_ne ‹_›
-  lt_of_lt_of_le ((connected_of_ediam_ne_top h).pos_dist_of_ne hne) <| dist_le_diam h
+  pos_iff_ne_zero.mp
+  <| lt_of_lt_of_le ((connected_of_ediam_ne_top h).pos_dist_of_ne hne) <| dist_le_diam h
 
 @[gcongr]
 lemma diam_anti_of_ediam_ne_top (h : G ≤ G') (hn : G.ediam ≠ ⊤) : G'.diam ≤ G.diam :=
@@ -215,8 +216,8 @@ lemma diam_eq_zero : G.diam = 0 ↔ G.ediam = ⊤ ∨ Subsingleton α := by
 lemma diam_eq_one [Nontrivial α] : G.diam = 1 ↔ G = ⊤ := by
   rw [diam, ENat.toNat_eq_iff one_ne_zero, Nat.cast_one, ediam_eq_one]
 
-lemma pos_diam_iff_ne_top_and_nt : 0 < G.diam  ↔ G.ediam ≠ ⊤ ∧ Nontrivial α := by
-  rw [pos_iff_ne_zero, ne_eq, diam_eq_zero, ← not_nontrivial_iff_subsingleton]
+lemma diam_ne_zero_iff_ne_top_and_nt : G.diam ≠ 0  ↔ G.ediam ≠ ⊤ ∧ Nontrivial α := by
+  rw [ne_eq, diam_eq_zero, ← not_nontrivial_iff_subsingleton]
   tauto
 
 lemma not_connected_of_diam_zero [Fintype α] [Nontrivial α] (h : G.diam = 0) : ¬ G.Connected := by

--- a/Mathlib/Combinatorics/SimpleGraph/Diam.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Diam.lean
@@ -112,13 +112,15 @@ lemma exists_edist_eq_ediam_of_finite [Nonempty α] [Finite α] :
     ∃ u v, G.edist u v = G.ediam :=
   Prod.exists'.mp <| ediam_def ▸ exists_eq_ciSup_of_finite
 
-lemma ediam_ne_top_of_preconnected [Nonempty α] [Finite α] (h : G.Preconnected) : G.ediam ≠ ⊤ :=
+/- In a finite graph with nontrivial vertex set, the graph is connected
+if and only if the extended diameter is not `⊤`.
+See `connected_of_ediam_ne_top` for one of the implications without
+the finiteness assumptions
+-/
+lemma connected_iff_ediam_ne_top [Nonempty α] [Finite α] : G.Connected ↔ G.ediam ≠ ⊤ :=
   have ⟨u, v, huv⟩ := G.exists_edist_eq_ediam_of_finite
-  huv ▸ edist_ne_top_iff_reachable.mpr (h u v)
-
-lemma not_preconnected_of_ediam_eq_top [Nonempty α] [Finite α] (h : G.ediam = ⊤) :
-    ¬G.Preconnected :=
-  mt G.ediam_ne_top_of_preconnected <| not_ne_iff.mpr h
+  ⟨fun h ↦ huv ▸ edist_ne_top_iff_reachable.mpr (h u v),
+   fun h ↦ G.connected_of_ediam_ne_top h⟩
 
 @[gcongr]
 lemma ediam_anti (h : G ≤ G') : G'.ediam ≤ G.ediam :=
@@ -190,8 +192,8 @@ lemma exists_dist_eq_diam [Nonempty α] :
 
 lemma diam_ne_zero_of_ediam_ne_top [Nontrivial α] (h : G.ediam ≠ ⊤) : G.diam ≠ 0 :=
   have ⟨_, _, hne⟩ := exists_pair_ne ‹_›
-  pos_iff_ne_zero.mp
-  <| lt_of_lt_of_le ((connected_of_ediam_ne_top h).pos_dist_of_ne hne) <| dist_le_diam h
+  pos_iff_ne_zero.mp <|
+    lt_of_lt_of_le ((connected_of_ediam_ne_top h).pos_dist_of_ne hne) <| dist_le_diam h
 
 @[gcongr]
 lemma diam_anti_of_ediam_ne_top (h : G ≤ G') (hn : G.ediam ≠ ⊤) : G'.diam ≤ G.diam :=
@@ -216,18 +218,18 @@ lemma diam_eq_zero : G.diam = 0 ↔ G.ediam = ⊤ ∨ Subsingleton α := by
 lemma diam_eq_one [Nontrivial α] : G.diam = 1 ↔ G = ⊤ := by
   rw [diam, ENat.toNat_eq_iff one_ne_zero, Nat.cast_one, ediam_eq_one]
 
-lemma diam_ne_zero_iff_ne_top_and_nt : G.diam ≠ 0  ↔ G.ediam ≠ ⊤ ∧ Nontrivial α := by
-  rw [ne_eq, diam_eq_zero, ← not_nontrivial_iff_subsingleton]
-  tauto
+@[simp]
+lemma diam_zero_iff_ediam_top [Nontrivial α] : G.diam = 0 ↔ G.ediam = ⊤ := by
+  rw [← not_iff_not]
+  exact ⟨ediam_ne_top_of_diam_ne_zero, diam_ne_zero_of_ediam_ne_top⟩
 
-lemma not_connected_of_diam_zero [Fintype α] [Nontrivial α] (h : G.diam = 0) : ¬ G.Connected := by
-  rw [connected_iff]
-  rw [diam_eq_zero] at h
-  cases h
-  · apply not_and_of_not_left
-    exact not_preconnected_of_ediam_eq_top ‹_›
-  · rw [← not_nontrivial_iff_subsingleton] at *
-    contradiction
+/-
+A finite and nontrivial graph is connected if and only if its diameter is not zero.
+See also `connected_iff_ediam_ne_top` for the extended diameter version.
+-/
+lemma connected_iff_diam_ne_zero [Fintype α] [Nontrivial α] :
+  G.Connected ↔ G.diam ≠ 0 := by
+  rw [connected_iff_ediam_ne_top, not_iff_not, diam_zero_iff_ediam_top]
 
 end diam
 

--- a/Mathlib/Combinatorics/SimpleGraph/Diam.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Diam.lean
@@ -97,11 +97,11 @@ lemma ediam_eq_top_of_not_preconnected (h : ¬G.Preconnected) : G.ediam = ⊤ :=
     rw [connected_iff]
     tauto
 
-lemma preconnected_of_ediam_ne_top (h : G.ediam ≠ ⊤ ) : G.Preconnected := by
-   apply Classical.not_not.mp (mt G.ediam_eq_top_of_not_preconnected h)
+lemma preconnected_of_ediam_ne_top (h : G.ediam ≠ ⊤) : G.Preconnected :=
+  not_not.mp <| mt G.ediam_eq_top_of_not_preconnected h
 
-lemma connected_of_ediam_ne_top_and_nonempty [Nonempty α] (h : G.ediam ≠ ⊤) : G.Connected := by
-  rw [connected_iff]; exact ⟨preconnected_of_ediam_ne_top h, by assumption⟩
+lemma connected_of_ediam_ne_top [Nonempty α] (h : G.ediam ≠ ⊤) : G.Connected :=
+  G.connected_iff.mpr ⟨preconnected_of_ediam_ne_top h, ‹_›⟩
 
 lemma exists_edist_eq_ediam_of_ne_top [Nonempty α] (h : G.ediam ≠ ⊤) :
     ∃ u v, G.edist u v = G.ediam :=
@@ -112,13 +112,13 @@ lemma exists_edist_eq_ediam_of_finite [Nonempty α] [Finite α] :
     ∃ u v, G.edist u v = G.ediam :=
   Prod.exists'.mp <| ediam_def ▸ exists_eq_ciSup_of_finite
 
-lemma ediam_ne_top_of_preconnected [Nonempty α] [Finite α] (h : G.Preconnected) : G.ediam ≠ ⊤ := by
-  by_contra h_top
-  have ⟨u, v, _⟩ := G.exists_edist_eq_ediam_of_finite
-  simp_all only [edist_ne_top_iff_reachable.mpr (h u v)]
+lemma ediam_ne_top_of_preconnected [Nonempty α] [Finite α] (h : G.Preconnected) : G.ediam ≠ ⊤ :=
+  have ⟨u, v, huv⟩ := G.exists_edist_eq_ediam_of_finite
+  huv ▸ edist_ne_top_iff_reachable.mpr (h u v)
 
-lemma not_preconn_of_ediam_eq_top [Nonempty α] [Finite α] (h : G.ediam = ⊤) : ¬G.Preconnected :=
-  (mt G.ediam_ne_top_of_preconnected) (not_ne_iff.mpr h)
+lemma not_preconnected_of_ediam_eq_top [Nonempty α] [Finite α] (h : G.ediam = ⊤) :
+    ¬G.Preconnected :=
+  mt G.ediam_ne_top_of_preconnected <| not_ne_iff.mpr h
 
 @[gcongr]
 lemma ediam_anti (h : G ≤ G') : G'.ediam ≤ G.ediam :=
@@ -188,11 +188,9 @@ lemma exists_dist_eq_diam [Nonempty α] :
     use u, v
     rw [diam, dist, congrArg ENat.toNat huv]
 
-lemma pos_diam_of_ne_top_and_nt (h : G.ediam ≠ ⊤) [Nontrivial α] : 0 < G.diam  := by
-  obtain ⟨u, v, uv_ne⟩ := exists_pair_ne ‹_›
-  have h_conn : G.Connected := connected_of_ediam_ne_top_and_nonempty h
-  calc 0 < G.dist u v := by apply Connected.pos_dist_of_ne h_conn uv_ne
-          _ ≤ G.diam := by apply dist_le_diam h
+lemma diam_pos_of_ediam_ne_top [Nontrivial α] (h : G.ediam ≠ ⊤) : 0 < G.diam  :=
+  have ⟨_, _, hne⟩ := exists_pair_ne ‹_›
+  lt_of_lt_of_le ((connected_of_ediam_ne_top h).pos_dist_of_ne hne) <| dist_le_diam h
 
 @[gcongr]
 lemma diam_anti_of_ediam_ne_top (h : G ≤ G') (hn : G.ediam ≠ ⊤) : G'.diam ≤ G.diam :=
@@ -217,18 +215,18 @@ lemma diam_eq_zero : G.diam = 0 ↔ G.ediam = ⊤ ∨ Subsingleton α := by
 lemma diam_eq_one [Nontrivial α] : G.diam = 1 ↔ G = ⊤ := by
   rw [diam, ENat.toNat_eq_iff one_ne_zero, Nat.cast_one, ediam_eq_one]
 
-lemma pos_diam_iff_ne_top_and_nt : G.diam > 0 ↔ G.ediam ≠ ⊤ ∧ Nontrivial α := by
-  rw [← not_iff_not, not_and, not_nontrivial_iff_subsingleton]
-  simp [diam_eq_zero]
+lemma pos_diam_iff_ne_top_and_nt : 0 < G.diam  ↔ G.ediam ≠ ⊤ ∧ Nontrivial α := by
+  rw [pos_iff_ne_zero, ne_eq, diam_eq_zero, ← not_nontrivial_iff_subsingleton]
   tauto
 
 lemma not_connected_of_diam_zero [Fintype α] [Nontrivial α] (h : G.diam = 0) : ¬ G.Connected := by
   rw [connected_iff]
   rw [diam_eq_zero] at h
-  simp
-  rcases h with t | s
-  · exact not_preconn_of_ediam_eq_top t
-  · absurd s; exact not_subsingleton α
+  cases h
+  · apply not_and_of_not_left
+    exact not_preconnected_of_ediam_eq_top ‹_›
+  · rw [← not_nontrivial_iff_subsingleton] at *
+    contradiction
 
 end diam
 

--- a/Mathlib/Combinatorics/SimpleGraph/Diam.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Diam.lean
@@ -112,11 +112,10 @@ lemma exists_edist_eq_ediam_of_finite [Nonempty α] [Finite α] :
     ∃ u v, G.edist u v = G.ediam :=
   Prod.exists'.mp <| ediam_def ▸ exists_eq_ciSup_of_finite
 
-/- In a finite graph with nontrivial vertex set, the graph is connected
+/-- In a finite graph with nontrivial vertex set, the graph is connected
 if and only if the extended diameter is not `⊤`.
 See `connected_of_ediam_ne_top` for one of the implications without
-the finiteness assumptions
--/
+the finiteness assumptions -/
 lemma connected_iff_ediam_ne_top [Nonempty α] [Finite α] : G.Connected ↔ G.ediam ≠ ⊤ :=
   have ⟨u, v, huv⟩ := G.exists_edist_eq_ediam_of_finite
   ⟨fun h ↦ huv ▸ edist_ne_top_iff_reachable.mpr (h u v),
@@ -218,17 +217,13 @@ lemma diam_eq_zero : G.diam = 0 ↔ G.ediam = ⊤ ∨ Subsingleton α := by
 lemma diam_eq_one [Nontrivial α] : G.diam = 1 ↔ G = ⊤ := by
   rw [diam, ENat.toNat_eq_iff one_ne_zero, Nat.cast_one, ediam_eq_one]
 
-@[simp]
 lemma diam_zero_iff_ediam_top [Nontrivial α] : G.diam = 0 ↔ G.ediam = ⊤ := by
   rw [← not_iff_not]
   exact ⟨ediam_ne_top_of_diam_ne_zero, diam_ne_zero_of_ediam_ne_top⟩
 
-/-
-A finite and nontrivial graph is connected if and only if its diameter is not zero.
-See also `connected_iff_ediam_ne_top` for the extended diameter version.
--/
-lemma connected_iff_diam_ne_zero [Fintype α] [Nontrivial α] :
-  G.Connected ↔ G.diam ≠ 0 := by
+/-- A finite and nontrivial graph is connected if and only if its diameter is not zero.
+See also `connected_iff_ediam_ne_top` for the extended diameter version. -/
+lemma connected_iff_diam_ne_zero [Fintype α] [Nontrivial α] : G.Connected ↔ G.diam ≠ 0 := by
   rw [connected_iff_ediam_ne_top, not_iff_not, diam_zero_iff_ediam_top]
 
 end diam

--- a/Mathlib/Combinatorics/SimpleGraph/Diam.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Diam.lean
@@ -217,14 +217,14 @@ lemma diam_eq_zero : G.diam = 0 ↔ G.ediam = ⊤ ∨ Subsingleton α := by
 lemma diam_eq_one [Nontrivial α] : G.diam = 1 ↔ G = ⊤ := by
   rw [diam, ENat.toNat_eq_iff one_ne_zero, Nat.cast_one, ediam_eq_one]
 
-lemma diam_eq_zero_iff_ediam_top [Nontrivial α] : G.diam = 0 ↔ G.ediam = ⊤ := by
+lemma diam_eq_zero_iff_ediam_eq_top [Nontrivial α] : G.diam = 0 ↔ G.ediam = ⊤ := by
   rw [← not_iff_not]
   exact ⟨ediam_ne_top_of_diam_ne_zero, diam_ne_zero_of_ediam_ne_top⟩
 
 /-- A finite and nontrivial graph is connected if and only if its diameter is not zero.
 See also `connected_iff_ediam_ne_top` for the extended diameter version. -/
 lemma connected_iff_diam_ne_zero [Fintype α] [Nontrivial α] : G.Connected ↔ G.diam ≠ 0 := by
-  rw [connected_iff_ediam_ne_top, not_iff_not, diam_zero_iff_ediam_top]
+  rw [connected_iff_ediam_ne_top, not_iff_not, diam_eq_zero_iff_ediam_eq_top]
 
 end diam
 

--- a/Mathlib/Combinatorics/SimpleGraph/Diam.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Diam.lean
@@ -97,6 +97,12 @@ lemma ediam_eq_top_of_not_preconnected (h : ¬G.Preconnected) : G.ediam = ⊤ :=
     rw [connected_iff]
     tauto
 
+lemma preconnected_of_ediam_ne_top (h : G.ediam ≠ ⊤ ) : G.Preconnected := by
+   apply Classical.not_not.mp (mt G.ediam_eq_top_of_not_preconnected h)
+
+lemma connected_of_ediam_ne_top_and_nonempty [Nonempty α] (h : G.ediam ≠ ⊤) : G.Connected := by
+  rw [connected_iff]; exact ⟨preconnected_of_ediam_ne_top h, by assumption⟩
+
 lemma exists_edist_eq_ediam_of_ne_top [Nonempty α] (h : G.ediam ≠ ⊤) :
     ∃ u v, G.edist u v = G.ediam :=
   ENat.exists_eq_iSup₂_of_lt_top h.lt_top
@@ -105,6 +111,14 @@ lemma exists_edist_eq_ediam_of_ne_top [Nonempty α] (h : G.ediam ≠ ⊤) :
 lemma exists_edist_eq_ediam_of_finite [Nonempty α] [Finite α] :
     ∃ u v, G.edist u v = G.ediam :=
   Prod.exists'.mp <| ediam_def ▸ exists_eq_ciSup_of_finite
+
+lemma ediam_ne_top_of_preconnected [Nonempty α] [Finite α] (h : G.Preconnected) : G.ediam ≠ ⊤ := by
+  by_contra h_top
+  have ⟨u, v, _⟩ := G.exists_edist_eq_ediam_of_finite
+  simp_all only [edist_ne_top_iff_reachable.mpr (h u v)]
+
+lemma not_preconn_of_ediam_eq_top [Nonempty α] [Finite α] (h : G.ediam = ⊤) : ¬G.Preconnected :=
+  (mt G.ediam_ne_top_of_preconnected) (not_ne_iff.mpr h)
 
 @[gcongr]
 lemma ediam_anti (h : G ≤ G') : G'.ediam ≤ G.ediam :=
@@ -174,6 +188,12 @@ lemma exists_dist_eq_diam [Nonempty α] :
     use u, v
     rw [diam, dist, congrArg ENat.toNat huv]
 
+lemma pos_diam_of_ne_top_and_nt (h : G.ediam ≠ ⊤) [Nontrivial α] : 0 < G.diam  := by
+  obtain ⟨u, v, uv_ne⟩ := exists_pair_ne ‹_›
+  have h_conn : G.Connected := connected_of_ediam_ne_top_and_nonempty h
+  calc 0 < G.dist u v := by apply Connected.pos_dist_of_ne h_conn uv_ne
+          _ ≤ G.diam := by apply dist_le_diam h
+
 @[gcongr]
 lemma diam_anti_of_ediam_ne_top (h : G ≤ G') (hn : G.ediam ≠ ⊤) : G'.diam ≤ G.diam :=
   ENat.toNat_le_toNat (ediam_anti h) hn
@@ -196,6 +216,19 @@ lemma diam_eq_zero : G.diam = 0 ↔ G.ediam = ⊤ ∨ Subsingleton α := by
 @[simp]
 lemma diam_eq_one [Nontrivial α] : G.diam = 1 ↔ G = ⊤ := by
   rw [diam, ENat.toNat_eq_iff one_ne_zero, Nat.cast_one, ediam_eq_one]
+
+lemma pos_diam_iff_ne_top_and_nt : G.diam > 0 ↔ G.ediam ≠ ⊤ ∧ Nontrivial α := by
+  rw [← not_iff_not, not_and, not_nontrivial_iff_subsingleton]
+  simp [diam_eq_zero]
+  tauto
+
+lemma not_connected_of_diam_zero [Fintype α] [Nontrivial α] (h : G.diam = 0) : ¬ G.Connected := by
+  rw [connected_iff]
+  rw [diam_eq_zero] at h
+  simp
+  rcases h with t | s
+  · exact not_preconn_of_ediam_eq_top t
+  · absurd s; exact not_subsingleton α
 
 end diam
 


### PR DESCRIPTION
Add converses of some `diam` and `ediam` lemmas.
These should improve the experience of working with diam/ediam by providing more direct relations between the terms `G.ediam = \top`, `G.diam = 0`, `G.Preconnected`, etc.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
