### PR TITLE
[Merged by Bors] - chore(Order/Minimal): don't import `CompleteLattice`

### DIFF
--- a/Counterexamples/AharoniKorman.lean
+++ b/Counterexamples/AharoniKorman.lean
@@ -8,7 +8,7 @@ import Mathlib.Algebra.Order.Field.Basic
 import Mathlib.Algebra.Order.Field.Rat
 import Mathlib.Algebra.Order.Star.Basic
 import Mathlib.Data.Nat.Cast.Order.Ring
-import Mathlib.Order.Chain
+import Mathlib.Order.CompleteLattice.Chain
 import Mathlib.Order.WellFoundedSet
 import Mathlib.Order.Interval.Set.Infinite
 import Mathlib.Data.Setoid.Partition

--- a/Counterexamples/AharoniKorman.lean
+++ b/Counterexamples/AharoniKorman.lean
@@ -3,16 +3,12 @@ Copyright (c) 2024 Bhavik Mehta. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Bhavik Mehta
 -/
-
 import Mathlib.Algebra.Order.Field.Basic
 import Mathlib.Algebra.Order.Field.Rat
-import Mathlib.Algebra.Order.Star.Basic
-import Mathlib.Data.Nat.Cast.Order.Ring
-import Mathlib.Order.CompleteLattice.Chain
-import Mathlib.Order.WellFoundedSet
-import Mathlib.Order.Interval.Set.Infinite
 import Mathlib.Data.Setoid.Partition
-import Mathlib.Topology.Filter
+import Mathlib.Order.Filter.AtTopBot.Basic
+import Mathlib.Order.Interval.Set.Infinite
+import Mathlib.Order.WellFoundedSet
 
 /-!
 # Disproof of the Aharoni–Korman conjecture

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4455,7 +4455,6 @@ import Mathlib.Order.Category.OmegaCompletePartialOrder
 import Mathlib.Order.Category.PartOrd
 import Mathlib.Order.Category.Preord
 import Mathlib.Order.Category.Semilat
-import Mathlib.Order.Chain
 import Mathlib.Order.Circular
 import Mathlib.Order.Closure
 import Mathlib.Order.Cofinal
@@ -4465,6 +4464,7 @@ import Mathlib.Order.Comparable
 import Mathlib.Order.Compare
 import Mathlib.Order.CompleteBooleanAlgebra
 import Mathlib.Order.CompleteLattice.Basic
+import Mathlib.Order.CompleteLattice.Chain
 import Mathlib.Order.CompleteLattice.Defs
 import Mathlib.Order.CompleteLattice.Finset
 import Mathlib.Order.CompleteLattice.Lemmas
@@ -4633,6 +4633,7 @@ import Mathlib.Order.Partition.Basic
 import Mathlib.Order.Partition.Equipartition
 import Mathlib.Order.Partition.Finpartition
 import Mathlib.Order.PiLex
+import Mathlib.Order.Preorder.Chain
 import Mathlib.Order.PrimeIdeal
 import Mathlib.Order.PrimeSeparator
 import Mathlib.Order.PropInstances

--- a/Mathlib/Data/Fin/FlagRange.lean
+++ b/Mathlib/Data/Fin/FlagRange.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury Kudryashov
 -/
 import Mathlib.Data.Fin.Basic
-import Mathlib.Order.Chain
+import Mathlib.Order.CompleteLattice.Chain
 import Mathlib.Order.Cover
 import Mathlib.Order.Fin.Basic
 

--- a/Mathlib/Data/Fin/FlagRange.lean
+++ b/Mathlib/Data/Fin/FlagRange.lean
@@ -3,8 +3,6 @@ Copyright (c) 2023 Yury Kudryashov. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury Kudryashov
 -/
-import Mathlib.Data.Fin.Basic
-import Mathlib.Order.CompleteLattice.Chain
 import Mathlib.Order.Cover
 import Mathlib.Order.Fin.Basic
 

--- a/Mathlib/Data/Matroid/Basic.lean
+++ b/Mathlib/Data/Matroid/Basic.lean
@@ -7,7 +7,7 @@ import Mathlib.Data.Finite.Prod
 import Mathlib.Data.Matroid.Init
 import Mathlib.Data.Set.Card
 import Mathlib.Data.Set.Finite.Powerset
-import Mathlib.Order.Minimal
+import Mathlib.Order.UpperLower.Closure
 
 /-!
 # Matroids

