### PR TITLE
[Merged by Bors] - feat(CategoryTheory/Limit/IsConnected): categories with initial/terminal objects are connected

### DIFF
--- a/Mathlib/CategoryTheory/Limits/IsConnected.lean
+++ b/Mathlib/CategoryTheory/Limits/IsConnected.lean
@@ -141,7 +141,8 @@ section
 
 variable (C : Type*) [Category C]
 
-instance isConnected_of_hasInitial [Limits.HasInitial C] : IsConnected C := by
+-- note : it seems making the following two as instances breaks things, so these are lemmas.
+lemma isConnected_of_hasInitial [Limits.HasInitial C] : IsConnected C := by
   letI : Nonempty C := ⟨⊥_ C⟩
   apply isConnected_of_zigzag
   intro j₁ j₂
@@ -150,7 +151,7 @@ instance isConnected_of_hasInitial [Limits.HasInitial C] : IsConnected C := by
     List.getLast_cons, List.cons_ne_self, List.getLast_singleton]
   exact ⟨Zag.symm <| Zag.of_hom <| Limits.initial.to _, Zag.of_hom <| Limits.initial.to _⟩
 
-instance isConnected_of_hasTerminal [Limits.HasTerminal C] : IsConnected C := by
+lemma isConnected_of_hasTerminal [Limits.HasTerminal C] : IsConnected C := by
   letI : Nonempty C := ⟨⊤_ C⟩
   apply isConnected_of_zigzag
   intro j₁ j₂

--- a/Mathlib/CategoryTheory/Limits/IsConnected.lean
+++ b/Mathlib/CategoryTheory/Limits/IsConnected.lean
@@ -160,7 +160,7 @@ instance isConnected_of_hasTerminal [Limits.HasTerminal C] : IsConnected C := by
   exact ⟨Zag.of_hom <| Limits.terminal.from _, Zag.symm <| Zag.of_hom <| Limits.terminal.from _⟩
 
 /-- Prove that a category is connected by supplying an explicit initial object. -/
-lemma isConnected_of_isInitial (x : C) (h : Limits.IsInitial x) : IsConnected C := by
+lemma isConnected_of_isInitial {x : C} (h : Limits.IsInitial x) : IsConnected C := by
   letI : Nonempty C := ⟨x⟩
   apply isConnected_of_zigzag
   intro j₁ j₂
@@ -170,7 +170,7 @@ lemma isConnected_of_isInitial (x : C) (h : Limits.IsInitial x) : IsConnected C 
   exact ⟨Zag.symm <| Zag.of_hom <| h.to _, Zag.of_hom <| h.to _⟩
 
 /-- Prove that a category is connected by supplying an explicit terminal object. -/
-lemma isConnected_of_isTerminal (x : C) (h : Limits.IsTerminal x) : IsConnected C := by
+lemma isConnected_of_isTerminal {x : C} (h : Limits.IsTerminal x) : IsConnected C := by
   letI : Nonempty C := ⟨x⟩
   apply isConnected_of_zigzag
   intro j₁ j₂

--- a/Mathlib/CategoryTheory/Limits/IsConnected.lean
+++ b/Mathlib/CategoryTheory/Limits/IsConnected.lean
@@ -137,4 +137,28 @@ theorem isConnected_iff_of_initial (F : C ⥤ D) [F.Initial] : IsConnected C ↔
 
 end Functor
 
+section
+
+variable (C : Type*) [Category C]
+
+instance isConnected_of_hasInitial [Limits.HasInitial C] : IsConnected C := by
+  letI : Nonempty C := ⟨⊥_ C⟩
+  apply isConnected_of_zigzag
+  intro j₁ j₂
+  use [⊥_ C, j₂]
+  simp only [List.chain_cons, List.Chain.nil, and_true, ne_eq, reduceCtorEq, not_false_eq_true,
+    List.getLast_cons, List.cons_ne_self, List.getLast_singleton]
+  exact ⟨Zag.symm <| Zag.of_hom <| Limits.initial.to _, Zag.of_hom <| Limits.initial.to _⟩
+
+instance isConnected_of_hasTerminal [Limits.HasTerminal C] : IsConnected C := by
+  letI : Nonempty C := ⟨⊤_ C⟩
+  apply isConnected_of_zigzag
+  intro j₁ j₂
+  use [⊤_ C, j₂]
+  simp only [List.chain_cons, List.Chain.nil, and_true, ne_eq, reduceCtorEq, not_false_eq_true,
+    List.getLast_cons, List.cons_ne_self, List.getLast_singleton]
+  exact ⟨Zag.of_hom <| Limits.terminal.from _, Zag.symm <| Zag.of_hom <| Limits.terminal.from _⟩
+
+end
+
 end CategoryTheory

