### PR TITLE
[Merged by Bors] - feat(Analysis/Normed): generalize lemmas to NormMulClass

### DIFF
--- a/Mathlib/Analysis/Normed/Field/Lemmas.lean
+++ b/Mathlib/Analysis/Normed/Field/Lemmas.lean
@@ -29,19 +29,19 @@ open scoped Topology NNReal Pointwise
 
 section NormedDivisionRing
 
-variable [NormedDivisionRing α] (a : α)
+variable [NormedDivisionRing α]
 
 /-- Multiplication by a nonzero element `a` on the left
 as a `DilationEquiv` of a normed division ring. -/
 @[simps!]
-def DilationEquiv.mulLeft (ha : a ≠ 0) : α ≃ᵈ α where
+def DilationEquiv.mulLeft (a : α) (ha : a ≠ 0) : α ≃ᵈ α where
   __ := Dilation.mulLeft a ha
   toEquiv := Equiv.mulLeft₀ a ha
 
 /-- Multiplication by a nonzero element `a` on the right
 as a `DilationEquiv` of a normed division ring. -/
 @[simps!]
-def DilationEquiv.mulRight (ha : a ≠ 0) : α ≃ᵈ α where
+def DilationEquiv.mulRight (a : α) (ha : a ≠ 0) : α ≃ᵈ α where
   __ := Dilation.mulRight a ha
   toEquiv := Equiv.mulRight₀ a ha
 

--- a/Mathlib/Analysis/Normed/Field/Lemmas.lean
+++ b/Mathlib/Analysis/Normed/Field/Lemmas.lean
@@ -29,20 +29,20 @@ open scoped Topology NNReal Pointwise
 
 section NormedDivisionRing
 
-variable [NormedDivisionRing α] {a : α}
+variable [NormedDivisionRing α] (a : α)
 
 /-- Multiplication by a nonzero element `a` on the left
 as a `DilationEquiv` of a normed division ring. -/
 @[simps!]
 def DilationEquiv.mulLeft (ha : a ≠ 0) : α ≃ᵈ α where
-  __ := Dilation.mulLeft ha
+  __ := Dilation.mulLeft a ha
   toEquiv := Equiv.mulLeft₀ a ha
 
 /-- Multiplication by a nonzero element `a` on the right
 as a `DilationEquiv` of a normed division ring. -/
 @[simps!]
 def DilationEquiv.mulRight (ha : a ≠ 0) : α ≃ᵈ α where
-  __ := Dilation.mulRight ha
+  __ := Dilation.mulRight a ha
   toEquiv := Equiv.mulRight₀ a ha
 
 namespace Filter
@@ -50,12 +50,12 @@ namespace Filter
 @[simp]
 lemma map_mul_left_cobounded {a : α} (ha : a ≠ 0) :
     map (a * ·) (cobounded α) = cobounded α :=
-  DilationEquiv.map_cobounded (DilationEquiv.mulLeft ha)
+  DilationEquiv.map_cobounded (DilationEquiv.mulLeft a ha)
 
 @[simp]
 lemma map_mul_right_cobounded {a : α} (ha : a ≠ 0) :
     map (· * a) (cobounded α) = cobounded α :=
-  DilationEquiv.map_cobounded (DilationEquiv.mulRight ha)
+  DilationEquiv.map_cobounded (DilationEquiv.mulRight a ha)
 
 /-- Multiplication on the left by a nonzero element of a normed division ring tends to infinity at
 infinity. -/

--- a/Mathlib/Analysis/Normed/Field/Lemmas.lean
+++ b/Mathlib/Analysis/Normed/Field/Lemmas.lean
@@ -3,12 +3,9 @@ Copyright (c) 2018 Patrick Massot. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Patrick Massot, Johannes Hölzl
 -/
-import Mathlib.Algebra.Group.AddChar
-import Mathlib.Algebra.Group.TypeTags.Finite
 import Mathlib.Analysis.Normed.Field.Basic
 import Mathlib.Analysis.Normed.Group.Rat
 import Mathlib.Analysis.Normed.Ring.Lemmas