--- a/Mathlib/Order/Antichain.lean
+++ b/Mathlib/Order/Antichain.lean
@@ -355,4 +355,3 @@ theorem Set.Subsingleton.isWeakAntichain (hs : s.Subsingleton) : IsWeakAntichain
   hs.isAntichain _
 
 end Pi
-#min_imports

--- a/Mathlib/Order/Antichain.lean
+++ b/Mathlib/Order/Antichain.lean
@@ -3,11 +3,8 @@ Copyright (c) 2021 Yaël Dillies. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies
 -/
-import Mathlib.Data.Set.Pairwise.Basic
 import Mathlib.Order.Bounds.Basic
-import Mathlib.Order.Directed
-import Mathlib.Order.Hom.Set
-import Mathlib.Order.Chain
+import Mathlib.Order.Preorder.Chain
 
 /-!
 # Antichains
@@ -24,6 +21,7 @@ relation is `G.adj` for `G : SimpleGraph α`, this corresponds to independent se
 * `IsAntichain.mk r s`: Turns `s` into an antichain by keeping only the "maximal" elements.
 -/
 
+assert_not_exists CompleteLattice
 
 open Function Set
 
@@ -357,3 +355,4 @@ theorem Set.Subsingleton.isWeakAntichain (hs : s.Subsingleton) : IsWeakAntichain
   hs.isAntichain _
 
 end Pi
+#min_imports

--- a/Mathlib/Order/Birkhoff.lean
+++ b/Mathlib/Order/Birkhoff.lean
@@ -3,9 +3,9 @@ Copyright (c) 2022 Yaël Dillies. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies, Filippo A. E. Nuccio, Sam van Gool
 -/
-import Mathlib.Data.Fintype.Order
 import Mathlib.Order.Interval.Finset.Basic
 import Mathlib.Order.Irreducible
+import Mathlib.Order.UpperLower.Closure
 
 /-!
 # Birkhoff representation

--- a/Mathlib/Order/Birkhoff.lean
+++ b/Mathlib/Order/Birkhoff.lean
@@ -3,6 +3,7 @@ Copyright (c) 2022 Yaël Dillies. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies, Filippo A. E. Nuccio, Sam van Gool
 -/
+import Mathlib.Data.Fintype.Order
 import Mathlib.Order.Interval.Finset.Basic
 import Mathlib.Order.Irreducible
 import Mathlib.Order.UpperLower.Closure

