### PR TITLE
[Merged by Bors] - feat: the inclusion of left/right exact functors into functors is fully faithful

### DIFF
--- a/Mathlib/CategoryTheory/Limits/ExactFunctor.lean
+++ b/Mathlib/CategoryTheory/Limits/ExactFunctor.lean
@@ -48,6 +48,10 @@ instance : (LeftExactFunctor.forget C D).Full :=
 instance : (LeftExactFunctor.forget C D).Faithful :=
   FullSubcategory.faithful _
 
+/-- The inclusion of left exact functors into functors is fully faithful. -/
+abbrev LeftExactFunctor.fullyFaithful : (LeftExactFunctor.forget C D).FullyFaithful :=
+  fullyFaithfulFullSubcategoryInclusion _
+
 /-- Bundled right-exact functors. -/
 def RightExactFunctor :=
   FullSubcategory fun F : C ⥤ D => PreservesFiniteColimits F

--- a/Mathlib/CategoryTheory/Limits/ExactFunctor.lean
+++ b/Mathlib/CategoryTheory/Limits/ExactFunctor.lean
@@ -72,6 +72,10 @@ instance : (RightExactFunctor.forget C D).Full :=
 instance : (RightExactFunctor.forget C D).Faithful :=
   FullSubcategory.faithful _
 
+/-- The inclusion of right exact functors into functors is fully faithful. -/
+abbrev RightExactFunctor.fullyFaithful : (RightExactFunctor.forget C D).FullyFaithful :=
+  fullyFaithfulFullSubcategoryInclusion _
+
 /-- Bundled exact functors. -/
 def ExactFunctor :=
   FullSubcategory fun F : C ⥤ D =>


### PR DESCRIPTION
From Toric


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
