### PR TITLE
[Merged by Bors] - chore(SimpleGraph/Prod): correct lemma names

### DIFF
--- a/Mathlib/Combinatorics/SimpleGraph/Hasse.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Hasse.lean
@@ -65,7 +65,7 @@ variable [PartialOrder α] [PartialOrder β]
 @[simp]
 theorem hasse_prod : hasse (α × β) = hasse α □ hasse β := by
   ext x y
-  simp_rw [boxProd_adj, hasse_adj, Prod.covBy_iff, or_and_right, @eq_comm _ y.1, @eq_comm _ y.2,
+  simp_rw [adj_boxProd, hasse_adj, Prod.covBy_iff, or_and_right, @eq_comm _ y.1, @eq_comm _ y.2,
     or_or_or_comm]
 
 end PartialOrder

--- a/Mathlib/Combinatorics/SimpleGraph/Hasse.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Hasse.lean
@@ -65,7 +65,7 @@ variable [PartialOrder α] [PartialOrder β]
 @[simp]
 theorem hasse_prod : hasse (α × β) = hasse α □ hasse β := by
   ext x y
-  simp_rw [adj_boxProd, hasse_adj, Prod.covBy_iff, or_and_right, @eq_comm _ y.1, @eq_comm _ y.2,
+  simp_rw [boxProd_adj, hasse_adj, Prod.covBy_iff, or_and_right, @eq_comm _ y.1, @eq_comm _ y.2,
     or_or_or_comm]
 
 end PartialOrder

--- a/Mathlib/Combinatorics/SimpleGraph/Prod.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Prod.lean
@@ -62,7 +62,7 @@ theorem neighborSet_boxProd (x : α × β) :
   simp only [mem_neighborSet, Set.mem_union, boxProd_adj, Set.mem_prod, Set.mem_singleton_iff]
   simp only [eq_comm, and_comm]
 
-@[deprecated (since := "2025-04-22")] alias boxProd_neighborSet := neighborSet_boxProd
+@[deprecated (since := "2025-05-08")] alias boxProd_neighborSet := neighborSet_boxProd
 
 variable (G H)
 
@@ -207,7 +207,7 @@ protected theorem Connected.ofBoxProdRight (h : (G □ H).Connected) : H.Connect
 theorem connected_boxProd : (G □ H).Connected ↔ G.Connected ∧ H.Connected :=
   ⟨fun h => ⟨h.ofBoxProdLeft, h.ofBoxProdRight⟩, fun h => h.1.boxProd h.2⟩
 
-@[deprecated (since := "2025-04-22")] alias boxProd_connected := connected_boxProd
+@[deprecated (since := "2025-05-08")] alias boxProd_connected := connected_boxProd
 
 instance boxProdFintypeNeighborSet (x : α × β)
     [Fintype (G.neighborSet x.1)] [Fintype (H.neighborSet x.2)] :
@@ -230,7 +230,7 @@ theorem neighborFinset_boxProd (x : α × β)
   convert_to (G □ H).neighborFinset x = _ using 2
   exact Eq.trans (Finset.map_map _ _ _) Finset.attach_map_val
 
-@[deprecated (since := "2025-04-22")] alias boxProd_neighborFinset := neighborFinset_boxProd
+@[deprecated (since := "2025-05-08")] alias boxProd_neighborFinset := neighborFinset_boxProd
 
 theorem degree_boxProd (x : α × β)
     [Fintype (G.neighborSet x.1)] [Fintype (H.neighborSet x.2)] [Fintype ((G □ H).neighborSet x)] :
@@ -238,7 +238,7 @@ theorem degree_boxProd (x : α × β)
   rw [degree, degree, degree, neighborFinset_boxProd, Finset.card_disjUnion]
   simp_rw [Finset.card_product, Finset.card_singleton, mul_one, one_mul]
 
-@[deprecated (since := "2025-04-22")] alias boxProd_degree := degree_boxProd
+@[deprecated (since := "2025-05-08")] alias boxProd_degree := degree_boxProd
 
 lemma reachable_boxProd {x y : α × β} :
     (G □ H).Reachable x y ↔ G.Reachable x.1 y.1 ∧ H.Reachable x.2 y.2 := by
@@ -249,7 +249,7 @@ lemma reachable_boxProd {x y : α × β} :
   · intro ⟨⟨w₁⟩, ⟨w₂⟩⟩
     exact ⟨(w₁.boxProdLeft _ _).append (w₂.boxProdRight _ _)⟩
 
-@[deprecated (since := "2025-04-22")] alias boxProd_reachable := reachable_boxProd
+@[deprecated (since := "2025-05-08")] alias boxProd_reachable := reachable_boxProd
 
 @[simp]
 lemma edist_boxProd (x y : α × β) :
@@ -275,6 +275,6 @@ lemma edist_boxProd (x y : α × β) :
       rw [← hw, Walk.length_boxProd]
       exact add_le_add (edist_le w.ofBoxProdLeft) (edist_le w.ofBoxProdRight)
 
-@[deprecated (since := "2025-04-22")] alias boxProd_edist := edist_boxProd
+@[deprecated (since := "2025-05-08")] alias boxProd_edist := edist_boxProd
 
 end SimpleGraph

--- a/Mathlib/Combinatorics/SimpleGraph/Prod.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Prod.lean
@@ -45,27 +45,21 @@ and `(a, b₁)` and `(a, b₂)` if `H` relates `b₁` and `b₂`. -/
 infixl:70 " □ " => boxProd
 
 @[simp]
-theorem adj_boxProd {x y : α × β} :
+theorem boxProd_adj {x y : α × β} :
     (G □ H).Adj x y ↔ G.Adj x.1 y.1 ∧ x.2 = y.2 ∨ H.Adj x.2 y.2 ∧ x.1 = y.1 :=
   Iff.rfl
 
-@[deprecated (since := "2025-03-29")] alias boxProd_adj := adj_boxProd
-
-theorem adj_boxProd_left {a₁ : α} {b : β} {a₂ : α} :
+theorem boxProd_adj_left {a₁ : α} {b : β} {a₂ : α} :
     (G □ H).Adj (a₁, b) (a₂, b) ↔ G.Adj a₁ a₂ := by
-  simp only [adj_boxProd, and_true, SimpleGraph.irrefl, false_and, or_false]
+  simp only [boxProd_adj, and_true, SimpleGraph.irrefl, false_and, or_false]
 
-@[deprecated (since := "2025-03-29")] alias boxProd_adj_left := adj_boxProd_left
-
-theorem adj_boxProd_right {a : α} {b₁ b₂ : β} : (G □ H).Adj (a, b₁) (a, b₂) ↔ H.Adj b₁ b₂ := by
-  simp only [adj_boxProd, SimpleGraph.irrefl, false_and, and_true, false_or]
-
-@[deprecated (since := "2025-03-29")] alias boxProd_adj_right := adj_boxProd_right
+theorem boxProd_adj_right {a : α} {b₁ b₂ : β} : (G □ H).Adj (a, b₁) (a, b₂) ↔ H.Adj b₁ b₂ := by
+  simp only [boxProd_adj, SimpleGraph.irrefl, false_and, and_true, false_or]
 
 theorem neighborSet_boxProd (x : α × β) :
     (G □ H).neighborSet x = G.neighborSet x.1 ×ˢ {x.2} ∪ {x.1} ×ˢ H.neighborSet x.2 := by
   ext ⟨a', b'⟩
-  simp only [mem_neighborSet, Set.mem_union, adj_boxProd, Set.mem_prod, Set.mem_singleton_iff]
+  simp only [mem_neighborSet, Set.mem_union, boxProd_adj, Set.mem_prod, Set.mem_singleton_iff]
   simp only [eq_comm, and_comm]
 
 @[deprecated (since := "2025-03-29")] alias boxProd_neighborSet := neighborSet_boxProd
@@ -80,7 +74,7 @@ def boxProdComm : G □ H ≃g H □ G := ⟨Equiv.prodComm _ _, or_comm⟩
 @[simps!]
 def boxProdAssoc (I : SimpleGraph γ) : G □ H □ I ≃g G □ (H □ I) :=
   ⟨Equiv.prodAssoc _ _ _, fun {x y} => by
-    simp only [adj_boxProd, Equiv.prodAssoc_apply, or_and_right, or_assoc, Prod.ext_iff,
+    simp only [boxProd_adj, Equiv.prodAssoc_apply, or_and_right, or_assoc, Prod.ext_iff,
       and_assoc, @and_comm (x.fst.fst = _)]⟩
 
 /-- The embedding of `G` into `G □ H` given by `b`. -/
@@ -88,14 +82,14 @@ def boxProdAssoc (I : SimpleGraph γ) : G □ H □ I ≃g G □ (H □ I) :=
 def boxProdLeft (b : β) : G ↪g G □ H where
   toFun a := (a, b)
   inj' _ _ := congr_arg Prod.fst
-  map_rel_iff' {_ _} := adj_boxProd_left
+  map_rel_iff' {_ _} := boxProd_adj_left
 
 /-- The embedding of `H` into `G □ H` given by `a`. -/
 @[simps]
 def boxProdRight (a : α) : H ↪g G □ H where
   toFun := Prod.mk a
   inj' _ _ := congr_arg Prod.snd
-  map_rel_iff' {_ _} := adj_boxProd_right
+  map_rel_iff' {_ _} := boxProd_adj_right
 
 namespace Walk
 
@@ -223,7 +217,7 @@ instance boxProdFintypeNeighborSet (x : α × β)
         Finset.disjoint_product.mpr <| Or.inl <| neighborFinset_disjoint_singleton _ _)
     ((Equiv.refl _).subtypeEquiv fun y => by
       simp_rw [Finset.mem_disjUnion, Finset.mem_product, Finset.mem_singleton, mem_neighborFinset,
-        mem_neighborSet, Equiv.refl_apply, adj_boxProd]
+        mem_neighborSet, Equiv.refl_apply, boxProd_adj]
       simp only [eq_comm, and_comm])
 
 theorem neighborFinset_boxProd (x : α × β)

--- a/Mathlib/Combinatorics/SimpleGraph/Prod.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Prod.lean
@@ -257,7 +257,7 @@ lemma edist_boxProd (x y : α × β) :
   classical
   -- The case `(G □ H).edist x y = ⊤` is used twice, so better to factor it out.
   have top_case : (G □ H).edist x y = ⊤ ↔ G.edist x.1 y.1 = ⊤ ∨ H.edist x.2 y.2 = ⊤ := by
-    simp_rw [← not_ne_iff, edist_ne_top_iff_reachable, boxProd_reachable, not_and_or]
+    simp_rw [← not_ne_iff, edist_ne_top_iff_reachable, reachable_boxProd, not_and_or]
   by_cases h : (G □ H).edist x y = ⊤
   · rw [top_case] at h
     aesop

--- a/Mathlib/Combinatorics/SimpleGraph/Prod.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Prod.lean
@@ -62,7 +62,7 @@ theorem neighborSet_boxProd (x : α × β) :
   simp only [mem_neighborSet, Set.mem_union, boxProd_adj, Set.mem_prod, Set.mem_singleton_iff]
   simp only [eq_comm, and_comm]
 
-@[deprecated (since := "2025-03-29")] alias boxProd_neighborSet := neighborSet_boxProd
+@[deprecated (since := "2025-04-22")] alias boxProd_neighborSet := neighborSet_boxProd
 
 variable (G H)
 
@@ -207,7 +207,7 @@ protected theorem Connected.ofBoxProdRight (h : (G □ H).Connected) : H.Connect
 theorem connected_boxProd : (G □ H).Connected ↔ G.Connected ∧ H.Connected :=
   ⟨fun h => ⟨h.ofBoxProdLeft, h.ofBoxProdRight⟩, fun h => h.1.boxProd h.2⟩
 
-@[deprecated (since := "2025-03-29")] alias boxProd_connected := connected_boxProd
+@[deprecated (since := "2025-04-22")] alias boxProd_connected := connected_boxProd
 
 instance boxProdFintypeNeighborSet (x : α × β)
     [Fintype (G.neighborSet x.1)] [Fintype (H.neighborSet x.2)] :
@@ -230,7 +230,7 @@ theorem neighborFinset_boxProd (x : α × β)
   convert_to (G □ H).neighborFinset x = _ using 2
   exact Eq.trans (Finset.map_map _ _ _) Finset.attach_map_val
 
-@[deprecated (since := "2025-03-29")] alias boxProd_neighborFinset := neighborFinset_boxProd
+@[deprecated (since := "2025-04-22")] alias boxProd_neighborFinset := neighborFinset_boxProd
 
 theorem degree_boxProd (x : α × β)
     [Fintype (G.neighborSet x.1)] [Fintype (H.neighborSet x.2)] [Fintype ((G □ H).neighborSet x)] :
@@ -238,7 +238,7 @@ theorem degree_boxProd (x : α × β)
   rw [degree, degree, degree, neighborFinset_boxProd, Finset.card_disjUnion]
   simp_rw [Finset.card_product, Finset.card_singleton, mul_one, one_mul]
 
-@[deprecated (since := "2025-03-29")] alias boxProd_degree := degree_boxProd
+@[deprecated (since := "2025-04-22")] alias boxProd_degree := degree_boxProd
 
 lemma reachable_boxProd {x y : α × β} :
     (G □ H).Reachable x y ↔ G.Reachable x.1 y.1 ∧ H.Reachable x.2 y.2 := by

--- a/Mathlib/Combinatorics/SimpleGraph/Prod.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Prod.lean
@@ -249,6 +249,8 @@ lemma reachable_boxProd {x y : α × β} :
   · intro ⟨⟨w₁⟩, ⟨w₂⟩⟩
     exact ⟨(w₁.boxProdLeft _ _).append (w₂.boxProdRight _ _)⟩
 
+@[deprecated (since := "2025-04-22")] alias boxProd_reachable := reachable_boxProd
+
 @[simp]
 lemma edist_boxProd (x y : α × β) :
     (G □ H).edist x y = G.edist x.1 y.1 + H.edist x.2 y.2 := by
@@ -272,5 +274,7 @@ lemma edist_boxProd (x y : α × β) :
     · have ⟨w, hw⟩ := exists_walk_of_edist_ne_top h
       rw [← hw, Walk.length_boxProd]
       exact add_le_add (edist_le w.ofBoxProdLeft) (edist_le w.ofBoxProdRight)
+
+@[deprecated (since := "2025-04-22")] alias boxProd_edist := edist_boxProd
 
 end SimpleGraph

--- a/Mathlib/Combinatorics/SimpleGraph/Prod.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Prod.lean
@@ -240,7 +240,7 @@ theorem degree_boxProd (x : α × β)
 
 @[deprecated (since := "2025-03-29")] alias boxProd_degree := degree_boxProd
 
-lemma boxProd_reachable {x y : α × β} :
+lemma reachable_boxProd {x y : α × β} :
     (G □ H).Reachable x y ↔ G.Reachable x.1 y.1 ∧ H.Reachable x.2 y.2 := by
   classical
   constructor
@@ -250,7 +250,7 @@ lemma boxProd_reachable {x y : α × β} :
     exact ⟨(w₁.boxProdLeft _ _).append (w₂.boxProdRight _ _)⟩
 
 @[simp]
-lemma boxProd_edist (x y : α × β) :
+lemma edist_boxProd (x y : α × β) :
     (G □ H).edist x y = G.edist x.1 y.1 + H.edist x.2 y.2 := by
   classical
   -- The case `(G □ H).edist x y = ⊤` is used twice, so better to factor it out.

--- a/Mathlib/Combinatorics/SimpleGraph/Prod.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Prod.lean
@@ -45,21 +45,21 @@ and `(a, b₁)` and `(a, b₂)` if `H` relates `b₁` and `b₂`. -/
 infixl:70 " □ " => boxProd
 
 @[simp]
-theorem boxProd_adj {x y : α × β} :
+theorem adj_boxProd {x y : α × β} :
     (G □ H).Adj x y ↔ G.Adj x.1 y.1 ∧ x.2 = y.2 ∨ H.Adj x.2 y.2 ∧ x.1 = y.1 :=
   Iff.rfl
 
-theorem boxProd_adj_left {a₁ : α} {b : β} {a₂ : α} :
+theorem adj_boxProd_left {a₁ : α} {b : β} {a₂ : α} :
     (G □ H).Adj (a₁, b) (a₂, b) ↔ G.Adj a₁ a₂ := by
-  simp only [boxProd_adj, and_true, SimpleGraph.irrefl, false_and, or_false]
+  simp only [adj_boxProd, and_true, SimpleGraph.irrefl, false_and, or_false]
 
-theorem boxProd_adj_right {a : α} {b₁ b₂ : β} : (G □ H).Adj (a, b₁) (a, b₂) ↔ H.Adj b₁ b₂ := by
-  simp only [boxProd_adj, SimpleGraph.irrefl, false_and, and_true, false_or]
+theorem adj_boxProd_right {a : α} {b₁ b₂ : β} : (G □ H).Adj (a, b₁) (a, b₂) ↔ H.Adj b₁ b₂ := by
+  simp only [adj_boxProd, SimpleGraph.irrefl, false_and, and_true, false_or]
 
-theorem boxProd_neighborSet (x : α × β) :
+theorem neighborSet_boxProd (x : α × β) :
     (G □ H).neighborSet x = G.neighborSet x.1 ×ˢ {x.2} ∪ {x.1} ×ˢ H.neighborSet x.2 := by
   ext ⟨a', b'⟩
-  simp only [mem_neighborSet, Set.mem_union, boxProd_adj, Set.mem_prod, Set.mem_singleton_iff]
+  simp only [mem_neighborSet, Set.mem_union, adj_boxProd, Set.mem_prod, Set.mem_singleton_iff]
   simp only [eq_comm, and_comm]
 
 variable (G H)
@@ -72,7 +72,7 @@ def boxProdComm : G □ H ≃g H □ G := ⟨Equiv.prodComm _ _, or_comm⟩
 @[simps!]
 def boxProdAssoc (I : SimpleGraph γ) : G □ H □ I ≃g G □ (H □ I) :=
   ⟨Equiv.prodAssoc _ _ _, fun {x y} => by
-    simp only [boxProd_adj, Equiv.prodAssoc_apply, or_and_right, or_assoc, Prod.ext_iff,
+    simp only [adj_boxProd, Equiv.prodAssoc_apply, or_and_right, or_assoc, Prod.ext_iff,
       and_assoc, @and_comm (x.fst.fst = _)]⟩
 
 /-- The embedding of `G` into `G □ H` given by `b`. -/
@@ -80,14 +80,14 @@ def boxProdAssoc (I : SimpleGraph γ) : G □ H □ I ≃g G □ (H □ I) :=
 def boxProdLeft (b : β) : G ↪g G □ H where
   toFun a := (a, b)
   inj' _ _ := congr_arg Prod.fst
-  map_rel_iff' {_ _} := boxProd_adj_left
+  map_rel_iff' {_ _} := adj_boxProd_left
 
 /-- The embedding of `H` into `G □ H` given by `a`. -/
 @[simps]
 def boxProdRight (a : α) : H ↪g G □ H where
   toFun := Prod.mk a
   inj' _ _ := congr_arg Prod.snd
-  map_rel_iff' {_ _} := boxProd_adj_right
+  map_rel_iff' {_ _} := adj_boxProd_right
 
 namespace Walk
 
@@ -133,7 +133,7 @@ theorem ofBoxProdLeft_boxProdLeft [DecidableEq β] [DecidableRel G.Adj] {a₁ a�
     · exact ⟨h, rfl⟩
 
 @[simp]
-theorem ofBoxProdLeft_boxProdRight [DecidableEq α] [DecidableRel G.Adj] {a b₁ b₂ : α} :
+theorem ofBoxProdRight_boxProdRight [DecidableEq α] [DecidableRel G.Adj] {a b₁ b₂ : α} :
     ∀ (w : G.Walk b₁ b₂), (w.boxProdRight G a).ofBoxProdRight = w
   | nil => rfl
   | cons' x y z h w => by
@@ -199,7 +199,7 @@ protected theorem Connected.ofBoxProdRight (h : (G □ H).Connected) : H.Connect
   exact ⟨h.preconnected.ofBoxProdRight⟩
 
 @[simp]
-theorem boxProd_connected : (G □ H).Connected ↔ G.Connected ∧ H.Connected :=
+theorem connected_boxProd : (G □ H).Connected ↔ G.Connected ∧ H.Connected :=
   ⟨fun h => ⟨h.ofBoxProdLeft, h.ofBoxProdRight⟩, fun h => h.1.boxProd h.2⟩
 
 instance boxProdFintypeNeighborSet (x : α × β)
@@ -210,10 +210,10 @@ instance boxProdFintypeNeighborSet (x : α × β)
         Finset.disjoint_product.mpr <| Or.inl <| neighborFinset_disjoint_singleton _ _)
     ((Equiv.refl _).subtypeEquiv fun y => by
       simp_rw [Finset.mem_disjUnion, Finset.mem_product, Finset.mem_singleton, mem_neighborFinset,
-        mem_neighborSet, Equiv.refl_apply, boxProd_adj]
+        mem_neighborSet, Equiv.refl_apply, adj_boxProd]
       simp only [eq_comm, and_comm])
 
-theorem boxProd_neighborFinset (x : α × β)
+theorem neighborFinset_boxProd (x : α × β)
     [Fintype (G.neighborSet x.1)] [Fintype (H.neighborSet x.2)] [Fintype ((G □ H).neighborSet x)] :
     (G □ H).neighborFinset x =
       (G.neighborFinset x.1 ×ˢ {x.2}).disjUnion ({x.1} ×ˢ H.neighborFinset x.2)
@@ -223,10 +223,10 @@ theorem boxProd_neighborFinset (x : α × β)
   convert_to (G □ H).neighborFinset x = _ using 2
   exact Eq.trans (Finset.map_map _ _ _) Finset.attach_map_val
 
-theorem boxProd_degree (x : α × β)
+theorem degree_boxProd (x : α × β)
     [Fintype (G.neighborSet x.1)] [Fintype (H.neighborSet x.2)] [Fintype ((G □ H).neighborSet x)] :
     (G □ H).degree x = G.degree x.1 + H.degree x.2 := by
-  rw [degree, degree, degree, boxProd_neighborFinset, Finset.card_disjUnion]
+  rw [degree, degree, degree, neighborFinset_boxProd, Finset.card_disjUnion]
   simp_rw [Finset.card_product, Finset.card_singleton, mul_one, one_mul]
 
 lemma boxProd_reachable {x y : α × β} :

--- a/Mathlib/Combinatorics/SimpleGraph/Prod.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Prod.lean
@@ -49,18 +49,26 @@ theorem adj_boxProd {x y : α × β} :
     (G □ H).Adj x y ↔ G.Adj x.1 y.1 ∧ x.2 = y.2 ∨ H.Adj x.2 y.2 ∧ x.1 = y.1 :=
   Iff.rfl
 
+@[deprecated (since := "2025-03-29")] alias boxProd_adj := adj_boxProd
+
 theorem adj_boxProd_left {a₁ : α} {b : β} {a₂ : α} :
     (G □ H).Adj (a₁, b) (a₂, b) ↔ G.Adj a₁ a₂ := by
   simp only [adj_boxProd, and_true, SimpleGraph.irrefl, false_and, or_false]
 
+@[deprecated (since := "2025-03-29")] alias boxProd_adj_left := adj_boxProd_left
+
 theorem adj_boxProd_right {a : α} {b₁ b₂ : β} : (G □ H).Adj (a, b₁) (a, b₂) ↔ H.Adj b₁ b₂ := by
   simp only [adj_boxProd, SimpleGraph.irrefl, false_and, and_true, false_or]
+
+@[deprecated (since := "2025-03-29")] alias boxProd_adj_right := adj_boxProd_right
 
 theorem neighborSet_boxProd (x : α × β) :
     (G □ H).neighborSet x = G.neighborSet x.1 ×ˢ {x.2} ∪ {x.1} ×ˢ H.neighborSet x.2 := by
   ext ⟨a', b'⟩
   simp only [mem_neighborSet, Set.mem_union, adj_boxProd, Set.mem_prod, Set.mem_singleton_iff]
   simp only [eq_comm, and_comm]
+
+@[deprecated (since := "2025-03-29")] alias boxProd_neighborSet := neighborSet_boxProd
 
 variable (G H)
 
@@ -139,8 +147,11 @@ theorem ofBoxProdRight_boxProdRight [DecidableEq α] [DecidableRel G.Adj] {a b�
   | cons' x y z h w => by
     rw [Walk.boxProdRight, map_cons, ofBoxProdRight, Or.by_cases, dif_pos, ←
       Walk.boxProdRight]
-    · simp [ofBoxProdLeft_boxProdRight]
+    · simp [ofBoxProdRight_boxProdRight]
     · exact ⟨h, rfl⟩
+
+@[deprecated (since := "2025-03-30")]
+alias ofBoxProdLeft_boxProdRight := ofBoxProdRight_boxProdRight
 
 lemma length_boxProd {a₁ a₂ : α} {b₁ b₂ : β} [DecidableEq α] [DecidableEq β]
     [DecidableRel G.Adj] [DecidableRel H.Adj] (w : (G □ H).Walk (a₁, b₁) (a₂, b₂)) :
@@ -202,6 +213,8 @@ protected theorem Connected.ofBoxProdRight (h : (G □ H).Connected) : H.Connect
 theorem connected_boxProd : (G □ H).Connected ↔ G.Connected ∧ H.Connected :=
   ⟨fun h => ⟨h.ofBoxProdLeft, h.ofBoxProdRight⟩, fun h => h.1.boxProd h.2⟩
 
+@[deprecated (since := "2025-03-29")] alias boxProd_connected := connected_boxProd
+
 instance boxProdFintypeNeighborSet (x : α × β)
     [Fintype (G.neighborSet x.1)] [Fintype (H.neighborSet x.2)] :
     Fintype ((G □ H).neighborSet x) :=
@@ -223,11 +236,15 @@ theorem neighborFinset_boxProd (x : α × β)
   convert_to (G □ H).neighborFinset x = _ using 2
   exact Eq.trans (Finset.map_map _ _ _) Finset.attach_map_val
 
+@[deprecated (since := "2025-03-29")] alias boxProd_neighborFinset := neighborFinset_boxProd
+
 theorem degree_boxProd (x : α × β)
     [Fintype (G.neighborSet x.1)] [Fintype (H.neighborSet x.2)] [Fintype ((G □ H).neighborSet x)] :
     (G □ H).degree x = G.degree x.1 + H.degree x.2 := by
   rw [degree, degree, degree, neighborFinset_boxProd, Finset.card_disjUnion]
   simp_rw [Finset.card_product, Finset.card_singleton, mul_one, one_mul]
+
+@[deprecated (since := "2025-03-29")] alias boxProd_degree := degree_boxProd
 
 lemma boxProd_reachable {x y : α × β} :
     (G □ H).Reachable x y ↔ G.Reachable x.1 y.1 ∧ H.Reachable x.2 y.2 := by


### PR DESCRIPTION
The head function should come first in the name even if dot notation is used.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->
In the future, we might want to rename `boxProd_adj` to `adj_boxProd`:
1. If we apply the basic algorithm from Std (https://github.com/leanprover/lean4/blob/master/doc/std/naming.md#naming-algorithm-for-theorems-and-some-definitions), we encounter `Adj` first, so we write it first.
2. The mathlib-specific algorithm says that most predicates should be prefixed: https://leanprover-community.github.io/contribute/naming.html#predicates-as-suffixes
3. Dot notation isn't an infix operator, although we can of course decide on a case by case basis that a specific function we are dot notating on is actually an infix.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
