### PR TITLE
[Merged by Bors] - feat(SimpleGraph): a connected graph with n - 1 edges is a tree

### DIFF
--- a/Mathlib/Combinatorics/SimpleGraph/Acyclic.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Acyclic.lean
@@ -204,12 +204,17 @@ lemma isTree_of_minimal_connected (h : Minimal Connected G) : IsTree G := by
   exact fun _ _ _ ↦ by_contra fun hbr ↦ h.not_prop_of_lt (by simpa [← edgeSet_ssubset_edgeSet])
     <| h.prop.connected_delete_edge_of_not_isBridge hbr
 
+/-- Every connected graph has a spanning tree. TODO : remove the `Fintype V` hypothesis. -/
+lemma Connected.exists_isTree_le [Fintype V] (h : G.Connected) : ∃ T ≤ G, IsTree T := by
+  obtain ⟨T, hTG, hmin⟩ := {H : SimpleGraph V | H.Connected}.toFinite.exists_minimal_le h
+  exact ⟨T, hTG, isTree_of_minimal_connected hmin⟩
+
 /-- Every connected graph on `n` vertices has at least `n-1` edges. -/
 lemma Connected.card_vert_le_card_edgeSet_add_one [Fintype V] [Fintype G.edgeSet]
-    (hG : G.Connected) : Fintype.card V ≤ Fintype.card G.edgeSet + 1 := by
+    (h : G.Connected) : Fintype.card V ≤ Fintype.card G.edgeSet + 1 := by
   classical
-  obtain ⟨T, hTG, hmin⟩ := {H : SimpleGraph V | H.Connected}.toFinite.exists_minimal_le hG
-  rw [← (isTree_of_minimal_connected hmin).card_edgeFinset, add_le_add_iff_right, ← edgeFinset_card]
+  obtain ⟨T, hle, hT⟩ := h.exists_isTree_le
+  rw [← hT.card_edgeFinset, add_le_add_iff_right, ← edgeFinset_card]
   exact Finset.card_mono <| by simpa
 
 lemma isTree_iff_connected_and_card [Fintype V] [Fintype G.edgeSet] :

--- a/Mathlib/Combinatorics/SimpleGraph/Acyclic.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Acyclic.lean
@@ -202,7 +202,8 @@ lemma IsTree.card_edgeFinset [Fintype V] [Fintype G.edgeSet] (hG : G.IsTree) :
 /-- A minimally connected graph is a tree. -/
 lemma isTree_of_minimal_connected (h : Minimal Connected G) : IsTree G := by
   rw [isTree_iff, and_iff_right h.prop, isAcyclic_iff_forall_adj_isBridge]
-  exact fun _ _ _ ↦ by_contra fun hbr ↦ h.not_prop_of_lt (by simpa [← edgeSet_ssubset_edgeSet])
+  exact fun _ _ _↦ by_contra fun hbr ↦ h.not_prop_of_lt
+    (by simpa [deleteEdges, ← edgeSet_ssubset_edgeSet])
     <| h.prop.connected_delete_edge_of_not_isBridge hbr
 
 /-- Every connected graph has a spanning tree. -/
@@ -232,6 +233,6 @@ lemma isTree_iff_connected_and_card [Finite V] :
     (h₁.connected_delete_edge_of_not_isBridge hbr).card_vert_le_card_edgeSet_add_one.not_lt ?_
   rw [Nat.card_eq_fintype_card, ← edgeFinset_card, ← h₂, Nat.card_eq_fintype_card,
     ← edgeFinset_card, add_lt_add_iff_right]
-  exact Finset.card_lt_card <| by simpa
+  exact Finset.card_lt_card <| by simpa [deleteEdges]
 
 end SimpleGraph

--- a/Mathlib/Combinatorics/SimpleGraph/Acyclic.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Acyclic.lean
@@ -216,8 +216,7 @@ lemma Connected.card_vert_le_card_edgeSet_add_one (h : G.Connected) :
     Nat.card V ≤ Nat.card G.edgeSet + 1 := by
   obtain hV | hV := (finite_or_infinite V).symm
   · simp
