### PR TITLE
[Merged by Bors] - fix(Order/Category): replace `nolint simpNF` with a correct lemma

### DIFF
--- a/Mathlib/Order/Category/PartOrd.lean
+++ b/Mathlib/Order/Category/PartOrd.lean
@@ -195,11 +195,19 @@ def preordToPartOrdForgetAdjunction :
 -- The `simpNF` linter would complain as `Functor.comp_obj`, `Preord.dual_obj` both apply to LHS
 -- of `preordToPartOrdCompToDualIsoToDualCompPreordToPartOrd_hom_app_coe`
 /-- `PreordToPartOrd` and `OrderDual` commute. -/
-@[simps! inv_app_hom_coe, simps! -isSimp hom_app_hom_coe]
+@[simps! -isSimp hom_app_hom_coe inv_app_hom_coe]
 def preordToPartOrdCompToDualIsoToDualCompPreordToPartOrd :
     preordToPartOrd.{u} ⋙ PartOrd.dual ≅ Preord.dual ⋙ preordToPartOrd :=
   NatIso.ofComponents (fun _ => PartOrd.Iso.mk <| OrderIso.dualAntisymmetrization _)
     (fun _ => PartOrd.ext fun x => Quotient.inductionOn' x fun _ => rfl)
 
--- This lemma was always bad, but the linter only noticed after https://github.com/leanprover/lean4/pull/2644
-attribute [nolint simpNF] preordToPartOrdCompToDualIsoToDualCompPreordToPartOrd_inv_app_hom_coe
+-- `simp`-normal form for `preordToPartOrdCompToDualIsoToDualCompPreordToPartOrd_inv_app_hom_coe`
+@[simp]
+lemma preordToPartOrdCompToDualIsoToDualCompPreordToPartOrd_inv_app_hom_coe' (X)
+  (a : preordToPartOrd.obj (Preord.dual.obj X)) :
+  (PartOrd.Hom.hom
+      (X := preordToPartOrd.obj (Preord.dual.obj X))
+      (Y := PartOrd.dual.obj (preordToPartOrd.obj X))
+      (preordToPartOrdCompToDualIsoToDualCompPreordToPartOrd.inv.app X)) a =
+    (OrderIso.dualAntisymmetrization ↑X).symm a :=
+  rfl


### PR DESCRIPTION
This PR adds a simp-normal form version of the `@[simps]`-generated lemma `preordToPartOrdCompToDualIsoToDualCompPreordToPartOrd_inv_app_hom_coe`, so we can remove a `nolint simpNF`.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
