### PR TITLE
[Merged by Bors] - feat: distributive Haar characters

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4263,6 +4263,7 @@ import Mathlib.MeasureTheory.Measure.FiniteMeasureProd
 import Mathlib.MeasureTheory.Measure.GiryMonad
 import Mathlib.MeasureTheory.Measure.Haar.Basic
 import Mathlib.MeasureTheory.Measure.Haar.Disintegration
+import Mathlib.MeasureTheory.Measure.Haar.DistribChar
 import Mathlib.MeasureTheory.Measure.Haar.InnerProductSpace
 import Mathlib.MeasureTheory.Measure.Haar.NormedSpace
 import Mathlib.MeasureTheory.Measure.Haar.OfBasis

--- a/Mathlib/MeasureTheory/Measure/Haar/DistribChar.lean
+++ b/Mathlib/MeasureTheory/Measure/Haar/DistribChar.lean
@@ -18,6 +18,9 @@ and `distribHaarChar` is a group homomorphism.
 
 ## See also
 
+`MeasureTheory.Measure.modularCharacter` for the analogous definition when the action is
+multiplicative instead of distributive.
+
 [Zulip](https://leanprover.zulipchat.com/#narrow/channel/217875-Is-there-code-for-X.3F/topic/canonical.20norm.20coming.20from.20Haar.20measure/near/480050592)
 -/
 

--- a/Mathlib/MeasureTheory/Measure/Haar/DistribChar.lean
+++ b/Mathlib/MeasureTheory/Measure/Haar/DistribChar.lean
@@ -38,7 +38,7 @@ measures `μ : Measure A`, set `s : Set A` and `g : G`. -/
 @[simps -isSimp]
 noncomputable def distribHaarChar : G →* ℝ≥0 :=
   letI := borel A
-  have : BorelSpace A := ⟨rfl⟩
+  haveI : BorelSpace A := ⟨rfl⟩
   {
     toFun g := addHaarScalarFactor (DomMulAct.mk g • addHaar) (addHaar (G := A))
     map_one' := by simp

--- a/Mathlib/MeasureTheory/Measure/Haar/DistribChar.lean
+++ b/Mathlib/MeasureTheory/Measure/Haar/DistribChar.lean
@@ -58,8 +58,7 @@ variable [MeasurableSpace A] [BorelSpace A] {μ : Measure A} [μ.IsAddHaarMeasur
 variable (μ) in
 lemma addHaarScalarFactor_smul_eq_distribHaarChar (g : G) :
     addHaarScalarFactor (DomMulAct.mk g • μ) μ = distribHaarChar A g := by
-  obtain ⟨rfl⟩ := ‹BorelSpace A›
-  letI := borel A
+  borelize A
   exact addHaarScalarFactor_smul_congr' ..
 
 variable (μ) in

--- a/Mathlib/MeasureTheory/Measure/Haar/DistribChar.lean
+++ b/Mathlib/MeasureTheory/Measure/Haar/DistribChar.lean
@@ -1,0 +1,87 @@
+/-
+Copyright (c) 2024 Andrew Yang, Yaël Dillies, Javier López-Contreras. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Andrew Yang, Yaël Dillies, Javier López-Contreras
+-/
+import Mathlib.MeasureTheory.Measure.Haar.Unique
+
+/-!
+# The distributive character of Haar measures
+
+Given a group `G` acting by additive morphisms on a locally compact additive commutative group `A`,
+and an element `g : G`, one can pull back the Haar measure `μ` of `A`
+along the map `(g • ·) : A → A` to get another Haar measure `μ'` on `A`.
+By unicity of Haar measures, there exists some nonnegative real number `r` such that `μ' = r • μ`.
+We can thus define a map `distribHaarChar : G → ℝ≥0` sending `g` to its associated real number `r`.
+Furthermore, this number doesn't depend on the Haar measure `μ` we started with,
+and `distribHaarChar` is a group homomorphism.
+
+## See also
+
+[Zulip](https://leanprover.zulipchat.com/#narrow/channel/217875-Is-there-code-for-X.3F/topic/canonical.20norm.20coming.20from.20Haar.20measure/near/480050592)
+-/
+
+open MeasureTheory.Measure
+open scoped NNReal Pointwise ENNReal
+
+namespace MeasureTheory
+variable {G A : Type*} [Group G] [AddCommGroup A] [DistribMulAction G A] [MeasurableSpace A]
+  -- We only need `MeasurableConstSMul G A` but we don't have this class. So we erroneously must
+  -- assume `MeasurableSpace G` + `MeasurableSMul G A`
+  [MeasurableSpace G] [MeasurableSMul G A] [TopologicalSpace A] [BorelSpace A]
+  [IsTopologicalAddGroup A] [LocallyCompactSpace A] [ContinuousConstSMul G A] {μ ν : Measure A}
+  {g : G} [μ.IsAddHaarMeasure]
+
+variable (A) in
+/-- The distributive Haar character of a group `G` acting distributively on a group `A` is the
+unique positive real number `Δ(g)` such that `μ (g • s) = Δ(g) * μ s` for all Haar
+measures `μ : Measure A`, set `s : Set A` and `g : G`. -/
+@[simps -isSimp]
+noncomputable def distribHaarChar : G →* ℝ≥0 where
+  toFun g := addHaarScalarFactor (DomMulAct.mk g • addHaar) (addHaar (G := A))
+  map_one' := by simp
+  map_mul' g g' := by
+    simp_rw [DomMulAct.mk_mul]
+    rw [addHaarScalarFactor_eq_mul _ (DomMulAct.mk g' • addHaar (G := A))]
+    congr 1
+    simp_rw [mul_smul]
+    rw [addHaarScalarFactor_domSMul]
+
+variable (μ) in
+lemma addHaarScalarFactor_smul_eq_distribHaarChar (g : G) :
+    addHaarScalarFactor (DomMulAct.mk g • μ) μ = distribHaarChar A g :=
+  addHaarScalarFactor_smul_congr' ..
+
+variable (μ) in
+lemma addHaarScalarFactor_smul_inv_eq_distribHaarChar (g : G) :
+    addHaarScalarFactor μ ((DomMulAct.mk g)⁻¹ • μ) = distribHaarChar A g := by
+  rw [← addHaarScalarFactor_domSMul _ _ (DomMulAct.mk g)]
+  simp_rw [← mul_smul, mul_inv_cancel, one_smul]
+  exact addHaarScalarFactor_smul_eq_distribHaarChar ..
+
+variable (μ) in
+lemma addHaarScalarFactor_smul_eq_distribHaarChar_inv (g : G) :
+    addHaarScalarFactor μ (DomMulAct.mk g • μ) = (distribHaarChar A g)⁻¹ := by
+  rw [← map_inv, ← addHaarScalarFactor_smul_inv_eq_distribHaarChar μ, DomMulAct.mk_inv, inv_inv]
+
+lemma distribHaarChar_pos : 0 < distribHaarChar A g :=
+  pos_iff_ne_zero.mpr ((Group.isUnit g).map (distribHaarChar A)).ne_zero
+
+variable [Regular μ] {s : Set A}
+
+variable (μ) in
+lemma distribHaarChar_mul (g : G) (s : Set A) : distribHaarChar A g * μ s = μ (g • s) := by
+  have : (DomMulAct.mk g • μ) s = μ (g • s) := by simp [dmaSMul_apply]
+  rw [eq_comm, ← nnreal_smul_coe_apply, ← addHaarScalarFactor_smul_eq_distribHaarChar μ,
+    ← this, ← smul_apply, ← isAddLeftInvariant_eq_smul_of_regular]
+
+lemma distribHaarChar_eq_div (hs₀ : μ s ≠ 0) (hs : μ s ≠ ∞) (g : G) :
+    distribHaarChar A g = μ (g • s) / μ s := by
+  rw [← distribHaarChar_mul, ENNReal.mul_div_cancel_right] <;> simp [*]
+
+lemma distribHaarChar_eq_of_measure_smul_eq_mul (hs₀ : μ s ≠ 0) (hs : μ s ≠ ∞) {r : ℝ≥0}
+    (hμgs : μ (g • s) = r * μ s) : distribHaarChar A g = r := by
+  refine ENNReal.coe_injective ?_
+  rw [distribHaarChar_eq_div hs₀ hs, hμgs, ENNReal.mul_div_cancel_right] <;> simp [*]
+
+end MeasureTheory


### PR DESCRIPTION
The name is made up in analogy with modular characters.

From FLT

Co-authored-by: Andrew Yang <the.erd.one@gmail.com>
Co-authored-by: Javier López-Contreras <38789151+javierlcontreras@users.noreply.github.com>


---

- [x] depends on: #24317

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
