### PR TITLE
[Merged by Bors] - chore: run lean4checker on itself

### DIFF
--- a/.github/build.in.yml
+++ b/.github/build.in.yml
@@ -330,7 +330,7 @@ jobs:
           scripts/lean-pr-testing-comments.sh lean
           scripts/lean-pr-testing-comments.sh batteries
 
-      - name: build lean4checker, but don't run it
+      - name: build lean4checker, but only run it on itself
         if: ${{ (always() && steps.build.outcome == 'success' || steps.build.outcome == 'failure') && contains(github.event.pull_request.changed_files, 'lean-toolchain') }}
         run: |
           git clone https://github.com/leanprover/lean4checker
@@ -346,6 +346,7 @@ jobs:
           # Build lean4checker using the same toolchain
           cp ../lean-toolchain .
           lake build
+          lake -q exe lean4checker Lean4Checker
 
   final:
     name: Post-CI jobJOB_NAME

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -340,7 +340,7 @@ jobs:
           scripts/lean-pr-testing-comments.sh lean
           scripts/lean-pr-testing-comments.sh batteries
 
-      - name: build lean4checker, but don't run it
+      - name: build lean4checker, but only run it on itself
         if: ${{ (always() && steps.build.outcome == 'success' || steps.build.outcome == 'failure') && contains(github.event.pull_request.changed_files, 'lean-toolchain') }}
         run: |
           git clone https://github.com/leanprover/lean4checker
@@ -356,6 +356,7 @@ jobs:
           # Build lean4checker using the same toolchain
           cp ../lean-toolchain .
           lake build
+          lake -q exe lean4checker Lean4Checker
 
   final:
     name: Post-CI job

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -347,7 +347,7 @@ jobs:
           scripts/lean-pr-testing-comments.sh lean
           scripts/lean-pr-testing-comments.sh batteries
 
-      - name: build lean4checker, but don't run it
+      - name: build lean4checker, but only run it on itself
         if: ${{ (always() && steps.build.outcome == 'success' || steps.build.outcome == 'failure') && contains(github.event.pull_request.changed_files, 'lean-toolchain') }}
         run: |
           git clone https://github.com/leanprover/lean4checker
@@ -363,6 +363,7 @@ jobs:
           # Build lean4checker using the same toolchain
           cp ../lean-toolchain .
           lake build
+          lake -q exe lean4checker Lean4Checker
 
   final:
     name: Post-CI job

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -344,7 +344,7 @@ jobs:
           scripts/lean-pr-testing-comments.sh lean
           scripts/lean-pr-testing-comments.sh batteries
 
-      - name: build lean4checker, but don't run it
+      - name: build lean4checker, but only run it on itself
         if: ${{ (always() && steps.build.outcome == 'success' || steps.build.outcome == 'failure') && contains(github.event.pull_request.changed_files, 'lean-toolchain') }}
         run: |
           git clone https://github.com/leanprover/lean4checker
@@ -360,6 +360,7 @@ jobs:
           # Build lean4checker using the same toolchain
           cp ../lean-toolchain .
           lake build
+          lake -q exe lean4checker Lean4Checker
 
   final:
     name: Post-CI job (fork)


### PR DESCRIPTION
This should hopefully allow detecting major breakages to lean4checker during Lean+Mathlib combined CI. (Recall the actual run of lean4checker over Mathlib only happens every 24 hours.)