### PR TITLE
[Merged by Bors] - chore: rename `dmaSMul_apply` to `domSMul_apply`

### DIFF
--- a/Mathlib/MeasureTheory/Group/MeasurableEquiv.lean
+++ b/Mathlib/MeasureTheory/Group/MeasurableEquiv.lean
@@ -232,11 +232,13 @@ noncomputable instance : DistribMulAction Gᵈᵐᵃ (Measure A) where
   smul_add g μ ν := show (μ + ν).map _ = μ.map _ + ν.map _ by
     rw [Measure.map_add]; exact measurable_const_smul ..
 
-lemma dmaSMul_apply (μ : Measure A) (g : Gᵈᵐᵃ) (s : Set A) :
+lemma domSMul_apply (μ : Measure A) (g : Gᵈᵐᵃ) (s : Set A) :
     (g • μ) s = μ (DomMulAct.mk.symm g • s) := by
   refine ((MeasurableEquiv.smul ((DomMulAct.mk.symm g : G)⁻¹)).map_apply _).trans ?_
   congr 1
   exact Set.preimage_smul_inv (DomMulAct.mk.symm g) s
+
+@[deprecated (since := "2025-08-05")] alias dmaSMul_apply := domSMul_apply
 
 instance : SMulCommClass ℝ≥0 Gᵈᵐᵃ (Measure A) where
   smul_comm r g μ := show r • μ.map _ = (r • μ).map _ by simp

--- a/Mathlib/MeasureTheory/Measure/Haar/DistribChar.lean
+++ b/Mathlib/MeasureTheory/Measure/Haar/DistribChar.lean
@@ -77,7 +77,7 @@ variable [Regular μ] {s : Set A}
 
 variable (μ) in
 lemma distribHaarChar_mul (g : G) (s : Set A) : distribHaarChar A g * μ s = μ (g • s) := by
-  have : (DomMulAct.mk g • μ) s = μ (g • s) := by simp [dmaSMul_apply]
+  have : (DomMulAct.mk g • μ) s = μ (g • s) := by simp [domSMul_apply]
   rw [eq_comm, ← nnreal_smul_coe_apply, ← addHaarScalarFactor_smul_eq_distribHaarChar μ,
     ← this, ← smul_apply, ← isAddLeftInvariant_eq_smul_of_regular]
 


### PR DESCRIPTION
It's clearer this way, as the `ma` in `dmaSMul` already means "Multiplicative Action", ie `smul`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