--- a/Mathlib/CategoryTheory/Limits/IsConnected.lean
+++ b/Mathlib/CategoryTheory/Limits/IsConnected.lean
@@ -141,25 +141,6 @@ section
 
 variable (C : Type*) [Category C]
 
--- note : it seems making the following two as instances breaks things, so these are lemmas.
-lemma isConnected_of_hasInitial [Limits.HasInitial C] : IsConnected C := by
-  letI : Nonempty C := ⟨⊥_ C⟩
-  apply isConnected_of_zigzag
-  intro j₁ j₂
-  use [⊥_ C, j₂]
-  simp only [List.chain_cons, List.Chain.nil, and_true, ne_eq, reduceCtorEq, not_false_eq_true,
-    List.getLast_cons, List.cons_ne_self, List.getLast_singleton]
-  exact ⟨Zag.symm <| Zag.of_hom <| Limits.initial.to _, Zag.of_hom <| Limits.initial.to _⟩
-
-lemma isConnected_of_hasTerminal [Limits.HasTerminal C] : IsConnected C := by
-  letI : Nonempty C := ⟨⊤_ C⟩
-  apply isConnected_of_zigzag
-  intro j₁ j₂
-  use [⊤_ C, j₂]
-  simp only [List.chain_cons, List.Chain.nil, and_true, ne_eq, reduceCtorEq, not_false_eq_true,
-    List.getLast_cons, List.cons_ne_self, List.getLast_singleton]
-  exact ⟨Zag.of_hom <| Limits.terminal.from _, Zag.symm <| Zag.of_hom <| Limits.terminal.from _⟩
-
 /-- Prove that a category is connected by supplying an explicit initial object. -/
 lemma isConnected_of_isInitial {x : C} (h : Limits.IsInitial x) : IsConnected C := by
   letI : Nonempty C := ⟨x⟩
@@ -179,6 +160,13 @@ lemma isConnected_of_isTerminal {x : C} (h : Limits.IsTerminal x) : IsConnected 
   simp only [List.chain_cons, List.Chain.nil, and_true, ne_eq, reduceCtorEq, not_false_eq_true,
     List.getLast_cons, List.cons_ne_self, List.getLast_singleton]
   exact ⟨Zag.of_hom <| h.from _, Zag.symm <| Zag.of_hom <| h.from _⟩
+
+-- note : it seems making the following two as instances breaks things, so these are lemmas.
+lemma isConnected_of_hasInitial [Limits.HasInitial C] : IsConnected C :=
+  isConnected_of_isInitial C (Limits.initialIsInitial)
+
+lemma isConnected_of_hasTerminal [Limits.HasTerminal C] : IsConnected C :=
+  isConnected_of_isTerminal C (Limits.terminalIsTerminal)
 
 end
 

--- a/Mathlib/CategoryTheory/Limits/IsConnected.lean
+++ b/Mathlib/CategoryTheory/Limits/IsConnected.lean
@@ -159,6 +159,26 @@ instance isConnected_of_hasTerminal [Limits.HasTerminal C] : IsConnected C := by
     List.getLast_cons, List.cons_ne_self, List.getLast_singleton]
   exact ⟨Zag.of_hom <| Limits.terminal.from _, Zag.symm <| Zag.of_hom <| Limits.terminal.from _⟩
 
+/-- Prove that a category is connected by supplying an explicit initial object. -/
+lemma isConnected_of_isInitial (x : C) (h : Limits.IsInitial x) : IsConnected C := by
+  letI : Nonempty C := ⟨x⟩
+  apply isConnected_of_zigzag
+  intro j₁ j₂
+  use [x, j₂]
+  simp only [List.chain_cons, List.Chain.nil, and_true, ne_eq, reduceCtorEq, not_false_eq_true,
+    List.getLast_cons, List.cons_ne_self, List.getLast_singleton]
+  exact ⟨Zag.symm <| Zag.of_hom <| h.to _, Zag.of_hom <| h.to _⟩
+
+/-- Prove that a category is connected by supplying an explicit terminal object. -/
+lemma isConnected_of_isTerminal (x : C) (h : Limits.IsTerminal x) : IsConnected C := by
+  letI : Nonempty C := ⟨x⟩
+  apply isConnected_of_zigzag
+  intro j₁ j₂
+  use [x, j₂]
+  simp only [List.chain_cons, List.Chain.nil, and_true, ne_eq, reduceCtorEq, not_false_eq_true,
+    List.getLast_cons, List.cons_ne_self, List.getLast_singleton]
+  exact ⟨Zag.of_hom <| h.from _, Zag.symm <| Zag.of_hom <| h.from _⟩
+
 end
 
 end CategoryTheory


### PR DESCRIPTION
Record the fact that a category with an initial or a terminal object is connected.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
