### PR TITLE
[Merged by Bors] - feat(MeasureTheory): add API to convolution of measures and lintegrals

### DIFF
--- a/Mathlib/MeasureTheory/Group/Convolution.lean
+++ b/Mathlib/MeasureTheory/Group/Convolution.lean
@@ -41,7 +41,7 @@ scoped[MeasureTheory] infixl:80 " ∗ " => MeasureTheory.Measure.conv
 theorem lintegral_mconv [MeasurableMul₂ M] {μ ν : Measure M} [SFinite ν]
     {f : M → ℝ≥0∞} (hf : Measurable f) :
     ∫⁻ z, f z ∂(μ ∗ ν) = ∫⁻ x, ∫⁻ y, f (x * y) ∂ν ∂μ := by
-  rw[mconv, lintegral_map hf measurable_mul, lintegral_prod]
+  rw [mconv, lintegral_map hf measurable_mul, lintegral_prod]
   fun_prop
 
 /-- Convolution of the dirac measure at 1 with a measure μ returns μ. -/

--- a/Mathlib/MeasureTheory/Group/Convolution.lean
+++ b/Mathlib/MeasureTheory/Group/Convolution.lean
@@ -38,7 +38,7 @@ scoped[MeasureTheory] infixl:80 " ∗ " => MeasureTheory.Measure.mconv
 scoped[MeasureTheory] infixl:80 " ∗ " => MeasureTheory.Measure.conv
 
 @[to_additive lintegral_conv]
-theorem lintegral_mconv [MeasurableMul₂ M] {μ : Measure M} {ν : Measure M} [SFinite ν]
+theorem lintegral_mconv [MeasurableMul₂ M] {μ ν : Measure M} [SFinite ν]
     {f : M → ℝ≥0∞} (hf : Measurable f):
     ∫⁻ z, f z ∂(μ ∗ ν) = ∫⁻ x, ∫⁻ y, f (x * y) ∂ν ∂μ := by
   rw[mconv, lintegral_map hf measurable_mul, lintegral_prod]

--- a/Mathlib/MeasureTheory/Group/Convolution.lean
+++ b/Mathlib/MeasureTheory/Group/Convolution.lean
@@ -36,6 +36,13 @@ scoped[MeasureTheory] infix:80 " ∗ " => MeasureTheory.Measure.mconv
 /-- Scoped notation for the additive convolution of measures. -/
 scoped[MeasureTheory] infix:80 " ∗ " => MeasureTheory.Measure.conv
 
+@[to_additive lintegral_conv]
+theorem lintegral_mconv [MeasurableMul₂ M] {μ : Measure M} {ν : Measure M} [SFinite ν]
+    {f : M → ℝ≥0∞} (hf : Measurable f):
+    ∫⁻ z, f z ∂(μ ∗ ν) = ∫⁻ x, ∫⁻ y, f (x * y) ∂ν ∂μ := by
+  rw[mconv, lintegral_map hf measurable_mul, lintegral_prod]
+  fun_prop
+
 /-- Convolution of the dirac measure at 1 with a measure μ returns μ. -/
 @[to_additive (attr := simp)]
 theorem dirac_one_mconv [MeasurableMul₂ M] (μ : Measure M) [SFinite μ] :
@@ -55,13 +62,13 @@ theorem mconv_dirac_one [MeasurableMul₂ M]
   fun_prop
 
 /-- Convolution of the zero measure with a measure μ returns the zero measure. -/
-@[to_additive (attr := simp) conv_zero]
+@[to_additive (attr := simp) zero_conv]
 theorem mconv_zero (μ : Measure M) : (0 : Measure M) ∗ μ = (0 : Measure M) := by
   unfold mconv
   simp
 
 /-- Convolution of a measure μ with the zero measure returns the zero measure. -/
-@[to_additive (attr := simp) zero_conv]
+@[to_additive (attr := simp) conv_zero]
 theorem zero_mconv (μ : Measure M) : μ ∗ (0 : Measure M) = (0 : Measure M) := by
   unfold mconv
   simp
