### PR TITLE
chore(Algebra): split `Order/Floor.lean` into `Defs` and `Basic`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -752,7 +752,8 @@ import Mathlib.Algebra.Order.Field.Pointwise
 import Mathlib.Algebra.Order.Field.Power
 import Mathlib.Algebra.Order.Field.Rat
 import Mathlib.Algebra.Order.Field.Subfield
-import Mathlib.Algebra.Order.Floor
+import Mathlib.Algebra.Order.Floor.Basic
+import Mathlib.Algebra.Order.Floor.Defs
 import Mathlib.Algebra.Order.Floor.Div
 import Mathlib.Algebra.Order.Group.Abs
 import Mathlib.Algebra.Order.Group.Action

--- a/Mathlib/Algebra/ContinuedFractions/Computation/Basic.lean
+++ b/Mathlib/Algebra/ContinuedFractions/Computation/Basic.lean
@@ -3,8 +3,9 @@ Copyright (c) 2020 Kevin Kappelmann. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kevin Kappelmann
 -/
-import Mathlib.Algebra.Order.Floor
 import Mathlib.Algebra.ContinuedFractions.Basic
+import Mathlib.Algebra.Order.Field.Defs
+import Mathlib.Algebra.Order.Floor.Defs
 
 /-!
 # Computable Continued Fractions

--- a/Mathlib/Algebra/ContinuedFractions/Computation/Translations.lean
+++ b/Mathlib/Algebra/ContinuedFractions/Computation/Translations.lean
@@ -5,6 +5,7 @@ Authors: Kevin Kappelmann
 -/
 import Mathlib.Algebra.ContinuedFractions.Computation.Basic
 import Mathlib.Algebra.ContinuedFractions.Translations
+import Mathlib.Algebra.Order.Floor.Basic
 
 /-!
 # Basic Translation Lemmas Between Structures Defined for Computing Continued Fractions

--- a/Mathlib/Algebra/Order/Floor/Basic.lean
+++ b/Mathlib/Algebra/Order/Floor/Basic.lean
@@ -3,14 +3,9 @@ Copyright (c) 2018 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Kevin Kappelmann
 -/
-import Mathlib.Algebra.Group.Int.Even
-import Mathlib.Algebra.Group.Int.Units
-import Mathlib.Algebra.Ring.CharZero
+import Mathlib.Algebra.Order.Floor.Defs
+import Mathlib.Order.SetNotation
 import Mathlib.Data.Nat.Cast.Order.Field
-import Mathlib.Data.Set.Function
-import Mathlib.Data.Set.Monotone
-import Mathlib.Data.Set.Subsingleton
-import Mathlib.Order.Interval.Set.Defs
 import Mathlib.Tactic.Abel
 import Mathlib.Tactic.FieldSimp
 import Mathlib.Tactic.Linarith
@@ -21,18 +16,7 @@ import Mathlib.Tactic.Positivity.Basic
 
 ## Summary
 
-We define the natural- and integer-valued floor and ceil functions on linearly ordered rings.
-
-## Main Definitions
-
-* `FloorSemiring`: An ordered semiring with natural-valued floor and ceil.
-* `Nat.floor a`: Greatest natural `n` such that `n ≤ a`. Equal to `0` if `a < 0`.
-* `Nat.ceil a`: Least natural `n` such that `a ≤ n`.
-
-* `FloorRing`: A linearly ordered ring with integer-valued floor and ceil.
-* `Int.floor a`: Greatest integer `z` such that `z ≤ a`.
-* `Int.ceil a`: Least integer `z` such that `a ≤ z`.
-* `Int.fract a`: Fractional part of `a`, defined as `a - floor a`.
+This file contains basic results on the floor, ceiling and fractional part operators.
 
 ## Notations
 
@@ -62,75 +46,7 @@ variable {F α β : Type*}
 
 /-! ### Floor semiring -/
 
-/-- A `FloorSemiring` is an ordered semiring over `α` with a function
-`floor : α → ℕ` satisfying `∀ (n : ℕ) (x : α), n ≤ ⌊x⌋ ↔ (n : α) ≤ x)`.
-Note that many lemmas require a `LinearOrder`. Please see the above `TODO`. -/
-class FloorSemiring (α) [OrderedSemiring α] where
-  /-- `FloorSemiring.floor a` computes the greatest natural `n` such that `(n : α) ≤ a`. -/
-  floor : α → ℕ
-  /-- `FloorSemiring.ceil a` computes the least natural `n` such that `a ≤ (n : α)`. -/
-  ceil : α → ℕ
-  /-- `FloorSemiring.floor` of a negative element is zero. -/
-  floor_of_neg {a : α} (ha : a < 0) : floor a = 0
-  /-- A natural number `n` is smaller than `FloorSemiring.floor a` iff its coercion to `α` is
-  smaller than `a`. -/
-  gc_floor {a : α} {n : ℕ} (ha : 0 ≤ a) : n ≤ floor a ↔ (n : α) ≤ a
-  /-- `FloorSemiring.ceil` is the lower adjoint of the coercion `↑ : ℕ → α`. -/
-  gc_ceil : GaloisConnection ceil (↑)
-
-instance : FloorSemiring ℕ where
-  floor := id
-  ceil := id
-  floor_of_neg ha := (Nat.not_lt_zero _ ha).elim
-  gc_floor _ := by
-    rw [Nat.cast_id]
-    rfl
-  gc_ceil n a := by
-    rw [Nat.cast_id]
-    rfl
-
 namespace Nat
