### PR TITLE
[Merged by Bors] - chore: avoid using typeless binders in structure fields that shadow `variable` parameters

### DIFF
--- a/Mathlib/Combinatorics/SimpleGraph/Bipartite.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Bipartite.lean
@@ -61,7 +61,7 @@ section IsBipartiteWith
 are adjacent in `G` then `v ∈ s` and `w ∈ t`, or `v ∈ t` and `w ∈ s`. -/
 structure IsBipartiteWith (G : SimpleGraph V) (s t : Set V) : Prop where
   disjoint : Disjoint s t
-  mem_of_adj ⦃v w⦄ : G.Adj v w → v ∈ s ∧ w ∈ t ∨ v ∈ t ∧ w ∈ s
+  mem_of_adj ⦃v w : _⦄ : G.Adj v w → v ∈ s ∧ w ∈ t ∨ v ∈ t ∧ w ∈ s
 
 theorem IsBipartiteWith.symm (h : G.IsBipartiteWith s t) : G.IsBipartiteWith t s where
   disjoint := h.disjoint.symm

--- a/Mathlib/Combinatorics/SimpleGraph/Bipartite.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Bipartite.lean
@@ -61,7 +61,7 @@ section IsBipartiteWith
 are adjacent in `G` then `v ∈ s` and `w ∈ t`, or `v ∈ t` and `w ∈ s`. -/
 structure IsBipartiteWith (G : SimpleGraph V) (s t : Set V) : Prop where
   disjoint : Disjoint s t
-  mem_of_adj ⦃v w : _⦄ : G.Adj v w → v ∈ s ∧ w ∈ t ∨ v ∈ t ∧ w ∈ s
+  mem_of_adj ⦃v w : V⦄ : G.Adj v w → v ∈ s ∧ w ∈ t ∨ v ∈ t ∧ w ∈ s
 
 theorem IsBipartiteWith.symm (h : G.IsBipartiteWith s t) : G.IsBipartiteWith t s where
   disjoint := h.disjoint.symm

--- a/Mathlib/Dynamics/Ergodic/Ergodic.lean
+++ b/Mathlib/Dynamics/Ergodic/Ergodic.lean
@@ -38,7 +38,7 @@ variable {α : Type*} {m : MeasurableSpace α} {s : Set α}
 /-- A map `f : α → α` is said to be pre-ergodic with respect to a measure `μ` if any measurable
 strictly invariant set is either almost empty or full. -/
 structure PreErgodic (f : α → α) (μ : Measure α := by volume_tac) : Prop where
-  aeconst_set ⦃s⦄ : MeasurableSet s → f ⁻¹' s = s → EventuallyConst s (ae μ)
+  aeconst_set ⦃s : _⦄ : MeasurableSet s → f ⁻¹' s = s → EventuallyConst s (ae μ)
 
 /-- A map `f : α → α` is said to be ergodic with respect to a measure `μ` if it is measure
 preserving and pre-ergodic. -/

--- a/Mathlib/Dynamics/Ergodic/Ergodic.lean
+++ b/Mathlib/Dynamics/Ergodic/Ergodic.lean
@@ -38,7 +38,7 @@ variable {α : Type*} {m : MeasurableSpace α} {s : Set α}
 /-- A map `f : α → α` is said to be pre-ergodic with respect to a measure `μ` if any measurable
 strictly invariant set is either almost empty or full. -/
 structure PreErgodic (f : α → α) (μ : Measure α := by volume_tac) : Prop where
-  aeconst_set ⦃s : _⦄ : MeasurableSet s → f ⁻¹' s = s → EventuallyConst s (ae μ)
+  aeconst_set ⦃s : Set α⦄ : MeasurableSet s → f ⁻¹' s = s → EventuallyConst s (ae μ)
 
 /-- A map `f : α → α` is said to be ergodic with respect to a measure `μ` if it is measure
 preserving and pre-ergodic. -/

--- a/Mathlib/MeasureTheory/SetSemiring.lean
+++ b/Mathlib/MeasureTheory/SetSemiring.lean
@@ -441,8 +441,8 @@ end IsSetSemiring
 It is then also stable by intersection (see `IsSetRing.inter_mem`). -/
 structure IsSetRing (C : Set (Set α)) : Prop where
   empty_mem : ∅ ∈ C
