### PR TITLE
[Merged by Bors] - feat: add a criterion for a set of roots to span an irreducible root system

### DIFF
--- a/Mathlib/Algebra/Module/Submodule/Defs.lean
+++ b/Mathlib/Algebra/Module/Submodule/Defs.lean
@@ -185,6 +185,13 @@ theorem smul_mem_iff' [Group G] [MulAction G M] [SMul G R] [IsScalarTower G R M]
     g • x ∈ p ↔ x ∈ p :=
   p.toSubMulAction.smul_mem_iff' g
 
+@[simp]
+lemma smul_mem_iff'' [Invertible r] :
+    r • x ∈ p ↔ x ∈ p := by
+  refine ⟨fun h ↦ ?_, p.smul_mem r⟩
+  rw [← invOf_smul_smul r x]
+  exact p.smul_mem _ h
+
 instance add : Add p :=
   ⟨fun x y => ⟨x.1 + y.1, add_mem x.2 y.2⟩⟩
 

--- a/Mathlib/LinearAlgebra/Reflection.lean
+++ b/Mathlib/LinearAlgebra/Reflection.lean
@@ -6,6 +6,7 @@ Authors: Oliver Nash, Deepro Choudhury, Mitchell Lee, Johan Commelin
 import Mathlib.Algebra.EuclideanDomain.Basic
 import Mathlib.Algebra.EuclideanDomain.Int
 import Mathlib.Algebra.Module.LinearMap.Basic
+import Mathlib.Algebra.Module.Submodule.Invariant
 import Mathlib.Algebra.Module.Torsion
 import Mathlib.GroupTheory.MonoidLocalization.Basic
 import Mathlib.GroupTheory.OrderOfElement
