### PR TITLE
chore: change UniformGroup to IsUniformGroup

### DIFF
--- a/Mathlib/Analysis/CStarAlgebra/Module/Synonym.lean
+++ b/Mathlib/Analysis/CStarAlgebra/Module/Synonym.lean
@@ -206,8 +206,8 @@ instance [UniformSpace E] [CompleteSpace E] : CompleteSpace (C⋆ᵐᵒᵈ E) :=
 instance [AddCommGroup E] [UniformSpace E] [ContinuousAdd E] : ContinuousAdd (C⋆ᵐᵒᵈ E) :=
   ContinuousAdd.induced (addEquiv E)
 
-instance [AddCommGroup E] [UniformSpace E] [UniformAddGroup E] : UniformAddGroup (C⋆ᵐᵒᵈ E) :=
-  UniformAddGroup.comap (addEquiv E)
+instance [AddCommGroup E] [UniformSpace E] [IsUniformAddGroup E] : IsUniformAddGroup (C⋆ᵐᵒᵈ E) :=
+  IsUniformAddGroup.comap (addEquiv E)
 
 instance [Semiring R] [TopologicalSpace R] [AddCommGroup E] [UniformSpace E] [Module R E]
     [ContinuousSMul R E] : ContinuousSMul R (C⋆ᵐᵒᵈ E) :=

--- a/Mathlib/Analysis/Complex/Circle.lean
+++ b/Mathlib/Analysis/Complex/Circle.lean
@@ -89,7 +89,7 @@ def toUnits : Circle →* Units ℂ := unitSphereToUnits ℂ
 instance : CompactSpace Circle := Metric.sphere.compactSpace _ _
 instance : IsTopologicalGroup Circle := Metric.sphere.topologicalGroup
 instance instUniformSpace : UniformSpace Circle := instUniformSpaceSubtype
-instance : UniformGroup Circle := by
+instance : IsUniformGroup Circle := by
   convert topologicalGroup_is_uniform_of_compactSpace Circle
   exact unique_uniformity_of_compact rfl rfl
 

--- a/Mathlib/Analysis/Convex/TotallyBounded.lean
+++ b/Mathlib/Analysis/Convex/TotallyBounded.lean
@@ -29,7 +29,7 @@ open Set Pointwise
 
 variable (E : Type*) {s : Set E}
 variable [AddCommGroup E] [Module ℝ E]
-variable [UniformSpace E] [UniformAddGroup E] [lcs : LocallyConvexSpace ℝ E] [ContinuousSMul ℝ E]
+variable [UniformSpace E] [IsUniformAddGroup E] [lcs : LocallyConvexSpace ℝ E] [ContinuousSMul ℝ E]
 
 theorem totallyBounded_convexHull (hs : TotallyBounded s) :
     TotallyBounded (convexHull ℝ s) := by

--- a/Mathlib/Analysis/LocallyConvex/Bounded.lean
+++ b/Mathlib/Analysis/LocallyConvex/Bounded.lean
@@ -367,7 +367,7 @@ end Bornology
 section UniformAddGroup
 
 variable (𝕜) [NormedField 𝕜] [AddCommGroup E] [Module 𝕜 E]
-variable [UniformSpace E] [UniformAddGroup E] [ContinuousSMul 𝕜 E]
+variable [UniformSpace E] [IsUniformAddGroup E] [ContinuousSMul 𝕜 E]
 
 theorem TotallyBounded.isVonNBounded {s : Set E} (hs : TotallyBounded s) :
     Bornology.IsVonNBounded 𝕜 s := by
