### PR TITLE
[Merged by Bors] - chore: split IsTopologicalBasis results out of Compactness.Compact

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -5831,6 +5831,7 @@ import Mathlib.Topology.ClopenBox
 import Mathlib.Topology.CompactOpen
 import Mathlib.Topology.Compactification.OnePoint
 import Mathlib.Topology.Compactification.OnePointEquiv
+import Mathlib.Topology.Compactness.Bases
 import Mathlib.Topology.Compactness.Compact
 import Mathlib.Topology.Compactness.CompactlyGeneratedSpace
 import Mathlib.Topology.Compactness.DeltaGeneratedSpace

--- a/Mathlib/Topology/ClopenBox.lean
+++ b/Mathlib/Topology/ClopenBox.lean
@@ -3,6 +3,7 @@ Copyright (c) 2023 Dagur Asgeirsson. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Dagur Asgeirsson
 -/
+import Mathlib.Topology.Compactness.Bases
 import Mathlib.Topology.CompactOpen
 import Mathlib.Topology.Separation.Profinite
 import Mathlib.Topology.Sets.Closeds

--- a/Mathlib/Topology/Compactness/Bases.lean
+++ b/Mathlib/Topology/Compactness/Bases.lean
@@ -1,0 +1,59 @@
+/-
+Copyright (c) 2022 Andrew Yang. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Andrew Yang, Dagur Asgeirsson
+-/
+import Mathlib.Topology.Bases
+import Mathlib.Topology.Compactness.Compact
+
+/-!
+# Topological bases in compact sets and compact spaces
+-/
+
+open Set TopologicalSpace
+
+variable {X ι : Type*} [TopologicalSpace X]
+
+lemma eq_finite_iUnion_of_isTopologicalBasis_of_isCompact_open (b : ι → Set X)
+    (hb : IsTopologicalBasis (Set.range b)) (U : Set X) (hUc : IsCompact U) (hUo : IsOpen U) :
+    ∃ s : Set ι, s.Finite ∧ U = ⋃ i ∈ s, b i := by
+  obtain ⟨Y, f, e, hf⟩ := hb.open_eq_iUnion hUo
+  choose f' hf' using hf
+  have : b ∘ f' = f := funext hf'
+  subst this
+  obtain ⟨t, ht⟩ :=
+    hUc.elim_finite_subcover (b ∘ f') (fun i => hb.isOpen (Set.mem_range_self _)) (by rw [e])
+  classical
+  refine ⟨t.image f', Set.toFinite _, le_antisymm ?_ ?_⟩
+  · refine Set.Subset.trans ht ?_
+    simp only [Set.iUnion_subset_iff]
+    intro i hi
+    simpa using subset_iUnion₂ (s := fun i _ => b (f' i)) i hi
+  · apply Set.iUnion₂_subset
+    rintro i hi
+    obtain ⟨j, -, rfl⟩ := Finset.mem_image.mp hi
+    rw [e]
+    exact Set.subset_iUnion (b ∘ f') j
+
+lemma eq_sUnion_finset_of_isTopologicalBasis_of_isCompact_open (b : Set (Set X))
+    (hb : IsTopologicalBasis b) (U : Set X) (hUc : IsCompact U) (hUo : IsOpen U) :
+    ∃ s : Finset b, U = s.toSet.sUnion := by
+  have hb' : b = range (fun i ↦ i : b → Set X) := by simp
+  rw [hb'] at hb
+  choose s hs hU using eq_finite_iUnion_of_isTopologicalBasis_of_isCompact_open _ hb U hUc hUo
+  have : Finite s := hs
+  let _ : Fintype s := Fintype.ofFinite _
+  use s.toFinset
+  simp [hU]
+
+/-- If `X` has a basis consisting of compact opens, then an open set in `X` is compact open iff
+  it is a finite union of some elements in the basis -/
+theorem isCompact_open_iff_eq_finite_iUnion_of_isTopologicalBasis (b : ι → Set X)
+    (hb : IsTopologicalBasis (Set.range b)) (hb' : ∀ i, IsCompact (b i)) (U : Set X) :
+    IsCompact U ∧ IsOpen U ↔ ∃ s : Set ι, s.Finite ∧ U = ⋃ i ∈ s, b i := by
+  constructor
+  · exact fun ⟨h₁, h₂⟩ ↦ eq_finite_iUnion_of_isTopologicalBasis_of_isCompact_open _ hb U h₁ h₂
+  · rintro ⟨s, hs, rfl⟩
+    constructor
+    · exact hs.isCompact_biUnion fun i _ => hb' i
+    · exact isOpen_biUnion fun i _ => hb.isOpen (Set.mem_range_self _)

--- a/Mathlib/Topology/Compactness/Compact.lean
+++ b/Mathlib/Topology/Compactness/Compact.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Mario Carneiro, Yury Kudryashov
 -/
 import Mathlib.Order.Filter.Tendsto
-import Mathlib.Topology.Bases
 import Mathlib.Data.Set.Accumulate
 import Mathlib.Topology.Bornology.Basic
 import Mathlib.Topology.Ultrafilter
@@ -490,50 +489,6 @@ theorem exists_subset_nhds_of_isCompact' [Nonempty ι] {V : ι → Set X}
       tauto
   have : ¬⋂ i : ι, V i ⊆ W := by simpa [← iInter_inter, inter_compl_nonempty_iff]
   contradiction
-
-lemma eq_finite_iUnion_of_isTopologicalBasis_of_isCompact_open (b : ι → Set X)
-    (hb : IsTopologicalBasis (Set.range b)) (U : Set X) (hUc : IsCompact U) (hUo : IsOpen U) :
-    ∃ s : Set ι, s.Finite ∧ U = ⋃ i ∈ s, b i := by
-  obtain ⟨Y, f, e, hf⟩ := hb.open_eq_iUnion hUo
-  choose f' hf' using hf
-  have : b ∘ f' = f := funext hf'
-  subst this
-  obtain ⟨t, ht⟩ :=
-    hUc.elim_finite_subcover (b ∘ f') (fun i => hb.isOpen (Set.mem_range_self _)) (by rw [e])
-  classical
-  refine ⟨t.image f', Set.toFinite _, le_antisymm ?_ ?_⟩
-  · refine Set.Subset.trans ht ?_
-    simp only [Set.iUnion_subset_iff]
-    intro i hi
-    simpa using subset_iUnion₂ (s := fun i _ => b (f' i)) i hi
-  · apply Set.iUnion₂_subset
-    rintro i hi
-    obtain ⟨j, -, rfl⟩ := Finset.mem_image.mp hi
-    rw [e]
-    exact Set.subset_iUnion (b ∘ f') j
-
-lemma eq_sUnion_finset_of_isTopologicalBasis_of_isCompact_open (b : Set (Set X))
-    (hb : IsTopologicalBasis b) (U : Set X) (hUc : IsCompact U) (hUo : IsOpen U) :
-    ∃ s : Finset b, U = s.toSet.sUnion := by
-  have hb' : b = range (fun i ↦ i : b → Set X) := by simp
-  rw [hb'] at hb
-  choose s hs hU using eq_finite_iUnion_of_isTopologicalBasis_of_isCompact_open _ hb U hUc hUo
-  have : Finite s := hs
-  let _ : Fintype s := Fintype.ofFinite _
-  use s.toFinset
-  simp [hU]
-
-/-- If `X` has a basis consisting of compact opens, then an open set in `X` is compact open iff
-  it is a finite union of some elements in the basis -/
-theorem isCompact_open_iff_eq_finite_iUnion_of_isTopologicalBasis (b : ι → Set X)
-    (hb : IsTopologicalBasis (Set.range b)) (hb' : ∀ i, IsCompact (b i)) (U : Set X) :
-    IsCompact U ∧ IsOpen U ↔ ∃ s : Set ι, s.Finite ∧ U = ⋃ i ∈ s, b i := by
-  constructor
-  · exact fun ⟨h₁, h₂⟩ ↦ eq_finite_iUnion_of_isTopologicalBasis_of_isCompact_open _ hb U h₁ h₂
-  · rintro ⟨s, hs, rfl⟩
-    constructor
-    · exact hs.isCompact_biUnion fun i _ => hb' i
-    · exact isOpen_biUnion fun i _ => hb.isOpen (Set.mem_range_self _)
 
 namespace Filter
 

--- a/Mathlib/Topology/Compactness/Compact.lean
+++ b/Mathlib/Topology/Compactness/Compact.lean
@@ -6,10 +6,9 @@ Authors: Johannes Hölzl, Mario Carneiro, Yury Kudryashov
 import Mathlib.Order.Filter.Tendsto
 import Mathlib.Data.Set.Accumulate
 import Mathlib.Topology.Bornology.Basic
+import Mathlib.Topology.ContinuousOn
 import Mathlib.Topology.Ultrafilter
 import Mathlib.Topology.Defs.Ultrafilter
-
-import Mathlib.Topology.Bases -- TODO shake
 
 /-!
 # Compact sets and compact spaces

--- a/Mathlib/Topology/Compactness/Compact.lean
+++ b/Mathlib/Topology/Compactness/Compact.lean
@@ -8,6 +8,9 @@ import Mathlib.Data.Set.Accumulate
 import Mathlib.Topology.Bornology.Basic
 import Mathlib.Topology.Ultrafilter
 import Mathlib.Topology.Defs.Ultrafilter
+
+import Mathlib.Topology.Bases -- TODO shake
+
 /-!
 # Compact sets and compact spaces
 

--- a/Mathlib/Topology/Compactness/SigmaCompact.lean
+++ b/Mathlib/Topology/Compactness/SigmaCompact.lean
@@ -3,8 +3,10 @@ Copyright (c) 2017 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Mario Carneiro, Yury Kudryashov
 -/
+import Mathlib.Topology.Bases
 import Mathlib.Topology.Compactness.LocallyCompact
 import Mathlib.Topology.Compactness.LocallyFinite
+
 /-!
 # Sigma-compactness in topological spaces
 

--- a/Mathlib/Topology/Constructible.lean
+++ b/Mathlib/Topology/Constructible.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies
 -/
 import Mathlib.Order.BooleanSubalgebra
+import Mathlib.Topology.Compactness.Bases
 import Mathlib.Topology.LocalAtTarget
 import Mathlib.Topology.QuasiSeparated
 import Mathlib.Topology.Spectral.Hom

--- a/Mathlib/Topology/QuasiSeparated.lean
+++ b/Mathlib/Topology/QuasiSeparated.lean
@@ -3,6 +3,7 @@ Copyright (c) 2022 Andrew Yang. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Andrew Yang
 -/
+import Mathlib.Topology.Compactness.Bases
 import Mathlib.Topology.NoetherianSpace
 
 /-!

--- a/Mathlib/Topology/Separation/Basic.lean
+++ b/Mathlib/Topology/Separation/Basic.lean
@@ -9,6 +9,7 @@ import Mathlib.Topology.Inseparable
 import Mathlib.Topology.Piecewise
 import Mathlib.Topology.Separation.SeparatedNhds
 import Mathlib.Topology.Compactness.LocallyCompact
+import Mathlib.Topology.Bases
 
 /-!
 # Separation properties of topological spaces

--- a/Mathlib/Topology/Sets/Opens.lean
+++ b/Mathlib/Topology/Sets/Opens.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Mario Carneiro, Floris van Doorn
 -/
 import Mathlib.Order.Hom.CompleteLattice
-import Mathlib.Topology.Bases
+import Mathlib.Topology.Compactness.Bases
 import Mathlib.Topology.ContinuousMap.Basic
 import Mathlib.Order.CompactlyGenerated.Basic
 import Mathlib.Order.Copy


### PR DESCRIPTION
Copyright from: https://github.com/leanprover-community/mathlib3/pull/15436 and https://github.com/leanprover-community/mathlib4/pull/12986.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

Conflicts with #23396.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
