### PR TITLE
[Merged by Bors] - feat(RingTheory): Chevalley's theorem

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -5173,6 +5173,7 @@ import Mathlib.RingTheory.Spectrum.Maximal.Defs
 import Mathlib.RingTheory.Spectrum.Maximal.Localization
 import Mathlib.RingTheory.Spectrum.Maximal.Topology
 import Mathlib.RingTheory.Spectrum.Prime.Basic
+import Mathlib.RingTheory.Spectrum.Prime.Chevalley
 import Mathlib.RingTheory.Spectrum.Prime.ChevalleyComplexity
 import Mathlib.RingTheory.Spectrum.Prime.ConstructibleSet
 import Mathlib.RingTheory.Spectrum.Prime.Defs

--- a/Mathlib/RingTheory/FinitePresentation.lean
+++ b/Mathlib/RingTheory/FinitePresentation.lean
@@ -389,6 +389,7 @@ variable {A B C : Type*} [CommRing A] [CommRing B] [CommRing C]
 def FinitePresentation (f : A →+* B) : Prop :=
   @Algebra.FinitePresentation A B _ _ f.toAlgebra
 
+@[simp]
 lemma finitePresentation_algebraMap [Algebra A B] :
     (algebraMap A B).FinitePresentation ↔ Algebra.FinitePresentation A B := by
   delta RingHom.FinitePresentation

--- a/Mathlib/RingTheory/FinitePresentation.lean
+++ b/Mathlib/RingTheory/FinitePresentation.lean
@@ -389,6 +389,12 @@ variable {A B C : Type*} [CommRing A] [CommRing B] [CommRing C]
 def FinitePresentation (f : A →+* B) : Prop :=
   @Algebra.FinitePresentation A B _ _ f.toAlgebra
 
+lemma finitePresentation_algebraMap [Algebra A B] :
+    (algebraMap A B).FinitePresentation ↔ Algebra.FinitePresentation A B := by
+  delta RingHom.FinitePresentation
+  congr!
+  exact Algebra.algebra_ext _ _ fun _ ↦ rfl
+
 namespace FiniteType
 
 theorem of_finitePresentation {f : A →+* B} (hf : f.FinitePresentation) : f.FiniteType :=

--- a/Mathlib/RingTheory/Spectrum/Prime/Chevalley.lean
+++ b/Mathlib/RingTheory/Spectrum/Prime/Chevalley.lean
@@ -10,7 +10,7 @@ import Mathlib.RingTheory.Spectrum.Prime.ChevalleyComplexity
 # Chevalley's theorem
 
 In this file we provide the usual (algebraic) version of Chevalley's theorem.
-For the proof see `Mathlib/RingTheory/Spectrum/Prime/ChevalleyComplex.lean`.
+For the proof see `Mathlib/RingTheory/Spectrum/Prime/ChevalleyComplexity.lean`.
 -/
 
 variable {R S : Type*} [CommRing R] [CommRing S]
@@ -41,7 +41,7 @@ lemma isConstructible_comap_image
   · intros R _ S _ f hf hf' s hs
     refine hs.image_of_isClosedEmbedding (isClosedEmbedding_comap_of_surjective _ f hf) ?_
     rw [range_comap_of_surjective _ f hf]
-    exact isRetrocompact_zeroLocus_compl_of_fg _ hf'
+    exact isRetrocompact_zeroLocus_compl_of_fg hf'
   · intros R _ S _ T _ f g H₁ H₂ s hs
     simp only [comap_comp, ContinuousMap.coe_comp, Set.image_comp]
     exact H₁ _ (H₂ _ hs)
@@ -60,6 +60,6 @@ lemma isOpenMap_comap_of_hasGoingDown_of_finitePresentation
     ((basicOpen f).2.stableUnderGeneralization.image
       (Algebra.HasGoingDown.iff_generalizingMap_primeSpectrumComap.mp ‹_›))
     (isConstructible_comap_image (RingHom.finitePresentation_algebraMap.mpr ‹_›)
-      (isConstructible_basicOpen _))
+      isConstructible_basicOpen)
 
 end PrimeSpectrum

