### PR TITLE
[Merged by Bors] - chore: rename TopologicalDivisionRing to IsTopologicalDivisionRing

### DIFF
--- a/Mathlib/Analysis/Normed/Field/Lemmas.lean
+++ b/Mathlib/Analysis/Normed/Field/Lemmas.lean
@@ -132,8 +132,11 @@ instance (priority := 100) NormedDivisionRing.to_hasContinuousInv₀ : HasContin
 
 -- see Note [lower instance priority]
 /-- A normed division ring is a topological division ring. -/
-instance (priority := 100) NormedDivisionRing.to_topologicalDivisionRing :
-    TopologicalDivisionRing α where
+instance (priority := 100) NormedDivisionRing.to_isTopologicalDivisionRing :
+    IsTopologicalDivisionRing α where
+
+@[deprecated (since := "2025-03-25")] alias NormedDivisionRing.to_topologicalDivisionRing :=
+  NormedDivisionRing.to_isTopologicalDivisionRing
 
 protected lemma IsOfFinOrder.norm_eq_one (ha : IsOfFinOrder a) : ‖a‖ = 1 :=
   ((normHom : α →*₀ ℝ).toMonoidHom.isOfFinOrder ha).eq_one <| norm_nonneg _

--- a/Mathlib/Analysis/SpecificLimits/Basic.lean
+++ b/Mathlib/Analysis/SpecificLimits/Basic.lean
@@ -76,7 +76,7 @@ algebra over `ℝ`, e.g., `ℂ`).
 TODO: introduce a typeclass saying that `1 / n` tends to 0 at top, making it possible to get this
 statement simultaneously on `ℚ`, `ℝ` and `ℂ`. -/
 theorem tendsto_natCast_div_add_atTop {𝕜 : Type*} [DivisionRing 𝕜] [TopologicalSpace 𝕜]
-    [CharZero 𝕜] [Algebra ℝ 𝕜] [ContinuousSMul ℝ 𝕜] [TopologicalDivisionRing 𝕜] (x : 𝕜) :
+    [CharZero 𝕜] [Algebra ℝ 𝕜] [ContinuousSMul ℝ 𝕜] [IsTopologicalDivisionRing 𝕜] (x : 𝕜) :
     Tendsto (fun n : ℕ ↦ (n : 𝕜) / (n + x)) atTop (𝓝 1) := by
   convert Tendsto.congr' ((eventually_ne_atTop 0).mp (Eventually.of_forall fun n hn ↦ _)) _
   · exact fun n : ℕ ↦ 1 / (1 + x / n)

--- a/Mathlib/Topology/Algebra/Field.lean
+++ b/Mathlib/Topology/Algebra/Field.lean
@@ -44,11 +44,11 @@ variable (K)
 
 /-- A topological division ring is a division ring with a topology where all operations are
     continuous, including inversion. -/
-class TopologicalDivisionRing : Prop extends IsTopologicalRing K, HasContinuousInv₀ K
+class IsTopologicalDivisionRing : Prop extends IsTopologicalRing K, HasContinuousInv₀ K
 
 section Subfield
 
-variable {α : Type*} [Field α] [TopologicalSpace α] [TopologicalDivisionRing α]
+variable {α : Type*} [Field α] [TopologicalSpace α] [IsTopologicalDivisionRing α]
 
 /-- The (topological-space) closure of a subfield of a topological field is
 itself a subfield. -/

--- a/Mathlib/Topology/Algebra/Field.lean
+++ b/Mathlib/Topology/Algebra/Field.lean
@@ -46,6 +46,8 @@ variable (K)
     continuous, including inversion. -/
 class IsTopologicalDivisionRing : Prop extends IsTopologicalRing K, HasContinuousInv₀ K
 
+@[deprecated (since := "2025-03-25")] alias TopologicalDivisionRing := IsTopologicalDivisionRing
+
 section Subfield
 
 variable {α : Type*} [Field α] [TopologicalSpace α] [IsTopologicalDivisionRing α]