-  union_mem ⦃s t : _⦄ : s ∈ C → t ∈ C → s ∪ t ∈ C
-  diff_mem ⦃s t : _⦄ : s ∈ C → t ∈ C → s \ t ∈ C
+  union_mem ⦃s t : Set α⦄ : s ∈ C → t ∈ C → s ∪ t ∈ C
+  diff_mem ⦃s t : Set α⦄ : s ∈ C → t ∈ C → s \ t ∈ C
 
 namespace IsSetRing
 

--- a/Mathlib/MeasureTheory/SetSemiring.lean
+++ b/Mathlib/MeasureTheory/SetSemiring.lean
@@ -441,8 +441,8 @@ end IsSetSemiring
 It is then also stable by intersection (see `IsSetRing.inter_mem`). -/
 structure IsSetRing (C : Set (Set α)) : Prop where
   empty_mem : ∅ ∈ C
-  union_mem ⦃s t⦄ : s ∈ C → t ∈ C → s ∪ t ∈ C
-  diff_mem ⦃s t⦄ : s ∈ C → t ∈ C → s \ t ∈ C
+  union_mem ⦃s t : _⦄ : s ∈ C → t ∈ C → s ∪ t ∈ C
+  diff_mem ⦃s t : _⦄ : s ∈ C → t ∈ C → s \ t ∈ C
 
 namespace IsSetRing
 