-  have := Fintype.ofFinite V
-  classical
+  have := Fintype.ofFinite
   obtain ⟨T, hle, hT⟩ := h.exists_isTree_le
   rw [Nat.card_eq_fintype_card, ← hT.card_edgeFinset, add_le_add_iff_right,
     Nat.card_eq_fintype_card, ← edgeFinset_card]

--- a/Mathlib/Combinatorics/SimpleGraph/Path.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Path.lean
@@ -461,8 +461,7 @@ lemma IsCycle.isPath_takeUntil {c : G.Walk v v} (hc : c.IsCycle) (h : w ∈ c.su
   rw [← isCycle_reverse, ← take_spec c h, reverse_append] at hc
   exact (c.takeUntil w h).isPath_reverse_iff.mp (hc.isPath_of_append_right (not_nil_of_ne hvw))
 
-/-- Taking a strict initial segment of a path removes the end vertex from the support.
-TODO : a `dropUntil` version. -/
+/-- Taking a strict initial segment of a path removes the end vertex from the support. -/
 lemma endpoint_not_mem_support_takeUntil {p : G.Walk u v} (hp : p.IsPath) (hw : w ∈ p.support)
     (h : v ≠ w) : v ∉ (p.takeUntil w hw).support := by
   intro hv
@@ -864,6 +863,11 @@ protected theorem Reachable.map {u v : V} {G : SimpleGraph V} {G' : SimpleGraph 
 protected lemma Reachable.mono {u v : V} {G G' : SimpleGraph V}
     (h : G ≤ G') (Guv : G.Reachable u v) : G'.Reachable u v := Guv.map (.ofLE h)
 
+theorem Reachable.exists_isPath {u v} (hr : G.Reachable u v) : ∃ p : G.Walk u v, p.IsPath := by
+  classical
+  obtain ⟨W⟩ := hr
+  exact ⟨_, Path.isPath W.toPath⟩
+
 theorem Iso.reachable_iff {G : SimpleGraph V} {G' : SimpleGraph V'} {φ : G ≃g G'} {u v : V} :
     G'.Reachable (φ u) (φ v) ↔ G.Reachable u v :=
   ⟨fun r => φ.left_inv u ▸ φ.left_inv v ▸ r.map φ.symm.toHom, Reachable.map φ.toHom⟩
@@ -930,6 +934,10 @@ theorem Iso.preconnected_iff {G : SimpleGraph V} {H : SimpleGraph V'} (e : G ≃
   ⟨Preconnected.map e.toHom e.toEquiv.surjective,
     Preconnected.map e.symm.toHom e.symm.toEquiv.surjective⟩
 
+theorem Preconnected.exists_isPath {G : SimpleGraph V} (h : G.Preconnected) (u v : V) :
+    ∃ p : G.Walk u v, p.IsPath :=
+  (h u v).exists_isPath
+
 /-- A graph is connected if it's preconnected and contains at least one vertex.
 This follows the convention observed by mathlib that something is connected iff it has
 exactly one connected component.
@@ -960,6 +968,10 @@ protected lemma Connected.mono {G G' : SimpleGraph V} (h : G ≤ G')
     (hG : G.Connected) : G'.Connected where
   preconnected := hG.preconnected.mono h
   nonempty := hG.nonempty
+
+theorem Connected.exists_isPath {G : SimpleGraph V} (h : G.Connected) (u v : V) :
+    ∃ p : G.Walk u v, p.IsPath :=
+  (h u v).exists_isPath
 
 lemma bot_not_connected [Nontrivial V] : ¬(⊥ : SimpleGraph V).Connected := by
   simp [bot_not_preconnected, connected_iff, ‹_›]
@@ -1349,24 +1361,22 @@ theorem isBridge_iff_mem_and_forall_cycle_not_mem {e : Sym2 V} :
     G.IsBridge e ↔ e ∈ G.edgeSet ∧ ∀ ⦃u : V⦄ (p : G.Walk u u), p.IsCycle → e ∉ p.edges :=
   Sym2.ind (fun _ _ => isBridge_iff_adj_and_forall_cycle_not_mem) e
 
-/-- Deleting a non-bridge edge from a connected graph preserves connectedness.
-TODO : Iff version. -/
+/-- Deleting a non-bridge edge from a connected graph preserves connectedness. -/
 lemma Connected.connected_delete_edge_of_not_isBridge (hG : G.Connected) {x y : V}
-    (h : ¬ G.IsBridge s(x, y)) : (G \ fromEdgeSet {s(x, y)}).Connected := by
+    (h : ¬ G.IsBridge s(x, y)) : (G.deleteEdges {s(x, y)}).Connected := by
   classical
   simp only [isBridge_iff, not_and, not_not] at h
   obtain hxy | hxy := em' <| G.Adj x y
-  · rwa [Disjoint.sdiff_eq_left (by simpa)]
+  · rwa [deleteEdges, Disjoint.sdiff_eq_left (by simpa)]
   refine (connected_iff_exists_forall_reachable _).2 ⟨x, fun w ↦ ?_⟩
-  obtain ⟨W⟩ := (hG.preconnected w x)
-  let P := W.toPath
-  obtain heP | heP := em' <| s(x,y) ∈ P.1.edges
-  · exact ⟨(P.1.toDeleteEdges {s(x,y)} (by aesop)).reverse⟩
-  have hyP := P.1.snd_mem_support_of_mem_edges heP
-  let P₁ := P.1.takeUntil y hyP
-  have hxP₁ := Walk.endpoint_not_mem_support_takeUntil P.2 hyP hxy.ne
+  obtain ⟨P, hP⟩ := hG.exists_isPath w x
+  obtain heP | heP := em' <| s(x,y) ∈ P.edges
+  · exact ⟨(P.toDeleteEdges {s(x,y)} (by aesop)).reverse⟩
+  have hyP := P.snd_mem_support_of_mem_edges heP
+  let P₁ := P.takeUntil y hyP
+  have hxP₁ := Walk.endpoint_not_mem_support_takeUntil hP hyP hxy.ne
   have heP₁ : s(x,y) ∉ P₁.edges := fun h ↦ hxP₁ <| P₁.fst_mem_support_of_mem_edges h
-  refine (h hxy).trans (Reachable.symm ⟨P₁.toDeleteEdges {s(x,y)} (by aesop)⟩)
+  exact (h hxy).trans (Reachable.symm ⟨P₁.toDeleteEdges {s(x,y)} (by aesop)⟩)
 
 end BridgeEdges
 

--- a/Mathlib/Combinatorics/SimpleGraph/Path.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Path.lean
@@ -1363,7 +1363,7 @@ lemma Connected.connected_delete_edge_of_not_isBridge (hG : G.Connected) {x y : 
   obtain heP | heP := em' <| s(x,y) ∈ P.1.edges
   · exact ⟨(P.1.toDeleteEdges {s(x,y)} (by aesop)).reverse⟩
   have hyP := P.1.snd_mem_support_of_mem_edges heP
-  set P₁ := P.1.takeUntil y hyP with hP₁
+  let P₁ := P.1.takeUntil y hyP
   have hxP₁ := Walk.endpoint_not_mem_support_takeUntil P.2 hyP hxy.ne
   have heP₁ : s(x,y) ∉ P₁.edges := fun h ↦ hxP₁ <| P₁.fst_mem_support_of_mem_edges h
   refine (h hxy).trans (Reachable.symm ⟨P₁.toDeleteEdges {s(x,y)} (by aesop)⟩)


### PR DESCRIPTION
We prove that a connected graph on n vertices and n-1 edges is a tree, with a few API lemmas along the way, including the existence of spanning trees of connected graphs.  

---

The large import is because we need some `Minimal` API. Invoking the existence of minimal/maximal objects in finite settings is standard in graph theory proofs, so this import should also be helpful with other things going forward. 



<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