--- a/Mathlib/Order/CompleteLattice/Chain.lean
+++ b/Mathlib/Order/CompleteLattice/Chain.lean
@@ -1,0 +1,106 @@
+/-
+Copyright (c) 2017 Johannes Hölzl. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Johannes Hölzl
+-/
+import Mathlib.Data.Set.Lattice
+import Mathlib.Order.Preorder.Chain
+
+/-!
+# Hausdorff's maximality principle
+
+This file proves Hausdorff's maximality principle.
+
+## Main declarations
+
+* `maxChain_spec`: Hausdorff's Maximality Principle.
+
+## Notes
+
+Originally ported from Isabelle/HOL. The
+[original file](https://isabelle.in.tum.de/dist/library/HOL/HOL/Zorn.html) was written by Jacques D.
+Fleuriot, Tobias Nipkow, Christian Sternagel.
+-/
+
+open Set
+
+variable {α : Type*} {r : α → α → Prop} {c c₁ c₂ s t : Set α} {a b x y : α}
+
+/-- Predicate for whether a set is reachable from `∅` using `SuccChain` and `⋃₀`. -/
+inductive ChainClosure (r : α → α → Prop) : Set α → Prop
+  | succ : ∀ {s}, ChainClosure r s → ChainClosure r (SuccChain r s)
+  | union : ∀ {s}, (∀ a ∈ s, ChainClosure r a) → ChainClosure r (⋃₀s)
+
+/-- An explicit maximal chain. `maxChain` is taken to be the union of all sets in `ChainClosure`. -/
+def maxChain (r : α → α → Prop) : Set α := ⋃₀ setOf (ChainClosure r)
+
+lemma chainClosure_empty : ChainClosure r ∅ := by
+  have : ChainClosure r (⋃₀∅) := ChainClosure.union fun a h => (not_mem_empty _ h).elim
+  simpa using this
+
+lemma chainClosure_maxChain : ChainClosure r (maxChain r) :=
+  ChainClosure.union fun _ => id
+
+private lemma chainClosure_succ_total_aux (hc₁ : ChainClosure r c₁)
+    (h : ∀ ⦃c₃⦄, ChainClosure r c₃ → c₃ ⊆ c₂ → c₂ = c₃ ∨ SuccChain r c₃ ⊆ c₂) :
+    SuccChain r c₂ ⊆ c₁ ∨ c₁ ⊆ c₂ := by
+  induction hc₁ with
+  | @succ c₃ hc₃ ih =>
+    obtain ih | ih := ih
+    · exact Or.inl (ih.trans subset_succChain)
+    · exact (h hc₃ ih).imp_left fun (h : c₂ = c₃) => h ▸ Subset.rfl
+  | union _ ih =>
+    refine or_iff_not_imp_left.2 fun hn => sUnion_subset fun a ha => ?_
+    exact (ih a ha).resolve_left fun h => hn <| h.trans <| subset_sUnion_of_mem ha
+
+private lemma chainClosure_succ_total (hc₁ : ChainClosure r c₁) (hc₂ : ChainClosure r c₂)
+    (h : c₁ ⊆ c₂) : c₂ = c₁ ∨ SuccChain r c₁ ⊆ c₂ := by
+  induction hc₂ generalizing c₁ hc₁ with
+  | succ _ ih =>
+    refine ((chainClosure_succ_total_aux hc₁) fun c₁ => ih).imp h.antisymm' fun h₁ => ?_
+    obtain rfl | h₂ := ih hc₁ h₁
+    · exact Subset.rfl
+    · exact h₂.trans subset_succChain
+  | union _ ih =>
+    apply Or.imp_left h.antisymm'
+    apply by_contradiction
+    simp only [sUnion_subset_iff, not_or, not_forall, exists_prop, and_imp, forall_exists_index]
+    intro c₃ hc₃ h₁ h₂
+    obtain h | h := chainClosure_succ_total_aux hc₁ fun c₄ => ih _ hc₃
+    · exact h₁ (subset_succChain.trans h)
+    obtain h' | h' := ih c₃ hc₃ hc₁ h
+    · exact h₁ h'.subset
+    · exact h₂ (h'.trans <| subset_sUnion_of_mem hc₃)
+
+lemma ChainClosure.total (hc₁ : ChainClosure r c₁) (hc₂ : ChainClosure r c₂) :
+    c₁ ⊆ c₂ ∨ c₂ ⊆ c₁ :=
+  ((chainClosure_succ_total_aux hc₂) fun _ hc₃ => chainClosure_succ_total hc₃ hc₁).imp_left
+    subset_succChain.trans
+
+lemma ChainClosure.succ_fixpoint (hc₁ : ChainClosure r c₁) (hc₂ : ChainClosure r c₂)
+    (hc : SuccChain r c₂ = c₂) : c₁ ⊆ c₂ := by
+  induction hc₁ with
+  | succ hc₁ h => exact (chainClosure_succ_total hc₁ hc₂ h).elim (fun h => h ▸ hc.subset) id
+  | union _ ih => exact sUnion_subset ih
+
+lemma ChainClosure.succ_fixpoint_iff (hc : ChainClosure r c) :
+    SuccChain r c = c ↔ c = maxChain r :=
+  ⟨fun h => (subset_sUnion_of_mem hc).antisymm <| chainClosure_maxChain.succ_fixpoint hc h,
+    fun h => subset_succChain.antisymm' <| (subset_sUnion_of_mem hc.succ).trans h.symm.subset⟩
+
+lemma ChainClosure.isChain (hc : ChainClosure r c) : IsChain r c := by
+  induction hc with
+  | succ _ h => exact h.succ
+  | union hs h =>
+    exact fun c₁ ⟨t₁, ht₁, (hc₁ : c₁ ∈ t₁)⟩ c₂ ⟨t₂, ht₂, (hc₂ : c₂ ∈ t₂)⟩ hneq =>
+      ((hs _ ht₁).total <| hs _ ht₂).elim (fun ht => h t₂ ht₂ (ht hc₁) hc₂ hneq) fun ht =>
+        h t₁ ht₁ hc₁ (ht hc₂) hneq
+
+/-- **Hausdorff's maximality principle**
+
+There exists a maximal totally ordered set of `α`.
+Note that we do not require `α` to be partially ordered by `r`. -/
+theorem maxChain_spec : IsMaxChain r (maxChain r) :=
+  by_contradiction fun h =>
+    let ⟨_, H⟩ := chainClosure_maxChain.isChain.superChain_succChain h
+    H.ne (chainClosure_maxChain.succ_fixpoint_iff.mpr rfl).symm

--- a/Mathlib/Order/Minimal.lean
+++ b/Mathlib/Order/Minimal.lean
@@ -4,8 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies, Peter Nelson
 -/
 import Mathlib.Order.Antichain
-import Mathlib.Order.Interval.Set.Basic
-import Mathlib.Order.UpperLower.Closure
 
 /-!
 # Minimality and Maximality
@@ -38,6 +36,8 @@ but it may be worth re-examining this to make it easier in the future; see the T
 * API to allow for easily expressing min/maximality with respect to an arbitrary non-`LE` relation.
 
 -/
+
+assert_not_exists CompleteLattice
 
 open Set OrderDual
 
@@ -406,18 +406,6 @@ theorem setOf_maximal_antichain (P : α → Prop) : IsAntichain (· ≤ ·) {x |
 
 theorem setOf_minimal_antichain (P : α → Prop) : IsAntichain (· ≤ ·) {x | Minimal P x} :=
   (setOf_maximal_antichain (α := αᵒᵈ) P).swap
-
-theorem IsAntichain.minimal_mem_upperClosure_iff_mem (hs : IsAntichain (· ≤ ·) s) :
-    Minimal (· ∈ upperClosure s) x ↔ x ∈ s := by
-  simp only [upperClosure, UpperSet.mem_mk, mem_setOf_eq]
-  refine ⟨fun h ↦ ?_, fun h ↦ ⟨⟨x, h, rfl.le⟩, fun b ⟨a, has, hab⟩ hbx ↦ ?_⟩⟩
-  · obtain ⟨a, has, hax⟩ := h.prop
-    rwa [h.eq_of_ge ⟨a, has, rfl.le⟩ hax]
-  rwa [← hs.eq has h (hab.trans hbx)]
-
-theorem IsAntichain.maximal_mem_lowerClosure_iff_mem (hs : IsAntichain (· ≤ ·) s) :
-    Maximal (· ∈ lowerClosure s) x ↔ x ∈ s :=
-  hs.to_dual.minimal_mem_upperClosure_iff_mem
 
 theorem IsLeast.minimal_iff (h : IsLeast s a) : Minimal (· ∈ s) x ↔ x = a :=
   ⟨fun h' ↦ h'.eq_of_ge h.1 (h.2 h'.prop), fun h' ↦ h' ▸ h.minimal⟩

--- a/Mathlib/Order/OmegaCompletePartialOrder.lean
+++ b/Mathlib/Order/OmegaCompletePartialOrder.lean
@@ -5,9 +5,10 @@ Authors: Simon Hudon, Ira Fesefeldt
 -/
 import Mathlib.Control.Monad.Basic
 import Mathlib.Dynamics.FixedPoints.Basic
-import Mathlib.Order.CompleteLattice.Chain
+import Mathlib.Order.CompleteLattice.Basic
 import Mathlib.Order.Iterate
 import Mathlib.Order.Part
+import Mathlib.Order.Preorder.Chain
 import Mathlib.Order.ScottContinuity
 
 /-!

--- a/Mathlib/Order/OmegaCompletePartialOrder.lean
+++ b/Mathlib/Order/OmegaCompletePartialOrder.lean
@@ -5,7 +5,7 @@ Authors: Simon Hudon, Ira Fesefeldt
 -/
 import Mathlib.Control.Monad.Basic
 import Mathlib.Dynamics.FixedPoints.Basic
-import Mathlib.Order.Chain
+import Mathlib.Order.CompleteLattice.Chain
 import Mathlib.Order.Iterate
 import Mathlib.Order.Part
 import Mathlib.Order.ScottContinuity

--- a/Mathlib/Order/Preorder/Chain.lean
+++ b/Mathlib/Order/Preorder/Chain.lean
@@ -4,19 +4,19 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl
 -/
 import Mathlib.Data.Set.Pairwise.Basic
-import Mathlib.Data.Set.Lattice
 import Mathlib.Data.SetLike.Basic
+import Mathlib.Order.Directed
+import Mathlib.Order.Hom.Set
+import Mathlib.Tactic.MinImports
 
 /-!
 # Chains and flags
 
-This file defines chains for an arbitrary relation and flags for an order and proves Hausdorff's
-Maximality Principle.
+This file defines chains for an arbitrary relation and flags for an order.
 
 ## Main declarations
 
 * `IsChain s`: A chain `s` is a set of comparable elements.
-* `maxChain_spec`: Hausdorff's Maximality Principle.
 * `Flag`: The type of flags, aka maximal chains, of an order.
 
 ## Notes
@@ -25,6 +25,8 @@ Originally ported from Isabelle/HOL. The
 [original file](https://isabelle.in.tum.de/dist/library/HOL/HOL/Zorn.html) was written by Jacques D.
 Fleuriot, Tobias Nipkow, Christian Sternagel.
 -/
+
+assert_not_exists CompleteLattice
 
 open Set
 
@@ -205,87 +207,6 @@ theorem subset_succChain : s ⊆ SuccChain r s :=
   else by
     rw [exists_and_left] at h
     simp [SuccChain, dif_neg, h, Subset.rfl]
-
-/-- Predicate for whether a set is reachable from `∅` using `SuccChain` and `⋃₀`. -/
-inductive ChainClosure (r : α → α → Prop) : Set α → Prop
-  | succ : ∀ {s}, ChainClosure r s → ChainClosure r (SuccChain r s)
-  | union : ∀ {s}, (∀ a ∈ s, ChainClosure r a) → ChainClosure r (⋃₀s)
-
-/-- An explicit maximal chain. `maxChain` is taken to be the union of all sets in `ChainClosure`.
--/
-def maxChain (r : α → α → Prop) : Set α :=
-  ⋃₀ setOf (ChainClosure r)
-
-theorem chainClosure_empty : ChainClosure r ∅ := by
-  have : ChainClosure r (⋃₀∅) := ChainClosure.union fun a h => (not_mem_empty _ h).elim
-  simpa using this
-
-theorem chainClosure_maxChain : ChainClosure r (maxChain r) :=
-  ChainClosure.union fun _ => id
-
-private theorem chainClosure_succ_total_aux (hc₁ : ChainClosure r c₁)
-    (h : ∀ ⦃c₃⦄, ChainClosure r c₃ → c₃ ⊆ c₂ → c₂ = c₃ ∨ SuccChain r c₃ ⊆ c₂) :
-    SuccChain r c₂ ⊆ c₁ ∨ c₁ ⊆ c₂ := by
-  induction hc₁ with
-  | @succ c₃ hc₃ ih =>
-    obtain ih | ih := ih
-    · exact Or.inl (ih.trans subset_succChain)
-    · exact (h hc₃ ih).imp_left fun (h : c₂ = c₃) => h ▸ Subset.rfl
-  | union _ ih =>
-    refine or_iff_not_imp_left.2 fun hn => sUnion_subset fun a ha => ?_
-    exact (ih a ha).resolve_left fun h => hn <| h.trans <| subset_sUnion_of_mem ha
-
-private theorem chainClosure_succ_total (hc₁ : ChainClosure r c₁) (hc₂ : ChainClosure r c₂)
-    (h : c₁ ⊆ c₂) : c₂ = c₁ ∨ SuccChain r c₁ ⊆ c₂ := by
-  induction hc₂ generalizing c₁ hc₁ with
-  | succ _ ih =>
-    refine ((chainClosure_succ_total_aux hc₁) fun c₁ => ih).imp h.antisymm' fun h₁ => ?_
-    obtain rfl | h₂ := ih hc₁ h₁
-    · exact Subset.rfl
-    · exact h₂.trans subset_succChain
-  | union _ ih =>
-    apply Or.imp_left h.antisymm'
-    apply by_contradiction
-    simp only [sUnion_subset_iff, not_or, not_forall, exists_prop, and_imp, forall_exists_index]
-    intro c₃ hc₃ h₁ h₂
-    obtain h | h := chainClosure_succ_total_aux hc₁ fun c₄ => ih _ hc₃
-    · exact h₁ (subset_succChain.trans h)
-    obtain h' | h' := ih c₃ hc₃ hc₁ h
-    · exact h₁ h'.subset
-    · exact h₂ (h'.trans <| subset_sUnion_of_mem hc₃)
-
-theorem ChainClosure.total (hc₁ : ChainClosure r c₁) (hc₂ : ChainClosure r c₂) :
-    c₁ ⊆ c₂ ∨ c₂ ⊆ c₁ :=
-  ((chainClosure_succ_total_aux hc₂) fun _ hc₃ => chainClosure_succ_total hc₃ hc₁).imp_left
-    subset_succChain.trans
-
-theorem ChainClosure.succ_fixpoint (hc₁ : ChainClosure r c₁) (hc₂ : ChainClosure r c₂)
-    (hc : SuccChain r c₂ = c₂) : c₁ ⊆ c₂ := by
-  induction hc₁ with
-  | succ hc₁ h => exact (chainClosure_succ_total hc₁ hc₂ h).elim (fun h => h ▸ hc.subset) id
-  | union _ ih => exact sUnion_subset ih
-
-theorem ChainClosure.succ_fixpoint_iff (hc : ChainClosure r c) :
-    SuccChain r c = c ↔ c = maxChain r :=
-  ⟨fun h => (subset_sUnion_of_mem hc).antisymm <| chainClosure_maxChain.succ_fixpoint hc h,
-    fun h => subset_succChain.antisymm' <| (subset_sUnion_of_mem hc.succ).trans h.symm.subset⟩
-
-theorem ChainClosure.isChain (hc : ChainClosure r c) : IsChain r c := by
-  induction hc with
-  | succ _ h => exact h.succ
-  | union hs h =>
-    exact fun c₁ ⟨t₁, ht₁, (hc₁ : c₁ ∈ t₁)⟩ c₂ ⟨t₂, ht₂, (hc₂ : c₂ ∈ t₂)⟩ hneq =>
-      ((hs _ ht₁).total <| hs _ ht₂).elim (fun ht => h t₂ ht₂ (ht hc₁) hc₂ hneq) fun ht =>
-        h t₁ ht₁ hc₁ (ht hc₂) hneq
-
-/-- **Hausdorff's maximality principle**
-
-There exists a maximal totally ordered set of `α`.
-Note that we do not require `α` to be partially ordered by `r`. -/
-theorem maxChain_spec : IsMaxChain r (maxChain r) :=
-  by_contradiction fun h =>
-    let ⟨_, H⟩ := chainClosure_maxChain.isChain.superChain_succChain h
-    H.ne (chainClosure_maxChain.succ_fixpoint_iff.mpr rfl).symm
 
 end Chain
 

--- a/Mathlib/Order/UpperLower/Closure.lean
+++ b/Mathlib/Order/UpperLower/Closure.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies, Sara Rousta
 -/
 import Mathlib.Order.Interval.Set.OrdConnected
+import Mathlib.Order.Minimal
 import Mathlib.Order.UpperLower.Principal
 
 /-!
@@ -23,8 +24,7 @@ open OrderDual Set
 
 variable {α β : Type*} {ι : Sort*}
 
-section closure
-
+section Preorder
 variable [Preorder α] [Preorder β] {s t : Set α} {x : α}
 
 /-- The greatest upper set containing a given set. -/
@@ -261,7 +261,24 @@ protected alias ⟨BddBelow.of_upperClosure, BddBelow.upperClosure⟩ := bddBelo
     ↑(lowerClosure s) = s ↔ IsLowerSet s :=
   @upperClosure_eq αᵒᵈ _ _
 
-end closure
+end Preorder
+
+section PartialOrder
+variable [PartialOrder α] {s : Set α} {x : α}
+
+lemma IsAntichain.minimal_mem_upperClosure_iff_mem (hs : IsAntichain (· ≤ ·) s) :
+    Minimal (· ∈ upperClosure s) x ↔ x ∈ s := by
+  simp only [upperClosure, UpperSet.mem_mk, mem_setOf_eq]
+  refine ⟨fun h ↦ ?_, fun h ↦ ⟨⟨x, h, rfl.le⟩, fun b ⟨a, has, hab⟩ hbx ↦ ?_⟩⟩
+  · obtain ⟨a, has, hax⟩ := h.prop
+    rwa [h.eq_of_ge ⟨a, has, rfl.le⟩ hax]
+  rwa [← hs.eq has h (hab.trans hbx)]
+
+lemma IsAntichain.maximal_mem_lowerClosure_iff_mem (hs : IsAntichain (· ≤ ·) s) :
+    Maximal (· ∈ lowerClosure s) x ↔ x ∈ s :=
+  hs.to_dual.minimal_mem_upperClosure_iff_mem
+
+end PartialOrder
 
 /-! ### Set Difference -/
 

--- a/Mathlib/Order/Zorn.lean
+++ b/Mathlib/Order/Zorn.lean
@@ -3,7 +3,7 @@ Copyright (c) 2017 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl
 -/
-import Mathlib.Order.Chain
+import Mathlib.Order.CompleteLattice.Chain
 import Mathlib.Order.Minimal
 
 /-!


### PR DESCRIPTION
Achieve this by:
* splitting `Order.Chain` into `Order.CompleteLattice.Chain` for the material requiring `CompleteLattice` and `Order.Preorder.Chain` for the rest.
* turning an import around between `Order.Minimal` and `Order.UpperLower.Closure`


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
