### PR TITLE
[Merged by Bors] - feat: Countable instances for Free constructions

### DIFF
--- a/Mathlib/SetTheory/Cardinal/Free.lean
+++ b/Mathlib/SetTheory/Cardinal/Free.lean
@@ -14,7 +14,7 @@ import Mathlib.SetTheory.Cardinal.Finsupp
 # Cardinalities of free constructions
 
 This file shows that all the free constructions over `α` have cardinality `max #α ℵ₀`,
-and are thus infinite.
+and are thus infinite, and specifically countable over countable generators.
 
 Combined with the ring `Fin n` for the finite cases, this lets us show that there is a `CommRing` of
 any cardinality.
@@ -41,6 +41,26 @@ instance : Infinite (FreeRing α) := by unfold FreeRing; infer_instance
 instance : Infinite (FreeCommRing α) := by unfold FreeCommRing; infer_instance
 
 end Infinite
+
+section Countable
+
+variable [Countable α]
+
+@[to_additive]
+instance : Countable (FreeMonoid α) := by unfold FreeMonoid; infer_instance
+
+@[to_additive]
+instance : Countable (FreeGroup α) := Quotient.countable
+
+instance : Countable (FreeAbelianGroup α) := Quotient.countable
+
+instance : Countable (FreeRing α) := Quotient.countable
+
+instance : Countable (FreeCommRing α) := by
+  unfold FreeCommRing Multiplicative
+  infer_instance
+
+end Countable
 
 namespace Cardinal
 


### PR DESCRIPTION
Add Countable instances for Free* constructions when the number of generators is countable.