### PR TITLE
[Merged by Bors] - refactor: make UnivLE a structure

### DIFF
--- a/Mathlib/CategoryTheory/UnivLE.lean
+++ b/Mathlib/CategoryTheory/UnivLE.lean
@@ -20,8 +20,8 @@ universe u v
 noncomputable section
 
 theorem UnivLE.ofEssSurj (w : (uliftFunctor.{u, v} : Type v ⥤ Type max u v).EssSurj) :
-    UnivLE.{max u v, v} :=
-  fun α ↦ by
+    UnivLE.{max u v, v} where
+  small α := by
     obtain ⟨a', ⟨m⟩⟩ := w.mem_essImage α
     exact ⟨a', ⟨(Iso.toEquiv m).symm.trans Equiv.ulift⟩⟩
 

--- a/Mathlib/Logic/UnivLE.lean
+++ b/Mathlib/Logic/UnivLE.lean
@@ -37,30 +37,46 @@ it could be bigger than both!
 See also `Mathlib.CategoryTheory.UnivLE` for the statement that the stronger definition is
 equivalent to `EssSurj (uliftFunctor : Type v ⥤ Type max u v)`.
 -/
-@[pp_with_univ]
-abbrev UnivLE : Prop := ∀ α : Type u, Small.{v} α
+@[pp_with_univ, mk_iff]
+class UnivLE : Prop where
+  small (α : Type u) : Small.{v} α
 
-example : UnivLE.{u, u} := inferInstance
-example : UnivLE.{u, u+1} := inferInstance
-example : UnivLE.{0, u} := inferInstance
+attribute [instance] UnivLE.small
+
+
 /- This is useless as an instance due to https://github.com/leanprover/lean4/issues/2297 -/
-theorem univLE_max : UnivLE.{u, max u v} := fun α ↦ small_max.{v} α
+theorem univLE_max : UnivLE.{u, max u v} where small α := small_max.{v} α
 
 theorem Small.trans_univLE (α : Type w) [hα : Small.{u} α] [h : UnivLE.{u, v}] :
     Small.{v} α :=
   let ⟨β, ⟨f⟩⟩ := hα.equiv_small
-  let ⟨_, ⟨g⟩⟩ := (h β).equiv_small
+  let ⟨_, ⟨g⟩⟩ := (h.small β).equiv_small
   ⟨_, ⟨f.trans g⟩⟩
 
-theorem UnivLE.trans [UnivLE.{u, v}] [UnivLE.{v, w}] : UnivLE.{u, w} :=
-  fun α ↦ Small.trans_univLE α
+theorem UnivLE.trans [UnivLE.{u, v}] [UnivLE.{v, w}] : UnivLE.{u, w} where
+  small α := Small.trans_univLE α
+
+instance UnivLE.self : UnivLE.{u, u} := ⟨inferInstance⟩
+instance UnivLE.zero : UnivLE.{0, u} := ⟨inferInstance⟩
+
+/-- This is redundant as an instance given the below. -/
+theorem UnivLE.succ [UnivLE.{u, v}] : UnivLE.{u, v + 1} := @UnivLE.trans _ ⟨inferInstance⟩
 
 /- This is the crucial instance that subsumes `univLE_max`. -/
 instance univLE_of_max [UnivLE.{max u v, v}] : UnivLE.{u, v} := @UnivLE.trans univLE_max ‹_›
+
+-- order doesn't matter
+example : UnivLE.{v, max v u} := inferInstance
+example : UnivLE.{v, max u v} := inferInstance
+example : UnivLE.{u, max v u} := inferInstance
+example : UnivLE.{u, max u v} := inferInstance
+-- `succ` is implied
+example : UnivLE.{u, u + 1} := inferInstance
+example : UnivLE.{2, 5} := inferInstance
 
 /- When `small_Pi` from `Mathlib.Logic.Small.Basic` is imported, we have : -/
 -- example (α : Type u) (β : Type v) [UnivLE.{u, v}] : Small.{v} (α → β) := inferInstance
 
 example : ¬ UnivLE.{u+1, u} := by
-  simp only [small_iff, not_forall, not_exists, not_nonempty_iff]
+  simp only [univLE_iff, small_iff, not_forall, not_exists, not_nonempty_iff]
   exact ⟨Type u, fun α => ⟨fun f => Function.not_surjective_Type.{u, u} f.symm f.symm.surjective⟩⟩

--- a/Mathlib/SetTheory/Cardinal/UnivLE.lean
+++ b/Mathlib/SetTheory/Cardinal/UnivLE.lean
@@ -17,7 +17,7 @@ universe u v
 open Cardinal
 
 theorem univLE_iff_cardinal_le : UnivLE.{u, v} ↔ univ.{u, v+1} ≤ univ.{v, u+1} := by
-  rw [← not_iff_not, UnivLE]; simp_rw [small_iff_lift_mk_lt_univ]; push_neg
+  rw [← not_iff_not, univLE_iff]; simp_rw [small_iff_lift_mk_lt_univ]; push_neg
   -- strange: simp_rw [univ_umax.{v,u}] doesn't work
   refine ⟨fun ⟨α, le⟩ ↦ ?_, fun h ↦ ?_⟩
   · rw [univ_umax.{v,u}, ← lift_le.{u+1}, lift_univ, lift_lift] at le


### PR DESCRIPTION
As an `abbrev`, typeclass search reduces this and goes on a wild goose chase for `Small.{v} α` where `α` is a variable.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
