### PR TITLE
[Merged by Bors] - chore: use induction tactic with Set.Finite.induction_on

### DIFF
--- a/Mathlib/Data/Set/Card.lean
+++ b/Mathlib/Data/Set/Card.lean
@@ -121,10 +121,11 @@ theorem encard_insert_of_not_mem {a : α} (has : a ∉ s) : (insert a s).encard 
   rw [← union_singleton, encard_union_eq (by simpa), encard_singleton]
 
 theorem Finite.encard_lt_top (h : s.Finite) : s.encard < ⊤ := by
-  refine h.induction_on _ (by simp) ?_
-  rintro a t hat _ ht'
-  rw [encard_insert_of_not_mem hat]
-  exact lt_tsub_iff_right.1 ht'
+  induction s, h using Set.Finite.induction_on with
+  | empty => simp
+  | insert hat _ ht' =>
+    rw [encard_insert_of_not_mem hat]
+    exact lt_tsub_iff_right.1 ht'
 
 theorem Finite.encard_eq_coe (h : s.Finite) : s.encard = ENat.toNat s.encard :=
   (ENat.coe_toNat h.encard_lt_top.ne).symm

--- a/Mathlib/Data/Set/Finite/Lattice.lean
+++ b/Mathlib/Data/Set/Finite/Lattice.lean
@@ -386,9 +386,10 @@ protected theorem Finite.bddAbove (hs : s.Finite) : BddAbove s :=
 
 /-- A finite union of sets which are all bounded above is still bounded above. -/
 theorem Finite.bddAbove_biUnion {I : Set β} {S : β → Set α} (H : I.Finite) :
-    BddAbove (⋃ i ∈ I, S i) ↔ ∀ i ∈ I, BddAbove (S i) :=
-  Finite.induction_on _ H (by simp only [biUnion_empty, bddAbove_empty, forall_mem_empty])
-    fun _ _ hs => by simp only [biUnion_insert, forall_mem_insert, bddAbove_union, hs]
+    BddAbove (⋃ i ∈ I, S i) ↔ ∀ i ∈ I, BddAbove (S i) := by
+  induction I, H using Set.Finite.induction_on with
+  | empty => simp only [biUnion_empty, bddAbove_empty, forall_mem_empty]
+  | insert _ _ hs => simp only [biUnion_insert, forall_mem_insert, bddAbove_union, hs]
 
 theorem infinite_of_not_bddAbove : ¬BddAbove s → s.Infinite :=
   mt Finite.bddAbove

--- a/Mathlib/LinearAlgebra/TensorProduct/Finiteness.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Finiteness.lean
@@ -100,8 +100,10 @@ theorem exists_finite_submodule_of_finite (s : Set (M ⊗[R] N)) (hs : s.Finite)
     ∃ (M' : Submodule R M) (N' : Submodule R N), Module.Finite R M' ∧ Module.Finite R N' ∧
       s ⊆ LinearMap.range (mapIncl M' N') := by
   simp_rw [Module.Finite.iff_fg]
-  refine hs.induction_on _ ⟨_, _, fg_bot, fg_bot, Set.empty_subset _⟩ ?_
-  rintro a s - - ⟨M', N', hM', hN', h⟩
+  induction s, hs using Set.Finite.induction_on with
+  | empty => exact ⟨_, _, fg_bot, fg_bot, Set.empty_subset _⟩
+  | @insert a s _ _ ih =>
+  obtain ⟨M', N', hM', hN', h⟩ := ih
   refine TensorProduct.induction_on a ?_ (fun x y ↦ ?_) fun x y hx hy ↦ ?_
   · exact ⟨M', N', hM', hN', Set.insert_subset (zero_mem _) h⟩
   · refine ⟨_, _, hM'.sup (fg_span_singleton x),

