### PR TITLE
[Merged by Bors] - fix(lakefile): remove duplicate `moreServerOptions`

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -23,10 +23,8 @@ require "leanprover-community" / "plausible" @ git "nightly-testing"
 ## Options for building mathlib
 -/
 
-/-- These options are used
-* as `leanOptions`, prefixed by `` `weak``, so that `lake build` uses them;
-* as `moreServerArgs`, to set their default value in mathlib
-  (as well as `Archive`, `Counterexamples` and `test`). -/
+/-- These options are used as `leanOptions`, prefixed by `` `weak``, so that
+`lake build` uses them, as well as `Archive` and `Counterexamples`. -/
 abbrev mathlibOnlyLinters : Array LeanOption := #[
   -- The `docPrime` linter is disabled: https://github.com/leanprover-community/mathlib4/issues/20560
   ⟨`linter.docPrime, false⟩,
@@ -71,9 +69,8 @@ package mathlib where
 
 @[default_target]
 lean_lib Mathlib where
+  -- Enforce Mathlib's default linters and style options.
   leanOptions := mathlibLeanOptions
-  -- Mathlib also enforces these linter options, which are not active by default.
-  moreServerOptions := mathlibOnlyLinters
 
 -- NB. When adding further libraries, check if they should be excluded from `getLeanLibs` in
 -- `scripts/mk_all.lean`.
@@ -85,11 +82,9 @@ lean_lib MathlibTest where
 
 lean_lib Archive where
   leanOptions := mathlibLeanOptions
-  moreServerOptions := mathlibOnlyLinters
 
 lean_lib Counterexamples where
   leanOptions := mathlibLeanOptions
-  moreServerOptions := mathlibOnlyLinters
 
 /-- Additional documentation in the form of modules that only contain module docstrings. -/
 lean_lib docs where


### PR DESCRIPTION
Since https://github.com/leanprover/lean4/pull/7376, it is sufficient to put linter options in `leanOptions` and we do not need to repeat them in `moreServerOptions`. In fact, doing so now causes errors when editing files at the bottom of the import hierarchy, when not all linters are imported yet. For example, `Mathlib/Tactic/Linter/Lint.lean` would complain about `invalid -D parameter, unknown configuration option 'linter.docPrime'`.

Zulip thread: https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/invalid.20-D.20parameter.2C.20lean.20v4.2E19.2E0-rc2/with/510194289


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
