### PR TITLE
[Merged by Bors] - chore: split LocallyFinite results out of Compactness.Compact 

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -5780,6 +5780,7 @@ import Mathlib.Topology.Compactness.DeltaGeneratedSpace
 import Mathlib.Topology.Compactness.Exterior
 import Mathlib.Topology.Compactness.Lindelof
 import Mathlib.Topology.Compactness.LocallyCompact
+import Mathlib.Topology.Compactness.LocallyFinite
 import Mathlib.Topology.Compactness.Paracompact
 import Mathlib.Topology.Compactness.PseudometrizableLindelof
 import Mathlib.Topology.Compactness.SigmaCompact

--- a/Mathlib/Topology/Compactness/Compact.lean
+++ b/Mathlib/Topology/Compactness/Compact.lean
@@ -7,7 +7,6 @@ import Mathlib.Order.Filter.Tendsto
 import Mathlib.Topology.Bases
 import Mathlib.Data.Set.Accumulate
 import Mathlib.Topology.Bornology.Basic
-import Mathlib.Topology.LocallyFinite
 import Mathlib.Topology.Ultrafilter
 import Mathlib.Topology.Defs.Ultrafilter
 /-!
@@ -251,17 +250,6 @@ theorem IsCompact.elim_finite_subfamily_closed {ι : Type v} (hs : IsCompact s)
   hs.elim_directed_family_closed _ (fun _ ↦ isClosed_biInter fun _ _ ↦ htc _)
     (by rwa [← iInter_eq_iInter_finset])
     (directed_of_isDirected_le fun _ _ h ↦ biInter_subset_biInter_left h)
-
-/-- If `s` is a compact set in a topological space `X` and `f : ι → Set X` is a locally finite
-family of sets, then `f i ∩ s` is nonempty only for a finitely many `i`. -/
-theorem LocallyFinite.finite_nonempty_inter_compact {f : ι → Set X}
-    (hf : LocallyFinite f) (hs : IsCompact s) : { i | (f i ∩ s).Nonempty }.Finite := by
-  choose U hxU hUf using hf
-  rcases hs.elim_nhds_subcover U fun x _ => hxU x with ⟨t, -, hsU⟩
-  refine (t.finite_toSet.biUnion fun x _ => hUf x).subset ?_
-  rintro i ⟨x, hx⟩
-  rcases mem_iUnion₂.1 (hsU hx.2) with ⟨c, hct, hcx⟩
-  exact mem_biUnion hct ⟨x, hx.1, hcx⟩
 
 /-- To show that a compact set intersects the intersection of a family of closed sets,
   it is sufficient to show that it intersects every finite subfamily. -/
