### PR TITLE
[Merged by Bors] - feat: clopen characterization of connected spaces

### DIFF
--- a/Mathlib/Topology/Connected/Clopen.lean
+++ b/Mathlib/Topology/Connected/Clopen.lean
@@ -563,3 +563,16 @@ theorem preconnectedSpace_of_forall_constant
     (hs : ∀ f : α → Bool, Continuous f → ∀ x y, f x = f y) : PreconnectedSpace α :=
   ⟨isPreconnected_of_forall_constant fun f hf x _ y _ =>
       hs f (continuous_iff_continuousOn_univ.mpr hf) x y⟩
+
+theorem preconnectedSpace_iff_clopen :
+    PreconnectedSpace α ↔ ∀ s : Set α, IsClopen s → s = ∅ ∨ s = Set.univ :=
+  ⟨fun _ _ => isClopen_iff.mp, fun h ↦ preconnectedSpace_of_forall_constant fun f hf x y =>
+    (h (f ⁻¹' {true}) ((isClopen_discrete {true}).preimage hf)).elim
+      (fun h => (eq_false_of_ne_true fun hx => Set.preimage_singleton_eq_empty.mp h ⟨x, hx⟩).trans
+        (eq_false_of_ne_true fun hy => Set.preimage_singleton_eq_empty.mp h ⟨y, hy⟩).symm)
+      (by aesop)⟩
+
+theorem connectedSpace_iff_clopen :
+    ConnectedSpace α ↔ Nonempty α ∧ ∀ s : Set α, IsClopen s → s = ∅ ∨ s = Set.univ := by
+  rw [connectedSpace_iff_univ, IsConnected, ← preconnectedSpace_iff_univ,
+    preconnectedSpace_iff_clopen, Set.nonempty_iff_univ_nonempty]

--- a/Mathlib/Topology/Connected/Clopen.lean
+++ b/Mathlib/Topology/Connected/Clopen.lean
@@ -565,12 +565,12 @@ theorem preconnectedSpace_of_forall_constant
       hs f (continuous_iff_continuousOn_univ.mpr hf) x y⟩
 
 theorem preconnectedSpace_iff_clopen :
-    PreconnectedSpace α ↔ ∀ s : Set α, IsClopen s → s = ∅ ∨ s = Set.univ :=
-  ⟨fun _ _ => isClopen_iff.mp, fun h ↦ preconnectedSpace_of_forall_constant fun f hf x y =>
-    (h (f ⁻¹' {true}) ((isClopen_discrete {true}).preimage hf)).elim
-      (fun h => (eq_false_of_ne_true fun hx => Set.preimage_singleton_eq_empty.mp h ⟨x, hx⟩).trans
-        (eq_false_of_ne_true fun hy => Set.preimage_singleton_eq_empty.mp h ⟨y, hy⟩).symm)
-      (by aesop)⟩
+    PreconnectedSpace α ↔ ∀ s : Set α, IsClopen s → s = ∅ ∨ s = Set.univ := by
+  refine ⟨fun _ _ => isClopen_iff.mp, fun h ↦ ?_⟩
+  refine preconnectedSpace_of_forall_constant fun f hf x y ↦ ?_
+  have : f ⁻¹' {false} = (f ⁻¹' {true})ᶜ := by
+    rw [← Set.preimage_compl, Bool.compl_singleton, Bool.not_true]
+  obtain (h | h) := h _ ((isClopen_discrete {true}).preimage hf) <;> simp_all
 
 theorem connectedSpace_iff_clopen :
     ConnectedSpace α ↔ Nonempty α ∧ ∀ s : Set α, IsClopen s → s = ∅ ∨ s = Set.univ := by


### PR DESCRIPTION
Proves that a space is connected iff it contains no nontrivial clopen sets.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
