### PR TITLE
[Merged by Bors] - feat(CategoryTheory/Core): functors and natural transformations induced on cores

### DIFF
--- a/Mathlib/CategoryTheory/Core.lean
+++ b/Mathlib/CategoryTheory/Core.lean
@@ -154,6 +154,19 @@ end Iso
 
 variable (D : Type u₂) [Category.{v₂} D]
 
+namespace Equivalence
+
+variable {D} in
+/-- Equivalent categories have equivalent cores. -/
+@[simps!]
+def core (E : C ≌ D) : Core C ≌ Core D where
+  functor := E.functor.core
+  inverse := E.inverse.core
+  unitIso := E.unitIso.core
+  counitIso := E.counitIso.core
+
+end Equivalence
+
 variable (C) in
 /-- Taking the core of a functor is functorial if we discard non-invertible natural
 transformations. -/

--- a/Mathlib/CategoryTheory/Core.lean
+++ b/Mathlib/CategoryTheory/Core.lean
@@ -122,33 +122,26 @@ lemma coreComp {F G H : C ⥤ D} (α : F ≅ G) (β : G ≅ H) : (α ≪≫ β).
 @[simp]
 lemma coreId {F : C ⥤ D} : (Iso.refl F).core = Iso.refl F.core := rfl
 
--- Arguments order and simp normal forms here are chosen to mimic simp lemmas of pseudofunctors.
-
-@[simp]
 lemma coreWhiskerLeft {E : Type u₃} [Category.{v₃} E] (F : C ⥤ D) {G H : D ⥤ E} (η : G ≅ H) :
     (isoWhiskerLeft F η).core =
     F.coreComp G ≪≫ isoWhiskerLeft F.core η.core ≪≫ (F.coreComp H).symm := by
   aesop_cat
 
-@[simp]
 lemma coreWhiskerRight {E : Type u₃} [Category.{v₃} E] {F G : C ⥤ D} (η : F ≅ G) (H : D ⥤ E) :
     (isoWhiskerRight η H ).core =
     F.coreComp H ≪≫ isoWhiskerRight η.core H.core ≪≫ (G.coreComp H).symm := by
   aesop_cat
 
-@[simp]
 lemma coreLeftUnitor {F : C ⥤ D} :
     F.leftUnitor.core =
     (𝟭 C).coreComp F ≪≫ isoWhiskerRight (Functor.coreId C) _ ≪≫ F.core.leftUnitor := by
   aesop_cat
 
-@[simp]
 lemma coreRightUnitor {F : C ⥤ D} :
     F.rightUnitor.core =
     (F).coreComp (𝟭 D) ≪≫ isoWhiskerLeft _ (Functor.coreId D) ≪≫ F.core.rightUnitor := by
   aesop_cat
 