-
-section OrderedSemiring
-
-variable [OrderedSemiring α] [FloorSemiring α] {a : α} {n : ℕ}
-
-/-- `⌊a⌋₊` is the greatest natural `n` such that `n ≤ a`. If `a` is negative, then `⌊a⌋₊ = 0`. -/
-def floor : α → ℕ :=
-  FloorSemiring.floor
-
-/-- `⌈a⌉₊` is the least natural `n` such that `a ≤ n` -/
-def ceil : α → ℕ :=
-  FloorSemiring.ceil
-
-@[simp]
-theorem floor_nat : (Nat.floor : ℕ → ℕ) = id :=
-  rfl
-
-@[simp]
-theorem ceil_nat : (Nat.ceil : ℕ → ℕ) = id :=
-  rfl
-
-@[inherit_doc]
-notation "⌊" a "⌋₊" => Nat.floor a
-
-@[inherit_doc]
-notation "⌈" a "⌉₊" => Nat.ceil a
-
-theorem le_floor_iff (ha : 0 ≤ a) : n ≤ ⌊a⌋₊ ↔ (n : α) ≤ a :=
-  FloorSemiring.gc_floor ha
-
-theorem le_floor (h : (n : α) ≤ a) : n ≤ ⌊a⌋₊ :=
-  (le_floor_iff <| n.cast_nonneg.trans h).2 h
-
-theorem gc_ceil_coe : GaloisConnection (ceil : α → ℕ) (↑) :=
-  FloorSemiring.gc_ceil
-
-@[simp]
-theorem ceil_le : ⌈a⌉₊ ≤ n ↔ a ≤ n :=
-  gc_ceil_coe _ _
-
-end OrderedSemiring
 
 section LinearOrderedSemiring
 
@@ -245,9 +161,6 @@ theorem preimage_floor_of_ne_zero {n : ℕ} (hn : n ≠ 0) :
 
 /-! #### Ceil -/
 
-theorem lt_ceil : n < ⌈a⌉₊ ↔ (n : α) < a :=
-  lt_iff_lt_of_le_iff_le ceil_le
-
 theorem add_one_le_ceil_iff : n + 1 ≤ ⌈a⌉₊ ↔ (n : α) < a := by
   rw [← Nat.lt_ceil, Nat.add_one_le_iff]
 
