### PR TITLE
[Merged by Bors] - feat: tightness criterion in a proper normed group

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4179,6 +4179,7 @@ import Mathlib.MeasureTheory.Measure.SeparableMeasure
 import Mathlib.MeasureTheory.Measure.Stieltjes
 import Mathlib.MeasureTheory.Measure.Sub
 import Mathlib.MeasureTheory.Measure.Tight
+import Mathlib.MeasureTheory.Measure.TightNormed
 import Mathlib.MeasureTheory.Measure.Tilted
 import Mathlib.MeasureTheory.Measure.Trim
 import Mathlib.MeasureTheory.Measure.Typeclasses

--- a/Mathlib/MeasureTheory/Measure/TightNormed.lean
+++ b/Mathlib/MeasureTheory/Measure/TightNormed.lean
@@ -3,8 +3,7 @@ Copyright (c) 2025 Rémy Degenne. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Rémy Degenne
 -/
-import Mathlib.Analysis.Normed.Module.FiniteDimension
-import Mathlib.Analysis.Normed.Order.Lattice
+import Mathlib.Analysis.Normed.Group.Basic
 import Mathlib.MeasureTheory.Measure.Tight
 import Mathlib.Order.CompletePartialOrder
 
@@ -15,9 +14,8 @@ Criteria for tightness of sets of measures in normed and inner product spaces.
 
 ## Main statements
 
-* `isTightMeasureSet_iff_tendsto_measure_norm_gt`: in a finite dimensional real normed space,
-  a set of measures `S` is tight if and only if the function `r ↦ ⨆ μ ∈ S, μ {x | r < ‖x‖}`
-  tends to `0` at infinity.
+* `isTightMeasureSet_iff_tendsto_measure_norm_gt`: in a proper normed group, a set of measures `S`
+  is tight if and only if the function `r ↦ ⨆ μ ∈ S, μ {x | r < ‖x‖}` tends to `0` at infinity.
 
 -/
 
@@ -27,44 +25,62 @@ open scoped Topology
 
 namespace MeasureTheory
 
-variable {E : Type*} [NormedAddCommGroup E] {mE : MeasurableSpace E} {S : Set (Measure E)}
+variable {E : Type*} {mE : MeasurableSpace E} {S : Set (Measure E)}
 
-section NormedSpace
+section PseudoMetricSpace
 
-lemma tendsto_measure_norm_gt_of_isTightMeasureSet (hS : IsTightMeasureSet S) :
-    Tendsto (fun r : ℝ ↦ ⨆ μ ∈ S, μ {x | r < ‖x‖}) atTop (𝓝 0) := by
-  suffices Tendsto ((⨆ μ ∈ S, μ) ∘ (fun r ↦ {x | r < ‖x‖})) atTop (𝓝 0) by
+variable [PseudoMetricSpace E]
+
+lemma tendsto_measure_compl_closedBall_of_isTightMeasureSet (hS : IsTightMeasureSet S) (x : E) :
+    Tendsto (fun r : ℝ ↦ ⨆ μ ∈ S, μ (Metric.closedBall x r)ᶜ) atTop (𝓝 0) := by
+  suffices Tendsto ((⨆ μ ∈ S, μ) ∘ (fun r ↦ (Metric.closedBall x r)ᶜ)) atTop (𝓝 0) by
     convert this with r
     simp
   refine hS.comp <| .mono_right ?_ <| monotone_smallSets Metric.cobounded_le_cocompact
-  refine HasAntitoneBasis.tendsto_smallSets ?_
-  exact ⟨Filter.atTop_basis_Ioi.cobounded_of_norm, fun _ _ hr x ↦ hr.trans_lt⟩
+  exact (Metric.hasAntitoneBasis_cobounded_compl_closedBall _).tendsto_smallSets
 
-section FiniteDimensional
-
-variable [NormedSpace ℝ E] [FiniteDimensional ℝ E]
-
-lemma isTightMeasureSet_of_tendsto_measure_norm_gt
-    (h : Tendsto (fun r : ℝ ↦ ⨆ μ ∈ S, μ {x | r < ‖x‖}) atTop (𝓝 0)) :
+lemma isTightMeasureSet_of_tendsto_measure_compl_closedBall [ProperSpace E] {x : E}
+    (h : Tendsto (fun r : ℝ ↦ ⨆ μ ∈ S, μ (Metric.closedBall x r)ᶜ) atTop (𝓝 0)) :
     IsTightMeasureSet S := by
   refine IsTightMeasureSet_iff_exists_isCompact_measure_compl_le.mpr fun ε hε ↦ ?_
   rw [ENNReal.tendsto_atTop_zero] at h
   obtain ⟨r, h⟩ := h ε hε
