### PR TITLE
feat(Tactic/Linter): one option for all Mathlib linters

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -5486,6 +5486,7 @@ import Mathlib.Tactic.LinearCombination
 import Mathlib.Tactic.LinearCombination'
 import Mathlib.Tactic.LinearCombination.Lemmas
 import Mathlib.Tactic.Linter
+import Mathlib.Tactic.Linter.Attr
 import Mathlib.Tactic.Linter.DeprecatedSyntaxLinter
 import Mathlib.Tactic.Linter.DirectoryDependency
 import Mathlib.Tactic.Linter.DocPrime

--- a/Mathlib/Tactic.lean
+++ b/Mathlib/Tactic.lean
@@ -142,6 +142,7 @@ import Mathlib.Tactic.LinearCombination
 import Mathlib.Tactic.LinearCombination'
 import Mathlib.Tactic.LinearCombination.Lemmas
 import Mathlib.Tactic.Linter
+import Mathlib.Tactic.Linter.Attr
 import Mathlib.Tactic.Linter.DeprecatedSyntaxLinter
 import Mathlib.Tactic.Linter.DirectoryDependency
 import Mathlib.Tactic.Linter.DocPrime

--- a/Mathlib/Tactic/Linter/Attr.lean
+++ b/Mathlib/Tactic/Linter/Attr.lean
@@ -1,0 +1,72 @@
+/-
+Copyright (c) 2025 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Anne Baanen
+-/
+import Lean.Linter.Basic
+
+/-! # The Mathlib standard linters
+
+This file defines which set of linters should be enabled by default in Mathlib and other projects
+that aim for the same quality standards.
+-/
+
+open Lean Linter
+
+/-- `linter.mathlibStandard` enables all the linters defined and used in Mathlib. -/
+register_option linter.mathlibStandard : Bool := {
+  defValue := false
+  descr := "enable the Mathlib linters"
+}
+
+/-- The list of linter settings enabled in Mathlib. -/
+abbrev mathlibStandardLinters : NameMap DataValue := .ofList [
+  -- The `docPrime` linter is disabled: https://github.com/leanprover-community/mathlib4/issues/20560
+  ⟨`linter.docPrime, false⟩,
+  ⟨`linter.hashCommand, true⟩,
+  ⟨`linter.oldObtain, true⟩,
+  ⟨`linter.style.cases, true⟩,
+  ⟨`linter.style.cdot, true⟩,
+  ⟨`linter.style.docString, true⟩,
+  ⟨`linter.style.dollarSyntax, true⟩,
+  ⟨`linter.style.header, true⟩,
+  ⟨`linter.style.lambdaSyntax, true⟩,
+  ⟨`linter.style.longLine, true⟩,
+  ⟨`linter.style.longFile, .ofNat 1500⟩,
+  ⟨`linter.style.missingEnd, true⟩,
+  ⟨`linter.style.multiGoal, true⟩,
+  ⟨`linter.style.openClassical, true⟩,
+  ⟨`linter.style.refine, true⟩,
+  ⟨`linter.style.setOption, true⟩
+]
+
+/-- Are Mathlib-standard linters enabled? -/
+def Mathlib.standardLintersEnabled (o : Options) : Bool :=
+  o.get linter.mathlibStandard.name false
+
+/-- Return whether a linter should be enabled.
+
+This function returns true in three cases:
+* the option `opt` is explicitly enabled, or
+* all linters are enabled (by `set_option linter.all true`), or
+* Mathlib-standard linters are enabled and `opt` is a Mathlib-standard linter.
+-/
+def Mathlib.getLinterValue (opt : Lean.Option Bool) (o : Options) : Bool :=
+  (Mathlib.standardLintersEnabled o &&
+    mathlibStandardLinters.find? opt.name == some (.ofBool true)) ||
+  Lean.Linter.getLinterValue opt o
+
+/-- Return a numeric value for this linter, or `0` if it is unset.
+
+This function returns nonzero values in two cases:
+* the option `opt` is set to a nonzero value, or
+* Mathlib-standard linters are enabled and Mathlib sets `opt` to a nonzero value.
+-/
+def Mathlib.getLinterNat (opt : Lean.Option Nat) (o : Options) : Nat :=
+  let setValue := opt.get o
+  if setValue == 0 && Mathlib.standardLintersEnabled o then
+    match mathlibStandardLinters.find? opt.name with
+    | some (.ofNat n) => n
+    | _ => 0
+  else
+    setValue

