### PR TITLE
feat(Topology/Instances/ENat): ENat and tsum

### DIFF
--- a/Mathlib/Data/ENat/Basic.lean
+++ b/Mathlib/Data/ENat/Basic.lean
@@ -94,6 +94,14 @@ theorem top_mul' : ⊤ * m = if m = 0 then 0 else ⊤ := WithTop.top_mul' m
 
 theorem top_pow {n : ℕ} (n_pos : 0 < n) : (⊤ : ℕ∞) ^ n = ⊤ := WithTop.top_pow n_pos
 
+-- this won't fire as `simp` without an explicit `ENat` version.
+@[simp]
+theorem add_eq_top {x y : ℕ∞} : x + y = ⊤ ↔ x = ⊤ ∨ y = ⊤ :=
+  WithTop.add_eq_top
+
+theorem add_ne_top {x y : ℕ∞} : x + y ≠ ⊤ ↔ x ≠ ⊤ ∧ y ≠ ⊤ :=
+  by simp
+
 /-- Convert a `ℕ∞` to a `ℕ` using a proof that it is not infinite. -/
 def lift (x : ℕ∞) (h : x < ⊤) : ℕ := WithTop.untop x (WithTop.lt_top_iff_ne_top.mp h)
 

--- a/Mathlib/Data/ENat/Basic.lean
+++ b/Mathlib/Data/ENat/Basic.lean
@@ -94,7 +94,6 @@ theorem top_mul' : ⊤ * m = if m = 0 then 0 else ⊤ := WithTop.top_mul' m
 
 theorem top_pow {n : ℕ} (n_pos : 0 < n) : (⊤ : ℕ∞) ^ n = ⊤ := WithTop.top_pow n_pos
 
--- this won't fire as `simp` without an explicit `ENat` version.
 @[simp]
 theorem add_eq_top {x y : ℕ∞} : x + y = ⊤ ↔ x = ⊤ ∨ y = ⊤ :=
   WithTop.add_eq_top

