### PR TITLE
[Merged by Bors] - feat: add lemmas about Field.toEuclideanDomain

### DIFF
--- a/Mathlib/Algebra/EuclideanDomain/Field.lean
+++ b/Mathlib/Algebra/EuclideanDomain/Field.lean
@@ -38,4 +38,12 @@ protected theorem gcd_eq [DecidableEq K] (a b : K) :
   unfold EuclideanDomain.gcd
   split_ifs <;> simp [*, Field.mod_eq]
 
+protected theorem gcd_zero_eq [DecidableEq K] (b : K) :
+    EuclideanDomain.gcd 0 b = b := by
+  rw [Field.gcd_eq, if_pos rfl]
+
+protected theorem gcd_eq_of_ne [DecidableEq K] {a : K} (ha : a ≠ 0) (b : K) :
+    EuclideanDomain.gcd a b = a := by
+  rw [Field.gcd_eq, if_neg ha]
+
 end Field

--- a/Mathlib/Algebra/EuclideanDomain/Field.lean
+++ b/Mathlib/Algebra/EuclideanDomain/Field.lean
@@ -12,9 +12,13 @@ import Mathlib.Algebra.GroupWithZero.Units.Basic
 * `Field.toEuclideanDomain`: shows that any field is a Euclidean domain.
 -/
 
+namespace Field
+
+variable {K : Type*} [Field K]
+
 -- see Note [lower instance priority]
-instance (priority := 100) Field.toEuclideanDomain {K : Type*} [Field K] : EuclideanDomain K :=
-{ toCommRing := Field.toCommRing
+instance (priority := 100) toEuclideanDomain : EuclideanDomain K :=
+{ toCommRing := toCommRing
   quotient := (· / ·), remainder := fun a b => a - a * b / b, quotient_zero := div_zero,
   quotient_mul_add_remainder_eq := fun a b => by
     by_cases h : b = 0 <;> simp [h, mul_div_cancel₀]
@@ -24,3 +28,14 @@ instance (priority := 100) Field.toEuclideanDomain {K : Type*} [Field K] : Eucli
       (Acc.intro _) fun _ ⟨hb, _⟩ => (Acc.intro _) fun _ ⟨_, hnb⟩ => False.elim <| hnb hb,
   remainder_lt := fun a b hnb => by simp [hnb],
   mul_left_not_lt := fun _ _ hnb ⟨hab, hna⟩ => Or.casesOn (mul_eq_zero.1 hab) hna hnb }
+
+@[simp]
+protected theorem mod_eq (a b : K) : a % b = a - a * b / b := rfl
+
+@[simp]
+protected theorem gcd_eq [DecidableEq K] (a b : K) :
+    EuclideanDomain.gcd a b = if a = 0 then b else a := by
+  unfold EuclideanDomain.gcd
+  split_ifs <;> simp [*, Field.mod_eq]
+
+end Field


### PR DESCRIPTION
The behaviour of mod and gcd in a field are somewhat unexpected. I think that adding simp lemmas to reduce them to more well-understood notions will be helpful for people who accidentally end up using them, even if the right-hand side is not necessarily "simp"ler on first sight.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