@@ -101,6 +108,20 @@ instance finite_of_finite_mconv (μ : Measure M) (ν : Measure M) [IsFiniteMeasu
     unfold mconv
     exact IsFiniteMeasure.measure_univ_lt_top
   exact {measure_univ_lt_top := h}
+
+/-- Convolution is associative -/
+@[to_additive conv_assoc]
+theorem mconv_assoc [MeasurableMul₂ M] (μ : Measure M) (ν : Measure M) (ρ : Measure M)
+    [SFinite ν] [SFinite ρ] :
+    (μ ∗ ν) ∗ ρ = μ ∗ (ν ∗ ρ) := by
+  rw[measure_eq_measure_iff_lintegral_eq_lintegral]
+  intro f hf
+  repeat rw[lintegral_mconv (by first | fun_prop | apply Measurable.lintegral_prod_right; fun_prop)]
+  refine lintegral_congr (fun x ↦ ?_)
+  rw[lintegral_mconv (by fun_prop)]
+  repeat refine lintegral_congr (fun x ↦ ?_)
+  apply congr_arg
+  simp [mul_assoc]
 
 @[to_additive probabilitymeasure_of_probabilitymeasures_conv]
 instance probabilitymeasure_of_probabilitymeasures_mconv (μ : Measure M) (ν : Measure M)

--- a/Mathlib/MeasureTheory/Group/Convolution.lean
+++ b/Mathlib/MeasureTheory/Group/Convolution.lean
@@ -115,12 +115,12 @@ instance finite_of_finite_mconv (μ : Measure M) (ν : Measure M) [IsFiniteMeasu
 theorem mconv_assoc [MeasurableMul₂ M] (μ ν ρ : Measure M)
     [SFinite ν] [SFinite ρ] :
     (μ ∗ ν) ∗ ρ = μ ∗ (ν ∗ ρ) := by
-  rw[measure_eq_measure_iff_lintegral_eq_lintegral]
+  rw [measure_eq_measure_iff_lintegral_eq_lintegral]
   intro f hf
-  repeat rw[lintegral_mconv (by first | fun_prop | apply Measurable.lintegral_prod_right; fun_prop)]
-  refine lintegral_congr (fun x ↦ ?_)
-  rw[lintegral_mconv (by fun_prop)]
-  repeat refine lintegral_congr (fun x ↦ ?_)
+  repeat rw [lintegral_mconv (by first | fun_prop | apply Measurable.lintegral_prod_right; fun_prop)]
+  refine lintegral_congr fun x ↦ ?_
+  rw [lintegral_mconv (by fun_prop)]
+  repeat refine lintegral_congr fun x ↦ ?_
   apply congr_arg
   simp [mul_assoc]
 

--- a/Mathlib/MeasureTheory/Group/Convolution.lean
+++ b/Mathlib/MeasureTheory/Group/Convolution.lean
@@ -112,7 +112,7 @@ instance finite_of_finite_mconv (μ : Measure M) (ν : Measure M) [IsFiniteMeasu
 
 /-- Convolution is associative -/
 @[to_additive conv_assoc]
-theorem mconv_assoc [MeasurableMul₂ M] (μ : Measure M) (ν : Measure M) (ρ : Measure M)
+theorem mconv_assoc [MeasurableMul₂ M] (μ ν ρ : Measure M)
     [SFinite ν] [SFinite ρ] :
     (μ ∗ ν) ∗ ρ = μ ∗ (ν ∗ ρ) := by
   rw[measure_eq_measure_iff_lintegral_eq_lintegral]

--- a/Mathlib/MeasureTheory/Group/Convolution.lean
+++ b/Mathlib/MeasureTheory/Group/Convolution.lean
@@ -115,9 +115,10 @@ instance finite_of_finite_mconv (μ : Measure M) (ν : Measure M) [IsFiniteMeasu
 theorem mconv_assoc [MeasurableMul₂ M] (μ ν ρ : Measure M)
     [SFinite ν] [SFinite ρ] :
     (μ ∗ ν) ∗ ρ = μ ∗ (ν ∗ ρ) := by
-  rw [measure_eq_measure_iff_lintegral_eq_lintegral]
+  apply ext_of_lintegral
   intro f hf
-  repeat rw [lintegral_mconv (by first | fun_prop | apply Measurable.lintegral_prod_right; fun_prop)]
+  repeat
+    rw [lintegral_mconv (by first | fun_prop | apply Measurable.lintegral_prod_right; fun_prop)]
   refine lintegral_congr fun x ↦ ?_
   rw [lintegral_mconv (by fun_prop)]
   repeat refine lintegral_congr fun x ↦ ?_

--- a/Mathlib/MeasureTheory/Group/Convolution.lean
+++ b/Mathlib/MeasureTheory/Group/Convolution.lean
@@ -22,6 +22,7 @@ In this file we define and prove properties about the convolutions of two measur
 namespace MeasureTheory
 
 namespace Measure
+open scoped ENNReal
 
 variable {M : Type*} [Monoid M] [MeasurableSpace M]
 
@@ -31,10 +32,10 @@ noncomputable def mconv (μ : Measure M) (ν : Measure M) :
     Measure M := Measure.map (fun x : M × M ↦ x.1 * x.2) (μ.prod ν)
 
 /-- Scoped notation for the multiplicative convolution of measures. -/
-scoped[MeasureTheory] infix:80 " ∗ " => MeasureTheory.Measure.mconv
+scoped[MeasureTheory] infixl:80 " ∗ " => MeasureTheory.Measure.mconv
 
 /-- Scoped notation for the additive convolution of measures. -/
-scoped[MeasureTheory] infix:80 " ∗ " => MeasureTheory.Measure.conv
+scoped[MeasureTheory] infixl:80 " ∗ " => MeasureTheory.Measure.conv
 
 @[to_additive lintegral_conv]
 theorem lintegral_mconv [MeasurableMul₂ M] {μ : Measure M} {ν : Measure M} [SFinite ν]
@@ -63,13 +64,13 @@ theorem mconv_dirac_one [MeasurableMul₂ M]
 
 /-- Convolution of the zero measure with a measure μ returns the zero measure. -/
 @[to_additive (attr := simp) zero_conv]
-theorem mconv_zero (μ : Measure M) : (0 : Measure M) ∗ μ = (0 : Measure M) := by
+theorem zero_mconv (μ : Measure M) : (0 : Measure M) ∗ μ = (0 : Measure M) := by
   unfold mconv
   simp
 
 /-- Convolution of a measure μ with the zero measure returns the zero measure. -/
 @[to_additive (attr := simp) conv_zero]
-theorem zero_mconv (μ : Measure M) : μ ∗ (0 : Measure M) = (0 : Measure M) := by
+theorem mconv_zero (μ : Measure M) : μ ∗ (0 : Measure M) = (0 : Measure M) := by
   unfold mconv
   simp
 

--- a/Mathlib/MeasureTheory/Group/Convolution.lean
+++ b/Mathlib/MeasureTheory/Group/Convolution.lean
@@ -39,7 +39,7 @@ scoped[MeasureTheory] infixl:80 " ∗ " => MeasureTheory.Measure.conv
 
 @[to_additive lintegral_conv]
 theorem lintegral_mconv [MeasurableMul₂ M] {μ ν : Measure M} [SFinite ν]
-    {f : M → ℝ≥0∞} (hf : Measurable f):
+    {f : M → ℝ≥0∞} (hf : Measurable f) :
     ∫⁻ z, f z ∂(μ ∗ ν) = ∫⁻ x, ∫⁻ y, f (x * y) ∂ν ∂μ := by
   rw[mconv, lintegral_map hf measurable_mul, lintegral_prod]
   fun_prop

--- a/Mathlib/MeasureTheory/Integral/Lebesgue.lean
+++ b/Mathlib/MeasureTheory/Integral/Lebesgue.lean
@@ -800,6 +800,14 @@ theorem lintegral_indicator_one {s : Set α} (hs : MeasurableSet s) :
     ∫⁻ a, s.indicator 1 a ∂μ = μ s :=
   (lintegral_indicator_const hs _).trans <| one_mul _
 
+theorem measure_eq_measure_iff_lintegral_eq_lintegral (ν : Measure α) :
+    μ = ν ↔ ∀ f : α → ℝ≥0∞, Measurable f → ∫⁻ a, f a ∂μ = ∫⁻ a, f a ∂ν := by
+  refine ⟨fun h _ _ ↦ by rw[h], ?_⟩
+  intro h
+  ext s hs
+  simp[← lintegral_indicator_one hs, h]
+  exact h (s.indicator 1) (by apply (measurable_indicator_const_iff 1).mpr hs)
+
 /-- A version of **Markov's inequality** for two functions. It doesn't follow from the standard
 Markov's inequality because we only assume measurability of `g`, not `f`. -/
 theorem lintegral_add_mul_meas_add_le_le_lintegral {f g : α → ℝ≥0∞} (hle : f ≤ᵐ[μ] g)

--- a/Mathlib/MeasureTheory/Integral/Lebesgue.lean
+++ b/Mathlib/MeasureTheory/Integral/Lebesgue.lean
@@ -802,7 +802,7 @@ theorem lintegral_indicator_one {s : Set α} (hs : MeasurableSet s) :
 
 theorem Measure.ext_iff_lintegral (ν : Measure α) :
     μ = ν ↔ ∀ f : α → ℝ≥0∞, Measurable f → ∫⁻ a, f a ∂μ = ∫⁻ a, f a ∂ν := by
-  refine ⟨fun h _ _ ↦ by rw[h], ?_⟩
+  refine ⟨fun h _ _ ↦ by rw [h], ?_⟩
   intro h
   ext s hs
   simp only [← lintegral_indicator_one hs]

--- a/Mathlib/MeasureTheory/Integral/Lebesgue.lean
+++ b/Mathlib/MeasureTheory/Integral/Lebesgue.lean
@@ -800,13 +800,17 @@ theorem lintegral_indicator_one {s : Set α} (hs : MeasurableSet s) :
     ∫⁻ a, s.indicator 1 a ∂μ = μ s :=
   (lintegral_indicator_const hs _).trans <| one_mul _
 
-theorem measure_eq_measure_iff_lintegral_eq_lintegral (ν : Measure α) :
+theorem Measure.ext_iff_lintegral (ν : Measure α) :
     μ = ν ↔ ∀ f : α → ℝ≥0∞, Measurable f → ∫⁻ a, f a ∂μ = ∫⁻ a, f a ∂ν := by
   refine ⟨fun h _ _ ↦ by rw[h], ?_⟩
   intro h
   ext s hs
-  simp[← lintegral_indicator_one hs, h]
+  simp only [← lintegral_indicator_one hs]
   exact h (s.indicator 1) (by apply (measurable_indicator_const_iff 1).mpr hs)
+
+theorem Measure.ext_of_lintegral (ν : Measure α)
+    (hμν : ∀ f : α → ℝ≥0∞, Measurable f → ∫⁻ a, f a ∂μ = ∫⁻ a, f a ∂ν) : μ = ν :=
+  (μ.ext_iff_lintegral ν).mpr hμν
 
 /-- A version of **Markov's inequality** for two functions. It doesn't follow from the standard
 Markov's inequality because we only assume measurability of `g`, not `f`. -/

--- a/Mathlib/MeasureTheory/Integral/Lebesgue.lean
+++ b/Mathlib/MeasureTheory/Integral/Lebesgue.lean
@@ -806,7 +806,7 @@ theorem Measure.ext_iff_lintegral (ν : Measure α) :
   intro h
   ext s hs
   simp only [← lintegral_indicator_one hs]
-  exact h (s.indicator 1) (by apply (measurable_indicator_const_iff 1).mpr hs)
+  exact h (s.indicator 1) ((measurable_indicator_const_iff 1).mpr hs)
 
 theorem Measure.ext_of_lintegral (ν : Measure α)
     (hμν : ∀ f : α → ℝ≥0∞, Measurable f → ∫⁻ a, f a ∂μ = ∫⁻ a, f a ∂ν) : μ = ν :=


### PR DESCRIPTION
The main theorem of this PR is "mconv_assoc" which shows that the convolution of measures is associative (under the right assumptions). 

To prove this we add a theorem "Measure.ext_iff" which allows one to show that two measures are equal by showing their lintegrals are equal on all measurable functions. Obviously when one wants to show two measures are equal one could always start with "ext" to introduce a measurable set and then convert to integrals over indicator functions, however I think this theorem provides a good quality of life improvement for proofs that use this structure (and don't use properties of indicators). 

In light of "mconv_assoc" making the operator left associative seems reasonable (even though it requires a few minor assumptions). Thus I have change "infix" -> "infixl" 

We also add a theorem "lintegral_mconv" which shows how to compute the lintegral of a function w.r.t a convolution of measures (in analogy with "lintegral_prod") 

Finally, unless I am missing something I think the names of the theorems "zero_mconv" and "mconv_zero" should be 
swapped to follow usually convention.