--- a/Mathlib/Data/Set/Card.lean
+++ b/Mathlib/Data/Set/Card.lean
@@ -962,6 +962,11 @@ theorem Infinite.exists_superset_ncard_eq {s t : Set α} (ht : t.Infinite) (hst 
   rwa [ncard_union_eq (disjoint_of_subset_right hs₁ disjoint_sdiff_right) hs hs₁fin, hs₁card,
     add_tsub_cancel_of_le]
 
+theorem Infinite.exists_finite_subset_encard_gt (hs : s.Infinite) (b : ℕ) :
+    ∃ t ⊆ s, b < t.encard ∧ t.Finite := by
+  obtain ⟨t, hts, hcard⟩ := hs.exists_subset_card_eq (b + 1)
+  exact ⟨t, by simpa, by simp [encard_coe_eq_coe_finsetCard, hcard, Nat.cast_lt, - Nat.cast_add]⟩
+
 theorem exists_subset_or_subset_of_two_mul_lt_ncard {n : ℕ} (hst : 2 * n < (s ∪ t).ncard) :
     ∃ r : Set α, n < r.ncard ∧ (r ⊆ s ∨ r ⊆ t) := by
   classical

--- a/Mathlib/Topology/Instances/ENat.lean
+++ b/Mathlib/Topology/Instances/ENat.lean
@@ -3,17 +3,22 @@ Copyright (c) 2022 Peter Nelson. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Peter Nelson
 -/
-import Mathlib.Data.ENat.Basic
+import Mathlib.Data.ENat.Lattice
+import Mathlib.Data.Set.Card
 import Mathlib.Topology.Instances.Discrete
+import Mathlib.Topology.Order.T5
 import Mathlib.Order.Interval.Set.WithBotTop
 import Mathlib.Order.Filter.Pointwise
 import Mathlib.Topology.Algebra.Monoid.Defs
+import Mathlib.Topology.Algebra.InfiniteSum.Constructions
+import Mathlib.Topology.Algebra.InfiniteSum.Order
+
 
 /-!
 # Topology on extended natural numbers
 -/
 
-open Filter Set Topology
+open Filter Set Topology Function
 
 namespace ENat
 
@@ -129,3 +134,189 @@ nonrec theorem Continuous.enatSub
     (hf : Continuous f) (hg : Continuous g) (h : ∀ x, f x ≠ ⊤ ∨ g x ≠ ⊤) :
     Continuous (fun x ↦ f x - g x) :=
   continuous_iff_continuousAt.2 fun x ↦ hf.continuousAt.enatSub hg.continuousAt (h x)
+
+namespace ENat
+
+section tsum
+
+variable {ι : Sort*} {α β : Type*} {f g : α → ℕ∞} {s t : Set α}
+
+protected theorem hasSum : HasSum f (⨆ s : Finset α, ∑ a ∈ s, f a) :=
+  tendsto_atTop_iSup fun _ _ ↦ Finset.sum_le_sum_of_subset
+
+@[simp] protected theorem summable : Summable f :=
+  ⟨_, ENat.hasSum⟩
+
+protected theorem tsum_eq_iSup_sum : ∑' x, f x = (⨆ s : Finset α, ∑ a ∈ s, f a) :=
+  ENat.hasSum.tsum_eq
+
+protected theorem tsum_comm {f : α → β → ℕ∞} : ∑' (a) (b), f a b = ∑' (b) (a), f a b :=
+  tsum_comm' ENat.summable (fun _ ↦ ENat.summable) fun _ ↦ ENat.summable
+
+protected theorem tsum_prod {f : α → β → ℕ∞} : ∑' p : α × β, f p.1 p.2 = ∑' (a) (b), f a b :=
+  tsum_prod' ENat.summable fun _ ↦ ENat.summable
+
+protected theorem tsum_add : ∑' a, (f a + g a) = ∑' a, f a + ∑' a, g a :=
+  tsum_add ENat.summable ENat.summable
+
+protected theorem tsum_le_tsum (h : f ≤ g) : ∑' a, f a ≤ ∑' a, g a :=
+  tsum_le_tsum h ENat.summable ENat.summable
+
+protected theorem sum_le_tsum {f : α → ℕ∞} (s : Finset α) : ∑ x ∈ s, f x ≤ ∑' x, f x :=
+  sum_le_tsum s (fun _ _ ↦ zero_le _) ENat.summable
+
+protected theorem le_tsum (a : α) : f a ≤ ∑' a, f a :=
+  le_tsum' ENat.summable a
+
+protected theorem le_tsum_of_mem {s : Set α} {a : α} (ha : a ∈ s) : f a ≤ ∑' x : s, f x :=
+  ENat.le_tsum (⟨a,ha⟩ : s)
+
+@[simp] protected theorem tsum_eq_zero : ∑' i, f i = 0 ↔ ∀ i, f i = 0 :=
+  tsum_eq_zero_iff ENat.summable
+
+protected theorem tsum_eq_top_of_eq_top : (∃ a, f a = ⊤) → ∑' a, f a = ⊤
+  | ⟨a, ha⟩ => top_unique <| ha ▸ ENat.le_tsum a
+
+protected theorem tsum_subtype_eq_top_of_eq_top {s : Set α} (h : ∃ a ∈ s, f a = ⊤) :
+    ∑' a : s, f a = ⊤ :=
+  let ⟨a, ha, has⟩ := h
+  ENat.tsum_eq_top_of_eq_top ⟨⟨a, ha⟩, has⟩
+
+protected theorem tsum_subtype_union_disjoint {s t : Set α} (hd : Disjoint s t) :
+    ∑' (x : ↑(s ∪ t)), f x = ∑' (x : s), f x + ∑' (x : t), f x :=
+  tsum_union_disjoint hd ENat.summable ENat.summable
+
+protected theorem tsum_subtype_le_of_subset {s t : Set α} (h : s ⊆ t) :
+    ∑' (x : s), f x ≤ ∑' (x : t), f x := by
+  rw [← diff_union_of_subset h, ENat.tsum_subtype_union_disjoint disjoint_sdiff_left]
+  exact le_add_self
+
+protected theorem tsum_subtype_union_le (s t : Set α) :
+    ∑' (x : ↑(s ∪ t)), f (x : α) ≤ ∑' (x : s), f x + ∑' (x : t), f x := by
+  rw [← diff_union_self, ENat.tsum_subtype_union_disjoint disjoint_sdiff_left]
+  exact add_le_add_right (ENat.tsum_subtype_le_of_subset diff_subset) _
+
+protected theorem tsum_subtype_insert {s : Set α} {a : α} (h : a ∉ s) :
+    ∑' (x : ↑(insert a s)), f x = f a + ∑' (x : s), f x := by
+  rw [← singleton_union, ENat.tsum_subtype_union_disjoint, tsum_singleton]
+  rwa [disjoint_singleton_left]
+
+protected theorem tsum_sub (hfin : ∑' a, g a ≠ ⊤) (h : g ≤ f) :
+    ∑' a, (f a - g a) = ∑' a, f a - ∑' a, g a := by
+  rw [← WithTop.add_right_inj hfin, ← ENat.tsum_add,
+    tsum_congr (fun i ↦ tsub_add_cancel_of_le (h i)), tsub_add_cancel_of_le (ENat.tsum_le_tsum h)]
+
+protected theorem mul_tsum (c : ℕ∞) : c * ∑' a, f a = ∑' a, c * f a := by
+  simp_rw [ENat.tsum_eq_iSup_sum, ENat.mul_iSup, Finset.mul_sum]
+
+protected theorem tsum_mul (c : ℕ∞) : (∑' a, f a) * c = ∑' a, f a * c := by
+  simp_rw [ENat.tsum_eq_iSup_sum, ENat.iSup_mul, Finset.sum_mul]
+
+protected theorem tsum_subtype_eq_top_iff_of_finite (hs : s.Finite) :
+    ∑' (x : s), f x = ⊤ ↔ ∃ a ∈ s, f a = ⊤ := by
+  induction s, hs using Set.Finite.induction_on with
+  | empty => simp
+  | @insert a s₀ has₀ hs₀ ih => simp [ENat.tsum_subtype_insert has₀, ih]
+
+protected theorem tsum_eq_top_of_support_infinite (hf : f.support.Infinite) : ∑' a, f a = ⊤ := by
+  rw [ENat.tsum_eq_iSup_sum, iSup_eq_top]
+  intro b hb
+  lift b to ℕ using hb.ne
+  obtain ⟨t, htf, hbt, hfin⟩ := hf.exists_finite_subset_encard_gt b
+  refine ⟨hfin.toFinset, hbt.trans_le ?_⟩
+  rw [hfin.encard_eq_coe_toFinset_card, Finset.card_eq_sum_ones, Nat.cast_sum]
+  refine Finset.sum_le_sum fun i hi ↦ ?_
+  simp only [Nat.cast_one, ENat.one_le_iff_ne_zero]
+  exact htf <| by simpa using hi
+
+protected theorem tsum_const_eq_top {ι : Type*} [Infinite ι] {c : ℕ∞} (hc : c ≠ 0) :
+    ∑' (_ : ι), c = ⊤ :=
+  ENat.tsum_eq_top_of_support_infinite <| by rwa [Function.support_const hc, infinite_univ_iff]
+
+protected theorem tsum_eq_top_iff : ∑' a, f a = ⊤ ↔ f.support.Infinite ∨ ∃ a, f a = ⊤ := by
+  rw [iff_def, or_imp, and_iff_right ENat.tsum_eq_top_of_support_infinite, or_iff_not_imp_left,
+    not_infinite]
+  refine ⟨fun htop hfin ↦ ?_, fun ⟨a, ha⟩ ↦ ?_⟩
+  · rw [← tsum_subtype_support, ENat.tsum_subtype_eq_top_iff_of_finite hfin] at htop
+    exact Exists.elim htop <| fun a h ↦ ⟨a, h.2⟩
+  rw [← top_le_iff, ← ha]
+  exact ENat.le_tsum a
+
+protected theorem tsum_subtype_eq_top_iff {s : Set α} :
+    ∑' (a : s), f a = ⊤ ↔ (s ∩ f.support).Infinite ∨ ∃ a ∈ s, f a = ⊤ := by
+  simp only [ENat.tsum_eq_top_iff, Subtype.exists, exists_prop]
+  convert Iff.rfl
+  convert Set.finite_image_iff Subtype.val_injective.injOn
+  aesop
+
+protected theorem tsum_subtype_eq_top_of_inter_support_infinite {s : Set α}
+    (hf : (s ∩ f.support).Infinite) : ∑' (a : s), f a = ⊤ :=
+  ENat.tsum_subtype_eq_top_iff.2 <| Or.inl hf
+
+protected theorem tsum_subtype_const_eq_top_of_ne_zero {s : Set α} (hs : s.Infinite) {c : ℕ∞}
+    (hc : c ≠ 0) : ∑' (_ : s), c = ⊤ :=
+  ENat.tsum_subtype_eq_top_of_inter_support_infinite (f := fun _ ↦ c)
+    <| by rwa [support_const hc, inter_univ]
+
+protected theorem tsum_comp_le_tsum_of_injective {f : α → β} (hf : Injective f) (g : β → ℕ∞) :
+    ∑' x, g (f x) ≤ ∑' y, g y :=
+  tsum_le_tsum_of_inj f hf (fun _ _ ↦ zero_le _) (fun _ ↦ le_rfl) ENat.summable ENat.summable
+
+protected theorem tsum_le_tsum_comp_of_surjective {f : α → β} (hf : Surjective f) (g : β → ℕ∞) :
+    ∑' y, g y ≤ ∑' x, g (f x) :=
+  calc ∑' y, g y = ∑' y, g (f (surjInv hf y)) := by simp only [surjInv_eq hf]
+    _ ≤ ∑' x, g (f x) := ENat.tsum_comp_le_tsum_of_injective (injective_surjInv hf) _
+
+protected theorem tsum_comp_eq_tsum_of_bijective {f : α → β} (hf : f.Bijective) (g : β → ℕ∞) :
+    ∑' x, g (f x) = ∑' y, g y :=
+  (ENat.tsum_comp_le_tsum_of_injective hf.injective g).antisymm
+    (ENat.tsum_le_tsum_comp_of_surjective hf.surjective g)
+
+protected theorem tsum_comp_eq_tsum_of_equiv (e : α ≃ β) (g : β → ℕ∞) :
+    ∑' x, g (e x) = ∑' y, g y := by
+  rw [ENat.tsum_comp_eq_tsum_of_bijective e.bijective]
+
+protected theorem tsum_subtype_mono (f : α → ℕ∞) {s t : Set α} (h : s ⊆ t) :
+    ∑' x : s, f x ≤ ∑' x : t, f x :=
+  ENat.tsum_comp_le_tsum_of_injective (inclusion_injective h) _
+
+protected theorem tsum_subtype_sigma {β : α → Type*} (f : ∀ a, β a → ℕ∞) :
+    ∑' p : Σa, β a, f p.1 p.2 = ∑' (a) (b), f a b :=
+  tsum_sigma' (fun _ ↦ ENat.summable) ENat.summable
+
+protected theorem tsum_subtype_sigma' {β : α → Type*} (f : (Σ a, β a) → ℕ∞) :
+    ∑' p : Σ a, β a, f p = ∑' (a) (b), f ⟨a, b⟩ :=
+  tsum_sigma' (fun _ ↦ ENat.summable) ENat.summable
+
+variable {ι : Type*}
+
+protected theorem tsum_subtype_iUnion_le_tsum (f : α → ℕ∞) (t : ι → Set α) :
+    ∑' x : ⋃ i, t i, f x ≤ ∑' i, ∑' x : (t i), f x :=
+  calc ∑' x : ⋃ i, t i, f x ≤ ∑' x : Σ i, t i, f x.2 :=
+    ENat.tsum_le_tsum_comp_of_surjective (sigmaToiUnion_surjective t) _
+  _ = ∑' i, ∑' x : t i, f x := ENat.tsum_subtype_sigma' _
+
+protected theorem tsum_subtype_biUnion_le_tsum (f : α → ℕ∞) (s : Set ι) (t : ι → Set α) :
+    ∑' x : ⋃ i ∈ s , t i, f x ≤ ∑' i : s, ∑' x : t i, f x :=
+  calc ∑' x : ⋃ i ∈ s, t i, f x = ∑' x : ⋃ i : s, t i, f x := by rw [tsum_congr_subtype]; simp
+  _ ≤ ∑' i : s, ∑' x : t i, f x := ENat.tsum_subtype_iUnion_le_tsum _ _
+
+protected theorem tsum_subtype_biUnion_le (f : α → ℕ∞) (s : Finset ι) (t : ι → Set α) :
+    ∑' x : ⋃ i ∈ s, t i, f x ≤ ∑ i ∈ s, ∑' x : t i, f x :=
+  (ENat.tsum_subtype_biUnion_le_tsum f s.toSet t).trans_eq <|
+    Finset.tsum_subtype s fun i ↦ ∑' x : t i, f x
+
+protected theorem tsum_subtype_iUnion_le [Fintype ι] (f : α → ℕ∞) (t : ι → Set α) :
+    ∑' x : ⋃ i, t i, f x ≤ ∑ i, ∑' x : t i, f x := by
+  rw [← tsum_fintype]
+  exact ENat.tsum_subtype_iUnion_le_tsum f t
+
+theorem tsum_subtype_iUnion_eq_tsum (f : α → ℕ∞) (t : ι → Set α) (ht : Pairwise (Disjoint on t)) :
+    ∑' x : ⋃ i, t i, f x = ∑' i, ∑' x : t i, f x :=
+  calc ∑' x : ⋃ i, t i, f x = ∑' x : Σ i, t i, f x.2 :=
+    (ENat.tsum_comp_eq_tsum_of_bijective (sigmaToiUnion_bijective t (fun _ _ hij ↦ ht hij)) _).symm
+    _ = _ := ENat.tsum_subtype_sigma' _
+
+end tsum
+
+end ENat


### PR DESCRIPTION
We give API for the interactions between `tsum` and `ENat`. The type is especially nice, because every function is summable, and there are simplifying lemmas like the statement that a sum is infinite iff either some term is infinite, or the support is infinite. 

This provides one of the missing pieces for working painlessly with discrete objects, 'propositional' finiteness and cardinality. For instance, one can sum a function `f : a -> ENat` over an arbitrary set with the term `∑' a : s, 1`, and it will be provable that `∑' a : s, 1 = s.encard` and `(support f).encard ≤ ∑' a, f a` without ever having to split into finite/infinite cases. 

As is pointed out in the module docstring for `Data.ENat`, there are strong analogies between `ENat` and `ENNReal`, and the API runs parallel to the API for `tsum`/`ENNReal`. One could call it 'duplication', but I have yet to find a common generalization of the two that saves work, or a third example of a natural type with these same properties.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
