### PR TITLE
[Merged by Bors] - chore(FieldTheory): clean up a few more `erw`s

### DIFF
--- a/Mathlib/FieldTheory/Fixed.lean
+++ b/Mathlib/FieldTheory/Fixed.lean
@@ -266,10 +266,9 @@ instance isSeparable : Algebra.IsSeparable (FixedPoints.subfield G F) F := by
   classical
   exact ⟨fun x => by
     cases nonempty_fintype G
-    -- this was a plain rw when we were using unbundled subrings
     rw [IsSeparable, ← minpoly_eq_minpoly,
-      ← Polynomial.separable_map (FixedPoints.subfield G F).subtype, minpoly]
-    erw [Polynomial.map_toSubring _ (subfield G F).toSubring]
+      ← Polynomial.separable_map (FixedPoints.subfield G F).subtype, minpoly,
+      ← Subfield.toSubring_subtype_eq_subtype, Polynomial.map_toSubring _ (subfield G F).toSubring]
     exact Polynomial.separable_prod_X_sub_C_iff.2 (injective_ofQuotientStabilizer G x)⟩
 
 instance : FiniteDimensional (subfield G F) F := by

--- a/Mathlib/FieldTheory/IntermediateField/Adjoin/Algebra.lean
+++ b/Mathlib/FieldTheory/IntermediateField/Adjoin/Algebra.lean
@@ -126,7 +126,8 @@ theorem adjoin_toSubalgebra_of_isAlgebraic (L : IntermediateField F K)
   apply_fun _ using Subalgebra.restrictScalars_injective F
   rw [← restrictScalars_toSubalgebra, restrictScalars_adjoin_of_algEquiv i' hi,
     Algebra.restrictScalars_adjoin_of_algEquiv i' hi, restrictScalars_adjoin]
-  erw [Algebra.restrictScalars_adjoin]
+  dsimp only [← E'.coe_type_toSubalgebra]
+  rw [Algebra.restrictScalars_adjoin F E'.toSubalgebra]
   exact E'.sup_toSubalgebra_of_isAlgebraic L (halg.imp
     (fun (_ : Algebra.IsAlgebraic F E) ↦ i'.isAlgebraic) id)
 

--- a/Mathlib/FieldTheory/IntermediateField/Adjoin/Basic.lean
+++ b/Mathlib/FieldTheory/IntermediateField/Adjoin/Basic.lean
@@ -399,7 +399,9 @@ variable {L : Type*} [Field L] [Algebra K L]
 where `d` is the degree of the minimal polynomial of `x`. -/
 noncomputable def powerBasisAux {x : L} (hx : IsIntegral K x) :
     Basis (Fin (minpoly K x).natDegree) K K⟮x⟯ :=
-  (AdjoinRoot.powerBasis (minpoly.ne_zero hx)).basis.map (adjoinRootEquivAdjoin K hx).toLinearEquiv
+  (AdjoinRoot.powerBasis (minpoly.ne_zero hx)).basis
+    |>.map (adjoinRootEquivAdjoin K hx).toLinearEquiv
+    |>.reindex (finCongr rfl)
 
 /-- The power basis `1, x, ..., x ^ (d - 1)` for `K⟮x⟯`,
 where `d` is the degree of the minimal polynomial of `x`. -/
@@ -409,11 +411,9 @@ noncomputable def adjoin.powerBasis {x : L} (hx : IsIntegral K x) : PowerBasis K
   dim := (minpoly K x).natDegree
   basis := powerBasisAux hx
   basis_eq_pow i := by
-    rw [powerBasisAux, Basis.map_apply]
-    -- This used to be `rw`, but we need `erw` after https://github.com/leanprover/lean4/pull/2644
-    erw [PowerBasis.basis_eq_pow]
-    rw [AlgEquiv.toLinearEquiv_apply, map_pow, AdjoinRoot.powerBasis_gen,
-      adjoinRootEquivAdjoin_apply_root]
+    rw [powerBasisAux, Basis.reindex_apply, Basis.map_apply, PowerBasis.basis_eq_pow,
+      finCongr_symm, finCongr_apply, Fin.cast_eq_self, AlgEquiv.toLinearEquiv_apply,
+      map_pow, AdjoinRoot.powerBasis_gen, adjoinRootEquivAdjoin_apply_root]
 
 theorem adjoin.finiteDimensional {x : L} (hx : IsIntegral K x) : FiniteDimensional K K⟮x⟯ :=
   (adjoin.powerBasis hx).finite
@@ -459,7 +459,8 @@ theorem adjoin_minpoly_coeff_of_exists_primitive_element
   have finrank_eq : ∀ K : IntermediateField F E, finrank K E = natDegree (minpoly K α) := by
     intro K
     have := adjoin.finrank (.of_finite K α)
-    erw [adjoin_eq_top_of_adjoin_eq_top F hprim, finrank_top K E] at this
+    rw [adjoin_eq_top_of_adjoin_eq_top F hprim] at this
+    erw [finrank_top K E] at this
     exact this
   refine eq_of_le_of_finrank_le' hsub ?_
   simp_rw [finrank_eq]


### PR DESCRIPTION
One slight redefinition in the power basis for adjoining an element to a field, otherwise use proof refactors.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
