### PR TITLE
[Merged by Bors] - feat(RingTheory/Nilpotent): prepare exp calculations

### DIFF
--- a/Mathlib/Algebra/Lie/Derivation/Basic.lean
+++ b/Mathlib/Algebra/Lie/Derivation/Basic.lean
@@ -3,7 +3,6 @@ Copyright (c) 2024 Frédéric Marbach. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Frédéric Marbach
 -/
-import Mathlib.Algebra.Algebra.Rat
 import Mathlib.Algebra.Lie.NonUnitalNonAssocAlgebra
 import Mathlib.Algebra.Lie.OfAssociative
 import Mathlib.Algebra.Lie.Subalgebra

--- a/Mathlib/Algebra/Lie/Derivation/Basic.lean
+++ b/Mathlib/Algebra/Lie/Derivation/Basic.lean
@@ -409,9 +409,8 @@ noncomputable def exp (h : IsNilpotent D.toLinearMap) :
         ← LinearMap.mul_eq_comp, h.exp_mul_exp_neg_self, LinearMap.one_apply] }
 
 lemma exp_apply (h : IsNilpotent D.toLinearMap) :
-    exp D h = IsNilpotent.exp D.toLinearMap := by
-  ext x
-  dsimp [exp]
+    exp D h = IsNilpotent.exp D.toLinearMap :=
+  rfl
 
 lemma exp_map_apply (h : IsNilpotent D.toLinearMap) (l : L) :
     exp D h l = IsNilpotent.exp D.toLinearMap l :=

--- a/Mathlib/Algebra/Lie/Derivation/Basic.lean
+++ b/Mathlib/Algebra/Lie/Derivation/Basic.lean
@@ -390,13 +390,13 @@ end Inner
 
 section ExpNilpotent
 
-variable {R L : Type*} [Field R] [CharZero R] [LieRing L] [LieAlgebra R L] (D : LieDerivation R L L)
+variable {R L : Type*} [Field R] [LieRing L] [LieAlgebra R L] [LieAlgebra ℚ L]
+  (D : LieDerivation R L L)
 
 /-- In characteristic zero, the exponential of a nilpotent derivation is a Lie algebra
 automorphism. -/
 noncomputable def exp (h : IsNilpotent D.toLinearMap) :
     L ≃ₗ⁅R⁆ L :=
-  let _i : LieAlgebra ℚ L := LieAlgebra.RestrictScalars.lieAlgebra ℚ R L
   { toLinearMap := IsNilpotent.exp D.toLinearMap
     map_lie' := by
       let _i := LieRing.toNonUnitalNonAssocRing L
@@ -411,12 +411,14 @@ noncomputable def exp (h : IsNilpotent D.toLinearMap) :
       simp only [AddHom.toFun_eq_coe, LinearMap.coe_toAddHom, ← LinearMap.comp_apply,
         ← LinearMap.mul_eq_comp, h.exp_mul_exp_neg_self, LinearMap.one_apply] }
 
-lemma exp_apply [Module ℚ L] (h : IsNilpotent D.toLinearMap) :
+lemma exp_apply (h : IsNilpotent D.toLinearMap) :
     exp D h = IsNilpotent.exp D.toLinearMap := by
   ext x
   dsimp [exp]
-  convert rfl
-  subsingleton
+
+lemma exp_map_apply (h : IsNilpotent D.toLinearMap) (l : L) :
+    exp D h l = IsNilpotent.exp D.toLinearMap l := by
+  exact (DFunLike.congr (id ((exp_apply D h))) rfl)
 
 end ExpNilpotent
 

--- a/Mathlib/Algebra/Lie/Derivation/Basic.lean
+++ b/Mathlib/Algebra/Lie/Derivation/Basic.lean
@@ -414,8 +414,8 @@ lemma exp_apply (h : IsNilpotent D.toLinearMap) :
   dsimp [exp]
 
 lemma exp_map_apply (h : IsNilpotent D.toLinearMap) (l : L) :
