### PR TITLE
[Merged by Bors] - feat: recursor for nonempty lists

### DIFF
--- a/Mathlib/Data/List/Induction.lean
+++ b/Mathlib/Data/List/Induction.lean
@@ -150,25 +150,10 @@ A dependent recursion principle for nonempty lists. Useful for dealing with
 operations like `List.head` which are not defined on the empty list.
 Same as `List.recNeNil`, with a more convenient argument order.
 -/
-@[elab_as_elim]
+@[elab_as_elim, simp]
 abbrev recOnNeNil {motive : (l : List α) → l ≠ [] → Sort*} (l : List α) (h : l ≠ [])
     (singleton : ∀ x, motive [x] (cons_ne_nil x []))
     (cons : ∀ x xs h, motive xs h → motive (x :: xs) (cons_ne_nil x xs)) :
     motive l h := recNeNil singleton cons l h
-
-@[simp]
-theorem recOnNeNil_singleton {motive : (l : List α) → l ≠ [] → Sort*} (x : α)
-    (singleton : ∀ x, motive [x] (cons_ne_nil x []))
-    (cons : ∀ x xs h, motive xs h → motive (x :: xs) (cons_ne_nil x xs)) :
-    recOnNeNil [x] (cons_ne_nil x []) singleton cons = singleton x := rfl
-
-@[simp]
-theorem recOnNeNil_cons {motive : (l : List α) → l ≠ [] → Sort*} (x : α) (xs : List α) (h : xs ≠ [])
-    (singleton : ∀ x, motive [x] (cons_ne_nil x []))
-    (cons : ∀ x xs h, motive xs h → motive (x :: xs) (cons_ne_nil x xs)) :
-    recOnNeNil (x :: xs) (cons_ne_nil x xs) singleton cons =
-      cons x xs h (recOnNeNil xs h singleton cons) :=
-  match xs with
-  | _ :: _ => rfl
 
 end List

--- a/Mathlib/Data/List/Induction.lean
+++ b/Mathlib/Data/List/Induction.lean
@@ -116,4 +116,59 @@ abbrev bidirectionalRecOn {C : List α → Sort*} (l : List α) (H0 : C []) (H1 
     (Hn : ∀ (a : α) (l : List α) (b : α), C l → C (a :: (l ++ [b]))) : C l :=
   bidirectionalRec H0 H1 Hn l
 
+/--
+A dependent recursion principle for nonempty lists. Useful for dealing with
+operations like `List.head` which are not defined on the empty list.
+-/
+@[elab_as_elim]
+def recNeNil {motive : (l : List α) → l ≠ [] → Sort*}
+    (singleton : ∀ x, motive [x] (cons_ne_nil x []))
+    (cons : ∀ x xs h, motive xs h → motive (x :: xs) (cons_ne_nil x xs))
+    (l : List α) (h : l ≠ []) : motive l h :=
+  match l with
+  | [x] => singleton x
+  | x :: y :: xs =>
+    cons x (y :: xs) (cons_ne_nil y xs) (recNeNil singleton cons (y :: xs) (cons_ne_nil y xs))
+
+@[simp]
+theorem recNeNil_singleton {motive : (l : List α) → l ≠ [] → Sort*} (x : α)
+    (singleton : ∀ x, motive [x] (cons_ne_nil x []))
+    (cons : ∀ x xs h, motive xs h → motive (x :: xs) (cons_ne_nil x xs)) :
+    recNeNil singleton cons [x] (cons_ne_nil x []) = singleton x := rfl
+
+@[simp]
+theorem recNeNil_cons {motive : (l : List α) → l ≠ [] → Sort*} (x : α) (xs : List α) (h : xs ≠ [])
+    (singleton : ∀ x, motive [x] (cons_ne_nil x []))
+    (cons : ∀ x xs h, motive xs h → motive (x :: xs) (cons_ne_nil x xs)) :
+    recNeNil singleton cons (x :: xs) (cons_ne_nil x xs) =
+      cons x xs h (recNeNil singleton cons xs h) :=
+  match xs with
+  | _ :: _ => rfl
+
+/--
+A dependent recursion principle for nonempty lists. Useful for dealing with
+operations like `List.head` which are not defined on the empty list.
+Same as `List.recNeNil`, with a more convenient argument order.
+-/
+@[elab_as_elim]
+abbrev recOnNeNil {motive : (l : List α) → l ≠ [] → Sort*} (l : List α) (h : l ≠ [])
+    (singleton : ∀ x, motive [x] (cons_ne_nil x []))
+    (cons : ∀ x xs h, motive xs h → motive (x :: xs) (cons_ne_nil x xs)) :
+    motive l h := recNeNil singleton cons l h
+
+@[simp]
+theorem recOnNeNil_singleton {motive : (l : List α) → l ≠ [] → Sort*} (x : α)
+    (singleton : ∀ x, motive [x] (cons_ne_nil x []))
+    (cons : ∀ x xs h, motive xs h → motive (x :: xs) (cons_ne_nil x xs)) :
+    recOnNeNil [x] (cons_ne_nil x []) singleton cons = singleton x := rfl
+
+@[simp]
+theorem recOnNeNil_cons {motive : (l : List α) → l ≠ [] → Sort*} (x : α) (xs : List α) (h : xs ≠ [])
+    (singleton : ∀ x, motive [x] (cons_ne_nil x []))
+    (cons : ∀ x xs h, motive xs h → motive (x :: xs) (cons_ne_nil x xs)) :
+    recOnNeNil (x :: xs) (cons_ne_nil x xs) singleton cons =
+      cons x xs h (recOnNeNil xs h singleton cons) :=
+  match xs with
+  | _ :: _ => rfl
+
 end List


### PR DESCRIPTION
Adds `List.recNeNil` and `List.recOnNeNil` for motives that depend on the list being nonempty. Taken from [Zulip](https://leanprover.zulipchat.com/#narrow/channel/217875-Is-there-code-for-X.3F/topic/accessing.20the.20source.20case.20during.20induction/near/502101211).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
