### PR TITLE
[Merged by Bors] - feat(MeasureTheory/Group/LIntegral): add `lintegral_div_left_eq_self`

### DIFF
--- a/Mathlib/MeasureTheory/Group/LIntegral.lean
+++ b/Mathlib/MeasureTheory/Group/LIntegral.lean
@@ -22,6 +22,23 @@ open scoped ENNReal
 
 variable {G : Type*} [MeasurableSpace G] {μ : Measure G}
 
+section MeasurableInv
+
+variable [InvolutiveInv G] [MeasurableInv G]
+
+/-- The Lebesgue integral of a function with respect to an inverse invariant measure is
+invariant under the change of variables x ↦ x⁻¹. -/
+@[to_additive
+      "The Lebesgue integral of a function with respect to an inverse invariant measure is
+invariant under the change of variables x ↦ -x."]
+theorem lintegral_inv_eq_self [IsInvInvariant μ] (f : G → ℝ≥0∞) :
+   ∫⁻ x, f x⁻¹ ∂μ = ∫⁻ x, f x ∂μ := by
+ convert (lintegral_map_equiv f <| MeasurableEquiv.inv _).symm
+ nth_rewrite 1 [← map_inv_eq_self μ]
+ rfl
+
+end MeasurableInv
+
 section MeasurableMul
 
 variable [Group G] [MeasurableMul G]
@@ -51,24 +68,13 @@ theorem lintegral_div_right_eq_self [IsMulRightInvariant μ] (f : G → ℝ≥0�
     (∫⁻ x, f (x / g) ∂μ) = ∫⁻ x, f x ∂μ := by
   simp_rw [div_eq_mul_inv, lintegral_mul_right_eq_self f g⁻¹]
 
+@[to_additive]
+theorem lintegral_div_left_eq_self [IsMulLeftInvariant μ] [MeasurableInv G] [IsInvInvariant μ]
+    (f : G → ℝ≥0∞) (g : G) : (∫⁻ x, f (g / x) ∂μ) = ∫⁻ x, f x ∂μ := by
+  simp_rw [div_eq_mul_inv, lintegral_inv_eq_self (f <| g * ·), lintegral_mul_left_eq_self]
+
 end MeasurableMul
 
-section MeasurableInv
-
-variable [InvolutiveInv G] [MeasurableInv G]
-
-/-- The Lebesgue integral of a function with respect to an inverse invariant measure is
-invariant under the change of variables x ↦ x⁻¹. -/
-@[to_additive
-      "The Lebesgue integral of a function with respect to an inverse invariant measure is
-invariant under the change of variables x ↦ -x."]
-theorem lintegral_inv_eq_self [IsInvInvariant μ] (f : G → ℝ≥0∞) :
-   ∫⁻ x, f x⁻¹ ∂μ = ∫⁻ x, f x ∂μ := by
- convert (lintegral_map_equiv f <| MeasurableEquiv.inv _).symm
- nth_rewrite 1 [← map_inv_eq_self μ]
- rfl
-
-end MeasurableInv
 
 section IsTopologicalGroup
 

--- a/Mathlib/MeasureTheory/Group/LIntegral.lean
+++ b/Mathlib/MeasureTheory/Group/LIntegral.lean
@@ -33,9 +33,7 @@ invariant under the change of variables x ↦ x⁻¹. -/
 invariant under the change of variables x ↦ -x."]
 theorem lintegral_inv_eq_self [IsInvInvariant μ] (f : G → ℝ≥0∞) :
    ∫⁻ x, f x⁻¹ ∂μ = ∫⁻ x, f x ∂μ := by
- convert (lintegral_map_equiv f <| MeasurableEquiv.inv _).symm
- nth_rewrite 1 [← map_inv_eq_self μ]
- rfl
+ simpa using (lintegral_map_equiv f (μ := μ) <| MeasurableEquiv.inv G).symm
 
 end MeasurableInv
 


### PR DESCRIPTION
- [x] Add `lintegral_div_left_eq_self`
- [x] Golf `lintegral_inv_eq_self`

Upstreamed from the [Carleson](https://github.com/fpvandoorn/carleson) project.

Co-authored-by: James Sundstrom

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
