### PR TITLE
[Merged by Bors] - chore: make dependabot group updates into a single PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,13 @@ updates:
     schedule:
       # Check for updates to GitHub Actions every month
       interval: "monthly"
+    groups:
+      # group updates into single PRs since we want to update both build.in.yml and its outputs at the same time
+      actions-version-updates:
+        applies-to: version-updates
+        patterns:
+          - "*"
+      actions-security-updates:
+        applies-to: security-updates
+        patterns:
+          - "*"


### PR DESCRIPTION
cf. docs at https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/optimizing-pr-creation-version-updates

---

It was a bit annoying to make a single bors batch for [#23544](https://github.com/leanprover-community/mathlib4/pull/23544) [#23543](https://github.com/leanprover-community/mathlib4/pull/23543) [#23541](https://github.com/leanprover-community/mathlib4/pull/23541) [#23540](https://github.com/leanprover-community/mathlib4/pull/23540).