### PR TITLE
[Merged by Bors] - feat(Padics/MahlerBasis): extend Mahler's theorem to Zp-modules

### DIFF
--- a/Mathlib/NumberTheory/Padics/MahlerBasis.lean
+++ b/Mathlib/NumberTheory/Padics/MahlerBasis.lean
@@ -16,10 +16,10 @@ import Mathlib.Topology.MetricSpace.Ultra.ContinuousMaps
 # The Mahler basis of continuous functions
 
 In this file we introduce the Mahler basis function `mahler k`, for `k : ℕ`, which is the unique
-continuous map `ℤ_[p] → ℚ_[p]` agreeing with `n ↦ n.choose k` for `n ∈ ℕ`.
+continuous map `ℤ_[p] → ℤ_[p]` agreeing with `n ↦ n.choose k` for `n ∈ ℕ`.
 
 Using this, we prove Mahler's theorem, showing that for any any continuous function `f` on `ℤ_[p]`
-(valued in a `p`-adic normed space `E`), the Mahler series `x ↦ ∑' k, mahler k x • Δ^[n] f 0`
+(valued in a normed `ℤ_[p]`-module `E`), the Mahler series `x ↦ ∑' k, mahler k x • Δ^[n] f 0`
 converges (uniformly) to `f`, and this construction defines a Banach-space isomorphism between
 `C(ℤ_[p], E)` and the space of sequences `ℕ → E` tending to 0.
 
