### PR TITLE
[Merged by Bors] - chore(IntegrableOn): drop a `MeasurableSet` assumption

### DIFF
--- a/Mathlib/MeasureTheory/Decomposition/RadonNikodym.lean
+++ b/Mathlib/MeasureTheory/Decomposition/RadonNikodym.lean
@@ -487,7 +487,7 @@ theorem withDensityᵥ_rnDeriv_eq (s : SignedMeasure α) (μ : Measure α) [Sigm
       rw [toSignedMeasure_apply_measurable hi, toSignedMeasure_apply_measurable hi]
     all_goals
       rw [← integrableOn_univ]
-      refine IntegrableOn.restrict ?_ MeasurableSet.univ
+      refine IntegrableOn.restrict ?_
       refine ⟨?_, hasFiniteIntegral_toReal_of_lintegral_ne_top ?_⟩
       · apply Measurable.aestronglyMeasurable (by fun_prop)
       · rw [setLIntegral_univ]

--- a/Mathlib/MeasureTheory/Decomposition/RadonNikodym.lean
+++ b/Mathlib/MeasureTheory/Decomposition/RadonNikodym.lean
@@ -486,12 +486,10 @@ theorem withDensityᵥ_rnDeriv_eq (s : SignedMeasure α) (μ : Measure α) [Sigm
       erw [VectorMeasure.sub_apply]
       rw [toSignedMeasure_apply_measurable hi, toSignedMeasure_apply_measurable hi]
     all_goals
-      rw [← integrableOn_univ]
-      refine IntegrableOn.restrict ?_
+      refine Integrable.integrableOn ?_
       refine ⟨?_, hasFiniteIntegral_toReal_of_lintegral_ne_top ?_⟩
       · apply Measurable.aestronglyMeasurable (by fun_prop)
-      · rw [setLIntegral_univ]
-        exact (lintegral_rnDeriv_lt_top _ _).ne
+      · exact (lintegral_rnDeriv_lt_top _ _).ne
   · exact equivMeasure.right_inv μ
 
 /-- The Radon-Nikodym theorem for signed measures. -/

--- a/Mathlib/MeasureTheory/Function/L1Space/Integrable.lean
+++ b/Mathlib/MeasureTheory/Function/L1Space/Integrable.lean
@@ -1001,7 +1001,7 @@ section restrict
 
 variable {E : Type*} [NormedAddCommGroup E] {f : α → E}
 
-/-- One should usually use `MeasureTheory.Integrable.IntegrableOn` instead. -/
+/-- One should usually use `MeasureTheory.Integrable.integrableOn` instead. -/
 lemma Integrable.restrict (hf : Integrable f μ) {s : Set α} : Integrable f (μ.restrict s) :=
   hf.mono_measure Measure.restrict_le_self
 

--- a/Mathlib/MeasureTheory/Integral/IntegrableOn.lean
+++ b/Mathlib/MeasureTheory/Integral/IntegrableOn.lean
@@ -134,9 +134,9 @@ theorem integrableOn_congr_fun (hst : EqOn f g s) (hs : MeasurableSet s) :
 
 theorem Integrable.integrableOn (h : Integrable f μ) : IntegrableOn f s μ := h.restrict
 
-theorem IntegrableOn.restrict (h : IntegrableOn f s μ) (hs : MeasurableSet s) :
-    IntegrableOn f s (μ.restrict t) := by
-  rw [IntegrableOn, Measure.restrict_restrict hs]; exact h.mono_set inter_subset_left
+theorem IntegrableOn.restrict (h : IntegrableOn f s μ) : IntegrableOn f s (μ.restrict t) := by
+  dsimp only [IntegrableOn] at h ⊢
+  exact h.mono_measure <| Measure.restrict_mono_measure Measure.restrict_le_self _
 
 theorem IntegrableOn.inter_of_restrict (h : IntegrableOn f s (μ.restrict t)) :
     IntegrableOn f (s ∩ t) μ := by

--- a/Mathlib/MeasureTheory/Integral/IntegralEqImproper.lean
+++ b/Mathlib/MeasureTheory/Integral/IntegralEqImproper.lean
@@ -579,7 +579,7 @@ theorem integrableOn_Ioc_of_intervalIntegral_norm_bounded {I a₀ b₀ : ℝ}
     (hb : Tendsto b l <| 𝓝 b₀) (h : ∀ᶠ i in l, (∫ x in Ioc (a i) (b i), ‖f x‖) ≤ I) :
     IntegrableOn f (Ioc a₀ b₀) := by
   refine (aecover_Ioc_of_Ioc ha hb).integrable_of_integral_norm_bounded I
-    (fun i => (hfi i).restrict measurableSet_Ioc) (h.mono fun i hi ↦ ?_)
+    (fun i => (hfi i).restrict) (h.mono fun i hi ↦ ?_)
   rw [Measure.restrict_restrict measurableSet_Ioc]
   refine le_trans (setIntegral_mono_set (hfi i).norm ?_ ?_) hi <;> apply ae_of_all
   · simp only [Pi.zero_apply, norm_nonneg, forall_const]

--- a/Mathlib/MeasureTheory/VectorMeasure/WithDensity.lean
+++ b/Mathlib/MeasureTheory/VectorMeasure/WithDensity.lean
@@ -82,9 +82,9 @@ theorem withDensityᵥ_add (hf : Integrable f μ) (hg : Integrable g μ) :
   rw [withDensityᵥ_apply (hf.add hg) hi, VectorMeasure.add_apply, withDensityᵥ_apply hf hi,
     withDensityᵥ_apply hg hi]
   simp_rw [Pi.add_apply]
-  rw [integral_add] <;> rw [← integrableOn_univ]
-  · exact hf.integrableOn.restrict
-  · exact hg.integrableOn.restrict
+  rw [integral_add]
+  · exact hf.integrableOn
+  · exact hg.integrableOn
 
 theorem withDensityᵥ_add' (hf : Integrable f μ) (hg : Integrable g μ) :
     (μ.withDensityᵥ fun x => f x + g x) = μ.withDensityᵥ f + μ.withDensityᵥ g :=

--- a/Mathlib/MeasureTheory/VectorMeasure/WithDensity.lean
+++ b/Mathlib/MeasureTheory/VectorMeasure/WithDensity.lean
@@ -83,8 +83,8 @@ theorem withDensityᵥ_add (hf : Integrable f μ) (hg : Integrable g μ) :
     withDensityᵥ_apply hg hi]
   simp_rw [Pi.add_apply]
   rw [integral_add] <;> rw [← integrableOn_univ]
-  · exact hf.integrableOn.restrict MeasurableSet.univ
-  · exact hg.integrableOn.restrict MeasurableSet.univ
+  · exact hf.integrableOn.restrict
+  · exact hg.integrableOn.restrict
 
 theorem withDensityᵥ_add' (hf : Integrable f μ) (hg : Integrable g μ) :
     (μ.withDensityᵥ fun x => f x + g x) = μ.withDensityᵥ f + μ.withDensityᵥ g :=


### PR DESCRIPTION
... in `IntegrableOn.restrict`.
Also fix a typo in a docstring and golf away some uses of this lemma.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
