### PR TITLE
[Merged by Bors] - feat: meromorphic functions in normal form on sets

### DIFF
--- a/Mathlib/Algebra/Order/WithTop/Untop0.lean
+++ b/Mathlib/Algebra/Order/WithTop/Untop0.lean
@@ -76,7 +76,7 @@ lemma untop₀_mul [DecidableEq α] [MulZeroClass α] (a b : WithTop α) :
 Elements of ordered additive commutative groups are nonnegative iff their untop₀ is nonnegative.
 -/
 @[simp]
-lemma untop0_nonneg [OrderedAddCommGroup α] {a : WithTop α} :
+lemma untop₀_nonneg [OrderedAddCommGroup α] {a : WithTop α} :
     0 ≤ a.untop₀ ↔ 0 ≤ a := by
   by_cases ha : a = ⊤
   · rw [ha]

--- a/Mathlib/Algebra/Order/WithTop/Untop0.lean
+++ b/Mathlib/Algebra/Order/WithTop/Untop0.lean
@@ -69,8 +69,25 @@ lemma untop₀_mul [DecidableEq α] [MulZeroClass α] (a b : WithTop α) :
     (a * b).untop₀ = a.untop₀ * b.untop₀ := untopD_zero_mul a b
 
 /-!
+## Simplifying Lemmas in cases where α is a OrderedAddCommGroup
+-/
+
+/--
+Elements of ordered additive commutative groups are nonnegative iff their untop₀ is nonnegative.
+-/
+@[simp]
+lemma nonneg_untop0_iff_nonneg [OrderedAddCommGroup α] (a : WithTop α) :
+    0 ≤ a.untop₀ ↔ 0 ≤ a := by
+  by_cases ha : a = ⊤
+  · rw [ha]
+    tauto
+  lift a to α using ha
+  simp
+
+/-!
 ## Simplifying Lemmas in cases where α is a LinearOrderedAddCommGroup
 -/
+
 @[simp]
 lemma untop₀_neg [LinearOrderedAddCommGroup α] (a : WithTop α) :
     (-a).untop₀ = -a.untop₀ := by

--- a/Mathlib/Algebra/Order/WithTop/Untop0.lean
+++ b/Mathlib/Algebra/Order/WithTop/Untop0.lean
@@ -76,7 +76,7 @@ lemma untop₀_mul [DecidableEq α] [MulZeroClass α] (a b : WithTop α) :
 Elements of ordered additive commutative groups are nonnegative iff their untop₀ is nonnegative.
 -/
 @[simp]
-lemma nonneg_untop0_iff_nonneg [OrderedAddCommGroup α] (a : WithTop α) :
+lemma untop0_nonneg [OrderedAddCommGroup α] {a : WithTop α} :
     0 ≤ a.untop₀ ↔ 0 ≤ a := by
   by_cases ha : a = ⊤
   · rw [ha]

--- a/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
+++ b/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
@@ -331,7 +331,7 @@ theorem meromorphicNFAt_toMeromorphicNFAt :
 
 /-- If `f` has normal form at `x`, then `f` equals `f.toNF`. -/
 @[simp] theorem toMeromorphicNFAt_eq_self :
-    f = toMeromorphicNFAt f x ↔ MeromorphicNFAt f x where
+    toMeromorphicNFAt f x = f ↔ MeromorphicNFAt f x where
   mp hf := by
     rw [hf]
     exact meromorphicNFAt_toMeromorphicNFAt
