### PR TITLE
[Merged by Bors] - feat(Matrix): abs_det_reindex_self_self

### DIFF
--- a/Mathlib/LinearAlgebra/Matrix/Determinant/Basic.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Determinant/Basic.lean
@@ -253,7 +253,7 @@ theorem det_reindex_self (e : m ≃ n) (A : Matrix m m R) : det (reindex e e A) 
 For the `simp` version of this lemma, see `abs_det_submatrix_equiv_equiv`;
 this one is unsuitable because `Matrix.reindex_apply` unfolds `reindex` first.
 -/
-theorem abs_det_reindex_self_self {R : Type*} [LinearOrderedCommRing R]
+theorem abs_det_reindex {R : Type*} [LinearOrderedCommRing R]
     (e₁ e₂ : m ≃ n) (A : Matrix m m R) :
     |det (reindex e₁ e₂ A)| = |det A| :=
   abs_det_submatrix_equiv_equiv e₁.symm e₂.symm A

--- a/Mathlib/LinearAlgebra/Matrix/Determinant/Basic.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Determinant/Basic.lean
@@ -248,6 +248,16 @@ For the `simp` version of this lemma, see `det_submatrix_equiv_self`; this one i
 theorem det_reindex_self (e : m ≃ n) (A : Matrix m m R) : det (reindex e e A) = det A :=
   det_submatrix_equiv_self e.symm A
 
+/-- Reindexing both indices along equivalences preserves the absolute of the determinant.
+
+For the `simp` version of this lemma, see `abs_det_submatrix_equiv_equiv`;
+this one is unsuitable because `Matrix.reindex_apply` unfolds `reindex` first.
+-/
+theorem abs_det_reindex_self_self {R : Type*} [LinearOrderedCommRing R]
+    (e₁ e₂ : m ≃ n) (A : Matrix m m R) :
+    |det (reindex e₁ e₂ A)| = |det A| :=
+  abs_det_submatrix_equiv_equiv e₁.symm e₂.symm A
+
 theorem det_smul (A : Matrix n n R) (c : R) : det (c • A) = c ^ Fintype.card n * det A :=
   calc
     det (c • A) = det ((diagonal fun _ => c) * A) := by rw [smul_eq_diagonal_mul]


### PR DESCRIPTION
Upstreamed from [a Ivan-Sergeyev/seymour PR](https://github.com/Ivan-Sergeyev/seymour/pull/59/files#diff-d06784b6163a686c71b26ebb6deee29020e4dcc9ec6972192315ec770f869d37R64-R68)

The equivalent to [`det_reindex_self`](https://leanprover-community.github.io/mathlib4_docs/Mathlib/LinearAlgebra/Matrix/Determinant/Basic.html#Matrix.det_reindex_self) with respect to [`abs_det_submatrix_equiv_equiv`](https://leanprover-community.github.io/mathlib4_docs/Mathlib/LinearAlgebra/Matrix/Determinant/Basic.html#Matrix.abs_det_submatrix_equiv_equiv).

Suggestions to the suffix of the `abs_det_reindex_self_self` are welcome.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
