### PR TITLE
perf(Quiver.Basic): make `IsThin` a `class` 

### DIFF
--- a/Mathlib/CategoryTheory/Bicategory/Coherence.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Coherence.lean
@@ -214,9 +214,9 @@ def normalizeEquiv (a b : B) : Hom a b ≌ Discrete (Path.{v + 1} a b) :=
         rfl))
 
 /-- The coherence theorem for bicategories. -/
-instance locally_thin {a b : FreeBicategory B} : Quiver.IsThin (a ⟶ b) := fun _ _ =>
+instance locally_thin {a b : FreeBicategory B} : Quiver.IsThin (a ⟶ b) := ⟨fun _ _ =>
   ⟨fun _ _ =>
-    (@normalizeEquiv B _ a b).functor.map_injective (Subsingleton.elim _ _)⟩
+    (@normalizeEquiv B _ a b).functor.map_injective (Subsingleton.elim _ _)⟩⟩
 
 /-- Auxiliary definition for `inclusion`. -/
 def inclusionMapCompAux {a b : B} :

--- a/Mathlib/CategoryTheory/Category/Basic.lean
+++ b/Mathlib/CategoryTheory/Category/Basic.lean
@@ -330,6 +330,10 @@ section
 
 variable [Quiver.IsThin C] (f : X ⟶ Y)
 
+-- We turn this on in the `CategoryTheory` namespace
+scoped instance {C : Type*} {X Y : C} [CategoryStruct C] [Quiver.IsThin C] :
+    Subsingleton (X ⟶ Y) := Quiver.IsThin.subsingleton_hom ..
+
 instance : Mono f where
   right_cancellation _ _ _ := Subsingleton.elim _ _
 

--- a/Mathlib/CategoryTheory/Category/Basic.lean
+++ b/Mathlib/CategoryTheory/Category/Basic.lean
@@ -330,10 +330,6 @@ section
 
 variable [Quiver.IsThin C] (f : X ⟶ Y)
 
--- We turn this on in the `CategoryTheory` namespace
-scoped instance {C : Type*} {X Y : C} [CategoryStruct C] [Quiver.IsThin C] :
-    Subsingleton (X ⟶ Y) := Quiver.IsThin.subsingleton_hom ..
-
 instance : Mono f where
   right_cancellation _ _ _ := Subsingleton.elim _ _
 

--- a/Mathlib/CategoryTheory/Category/Preorder.lean
+++ b/Mathlib/CategoryTheory/Category/Preorder.lean
@@ -50,7 +50,7 @@ instance subsingleton_hom {α : Type u} [Preorder α] (U V : α) :
   Subsingleton (U ⟶ V) := ⟨fun _ _ => ULift.ext _ _ (Subsingleton.elim _ _ )⟩
 
 instance instIsThin {α : Type u} [Preorder α] : Quiver.IsThin α where
-  subsingleton_hom _ _ := inferInstance
+  thin _ _ := inferInstance
 
 end Preorder
 

--- a/Mathlib/CategoryTheory/Category/Preorder.lean
+++ b/Mathlib/CategoryTheory/Category/Preorder.lean
@@ -49,6 +49,9 @@ instance (priority := 100) smallCategory (α : Type u) [Preorder α] : SmallCate
 instance subsingleton_hom {α : Type u} [Preorder α] (U V : α) :
   Subsingleton (U ⟶ V) := ⟨fun _ _ => ULift.ext _ _ (Subsingleton.elim _ _ )⟩
 
+instance instIsThin {α : Type u} [Preorder α] : Quiver.IsThin α where
+  thin _ _ := inferInstance
+
 end Preorder
 
 namespace CategoryTheory

--- a/Mathlib/CategoryTheory/Category/Preorder.lean
+++ b/Mathlib/CategoryTheory/Category/Preorder.lean
@@ -50,7 +50,7 @@ instance subsingleton_hom {α : Type u} [Preorder α] (U V : α) :
   Subsingleton (U ⟶ V) := ⟨fun _ _ => ULift.ext _ _ (Subsingleton.elim _ _ )⟩
 
 instance instIsThin {α : Type u} [Preorder α] : Quiver.IsThin α where
-  thin _ _ := inferInstance
+  subsingleton_hom _ _ := inferInstance
 
 end Preorder
 

--- a/Mathlib/CategoryTheory/Generator/Basic.lean
+++ b/Mathlib/CategoryTheory/Generator/Basic.lean
@@ -237,14 +237,14 @@ end Mono
 
 section Empty
 
-theorem thin_of_isSeparating_empty (h : IsSeparating (∅ : Set C)) : Quiver.IsThin C := fun _ _ =>
-  ⟨fun _ _ => h _ _ fun _ => False.elim⟩
+theorem thin_of_isSeparating_empty (h : IsSeparating (∅ : Set C)) : Quiver.IsThin C :=
+  ⟨fun _ _ => ⟨fun _ _ => h _ _ fun _ => False.elim⟩⟩
 
 theorem isSeparating_empty_of_thin [Quiver.IsThin C] : IsSeparating (∅ : Set C) :=
   fun _ _ _ _ _ => Subsingleton.elim _ _
 
 theorem thin_of_isCoseparating_empty (h : IsCoseparating (∅ : Set C)) : Quiver.IsThin C :=