-  refine ⟨Metric.closedBall 0 r, isCompact_closedBall 0 r, ?_⟩
-  specialize h r le_rfl
-  simp only [iSup_le_iff] at h
-  convert h using 4 with μ hμ
+  exact ⟨Metric.closedBall x r, isCompact_closedBall x r, by simpa using h r le_rfl⟩
+
+/-- In a proper pseudo-metric space, a set of measures `S` is tight if and only if
+the function `r ↦ ⨆ μ ∈ S, μ (Metric.closedBall x r)ᶜ` tends to `0` at infinity. -/
+lemma isTightMeasureSet_iff_tendsto_measure_compl_closedBall [ProperSpace E] (x : E) :
+    IsTightMeasureSet S ↔ Tendsto (fun r : ℝ ↦ ⨆ μ ∈ S, μ (Metric.closedBall x r)ᶜ) atTop (𝓝 0) :=
+  ⟨fun hS ↦ tendsto_measure_compl_closedBall_of_isTightMeasureSet hS x,
+    isTightMeasureSet_of_tendsto_measure_compl_closedBall⟩
+
+end PseudoMetricSpace
+
+section NormedAddCommGroup
+
+variable [NormedAddCommGroup E]
+
+lemma tendsto_measure_norm_gt_of_isTightMeasureSet (hS : IsTightMeasureSet S) :
+    Tendsto (fun r : ℝ ↦ ⨆ μ ∈ S, μ {x | r < ‖x‖}) atTop (𝓝 0) := by
+  have h := tendsto_measure_compl_closedBall_of_isTightMeasureSet hS 0
+  convert h using 6 with r
   ext
   simp
 
-/-- In a finite dimensional real normed space, a set of measures `S` is tight if and only if
+lemma isTightMeasureSet_of_tendsto_measure_norm_gt [ProperSpace E]
+    (h : Tendsto (fun r : ℝ ↦ ⨆ μ ∈ S, μ {x | r < ‖x‖}) atTop (𝓝 0)) :
+    IsTightMeasureSet S := by
+  refine isTightMeasureSet_of_tendsto_measure_compl_closedBall (x := 0) ?_
+  convert h using 6 with r
+  ext
+  simp
+
+/-- In a proper normed group, a set of measures `S` is tight if and only if
 the function `r ↦ ⨆ μ ∈ S, μ {x | r < ‖x‖}` tends to `0` at infinity. -/
-lemma isTightMeasureSet_iff_tendsto_measure_norm_gt :
+lemma isTightMeasureSet_iff_tendsto_measure_norm_gt [ProperSpace E] :
     IsTightMeasureSet S ↔ Tendsto (fun r : ℝ ↦ ⨆ μ ∈ S, μ {x | r < ‖x‖}) atTop (𝓝 0) :=
   ⟨tendsto_measure_norm_gt_of_isTightMeasureSet, isTightMeasureSet_of_tendsto_measure_norm_gt⟩
 
-end FiniteDimensional
-
-end NormedSpace
+end NormedAddCommGroup
 
 end MeasureTheory

