### PR TITLE
[Merged by Bors] - chore(ci): report dependency changes in lake update notifications

### DIFF
--- a/.github/workflows/update_dependencies_zulip.yml
+++ b/.github/workflows/update_dependencies_zulip.yml
@@ -27,7 +27,10 @@ jobs:
       - name: Parse dependency changes
         id: parse_changes
         run: |
-          echo "changes=$(./scripts/parse_lake_manifest_changes.py)" >> $GITHUB_OUTPUT
+          output="$(./scripts/parse_lake_manifest_changes.py)"
+          echo "Dependency changes:"
+          echo "$output"
+          echo "changes=$output" >> $GITHUB_OUTPUT
 
       - name: Construct message
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
@@ -89,7 +92,10 @@ jobs:
       - name: Parse dependency changes
         id: parse_changes
         run: |
-          echo "changes=$(./scripts/parse_lake_manifest_changes.py)" >> $GITHUB_OUTPUT
+          output="$(./scripts/parse_lake_manifest_changes.py)"
+          echo "Dependency changes:"
+          echo "$output"
+          echo "changes=$output" >> $GITHUB_OUTPUT
 
       - name: Construct success message
         id: construct_message

--- a/.github/workflows/update_dependencies_zulip.yml
+++ b/.github/workflows/update_dependencies_zulip.yml
@@ -14,6 +14,21 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'failure' }}
 
     steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 2  # Need previous commit for diff
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+
+      - name: Parse dependency changes
+        id: parse_changes
+        run: |
+          chmod +x ./scripts/parse_lake_manifest_changes.py
+          echo "changes=$(./scripts/parse_lake_manifest_changes.py)" >> $GITHUB_OUTPUT
+
       - name: Construct message
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         id: construct_message
@@ -42,6 +57,7 @@ jobs:
             } else {
               output += "No PR found for this run! If you are feeling impatient and have write access, please go to the following page and click the \"Run workflow\" button!\nhttps://github.com/leanprover-community/mathlib4/actions/workflows/update_dependencies.yml";
             }
+            output += "\n\n" + "${{ steps.parse_changes.outputs.changes }}";
             return output;
 
       - name: Send Zulip message
@@ -61,6 +77,21 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
 
     steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 2  # Need previous commit for diff
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+
+      - name: Parse dependency changes
+        id: parse_changes
+        run: |
+          chmod +x ./scripts/parse_lake_manifest_changes.py
+          echo "changes=$(./scripts/parse_lake_manifest_changes.py)" >> $GITHUB_OUTPUT
+
       - name: Construct success message
         id: construct_message
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
@@ -75,6 +106,7 @@ jobs:
               for (let pr of prs) {
                 output += "merged via #" + pr.number + ". ";
               }
+              output += "\n\n" + "${{ steps.parse_changes.outputs.changes }}";
               return output
             }
             return ''  // Return empty string if no PRs found

--- a/.github/workflows/update_dependencies_zulip.yml
+++ b/.github/workflows/update_dependencies_zulip.yml
@@ -27,7 +27,6 @@ jobs:
       - name: Parse dependency changes
         id: parse_changes
         run: |
-          chmod +x ./scripts/parse_lake_manifest_changes.py
           echo "changes=$(./scripts/parse_lake_manifest_changes.py)" >> $GITHUB_OUTPUT
 
       - name: Construct message
@@ -90,7 +89,6 @@ jobs:
       - name: Parse dependency changes
         id: parse_changes
         run: |
-          chmod +x ./scripts/parse_lake_manifest_changes.py
           echo "changes=$(./scripts/parse_lake_manifest_changes.py)" >> $GITHUB_OUTPUT
 
       - name: Construct success message
@@ -121,6 +119,6 @@ jobs:
           organization-url: 'https://leanprover.zulipchat.com'
           to: 'mathlib reviewers'
           type: 'stream'
-          topic: 'Mathlib `lake update` failure'
+          topic: 'Mathlib `lake update` success'
           content: |
             ${{ steps.construct_message.outputs.result }}

--- a/.github/workflows/update_dependencies_zulip.yml
+++ b/.github/workflows/update_dependencies_zulip.yml
@@ -14,12 +14,13 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'failure' }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
         with:
           fetch-depth: 2  # Need previous commit for diff
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
         with:
           python-version: '3.x'
 
@@ -77,12 +78,12 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 2  # Need previous commit for diff
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
         with:
           python-version: '3.x'
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -95,6 +95,9 @@ Both of these files should tend to zero over time;
 please do not add new entries to these files. PRs removing (the need for) entries are welcome.
 
 **API surrounding CI**
