### PR TITLE
feat: `Filter.atMax` and `Filter.atMin`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4489,6 +4489,7 @@ import Mathlib.Order.Disjointed
 import Mathlib.Order.Estimator
 import Mathlib.Order.Extension.Linear
 import Mathlib.Order.Extension.Well
+import Mathlib.Order.Filter.AtMaxMin
 import Mathlib.Order.Filter.AtTopBot.Archimedean
 import Mathlib.Order.Filter.AtTopBot.Basic
 import Mathlib.Order.Filter.AtTopBot.BigOperators

--- a/Mathlib/Order/Filter/AtMaxMin.lean
+++ b/Mathlib/Order/Filter/AtMaxMin.lean
@@ -106,4 +106,36 @@ theorem atMin_eq_atBot [Preorder α] [IsDirected α (· ≥ ·)] : (atMin : Filt
   obtain ⟨z, hzx, hzy⟩ := exists_le_le x y
   exact ⟨z, hzx, fun u huz => hy u (huz.trans hzy)⟩
 
+theorem pure_le_atMax [Preorder α] (x : α) : pure x ≤ atMax ↔ IsMax x := by
+  constructor
+  · intro h
+    by_contra hx
+    rw [not_isMax_iff] at hx
+    obtain ⟨y, hxy⟩ := hx
+    suffices hy : (Iio y)ᶜ ∈ atMax from h hy hxy
+    intro z
+    by_cases hzy : z ≤ y
+    · exact ⟨y, hzy, fun u hyu huy => huy.not_le hyu⟩
+    · exact ⟨z, le_rfl, fun u hzu huy => hzy (hzu.trans huy.le)⟩
+  · intro hx s hs
+    rw [mem_atMax] at hs
+    obtain ⟨y, hxy, hy⟩ := hs x
+    exact hy (hx hxy)
+
+theorem pure_le_atMin [Preorder α] (x : α) : pure x ≤ atMin ↔ IsMin x := by
+  constructor
+  · intro h
+    by_contra hx
+    rw [not_isMin_iff] at hx
+    obtain ⟨y, hxy⟩ := hx
+    suffices hy : (Ioi y)ᶜ ∈ atMin from h hy hxy
+    intro z
+    by_cases hyz : y ≤ z
+    · exact ⟨y, hyz, fun u huy hyu => hyu.not_le huy⟩
+    · exact ⟨z, le_rfl, fun u huz hyu => hyz (hyu.le.trans huz)⟩
+  · intro hx s hs
+    rw [mem_atMin] at hs
+    obtain ⟨y, hyx, hy⟩ := hs x
+    exact hy (hx hyx)
+
 end Filter

--- a/Mathlib/Order/Filter/AtMaxMin.lean
+++ b/Mathlib/Order/Filter/AtMaxMin.lean
@@ -18,8 +18,12 @@ open Set
 namespace Filter
 
 /--
-`atMax` is the filter representing the limit `→ ∞` on an ordered set,
-and contains all maximal elements.
+`atMax` is the filter representing the limit `→ ∞` on an ordered set.
+It contains all maximal elements.
+
+While `atTop` and `atMax` both denote a limit at `∞`,
+`atTop` captures the idea of a process which increases past every element while
+`atMax` captures the idea of a process which increases as much as possible.
 -/
 def atMax [Preorder α] : Filter α where
   sets := {s | ∀ x, ∃ y ≥ x, Ici y ⊆ s}
@@ -35,8 +39,12 @@ def atMax [Preorder α] : Filter α where
     exact ⟨z, hxy.trans hyz, subset_inter ((Ici_subset_Ici.mpr hyz).trans hy) hz⟩
 
 /--
-`atMin` is the filter representing the limit `→ -∞` on an ordered set,
-and contains all minimal elements.
+`atMin` is the filter representing the limit `→ -∞` on an ordered set
+It contains all minimal elements.
+
+While `atBot` and `atMin` both denote a limit at `-∞`,
+`atBot` captures the idea of a process which decends past every element while
+`atMin` captures the idea of a process which decreases as much as possible.
 -/
 def atMin [Preorder α] : Filter α where
   sets := {s | ∀ x, ∃ y ≤ x, Iic y ⊆ s}

--- a/Mathlib/Order/Filter/AtMaxMin.lean
+++ b/Mathlib/Order/Filter/AtMaxMin.lean
@@ -62,7 +62,11 @@ def atMin [Preorder α] : Filter α where
 theorem mem_atMax [Preorder α] (s : Set α) : s ∈ atMax ↔ ∀ x, ∃ y ≥ x, Ici y ⊆ s := Iff.rfl
 theorem mem_atMin [Preorder α] (s : Set α) : s ∈ atMin ↔ ∀ x, ∃ y ≤ x, Iic y ⊆ s := Iff.rfl
 
-instance [Preorder α] [Nonempty α] : NeBot (atMax : Filter α) where
+
+section Preorder
+variable [Preorder α] (x : α)
+
+instance [Nonempty α] : NeBot (atMax : Filter α) where
   ne' := by
     intro h
     rw [← empty_mem_iff_bot, mem_atMax] at h
@@ -70,7 +74,7 @@ instance [Preorder α] [Nonempty α] : NeBot (atMax : Filter α) where
     obtain ⟨y, _, hy⟩ := h x
     exact hy le_rfl
 
-instance [Preorder α] [Nonempty α] : NeBot (atMin : Filter α) where
+instance [Nonempty α] : NeBot (atMin : Filter α) where
   ne' := by
     intro h
     rw [← empty_mem_iff_bot, mem_atMin] at h
@@ -78,7 +82,7 @@ instance [Preorder α] [Nonempty α] : NeBot (atMin : Filter α) where
     obtain ⟨y, _, hy⟩ := h x
     exact hy le_rfl
 
-theorem atTop_le_atMax [Preorder α] : (atTop : Filter α) ≤ atMax := by
+theorem atTop_le_atMax : (atTop : Filter α) ≤ atMax := by
   intro s hs
   obtain h | ⟨⟨x⟩⟩ := isEmpty_or_nonempty α
   · rw [atTop.filter_eq_bot_of_isEmpty]
@@ -87,7 +91,7 @@ theorem atTop_le_atMax [Preorder α] : (atTop : Filter α) ≤ atMax := by
     obtain ⟨y, _, hy⟩ := hs x
     filter_upwards [Ici_mem_atTop y] using hy
 
-theorem atBot_le_atMin [Preorder α] : (atBot : Filter α) ≤ atMin := by
+theorem atBot_le_atMin : (atBot : Filter α) ≤ atMin := by
   intro s hs
   obtain h | ⟨⟨x⟩⟩ := isEmpty_or_nonempty α
   · rw [atBot.filter_eq_bot_of_isEmpty]
@@ -96,7 +100,7 @@ theorem atBot_le_atMin [Preorder α] : (atBot : Filter α) ≤ atMin := by
     obtain ⟨y, _, hy⟩ := hs x
     filter_upwards [Iic_mem_atBot y] using hy
 
-theorem atMax_eq_atTop [Preorder α] [IsDirected α (· ≤ ·)] : (atMax : Filter α) = atTop := by
+theorem atMax_eq_atTop [IsDirected α (· ≤ ·)] : (atMax : Filter α) = atTop := by
   apply atTop_le_atMax.antisymm'
   intro s hs x
   have : Nonempty α := ⟨x⟩
@@ -105,7 +109,7 @@ theorem atMax_eq_atTop [Preorder α] [IsDirected α (· ≤ ·)] : (atMax : Filt
   obtain ⟨z, hxz, hyz⟩ := exists_ge_ge x y
   exact ⟨z, hxz, fun u hzu => hy u (hyz.trans hzu)⟩
 
-theorem atMin_eq_atBot [Preorder α] [IsDirected α (· ≥ ·)] : (atMin : Filter α) = atBot := by
+theorem atMin_eq_atBot [IsDirected α (· ≥ ·)] : (atMin : Filter α) = atBot := by
   apply atBot_le_atMin.antisymm'
   intro s hs x
   have : Nonempty α := ⟨x⟩
@@ -114,7 +118,7 @@ theorem atMin_eq_atBot [Preorder α] [IsDirected α (· ≥ ·)] : (atMin : Filt
   obtain ⟨z, hzx, hzy⟩ := exists_le_le x y
   exact ⟨z, hzx, fun u huz => hy u (huz.trans hzy)⟩
 
-theorem pure_le_atMax [Preorder α] (x : α) : pure x ≤ atMax ↔ IsMax x := by
+theorem pure_le_atMax : pure x ≤ atMax ↔ IsMax x := by
   constructor
   · intro h
     by_contra hx
@@ -130,7 +134,7 @@ theorem pure_le_atMax [Preorder α] (x : α) : pure x ≤ atMax ↔ IsMax x := b
     obtain ⟨y, hxy, hy⟩ := hs x
     exact hy (hx hxy)
 
-theorem pure_le_atMin [Preorder α] (x : α) : pure x ≤ atMin ↔ IsMin x := by
+theorem pure_le_atMin : pure x ≤ atMin ↔ IsMin x := by
   constructor
   · intro h
     by_contra hx
@@ -145,5 +149,7 @@ theorem pure_le_atMin [Preorder α] (x : α) : pure x ≤ atMin ↔ IsMin x := b
     rw [mem_atMin] at hs
     obtain ⟨y, hyx, hy⟩ := hs x
     exact hy (hx hyx)
+
+end Preorder
 
 end Filter

--- a/Mathlib/Order/Filter/AtMaxMin.lean
+++ b/Mathlib/Order/Filter/AtMaxMin.lean
@@ -1,0 +1,109 @@
+/-
+Copyright (c) 2025 Aaron Liu. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Aaron Liu
+-/
+import Mathlib.Order.Filter.AtTopBot.Basic
+
+/-!
+# The `Filter.atMax` and `Filter.atMin` filters
+
+We define the filters `Filter.atMax` and `Filter.atMin`.
+-/
+
+variable {α : Type*}
+
+open Set
+
+namespace Filter
+
+/--
+`atMax` is the filter representing the limit `→ ∞` on an ordered set,
+and contains all maximal elements.
+-/
+def atMax [Preorder α] : Filter α where
+  sets := {s | ∀ x, ∃ y ≥ x, Ici y ⊆ s}
+  univ_sets := fun x => ⟨x, le_rfl, subset_univ _⟩
+  sets_of_superset := by
+    intro s t hs hst x
+    obtain ⟨y, hxy, hy⟩ := hs x
+    exact ⟨y, hxy, hy.trans hst⟩
+  inter_sets := by
+    intro s t hs ht x
+    obtain ⟨y, hxy, hy⟩ := hs x
+    obtain ⟨z, hyz, hz⟩ := ht y
+    exact ⟨z, hxy.trans hyz, subset_inter ((Ici_subset_Ici.mpr hyz).trans hy) hz⟩
+
+/--
+`atMin` is the filter representing the limit `→ -∞` on an ordered set,
+and contains all minimal elements.
+-/
+def atMin [Preorder α] : Filter α where
+  sets := {s | ∀ x, ∃ y ≤ x, Iic y ⊆ s}
+  univ_sets := fun x => ⟨x, le_rfl, subset_univ _⟩
+  sets_of_superset := by
+    intro s t hs hst x
+    obtain ⟨y, hyx, hy⟩ := hs x
+    exact ⟨y, hyx, hy.trans hst⟩
+  inter_sets := by
+    intro s t hs ht x
+    obtain ⟨y, hyx, hy⟩ := hs x
+    obtain ⟨z, hzy, hz⟩ := ht y
+    exact ⟨z, hzy.trans hyx, subset_inter ((Iic_subset_Iic.mpr hzy).trans hy) hz⟩
+
+theorem mem_atMax [Preorder α] (s : Set α) : s ∈ atMax ↔ ∀ x, ∃ y ≥ x, Ici y ⊆ s := Iff.rfl
+theorem mem_atMin [Preorder α] (s : Set α) : s ∈ atMin ↔ ∀ x, ∃ y ≤ x, Iic y ⊆ s := Iff.rfl
+
+instance [Preorder α] [Nonempty α] : NeBot (atMax : Filter α) where
+  ne' := by
+    intro h
+    rw [← empty_mem_iff_bot, mem_atMax] at h
+    obtain ⟨x⟩ := ‹Nonempty α›
+    obtain ⟨y, _, hy⟩ := h x
+    exact hy le_rfl
+
+instance [Preorder α] [Nonempty α] : NeBot (atMin : Filter α) where
+  ne' := by
+    intro h
+    rw [← empty_mem_iff_bot, mem_atMin] at h
+    obtain ⟨x⟩ := ‹Nonempty α›
+    obtain ⟨y, _, hy⟩ := h x
+    exact hy le_rfl
+
+theorem atTop_le_atMax [Preorder α] : (atTop : Filter α) ≤ atMax := by
+  intro s hs
+  obtain h | ⟨⟨x⟩⟩ := isEmpty_or_nonempty α
+  · rw [atTop.filter_eq_bot_of_isEmpty]
+    exact mem_bot
+  · rw [mem_atMax] at hs
+    obtain ⟨y, _, hy⟩ := hs x
+    filter_upwards [Ici_mem_atTop y] using hy
+
+theorem atBot_le_atMin [Preorder α] : (atBot : Filter α) ≤ atMin := by
+  intro s hs
+  obtain h | ⟨⟨x⟩⟩ := isEmpty_or_nonempty α
+  · rw [atBot.filter_eq_bot_of_isEmpty]
+    exact mem_bot
+  · rw [mem_atMin] at hs
+    obtain ⟨y, _, hy⟩ := hs x
+    filter_upwards [Iic_mem_atBot y] using hy
+
+theorem atMax_eq_atTop [Preorder α] [IsDirected α (· ≤ ·)] : (atMax : Filter α) = atTop := by
+  apply atTop_le_atMax.antisymm'
+  intro s hs x
+  have : Nonempty α := ⟨x⟩
+  rw [mem_atTop_sets] at hs
+  obtain ⟨y, hy⟩ := hs
+  obtain ⟨z, hxz, hyz⟩ := exists_ge_ge x y
+  exact ⟨z, hxz, fun u hzu => hy u (hyz.trans hzu)⟩
+
+theorem atMin_eq_atBot [Preorder α] [IsDirected α (· ≥ ·)] : (atMin : Filter α) = atBot := by
+  apply atBot_le_atMin.antisymm'
+  intro s hs x
+  have : Nonempty α := ⟨x⟩
+  rw [mem_atBot_sets] at hs
+  obtain ⟨y, hy⟩ := hs
+  obtain ⟨z, hzx, hzy⟩ := exists_le_le x y
+  exact ⟨z, hzx, fun u huz => hy u (huz.trans hzy)⟩
+
+end Filter

--- a/Mathlib/Order/Filter/AtMaxMin.lean
+++ b/Mathlib/Order/Filter/AtMaxMin.lean
@@ -20,10 +20,6 @@ namespace Filter
 /--
 `atMax` is the filter representing the limit `→ ∞` on an ordered set.
 It contains all maximal elements.
-
-While `atTop` and `atMax` both denote a limit at `∞`,
-`atTop` captures the idea of a process which increases past every element while
-`atMax` captures the idea of a process which increases as much as possible.
 -/
 def atMax [Preorder α] : Filter α where
   sets := {s | ∀ x, ∃ y ≥ x, Ici y ⊆ s}
@@ -41,10 +37,6 @@ def atMax [Preorder α] : Filter α where
 /--
 `atMin` is the filter representing the limit `→ -∞` on an ordered set
 It contains all minimal elements.
-
-While `atBot` and `atMin` both denote a limit at `-∞`,
-`atBot` captures the idea of a process which decends past every element while
-`atMin` captures the idea of a process which decreases as much as possible.
 -/
 def atMin [Preorder α] : Filter α where
   sets := {s | ∀ x, ∃ y ≤ x, Iic y ⊆ s}


### PR DESCRIPTION
Adds `atMax` and `atMin`, filters. Making an analogy, `atMax` : `atTop` :: `IsMax` : `IsTop`.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
