### PR TITLE
[Merged by Bors] - feat(Combinatorics/SimpleGraph/Prod): add edist lemmas about graph box product

### DIFF
--- a/Mathlib/Combinatorics/SimpleGraph/Prod.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Prod.lean
@@ -213,7 +213,7 @@ theorem boxProd_degree (x : α × β)
   rw [degree, degree, degree, boxProd_neighborFinset, Finset.card_disjUnion]
   simp_rw [Finset.card_product, Finset.card_singleton, mul_one, one_mul]
 
-lemma boxProd_reach (x y : α × β) :
+lemma boxProd_reachable (x y : α × β) :
     (G □ H).Reachable x y ↔ G.Reachable x.1 y.1 ∧ H.Reachable x.2 y.2 := by
   classical
   constructor
@@ -222,10 +222,10 @@ lemma boxProd_reach (x y : α × β) :
   · intro ⟨⟨w₁⟩, ⟨w₂⟩⟩
     exact ⟨(w₁.boxProdLeft _ _).append (w₂.boxProdRight _ _)⟩
 
-lemma boxProd_edist_top (x y : α × β) :
+lemma boxProd_edist_eq_top (x y : α × β) :
     (G □ H).edist x y = ⊤ ↔ G.edist x.1 y.1 = ⊤ ∨ H.edist x.2 y.2 = ⊤ := by
   repeat rw [← not_ne_iff, edist_ne_top_iff_reachable]
-  rw [boxProd_reach]
+  rw [boxProd_reachable]
   tauto
 
 lemma boxProd_len_eq_sum_projections {a₁ a₂ : α} {b₁ b₂ : β} [DecidableEq α] [DecidableEq β]