-import Mathlib.GroupTheory.OrderOfElement
 import Mathlib.Topology.MetricSpace.DilationEquiv
 
 /-!
@@ -25,7 +22,7 @@ Some useful results that relate the topology of the normed field to the discrete
 -- Guard against import creep.
 assert_not_exists RestrictScalars
 
-variable {α : Type*} {β : Type*} {ι : Type*}
+variable {α β ι : Type*}
 
 open Filter Bornology
 open scoped Topology NNReal Pointwise
@@ -34,50 +31,29 @@ section NormedDivisionRing
 
 variable [NormedDivisionRing α] {a : α}
 
-lemma antilipschitzWith_mul_left {a : α} (ha : a ≠ 0) : AntilipschitzWith (‖a‖₊⁻¹) (a * ·) :=
-  AntilipschitzWith.of_le_mul_dist fun _ _ ↦ by simp [dist_eq_norm, ← _root_.mul_sub, ha]
-
-lemma antilipschitzWith_mul_right {a : α} (ha : a ≠ 0) : AntilipschitzWith (‖a‖₊⁻¹) (· * a) :=
-  AntilipschitzWith.of_le_mul_dist fun _ _ ↦ by
-    simp [dist_eq_norm, ← _root_.sub_mul, ← mul_comm (‖a‖), ha]
-
 /-- Multiplication by a nonzero element `a` on the left
 as a `DilationEquiv` of a normed division ring. -/
 @[simps!]
-def DilationEquiv.mulLeft (a : α) (ha : a ≠ 0) : α ≃ᵈ α where
-  toEquiv := Equiv.mulLeft₀ a ha
-  edist_eq' := ⟨‖a‖₊, nnnorm_ne_zero_iff.2 ha, fun x y ↦ by
-    simp [edist_nndist, nndist_eq_nnnorm, ← mul_sub]⟩
+def DilationEquiv.mulLeft (ha : a ≠ 0) : α ≃ᵈ α :=
+  { Dilation.mulLeft ha with toEquiv := Equiv.mulLeft₀ a ha }
 
 /-- Multiplication by a nonzero element `a` on the right
 as a `DilationEquiv` of a normed division ring. -/
 @[simps!]
-def DilationEquiv.mulRight (a : α) (ha : a ≠ 0) : α ≃ᵈ α where
-  toEquiv := Equiv.mulRight₀ a ha
-  edist_eq' := ⟨‖a‖₊, nnnorm_ne_zero_iff.2 ha, fun x y ↦ by
-    simp [edist_nndist, nndist_eq_nnnorm, ← sub_mul, ← mul_comm (‖a‖₊)]⟩
+def DilationEquiv.mulRight (ha : a ≠ 0) : α ≃ᵈ α :=
+  { Dilation.mulRight ha with toEquiv := Equiv.mulRight₀ a ha }
 
 namespace Filter
 
 @[simp]
-lemma comap_mul_left_cobounded {a : α} (ha : a ≠ 0) :
-    comap (a * ·) (cobounded α) = cobounded α :=
-  Dilation.comap_cobounded (DilationEquiv.mulLeft a ha)
-
-@[simp]
 lemma map_mul_left_cobounded {a : α} (ha : a ≠ 0) :
     map (a * ·) (cobounded α) = cobounded α :=
-  DilationEquiv.map_cobounded (DilationEquiv.mulLeft a ha)
-
-@[simp]
-lemma comap_mul_right_cobounded {a : α} (ha : a ≠ 0) :
-    comap (· * a) (cobounded α) = cobounded α :=
-  Dilation.comap_cobounded (DilationEquiv.mulRight a ha)
+  DilationEquiv.map_cobounded (DilationEquiv.mulLeft ha)
 
 @[simp]
 lemma map_mul_right_cobounded {a : α} (ha : a ≠ 0) :
     map (· * a) (cobounded α) = cobounded α :=