-    exp D h l = IsNilpotent.exp D.toLinearMap l := by
-  exact (DFunLike.congr (id ((exp_apply D h))) rfl)
+    exp D h l = IsNilpotent.exp D.toLinearMap l :=
+  DFunLike.congr_fun (exp_apply D h) l
 
 end ExpNilpotent
 

--- a/Mathlib/Algebra/Lie/Derivation/Basic.lean
+++ b/Mathlib/Algebra/Lie/Derivation/Basic.lean
@@ -387,7 +387,7 @@ end Inner
 
 section ExpNilpotent
 
-variable {R L : Type*} [Field R] [LieRing L] [LieAlgebra R L] [LieAlgebra ℚ L]
+variable {R L : Type*} [CommRing R] [LieRing L] [LieAlgebra R L] [LieAlgebra ℚ L]
   (D : LieDerivation R L L)
 
 /-- In characteristic zero, the exponential of a nilpotent derivation is a Lie algebra

--- a/Mathlib/Algebra/Lie/Derivation/Basic.lean
+++ b/Mathlib/Algebra/Lie/Derivation/Basic.lean
@@ -4,8 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Frédéric Marbach
 -/
 import Mathlib.Algebra.Algebra.Rat
-import Mathlib.Algebra.Lie.BaseChange
-import Mathlib.Algebra.Lie.Basic
 import Mathlib.Algebra.Lie.NonUnitalNonAssocAlgebra
 import Mathlib.Algebra.Lie.OfAssociative
 import Mathlib.Algebra.Lie.Subalgebra

