### PR TITLE
[Merged by Bors] - fix(Tactic/Lift): replace `simp at h h` with `simp at h`

### DIFF
--- a/Mathlib/NumberTheory/Pell.lean
+++ b/Mathlib/NumberTheory/Pell.lean
@@ -593,7 +593,6 @@ theorem mul_inv_x_lt_x {a₁ : Solution₁ d} (h : IsFundamental a₁) {a : Solu
 theorem eq_pow_of_nonneg {a₁ : Solution₁ d} (h : IsFundamental a₁) {a : Solution₁ d} (hax : 0 < a.x)
     (hay : 0 ≤ a.y) : ∃ n : ℕ, a = a₁ ^ n := by
   lift a.x to ℕ using hax.le with ax hax'
-  clear hax
   induction ax using Nat.strong_induction_on generalizing a with | h x ih =>
   rcases hay.eq_or_lt with hy | hy
   · -- case 1: `a = 1`

--- a/Mathlib/Tactic/Lift.lean
+++ b/Mathlib/Tactic/Lift.lean
@@ -147,9 +147,8 @@ def Lift.main (e t : TSyntax `term) (hUsing : Option (TSyntax `term))
     for decl in ← getLCtx do
       if decl.userName != newEqName then
         let declIdent := mkIdent decl.userName
-        -- The line below fails if $declIdent is there only once.
         evalTactic (← `(tactic| simp (config := {failIfUnchanged := false})
-          only [← $newEqIdent] at $declIdent $declIdent))
+          only [← $newEqIdent] at $declIdent:ident))
     evalTactic (← `(tactic| simp (config := {failIfUnchanged := false}) only [← $newEqIdent]))
   -- Clear the temporary hypothesis used for the new variable name if applicable
   if isNewVar && !isNewEq then

--- a/MathlibTest/lift.lean
+++ b/MathlibTest/lift.lean
@@ -222,16 +222,16 @@ example (n : ℤ) (hn : 0 < n) : True := by
 
 -- https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Bug.20in.20.60lift.60.20tactic.3F/near/508521400
 /--
-error: tactic 'fail' failed
-case intro
+info: case intro
 x : WithTop ℕ
 P : WithTop ℕ → Prop
 u : ℕ
 hu : ↑u = x
 h : P ↑u
-⊢ False
+⊢ P ↑u
 -/
 #guard_msgs in
-example {x : WithTop ℕ} (hx : x ≠ ⊤) (P : WithTop ℕ → Prop) (h : P x) : False := by
+example {x : WithTop ℕ} (hx : x ≠ ⊤) (P : WithTop ℕ → Prop) (h : P x) : P x := by
   lift x to ℕ using hx with u hu
-  fail
+  trace_state
+  exact h

--- a/MathlibTest/lift.lean
+++ b/MathlibTest/lift.lean
@@ -8,7 +8,6 @@ import Mathlib.Data.Set.Image
 import Mathlib.Data.Set.List
 import Mathlib.Data.Rat.Defs
 import Mathlib.Data.PNat.Defs
-import Mathlib.Order.WithBot
 
 /-! Some tests of the `lift` tactic. -/
 
@@ -233,6 +232,6 @@ h : P ↑u
 ⊢ False
 -/
 #guard_msgs in
-lemma k {x : WithTop ℕ} (hx : x ≠ ⊤) (P : WithTop ℕ → Prop) (h : P x) : False := by
+example {x : WithTop ℕ} (hx : x ≠ ⊤) (P : WithTop ℕ → Prop) (h : P x) : False := by
   lift x to ℕ using hx with u hu
   fail

--- a/MathlibTest/lift.lean
+++ b/MathlibTest/lift.lean
@@ -8,6 +8,7 @@ import Mathlib.Data.Set.Image
 import Mathlib.Data.Set.List
 import Mathlib.Data.Rat.Defs
 import Mathlib.Data.PNat.Defs
+import Mathlib.Order.WithBot
 
 /-! Some tests of the `lift` tactic. -/
 
@@ -219,3 +220,19 @@ example (n : ℤ) (hn : 0 < n) : True := by
   guard_hyp n : ℕ+
   guard_hyp hn : 0 < (n : ℤ)
   trivial
+
+-- https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Bug.20in.20.60lift.60.20tactic.3F/near/508521400
+/--
+error: tactic 'fail' failed
+case intro
+x : WithTop ℕ
+P : WithTop ℕ → Prop
+u : ℕ
+hu : ↑u = x
+h : P ↑u
+⊢ False
+-/
+#guard_msgs in
+lemma k {x : WithTop ℕ} (hx : x ≠ ⊤) (P : WithTop ℕ → Prop) (h : P x) : False := by
+  lift x to ℕ using hx with u hu
+  fail


### PR DESCRIPTION
The `lift` tactic previously called `simp only [h_eq] at h h` instead of `simp only [h_eq] at h` when rewriting a local hypothesis `h` with `h_eq : old_value = ↑lifted_value`. This caused hypothesis duplication in some cases:  
[#mathlib4 > Bug in &#96;lift&#96; tactic? @ 💬](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Bug.20in.20.60lift.60.20tactic.3F/near/508521400)  

This PR removes the second `h` in the `simp` call.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