-  DilationEquiv.map_cobounded (DilationEquiv.mulRight a ha)
+  DilationEquiv.map_cobounded (DilationEquiv.mulRight ha)
 
 /-- Multiplication on the left by a nonzero element of a normed division ring tends to infinity at
 infinity. -/
@@ -137,15 +113,6 @@ instance (priority := 100) NormedDivisionRing.to_isTopologicalDivisionRing :
 
 @[deprecated (since := "2025-03-25")] alias NormedDivisionRing.to_topologicalDivisionRing :=
   NormedDivisionRing.to_isTopologicalDivisionRing
-
-protected lemma IsOfFinOrder.norm_eq_one (ha : IsOfFinOrder a) : ‖a‖ = 1 :=
-  ((normHom : α →*₀ ℝ).toMonoidHom.isOfFinOrder ha).eq_one <| norm_nonneg _
-
-example [Monoid β] (φ : β →* α) {x : β} {k : ℕ+} (h : x ^ (k : ℕ) = 1) :
-    ‖φ x‖ = 1 := (φ.isOfFinOrder <| isOfFinOrder_iff_pow_eq_one.2 ⟨_, k.2, h⟩).norm_eq_one
-
-@[simp] lemma AddChar.norm_apply {G : Type*} [AddLeftCancelMonoid G] [Finite G] (ψ : AddChar G α)
-    (x : G) : ‖ψ x‖ = 1 := (ψ.toMonoidHom.isOfFinOrder <| isOfFinOrder_of_finite _).norm_eq_one
 
 lemma NormedField.tendsto_norm_inv_nhdsNE_zero_atTop : Tendsto (fun x : α ↦ ‖x⁻¹‖) (𝓝[≠] 0) atTop :=
   (tendsto_inv_nhdsGT_zero.comp tendsto_norm_nhdsNE_zero).congr fun x ↦ (norm_inv x).symm

--- a/Mathlib/Analysis/Normed/Field/Lemmas.lean
+++ b/Mathlib/Analysis/Normed/Field/Lemmas.lean
@@ -34,14 +34,16 @@ variable [NormedDivisionRing α] {a : α}
 /-- Multiplication by a nonzero element `a` on the left
 as a `DilationEquiv` of a normed division ring. -/
 @[simps!]
-def DilationEquiv.mulLeft (ha : a ≠ 0) : α ≃ᵈ α :=
-  { Dilation.mulLeft ha with toEquiv := Equiv.mulLeft₀ a ha }
+def DilationEquiv.mulLeft (ha : a ≠ 0) : α ≃ᵈ α where
+  __ := Dilation.mulLeft ha
+  toEquiv := Equiv.mulLeft₀ a ha
 
 /-- Multiplication by a nonzero element `a` on the right
 as a `DilationEquiv` of a normed division ring. -/
 @[simps!]
-def DilationEquiv.mulRight (ha : a ≠ 0) : α ≃ᵈ α :=
-  { Dilation.mulRight ha with toEquiv := Equiv.mulRight₀ a ha }
+def DilationEquiv.mulRight (ha : a ≠ 0) : α ≃ᵈ α where
+  __ := Dilation.mulRight ha
+  toEquiv := Equiv.mulRight₀ a ha
 
 namespace Filter
 

--- a/Mathlib/Analysis/Normed/Ring/Lemmas.lean
+++ b/Mathlib/Analysis/Normed/Ring/Lemmas.lean
@@ -220,6 +220,9 @@ section NormMulClass
 
 variable [NormedRing α] [NormMulClass α] {a : α}
 
+lemma antilipschitzWith_mul_left {a : α} (ha : a ≠ 0) : AntilipschitzWith (‖a‖₊⁻¹) (a * ·) :=
+  AntilipschitzWith.of_le_mul_dist fun _ _ ↦ by simp [dist_eq_norm, ← _root_.mul_sub, ha]
+
 lemma antilipschitzWith_mul_right {a : α} (ha : a ≠ 0) : AntilipschitzWith (‖a‖₊⁻¹) (· * a) :=
   AntilipschitzWith.of_le_mul_dist fun _ _ ↦ by
     simp [dist_eq_norm, ← _root_.sub_mul, ← mul_comm (‖a‖), ha]

