### PR TITLE
[Merged by Bors] - feat(Data/Nat/Cast/Basic): add `OfNat` instance for pi types

### DIFF
--- a/Mathlib/Algebra/Notation/Pi.lean
+++ b/Mathlib/Algebra/Notation/Pi.lean
@@ -35,7 +35,7 @@ namespace Pi
 instance instOne [∀ i, One <| f i] : One (∀ i : I, f i) :=
   ⟨fun _ => 1⟩
 
-@[to_additive (attr := simp high]
+@[to_additive (attr := simp high)]
 theorem one_apply [∀ i, One <| f i] : (1 : ∀ i, f i) i = 1 :=
   rfl
 

--- a/Mathlib/Algebra/Notation/Pi.lean
+++ b/Mathlib/Algebra/Notation/Pi.lean
@@ -35,7 +35,7 @@ namespace Pi
 instance instOne [∀ i, One <| f i] : One (∀ i : I, f i) :=
   ⟨fun _ => 1⟩
 
-@[to_additive]
+@[to_additive (attr := simp high]
 theorem one_apply [∀ i, One <| f i] : (1 : ∀ i, f i) i = 1 :=
   rfl
 

--- a/Mathlib/Algebra/Notation/Pi.lean
+++ b/Mathlib/Algebra/Notation/Pi.lean
@@ -35,7 +35,7 @@ namespace Pi
 instance instOne [∀ i, One <| f i] : One (∀ i : I, f i) :=
   ⟨fun _ => 1⟩
 
-@[to_additive (attr := simp)]
+@[to_additive]
 theorem one_apply [∀ i, One <| f i] : (1 : ∀ i, f i) i = 1 :=
   rfl
 

--- a/Mathlib/Algebra/Notation/Pi.lean
+++ b/Mathlib/Algebra/Notation/Pi.lean
@@ -133,7 +133,4 @@ theorem div_comp [Div γ] (x y : β → γ) (z : α → β) : (x / y) ∘ z = x 
 @[to_additive (attr := simp)]
 lemma _root_.Function.const_div [Div β] (a b : β) : const α a / const α b = const α (a / b) := rfl
 
-instance instofNat (n : ℕ) [∀ i, OfNat (f i) n] : OfNat ((i : I) → f i) n where
-  ofNat := fun _ ↦ OfNat.ofNat n
-
 end Pi

--- a/Mathlib/Algebra/Notation/Pi.lean
+++ b/Mathlib/Algebra/Notation/Pi.lean
@@ -133,4 +133,7 @@ theorem div_comp [Div γ] (x y : β → γ) (z : α → β) : (x / y) ∘ z = x 
 @[to_additive (attr := simp)]
 lemma _root_.Function.const_div [Div β] (a b : β) : const α a / const α b = const α (a / b) := rfl
 
+instance instofNat (n : ℕ) [∀ i, OfNat (f i) n] : OfNat ((i : I) → f i) n where
+  ofNat := fun _ ↦ OfNat.ofNat n
+
 end Pi

--- a/Mathlib/Data/Nat/Cast/Basic.lean
+++ b/Mathlib/Data/Nat/Cast/Basic.lean
@@ -179,12 +179,12 @@ instance Nat.uniqueRingHom {R : Type*} [NonAssocSemiring R] : Unique (ℕ →+* 
 
 namespace Pi
 
-variable {π : α → Type*} [∀ a, NatCast (π a)]
+variable {π : α → Type*}
+
+section NatCast
+variable [∀ a, NatCast (π a)]
 
 instance instNatCast : NatCast (∀ a, π a) where natCast n _ := n
-
-instance instOfNat (n : ℕ) [∀ i, OfNat (π i) n] : OfNat ((i : α) → π i) n where
-  ofNat _ := OfNat.ofNat n
 
 theorem natCast_apply (n : ℕ) (a : α) : (n : ∀ a, π a) a = n :=
   rfl
@@ -193,10 +193,21 @@ theorem natCast_apply (n : ℕ) (a : α) : (n : ∀ a, π a) a = n :=
 theorem natCast_def (n : ℕ) : (n : ∀ a, π a) = fun _ ↦ ↑n :=
   rfl
 
-@[simp]
-theorem ofNat_apply (n : ℕ) [n.AtLeastTwo] (a : α) : (OfNat.ofNat n : ∀ a, π a) a = n := rfl
+end NatCast
 
-lemma ofNat_def (n : ℕ) [n.AtLeastTwo] : (OfNat.ofNat n : ∀ a, π a) = fun _ ↦ OfNat.ofNat n := rfl
+section OfNat
+
+-- This instance is low priority, as `to_additive` only works with the one that comes from `One`
+-- and `Zero`.
+instance (priority := low) instOfNat (n : ℕ) [∀ i, OfNat (π i) n] : OfNat ((i : α) → π i) n where
+  ofNat _ := OfNat.ofNat n
+
+@[simp]
+theorem ofNat_apply (n : ℕ) [∀ i, OfNat (π i) n] (a : α) : (ofNat(n) : ∀ a, π a) a = ofNat(n) := rfl
+
+lemma ofNat_def (n : ℕ) [∀ i, OfNat (π i) n] : (ofNat(n) : ∀ a, π a) = fun _ ↦ ofNat(n) := rfl
+
+end OfNat
 
 end Pi
 

--- a/Mathlib/Data/Nat/Cast/Basic.lean
+++ b/Mathlib/Data/Nat/Cast/Basic.lean
@@ -183,6 +183,9 @@ variable {π : α → Type*} [∀ a, NatCast (π a)]
 
 instance instNatCast : NatCast (∀ a, π a) where natCast n _ := n
 
+instance instOfNat (n : ℕ) [∀ i, OfNat (π i) n] : OfNat ((i : α) → π i) n where
+  ofNat _ := OfNat.ofNat n
+
 theorem natCast_apply (n : ℕ) (a : α) : (n : ∀ a, π a) a = n :=
   rfl
 

--- a/Mathlib/Probability/Variance.lean
+++ b/Mathlib/Probability/Variance.lean
@@ -330,7 +330,7 @@ theorem IndepFun.variance_sum [IsProbabilityMeasure μ] {ι : Type*} {X : ι →
         variance_def' (memLp_finset_sum' _ fun i hi => hs _ (mem_insert_of_mem hi))]
       ring
     _ = variance (X k) μ + variance (∑ i ∈ s, X i) μ := by
-      simp_rw [Pi.mul_apply, Pi.ofNat_apply, Nat.cast_ofNat, sum_apply, mul_sum, mul_assoc,
+      simp_rw [Pi.mul_apply, Pi.ofNat_apply, sum_apply, mul_sum, mul_assoc,
         add_eq_left]
       rw [integral_finset_sum s fun i hi => ?_]; swap
       · apply Integrable.const_mul _ (2 : ℝ)


### PR DESCRIPTION
The initial motivation for doing this comes from #23310.

This also fixed a missing `ofNat()` in `Pi.ofNat_apply`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
