### PR TITLE
[Merged by Bors] - chore(Algebra/BigOperators/Finsupp): add Finsupp.sum_apply''

### DIFF
--- a/Mathlib/Algebra/BigOperators/Finsupp/Basic.lean
+++ b/Mathlib/Algebra/BigOperators/Finsupp/Basic.lean
@@ -543,9 +543,14 @@ theorem Finset.sum_apply' : (∑ k ∈ s, f k) i = ∑ k ∈ s, f k i :=
 theorem Finsupp.sum_apply' : g.sum k x = g.sum fun i b => k i b x :=
   Finset.sum_apply _ _ _
 
+/-- Version of `Finsupp.apply'` that applies in large generality to linear combinations
+of functions in any `FunLike` type on which addition is defined pointwise.
+
+At the time of writing Mathlib does not have a typeclass to express the condition
+that addition on a `FunLike` type is pointwise; hence this is asserted via explicit hypotheses. -/
 theorem Finsupp.sum_apply'' {A F : Type*} [AddZeroClass A] [AddCommMonoid F] [FunLike F γ B]
     (g : ι →₀ A) (k : ι → A → F) (x : γ)
-    (hg0 : ∀ (a : ι), k a 0 = 0) (hgadd : ∀ (a : ι) (b₁ b₂ : A), k a (b₁ + b₂) = k a b₁ + k a b₂)
+    (hg0 : ∀ (i : ι), k i 0 = 0) (hgadd : ∀ (i : ι) (a₁ a₂ : A), k i (a₁ + a₂) = k i a₁ + k i a₂)
     (h0 : (0 : F) x = 0) (hadd : ∀ (f g : F), (f + g : F) x = f x + g x) :
     g.sum k x = g.sum (fun i a ↦ k i a x) := by
   induction g using Finsupp.induction with

--- a/Mathlib/Algebra/BigOperators/Finsupp/Basic.lean
+++ b/Mathlib/Algebra/BigOperators/Finsupp/Basic.lean
@@ -543,6 +543,21 @@ theorem Finset.sum_apply' : (∑ k ∈ s, f k) i = ∑ k ∈ s, f k i :=
 theorem Finsupp.sum_apply' : g.sum k x = g.sum fun i b => k i b x :=
   Finset.sum_apply _ _ _
 
+theorem Finsupp.sum_apply'' {A F : Type*} [AddZeroClass A] [AddCommMonoid F] [FunLike F γ B]
+    (g : ι →₀ A) (k : ι → A → F) (x : γ)
+    (hg0 : ∀ (a : ι), k a 0 = 0) (hgadd : ∀ (a : ι) (b₁ b₂ : A), k a (b₁ + b₂) = k a b₁ + k a b₂)
+    (h0 : (0 : F) x = 0) (hadd : ∀ (f g : F), (f + g : F) x = f x + g x) :
+    g.sum k x = g.sum (fun i a ↦ k i a x) := by
+  induction g using Finsupp.induction with
+  | h0 => simp [h0]
+  | ha i a f hf ha ih =>
+    rw [Finsupp.sum_add_index' hg0 hgadd, Finsupp.sum_add_index', hadd, ih]
+    · congr 1
+      rw [Finsupp.sum_single_index (hg0 i), Finsupp.sum_single_index]
+      simp [hg0, h0]
+    · simp [hg0, h0]
+    · simp [hgadd, hadd]
+
 theorem Finsupp.sum_sum_index' (h0 : ∀ i, t i 0 = 0) (h1 : ∀ i x y, t i (x + y) = t i x + t i y) :
     (∑ x ∈ s, f x).sum t = ∑ x ∈ s, (f x).sum t := by
   classical


### PR DESCRIPTION
Part of an attempt to factor some reusable bits out of
`Mathlib/Topology/Category/Profinite/Nobeling.lean`

This lemma applies in situations where `Finsupp.sum_apply'` does not,
because coercions are getting in the way.

We currently don't have a typeclass to express
"addition on this FunLike is pointwise"
so I have expressed that with explicit arguments.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
