### PR TITLE
[Merged by Bors] - feat(Probability/Independence/Basic): upstream `iIndepFun_iff_pi_map_eq_map` from PFR

### DIFF
--- a/Mathlib/MeasureTheory/Measure/MeasureSpaceDef.lean
+++ b/Mathlib/MeasureTheory/Measure/MeasureSpaceDef.lean
@@ -419,10 +419,10 @@ theorem Measurable.comp_aemeasurable' [MeasurableSpace δ] {f : α → δ} {g : 
     (hg : Measurable g) (hf : AEMeasurable f μ) : AEMeasurable (fun x ↦ g (f x)) μ :=
   Measurable.comp_aemeasurable hg hf
 
-variable {δ : Type*} [Countable δ] {X : δ → Type*} [∀ a, MeasurableSpace (X a)]
+variable {δ : Type*} [Countable δ] {X : δ → Type*} {mX : ∀ a, MeasurableSpace (X a)}
 
-theorem aemeasurable_pi_iff {g : α → ∀ a, X a} :
-    AEMeasurable g μ ↔ ∀ a, AEMeasurable (fun x => g x a) μ := by
+theorem aemeasurable_pi_iff {g : α → Π a, X a} :
+    AEMeasurable g μ ↔ ∀ a, AEMeasurable (fun x ↦ g x a) μ := by
   constructor
   · intro hg a
     use fun x ↦ hg.mk g x a, hg.measurable_mk.eval
@@ -432,7 +432,7 @@ theorem aemeasurable_pi_iff {g : α → ∀ a, X a} :
     exact (eventually_countable_forall.mpr fun a ↦ (h a).ae_eq_mk).mono fun _ h ↦ funext h
 
 @[fun_prop, aesop safe 100 apply (rule_sets := [Measurable])]
-theorem aemeasurable_pi_lambda (f : α → ∀ a, X a) (hf : ∀ a, AEMeasurable (fun c => f c a) μ) :
+theorem aemeasurable_pi_lambda (f : α → Π a, X a) (hf : ∀ a, AEMeasurable (fun c ↦ f c a) μ) :
     AEMeasurable f μ :=
   aemeasurable_pi_iff.mpr hf
 

--- a/Mathlib/MeasureTheory/Measure/MeasureSpaceDef.lean
+++ b/Mathlib/MeasureTheory/Measure/MeasureSpaceDef.lean
@@ -419,4 +419,21 @@ theorem Measurable.comp_aemeasurable' [MeasurableSpace δ] {f : α → δ} {g : 
     (hg : Measurable g) (hf : AEMeasurable f μ) : AEMeasurable (fun x ↦ g (f x)) μ :=
   Measurable.comp_aemeasurable hg hf
 
+variable {δ : Type*} [Countable δ] {X : δ → Type*} [∀ a, MeasurableSpace (X a)]
+
+theorem aemeasurable_pi_iff {g : α → ∀ a, X a} :
+    AEMeasurable g μ ↔ ∀ a, AEMeasurable (fun x => g x a) μ := by
+  constructor
+  · intro hg a
+    use fun x ↦ hg.mk g x a, hg.measurable_mk.eval
+    exact hg.ae_eq_mk.mono fun _ h ↦ congrFun h _
+  · intro h
+    use fun x a ↦ (h a).mk _ x, measurable_pi_lambda _ fun a ↦ (h a).measurable_mk
+    exact (eventually_countable_forall.mpr fun a ↦ (h a).ae_eq_mk).mono fun _ h ↦ funext h
+
+@[fun_prop, aesop safe 100 apply (rule_sets := [Measurable])]
+theorem aemeasurable_pi_lambda (f : α → ∀ a, X a) (hf : ∀ a, AEMeasurable (fun c => f c a) μ) :
+    AEMeasurable f μ :=
+  aemeasurable_pi_iff.mpr hf
+
 end