@@ -828,24 +816,6 @@ theorem finite_cover_nhds [CompactSpace X] {U : X → Set X} (hU : ∀ x, U x �
     ∃ t : Finset X, ⋃ x ∈ t, U x = univ :=
   let ⟨t, ht⟩ := finite_cover_nhds_interior hU
   ⟨t, univ_subset_iff.1 <| ht.symm.subset.trans <| iUnion₂_mono fun _ _ => interior_subset⟩
-
-/-- If `X` is a compact space, then a locally finite family of sets of `X` can have only finitely
-many nonempty elements. -/
-theorem LocallyFinite.finite_nonempty_of_compact [CompactSpace X] {f : ι → Set X}
-    (hf : LocallyFinite f) : { i | (f i).Nonempty }.Finite := by
-  simpa only [inter_univ] using hf.finite_nonempty_inter_compact isCompact_univ
-
-/-- If `X` is a compact space, then a locally finite family of nonempty sets of `X` can have only
-finitely many elements, `Set.Finite` version. -/
-theorem LocallyFinite.finite_of_compact [CompactSpace X] {f : ι → Set X}
-    (hf : LocallyFinite f) (hne : ∀ i, (f i).Nonempty) : (univ : Set ι).Finite := by
-  simpa only [hne] using hf.finite_nonempty_of_compact
-
-/-- If `X` is a compact space, then a locally finite family of nonempty sets of `X` can have only
-finitely many elements, `Fintype` version. -/
-noncomputable def LocallyFinite.fintypeOfCompact [CompactSpace X] {f : ι → Set X}
-    (hf : LocallyFinite f) (hne : ∀ i, (f i).Nonempty) : Fintype ι :=
-  fintypeOfFiniteUniv (hf.finite_of_compact hne)
 
 /-- The comap of the cocompact filter on `Y` by a continuous function `f : X → Y` is less than or
 equal to the cocompact filter on `X`.

--- a/Mathlib/Topology/Compactness/LocallyFinite.lean
+++ b/Mathlib/Topology/Compactness/LocallyFinite.lean
@@ -1,0 +1,49 @@
+/-
+Copyright (c) 2021 Yury Kudryashov. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yury Kudryashov
+-/
+
+import Mathlib.Topology.LocallyFinite
+import Mathlib.Topology.Compactness.Compact
+
+/-!
+# Compact sets and compact spaces and locally finite functions
+-/
+
+open Set
+
+variable {X ι : Type*} [TopologicalSpace X] {s : Set X}
+
+namespace LocallyFinite
+
+/-- If `s` is a compact set in a topological space `X` and `f : ι → Set X` is a locally finite
+family of sets, then `f i ∩ s` is nonempty only for a finitely many `i`. -/
+theorem finite_nonempty_inter_compact {f : ι → Set X}
+    (hf : LocallyFinite f) (hs : IsCompact s) : { i | (f i ∩ s).Nonempty }.Finite := by
+  choose U hxU hUf using hf
+  rcases hs.elim_nhds_subcover U fun x _ => hxU x with ⟨t, -, hsU⟩
+  refine (t.finite_toSet.biUnion fun x _ => hUf x).subset ?_
+  rintro i ⟨x, hx⟩
+  rcases mem_iUnion₂.1 (hsU hx.2) with ⟨c, hct, hcx⟩
+  exact mem_biUnion hct ⟨x, hx.1, hcx⟩
+
+/-- If `X` is a compact space, then a locally finite family of sets of `X` can have only finitely
+many nonempty elements. -/
+theorem finite_nonempty_of_compact [CompactSpace X] {f : ι → Set X}
+    (hf : LocallyFinite f) : { i | (f i).Nonempty }.Finite := by
+  simpa only [inter_univ] using hf.finite_nonempty_inter_compact isCompact_univ
+
+/-- If `X` is a compact space, then a locally finite family of nonempty sets of `X` can have only
+finitely many elements, `Set.Finite` version. -/
+theorem finite_of_compact [CompactSpace X] {f : ι → Set X}
+    (hf : LocallyFinite f) (hne : ∀ i, (f i).Nonempty) : (univ : Set ι).Finite := by
+  simpa only [hne] using hf.finite_nonempty_of_compact
+
+/-- If `X` is a compact space, then a locally finite family of nonempty sets of `X` can have only
+finitely many elements, `Fintype` version. -/
+noncomputable def fintypeOfCompact [CompactSpace X] {f : ι → Set X}
+    (hf : LocallyFinite f) (hne : ∀ i, (f i).Nonempty) : Fintype ι :=
+  fintypeOfFiniteUniv (hf.finite_of_compact hne)
+
+end LocallyFinite

--- a/Mathlib/Topology/Compactness/SigmaCompact.lean
+++ b/Mathlib/Topology/Compactness/SigmaCompact.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Mario Carneiro, Yury Kudryashov
 -/
 import Mathlib.Topology.Compactness.LocallyCompact
+import Mathlib.Topology.Compactness.LocallyFinite
 /-!
 # Sigma-compactness in topological spaces
 


### PR DESCRIPTION
Copyright from: https://github.com/leanprover-community/mathlib3/pull/6352 and https://github.com/leanprover-community/mathlib3/pull/6948.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

Conflicts with #23401.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
