### PR TITLE
[Merged by Bors] - feat(MeasureTheory/Group): add theorem for involution preserves lebesgue integral of inverse invariant measure

### DIFF
--- a/Mathlib/MeasureTheory/Group/LIntegral.lean
+++ b/Mathlib/MeasureTheory/Group/LIntegral.lean
@@ -53,6 +53,21 @@ theorem lintegral_div_right_eq_self [IsMulRightInvariant μ] (f : G → ℝ≥0�
 
 end MeasurableMul
 
+section MeasurableInv
+
+variable [Group G] [MeasurableInv G]
+
+/-- Involuting a function does not change its Lebesgue integral with respect to a
+inverse-invariant measure. -/
+@[to_additive]
+theorem lintegral_inv_eq_self [IsInvInvariant μ] (f : G → ℝ≥0∞) :
+   (∫⁻ x, f x⁻¹ ∂μ) = ∫⁻ x, f x ∂μ := by
+   convert (lintegral_map_equiv f <| MeasurableEquiv.inv _).symm
+   nth_rewrite 1 [← map_inv_eq_self μ]
+   rfl
+
+end MeasurableInv
+
 section IsTopologicalGroup
 
 variable [TopologicalSpace G] [Group G] [IsTopologicalGroup G] [BorelSpace G] [IsMulLeftInvariant μ]

--- a/Mathlib/MeasureTheory/Group/LIntegral.lean
+++ b/Mathlib/MeasureTheory/Group/LIntegral.lean
@@ -57,9 +57,11 @@ section MeasurableInv
 
 variable [InvolutiveInv G] [MeasurableInv G]
 
-/-- Involuting a function does not change its Lebesgue integral with respect to a
-inverse-invariant measure. -/
-@[to_additive]
+/-- The Lebesgue integral of a function with respect to an inverse invariant measure is
+invariant under the change of variables x ↦ x⁻¹. -/
+@[to_additive
+      "The Lebesgue integral of a function with respect to an inverse invariant measure is
+invariant under the change of variables x ↦ -x."]
 theorem lintegral_inv_eq_self [IsInvInvariant μ] (f : G → ℝ≥0∞) :
    ∫⁻ x, f x⁻¹ ∂μ = ∫⁻ x, f x ∂μ := by
  convert (lintegral_map_equiv f <| MeasurableEquiv.inv _).symm

--- a/Mathlib/MeasureTheory/Group/LIntegral.lean
+++ b/Mathlib/MeasureTheory/Group/LIntegral.lean
@@ -61,10 +61,10 @@ variable [Group G] [MeasurableInv G]
 inverse-invariant measure. -/
 @[to_additive]
 theorem lintegral_inv_eq_self [IsInvInvariant μ] (f : G → ℝ≥0∞) :
-   (∫⁻ x, f x⁻¹ ∂μ) = ∫⁻ x, f x ∂μ := by
-   convert (lintegral_map_equiv f <| MeasurableEquiv.inv _).symm
-   nth_rewrite 1 [← map_inv_eq_self μ]
-   rfl
+   ∫⁻ x, f x⁻¹ ∂μ = ∫⁻ x, f x ∂μ := by
+ convert (lintegral_map_equiv f <| MeasurableEquiv.inv _).symm
+ nth_rewrite 1 [← map_inv_eq_self μ]
+ rfl
 
 end MeasurableInv
 

--- a/Mathlib/MeasureTheory/Group/LIntegral.lean
+++ b/Mathlib/MeasureTheory/Group/LIntegral.lean
@@ -55,7 +55,7 @@ end MeasurableMul
 
 section MeasurableInv
 
-variable [Group G] [MeasurableInv G]
+variable [InvolutiveInv G] [MeasurableInv G]
 
 /-- Involuting a function does not change its Lebesgue integral with respect to a
 inverse-invariant measure. -/


### PR DESCRIPTION
Add "lintegral_inv_eq_self" which states that involuting a function does not change its Lebesgue integral with respect to a
inverse-invariant measure. I would like to use this to prove facts about the (lintegral) convolution of functions (which I am working on). 