### PR TITLE
[Merged by Bors] - chore: rename primed theorem for `CharP`

### DIFF
--- a/Mathlib/Algebra/CharP/Algebra.lean
+++ b/Mathlib/Algebra/CharP/Algebra.lean
@@ -49,7 +49,7 @@ theorem CharP.of_ringHom_of_ne_zero {R A : Type*} [Ring R] [NoZeroDivisors R]
 /-- If a ring homomorphism `R →+* A` is injective then `A` has the same characteristic as `R`. -/
 theorem charP_of_injective_ringHom {R A : Type*} [NonAssocSemiring R] [NonAssocSemiring A]
     {f : R →+* A} (h : Function.Injective f) (p : ℕ) [CharP R p] : CharP A p where
-  cast_eq_zero_iff' x := by
+  cast_eq_zero_iff x := by
     rw [← CharP.cast_eq_zero_iff R p x, ← map_natCast f x, map_eq_zero_iff f h]
 
 /-- If the algebra map `R →+* A` is injective then `A` has the same characteristic as `R`. -/

--- a/Mathlib/Algebra/CharP/Basic.lean
+++ b/Mathlib/Algebra/CharP/Basic.lean
@@ -134,7 +134,7 @@ variable (S : Type*) [AddMonoidWithOne R] [AddMonoidWithOne S] (p q : ℕ) [Char
 /-- The characteristic of the product of rings is the least common multiple of the
 characteristics of the two rings. -/
 instance Nat.lcm.charP [CharP S q] : CharP (R × S) (Nat.lcm p q) where
-  cast_eq_zero_iff' := by
+  cast_eq_zero_iff := by
     simp [Prod.ext_iff, CharP.cast_eq_zero_iff R p, CharP.cast_eq_zero_iff S q, Nat.lcm_dvd_iff]
 
 /-- The characteristic of the product of two rings of the same characteristic
@@ -151,10 +151,10 @@ instance Prod.charZero_of_right [CharZero S] : CharZero (R × S) where
 end Prod
 
 instance ULift.charP [AddMonoidWithOne R] (p : ℕ) [CharP R p] : CharP (ULift R) p where
-  cast_eq_zero_iff' n := Iff.trans ULift.ext_iff <| CharP.cast_eq_zero_iff R p n
+  cast_eq_zero_iff n := Iff.trans ULift.ext_iff <| CharP.cast_eq_zero_iff R p n
 
 instance MulOpposite.charP [AddMonoidWithOne R] (p : ℕ) [CharP R p] : CharP Rᵐᵒᵖ p where
-  cast_eq_zero_iff' n := MulOpposite.unop_inj.symm.trans <| CharP.cast_eq_zero_iff R p n
+  cast_eq_zero_iff n := MulOpposite.unop_inj.symm.trans <| CharP.cast_eq_zero_iff R p n
 
 section
 
@@ -186,7 +186,7 @@ namespace Fin
 
 /-- The characteristic of `F_p` is `p`. -/
 @[stacks 09FS "First part. We don't require `p` to be a prime in mathlib."]
-instance charP (n : ℕ) [NeZero n] : CharP (Fin n) n where cast_eq_zero_iff' _ := natCast_eq_zero
+instance charP (n : ℕ) [NeZero n] : CharP (Fin n) n where cast_eq_zero_iff _ := natCast_eq_zero
 
 end Fin
 

--- a/Mathlib/Algebra/CharP/Defs.lean
+++ b/Mathlib/Algebra/CharP/Defs.lean
@@ -38,14 +38,14 @@ For instance, endowing `{0, 1}` with addition given by `max` (i.e. `1` is absorb
 This example is formalized in `Counterexamples/CharPZeroNeCharZero.lean`.
 -/
 @[mk_iff]
-class _root_.CharP : Prop where
-  cast_eq_zero_iff' : ∀ x : ℕ, (x : R) = 0 ↔ p ∣ x
+class _root_.CharP (R : Type*) [AddMonoidWithOne R] (p : ℕ) : Prop where
+  cast_eq_zero_iff (R p) : ∀ x : ℕ, (x : R) = 0 ↔ p ∣ x
 
 variable [CharP R p] {a b : ℕ}
 
--- Porting note: the field of the structure had implicit arguments where they were
--- explicit in Lean 3
-lemma cast_eq_zero_iff (a : ℕ) : (a : R) = 0 ↔ p ∣ a := cast_eq_zero_iff' a
+@[deprecated CharP.cast_eq_zero_iff (since := "2025-04-03")]
+lemma cast_eq_zero_iff' (R : Type*) [AddMonoidWithOne R] (p : ℕ) [CharP R p] (a : ℕ) :
+    (a : R) = 0 ↔ p ∣ a := cast_eq_zero_iff R p a
 
 variable {R} in
 lemma congr {q : ℕ} (h : p = q) : CharP R q := h ▸ ‹CharP R p›
@@ -64,7 +64,7 @@ lemma eq {p q : ℕ} (_hp : CharP R p) (_hq : CharP R q) : p = q :=
     ((cast_eq_zero_iff R q p).1 (cast_eq_zero _ _))
 
 instance ofCharZero [CharZero R] : CharP R 0 where
-  cast_eq_zero_iff' x := by rw [zero_dvd_iff, ← Nat.cast_zero, Nat.cast_inj]
+  cast_eq_zero_iff x := by rw [zero_dvd_iff, ← Nat.cast_zero, Nat.cast_inj]
 
 end AddMonoidWithOne
 

--- a/Mathlib/Algebra/CharP/LinearMaps.lean
+++ b/Mathlib/Algebra/CharP/LinearMaps.lean
@@ -39,7 +39,7 @@ variable {R M : Type*} [CommSemiring R] [AddCommMonoid M] [Module R M]
   characteristic of the `R`-linear endomorphisms of `M`. -/
 theorem charP_end {p : ℕ} [hchar : CharP R p]
     (htorsion : ∃ x : M, Ideal.torsionOf R M x = ⊥) : CharP (M →ₗ[R] M) p where
-  cast_eq_zero_iff' n := by
+  cast_eq_zero_iff n := by
     have exact : (n : M →ₗ[R] M) = (n : R) • 1 := by
       simp only [Nat.cast_smul_eq_nsmul, nsmul_eq_mul, mul_one]
     rw [exact, LinearMap.ext_iff, ← hchar.1]

--- a/Mathlib/Algebra/CharP/Two.lean
+++ b/Mathlib/Algebra/CharP/Two.lean
@@ -30,7 +30,7 @@ theorem two_eq_zero [CharP R 2] : (2 : R) = 0 := by
 
 /-- The only hypotheses required to build a `CharP R 2` instance are `1 ≠ 0` and `2 = 0`. -/
 theorem of_one_ne_zero_of_two_eq_zero (h₁ : (1 : R) ≠ 0) (h₂ : (2 : R) = 0) : CharP R 2 where
-  cast_eq_zero_iff' n := by
+  cast_eq_zero_iff n := by
     obtain hn | hn := Nat.even_or_odd n
     · simp_rw [hn.two_dvd, iff_true]
       exact natCast_eq_zero_of_even_of_two_eq_zero hn h₂

--- a/Mathlib/Data/Matrix/CharP.lean
+++ b/Mathlib/Data/Matrix/CharP.lean
@@ -20,5 +20,5 @@ variable {n : Type*} {R : Type*} [AddMonoidWithOne R]
 
 instance Matrix.charP [DecidableEq n] [Nonempty n] (p : ℕ) [CharP R p] :
     CharP (Matrix n n R) p where
-  cast_eq_zero_iff' k := by simp_rw [← diagonal_natCast, ← diagonal_zero, diagonal_eq_diagonal_iff,
+  cast_eq_zero_iff k := by simp_rw [← diagonal_natCast, ← diagonal_zero, diagonal_eq_diagonal_iff,
     CharP.cast_eq_zero_iff R p k, forall_const]

--- a/Mathlib/Data/ZMod/Basic.lean
+++ b/Mathlib/Data/ZMod/Basic.lean
@@ -101,7 +101,7 @@ lemma eq_one_of_isUnit_natCast {n : ℕ} (h : IsUnit (n : ZMod 0)) : n = 1 := by
   rw [← Nat.mod_zero n, ← val_natCast, val_unit'.mp h]
 
 instance charP (n : ℕ) : CharP (ZMod n) n where
-  cast_eq_zero_iff' := by
+  cast_eq_zero_iff := by
     intro k
     rcases n with - | n
     · simp [zero_dvd_iff, Int.natCast_eq_zero]

--- a/Mathlib/GroupTheory/OrderOfElement.lean
+++ b/Mathlib/GroupTheory/OrderOfElement.lean
@@ -1133,13 +1133,13 @@ section NonAssocRing
 variable (R : Type*) [NonAssocRing R] (p : ℕ)
 
 lemma CharP.addOrderOf_one : CharP R (addOrderOf (1 : R)) where
-  cast_eq_zero_iff' n := by rw [← Nat.smul_one_eq_cast, addOrderOf_dvd_iff_nsmul_eq_zero]
+  cast_eq_zero_iff n := by rw [← Nat.smul_one_eq_cast, addOrderOf_dvd_iff_nsmul_eq_zero]
 
 variable [Fintype R]
 
 variable {R} in
 lemma charP_of_ne_zero (hn : card R = p) (hR : ∀ i < p, (i : R) = 0 → i = 0) : CharP R p where
-  cast_eq_zero_iff' n := by
+  cast_eq_zero_iff n := by
     have H : (p : R) = 0 := by rw [← hn, Nat.cast_card_eq_zero]
     constructor
     · intro h

--- a/Mathlib/RingTheory/MvPolynomial/Basic.lean
+++ b/Mathlib/RingTheory/MvPolynomial/Basic.lean
@@ -54,7 +54,7 @@ instance {σ : Type*} {R : Type*} [CommSemiring R]
 section CharP
 
 instance [CharP R p] : CharP (MvPolynomial σ R) p where
-  cast_eq_zero_iff' n := by rw [← C_eq_coe_nat, ← C_0, C_inj, CharP.cast_eq_zero_iff R p]
+  cast_eq_zero_iff n := by rw [← C_eq_coe_nat, ← C_0, C_inj, CharP.cast_eq_zero_iff R p]
 
 end CharP
 


### PR DESCRIPTION
For `CharP`, make use of the new feature where binder kinds of structure parameters can be precisely controlled. Now `CharP.cast_eq_zero_iff` is the field and `CharP.cast_eq_zero_iff'` is a definition.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
