### PR TITLE
[Merged by Bors] - feat(Analysis/ODE/Gronwall): add global uniqueness of ODE solutions

### DIFF
--- a/Mathlib/Analysis/ODE/Gronwall.lean
+++ b/Mathlib/Analysis/ODE/Gronwall.lean
@@ -374,9 +374,9 @@ theorem ODE_solution_unique_univ
     use (min (-|t|) (-|t₀|) - 1), (max |t| |t₀| + 1)
     rw [Set.mem_Ioo, Set.mem_Ioo]
     refine ⟨⟨?_, ?_⟩, ?_, ?_⟩
-    · apply lt_of_lt_of_le (sub_one_lt _) (le_trans (min_le_left _ _) (neg_abs_le t))
-    · apply lt_of_le_of_lt (le_trans (le_abs_self _) (le_max_left _ _)) (lt_add_one _)
-    · apply lt_of_lt_of_le (sub_one_lt _) (le_trans (min_le_right _ _) (neg_abs_le t₀))
-    · apply lt_of_le_of_lt (le_trans (le_abs_self _) (le_max_right _ _)) (lt_add_one _)
-  apply ODE_solution_unique_of_mem_Ioo (fun t _ => hv t) Ht₀ (fun t _ => hf t)
-    (fun t _ => hg t) heq Ht
+    · exact sub_one_lt _ |>.trans_le <| min_le_left _ _ |>.trans <| neg_abs_le t
+    · exact le_abs_self _ |>.trans_lt <| le_max_left _ _ |>.trans_lt <| lt_add_one _
+    · exact sub_one_lt _ |>.trans_le <| min_le_right _ _ |>.trans <| neg_abs_le t₀
+    · exact le_abs_self _ |>.trans_lt <| le_max_right _ _ |>.trans_lt <| lt_add_one _
+  exact ODE_solution_unique_of_mem_Ioo
+    (fun t _ => hv t) Ht₀ (fun t _ => hf t) (fun t _ => hg t) heq Ht

--- a/Mathlib/Analysis/ODE/Gronwall.lean
+++ b/Mathlib/Analysis/ODE/Gronwall.lean
@@ -361,3 +361,22 @@ theorem ODE_solution_unique
   have hfs : ∀ t ∈ Ico a b, f t ∈ @univ E := fun _ _ => trivial
   ODE_solution_unique_of_mem_Icc_right (fun t _ => (hv t).lipschitzOnWith) hf hf' hfs hg hg'
     (fun _ _ => trivial) ha
+
+/-- There exists only one global solution to an ODE \(\dot x=v(t, x\) with a given initial value
+provided that the RHS is Lipschitz continuous. -/
+theorem ODE_solution_unique_univ
+    (hv : ∀ t, LipschitzOnWith K (v t) (s t))
+    (hf : ∀ t, HasDerivAt f (v t (f t)) t ∧ f t ∈ s t)
+    (hg : ∀ t, HasDerivAt g (v t (g t)) t ∧ g t ∈ s t)
+    (heq : f t₀ = g t₀) : f = g := by
+  ext t
+  obtain ⟨A, B, Ht, Ht₀⟩ : ∃ A B, t ∈ Set.Ioo A B ∧ t₀ ∈ Set.Ioo A B := by
+    use (min (-|t|) (-|t₀|) - 1), (max |t| |t₀| + 1)
+    rw [Set.mem_Ioo, Set.mem_Ioo]
+    refine ⟨⟨?_, ?_⟩, ?_, ?_⟩
+    · apply lt_of_lt_of_le (sub_one_lt _) (le_trans (min_le_left _ _) (neg_abs_le t))
+    · apply lt_of_le_of_lt (le_trans (le_abs_self _) (le_max_left _ _)) (lt_add_one _)
+    · apply lt_of_lt_of_le (sub_one_lt _) (le_trans (min_le_right _ _) (neg_abs_le t₀))
+    · apply lt_of_le_of_lt (le_trans (le_abs_self _) (le_max_right _ _)) (lt_add_one _)
+  apply ODE_solution_unique_of_mem_Ioo (fun t _ => hv t) Ht₀ (fun t _ => hf t)
+    (fun t _ => hg t) heq Ht


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
