### PR TITLE
[Merged by Bors] - feat(FieldTheory/KrullTopology): add `IntermediateField.finrank_eq_fixingSubgroup_index`

### DIFF
--- a/Mathlib/FieldTheory/KrullTopology.lean
+++ b/Mathlib/FieldTheory/KrullTopology.lean
@@ -40,6 +40,10 @@ all intermediate fields `E` with `E/K` finite dimensional.
 - `krullTopology_totallyDisconnected K L`. For an integral field extension `L/K`, the topology
   `krullTopology K L` is totally disconnected.
 
+- `IntermediateField.finrank_eq_fixingSubgroup_index`: given a Galois extension `K/k` and an
+  intermediate field `L`, the `[L : k]` as a natural number is equal to the index of the
+  fixing subgroup of `L`.
+
 ## Notations
 
 - In docstrings, we will write `Gal(L/E)` to denote the fixing subgroup of an intermediate field
@@ -175,6 +179,7 @@ instance krullTopology (K L : Type*) [Field K] [Field L] [Algebra K L] :
   GroupFilterBasis.topology (galGroupBasis K L)
 
 /-- For a field extension `L/K`, the Krull topology on `L ≃ₐ[K] L` makes it a topological group. -/
+@[stacks 0BMJ "We define Krull topology directly without proving the universal property"]
 instance (K L : Type*) [Field K] [Field L] [Algebra K L] : IsTopologicalGroup (L ≃ₐ[K] L) :=
   GroupFilterBasis.isTopologicalGroup (galGroupBasis K L)
 
