### PR TITLE
[Merged by Bors] - chore: make `isUnit_iff_eq_one` simp

### DIFF
--- a/Mathlib/Algebra/Group/Nat/Units.lean
+++ b/Mathlib/Algebra/Group/Nat/Units.lean
@@ -22,10 +22,6 @@ lemma units_eq_one (u : ℕˣ) : u = 1 := Units.ext <| Nat.eq_one_of_dvd_one ⟨
 lemma addUnits_eq_zero (u : AddUnits ℕ) : u = 0 :=
   AddUnits.ext <| (Nat.eq_zero_of_add_eq_zero u.val_neg).1
 
-@[simp] protected lemma isUnit_iff {n : ℕ} : IsUnit n ↔ n = 1 where
-  mp := by rintro ⟨u, rfl⟩; obtain rfl := Nat.units_eq_one u; rfl
-  mpr h := h.symm ▸ ⟨1, rfl⟩
-
 instance unique_units : Unique ℕˣ where
   default := 1
   uniq := Nat.units_eq_one
@@ -33,5 +29,11 @@ instance unique_units : Unique ℕˣ where
 instance unique_addUnits : Unique (AddUnits ℕ) where
   default := 0
   uniq := Nat.addUnits_eq_zero
+
+/-- Alias of `isUnit_iff_eq_one` for discoverability. -/
+protected lemma isUnit_iff {n : ℕ} : IsUnit n ↔ n = 1 := isUnit_iff_eq_one
+
+/-- Alias of `isAddUnit_iff_eq_zero` for discoverability. -/
+protected lemma isAddUnit_iff {n : ℕ} : IsAddUnit n ↔ n = 0 := isAddUnit_iff_eq_zero
 
 end Nat

--- a/Mathlib/Algebra/Group/Units/Defs.lean
+++ b/Mathlib/Algebra/Group/Units/Defs.lean
@@ -414,7 +414,8 @@ lemma IsUnit.exists_left_inv {a : M} (h : IsUnit a) : ∃ b, b * a = 1 := by
 @[to_additive] lemma IsUnit.pow (n : ℕ) : IsUnit a → IsUnit (a ^ n) := by
   rintro ⟨u, rfl⟩; exact ⟨u ^ n, rfl⟩
 
-@[to_additive] lemma isUnit_iff_eq_one [Subsingleton Mˣ] {x : M} : IsUnit x ↔ x = 1 :=
+@[to_additive (attr := simp)]
+lemma isUnit_iff_eq_one [Subsingleton Mˣ] {x : M} : IsUnit x ↔ x = 1 :=
   ⟨fun ⟨u, hu⟩ ↦ by rw [← hu, Subsingleton.elim u 1, Units.val_one], fun h ↦ h ▸ isUnit_one⟩
 
 end Monoid

--- a/Mathlib/RingTheory/Ideal/Operations.lean
+++ b/Mathlib/RingTheory/Ideal/Operations.lean
@@ -1123,7 +1123,8 @@ In a Dedekind domain, to divide and contain are equivalent, see `Ideal.dvd_iff_l
 theorem le_of_dvd {I J : Ideal R} : I ∣ J → J ≤ I
   | ⟨_, h⟩ => h.symm ▸ le_trans mul_le_inf inf_le_left
 
-@[simp]
+/-- See also `isUnit_iff_eq_one`. -/
+@[simp high]
 theorem isUnit_iff {I : Ideal R} : IsUnit I ↔ I = ⊤ :=
   isUnit_iff_dvd_one.trans
     ((@one_eq_top R _).symm ▸

--- a/Mathlib/SetTheory/Cardinal/Divisibility.lean
+++ b/Mathlib/SetTheory/Cardinal/Divisibility.lean
@@ -35,7 +35,7 @@ universe u
 
 variable {a b : Cardinal.{u}} {n m : ℕ}
 
-@[simp]
+/-- Alias of `isUnit_iff_eq_one` for discoverability. -/
 theorem isUnit_iff : IsUnit a ↔ a = 1 := by
   refine
     ⟨fun h => ?_, by


### PR DESCRIPTION
This is very useful when talking about salient monoids (monoids whose only unit is `1`).

From Toric


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
