### PR TITLE
[Merged by Bors] - refactor: generalize `unbounded_of_tendsto_atTop`

### DIFF
--- a/Mathlib/Order/Filter/AtTopBot/Basic.lean
+++ b/Mathlib/Order/Filter/AtTopBot/Basic.lean
@@ -450,32 +450,26 @@ theorem map_div_atTop_eq_nat (k : ℕ) (hk : 0 < k) : map (fun a => a / k) atTop
     fun b _ => by rw [Nat.mul_add_div hk, Nat.div_eq_of_lt, Nat.add_zero]; omega
 
 section IsDirected
-variable [Nonempty α] [Preorder α] [IsDirected α (· ≤ ·)] [Preorder β] {f : α → β}
+variable [Preorder β] {l : Filter α} [NeBot l] {f : α → β}
 
-theorem unbounded_of_tendsto_atTop [NoMaxOrder β] (h : Tendsto f atTop atTop) :
+theorem unbounded_of_tendsto_atTop [NoMaxOrder β] (h : Tendsto f l atTop) :
     ¬BddAbove (range f) := by
   rintro ⟨M, hM⟩
-  obtain ⟨a, ha⟩ := mem_atTop_sets.mp (h <| Ioi_mem_atTop M)
-  apply lt_irrefl M
-  calc
-    M < f a := ha a le_rfl
-    _ ≤ M := hM (Set.mem_range_self a)
+  have : ∀ x, f x ≤ M := by aesop
+  have : ∅ = f ⁻¹' Ioi M := by aesop (add forward safe not_le_of_lt)
+  apply Filter.empty_not_mem l
+  aesop (add safe Ioi_mem_atTop)
 
-theorem unbounded_of_tendsto_atBot [NoMinOrder β] (h : Tendsto f atTop atBot) :
+theorem unbounded_of_tendsto_atBot [NoMinOrder β] (h : Tendsto f l atBot) :
     ¬BddBelow (range f) := unbounded_of_tendsto_atTop (β := βᵒᵈ) h
 
+@[deprecated (since := "2025-04-01")]
+alias unbounded_of_tendsto_atTop' := unbounded_of_tendsto_atTop
+
+@[deprecated (since := "2025-04-01")]
+alias unbounded_of_tendsto_atBot' := unbounded_of_tendsto_atBot
+
 end IsDirected
-
-section IsCodirected
-variable [Nonempty α] [Preorder α] [IsDirected α (· ≥ ·)] [Preorder β] {f : α → β}
-
-theorem unbounded_of_tendsto_atTop' [NoMaxOrder β] (h : Tendsto f atBot atTop) :
-    ¬BddAbove (range f) := unbounded_of_tendsto_atTop (α := αᵒᵈ) h
-
-theorem unbounded_of_tendsto_atBot' [NoMinOrder β] (h : Tendsto f atBot atBot) :
-    ¬BddBelow (range f) := unbounded_of_tendsto_atTop (α := αᵒᵈ) (β := βᵒᵈ) h
-
-end IsCodirected
 
 theorem HasAntitoneBasis.eventually_subset [Preorder ι] {l : Filter α} {s : ι → Set α}
     (hl : l.HasAntitoneBasis s) {t : Set α} (ht : t ∈ l) : ∀ᶠ i in atTop, s i ⊆ t :=

--- a/Mathlib/Order/Filter/AtTopBot/Basic.lean
+++ b/Mathlib/Order/Filter/AtTopBot/Basic.lean
@@ -449,7 +449,7 @@ theorem map_div_atTop_eq_nat (k : ℕ) (hk : 0 < k) : map (fun a => a / k) atTop
     (fun a b _ => by rw [Nat.div_le_iff_le_mul_add_pred hk])
     fun b _ => by rw [Nat.mul_add_div hk, Nat.div_eq_of_lt, Nat.add_zero]; omega
 
-section IsDirected
+section NeBot
 variable [Preorder β] {l : Filter α} [NeBot l] {f : α → β}
 
 theorem unbounded_of_tendsto_atTop [NoMaxOrder β] (h : Tendsto f l atTop) :
@@ -469,7 +469,7 @@ alias unbounded_of_tendsto_atTop' := unbounded_of_tendsto_atTop
 @[deprecated (since := "2025-04-01")]
 alias unbounded_of_tendsto_atBot' := unbounded_of_tendsto_atBot
 