@@ -90,29 +90,17 @@ lemma continuous_choose (k : ℕ) : Continuous (fun x : ℤ_[p] ↦ Ring.choose 
 end PadicInt
 
 /--
-The `k`-th Mahler basis function, i.e. the unique continuous function `ℤ_[p] → ℚ_[p]`
+The `k`-th Mahler basis function, i.e. the unique continuous function `ℤ_[p] → ℤ_[p]`
 agreeing with `n ↦ n.choose k` for `n ∈ ℕ`. See [colmez2010], §1.2.1.
 -/
-noncomputable def mahler (k : ℕ) : C(ℤ_[p], ℚ_[p]) where
-  toFun x := ↑(Ring.choose x k)
-  continuous_toFun := continuous_induced_rng.mp (PadicInt.continuous_choose k)
+noncomputable def mahler (k : ℕ) : C(ℤ_[p], ℤ_[p]) where
+  continuous_toFun := PadicInt.continuous_choose k
 
 lemma mahler_apply (k : ℕ) (x : ℤ_[p]) : mahler k x = Ring.choose x k := rfl
 
 /-- The function `mahler k` extends `n ↦ n.choose k` on `ℕ`. -/
 lemma mahler_natCast_eq (k n : ℕ) : mahler k (n : ℤ_[p]) = n.choose k := by
   simp only [mahler_apply, Ring.choose_natCast, PadicInt.coe_natCast]
-
-/--
-The uniform norm of the `k`-th Mahler basis function is 1, for every `k`.
--/
-@[simp] lemma norm_mahler_eq (k : ℕ) : ‖(mahler k : C(ℤ_[p], ℚ_[p]))‖ = 1 := by
-  apply le_antisymm
-  · -- Show all values have norm ≤ 1
-    exact (mahler k).norm_le_of_nonempty.mpr (fun _ ↦ PadicInt.norm_le_one _)
-  · -- Show norm 1 is attained at `x = k`
-    refine (le_of_eq ?_).trans ((mahler k).norm_coe_le_norm k)
-    rw [mahler_natCast_eq, Nat.choose_self, Nat.cast_one, norm_one]
 
 section fwdDiff
 
@@ -155,7 +143,7 @@ namespace PadicInt
 section norm_fwdDiff
 
 variable {p : ℕ} [hp : Fact p.Prime] {E : Type*}
-  [NormedAddCommGroup E] [NormedSpace ℚ_[p] E] [IsUltrametricDist E]
+  [NormedAddCommGroup E] [Module ℤ_[p] E] [IsBoundedSMul ℤ_[p] E] [IsUltrametricDist E]
 
 /--
 Second step in Bojanić's proof of Mahler's theorem (equation (11) of [bojanic74]): show that values
@@ -176,21 +164,23 @@ private lemma bojanic_mahler_step2 {f : C(ℤ_[p], E)} {s t : ℕ}
     -- a binomial coefficient which is divisible by `p`
     rw [norm_neg, ← coe_nnnorm, coe_le_coe]
     refine nnnorm_sum_le_of_forall_le (fun i hi ↦ Finset.le_sup_of_le hi ?_)
-    rw [mem_range] at hi
-    rw [← Nat.cast_smul_eq_nsmul ℚ_[p], nnnorm_smul, div_eq_inv_mul]
-    refine mul_le_mul_of_nonneg_right ?_ (by simp only [zero_le])
+    rw [← Nat.cast_smul_eq_nsmul ℤ_[p], div_eq_inv_mul]
+    refine (nnnorm_smul_le _ _).trans <| mul_le_mul_of_nonneg_right ?_ (by simp only [zero_le])
     -- remains to show norm of binomial coeff is `≤ p⁻¹`
+    rw [mem_range] at hi
     have : 0 < (p ^ t).choose (i + 1) := Nat.choose_pos (by omega)
-    rw [← zpow_neg_one, ← coe_le_coe, coe_nnnorm, Padic.norm_eq_zpow_neg_valuation
+    rw [← zpow_neg_one, ← coe_le_coe, coe_nnnorm, PadicInt.norm_eq_zpow_neg_valuation
       (mod_cast this.ne'), coe_zpow, NNReal.coe_natCast,
-      zpow_le_zpow_iff_right₀ (mod_cast hp.out.one_lt), neg_le_neg_iff, Padic.valuation_natCast,
-      Nat.one_le_cast]
+      zpow_le_zpow_iff_right₀ (mod_cast hp.out.one_lt), neg_le_neg_iff,
+      ← PadicInt.valuation_coe, PadicInt.coe_natCast, Padic.valuation_natCast, Nat.one_le_cast]
     exact one_le_padicValNat_of_dvd this <| hp.out.dvd_choose_pow (by omega) (by omega)
   · -- Bounding the sum over `range (n + 1)`: every term is small by the choice of `t`
     refine norm_sum_le_of_forall_le_of_nonempty nonempty_range_succ (fun i _ ↦ ?_)
     calc ‖((-1 : ℤ) ^ (n - i) * n.choose i) • (f (i + ↑(p ^ t)) - f i)‖
+    _ ≤ ‖((-1 : ℤ) ^ (n - i) * n.choose i : ℤ_[p])‖ * ‖(f (i + ↑(p ^ t)) - f i)‖ := by
+      rw [← Int.cast_smul_eq_zsmul ℤ_[p]]
+      exact (norm_smul_le ..).trans (by norm_cast)
     _ ≤ ‖f (i + ↑(p ^ t)) - f i‖ := by
-      rw [← Int.cast_smul_eq_zsmul ℚ_[p], norm_smul]
       apply mul_le_of_le_one_left (norm_nonneg _)
       simpa only [← coe_intCast] using norm_le_one _
     _ ≤ ‖f‖ / p ^ s := by
@@ -246,20 +236,37 @@ end norm_fwdDiff
 
 section mahler_coeff
 
-variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℚ_[p] E]
+variable {E : Type*} [NormedAddCommGroup E] [Module ℤ_[p] E] [IsBoundedSMul ℤ_[p] E]
   (a : E) (n : ℕ) (x : ℤ_[p])
 
 /--
 A single term of a Mahler series, given by the product of the scalar-valued continuous map
-`mahler n : ℤ_[p] → ℚ_[p]` with a constant vector in some normed `ℚ_[p]`-vector space.
+`mahler n : ℤ_[p] → ℤ_[p]` with a constant vector in some normed `ℤ_[p]`-module.
 -/
-noncomputable def mahlerTerm : C(ℤ_[p], E) := (mahler n : C(_, ℚ_[p])) • .const _ a
+noncomputable def mahlerTerm : C(ℤ_[p], E) := (mahler n : C(_, ℤ_[p])) • .const _ a
 
 lemma mahlerTerm_apply : mahlerTerm a n x = mahler n x • a := by
   simp only [mahlerTerm, ContinuousMap.smul_apply', ContinuousMap.const_apply]
 
+@[simp]
 lemma norm_mahlerTerm : ‖(mahlerTerm a n : C(ℤ_[p], E))‖ = ‖a‖ := by
-  simp only [mahlerTerm, ContinuousMap.norm_smul_const, norm_mahler_eq, one_mul]
+  apply le_antisymm
+  · -- Show all values have norm ≤ 1
+    rw [ContinuousMap.norm_le_of_nonempty]
+    refine fun _ ↦ (norm_smul_le _ _).trans <| mul_le_of_le_one_left (norm_nonneg _) (norm_le_one _)
+  · -- Show norm 1 is attained at `x = k`
+    refine le_trans ?_ <| (mahlerTerm a n).norm_coe_le_norm n
+    simp [mahlerTerm_apply, mahler_natCast_eq]
+
+@[simp]
+lemma mahlerTerm_one : (mahlerTerm 1 n : C(ℤ_[p], ℤ_[p])) = mahler n := by
+  ext; simp [mahlerTerm_apply]
+
+/--
+The uniform norm of the `k`-th Mahler basis function is 1, for every `k`.
+-/
+@[simp] lemma norm_mahler_eq (k : ℕ) : ‖(mahler k : C(ℤ_[p], ℤ_[p]))‖ = 1 := by
+  simp [← mahlerTerm_one]
 
 /-- A series of the form considered in Mahler's theorem. -/
 noncomputable def mahlerSeries (a : ℕ → E) : C(ℤ_[p], E) := ∑' n, mahlerTerm (a n) n
@@ -317,13 +324,6 @@ lemma fwdDiff_mahlerSeries (ha : Tendsto a atTop (𝓝 0)) (n) :
     simp only [fwdDiff_iter_choose_zero, ite_smul, one_smul, zero_smul, sum_ite_eq,
       Finset.mem_range, lt_add_iff_pos_right, zero_lt_one, ↓reduceIte]
 
-end mahler_coeff
-
-section mahler_coeff
-
-variable {p : ℕ} [hp : Fact p.Prime] {E : Type*}
-  [NormedAddCommGroup E] [NormedSpace ℚ_[p] E] [IsUltrametricDist E] [CompleteSpace E]
-
 /--
 **Mahler's theorem**: for any continuous function `f` from `ℤ_[p]` to a `p`-adic Banach space, the
 Mahler series with coefficients `n ↦ Δ_[1]^[n] f 0` converges to the original function `f`.
@@ -332,20 +332,20 @@ lemma hasSum_mahler (f : C(ℤ_[p], E)) : HasSum (fun n ↦ mahlerTerm (Δ_[1]^[
   -- First show `∑' n, mahlerTerm f n` converges to *something*.
   have : HasSum (fun n ↦ mahlerTerm (Δ_[1]^[n] f 0) n)
       (mahlerSeries (Δ_[1]^[·] f 0) : C(ℤ_[p], E)) :=
-    hasSum_mahlerSeries (PadicInt.fwdDiff_tendsto_zero f)
+    hasSum_mahlerSeries (fwdDiff_tendsto_zero f)
   -- Now show that the sum of the Mahler terms must equal `f` on a dense set, so it is actually `f`.
   convert this using 1
-  refine ContinuousMap.coe_injective (PadicInt.denseRange_natCast.equalizer
+  refine ContinuousMap.coe_injective (denseRange_natCast.equalizer
     (map_continuous f) (map_continuous _) (funext fun n ↦ ?_))
-  simpa only [Function.comp_apply, mahlerSeries_apply_nat (fwdDiff_tendsto_zero f) le_rfl,
-    zero_add, sum_apply, Pi.smul_apply, nsmul_one] using (shift_eq_sum_fwdDiff_iter 1 f n 0)
+  simpa [mahlerSeries_apply_nat (fwdDiff_tendsto_zero f) le_rfl]
+    using shift_eq_sum_fwdDiff_iter 1 f n 0
 
 variable (E) in
 /--
 The isometric equivalence from `C(ℤ_[p], E)` to the space of sequences in `E` tending to `0` given
 by Mahler's theorem, for `E` a nonarchimedean `ℚ_[p]`-Banach space.
 -/
-noncomputable def mahlerEquiv : C(ℤ_[p], E) ≃ₗᵢ[ℚ_[p]] C₀(ℕ, E) where
+noncomputable def mahlerEquiv : C(ℤ_[p], E) ≃ₗᵢ[ℤ_[p]] C₀(ℕ, E) where
   toFun f := ⟨⟨(Δ_[1]^[·] f 0), continuous_of_discreteTopology⟩,
     cocompact_eq_atTop (α := ℕ) ▸ fwdDiff_tendsto_zero f⟩
   invFun a := mahlerSeries a


### PR DESCRIPTION
Generalize Mahler's theorem to continuous functions taking values in an arbitrary normed Zp-module (not necessarily a Qp-Banach space)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
