### PR TITLE
[Merged by Bors] - chore(Topology.MetricSpace.Lipschitz): stop depending on Topology.Algebra

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -5643,6 +5643,7 @@ import Mathlib.Topology.Algebra.IntermediateField
 import Mathlib.Topology.Algebra.IsOpenUnits
 import Mathlib.Topology.Algebra.LinearTopology
 import Mathlib.Topology.Algebra.Localization
+import Mathlib.Topology.Algebra.MetricSpace.Lipschitz
 import Mathlib.Topology.Algebra.Module.Alternating.Basic
 import Mathlib.Topology.Algebra.Module.Alternating.Topology
 import Mathlib.Topology.Algebra.Module.Basic

--- a/Mathlib/Analysis/Normed/Group/AddTorsor.lean
+++ b/Mathlib/Analysis/Normed/Group/AddTorsor.lean
@@ -6,6 +6,7 @@ Authors: Joseph Myers, Yury Kudryashov
 import Mathlib.Analysis.Normed.Group.Submodule
 import Mathlib.LinearAlgebra.AffineSpace.AffineSubspace.Basic
 import Mathlib.LinearAlgebra.AffineSpace.Midpoint
+import Mathlib.Topology.Algebra.MulAction
 import Mathlib.Topology.MetricSpace.IsometricSMul
 import Mathlib.Topology.Metrizable.Uniformity
 import Mathlib.Topology.Sequences

--- a/Mathlib/Analysis/NormedSpace/Multilinear/Basic.lean
+++ b/Mathlib/Analysis/NormedSpace/Multilinear/Basic.lean
@@ -6,6 +6,7 @@ Authors: Sébastien Gouëzel, Sophie Morel, Yury Kudryashov
 import Mathlib.Analysis.NormedSpace.OperatorNorm.NormedSpace
 import Mathlib.Logic.Embedding.Basic
 import Mathlib.Data.Fintype.CardEmbedding
+import Mathlib.Topology.Algebra.MetricSpace.Lipschitz
 import Mathlib.Topology.Algebra.Module.Multilinear.Topology
 
 /-!

--- a/Mathlib/Analysis/SpecialFunctions/Exp.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Exp.lean
@@ -6,6 +6,7 @@ Authors: Chris Hughes, Abhimanyu Pallavi Sudhir, Jean Lo, Calle Sönne
 import Mathlib.Analysis.Complex.Asymptotics
 import Mathlib.Analysis.SpecificLimits.Normed
 import Mathlib.Data.Complex.Trigonometric
+import Mathlib.Topology.Algebra.MetricSpace.Lipschitz
 
 /-!
 # Complex and real exponential

--- a/Mathlib/Topology/Algebra/MetricSpace/Lipschitz.lean
+++ b/Mathlib/Topology/Algebra/MetricSpace/Lipschitz.lean
@@ -1,37 +1,25 @@
 /-
-Copyright (c) 2018 Rohan Mitta. All rights reserved.
+Copyright (c) 2020 Sébastien Gouëzel. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Rohan Mitta, Kevin Buzzard, Alistair Tucker, Johannes Hölzl, Yury Kudryashov
+Authors: Sébastien Gouëzel
 -/
-import Mathlib.Order.Interval.Set.ProjIcc
 import Mathlib.Topology.Algebra.Order.Field
-import Mathlib.Topology.Bornology.Hom
 import Mathlib.Topology.MetricSpace.Lipschitz
-import Mathlib.Topology.Maps.Proper.Basic
-import Mathlib.Topology.MetricSpace.Basic
-import Mathlib.Topology.MetricSpace.Bounded
 
 /-!
 # Lipschitz continuous functions
-TODO
+
+This file develops Lipschitz continuous functions further with some results that depend on algebra.
 -/
 
 assert_not_exists Basis Ideal
 
-universe u v w x
+open Filter Set NNReal Metric
 
-open Filter Function Set Topology NNReal ENNReal Bornology
+variable {α β : Type*} [PseudoMetricSpace α] [PseudoMetricSpace β] {K : ℝ≥0}
 
-variable {α : Type u} {β : Type v} {γ : Type w} {ι : Type x}
-
-namespace LipschitzWith
-
-section Metric
-
-variable [PseudoMetricSpace α] [PseudoMetricSpace β] [PseudoMetricSpace γ] {K : ℝ≥0} {f : α → β}
-  {x y : α} {r : ℝ}
-
-lemma cauchySeq_comp (hf : LipschitzWith K f) {u : ℕ → α} (hu : CauchySeq u) :
+lemma LipschitzWith.cauchySeq_comp {f : α → β} (hf : LipschitzWith K f) {u : ℕ → α}
+    (hu : CauchySeq u) :
     CauchySeq (f ∘ u) := by
   rcases cauchySeq_iff_le_tendsto_0.1 hu with ⟨b, b_nonneg, hb, blim⟩
   refine cauchySeq_iff_le_tendsto_0.2 ⟨fun n ↦ K * b n, ?_, ?_, ?_⟩