--- a/Mathlib/MeasureTheory/Measure/TightNormed.lean
+++ b/Mathlib/MeasureTheory/Measure/TightNormed.lean
@@ -1,0 +1,82 @@
+/-
+Copyright (c) 2025 Rémy Degenne. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Rémy Degenne
+-/
+import Mathlib.Analysis.Normed.Module.FiniteDimension
+import Mathlib.Analysis.Normed.Order.Lattice
+import Mathlib.MeasureTheory.Measure.Tight
+import Mathlib.Order.CompletePartialOrder
+
+/-!
+# Tight sets of measures in normed spaces
+
+Criteria for tightness of sets of measures in normed and inner product spaces.
+
+## Main statements
+
+* `isTightMeasureSet_iff_tendsto_measure_norm_gt`: a set of measures `S` is tight if and only if
+  the function `r ↦ ⨆ μ ∈ S, μ {x | r < ‖x‖}` tends to `0` at infinity.
+
+-/
+
+open Filter
+
+open scoped Topology
+
+namespace MeasureTheory
+
+variable {E : Type*} [NormedAddCommGroup E] {mE : MeasurableSpace E} {S : Set (Measure E)}
+
+section NormedSpace
+
+lemma tendsto_measure_norm_gt_of_isTightMeasureSet (hS : IsTightMeasureSet S) :
+    Tendsto (fun r : ℝ ↦ ⨆ μ ∈ S, μ {x | r < ‖x‖}) atTop (𝓝 0) := by
+  suffices Tendsto ((⨆ μ ∈ S, μ) ∘ (fun r ↦ {x | r < ‖x‖})) atTop (𝓝 0) by
+    convert this with r
+    simp
+  refine hS.comp ?_
+  simp only [tendsto_smallSets_iff, mem_cocompact, eventually_atTop, ge_iff_le, forall_exists_index,
+    and_imp]
+  intro s t ht_compact hts
+  rcases Set.eq_empty_or_nonempty t with rfl | ht_nonempty
+  · simp only [Set.compl_empty, Set.univ_subset_iff] at hts
+    simp [hts]
+  obtain ⟨r, h_subset⟩ : ∃ r, t ⊆ {x | ‖x‖ ≤ r} := by
+    obtain ⟨xmax, _, hxmax⟩ : ∃ x ∈ t, IsMaxOn (fun x ↦ ‖x‖) t x :=
+      ht_compact.exists_isMaxOn (f := fun x : E ↦ ‖x‖) ht_nonempty (by fun_prop)
+    exact ⟨‖xmax‖, fun x hxK ↦ hxmax hxK⟩
+  refine ⟨r, fun u hu ↦ subset_trans ?_ hts⟩
+  simp_rw [← not_le]
+  refine Set.compl_subset_compl.mp ?_
+  simp only [compl_compl, not_le]
+  refine h_subset.trans fun x ↦ ?_
+  simp only [Set.mem_setOf_eq, Set.mem_compl_iff, not_lt]
+  exact fun hx ↦ hx.trans hu
+
+section FiniteDimensional
+
+variable [NormedSpace ℝ E] [FiniteDimensional ℝ E]
+
+lemma isTightMeasureSet_of_tendsto_measure_norm_gt
+    (h : Tendsto (fun r : ℝ ↦ ⨆ μ ∈ S, μ {x | r < ‖x‖}) atTop (𝓝 0)) :
+    IsTightMeasureSet S := by
+  refine IsTightMeasureSet_iff_exists_isCompact_measure_compl_le.mpr fun ε hε ↦ ?_
+  rw [ENNReal.tendsto_atTop_zero] at h
+  obtain ⟨r, h⟩ := h ε hε
+  refine ⟨Metric.closedBall 0 r, isCompact_closedBall 0 r, ?_⟩
+  specialize h r le_rfl
+  simp only [iSup_le_iff] at h
+  convert h using 4 with μ hμ
+  ext
+  simp
+
+lemma isTightMeasureSet_iff_tendsto_measure_norm_gt :
+    IsTightMeasureSet S ↔ Tendsto (fun r : ℝ ↦ ⨆ μ ∈ S, μ {x | r < ‖x‖}) atTop (𝓝 0) :=
+  ⟨tendsto_measure_norm_gt_of_isTightMeasureSet, isTightMeasureSet_of_tendsto_measure_norm_gt⟩
+
+end FiniteDimensional
+
+end NormedSpace
+
+end MeasureTheory

--- a/Mathlib/MeasureTheory/Measure/TightNormed.lean
+++ b/Mathlib/MeasureTheory/Measure/TightNormed.lean
@@ -36,24 +36,9 @@ lemma tendsto_measure_norm_gt_of_isTightMeasureSet (hS : IsTightMeasureSet S) :
   suffices Tendsto ((⨆ μ ∈ S, μ) ∘ (fun r ↦ {x | r < ‖x‖})) atTop (𝓝 0) by
     convert this with r
     simp
