### PR TITLE
[Merged by Bors] - feat(Topology): Continuous open maps with irreducible fibers induce bijections between irreducible components

### DIFF
--- a/Mathlib/Topology/Irreducible.lean
+++ b/Mathlib/Topology/Irreducible.lean
@@ -319,24 +319,23 @@ open Set.Notation
 
 @[stacks 004Z]
 lemma IsPreirreducible.preimage_of_dense_isPreirreducible_fiber
-    {V : Set Y} (hV : IsPreirreducible V)
-    (f : X → Y) (hf' : IsOpenMap f) (hf'' : Dense (V ↓∩ { x | IsPreirreducible (f ⁻¹' {x}) })) :
+    {V : Set Y} (hV : IsPreirreducible V) (f : X → Y) (hf' : IsOpenMap f)
+    (hf'' : V ⊆ closure (V ∩ { x | IsPreirreducible (f ⁻¹' {x}) })) :
     IsPreirreducible (f ⁻¹' V) := by
   rintro U₁ U₂ hU₁ hU₂ ⟨x, hxV, hxU₁⟩ ⟨y, hyV, hyU₂⟩
   obtain ⟨z, hzV, hz₁, hz₂⟩ :=
     hV _ _ (hf' _ hU₁) (hf' _ hU₂) ⟨f x, hxV, x, hxU₁, rfl⟩ ⟨f y, hyV, y, hyU₂, rfl⟩
-  obtain ⟨z, ⟨⟨z₁, hz₁, e₁⟩, ⟨z₂, hz₂, e₂⟩⟩, hz⟩ :=
-    hf''.inter_open_nonempty (V ↓∩ (f '' U₁ ∩ f '' U₂)) ⟨_, (hf' _ hU₁).inter (hf' _ hU₂), rfl⟩
-      ⟨⟨z, hzV⟩, hz₁, hz₂⟩
+  obtain ⟨z, ⟨⟨z₁, hz₁, e₁⟩, ⟨z₂, hz₂, e₂⟩⟩, hzV, hz⟩ :=
+    mem_closure_iff.mp (hf'' hzV) _ ((hf' _ hU₁).inter (hf' _ hU₂)) ⟨hz₁, hz₂⟩
   obtain ⟨z₃, hz₃, hz₃'⟩ := hz _ _ hU₁ hU₂ ⟨z₁, e₁, hz₁⟩ ⟨z₂, e₂, hz₂⟩
-  refine ⟨z₃, show f z₃ ∈ _ from (show f z₃ = z from hz₃) ▸ z.2, hz₃'⟩
+  refine ⟨z₃, show f z₃ ∈ _ from (show f z₃ = z from hz₃) ▸ hzV, hz₃'⟩
 
 lemma IsPreirreducible.preimage_of_isPreirreducible_fiber
     {V : Set Y} (hV : IsPreirreducible V)
     (f : X → Y) (hf' : IsOpenMap f) (hf'' : ∀ x, IsPreirreducible (f ⁻¹' {x})) :
     IsPreirreducible (f ⁻¹' V) := by
   refine hV.preimage_of_dense_isPreirreducible_fiber f hf' ?_
-  simp [hf'']
+  simp [hf'', subset_closure]
 
 variable (f : X → Y) (hf₁ : Continuous f) (hf₂ : IsOpenMap f)
 variable (hf₃ : ∀ x, IsPreirreducible (f ⁻¹' {x})) (hf₄ : Function.Surjective f)


### PR DESCRIPTION
Co-authored-by: Christian Merten

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
