### PR TITLE
refactor: smooth over Lattice/LinearOrder inheritance

### DIFF
--- a/Mathlib/Algebra/Order/Group/Defs.lean
+++ b/Mathlib/Algebra/Order/Group/Defs.lean
@@ -99,13 +99,13 @@ attribute [to_additive] OrderedCommGroup.lt_of_mul_lt_mul_left
 /-- A linearly ordered additive commutative group is an
 additive commutative group with a linear order in which
 addition is monotone. -/
-class LinearOrderedAddCommGroup (α : Type u) extends OrderedAddCommGroup α, LinearOrder α
+class LinearOrderedAddCommGroup (α : Type u) extends OrderedAddCommGroup α, LinearOrderedLattice α
 
 /-- A linearly ordered commutative group is a
 commutative group with a linear order in which
 multiplication is monotone. -/
 @[to_additive]
-class LinearOrderedCommGroup (α : Type u) extends OrderedCommGroup α, LinearOrder α
+class LinearOrderedCommGroup (α : Type u) extends OrderedCommGroup α, LinearOrderedLattice α
 
 section LinearOrderedCommGroup
 

--- a/Mathlib/Algebra/Order/Monoid/Defs.lean
+++ b/Mathlib/Algebra/Order/Monoid/Defs.lean
@@ -82,11 +82,11 @@ instance (priority := 100) OrderedCancelCommMonoid.toCancelCommMonoid : CancelCo
 end OrderedCancelCommMonoid
 
 /-- A linearly ordered additive commutative monoid. -/
-class LinearOrderedAddCommMonoid (α : Type*) extends OrderedAddCommMonoid α, LinearOrder α
+class LinearOrderedAddCommMonoid (α : Type*) extends OrderedAddCommMonoid α, LinearOrderedLattice α
 
 /-- A linearly ordered commutative monoid. -/
 @[to_additive]
-class LinearOrderedCommMonoid (α : Type*) extends OrderedCommMonoid α, LinearOrder α
+class LinearOrderedCommMonoid (α : Type*) extends OrderedCommMonoid α, LinearOrderedLattice α
 
 /-- A linearly ordered cancellative additive commutative monoid is an additive commutative monoid
 with a decidable linear order in which addition is cancellative and monotone. -/

--- a/Mathlib/Order/Basic.lean
+++ b/Mathlib/Order/Basic.lean
@@ -485,21 +485,20 @@ theorem PartialOrder.toPreorder_injective :
   congr
 
 @[ext]
-theorem LinearOrder.toPartialOrder_injective :
-    Function.Injective (@LinearOrder.toPartialOrder α) :=
+theorem LinearOrder.toLinearOrderBase_injective :
+    Function.Injective (@LinearOrder.toLinearOrderBase α) :=
   fun A B h ↦ match A, B with
   | { le := A_le, lt := A_lt,
       decidableLE := A_decidableLE, decidableEq := A_decidableEq, decidableLT := A_decidableLT
-      min := A_min, max := A_max, min_def := A_min_def, max_def := A_max_def,
-      compare := A_compare, compare_eq_compareOfLessAndEq := A_compare_canonical, .. },
+      min := A_min, max := A_max,
+      compare := A_compare, compare_eq_compareOfLessAndEq := A_compare_canonical,
+      min_def := A_min_def, max_def := A_max_def, .. },
     { le := B_le, lt := B_lt,
       decidableLE := B_decidableLE, decidableEq := B_decidableEq, decidableLT := B_decidableLT
-      min := B_min, max := B_max, min_def := B_min_def, max_def := B_max_def,
-      compare := B_compare, compare_eq_compareOfLessAndEq := B_compare_canonical, .. } => by
+      min := B_min, max := B_max,
+      compare := B_compare, compare_eq_compareOfLessAndEq := B_compare_canonical,
+      min_def := B_min_def, max_def := B_max_def, .. } => by
     cases h
