### PR TITLE
[Merged by Bors] - chore: use full name for `natCast`, `intCast`, etc

### DIFF
--- a/Archive/Imo/Imo2024Q1.lean
+++ b/Archive/Imo/Imo2024Q1.lean
@@ -50,7 +50,7 @@ lemma condition_sub_two_mul_int_iff {α : ℝ} (m : ℤ) : Condition (α - 2 * m
   apply dvd_iff_dvd_of_dvd_sub
   simp_rw [← Finset.sum_sub_distrib, mul_sub]
   norm_cast
-  simp_rw [Int.floor_sub_int, sub_sub_cancel_left]
+  simp_rw [Int.floor_sub_intCast, sub_sub_cancel_left]
   convert condition_two_mul_int (-m) n hn
   norm_cast
   rw [Int.floor_intCast]

--- a/Archive/Imo/Imo2024Q6.lean
+++ b/Archive/Imo/Imo2024Q6.lean
@@ -184,8 +184,8 @@ lemma add_fExample (x y : ℚ) : x + fExample y = ⌊x⌋ + ⌊y⌋ + (Int.fract
   rw [add_comm, fExample_add]
   abel
 
-lemma fExample_int_add (x : ℤ) (y : ℚ) : fExample (x + y) = x + fExample y := by
-  simp_rw [fExample, Int.floor_int_add, Int.fract_int_add, ← add_sub_assoc]
+lemma fExample_intCast_add (x : ℤ) (y : ℚ) : fExample (x + y) = x + fExample y := by
+  simp_rw [fExample, Int.floor_intCast_add, Int.fract_intCast_add, ← add_sub_assoc]
   exact_mod_cast rfl
 
 lemma fExample_of_mem_Ico {x : ℚ} (h : x ∈ Set.Ico 0 1) : fExample x = -x := by
@@ -197,7 +197,7 @@ lemma apply_fExample_add_apply_of_fract_le {x y : ℚ} (h : Int.fract y ≤ Int.
   rw [← sub_nonneg] at h
   have h₁ : Int.fract x - Int.fract y < 1 :=
     (sub_le_self (Int.fract x) (Int.fract_nonneg y)).trans_lt (Int.fract_lt_one x)
-  rw [fExample_add, add_fExample, add_assoc, fExample_int_add, fExample_int_add,
+  rw [fExample_add, add_fExample, add_assoc, fExample_intCast_add, fExample_intCast_add,
       fExample_of_mem_Ico ⟨h, h₁⟩]
   abel
 
@@ -220,7 +220,7 @@ lemma floor_fExample (x : ℚ) :
   · simp only [h, if_true, fExample, sub_zero, Int.floor_intCast]
     rw [Int.fract, sub_eq_zero] at h
     exact h.symm
-  · simp only [h, if_false, fExample, sub_eq_add_neg, Int.floor_int_add, Int.cast_add,
+  · simp only [h, if_false, fExample, sub_eq_add_neg, Int.floor_intCast_add, Int.cast_add,
                add_right_inj]
     suffices ⌊-Int.fract x⌋ = -1 from mod_cast this
     rw [Int.floor_eq_iff]
@@ -245,7 +245,7 @@ lemma card_range_fExample : #(Set.range (fun x ↦ fExample x + fExample (-x))) 
     · rcases h with rfl | rfl
       · refine ⟨0, by simp [fExample]⟩
       · refine ⟨1 / 2, ?_⟩
-        rw [(by norm_num : (-(1 / 2) : ℚ) = (-1 : ℤ) + (1 / 2 : ℚ)), fExample_int_add,
+        rw [(by norm_num : (-(1 / 2) : ℚ) = (-1 : ℤ) + (1 / 2 : ℚ)), fExample_intCast_add,
             fExample_of_mem_Ico ⟨by norm_num, by norm_num⟩]
         norm_num
   rw [h]

--- a/Mathlib/Algebra/Field/Periodic.lean
+++ b/Mathlib/Algebra/Field/Periodic.lean
@@ -161,4 +161,4 @@ theorem Antiperiodic.div_inv [DivisionSemiring α] [Neg β] (h : Antiperiodic f 
 end Function
 
 theorem Int.fract_periodic (α) [LinearOrderedRing α] [FloorRing α] :
-    Function.Periodic Int.fract (1 : α) := fun a => mod_cast Int.fract_add_int a 1
+    Function.Periodic Int.fract (1 : α) := fun a => mod_cast Int.fract_add_intCast a 1

--- a/Mathlib/Algebra/Order/Floor.lean
+++ b/Mathlib/Algebra/Order/Floor.lean
@@ -1111,7 +1111,7 @@ theorem ceil_mono : Monotone (ceil : α → ℤ) :=
 
 @[simp]
 theorem ceil_add_intCast (a : α) (z : ℤ) : ⌈a + z⌉ = ⌈a⌉ + z := by
-  rw [← neg_inj, neg_add', ← floor_neg, ← floor_neg, neg_add', floor_sub_int]
+  rw [← neg_inj, neg_add', ← floor_neg, ← floor_neg, neg_add', floor_sub_intCast]
 
 @[deprecated (since := "2025-04-01")] alias ceil_add_int := ceil_add_intCast
 
@@ -1504,3 +1504,6 @@ def evalIntCeil : PositivityExt where eval {u α} _zα _pα e := do
   | _, _, _ => throwError "failed to match on Int.ceil application"
 
 end Mathlib.Meta.Positivity
+
+-- Pushed over the limit by deprecations
+set_option linter.style.longFile 1600

--- a/Mathlib/Algebra/Order/Floor.lean
+++ b/Mathlib/Algebra/Order/Floor.lean
@@ -371,7 +371,7 @@ theorem preimage_Iic {a : α} (ha : 0 ≤ a) : (Nat.cast : ℕ → α) ⁻¹' Se
   ext
   simp [le_floor_iff, ha]
 
-theorem floor_add_nat (ha : 0 ≤ a) (n : ℕ) : ⌊a + n⌋₊ = ⌊a⌋₊ + n :=
+theorem floor_add_natCast (ha : 0 ≤ a) (n : ℕ) : ⌊a + n⌋₊ = ⌊a⌋₊ + n :=
   eq_of_forall_le_iff fun b => by
     rw [le_floor_iff (add_nonneg ha n.cast_nonneg)]
     obtain hb | hb := le_total n b
@@ -383,34 +383,38 @@ theorem floor_add_nat (ha : 0 ≤ a) (n : ℕ) : ⌊a + n⌋₊ = ⌊a⌋₊ + n
       refine iff_of_true ?_ le_self_add
       exact le_add_of_nonneg_right <| ha.trans <| le_add_of_nonneg_right d.cast_nonneg
 
+@[deprecated (since := "2025-04-01")] alias floor_add_nat := floor_add_natCast
+
 theorem floor_add_one (ha : 0 ≤ a) : ⌊a + 1⌋₊ = ⌊a⌋₊ + 1 := by
-  rw [← cast_one, floor_add_nat ha 1]
+  rw [← cast_one, floor_add_natCast ha 1]
 
 theorem floor_add_ofNat (ha : 0 ≤ a) (n : ℕ) [n.AtLeastTwo] :
     ⌊a + ofNat(n)⌋₊ = ⌊a⌋₊ + ofNat(n) :=
-  floor_add_nat ha n
+  floor_add_natCast ha n
 
 @[simp]
-theorem floor_sub_nat [Sub α] [OrderedSub α] [ExistsAddOfLE α] (a : α) (n : ℕ) :
+theorem floor_sub_natCast [Sub α] [OrderedSub α] [ExistsAddOfLE α] (a : α) (n : ℕ) :
     ⌊a - n⌋₊ = ⌊a⌋₊ - n := by
   obtain ha | ha := le_total a 0
   · rw [floor_of_nonpos ha, floor_of_nonpos (tsub_nonpos_of_le (ha.trans n.cast_nonneg)), zero_tsub]
   rcases le_total a n with h | h
   · rw [floor_of_nonpos (tsub_nonpos_of_le h), eq_comm, tsub_eq_zero_iff_le]
     exact Nat.cast_le.1 ((Nat.floor_le ha).trans h)
-  · rw [eq_tsub_iff_add_eq_of_le (le_floor h), ← floor_add_nat _, tsub_add_cancel_of_le h]
+  · rw [eq_tsub_iff_add_eq_of_le (le_floor h), ← floor_add_natCast _, tsub_add_cancel_of_le h]
     exact le_tsub_of_add_le_left ((add_zero _).trans_le h)
+
+@[deprecated (since := "2025-04-01")] alias floor_sub_nat := floor_sub_natCast
 
 @[simp]
 theorem floor_sub_one [Sub α] [OrderedSub α] [ExistsAddOfLE α] (a : α) : ⌊a - 1⌋₊ = ⌊a⌋₊ - 1 :=
-  mod_cast floor_sub_nat a 1
+  mod_cast floor_sub_natCast a 1
 
 @[simp]
 theorem floor_sub_ofNat [Sub α] [OrderedSub α] [ExistsAddOfLE α] (a : α) (n : ℕ) [n.AtLeastTwo] :
     ⌊a - ofNat(n)⌋₊ = ⌊a⌋₊ - ofNat(n) :=
-  floor_sub_nat a n
+  floor_sub_natCast a n
 
-theorem ceil_add_nat (ha : 0 ≤ a) (n : ℕ) : ⌈a + n⌉₊ = ⌈a⌉₊ + n :=
+theorem ceil_add_natCast (ha : 0 ≤ a) (n : ℕ) : ⌈a + n⌉₊ = ⌈a⌉₊ + n :=
   eq_of_forall_ge_iff fun b => by
     rw [← not_lt, ← not_lt, not_iff_not, lt_ceil]
     obtain hb | hb := le_or_lt n b
@@ -419,12 +423,14 @@ theorem ceil_add_nat (ha : 0 ≤ a) (n : ℕ) : ⌈a + n⌉₊ = ⌈a⌉₊ + n 
         lt_ceil]
     · exact iff_of_true (lt_add_of_nonneg_of_lt ha <| cast_lt.2 hb) (Nat.lt_add_left _ hb)
 
+@[deprecated (since := "2025-04-01")] alias ceil_add_nat := ceil_add_natCast
+
 theorem ceil_add_one (ha : 0 ≤ a) : ⌈a + 1⌉₊ = ⌈a⌉₊ + 1 := by
-  rw [cast_one.symm, ceil_add_nat ha 1]
+  rw [cast_one.symm, ceil_add_natCast ha 1]
 
 theorem ceil_add_ofNat (ha : 0 ≤ a) (n : ℕ) [n.AtLeastTwo] :
     ⌈a + ofNat(n)⌉₊ = ⌈a⌉₊ + ofNat(n) :=
-  ceil_add_nat ha n
+  ceil_add_natCast ha n
 
 @[bound]
 theorem ceil_lt_add_one (ha : 0 ≤ a) : (⌈a⌉₊ : α) < a + 1 :=
@@ -453,7 +459,7 @@ variable [LinearOrderedSemifield α] [FloorSemiring α]
 
 -- TODO: should these lemmas be `simp`? `norm_cast`?
 
-theorem floor_div_nat (a : α) (n : ℕ) : ⌊a / n⌋₊ = ⌊a⌋₊ / n := by
+theorem floor_div_natCast (a : α) (n : ℕ) : ⌊a / n⌋₊ = ⌊a⌋₊ / n := by
   rcases le_total a 0 with ha | ha
   · rw [floor_of_nonpos, floor_of_nonpos ha]
     · simp
@@ -468,13 +474,15 @@ theorem floor_div_nat (a : α) (n : ℕ) : ⌊a / n⌋₊ = ⌊a⌋₊ / n := by
   · exact lt_div_mul_add hn
   · exact cast_pos.2 hn
 
+@[deprecated (since := "2025-04-01")] alias floor_div_nat := floor_div_natCast
+
 theorem floor_div_ofNat (a : α) (n : ℕ) [n.AtLeastTwo] :
     ⌊a / ofNat(n)⌋₊ = ⌊a⌋₊ / ofNat(n) :=
-  floor_div_nat a n
+  floor_div_natCast a n
 
 /-- Natural division is the floor of field division. -/
 theorem floor_div_eq_div (m n : ℕ) : ⌊(m : α) / n⌋₊ = m / n := by
-  convert floor_div_nat (m : α) n
+  convert floor_div_natCast (m : α) n
   rw [m.floor_natCast]
 
 end LinearOrderedSemifield
@@ -817,21 +825,21 @@ theorem fract_add_natCast (a : α) (m : ℕ) : fract (a + m) = fract a := by
 @[deprecated (since := "2025-04-01")] alias fract_add_nat := fract_add_natCast
 
 @[simp]
-theorem fract_add_one (a : α) : fract (a + 1) = fract a := mod_cast fract_add_nat a 1
+theorem fract_add_one (a : α) : fract (a + 1) = fract a := mod_cast fract_add_natCast a 1
 
 @[simp]
 theorem fract_add_ofNat (a : α) (n : ℕ) [n.AtLeastTwo] :
     fract (a + ofNat(n)) = fract a :=
-  fract_add_nat a n
+  fract_add_natCast a n
 
 @[simp]
 theorem fract_intCast_add (m : ℤ) (a : α) : fract (↑m + a) = fract a := by
-  rw [add_comm, fract_add_int]
+  rw [add_comm, fract_add_intCast]
 @[deprecated (since := "2025-04-01")] alias fract_int_add := fract_intCast_add
 
 @[simp]
 theorem fract_natCast_add (n : ℕ) (a : α) : fract (↑n + a) = fract a := by
-  rw [add_comm, fract_add_nat]
+  rw [add_comm, fract_add_natCast]
 @[deprecated (since := "2025-04-01")] alias fract_nat_add := fract_natCast_add
 
 @[simp]
@@ -843,22 +851,24 @@ theorem fract_ofNat_add (n : ℕ) [n.AtLeastTwo] (a : α) :
   fract_natCast_add n a
 
 @[simp]
-theorem fract_sub_int (a : α) (m : ℤ) : fract (a - m) = fract a := by
+theorem fract_sub_intCast (a : α) (m : ℤ) : fract (a - m) = fract a := by
   rw [fract]
   simp
+@[deprecated (since := "2025-04-01")] alias fract_sub_int := fract_sub_intCast
 
 @[simp]
-theorem fract_sub_nat (a : α) (n : ℕ) : fract (a - n) = fract a := by
+theorem fract_sub_natCast (a : α) (n : ℕ) : fract (a - n) = fract a := by
   rw [fract]
   simp
+@[deprecated (since := "2025-04-01")] alias fract_sub_nat := fract_sub_natCast
 
 @[simp]
-theorem fract_sub_one (a : α) : fract (a - 1) = fract a := mod_cast fract_sub_nat a 1
+theorem fract_sub_one (a : α) : fract (a - 1) = fract a := mod_cast fract_sub_natCast a 1
 
 @[simp]
 theorem fract_sub_ofNat (a : α) (n : ℕ) [n.AtLeastTwo] :
     fract (a - ofNat(n)) = fract a :=
-  fract_sub_nat a n
+  fract_sub_natCast a n
 
 -- Was a duplicate lemma under a bad name
 
@@ -970,7 +980,7 @@ theorem fract_neg_eq_zero {x : α} : fract (-x) = 0 ↔ fract x = 0 := by
   simp only [fract_eq_iff, le_refl, zero_lt_one, tsub_zero, true_and]
   constructor <;> rintro ⟨z, hz⟩ <;> use -z <;> simp [← hz]
 
-theorem fract_mul_nat (a : α) (b : ℕ) : ∃ z : ℤ, fract a * b - fract (a * b) = z := by
+theorem fract_mul_natCast (a : α) (b : ℕ) : ∃ z : ℤ, fract a * b - fract (a * b) = z := by
   induction b with
   | zero => use 0; simp
   | succ c hc =>
@@ -980,6 +990,8 @@ theorem fract_mul_nat (a : α) (b : ℕ) : ∃ z : ℤ, fract a * b - fract (a *
     use z - y
     rw [Int.cast_sub, ← hz, ← hy]
     abel
+
+@[deprecated (since := "2025-04-01")] alias fract_mul_nat := fract_mul_natCast
 
 theorem preimage_fract (s : Set α) :
     fract ⁻¹' s = ⋃ m : ℤ, (fun x => x - (m : α)) ⁻¹' (s ∩ Ico (0 : α) 1) := by

--- a/Mathlib/Algebra/Order/Floor.lean
+++ b/Mathlib/Algebra/Order/Floor.lean
@@ -691,13 +691,15 @@ theorem floor_pos : 0 < ⌊a⌋ ↔ 1 ≤ a := by
   rw [Int.lt_iff_add_one_le, zero_add, le_floor, cast_one]
 
 @[simp]
-theorem floor_add_int (a : α) (z : ℤ) : ⌊a + z⌋ = ⌊a⌋ + z :=
+theorem floor_add_intCast (a : α) (z : ℤ) : ⌊a + z⌋ = ⌊a⌋ + z :=
   eq_of_forall_le_iff fun a => by
     rw [le_floor, ← sub_le_iff_le_add, ← sub_le_iff_le_add, le_floor, Int.cast_sub]
 
+@[deprecated (since := "2025-04-01")] alias floor_add_int := floor_add_intCast
+
 @[simp]
 theorem floor_add_one (a : α) : ⌊a + 1⌋ = ⌊a⌋ + 1 := by
-  rw [← cast_one, floor_add_int]
+  rw [← cast_one, floor_add_intCast]
 
 @[bound]
 theorem le_floor_add (a b : α) : ⌊a⌋ + ⌊b⌋ ≤ ⌊a + b⌋ := by
@@ -712,41 +714,51 @@ theorem le_floor_add_floor (a b : α) : ⌊a + b⌋ - 1 ≤ ⌊a⌋ + ⌊b⌋ :=
   exact floor_le _
 
 @[simp]
-theorem floor_int_add (z : ℤ) (a : α) : ⌊↑z + a⌋ = z + ⌊a⌋ := by
-  simpa only [add_comm] using floor_add_int a z
+theorem floor_intCast_add (z : ℤ) (a : α) : ⌊↑z + a⌋ = z + ⌊a⌋ := by
+  simpa only [add_comm] using floor_add_intCast a z
+
+@[deprecated (since := "2025-04-01")] alias floor_int_add := floor_intCast_add
 
 @[simp]
-theorem floor_add_nat (a : α) (n : ℕ) : ⌊a + n⌋ = ⌊a⌋ + n := by
-  rw [← Int.cast_natCast, floor_add_int]
+theorem floor_add_natCast (a : α) (n : ℕ) : ⌊a + n⌋ = ⌊a⌋ + n := by
+  rw [← Int.cast_natCast, floor_add_intCast]
+
+@[deprecated (since := "2025-04-01")] alias floor_add_nat := floor_add_natCast
 
 @[simp]
 theorem floor_add_ofNat (a : α) (n : ℕ) [n.AtLeastTwo] :
     ⌊a + ofNat(n)⌋ = ⌊a⌋ + ofNat(n) :=
-  floor_add_nat a n
+  floor_add_natCast a n
 
 @[simp]
-theorem floor_nat_add (n : ℕ) (a : α) : ⌊↑n + a⌋ = n + ⌊a⌋ := by
-  rw [← Int.cast_natCast, floor_int_add]
+theorem floor_natCast_add (n : ℕ) (a : α) : ⌊↑n + a⌋ = n + ⌊a⌋ := by
+  rw [← Int.cast_natCast, floor_intCast_add]
+
+@[deprecated (since := "2025-04-01")] alias floor_nat_add := floor_natCast_add
 
 @[simp]
 theorem floor_ofNat_add (n : ℕ) [n.AtLeastTwo] (a : α) :
     ⌊ofNat(n) + a⌋ = ofNat(n) + ⌊a⌋ :=
-  floor_nat_add n a
+  floor_natCast_add n a
 
 @[simp]
-theorem floor_sub_int (a : α) (z : ℤ) : ⌊a - z⌋ = ⌊a⌋ - z :=
-  Eq.trans (by rw [Int.cast_neg, sub_eq_add_neg]) (floor_add_int _ _)
+theorem floor_sub_intCast (a : α) (z : ℤ) : ⌊a - z⌋ = ⌊a⌋ - z :=
+  Eq.trans (by rw [Int.cast_neg, sub_eq_add_neg]) (floor_add_intCast _ _)
+
+@[deprecated (since := "2025-04-01")] alias floor_sub_int := floor_sub_intCast
 
 @[simp]
-theorem floor_sub_nat (a : α) (n : ℕ) : ⌊a - n⌋ = ⌊a⌋ - n := by
-  rw [← Int.cast_natCast, floor_sub_int]
+theorem floor_sub_natCast (a : α) (n : ℕ) : ⌊a - n⌋ = ⌊a⌋ - n := by
+  rw [← Int.cast_natCast, floor_sub_intCast]
 
-@[simp] theorem floor_sub_one (a : α) : ⌊a - 1⌋ = ⌊a⌋ - 1 := mod_cast floor_sub_nat a 1
+@[deprecated (since := "2025-04-01")] alias floor_sub_nat := floor_sub_natCast
+
+@[simp] theorem floor_sub_one (a : α) : ⌊a - 1⌋ = ⌊a⌋ - 1 := mod_cast floor_sub_natCast a 1
 
 @[simp]
 theorem floor_sub_ofNat (a : α) (n : ℕ) [n.AtLeastTwo] :
     ⌊a - ofNat(n)⌋ = ⌊a⌋ - ofNat(n) :=
-  floor_sub_nat a n
+  floor_sub_natCast a n
 
 theorem abs_sub_lt_one_of_floor_eq_floor {α : Type*} [LinearOrderedCommRing α] [FloorRing α]
     {a b : α} (h : ⌊a⌋ = ⌊b⌋) : |a - b| < 1 := by
@@ -1098,29 +1110,38 @@ theorem ceil_mono : Monotone (ceil : α → ℤ) :=
 @[gcongr, bound] lemma ceil_le_ceil (hab : a ≤ b) : ⌈a⌉ ≤ ⌈b⌉ := ceil_mono hab
 
 @[simp]
-theorem ceil_add_int (a : α) (z : ℤ) : ⌈a + z⌉ = ⌈a⌉ + z := by
+theorem ceil_add_intCast (a : α) (z : ℤ) : ⌈a + z⌉ = ⌈a⌉ + z := by
   rw [← neg_inj, neg_add', ← floor_neg, ← floor_neg, neg_add', floor_sub_int]
 
+@[deprecated (since := "2025-04-01")] alias ceil_add_int := ceil_add_intCast
+
 @[simp]
-theorem ceil_add_nat (a : α) (n : ℕ) : ⌈a + n⌉ = ⌈a⌉ + n := by rw [← Int.cast_natCast, ceil_add_int]
+theorem ceil_add_natCast (a : α) (n : ℕ) : ⌈a + n⌉ = ⌈a⌉ + n := by
+  rw [← Int.cast_natCast, ceil_add_intCast]
+
+@[deprecated (since := "2025-04-01")] alias ceil_add_nat := ceil_add_natCast
 
 @[simp]
 theorem ceil_add_one (a : α) : ⌈a + 1⌉ = ⌈a⌉ + 1 := by
-  rw [← ceil_add_int a (1 : ℤ), cast_one]
+  rw [← ceil_add_intCast a (1 : ℤ), cast_one]
 
 @[simp]
 theorem ceil_add_ofNat (a : α) (n : ℕ) [n.AtLeastTwo] :
     ⌈a + ofNat(n)⌉ = ⌈a⌉ + ofNat(n) :=
-  ceil_add_nat a n
+  ceil_add_natCast a n
 
 @[simp]
-theorem ceil_sub_int (a : α) (z : ℤ) : ⌈a - z⌉ = ⌈a⌉ - z :=
-  Eq.trans (by rw [Int.cast_neg, sub_eq_add_neg]) (ceil_add_int _ _)
+theorem ceil_sub_intCast (a : α) (z : ℤ) : ⌈a - z⌉ = ⌈a⌉ - z :=
+  Eq.trans (by rw [Int.cast_neg, sub_eq_add_neg]) (ceil_add_intCast _ _)
+
+@[deprecated (since := "2025-04-01")] alias ceil_sub_int := ceil_sub_intCast
 
 @[simp]
-theorem ceil_sub_nat (a : α) (n : ℕ) : ⌈a - n⌉ = ⌈a⌉ - n := by
-  convert ceil_sub_int a n using 1
+theorem ceil_sub_natCast (a : α) (n : ℕ) : ⌈a - n⌉ = ⌈a⌉ - n := by
+  convert ceil_sub_intCast a n using 1
   simp
+
+@[deprecated (since := "2025-04-01")] alias ceil_sub_nat := ceil_sub_natCast
 
 @[simp]
 theorem ceil_sub_one (a : α) : ⌈a - 1⌉ = ⌈a⌉ - 1 := by
@@ -1129,11 +1150,11 @@ theorem ceil_sub_one (a : α) : ⌈a - 1⌉ = ⌈a⌉ - 1 := by
 @[simp]
 theorem ceil_sub_ofNat (a : α) (n : ℕ) [n.AtLeastTwo] :
     ⌈a - ofNat(n)⌉ = ⌈a⌉ - ofNat(n) :=
-  ceil_sub_nat a n
+  ceil_sub_natCast a n
 
 @[bound]
 theorem ceil_lt_add_one (a : α) : (⌈a⌉ : α) < a + 1 := by
-  rw [← lt_ceil, ← Int.cast_one, ceil_add_int]
+  rw [← lt_ceil, ← Int.cast_one, ceil_add_intCast]
   apply lt_add_one
 
 @[bound]

--- a/Mathlib/Algebra/Order/Floor.lean
+++ b/Mathlib/Algebra/Order/Floor.lean
@@ -805,14 +805,16 @@ theorem fract_add_floor (a : α) : fract a + ⌊a⌋ = a :=
   sub_add_cancel _ _
 
 @[simp]
-theorem fract_add_int (a : α) (m : ℤ) : fract (a + m) = fract a := by
+theorem fract_add_intCast (a : α) (m : ℤ) : fract (a + m) = fract a := by
   rw [fract]
   simp
+@[deprecated (since := "2025-04-01")] alias fract_add_int := fract_add_intCast
 
 @[simp]
-theorem fract_add_nat (a : α) (m : ℕ) : fract (a + m) = fract a := by
+theorem fract_add_natCast (a : α) (m : ℕ) : fract (a + m) = fract a := by
   rw [fract]
   simp
+@[deprecated (since := "2025-04-01")] alias fract_add_nat := fract_add_natCast
 
 @[simp]
 theorem fract_add_one (a : α) : fract (a + 1) = fract a := mod_cast fract_add_nat a 1
@@ -823,18 +825,22 @@ theorem fract_add_ofNat (a : α) (n : ℕ) [n.AtLeastTwo] :
   fract_add_nat a n
 
 @[simp]
-theorem fract_int_add (m : ℤ) (a : α) : fract (↑m + a) = fract a := by rw [add_comm, fract_add_int]
+theorem fract_intCast_add (m : ℤ) (a : α) : fract (↑m + a) = fract a := by
+  rw [add_comm, fract_add_int]
+@[deprecated (since := "2025-04-01")] alias fract_int_add := fract_intCast_add
 
 @[simp]
-theorem fract_nat_add (n : ℕ) (a : α) : fract (↑n + a) = fract a := by rw [add_comm, fract_add_nat]
+theorem fract_natCast_add (n : ℕ) (a : α) : fract (↑n + a) = fract a := by
+  rw [add_comm, fract_add_nat]
+@[deprecated (since := "2025-04-01")] alias fract_nat_add := fract_natCast_add
 
 @[simp]
-theorem fract_one_add (a : α) : fract (1 + a) = fract a := mod_cast fract_nat_add 1 a
+theorem fract_one_add (a : α) : fract (1 + a) = fract a := mod_cast fract_natCast_add 1 a
 
 @[simp]
 theorem fract_ofNat_add (n : ℕ) [n.AtLeastTwo] (a : α) :
     fract (ofNat(n) + a) = fract a :=
-  fract_nat_add n a
+  fract_natCast_add n a
 
 @[simp]
 theorem fract_sub_int (a : α) (m : ℤ) : fract (a - m) = fract a := by
@@ -1049,7 +1055,7 @@ theorem fract_div_intCast_eq_div_intCast_mod {m : ℤ} {n : ℕ} :
     _ = fract ((m₁ : k) / n) := ?_
     _ = Int.cast (m₁ % (n : ℤ)) / Nat.cast n := this hm₁
     _ = Int.cast (-(↑m₀ : ℤ) % ↑n) / Nat.cast n := ?_
-  · rw [← fract_int_add q, ← mul_div_cancel_right₀ (q : k) hn.ne', ← add_div, ← sub_eq_add_neg]
+  · rw [← fract_intCast_add q, ← mul_div_cancel_right₀ (q : k) hn.ne', ← add_div, ← sub_eq_add_neg]
     simp [m₁]
   · congr 2
     simp only [m₁]

--- a/Mathlib/Algebra/Order/Round.lean
+++ b/Mathlib/Algebra/Order/Round.lean
@@ -59,8 +59,8 @@ theorem round_intCast (n : ℤ) : round (n : α) = n := by simp [round]
 
 @[simp]
 theorem round_add_intCast (x : α) (y : ℤ) : round (x + y) = round x + y := by
-  rw [round, round, Int.fract_add_int, Int.floor_add_intCast, Int.ceil_add_intCast, ← apply_ite₂,
-    ite_self]
+  rw [round, round, Int.fract_add_intCast, Int.floor_add_intCast, Int.ceil_add_intCast,
+    ← apply_ite₂, ite_self]
 
 @[deprecated (since := "2025-03-23")]
 alias round_add_int := round_add_intCast

--- a/Mathlib/Algebra/Order/Round.lean
+++ b/Mathlib/Algebra/Order/Round.lean
@@ -59,7 +59,8 @@ theorem round_intCast (n : ℤ) : round (n : α) = n := by simp [round]
 
 @[simp]
 theorem round_add_intCast (x : α) (y : ℤ) : round (x + y) = round x + y := by
-  rw [round, round, Int.fract_add_int, Int.floor_add_int, Int.ceil_add_int, ← apply_ite₂, ite_self]
+  rw [round, round, Int.fract_add_int, Int.floor_add_intCast, Int.ceil_add_intCast, ← apply_ite₂,
+    ite_self]
 
 @[deprecated (since := "2025-03-23")]
 alias round_add_int := round_add_intCast
@@ -155,7 +156,7 @@ variable [LinearOrderedField α] [FloorRing α]
 theorem round_eq (x : α) : round x = ⌊x + 1 / 2⌋ := by
   simp_rw [round, (by simp only [lt_div_iff₀', two_pos] : 2 * fract x < 1 ↔ fract x < 1 / 2)]
   rcases lt_or_le (fract x) (1 / 2) with hx | hx
-  · conv_rhs => rw [← fract_add_floor x, add_assoc, add_left_comm, floor_int_add]
+  · conv_rhs => rw [← fract_add_floor x, add_assoc, add_left_comm, floor_intCast_add]
     rw [if_pos hx, left_eq_add, floor_eq_iff, cast_zero, zero_add]
     constructor
     · linarith [fract_nonneg x]
@@ -167,8 +168,8 @@ theorem round_eq (x : α) : round x = ⌊x + 1 / 2⌋ := by
         linarith
       · norm_num
         linarith [fract_lt_one x]
-    rw [if_neg (not_lt.mpr hx), ← fract_add_floor x, add_assoc, add_left_comm, floor_int_add,
-      ceil_add_int, add_comm _ ⌊x⌋, add_right_inj, ceil_eq_iff, this, cast_one, sub_self]
+    rw [if_neg (not_lt.mpr hx), ← fract_add_floor x, add_assoc, add_left_comm, floor_intCast_add,
+      ceil_add_intCast, add_comm _ ⌊x⌋, add_right_inj, ceil_eq_iff, this, cast_one, sub_self]
     constructor
     · linarith
     · linarith [fract_lt_one x]

--- a/Mathlib/Data/Int/CardIntervalMod.lean
+++ b/Mathlib/Data/Int/CardIntervalMod.lean
@@ -127,7 +127,7 @@ theorem count_modEq_card_eq_ceil (v : ℕ) :
     max_eq_left (sub_nonneg.mpr <| by gcongr <;> positivity)]
   conv_lhs =>
     rw [← div_add_mod v r, cast_add, cast_mul, add_comm]
-    tactic => simp_rw [← sub_sub, sub_div (_ - _), mul_div_cancel_left₀ _ hr'.ne', ceil_sub_nat]
+    tactic => simp_rw [← sub_sub, sub_div (_ - _), mul_div_cancel_left₀ _ hr'.ne', ceil_sub_natCast]
     rw [sub_sub_sub_cancel_right, cast_zero, zero_sub]
   rw [sub_eq_self, ceil_eq_zero_iff, Set.mem_Ioc, div_le_iff₀ hr', lt_div_iff₀ hr', neg_one_mul,
     zero_mul, neg_lt_neg_iff, cast_lt]
@@ -140,7 +140,7 @@ theorem count_modEq_card (v : ℕ) :
   have hr' : 0 < (r : ℚ) := by positivity
   rw [← ofNat_inj, count_modEq_card_eq_ceil _ hr, cast_add]
   conv_lhs => rw [← div_add_mod b r, cast_add, cast_mul, ← add_sub, _root_.add_div,
-    mul_div_cancel_left₀ _ hr'.ne', add_comm, Int.ceil_add_nat, add_comm]
+    mul_div_cancel_left₀ _ hr'.ne', add_comm, Int.ceil_add_natCast, add_comm]
   rw [add_right_inj]
   split_ifs with h
   · rw [← cast_sub h.le, Int.ceil_eq_iff, div_le_iff₀ hr', lt_div_iff₀ hr', cast_one, Int.cast_one,

--- a/Mathlib/Data/Real/GoldenRatio.lean
+++ b/Mathlib/Data/Real/GoldenRatio.lean
@@ -120,16 +120,16 @@ theorem neg_one_lt_goldConj : -1 < ψ := by
 /-- The golden ratio is irrational. -/
 theorem gold_irrational : Irrational φ := by
   have := Nat.Prime.irrational_sqrt (show Nat.Prime 5 by norm_num)
-  have := this.rat_add 1
-  convert this.rat_mul (show (0.5 : ℚ) ≠ 0 by norm_num)
+  have := this.ratCast_add 1
+  convert this.ratCast_mul (show (0.5 : ℚ) ≠ 0 by norm_num)
   norm_num
   field_simp
 
 /-- The conjugate of the golden ratio is irrational. -/
 theorem goldConj_irrational : Irrational ψ := by
   have := Nat.Prime.irrational_sqrt (show Nat.Prime 5 by norm_num)
-  have := this.rat_sub 1
-  convert this.rat_mul (show (0.5 : ℚ) ≠ 0 by norm_num)
+  have := this.ratCast_sub 1
+  convert this.ratCast_mul (show (0.5 : ℚ) ≠ 0 by norm_num)
   norm_num
   field_simp
 

--- a/Mathlib/Data/Real/Irrational.lean
+++ b/Mathlib/Data/Real/Irrational.lean
@@ -279,41 +279,53 @@ protected theorem neg (h : Irrational x) : Irrational (-x) :=
 -/
 
 
-theorem sub_rat (h : Irrational x) : Irrational (x - q) := by
+theorem sub_ratCast (h : Irrational x) : Irrational (x - q) := by
   simpa only [sub_eq_add_neg, cast_neg] using h.add_ratCast (-q)
+@[deprecated (since := "2025-04-01")] alias sub_rat := sub_ratCast
 
-theorem rat_sub (h : Irrational x) : Irrational (q - x) := by
+theorem ratCast_sub (h : Irrational x) : Irrational (q - x) := by
   simpa only [sub_eq_add_neg] using h.neg.ratCast_add q
+@[deprecated (since := "2025-04-01")] alias rat_sub := ratCast_sub
 
-theorem of_sub_rat (h : Irrational (x - q)) : Irrational x :=
+theorem of_sub_ratCast (h : Irrational (x - q)) : Irrational x :=
   of_add_ratCast (-q) <| by simpa only [cast_neg, sub_eq_add_neg] using h
+@[deprecated (since := "2025-04-01")] alias of_sub_rat := of_sub_ratCast
 
-theorem of_rat_sub (h : Irrational (q - x)) : Irrational x :=
+theorem of_ratCast_sub (h : Irrational (q - x)) : Irrational x :=
   of_neg (of_ratCast_add q (by simpa only [sub_eq_add_neg] using h))
+@[deprecated (since := "2025-04-01")] alias of_rat_sub := of_ratCast_sub
 
-theorem sub_int (h : Irrational x) (m : ℤ) : Irrational (x - m) := by
-  simpa only [Rat.cast_intCast] using h.sub_rat m
+theorem sub_intCast (h : Irrational x) (m : ℤ) : Irrational (x - m) := by
+  simpa only [Rat.cast_intCast] using h.sub_ratCast m
+@[deprecated (since := "2025-04-01")] alias sub_int := sub_intCast
 
-theorem int_sub (h : Irrational x) (m : ℤ) : Irrational (m - x) := by
-  simpa only [Rat.cast_intCast] using h.rat_sub m
+theorem intCast_sub (h : Irrational x) (m : ℤ) : Irrational (m - x) := by
+  simpa only [Rat.cast_intCast] using h.ratCast_sub m
+@[deprecated (since := "2025-04-01")] alias int_sub := intCast_sub
 
-theorem of_sub_int (m : ℤ) (h : Irrational (x - m)) : Irrational x :=
-  of_sub_rat m <| by rwa [Rat.cast_intCast]
+theorem of_sub_intCast (m : ℤ) (h : Irrational (x - m)) : Irrational x :=
+  of_sub_ratCast m <| by rwa [Rat.cast_intCast]
+@[deprecated (since := "2025-04-01")] alias of_sub_int := of_sub_intCast
 
-theorem of_int_sub (m : ℤ) (h : Irrational (m - x)) : Irrational x :=
-  of_rat_sub m <| by rwa [Rat.cast_intCast]
+theorem of_intCast_sub (m : ℤ) (h : Irrational (m - x)) : Irrational x :=
+  of_ratCast_sub m <| by rwa [Rat.cast_intCast]
+@[deprecated (since := "2025-04-01")] alias of_int_sub := of_intCast_sub
 
-theorem sub_nat (h : Irrational x) (m : ℕ) : Irrational (x - m) :=
-  h.sub_int m
+theorem sub_natCast (h : Irrational x) (m : ℕ) : Irrational (x - m) :=
+  h.sub_intCast m
+@[deprecated (since := "2025-04-01")] alias sub_nat := sub_natCast
 
-theorem nat_sub (h : Irrational x) (m : ℕ) : Irrational (m - x) :=
-  h.int_sub m
+theorem natCast_sub (h : Irrational x) (m : ℕ) : Irrational (m - x) :=
+  h.intCast_sub m
+@[deprecated (since := "2025-04-01")] alias nat_sub := natCast_sub
 
-theorem of_sub_nat (m : ℕ) (h : Irrational (x - m)) : Irrational x :=
-  h.of_sub_int m
+theorem of_sub_natCast (m : ℕ) (h : Irrational (x - m)) : Irrational x :=
+  h.of_sub_intCast m
+@[deprecated (since := "2025-04-01")] alias of_sub_nat := of_sub_natCast
 
-theorem of_nat_sub (m : ℕ) (h : Irrational (m - x)) : Irrational x :=
-  h.of_int_sub m
+theorem of_natCast_sub (m : ℕ) (h : Irrational (m - x)) : Irrational x :=
+  h.of_intCast_sub m
+@[deprecated (since := "2025-04-01")] alias of_nat_sub := of_natCast_sub
 
 /-!
 #### Multiplication by rational numbers
@@ -326,43 +338,55 @@ theorem mul_cases : Irrational (x * y) → Irrational x ∨ Irrational y := by
   rintro ⟨⟨rx, rfl⟩, ⟨ry, rfl⟩⟩
   exact ⟨rx * ry, cast_mul rx ry⟩
 
-theorem of_mul_rat (h : Irrational (x * q)) : Irrational x :=
+theorem of_mul_ratCast (h : Irrational (x * q)) : Irrational x :=
   h.mul_cases.resolve_right q.not_irrational
+@[deprecated (since := "2025-04-01")] alias of_mul_rat := of_mul_ratCast
 
-theorem mul_rat (h : Irrational x) {q : ℚ} (hq : q ≠ 0) : Irrational (x * q) :=
-  of_mul_rat q⁻¹ <| by rwa [mul_assoc, ← cast_mul, mul_inv_cancel₀ hq, cast_one, mul_one]
+theorem mul_ratCast (h : Irrational x) {q : ℚ} (hq : q ≠ 0) : Irrational (x * q) :=
+  of_mul_ratCast q⁻¹ <| by rwa [mul_assoc, ← cast_mul, mul_inv_cancel₀ hq, cast_one, mul_one]
+@[deprecated (since := "2025-04-01")] alias mul_rat := mul_ratCast
 
-theorem of_rat_mul : Irrational (q * x) → Irrational x :=
-  mul_comm x q ▸ of_mul_rat q
+theorem of_ratCast_mul : Irrational (q * x) → Irrational x :=
+  mul_comm x q ▸ of_mul_ratCast q
+@[deprecated (since := "2025-04-01")] alias of_rat_mul := of_ratCast_mul
 
-theorem rat_mul (h : Irrational x) {q : ℚ} (hq : q ≠ 0) : Irrational (q * x) :=
-  mul_comm x q ▸ h.mul_rat hq
+theorem ratCast_mul (h : Irrational x) {q : ℚ} (hq : q ≠ 0) : Irrational (q * x) :=
+  mul_comm x q ▸ h.mul_ratCast hq
+@[deprecated (since := "2025-04-01")] alias rat_mul := ratCast_mul
 
-theorem of_mul_int (m : ℤ) (h : Irrational (x * m)) : Irrational x :=
-  of_mul_rat m <| by rwa [cast_intCast]
+theorem of_mul_intCast (m : ℤ) (h : Irrational (x * m)) : Irrational x :=
+  of_mul_ratCast m <| by rwa [cast_intCast]
+@[deprecated (since := "2025-04-01")] alias of_mul_int := of_mul_intCast
 
-theorem of_int_mul (m : ℤ) (h : Irrational (m * x)) : Irrational x :=
-  of_rat_mul m <| by rwa [cast_intCast]
+theorem of_intCast_mul (m : ℤ) (h : Irrational (m * x)) : Irrational x :=
+  of_ratCast_mul m <| by rwa [cast_intCast]
+@[deprecated (since := "2025-04-01")] alias of_int_mul := of_intCast_mul
 
-theorem mul_int (h : Irrational x) {m : ℤ} (hm : m ≠ 0) : Irrational (x * m) := by
+theorem mul_intCast (h : Irrational x) {m : ℤ} (hm : m ≠ 0) : Irrational (x * m) := by
   rw [← cast_intCast]
-  refine h.mul_rat ?_
+  refine h.mul_ratCast ?_
   rwa [Int.cast_ne_zero]
+@[deprecated (since := "2025-04-01")] alias mul_int := mul_intCast
 
-theorem int_mul (h : Irrational x) {m : ℤ} (hm : m ≠ 0) : Irrational (m * x) :=
-  mul_comm x m ▸ h.mul_int hm
+theorem intCast_mul (h : Irrational x) {m : ℤ} (hm : m ≠ 0) : Irrational (m * x) :=
+  mul_comm x m ▸ h.mul_intCast hm
+@[deprecated (since := "2025-04-01")] alias int_mul := intCast_mul
 
-theorem of_mul_nat (m : ℕ) (h : Irrational (x * m)) : Irrational x :=
-  h.of_mul_int m
+theorem of_mul_natCast (m : ℕ) (h : Irrational (x * m)) : Irrational x :=
+  h.of_mul_intCast m
+@[deprecated (since := "2025-04-01")] alias of_mul_nat := of_mul_natCast
 
-theorem of_nat_mul (m : ℕ) (h : Irrational (m * x)) : Irrational x :=
-  h.of_int_mul m
+theorem of_natCast_mul (m : ℕ) (h : Irrational (m * x)) : Irrational x :=
+  h.of_intCast_mul m
+@[deprecated (since := "2025-04-01")] alias of_nat_mul := of_natCast_mul
 
-theorem mul_nat (h : Irrational x) {m : ℕ} (hm : m ≠ 0) : Irrational (x * m) :=
-  h.mul_int <| Int.natCast_ne_zero.2 hm
+theorem mul_natCast (h : Irrational x) {m : ℕ} (hm : m ≠ 0) : Irrational (x * m) :=
+  h.mul_intCast <| Int.natCast_ne_zero.2 hm
+@[deprecated (since := "2025-04-01")] alias mul_nat := mul_natCast
 
-theorem nat_mul (h : Irrational x) {m : ℕ} (hm : m ≠ 0) : Irrational (m * x) :=
-  h.int_mul <| Int.natCast_ne_zero.2 hm
+theorem natCast_mul (h : Irrational x) {m : ℕ} (hm : m ≠ 0) : Irrational (m * x) :=
+  h.intCast_mul <| Int.natCast_ne_zero.2 hm
+@[deprecated (since := "2025-04-01")] alias nat_mul := natCast_mul
 
 /-!
 #### Inverse
@@ -382,47 +406,59 @@ protected theorem inv (h : Irrational x) : Irrational x⁻¹ :=
 theorem div_cases (h : Irrational (x / y)) : Irrational x ∨ Irrational y :=
   h.mul_cases.imp id of_inv
 
-theorem of_rat_div (h : Irrational (q / x)) : Irrational x :=
-  (h.of_rat_mul q).of_inv
+theorem of_ratCast_div (h : Irrational (q / x)) : Irrational x :=
+  (h.of_ratCast_mul q).of_inv
+@[deprecated (since := "2025-04-01")] alias of_rat_div := of_ratCast_div
 
-theorem of_div_rat (h : Irrational (x / q)) : Irrational x :=
+theorem of_div_ratCast (h : Irrational (x / q)) : Irrational x :=
   h.div_cases.resolve_right q.not_irrational
+@[deprecated (since := "2025-04-01")] alias of_div_rat := of_div_ratCast
 
-theorem rat_div (h : Irrational x) {q : ℚ} (hq : q ≠ 0) : Irrational (q / x) :=
-  h.inv.rat_mul hq
+theorem ratCast_div (h : Irrational x) {q : ℚ} (hq : q ≠ 0) : Irrational (q / x) :=
+  h.inv.ratCast_mul hq
+@[deprecated (since := "2025-04-01")] alias rat_div := ratCast_div
 
-theorem div_rat (h : Irrational x) {q : ℚ} (hq : q ≠ 0) : Irrational (x / q) := by
+theorem div_ratCast (h : Irrational x) {q : ℚ} (hq : q ≠ 0) : Irrational (x / q) := by
   rw [div_eq_mul_inv, ← cast_inv]
-  exact h.mul_rat (inv_ne_zero hq)
+  exact h.mul_ratCast (inv_ne_zero hq)
+@[deprecated (since := "2025-04-01")] alias div_rat := div_ratCast
 
-theorem of_int_div (m : ℤ) (h : Irrational (m / x)) : Irrational x :=
+theorem of_intCast_div (m : ℤ) (h : Irrational (m / x)) : Irrational x :=
   h.div_cases.resolve_left m.not_irrational
+@[deprecated (since := "2025-04-01")] alias of_int_div := of_intCast_div
 
-theorem of_div_int (m : ℤ) (h : Irrational (x / m)) : Irrational x :=
+theorem of_div_intCast (m : ℤ) (h : Irrational (x / m)) : Irrational x :=
   h.div_cases.resolve_right m.not_irrational
+@[deprecated (since := "2025-04-01")] alias of_div_int := of_div_intCast
 
-theorem int_div (h : Irrational x) {m : ℤ} (hm : m ≠ 0) : Irrational (m / x) :=
-  h.inv.int_mul hm
+theorem intCast_div (h : Irrational x) {m : ℤ} (hm : m ≠ 0) : Irrational (m / x) :=
+  h.inv.intCast_mul hm
+@[deprecated (since := "2025-04-01")] alias int_div := intCast_div
 
-theorem div_int (h : Irrational x) {m : ℤ} (hm : m ≠ 0) : Irrational (x / m) := by
+theorem div_intCast (h : Irrational x) {m : ℤ} (hm : m ≠ 0) : Irrational (x / m) := by
   rw [← cast_intCast]
-  refine h.div_rat ?_
+  refine h.div_ratCast ?_
   rwa [Int.cast_ne_zero]
+@[deprecated (since := "2025-04-01")] alias div_int := div_intCast
 
-theorem of_nat_div (m : ℕ) (h : Irrational (m / x)) : Irrational x :=
-  h.of_int_div m
+theorem of_natCast_div (m : ℕ) (h : Irrational (m / x)) : Irrational x :=
+  h.of_intCast_div m
+@[deprecated (since := "2025-04-01")] alias of_nat_div := of_natCast_div
 
-theorem of_div_nat (m : ℕ) (h : Irrational (x / m)) : Irrational x :=
-  h.of_div_int m
+theorem of_div_natCast (m : ℕ) (h : Irrational (x / m)) : Irrational x :=
+  h.of_div_intCast m
+@[deprecated (since := "2025-04-01")] alias of_div_nat := of_div_natCast
 
-theorem nat_div (h : Irrational x) {m : ℕ} (hm : m ≠ 0) : Irrational (m / x) :=
-  h.inv.nat_mul hm
+theorem natCast_div (h : Irrational x) {m : ℕ} (hm : m ≠ 0) : Irrational (m / x) :=
+  h.inv.natCast_mul hm
+@[deprecated (since := "2025-04-01")] alias nat_div := natCast_div
 
-theorem div_nat (h : Irrational x) {m : ℕ} (hm : m ≠ 0) : Irrational (x / m) :=
-  h.div_int <| by rwa [Int.natCast_ne_zero]
+theorem div_natCast (h : Irrational x) {m : ℕ} (hm : m ≠ 0) : Irrational (x / m) :=
+  h.div_intCast <| by rwa [Int.natCast_ne_zero]
+@[deprecated (since := "2025-04-01")] alias div_nat := div_natCast
 
 theorem of_one_div (h : Irrational (1 / x)) : Irrational x :=
-  of_rat_div 1 <| by rwa [cast_one]
+  of_ratCast_div 1 <| by rwa [cast_one]
 
 /-!
 #### Natural and integer power
@@ -516,32 +552,32 @@ theorem irrational_add_natCast_iff : Irrational (x + n) ↔ Irrational x :=
 
 @[simp]
 theorem irrational_ratCast_sub_iff : Irrational (q - x) ↔ Irrational x :=
-  ⟨of_rat_sub q, rat_sub q⟩
+  ⟨of_ratCast_sub q, ratCast_sub q⟩
 @[deprecated (since := "2025-04-01")] alias irrational_rat_sub_iff := irrational_ratCast_sub_iff
 
 @[simp]
 theorem irrational_intCast_sub_iff : Irrational (m - x) ↔ Irrational x :=
-  ⟨of_int_sub m, fun h => h.int_sub m⟩
+  ⟨of_intCast_sub m, fun h => h.intCast_sub m⟩
 @[deprecated (since := "2025-04-01")] alias irrational_int_sub_iff := irrational_intCast_sub_iff
 
 @[simp]
 theorem irrational_natCast_sub_iff : Irrational (n - x) ↔ Irrational x :=
-  ⟨of_nat_sub n, fun h => h.nat_sub n⟩
+  ⟨of_natCast_sub n, fun h => h.natCast_sub n⟩
 @[deprecated (since := "2025-04-01")] alias irrational_nat_sub_iff := irrational_natCast_sub_iff
 
 @[simp]
 theorem irrational_sub_ratCast_iff : Irrational (x - q) ↔ Irrational x :=
-  ⟨of_sub_rat q, sub_rat q⟩
+  ⟨of_sub_ratCast q, sub_ratCast q⟩
 @[deprecated (since := "2025-04-01")] alias irrational_sub_rat_iff := irrational_sub_ratCast_iff
 
 @[simp]
 theorem irrational_sub_intCast_iff : Irrational (x - m) ↔ Irrational x :=
-  ⟨of_sub_int m, fun h => h.sub_int m⟩
+  ⟨of_sub_intCast m, fun h => h.sub_intCast m⟩
 @[deprecated (since := "2025-04-01")] alias irrational_sub_int_iff := irrational_sub_intCast_iff
 
 @[simp]
 theorem irrational_sub_natCast_iff : Irrational (x - n) ↔ Irrational x :=
-  ⟨of_sub_nat n, fun h => h.sub_nat n⟩
+  ⟨of_sub_natCast n, fun h => h.sub_natCast n⟩
 @[deprecated (since := "2025-04-01")] alias irrational_sub_nat_iff := irrational_sub_natCast_iff
 
 @[simp]
@@ -554,8 +590,8 @@ theorem irrational_inv_iff : Irrational x⁻¹ ↔ Irrational x :=
 
 @[simp]
 theorem irrational_ratCast_mul_iff : Irrational (q * x) ↔ q ≠ 0 ∧ Irrational x :=
-  ⟨fun h => ⟨Rat.cast_ne_zero.1 <| left_ne_zero_of_mul h.ne_zero, h.of_rat_mul q⟩, fun h =>
-    h.2.rat_mul h.1⟩
+  ⟨fun h => ⟨Rat.cast_ne_zero.1 <| left_ne_zero_of_mul h.ne_zero, h.of_ratCast_mul q⟩, fun h =>
+    h.2.ratCast_mul h.1⟩
 @[deprecated (since := "2025-04-01")] alias irrational_rat_mul_iff := irrational_ratCast_mul_iff
 
 @[simp]

--- a/Mathlib/Data/Real/Irrational.lean
+++ b/Mathlib/Data/Real/Irrational.lean
@@ -213,43 +213,56 @@ theorem add_cases : Irrational (x + y) → Irrational x ∨ Irrational y := by
   rintro ⟨⟨rx, rfl⟩, ⟨ry, rfl⟩⟩
   exact ⟨rx + ry, cast_add rx ry⟩
 
-theorem of_rat_add (h : Irrational (q + x)) : Irrational x :=
+theorem of_ratCast_add (h : Irrational (q + x)) : Irrational x :=
   h.add_cases.resolve_left q.not_irrational
+@[deprecated (since := "2025-04-01")] alias of_rat_add := of_ratCast_add
 
-theorem rat_add (h : Irrational x) : Irrational (q + x) :=
-  of_rat_add (-q) <| by rwa [cast_neg, neg_add_cancel_left]
+theorem ratCast_add (h : Irrational x) : Irrational (q + x) :=
+  of_ratCast_add (-q) <| by rwa [cast_neg, neg_add_cancel_left]
+@[deprecated (since := "2025-04-01")] alias rat_add := ratCast_add
 
-theorem of_add_rat : Irrational (x + q) → Irrational x :=
-  add_comm (↑q) x ▸ of_rat_add q
+theorem of_add_ratCast : Irrational (x + q) → Irrational x :=
+  add_comm (↑q) x ▸ of_ratCast_add q
+@[deprecated (since := "2025-04-01")] alias of_add_rat := of_add_ratCast
 
-theorem add_rat (h : Irrational x) : Irrational (x + q) :=
-  add_comm (↑q) x ▸ h.rat_add q
+theorem add_ratCast (h : Irrational x) : Irrational (x + q) :=
+  add_comm (↑q) x ▸ h.ratCast_add q
+@[deprecated (since := "2025-04-01")] alias add_rat := add_ratCast
 
-theorem of_int_add (m : ℤ) (h : Irrational (m + x)) : Irrational x := by
+theorem of_intCast_add (m : ℤ) (h : Irrational (m + x)) : Irrational x := by
   rw [← cast_intCast] at h
-  exact h.of_rat_add m
+  exact h.of_ratCast_add m
+@[deprecated (since := "2025-04-01")] alias of_int_add := of_intCast_add
 
-theorem of_add_int (m : ℤ) (h : Irrational (x + m)) : Irrational x :=
-  of_int_add m <| add_comm x m ▸ h
+theorem of_add_intCast (m : ℤ) (h : Irrational (x + m)) : Irrational x :=
+  of_intCast_add m <| add_comm x m ▸ h
+@[deprecated (since := "2025-04-01")] alias of_add_int := of_add_intCast
 
-theorem int_add (h : Irrational x) (m : ℤ) : Irrational (m + x) := by
+theorem intCast_add (h : Irrational x) (m : ℤ) : Irrational (m + x) := by
   rw [← cast_intCast]
-  exact h.rat_add m
+  exact h.ratCast_add m
+@[deprecated (since := "2025-04-01")] alias int_add := intCast_add
 
-theorem add_int (h : Irrational x) (m : ℤ) : Irrational (x + m) :=
-  add_comm (↑m) x ▸ h.int_add m
 
-theorem of_nat_add (m : ℕ) (h : Irrational (m + x)) : Irrational x :=
-  h.of_int_add m
+theorem add_intCast (h : Irrational x) (m : ℤ) : Irrational (x + m) :=
+  add_comm (↑m) x ▸ h.intCast_add m
+@[deprecated (since := "2025-04-01")] alias add_int := add_intCast
 
-theorem of_add_nat (m : ℕ) (h : Irrational (x + m)) : Irrational x :=
-  h.of_add_int m
+theorem of_natCast_add (m : ℕ) (h : Irrational (m + x)) : Irrational x :=
+  h.of_intCast_add m
+@[deprecated (since := "2025-04-01")] alias of_nat_add := of_natCast_add
 
-theorem nat_add (h : Irrational x) (m : ℕ) : Irrational (m + x) :=
-  h.int_add m
+theorem of_add_natCast (m : ℕ) (h : Irrational (x + m)) : Irrational x :=
+  h.of_add_intCast m
+@[deprecated (since := "2025-04-01")] alias of_add_nat := of_add_natCast
 
-theorem add_nat (h : Irrational x) (m : ℕ) : Irrational (x + m) :=
-  h.add_int m
+theorem natCast_add (h : Irrational x) (m : ℕ) : Irrational (m + x) :=
+  h.intCast_add m
+@[deprecated (since := "2025-04-01")] alias nat_add := natCast_add
+
+theorem add_natCast (h : Irrational x) (m : ℕ) : Irrational (x + m) :=
+  h.add_intCast m
+@[deprecated (since := "2025-04-01")] alias add_nat := add_natCast
 
 /-!
 #### Negation
@@ -267,16 +280,16 @@ protected theorem neg (h : Irrational x) : Irrational (-x) :=
 
 
 theorem sub_rat (h : Irrational x) : Irrational (x - q) := by
-  simpa only [sub_eq_add_neg, cast_neg] using h.add_rat (-q)
+  simpa only [sub_eq_add_neg, cast_neg] using h.add_ratCast (-q)
 
 theorem rat_sub (h : Irrational x) : Irrational (q - x) := by
-  simpa only [sub_eq_add_neg] using h.neg.rat_add q
+  simpa only [sub_eq_add_neg] using h.neg.ratCast_add q
 
 theorem of_sub_rat (h : Irrational (x - q)) : Irrational x :=
-  of_add_rat (-q) <| by simpa only [cast_neg, sub_eq_add_neg] using h
+  of_add_ratCast (-q) <| by simpa only [cast_neg, sub_eq_add_neg] using h
 
 theorem of_rat_sub (h : Irrational (q - x)) : Irrational x :=
-  of_neg (of_rat_add q (by simpa only [sub_eq_add_neg] using h))
+  of_neg (of_ratCast_add q (by simpa only [sub_eq_add_neg] using h))
 
 theorem sub_int (h : Irrational x) (m : ℤ) : Irrational (x - m) := by
   simpa only [Rat.cast_intCast] using h.sub_rat m
@@ -472,52 +485,64 @@ open Irrational
 
 
 @[simp]
-theorem irrational_rat_add_iff : Irrational (q + x) ↔ Irrational x :=
-  ⟨of_rat_add q, rat_add q⟩
+theorem irrational_ratCast_add_iff : Irrational (q + x) ↔ Irrational x :=
+  ⟨of_ratCast_add q, ratCast_add q⟩
+@[deprecated (since := "2025-04-01")] alias irrational_rat_add_iff := irrational_ratCast_add_iff
 
 @[simp]
-theorem irrational_int_add_iff : Irrational (m + x) ↔ Irrational x :=
-  ⟨of_int_add m, fun h => h.int_add m⟩
+theorem irrational_intCast_add_iff : Irrational (m + x) ↔ Irrational x :=
+  ⟨of_intCast_add m, fun h => h.intCast_add m⟩
+@[deprecated (since := "2025-04-01")] alias irrational_int_add_iff := irrational_intCast_add_iff
 
 @[simp]
-theorem irrational_nat_add_iff : Irrational (n + x) ↔ Irrational x :=
-  ⟨of_nat_add n, fun h => h.nat_add n⟩
+theorem irrational_natCast_add_iff : Irrational (n + x) ↔ Irrational x :=
+  ⟨of_natCast_add n, fun h => h.natCast_add n⟩
+@[deprecated (since := "2025-04-01")] alias irrational_nat_add_iff := irrational_natCast_add_iff
 
 @[simp]
-theorem irrational_add_rat_iff : Irrational (x + q) ↔ Irrational x :=
-  ⟨of_add_rat q, add_rat q⟩
+theorem irrational_add_ratCast_iff : Irrational (x + q) ↔ Irrational x :=
+  ⟨of_add_ratCast q, add_ratCast q⟩
+@[deprecated (since := "2025-04-01")] alias irrational_add_rat_iff := irrational_add_ratCast_iff
 
 @[simp]
-theorem irrational_add_int_iff : Irrational (x + m) ↔ Irrational x :=
-  ⟨of_add_int m, fun h => h.add_int m⟩
+theorem irrational_add_intCast_iff : Irrational (x + m) ↔ Irrational x :=
+  ⟨of_add_intCast m, fun h => h.add_intCast m⟩
+@[deprecated (since := "2025-04-01")] alias irrational_add_int_iff := irrational_add_intCast_iff
 
 @[simp]
-theorem irrational_add_nat_iff : Irrational (x + n) ↔ Irrational x :=
-  ⟨of_add_nat n, fun h => h.add_nat n⟩
+theorem irrational_add_natCast_iff : Irrational (x + n) ↔ Irrational x :=
+  ⟨of_add_natCast n, fun h => h.add_natCast n⟩
+@[deprecated (since := "2025-04-01")] alias irrational_add_nat_iff := irrational_add_natCast_iff
 
 @[simp]
-theorem irrational_rat_sub_iff : Irrational (q - x) ↔ Irrational x :=
+theorem irrational_ratCast_sub_iff : Irrational (q - x) ↔ Irrational x :=
   ⟨of_rat_sub q, rat_sub q⟩
+@[deprecated (since := "2025-04-01")] alias irrational_rat_sub_iff := irrational_ratCast_sub_iff
 
 @[simp]
-theorem irrational_int_sub_iff : Irrational (m - x) ↔ Irrational x :=
+theorem irrational_intCast_sub_iff : Irrational (m - x) ↔ Irrational x :=
   ⟨of_int_sub m, fun h => h.int_sub m⟩
+@[deprecated (since := "2025-04-01")] alias irrational_int_sub_iff := irrational_intCast_sub_iff
 
 @[simp]
-theorem irrational_nat_sub_iff : Irrational (n - x) ↔ Irrational x :=
+theorem irrational_natCast_sub_iff : Irrational (n - x) ↔ Irrational x :=
   ⟨of_nat_sub n, fun h => h.nat_sub n⟩
+@[deprecated (since := "2025-04-01")] alias irrational_nat_sub_iff := irrational_natCast_sub_iff
 
 @[simp]
-theorem irrational_sub_rat_iff : Irrational (x - q) ↔ Irrational x :=
+theorem irrational_sub_ratCast_iff : Irrational (x - q) ↔ Irrational x :=
   ⟨of_sub_rat q, sub_rat q⟩
+@[deprecated (since := "2025-04-01")] alias irrational_sub_rat_iff := irrational_sub_ratCast_iff
 
 @[simp]
-theorem irrational_sub_int_iff : Irrational (x - m) ↔ Irrational x :=
+theorem irrational_sub_intCast_iff : Irrational (x - m) ↔ Irrational x :=
   ⟨of_sub_int m, fun h => h.sub_int m⟩
+@[deprecated (since := "2025-04-01")] alias irrational_sub_int_iff := irrational_sub_intCast_iff
 
 @[simp]
-theorem irrational_sub_nat_iff : Irrational (x - n) ↔ Irrational x :=
+theorem irrational_sub_natCast_iff : Irrational (x - n) ↔ Irrational x :=
   ⟨of_sub_nat n, fun h => h.sub_nat n⟩
+@[deprecated (since := "2025-04-01")] alias irrational_sub_nat_iff := irrational_sub_natCast_iff
 
 @[simp]
 theorem irrational_neg_iff : Irrational (-x) ↔ Irrational x :=
@@ -528,57 +553,69 @@ theorem irrational_inv_iff : Irrational x⁻¹ ↔ Irrational x :=
   ⟨of_inv, Irrational.inv⟩
 
 @[simp]
-theorem irrational_rat_mul_iff : Irrational (q * x) ↔ q ≠ 0 ∧ Irrational x :=
+theorem irrational_ratCast_mul_iff : Irrational (q * x) ↔ q ≠ 0 ∧ Irrational x :=
   ⟨fun h => ⟨Rat.cast_ne_zero.1 <| left_ne_zero_of_mul h.ne_zero, h.of_rat_mul q⟩, fun h =>
     h.2.rat_mul h.1⟩
+@[deprecated (since := "2025-04-01")] alias irrational_rat_mul_iff := irrational_ratCast_mul_iff
 
 @[simp]
-theorem irrational_mul_rat_iff : Irrational (x * q) ↔ q ≠ 0 ∧ Irrational x := by
-  rw [mul_comm, irrational_rat_mul_iff]
+theorem irrational_mul_ratCast_iff : Irrational (x * q) ↔ q ≠ 0 ∧ Irrational x := by
+  rw [mul_comm, irrational_ratCast_mul_iff]
+@[deprecated (since := "2025-04-01")] alias irrational_mul_rat_iff := irrational_mul_ratCast_iff
 
 @[simp]
-theorem irrational_int_mul_iff : Irrational (m * x) ↔ m ≠ 0 ∧ Irrational x := by
-  rw [← cast_intCast, irrational_rat_mul_iff, Int.cast_ne_zero]
+theorem irrational_intCast_mul_iff : Irrational (m * x) ↔ m ≠ 0 ∧ Irrational x := by
+  rw [← cast_intCast, irrational_ratCast_mul_iff, Int.cast_ne_zero]
+@[deprecated (since := "2025-04-01")] alias irrational_int_mul_iff := irrational_intCast_mul_iff
 
 @[simp]
-theorem irrational_mul_int_iff : Irrational (x * m) ↔ m ≠ 0 ∧ Irrational x := by
-  rw [← cast_intCast, irrational_mul_rat_iff, Int.cast_ne_zero]
+theorem irrational_mul_intCast_iff : Irrational (x * m) ↔ m ≠ 0 ∧ Irrational x := by
+  rw [← cast_intCast, irrational_mul_ratCast_iff, Int.cast_ne_zero]
+@[deprecated (since := "2025-04-01")] alias irrational_mul_int_iff := irrational_mul_intCast_iff
 
 @[simp]
-theorem irrational_nat_mul_iff : Irrational (n * x) ↔ n ≠ 0 ∧ Irrational x := by
-  rw [← cast_natCast, irrational_rat_mul_iff, Nat.cast_ne_zero]
+theorem irrational_natCast_mul_iff : Irrational (n * x) ↔ n ≠ 0 ∧ Irrational x := by
+  rw [← cast_natCast, irrational_ratCast_mul_iff, Nat.cast_ne_zero]
+@[deprecated (since := "2025-04-01")] alias irrational_nat_mul_iff := irrational_natCast_mul_iff
 
 @[simp]
-theorem irrational_mul_nat_iff : Irrational (x * n) ↔ n ≠ 0 ∧ Irrational x := by
-  rw [← cast_natCast, irrational_mul_rat_iff, Nat.cast_ne_zero]
+theorem irrational_mul_natCast_iff : Irrational (x * n) ↔ n ≠ 0 ∧ Irrational x := by
+  rw [← cast_natCast, irrational_mul_ratCast_iff, Nat.cast_ne_zero]
+@[deprecated (since := "2025-04-01")] alias irrational_mul_nat_iff := irrational_mul_natCast_iff
 
 @[simp]
-theorem irrational_rat_div_iff : Irrational (q / x) ↔ q ≠ 0 ∧ Irrational x := by
+theorem irrational_ratCast_div_iff : Irrational (q / x) ↔ q ≠ 0 ∧ Irrational x := by
   simp [div_eq_mul_inv]
+@[deprecated (since := "2025-04-01")] alias irrational_rat_div_iff := irrational_ratCast_div_iff
 
 @[simp]
-theorem irrational_div_rat_iff : Irrational (x / q) ↔ q ≠ 0 ∧ Irrational x := by
-  rw [div_eq_mul_inv, ← cast_inv, irrational_mul_rat_iff, Ne, inv_eq_zero]
+theorem irrational_div_ratCast_iff : Irrational (x / q) ↔ q ≠ 0 ∧ Irrational x := by
+  rw [div_eq_mul_inv, ← cast_inv, irrational_mul_ratCast_iff, Ne, inv_eq_zero]
+@[deprecated (since := "2025-04-01")] alias irrational_div_rat_iff := irrational_div_ratCast_iff
 
 @[simp]
-theorem irrational_int_div_iff : Irrational (m / x) ↔ m ≠ 0 ∧ Irrational x := by
+theorem irrational_intCast_div_iff : Irrational (m / x) ↔ m ≠ 0 ∧ Irrational x := by
   simp [div_eq_mul_inv]
+@[deprecated (since := "2025-04-01")] alias irrational_int_div_iff := irrational_intCast_div_iff
 
 @[simp]
-theorem irrational_div_int_iff : Irrational (x / m) ↔ m ≠ 0 ∧ Irrational x := by
-  rw [← cast_intCast, irrational_div_rat_iff, Int.cast_ne_zero]
+theorem irrational_div_intCast_iff : Irrational (x / m) ↔ m ≠ 0 ∧ Irrational x := by
+  rw [← cast_intCast, irrational_div_ratCast_iff, Int.cast_ne_zero]
+@[deprecated (since := "2025-04-01")] alias irrational_div_int_iff := irrational_div_intCast_iff
 
 @[simp]
-theorem irrational_nat_div_iff : Irrational (n / x) ↔ n ≠ 0 ∧ Irrational x := by
+theorem irrational_natCast_div_iff : Irrational (n / x) ↔ n ≠ 0 ∧ Irrational x := by
   simp [div_eq_mul_inv]
+@[deprecated (since := "2025-04-01")] alias irrational_nat_div_iff := irrational_natCast_div_iff
 
 @[simp]
-theorem irrational_div_nat_iff : Irrational (x / n) ↔ n ≠ 0 ∧ Irrational x := by
-  rw [← cast_natCast, irrational_div_rat_iff, Nat.cast_ne_zero]
+theorem irrational_div_natCast_iff : Irrational (x / n) ↔ n ≠ 0 ∧ Irrational x := by
+  rw [← cast_natCast, irrational_div_ratCast_iff, Nat.cast_ne_zero]
+@[deprecated (since := "2025-04-01")] alias irrational_div_nat_iff := irrational_div_natCast_iff
 
 /-- There is an irrational number `r` between any two reals `x < r < y`. -/
 theorem exists_irrational_btwn {x y : ℝ} (h : x < y) : ∃ r, Irrational r ∧ x < r ∧ r < y :=
   let ⟨q, ⟨hq1, hq2⟩⟩ := exists_rat_btwn ((sub_lt_sub_iff_right (√2)).mpr h)
-  ⟨q + √2, irrational_sqrt_two.rat_add _, sub_lt_iff_lt_add.mp hq1, lt_sub_iff_add_lt.mp hq2⟩
+  ⟨q + √2, irrational_sqrt_two.ratCast_add _, sub_lt_iff_lt_add.mp hq1, lt_sub_iff_add_lt.mp hq2⟩
 
 end

--- a/Mathlib/Data/Real/Pi/Irrational.lean
+++ b/Mathlib/Data/Real/Pi/Irrational.lean
@@ -274,7 +274,7 @@ private lemma not_irrational_exists_rep {x : ℝ} :
   exact ⟨q.num, q.den, q.pos, by exact_mod_cast (Rat.num_div_den _).symm⟩
 
 @[simp] theorem irrational_pi : Irrational π := by
-  apply Irrational.of_div_nat 2
+  apply Irrational.of_div_natCast 2
   rw [Nat.cast_two]
   by_contra h'
   obtain ⟨a, b, hb, h⟩ := not_irrational_exists_rep h'

--- a/Mathlib/Dynamics/Circle/RotationNumber/TranslationNumber.lean
+++ b/Mathlib/Dynamics/Circle/RotationNumber/TranslationNumber.lean
@@ -408,12 +408,12 @@ theorem map_map_zero_le : f (g 0) ≤ f 0 + ⌈g 0⌉ :=
 theorem floor_map_map_zero_le : ⌊f (g 0)⌋ ≤ ⌊f 0⌋ + ⌈g 0⌉ :=
   calc
     ⌊f (g 0)⌋ ≤ ⌊f 0 + ⌈g 0⌉⌋ := floor_mono <| f.map_map_zero_le g
-    _ = ⌊f 0⌋ + ⌈g 0⌉ := floor_add_int _ _
+    _ = ⌊f 0⌋ + ⌈g 0⌉ := floor_add_intCast _ _
 
 theorem ceil_map_map_zero_le : ⌈f (g 0)⌉ ≤ ⌈f 0⌉ + ⌈g 0⌉ :=
   calc
     ⌈f (g 0)⌉ ≤ ⌈f 0 + ⌈g 0⌉⌉ := ceil_mono <| f.map_map_zero_le g
-    _ = ⌈f 0⌉ + ⌈g 0⌉ := ceil_add_int _ _
+    _ = ⌈f 0⌉ + ⌈g 0⌉ := ceil_add_intCast _ _
 
 theorem map_map_zero_lt : f (g 0) < f 0 + g 0 + 1 :=
   calc
@@ -431,12 +431,12 @@ theorem le_map_map_zero : f 0 + ⌊g 0⌋ ≤ f (g 0) :=
 
 theorem le_floor_map_map_zero : ⌊f 0⌋ + ⌊g 0⌋ ≤ ⌊f (g 0)⌋ :=
   calc
-    ⌊f 0⌋ + ⌊g 0⌋ = ⌊f 0 + ⌊g 0⌋⌋ := (floor_add_int _ _).symm
+    ⌊f 0⌋ + ⌊g 0⌋ = ⌊f 0 + ⌊g 0⌋⌋ := (floor_add_intCast _ _).symm
     _ ≤ ⌊f (g 0)⌋ := floor_mono <| f.le_map_map_zero g
 
 theorem le_ceil_map_map_zero : ⌈f 0⌉ + ⌊g 0⌋ ≤ ⌈(f * g) 0⌉ :=
   calc
-    ⌈f 0⌉ + ⌊g 0⌋ = ⌈f 0 + ⌊g 0⌋⌉ := (ceil_add_int _ _).symm
+    ⌈f 0⌉ + ⌊g 0⌋ = ⌈f 0 + ⌊g 0⌋⌉ := (ceil_add_intCast _ _).symm
     _ ≤ ⌈f (g 0)⌉ := ceil_mono <| f.le_map_map_zero g
 
 theorem lt_map_map_zero : f 0 + g 0 - 1 < f (g 0) :=

--- a/Mathlib/NumberTheory/Rayleigh.lean
+++ b/Mathlib/NumberTheory/Rayleigh.lean
@@ -166,7 +166,7 @@ theorem Irrational.beattySeq'_pos_eq {r : ℝ} (hr : Irrational r) :
   congr! 4; rename_i k; rw [and_congr_right_iff]; intro hk; congr!
   rw [sub_eq_iff_eq_add, Int.ceil_eq_iff, Int.cast_add, Int.cast_one, add_sub_cancel_right]
   refine ⟨(Int.floor_le _).lt_of_ne fun h ↦ ?_, (Int.lt_floor_add_one _).le⟩
-  exact (hr.int_mul hk.ne').ne_int ⌊k * r⌋ h.symm
+  exact (hr.intCast_mul hk.ne').ne_int ⌊k * r⌋ h.symm
 
 /-- **Rayleigh's theorem** on Beatty sequences. Let `r` be an irrational number greater than 1, and
 `1/r + 1/s = 1`. Then `B⁺_r` and `B⁺_s` partition the positive integers. -/

--- a/Mathlib/Topology/Instances/Irrational.lean
+++ b/Mathlib/Topology/Instances/Irrational.lean
@@ -58,10 +58,10 @@ instance : OrderTopology { x // Irrational x } :=
     ⟨⟨z, hz⟩, hxz, hzy⟩
 
 instance : NoMaxOrder { x // Irrational x } :=
-  ⟨fun ⟨x, hx⟩ => ⟨⟨x + (1 : ℕ), hx.add_nat 1⟩, by simp⟩⟩
+  ⟨fun ⟨x, hx⟩ => ⟨⟨x + (1 : ℕ), hx.add_natCast 1⟩, by simp⟩⟩
 
 instance : NoMinOrder { x // Irrational x } :=
-  ⟨fun ⟨x, hx⟩ => ⟨⟨x - (1 : ℕ), hx.sub_nat 1⟩, by simp⟩⟩
+  ⟨fun ⟨x, hx⟩ => ⟨⟨x - (1 : ℕ), hx.sub_natCast 1⟩, by simp⟩⟩
 
 instance : DenselyOrdered { x // Irrational x } :=
   ⟨fun _ _ hlt =>


### PR DESCRIPTION
This is not exhaustive, and only covers `Irrational` and `FloorRing`.

Every renamed lemma has been deprecated.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
