### PR TITLE
[Merged by Bors] - chore: fix namespace of `FullyFaithful.over`

### DIFF
--- a/Mathlib/CategoryTheory/Comma/Over/Basic.lean
+++ b/Mathlib/CategoryTheory/Comma/Over/Basic.lean
@@ -385,7 +385,8 @@ instance [F.Full] [F.EssSurj] : (Over.post (X := X) F).EssSurj where
 instance [F.IsEquivalence] : (Over.post (X := X) F).IsEquivalence where
 
 /-- If `F` is fully faithful, then so is `Over.post F`. -/
-def FullyFaithful.over (h : F.FullyFaithful) : (Over.post (X := X) F).FullyFaithful where
+def _root_.CategoryTheory.Functor.FullyFaithful.over (h : F.FullyFaithful) :
+    (post (X := X) F).FullyFaithful where
   preimage {A B} f := Over.homMk (h.preimage f.left) <| h.map_injective (by simpa using Over.w f)
 
 /-- An equivalence of categories induces an equivalence on over categories. -/
@@ -726,7 +727,8 @@ instance [F.Full] [F.EssSurj] : (Under.post (X := X) F).EssSurj where
 instance [F.IsEquivalence] : (Under.post (X := X) F).IsEquivalence where
 
 /-- If `F` is fully faithful, then so is `Under.post F`. -/
-def FullyFaithful.under (h : F.FullyFaithful) : (Under.post (X := X) F).FullyFaithful where
+def _root_.CategoryTheory.Functor.FullyFaithful.under (h : F.FullyFaithful) :
+    (post (X := X) F).FullyFaithful where
   preimage {A B} f := Under.homMk (h.preimage f.right) <| h.map_injective (by simpa using Under.w f)
 
 /-- An equivalence of categories induces an equivalence on under categories. -/


### PR DESCRIPTION
No deprecation because it's a namespace change and because this was just introduced in #23481.

From Toric


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