--- a/Mathlib/Analysis/Normed/Ring/Lemmas.lean
+++ b/Mathlib/Analysis/Normed/Ring/Lemmas.lean
@@ -216,9 +216,8 @@ instance Int.instNormOneClass : NormOneClass ℤ :=
 instance Int.instNormMulClass : NormMulClass ℤ :=
   ⟨fun a b ↦ by simp [← Int.norm_cast_real, abs_mul]⟩
 
-section NormMulClass
-
-variable [NormedRing α] [NormMulClass α] {a : α}
+section NonUnital
+variable [NonUnitalNormedRing α] [NormMulClass α] {a : α}
 
 lemma antilipschitzWith_mul_left {a : α} (ha : a ≠ 0) : AntilipschitzWith (‖a‖₊⁻¹) (a * ·) :=
   AntilipschitzWith.of_le_mul_dist fun _ _ ↦ by simp [dist_eq_norm, ← _root_.mul_sub, ha]
@@ -257,8 +256,10 @@ lemma comap_mul_right_cobounded {a : α} (ha : a ≠ 0) :
 
 end Filter
 
-section NormOneClass
-variable [NormOneClass α]
+end NonUnital
+
+section NormedRing
+variable [NormedRing α] [NormMulClass α] [NormOneClass α] {a : α}
 
 protected lemma IsOfFinOrder.norm_eq_one (ha : IsOfFinOrder a) : ‖a‖ = 1 :=
   ((normHom : α →*₀ ℝ).toMonoidHom.isOfFinOrder ha).eq_one <| norm_nonneg _
