### PR TITLE
[Merged by Bors] - feat(Data/ENat): multiplication and Inf/Sup lemmas

### DIFF
--- a/Mathlib/Data/ENat/Basic.lean
+++ b/Mathlib/Data/ENat/Basic.lean
@@ -356,7 +356,7 @@ lemma add_right_injective_of_ne_top {n : ℕ∞} (hn : n ≠ ⊤) : Function.Inj
   simp_rw [add_comm n _]
   exact add_left_injective_of_ne_top hn
 
-theorem mul_left_strictMono (ha : a ≠ 0) (h_top : a ≠ ⊤) : StrictMono (a * ·) := by
+lemma mul_left_strictMono (ha : a ≠ 0) (h_top : a ≠ ⊤) : StrictMono (a * ·) := by
   lift a to ℕ using h_top
   intro x y hxy
   induction x with
@@ -372,18 +372,18 @@ theorem mul_left_strictMono (ha : a ≠ 0) (h_top : a ≠ ⊤) : StrictMono (a *
   rw [ENat.coe_lt_coe] at hxy
   exact Nat.mul_lt_mul_of_pos_left hxy (Nat.pos_of_ne_zero (by simpa using ha))
 
-protected theorem mul_right_strictMono (ha : a ≠ 0) (h_top : a ≠ ⊤) : StrictMono (· * a) := by
+lemma mul_right_strictMono (ha : a ≠ 0) (h_top : a ≠ ⊤) : StrictMono (· * a) := by
   intro x y hxy
   simp only [mul_comm _ a]
   exact ENat.mul_left_strictMono ha h_top hxy
 
-theorem mul_le_mul_left_iff {x y : ℕ∞} (ha : a ≠ 0) (h_top : a ≠ ⊤) : a * x ≤ a * y ↔ x ≤ y :=
+lemma mul_le_mul_left_iff {x y : ℕ∞} (ha : a ≠ 0) (h_top : a ≠ ⊤) : a * x ≤ a * y ↔ x ≤ y :=
   (ENat.mul_left_strictMono ha h_top).le_iff_le
 
-theorem mul_le_mul_right_iff {x y : ℕ∞} (ha : a ≠ 0) (h_top : a ≠ ⊤) : x * a ≤ y * a ↔ x ≤ y :=
+lemma mul_le_mul_right_iff {x y : ℕ∞} (ha : a ≠ 0) (h_top : a ≠ ⊤) : x * a ≤ y * a ↔ x ≤ y :=
   (ENat.mul_right_strictMono ha h_top).le_iff_le
 
-theorem self_le_mul_right (a : ℕ∞) (hc : c ≠ 0) : a ≤ a * c := by
+lemma self_le_mul_right (a : ℕ∞) (hc : c ≠ 0) : a ≤ a * c := by
   obtain rfl | hne := eq_or_ne a ⊤
   · simp [top_mul hc]
   obtain rfl | h0 := eq_or_ne a 0
@@ -391,7 +391,7 @@ theorem self_le_mul_right (a : ℕ∞) (hc : c ≠ 0) : a ≤ a * c := by
   nth_rewrite 1 [← mul_one a, ENat.mul_le_mul_left_iff h0 hne, ENat.one_le_iff_ne_zero]
   assumption
 
-theorem self_le_mul_left (a : ℕ∞) (hc : c ≠ 0) : a ≤ c * a := by
+lemma self_le_mul_left (a : ℕ∞) (hc : c ≠ 0) : a ≤ c * a := by
   rw [mul_comm]
   exact ENat.self_le_mul_right a hc
 

--- a/Mathlib/Data/ENat/Basic.lean
+++ b/Mathlib/Data/ENat/Basic.lean
@@ -373,9 +373,7 @@ lemma mul_left_strictMono (ha : a ≠ 0) (h_top : a ≠ ⊤) : StrictMono (a * �
   exact Nat.mul_lt_mul_of_pos_left hxy (Nat.pos_of_ne_zero (by simpa using ha))
 
 lemma mul_right_strictMono (ha : a ≠ 0) (h_top : a ≠ ⊤) : StrictMono (· * a) := by
-  intro x y hxy
-  simp only [mul_comm _ a]
-  exact ENat.mul_left_strictMono ha h_top hxy
+  simpa [show (· * a) = (a * ·) by simp [mul_comm]] using mul_left_strictMono ha h_top
 
 lemma mul_le_mul_left_iff {x y : ℕ∞} (ha : a ≠ 0) (h_top : a ≠ ⊤) : a * x ≤ a * y ↔ x ≤ y :=
   (ENat.mul_left_strictMono ha h_top).le_iff_le

--- a/Mathlib/Data/ENat/Basic.lean
+++ b/Mathlib/Data/ENat/Basic.lean
@@ -86,6 +86,14 @@ theorem coe_sub (m n : ℕ) : ↑(m - n) = (m - n : ℕ∞) :=
 @[simp] theorem mul_top (hm : m ≠ 0) : m * ⊤ = ⊤ := WithTop.mul_top hm
 @[simp] theorem top_mul (hm : m ≠ 0) : ⊤ * m = ⊤ := WithTop.top_mul hm
 
+theorem top_mul_eq_ite (a : ℕ∞) : ⊤ * a = if a = 0 then 0 else ⊤ := by
+  split_ifs with h
+  · simp [h]
+  simp [top_mul h]
+
+theorem mul_top_eq_ite (a : ℕ∞) : a * ⊤ = if a = 0 then 0 else ⊤ := by
+  rw [mul_comm, ENat.top_mul_eq_ite]
+
 theorem top_pow {n : ℕ} (n_pos : 0 < n) : (⊤ : ℕ∞) ^ n = ⊤ := WithTop.top_pow n_pos
 
 /-- Convert a `ℕ∞` to a `ℕ` using a proof that it is not infinite. -/
@@ -347,6 +355,45 @@ lemma add_left_injective_of_ne_top {n : ℕ∞} (hn : n ≠ ⊤) : Function.Inje
 lemma add_right_injective_of_ne_top {n : ℕ∞} (hn : n ≠ ⊤) : Function.Injective (n + ·) := by
   simp_rw [add_comm n _]
   exact add_left_injective_of_ne_top hn
+
+theorem mul_left_strictMono (ha : a ≠ 0) (h_top : a ≠ ⊤) : StrictMono (a * ·) := by
+  lift a to ℕ using h_top
+  intro x y hxy
+  induction x with
+  | top => simp at hxy
+  | coe x =>
+  induction y with
+  | top =>
+    simp only [mul_top ha, ← ENat.coe_mul]
+    exact coe_lt_top (a * x)
+  | coe y =>
+  simp only
+  rw [← ENat.coe_mul, ← ENat.coe_mul, ENat.coe_lt_coe]
+  rw [ENat.coe_lt_coe] at hxy
+  exact Nat.mul_lt_mul_of_pos_left hxy (Nat.pos_of_ne_zero (by simpa using ha))
+
+protected theorem mul_right_strictMono (ha : a ≠ 0) (h_top : a ≠ ⊤) : StrictMono (· * a) := by
+  intro x y hxy
+  simp only [mul_comm _ a]
+  exact ENat.mul_left_strictMono ha h_top hxy
+
+theorem mul_le_mul_left_iff {x y : ℕ∞} (ha : a ≠ 0) (h_top : a ≠ ⊤) : a * x ≤ a * y ↔ x ≤ y :=
+  (ENat.mul_left_strictMono ha h_top).le_iff_le
+
+theorem mul_le_mul_right_iff {x y : ℕ∞} (ha : a ≠ 0) (h_top : a ≠ ⊤) : x * a ≤ y * a ↔ x ≤ y :=
+  (ENat.mul_right_strictMono ha h_top).le_iff_le
+
+theorem self_le_mul_right (a : ℕ∞) (hc : c ≠ 0) : a ≤ a * c := by
+  obtain rfl | hne := eq_or_ne a ⊤
+  · simp [top_mul hc]
+  obtain rfl | h0 := eq_or_ne a 0
+  · simp
+  nth_rewrite 1 [← mul_one a, ENat.mul_le_mul_left_iff h0 hne, ENat.one_le_iff_ne_zero]
+  assumption
+
+theorem self_le_mul_left (a : ℕ∞) (hc : c ≠ 0) : a ≤ c * a := by
+  rw [mul_comm]
+  exact ENat.self_le_mul_right a hc
 
 section withTop_enat
 

--- a/Mathlib/Data/ENat/Basic.lean
+++ b/Mathlib/Data/ENat/Basic.lean
@@ -373,11 +373,18 @@ lemma mul_left_strictMono (ha : a ≠ 0) (h_top : a ≠ ⊤) : StrictMono (a * �
 lemma mul_right_strictMono (ha : a ≠ 0) (h_top : a ≠ ⊤) : StrictMono (· * a) := by
   simpa [show (· * a) = (a * ·) by simp [mul_comm]] using mul_left_strictMono ha h_top
 
+@[simp]
 lemma mul_le_mul_left_iff {x y : ℕ∞} (ha : a ≠ 0) (h_top : a ≠ ⊤) : a * x ≤ a * y ↔ x ≤ y :=
   (ENat.mul_left_strictMono ha h_top).le_iff_le
 
+@[simp]
 lemma mul_le_mul_right_iff {x y : ℕ∞} (ha : a ≠ 0) (h_top : a ≠ ⊤) : x * a ≤ y * a ↔ x ≤ y :=
   (ENat.mul_right_strictMono ha h_top).le_iff_le
+
+@[gcongr]
+lemma mul_le_mul_of_le_right {x y : ℕ∞} (hxy : x ≤ y) (ha : a ≠ 0) (h_top : a ≠ ⊤) :
+    x * a ≤ y * a := by
+  simpa [ha, h_top]
 
 lemma self_le_mul_right (a : ℕ∞) (hc : c ≠ 0) : a ≤ a * c := by
   obtain rfl | hne := eq_or_ne a ⊤

--- a/Mathlib/Data/ENat/Basic.lean
+++ b/Mathlib/Data/ENat/Basic.lean
@@ -86,13 +86,11 @@ theorem coe_sub (m n : ℕ) : ↑(m - n) = (m - n : ℕ∞) :=
 @[simp] theorem mul_top (hm : m ≠ 0) : m * ⊤ = ⊤ := WithTop.mul_top hm
 @[simp] theorem top_mul (hm : m ≠ 0) : ⊤ * m = ⊤ := WithTop.top_mul hm
 
-theorem top_mul_eq_ite (a : ℕ∞) : ⊤ * a = if a = 0 then 0 else ⊤ := by
-  split_ifs with h
-  · simp [h]
-  simp [top_mul h]
+/-- A version of `mul_top` where the RHS is stated as an `ite` -/
+theorem mul_top' : m * ⊤ = if m = 0 then 0 else ⊤ := WithTop.mul_top' m
 
-theorem mul_top_eq_ite (a : ℕ∞) : a * ⊤ = if a = 0 then 0 else ⊤ := by
-  rw [mul_comm, ENat.top_mul_eq_ite]
+/-- A version of `top_mul` where the RHS is stated as an `ite` -/
+theorem top_mul' : ⊤ * m = if m = 0 then 0 else ⊤ := WithTop.top_mul' m
 
 theorem top_pow {n : ℕ} (n_pos : 0 < n) : (⊤ : ℕ∞) ^ n = ⊤ := WithTop.top_pow n_pos
 

--- a/Mathlib/Data/ENat/Lattice.lean
+++ b/Mathlib/Data/ENat/Lattice.lean
@@ -144,7 +144,7 @@ lemma mul_iSup (a : ℕ∞) (f : ι → ℕ∞) : a * ⨆ i, f i = ⨆ i, a * f 
   · simp
   obtain hι | hι := isEmpty_or_nonempty ι
   · simp
-  induction d using ENat.recTopCoe with
+  cases d with
   | top => simp
   | coe d =>
   obtain htop | hlt := (le_top (a := ⨆ i, f i)).eq_or_lt

--- a/Mathlib/Data/ENat/Lattice.lean
+++ b/Mathlib/Data/ENat/Lattice.lean
@@ -93,8 +93,7 @@ lemma exists_eq_iInf [Nonempty ι] (f : ι → ℕ∞) : ∃ a, f a = ⨅ x, f x
   intro f'
   obtain htop | hlt := eq_top_or_lt_top (⨅ x, f' x)
   · rw [htop]
-    simp only [iInf_eq_top] at htop
-    exact ⟨Classical.arbitrary _, htop _⟩
+    exact ⟨Classical.arbitrary _, iInf_eq_top.1 htop _⟩
   apply exists_eq_iInf_of_not_isPredPrelimit
   simp only [Order.IsPredPrelimit, not_forall, not_not]
   refine ⟨Order.succ (⨅ x, f' x), Order.covBy_succ_of_not_isMax fun hmax ↦ ?_⟩
@@ -176,7 +175,7 @@ lemma iInf_mul [Nonempty ι] : (⨅ i, f i) * a = ⨅ i, f i * a := by
 /-- A version of `mul_iInf` with a slightly more general hypothesis. -/
 lemma mul_iInf' (h₀ : a = 0 → Nonempty ι) : a * ⨅ i, f i = ⨅ i, a * f i := by
   obtain hι | hι := isEmpty_or_nonempty ι
-  · suffices a ≠ 0 by simpa [iInf_of_empty, ite_eq_right_iff, mul_top_eq_ite]
+  · suffices a ≠ 0 by simpa [iInf_of_empty, ite_eq_right_iff, mul_top']
     aesop
   rw [mul_iInf]
 

--- a/Mathlib/Data/ENat/Lattice.lean
+++ b/Mathlib/Data/ENat/Lattice.lean
@@ -173,12 +173,14 @@ lemma mul_iInf [Nonempty ι] : a * ⨅ i, f i = ⨅ i, a * f i := by
 lemma iInf_mul [Nonempty ι] : (⨅ i, f i) * a = ⨅ i, f i * a := by
   simp_rw [mul_comm, mul_iInf]
 
+/-- A version of `mul_iInf` with a slightly more general hypothesis. -/
 lemma mul_iInf' (h₀ : a = 0 → Nonempty ι) : a * ⨅ i, f i = ⨅ i, a * f i := by
   obtain hι | hι := isEmpty_or_nonempty ι
   · suffices a ≠ 0 by simpa [iInf_of_empty, ite_eq_right_iff, mul_top_eq_ite]
     aesop
   rw [mul_iInf]
 
+/-- A version of `iInf_mul` with a slightly more general hypothesis. -/
 lemma iInf_mul' (h₀ : a = 0 → Nonempty ι) : (⨅ i, f i) * a = ⨅ i, f i * a := by
   simp_rw [mul_comm, mul_iInf' h₀]
 

--- a/Mathlib/Data/ENat/Lattice.lean
+++ b/Mathlib/Data/ENat/Lattice.lean
@@ -87,16 +87,12 @@ lemma sSup_eq_zero' : sSup s = 0 ↔ s = ∅ ∨ s = {0} :=
 @[simp] lemma iSup_zero : ⨆ _ : ι, (0 : ℕ∞) = 0 := by simp
 
 lemma exists_eq_iInf [Nonempty ι] (f : ι → ℕ∞) : ∃ a, f a = ⨅ x, f x := by
-  suffices aux : ∀ f' : PLift ι → ℕ∞, ∃ a, f' a = ⨅ x, f' x by
-    obtain ⟨a, ha⟩ := aux (fun i ↦ f i.down)
-    exact ⟨a.down, by rw [ha, iInf_plift_down]⟩
-  intro f'
-  obtain htop | hlt := eq_top_or_lt_top (⨅ x, f' x)
+  obtain htop | hlt := eq_top_or_lt_top (⨅ x, f x)
   · rw [htop]
     exact ⟨Classical.arbitrary _, iInf_eq_top.1 htop _⟩
   apply exists_eq_iInf_of_not_isPredPrelimit
   simp only [Order.IsPredPrelimit, not_forall, not_not]
-  refine ⟨Order.succ (⨅ x, f' x), Order.covBy_succ_of_not_isMax fun hmax ↦ ?_⟩
+  refine ⟨Order.succ (⨅ x, f x), Order.covBy_succ_of_not_isMax fun hmax ↦ ?_⟩
   simp only [isMax_iff_eq_top, iInf_eq_top] at hmax
   simp [hmax] at hlt
 

--- a/Mathlib/Data/ENat/Lattice.lean
+++ b/Mathlib/Data/ENat/Lattice.lean
@@ -3,9 +3,10 @@ Copyright (c) 2022 Yury Kudryashov. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury Kudryashov
 -/
+import Mathlib.Algebra.Group.Action.Defs
 import Mathlib.Data.Nat.Lattice
 import Mathlib.Data.ENat.Basic
-import Mathlib.Algebra.Group.Action.Defs
+import Mathlib.Order.SuccPred.CompleteLinearOrder
 
 /-!
 # Extended natural numbers form a complete linear order
@@ -85,6 +86,21 @@ lemma sSup_eq_zero' : sSup s = 0 ↔ s = ∅ ∨ s = {0} :=
 @[simp] lemma iSup_eq_zero : iSup f = 0 ↔ ∀ i, f i = 0 := iSup_eq_bot
 @[simp] lemma iSup_zero : ⨆ _ : ι, (0 : ℕ∞) = 0 := by simp
 
+lemma exists_eq_iInf [Nonempty ι] (f : ι → ℕ∞) : ∃ a, f a = ⨅ x, f x := by
+  suffices aux : ∀ f' : PLift ι → ℕ∞, ∃ a, f' a = ⨅ x, f' x by
+    obtain ⟨a, ha⟩ := aux (fun i ↦ f i.down)
+    exact ⟨a.down, by rw [ha, iInf_plift_down]⟩
+  intro f'
+  obtain htop | hlt := eq_top_or_lt_top (⨅ x, f' x)
+  · rw [htop]
+    simp only [iInf_eq_top] at htop
+    exact ⟨Classical.arbitrary _, htop _⟩
+  apply exists_eq_iInf_of_not_isPredPrelimit
+  simp only [Order.IsPredPrelimit, not_forall, not_not]
+  refine ⟨Order.succ (⨅ x, f' x), Order.covBy_succ_of_not_isMax fun hmax ↦ ?_⟩
+  simp only [isMax_iff_eq_top, iInf_eq_top] at hmax
+  simp [hmax] at hlt
+
 lemma sSup_eq_top_of_infinite (h : s.Infinite) : sSup s = ⊤ := by
   apply (sSup_eq_top ..).mpr
   intro x hx
@@ -122,26 +138,59 @@ variable {ι κ : Sort*} {f g : ι → ℕ∞} {s : Set ℕ∞} {a : ℕ∞}
 lemma iSup_natCast : ⨆ n : ℕ, (n : ℕ∞) = ⊤ :=
   (iSup_eq_top _).2 fun _b hb ↦ ENat.exists_nat_gt (lt_top_iff_ne_top.1 hb)
 
-proof_wanted mul_iSup (a : ℕ∞) (f : ι → ℕ∞) : a * ⨆ i, f i = ⨆ i, a * f i
-proof_wanted iSup_mul (f : ι → ℕ∞) (a : ℕ∞) : (⨆ i, f i) * a = ⨆ i, f i * a
-proof_wanted mul_sSup : a * sSup s = ⨆ b ∈ s, a * b
-proof_wanted sSup_mul : sSup s * a = ⨆ b ∈ s, b * a
+lemma mul_iSup (a : ℕ∞) (f : ι → ℕ∞) : a * ⨆ i, f i = ⨆ i, a * f i := by
+  refine (iSup_le fun i ↦ mul_le_mul' rfl.le <| le_iSup_iff.2 fun _ a ↦ a i).antisymm' <|
+    le_iSup_iff.2 fun d h ↦ ?_
+  obtain rfl | hne := eq_or_ne a 0
+  · simp
+  obtain hι | hι := isEmpty_or_nonempty ι
+  · simp
+  induction d using ENat.recTopCoe with
+  | top => simp
+  | coe d =>
+  obtain htop | hlt := (le_top (a := ⨆ i, f i)).eq_or_lt
+  · obtain ⟨i, hi : d < f i⟩ := (iSup_eq_top ..).1 htop d (by simp)
+    exact False.elim <| (((h i).trans_lt hi).trans_le (ENat.self_le_mul_left _ hne)).ne rfl
+  obtain ⟨j, hj⟩ := exists_eq_iSup_of_lt_top hlt
+  rw [← hj]
+  apply h
 
-proof_wanted mul_iInf' (_h₀ : a = 0 → Nonempty ι) :
-    a * ⨅ i, f i = ⨅ i, a * f i
+lemma iSup_mul (f : ι → ℕ∞) (a : ℕ∞) : (⨆ i, f i) * a = ⨆ i, f i * a := by
+  simp_rw [mul_comm, ENat.mul_iSup]
 
-proof_wanted iInf_mul' (_h₀ : a = 0 → Nonempty ι) : (⨅ i, f i) * a = ⨅ i, f i * a
+lemma mul_sSup : a * sSup s = ⨆ b ∈ s, a * b := by
+  simp_rw [sSup_eq_iSup, mul_iSup]
 
-/-- If `a ≠ 0` and `a ≠ ⊤`, then right multiplication by `a` maps infimum to infimum.
-See also `ENNReal.iInf_mul` that assumes `[Nonempty ι]` but does not require `a ≠ 0`. -/
-proof_wanted mul_iInf_of_ne (_ha₀ : a ≠ 0) (_ha : a ≠ ⊤) : a * ⨅ i, f i = ⨅ i, a * f i
+lemma sSup_mul : sSup s * a = ⨆ b ∈ s, b * a := by
+  simp_rw [mul_comm, mul_sSup]
 
-/-- If `a ≠ 0` and `a ≠ ⊤`, then right multiplication by `a` maps infimum to infimum.
-See also `ENNReal.iInf_mul` that assumes `[Nonempty ι]` but does not require `a ≠ 0`. -/
-proof_wanted iInf_mul_of_ne (_ha₀ : a ≠ 0) (_ha : a ≠ ⊤) : (⨅ i, f i) * a = ⨅ i, f i * a
+lemma mul_iInf [Nonempty ι] : a * ⨅ i, f i = ⨅ i, a * f i := by
+  refine (le_iInf fun x ↦ (mul_le_mul_left' (iInf_le ..) a)).antisymm ?_
+  obtain ⟨b, hb⟩ := ENat.exists_eq_iInf f
+  rw [← hb, iInf_le_iff]
+  exact fun x h ↦ h _
 
-proof_wanted mul_iInf [Nonempty ι] : a * ⨅ i, f i = ⨅ i, a * f i
-proof_wanted iInf_mul [Nonempty ι] : (⨅ i, f i) * a = ⨅ i, f i * a
+lemma iInf_mul [Nonempty ι] : (⨅ i, f i) * a = ⨅ i, f i * a := by
+  simp_rw [mul_comm, mul_iInf]
+
+lemma mul_iInf' (h₀ : a = 0 → Nonempty ι) : a * ⨅ i, f i = ⨅ i, a * f i := by
+  obtain hι | hι := isEmpty_or_nonempty ι
+  · suffices a ≠ 0 by simpa [iInf_of_empty, ite_eq_right_iff, mul_top_eq_ite]
+    aesop
+  rw [mul_iInf]
+
+lemma iInf_mul' (h₀ : a = 0 → Nonempty ι) : (⨅ i, f i) * a = ⨅ i, f i * a := by
+  simp_rw [mul_comm, mul_iInf' h₀]
+
+/-- If `a ≠ 0`, then right multiplication by `a` maps infimum to infimum.
+See also `ENat.iInf_mul` that assumes `[Nonempty ι]` but does not require `a ≠ 0`. -/
+lemma mul_iInf_of_ne (ha₀ : a ≠ 0) : a * ⨅ i, f i = ⨅ i, a * f i :=
+  mul_iInf' <| by simp [ha₀]
+
+/-- If `a ≠ 0`, then right multiplication by `a` maps infimum to infimum.
+See also `ENat.iInf_mul` that assumes `[Nonempty ι]` but does not require `a ≠ 0`. -/
+lemma iInf_mul_of_ne (ha₀ : a ≠ 0) : (⨅ i, f i) * a = ⨅ i, f i * a :=
+  iInf_mul' <| by simp [ha₀]
 
 lemma add_iSup [Nonempty ι] (f : ι → ℕ∞) : a + ⨆ i, f i = ⨆ i, a + f i := by
   obtain rfl | ha := eq_or_ne a ⊤

--- a/Mathlib/Order/SuccPred/CompleteLinearOrder.lean
+++ b/Mathlib/Order/SuccPred/CompleteLinearOrder.lean
@@ -14,7 +14,7 @@ import Mathlib.Order.SuccPred.Limit
 
 open Order Set
 
-variable {ι α : Type*}
+variable {ι : Sort*} {α : Type*}
 
 section ConditionallyCompleteLinearOrder
 variable [ConditionallyCompleteLinearOrder α] [Nonempty ι] {f : ι → α} {s : Set α} {x : α}


### PR DESCRIPTION
We add some lemmas for multiplication and suprema/infima for `ENat`, including a handful that were stated as `proof_wanted`. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
