### PR TITLE
[Merged by Bors] - feat(CategoryTheory): stability properties of morphisms properties in functor categories

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2267,6 +2267,7 @@ import Mathlib.CategoryTheory.MorphismProperty.Comma
 import Mathlib.CategoryTheory.MorphismProperty.Composition
 import Mathlib.CategoryTheory.MorphismProperty.Concrete
 import Mathlib.CategoryTheory.MorphismProperty.Factorization
+import Mathlib.CategoryTheory.MorphismProperty.FunctorCategory
 import Mathlib.CategoryTheory.MorphismProperty.IsInvertedBy
 import Mathlib.CategoryTheory.MorphismProperty.IsSmall
 import Mathlib.CategoryTheory.MorphismProperty.LiftingProperty

--- a/Mathlib/CategoryTheory/MorphismProperty/FunctorCategory.lean
+++ b/Mathlib/CategoryTheory/MorphismProperty/FunctorCategory.lean
@@ -1,0 +1,119 @@
+/-
+Copyright (c) 2025 Joël Riou. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joël Riou
+-/
+import Mathlib.CategoryTheory.Limits.FunctorCategory.EpiMono
+import Mathlib.CategoryTheory.MorphismProperty.Retract
+import Mathlib.CategoryTheory.MorphismProperty.Limits
+import Mathlib.CategoryTheory.MorphismProperty.TransfiniteComposition
+
+/-!
+# Stability properties of morphism properties on functor categories
+
+Given `W : MorphismProperty C` and a category `J`, we study the
+stability properties of `W.functorCategory J : MorphismProperty (J ⥤ C)`.
+
+Under suitable assumptions, we also show that if monomorphisms
+in `C` are stable under transfinite compositions, then the same
+holds in the category `J ⥤ C`.
+
+-/
+
+universe v v' v'' u u' u''
+
+namespace CategoryTheory
+
+open Limits
+
+namespace MorphismProperty
+
+variable {C : Type u} [Category.{v} C] (W : MorphismProperty C)
+
+instance [W.IsStableUnderRetracts] (J : Type u'') [Category.{v''} J] :
+    (W.functorCategory J).IsStableUnderRetracts where
+  of_retract hfg hg j :=
+    W.of_retract (hfg.map ((evaluation _ _).obj j).mapArrow) (hg j)
+
+variable {W}
+
+lemma IsStableUnderLimitsOfShape.functorCategory
+    {K : Type u'} [Category.{v'} K]
+    (hW : W.IsStableUnderLimitsOfShape K)
+    (J : Type u'') [Category.{v''} J]
+    [HasLimitsOfShape K C] :
+    (W.functorCategory J).IsStableUnderLimitsOfShape K := by
+  intro X₁ X₂ c₁ c₂ hc₁ hc₂ f hf j
+  convert hW (X₁ ⋙ (evaluation _ _ ).obj j) (X₂ ⋙ (evaluation _ _ ).obj j)
+    _ _ (isLimitOfPreserves _ hc₁) (isLimitOfPreserves _ hc₂) (whiskerRight f _)
+    (fun k ↦ hf k j)
+  apply (isLimitOfPreserves ((evaluation J C).obj j) hc₂).hom_ext
+  intro k
+  rw [IsLimit.fac]
+  dsimp
+  rw [← NatTrans.comp_app, IsLimit.fac]
+  dsimp
+
+lemma IsStableUnderColimitsOfShape.functorCategory
+    {K : Type u'} [Category.{v'} K]
+    (hW : W.IsStableUnderColimitsOfShape K)
+    (J : Type u'') [Category.{v''} J]
+    [HasColimitsOfShape K C] :
+    (W.functorCategory J).IsStableUnderColimitsOfShape K := by
+  intro X₁ X₂ c₁ c₂ hc₁ hc₂ f hf j
+  convert hW (X₁ ⋙ (evaluation _ _ ).obj j) (X₂ ⋙ (evaluation _ _ ).obj j)
+    _ _ (isColimitOfPreserves _ hc₁) (isColimitOfPreserves _ hc₂) (whiskerRight f _)
+    (fun k ↦ hf k j)
+  apply (isColimitOfPreserves ((evaluation J C).obj j) hc₁).hom_ext
+  intro k
+  rw [IsColimit.fac]
+  dsimp
+  rw [← NatTrans.comp_app, IsColimit.fac]
+  dsimp
+
+instance [W.IsStableUnderBaseChange] (J : Type u'') [Category.{v''} J] [HasPullbacks C] :
+    (W.functorCategory J).IsStableUnderBaseChange where
+  of_isPullback sq hr j :=
+    W.of_isPullback (sq.map ((evaluation _ _).obj j)) (hr j)
+
+instance [W.IsStableUnderCobaseChange] (J : Type u'') [Category.{v''} J] [HasPushouts C] :
+    (W.functorCategory J).IsStableUnderCobaseChange where
+  of_isPushout sq hr j :=
+    W.of_isPushout (sq.map ((evaluation _ _).obj j)) (hr j)
+
+instance (K : Type u') [LinearOrder K] [SuccOrder K] [OrderBot K] [WellFoundedLT K]
+    [W.IsStableUnderTransfiniteCompositionOfShape K] (J : Type u'') [Category.{v''} J]
+    [HasIterationOfShape K C] :
+    (W.functorCategory J).IsStableUnderTransfiniteCompositionOfShape K where
+  le := by
+    rintro X Y f ⟨hf⟩ j
+    have : W.functorCategory J ≤ W.inverseImage ((evaluation _ _).obj j) := fun _ _ _ h ↦ h _
+    exact W.transfiniteCompositionsOfShape_le K _ ⟨(hf.ofLE this).map⟩
+
+variable (J : Type u'') [Category.{v''} J]
+
+lemma functorCategory_isomorphisms :
+    (isomorphisms C).functorCategory J = isomorphisms (J ⥤ C) := by
+  ext _ _ f
+  simp only [functorCategory, isomorphisms.iff, NatTrans.isIso_iff_isIso_app]
+
+lemma functorCategory_monomorphisms [HasPullbacks C] :
+    (monomorphisms C).functorCategory J = monomorphisms (J ⥤ C) := by
+  ext _ _ f
+  simp only [functorCategory, monomorphisms.iff, NatTrans.mono_iff_mono_app]
+
+lemma functorCategory_epimorphisms [HasPushouts C] :
+    (epimorphisms C).functorCategory J = epimorphisms (J ⥤ C) := by
+  ext _ _ f
+  simp only [functorCategory, epimorphisms.iff, NatTrans.epi_iff_epi_app]
+
+instance (K : Type u') [LinearOrder K] [SuccOrder K] [OrderBot K] [WellFoundedLT K]
+    [(monomorphisms C).IsStableUnderTransfiniteCompositionOfShape K]
+    [HasPullbacks C] (J : Type u'') [Category.{v''} J] [HasIterationOfShape K C] :
+    (monomorphisms (J ⥤ C)).IsStableUnderTransfiniteCompositionOfShape K := by
+  rw [← functorCategory_monomorphisms]
+  infer_instance
+
+end MorphismProperty
+
+end CategoryTheory


### PR DESCRIPTION
Given `W : MorphismProperty C` and a category `J`, we study the stability properties of `W.functorCategory J : MorphismProperty (J ⥤ C)`.

Under suitable assumptions, we also show that if monomorphisms in `C` are stable under transfinite compositions, then the same holds in the category `J ⥤ C`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