--- a/Mathlib/Order/DirectedInverseSystem.lean
+++ b/Mathlib/Order/DirectedInverseSystem.lean
@@ -249,8 +249,8 @@ variable (f : ∀ ⦃i j : ι⦄, i ≤ j → F j → F i) ⦃i j : ι⦄ (h : i
 /-- A inverse system indexed by a preorder is a contravariant functor from the preorder
 to another category. It is dual to `DirectedSystem`. -/
 class InverseSystem : Prop where
-  map_self ⦃i : _⦄ (x : F i) : f le_rfl x = x
-  map_map ⦃k j i : _⦄ (hkj : k ≤ j) (hji : j ≤ i) (x : F i) : f hkj (f hji x) = f (hkj.trans hji) x
+  map_self ⦃i : ι⦄ (x : F i) : f le_rfl x = x
+  map_map ⦃k j i : ι⦄ (hkj : k ≤ j) (hji : j ≤ i) (x : F i) : f hkj (f hji x) = f (hkj.trans hji) x
 
 namespace InverseSystem
 
@@ -400,7 +400,7 @@ variable [SuccOrder ι] (f) (equivSucc : ∀ ⦃i⦄, ¬IsMax i → F i⁺ ≃ F
   /-- It is a natural family of bijections. -/
   nat : IsNatEquiv f equiv
   /-- It is compatible with a family of bijections relating `F i⁺` to `F i`. -/
-  compat {i : _} (hsi : (i⁺ : ι) ∈ s) (hi : ¬IsMax i) (x) :
+  compat {i : ι} (hsi : (i⁺ : ι) ∈ s) (hi : ¬IsMax i) (x) :
     equiv ⟨i⁺, hsi⟩ x ⟨i, lt_succ_of_not_isMax hi⟩ = (equivSucc hi x).2
 
 variable {s t : Set ι} {f equivSucc} [WellFoundedLT ι]

--- a/Mathlib/Order/DirectedInverseSystem.lean
+++ b/Mathlib/Order/DirectedInverseSystem.lean
@@ -249,8 +249,8 @@ variable (f : ∀ ⦃i j : ι⦄, i ≤ j → F j → F i) ⦃i j : ι⦄ (h : i
 /-- A inverse system indexed by a preorder is a contravariant functor from the preorder
 to another category. It is dual to `DirectedSystem`. -/
 class InverseSystem : Prop where
-  map_self ⦃i⦄ (x : F i) : f le_rfl x = x
-  map_map ⦃k j i⦄ (hkj : k ≤ j) (hji : j ≤ i) (x : F i) : f hkj (f hji x) = f (hkj.trans hji) x
+  map_self ⦃i : _⦄ (x : F i) : f le_rfl x = x
+  map_map ⦃k j i : _⦄ (hkj : k ≤ j) (hji : j ≤ i) (x : F i) : f hkj (f hji x) = f (hkj.trans hji) x
 
 namespace InverseSystem
 
@@ -400,7 +400,7 @@ variable [SuccOrder ι] (f) (equivSucc : ∀ ⦃i⦄, ¬IsMax i → F i⁺ ≃ F
   /-- It is a natural family of bijections. -/
   nat : IsNatEquiv f equiv
   /-- It is compatible with a family of bijections relating `F i⁺` to `F i`. -/
-  compat {i} (hsi : (i⁺ : ι) ∈ s) (hi : ¬IsMax i) (x) :
+  compat {i : _} (hsi : (i⁺ : ι) ∈ s) (hi : ¬IsMax i) (x) :
     equiv ⟨i⁺, hsi⟩ x ⟨i, lt_succ_of_not_isMax hi⟩ = (equivSucc hi x).2
 
 variable {s t : Set ι} {f equivSucc} [WellFoundedLT ι]

--- a/Mathlib/Order/Interval/Set/Defs.lean
+++ b/Mathlib/Order/Interval/Set/Defs.lean
@@ -81,6 +81,6 @@ the `OrderTopology`, then this condition is equivalent to `IsPreconnected s`. If
 `LinearOrderedField`, then this condition is also equivalent to `Convex α s`. -/
 class OrdConnected (s : Set α) : Prop where
   /-- `s : Set α` is `OrdConnected` if for all `x y ∈ s` it includes the interval `[[x, y]]`. -/
-  out' ⦃x : _⦄ (hx : x ∈ s) ⦃y : _⦄ (hy : y ∈ s) : Icc x y ⊆ s
+  out' ⦃x : α⦄ (hx : x ∈ s) ⦃y : α⦄ (hy : y ∈ s) : Icc x y ⊆ s
 
 end Set

--- a/Mathlib/Order/Interval/Set/Defs.lean
+++ b/Mathlib/Order/Interval/Set/Defs.lean
@@ -81,6 +81,6 @@ the `OrderTopology`, then this condition is equivalent to `IsPreconnected s`. If
 `LinearOrderedField`, then this condition is also equivalent to `Convex α s`. -/
 class OrdConnected (s : Set α) : Prop where
   /-- `s : Set α` is `OrdConnected` if for all `x y ∈ s` it includes the interval `[[x, y]]`. -/
-  out' ⦃x⦄ (hx : x ∈ s) ⦃y⦄ (hy : y ∈ s) : Icc x y ⊆ s
+  out' ⦃x : _⦄ (hx : x ∈ s) ⦃y : _⦄ (hy : y ∈ s) : Icc x y ⊆ s
 
 end Set

--- a/Mathlib/Tactic/Positivity/Core.lean
+++ b/Mathlib/Tactic/Positivity/Core.lean
@@ -63,7 +63,7 @@ def Strictness.toNonzero {e} : Strictness zα pα e → Option Q($e ≠ 0)
 /-- An extension for `positivity`. -/
 structure PositivityExt where
   /-- Attempts to prove an expression `e : α` is `>0`, `≥0`, or `≠0`. -/
-  eval {u : _} {α : Q(Type u)} (zα : Q(Zero $α)) (pα : Q(PartialOrder $α)) (e : Q($α)) :
+  eval {u : Level} {α : Q(Type u)} (zα : Q(Zero $α)) (pα : Q(PartialOrder $α)) (e : Q($α)) :
     MetaM (Strictness zα pα e)
 
 /-- Read a `positivity` extension from a declaration of the right type. -/

--- a/Mathlib/Tactic/Positivity/Core.lean
+++ b/Mathlib/Tactic/Positivity/Core.lean
@@ -63,7 +63,7 @@ def Strictness.toNonzero {e} : Strictness zα pα e → Option Q($e ≠ 0)
 /-- An extension for `positivity`. -/
 structure PositivityExt where
   /-- Attempts to prove an expression `e : α` is `>0`, `≥0`, or `≠0`. -/
-  eval {u} {α : Q(Type u)} (zα : Q(Zero $α)) (pα : Q(PartialOrder $α)) (e : Q($α)) :
+  eval {u : _} {α : Q(Type u)} (zα : Q(Zero $α)) (pα : Q(PartialOrder $α)) (e : Q($α)) :
     MetaM (Strictness zα pα e)
 
 /-- Read a `positivity` extension from a declaration of the right type. -/


### PR DESCRIPTION
This is motivated by https://github.com/leanprover/lean4/pull/7742, which makes it possible to override the inferred binder kinds of structure/class fields using typeless binders. These are all cases where field binders shadow a possible parameter for the type. The fix is to give the binder a type.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
