### PR TITLE
[Merged by Bors] - chore (ModelTheory/Syntax): Rename Lequiv -> LEquiv

### DIFF
--- a/Mathlib/ModelTheory/Syntax.lean
+++ b/Mathlib/ModelTheory/Syntax.lean
@@ -278,7 +278,7 @@ def LEquiv.onTerm (φ : L ≃ᴸ L') : L.Term α ≃ L'.Term α where
     rw [Function.rightInverse_iff_comp, ← LHom.comp_onTerm, φ.right_inv, LHom.id_onTerm]
 
 /-- Maps a term's symbols along a language equivalence. Deprecated in favor of `LEquiv.onTerm`. -/
-@[deprecated LEquiv.onTerm (since := "2025-03-31")] alias Lequiv.onTerm := @LEquiv.onTerm
+@[deprecated LEquiv.onTerm (since := "2025-03-31")] alias Lequiv.onTerm := LEquiv.onTerm
 
 variable (L) (α)
 

--- a/Mathlib/ModelTheory/Syntax.lean
+++ b/Mathlib/ModelTheory/Syntax.lean
@@ -278,8 +278,7 @@ def LEquiv.onTerm (φ : L ≃ᴸ L') : L.Term α ≃ L'.Term α where
     rw [Function.rightInverse_iff_comp, ← LHom.comp_onTerm, φ.right_inv, LHom.id_onTerm]
 
 /-- Maps a term's symbols along a language equivalence. Deprecated in favor of `LEquiv.onTerm`. -/
-@[deprecated LEquiv.onTerm (since := "2025-03-31")]
-def Lequiv.onTerm := @LEquiv.onTerm
+@[deprecated LEquiv.onTerm (since := "2025-03-31")] alias Lequiv.onTerm := @LEquiv.onTerm
 
 variable (L) (α)
 

--- a/Mathlib/ModelTheory/Syntax.lean
+++ b/Mathlib/ModelTheory/Syntax.lean
@@ -278,7 +278,7 @@ def LEquiv.onTerm (φ : L ≃ᴸ L') : L.Term α ≃ L'.Term α where
     rw [Function.rightInverse_iff_comp, ← LHom.comp_onTerm, φ.right_inv, LHom.id_onTerm]
 
 /-- Maps a term's symbols along a language equivalence. Deprecated in favor of `LEquiv.onTerm`. -/
-@[deprecated LEquiv.onTerm (since := "2025-31-03")]
+@[deprecated LEquiv.onTerm (since := "2025-03-31")]
 def Lequiv.onTerm := @LEquiv.onTerm
 
 variable (L) (α)

--- a/Mathlib/ModelTheory/Syntax.lean
+++ b/Mathlib/ModelTheory/Syntax.lean
@@ -269,13 +269,17 @@ end LHom
 
 /-- Maps a term's symbols along a language equivalence. -/
 @[simps]
-def Lequiv.onTerm (φ : L ≃ᴸ L') : L.Term α ≃ L'.Term α where
+def LEquiv.onTerm (φ : L ≃ᴸ L') : L.Term α ≃ L'.Term α where
   toFun := φ.toLHom.onTerm
   invFun := φ.invLHom.onTerm
   left_inv := by
     rw [Function.leftInverse_iff_comp, ← LHom.comp_onTerm, φ.left_inv, LHom.id_onTerm]
   right_inv := by
     rw [Function.rightInverse_iff_comp, ← LHom.comp_onTerm, φ.right_inv, LHom.id_onTerm]
+
+/-- Maps a term's symbols along a language equivalence. Deprecated in favor of `LEquiv.onTerm`. -/
+@[deprecated LEquiv.onTerm (since := "2025-31-03")]
+def Lequiv.onTerm := @LEquiv.onTerm
 
 variable (L) (α)
 


### PR DESCRIPTION
This function was named `Lequiv.onTerm`, this was probably a mistake because the object it uses it called `LEquiv`. This renames it and adds a deprecated alias.

---

Pulled out from #19695 .

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