--- a/Mathlib/Tactic/Linter/Attr.lean
+++ b/Mathlib/Tactic/Linter/Attr.lean
@@ -46,15 +46,22 @@ def Mathlib.standardLintersEnabled (o : Options) : Bool :=
 
 /-- Return whether a linter should be enabled.
 
-This function returns true in three cases:
-* the option `opt` is explicitly enabled, or
+If the value of `opt` has been set using the `set_option` command, return that setting.
+Otherwise this function returns true if:
+* the linter is enabled by default, or
 * all linters are enabled (by `set_option linter.all true`), or
 * Mathlib-standard linters are enabled and `opt` is a Mathlib-standard linter.
 -/
 def Mathlib.getLinterValue (opt : Lean.Option Bool) (o : Options) : Bool :=
-  (Mathlib.standardLintersEnabled o &&
-    mathlibStandardLinters.find? opt.name == some (.ofBool true)) ||
-  Lean.Linter.getLinterValue opt o
+  -- Always return the value that the option is explicitly set to, if any.
+  if let some val := opt.get? o then
+    val
+  else
+    -- Otherwise it could be a standard linter...
+    (Mathlib.standardLintersEnabled o &&
+      mathlibStandardLinters.find? opt.name == some (.ofBool true)) ||
+    -- ... or it is enabled in the regular way.
+    Lean.Linter.getLinterValue opt o
 
 /-- Return a numeric value for this linter, or `0` if it is unset.
 

--- a/Mathlib/Tactic/Linter/DeprecatedSyntaxLinter.lean
+++ b/Mathlib/Tactic/Linter/DeprecatedSyntaxLinter.lean
@@ -91,9 +91,9 @@ replacement syntax. For each individual case, linting can be turned on or off se
 * `admit`, superseded by `sorry` (controlled by `linter.style.admit`)
 -/
 def deprecatedSyntaxLinter : Linter where run := withSetOptionIn fun stx => do
-  unless Linter.getLinterValue linter.style.refine (← getOptions) ||
-      Linter.getLinterValue linter.style.cases (← getOptions) ||
-      Linter.getLinterValue linter.style.admit (← getOptions) do
+  unless Mathlib.getLinterValue linter.style.refine (← getOptions) ||
+      Mathlib.getLinterValue linter.style.cases (← getOptions) ||
+      Mathlib.getLinterValue linter.style.admit (← getOptions) do
     return
   if (← MonadState.get).messages.hasErrors then
     return

--- a/Mathlib/Tactic/Linter/DirectoryDependency.lean
+++ b/Mathlib/Tactic/Linter/DirectoryDependency.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Anne Baanen
 -/
 import Lean.Elab.Command
+import Mathlib.Tactic.Linter.Attr
 
 /-! # The `directoryDependency` linter
 
@@ -474,7 +475,7 @@ open DirectoryDependency
 
 @[inherit_doc Mathlib.Linter.linter.directoryDependency]
 def directoryDependencyCheck (mainModule : Name) : CommandElabM (Option MessageData) := do
-  unless Linter.getLinterValue linter.directoryDependency (← getOptions) do
+  unless Mathlib.getLinterValue linter.directoryDependency (← getOptions) do
     return none
   let env ← getEnv
   let imports := env.allImportedModuleNames

--- a/Mathlib/Tactic/Linter/DocPrime.lean
+++ b/Mathlib/Tactic/Linter/DocPrime.lean
@@ -38,7 +38,7 @@ namespace DocPrime
 
 @[inherit_doc Mathlib.Linter.linter.docPrime]
 def docPrimeLinter : Linter where run := withSetOptionIn fun stx ↦ do
-  unless Linter.getLinterValue linter.docPrime (← getOptions) do
+  unless Mathlib.getLinterValue linter.docPrime (← getOptions) do
     return
   if (← get).messages.hasErrors then
     return

--- a/Mathlib/Tactic/Linter/DocString.lean
+++ b/Mathlib/Tactic/Linter/DocString.lean
@@ -28,7 +28,7 @@ namespace Style
 
 @[inherit_doc Mathlib.Linter.linter.style.docString]
 def docStringLinter : Linter where run := withSetOptionIn fun stx ↦ do
