### PR TITLE
[Merged by Bors] - chore: use `dist_eq_norm_sub` not `dist_eq`

### DIFF
--- a/Mathlib/Topology/ContinuousMap/Bounded/Basic.lean
+++ b/Mathlib/Topology/ContinuousMap/Bounded/Basic.lean
@@ -1409,7 +1409,7 @@ instance instSup : Max (α →ᵇ β) where
         obtain ⟨C₁, hf⟩ := f.bounded
         obtain ⟨C₂, hg⟩ := g.bounded
         refine ⟨C₁ + C₂, fun x y ↦ ?_⟩
-        simp_rw [NormedAddCommGroup.dist_eq] at hf hg ⊢
+        simp_rw [dist_eq_norm_sub] at hf hg ⊢
         exact (norm_sup_sub_sup_le_add_norm _ _ _ _).trans (add_le_add (hf _ _) (hg _ _)) }
 
 instance instInf : Min (α →ᵇ β) where
@@ -1420,7 +1420,7 @@ instance instInf : Min (α →ᵇ β) where
         obtain ⟨C₁, hf⟩ := f.bounded
         obtain ⟨C₂, hg⟩ := g.bounded
         refine ⟨C₁ + C₂, fun x y ↦ ?_⟩
-        simp_rw [NormedAddCommGroup.dist_eq] at hf hg ⊢
+        simp_rw [dist_eq_norm_sub] at hf hg ⊢
         exact (norm_inf_sub_inf_le_add_norm _ _ _ _).trans (add_le_add (hf _ _) (hg _ _)) }
 
 @[simp, norm_cast] lemma coe_sup (f g : α →ᵇ β) : ⇑(f ⊔ g) = ⇑f ⊔ ⇑g := rfl


### PR DESCRIPTION
This is extracted from #9642


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
