### PR TITLE
[Merged by Bors] - feat: add isOpen_setOf_affineIndependent

### DIFF
--- a/Mathlib/Analysis/Normed/Module/FiniteDimension.lean
+++ b/Mathlib/Analysis/Normed/Module/FiniteDimension.lean
@@ -281,8 +281,7 @@ theorem isOpen_setOf_affineIndependent {ι : Type*} [Finite ι] :
     haveI : Fintype ι' := Subtype.fintype _
     convert_to
       IsOpen ((fun (p : ι → E) (i : ι') ↦ p i -ᵥ p i₀) ⁻¹' {p : ι' → E | LinearIndependent 𝕜 p})
-    refine isOpen_setOf_linearIndependent.preimage ?_
-    fun_prop
+    exact isOpen_setOf_linearIndependent.preimage (by fun_prop)
 
 namespace Module.Basis
 

--- a/Mathlib/Analysis/Normed/Module/FiniteDimension.lean
+++ b/Mathlib/Analysis/Normed/Module/FiniteDimension.lean
@@ -270,6 +270,21 @@ theorem isOpen_setOf_nat_le_rank (n : ℕ) :
     continuous_pi fun x => (ContinuousLinearMap.apply 𝕜 F (x : E)).continuous
   exact isOpen_setOf_linearIndependent.preimage this
 
+theorem isOpen_setOf_affineIndependent {ι : Type*} [Finite ι] :
+    IsOpen {p : ι → E | AffineIndependent 𝕜 p} := by
+  classical
+  rcases isEmpty_or_nonempty ι with h | ⟨⟨i₀⟩⟩
+  · exact isOpen_discrete _
+  · simp_rw [affineIndependent_iff_linearIndependent_vsub 𝕜 _ i₀]
+    let ι' := { x // x ≠ i₀ }
+    cases nonempty_fintype ι
+    haveI : Fintype ι' := Subtype.fintype _
+    convert_to
+      IsOpen ((fun (p : ι → E) (i : ι') ↦ p i -ᵥ p i₀) ⁻¹' {p : ι' → E | LinearIndependent 𝕜 p})
+    refine isOpen_setOf_linearIndependent.preimage ?_
+    exact continuous_pi fun i' ↦
+      (continuous_apply (π := fun _ : ι ↦ E) i'.1).vsub <| continuous_apply i₀
+
 namespace Module.Basis
 
 theorem opNNNorm_le {ι : Type*} [Fintype ι] (v : Basis ι 𝕜 E) {u : E →L[𝕜] F} (M : ℝ≥0)

--- a/Mathlib/Analysis/Normed/Module/FiniteDimension.lean
+++ b/Mathlib/Analysis/Normed/Module/FiniteDimension.lean
@@ -282,8 +282,7 @@ theorem isOpen_setOf_affineIndependent {ι : Type*} [Finite ι] :
     convert_to
       IsOpen ((fun (p : ι → E) (i : ι') ↦ p i -ᵥ p i₀) ⁻¹' {p : ι' → E | LinearIndependent 𝕜 p})
     refine isOpen_setOf_linearIndependent.preimage ?_
-    exact continuous_pi fun i' ↦
-      (continuous_apply (π := fun _ : ι ↦ E) i'.1).vsub <| continuous_apply i₀
+    fun_prop
 
 namespace Module.Basis
 


### PR DESCRIPTION
From sphere-eversion.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
