### PR TITLE
[Merged by Bors] - feat(GroupTheory/FreeGroup/Basic): add lemmas for invRev

### DIFF
--- a/Mathlib/GroupTheory/FreeGroup/Basic.lean
+++ b/Mathlib/GroupTheory/FreeGroup/Basic.lean
@@ -459,6 +459,13 @@ theorem invRev_invRev : invRev (invRev L₁) = L₁ := by
 theorem invRev_empty : invRev ([] : List (α × Bool)) = [] :=
   rfl
 
+@[to_additive (attr := simp)]
+theorem invRev_append : invRev (L₁ ++ L₂) = invRev L₂ ++ invRev L₁ := by simp [invRev]
+
+@[to_additive]
+theorem invRev_cons {a : (α × Bool)} : invRev (a :: L) = invRev L ++ invRev [a] := by
+  simp [invRev]
+
 @[to_additive]
 theorem invRev_involutive : Function.Involutive (@invRev α) := fun _ => invRev_invRev
 


### PR DESCRIPTION
Upstreamed from the [EquationalTheories](https://github.com/teorth/equational_theories) project.

This PR adds the lemmas `invRev_append` and `invRev_cons` describing the interaction of `invRev` with the typical list operations. Note that `invRev_append` is a simp lemma, but `invRev_cons` is not, as otherwise there would be an infinite simp loop.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
