### PR TITLE
feat(Mathlib/RingTheory/Int/Basic): add eq_pow_of_mul_eq_pow for Nat

### DIFF
--- a/Mathlib/RingTheory/Int/Basic.lean
+++ b/Mathlib/RingTheory/Int/Basic.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2018 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Johannes Hölzl, Jens Wagemaker, Aaron Anderson
+Authors: Johannes Hölzl, Jens Wagemaker, Aaron Anderson, Sabbir Rahman
 -/
 import Mathlib.Algebra.EuclideanDomain.Basic
 import Mathlib.Algebra.EuclideanDomain.Int
@@ -10,10 +10,10 @@ import Mathlib.Data.Nat.Prime.Int
 import Mathlib.RingTheory.PrincipalIdealDomain
 
 /-!
-# Divisibility over ℤ
+# Divisibility over ℤ and ℕ
 
 This file collects results for the integers that use ring theory in their proofs or
-cases of ℤ being examples of structures in ring theory.
+cases of ℤ or ℕ being examples of structures in ring theory.
 
 ## Main statements
 
@@ -131,3 +131,20 @@ theorem eq_pow_of_mul_eq_pow_odd {a b c : ℤ} (hab : IsCoprime a b) {k : ℕ} (
   ⟨eq_pow_of_mul_eq_pow_odd_left hab hk h, eq_pow_of_mul_eq_pow_odd_right hab hk h⟩
 
 end Int
+
+namespace Nat
+
+theorem eq_pow_of_mul_eq_pow_left {a b c k : ℕ} (hab : Coprime a b) (h : a * b = c ^ k) :
+  ∃ d, a = d ^ k := by
+  obtain ⟨d, hd⟩ := exists_associated_pow_of_mul_eq_pow (isUnit_iff_eq_one.mpr hab) h
+  use d
+  rw [associated_iff_eq.mp hd]
+
+theorem eq_pow_of_mul_eq_pow_right {a b c k : ℕ} (hab : Coprime a b) (h : a * b = c ^ k) :
+  ∃ d, b = d ^ k := by
+  obtain ⟨d, hd⟩ := exists_associated_pow_of_mul_eq_pow (isUnit_iff_eq_one.mpr hab.symm)
+    (by rwa [mul_comm] at h)
+  use d
+  rw [associated_iff_eq.mp hd]
+
+end Nat


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

This pr adds theorems analogous to [Int.sq_of_isCoprime](https://leanprover-community.github.io/mathlib4_docs/Mathlib/RingTheory/Int/Basic.html#Int.sq_of_isCoprime), but with generic power and both left and right versions. I had asked in [this zulip thread](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Nat.20and.20left.2C.20right.20version.20of.20Int.2Esq_of_isCoprime) before to make sure this theorem was missing.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