--- a/Mathlib/Topology/Algebra/Order/Field.lean
+++ b/Mathlib/Topology/Algebra/Order/Field.lean
@@ -299,8 +299,8 @@ instance (priority := 100) LinearOrderedSemifield.toHasContinuousInv₀ {𝕜}
   · filter_upwards [Ioi_mem_nhds (inv_lt_one_of_one_lt₀ hx)] with y hy
     exact inv_lt_of_inv_lt₀ (by positivity) hy
 
-instance (priority := 100) LinearOrderedField.toTopologicalDivisionRing :
-    TopologicalDivisionRing 𝕜 := ⟨⟩
+instance (priority := 100) LinearOrderedField.toIsTopologicalDivisionRing :
+    IsTopologicalDivisionRing 𝕜 := ⟨⟩
 
 -- TODO: generalize to a `GroupWithZero`
 theorem comap_mulLeft_nhdsGT_zero {x : 𝕜} (hx : 0 < x) : comap (x * ·) (𝓝[>] 0) = 𝓝[>] 0 := by

--- a/Mathlib/Topology/Algebra/Order/Field.lean
+++ b/Mathlib/Topology/Algebra/Order/Field.lean
@@ -302,7 +302,8 @@ instance (priority := 100) LinearOrderedSemifield.toHasContinuousInv₀ {𝕜}
 instance (priority := 100) LinearOrderedField.toIsTopologicalDivisionRing :
     IsTopologicalDivisionRing 𝕜 := ⟨⟩
 
-@[deprecated (since := "2025-03-25")] alias LinearOrderedField.toTopologicalDivisionRing := LinearOrderedField.toIsTopologicalDivisionRing
+@[deprecated (since := "2025-03-25")] alias LinearOrderedField.toTopologicalDivisionRing :=
+  LinearOrderedField.toIsTopologicalDivisionRing
 
 -- TODO: generalize to a `GroupWithZero`
 theorem comap_mulLeft_nhdsGT_zero {x : 𝕜} (hx : 0 < x) : comap (x * ·) (𝓝[>] 0) = 𝓝[>] 0 := by

--- a/Mathlib/Topology/Algebra/Order/Field.lean
+++ b/Mathlib/Topology/Algebra/Order/Field.lean
@@ -302,6 +302,8 @@ instance (priority := 100) LinearOrderedSemifield.toHasContinuousInv₀ {𝕜}
 instance (priority := 100) LinearOrderedField.toIsTopologicalDivisionRing :
     IsTopologicalDivisionRing 𝕜 := ⟨⟩
 
+@[deprecated (since := "2025-03-25")] alias LinearOrderedField.toTopologicalDivisionRing := LinearOrderedField.toIsTopologicalDivisionRing
+
 -- TODO: generalize to a `GroupWithZero`
 theorem comap_mulLeft_nhdsGT_zero {x : 𝕜} (hx : 0 < x) : comap (x * ·) (𝓝[>] 0) = 𝓝[>] 0 := by
   rw [nhdsWithin, comap_inf, comap_principal, preimage_const_mul_Ioi _ hx, zero_div]

--- a/Mathlib/Topology/Algebra/Ring/Real.lean
+++ b/Mathlib/Topology/Algebra/Ring/Real.lean
@@ -54,7 +54,7 @@ theorem Real.uniformContinuous_const_mul {x : ℝ} : UniformContinuous (x * ·) 
 -- short-circuit type class inference
 instance : IsTopologicalAddGroup ℝ := by infer_instance
 instance : IsTopologicalRing ℝ := inferInstance
-instance : TopologicalDivisionRing ℝ := inferInstance
+instance : IsTopologicalDivisionRing ℝ := inferInstance
 
 namespace EReal
 

--- a/Mathlib/Topology/Algebra/UniformField.lean
+++ b/Mathlib/Topology/Algebra/UniformField.lean
@@ -28,7 +28,7 @@ which implies one is sent to zero and the completion ring is trivial.
 
 The main definition is `CompletableTopField` which packages the assumptions as a Prop-valued
 type class and the main results are the instances `UniformSpace.Completion.Field` and
