### PR TITLE
doc: ensure that notation is used in the documentation

### DIFF
--- a/Mathlib/Analysis/SpecialFunctions/Log/PosLog.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Log/PosLog.lean
@@ -23,11 +23,12 @@ namespace Real
 /-!
 ## Definition, Notation and Reformulations
 -/
+
 /-- Definition: the positive part of the logarithm. -/
-noncomputable def posLog : ℝ → ℝ := fun r ↦ max 0 (log r)
+@[pp_nodot] noncomputable def posLog : ℝ → ℝ := fun r ↦ max 0 (log r)
 
 /-- Notation `log⁺` for the positive part of the logarithm. -/
-scoped notation "log⁺" => posLog
+notation "log⁺" => posLog
 
 /-- Definition of the positive part of the logarithm, formulated as a theorem. -/
 theorem posLog_def {r : ℝ} : log⁺ r = max 0 (log r) := rfl
@@ -35,6 +36,7 @@ theorem posLog_def {r : ℝ} : log⁺ r = max 0 (log r) := rfl
 /-!
 ## Elementary Properties
 -/
+
 /-- Presentation of `log` in terms of its positive part. -/
 theorem posLog_sub_posLog_inv {r : ℝ} : log⁺ r - log⁺ r⁻¹ = log r := by
   rw [posLog_def, posLog_def, log_inv]
@@ -90,6 +92,7 @@ theorem monotoneOn_posLog : MonotoneOn log⁺ (Set.Ici 0) := by
 /-!
 ## Estimates for Products
 -/
+
 /-- Estimate for `log⁺` of a product. See `Real.posLog_prod` for a variant involving
 multiple factors. -/
 theorem posLog_mul {a b : ℝ} :
@@ -128,6 +131,7 @@ theorem posLog_prod {α : Type*} (s : Finset α) (f : α → ℝ) :
 /-!
 ## Estimates for Sums
 -/
+
 /-- Estimate for `log⁺` of a sum. See `Real.posLog_add` for a variant involving
 just two summands. -/
 theorem posLog_sum {α : Type*} (s : Finset α) (f : α → ℝ) :


### PR DESCRIPTION
Ensure that the documentation generator uses the notation `log⁺`. Currently, the documentation generator writes `x.posLog` instead of `log⁺ x`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
