### PR TITLE
[Merged by Bors] - feat(Data/Matroid): matroid deletion/contraction

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2994,6 +2994,7 @@ import Mathlib.Data.Matroid.IndepAxioms
 import Mathlib.Data.Matroid.Init
 import Mathlib.Data.Matroid.Loop
 import Mathlib.Data.Matroid.Map
+import Mathlib.Data.Matroid.Minor.Basic
 import Mathlib.Data.Matroid.Rank.Cardinal
 import Mathlib.Data.Matroid.Rank.Finite
 import Mathlib.Data.Matroid.Restrict

--- a/Mathlib/Data/Matroid/Minor/Basic.lean
+++ b/Mathlib/Data/Matroid/Minor/Basic.lean
@@ -1,0 +1,276 @@
+/-
+Copyright (c) 2025 Peter Nelson. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Peter Nelson
+-/
+import Mathlib.Data.Matroid.Loop
+
+/-!
+# Matroid Minors
+
+For `M : Matroid α` and `X : Set α`, we can remove the elements of `X` from `M`
+to obtain a matroid with ground set `M.E \ X` in two different  ways: 'deletion' and 'contraction'.
+The *deletion* of `X` from `M`, denoted `M ＼ X`, is the matroid whose independent sets are the
+independent sets of `M` that are disjoint from `X`. The *contraction* of `X` is the matroid `M ／ X`
+in which a set `I` is independent if and only if `I ∪ J` is independent in `M`,
+where `J` is an arbitrarily chosen basis for `X`.
+
+We also have `M ＼ X = M ↾ (M.E \ X)` and (a little more cryptically) `M ／ X = (M✶ ＼ X)✶`.
+We use these as the definitions, and prove that the independent sets are the same as those just
+specified.
+
+A matroid obtained from `M` by a sequence of deletions/contractions
+(or equivalently, by a single deletion and a single contraction) is a *minor* of `M`.
+This gives a partial order on `Matroid α` that is ubiquitous in matroid theory,
+and interacts nicely with duality and linear representations.
+
+# Main Declarations
+
+* `Matroid.delete M D`, written `M ＼ D`, is the restriction of `M` to the set `M.E \ D`.
+* `Matroid.contract M C`, written `M ／ C`, is the matroid on ground set `M.E \ C` in which a set
+  `I ⊆ M.E \ C` is independent if and only if `I ∪ J` is independent in `M`,
+  where `J` is an arbitrary basis for `C`.
+* `Matroid.contract_dual M C : (M ／ X)✶ = M✶ ＼ X`; the dual of contraction is deletion.
+* `Matroid.delete_dual M C : (M ＼ X)✶ = M✶ ／ X`; the dual of deletion is contraction.
+
+# Naming conventions
+
+We use the abbreviations `deleteElem` and `contractElem` in lemma names to refer to the
+deletion or contraction of a single element `e : α` from `M : Matroid α`.
+
+-/
+
+open Set
+
+variable {α : Type*} {M M' N : Matroid α} {e f : α} {I J R B X Y Z K S : Set α}
+
+namespace Matroid
+
+section Delete
+
+variable {D D₁ D₂ R : Set α}
+
+/-- The deletion `M ＼ D` is the restriction of a matroid `M` to `M.E \ D`.
+Its independent sets are the `M`-independent subsets of `M.E \ D`. -/
+def delete (M : Matroid α) (D : Set α) : Matroid α := M ↾ (M.E \ D)
+
+/-- `M ＼ D` refers to the deletion of a set `D` from the matroid `M`. -/
+infixl:75 " ＼ " => Matroid.delete
+
+lemma delete_eq_restrict (M : Matroid α) (D : Set α) : M ＼ D = M ↾ (M.E \ D) := rfl
+
+instance delete_finite [M.Finite] : (M ＼ D).Finite :=
+  ⟨M.ground_finite.diff⟩
+
+instance delete_rankFinite [RankFinite M] : RankFinite (M ＼ D) :=
+  restrict_rankFinite _
+
+lemma restrict_compl (M : Matroid α) (D : Set α) : M ↾ (M.E \ D) = M ＼ D := rfl
+
+@[simp]
+lemma delete_compl (hR : R ⊆ M.E := by aesop_mat) : M ＼ (M.E \ R) = M ↾ R := by
+  rw [← restrict_compl, diff_diff_cancel_left hR]
+
+@[simp]
+lemma delete_isRestriction (M : Matroid α) (D : Set α) : M ＼ D ≤r M :=
+  restrict_isRestriction _ _ diff_subset
+
+lemma IsRestriction.exists_eq_delete (hNM : N ≤r M) : ∃ D ⊆ M.E, N = M ＼ D :=
+  ⟨M.E \ N.E, diff_subset, by obtain ⟨R, hR, rfl⟩ := hNM; rw [delete_compl, restrict_ground_eq]⟩
+
+lemma isRestriction_iff_exists_eq_delete : N ≤r M ↔ ∃ D ⊆ M.E, N = M ＼ D :=
+  ⟨IsRestriction.exists_eq_delete, by rintro ⟨D, -, rfl⟩; apply delete_isRestriction⟩
+
+@[simp]
+lemma delete_ground (M : Matroid α) (D : Set α) : (M ＼ D).E = M.E \ D := rfl
+
+@[aesop unsafe 10% (rule_sets := [Matroid])]
+lemma delete_subset_ground (M : Matroid α) (D : Set α) : (M ＼ D).E ⊆ M.E :=
+  diff_subset
+
+@[simp]
+lemma delete_eq_self_iff : M ＼ D = M ↔ Disjoint D M.E := by
+  rw [← restrict_compl, restrict_eq_self_iff, sdiff_eq_left, disjoint_comm]
+
+alias ⟨_, delete_eq_self⟩ := delete_eq_self_iff
+
+lemma deleteElem_eq_self (he : e ∉ M.E) : M ＼ {e} = M := by
+  simpa
+
+@[simp]
+lemma delete_delete (M : Matroid α) (D₁ D₂ : Set α) : M ＼ D₁ ＼ D₂ = M ＼ (D₁ ∪ D₂) := by
+  rw [← restrict_compl, ← restrict_compl, ← restrict_compl, restrict_restrict_eq,
+    restrict_ground_eq, diff_diff]
+  simp [diff_subset]
+
+lemma delete_comm (M : Matroid α) (D₁ D₂ : Set α) : M ＼ D₁ ＼ D₂ = M ＼ D₂ ＼ D₁ := by
+  rw [delete_delete, union_comm, delete_delete]
+
+lemma delete_inter_ground_eq (M : Matroid α) (D : Set α) : M ＼ (D ∩ M.E) = M ＼ D := by
+  rw [← restrict_compl, ← restrict_compl, diff_inter_self_eq_diff]
+
+lemma delete_eq_delete_iff : M ＼ D₁ = M ＼ D₂ ↔ D₁ ∩ M.E = D₂ ∩ M.E := by
+  rw [← delete_inter_ground_eq, ← M.delete_inter_ground_eq D₂]
+  refine ⟨fun h ↦ ?_, fun h ↦ by rw [h]⟩
+  apply_fun (M.E \ Matroid.E ·) at h
+  simp_rw [delete_ground, diff_diff_cancel_left inter_subset_right] at h
+  assumption
+
+lemma IsRestriction.restrict_delete_of_disjoint (h : N ≤r M) (hX : Disjoint X N.E) :
+    N ≤r (M ＼ X) := by
+  obtain ⟨D, hD, rfl⟩ := isRestriction_iff_exists_eq_delete.1 h
+  refine isRestriction_iff_exists_eq_delete.2 ⟨D \ X, diff_subset_diff_left hD, ?_⟩
+  rwa [delete_delete, union_diff_self, union_comm, ← delete_delete, eq_comm,
+    delete_eq_self_iff]
+
+lemma IsRestriction.restriction_deleteElem (h : N ≤r M) (he : e ∉ N.E) : N ≤r M ＼ {e} :=
+  h.restrict_delete_of_disjoint (by simpa)
+
+@[simp]
+lemma delete_indep_iff : (M ＼ D).Indep I ↔ M.Indep I ∧ Disjoint I D := by
+  rw [← restrict_compl, restrict_indep_iff, subset_diff, ← and_assoc,
+    and_iff_left_of_imp Indep.subset_ground]
+
+lemma deleteElem_indep_iff : (M ＼ {e}).Indep I ↔ M.Indep I ∧ e ∉ I := by
+  simp
+
+lemma Indep.of_delete (h : (M ＼ D).Indep I) : M.Indep I :=
+  (delete_indep_iff.mp h).1
+
+lemma Indep.indep_delete_of_disjoint (h : M.Indep I) (hID : Disjoint I D) : (M ＼ D).Indep I :=
+  delete_indep_iff.mpr ⟨h, hID⟩
+
+lemma indep_iff_delete_of_disjoint (hID : Disjoint I D) : M.Indep I ↔ (M ＼ D).Indep I :=
+  ⟨fun h ↦ h.indep_delete_of_disjoint hID, fun h ↦ h.of_delete⟩
+
+@[simp]
+lemma delete_dep_iff : (M ＼ D).Dep X ↔ M.Dep X ∧ Disjoint X D := by
+  rw [dep_iff, dep_iff, delete_indep_iff, delete_ground, subset_diff]; tauto
+
+@[simp]
+lemma delete_isBase_iff : (M ＼ D).IsBase B ↔ M.IsBasis B (M.E \ D) := by
+  rw [← restrict_compl, isBase_restrict_iff]
+
+@[simp]
+lemma delete_isBasis_iff : (M ＼ D).IsBasis I X ↔ M.IsBasis I X ∧ Disjoint X D := by
+  rw [← restrict_compl, isBasis_restrict_iff, subset_diff, ← and_assoc,
+    and_iff_left_of_imp IsBasis.subset_ground]
+
+@[simp]
+lemma delete_isBasis'_iff : (M ＼ D).IsBasis' I X ↔ M.IsBasis' I (X \ D) := by
+  rw [isBasis'_iff_isBasis_inter_ground, delete_isBasis_iff, delete_ground, diff_eq, inter_comm M.E,
+    ← inter_assoc, ← diff_eq, ← isBasis'_iff_isBasis_inter_ground, and_iff_left_iff_imp,
+    inter_comm, ← inter_diff_assoc]
+  exact fun _ ↦ disjoint_sdiff_left
+
+lemma IsBasis.of_delete (h : (M ＼ D).IsBasis I X) : M.IsBasis I X :=
+  (delete_isBasis_iff.mp h).1
+
+lemma IsBasis.to_delete (h : M.IsBasis I X) (hX : Disjoint X D) : (M ＼ D).IsBasis I X := by
+  rw [delete_isBasis_iff]; exact ⟨h, hX⟩
+
+@[simp]
+lemma delete_isLoop_iff : (M ＼ D).IsLoop e ↔ M.IsLoop e ∧ e ∉ D := by
+  rw [← singleton_dep, delete_dep_iff, disjoint_singleton_left, singleton_dep]
+
+@[simp]
+lemma delete_isNonloop_iff : (M ＼ D).IsNonloop e ↔ M.IsNonloop e ∧ e ∉ D := by
+  rw [← indep_singleton, delete_indep_iff, disjoint_singleton_left, indep_singleton]
+
+lemma IsNonloop.of_delete (h : (M ＼ D).IsNonloop e) : M.IsNonloop e :=
+  (delete_isNonloop_iff.1 h).1
+
+lemma isNonloop_iff_delete_of_not_mem (he : e ∉ D) : M.IsNonloop e ↔ (M ＼ D).IsNonloop e :=
+  ⟨fun h ↦ delete_isNonloop_iff.2 ⟨h, he⟩, fun h ↦ h.of_delete⟩
+
+@[simp]
+lemma delete_isCircuit_iff {C : Set α} :
+    (M ＼ D).IsCircuit C ↔ M.IsCircuit C ∧ Disjoint C D := by
+  simp_rw [isCircuit_iff, delete_dep_iff, and_imp]
+  rw [and_comm, ← and_assoc, and_congr_left_iff, and_comm, and_congr_right_iff]
+  exact fun hdj _↦ ⟨fun h I hId hIC ↦ h hId (disjoint_of_subset_left hIC hdj) hIC,
+    fun h I hI _ hIC ↦ h hI hIC⟩
+
+lemma IsCircuit.of_delete {C : Set α} (h : (M ＼ D).IsCircuit C) : M.IsCircuit C :=
+  (delete_isCircuit_iff.1 h).1
+
+lemma circuit_iff_delete_of_disjoint {C : Set α} (hCD : Disjoint C D) :
+    M.IsCircuit C ↔ (M ＼ D).IsCircuit C :=
+  ⟨fun h ↦ delete_isCircuit_iff.2 ⟨h, hCD⟩, fun h ↦ h.of_delete⟩
+
+@[simp]
+lemma delete_closure_eq (M : Matroid α) (D X : Set α) :
+    (M ＼ D).closure X = M.closure (X \ D) \ D := by
+  rw [← restrict_compl, restrict_closure_eq', sdiff_sdiff_self, bot_eq_empty, union_empty,
+    diff_eq, inter_comm M.E, ← inter_assoc X, ← diff_eq, closure_inter_ground,
+    ← inter_assoc, ← diff_eq, inter_eq_left]
+  exact diff_subset.trans (M.closure_subset_ground _)
+
+@[simp]
+lemma delete_loops_eq (M : Matroid α) (D : Set α) : (M ＼ D).loops = M.loops \ D := by
+  simp [loops]
+
+@[simp]
+lemma delete_empty (M : Matroid α) : M ＼ ∅ = M := by
+  rw [delete_eq_self_iff]
+  exact empty_disjoint _
+
+lemma delete_delete_diff (M : Matroid α) (D₁ D₂ : Set α) : M ＼ D₁ ＼ D₂ = M ＼ D₁ ＼ (D₂ \ D₁) :=
+  by simp
+
+instance delete_finitary (M : Matroid α) [Finitary M] (D : Set α) : Finitary (M ＼ D) := by
+  change Finitary (M ↾ (M.E \ D)); infer_instance
+
+lemma Coindep.delete_isBase_iff (hD : M.Coindep D) :
+    (M ＼ D).IsBase B ↔ M.IsBase B ∧ Disjoint B D := by
+  rw [Matroid.delete_isBase_iff]
+  refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
+  · have hss := h.subset
+    rw [subset_diff] at hss
+    have hcl := h.isBasis_closure_right
+    rw [hD.closure_compl, isBasis_ground_iff] at hcl
+    exact ⟨hcl, hss.2⟩
+  exact h.1.isBasis_ground.isBasis_subset (by simp [subset_diff, h.1.subset_ground, h.2])
+    diff_subset
+
+lemma Coindep.delete_rankPos [M.RankPos] (hD : M.Coindep D) : (M ＼ D).RankPos := by
+  rw [rankPos_iff, hD.delete_isBase_iff]
+  simp [M.empty_not_isBase]
+
+lemma Coindep.delete_spanning_iff (hD : M.Coindep D) :
+    (M ＼ D).Spanning S ↔ M.Spanning S ∧ Disjoint S D := by
+  simp only [spanning_iff_exists_isBase_subset', hD.delete_isBase_iff, and_assoc, delete_ground,
+    subset_diff, and_congr_left_iff, and_imp]
+  refine fun hSE hSD ↦ ⟨fun ⟨B, hB, hBD, hBS⟩ ↦ ⟨B, hB, hBS⟩, fun ⟨B, hB, hBS⟩ ↦ ⟨B, hB, ?_, hBS⟩⟩
+  exact hSD.mono_left hBS
+
+end Delete
+
+section Contract
+
+/-- The contraction `M ／ C` is the matroid on `M.E \ C` in which a set `I ⊆ M.E \ C` is independent
+if and only if `I ∪ J` is independent, where `J` is an arbitrarily chosen basis for `C`.
+It is also equal to `(M✶ ＼ C)✶`, and is defined this way so we don't have to give
+a separate proof that it is actually a matroid.
+(Currently the proof it has the correct independent sets is TODO. ) -/
+def contract (M : Matroid α) (C : Set α) : Matroid α := (M✶ ＼ C)✶
+
+/-- `M ／ C` refers to the contraction of a set `C` from the matroid `M`. -/
+infixl:75 " ／ " => Matroid.contract
+
+lemma dual_delete_dual (M : Matroid α) (X : Set α) : (M✶ ＼ X)✶ = M ／ X := rfl
+
+@[simp]
+lemma delete_dual (M : Matroid α) (X : Set α) : (M ＼ X)✶ = M✶ ／ X := by
+  rw [← dual_dual M, dual_delete_dual, dual_dual]
+
+@[simp]
+lemma contract_dual (M : Matroid α) (X : Set α) : (M ／ X)✶ = M✶ ＼ X := by
+  rw [← dual_delete_dual, dual_dual]
+
+lemma dual_contract_dual (M : Matroid α) (X : Set α) : (M✶ ／ X)✶ = M ＼ X := by
+  simp
+
+end Contract
+
+end Matroid

--- a/Mathlib/Data/Matroid/Minor/Basic.lean
+++ b/Mathlib/Data/Matroid/Minor/Basic.lean
@@ -36,7 +36,7 @@ and interacts nicely with duality and linear representations.
 # Naming conventions
 
 We use the abbreviations `deleteElem` and `contractElem` in lemma names to refer to the
-deletion or contraction of a single element `e : α` from `M : Matroid α`.
+deletion `M ＼ {e}` or contraction `M ／ {e}` of a single element `e : α` from `M : Matroid α`.
 
 -/
 
@@ -55,7 +55,7 @@ Its independent sets are the `M`-independent subsets of `M.E \ D`. -/
 def delete (M : Matroid α) (D : Set α) : Matroid α := M ↾ (M.E \ D)
 
 /-- `M ＼ D` refers to the deletion of a set `D` from the matroid `M`. -/
-infixl:75 " ＼ " => Matroid.delete
+scoped infixl:75 " ＼ " => Matroid.delete
 
 lemma delete_eq_restrict (M : Matroid α) (D : Set α) : M ＼ D = M ↾ (M.E \ D) := rfl
 
@@ -123,7 +123,7 @@ lemma IsRestriction.restrict_delete_of_disjoint (h : N ≤r M) (hX : Disjoint X 
   rwa [delete_delete, union_diff_self, union_comm, ← delete_delete, eq_comm,
     delete_eq_self_iff]
 
-lemma IsRestriction.restriction_deleteElem (h : N ≤r M) (he : e ∉ N.E) : N ≤r M ＼ {e} :=
+lemma IsRestriction.isRestriction_deleteElem (h : N ≤r M) (he : e ∉ N.E) : N ≤r M ＼ {e} :=
   h.restrict_delete_of_disjoint (by simpa)
 
 @[simp]
@@ -166,7 +166,7 @@ lemma delete_isBasis'_iff : (M ＼ D).IsBasis' I X ↔ M.IsBasis' I (X \ D) := b
 lemma IsBasis.of_delete (h : (M ＼ D).IsBasis I X) : M.IsBasis I X :=
   (delete_isBasis_iff.mp h).1
 
-lemma IsBasis.to_delete (h : M.IsBasis I X) (hX : Disjoint X D) : (M ＼ D).IsBasis I X := by
+lemma IsBasis.delete (h : M.IsBasis I X) (hX : Disjoint X D) : (M ＼ D).IsBasis I X := by
   rw [delete_isBasis_iff]; exact ⟨h, hX⟩
 
 @[simp]
@@ -186,10 +186,9 @@ lemma isNonloop_iff_delete_of_not_mem (he : e ∉ D) : M.IsNonloop e ↔ (M ＼ 
 @[simp]
 lemma delete_isCircuit_iff {C : Set α} :
     (M ＼ D).IsCircuit C ↔ M.IsCircuit C ∧ Disjoint C D := by
-  simp_rw [isCircuit_iff, delete_dep_iff, and_imp]
-  rw [and_comm, ← and_assoc, and_congr_left_iff, and_comm, and_congr_right_iff]
-  exact fun hdj _↦ ⟨fun h I hId hIC ↦ h hId (disjoint_of_subset_left hIC hdj) hIC,
-    fun h I hI _ hIC ↦ h hI hIC⟩
+  rw [delete_eq_restrict, restrict_isCircuit_iff, and_congr_right_iff, subset_diff,
+    and_iff_right_iff_imp]
+  exact fun h _ ↦ h.subset_ground
 
 lemma IsCircuit.of_delete {C : Set α} (h : (M ＼ D).IsCircuit C) : M.IsCircuit C :=
   (delete_isCircuit_iff.1 h).1
@@ -215,7 +214,8 @@ lemma delete_empty (M : Matroid α) : M ＼ ∅ = M := by
   rw [delete_eq_self_iff]
   exact empty_disjoint _
 
-lemma delete_delete_diff (M : Matroid α) (D₁ D₂ : Set α) : M ＼ D₁ ＼ D₂ = M ＼ D₁ ＼ (D₂ \ D₁) :=
+lemma delete_delete_eq_delete_diff (M : Matroid α) (D₁ D₂ : Set α) :
+    M ＼ D₁ ＼ D₂ = M ＼ D₁ ＼ (D₂ \ D₁) :=
   by simp
 
 instance delete_finitary (M : Matroid α) [Finitary M] (D : Set α) : Finitary (M ＼ D) := by
@@ -261,11 +261,11 @@ infixl:75 " ／ " => Matroid.contract
 lemma dual_delete_dual (M : Matroid α) (X : Set α) : (M✶ ＼ X)✶ = M ／ X := rfl
 
 @[simp]
-lemma delete_dual (M : Matroid α) (X : Set α) : (M ＼ X)✶ = M✶ ／ X := by
+lemma dual_delete (M : Matroid α) (X : Set α) : (M ＼ X)✶ = M✶ ／ X := by
   rw [← dual_dual M, dual_delete_dual, dual_dual]
 
 @[simp]
-lemma contract_dual (M : Matroid α) (X : Set α) : (M ／ X)✶ = M✶ ＼ X := by
+lemma dual_contract (M : Matroid α) (X : Set α) : (M ／ X)✶ = M✶ ＼ X := by
   rw [← dual_delete_dual, dual_dual]
 
 lemma dual_contract_dual (M : Matroid α) (X : Set α) : (M✶ ／ X)✶ = M ＼ X := by
@@ -278,10 +278,10 @@ lemma contract_contract (M : Matroid α) (C₁ C₂ : Set α) : M ／ C₁ ／ C
 lemma contract_comm (M : Matroid α) (C₁ C₂ : Set α) : M ／ C₁ ／ C₂ = M ／ C₂ ／ C₁ := by
   simp [union_comm]
 
-lemma contract_delete_dual (M : Matroid α) (X Y : Set α) : (M ／ X ＼ Y)✶ = M✶ ＼ X ／ Y := by
+lemma dual_contract_delete (M : Matroid α) (X Y : Set α) : (M ／ X ＼ Y)✶ = M✶ ＼ X ／ Y := by
   simp
 
-lemma delete_contract_dual (M : Matroid α) (X Y : Set α) : (M ＼ X ／ Y)✶ = M✶ ／ X ＼ Y := by
+lemma dual_delete_contract (M : Matroid α) (X Y : Set α) : (M ＼ X ／ Y)✶ = M✶ ／ X ＼ Y := by
   simp
 
 end Contract

--- a/Mathlib/Data/Matroid/Minor/Basic.lean
+++ b/Mathlib/Data/Matroid/Minor/Basic.lean
@@ -271,6 +271,19 @@ lemma contract_dual (M : Matroid α) (X : Set α) : (M ／ X)✶ = M✶ ＼ X :=
 lemma dual_contract_dual (M : Matroid α) (X : Set α) : (M✶ ／ X)✶ = M ＼ X := by
   simp
 
+@[simp]
+lemma contract_contract (M : Matroid α) (C₁ C₂ : Set α) : M ／ C₁ ／ C₂ = M ／ (C₁ ∪ C₂) := by
+  simp [← dual_inj]
+
+lemma contract_comm (M : Matroid α) (C₁ C₂ : Set α) : M ／ C₁ ／ C₂ = M ／ C₂ ／ C₁ := by
+  simp [union_comm]
+
+lemma contract_delete_dual (M : Matroid α) (X Y : Set α) : (M ／ X ＼ Y)✶ = M✶ ＼ X ／ Y := by
+  simp
+
+lemma delete_contract_dual (M : Matroid α) (X Y : Set α) : (M ＼ X ／ Y)✶ = M✶ ／ X ＼ Y := by
+  simp
+
 end Contract
 
 end Matroid


### PR DESCRIPTION
We define deletions and contractions of sets in matroids. 

We provide basic API for deletion, and its interaction with most of the existing matroid notions in mathlib. 
The API for contraction is more complicated, so to limit size of this first PR, we just give the definition and the fact that it is dual to deletion. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