-  unless Linter.getLinterValue linter.style.docString (← getOptions) do
+  unless Mathlib.getLinterValue linter.style.docString (← getOptions) do
     return
   if (← get).messages.hasErrors then
     return

--- a/Mathlib/Tactic/Linter/FlexibleLinter.lean
+++ b/Mathlib/Tactic/Linter/FlexibleLinter.lean
@@ -370,7 +370,7 @@ def reallyPersist
 
 /-- The main implementation of the flexible linter. -/
 def flexibleLinter : Linter where run := withSetOptionIn fun _stx => do
-  unless Linter.getLinterValue linter.flexible (← getOptions) && (← getInfoState).enabled do
+  unless Mathlib.getLinterValue linter.flexible (← getOptions) && (← getInfoState).enabled do
     return
   if (← MonadState.get).messages.hasErrors then
     return

--- a/Mathlib/Tactic/Linter/GlobalAttributeIn.lean
+++ b/Mathlib/Tactic/Linter/GlobalAttributeIn.lean
@@ -91,7 +91,7 @@ namespace globalAttributeInLinter
 
 /-- Gets the value of the `linter.globalAttributeIn` option. -/
 def getLinterGlobalAttributeIn (o : Options) : Bool :=
-  Linter.getLinterValue linter.globalAttributeIn o
+  Mathlib.getLinterValue linter.globalAttributeIn o
 
 /--
 `getGlobalAttributesIn? cmd` assumes that `cmd` represents a `attribute [...] id in ...` command.

--- a/Mathlib/Tactic/Linter/HashCommandLinter.lean
+++ b/Mathlib/Tactic/Linter/HashCommandLinter.lean
@@ -65,7 +65,7 @@ This means that CI will eventually fail on `#`-commands, but does not stop it fr
 However, in order to avoid local clutter, when `warningAsError` is `false`, the linter
 logs a warning only for the `#`-commands that do not already emit a message. -/
 def hashCommandLinter : Linter where run := withSetOptionIn' fun stx => do
-  if Linter.getLinterValue linter.hashCommand (← getOptions) &&
+  if Mathlib.getLinterValue linter.hashCommand (← getOptions) &&
     ((← get).messages.reportedPlusUnreported.isEmpty || warningAsError.get (← getOptions))
   then
     if let some sa := stx.getHead? then

--- a/Mathlib/Tactic/Linter/Header.lean
+++ b/Mathlib/Tactic/Linter/Header.lean
@@ -305,7 +305,7 @@ def headerLinter : Linter where run := withSetOptionIn fun stx ↦ do
   -- The linter skips files not imported in `Mathlib.lean`, to avoid linting "scratch files".
   -- It is however active in the test file `MathlibTest.Header` for the linter itself.
   unless inMathlib? || mainModule == `MathlibTest.Header do return
-  unless Linter.getLinterValue linter.style.header (← getOptions) do
+  unless Mathlib.getLinterValue linter.style.header (← getOptions) do
     return
   if (← get).messages.hasErrors then
     return

--- a/Mathlib/Tactic/Linter/Lint.lean
+++ b/Mathlib/Tactic/Linter/Lint.lean
@@ -81,7 +81,7 @@ open Lean Parser Elab Command Meta
 
 @[inherit_doc linter.dupNamespace]
 def dupNamespace : Linter where run := withSetOptionIn fun stx ↦ do
-  if Linter.getLinterValue linter.dupNamespace (← getOptions) then
+  if Mathlib.getLinterValue linter.dupNamespace (← getOptions) then
     let mut aliases := #[]
     if let some exp := stx.find? (·.isOfKind `Lean.Parser.Command.export) then
       aliases ← getAliasSyntax exp

