### PR TITLE
[Merged by Bors] - feat(Cache): root hash generation counter

### DIFF
--- a/Cache/Hashing.lean
+++ b/Cache/Hashing.lean
@@ -101,7 +101,7 @@ def getRootHash : CacheM UInt64 := do
     mathlibDepPath / "lake-manifest.json"]
   let hashes ← rootFiles.mapM fun path =>
     hashFileContents <$> IO.FS.readFile path
-  return hash (hash Lean.githash :: hashes)
+  return hash (rootHashGeneration :: hash Lean.githash :: hashes)
 
 /--
 Computes the hash of a file, which mixes:

--- a/Cache/IO.lean
+++ b/Cache/IO.lean
@@ -87,6 +87,11 @@ def getCurl : IO String := do
 def getLeanTar : IO String := do
   return if (← LEANTARBIN.pathExists) then LEANTARBIN.toString else "leantar"
 
+/-- Bump this number to invalidate the cache, in case the existing hashing inputs are insufficient.
+It is not a global counter, and can be reset to 0 as long as the lean githash or lake manifest has
+changed since the last time this counter was touched. -/
+def rootHashGeneration : UInt64 := 0
+
 /--
 `CacheM` stores the following information:
 * the source directory where `Mathlib.lean` lies


### PR DESCRIPTION
This should provide a better canonical way to invalidate the cache rather than changing whitespace in inconspicuous places in one of the three root hash files or in `Mathlib.Init`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