-    obtain rfl : A_decidableLE = B_decidableLE := Subsingleton.elim _ _
-    obtain rfl : A_decidableEq = B_decidableEq := Subsingleton.elim _ _
-    obtain rfl : A_decidableLT = B_decidableLT := Subsingleton.elim _ _
     have : A_min = B_min := by
       funext a b
       exact (A_min_def _ _).trans (B_min_def _ _).symm
@@ -508,6 +507,23 @@ theorem LinearOrder.toPartialOrder_injective :
       funext a b
       exact (A_max_def _ _).trans (B_max_def _ _).symm
     cases this
+    congr
+
+@[ext]
+theorem LinearOrder.toPartialOrder_injective :
+    Function.Injective (fun _ : LinearOrder α => @LinearOrderBase.toPartialOrder α _) :=
+  (.comp · LinearOrder.toLinearOrderBase_injective) <|
+  fun A B h ↦ match A, B with
+  | { le := A_le, lt := A_lt,
+      decidableLE := A_decidableLE, decidableEq := A_decidableEq, decidableLT := A_decidableLT
+      compare := A_compare, compare_eq_compareOfLessAndEq := A_compare_canonical, .. },
+    { le := B_le, lt := B_lt,
+      decidableLE := B_decidableLE, decidableEq := B_decidableEq, decidableLT := B_decidableLT
+      compare := B_compare, compare_eq_compareOfLessAndEq := B_compare_canonical, .. } => by
+    cases h
+    obtain rfl : A_decidableLE = B_decidableLE := Subsingleton.elim _ _
+    obtain rfl : A_decidableEq = B_decidableEq := Subsingleton.elim _ _
+    obtain rfl : A_decidableLT = B_decidableLT := Subsingleton.elim _ _
     have : A_compare = B_compare := by
       funext a b
       exact (A_compare_canonical _ _).trans (B_compare_canonical _ _).symm
@@ -722,7 +738,7 @@ instance instLinearOrder (α : Type*) [LinearOrder α] : LinearOrder αᵒᵈ wh
   decidableLT := (inferInstance : DecidableRel (fun a b : α ↦ b < a))
   decidableEq := (inferInstance : DecidableEq α)
   compare_eq_compareOfLessAndEq a b := by
-    simp only [compare, LinearOrder.compare_eq_compareOfLessAndEq, compareOfLessAndEq, eq_comm]
+    simp only [compare, LinearOrderBase.compare_eq_compareOfLessAndEq, compareOfLessAndEq, eq_comm]
     rfl
 
 /-- The opposite linear order to a given linear order -/
@@ -966,7 +982,7 @@ theorem compare_of_injective_eq_compareOfLessAndEq (a b : α) [LinearOrder β]
     [Decidable (LT.lt (self := PartialOrder.lift f inj |>.toLT) a b)] :
     compare (f a) (f b) =
       @compareOfLessAndEq _ a b (PartialOrder.lift f inj |>.toLT) _ _ := by
-  have h := LinearOrder.compare_eq_compareOfLessAndEq (f a) (f b)
+  have h := LinearOrderBase.compare_eq_compareOfLessAndEq (f a) (f b)
   simp only [h, compareOfLessAndEq]
   split_ifs <;> try (first | rfl | contradiction)
   · have : ¬ f a = f b := by rename_i h; exact inj.ne h

