### PR TITLE
[Merged by Bors] - chore(CategoryTheory/Limits/IsConnected): remove unnecessary parentheses from #23410

### DIFF
--- a/Mathlib/CategoryTheory/Limits/IsConnected.lean
+++ b/Mathlib/CategoryTheory/Limits/IsConnected.lean
@@ -163,10 +163,10 @@ lemma isConnected_of_isTerminal {x : C} (h : Limits.IsTerminal x) : IsConnected 
 
 -- note : it seems making the following two as instances breaks things, so these are lemmas.
 lemma isConnected_of_hasInitial [Limits.HasInitial C] : IsConnected C :=
-  isConnected_of_isInitial C (Limits.initialIsInitial)
+  isConnected_of_isInitial C Limits.initialIsInitial
 
 lemma isConnected_of_hasTerminal [Limits.HasTerminal C] : IsConnected C :=
-  isConnected_of_isTerminal C (Limits.terminalIsTerminal)
+  isConnected_of_isTerminal C Limits.terminalIsTerminal
 
 end
 


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
