### PR TITLE
[Merged by Bors] - chore(Topology/LocallyConstant): Add `eval` as locally constant function

### DIFF
--- a/Mathlib/Topology/LocallyConstant/Basic.lean
+++ b/Mathlib/Topology/LocallyConstant/Basic.lean
@@ -277,6 +277,7 @@ def const (X : Type*) {Y : Type*} [TopologicalSpace X] (y : Y) : LocallyConstant
 theorem coe_const (y : Y) : (const X y : X → Y) = Function.const X y :=
   rfl
 
+/-- Evaluation/projection as a locally constant function. -/
 @[simps]
 def eval {ι : Type*} {X : ι → Type*}
     [∀ i, TopologicalSpace (X i)] [∀ i, DiscreteTopology (X i)] (i : ι) :

--- a/Mathlib/Topology/LocallyConstant/Basic.lean
+++ b/Mathlib/Topology/LocallyConstant/Basic.lean
@@ -280,7 +280,7 @@ theorem coe_const (y : Y) : (const X y : X → Y) = Function.const X y :=
 /-- Evaluation/projection as a locally constant function. -/
 @[simps]
 def eval {ι : Type*} {X : ι → Type*}
-    [∀ i, TopologicalSpace (X i)] [∀ i, DiscreteTopology (X i)] (i : ι) :
+    [∀ i, TopologicalSpace (X i)] (i : ι) [DiscreteTopology (X i)] :
     LocallyConstant (Π i, X i) (X i) where
   toFun := fun f ↦ f i
   isLocallyConstant := (IsLocallyConstant.iff_continuous _).mpr <| continuous_apply i

--- a/Mathlib/Topology/LocallyConstant/Basic.lean
+++ b/Mathlib/Topology/LocallyConstant/Basic.lean
@@ -277,6 +277,13 @@ def const (X : Type*) {Y : Type*} [TopologicalSpace X] (y : Y) : LocallyConstant
 theorem coe_const (y : Y) : (const X y : X → Y) = Function.const X y :=
   rfl
 
+@[simps]
+def eval {ι : Type*} {X : ι → Type*}
+    [∀ i, TopologicalSpace (X i)] [∀ i, DiscreteTopology (X i)] (i : ι) :
+    LocallyConstant (Π i, X i) (X i) where
+  toFun := fun f ↦ f i
+  isLocallyConstant := (IsLocallyConstant.iff_continuous _).mpr <| continuous_apply i
+
 /-- The locally constant function to `Fin 2` associated to a clopen set. -/
 def ofIsClopen {X : Type*} [TopologicalSpace X] {U : Set X} [∀ x, Decidable (x ∈ U)]
     (hU : IsClopen U) : LocallyConstant X (Fin 2) where


### PR DESCRIPTION
Part of an attempt to factor some reusable bits out of
`Mathlib/Topology/Category/Profinite/Nobeling.lean`


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
