### PR TITLE
[Merged by Bors] - feat: typeclass for subgroups of finite relative index

### DIFF
--- a/Mathlib/GroupTheory/Complement.lean
+++ b/Mathlib/GroupTheory/Complement.lean
@@ -589,7 +589,7 @@ alias _root_.Subgroup.MemLeftTransversals.toEquiv := leftQuotientEquiv
 @[to_additive "A left transversal is finite iff the subgroup has finite index."]
 theorem finite_left_iff (h : IsComplement S H) : Finite S ↔ H.FiniteIndex := by
   rw [← h.leftQuotientEquiv.finite_iff]
-  exact ⟨fun _ ↦ finiteIndex_of_finite_quotient H, fun _ ↦ finite_quotient_of_finiteIndex H⟩
+  exact ⟨fun _ ↦ finiteIndex_of_finite_quotient, fun _ ↦ finite_quotient_of_finiteIndex⟩
 
 @[deprecated (since := "2024-12-28")]
 alias _root_.Subgroup.MemLeftTransversals.finite_iff := finite_left_iff
@@ -653,7 +653,7 @@ alias _root_.Subgroup.MemRightTransversals.toEquiv := rightQuotientEquiv
 theorem finite_right_iff (h : IsComplement H T) : Finite T ↔ H.FiniteIndex := by
   rw [← h.rightQuotientEquiv.finite_iff,
     (QuotientGroup.quotientRightRelEquivQuotientLeftRel H).finite_iff]
-  exact ⟨fun _ ↦ finiteIndex_of_finite_quotient H, fun _ ↦ finite_quotient_of_finiteIndex H⟩
+  exact ⟨fun _ ↦ finiteIndex_of_finite_quotient, fun _ ↦ finite_quotient_of_finiteIndex⟩
 
 @[deprecated (since := "2024-12-28")]
 alias _root_.Subgroup.MemRightTransversals.finite_iff := finite_right_iff

--- a/Mathlib/GroupTheory/CosetCover.lean
+++ b/Mathlib/GroupTheory/CosetCover.lean
@@ -374,7 +374,7 @@ theorem Subspace.biUnion_ne_univ_of_top_nmem (hs : ⊤ ∉ s) :
     ⋃ p ∈ s, (p : Set E) ≠ Set.univ := by
   intro hcovers
   have ⟨p, hp, hfi⟩ := Submodule.exists_finiteIndex_of_cover hcovers
-  have : Finite (E ⧸ p) := AddSubgroup.finite_quotient_of_finiteIndex _
+  have : Finite (E ⧸ p) := AddSubgroup.finite_quotient_of_finiteIndex
   have : Nontrivial (E ⧸ p) :=
     Submodule.Quotient.nontrivial_of_lt_top p (ne_of_mem_of_not_mem hp hs).lt_top
   have : Infinite (E ⧸ p) := Module.Free.infinite k (E ⧸ p)

--- a/Mathlib/GroupTheory/Index.lean
+++ b/Mathlib/GroupTheory/Index.lean
@@ -525,20 +525,20 @@ variable (H) in
 /-- Typeclass for a subgroup `H` to have finite index in a subgroup `K`. -/
 class _root_.AddSubgroup.IsFiniteRelIndex {G : Type*} [AddGroup G] (H K : AddSubgroup G) :
     Prop where
-  protected relIndex_ne_zero : H.relindex K ≠ 0
+  protected relindex_ne_zero  : H.relindex K ≠ 0
 
 variable (H K) in
 /-- Typeclass for a subgroup `H` to have finite index in a subgroup `K`. -/
 @[to_additive] class IsFiniteRelIndex : Prop where
-  protected relIndex_ne_zero : H.relindex K ≠ 0
+  protected relindex_ne_zero  : H.relindex K ≠ 0
 
