### PR TITLE
[Merged by Bors] - feat(Topology/Order): add `Dense.exists_seq_strict{Mono/Anti}_tendsto`

### DIFF
--- a/Mathlib/Topology/Instances/Real/Lemmas.lean
+++ b/Mathlib/Topology/Instances/Real/Lemmas.lean
@@ -81,18 +81,12 @@ theorem Real.subfield_eq_of_closed {K : Subfield ℝ} (hc : IsClosed (K : Set �
   exact SubfieldClass.ratCast_mem K _
 
 theorem Real.exists_seq_rat_strictMono_tendsto (x : ℝ) :
-    ∃ u : ℕ → ℚ, StrictMono u ∧ (∀ n, u n < x) ∧ Tendsto (u · : ℕ → ℝ) atTop (𝓝 x) := by
-  obtain ⟨u, hu_mono, hu_mem, hux⟩ := Rat.denseRange_cast.exists_seq_strictMono_tendsto x
-  refine ⟨fun n ↦ (hu_mem n).2.choose, ?_, ?_⟩
-  · simpa [StrictMono, ← (Rat.cast_strictMono (K := ℝ)).lt_iff_lt, fun n ↦ (hu_mem n).2.choose_spec]
-  · aesop (add simp (fun n ↦ (hu_mem n).2.choose_spec))
+    ∃ u : ℕ → ℚ, StrictMono u ∧ (∀ n, u n < x) ∧ Tendsto (u · : ℕ → ℝ) atTop (𝓝 x) :=
+  Rat.denseRange_cast.exists_seq_strictMono_tendsto Rat.cast_strictMono.monotone x
 
 theorem Real.exists_seq_rat_strictAnti_tendsto (x : ℝ) :
-    ∃ u : ℕ → ℚ, StrictAnti u ∧ (∀ n, x < u n) ∧ Tendsto (u · : ℕ → ℝ) atTop (𝓝 x) := by
-  obtain ⟨u, hu_anti, hu_mem, hux⟩ := Rat.denseRange_cast.exists_seq_strictAnti_tendsto x
-  refine ⟨fun n ↦ (hu_mem n).2.choose, ?_, ?_⟩
-  · simpa [StrictAnti, ← (Rat.cast_strictMono (K := ℝ)).lt_iff_lt, fun n ↦ (hu_mem n).2.choose_spec]
-  · aesop (add simp (fun n ↦ (hu_mem n).2.choose_spec))
+    ∃ u : ℕ → ℚ, StrictAnti u ∧ (∀ n, x < u n) ∧ Tendsto (u · : ℕ → ℝ) atTop (𝓝 x) :=
+  Rat.denseRange_cast.exists_seq_strictAnti_tendsto Rat.cast_strictMono.monotone x
 
 section
 

--- a/Mathlib/Topology/Instances/Real/Lemmas.lean
+++ b/Mathlib/Topology/Instances/Real/Lemmas.lean
@@ -80,6 +80,20 @@ theorem Real.subfield_eq_of_closed {K : Subfield ℝ} (hc : IsClosed (K : Set �
   rintro - ⟨_, rfl⟩
   exact SubfieldClass.ratCast_mem K _
 
+theorem Real.exists_seq_rat_strictMono_tendsto (x : ℝ) :
+    ∃ u : ℕ → ℚ, StrictMono u ∧ (∀ n, u n < x) ∧ Tendsto (u · : ℕ → ℝ) atTop (𝓝 x) := by
+  obtain ⟨u, hu_mono, hu_mem, hux⟩ := Rat.denseRange_cast.exists_seq_strictMono_tendsto x
+  refine ⟨fun n ↦ (hu_mem n).2.choose, ?_, ?_⟩
+  · simpa [StrictMono, ← (Rat.cast_strictMono (K := ℝ)).lt_iff_lt, fun n ↦ (hu_mem n).2.choose_spec]
+  · aesop (add simp (fun n ↦ (hu_mem n).2.choose_spec))
+
+theorem Real.exists_seq_rat_strictAnti_tendsto (x : ℝ) :
+    ∃ u : ℕ → ℚ, StrictAnti u ∧ (∀ n, x < u n) ∧ Tendsto (u · : ℕ → ℝ) atTop (𝓝 x) := by
+  obtain ⟨u, hu_anti, hu_mem, hux⟩ := Rat.denseRange_cast.exists_seq_strictAnti_tendsto x
+  refine ⟨fun n ↦ (hu_mem n).2.choose, ?_, ?_⟩
+  · simpa [StrictAnti, ← (Rat.cast_strictMono (K := ℝ)).lt_iff_lt, fun n ↦ (hu_mem n).2.choose_spec]
+  · aesop (add simp (fun n ↦ (hu_mem n).2.choose_spec))
+
 section
 
 theorem closure_of_rat_image_lt {q : ℚ} :

--- a/Mathlib/Topology/Order/IsLUB.lean
+++ b/Mathlib/Topology/Order/IsLUB.lean
@@ -214,7 +214,7 @@ theorem exists_seq_tendsto_sSup {α : Type*} [ConditionallyCompleteLinearOrder �
   rcases (isLUB_csSup hS hS').exists_seq_monotone_tendsto hS with ⟨u, hu⟩
   exact ⟨u, hu.1, hu.2.2⟩
 
-theorem Dense.exists_seq_strictMono_tendsto' [DenselyOrdered α] [FirstCountableTopology α]
+theorem Dense.exists_seq_strictMono_tendsto_of_lt [DenselyOrdered α] [FirstCountableTopology α]
     {s : Set α} (hs : Dense s) {x y : α} (hy : y < x) :
     ∃ u : ℕ → α, StrictMono u ∧ (∀ n, u n ∈ (Ioo y x ∩ s)) ∧ Tendsto u atTop (𝓝 x) := by
   have hnonempty : (Ioo y x ∩ s).Nonempty := by
@@ -228,8 +228,30 @@ theorem Dense.exists_seq_strictMono_tendsto [DenselyOrdered α] [NoMinOrder α]
     [FirstCountableTopology α] {s : Set α} (hs : Dense s) (x : α) :
     ∃ u : ℕ → α, StrictMono u ∧ (∀ n, u n ∈ (Iio x ∩ s)) ∧ Tendsto u atTop (𝓝 x) := by
   obtain ⟨y, hy⟩ := exists_lt x
-  apply hs.exists_seq_strictMono_tendsto' (exists_lt x).choose_spec |>.imp
+  apply hs.exists_seq_strictMono_tendsto_of_lt (exists_lt x).choose_spec |>.imp
   aesop
+
+theorem DenseRange.exists_seq_strictMono_tendsto_of_lt {β : Type*} [LinearOrder β]
+    [DenselyOrdered α] [FirstCountableTopology α] {f : β → α} {x y : α} (hf : DenseRange f)
+    (hmono : Monotone f) (hlt : y < x) :
+    ∃ u : ℕ → β, StrictMono u ∧ (∀ n, f (u n) ∈ Ioo y x) ∧ Tendsto (f ∘ u) atTop (𝓝 x) := by
+  rcases Dense.exists_seq_strictMono_tendsto_of_lt hf hlt with ⟨u, hu, huyxf, hlim⟩
+  have huyx (n : ℕ) : u n ∈ Ioo y x := (huyxf n).1
+  have huf (n : ℕ) : u n ∈ range f := (huyxf n).2
+  choose v hv using huf
+  obtain rfl : f ∘ v = u := funext hv
+  exact ⟨v, fun a b hlt ↦ hmono.reflect_lt <| hu hlt, huyx, hlim⟩
+
+theorem DenseRange.exists_seq_strictMono_tendsto {β : Type*} [LinearOrder β] [DenselyOrdered α]
+    [NoMinOrder α] [FirstCountableTopology α] {f : β → α} (hf : DenseRange f) (hmono : Monotone f)
+    (x : α):
+    ∃ u : ℕ → β, StrictMono u ∧ (∀ n, f (u n) ∈ Iio x) ∧ Tendsto (f ∘ u) atTop (𝓝 x) := by
+  rcases Dense.exists_seq_strictMono_tendsto hf x with ⟨u, hu, huxf, hlim⟩
+  have hux (n : ℕ) : u n ∈ Iio x := (huxf n).1
+  have huf (n : ℕ) : u n ∈ range f := (huxf n).2
+  choose v hv using huf
+  obtain rfl : f ∘ v = u := funext hv
+  exact ⟨v, fun a b hlt ↦ hmono.reflect_lt <| hu hlt, hux, hlim⟩
 
 theorem IsGLB.exists_seq_strictAnti_tendsto_of_not_mem {t : Set α} {x : α}
     [IsCountablyGenerated (𝓝 x)] (htx : IsGLB t x) (not_mem : x ∉ t) (ht : t.Nonempty) :
@@ -269,14 +291,27 @@ theorem exists_seq_tendsto_sInf {α : Type*} [ConditionallyCompleteLinearOrder �
     (hS' : BddBelow S) : ∃ u : ℕ → α, Antitone u ∧ Tendsto u atTop (𝓝 (sInf S)) ∧ ∀ n, u n ∈ S :=
   exists_seq_tendsto_sSup (α := αᵒᵈ) hS hS'
 
-theorem Dense.exists_seq_strictAnti_tendsto' [DenselyOrdered α] [FirstCountableTopology α]
+theorem Dense.exists_seq_strictAnti_tendsto_of_lt [DenselyOrdered α] [FirstCountableTopology α]
     {s : Set α} (hs : Dense s) {x y : α} (hy : x < y) :
     ∃ u : ℕ → α, StrictAnti u ∧ (∀ n, u n ∈ (Ioo x y ∩ s)) ∧ Tendsto u atTop (𝓝 x) := by
-  simpa using hs.exists_seq_strictMono_tendsto' (α := αᵒᵈ) (OrderDual.toDual_lt_toDual.2 hy)
+  simpa using hs.exists_seq_strictMono_tendsto_of_lt (α := αᵒᵈ) (OrderDual.toDual_lt_toDual.2 hy)
 
 theorem Dense.exists_seq_strictAnti_tendsto [DenselyOrdered α] [NoMaxOrder α]
     [FirstCountableTopology α] {s : Set α} (hs : Dense s) (x : α) :
     ∃ u : ℕ → α, StrictAnti u ∧ (∀ n, u n ∈ (Ioi x ∩ s)) ∧ Tendsto u atTop (𝓝 x) :=
   hs.exists_seq_strictMono_tendsto (α := αᵒᵈ) x
+
+theorem DenseRange.exists_seq_strictAnti_tendsto_of_lt {β : Type*} [LinearOrder β]
+    [DenselyOrdered α] [FirstCountableTopology α] {f : β → α} {x y : α} (hf : DenseRange f)
+    (hmono : Monotone f) (hlt : x < y) :
+    ∃ u : ℕ → β, StrictAnti u ∧ (∀ n, f (u n) ∈ Ioo x y) ∧ Tendsto (f ∘ u) atTop (𝓝 x) := by
+  simpa using hf.exists_seq_strictMono_tendsto_of_lt (α := αᵒᵈ) (β := βᵒᵈ) hmono.dual
+    (OrderDual.toDual_lt_toDual.2 hlt)
+
+theorem DenseRange.exists_seq_strictAnti_tendsto {β : Type*} [LinearOrder β] [DenselyOrdered α]
+    [NoMaxOrder α] [FirstCountableTopology α] {f : β → α} (hf : DenseRange f) (hmono : Monotone f)
+    (x : α):
+    ∃ u : ℕ → β, StrictAnti u ∧ (∀ n, f (u n) ∈ Ioi x) ∧ Tendsto (f ∘ u) atTop (𝓝 x) :=
+  hf.exists_seq_strictMono_tendsto (α := αᵒᵈ) (β := βᵒᵈ) hmono.dual x
 
 end OrderTopology

--- a/Mathlib/Topology/Order/IsLUB.lean
+++ b/Mathlib/Topology/Order/IsLUB.lean
@@ -142,21 +142,21 @@ theorem IsGLB.mem_of_isClosed {a : α} {s : Set α} (ha : IsGLB s a) (hs : s.Non
 
 alias IsClosed.isGLB_mem := IsGLB.mem_of_isClosed
 
-protected theorem Set.Subset.isLUB_congr {α : Type*} [TopologicalSpace α] [Preorder α]
+theorem isLUB_iff_of_subset_of_subset_closure {α : Type*} [TopologicalSpace α] [Preorder α]
     [ClosedIicTopology α] {s t : Set α} (hst : s ⊆ t) (hts : t ⊆ closure s) {x : α} :
     IsLUB s x ↔ IsLUB t x :=
   isLUB_congr <| (upperBounds_closure (s := s) ▸ upperBounds_mono_set hts).antisymm <|
     upperBounds_mono_set hst
 
-protected theorem Set.Subset.isGLB_congr {α : Type*} [TopologicalSpace α] [Preorder α]
+theorem isGLB_iff_of_subset_of_subset_closure {α : Type*} [TopologicalSpace α] [Preorder α]
     [ClosedIciTopology α] {s t : Set α} (hst : s ⊆ t) (hts : t ⊆ closure s) {x : α} :
     IsGLB s x ↔ IsGLB t x :=
-  Set.Subset.isLUB_congr (α := αᵒᵈ) hst hts
+  isLUB_iff_of_subset_of_subset_closure (α := αᵒᵈ) hst hts
 
 theorem Dense.isLUB_inter_iff {α : Type*} [TopologicalSpace α] [Preorder α] [ClosedIicTopology α]
     {s t : Set α} (hs : Dense s) (ht : IsOpen t) {x : α} :
     IsLUB (t ∩ s) x ↔ IsLUB t x :=
-  Set.Subset.isLUB_congr (by simp) <| hs.open_subset_closure_inter ht
+  isLUB_iff_of_subset_of_subset_closure (by simp) <| hs.open_subset_closure_inter ht
 
 theorem Dense.isGLB_inter_iff {α : Type*} [TopologicalSpace α] [Preorder α] [ClosedIciTopology α]
     {s t : Set α} (hs : Dense s) (ht : IsOpen t) {x : α} :

--- a/Mathlib/Topology/Order/IsLUB.lean
+++ b/Mathlib/Topology/Order/IsLUB.lean
@@ -142,6 +142,27 @@ theorem IsGLB.mem_of_isClosed {a : α} {s : Set α} (ha : IsGLB s a) (hs : s.Non
 
 alias IsClosed.isGLB_mem := IsGLB.mem_of_isClosed
 
+protected theorem Set.Subset.isLUB_congr {α : Type*} [TopologicalSpace α] [Preorder α]
+    [ClosedIicTopology α] {s t : Set α} (hst : s ⊆ t) (hts : t ⊆ closure s) {x : α} :
+    IsLUB s x ↔ IsLUB t x :=
+  isLUB_congr <| (upperBounds_closure (s := s) ▸ upperBounds_mono_set hts).antisymm <|
+    upperBounds_mono_set hst
+
+protected theorem Set.Subset.isGLB_congr {α : Type*} [TopologicalSpace α] [Preorder α]
+    [ClosedIciTopology α] {s t : Set α} (hst : s ⊆ t) (hts : t ⊆ closure s) {x : α} :
+    IsGLB s x ↔ IsGLB t x :=
+  Set.Subset.isLUB_congr (α := αᵒᵈ) hst hts
+
+theorem Dense.isLUB_inter_iff {α : Type*} [TopologicalSpace α] [Preorder α] [ClosedIicTopology α]
+    {s t : Set α} (hs : Dense s) (ht : IsOpen t) {x : α} :
+    IsLUB (t ∩ s) x ↔ IsLUB t x :=
+  Set.Subset.isLUB_congr (by simp) <| hs.open_subset_closure_inter ht
+
+theorem Dense.isGLB_inter_iff {α : Type*} [TopologicalSpace α] [Preorder α] [ClosedIciTopology α]
+    {s t : Set α} (hs : Dense s) (ht : IsOpen t) {x : α} :
+    IsGLB (t ∩ s) x ↔ IsGLB t x :=
+  Dense.isLUB_inter_iff (α := αᵒᵈ) hs ht
+
 /-!
 ### Existence of sequences tending to `sInf` or `sSup` of a given set
 -/
@@ -193,6 +214,25 @@ theorem exists_seq_tendsto_sSup {α : Type*} [ConditionallyCompleteLinearOrder �
   rcases (isLUB_csSup hS hS').exists_seq_monotone_tendsto hS with ⟨u, hu⟩
   exact ⟨u, hu.1, hu.2.2⟩
 
+theorem Dense.exists_seq_strictMono_tendsto' [DenselyOrdered α] [FirstCountableTopology α]
+    {s : Set α} (hs : Dense s) {x y : α} (hy : y < x) :
+    ∃ u : ℕ → α, StrictMono u ∧ (∀ n, u n ∈ (Ioo y x ∩ s)) ∧ Tendsto u atTop (𝓝 x) := by
+  have hnonempty : (Ioo y x ∩ s).Nonempty := by
+    obtain ⟨z, hyz, hzx⟩ := hs.exists_between hy
+    exact ⟨z, mem_inter hzx hyz⟩
+  have hx : IsLUB (Ioo y x ∩ s) x := hs.isLUB_inter_iff isOpen_Ioo |>.mpr <| isLUB_Ioo hy
+  obtain ⟨u, hu⟩ := hx.exists_seq_strictMono_tendsto_of_not_mem (by simp) hnonempty
+  exact ⟨u, hu.1, hu.2.2.symm⟩
+
+theorem Dense.exists_seq_strictMono_tendsto [DenselyOrdered α] [NoMinOrder α]
+    [FirstCountableTopology α] {s : Set α} (hs : Dense s) (x : α) :
+    ∃ u : ℕ → α, StrictMono u ∧ (∀ n, u n ∈ (Iio x ∩ s)) ∧ Tendsto u atTop (𝓝 x) := by
+  obtain ⟨y, hy⟩ : ∃ y, y < x := exists_lt x
+  obtain ⟨u, hu_mono, hu_mem, hux⟩ := hs.exists_seq_strictMono_tendsto' hy
+  have hu_mem' (n) : u n ∈ Iio x ∩ s :=
+    Set.mem_of_mem_of_subset (hu_mem n) <| inter_subset_inter_left _ Ioo_subset_Iio_self
+  exact ⟨u, hu_mono, hu_mem', hux⟩
+
 theorem IsGLB.exists_seq_strictAnti_tendsto_of_not_mem {t : Set α} {x : α}
     [IsCountablyGenerated (𝓝 x)] (htx : IsGLB t x) (not_mem : x ∉ t) (ht : t.Nonempty) :
     ∃ u : ℕ → α, StrictAnti u ∧ (∀ n, x < u n) ∧ Tendsto u atTop (𝓝 x) ∧ ∀ n, u n ∈ t :=
@@ -230,5 +270,15 @@ theorem exists_seq_tendsto_sInf {α : Type*} [ConditionallyCompleteLinearOrder �
     [TopologicalSpace α] [OrderTopology α] [FirstCountableTopology α] {S : Set α} (hS : S.Nonempty)
     (hS' : BddBelow S) : ∃ u : ℕ → α, Antitone u ∧ Tendsto u atTop (𝓝 (sInf S)) ∧ ∀ n, u n ∈ S :=
   exists_seq_tendsto_sSup (α := αᵒᵈ) hS hS'
+
+theorem Dense.exists_seq_strictAnti_tendsto' [DenselyOrdered α] [FirstCountableTopology α]
+    {s : Set α} (hs : Dense s) {x y : α} (hy : x < y) :
+    ∃ u : ℕ → α, StrictAnti u ∧ (∀ n, u n ∈ (Ioo x y ∩ s)) ∧ Tendsto u atTop (𝓝 x) := by
+  simpa using hs.exists_seq_strictMono_tendsto' (α := αᵒᵈ) (OrderDual.toDual_lt_toDual.2 hy)
+
+theorem Dense.exists_seq_strictAnti_tendsto [DenselyOrdered α] [NoMaxOrder α]
+    [FirstCountableTopology α] {s : Set α} (hs : Dense s) (x : α) :
+    ∃ u : ℕ → α, StrictAnti u ∧ (∀ n, u n ∈ (Ioi x ∩ s)) ∧ Tendsto u atTop (𝓝 x) :=
+  hs.exists_seq_strictMono_tendsto (α := αᵒᵈ) x
 
 end OrderTopology

--- a/Mathlib/Topology/Order/IsLUB.lean
+++ b/Mathlib/Topology/Order/IsLUB.lean
@@ -161,7 +161,7 @@ theorem Dense.isLUB_inter_iff {α : Type*} [TopologicalSpace α] [Preorder α] [
 theorem Dense.isGLB_inter_iff {α : Type*} [TopologicalSpace α] [Preorder α] [ClosedIciTopology α]
     {s t : Set α} (hs : Dense s) (ht : IsOpen t) {x : α} :
     IsGLB (t ∩ s) x ↔ IsGLB t x :=
-  Dense.isLUB_inter_iff (α := αᵒᵈ) hs ht
+  hs.isLUB_inter_iff (α := αᵒᵈ) ht
 
 /-!
 ### Existence of sequences tending to `sInf` or `sSup` of a given set
@@ -221,17 +221,15 @@ theorem Dense.exists_seq_strictMono_tendsto' [DenselyOrdered α] [FirstCountable
     obtain ⟨z, hyz, hzx⟩ := hs.exists_between hy
     exact ⟨z, mem_inter hzx hyz⟩
   have hx : IsLUB (Ioo y x ∩ s) x := hs.isLUB_inter_iff isOpen_Ioo |>.mpr <| isLUB_Ioo hy
-  obtain ⟨u, hu⟩ := hx.exists_seq_strictMono_tendsto_of_not_mem (by simp) hnonempty
-  exact ⟨u, hu.1, hu.2.2.symm⟩
+  apply hx.exists_seq_strictMono_tendsto_of_not_mem (by aesop) hnonempty |>.imp
+  aesop
 
 theorem Dense.exists_seq_strictMono_tendsto [DenselyOrdered α] [NoMinOrder α]
     [FirstCountableTopology α] {s : Set α} (hs : Dense s) (x : α) :
     ∃ u : ℕ → α, StrictMono u ∧ (∀ n, u n ∈ (Iio x ∩ s)) ∧ Tendsto u atTop (𝓝 x) := by
-  obtain ⟨y, hy⟩ : ∃ y, y < x := exists_lt x
-  obtain ⟨u, hu_mono, hu_mem, hux⟩ := hs.exists_seq_strictMono_tendsto' hy
-  have hu_mem' (n) : u n ∈ Iio x ∩ s :=
-    Set.mem_of_mem_of_subset (hu_mem n) <| inter_subset_inter_left _ Ioo_subset_Iio_self
-  exact ⟨u, hu_mono, hu_mem', hux⟩
+  obtain ⟨y, hy⟩ := exists_lt x
+  apply hs.exists_seq_strictMono_tendsto' (exists_lt x).choose_spec |>.imp
+  aesop
 
 theorem IsGLB.exists_seq_strictAnti_tendsto_of_not_mem {t : Set α} {x : α}
     [IsCountablyGenerated (𝓝 x)] (htx : IsGLB t x) (not_mem : x ∉ t) (ht : t.Nonempty) :


### PR DESCRIPTION
Add `Dense.exists_seq_strict{Mono/Anti}_tendsto{'}` that restricts the sequence to a dense subset. This is useful for e.g. finding a monotone rational sequence approaching a real number.

Co-authored-by: Jireh Loreaux <loreaujy@gmail.com>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