-  refine hS.comp ?_
-  simp only [tendsto_smallSets_iff, mem_cocompact, eventually_atTop, ge_iff_le, forall_exists_index,
-    and_imp]
-  intro s t ht_compact hts
-  rcases Set.eq_empty_or_nonempty t with rfl | ht_nonempty
-  · simp only [Set.compl_empty, Set.univ_subset_iff] at hts
-    simp [hts]
-  obtain ⟨r, h_subset⟩ : ∃ r, t ⊆ {x | ‖x‖ ≤ r} := by
-    obtain ⟨xmax, _, hxmax⟩ : ∃ x ∈ t, IsMaxOn (fun x ↦ ‖x‖) t x :=
-      ht_compact.exists_isMaxOn (f := fun x : E ↦ ‖x‖) ht_nonempty (by fun_prop)
-    exact ⟨‖xmax‖, fun x hxK ↦ hxmax hxK⟩
-  refine ⟨r, fun u hu ↦ subset_trans ?_ hts⟩
-  simp_rw [← not_le]
-  refine Set.compl_subset_compl.mp ?_
-  simp only [compl_compl, not_le]
-  refine h_subset.trans fun x ↦ ?_
-  simp only [Set.mem_setOf_eq, Set.mem_compl_iff, not_lt]
-  exact fun hx ↦ hx.trans hu
+  refine hS.comp <| .mono_right ?_ <| monotone_smallSets Metric.cobounded_le_cocompact
+  refine HasAntitoneBasis.tendsto_smallSets ?_
+  exact ⟨Filter.atTop_basis_Ioi.cobounded_of_norm, fun _ _ hr x ↦ hr.trans_lt⟩
 
 section FiniteDimensional
 

--- a/Mathlib/MeasureTheory/Measure/TightNormed.lean
+++ b/Mathlib/MeasureTheory/Measure/TightNormed.lean
@@ -15,8 +15,9 @@ Criteria for tightness of sets of measures in normed and inner product spaces.
 
 ## Main statements
 
-* `isTightMeasureSet_iff_tendsto_measure_norm_gt`: a set of measures `S` is tight if and only if
-  the function `r ↦ ⨆ μ ∈ S, μ {x | r < ‖x‖}` tends to `0` at infinity.
+* `isTightMeasureSet_iff_tendsto_measure_norm_gt`: in a finite dimensional real normed space,
+  a set of measures `S` is tight if and only if the function `r ↦ ⨆ μ ∈ S, μ {x | r < ‖x‖}`
+  tends to `0` at infinity.
 
 -/
 
@@ -71,6 +72,8 @@ lemma isTightMeasureSet_of_tendsto_measure_norm_gt
   ext
   simp
 
+/-- In a finite dimensional real normed space, a set of measures `S` is tight if and only if
+the function `r ↦ ⨆ μ ∈ S, μ {x | r < ‖x‖}` tends to `0` at infinity. -/
 lemma isTightMeasureSet_iff_tendsto_measure_norm_gt :
     IsTightMeasureSet S ↔ Tendsto (fun r : ℝ ↦ ⨆ μ ∈ S, μ {x | r < ‖x‖}) atTop (𝓝 0) :=
   ⟨tendsto_measure_norm_gt_of_isTightMeasureSet, isTightMeasureSet_of_tendsto_measure_norm_gt⟩

--- a/Mathlib/Topology/MetricSpace/Bounded.lean
+++ b/Mathlib/Topology/MetricSpace/Bounded.lean
@@ -102,9 +102,17 @@ theorem hasBasis_cobounded_compl_closedBall (c : α) :
     (cobounded α).HasBasis (fun _ ↦ True) (fun r ↦ (closedBall c r)ᶜ) :=
   ⟨compl_surjective.forall.2 fun _ ↦ (isBounded_iff_subset_closedBall c).trans <| by simp⟩
 
+theorem hasAntitoneBasis_cobounded_compl_closedBall (c : α) :
+    (cobounded α).HasAntitoneBasis (fun r ↦ (closedBall c r)ᶜ) :=
+  ⟨Metric.hasBasis_cobounded_compl_closedBall _, fun _ _ hr _ ↦ by simpa using hr.trans_lt⟩
+
 theorem hasBasis_cobounded_compl_ball (c : α) :
     (cobounded α).HasBasis (fun _ ↦ True) (fun r ↦ (ball c r)ᶜ) :=
   ⟨compl_surjective.forall.2 fun _ ↦ (isBounded_iff_subset_ball c).trans <| by simp⟩
+
+theorem hasAntitoneBasis_cobounded_compl_ball (c : α) :
+    (cobounded α).HasAntitoneBasis (fun r ↦ (ball c r)ᶜ) :=
+  ⟨Metric.hasBasis_cobounded_compl_ball _, fun _ _ hr _ ↦ by simpa using hr.trans⟩
 
 @[simp]
 theorem comap_dist_right_atTop (c : α) : comap (dist · c) atTop = cobounded α :=


### PR DESCRIPTION
In a proper normed group, a set of measures `S` is tight if and only if the function `r ↦ ⨆ μ ∈ S, μ {x | r < ‖x‖}` tends to `0` at infinity.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
