### PR TITLE
[Merged by Bors] - feat: behavior of divisors under addition

### DIFF
--- a/Mathlib/Analysis/Meromorphic/Divisor.lean
+++ b/Mathlib/Analysis/Meromorphic/Divisor.lean
@@ -127,7 +127,6 @@ theorem divisor_inv [CompleteSpace 𝕜] {f : 𝕜 → 𝕜} :
   · simp [divisor_def, h]
 
 /-- Adding an analytic function to a meromorphic one does not change the pole divisor. -/
-@[simp]
 theorem divisor_add_analytic {f₁ f₂ : 𝕜 → E} (hf₁ : MeromorphicOn f₁ U)
     (hf₂ : AnalyticOnNhd 𝕜 f₂ U) :
     (divisor f₁ U)⁻ = (divisor (f₁ + f₂) U)⁻ := by

--- a/Mathlib/Analysis/Meromorphic/Divisor.lean
+++ b/Mathlib/Analysis/Meromorphic/Divisor.lean
@@ -132,19 +132,19 @@ theorem negPart_divisor_add_of_analyticNhdOn_right {f₁ f₂ : 𝕜 → E} (hf�
     (divisor (f₁ + f₂) U)⁻ = (divisor f₁ U)⁻ := by
   ext x
   by_cases hx : x ∈ U
-  · simp [negPart_def, hx, hf₁, hf₁.add hf₂.meromorphicOn]
+  · suffices -(hf₁.add (hf₂.meromorphicOn) x hx).order.untop₀ ⊔ 0 = -(hf₁ x hx).order.untop₀ ⊔ 0 by
+      simpa [negPart_def, hx, hf₁, hf₁.add hf₂.meromorphicOn]
     by_cases h : 0 ≤ (hf₁ x hx).order
-    · simp only [Int.neg_nonpos_iff_nonneg, WithTop.untop₀_nonneg, h, sup_of_le_right,
-        right_eq_sup, eq_comm]
+    · suffices 0 ≤ (add hf₁ (AnalyticOnNhd.meromorphicOn hf₂) x hx).order by simp_all
       calc 0
-      _ ≤ min (hf₁ x hx).order (hf₂.meromorphicOn x hx).order := by
-        exact le_inf h (hf₂ x hx).meromorphicAt_order_nonneg
-      _ ≤ ((hf₁.add hf₂.meromorphicOn) x hx).order := by
-        exact (hf₁ x hx).order_add (hf₂ x hx).meromorphicAt
-    · simp at h
-      rw [(hf₁ x hx).order_add_of_order_lt_order (hf₂.meromorphicOn x hx)]
+      _ ≤ min (hf₁ x hx).order (hf₂.meromorphicOn x hx).order :=
+        le_inf h (hf₂ x hx).meromorphicAt_order_nonneg
+      _ ≤ ((hf₁.add hf₂.meromorphicOn) x hx).order :=
+        (hf₁ x hx).order_add (hf₂ x hx).meromorphicAt
+    · suffices (hf₁ x hx).order < (AnalyticOnNhd.meromorphicOn hf₂ x hx).order by
+        rwa [(hf₁ x hx).order_add_of_order_lt_order (hf₂.meromorphicOn x hx)]
       calc (hf₁ x hx).order
-      _ < 0 := h
+      _ < 0 := by simpa using h
       _ ≤ (hf₂.meromorphicOn x hx).order := (hf₂ x hx).meromorphicAt_order_nonneg
   simp [hx]
 

--- a/Mathlib/Analysis/Meromorphic/Divisor.lean
+++ b/Mathlib/Analysis/Meromorphic/Divisor.lean
@@ -129,13 +129,13 @@ theorem divisor_inv [CompleteSpace 𝕜] {f : 𝕜 → 𝕜} :
 /-- Adding an analytic function to a meromorphic one does not change the pole divisor. -/
 theorem negPart_divisor_add_of_analyticNhdOn_right {f₁ f₂ : 𝕜 → E} (hf₁ : MeromorphicOn f₁ U)
     (hf₂ : AnalyticOnNhd 𝕜 f₂ U) :
-    (divisor f₁ U)⁻ = (divisor (f₁ + f₂) U)⁻ := by
+    (divisor (f₁ + f₂) U)⁻ = (divisor f₁ U)⁻ := by
   ext x
   by_cases hx : x ∈ U
   · simp [negPart_def, hx, hf₁, hf₁.add hf₂.meromorphicOn]
     by_cases h : 0 ≤ (hf₁ x hx).order
     · simp only [Int.neg_nonpos_iff_nonneg, WithTop.untop₀_nonneg, h, sup_of_le_right,
-        right_eq_sup]
+        right_eq_sup, eq_comm]
       calc 0
       _ ≤ min (hf₁ x hx).order (hf₂.meromorphicOn x hx).order := by
         exact le_inf h (hf₂ x hx).meromorphicAt_order_nonneg
