### PR TITLE
[Merged by Bors] - feat(LinearAlgebra/Dual/Basis): Add two lemmas small about coords and dual bases

### DIFF
--- a/Mathlib/LinearAlgebra/Dual/Basis.lean
+++ b/Mathlib/LinearAlgebra/Dual/Basis.lean
@@ -205,7 +205,7 @@ theorem eval_range {ι : Type*} [Finite ι] (b : Basis ι R M) :
 
 lemma dualBasis_coord_toDualEquiv_apply [Finite ι] (i : ι) (f : M) :
     b.dualBasis.coord i (b.toDualEquiv f) = b.coord i f := by
-  simp [-toDualEquiv_apply]
+  simp [-toDualEquiv_apply, Basis.dualBasis]
 
 lemma coord_toDualEquiv_symm_apply [Finite ι] (i : ι) (f : Module.Dual R M) :
     b.coord i (b.toDualEquiv.symm f) = b.dualBasis.coord i f := by

--- a/Mathlib/LinearAlgebra/Dual/Basis.lean
+++ b/Mathlib/LinearAlgebra/Dual/Basis.lean
@@ -203,6 +203,15 @@ theorem eval_range {ι : Type*} [Finite ι] (b : Basis ι R M) :
     cases nonempty_fintype ι
     rw [← b.toDual_toDual, range_comp, b.toDual_range, Submodule.map_top, toDual_range _]
 
+lemma coord_toDualEquiv_apply [Finite ι] (i : ι) (f : M) :
+    b.dualBasis.coord i (b.toDualEquiv f) = b.coord i f := by
+  simp only [Basis.dualBasis, Basis.map_repr, LinearEquiv.trans_apply, coord_apply,
+    LinearEquiv.symm_apply_apply]
+
+lemma coord_toDualEquiv_symm_apply [Finite ι] (i : ι) (f : Module.Dual R M) :
+    b.coord i (b.toDualEquiv.symm f) = b.dualBasis.coord i f := by
+  simp [Basis.dualBasis]
+
 end CommRing
 
 /-- `simp` normal form version of `linearCombination_dualBasis` -/

--- a/Mathlib/LinearAlgebra/Dual/Basis.lean
+++ b/Mathlib/LinearAlgebra/Dual/Basis.lean
@@ -205,8 +205,7 @@ theorem eval_range {ι : Type*} [Finite ι] (b : Basis ι R M) :
 
 lemma dualBasis_coord_toDualEquiv_apply [Finite ι] (i : ι) (f : M) :
     b.dualBasis.coord i (b.toDualEquiv f) = b.coord i f := by
-  simp [-toDualEquiv_apply, Basis.dualBasis, Basis.map_repr, LinearEquiv.trans_apply,
-    coord_apply, LinearEquiv.symm_apply_apply]
+  simp [-toDualEquiv_apply]
 
 lemma coord_toDualEquiv_symm_apply [Finite ι] (i : ι) (f : Module.Dual R M) :
     b.coord i (b.toDualEquiv.symm f) = b.dualBasis.coord i f := by

--- a/Mathlib/LinearAlgebra/Dual/Basis.lean
+++ b/Mathlib/LinearAlgebra/Dual/Basis.lean
@@ -205,8 +205,8 @@ theorem eval_range {ι : Type*} [Finite ι] (b : Basis ι R M) :
 
 lemma dualBasis_coord_toDualEquiv_apply [Finite ι] (i : ι) (f : M) :
     b.dualBasis.coord i (b.toDualEquiv f) = b.coord i f := by
-  simp only [Basis.dualBasis, Basis.map_repr, LinearEquiv.trans_apply, coord_apply,
-    LinearEquiv.symm_apply_apply]
+  simp [-toDualEquiv_apply, Basis.dualBasis, Basis.map_repr, LinearEquiv.trans_apply,
+    coord_apply, LinearEquiv.symm_apply_apply]
 
 lemma coord_toDualEquiv_symm_apply [Finite ι] (i : ι) (f : Module.Dual R M) :
     b.coord i (b.toDualEquiv.symm f) = b.dualBasis.coord i f := by

--- a/Mathlib/LinearAlgebra/Dual/Basis.lean
+++ b/Mathlib/LinearAlgebra/Dual/Basis.lean
@@ -203,13 +203,11 @@ theorem eval_range {ι : Type*} [Finite ι] (b : Basis ι R M) :
     cases nonempty_fintype ι
     rw [← b.toDual_toDual, range_comp, b.toDual_range, Submodule.map_top, toDual_range _]
 
-@[simp]
 lemma dualBasis_coord_toDualEquiv_apply [Finite ι] (i : ι) (f : M) :
     b.dualBasis.coord i (b.toDualEquiv f) = b.coord i f := by
   simp only [Basis.dualBasis, Basis.map_repr, LinearEquiv.trans_apply, coord_apply,
     LinearEquiv.symm_apply_apply]
 
-@[simp]
 lemma coord_toDualEquiv_symm_apply [Finite ι] (i : ι) (f : Module.Dual R M) :
     b.coord i (b.toDualEquiv.symm f) = b.dualBasis.coord i f := by
   simp [Basis.dualBasis]

--- a/Mathlib/LinearAlgebra/Dual/Basis.lean
+++ b/Mathlib/LinearAlgebra/Dual/Basis.lean
@@ -203,11 +203,13 @@ theorem eval_range {ι : Type*} [Finite ι] (b : Basis ι R M) :
     cases nonempty_fintype ι
     rw [← b.toDual_toDual, range_comp, b.toDual_range, Submodule.map_top, toDual_range _]
 
-lemma coord_toDualEquiv_apply [Finite ι] (i : ι) (f : M) :
+@[simp]
+lemma dualBasis_coord_toDualEquiv_apply [Finite ι] (i : ι) (f : M) :
     b.dualBasis.coord i (b.toDualEquiv f) = b.coord i f := by
   simp only [Basis.dualBasis, Basis.map_repr, LinearEquiv.trans_apply, coord_apply,
     LinearEquiv.symm_apply_apply]
 
+@[simp]
 lemma coord_toDualEquiv_symm_apply [Finite ι] (i : ι) (f : Module.Dual R M) :
     b.coord i (b.toDualEquiv.symm f) = b.dualBasis.coord i f := by
   simp [Basis.dualBasis]


### PR DESCRIPTION
This PR adds two small lemmas about how coordinates behave when moving to the dual space.

These aren't `simp` lemmas since they are not in simp-normal form.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
