### PR TITLE
[Merged by Bors] - feat(Adjunction/Opposites): left and right opposites of an adjunction

### DIFF
--- a/Mathlib/CategoryTheory/Adjunction/Opposites.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Opposites.lean
@@ -71,11 +71,11 @@ def rightOp {F : Cᵒᵖ ⥤ D} {G : Dᵒᵖ ⥤ C} (a : F.rightOp ⊣ G) : G.ri
   left_triangle_components X := congr($(a.right_triangle_components (.op X)).op)
   right_triangle_components X := congr($(a.left_triangle_components X.unop).unop)
 
-lemma leftOp_def {F : C ⥤ Dᵒᵖ} {G : D ⥤ Cᵒᵖ} (a : F ⊣ G.leftOp) :
+lemma leftOp_eq {F : C ⥤ Dᵒᵖ} {G : D ⥤ Cᵒᵖ} (a : F ⊣ G.leftOp) :
     a.leftOp = (opOpEquivalence D).symm.toAdjunction.comp a.op := by
   ext X; simp [Equivalence.unit]
 
-lemma rightOp_def {F : Cᵒᵖ ⥤ D} {G : Dᵒᵖ ⥤ C} (a : F.rightOp ⊣ G) :
+lemma rightOp_eq {F : Cᵒᵖ ⥤ D} {G : Dᵒᵖ ⥤ C} (a : F.rightOp ⊣ G) :
     a.rightOp = (opOpEquivalence D).symm.toAdjunction.comp a.op := by
   ext X; simp [Equivalence.unit]
 

--- a/Mathlib/CategoryTheory/Adjunction/Opposites.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Opposites.lean
@@ -55,6 +55,22 @@ def op {F : C ⥤ D} {G : D ⥤ C} (h : G ⊣ F) : F.op ⊣ G.op where
 @[deprecated (since := "2025-01-01")] alias opAdjointOfUnopAdjoint := op
 @[deprecated (since := "2025-01-01")] alias adjointOfUnopAdjointUnop := op
 
+/-- If `F` is adjoint to `G.leftOp` then `G` is adjoint to `F.leftOp`. -/
+@[simps]
+def leftOp {F : C ⥤ Dᵒᵖ} {G : D ⥤ Cᵒᵖ} (a : F ⊣ G.leftOp) : G ⊣ F.leftOp where
+  unit := NatTrans.unop a.counit
+  counit := NatTrans.op a.unit
+  left_triangle_components X := congr($(a.right_triangle_components (.op X)).op)
+  right_triangle_components X := congr($(a.left_triangle_components X.unop).unop)
+
+/-- If `F.rightOp` is adjoint to `G` then `G.rightOp` is adjoint to `F`. -/
+@[simps]
+def rightOp {F : Cᵒᵖ ⥤ D} {G : Dᵒᵖ ⥤ C} (a : F.rightOp ⊣ G) : G.rightOp ⊣ F where
+  unit := NatTrans.unop a.counit
+  counit := NatTrans.op a.unit
+  left_triangle_components X := congr($(a.right_triangle_components (.op X)).op)
+  right_triangle_components X := congr($(a.left_triangle_components X.unop).unop)
+
 /-- If `F` and `F'` are both adjoint to `G`, there is a natural isomorphism
 `F.op ⋙ coyoneda ≅ F'.op ⋙ coyoneda`.
 We use this in combination with `fullyFaithfulCancelRight` to show left adjoints are unique.

--- a/Mathlib/CategoryTheory/Adjunction/Opposites.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Opposites.lean
@@ -71,6 +71,14 @@ def rightOp {F : Cᵒᵖ ⥤ D} {G : Dᵒᵖ ⥤ C} (a : F.rightOp ⊣ G) : G.ri
   left_triangle_components X := congr($(a.right_triangle_components (.op X)).op)
   right_triangle_components X := congr($(a.left_triangle_components X.unop).unop)
 
+lemma leftOp_def {F : C ⥤ Dᵒᵖ} {G : D ⥤ Cᵒᵖ} (a : F ⊣ G.leftOp) :
+    a.leftOp = (opOpEquivalence D).symm.toAdjunction.comp a.op := by
+  ext X; simp [Equivalence.unit]
+
+lemma rightOp_def {F : Cᵒᵖ ⥤ D} {G : Dᵒᵖ ⥤ C} (a : F.rightOp ⊣ G) :
+    a.rightOp = (opOpEquivalence D).symm.toAdjunction.comp a.op := by
+  ext X; simp [Equivalence.unit]
+
 /-- If `F` and `F'` are both adjoint to `G`, there is a natural isomorphism
 `F.op ⋙ coyoneda ≅ F'.op ⋙ coyoneda`.
 We use this in combination with `fullyFaithfulCancelRight` to show left adjoints are unique.


### PR DESCRIPTION
From Toric

Co-authored-by: Andrew Yang <the.erd.one@gmail.com>


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
