### PR TITLE
[Merged by Bors] - feat(Data/Matroid/Loop): matroid coloops

### DIFF
--- a/Mathlib/Data/Matroid/Loop.lean
+++ b/Mathlib/Data/Matroid/Loop.lean
@@ -7,7 +7,9 @@ import Mathlib.Data.Matroid.Circuit
 import Mathlib.Tactic.TFAE
 
 /-!
-# Loops
+# Matroid loops and coloops
+
+## Loops
 A 'loop' of a matroid `M` is an element `e` satisfying one of the following equivalent conditions:
 * `e ∈ M.closure ∅`;
 * `{e}` is dependent in `M`;
@@ -23,7 +25,7 @@ For `M : Matroid α`, this file defines a set `Matroid.loops M : Set α`,
 as well as predicates `Matroid.IsLoop M : α → Prop` and `Matroid.IsNonloop M : α → Prop`,
 and provides API for interacting with them.
 
-# Coloops
+## Coloops
 The dual notion of a loop is a 'coloop'. Geometrically, these can be thought of elements that are
 skew to the remainder of the matroid. Coloops in graphic matroids are 'bridge' edges of the graph,
 and coloops in linearly representable matroids are vectors not spanned by the other vectors
@@ -37,7 +39,7 @@ a coloop is an element of `M.E` if any of the following equivalent conditions ho
 * for all `X ⊆ M.E`, `e ∈ X ↔ e ∈ M.closure X`,
 * `M.E \ {e}` is nonspanning.
 
-# Main Declarations
+## Main Declarations
 For `M` : Matroid `α`:
 * `M.loops` is the set `M.closure ∅`.
 * `M.IsLoop e` means that `e : α` is a loop of `M`, defined as the statement `e ∈ M.loops`.
@@ -46,7 +48,6 @@ For `M` : Matroid `α`:
 * `M.IsColoop e ` means that `e` is a loop of `M✶`.
 * `M.coloops` is the set of coloops of `M✶`.
 * `M.isColoop_tfae` gives a number of properties that are equivalent to `IsColoop`.
-
 -/
 
 variable {α β : Type*} {M N : Matroid α} {e f : α} {F X C I : Set α}