-  fun _ _ => ⟨fun _ _ => h _ _ fun _ => False.elim⟩
+  ⟨fun _ _ => ⟨fun _ _ => h _ _ fun _ => False.elim⟩⟩
 
 theorem isCoseparating_empty_of_thin [Quiver.IsThin C] : IsCoseparating (∅ : Set C) :=
   fun _ _ _ _ _ => Subsingleton.elim _ _

--- a/Mathlib/CategoryTheory/Groupoid/Basic.lean
+++ b/Mathlib/CategoryTheory/Groupoid/Basic.lean
@@ -19,7 +19,7 @@ variable (C : Type*) [Groupoid C]
 section Thin
 
 theorem isThin_iff : Quiver.IsThin C ↔ ∀ c : C, Subsingleton (c ⟶ c) := by
-  refine ⟨fun h c => h c c, fun h c d => Subsingleton.intro fun f g => ?_⟩
+  refine ⟨fun h c => h.1 c c, fun h => ⟨fun c d => Subsingleton.intro fun f g => ?_⟩⟩
   haveI := h d
   calc
     f = f ≫ inv g ≫ g := by simp only [inv_eq_inv, IsIso.inv_hom_id, Category.comp_id]

--- a/Mathlib/CategoryTheory/Limits/Shapes/WidePullbacks.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/WidePullbacks.lean
@@ -84,13 +84,13 @@ def evalCasesBash : TacticM Unit := do
 
 attribute [local aesop safe tactic (rule_sets := [CategoryTheory])] evalCasesBash
 
-instance subsingleton_hom : Quiver.IsThin (WidePullbackShape J) := fun _ _ => by
+instance subsingleton_hom : Quiver.IsThin (WidePullbackShape J) := ⟨fun _ _ => by
   constructor
   intro a b
   casesm* WidePullbackShape _, (_ : WidePullbackShape _) ⟶ (_ : WidePullbackShape _)
   · rfl
   · rfl
-  · rfl
+  · rfl⟩
 
 instance category : SmallCategory (WidePullbackShape J) :=
   thin_category
@@ -184,11 +184,11 @@ def evalCasesBash' : TacticM Unit := do
 
 attribute [local aesop safe tactic (rule_sets := [CategoryTheory])] evalCasesBash'
 
-instance subsingleton_hom : Quiver.IsThin (WidePushoutShape J) := fun _ _ => by
+instance subsingleton_hom : Quiver.IsThin (WidePushoutShape J) := ⟨fun _ _ => by
   constructor
   intro a b
   casesm* WidePushoutShape _, (_ : WidePushoutShape _) ⟶ (_ : WidePushoutShape _)
-  repeat rfl
+  repeat rfl⟩
 
 instance category : SmallCategory (WidePushoutShape J) :=
   thin_category

--- a/Mathlib/CategoryTheory/Limits/SmallComplete.lean
+++ b/Mathlib/CategoryTheory/Limits/SmallComplete.lean
@@ -41,7 +41,7 @@ in Lean, a preorder category is one where the morphisms are in Prop, which is we
 notion of a preorder/thin category which says that each homset is subsingleton; we show the latter
 rather than providing a `Preorder C` instance.
 -/
-instance (priority := 100) : Quiver.IsThin C := fun X Y =>
+instance (priority := 100) : Quiver.IsThin C := ⟨fun X Y =>
   ⟨fun r s => by
     classical
       by_contra r_ne_s
@@ -70,6 +70,6 @@ instance (priority := 100) : Quiver.IsThin C := fun X Y =>
           exact ⟨_, _, f⟩
         · rintro f g k
           cases k
-          rfl⟩
+          rfl⟩⟩
 
 end CategoryTheory

--- a/Mathlib/CategoryTheory/Monoidal/Free/Coherence.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Free/Coherence.lean
@@ -294,12 +294,12 @@ def fullNormalizeIso : 𝟭 (F C) ≅ fullNormalize C ⋙ inclusion :=
 end
 
 /-- The monoidal coherence theorem. -/
-instance subsingleton_hom : Quiver.IsThin (F C) := fun X Y =>
+instance subsingleton_hom : Quiver.IsThin (F C) := ⟨fun X Y =>
   ⟨fun f g => by
     have hfg : (fullNormalize C).map f = (fullNormalize C).map g := Subsingleton.elim _ _
     have hf := NatIso.naturality_2 (fullNormalizeIso.{u} C) f
     have hg := NatIso.naturality_2 (fullNormalizeIso.{u} C) g
-    exact hf.symm.trans (Eq.trans (by simp only [Functor.comp_map, hfg]) hg)⟩
+    exact hf.symm.trans (Eq.trans (by simp only [Functor.comp_map, hfg]) hg)⟩⟩
 
 section Groupoid
 

