### PR TITLE
perf(CategoryTheory/Subobject/Lattice): reorder instance arguments

### DIFF
--- a/Mathlib/CategoryTheory/Subobject/Lattice.lean
+++ b/Mathlib/CategoryTheory/Subobject/Lattice.lean
@@ -496,7 +496,7 @@ section Lattice
 instance boundedOrder [HasInitial C] [InitialMonoClass C] {B : C} : BoundedOrder (Subobject B) :=
   { Subobject.orderTop, Subobject.orderBot with }
 
-variable [HasPullbacks C] [HasImages C] [HasBinaryCoproducts C]
+variable [HasImages C] [HasPullbacks C] [HasBinaryCoproducts C]
 
 instance {B : C} : Lattice (Subobject B) :=
   { Subobject.semilatticeInf, Subobject.semilatticeSup with }
@@ -596,15 +596,14 @@ end Inf
 
 section Sup
 
-variable [LocallySmall.{w} C] [WellPowered.{w} C] [HasCoproducts.{w} C]
-
 /-- The universal morphism out of the coproduct of a set of subobjects,
 after using `[WellPowered C]` to reindex by a small type.
 -/
-def smallCoproductDesc {A : C} (s : Set (Subobject A)) :=
+def smallCoproductDesc [LocallySmall.{w} C] [WellPowered.{w} C] [HasCoproducts.{w} C]
+    {A : C} (s : Set (Subobject A)) :=
   Limits.Sigma.desc fun j : equivShrink _ '' s => ((equivShrink (Subobject A)).symm j).arrow
 
-variable [HasImages C]
+variable [HasImages C] [LocallySmall.{w} C] [WellPowered.{w} C] [HasCoproducts.{w} C]
 
 /-- When `[WellPowered C] [HasImages C] [HasCoproducts C]`,
 `Subobject A` has arbitrary supremums. -/


### PR DESCRIPTION
The `HasImages C` type class fails more quickly, so I set it as the first type class argument.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
