### PR TITLE
[Merged by Bors] - chore: move `Module.End`-related decls to the `Module.End` namespace

### DIFF
--- a/Mathlib/Algebra/Algebra/Basic.lean
+++ b/Mathlib/Algebra/Algebra/Basic.lean
@@ -189,23 +189,23 @@ section
 
 variable {R M}
 
-theorem End_algebraMap_isUnit_inv_apply_eq_iff {x : R}
+theorem End.algebraMap_isUnit_inv_apply_eq_iff {x : R}
     (h : IsUnit (algebraMap R (Module.End S M) x)) (m m' : M) :
     (↑(h.unit⁻¹) : Module.End S M) m = m' ↔ m = x • m' where
-  mp H := H ▸ (End_isUnit_apply_inv_apply_of_isUnit h m).symm
+  mp H := H ▸ (isUnit_apply_inv_apply_of_isUnit h m).symm
   mpr H :=
     H.symm ▸ by
-      apply_fun ⇑h.unit.val using ((Module.End_isUnit_iff _).mp h).injective
-      simpa using End_isUnit_apply_inv_apply_of_isUnit h (x • m')
+      apply_fun ⇑h.unit.val using ((isUnit_iff _).mp h).injective
+      simpa using Module.End.isUnit_apply_inv_apply_of_isUnit h (x • m')
 
-theorem End_algebraMap_isUnit_inv_apply_eq_iff' {x : R}
+theorem End.algebraMap_isUnit_inv_apply_eq_iff' {x : R}
     (h : IsUnit (algebraMap R (Module.End S M) x)) (m m' : M) :
     m' = (↑h.unit⁻¹ : Module.End S M) m ↔ m = x • m' where
-  mp H := H ▸ (End_isUnit_apply_inv_apply_of_isUnit h m).symm
+  mp H := H ▸ (isUnit_apply_inv_apply_of_isUnit h m).symm
   mpr H :=
     H.symm ▸ by
-      apply_fun (↑h.unit : M → M) using ((Module.End_isUnit_iff _).mp h).injective
-      simpa using End_isUnit_apply_inv_apply_of_isUnit h (x • m') |>.symm
+      apply_fun (↑h.unit : M → M) using ((isUnit_iff _).mp h).injective
+      simpa using isUnit_apply_inv_apply_of_isUnit h (x • m') |>.symm
 
 end
 

--- a/Mathlib/Algebra/Algebra/Basic.lean
+++ b/Mathlib/Algebra/Algebra/Basic.lean
@@ -198,6 +198,9 @@ theorem End.algebraMap_isUnit_inv_apply_eq_iff {x : R}
       apply_fun ⇑h.unit.val using ((isUnit_iff _).mp h).injective
       simpa using Module.End.isUnit_apply_inv_apply_of_isUnit h (x • m')
 
+@[deprecated (since := "2025-04-28")]
+alias End_algebraMap_isUnit_inv_apply_eq_iff := End.algebraMap_isUnit_inv_apply_eq_iff
+
 theorem End.algebraMap_isUnit_inv_apply_eq_iff' {x : R}
     (h : IsUnit (algebraMap R (Module.End S M) x)) (m m' : M) :
     m' = (↑h.unit⁻¹ : Module.End S M) m ↔ m = x • m' where
@@ -206,6 +209,9 @@ theorem End.algebraMap_isUnit_inv_apply_eq_iff' {x : R}
     H.symm ▸ by
       apply_fun (↑h.unit : M → M) using ((isUnit_iff _).mp h).injective
       simpa using isUnit_apply_inv_apply_of_isUnit h (x • m') |>.symm
+
+@[deprecated (since := "2025-04-28")]
+alias End_algebraMap_isUnit_inv_apply_eq_iff' := End.algebraMap_isUnit_inv_apply_eq_iff'
 
 end
 

--- a/Mathlib/Algebra/Algebra/Bilinear.lean
+++ b/Mathlib/Algebra/Algebra/Bilinear.lean
@@ -190,8 +190,8 @@ theorem mulLeft_eq_zero_iff (a : A) : mulLeft R a = 0 ↔ a = 0 := by
 @[simp]
 theorem pow_mulLeft (a : A) (n : ℕ) : mulLeft R a ^ n = mulLeft R (a ^ n) :=
   match n with
-  | 0 => by rw [pow_zero, pow_zero, mulLeft_one, LinearMap.one_eq_id]
-  | (n + 1) => by rw [pow_succ, pow_succ, mulLeft_mul, LinearMap.mul_eq_comp, pow_mulLeft]
+  | 0 => by rw [pow_zero, pow_zero, mulLeft_one, Module.End.one_eq_id]
+  | (n + 1) => by rw [pow_succ, pow_succ, mulLeft_mul, Module.End.mul_eq_comp, pow_mulLeft]
 
 end left
 
@@ -211,8 +211,8 @@ theorem mulRight_eq_zero_iff (a : A) : mulRight R a = 0 ↔ a = 0 := by
 @[simp]
 theorem pow_mulRight (a : A) (n : ℕ) : mulRight R a ^ n = mulRight R (a ^ n) :=
   match n with
-  | 0 => by rw [pow_zero, pow_zero, mulRight_one, LinearMap.one_eq_id]
-  | (n + 1) => by rw [pow_succ, pow_succ', mulRight_mul, LinearMap.mul_eq_comp, pow_mulRight]
+  | 0 => by rw [pow_zero, pow_zero, mulRight_one, Module.End.one_eq_id]
+  | (n + 1) => by rw [pow_succ, pow_succ', mulRight_mul, Module.End.mul_eq_comp, pow_mulRight]
 
 end right
 
@@ -240,7 +240,7 @@ theorem _root_.Algebra.lmul_injective : Function.Injective (Algebra.lmul R A) :=
 
 theorem _root_.Algebra.lmul_isUnit_iff {x : A} :
     IsUnit (Algebra.lmul R A x) ↔ IsUnit x := by
-  rw [Module.End_isUnit_iff, Iff.comm]
+  rw [Module.End.isUnit_iff, Iff.comm]
   exact IsUnit.isUnit_iff_mulLeft_bijective
 
 theorem toSpanSingleton_eq_algebra_linearMap : toSpanSingleton R A 1 = Algebra.linearMap R A := by

--- a/Mathlib/Algebra/Group/ForwardDiff.lean
+++ b/Mathlib/Algebra/Group/ForwardDiff.lean
@@ -91,21 +91,18 @@ def fwdDiffₗ : Module.End ℤ (M → G) where
 lemma coe_fwdDiffₗ : ↑(fwdDiffₗ M G h) = fwdDiff h := rfl
 
 lemma coe_fwdDiffₗ_pow (n : ℕ) : ↑(fwdDiffₗ M G h ^ n) = (fwdDiff h)^[n] := by
-  ext; rw [LinearMap.pow_apply, coe_fwdDiffₗ]
+  ext; rw [Module.End.pow_apply, coe_fwdDiffₗ]
 
 variable (M G) in
 /-- Linear-endomorphism version of the shift-by-1 operator. -/
 def shiftₗ : Module.End ℤ (M → G) := fwdDiffₗ M G h + 1
 
-lemma shiftₗ_apply (f : M → G) (y : M) : shiftₗ M G h f y = f (y + h) := by
-  rw [shiftₗ, LinearMap.add_apply, Pi.add_apply, LinearMap.one_apply, fwdDiffₗ_apply, fwdDiff,
-    sub_add_cancel]
+lemma shiftₗ_apply (f : M → G) (y : M) : shiftₗ M G h f y = f (y + h) := by simp [shiftₗ, fwdDiff]
 
 lemma shiftₗ_pow_apply (f : M → G) (k : ℕ) (y : M) : (shiftₗ M G h ^ k) f y = f (y + k • h) := by
   induction' k with k IH generalizing f
-  · simp only [pow_zero, LinearMap.one_apply, cast_zero, add_zero, zero_smul]
-  · simp only [pow_add, pow_one, LinearMap.mul_apply, IH (shiftₗ M G h f), shiftₗ_apply, add_assoc,
-      add_nsmul, one_smul]
+  · simp
+  · simp [pow_add, IH (shiftₗ M G h f), shiftₗ_apply, add_assoc, add_nsmul]
 
 end fwdDiff_aux
 
@@ -139,7 +136,7 @@ theorem fwdDiff_iter_eq_sum_shift (f : M → G) (n : ℕ) (y : M) :
     Δ_[h]^[n] f y = ∑ k ∈ range (n + 1), ((-1 : ℤ) ^ (n - k) * n.choose k) • f (y + k • h) := by
   -- rewrite in terms of `(shiftₗ - 1) ^ n`
   have : fwdDiffₗ M G h = shiftₗ M G h - 1 := by simp only [shiftₗ, add_sub_cancel_right]
-  rw [← coe_fwdDiffₗ, this, ← LinearMap.pow_apply]
+  rw [← coe_fwdDiffₗ, this, ← Module.End.pow_apply]
   -- use binomial theorem `Commute.add_pow` to expand this
   have : Commute (shiftₗ M G h) (-1) := (Commute.one_right _).neg_right
   convert congr_fun (LinearMap.congr_fun (this.add_pow n) f) y using 3
@@ -148,7 +145,7 @@ theorem fwdDiff_iter_eq_sum_shift (f : M → G) (n : ℕ) (y : M) :
     congr 1 with k
     have : ((-1) ^ (n - k) * n.choose k : Module.End ℤ (M → G))
               = ↑((-1) ^ (n - k) * n.choose k : ℤ) := by norm_cast
-    rw [mul_assoc, LinearMap.mul_apply, this, Module.End.intCast_apply, LinearMap.map_smul,
+    rw [mul_assoc, Module.End.mul_apply, this, Module.End.intCast_apply, LinearMap.map_smul,
       Pi.smul_apply, shiftₗ_pow_apply]
 
 /--
@@ -160,8 +157,7 @@ theorem shift_eq_sum_fwdDiff_iter (f : M → G) (n : ℕ) (y : M) :
   convert congr_fun (LinearMap.congr_fun
       ((Commute.one_right (fwdDiffₗ M G h)).add_pow n) f) y using 1
   · rw [← shiftₗ_pow_apply h f, shiftₗ]
-  · simp only [LinearMap.sum_apply, sum_apply, one_pow, mul_one, LinearMap.mul_apply,
-      Module.End.natCast_apply, map_nsmul, Pi.smul_apply, LinearMap.pow_apply, coe_fwdDiffₗ]
+  · simp [Module.End.pow_apply, coe_fwdDiffₗ]
 
 end newton_formulae
 

--- a/Mathlib/Algebra/Lie/CartanExists.lean
+++ b/Mathlib/Algebra/Lie/CartanExists.lean
@@ -319,15 +319,15 @@ lemma engel_isBot_of_isMin (hLK : finrank K L ≤ #K) (U : LieSubalgebra K L)
     rw [← hn]
     clear hn
     induction n with
-    | zero => simp only [z', pow_zero, LinearMap.one_apply]
-    | succ n ih => rw [pow_succ', pow_succ', LinearMap.mul_apply, ih]; rfl
+    | zero => simp only [z', pow_zero, Module.End.one_apply]
+    | succ n ih => rw [pow_succ', pow_succ', Module.End.mul_apply, ih]; rfl
   classical
   -- Now let `n` be the smallest power such that `⁅v, _⁆ ^ n` kills `z'`.
   set n := Nat.find hz' with _hn
   have hn : (toEnd K U Q v ^ n) z' = 0 := Nat.find_spec hz'
   -- If `n = 0`, then we are done.
   obtain hn₀|⟨k, hk⟩ : n = 0 ∨ ∃ k, n = k + 1 := by cases n <;> simp
-  · simpa only [hn₀, pow_zero, LinearMap.one_apply] using hn
+  · simpa only [hn₀, pow_zero, Module.End.one_apply] using hn
   -- If `n = k + 1`, then we can write `⁅v, _⁆ ^ n = ⁅v, _⁆ ∘ ⁅v, _⁆ ^ k`.
   -- Recall that `constantCoeff ψ` is non-zero on `α`, and `v = α • u + x`.
   specialize hsψ α hα
@@ -341,7 +341,7 @@ lemma engel_isBot_of_isMin (hLK : finrank K L ≤ #K) (U : LieSubalgebra K L)
   refine ⟨?_, ?_⟩
   · -- And `⁅v, _⁆ ^ k` applied to `z'` is non-zero by definition of `n`.
     apply Nat.find_min hz'; omega
-  · rw [← hn, hk, pow_succ', LinearMap.mul_apply]
+  · rw [← hn, hk, pow_succ', Module.End.mul_apply]
 
 variable (K L)
 

--- a/Mathlib/Algebra/Lie/Derivation/Basic.lean
+++ b/Mathlib/Algebra/Lie/Derivation/Basic.lean
@@ -291,7 +291,7 @@ variable {R L : Type*} [CommRing R] [LieRing L] [LieAlgebra R L]
 instance instBracket : Bracket (LieDerivation R L L) (LieDerivation R L L) where
   bracket D1 D2 := LieDerivation.mk ⁅(D1 : Module.End R L), (D2 : Module.End R L)⁆ (fun a b => by
     simp only [Ring.lie_def, apply_lie_eq_add, coeFn_coe,
-      LinearMap.sub_apply, LinearMap.mul_apply, map_add, sub_lie, lie_sub, ← lie_skew b]
+      LinearMap.sub_apply, Module.End.mul_apply, map_add, sub_lie, lie_sub, ← lie_skew b]
     abel)
 
 variable {D1 D2 : LieDerivation R L L}
@@ -401,10 +401,10 @@ noncomputable def exp (h : IsNilpotent D.toLinearMap) :
     invFun x := IsNilpotent.exp (- D.toLinearMap) x
     left_inv x := by
       simp only [AddHom.toFun_eq_coe, LinearMap.coe_toAddHom, ← LinearMap.comp_apply,
-        ← LinearMap.mul_eq_comp, h.exp_neg_mul_exp_self, LinearMap.one_apply]
+        ← Module.End.mul_eq_comp, h.exp_neg_mul_exp_self, Module.End.one_apply]
     right_inv x := by
       simp only [AddHom.toFun_eq_coe, LinearMap.coe_toAddHom, ← LinearMap.comp_apply,
-        ← LinearMap.mul_eq_comp, h.exp_mul_exp_neg_self, LinearMap.one_apply] }
+        ← Module.End.mul_eq_comp, h.exp_mul_exp_neg_self, Module.End.one_apply] }
 
 lemma exp_apply (h : IsNilpotent D.toLinearMap) :
     exp D h = IsNilpotent.exp D.toLinearMap :=

--- a/Mathlib/Algebra/Lie/Engel.lean
+++ b/Mathlib/Algebra/Lie/Engel.lean
@@ -111,13 +111,13 @@ theorem lcs_le_lcs_of_is_nilpotent_span_sup_eq_top {n i j : ℕ}
   intro l
   induction l with
   | zero =>
-    simp only [add_zero, LieIdeal.lcs_succ, pow_zero, LinearMap.one_eq_id,
+    simp only [add_zero, LieIdeal.lcs_succ, pow_zero, Module.End.one_eq_id,
       Submodule.map_id]
     exact le_sup_of_le_left hIM
   | succ l ih =>
     simp only [LieIdeal.lcs_succ, i.add_succ l, lie_top_eq_of_span_sup_eq_top hxI, sup_le_iff]
     refine ⟨(Submodule.map_mono ih).trans ?_, le_sup_of_le_right ?_⟩
-    · rw [Submodule.map_sup, ← Submodule.map_comp, ← LinearMap.mul_eq_comp, ← pow_succ', ←
+    · rw [Submodule.map_sup, ← Submodule.map_comp, ← Module.End.mul_eq_comp, ← pow_succ', ←
         I.lcs_succ]
       exact sup_le_sup_left coe_map_toEnd_le _
     · refine le_trans (mono_lie_right I ?_) (mono_lie_right I hIM)

--- a/Mathlib/Algebra/Lie/EngelSubalgebra.lean
+++ b/Mathlib/Algebra/Lie/EngelSubalgebra.lean
@@ -57,7 +57,7 @@ def engel (x : L) : LieSubalgebra R L :=
       apply Finset.sum_eq_zero
       intro ij hij
       obtain (h|h) : m ≤ ij.1 ∨ n ≤ ij.2 := by rw [Finset.mem_antidiagonal] at hij; omega
-      all_goals simp [LinearMap.pow_map_zero_of_le h, hm, hn] }
+      all_goals simp [Module.End.pow_map_zero_of_le h, hm, hn] }
 
 lemma mem_engel_iff (x y : L) :
     y ∈ engel R x ↔ ∃ n : ℕ, ((ad R L x) ^ n) y = 0 :=
@@ -89,7 +89,7 @@ lemma normalizer_engel (x : L) : normalizer (engel R x) = engel R x := by
   rcases hy with ⟨n, hn⟩
   rw [mem_engel_iff]
   use n+1
-  rw [pow_succ, LinearMap.mul_apply]
+  rw [pow_succ, Module.End.mul_apply]
   exact hn
 
 variable {R}
@@ -128,14 +128,14 @@ lemma normalizer_eq_self_of_engel_le [IsArtinian R L]
     generalize k+1 = k
     induction k generalizing y with
     | zero =>
-      cases y; intro hy; simp only [pow_zero, LinearMap.one_apply]
+      cases y; intro hy; simp only [pow_zero, Module.End.one_apply]
       exact (AddSubmonoid.mk_eq_zero N.toAddSubmonoid).mp hy
-    | succ k ih => simp only [pow_succ, LinearMap.mem_ker, LinearMap.mul_apply] at ih ⊢; apply ih
+    | succ k ih => simp only [pow_succ, LinearMap.mem_ker, Module.End.mul_apply] at ih ⊢; apply ih
   · rw [← Submodule.map_le_iff_le_comap]
     apply le_sup_of_le_right
     rw [Submodule.map_le_iff_le_comap]
     rintro _ ⟨y, rfl⟩
-    simp only [pow_succ', LinearMap.mul_apply, Submodule.mem_comap, mem_toSubmodule]
+    simp only [pow_succ', Module.End.mul_apply, Submodule.mem_comap, mem_toSubmodule]
     apply aux₁
     simp only [Submodule.coe_subtype, SetLike.coe_mem]
 
@@ -151,7 +151,7 @@ lemma isNilpotent_of_forall_le_engel [IsNoetherian R L]
   case mono =>
     intro y hy
     rw [LinearMap.mem_ker] at hy ⊢
-    exact LinearMap.pow_map_zero_of_le hmn hy
+    exact Module.End.pow_map_zero_of_le hmn hy
   obtain ⟨n, hn⟩ := monotone_stabilizes_iff_noetherian.mpr inferInstance K
   use n
   ext y
@@ -160,7 +160,7 @@ lemma isNilpotent_of_forall_le_engel [IsNoetherian R L]
   rw [mem_engel_iff] at h
   obtain ⟨m, hm⟩ := h
   obtain (hmn|hmn) : m ≤ n ∨ n ≤ m := le_total m n
-  · exact LinearMap.pow_map_zero_of_le hmn hm
+  · exact Module.End.pow_map_zero_of_le hmn hm
   · have : ∀ k : ℕ, ((ad R L) x ^ k) y = 0 ↔ y ∈ K k := by simp [K, Subtype.ext_iff, coe_ad_pow]
     rwa [this, ← hn m hmn, ← this] at hm
 

--- a/Mathlib/Algebra/Lie/LieTheorem.lean
+++ b/Mathlib/Algebra/Lie/LieTheorem.lean
@@ -69,14 +69,14 @@ private lemma weightSpaceOfIsLieTower_aux (z : L) (v : V) (hv : v ∈ weightSpac
       forall_exists_index, and_imp, forall_apply_eq_imp_iff₂]
     induction n generalizing w
     · simp only [zero_add, Nat.lt_one_iff, LinearMap.sub_apply, LieModule.toEnd_apply_apply,
-        LinearMap.smul_apply, LinearMap.one_apply, forall_eq, pow_zero, hv w, sub_self, zero_mem]
+        LinearMap.smul_apply, Module.End.one_apply, forall_eq, pow_zero, hv w, sub_self, zero_mem]
     · next n hn =>
       intro m hm
       obtain (hm | rfl) : m < n + 1 ∨ m = n + 1 := by omega
       · exact U'.mono (Nat.le_succ n) (hn w m hm)
       have H : ∀ w, ⁅w, (π z ^ n) v⁆ = (T χ w) ((π z ^ n) v) + χ w • ((π z ^ n) v) := by simp
-      rw [T, LinearMap.sub_apply, pow_succ', LinearMap.mul_apply, LieModule.toEnd_apply_apply,
-        LieModule.toEnd_apply_apply, LinearMap.smul_apply, LinearMap.one_apply, leibniz_lie,
+      rw [T, LinearMap.sub_apply, pow_succ', Module.End.mul_apply, LieModule.toEnd_apply_apply,
+        LieModule.toEnd_apply_apply, LinearMap.smul_apply, Module.End.one_apply, leibniz_lie,
         lie_swap_lie w z, H, H, lie_add, lie_smul, add_sub_assoc, add_sub_assoc, sub_self, add_zero]
       refine add_mem (neg_mem <| add_mem ?_ ?_) ?_
       · exact U'.mono n.le_succ (hn _ n n.lt_succ_self)
@@ -109,7 +109,7 @@ private lemma weightSpaceOfIsLieTower_aux (z : L) (v : V) (hv : v ∈ weightSpac
       exact ⟨j, j.lt_succ_self, T_apply_succ w j⟩
     apply IsNilpotent.eq_zero
     apply LinearMap.isNilpotent_trace_of_isNilpotent
-    rw [Module.Finite.Module.End.isNilpotent_iff_of_finite]
+    rw [Module.End.isNilpotent_iff_of_finite]
     suffices ⨆ i, U' i ≤ Module.End.maxGenEigenspace (T χ w) 0 by
       intro x
       specialize this x.2
@@ -128,7 +128,7 @@ private lemma weightSpaceOfIsLieTower_aux (z : L) (v : V) (hv : v ∈ weightSpac
     obtain ⟨j, hj, hj'⟩ := key i hi
     obtain ⟨k, hk⟩ := ih j hj (hj' <| Submodule.mem_map_of_mem hx)
     use k+1
-    rw [pow_succ, LinearMap.mul_apply, hk]
+    rw [pow_succ, Module.End.mul_apply, hk]
   have trace_za : (toEnd R A _ ⁅z, a⁆).trace R U = χ ⁅z, a⁆ • (finrank R U) := by
     simpa [T, sub_eq_zero] using trace_T_U_zero ⁅z, a⁆
   suffices finrank R U ≠ 0 by simp_all
@@ -137,7 +137,7 @@ private lemma weightSpaceOfIsLieTower_aux (z : L) (v : V) (hv : v ∈ weightSpac
     apply Submodule.mem_iSup_of_mem 1
     apply Submodule.subset_span
     use 0, zero_lt_one
-    rw [pow_zero, LinearMap.one_apply]
+    rw [pow_zero, Module.End.one_apply]
   exact nontrivial_of_ne ⟨v, hvU⟩ 0 <| by simp [hv']
 
 variable (R V) in

--- a/Mathlib/Algebra/Lie/Nilpotent.lean
+++ b/Mathlib/Algebra/Lie/Nilpotent.lean
@@ -325,7 +325,7 @@ theorem exists_forall_pow_toEnd_eq_zero [IsNilpotent L M] :
   obtain ⟨k, hM⟩ := IsNilpotent.nilpotent R L M
   use k
   intro x; ext m
-  rw [LinearMap.pow_apply, LinearMap.zero_apply, ← @LieSubmodule.mem_bot R L M, ← hM]
+  rw [Module.End.pow_apply, LinearMap.zero_apply, ← @LieSubmodule.mem_bot R L M, ← hM]
   exact iterate_toEnd_mem_lowerCentralSeries R L M x m k
 
 theorem isNilpotent_toEnd_of_isNilpotent [IsNilpotent L M] (x : L) :
@@ -341,7 +341,7 @@ theorem isNilpotent_toEnd_of_isNilpotent₂ [IsNilpotent L M] (x y : L) :
     rw [eq_bot_iff, ← hM]; exact antitone_lowerCentralSeries R L M (by omega)
   use k
   ext m
-  rw [LinearMap.pow_apply, LinearMap.zero_apply, ← LieSubmodule.mem_bot (R := R) (L := L), ← hM]
+  rw [Module.End.pow_apply, LinearMap.zero_apply, ← LieSubmodule.mem_bot (R := R) (L := L), ← hM]
   exact iterate_toEnd_mem_lowerCentralSeries₂ R L M x y m k
 
 @[simp] lemma maxGenEigenSpace_toEnd_eq_top [IsNilpotent L M] (x : L) :
@@ -953,7 +953,7 @@ theorem _root_.LieSubalgebra.isNilpotent_ad_of_isNilpotent_ad {L : Type v} [LieR
     IsNilpotent (LieAlgebra.ad R K x) := by
   obtain ⟨n, hn⟩ := h
   use n
-  exact LinearMap.submodule_pow_eq_zero_of_pow_eq_zero (K.ad_comp_incl_eq x) hn
+  exact Module.End.submodule_pow_eq_zero_of_pow_eq_zero (K.ad_comp_incl_eq x) hn
 
 theorem _root_.LieAlgebra.isNilpotent_ad_of_isNilpotent {L : LieSubalgebra R A} {x : L}
     (h : IsNilpotent (x : A)) : IsNilpotent (LieAlgebra.ad R L x) :=

--- a/Mathlib/Algebra/Lie/OfAssociative.lean
+++ b/Mathlib/Algebra/Lie/OfAssociative.lean
@@ -249,7 +249,7 @@ lemma LieSubmodule.coe_toEnd_pow (N : LieSubmodule R L M) (x : L) (y : N) (n : �
     ((toEnd R L N x ^ n) y : M) = (toEnd R L M x ^ n) y := by
   induction n generalizing y with
   | zero => rfl
-  | succ n ih => simp only [pow_succ', LinearMap.mul_apply, ih, LieSubmodule.coe_toEnd]
+  | succ n ih => simp only [pow_succ', Module.End.mul_apply, ih, LieSubmodule.coe_toEnd]
 
 lemma LieSubalgebra.coe_ad (H : LieSubalgebra R L) (x y : H) :
     (ad R H x y : L) = ad R L x y := rfl
@@ -279,7 +279,7 @@ lemma LieModule.toEnd_pow_lie (x y : L) (z : M) (n : ℕ) :
   | succ n ih =>
     rw [Finset.sum_antidiagonal_choose_succ_nsmul
       (fun i j ↦ ⁅((ad R L x) ^ i) y, ((φ x) ^ j) z⁆) n]
-    simp only [pow_succ', LinearMap.mul_apply, ih, map_sum, map_nsmul,
+    simp only [pow_succ', Module.End.mul_apply, ih, map_sum, map_nsmul,
       toEnd_lie, nsmul_add, sum_add_distrib]
     rw [add_comm, add_left_cancel_iff, sum_congr rfl]
     rintro ⟨i, j⟩ hij
@@ -303,7 +303,7 @@ variable {M₂ : Type w₁} [AddCommGroup M₂] [Module R M₂] [LieRingModule L
 
 lemma toEnd_pow_comp_lieHom :
     (toEnd R L M₂ x ^ k) ∘ₗ f = f ∘ₗ toEnd R L M x ^ k := by
-  apply LinearMap.commute_pow_left_of_commute
+  apply Module.End.commute_pow_left_of_commute
   ext
   simp
 
@@ -340,7 +340,7 @@ theorem toEnd_restrict_eq_toEnd (h := N.toEnd_comp_subtype_mem x) :
 
 lemma mapsTo_pow_toEnd_sub_algebraMap {φ : R} {k : ℕ} {x : L} :
     MapsTo ((toEnd R L M x - algebraMap R (Module.End R M) φ) ^ k) N N := by
-  rw [LinearMap.coe_pow]
+  rw [Module.End.coe_pow]
   exact MapsTo.iterate (fun m hm ↦ N.sub_mem (N.lie_mem hm) (N.smul_mem _ hm)) k
 
 end LieSubmodule
@@ -381,7 +381,7 @@ def lieConj : Module.End R M₁ ≃ₗ⁅R⁆ Module.End R M₂ :=
   { e.conj with
     map_lie' := fun {f g} =>
       show e.conj ⁅f, g⁆ = ⁅e.conj f, e.conj g⁆ by
-        simp only [LieRing.of_associative_ring_bracket, LinearMap.mul_eq_comp, e.conj_comp,
+        simp only [LieRing.of_associative_ring_bracket, Module.End.mul_eq_comp, e.conj_comp,
           map_sub] }
 
 @[simp]

--- a/Mathlib/Algebra/Lie/Sl2.lean
+++ b/Mathlib/Algebra/Lie/Sl2.lean
@@ -112,7 +112,7 @@ lemma lie_h_pow_toEnd_f (n : ℕ) :
   induction n with
   | zero => simpa using P.lie_h
   | succ n ih =>
-    rw [pow_succ', LinearMap.mul_apply, toEnd_apply_apply, Nat.cast_add, Nat.cast_one,
+    rw [pow_succ', Module.End.mul_apply, toEnd_apply_apply, Nat.cast_add, Nat.cast_one,
       leibniz_lie h, t.lie_lie_smul_f R, ← neg_smul, ih, lie_smul, smul_lie, ← add_smul]
     congr
     ring
@@ -122,10 +122,10 @@ lemma lie_e_pow_succ_toEnd_f (n : ℕ) :
   induction n with
   | zero =>
       simp only [zero_add, pow_one, toEnd_apply_apply, Nat.cast_zero, sub_zero, one_mul,
-        pow_zero, LinearMap.one_apply, leibniz_lie e, t.lie_e_f, P.lie_e, P.lie_h, lie_zero,
+        pow_zero, Module.End.one_apply, leibniz_lie e, t.lie_e_f, P.lie_e, P.lie_h, lie_zero,
         add_zero]
   | succ n ih =>
-    rw [pow_succ', LinearMap.mul_apply, toEnd_apply_apply, leibniz_lie e, t.lie_e_f,
+    rw [pow_succ', Module.End.mul_apply, toEnd_apply_apply, leibniz_lie e, t.lie_e_f,
       lie_h_pow_toEnd_f P, ih, lie_smul, lie_f_pow_toEnd_f P, ← add_smul,
       Nat.cast_add, Nat.cast_one]
     congr

--- a/Mathlib/Algebra/Lie/TraceForm.lean
+++ b/Mathlib/Algebra/Lie/TraceForm.lean
@@ -70,11 +70,11 @@ lemma traceForm_apply_lie_apply (x y z : L) :
     _ = trace R _ (φ x * (φ y * φ z)) - trace R _ (φ y * (φ x * φ z)) := ?_
     _ = trace R _ (φ x * (φ y * φ z)) - trace R _ (φ x * (φ z * φ y)) := ?_
     _ = traceForm R L M x ⁅y, z⁆ := ?_
-  · simp only [LieHom.map_lie, Ring.lie_def, ← LinearMap.mul_eq_comp]
+  · simp only [LieHom.map_lie, Ring.lie_def, ← Module.End.mul_eq_comp]
   · simp only [sub_mul, mul_sub, map_sub, mul_assoc]
   · simp only [LinearMap.trace_mul_cycle' R (φ x) (φ z) (φ y)]
   · simp only [traceForm_apply_apply, LieHom.map_lie, Ring.lie_def, mul_sub, map_sub,
-      ← LinearMap.mul_eq_comp]
+      ← Module.End.mul_eq_comp]
 
 /-- Given a representation `M` of a Lie algebra `L`, the action of any `x : L` is skew-adjoint wrt
 the trace form. -/
@@ -172,8 +172,8 @@ lemma eq_zero_of_mem_genWeightSpace_mem_posFitting [LieRing.IsNilpotent L]
     intro m n
     replace hB : ∀ m, B m (φ x n) = (- 1 : R) • B (φ x m) n := by simp [hB]
     have : (-1 : R) ^ k • (-1 : R) = (-1 : R) ^ (k + 1) := by rw [pow_succ (-1 : R), smul_eq_mul]
-    conv_lhs => rw [pow_succ, LinearMap.mul_eq_comp, LinearMap.comp_apply, ih, hB,
-      ← (φ x).comp_apply, ← LinearMap.mul_eq_comp, ← pow_succ', ← smul_assoc, this]
+    conv_lhs => rw [pow_succ, Module.End.mul_eq_comp, LinearMap.comp_apply, ih, hB,
+      ← (φ x).comp_apply, ← Module.End.mul_eq_comp, ← pow_succ', ← smul_assoc, this]
   suffices ∀ (x : L) m, m ∈ posFittingCompOf R M x → B m₀ m = 0 by
     refine LieSubmodule.iSup_induction (motive := fun m ↦ (B m₀) m = 0) _ hm₁ this (map_zero _) ?_
     aesop

--- a/Mathlib/Algebra/Lie/Weights/Basic.lean
+++ b/Mathlib/Algebra/Lie/Weights/Basic.lean
@@ -89,8 +89,8 @@ protected theorem weight_vector_multiplication (M₁ M₂ M₃ : Type*)
   swap
   · rintro t₁ t₂ ⟨k₁, hk₁⟩ ⟨k₂, hk₂⟩; use max k₁ k₂
     simp only [LieModuleHom.map_add, LinearMap.map_add,
-      LinearMap.pow_map_zero_of_le (le_max_left k₁ k₂) hk₁,
-      LinearMap.pow_map_zero_of_le (le_max_right k₁ k₂) hk₂, add_zero]
+      Module.End.pow_map_zero_of_le (le_max_left k₁ k₂) hk₁,
+      Module.End.pow_map_zero_of_le (le_max_right k₁ k₂) hk₂, add_zero]
   -- Now the main argument: pure tensors.
   rintro ⟨m₁, hm₁⟩ ⟨m₂, hm₂⟩
   change ∃ k, (F ^ k) ((g : M₁ ⊗[R] M₂ →ₗ[R] M₃) (m₁ ⊗ₜ m₂)) = (0 : M₃)
@@ -101,7 +101,7 @@ protected theorem weight_vector_multiplication (M₁ M₂ M₃ : Type*)
     ext m₁ m₂
     simp only [f₁, f₂, F, ← g.map_lie x (m₁ ⊗ₜ m₂), add_smul, sub_tmul, tmul_sub, smul_tmul,
       lie_tmul_right, tmul_smul, toEnd_apply_apply, LieModuleHom.map_smul,
-      LinearMap.one_apply, LieModuleHom.coe_toLinearMap, LinearMap.smul_apply, Function.comp_apply,
+      Module.End.one_apply, LieModuleHom.coe_toLinearMap, LinearMap.smul_apply, Function.comp_apply,
       LinearMap.coe_comp, LinearMap.rTensor_tmul, LieModuleHom.map_add, LinearMap.add_apply,
       LieModuleHom.map_sub, LinearMap.sub_apply, LinearMap.lTensor_tmul,
       AlgebraTensorModule.curry_apply, TensorProduct.curry_apply, LinearMap.toFun_eq_coe,
@@ -110,7 +110,7 @@ protected theorem weight_vector_multiplication (M₁ M₂ M₃ : Type*)
   rsuffices ⟨k, hk⟩ : ∃ k : ℕ, ((f₁ + f₂) ^ k) (m₁ ⊗ₜ m₂) = 0
   · use k
     change (F ^ k) (g.toLinearMap (m₁ ⊗ₜ[R] m₂)) = 0
-    rw [← LinearMap.comp_apply, LinearMap.commute_pow_left_of_commute h_comm_square,
+    rw [← LinearMap.comp_apply, Module.End.commute_pow_left_of_commute h_comm_square,
       LinearMap.comp_apply, hk, LinearMap.map_zero]
   -- Unpack the information we have about `m₁`, `m₂`.
   simp only [Module.End.mem_maxGenEigenspace] at hm₁ hm₂
@@ -124,7 +124,7 @@ protected theorem weight_vector_multiplication (M₁ M₂ M₃ : Type*)
   use k₁ + k₂ - 1
   have hf_comm : Commute f₁ f₂ := by
     ext m₁ m₂
-    simp only [f₁, f₂, LinearMap.mul_apply, LinearMap.rTensor_tmul, LinearMap.lTensor_tmul,
+    simp only [f₁, f₂, Module.End.mul_apply, LinearMap.rTensor_tmul, LinearMap.lTensor_tmul,
       AlgebraTensorModule.curry_apply, LinearMap.toFun_eq_coe, LinearMap.lTensor_tmul,
       TensorProduct.curry_apply, LinearMap.coe_restrictScalars]
   rw [hf_comm.add_pow']
@@ -137,9 +137,9 @@ protected theorem weight_vector_multiplication (M₁ M₂ M₃ : Type*)
   suffices (f₁ ^ i * f₂ ^ j) (m₁ ⊗ₜ m₂) = 0 by rw [this]; apply smul_zero
   -- Finish off with appropriate case analysis.
   rcases Nat.le_or_le_of_add_eq_add_pred (Finset.mem_antidiagonal.mp hij) with hi | hj
-  · rw [(hf_comm.pow_pow i j).eq, LinearMap.mul_apply, LinearMap.pow_map_zero_of_le hi hf₁,
+  · rw [(hf_comm.pow_pow i j).eq, Module.End.mul_apply, Module.End.pow_map_zero_of_le hi hf₁,
       LinearMap.map_zero]
-  · rw [LinearMap.mul_apply, LinearMap.pow_map_zero_of_le hj hf₂, LinearMap.map_zero]
+  · rw [Module.End.mul_apply, Module.End.pow_map_zero_of_le hj hf₂, LinearMap.map_zero]
 
 lemma lie_mem_maxGenEigenspace_toEnd
     {χ₁ χ₂ : R} {x y : L} {m : M} (hy : y ∈ 𝕎(L, χ₁, x)) (hm : m ∈ 𝕎(M, χ₂, x)) :
@@ -344,7 +344,7 @@ lemma isNilpotent_toEnd_sub_algebraMap [IsNoetherian R M] (χ : L → R) (x : L)
   obtain ⟨k, hk⟩ := exists_genWeightSpace_le_ker_of_isNoetherian M χ x
   use k
   ext ⟨m, hm⟩
-  simp only [this, LinearMap.pow_restrict _, LinearMap.zero_apply, ZeroMemClass.coe_zero,
+  simp only [this, Module.End.pow_restrict _, LinearMap.zero_apply, ZeroMemClass.coe_zero,
     ZeroMemClass.coe_eq_zero]
   exact ZeroMemClass.coe_eq_zero.mp (hk hm)
 
@@ -371,7 +371,7 @@ lemma genWeightSpace_zero_normalizer_eq_self :
   intro y
   obtain ⟨k, hk⟩ := hm y y
   use k + 1
-  simpa [pow_succ, LinearMap.mul_eq_comp]
+  simpa [pow_succ, Module.End.mul_eq_comp]
 
 lemma iSup_ucs_le_genWeightSpace_zero :
     ⨆ k, (⊥ : LieSubmodule R L M).ucs k ≤ genWeightSpace M (0 : L → R) := by
@@ -414,9 +414,9 @@ def posFittingCompOf (x : L) : LieSubmodule R L M :=
       obtain ⟨q, hq⟩ := h₁.add_pow_dvd_pow_of_pow_eq_zero_right (N + k).le_succ hN
       use toModuleHom R L M (q (y ⊗ₜ m))
       change (φ ^ k).comp ((toModuleHom R L M : L ⊗[R] M →ₗ[R] M)) _ = _
-      simp [φ, f₁, f₂, LinearMap.commute_pow_left_of_commute h₂,
+      simp [φ, f₁, f₂, Module.End.commute_pow_left_of_commute h₂,
         LinearMap.comp_apply (g := (f₁ + f₂) ^ k), ← LinearMap.comp_apply (g := q),
-        ← LinearMap.mul_eq_comp, ← hq] }
+        ← Module.End.mul_eq_comp, ← hq] }
 
 variable {M} in
 lemma mem_posFittingCompOf (x : L) (m : M) :
@@ -433,7 +433,7 @@ lemma mem_posFittingCompOf (x : L) (m : M) :
   induction l with
   | zero => simp
   | succ l ih =>
-    simp only [lowerCentralSeries_succ, pow_succ', LinearMap.mul_apply]
+    simp only [lowerCentralSeries_succ, pow_succ', Module.End.mul_apply]
     exact LieSubmodule.lie_mem_lie (LieSubmodule.mem_top x) ih
 
 @[simp] lemma posFittingCompOf_eq_bot_of_isNilpotent
@@ -483,7 +483,7 @@ lemma posFittingComp_le_iInf_lowerCentralSeries :
   suffices (toEnd R L (M ⧸ F) x ^ k) (LieSubmodule.Quotient.mk (N := F) m) =
     LieSubmodule.Quotient.mk (N := F) ((toEnd R L M x ^ k) m)
       by simpa [Submodule.Quotient.quot_mk_eq_mk, this]
-  have := LinearMap.congr_fun (LinearMap.commute_pow_left_of_commute
+  have := LinearMap.congr_fun (Module.End.commute_pow_left_of_commute
     (LieSubmodule.Quotient.toEnd_comp_mk' F x) k) m
   simpa using this
 
@@ -519,7 +519,8 @@ lemma map_genWeightSpace_le :
   have : (toEnd R L M₂ x - χ x • ↑1) ∘ₗ f = f ∘ₗ (toEnd R L M x - χ x • ↑1) := by
     ext; simp
   obtain ⟨k, h⟩ := (mem_genWeightSpace _ _ _).mp hm x
-  exact ⟨k, by simpa [h] using LinearMap.congr_fun (LinearMap.commute_pow_left_of_commute this k) m⟩
+  refine ⟨k, ?_⟩
+  simpa [h] using LinearMap.congr_fun (Module.End.commute_pow_left_of_commute this k) m
 
 variable {f}
 
@@ -535,7 +536,7 @@ lemma comap_genWeightSpace_eq_of_injective (hf : Injective f) :
     use k
     suffices f (((toEnd R L M x - χ x • ↑1) ^ k) m) = 0 by
       rw [← f.map_zero] at this; exact hf this
-    simpa [hk] using (LinearMap.congr_fun (LinearMap.commute_pow_left_of_commute h k) m).symm
+    simpa [hk] using (LinearMap.congr_fun (Module.End.commute_pow_left_of_commute h k) m).symm
   · rw [← LieSubmodule.map_le_iff_le_comap]
     exact map_genWeightSpace_le f
 

--- a/Mathlib/Algebra/Lie/Weights/Cartan.lean
+++ b/Mathlib/Algebra/Lie/Weights/Cartan.lean
@@ -72,7 +72,7 @@ lemma toEnd_pow_apply_mem {χ₁ χ₂ : H → R} {x : L} {m : M}
   induction n with
   | zero => simpa using hm
   | succ n IH =>
-    simp only [pow_succ', LinearMap.mul_apply, toEnd_apply_apply,
+    simp only [pow_succ', Module.End.mul_apply, toEnd_apply_apply,
       Nat.cast_add, Nat.cast_one, rootSpace]
     convert lie_mem_genWeightSpace_of_mem_genWeightSpace hx IH using 2
     rw [succ_nsmul, ← add_assoc, add_comm (n • _)]
@@ -180,10 +180,10 @@ theorem toLieSubmodule_le_rootSpace_zero : H.toLieSubmodule ≤ rootSpace H 0 :=
       LinearMap.coe_comp]
     rfl
   change (g ^ k).comp (H : Submodule R L).subtype ⟨x, hx⟩ = 0
-  rw [LinearMap.commute_pow_left_of_commute hfg k]
+  rw [Module.End.commute_pow_left_of_commute hfg k]
   have h := iterate_toEnd_mem_lowerCentralSeries R H H y ⟨x, hx⟩ k
   rw [hk, LieSubmodule.mem_bot] at h
-  simp only [Submodule.subtype_apply, Function.comp_apply, LinearMap.pow_apply, LinearMap.coe_comp,
+  simp only [Submodule.subtype_apply, Function.comp_apply, Module.End.pow_apply, LinearMap.coe_comp,
     Submodule.coe_eq_zero]
   exact h
 
@@ -211,7 +211,7 @@ theorem zeroRootSubalgebra_normalizer_eq_self :
   obtain ⟨k, hk⟩ := hx ⟨y, hy⟩
   rw [← lie_skew, LinearMap.map_neg, neg_eq_zero] at hk
   use k + 1
-  rw [LinearMap.iterate_succ, LinearMap.coe_comp, Function.comp_apply, toEnd_apply_apply,
+  rw [Module.End.iterate_succ, LinearMap.coe_comp, Function.comp_apply, toEnd_apply_apply,
     LieSubalgebra.coe_bracket_of_module, Submodule.coe_mk, hk]
 
 /-- If the zero root subalgebra of a nilpotent Lie subalgebra `H` is just `H` then `H` is a Cartan

--- a/Mathlib/Algebra/Lie/Weights/Chain.lean
+++ b/Mathlib/Algebra/Lie/Weights/Chain.lean
@@ -389,7 +389,7 @@ variable {K : Type*} [Field K] [CharZero K] [LieAlgebra K L]
 lemma LieModule.isNilpotent_toEnd_of_mem_rootSpace
     {x : L} {χ : H → K} (hχ : χ ≠ 0) (hx : x ∈ rootSpace H χ) :
     _root_.IsNilpotent (toEnd K L M x) := by
-  refine Module.Finite.Module.End.isNilpotent_iff_of_finite.mpr fun m ↦ ?_
+  refine Module.End.isNilpotent_iff_of_finite.mpr fun m ↦ ?_
   have hm : m ∈ ⨆ χ : LieModule.Weight K H M, genWeightSpace M χ := by
     simp [iSup_genWeightSpace_eq_top' K H M]
   induction hm using LieSubmodule.iSup_induction' with
@@ -403,8 +403,8 @@ lemma LieModule.isNilpotent_toEnd_of_mem_rootSpace
     obtain ⟨n₁, hn₁⟩ := hm₁'
     obtain ⟨n₂, hn₂⟩ := hm₂'
     refine ⟨max n₁ n₂, ?_⟩
-    rw [map_add, LinearMap.pow_map_zero_of_le le_sup_left hn₁,
-      LinearMap.pow_map_zero_of_le le_sup_right hn₂, add_zero]
+    rw [map_add, Module.End.pow_map_zero_of_le le_sup_left hn₁,
+      Module.End.pow_map_zero_of_le le_sup_right hn₂, add_zero]
 
 lemma LieAlgebra.isNilpotent_ad_of_mem_rootSpace
     [IsTriangularizable K H L] [FiniteDimensional K L]

--- a/Mathlib/Algebra/Lie/Weights/Killing.lean
+++ b/Mathlib/Algebra/Lie/Weights/Killing.lean
@@ -153,7 +153,7 @@ lemma eq_zero_of_isNilpotent_ad_of_mem_isCartanSubalgebra {x : L} (hx : x ∈ H)
   ext y
   have comm : Commute (toEnd K H L ⟨x, hx⟩) (toEnd K H L y) := by
     rw [commute_iff_lie_eq, ← LieHom.map_lie, trivial_lie_zero, LieHom.map_zero]
-  rw [traceForm_apply_apply, ← LinearMap.mul_eq_comp, LinearMap.zero_apply]
+  rw [traceForm_apply_apply, ← Module.End.mul_eq_comp, LinearMap.zero_apply]
   exact (LinearMap.isNilpotent_trace_of_isNilpotent (comm.isNilpotent_mul_left hx')).eq_zero
 
 @[simp]

--- a/Mathlib/Algebra/Module/Equiv/Basic.lean
+++ b/Mathlib/Algebra/Module/Equiv/Basic.lean
@@ -58,13 +58,13 @@ theorem restrictScalars_inj (f g : M ≃ₗ[S] M₂) :
 
 end RestrictScalars
 
-theorem _root_.Module.End_isUnit_iff [Module R M] (f : Module.End R M) :
+theorem _root_.Module.End.isUnit_iff [Module R M] (f : Module.End R M) :
     IsUnit f ↔ Function.Bijective f :=
   ⟨fun h ↦
     Function.bijective_iff_has_inverse.mpr <|
       ⟨h.unit.inv,
-        ⟨Module.End_isUnit_inv_apply_apply_of_isUnit h,
-        Module.End_isUnit_apply_inv_apply_of_isUnit h⟩⟩,
+        ⟨Module.End.isUnit_inv_apply_apply_of_isUnit h,
+        Module.End.isUnit_apply_inv_apply_of_isUnit h⟩⟩,
     fun H ↦
     let e : M ≃ₗ[R] M := { f, Equiv.ofBijective f H with }
     ⟨⟨_, e.symm, LinearMap.ext e.right_inv, LinearMap.ext e.left_inv⟩, rfl⟩⟩
@@ -314,7 +314,7 @@ def ringLmapEquivSelf [Module S M] [SMulCommClass R S M] : (R →ₗ[R] M) ≃�
     invFun := smulRight (1 : R →ₗ[R] R)
     left_inv := fun f ↦ by
       ext
-      simp only [coe_smulRight, one_apply, smul_eq_mul, ← map_smul f, mul_one]
+      simp only [coe_smulRight, Module.End.one_apply, smul_eq_mul, ← map_smul f, mul_one]
     right_inv := fun x ↦ by simp }
 
 end LinearMap

--- a/Mathlib/Algebra/Module/Equiv/Basic.lean
+++ b/Mathlib/Algebra/Module/Equiv/Basic.lean
@@ -69,6 +69,9 @@ theorem _root_.Module.End.isUnit_iff [Module R M] (f : Module.End R M) :
     let e : M ≃ₗ[R] M := { f, Equiv.ofBijective f H with }
     ⟨⟨_, e.symm, LinearMap.ext e.right_inv, LinearMap.ext e.left_inv⟩, rfl⟩⟩
 
+@[deprecated (since := "2025-04-28")]
+alias _root_.Module.End_isUnit_iff := _root_.Module.End.isUnit_iff
+
 section Automorphisms
 
 variable [Module R M]

--- a/Mathlib/Algebra/Module/FinitePresentation.lean
+++ b/Mathlib/Algebra/Module/FinitePresentation.lean
@@ -463,8 +463,8 @@ lemma exists_bijective_map_powers [Module.Finite R M] [Module.FinitePresentation
       (map_dvd (algebraMap R Rₛ) (dvd_trans ⟨s₀ * s₁, by ring⟩ ht))
   let lₛ' := LocalizedModule.map (.powers t) l'
   have H_left : ((hu₀.unit⁻¹).1 • lₛ') ∘ₗ lₛ = LinearMap.id := by
-    apply ((Module.End_isUnit_iff _).mp (hu₂.map (algebraMap Rₛ (Module.End Rₛ _)))).1
-    apply ((Module.End_isUnit_iff _).mp (hu₀.map (algebraMap Rₛ (Module.End Rₛ _)))).1
+    apply ((Module.End.isUnit_iff _).mp (hu₂.map (algebraMap Rₛ (Module.End Rₛ _)))).1
+    apply ((Module.End.isUnit_iff _).mp (hu₀.map (algebraMap Rₛ (Module.End Rₛ _)))).1
     simp only [Module.algebraMap_end_apply, algebraMap_smul, LinearMap.map_smul_of_tower]
     rw [LinearMap.smul_comp, ← smul_assoc s₀.1, Algebra.smul_def s₀.1, IsUnit.mul_val_inv, one_smul]
     apply LinearMap.restrictScalars_injective R
@@ -474,8 +474,8 @@ lemma exists_bijective_map_powers [Module.Finite R M] [Module.FinitePresentation
     have : s₂.1 • l' (l x) = s₂.1 • s₀.1 • x := congr($hs₂ x)
     simp [lₛ, lₛ', LocalizedModule.smul'_mk, this]
   have H_right : lₛ ∘ₗ ((hu₀.unit⁻¹).1 • lₛ') = LinearMap.id := by
-    apply ((Module.End_isUnit_iff _).mp (hu₁.map (algebraMap Rₛ (Module.End Rₛ _)))).1
-    apply ((Module.End_isUnit_iff _).mp (hu₀.map (algebraMap Rₛ (Module.End Rₛ _)))).1
+    apply ((Module.End.isUnit_iff _).mp (hu₁.map (algebraMap Rₛ (Module.End Rₛ _)))).1
+    apply ((Module.End.isUnit_iff _).mp (hu₀.map (algebraMap Rₛ (Module.End Rₛ _)))).1
     simp only [Module.algebraMap_end_apply, algebraMap_smul, LinearMap.map_smul_of_tower]
     rw [LinearMap.comp_smul, ← smul_assoc s₀.1, Algebra.smul_def s₀.1, IsUnit.mul_val_inv, one_smul]
     apply LinearMap.restrictScalars_injective R
@@ -517,7 +517,7 @@ lemma Module.FinitePresentation.exists_lift_equiv_of_isLocalizedModule
       rw [← LinearMap.comp_apply, H]
       simp
     rw [this]
-    exact ((Module.End_isUnit_iff _).mp (IsLocalizedModule.map_units g s)).comp l.bijective
+    exact ((Module.End.isUnit_iff _).mp (IsLocalizedModule.map_units g s)).comp l.bijective
   obtain ⟨r, hr, hr'⟩ := exists_bijective_map_powers S f g _ this
   let rs : Submonoid R := (.powers <| r * s)
   let Rᵣₛ := Localization rs
@@ -525,33 +525,33 @@ lemma Module.FinitePresentation.exists_lift_equiv_of_isLocalizedModule
       (hu := IsLocalization.map_units (M := rs) Rᵣₛ ⟨_, Submonoid.mem_powers _⟩)
       (map_dvd (algebraMap R Rᵣₛ) ⟨r, mul_comm _ _⟩)
   have : Function.Bijective ((hsu.unit⁻¹).1 • LocalizedModule.map rs l') :=
-    ((Module.End_isUnit_iff _).mp ((hsu.unit⁻¹).isUnit.map (algebraMap _ (End Rᵣₛ
+    ((Module.End.isUnit_iff _).mp ((hsu.unit⁻¹).isUnit.map (algebraMap _ (End Rᵣₛ
       (LocalizedModule rs N))))).comp (hr' (r * s) (dvd_mul_right _ _))
   refine ⟨r * s, mul_mem hr s.2, LinearEquiv.ofBijective _ this, ?_⟩
   apply IsLocalizedModule.ext rs (LocalizedModule.mkLinearMap rs M) fun x ↦ map_units g
     ⟨x.1, SetLike.le_def.mp (Submonoid.powers_le.mpr (mul_mem hr s.2)) x.2⟩
   ext x
-  apply ((Module.End_isUnit_iff _).mp (IsLocalizedModule.map_units g s)).1
+  apply ((Module.End.isUnit_iff _).mp (IsLocalizedModule.map_units g s)).1
   have : ∀ x, g (l' x) = s.1 • (l (f x)) := LinearMap.congr_fun H
   simp only [rs, LinearMap.coe_comp, LinearMap.coe_restrictScalars, LinearEquiv.coe_coe,
     Function.comp_apply, LocalizedModule.mkLinearMap_apply, LinearEquiv.ofBijective_apply,
     LinearMap.smul_apply, LocalizedModule.map_mk, algebraMap_end_apply]
   rw [← map_smul, ← smul_assoc, Algebra.smul_def s.1, hsu.mul_val_inv, one_smul]
   simp only [LocalizedModule.lift_mk, OneMemClass.coe_one, map_one, IsUnit.unit_one,
-    inv_one, Units.val_one, LinearMap.one_apply, this]
+    inv_one, Units.val_one, Module.End.one_apply, this]
 
 instance Module.FinitePresentation.isLocalizedModule_map [Module.FinitePresentation R M] :
     IsLocalizedModule S (IsLocalizedModule.map S f g) := by
   constructor
   · intro s
-    rw [Module.End_isUnit_iff]
-    have := (Module.End_isUnit_iff _).mp (IsLocalizedModule.map_units (S := S) (f := g) s)
+    rw [Module.End.isUnit_iff]
+    have := (Module.End.isUnit_iff _).mp (IsLocalizedModule.map_units (S := S) (f := g) s)
     constructor
     · exact fun _ _ e ↦ LinearMap.ext fun m ↦ this.left (LinearMap.congr_fun e m)
     · intro h
       use ((IsLocalizedModule.map_units (S := S) (f := g) s).unit⁻¹).1 ∘ₗ h
       ext x
-      exact Module.End_isUnit_apply_inv_apply_of_isUnit
+      exact Module.End.isUnit_apply_inv_apply_of_isUnit
         (IsLocalizedModule.map_units (S := S) (f := g) s) (h x)
   · intro h
     obtain ⟨h', s, e⟩ := Module.FinitePresentation.exists_lift_of_isLocalizedModule S g (h ∘ₗ f)

--- a/Mathlib/Algebra/Module/LinearMap/End.lean
+++ b/Mathlib/Algebra/Module/LinearMap/End.lean
@@ -116,9 +116,15 @@ theorem isUnit_apply_inv_apply_of_isUnit {f : End R M} (h : IsUnit f) (x : M) :
     f (h.unit.inv x) = x :=
   show (f * h.unit.inv) x = x by simp
 
+@[deprecated (since := "2025-04-28")]
+alias _root_.Module.End_isUnit_apply_inv_apply_of_isUnit := isUnit_apply_inv_apply_of_isUnit
+
 theorem isUnit_inv_apply_apply_of_isUnit {f : End R M} (h : IsUnit f) (x : M) :
     h.unit.inv (f x) = x :=
   (by simp : (h.unit.inv * f) x = x)
+
+@[deprecated (since := "2025-04-28")]
+alias _root_.Module.End_isUnit_inv_apply_apply_of_isUnit := isUnit_inv_apply_apply_of_isUnit
 
 theorem coe_pow (f : End R M) (n : ℕ) : ⇑(f ^ n) = f^[n] := hom_coe_pow _ rfl (fun _ _ ↦ rfl) _ _
 

--- a/Mathlib/Algebra/Module/LinearMap/End.lean
+++ b/Mathlib/Algebra/Module/LinearMap/End.lean
@@ -16,9 +16,8 @@ including the action of `Module.End` on the module we are considering endomorphi
 
 ## Main results
 
-* `Module.End.semiring` and `Module.End.ring`: the (semi)ring of endomorphisms formed by taking the
-  additive structure above with composition as multiplication.
-
+* `Module.End.instSemiring` and `Module.End.instRing`: the (semi)ring of endomorphisms formed by
+  taking the additive structure above with composition as multiplication.
 -/
 
 universe u v
@@ -30,15 +29,13 @@ abbrev Module.End (R : Type u) (M : Type v) [Semiring R] [AddCommMonoid M] [Modu
 
 variable {R R₂ S M M₁ M₂ M₃ N₁ : Type*}
 
-namespace LinearMap
-
-open Function
+open Function LinearMap
 
 /-!
 ## Monoid structure of endomorphisms
 -/
 
-section Endomorphisms
+namespace Module.End
 
 variable [Semiring R] [AddCommMonoid M] [AddCommGroup N₁] [Module R M] [Module R N₁]
 
@@ -46,7 +43,7 @@ instance : One (Module.End R M) := ⟨LinearMap.id⟩
 
 instance : Mul (Module.End R M) := ⟨fun f g => LinearMap.comp f g⟩
 
-theorem one_eq_id : (1 : Module.End R M) = id := rfl
+theorem one_eq_id : (1 : Module.End R M) = .id := rfl
 
 theorem mul_eq_comp (f g : Module.End R M) : f * g = f.comp g := rfl
 
@@ -60,77 +57,74 @@ theorem coe_one : ⇑(1 : Module.End R M) = _root_.id := rfl
 
 theorem coe_mul (f g : Module.End R M) : ⇑(f * g) = f ∘ g := rfl
 
-instance _root_.Module.End.instNontrivial [Nontrivial M] : Nontrivial (Module.End R M) := by
+instance instNontrivial [Nontrivial M] : Nontrivial (Module.End R M) := by
   obtain ⟨m, ne⟩ := exists_ne (0 : M)
   exact nontrivial_of_ne 1 0 fun p => ne (LinearMap.congr_fun p m)
 
-instance _root_.Module.End.monoid : Monoid (Module.End R M) where
-  mul := (· * ·)
-  one := (1 : M →ₗ[R] M)
+instance instMonoid : Monoid (Module.End R M) where
   mul_assoc _ _ _ := LinearMap.ext fun _ ↦ rfl
   mul_one := comp_id
   one_mul := id_comp
 
-instance _root_.Module.End.semiring : Semiring (Module.End R M) :=
-  { AddMonoidWithOne.unary, Module.End.monoid, LinearMap.addCommMonoid with
-    mul_zero := comp_zero
-    zero_mul := zero_comp
-    left_distrib := fun _ _ _ ↦ comp_add _ _ _
-    right_distrib := fun _ _ _ ↦ add_comp _ _ _
-    natCast := fun n ↦ n • (1 : M →ₗ[R] M)
-    natCast_zero := zero_smul ℕ (1 : M →ₗ[R] M)
-    natCast_succ := fun n ↦ AddMonoid.nsmul_succ n (1 : M →ₗ[R] M) }
+instance instSemiring : Semiring (Module.End R M) where
+  __ := AddMonoidWithOne.unary
+  __ := instMonoid
+  __ := addCommMonoid
+  mul_zero := comp_zero
+  zero_mul := zero_comp
+  left_distrib := fun _ _ _ ↦ comp_add _ _ _
+  right_distrib := fun _ _ _ ↦ add_comp _ _ _
+  natCast := fun n ↦ n • (1 : M →ₗ[R] M)
+  natCast_zero := zero_smul ℕ (1 : M →ₗ[R] M)
+  natCast_succ := fun n ↦ AddMonoid.nsmul_succ n (1 : M →ₗ[R] M)
 
 /-- See also `Module.End.natCast_def`. -/
 @[simp]
-theorem _root_.Module.End.natCast_apply (n : ℕ) (m : M) : (↑n : Module.End R M) m = n • m := rfl
+theorem natCast_apply (n : ℕ) (m : M) : (↑n : Module.End R M) m = n • m := rfl
 
 @[simp]
-theorem _root_.Module.End.ofNat_apply (n : ℕ) [n.AtLeastTwo] (m : M) :
+theorem ofNat_apply (n : ℕ) [n.AtLeastTwo] (m : M) :
     (ofNat(n) : Module.End R M) m = ofNat(n) • m := rfl
 
-instance _root_.Module.End.ring : Ring (Module.End R N₁) :=
-  { Module.End.semiring, LinearMap.addCommGroup with
-    intCast := fun z ↦ z • (1 : N₁ →ₗ[R] N₁)
-    intCast_ofNat := natCast_zsmul _
-    intCast_negSucc := negSucc_zsmul _ }
+instance instRing : Ring (Module.End R N₁) where
+  intCast z := z • (1 : N₁ →ₗ[R] N₁)
+  intCast_ofNat := natCast_zsmul _
+  intCast_negSucc := negSucc_zsmul _
 
 /-- See also `Module.End.intCast_def`. -/
 @[simp]
-theorem _root_.Module.End.intCast_apply (z : ℤ) (m : N₁) : (z : Module.End R N₁) m = z • m :=
+theorem intCast_apply (z : ℤ) (m : N₁) : (z : Module.End R N₁) m = z • m :=
   rfl
 
 section
 
 variable [Monoid S] [DistribMulAction S M] [SMulCommClass R S M]
 
-instance _root_.Module.End.isScalarTower :
+instance instIsScalarTower :
     IsScalarTower S (Module.End R M) (Module.End R M) :=
   ⟨smul_comp⟩
 
-instance _root_.Module.End.smulCommClass [SMul S R] [IsScalarTower S R M] :
+instance instSMulCommClass [SMul S R] [IsScalarTower S R M] :
     SMulCommClass S (Module.End R M) (Module.End R M) :=
   ⟨fun s _ _ ↦ (comp_smul _ s _).symm⟩
 
-instance _root_.Module.End.smulCommClass' [SMul S R] [IsScalarTower S R M] :
+instance instSMulCommClass' [SMul S R] [IsScalarTower S R M] :
     SMulCommClass (Module.End R M) S (Module.End R M) :=
   SMulCommClass.symm _ _ _
 
-theorem _root_.Module.End_isUnit_apply_inv_apply_of_isUnit
-    {f : Module.End R M} (h : IsUnit f) (x : M) :
+theorem isUnit_apply_inv_apply_of_isUnit {f : End R M} (h : IsUnit f) (x : M) :
     f (h.unit.inv x) = x :=
   show (f * h.unit.inv) x = x by simp
 
-theorem _root_.Module.End_isUnit_inv_apply_apply_of_isUnit
-    {f : Module.End R M} (h : IsUnit f) (x : M) :
+theorem isUnit_inv_apply_apply_of_isUnit {f : End R M} (h : IsUnit f) (x : M) :
     h.unit.inv (f x) = x :=
   (by simp : (h.unit.inv * f) x = x)
 
-theorem coe_pow (f : M →ₗ[R] M) (n : ℕ) : ⇑(f ^ n) = f^[n] := hom_coe_pow _ rfl (fun _ _ ↦ rfl) _ _
+theorem coe_pow (f : End R M) (n : ℕ) : ⇑(f ^ n) = f^[n] := hom_coe_pow _ rfl (fun _ _ ↦ rfl) _ _
 
-theorem pow_apply (f : M →ₗ[R] M) (n : ℕ) (m : M) : (f ^ n) m = f^[n] m := congr_fun (coe_pow f n) m
+theorem pow_apply (f : End R M) (n : ℕ) (m : M) : (f ^ n) m = f^[n] m := congr_fun (coe_pow f n) m
 
-theorem pow_map_zero_of_le {f : Module.End R M} {m : M} {k l : ℕ} (hk : k ≤ l)
+theorem pow_map_zero_of_le {f : End R M} {m : M} {k l : ℕ} (hk : k ≤ l)
     (hm : (f ^ k) m = 0) : (f ^ l) m = 0 := by
   rw [← Nat.sub_add_cancel hk, pow_add, mul_apply, hm, map_zero]
 
@@ -139,17 +133,17 @@ theorem commute_pow_left_of_commute
     {f : M →ₛₗ[σ₁₂] M₂} {g : Module.End R M} {g₂ : Module.End R₂ M₂}
     (h : g₂.comp f = f.comp g) (k : ℕ) : (g₂ ^ k).comp f = f.comp (g ^ k) := by
   induction k with
-  | zero => simp only [pow_zero, one_eq_id, id_comp, comp_id]
-  | succ k ih => rw [pow_succ', pow_succ', LinearMap.mul_eq_comp, LinearMap.comp_assoc, ih,
-    ← LinearMap.comp_assoc, h, LinearMap.comp_assoc, LinearMap.mul_eq_comp]
+  | zero => simp [one_eq_id]
+  | succ k ih => rw [pow_succ', pow_succ', mul_eq_comp, LinearMap.comp_assoc, ih,
+    ← LinearMap.comp_assoc, h, LinearMap.comp_assoc, mul_eq_comp]
 
 @[simp]
-theorem id_pow (n : ℕ) : (id : M →ₗ[R] M) ^ n = id :=
+theorem id_pow (n : ℕ) : (id : End R M) ^ n = .id :=
   one_pow n
 
-variable {f' : M →ₗ[R] M}
+variable {f' : End R M}
 
-theorem iterate_succ (n : ℕ) : f' ^ (n + 1) = comp (f' ^ n) f' := by rw [pow_succ, mul_eq_comp]
+theorem iterate_succ (n : ℕ) : f' ^ (n + 1) = .comp (f' ^ n) f' := by rw [pow_succ, mul_eq_comp]
 
 theorem iterate_surjective (h : Surjective f') : ∀ n : ℕ, Surjective (f' ^ n)
   | 0 => surjective_id
@@ -216,9 +210,7 @@ instance apply_isScalarTower [Monoid S] [DistribMulAction S M] [SMulCommClass R 
     IsScalarTower S (Module.End R M) M :=
   ⟨fun _ _ _ ↦ rfl⟩
 
-end Endomorphisms
-
-end LinearMap
+end Module.End
 
 /-! ## Actions as module endomorphisms -/
 

--- a/Mathlib/Algebra/Module/LocalizedModule/Basic.lean
+++ b/Mathlib/Algebra/Module/LocalizedModule/Basic.lean
@@ -552,7 +552,7 @@ lemma IsLocalizedModule.eq_iff_exists [IsLocalizedModule S f] {x₁ x₂} :
   Iff.intro exists_of_eq fun ⟨c, h⟩ ↦ by
     apply_fun f at h
     simp_rw [f.map_smul_of_tower, Submonoid.smul_def, ← Module.algebraMap_end_apply R R] at h
-    exact ((Module.End_isUnit_iff _).mp <| map_units f c).1 h
+    exact ((Module.End.isUnit_iff _).mp <| map_units f c).1 h
 
 lemma IsLocalizedModule.injective_iff_isRegular [IsLocalizedModule S f] :
     Function.Injective f ↔ ∀ c : S, IsSMulRegular M c := by
@@ -562,9 +562,9 @@ instance IsLocalizedModule.of_linearEquiv (e : M' ≃ₗ[R] M'') [hf : IsLocaliz
     IsLocalizedModule S (e ∘ₗ f : M →ₗ[R] M'') where
   map_units s := by
     rw [show algebraMap R (Module.End R M'') s = e ∘ₗ (algebraMap R (Module.End R M') s) ∘ₗ e.symm
-      by ext; simp, Module.End_isUnit_iff, LinearMap.coe_comp, LinearMap.coe_comp,
+      by ext; simp, Module.End.isUnit_iff, LinearMap.coe_comp, LinearMap.coe_comp,
       LinearEquiv.coe_coe, LinearEquiv.coe_coe, EquivLike.comp_bijective, EquivLike.bijective_comp]
-    exact (Module.End_isUnit_iff _).mp <| hf.map_units s
+    exact (Module.End.isUnit_iff _).mp <| hf.map_units s
   surj' x := by
     obtain ⟨p, h⟩ := hf.surj' (e.symm x)
     exact ⟨p, by rw [LinearMap.coe_comp, LinearEquiv.coe_coe, Function.comp_apply, ← e.congr_arg h,
@@ -606,16 +606,16 @@ noncomputable def lift' (g : M →ₗ[R] M'')
   m.liftOn (fun p => (h p.2).unit⁻¹.val <| g p.1) fun ⟨m, s⟩ ⟨m', s'⟩ ⟨c, eq1⟩ => by
     dsimp only
     simp only [Submonoid.smul_def] at eq1
-    rw [Module.End_algebraMap_isUnit_inv_apply_eq_iff, ← map_smul, eq_comm,
-      Module.End_algebraMap_isUnit_inv_apply_eq_iff]
+    rw [Module.End.algebraMap_isUnit_inv_apply_eq_iff, ← map_smul, eq_comm,
+      Module.End.algebraMap_isUnit_inv_apply_eq_iff]
     have : c • s • g m' = c • s' • g m := by
       simp only [Submonoid.smul_def, ← g.map_smul, eq1]
-    have : Function.Injective (h c).unit.inv := ((Module.End_isUnit_iff _).1 (by simp)).1
+    have : Function.Injective (h c).unit.inv := ((Module.End.isUnit_iff _).1 (by simp)).1
     apply_fun (h c).unit.inv
-    rw [Units.inv_eq_val_inv, Module.End_algebraMap_isUnit_inv_apply_eq_iff, ←
+    rw [Units.inv_eq_val_inv, Module.End.algebraMap_isUnit_inv_apply_eq_iff, ←
       (h c).unit⁻¹.val.map_smul]
     symm
-    rw [Module.End_algebraMap_isUnit_inv_apply_eq_iff, ← g.map_smul, ← g.map_smul, ← g.map_smul, ←
+    rw [Module.End.algebraMap_isUnit_inv_apply_eq_iff, ← g.map_smul, ← g.map_smul, ← g.map_smul, ←
       g.map_smul, eq1]
 
 theorem lift'_mk (g : M →ₗ[R] M'') (h : ∀ x : S, IsUnit ((algebraMap R (Module.End R M'')) x))
@@ -631,14 +631,14 @@ theorem lift'_add (g : M →ₗ[R] M'') (h : ∀ x : S, IsUnit ((algebraMap R (M
     (by
       intro a a' b b'
       rw [mk_add_mk, LocalizedModule.lift'_mk, LocalizedModule.lift'_mk, LocalizedModule.lift'_mk]
-      rw [map_add, Module.End_algebraMap_isUnit_inv_apply_eq_iff, smul_add, ← map_smul,
+      rw [map_add, Module.End.algebraMap_isUnit_inv_apply_eq_iff, smul_add, ← map_smul,
         ← map_smul, ← map_smul]
       congr 1 <;> symm
-      · rw [Module.End_algebraMap_isUnit_inv_apply_eq_iff]
+      · rw [Module.End.algebraMap_isUnit_inv_apply_eq_iff]
         simp only [Submonoid.coe_mul, LinearMap.map_smul_of_tower]
         rw [mul_smul, Submonoid.smul_def]
       · dsimp
-        rw [Module.End_algebraMap_isUnit_inv_apply_eq_iff, mul_comm, mul_smul, ← map_smul]
+        rw [Module.End.algebraMap_isUnit_inv_apply_eq_iff, mul_comm, mul_smul, ← map_smul]
         rfl)
     x y
 
@@ -692,7 +692,7 @@ theorem lift_unique (g : M →ₗ[R] M'') (h : ∀ x : S, IsUnit ((algebraMap R 
     LocalizedModule.lift S g h = l := by
   ext x; induction' x with m s
   rw [LocalizedModule.lift_mk]
-  rw [Module.End_algebraMap_isUnit_inv_apply_eq_iff, ← hl, LinearMap.coe_comp,
+  rw [Module.End.algebraMap_isUnit_inv_apply_eq_iff, ← hl, LinearMap.coe_comp,
     Function.comp_apply, LocalizedModule.mkLinearMap_apply, ← l.map_smul, LocalizedModule.smul'_mk]
   congr 1; rw [LocalizedModule.mk_eq]
   refine ⟨1, ?_⟩; simp only [one_smul, Submonoid.smul_def]
@@ -724,7 +724,7 @@ lemma IsLocalizedModule.of_restrictScalars (S : Submonoid R)
   map_units x := by
     obtain ⟨_, x, hx, rfl⟩ := x
     have := IsLocalizedModule.map_units (f.restrictScalars R) ⟨x, hx⟩
-    simp only [← IsScalarTower.algebraMap_apply, Module.End_isUnit_iff] at this ⊢
+    simp only [← IsScalarTower.algebraMap_apply, Module.End.isUnit_iff] at this ⊢
     exact this
   surj' y := by
     obtain ⟨⟨x, t⟩, e⟩ := IsLocalizedModule.surj S (f.restrictScalars R) y
@@ -761,8 +761,8 @@ noncomputable def fromLocalizedModule' : LocalizedModule S M → M' := fun p =>
     (by
       rintro ⟨a, b⟩ ⟨a', b'⟩ ⟨c, eq1⟩
       dsimp
-      rw [Module.End_algebraMap_isUnit_inv_apply_eq_iff, ← map_smul, ← map_smul,
-        Module.End_algebraMap_isUnit_inv_apply_eq_iff', ← map_smul]
+      rw [Module.End.algebraMap_isUnit_inv_apply_eq_iff, ← map_smul, ← map_smul,
+        Module.End.algebraMap_isUnit_inv_apply_eq_iff', ← map_smul]
       exact (IsLocalizedModule.eq_iff_exists S f).mpr ⟨c, eq1.symm⟩)
 
 @[simp]
@@ -777,10 +777,10 @@ theorem fromLocalizedModule'_add (x y : LocalizedModule S M) :
     (by
       intro a a' b b'
       simp only [LocalizedModule.mk_add_mk, fromLocalizedModule'_mk]
-      rw [Module.End_algebraMap_isUnit_inv_apply_eq_iff, smul_add, ← map_smul, ← map_smul,
+      rw [Module.End.algebraMap_isUnit_inv_apply_eq_iff, smul_add, ← map_smul, ← map_smul,
         ← map_smul, map_add]
       congr 1
-      all_goals rw [Module.End_algebraMap_isUnit_inv_apply_eq_iff']
+      all_goals rw [Module.End.algebraMap_isUnit_inv_apply_eq_iff']
       · simp [mul_smul, Submonoid.smul_def]
       · rw [Submonoid.coe_mul, LinearMap.map_smul_of_tower, mul_comm, mul_smul, Submonoid.smul_def])
     x y
@@ -811,15 +811,15 @@ theorem fromLocalizedModule.inj : Function.Injective <| fromLocalizedModule S f 
   induction' x with a b
   induction' y with a' b'
   simp only [fromLocalizedModule_mk] at eq1
-  rw [Module.End_algebraMap_isUnit_inv_apply_eq_iff, ← LinearMap.map_smul,
-    Module.End_algebraMap_isUnit_inv_apply_eq_iff'] at eq1
+  rw [Module.End.algebraMap_isUnit_inv_apply_eq_iff, ← LinearMap.map_smul,
+    Module.End.algebraMap_isUnit_inv_apply_eq_iff'] at eq1
   rw [LocalizedModule.mk_eq, ← IsLocalizedModule.eq_iff_exists S f, Submonoid.smul_def,
     Submonoid.smul_def, f.map_smul, f.map_smul, eq1]
 
 theorem fromLocalizedModule.surj : Function.Surjective <| fromLocalizedModule S f := fun x =>
   let ⟨⟨m, s⟩, eq1⟩ := IsLocalizedModule.surj S f x
   ⟨LocalizedModule.mk m s, by
-    rw [fromLocalizedModule_mk, Module.End_algebraMap_isUnit_inv_apply_eq_iff, ← eq1,
+    rw [fromLocalizedModule_mk, Module.End.algebraMap_isUnit_inv_apply_eq_iff, ← eq1,
       Submonoid.smul_def]⟩
 
 theorem fromLocalizedModule.bij : Function.Bijective <| fromLocalizedModule S f :=
@@ -847,7 +847,7 @@ theorem iso_symm_apply_aux (m : M') :
         (IsLocalizedModule.surj S f m).choose.2 := by
   apply_fun iso S f using LinearEquiv.injective (iso S f)
   rw [LinearEquiv.apply_symm_apply]
-  simp [iso, fromLocalizedModule, Module.End_algebraMap_isUnit_inv_apply_eq_iff',
+  simp [iso, fromLocalizedModule, Module.End.algebraMap_isUnit_inv_apply_eq_iff',
     ← Submonoid.smul_def, (surj' _).choose_spec]
 
 theorem iso_symm_apply' (m : M') (a : M) (b : S) (eq1 : b • m = f a) :
@@ -958,7 +958,7 @@ variable {S}
 
 include f in
 theorem smul_injective (s : S) : Function.Injective fun m : M' => s • m :=
-  ((Module.End_isUnit_iff _).mp (IsLocalizedModule.map_units f s)).injective
+  ((Module.End.isUnit_iff _).mp (IsLocalizedModule.map_units f s)).injective
 
 include f in
 theorem smul_inj (s : S) (m₁ m₂ : M') : s • m₁ = s • m₂ ↔ m₁ = m₂ :=
@@ -992,14 +992,14 @@ variable (S) in
 @[simp]
 theorem mk'_one (m : M) : mk' f m (1 : S) = f m := by
   delta mk'
-  rw [fromLocalizedModule_mk, Module.End_algebraMap_isUnit_inv_apply_eq_iff, Submonoid.coe_one,
+  rw [fromLocalizedModule_mk, Module.End.algebraMap_isUnit_inv_apply_eq_iff, Submonoid.coe_one,
     one_smul]
 
 @[simp]
 theorem mk'_cancel (m : M) (s : S) : mk' f (s • m) s = f m := by
   delta mk'
   rw [LocalizedModule.mk_cancel, ← mk'_one S f, fromLocalizedModule_mk,
-    Module.End_algebraMap_isUnit_inv_apply_eq_iff, OneMemClass.coe_one, mk'_one, one_smul]
+    Module.End.algebraMap_isUnit_inv_apply_eq_iff, OneMemClass.coe_one, mk'_one, one_smul]
 
 @[simp]
 theorem mk'_cancel' (m : M) (s : S) : s • mk' f m s = f m := by
@@ -1045,7 +1045,7 @@ theorem mk'_mul_mk'_of_map_mul {M M' : Type*} [NonUnitalNonAssocSemiring M] [Sem
     [IsLocalizedModule S f] (m₁ m₂ : M) (s₁ s₂ : S) :
     mk' f m₁ s₁ * mk' f m₂ s₂ = mk' f (m₁ * m₂) (s₁ * s₂) := by
   symm
-  apply (Module.End_algebraMap_isUnit_inv_apply_eq_iff _ _ _ _).mpr
+  apply (Module.End.algebraMap_isUnit_inv_apply_eq_iff _ _ _ _).mpr
   simp_rw [Submonoid.coe_mul, ← smul_eq_mul]
   rw [smul_smul_smul_comm, ← mk'_smul, ← mk'_smul]
   simp_rw [← Submonoid.smul_def, mk'_cancel, smul_eq_mul, hf]
@@ -1116,7 +1116,7 @@ lemma liftOfLE_comp : (liftOfLE S₁ S₂ h f₁ f₂).comp f₁ = f₂ := lift_
 @[simp]
 lemma liftOfLE_mk' (m : M) (s : S₁) :
     liftOfLE S₁ S₂ h f₁ f₂ (mk' f₁ m s) = mk' f₂ m ⟨s.1, h s.2⟩ := by
-  apply ((Module.End_isUnit_iff _).mp (map_units f₂ ⟨s, h s.2⟩)).1
+  apply ((Module.End.isUnit_iff _).mp (map_units f₂ ⟨s, h s.2⟩)).1
   simp only [Module.algebraMap_end_apply, ← map_smul, ← Submonoid.smul_def, mk'_cancel']
   rw [liftOfLE, lift_apply]
   exact (mk'_cancel' (S := S₂) f₂ m ⟨s.1, h s.2⟩).symm
@@ -1241,7 +1241,7 @@ lemma map_LocalizedModules (g : M₀ →ₗ[R] M₁) (m : M₀) (s : S) :
 lemma map_iso_commute (g : M₀ →ₗ[R] M₁) : (map S f₀ f₁) g ∘ₗ (iso S f₀) =
     (iso S f₁) ∘ₗ (map S (mkLinearMap S M₀) (mkLinearMap S M₁)) g := by
   ext x
-  refine induction_on (fun m s ↦ ((Module.End_isUnit_iff _).1 (map_units f₁ s)).1 ?_) x
+  refine induction_on (fun m s ↦ ((Module.End.isUnit_iff _).1 (map_units f₁ s)).1 ?_) x
   repeat rw [Module.algebraMap_end_apply, ← CompatibleSMul.map_smul, smul'_mk, ← mk_smul, mk_cancel]
   simp -- Can't be combined with next simp. This uses map_apply, which would be preempted by map.
   simp [map, lift, iso_localizedModule_eq_refl, lift_mk]
@@ -1277,7 +1277,7 @@ theorem mkOfAlgebra {R S S' : Type*} [CommSemiring R] [Ring S] [Ring S'] [Algebr
         simpa [Submonoid.smul_def] using f.congr_arg e
   constructor
   · intro x
-    rw [Module.End_isUnit_iff]
+    rw [Module.End.isUnit_iff]
     constructor
     · rintro a b (e : x • a = x • b)
       simp_rw [Submonoid.smul_def, Algebra.smul_def] at e

--- a/Mathlib/Algebra/Module/LocalizedModule/Submodule.lean
+++ b/Mathlib/Algebra/Module/LocalizedModule/Submodule.lean
@@ -161,7 +161,7 @@ abbrev toLocalized : M' →ₗ[R] M'.localized p :=
 
 instance : IsLocalizedModule p (M'.toLocalized₀ p f) where
   map_units x := by
-    simp_rw [Module.End_isUnit_iff]
+    simp_rw [Module.End.isUnit_iff]
     constructor
     · exact fun _ _ e ↦ Subtype.ext
         (IsLocalizedModule.smul_injective f x (congr_arg Subtype.val e))
@@ -223,7 +223,7 @@ open Submodule Submodule.Quotient IsLocalization in
 instance IsLocalizedModule.toLocalizedQuotient' (M' : Submodule R M) :
     IsLocalizedModule p (M'.toLocalizedQuotient' S p f) where
   map_units x := by
-    refine (Module.End_isUnit_iff _).mpr ⟨fun m n e ↦ ?_, fun m ↦ ⟨(IsLocalization.mk' S 1 x) • m,
+    refine (Module.End.isUnit_iff _).mpr ⟨fun m n e ↦ ?_, fun m ↦ ⟨(IsLocalization.mk' S 1 x) • m,
         by rw [Module.algebraMap_end_apply, ← smul_assoc, smul_mk'_one, mk'_self', one_smul]⟩⟩
     obtain ⟨⟨m, rfl⟩, n, rfl⟩ := PProd.mk (mk_surjective _ m) (mk_surjective _ n)
     simp only [Module.algebraMap_end_apply, ← mk_smul, Submodule.Quotient.eq, ← smul_sub] at e

--- a/Mathlib/Algebra/Module/Submodule/Ker.lean
+++ b/Mathlib/Algebra/Module/Submodule/Ker.lean
@@ -85,7 +85,7 @@ theorem ker_le_ker_comp (f : M →ₛₗ[τ₁₂] M₂) (g : M₂ →ₛₗ[τ�
 theorem ker_sup_ker_le_ker_comp_of_commute {f g : M →ₗ[R] M} (h : Commute f g) :
     ker f ⊔ ker g ≤ ker (f ∘ₗ g) := by
   refine sup_le_iff.mpr ⟨?_, ker_le_ker_comp g f⟩
-  rw [← mul_eq_comp, h.eq, mul_eq_comp]
+  rw [← Module.End.mul_eq_comp, h.eq, Module.End.mul_eq_comp]
   exact ker_le_ker_comp f g
 
 @[simp]
@@ -143,7 +143,7 @@ def iterateKer (f : M →ₗ[R] M) : ℕ →o Submodule R M where
   monotone' n m w x h := by
     obtain ⟨c, rfl⟩ := Nat.exists_eq_add_of_le w
     rw [LinearMap.mem_ker] at h
-    rw [LinearMap.mem_ker, add_comm, pow_add, LinearMap.mul_apply, h, LinearMap.map_zero]
+    rw [LinearMap.mem_ker, add_comm, pow_add, Module.End.mul_apply, h, LinearMap.map_zero]
 
 end AddCommMonoid
 

--- a/Mathlib/Algebra/Module/Submodule/LinearMap.lean
+++ b/Mathlib/Algebra/Module/Submodule/LinearMap.lean
@@ -236,9 +236,8 @@ lemma restrict_smul_one
 lemma restrict_commute {f g : M →ₗ[R] M} (h : Commute f g) {p : Submodule R M}
     (hf : MapsTo f p p) (hg : MapsTo g p p) :
     Commute (f.restrict hf) (g.restrict hg) := by
-  change _ * _ = _ * _
-  conv_lhs => rw [mul_eq_comp, ← restrict_comp]; congr; rw [← mul_eq_comp, h.eq]
-  rfl
+  change (f ∘ₗ g).restrict (hf.comp hg) = (g ∘ₗ f).restrict (hg.comp hf)
+  congr 1
 
 theorem subtype_comp_restrict {f : M →ₗ[R] M₁} {p : Submodule R M} {q : Submodule R M₁}
     (hf : ∀ x ∈ p, f x ∈ q) : q.subtype.comp (f.restrict hf) = f.domRestrict p :=
@@ -267,31 +266,31 @@ theorem coeFn_sum {ι : Type*} (t : Finset ι) (f : ι → M →ₛₗ[σ₁₂]
              map_zero' := rfl
              map_add' := fun _ _ => rfl }) _ _
 
-theorem submodule_pow_eq_zero_of_pow_eq_zero {N : Submodule R M} {g : Module.End R N}
-    {G : Module.End R M} (h : G.comp N.subtype = N.subtype.comp g) {k : ℕ} (hG : G ^ k = 0) :
-    g ^ k = 0 := by
+theorem _root_.Module.End.submodule_pow_eq_zero_of_pow_eq_zero {N : Submodule R M}
+    {g : Module.End R N} {G : Module.End R M} (h : G.comp N.subtype = N.subtype.comp g) {k : ℕ}
+    (hG : G ^ k = 0) : g ^ k = 0 := by
   ext m
   have hg : N.subtype.comp (g ^ k) m = 0 := by
-    rw [← commute_pow_left_of_commute h, hG, zero_comp, zero_apply]
+    rw [← Module.End.commute_pow_left_of_commute h, hG, zero_comp, zero_apply]
   simpa using hg
 
 section
 
 variable {f' : M →ₗ[R] M}
 
-theorem pow_apply_mem_of_forall_mem {p : Submodule R M} (n : ℕ) (h : ∀ x ∈ p, f' x ∈ p) (x : M)
-    (hx : x ∈ p) : (f' ^ n) x ∈ p := by
+theorem _root_.Module.End.pow_apply_mem_of_forall_mem {p : Submodule R M} (n : ℕ)
+    (h : ∀ x ∈ p, f' x ∈ p) (x : M) (hx : x ∈ p) : (f' ^ n) x ∈ p := by
   induction n generalizing x with
   | zero => simpa
   | succ n ih =>
     simpa only [iterate_succ, coe_comp, Function.comp_apply, restrict_apply] using ih _ (h _ hx)
 
-theorem pow_restrict {p : Submodule R M} (n : ℕ) (h : ∀ x ∈ p, f' x ∈ p)
-    (h' := pow_apply_mem_of_forall_mem n h) :
+theorem _root_.Module.End.pow_restrict {p : Submodule R M} (n : ℕ) (h : ∀ x ∈ p, f' x ∈ p)
+    (h' := Module.End.pow_apply_mem_of_forall_mem n h) :
     (f'.restrict h) ^ n = (f' ^ n).restrict h' := by
   ext x
   have : Semiconj (↑) (f'.restrict h) f' := fun _ ↦ restrict_coe_apply _ _ _
-  simp [coe_pow, this.iterate_right _ _]
+  simp [Module.End.coe_pow, this.iterate_right _ _]
 
 end
 

--- a/Mathlib/Algebra/Module/Submodule/Map.lean
+++ b/Mathlib/Algebra/Module/Submodule/Map.lean
@@ -202,11 +202,11 @@ theorem comap_comp (f : M →ₛₗ[σ₁₂] M₂) (g : M₂ →ₛₗ[σ₂₃
 theorem comap_mono {f : F} {q q' : Submodule R₂ M₂} : q ≤ q' → comap f q ≤ comap f q' :=
   preimage_mono
 
-theorem le_comap_pow_of_le_comap (p : Submodule R M) {f : M →ₗ[R] M} (h : p ≤ p.comap f) (k : ℕ) :
-    p ≤ p.comap (f ^ k) := by
+theorem le_comap_pow_of_le_comap (p : Submodule R M) {f : M →ₗ[R] M}
+    (h : p ≤ p.comap f) (k : ℕ) : p ≤ p.comap (f ^ k) := by
   induction k with
-  | zero => simp [LinearMap.one_eq_id]
-  | succ k ih => simp [LinearMap.iterate_succ, comap_comp, h.trans (comap_mono ih)]
+  | zero => simp [Module.End.one_eq_id]
+  | succ k ih => simp [Module.End.iterate_succ, comap_comp, h.trans (comap_mono ih)]
 
 section
 

--- a/Mathlib/Algebra/Module/Submodule/Range.lean
+++ b/Mathlib/Algebra/Module/Submodule/Range.lean
@@ -140,7 +140,7 @@ def iterateRange (f : M →ₗ[R] M) : ℕ →o (Submodule R M)ᵒᵈ where
     obtain ⟨m, rfl⟩ := h
     rw [LinearMap.mem_range]
     use (f ^ c) m
-    rw [pow_add, LinearMap.mul_apply]
+    rw [pow_add, Module.End.mul_apply]
 
 /-- Restrict the codomain of a linear map `f` to `f.range`.
 

--- a/Mathlib/Algebra/Polynomial/Derivative.lean
+++ b/Mathlib/Algebra/Polynomial/Derivative.lean
@@ -136,7 +136,7 @@ theorem derivative_sum {s : Finset ι} {f : ι → R[X]} :
 
 theorem iterate_derivative_sum (k : ℕ) (s : Finset ι) (f : ι → R[X]) :
     derivative^[k] (∑ b ∈ s, f b) = ∑ b ∈ s, derivative^[k] (f b) := by
-  simp_rw [← LinearMap.pow_apply, map_sum]
+  simp_rw [← Module.End.pow_apply, map_sum]
 
 theorem derivative_smul {S : Type*} [SMulZeroClass S R] [IsScalarTower S R R] (s : S)
     (p : R[X]) : derivative (s • p) = s • derivative p :=

--- a/Mathlib/Algebra/Polynomial/Module/Basic.lean
+++ b/Mathlib/Algebra/Polynomial/Module/Basic.lean
@@ -114,7 +114,7 @@ instance isScalarTower' (M : Type u) [AddCommGroup M] [Module R M] [Module S M]
 @[simp]
 theorem monomial_smul_single (i : ℕ) (r : R) (j : ℕ) (m : M) :
     monomial i r • single R j m = single R (i + j) (r • m) := by
-  simp only [LinearMap.mul_apply, Polynomial.aeval_monomial, LinearMap.pow_apply,
+  simp only [Module.End.mul_apply, Polynomial.aeval_monomial, Module.End.pow_apply,
     Module.algebraMap_end_apply, smul_def]
   induction i generalizing r j m with
   | zero =>

--- a/Mathlib/AlgebraicGeometry/Modules/Tilde.lean
+++ b/Mathlib/AlgebraicGeometry/Modules/Tilde.lean
@@ -232,7 +232,7 @@ noncomputable def toStalk (x : PrimeSpectrum.Top R) :
 open LocalizedModule TopCat.Presheaf in
 lemma isUnit_toStalk (x : PrimeSpectrum.Top R) (r : x.asIdeal.primeCompl) :
     IsUnit ((algebraMap R (Module.End R ((tildeInModuleCat M).stalk x))) r) := by
-  rw [Module.End_isUnit_iff]
+  rw [Module.End.isUnit_iff]
   refine ⟨LinearMap.ker_eq_bot.1 <| eq_bot_iff.2 fun st (h : r.1 • st = 0) ↦
     smul_stalk_no_nonzero_divisor M r st h, fun st ↦ ?_⟩
   obtain ⟨U, mem, s, rfl⟩ := germ_exist (F := M.tildeInModuleCat) x st
@@ -362,9 +362,9 @@ theorem localizationToStalk_mk (x : PrimeSpectrum.Top R) (f : M) (s : x.asIdeal.
     (localizationToStalk M x).hom (LocalizedModule.mk f s) =
       (tildeInModuleCat M).germ (PrimeSpectrum.basicOpen (s : R)) x s.2
         (const M f s (PrimeSpectrum.basicOpen s) fun _ => id) :=
-  (Module.End_isUnit_iff _ |>.1 (isUnit_toStalk M x s)).injective <| by
-  erw [← LinearMap.mul_apply]
-  simp only [IsUnit.mul_val_inv, LinearMap.one_apply, Module.algebraMap_end_apply]
+  (Module.End.isUnit_iff _ |>.1 (isUnit_toStalk M x s)).injective <| by
+  erw [← Module.End.mul_apply]
+  simp only [IsUnit.mul_val_inv, Module.End.one_apply, Module.algebraMap_end_apply]
   show (M.tildeInModuleCat.germ ⊤ x ⟨⟩) ((toOpen M ⊤) f) = _
   rw [← map_smul]
   fapply TopCat.Presheaf.germ_ext (W := PrimeSpectrum.basicOpen s.1) (hxW := s.2)

--- a/Mathlib/Analysis/Calculus/LagrangeMultipliers.lean
+++ b/Mathlib/Analysis/Calculus/LagrangeMultipliers.lean
@@ -74,7 +74,7 @@ theorem IsLocalExtrOn.exists_linear_map_of_hasStrictFDerivAt
     LinearEquiv.refl_apply, LinearMap.ringLmapEquivSelf_symm_apply, LinearMap.coprodEquiv_apply,
     ContinuousLinearMap.coe_prod, LinearMap.coprod_comp_prod, LinearMap.add_apply,
     LinearMap.coe_comp, ContinuousLinearMap.coe_coe, Function.comp_apply, LinearMap.coe_smulRight,
-    LinearMap.one_apply, mul_comm]
+    Module.End.one_apply, mul_comm]
 
 /-- Lagrange multipliers theorem: if `φ : E → ℝ` has a local extremum on the set `{x | f x = f x₀}`
 at `x₀`, and both `f : E → ℝ` and `φ` are strictly differentiable at `x₀`, then there exist

--- a/Mathlib/Analysis/InnerProductSpace/Adjoint.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Adjoint.lean
@@ -436,19 +436,19 @@ theorem isAdjointPair_inner (A : E →ₗ[𝕜] F) :
 /-- The Gram operator T†T is symmetric. -/
 theorem isSymmetric_adjoint_mul_self (T : E →ₗ[𝕜] E) : IsSymmetric (LinearMap.adjoint T * T) := by
   intro x y
-  simp only [mul_apply, adjoint_inner_left, adjoint_inner_right]
+  simp [adjoint_inner_left, adjoint_inner_right]
 
 /-- The Gram operator T†T is a positive operator. -/
 theorem re_inner_adjoint_mul_self_nonneg (T : E →ₗ[𝕜] E) (x : E) :
     0 ≤ re ⟪x, (LinearMap.adjoint T * T) x⟫ := by
-  simp only [mul_apply, adjoint_inner_right, inner_self_eq_norm_sq_to_K]
+  simp only [Module.End.mul_apply, adjoint_inner_right, inner_self_eq_norm_sq_to_K]
   norm_cast
   exact sq_nonneg _
 
 @[simp]
 theorem im_inner_adjoint_mul_self_eq_zero (T : E →ₗ[𝕜] E) (x : E) :
     im ⟪x, LinearMap.adjoint T (T x)⟫ = 0 := by
-  simp only [mul_apply, adjoint_inner_right, inner_self_eq_norm_sq_to_K]
+  simp only [Module.End.mul_apply, adjoint_inner_right, inner_self_eq_norm_sq_to_K]
   norm_cast
 
 end LinearMap

--- a/Mathlib/Analysis/InnerProductSpace/Symmetric.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Symmetric.lean
@@ -99,12 +99,12 @@ theorem IsSymmetric.smul {c : 𝕜} (hc : conj c = c) {T : E →ₗ[𝕜] E} (hT
 @[aesop 30% apply]
 lemma IsSymmetric.mul_of_commute {S T : E →ₗ[𝕜] E} (hS : S.IsSymmetric) (hT : T.IsSymmetric)
     (hST : Commute S T) : (S * T).IsSymmetric :=
-  fun _ _ ↦ by rw [mul_apply, hS, hT, hST, mul_apply]
+  fun _ _ ↦ by rw [Module.End.mul_apply, hS, hT, hST, Module.End.mul_apply]
 
 @[aesop safe apply]
 lemma IsSymmetric.pow {T : E →ₗ[𝕜] E} (hT : T.IsSymmetric) (n : ℕ) : (T ^ n).IsSymmetric := by
-  refine Nat.le_induction (by simp [one_eq_id]) (fun k _ ih ↦ ?_) n n.zero_le
-  rw [iterate_succ, ← mul_eq_comp]
+  refine Nat.le_induction (by simp [Module.End.one_eq_id]) (fun k _ ih ↦ ?_) n n.zero_le
+  rw [Module.End.iterate_succ, ← Module.End.mul_eq_comp]
   exact ih.mul_of_commute hT <| .pow_left rfl k
 
 /-- For a symmetric operator `T`, the function `fun x ↦ ⟪T x, x⟫` is real-valued. -/

--- a/Mathlib/Data/Matrix/Bilinear.lean
+++ b/Mathlib/Data/Matrix/Bilinear.lean
@@ -150,9 +150,9 @@ theorem mulLeftLinearMap_eq_zero_iff [Nonempty n] (a : Matrix l m A) :
 theorem pow_mulLeftLinearMap (a : Matrix m m A) (k : ℕ) :
     mulLeftLinearMap n R a ^ k = mulLeftLinearMap n R (a ^ k) :=
   match k with
-  | 0 => by rw [pow_zero, pow_zero, mulLeftLinearMap_one, LinearMap.one_eq_id]
+  | 0 => by rw [pow_zero, pow_zero, mulLeftLinearMap_one, Module.End.one_eq_id]
   | (n + 1) => by
-    rw [pow_succ, pow_succ, mulLeftLinearMap_mul, LinearMap.mul_eq_comp, pow_mulLeftLinearMap]
+    rw [pow_succ, pow_succ, mulLeftLinearMap_mul, Module.End.mul_eq_comp, pow_mulLeftLinearMap]
 
 end left
 
@@ -183,9 +183,9 @@ theorem mulRightLinearMap_eq_zero_iff (a : Matrix m n A) [Nonempty l] :
 theorem pow_mulRightLinearMap (a : Matrix m m A) (k : ℕ) :
     mulRightLinearMap l R a ^ k = mulRightLinearMap l R (a ^ k) :=
   match k with
-  | 0 => by rw [pow_zero, pow_zero, mulRightLinearMap_one, LinearMap.one_eq_id]
+  | 0 => by rw [pow_zero, pow_zero, mulRightLinearMap_one, Module.End.one_eq_id]
   | (n + 1) => by
-    rw [pow_succ, pow_succ', mulRightLinearMap_mul, LinearMap.mul_eq_comp, pow_mulRightLinearMap]
+    rw [pow_succ, pow_succ', mulRightLinearMap_mul, Module.End.mul_eq_comp, pow_mulRightLinearMap]
 
 end right
 

--- a/Mathlib/FieldTheory/JacobsonNoether.lean
+++ b/Mathlib/FieldTheory/JacobsonNoether.lean
@@ -90,7 +90,7 @@ lemma exist_pow_eq_zero_of_le (p : ℕ) [hchar : ExpChar D p]
   refine ⟨m, ⟨hm.1, fun n hn ↦ ?_⟩⟩
   have inter : (ad k D a)^[p ^ m] = 0 := by
     ext x
-    rw [ad_eq_lmul_left_sub_lmul_right, ← pow_apply, Pi.sub_apply,
+    rw [ad_eq_lmul_left_sub_lmul_right, ← Module.End.pow_apply, Pi.sub_apply,
       sub_pow_expChar_pow_of_commute p m (commute_mulLeft_right a a), sub_apply,
       pow_mulLeft, mulLeft_apply, pow_mulRight, mulRight_apply, Pi.zero_apply,
       Subring.mem_center_iff.1 hm.2 x]

--- a/Mathlib/LinearAlgebra/Charpoly/Basic.lean
+++ b/Mathlib/LinearAlgebra/Charpoly/Basic.lean
@@ -103,7 +103,7 @@ theorem minpoly_coeff_zero_of_injective [Nontrivial R] (hf : Function.Injective 
       rwa [Monic.def, hP, mul_comm, leadingCoeff_mul_X, ← Monic.def] at this
     exact minpoly.monic (isIntegral f)
   have hzero : aeval f (minpoly R f) = 0 := minpoly.aeval _ _
-  simp only [hP, mul_eq_comp, LinearMap.ext_iff, hf, aeval_X, map_eq_zero_iff, coe_comp,
+  simp only [hP, Module.End.mul_eq_comp, LinearMap.ext_iff, hf, aeval_X, map_eq_zero_iff, coe_comp,
     map_mul, zero_apply, Function.comp_apply] at hzero
   exact not_le.2 hdegP (minpoly.min _ _ hPmonic (LinearMap.ext hzero))
 

--- a/Mathlib/LinearAlgebra/Eigenspace/Basic.lean
+++ b/Mathlib/LinearAlgebra/Eigenspace/Basic.lean
@@ -118,12 +118,12 @@ lemma genEigenspace_one {f : End R M} {μ : R} :
 lemma mem_genEigenspace_one {f : End R M} {μ : R} {x : M} :
     x ∈ f.genEigenspace μ 1 ↔ f x = μ • x := by
   rw [genEigenspace_one, LinearMap.mem_ker, LinearMap.sub_apply,
-    sub_eq_zero, LinearMap.smul_apply, LinearMap.one_apply]
+    sub_eq_zero, LinearMap.smul_apply, Module.End.one_apply]
 
 -- `simp` can prove this using `genEigenspace_zero`
 lemma mem_genEigenspace_zero {f : End R M} {μ : R} {x : M} :
     x ∈ f.genEigenspace μ 0 ↔ x = 0 := by
-  rw [← Nat.cast_zero, mem_genEigenspace_nat, pow_zero, LinearMap.mem_ker, LinearMap.one_apply]
+  rw [← Nat.cast_zero, mem_genEigenspace_nat, pow_zero, LinearMap.mem_ker, Module.End.one_apply]
 
 @[simp]
 lemma genEigenspace_zero {f : End R M} {μ : R} :
@@ -311,7 +311,7 @@ lemma HasUnifEigenvalue.lt {f : End R M} {μ : R} {k m : ℕ∞}
   rw [mem_genEigenspace] at hx
   rcases hx with ⟨l, -, hx⟩
   rwa [LinearMap.ker_eq_bot.mpr] at hx
-  rw [LinearMap.coe_pow (f - μ • 1) l]
+  rw [Module.End.coe_pow (f - μ • 1) l]
   exact Function.Injective.iterate contra l
 
 /-- Generalized eigenvalues are actually just eigenvalues. -/
@@ -356,7 +356,7 @@ lemma mapsTo_genEigenspace_of_comm {f g : End R M} (h : Commute f g) (μ : R) (k
   replace h : Commute ((f - μ • (1 : End R M)) ^ l) g :=
     (h.sub_left <| Algebra.commute_algebraMap_left μ g).pow_left l
   use l, hl
-  rw [← LinearMap.comp_apply, ← LinearMap.mul_eq_comp, h.eq, LinearMap.mul_eq_comp,
+  rw [← LinearMap.comp_apply, ← Module.End.mul_eq_comp, h.eq, Module.End.mul_eq_comp,
     LinearMap.comp_apply, hx, map_zero]
 
 /-- The restriction of `f - μ • 1` to the `k`-fold generalized `μ`-eigenspace is nilpotent. -/
@@ -369,7 +369,7 @@ lemma isNilpotent_restrict_genEigenspace_nat (f : End R M) (μ : R) (k : ℕ)
   ext ⟨x, hx⟩
   rw [mem_genEigenspace_nat] at hx
   rw [LinearMap.zero_apply, ZeroMemClass.coe_zero, ZeroMemClass.coe_eq_zero,
-    LinearMap.pow_restrict, LinearMap.restrict_apply]
+    Module.End.pow_restrict, LinearMap.restrict_apply]
   ext
   simpa
 
@@ -757,7 +757,7 @@ theorem genEigenspace_restrict (f : End R M) (p : Submodule R M) (k : ℕ∞) (�
   simp only [genEigenspace_nat, OrderHom.coe_mk, ← LinearMap.ker_comp]
   induction l with
   | zero =>
-    rw [pow_zero, pow_zero, LinearMap.one_eq_id]
+    rw [pow_zero, pow_zero, Module.End.one_eq_id]
     apply (Submodule.ker_subtype _).symm
   | succ l ih =>
     erw [pow_succ, pow_succ, LinearMap.ker_comp, LinearMap.ker_comp, ih, ← LinearMap.ker_comp,
@@ -777,7 +777,7 @@ lemma mapsTo_restrict_maxGenEigenspace_restrict_of_mapsTo
       (maxGenEigenspace (g.restrict hg) μ₂) := by
   intro x hx
   simp_rw [SetLike.mem_coe, mem_maxGenEigenspace, ← LinearMap.restrict_smul_one _,
-    LinearMap.restrict_sub _, LinearMap.pow_restrict _, LinearMap.restrict_apply,
+    LinearMap.restrict_sub _, Module.End.pow_restrict _, LinearMap.restrict_apply,
     Submodule.mk_eq_zero, ← mem_maxGenEigenspace] at hx ⊢
   exact h hx
 
@@ -872,9 +872,9 @@ lemma genEigenspace_inf_le_add
     rw [LinearMap.smul_apply, this, smul_zero]
   rw [Finset.mem_antidiagonal] at hij
   obtain hi|hj : l₁ ≤ i ∨ l₂ ≤ j := by omega
-  · rw [(h.pow_pow i j).eq, LinearMap.mul_apply, LinearMap.pow_map_zero_of_le hi hl₁,
+  · rw [(h.pow_pow i j).eq, Module.End.mul_apply, Module.End.pow_map_zero_of_le hi hl₁,
       LinearMap.map_zero]
-  · rw [LinearMap.mul_apply, LinearMap.pow_map_zero_of_le hj hl₂, LinearMap.map_zero]
+  · rw [Module.End.mul_apply, Module.End.pow_map_zero_of_le hj hl₂, LinearMap.map_zero]
 
 @[deprecated genEigenspace_inf_le_add (since := "2024-10-23")]
 lemma iSup_genEigenspace_inf_le_add

--- a/Mathlib/LinearAlgebra/Eigenspace/Minpoly.lean
+++ b/Mathlib/LinearAlgebra/Eigenspace/Minpoly.lean
@@ -53,7 +53,7 @@ theorem aeval_apply_of_hasEigenvector {f : End K V} {p : K[X]} {μ : K} {x : V}
   · intro a; simp [Module.algebraMap_end_apply]
   · intro p q hp hq; simp [hp, hq, add_smul]
   · intro n a hna
-    rw [mul_comm, pow_succ', mul_assoc, map_mul, LinearMap.mul_apply, mul_comm, hna]
+    rw [mul_comm, pow_succ', mul_assoc, map_mul, Module.End.mul_apply, mul_comm, hna]
     simp only [mem_eigenspace_iff.1 h.1, smul_smul, aeval_X, eval_mul, eval_C, eval_pow, eval_X,
       LinearMap.map_smulₛₗ, RingHom.id_apply, mul_comm]
 

--- a/Mathlib/LinearAlgebra/Eigenspace/Pi.lean
+++ b/Mathlib/LinearAlgebra/Eigenspace/Pi.lean
@@ -121,7 +121,7 @@ lemma independent_iInf_maxGenEigenspace_of_forall_mapsTo
   obtain ⟨k, hk : (g ^ k) y = 0⟩ := (mem_iInf_maxGenEigenspace_iff _ _ _).mp hy l
   have aux (f : End R M) (φ : R) (k : ℕ) (p : Submodule R M) (hp : MapsTo f p p) :
       MapsTo ((f - algebraMap R (Module.End R M) φ) ^ k) p p := by
-    rw [LinearMap.coe_pow]
+    rw [Module.End.coe_pow]
     exact MapsTo.iterate (fun m hm ↦ p.sub_mem (hp hm) (p.smul_mem _ hm)) k
   refine ⟨k, Submodule.mem_inf.mp ⟨?_, ?_⟩⟩
   · refine aux (f l) (χ₂ l) k (⨅ i, (f i).maxGenEigenspace (χ₁ i)) ?_ hx

--- a/Mathlib/LinearAlgebra/Eigenspace/Triangularizable.lean
+++ b/Mathlib/LinearAlgebra/Eigenspace/Triangularizable.lean
@@ -176,11 +176,11 @@ theorem inf_iSup_genEigenspace [FiniteDimensional K V] (h : ∀ x ∈ p, f x ∈
       simpa only [Nat.cast_le] using Finset.le_sup hμ'
     have : _ = g := (m.support.erase μ).noncommProd_erase_mul (Finset.mem_erase.mpr ⟨hμμ', hμ'⟩)
       (fun μ ↦ (f - algebraMap K (End K V) μ) ^ l₀) (fun μ₁ _ μ₂ _ _ ↦ h_comm μ₁ μ₂)
-    rw [← this, LinearMap.mul_apply, hl₀, _root_.map_zero]
+    rw [← this, Module.End.mul_apply, hl₀, _root_.map_zero]
   have hg₁ : MapsTo g p p := Finset.noncommProd_induction _ _ _ (fun g' : End K V ↦ MapsTo g' p p)
       (fun f₁ f₂ ↦ MapsTo.comp) (mapsTo_id _) fun μ' _ ↦ by
     suffices MapsTo (f - algebraMap K (End K V) μ') p p by
-      simp only [LinearMap.coe_pow]; exact this.iterate l₀
+      simp only [Module.End.coe_pow]; exact this.iterate l₀
     intro x hx
     rw [LinearMap.sub_apply, algebraMap_end_apply]
     exact p.sub_mem (h _ hx) (smul_mem p μ' hx)

--- a/Mathlib/LinearAlgebra/Eigenspace/Zero.lean
+++ b/Mathlib/LinearAlgebra/Eigenspace/Zero.lean
@@ -148,13 +148,13 @@ lemma finrank_maxGenEigenspace (φ : Module.End K M) :
       forall_exists_index]
     intro x n hx
     use n
-    rw [← LinearMap.mul_apply, ← pow_succ, pow_succ', LinearMap.mul_apply, hx, map_zero]
+    rw [← Module.End.mul_apply, ← pow_succ, pow_succ', Module.End.mul_apply, hx, map_zero]
   have hφW : ∀ x ∈ W, φ x ∈ W := by
     simp only [W, Submodule.mem_iInf, mem_range]
     intro x H n
     obtain ⟨y, rfl⟩ := H n
     use φ y
-    rw [← LinearMap.mul_apply, ← pow_succ, pow_succ', LinearMap.mul_apply]
+    rw [← Module.End.mul_apply, ← pow_succ, pow_succ', Module.End.mul_apply]
   let F := φ.restrict hφV
   let G := φ.restrict hφW
   let ψ := F.prodMap G
@@ -193,8 +193,6 @@ lemma finrank_maxGenEigenspace (φ : Module.End K M) :
   refine .trans ?_ hx
   generalize_proofs h'
   clear hx
-  induction n with
-  | zero => simp only [pow_zero, one_apply]
-  | succ n ih => simp only [pow_succ', LinearMap.mul_apply, ih, restrict_apply]
+  induction n <;> simp [pow_succ', *]
 
 end LinearMap

--- a/Mathlib/LinearAlgebra/FiniteDimensional/Basic.lean
+++ b/Mathlib/LinearAlgebra/FiniteDimensional/Basic.lean
@@ -344,18 +344,18 @@ theorem ker_comp_eq_of_commute_of_disjoint_ker [FiniteDimensional K V] {f g : V 
     ker (f ∘ₗ g) = ker f ⊔ ker g := by
   suffices ∀ x, f x = 0 → f (g x) = 0 by rw [ker_comp, comap_eq_sup_ker_of_disjoint _ h']; simpa
   intro x hx
-  rw [← comp_apply, ← mul_eq_comp, h.eq, mul_apply, hx, map_zero]
+  rw [← comp_apply, ← Module.End.mul_eq_comp, h.eq, Module.End.mul_apply, hx, map_zero]
 
 theorem ker_noncommProd_eq_of_supIndep_ker [FiniteDimensional K V] {ι : Type*} {f : ι → V →ₗ[K] V}
     (s : Finset ι) (comm) (h : s.SupIndep fun i ↦ ker (f i)) :
     ker (s.noncommProd f comm) = ⨆ i ∈ s, ker (f i) := by
   classical
   induction s using Finset.induction_on with
-  | empty => simp [one_eq_id]
+  | empty => simp [Module.End.one_eq_id]
   | @insert i s hi ih =>
     replace ih : ker (Finset.noncommProd s f <| Set.Pairwise.mono (s.subset_insert i) comm) =
         ⨆ x ∈ s, ker (f x) := ih _ (h.subset (s.subset_insert i))
-    rw [Finset.noncommProd_insert_of_not_mem _ _ _ _ hi, mul_eq_comp,
+    rw [Finset.noncommProd_insert_of_not_mem _ _ _ _ hi, Module.End.mul_eq_comp,
       ker_comp_eq_of_commute_of_disjoint_ker]
     · simp_rw [Finset.mem_insert_coe, iSup_insert, Finset.mem_coe, ih]
     · exact s.noncommProd_commute _ _ _ fun j hj ↦
@@ -576,7 +576,7 @@ theorem ker_pow_constant {f : End K V} {k : ℕ}
     · rw [add_comm, pow_add]
       apply LinearMap.ker_le_ker_comp
     · rw [ker_pow_constant h m, add_comm m 1, ← add_assoc, pow_add, pow_add f k m,
-        LinearMap.mul_eq_comp, LinearMap.mul_eq_comp, LinearMap.ker_comp, LinearMap.ker_comp, h,
+        Module.End.mul_eq_comp, Module.End.mul_eq_comp, LinearMap.ker_comp, LinearMap.ker_comp, h,
         Nat.add_one]
 
 end End

--- a/Mathlib/LinearAlgebra/Matrix/InvariantBasisNumber.lean
+++ b/Mathlib/LinearAlgebra/Matrix/InvariantBasisNumber.lean
@@ -36,7 +36,7 @@ instance (priority := 100) rankCondition_of_nontrivial_of_commSemiring {R : Type
       (LinearMap.range_eq_top.mpr <| hp.comp hf)
     let e := Matrix.toLinAlgEquiv' (R := R) (n := Fin n).symm
     apply_fun e at eq
-    rw [← LinearMap.mul_eq_comp, ← LinearMap.one_eq_id, map_mul, map_one,
+    rw [← Module.End.mul_eq_comp, ← Module.End.one_eq_id, map_mul, map_one,
       Matrix.mul_eq_one_comm_of_equiv (Equiv.refl _),
       ← map_mul, ← map_one e, e.injective.eq_iff] at eq
     have : Injective p := (p.coe_comp f ▸ LinearMap.injective_of_comp_eq_id _ _ eq).of_comp_right hf

--- a/Mathlib/LinearAlgebra/Matrix/ToLin.lean
+++ b/Mathlib/LinearAlgebra/Matrix/ToLin.lean
@@ -166,7 +166,7 @@ theorem Matrix.toLinearMapRight'_mul_apply [Fintype l] [DecidableEq l] (M : Matr
 theorem Matrix.toLinearMapRight'_one :
     Matrix.toLinearMapRight' (1 : Matrix m m R) = LinearMap.id := by
   ext
-  simp [LinearMap.one_apply]
+  simp [Module.End.one_apply]
 
 /-- If `M` and `M'` are each other's inverse matrices, they provide an equivalence between `n → A`
 and `m → A` corresponding to `M.vecMul` and `M'.vecMul`. -/
@@ -635,7 +635,7 @@ theorem LinearMap.toMatrix_comp [Finite l] [DecidableEq m] (f : M₂ →ₗ[R] M
 
 theorem LinearMap.toMatrix_mul (f g : M₁ →ₗ[R] M₁) :
     LinearMap.toMatrix v₁ v₁ (f * g) = LinearMap.toMatrix v₁ v₁ f * LinearMap.toMatrix v₁ v₁ g := by
-  rw [LinearMap.mul_eq_comp, LinearMap.toMatrix_comp v₁ v₁ v₁ f g]
+  rw [Module.End.mul_eq_comp, LinearMap.toMatrix_comp v₁ v₁ v₁ f g]
 
 lemma LinearMap.toMatrix_pow (f : M₁ →ₗ[R] M₁) (k : ℕ) :
     (toMatrix v₁ v₁ f) ^ k = toMatrix v₁ v₁ (f ^ k) := by
@@ -744,7 +744,7 @@ theorem LinearMap.toMatrixAlgEquiv_comp (f g : M₁ →ₗ[R] M₁) :
 theorem LinearMap.toMatrixAlgEquiv_mul (f g : M₁ →ₗ[R] M₁) :
     LinearMap.toMatrixAlgEquiv v₁ (f * g) =
       LinearMap.toMatrixAlgEquiv v₁ f * LinearMap.toMatrixAlgEquiv v₁ g := by
-  rw [LinearMap.mul_eq_comp, LinearMap.toMatrixAlgEquiv_comp v₁ f g]
+  rw [Module.End.mul_eq_comp, LinearMap.toMatrixAlgEquiv_comp v₁ f g]
 
 theorem Matrix.toLinAlgEquiv_mul (A B : Matrix n n R) :
     Matrix.toLinAlgEquiv v₁ (A * B) =
@@ -915,7 +915,7 @@ def LinearEquiv.algConj (e : M₁ ≃ₗ[R] M₂) : Module.End R M₁ ≃ₐ[R] 
     commutes' := fun r ↦ by
       change e.conj _ = _
       simp only [Algebra.algebraMap_eq_smul_one, LinearEquiv.map_smul,
-        one_eq_id, LinearEquiv.conj_id] }
+        Module.End.one_eq_id, LinearEquiv.conj_id] }
 
 /-- A basis of a module induces an equivalence of algebras from the endomorphisms of the module to
 square matrices. -/
@@ -1016,7 +1016,7 @@ def endVecRingEquivMatrixEnd :
   right_inv m := by ext; simp [Pi.single_apply, apply_ite]
   map_mul' f g := by
     ext
-    simp only [LinearMap.mul_apply, LinearMap.coe_mk, AddHom.coe_mk, Matrix.mul_apply, coeFn_sum,
+    simp only [Module.End.mul_apply, LinearMap.coe_mk, AddHom.coe_mk, Matrix.mul_apply, coeFn_sum,
       Finset.sum_apply]
     rw [← Fintype.sum_apply, ← map_sum]
     exact congr_arg₂ _ (by aesop) rfl

--- a/Mathlib/LinearAlgebra/Projection.lean
+++ b/Mathlib/LinearAlgebra/Projection.lean
@@ -381,7 +381,7 @@ theorem isProj_iff_isIdempotentElem (f : M →ₗ[S] M) :
       exact mem_range_self f x
     · intro x hx
       obtain ⟨y, hy⟩ := mem_range.1 hx
-      rw [← hy, ← mul_apply, h]
+      rw [← hy, ← Module.End.mul_apply, h]
 
 @[deprecated (since := "2025-01-12")] alias isProj_iff_idempotent := isProj_iff_isIdempotentElem
 

--- a/Mathlib/LinearAlgebra/QuadraticForm/Basic.lean
+++ b/Mathlib/LinearAlgebra/QuadraticForm/Basic.lean
@@ -882,14 +882,8 @@ general ring with no nontrivial distinguished commutative subring, use `Quadrati
 which gives an additive homomorphism (or more precisely a `ℤ`-linear map.) -/
 def associatedHom : QuadraticMap R M N →ₗ[S] (BilinMap R M N) where
   toFun Q := ⅟ (2 : Module.End R N) • polarBilin Q
-  map_add' _ _ :=
-    LinearMap.ext₂ fun _ _ ↦ by
-      simp only [LinearMap.smul_apply, polarBilin_apply_apply, coeFn_add, polar_add,
-        LinearMap.smul_def, LinearMap.map_add, LinearMap.add_apply]
-  map_smul' _ _ :=
-    LinearMap.ext₂ fun _ _ ↦ by
-      simp only [LinearMap.smul_apply, polarBilin_apply_apply, coeFn_smul, polar_smul,
-        LinearMap.smul_def, LinearMap.map_smul_of_tower, RingHom.id_apply]
+  map_add' _ _ := LinearMap.ext₂ fun _ _ ↦ by simp [polar_add]
+  map_smul' _ _ := LinearMap.ext₂ fun _ _ ↦ by simp [polar_smul]
 
 variable (Q : QuadraticMap R M N)
 
@@ -902,7 +896,7 @@ theorem associated_apply (x y : M) :
 @[simp] theorem two_nsmul_associated : 2 • associatedHom S Q = Q.polarBilin := by
   ext
   dsimp
-  rw [← LinearMap.smul_apply, nsmul_eq_mul, Nat.cast_ofNat, mul_invOf_self', LinearMap.one_apply,
+  rw [← LinearMap.smul_apply, nsmul_eq_mul, Nat.cast_ofNat, mul_invOf_self', Module.End.one_apply,
     polar]
 
 theorem associated_isSymm (Q : QuadraticMap R M N) (x y : M) :
@@ -929,7 +923,7 @@ theorem associated_comp {N' : Type*} [AddCommGroup N'] [Module R N'] (f : N' →
 theorem associated_toQuadraticMap (B : BilinMap R M N) (x y : M) :
     associatedHom S B.toQuadraticMap x y = ⅟ (2 : Module.End R N) • (B x y + B y x) := by
   simp only [associated_apply, BilinMap.toQuadraticMap_apply, map_add, LinearMap.add_apply,
-    LinearMap.smul_def, map_sub]
+    Module.End.smul_def, map_sub]
   abel_nf
 
 theorem associated_left_inverse {B₁ : BilinMap R M N} (h : ∀ x y, B₁ x y = B₁ y x) :
@@ -1012,7 +1006,7 @@ theorem associated_linMulLin [Invertible (2 : R)] (f g : M →ₗ[R] R) :
   ext
   simp only [associated_apply, linMulLin_apply, map_add, smul_add, LinearMap.add_apply,
     LinearMap.smul_apply, compl₁₂_apply, mul_apply', smul_eq_mul, invOf_smul_eq_iff]
-  simp only [smul_add, LinearMap.smul_def, Module.End.ofNat_apply, nsmul_eq_mul, Nat.cast_ofNat,
+  simp only [smul_add, Module.End.smul_def, Module.End.ofNat_apply, nsmul_eq_mul, Nat.cast_ofNat,
     mul_invOf_cancel_left']
   ring_nf
 
@@ -1378,7 +1372,7 @@ theorem basisRepr_eq_of_iIsOrtho {R M} [CommRing R] [AddCommGroup M] [Module R M
   refine sum_congr rfl fun j hj => ?_
   rw [← @associated_eq_self_apply R, LinearMap.map_sum₂, sum_eq_single_of_mem j hj]
   · rw [LinearMap.map_smul, LinearMap.map_smul₂, smul_eq_mul, associated_apply, smul_eq_mul,
-      smul_eq_mul, LinearMap.smul_def, half_moduleEnd_apply_eq_half_smul]
+      smul_eq_mul, Module.End.smul_def, half_moduleEnd_apply_eq_half_smul]
     ring_nf
   · intro i _ hij
     rw [LinearMap.map_smul, LinearMap.map_smul₂, hv₂ hij]

--- a/Mathlib/LinearAlgebra/QuadraticForm/Dual.lean
+++ b/Mathlib/LinearAlgebra/QuadraticForm/Dual.lean
@@ -140,9 +140,9 @@ def toDualProd (Q : QuadraticForm R M) [Invertible (2 : R)] :
       LinearMap.coe_comp, Function.comp_apply, LinearMap.fst_apply, LinearMap.snd_apply,
       LinearMap.sub_apply, dualProd_apply, polarBilin_apply_apply, prod_apply, neg_apply]
     simp only [polar_sub_right, polar_self, nsmul_eq_mul, Nat.cast_ofNat, polar_comm _ x.1 x.2,
-      smul_sub, LinearMap.smul_def, sub_add_sub_cancel, ← sub_eq_add_neg (Q x.1) (Q x.2)]
-    rw [← LinearMap.map_sub (⅟ 2 : Module.End R R), ← mul_sub, ← LinearMap.smul_def]
-    simp only [LinearMap.smul_def, half_moduleEnd_apply_eq_half_smul, smul_eq_mul,
+      smul_sub, Module.End.smul_def, sub_add_sub_cancel, ← sub_eq_add_neg (Q x.1) (Q x.2)]
+    rw [← LinearMap.map_sub (⅟ 2 : Module.End R R), ← mul_sub, ← Module.End.smul_def]
+    simp only [Module.End.smul_def, half_moduleEnd_apply_eq_half_smul, smul_eq_mul,
       invOf_mul_cancel_left']
 
 /-!

--- a/Mathlib/LinearAlgebra/Quotient/Basic.lean
+++ b/Mathlib/LinearAlgebra/Quotient/Basic.lean
@@ -216,9 +216,9 @@ theorem mapQ_pow {f : M →ₗ[R] M} (h : p ≤ p.comap f) (k : ℕ)
     (h' : p ≤ p.comap (f ^ k) := p.le_comap_pow_of_le_comap h k) :
     p.mapQ p (f ^ k) h' = p.mapQ p f h ^ k := by
   induction k with
-  | zero => simp [LinearMap.one_eq_id]
+  | zero => simp [Module.End.one_eq_id]
   | succ k ih =>
-    simp only [LinearMap.iterate_succ]
+    simp only [Module.End.iterate_succ]
     rw [mapQ_comp, ih]
 
 theorem comap_liftQ (f : M →ₛₗ[τ₁₂] M₂) (h) : q.comap (p.liftQ f h) = (q.comap f).map (mkQ p) :=

--- a/Mathlib/LinearAlgebra/Reflection.lean
+++ b/Mathlib/LinearAlgebra/Reflection.lean
@@ -347,7 +347,7 @@ lemma Dual.eq_of_preReflection_mapsTo [CharZero R] [NoZeroSMulDivisors R M]
   have hu : u = LinearMap.id (R := R) (M := M) + (f - g).smulRight x := by
     ext y
     simp only [u, reflection_apply, hg₁, two_smul, LinearEquiv.coe_toLinearMap_mul,
-      LinearMap.id_coe, LinearEquiv.coe_coe, LinearMap.mul_apply, LinearMap.add_apply, id_eq,
+      LinearMap.id_coe, LinearEquiv.coe_coe, Module.End.mul_apply, LinearMap.add_apply, id_eq,
       LinearMap.coe_smulRight, LinearMap.sub_apply, map_sub, map_smul, sub_add_cancel_left,
       smul_neg, sub_neg_eq_add, sub_smul]
     abel
@@ -360,7 +360,7 @@ lemma Dual.eq_of_preReflection_mapsTo [CharZero R] [NoZeroSMulDivisors R M]
       have : ((f - g).smulRight x).comp ((n : R) • (f - g).smulRight x) = 0 := by
         ext; simp [hf₁, hg₁]
       rw [pow_succ', LinearEquiv.coe_toLinearMap_mul, ih, hu, add_mul, mul_add, mul_add]
-      simp_rw [LinearMap.mul_eq_comp, LinearMap.comp_id, LinearMap.id_comp, this, add_zero,
+      simp_rw [Module.End.mul_eq_comp, LinearMap.comp_id, LinearMap.id_comp, this, add_zero,
         add_assoc, Nat.cast_succ, add_smul, one_smul]
   suffices IsOfFinOrder u by
     obtain ⟨n, hn₀, hn₁⟩ := isOfFinOrder_iff_pow_eq_one.mp this

--- a/Mathlib/LinearAlgebra/RootSystem/Defs.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Defs.lean
@@ -744,7 +744,7 @@ lemma isOrthogonal_comm (h : IsOrthogonal P i j) : Commute (P.reflection i) (P.r
   rw [commute_iff_eq]
   ext v
   replace h : P.pairing i j = 0 ∧ P.pairing j i = 0 := by simpa [IsOrthogonal] using h
-  erw [LinearMap.mul_apply, LinearMap.mul_apply]
+  erw [Module.End.mul_apply, Module.End.mul_apply]
   simp only [LinearEquiv.coe_coe, reflection_apply, PerfectPairing.flip_apply_apply, map_sub,
     map_smul, root_coroot_eq_pairing, h, zero_smul, sub_zero]
   abel

--- a/Mathlib/LinearAlgebra/RootSystem/Hom.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Hom.lean
@@ -207,9 +207,9 @@ lemma weightHom_injective (P : RootPairing ι R M N) : Injective (weightHom P) :
 def coweightHom (P : RootPairing ι R M N) : End P →* (N →ₗ[R] N)ᵐᵒᵖ where
   toFun g := MulOpposite.op (Hom.coweightMap (P := P) (Q := P) g)
   map_mul' g h := by
-    simp only [← MulOpposite.op_mul, coweightMap_mul, LinearMap.mul_eq_comp]
+    simp only [← MulOpposite.op_mul, coweightMap_mul, Module.End.mul_eq_comp]
   map_one' := by
-    simp only [MulOpposite.op_eq_one_iff, coweightMap_one, LinearMap.one_eq_id]
+    simp only [MulOpposite.op_eq_one_iff, coweightMap_one, Module.End.one_eq_id]
 
 lemma coweightHom_injective (P : RootPairing ι R M N) : Injective (coweightHom P) := by
   intro f g hfg

--- a/Mathlib/LinearAlgebra/Semisimple.lean
+++ b/Mathlib/LinearAlgebra/Semisimple.lean
@@ -142,7 +142,7 @@ lemma eq_zero_of_isNilpotent_of_isFinitelySemisimple
     rintro - ⟨i, hi, rfl⟩
     apply Submodule.subset_span
     rcases lt_or_eq_of_le hi with hik | rfl
-    · exact ⟨i + 1, hik, by simpa [LinearMap.pow_apply] using iterate_succ_apply' f i x⟩
+    · exact ⟨i + 1, hik, by simpa [Module.End.pow_apply] using iterate_succ_apply' f i x⟩
     · exact ⟨i, by simp [hk]⟩
   have hp₂ : Module.Finite R p := by
     let g : ℕ → M := fun i ↦ (f ^ i) x

--- a/Mathlib/LinearAlgebra/Span/Basic.lean
+++ b/Mathlib/LinearAlgebra/Span/Basic.lean
@@ -642,15 +642,15 @@ variable {R M}
 
 theorem toSpanSingleton_isIdempotentElem_iff {e : R} :
     IsIdempotentElem (toSpanSingleton R R e) ↔ IsIdempotentElem e := by
-  simp_rw [IsIdempotentElem, LinearMap.ext_iff, mul_apply, toSpanSingleton_apply, smul_eq_mul,
-    mul_assoc]
+  simp_rw [IsIdempotentElem, LinearMap.ext_iff, Module.End.mul_apply, toSpanSingleton_apply,
+    smul_eq_mul, mul_assoc]
   exact ⟨fun h ↦ by conv_rhs => rw [← one_mul e, ← h, one_mul], fun h _ ↦ by rw [h]⟩
 
 theorem isIdempotentElem_apply_one_iff {f : Module.End R R} :
     IsIdempotentElem (f 1) ↔ IsIdempotentElem f := by
   rw [IsIdempotentElem, ← smul_eq_mul, ← map_smul, smul_eq_mul, mul_one, IsIdempotentElem,
     LinearMap.ext_iff]
-  simp_rw [mul_apply]
+  simp_rw [Module.End.mul_apply]
   exact ⟨fun h r ↦ by rw [← mul_one r, ← smul_eq_mul, map_smul, map_smul, h], (· 1)⟩
 
 end

--- a/Mathlib/LinearAlgebra/TensorProduct/Basic.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Basic.lean
@@ -1124,12 +1124,12 @@ variable {M}
 @[simp]
 theorem rTensor_pow (f : M →ₗ[R] M) (n : ℕ) : f.rTensor N ^ n = (f ^ n).rTensor N := by
   have h := TensorProduct.map_pow f (id : N →ₗ[R] N) n
-  rwa [id_pow] at h
+  rwa [Module.End.id_pow] at h
 
 @[simp]
 theorem lTensor_pow (f : N →ₗ[R] N) (n : ℕ) : f.lTensor M ^ n = (f ^ n).lTensor M := by
   have h := TensorProduct.map_pow (id : M →ₗ[R] M) f n
-  rwa [id_pow] at h
+  rwa [Module.End.id_pow] at h
 
 end LinearMap
 

--- a/Mathlib/LinearAlgebra/Trace.lean
+++ b/Mathlib/LinearAlgebra/Trace.lean
@@ -174,7 +174,7 @@ theorem trace_one : trace R M 1 = (finrank R M : R) := by
 
 /-- The trace of the identity endomorphism is the dimension of the free module. -/
 @[simp]
-theorem trace_id : trace R M id = (finrank R M : R) := by rw [← one_eq_id, trace_one]
+theorem trace_id : trace R M id = (finrank R M : R) := by rw [← Module.End.one_eq_id, trace_one]
 
 @[simp]
 theorem trace_transpose : trace R (Module.Dual R M) ∘ₗ Module.Dual.transpose = trace R M := by
@@ -308,7 +308,7 @@ lemma trace_comp_eq_mul_of_commute_of_isNilpotent [IsReduced R] {f g : Module.En
     trace R M (f ∘ₗ g) = μ * trace R M f := by
   set n := g - algebraMap R _ μ
   replace hg : trace R M (f ∘ₗ n) = 0 := by
-    rw [← isNilpotent_iff_eq_zero, ← mul_eq_comp]
+    rw [← isNilpotent_iff_eq_zero, ← Module.End.mul_eq_comp]
     refine isNilpotent_trace_of_isNilpotent (Commute.isNilpotent_mul_right ?_ hg)
     exact h_comm.sub_right (Algebra.commute_algebraMap_right μ f)
   have hμ : g = algebraMap R _ μ + n := eq_add_of_sub_eq' rfl

--- a/Mathlib/RepresentationTheory/Basic.lean
+++ b/Mathlib/RepresentationTheory/Basic.lean
@@ -405,7 +405,7 @@ theorem smul_tprod_one_asModule (r : MonoidAlgebra k G) (x : V) (y : W) :
     r • z = (r • x') ⊗ₜ y := by
   show asAlgebraHom (ρV ⊗ 1) _ _ = asAlgebraHom ρV _ _ ⊗ₜ _
   simp only [asAlgebraHom_def, MonoidAlgebra.lift_apply, tprod_apply, MonoidHom.one_apply,
-    LinearMap.finsupp_sum_apply, LinearMap.smul_apply, TensorProduct.map_tmul, LinearMap.one_apply]
+    LinearMap.finsupp_sum_apply, LinearMap.smul_apply, TensorProduct.map_tmul, Module.End.one_apply]
   simp only [Finsupp.sum, TensorProduct.sum_tmul]
   rfl
 
@@ -416,7 +416,7 @@ theorem smul_one_tprod_asModule (r : MonoidAlgebra k G) (x : V) (y : W) :
     r • z = x ⊗ₜ (r • y') := by
   show asAlgebraHom (1 ⊗ ρW) _ _ = _ ⊗ₜ asAlgebraHom ρW _ _
   simp only [asAlgebraHom_def, MonoidAlgebra.lift_apply, tprod_apply, MonoidHom.one_apply,
-    LinearMap.finsupp_sum_apply, LinearMap.smul_apply, TensorProduct.map_tmul, LinearMap.one_apply]
+    LinearMap.finsupp_sum_apply, LinearMap.smul_apply, TensorProduct.map_tmul, Module.End.one_apply]
   simp only [Finsupp.sum, TensorProduct.tmul_sum, TensorProduct.tmul_smul]
 
 end TensorProduct
@@ -435,8 +435,8 @@ def linHom : Representation k G (V →ₗ[k] W) where
     { toFun := fun f => ρW g ∘ₗ f ∘ₗ ρV g⁻¹
       map_add' := fun f₁ f₂ => by simp_rw [add_comp, comp_add]
       map_smul' := fun r f => by simp_rw [RingHom.id_apply, smul_comp, comp_smul] }
-  map_one' := ext fun x => by simp [one_eq_id]
-  map_mul' g h := ext fun x => by simp [mul_eq_comp, comp_assoc]
+  map_one' := ext fun x => by simp [Module.End.one_eq_id]
+  map_mul' g h := ext fun x => by simp [Module.End.mul_eq_comp, comp_assoc]
 
 @[simp]
 theorem linHom_apply (g : G) (f : V →ₗ[k] W) : (linHom ρV ρW) g f = ρW g ∘ₗ f ∘ₗ ρV g⁻¹ :=

--- a/Mathlib/RepresentationTheory/FDRep.lean
+++ b/Mathlib/RepresentationTheory/FDRep.lean
@@ -135,12 +135,12 @@ theorem of_ρ' {V : Type u} [AddCommGroup V] [Module R V] [Module.Finite R V] (�
 @[simp]
 theorem ρ_inv_self_apply {G : Type u} [Group G] {A : FDRep R G} (g : G) (x : A) :
     A.ρ g⁻¹ (A.ρ g x) = x :=
-  show (A.ρ g⁻¹ * A.ρ g) x = x by rw [← map_mul, inv_mul_cancel, map_one, LinearMap.one_apply]
+  show (A.ρ g⁻¹ * A.ρ g) x = x by rw [← map_mul, inv_mul_cancel, map_one, Module.End.one_apply]
 
 @[simp]
 theorem ρ_self_inv_apply {G : Type u} [Group G] {A : FDRep R G} (g : G) (x : A) :
     A.ρ g (A.ρ g⁻¹ x) = x :=
-  show (A.ρ g * A.ρ g⁻¹) x = x by rw [← map_mul, mul_inv_cancel, map_one, LinearMap.one_apply]
+  show (A.ρ g * A.ρ g⁻¹) x = x by rw [← map_mul, mul_inv_cancel, map_one, Module.End.one_apply]
 
 instance : HasForget₂ (FDRep R G) (Rep R G) where
   forget₂ := (forget₂ (FGModuleCat R) (ModuleCat R)).mapAction G

--- a/Mathlib/RepresentationTheory/GroupCohomology/LowDegree.lean
+++ b/Mathlib/RepresentationTheory/GroupCohomology/LowDegree.lean
@@ -204,7 +204,7 @@ theorem dTwo_comp_eq :
 theorem dOne_comp_dZero : dOne A ∘ₗ dZero A = 0 := by
   ext x g
   simp only [LinearMap.coe_comp, Function.comp_apply, dOne_apply A, dZero_apply A, map_sub,
-    map_mul, LinearMap.mul_apply, sub_sub_sub_cancel_left, sub_add_sub_cancel, sub_self]
+    map_mul, Module.End.mul_apply, sub_sub_sub_cancel_left, sub_add_sub_cancel, sub_self]
   rfl
 
 theorem dTwo_comp_dOne : dTwo A ∘ₗ dOne A = 0 := by
@@ -269,7 +269,7 @@ theorem mem_oneCocycles_iff (f : G → A) :
 
 @[simp] theorem oneCocycles_map_one (f : oneCocycles A) : f 1 = 0 := by
   have := (mem_oneCocycles_def f).1 f.2 1 1
-  simpa only [map_one, LinearMap.one_apply, mul_one, sub_self, zero_add] using this
+  simpa only [map_one, Module.End.one_apply, mul_one, sub_self, zero_add] using this
 
 @[simp] theorem oneCocycles_map_inv (f : oneCocycles A) (g : G) :
     A.ρ g (f g⁻¹) = - f g := by
@@ -337,7 +337,7 @@ theorem mem_twoCocycles_iff (f : G × G → A) :
 theorem twoCocycles_map_one_fst (f : twoCocycles A) (g : G) :
     f (1, g) = f (1, 1) := by
   have := ((mem_twoCocycles_iff f).1 f.2 1 1 g).symm
-  simpa only [map_one, LinearMap.one_apply, one_mul, add_right_inj, this]
+  simpa only [map_one, Module.End.one_apply, one_mul, add_right_inj, this]
 
 theorem twoCocycles_map_one_snd (f : twoCocycles A) (g : G) :
     f (g, 1) = A.ρ g (f (1, 1)) := by

--- a/Mathlib/RepresentationTheory/GroupCohomology/Resolution.lean
+++ b/Mathlib/RepresentationTheory/GroupCohomology/Resolution.lean
@@ -336,7 +336,7 @@ theorem diagonalHomEquiv_symm_apply (f : (Fin n → G) → A) (x : Fin (n + 1) �
     erw [TensorProduct.uncurry_apply, Finsupp.lift_apply, Finsupp.sum_single_index]
     · simp only [one_smul]
       erw [Representation.linHom_apply]
-      simp only [LinearMap.comp_apply, MonoidHom.one_apply, LinearMap.one_apply]
+      simp only [LinearMap.comp_apply, MonoidHom.one_apply, Module.End.one_apply]
       erw [Finsupp.llift_apply]
       rw [Finsupp.lift_apply]
       erw [Finsupp.sum_single_index]
@@ -352,7 +352,7 @@ theorem diagonalHomEquiv_symm_partialProd_succ (f : (Fin n → G) → A) (g : Fi
     ((diagonalHomEquiv n A).symm f).hom (Finsupp.single (Fin.partialProd g ∘ a.succ.succAbove) 1)
       = f (Fin.contractNth a (· * ·) g) := by
   simp only [diagonalHomEquiv_symm_apply, Function.comp_apply, Fin.succ_succAbove_zero,
-    Fin.partialProd_zero, map_one, Fin.succ_succAbove_succ, LinearMap.one_apply,
+    Fin.partialProd_zero, map_one, Fin.succ_succAbove_succ, Module.End.one_apply,
     Fin.partialProd_succ]
   congr
   ext

--- a/Mathlib/RepresentationTheory/Invariants.lean
+++ b/Mathlib/RepresentationTheory/Invariants.lean
@@ -96,7 +96,7 @@ noncomputable def averageMap : V →ₗ[k] V :=
 /-- The `averageMap` sends elements of `V` to the subspace of invariants.
 -/
 theorem averageMap_invariant (v : V) : averageMap ρ v ∈ invariants ρ := fun g => by
-  rw [averageMap, ← asAlgebraHom_single_one, ← LinearMap.mul_apply, ← map_mul (asAlgebraHom ρ),
+  rw [averageMap, ← asAlgebraHom_single_one, ← Module.End.mul_apply, ← map_mul (asAlgebraHom ρ),
     mul_average_left]
 
 /-- The `averageMap` acts as the identity on the subspace of invariants.

--- a/Mathlib/RepresentationTheory/Rep.lean
+++ b/Mathlib/RepresentationTheory/Rep.lean
@@ -89,12 +89,12 @@ lemma ofHom_ρ {X : Rep k G} (g : G) : ModuleCat.ofHom (X.ρ g) = Action.ρ X g 
 @[simp]
 theorem ρ_inv_self_apply {G : Type u} [Group G] (A : Rep k G) (g : G) (x : A) :
     A.ρ g⁻¹ (A.ρ g x) = x :=
-  show (A.ρ g⁻¹ * A.ρ g) x = x by rw [← map_mul, inv_mul_cancel, map_one, LinearMap.one_apply]
+  show (A.ρ g⁻¹ * A.ρ g) x = x by rw [← map_mul, inv_mul_cancel, map_one, Module.End.one_apply]
 
 @[simp]
 theorem ρ_self_inv_apply {G : Type u} [Group G] {A : Rep k G} (g : G) (x : A) :
     A.ρ g (A.ρ g⁻¹ x) = x :=
-  show (A.ρ g * A.ρ g⁻¹) x = x by rw [← map_mul, mul_inv_cancel, map_one, LinearMap.one_apply]
+  show (A.ρ g * A.ρ g⁻¹) x = x by rw [← map_mul, mul_inv_cancel, map_one, Module.End.one_apply]
 
 theorem hom_comm_apply {A B : Rep k G} (f : A ⟶ B) (g : G) (x : A) :
     f.hom (A.ρ g x) = B.ρ g (f.hom x) :=

--- a/Mathlib/RingTheory/Artinian/Module.lean
+++ b/Mathlib/RingTheory/Artinian/Module.lean
@@ -177,8 +177,8 @@ theorem surjective_of_injective_endomorphism (f : M →ₗ[R] M) (s : Injective 
   rw [IsArtinian, WellFoundedLT, isWellFounded_iff]
   refine (RelEmbedding.natGT (LinearMap.range <| f ^ ·) ?_).not_wellFounded_of_decreasing_seq
   intro n
-  simp_rw [pow_succ, LinearMap.mul_eq_comp, LinearMap.range_comp, ← Submodule.map_top (f ^ n)]
-  refine Submodule.map_strictMono_of_injective (LinearMap.iterate_injective s n) (Ne.lt_top ?_)
+  simp_rw [pow_succ, Module.End.mul_eq_comp, LinearMap.range_comp, ← Submodule.map_top (f ^ n)]
+  refine Submodule.map_strictMono_of_injective (Module.End.iterate_injective s n) (Ne.lt_top ?_)
   rwa [Ne, LinearMap.range_eq_top]
 
 /-- Any injective endomorphism of an Artinian module is bijective. -/
@@ -303,7 +303,7 @@ variable [IsArtinian R M]
 
 /-- For any endomorphism of an Artinian module, any sufficiently high iterate has codisjoint kernel
 and range. -/
-theorem eventually_codisjoint_ker_pow_range_pow (f : M →ₗ[R] M) :
+theorem eventually_codisjoint_ker_pow_range_pow (f : Module.End R M) :
     ∀ᶠ n in atTop, Codisjoint (LinearMap.ker (f ^ n)) (LinearMap.range (f ^ n)) := by
   obtain ⟨n, hn : ∀ m, n ≤ m → LinearMap.range (f ^ n) = LinearMap.range (f ^ m)⟩ :=
     IsArtinian.monotone_stabilizes f.iterateRange
@@ -320,7 +320,7 @@ theorem eventually_codisjoint_ker_pow_range_pow (f : M →ₗ[R] M) :
 /-- This is the Fitting decomposition of the module `M` with respect to the endomorphism `f`.
 
 See also `LinearMap.isCompl_iSup_ker_pow_iInf_range_pow` for an alternative spelling. -/
-theorem eventually_isCompl_ker_pow_range_pow [IsNoetherian R M] (f : M →ₗ[R] M) :
+theorem eventually_isCompl_ker_pow_range_pow [IsNoetherian R M] (f : Module.End R M) :
     ∀ᶠ n in atTop, IsCompl (LinearMap.ker (f ^ n)) (LinearMap.range (f ^ n)) := by
   filter_upwards [f.eventually_disjoint_ker_pow_range_pow.and
     f.eventually_codisjoint_ker_pow_range_pow] with n hn

--- a/Mathlib/RingTheory/CotangentLocalizationAway.lean
+++ b/Mathlib/RingTheory/CotangentLocalizationAway.lean
@@ -138,7 +138,7 @@ lemma liftBaseChange_injective_of_isLocalizationAway :
   apply sq_ker_comp_le_ker_compLocalizationAwayAlgHom
   simpa only [LinearEquiv.coe_coe, LinearMap.ringLmapEquivSelf_symm_apply,
     mk_apply, lift.tmul, LinearMap.coe_restrictScalars, LinearMap.coe_smulRight,
-    LinearMap.one_apply, LinearMap.smul_apply, one_smul, Algebra.Extension.Cotangent.map_mk,
+    Module.End.one_apply, LinearMap.smul_apply, one_smul, Algebra.Extension.Cotangent.map_mk,
     Extension.Cotangent.mk_eq_zero_iff] using hx
 
 end Algebra.Generators

--- a/Mathlib/RingTheory/Derivation/Lie.lean
+++ b/Mathlib/RingTheory/Derivation/Lie.lean
@@ -29,7 +29,7 @@ section LieStructures
 instance : Bracket (Derivation R A A) (Derivation R A A) :=
   ⟨fun D1 D2 =>
     mk' ⁅(D1 : Module.End R A), (D2 : Module.End R A)⁆ fun a b => by
-      simp only [Ring.lie_def, map_add, Algebra.id.smul_eq_mul, LinearMap.mul_apply, leibniz,
+      simp only [Ring.lie_def, map_add, Algebra.id.smul_eq_mul, Module.End.mul_apply, leibniz,
         coeFn_coe, LinearMap.sub_apply]
       ring⟩
 

--- a/Mathlib/RingTheory/Finiteness/Nilpotent.lean
+++ b/Mathlib/RingTheory/Finiteness/Nilpotent.lean
@@ -11,11 +11,7 @@ import Mathlib.RingTheory.Nilpotent.Defs
 
 -/
 
-namespace Module
-
 variable {R M : Type*} [CommSemiring R] [AddCommMonoid M] [Module R M]
-
-namespace Finite
 
 theorem Module.End.isNilpotent_iff_of_finite [Module.Finite R M] {f : End R M} :
     IsNilpotent f ↔ ∀ m : M, ∃ n : ℕ, (f ^ n) m = 0 := by
@@ -26,11 +22,7 @@ theorem Module.End.isNilpotent_iff_of_finite [Module.Finite R M] {f : End R M} :
   ext m
   have hm : m ∈ Submodule.span R S := by simp [hS]
   induction hm using Submodule.span_induction with
-  | mem x hx => exact LinearMap.pow_map_zero_of_le (Finset.le_sup hx) (hg x)
+  | mem x hx => exact pow_map_zero_of_le (Finset.le_sup hx) (hg x)
   | zero => simp
   | add => simp_all
   | smul => simp_all
-
-end Finite
-
-end Module

--- a/Mathlib/RingTheory/IsTensorProduct.lean
+++ b/Mathlib/RingTheory/IsTensorProduct.lean
@@ -223,7 +223,7 @@ noncomputable nonrec def IsBaseChange.equiv : S ⊗[R] M ≃ₗ[S] N :=
       · rw [smul_zero, map_zero, smul_zero]
       · intro x y
         -- Porting note (https://github.com/leanprover-community/mathlib4/issues/10745): was simp [smul_tmul', Algebra.ofId_apply]
-        simp only [Algebra.linearMap_apply, lift.tmul, smul_eq_mul, LinearMap.mul_apply,
+        simp only [Algebra.linearMap_apply, lift.tmul, smul_eq_mul, Module.End.mul_apply,
           LinearMap.smul_apply, IsTensorProduct.equiv_apply, Module.algebraMap_end_apply, map_mul,
           smul_tmul', eq_self_iff_true, LinearMap.coe_restrictScalars, LinearMap.flip_apply]
       · intro x y hx hy

--- a/Mathlib/RingTheory/Kaehler/TensorProduct.lean
+++ b/Mathlib/RingTheory/Kaehler/TensorProduct.lean
@@ -95,7 +95,7 @@ instance [Algebra.IsPushout R S A B] :
   show (Algebra.pushoutDesc B (Algebra.lsmul R (A := S) S (S ⊗[R] Ω[A⁄R]))
     (Algebra.lsmul R (A := A) _ _) (LinearMap.ext <| smul_comm · ·)
       (algebraMap A B r)) • x = r • x
-  simp only [Algebra.pushoutDesc_right, LinearMap.smul_def, Algebra.lsmul_coe]
+  simp only [Algebra.pushoutDesc_right, Module.End.smul_def, Algebra.lsmul_coe]
 
 instance [Algebra.IsPushout R S A B] :
     IsScalarTower S B (S ⊗[R] Ω[A⁄R]) := by
@@ -104,7 +104,7 @@ instance [Algebra.IsPushout R S A B] :
   show (Algebra.pushoutDesc B (Algebra.lsmul R (A := S) S (S ⊗[R] Ω[A⁄R]))
     (Algebra.lsmul R (A := A) _ _) (LinearMap.ext <| smul_comm · ·)
       (algebraMap S B r)) • x = r • x
-  simp only [Algebra.pushoutDesc_left, LinearMap.smul_def, Algebra.lsmul_coe]
+  simp only [Algebra.pushoutDesc_left, Module.End.smul_def, Algebra.lsmul_coe]
 
 lemma map_liftBaseChange_smul [h : Algebra.IsPushout R S A B] (b : B) (x) :
     ((map R S A B).restrictScalars R).liftBaseChange S (b • x) =

--- a/Mathlib/RingTheory/LocalProperties/Projective.lean
+++ b/Mathlib/RingTheory/LocalProperties/Projective.lean
@@ -88,7 +88,7 @@ theorem LinearMap.split_surjective_of_localization_maximal
       obtain ⟨a, ha, c, rfl⟩ := hf
       obtain ⟨g, rfl⟩ := ha
       use IsLocalizedModule.mk' (LocalizedModule.map I.primeCompl) g c
-      apply ((Module.End_isUnit_iff _).mp <| IsLocalizedModule.map_units
+      apply ((Module.End.isUnit_iff _).mp <| IsLocalizedModule.map_units
         (LocalizedModule.map I.primeCompl) c).injective
       dsimp
       conv_rhs => rw [← Submonoid.smul_def]
@@ -106,7 +106,7 @@ theorem LinearMap.split_surjective_of_localization_maximal
         IsLocalizedModule.mk'_surjective I.primeCompl (LocalizedModule.map I.primeCompl) g
       simp only [Function.uncurry_apply_pair, Submodule.restrictScalars_mem]
       refine ⟨f.comp g, ⟨g, rfl⟩, s, ?_⟩
-      apply ((Module.End_isUnit_iff _).mp <| IsLocalizedModule.map_units
+      apply ((Module.End.isUnit_iff _).mp <| IsLocalizedModule.map_units
          (LocalizedModule.map I.primeCompl) s).injective
       simp only [Module.algebraMap_end_apply, ← Submonoid.smul_def, IsLocalizedModule.mk'_cancel',
         ← LinearMap.map_smul_of_tower]
@@ -166,7 +166,7 @@ theorem Module.projective_of_localization_maximal'
       map_smul' := ?_ }
   · intros r m
     obtain ⟨r, s, rfl⟩ := IsLocalization.mk'_surjective P.primeCompl r
-    apply ((Module.End_isUnit_iff _).mp
+    apply ((Module.End.isUnit_iff _).mp
       (IsLocalizedModule.map_units (LocalizedModule.mkLinearMap P.primeCompl M) s)).1
     dsimp
     simp only [← map_smul, ← smul_assoc, IsLocalization.smul_mk'_self, algebraMap_smul,

--- a/Mathlib/RingTheory/Localization/Algebra.lean
+++ b/Mathlib/RingTheory/Localization/Algebra.lean
@@ -38,7 +38,7 @@ variable (M S) in
 instance Algebra.idealMap_isLocalizedModule (I : Ideal R) :
     IsLocalizedModule M (Algebra.idealMap I (S := S)) where
   map_units x :=
-    (Module.End_isUnit_iff _).mpr ⟨fun a b e ↦ Subtype.ext ((map_units S x).mul_right_injective
+    (Module.End.isUnit_iff _).mpr ⟨fun a b e ↦ Subtype.ext ((map_units S x).mul_right_injective
       (by simpa [Algebra.smul_def] using congr(($e).1))),
       fun a ↦ ⟨⟨_, Ideal.mul_mem_left _ (map_units S x).unit⁻¹.1 a.2⟩,
         Subtype.ext (by simp [Algebra.smul_def, ← mul_assoc])⟩⟩

--- a/Mathlib/RingTheory/Nilpotent/Exp.lean
+++ b/Mathlib/RingTheory/Nilpotent/Exp.lean
@@ -220,7 +220,7 @@ theorem commute_exp_left_of_commute
   replace hfM : fM ^ kl = 0 := pow_eq_zero_of_le (by omega) hfM
   replace hfN : fN ^ kl = 0 := pow_eq_zero_of_le (by omega) hfN
   have (i : ℕ) : (fN ^ i) (g m) = g ((fM ^ i) m) := by
-    simpa using LinearMap.congr_fun (LinearMap.commute_pow_left_of_commute h i) m
+    simpa using LinearMap.congr_fun (Module.End.commute_pow_left_of_commute h i) m
   simp [exp_eq_sum hfM, exp_eq_sum hfN, this, map_rat_smul]
 
 theorem exp_mul_of_derivation (R B : Type*) [CommRing R] [NonUnitalNonAssocRing B]

--- a/Mathlib/RingTheory/Nilpotent/Lemmas.lean
+++ b/Mathlib/RingTheory/Nilpotent/Lemmas.lean
@@ -107,7 +107,7 @@ lemma isNilpotent_restrict_of_le {f : End R M} {p q : Submodule R M}
   ext ⟨x, hx⟩
   replace hn := DFunLike.congr_fun hn ⟨x, h hx⟩
   simp_rw [LinearMap.zero_apply, ZeroMemClass.coe_zero, ZeroMemClass.coe_eq_zero] at hn ⊢
-  rw [LinearMap.pow_restrict, LinearMap.restrict_apply] at hn ⊢
+  rw [Module.End.pow_restrict, LinearMap.restrict_apply] at hn ⊢
   ext
   exact (congr_arg Subtype.val hn :)
 
@@ -115,7 +115,7 @@ lemma isNilpotent.restrict
     {f : M →ₗ[R] M} {p : Submodule R M} (hf : MapsTo f p p) (hnil : IsNilpotent f) :
     IsNilpotent (f.restrict hf) := by
   obtain ⟨n, hn⟩ := hnil
-  exact ⟨n, LinearMap.ext fun m ↦ by simp only [LinearMap.pow_restrict n, hn,
+  exact ⟨n, LinearMap.ext fun m ↦ by simp only [Module.End.pow_restrict n, hn,
     LinearMap.restrict_apply, LinearMap.zero_apply]; rfl⟩
 
 end

--- a/Mathlib/RingTheory/Noetherian/Defs.lean
+++ b/Mathlib/RingTheory/Noetherian/Defs.lean
@@ -167,14 +167,14 @@ variable [IsNoetherian R M]
 open Filter
 /-- For an endomorphism of a Noetherian module, any sufficiently large iterate has disjoint kernel
 and range. -/
-theorem LinearMap.eventually_disjoint_ker_pow_range_pow (f : M →ₗ[R] M) :
+theorem Module.End.eventually_disjoint_ker_pow_range_pow (f : End R M) :
     ∀ᶠ n in atTop, Disjoint (LinearMap.ker (f ^ n)) (LinearMap.range (f ^ n)) := by
   obtain ⟨n, hn : ∀ m, n ≤ m → LinearMap.ker (f ^ n) = LinearMap.ker (f ^ m)⟩ :=
     monotone_stabilizes_iff_noetherian.mpr inferInstance f.iterateKer
   refine eventually_atTop.mpr ⟨n, fun m hm ↦ disjoint_iff.mpr ?_⟩
   rw [← hn _ hm, Submodule.eq_bot_iff]
   rintro - ⟨hx, ⟨x, rfl⟩⟩
-  apply LinearMap.pow_map_zero_of_le hm
+  apply pow_map_zero_of_le hm
   replace hx : x ∈ LinearMap.ker (f ^ (n + m)) := by
     simpa [f.pow_apply n, f.pow_apply m, ← f.pow_apply (n + m), ← iterate_add_apply] using hx
   rwa [← hn _ (n.le_add_right m)] at hx

--- a/Mathlib/RingTheory/Polynomial/Basic.lean
+++ b/Mathlib/RingTheory/Polynomial/Basic.lean
@@ -926,9 +926,9 @@ theorem sup_aeval_range_eq_top_of_isCoprime (f : M →ₗ[R] M) {p q : R[X]} (hp
   rw [Submodule.mem_sup]
   rcases hpq with ⟨p', q', hpq'⟩
   use aeval f (p * p') v
-  use LinearMap.mem_range.2 ⟨aeval f p' v, by simp only [LinearMap.mul_apply, aeval_mul]⟩
+  use LinearMap.mem_range.2 ⟨aeval f p' v, by simp only [Module.End.mul_apply, aeval_mul]⟩
   use aeval f (q * q') v
-  use LinearMap.mem_range.2 ⟨aeval f q' v, by simp only [LinearMap.mul_apply, aeval_mul]⟩
+  use LinearMap.mem_range.2 ⟨aeval f q' v, by simp only [Module.End.mul_apply, aeval_mul]⟩
   simpa only [mul_comm p p', mul_comm q q', aeval_one, aeval_add] using
     congr_arg (fun p : R[X] => aeval f p v) hpq'
 
@@ -940,9 +940,9 @@ theorem sup_ker_aeval_le_ker_aeval_mul {f : M →ₗ[R] M} {p q : R[X]} :
   intro v hv
   rcases Submodule.mem_sup.1 hv with ⟨x, hx, y, hy, hxy⟩
   have h_eval_x : aeval f (p * q) x = 0 := by
-    rw [mul_comm, aeval_mul, LinearMap.mul_apply, LinearMap.mem_ker.1 hx, LinearMap.map_zero]
+    rw [mul_comm, aeval_mul, Module.End.mul_apply, LinearMap.mem_ker.1 hx, LinearMap.map_zero]
   have h_eval_y : aeval f (p * q) y = 0 := by
-    rw [aeval_mul, LinearMap.mul_apply, LinearMap.mem_ker.1 hy, LinearMap.map_zero]
+    rw [aeval_mul, Module.End.mul_apply, LinearMap.mem_ker.1 hy, LinearMap.map_zero]
   rw [LinearMap.mem_ker, ← hxy, LinearMap.map_add, h_eval_x, h_eval_y, add_zero]
 
 theorem sup_ker_aeval_eq_ker_aeval_mul_of_coprime (f : M →ₗ[R] M) {p q : R[X]}
@@ -956,12 +956,12 @@ theorem sup_ker_aeval_eq_ker_aeval_mul_of_coprime (f : M →ₗ[R] M) {p q : R[X
     calc
       aeval f (q * (p * p')) v = aeval f (p' * (p * q)) v := by
         rw [mul_comm, mul_assoc, mul_comm, mul_assoc, mul_comm q p]
-      _ = 0 := by rw [aeval_mul, LinearMap.mul_apply, LinearMap.mem_ker.1 hv, LinearMap.map_zero]
+      _ = 0 := by rw [aeval_mul, Module.End.mul_apply, LinearMap.mem_ker.1 hv, LinearMap.map_zero]
 
   have h_eval₂_pqq' :=
     calc
       aeval f (p * (q * q')) v = aeval f (q' * (p * q)) v := by rw [← mul_assoc, mul_comm]
-      _ = 0 := by rw [aeval_mul, LinearMap.mul_apply, LinearMap.mem_ker.1 hv, LinearMap.map_zero]
+      _ = 0 := by rw [aeval_mul, Module.End.mul_apply, LinearMap.mem_ker.1 hv, LinearMap.map_zero]
 
   rw [aeval_mul] at h_eval₂_qpp' h_eval₂_pqq'
   refine

--- a/Mathlib/RingTheory/Polynomial/Bernstein.lean
+++ b/Mathlib/RingTheory/Polynomial/Bernstein.lean
@@ -239,7 +239,7 @@ theorem linearIndependent_aux (n k : ℕ) (h : k ≤ n + 1) :
       simp only [not_exists, not_and, Submodule.mem_map, Submodule.span_image _]
       intro p m
       apply_fun Polynomial.eval (1 : ℚ)
-      simp only [LinearMap.pow_apply]
+      simp only [Module.End.pow_apply]
       -- The right hand side is nonzero,
       -- so it will suffice to show the left hand side is always zero.
       suffices (Polynomial.derivative^[n - k] p).eval 1 = 0 by

--- a/Mathlib/RingTheory/SimpleModule/Basic.lean
+++ b/Mathlib/RingTheory/SimpleModule/Basic.lean
@@ -430,9 +430,8 @@ theorem isCoatom_ker_of_surjective [IsSimpleModule R N] {f : M →ₗ[R] N}
   exact IsSimpleModule.congr (f.quotKerEquivOfSurjective hf)
 
 /-- Schur's Lemma makes the endomorphism ring of a simple module a division ring. -/
-noncomputable instance _root_.Module.End.divisionRing
+noncomputable instance _root_.Module.End.instDivisionRing
     [DecidableEq (Module.End R M)] [IsSimpleModule R M] : DivisionRing (Module.End R M) where
-  __ := Module.End.ring
   inv f := if h : f = 0 then 0 else (LinearEquiv.ofBijective _ <| bijective_of_ne_zero h).symm
   exists_pair_ne := ⟨0, 1, have := IsSimpleModule.nontrivial R M; zero_ne_one⟩
   mul_inv_cancel a a0 := by

--- a/Mathlib/RingTheory/Spectrum/Prime/FreeLocus.lean
+++ b/Mathlib/RingTheory/Spectrum/Prime/FreeLocus.lean
@@ -59,7 +59,7 @@ lemma mem_freeLocus_of_isLocalization (p : PrimeSpectrum R)
   refine { __ := IsLocalizedModule.iso p.asIdeal.primeCompl f, map_smul' := ?_ }
   intro r x
   obtain ⟨r, s, rfl⟩ := IsLocalization.mk'_surjective p.asIdeal.primeCompl r
-  apply ((Module.End_isUnit_iff _).mp (IsLocalizedModule.map_units f s)).1
+  apply ((Module.End.isUnit_iff _).mp (IsLocalizedModule.map_units f s)).1
   simp only [AddHom.toFun_eq_coe, LinearMap.coe_toAddHom, LinearEquiv.coe_coe,
     algebraMap_end_apply, AlgEquiv.toRingEquiv_eq_coe,
     AlgEquiv.toRingEquiv_toRingHom, RingHom.coe_coe, IsLocalization.algEquiv_apply,

--- a/Mathlib/RingTheory/TensorProduct/Basic.lean
+++ b/Mathlib/RingTheory/TensorProduct/Basic.lean
@@ -1307,7 +1307,7 @@ def tensorProductEnd : A ⊗[R] (End R M) →ₐ[A] End A (A ⊗[R] M) :=
     (fun a b f g ↦ by
       apply LinearMap.ext
       intro x
-      simp only [tensorProduct, mul_comm a b, mul_eq_comp,
+      simp only [tensorProduct, mul_comm a b, Module.End.mul_eq_comp,
         TensorProduct.AlgebraTensorModule.lift_apply, TensorProduct.lift.tmul, coe_restrictScalars,
         coe_mk, AddHom.coe_mk, mul_smul, smul_apply, baseChangeHom_apply, baseChange_comp,
         comp_apply, Algebra.mul_smul_comm, Algebra.smul_mul_assoc])
@@ -1316,8 +1316,8 @@ def tensorProductEnd : A ⊗[R] (End R M) →ₐ[A] End A (A ⊗[R] M) :=
       intro x
       simp only [tensorProduct, TensorProduct.AlgebraTensorModule.lift_apply,
         TensorProduct.lift.tmul, coe_restrictScalars, coe_mk, AddHom.coe_mk, one_smul,
-        baseChangeHom_apply, baseChange_eq_ltensor, one_apply, one_eq_id, lTensor_id,
-        LinearMap.id_apply])
+        baseChangeHom_apply, baseChange_eq_ltensor, Module.End.one_apply, Module.End.one_eq_id,
+        lTensor_id, LinearMap.id_apply])
 
 end LinearMap
 


### PR DESCRIPTION
No deprecations, since they would clash across namespaces.

From Toric


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