@@ -503,11 +504,11 @@ lemma isColoop_tfae (M : Matroid α) (e : α) : List.TFAE [
     · obtain ⟨C, -, hC, heC⟩ := (mem_closure_iff_exists_isCircuit heX').1 heX
       exact h hC heC
     simpa [hC.mem_closure_diff_singleton_of_mem heC] using h (C \ {e})
-  tfae_have 4 <-> 7 := by
-    refine ⟨fun h hsp ↦ ?_, fun h B hB ↦ by_contra fun heB ↦ h ?_⟩
-    · obtain ⟨B, hB⟩ := M.exists_isBasis (M.E \ {e}) diff_subset
-      exact (hB.subset <| h (hB.isBase_of_spanning hsp)).2 rfl
-    exact hB.spanning_of_superset (subset_diff_singleton hB.subset_ground heB) diff_subset
+  tfae_have 1 <-> 7 := by
+    wlog he : e ∈ M.E
+    · exact iff_of_false (fun h ↦ he h.mem_ground) <| by simp [he, M.ground_spanning]
+    rw [spanning_iff_compl_coindep diff_subset, ← dual_isLoop_iff_isColoop, ← singleton_dep,
+      diff_diff_cancel_left (by simpa), ← not_indep_iff (by simpa)]
   tfae_finish
 
 lemma isColoop_iff_forall_mem_isBase : M.IsColoop e ↔ ∀ ⦃B⦄, M.IsBase B → e ∈ B :=

--- a/Mathlib/Data/Matroid/Loop.lean
+++ b/Mathlib/Data/Matroid/Loop.lean
@@ -24,9 +24,12 @@ as well as predicates `Matroid.IsLoop M : α → Prop` and `Matroid.IsNonloop M 
 and provides API for interacting with them.
 
 # Coloops
-The dual notion of a loop is a 'coloop'. These elements are 'maximally free' in the same way
-that loops are minimaly free, and also have many equivalent definitions;
-in fact, a coloop is an element of `M.E` satisfying any of the following conditions:
+The dual notion of a loop is a 'coloop'. Geometrically, these can be thought of elements that are
+skew to the remainder of the matroid. Coloops in graphic matroids are 'bridge' edges of the graph,
+and coloops in linearly representable matroids are vectors not spanned by the other vectors
+in the elements of the matroid.
+Coloops also have many equivalent definitions in abstract matroid language;
+a coloop is an element of `M.E` if any of the following equivalent conditions holds :
 * `e` is a loop of `M✶`;
 * `{e}` is a cocircuit of `M`;
 * `e` is in no circuit of `M`;

--- a/Mathlib/Data/Matroid/Loop.lean
+++ b/Mathlib/Data/Matroid/Loop.lean
@@ -7,7 +7,7 @@ import Mathlib.Data.Matroid.Circuit
 import Mathlib.Tactic.TFAE
 
 /-!
-# Matroid Loops
+# Loops
 A 'loop' of a matroid `M` is an element `e` satisfying one of the following equivalent conditions:
 * `e ∈ M.closure ∅`;
 * `{e}` is dependent in `M`;
@@ -23,11 +23,27 @@ For `M : Matroid α`, this file defines a set `Matroid.loops M : Set α`,
 as well as predicates `Matroid.IsLoop M : α → Prop` and `Matroid.IsNonloop M : α → Prop`,
 and provides API for interacting with them.
 
+# Coloops
+The dual notion of a loop is a 'coloop'. These elements are 'maximally free' in the same way
+that loops are minimaly free, and also have many equivalent definitions;
+in fact, a coloop is an element of `M.E` satisfying any of the following conditions:
+* `e` is a loop of `M✶`;
+* `{e}` is a cocircuit of `M`;
+* `e` is in no circuit of `M`;
+* `e` is in every base of `M`;
+* for all `X ⊆ M.E`, `e ∈ X ↔ e ∈ M.closure X`,
+* `M.E \ {e}` is nonspanning.
+
 # Main Declarations
 For `M` : Matroid `α`:
 * `M.loops` is the set `M.closure ∅`.
 * `M.IsLoop e` means that `e : α` is a loop of `M`, defined as the statement `e ∈ M.loops`.
+* `M.isLoop_tfae` gives a number of properties that are equivalent to `IsLoop`.
 * `M.IsNonloop e` means that `e ∈ M.E`, but `e` is not a loop of `M`.
+* `M.IsColoop e ` means that `e` is a loop of `M✶`.
+* `M.coloops` is the set of coloops of `M✶`.
+* `M.isColoop_tfae` gives a number of properties that are equivalent to `IsColoop`.
+
 -/
 
 variable {α β : Type*} {M N : Matroid α} {e f : α} {F X C I : Set α}
@@ -247,10 +263,12 @@ lemma isNonloop_of_not_isLoop (he : e ∈ M.E := by aesop_mat) (h : ¬ M.IsLoop 
 lemma isLoop_of_not_isNonloop (he : e ∈ M.E := by aesop_mat) (h : ¬ M.IsNonloop e) : M.IsLoop e :=
   by rwa [isNonloop_iff, and_iff_left he, not_not] at h
 
-@[simp] lemma not_isLoop_iff (he : e ∈ M.E := by aesop_mat) : ¬M.IsLoop e ↔ M.IsNonloop e :=
+@[simp]
+lemma not_isLoop_iff (he : e ∈ M.E := by aesop_mat) : ¬M.IsLoop e ↔ M.IsNonloop e :=
   ⟨fun h ↦ ⟨h, he⟩, IsNonloop.not_isLoop⟩
 
-@[simp] lemma not_isNonloop_iff (he : e ∈ M.E := by aesop_mat) : ¬M.IsNonloop e ↔ M.IsLoop e := by
+@[simp]
+lemma not_isNonloop_iff (he : e ∈ M.E := by aesop_mat) : ¬M.IsNonloop e ↔ M.IsLoop e := by
   rw [← not_isLoop_iff, not_not]
 
 lemma isNonloop_iff_mem_compl_loops : M.IsNonloop e ↔ e ∈ M.E \ M.loops := by
@@ -269,7 +287,8 @@ lemma isLoop_or_isNonloop (M : Matroid α) (e : α) (he : e ∈ M.E := by aesop_
     M.IsLoop e ∨ M.IsNonloop e := by
   rw [isNonloop_iff, and_iff_left he]; apply em
 
-@[simp] lemma indep_singleton : M.Indep {e} ↔ M.IsNonloop e := by
+@[simp]
+lemma indep_singleton : M.Indep {e} ↔ M.IsNonloop e := by
   rw [isNonloop_iff, ← singleton_dep, dep_iff, not_and, not_imp_not, singleton_subset_iff]
   exact ⟨fun h ↦ ⟨fun _ ↦ h, singleton_subset_iff.mp h.subset_ground⟩, fun h ↦ h.1 h.2⟩
 
@@ -365,7 +384,8 @@ lemma exists_isNonloop (M : Matroid α) [RankPos M] : ∃ e, M.IsNonloop e :=
 lemma IsNonloop.rankPos (h : M.IsNonloop e) : M.RankPos :=
   h.indep.rankPos_of_nonempty (singleton_nonempty e)
 
-@[simp] lemma restrict_isNonloop_iff {R : Set α} : (M ↾ R).IsNonloop e ↔ M.IsNonloop e ∧ e ∈ R := by
+@[simp]
+lemma restrict_isNonloop_iff {R : Set α} : (M ↾ R).IsNonloop e ↔ M.IsNonloop e ∧ e ∈ R := by
   rw [← indep_singleton, restrict_indep_iff, singleton_subset_iff, indep_singleton]
 
 lemma IsNonloop.of_restrict {R : Set α} (h : (M ↾ R).IsNonloop e) : M.IsNonloop e :=
@@ -378,15 +398,18 @@ lemma isNonloop_iff_restrict_of_mem {R : Set α} (he : e ∈ R) :
     M.IsNonloop e ↔ (M ↾ R).IsNonloop e :=
   ⟨fun h ↦ restrict_isNonloop_iff.2 ⟨h, he⟩, fun h ↦ h.of_restrict⟩
 
-@[simp] lemma comap_isNonloop_iff {M : Matroid β} {f : α → β} :
+@[simp]
+lemma comap_isNonloop_iff {M : Matroid β} {f : α → β} :
     (M.comap f).IsNonloop e ↔ M.IsNonloop (f e) := by
   rw [← indep_singleton, comap_indep_iff, image_singleton, indep_singleton,
     and_iff_left (injOn_singleton _ _)]
 
-@[simp] lemma freeOn_isNonloop_iff {E : Set α} : (freeOn E).IsNonloop e ↔ e ∈ E := by
+@[simp]
+lemma freeOn_isNonloop_iff {E : Set α} : (freeOn E).IsNonloop e ↔ e ∈ E := by
   rw [← indep_singleton, freeOn_indep_iff, singleton_subset_iff]
 
-@[simp] lemma uniqueBaseOn_isNonloop_iff {I E : Set α} :
+@[simp]
+lemma uniqueBaseOn_isNonloop_iff {I E : Set α} :
     (uniqueBaseOn I E).IsNonloop e ↔ e ∈ I ∩ E := by
   rw [← indep_singleton, uniqueBaseOn_indep_iff', singleton_subset_iff]
 
@@ -400,5 +423,299 @@ lemma closure_inter_setOf_isNonloop_eq (M : Matroid α) (X : Set α) :
   rw [setOf_isNonloop_eq, ← inter_diff_assoc, closure_diff_loops_eq, closure_inter_ground]
 
 end IsNonloop
+
+section IsColoop
+
+variable {B K : Set α}
+
+/-- A coloop is a loop of the dual matroid.
+See `Matroid.isColoop_tfae` for a number of equivalent definitions. -/
+def IsColoop (M : Matroid α) (e : α) : Prop := M✶.IsLoop e
+
+/-- `M.coloops` is the set of coloops of `M`. -/
+def coloops (M : Matroid α) := M✶.loops
+
+@[aesop unsafe 20% (rule_sets := [Matroid])]
+lemma IsColoop.mem_ground (he : M.IsColoop e) : e ∈ M.E :=
+  @IsLoop.mem_ground α (M✶) e he
+
+@[aesop unsafe 20% (rule_sets := [Matroid])]
+lemma coloops_subset_ground (M : Matroid α) : M.coloops ⊆ M.E :=
+  fun _ ↦ IsColoop.mem_ground
+
+lemma isColoop_iff_mem_loops : M.IsColoop e ↔ e ∈ M.coloops := Iff.rfl
+
+@[simp]
+lemma dual_loops : M✶.loops = M.coloops := rfl
+
+@[simp]
+lemma dual_coloops : M✶.coloops = M.loops := by
+  rw [coloops, dual_dual]
+
+lemma IsColoop.dual_isLoop (he : M.IsColoop e) : M✶.IsLoop e :=
+  he
+
+lemma IsColoop.isCocircuit (he : M.IsColoop e) : M.IsCocircuit {e} :=
+  IsLoop.isCircuit he
+
+lemma IsLoop.dual_isColoop (he : M.IsLoop e) : M✶.IsColoop e :=
+  by rwa [IsColoop, dual_dual]
+
+@[simp]
+lemma dual_isColoop_iff_isLoop : M✶.IsColoop e ↔ M.IsLoop e :=
+  ⟨fun h ↦ by rw [← dual_dual M]; exact h.dual_isLoop, IsLoop.dual_isColoop⟩
+
+@[simp]
+lemma dual_isLoop_iff_isColoop : M✶.IsLoop e ↔ M.IsColoop e :=
+  ⟨fun h ↦ by rw [← dual_dual M]; exact h.dual_isColoop, IsColoop.dual_isLoop⟩
+
+lemma singleton_isCocircuit : M.IsCocircuit {e} ↔ M.IsColoop e := by
+  simp
+
+lemma isColoop_tfae (M : Matroid α) (e : α) : List.TFAE [
+    M.IsColoop e,
+    e ∈ M.coloops,
+    M.IsCocircuit {e},
+    ∀ ⦃B⦄, M.IsBase B → e ∈ B,
+    (∀ ⦃C⦄, M.IsCircuit C → e ∉ C) ∧ e ∈ M.E,
+    (∀ X, e ∈ M.closure X ↔ e ∈ X) ∧ e ∈ M.E,
+    ¬ M.Spanning (M.E \ {e}) ] := by
+  tfae_have 1 <-> 2 := Iff.rfl
+  tfae_have 1 <-> 3 := singleton_isCocircuit.symm
+  tfae_have 1 <-> 4 := by
+    simp_rw [← dual_isLoop_iff_isColoop, isLoop_iff_forall_mem_compl_isBase]
+    refine ⟨fun h B hB ↦ ?_, fun h B hB ↦ h hB.compl_isBase_of_dual⟩
+    obtain ⟨-, heB : e ∈ B⟩ := by simpa using h (M.E \ B) hB.compl_isBase_dual
+    assumption
+  tfae_have 3 -> 5 := fun h ↦
+    ⟨fun C hC heC ↦ hC.inter_isCocircuit_ne_singleton h (e := e) (by simpa), h.subset_ground rfl⟩
+  tfae_have 5 -> 4 := by
+    refine fun ⟨h, heE⟩ B hB ↦ by_contra fun heB ↦ ?_
+    rw [← hB.closure_eq] at heE
+    obtain ⟨C, -, hC, heC⟩ := (mem_closure_iff_exists_isCircuit heB).1 heE
+    exact h hC heC
+  tfae_have 5 <-> 6 := by
+    refine ⟨fun ⟨h, he⟩ ↦ ⟨fun X ↦ ⟨fun heX ↦ by_contra fun heX' ↦ ?_,
+      fun h' ↦ M.mem_closure_of_mem' h' he⟩, he⟩, fun ⟨h, he⟩ ↦ ⟨fun C hC heC ↦ ?_, he⟩⟩
+    · obtain ⟨C, -, hC, heC⟩ := (mem_closure_iff_exists_isCircuit heX').1 heX
+      exact h hC heC
+    simpa [hC.mem_closure_diff_singleton_of_mem heC] using h (C \ {e})
+  tfae_have 4 <-> 7 := by
+    refine ⟨fun h hsp ↦ ?_, fun h B hB ↦ by_contra fun heB ↦ h ?_⟩
+    · obtain ⟨B, hB⟩ := M.exists_isBasis (M.E \ {e}) diff_subset
+      exact (hB.subset <| h (hB.isBase_of_spanning hsp)).2 rfl
+    exact hB.spanning_of_superset (subset_diff_singleton hB.subset_ground heB) diff_subset
+  tfae_finish
+
+lemma isColoop_iff_forall_mem_isBase : M.IsColoop e ↔ ∀ ⦃B⦄, M.IsBase B → e ∈ B :=
+  (M.isColoop_tfae e).out 0 3
+
+lemma IsBase.mem_of_isColoop (hB : M.IsBase B) (he : M.IsColoop e) : e ∈ B :=
+  isColoop_iff_forall_mem_isBase.mp he hB
+
+lemma IsColoop.mem_of_isBase (he : M.IsColoop e) (hB : M.IsBase B) : e ∈ B :=
+  isColoop_iff_forall_mem_isBase.mp he hB
+
+lemma IsBase.coloops_subset (hB : M.IsBase B) : M.coloops ⊆ B :=
+  fun _ he ↦ IsColoop.mem_of_isBase he hB
+
+lemma IsColoop.isNonloop (h : M.IsColoop e) : M.IsNonloop e :=
+  let ⟨_, hB⟩ := M.exists_isBase
+  hB.indep.isNonloop_of_mem ((isColoop_iff_forall_mem_isBase.mp h) hB)
+
+lemma IsLoop.not_isColoop (h : M.IsLoop e) : ¬M.IsColoop e := by
+  rw [← dual_isLoop_iff_isColoop]; rw [← dual_dual M, dual_isLoop_iff_isColoop] at h
+  exact h.isNonloop.not_isLoop
+
+lemma IsColoop.not_mem_isCircuit (he : M.IsColoop e) (hC : M.IsCircuit C) : e ∉ C :=
+  fun h ↦ (hC.isCocircuit.isNonloop_of_mem h).not_isLoop he
+
+lemma IsCircuit.disjoint_coloops (hC : M.IsCircuit C) : Disjoint C M.coloops :=
+  disjoint_right.2 <| fun _ he ↦ IsColoop.not_mem_isCircuit he hC
+
+lemma isColoop_iff_forall_not_mem_isCircuit (he : e ∈ M.E := by aesop_mat) :
+    M.IsColoop e ↔ ∀ ⦃C⦄, M.IsCircuit C → e ∉ C := by
+  simp_rw [(M.isColoop_tfae e).out 0 4, and_iff_left he]
+
+lemma isColoop_iff_forall_mem_compl_isCircuit [RankPos M✶] :
+    M.IsColoop e ↔ ∀ C, M.IsCircuit C → e ∈ M.E \ C := by
+  by_cases he : e ∈ M.E
+  · simp [isColoop_iff_forall_not_mem_isCircuit, he]
+  obtain ⟨C, hC⟩ := M.exists_isCircuit
+  exact iff_of_false (fun h ↦ he h.mem_ground) fun h ↦ he (h C hC).1
+
+lemma IsCircuit.not_isColoop_of_mem (hC : M.IsCircuit C) (heC : e ∈ C) : ¬ M.IsColoop e :=
+  fun h ↦ h.not_mem_isCircuit hC heC
+
+lemma isColoop_iff_forall_mem_closure_iff_mem :
+    M.IsColoop e ↔ (∀ X, e ∈ M.closure X ↔ e ∈ X) ∧ e ∈ M.E :=
+  (M.isColoop_tfae e).out 0 5
+
+/-- A version of `Matroid.isColoop_iff_forall_mem_closure_iff_mem` where we only quantify
+over subsets of the ground set. -/
+lemma isColoop_iff_forall_mem_closure_iff_mem' :
+    M.IsColoop e ↔ (∀ X, X ⊆ M.E → (e ∈ M.closure X ↔ e ∈ X)) ∧ e ∈ M.E := by
+  rw [isColoop_iff_forall_mem_closure_iff_mem, and_congr_left_iff]
+  refine fun he ↦ ⟨fun h X _ ↦ h X, fun h X ↦ ?_⟩
+  rw [← closure_inter_ground, h (X ∩ M.E) inter_subset_right, mem_inter_iff, and_iff_left he]
+
+lemma IsColoop.mem_closure_iff_mem (he : M.IsColoop e) : e ∈ M.closure X ↔ e ∈ X :=
+  (isColoop_iff_forall_mem_closure_iff_mem.1 he).1 X
+
+lemma IsColoop.mem_of_mem_closure (he : M.IsColoop e) (heX : e ∈ M.closure X) : e ∈ X :=
+  he.mem_closure_iff_mem.1 heX
+
+lemma isColoop_iff_diff_not_spanning : M.IsColoop e ↔ ¬ M.Spanning (M.E \ {e}) :=
+  (M.isColoop_tfae e).out 0 6
+
+alias ⟨IsColoop.diff_not_spanning, _⟩ := isColoop_iff_diff_not_spanning
+
+lemma isColoop_iff_diff_closure : M.IsColoop e ↔ M.closure (M.E \ {e}) ≠ M.E := by
+  rw [isColoop_iff_diff_not_spanning, spanning_iff_closure_eq]
+
+lemma isColoop_iff_not_mem_closure_compl (he : e ∈ M.E := by aesop_mat) :
+    M.IsColoop e ↔ e ∉ M.closure (M.E \ {e}) := by
+  rw [isColoop_iff_diff_closure, not_iff_not]
+  refine ⟨fun h ↦ by rwa [h], fun h ↦ (M.closure_subset_ground _).antisymm fun x hx ↦ ?_⟩
+  obtain (rfl | hne) := eq_or_ne x e
+  · assumption
+  exact M.subset_closure (M.E \ {e}) diff_subset (show x ∈ M.E \ {e} from ⟨hx, hne⟩)
+
+lemma IsBase.isColoop_iff_forall_not_mem_fundCircuit (hB : M.IsBase B) (he : e ∈ B) :
+    M.IsColoop e ↔ ∀ x ∈ M.E \ B, e ∉ M.fundCircuit x B := by
+  refine ⟨fun h x hx heC ↦ (h.not_mem_isCircuit <| hB.fundCircuit_isCircuit hx.1 hx.2) heC,
+    fun h ↦ ?_⟩
+  have h' : M.E \ {e} ⊆ M.closure (B \ {e}) := by
+    rintro x ⟨hxE, hne : x ≠ e⟩
+    obtain (hx | hx) := em (x ∈ B)
+    · exact M.subset_closure (B \ {e}) (diff_subset.trans hB.subset_ground) ⟨hx, hne⟩
+    have h_cct := (hB.fundCircuit_isCircuit hxE hx).mem_closure_diff_singleton_of_mem
+      (M.mem_fundCircuit x B)
+    refine (M.closure_subset_closure (subset_diff_singleton ?_ ?_)) h_cct
+    · simpa using fundCircuit_subset_insert ..
+    simp [hne.symm, h x ⟨hxE, hx⟩]
+  rw [isColoop_iff_not_mem_closure_compl (hB.subset_ground he)]
+  exact not_mem_subset (M.closure_subset_closure_of_subset_closure h') <|
+    hB.indep.not_mem_closure_diff_of_mem he
+
+lemma IsBasis'.inter_coloops_subset (hIX : M.IsBasis' I X) : X ∩ M.coloops ⊆ I := by
+  intro e ⟨heX, (heI : M.IsColoop e)⟩
+  rwa [← heI.mem_closure_iff_mem, hIX.isBasis_closure_right.closure_eq_right,
+    heI.mem_closure_iff_mem]
+
+lemma IsBasis.inter_coloops_subset (hIX : M.IsBasis I X) : X ∩ M.coloops ⊆ I :=
+  hIX.isBasis'.inter_coloops_subset
+
+lemma exists_mem_isCircuit_of_not_isColoop (heE : e ∈ M.E) (he : ¬ M.IsColoop e) :
+    ∃ C, M.IsCircuit C ∧ e ∈ C := by
+  simp only [isColoop_iff_forall_mem_isBase, not_forall, Classical.not_imp, exists_prop] at he
+  obtain ⟨B, hB, heB⟩ := he
+  exact ⟨M.fundCircuit e B, hB.fundCircuit_isCircuit heE heB, .inl rfl⟩
+
+@[simp]
+lemma closure_inter_coloops_eq (M : Matroid α) (X : Set α) :
+    M.closure X ∩ M.coloops = X ∩ M.coloops := by
+  simp_rw [Set.ext_iff, mem_inter_iff, ← isColoop_iff_mem_loops, and_congr_left_iff]
+  intro e he
+  rw [he.mem_closure_iff_mem]
+
+lemma closure_inter_eq_of_subset_coloops (X : Set α) (hK : K ⊆ M.coloops) :
+     M.closure X ∩ K = X ∩ K := by
+  nth_rw 1 [← inter_eq_self_of_subset_right hK]
+  rw [← inter_assoc, closure_inter_coloops_eq, inter_assoc, inter_eq_self_of_subset_right hK]
+
+lemma closure_union_eq_of_subset_coloops (X : Set α) (hK : K ⊆ M.coloops) :
+    M.closure (X ∪ K) = M.closure X ∪ K := by
+  rw [← closure_union_closure_left_eq, subset_antisymm_iff, and_iff_left (M.subset_closure _),
+    ← diff_eq_empty, eq_empty_iff_forall_not_mem]
+  refine fun e ⟨hecl, he⟩ ↦ he (.inl ?_)
+  obtain ⟨C, hCss, hC, heC⟩ := (mem_closure_iff_exists_isCircuit he).1 hecl
+  rw [← singleton_union, ← union_assoc, union_comm, ← diff_subset_iff,
+    (hC.disjoint_coloops.mono_right hK).sdiff_eq_left, singleton_union] at hCss
+  exact M.closure_subset_closure_of_subset_closure (by simpa) <|
+    hC.mem_closure_diff_singleton_of_mem heC
+
+lemma closure_insert_isColoop_eq (X : Set α) (he : M.IsColoop e) :
+    M.closure (insert e X) = insert e (M.closure X) := by
+  rw [← union_singleton, closure_union_eq_of_subset_coloops _ (by simpa), union_singleton]
+
+lemma closure_eq_of_subset_coloops (hK : K ⊆ M.coloops) : M.closure K = K ∪ M.loops := by
+  rw [← empty_union K, closure_union_eq_of_subset_coloops _ hK, empty_union, union_comm,
+    closure_empty]
+
+lemma closure_diff_eq_of_subset_coloops (X : Set α) (hK : K ⊆ M.coloops) :
+    M.closure (X \ K) = M.closure X \ K := by
+  nth_rw 2 [← inter_union_diff X K]
+  rw [union_comm, closure_union_eq_of_subset_coloops _ (inter_subset_right.trans hK),
+    union_diff_distrib, diff_eq_empty.mpr inter_subset_right, union_empty, eq_comm,
+    sdiff_eq_self_iff_disjoint, disjoint_iff_forall_ne]
+  rintro e heK _ heX rfl
+  rw [IsColoop.mem_closure_iff_mem (hK heK)] at heX
+  exact heX.2 heK
+
+lemma closure_disjoint_of_disjoint_of_subset_coloops (hXK : Disjoint X K) (hK : K ⊆ M.coloops) :
+    Disjoint (M.closure X) K := by
+  rwa [disjoint_iff_inter_eq_empty, closure_inter_eq_of_subset_coloops X hK,
+    ← disjoint_iff_inter_eq_empty]
+
+lemma closure_disjoint_coloops_of_disjoint_coloops (hX : Disjoint X (M.coloops)) :
+    Disjoint (M.closure X) M.coloops :=
+  closure_disjoint_of_disjoint_of_subset_coloops hX Subset.rfl
+
+lemma closure_union_coloops_eq (M : Matroid α) (X : Set α) :
+    M.closure (X ∪ M.coloops) = M.closure X ∪ M.coloops :=
+  closure_union_eq_of_subset_coloops _ Subset.rfl
+
+lemma IsColoop.not_mem_closure_of_not_mem (he : M.IsColoop e) (hX : e ∉ X) : e ∉ M.closure X :=
+  mt he.mem_closure_iff_mem.mp hX
+
+lemma IsColoop.insert_indep_of_indep (he : M.IsColoop e) (hI : M.Indep I) :
+    M.Indep (insert e I) := by
+  refine (em (e ∈ I)).elim (fun h ↦ by rwa [insert_eq_of_mem h]) fun h ↦ ?_
+  rw [← hI.not_mem_closure_iff_of_not_mem h]
+  exact he.not_mem_closure_of_not_mem h
+
+lemma union_indep_iff_indep_of_subset_coloops (hK : K ⊆ M.coloops) :
+    M.Indep (I ∪ K) ↔ M.Indep I := by
+  refine ⟨fun h ↦ h.subset subset_union_left, fun h ↦ ?_⟩
+  obtain ⟨B, hB, hIB⟩ := h.exists_isBase_superset
+  exact hB.indep.subset (union_subset hIB (hK.trans fun e he ↦ IsColoop.mem_of_isBase he hB))
+
+lemma diff_indep_iff_indep_of_subset_coloops (hK : K ⊆ M.coloops) :
+    M.Indep (I \ K) ↔ M.Indep I := by
+  rw [← union_indep_iff_indep_of_subset_coloops hK, diff_union_self,
+    union_indep_iff_indep_of_subset_coloops hK]
+
+@[simp]
+lemma union_coloops_indep_iff : M.Indep (I ∪ M.coloops) ↔ M.Indep I :=
+  union_indep_iff_indep_of_subset_coloops Subset.rfl
+
+@[simp]
+lemma diff_coloops_indep_iff : M.Indep (I \ M.coloops) ↔ M.Indep I :=
+  diff_indep_iff_indep_of_subset_coloops Subset.rfl
+
+lemma coloops_indep (M : Matroid α) : M.Indep M.coloops := by
+  rw [← empty_union M.coloops, union_coloops_indep_iff]
+  exact M.empty_indep
+
+/-- If two matroids agree on loops and coloops, and have the same independent sets after
+  loops/coloops are removed, they are equal. -/
+lemma ext_indep_disjoint_loops_coloops {M₁ M₂ : Matroid α} (hE : M₁.E = M₂.E)
+    (hl : M₁.loops = M₂.loops) (hc : M₁.coloops = M₂.coloops)
+    (h : ∀ I, I ⊆ M₁.E → Disjoint I (M₁.loops ∪ M₁.coloops) → (M₁.Indep I ↔ M₂.Indep I)) :
+    M₁ = M₂ := by
+  refine ext_indep hE fun I hI ↦ ?_
+  rw [← diff_coloops_indep_iff, ← @diff_coloops_indep_iff _ M₂, ← hc]
+  obtain hdj | hndj := em (Disjoint I (M₁.loops))
+  · rw [h _ (diff_subset.trans hI)]
+    rw [disjoint_union_right]
+    exact ⟨disjoint_of_subset_left diff_subset hdj, disjoint_sdiff_left⟩
+  obtain ⟨e, heI, hel : M₁.IsLoop e⟩ := not_disjoint_iff_nonempty_inter.mp hndj
+  refine iff_of_false (hel.not_indep_of_mem ⟨heI, hel.not_isColoop⟩) ?_
+  rw [isLoop_iff, hl, ← isLoop_iff] at hel
+  rw [hc]
+  exact hel.not_indep_of_mem ⟨heI, hel.not_isColoop⟩
+
+end IsColoop
 
 end Matroid


### PR DESCRIPTION
We give API for the dual notion `Matroid.IsColoop` of `Matroid.IsLoop`. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
