### PR TITLE
[Merged by Bors] - chore(RingTheory): clean up a few `erw`s

### DIFF
--- a/Mathlib/RingTheory/Derivation/MapCoeffs.lean
+++ b/Mathlib/RingTheory/Derivation/MapCoeffs.lean
@@ -46,11 +46,16 @@ def mapCoeffs : Derivation R A[X] (PolynomialModule A M) where
         dsimp [PolynomialModule.equivPolynomial, PolynomialModule.map]
         simp only [toFinsupp_mul, toFinsupp_monomial, AddMonoidAlgebra.single_mul_single]
         show d _ = _ + _
-        erw [Finsupp.mapRange.linearMap_apply, Finsupp.mapRange.linearMap_apply]
+        -- TODO: copy more `Finsupp` API to `PolynomialModule`.
+        -- We have to do a bit of work to go through the identification
+        -- `PolynomialModule A M = ℕ →₀ M`...
+        dsimp only [PolynomialModule, Finsupp.mapRange.linearMap_apply, coeFn_coe]
         rw [Finsupp.mapRange_single, Finsupp.mapRange_single]
-        erw [PolynomialModule.monomial_smul_single, PolynomialModule.monomial_smul_single]
-        simp only [AddMonoidAlgebra.single_apply, apply_ite d, leibniz, map_zero, coeFn_coe,
-          PolynomialModule.single_apply, ite_add_zero, add_comm m n]
+        -- ... and here we go back through the identification.
+        show _ = (_ • PolynomialModule.single A _ _) _ + (_ • PolynomialModule.single A _ _) i
+        simp only [PolynomialModule.monomial_smul_single, AddMonoidAlgebra.single_apply,
+          apply_ite d, leibniz, map_zero, coeFn_coe, PolynomialModule.single_apply, ite_add_zero,
+          add_comm m n]
 
 @[simp]
 lemma mapCoeffs_apply (p : A[X]) (i) :

--- a/Mathlib/RingTheory/Etale/Kaehler.lean
+++ b/Mathlib/RingTheory/Etale/Kaehler.lean
@@ -215,9 +215,7 @@ def tensorCotangent [alg : Algebra P.Ring Q.Ring] (halg : algebraMap P.Ring Q.Ri
       | add x y _ _ => simp only [map_add, *]
       | tmul a b =>
         simp only [LinearMap.liftBaseChange_tmul, map_smul]
-        erw [tensorCotangentInvFun_smul_mk]
-        simp
-        rfl }
+        simp [Hom.mapKer, tensorCotangentInvFun_smul_mk] }
 
 set_option synthInstance.maxHeartbeats 100000 in
 /-- If `J ≃ Q ⊗ₚ I`, `S → T` is flat and `P → Q` is formally etale, then `T ⊗ H¹(L_P) ≃ H¹(L_Q)`. -/

--- a/Mathlib/RingTheory/Finiteness/Basic.lean
+++ b/Mathlib/RingTheory/Finiteness/Basic.lean
@@ -303,7 +303,7 @@ theorem trans {R : Type*} (A M : Type*) [Semiring R] [Semiring A] [Module R A]
     ⟨Submodule.fg_def.2
         ⟨Set.image2 (· • ·) (↑s : Set A) (↑t : Set M),
           Set.Finite.image2 _ s.finite_toSet t.finite_toSet, by
