### PR TITLE
[Merged by Bors] - fix(Tactic/Simproc): ensure `a'` is independent from `a` in `existsAndEq`

### DIFF
--- a/Mathlib/Tactic/Simproc/ExistsAndEq.lean
+++ b/Mathlib/Tactic/Simproc/ExistsAndEq.lean
@@ -8,9 +8,10 @@ import Mathlib.Init
 /-!
 # simproc for `∃ a', ... ∧ a' = a ∧ ...`
 
-This module implements the `existsAndEq` simproc that checks whether `P a'` has
-the form `... ∧ a' = a ∧ ...` or `... ∧ a = a' ∧ ...` for the goal `∃ a', P a'`.
-If so, it rewrites the latter as `P a`.
+This module implements the `existsAndEq` simproc that triggers on goals of the form `∃ a, body` and
+checks whether `body` has the form `... ∧ a = a' ∧ ...` or `... ∧ a' = a ∧ ...` for some `a'` that
+is independent of `a`. If so, it replaces all occurancies of `a` with `a'` and removes the
+quantifier.
 -/
 
 open Lean Meta
@@ -63,8 +64,9 @@ where
 
 end existsAndEq
 
-/-- Checks whether `P a'` has the form `... ∧ a' = a ∧ ...` or `... ∧ a = a' ∧ ...` in
-the goal `∃ a', P a'`. If so, rewrites the goal as `P a`. -/
+/-- Triggers on goals of the form `∃ a, body` and checks whether `body` has the
+form `... ∧ a = a' ∧ ...` or `... ∧ a' = a ∧ ...` for some `a'` that is independent of `a`.
+If so, it replaces all occurancies of `a` with `a'` and removes the quantifier. -/
 simproc existsAndEq (Exists (fun _ => And _ _)) := fun e => do
   match e.getAppFnArgs with
   | (``Exists, #[_, p]) =>

--- a/Mathlib/Tactic/Simproc/ExistsAndEq.lean
+++ b/Mathlib/Tactic/Simproc/ExistsAndEq.lean
@@ -47,9 +47,9 @@ where
     | (``Eq, #[β, a, b]) =>
       if !(← isDefEq (← inferType x) β) then
         return none
-      if ← isDefEq x a then
+      if (← isDefEq x a) && !(b.containsFVar x.fvarId!) then
         return .some ⟨b, ← mkAppM ``Eq.symm #[h]⟩
-      if ← isDefEq x b then
+      if (← isDefEq x b) && !(a.containsFVar x.fvarId!) then
         return .some ⟨a, h⟩
       else
         return .none

--- a/MathlibTest/Simproc/ExistsAndEq.lean
+++ b/MathlibTest/Simproc/ExistsAndEq.lean
@@ -11,6 +11,14 @@ example (a : α) (hp : p a) (hq : q a) : ∃ b : α, (p b ∧ b = a) ∧ q b := 
 example (a : α) : ∃ b : α, b = a := by
   simp only [existsAndEq]
 
+/--
+error: simp made no progress
+-/
+#guard_msgs in
+example (a : α) (f : α → α) (hp : p a) (hq : q a) : ∃ b : α, (p b ∧ b = f b) ∧ q b := by
+  simp only [existsAndEq]
+  sorry
+
 open Lean Meta Simp
 
 set_option linter.unusedTactic false in

--- a/MathlibTest/Simproc/ExistsAndEq.lean
+++ b/MathlibTest/Simproc/ExistsAndEq.lean
@@ -15,7 +15,7 @@ example (a : α) : ∃ b : α, b = a := by
 error: simp made no progress
 -/
 #guard_msgs in
-example (a : α) (f : α → α) (hp : p a) (hq : q a) : ∃ b : α, (p b ∧ b = f b) ∧ q b := by
+example (f : α → α) : ∃ a : α, a = f a := by
   simp only [existsAndEq]
   sorry
 


### PR DESCRIPTION
In the `existsAndEq` simproc, we should ignore subexpressions of the form `a = a'` when `a'` depends on `a`.

The following test previously failed with an `application type mismatch`:  
```lean
example (f : α → α) : ∃ a : α, a = f a := by
  simp only [existsAndEq] -- application type mismatch
  sorry
```

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