@@ -269,6 +270,4 @@ example [Monoid β] (φ : β →* α) {x : β} {k : ℕ+} (h : x ^ (k : ℕ) = 1
 @[simp] lemma AddChar.norm_apply {G : Type*} [AddLeftCancelMonoid G] [Finite G] (ψ : AddChar G α)
     (x : G) : ‖ψ x‖ = 1 := (ψ.toMonoidHom.isOfFinOrder <| isOfFinOrder_of_finite _).norm_eq_one
 
-end NormOneClass
-
-end NormMulClass
+end NormedRing

--- a/Mathlib/Analysis/Normed/Ring/Lemmas.lean
+++ b/Mathlib/Analysis/Normed/Ring/Lemmas.lean
@@ -216,7 +216,7 @@ instance Int.instNormOneClass : NormOneClass ℤ :=
 instance Int.instNormMulClass : NormMulClass ℤ :=
   ⟨fun a b ↦ by simp [← Int.norm_cast_real, abs_mul]⟩
 
-section NonUnital
+section NonUnitalNormedRing
 variable [NonUnitalNormedRing α] [NormMulClass α] {a : α}
 
 lemma antilipschitzWith_mul_left {a : α} (ha : a ≠ 0) : AntilipschitzWith (‖a‖₊⁻¹) (a * ·) :=
@@ -256,7 +256,7 @@ lemma comap_mul_right_cobounded {a : α} (ha : a ≠ 0) :
 
 end Filter
 
-end NonUnital
+end NonUnitalNormedRing
 
 section NormedRing
 variable [NormedRing α] [NormMulClass α] [NormOneClass α] {a : α}

--- a/Mathlib/Analysis/Normed/Ring/Lemmas.lean
+++ b/Mathlib/Analysis/Normed/Ring/Lemmas.lean
@@ -220,11 +220,10 @@ section NonUnitalNormedRing
 variable [NonUnitalNormedRing α] [NormMulClass α] {a : α}
 
 lemma antilipschitzWith_mul_left {a : α} (ha : a ≠ 0) : AntilipschitzWith (‖a‖₊⁻¹) (a * ·) :=
-  AntilipschitzWith.of_le_mul_dist fun _ _ ↦ by simp [dist_eq_norm, ← _root_.mul_sub, ha]
+  AntilipschitzWith.of_le_mul_dist fun _ _ ↦ by simp [dist_eq_norm, ← mul_sub, ha]
 
 lemma antilipschitzWith_mul_right {a : α} (ha : a ≠ 0) : AntilipschitzWith (‖a‖₊⁻¹) (· * a) :=
-  AntilipschitzWith.of_le_mul_dist fun _ _ ↦ by
-    simp [dist_eq_norm, ← _root_.sub_mul, ← mul_comm (‖a‖), ha]
+  AntilipschitzWith.of_le_mul_dist fun _ _ ↦ by simp [dist_eq_norm, ← sub_mul, mul_comm, ha]
 
 /-- Multiplication by a nonzero element `a` on the left, as a `Dilation` of a ring with a strictly
 multiplicative norm. -/

--- a/Mathlib/Analysis/Normed/Ring/Lemmas.lean
+++ b/Mathlib/Analysis/Normed/Ring/Lemmas.lean
@@ -228,7 +228,7 @@ lemma antilipschitzWith_mul_right {a : α} (ha : a ≠ 0) : AntilipschitzWith (�
 /-- Multiplication by a nonzero element `a` on the left, as a `Dilation` of a ring with a strictly
 multiplicative norm. -/
 @[simps!]
-def Dilation.mulLeft {a : α} (ha : a ≠ 0) : α →ᵈ α where
+def Dilation.mulLeft (a : α) (ha : a ≠ 0) : α →ᵈ α where
   toFun b := a * b
   edist_eq' := ⟨‖a‖₊, nnnorm_ne_zero_iff.2 ha, fun x y ↦ by
     simp [edist_nndist, nndist_eq_nnnorm, ← mul_sub]⟩
@@ -236,7 +236,7 @@ def Dilation.mulLeft {a : α} (ha : a ≠ 0) : α →ᵈ α where
 /-- Multiplication by a nonzero element `a` on the right, as a `Dilation` of a ring with a strictly
 multiplicative norm. -/
 @[simps!]
-def Dilation.mulRight {a : α} (ha : a ≠ 0) : α →ᵈ α where
+def Dilation.mulRight (a : α) (ha : a ≠ 0) : α →ᵈ α where
   toFun b := b * a
   edist_eq' := ⟨‖a‖₊, nnnorm_ne_zero_iff.2 ha, fun x y ↦ by
     simp [edist_nndist, nndist_eq_nnnorm, ← sub_mul, ← mul_comm (‖a‖₊)]⟩
@@ -246,12 +246,12 @@ namespace Filter
 @[simp]
 lemma comap_mul_left_cobounded {a : α} (ha : a ≠ 0) :
     comap (a * ·) (cobounded α) = cobounded α :=
-  Dilation.comap_cobounded (Dilation.mulLeft ha)
+  Dilation.comap_cobounded (Dilation.mulLeft a ha)
 
 @[simp]
 lemma comap_mul_right_cobounded {a : α} (ha : a ≠ 0) :
     comap (· * a) (cobounded α) = cobounded α :=
-  Dilation.comap_cobounded (Dilation.mulRight ha)
+  Dilation.comap_cobounded (Dilation.mulRight a ha)
 
 end Filter
 

--- a/Mathlib/Analysis/Normed/Ring/Lemmas.lean
+++ b/Mathlib/Analysis/Normed/Ring/Lemmas.lean
@@ -3,20 +3,21 @@ Copyright (c) 2018 Patrick Massot. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Patrick Massot, Johannes Hölzl
 -/
+import Mathlib.Algebra.Group.AddChar
+import Mathlib.Algebra.Group.TypeTags.Finite
 import Mathlib.Algebra.Order.GroupWithZero.Finset
 import Mathlib.Analysis.Normed.Group.Bounded
 import Mathlib.Analysis.Normed.Group.Int
 import Mathlib.Analysis.Normed.Group.Uniform
 import Mathlib.Analysis.Normed.Ring.Basic
+import Mathlib.GroupTheory.OrderOfElement
+import Mathlib.Topology.MetricSpace.Dilation
 
 /-!
 # Normed rings
 
 In this file we continue building the theory of (semi)normed rings.
 -/
-
--- Guard against import creep.
-assert_not_exists RestrictScalars
 
 variable {α : Type*} {β : Type*} {ι : Type*}
 
@@ -214,3 +215,57 @@ instance Int.instNormOneClass : NormOneClass ℤ :=
 
 instance Int.instNormMulClass : NormMulClass ℤ :=
   ⟨fun a b ↦ by simp [← Int.norm_cast_real, abs_mul]⟩
+
+section NormMulClass
+
+variable [NormedRing α] [NormMulClass α] {a : α}
+
+lemma antilipschitzWith_mul_right {a : α} (ha : a ≠ 0) : AntilipschitzWith (‖a‖₊⁻¹) (· * a) :=
+  AntilipschitzWith.of_le_mul_dist fun _ _ ↦ by
+    simp [dist_eq_norm, ← _root_.sub_mul, ← mul_comm (‖a‖), ha]
+
+/-- Multiplication by a nonzero element `a` on the left, as a `Dilation` of a ring with a strictly
+multiplicative norm. -/
+@[simps!]
+def Dilation.mulLeft {a : α} (ha : a ≠ 0) : α →ᵈ α where
+  toFun b := a * b
+  edist_eq' := ⟨‖a‖₊, nnnorm_ne_zero_iff.2 ha, fun x y ↦ by
+    simp [edist_nndist, nndist_eq_nnnorm, ← mul_sub]⟩
+
+/-- Multiplication by a nonzero element `a` on the right, as a `Dilation` of a ring with a strictly
+multiplicative norm. -/
+@[simps!]
+def Dilation.mulRight {a : α} (ha : a ≠ 0) : α →ᵈ α where
+  toFun b := b * a
+  edist_eq' := ⟨‖a‖₊, nnnorm_ne_zero_iff.2 ha, fun x y ↦ by
+    simp [edist_nndist, nndist_eq_nnnorm, ← sub_mul, ← mul_comm (‖a‖₊)]⟩
+
+namespace Filter
+
+@[simp]
+lemma comap_mul_left_cobounded {a : α} (ha : a ≠ 0) :
+    comap (a * ·) (cobounded α) = cobounded α :=
+  Dilation.comap_cobounded (Dilation.mulLeft ha)
+
+@[simp]
+lemma comap_mul_right_cobounded {a : α} (ha : a ≠ 0) :
+    comap (· * a) (cobounded α) = cobounded α :=
+  Dilation.comap_cobounded (Dilation.mulRight ha)
+
+end Filter
+
+section NormOneClass
+variable [NormOneClass α]
+
+protected lemma IsOfFinOrder.norm_eq_one (ha : IsOfFinOrder a) : ‖a‖ = 1 :=
+  ((normHom : α →*₀ ℝ).toMonoidHom.isOfFinOrder ha).eq_one <| norm_nonneg _
+
+example [Monoid β] (φ : β →* α) {x : β} {k : ℕ+} (h : x ^ (k : ℕ) = 1) :
+    ‖φ x‖ = 1 := (φ.isOfFinOrder <| isOfFinOrder_iff_pow_eq_one.2 ⟨_, k.2, h⟩).norm_eq_one
+
+@[simp] lemma AddChar.norm_apply {G : Type*} [AddLeftCancelMonoid G] [Finite G] (ψ : AddChar G α)
+    (x : G) : ‖ψ x‖ = 1 := (ψ.toMonoidHom.isOfFinOrder <| isOfFinOrder_of_finite _).norm_eq_one
+
+end NormOneClass
+
+end NormMulClass


### PR DESCRIPTION
Generalise some lemmas about `NormedDivisionRing` to any normed ring satisfying `NormMulClass`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