@@ -40,24 +28,7 @@ lemma cauchySeq_comp (hf : LipschitzWith K f) {u : ℕ → α} (hu : CauchySeq u
   · rw [← mul_zero (K : ℝ)]
     exact blim.const_mul _
 
-end Metric
-
-end LipschitzWith
-
-namespace Metric
-
-variable [PseudoMetricSpace α] [PseudoMetricSpace β] {s : Set α} {t : Set β}
-
-end Metric
-
-namespace LipschitzOnWith
-
-section Metric
-
-variable [PseudoMetricSpace α] [PseudoMetricSpace β] [PseudoMetricSpace γ]
-variable {K : ℝ≥0} {s : Set α} {f : α → β}
-
-lemma cauchySeq_comp (hf : LipschitzOnWith K f s)
+lemma LipschitzOnWith.cauchySeq_comp {s : Set α} {f : α → β} (hf : LipschitzOnWith K f s)
     {u : ℕ → α} (hu : CauchySeq u) (h'u : range u ⊆ s) :
     CauchySeq (f ∘ u) := by
   rcases cauchySeq_iff_le_tendsto_0.1 hu with ⟨b, b_nonneg, hb, blim⟩
@@ -70,20 +41,8 @@ lemma cauchySeq_comp (hf : LipschitzOnWith K f s)
   · rw [← mul_zero (K : ℝ)]
     exact blim.const_mul _
 
-end Metric
-
-end LipschitzOnWith
-
-namespace LocallyLipschitz
-
-end LocallyLipschitz
-
-open Metric
-
-variable [PseudoMetricSpace α] [PseudoMetricSpace β] {f : α → β}
-
 /-- If a function is locally Lipschitz around a point, then it is continuous at this point. -/
-theorem continuousAt_of_locally_lipschitz {x : α} {r : ℝ} (hr : 0 < r) (K : ℝ)
+theorem continuousAt_of_locally_lipschitz {f : α → β} {x : α} {r : ℝ} (hr : 0 < r) (K : ℝ)
     (h : ∀ y, dist y x < r → dist (f y) (f x) ≤ K * dist y x) : ContinuousAt f x := by
   -- We use `h` to squeeze `dist (f y) (f x)` between `0` and `K * dist y x`
   refine tendsto_iff_dist_tendsto_zero.2 (squeeze_zero' (Eventually.of_forall fun _ => dist_nonneg)

--- a/Mathlib/Topology/Algebra/MetricSpace/Lipschitz.lean
+++ b/Mathlib/Topology/Algebra/MetricSpace/Lipschitz.lean
@@ -1,0 +1,93 @@
+/-
+Copyright (c) 2018 Rohan Mitta. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Rohan Mitta, Kevin Buzzard, Alistair Tucker, Johannes Hölzl, Yury Kudryashov
+-/
+import Mathlib.Order.Interval.Set.ProjIcc
+import Mathlib.Topology.Algebra.Order.Field
+import Mathlib.Topology.Bornology.Hom
+import Mathlib.Topology.MetricSpace.Lipschitz
+import Mathlib.Topology.Maps.Proper.Basic
+import Mathlib.Topology.MetricSpace.Basic
+import Mathlib.Topology.MetricSpace.Bounded
+
+/-!
+# Lipschitz continuous functions
+TODO
+-/
+
+assert_not_exists Basis Ideal
+
+universe u v w x
+
+open Filter Function Set Topology NNReal ENNReal Bornology
+
+variable {α : Type u} {β : Type v} {γ : Type w} {ι : Type x}
+
+namespace LipschitzWith
+
+section Metric
+
+variable [PseudoMetricSpace α] [PseudoMetricSpace β] [PseudoMetricSpace γ] {K : ℝ≥0} {f : α → β}
+  {x y : α} {r : ℝ}
+
+lemma cauchySeq_comp (hf : LipschitzWith K f) {u : ℕ → α} (hu : CauchySeq u) :
+    CauchySeq (f ∘ u) := by
+  rcases cauchySeq_iff_le_tendsto_0.1 hu with ⟨b, b_nonneg, hb, blim⟩
+  refine cauchySeq_iff_le_tendsto_0.2 ⟨fun n ↦ K * b n, ?_, ?_, ?_⟩
+  · exact fun n ↦ mul_nonneg (by positivity) (b_nonneg n)
+  · exact fun n m N hn hm ↦ hf.dist_le_mul_of_le (hb n m N hn hm)
+  · rw [← mul_zero (K : ℝ)]
+    exact blim.const_mul _
+
+end Metric
+
+end LipschitzWith
+
+namespace Metric
+
+variable [PseudoMetricSpace α] [PseudoMetricSpace β] {s : Set α} {t : Set β}
+
+end Metric
+
+namespace LipschitzOnWith
+
+section Metric
+
+variable [PseudoMetricSpace α] [PseudoMetricSpace β] [PseudoMetricSpace γ]
+variable {K : ℝ≥0} {s : Set α} {f : α → β}
+
+lemma cauchySeq_comp (hf : LipschitzOnWith K f s)
+    {u : ℕ → α} (hu : CauchySeq u) (h'u : range u ⊆ s) :
+    CauchySeq (f ∘ u) := by
+  rcases cauchySeq_iff_le_tendsto_0.1 hu with ⟨b, b_nonneg, hb, blim⟩
+  refine cauchySeq_iff_le_tendsto_0.2 ⟨fun n ↦ K * b n, ?_, ?_, ?_⟩
+  · exact fun n ↦ mul_nonneg (by positivity) (b_nonneg n)
+  · intro n m N hn hm
+    have A n : u n ∈ s := h'u (mem_range_self _)
+    apply (hf.dist_le_mul _ (A n) _ (A m)).trans
+    exact mul_le_mul_of_nonneg_left (hb n m N hn hm) K.2
+  · rw [← mul_zero (K : ℝ)]
+    exact blim.const_mul _
+
+end Metric
+
+end LipschitzOnWith
+
+namespace LocallyLipschitz
+
+end LocallyLipschitz
+
+open Metric
+
+variable [PseudoMetricSpace α] [PseudoMetricSpace β] {f : α → β}
+
+/-- If a function is locally Lipschitz around a point, then it is continuous at this point. -/
+theorem continuousAt_of_locally_lipschitz {x : α} {r : ℝ} (hr : 0 < r) (K : ℝ)
+    (h : ∀ y, dist y x < r → dist (f y) (f x) ≤ K * dist y x) : ContinuousAt f x := by
+  -- We use `h` to squeeze `dist (f y) (f x)` between `0` and `K * dist y x`
+  refine tendsto_iff_dist_tendsto_zero.2 (squeeze_zero' (Eventually.of_forall fun _ => dist_nonneg)
+    (mem_of_superset (ball_mem_nhds _ hr) h) ?_)
+  -- Then show that `K * dist y x` tends to zero as `y → x`
+  refine (continuous_const.mul (continuous_id.dist continuous_const)).tendsto' _ _ ?_
+  simp

--- a/Mathlib/Topology/MetricSpace/Algebra.lean
+++ b/Mathlib/Topology/MetricSpace/Algebra.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Heather Macbeth
 -/
 import Mathlib.Topology.Algebra.MulAction
+import Mathlib.Topology.Algebra.Order.Field
 import Mathlib.Topology.Algebra.SeparationQuotient.Basic
 import Mathlib.Topology.Algebra.UniformMulAction
 import Mathlib.Topology.MetricSpace.Lipschitz

--- a/Mathlib/Topology/MetricSpace/IsometricSMul.lean
+++ b/Mathlib/Topology/MetricSpace/IsometricSMul.lean
@@ -5,6 +5,7 @@ Authors: Yury Kudryashov
 -/
 import Mathlib.Algebra.GroupWithZero.Pointwise.Set.Basic
 import Mathlib.Algebra.Ring.Pointwise.Set
+import Mathlib.Topology.Algebra.ConstMulAction
 import Mathlib.Topology.MetricSpace.Isometry
 import Mathlib.Topology.MetricSpace.Lipschitz
 

--- a/Mathlib/Topology/MetricSpace/Lipschitz.lean
+++ b/Mathlib/Topology/MetricSpace/Lipschitz.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Rohan Mitta, Kevin Buzzard, Alistair Tucker, Johannes Hölzl, Yury Kudryashov
 -/
 import Mathlib.Order.Interval.Set.ProjIcc
-import Mathlib.Topology.Algebra.Order.Field
 import Mathlib.Topology.Bornology.Hom
 import Mathlib.Topology.EMetricSpace.Lipschitz
 import Mathlib.Topology.Maps.Proper.Basic

--- a/Mathlib/Topology/MetricSpace/Lipschitz.lean
+++ b/Mathlib/Topology/MetricSpace/Lipschitz.lean
@@ -30,7 +30,7 @@ coercions both to `ℝ` and `ℝ≥0∞`. Constructors whose names end with `'` 
 argument, and return `LipschitzWith (Real.toNNReal K) f`.
 -/
 
-assert_not_exists Basis Ideal
+assert_not_exists Basis Ideal ContinuousMul
 
 universe u v w x
 

--- a/Mathlib/Topology/MetricSpace/Lipschitz.lean
+++ b/Mathlib/Topology/MetricSpace/Lipschitz.lean
@@ -165,15 +165,6 @@ lemma _root_.Real.lipschitzWith_toNNReal : LipschitzWith 1 Real.toNNReal := by
   simpa only [NNReal.coe_one, dist_prod_same_right, one_mul, Real.dist_eq] using
     lipschitzWith_iff_dist_le_mul.mp lipschitzWith_max (x, 0) (y, 0)
 
-lemma cauchySeq_comp (hf : LipschitzWith K f) {u : ℕ → α} (hu : CauchySeq u) :
-    CauchySeq (f ∘ u) := by
-  rcases cauchySeq_iff_le_tendsto_0.1 hu with ⟨b, b_nonneg, hb, blim⟩
-  refine cauchySeq_iff_le_tendsto_0.2 ⟨fun n ↦ K * b n, ?_, ?_, ?_⟩
-  · exact fun n ↦ mul_nonneg (by positivity) (b_nonneg n)
-  · exact fun n m N hn hm ↦ hf.dist_le_mul_of_le (hb n m N hn hm)
-  · rw [← mul_zero (K : ℝ)]
-    exact blim.const_mul _
-
 end Metric
 
 section EMetric
@@ -274,19 +265,6 @@ theorem isBounded_image2 (f : α → β → γ) {K₁ K₂ : ℝ≥0} {s : Set �
           ENNReal.mul_ne_top ENNReal.coe_ne_top ht.ediam_ne_top⟩)
       (ediam_image2_le _ _ _ hf₁ hf₂)
 
-lemma cauchySeq_comp (hf : LipschitzOnWith K f s)
-    {u : ℕ → α} (hu : CauchySeq u) (h'u : range u ⊆ s) :
-    CauchySeq (f ∘ u) := by
-  rcases cauchySeq_iff_le_tendsto_0.1 hu with ⟨b, b_nonneg, hb, blim⟩
-  refine cauchySeq_iff_le_tendsto_0.2 ⟨fun n ↦ K * b n, ?_, ?_, ?_⟩
-  · exact fun n ↦ mul_nonneg (by positivity) (b_nonneg n)
-  · intro n m N hn hm
-    have A n : u n ∈ s := h'u (mem_range_self _)
-    apply (hf.dist_le_mul _ (A n) _ (A m)).trans
-    exact mul_le_mul_of_nonneg_left (hb n m N hn hm) K.2
-  · rw [← mul_zero (K : ℝ)]
-    exact blim.const_mul _
-
 end Metric
 
 end LipschitzOnWith
@@ -325,16 +303,6 @@ end LocallyLipschitz
 open Metric
 
 variable [PseudoMetricSpace α] [PseudoMetricSpace β] {f : α → β}
-
-/-- If a function is locally Lipschitz around a point, then it is continuous at this point. -/
-theorem continuousAt_of_locally_lipschitz {x : α} {r : ℝ} (hr : 0 < r) (K : ℝ)
-    (h : ∀ y, dist y x < r → dist (f y) (f x) ≤ K * dist y x) : ContinuousAt f x := by
-  -- We use `h` to squeeze `dist (f y) (f x)` between `0` and `K * dist y x`
-  refine tendsto_iff_dist_tendsto_zero.2 (squeeze_zero' (Eventually.of_forall fun _ => dist_nonneg)
-    (mem_of_superset (ball_mem_nhds _ hr) h) ?_)
-  -- Then show that `K * dist y x` tends to zero as `y → x`
-  refine (continuous_const.mul (continuous_id.dist continuous_const)).tendsto' _ _ ?_
-  simp
 
 /-- A function `f : α → ℝ` which is `K`-Lipschitz on a subset `s` admits a `K`-Lipschitz extension
 to the whole space. -/

--- a/Mathlib/Topology/MetricSpace/PiNat.lean
+++ b/Mathlib/Topology/MetricSpace/PiNat.lean
@@ -3,6 +3,7 @@ Copyright (c) 2022 Sébastien Gouëzel. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sébastien Gouëzel
 -/
+import Mathlib.Topology.Algebra.MetricSpace.Lipschitz
 import Mathlib.Topology.MetricSpace.HausdorffDistance
 
 /-!


### PR DESCRIPTION
Noticed while playing with the new `directoryDependency` linter. Not sure if these could be proved without assuming the continuity of real multiplication.

Copyright from https://github.com/leanprover-community/mathlib3/pull/1921 and https://github.com/leanprover-community/mathlib4/pull/11840.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
