### PR TITLE
[Merged by Bors] - feat: don't delaborate to `⊔` or `⊓` if we have a `LinearOrder`

### DIFF
--- a/Mathlib/Lean/PrettyPrinter/Delaborator.lean
+++ b/Mathlib/Lean/PrettyPrinter/Delaborator.lean
@@ -12,7 +12,7 @@ import Lean.PrettyPrinter.Delaborator.Basic
 
 namespace Lean.PrettyPrinter.Delaborator
 
-open Lean.Meta Lean.SubExpr SubExpr
+open SubExpr
 
 /-- Assuming the current expression in a lambda or pi,
 descend into the body using an unused name generated from the binder's name.
@@ -30,5 +30,18 @@ def OptionsPerPos.setBool (opts : OptionsPerPos) (p : SubExpr.Pos) (n : Name) (v
     OptionsPerPos :=
   let e := opts.findD p {} |>.setBool n v
   opts.insert p e
+
+/-- Annotates `stx` with the go-to-def information of `target`. -/
+def annotateGoToDef (stx : Term) (target : Name) : DelabM Term := do
+  let module := (← findModuleOf? target).getD (← getEnv).mainModule
+  let some range ← findDeclarationRanges? target | return stx
+  let stx ← annotateCurPos stx
+  let location := { module, range := range.selectionRange }
+  addDelabTermInfo (← getPos) stx (← getExpr) (location? := some location)
+  return stx
+
+/-- Annotates `stx` with the go-to-def information of the notation used in `stx`. -/
+def annotateGoToSyntaxDef (stx : Term) : DelabM Term := do
+  annotateGoToDef stx stx.raw.getKind
 
 end Lean.PrettyPrinter.Delaborator

--- a/Mathlib/Order/Notation.lean
+++ b/Mathlib/Order/Notation.lean
@@ -54,11 +54,17 @@ class Inf (α : Type*) where
 
 attribute [ext] Min Max
 
-@[inherit_doc Max.max]
-syntax:68 (name := sup) term:68 " ⊔ " term:69 : term
+/--
+Least upper bound (`\lub` notation). `x ⊔ y` is the same as `max x y`
+and it is preferred when the type of `x` and `y` is not a linear order.
+-/
+syntax:68 term:68 " ⊔ " term:69 : term
 
-@[inherit_doc Min.min]
-syntax:69 (name := inf) term:69 " ⊓ " term:70 : term
+/--
+Greatest lower bound (`\glb` notation). `x ⊓ y` is the same as `min x y`
+and it is preferred when the type of `x` and `y` is not a linear order.
+-/
+syntax:69 term:69 " ⊓ " term:70 : term
 
 macro_rules
 | `($a ⊔ $b) => `(Max.max $a $b)

--- a/Mathlib/Order/Notation.lean
+++ b/Mathlib/Order/Notation.lean
@@ -69,6 +69,7 @@ section Delab
 
 open Lean Meta PrettyPrinter Delaborator SubExpr Qq
 
+/-- Return `true` if `LinearOrder` is imported and there is an instance of `LinearOrder e`. -/
 private def hasLinearOrder (u : Level) (e : Q(Type $u)) : MetaM Bool := do
   try
     _ ← synthInstance (.app (.const `LinearOrder [u]) e)

--- a/Mathlib/Order/Notation.lean
+++ b/Mathlib/Order/Notation.lean
@@ -5,7 +5,6 @@ Authors: Johannes Hölzl, Yury Kudryashov, Yaël Dillies
 -/
 import Mathlib.Tactic.TypeStar
 import Mathlib.Tactic.Simps.NotationClass
-import Qq
 
 /-!
 # Notation classes for lattice operations
@@ -67,10 +66,10 @@ macro_rules
 
 section Delab
 
-open Lean Meta PrettyPrinter Delaborator SubExpr Qq
+open Lean Meta PrettyPrinter Delaborator SubExpr
 
 /-- Return `true` if `LinearOrder` is imported and there is an instance of `LinearOrder e`. -/
-private def hasLinearOrder (u : Level) (e : Q(Type $u)) : MetaM Bool := do
+private def hasLinearOrder (u : Level) (e : Expr) : MetaM Bool := do
   try
     _ ← synthInstance (.app (.const `LinearOrder [u]) e)
     return true

--- a/Mathlib/Order/Notation.lean
+++ b/Mathlib/Order/Notation.lean
@@ -108,9 +108,9 @@ private def hasLinearOrder (u : Level) (α : Q(Type u)) (cls : Q(Type u → Type
 
 /-- Annotate the syntax `stx` with the go-to-def information of `target`. -/
 def withGoToDef (stx : Term) (target : Name) : DelabM Term := do
-  let stx ← annotateCurPos stx
   let module := (← findModuleOf? target).getD (← getEnv).mainModule
-  let some range ← findDeclarationRanges? target | failure
+  let some range ← findDeclarationRanges? target | return stx
+  let stx ← annotateCurPos stx
   let location := { module, range := range.selectionRange }
   addDelabTermInfo (← getPos) stx (← getExpr) (location? := some location)
   return stx

--- a/Mathlib/Order/Notation.lean
+++ b/Mathlib/Order/Notation.lean
@@ -62,13 +62,13 @@ attribute [ext] Min Max
 
 /--
 The supremum/join operation: `x ⊔ y`. It is notation for `max x y`
-when the type is not a linear order.
+and should be used when the type is not a linear order.
 -/
 syntax:68 term:68 " ⊔ " term:69 : term
 
 /--
 The infimum/meet operation: `x ⊓ y`. It is notation for `min x y`
-when the type is not a linear order.
+and should be used when the type is not a linear order.
 -/
 syntax:69 term:69 " ⊓ " term:70 : term
 

--- a/Mathlib/Order/Notation.lean
+++ b/Mathlib/Order/Notation.lean
@@ -5,6 +5,7 @@ Authors: Johannes Hölzl, Yury Kudryashov, Yaël Dillies
 -/
 import Mathlib.Tactic.TypeStar
 import Mathlib.Tactic.Simps.NotationClass
+import Qq
 
 /-!
 # Notation classes for lattice operations
@@ -66,11 +67,11 @@ macro_rules
 
 section Delab
 
-open Lean Meta PrettyPrinter Delaborator SubExpr
+open Lean Meta PrettyPrinter Delaborator SubExpr Qq
 
-private def hasLinearOrder (u : Level) (e : Expr) : MetaM Bool := do
+private def hasLinearOrder (u : Level) (e : Q(Type $u)) : MetaM Bool := do
   try
-    _ ← synthInstance (mkApp (.const `LinearOrder [u]) e)
+    _ ← synthInstance (.app (.const `LinearOrder [u]) e)
     return true
   catch _ =>
     return false

--- a/Mathlib/Order/Notation.lean
+++ b/Mathlib/Order/Notation.lean
@@ -68,17 +68,17 @@ section Delab
 
 open Lean Meta PrettyPrinter Delaborator SubExpr
 
-private def hasLinearOrder (e : Expr) : MetaM Bool := do
+private def hasLinearOrder (u : Level) (e : Expr) : MetaM Bool := do
   try
-    _ ← synthInstance (← mkAppM `LinearOrder #[e])
+    _ ← synthInstance (mkApp (.const `LinearOrder [u]) e)
     return true
   catch _ =>
     return false
 
 @[delab app.Max.max]
 def elabSup : Delab := do
-  let_expr Max.max α _ _ _ := ← getExpr | failure
-  if ← hasLinearOrder α then
+  let_expr f@Max.max α _ _ _ := ← getExpr | failure
+  if ← hasLinearOrder f.constLevels![0]! α then
     failure -- use the default delaborator
   else
     let x ← withNaryArg 2 delab
@@ -87,8 +87,8 @@ def elabSup : Delab := do
 
 @[delab app.Min.min]
 def elabInf : Delab := do
-  let_expr Min.min α _ _ _ := ← getExpr | failure
-  if ← hasLinearOrder α then
+  let_expr f@Min.min α _ _ _ := ← getExpr | failure
+  if ← hasLinearOrder f.constLevels![0]! α then
     failure -- use the default delaborator
   else
     let x ← withNaryArg 2 delab

--- a/Mathlib/Order/Notation.lean
+++ b/Mathlib/Order/Notation.lean
@@ -78,22 +78,18 @@ private def hasLinearOrder (u : Level) (e : Expr) : MetaM Bool := do
 @[delab app.Max.max]
 def elabSup : Delab := do
   let_expr f@Max.max α _ _ _ := ← getExpr | failure
-  if ← hasLinearOrder f.constLevels![0]! α then
-    failure -- use the default delaborator
-  else
-    let x ← withNaryArg 2 delab
-    let y ← withNaryArg 3 delab
-    `($x ⊔ $y)
+  if ← hasLinearOrder f.constLevels![0]! α then failure -- use the default delaborator
+  let x ← withNaryArg 2 delab
+  let y ← withNaryArg 3 delab
+  `($x ⊔ $y)
 
 @[delab app.Min.min]
 def elabInf : Delab := do
   let_expr f@Min.min α _ _ _ := ← getExpr | failure
-  if ← hasLinearOrder f.constLevels![0]! α then
-    failure -- use the default delaborator
-  else
-    let x ← withNaryArg 2 delab
-    let y ← withNaryArg 3 delab
-    `($x ⊓ $y)
+  if ← hasLinearOrder f.constLevels![0]! α then failure -- use the default delaborator
+  let x ← withNaryArg 2 delab
+  let y ← withNaryArg 3 delab
+  `($x ⊓ $y)
 
 end Delab
 

--- a/Mathlib/Order/Notation.lean
+++ b/Mathlib/Order/Notation.lean
@@ -28,7 +28,7 @@ We implement a delaborator that pretty prints `max x y`/`min x y` as `x ⊔ y`/`
 if and only if the order on `α` does not have a `LinearOrder α` instance (where `x y : α`).
 
 This is so that in a lattice we can use the same underlying constants `max`/`min`
-as in linear orders, while using the more iniomatic notation `x ⊔ y`/`x ⊓ y`.
+as in linear orders, while using the more idiomatic notation `x ⊔ y`/`x ⊓ y`.
 Lemmas about the operators `⊔` and `⊓` should use the names `sup` and `inf` respectively.
 
 -/

--- a/Mathlib/Order/Notation.lean
+++ b/Mathlib/Order/Notation.lean
@@ -68,28 +68,29 @@ section Delab
 
 open Lean Meta PrettyPrinter Delaborator SubExpr
 
+private def hasLinearOrder (e : Expr) : MetaM Bool := do
+  try
+    _ ← synthInstance (← mkAppM `LinearOrder #[e])
+    return true
+  catch _ =>
+    return false
+
 @[delab app.Max.max]
 def elabSup : Delab := do
-  let e ← getExpr
-  guard (e.isAppOfArity ``Max.max 4)
-  let α := e.appFn!.appFn!.appFn!.appArg!
-  try
-    discard <| synthInstance (← mkAppM `LinearOrder #[α])
+  let_expr Max.max α _ _ _ := ← getExpr | failure
+  if ← hasLinearOrder α then
     failure -- use the default delaborator
-  catch _ =>
+  else
     let x ← withNaryArg 2 delab
     let y ← withNaryArg 3 delab
     `($x ⊔ $y)
 
 @[delab app.Min.min]
 def elabInf : Delab := do
-  let e ← getExpr
-  guard (e.isAppOfArity ``Min.min 4)
-  let α := e.appFn!.appFn!.appFn!.appArg!
-  try
-    discard <| synthInstance (← mkAppM `LinearOrder #[α])
+  let_expr Min.min α _ _ _ := ← getExpr | failure
+  if ← hasLinearOrder α then
     failure -- use the default delaborator
-  catch _ =>
+  else
     let x ← withNaryArg 2 delab
     let y ← withNaryArg 3 delab
     `($x ⊓ $y)

--- a/Mathlib/Order/Notation.lean
+++ b/Mathlib/Order/Notation.lean
@@ -84,10 +84,10 @@ private def hasLinearOrder (u : Level) (α : Q(Type u)) (cls linearOrder : Q(Typ
     (toCls : Q((α : Type u) → $linearOrder α → $cls α))
     (inst : Q($cls $α)) : MetaM Bool := do
   try
-    let mvar ← mkFreshExprMVarQ q($linearOrder $α)
-    let inst' : Q($cls $α) := q($toCls $α $mvar)
-    -- `isDefEq` may call type class syntesis, so we need to give it the local instances
+    -- `isDefEq` may call type class syntesis to instantiate `mvar`, so we need the local instances
     withLocalInstances (← getLCtx).decls.toList.reduceOption do
+      let mvar ← mkFreshExprMVarQ q($linearOrder $α) (kind := .synthetic)
+      let inst' : Q($cls $α) := q($toCls $α $mvar)
       isDefEq inst inst'
   catch _ =>
     return false

--- a/Mathlib/Order/Notation.lean
+++ b/Mathlib/Order/Notation.lean
@@ -14,17 +14,22 @@ In this file we introduce typeclasses and definitions for lattice operations.
 
 ## Main definitions
 
-* the `⊔` notation is used for `Max` since November 2024
-* the `⊓` notation is used for `Min` since November 2024
 * `HasCompl`: type class for the `ᶜ` notation
 * `Top`: type class for the `⊤` notation
 * `Bot`: type class for the `⊥` notation
 
 ## Notations
 
-* `x ⊔ y`: lattice join operation;
-* `x ⊓ y`: lattice meet operation;
 * `xᶜ`: complement in a lattice;
+* `x ⊔ y`: supremum/join, which is notation for `max x y`;
+* `x ⊓ y`: infimum/meet, which is notation for `min x y`;
+
+We implement a delaborator that pretty prints `max x y`/`min x y` as `x ⊔ y`/`x ⊓ y`
+if and only if the order on `α` does not have a `LinearOrder α` instance (where `x y : α`).
+
+This is so that in a lattice we can use the same underlying constants `max`/`min`
+as in linear orders, while using the more iniomatic notation `x ⊔ y`/`x ⊓ y`.
+Lemmas about the operators `⊔` and `⊓` should use the names `sup` and `inf` respectively.
 
 -/
 
@@ -56,14 +61,14 @@ class Inf (α : Type*) where
 attribute [ext] Min Max
 
 /--
-Least upper bound (`\lub` notation). `x ⊔ y` is the same as `max x y`
-and it is preferred when the type of `x` and `y` is not a linear order.
+The supremum/join operation: `x ⊔ y`. It is notation for `max x y`
+when the type is not a linear order.
 -/
 syntax:68 term:68 " ⊔ " term:69 : term
 
 /--
-Greatest lower bound (`\glb` notation). `x ⊓ y` is the same as `min x y`
-and it is preferred when the type of `x` and `y` is not a linear order.
+The infimum/meet operation: `x ⊓ y`. It is notation for `min x y`
+when the type is not a linear order.
 -/
 syntax:69 term:69 " ⊓ " term:70 : term
 

--- a/Mathlib/Order/Notation.lean
+++ b/Mathlib/Order/Notation.lean
@@ -97,6 +97,7 @@ private def hasLinearOrder (u : Level) (α : Q(Type u)) (cls : Q(Type u → Type
     (toCls : Q((α : Type u) → $(linearOrderExpr u) α → $cls α)) (inst : Q($cls $α)) :
     MetaM Bool := do
   try
+    withNewMCtxDepth do
     -- `isDefEq` may call type class search to instantiate `mvar`, so we need the local instances
     withLocalInstances (← getLCtx).decls.toList.reduceOption do
       let mvar ← mkFreshExprMVarQ q($(linearOrderExpr u) $α) (kind := .synthetic)

--- a/Mathlib/Order/Notation.lean
+++ b/Mathlib/Order/Notation.lean
@@ -3,9 +3,10 @@ Copyright (c) 2017 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Yury Kudryashov, Yaël Dillies
 -/
+import Qq
+import Mathlib.Lean.PrettyPrinter.Delaborator
 import Mathlib.Tactic.TypeStar
 import Mathlib.Tactic.Simps.NotationClass
-import Qq
 
 /-!
 # Notation classes for lattice operations
@@ -108,19 +109,6 @@ private def hasLinearOrder (u : Level) (α : Q(Type u)) (cls : Q(Type u → Type
   catch _ =>
     -- For instance, if `LinearOrder` is not yet imported.
     return false
-
-/-- Annotates `stx` with the go-to-def information of `target`. -/
-def annotateGoToDef (stx : Term) (target : Name) : DelabM Term := do
-  let module := (← findModuleOf? target).getD (← getEnv).mainModule
-  let some range ← findDeclarationRanges? target | return stx
-  let stx ← annotateCurPos stx
-  let location := { module, range := range.selectionRange }
-  addDelabTermInfo (← getPos) stx (← getExpr) (location? := some location)
-  return stx
-
-/-- Annotates `stx` with the go-to-def information of the notation used in `stx`. -/
-def annotateGoToSyntaxDef (stx : Term) : DelabM Term := do
-  annotateGoToDef stx stx.raw.getKind
 
 /-- Delaborate `max x y` into `x ⊔ y` if the type is not a linear order. -/
 @[delab app.Max.max]

--- a/Mathlib/Order/Notation.lean
+++ b/Mathlib/Order/Notation.lean
@@ -109,14 +109,18 @@ private def hasLinearOrder (u : Level) (α : Q(Type u)) (cls : Q(Type u → Type
     -- For instance, if `LinearOrder` is not yet imported.
     return false
 
-/-- Annotate the syntax `stx` with the go-to-def information of `target`. -/
-def withGoToDef (stx : Term) (target : Name) : DelabM Term := do
+/-- Annotates `stx` with the go-to-def information of `target`. -/
+def annotateGoToDef (stx : Term) (target : Name) : DelabM Term := do
   let module := (← findModuleOf? target).getD (← getEnv).mainModule
   let some range ← findDeclarationRanges? target | return stx
   let stx ← annotateCurPos stx
   let location := { module, range := range.selectionRange }
   addDelabTermInfo (← getPos) stx (← getExpr) (location? := some location)
   return stx
+
+/-- Annotates `stx` with the go-to-def information of the notation used in `stx`. -/
+def annotateGoToSyntaxDef (stx : Term) : DelabM Term := do
+  annotateGoToDef stx stx.raw.getKind
 
 /-- Delaborate `max x y` into `x ⊔ y` if the type is not a linear order. -/
 @[delab app.Max.max]
@@ -128,7 +132,7 @@ def delabSup : Delab := do
   let x ← withNaryArg 2 delab
   let y ← withNaryArg 3 delab
   let stx ← `($x ⊔ $y)
-  withGoToDef stx ``«term_⊔_»
+  annotateGoToSyntaxDef stx
 
 /-- Delaborate `min x y` into `x ⊓ y` if the type is not a linear order. -/
 @[delab app.Min.min]
@@ -140,7 +144,7 @@ def delabInf : Delab := do
   let x ← withNaryArg 2 delab
   let y ← withNaryArg 3 delab
   let stx ← `($x ⊓ $y)
-  withGoToDef stx ``«term_⊓_»
+  annotateGoToSyntaxDef stx
 
 end Mathlib.Meta
 

--- a/Mathlib/Order/Notation.lean
+++ b/Mathlib/Order/Notation.lean
@@ -99,6 +99,8 @@ private def hasLinearOrder (u : Level) (α : Q(Type u)) (cls : Q(Type u → Type
   try
     withNewMCtxDepth do
     -- `isDefEq` may call type class search to instantiate `mvar`, so we need the local instances
+    -- In Lean 4.19 the pretty printer clears local instances, so we re-add them here.
+    -- TODO(Jovan): remove
     withLocalInstances (← getLCtx).decls.toList.reduceOption do
       let mvar ← mkFreshExprMVarQ q($(linearOrderExpr u) $α) (kind := .synthetic)
       let inst' : Q($cls $α) := q($toCls $α $mvar)

--- a/MathlibTest/Delab/SupInf.lean
+++ b/MathlibTest/Delab/SupInf.lean
@@ -12,14 +12,14 @@ import Mathlib
 #guard_msgs in
 #check max ({1} : Set Nat) {2}
 
-variable {α : Type} (a b : α) [Lattice α]
+variable {α : Type} (a b : α)
 
+variable [Lattice α] in
 /-- info: a ⊔ b : α -/
 #guard_msgs in
 #check max a b
 
-variable [LinearOrder α]
-
+variable [LinearOrder α] in
 /-- info: max a b : α -/
 #guard_msgs in
 #check max a b

--- a/MathlibTest/Delab/SupInf.lean
+++ b/MathlibTest/Delab/SupInf.lean
@@ -23,3 +23,13 @@ variable [LinearOrder α] in
 /-- info: max a b : α -/
 #guard_msgs in
 #check max a b
+
+variable [CompleteLinearOrder α] in
+/-- info: max a b : α -/
+#guard_msgs in
+#check max a b
+
+variable [ConditionallyCompleteLinearOrder α] in
+/-- info: max a b : α -/
+#guard_msgs in
+#check max a b

--- a/MathlibTest/Delab/SupInf.lean
+++ b/MathlibTest/Delab/SupInf.lean
@@ -1,0 +1,25 @@
+import Mathlib
+
+/-- info: max 1 2 : ℕ -/
+#guard_msgs in
+#check max (1 : ℕ) 2
+
+/-- info: max 1 2 : ℝ -/
+#guard_msgs in
+#check max (1 : ℝ) 2
+
+/-- info: {1} ⊔ {2} : Set ℕ -/
+#guard_msgs in
+#check max ({1} : Set Nat) {2}
+
+variable {α : Type} (a b : α) [Lattice α]
+
+/-- info: a ⊔ b : α -/
+#guard_msgs in
+#check max a b
+
+variable [LinearOrder α]
+
+/-- info: max a b : α -/
+#guard_msgs in
+#check max a b

--- a/MathlibTest/Delab/SupInf.lean
+++ b/MathlibTest/Delab/SupInf.lean
@@ -8,9 +8,9 @@ import Mathlib
 #guard_msgs in
 #check max (1 : ℝ) 2
 
-/-- info: {1} ⊔ {2} : Set ℕ -/
+/-- info: ({0} ⊔ {1} ⊔ ({2} ⊔ {3})) ⊓ ({4} ⊔ {5}) ⊔ {6} ⊓ {7} ⊓ ({8} ⊓ {9}) : Set ℕ -/
 #guard_msgs in
-#check max ({1} : Set Nat) {2}
+#check (max (min (max (max {0} {1}) (max {2} {3})) (max {4} {5})) (min (min {6} {7}) (min {8} {9})) : Set ℕ)
 
 variable {α : Type*} (a b : α)
 

--- a/MathlibTest/Delab/SupInf.lean
+++ b/MathlibTest/Delab/SupInf.lean
@@ -12,7 +12,7 @@ import Mathlib
 #guard_msgs in
 #check max ({1} : Set Nat) {2}
 
-variable {α : Type} (a b : α)
+variable {α : Type*} (a b : α)
 
 variable [Lattice α] in
 /-- info: a ⊔ b : α -/

--- a/MathlibTest/Delab/SupInf.lean
+++ b/MathlibTest/Delab/SupInf.lean
@@ -1,5 +1,6 @@
 import Mathlib
 
+
 /-- info: max 1 2 : ℕ -/
 #guard_msgs in
 #check max (1 : ℕ) 2
@@ -11,6 +12,9 @@ import Mathlib
 /-- info: ({0} ⊔ {1} ⊔ ({2} ⊔ {3})) ⊓ ({4} ⊔ {5}) ⊔ {6} ⊓ {7} ⊓ ({8} ⊓ {9}) : Set ℕ -/
 #guard_msgs in
 #check (max (min (max (max {0} {1}) (max {2} {3})) (max {4} {5})) (min (min {6} {7}) (min {8} {9})) : Set ℕ)
+
+
+section
 
 variable {α : Type*} (a b : α)
 
@@ -33,3 +37,28 @@ variable [ConditionallyCompleteLinearOrder α] in
 /-- info: max a b : α -/
 #guard_msgs in
 #check max a b
+
+end
+
+universe u
+
+/-- info: fun α [Lattice α] a b => a ⊔ b : (α : Type u) → [inst : Lattice α] → α → α → α -/
+#guard_msgs in
+#check fun (α : Type u) [Lattice α] (a b : α) => max a b
+
+/-- info: fun α [LinearOrder α] a b => max a b : (α : Type u) → [inst : LinearOrder α] → α → α → α -/
+#guard_msgs in
+#check fun (α : Type u) [LinearOrder α] (a b : α) => max a b
+
+/--
+info: fun α [CompleteLinearOrder α] a b => max a b : (α : Type u) → [inst : CompleteLinearOrder α] → α → α → α
+-/
+#guard_msgs in
+#check fun (α : Type u) [CompleteLinearOrder α] (a b : α) => max a b
+
+/--
+info: fun α [ConditionallyCompleteLinearOrder α] a b =>
+  max a b : (α : Type u) → [inst : ConditionallyCompleteLinearOrder α] → α → α → α
+-/
+#guard_msgs in
+#check fun (α : Type u) [ConditionallyCompleteLinearOrder α] (a b : α) => max a b


### PR DESCRIPTION
This PR changes the `⊔` and `⊓` notations to only be used by the delaborator if the type in question is not a linear order.

This was suggested here [#mathlib4 > max and min delaborators @ 💬](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/max.20and.20min.20delaborators/near/500701449)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
