### PR TITLE
[Merged by Bors] - feat(GroupTheory/Congruences): add the equiv between congruence relations on a group and its normal subgroup

### DIFF
--- a/Mathlib/GroupTheory/QuotientGroup/Defs.lean
+++ b/Mathlib/GroupTheory/QuotientGroup/Defs.lean
@@ -60,8 +60,7 @@ as a congruence relation.
 @[to_additive QuotientAddGroup.con_ker_eq_addConKer
 "The additive congruence relation defined by the kernel of an additive group homomorphism is
 equal to its kernel as an additive congruence relation."]
-theorem con_ker_eq_conKer {M : Type*} [Monoid M] (f : G →* M) :
-    QuotientGroup.con f.ker = Con.ker f := by
+theorem con_ker_eq_conKer (f : G →* M) : QuotientGroup.con f.ker = Con.ker f := by
   ext
   rw [QuotientGroup.con, Con.rel_mk, Setoid.comm', leftRel_apply, Con.ker_rel, MonoidHom.eq_iff]
 

--- a/Mathlib/GroupTheory/QuotientGroup/Defs.lean
+++ b/Mathlib/GroupTheory/QuotientGroup/Defs.lean
@@ -55,7 +55,7 @@ instance Quotient.group : Group (G ⧸ N) :=
 
 /--
 The congruence relation defined by the kernel of a group homomorphism `f` is equal to the symmetric
-of congruence relation defined by the kernel of `f`.
+of the congruence relation defined by the kernel of `f`.
 -/
 @[to_additive
 "The additive congruence relation defined by the kernel of a additive group homomorphism `f`

--- a/Mathlib/GroupTheory/QuotientGroup/Defs.lean
+++ b/Mathlib/GroupTheory/QuotientGroup/Defs.lean
@@ -54,16 +54,16 @@ instance Quotient.group : Group (G ⧸ N) :=
   (QuotientGroup.con N).group
 
 /--
-The congruence relation defined by the kernel of a group homomorphism `f` is equal to the symmetric
-of the congruence relation defined by the kernel of `f`.
+The congruence relation defined by the kernel of a group homomorphism is equal to its kernel
+as a congruence relation.
 -/
 @[to_additive
-"The additive congruence relation defined by the kernel of a additive group homomorphism `f`
-is equal to the symmetric of the additive congruence relation defined by the kernel of `f`"]
-theorem con_ker_eq_Con_ker {M : Type*} [Monoid M] (f : G →* M) {x y : G} :
-    QuotientGroup.con f.ker x y = Con.ker f y x  := by
+"The additive congruence relation defined by the kernel of an additive group homomorphism is
+equal to its kernel as an additive congruence relation."]
+theorem con_ker_eq_Con_ker {M : Type*} [Monoid M] (f : G →* M) :
+    QuotientGroup.con f.ker = Con.ker f := by
   ext
-  simp [QuotientGroup.con, leftRel_apply, MonoidHom.eq_iff]
+  rw [QuotientGroup.con, Con.rel_mk, Setoid.comm', leftRel_apply, Con.ker_rel, MonoidHom.eq_iff]
 
 /-- The group homomorphism from `G` to `G/N`. -/
 @[to_additive "The additive group homomorphism from `G` to `G/N`."]
@@ -162,9 +162,12 @@ theorem mk_zpow (a : G) (n : ℤ) : ((a ^ n : G) : Q) = (a : Q) ^ n :=
 
 @[to_additive (attr := simp)] lemma map_mk'_self : N.map (mk' N) = ⊥ := by aesop
 
-/-- The subgroup of `G` defined by the class of `1` for a congruence relation on a group `G`. -/
-@[to_additive "The `AddSubgroup` of `G` defined by the class of `0` for an additive
-congruence relation on an `AddGroup` `G`."]
+/--
+The subgroup defined by the class of `1` for a congruence relation on a group.
+-/
+@[to_additive
+"The `AddSubgroup` defined by the class of `0` for an additive congruence relation
+on an `AddGroup`."]
 protected def _root_.Con.subgroup (c : Con G) : Subgroup G where
   carrier := { x | c 1 x }
   one_mem' := c.refl 1
@@ -193,10 +196,10 @@ theorem con_subgroup (c : Con G) :
   exact ⟨fun h ↦ by simpa using c.mul (c.refl x) h, fun h ↦ by simpa using c.mul (c.refl x⁻¹) h⟩
 
 /--
-The normal subgroups correspond to congruence relations on a group.
+The normal subgroups correspond to the congruence relations on a group.
 -/
 @[to_additive
-"The normal subgroups correspond to additive congruence relations on an `AddGroup`."]
+"The normal subgroups correspond to the additive congruence relations on an `AddGroup`."]
 def _root_.Subgroup.orderIsoCon :
     { N : Subgroup G // N.Normal } ≃o Con G where
   toFun := fun ⟨N, _⟩ ↦ QuotientGroup.con N
@@ -219,8 +222,7 @@ group homomorphism `G/N →* M`. -/
 @[to_additive "An `AddGroup` homomorphism `φ : G →+ M` with `N ⊆ ker(φ)` descends (i.e. `lift`s)
  to a group homomorphism `G/N →* M`."]
 def lift (φ : G →* M) (HN : N ≤ φ.ker) : Q →* M :=
-  (QuotientGroup.con N).lift φ fun _ _ h =>
-    (con_ker_eq_Con_ker φ).mp <| (QuotientGroup.con φ.ker).symm <| con_le_iff.mp HN h
+  (QuotientGroup.con N).lift φ <| con_ker_eq_Con_ker φ ▸ con_le_iff.mp HN
 
 @[to_additive (attr := simp)]
 theorem lift_mk {φ : G →* M} (HN : N ≤ φ.ker) (g : G) : lift N φ HN (g : Q) = φ g :=

--- a/Mathlib/GroupTheory/QuotientGroup/Defs.lean
+++ b/Mathlib/GroupTheory/QuotientGroup/Defs.lean
@@ -8,7 +8,6 @@ Authors: Kevin Buzzard, Patrick Massot
 import Mathlib.Algebra.Group.Subgroup.Ker
 import Mathlib.GroupTheory.Congruence.Hom
 import Mathlib.GroupTheory.Coset.Defs
-import Mathlib.GroupTheory.Congruence.Opposite
 
 /-!
 # Quotients of groups by normal subgroups

--- a/Mathlib/GroupTheory/QuotientGroup/Defs.lean
+++ b/Mathlib/GroupTheory/QuotientGroup/Defs.lean
@@ -181,7 +181,7 @@ theorem _root_.Con.mem_subgroup_iff {c : Con G} {x : G} :
 instance (c : Con G) : c.subgroup.Normal :=
   ⟨fun x hx g ↦ by simpa using (c.mul (c.mul (c.refl g) hx) (c.refl g⁻¹))⟩
 
-@[to_additive? (attr := simp)]
+@[to_additive (attr := simp)]
 theorem _root_.Con.subgroup_quotientGroupCon (H : Subgroup G) [H.Normal] :
     (QuotientGroup.con H).subgroup = H := by
   ext

--- a/Mathlib/GroupTheory/QuotientGroup/Defs.lean
+++ b/Mathlib/GroupTheory/QuotientGroup/Defs.lean
@@ -203,7 +203,9 @@ The normal subgroups correspond to the congruence relations on a group.
 "The normal subgroups correspond to the additive congruence relations on an `AddGroup`."]
 def _root_.Subgroup.orderIsoCon :
     { N : Subgroup G // N.Normal } ≃o Con G where
-  toFun := fun ⟨N, _⟩ ↦ QuotientGroup.con N
+  toFun N :=
+    have : N.val.Normal := N.prop
+    QuotientGroup.con N
   invFun c := ⟨c.subgroup, inferInstance⟩
   left_inv := fun ⟨N, _⟩ ↦ Subtype.mk_eq_mk.mpr (Con.subgroup_quotientGroupCon N)
   right_inv c := QuotientGroup.con_subgroup c

--- a/Mathlib/GroupTheory/QuotientGroup/Defs.lean
+++ b/Mathlib/GroupTheory/QuotientGroup/Defs.lean
@@ -57,7 +57,7 @@ instance Quotient.group : Group (G ⧸ N) :=
 The congruence relation defined by the kernel of a group homomorphism is equal to its kernel
 as a congruence relation.
 -/
-@[to_additive
+@[to_additive QuotientAddGroup.con_ker_eq_addConKer
 "The additive congruence relation defined by the kernel of an additive group homomorphism is
 equal to its kernel as an additive congruence relation."]
 theorem con_ker_eq_conKer {M : Type*} [Monoid M] (f : G →* M) :
@@ -182,7 +182,7 @@ theorem _root_.Con.mem_subgroup_iff {c : Con G} {x : G} :
 instance (c : Con G) : c.subgroup.Normal :=
   ⟨fun x hx g ↦ by simpa using (c.mul (c.mul (c.refl g) hx) (c.refl g⁻¹))⟩
 
-@[to_additive]
+@[to_additive (attr := simp)]
 theorem _root_.Con.subgroup_quotientGroupCon (H : Subgroup G) [H.Normal] :
     (QuotientGroup.con H).subgroup = H := by
   ext
@@ -199,7 +199,7 @@ theorem con_subgroup (c : Con G) :
 /--
 The normal subgroups correspond to the congruence relations on a group.
 -/
-@[to_additive
+@[to_additive (attr := simps)
 "The normal subgroups correspond to the additive congruence relations on an `AddGroup`."]
 def _root_.Subgroup.orderIsoCon :
     { N : Subgroup G // N.Normal } ≃o Con G where
@@ -213,12 +213,12 @@ def _root_.Subgroup.orderIsoCon :
     specialize @h 1 x
     simp_all
 
-@[to_additive]
+@[to_additive (attr := simp)]
 lemma con_le_iff {N M : Subgroup G} [N.Normal] [M.Normal] :
     QuotientGroup.con N ≤ QuotientGroup.con M ↔ N ≤ M :=
   (Subgroup.orderIsoCon.map_rel_iff (a := ⟨N, inferInstance⟩) (b := ⟨M, inferInstance⟩))
 
-@[to_additive]
+@[to_additive (attr := gcongr)]
 lemma con_mono {N M : Subgroup G} [hN : N.Normal] [hM : M.Normal] (h : N ≤ M) :
     QuotientGroup.con N ≤ QuotientGroup.con M :=
   con_le_iff.mpr h

--- a/Mathlib/GroupTheory/QuotientGroup/Defs.lean
+++ b/Mathlib/GroupTheory/QuotientGroup/Defs.lean
@@ -198,13 +198,11 @@ theorem con_subgroup (c : Con G) :
 /--
 The normal subgroups correspond to the congruence relations on a group.
 -/
-@[to_additive  (attr := simps) AddSubgroup.orderIsoAddCon
+@[to_additive (attr := simps) AddSubgroup.orderIsoAddCon
 "The normal subgroups correspond to the additive congruence relations on an `AddGroup`."]
 def _root_.Subgroup.orderIsoCon :
     { N : Subgroup G // N.Normal } ≃o Con G where
-  toFun N :=
-    have : N.val.Normal := N.prop
-    QuotientGroup.con N
+  toFun N := letI : N.val.Normal := N.prop; QuotientGroup.con N
   invFun c := ⟨c.subgroup, inferInstance⟩
   left_inv := fun ⟨N, _⟩ ↦ Subtype.mk_eq_mk.mpr (Con.subgroup_quotientGroupCon N)
   right_inv c := QuotientGroup.con_subgroup c

--- a/Mathlib/GroupTheory/QuotientGroup/Defs.lean
+++ b/Mathlib/GroupTheory/QuotientGroup/Defs.lean
@@ -164,7 +164,7 @@ theorem mk_zpow (a : G) (n : ℤ) : ((a ^ n : G) : Q) = (a : Q) ^ n :=
 
 /-- The subgroup of `G` defined by the class of `1` for a congruence relation on a group `G`. -/
 @[to_additive "The `AddSubgroup` of `G` defined by the class of `0` for an additive
-congruence relation on an `AddGroup` `M`."]
+congruence relation on an `AddGroup` `G`."]
 protected def _root_.Con.subgroup (c : Con G) : Subgroup G where
   carrier := { x | c 1 x }
   one_mem' := c.refl 1

--- a/Mathlib/GroupTheory/QuotientGroup/Defs.lean
+++ b/Mathlib/GroupTheory/QuotientGroup/Defs.lean
@@ -182,7 +182,7 @@ theorem _root_.Con.mem_subgroup_iff {c : Con G} {x : G} :
 instance (c : Con G) : c.subgroup.Normal :=
   ⟨fun x hx g ↦ by simpa using (c.mul (c.mul (c.refl g) hx) (c.refl g⁻¹))⟩
 
-@[to_additive (attr := simp)]
+@[to_additive? (attr := simp)]
 theorem _root_.Con.subgroup_quotientGroupCon (H : Subgroup G) [H.Normal] :
     (QuotientGroup.con H).subgroup = H := by
   ext
@@ -199,7 +199,7 @@ theorem con_subgroup (c : Con G) :
 /--
 The normal subgroups correspond to the congruence relations on a group.
 -/
-@[to_additive (attr := simps)
+@[to_additive  (attr := simps) AddSubgroup.orderIsoAddCon
 "The normal subgroups correspond to the additive congruence relations on an `AddGroup`."]
 def _root_.Subgroup.orderIsoCon :
     { N : Subgroup G // N.Normal } ≃o Con G where

--- a/Mathlib/GroupTheory/QuotientGroup/Defs.lean
+++ b/Mathlib/GroupTheory/QuotientGroup/Defs.lean
@@ -196,7 +196,8 @@ theorem con_subgroup (c : Con G) :
 /--
 The normal subgroups correspond to congruence relations on a group.
 -/
-@[to_additive]
+@[to_additive
+"The normal subgroups correspond to additive congruence relations on an `AddGroup`."]
 def _root_.Subgroup.orderIsoCon :
     { N : Subgroup G // N.Normal } ≃o Con G where
   toFun := fun ⟨N, _⟩ ↦ QuotientGroup.con N


### PR DESCRIPTION
Let `G` be a group, we prove
```lean
{ N : Subgroup G // N.Normal } ≃o Con G
```
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