--- a/Mathlib/CategoryTheory/Skeletal.lean
+++ b/Mathlib/CategoryTheory/Skeletal.lean
@@ -189,10 +189,10 @@ some of the statements can be shown without this assumption.
 namespace ThinSkeleton
 
 /-- The thin skeleton is thin. -/
-instance thin : Quiver.IsThin (ThinSkeleton C) := fun _ _ =>
+instance thin : Quiver.IsThin (ThinSkeleton C) := ⟨fun _ _ =>
   ⟨by
     rintro ⟨⟨f₁⟩⟩ ⟨⟨_⟩⟩
-    rfl⟩
+    rfl⟩⟩
 
 variable {C} {D}
 

--- a/Mathlib/CategoryTheory/Subobject/MonoOver.lean
+++ b/Mathlib/CategoryTheory/Subobject/MonoOver.lean
@@ -108,13 +108,13 @@ instance mono (f : MonoOver X) : Mono f.arrow :=
 
 /-- The category of monomorphisms over X is a thin category,
 which makes defining its skeleton easy. -/
-instance isThin {X : C} : Quiver.IsThin (MonoOver X) := fun f g =>
+instance isThin {X : C} : Quiver.IsThin (MonoOver X) := ⟨fun f g =>
   ⟨by
     intro h₁ h₂
     apply Over.OverMorphism.ext
     rw [← cancel_mono g.arrow]
     erw [Over.w h₁]
-    erw [Over.w h₂]⟩
+    erw [Over.w h₂]⟩⟩
 
 @[reassoc]
 theorem w {f g : MonoOver X} (k : f ⟶ g) : k.left ≫ g.arrow = f.arrow :=

--- a/Mathlib/CategoryTheory/Thin.lean
+++ b/Mathlib/CategoryTheory/Thin.lean
@@ -43,8 +43,8 @@ variable [Category.{v₁} C] {D : Type u₂} [Category.{v₂} D]
 variable [Quiver.IsThin C]
 
 /-- If `C` is a thin category, then `D ⥤ C` is a thin category. -/
-instance functor_thin : Quiver.IsThin (D ⥤ C) := fun _ _ =>
-  ⟨fun α β => NatTrans.ext (by subsingleton)⟩
+instance functor_thin : Quiver.IsThin (D ⥤ C) := ⟨fun _ _ =>
+  ⟨fun α β => NatTrans.ext (by subsingleton)⟩⟩
 
 /-- To show `X ≅ Y` in a thin category, it suffices to just give any morphism in each direction. -/
 def iso_of_both_ways {X Y : C} (f : X ⟶ Y) (g : Y ⟶ X) :

--- a/Mathlib/Combinatorics/Quiver/Basic.lean
+++ b/Mathlib/Combinatorics/Quiver/Basic.lean
@@ -77,8 +77,11 @@ instance emptyQuiver (V : Type u) : Quiver.{u} (Empty V) := ⟨fun _ _ => PEmpty
 theorem empty_arrow {V : Type u} (a b : Empty V) : (a ⟶ b) = PEmpty := rfl
 
 /-- A quiver is thin if it has no parallel arrows. -/
-abbrev IsThin (V : Type u) [Quiver V] : Prop := ∀ a b : V, Subsingleton (a ⟶ b)
+class IsThin (V : Type u) [Quiver V] : Prop where
+  /-- For any two vertices `a` and `b`, there is at most one arrow from `a` to `b`. -/
+  thin : ∀ a b : V, Subsingleton (a ⟶ b)
 
+attribute [instance 10] IsThin.thin
 
 section
 

--- a/Mathlib/Combinatorics/Quiver/Basic.lean
+++ b/Mathlib/Combinatorics/Quiver/Basic.lean
@@ -79,7 +79,9 @@ theorem empty_arrow {V : Type u} (a b : Empty V) : (a ⟶ b) = PEmpty := rfl
 /-- A quiver is thin if it has no parallel arrows. -/
 class IsThin (V : Type u) [Quiver V] : Prop where
   /-- For any two vertices `a` and `b`, there is at most one arrow from `a` to `b`. -/
-  subsingleton_hom : ∀ a b : V, Subsingleton (a ⟶ b)
+  thin : ∀ a b : V, Subsingleton (a ⟶ b)
+
+attribute [instance 10] IsThin.thin
 
 section
 

--- a/Mathlib/Combinatorics/Quiver/Basic.lean
+++ b/Mathlib/Combinatorics/Quiver/Basic.lean
@@ -79,9 +79,7 @@ theorem empty_arrow {V : Type u} (a b : Empty V) : (a ⟶ b) = PEmpty := rfl
 /-- A quiver is thin if it has no parallel arrows. -/
 class IsThin (V : Type u) [Quiver V] : Prop where
   /-- For any two vertices `a` and `b`, there is at most one arrow from `a` to `b`. -/
-  thin : ∀ a b : V, Subsingleton (a ⟶ b)
-
-attribute [instance 10] IsThin.thin
+  subsingleton_hom : ∀ a b : V, Subsingleton (a ⟶ b)
 
 section
 


### PR DESCRIPTION
It seems problematic that `Quiver.IsThin` is an `abbrev` for (essentially) `Subsingleton`. We turn it in a one-field class.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