--- a/Mathlib/Tactic/Linter/MinImports.lean
+++ b/Mathlib/Tactic/Linter/MinImports.lean
@@ -100,7 +100,7 @@ macro "#import_bumps" : command => `(
 
 @[inherit_doc Mathlib.Linter.linter.minImports]
 def minImportsLinter : Linter where run := withSetOptionIn fun stx ↦ do
-    unless Linter.getLinterValue linter.minImports (← getOptions) do
+    unless Mathlib.getLinterValue linter.minImports (← getOptions) do
       return
     if (← get).messages.hasErrors then
       return
@@ -155,7 +155,7 @@ def minImportsLinter : Linter where run := withSetOptionIn fun stx ↦ do
       let redundant := importsSoFar.toArray.filter (!currImports.contains ·)
       -- to make `test` files more stable, we suppress the exact count of import changes if
       -- the `linter.minImports.increases` option is `false`
-      let byCount :=  if Linter.getLinterValue linter.minImports.increases (← getOptions) then
+      let byCount := if Mathlib.getLinterValue linter.minImports.increases (← getOptions) then
                       m!"by {newCumulImps - oldCumulImps} "
                     else
                       m!""

--- a/Mathlib/Tactic/Linter/Multigoal.lean
+++ b/Mathlib/Tactic/Linter/Multigoal.lean
@@ -156,7 +156,7 @@ def getManyGoals : InfoTree → Array (Syntax × Nat × Nat × Nat)
 
 @[inherit_doc Mathlib.Linter.linter.style.multiGoal]
 def multiGoalLinter : Linter where run := withSetOptionIn fun _stx ↦ do
-    unless Linter.getLinterValue linter.style.multiGoal (← getOptions) do
+    unless Mathlib.getLinterValue linter.style.multiGoal (← getOptions) do
       return
     if (← get).messages.hasErrors then
       return

--- a/Mathlib/Tactic/Linter/OldObtain.lean
+++ b/Mathlib/Tactic/Linter/OldObtain.lean
@@ -73,7 +73,7 @@ register_option linter.oldObtain : Bool := {
 
 /-- The `oldObtain` linter: see docstring above -/
 def oldObtainLinter : Linter where run := withSetOptionIn fun stx => do
-    unless Linter.getLinterValue linter.oldObtain (← getOptions) do
+    unless Mathlib.getLinterValue linter.oldObtain (← getOptions) do
       return
     if (← MonadState.get).messages.hasErrors then
       return

--- a/Mathlib/Tactic/Linter/PPRoundtrip.lean
+++ b/Mathlib/Tactic/Linter/PPRoundtrip.lean
@@ -115,7 +115,7 @@ namespace PPRoundtrip
 
 @[inherit_doc Mathlib.Linter.linter.ppRoundtrip]
 def ppRoundtrip : Linter where run := withSetOptionIn fun stx ↦ do
-    unless Linter.getLinterValue linter.ppRoundtrip (← getOptions) do
+    unless Mathlib.getLinterValue linter.ppRoundtrip (← getOptions) do
       return
     if (← MonadState.get).messages.hasErrors then
       return

--- a/Mathlib/Tactic/Linter/Style.lean
+++ b/Mathlib/Tactic/Linter/Style.lean
@@ -81,7 +81,7 @@ used in production code.
 (Some tests will intentionally use one of these options; in this case, simply allow the linter.)
 -/
 def setOptionLinter : Linter where run := withSetOptionIn fun stx => do
-    unless Linter.getLinterValue linter.style.setOption (← getOptions) do
+    unless Mathlib.getLinterValue linter.style.setOption (← getOptions) do
       return
     if (← MonadState.get).messages.hasErrors then
       return
@@ -122,7 +122,7 @@ namespace Style.missingEnd
 def missingEndLinter : Linter where run := withSetOptionIn fun stx ↦ do
     -- Only run this linter at the end of a module.
     unless stx.isOfKind ``Lean.Parser.Command.eoi do return
-    if Linter.getLinterValue linter.style.missingEnd (← getOptions) &&
+    if Mathlib.getLinterValue linter.style.missingEnd (← getOptions) &&
         !(← MonadState.get).messages.hasErrors then
       let sc ← getScopes
       -- The last scope is always the "base scope", corresponding to no active `section`s or
@@ -191,7 +191,7 @@ namespace Style
 
 @[inherit_doc linter.style.cdot]
 def cdotLinter : Linter where run := withSetOptionIn fun stx ↦ do
-    unless Linter.getLinterValue linter.style.cdot (← getOptions) do
+    unless Mathlib.getLinterValue linter.style.cdot (← getOptions) do
       return
     if (← MonadState.get).messages.hasErrors then
       return
@@ -239,7 +239,7 @@ def findDollarSyntax : Syntax → Array Syntax
 
 @[inherit_doc linter.style.dollarSyntax]
 def dollarSyntaxLinter : Linter where run := withSetOptionIn fun stx ↦ do
-    unless Linter.getLinterValue linter.style.dollarSyntax (← getOptions) do
+    unless Mathlib.getLinterValue linter.style.dollarSyntax (← getOptions) do
       return
     if (← MonadState.get).messages.hasErrors then
       return
@@ -283,7 +283,7 @@ def findLambdaSyntax : Syntax → Array Syntax
 
 @[inherit_doc linter.style.lambdaSyntax]
 def lambdaSyntaxLinter : Linter where run := withSetOptionIn fun stx ↦ do
-    unless Linter.getLinterValue linter.style.lambdaSyntax (← getOptions) do
+    unless Mathlib.getLinterValue linter.style.lambdaSyntax (← getOptions) do
       return
     if (← MonadState.get).messages.hasErrors then
       return
@@ -325,7 +325,7 @@ namespace Style.longFile
 
 @[inherit_doc Mathlib.Linter.linter.style.longFile]
 def longFileLinter : Linter where run := withSetOptionIn fun stx ↦ do
-  let linterBound := linter.style.longFile.get (← getOptions)
+  let linterBound := Mathlib.getLinterNat linter.style.longFile (← getOptions)
   if linterBound == 0 then
     return
   let defValue := linter.style.longFileDefValue.get (← getOptions)
@@ -396,7 +396,7 @@ namespace Style.longLine
 
 @[inherit_doc Mathlib.Linter.linter.style.longLine]
 def longLineLinter : Linter where run := withSetOptionIn fun stx ↦ do
-    unless Linter.getLinterValue linter.style.longLine (← getOptions) do
+    unless Mathlib.getLinterValue linter.style.longLine (← getOptions) do
       return
     if (← MonadState.get).messages.hasErrors then
       return
@@ -447,7 +447,7 @@ namespace Style.nameCheck
 
 @[inherit_doc linter.style.nameCheck]
 def doubleUnderscore: Linter where run := withSetOptionIn fun stx => do
-    unless Linter.getLinterValue linter.style.nameCheck (← getOptions) do
+    unless Mathlib.getLinterValue linter.style.nameCheck (← getOptions) do
       return
     if (← get).messages.hasErrors then
       return
@@ -502,7 +502,7 @@ def extractOpenNames : Syntax → Array (TSyntax `ident)
 
 @[inherit_doc Mathlib.Linter.linter.style.openClassical]
 def openClassicalLinter : Linter where run stx := do
