### PR TITLE
[Merged by Bors] - feat(Data/List/Basic): add forall_append

### DIFF
--- a/Mathlib/Data/List/Basic.lean
+++ b/Mathlib/Data/List/Basic.lean
@@ -1231,6 +1231,12 @@ theorem forall_cons (p : α → Prop) (x : α) : ∀ l : List α, Forall p (x ::
   | [] => (and_iff_left_of_imp fun _ ↦ trivial).symm
   | _ :: _ => Iff.rfl
 
+@[simp]
+theorem forall_append {p : α → Prop} : ∀ {xs ys : List α},
+    Forall p (xs ++ ys) ↔ Forall p xs ∧ Forall p ys
+  | [] => by simp
+  | _ :: _ => by simp [forall_append, and_assoc]
+
 theorem forall_iff_forall_mem : ∀ {l : List α}, Forall p l ↔ ∀ x ∈ l, p x
   | [] => (iff_true_intro <| forall_mem_nil _).symm
   | x :: l => by rw [forall_mem_cons, forall_cons, forall_iff_forall_mem]


### PR DESCRIPTION
Add `List.forall_append`, stating that a proposition holds for all elements of the concatenation of two lists iff it holds for all elements in both lists

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->
(I am kind of surprised this didn't exist. I hope it was not because I was blind and I added a duplicate theorem)


[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