--- a/Mathlib/MeasureTheory/Integral/IntegrableOn.lean
+++ b/Mathlib/MeasureTheory/Integral/IntegrableOn.lean
@@ -175,8 +175,10 @@ theorem integrableOn_singleton_iff {x : α} [MeasurableSingletonClass α] :
 
 @[simp]
 theorem integrableOn_finite_biUnion {s : Set β} (hs : s.Finite) {t : β → Set α} :
-    IntegrableOn f (⋃ i ∈ s, t i) μ ↔ ∀ i ∈ s, IntegrableOn f (t i) μ :=
-  hs.induction_on _ (by simp) <| by intro a s _ _ hf; simp [hf, or_imp, forall_and]
+    IntegrableOn f (⋃ i ∈ s, t i) μ ↔ ∀ i ∈ s, IntegrableOn f (t i) μ := by
+  induction s, hs using Set.Finite.induction_on with
+  | empty => simp
+  | insert _ _ hf => simp [hf, or_imp, forall_and]
 
 @[simp]
 theorem integrableOn_finset_iUnion {s : Finset β} {t : β → Set α} :

--- a/Mathlib/Order/Filter/Finite.lean
+++ b/Mathlib/Order/Filter/Finite.lean
@@ -24,8 +24,10 @@ variable {α : Type u} {f g : Filter α} {s t : Set α}
 
 @[simp]
 theorem biInter_mem {β : Type v} {s : β → Set α} {is : Set β} (hf : is.Finite) :
-    (⋂ i ∈ is, s i) ∈ f ↔ ∀ i ∈ is, s i ∈ f :=
-  Finite.induction_on _ hf (by simp) fun _ _ hs => by simp [hs]
+    (⋂ i ∈ is, s i) ∈ f ↔ ∀ i ∈ is, s i ∈ f := by
+  induction is, hf using Set.Finite.induction_on with
+  | empty => simp
+  | insert _ _ hs => simp [hs]
 
 @[simp]
 theorem biInter_finset_mem {β : Type v} {s : β → Set α} (is : Finset β) :

--- a/Mathlib/Order/Filter/Ultrafilter/Basic.lean
+++ b/Mathlib/Order/Filter/Ultrafilter/Basic.lean
@@ -26,9 +26,10 @@ namespace Ultrafilter
 
 variable {f : Ultrafilter α} {s : Set α}
 
-theorem finite_sUnion_mem_iff {s : Set (Set α)} (hs : s.Finite) : ⋃₀ s ∈ f ↔ ∃ t ∈ s, t ∈ f :=
-  Finite.induction_on _ hs (by simp) fun _ _ his => by
-    simp [union_mem_iff, his, or_and_right, exists_or]
+theorem finite_sUnion_mem_iff {s : Set (Set α)} (hs : s.Finite) : ⋃₀ s ∈ f ↔ ∃ t ∈ s, t ∈ f := by
+  induction s, hs using Set.Finite.induction_on with
+  | empty => simp
+  | insert _ _ his => simp [union_mem_iff, his, or_and_right, exists_or]
 
 theorem finite_biUnion_mem_iff {is : Set β} {s : β → Set α} (his : is.Finite) :
     (⋃ i ∈ is, s i) ∈ f ↔ ∃ i ∈ is, s i ∈ f := by

