### PR TITLE
[Merged by Bors] - feat: minimality with respect to a function

### DIFF
--- a/Mathlib/Order/Defs/Unbundled.lean
+++ b/Mathlib/Order/Defs/Unbundled.lean
@@ -246,18 +246,18 @@ section LE
 variable {ι : Sort*} {α : Type*} [LE α] {P : ι → Prop} {f : ι → α} {i j : ι}
 
 /-- `Minimal P i` means that `i` is an element with minimal image along `f` satisfying `P`. -/
-def MinimalWrt (P : ι → Prop) (f : ι → α) (i : ι) : Prop := P i ∧ ∀ ⦃j⦄, P j → f j ≤ f i → f i ≤ f j
+def MinimalFor (P : ι → Prop) (f : ι → α) (i : ι) : Prop := P i ∧ ∀ ⦃j⦄, P j → f j ≤ f i → f i ≤ f j
 
 /-- `Maximal P i` means that `i` is an element with minimal image along `f` satisfying `P`. -/
-def MaximalWrt (P : ι → Prop) (f : ι → α) (i : ι) : Prop := P i ∧ ∀ ⦃j⦄, P j → f i ≤ f j → f j ≤ f i
+def MaximalFor (P : ι → Prop) (f : ι → α) (i : ι) : Prop := P i ∧ ∀ ⦃j⦄, P j → f i ≤ f j → f j ≤ f i
 
-lemma MinimalWrt.prop (h : MinimalWrt P f i) : P i := h.1
-lemma MaximalWrt.prop (h : MaximalWrt P f i) : P i := h.1
+lemma MinimalFor.prop (h : MinimalFor P f i) : P i := h.1
+lemma MaximalFor.prop (h : MaximalFor P f i) : P i := h.1
 
-lemma MinimalWrt.le_of_le (h : MinimalWrt P f i) (hj : P j) (hji : f j ≤ f i) : f i ≤ f j :=
+lemma MinimalFor.le_of_le (h : MinimalFor P f i) (hj : P j) (hji : f j ≤ f i) : f i ≤ f j :=
   h.2 hj hji
 
-lemma MaximalWrt.le_of_le (h : MaximalWrt P f i) (hj : P j) (hij : f i ≤ f j) : f j ≤ f i :=
+lemma MaximalFor.le_of_le (h : MaximalFor P f i) (hj : P j) (hij : f i ≤ f j) : f j ≤ f i :=
   h.2 hj hij
 
 end LE

--- a/Mathlib/Order/Defs/Unbundled.lean
+++ b/Mathlib/Order/Defs/Unbundled.lean
@@ -242,6 +242,26 @@ lemma Maximal.le_of_ge (h : Maximal P x) (hy : P y) (hge : x ≤ y) : y ≤ x :=
 
 end LE
 
+section LE
+variable {ι : Sort*} {α : Type*} [LE α] {P : ι → Prop} {f : ι → α} {i j : ι}
+
+/-- `Minimal P i` means that `i` is an element with minimal image along `f` satisfying `P`. -/
+def MinimalWrt (P : ι → Prop) (f : ι → α) (i : ι) : Prop := P i ∧ ∀ ⦃j⦄, P j → f j ≤ f i → f i ≤ f j
+
+/-- `Maximal P i` means that `i` is an element with minimal image along `f` satisfying `P`. -/
+def MaximalWrt (P : ι → Prop) (f : ι → α) (i : ι) : Prop := P i ∧ ∀ ⦃j⦄, P j → f i ≤ f j → f j ≤ f i
+
+lemma MinimalWrt.prop (h : MinimalWrt P f i) : P i := h.1
+lemma MaximalWrt.prop (h : MaximalWrt P f i) : P i := h.1
+
+lemma MinimalWrt.le_of_le (h : MinimalWrt P f i) (hj : P j) (hji : f j ≤ f i) : f i ≤ f j :=
+  h.2 hj hji
+
+lemma MaximalWrt.le_of_le (h : MaximalWrt P f i) (hj : P j) (hij : f i ≤ f j) : f j ≤ f i :=
+  h.2 hj hij
+
+end LE
+
 /-! ### Upper and lower sets -/
 
 /-- An upper set in an order `α` is a set such that any element greater than one of its members is

--- a/Mathlib/Order/Minimal.lean
+++ b/Mathlib/Order/Minimal.lean
@@ -34,7 +34,7 @@ but it may be worth re-examining this to make it easier in the future; see the T
 * `Finset` versions of the lemmas about sets.
 
 * API to allow for easily expressing min/maximality with respect to an arbitrary non-`LE` relation.
-
+* API for `MinimalFor`/`MaximalFor`
 -/
 
 assert_not_exists CompleteLattice


### PR DESCRIPTION
Introduce `MinimalFor`/`MaximalFor`, which generalise `Minimal` and `Maximal` to the case where the predicate `P : ι → Prop` doesn't have an ordered domain, but where instead we have a function `f : ι → α` to an order. Typical examples include extremal properties of graphs, such as `Simple.IsTuran.Maximal`, where we don't just care about having a maximal clique-free graph, but we also want it to have the maximal number of edges.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