-@[simp]
 lemma coreAssociator {E : Type u₃} [Category.{v₃} E] {E' : Type u₄} [Category.{v₄} E']
     (F : C ⥤ D) (G : D ⥤ E) (H : E ⥤ E') :
     (Functor.associator F G H).core =

--- a/Mathlib/CategoryTheory/Core.lean
+++ b/Mathlib/CategoryTheory/Core.lean
@@ -23,7 +23,7 @@ but this is not functorial with respect to `F`.
 
 namespace CategoryTheory
 
-universe v₁ v₂ u₁ u₂
+universe v₁ v₂ v₃ v₄ u₁ u₂ u₃ u₄
 
 -- morphism levels before object levels. See note [CategoryTheory universes].
 /-- The core of a category C is the groupoid whose morphisms are all the
@@ -49,9 +49,13 @@ theorem id_hom (X : C) : Iso.hom (coreCategory.id X) = @CategoryStruct.id C _ X 
 theorem comp_hom {X Y Z : Core C} (f : X ⟶ Y) (g : Y ⟶ Z) : (f ≫ g).hom = f.hom ≫ g.hom :=
   rfl
 
+@[ext]
+theorem hom_ext {X Y : Core C} {f g : X ⟶ Y} (h : f.hom = g.hom) : f = g := Iso.ext h
+
 variable (C)
 
 /-- The core of a category is naturally included in the category. -/
+@[simps!]
 def inclusion : Core C ⥤ C where
   obj := id
   map f := f.hom
@@ -78,6 +82,85 @@ def forgetFunctorToCore : (G ⥤ Core C) ⥤ G ⥤ C :=
   (whiskeringRight _ _ _).obj (inclusion C)
 
 end Core
+
+section
+
+namespace Functor
+
+variable {D : Type u₂} [Category.{v₂} D]
+
+/-- A functor `C ⥤ D` induces a functor `Core C ⥤ Core D` -/
+@[simps!]
+def core (F : C ⥤ D) : Core C ⥤ Core D := Core.functorToCore (Core.inclusion _ ⋙ F)
+
+variable (C) in
+/-- The core of the identity functor is the identity functor on the cores. -/
+@[simps! hom_app inv_app]
+def coreId : (𝟭 C).core ≅ 𝟭 (Core C) := Iso.refl _
+
+/-- The core of the composition of F and G is the composition of the cores. -/
+@[simps! hom_app inv_app]
+def coreComp {E : Type u₃} [Category.{v₃} E] (F : C ⥤ D) (G : D ⥤ E) :
+  (F ⋙ G).core ≅ F.core ⋙ G.core := Iso.refl _
+
+end Functor
+
+namespace Iso
+
+variable {D : Type u₂} [Category.{v₂} D]
+
+/-- A natural isomorphism of functors induces a natural isomorphism between their cores. -/
+@[simps! hom_app inv_app]
+def core {F G : C ⥤ D} (α : F ≅ G) : F.core ≅ G.core :=
+  NatIso.ofComponents
+    (fun x ↦ Groupoid.isoEquivHom _ _|>.symm <| α.app x)
+    (fun {_ _} f ↦ by aesop_cat)
+
+@[simp]
+lemma coreComp {F G H : C ⥤ D} (α : F ≅ G) (β : G ≅ H) : (α ≪≫ β).core = α.core ≪≫ β.core := rfl
+
+@[simp]
+lemma coreId {F : C ⥤ D} : (Iso.refl F).core = Iso.refl F.core := rfl
+
+-- Arguments order and simp normal forms here are chosen to mimic simp lemmas of pseudofunctors.
+
+@[simp]
+lemma coreWhiskerLeft {E : Type u₃} [Category.{v₃} E] (F : C ⥤ D) {G H : D ⥤ E} (η : G ≅ H) :
+    (isoWhiskerLeft F η).core =
+    F.coreComp G ≪≫ isoWhiskerLeft F.core η.core ≪≫ (F.coreComp H).symm := by
+  aesop_cat
+
+@[simp]
+lemma coreWhiskerRight {E : Type u₃} [Category.{v₃} E] {F G : C ⥤ D} (η : F ≅ G) (H : D ⥤ E) :
+    (isoWhiskerRight η H ).core =
+    F.coreComp H ≪≫ isoWhiskerRight η.core H.core ≪≫ (G.coreComp H).symm := by
+  aesop_cat
+
+@[simp]
+lemma coreLeftUnitor {F : C ⥤ D} :
+    F.leftUnitor.core =
+    (𝟭 C).coreComp F ≪≫ isoWhiskerRight (Functor.coreId C) _ ≪≫ F.core.leftUnitor := by
+  aesop_cat
+
+@[simp]
+lemma coreRightUnitor {F : C ⥤ D} :
+    F.rightUnitor.core =
+    (F).coreComp (𝟭 D) ≪≫ isoWhiskerLeft _ (Functor.coreId D) ≪≫ F.core.rightUnitor := by
+  aesop_cat
+
+@[simp]
+lemma coreAssociator {E : Type u₃} [Category.{v₃} E] {E' : Type u₄} [Category.{v₄} E']
+    (F : C ⥤ D) (G : D ⥤ E) (H : E ⥤ E') :
+    (Functor.associator F G H).core =
+    (F ⋙ G).coreComp H ≪≫ isoWhiskerRight (F.coreComp G) H.core ≪≫
+      Functor.associator F.core G.core H.core ≪≫ (isoWhiskerLeft F.core (G.coreComp H)).symm ≪≫
+      (F.coreComp (G ⋙ H)).symm
+      := by
+  aesop_cat
+
+end Iso
+
+end
 
 /-- `ofEquivFunctor m` lifts a type-level `EquivFunctor`
 to a categorical functor `Core (Type u₁) ⥤ Core (Type u₂)`.

--- a/Mathlib/CategoryTheory/Core.lean
+++ b/Mathlib/CategoryTheory/Core.lean
@@ -89,7 +89,7 @@ namespace Functor
 
 variable {D : Type u₂} [Category.{v₂} D]
 
-/-- A functor `C ⥤ D` induces a functor `Core C ⥤ Core D` -/
+/-- A functor `C ⥤ D` induces a functor `Core C ⥤ Core D`. -/
 @[simps!]
 def core (F : C ⥤ D) : Core C ⥤ Core D := Core.functorToCore (Core.inclusion _ ⋙ F)
 

--- a/Mathlib/CategoryTheory/Core.lean
+++ b/Mathlib/CategoryTheory/Core.lean
@@ -160,18 +160,15 @@ lemma coreAssociator {E : Type u₃} [Category.{v₃} E] {E' : Type u₄} [Categ
 
 end Iso
 
-namespace Functor
+variable (D : Type u₂) [Category.{v₂} D]
 
-variable {D : Type u₂} [Category.{v₂} D]
-
+variable (C) in
 /-- Taking the core of a functor is functorial if we discard non-invertible natural
 transformations. -/
 @[simps!]
 def coreFunctor : Core (C ⥤ D) ⥤ Core C ⥤ Core D where
   obj F := F.core
   map η := η.core.hom
-
-end Functor
 
 end
 

--- a/Mathlib/CategoryTheory/Core.lean
+++ b/Mathlib/CategoryTheory/Core.lean
@@ -160,6 +160,19 @@ lemma coreAssociator {E : Type u₃} [Category.{v₃} E] {E' : Type u₄} [Categ
 
 end Iso
 
+namespace Functor
+
+variable {D : Type u₂} [Category.{v₂} D]
+
+/-- Taking the core of a functor is functorial if we discard non-invertible natural
+transformations. -/
+@[simps!]
+def coreFunctor : Core (C ⥤ D) ⥤ Core C ⥤ Core D where
+  obj F := F.core
+  map η := η.core.hom
+
+end Functor
+
 end
 
 /-- `ofEquivFunctor m` lifts a type-level `EquivFunctor`

--- a/Mathlib/CategoryTheory/Core.lean
+++ b/Mathlib/CategoryTheory/Core.lean
@@ -154,8 +154,7 @@ lemma coreAssociator {E : Type u₃} [Category.{v₃} E] {E' : Type u₄} [Categ
     (Functor.associator F G H).core =
     (F ⋙ G).coreComp H ≪≫ isoWhiskerRight (F.coreComp G) H.core ≪≫
       Functor.associator F.core G.core H.core ≪≫ (isoWhiskerLeft F.core (G.coreComp H)).symm ≪≫
-      (F.coreComp (G ⋙ H)).symm
-      := by
+      (F.coreComp (G ⋙ H)).symm := by
   aesop_cat
 
 end Iso

--- a/Mathlib/CategoryTheory/Groupoid.lean
+++ b/Mathlib/CategoryTheory/Groupoid.lean
@@ -93,6 +93,7 @@ instance functorMapReverse {D : Type*} [Groupoid D] (F : C ⥤ D) : F.toPrefunct
 variable (X Y)
 
 /-- In a groupoid, isomorphisms are equivalent to morphisms. -/
+@[simps!]
 def Groupoid.isoEquivHom : (X ≅ Y) ≃ (X ⟶ Y) where
   toFun := Iso.hom
   invFun f := ⟨f, Groupoid.inv f, (by simp), (by simp)⟩


### PR DESCRIPTION
Add a constructor for functors `Core C ⥤ Core D` from functors `C ⥤ D`. Show that this construction respects composition and identity functors. Add a constructor for natural isomorphisms of functors of this form, and show compatibility of the construction with respect to composition, identities, left/right whiskering, left/right unitors, and associators. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

I added an `ext` lemma for morphisms in cores and tagged `Core.inclusion` and `Groupoid.isoEquivHom` with `@[simps!]` so that all proofs are found by aesop_cat.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