-    unless Linter.getLinterValue linter.style.openClassical (← getOptions) do
+    unless Mathlib.getLinterValue linter.style.openClassical (← getOptions) do
       return
     if (← get).messages.hasErrors then
       return

--- a/Mathlib/Tactic/Linter/UnusedTactic.lean
+++ b/Mathlib/Tactic/Linter/UnusedTactic.lean
@@ -176,7 +176,7 @@ end
 
 /-- The main entry point to the unused tactic linter. -/
 def unusedTacticLinter : Linter where run := withSetOptionIn fun stx => do
-  unless Linter.getLinterValue linter.unusedTactic (← getOptions) && (← getInfoState).enabled do
+  unless Mathlib.getLinterValue linter.unusedTactic (← getOptions) && (← getInfoState).enabled do
     return
   if (← get).messages.hasErrors then
     return

--- a/Mathlib/Tactic/Linter/UpstreamableDecl.lean
+++ b/Mathlib/Tactic/Linter/UpstreamableDecl.lean
@@ -86,12 +86,12 @@ namespace DoubleImports
 
 @[inherit_doc Mathlib.Linter.linter.upstreamableDecl]
 def upstreamableDeclLinter : Linter where run := withSetOptionIn fun stx ↦ do
-    unless Linter.getLinterValue linter.upstreamableDecl (← getOptions) do
+    unless Mathlib.getLinterValue linter.upstreamableDecl (← getOptions) do
       return
     if (← get).messages.hasErrors then
       return
-    let skipDef := !Linter.getLinterValue linter.upstreamableDecl.defs (← getOptions)
-    let skipPrivate := !Linter.getLinterValue linter.upstreamableDecl.private (← getOptions)
+    let skipDef := !Mathlib.getLinterValue linter.upstreamableDecl.defs (← getOptions)
+    let skipPrivate := !Mathlib.getLinterValue linter.upstreamableDecl.private (← getOptions)
     if stx == (← `(command| set_option $(mkIdent `linter.upstreamableDecl) true)) then return
     let env ← getEnv
     let id ← getId stx

