### PR TITLE
[Merged by Bors] - feat: behavior of MeromorphicAt.order under addition

### DIFF
--- a/Mathlib/Analysis/Analytic/Order.lean
+++ b/Mathlib/Analysis/Analytic/Order.lean
@@ -48,7 +48,8 @@ lemma order_eq_top_iff (hf : AnalyticAt 𝕜 f z₀) : hf.order = ⊤ ↔ ∀ᶠ
 
 /-- The order of an analytic function `f` at `z₀` equals a natural number `n` iff `f` can locally
 be written as `f z = (z - z₀) ^ n • g z`, where `g` is analytic and does not vanish at `z₀`. -/
-lemma order_eq_nat_iff (hf : AnalyticAt 𝕜 f z₀) (n : ℕ) : hf.order = ↑n ↔
+lemma order_eq_nat_iff {n : ℕ} (hf : AnalyticAt 𝕜 f z₀) :
+    hf.order = ↑n ↔
     ∃ (g : 𝕜 → E), AnalyticAt 𝕜 g z₀ ∧ g z₀ ≠ 0 ∧ ∀ᶠ z in 𝓝 z₀, f z = (z - z₀) ^ n • g z := by
   unfold order
   split_ifs with h
@@ -77,7 +78,7 @@ alias order_neq_top_iff := order_ne_top_iff
 /-- The order of an analytic function `f` at `z₀` is zero iff `f` does not vanish at `z₀`. -/
 lemma order_eq_zero_iff (hf : AnalyticAt 𝕜 f z₀) :
     hf.order = 0 ↔ f z₀ ≠ 0 := by
-  rw [← ENat.coe_zero, order_eq_nat_iff hf 0]
+  rw [← ENat.coe_zero, hf.order_eq_nat_iff]
   constructor
   · intro ⟨g, _, _, hg⟩
     simpa [hg.self_of_nhds]

