### PR TITLE
[Merged by Bors] - feat(CategoryTheory): joins of categories

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2024,6 +2024,7 @@ import Mathlib.CategoryTheory.Idempotents.SimplicialObject
 import Mathlib.CategoryTheory.IsConnected
 import Mathlib.CategoryTheory.Iso
 import Mathlib.CategoryTheory.IsomorphismClasses
+import Mathlib.CategoryTheory.Join.Basic
 import Mathlib.CategoryTheory.LiftingProperties.Adjunction
 import Mathlib.CategoryTheory.LiftingProperties.Basic
 import Mathlib.CategoryTheory.LiftingProperties.Limits

--- a/Mathlib/CategoryTheory/Join.lean
+++ b/Mathlib/CategoryTheory/Join.lean
@@ -1,0 +1,326 @@
+/-
+Copyright (c) 2025 Robin Carlier. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robin Carlier
+-/
+
+import Mathlib.CategoryTheory.Functor.Category
+import Mathlib.CategoryTheory.Functor.FullyFaithful
+import Mathlib.CategoryTheory.Whiskering
+
+/-!
+# Joins of category
+
+Given categories `C, D`, this file constructs a category `C ⋆ D`.... -- TODO
+-/
+
+universe v₁ v₂ v₃ v₄ v₅ v₆ u₁ u₂ u₃ u₄ u₅ u₆
+
+namespace CategoryTheory
+
+
+/-- Elements of `Join C D` are either elements of `C` or elements of `D`. -/
+-- Impl. : We are not defining it as a type alias for `C ⊕ D` so that we can have
+-- aesop to call cases on `Join C D`
+inductive Join (C : Type u₁) [Category.{v₁} C] (D : Type u₂) [Category.{v₂} D] : Type (max u₁ u₂)
+  | left : C → Join C D
+  | right : D → Join C D
+
+attribute [local aesop safe cases (rule_sets := [CategoryTheory])] Join
+
+@[inherit_doc] infixr:30 " ⋆ " => Join
+
+namespace Join
+
+variable (C : Type u₁) [Category.{v₁} C] (D : Type u₂) [Category.{v₂} D]
+
+variable {C D}
+
+/-- Morphisms in `C ⋆ D` are those of `C` and `D`, plus an unique
+morphism `(left c ⟶ right d)` for every `c : C` and `d : D`. -/
+@[simp]
+def Hom : C ⋆ D → C ⋆ D → Type (max v₁ v₂)
+  | .left x, .left y => ULift (x ⟶ y)
+  | .right x, .right y => ULift (x ⟶ y)
+  | .left _, .right _ => PUnit
+  | .right _, .left _ => PEmpty
+attribute [nolint simpNF] Hom.eq_3
+
+/-- Identity morphisms in `C ⋆ D` are inherited from those in `C` and `D`. -/
+@[simp]
+def id : ∀ (X : C ⋆ D), Hom X X
+  | .left x => ULift.up (𝟙 x)
+  | .right x => ULift.up (𝟙 x)
+
+/-- Composition in `C ⋆ D` is inherited from the compositions in `C` and `D`. -/
+@[simp]
+def comp : ∀ {x y z : C ⋆ D}, Hom x y → Hom y z → Hom x z
+  | .left _x, .left _y, .left _z => fun f g ↦ ULift.up (ULift.down f ≫ ULift.down g)
+  | .left _x, .left _y, .right _z => fun _ _ ↦ PUnit.unit
+  | .left _x, .right _y, .left _z => fun _ g ↦ PEmpty.elim g
+  | .left _x, .right _y, .right _z => fun _ _ ↦ PUnit.unit
+  | .right _x, .left _y, .left _z => fun f _ ↦ PEmpty.elim f
+  | .right _x, .left _y, .right _z => fun f _ ↦ PEmpty.elim f
+  | .right _x, .right _y, .left _z => fun _ g ↦ PEmpty.elim g
+  | .right _x, .right _y, .right _z => fun f g ↦ ULift.up (ULift.down f ≫ ULift.down g)
+
+instance : Category.{max v₁ v₂} (C ⋆ D) where
+  Hom X Y := Hom X Y
+  id _ := id _
+  comp := comp
+  assoc {a b c d} f g h := by
+    cases a <;>
+    cases b <;>
+    cases c <;>
+    cases d <;>
+    simp only [Hom, id, comp, Category.assoc] <;>
+    tauto
+
+@[aesop safe destruct (rule_sets := [CategoryTheory])]
+lemma false_of_right_to_left {X : D} {Y : C} (f : right X ⟶ left Y) : False := (f : PEmpty).elim
+
+instance {X : C} {Y : D} : Unique (left X ⟶ right Y) := inferInstanceAs (Unique PUnit)
+
+namespace Hom
+
+/-- Get back a morphism `X ⟶ Y` in C from a morphism `left X ⟶ left Y` in `C ⋆ D`. -/
+def downl {X Y : C} (f : (left X : C ⋆ D) ⟶ left Y) : X ⟶ Y := ULift.down f
+
+/-- Get back a morphism `X ⟶ Y` in `D` from a morphism `right X ⟶ right Y` in `C ⋆ D`. -/
+def downr {X Y : D} (f : (right X : C ⋆ D) ⟶ right Y) : X ⟶ Y := ULift.down f
+
+/-- Construct a morphism `left X ⟶ left Y` in `C ⋆ D` from a morphism `X ⟶ Y` in C. -/
+def upl {X Y : C} (f : X ⟶ Y) : (left X : C ⋆ D) ⟶ left Y := ULift.up f
+
+/-- Construct a morphism `right X ⟶ right Y` in `C ⋆ D` from a morphism `X ⟶ Y` in D. -/
+def upr {X Y : D} (f : X ⟶ Y) : (right X : C ⋆ D) ⟶ right Y := ULift.up f
+
+@[simp]
+lemma downl_upl {X Y : C} (f : X ⟶ Y) : downl (upl f : (_ : C ⋆ D) ⟶ _) = f := rfl
+
+@[simp]
+lemma downr_upr {X Y : D} (f : X ⟶ Y) : downr (upr f : (_ : C ⋆ D) ⟶ _) = f := rfl
+
+@[simp]
+lemma upl_downl {X Y : C} (f : (left X : C ⋆ D) ⟶ left Y) : upl (downl f) = f := rfl
+
+@[simp]
+lemma upr_downr {X Y : D} (f : (right X : C ⋆ D) ⟶ right Y) : upr (downr f) = f := rfl
+
+@[simp]
+lemma downl_comp {X Y Z : C} (f : (left X : C ⋆ D) ⟶ left Y) (g : (left Y : C ⋆ D) ⟶ left Z) :
+    downl (f ≫ g) = downl f ≫ downl g :=
+  rfl
+
+@[simp]
+lemma downr_comp {X Y Z : D} (f : (right X : C ⋆ D) ⟶ right Y) (g : (right Y : C ⋆ D) ⟶ right Z) :
+    downr (f ≫ g) = downr f ≫ downr g :=
+  rfl
+
+@[simp]
+lemma upl_comp {X Y Z : C} (f : X ⟶ Y) (g : Y ⟶ Z) :
+    (upl (f ≫ g) : (_ : C ⋆ D) ⟶ _) = upl f ≫ upl g :=
+  rfl
+
+@[simp]
+lemma upr_comp {X Y Z : D} (f : X ⟶ Y) (g : Y ⟶ Z) :
+    (upr (f ≫ g) : (_ : C ⋆ D) ⟶ _) = upr f ≫ upr g :=
+  rfl
+
+@[simp]
+lemma upl_id {X : C} : (upl (𝟙 X) : (_ : C ⋆ D) ⟶ _) = 𝟙 (left X) := rfl
+
+@[simp]
+lemma upr_id {X : D} : (upr (𝟙 X) : (_ : C ⋆ D) ⟶ _) = 𝟙 (right X) := rfl
+
+@[simp]
+lemma downl_id {X : C} : downl (𝟙 (left X : C ⋆ D)) = 𝟙 X := rfl
+
+@[simp]
+lemma downr_id {X : D} : downr (𝟙 (right X : C ⋆ D)) = 𝟙 X := rfl
+
+end Hom
+
+/-- The canonical inclusion from C to `C ⋆ D`. -/
+@[simps]
+def inclLeft : C ⥤ C ⋆ D where
+  obj := left
+  map := Hom.upl
+
+/-- The canonical inclusion from D to `C ⋆ D`. -/
+@[simps]
+def inclRight : D ⥤ C ⋆ D where
+  obj := right
+  map := Hom.upr
+
+instance : (inclLeft : C ⥤ C ⋆ D).Full where
+  map_surjective f := ⟨Hom.downl f, rfl⟩
+
+instance : (inclRight : D ⥤ C ⋆ D).Full where
+  map_surjective f := ⟨Hom.downr f, rfl⟩
+
+instance : (inclLeft : C ⥤ C ⋆ D).Faithful where
+  map_injective {_ _} _ _ h := congrArg (fun k ↦ Hom.downl k) h
+
+instance : (inclRight : D ⥤ C ⋆ D).Faithful where
+  map_injective {_ _} _ _ h := congrArg (fun k ↦ Hom.downr k) h
+
+section Functoriality
+
+variable {E : Type u₃} [Category.{v₃} E] (Fₗ : C ⥤ E)
+  {E' : Type u₄} [Category.{v₄} E'] (Fᵣ : D ⥤ E')
+
+/-- A functor (C ⥤ E) induces a functor (C ⋆ D ⥤ E ⋆ D). -/
+@[simps!]
+def mapLeft : (C ⋆ D) ⥤ (E ⋆ D) where
+  obj X :=
+    match X with
+    | .left x => left (Fₗ.obj x)
+    | .right x => right x
+  map {X Y} f :=
+    match X, Y, f with
+    | .left x, .left y, f => Hom.upl <| Fₗ.map <| Hom.downl f
+    | .right x, .right y, f => Hom.upr <| Hom.downr f
+    | .left _, .right _, _ => PUnit.unit
+
+/-- A functor (D ⥤ E') induces a functor (C ⋆ D ⥤ C ⋆ E'). -/
+@[simps!]
+def mapRight : (C ⋆ D) ⥤ (C ⋆ E') where
+  obj X :=
+    match X with
+    | .left x => left x
+    | .right x => right (Fᵣ.obj x)
+  map {X Y} f :=
+    match X, Y, f with
+    | .left x, .left y, f => Hom.upl <| Hom.downl f
+    | .right x, .right y, f => Hom.upr <| Fᵣ.map <| Hom.downr f
+    | .left _, .right _, _ => PUnit.unit
+
+/-- A pair of functors ((C ⥤ E), (D ⥤ E')) induces a functor (C ⋆ D ⥤ E ⋆ E'). -/
+@[simps!]
+def mapPair : (C ⋆ D) ⥤ (E ⋆ E') where
+  obj X :=
+    match X with
+    | .left x => left (Fₗ.obj x)
+    | .right x => right (Fᵣ.obj x)
+  map {X Y} f :=
+    match X, Y, f with
+    | .left x, .left y, f => Hom.upl <| Fₗ.map <| Hom.downl f
+    | .right x, .right y, f => Hom.upr <| Fᵣ.map <| Hom.downr f
+    | .left _, .right _, _ => PUnit.unit
+
+/-- We can decompose mapPair as first `mapLeft`, then `mapRight`. -/
+@[simps!]
+def mapPairIsoMapLeftCompMapRight : mapPair Fₗ Fᵣ ≅ mapLeft Fₗ ⋙ mapRight Fᵣ :=
+  NatIso.ofComponents (fun X ↦ match X with
+    | left _ => Iso.refl _
+    | right _ => Iso.refl _)
+
+/-- We can decompose `mapPair` as first mapRight, then `mapLeft`. -/
+@[simps!]
+def mapPairIsoMapRightCompMapLeft : mapPair Fₗ Fᵣ ≅ mapRight Fᵣ ⋙ mapLeft Fₗ :=
+  NatIso.ofComponents (fun X ↦ match X with
+    | left _ => Iso.refl _
+    | right _ => Iso.refl _)
+
+/-- `mapLeft` respects the identity functors. -/
+@[simps!]
+def mapLeftId : mapLeft (𝟭 C) ≅ 𝟭 (C ⋆ D) :=
+  NatIso.ofComponents (fun X ↦ match X with
+    | left _ => Iso.refl _
+    | right _ => Iso.refl _)
+
+/-- `mapRight` respects the identity functors. -/
+@[simps!]
+def mapRightId : mapRight (𝟭 D) ≅ 𝟭 (C ⋆ D) :=
+  NatIso.ofComponents (fun X ↦ match X with
+    | left _ => Iso.refl _
+    | right _ => Iso.refl _)
+
+/-- `mapPair F (𝟭 D)` is naturally isomorphic to `mapLeft F`. -/
+@[simps!]
+def mapPairIdRight : mapPair Fₗ (𝟭 D) ≅ mapLeft Fₗ :=
+  NatIso.ofComponents (fun X ↦ match X with
+    | left _ => Iso.refl _
+    | right _ => Iso.refl _)
+
+/-- `mapPair (𝟭 C) F` is naturally isomorphic to `mapLeft R`. -/
+@[simps!]
+def mapPairIdLeft : mapPair (𝟭 C) Fᵣ ≅ mapRight Fᵣ :=
+  NatIso.ofComponents (fun X ↦ match X with
+    | left _ => Iso.refl _
+    | right _ => Iso.refl _)
+
+/-- `mapPair` respects identities. -/
+@[simps!]
+def mapPairId : mapPair (𝟭 C) (𝟭 D) ≅ 𝟭 (C ⋆ D) :=
+  NatIso.ofComponents (fun X ↦ match X with
+    | left _ => Iso.refl _
+    | right _ => Iso.refl _)
+
+/-- Coherence of the previous isomorphims. -/
+@[simp]
+lemma mapPairId_coherence_left :
+    (mapPairId : mapPair (𝟭 C) (𝟭 D) ≅ 𝟭 (C ⋆ D)) = mapPairIdLeft (𝟭 D) ≪≫ mapLeftId := by
+  aesop_cat
+
+/-- Coherence of the previous isomorphims. -/
+@[simp]
+lemma mapPairId_coherence_right :
+    (mapPairId : mapPair (𝟭 C) (𝟭 D) ≅ 𝟭 (C ⋆ D)) = mapPairIdRight (𝟭 C) ≪≫ mapRightId := by
+  aesop_cat
+
+@[simp]
+lemma mapPairIsoMapLeftCompMapRight_coherence_id :
+    mapPairIsoMapLeftCompMapRight (𝟭 C) (𝟭 D) ≪≫
+      (isoWhiskerLeft (mapLeft _) mapRightId) ≪≫ (isoWhiskerRight mapLeftId _) ≪≫
+      (Functor.leftUnitor _) =
+    (mapPairId : mapPair (𝟭 C) (𝟭 D) ≅ 𝟭 (C ⋆ D)) := by
+  aesop_cat
+
+@[simp]
+lemma mapPairIsoMapRightCompMapLeft_coherence_id :
+    mapPairIsoMapRightCompMapLeft (𝟭 C) (𝟭 D) ≪≫
+      (isoWhiskerLeft (mapRight _) mapLeftId) ≪≫ (isoWhiskerRight mapLeftId _) ≪≫
+      (Functor.leftUnitor _) =
+    (mapPairId : mapPair (𝟭 C) (𝟭 D) ≅ 𝟭 (C ⋆ D)) := by
+  aesop_cat
+
+variable {J : Type u₅} [Category.{v₅} J] (Gₗ : E ⥤ J)
+  {J' : Type u₆} [Category.{v₆} J'] (Gᵣ : E' ⥤ J')
+
+/-- `mapLeft` respects functor composition. -/
+@[simps!]
+def mapLeftComp : (mapLeft (Fₗ ⋙ Gₗ) : C ⋆ D ⥤ J ⋆ D) ≅ mapLeft Fₗ ⋙ mapLeft Gₗ :=
+  NatIso.ofComponents (fun X ↦ match X with
+    | left _ => Iso.refl _
+    | right _ => Iso.refl _)
+
+/-- `mapRight` respects functor composition. -/
+@[simps!]
+def mapRightComp : (mapRight (Fᵣ ⋙ Gᵣ) : C ⋆ D ⥤ C ⋆ J') ≅ mapRight Fᵣ ⋙ mapRight Gᵣ :=
+  NatIso.ofComponents (fun X ↦ match X with
+    | left _ => Iso.refl _
+    | right _ => Iso.refl _)
+
+/-- `mapRight` respects functor composition. -/
+@[simps!]
+def mapPairComp : (mapPair (Fₗ ⋙ Gₗ) (Fᵣ ⋙ Gᵣ) : C ⋆ D ⥤ J ⋆ J') ≅ mapPair Fₗ Fᵣ ⋙ mapPair Gₗ Gᵣ :=
+  NatIso.ofComponents (fun X ↦ match X with
+    | left _ => Iso.refl _
+    | right _ => Iso.refl _)
+
+@[simps!]
+def mapPairComp_coherence_left :
+    mapPairComp Fₗ Fᵣ Gₗ Gᵣ = mapPairIsoMapLeftCompMapRight (Fₗ ≫ Gₗ) (Fᵣ ≫ Gᵣ) ≪≫ 
+      (isoWhiskerLeft (mapRight _) (mapLeftComp _ _)) ≪≫ (isoWhiskerRight mapLeftId _) := by
+  NatIso.ofComponents (fun X ↦ match X with
+    | left _ => Iso.refl _
+    | right _ => Iso.refl _)
+
+end Functoriality
+
+end Join
+
+
+end CategoryTheory

--- a/Mathlib/CategoryTheory/Join.lean
+++ b/Mathlib/CategoryTheory/Join.lean
@@ -6,18 +6,35 @@ Authors: Robin Carlier
 
 import Mathlib.CategoryTheory.Functor.Category
 import Mathlib.CategoryTheory.Functor.FullyFaithful
+import Mathlib.CategoryTheory.Comma.Basic
 import Mathlib.CategoryTheory.Whiskering
+import Mathlib.CategoryTheory.Bicategory.Functor.Pseudofunctor
 
 /-!
 # Joins of category
 
-Given categories `C, D`, this file constructs a category `C ⋆ D`.... -- TODO
+Given categories `C, D`, this file constructs a category `C ⋆ D`. Its objects are either
+objects of `C` or objects of `D`, morphisms between objects of `C` are morphisms in `C`,
+morphisms between object of `D` are morphisms in `D`, and finally, given `c : C` and `d : D`,
+there is a unique morphism `c ⟶ d` in `C ⋆ D`.
+
+## Main constructions
+- `Join.edge c d`: the unique map from `c` to `d`.
+- `Join.inclLeft : C ⥤ C ⋆ D`, the left inclusion. Its action on morphism is the main entry point
+to constructs maps in `C ⋆ D` between objects coming from `C`.
+- `Join.inclRight : D ⥤ C ⋆ D`, the left inclusion. Its action on morphism is the main entry point
+to constructs maps in `C ⋆ D` between object coming from `D`.
+- `Join.mkFunctor`, A constructor for functors out of a join of categories.
+- `Join.mkNatTrans`, A constructor for natural transformations between functors out of a join
+  of categories.
+
+# TODOs
+- Cofinality of the right inclusion, finality of the left inclusion.
 -/
 
 universe v₁ v₂ v₃ v₄ v₅ v₆ u₁ u₂ u₃ u₄ u₅ u₆
 
 namespace CategoryTheory
-
 
 /-- Elements of `Join C D` are either elements of `C` or elements of `D`. -/
 -- Impl. : We are not defining it as a type alias for `C ⊕ D` so that we can have
@@ -34,26 +51,24 @@ namespace Join
 
 variable (C : Type u₁) [Category.{v₁} C] (D : Type u₂) [Category.{v₂} D]
 
+section CategoryStructure
+
 variable {C D}
 
 /-- Morphisms in `C ⋆ D` are those of `C` and `D`, plus an unique
 morphism `(left c ⟶ right d)` for every `c : C` and `d : D`. -/
-@[simp]
 def Hom : C ⋆ D → C ⋆ D → Type (max v₁ v₂)
   | .left x, .left y => ULift (x ⟶ y)
   | .right x, .right y => ULift (x ⟶ y)
   | .left _, .right _ => PUnit
   | .right _, .left _ => PEmpty
-attribute [nolint simpNF] Hom.eq_3
 
 /-- Identity morphisms in `C ⋆ D` are inherited from those in `C` and `D`. -/
-@[simp]
 def id : ∀ (X : C ⋆ D), Hom X X
   | .left x => ULift.up (𝟙 x)
   | .right x => ULift.up (𝟙 x)
 
 /-- Composition in `C ⋆ D` is inherited from the compositions in `C` and `D`. -/
-@[simp]
 def comp : ∀ {x y z : C ⋆ D}, Hom x y → Hom y z → Hom x z
   | .left _x, .left _y, .left _z => fun f g ↦ ULift.up (ULift.down f ≫ ULift.down g)
   | .left _x, .left _y, .right _z => fun _ _ ↦ PUnit.unit
@@ -75,252 +90,309 @@ instance : Category.{max v₁ v₂} (C ⋆ D) where
     cases d <;>
     simp only [Hom, id, comp, Category.assoc] <;>
     tauto
+  id_comp {x y} f := by
+    cases x <;> cases y <;> simp only [Hom, id, comp, Category.id_comp] <;> tauto
+  comp_id {x y} f := by
+    cases x <;> cases y <;> simp only [Hom, id, comp, Category.comp_id] <;> tauto
 
 @[aesop safe destruct (rule_sets := [CategoryTheory])]
 lemma false_of_right_to_left {X : D} {Y : C} (f : right X ⟶ left Y) : False := (f : PEmpty).elim
 
 instance {X : C} {Y : D} : Unique (left X ⟶ right Y) := inferInstanceAs (Unique PUnit)
 
-namespace Hom
-
-/-- Get back a morphism `X ⟶ Y` in C from a morphism `left X ⟶ left Y` in `C ⋆ D`. -/
-def downl {X Y : C} (f : (left X : C ⋆ D) ⟶ left Y) : X ⟶ Y := ULift.down f
-
-/-- Get back a morphism `X ⟶ Y` in `D` from a morphism `right X ⟶ right Y` in `C ⋆ D`. -/
-def downr {X Y : D} (f : (right X : C ⋆ D) ⟶ right Y) : X ⟶ Y := ULift.down f
-
-/-- Construct a morphism `left X ⟶ left Y` in `C ⋆ D` from a morphism `X ⟶ Y` in C. -/
-def upl {X Y : C} (f : X ⟶ Y) : (left X : C ⋆ D) ⟶ left Y := ULift.up f
-
-/-- Construct a morphism `right X ⟶ right Y` in `C ⋆ D` from a morphism `X ⟶ Y` in D. -/
-def upr {X Y : D} (f : X ⟶ Y) : (right X : C ⋆ D) ⟶ right Y := ULift.up f
+/-- Join.edge c d is the unique morphism from c to d. -/
+def edge (c : C) (d : D) : left c ⟶ right d := default
 
 @[simp]
-lemma downl_upl {X Y : C} (f : X ⟶ Y) : downl (upl f : (_ : C ⋆ D) ⟶ _) = f := rfl
+lemma eq_edge {c : C} {d : D} (f : left c ⟶ right d) : f = edge c d := rfl
 
-@[simp]
-lemma downr_upr {X Y : D} (f : X ⟶ Y) : downr (upr f : (_ : C ⋆ D) ⟶ _) = f := rfl
+end CategoryStructure
 
-@[simp]
-lemma upl_downl {X Y : C} (f : (left X : C ⋆ D) ⟶ left Y) : upl (downl f) = f := rfl
-
-@[simp]
-lemma upr_downr {X Y : D} (f : (right X : C ⋆ D) ⟶ right Y) : upr (downr f) = f := rfl
-
-@[simp]
-lemma downl_comp {X Y Z : C} (f : (left X : C ⋆ D) ⟶ left Y) (g : (left Y : C ⋆ D) ⟶ left Z) :
-    downl (f ≫ g) = downl f ≫ downl g :=
-  rfl
-
-@[simp]
-lemma downr_comp {X Y Z : D} (f : (right X : C ⋆ D) ⟶ right Y) (g : (right Y : C ⋆ D) ⟶ right Z) :
-    downr (f ≫ g) = downr f ≫ downr g :=
-  rfl
-
-@[simp]
-lemma upl_comp {X Y Z : C} (f : X ⟶ Y) (g : Y ⟶ Z) :
-    (upl (f ≫ g) : (_ : C ⋆ D) ⟶ _) = upl f ≫ upl g :=
-  rfl
-
-@[simp]
-lemma upr_comp {X Y Z : D} (f : X ⟶ Y) (g : Y ⟶ Z) :
-    (upr (f ≫ g) : (_ : C ⋆ D) ⟶ _) = upr f ≫ upr g :=
-  rfl
-
-@[simp]
-lemma upl_id {X : C} : (upl (𝟙 X) : (_ : C ⋆ D) ⟶ _) = 𝟙 (left X) := rfl
-
-@[simp]
-lemma upr_id {X : D} : (upr (𝟙 X) : (_ : C ⋆ D) ⟶ _) = 𝟙 (right X) := rfl
-
-@[simp]
-lemma downl_id {X : C} : downl (𝟙 (left X : C ⋆ D)) = 𝟙 X := rfl
-
-@[simp]
-lemma downr_id {X : D} : downr (𝟙 (right X : C ⋆ D)) = 𝟙 X := rfl
-
-end Hom
+section Inclusions
 
 /-- The canonical inclusion from C to `C ⋆ D`. -/
-@[simps]
+@[simps! obj]
 def inclLeft : C ⥤ C ⋆ D where
   obj := left
-  map := Hom.upl
+  map := ULift.up
 
 /-- The canonical inclusion from D to `C ⋆ D`. -/
-@[simps]
+@[simps! obj]
 def inclRight : D ⥤ C ⋆ D where
   obj := right
-  map := Hom.upr
+  map := ULift.up
 
-instance : (inclLeft : C ⥤ C ⋆ D).Full where
-  map_surjective f := ⟨Hom.downl f, rfl⟩
+variable {C D}
 
-instance : (inclRight : D ⥤ C ⋆ D).Full where
-  map_surjective f := ⟨Hom.downr f, rfl⟩
+/-- An induction principle for morphisms in a join of category: a morphism is either of the form
+`(inclLeft _ _).map _`, `(inclRight _ _).map _)`, or is `edge _ _`. -/
+@[elab_as_elim, cases_eliminator, induction_eliminator]
+def homInduction {P : {x y : C ⋆ D} → (x ⟶ y) → Sort*}
+    (left : ∀ x y : C, (f : x ⟶ y) → P ((inclLeft C D).map f))
+    (right : ∀ x y : D, (f : x ⟶ y) → P ((inclRight C D).map f))
+    (edge : ∀ (c : C) (d : D), P (edge c d))
+    {x y : C ⋆ D} (f : x ⟶ y) : P f :=
+  match x, y, f with
+  | .left x, .left y, f => left x y f.down
+  | .right x, .right y, f => right x y f.down
+  | .left x, .right y, _ => edge x y
 
-instance : (inclLeft : C ⥤ C ⋆ D).Faithful where
-  map_injective {_ _} _ _ h := congrArg (fun k ↦ Hom.downl k) h
+@[simp]
+lemma homInduction_left {P : {x y : C ⋆ D} → (x ⟶ y) → Sort*}
+    (left : ∀ x y : C, (f : x ⟶ y) → P ((inclLeft C D).map f))
+    (right : ∀ x y : D, (f : x ⟶ y) → P ((inclRight C D).map f))
+    (edge : ∀ (c : C) (d : D), P (edge c d))
+    {x y : C} (f : x ⟶ y) : homInduction left right edge ((inclLeft C D).map f) = left x y f :=
+  rfl
 
-instance : (inclRight : D ⥤ C ⋆ D).Faithful where
-  map_injective {_ _} _ _ h := congrArg (fun k ↦ Hom.downr k) h
+@[simp]
+lemma homInduction_right {P : {x y : C ⋆ D} → (x ⟶ y) → Sort*}
+    (left : ∀ x y : C, (f : x ⟶ y) → P ((inclLeft C D).map f))
+    (right : ∀ x y : D, (f : x ⟶ y) → P ((inclRight C D).map f))
+    (edge : ∀ (c : C) (d : D), P (edge c d))
+    {x y : D} (f : x ⟶ y) : homInduction left right edge ((inclRight C D).map f) = right x y f :=
+  rfl
+
+@[simp]
+lemma homInduction_edge {P : {x y : C ⋆ D} → (x ⟶ y) → Sort*}
+    (left : ∀ x y : C, (f : x ⟶ y) → P ((inclLeft C D).map f))
+    (right : ∀ x y : D, (f : x ⟶ y) → P ((inclRight C D).map f))
+    (edge : ∀ (c : C) (d : D), P (edge c d))
+    {c : C} {d : D} : homInduction left right edge (Join.edge c d) = edge c d :=
+  rfl
+
+variable (C D)
+
+instance inclLeftFull: (inclLeft C D).Full where
+  map_surjective f := by
+    cases f
+    use (by assumption)
+
+instance inclRightFull: (inclRight C D).Full where
+  map_surjective f := by
+    cases f
+    use (by assumption)
+
+instance inclLeftFaithFull: (inclLeft C D).Faithful where
+  map_injective {_ _} _ _ h := by injection h
+
+instance inclRightFaithfull: (inclRight C D).Faithful where
+  map_injective {_ _} _ _ h := by injection h
+
+variable {C} in
+/-- A situational lemma to help putting identities in the form `(inclLeft _ _).map _` when using
+`homInduction`. -/
+lemma id_left (c : C) : 𝟙 (left c) = (inclLeft C D).map (𝟙 c) := rfl
+
+variable {D} in
+/-- A situational lemma to help putting identities in the form `(inclRight _ _).map _` when using
+`homInduction`. -/
+lemma id_right (d : D) : 𝟙 (right d) = (inclRight C D).map (𝟙 d) := rfl
+
+/-- The "canonical" natural transformation from `(Prod.fst C D) ⋙ inclLeft C D` to
+`(Prod.snd C D) ⋙ inclRight C D`. This is bundling together all the edge morphisms
+into the data of a natural transformation. -/
+@[simps]
+def edgeTransform :
+    (Prod.fst C D) ⋙ inclLeft C D ⟶ (Prod.snd C D) ⋙ inclRight C D where
+  app := fun (c, d) ↦ edge c d
+
+end Inclusions
 
 section Functoriality
 
-variable {E : Type u₃} [Category.{v₃} E] (Fₗ : C ⥤ E)
-  {E' : Type u₄} [Category.{v₄} E'] (Fᵣ : D ⥤ E')
+variable {C D} {E : Type u₃} [Category.{v₃} E] {E' : Type u₄} [Category.{v₄} E']
 
-/-- A functor (C ⥤ E) induces a functor (C ⋆ D ⥤ E ⋆ D). -/
-@[simps!]
-def mapLeft : (C ⋆ D) ⥤ (E ⋆ D) where
+/-- A pair of functor `F : C ⥤ E, G : D ⥤ E` as well as a natural transformation
+`α : (Prod.fst C D) ⋙ F ⟶ (Prod.snd C D) ⋙ G`. defines a functor out of `C ⋆ D`.
+This is the main entry point to define functors out of a join of categories. -/
+def mkFunctor (F : C ⥤ E) (G : D ⥤ E) (α : (Prod.fst C D) ⋙ F ⟶ (Prod.snd C D) ⋙ G) :
+    C ⋆ D ⥤ E where
   obj X :=
     match X with
-    | .left x => left (Fₗ.obj x)
-    | .right x => right x
-  map {X Y} f :=
-    match X, Y, f with
-    | .left x, .left y, f => Hom.upl <| Fₗ.map <| Hom.downl f
-    | .right x, .right y, f => Hom.upr <| Hom.downr f
-    | .left _, .right _, _ => PUnit.unit
+    | .left x => (F.obj x)
+    | .right x => (G.obj x)
+  map f :=
+    homInduction
+      (left := fun _ _ f ↦ F.map f)
+      (right := fun _ _ g ↦ G.map g)
+      (edge := fun c d ↦ α.app (c,d))
+      f
+  map_id x := by
+    cases x
+    · dsimp only [id_left, homInduction_left]
+      simp
+    · dsimp only [id_right, homInduction_right]
+      simp
+  map_comp {x y z} f g := by
+    cases f <;> cases g
+    · simp [← Functor.map_comp]
+    · rename_i f d
+      simpa using (α.naturality <| (Prod.sectL _ d).map f).symm
+    · simp [← Functor.map_comp]
+    · rename_i c c' d f
+      simpa using α.naturality <| (Prod.sectR c _).map f
 
-/-- A functor (D ⥤ E') induces a functor (C ⋆ D ⥤ C ⋆ E'). -/
-@[simps!]
-def mapRight : (C ⋆ D) ⥤ (C ⋆ E') where
-  obj X :=
-    match X with
-    | .left x => left x
-    | .right x => right (Fᵣ.obj x)
-  map {X Y} f :=
-    match X, Y, f with
-    | .left x, .left y, f => Hom.upl <| Hom.downl f
-    | .right x, .right y, f => Hom.upr <| Fᵣ.map <| Hom.downr f
-    | .left _, .right _, _ => PUnit.unit
+section
+
+variable (F : C ⥤ E) (G : D ⥤ E) (α : (Prod.fst C D) ⋙ F ⟶ (Prod.snd C D) ⋙ G)
+
+/-- Precomposing `mkFunctor F G α` with the left inclusion gives back `F`. -/
+def mkFunctorLeft : inclLeft C D ⋙ (mkFunctor F G α) ≅ F := Iso.refl _
+
+@[simp]
+lemma mkFunctor_map_inclLeft {c c' : C} (f : c ⟶ c') :
+    (mkFunctor F G α).map ((inclLeft C D).map f) = F.map f :=
+  rfl
+
+/-- Precomposing `mkFunctor F G α` with the right inclusion gives back `G`. -/
+def mkFunctorRight : inclRight C D ⋙ (mkFunctor F G α) ≅ G := Iso.refl _
+
+@[simp]
+lemma mkFunctor_map_inclRight {d d' : D} (f : d ⟶ d') :
+    (mkFunctor F G α).map ((inclRight C D).map f) = G.map f :=
+  rfl
+
+/-- Whiskering `mkFunctor F G α` with the universal transformation gives back `α`. -/
+@[simp]
+lemma mkFunctor_edgeTransform :
+    whiskerRight (edgeTransform C D) (mkFunctor F G α) = α := by
+  ext x
+  simp [mkFunctor]
+
+@[simp]
+lemma mkFunctor_map_edge (c : C) (d : D) :
+    (mkFunctor F G α).map (edge c d) = α.app (c, d) :=
+  rfl
+
+end
+/-- Two functors out of a join of category are naturally isomorphic if their
+compositions with the inclusions are isomorphic and the whiskering with the canonical
+transformation is respected through these isomorphisms. -/
+def functorIsoExt {F : C ⋆ D ⥤ E} {G : C ⋆ D ⥤ E}
+    (eₗ : inclLeft C D ⋙ F ≅ inclLeft C D ⋙ G)
+    (eᵣ : inclRight C D ⋙ F ≅ inclRight C D ⋙ G)
+    (h : (isoWhiskerLeft (Prod.fst C D) eₗ).hom ≫ whiskerRight (edgeTransform C D) G =
+      whiskerRight (edgeTransform C D) F ≫ (isoWhiskerLeft (Prod.snd C D) eᵣ).hom :=
+      by aesop_cat) :
+    F ≅ G :=
+  NatIso.ofComponents
+    (fun x ↦ match x with
+      | left x => eₗ.app x
+      | right x => eᵣ.app x)
+    (fun f ↦ by
+      cases f with
+      | @left x y f => simpa using eₗ.hom.naturality f
+      | @right x y f => simpa using eᵣ.hom.naturality f
+      | edge c d => simpa using (congrArg (fun α ↦ α.app (c,d)) h).symm)
+
+/-- A version of `functorIsoExt` in which the hypothesis on the universal transform is supplied
+extensionnaly, rather than as an equality of natural transformations. -/
+def functorIsoExt' {F : C ⋆ D ⥤ E} {G : C ⋆ D ⥤ E}
+    (eₗ : inclLeft C D ⋙ F ≅ inclLeft C D ⋙ G)
+    (eᵣ : inclRight C D ⋙ F ≅ inclRight C D ⋙ G)
+    (h : ∀ (c : C) (d : D), eₗ.hom.app c ≫ G.map (edge c d) = F.map (edge c d) ≫ eᵣ.hom.app d :=
+      by aesop_cat) :
+    F ≅ G := functorIsoExt eₗ eᵣ
 
 /-- A pair of functors ((C ⥤ E), (D ⥤ E')) induces a functor (C ⋆ D ⥤ E ⋆ E'). -/
-@[simps!]
-def mapPair : (C ⋆ D) ⥤ (E ⋆ E') where
-  obj X :=
-    match X with
-    | .left x => left (Fₗ.obj x)
-    | .right x => right (Fᵣ.obj x)
-  map {X Y} f :=
-    match X, Y, f with
-    | .left x, .left y, f => Hom.upl <| Fₗ.map <| Hom.downl f
-    | .right x, .right y, f => Hom.upr <| Fᵣ.map <| Hom.downr f
-    | .left _, .right _, _ => PUnit.unit
+def mapPair (Fₗ : C ⥤ E) (Fᵣ : D ⥤ E') : (C ⋆ D) ⥤ (E ⋆ E') :=
+  mkFunctor (Fₗ ⋙ inclLeft _ _) (Fᵣ ⋙ inclRight _ _) { app := fun _ ↦ edge _ _ }
 
-/-- We can decompose mapPair as first `mapLeft`, then `mapRight`. -/
+/-- Any functor out of a join is naturally isomorphic to a functor of the form `mkFunctor F G α`. -/
 @[simps!]
-def mapPairIsoMapLeftCompMapRight : mapPair Fₗ Fᵣ ≅ mapLeft Fₗ ⋙ mapRight Fᵣ :=
-  NatIso.ofComponents (fun X ↦ match X with
-    | left _ => Iso.refl _
-    | right _ => Iso.refl _)
+def isoMkFunctor (F : C ⋆ D ⥤ E) :
+    F ≅ mkFunctor (inclLeft C D ⋙ F) (inclRight C D ⋙ F) (whiskerRight (edgeTransform C D) F) :=
+  functorIsoExt (Iso.refl _) (Iso.refl _)
 
-/-- We can decompose `mapPair` as first mapRight, then `mapLeft`. -/
+section
+
+variable (Fₗ : C ⥤ E) (Fᵣ : D ⥤ E')
+
+/-- Characterizing `mapPair` on left morphisms. -/
 @[simps!]
-def mapPairIsoMapRightCompMapLeft : mapPair Fₗ Fᵣ ≅ mapRight Fᵣ ⋙ mapLeft Fₗ :=
-  NatIso.ofComponents (fun X ↦ match X with
-    | left _ => Iso.refl _
-    | right _ => Iso.refl _)
+def mapPairLeft : inclLeft _ _ ⋙ (mapPair Fₗ Fᵣ) ≅ (Fₗ ⋙ inclLeft _ _) := mkFunctorLeft _ _ _
 
-/-- `mapLeft` respects the identity functors. -/
+/-- Characterizing `mapPair` on right morphisms. -/
 @[simps!]
-def mapLeftId : mapLeft (𝟭 C) ≅ 𝟭 (C ⋆ D) :=
-  NatIso.ofComponents (fun X ↦ match X with
-    | left _ => Iso.refl _
-    | right _ => Iso.refl _)
+def mapPairRight : inclRight _ _ ⋙ (mapPair Fₗ Fᵣ) ≅ (Fᵣ ⋙ inclRight _ _) := mkFunctorRight _ _ _
 
-/-- `mapRight` respects the identity functors. -/
-@[simps!]
-def mapRightId : mapRight (𝟭 D) ≅ 𝟭 (C ⋆ D) :=
-  NatIso.ofComponents (fun X ↦ match X with
-    | left _ => Iso.refl _
-    | right _ => Iso.refl _)
-
-/-- `mapPair F (𝟭 D)` is naturally isomorphic to `mapLeft F`. -/
-@[simps!]
-def mapPairIdRight : mapPair Fₗ (𝟭 D) ≅ mapLeft Fₗ :=
-  NatIso.ofComponents (fun X ↦ match X with
-    | left _ => Iso.refl _
-    | right _ => Iso.refl _)
-
-/-- `mapPair (𝟭 C) F` is naturally isomorphic to `mapLeft R`. -/
-@[simps!]
-def mapPairIdLeft : mapPair (𝟭 C) Fᵣ ≅ mapRight Fᵣ :=
-  NatIso.ofComponents (fun X ↦ match X with
-    | left _ => Iso.refl _
-    | right _ => Iso.refl _)
-
-/-- `mapPair` respects identities. -/
-@[simps!]
-def mapPairId : mapPair (𝟭 C) (𝟭 D) ≅ 𝟭 (C ⋆ D) :=
-  NatIso.ofComponents (fun X ↦ match X with
-    | left _ => Iso.refl _
-    | right _ => Iso.refl _)
-
-/-- Coherence of the previous isomorphims. -/
+/-- Characterizing the action of map_pair on edges. -/
 @[simp]
-lemma mapPairId_coherence_left :
-    (mapPairId : mapPair (𝟭 C) (𝟭 D) ≅ 𝟭 (C ⋆ D)) = mapPairIdLeft (𝟭 D) ≪≫ mapLeftId := by
-  aesop_cat
+def mapPairEdge (c : C) (d : D):
+    (mapPair Fₗ Fᵣ).map (edge c d) = edge (Fₗ.obj c) (Fᵣ.obj d) :=
+  rfl
 
-/-- Coherence of the previous isomorphims. -/
-@[simp]
-lemma mapPairId_coherence_right :
-    (mapPairId : mapPair (𝟭 C) (𝟭 D) ≅ 𝟭 (C ⋆ D)) = mapPairIdRight (𝟭 C) ≪≫ mapRightId := by
-  aesop_cat
+end
 
-@[simp]
-lemma mapPairIsoMapLeftCompMapRight_coherence_id :
-    mapPairIsoMapLeftCompMapRight (𝟭 C) (𝟭 D) ≪≫
-      (isoWhiskerLeft (mapLeft _) mapRightId) ≪≫ (isoWhiskerRight mapLeftId _) ≪≫
-      (Functor.leftUnitor _) =
-    (mapPairId : mapPair (𝟭 C) (𝟭 D) ≅ 𝟭 (C ⋆ D)) := by
-  aesop_cat
-
-@[simp]
-lemma mapPairIsoMapRightCompMapLeft_coherence_id :
-    mapPairIsoMapRightCompMapLeft (𝟭 C) (𝟭 D) ≪≫
-      (isoWhiskerLeft (mapRight _) mapLeftId) ≪≫ (isoWhiskerRight mapLeftId _) ≪≫
-      (Functor.leftUnitor _) =
-    (mapPairId : mapPair (𝟭 C) (𝟭 D) ≅ 𝟭 (C ⋆ D)) := by
-  aesop_cat
-
-variable {J : Type u₅} [Category.{v₅} J] (Gₗ : E ⥤ J)
-  {J' : Type u₆} [Category.{v₆} J'] (Gᵣ : E' ⥤ J')
-
-/-- `mapLeft` respects functor composition. -/
+/-- `mapPair` respects identities -/
 @[simps!]
-def mapLeftComp : (mapLeft (Fₗ ⋙ Gₗ) : C ⋆ D ⥤ J ⋆ D) ≅ mapLeft Fₗ ⋙ mapLeft Gₗ :=
-  NatIso.ofComponents (fun X ↦ match X with
-    | left _ => Iso.refl _
-    | right _ => Iso.refl _)
+def mapPairId : mapPair (𝟭 C) (𝟭 D) ≅ 𝟭 (C ⋆ D) := functorIsoExt (Iso.refl _) (Iso.refl _)
 
-/-- `mapRight` respects functor composition. -/
-@[simps!]
-def mapRightComp : (mapRight (Fᵣ ⋙ Gᵣ) : C ⋆ D ⥤ C ⋆ J') ≅ mapRight Fᵣ ⋙ mapRight Gᵣ :=
-  NatIso.ofComponents (fun X ↦ match X with
-    | left _ => Iso.refl _
-    | right _ => Iso.refl _)
+variable {J : Type u₅} [Category.{v₅} J]
+  {K : Type u₆} [Category.{v₆} K]
 
-/-- `mapRight` respects functor composition. -/
+/-- `mapPair` respects composition -/
 @[simps!]
-def mapPairComp : (mapPair (Fₗ ⋙ Gₗ) (Fᵣ ⋙ Gᵣ) : C ⋆ D ⥤ J ⋆ J') ≅ mapPair Fₗ Fᵣ ⋙ mapPair Gₗ Gᵣ :=
-  NatIso.ofComponents (fun X ↦ match X with
-    | left _ => Iso.refl _
-    | right _ => Iso.refl _)
-
-@[simps!]
-def mapPairComp_coherence_left :
-    mapPairComp Fₗ Fᵣ Gₗ Gᵣ = mapPairIsoMapLeftCompMapRight (Fₗ ≫ Gₗ) (Fᵣ ≫ Gᵣ) ≪≫ 
-      (isoWhiskerLeft (mapRight _) (mapLeftComp _ _)) ≪≫ (isoWhiskerRight mapLeftId _) := by
-  NatIso.ofComponents (fun X ↦ match X with
-    | left _ => Iso.refl _
-    | right _ => Iso.refl _)
+def mapPairComp (Fₗ : C ⥤ E) (Fᵣ : D ⥤ E') (Gₗ : E ⥤ J) (Gᵣ : E' ⥤ K) :
+    mapPair (Fₗ ⋙ Gₗ) (Fᵣ ⋙ Gᵣ) ≅ mapPair Fₗ Fᵣ ⋙ mapPair Gₗ Gᵣ :=
+  functorIsoExt (Iso.refl _) (Iso.refl _)
 
 end Functoriality
 
-end Join
+section NaturalTransforms
 
+variable {E : Type u₃} [Category.{v₃} E]
+  {E' : Type u₄} [Category.{v₄} E']
+
+variable {C D}
+
+/-- Construct a natural transformation between functors from a join from
+the data of natural transformations between each side that are compatible with the
+action on edge maps. -/
+@[simps!]
+def mkNatTrans (F : C ⋆ D ⥤ E) (F' : C ⋆ D ⥤ E)
+    (αₗ : inclLeft C D ⋙ F ⟶ inclLeft C D ⋙ F') (αᵣ : inclRight C D ⋙ F ⟶ inclRight C D ⋙ F')
+    (h : whiskerRight (edgeTransform C D) F ≫ whiskerLeft (Prod.snd C D) αᵣ =
+      whiskerLeft (Prod.fst C D) αₗ ≫ whiskerRight (edgeTransform C D) F' :=
+      by aesop_cat) :
+    F ⟶ F' where
+  app x := match x with
+    | left x => αₗ.app x
+    | right x => αᵣ.app x
+  naturality {x y} f := by
+    cases f with
+    | @left x y f => simpa using αₗ.naturality f
+    | @right x y f => simpa using αᵣ.naturality f
+    | @edge c d => exact funext_iff.mp (NatTrans.ext_iff.mp h) (c, d)
+
+/-- A natural transformation `Fₗ ⟶ Gₗ` induces a natural transformation
+  `mapPair Fₗ H ⟶ mapPair Gₗ H` for every `H : D ⥤ E'`. -/
+@[simps!]
+def mapWhiskerRight {Fₗ : C ⥤ E} {Gₗ : C ⥤ E} (α : Fₗ ⟶ Gₗ) (H : D ⥤ E') :
+    mapPair Fₗ H ⟶ mapPair Gₗ H :=
+  mkNatTrans _ _
+    ((mapPairLeft Fₗ H).inv ≫ (whiskerRight α (inclLeft E E')) ≫ (mapPairLeft Gₗ H).hom)
+    (𝟙 _)
+
+/-- A natural transformation `Fᵣ ⟶ Gᵣ` induces a natural transformation
+  `mapPair H Fᵣ ⟶ mapPair H Gᵣ` for every `H : C ⥤ E`. -/
+@[simps!]
+def mapWhiskerLeft (H : C ⥤ E) {Fᵣ : D ⥤ E'} {Gᵣ : D ⥤ E'} (α : Fᵣ ⟶ Gᵣ) :
+    mapPair H Fᵣ ⟶ mapPair H Gᵣ :=
+  mkNatTrans _ _
+    (𝟙 _)
+    ((mapPairRight H Fᵣ).inv ≫ (whiskerRight α (inclRight E E')) ≫ (mapPairRight H Gᵣ).hom)
+
+/-- One can exchange `mapWhiskerLeft` and `mapWhiskerRight`. -/
+lemma mapWhisker_exchange (Fₗ : C ⥤ E) (Gₗ : C ⥤ E) (Fᵣ : D ⥤ E') (Gᵣ : D ⥤ E')
+    (αₗ : Fₗ ⟶ Gₗ) (αᵣ : Fᵣ ⟶ Gᵣ) :
+    mapWhiskerLeft Fₗ αᵣ ≫ mapWhiskerRight αₗ Gᵣ =
+      mapWhiskerRight αₗ Fᵣ ≫ mapWhiskerLeft Gₗ αᵣ := by
+  aesop_cat
+
+end NaturalTransforms
+
+end Join
 
 end CategoryTheory

--- a/Mathlib/CategoryTheory/Join/Basic.lean
+++ b/Mathlib/CategoryTheory/Join/Basic.lean
@@ -5,10 +5,7 @@ Authors: Robin Carlier
 -/
 
 import Mathlib.CategoryTheory.Functor.Category
-import Mathlib.CategoryTheory.Functor.FullyFaithful
-import Mathlib.CategoryTheory.Comma.Basic
-import Mathlib.CategoryTheory.Whiskering
-import Mathlib.CategoryTheory.Bicategory.Functor.Pseudofunctor
+import Mathlib.CategoryTheory.Products.Basic
 
 /-!
 # Joins of category
@@ -30,8 +27,6 @@ to constructs maps in `C ⋆ D` between object coming from `D`.
 - `Join.mkNatIso`, A constructor for natural isomorphisms between functors out of a join
   of categories.
 
-# TODOs
-- Cofinality of the right inclusion, finality of the left inclusion.
 -/
 
 universe v₁ v₂ v₃ v₄ v₅ v₆ u₁ u₂ u₃ u₄ u₅ u₆
@@ -166,17 +161,23 @@ lemma homInduction_edge {P : {x y : C ⋆ D} → (x ⟶ y) → Sort*}
 
 variable (C D)
 
-instance inclLeftFull: (inclLeft C D).Full where
-  map_surjective f := by aesop_cat
+/-- The left inclusion is fully faithful. This definition is the intended way to
+deconstruct a morphism `left x ⟶ left y` in `C ⋆ D` to a morphism in `C` if needed. -/
+def inclLeftFullyFaithful: (inclLeft C D).FullyFaithful where
+  preimage f := f.down
 
-instance inclRightFull: (inclRight C D).Full where
-  map_surjective f := by aesop_cat
+/-- The right inclusion is fully faithful. This definition is the intended way to
+deconstruct a morphism `right x ⟶ right y` in `C ⋆ D` to a morphism in `D` if needed. -/
+def inclRightFullyFaithful: (inclRight C D).FullyFaithful where
+  preimage f := f.down
 
-instance inclLeftFaithFull: (inclLeft C D).Faithful where
-  map_injective {_ _} _ _ h := by injection h
+instance inclLeftFull: (inclLeft C D).Full := inclLeftFullyFaithful C D |>.full
 
-instance inclRightFaithfull: (inclRight C D).Faithful where
-  map_injective {_ _} _ _ h := by injection h
+instance inclRightFull: (inclRight C D).Full := inclRightFullyFaithful C D |>.full
+
+instance inclLeftFaithFull: (inclLeft C D).Faithful := inclLeftFullyFaithful C D |>.faithful
+
+instance inclRightFaithfull: (inclRight C D).Faithful := inclRightFullyFaithful C D |>.faithful
 
 variable {C} in
 /-- A situational lemma to help putting identities in the form `(inclLeft _ _).map _` when using
@@ -395,6 +396,7 @@ def mapPairLeft : inclLeft _ _ ⋙ (mapPair Fₗ Fᵣ) ≅ (Fₗ ⋙ inclLeft _ 
 def mapPairRight : inclRight _ _ ⋙ (mapPair Fₗ Fᵣ) ≅ (Fᵣ ⋙ inclRight _ _) := mkFunctorRight _ _ _
 
 end mapPair
+
 /-- Any functor out of a join is naturally isomorphic to a functor of the form `mkFunctor F G α`. -/
 @[simps!]
 def isoMkFunctor (F : C ⋆ D ⥤ E) :
@@ -506,7 +508,7 @@ lemma mapWhisker_exchange (Fₗ : C ⥤ E) (Gₗ : C ⥤ E) (Fᵣ : D ⥤ E') (G
 
 /-- A natural isomorphism `Fᵣ ≅ Gᵣ` induces a natural isomorphism
   `mapPair H Fᵣ ≅ mapPair H Gᵣ` for every `H : C ⥤ E`. -/
-@[simps!?]
+@[simps!]
 def mapIsoWhiskerLeft (H : C ⥤ E) {Fᵣ : D ⥤ E'} {Gᵣ : D ⥤ E'} (α : Fᵣ ≅ Gᵣ) :
     mapPair H Fᵣ ≅ mapPair H Gᵣ :=
   mkNatIso

--- a/Mathlib/CategoryTheory/Join/Basic.lean
+++ b/Mathlib/CategoryTheory/Join/Basic.lean
@@ -3,7 +3,6 @@ Copyright (c) 2025 Robin Carlier. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robin Carlier
 -/
-
 import Mathlib.CategoryTheory.Functor.Category
 import Mathlib.CategoryTheory.Products.Basic
 
@@ -16,16 +15,21 @@ morphisms between object of `D` are morphisms in `D`, and finally, given `c : C`
 there is a unique morphism `c ⟶ d` in `C ⋆ D`.
 
 ## Main constructions
-- `Join.edge c d`: the unique map from `c` to `d`.
-- `Join.inclLeft : C ⥤ C ⋆ D`, the left inclusion. Its action on morphism is the main entry point
+
+* `Join.edge c d`: the unique map from `c` to `d`.
+* `Join.inclLeft : C ⥤ C ⋆ D`, the left inclusion. Its action on morphism is the main entry point
 to constructs maps in `C ⋆ D` between objects coming from `C`.
-- `Join.inclRight : D ⥤ C ⋆ D`, the left inclusion. Its action on morphism is the main entry point
+* `Join.inclRight : D ⥤ C ⋆ D`, the left inclusion. Its action on morphism is the main entry point
 to constructs maps in `C ⋆ D` between object coming from `D`.
-- `Join.mkFunctor`, A constructor for functors out of a join of categories.
-- `Join.mkNatTrans`, A constructor for natural transformations between functors out of a join
+* `Join.mkFunctor`, A constructor for functors out of a join of categories.
+* `Join.mkNatTrans`, A constructor for natural transformations between functors out of a join
   of categories.
-- `Join.mkNatIso`, A constructor for natural isomorphisms between functors out of a join
+* `Join.mkNatIso`, A constructor for natural isomorphisms between functors out of a join
   of categories.
+
+## References
+
+* [Kerodon: section 1.4.3.2](https://kerodon.net/tag/0160)
 
 -/
 
@@ -40,7 +44,7 @@ inductive Join (C : Type u₁) [Category.{v₁} C] (D : Type u₂) [Category.{v�
   | left : C → Join C D
   | right : D → Join C D
 
-attribute [local aesop safe cases (rule_sets := [CategoryTheory])] Join
+attribute [aesop safe cases (rule_sets := [CategoryTheory])] Join
 
 @[inherit_doc] infixr:30 " ⋆ " => Join
 
@@ -54,7 +58,6 @@ variable {C D}
 
 /-- Morphisms in `C ⋆ D` are those of `C` and `D`, plus an unique
 morphism `(left c ⟶ right d)` for every `c : C` and `d : D`. -/
-@[aesop norm unfold (rule_sets := [CategoryTheory])]
 def Hom : C ⋆ D → C ⋆ D → Type (max v₁ v₂)
   | .left x, .left y => ULift (x ⟶ y)
   | .right x, .right y => ULift (x ⟶ y)

--- a/Mathlib/CategoryTheory/Join/Basic.lean
+++ b/Mathlib/CategoryTheory/Join/Basic.lean
@@ -101,9 +101,6 @@ instance {X : C} {Y : D} : Unique (left X ⟶ right Y) := inferInstanceAs (Uniqu
 /-- Join.edge c d is the unique morphism from c to d. -/
 def edge (c : C) (d : D) : left c ⟶ right d := default
 
-@[simp]
-lemma eq_edge {c : C} {d : D} (f : left c ⟶ right d) : f = edge c d := rfl
-
 end CategoryStructure
 
 section Inclusions
@@ -333,7 +330,6 @@ lemma eq_mkNatTrans {F F' : C ⋆ D ⥤ E} (α : F ⟶ F') :
 section
 
 /-- `mkNatTrans` respects vertical composition. -/
-@[simp]
 lemma mkNatTransComp
     {F F' F'' : C ⋆ D ⥤ E}
     (αₗ : inclLeft C D ⋙ F ⟶ inclLeft C D ⋙ F')

--- a/Mathlib/CategoryTheory/Join/Basic.lean
+++ b/Mathlib/CategoryTheory/Join/Basic.lean
@@ -46,9 +46,9 @@ inductive Join (C : Type u₁) [Category.{v₁} C] (D : Type u₂) [Category.{v�
 
 attribute [aesop safe cases (rule_sets := [CategoryTheory])] Join
 
-@[inherit_doc] infixr:30 " ⋆ " => Join
-
 namespace Join
+
+@[inherit_doc] scoped infixr:30 " ⋆ " => Join
 
 variable (C : Type u₁) [Category.{v₁} C] (D : Type u₂) [Category.{v₂} D]
 

--- a/Mathlib/CategoryTheory/Join/Basic.lean
+++ b/Mathlib/CategoryTheory/Join/Basic.lean
@@ -125,7 +125,7 @@ def inclRight : D ⥤ C ⋆ D where
 variable {C D}
 
 /-- An induction principle for morphisms in a join of category: a morphism is either of the form
-`(inclLeft _ _).map _`, `(inclRight _ _).map _)`, or is `edge _ _`. -/
+`(inclLeft _ _).map _`, `(inclRight _ _).map _`, or is `edge _ _`. -/
 @[elab_as_elim, cases_eliminator, induction_eliminator]
 def homInduction {P : {x y : C ⋆ D} → (x ⟶ y) → Sort*}
     (left : ∀ x y : C, (f : x ⟶ y) → P ((inclLeft C D).map f))

--- a/Mathlib/CategoryTheory/Join/Basic.lean
+++ b/Mathlib/CategoryTheory/Join/Basic.lean
@@ -65,7 +65,7 @@ def Hom : C ⋆ D → C ⋆ D → Type (max v₁ v₂)
   | .right _, .left _ => PEmpty
 
 /-- Identity morphisms in `C ⋆ D` are inherited from those in `C` and `D`. -/
-def id : ∀ (X : C ⋆ D), Hom X X
+def id : ∀ X : C ⋆ D, Hom X X
   | .left x => ULift.up (𝟙 x)
   | .right x => ULift.up (𝟙 x)
 
@@ -206,12 +206,12 @@ variable {C D} {E : Type u₃} [Category.{v₃} E] {E' : Type u₄} [Category.{v
 /-- A pair of functor `F : C ⥤ E, G : D ⥤ E` as well as a natural transformation
 `α : (Prod.fst C D) ⋙ F ⟶ (Prod.snd C D) ⋙ G`. defines a functor out of `C ⋆ D`.
 This is the main entry point to define functors out of a join of categories. -/
-def mkFunctor (F : C ⥤ E) (G : D ⥤ E) (α : (Prod.fst C D) ⋙ F ⟶ (Prod.snd C D) ⋙ G) :
+def mkFunctor (F : C ⥤ E) (G : D ⥤ E) (α : Prod.fst C D ⋙ F ⟶ Prod.snd C D ⋙ G) :
     C ⋆ D ⥤ E where
   obj X :=
     match X with
-    | .left x => (F.obj x)
-    | .right x => (G.obj x)
+    | .left x => F.obj x
+    | .right x => G.obj x
   map f :=
     homInduction
       (left := fun _ _ f ↦ F.map f)
@@ -233,7 +233,7 @@ def mkFunctor (F : C ⥤ E) (G : D ⥤ E) (α : (Prod.fst C D) ⋙ F ⟶ (Prod.s
 
 section
 
-variable (F : C ⥤ E) (G : D ⥤ E) (α : (Prod.fst C D) ⋙ F ⟶ (Prod.snd C D) ⋙ G)
+variable (F : C ⥤ E) (G : D ⥤ E) (α : Prod.fst C D ⋙ F ⟶ Prod.snd C D ⋙ G)
 
 -- As these equality of objects are definitional, they should be fine.
 @[simp]
@@ -249,11 +249,11 @@ lemma mkFunctor_map_inclLeft {c c' : C} (f : c ⟶ c') :
 
 /-- Precomposing `mkFunctor F G α` with the left inclusion gives back `F`. -/
 @[simps!]
-def mkFunctorLeft : inclLeft C D ⋙ (mkFunctor F G α) ≅ F := Iso.refl _
+def mkFunctorLeft : inclLeft C D ⋙ mkFunctor F G α ≅ F := Iso.refl _
 
 /-- Precomposing `mkFunctor F G α` with the right inclusion gives back `G`. -/
 @[simps!]
-def mkFunctorRight : inclRight C D ⋙ (mkFunctor F G α) ≅ G := Iso.refl _
+def mkFunctorRight : inclRight C D ⋙ mkFunctor F G α ≅ G := Iso.refl _
 
 @[simp]
 lemma mkFunctor_map_inclRight {d d' : D} (f : d ⟶ d') :
@@ -365,7 +365,7 @@ def mkNatIso {F : C ⋆ D ⥤ E} {G : C ⋆ D ⥤ E}
     Iso.inv_comp_eq, ← Category.assoc, Eq.comm, Iso.comp_inv_eq, h])
 
 /-- A pair of functors ((C ⥤ E), (D ⥤ E')) induces a functor (C ⋆ D ⥤ E ⋆ E'). -/
-def mapPair (Fₗ : C ⥤ E) (Fᵣ : D ⥤ E') : (C ⋆ D) ⥤ (E ⋆ E') :=
+def mapPair (Fₗ : C ⥤ E) (Fᵣ : D ⥤ E') : C ⋆ D ⥤ E ⋆ E' :=
   mkFunctor (Fₗ ⋙ inclLeft _ _) (Fᵣ ⋙ inclRight _ _) { app := fun _ ↦ edge _ _ }
 
 section mapPair
@@ -388,11 +388,11 @@ lemma mapPair_map_inclRight {d d' : D} (f : d ⟶ d') :
 
 /-- Characterizing `mapPair` on left morphisms. -/
 @[simps! hom_app inv_app]
-def mapPairLeft : inclLeft _ _ ⋙ (mapPair Fₗ Fᵣ) ≅ (Fₗ ⋙ inclLeft _ _) := mkFunctorLeft _ _ _
+def mapPairLeft : inclLeft _ _ ⋙ mapPair Fₗ Fᵣ ≅ Fₗ ⋙ inclLeft _ _ := mkFunctorLeft _ _ _
 
 /-- Characterizing `mapPair` on right morphisms. -/
 @[simps! hom_app inv_app]
-def mapPairRight : inclRight _ _ ⋙ (mapPair Fₗ Fᵣ) ≅ (Fᵣ ⋙ inclRight _ _) := mkFunctorRight _ _ _
+def mapPairRight : inclRight _ _ ⋙ mapPair Fₗ Fᵣ ≅ Fᵣ ⋙ inclRight _ _ := mkFunctorRight _ _ _
 
 end mapPair
 
@@ -511,7 +511,7 @@ lemma mapWhisker_exchange (Fₗ : C ⥤ E) (Gₗ : C ⥤ E) (Fᵣ : D ⥤ E') (G
 def mapIsoWhiskerLeft (H : C ⥤ E) {Fᵣ : D ⥤ E'} {Gᵣ : D ⥤ E'} (α : Fᵣ ≅ Gᵣ) :
     mapPair H Fᵣ ≅ mapPair H Gᵣ :=
   mkNatIso
-    ((mapPairLeft H Fᵣ) ≪≫ isoWhiskerRight (Iso.refl H) (inclLeft _ _) ≪≫ (mapPairLeft H Gᵣ).symm)
+    (mapPairLeft H Fᵣ ≪≫ isoWhiskerRight (Iso.refl H) (inclLeft _ _) ≪≫ (mapPairLeft H Gᵣ).symm)
     (mapPairRight H Fᵣ ≪≫ isoWhiskerRight α (inclRight E E') ≪≫ (mapPairRight H Gᵣ).symm)
 
 /-- A natural isomorphism `Fᵣ ≅ Gᵣ` induces a natural isomorphism

--- a/Mathlib/CategoryTheory/Join/Basic.lean
+++ b/Mathlib/CategoryTheory/Join/Basic.lean
@@ -71,14 +71,10 @@ def id : ∀ (X : C ⋆ D), Hom X X
 
 /-- Composition in `C ⋆ D` is inherited from the compositions in `C` and `D`. -/
 def comp : ∀ {x y z : C ⋆ D}, Hom x y → Hom y z → Hom x z
-  | .left _x, .left _y, .left _z => fun f g ↦ ULift.up (ULift.down f ≫ ULift.down g)
-  | .left _x, .left _y, .right _z => fun _ _ ↦ PUnit.unit
-  | .left _x, .right _y, .left _z => fun _ g ↦ PEmpty.elim g
-  | .left _x, .right _y, .right _z => fun _ _ ↦ PUnit.unit
-  | .right _x, .left _y, .left _z => fun f _ ↦ PEmpty.elim f
-  | .right _x, .left _y, .right _z => fun f _ ↦ PEmpty.elim f
-  | .right _x, .right _y, .left _z => fun _ g ↦ PEmpty.elim g
-  | .right _x, .right _y, .right _z => fun f g ↦ ULift.up (ULift.down f ≫ ULift.down g)
+  | .left _x, .left _y, .left _z, f, g => ULift.up (ULift.down f ≫ ULift.down g)
+  | .left _x, .left _y, .right _z, _, _ => PUnit.unit
+  | .left _x, .right _y, .right _z, _, _ =>  PUnit.unit
+  | .right _x, .right _y, .right _z, f, g => ULift.up (ULift.down f ≫ ULift.down g)
 
 instance : Category.{max v₁ v₂} (C ⋆ D) where
   Hom X Y := Hom X Y
@@ -108,13 +104,19 @@ end CategoryStructure
 
 section Inclusions
 
-/-- The canonical inclusion from C to `C ⋆ D`. -/
+/-- The canonical inclusion from C to `C ⋆ D`.
+Terms of the form `(inclLeft C D).map f`should be treated as primitive when working with joins
+and one should avoid trying to reduce them. For this reason, there is no `inclLeft_map` simp
+lemma. -/
 @[simps! obj]
 def inclLeft : C ⥤ C ⋆ D where
   obj := left
   map := ULift.up
 
-/-- The canonical inclusion from D to `C ⋆ D`. -/
+/-- The canonical inclusion from D to `C ⋆ D`.
+Terms of the form `(inclRight C D).map f`should be treated as primitive when working with joins
+and one should avoid trying to reduce them. For this reason, there is no `inclRight_map` simp
+lemma. -/
 @[simps! obj]
 def inclRight : D ⥤ C ⋆ D where
   obj := right

--- a/Mathlib/CategoryTheory/Join/Basic.lean
+++ b/Mathlib/CategoryTheory/Join/Basic.lean
@@ -194,7 +194,7 @@ lemma id_right (d : D) : 𝟙 (right d) = (inclRight C D).map (𝟙 d) := rfl
 into the data of a natural transformation. -/
 @[simps!]
 def edgeTransform :
-    (Prod.fst C D) ⋙ inclLeft C D ⟶ (Prod.snd C D) ⋙ inclRight C D where
+    Prod.fst C D ⋙ inclLeft C D ⟶ Prod.snd C D ⋙ inclRight C D where
   app := fun (c, d) ↦ edge c d
 
 end Inclusions

--- a/Mathlib/CategoryTheory/Join/Basic.lean
+++ b/Mathlib/CategoryTheory/Join/Basic.lean
@@ -364,7 +364,7 @@ def mkNatIso {F : C ⋆ D ⥤ E} {G : C ⋆ D ⥤ E}
   inv := mkNatTrans eₗ.inv eᵣ.inv (by rw [Eq.comm, ← isoWhiskerLeft_inv, ← isoWhiskerLeft_inv,
     Iso.inv_comp_eq, ← Category.assoc, Eq.comm, Iso.comp_inv_eq, h])
 
-/-- A pair of functors ((C ⥤ E), (D ⥤ E')) induces a functor (C ⋆ D ⥤ E ⋆ E'). -/
+/-- A pair of functors ((C ⥤ E), (D ⥤ E')) induces a functor `C ⋆ D ⥤ E ⋆ E'`. -/
 def mapPair (Fₗ : C ⥤ E) (Fᵣ : D ⥤ E') : C ⋆ D ⥤ E ⋆ E' :=
   mkFunctor (Fₗ ⋙ inclLeft _ _) (Fᵣ ⋙ inclRight _ _) { app := fun _ ↦ edge _ _ }
 

--- a/Mathlib/CategoryTheory/Join/Basic.lean
+++ b/Mathlib/CategoryTheory/Join/Basic.lean
@@ -18,7 +18,7 @@ there is a unique morphism `c ⟶ d` in `C ⋆ D`.
 
 * `Join.edge c d`: the unique map from `c` to `d`.
 * `Join.inclLeft : C ⥤ C ⋆ D`, the left inclusion. Its action on morphism is the main entry point
-to constructs maps in `C ⋆ D` between objects coming from `C`.
+  to constructs maps in `C ⋆ D` between objects coming from `C`.
 * `Join.inclRight : D ⥤ C ⋆ D`, the left inclusion. Its action on morphism is the main entry point
 to constructs maps in `C ⋆ D` between object coming from `D`.
 * `Join.mkFunctor`, A constructor for functors out of a join of categories.

--- a/Mathlib/CategoryTheory/Join/Basic.lean
+++ b/Mathlib/CategoryTheory/Join/Basic.lean
@@ -163,13 +163,11 @@ lemma homInduction_edge {P : {x y : C ⋆ D} → (x ⟶ y) → Sort*}
 
 variable (C D)
 
-/-- The left inclusion is fully faithful. This definition is the intended way to
-deconstruct a morphism `left x ⟶ left y` in `C ⋆ D` to a morphism in `C` if needed. -/
+/-- The left inclusion is fully faithful. -/
 def inclLeftFullyFaithful: (inclLeft C D).FullyFaithful where
   preimage f := f.down
 
-/-- The right inclusion is fully faithful. This definition is the intended way to
-deconstruct a morphism `right x ⟶ right y` in `C ⋆ D` to a morphism in `D` if needed. -/
+/-- The right inclusion is fully faithful. -/
 def inclRightFullyFaithful: (inclRight C D).FullyFaithful where
   preimage f := f.down
 

--- a/Mathlib/CategoryTheory/Join/Basic.lean
+++ b/Mathlib/CategoryTheory/Join/Basic.lean
@@ -18,9 +18,9 @@ there is a unique morphism `c ⟶ d` in `C ⋆ D`.
 
 * `Join.edge c d`: the unique map from `c` to `d`.
 * `Join.inclLeft : C ⥤ C ⋆ D`, the left inclusion. Its action on morphism is the main entry point
-  to constructs maps in `C ⋆ D` between objects coming from `C`.
+  to construct maps in `C ⋆ D` between objects coming from `C`.
 * `Join.inclRight : D ⥤ C ⋆ D`, the left inclusion. Its action on morphism is the main entry point
-to constructs maps in `C ⋆ D` between object coming from `D`.
+  to construct maps in `C ⋆ D` between object coming from `D`.
 * `Join.mkFunctor`, A constructor for functors out of a join of categories.
 * `Join.mkNatTrans`, A constructor for natural transformations between functors out of a join
   of categories.

--- a/Mathlib/CategoryTheory/Join/Basic.lean
+++ b/Mathlib/CategoryTheory/Join/Basic.lean
@@ -535,7 +535,7 @@ lemma mapIsoWhiskerLeft_hom (H : C ⥤ E) {Fᵣ : D ⥤ E'} {Gᵣ : D ⥤ E'} (�
     (mapIsoWhiskerLeft H α).hom = mapWhiskerLeft H α.hom := rfl
 
 lemma mapIsoWhiskerLeft_inv (H : C ⥤ E) {Fᵣ : D ⥤ E'} {Gᵣ : D ⥤ E'} (α : Fᵣ ≅ Gᵣ) :
-    (mapIsoWhiskerLeft H α).inv = mapWhiskerLeft H α.inv:= by
+    (mapIsoWhiskerLeft H α).inv = mapWhiskerLeft H α.inv := by
   ext x
   cases x <;> simp [mapIsoWhiskerLeft]
 


### PR DESCRIPTION
Define the join of two categories `C`, `D` as the category `C ⋆ D` characterized by the existence of fully faithful functors 
`Join.inclLeft C D : C ⥤ C ⋆ D` and `Join.inclRight C D: D ⥤ C ⋆ D` that are jointly surjective on objects, and such that there is a unique map `edge c d : (inclLeft C D).obj c ⟶ (inclRight C D).obj d` for every `c : C` and `d : D`.

We also provide constructors for functors out of joins, and natural transforms between such functors. The main reference is [Kerodon: section 1.4.3.2](https://kerodon.net/tag/0160).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

First of a small burst of PRs about joins of categories. Eventually, this construction should replace `WithInitial C` (which is `PUnit ⋆ C`) and `WithTerminal C` (which is `C ⋆ PUnit`).

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
