### PR TITLE
[Merged by Bors] - feat: norm and inner product of elements of an orthonormal basis

### DIFF
--- a/Mathlib/Analysis/InnerProductSpace/Orthonormal.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Orthonormal.lean
@@ -50,6 +50,12 @@ def Orthonormal (v : ι → E) : Prop :=
 
 variable {𝕜}
 
+lemma Orthonormal.norm_eq_one {v : ι → E} {i : ι} (h : Orthonormal 𝕜 v) :
+    ‖v i‖ = 1 := h.1 i
+
+lemma Orthonormal.inner_eq_zero {v : ι → E} {i j : ι} (h : Orthonormal 𝕜 v) (hij : i ≠ j) :
+    ⟪v i, v j⟫ = 0 := h.2 hij
+
 /-- `if ... then ... else` characterization of an indexed set of vectors being orthonormal.  (Inner
 product equals Kronecker delta.) -/
 theorem orthonormal_iff_ite [DecidableEq ι] {v : ι → E} :
@@ -57,8 +63,8 @@ theorem orthonormal_iff_ite [DecidableEq ι] {v : ι → E} :
   constructor
   · intro hv i j
     split_ifs with h
-    · simp [h, inner_self_eq_norm_sq_to_K, hv.1]
-    · exact hv.2 h
+    · simp [h, inner_self_eq_norm_sq_to_K, hv.norm_eq_one]
+    · exact hv.inner_eq_zero h
   · intro h
     constructor
     · intro i

--- a/Mathlib/Analysis/InnerProductSpace/Orthonormal.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Orthonormal.lean
@@ -50,15 +50,15 @@ def Orthonormal (v : ι → E) : Prop :=
 
 variable {𝕜}
 
-lemma Orthonormal.norm_eq_one {v : ι → E} {i : ι} (h : Orthonormal 𝕜 v) :
+lemma Orthonormal.norm_eq_one {v : ι → E} (h : Orthonormal 𝕜 v) (i : ι) :
     ‖v i‖ = 1 := h.1 i
 
-lemma Orthonormal.nnnorm_eq_one {v : ι → E} {i : ι} (h : Orthonormal 𝕜 v) :
+lemma Orthonormal.nnnorm_eq_one {v : ι → E} (h : Orthonormal 𝕜 v) (i : ι) :
     ‖v i‖₊ = 1 := by
   suffices (‖v i‖₊ : ℝ) = 1 by norm_cast at this
   simp [h.norm_eq_one]
 
-lemma Orthonormal.enorm_eq_one {v : ι → E} {i : ι} (h : Orthonormal 𝕜 v) :
+lemma Orthonormal.enorm_eq_one {v : ι → E} (h : Orthonormal 𝕜 v) (i : ι) :
     ‖v i‖ₑ = 1 := by rw [← ofReal_norm]; simp [h.norm_eq_one]
 
 lemma Orthonormal.inner_eq_zero {v : ι → E} {i j : ι} (h : Orthonormal 𝕜 v) (hij : i ≠ j) :

--- a/Mathlib/Analysis/InnerProductSpace/Orthonormal.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Orthonormal.lean
@@ -53,6 +53,14 @@ variable {𝕜}
 lemma Orthonormal.norm_eq_one {v : ι → E} {i : ι} (h : Orthonormal 𝕜 v) :
     ‖v i‖ = 1 := h.1 i
 
+lemma Orthonormal.nnnorm_eq_one {v : ι → E} {i : ι} (h : Orthonormal 𝕜 v) :
+    ‖v i‖₊ = 1 := by
+  suffices (‖v i‖₊ : ℝ) = 1 by norm_cast at this
+  simp [h.norm_eq_one]
+
+lemma Orthonormal.enorm_eq_one {v : ι → E} {i : ι} (h : Orthonormal 𝕜 v) :
+    ‖v i‖ₑ = 1 := by rw [← ofReal_norm]; simp [h.norm_eq_one]
+
 lemma Orthonormal.inner_eq_zero {v : ι → E} {i j : ι} (h : Orthonormal 𝕜 v) (hij : i ≠ j) :
     ⟪v i, v j⟫ = 0 := h.2 hij
 

--- a/Mathlib/Analysis/InnerProductSpace/PiL2.lean
+++ b/Mathlib/Analysis/InnerProductSpace/PiL2.lean
@@ -387,13 +387,11 @@ lemma norm_eq_one (b : OrthonormalBasis ι 𝕜 E) (i : ι) :
 
 @[simp]
 lemma nnnorm_eq_one (b : OrthonormalBasis ι 𝕜 E) (i : ι) :
-    ‖b i‖₊ = 1 := by
-  suffices (‖b i‖₊ : ℝ) = 1 by norm_cast at this
-  simp
+    ‖b i‖₊ = 1 := b.orthonormal.nnnorm_eq_one
 
 @[simp]
 lemma enorm_eq_one (b : OrthonormalBasis ι 𝕜 E) (i : ι) :
-    ‖b i‖ₑ = 1 := by rw [← ofReal_norm]; simp
+    ‖b i‖ₑ = 1 := b.orthonormal.enorm_eq_one
 
 @[simp]
 lemma inner_eq_zero (b : OrthonormalBasis ι 𝕜 E) {i j : ι} (hij : i ≠ j) :