@@ -399,7 +399,7 @@ theorem Filter.Tendsto.isVonNBounded_range [NormedField 𝕜] [AddCommGroup E] [
     [TopologicalSpace E] [IsTopologicalAddGroup E] [ContinuousSMul 𝕜 E]
     {f : ℕ → E} {x : E} (hf : Tendsto f atTop (𝓝 x)) : Bornology.IsVonNBounded 𝕜 (range f) :=
   letI := IsTopologicalAddGroup.toUniformSpace E
-  haveI := uniformAddGroup_of_addCommGroup (G := E)
+  haveI := isUniformAddGroup_of_addCommGroup (G := E)
   hf.cauchySeq.totallyBounded_range.isVonNBounded 𝕜
 
 variable (𝕜) in

--- a/Mathlib/Analysis/Normed/Group/Uniform.lean
+++ b/Mathlib/Analysis/Normed/Group/Uniform.lean
@@ -351,7 +351,7 @@ instance (priority := 100) SeminormedCommGroup.to_lipschitzMul : LipschitzMul E 
 continuous. -/
 @[to_additive "A seminormed group is a uniform additive group, i.e., addition and subtraction are
 uniformly continuous."]
-instance (priority := 100) SeminormedCommGroup.to_uniformGroup : UniformGroup E :=
+instance (priority := 100) SeminormedCommGroup.to_isUniformGroup : IsUniformGroup E :=
   ⟨(LipschitzWith.prod_fst.div LipschitzWith.prod_snd).uniformContinuous⟩
 
 -- short-circuit type class inference

--- a/Mathlib/Analysis/Seminorm.lean
+++ b/Mathlib/Analysis/Seminorm.lean
@@ -1072,7 +1072,7 @@ theorem continuousAt_zero [TopologicalSpace E] [ContinuousConstSMul 𝕜 E] {p :
     (hp : p.ball 0 r ∈ (𝓝 0 : Filter E)) : ContinuousAt p 0 :=
   continuousAt_zero' (Filter.mem_of_superset hp <| p.ball_subset_closedBall _ _)
 
-protected theorem uniformContinuous_of_continuousAt_zero [UniformSpace E] [UniformAddGroup E]
+protected theorem uniformContinuous_of_continuousAt_zero [UniformSpace E] [IsUniformAddGroup E]
     {p : Seminorm 𝕝 E} (hp : ContinuousAt p 0) : UniformContinuous p := by
   have hp : Filter.Tendsto p (𝓝 0) (𝓝 0) := map_zero p ▸ hp
   rw [UniformContinuous, uniformity_eq_comap_nhds_zero_swapped,
@@ -1084,18 +1084,18 @@ protected theorem uniformContinuous_of_continuousAt_zero [UniformSpace E] [Unifo
 protected theorem continuous_of_continuousAt_zero [TopologicalSpace E] [IsTopologicalAddGroup E]
     {p : Seminorm 𝕝 E} (hp : ContinuousAt p 0) : Continuous p := by
   letI := IsTopologicalAddGroup.toUniformSpace E
-  haveI : UniformAddGroup E := uniformAddGroup_of_addCommGroup
+  haveI : IsUniformAddGroup E := isUniformAddGroup_of_addCommGroup
   exact (Seminorm.uniformContinuous_of_continuousAt_zero hp).continuous
 
 /-- A seminorm is uniformly continuous if `p.ball 0 r ∈ 𝓝 0` for *all* `r > 0`.
 Over a `NontriviallyNormedField` it is actually enough to check that this is true
 for *some* `r`, see `Seminorm.uniformContinuous`. -/
-protected theorem uniformContinuous_of_forall [UniformSpace E] [UniformAddGroup E]
+protected theorem uniformContinuous_of_forall [UniformSpace E] [IsUniformAddGroup E]
     {p : Seminorm 𝕝 E} (hp : ∀ r > 0, p.ball 0 r ∈ (𝓝 0 : Filter E)) :
     UniformContinuous p :=
   Seminorm.uniformContinuous_of_continuousAt_zero (continuousAt_zero_of_forall hp)
 
-protected theorem uniformContinuous [UniformSpace E] [UniformAddGroup E] [ContinuousConstSMul 𝕜 E]
+protected theorem uniformContinuous [UniformSpace E] [IsUniformAddGroup E] [ContinuousConstSMul 𝕜 E]
     {p : Seminorm 𝕜 E} {r : ℝ} (hp : p.ball 0 r ∈ (𝓝 0 : Filter E)) :
     UniformContinuous p :=
   Seminorm.uniformContinuous_of_continuousAt_zero (continuousAt_zero hp)
@@ -1103,13 +1103,14 @@ protected theorem uniformContinuous [UniformSpace E] [UniformAddGroup E] [Contin
 /-- A seminorm is uniformly continuous if `p.closedBall 0 r ∈ 𝓝 0` for *all* `r > 0`.
 Over a `NontriviallyNormedField` it is actually enough to check that this is true
 for *some* `r`, see `Seminorm.uniformContinuous'`. -/
-protected theorem uniformContinuous_of_forall' [UniformSpace E] [UniformAddGroup E]
+protected theorem uniformContinuous_of_forall' [UniformSpace E] [IsUniformAddGroup E]
     {p : Seminorm 𝕝 E} (hp : ∀ r > 0, p.closedBall 0 r ∈ (𝓝 0 : Filter E)) :
     UniformContinuous p :=
   Seminorm.uniformContinuous_of_continuousAt_zero (continuousAt_zero_of_forall' hp)
 
-protected theorem uniformContinuous' [UniformSpace E] [UniformAddGroup E] [ContinuousConstSMul 𝕜 E]
-    {p : Seminorm 𝕜 E} {r : ℝ} (hp : p.closedBall 0 r ∈ (𝓝 0 : Filter E)) :
+protected theorem uniformContinuous' [UniformSpace E] [IsUniformAddGroup E]
+    [ContinuousConstSMul 𝕜 E] {p : Seminorm 𝕜 E} {r : ℝ}
+    (hp : p.closedBall 0 r ∈ (𝓝 0 : Filter E)) :
     UniformContinuous p :=
   Seminorm.uniformContinuous_of_continuousAt_zero (continuousAt_zero' hp)
 
@@ -1152,11 +1153,12 @@ lemma ball_mem_nhds [TopologicalSpace E] {p : Seminorm 𝕝 E} (hp : Continuous 
   by simpa only [p.ball_zero_eq] using this (Iio_mem_nhds hr)
 
 lemma uniformSpace_eq_of_hasBasis
-    {ι} [UniformSpace E] [UniformAddGroup E] [ContinuousConstSMul 𝕜 E]
+    {ι} [UniformSpace E] [IsUniformAddGroup E] [ContinuousConstSMul 𝕜 E]
     {p' : ι → Prop} {s : ι → Set E} (p : Seminorm 𝕜 E) (hb : (𝓝 0 : Filter E).HasBasis p' s)
     (h₁ : ∃ r, p.closedBall 0 r ∈ 𝓝 0) (h₂ : ∀ i, p' i → ∃ r > 0, p.ball 0 r ⊆ s i) :
     ‹UniformSpace E› = p.toAddGroupSeminorm.toSeminormedAddGroup.toUniformSpace := by
-  refine UniformAddGroup.ext ‹_› p.toAddGroupSeminorm.toSeminormedAddCommGroup.to_uniformAddGroup ?_
+  refine IsUniformAddGroup.ext ‹_›
+    p.toAddGroupSeminorm.toSeminormedAddCommGroup.to_isUniformAddGroup ?_
   apply le_antisymm
   · rw [← @comap_norm_nhds_zero E p.toAddGroupSeminorm.toSeminormedAddGroup, ← tendsto_iff_comap]
     suffices Continuous p from this.tendsto' 0 _ (map_zero p)
@@ -1167,7 +1169,7 @@ lemma uniformSpace_eq_of_hasBasis
     simpa only [subset_def, mem_ball_zero] using h₂
 
 lemma uniformity_eq_of_hasBasis
-    {ι} [UniformSpace E] [UniformAddGroup E] [ContinuousConstSMul 𝕜 E]
+    {ι} [UniformSpace E] [IsUniformAddGroup E] [ContinuousConstSMul 𝕜 E]
     {p' : ι → Prop} {s : ι → Set E} (p : Seminorm 𝕜 E) (hb : (𝓝 0 : Filter E).HasBasis p' s)
     (h₁ : ∃ r, p.closedBall 0 r ∈ 𝓝 0) (h₂ : ∀ i, p' i → ∃ r > 0, p.ball 0 r ⊆ s i) :
     𝓤 E = ⨅ r > 0, 𝓟 {x | p (x.1 - x.2) < r} := by

--- a/Mathlib/RingTheory/MvPowerSeries/PiTopology.lean
+++ b/Mathlib/RingTheory/MvPowerSeries/PiTopology.lean
@@ -217,8 +217,8 @@ theorem instCompleteSpace [CompleteSpace R] :
 
 /-- The `UniformAddGroup` structure on `MvPowerSeries` of a `UniformAddGroup` -/
 @[scoped instance]
-theorem instUniformAddGroup [AddGroup R] [UniformAddGroup R] :
-    UniformAddGroup (MvPowerSeries σ R) := Pi.instUniformAddGroup
+theorem instUniformAddGroup [AddGroup R] [IsUniformAddGroup R] :
+    IsUniformAddGroup (MvPowerSeries σ R) := Pi.instIsUniformAddGroup
 
 end Uniformity
 

--- a/Mathlib/Topology/Algebra/Algebra.lean
+++ b/Mathlib/Topology/Algebra/Algebra.lean
@@ -152,8 +152,8 @@ instance : ContinuousMapClass (A →A[R] B) A B where
 protected theorem continuous (f : A →A[R] B) : Continuous f := f.2
 
 protected theorem uniformContinuous {E₁ E₂ : Type*} [UniformSpace E₁] [UniformSpace E₂]
-    [Ring E₁] [Ring E₂] [Algebra R E₁] [Algebra R E₂] [UniformAddGroup E₁]
-    [UniformAddGroup E₂] (f : E₁ →A[R] E₂) : UniformContinuous f :=
+    [Ring E₁] [Ring E₂] [Algebra R E₁] [Algebra R E₂] [IsUniformAddGroup E₁]
+    [IsUniformAddGroup E₂] (f : E₁ →A[R] E₂) : UniformContinuous f :=
   uniformContinuous_addMonoidHom_of_continuous f.continuous
 
 /-- See Note [custom simps projection]. We need to specify this projection explicitly in this case,

--- a/Mathlib/Topology/Algebra/Algebra/Equiv.lean
+++ b/Mathlib/Topology/Algebra/Algebra/Equiv.lean
@@ -285,13 +285,13 @@ theorem preimage_symm_preimage (e : A ≃A[R] B) (S : Set A) : e ⁻¹' (e.symm 
   e.symm.symm_preimage_preimage S
 
 theorem isUniformEmbedding {E₁ E₂ : Type*} [UniformSpace E₁] [UniformSpace E₂] [Ring E₁]
-    [UniformAddGroup E₁] [Algebra R E₁] [Ring E₂] [UniformAddGroup E₂] [Algebra R E₂]
+    [IsUniformAddGroup E₁] [Algebra R E₁] [Ring E₂] [IsUniformAddGroup E₂] [Algebra R E₂]
     (e : E₁ ≃A[R] E₂) : IsUniformEmbedding e :=
   e.toAlgEquiv.isUniformEmbedding e.toContinuousAlgHom.uniformContinuous
     e.symm.toContinuousAlgHom.uniformContinuous
 
 theorem _root_.AlgEquiv.isUniformEmbedding {E₁ E₂ : Type*} [UniformSpace E₁] [UniformSpace E₂]
-    [Ring E₁] [UniformAddGroup E₁] [Algebra R E₁] [Ring E₂] [UniformAddGroup E₂] [Algebra R E₂]
+    [Ring E₁] [IsUniformAddGroup E₁] [Algebra R E₁] [Ring E₂] [IsUniformAddGroup E₂] [Algebra R E₂]
     (e : E₁ ≃ₐ[R] E₂) (h₁ : Continuous e) (h₂ : Continuous e.symm) :
     IsUniformEmbedding e :=
   ContinuousAlgEquiv.isUniformEmbedding { e with continuous_toFun := h₁ }

--- a/Mathlib/Topology/Algebra/Equicontinuity.lean
+++ b/Mathlib/Topology/Algebra/Equicontinuity.lean
@@ -17,7 +17,7 @@ open UniformConvergence
 
 @[to_additive]
 theorem equicontinuous_of_equicontinuousAt_one {ι G M hom : Type*} [TopologicalSpace G]
-    [UniformSpace M] [Group G] [Group M] [IsTopologicalGroup G] [UniformGroup M]
+    [UniformSpace M] [Group G] [Group M] [IsTopologicalGroup G] [IsUniformGroup M]
     [FunLike hom G M] [MonoidHomClass hom G M] (F : ι → hom)
     (hf : EquicontinuousAt ((↑) ∘ F) (1 : G)) :
     Equicontinuous ((↑) ∘ F) := by
@@ -31,7 +31,7 @@ theorem equicontinuous_of_equicontinuousAt_one {ι G M hom : Type*} [Topological
 
 @[to_additive]
 theorem uniformEquicontinuous_of_equicontinuousAt_one {ι G M hom : Type*} [UniformSpace G]
-    [UniformSpace M] [Group G] [Group M] [UniformGroup G] [UniformGroup M]
+    [UniformSpace M] [Group G] [Group M] [IsUniformGroup G] [IsUniformGroup M]
     [FunLike hom G M] [MonoidHomClass hom G M]
     (F : ι → hom) (hf : EquicontinuousAt ((↑) ∘ F) (1 : G)) :
     UniformEquicontinuous ((↑) ∘ F) := by

--- a/Mathlib/Topology/Algebra/Group/CompactOpen.lean
+++ b/Mathlib/Topology/Algebra/Group/CompactOpen.lean
@@ -136,7 +136,7 @@ def compRight {B : Type*} [CommGroup B] [TopologicalSpace B] [IsTopologicalGroup
 section LocallyCompact
 
 variable {X Y : Type*} [TopologicalSpace X] [Group X] [IsTopologicalGroup X]
-  [UniformSpace Y] [CommGroup Y] [UniformGroup Y] [T0Space Y] [CompactSpace Y]
+  [UniformSpace Y] [CommGroup Y] [IsUniformGroup Y] [T0Space Y] [CompactSpace Y]
 
 @[to_additive]
 theorem locallyCompactSpace_of_equicontinuousAt (U : Set X) (V : Set Y)

--- a/Mathlib/Topology/Algebra/GroupCompletion.lean
+++ b/Mathlib/Topology/Algebra/GroupCompletion.lean
@@ -75,7 +75,7 @@ end Zero
 
 section UniformAddGroup
 
-variable [UniformSpace α] [AddGroup α] [UniformAddGroup α]
+variable [UniformSpace α] [AddGroup α] [IsUniformAddGroup α]
 
 @[norm_cast]
 theorem coe_neg (a : α) : ((-a : α) : Completion α) = -a :=
@@ -156,7 +156,7 @@ instance addGroup : AddGroup (Completion α) :=
           rw_mod_cast [neg_add_cancel]
           rfl }
 
-instance uniformAddGroup : UniformAddGroup (Completion α) :=
+instance uniformAddGroup : IsUniformAddGroup (Completion α) :=
   ⟨uniformContinuous_map₂ Sub.sub⟩
 
 instance {M} [Monoid M] [DistribMulAction M α] [UniformContinuousConstSMul M α] :
@@ -187,7 +187,7 @@ end UniformAddGroup
 
 section UniformAddCommGroup
 
-variable [UniformSpace α] [AddCommGroup α] [UniformAddGroup α]
+variable [UniformSpace α] [AddCommGroup α] [IsUniformAddGroup α]
 
 instance instAddCommGroup : AddCommGroup (Completion α) :=
   { (inferInstance : AddGroup <| Completion α) with
@@ -214,8 +214,8 @@ end UniformSpace.Completion
 
 section AddMonoidHom
 
-variable [UniformSpace α] [AddGroup α] [UniformAddGroup α] [UniformSpace β] [AddGroup β]
-  [UniformAddGroup β]
+variable [UniformSpace α] [AddGroup α] [IsUniformAddGroup α] [UniformSpace β] [AddGroup β]
+  [IsUniformAddGroup β]
 
 open UniformSpace UniformSpace.Completion
 
@@ -266,7 +266,7 @@ theorem AddMonoidHom.completion_zero :
     simp [(0 : α →+ β).completion_coe continuous_const, coe_zero]
 
 theorem AddMonoidHom.completion_add {γ : Type*} [AddCommGroup γ] [UniformSpace γ]
-    [UniformAddGroup γ] (f g : α →+ γ) (hf : Continuous f) (hg : Continuous g) :
+    [IsUniformAddGroup γ] (f g : α →+ γ) (hf : Continuous f) (hg : Continuous g) :
     AddMonoidHom.completion (f + g) (hf.add hg) =
     AddMonoidHom.completion f hf + AddMonoidHom.completion g hg := by
   have hfg := hf.add hg

--- a/Mathlib/Topology/Algebra/InfiniteSum/Constructions.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/Constructions.lean
@@ -186,7 +186,7 @@ end ContinuousMul
 
 section CompleteSpace
 
-variable [CommGroup α] [UniformSpace α] [UniformGroup α]
+variable [CommGroup α] [UniformSpace α] [IsUniformGroup α]
 
 @[to_additive]
 theorem HasProd.of_sigma {γ : β → Type*} {f : (Σ b : β, γ b) → α} {g : β → α} {a : α}

--- a/Mathlib/Topology/Algebra/InfiniteSum/Group.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/Group.lean
@@ -198,7 +198,7 @@ theorem multipliable_iff_cauchySeq_finset [CompleteSpace α] {f : β → α} :
     Multipliable f ↔ CauchySeq fun s : Finset β ↦ ∏ b ∈ s, f b := by
   classical exact cauchy_map_iff_exists_tendsto.symm
 
-variable [UniformGroup α] {f g : β → α}
+variable [IsUniformGroup α] {f g : β → α}
 
 @[to_additive]
 theorem cauchySeq_finset_iff_prod_vanishing :
@@ -322,7 +322,7 @@ theorem Multipliable.vanishing (hf : Multipliable f) ⦃e : Set G⦄ (he : e ∈
     ∃ s : Finset α, ∀ t, Disjoint t s → (∏ k ∈ t, f k) ∈ e := by
   classical
   letI : UniformSpace G := IsTopologicalGroup.toUniformSpace G
-  have : UniformGroup G := uniformGroup_of_commGroup
+  have : IsUniformGroup G := isUniformGroup_of_commGroup
   exact cauchySeq_finset_iff_prod_vanishing.1 hf.hasProd.cauchySeq e he
 
 @[to_additive]
@@ -330,7 +330,7 @@ theorem Multipliable.tprod_vanishing (hf : Multipliable f) ⦃e : Set G⦄ (he :
     ∃ s : Finset α, ∀ t : Set α, Disjoint t s → (∏' b : t, f b) ∈ e := by
   classical
   letI : UniformSpace G := IsTopologicalGroup.toUniformSpace G
-  have : UniformGroup G := uniformGroup_of_commGroup
+  have : IsUniformGroup G := isUniformGroup_of_commGroup
   exact cauchySeq_finset_iff_tprod_vanishing.1 hf.hasProd.cauchySeq e he
 
 /-- The product over the complement of a finset tends to `1` when the finset grows to cover the

--- a/Mathlib/Topology/Algebra/InfiniteSum/GroupCompletion.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/GroupCompletion.lean
@@ -12,7 +12,7 @@ import Mathlib.Topology.Algebra.InfiniteSum.Group
 
 open UniformSpace.Completion
 
-variable {α β : Type*} [AddCommGroup α] [UniformSpace α] [UniformAddGroup α]
+variable {α β : Type*} [AddCommGroup α] [UniformSpace α] [IsUniformAddGroup α]
 
 /-- A function `f` has a sum in an uniform additive group `α` if and only if it has that sum in the
 completion of `α`. -/

--- a/Mathlib/Topology/Algebra/InfiniteSum/NatInt.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/NatInt.lean
@@ -259,7 +259,7 @@ end IsTopologicalGroup
 
 section UniformGroup
 
-variable [UniformSpace G] [UniformGroup G]
+variable [UniformSpace G] [IsUniformGroup G]
 
 @[to_additive]
 theorem cauchySeq_finset_iff_nat_tprod_vanishing {f : ℕ → G} :
@@ -293,7 +293,7 @@ variable [TopologicalSpace G] [IsTopologicalGroup G]
 theorem Multipliable.nat_tprod_vanishing {f : ℕ → G} (hf : Multipliable f) ⦃e : Set G⦄
     (he : e ∈ 𝓝 1) : ∃ N : ℕ, ∀ t ⊆ {n | N ≤ n}, (∏' n : t, f n) ∈ e :=
   letI : UniformSpace G := IsTopologicalGroup.toUniformSpace G
-  have : UniformGroup G := uniformGroup_of_commGroup
+  have : IsUniformGroup G := isUniformGroup_of_commGroup
   cauchySeq_finset_iff_nat_tprod_vanishing.1 hf.hasProd.cauchySeq e he
 
 @[to_additive]
@@ -494,9 +494,9 @@ lemma tprod_of_nat_of_neg [T2Space G] {f : ℤ → G}
 
 end IsTopologicalGroup
 
-section UniformGroup -- results which depend on completeness
+section IsUniformGroup -- results which depend on completeness
 
-variable [UniformSpace G] [UniformGroup G] [CompleteSpace G]
+variable [UniformSpace G] [IsUniformGroup G] [CompleteSpace G]
 
 /-- "iff" version of `Multipliable.of_nat_of_neg_add_one`. -/
 @[to_additive "\"iff\" version of `Summable.of_nat_of_neg_add_one`."]
@@ -514,7 +514,7 @@ lemma multipliable_int_iff_multipliable_nat_and_neg {f : ℤ → G} :
   apply p.comp_injective
   exacts [Nat.cast_injective, neg_injective.comp Nat.cast_injective]
 
-end UniformGroup
+end IsUniformGroup
 
 end Int
 

--- a/Mathlib/Topology/Algebra/InfiniteSum/Order.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/Order.lean
@@ -72,7 +72,7 @@ theorem tprod_le_tprod_of_inj {g : κ → α} (e : ι → κ) (he : Injective e)
   hasProd_le_inj _ he hs h hf.hasProd hg.hasProd
 
 @[to_additive]
-lemma tprod_subtype_le {κ γ : Type*} [OrderedCommGroup γ] [UniformSpace γ] [UniformGroup γ]
+lemma tprod_subtype_le {κ γ : Type*} [OrderedCommGroup γ] [UniformSpace γ] [IsUniformGroup γ]
     [OrderClosedTopology γ] [CompleteSpace γ] (f : κ → γ) (β : Set κ) (h : ∀ a : κ, 1 ≤ f a)
     (hf : Multipliable f) : (∏' (b : β), f b) ≤ (∏' (a : κ), f a) := by
   apply tprod_le_tprod_of_inj _
@@ -263,7 +263,7 @@ theorem hasProd_of_isLUB [LinearOrderedCommMonoid α] [CanonicallyOrderedMul α]
   tendsto_atTop_isLUB (Finset.prod_mono_set' f) hf
 
 @[to_additive]
-theorem multipliable_mabs_iff [LinearOrderedCommGroup α] [UniformSpace α] [UniformGroup α]
+theorem multipliable_mabs_iff [LinearOrderedCommGroup α] [UniformSpace α] [IsUniformGroup α]
     [CompleteSpace α] {f : ι → α} : (Multipliable fun x ↦ mabs (f x)) ↔ Multipliable f :=
   let s := { x | 1 ≤ f x }
   have h1 : ∀ x : s, mabs (f x) = f x := fun x ↦ mabs_of_one_le x.2

--- a/Mathlib/Topology/Algebra/Module/Equiv.lean
+++ b/Mathlib/Topology/Algebra/Module/Equiv.lean
@@ -464,8 +464,8 @@ protected theorem preimage_symm_preimage (e : M₁ ≃SL[σ₁₂] M₂) (s : Se
   e.symm.symm_preimage_preimage s
 
 lemma isUniformEmbedding {E₁ E₂ : Type*} [UniformSpace E₁] [UniformSpace E₂]
-    [AddCommGroup E₁] [AddCommGroup E₂] [Module R₁ E₁] [Module R₂ E₂] [UniformAddGroup E₁]
-    [UniformAddGroup E₂] (e : E₁ ≃SL[σ₁₂] E₂) : IsUniformEmbedding e :=
+    [AddCommGroup E₁] [AddCommGroup E₂] [Module R₁ E₁] [Module R₂ E₂] [IsUniformAddGroup E₁]
+    [IsUniformAddGroup E₂] (e : E₁ ≃SL[σ₁₂] E₂) : IsUniformEmbedding e :=
   e.toLinearEquiv.toEquiv.isUniformEmbedding e.toContinuousLinearMap.uniformContinuous
     e.symm.toContinuousLinearMap.uniformContinuous
 
@@ -473,7 +473,7 @@ lemma isUniformEmbedding {E₁ E₂ : Type*} [UniformSpace E₁] [UniformSpace E
 
 protected theorem _root_.LinearEquiv.isUniformEmbedding {E₁ E₂ : Type*} [UniformSpace E₁]
     [UniformSpace E₂] [AddCommGroup E₁] [AddCommGroup E₂] [Module R₁ E₁] [Module R₂ E₂]
-    [UniformAddGroup E₁] [UniformAddGroup E₂] (e : E₁ ≃ₛₗ[σ₁₂] E₂)
+    [IsUniformAddGroup E₁] [IsUniformAddGroup E₂] (e : E₁ ≃ₛₗ[σ₁₂] E₂)
     (h₁ : Continuous e) (h₂ : Continuous e.symm) : IsUniformEmbedding e :=
   ContinuousLinearEquiv.isUniformEmbedding
     ({ e with

--- a/Mathlib/Topology/Algebra/Module/FiniteDimension.lean
+++ b/Mathlib/Topology/Algebra/Module/FiniteDimension.lean
@@ -191,7 +191,7 @@ variable [CompleteSpace 𝕜]
 private theorem continuous_equivFun_basis_aux [T2Space E] {ι : Type v} [Fintype ι]
     (ξ : Basis ι 𝕜 E) : Continuous ξ.equivFun := by
   letI : UniformSpace E := IsTopologicalAddGroup.toUniformSpace E
-  letI : UniformAddGroup E := uniformAddGroup_of_addCommGroup
+  letI : IsUniformAddGroup E := isUniformAddGroup_of_addCommGroup
   suffices ∀ n, Fintype.card ι = n → Continuous ξ.equivFun by exact this _ rfl
   intro n hn
   induction n generalizing ι E with
@@ -204,7 +204,7 @@ private theorem continuous_equivFun_basis_aux [T2Space E] {ι : Type v} [Fintype
     -- to a standard space of dimension n, hence it is complete and therefore closed.
     have H₁ : ∀ s : Submodule 𝕜 E, finrank 𝕜 s = n → IsClosed (s : Set E) := by
       intro s s_dim
-      letI : UniformAddGroup s := s.toAddSubgroup.uniformAddGroup
+      letI : IsUniformAddGroup s := s.toAddSubgroup.isUniformAddGroup
       let b := Basis.ofVectorSpace 𝕜 s
       have U : IsUniformEmbedding b.equivFun.symm.toEquiv := by
         have : Fintype.card (Basis.ofVectorSpaceIndex 𝕜 s) = n := by
@@ -485,7 +485,7 @@ end NormedField
 section UniformAddGroup
 
 variable (𝕜 E : Type*) [NontriviallyNormedField 𝕜]
-  [CompleteSpace 𝕜] [AddCommGroup E] [UniformSpace E] [T2Space E] [UniformAddGroup E]
+  [CompleteSpace 𝕜] [AddCommGroup E] [UniformSpace E] [T2Space E] [IsUniformAddGroup E]
   [Module 𝕜 E] [ContinuousSMul 𝕜 E]
 
 include 𝕜 in
@@ -499,7 +499,7 @@ variable {𝕜 E}
 /-- A finite-dimensional subspace is complete. -/
 theorem Submodule.complete_of_finiteDimensional (s : Submodule 𝕜 E) [FiniteDimensional 𝕜 s] :
     IsComplete (s : Set E) :=
-  haveI : UniformAddGroup s := s.toAddSubgroup.uniformAddGroup
+  haveI : IsUniformAddGroup s := s.toAddSubgroup.isUniformAddGroup
   completeSpace_coe_iff_isComplete.1 (FiniteDimensional.complete 𝕜 s)
 
 end UniformAddGroup
@@ -515,7 +515,7 @@ theorem Submodule.closed_of_finiteDimensional
     [T2Space E] (s : Submodule 𝕜 E) [FiniteDimensional 𝕜 s] :
     IsClosed (s : Set E) :=
   letI := IsTopologicalAddGroup.toUniformSpace E
-  haveI : UniformAddGroup E := uniformAddGroup_of_addCommGroup
+  haveI : IsUniformAddGroup E := isUniformAddGroup_of_addCommGroup
   s.complete_of_finiteDimensional.isClosed
 
 /-- An injective linear map with finite-dimensional domain is a closed embedding. -/

--- a/Mathlib/Topology/Algebra/Module/LinearMap.lean
+++ b/Mathlib/Topology/Algebra/Module/LinearMap.lean
@@ -107,8 +107,8 @@ protected theorem continuous (f : M₁ →SL[σ₁₂] M₂) : Continuous f :=
   f.2
 
 protected theorem uniformContinuous {E₁ E₂ : Type*} [UniformSpace E₁] [UniformSpace E₂]
-    [AddCommGroup E₁] [AddCommGroup E₂] [Module R₁ E₁] [Module R₂ E₂] [UniformAddGroup E₁]
-    [UniformAddGroup E₂] (f : E₁ →SL[σ₁₂] E₂) : UniformContinuous f :=
+    [AddCommGroup E₁] [AddCommGroup E₂] [Module R₁ E₁] [Module R₂ E₂] [IsUniformAddGroup E₁]
+    [IsUniformAddGroup E₂] (f : E₁ →SL[σ₁₂] E₂) : UniformContinuous f :=
   uniformContinuous_addMonoidHom_of_continuous f.continuous
 
 @[simp, norm_cast]

--- a/Mathlib/Topology/Algebra/Module/LocallyConvex.lean
+++ b/Mathlib/Topology/Algebra/Module/LocallyConvex.lean
@@ -132,7 +132,7 @@ theorem Disjoint.exists_open_convexes [LocallyConvexSpace 𝕜 E] {s t : Set E} 
     (hs₁ : Convex 𝕜 s) (hs₂ : IsCompact s) (ht₁ : Convex 𝕜 t) (ht₂ : IsClosed t) :
     ∃ u v, IsOpen u ∧ IsOpen v ∧ Convex 𝕜 u ∧ Convex 𝕜 v ∧ s ⊆ u ∧ t ⊆ v ∧ Disjoint u v := by
   letI : UniformSpace E := IsTopologicalAddGroup.toUniformSpace E
-  haveI : UniformAddGroup E := uniformAddGroup_of_addCommGroup
+  haveI : IsUniformAddGroup E := isUniformAddGroup_of_addCommGroup
   have := (LocallyConvexSpace.convex_open_basis_zero 𝕜 E).comap fun x : E × E => x.2 - x.1
   rw [← uniformity_eq_comap_nhds_zero] at this
   rcases disj.exists_uniform_thickening_of_basis this hs₂ ht₂ with ⟨V, ⟨hV0, hVopen, hVconvex⟩, hV⟩

--- a/Mathlib/Topology/Algebra/Nonarchimedean/AdicTopology.lean
+++ b/Mathlib/Topology/Algebra/Nonarchimedean/AdicTopology.lean
@@ -224,8 +224,8 @@ instance (priority := 100) : NonarchimedeanRing R :=
 instance (priority := 100) : UniformSpace R :=
   IsTopologicalAddGroup.toUniformSpace R
 
-instance (priority := 100) : UniformAddGroup R :=
-  uniformAddGroup_of_addCommGroup
+instance (priority := 100) : IsUniformAddGroup R :=
+  isUniformAddGroup_of_addCommGroup
 
 /-- The adic topology on an `R` module coming from the ideal `WithIdeal.I`.
 This cannot be an instance because `R` cannot be inferred from `M`. -/

--- a/Mathlib/Topology/Algebra/Nonarchimedean/Completion.lean
+++ b/Mathlib/Topology/Algebra/Nonarchimedean/Completion.lean
@@ -18,8 +18,8 @@ The completion of a nonarchimedean ring is a nonarchimedean ring.
 open UniformSpace UniformSpace.Completion AddSubgroup OpenAddSubgroup Topology
 
 /-- The completion of a nonarchimedean additive group is a nonarchimedean additive group. -/
-instance {G : Type*} [AddGroup G] [UniformSpace G] [UniformAddGroup G] [NonarchimedeanAddGroup G] :
-    NonarchimedeanAddGroup (Completion G) where
+instance {G : Type*} [AddGroup G] [UniformSpace G] [IsUniformAddGroup G]
+    [NonarchimedeanAddGroup G] : NonarchimedeanAddGroup (Completion G) where
   is_nonarchimedean := by
     /- Let `U` be a neighborhood of `0` in `Completion G`. We wish to show that `U` contains an open
     additive subgroup of `Completion G`. -/
@@ -60,7 +60,7 @@ instance {G : Type*} [AddGroup G] [UniformSpace G] [UniformAddGroup G] [Nonarchi
     exact closure_minimal (Set.image_subset_iff.mpr hCW) C_closed
 
 /-- The completion of a nonarchimedean ring is a nonarchimedean ring. -/
-instance {R : Type*} [Ring R] [UniformSpace R] [IsTopologicalRing R] [UniformAddGroup R]
+instance {R : Type*} [Ring R] [UniformSpace R] [IsTopologicalRing R] [IsUniformAddGroup R]
     [NonarchimedeanRing R] :
     NonarchimedeanRing (Completion R) where
   is_nonarchimedean := NonarchimedeanAddGroup.is_nonarchimedean

--- a/Mathlib/Topology/Algebra/Ring/Real.lean
+++ b/Mathlib/Topology/Algebra/Ring/Real.lean
@@ -44,8 +44,8 @@ theorem Real.uniformContinuous_neg : UniformContinuous (@Neg.neg ℝ _) :=
   Metric.uniformContinuous_iff.2 fun ε ε0 =>
     ⟨_, ε0, fun _ _ h => by simpa only [abs_sub_comm, Real.dist_eq, neg_sub_neg] using h⟩
 
-instance : UniformAddGroup ℝ :=
-  UniformAddGroup.mk' Real.uniformContinuous_add Real.uniformContinuous_neg
+instance : IsUniformAddGroup ℝ :=
+  IsUniformAddGroup.mk' Real.uniformContinuous_add Real.uniformContinuous_neg
 
 theorem Real.uniformContinuous_const_mul {x : ℝ} : UniformContinuous (x * ·) :=
   uniformContinuous_of_continuousAt_zero (DistribMulAction.toAddMonoidHom ℝ x)

--- a/Mathlib/Topology/Algebra/SeparationQuotient/Basic.lean
+++ b/Mathlib/Topology/Algebra/SeparationQuotient/Basic.lean
@@ -205,8 +205,8 @@ end Group
 section UniformGroup
 
 @[to_additive]
-instance instUniformGroup {G : Type*} [Group G] [UniformSpace G] [UniformGroup G] :
-    UniformGroup (SeparationQuotient G) where
+instance instUniformGroup {G : Type*} [Group G] [UniformSpace G] [IsUniformGroup G] :
+    IsUniformGroup (SeparationQuotient G) where
   uniformContinuous_div := by
     rw [uniformContinuous_dom₂]
     exact uniformContinuous_mk.comp uniformContinuous_div

--- a/Mathlib/Topology/Algebra/SeparationQuotient/Section.lean
+++ b/Mathlib/Topology/Algebra/SeparationQuotient/Section.lean
@@ -75,7 +75,7 @@ end VectorSpace
 section VectorSpaceUniform
 
 variable (K E : Type*) [DivisionRing K] [AddCommGroup E] [Module K E]
-    [UniformSpace E] [UniformAddGroup E] [ContinuousConstSMul K E]
+    [UniformSpace E] [IsUniformAddGroup E] [ContinuousConstSMul K E]
 
 theorem outCLM_isUniformInducing : IsUniformInducing (outCLM K E) := by
   rw [← isUniformInducing_mk.isUniformInducing_comp_iff, mk_comp_outCLM]

--- a/Mathlib/Topology/Algebra/UniformConvergence.lean
+++ b/Mathlib/Topology/Algebra/UniformConvergence.lean
@@ -207,12 +207,12 @@ end AlgebraicInstances
 
 section Group
 
-variable {α G ι : Type*} [Group G] {𝔖 : Set <| Set α} [UniformSpace G] [UniformGroup G]
+variable {α G ι : Type*} [Group G] {𝔖 : Set <| Set α} [UniformSpace G] [IsUniformGroup G]
 
 /-- If `G` is a uniform group, then `α →ᵤ G` is a uniform group as well. -/
 @[to_additive "If `G` is a uniform additive group,
 then `α →ᵤ G` is a uniform additive group as well."]
-instance : UniformGroup (α →ᵤ G) :=
+instance : IsUniformGroup (α →ᵤ G) :=
   ⟨(-- Since `(/) : G × G → G` is uniformly continuous,
     -- `UniformFun.postcomp_uniformContinuous` tells us that
     -- `((/) ∘ —) : (α →ᵤ G × G) → (α →ᵤ G)` is uniformly continuous too. By precomposing with
@@ -238,7 +238,7 @@ protected theorem UniformFun.hasBasis_nhds_one :
 well. -/
 @[to_additive "Let `𝔖 : Set (Set α)`. If `G` is a uniform additive group,
 then `α →ᵤ[𝔖] G` is a uniform additive group as well."]
-instance : UniformGroup (α →ᵤ[𝔖] G) :=
+instance : IsUniformGroup (α →ᵤ[𝔖] G) :=
   ⟨(-- Since `(/) : G × G → G` is uniformly continuous,
     -- `UniformOnFun.postcomp_uniformContinuous` tells us that
     -- `((/) ∘ —) : (α →ᵤ[𝔖] G × G) → (α →ᵤ[𝔖] G)` is uniformly continuous too. By precomposing with

--- a/Mathlib/Topology/Algebra/UniformField.lean
+++ b/Mathlib/Topology/Algebra/UniformField.lean
@@ -116,7 +116,7 @@ theorem coe_inv (x : K) : (x : hat K)⁻¹ = ((x⁻¹ : K) : hat K) := by
     · exact hatInv_extends h
     · exact fun H => h (isDenseEmbedding_coe.injective H)
 
-variable [UniformAddGroup K]
+variable [IsUniformAddGroup K]
 
 theorem mul_hatInv_cancel {x : hat K} (x_ne : x ≠ 0) : x * hatInv x = 1 := by
   haveI : T1Space (hat K) := T2Space.t1Space

--- a/Mathlib/Topology/Algebra/UniformFilterBasis.lean
+++ b/Mathlib/Topology/Algebra/UniformFilterBasis.lean
@@ -32,14 +32,17 @@ protected def uniformSpace : UniformSpace G :=
 
 /-- The uniform space structure associated to an abelian group filter basis via the associated
 topological abelian group structure is compatible with its group structure. -/
-protected theorem uniformAddGroup : @UniformAddGroup G B.uniformSpace _ :=
-  @uniformAddGroup_of_addCommGroup G _ B.topology B.isTopologicalAddGroup
+protected theorem isUniformAddGroup : @IsUniformAddGroup G B.uniformSpace _ :=
+  @isUniformAddGroup_of_addCommGroup G _ B.topology B.isTopologicalAddGroup
+
+@[deprecated (since := "2025-03-26")] alias UniformAddGroup :=
+    AddGroupFilterBasis.isUniformAddGroup
 
 theorem cauchy_iff {F : Filter G} :
     @Cauchy G B.uniformSpace F ↔
       F.NeBot ∧ ∀ U ∈ B, ∃ M ∈ F, ∀ᵉ (x ∈ M) (y ∈ M), y - x ∈ U := by
   letI := B.uniformSpace
-  haveI := B.uniformAddGroup
+  haveI := B.isUniformAddGroup
   suffices F ×ˢ F ≤ uniformity G ↔ ∀ U ∈ B, ∃ M ∈ F, ∀ᵉ (x ∈ M) (y ∈ M), y - x ∈ U by
     constructor <;> rintro ⟨h', h⟩ <;> refine ⟨h', ?_⟩ <;> [rwa [← this]; rwa [this]]
   rw [uniformity_eq_comap_nhds_zero G, ← map_le_iff_le_comap]

--- a/Mathlib/Topology/Algebra/UniformGroup/Basic.lean
+++ b/Mathlib/Topology/Algebra/UniformGroup/Basic.lean
@@ -29,20 +29,22 @@ noncomputable section
 
 open Uniformity Topology Filter Pointwise
 
-section UniformGroup
+section IsUniformGroup
 
 open Filter Set
 
 variable {α : Type*} {β : Type*}
 
-variable [UniformSpace α] [Group α] [UniformGroup α]
+variable [UniformSpace α] [Group α] [IsUniformGroup α]
 
 @[to_additive]
-instance Pi.instUniformGroup {ι : Type*} {G : ι → Type*} [∀ i, UniformSpace (G i)]
-    [∀ i, Group (G i)] [∀ i, UniformGroup (G i)] : UniformGroup (∀ i, G i) where
+instance Pi.instIsUniformGroup {ι : Type*} {G : ι → Type*} [∀ i, UniformSpace (G i)]
+    [∀ i, Group (G i)] [∀ i, IsUniformGroup (G i)] : IsUniformGroup (∀ i, G i) where
   uniformContinuous_div := uniformContinuous_pi.mpr fun i ↦
     (uniformContinuous_proj G i).comp uniformContinuous_fst |>.div <|
       (uniformContinuous_proj G i).comp uniformContinuous_snd
+
+@[deprecated (since := "2025-03-26")] alias Pi.instUniformGroup := Pi.instIsUniformGroup
 
 @[to_additive]
 theorem isUniformEmbedding_translate_mul (a : α) : IsUniformEmbedding fun x : α => x * a :=
@@ -57,9 +59,9 @@ alias uniformEmbedding_translate_mul := isUniformEmbedding_translate_mul
 
 section Cauchy
 
-namespace UniformGroup
+namespace IsUniformGroup
 
-variable {ι G : Type*} [Group G] [UniformSpace G] [UniformGroup G]
+variable {ι G : Type*} [Group G] [UniformSpace G] [IsUniformGroup G]
 
 @[to_additive]
 lemma cauchy_iff_tendsto (𝓕 : Filter G) :
@@ -81,7 +83,7 @@ lemma cauchy_map_iff_tendsto_swapped (𝓕 : Filter ι) (f : ι → G) :
     Cauchy (map f 𝓕) ↔ NeBot 𝓕 ∧ Tendsto (fun p ↦ f p.2 / f p.1) (𝓕 ×ˢ 𝓕) (𝓝 1) := by
   simp [cauchy_map_iff, uniformity_eq_comap_nhds_one, Function.comp_def]
 
-end UniformGroup
+end IsUniformGroup
 
 end Cauchy
 
@@ -90,28 +92,34 @@ section LatticeOps
 variable [Group β]
 
 @[to_additive]
-lemma IsUniformInducing.uniformGroup {γ : Type*} [Group γ] [UniformSpace γ] [UniformGroup γ]
+lemma IsUniformInducing.isUniformGroup {γ : Type*} [Group γ] [UniformSpace γ] [IsUniformGroup γ]
     [UniformSpace β] {F : Type*} [FunLike F β γ] [MonoidHomClass F β γ]
     (f : F) (hf : IsUniformInducing f) :
-    UniformGroup β where
+    IsUniformGroup β where
   uniformContinuous_div := by
     simp_rw [hf.uniformContinuous_iff, Function.comp_def, map_div]
     exact uniformContinuous_div.comp (hf.uniformContinuous.prodMap hf.uniformContinuous)
 
-@[deprecated (since := "2024-10-05")]
-alias UniformInducing.uniformGroup := IsUniformInducing.uniformGroup
+@[deprecated (since := "2025-03-26")]
+alias UniformInducing.UniformGroup := IsUniformInducing.isUniformGroup
 
 @[to_additive]
-protected theorem UniformGroup.comap {γ : Type*} [Group γ] {u : UniformSpace γ} [UniformGroup γ]
-    {F : Type*} [FunLike F β γ] [MonoidHomClass F β γ] (f : F) : @UniformGroup β (u.comap f) _ :=
-  letI : UniformSpace β := u.comap f; IsUniformInducing.uniformGroup f ⟨rfl⟩
+protected theorem IsUniformGroup.comap {γ : Type*} [Group γ] {u : UniformSpace γ} [IsUniformGroup γ]
+    {F : Type*} [FunLike F β γ] [MonoidHomClass F β γ] (f : F) : @IsUniformGroup β (u.comap f) _ :=
+  letI : UniformSpace β := u.comap f; IsUniformInducing.isUniformGroup f ⟨rfl⟩
+
+@[deprecated (since := "2025-03-26")] alias UniformGroup.comap := IsUniformGroup.comap
 
 end LatticeOps
 
 namespace Subgroup
 
 @[to_additive]
-instance uniformGroup (S : Subgroup α) : UniformGroup S := .comap S.subtype
+instance isUniformGroup (S : Subgroup α) : IsUniformGroup S := .comap S.subtype
+
+@[deprecated (since := "2025-03-26")] alias UniformGroup := isUniformGroup
+@[deprecated (since := "2025-03-26")] alias AddSubgroup.UniformAddGroup :=
+    AddSubgroup.isUniformAddGroup
 
 end Subgroup
 
@@ -194,7 +202,7 @@ theorem UniformCauchySeqOn.div (hf : UniformCauchySeqOn f l s) (hf' : UniformCau
 
 end UniformConvergence
 
-end UniformGroup
+end IsUniformGroup
 
 section IsTopologicalGroup
 
@@ -205,7 +213,7 @@ variable (G : Type*) [Group G] [TopologicalSpace G] [IsTopologicalGroup G]
 attribute [local instance] IsTopologicalGroup.toUniformSpace
 
 @[to_additive]
-theorem topologicalGroup_is_uniform_of_compactSpace [CompactSpace G] : UniformGroup G :=
+theorem topologicalGroup_is_uniform_of_compactSpace [CompactSpace G] : IsUniformGroup G :=
   ⟨by
     apply CompactSpace.uniformContinuous_of_continuous
     exact continuous_div'⟩
@@ -317,7 +325,7 @@ private theorem extend_Z_bilin_aux (x₀ : α) (y₁ : δ) : ∃ U₂ ∈ comap 
   simp_rw [forall_mem_comm]
   exact lim W' W'_nhd
 
-variable [UniformAddGroup G]
+variable [IsUniformAddGroup G]
 
 include df W'_nhd in
 private theorem extend_Z_bilin_key (x₀ : α) (y₀ : γ) : ∃ U ∈ comap e (𝓝 x₀), ∃ V ∈ comap f (𝓝 y₀),
@@ -531,10 +539,10 @@ uniform structure, so it is still provided manually via `IsTopologicalAddGroup.t
 In the most common use case ─ quotients of normed additive commutative groups by subgroups ─
 significant care was taken so that the uniform structure inherent in that setting coincides
 (definitionally) with the uniform structure provided here."]
-instance QuotientGroup.completeSpace (G : Type u) [Group G] [us : UniformSpace G] [UniformGroup G]
+instance QuotientGroup.completeSpace (G : Type u) [Group G] [us : UniformSpace G] [IsUniformGroup G]
     [FirstCountableTopology G] (N : Subgroup G) [N.Normal] [hG : CompleteSpace G] :
     @CompleteSpace (G ⧸ N) (IsTopologicalGroup.toUniformSpace (G ⧸ N)) := by
-  rw [← @UniformGroup.toUniformSpace_eq _ us _ _] at hG
+  rw [← @IsUniformGroup.toUniformSpace_eq _ us _ _] at hG
   infer_instance
 
 end CompleteQuotient

--- a/Mathlib/Topology/Algebra/UniformGroup/Defs.lean
+++ b/Mathlib/Topology/Algebra/UniformGroup/Defs.lean
@@ -419,10 +419,10 @@ theorem isUniformGroup_of_commGroup : IsUniformGroup G := by
   exact (continuous_div'.tendsto' 1 1 (div_one 1)).comp tendsto_comap
 
 @[deprecated (since := "2025-03-26")]
-alias comm_topologicalGroup_is_uniform := isUniformGroup_of_commGroup
+alias uniformGroup_of_commGroup := isUniformGroup_of_commGroup
 
 @[deprecated (since := "2025-03-26")]
-alias comm_topologicalAddGroup_is_uniform := isUniformAddGroup_of_addCommGroup
+alias UniformAddGroup_of_commGroup := isUniformAddGroup_of_addCommGroup
 
 open Set
 

--- a/Mathlib/Topology/Algebra/UniformGroup/Defs.lean
+++ b/Mathlib/Topology/Algebra/UniformGroup/Defs.lean
@@ -37,29 +37,37 @@ open Filter Set
 
 variable {α : Type*} {β : Type*}
 
+
 /-- A uniform group is a group in which multiplication and inversion are uniformly continuous. -/
-class UniformGroup (α : Type*) [UniformSpace α] [Group α] : Prop where
+class IsUniformGroup (α : Type*) [UniformSpace α] [Group α] : Prop where
   uniformContinuous_div : UniformContinuous fun p : α × α => p.1 / p.2
+
+@[deprecated (since := "2025-03-26")] alias UniformGroup := IsUniformGroup
 
 /-- A uniform additive group is an additive group in which addition
   and negation are uniformly continuous. -/
-class UniformAddGroup (α : Type*) [UniformSpace α] [AddGroup α] : Prop where
+class IsUniformAddGroup (α : Type*) [UniformSpace α] [AddGroup α] : Prop where
   uniformContinuous_sub : UniformContinuous fun p : α × α => p.1 - p.2
 
-attribute [to_additive] UniformGroup
+@[deprecated (since := "2025-03-26")] alias UniformAddGroup := IsUniformAddGroup
+
+attribute [to_additive] IsUniformGroup
 
 @[to_additive]
-theorem UniformGroup.mk' {α} [UniformSpace α] [Group α]
+theorem IsUniformGroup.mk' {α} [UniformSpace α] [Group α]
     (h₁ : UniformContinuous fun p : α × α => p.1 * p.2) (h₂ : UniformContinuous fun p : α => p⁻¹) :
-    UniformGroup α :=
+    IsUniformGroup α :=
   ⟨by simpa only [div_eq_mul_inv] using
     h₁.comp (uniformContinuous_fst.prodMk (h₂.comp uniformContinuous_snd))⟩
 
-variable [UniformSpace α] [Group α] [UniformGroup α]
+@[deprecated (since := "2025-03-26")] alias UniformAddGroup.mk' := IsUniformAddGroup.mk'
+@[deprecated (since := "2025-03-26")] alias UniformGroup.mk' := IsUniformGroup.mk'
+
+variable [UniformSpace α] [Group α] [IsUniformGroup α]
 
 @[to_additive]
 theorem uniformContinuous_div : UniformContinuous fun p : α × α => p.1 / p.2 :=
-  UniformGroup.uniformContinuous_div
+  IsUniformGroup.uniformContinuous_div
 
 @[to_additive]
 theorem UniformContinuous.div [UniformSpace β] {f : β → α} {g : β → α} (hf : UniformContinuous f)
@@ -147,9 +155,9 @@ instance (priority := 10) UniformGroup.to_topologicalGroup : IsTopologicalGroup 
   continuous_inv := uniformContinuous_inv.continuous
 
 @[to_additive]
-instance Prod.instUniformGroup [UniformSpace β] [Group β] [UniformGroup β] : UniformGroup (α × β) :=
-  ⟨((uniformContinuous_fst.comp uniformContinuous_fst).div
-          (uniformContinuous_fst.comp uniformContinuous_snd)).prodMk
+instance Prod.instIsUniformGroup [UniformSpace β] [Group β] [IsUniformGroup β] :
+    IsUniformGroup (α × β) := ⟨((uniformContinuous_fst.comp uniformContinuous_fst).div
+      (uniformContinuous_fst.comp uniformContinuous_snd)).prodMk
       ((uniformContinuous_snd.comp uniformContinuous_fst).div
         (uniformContinuous_snd.comp uniformContinuous_snd))⟩
 
@@ -167,7 +175,7 @@ theorem uniformity_translate_mul (a : α) : ((𝓤 α).map fun x : α × α => (
 namespace MulOpposite
 
 @[to_additive]
-instance : UniformGroup αᵐᵒᵖ :=
+instance : IsUniformGroup αᵐᵒᵖ :=
   ⟨uniformContinuous_op.comp
       ((uniformContinuous_unop.comp uniformContinuous_snd).inv.mul <|
         uniformContinuous_unop.comp uniformContinuous_fst)⟩
@@ -179,23 +187,23 @@ section LatticeOps
 variable [Group β]
 
 @[to_additive]
-theorem uniformGroup_sInf {us : Set (UniformSpace β)} (h : ∀ u ∈ us, @UniformGroup β u _) :
-    @UniformGroup β (sInf us) _ :=
-  @UniformGroup.mk β (_) _ <|
+theorem isUniformGroup_sInf {us : Set (UniformSpace β)} (h : ∀ u ∈ us, @IsUniformGroup β u _) :
+    @IsUniformGroup β (sInf us) _ :=
+  @IsUniformGroup.mk β (_) _ <|
     uniformContinuous_sInf_rng.mpr fun u hu =>
-      uniformContinuous_sInf_dom₂ hu hu (@UniformGroup.uniformContinuous_div β u _ (h u hu))
+      uniformContinuous_sInf_dom₂ hu hu (@IsUniformGroup.uniformContinuous_div β u _ (h u hu))
 
 @[to_additive]
-theorem uniformGroup_iInf {ι : Sort*} {us' : ι → UniformSpace β}
-    (h' : ∀ i, @UniformGroup β (us' i) _) : @UniformGroup β (⨅ i, us' i) _ := by
+theorem isUniformGroup_iInf {ι : Sort*} {us' : ι → UniformSpace β}
+    (h' : ∀ i, @IsUniformGroup β (us' i) _) : @IsUniformGroup β (⨅ i, us' i) _ := by
   rw [← sInf_range]
-  exact uniformGroup_sInf (Set.forall_mem_range.mpr h')
+  exact isUniformGroup_sInf (Set.forall_mem_range.mpr h')
 
 @[to_additive]
-theorem uniformGroup_inf {u₁ u₂ : UniformSpace β} (h₁ : @UniformGroup β u₁ _)
-    (h₂ : @UniformGroup β u₂ _) : @UniformGroup β (u₁ ⊓ u₂) _ := by
+theorem isUniformGroup_inf {u₁ u₂ : UniformSpace β} (h₁ : @IsUniformGroup β u₁ _)
+    (h₂ : @IsUniformGroup β u₂ _) : @IsUniformGroup β (u₁ ⊓ u₂) _ := by
   rw [inf_eq_iInf]
-  refine uniformGroup_iInf fun b => ?_
+  refine isUniformGroup_iInf fun b => ?_
   cases b <;> assumption
 
 end LatticeOps
@@ -226,22 +234,22 @@ theorem uniformity_eq_comap_nhds_one_swapped :
   rfl
 
 @[to_additive]
-theorem UniformGroup.ext {G : Type*} [Group G] {u v : UniformSpace G} (hu : @UniformGroup G u _)
-    (hv : @UniformGroup G v _)
+theorem IsUniformGroup.ext {G : Type*} [Group G] {u v : UniformSpace G} (hu : @IsUniformGroup G u _)
+    (hv : @IsUniformGroup G v _)
     (h : @nhds _ u.toTopologicalSpace 1 = @nhds _ v.toTopologicalSpace 1) : u = v :=
   UniformSpace.ext <| by
     rw [@uniformity_eq_comap_nhds_one _ u _ hu, @uniformity_eq_comap_nhds_one _ v _ hv, h]
 
 @[to_additive]
-theorem UniformGroup.ext_iff {G : Type*} [Group G] {u v : UniformSpace G}
-    (hu : @UniformGroup G u _) (hv : @UniformGroup G v _) :
+theorem IsUniformGroup.ext_iff {G : Type*} [Group G] {u v : UniformSpace G}
+    (hu : @ IsUniformGroup G u _) (hv : @IsUniformGroup G v _) :
     u = v ↔ @nhds _ u.toTopologicalSpace 1 = @nhds _ v.toTopologicalSpace 1 :=
   ⟨fun h => h ▸ rfl, hu.ext hv⟩
 
 variable {α}
 
 @[to_additive]
-theorem UniformGroup.uniformity_countably_generated [(𝓝 (1 : α)).IsCountablyGenerated] :
+theorem IsUniformGroup.uniformity_countably_generated [(𝓝 (1 : α)).IsCountablyGenerated] :
     (𝓤 α).IsCountablyGenerated := by
   rw [uniformity_eq_comap_nhds_one]
   exact Filter.comap.isCountablyGenerated _ _
@@ -292,7 +300,7 @@ theorem Filter.HasBasis.uniformity_of_nhds_one_inv_mul_swapped {ι} {p : ι → 
   exact h.comap _
 
 @[to_additive]
-theorem uniformContinuous_of_tendsto_one {hom : Type*} [UniformSpace β] [Group β] [UniformGroup β]
+theorem uniformContinuous_of_tendsto_one {hom : Type*} [UniformSpace β] [Group β] [IsUniformGroup β]
     [FunLike hom α β] [MonoidHomClass hom α β] {f : hom} (h : Tendsto f (𝓝 1) (𝓝 1)) :
     UniformContinuous f := by
   have :
@@ -309,22 +317,22 @@ two uniform groups is uniformly continuous provided that it is continuous at one
 `AddMonoidHomClass`) between two uniform additive groups is uniformly continuous provided that it
 is continuous at zero. See also `continuous_of_continuousAt_zero`."]
 theorem uniformContinuous_of_continuousAt_one {hom : Type*} [UniformSpace β] [Group β]
-    [UniformGroup β] [FunLike hom α β] [MonoidHomClass hom α β]
+    [IsUniformGroup β] [FunLike hom α β] [MonoidHomClass hom α β]
     (f : hom) (hf : ContinuousAt f 1) :
     UniformContinuous f :=
   uniformContinuous_of_tendsto_one (by simpa using hf.tendsto)
 
 @[to_additive]
-theorem MonoidHom.uniformContinuous_of_continuousAt_one [UniformSpace β] [Group β] [UniformGroup β]
-    (f : α →* β) (hf : ContinuousAt f 1) : UniformContinuous f :=
+theorem MonoidHom.uniformContinuous_of_continuousAt_one [UniformSpace β] [Group β]
+    [IsUniformGroup β] (f : α →* β) (hf : ContinuousAt f 1) : UniformContinuous f :=
   _root_.uniformContinuous_of_continuousAt_one f hf
 
 /-- A homomorphism from a uniform group to a discrete uniform group is continuous if and only if
 its kernel is open. -/
 @[to_additive "A homomorphism from a uniform additive group to a discrete uniform additive group is
 continuous if and only if its kernel is open."]
-theorem UniformGroup.uniformContinuous_iff_isOpen_ker {hom : Type*} [UniformSpace β]
-    [DiscreteTopology β] [Group β] [UniformGroup β] [FunLike hom α β] [MonoidHomClass hom α β]
+theorem IsUniformGroup.uniformContinuous_iff_isOpen_ker {hom : Type*} [UniformSpace β]
+    [DiscreteTopology β] [Group β] [IsUniformGroup β] [FunLike hom α β] [MonoidHomClass hom α β]
     {f : hom} :
     UniformContinuous f ↔ IsOpen ((f : α →* β).ker : Set α) := by
   refine ⟨fun hf => ?_, fun hf => ?_⟩
@@ -333,14 +341,14 @@ theorem UniformGroup.uniformContinuous_iff_isOpen_ker {hom : Type*} [UniformSpac
     rw [ContinuousAt, nhds_discrete β, map_one, tendsto_pure]
     exact hf.mem_nhds (map_one f)
 
-@[deprecated (since := "2024-11-18")] alias UniformGroup.uniformContinuous_iff_open_ker :=
-  UniformGroup.uniformContinuous_iff_isOpen_ker
-@[deprecated (since := "2024-11-18")] alias UniformAddGroup.uniformContinuous_iff_open_ker :=
-  UniformAddGroup.uniformContinuous_iff_isOpen_ker
+@[deprecated (since := "2025-03-26")] alias UniformGroup.uniformContinuous_iff_open_ker :=
+  IsUniformGroup.uniformContinuous_iff_isOpen_ker
+@[deprecated (since := "2025-03-26")] alias UniformAddGroup.uniformContinuous_iff_open_ker :=
+  IsUniformAddGroup.uniformContinuous_iff_isOpen_ker
 
 @[to_additive]
 theorem uniformContinuous_monoidHom_of_continuous {hom : Type*} [UniformSpace β] [Group β]
-    [UniformGroup β] [FunLike hom α β] [MonoidHomClass hom α β] {f : hom} (h : Continuous f) :
+    [IsUniformGroup β] [FunLike hom α β] [MonoidHomClass hom α β] {f : hom} (h : Continuous f) :
     UniformContinuous f :=
   uniformContinuous_of_tendsto_one <|
     suffices Tendsto f (𝓝 1) (𝓝 (f 1)) by rwa [map_one] at this
@@ -403,26 +411,26 @@ attribute [local instance] IsTopologicalGroup.toUniformSpace
 variable {G}
 
 @[to_additive]
-theorem uniformGroup_of_commGroup : UniformGroup G := by
+theorem isUniformGroup_of_commGroup : IsUniformGroup G := by
   constructor
   simp only [UniformContinuous, uniformity_prod_eq_prod, uniformity_eq_comap_nhds_one',
     tendsto_comap_iff, tendsto_map'_iff, prod_comap_comap_eq, Function.comp_def,
     div_div_div_comm _ (Prod.snd (Prod.snd _)), ← nhds_prod_eq, Prod.mk_one_one]
   exact (continuous_div'.tendsto' 1 1 (div_one 1)).comp tendsto_comap
 
-@[deprecated (since := "2027-02-28")]
-alias comm_topologicalGroup_is_uniform := uniformGroup_of_commGroup
+@[deprecated (since := "2025-03-26")]
+alias comm_topologicalGroup_is_uniform := isUniformGroup_of_commGroup
 
-@[deprecated (since := "2027-02-28")]
-alias comm_topologicalAddGroup_is_uniform := uniformAddGroup_of_addCommGroup
+@[deprecated (since := "2025-03-26")]
+alias comm_topologicalAddGroup_is_uniform := isUniformAddGroup_of_addCommGroup
 
 open Set
 
 end
 
 @[to_additive]
-theorem UniformGroup.toUniformSpace_eq {G : Type*} [u : UniformSpace G] [Group G]
-    [UniformGroup G] : IsTopologicalGroup.toUniformSpace G = u := by
+theorem IsUniformGroup.toUniformSpace_eq {G : Type*} [u : UniformSpace G] [Group G]
+    [IsUniformGroup G] : IsTopologicalGroup.toUniformSpace G = u := by
   ext : 1
   rw [uniformity_eq_comap_nhds_one' G, uniformity_eq_comap_nhds_one G]
 
@@ -490,7 +498,7 @@ private theorem extend_Z_bilin_aux (x₀ : α) (y₁ : δ) : ∃ U₂ ∈ comap 
   simp_rw [forall_mem_comm]
   exact lim W' W'_nhd
 
-variable [UniformAddGroup G]
+variable [IsUniformAddGroup G]
 
 include df W'_nhd in
 private theorem extend_Z_bilin_key (x₀ : α) (y₀ : γ) : ∃ U ∈ comap e (𝓝 x₀), ∃ V ∈ comap f (𝓝 y₀),

--- a/Mathlib/Topology/Algebra/UniformMulAction.lean
+++ b/Mathlib/Topology/Algebra/UniformMulAction.lean
@@ -44,11 +44,11 @@ export UniformContinuousConstVAdd (uniformContinuous_const_vadd)
 
 export UniformContinuousConstSMul (uniformContinuous_const_smul)
 
-instance AddMonoid.uniformContinuousConstSMul_nat [AddGroup X] [UniformAddGroup X] :
+instance AddMonoid.uniformContinuousConstSMul_nat [AddGroup X] [IsUniformAddGroup X] :
     UniformContinuousConstSMul ℕ X :=
   ⟨uniformContinuous_const_nsmul⟩
 
-instance AddGroup.uniformContinuousConstSMul_int [AddGroup X] [UniformAddGroup X] :
+instance AddGroup.uniformContinuousConstSMul_int [AddGroup X] [IsUniformAddGroup X] :
     UniformContinuousConstSMul ℤ X :=
   ⟨uniformContinuous_const_zsmul⟩
 
@@ -56,19 +56,19 @@ instance AddGroup.uniformContinuousConstSMul_int [AddGroup X] [UniformAddGroup X
 This can't be an instance due to it forming a loop with
 `UniformContinuousConstSMul.to_continuousConstSMul` -/
 theorem uniformContinuousConstSMul_of_continuousConstSMul [Monoid R] [AddCommGroup M]
-    [DistribMulAction R M] [UniformSpace M] [UniformAddGroup M] [ContinuousConstSMul R M] :
+    [DistribMulAction R M] [UniformSpace M] [IsUniformAddGroup M] [ContinuousConstSMul R M] :
     UniformContinuousConstSMul R M :=
   ⟨fun r =>
     uniformContinuous_of_continuousAt_zero (DistribMulAction.toAddMonoidHom M r)
       (Continuous.continuousAt (continuous_const_smul r))⟩
 
 /-- The action of `Semiring.toModule` is uniformly continuous. -/
-instance Ring.uniformContinuousConstSMul [Ring R] [UniformSpace R] [UniformAddGroup R]
+instance Ring.uniformContinuousConstSMul [Ring R] [UniformSpace R] [IsUniformAddGroup R]
     [ContinuousMul R] : UniformContinuousConstSMul R R :=
   uniformContinuousConstSMul_of_continuousConstSMul _ _
 
 /-- The action of `Semiring.toOppositeModule` is uniformly continuous. -/
-instance Ring.uniformContinuousConstSMul_op [Ring R] [UniformSpace R] [UniformAddGroup R]
+instance Ring.uniformContinuousConstSMul_op [Ring R] [UniformSpace R] [IsUniformAddGroup R]
     [ContinuousMul R] : UniformContinuousConstSMul Rᵐᵒᵖ R :=
   uniformContinuousConstSMul_of_continuousConstSMul _ _
 
@@ -116,11 +116,16 @@ instance MulOpposite.uniformContinuousConstSMul [UniformContinuousConstSMul M X]
 end SMul
 
 @[to_additive]
-instance UniformGroup.to_uniformContinuousConstSMul {G : Type u} [Group G] [UniformSpace G]
-    [UniformGroup G] : UniformContinuousConstSMul G G :=
+instance IsUniformGroup.to_uniformContinuousConstSMul {G : Type u} [Group G] [UniformSpace G]
+    [IsUniformGroup G] : UniformContinuousConstSMul G G :=
   ⟨fun _ => uniformContinuous_const.mul uniformContinuous_id⟩
 
+@[deprecated (since := "2025-03-26")] alias UniformGroup.to_uniformContinuousConstSMul :=
+  IsUniformGroup.to_uniformContinuousConstSMul
+@[deprecated (since := "2025-03-26")] alias UniformAddGroup.to_uniformContinuousConstVAdd :=
+  IsUniformAddGroup.to_uniformContinuousConstVAdd
 section Ring
+
 
 variable {R β : Type*} [Ring R] [UniformSpace R] [UniformSpace β]
 

--- a/Mathlib/Topology/Algebra/UniformRing.lean
+++ b/Mathlib/Topology/Algebra/UniformRing.lean
@@ -63,7 +63,7 @@ theorem coe_mul (a b : α) : ((a * b : α) : Completion α) = a * b :=
   ((isDenseInducing_coe.prodMap isDenseInducing_coe).extend_eq
       ((continuous_coe α).comp (@continuous_mul α _ _ _)) (a, b)).symm
 
-variable [UniformAddGroup α]
+variable [IsUniformAddGroup α]
 
 instance : ContinuousMul (Completion α) where
   continuous_mul := by
@@ -139,7 +139,7 @@ def coeRingHom : α →+* Completion α where
 theorem continuous_coeRingHom : Continuous (coeRingHom : α → Completion α) :=
   continuous_coe α
 
-variable {β : Type u} [UniformSpace β] [Ring β] [UniformAddGroup β] [IsTopologicalRing β]
+variable {β : Type u} [UniformSpace β] [Ring β] [IsUniformAddGroup β] [IsTopologicalRing β]
   (f : α →+* β) (hf : Continuous f)
 
 /-- The completion extension as a ring morphism. -/
@@ -180,8 +180,8 @@ def mapRingHom (hf : Continuous f) : Completion α →+* Completion β :=
 
 section Algebra
 
-variable (A : Type*) [Ring A] [UniformSpace A] [UniformAddGroup A] [IsTopologicalRing A] (R : Type*)
-  [CommSemiring R] [Algebra R A] [UniformContinuousConstSMul R A]
+variable (A : Type*) [Ring A] [UniformSpace A] [IsUniformAddGroup A] [IsTopologicalRing A]
+  (R : Type*) [CommSemiring R] [Algebra R A] [UniformContinuousConstSMul R A]
 
 @[simp]
 theorem map_smul_eq_mul_coe (r : R) :
@@ -207,7 +207,7 @@ end Algebra
 
 section CommRing
 
-variable (R : Type*) [CommRing R] [UniformSpace R] [UniformAddGroup R] [IsTopologicalRing R]
+variable (R : Type*) [CommRing R] [UniformSpace R] [IsUniformAddGroup R] [IsTopologicalRing R]
 
 instance commRing : CommRing (Completion R) :=
   { Completion.ring with

--- a/Mathlib/Topology/Algebra/Valued/ValuationTopology.lean
+++ b/Mathlib/Topology/Algebra/Valued/ValuationTopology.lean
@@ -86,7 +86,7 @@ the same universe as the ring.
 
 See Note [forgetful inheritance] for why we extend `UniformSpace`, `UniformAddGroup`. -/
 class Valued (R : Type u) [Ring R] (Γ₀ : outParam (Type v))
-  [LinearOrderedCommGroupWithZero Γ₀] extends UniformSpace R, UniformAddGroup R where
+  [LinearOrderedCommGroupWithZero Γ₀] extends UniformSpace R, IsUniformAddGroup R where
   v : Valuation R Γ₀
   is_topological_valuation : ∀ s, s ∈ 𝓝 (0 : R) ↔ ∃ γ : Γ₀ˣ, { x : R | v x < γ } ⊆ s
 
@@ -96,7 +96,7 @@ namespace Valued
 def mk' (v : Valuation R Γ₀) : Valued R Γ₀ :=
   { v
     toUniformSpace := @IsTopologicalAddGroup.toUniformSpace R _ v.subgroups_basis.topology _
-    toUniformAddGroup := @uniformAddGroup_of_addCommGroup _ _ v.subgroups_basis.topology _
+    toIsUniformAddGroup := @isUniformAddGroup_of_addCommGroup _ _ v.subgroups_basis.topology _
     is_topological_valuation := by
       letI := @IsTopologicalAddGroup.toUniformSpace R _ v.subgroups_basis.topology _
       intro s

--- a/Mathlib/Topology/ContinuousMap/Algebra.lean
+++ b/Mathlib/Topology/ContinuousMap/Algebra.lean
@@ -333,7 +333,7 @@ instance instCommGroupContinuousMap [CommGroup β] [IsTopologicalGroup β] : Com
 instance [CommGroup β] [IsTopologicalGroup β] : IsTopologicalGroup C(α, β) where
   continuous_mul := by
     letI : UniformSpace β := IsTopologicalGroup.toUniformSpace β
-    have : UniformGroup β := uniformGroup_of_commGroup
+    have : IsUniformGroup β := isUniformGroup_of_commGroup
     rw [continuous_iff_continuousAt]
     rintro ⟨f, g⟩
     rw [ContinuousAt, tendsto_iff_forall_isCompact_tendstoUniformlyOn, nhds_prod_eq]
@@ -343,7 +343,7 @@ instance [CommGroup β] [IsTopologicalGroup β] : IsTopologicalGroup C(α, β) w
           (tendsto_iff_forall_isCompact_tendstoUniformlyOn.mp Filter.tendsto_id K hK))
   continuous_inv := by
     letI : UniformSpace β := IsTopologicalGroup.toUniformSpace β
-    have : UniformGroup β := uniformGroup_of_commGroup
+    have : IsUniformGroup β := isUniformGroup_of_commGroup
     rw [continuous_iff_continuousAt]
     intro f
     rw [ContinuousAt, tendsto_iff_forall_isCompact_tendstoUniformlyOn]

--- a/Mathlib/Topology/Instances/Rat.lean
+++ b/Mathlib/Topology/Instances/Rat.lean
@@ -98,8 +98,8 @@ theorem uniformContinuous_neg : UniformContinuous (@Neg.neg ℚ _) :=
   Metric.uniformContinuous_iff.2 fun ε ε0 =>
     ⟨_, ε0, fun _ _ h => by simpa only [abs_sub_comm, dist_eq, cast_neg, neg_sub_neg] using h⟩
 
-instance : UniformAddGroup ℚ :=
-  UniformAddGroup.mk' Rat.uniformContinuous_add Rat.uniformContinuous_neg
+instance : IsUniformAddGroup ℚ :=
+  IsUniformAddGroup.mk' Rat.uniformContinuous_add Rat.uniformContinuous_neg
 
 instance : IsTopologicalAddGroup ℚ := inferInstance
 

--- a/Mathlib/Topology/Instances/TrivSqZeroExt.lean
+++ b/Mathlib/Topology/Instances/TrivSqZeroExt.lean
@@ -161,9 +161,9 @@ instance instUniformSpace : UniformSpace (tsze R M) where
 instance [CompleteSpace R] [CompleteSpace M] : CompleteSpace (tsze R M) :=
   inferInstanceAs <| CompleteSpace (R × M)
 
-instance [AddGroup R] [AddGroup M] [UniformAddGroup R] [UniformAddGroup M] :
-    UniformAddGroup (tsze R M) :=
-  inferInstanceAs <| UniformAddGroup (R × M)
+instance [AddGroup R] [AddGroup M] [IsUniformAddGroup R] [IsUniformAddGroup M] :
+    IsUniformAddGroup (tsze R M) :=
+  inferInstanceAs <| IsUniformAddGroup (R × M)
 
 open Uniformity
 

--- a/Mathlib/Topology/UniformSpace/DiscreteUniformity.lean
+++ b/Mathlib/Topology/UniformSpace/DiscreteUniformity.lean
@@ -66,7 +66,7 @@ theorem uniformContinuous {Y : Type*} [UniformSpace Y] (f : X → Y) :
 
 /-- The discrete uniformity makes a group a `UniformGroup. -/
 @[to_additive "The discrete uniformity makes an additive group a `UniformAddGroup`."]
-instance [Group X] : UniformGroup X where
+instance [Group X] : IsUniformGroup X where
   uniformContinuous_div := uniformContinuous (X × X) fun p ↦ p.1 / p.2
 
 variable {X} in

--- a/Mathlib/Topology/UniformSpace/Matrix.lean
+++ b/Mathlib/Topology/UniformSpace/Matrix.lean
@@ -21,9 +21,9 @@ namespace Matrix
 instance instUniformSpace : UniformSpace (Matrix m n 𝕜) :=
   (by infer_instance : UniformSpace (m → n → 𝕜))
 
-instance instUniformAddGroup [AddGroup 𝕜] [UniformAddGroup 𝕜] :
-    UniformAddGroup (Matrix m n 𝕜) :=
-  inferInstanceAs <| UniformAddGroup (m → n → 𝕜)
+instance instUniformAddGroup [AddGroup 𝕜] [IsUniformAddGroup 𝕜] :
+    IsUniformAddGroup (Matrix m n 𝕜) :=
+  inferInstanceAs <| IsUniformAddGroup (m → n → 𝕜)
 
 theorem uniformity :
     𝓤 (Matrix m n 𝕜) = ⨅ (i : m) (j : n), (𝓤 𝕜).comap fun a => (a.1 i j, a.2 i j) := by


### PR DESCRIPTION
According to Mathlib's conventions, we modify the name of the `Prop`-valued class `UniformGroup` to `IsUniformGroup`.