-`UniformSpace.Completion.TopologicalDivisionRing`.
+`UniformSpace.Completion.IsTopologicalDivisionRing`.
 -/
 
 noncomputable section
@@ -97,7 +97,7 @@ Here we explicitly enforce the `inv_zero` axiom.
 instance instInvCompletion : Inv (hat K) :=
   ⟨fun x => if x = 0 then 0 else hatInv x⟩
 
-variable [TopologicalDivisionRing K]
+variable [IsTopologicalDivisionRing K]
 
 theorem hatInv_extends {x : K} (h : x ≠ 0) : hatInv (x : hat K) = ↑(x⁻¹ : K) :=
   isDenseInducing_coe.extend_eq_at ((continuous_coe K).continuousAt.comp (continuousAt_inv₀ h))
@@ -154,7 +154,7 @@ instance instField : Field (hat K) where
   qsmul := _
   qsmul_def := fun _ _ => rfl
 
-instance : TopologicalDivisionRing (hat K) :=
+instance : IsTopologicalDivisionRing (hat K) :=
   { Completion.topologicalRing with
     continuousAt_inv₀ := by
       intro x x_ne
@@ -183,7 +183,7 @@ instance Subfield.completableTopField (K : Subfield L) : CompletableTopField K w
     rw [← Filter.push_pull', ← map_zero i, ← hi.isInducing.nhds_eq_comap, inf_F, Filter.map_bot]
 
 instance (priority := 100) completableTopField_of_complete (L : Type*) [Field L] [UniformSpace L]
-    [TopologicalDivisionRing L] [T0Space L] [CompleteSpace L] : CompletableTopField L where
+    [IsTopologicalDivisionRing L] [T0Space L] [CompleteSpace L] : CompletableTopField L where
   nice F cau_F hF := by
     haveI : NeBot F := cau_F.1
     rcases CompleteSpace.complete cau_F with ⟨x, hx⟩

--- a/Mathlib/Topology/Algebra/Valued/ValuedField.lean
+++ b/Mathlib/Topology/Algebra/Valued/ValuedField.lean
@@ -75,8 +75,8 @@ open Valued
 
 /-- The topology coming from a valuation on a division ring makes it a topological division ring
     [BouAC, VI.5.1 middle of Proposition 1] -/
-instance (priority := 100) Valued.topologicalDivisionRing [Valued K Γ₀] :
-    TopologicalDivisionRing K :=
+instance (priority := 100) Valued.isTopologicalDivisionRing [Valued K Γ₀] :
+    IsTopologicalDivisionRing K :=
   { (by infer_instance : IsTopologicalRing K) with
     continuousAt_inv₀ := by
       intro x x_ne s s_in

--- a/Mathlib/Topology/Instances/Complex.lean
+++ b/Mathlib/Topology/Instances/Complex.lean
@@ -48,7 +48,7 @@ continuous, then `ψ` is either the inclusion map or the composition of the incl
 complex conjugation. -/
 theorem Complex.uniformContinuous_ringHom_eq_id_or_conj (K : Subfield ℂ) {ψ : K →+* ℂ}
     (hc : UniformContinuous ψ) : ψ.toFun = K.subtype ∨ ψ.toFun = conj ∘ K.subtype := by
-  letI : TopologicalDivisionRing ℂ := TopologicalDivisionRing.mk
+  letI : IsTopologicalDivisionRing ℂ := IsTopologicalDivisionRing.mk
   letI : IsTopologicalRing K.topologicalClosure :=
     Subring.instIsTopologicalRing K.topologicalClosure.toSubring
   set ι : K → K.topologicalClosure := ⇑(Subfield.inclusion K.le_topologicalClosure)


### PR DESCRIPTION
To follow the new naming convention on Prop-valued definitions starting with an adjective.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