--- a/Mathlib/Analysis/InnerProductSpace/PiL2.lean
+++ b/Mathlib/Analysis/InnerProductSpace/PiL2.lean
@@ -381,6 +381,13 @@ protected theorem orthonormal (b : OrthonormalBasis ι 𝕜 E) : Orthonormal �
     rw [← b.repr.inner_map_map (b i) (b j), b.repr_self i, b.repr_self j,
       EuclideanSpace.inner_single_left, EuclideanSpace.single_apply, map_one, one_mul]
 
+@[simp]
+lemma norm_eq_one (b : OrthonormalBasis ι 𝕜 E) (i : ι) :
+    ‖b i‖ = 1 := b.orthonormal.1 i
+
+lemma inner_eq_zero (b : OrthonormalBasis ι 𝕜 E) {i j : ι} (hij : i ≠ j) :
+    ⟪b i, b j⟫ = 0 := b.orthonormal.2 hij
+
 /-- The `Basis ι 𝕜 E` underlying the `OrthonormalBasis` -/
 protected def toBasis (b : OrthonormalBasis ι 𝕜 E) : Basis ι 𝕜 E :=
   Basis.ofEquivFun b.repr.toLinearEquiv

--- a/Mathlib/Analysis/InnerProductSpace/PiL2.lean
+++ b/Mathlib/Analysis/InnerProductSpace/PiL2.lean
@@ -383,15 +383,15 @@ protected theorem orthonormal (b : OrthonormalBasis ι 𝕜 E) : Orthonormal �
 
 @[simp]
 lemma norm_eq_one (b : OrthonormalBasis ι 𝕜 E) (i : ι) :
-    ‖b i‖ = 1 := b.orthonormal.norm_eq_one
+    ‖b i‖ = 1 := b.orthonormal.norm_eq_one i
 
 @[simp]
 lemma nnnorm_eq_one (b : OrthonormalBasis ι 𝕜 E) (i : ι) :
-    ‖b i‖₊ = 1 := b.orthonormal.nnnorm_eq_one
+    ‖b i‖₊ = 1 := b.orthonormal.nnnorm_eq_one i
 
 @[simp]
 lemma enorm_eq_one (b : OrthonormalBasis ι 𝕜 E) (i : ι) :
-    ‖b i‖ₑ = 1 := b.orthonormal.enorm_eq_one
+    ‖b i‖ₑ = 1 := b.orthonormal.enorm_eq_one i
 
 @[simp]
 lemma inner_eq_zero (b : OrthonormalBasis ι 𝕜 E) {i j : ι} (hij : i ≠ j) :

--- a/Mathlib/Analysis/InnerProductSpace/PiL2.lean
+++ b/Mathlib/Analysis/InnerProductSpace/PiL2.lean
@@ -383,10 +383,10 @@ protected theorem orthonormal (b : OrthonormalBasis ι 𝕜 E) : Orthonormal �
 
 @[simp]
 lemma norm_eq_one (b : OrthonormalBasis ι 𝕜 E) (i : ι) :
-    ‖b i‖ = 1 := b.orthonormal.1 i
+    ‖b i‖ = 1 := b.orthonormal.norm_eq_one
 
 lemma inner_eq_zero (b : OrthonormalBasis ι 𝕜 E) {i j : ι} (hij : i ≠ j) :
-    ⟪b i, b j⟫ = 0 := b.orthonormal.2 hij
+    ⟪b i, b j⟫ = 0 := b.orthonormal.inner_eq_zero hij
 
 /-- The `Basis ι 𝕜 E` underlying the `OrthonormalBasis` -/
 protected def toBasis (b : OrthonormalBasis ι 𝕜 E) : Basis ι 𝕜 E :=

--- a/Mathlib/Analysis/InnerProductSpace/PiL2.lean
+++ b/Mathlib/Analysis/InnerProductSpace/PiL2.lean
@@ -385,6 +385,17 @@ protected theorem orthonormal (b : OrthonormalBasis ι 𝕜 E) : Orthonormal �
 lemma norm_eq_one (b : OrthonormalBasis ι 𝕜 E) (i : ι) :
     ‖b i‖ = 1 := b.orthonormal.norm_eq_one
 
+@[simp]
+lemma nnnorm_eq_one (b : OrthonormalBasis ι 𝕜 E) (i : ι) :
+    ‖b i‖₊ = 1 := by
+  suffices (‖b i‖₊ : ℝ) = 1 by norm_cast at this
+  simp
+
+@[simp]
+lemma enorm_eq_one (b : OrthonormalBasis ι 𝕜 E) (i : ι) :
+    ‖b i‖ₑ = 1 := by rw [← ofReal_norm]; simp
+
+@[simp]
 lemma inner_eq_zero (b : OrthonormalBasis ι 𝕜 E) {i j : ι} (hij : i ≠ j) :
     ⟪b i, b j⟫ = 0 := b.orthonormal.inner_eq_zero hij
 


### PR DESCRIPTION

This does not put a `simp` attribute on `Orthonormal.norm_eq_one` because  `simp` won't actually use it, due to a refusal to unify `𝕜` with an assumption.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->


[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