-@[to_additive] lemma relIndex_ne_zero [H.IsFiniteRelIndex K] : H.relindex K ≠ 0 :=
-  IsFiniteRelIndex.relIndex_ne_zero
+@[to_additive] lemma relindex_ne_zero  [H.IsFiniteRelIndex K] : H.relindex K ≠ 0 :=
+  IsFiniteRelIndex.relindex_ne_zero
 
 @[to_additive]
 instance IsFiniteRelIndex.to_finiteIndex_subgroupOf [H.IsFiniteRelIndex K] :
     (H.subgroupOf K).FiniteIndex where
-  index_ne_zero := relIndex_ne_zero
+  index_ne_zero := relindex_ne_zero
 
 /-- A finite index subgroup has finite quotient. -/
 @[to_additive "A finite index subgroup has finite quotient"]

--- a/Mathlib/GroupTheory/Index.lean
+++ b/Mathlib/GroupTheory/Index.lean
@@ -504,14 +504,6 @@ lemma _root_.AddSubgroup.relindex_toSubgroup {G : Type*} [AddGroup G] (H K : Add
 
 section FiniteIndex
 
-variable (H K)
-
-/-- Typeclass for finite index subgroups. -/
-class FiniteIndex : Prop where
-  /-- The subgroup has finite index;
-  recall that `Subgroup.index` returns 0 when the index is infinite. -/
-  index_ne_zero : H.index ≠ 0
-
 /-- Typeclass for finite index subgroups. -/
 class _root_.AddSubgroup.FiniteIndex {G : Type*} [AddGroup G] (H : AddSubgroup G) : Prop where
   /-- The additive subgroup has finite index;
@@ -523,6 +515,31 @@ alias _root_AddSubgroup.FiniteIndex.finiteIndex := AddSubgroup.FiniteIndex.index
 
 @[deprecated (since := "2025-04-13")] alias FiniteIndex.finiteIndex := FiniteIndex.index_ne_zero
 
+variable (H) in
+/-- Typeclass for finite index subgroups. -/
+@[to_additive] class FiniteIndex : Prop where
+  /-- The subgroup has finite index;
+  recall that `Subgroup.index` returns 0 when the index is infinite. -/
+  index_ne_zero : H.index ≠ 0
+
+/-- Typeclass for a subgroup `H` to have finite index in a subgroup `K`. -/
+class _root_.AddSubgroup.IsFiniteRelIndex {G : Type*} [AddGroup G] (H K : AddSubgroup G) :
+    Prop where
+  protected relIndex_ne_zero : H.relindex K ≠ 0
+
+variable (H K) in
+/-- Typeclass for a subgroup `H` to have finite index in a subgroup `K`. -/
+@[to_additive] class IsFiniteRelIndex : Prop where
+  protected relIndex_ne_zero : H.relindex K ≠ 0
+
+@[to_additive] lemma relIndex_ne_zero [H.IsFiniteRelIndex K] : H.relindex K ≠ 0 :=
+  IsFiniteRelIndex.relIndex_ne_zero
+
+@[to_additive]
+instance IsFiniteRelIndex.to_finiteIndex_subgroupOf [H.IsFiniteRelIndex K] :
+    (H.subgroupOf K).FiniteIndex where
+  finiteIndex := relIndex_ne_zero
+
 /-- A finite index subgroup has finite quotient. -/
 @[to_additive "A finite index subgroup has finite quotient"]
 noncomputable def fintypeQuotientOfFiniteIndex [FiniteIndex H] : Fintype (G ⧸ H) :=
@@ -530,7 +547,7 @@ noncomputable def fintypeQuotientOfFiniteIndex [FiniteIndex H] : Fintype (G ⧸ 
 
 @[to_additive]
 instance finite_quotient_of_finiteIndex [FiniteIndex H] : Finite (G ⧸ H) :=
-  H.fintypeQuotientOfFiniteIndex.finite
+  fintypeQuotientOfFiniteIndex.finite
 
 @[to_additive]
 theorem finiteIndex_of_finite_quotient [Finite (G ⧸ H)] : FiniteIndex H :=
@@ -565,8 +582,6 @@ theorem finiteIndex_iInf' {ι : Type*} {s : Finset ι}
 instance instFiniteIndex_subgroupOf (H K : Subgroup G) [H.FiniteIndex] :
     (H.subgroupOf K).FiniteIndex :=
   ⟨fun h => H.index_ne_zero_of_finite <| H.index_eq_zero_of_relindex_eq_zero h⟩
-
-variable {H K}
 
 @[to_additive]
 theorem finiteIndex_of_le [FiniteIndex H] (h : H ≤ K) : FiniteIndex K :=

--- a/Mathlib/GroupTheory/Index.lean
+++ b/Mathlib/GroupTheory/Index.lean
@@ -513,14 +513,14 @@ class _root_.AddSubgroup.FiniteIndex {G : Type*} [AddGroup G] (H : AddSubgroup G
 @[deprecated (since := "2025-04-13")]
 alias _root_AddSubgroup.FiniteIndex.finiteIndex := AddSubgroup.FiniteIndex.index_ne_zero
 
-@[deprecated (since := "2025-04-13")] alias FiniteIndex.finiteIndex := FiniteIndex.index_ne_zero
-
 variable (H) in
 /-- Typeclass for finite index subgroups. -/
 @[to_additive] class FiniteIndex : Prop where
   /-- The subgroup has finite index;
   recall that `Subgroup.index` returns 0 when the index is infinite. -/
   index_ne_zero : H.index ≠ 0
+
+@[deprecated (since := "2025-04-13")] alias FiniteIndex.finiteIndex := FiniteIndex.index_ne_zero
 
 /-- Typeclass for a subgroup `H` to have finite index in a subgroup `K`. -/
 class _root_.AddSubgroup.IsFiniteRelIndex {G : Type*} [AddGroup G] (H K : AddSubgroup G) :
@@ -538,7 +538,7 @@ variable (H K) in
 @[to_additive]
 instance IsFiniteRelIndex.to_finiteIndex_subgroupOf [H.IsFiniteRelIndex K] :
     (H.subgroupOf K).FiniteIndex where
-  finiteIndex := relIndex_ne_zero
+  index_ne_zero := relIndex_ne_zero
 
 /-- A finite index subgroup has finite quotient. -/
 @[to_additive "A finite index subgroup has finite quotient"]

--- a/Mathlib/GroupTheory/Index.lean
+++ b/Mathlib/GroupTheory/Index.lean
@@ -525,12 +525,12 @@ variable (H) in
 /-- Typeclass for a subgroup `H` to have finite index in a subgroup `K`. -/
 class _root_.AddSubgroup.IsFiniteRelIndex {G : Type*} [AddGroup G] (H K : AddSubgroup G) :
     Prop where
-  protected relindex_ne_zero  : H.relindex K ≠ 0
+  protected relindex_ne_zero : H.relindex K ≠ 0
 
 variable (H K) in
 /-- Typeclass for a subgroup `H` to have finite index in a subgroup `K`. -/
 @[to_additive] class IsFiniteRelIndex : Prop where
-  protected relindex_ne_zero  : H.relindex K ≠ 0
+  protected relindex_ne_zero : H.relindex K ≠ 0
 
 @[to_additive] lemma relindex_ne_zero  [H.IsFiniteRelIndex K] : H.relindex K ≠ 0 :=
   IsFiniteRelIndex.relindex_ne_zero


### PR DESCRIPTION
This is useful to state the following:

https://github.com/ImperialCollegeLondon/FLT/blob/c51f2573c22ded973f354f56f598507b0f349f51/FLT/Mathlib/MeasureTheory/Group/Action.lean#L57-L59

namely that the Haar measure of a subgroup `H` of finite index inside a subgroup `K` is the Haar measure of `K` divided by the index.

A possible alternative would be to have some `ENat`-valued index.

From FLT


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
