### PR TITLE
[Merged by Bors] - doc(docs/1000.yaml): add some missing theorems

### DIFF
--- a/Mathlib/Analysis/Convex/Radon.lean
+++ b/Mathlib/Analysis/Convex/Radon.lean
@@ -35,7 +35,9 @@ variable {ι 𝕜 E : Type*} [LinearOrderedField 𝕜] [AddCommGroup E] [Module 
 /-- **Radon's theorem on convex sets**.
 
 Any family `f` of affine dependent vectors contains a set `I` with the property that convex hulls of
-`I` and `Iᶜ` intersect nontrivially. -/
+`I` and `Iᶜ` intersect nontrivially.
+In particular, any `d + 2` points in a `d`-dimensional space can be partitioned this way, since they
+are affinely dependent (see `finrank_vectorSpan_le_iff_not_affineIndependent`). -/
 theorem radon_partition {f : ι → E} (h : ¬ AffineIndependent 𝕜 f) :
     ∃ I, (convexHull 𝕜 (f '' I) ∩ convexHull 𝕜 (f '' Iᶜ)).Nonempty := by
   rw [affineIndependent_iff] at h

--- a/Mathlib/Analysis/InnerProductSpace/Dual.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Dual.lean
@@ -118,7 +118,7 @@ theorem ext_inner_right_basis {ι : Type*} {x y : E} (b : Basis ι 𝕜 E)
 variable (𝕜) (E)
 variable [CompleteSpace E]
 
-/-- Fréchet-Riesz representation: any `ℓ` in the dual of a Hilbert space `E` is of the form
+/-- **Fréchet-Riesz representation**: any `ℓ` in the dual of a Hilbert space `E` is of the form
 `fun u => ⟪y, u⟫` for some `y : E`, i.e. `toDualMap` is surjective.
 -/
 def toDual : E ≃ₗᵢ⋆[𝕜] NormedSpace.Dual 𝕜 E :=

--- a/Mathlib/Order/CountableDenseLinearOrder.lean
+++ b/Mathlib/Order/CountableDenseLinearOrder.lean
@@ -239,7 +239,8 @@ theorem embedding_from_countable_to_dense [Countable α] [DenselyOrdered β] [No
   rcases our_ideal.directed _ hf _ hg with ⟨m, _hm, fm, gm⟩
   exact (lt_iff_lt_of_cmp_eq_cmp <| m.prop (a₁, _) (fm ha₁) (a₂, _) (gm ha₂)).mp
 
-/-- Any two countable dense, nonempty linear orders without endpoints are order isomorphic. -/
+/-- Any two countable dense, nonempty linear orders without endpoints are order isomorphic. This is
+also known as Cantor's isomorphism theorem. -/
 theorem iso_of_countable_dense [Countable α] [DenselyOrdered α] [NoMinOrder α] [NoMaxOrder α]
     [Nonempty α] [Countable β] [DenselyOrdered β] [NoMinOrder β] [NoMaxOrder β] [Nonempty β] :
     Nonempty (α ≃o β) := by

--- a/Mathlib/Order/CountableDenseLinearOrder.lean
+++ b/Mathlib/Order/CountableDenseLinearOrder.lean
@@ -240,7 +240,7 @@ theorem embedding_from_countable_to_dense [Countable α] [DenselyOrdered β] [No
   exact (lt_iff_lt_of_cmp_eq_cmp <| m.prop (a₁, _) (fm ha₁) (a₂, _) (gm ha₂)).mp
 
 /-- Any two countable dense, nonempty linear orders without endpoints are order isomorphic. This is
-also known as Cantor's isomorphism theorem. -/
+also known as **Cantor's isomorphism theorem**. -/
 theorem iso_of_countable_dense [Countable α] [DenselyOrdered α] [NoMinOrder α] [NoMaxOrder α]
     [Nonempty α] [Countable β] [DenselyOrdered β] [NoMinOrder β] [NoMaxOrder β] [Nonempty β] :
     Nonempty (α ≃o β) := by

--- a/docs/1000.yaml
+++ b/docs/1000.yaml
@@ -1576,6 +1576,9 @@ Q1457052:
 
 Q1471282:
   title: Radon's theorem
+  decl: Convex.radon_partition
+  authors: Vasilii Nesterov
+  date: 2023
 
 Q1472120:
   title: Hellinger&ndash;Toeplitz theorem
@@ -4036,6 +4039,10 @@ Q107709489:
 
 Q107710112:
   title: Cantor's isomorphism theorem
+  decl: Order.iso_of_countable_dense
+  authors: David Wärn
+  date: 2020
+  
 
 Q110921617:
   title: Feferman–Vaught theorem

--- a/docs/1000.yaml
+++ b/docs/1000.yaml
@@ -44,6 +44,9 @@ Q119450:
 
 Q132427:
   title: Rademacher's theorem
+  decl: LipschitzOnWith.ae_differentiableWithinAt
+  authors: Sébastien Gouëzel
+  date: 2023
 
 Q132469:
   title: Fermat's Last Theorem
@@ -1079,6 +1082,9 @@ Q977912:
 
 Q978688:
   title: Gershgorin circle theorem
+  decl: eigenvalue_mem_ball
+  authors: Xavier Roblot
+  date: 2023
 
 Q985009:
   title: Helmholtz's theorems
@@ -1504,6 +1510,9 @@ Q1349282:
 
 Q1357684:
   title: Riesz representation theorem
+  decl: InnerProductSpace.toDual
+  authors: Frédéric Dupuis
+  date: 2020
 
 Q1361031:
   title: Frobenius theorem (real division algebras)
@@ -4042,7 +4051,7 @@ Q107710112:
   decl: Order.iso_of_countable_dense
   authors: David Wärn
   date: 2020
-  
+
 
 Q110921617:
   title: Feferman–Vaught theorem


### PR DESCRIPTION
Add some missed theorems to 1000.yaml:
* Rademacher's theorem
* Gershgorin circle theorem
* Riesz representation theorem
* Radon's theorem
* Cantor's isomorphism theorem

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