+- `parse_lake_manifest_changes.py` compares two versions of `lake-manifest.json` to report
+  dependency changes in Zulip notifications. Used by the `update_dependencies_zulip.yml` workflow
+  to show which dependencies were updated, added, or removed, with links to GitHub diffs.
 - `update_PR_comment.sh` is a script that edits an existing message (or creates a new one).
   It is used by the `PR_summary` workflow to maintain an up-to-date report with a searchable history.
 - `get_tlabel.sh` extracts the `t-`label that a PR has (assuming that there is exactly one).

--- a/scripts/parse_lake_manifest_changes.py
+++ b/scripts/parse_lake_manifest_changes.py
@@ -112,18 +112,15 @@ def format_changes(changes):
 def main():
     old_manifest = get_json_at_rev('HEAD~1', 'lake-manifest.json')
     if not old_manifest:
-        print("Failed to read old lake-manifest.json at HEAD~1")
-        return 1
+        raise SystemExit("Failed to read old lake-manifest.json at HEAD~1")
 
     new_manifest = get_json_at_rev('HEAD', 'lake-manifest.json')
     if not new_manifest:
-        print("Failed to read new lake-manifest.json at HEAD")
-        return 1
+        raise SystemExit("Failed to read new lake-manifest.json at HEAD")
 
     changes = find_package_changes(old_manifest, new_manifest)
     message = format_changes(changes)
     print(message)
-    return 0
 
 if __name__ == "__main__":
-    sys.exit(main())
+    main()

--- a/scripts/parse_lake_manifest_changes.py
+++ b/scripts/parse_lake_manifest_changes.py
@@ -111,10 +111,13 @@ def format_changes(changes):
 
 def main():
     old_manifest = get_json_at_rev('HEAD~1', 'lake-manifest.json')
-    new_manifest = get_json_at_rev('HEAD', 'lake-manifest.json')
+    if not old_manifest:
+        print("Failed to read old lake-manifest.json at HEAD~1")
+        return 1
 
-    if not old_manifest or not new_manifest:
-        print("Failed to read lake-manifest.json versions")
+    new_manifest = get_json_at_rev('HEAD', 'lake-manifest.json')
+    if not new_manifest:
+        print("Failed to read new lake-manifest.json at HEAD")
         return 1
 
     changes = find_package_changes(old_manifest, new_manifest)

--- a/scripts/parse_lake_manifest_changes.py
+++ b/scripts/parse_lake_manifest_changes.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+
+import json
+import subprocess
+import sys
+
+def get_git_diff():
+    """Get the git diff for lake-manifest.json between HEAD and HEAD~1"""
+    try:
+        result = subprocess.run(
+            ['git', 'diff', 'HEAD~1..HEAD', '--', 'lake-manifest.json'],
+            capture_output=True,
+            text=True,
+            check=True
+        )
+        return result.stdout
+    except subprocess.CalledProcessError:
+        print("Error: Failed to get git diff", file=sys.stderr)
+        return None
+
+def parse_manifest_changes(diff_text):
+    """Parse the diff to find version changes in dependencies"""
+    changes = []
+    old_version = None
+    new_version = None
+    package_name = None
+
+    lines = diff_text.split('\n')
+    for i, line in enumerate(lines):
+        # When we find a rev change
+        if line.startswith('-   "rev":'):
+            old_version = line.split('"')[3]
+            # Look ahead for the new version
+            for next_line in lines[i:]:
+                if next_line.startswith('+   "rev":'):
+                    new_version = next_line.split('"')[3]
+                    # Look ahead for the package name
+                    for name_line in lines[i:]:
+                        if name_line.startswith('   "name":'):
+                            package_name = name_line.split('"')[3]
+                            changes.append({
+                                'dependency': package_name,
+                                'old_version': old_version,
+                                'new_version': new_version
+                            })
+                            break
+                    break
+            # Reset for next package
+            old_version = None
+            new_version = None
+            package_name = None
+
+    return changes
+
+def format_changes(changes):
+    """Format the changes into a readable message"""
+    if not changes:
+        return "No dependency versions were changed"
+
+    lines = ["The following dependencies were updated:"]
+    for change in changes:
+        lines.append(f"* {change['dependency']}: {change['old_version']} → {change['new_version']}")
+
+    return "\n".join(lines)
+
+def main():
+    diff = get_git_diff()
+    if not diff:
+        print("No changes found in lake-manifest.json")
+        return 1
+
+    changes = parse_manifest_changes(diff)
+    message = format_changes(changes)
+    print(message)
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Add Python script to parse lake-manifest.json changes and include the
dependency version changes in the Zulip notifications for lake update
success/failure.

The script detects which packages were updated and shows their old and new
git revisions in a readable format.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
