### PR TITLE
feat: euclidean half spaces and quadrants have convex interior

### DIFF
--- a/Mathlib/Geometry/Manifold/Instances/Real.lean
+++ b/Mathlib/Geometry/Manifold/Instances/Real.lean
@@ -197,26 +197,21 @@ theorem frontier_quadrant (n : ℕ) (p : ℝ≥0∞) (a : ℝ) :
   simp only [mem_diff, mem_setOf_eq, not_forall, not_lt, and_congr_right_iff]
   exact fun aux ↦ exists_congr fun i ↦ ⟨fun h ↦ by linarith [aux i], fun h ↦ by linarith⟩
 
-lemma aux {a b c d : ℝ} (ha : 0 ≤ a) (hb : 0 ≤ b) (hab : a + b = 1) (hc : 0 < c) (hd : 0 < d) :
-    0 < a * c + b * d := by
-  have : 0 < a ∨ 0 < b := by
-    by_contra!
-    linarith
-  cases this <;> positivity
-
 theorem EuclideanHalfSpace.convex_interior [NeZero n] :
     Convex ℝ (interior { x : EuclideanSpace ℝ (Fin n) | 0 ≤ x 0 }) := by
   rw [interior_halfSpace]
   intro x hx y hy a b ha hb hab
   dsimp at hx hy ⊢
-  exact aux ha hb hab hx hy
+  exact (by positivity : 0 < min (x 0) (y 0)).trans_le (Convex.min_le_combo (x 0) (y 0) ha hb hab)
 
 theorem EuclideanQuadrant.convex_interior :
     Convex ℝ (interior { x : EuclideanSpace ℝ (Fin n) | ∀ i, 0 ≤ x i }) := by
   rw [interior_quadrant]
   intro x hx y hy a b ha hb hab
   dsimp at hx hy ⊢
-  exact fun i ↦ aux ha hb hab (hx i) (hy i)
+  intro i
+  have : 0 < min (x i) (y i) := by specialize hx i; specialize hy i; positivity
+  exact this.trans_le (Convex.min_le_combo (x i) (y i) ha hb hab)
 
 end
 

--- a/Mathlib/Geometry/Manifold/Instances/Real.lean
+++ b/Mathlib/Geometry/Manifold/Instances/Real.lean
@@ -168,25 +168,24 @@ open ENNReal in
 theorem interior_quadrant (n : ℕ) (p : ℝ≥0∞) (a : ℝ) :
     interior { y : PiLp p (fun _ : Fin n ↦ ℝ) | ∀ i : Fin n, a ≤ y i } =
       { y | ∀ i : Fin n, a < y i } := by
-  let f : (Fin n) → (Π _ : Fin n, ℝ) →L[ℝ] ℝ := fun i ↦ ContinuousLinearMap.proj i
-  have h : { y : PiLp p (fun _ : Fin n ↦ ℝ) | ∀ i : Fin n, a ≤ y i } = ⋂ i, (f i )⁻¹' Ici a := by
-    ext; simp; rfl
-  have h' : { y : PiLp p (fun _ : Fin n ↦ ℝ) | ∀ i : Fin n, a < y i } = ⋂ i, (f i )⁻¹' Ioi a := by
-    ext; simp; rfl
+  let f : Fin n → (Π _ : Fin n, ℝ) →L[ℝ] ℝ := fun i ↦ ContinuousLinearMap.proj i
+  have h : { y : PiLp p (fun _ : Fin n ↦ ℝ) | ∀ i : Fin n, a ≤ y i } = ⋂ i, (f i)⁻¹' Ici a := by
+    ext; simp [f]
+  have h' : { y : PiLp p (fun _ : Fin n ↦ ℝ) | ∀ i : Fin n, a < y i } = ⋂ i, (f i)⁻¹' Ioi a := by
+    ext; simp [f]
   rw [h, h', interior_iInter_of_finite]
   apply iInter_congr fun i ↦ ?_
   rw [(f i).interior_preimage, interior_Ici]
-  apply Function.surjective_eval
+  exact Function.surjective_eval _
 
 open ENNReal in
 theorem closure_quadrant (n : ℕ) (p : ℝ≥0∞) (a : ℝ) :
     closure { y : PiLp p (fun _ : Fin n ↦ ℝ) | ∀ i : Fin n, a ≤ y i } =
       { y | ∀ i : Fin n, a ≤ y i } := by
-  let f : (Fin n) → (Π _ : Fin n, ℝ) →L[ℝ] ℝ := fun i ↦ ContinuousLinearMap.proj i
-  have h : { y : PiLp p (fun _ : Fin n ↦ ℝ) | ∀ i : Fin n, a ≤ y i } = ⋂ i, (f i )⁻¹' Ici a := by
-    ext; simp; rfl
-  rw [h]
-  exact (isClosed_iInter fun i ↦ isClosed_Ici.preimage (f i).continuous).closure_eq
+  let f : Fin n → (Π _ : Fin n, ℝ) →L[ℝ] ℝ := fun i ↦ ContinuousLinearMap.proj i
+  have h : { y : PiLp p (fun _ : Fin n ↦ ℝ) | ∀ i : Fin n, a ≤ y i } = ⋂ i, (f i)⁻¹' Ici a := by
+    ext; simp [f]
+  exact h ▸ (isClosed_iInter fun i ↦ isClosed_Ici.preimage (f i).continuous).closure_eq
 
 open ENNReal in
 theorem frontier_quadrant (n : ℕ) (p : ℝ≥0∞) (a : ℝ) :
@@ -195,7 +194,7 @@ theorem frontier_quadrant (n : ℕ) (p : ℝ≥0∞) (a : ℝ) :
   rw [frontier, closure_quadrant, interior_quadrant]
   ext y
   simp only [mem_diff, mem_setOf_eq, not_forall, not_lt, and_congr_right_iff]
-  exact fun aux ↦ exists_congr fun i ↦ ⟨fun h ↦ by linarith [aux i], fun h ↦ by linarith⟩
+  exact fun h ↦ exists_congr fun i ↦ ⟨fun _ ↦ by linarith [h i], fun h ↦ by linarith⟩
 
 theorem EuclideanHalfSpace.convex_interior [NeZero n] :
     Convex ℝ (interior { x : EuclideanSpace ℝ (Fin n) | 0 ≤ x 0 }) := by


### PR DESCRIPTION
These lemmas are a prerequisite for #23658, which will impose that real or complex models with corners have convex interior.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
