### PR TITLE
[Merged by Bors] - chore(CategoryTheory/Equivalence): simp lemmas for co/unit naturality

### DIFF
--- a/Mathlib/CategoryTheory/Equivalence.lean
+++ b/Mathlib/CategoryTheory/Equivalence.lean
@@ -212,6 +212,16 @@ theorem inv_fun_map (e : C ≌ D) (X Y : C) (f : X ⟶ Y) :
     e.inverse.map (e.functor.map f) = e.unitInv.app X ≫ f ≫ e.unit.app Y :=
   (NatIso.naturality_1 e.unitIso f).symm
 
+@[reassoc (attr := simp)]
+theorem counit_naturality (e : C ≌ D) {X Y : D} (f : X ⟶ Y) :
+    e.functor.map (e.inverse.map f) ≫ e.counit.app Y = e.counit.app X ≫ f :=
+  e.counit.naturality f
+
+@[reassoc (attr := simp)]
+theorem unit_naturality (e : C ≌ D) {X Y : C} (f : X ⟶ Y) :
+    e.unit.app X ≫ e.inverse.map (e.functor.map f) = f ≫ e.unit.app Y :=
+  (e.unit.naturality f).symm
+
 section
 
 -- In this section we convert an arbitrary equivalence to a half-adjoint equivalence.

--- a/Mathlib/CategoryTheory/Equivalence.lean
+++ b/Mathlib/CategoryTheory/Equivalence.lean
@@ -132,18 +132,22 @@ theorem Equivalence_mk'_counitInv (functor inverse unit_iso counit_iso f) :
     (⟨functor, inverse, unit_iso, counit_iso, f⟩ : C ≌ D).counitInv = counit_iso.inv :=
   rfl
 
+@[reassoc]
 theorem counit_naturality (e : C ≌ D) {X Y : D} (f : X ⟶ Y) :
     e.functor.map (e.inverse.map f) ≫ e.counit.app Y = e.counit.app X ≫ f :=
   e.counit.naturality f
 
+@[reassoc]
 theorem unit_naturality (e : C ≌ D) {X Y : C} (f : X ⟶ Y) :
     e.unit.app X ≫ e.inverse.map (e.functor.map f) = f ≫ e.unit.app Y :=
   (e.unit.naturality f).symm
 
+@[reassoc]
 theorem counitInv_naturality (e : C ≌ D) {X Y : D} (f : X ⟶ Y) :
     e.counitInv.app X ≫ e.functor.map (e.inverse.map f) = f ≫ e.counitInv.app Y :=
   (e.counitInv.naturality f).symm
 
+@[reassoc]
 theorem unitInv_naturality (e : C ≌ D) {X Y : C} (f : X ⟶ Y) :
     e.inverse.map (e.functor.map f) ≫ e.unitInv.app Y = e.unitInv.app X ≫ f :=
   e.unitInv.naturality f

--- a/Mathlib/CategoryTheory/Equivalence.lean
+++ b/Mathlib/CategoryTheory/Equivalence.lean
@@ -132,22 +132,18 @@ theorem Equivalence_mk'_counitInv (functor inverse unit_iso counit_iso f) :
     (⟨functor, inverse, unit_iso, counit_iso, f⟩ : C ≌ D).counitInv = counit_iso.inv :=
   rfl
 
-@[reassoc (attr := local simp)]
 theorem counit_naturality (e : C ≌ D) {X Y : D} (f : X ⟶ Y) :
     e.functor.map (e.inverse.map f) ≫ e.counit.app Y = e.counit.app X ≫ f :=
   e.counit.naturality f
 
-@[reassoc (attr := local simp)]
 theorem unit_naturality (e : C ≌ D) {X Y : C} (f : X ⟶ Y) :
     e.unit.app X ≫ e.inverse.map (e.functor.map f) = f ≫ e.unit.app Y :=
   (e.unit.naturality f).symm
 
-@[reassoc (attr := local simp)]
 theorem counitInv_naturality (e : C ≌ D) {X Y : D} (f : X ⟶ Y) :
     e.counitInv.app X ≫ e.functor.map (e.inverse.map f) = f ≫ e.counitInv.app Y :=
   (e.counitInv.naturality f).symm
 