@@ -291,9 +204,6 @@ theorem ceil_ofNat (n : ℕ) [n.AtLeastTwo] : ⌈(ofNat(n) : α)⌉₊ = ofNat(n
 
 @[simp]
 theorem ceil_eq_zero : ⌈a⌉₊ = 0 ↔ a ≤ 0 := by rw [← Nat.le_zero, ceil_le, Nat.cast_zero]
-
-@[simp]
-theorem ceil_pos : 0 < ⌈a⌉₊ ↔ 0 < a := by rw [lt_ceil, cast_zero]
 
 theorem lt_of_ceil_lt (h : ⌈a⌉₊ < n) : a < n :=
   (le_ceil a).trans_lt (Nat.cast_lt.2 h)
@@ -546,108 +456,14 @@ theorem subsingleton_floorSemiring {α} [LinearOrderedSemiring α] :
 
 /-! ### Floor rings -/
 
-/-- A `FloorRing` is a linear ordered ring over `α` with a function
-`floor : α → ℤ` satisfying `∀ (z : ℤ) (a : α), z ≤ floor a ↔ (z : α) ≤ a)`.
--/
-class FloorRing (α) [LinearOrderedRing α] where
-  /-- `FloorRing.floor a` computes the greatest integer `z` such that `(z : α) ≤ a`. -/
-  floor : α → ℤ
-  /-- `FloorRing.ceil a` computes the least integer `z` such that `a ≤ (z : α)`. -/
-  ceil : α → ℤ
-  /-- `FloorRing.ceil` is the upper adjoint of the coercion `↑ : ℤ → α`. -/
-  gc_coe_floor : GaloisConnection (↑) floor
-  /-- `FloorRing.ceil` is the lower adjoint of the coercion `↑ : ℤ → α`. -/
-  gc_ceil_coe : GaloisConnection ceil (↑)
-
-instance : FloorRing ℤ where
-  floor := id
-  ceil := id
-  gc_coe_floor a b := by
-    rw [Int.cast_id]
-    rfl
-  gc_ceil_coe a b := by
-    rw [Int.cast_id]
-    rfl
-
-/-- A `FloorRing` constructor from the `floor` function alone. -/
-def FloorRing.ofFloor (α) [LinearOrderedRing α] (floor : α → ℤ)
-    (gc_coe_floor : GaloisConnection (↑) floor) : FloorRing α :=
-  { floor
-    ceil := fun a => -floor (-a)
-    gc_coe_floor
-    gc_ceil_coe := fun a z => by rw [neg_le, ← gc_coe_floor, Int.cast_neg, neg_le_neg_iff] }
-
-/-- A `FloorRing` constructor from the `ceil` function alone. -/
-def FloorRing.ofCeil (α) [LinearOrderedRing α] (ceil : α → ℤ)
-    (gc_ceil_coe : GaloisConnection ceil (↑)) : FloorRing α :=
-  { floor := fun a => -ceil (-a)
-    ceil
-    gc_coe_floor := fun a z => by rw [le_neg, gc_ceil_coe, Int.cast_neg, neg_le_neg_iff]
-    gc_ceil_coe }
-
 namespace Int
 
 variable [LinearOrderedRing α] [FloorRing α] {z : ℤ} {a b : α}
 
-/-- `Int.floor a` is the greatest integer `z` such that `z ≤ a`. It is denoted with `⌊a⌋`. -/
-def floor : α → ℤ :=
-  FloorRing.floor
-
-/-- `Int.ceil a` is the smallest integer `z` such that `a ≤ z`. It is denoted with `⌈a⌉`. -/
-def ceil : α → ℤ :=
-  FloorRing.ceil
-
-/-- `Int.fract a` the fractional part of `a`, is `a` minus its floor. -/
-def fract (a : α) : α :=
-  a - floor a
-
-@[simp]
-theorem floor_int : (Int.floor : ℤ → ℤ) = id :=
-  rfl
-
-@[simp]
-theorem ceil_int : (Int.ceil : ℤ → ℤ) = id :=
-  rfl
-
-@[simp]
-theorem fract_int : (Int.fract : ℤ → ℤ) = 0 :=
-  funext fun x => by simp [fract]
-
-@[inherit_doc]
-notation "⌊" a "⌋" => Int.floor a
-
-@[inherit_doc]
-notation "⌈" a "⌉" => Int.ceil a
-
--- Mathematical notation for `fract a` is usually `{a}`. Let's not even go there.
-
-@[simp]
-theorem floorRing_floor_eq : @FloorRing.floor = @Int.floor :=
-  rfl
-
-@[simp]
-theorem floorRing_ceil_eq : @FloorRing.ceil = @Int.ceil :=
-  rfl
-
 /-! #### Floor -/
-
-theorem gc_coe_floor : GaloisConnection ((↑) : ℤ → α) floor :=
-  FloorRing.gc_coe_floor
-
-theorem le_floor : z ≤ ⌊a⌋ ↔ (z : α) ≤ a :=
-  (gc_coe_floor z a).symm
-
-theorem floor_lt : ⌊a⌋ < z ↔ a < z :=
-  lt_iff_lt_of_le_iff_le le_floor
-
-@[bound]
-theorem floor_le (a : α) : (⌊a⌋ : α) ≤ a :=
-  gc_coe_floor.l_u_le a
 
 theorem floor_le_iff : ⌊a⌋ ≤ z ↔ a < z + 1 := by rw [← lt_add_one_iff, floor_lt]; norm_cast
 theorem lt_floor_iff : z < ⌊a⌋ ↔ z + 1 ≤ a := by rw [← add_one_le_iff, le_floor]; norm_cast
-
-theorem floor_nonneg : 0 ≤ ⌊a⌋ ↔ 0 ≤ a := by rw [le_floor, Int.cast_zero]
 
 @[simp]
 theorem floor_le_sub_one_iff : ⌊a⌋ ≤ z - 1 ↔ a < z := by rw [← floor_lt, le_sub_one_iff]
@@ -655,11 +471,6 @@ theorem floor_le_sub_one_iff : ⌊a⌋ ≤ z - 1 ↔ a < z := by rw [← floor_l
 @[simp]
 theorem floor_le_neg_one_iff : ⌊a⌋ ≤ -1 ↔ a < 0 := by
   rw [← zero_sub (1 : ℤ), floor_le_sub_one_iff, cast_zero]
-
-@[bound]
-theorem floor_nonpos (ha : a ≤ 0) : ⌊a⌋ ≤ 0 := by
-  rw [← @cast_le α, Int.cast_zero]
-  exact (floor_le a).trans ha
 
 theorem lt_succ_floor (a : α) : a < ⌊a⌋.succ :=
   floor_lt.1 <| Int.lt_succ_self _
@@ -1080,20 +891,11 @@ end LinearOrderedField
 
 /-! #### Ceil -/
 
-theorem gc_ceil_coe : GaloisConnection ceil ((↑) : ℤ → α) :=
-  FloorRing.gc_ceil_coe
-
-theorem ceil_le : ⌈a⌉ ≤ z ↔ a ≤ z :=
-  gc_ceil_coe a z
-
 theorem floor_neg : ⌊-a⌋ = -⌈a⌉ :=
   eq_of_forall_le_iff fun z => by rw [le_neg, ceil_le, le_floor, Int.cast_neg, le_neg]
 
 theorem ceil_neg : ⌈-a⌉ = -⌊a⌋ :=
   eq_of_forall_ge_iff fun z => by rw [neg_le, ceil_le, le_floor, Int.cast_neg, neg_le]
-
-theorem lt_ceil : z < ⌈a⌉ ↔ (z : α) < a :=
-  lt_iff_lt_of_le_iff_le ceil_le
 
 @[simp]
 theorem add_one_le_ceil_iff : z + 1 ≤ ⌈a⌉ ↔ (z : α) < a := by rw [← lt_ceil, add_one_le_iff]
@@ -1106,10 +908,6 @@ theorem one_le_ceil_iff : 1 ≤ ⌈a⌉ ↔ 0 < a := by
 theorem ceil_le_floor_add_one (a : α) : ⌈a⌉ ≤ ⌊a⌋ + 1 := by
   rw [ceil_le, Int.cast_add, Int.cast_one]
   exact (lt_floor_add_one a).le
-
-@[bound]
-theorem le_ceil (a : α) : a ≤ ⌈a⌉ :=
-  gc_ceil_coe.le_u_l a
 
 lemma le_ceil_iff : z ≤ ⌈a⌉ ↔ z - 1 < a := by rw [← sub_one_lt_iff, lt_ceil]; norm_cast
 lemma ceil_lt_iff : ⌈a⌉ < z ↔ a ≤ z - 1 := by rw [← le_sub_one_iff, ceil_le]; norm_cast
@@ -1191,16 +989,10 @@ theorem ceil_add_ceil_le (a b : α) : ⌈a⌉ + ⌈b⌉ ≤ ⌈a + b⌉ + 1 := b
   exact le_ceil _
 
 @[simp]
-theorem ceil_pos : 0 < ⌈a⌉ ↔ 0 < a := by rw [lt_ceil, cast_zero]
-
-@[simp]
 theorem ceil_zero : ⌈(0 : α)⌉ = 0 := by rw [← cast_zero, ceil_intCast]
 
 @[simp]
 theorem ceil_one : ⌈(1 : α)⌉ = 1 := by rw [← cast_one, ceil_intCast]
-
-@[bound]
-theorem ceil_nonneg (ha : 0 ≤ a) : 0 ≤ ⌈a⌉ := mod_cast ha.trans (le_ceil a)
 
 theorem ceil_nonneg_of_neg_one_lt (ha : -1 < a) : 0 ≤ ⌈a⌉ := by
   rwa [Int.le_ceil_iff, Int.cast_zero, zero_sub]
@@ -1408,29 +1200,6 @@ variable [LinearOrderedRing α] [FloorRing α]
 
 /-! #### A floor ring as a floor semiring -/
 
-
--- see Note [lower instance priority]
-instance (priority := 100) FloorRing.toFloorSemiring : FloorSemiring α where
-  floor a := ⌊a⌋.toNat
-  ceil a := ⌈a⌉.toNat
-  floor_of_neg {_} ha := Int.toNat_of_nonpos (Int.floor_nonpos ha.le)
-  gc_floor {a n} ha := by rw [Int.le_toNat (Int.floor_nonneg.2 ha), Int.le_floor, Int.cast_natCast]
-  gc_ceil a n := by rw [Int.toNat_le, Int.ceil_le, Int.cast_natCast]
-
-theorem Int.floor_toNat (a : α) : ⌊a⌋.toNat = ⌊a⌋₊ :=
-  rfl
-
-theorem Int.ceil_toNat (a : α) : ⌈a⌉.toNat = ⌈a⌉₊ :=
-  rfl
-
-@[simp]
-theorem Nat.floor_int : (Nat.floor : ℤ → ℕ) = Int.toNat :=
-  rfl
-
-@[simp]
-theorem Nat.ceil_int : (Nat.ceil : ℤ → ℕ) = Int.toNat :=
-  rfl
-
 variable {a : α}
 
 theorem Int.natCast_floor_eq_floor (ha : 0 ≤ a) : (⌊a⌋₊ : ℤ) = ⌊a⌋ := by
@@ -1460,71 +1229,3 @@ theorem subsingleton_floorRing {α} [LinearOrderedRing α] : Subsingleton (Floor
     funext fun a => (H₁.gc_coe_floor.u_unique H₂.gc_coe_floor) fun _ => rfl
   have : H₁.ceil = H₂.ceil := funext fun a => (H₁.gc_ceil_coe.l_unique H₂.gc_ceil_coe) fun _ => rfl
   cases H₁; cases H₂; congr
-
-namespace Mathlib.Meta.Positivity
-open Lean.Meta Qq
-
-private theorem int_floor_nonneg [LinearOrderedRing α] [FloorRing α] {a : α} (ha : 0 ≤ a) :
-    0 ≤ ⌊a⌋ :=
-  Int.floor_nonneg.2 ha
-
-private theorem int_floor_nonneg_of_pos [LinearOrderedRing α] [FloorRing α] {a : α}
-    (ha : 0 < a) :
-    0 ≤ ⌊a⌋ :=
-  int_floor_nonneg ha.le
-
-/-- Extension for the `positivity` tactic: `Int.floor` is nonnegative if its input is. -/
-@[positivity ⌊ _ ⌋]
-def evalIntFloor : PositivityExt where eval {u α} _zα _pα e := do
-  match u, α, e with
-  | 0, ~q(ℤ), ~q(@Int.floor $α' $i $j $a) =>
-    match ← core q(inferInstance) q(inferInstance) a with
-    | .positive pa =>
-        assertInstancesCommute
-        pure (.nonnegative q(int_floor_nonneg_of_pos (α := $α') $pa))
-    | .nonnegative pa =>
-        assertInstancesCommute
-        pure (.nonnegative q(int_floor_nonneg (α := $α') $pa))
-    | _ => pure .none
-  | _, _, _ => throwError "failed to match on Int.floor application"
-
-private theorem nat_ceil_pos [LinearOrderedSemiring α] [FloorSemiring α] {a : α} :
-    0 < a → 0 < ⌈a⌉₊ :=
-  Nat.ceil_pos.2
-
-/-- Extension for the `positivity` tactic: `Nat.ceil` is positive if its input is. -/
-@[positivity ⌈ _ ⌉₊]
-def evalNatCeil : PositivityExt where eval {u α} _zα _pα e := do
-  match u, α, e with
-  | 0, ~q(ℕ), ~q(@Nat.ceil $α' $i $j $a) =>
-    let _i : Q(LinearOrderedSemiring $α') ← synthInstanceQ (u := u_1) _
-    assertInstancesCommute
-    match ← core q(inferInstance) q(inferInstance) a with
-    | .positive pa =>
-      assertInstancesCommute
-      pure (.positive q(nat_ceil_pos (α := $α') $pa))
-    | _ => pure .none
-  | _, _, _ => throwError "failed to match on Nat.ceil application"
-
-private theorem int_ceil_pos [LinearOrderedRing α] [FloorRing α] {a : α} : 0 < a → 0 < ⌈a⌉ :=
-  Int.ceil_pos.2
-
-/-- Extension for the `positivity` tactic: `Int.ceil` is positive/nonnegative if its input is. -/
-@[positivity ⌈ _ ⌉]
-def evalIntCeil : PositivityExt where eval {u α} _zα _pα e := do
-  match u, α, e with
-  | 0, ~q(ℤ), ~q(@Int.ceil $α' $i $j $a) =>
-    match ← core q(inferInstance) q(inferInstance) a with
-    | .positive pa =>
-        assertInstancesCommute
-        pure (.positive q(int_ceil_pos (α := $α') $pa))
-    | .nonnegative pa =>
-        assertInstancesCommute
-        pure (.nonnegative q(Int.ceil_nonneg (α := $α') $pa))
-    | _ => pure .none
-  | _, _, _ => throwError "failed to match on Int.ceil application"
-
-end Mathlib.Meta.Positivity
-
--- Pushed over the limit by deprecations
-set_option linter.style.longFile 1600

--- a/Mathlib/Algebra/Order/Floor/Defs.lean
+++ b/Mathlib/Algebra/Order/Floor/Defs.lean
@@ -1,0 +1,363 @@
+/-
+Copyright (c) 2018 Mario Carneiro. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mario Carneiro, Kevin Kappelmann
+-/
+import Mathlib.Tactic.Positivity.Core
+
+/-!
+# Floor and ceil
+
+## Summary
+
+We define the natural- and integer-valued floor and ceil functions on linearly ordered rings.
+We also provide `positivity` extensions to handle floor and ceil.
+
+## Main Definitions
+
+* `FloorSemiring`: An ordered semiring with natural-valued floor and ceil.
+* `Nat.floor a`: Greatest natural `n` such that `n ≤ a`. Equal to `0` if `a < 0`.
+* `Nat.ceil a`: Least natural `n` such that `a ≤ n`.
+
+* `FloorRing`: A linearly ordered ring with integer-valued floor and ceil.
+* `Int.floor a`: Greatest integer `z` such that `z ≤ a`.
+* `Int.ceil a`: Least integer `z` such that `a ≤ z`.
+* `Int.fract a`: Fractional part of `a`, defined as `a - floor a`.
+
+## Notations
+
+* `⌊a⌋₊` is `Nat.floor a`.
+* `⌈a⌉₊` is `Nat.ceil a`.
+* `⌊a⌋` is `Int.floor a`.
+* `⌈a⌉` is `Int.ceil a`.
+
+The index `₊` in the notations for `Nat.floor` and `Nat.ceil` is used in analogy to the notation
+for `nnnorm`.
+
+## TODO
+
+`LinearOrderedRing`/`LinearOrderedSemiring` can be relaxed to `OrderedRing`/`OrderedSemiring` in
+many lemmas.
+
+## Tags
+
+rounding, floor, ceil
+-/
+
+assert_not_exists Finset
+
+open Set
+
+variable {F α β : Type*}
+
+/-! ### Floor semiring -/
+
+/-- A `FloorSemiring` is an ordered semiring over `α` with a function
+`floor : α → ℕ` satisfying `∀ (n : ℕ) (x : α), n ≤ ⌊x⌋ ↔ (n : α) ≤ x)`.
+Note that many lemmas require a `LinearOrder`. Please see the above `TODO`. -/
+class FloorSemiring (α) [OrderedSemiring α] where
+  /-- `FloorSemiring.floor a` computes the greatest natural `n` such that `(n : α) ≤ a`. -/
+  floor : α → ℕ
+  /-- `FloorSemiring.ceil a` computes the least natural `n` such that `a ≤ (n : α)`. -/
+  ceil : α → ℕ
+  /-- `FloorSemiring.floor` of a negative element is zero. -/
+  floor_of_neg {a : α} (ha : a < 0) : floor a = 0
+  /-- A natural number `n` is smaller than `FloorSemiring.floor a` iff its coercion to `α` is
+  smaller than `a`. -/
+  gc_floor {a : α} {n : ℕ} (ha : 0 ≤ a) : n ≤ floor a ↔ (n : α) ≤ a
+  /-- `FloorSemiring.ceil` is the lower adjoint of the coercion `↑ : ℕ → α`. -/
+  gc_ceil : GaloisConnection ceil (↑)
+
+instance : FloorSemiring ℕ where
+  floor := id
+  ceil := id
+  floor_of_neg ha := (Nat.not_lt_zero _ ha).elim
+  gc_floor _ := by
+    rw [Nat.cast_id]
+    rfl
+  gc_ceil n a := by
+    rw [Nat.cast_id]
+    rfl
+
+namespace Nat
+
+section OrderedSemiring
+
+variable [OrderedSemiring α] [FloorSemiring α] {a : α} {n : ℕ}
+
+/-- `⌊a⌋₊` is the greatest natural `n` such that `n ≤ a`. If `a` is negative, then `⌊a⌋₊ = 0`. -/
+def floor : α → ℕ :=
+  FloorSemiring.floor
+
+/-- `⌈a⌉₊` is the least natural `n` such that `a ≤ n` -/
+def ceil : α → ℕ :=
+  FloorSemiring.ceil
+
+@[simp]
+theorem floor_nat : (Nat.floor : ℕ → ℕ) = id :=
+  rfl
+
+@[simp]
+theorem ceil_nat : (Nat.ceil : ℕ → ℕ) = id :=
+  rfl
+
+@[inherit_doc]
+notation "⌊" a "⌋₊" => Nat.floor a
+
+@[inherit_doc]
+notation "⌈" a "⌉₊" => Nat.ceil a
+
+theorem le_floor_iff (ha : 0 ≤ a) : n ≤ ⌊a⌋₊ ↔ (n : α) ≤ a :=
+  FloorSemiring.gc_floor ha
+
+theorem le_floor (h : (n : α) ≤ a) : n ≤ ⌊a⌋₊ :=
+  (le_floor_iff <| n.cast_nonneg.trans h).2 h
+
+theorem gc_ceil_coe : GaloisConnection (ceil : α → ℕ) (↑) :=
+  FloorSemiring.gc_ceil
+
+@[simp]
+theorem ceil_le : ⌈a⌉₊ ≤ n ↔ a ≤ n :=
+  gc_ceil_coe _ _
+
+end OrderedSemiring
+
+section LinearOrderedSemiring
+
+variable [LinearOrderedSemiring α] [FloorSemiring α] {a b : α} {n : ℕ}
+
+theorem lt_ceil : n < ⌈a⌉₊ ↔ (n : α) < a :=
+  lt_iff_lt_of_le_iff_le ceil_le
+
+@[simp]
+theorem ceil_pos : 0 < ⌈a⌉₊ ↔ 0 < a := by rw [lt_ceil, cast_zero]
+
+end LinearOrderedSemiring
+
+end Nat
+
+/-! ### Floor rings -/
+
+/-- A `FloorRing` is a linear ordered ring over `α` with a function
+`floor : α → ℤ` satisfying `∀ (z : ℤ) (a : α), z ≤ floor a ↔ (z : α) ≤ a)`.
+-/
+class FloorRing (α) [LinearOrderedRing α] where
+  /-- `FloorRing.floor a` computes the greatest integer `z` such that `(z : α) ≤ a`. -/
+  floor : α → ℤ
+  /-- `FloorRing.ceil a` computes the least integer `z` such that `a ≤ (z : α)`. -/
+  ceil : α → ℤ
+  /-- `FloorRing.ceil` is the upper adjoint of the coercion `↑ : ℤ → α`. -/
+  gc_coe_floor : GaloisConnection (↑) floor
+  /-- `FloorRing.ceil` is the lower adjoint of the coercion `↑ : ℤ → α`. -/
+  gc_ceil_coe : GaloisConnection ceil (↑)
+
+instance : FloorRing ℤ where
+  floor := id
+  ceil := id
+  gc_coe_floor a b := by
+    rw [Int.cast_id]
+    rfl
+  gc_ceil_coe a b := by
+    rw [Int.cast_id]
+    rfl
+
+/-- A `FloorRing` constructor from the `floor` function alone. -/
+def FloorRing.ofFloor (α) [LinearOrderedRing α] (floor : α → ℤ)
+    (gc_coe_floor : GaloisConnection (↑) floor) : FloorRing α :=
+  { floor
+    ceil := fun a => -floor (-a)
+    gc_coe_floor
+    gc_ceil_coe := fun a z => by rw [neg_le, ← gc_coe_floor, Int.cast_neg, neg_le_neg_iff] }
+
+/-- A `FloorRing` constructor from the `ceil` function alone. -/
+def FloorRing.ofCeil (α) [LinearOrderedRing α] (ceil : α → ℤ)
+    (gc_ceil_coe : GaloisConnection ceil (↑)) : FloorRing α :=
+  { floor := fun a => -ceil (-a)
+    ceil
+    gc_coe_floor := fun a z => by rw [le_neg, gc_ceil_coe, Int.cast_neg, neg_le_neg_iff]
+    gc_ceil_coe }
+
+namespace Int
+
+variable [LinearOrderedRing α] [FloorRing α] {z : ℤ} {a b : α}
+
+/-- `Int.floor a` is the greatest integer `z` such that `z ≤ a`. It is denoted with `⌊a⌋`. -/
+def floor : α → ℤ :=
+  FloorRing.floor
+
+/-- `Int.ceil a` is the smallest integer `z` such that `a ≤ z`. It is denoted with `⌈a⌉`. -/
+def ceil : α → ℤ :=
+  FloorRing.ceil
+
+/-- `Int.fract a` the fractional part of `a`, is `a` minus its floor. -/
+def fract (a : α) : α :=
+  a - floor a
+
+@[simp]
+theorem floor_int : (Int.floor : ℤ → ℤ) = id :=
+  rfl
+
+@[simp]
+theorem ceil_int : (Int.ceil : ℤ → ℤ) = id :=
+  rfl
+
+@[simp]
+theorem fract_int : (Int.fract : ℤ → ℤ) = 0 :=
+  funext fun x => by simp [fract]
+
+@[inherit_doc]
+notation "⌊" a "⌋" => Int.floor a
+
+@[inherit_doc]
+notation "⌈" a "⌉" => Int.ceil a
+
+-- Mathematical notation for `fract a` is usually `{a}`. Let's not even go there.
+
+@[simp]
+theorem floorRing_floor_eq : @FloorRing.floor = @Int.floor :=
+  rfl
+
+@[simp]
+theorem floorRing_ceil_eq : @FloorRing.ceil = @Int.ceil :=
+  rfl
+
+/-! #### Floor -/
+
+theorem gc_coe_floor : GaloisConnection ((↑) : ℤ → α) floor :=
+  FloorRing.gc_coe_floor
+
+theorem le_floor : z ≤ ⌊a⌋ ↔ (z : α) ≤ a :=
+  (gc_coe_floor z a).symm
+
+theorem floor_lt : ⌊a⌋ < z ↔ a < z :=
+  lt_iff_lt_of_le_iff_le le_floor
+
+@[bound]
+theorem floor_le (a : α) : (⌊a⌋ : α) ≤ a :=
+  gc_coe_floor.l_u_le a
+
+theorem floor_nonneg : 0 ≤ ⌊a⌋ ↔ 0 ≤ a := by rw [le_floor, Int.cast_zero]
+
+@[bound]
+theorem floor_nonpos (ha : a ≤ 0) : ⌊a⌋ ≤ 0 := by
+  rw [← @cast_le α, Int.cast_zero]
+  exact (floor_le a).trans ha
+
+/-! #### Ceil -/
+
+theorem gc_ceil_coe : GaloisConnection ceil ((↑) : ℤ → α) :=
+  FloorRing.gc_ceil_coe
+
+theorem ceil_le : ⌈a⌉ ≤ z ↔ a ≤ z :=
+  gc_ceil_coe a z
+
+theorem lt_ceil : z < ⌈a⌉ ↔ (z : α) < a :=
+  lt_iff_lt_of_le_iff_le ceil_le
+
+@[bound]
+theorem le_ceil (a : α) : a ≤ ⌈a⌉ :=
+  gc_ceil_coe.le_u_l a
+
+@[bound]
+theorem ceil_nonneg (ha : 0 ≤ a) : 0 ≤ ⌈a⌉ := mod_cast ha.trans (le_ceil a)
+
+@[simp]
+theorem ceil_pos : 0 < ⌈a⌉ ↔ 0 < a := by rw [lt_ceil, cast_zero]
+
+end Int
+
+section FloorRingToSemiring
+
+variable [LinearOrderedRing α] [FloorRing α]
+
+/-! #### A floor ring as a floor semiring -/
+
+
+-- see Note [lower instance priority]
+instance (priority := 100) FloorRing.toFloorSemiring : FloorSemiring α where
+  floor a := ⌊a⌋.toNat
+  ceil a := ⌈a⌉.toNat
+  floor_of_neg {_} ha := Int.toNat_of_nonpos (Int.floor_nonpos ha.le)
+  gc_floor {a n} ha := by rw [Int.le_toNat (Int.floor_nonneg.2 ha), Int.le_floor, Int.cast_natCast]
+  gc_ceil a n := by rw [Int.toNat_le, Int.ceil_le, Int.cast_natCast]
+
+theorem Int.floor_toNat (a : α) : ⌊a⌋.toNat = ⌊a⌋₊ :=
+  rfl
+
+theorem Int.ceil_toNat (a : α) : ⌈a⌉.toNat = ⌈a⌉₊ :=
+  rfl
+
+@[simp]
+theorem Nat.floor_int : (Nat.floor : ℤ → ℕ) = Int.toNat :=
+  rfl
+
+@[simp]
+theorem Nat.ceil_int : (Nat.ceil : ℤ → ℕ) = Int.toNat :=
+  rfl
+
+end FloorRingToSemiring
+
+namespace Mathlib.Meta.Positivity
+open Lean.Meta Qq
+
+private theorem int_floor_nonneg [LinearOrderedRing α] [FloorRing α] {a : α} (ha : 0 ≤ a) :
+    0 ≤ ⌊a⌋ :=
+  Int.floor_nonneg.2 ha
+
+private theorem int_floor_nonneg_of_pos [LinearOrderedRing α] [FloorRing α] {a : α}
+    (ha : 0 < a) :
+    0 ≤ ⌊a⌋ :=
+  int_floor_nonneg ha.le
+
+/-- Extension for the `positivity` tactic: `Int.floor` is nonnegative if its input is. -/
+@[positivity ⌊ _ ⌋]
+def evalIntFloor : PositivityExt where eval {u α} _zα _pα e := do
+  match u, α, e with
+  | 0, ~q(ℤ), ~q(@Int.floor $α' $i $j $a) =>
+    match ← core q(inferInstance) q(inferInstance) a with
+    | .positive pa =>
+        assertInstancesCommute
+        pure (.nonnegative q(int_floor_nonneg_of_pos (α := $α') $pa))
+    | .nonnegative pa =>
+        assertInstancesCommute
+        pure (.nonnegative q(int_floor_nonneg (α := $α') $pa))
+    | _ => pure .none
+  | _, _, _ => throwError "failed to match on Int.floor application"
+
+private theorem nat_ceil_pos [LinearOrderedSemiring α] [FloorSemiring α] {a : α} :
+    0 < a → 0 < ⌈a⌉₊ :=
+  Nat.ceil_pos.2
+
+/-- Extension for the `positivity` tactic: `Nat.ceil` is positive if its input is. -/
+@[positivity ⌈ _ ⌉₊]
+def evalNatCeil : PositivityExt where eval {u α} _zα _pα e := do
+  match u, α, e with
+  | 0, ~q(ℕ), ~q(@Nat.ceil $α' $i $j $a) =>
+    let _i : Q(LinearOrderedSemiring $α') ← synthInstanceQ (u := u_1) _
+    assertInstancesCommute
+    match ← core q(inferInstance) q(inferInstance) a with
+    | .positive pa =>
+      assertInstancesCommute
+      pure (.positive q(nat_ceil_pos (α := $α') $pa))
+    | _ => pure .none
+  | _, _, _ => throwError "failed to match on Nat.ceil application"
+
+private theorem int_ceil_pos [LinearOrderedRing α] [FloorRing α] {a : α} : 0 < a → 0 < ⌈a⌉ :=
+  Int.ceil_pos.2
+
+/-- Extension for the `positivity` tactic: `Int.ceil` is positive/nonnegative if its input is. -/
+@[positivity ⌈ _ ⌉]
+def evalIntCeil : PositivityExt where eval {u α} _zα _pα e := do
+  match u, α, e with
+  | 0, ~q(ℤ), ~q(@Int.ceil $α' $i $j $a) =>
+    match ← core q(inferInstance) q(inferInstance) a with
+    | .positive pa =>
+        assertInstancesCommute
+        pure (.positive q(int_ceil_pos (α := $α') $pa))
+    | .nonnegative pa =>
+        assertInstancesCommute
+        pure (.nonnegative q(Int.ceil_nonneg (α := $α') $pa))
+    | _ => pure .none
+  | _, _, _ => throwError "failed to match on Int.ceil application"
+
+end Mathlib.Meta.Positivity

--- a/Mathlib/Algebra/Order/Nonneg/Floor.lean
+++ b/Mathlib/Algebra/Order/Nonneg/Floor.lean
@@ -3,9 +3,8 @@ Copyright (c) 2021 Floris van Doorn. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Floris van Doorn
 -/
-import Mathlib.Algebra.Order.Floor
-import Mathlib.Algebra.Order.Nonneg.Basic
-import Mathlib.Algebra.Order.Nonneg.Lattice
+import Mathlib.Algebra.Order.Floor.Defs
+import Mathlib.Algebra.Order.Nonneg.Ring
 
 /-!
 # Nonnegative elements are archimedean
@@ -20,7 +19,7 @@ This is used to derive algebraic structures on `ℝ≥0` and `ℚ≥0` automatic
 * `{x : α // 0 ≤ x}` is a `FloorSemiring` if `α` is.
 -/
 
-assert_not_exists Finset
+assert_not_exists Finset LinearOrderedField
 
 namespace Nonneg
 

--- a/Mathlib/Algebra/Order/Round.lean
+++ b/Mathlib/Algebra/Order/Round.lean
@@ -3,7 +3,7 @@ Copyright (c) 2018 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Kevin Kappelmann
 -/
-import Mathlib.Algebra.Order.Floor
+import Mathlib.Algebra.Order.Floor.Basic
 import Mathlib.Algebra.Order.Interval.Set.Group
 
 /-!

--- a/Mathlib/Data/Int/Log.lean
+++ b/Mathlib/Data/Int/Log.lean
@@ -3,7 +3,7 @@ Copyright (c) 2022 Eric Wieser. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Eric Wieser
 -/
-import Mathlib.Algebra.Order.Floor
+import Mathlib.Algebra.Order.Floor.Basic
 import Mathlib.Data.Nat.Log
 
 /-!

--- a/Mathlib/Order/Filter/AtTopBot/Floor.lean
+++ b/Mathlib/Order/Filter/AtTopBot/Floor.lean
@@ -3,7 +3,7 @@ Copyright (c) 2022 Yuyang Zhao. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yuyang Zhao
 -/
-import Mathlib.Algebra.Order.Floor
+import Mathlib.Algebra.Order.Floor.Basic
 import Mathlib.Order.Filter.AtTopBot.Finite
 
 /-!

--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -319,7 +319,6 @@
   ["Mathlib.Algebra.Group.ZeroOne", "Mathlib.Tactic.Bound.Init"],
   "Mathlib.Tactic.Bound":
   ["Mathlib.Algebra.Order.AbsoluteValue",
-   "Mathlib.Algebra.Order.Floor",
    "Mathlib.Analysis.Analytic.Basic",
    "Mathlib.Tactic.Bound.Init"],
   "Mathlib.Tactic.Basic":
@@ -344,7 +343,6 @@
   ["Mathlib.LinearAlgebra.FreeModule.IdealQuotient"],
   "Mathlib.RingTheory.Finiteness.Defs":
   ["Mathlib.Data.Finsupp.Defs", "Mathlib.Tactic.Algebraize"],
-  "Mathlib.RingTheory.Binomial": ["Mathlib.Algebra.Order.Floor"],
   "Mathlib.RingTheory.Adjoin.Basic": ["Mathlib.LinearAlgebra.Finsupp.SumProd"],
   "Mathlib.RepresentationTheory.FdRep":
   ["Mathlib.CategoryTheory.Monoidal.Rigid.Braided"],


### PR DESCRIPTION
This is an alternative approach to #23652: `Data.NNReal.Basic` imports `Algebra.Order.Floor` but it barely seems to be used downstream. So by splitting it into just the definitions that `Data.NNReal.Basic` needs, we would be able to save a lot of imports. Unfortunetely, we still need `Floor.Basic` in `Data.Rat.Floor` which is imported into `Algebra.Order.Archimedean.Basic` (a good splitting target!), so this PR by itself does not have impressive downstream effects.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