-          erw [Set.image2_smul, Submodule.span_smul_of_span_eq_top hs (↑t : Set M), ht,
+          rw [Set.image2_smul, Submodule.span_smul_of_span_eq_top hs (↑t : Set M), ht,
             Submodule.restrictScalars_top]⟩⟩
 
 lemma of_equiv_equiv {A₁ B₁ A₂ B₂ : Type*} [CommRing A₁] [CommRing B₁]

--- a/Mathlib/RingTheory/Kaehler/Basic.lean
+++ b/Mathlib/RingTheory/Kaehler/Basic.lean
@@ -204,9 +204,9 @@ def KaehlerDifferential.D : Derivation R S (Ω[S⁄R]) :=
     leibniz' := fun a b => by
       have : LinearMap.CompatibleSMul { x // x ∈ ideal R S } (Ω[S⁄R]) S (S ⊗[R] S) := inferInstance
       dsimp [KaehlerDifferential.DLinearMap_apply]
-      -- This used to be `rw`, but we need `erw` after https://github.com/leanprover/lean4/pull/2644
-      erw [← LinearMap.map_smul_of_tower (M₂ := Ω[S⁄R]),
-        ← LinearMap.map_smul_of_tower (M₂ := Ω[S⁄R]), ← map_add, Ideal.toCotangent_eq, pow_two]
+      rw [← LinearMap.map_smul_of_tower (ideal R S).toCotangent,
+        ← LinearMap.map_smul_of_tower (ideal R S).toCotangent,
+        ← map_add (ideal R S).toCotangent, Ideal.toCotangent_eq, pow_two]
       convert Submodule.mul_mem_mul (KaehlerDifferential.one_smul_sub_smul_one_mem_ideal R a :)
         (KaehlerDifferential.one_smul_sub_smul_one_mem_ideal R b :) using 1
       simp only [AddSubgroupClass.coe_sub, Submodule.coe_add, Submodule.coe_mk,

--- a/Mathlib/RingTheory/Norm/Basic.lean
+++ b/Mathlib/RingTheory/Norm/Basic.lean
@@ -135,12 +135,12 @@ theorem norm_eq_norm_adjoin [FiniteDimensional K L] [Algebra.IsSeparable K L] (x
   letI := Algebra.isSeparable_tower_top_of_isSeparable K K⟮x⟯ L
   let pbL := Field.powerBasisOfFiniteOfSeparable K⟮x⟯ L
   let pbx := IntermediateField.adjoin.powerBasis (Algebra.IsSeparable.isIntegral K x)
-  -- This used to be `rw`, but we need `erw` after https://github.com/leanprover/lean4/pull/2644
-  erw [← AdjoinSimple.algebraMap_gen K x, norm_eq_matrix_det (pbx.basis.smulTower pbL.basis) _,
-    smulTower_leftMulMatrix_algebraMap, det_blockDiagonal, norm_eq_matrix_det pbx.basis]
+  rw [← AdjoinSimple.algebraMap_gen K x, norm_eq_matrix_det (pbx.basis.smulTower pbL.basis) _,
+    smulTower_leftMulMatrix_algebraMap, det_blockDiagonal, AdjoinSimple.algebraMap_gen,
+    norm_eq_matrix_det pbx.basis]
   simp only [Finset.card_fin, Finset.prod_const]
   congr
-  rw [← PowerBasis.finrank, AdjoinSimple.algebraMap_gen K x]
+  rw [← PowerBasis.finrank]
 
 section IntermediateField
 

--- a/Mathlib/RingTheory/RingHom/Finite.lean
+++ b/Mathlib/RingTheory/RingHom/Finite.lean
@@ -128,6 +128,7 @@ theorem IsLocalization.smul_mem_finsetIntegerMultiple_span [Algebra R S] [Algebr
         (IsLocalization.finsetIntegerMultiple (M.map (algebraMap R S)) s : Set S) := by
   let g : S →ₐ[R] S' :=
     AlgHom.mk' (algebraMap S S') fun c x => by simp [Algebra.algebraMap_eq_smul_one]
+  have g_apply : ∀ x, g x = algebraMap S S' x := fun _ => rfl
   -- We first obtain the `y' ∈ M` such that `s' = y' • s` is falls in the image of `S` in `S'`.
   let y := IsLocalization.commonDenomOfFinset (M.map (algebraMap R S)) s
   have hx₁ : (y : S) • (s : Set S') = g '' _ :=
@@ -139,8 +140,8 @@ theorem IsLocalization.smul_mem_finsetIntegerMultiple_span [Algebra R S] [Algebr
   replace hx₁ := congr_arg (Submodule.span R) hx₁
   rw [Submodule.span_smul] at hx₁
   replace hx : _ ∈ y' • Submodule.span R (s : Set S') := Set.smul_mem_smul_set hx
-  rw [hx₁] at hx
-  erw [← _root_.map_smul g, ← Submodule.map_span (g : S →ₗ[R] S')] at hx
+  rw [hx₁, ← g_apply, ← _root_.map_smul g, g_apply, ← Algebra.linearMap_apply, ← Submodule.map_span]
+    at hx
   -- Since `x` falls in the span of `s` in `S'`, `y' • x : S` falls in the span of `s'` in `S'`.
   -- That is, there exists some `x' : S` in the span of `s'` in `S` and `x' = y' • x` in `S'`.
   -- Thus `a • (y' • x) = a • x' ∈ span s'` in `S` for some `a ∈ M`.


### PR DESCRIPTION
These are mostly straightforward rewrites of proofs to add an explicit equality. One `erw` can become `rw` for free.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
