### PR TITLE
[Merged by Bors] - chore(GroupTheory/FreeAbelianGroupFinsupp): split file

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -266,6 +266,7 @@ import Mathlib.Algebra.Field.Subfield.Defs
 import Mathlib.Algebra.Field.ULift
 import Mathlib.Algebra.Field.ZMod
 import Mathlib.Algebra.Free
+import Mathlib.Algebra.FreeAbelianGroup.Finsupp
 import Mathlib.Algebra.FreeAlgebra
 import Mathlib.Algebra.FreeAlgebra.Cardinality
 import Mathlib.Algebra.FreeMonoid.Basic
@@ -3555,8 +3556,8 @@ import Mathlib.GroupTheory.Finiteness
 import Mathlib.GroupTheory.FixedPointFree
 import Mathlib.GroupTheory.Frattini
 import Mathlib.GroupTheory.FreeAbelianGroup
-import Mathlib.GroupTheory.FreeAbelianGroupFinsupp
 import Mathlib.GroupTheory.FreeGroup.Basic
+import Mathlib.GroupTheory.FreeGroup.GeneratorEquiv
 import Mathlib.GroupTheory.FreeGroup.IsFreeGroup
 import Mathlib.GroupTheory.FreeGroup.NielsenSchreier
 import Mathlib.GroupTheory.FreeGroup.Reduce

--- a/Mathlib/Algebra/FreeAbelianGroup/Finsupp.lean
+++ b/Mathlib/Algebra/FreeAbelianGroup/Finsupp.lean
@@ -3,10 +3,9 @@ Copyright (c) 2021 Johan Commelin. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johan Commelin
 -/
-import Mathlib.Algebra.Group.Equiv.TypeTags
+import Mathlib.Algebra.BigOperators.Finsupp.Basic
+import Mathlib.Algebra.Module.End
 import Mathlib.GroupTheory.FreeAbelianGroup
-import Mathlib.GroupTheory.FreeGroup.IsFreeGroup
-import Mathlib.LinearAlgebra.Dimension.StrongRankCondition
 
 /-!
 # Isomorphism between `FreeAbelianGroup X` and `X →₀ ℤ`