--- a/Mathlib/RingTheory/Finiteness/Nakayama.lean
+++ b/Mathlib/RingTheory/Finiteness/Nakayama.lean
@@ -26,7 +26,7 @@ theorem exists_sub_one_mem_and_smul_eq_zero_of_fg_of_le_smul {R : Type*} [CommRi
     ∃ r : R, r - 1 ∈ I ∧ ∀ n ∈ N, r • n = (0 : M) := by
   rw [fg_def] at hn
   rcases hn with ⟨s, hfs, hs⟩
-  have : ∃ r : R, r - 1 ∈ I ∧ N ≤ (I • span R s).comap (LinearMap.lsmul R M r) ∧ s ⊆ N := by
+  have H : ∃ r : R, r - 1 ∈ I ∧ N ≤ (I • span R s).comap (LinearMap.lsmul R M r) ∧ s ⊆ N := by
     refine ⟨1, ?_, ?_, ?_⟩
     · rw [sub_self]
       exact I.zero_mem
@@ -38,12 +38,13 @@ theorem exists_sub_one_mem_and_smul_eq_zero_of_fg_of_le_smul {R : Type*} [CommRi
       exact hin hn
     · rw [← span_le, hs]
   clear hin hs
-  revert this
-  refine Set.Finite.induction_on _ hfs (fun H => ?_) @fun i s _ _ ih H => ?_
-  · rcases H with ⟨r, hr1, hrn, _⟩
+  induction s, hfs using Set.Finite.induction_on with
+  | empty =>
+    rcases H with ⟨r, hr1, hrn, _⟩
     refine ⟨r, hr1, fun n hn => ?_⟩
     specialize hrn hn
     rwa [mem_comap, span_empty, smul_bot, mem_bot] at hrn
+  | @insert i s _ _ ih =>
   apply ih
   rcases H with ⟨r, hr1, hrn, hs⟩
   rw [← Set.singleton_union, span_union, smul_sup] at hrn

--- a/Mathlib/RingTheory/IntegralClosure/IsIntegral/Basic.lean
+++ b/Mathlib/RingTheory/IntegralClosure/IsIntegral/Basic.lean
@@ -188,18 +188,16 @@ theorem isIntegral_iff_isIntegral_closure_finite {r : B} :
 
 @[stacks 09GH]
 theorem fg_adjoin_of_finite {s : Set A} (hfs : s.Finite) (his : ∀ x ∈ s, IsIntegral R x) :
-    (Algebra.adjoin R s).toSubmodule.FG :=
-  Set.Finite.induction_on _ hfs
-    (fun _ =>
-      ⟨{1},
-        Submodule.ext fun x => by
-          rw [Algebra.adjoin_empty, Finset.coe_singleton, ← one_eq_span, Algebra.toSubmodule_bot]⟩)
-    (fun {a s} _ _ ih his => by
-      rw [← Set.union_singleton, Algebra.adjoin_union_coe_submodule]
-      exact
-        FG.mul (ih fun i hi => his i <| Set.mem_insert_of_mem a hi)
-          (his a <| Set.mem_insert a s).fg_adjoin_singleton)
-    his
+    (Algebra.adjoin R s).toSubmodule.FG := by
+  induction s, hfs using Set.Finite.induction_on with
+  | empty =>
+    refine ⟨{1}, Submodule.ext fun x => ?_⟩
+    rw [Algebra.adjoin_empty, Finset.coe_singleton, ← one_eq_span, Algebra.toSubmodule_bot]
+  | @insert a s _ _ ih =>
+    rw [← Set.union_singleton, Algebra.adjoin_union_coe_submodule]
+    exact FG.mul
+      (ih fun i hi => his i <| Set.mem_insert_of_mem a hi)
+      (his a <| Set.mem_insert a s).fg_adjoin_singleton
 
 theorem Algebra.finite_adjoin_of_finite_of_isIntegral {s : Set A} (hf : s.Finite)
     (hi : ∀ x ∈ s, IsIntegral R x) : Module.Finite R (adjoin R s) :=

--- a/Mathlib/Topology/Basic.lean
+++ b/Mathlib/Topology/Basic.lean
@@ -118,9 +118,11 @@ lemma isOpen_iff_of_cover {f : α → Set X} (ho : ∀ i, IsOpen (f i)) (hU : (�
 @[simp] theorem isOpen_empty : IsOpen (∅ : Set X) := by
   rw [← sUnion_empty]; exact isOpen_sUnion fun a => False.elim
 
-theorem Set.Finite.isOpen_sInter {s : Set (Set X)} (hs : s.Finite) :
-    (∀ t ∈ s, IsOpen t) → IsOpen (⋂₀ s) :=
-  Finite.induction_on _ hs (fun _ => by rw [sInter_empty]; exact isOpen_univ) fun _ _ ih h => by
+theorem Set.Finite.isOpen_sInter {s : Set (Set X)} (hs : s.Finite) (h : ∀ t ∈ s, IsOpen t) :
+    IsOpen (⋂₀ s) := by
+  induction s, hs using Set.Finite.induction_on with
+  | empty => rw [sInter_empty]; exact isOpen_univ
+  | insert _ _ ih =>
     simp only [sInter_insert, forall_mem_insert] at h ⊢
     exact h.1.inter (ih h.2)
 
@@ -280,8 +282,10 @@ theorem interior_inter : interior (s ∩ t) = interior s ∩ interior t :=
       isOpen_interior.inter isOpen_interior
 
 theorem Set.Finite.interior_biInter {ι : Type*} {s : Set ι} (hs : s.Finite) (f : ι → Set X) :
-    interior (⋂ i ∈ s, f i) = ⋂ i ∈ s, interior (f i) :=
-  hs.induction_on _ (by simp) <| by intros; simp [*]
+    interior (⋂ i ∈ s, f i) = ⋂ i ∈ s, interior (f i) := by
+  induction s, hs using Set.Finite.induction_on with
+  | empty => simp
+  | insert _ _ _ => simp [*]
 
 theorem Set.Finite.interior_sInter {S : Set (Set X)} (hS : S.Finite) :
     interior (⋂₀ S) = ⋂ s ∈ S, interior s := by

--- a/Mathlib/Topology/ContinuousOn.lean
+++ b/Mathlib/Topology/ContinuousOn.lean
@@ -231,9 +231,10 @@ theorem nhds_of_Ici_Iic [LinearOrder α] {b : α}
     (inter_mem hL self_mem_nhdsWithin) (inter_mem hR self_mem_nhdsWithin)
 
 theorem nhdsWithin_biUnion {ι} {I : Set ι} (hI : I.Finite) (s : ι → Set α) (a : α) :
-    𝓝[⋃ i ∈ I, s i] a = ⨆ i ∈ I, 𝓝[s i] a :=
-  Set.Finite.induction_on _ hI (by simp) fun _ _ hT ↦ by
-    simp only [hT, nhdsWithin_union, iSup_insert, biUnion_insert]
+    𝓝[⋃ i ∈ I, s i] a = ⨆ i ∈ I, 𝓝[s i] a := by
+  induction I, hI using Set.Finite.induction_on with
+  | empty => simp
+  | insert _ _ hT => simp only [hT, nhdsWithin_union, iSup_insert, biUnion_insert]
 
 theorem nhdsWithin_sUnion {S : Set (Set α)} (hS : S.Finite) (a : α) :
     𝓝[⋃₀ S] a = ⨆ s ∈ S, 𝓝[s] a := by

--- a/Mathlib/Topology/MetricSpace/MetricSeparated.lean
+++ b/Mathlib/Topology/MetricSpace/MetricSeparated.lean
@@ -137,8 +137,9 @@ theorem union_right_iff {t'} :
 
 theorem finite_iUnion_left_iff {ι : Type*} {I : Set ι} (hI : I.Finite) {s : ι → Set X}
     {t : Set X} : AreSeparated (⋃ i ∈ I, s i) t ↔ ∀ i ∈ I, AreSeparated (s i) t := by
-  refine Finite.induction_on _ hI (by simp) @fun i I _ _ hI => ?_
-  rw [biUnion_insert, forall_mem_insert, union_left_iff, hI]
+  induction I, hI using Set.Finite.induction_on with
+  | empty => simp
+  | insert _ _ hI => rw [biUnion_insert, forall_mem_insert, union_left_iff, hI]
 
 alias ⟨_, finite_iUnion_left⟩ := finite_iUnion_left_iff
 


### PR DESCRIPTION
This seems rather more readable.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