@@ -243,19 +243,19 @@ lemma boxProd_len_eq_sum_projections {a₁ a₂ : α} {b₁ b₂ : β} [Decidabl
         congr
         · exact h₁.2.symm
         · simp only [heq_eqRec_iff_heq, heq_eq_eq]
-
       · simp only [h₂, SimpleGraph.irrefl, false_and, ↓reduceDIte, Walk.length_cons, add_assoc]
         congr
         · exact h₂.2.symm
         · simp only [heq_eqRec_iff_heq, heq_eq_eq]
 
+@[simp]
 lemma boxProd_edist (x y : α × β) :
     (G □ H).edist x y = G.edist x.1 y.1 + H.edist x.2 y.2 := by
   classical
   by_cases h : (G □ H).edist x y = ⊤
-  · rw [h]; rw [boxProd_edist_top] at h
+  · rw [h]; rw [boxProd_edist_eq_top] at h
     aesop
-  · have rGH : G.edist x.1 y.1 ≠ ⊤ ∧ H.edist x.2 y.2 ≠ ⊤ := by rw [boxProd_edist_top] at h; tauto
+  · have rGH : G.edist x.1 y.1 ≠ ⊤ ∧ H.edist x.2 y.2 ≠ ⊤ := by rw [boxProd_edist_eq_top] at h; tauto
     have ⟨wG, hwG⟩ := exists_walk_of_edist_ne_top rGH.1
     have ⟨wH, hwH⟩ := exists_walk_of_edist_ne_top rGH.2
 

--- a/Mathlib/Combinatorics/SimpleGraph/Prod.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Prod.lean
@@ -222,12 +222,6 @@ lemma boxProd_reachable {x y : α × β} :
   · intro ⟨⟨w₁⟩, ⟨w₂⟩⟩
     exact ⟨(w₁.boxProdLeft _ _).append (w₂.boxProdRight _ _)⟩
 
-lemma edist_boxProd_eq_top {x y : α × β}:
-    (G □ H).edist x y = ⊤ ↔ G.edist x.1 y.1 = ⊤ ∨ H.edist x.2 y.2 = ⊤ := by
-  repeat rw [← not_ne_iff, edist_ne_top_iff_reachable]
-  rw [boxProd_reachable]
-  tauto
-
 lemma boxProd_len_eq_sum_projections {a₁ a₂ : α} {b₁ b₂ : β} [DecidableEq α] [DecidableEq β]
     [DecidableRel G.Adj] [DecidableRel H.Adj] (w : (G □ H).Walk (a₁, b₁) (a₂, b₂)) :
     w.length = w.ofBoxProdLeft.length + w.ofBoxProdRight.length := by
@@ -252,10 +246,13 @@ lemma boxProd_len_eq_sum_projections {a₁ a₂ : α} {b₁ b₂ : β} [Decidabl
 lemma boxProd_edist (x y : α × β) :
     (G □ H).edist x y = G.edist x.1 y.1 + H.edist x.2 y.2 := by
   classical
+  have top_case : (G □ H).edist x y = ⊤ ↔ G.edist x.1 y.1 = ⊤ ∨ H.edist x.2 y.2 = ⊤ := by
+    simp_rw [← not_ne_iff, edist_ne_top_iff_reachable, boxProd_reachable, not_and_or]
+
   by_cases h : (G □ H).edist x y = ⊤
-  · rw [h]; rw [edist_boxProd_eq_top] at h
+  · rw [top_case] at h
     aesop
-  · have rGH : G.edist x.1 y.1 ≠ ⊤ ∧ H.edist x.2 y.2 ≠ ⊤ := by rw [edist_boxProd_eq_top] at h; tauto
+  · have rGH : G.edist x.1 y.1 ≠ ⊤ ∧ H.edist x.2 y.2 ≠ ⊤ := by rw [top_case] at h; aesop
     have ⟨wG, hwG⟩ := exists_walk_of_edist_ne_top rGH.1
     have ⟨wH, hwH⟩ := exists_walk_of_edist_ne_top rGH.2
 
@@ -268,7 +265,7 @@ lemma boxProd_edist (x y : α × β) :
     ·  calc (G □ H).edist x y ≤ w_app.length := by exact edist_le _
           _ = wG.length + wH.length := by exact_mod_cast w_len
           _ = G.edist x.1 y.1 + H.edist x.2 y.2 := by simp only [hwG, hwH]
-    · have ⟨w, hw⟩ :=  exists_walk_of_edist_ne_top h
+    · have ⟨w, hw⟩ := exists_walk_of_edist_ne_top h
       rw [← hw, boxProd_len_eq_sum_projections]
       exact add_le_add (edist_le w.ofBoxProdLeft) (edist_le w.ofBoxProdRight)
 

--- a/Mathlib/Combinatorics/SimpleGraph/Prod.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Prod.lean
@@ -142,6 +142,26 @@ theorem ofBoxProdLeft_boxProdRight [DecidableEq α] [DecidableRel G.Adj] {a b₁
     · simp [ofBoxProdLeft_boxProdRight]
     · exact ⟨h, rfl⟩
 
+lemma length_boxProd {a₁ a₂ : α} {b₁ b₂ : β} [DecidableEq α] [DecidableEq β]
+    [DecidableRel G.Adj] [DecidableRel H.Adj] (w : (G □ H).Walk (a₁, b₁) (a₂, b₂)) :
+    w.length = w.ofBoxProdLeft.length + w.ofBoxProdRight.length := by
+  match w with
+  | .nil => simp [length, ofBoxProdLeft, ofBoxProdRight]
+  | .cons x w' => next c =>
+      unfold ofBoxProdLeft ofBoxProdRight Or.by_cases
+      rw [length_cons, length_boxProd w']
+      have disj : (G.Adj a₁ c.1 ∧ b₁ = c.2) ∨ (H.Adj b₁ c.2 ∧ a₁ = c.1) := by aesop
+      rcases disj with h₁ | h₂
+      · simp only [h₁, SimpleGraph.irrefl, false_and, and_self, ↓reduceDIte, length_cons]
+        rw [add_comm, add_comm w'.ofBoxProdLeft.length 1, add_assoc]
+        congr
+        · exact h₁.2.symm
+        · simp only [heq_eqRec_iff_heq, heq_eq_eq]
+      · simp only [h₂, SimpleGraph.irrefl, false_and, ↓reduceDIte, length_cons, add_assoc]
+        congr
+        · exact h₂.2.symm
+        · simp only [heq_eqRec_iff_heq, heq_eq_eq]
+
 end Walk
 
 variable {G H}
@@ -222,25 +242,7 @@ lemma boxProd_reachable {x y : α × β} :
   · intro ⟨⟨w₁⟩, ⟨w₂⟩⟩
     exact ⟨(w₁.boxProdLeft _ _).append (w₂.boxProdRight _ _)⟩
 
-lemma boxProd_len_eq_sum_projections {a₁ a₂ : α} {b₁ b₂ : β} [DecidableEq α] [DecidableEq β]
-    [DecidableRel G.Adj] [DecidableRel H.Adj] (w : (G □ H).Walk (a₁, b₁) (a₂, b₂)) :
-    w.length = w.ofBoxProdLeft.length + w.ofBoxProdRight.length := by
-  match w with
-  | .nil => simp [Walk.length, Walk.ofBoxProdLeft, Walk.ofBoxProdRight]
-  | .cons x w' => next c =>
-      unfold Walk.ofBoxProdLeft Walk.ofBoxProdRight Or.by_cases
-      rw [Walk.length_cons, boxProd_len_eq_sum_projections w']
-      have disj : (G.Adj a₁ c.1 ∧ b₁ = c.2) ∨ (H.Adj b₁ c.2 ∧ a₁ = c.1) := by aesop
-      rcases disj with h₁ | h₂
-      · simp only [h₁, SimpleGraph.irrefl, false_and, and_self, ↓reduceDIte, Walk.length_cons]
-        rw [add_comm, add_comm w'.ofBoxProdLeft.length 1, add_assoc]
-        congr
-        · exact h₁.2.symm
-        · simp only [heq_eqRec_iff_heq, heq_eq_eq]
-      · simp only [h₂, SimpleGraph.irrefl, false_and, ↓reduceDIte, Walk.length_cons, add_assoc]
-        congr
-        · exact h₂.2.symm
-        · simp only [heq_eqRec_iff_heq, heq_eq_eq]
+
 
 @[simp]
 lemma boxProd_edist (x y : α × β) :
@@ -266,7 +268,7 @@ lemma boxProd_edist (x y : α × β) :
           _ = wG.length + wH.length := by exact_mod_cast w_len
           _ = G.edist x.1 y.1 + H.edist x.2 y.2 := by simp only [hwG, hwH]
     · have ⟨w, hw⟩ := exists_walk_of_edist_ne_top h
-      rw [← hw, boxProd_len_eq_sum_projections]
+      rw [← hw, Walk.length_boxProd]
       exact add_le_add (edist_le w.ofBoxProdLeft) (edist_le w.ofBoxProdRight)
 
 end SimpleGraph

--- a/Mathlib/Combinatorics/SimpleGraph/Prod.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Prod.lean
@@ -148,19 +148,15 @@ lemma length_boxProd {a₁ a₂ : α} {b₁ b₂ : β} [DecidableEq α] [Decidab
   match w with
   | .nil => simp [ofBoxProdLeft, ofBoxProdRight]
   | .cons x w' => next c =>
-    unfold ofBoxProdLeft ofBoxProdRight Or.by_cases
+    unfold ofBoxProdLeft ofBoxProdRight
     rw [length_cons, length_boxProd w']
     have disj : (G.Adj a₁ c.1 ∧ b₁ = c.2) ∨ (H.Adj b₁ c.2 ∧ a₁ = c.1) := by aesop
     rcases disj with h₁ | h₂
-    · simp only [h₁, SimpleGraph.irrefl, false_and, and_self, ↓reduceDIte, length_cons]
+    · simp only [h₁,irrefl, false_and, and_self, ↓reduceDIte, length_cons, Or.by_cases]
       rw [add_comm, add_comm w'.ofBoxProdLeft.length 1, add_assoc]
-      congr
-      · exact h₁.2.symm
-      · simp
-    · simp only [h₂, SimpleGraph.irrefl, false_and, ↓reduceDIte, length_cons, add_assoc]
-      congr
-      · exact h₂.2.symm
-      · simp
+      congr <;> simp [h₁.2.symm]
+    · simp only [h₂, irrefl, false_and, ↓reduceDIte, length_cons, add_assoc, Or.by_cases]
+      congr <;> simp [h₂.2.symm]
 
 end Walk
 


### PR DESCRIPTION
This PR adds some basic lemmas about metric aspects of box products. In particular, it adds:
a lemma stating that `(G □ H).edist x y = G.edist x.1 y.1 + H.edist x.2 y.2`, and a couple of auxiliary facts to prove it.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