@@ -19,9 +18,9 @@ We use this to transport the notion of `support` from `Finsupp` to `FreeAbelianG
 - `FreeAbelianGroup.equivFinsupp`: group isomorphism between `FreeAbelianGroup X` and `X →₀ ℤ`
 - `FreeAbelianGroup.coeff`: the multiplicity of `x : X` in `a : FreeAbelianGroup X`
 - `FreeAbelianGroup.support`: the finset of `x : X` that occur in `a : FreeAbelianGroup X`
-
 -/
 
+assert_not_exists Basis
 
 noncomputable section
 
@@ -89,32 +88,6 @@ def equivFinsupp : FreeAbelianGroup X ≃+ (X →₀ ℤ) where
   left_inv := toFreeAbelianGroup_toFinsupp
   right_inv := toFinsupp_toFreeAbelianGroup
   map_add' := toFinsupp.map_add
-
-/-- `A` is a basis of the ℤ-module `FreeAbelianGroup A`. -/
-noncomputable def basis (α : Type*) : Basis α ℤ (FreeAbelianGroup α) :=
-  ⟨(FreeAbelianGroup.equivFinsupp α).toIntLinearEquiv⟩
-
-/-- Isomorphic free abelian groups (as modules) have equivalent bases. -/
-def Equiv.ofFreeAbelianGroupLinearEquiv {α β : Type*}
-    (e : FreeAbelianGroup α ≃ₗ[ℤ] FreeAbelianGroup β) : α ≃ β :=
-  let t : Basis α ℤ (FreeAbelianGroup β) := (FreeAbelianGroup.basis α).map e
-  t.indexEquiv <| FreeAbelianGroup.basis _
-
-/-- Isomorphic free abelian groups (as additive groups) have equivalent bases. -/
-def Equiv.ofFreeAbelianGroupEquiv {α β : Type*} (e : FreeAbelianGroup α ≃+ FreeAbelianGroup β) :
-    α ≃ β :=
-  Equiv.ofFreeAbelianGroupLinearEquiv e.toIntLinearEquiv
-
-/-- Isomorphic free groups have equivalent bases. -/
-def Equiv.ofFreeGroupEquiv {α β : Type*} (e : FreeGroup α ≃* FreeGroup β) : α ≃ β :=
-  Equiv.ofFreeAbelianGroupEquiv (MulEquiv.toAdditive e.abelianizationCongr)
-
-open IsFreeGroup
-
-/-- Isomorphic free groups have equivalent bases (`IsFreeGroup` variant). -/
-def Equiv.ofIsFreeGroupEquiv {G H : Type*} [Group G] [Group H] [IsFreeGroup G] [IsFreeGroup H]
-    (e : G ≃* H) : Generators G ≃ Generators H :=
-  Equiv.ofFreeGroupEquiv <| MulEquiv.trans (toFreeGroup G).symm <| MulEquiv.trans e <| toFreeGroup H
 
 variable {X}
 

--- a/Mathlib/GroupTheory/FreeGroup/Basic.lean
+++ b/Mathlib/GroupTheory/FreeGroup/Basic.lean
@@ -691,9 +691,7 @@ theorem map_eq_lift : map f x = lift (of ∘ f) x :=
 
 /-- Equivalent types give rise to multiplicatively equivalent free groups.
 
-The converse can be found in `GroupTheory.FreeAbelianGroupFinsupp`,
-as `Equiv.of_freeGroupEquiv`
--/
+The converse can be found in `GroupTheory.FreeGroup.GeneratorEquiv`, as `Equiv.ofFreeGroupEquiv`. -/
 @[to_additive (attr := simps apply)
   "Equivalent types give rise to additively equivalent additive free groups."]
 def freeGroupCongr {α β} (e : α ≃ β) : FreeGroup α ≃* FreeGroup β where

--- a/Mathlib/GroupTheory/FreeGroup/GeneratorEquiv.lean
+++ b/Mathlib/GroupTheory/FreeGroup/GeneratorEquiv.lean
@@ -1,0 +1,48 @@
+/-
+Copyright (c) 2021 Johan Commelin. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Johan Commelin
+-/
+import Mathlib.Algebra.FreeAbelianGroup.Finsupp
+import Mathlib.GroupTheory.FreeGroup.IsFreeGroup
+import Mathlib.LinearAlgebra.Dimension.StrongRankCondition
+
+/-!
+# Isomorphisms between free groups come from equivalences of their generators
+
+This file proves that an isomorphism `e : G ≃* H` between free groups `G` and `H` is induced by an
+equivalence of generators.
+
+## TODO
+
+We currently construct the equivalence of generators, but don't show that it induces the isomorphism
+of groups.
+-/
+
+noncomputable section
+
+variable {α β G H : Type*}
+
+open IsFreeGroup
+
+/-- `A` is a basis of the ℤ-module `FreeAbelianGroup A`. -/
+noncomputable def FreeAbelianGroup.basis (α : Type*) : Basis α ℤ (FreeAbelianGroup α) :=
+  ⟨(FreeAbelianGroup.equivFinsupp α).toIntLinearEquiv⟩
+
+/-- Isomorphic free abelian groups (as modules) have equivalent bases. -/
+def Equiv.ofFreeAbelianGroupLinearEquiv (e : FreeAbelianGroup α ≃ₗ[ℤ] FreeAbelianGroup β) : α ≃ β :=
+  let t : Basis α ℤ (FreeAbelianGroup β) := (FreeAbelianGroup.basis α).map e
+  t.indexEquiv <| FreeAbelianGroup.basis _
+
+/-- Isomorphic free abelian groups (as additive groups) have equivalent bases. -/
+def Equiv.ofFreeAbelianGroupEquiv (e : FreeAbelianGroup α ≃+ FreeAbelianGroup β) : α ≃ β :=
+  .ofFreeAbelianGroupLinearEquiv e.toIntLinearEquiv
+
+/-- Isomorphic free groups have equivalent bases. -/
+def Equiv.ofFreeGroupEquiv (e : FreeGroup α ≃* FreeGroup β) : α ≃ β :=
+  .ofFreeAbelianGroupEquiv (MulEquiv.toAdditive e.abelianizationCongr)
+
+/-- Isomorphic free groups have equivalent bases (`IsFreeGroup` variant). -/
+def Equiv.ofIsFreeGroupEquiv [Group G] [Group H] [IsFreeGroup G] [IsFreeGroup H] (e : G ≃* H) :
+    Generators G ≃ Generators H :=
+  .ofFreeGroupEquiv <| (toFreeGroup G).symm.trans <| e.trans <| toFreeGroup H

--- a/Mathlib/SetTheory/Cardinal/Free.lean
+++ b/Mathlib/SetTheory/Cardinal/Free.lean
@@ -3,8 +3,9 @@ Copyright (c) 2024 Eric Wieser. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Eric Wieser, Daniel Weber
 -/
+import Mathlib.Algebra.Equiv.TransferInstance
+import Mathlib.Algebra.FreeAbelianGroup.Finsupp
 import Mathlib.Data.Finsupp.Fintype
-import Mathlib.GroupTheory.FreeAbelianGroupFinsupp
 import Mathlib.GroupTheory.FreeGroup.Reduce
 import Mathlib.RingTheory.FreeCommRing
 import Mathlib.SetTheory.Cardinal.Arithmetic


### PR DESCRIPTION
There are two very distinct things going on in this file:
1. The free abelian group with generators `α` is isomorphic to finitely supported function `α →₀ ℤ`.
2. Isomorphisms of free abelian groups come from equivalences of their generators.

2 depends on 1, but also on a huge lot of linear algebra (it needs the invariant basis number theorem). Therefore, splitting the file along 1 and 2 makes 1 much lighter. This is what this PR does.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
