### PR TITLE
[Merged by Bors] - chore: remove "added `dsimp`" porting notes

### DIFF
--- a/Mathlib/RepresentationTheory/Basic.lean
+++ b/Mathlib/RepresentationTheory/Basic.lean
@@ -435,14 +435,8 @@ def linHom : Representation k G (V →ₗ[k] W) where
     { toFun := fun f => ρW g ∘ₗ f ∘ₗ ρV g⁻¹
       map_add' := fun f₁ f₂ => by simp_rw [add_comp, comp_add]
       map_smul' := fun r f => by simp_rw [RingHom.id_apply, smul_comp, comp_smul] }
-  map_one' :=
-    LinearMap.ext fun x => by
-      dsimp -- Porting note (https://github.com/leanprover-community/mathlib4/issues/11227):now needed
-      simp_rw [inv_one, map_one, one_eq_id, comp_id, id_comp]
-  map_mul' g h :=
-    LinearMap.ext fun x => by
-      dsimp -- Porting note (https://github.com/leanprover-community/mathlib4/issues/11227):now needed
-      simp_rw [mul_inv_rev, map_mul, mul_eq_comp, comp_assoc]
+  map_one' := ext fun x => by simp [one_eq_id]
+  map_mul' g h := ext fun x => by simp [mul_eq_comp, comp_assoc]
 
 @[simp]
 theorem linHom_apply (g : G) (f : V →ₗ[k] W) : (linHom ρV ρW) g f = ρW g ∘ₗ f ∘ₗ ρV g⁻¹ :=
@@ -458,14 +452,8 @@ def dual : Representation k G (Module.Dual k V) where
       map_smul' := fun r f => by
         ext
         simp only [coe_comp, Function.comp_apply, smul_apply, RingHom.id_apply] }
-  map_one' := by
-    ext
-    dsimp -- Porting note (https://github.com/leanprover-community/mathlib4/issues/11227):now needed
-    simp only [coe_comp, Function.comp_apply, map_one, inv_one, coe_mk, one_apply]
-  map_mul' g h := by
-    ext
-    dsimp -- Porting note (https://github.com/leanprover-community/mathlib4/issues/11227):now needed
-    simp only [coe_comp, Function.comp_apply, mul_inv_rev, map_mul, coe_mk, mul_apply]
+  map_one' := by ext; simp
+  map_mul' g h := by ext; simp
 
 @[simp]
 theorem dual_apply (g : G) : (dual ρV) g = Module.Dual.transpose (R := k) (ρV g⁻¹) :=

--- a/Mathlib/RingTheory/IsAdjoinRoot.lean
+++ b/Mathlib/RingTheory/IsAdjoinRoot.lean
@@ -339,9 +339,7 @@ theorem modByMonicHom_map (h : IsAdjoinRootMonic S f) (g : R[X]) :
 
 @[simp]
 theorem map_modByMonicHom (h : IsAdjoinRootMonic S f) (x : S) : h.map (h.modByMonicHom x) = x := by
-  rw [modByMonicHom, LinearMap.coe_mk]
-  dsimp -- Porting note (https://github.com/leanprover-community/mathlib4/issues/11227):added a `dsimp`
-  rw [map_modByMonic, map_repr]
+  simp [modByMonicHom, map_modByMonic, map_repr]
 
 @[simp]
 theorem modByMonicHom_root_pow (h : IsAdjoinRootMonic S f) {n : ℕ} (hdeg : n < natDegree f) :
@@ -373,12 +371,9 @@ def basis (h : IsAdjoinRootMonic S f) : Basis (Fin (natDegree f)) R S :=
         contrapose! hi
         simp only [Polynomial.toFinsupp_apply, Classical.not_not, Finsupp.mem_support_iff, Ne,
           modByMonicHom, LinearMap.coe_mk, Finset.mem_coe]
-        by_cases hx : h.toIsAdjoinRoot.repr x %ₘ f = 0
-        · simp [hx]
-        refine coeff_eq_zero_of_natDegree_lt (lt_of_lt_of_le ?_ hi)
-        dsimp -- Porting note (https://github.com/leanprover-community/mathlib4/issues/11227):added a `dsimp`
-        rw [natDegree_lt_natDegree_iff hx]
-        exact degree_modByMonic_lt _ h.Monic
+        obtain rfl | hf := eq_or_ne f 1
+        · simp
+        · exact coeff_eq_zero_of_natDegree_lt <| (natDegree_modByMonic_lt _ h.Monic hf).trans_le hi
       right_inv := fun g => by
         nontriviality R
         ext i


### PR DESCRIPTION
All relevant proofs can be golfed back.

Close #11227.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
