### PR TITLE
[Merged by Bors] - feat(Data/Matroid/Minor): organize minor API 

### DIFF
--- a/Mathlib/Data/Matroid/Loop.lean
+++ b/Mathlib/Data/Matroid/Loop.lean
@@ -701,6 +701,14 @@ lemma coloops_indep (M : Matroid α) : M.Indep M.coloops := by
   rw [← empty_union M.coloops, union_coloops_indep_iff]
   exact M.empty_indep
 
+lemma restrict_isColoop_iff {R : Set α} (hRE : R ⊆ M.E) :
+    (M ↾ R).IsColoop e ↔ e ∉ M.closure (R \ {e}) ∧ e ∈ R := by
+  wlog heR : e ∈ R
+  · exact iff_of_false (fun h ↦ heR h.mem_ground) fun h ↦ heR h.2
+  rw [isColoop_iff_forall_not_mem_isCircuit heR, mem_closure_iff_exists_isCircuit (by simp)]
+  simp only [restrict_isCircuit_iff hRE, insert_diff_singleton]
+  aesop
+
 /-- If two matroids agree on loops and coloops, and have the same independent sets after
   loops/coloops are removed, they are equal. -/
 lemma ext_indep_disjoint_loops_coloops {M₁ M₂ : Matroid α} (hE : M₁.E = M₂.E)

--- a/Mathlib/Data/Matroid/Minor/Basic.lean
+++ b/Mathlib/Data/Matroid/Minor/Basic.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Peter Nelson
 -/
 import Mathlib.Data.Matroid.Loop
+import Mathlib.Tactic.TautoSet
 
 /-!
 # Matroid Minors
@@ -32,6 +33,8 @@ and interacts nicely with duality and linear representations.
   where `J` is an arbitrary basis for `C`.
 * `Matroid.contract_dual M C : (M ／ X)✶ = M✶ ＼ X`; the dual of contraction is deletion.
 * `Matroid.delete_dual M C : (M ＼ X)✶ = M✶ ／ X`; the dual of deletion is contraction.
+* `Matroid.IsBasis.contract_indep_iff`; if `I` is a basis for `C`, then the independent
+  sets of `M ／ C` are exactly the `J ⊆ M.E \ C` for which `I ∪ J` is independent in `M`.
 
 # Naming conventions
 
