### PR TITLE
[Merged by Bors] - chore(CategoryTheory/Whiskering): move definition of functor associators and unitors

### DIFF
--- a/Mathlib/CategoryTheory/Functor/Category.lean
+++ b/Mathlib/CategoryTheory/Functor/Category.lean
@@ -11,6 +11,11 @@ import Mathlib.CategoryTheory.Iso
 
 We provide the category instance on `C ⥤ D`, with morphisms the natural transformations.
 
+At the end of the file, we provide the left and right unitors, and the associator,
+for functor composition.
+(In fact functor composition is definitionally associative, but very often relying on this causes
+extremely slow elaboration, so it is better to insert it explicitly.)
+
 ## Universes
 
 If `C` and `D` are both small categories at the same universe level,
@@ -139,6 +144,37 @@ protected def flip (F : C ⥤ D ⥤ E) : D ⥤ C ⥤ E where
     { obj := fun j => (F.obj j).obj k,
       map := fun f => (F.map f).app k, }
   map f := { app := fun j => (F.obj j).map f }
+
+
+/-- The left unitor, a natural isomorphism `((𝟭 _) ⋙ F) ≅ F`.
+-/
+@[simps]
+def leftUnitor (F : C ⥤ D) :
+    𝟭 C ⋙ F ≅ F where
+  hom := { app := fun X => 𝟙 (F.obj X) }
+  inv := { app := fun X => 𝟙 (F.obj X) }
+
+/-- The right unitor, a natural isomorphism `(F ⋙ (𝟭 B)) ≅ F`.
+-/
+@[simps]
+def rightUnitor (F : C ⥤ D) :
+    F ⋙ 𝟭 D ≅ F where
+  hom := { app := fun X => 𝟙 (F.obj X) }
+  inv := { app := fun X => 𝟙 (F.obj X) }
+
+/-- The associator for functors, a natural isomorphism `((F ⋙ G) ⋙ H) ≅ (F ⋙ (G ⋙ H))`.
+
+(In fact, `iso.refl _` will work here, but it tends to make Lean slow later,
+and it's usually best to insert explicit associators.)
+-/
+@[simps]
+def associator (F : C ⥤ D) (G : D ⥤ E) (H : E ⥤ E') :
+    (F ⋙ G) ⋙ H ≅ F ⋙ G ⋙ H where
+  hom := { app := fun _ => 𝟙 _ }
+  inv := { app := fun _ => 𝟙 _ }
+
+protected theorem assoc (F : C ⥤ D) (G : D ⥤ E) (H : E ⥤ E') : (F ⋙ G) ⋙ H = F ⋙ G ⋙ H :=
+  rfl
 
 end Functor
 

--- a/Mathlib/CategoryTheory/Whiskering.lean
+++ b/Mathlib/CategoryTheory/Whiskering.lean
@@ -21,11 +21,8 @@ This operation is functorial in `F`, and we package this as `whiskeringLeft`. He
 
 We also provide analogues for composition on the right, and for these operations on isomorphisms.
 
-At the end of the file, we provide the left and right unitors, and the associator,
-for functor composition.
-(In fact functor composition is definitionally associative, but very often relying on this causes
-extremely slow elaboration, so it is better to insert it explicitly.)
-We also show these natural isomorphisms satisfy the triangle and pentagon identities.
+We show the associators an unitor natural isomorphisms satisfy the triangle and pentagon
+identities.
 -/
 
 
@@ -270,49 +267,13 @@ namespace Functor
 
 universe u₅ v₅
 
-variable {A : Type u₁} [Category.{v₁} A]
-variable {B : Type u₂} [Category.{v₂} B]
+variable {A : Type u₁} [Category.{v₁} A] {B : Type u₂} [Category.{v₂} B]
+  {C : Type u₃} [Category.{v₃} C] {D : Type u₄} [Category.{v₄} D] {E : Type u₅} [Category.{v₅} E]
+  (F : A ⥤ B) (G : B ⥤ C) (H : C ⥤ D) (K : D ⥤ E)
 
-/-- The left unitor, a natural isomorphism `((𝟭 _) ⋙ F) ≅ F`.
--/
-@[simps]
-def leftUnitor (F : A ⥤ B) :
-    𝟭 A ⋙ F ≅ F where
-  hom := { app := fun X => 𝟙 (F.obj X) }
-  inv := { app := fun X => 𝟙 (F.obj X) }
-
-/-- The right unitor, a natural isomorphism `(F ⋙ (𝟭 B)) ≅ F`.
--/
-@[simps]
-def rightUnitor (F : A ⥤ B) :
-    F ⋙ 𝟭 B ≅ F where
-  hom := { app := fun X => 𝟙 (F.obj X) }
-  inv := { app := fun X => 𝟙 (F.obj X) }
-
-variable {C : Type u₃} [Category.{v₃} C]
-variable {D : Type u₄} [Category.{v₄} D]
-
-/-- The associator for functors, a natural isomorphism `((F ⋙ G) ⋙ H) ≅ (F ⋙ (G ⋙ H))`.
-
-(In fact, `iso.refl _` will work here, but it tends to make Lean slow later,
-and it's usually best to insert explicit associators.)
--/
-@[simps]
-def associator (F : A ⥤ B) (G : B ⥤ C) (H : C ⥤ D) :
-    (F ⋙ G) ⋙ H ≅ F ⋙ G ⋙ H where
-  hom := { app := fun _ => 𝟙 _ }
-  inv := { app := fun _ => 𝟙 _ }
-
-protected theorem assoc (F : A ⥤ B) (G : B ⥤ C) (H : C ⥤ D) : (F ⋙ G) ⋙ H = F ⋙ G ⋙ H :=
-  rfl
-
-theorem triangle (F : A ⥤ B) (G : B ⥤ C) :
+theorem triangle :
     (associator F (𝟭 B) G).hom ≫ whiskerLeft F (leftUnitor G).hom =
       whiskerRight (rightUnitor F).hom G := by aesop_cat
-
--- See note [dsimp, simp].
-variable {E : Type u₅} [Category.{v₅} E]
-variable (F : A ⥤ B) (G : B ⥤ C) (H : C ⥤ D) (K : D ⥤ E)
 
 theorem pentagon :
     whiskerRight (associator F G H).hom K ≫


### PR DESCRIPTION
The definition of functor associators and unitors are moved to `CategoryTheory/Functor/Category.lean`. Pentagon and triangle identities remain in `CategoryTheory/Whiskering.lean`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[#mathlib4 > &#96;whiskerLeft_twice&#96; and co.](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/.60whiskerLeft_twice.60.20and.20co.2E)

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