-end IsDirected
+end NeBot
 
 theorem HasAntitoneBasis.eventually_subset [Preorder ι] {l : Filter α} {s : ι → Set α}
     (hl : l.HasAntitoneBasis s) {t : Set α} (ht : t ∈ l) : ∀ᶠ i in atTop, s i ⊆ t :=

--- a/Mathlib/Order/Filter/AtTopBot/Basic.lean
+++ b/Mathlib/Order/Filter/AtTopBot/Basic.lean
@@ -452,7 +452,7 @@ theorem map_div_atTop_eq_nat (k : ℕ) (hk : 0 < k) : map (fun a => a / k) atTop
 section NeBot
 variable [Preorder β] {l : Filter α} [NeBot l] {f : α → β}
 
-theorem unbounded_of_tendsto_atTop [NoMaxOrder β] (h : Tendsto f l atTop) :
+theorem not_bddAbove_of_tendsto_atTop [NoMaxOrder β] (h : Tendsto f l atTop) :
     ¬BddAbove (range f) := by
   rintro ⟨M, hM⟩
   have : ∀ x, f x ≤ M := by aesop
@@ -460,14 +460,20 @@ theorem unbounded_of_tendsto_atTop [NoMaxOrder β] (h : Tendsto f l atTop) :
   apply Filter.empty_not_mem l
   aesop (add safe Ioi_mem_atTop)
 
-theorem unbounded_of_tendsto_atBot [NoMinOrder β] (h : Tendsto f l atBot) :
-    ¬BddBelow (range f) := unbounded_of_tendsto_atTop (β := βᵒᵈ) h
+theorem not_bddBelow_of_tendsto_atBot [NoMinOrder β] (h : Tendsto f l atBot) :
+    ¬BddBelow (range f) := not_bddAbove_of_tendsto_atTop (β := βᵒᵈ) h
 
-@[deprecated (since := "2025-04-01")]
-alias unbounded_of_tendsto_atTop' := unbounded_of_tendsto_atTop
+@[deprecated (since := "2025-04-28")]
+alias unbounded_of_tendsto_atTop := not_bddAbove_of_tendsto_atTop
 
-@[deprecated (since := "2025-04-01")]
-alias unbounded_of_tendsto_atBot' := unbounded_of_tendsto_atBot
+@[deprecated (since := "2025-04-28")]
+alias unbounded_of_tendsto_atBot := not_bddBelow_of_tendsto_atBot
+
+@[deprecated (since := "2025-04-28")]
+alias unbounded_of_tendsto_atTop' := not_bddAbove_of_tendsto_atTop
+
+@[deprecated (since := "2025-04-28")]
+alias unbounded_of_tendsto_atBot' := not_bddBelow_of_tendsto_atBot
 
 end NeBot
 

--- a/Mathlib/Probability/Martingale/BorelCantelli.lean
+++ b/Mathlib/Probability/Martingale/BorelCantelli.lean
@@ -249,13 +249,13 @@ theorem Martingale.ae_not_tendsto_atTop_atTop [IsFiniteMeasure μ] (hf : Marting
     (hbdd : ∀ᵐ ω ∂μ, ∀ i, |f (i + 1) ω - f i ω| ≤ R) :
     ∀ᵐ ω ∂μ, ¬Tendsto (fun n => f n ω) atTop atTop := by
   filter_upwards [hf.bddAbove_range_iff_bddBelow_range hbdd] with ω hω htop using
-    unbounded_of_tendsto_atTop htop (hω.2 <| bddBelow_range_of_tendsto_atTop_atTop htop)
+    not_bddAbove_of_tendsto_atTop htop (hω.2 <| bddBelow_range_of_tendsto_atTop_atTop htop)
 
 theorem Martingale.ae_not_tendsto_atTop_atBot [IsFiniteMeasure μ] (hf : Martingale f ℱ μ)
     (hbdd : ∀ᵐ ω ∂μ, ∀ i, |f (i + 1) ω - f i ω| ≤ R) :
     ∀ᵐ ω ∂μ, ¬Tendsto (fun n => f n ω) atTop atBot := by
   filter_upwards [hf.bddAbove_range_iff_bddBelow_range hbdd] with ω hω htop using
-    unbounded_of_tendsto_atBot htop (hω.1 <| bddAbove_range_of_tendsto_atTop_atBot htop)
+    not_bddBelow_of_tendsto_atBot htop (hω.1 <| bddAbove_range_of_tendsto_atTop_atBot htop)
 
 namespace BorelCantelli
 


### PR DESCRIPTION
---

Not sure if I like this style of proofs with `aesop` for future PRs. It's short, though.
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