@@ -515,11 +515,10 @@ theorem meromorphicNFOn_mul_iff_left_of_analyticOnNhd {f g : 𝕜 → 𝕜} (h�
 /--
 A function to 𝕜 is meromorphic in normal form on `U` iff its inverse is.
 -/
-theorem meromorphicNFOn_iff_meromorphicNFOn_inv {f : 𝕜 → 𝕜} :
-    MeromorphicNFOn f U ↔ MeromorphicNFOn f⁻¹ U := by
-  constructor
-  · exact fun h x hx ↦ meromorphicNFAt_inv.2 (h hx)
-  · exact fun h x hx ↦ meromorphicNFAt_inv.1 (h hx)
+theorem meromorphicNFOn_inv {f : 𝕜 → 𝕜} :
+    MeromorphicNFOn f⁻¹ U ↔ MeromorphicNFOn f U where
+  mp h x hx := meromorphicNFAt_inv.1 (h hx)
+  mpr h x hx := meromorphicNFAt_inv.2 (h hx)
 
 /-!
 ## Continuous extension and conversion to normal form
@@ -628,7 +627,7 @@ If `f` has normal form on `U`, then `f` equals `toMeromorphicNFOn f U`.
 /--
 Conversion of normal form does not affect orders.
 -/
-@[simp] theorem toMeromorphicNFOn_order [CompleteSpace E] (hf : MeromorphicOn f U) (hx : x ∈ U) :
+@[simp] theorem order_toMeromorphicNFOn [CompleteSpace E] (hf : MeromorphicOn f U) (hx : x ∈ U) :
     ((meromorphicNFOn_toMeromorphicNFOn f U) hx).meromorphicAt.order = (hf x hx).order := by
   apply MeromorphicAt.order_congr
   exact hf.toMeromorphicNFOn_eq_self_on_nhdNE hx

--- a/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
+++ b/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
@@ -331,8 +331,11 @@ theorem meromorphicNFAt_toMeromorphicNFAt :
 
 /-- If `f` has normal form at `x`, then `f` equals `f.toNF`. -/
 @[simp] theorem toMeromorphicNFAt_eq_self :
-    MeromorphicNFAt f x ↔ f = toMeromorphicNFAt f x where
+    f = toMeromorphicNFAt f x ↔ MeromorphicNFAt f x where
   mp hf := by
+    rw [hf]
+    exact meromorphicNFAt_toMeromorphicNFAt
+  mpr hf := by
     funext z
     by_cases hz : z = x
     · rw [hz]
@@ -371,9 +374,6 @@ theorem meromorphicNFAt_toMeromorphicNFAt :
           rw [hn] at this
           tauto
     · exact hf.meromorphicAt.eqOn_compl_singleton_toMermomorphicNFAt hz
-  mpr hf := by
-    rw [hf]
-    exact meromorphicNFAt_toMeromorphicNFAt
 
 /--
 If `f` is meromorphic in normal form, then so is its inverse.
@@ -564,7 +564,7 @@ theorem toMeromorphicNFOn_eqOn_codiscrete [CompleteSpace E] (hf : MeromorphicOn 
   have : U ∈ Filter.codiscreteWithin U := by
     simp [mem_codiscreteWithin.2]
   filter_upwards [hf.analyticAt_mem_codiscreteWithin, this] with a h₁a h₂a
-  simp [toMeromorphicNFOn, hf, ← toMeromorphicNFAt_eq_self.1 h₁a.meromorphicNFAt]
+  simp [toMeromorphicNFOn, hf, ← toMeromorphicNFAt_eq_self.2 h₁a.meromorphicNFAt]
 
 /--
 If `f` is meromorphic on `U` and `x ∈ U`, then `f` and its conversion to normal
@@ -574,7 +574,7 @@ theorem MeromorphicOn.toMeromorphicNFOn_eq_self_on_nhdNE [CompleteSpace E]
     (hf : MeromorphicOn f U) (hx : x ∈ U) :
     toMeromorphicNFOn f U =ᶠ[𝓝[≠] x] f := by
   filter_upwards [(hf x hx).eventually_analyticAt] with a ha
-  simp [toMeromorphicNFOn, hf, ← toMeromorphicNFAt_eq_self.1 ha.meromorphicNFAt]
+  simp [toMeromorphicNFOn, hf, ← toMeromorphicNFAt_eq_self.2 ha.meromorphicNFAt]
 
 /--
 If `f` is meromorphic on `U` and `x ∈ U`, then conversion to normal form at `x`
@@ -620,7 +620,7 @@ If `f` has normal form on `U`, then `f` equals `toMeromorphicNFOn f U`.
   · ext x
     by_cases hx : x ∈ U
     · simp only [toMeromorphicNFOn, h.meromorphicOn, ↓reduceDIte, hx]
-      rw [← toMeromorphicNFAt_eq_self.1 (h hx)]
+      rw [← toMeromorphicNFAt_eq_self.2 (h hx)]
     · simp [toMeromorphicNFOn, h.meromorphicOn, hx]
   · rw [h]
     apply meromorphicNFOn_toMeromorphicNFOn

--- a/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
+++ b/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
@@ -393,7 +393,7 @@ theorem MeromorphicNFAt.inv {f : 𝕜 → 𝕜} (hf : MeromorphicNFAt f x) :
 /--
 A function to 𝕜 is meromorphic in normal form at a point iff its inverse is.
 -/
-theorem meromorphicNFAt_inv {f : 𝕜 → 𝕜} : MeromorphicNFAt f⁻¹ x ↔ MeromorphicNFAt f x where
+@[simp] theorem meromorphicNFAt_inv {f : 𝕜 → 𝕜} : MeromorphicNFAt f⁻¹ x ↔ MeromorphicNFAt f x where
   mp := by
     nth_rw 2 [← inv_inv f]
     exact .inv

--- a/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
+++ b/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
@@ -393,12 +393,9 @@ theorem MeromorphicNFAt.inv {f : 𝕜 → 𝕜} (hf : MeromorphicNFAt f x) :
 /--
 A function to 𝕜 is meromorphic in normal form at a point iff its inverse is.
 -/
-theorem meromorphicNFAt_iff_meromorphicNFAt_inv {f : 𝕜 → 𝕜} :
-    MeromorphicNFAt f x ↔ MeromorphicNFAt f⁻¹ x := by
-  constructor
-  · exact MeromorphicNFAt.inv
-  · nth_rw 2 [← inv_inv f]
-    exact MeromorphicNFAt.inv
+theorem meromorphicNFAt_inv {f : 𝕜 → 𝕜} : MeromorphicNFAt f⁻¹ x ↔ MeromorphicNFAt f x where
+  mp := .inv
+  mpr hf := by simpa using hf.inv
 
 /-!
 # Normal form of meromorphic functions on a given set
@@ -410,7 +407,7 @@ theorem meromorphicNFAt_iff_meromorphicNFAt_inv {f : 𝕜 → 𝕜} :
 A function is 'meromorphic in normal form' on `U` if has normal form at every
 point of `U`.
 -/
-def MeromorphicNFOn (f : 𝕜 → E) (U : Set 𝕜) := ∀ z ∈ U, MeromorphicNFAt f z
+def MeromorphicNFOn (f : 𝕜 → E) (U : Set 𝕜) := ∀ ⦃z⦄, z ∈ U → MeromorphicNFAt f z
 
 /-!
 ## Relation to other properties of functions
@@ -427,7 +424,7 @@ theorem MeromorphicNFOn.meromorphicOn (hf : MeromorphicNFOn f U) :
 If a function is meromorphic in normal form on `U`, then its divisor is
 non-negative iff it is analytic.
 -/
-theorem MeromorphicNFOn.nonneg_divisor_iff_analyticOnNhd [CompleteSpace E]
+theorem MeromorphicNFOn.divisor_nonneg_iff_analyticOnNhd [CompleteSpace E]
     (h₁f : MeromorphicNFOn f U) :
     0 ≤ MeromorphicOn.divisor f U ↔ AnalyticOnNhd 𝕜 f U := by
   constructor <;> intro h x
@@ -457,7 +454,7 @@ then its zero set equals the support of the associated divisor.
 -/
 theorem MeromorphicNFOn.zero_set_eq_divisor_support [CompleteSpace E] (h₁f : MeromorphicNFOn f U)
     (h₂f : ∀ u : U, (h₁f u u.2).meromorphicAt.order ≠ ⊤) :
-    U ∩ f⁻¹' {0} = (Function.support (MeromorphicOn.divisor f U)) := by
+    U ∩ f⁻¹' {0} = Function.support (MeromorphicOn.divisor f U) := by
   ext u
   constructor <;> intro hu
   · simp_all only [ne_eq, Subtype.forall, Set.mem_inter_iff, Set.mem_preimage,
@@ -483,7 +480,7 @@ meromorphic in normal form on `U` iff `g • f` is meromorphic in normal form on
 `U`.
 -/
 theorem meromorphicNFOn_smul_iff_right_of_analyticOnNhd {g : 𝕜 → 𝕜} (h₁g : AnalyticOnNhd 𝕜 g U)
-    (h₂g : ∀ u : U, g u ≠ 0) :
+    (h₂g : ∀ u ∈ U, g u ≠ 0) :
     MeromorphicNFOn (g • f) U ↔ MeromorphicNFOn f U := by
   constructor <;> intro h z hz
   · rw [← meromorphicNFAt_smul_iff_right_of_analyticAt (h₁g z hz) (h₂g ⟨z, hz⟩)]

--- a/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
+++ b/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
@@ -333,7 +333,7 @@ theorem meromorphicNFAt_toMeromorphicNFAt :
 @[simp] theorem toMeromorphicNFAt_eq_self :
     toMeromorphicNFAt f x = f ↔ MeromorphicNFAt f x where
   mp hf := by
-    rw [hf]
+    rw [hf.symm]
     exact meromorphicNFAt_toMeromorphicNFAt
   mpr hf := by
     funext z
@@ -343,7 +343,7 @@ theorem meromorphicNFAt_toMeromorphicNFAt :
       have h₀f := hf
       rcases hf with h₁f | h₁f
       · simpa [(h₀f.meromorphicAt.order_eq_top_iff).2 (h₁f.filter_mono nhdsWithin_le_nhds)]
-          using h₁f.eq_of_nhds
+          using h₁f.eq_of_nhds.symm
       · obtain ⟨n, g, h₁g, h₂g, h₃g⟩ := h₁f
         rw [Filter.EventuallyEq.eq_of_nhds h₃g]
         have : h₀f.meromorphicAt.order = n := by
@@ -365,15 +365,16 @@ theorem meromorphicNFAt_toMeromorphicNFAt :
             simp only [zpow_zero, one_smul, ne_eq] at h₃g h₂
             exact (h₃g.filter_mono nhdsWithin_le_nhds).symm.trans h₂
           simp only [Function.update_self]
-          exact Filter.EventuallyEq.eq_of_nhds this
-        · simp only [Pi.smul_apply', Pi.pow_apply, sub_self, h₃f, ↓reduceDIte, smul_eq_zero,
+          exact Filter.EventuallyEq.eq_of_nhds this.symm
+        · rw [eq_comm]
+          simp only [Pi.smul_apply', Pi.pow_apply, sub_self, h₃f, ↓reduceDIte, smul_eq_zero,
             Function.update_self, smul_eq_zero]
           left
           apply zero_zpow n
           by_contra hn
           rw [hn] at this
           tauto
-    · exact hf.meromorphicAt.eqOn_compl_singleton_toMermomorphicNFAt hz
+    · exact (hf.meromorphicAt.eqOn_compl_singleton_toMermomorphicNFAt hz).symm
 
 /--
 If `f` is meromorphic in normal form, then so is its inverse.
@@ -517,8 +518,8 @@ A function to 𝕜 is meromorphic in normal form on `U` iff its inverse is.
 -/
 theorem meromorphicNFOn_inv {f : 𝕜 → 𝕜} :
     MeromorphicNFOn f⁻¹ U ↔ MeromorphicNFOn f U where
-  mp h x hx := meromorphicNFAt_inv.1 (h hx)
-  mpr h x hx := meromorphicNFAt_inv.2 (h hx)
+  mp h _ hx := meromorphicNFAt_inv.1 (h hx)
+  mpr h _ hx := meromorphicNFAt_inv.2 (h hx)
 
 /-!
 ## Continuous extension and conversion to normal form
@@ -563,7 +564,7 @@ theorem toMeromorphicNFOn_eqOn_codiscrete [CompleteSpace E] (hf : MeromorphicOn 
   have : U ∈ Filter.codiscreteWithin U := by
     simp [mem_codiscreteWithin.2]
   filter_upwards [hf.analyticAt_mem_codiscreteWithin, this] with a h₁a h₂a
-  simp [toMeromorphicNFOn, hf, ← toMeromorphicNFAt_eq_self.2 h₁a.meromorphicNFAt]
+  simp [toMeromorphicNFOn, hf, ← (toMeromorphicNFAt_eq_self.2 h₁a.meromorphicNFAt).symm]
 
 /--
 If `f` is meromorphic on `U` and `x ∈ U`, then `f` and its conversion to normal
@@ -573,7 +574,7 @@ theorem MeromorphicOn.toMeromorphicNFOn_eq_self_on_nhdNE [CompleteSpace E]
     (hf : MeromorphicOn f U) (hx : x ∈ U) :
     toMeromorphicNFOn f U =ᶠ[𝓝[≠] x] f := by
   filter_upwards [(hf x hx).eventually_analyticAt] with a ha
-  simp [toMeromorphicNFOn, hf, ← toMeromorphicNFAt_eq_self.2 ha.meromorphicNFAt]
+  simp [toMeromorphicNFOn, hf, ← (toMeromorphicNFAt_eq_self.2 ha.meromorphicNFAt).symm]
 
 /--
 If `f` is meromorphic on `U` and `x ∈ U`, then conversion to normal form at `x`
@@ -621,7 +622,7 @@ If `f` has normal form on `U`, then `f` equals `toMeromorphicNFOn f U`.
   · ext x
     by_cases hx : x ∈ U
     · simp only [toMeromorphicNFOn, h.meromorphicOn, ↓reduceDIte, hx]
-      rw [← toMeromorphicNFAt_eq_self.2 (h hx)]
+      rw [toMeromorphicNFAt_eq_self.2 (h hx)]
     · simp [toMeromorphicNFOn, h.meromorphicOn, hx]
 
 /--

--- a/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
+++ b/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
@@ -3,7 +3,7 @@ Copyright (c) 2025 Stefan Kebekus. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Stefan Kebekus
 -/
-import Mathlib.Analysis.Meromorphic.Order
+import Mathlib.Analysis.Meromorphic.Divisor
 
 /-!
 # Normal form of meromorphic functions and continuous extension
@@ -24,13 +24,14 @@ does not vanish at `x`.
 Establish the analogous notion `MeromorphicNFOn`.
 -/
 
-open Topology
+open Topology WithTop
 
 variable
   {𝕜 : Type*} [NontriviallyNormedField 𝕜]
   {E : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E]
   {f : 𝕜 → E} {g : 𝕜 → 𝕜}
   {x : 𝕜}
+  {U : Set 𝕜}
 
 /-!
 # Normal form of meromorphic functions at a given point
@@ -373,3 +374,271 @@ theorem meromorphicNFAt_toMeromorphicNFAt :
   mpr hf := by
     rw [hf]
     exact meromorphicNFAt_toMeromorphicNFAt
+
+/--
+If `f` is meromorphic in normal form, then so is its inverse.
+-/
+theorem MeromorphicNFAt.inv {f : 𝕜 → 𝕜} (hf : MeromorphicNFAt f x) :
+    MeromorphicNFAt f⁻¹ x := by
+  rcases hf with h | ⟨n, g, h₁, h₂, h₃⟩
+  · left
+    filter_upwards [h] with x hx
+    simp [hx]
+  · right
+    use -n, g⁻¹, h₁.inv h₂, (by simp_all)
+    filter_upwards [h₃] with y hy
+    simp only [Pi.inv_apply, hy, Pi.smul_apply', Pi.pow_apply, smul_eq_mul, mul_inv_rev, zpow_neg]
+    ring
+
+/--
+A function to 𝕜 is meromorphic in normal form at a point iff its inverse is.
+-/
+theorem meromorphicNFAt_iff_meromorphicNFAt_inv {f : 𝕜 → 𝕜} :
+    MeromorphicNFAt f x ↔ MeromorphicNFAt f⁻¹ x := by
+  constructor
+  · exact MeromorphicNFAt.inv
+  · nth_rw 2 [← inv_inv f]
+    exact MeromorphicNFAt.inv
+
+/-!
+# Normal form of meromorphic functions on a given set
+
+## Definition
+-/
+
+/--
+A function is 'meromorphic in normal form' on `U` if has normal form at every
+point of `U`.
+-/
+def MeromorphicNFOn (f : 𝕜 → E) (U : Set 𝕜) := ∀ z ∈ U, MeromorphicNFAt f z
+
+/-!
+## Relation to other properties of functions
+-/
+
+/--
+If a function is meromorphic in normal form on `U`, then it is meromorphic on
+`U`.
+-/
+theorem MeromorphicNFOn.meromorphicOn (hf : MeromorphicNFOn f U) :
+    MeromorphicOn f U := fun z hz ↦ (hf z hz).meromorphicAt
+
+/--
+If a function is meromorphic in normal form on `U`, then its divisor is
+non-negative iff it is analytic.
+-/
+theorem MeromorphicNFOn.nonneg_divisor_iff_analyticOnNhd [CompleteSpace E]
+    (h₁f : MeromorphicNFOn f U) :
+    0 ≤ MeromorphicOn.divisor f U ↔ AnalyticOnNhd 𝕜 f U := by
+  constructor <;> intro h x
+  · intro hx
+    rw [← (h₁f x hx).order_nonneg_iff_analyticAt]
+    have := h x
+    simp only [Function.locallyFinsuppWithin.coe_zero, Pi.zero_apply, h₁f.meromorphicOn, hx,
+      MeromorphicOn.divisor_apply, nonneg_untop0_iff_nonneg] at this
+    assumption
+  · by_cases hx : x ∈ U
+    · simp only [Function.locallyFinsuppWithin.coe_zero, Pi.zero_apply, h₁f.meromorphicOn, hx,
+        MeromorphicOn.divisor_apply, nonneg_untop0_iff_nonneg]
+      exact (h₁f x hx).order_nonneg_iff_analyticAt.2 (h x hx)
+    · simp [h₁f.meromorphicOn, hx]
+
+/-- Analytic functions are meromorphic in normal form. -/
+theorem AnalyticOnNhd.meromorphicNFOn (h₁f : AnalyticOnNhd 𝕜 f U) :
+    MeromorphicNFOn f U := fun z hz ↦ (h₁f z hz).meromorphicNFAt
+
+/-!
+## Divisors and zeros of meromorphic functions in normal form.
+-/
+
+/--
+If `f` is meromorphic in normal form on `U` and nowhere locally constant zero,
+then its zero set equals the support of the associated divisor.
+-/
+theorem MeromorphicNFOn.zero_set_eq_divisor_support [CompleteSpace E] (h₁f : MeromorphicNFOn f U)
+    (h₂f : ∀ u : U, (h₁f u u.2).meromorphicAt.order ≠ ⊤) :
+    U ∩ f⁻¹' {0} = (Function.support (MeromorphicOn.divisor f U)) := by
+  ext u
+  constructor <;> intro hu
+  · simp_all only [ne_eq, Subtype.forall, Set.mem_inter_iff, Set.mem_preimage,
+      Set.mem_singleton_iff, Function.mem_support, h₁f.meromorphicOn, MeromorphicOn.divisor_apply,
+      WithTop.untop₀_eq_zero, (h₁f u hu.1).order_eq_zero_iff, not_true_eq_false, or_self,
+      not_false_eq_true]
+  · simp only [Function.mem_support, ne_eq] at hu
+    constructor
+    · exact (MeromorphicOn.divisor f U).supportWithinDomain hu
+    · rw [Set.mem_preimage, Set.mem_singleton_iff]
+      have := (h₁f u ((MeromorphicOn.divisor f U).supportWithinDomain hu)).order_eq_zero_iff.not
+      simp only [h₁f.meromorphicOn, (MeromorphicOn.divisor f U).supportWithinDomain hu,
+        MeromorphicOn.divisor_apply, WithTop.untop₀_eq_zero, not_or] at hu
+      simp_all [this, hu.1]
+
+/-!
+## Criteria to guarantee normal form
+-/
+
+/--
+If `f` is any function and `g` is analytic without zero on `U`, then `f` is
+meromorphic in normal form on `U` iff `g • f` is meromorphic in normal form on
+`U`.
+-/
+theorem meromorphicNFOn_smul_iff_right_of_analyticOnNhd {g : 𝕜 → 𝕜} (h₁g : AnalyticOnNhd 𝕜 g U)
+    (h₂g : ∀ u : U, g u ≠ 0) :
+    MeromorphicNFOn (g • f) U ↔ MeromorphicNFOn f U := by
+  constructor <;> intro h z hz
+  · rw [← meromorphicNFAt_smul_iff_right_of_analyticAt (h₁g z hz) (h₂g ⟨z, hz⟩)]
+    exact h z hz
+  · apply (h z hz).smul_analytic (h₁g z hz)
+    exact h₂g ⟨z, hz⟩
+
+/--
+If `f` is any function and `g` is analytic without zero in `U`, then `f` is
+meromorphic in normal form on `U` iff `g * f` is meromorphic in normal form on
+`U`.
+-/
+theorem meromorphicNFOn_mul_iff_right_of_analyticOnNhd {f g : 𝕜 → 𝕜} (h₁g : AnalyticOnNhd 𝕜 g U)
+    (h₂g : ∀ u : U, g u ≠ 0) :
+    MeromorphicNFOn (g * f) U ↔ MeromorphicNFOn f U := by
+  rw [← smul_eq_mul]
+  exact meromorphicNFOn_smul_iff_right_of_analyticOnNhd h₁g h₂g
+
+/--
+If `f` is any function and `g` is analytic without zero in `U`, then `f` is
+meromorphic in normal form on `U` iff `f * g` is meromorphic in normal form on
+`U`.
+-/
+theorem meromorphicNFOn_mul_iff_left_of_analyticOnNhd {f g : 𝕜 → 𝕜} (h₁g : AnalyticOnNhd 𝕜 g U)
+    (h₂g : ∀ u : U, g u ≠ 0) :
+    MeromorphicNFOn (f * g) U ↔ MeromorphicNFOn f U := by
+  rw [mul_comm, ← smul_eq_mul]
+  exact meromorphicNFOn_mul_iff_right_of_analyticOnNhd h₁g h₂g
+
+/--
+A function to 𝕜 is meromorphic in normal form on `U` iff its inverse is.
+-/
+theorem meromorphicNFOn_iff_meromorphicNFOn_inv {f : 𝕜 → 𝕜} :
+    MeromorphicNFOn f U ↔ MeromorphicNFOn f⁻¹ U := by
+  constructor
+  · exact fun h x hx ↦ meromorphicNFAt_iff_meromorphicNFAt_inv.1 (h x hx)
+  · exact fun h x hx ↦ meromorphicNFAt_iff_meromorphicNFAt_inv.2 (h x hx)
+
+/-!
+## Continuous extension and conversion to normal form
+-/
+
+variable (f U) in
+/--
+If `f` is meromorphic on `U`, convert `f` to normal form on `U` by changing its
+values along a discrete subset within `U`. Otherwise, returns the 0 function.
+-/
+noncomputable def toMeromorphicNFOn :
+    𝕜 → E := by
+  by_cases h₁f : MeromorphicOn f U
+  · intro z
+    by_cases hz : z ∈ U
+    · exact toMeromorphicNFAt f z z
+    · exact f z
+  · exact 0
+
+/--
+If `f` is not meromorphic on `U`, conversion to normal form  maps the function
+to `0`.
+-/
+@[simp] lemma toMeromorphicNFOn_of_not_meromorphicOn (hf : ¬MeromorphicOn f U) :
+    toMeromorphicNFOn f U = 0 := by
+  simp [toMeromorphicNFOn, hf]
+
+/--
+Conversion to normal form on `U` does not change values outside of `U`.
+-/
+@[simp] lemma toMeromorphicNFOn_eq_self_on_compl (hf : MeromorphicOn f U) :
+    Set.EqOn f (toMeromorphicNFOn f U) Uᶜ := by
+  intro x hx
+  simp_all [toMeromorphicNFOn]
+
+/--
+Conversion to normal form on `U` changes the value only along a discrete subset
+of `U`.
+-/
+theorem toMeromorphicNFOn_eqOn_codiscrete [CompleteSpace E] (hf : MeromorphicOn f U) :
+    f =ᶠ[Filter.codiscreteWithin U] toMeromorphicNFOn f U := by
+  have : U ∈ Filter.codiscreteWithin U := by
+    simp [mem_codiscreteWithin.2]
+  filter_upwards [hf.analyticAt_mem_codiscreteWithin, this] with a h₁a h₂a
+  simp [toMeromorphicNFOn, hf, ← toMeromorphicNFAt_eq_self.1 h₁a.meromorphicNFAt]
+
+/--
+If `f` is meromorphic on `U` and `x ∈ U`, then `f` and its conversion to normal
+form on `U` agree in a punctured neighborhood of `x`.
+-/
+theorem MeromorphicOn.toMeromorphicNFOn_eq_self_on_nhdNE [CompleteSpace E]
+    (hf : MeromorphicOn f U) (hx : x ∈ U) :
+    toMeromorphicNFOn f U =ᶠ[𝓝[≠] x] f := by
+  filter_upwards [(hf x hx).eventually_analyticAt] with a ha
+  simp [toMeromorphicNFOn, hf, ← toMeromorphicNFAt_eq_self.1 ha.meromorphicNFAt]
+
+/--
+If `f` is meromorphic on `U` and `x ∈ U`, then conversion to normal form at `x`
+and conversion to normal form on `U` agree in a neighborhood of `x`.
+-/
+theorem toMeromorphicNFOn_eq_toMeromorphicNFAt_on_nhd [CompleteSpace E] (hf : MeromorphicOn f U)
+    (hx : x ∈ U) :
+    toMeromorphicNFOn f U =ᶠ[𝓝 x] toMeromorphicNFAt f x := by
+  apply eventuallyEq_nhds_of_eventuallyEq_nhdsNE
+  · exact (hf.toMeromorphicNFOn_eq_self_on_nhdNE hx).trans (hf x hx).eq_nhdNE_toMeromorphicNFAt
+  · simp [toMeromorphicNFOn, hf, hx]
+
+/--
+If `f` is meromorphic on `U` and `x ∈ U`, then conversion to normal form at `x`
+and conversion to normal form on `U` agree at `x`.
+-/
+theorem toMeromorphicNFOn_eq_toMeromorphicNFAt [CompleteSpace E] (hf : MeromorphicOn f U)
+    (hx : x ∈ U) :
+    toMeromorphicNFOn f U x = toMeromorphicNFAt f x x := by
+  apply Filter.EventuallyEq.eq_of_nhds (g := toMeromorphicNFAt f x)
+  simp [(toMeromorphicNFOn_eq_toMeromorphicNFAt_on_nhd hf hx).trans]
+
+variable (f U) in
+/--
+After conversion to normal form on `U`, the function has normal form.
+-/
+theorem meromorphicNFOn_toMeromorphicNFOn [CompleteSpace E] :
+    MeromorphicNFOn (toMeromorphicNFOn f U) U := by
+  by_cases hf : MeromorphicOn f U
+  · intro z hz
+    rw [meromorphicNFAt_congr (toMeromorphicNFOn_eq_toMeromorphicNFAt_on_nhd hf hz)]
+    exact meromorphicNFAt_toMeromorphicNFAt
+  · simp [hf]
+    apply AnalyticOnNhd.meromorphicNFOn
+    exact analyticOnNhd_const
+
+/--
+If `f` has normal form on `U`, then `f` equals `toMeromorphicNFOn f U`.
+-/
+@[simp] theorem toMeromorphicNFOn_eq_self [CompleteSpace E] :
+    MeromorphicNFOn f U ↔ f = toMeromorphicNFOn f U := by
+  constructor <;> intro h
+  · ext x
+    by_cases hx : x ∈ U
+    · simp only [toMeromorphicNFOn, h.meromorphicOn, ↓reduceDIte, hx]
+      rw [← toMeromorphicNFAt_eq_self.1 (h x hx)]
+    · simp [toMeromorphicNFOn, h.meromorphicOn, hx]
+  · rw [h]
+    apply meromorphicNFOn_toMeromorphicNFOn
+
+/--
+Conversion of normal form does not affect orders.
+-/
+@[simp] theorem toMeromorphicNFOn_order [CompleteSpace E] (hf : MeromorphicOn f U) (hx : x ∈ U) :
+    ((meromorphicNFOn_toMeromorphicNFOn f U) x hx).meromorphicAt.order = (hf x hx).order := by
+  apply MeromorphicAt.order_congr
+  exact hf.toMeromorphicNFOn_eq_self_on_nhdNE hx
+
+/--
+Conversion of normal form does not affect divisors.
+-/
+@[simp] theorem MeromorphicOn.divisor_of_toMeromorphicNFOn [CompleteSpace E]
+    (hf : MeromorphicOn f U) :
+    divisor (toMeromorphicNFOn f U) U = divisor f U := by
+  ext z
+  by_cases hz : z ∈ U <;> simp [hf, (meromorphicNFOn_toMeromorphicNFOn f U).meromorphicOn, hz]

--- a/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
+++ b/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
@@ -435,11 +435,11 @@ theorem MeromorphicNFOn.nonneg_divisor_iff_analyticOnNhd [CompleteSpace E]
     rw [← (h₁f x hx).order_nonneg_iff_analyticAt]
     have := h x
     simp only [Function.locallyFinsuppWithin.coe_zero, Pi.zero_apply, h₁f.meromorphicOn, hx,
-      MeromorphicOn.divisor_apply, nonneg_untop0_iff_nonneg] at this
+      MeromorphicOn.divisor_apply, untop0_nonneg] at this
     assumption
   · by_cases hx : x ∈ U
     · simp only [Function.locallyFinsuppWithin.coe_zero, Pi.zero_apply, h₁f.meromorphicOn, hx,
-        MeromorphicOn.divisor_apply, nonneg_untop0_iff_nonneg]
+        MeromorphicOn.divisor_apply, untop0_nonneg]
       exact (h₁f x hx).order_nonneg_iff_analyticAt.2 (h x hx)
     · simp [h₁f.meromorphicOn, hx]
 

--- a/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
+++ b/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
@@ -394,7 +394,9 @@ theorem MeromorphicNFAt.inv {f : 𝕜 → 𝕜} (hf : MeromorphicNFAt f x) :
 A function to 𝕜 is meromorphic in normal form at a point iff its inverse is.
 -/
 theorem meromorphicNFAt_inv {f : 𝕜 → 𝕜} : MeromorphicNFAt f⁻¹ x ↔ MeromorphicNFAt f x where
-  mp := .inv
+  mp := by
+    nth_rw 2 [← inv_inv f]
+    exact .inv
   mpr hf := by simpa using hf.inv
 
 /-!
@@ -418,7 +420,7 @@ If a function is meromorphic in normal form on `U`, then it is meromorphic on
 `U`.
 -/
 theorem MeromorphicNFOn.meromorphicOn (hf : MeromorphicNFOn f U) :
-    MeromorphicOn f U := fun z hz ↦ (hf z hz).meromorphicAt
+    MeromorphicOn f U := fun _ hz ↦ (hf hz).meromorphicAt
 
 /--
 If a function is meromorphic in normal form on `U`, then its divisor is
@@ -429,7 +431,7 @@ theorem MeromorphicNFOn.divisor_nonneg_iff_analyticOnNhd [CompleteSpace E]
     0 ≤ MeromorphicOn.divisor f U ↔ AnalyticOnNhd 𝕜 f U := by
   constructor <;> intro h x
   · intro hx
-    rw [← (h₁f x hx).order_nonneg_iff_analyticAt]
+    rw [← (h₁f hx).order_nonneg_iff_analyticAt]
     have := h x
     simp only [Function.locallyFinsuppWithin.coe_zero, Pi.zero_apply, h₁f.meromorphicOn, hx,
       MeromorphicOn.divisor_apply, untop0_nonneg] at this
@@ -437,7 +439,7 @@ theorem MeromorphicNFOn.divisor_nonneg_iff_analyticOnNhd [CompleteSpace E]
   · by_cases hx : x ∈ U
     · simp only [Function.locallyFinsuppWithin.coe_zero, Pi.zero_apply, h₁f.meromorphicOn, hx,
         MeromorphicOn.divisor_apply, untop0_nonneg]
-      exact (h₁f x hx).order_nonneg_iff_analyticAt.2 (h x hx)
+      exact (h₁f hx).order_nonneg_iff_analyticAt.2 (h x hx)
     · simp [h₁f.meromorphicOn, hx]
 
 /-- Analytic functions are meromorphic in normal form. -/
@@ -453,19 +455,19 @@ If `f` is meromorphic in normal form on `U` and nowhere locally constant zero,
 then its zero set equals the support of the associated divisor.
 -/
 theorem MeromorphicNFOn.zero_set_eq_divisor_support [CompleteSpace E] (h₁f : MeromorphicNFOn f U)
-    (h₂f : ∀ u : U, (h₁f u u.2).meromorphicAt.order ≠ ⊤) :
+    (h₂f : ∀ u : U, (h₁f u.2).meromorphicAt.order ≠ ⊤) :
     U ∩ f⁻¹' {0} = Function.support (MeromorphicOn.divisor f U) := by
   ext u
   constructor <;> intro hu
   · simp_all only [ne_eq, Subtype.forall, Set.mem_inter_iff, Set.mem_preimage,
       Set.mem_singleton_iff, Function.mem_support, h₁f.meromorphicOn, MeromorphicOn.divisor_apply,
-      WithTop.untop₀_eq_zero, (h₁f u hu.1).order_eq_zero_iff, not_true_eq_false, or_self,
+      WithTop.untop₀_eq_zero, (h₁f hu.1).order_eq_zero_iff, not_true_eq_false, or_self,
       not_false_eq_true]
   · simp only [Function.mem_support, ne_eq] at hu
     constructor
     · exact (MeromorphicOn.divisor f U).supportWithinDomain hu
     · rw [Set.mem_preimage, Set.mem_singleton_iff]
-      have := (h₁f u ((MeromorphicOn.divisor f U).supportWithinDomain hu)).order_eq_zero_iff.not
+      have := (h₁f ((MeromorphicOn.divisor f U).supportWithinDomain hu)).order_eq_zero_iff.not
       simp only [h₁f.meromorphicOn, (MeromorphicOn.divisor f U).supportWithinDomain hu,
         MeromorphicOn.divisor_apply, WithTop.untop₀_eq_zero, not_or] at hu
       simp_all [this, hu.1]
@@ -483,10 +485,10 @@ theorem meromorphicNFOn_smul_iff_right_of_analyticOnNhd {g : 𝕜 → 𝕜} (h�
     (h₂g : ∀ u ∈ U, g u ≠ 0) :
     MeromorphicNFOn (g • f) U ↔ MeromorphicNFOn f U := by
   constructor <;> intro h z hz
-  · rw [← meromorphicNFAt_smul_iff_right_of_analyticAt (h₁g z hz) (h₂g ⟨z, hz⟩)]
-    exact h z hz
-  · apply (h z hz).smul_analytic (h₁g z hz)
-    exact h₂g ⟨z, hz⟩
+  · rw [← meromorphicNFAt_smul_iff_right_of_analyticAt (h₁g z hz) (h₂g z hz)]
+    exact h hz
+  · apply (h hz).smul_analytic (h₁g z hz)
+    exact h₂g z hz
 
 /--
 If `f` is any function and `g` is analytic without zero in `U`, then `f` is
@@ -494,7 +496,7 @@ meromorphic in normal form on `U` iff `g * f` is meromorphic in normal form on
 `U`.
 -/
 theorem meromorphicNFOn_mul_iff_right_of_analyticOnNhd {f g : 𝕜 → 𝕜} (h₁g : AnalyticOnNhd 𝕜 g U)
-    (h₂g : ∀ u : U, g u ≠ 0) :
+    (h₂g : ∀ u ∈ U, g u ≠ 0) :
     MeromorphicNFOn (g * f) U ↔ MeromorphicNFOn f U := by
   rw [← smul_eq_mul]
   exact meromorphicNFOn_smul_iff_right_of_analyticOnNhd h₁g h₂g
@@ -505,7 +507,7 @@ meromorphic in normal form on `U` iff `f * g` is meromorphic in normal form on
 `U`.
 -/
 theorem meromorphicNFOn_mul_iff_left_of_analyticOnNhd {f g : 𝕜 → 𝕜} (h₁g : AnalyticOnNhd 𝕜 g U)
-    (h₂g : ∀ u : U, g u ≠ 0) :
+    (h₂g : ∀ u ∈ U, g u ≠ 0) :
     MeromorphicNFOn (f * g) U ↔ MeromorphicNFOn f U := by
   rw [mul_comm, ← smul_eq_mul]
   exact meromorphicNFOn_mul_iff_right_of_analyticOnNhd h₁g h₂g
@@ -516,8 +518,8 @@ A function to 𝕜 is meromorphic in normal form on `U` iff its inverse is.
 theorem meromorphicNFOn_iff_meromorphicNFOn_inv {f : 𝕜 → 𝕜} :
     MeromorphicNFOn f U ↔ MeromorphicNFOn f⁻¹ U := by
   constructor
-  · exact fun h x hx ↦ meromorphicNFAt_iff_meromorphicNFAt_inv.1 (h x hx)
-  · exact fun h x hx ↦ meromorphicNFAt_iff_meromorphicNFAt_inv.2 (h x hx)
+  · exact fun h x hx ↦ meromorphicNFAt_inv.2 (h hx)
+  · exact fun h x hx ↦ meromorphicNFAt_inv.1 (h hx)
 
 /-!
 ## Continuous extension and conversion to normal form
@@ -618,7 +620,7 @@ If `f` has normal form on `U`, then `f` equals `toMeromorphicNFOn f U`.
   · ext x
     by_cases hx : x ∈ U
     · simp only [toMeromorphicNFOn, h.meromorphicOn, ↓reduceDIte, hx]
-      rw [← toMeromorphicNFAt_eq_self.1 (h x hx)]
+      rw [← toMeromorphicNFAt_eq_self.1 (h hx)]
     · simp [toMeromorphicNFOn, h.meromorphicOn, hx]
   · rw [h]
     apply meromorphicNFOn_toMeromorphicNFOn
@@ -627,7 +629,7 @@ If `f` has normal form on `U`, then `f` equals `toMeromorphicNFOn f U`.
 Conversion of normal form does not affect orders.
 -/
 @[simp] theorem toMeromorphicNFOn_order [CompleteSpace E] (hf : MeromorphicOn f U) (hx : x ∈ U) :
-    ((meromorphicNFOn_toMeromorphicNFOn f U) x hx).meromorphicAt.order = (hf x hx).order := by
+    ((meromorphicNFOn_toMeromorphicNFOn f U) hx).meromorphicAt.order = (hf x hx).order := by
   apply MeromorphicAt.order_congr
   exact hf.toMeromorphicNFOn_eq_self_on_nhdNE hx
 

--- a/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
+++ b/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
@@ -615,9 +615,9 @@ theorem meromorphicNFOn_toMeromorphicNFOn [CompleteSpace E] :
 If `f` has normal form on `U`, then `f` equals `toMeromorphicNFOn f U`.
 -/
 @[simp] theorem toMeromorphicNFOn_eq_self [CompleteSpace E] :
-    f = toMeromorphicNFOn f U ↔ MeromorphicNFOn f U := by
+    toMeromorphicNFOn f U = f ↔ MeromorphicNFOn f U := by
   constructor <;> intro h
-  · rw [h]
+  · rw [h.symm]
     apply meromorphicNFOn_toMeromorphicNFOn
   · ext x
     by_cases hx : x ∈ U

--- a/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
+++ b/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
@@ -615,15 +615,15 @@ theorem meromorphicNFOn_toMeromorphicNFOn [CompleteSpace E] :
 If `f` has normal form on `U`, then `f` equals `toMeromorphicNFOn f U`.
 -/
 @[simp] theorem toMeromorphicNFOn_eq_self [CompleteSpace E] :
-    MeromorphicNFOn f U ↔ f = toMeromorphicNFOn f U := by
+    f = toMeromorphicNFOn f U ↔ MeromorphicNFOn f U := by
   constructor <;> intro h
+  · rw [h]
+    apply meromorphicNFOn_toMeromorphicNFOn
   · ext x
     by_cases hx : x ∈ U
     · simp only [toMeromorphicNFOn, h.meromorphicOn, ↓reduceDIte, hx]
       rw [← toMeromorphicNFAt_eq_self.2 (h hx)]
     · simp [toMeromorphicNFOn, h.meromorphicOn, hx]
-  · rw [h]
-    apply meromorphicNFOn_toMeromorphicNFOn
 
 /--
 Conversion of normal form does not affect orders.

--- a/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
+++ b/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
@@ -551,7 +551,7 @@ to `0`.
 Conversion to normal form on `U` does not change values outside of `U`.
 -/
 @[simp] lemma toMeromorphicNFOn_eq_self_on_compl (hf : MeromorphicOn f U) :
-    Set.EqOn f (toMeromorphicNFOn f U) Uᶜ := by
+    Set.EqOn (toMeromorphicNFOn f U) f Uᶜ := by
   intro x hx
   simp_all [toMeromorphicNFOn]
 

--- a/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
+++ b/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
@@ -435,11 +435,11 @@ theorem MeromorphicNFOn.divisor_nonneg_iff_analyticOnNhd [CompleteSpace E]
     rw [← (h₁f hx).order_nonneg_iff_analyticAt]
     have := h x
     simp only [Function.locallyFinsuppWithin.coe_zero, Pi.zero_apply, h₁f.meromorphicOn, hx,
-      MeromorphicOn.divisor_apply, untop0_nonneg] at this
+      MeromorphicOn.divisor_apply, untop₀_nonneg] at this
     assumption
   · by_cases hx : x ∈ U
     · simp only [Function.locallyFinsuppWithin.coe_zero, Pi.zero_apply, h₁f.meromorphicOn, hx,
-        MeromorphicOn.divisor_apply, untop0_nonneg]
+        MeromorphicOn.divisor_apply, untop₀_nonneg]
       exact (h₁f hx).order_nonneg_iff_analyticAt.2 (h x hx)
     · simp [h₁f.meromorphicOn, hx]
 


### PR DESCRIPTION
In analogy to existing code concerning meromorphic functions at are in normal form at a given point, define meromorphic functions that are in normal form on a given set.

This material is used in [Project VD](https://github.com/kebekus/ProjectVD), which aims to formalize Value Distribution Theory for meromorphic functions on the complex plane.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
