### PR TITLE
[Merged by Bors] - fix(test): add missing `approximately` flag to count_heartbeats

### DIFF
--- a/MathlibTest/CountHeartbeats.lean
+++ b/MathlibTest/CountHeartbeats.lean
@@ -3,9 +3,9 @@ import Mathlib.Util.SleepHeartbeats
 
 set_option linter.style.header false
 
-/-- info: Used 7 heartbeats, which is less than the current maximum of 200000. -/
+/-- info: Used approximately 0 heartbeats, which is less than the current maximum of 200000. -/
 #guard_msgs in
-#count_heartbeats in
+#count_heartbeats approximately in
 example (a : Nat) : a = a := rfl
 
 /-- info: Used 7 heartbeats, which is less than the minimum of 200000. -/

--- a/MathlibTest/CountHeartbeats.lean
+++ b/MathlibTest/CountHeartbeats.lean
@@ -8,17 +8,17 @@ set_option linter.style.header false
 #count_heartbeats approximately in
 example (a : Nat) : a = a := rfl
 
-/-- info: Used 7 heartbeats, which is less than the minimum of 200000. -/
+/-- info: Used approximately 0 heartbeats, which is less than the minimum of 200000. -/
 #guard_msgs in
-guard_min_heartbeats in
+guard_min_heartbeats approximately in
 example (a : Nat) : a = a := rfl
 
-/-- info: Used 7 heartbeats, which is less than the minimum of 2000. -/
+/-- info: Used approximately 0 heartbeats, which is less than the minimum of 2000. -/
 #guard_msgs in
-guard_min_heartbeats 2000 in
+guard_min_heartbeats approximately 2000 in
 example (a : Nat) : a = a := rfl
 
-guard_min_heartbeats 1 in
+guard_min_heartbeats approximately 1 in
 example (a : Nat) : a = a := rfl
 
 /-!


### PR DESCRIPTION
Reported on [#lean4 dev > mathlib test build fails (8 instead of 7 heartbeats) @ 💬](https://leanprover.zulipchat.com/#narrow/channel/341532-lean4-dev/topic/mathlib.20test.20build.20fails.20.288.20instead.20of.207.20heartbeats.29/near/509066668).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