--- a/Mathlib/Order/CompleteLattice/Defs.lean
+++ b/Mathlib/Order/CompleteLattice/Defs.lean
@@ -261,28 +261,8 @@ def completeLatticeOfCompleteSemilatticeSup (α : Type*) [CompleteSemilatticeSup
   completeLatticeOfSup α fun s => isLUB_sSup s
 
 /-- A complete linear order is a linear order whose lattice structure is complete. -/
--- Note that we do not use `extends LinearOrder α`,
--- and instead construct the forgetful instance manually.
-class CompleteLinearOrder (α : Type*) extends CompleteLattice α, BiheytingAlgebra α where
-  /-- A linear order is total. -/
-  le_total (a b : α) : a ≤ b ∨ b ≤ a
-  /-- In a linearly ordered type, we assume the order relations are all decidable. -/
-  decidableLE : DecidableLE α
-  /-- In a linearly ordered type, we assume the order relations are all decidable. -/
-  decidableEq : DecidableEq α := @decidableEqOfDecidableLE _ _ decidableLE
-  /-- In a linearly ordered type, we assume the order relations are all decidable. -/
-  decidableLT : DecidableLT α := @decidableLTOfDecidableLE _ _ decidableLE
-
-instance CompleteLinearOrder.toLinearOrder [i : CompleteLinearOrder α] : LinearOrder α where
-  __ := i
-  min_def a b := by
-    split_ifs with h
-    · simp [h]
-    · simp [(CompleteLinearOrder.le_total a b).resolve_left h]
-  max_def a b := by
-    split_ifs with h
-    · simp [h]
-    · simp [(CompleteLinearOrder.le_total a b).resolve_left h]
+class CompleteLinearOrder (α : Type*)
+  extends CompleteLattice α, BiheytingAlgebra α, LinearOrderedLattice α where
 
 namespace OrderDual
 

--- a/Mathlib/Order/ConditionallyCompleteLattice/Defs.lean
+++ b/Mathlib/Order/ConditionallyCompleteLattice/Defs.lean
@@ -58,15 +58,8 @@ To differentiate the statements from the corresponding statements in (unconditio
 complete linear orders, we prefix `sInf` and `sSup` by a `c` everywhere. The same statements should
 hold in both worlds, sometimes with additional assumptions of nonemptiness or
 boundedness. -/
-class ConditionallyCompleteLinearOrder (α : Type*) extends ConditionallyCompleteLattice α where
-  /-- A `ConditionallyCompleteLinearOrder` is total. -/
-  le_total (a b : α) : a ≤ b ∨ b ≤ a
-  /-- In a `ConditionallyCompleteLinearOrder`, we assume the order relations are all decidable. -/
-  decidableLE : DecidableLE α
-  /-- In a `ConditionallyCompleteLinearOrder`, we assume the order relations are all decidable. -/
-  decidableEq : DecidableEq α := @decidableEqOfDecidableLE _ _ decidableLE
-  /-- In a `ConditionallyCompleteLinearOrder`, we assume the order relations are all decidable. -/
-  decidableLT : DecidableLT α := @decidableLTOfDecidableLE _ _ decidableLE
+class ConditionallyCompleteLinearOrder (α : Type*) extends
+    ConditionallyCompleteLattice α, LinearOrderedLattice α where
   /-- If a set is not bounded above, its supremum is by convention `sSup ∅`. -/
   csSup_of_not_bddAbove : ∀ s, ¬BddAbove s → sSup s = sSup (∅ : Set α)
   /-- If a set is not bounded below, its infimum is by convention `sInf ∅`. -/

--- a/Mathlib/Order/Defs/LinearOrder.lean
+++ b/Mathlib/Order/Defs/LinearOrder.lean
@@ -50,9 +50,8 @@ macro "compareOfLessAndEq_rfl" : tactic =>
 
 /-- Auxiliary typeclass to avoid diamonds.
 
-This is mathematically equivalent to `LinearOrder`, but without the `min` and `max` fields which
-cause trouble with duplicate `inf` and `sup` fields in later files.
-It should not be used except as a base class.
+This exists only to act as a common base class for `LinearOrder` and `LinearOrderedLattice`.
+It should contain all the fields of `LinearOrder` except `min` and `max`.
 -/
 class LinearOrderBase (α : Type*) extends PartialOrder α, Ord α where
   /-- A linear order is total. -/

--- a/Mathlib/Order/Lattice.lean
+++ b/Mathlib/Order/Lattice.lean
@@ -642,12 +642,34 @@ abbrev DistribLattice.ofInfSupLe
 ### Lattices derived from linear orders
 -/
 
-
--- see Note [lower instance priority]
-instance (priority := 100) LinearOrder.toLattice {α : Type u} [o : LinearOrder α] : Lattice α where
-  __ := o
+instance (priority := 100) LinearOrder.toLattice {α : Type u} [LinearOrder α] :
+    Lattice α where
+  __ : LinearOrder α := ‹_›
   le_sup_left := le_max_left; le_sup_right := le_max_right; sup_le _ _ _ := max_le
   inf_le_left := min_le_left; inf_le_right := min_le_right; le_inf _ _ _ := le_min
+
+/--
+A copy of `LinearOrder` which works better as a base class for lattice-theoretic typeclasses.
+
+An internal class to resolve instance diamonds with `LinearOrder` when building deeper lattice
+subclasses.
+The alternative would be to make `LinearOrder` extend `Lattice`, but then we would have to use
+the undesirable `min` and `max` names within the `Lattice` fields.
+
+This should be avoided in lemma statements, and specialized instances of it should not be defined;
+it exists only to be used in `extends`. -/
+class LinearOrderedLattice (α : Type*) extends Lattice α, LinearOrderBase α where
+
+instance (priority := 100) LinearOrderedLattice.toLinearOrder {α : Type u}
+    [LinearOrderedLattice α] : LinearOrder α where
+  min_def a b := by
+    split_ifs with h
+    · simp [h]
+    · simp [(le_total a b).resolve_left h]
+  max_def a b := by
+    split_ifs with h
+    · simp [h]
+    · simp [(le_total a b).resolve_left h]
 
 section LinearOrder
 

--- a/Mathlib/Order/Lattice.lean
+++ b/Mathlib/Order/Lattice.lean
@@ -656,8 +656,9 @@ subclasses.
 The alternative would be to make `LinearOrder` extend `Lattice`, but then we would have to use
 the undesirable `min` and `max` names within the `Lattice` fields.
 
-This should be avoided in lemma statements, and specialized instances of it should not be defined;
-it exists only to be used in `extends`. -/
+This should be avoided in lemma statements, as it provides no results not provided by
+`LinearOrder`. However, it is fine to create `instances` of this, if the lattice fields are
+easier to populate than the `min_def` and `max_def` fields. -/
 class LinearOrderedLattice (α : Type*) extends Lattice α, LinearOrderBase α where
 
 instance (priority := 100) LinearOrderedLattice.toLinearOrder {α : Type u}


### PR DESCRIPTION
This fixes the forgetful inheritance in `CompleteLinearOrder` and `ConditionallyCompleteLinearOrder`, which previously did not carry `compare` fields. (edit: moved to #23515)

The following is the inheritance diagram before, where the dotted lines are manual instances. Note that every lattice typeclass that extends `LinearOrder` has to implement another dotted line edge, and remember to copy all the necessary data fields.
```mermaid
graph TD
   LinearOrder --> Min,Max;
   LinearOrder --> PartialOrder;
   Lattice --> PartialOrder;
   CompleteLinearOrder --> Lattice;
   ConditionallyCompleteLinearOrder --> Lattice;
   LinearOrder-.-> Lattice;
   CompleteLinearOrder -.-> LinearOrder;
   ConditionallyCompleteLinearOrder -.-> LinearOrder;
```
This change introduces two new auxiliary typeclasses, to encapsulate these troublesome edges. `LinearOrderedLattice` can be thought of as `LinearOrder`, but with `sup`/`inf` instead of `min`/`max`. This is crucial, because it ensures the duplicate fields are merged in `extends CompleteLattice X, LinearOrderedLattice X`, which would not be the case for `extends CompleteLattice X, LinearOrder X`. The result is:
```mermaid
graph TD
   LinearOrder --> Min,Max;
   LinearOrder --> LinearOrderBase;
   LinearOrderBase --> PartialOrder;
   Lattice --> PartialOrder;
   LinearOrderedLattice -.-> LinearOrder;
   LinearOrderedLattice --> LinearOrderBase;
   LinearOrderedLattice --> Lattice;
   CompleteLinearOrder --> LinearOrderedLattice;
   ConditionallyCompleteLinearOrder --> LinearOrderedLattice;
```


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]

-->

- [ ] depends on: #23515
- [ ] 
[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