@@ -46,6 +49,8 @@ variable {α : Type*} {M M' N : Matroid α} {e f : α} {I J R B X Y Z K S : Set 
 
 namespace Matroid
 
+/-! ## Deletion -/
+
 section Delete
 
 variable {D D₁ D₂ R : Set α}
@@ -58,12 +63,6 @@ def delete (M : Matroid α) (D : Set α) : Matroid α := M ↾ (M.E \ D)
 scoped infixl:75 " ＼ " => Matroid.delete
 
 lemma delete_eq_restrict (M : Matroid α) (D : Set α) : M ＼ D = M ↾ (M.E \ D) := rfl
-
-instance delete_finite [M.Finite] : (M ＼ D).Finite :=
-  ⟨M.ground_finite.diff⟩
-
-instance delete_rankFinite [RankFinite M] : RankFinite (M ＼ D) :=
-  restrict_rankFinite _
 
 lemma restrict_compl (M : Matroid α) (D : Set α) : M ↾ (M.E \ D) = M ＼ D := rfl
 
@@ -116,6 +115,15 @@ lemma delete_eq_delete_iff : M ＼ D₁ = M ＼ D₂ ↔ D₁ ∩ M.E = D₂ ∩
   simp_rw [delete_ground, diff_diff_cancel_left inter_subset_right] at h
   assumption
 
+@[simp]
+lemma delete_empty (M : Matroid α) : M ＼ ∅ = M := by
+  rw [delete_eq_self_iff]
+  exact empty_disjoint _
+
+lemma delete_delete_eq_delete_diff (M : Matroid α) (D₁ D₂ : Set α) :
+    M ＼ D₁ ＼ D₂ = M ＼ D₁ ＼ (D₂ \ D₁) :=
+  by simp
+
 lemma IsRestriction.restrict_delete_of_disjoint (h : N ≤r M) (hX : Disjoint X N.E) :
     N ≤r (M ＼ X) := by
   obtain ⟨D, hD, rfl⟩ := isRestriction_iff_exists_eq_delete.1 h
@@ -125,6 +133,8 @@ lemma IsRestriction.restrict_delete_of_disjoint (h : N ≤r M) (hX : Disjoint X 
 
 lemma IsRestriction.isRestriction_deleteElem (h : N ≤r M) (he : e ∉ N.E) : N ≤r M ＼ {e} :=
   h.restrict_delete_of_disjoint (by simpa)
+
+/-! ### Independence and Bases -/
 
 @[simp]
 lemma delete_indep_iff : (M ＼ D).Indep I ↔ M.Indep I ∧ Disjoint I D := by
@@ -169,6 +179,31 @@ lemma IsBasis.of_delete (h : (M ＼ D).IsBasis I X) : M.IsBasis I X :=
 lemma IsBasis.delete (h : M.IsBasis I X) (hX : Disjoint X D) : (M ＼ D).IsBasis I X := by
   rw [delete_isBasis_iff]; exact ⟨h, hX⟩
 
+lemma Coindep.delete_isBase_iff (hD : M.Coindep D) :
+    (M ＼ D).IsBase B ↔ M.IsBase B ∧ Disjoint B D := by
+  rw [Matroid.delete_isBase_iff]
+  refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
+  · have hss := h.subset
+    rw [subset_diff] at hss
+    have hcl := h.isBasis_closure_right
+    rw [hD.closure_compl, isBasis_ground_iff] at hcl
+    exact ⟨hcl, hss.2⟩
+  exact h.1.isBasis_ground.isBasis_subset (by simp [subset_diff, h.1.subset_ground, h.2])
+    diff_subset
+
+lemma Coindep.delete_rankPos [M.RankPos] (hD : M.Coindep D) : (M ＼ D).RankPos := by
+  rw [rankPos_iff, hD.delete_isBase_iff]
+  simp [M.empty_not_isBase]
+
+lemma Coindep.delete_spanning_iff (hD : M.Coindep D) :
+    (M ＼ D).Spanning S ↔ M.Spanning S ∧ Disjoint S D := by
+  simp only [spanning_iff_exists_isBase_subset', hD.delete_isBase_iff, and_assoc, delete_ground,
+    subset_diff, and_congr_left_iff, and_imp]
+  refine fun hSE hSD ↦ ⟨fun ⟨B, hB, hBD, hBS⟩ ↦ ⟨B, hB, hBS⟩, fun ⟨B, hB, hBS⟩ ↦ ⟨B, hB, ?_, hBS⟩⟩
+  exact hSD.mono_left hBS
+
+/-! ### Loops, circuits and closure -/
+
 @[simp]
 lemma delete_isLoop_iff : (M ＼ D).IsLoop e ↔ M.IsLoop e ∧ e ∉ D := by
   rw [← singleton_dep, delete_dep_iff, disjoint_singleton_left, singleton_dep]
@@ -205,58 +240,48 @@ lemma delete_closure_eq (M : Matroid α) (D X : Set α) :
     ← inter_assoc, ← diff_eq, inter_eq_left]
   exact diff_subset.trans (M.closure_subset_ground _)
 
+lemma delete_closure_eq_of_disjoint (M : Matroid α) {D X : Set α} (hXD : Disjoint X D) :
+    (M ＼ D).closure X = M.closure X \ D := by
+  rw [delete_closure_eq, hXD.sdiff_eq_left]
+
 @[simp]
 lemma delete_loops_eq (M : Matroid α) (D : Set α) : (M ＼ D).loops = M.loops \ D := by
   simp [loops]
 
-@[simp]
-lemma delete_empty (M : Matroid α) : M ＼ ∅ = M := by
-  rw [delete_eq_self_iff]
-  exact empty_disjoint _
+lemma delete_isColoop_iff (M : Matroid α) (D : Set α) :
+    (M ＼ D).IsColoop e ↔ e ∉ M.closure ((M.E \ D) \ {e}) ∧ e ∈ M.E ∧ e ∉ D := by
+  rw [delete_eq_restrict, restrict_isColoop_iff diff_subset, mem_diff, and_congr_left_iff, and_imp]
+  simp
 
-lemma delete_delete_eq_delete_diff (M : Matroid α) (D₁ D₂ : Set α) :
-    M ＼ D₁ ＼ D₂ = M ＼ D₁ ＼ (D₂ \ D₁) :=
-  by simp
+/-! ### Finiteness -/
 
-instance delete_finitary (M : Matroid α) [Finitary M] (D : Set α) : Finitary (M ＼ D) := by
-  change Finitary (M ↾ (M.E \ D)); infer_instance
+instance delete_finitary (M : Matroid α) [Finitary M] (D : Set α) : Finitary (M ＼ D) :=
+  inferInstanceAs <| Finitary (M ↾ (M.E \ D))
 
-lemma Coindep.delete_isBase_iff (hD : M.Coindep D) :
-    (M ＼ D).IsBase B ↔ M.IsBase B ∧ Disjoint B D := by
-  rw [Matroid.delete_isBase_iff]
-  refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
-  · have hss := h.subset
-    rw [subset_diff] at hss
-    have hcl := h.isBasis_closure_right
-    rw [hD.closure_compl, isBasis_ground_iff] at hcl
-    exact ⟨hcl, hss.2⟩
-  exact h.1.isBasis_ground.isBasis_subset (by simp [subset_diff, h.1.subset_ground, h.2])
-    diff_subset
+instance delete_finite [M.Finite] : (M ＼ D).Finite :=
+  ⟨M.ground_finite.diff⟩
 
-lemma Coindep.delete_rankPos [M.RankPos] (hD : M.Coindep D) : (M ＼ D).RankPos := by
-  rw [rankPos_iff, hD.delete_isBase_iff]
-  simp [M.empty_not_isBase]
-
-lemma Coindep.delete_spanning_iff (hD : M.Coindep D) :
-    (M ＼ D).Spanning S ↔ M.Spanning S ∧ Disjoint S D := by
-  simp only [spanning_iff_exists_isBase_subset', hD.delete_isBase_iff, and_assoc, delete_ground,
-    subset_diff, and_congr_left_iff, and_imp]
-  refine fun hSE hSD ↦ ⟨fun ⟨B, hB, hBD, hBS⟩ ↦ ⟨B, hB, hBS⟩, fun ⟨B, hB, hBS⟩ ↦ ⟨B, hB, ?_, hBS⟩⟩
-  exact hSD.mono_left hBS
+instance delete_rankFinite [RankFinite M] : RankFinite (M ＼ D) :=
+  restrict_rankFinite _
 
 end Delete
 
+/-! ## Contraction -/
+
 section Contract
+
+variable {C C₁ C₂ : Set α}
 
 /-- The contraction `M ／ C` is the matroid on `M.E \ C` in which a set `I ⊆ M.E \ C` is independent
 if and only if `I ∪ J` is independent, where `J` is an arbitrarily chosen basis for `C`.
-It is also equal to `(M✶ ＼ C)✶`, and is defined this way so we don't have to give
-a separate proof that it is actually a matroid.
-(Currently the proof it has the correct independent sets is TODO. ) -/
+It is also equal by definition to `(M✶ ＼ C)✶`; see `Matroid.IsBasis.contract_indep_iff` for
+a proof that its independent sets are the claimed ones. -/
 def contract (M : Matroid α) (C : Set α) : Matroid α := (M✶ ＼ C)✶
 
 /-- `M ／ C` refers to the contraction of a set `C` from the matroid `M`. -/
 infixl:75 " ／ " => Matroid.contract
+
+@[simp] lemma contract_ground (M : Matroid α) (C : Set α) : (M ／ C).E = M.E \ C := rfl
 
 lemma dual_delete_dual (M : Matroid α) (X : Set α) : (M✶ ＼ X)✶ = M ／ X := rfl
 
@@ -283,6 +308,231 @@ lemma dual_contract_delete (M : Matroid α) (X Y : Set α) : (M ／ X ＼ Y)✶ 
 
 lemma dual_delete_contract (M : Matroid α) (X Y : Set α) : (M ＼ X ／ Y)✶ = M✶ ／ X ＼ Y := by
   simp
+
+lemma contract_eq_self_iff : M ／ C = M ↔ Disjoint C M.E := by
+  rw [← dual_delete_dual, ← dual_inj, dual_dual, delete_eq_self_iff, dual_ground]
+
+lemma contractElem_eq_self (he : e ∉ M.E) : M ／ {e} = M := by
+  rw [← dual_delete_dual, deleteElem_eq_self (by simpa), dual_dual]
+
+@[simp] lemma contract_empty (M : Matroid α) : M ／ ∅ = M := by
+  rw [← dual_delete_dual, delete_empty, dual_dual]
+
+lemma contract_contract_eq_contract_diff (M : Matroid α) (C₁ C₂ : Set α) :
+    M ／ C₁ ／ C₂ = M ／ C₁ ／ (C₂ \ C₁) := by
+  simp
+
+lemma contract_eq_contract_iff : M ／ C₁ = M ／ C₂ ↔ C₁ ∩ M.E = C₂ ∩ M.E := by
+  rw [← dual_delete_dual, ← dual_delete_dual, dual_inj, delete_eq_delete_iff, dual_ground]
+
+@[simp] lemma contract_inter_ground_eq (M : Matroid α) (C : Set α) : M ／ (C ∩ M.E) = M ／ C := by
+  rw [← dual_delete_dual, (show M.E = M✶.E from rfl), delete_inter_ground_eq]
+  rfl
+
+@[aesop unsafe 10% (rule_sets := [Matroid])]
+lemma contract_ground_subset_ground (M : Matroid α) (C : Set α) : (M ／ C).E ⊆ M.E :=
+  (M.contract_ground C).trans_subset diff_subset
+
+/-! ### Independence and Coindependence -/
+
+lemma coindep_contract_iff : (M ／ C).Coindep X ↔ M.Coindep X ∧ Disjoint X C := by
+  rw [coindep_def, dual_contract, delete_indep_iff, ← coindep_def]
+
+lemma Coindep.coindep_contract_of_disjoint (hX : M.Coindep X) (hXC : Disjoint X C) :
+    (M ／ C).Coindep X :=
+  coindep_contract_iff.2 ⟨hX, hXC⟩
+
+@[simp] lemma contract_isCocircuit_iff :
+    (M ／ C).IsCocircuit K ↔ M.IsCocircuit K ∧ Disjoint K C := by
+  rw [isCocircuit_def, dual_contract, delete_isCircuit_iff]
+
+lemma Indep.contract_isBase_iff (hI : M.Indep I) :
+    (M ／ I).IsBase B ↔ M.IsBase (B ∪ I) ∧ Disjoint B I := by
+  rw [← dual_delete_dual, dual_isBase_iff', delete_ground, dual_ground, delete_isBase_iff,
+    subset_diff, ← and_assoc, and_congr_left_iff, ← dual_dual M, dual_isBase_iff', dual_dual,
+    dual_dual, union_comm, dual_ground, union_subset_iff, and_iff_right hI.subset_ground,
+    and_congr_left_iff, ← isBase_restrict_iff, diff_diff, Spanning.isBase_restrict_iff,
+    and_iff_left (diff_subset_diff_right subset_union_left)]
+  · simp
+  rwa [← dual_ground, ← coindep_iff_compl_spanning, dual_coindep_iff]
+
+lemma Indep.contract_indep_iff (hI : M.Indep I) :
+    (M ／ I).Indep J ↔ Disjoint J I ∧ M.Indep (J ∪ I) := by
+  simp_rw [indep_iff, hI.contract_isBase_iff, union_subset_iff]
+  exact ⟨fun ⟨B, ⟨hBI, hdj⟩, hJB⟩ ↦ ⟨disjoint_of_subset_left hJB hdj, _, hBI,
+    hJB.trans subset_union_left, subset_union_right⟩,
+    fun ⟨hdj, B, hB, hJB, hIB⟩ ↦ ⟨B \ I,⟨by simpa [union_eq_self_of_subset_right hIB],
+      disjoint_sdiff_left⟩, subset_diff.2 ⟨hJB, hdj⟩ ⟩⟩
+
+lemma IsNonloop.contractElem_indep_iff (he : M.IsNonloop e) :
+    (M ／ {e}).Indep I ↔ e ∉ I ∧ M.Indep (insert e I) := by
+  simp [he.indep.contract_indep_iff]
+
+lemma Indep.union_indep_iff_contract_indep (hI : M.Indep I) :
+    M.Indep (I ∪ J) ↔ (M ／ I).Indep (J \ I) := by
+  rw [hI.contract_indep_iff, and_iff_right disjoint_sdiff_left, diff_union_self, union_comm]
+
+lemma Indep.diff_indep_contract_of_subset (hJ : M.Indep J) (hIJ : I ⊆ J) :
+    (M ／ I).Indep (J \ I) := by
+  rwa [← (hJ.subset hIJ).union_indep_iff_contract_indep, union_eq_self_of_subset_left hIJ]
+
+lemma Indep.contract_dep_iff (hI : M.Indep I) :
+    (M ／ I).Dep J ↔ Disjoint J I ∧ M.Dep (J ∪ I) := by
+  rw [dep_iff, hI.contract_indep_iff, dep_iff, contract_ground, subset_diff, disjoint_comm,
+    union_subset_iff, and_iff_left hI.subset_ground]
+  tauto
+
+/-! ### Bases -/
+
+/-- Contracting a set is the same as contracting a basis for the set, and deleting the rest. -/
+lemma IsBasis.contract_eq_contract_delete (hI : M.IsBasis I X) : M ／ X = M ／ I ＼ (X \ I) := by
+  nth_rw 1 [← diff_union_of_subset hI.subset, ← dual_inj, dual_contract_delete, dual_contract,
+    union_comm, ← delete_delete, ext_iff_indep]
+  refine ⟨rfl, fun J hJ ↦ ?_⟩
+  have hss : X \ I ⊆ (M✶ ＼ I).coloops := fun e he ↦ by
+    rw [← dual_contract, dual_coloops, ← IsLoop, ← singleton_dep, hI.indep.contract_dep_iff,
+      singleton_union, and_iff_right (by simpa using he.2), hI.indep.insert_dep_iff,
+      hI.closure_eq_closure]
+    exact diff_subset_diff_left (M.subset_closure X) he
+  rw [((coloops_indep _).subset hss).contract_indep_iff, delete_indep_iff,
+    union_indep_iff_indep_of_subset_coloops hss, and_comm]
+
+lemma Indep.union_isBasis_union_of_contract_isBasis (hI : M.Indep I) (hB : (M ／ I).IsBasis J X) :
+    M.IsBasis (J ∪ I) (X ∪ I) := by
+  simp_rw [IsBasis, hI.contract_indep_iff, contract_ground, subset_diff,
+    maximal_subset_iff, and_imp] at hB
+  refine hB.1.1.1.2.isBasis_of_maximal_subset (union_subset_union_left _ hB.1.1.2)
+    fun K hK hKJ hKX ↦ ?_
+  rw [union_subset_iff] at hKJ
+  rw [hB.1.2 (t := K \ I) disjoint_sdiff_left (by simpa [diff_union_of_subset hKJ.2])
+    (diff_subset_iff.2 (by rwa [union_comm])) (subset_diff.2 ⟨hKJ.1, hB.1.1.1.1⟩),
+    diff_union_of_subset hKJ.2]
+
+lemma IsBasis'.contract_isBasis'_diff_diff_of_subset (hIX : M.IsBasis' I X) (hJI : J ⊆ I) :
+    (M ／ J).IsBasis' (I \ J) (X \ J) := by
+  suffices ∀ ⦃K⦄, Disjoint K J → M.Indep (K ∪ J) → K ⊆ X → I ⊆ K ∪ J → K ⊆ I by
+    simpa +contextual [IsBasis', (hIX.indep.subset hJI).contract_indep_iff,
+      subset_diff, maximal_subset_iff, disjoint_sdiff_left,
+      union_eq_self_of_subset_right hJI, hIX.indep, diff_subset.trans hIX.subset,
+      diff_subset_iff, subset_antisymm_iff, union_comm J]
+  exact fun K hJK hKJi hKX hIJK ↦ by
+    simp [hIX.eq_of_subset_indep hKJi hIJK (union_subset hKX (hJI.trans hIX.subset))]
+
+lemma IsBasis'.contract_isBasis'_diff_of_subset (hIX : M.IsBasis' I X) (hJI : J ⊆ I) :
+    (M ／ J).IsBasis' (I \ J) X := by
+  simpa [isBasis'_iff_isBasis_inter_ground, inter_diff_assoc, ← diff_inter_distrib_right] using
+    (hIX.contract_isBasis'_diff_diff_of_subset hJI).isBasis_inter_ground
+
+lemma IsBasis.contract_isBasis_diff_diff_of_subset (hIX : M.IsBasis I X) (hJI : J ⊆ I) :
+    (M ／ J).IsBasis (I \ J) (X \ J) := by
+  have h := (hIX.isBasis'.contract_isBasis'_diff_of_subset hJI).isBasis_inter_ground
+  rwa [contract_ground, ← inter_diff_assoc, inter_eq_self_of_subset_left hIX.subset_ground] at h
+
+lemma IsBasis.contract_diff_isBasis_diff (hIX : M.IsBasis I X) (hJY : M.IsBasis J Y) (hIJ : I ⊆ J) :
+    (M ／ I).IsBasis (J \ I) (Y \ X) := by
+  refine (hJY.contract_isBasis_diff_diff_of_subset hIJ).isBasis_subset ?_ ?_
+  · rw [subset_diff, and_iff_right (diff_subset.trans hJY.subset),
+      hIX.eq_of_subset_indep (hJY.indep.inter_right X) (subset_inter hIJ hIX.subset)
+      inter_subset_right, diff_self_inter]
+    exact disjoint_sdiff_left
+  refine diff_subset_diff_right hIX.subset
+
+lemma IsBasis'.contract_isBasis_union_union (h : M.IsBasis' (J ∪ I) (X ∪ I))
+    (hJI : Disjoint J I) (hXI : Disjoint X I) : (M ／ I).IsBasis' J X := by
+  simpa [hJI.sdiff_eq_left, hXI.sdiff_eq_left] using
+    h.contract_isBasis'_diff_diff_of_subset subset_union_right
+
+lemma IsBasis.contract_isBasis_union_union (h : M.IsBasis (J ∪ I) (X ∪ I))
+    (hJI : Disjoint J I) (hXI : Disjoint X I) : (M ／ I).IsBasis J X := by
+  refine (isBasis'_iff_isBasis ?_).1 <| h.isBasis'.contract_isBasis_union_union hJI hXI
+  rw [contract_ground, subset_diff, and_iff_left hXI]
+  exact subset_union_left.trans h.subset_ground
+
+lemma IsBasis'.contract_eq_contract_delete (hI : M.IsBasis' I X) : M ／ X = M ／ I ＼ (X \ I) := by
+  rw [← contract_inter_ground_eq, hI.isBasis_inter_ground.contract_eq_contract_delete, eq_comm,
+    ← delete_inter_ground_eq, contract_ground, diff_eq, diff_eq, ← inter_inter_distrib_right,
+    ← diff_eq]
+
+lemma IsBasis'.contract_indep_iff (hI : M.IsBasis' I X) :
+    (M ／ X).Indep J ↔ M.Indep (J ∪ I) ∧ Disjoint X J := by
+  rw [hI.contract_eq_contract_delete, delete_indep_iff, hI.indep.contract_indep_iff,
+    and_comm, ← and_assoc, ← disjoint_union_right, diff_union_self,
+    union_eq_self_of_subset_right hI.subset, and_comm, disjoint_comm]
+
+lemma IsBasis.contract_indep_iff (hI : M.IsBasis I X) :
+    (M ／ X).Indep J ↔ M.Indep (J ∪ I) ∧ Disjoint X J :=
+  hI.isBasis'.contract_indep_iff
+
+lemma IsBasis'.contract_dep_iff (hI : M.IsBasis' I X) {D : Set α} :
+    (M ／ X).Dep D ↔ M.Dep (D ∪ I) ∧ Disjoint X D := by
+  rw [hI.contract_eq_contract_delete, delete_dep_iff, hI.indep.contract_dep_iff, and_comm,
+    ← and_assoc, ← disjoint_union_right, diff_union_of_subset hI.subset, disjoint_comm, and_comm]
+
+lemma IsBasis.contract_dep_iff (hI : M.IsBasis I X) {D : Set α} :
+    (M ／ X).Dep D ↔ M.Dep (D ∪ I) ∧ Disjoint X D :=
+  hI.isBasis'.contract_dep_iff
+
+lemma IsBasis.contract_indep_iff_of_disjoint (hI : M.IsBasis I X) (hdj : Disjoint X J) :
+    (M ／ X).Indep J ↔ M.Indep (J ∪ I) := by
+  rw [hI.contract_indep_iff, and_iff_left hdj]
+
+lemma IsBasis.contract_indep_diff_iff (hI : M.IsBasis I X) :
+    (M ／ X).Indep (J \ X) ↔ M.Indep ((J \ X) ∪ I) := by
+  rw [hI.contract_indep_iff, and_iff_left disjoint_sdiff_right]
+
+lemma IsBasis'.contract_indep_diff_iff (hI : M.IsBasis' I X) :
+    (M ／ X).Indep (J \ X) ↔ M.Indep ((J \ X) ∪ I) := by
+  rw [hI.contract_indep_iff, and_iff_left disjoint_sdiff_right]
+
+lemma IsBasis.contract_isBasis_of_isBasis' (h : M.IsBasis I X) (hJC : M.IsBasis' J C)
+    (h_ind : M.Indep (I \ C ∪ J)) : (M ／ C).IsBasis (I \ C) (X \ C) := by
+  have hIX := h.subset
+  have hJCss := hJC.subset
+  rw [hJC.contract_eq_contract_delete, delete_isBasis_iff]
+  refine ⟨contract_isBasis_union_union (h_ind.isBasis_of_subset_of_subset_closure ?_ ?_) ?_ ?_, ?_⟩
+  rotate_left
+  · rw [closure_union_congr_right hJC.closure_eq_closure, diff_union_self,
+      closure_union_congr_left h.closure_eq_closure]
+    exact subset_closure_of_subset' _ (by tauto_set)
+      (union_subset (diff_subset.trans h.subset_ground) hJC.indep.subset_ground)
+  all_goals tauto_set
+
+lemma IsBasis'.contract_isBasis' (h : M.IsBasis' I X) (hJC : M.IsBasis' J C)
+    (h_ind : M.Indep (I \ C ∪ J)) : (M ／ C).IsBasis' (I \ C) (X \ C) := by
+  rw [isBasis'_iff_isBasis_inter_ground, contract_ground, ← diff_inter_distrib_right]
+  exact h.isBasis_inter_ground.contract_isBasis_of_isBasis' hJC h_ind
+
+lemma IsBasis.contract_isBasis (h : M.IsBasis I X) (hJC : M.IsBasis J C)
+    (h_ind : M.Indep (I \ C ∪ J)) : (M ／ C).IsBasis (I \ C) (X \ C) :=
+  h.contract_isBasis_of_isBasis' hJC.isBasis' h_ind
+
+lemma IsBasis.contract_isBasis_of_disjoint (h : M.IsBasis I X) (hJC : M.IsBasis J C)
+    (hdj : Disjoint C X) (h_ind : M.Indep (I ∪ J)) : (M ／ C).IsBasis I X := by
+  have h' := h.contract_isBasis hJC
+  rwa [(hdj.mono_right h.subset).sdiff_eq_right, hdj.sdiff_eq_right, imp_iff_right h_ind] at h'
+
+lemma IsBasis'.contract_isBasis_of_indep (h : M.IsBasis' I X) (h_ind : M.Indep (I ∪ J)) :
+    (M ／ J).IsBasis' (I \ J) (X \ J) :=
+  h.contract_isBasis' (h_ind.subset subset_union_right).isBasis_self.isBasis' (by simpa)
+
+lemma IsBasis.contract_isBasis_of_indep (h : M.IsBasis I X) (h_ind : M.Indep (I ∪ J)) :
+    (M ／ J).IsBasis (I \ J) (X \ J) :=
+  h.contract_isBasis (h_ind.subset subset_union_right).isBasis_self (by simpa)
+
+lemma IsBasis.contract_isBasis_of_disjoint_indep (h : M.IsBasis I X) (hdj : Disjoint J X)
+    (h_ind : M.Indep (I ∪ J)) : (M ／ J).IsBasis I X := by
+  rw [← hdj.sdiff_eq_right, ← (hdj.mono_right h.subset).sdiff_eq_right]
+  exact h.contract_isBasis_of_indep h_ind
+
+lemma Indep.of_contract (hI : (M ／ C).Indep I) : M.Indep I :=
+  ((M.exists_isBasis' C).choose_spec.contract_indep_iff.1 hI).1.subset subset_union_left
+
+lemma Dep.of_contract (h : (M ／ C).Dep X) (hC : C ⊆ M.E := by aesop_mat) : M.Dep (C ∪ X) := by
+  rw [Dep, and_iff_left (union_subset hC (h.subset_ground.trans diff_subset))]
+  intro hi
+  rw [Dep, (hi.subset subset_union_left).contract_indep_iff, union_comm,
+    and_iff_left hi] at h
+  exact h.1 (subset_diff.1 h.2).2
 
 end Contract
 

--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -416,6 +416,7 @@
   "Mathlib.Data.Nat.Init": ["Batteries.Tactic.Init"],
   "Mathlib.Data.Nat.Find": ["Batteries.WF"],
   "Mathlib.Data.Multiset.Bind": ["Mathlib.Algebra.GroupWithZero.Action.Defs"],
+  "Mathlib.Data.Matroid.Minor.Basic": ["Mathlib.Tactic.TautoSet"],
   "Mathlib.Data.List.Sigma": ["Batteries.Tactic.Congr"],
   "Mathlib.Data.List.Rotate": ["Mathlib.Data.Quot"],
   "Mathlib.Data.List.Range": ["Batteries.Data.Nat.Lemmas"],


### PR DESCRIPTION
This gives some API for the interaction of `Matroid.contract` with independence and bases, and tidies up `Matroid.Minor.Basic` by introducing section headings. Split from #23557 .

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
