### PR TITLE
feat(Combinatorics/SimpleGraph): every circuit contains a cycle proof 

### DIFF
--- a/Mathlib/Combinatorics/SimpleGraph/Path.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Path.lean
@@ -647,9 +647,6 @@ end Walk
 
 /-! ### Circuits to cycles -/
 
--- The type of cycles for a closed walk.
-abbrev Cycle (u : V) := { p : G.Walk u u // p.IsCycle }
-
 namespace Walk
 
 variable {G} [DecidableEq V]
@@ -657,26 +654,20 @@ variable {G} [DecidableEq V]
 /-- Given a closed walk, produces a closed walk removing subwalks between repeated vertices
 through the use of the bypass definition.
 If the walk provided is a circuit, this results in a cycle, as
-seen in `SimpleGraph.Walk.isCycle_shortcircuit`
-This idea is packaged up in `SimpleGraph.Walk.ToCycle`. -/
+seen in `SimpleGraph.Walk.isCycle_shortcircuit` -/
 def shortCircuit {u : V} : G.Walk u u → G.Walk u u
   | nil => nil
   | cons ha p => cons ha p.bypass
 
-theorem isCycle_shortcircuit {u : V} (p : G.Walk u u) (h : p.IsCircuit) :
-    p.shortcircuit.IsCycle :=
+theorem isCycle_shortCircuit {u : V} (p : G.Walk u u) (h : p.IsCircuit) :
+    p.shortCircuit.IsCycle :=
   match p, h.ne_nil with
   | cons (v := v) ha p, _ => by
     contrapose h
     suffices s(u, v) ∈ p.edges by simp [isCircuit_def, this]
     have : s(u, v) ∈ p.bypass.edges := by
-      simpa [shortcircuit, cons_isCycle_iff, bypass_isPath] using h
+      simpa [shortCircuit, cons_isCycle_iff, bypass_isPath] using h
     exact edges_bypass_subset p this
-
-/-- Given a closed walk that is a circuit, produces a cycle with the same initial & final
-vertex using `SimpleGraph.Walk.shortcircuit`. -/
-def toCycle {u : V} (p : G.Walk u u) (h: p.IsCircuit) : G.Cycle u :=
-  ⟨p.shortcircuit, p.isCycle_shortcircuit h⟩
 
 end Walk
 

--- a/Mathlib/Combinatorics/SimpleGraph/Path.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Path.lean
@@ -671,7 +671,7 @@ theorem isCycle_shortcircuit {u : V} (p : G.Walk u u) (h : p.IsCircuit) :
     suffices s(u, v) ∈ p.edges by simp [isCircuit_def, this]
     have : s(u, v) ∈ p.bypass.edges := by
       simpa [shortcircuit, cons_isCycle_iff, bypass_isPath] using h
-    exact (edges_bypass_subset p) this
+    exact edges_bypass_subset p this
 
 /-- Given a closed walk that is a circuit, produces a cycle with the same initial & final
 vertex using `SimpleGraph.Walk.shortcircuit`. -/

--- a/Mathlib/Combinatorics/SimpleGraph/Path.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Path.lean
@@ -659,7 +659,7 @@ through the use of the bypass definition.
 If the walk provided is a circuit, this results in a cycle, as
 seen in `SimpleGraph.Walk.isCycle_shortcircuit`
 This idea is packaged up in `SimpleGraph.Walk.ToCycle`. -/
-def shortcircuit {u : V} : G.Walk u u → G.Walk u u
+def shortCircuit {u : V} : G.Walk u u → G.Walk u u
   | nil => nil
   | cons ha p => cons ha p.bypass
 


### PR DESCRIPTION
circuit to cycle proof

---
This PR uses the bypass definition in a new function for closed walks that removes repeated vertices. Then proves if the closed walk given is a circuit, that the result from this function is a cycle. This is then packaged up similar to the existing ToPath definition, creating a way of transforming a circuit into a cycle.
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
