### PR TITLE
[Merged by Bors] - docs: mention `continuous_of_discreteTopology` in `continuous_empty_function`

### DIFF
--- a/Mathlib/Topology/Order.lean
+++ b/Mathlib/Topology/Order.lean
@@ -498,6 +498,7 @@ instance {n} : DiscreteTopology (Fin n) := ⟨rfl⟩
 instance sierpinskiSpace : TopologicalSpace Prop :=
   generateFrom {{True}}
 
+/-- See also `continuous_of_discreteTopology`, which works for `IsEmpty α`. -/
 theorem continuous_empty_function [TopologicalSpace α] [TopologicalSpace β] [IsEmpty β]
     (f : α → β) : Continuous f :=
   letI := Function.isEmpty f


### PR DESCRIPTION
Adds a docstring to `continuous_empty_function` that points to `continuous_of_discreteTopology`, to aid searching.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
