### PR TITLE
[Merged by Bors] - refactor(RingTheory/Smooth): remove universe parameters for generators and relations in `Algebra.IsStandardSmooth`

### DIFF
--- a/Mathlib/AlgebraicGeometry/Morphisms/Smooth.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/Smooth.lean
@@ -29,9 +29,6 @@ equivalence of `Locally IsStandardSmooth` and `Algebra.IsSmooth`, but the latter
 The reason why we choose the definition via `IsStandardSmooth`, is because verifying that
 `Algebra.IsSmooth` is local in the sense of `RingHom.PropertyIsLocal` is a (hard) TODO.
 
-- The definition `RingHom.IsStandardSmooth` depends on universe levels for the generators and
-relations. For morphisms of schemes we set both to `0` to avoid unnecessary complications.
-
 ## Notes
 
 This contribution was created as part of the AIM workshop "Formalizing algebraic geometry" in
@@ -61,11 +58,11 @@ standard smooth.
 @[mk_iff]
 class IsSmooth : Prop where
   exists_isStandardSmooth : ∀ (x : X), ∃ (U : Y.affineOpens) (V : X.affineOpens) (_ : x ∈ V.1)
-    (e : V.1 ≤ f ⁻¹ᵁ U.1), IsStandardSmooth.{0, 0} (f.appLE U V e).hom
+    (e : V.1 ≤ f ⁻¹ᵁ U.1), IsStandardSmooth (f.appLE U V e).hom
 
 /-- The property of scheme morphisms `IsSmooth` is associated with the ring
-homomorphism property `Locally IsStandardSmooth.{0, 0}`. -/
-instance : HasRingHomProperty @IsSmooth (Locally IsStandardSmooth.{0, 0}) := by
+homomorphism property `Locally IsStandardSmooth`. -/
+instance : HasRingHomProperty @IsSmooth (Locally IsStandardSmooth) := by
   apply HasRingHomProperty.locally_of_iff
   · exact isStandardSmooth_localizationPreserves.away
   · exact isStandardSmooth_stableUnderCompositionWithLocalizationAway
@@ -98,7 +95,7 @@ standard smooth of relative dimension `n`.
 class IsSmoothOfRelativeDimension : Prop where
   exists_isStandardSmoothOfRelativeDimension : ∀ (x : X), ∃ (U : Y.affineOpens)
     (V : X.affineOpens) (_ : x ∈ V.1) (e : V.1 ≤ f ⁻¹ᵁ U.1),
-    IsStandardSmoothOfRelativeDimension.{0, 0} n (f.appLE U V e).hom
+    IsStandardSmoothOfRelativeDimension n (f.appLE U V e).hom
 
 /-- If `f` is smooth of any relative dimension, it is smooth. -/
 lemma IsSmoothOfRelativeDimension.isSmooth [IsSmoothOfRelativeDimension n f] : IsSmooth f where
@@ -107,9 +104,9 @@ lemma IsSmoothOfRelativeDimension.isSmooth [IsSmoothOfRelativeDimension n f] : I
     exact ⟨U, V, hx, e, hf.isStandardSmooth⟩
 
 /-- The property of scheme morphisms `IsSmoothOfRelativeDimension n` is associated with the ring
-homomorphism property `Locally (IsStandardSmoothOfRelativeDimension.{0, 0} n)`. -/
+homomorphism property `Locally (IsStandardSmoothOfRelativeDimension n)`. -/
 instance : HasRingHomProperty (@IsSmoothOfRelativeDimension n)
-    (Locally (IsStandardSmoothOfRelativeDimension.{0, 0} n)) := by
+    (Locally (IsStandardSmoothOfRelativeDimension n)) := by
   apply HasRingHomProperty.locally_of_iff
   · exact (isStandardSmoothOfRelativeDimension_localizationPreserves n).away
   · exact isStandardSmoothOfRelativeDimension_stableUnderCompositionWithLocalizationAway n