@@ -147,5 +147,12 @@ theorem negPart_divisor_add_of_analyticNhdOn_right {f₁ f₂ : 𝕜 → E} (hf�
       _ < 0 := h
       _ ≤ (hf₂.meromorphicOn x hx).order := (hf₂ x hx).meromorphicAt_order_nonneg
   simp [hx]
+
+/-- Adding an analytic function to a meromorphic one does not change the pole divisor. -/
+theorem negPart_divisor_add_of_analyticNhdOn_left {f₁ f₂ : 𝕜 → E} (hf₁ : AnalyticOnNhd 𝕜 f₁ U)
+    (hf₂ : MeromorphicOn f₂ U) :
+    (divisor (f₁ + f₂) U)⁻ = (divisor f₂ U)⁻ := by
+  rw [add_comm]
+  exact negPart_divisor_add_of_analyticNhdOn_right hf₂ hf₁
 
 end MeromorphicOn

--- a/Mathlib/Analysis/Meromorphic/Divisor.lean
+++ b/Mathlib/Analysis/Meromorphic/Divisor.lean
@@ -16,8 +16,6 @@ divisors.
 ## TODO
 
 - Compatibility with restriction of divisors/functions
-- Non-negativity of the divisor for an analytic function
-- Behavior under addition of functions
 - Congruence lemmas for `codiscreteWithin`
 -/
 
@@ -70,6 +68,18 @@ lemma divisor_apply {f : 𝕜 → E} (hf : MeromorphicOn f U) (hz : z ∈ U) :
     divisor f U z = (hf z hz).order.untop₀ := by simp_all [MeromorphicOn.divisor_def, hz]
 
 /-!
+## Divisors of Analytic Functions
+-/
+
+/-- Analytic functions have non-negative divisors. -/
+theorem AnalyticOnNhd.divisor_nonneg {f : 𝕜 → E} (hf : AnalyticOnNhd 𝕜 f U) :
+    0 ≤ MeromorphicOn.divisor f U := by
+  intro x
+  by_cases hx : x ∈ U
+  · simp [hf.meromorphicOn, hx, (hf x hx).meromorphicAt_order_nonneg]
+  simp [hx]
+
+/-!
 ## Behavior under Standard Operations
 -/
 
@@ -115,5 +125,28 @@ theorem divisor_inv [CompleteSpace 𝕜] {f : 𝕜 → 𝕜} :
   by_cases h : MeromorphicOn f U ∧ z ∈ U
   · simp [divisor_apply, h, (h.1 z h.2).order_inv]
   · simp [divisor_def, h]
+
+/-- Adding an analytic function to a meromorphic one does not change the pole divisor. -/
+@[simp]
+theorem divisor_add_analytic {f₁ f₂ : 𝕜 → E} (hf₁ : MeromorphicOn f₁ U)
+    (hf₂ : AnalyticOnNhd 𝕜 f₂ U) :
+    (divisor f₁ U)⁻ = (divisor (f₁ + f₂) U)⁻ := by
+  ext x
+  by_cases hx : x ∈ U
+  · simp [negPart_def, hx, hf₁, hf₁.add hf₂.meromorphicOn]
+    by_cases h : 0 ≤ (hf₁ x hx).order
+    · simp only [Int.neg_nonpos_iff_nonneg, WithTop.untop₀_nonneg, h, sup_of_le_right,
+        right_eq_sup]
+      calc 0
+      _ ≤ min (hf₁ x hx).order (hf₂.meromorphicOn x hx).order := by
+        exact le_inf_iff.2 ⟨h, (hf₂ x hx).meromorphicAt_order_nonneg⟩
+      _ ≤ ((hf₁.add hf₂.meromorphicOn) x hx).order := by
+        exact (hf₁ x hx).order_add (hf₂ x hx).meromorphicAt
+    · simp at h
+      rw [(hf₁ x hx).order_add_of_order_lt_order (hf₂.meromorphicOn x hx)]
+      calc (hf₁ x hx).order
+      _ < 0 := h
+      _ ≤ (hf₂.meromorphicOn x hx).order := (hf₂ x hx).meromorphicAt_order_nonneg
+  simp [hx]
 
 end MeromorphicOn

--- a/Mathlib/Analysis/Meromorphic/Divisor.lean
+++ b/Mathlib/Analysis/Meromorphic/Divisor.lean
@@ -127,7 +127,7 @@ theorem divisor_inv [CompleteSpace 𝕜] {f : 𝕜 → 𝕜} :
   · simp [divisor_def, h]
 
 /-- Adding an analytic function to a meromorphic one does not change the pole divisor. -/
-theorem divisor_add_analytic {f₁ f₂ : 𝕜 → E} (hf₁ : MeromorphicOn f₁ U)
+theorem negPart_divisor_add_of_analyticNhdOn_right {f₁ f₂ : 𝕜 → E} (hf₁ : MeromorphicOn f₁ U)
     (hf₂ : AnalyticOnNhd 𝕜 f₂ U) :
     (divisor f₁ U)⁻ = (divisor (f₁ + f₂) U)⁻ := by
   ext x
@@ -138,7 +138,7 @@ theorem divisor_add_analytic {f₁ f₂ : 𝕜 → E} (hf₁ : MeromorphicOn f�
         right_eq_sup]
       calc 0
       _ ≤ min (hf₁ x hx).order (hf₂.meromorphicOn x hx).order := by
-        exact le_inf_iff.2 ⟨h, (hf₂ x hx).meromorphicAt_order_nonneg⟩
+        exact le_inf h (hf₂ x hx).meromorphicAt_order_nonneg
       _ ≤ ((hf₁.add hf₂.meromorphicOn) x hx).order := by
         exact (hf₁ x hx).order_add (hf₂ x hx).meromorphicAt
     · simp at h


### PR DESCRIPTION
Deliver on two elementary TODOs: Show that the divisor of an analytic function is non-negative. Show that adding an analytic function to a meromorphic one does not change the pole divisor.

This material is used in [Project VD](https://github.com/kebekus/ProjectVD), which aims to formalize Value Distribution Theory for meromorphic functions on the complex plane.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
