### PR TITLE
[Merged by Bors] - refactor(Data): split off material on `Set.Pairwise` from `List.Nodup`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3245,6 +3245,7 @@ import Mathlib.Data.Set.Opposite
 import Mathlib.Data.Set.Order
 import Mathlib.Data.Set.Pairwise.Basic
 import Mathlib.Data.Set.Pairwise.Lattice
+import Mathlib.Data.Set.Pairwise.List
 import Mathlib.Data.Set.Piecewise
 import Mathlib.Data.Set.Pointwise.Support
 import Mathlib.Data.Set.Prod

--- a/Mathlib/Data/Finset/Pairwise.lean
+++ b/Mathlib/Data/Finset/Pairwise.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies
 -/
 import Mathlib.Data.Finset.Lattice.Fold
+import Mathlib.Data.Set.Pairwise.List
 
 /-!
 # Relations holding pairwise on finite sets

--- a/Mathlib/Data/List/Dedup.lean
+++ b/Mathlib/Data/List/Dedup.lean
@@ -130,7 +130,7 @@ theorem dedup_map_of_injective [DecidableEq β] {f : α → β} (hf : Function.I
 /-- Note that the weaker `List.Subset.dedup_append_left` is proved later. -/
 theorem Subset.dedup_append_right {xs ys : List α} (h : xs ⊆ ys) :
     dedup (xs ++ ys) = dedup ys := by
-  rw [List.dedup_append, Subset.union_eq_right (h.trans <| subset_dedup _)]
+  rw [List.dedup_append, Subset.union_eq_right (List.Subset.trans h <| subset_dedup _)]
 
 theorem Disjoint.union_eq {xs ys : List α} (h : Disjoint xs ys) :
     xs ∪ ys = xs.dedup ++ ys := by

--- a/Mathlib/Data/List/Nodup.lean
+++ b/Mathlib/Data/List/Nodup.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Kenny Lau
 -/
 import Mathlib.Data.List.Forall2
-import Mathlib.Data.Set.Pairwise.Basic
 
 /-!
 # Lists with no duplicates
@@ -376,20 +375,6 @@ theorem Nodup.pairwise_of_forall_ne {l : List α} {r : α → α → Prop} (hl :
   else
     apply h <;> try (apply hab.subset; simp)
     exact heq
-
-theorem Nodup.pairwise_of_set_pairwise {l : List α} {r : α → α → Prop} (hl : l.Nodup)
-    (h : {x | x ∈ l}.Pairwise r) : l.Pairwise r :=
-  hl.pairwise_of_forall_ne h
-
-@[simp]
-theorem Nodup.pairwise_coe [IsSymm α r] (hl : l.Nodup) :
-    { a | a ∈ l }.Pairwise r ↔ l.Pairwise r := by
-  induction l with | nil => simp | cons a l ih => ?_
-  rw [List.nodup_cons] at hl
-  have : ∀ b ∈ l, ¬a = b → r a b ↔ r a b := fun b hb =>
-    imp_iff_right (ne_of_mem_of_not_mem hb hl.1).symm
-  simp [Set.setOf_or, Set.pairwise_insert_of_symmetric fun _ _ ↦ symm_of r, ih hl.2, and_comm,
-    forall₂_congr this]
 
 theorem Nodup.take_eq_filter_mem [DecidableEq α] :
     ∀ {l : List α} {n : ℕ} (_ : l.Nodup), l.take n = l.filter (l.take n).elem

--- a/Mathlib/Data/List/Perm/Lattice.lean
+++ b/Mathlib/Data/List/Perm/Lattice.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leonardo de Moura, Jeremy Avigad, Mario Carneiro
 -/
 import Mathlib.Data.List.Forall2
-import Mathlib.Data.Set.Pairwise.Basic
 import Mathlib.Data.List.TakeDrop
 import Mathlib.Data.List.Lattice
 import Mathlib.Data.List.Nodup

--- a/Mathlib/Data/List/Rotate.lean
+++ b/Mathlib/Data/List/Rotate.lean
@@ -5,6 +5,7 @@ Authors: Chris Hughes, Yakov Pechersky
 -/
 import Mathlib.Data.List.Nodup
 import Mathlib.Data.List.Infix
+import Mathlib.Data.Quot
 
 /-!
 # List rotation

--- a/Mathlib/Data/List/Sigma.lean
+++ b/Mathlib/Data/List/Sigma.lean
@@ -3,9 +3,11 @@ Copyright (c) 2018 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Sean Leather
 -/
+import Batteries.Tactic.Congr
 import Mathlib.Data.List.Pairwise
 import Mathlib.Data.List.Nodup
 import Mathlib.Data.List.Lookmap
+import Mathlib.Data.Sigma.Basic
 
 /-!
 # Utilities for lists of sigmas

--- a/Mathlib/Data/Multiset/Filter.lean
+++ b/Mathlib/Data/Multiset/Filter.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
 import Mathlib.Data.Multiset.MapFold
+import Mathlib.Data.Set.Function
 import Mathlib.Order.Hom.Basic
 
 /-!

--- a/Mathlib/Data/Multiset/UnionInter.lean
+++ b/Mathlib/Data/Multiset/UnionInter.lean
@@ -6,6 +6,7 @@ Authors: Mario Carneiro
 import Mathlib.Data.List.Perm.Lattice
 import Mathlib.Data.Multiset.Filter
 import Mathlib.Order.MinMax
+import Mathlib.Logic.Pairwise
 
 /-!
 # Distributive lattice structure on multisets

--- a/Mathlib/Data/Prod/TProd.lean
+++ b/Mathlib/Data/Prod/TProd.lean
@@ -4,6 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Floris van Doorn
 -/
 import Mathlib.Data.List.Nodup
+import Mathlib.Data.Set.Prod
+
 /-!
 # Finite products of types
 

--- a/Mathlib/Data/Set/Pairwise/List.lean
+++ b/Mathlib/Data/Set/Pairwise/List.lean
@@ -1,0 +1,36 @@
+/-
+Copyright (c) 2018 Mario Carneiro. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mario Carneiro, Kenny Lau
+-/
+import Mathlib.Data.List.Nodup
+import Mathlib.Data.Set.Pairwise.Basic
+
+/-!
+# Translating pairwise relations on sets to lists
+
+On a list with no duplicates, the condition of `Set.Pairwise` and `List.Pairwise` are equivalent.
+-/
+
+
+variable {α : Type*} {r : α → α → Prop}
+
+namespace List
+
+variable {l : List α}
+
+theorem Nodup.pairwise_of_set_pairwise {l : List α} {r : α → α → Prop} (hl : l.Nodup)
+    (h : {x | x ∈ l}.Pairwise r) : l.Pairwise r :=
+  hl.pairwise_of_forall_ne h
+
+@[simp]
+theorem Nodup.pairwise_coe [IsSymm α r] (hl : l.Nodup) :
+    { a | a ∈ l }.Pairwise r ↔ l.Pairwise r := by
+  induction l with | nil => simp | cons a l ih => ?_
+  rw [List.nodup_cons] at hl
+  have : ∀ b ∈ l, ¬a = b → r a b ↔ r a b := fun b hb =>
+    imp_iff_right (ne_of_mem_of_not_mem hb hl.1).symm
+  simp [Set.setOf_or, Set.pairwise_insert_of_symmetric fun _ _ ↦ symm_of r, ih hl.2, and_comm,
+    forall₂_congr this]
+
+end List

--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -414,6 +414,8 @@
   "Mathlib.Data.Nat.Init": ["Batteries.Tactic.Init"],
   "Mathlib.Data.Nat.Find": ["Batteries.WF"],
   "Mathlib.Data.Multiset.Bind": ["Mathlib.Algebra.GroupWithZero.Action.Defs"],
+  "Mathlib.Data.List.Sigma": ["Batteries.Tactic.Congr"],
+  "Mathlib.Data.List.Rotate": ["Mathlib.Data.Quot"],
   "Mathlib.Data.List.Range": ["Batteries.Data.Nat.Lemmas"],
   "Mathlib.Data.List.ProdSigma":
   ["Batteries.Data.Nat.Lemmas", "Mathlib.Data.List.Basic"],


### PR DESCRIPTION
Importing `Data.Set.Pairwise` in `Data.List.Nodup` comes with quite a bit of transitive dependencies, including on the long pole. I tried reversing the import direction, but going the other way lead to a lot more transitive imports. So let's split the files.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