--- a/Mathlib/RingTheory/Nilpotent/Exp.lean
+++ b/Mathlib/RingTheory/Nilpotent/Exp.lean
@@ -67,9 +67,9 @@ theorem exp_eq_sum_apply {M : Type*} [AddCommGroup M] [Module A M] [Module ℚ M
     {k : ℕ} (h : (a ^ k) • m = 0) (hn : IsNilpotent a) :
       (exp a) • m = ∑ i ∈ range k, ((i.factorial : ℚ)⁻¹ • (a ^ i)) • m := by
   rcases le_or_lt (nilpotencyClass a) k with h₀ | h₀
-  · rw [exp_eq_sum (pow_eq_zero_of_le h₀ (pow_nilpotencyClass hn)), Finset.sum_smul]
+  · rw [exp_eq_sum (pow_eq_zero_of_le h₀ (pow_nilpotencyClass hn)), sum_smul]
   dsimp [exp]
-  rw [Finset.sum_smul, (sum_range_add_sum_Ico _ (Nat.le_of_succ_le h₀)).symm]
+  rw [sum_smul, (sum_range_add_sum_Ico _ (Nat.le_of_succ_le h₀)).symm]
   suffices ∑ i ∈ Ico k (nilpotencyClass a), ((i.factorial : ℚ)⁻¹ • (a ^ i)) • m = 0 by
     rw [this, add_zero]
   exact sum_eq_zero fun r h₂ => by

--- a/Mathlib/RingTheory/Nilpotent/Exp.lean
+++ b/Mathlib/RingTheory/Nilpotent/Exp.lean
@@ -63,18 +63,16 @@ theorem exp_eq_sum {a : A} {k : ℕ} (h : a ^ k = 0) :
   exact sum_eq_zero fun _ h₂ => by
     rw [pow_eq_zero_of_le (mem_Ico.1 h₂).1 (pow_nilpotencyClass ⟨k, h⟩), smul_zero]
 
-theorem exp_eq_sum_apply {M : Type*} [AddCommGroup M] [Module A M] [Module ℚ M] {a : A} {m : M}
+theorem exp_smul_eq_sum {M : Type*} [AddCommGroup M] [Module A M] [Module ℚ M] {a : A} {m : M}
     {k : ℕ} (h : (a ^ k) • m = 0) (hn : IsNilpotent a) :
-      (exp a) • m = ∑ i ∈ range k, ((i.factorial : ℚ)⁻¹ • (a ^ i)) • m := by
+      exp a • m = ∑ i ∈ range k, (i.factorial : ℚ)⁻¹ • (a ^ i) • m := by
   rcases le_or_lt (nilpotencyClass a) k with h₀ | h₀
-  · rw [exp_eq_sum (pow_eq_zero_of_le h₀ (pow_nilpotencyClass hn)), sum_smul]
-  dsimp [exp]
-  rw [sum_smul, (sum_range_add_sum_Ico _ (Nat.le_of_succ_le h₀)).symm]
+  · simp_rw [exp_eq_sum (pow_eq_zero_of_le h₀ (pow_nilpotencyClass hn)), sum_smul, smul_assoc]
+  rw [exp, sum_smul, ← sum_range_add_sum_Ico _ (Nat.le_of_succ_le h₀)]
   suffices ∑ i ∈ Ico k (nilpotencyClass a), ((i.factorial : ℚ)⁻¹ • (a ^ i)) • m = 0 by
-    rw [this, add_zero]
-  exact sum_eq_zero fun r h₂ => by
-    rw [smul_assoc, (pow_sub_mul_pow a (mem_Ico.1 h₂).1).symm, mul_smul, h, smul_zero (a ^ (r - k)),
-      smul_zero]
+    simp_rw [this, add_zero, smul_assoc]
+  refine sum_eq_zero fun r h₂ ↦ ?_
+  rw [smul_assoc, ← pow_sub_mul_pow a (mem_Ico.1 h₂).1, mul_smul, h, smul_zero, smul_zero]
 
 theorem exp_add_of_commute {a b : A} (h₁ : Commute a b) (h₂ : IsNilpotent a) (h₃ : IsNilpotent b) :
     exp (a + b) = exp a * exp b := by

--- a/Mathlib/RingTheory/Nilpotent/Exp.lean
+++ b/Mathlib/RingTheory/Nilpotent/Exp.lean
@@ -6,6 +6,7 @@ Authors: Janos Wolosz
 import Mathlib.Algebra.Algebra.Basic
 import Mathlib.Algebra.Algebra.Bilinear
 import Mathlib.Algebra.BigOperators.GroupWithZero.Action
+import Mathlib.Algebra.Module.BigOperators
 import Mathlib.Algebra.Module.Rat
 import Mathlib.Data.Nat.Cast.Field
 import Mathlib.LinearAlgebra.TensorProduct.Tower
@@ -61,6 +62,19 @@ theorem exp_eq_sum {a : A} {k : ℕ} (h : a ^ k = 0) :
     rw [h₁, this, add_zero]
   exact sum_eq_zero fun _ h₂ => by
     rw [pow_eq_zero_of_le (mem_Ico.1 h₂).1 (pow_nilpotencyClass ⟨k, h⟩), smul_zero]
+
+theorem exp_eq_sum_apply {M : Type*} [AddCommGroup M] [Module A M] [Module ℚ M] {a : A} {m : M}
+    {k : ℕ} (h : (a ^ k) • m = 0) (hn : IsNilpotent a) :
+      (exp a) • m = ∑ i ∈ range k, ((i.factorial : ℚ)⁻¹ • (a ^ i)) • m := by
+  rcases le_or_lt (nilpotencyClass a) k with h₀ | h₀
+  · rw [exp_eq_sum (pow_eq_zero_of_le h₀ (pow_nilpotencyClass hn)), Finset.sum_smul]
+  dsimp [exp]
+  rw [Finset.sum_smul, (sum_range_add_sum_Ico _ (Nat.le_of_succ_le h₀)).symm]
+  suffices ∑ i ∈ Ico k (nilpotencyClass a), ((i.factorial : ℚ)⁻¹ • (a ^ i)) • m = 0 by
+    rw [this, add_zero]
+  exact sum_eq_zero fun r h₂ => by
+    rw [smul_assoc, (pow_sub_mul_pow a (mem_Ico.1 h₂).1).symm, mul_smul, h, smul_zero (a ^ (r - k)),
+      smul_zero]
 
 theorem exp_add_of_commute {a b : A} (h₁ : Commute a b) (h₂ : IsNilpotent a) (h₃ : IsNilpotent b) :
     exp (a + b) = exp a * exp b := by


### PR DESCRIPTION
Changes for IsNilpotent.exp calculations
---
This PR introduces changes and helper lemmas to simplify working with the `IsNilpotent.exp`.
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