@@ -124,6 +125,20 @@ lemma invOn_reflection_of_mapsTo {Φ : Set M} (h : f x = 2) :
 lemma bijOn_reflection_of_mapsTo {Φ : Set M} (h : f x = 2) (h' : MapsTo (reflection h) Φ Φ) :
     BijOn (reflection h) Φ Φ :=
   (invOn_reflection_of_mapsTo h).bijOn h' h'
+
+-- If `reflection` instead demanded a linear form `f` such that `f x = 1` rather than `f x = 2`,
+-- (and was thus defined as `y ↦ y - (2 * f y) • x`) then we could avoid `Invertible (2 : R)` here.
+lemma _root_.Submodule.mem_invtSubmodule_reflection_of_mem [Invertible (2 : R)] (h : f x = 2)
+    (p : Submodule R M) (hx : x ∈ p) :
+    p ∈ End.invtSubmodule (reflection h) := by
+  suffices ∀ y ∈ p, reflection h y ∈ p from
+    (End.mem_invtSubmodule _).mpr fun y hy ↦ by simpa using this y hy
+  intro y hy
+  set z := (2 : R) • y - f y • x with hz₀
+  have hz₁ : z ∈ p := sub_mem (p.smul_mem _ hy) (p.smul_mem _ hx)
+  have hz₂ : (2 : R) • reflection h y = z - f y • x := by simp only [reflection_apply, hz₀]; module
+  rw [← p.smul_mem_iff'' (r := (2 : R)), hz₂]
+  exact sub_mem hz₁ <| p.smul_mem _ hx
 
 /-! ### Powers of the product of two reflections
 

--- a/Mathlib/LinearAlgebra/RootSystem/Defs.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Defs.lean
@@ -706,9 +706,6 @@ def IsOrthogonal : Prop := pairing P i j = 0 ∧ pairing P j i = 0
 lemma isOrthogonal_symm : IsOrthogonal P i j ↔ IsOrthogonal P j i := by
   simp only [IsOrthogonal, and_comm]
 
-lemma IsOrthogonal.symm (h : IsOrthogonal P i j) : IsOrthogonal P j i :=
-  ⟨h.2, h.1⟩
-
 lemma isOrthogonal_comm (h : IsOrthogonal P i j) : Commute (P.reflection i) (P.reflection j) := by
   rw [commute_iff_eq]
   ext v
@@ -717,5 +714,39 @@ lemma isOrthogonal_comm (h : IsOrthogonal P i j) : Commute (P.reflection i) (P.r
   simp only [LinearEquiv.coe_coe, reflection_apply, PerfectPairing.flip_apply_apply, map_sub,
     map_smul, root_coroot_eq_pairing, h, zero_smul, sub_zero]
   abel
+
+variable {P i j}
+
+lemma IsOrthogonal.flip (h : IsOrthogonal P i j) : IsOrthogonal P.flip i j := ⟨h.2, h.1⟩
+
+lemma IsOrthogonal.symm (h : IsOrthogonal P i j) : IsOrthogonal P j i := ⟨h.2, h.1⟩
+
+lemma IsOrthogonal.reflection_apply_left (h : IsOrthogonal P i j) :
+    P.reflection j (P.root i) = P.root i := by
+  simp [reflection_apply, h.1]
+
+lemma IsOrthogonal.reflection_apply_right (h : IsOrthogonal P j i) :
+    P.reflection j (P.root i) = P.root i :=
+  h.symm.reflection_apply_left
+
+lemma IsOrthogonal.coreflection_apply_left (h : IsOrthogonal P i j) :
+    P.coreflection j (P.coroot i) = P.coroot i :=
+  h.flip.reflection_apply_left
+
+lemma IsOrthogonal.coreflection_apply_right (h : IsOrthogonal P j i) :
+    P.coreflection j (P.coroot i) = P.coroot i :=
+  h.flip.reflection_apply_right
+
+lemma isFixedPt_reflection_of_isOrthogonal {s : Set ι} (hj : ∀ i ∈ s, P.IsOrthogonal j i)
+    {x : M} (hx : x ∈ span R (P.root '' s)) :
+    IsFixedPt (P.reflection j) x := by
+  rw [IsFixedPt]
+  induction hx using Submodule.span_induction with
+  | zero => rw [map_zero]
+  | add u v hu hv hu' hv' => rw [map_add, hu', hv']
+  | smul t u hu hu' => rw [map_smul, hu']
+  | mem u hu =>
+      obtain ⟨i, his, rfl⟩ := hu
+      exact IsOrthogonal.reflection_apply_right <| hj i his
 
 end RootPairing

--- a/Mathlib/LinearAlgebra/RootSystem/Finite/Lemmas.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Finite/Lemmas.lean
@@ -239,13 +239,24 @@ lemma exists_apply_eq_or [Nonempty ι] : ∃ i j, ∀ k,
     have := exists_apply_eq_or_aux hij hik hjk
     aesop
 
+lemma apply_eq_or_of_apply_ne
+    (h : B.form (P.root i) (P.root i) ≠ B.form (P.root j) (P.root j)) (k : ι) :
+    B.form (P.root k) (P.root k) = B.form (P.root i) (P.root i) ∨
+    B.form (P.root k) (P.root k) = B.form (P.root j) (P.root j) := by
+  have : Nonempty ι := ⟨i⟩
+  obtain ⟨i', j', h'⟩ := B.exists_apply_eq_or
+  rcases h' i with hi | hi <;>
+  rcases h' j with hj | hj <;>
+  specialize h' k <;>
+  aesop
+
 end InvariantForm
 
 namespace Base
 
 variable {P}
 variable (b : P.Base) (i j k : ι) (hij : i ≠ j) (hi : i ∈ b.support) (hj : j ∈ b.support)
-include b hij hi hj
+include hij hi hj
 
 variable {i j} in
 lemma pairingIn_le_zero_of_ne :

--- a/Mathlib/LinearAlgebra/RootSystem/Irreducible.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Irreducible.lean
@@ -126,4 +126,16 @@ lemma exists_form_eq_form_and_form_ne_zero (B : P.InvariantForm) (i j : ι) :
   apply contra
   simp [← Subgroup.smul_def g]
 
+lemma span_root_image_eq_top_of_forall_orthogonal [Invertible (2 : R)] (s : Set ι)
+    (hne : s.Nonempty) (h : ∀ j, P.root j ∉ span R (P.root '' s) → ∀ i ∈ s, P.IsOrthogonal j i) :
+    span R (P.root '' s) = ⊤ := by
+  have hq (j : ι) : span R (P.root '' s) ∈ Module.End.invtSubmodule (P.reflection j) := by
+    by_cases hj : P.root j ∈ span R (P.root '' s)
+    · exact Submodule.mem_invtSubmodule_reflection_of_mem _ _ hj
+    · refine (Module.End.mem_invtSubmodule _).mpr fun x hx ↦ ?_
+      rwa [Submodule.mem_comap, LinearEquiv.coe_coe,
+        (isFixedPt_reflection_of_isOrthogonal (h _ hj) hx).eq]
+  apply IsIrreducible.eq_top_of_invtSubmodule_reflection _ hq
+  simpa using ⟨hne.choose, hne.choose_spec, P.ne_zero _⟩
+
 end RootPairing


### PR DESCRIPTION
The headline item is `RootPairing.span_root_image_eq_top_of_forall_orthogonal`.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