-@[reassoc (attr := local simp)]
 theorem unitInv_naturality (e : C ≌ D) {X Y : C} (f : X ⟶ Y) :
     e.inverse.map (e.functor.map f) ≫ e.unitInv.app Y = e.unitInv.app X ≫ f :=
   e.unitInv.naturality f

--- a/Mathlib/CategoryTheory/Equivalence.lean
+++ b/Mathlib/CategoryTheory/Equivalence.lean
@@ -133,6 +133,26 @@ theorem Equivalence_mk'_counitInv (functor inverse unit_iso counit_iso f) :
   rfl
 
 @[reassoc (attr := simp)]
+theorem counit_naturality (e : C ≌ D) {X Y : D} (f : X ⟶ Y) :
+    e.functor.map (e.inverse.map f) ≫ e.counit.app Y = e.counit.app X ≫ f :=
+  e.counit.naturality f
+
+@[reassoc (attr := simp)]
+theorem unit_naturality (e : C ≌ D) {X Y : C} (f : X ⟶ Y) :
+    e.unit.app X ≫ e.inverse.map (e.functor.map f) = f ≫ e.unit.app Y :=
+  (e.unit.naturality f).symm
+
+@[reassoc (attr := simp)]
+theorem counitInv_naturality (e : C ≌ D) {X Y : D} (f : X ⟶ Y) :
+    e.counitInv.app X ≫ e.functor.map (e.inverse.map f) = f ≫ e.counitInv.app Y :=
+  (e.counitInv.naturality f).symm
+
+@[reassoc (attr := simp)]
+theorem unitInv_naturality (e : C ≌ D) {X Y : C} (f : X ⟶ Y) :
+    e.inverse.map (e.functor.map f) ≫ e.unitInv.app Y = e.unitInv.app X ≫ f :=
+  e.unitInv.naturality f
+
+@[reassoc (attr := simp)]
 theorem functor_unit_comp (e : C ≌ D) (X : C) :
     e.functor.map (e.unit.app X) ≫ e.counit.app (e.functor.obj X) = 𝟙 (e.functor.obj X) :=
   e.functor_unitIso_comp X
@@ -165,23 +185,31 @@ theorem unit_inverse_comp (e : C ≌ D) (Y : D) :
   dsimp
   rw [← Iso.hom_inv_id_assoc (e.unitIso.app _) (e.inverse.map (e.functor.map _)), Iso.app_hom,
     Iso.app_inv]
-  slice_lhs 2 3 => erw [e.unit.naturality]
-  slice_lhs 1 2 => erw [e.unit.naturality]
+  slice_lhs 2 3 => rw [← e.unit_naturality]
+  slice_lhs 1 2 => rw [← e.unit_naturality]
   slice_lhs 4 4 =>
     rw [← Iso.hom_inv_id_assoc (e.inverse.mapIso (e.counitIso.app _)) (e.unitInv.app _)]
   slice_lhs 3 4 =>
-    erw [← map_comp e.inverse]
-    erw [e.counit.naturality]
-    erw [(e.counitIso.app _).hom_inv_id, map_id]
-  erw [id_comp]
-  slice_lhs 2 3 => erw [← map_comp e.inverse, e.counitIso.inv.naturality, map_comp]
-  slice_lhs 3 4 => erw [e.unitInv.naturality]
-  slice_lhs 4 5 => erw [← map_comp (e.functor ⋙ e.inverse), (e.unitIso.app _).hom_inv_id, map_id]
-  erw [id_comp]
-  slice_lhs 3 4 => erw [← e.unitInv.naturality]
+    dsimp only [Functor.mapIso_hom, Iso.app_hom]
+    rw [← map_comp e.inverse, e.counit_naturality, e.counitIso.hom_inv_id_app]
+    dsimp only [Functor.comp_obj]
+    rw [map_id]
+  dsimp only [comp_obj, id_obj]
+  rw [id_comp]
   slice_lhs 2 3 =>
