### PR TITLE
[Merged by Bors] - chore: fix minor typo

### DIFF
--- a/Mathlib/Analysis/Meromorphic/Order.lean
+++ b/Mathlib/Analysis/Meromorphic/Order.lean
@@ -176,11 +176,11 @@ The order of a sum is at least the minimum of the orders of the summands.
 theorem order_add (hf₁ : MeromorphicAt f₁ x) (hf₂ : MeromorphicAt f₂ x) :
     min hf₁.order hf₂.order ≤ (hf₁.add hf₂).order := by
   -- Handle the trivial cases where one of the orders equals ⊤
-  by_cases h₂f₁: hf₁.order = ⊤
+  by_cases h₂f₁ : hf₁.order = ⊤
   · rw [h₂f₁, min_top_left, (hf₁.add hf₂).order_congr]
     filter_upwards [hf₁.order_eq_top_iff.1 h₂f₁]
     simp
-  by_cases h₂f₂: hf₂.order = ⊤
+  by_cases h₂f₂ : hf₂.order = ⊤
   · simp only [h₂f₂, le_top, inf_of_le_left]
     rw [(hf₁.add hf₂).order_congr]
     filter_upwards [hf₂.order_eq_top_iff.1 h₂f₂]


### PR DESCRIPTION
Fix minor typo found by @sgouezel while bors was already merging PR #23362. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