@@ -302,3 +307,68 @@ instance krullTopology_discreteTopology_of_finiteDimensional (K L : Type*) [Fiel
   change IsOpen ((⊥ : Subgroup (L ≃ₐ[K] L)) : Set (L ≃ₐ[K] L))
   rw [← IntermediateField.fixingSubgroup_top]
   exact IntermediateField.fixingSubgroup_isOpen ⊤
+
+namespace IntermediateField
+
+variable {k E : Type*} (K : Type*) [Field k] [Field E] [Field K]
+  [Algebra k E] [Algebra k K] [Algebra E K] [IsScalarTower k E K] (L : IntermediateField k E)
+
+/-- If `K / E / k` is a field extension tower with `E / k` normal,
+`L` is an intermediate field of `E / k`, then the fixing subgroup of `L` viewed as an
+intermediate field of `K / k` is equal to the preimage of the fixing subgroup of `L` viewed as an
+intermediate field of `E / k` under the natural map `Aut(K / k) → Aut(E / k)`
+(`AlgEquiv.restrictNormalHom`). -/
+theorem map_fixingSubgroup [Normal k E] :
+    (L.map (IsScalarTower.toAlgHom k E K)).fixingSubgroup =
+      L.fixingSubgroup.comap (AlgEquiv.restrictNormalHom (F := k) (K₁ := K) E) := by
+  ext f
+  simp only [Subgroup.mem_comap, mem_fixingSubgroup_iff]
+  constructor
+  · rintro h x hx
+    change f.restrictNormal E x = x
+    apply_fun _ using (algebraMap E K).injective
+    rw [AlgEquiv.restrictNormal_commutes]
+    exact h _ ⟨x, hx, rfl⟩
+  · rintro h _ ⟨x, hx, rfl⟩
+    replace h := congr(algebraMap E K $(show f.restrictNormal E x = x from h x hx))
+    rwa [AlgEquiv.restrictNormal_commutes] at h
+
+/-- If `K / E / k` is a field extension tower with `E / k` and `K / k` normal,
+`L` is an intermediate field of `E / k`, then the indx of the fixing subgroup of `L` viewed as an
+intermediate field of `K / k` is equal to the index of the fixing subgroup of `L` viewed as an
+intermediate field of `E / k`. -/
+theorem map_fixingSubgroup_index [Normal k E] [Normal k K] :
+    (L.map (IsScalarTower.toAlgHom k E K)).fixingSubgroup.index = L.fixingSubgroup.index := by
+  rw [L.map_fixingSubgroup K, L.fixingSubgroup.index_comap_of_surjective
+    (AlgEquiv.restrictNormalHom_surjective _)]
+
+variable {K} in
+/-- If `K / k` is a Galois extension, `L` is an intermediate field of `K / k`, then `[L : k]`
+as a natural number is equal to the index of the fixing subgroup of `L`. -/
+theorem finrank_eq_fixingSubgroup_index (L : IntermediateField k K) [IsGalois k K] :
+    Module.finrank k L = L.fixingSubgroup.index := by
+  wlog hnfd : FiniteDimensional k L generalizing L
+  · rw [Module.finrank_of_infinite_dimensional hnfd]
+    by_contra! h
+    replace h : L.fixingSubgroup.FiniteIndex := ⟨h.symm⟩
+    obtain ⟨L', hfd, hL'⟩ :=
+      exists_lt_finrank_of_infinite_dimensional hnfd L.fixingSubgroup.index
+    let i := (liftAlgEquiv L').toLinearEquiv
+    replace hfd := i.finiteDimensional
+    rw [i.finrank_eq, this _ hfd] at hL'
+    exact (Subgroup.index_antitone <| fixingSubgroup.antimono <|
+      IntermediateField.lift_le L').not_lt hL'
+  let E := normalClosure k L K
+  have hle : L ≤ E := by simpa only [fieldRange_val] using L.val.fieldRange_le_normalClosure
+  let L' := restrict hle
+  have h := Module.finrank_mul_finrank k ↥L' ↥E
+  classical
+  rw [← IsGalois.card_fixingSubgroup_eq_finrank L', ← IsGalois.card_aut_eq_finrank k E] at h
+  nth_rw 2 [Fintype.card_eq_nat_card] at h
+  rw [← L'.fixingSubgroup.index_mul_card, Nat.card_eq_fintype_card,
+    Nat.mul_left_inj Fintype.card_ne_zero] at h
+  rw [(restrict_algEquiv hle).toLinearEquiv.finrank_eq, h, ← L'.map_fixingSubgroup_index K]
+  congr 2
+  exact lift_restrict hle
+
+end IntermediateField

--- a/Mathlib/FieldTheory/KrullTopology.lean
+++ b/Mathlib/FieldTheory/KrullTopology.lean
@@ -334,7 +334,7 @@ theorem map_fixingSubgroup [Normal k E] :
     rwa [AlgEquiv.restrictNormal_commutes] at h
 
 /-- If `K / E / k` is a field extension tower with `E / k` and `K / k` normal,
-`L` is an intermediate field of `E / k`, then the indx of the fixing subgroup of `L` viewed as an
+`L` is an intermediate field of `E / k`, then the index of the fixing subgroup of `L` viewed as an
 intermediate field of `K / k` is equal to the index of the fixing subgroup of `L` viewed as an
 intermediate field of `E / k`. -/
 theorem map_fixingSubgroup_index [Normal k E] [Normal k K] :


### PR DESCRIPTION
... which states that given a Galois extension `K/k` and an intermediate field `L`, the `[L : k]` as a natural number is equal to the index of the fixing subgroup of `L`.

The proof of it uses some results in this file, so it can't be put into earlier files.

Also add some results on fixing subgroups used in the proof.

Also add a stack tag to Krull topology.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

Discussion: [#Is there code for X? > in K / L / k, &#91;L : k&#93; = index of fixing subgroup of L](https://leanprover.zulipchat.com/#narrow/channel/217875-Is-there-code-for-X.3F/topic/in.20K.20.2F.20L.20.2F.20k.2C.20.5BL.20.3A.20k.5D.20.3D.20index.20of.20fixing.20subgroup.20of.20L)

This is used in Iwasawa Theory project https://github.com/acmepjz/lean-iwasawa/blob/master/Iwasawalib/FieldTheory/ZpExtension/Basic.lean