-    erw [← map_comp e.inverse, ← e.counitIso.inv.naturality, (e.counitIso.app _).hom_inv_id,
-      map_id]
+    dsimp only [Functor.mapIso_inv, Iso.app_inv]
+    rw [← map_comp e.inverse, ← e.counitInv_naturality, map_comp]
+  slice_lhs 3 4 => rw [e.unitInv_naturality]
+  slice_lhs 4 5 =>
+    rw [← map_comp e.inverse, ← map_comp e.functor, e.unitIso.hom_inv_id_app]
+    dsimp only [Functor.id_obj]
+    rw [map_id, map_id]
+  dsimp only [comp_obj, id_obj]
+  rw [id_comp]
+  slice_lhs 3 4 => rw [← e.unitInv_naturality]
+  slice_lhs 2 3 =>
+    rw [← map_comp e.inverse, e.counitInv_naturality, e.counitIso.hom_inv_id_app]
+  dsimp only [Functor.comp_obj]
   simp
 
 @[reassoc (attr := simp)]
@@ -211,16 +239,6 @@ theorem fun_inv_map (e : C ≌ D) (X Y : D) (f : X ⟶ Y) :
 theorem inv_fun_map (e : C ≌ D) (X Y : C) (f : X ⟶ Y) :
     e.inverse.map (e.functor.map f) = e.unitInv.app X ≫ f ≫ e.unit.app Y :=
   (NatIso.naturality_1 e.unitIso f).symm
-
-@[reassoc (attr := simp)]
-theorem counit_naturality (e : C ≌ D) {X Y : D} (f : X ⟶ Y) :
-    e.functor.map (e.inverse.map f) ≫ e.counit.app Y = e.counit.app X ≫ f :=
-  e.counit.naturality f
-
-@[reassoc (attr := simp)]
-theorem unit_naturality (e : C ≌ D) {X Y : C} (f : X ⟶ Y) :
-    e.unit.app X ≫ e.inverse.map (e.functor.map f) = f ≫ e.unit.app Y :=
-  (e.unit.naturality f).symm
 
 section
 

--- a/Mathlib/CategoryTheory/Equivalence.lean
+++ b/Mathlib/CategoryTheory/Equivalence.lean
@@ -132,22 +132,22 @@ theorem Equivalence_mk'_counitInv (functor inverse unit_iso counit_iso f) :
     (⟨functor, inverse, unit_iso, counit_iso, f⟩ : C ≌ D).counitInv = counit_iso.inv :=
   rfl
 
-@[reassoc (attr := simp)]
+@[reassoc (attr := local simp)]
 theorem counit_naturality (e : C ≌ D) {X Y : D} (f : X ⟶ Y) :
     e.functor.map (e.inverse.map f) ≫ e.counit.app Y = e.counit.app X ≫ f :=
   e.counit.naturality f
 
-@[reassoc (attr := simp)]
+@[reassoc (attr := local simp)]
 theorem unit_naturality (e : C ≌ D) {X Y : C} (f : X ⟶ Y) :
     e.unit.app X ≫ e.inverse.map (e.functor.map f) = f ≫ e.unit.app Y :=
   (e.unit.naturality f).symm
 
-@[reassoc (attr := simp)]
+@[reassoc (attr := local simp)]
 theorem counitInv_naturality (e : C ≌ D) {X Y : D} (f : X ⟶ Y) :
     e.counitInv.app X ≫ e.functor.map (e.inverse.map f) = f ≫ e.counitInv.app Y :=
   (e.counitInv.naturality f).symm
 
-@[reassoc (attr := simp)]
+@[reassoc (attr := local simp)]
 theorem unitInv_naturality (e : C ≌ D) {X Y : C} (f : X ⟶ Y) :
     e.inverse.map (e.functor.map f) ≫ e.unitInv.app Y = e.unitInv.app X ≫ f :=
   e.unitInv.naturality f


### PR DESCRIPTION
Add simp lemmas for naturality of the co/units of an equivalence, and use them to remove some `erw's`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

Adjunction have similar lemmas. They seem useful as e.g `e.counit.naturality` have terms of the form `(𝟭 C).obj x` or `(functor ⋙ inverse).obj x` rather than `inverse.obj (functor.obj x)`, and then `simp` has a tendency to get stuck on terms like this. So in practice I found one has to introduce them using `have`, then dsimp on them before being able to rewrite using them.

Using them, I removed the 11 `erw` in `unit_inverse_comp`.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
