### PR TITLE
[Merged by Bors] - chore(RingTheory/PowerSeries/Evaluation): adjust docstrings and names 

### DIFF
--- a/Mathlib/RingTheory/MvPowerSeries/Evaluation.lean
+++ b/Mathlib/RingTheory/MvPowerSeries/Evaluation.lean
@@ -103,7 +103,7 @@ variable [IsTopologicalRing S] [IsLinearTopology S S]
 
 /-- The domain of evaluation of `MvPowerSeries`, as an ideal -/
 @[simps]
-def hasEvalIdeal [IsTopologicalRing S] [IsLinearTopology S S] : Ideal (σ → S) where
+def hasEvalIdeal : Ideal (σ → S) where
   carrier := {a | HasEval a}
   add_mem' := HasEval.add
   zero_mem' := HasEval.zero

--- a/Mathlib/RingTheory/MvPowerSeries/Evaluation.lean
+++ b/Mathlib/RingTheory/MvPowerSeries/Evaluation.lean
@@ -99,6 +99,8 @@ protected theorem HasEval.X:
   hpow s := tendsto_pow_zero_of_constantCoeff_zero (constantCoeff_X s)
   tendsto_zero := variables_tendsto_zero
 
+variable [IsTopologicalRing S] [IsLinearTopology S S]
+
 /-- The domain of evaluation of `MvPowerSeries`, as an ideal -/
 @[simps]
 def hasEvalIdeal [IsTopologicalRing S] [IsLinearTopology S S] : Ideal (σ → S) where
@@ -107,7 +109,7 @@ def hasEvalIdeal [IsTopologicalRing S] [IsLinearTopology S S] : Ideal (σ → S)
   zero_mem' := HasEval.zero
   smul_mem' := HasEval.mul_left
 
-theorem mem_hasEvalIdeal_iff [IsTopologicalRing S] [IsLinearTopology S S] {a : σ → S} :
+theorem mem_hasEvalIdeal_iff {a : σ → S} :
     a ∈ hasEvalIdeal ↔ HasEval a := by
   simp [hasEvalIdeal]
 

--- a/Mathlib/RingTheory/MvPowerSeries/PiTopology.lean
+++ b/Mathlib/RingTheory/MvPowerSeries/PiTopology.lean
@@ -87,7 +87,7 @@ theorem continuous_coeff [Semiring R] (d : σ →₀ ℕ) :
   continuous_pi_iff.mp continuous_id d
 
 variable (R) in
-/-- `MvPolynomial.constantCoeff` is continuous -/
+/-- `MvPowerSeries.constantCoeff` is continuous -/
 theorem continuous_constantCoeff [Semiring R] : Continuous (constantCoeff σ R) :=
   continuous_coeff R 0
 

--- a/Mathlib/RingTheory/PowerSeries/Evaluation.lean
+++ b/Mathlib/RingTheory/PowerSeries/Evaluation.lean
@@ -45,21 +45,71 @@ open WithPiTopology
 
 variable {R : Type*} [CommRing R]
 variable {S : Type*} [CommRing S]
+variable {φ : R →+* S}
 
 section
 
 variable [TopologicalSpace R] [TopologicalSpace S]
 
+/-- Points at which evaluation of power series is well behaved -/
+abbrev HasEval (a : S) := IsTopologicallyNilpotent a
+
 theorem hasEval_iff {a : S} :
-    MvPowerSeries.HasEval (fun (_ : Unit) ↦ a) ↔ IsTopologicallyNilpotent a :=
-  ⟨fun ha ↦ ha.hpow default, fun ha ↦ ⟨fun _ ↦ ha, by simp⟩⟩
+    HasEval a ↔ MvPowerSeries.HasEval (fun (_ : Unit) ↦ a) :=
+  ⟨fun ha ↦ ⟨fun _ ↦ ha, by simp⟩, fun ha ↦ ha.hpow default⟩
 
-theorem hasEval {a : S} (ha : IsTopologicallyNilpotent a) :
-    MvPowerSeries.HasEval (fun (_ : Unit) ↦ a) := hasEval_iff.mpr ha
+theorem hasEval {a : S} (ha : HasEval a) :
+    MvPowerSeries.HasEval (fun (_ : Unit) ↦ a) := hasEval_iff.mp ha
 
-theorem isTopologicallyNilpotent_X :
-    IsTopologicallyNilpotent (PowerSeries.X : PowerSeries R) :=
-  tendsto_pow_zero_of_constantCoeff_zero PowerSeries.constantCoeff_X
+theorem HasEval.mono {S : Type*} [CommRing S] {a : S}
+    {t u : TopologicalSpace S} (h : t ≤ u) (ha : @HasEval _ _ t a) :
+    @HasEval _ _ u a := by
+  simp only [hasEval_iff] at ha ⊢
+  exact ha.mono h
+
+theorem HasEval.zero : HasEval (0 : S) := by
+    rw [hasEval_iff]; exact MvPowerSeries.HasEval.zero
+
+theorem HasEval.add [ContinuousAdd S] [IsLinearTopology S S]
+    {a b : S} (ha : HasEval a) (hb : HasEval b) : HasEval (a + b) := by
+  simp only [hasEval_iff] at ha hb ⊢
+  exact ha.add hb
+
+theorem HasEval.mul_left [IsLinearTopology S S]
+    (c : S) {x : S} (hx : HasEval x) : HasEval (c * x) := by
+  simp only [hasEval_iff] at hx ⊢
+  exact hx.mul_left _
+
+theorem HasEval.mul_right [IsLinearTopology S S]
+    (c : S) {x : S} (hx : HasEval x) : HasEval (x * c) := by
+  simp only [hasEval_iff] at hx ⊢
+  exact hx.mul_right _
+
+/-- [Bourbaki, *Algebra*, chap. 4, §4, n°3, Prop. 4 (i) (a & b)][bourbaki1981]. -/
+theorem HasEval.map (hφ : Continuous φ) {a : R} (ha : HasEval a) :
+    HasEval (φ a) := by
+  simp only [hasEval_iff] at ha ⊢
+  exact ha.map hφ
+
+protected theorem HasEval.X:
+    HasEval (X : R⟦X⟧) := by
+  rw [hasEval_iff]
+  exact MvPowerSeries.HasEval.X
+
+
+variable [IsTopologicalRing S] [IsLinearTopology S S]
+
+/-- The domain of evaluation of `MvPowerSeries`, as an ideal -/
+@[simps]
+def hasEvalIdeal : Ideal S where
+  carrier := {a | HasEval a}
+  add_mem' := HasEval.add
+  zero_mem' := HasEval.zero
+  smul_mem' := HasEval.mul_left
+
+theorem mem_hasEvalIdeal_iff {a : S} :
+    a ∈ hasEvalIdeal ↔ HasEval a := by
+  simp [hasEvalIdeal]
 
 end
 
@@ -174,7 +224,7 @@ theorem aeval_coe (ha : IsTopologicallyNilpotent a) (p : Polynomial R) :
   rw [coe_aeval, Polynomial.aeval_def, eval₂_coe]
 
 theorem aeval_unique {ε : PowerSeries R →ₐ[R] S} (hε : Continuous ε) :
-    aeval (isTopologicallyNilpotent_X.map hε) = ε :=
+    aeval (HasEval.X.map hε) = ε :=
   MvPowerSeries.aeval_unique hε
 
 theorem hasSum_aeval (ha : IsTopologicallyNilpotent a) (f : PowerSeries R) :


### PR DESCRIPTION
This is a minor modification of a very recent file to provide a better support for dot notation.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
