### PR TITLE
feat(NumberField/Units): an algebra map between ring of integers is a `localHom`

### DIFF
--- a/Mathlib/NumberTheory/NumberField/Units/Basic.lean
+++ b/Mathlib/NumberTheory/NumberField/Units/Basic.lean
@@ -55,6 +55,17 @@ theorem NumberField.isUnit_iff_norm [NumberField K] {x : 𝓞 K} :
   convert (RingOfIntegers.isUnit_norm ℚ (F := K)).symm
   rw [← abs_one, abs_eq_abs, ← Rat.RingOfIntegers.isUnit_iff]
 
+/--
+An algebra map between rings of integers is a `localHom` in the sense that is sends non-unit
+to non-unit.
+-/
+instance [NumberField K] {L : Type*} [Field L] [NumberField L] [Algebra K L] :
+    IsLocalHom (algebraMap (𝓞 K) (𝓞 L)) := ⟨fun u hu ↦ by
+  rwa [isUnit_iff_norm, RingOfIntegers.coe_norm, ← Algebra.norm_norm (S := K),
+    show algebraMap (𝓞 K) (𝓞 L) u = algebraMap K L (u : K) by rfl, Algebra.norm_algebraMap,
+    map_pow, abs_pow_eq_one _ Module.finrank_pos.ne', ← @RingOfIntegers.coe_norm,
+    ← isUnit_iff_norm] at hu⟩
+
 end IsUnit
 
 namespace NumberField.Units


### PR DESCRIPTION
Add the instance
```lean
instance {K : Type*} [Field K] [NumberField K] {L : Type*} [Field L] [NumberField L] [Algebra K L] :
    IsLocalHom (algebraMap (𝓞 K) (𝓞 L)) 
```
that is `algebraMap (𝓞 K) (𝓞 L) x` is an unit iff `x` is a unit. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
