### PR TITLE
[Merged by Bors] - feat(Probability/Moments): moment generating function of a sum of measures

### DIFF
--- a/Mathlib/Probability/Moments/Basic.lean
+++ b/Mathlib/Probability/Moments/Basic.lean
@@ -229,6 +229,14 @@ theorem mgf_const_add (α : ℝ) : mgf (fun ω => α + X ω) μ t = exp (t * α)
 theorem mgf_add_const (α : ℝ) : mgf (fun ω => X ω + α) μ t = mgf X μ t *  exp (t * α) := by
   simp only [add_comm, mgf_const_add, mul_comm]
 
+lemma mgf_add_measure {ν : Measure Ω}
+    (hμ : Integrable (fun ω ↦ exp (t * X ω)) μ) (hν : Integrable (fun ω ↦ exp (t * X ω)) ν) :
+    mgf X (μ + ν) t = mgf X μ t + mgf X ν t := by
+  rw [mgf, integral_add_measure hμ hν, mgf, mgf]
+
+lemma mgf_smul_measure (c : ℝ≥0∞) : mgf X (c • μ) t = c.toReal * mgf X μ t := by
+  rw [mgf, integral_smul_measure, mgf, smul_eq_mul]
+
 /-- The moment generating function is monotone in the random variable for `t ≥ 0`. -/
 lemma mgf_mono_of_nonneg {Y : Ω → ℝ} (hXY : X ≤ᵐ[μ] Y) (ht : 0 ≤ t)
     (htY : Integrable (fun ω ↦ exp (t * Y ω)) μ) :

--- a/Mathlib/Probability/Moments/Basic.lean
+++ b/Mathlib/Probability/Moments/Basic.lean
@@ -234,6 +234,11 @@ lemma mgf_add_measure {ν : Measure Ω}
     mgf X (μ + ν) t = mgf X μ t + mgf X ν t := by
   rw [mgf, integral_add_measure hμ hν, mgf, mgf]
 
+lemma mgf_sum_measure {ι : Type*} {μ : ι → Measure Ω}
+    (hμ : Integrable (fun ω ↦ exp (t * X ω)) (Measure.sum μ)) :
+    mgf X (Measure.sum μ) t = ∑' i, mgf X (μ i) t := by
+  simp_rw [mgf, integral_sum_measure hμ]
+
 lemma mgf_smul_measure (c : ℝ≥0∞) : mgf X (c • μ) t = c.toReal * mgf X μ t := by
   rw [mgf, integral_smul_measure, mgf, smul_eq_mul]
 


### PR DESCRIPTION
Add `mgf_add_measure` and `mgf_sum_measure` about sums of measures, and `mgf_smul_measure` about scalar multiplication.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
