### PR TITLE
[Merged by Bors] - chore(GroupTheory/Perm): rename arguments to `swap_induction_on`

### DIFF
--- a/Mathlib/GroupTheory/Perm/Option.lean
+++ b/Mathlib/GroupTheory/Perm/Option.lean
@@ -30,9 +30,9 @@ theorem Equiv.optionCongr_swap {α : Type*} [DecidableEq α] (x y : α) :
 @[simp]
 theorem Equiv.optionCongr_sign {α : Type*} [DecidableEq α] [Fintype α] (e : Perm α) :
     Perm.sign e.optionCongr = Perm.sign e := by
-  refine Perm.swap_induction_on e ?_ ?_
-  · simp [Perm.one_def]
-  · intro f x y hne h
+  induction e using Perm.swap_induction_on with
+  | one => simp [Perm.one_def]
+  | swap_mul f x y hne h =>
     simp [h, hne, Perm.mul_def, ← Equiv.optionCongr_trans]
 
 @[simp]

--- a/Mathlib/LinearAlgebra/Alternating/Basic.lean
+++ b/Mathlib/LinearAlgebra/Alternating/Basic.lean
@@ -636,10 +636,9 @@ theorem map_swap [DecidableEq ι] {i j : ι} (hij : i ≠ j) : g (v ∘ Equiv.sw
 
 theorem map_perm [DecidableEq ι] [Fintype ι] (v : ι → M) (σ : Equiv.Perm ι) :
     g (v ∘ σ) = Equiv.Perm.sign σ • g v := by
-  -- Porting note: `apply` → `induction`
-  induction σ using Equiv.Perm.swap_induction_on'
-  · simp
-  · rename_i s x y hxy hI
+  induction σ using Equiv.Perm.swap_induction_on' with
+  | one => simp
+  | mul_swap s x y hxy hI =>
     -- Porting note: `← Function.comp_assoc` & `-Equiv.Perm.sign_swap'` are required.
     simpa [← Function.comp_assoc, g.map_swap (v ∘ s) hxy,
       Equiv.Perm.sign_swap hxy, -Equiv.Perm.sign_swap'] using hI


### PR DESCRIPTION
This makes the `induction` tactic nicer to use.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
