### PR TITLE
[Merged by Bors] - refactor: generalise `∏ i ∈ s, f i = 1 ↔ ∀ i ∈ s, f i = 1` to monoids with a single unit

### DIFF
--- a/Mathlib/Algebra/BigOperators/Group/Finset/Basic.lean
+++ b/Mathlib/Algebra/BigOperators/Group/Finset/Basic.lean
@@ -1498,3 +1498,5 @@ theorem nat_abs_sum_le {ι : Type*} (s : Finset ι) (f : ι → ℤ) :
   | cons i s his IH =>
     simp only [Finset.sum_cons, not_false_iff]
     exact (Int.natAbs_add_le _ _).trans (Nat.add_le_add_left IH _)
+
+set_option linter.style.longFile 1600

--- a/Mathlib/Algebra/BigOperators/Group/Finset/Basic.lean
+++ b/Mathlib/Algebra/BigOperators/Group/Finset/Basic.lean
@@ -162,10 +162,10 @@ theorem prod_filter_xor (p q : α → Prop) [DecidablePred p] [DecidablePred q] 
   classical rw [← prod_union (disjoint_filter_and_not_filter _ _), ← filter_or]
   simp only [Xor']
 
-/-- In a salient monoid (whose only unit is `1`), a product is equal to `1` iff all factors are `1`.
+/-- In a monoid whose only unit is `1`, a product is equal to `1` iff all factors are `1`.
 -/
 @[to_additive (attr := simp)
-"In a salient monoid (whose only unit is `0`), a sum is equal to `0` iff all terms are `0`."]
+"In a monoid whose only unit is `0`, a sum is equal to `0` iff all terms are `0`."]
 lemma prod_eq_one_iff [Subsingleton βˣ] : ∏ i ∈ s, f i = 1 ↔ ∀ i ∈ s, f i = 1 := by
   induction' s using Finset.cons_induction with i s hi ih <;> simp [*]
 

--- a/Mathlib/Algebra/BigOperators/Group/Finset/Basic.lean
+++ b/Mathlib/Algebra/BigOperators/Group/Finset/Basic.lean
@@ -162,8 +162,7 @@ theorem prod_filter_xor (p q : α → Prop) [DecidablePred p] [DecidablePred q] 
   classical rw [← prod_union (disjoint_filter_and_not_filter _ _), ← filter_or]
   simp only [Xor']
 
-/-- In a monoid whose only unit is `1`, a product is equal to `1` iff all factors are `1`.
--/
+/-- In a monoid whose only unit is `1`, a product is equal to `1` iff all factors are `1`. -/
 @[to_additive (attr := simp)
 "In a monoid whose only unit is `0`, a sum is equal to `0` iff all terms are `0`."]
 lemma prod_eq_one_iff [Subsingleton βˣ] : ∏ i ∈ s, f i = 1 ↔ ∀ i ∈ s, f i = 1 := by

--- a/Mathlib/Algebra/BigOperators/Group/Finset/Basic.lean
+++ b/Mathlib/Algebra/BigOperators/Group/Finset/Basic.lean
@@ -162,6 +162,15 @@ theorem prod_filter_xor (p q : α → Prop) [DecidablePred p] [DecidablePred q] 
   classical rw [← prod_union (disjoint_filter_and_not_filter _ _), ← filter_or]
   simp only [Xor']
 
+/-- In a salient monoid (whose only unit is `1`), a product is equal to `1` iff all factors are `1`.
+-/
+@[to_additive (attr := simp)
+"In a salient monoid (whose only unit is `0`), a sum is equal to `0` iff all terms are `0`."]
+lemma prod_eq_one_iff [Subsingleton βˣ] : ∏ i ∈ s, f i = 1 ↔ ∀ i ∈ s, f i = 1 := by
+  induction' s using Finset.cons_induction with i s hi ih <;> simp [*]
+
+@[deprecated (since := "2025-03-31")] alias prod_eq_one_iff' := prod_eq_one_iff
+
 end CommMonoid
 
 end Finset

--- a/Mathlib/Algebra/Order/BigOperators/Group/Finset.lean
+++ b/Mathlib/Algebra/Order/BigOperators/Group/Finset.lean
@@ -363,10 +363,6 @@ lemma _root_.CanonicallyOrderedCommMonoid.single_le_prod {i : ι} (hi : i ∈ s)
     f i ≤ ∏ j ∈ s, f j :=
   single_le_prod' (fun _ _ ↦ one_le _) hi
 
-@[to_additive (attr := simp) sum_eq_zero_iff]
-theorem prod_eq_one_iff' : ∏ x ∈ s, f x = 1 ↔ ∀ x ∈ s, f x = 1 :=
-  prod_eq_one_iff_of_one_le' fun x _ ↦ one_le (f x)
-
 @[to_additive sum_le_sum_of_subset]
 theorem prod_le_prod_of_subset' (h : s ⊆ t) : ∏ x ∈ s, f x ≤ ∏ x ∈ t, f x :=
   prod_le_prod_of_subset_of_one_le' h fun _ _ _ ↦ one_le _


### PR DESCRIPTION
namely whose only unit is `1`. Also unprime the multiplicative name since it doesn't conflict with anything.

From Toric

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
