### PR TITLE
[Merged by Bors] - chore(RingTheory): even more `erw`s

### DIFF
--- a/Mathlib/RingTheory/Presentation.lean
+++ b/Mathlib/RingTheory/Presentation.lean
@@ -296,6 +296,8 @@ def baseChange : Presentation T (T ⊗[R] S) where
   relation i := MvPolynomial.map (algebraMap R T) (P.relation i)
   span_range_relation_eq_ker := P.span_range_relation_eq_ker_baseChange T
 
+lemma baseChange_toGenerators : (P.baseChange T).toGenerators = P.toGenerators.baseChange := rfl
+
 instance baseChange_isFinite [P.IsFinite] : (P.baseChange T).IsFinite where
   finite_vars := inferInstanceAs <| Finite (P.vars)
   finite_rels := inferInstanceAs <| Finite (P.rels)
@@ -440,6 +442,8 @@ noncomputable def comp : Presentation R T where
   relation := Sum.elim (Q.comp_relation_aux P)
     (fun rp ↦ MvPolynomial.rename Sum.inr <| P.relation rp)
   span_range_relation_eq_ker := Q.span_range_relation_eq_ker_comp P
+
+lemma toGenerators_comp : (Q.comp P).toGenerators = Q.toGenerators.comp P.toGenerators := rfl
 
 @[simp]
 lemma comp_relation_inr (r : P.rels) :

--- a/Mathlib/RingTheory/RingHom/FinitePresentation.lean
+++ b/Mathlib/RingTheory/RingHom/FinitePresentation.lean
@@ -124,7 +124,7 @@ theorem finitePresentation_ofLocalizationSpanTarget :
     simp only [Finset.univ_eq_attach, I, Ideal.mem_span_singleton] at hp
     obtain ⟨q, rfl⟩ := hp
     simp only [map_mul, map_sub, map_sum, map_one, hg', hh']
-    erw [Finsupp.linearCombination_apply_of_mem_supported S (s := s.attach)] at hl
+    rw [Finsupp.linearCombination_apply_of_mem_supported (α := (s : Set S)) S (s := s.attach)] at hl
     · rw [← hl]
       simp only [Finset.coe_sort_coe, smul_eq_mul, mul_comm, sub_self, mul_zero, zero_mul]
     · rintro a -