--- a/Mathlib/Analysis/Meromorphic/Basic.lean
+++ b/Mathlib/Analysis/Meromorphic/Basic.lean
@@ -143,7 +143,7 @@ lemma congr {f g : 𝕜 → E} {x : 𝕜} (hf : MeromorphicAt f x) (hfg : f =ᶠ
   · rw [hz (Set.mem_compl_singleton_iff.mp hn), pow_succ', mul_smul]
 
 /--
-If two functions agree in a punctured neighborhood, then one is meromorphic iff so is the other.
+If two functions agree on a punctured neighborhood, then one is meromorphic iff the other is so.
 -/
 lemma meromorphicAt_congr {f g : 𝕜 → E} {x : 𝕜} (h : f =ᶠ[𝓝[≠] x] g) :
     MeromorphicAt f x ↔ MeromorphicAt g x :=

--- a/Mathlib/Analysis/Meromorphic/Basic.lean
+++ b/Mathlib/Analysis/Meromorphic/Basic.lean
@@ -142,6 +142,13 @@ lemma congr {f g : 𝕜 → E} {x : 𝕜} (hf : MeromorphicAt f x) (hfg : f =ᶠ
   · simp
   · rw [hz (Set.mem_compl_singleton_iff.mp hn), pow_succ', mul_smul]
 
+/--
+If two functions agree in a punctured neighborhood, then one is meromorphic iff so is the other.
+-/
+lemma meromorphicAt_congr {f g : 𝕜 → E} {x : 𝕜} (h : f =ᶠ[𝓝[≠] x] g) :
+    MeromorphicAt f x ↔ MeromorphicAt g x :=
+  ⟨fun hf ↦ hf.congr h, fun hg ↦ hg.congr h.symm⟩
+
 @[fun_prop]
 lemma inv {f : 𝕜 → 𝕜} {x : 𝕜} (hf : MeromorphicAt f x) : MeromorphicAt f⁻¹ x := by
   rcases hf with ⟨m, hf⟩

--- a/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
+++ b/Mathlib/Analysis/Meromorphic/NormalFormAt.lean
@@ -81,7 +81,7 @@ theorem meromorphicNFAt_iff_analyticAt_or :
         simpa
     · right
       lift h₁.order to ℤ using LT.lt.ne_top h₂ with n hn
-      obtain ⟨g, h₁g, h₂g, h₃g⟩ := (h₁.order_eq_int_iff n).1 hn.symm
+      obtain ⟨g, h₁g, h₂g, h₃g⟩ := h₁.order_eq_int_iff.1 hn.symm
       use n, g, h₁g, h₂g
       filter_upwards [eventually_nhdsWithin_iff.1 h₃g]
       intro z hz
@@ -158,7 +158,7 @@ theorem MeromorphicNFAt.order_eq_zero_iff (hf : MeromorphicNFAt f x) :
         simp only [Pi.smul_apply', Pi.pow_apply, sub_self, zero_zpow n hContra, zero_smul] at this
         tauto
       simp only [this, zpow_zero, smul_eq_mul, one_mul] at h₃g
-      apply (hf.meromorphicAt.order_eq_int_iff 0).2
+      apply hf.meromorphicAt.order_eq_int_iff.2
       use g, h₁g, h₂g
       simp only [zpow_zero, smul_eq_mul, one_mul]
       exact h₃g.filter_mono nhdsWithin_le_nhds
@@ -312,14 +312,14 @@ theorem meromorphicNFAt_toMeromorphicNFAt :
       rw [analyticAt_congr this]
       exact analyticAt_const
     · lift hf.order to ℤ using h₂f with n hn
-      obtain ⟨g, h₁g, h₂g, h₃g⟩ := (hf.order_eq_int_iff n).1 hn.symm
+      obtain ⟨g, h₁g, h₂g, h₃g⟩ := hf.order_eq_int_iff.1 hn.symm
       right
       use n, g, h₁g, h₂g
       apply eventuallyEq_nhds_of_eventuallyEq_nhdsNE (hf.eq_nhdNE_toMeromorphicNFAt.symm.trans h₃g)
       simp only [toMeromorphicNFAt, hf, ↓reduceDIte, ← hn, WithTop.coe_zero,
         WithTop.coe_eq_zero, ne_eq, Function.update_self, sub_self]
       split_ifs with h₃f
-      · obtain ⟨h₁G, _, h₃G⟩ := Classical.choose_spec ((hf.order_eq_int_iff 0).1 (h₃f ▸ hn.symm))
+      · obtain ⟨h₁G, _, h₃G⟩ := Classical.choose_spec (hf.order_eq_int_iff.1 (h₃f ▸ hn.symm))
         apply Filter.EventuallyEq.eq_of_nhds
         apply (h₁G.continuousAt.eventuallyEq_nhd_iff_eventuallyEq_nhdNE (by fun_prop)).1
         filter_upwards [h₃g, h₃G]
@@ -343,7 +343,7 @@ theorem meromorphicNFAt_toMeromorphicNFAt :
       · obtain ⟨n, g, h₁g, h₂g, h₃g⟩ := h₁f
         rw [Filter.EventuallyEq.eq_of_nhds h₃g]
         have : h₀f.meromorphicAt.order = n := by
-          rw [MeromorphicAt.order_eq_int_iff (MeromorphicNFAt.meromorphicAt h₀f) n]
+          rw [h₀f.meromorphicAt.order_eq_int_iff]
           use g, h₁g, h₂g
           exact eventually_nhdsWithin_of_eventually_nhds h₃g
         by_cases h₃f : h₀f.meromorphicAt.order = 0
@@ -353,9 +353,9 @@ theorem meromorphicNFAt_toMeromorphicNFAt :
             exact WithTop.coe_eq_zero.mp this.symm
           simp_rw [hn]
           simp only [zpow_zero, one_smul]
-          have : g =ᶠ[𝓝 x] (Classical.choose ((h₀f.meromorphicAt.order_eq_int_iff 0).1 h₃f)) := by
+          have : g =ᶠ[𝓝 x] (Classical.choose (h₀f.meromorphicAt.order_eq_int_iff.1 h₃f)) := by
             obtain ⟨h₀, h₁, h₂⟩ := Classical.choose_spec
-              ((h₀f.meromorphicAt.order_eq_int_iff 0).1 h₃f)
+              (h₀f.meromorphicAt.order_eq_int_iff.1 h₃f)
             rw [← h₁g.continuousAt.eventuallyEq_nhd_iff_eventuallyEq_nhdNE h₀.continuousAt]
             rw [hn] at h₃g
             simp only [zpow_zero, one_smul, ne_eq] at h₃g h₂

--- a/Mathlib/Analysis/Meromorphic/Order.lean
+++ b/Mathlib/Analysis/Meromorphic/Order.lean
@@ -200,7 +200,7 @@ theorem order_add (hf₁ : MeromorphicAt f₁ x) (hf₂ : MeromorphicAt f₂ x) 
     filter_upwards [h₃g₁, h₃g₂, self_mem_nhdsWithin]
     simp_all [g, ← smul_assoc, ← zpow_add', sub_ne_zero]
   have t₀ : MeromorphicAt ((·  - x) ^ n) x := by fun_prop
-  have t₁ : t₀.order = n := (t₀.order_eq_int_iff _).mpr ⟨1, analyticAt_const, by simp⟩
+  have t₁ : t₀.order = n := t₀.order_eq_int_iff.2 ⟨1, analyticAt_const, by simp⟩
   rw [(hf₁.add hf₂).order_congr this, t₀.order_smul h₁g.meromorphicAt, t₁]
   exact le_add_of_nonneg_right h₁g.meromorphicAt_order_nonneg
 
@@ -221,12 +221,10 @@ lemma order_add_of_order_lt_order (hf₁ : MeromorphicAt f₁ x) (hf₂ : Meromo
   obtain ⟨g₁, h₁g₁, h₂g₁, h₃g₁⟩ := hf₁.order_eq_int_iff.1 hn₁.symm
   obtain ⟨g₂, h₁g₂, h₂g₂, h₃g₂⟩ := hf₂.order_eq_int_iff.1 hn₂.symm
   rw [(hf₁.add hf₂).order_eq_int_iff]
-  use g₁ + (· - x) ^ (n₂ - n₁) • g₂
-  constructor
+  refine ⟨g₁ + (· - x) ^ (n₂ - n₁) • g₂, ?_, ?_, ?_⟩
   · apply h₁g₁.add (AnalyticAt.smul _ h₁g₂)
     apply AnalyticAt.zpow_nonneg (by fun_prop)
       (sub_nonneg.2 (le_of_lt (WithTop.coe_lt_coe.1 h)))
-  constructor
   · simpa [zero_zpow _ <| sub_ne_zero.mpr (WithTop.coe_lt_coe.1 h).ne']
   · filter_upwards [h₃g₁, h₃g₂, self_mem_nhdsWithin]
     simp_all [smul_add, ← smul_assoc, ← zpow_add', sub_ne_zero]

--- a/Mathlib/Analysis/Meromorphic/Order.lean
+++ b/Mathlib/Analysis/Meromorphic/Order.lean
@@ -20,6 +20,7 @@ open scoped Topology
 
 variable {𝕜 : Type*} [NontriviallyNormedField 𝕜]
   {E : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E]
+  {f f₁ f₂ : 𝕜 → E} {x : 𝕜}
 
 /-!
 ## Order at a Point: Definition and Characterization
@@ -33,12 +34,12 @@ The order is defined to be `∞` if `f` is identically 0 on a neighbourhood of `
 unique `n` such that `f` can locally be written as `f z = (z - z₀) ^ n • g z`, where `g` is analytic
 and does not vanish at `z₀`. See `MeromorphicAt.order_eq_top_iff` and
 `MeromorphicAt.order_eq_nat_iff` for these equivalences. -/
-noncomputable def order {f : 𝕜 → E} {x : 𝕜} (hf : MeromorphicAt f x) : WithTop ℤ :=
+noncomputable def order (hf : MeromorphicAt f x) : WithTop ℤ :=
   (hf.choose_spec.order.map (↑· : ℕ → ℤ)) - hf.choose
 
 /-- The order of a meromorphic function `f` at a `z₀` is infinity iff `f` vanishes locally around
 `z₀`. -/
-lemma order_eq_top_iff {f : 𝕜 → E} {x : 𝕜} (hf : MeromorphicAt f x) :
+lemma order_eq_top_iff (hf : MeromorphicAt f x) :
     hf.order = ⊤ ↔ ∀ᶠ z in 𝓝[≠] x, f z = 0 := by
   unfold order
   by_cases h : hf.choose_spec.order = ⊤
@@ -59,7 +60,7 @@ lemma order_eq_top_iff {f : 𝕜 → E} {x : 𝕜} (hf : MeromorphicAt f x) :
 
 /-- The order of a meromorphic function `f` at `z₀` equals an integer `n` iff `f` can locally be
 written as `f z = (z - z₀) ^ n • g z`, where `g` is analytic and does not vanish at `z₀`. -/
-lemma order_eq_int_iff {f : 𝕜 → E} {x : 𝕜} (hf : MeromorphicAt f x) (n : ℤ) : hf.order = n ↔
+lemma order_eq_int_iff (hf : MeromorphicAt f x) (n : ℤ) : hf.order = n ↔
     ∃ g : 𝕜 → E, AnalyticAt 𝕜 g x ∧ g x ≠ 0 ∧ ∀ᶠ z in 𝓝[≠] x, f z = (z - x) ^ n • g z := by
   unfold order
   by_cases h : hf.choose_spec.order = ⊤
@@ -88,7 +89,7 @@ lemma order_eq_int_iff {f : 𝕜 → E} {x : 𝕜} (hf : MeromorphicAt f x) (n :
 
 /-- Meromorphic functions that agree in a punctured neighborhood of `z₀` have the same order at
 `z₀`. -/
-theorem order_congr {f₁ f₂ : 𝕜 → E} {x : 𝕜} (hf₁ : MeromorphicAt f₁ x)
+theorem order_congr (hf₁ : MeromorphicAt f₁ x)
     (hf₁₂ : f₁ =ᶠ[𝓝[≠] x] f₂) :
     hf₁.order = (hf₁.congr hf₁₂).order := by
   by_cases h₁f₁ : hf₁.order = ⊤
@@ -102,7 +103,7 @@ theorem order_congr {f₁ f₂ : 𝕜 → E} {x : 𝕜} (hf₁ : MeromorphicAt f
     exact EventuallyEq.rw h₃g (fun x => Eq (f₂ x)) hf₁₂.symm
 
 /-- Compatibility of notions of `order` for analytic and meromorphic functions. -/
-lemma _root_.AnalyticAt.meromorphicAt_order {f : 𝕜 → E} {x : 𝕜} (hf : AnalyticAt 𝕜 f x) :
+lemma _root_.AnalyticAt.meromorphicAt_order (hf : AnalyticAt 𝕜 f x) :
     hf.meromorphicAt.order = hf.order.map (↑) := by
   rcases eq_or_ne hf.order ⊤ with ho | ho
   · rw [ho, ENat.map_top, order_eq_top_iff]
@@ -115,7 +116,7 @@ lemma _root_.AnalyticAt.meromorphicAt_order {f : 𝕜 → E} {x : 𝕜} (hf : An
 /--
 When seen as meromorphic functions, analytic functions have nonnegative order.
 -/
-theorem _root_.AnalyticAt.meromorphicAt_order_nonneg {f : 𝕜 → E} {x : 𝕜} (hf : AnalyticAt 𝕜 f x) :
+theorem _root_.AnalyticAt.meromorphicAt_order_nonneg (hf : AnalyticAt 𝕜 f x) :
     0 ≤ hf.meromorphicAt.order := by
   simp [hf.meromorphicAt_order, (by rfl : (0 : WithTop ℤ) = (0 : ℕ∞).map _)]
 
@@ -123,13 +124,10 @@ theorem _root_.AnalyticAt.meromorphicAt_order_nonneg {f : 𝕜 → E} {x : 𝕜}
 ## Order at a Point: Behaviour under Ring Operations
 
 We establish additivity of the order under multiplication and taking powers.
-
-TODO: Behaviour under Addition/Subtraction. API unification with analytic functions
 -/
 
 /-- The order is additive when multiplying scalar-valued and vector-valued meromorphic functions. -/
-theorem order_smul {f : 𝕜 → 𝕜} {g : 𝕜 → E} {x : 𝕜}
-    (hf : MeromorphicAt f x) (hg : MeromorphicAt g x) :
+theorem order_smul {f : 𝕜 → 𝕜} {g : 𝕜 → E} (hf : MeromorphicAt f x) (hg : MeromorphicAt g x) :
     (hf.smul hg).order = hf.order + hg.order := by
   -- Trivial cases: one of the functions vanishes around z₀
   cases h₂f : hf.order with
@@ -150,12 +148,12 @@ theorem order_smul {f : 𝕜 → 𝕜} {g : 𝕜 → E} {x : 𝕜}
       simp [hfa, hga, smul_comm (F a), zpow_add₀ (sub_ne_zero.mpr ha), mul_smul]
 
 /-- The order is additive when multiplying meromorphic functions. -/
-theorem order_mul {f g : 𝕜 → 𝕜} {x : 𝕜} (hf : MeromorphicAt f x) (hg : MeromorphicAt g x) :
+theorem order_mul {f g : 𝕜 → 𝕜} (hf : MeromorphicAt f x) (hg : MeromorphicAt g x) :
     (hf.mul hg).order = hf.order + hg.order :=
   hf.order_smul hg
 
 /-- The order of the inverse is the negative of the order. -/
-theorem order_inv {f : 𝕜 → 𝕜} {z₀ : 𝕜} (hf : MeromorphicAt f z₀) :
+theorem order_inv {f : 𝕜 → 𝕜} (hf : MeromorphicAt f x) :
     hf.inv.order = -hf.order := by
   by_cases h₂f : hf.order = ⊤
   · rw [h₂f, ← LinearOrderedAddCommGroupWithTop.neg_top, neg_neg]
@@ -175,7 +173,7 @@ theorem order_inv {f : 𝕜 → 𝕜} {z₀ : 𝕜} (hf : MeromorphicAt f z₀) 
 /--
 The order of a sum at least the minimum of the orders of the summands.
 -/
-theorem order_add {f₁ f₂ : 𝕜 → E} {x : 𝕜} (hf₁ : MeromorphicAt f₁ x) (hf₂ : MeromorphicAt f₂ x) :
+theorem order_add (hf₁ : MeromorphicAt f₁ x) (hf₂ : MeromorphicAt f₂ x) :
     min hf₁.order hf₂.order ≤ (hf₁.add hf₂).order := by
   -- Handle the trivial cases where one of the orders equals ⊤
   by_cases h₂f₁: hf₁.order = ⊤
@@ -212,8 +210,8 @@ theorem order_add {f₁ f₂ : 𝕜 → E} {x : 𝕜} (hf₁ : MeromorphicAt f�
 /--
 Helper lemma for MeromorphicAt.order_add_of_unequal_order.
 -/
-lemma order_add_of_order_lt_order {f₁ f₂ : 𝕜 → E} {x : 𝕜} (hf₁ : MeromorphicAt f₁ x)
-    (hf₂ : MeromorphicAt f₂ x) (h : hf₁.order < hf₂.order) :
+lemma order_add_of_order_lt_order (hf₁ : MeromorphicAt f₁ x) (hf₂ : MeromorphicAt f₂ x)
+    (h : hf₁.order < hf₂.order) :
     (hf₁.add hf₂).order = hf₁.order := by
   -- Trivial case: f₂ vanishes identically around z₀
   by_cases h₁f₂ : hf₂.order = ⊤
@@ -240,8 +238,8 @@ lemma order_add_of_order_lt_order {f₁ f₂ : 𝕜 → E} {x : 𝕜} (hf₁ : M
 If two meromorphic functions have unequal orders, then the order of their sum is
 exactly the minimum of the orders of the summands.
 -/
-theorem order_add_of_unequal_order {f₁ f₂ : 𝕜 → E} {x : 𝕜} (hf₁ : MeromorphicAt f₁ x)
-    (hf₂ : MeromorphicAt f₂ x) (h : hf₁.order ≠ hf₂.order) :
+theorem order_add_of_unequal_order (hf₁ : MeromorphicAt f₁ x) (hf₂ : MeromorphicAt f₂ x)
+    (h : hf₁.order ≠ hf₂.order) :
     (hf₁.add hf₂).order = min hf₁.order hf₂.order := by
   rcases lt_or_lt_iff_ne.mpr h with h | h
   · simpa [h.le] using hf₁.order_add_of_order_lt_order hf₂ h
@@ -251,14 +249,11 @@ end MeromorphicAt
 
 /-!
 ## Level Sets of the Order Function
-
-TODO: investigate whether `codiscrete_setOf_order_eq_zero_or_top` really needs a completeness
-hypothesis.
 -/
 
 namespace MeromorphicOn
 
-variable {f : 𝕜 → E} {U : Set 𝕜} (hf : MeromorphicOn f U)
+variable {U : Set 𝕜} (hf : MeromorphicOn f U)
 
 /-- The set where a meromorphic function has infinite order is clopen in its domain of meromorphy.
 -/
@@ -330,7 +325,7 @@ theorem exists_order_ne_top_iff_forall (hU : IsConnected U) :
 
 /-- On a preconnected set, a meromorphic function has finite order at one point if it has finite
 order at another point. -/
-theorem order_ne_top_of_isPreconnected {x y : 𝕜} (hU : IsPreconnected U) (h₁x : x ∈ U) (hy : y ∈ U)
+theorem order_ne_top_of_isPreconnected {y : 𝕜} (hU : IsPreconnected U) (h₁x : x ∈ U) (hy : y ∈ U)
     (h₂x : (hf x h₁x).order ≠ ⊤) :
     (hf y hy).order ≠ ⊤ :=
   (hf.exists_order_ne_top_iff_forall ⟨nonempty_of_mem h₁x, hU⟩).1 (by use ⟨x, h₁x⟩) ⟨y, hy⟩

--- a/Mathlib/Analysis/Meromorphic/Order.lean
+++ b/Mathlib/Analysis/Meromorphic/Order.lean
@@ -60,7 +60,7 @@ lemma order_eq_top_iff (hf : MeromorphicAt f x) :
 
 /-- The order of a meromorphic function `f` at `z₀` equals an integer `n` iff `f` can locally be
 written as `f z = (z - z₀) ^ n • g z`, where `g` is analytic and does not vanish at `z₀`. -/
-lemma order_eq_int_iff (hf : MeromorphicAt f x) (n : ℤ) : hf.order = n ↔
+lemma order_eq_int_iff {n : ℤ} (hf : MeromorphicAt f x) : hf.order = n ↔
     ∃ g : 𝕜 → E, AnalyticAt 𝕜 g x ∧ g x ≠ 0 ∧ ∀ᶠ z in 𝓝[≠] x, f z = (z - x) ^ n • g z := by
   unfold order
   by_cases h : hf.choose_spec.order = ⊤
@@ -77,7 +77,7 @@ lemma order_eq_int_iff (hf : MeromorphicAt f x) (n : ℤ) : hf.order = n ↔
     exact mul_ne_zero (pow_ne_zero _ (sub_ne_zero.mpr hz)) (zpow_ne_zero _ (sub_ne_zero.mpr hz))
   · obtain ⟨m, h⟩ := ENat.ne_top_iff_exists.mp h
     rw [← h, ENat.map_coe, ← WithTop.coe_natCast, ← coe_sub, WithTop.coe_inj]
-    obtain ⟨g, hg_an, hg_ne, hg_eq⟩ := (AnalyticAt.order_eq_nat_iff _ _).mp h.symm
+    obtain ⟨g, hg_an, hg_ne, hg_eq⟩ := (AnalyticAt.order_eq_nat_iff _).mp h.symm
     replace hg_eq : ∀ᶠ (z : 𝕜) in 𝓝[≠] x, f z = (z - x) ^ (↑m - ↑hf.choose : ℤ) • g z := by
       rw [eventually_nhdsWithin_iff]
       filter_upwards [hg_eq] with z hg_eq hz
@@ -97,7 +97,7 @@ theorem order_congr (hf₁ : MeromorphicAt f₁ x)
     rw [hf₁.order_eq_top_iff] at h₁f₁
     exact EventuallyEq.rw h₁f₁ (fun x => Eq (f₂ x)) hf₁₂.symm
   · obtain ⟨n, hn : hf₁.order = n⟩ := Option.ne_none_iff_exists'.mp h₁f₁
-    obtain ⟨g, h₁g, h₂g, h₃g⟩ := (hf₁.order_eq_int_iff n).1 hn
+    obtain ⟨g, h₁g, h₂g, h₃g⟩ := hf₁.order_eq_int_iff.1 hn
     rw [hn, eq_comm, (hf₁.congr hf₁₂).order_eq_int_iff]
     use g, h₁g, h₂g
     exact EventuallyEq.rw h₃g (fun x => Eq (f₂ x)) hf₁₂.symm
@@ -110,7 +110,7 @@ lemma _root_.AnalyticAt.meromorphicAt_order (hf : AnalyticAt 𝕜 f x) :
     exact (hf.order_eq_top_iff.mp ho).filter_mono nhdsWithin_le_nhds
   · obtain ⟨n, hn⟩ := ENat.ne_top_iff_exists.mp ho
     simp_rw [← hn, ENat.map_coe, order_eq_int_iff, zpow_natCast]
-    rcases (hf.order_eq_nat_iff _).mp hn.symm with ⟨g, h1, h2, h3⟩
+    rcases hf.order_eq_nat_iff.mp hn.symm with ⟨g, h1, h2, h3⟩
     exact ⟨g, h1, h2, h3.filter_mono nhdsWithin_le_nhds⟩
 
 /--
@@ -141,8 +141,8 @@ theorem order_smul {f : 𝕜 → 𝕜} {g : 𝕜 → E} (hf : MeromorphicAt f x)
       filter_upwards [h₂g] with z hz using by simp [hz]
     | coe n => -- Non-trivial case: both functions do not vanish around z₀
       rw [← WithTop.coe_add, order_eq_int_iff]
-      obtain ⟨F, h₁F, h₂F, h₃F⟩ := (hf.order_eq_int_iff _).1 h₂f
-      obtain ⟨G, h₁G, h₂G, h₃G⟩ := (hg.order_eq_int_iff _).1 h₂g
+      obtain ⟨F, h₁F, h₂F, h₃F⟩ := hf.order_eq_int_iff.1 h₂f
+      obtain ⟨G, h₁G, h₂G, h₃G⟩ := hg.order_eq_int_iff.1 h₂g
       use F • G, h₁F.smul h₁G, by simp [h₂F, h₂G]
       filter_upwards [self_mem_nhdsWithin, h₃F, h₃G] with a ha hfa hga
       simp [hfa, hga, smul_comm (F a), zpow_add₀ (sub_ne_zero.mpr ha), mul_smul]
@@ -161,8 +161,8 @@ theorem order_inv {f : 𝕜 → 𝕜} (hf : MeromorphicAt f x) :
     filter_upwards [h₂f]
     simp
   lift hf.order to ℤ using h₂f with a ha
-  apply (hf.inv.order_eq_int_iff (-a)).2
-  obtain ⟨g, h₁g, h₂g, h₃g⟩ := (hf.order_eq_int_iff a).1 ha.symm
+  apply hf.inv.order_eq_int_iff.2
+  obtain ⟨g, h₁g, h₂g, h₃g⟩ := hf.order_eq_int_iff.1 ha.symm
   use g⁻¹, h₁g.inv h₂g, inv_eq_zero.not.2 h₂g
   rw [eventually_nhdsWithin_iff] at *
   filter_upwards [h₃g]
@@ -188,14 +188,14 @@ theorem order_add (hf₁ : MeromorphicAt f₁ x) (hf₂ : MeromorphicAt f₂ x) 
   -- General case
   lift hf₁.order to ℤ using h₂f₁ with n₁ hn₁
   lift hf₂.order to ℤ using h₂f₂ with n₂ hn₂
-  obtain ⟨g₁, h₁g₁, h₂g₁, h₃g₁⟩ := (hf₁.order_eq_int_iff n₁).1 hn₁.symm
-  obtain ⟨g₂, h₁g₂, h₂g₂, h₃g₂⟩ := (hf₂.order_eq_int_iff n₂).1 hn₂.symm
+  obtain ⟨g₁, h₁g₁, h₂g₁, h₃g₁⟩ := hf₁.order_eq_int_iff.1 hn₁.symm
+  obtain ⟨g₂, h₁g₂, h₂g₂, h₃g₂⟩ := hf₂.order_eq_int_iff.1 hn₂.symm
   let n := min n₁ n₂
   let g := (fun z ↦ (z - x) ^ (n₁ - n)) • g₁ +  (fun z ↦ (z - x) ^ (n₂ - n)) • g₂
   have h₁g : AnalyticAt 𝕜 g x := by
     apply AnalyticAt.add
-    apply (AnalyticAt.zpow_nonneg (by fun_prop) (sub_nonneg.2 (Int.min_le_left n₁ n₂))).smul h₁g₁
-    apply (AnalyticAt.zpow_nonneg (by fun_prop) (sub_nonneg.2 (Int.min_le_right n₁ n₂))).smul h₁g₂
+    apply (AnalyticAt.zpow_nonneg (by fun_prop) (sub_nonneg.2 (min_le_left n₁ n₂))).smul h₁g₁
+    apply (AnalyticAt.zpow_nonneg (by fun_prop) (sub_nonneg.2 (min_le_right n₁ n₂))).smul h₁g₂
   have : f₁ + f₂ =ᶠ[𝓝[≠] x] ((· - x) ^ n) • g := by
     filter_upwards [h₃g₁, h₃g₂, self_mem_nhdsWithin]
     simp_all [g, ← smul_assoc, ← zpow_add', sub_ne_zero]
@@ -221,17 +221,17 @@ lemma order_add_of_order_lt_order (hf₁ : MeromorphicAt f₁ x) (hf₂ : Meromo
   -- General case
   lift hf₂.order to ℤ using h₁f₂ with n₂ hn₂
   lift hf₁.order to ℤ using h.ne_top with n₁ hn₁
-  obtain ⟨g₁, h₁g₁, h₂g₁, h₃g₁⟩ := (hf₁.order_eq_int_iff n₁).1 hn₁.symm
-  obtain ⟨g₂, h₁g₂, h₂g₂, h₃g₂⟩ := (hf₂.order_eq_int_iff n₂).1 hn₂.symm
-  rw [(hf₁.add hf₂).order_eq_int_iff n₁]
+  obtain ⟨g₁, h₁g₁, h₂g₁, h₃g₁⟩ := hf₁.order_eq_int_iff.1 hn₁.symm
+  obtain ⟨g₂, h₁g₂, h₂g₂, h₃g₂⟩ := hf₂.order_eq_int_iff.1 hn₂.symm
+  rw [(hf₁.add hf₂).order_eq_int_iff]
   use g₁ + (· - x) ^ (n₂ - n₁) • g₂
   constructor
   · apply h₁g₁.add (AnalyticAt.smul _ h₁g₂)
     apply AnalyticAt.zpow_nonneg (by fun_prop)
-      (sub_nonneg.2 (Int.le_of_lt (WithTop.coe_lt_coe.1 h)))
+      (sub_nonneg.2 (le_of_lt (WithTop.coe_lt_coe.1 h)))
   constructor
   · simpa [zero_zpow _ <| sub_ne_zero.mpr (WithTop.coe_lt_coe.1 h).ne']
-  · filter_upwards [h₃g₁, h₃g₂, (self_mem_nhdsWithin : {x}ᶜ ∈ 𝓝[≠] x)]
+  · filter_upwards [h₃g₁, h₃g₂, self_mem_nhdsWithin]
     simp_all [smul_add, ← smul_assoc, ← zpow_add', sub_ne_zero]
 
 /--

--- a/Mathlib/Analysis/Meromorphic/Order.lean
+++ b/Mathlib/Analysis/Meromorphic/Order.lean
@@ -200,10 +200,7 @@ theorem order_add (hf₁ : MeromorphicAt f₁ x) (hf₂ : MeromorphicAt f₂ x) 
     filter_upwards [h₃g₁, h₃g₂, self_mem_nhdsWithin]
     simp_all [g, ← smul_assoc, ← zpow_add', sub_ne_zero]
   have t₀ : MeromorphicAt ((·  - x) ^ n) x := by fun_prop
-  have t₁ : t₀.order = n := by
-    rw [t₀.order_eq_int_iff]
-    use 1, analyticAt_const
-    simp
+  have t₁ : t₀.order = n := (t₀.order_eq_int_iff _).mpr ⟨1, analyticAt_const, by simp⟩
   rw [(hf₁.add hf₂).order_congr this, t₀.order_smul h₁g.meromorphicAt, t₁]
   exact le_add_of_nonneg_right h₁g.meromorphicAt_order_nonneg
 

--- a/Mathlib/Analysis/Meromorphic/Order.lean
+++ b/Mathlib/Analysis/Meromorphic/Order.lean
@@ -112,6 +112,14 @@ lemma _root_.AnalyticAt.meromorphicAt_order {f : 𝕜 → E} {x : 𝕜} (hf : An
     rcases (hf.order_eq_nat_iff _).mp hn.symm with ⟨g, h1, h2, h3⟩
     exact ⟨g, h1, h2, h3.filter_mono nhdsWithin_le_nhds⟩
 
+/--
+When seen as meromorphic functions, analytic functions have nonnegative order.
+-/
+theorem _root_.AnalyticAt.meromorphicAt_order_nonneg {f : 𝕜 → E} {x : 𝕜} (hf : AnalyticAt 𝕜 f x) :
+    0 ≤ hf.meromorphicAt.order := by
+  rw [hf.meromorphicAt_order, (by rfl : (0 : WithTop ℤ) = WithTop.map Nat.cast (0 : ℕ∞))]
+  simp
+
 /-!
 ## Order at a Point: Behaviour under Ring Operations
 
@@ -164,6 +172,90 @@ theorem order_inv {f : 𝕜 → 𝕜} {z₀ : 𝕜} (hf : MeromorphicAt f z₀) 
   intro _ h₁a h₂a
   simp only [Pi.inv_apply, h₁a h₂a, smul_eq_mul, mul_inv_rev, zpow_neg]
   ring
+
+/--
+The order of a sum at least the minimum of the orders of the summands.
+-/
+theorem order_add {f₁ f₂ : 𝕜 → E} {x : 𝕜} (hf₁ : MeromorphicAt f₁ x) (hf₂ : MeromorphicAt f₂ x) :
+    min hf₁.order hf₂.order ≤ (hf₁.add hf₂).order := by
+  -- Handle the trivial cases where one of the orders equals ⊤
+  by_cases h₂f₁: hf₁.order = ⊤
+  · simp only [h₂f₁, le_top, inf_of_le_right]
+    rw [(hf₁.add hf₂).order_congr]
+    filter_upwards [hf₁.order_eq_top_iff.1 h₂f₁]
+    simp
+  by_cases h₂f₂: hf₂.order = ⊤
+  · simp only [h₂f₂, le_top, inf_of_le_left]
+    rw [(hf₁.add hf₂).order_congr]
+    filter_upwards [hf₂.order_eq_top_iff.1 h₂f₂]
+    simp
+  -- General case
+  lift hf₁.order to ℤ using h₂f₁ with n₁ hn₁
+  lift hf₂.order to ℤ using h₂f₂ with n₂ hn₂
+  obtain ⟨g₁, h₁g₁, h₂g₁, h₃g₁⟩ := (hf₁.order_eq_int_iff n₁).1 hn₁.symm
+  obtain ⟨g₂, h₁g₂, h₂g₂, h₃g₂⟩ := (hf₂.order_eq_int_iff n₂).1 hn₂.symm
+  let n := min n₁ n₂
+  let g := (fun z ↦ (z - x) ^ (n₁ - n)) • g₁ +  (fun z ↦ (z - x) ^ (n₂ - n)) • g₂
+  have h₁g : AnalyticAt 𝕜 g x := by
+    apply AnalyticAt.add
+    apply (AnalyticAt.zpow_nonneg (by fun_prop) (sub_nonneg.2 (Int.min_le_left n₁ n₂))).smul h₁g₁
+    apply (AnalyticAt.zpow_nonneg (by fun_prop) (sub_nonneg.2 (Int.min_le_right n₁ n₂))).smul h₁g₂
+  have : f₁ + f₂ =ᶠ[𝓝[≠] x] ((· - x) ^ n) • g := by
+    filter_upwards [h₃g₁, h₃g₂, (self_mem_nhdsWithin : {x}ᶜ ∈ 𝓝[≠] x)]
+    unfold g
+    simp_all [smul_add, ← smul_assoc, ← zpow_add', sub_ne_zero]
+  have t₀ : MeromorphicAt ((·  - x) ^ n) x := by fun_prop
+  have t₁ : t₀.order = n := by
+    rw [t₀.order_eq_int_iff]
+    use 1, analyticAt_const
+    simp
+  rw [(hf₁.add hf₂).order_congr this, t₀.order_smul h₁g.meromorphicAt, t₁]
+  exact le_add_of_nonneg_right h₁g.meromorphicAt_order_nonneg
+
+/--
+Helper lemma for MeromorphicAt.order_add_of_unequal_order.
+-/
+lemma order_add_of_order_lt_order {f₁ f₂ : 𝕜 → E} {x : 𝕜} (hf₁ : MeromorphicAt f₁ x)
+    (hf₂ : MeromorphicAt f₂ x) (h : hf₁.order < hf₂.order) :
+    (hf₁.add hf₂).order = hf₁.order := by
+  -- Trivial case: f₂ vanishes identically around z₀
+  by_cases h₁f₂ : hf₂.order = ⊤
+  · rw [(hf₁.add hf₂).order_congr]
+    filter_upwards [hf₂.order_eq_top_iff.1 h₁f₂]
+    simp
+  -- General case
+  lift hf₂.order to ℤ using h₁f₂ with n₂ hn₂
+  lift hf₁.order to ℤ using h.ne_top with n₁ hn₁
+  obtain ⟨g₁, h₁g₁, h₂g₁, h₃g₁⟩ := (hf₁.order_eq_int_iff n₁).1 hn₁.symm
+  obtain ⟨g₂, h₁g₂, h₂g₂, h₃g₂⟩ := (hf₂.order_eq_int_iff n₂).1 hn₂.symm
+  rw [(hf₁.add hf₂).order_eq_int_iff n₁]
+  use g₁ + (· - x) ^ (n₂ - n₁) • g₂
+  constructor
+  · apply h₁g₁.add (AnalyticAt.smul _ h₁g₂)
+    apply AnalyticAt.zpow_nonneg (by fun_prop)
+      (sub_nonneg.2 (Int.le_of_lt (WithTop.coe_lt_coe.1 h)))
+  constructor
+  · have : (0 : 𝕜) ^ (n₂ - n₁) = (0 : 𝕜) := by
+      rw [zpow_eq_zero_iff]
+      rw [ne_eq, sub_eq_zero, eq_comm, ← ne_eq]
+      exact ne_of_lt (WithTop.coe_lt_coe.1 h)
+    simpa [this]
+  · filter_upwards [h₃g₁, h₃g₂, (self_mem_nhdsWithin : {x}ᶜ ∈ 𝓝[≠] x)]
+    simp_all [smul_add, ← smul_assoc, ← zpow_add', sub_ne_zero]
+
+/--
+If two meromorphic functions have unequal orders, then the order of their sum is
+exactly the minimum of the orders of the summands.
+-/
+theorem order_add_of_unequal_order {f₁ f₂ : 𝕜 → E} {x : 𝕜} (hf₁ : MeromorphicAt f₁ x)
+    (hf₂ : MeromorphicAt f₂ x) (h : hf₁.order ≠ hf₂.order) :
+    (hf₁.add hf₂).order = min hf₁.order hf₂.order := by
+  by_cases h₁ : hf₁.order < hf₂.order
+  · rw [min_eq_left (le_of_lt h₁)]
+    exact hf₁.order_add_of_order_lt_order hf₂ h₁
+  · rw [min_eq_right (le_of_not_lt h₁)]
+    simp_rw [AddCommMagma.add_comm f₁ f₂]
+    exact hf₂.order_add_of_order_lt_order hf₁ (lt_of_le_of_ne (le_of_not_lt h₁) h.symm)
 
 end MeromorphicAt
 

--- a/Mathlib/Analysis/Meromorphic/Order.lean
+++ b/Mathlib/Analysis/Meromorphic/Order.lean
@@ -117,8 +117,7 @@ When seen as meromorphic functions, analytic functions have nonnegative order.
 -/
 theorem _root_.AnalyticAt.meromorphicAt_order_nonneg {f : 𝕜 → E} {x : 𝕜} (hf : AnalyticAt 𝕜 f x) :
     0 ≤ hf.meromorphicAt.order := by
-  rw [hf.meromorphicAt_order, (by rfl : (0 : WithTop ℤ) = WithTop.map Nat.cast (0 : ℕ∞))]
-  simp
+  simp [hf.meromorphicAt_order, (by rfl : (0 : WithTop ℤ) = (0 : ℕ∞).map _)]
 
 /-!
 ## Order at a Point: Behaviour under Ring Operations
@@ -180,8 +179,7 @@ theorem order_add {f₁ f₂ : 𝕜 → E} {x : 𝕜} (hf₁ : MeromorphicAt f�
     min hf₁.order hf₂.order ≤ (hf₁.add hf₂).order := by
   -- Handle the trivial cases where one of the orders equals ⊤
   by_cases h₂f₁: hf₁.order = ⊤
-  · simp only [h₂f₁, le_top, inf_of_le_right]
-    rw [(hf₁.add hf₂).order_congr]
+  · rw [h₂f₁, min_top_left, (hf₁.add hf₂).order_congr]
     filter_upwards [hf₁.order_eq_top_iff.1 h₂f₁]
     simp
   by_cases h₂f₂: hf₂.order = ⊤
@@ -201,9 +199,8 @@ theorem order_add {f₁ f₂ : 𝕜 → E} {x : 𝕜} (hf₁ : MeromorphicAt f�
     apply (AnalyticAt.zpow_nonneg (by fun_prop) (sub_nonneg.2 (Int.min_le_left n₁ n₂))).smul h₁g₁
     apply (AnalyticAt.zpow_nonneg (by fun_prop) (sub_nonneg.2 (Int.min_le_right n₁ n₂))).smul h₁g₂
   have : f₁ + f₂ =ᶠ[𝓝[≠] x] ((· - x) ^ n) • g := by
-    filter_upwards [h₃g₁, h₃g₂, (self_mem_nhdsWithin : {x}ᶜ ∈ 𝓝[≠] x)]
-    unfold g
-    simp_all [smul_add, ← smul_assoc, ← zpow_add', sub_ne_zero]
+    filter_upwards [h₃g₁, h₃g₂, self_mem_nhdsWithin]
+    simp_all [g, ← smul_assoc, ← zpow_add', sub_ne_zero]
   have t₀ : MeromorphicAt ((·  - x) ^ n) x := by fun_prop
   have t₁ : t₀.order = n := by
     rw [t₀.order_eq_int_iff]
@@ -235,11 +232,7 @@ lemma order_add_of_order_lt_order {f₁ f₂ : 𝕜 → E} {x : 𝕜} (hf₁ : M
     apply AnalyticAt.zpow_nonneg (by fun_prop)
       (sub_nonneg.2 (Int.le_of_lt (WithTop.coe_lt_coe.1 h)))
   constructor
-  · have : (0 : 𝕜) ^ (n₂ - n₁) = (0 : 𝕜) := by
-      rw [zpow_eq_zero_iff]
-      rw [ne_eq, sub_eq_zero, eq_comm, ← ne_eq]
-      exact ne_of_lt (WithTop.coe_lt_coe.1 h)
-    simpa [this]
+  · simpa [zero_zpow _ <| sub_ne_zero.mpr (WithTop.coe_lt_coe.1 h).ne']
   · filter_upwards [h₃g₁, h₃g₂, (self_mem_nhdsWithin : {x}ᶜ ∈ 𝓝[≠] x)]
     simp_all [smul_add, ← smul_assoc, ← zpow_add', sub_ne_zero]
 
@@ -250,12 +243,9 @@ exactly the minimum of the orders of the summands.
 theorem order_add_of_unequal_order {f₁ f₂ : 𝕜 → E} {x : 𝕜} (hf₁ : MeromorphicAt f₁ x)
     (hf₂ : MeromorphicAt f₂ x) (h : hf₁.order ≠ hf₂.order) :
     (hf₁.add hf₂).order = min hf₁.order hf₂.order := by
-  by_cases h₁ : hf₁.order < hf₂.order
-  · rw [min_eq_left (le_of_lt h₁)]
-    exact hf₁.order_add_of_order_lt_order hf₂ h₁
-  · rw [min_eq_right (le_of_not_lt h₁)]
-    simp_rw [AddCommMagma.add_comm f₁ f₂]
-    exact hf₂.order_add_of_order_lt_order hf₁ (lt_of_le_of_ne (le_of_not_lt h₁) h.symm)
+  rcases lt_or_lt_iff_ne.mpr h with h | h
+  · simpa [h.le] using hf₁.order_add_of_order_lt_order hf₂ h
+  · simpa [h.le, add_comm] using hf₂.order_add_of_order_lt_order hf₁ h
 
 end MeromorphicAt
 

--- a/Mathlib/Analysis/Meromorphic/Order.lean
+++ b/Mathlib/Analysis/Meromorphic/Order.lean
@@ -171,7 +171,7 @@ theorem order_inv {f : 𝕜 → 𝕜} (hf : MeromorphicAt f x) :
   ring
 
 /--
-The order of a sum at least the minimum of the orders of the summands.
+The order of a sum is at least the minimum of the orders of the summands.
 -/
 theorem order_add (hf₁ : MeromorphicAt f₁ x) (hf₂ : MeromorphicAt f₂ x) :
     min hf₁.order hf₂.order ≤ (hf₁.add hf₂).order := by


### PR DESCRIPTION
Deliver on one of the open TODOs and establish the behavior of `MeromorphicAt.order` under addition. 

This material is used in [Project VD](https://github.com/kebekus/ProjectVD), which aims to formalize Value Distribution Theory for meromorphic functions on the complex plane.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