--- a/Mathlib/Probability/Independence/Basic.lean
+++ b/Mathlib/Probability/Independence/Basic.lean
@@ -615,6 +615,32 @@ theorem indepFun_iff_map_prod_eq_prod_map_map {mβ : MeasurableSpace β} {mβ' :
   · intro h s t hs ht
     rw [(h₀ hs ht).1, (h₀ hs ht).2, h, Measure.prod_prod]
 
+theorem iIndepFun_iff_pi_map_eq_map [Fintype ι] {β : ι → Type*}
+    {m : (i : ι) → MeasurableSpace (β i)} {f : (i : ι) → Ω → β i} [IsProbabilityMeasure μ]
+    (hf : ∀ i, AEMeasurable (f i) μ) :
+    iIndepFun f μ ↔ Measure.pi (fun i ↦ μ.map (f i)) = μ.map (fun ω i ↦ f i ω) := by
+  classical
+  rw [iIndepFun_iff_measure_inter_preimage_eq_mul]
+  have h₀ {s : ∀ i, Set (β i)} (hm : ∀ (i : ι), MeasurableSet (s i)) :
+      ∏ i : ι, μ (f i ⁻¹' s i) = ∏ i : ι, μ.map (f i) (s i) ∧
+      μ (⋂ i : ι, (f i ⁻¹' s i)) = μ.map (fun ω i ↦ f i ω) (univ.pi s) := by
+    constructor
+    · congr with x
+      rw [Measure.map_apply_of_aemeasurable (hf x) (hm x)]
+    · rw [Measure.map_apply_of_aemeasurable (aemeasurable_pi_lambda _ fun x ↦ hf x)
+        (.univ_pi hm)]
+      congr with x
+      simp
+  constructor
+  · refine fun hS ↦ Measure.pi_eq fun h hm ↦ ?_
+    rw [← (h₀ hm).1, ← (h₀ hm).2]
+    simpa [hm] using hS Finset.univ (sets := h)
+  · intro h S s hs
+    specialize h₀ (s := fun i ↦ if i ∈ S then s i else univ)
+      fun i ↦ by beta_reduce; split_ifs with hiS <;> simp [hiS, hs]
+    simp [← h, apply_ite, Finset.prod_ite, iInter_ite] at h₀
+    rw [h₀.2, ← h₀.1]
+
 @[symm]
 nonrec theorem IndepFun.symm {_ : MeasurableSpace β} {_ : MeasurableSpace β'}
     (hfg : IndepFun f g μ) : IndepFun g f μ := hfg.symm
@@ -730,31 +756,6 @@ lemma iIndepFun_precomp_of_bijective {g : ι' → ι} (hg : g.Bijective) :
     iIndepFun (m := fun i ↦ m (g i)) (fun i ↦ f (g i)) μ ↔ iIndepFun f μ where
   mp := .of_precomp hg.surjective
   mpr := .precomp hg.injective
-
-theorem iIndepFun_iff_pi_map_eq_map [Fintype ι] [IsProbabilityMeasure μ]
-    (hf : ∀ (x : ι), AEMeasurable (f x) μ) :
-    iIndepFun f μ ↔ Measure.pi (fun i ↦ μ.map (f i)) = μ.map (fun ω i ↦ f i ω) := by
-  classical
-  rw [iIndepFun_iff_measure_inter_preimage_eq_mul]
-  have h₀ {s : ∀ i, Set (β i)} (hm : ∀ (i : ι), MeasurableSet (s i)) :
-      ∏ i : ι, μ (f i ⁻¹' s i) = ∏ i : ι, μ.map (f i) (s i) ∧
-      μ (⋂ i : ι, (f i ⁻¹' s i)) = μ.map (fun ω i ↦ f i ω) (univ.pi s) := by
-    constructor
-    · congr with x
-      rw [Measure.map_apply_of_aemeasurable (hf x) (hm x)]
-    · rw [Measure.map_apply_of_aemeasurable (aemeasurable_pi_lambda _ fun x ↦ hf x)
-        (.univ_pi hm)]
-      congr with x
-      simp
-  constructor
-  · refine fun hS ↦ Measure.pi_eq fun h hm ↦ ?_
-    rw [← (h₀ hm).1, ← (h₀ hm).2]
-    simpa [hm] using hS Finset.univ (sets := h)
-  · intro h S s hs
-    specialize h₀ (s := fun i ↦ if i ∈ S then s i else univ)
-      fun i ↦ by beta_reduce; split_ifs with hiS <;> simp [hiS, hs]
-    simp [← h, apply_ite, Finset.prod_ite, iInter_ite] at h₀
-    rw [h₀.2, ← h₀.1]
 
 end iIndepFun
 

--- a/Mathlib/Probability/Independence/Basic.lean
+++ b/Mathlib/Probability/Independence/Basic.lean
@@ -616,7 +616,7 @@ theorem indepFun_iff_map_prod_eq_prod_map_map {mβ : MeasurableSpace β} {mβ' :
     rw [(h₀ hs ht).1, (h₀ hs ht).2, h, Measure.prod_prod]
 
 theorem iIndepFun_iff_pi_map_eq_map [Fintype ι] {β : ι → Type*}
-    {m : (i : ι) → MeasurableSpace (β i)} {f : (i : ι) → Ω → β i} [IsProbabilityMeasure μ]
+    {m : ∀ i, MeasurableSpace (β i)} {f : Π i, Ω → β i} [IsProbabilityMeasure μ]
     (hf : ∀ i, AEMeasurable (f i) μ) :
     iIndepFun f μ ↔ Measure.pi (fun i ↦ μ.map (f i)) = μ.map (fun ω i ↦ f i ω) := by
   classical

--- a/Mathlib/Probability/Independence/Basic.lean
+++ b/Mathlib/Probability/Independence/Basic.lean
@@ -615,10 +615,10 @@ theorem indepFun_iff_map_prod_eq_prod_map_map {mβ : MeasurableSpace β} {mβ' :
   · intro h s t hs ht
     rw [(h₀ hs ht).1, (h₀ hs ht).2, h, Measure.prod_prod]
 
-theorem iIndepFun_iff_pi_map_eq_map [Fintype ι] {β : ι → Type*}
+theorem iIndepFun_iff_map_fun_eq_pi_map [Fintype ι] {β : ι → Type*}
     {m : ∀ i, MeasurableSpace (β i)} {f : Π i, Ω → β i} [IsProbabilityMeasure μ]
     (hf : ∀ i, AEMeasurable (f i) μ) :
-    iIndepFun f μ ↔ Measure.pi (fun i ↦ μ.map (f i)) = μ.map (fun ω i ↦ f i ω) := by
+    iIndepFun f μ ↔ μ.map (fun ω i ↦ f i ω) = Measure.pi (fun i ↦ μ.map (f i)) := by
   classical
   rw [iIndepFun_iff_measure_inter_preimage_eq_mul]
   have h₀ {s : ∀ i, Set (β i)} (hm : ∀ (i : ι), MeasurableSet (s i)) :
@@ -632,13 +632,15 @@ theorem iIndepFun_iff_pi_map_eq_map [Fintype ι] {β : ι → Type*}
       congr with x
       simp
   constructor
-  · refine fun hS ↦ Measure.pi_eq fun h hm ↦ ?_
+  · refine fun hS ↦ (Measure.pi_eq fun h hm ↦ ?_).symm
     rw [← (h₀ hm).1, ← (h₀ hm).2]
     simpa [hm] using hS Finset.univ (sets := h)
   · intro h S s hs
     specialize h₀ (s := fun i ↦ if i ∈ S then s i else univ)
       fun i ↦ by beta_reduce; split_ifs with hiS <;> simp [hiS, hs]
-    simp [← h, apply_ite, Finset.prod_ite, iInter_ite] at h₀
+    simp only [apply_ite, preimage_univ, measure_univ, Finset.prod_ite_mem, Finset.univ_inter,
+      Finset.prod_ite, Finset.filter_univ_mem, iInter_ite, iInter_univ, inter_univ, h,
+      Measure.pi_pi] at h₀
     rw [h₀.2, ← h₀.1]
 
 @[symm]

--- a/Mathlib/Probability/Independence/Basic.lean
+++ b/Mathlib/Probability/Independence/Basic.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Rémy Degenne
 -/
 import Mathlib.Probability.Independence.Kernel
-import Mathlib.MeasureTheory.Measure.Prod
+import Mathlib.MeasureTheory.Constructions.Pi
 
 /-!
 # Independence of sets of sets and measure spaces (σ-algebras)
@@ -730,6 +730,31 @@ lemma iIndepFun_precomp_of_bijective {g : ι' → ι} (hg : g.Bijective) :
     iIndepFun (m := fun i ↦ m (g i)) (fun i ↦ f (g i)) μ ↔ iIndepFun f μ where
   mp := .of_precomp hg.surjective
   mpr := .precomp hg.injective
+
+theorem iIndepFun_iff_pi_map_eq_map [Fintype ι] [IsProbabilityMeasure μ]
+    (hf : ∀ (x : ι), AEMeasurable (f x) μ) :
+    iIndepFun f μ ↔ Measure.pi (fun i ↦ μ.map (f i)) = μ.map (fun ω i ↦ f i ω) := by
+  classical
+  rw [iIndepFun_iff_measure_inter_preimage_eq_mul]
+  have h₀ {s : ∀ i, Set (β i)} (hm : ∀ (i : ι), MeasurableSet (s i)) :
+      ∏ i : ι, μ (f i ⁻¹' s i) = ∏ i : ι, μ.map (f i) (s i) ∧
+      μ (⋂ i : ι, (f i ⁻¹' s i)) = μ.map (fun ω i ↦ f i ω) (univ.pi s) := by
+    constructor
+    · congr with x
+      rw [Measure.map_apply_of_aemeasurable (hf x) (hm x)]
+    · rw [Measure.map_apply_of_aemeasurable (aemeasurable_pi_lambda _ fun x ↦ hf x)
+        (.univ_pi hm)]
+      congr with x
+      simp
+  constructor
+  · refine fun hS ↦ Measure.pi_eq fun h hm ↦ ?_
+    rw [← (h₀ hm).1, ← (h₀ hm).2]
+    simpa [hm] using hS Finset.univ (sets := h)
+  · intro h S s hs
+    specialize h₀ (s := fun i ↦ if i ∈ S then s i else univ)
+      fun i ↦ by beta_reduce; split_ifs with hiS <;> simp [hiS, hs]
+    simp [← h, apply_ite, Finset.prod_ite, iInter_ite] at h₀
+    rw [h₀.2, ← h₀.1]
 
 end iIndepFun
 


### PR DESCRIPTION
* Added lemma `aemeasurable_pi_lambda` for `AEMeasurable (f : α → ∀ a : δ, X a) μ` for countable `δ`, parallel to `measurable_pi_lambda`.
* Showed that a finite collection of random variables are independent iff their joint law is the product distribution of their respective laws.

This lemma is needed in CLT.

I am using git blame on PFR to figure out the person (@MantasBaksys) who wrote this and adding to co-authored-by field:

Co-authored-by: Mantas Bakšys <baksys.mantas@gmail.com>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
