### PR TITLE
[Merged by Bors] - feat(RingTheory): length of submodules and quotients

### DIFF
--- a/Mathlib/LinearAlgebra/Quotient/Basic.lean
+++ b/Mathlib/LinearAlgebra/Quotient/Basic.lean
@@ -286,7 +286,7 @@ end
 
 /-- The correspondence theorem for modules: there is an order isomorphism between submodules of the
 quotient of `M` by `p`, and submodules of `M` larger than `p`. -/
-def comapMkQRelIso : Submodule R (M ⧸ p) ≃o { p' : Submodule R M // p ≤ p' } where
+def comapMkQRelIso : Submodule R (M ⧸ p) ≃o Set.Ici p where
   toFun p' := ⟨comap p.mkQ p', le_comap_mkQ p _⟩
   invFun q := map p.mkQ q
   left_inv p' := map_comap_eq_self <| by simp

--- a/Mathlib/RingTheory/Length.lean
+++ b/Mathlib/RingTheory/Length.lean
@@ -90,6 +90,32 @@ lemma Module.length_ne_top [IsArtinian R M] [IsNoetherian R M] : Module.length R
   rw [Module.length_ne_top_iff, isFiniteLength_iff_isNoetherian_isArtinian]
   exact ⟨‹_›, ‹_›⟩
 
+lemma Module.length_submodule {N : Submodule R M} :
+    Module.length R N = Order.height N := by
+  apply WithBot.coe_injective
+  rw [Order.height_eq_krullDim_Iic, coe_length, Order.krullDim_eq_of_orderIso (Submodule.mapIic _)]
+
+lemma Module.length_quotient {N : Submodule R M} :
+    Module.length R (M ⧸ N) = Order.coheight N := by
+  apply WithBot.coe_injective
+  rw [Order.coheight_eq_krullDim_Ici, coe_length,
+    Order.krullDim_eq_of_orderIso (Submodule.comapMkQRelIso N)]
+  rfl
+
+lemma LinearEquiv.length_eq {N : Type*} [AddCommGroup N] [Module R N] (e : M ≃ₗ[R] N) :
+    Module.length R M = Module.length R N := by
+  apply WithBot.coe_injective
+  rw [Module.coe_length, Module.coe_length,
+    Order.krullDim_eq_of_orderIso (Submodule.orderIsoMapComap e)]
+
+@[simp] lemma Module.length_bot :
+    Module.length R (⊥ : Submodule R M) = 0 :=
+  Module.length_eq_zero
+
+@[simp] lemma Module.length_top :
+    Module.length R (⊤ : Submodule R M) = Module.length R M := by
+  rw [Module.length_submodule, Module.length_eq_height]
+
 variable {N P : Type*} [AddCommGroup N] [AddCommGroup P] [Module R N] [Module R P]
 variable (f : N →ₗ[R] M) (g : M →ₗ[R] P) (hf : Function.Injective f) (hg : Function.Surjective g)
 variable (H : Function.Exact f g)
@@ -121,3 +147,15 @@ lemma Module.length_eq_add_of_exact :
   · have := mt (IsFiniteLength.of_surjective · hg) hP
     rw [← Module.length_ne_top_iff, ne_eq, not_not] at hP this
     rw [hP, this, add_top]
+
+include hf in
+lemma Module.length_le_of_injective : Module.length R N ≤ Module.length R M := by
+  rw [Module.length_eq_add_of_exact f (LinearMap.range f).mkQ hf
+    (Submodule.mkQ_surjective _) (LinearMap.exact_map_mkQ_range f)]
+  exact le_self_add
+
+include hg in
+lemma Module.length_le_of_surjective : Module.length R P ≤ Module.length R M := by
+  rw [Module.length_eq_add_of_exact (LinearMap.ker g).subtype g (Submodule.subtype_injective _) hg
+    (LinearMap.exact_subtype_ker_map g)]
+  exact le_add_self

--- a/Mathlib/RingTheory/Length.lean
+++ b/Mathlib/RingTheory/Length.lean
@@ -100,7 +100,6 @@ lemma Module.length_quotient {N : Submodule R M} :
   apply WithBot.coe_injective
   rw [Order.coheight_eq_krullDim_Ici, coe_length,
     Order.krullDim_eq_of_orderIso (Submodule.comapMkQRelIso N)]
-  rfl
 
 lemma LinearEquiv.length_eq {N : Type*} [AddCommGroup N] [Module R N] (e : M ≃ₗ[R] N) :
     Module.length R M = Module.length R N := by


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