--- a/Mathlib/RingTheory/Spectrum/Prime/Chevalley.lean
+++ b/Mathlib/RingTheory/Spectrum/Prime/Chevalley.lean
@@ -59,7 +59,7 @@ lemma isOpenMap_comap_of_hasGoingDown_of_finitePresentation
   exact isOpen_of_stableUnderGeneralization_of_isConstructible
     ((basicOpen f).2.stableUnderGeneralization.image
       (Algebra.HasGoingDown.iff_generalizingMap_primeSpectrumComap.mp ‹_›))
-    (isConstructible_comap_image (finitePresentation_algebraMap.mpr ‹_›)
+    (isConstructible_comap_image (RingHom.finitePresentation_algebraMap.mpr ‹_›)
       (isConstructible_basicOpen _))
 
 end PrimeSpectrum

--- a/Mathlib/RingTheory/Spectrum/Prime/Chevalley.lean
+++ b/Mathlib/RingTheory/Spectrum/Prime/Chevalley.lean
@@ -1,0 +1,65 @@
+/-
+Copyright (c) 2025 Andrew Yang. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Andrew Yang
+-/
+import Mathlib.RingTheory.Ideal.GoingDown
+import Mathlib.RingTheory.Spectrum.Prime.ChevalleyComplexity
+
+/-!
+# Chevalley's theorem
+
+In this file we provide the usual (algebraic) version of Chevalley's theorem.
+For the proof see `Mathlib/RingTheory/Spectrum/Prime/ChevalleyComplex.lean`.
+-/
+
+variable {R S : Type*} [CommRing R] [CommRing S]
+
+open Function Localization MvPolynomial Polynomial TensorProduct PrimeSpectrum Topology
+open scoped Pointwise
+
+namespace PrimeSpectrum
+
+lemma isConstructible_comap_C
+    {s : Set (PrimeSpectrum (Polynomial R))} (hs : IsConstructible s) :
+    IsConstructible (comap Polynomial.C '' s) := by
+  obtain ⟨S, rfl⟩ := exists_constructibleSetData_iff.mpr hs
+  obtain ⟨T, hT, -⟩ := ChevalleyThm.chevalley_polynomialC _ Submodule.mem_top S (by simp)
+  rw [hT]
+  exact T.isConstructible_toSet
+
+/-- **Chevalley's theorem**: If `f` is of finite presentation,
+then the image of a constructible set under `Spec(f)` is constructible. -/
+lemma isConstructible_comap_image
+    {f : R →+* S} (hf : f.FinitePresentation)
+    {s : Set (PrimeSpectrum S)} (hs : IsConstructible s) :
+    IsConstructible (comap f '' s) := by
+  refine hf.polynomial_induction
+    (fun _ _ _ _ f ↦ ∀ s, IsConstructible s → IsConstructible (comap f '' s))
+    (fun _ _ _ _ f ↦ ∀ s, IsConstructible s → IsConstructible (comap f '' s))
+    (fun _ _ _ ↦ isConstructible_comap_C) ?_ ?_ f s hs
+  · intros R _ S _ f hf hf' s hs
+    refine hs.image_of_isClosedEmbedding (isClosedEmbedding_comap_of_surjective _ f hf) ?_
+    rw [range_comap_of_surjective _ f hf]
+    exact isRetrocompact_zeroLocus_compl_of_fg _ hf'
+  · intros R _ S _ T _ f g H₁ H₂ s hs
+    simp only [comap_comp, ContinuousMap.coe_comp, Set.image_comp]
+    exact H₁ _ (H₂ _ hs)
+
+lemma isConstructible_range_comap {f : R →+* S} (hf : f.FinitePresentation) :
+    IsConstructible (Set.range <| comap f) :=
+  Set.image_univ ▸ isConstructible_comap_image hf .univ
+
+@[stacks 00I1]
+lemma isOpenMap_comap_of_hasGoingDown_of_finitePresentation
+    [Algebra R S] [Algebra.HasGoingDown R S] [Algebra.FinitePresentation R S] :
+    IsOpenMap (comap (algebraMap R S)) := by
+  rw [isBasis_basic_opens.isOpenMap_iff]
+  rintro _ ⟨_, ⟨f, rfl⟩, rfl⟩
+  exact isOpen_of_stableUnderGeneralization_of_isConstructible
+    ((basicOpen f).2.stableUnderGeneralization.image
+      (Algebra.HasGoingDown.iff_generalizingMap_primeSpectrumComap.mp ‹_›))
+    (isConstructible_comap_image (finitePresentation_algebraMap.mpr ‹_›)
+      (isConstructible_basicOpen _))
+
+end PrimeSpectrum

--- a/Mathlib/RingTheory/Spectrum/Prime/ChevalleyComplexity.lean
+++ b/Mathlib/RingTheory/Spectrum/Prime/ChevalleyComplexity.lean
@@ -12,6 +12,8 @@ import Mathlib.RingTheory.Spectrum.Prime.Polynomial
 /-!
 # Chevalley's theorem with complexity bound
 
+⚠ For general usage, see `Mathlib/RingTheory/Spectrum/Prime/Chevalley.lean`.
+
 Chevalley's theorem states that if `f : R → S` is a finitely presented ring hom between commutative
 rings, then the image of a constructible set in `Spec S` is a constructible set in `Spec R`.
 
@@ -54,9 +56,6 @@ two maps `C : R[Y₁, ..., Yₙ] → R[X₁, ..., Xₘ, Y₁, ..., Yₙ]` and
 The structure of the proof follows https://stacks.math.columbia.edu/tag/00FE, although they do
 not give an explicit bound on the complexity.
 
-## TODO
-
-More general complexity-less version of Chevalley's theorem. This will be PRed soon.
 -/
 
 variable {R₀ R S M A : Type*} [CommRing R₀] [CommRing R] [Algebra R₀ R] [CommRing S] [Algebra R₀ S]

--- a/Mathlib/RingTheory/Spectrum/Prime/ConstructibleSet.lean
+++ b/Mathlib/RingTheory/Spectrum/Prime/ConstructibleSet.lean
@@ -101,12 +101,12 @@ def degBound (S : ConstructibleSetData R[X]) : ℕ := S.sup fun C ↦ ∑ i, (C.
 
 lemma isConstructible_toSet (S : ConstructibleSetData R) :
     IsConstructible S.toSet := by
-  refine IsConstructible.biUnion S.finite_toSet fun _ _ ↦ .sdiff ?_ ?_
+  refine .biUnion S.finite_toSet fun _ _ ↦ .sdiff ?_ ?_
   · rw [← isConstructible_compl]
-    exact (isRetrocompact_zeroLocus_compl _ (Set.finite_range _)).isConstructible
+    exact (isRetrocompact_zeroLocus_compl (Set.finite_range _)).isConstructible
       (isClosed_zeroLocus _).isOpen_compl
   · rw [← isConstructible_compl]
-    exact (isRetrocompact_zeroLocus_compl _ (Set.finite_singleton _)).isConstructible
+    exact (isRetrocompact_zeroLocus_compl (Set.finite_singleton _)).isConstructible
       (isClosed_zeroLocus _).isOpen_compl
 
 end ConstructibleSetData

--- a/Mathlib/RingTheory/Spectrum/Prime/Topology.lean
+++ b/Mathlib/RingTheory/Spectrum/Prime/Topology.lean
@@ -602,11 +602,6 @@ instance : QuasiSeparatedSpace (PrimeSpectrum R) :=
     simpa [← TopologicalSpace.Opens.coe_inf, ← basicOpen_mul, -basicOpen_eq_zeroLocus_compl]
       using isCompact_basicOpen _
 
--- TODO: Abstract out this lemma to spectral spaces
-lemma isRetrocompact_iff {U : Set (PrimeSpectrum R)} (hU : IsOpen U) :
-    IsRetrocompact U ↔ IsCompact U :=
-  isTopologicalBasis_basic_opens.isRetrocompact_iff_isCompact isCompact_basicOpen hU
-
 end BasicOpen
 
 section DiscreteTopology
@@ -891,6 +886,29 @@ lemma exists_idempotent_basicOpen_eq_of_isClopen {s : Set (PrimeSpectrum R)}
 @[deprecated (since := "2024-11-11")]
 alias exists_idempotent_basicOpen_eq_of_is_clopen := exists_idempotent_basicOpen_eq_of_isClopen
 
+-- TODO: Abstract out this lemma to spectral spaces
+lemma isRetrocompact_iff {U : Set (PrimeSpectrum R)} (hU : IsOpen U) :
+    IsRetrocompact U ↔ IsCompact U :=
+  isTopologicalBasis_basic_opens.isRetrocompact_iff_isCompact isCompact_basicOpen hU
+
+lemma isRetrocompact_zeroLocus_compl (s : Set R) (hs : s.Finite) :
+    IsRetrocompact (zeroLocus s)ᶜ :=
+  (isRetrocompact_iff (isClosed_zeroLocus _).isOpen_compl).mpr
+    (isCompact_isOpen_iff.mpr ⟨hs.toFinset, by simp⟩).1
+
+lemma isRetrocompact_zeroLocus_compl_of_fg (I : Ideal R) (hI : I.FG) :
+    IsRetrocompact (zeroLocus (I : Set R))ᶜ := by
+  obtain ⟨s, rfl⟩ := hI
+  rw [zeroLocus_span]
+  exact isRetrocompact_zeroLocus_compl _ s.finite_toSet
+
+lemma isRetrocompact_basicOpen (f : R) :
+    IsRetrocompact (basicOpen f : Set (PrimeSpectrum R)) := by
+  simpa using isRetrocompact_zeroLocus_compl _ (Set.finite_singleton f)
+
+lemma isConstructible_basicOpen (f : R) :
+    IsConstructible (basicOpen f : Set (PrimeSpectrum R)) :=
+  (isRetrocompact_basicOpen f).isConstructible (basicOpen f).2
 section IsIntegral
 
 open Polynomial

--- a/Mathlib/RingTheory/Spectrum/Prime/Topology.lean
+++ b/Mathlib/RingTheory/Spectrum/Prime/Topology.lean
@@ -891,24 +891,24 @@ lemma isRetrocompact_iff {U : Set (PrimeSpectrum R)} (hU : IsOpen U) :
     IsRetrocompact U ↔ IsCompact U :=
   isTopologicalBasis_basic_opens.isRetrocompact_iff_isCompact isCompact_basicOpen hU
 
-lemma isRetrocompact_zeroLocus_compl (s : Set R) (hs : s.Finite) :
+lemma isRetrocompact_zeroLocus_compl {s : Set R} (hs : s.Finite) :
     IsRetrocompact (zeroLocus s)ᶜ :=
   (isRetrocompact_iff (isClosed_zeroLocus _).isOpen_compl).mpr
     (isCompact_isOpen_iff.mpr ⟨hs.toFinset, by simp⟩).1
 
-lemma isRetrocompact_zeroLocus_compl_of_fg (I : Ideal R) (hI : I.FG) :
+lemma isRetrocompact_zeroLocus_compl_of_fg {I : Ideal R} (hI : I.FG) :
     IsRetrocompact (zeroLocus (I : Set R))ᶜ := by
   obtain ⟨s, rfl⟩ := hI
   rw [zeroLocus_span]
-  exact isRetrocompact_zeroLocus_compl _ s.finite_toSet
+  exact isRetrocompact_zeroLocus_compl s.finite_toSet
 
-lemma isRetrocompact_basicOpen (f : R) :
+lemma isRetrocompact_basicOpen {f : R} :
     IsRetrocompact (basicOpen f : Set (PrimeSpectrum R)) := by
-  simpa using isRetrocompact_zeroLocus_compl _ (Set.finite_singleton f)
+  simpa using isRetrocompact_zeroLocus_compl (Set.finite_singleton f)
 
-lemma isConstructible_basicOpen (f : R) :
+lemma isConstructible_basicOpen {f : R} :
     IsConstructible (basicOpen f : Set (PrimeSpectrum R)) :=
-  (isRetrocompact_basicOpen f).isConstructible (basicOpen f).2
+  isRetrocompact_basicOpen.isConstructible (basicOpen f).2
 
 section IsIntegral
 

--- a/Mathlib/RingTheory/Spectrum/Prime/Topology.lean
+++ b/Mathlib/RingTheory/Spectrum/Prime/Topology.lean
@@ -909,6 +909,7 @@ lemma isRetrocompact_basicOpen (f : R) :
 lemma isConstructible_basicOpen (f : R) :
     IsConstructible (basicOpen f : Set (PrimeSpectrum R)) :=
   (isRetrocompact_basicOpen f).isConstructible (basicOpen f).2
+
 section IsIntegral
 
 open Polynomial


### PR DESCRIPTION
Also shows that flat ring homomorphisms of finite presentation are open maps on the prime spectrum

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