--- a/MathlibTest/MathlibStandardLints.lean
+++ b/MathlibTest/MathlibStandardLints.lean
@@ -14,3 +14,8 @@ note: this linter can be disabled with `set_option linter.hashCommand false`
 -/
 #guard_msgs in
 #guard true
+
+-- Explicitly overriding a linter should silence it
+set_option linter.hashCommand false in
+#guard_msgs in
+#guard true

--- a/MathlibTest/MathlibStandardLints.lean
+++ b/MathlibTest/MathlibStandardLints.lean
@@ -1,0 +1,16 @@
+import Mathlib.Tactic.Linter.HashCommandLinter
+
+-- No complaints if the default linters are not enabled.
+/--
+-/
+#guard_msgs in
+#guard true
+
+set_option linter.mathlibStandard true
+
+/--
+warning: `#`-commands, such as '#guard', are not allowed in 'Mathlib'
+note: this linter can be disabled with `set_option linter.hashCommand false`
+-/
+#guard_msgs in
+#guard true

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -26,24 +26,8 @@ require "leanprover-community" / "plausible" @ git "nightly-testing"
 /-- These options are used as `leanOptions`, prefixed by `` `weak``, so that
 `lake build` uses them, as well as `Archive` and `Counterexamples`. -/
 abbrev mathlibOnlyLinters : Array LeanOption := #[
-  -- The `docPrime` linter is disabled: https://github.com/leanprover-community/mathlib4/issues/20560
-  ⟨`linter.docPrime, false⟩,
-  ⟨`linter.hashCommand, true⟩,
-  ⟨`linter.oldObtain, true⟩,
-  ⟨`linter.style.cases, true⟩,
-  ⟨`linter.style.cdot, true⟩,
-  ⟨`linter.style.docString, true⟩,
-  ⟨`linter.style.dollarSyntax, true⟩,
-  ⟨`linter.style.header, true⟩,
-  ⟨`linter.style.lambdaSyntax, true⟩,
-  ⟨`linter.style.longLine, true⟩,
-  ⟨`linter.style.longFile, .ofNat 1500⟩,
+  ⟨`linter.mathlibStandard, true⟩,
   -- `latest_import.yml` uses this comment: if you edit it, make sure that the workflow still works
-  ⟨`linter.style.missingEnd, true⟩,
-  ⟨`linter.style.multiGoal, true⟩,
-  ⟨`linter.style.openClassical, true⟩,
-  ⟨`linter.style.refine, true⟩,
-  ⟨`linter.style.setOption, true⟩
 ]
 
 /-- These options are passed as `leanOptions` to building mathlib, as well as the

--- a/scripts/lint-style.lean
+++ b/scripts/lint-style.lean
@@ -75,7 +75,8 @@ def checkInitImports : IO Bool := do
   -- Now, it only remains to check that every module (except for the Header linter itself)
   -- imports some file in Mathlib.
   let missing := modulesWithoutMathlibImports.erase `Mathlib.Tactic.Linter.Header
-    -- This file is imported by `Mathlib.Tactic.Linter.Header`.
+    -- These files are imported by `Mathlib.Tactic.Linter.Header`.
+    |>.erase `Mathlib.Tactic.Linter.Attr
     |>.erase `Mathlib.Tactic.Linter.DirectoryDependency
   if missing.size > 0 then
     IO.eprintln s!"error: the following {missing.size} module(s) do not import Mathlib.Init: \


### PR DESCRIPTION
This is intended to make downstream projects easier to maintain and keep up to Mathlib standards, by having one option `linter.mathlibStandard` control all the linters that we previously had to enable one by one in the lakefile.

This is accomplished by introducing a new check `Mathlib.getLinterValue` that takes the `linter.mathlibStandard` option into account. If that option is set to true, it checks if this is one of the Mathlib standard linters, and enables the linter if so.

I also considered a few ways of implementing this feature by setting options automatically. But I couldn't get any to work without modifying Lean itself:
* an `initialize` command doesn't get access to the options in the current file (since it runs in IO rather than CoreM),
* hooking the `runLinters` step of elaboration doesn't work because each linter restores the state (including options) after running.

A drawback of the current approach is that a linter defined upstream of Mathlib cannot be enabled this way. There is no such linter currently, and we can fall back to the previous `lakefile` approach if that happens.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