--- a/Mathlib/RingTheory/Presentation.lean
+++ b/Mathlib/RingTheory/Presentation.lean
@@ -490,6 +490,12 @@ lemma isFinite_reindex_iff {ι κ : Type*} (e : ι ≃ P.vars) (f : κ ≃ P.rel
 
 alias ⟨_, IsFinite.reindex⟩ := isFinite_reindex_iff
 
+@[simp]
+lemma presentation_reindex (P : Presentation.{w, t} R S) {ι κ : Type*} (e : ι ≃ P.vars)
+    (f : κ ≃ P.rels) :
+    (P.reindex e f).dimension = P.dimension := by
+  simp [dimension, Generators.reindex_vars, reindex_rels, Nat.card_congr e, Nat.card_congr f]
+
 end Construction
 
 end Presentation

--- a/Mathlib/RingTheory/Presentation.lean
+++ b/Mathlib/RingTheory/Presentation.lean
@@ -491,7 +491,7 @@ lemma isFinite_reindex_iff {ι κ : Type*} (e : ι ≃ P.vars) (f : κ ≃ P.rel
 alias ⟨_, IsFinite.reindex⟩ := isFinite_reindex_iff
 
 @[simp]
-lemma presentation_reindex (P : Presentation.{w, t} R S) {ι κ : Type*} (e : ι ≃ P.vars)
+lemma dimension_reindex (P : Presentation.{w, t} R S) {ι κ : Type*} (e : ι ≃ P.vars)
     (f : κ ≃ P.rels) :
     (P.reindex e f).dimension = P.dimension := by
   simp [dimension, Generators.reindex_vars, reindex_rels, Nat.card_congr e, Nat.card_congr f]

--- a/Mathlib/RingTheory/RingHom/StandardSmooth.lean
+++ b/Mathlib/RingTheory/RingHom/StandardSmooth.lean
@@ -32,26 +32,26 @@ variable {R : Type u} {S : Type v} [CommRing R] [CommRing S]
 /-- A ring homomorphism `R →+* S` is standard smooth if `S` is standard smooth as `R`-algebra. -/
 @[algebraize RingHom.IsStandardSmooth.toAlgebra]
 def IsStandardSmooth (f : R →+* S) : Prop :=
-  @Algebra.IsStandardSmooth.{t, w} _ _ _ _ f.toAlgebra
+  @Algebra.IsStandardSmooth _ _ _ _ f.toAlgebra
 
 /-- Helper lemma for the `algebraize` tactic -/
-lemma IsStandardSmooth.toAlgebra {f : R →+* S} (hf : IsStandardSmooth.{t, w} f) :
-    @Algebra.IsStandardSmooth.{t, w} R S _ _ f.toAlgebra := hf
+lemma IsStandardSmooth.toAlgebra {f : R →+* S} (hf : IsStandardSmooth f) :
+    @Algebra.IsStandardSmooth R S _ _ f.toAlgebra := hf
 
 /-- A ring homomorphism `R →+* S` is standard smooth of relative dimension `n` if
 `S` is standard smooth of relative dimension `n` as `R`-algebra. -/
 @[algebraize RingHom.IsStandardSmoothOfRelativeDimension.toAlgebra]
 def IsStandardSmoothOfRelativeDimension (f : R →+* S) : Prop :=
-  @Algebra.IsStandardSmoothOfRelativeDimension.{t, w} n _ _ _ _ f.toAlgebra
+  @Algebra.IsStandardSmoothOfRelativeDimension n _ _ _ _ f.toAlgebra
 
 /-- Helper lemma for the `algebraize` tactic -/
 lemma IsStandardSmoothOfRelativeDimension.toAlgebra {f : R →+* S}
-    (hf : IsStandardSmoothOfRelativeDimension.{t, w} n f) :
-    @Algebra.IsStandardSmoothOfRelativeDimension.{t, w} n R S _ _ f.toAlgebra := hf
+    (hf : IsStandardSmoothOfRelativeDimension n f) :
+    @Algebra.IsStandardSmoothOfRelativeDimension n R S _ _ f.toAlgebra := hf
 
 lemma IsStandardSmoothOfRelativeDimension.isStandardSmooth (f : R →+* S)
-    (hf : IsStandardSmoothOfRelativeDimension.{t, w} n f) :
-    IsStandardSmooth.{t, w} f := by
+    (hf : IsStandardSmoothOfRelativeDimension n f) :
+    IsStandardSmooth f := by
   algebraize [f]
   exact Algebra.IsStandardSmoothOfRelativeDimension.isStandardSmooth n
 
@@ -59,42 +59,42 @@ variable {n m}
 
 variable (R) in
 lemma IsStandardSmoothOfRelativeDimension.id :
-    IsStandardSmoothOfRelativeDimension.{t, w} 0 (RingHom.id R) :=
+    IsStandardSmoothOfRelativeDimension 0 (RingHom.id R) :=
   Algebra.IsStandardSmoothOfRelativeDimension.id R
 
 lemma IsStandardSmoothOfRelativeDimension.equiv (e : R ≃+* S) :
-    IsStandardSmoothOfRelativeDimension.{t, w} 0 (e : R →+* S) := by
+    IsStandardSmoothOfRelativeDimension 0 (e : R →+* S) := by
   algebraize [e.toRingHom]
   exact Algebra.IsStandardSmoothOfRelativeDimension.of_algebraMap_bijective e.bijective
 
 variable {T : Type*} [CommRing T]
 
 lemma IsStandardSmooth.comp {g : S →+* T} {f : R →+* S}
-    (hg : IsStandardSmooth.{t', w'} g) (hf : IsStandardSmooth.{t, w} f) :
-    IsStandardSmooth.{max t t', max w w'} (g.comp f) := by
+    (hg : IsStandardSmooth g) (hf : IsStandardSmooth f) :
+    IsStandardSmooth (g.comp f) := by
   rw [IsStandardSmooth]
   algebraize [f, g, (g.comp f)]
-  exact Algebra.IsStandardSmooth.trans.{t, t', w, w'} R S T
+  exact Algebra.IsStandardSmooth.trans R S T
 
 lemma IsStandardSmoothOfRelativeDimension.comp {g : S →+* T} {f : R →+* S}
-    (hg : IsStandardSmoothOfRelativeDimension.{t', w'} n g)
-    (hf : IsStandardSmoothOfRelativeDimension.{t, w} m f) :
-    IsStandardSmoothOfRelativeDimension.{max t t', max w w'} (n + m) (g.comp f) := by
+    (hg : IsStandardSmoothOfRelativeDimension n g)
+    (hf : IsStandardSmoothOfRelativeDimension m f) :
+    IsStandardSmoothOfRelativeDimension (n + m) (g.comp f) := by
   rw [IsStandardSmoothOfRelativeDimension]
   algebraize [f, g, (g.comp f)]
   exact Algebra.IsStandardSmoothOfRelativeDimension.trans m n R S T
 
 lemma isStandardSmooth_stableUnderComposition :
-    StableUnderComposition @IsStandardSmooth.{t, w} :=
+    StableUnderComposition @IsStandardSmooth :=
   fun _ _ _ _ _ _ _ _ hf hg ↦ hg.comp hf
 
-lemma isStandardSmooth_respectsIso : RespectsIso @IsStandardSmooth.{t, w} := by
+lemma isStandardSmooth_respectsIso : RespectsIso @IsStandardSmooth := by
   apply isStandardSmooth_stableUnderComposition.respectsIso
   introv
   exact (IsStandardSmoothOfRelativeDimension.equiv e).isStandardSmooth
 
 lemma isStandardSmoothOfRelativeDimension_respectsIso :
-    RespectsIso (@IsStandardSmoothOfRelativeDimension.{t, w} n) where
+    RespectsIso (@IsStandardSmoothOfRelativeDimension n) where
   left {R S T _ _ _} f e hf := by
     rw [← zero_add n]
     exact (IsStandardSmoothOfRelativeDimension.equiv e).comp hf
@@ -103,7 +103,7 @@ lemma isStandardSmoothOfRelativeDimension_respectsIso :
     exact hf.comp (IsStandardSmoothOfRelativeDimension.equiv e)
 
 lemma isStandardSmooth_isStableUnderBaseChange :
-    IsStableUnderBaseChange @IsStandardSmooth.{t, w} := by
+    IsStableUnderBaseChange @IsStandardSmooth := by
   apply IsStableUnderBaseChange.mk
   · exact isStandardSmooth_respectsIso
   · introv h
@@ -116,7 +116,7 @@ lemma isStandardSmooth_isStableUnderBaseChange :
 variable (n)
 
 lemma isStandardSmoothOfRelativeDimension_isStableUnderBaseChange :
-    IsStableUnderBaseChange (@IsStandardSmoothOfRelativeDimension.{t, w} n) := by
+    IsStableUnderBaseChange (@IsStandardSmoothOfRelativeDimension n) := by
   apply IsStableUnderBaseChange.mk
   · exact isStandardSmoothOfRelativeDimension_respectsIso
   · introv h
@@ -130,7 +130,7 @@ lemma isStandardSmoothOfRelativeDimension_isStableUnderBaseChange :
 
 lemma IsStandardSmoothOfRelativeDimension.algebraMap_isLocalizationAway {Rᵣ : Type*} [CommRing Rᵣ]
     [Algebra R Rᵣ] (r : R) [IsLocalization.Away r Rᵣ] :
-    IsStandardSmoothOfRelativeDimension.{0, 0} 0 (algebraMap R Rᵣ) := by
+    IsStandardSmoothOfRelativeDimension 0 (algebraMap R Rᵣ) := by
   have : (algebraMap R Rᵣ).toAlgebra = ‹Algebra R Rᵣ› := by
     ext
     rw [Algebra.smul_def]
@@ -138,30 +138,30 @@ lemma IsStandardSmoothOfRelativeDimension.algebraMap_isLocalizationAway {Rᵣ : 
   rw [IsStandardSmoothOfRelativeDimension, this]
   exact Algebra.IsStandardSmoothOfRelativeDimension.localization_away r
 
-lemma isStandardSmooth_localizationPreserves : LocalizationPreserves IsStandardSmooth.{t, w} :=
+lemma isStandardSmooth_localizationPreserves : LocalizationPreserves IsStandardSmooth :=
   isStandardSmooth_isStableUnderBaseChange.localizationPreserves
 
 lemma isStandardSmoothOfRelativeDimension_localizationPreserves :
-    LocalizationPreserves (IsStandardSmoothOfRelativeDimension.{t, w} n) :=
+    LocalizationPreserves (IsStandardSmoothOfRelativeDimension n) :=
   (isStandardSmoothOfRelativeDimension_isStableUnderBaseChange n).localizationPreserves
 
 lemma isStandardSmooth_holdsForLocalizationAway :
-    HoldsForLocalizationAway IsStandardSmooth.{0, 0} := by
+    HoldsForLocalizationAway IsStandardSmooth := by
   introv R h
   exact (IsStandardSmoothOfRelativeDimension.algebraMap_isLocalizationAway r).isStandardSmooth
 
 lemma isStandardSmoothOfRelativeDimension_holdsForLocalizationAway :
-    HoldsForLocalizationAway (IsStandardSmoothOfRelativeDimension.{0, 0} 0) := by
+    HoldsForLocalizationAway (IsStandardSmoothOfRelativeDimension 0) := by
   introv R h
   exact IsStandardSmoothOfRelativeDimension.algebraMap_isLocalizationAway r
 
 lemma isStandardSmooth_stableUnderCompositionWithLocalizationAway :
-    StableUnderCompositionWithLocalizationAway IsStandardSmooth.{0, 0} :=
+    StableUnderCompositionWithLocalizationAway IsStandardSmooth :=
   isStandardSmooth_stableUnderComposition.stableUnderCompositionWithLocalizationAway
     isStandardSmooth_holdsForLocalizationAway
 
 lemma isStandardSmoothOfRelativeDimension_stableUnderCompositionWithLocalizationAway :
-    StableUnderCompositionWithLocalizationAway (IsStandardSmoothOfRelativeDimension.{0, 0} n) where
+    StableUnderCompositionWithLocalizationAway (IsStandardSmoothOfRelativeDimension n) where
   left R S _ _ _ _ _ r _ _ hf :=
     have : (algebraMap R S).IsStandardSmoothOfRelativeDimension 0 :=
       IsStandardSmoothOfRelativeDimension.algebraMap_isLocalizationAway r

--- a/Mathlib/RingTheory/Smooth/StandardSmooth.lean
+++ b/Mathlib/RingTheory/Smooth/StandardSmooth.lean
@@ -594,14 +594,21 @@ An `R`-algebra `S` is called standard smooth, if there
 exists a submersive presentation.
 -/
 class IsStandardSmooth : Prop where
-  out : Nonempty (SubmersivePresentation.{t, w} R S)
+  out : Nonempty (SubmersivePresentation.{0, 0} R S)
+
+lemma SubmersivePresentation.isStandardSmooth (P : SubmersivePresentation.{t, w} R S) :
+    IsStandardSmooth R S := by
+  cases nonempty_fintype P.vars
+  cases nonempty_fintype P.rels
+  exact ⟨⟨P.reindex _ _ (Fintype.equivFin P.vars).symm (Fintype.equivFin P.rels).symm⟩⟩
 
 /--
 The relative dimension of a standard smooth `R`-algebra `S` is
 the dimension of an arbitrarily chosen submersive `R`-presentation of `S`.
 
 Note: If `S` is non-trivial, this number is independent of the choice of the presentation as it is
-equal to the `S`-rank of `Ω[S/R]` (TODO).
+equal to the `S`-rank of `Ω[S/R]`
+(see `IsStandardSmoothOfRelativeDimension.rank_kaehlerDifferential`).
 -/
 noncomputable def IsStandardSmooth.relativeDimension [IsStandardSmooth R S] : ℕ :=
   ‹IsStandardSmooth R S›.out.some.dimension
@@ -611,23 +618,30 @@ An `R`-algebra `S` is called standard smooth of relative dimension `n`, if there
 a submersive presentation of dimension `n`.
 -/
 class IsStandardSmoothOfRelativeDimension : Prop where
-  out : ∃ P : SubmersivePresentation.{t, w} R S, P.dimension = n
+  out : ∃ P : SubmersivePresentation.{0, 0} R S, P.dimension = n
+
+lemma SubmersivePresentation.isStandardSmoothOfRelativeDimension
+    (P : SubmersivePresentation.{t, w} R S) (hP : P.dimension = n) :
+    IsStandardSmoothOfRelativeDimension n R S := by
+  cases nonempty_fintype P.vars
+  cases nonempty_fintype P.rels
+  refine ⟨⟨P.reindex _ _ (Fintype.equivFin P.vars).symm (Fintype.equivFin P.rels).symm, ?_⟩⟩
+  simp [hP]
 
 variable {R} {S}
 
 lemma IsStandardSmoothOfRelativeDimension.isStandardSmooth
-    [IsStandardSmoothOfRelativeDimension.{t, w} n R S] :
-    IsStandardSmooth.{t, w} R S :=
+    [IsStandardSmoothOfRelativeDimension n R S] : IsStandardSmooth R S :=
   ⟨‹IsStandardSmoothOfRelativeDimension n R S›.out.nonempty⟩
 
 lemma IsStandardSmoothOfRelativeDimension.of_algebraMap_bijective
     (h : Function.Bijective (algebraMap R S)) :
-    IsStandardSmoothOfRelativeDimension.{t, w} 0 R S :=
+    IsStandardSmoothOfRelativeDimension 0 R S :=
   ⟨SubmersivePresentation.ofBijectiveAlgebraMap h, Presentation.ofBijectiveAlgebraMap_dimension h⟩
 
 variable (R) in
 instance IsStandardSmoothOfRelativeDimension.id :
-    IsStandardSmoothOfRelativeDimension.{t, w} 0 R R :=
+    IsStandardSmoothOfRelativeDimension 0 R R :=
   IsStandardSmoothOfRelativeDimension.of_algebraMap_bijective Function.bijective_id
 
 instance (priority := 100) IsStandardSmooth.finitePresentation [IsStandardSmooth R S] :
@@ -639,16 +653,16 @@ section Composition
 
 variable (R S T) [CommRing T] [Algebra R T] [Algebra S T] [IsScalarTower R S T]
 
-lemma IsStandardSmooth.trans [IsStandardSmooth.{t, w} R S] [IsStandardSmooth.{t', w'} S T] :
-    IsStandardSmooth.{max t t', max w w'} R T where
+lemma IsStandardSmooth.trans [IsStandardSmooth R S] [IsStandardSmooth S T] :
+    IsStandardSmooth R T where
   out := by
     obtain ⟨⟨P⟩⟩ := ‹IsStandardSmooth R S›
     obtain ⟨⟨Q⟩⟩ := ‹IsStandardSmooth S T›
     exact ⟨Q.comp P⟩
 
-lemma IsStandardSmoothOfRelativeDimension.trans [IsStandardSmoothOfRelativeDimension.{t, w} n R S]
-    [IsStandardSmoothOfRelativeDimension.{t', w'} m S T] :
-    IsStandardSmoothOfRelativeDimension.{max t t', max w w'} (m + n) R T where
+lemma IsStandardSmoothOfRelativeDimension.trans [IsStandardSmoothOfRelativeDimension n R S]
+    [IsStandardSmoothOfRelativeDimension m S T] :
+    IsStandardSmoothOfRelativeDimension (m + n) R T where
   out := by
     obtain ⟨P, hP⟩ := ‹IsStandardSmoothOfRelativeDimension n R S›
     obtain ⟨Q, hQ⟩ := ‹IsStandardSmoothOfRelativeDimension m S T›
@@ -658,11 +672,11 @@ lemma IsStandardSmoothOfRelativeDimension.trans [IsStandardSmoothOfRelativeDimen
 end Composition
 
 lemma IsStandardSmooth.localization_away (r : R) [IsLocalization.Away r S] :
-    IsStandardSmooth.{0, 0} R S where
+    IsStandardSmooth R S where
   out := ⟨SubmersivePresentation.localizationAway S r⟩
 
 lemma IsStandardSmoothOfRelativeDimension.localization_away (r : R) [IsLocalization.Away r S] :
-    IsStandardSmoothOfRelativeDimension.{0, 0} 0 R S where
+    IsStandardSmoothOfRelativeDimension 0 R S where
   out := ⟨SubmersivePresentation.localizationAway S r,
     Presentation.localizationAway_dimension_zero r⟩
 
@@ -670,15 +684,15 @@ section BaseChange
 
 variable (T) [CommRing T] [Algebra R T]
 
-instance IsStandardSmooth.baseChange [IsStandardSmooth.{t, w} R S] :
-    IsStandardSmooth.{t, w} T (T ⊗[R] S) where
+instance IsStandardSmooth.baseChange [IsStandardSmooth R S] :
+    IsStandardSmooth T (T ⊗[R] S) where
   out := by
     obtain ⟨⟨P⟩⟩ := ‹IsStandardSmooth R S›
     exact ⟨P.baseChange R S T⟩
 
 instance IsStandardSmoothOfRelativeDimension.baseChange
-    [IsStandardSmoothOfRelativeDimension.{t, w} n R S] :
-    IsStandardSmoothOfRelativeDimension.{t, w} n T (T ⊗[R] S) where
+    [IsStandardSmoothOfRelativeDimension n R S] :
+    IsStandardSmoothOfRelativeDimension n T (T ⊗[R] S) where
   out := by
     obtain ⟨P, hP⟩ := ‹IsStandardSmoothOfRelativeDimension n R S›
     exact ⟨P.baseChange R S T, hP⟩


### PR DESCRIPTION
We ask for the existence of a presentation with generators and relations in `Type` and provide a constructor taking a presentation with arbitrary universe levels.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