--- a/Mathlib/RingTheory/SimpleModule/Basic.lean
+++ b/Mathlib/RingTheory/SimpleModule/Basic.lean
@@ -370,7 +370,8 @@ theorem IsSemisimpleRing.ideal_eq_span_idempotent [IsSemisimpleRing R] (I : Idea
   obtain ⟨J, h⟩ := exists_isCompl I
   obtain ⟨f, idem, rfl⟩ := I.isIdempotentElemEquiv.symm (I.isComplEquivProj ⟨J, h⟩)
   exact ⟨f 1, LinearMap.isIdempotentElem_apply_one_iff.mpr idem, by
-    erw [LinearMap.range_eq_map, ← Ideal.span_one, LinearMap.map_span, Set.image_singleton]; rfl⟩
+    rw [LinearMap.range_eq_map, ← Ideal.span_one, ← Ideal.submodule_span_eq, LinearMap.map_span,
+      Set.image_one, Ideal.submodule_span_eq]⟩
 
 instance [IsSemisimpleRing R] : IsPrincipalIdealRing R where
   principal I := have ⟨e, _, he⟩ := IsSemisimpleRing.ideal_eq_span_idempotent I; ⟨e, he⟩

--- a/Mathlib/RingTheory/Smooth/Basic.lean
+++ b/Mathlib/RingTheory/Smooth/Basic.lean
@@ -108,16 +108,14 @@ noncomputable def liftOfSurjective [FormallySmooth R A] (f : A →ₐ[R] C)
 
 @[simp]
 theorem liftOfSurjective_apply [FormallySmooth R A] (f : A →ₐ[R] C) (g : B →ₐ[R] C)
-    (hg : Function.Surjective g) (hg' : IsNilpotent <| RingHom.ker (g : B →+* C)) (x : A) :
+    (hg : Function.Surjective g) (hg' : IsNilpotent <| RingHom.ker g) (x : A) :
     g (FormallySmooth.liftOfSurjective f g hg hg' x) = f x := by
   apply (Ideal.quotientKerAlgEquivOfSurjective hg).symm.injective
-  change _ = ((Ideal.quotientKerAlgEquivOfSurjective hg).symm.toAlgHom.comp f) x
-  -- This used to be `rw`, but we need `erw` after https://github.com/leanprover/lean4/pull/2644
-  erw [← FormallySmooth.mk_lift _ hg'
-    ((Ideal.quotientKerAlgEquivOfSurjective hg).symm.toAlgHom.comp f)]
+  conv_rhs => rw [← AlgHom.coe_coe, ← AlgHom.comp_apply, ← FormallySmooth.mk_lift (A := A) _ hg']
   apply (Ideal.quotientKerAlgEquivOfSurjective hg).injective
-  simp only [liftOfSurjective, AlgEquiv.apply_symm_apply, AlgEquiv.toAlgHom_eq_coe,
-    Ideal.quotientKerAlgEquivOfSurjective_apply, RingHom.kerLift_mk, RingHom.coe_coe]
+  rw [AlgEquiv.apply_symm_apply, Ideal.quotientKerAlgEquivOfSurjective_apply]
+  simp only [liftOfSurjective, ← RingHom.ker_coe_toRingHom g, RingHom.kerLift_mk,
+    AlgEquiv.toAlgHom_eq_coe, RingHom.coe_coe]
 
 @[simp]
 theorem comp_liftOfSurjective [FormallySmooth R A] (f : A →ₐ[R] C) (g : B →ₐ[R] C)
@@ -227,29 +225,20 @@ theorem iff_split_surjection [FormallySmooth R P] :
       ⟨Submodule.Quotient.mk (hf x).choose, (hf x).choose_spec⟩
     have sqz : RingHom.ker f.kerSquareLift.toRingHom ^ 2 = 0 := by
       rw [AlgHom.ker_kerSquareLift, Ideal.cotangentIdeal_square, Ideal.zero_eq_bot]
+    dsimp only [AlgHom.toRingHom_eq_coe, RingHom.ker_coe_toRingHom] at sqz
     refine
       ⟨FormallySmooth.lift _ ⟨2, sqz⟩ (Ideal.quotientKerAlgEquivOfSurjective surj).symm.toAlgHom,
         ?_⟩
+    dsimp only [AlgHom.toRingHom_eq_coe, AlgEquiv.toAlgHom_eq_coe]
     ext x
     have :=
-      (Ideal.quotientKerAlgEquivOfSurjective surj).toAlgHom.congr_arg
-        (FormallySmooth.mk_lift _ ⟨2, sqz⟩
-          (Ideal.quotientKerAlgEquivOfSurjective surj).symm.toAlgHom x)
-    -- Porting note: was
-    -- dsimp at this
-    -- rw [AlgEquiv.apply_symm_apply] at this
-    erw [AlgEquiv.apply_symm_apply] at this
+      (Ideal.quotientKerAlgEquivOfSurjective surj).congr_arg
+        (FormallySmooth.mk_lift (R := R) _ ⟨2, sqz⟩
+          (Ideal.quotientKerAlgEquivOfSurjective surj).symm x)
+    dsimp only [AlgHom.toRingHom_eq_coe, AlgHom.coe_coe] at this
+    rw [AlgEquiv.apply_symm_apply] at this
     conv_rhs => rw [← this, AlgHom.id_apply]
     rfl
-    -- Porting note: lean3 was not finished here:
-    -- obtain ⟨y, e⟩ :=
-    --   Ideal.Quotient.mk_surjective
-    --     (FormallySmooth.lift _ ⟨2, sqz⟩
-    --       (Ideal.quotientKerAlgEquivOfSurjective surj).symm.toAlgHom
-    --       x)
-    -- dsimp at e ⊢
-    -- rw [← e]
-    -- rfl
   · rintro ⟨g, hg⟩; exact FormallySmooth.of_split f g hg
 
 end OfSurjective

--- a/Mathlib/RingTheory/Smooth/Kaehler.lean
+++ b/Mathlib/RingTheory/Smooth/Kaehler.lean
@@ -131,6 +131,8 @@ lemma retractionOfSectionOfKerSqZero_tmul_D (s : S) (t : P) :
   haveI := isScalarTower_of_section_of_ker_sqZero g hf' hg
   simp only [retractionOfSectionOfKerSqZero, AlgHom.toRingHom_eq_coe, LinearMap.coe_restrictScalars,
     LinearMap.liftBaseChange_tmul, SetLike.val_smul_of_tower]
+  -- The issue is a mismatch between `RingHom.ker (algebraMap P S)` and
+  -- `RingHom.ker (IsScalarTower.toAlgHom R P S)`, but `rw` and `simp` can't rewrite it away...
   erw [Derivation.liftKaehlerDifferential_comp_D]
   exact mul_sub (g s) t (g (algebraMap P S t))
 

--- a/Mathlib/RingTheory/Smooth/StandardSmooth.lean
+++ b/Mathlib/RingTheory/Smooth/StandardSmooth.lean
@@ -254,12 +254,17 @@ noncomputable def comp : PreSubmersivePresentation R T where
     ((Sum.inr_injective).comp (P.map_inj)) <| by simp
   relations_finite := inferInstanceAs <| Finite (Q.rels ⊕ P.rels)
 
+lemma toPresentation_comp : (Q.comp P).toPresentation = Q.toPresentation.comp P.toPresentation :=
+  rfl
+
+lemma toGenerators_comp : (Q.comp P).toGenerators = Q.toGenerators.comp P.toGenerators := rfl
+
 /-- The dimension of the composition of two finite submersive presentations is
 the sum of the dimensions. -/
 lemma dimension_comp_eq_dimension_add_dimension [Q.IsFinite] [P.IsFinite] :
     (Q.comp P).dimension = Q.dimension + P.dimension := by
-  simp only [Presentation.dimension]
-  erw [Presentation.comp_rels, Generators.comp_vars]
+  simp only [Presentation.dimension, toPresentation_comp, Presentation.comp_rels,
+    Presentation.toGenerators_comp, Generators.comp_vars]
   have : Nat.card P.rels ≤ Nat.card P.vars :=
     card_relations_le_card_vars_of_isFinite P
   have : Nat.card Q.rels ≤ Nat.card Q.vars :=
@@ -345,12 +350,11 @@ private lemma jacobiMatrix_comp_₂₂_det :
   simp only [aeval, AlgHom.coe_mk, coe_eval₂Hom]
   generalize P.jacobiMatrix i j = p
   induction' p using MvPolynomial.induction_on with a p q hp hq p i hp
-  · simp only [algHom_C, algebraMap_eq, eval₂_C]
-    erw [MvPolynomial.eval₂_C]
+  · simp only [algHom_C, algebraMap_eq, eval₂_C, ← Generators.comp_vars,
+      ← Presentation.toGenerators_comp, ← toPresentation_comp]
   · simp [hp, hq]
-  · simp only [map_mul, rename_X, eval₂_mul, hp, eval₂_X]
-    erw [Generators.comp_val]
-    simp
+  · simp only [map_mul, eval₂_mul, hp]
+    simp [Presentation.toGenerators_comp, toPresentation_comp]
 
 end P
 
@@ -388,6 +392,12 @@ noncomputable def baseChange : PreSubmersivePresentation T (T ⊗[R] S) where
   map_inj := P.map_inj
   relations_finite := P.relations_finite
 
+lemma baseChange_toPresentation :
+    (P.baseChange R).toPresentation = P.toPresentation.baseChange R :=
+  rfl
+
+lemma baseChange_ring : (P.baseChange R).Ring = P.Ring := rfl
+
 @[simp]
 lemma baseChange_jacobian : (P.baseChange T).jacobian = 1 ⊗ₜ P.jacobian := by
   classical
@@ -398,9 +408,8 @@ lemma baseChange_jacobian : (P.baseChange T).jacobian = 1 ⊗ₜ P.jacobian := b
       (MvPolynomial.map (algebraMap R T)).mapMatrix P.jacobiMatrix := by
     ext i j : 1
     simp only [baseChange, jacobiMatrix_apply, Presentation.baseChange_relation,
-      RingHom.mapMatrix_apply, Matrix.map_apply]
-    erw [MvPolynomial.pderiv_map]
-    rfl
+      RingHom.mapMatrix_apply, Matrix.map_apply, Generators.baseChange_vars,
+      Presentation.baseChange_toGenerators, baseChange_toPresentation, MvPolynomial.pderiv_map]
   rw [h]
   erw [← RingHom.map_det, aeval_map_algebraMap]
   rw [P.algebraMap_apply]

--- a/Mathlib/RingTheory/TensorProduct/MvPolynomial.lean
+++ b/Mathlib/RingTheory/TensorProduct/MvPolynomial.lean
@@ -163,7 +163,7 @@ lemma rTensorAlgHom_toLinearMap :
     LinearMap.coe_restrictScalars, AlgHom.toLinearMap_apply]
   rw [coeff_rTensorAlgHom_tmul]
   simp only [coeff]
-  erw [finsuppLeft_apply_tmul_apply]
+  exact (finsuppLeft_apply_tmul_apply _ _ _).symm
 
 lemma rTensorAlgHom_apply_eq (p : MvPolynomial σ S ⊗[R] N) :
     rTensorAlgHom (S := S) p = rTensor p := by

--- a/Mathlib/RingTheory/Valuation/ValuationRing.lean
+++ b/Mathlib/RingTheory/Valuation/ValuationRing.lean
@@ -267,7 +267,7 @@ instance (priority := 100) isLocalRing : IsLocalRing A :=
 instance le_total_ideal : IsTotal (Ideal A) LE.le := by
   constructor; intro α β
   by_cases h : α ≤ β; · exact Or.inl h
-  erw [not_forall] at h
+  rw [SetLike.le_def, not_forall] at h
   push_neg at h
   obtain ⟨a, h₁, h₂⟩ := h
   right

--- a/Mathlib/RingTheory/Valuation/ValuationSubring.lean
+++ b/Mathlib/RingTheory/Valuation/ValuationSubring.lean
@@ -334,7 +334,7 @@ theorem idealOfLE_le_of_le (R S : ValuationSubring K) (hR : A ≤ R) (hS : A ≤
       apply not_le_of_lt ((valuation_lt_one_iff S _).1 hx) c)
 
 /-- The equivalence between coarsenings of a valuation ring and its prime ideals. -/
-@[simps]
+@[simps apply]
 def primeSpectrumEquiv : PrimeSpectrum A ≃ {S // A ≤ S} where
   toFun P := ⟨ofPrime A P.asIdeal, le_ofPrime _ _⟩
   invFun S := ⟨idealOfLE _ S S.2, inferInstance⟩
@@ -344,13 +344,13 @@ def primeSpectrumEquiv : PrimeSpectrum A ≃ {S // A ≤ S} where
 /-- An ordered variant of `primeSpectrumEquiv`. -/
 @[simps!]
 def primeSpectrumOrderEquiv : (PrimeSpectrum A)ᵒᵈ ≃o {S // A ≤ S} :=
-  { primeSpectrumEquiv A with
-    map_rel_iff' :=
-      ⟨fun h => by
+  { OrderDual.ofDual.trans (primeSpectrumEquiv A) with
+    map_rel_iff' {a b} :=
+      ⟨a.rec <| fun a => b.rec <| fun b => fun h => by
+        simp only [OrderDual.toDual_le_toDual]
         dsimp at h
         have := idealOfLE_le_of_le A _ _ ?_ ?_ h
-        iterate 2 erw [idealOfLE_ofPrime] at this
-        · exact this
+        · rwa [idealOfLE_ofPrime, idealOfLE_ofPrime] at this
         all_goals exact le_ofPrime A (PrimeSpectrum.asIdeal _),
       fun h => by apply ofPrime_le_of_le; exact h⟩ }
 

--- a/Mathlib/RingTheory/WittVector/Isocrystal.lean
+++ b/Mathlib/RingTheory/WittVector/Isocrystal.lean
@@ -208,14 +208,13 @@ theorem isocrystal_classification (k : Type*) [Field k] [IsAlgClosed k] [CharP k
       rw [LinearMap.span_singleton_eq_range]
   refine ⟨⟨(LinearEquiv.smulOfNeZero K(p, k) _ _ hb).trans F, fun c ↦ ?_⟩⟩
   rw [LinearEquiv.trans_apply, LinearEquiv.trans_apply, LinearEquiv.smulOfNeZero_apply,
-    LinearEquiv.smulOfNeZero_apply, LinearEquiv.map_smul, LinearEquiv.map_smul]
-  -- Porting note: was
-  -- simp only [hax, LinearEquiv.ofBijective_apply, LinearMap.toSpanSingleton_apply,
-  --   LinearEquiv.map_smulₛₗ, StandardOneDimIsocrystal.frobenius_apply, Algebra.id.smul_eq_mul]
-  rw [LinearEquiv.ofBijective_apply, LinearEquiv.ofBijective_apply]
-  erw [LinearMap.toSpanSingleton_apply K(p, k) V x c, LinearMap.toSpanSingleton_apply K(p, k) V x]
+    LinearEquiv.smulOfNeZero_apply, LinearEquiv.map_smul, LinearEquiv.map_smul,
+    LinearEquiv.ofBijective_apply, LinearEquiv.ofBijective_apply,
+    StandardOneDimIsocrystal.frobenius_apply]
+  unfold StandardOneDimIsocrystal
+  rw [LinearMap.toSpanSingleton_apply K(p, k) V x c, LinearMap.toSpanSingleton_apply K(p, k) V x]
   simp only [hax, LinearEquiv.ofBijective_apply, LinearMap.toSpanSingleton_apply,
-    LinearEquiv.map_smulₛₗ, StandardOneDimIsocrystal.frobenius_apply, Algebra.id.smul_eq_mul]
+    LinearEquiv.map_smulₛₗ, Algebra.id.smul_eq_mul]
   simp only [← mul_smul]
   congr 1
   linear_combination φ(p, k) c * hmb


### PR DESCRIPTION
Nothing very exciting, just a few manual unfolds and a few `erw`s removed through proof refactoring.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
