### PR TITLE
[Merged by Bors] - feat(Analysis/NormedSpace): ball is contractible and connected

### DIFF
--- a/Mathlib/Analysis/NormedSpace/Connected.lean
+++ b/Mathlib/Analysis/NormedSpace/Connected.lean
@@ -128,7 +128,7 @@ section Ball
 
 namespace Metric
 
-theorem ball_contracitble {x : E} {r : ℝ} (hr : 0 < r) :
+theorem ball_contractible {x : E} {r : ℝ} (hr : 0 < r) :
     ContractibleSpace (ball x r) :=
   Convex.contractibleSpace (convex_ball _ _) (by simpa)
 
@@ -140,26 +140,26 @@ theorem eball_contractible {x : E} {r : ENNReal} (hr : 0 < r) :
     exact RealTopologicalVectorSpace.contractibleSpace
   | coe r =>
     rw [emetric_ball_nnreal]
-    apply ball_contracitble
+    apply ball_contractible
     simpa using hr
 
-theorem ball_PathConnected {x : E} {r : ℝ} (hr : 0 < r) :
+theorem ball_pathConnectedSpace {x : E} {r : ℝ} (hr : 0 < r) :
     PathConnectedSpace (ball x r) :=
-  @ContractibleSpace.instPathConnectedSpace _ _ (ball_contracitble hr)
+  @ContractibleSpace.instPathConnectedSpace _ _ (ball_contractible hr)
 
-theorem eball_PathConnected {x : E} {r : ENNReal} (hr : 0 < r) :
+theorem eball_pathConnectedSpace {x : E} {r : ENNReal} (hr : 0 < r) :
     PathConnectedSpace (EMetric.ball x r) :=
   @ContractibleSpace.instPathConnectedSpace _ _ (eball_contractible hr)
 
-theorem ball_connected {x : E} {r : ℝ} (hr : 0 < r) :
+theorem isConnected_ball {x : E} {r : ℝ} (hr : 0 < r) :
     IsConnected (ball x r) := by
   rw [isConnected_iff_connectedSpace]
-  exact @PathConnectedSpace.connectedSpace _ _ (ball_PathConnected hr)
+  exact @PathConnectedSpace.connectedSpace _ _ (ball_pathConnectedSpace hr)
 
-theorem eball_connected {x : E} {r : ENNReal} (hr : 0 < r) :
+theorem isConnected_eball {x : E} {r : ENNReal} (hr : 0 < r) :
     IsConnected (EMetric.ball x r) := by
   rw [isConnected_iff_connectedSpace]
-  exact @PathConnectedSpace.connectedSpace _ _ (eball_PathConnected hr)
+  exact @PathConnectedSpace.connectedSpace _ _ (eball_pathConnectedSpace hr)
 
 end Metric
 

--- a/Mathlib/Analysis/NormedSpace/Connected.lean
+++ b/Mathlib/Analysis/NormedSpace/Connected.lean
@@ -3,7 +3,9 @@ Copyright (c) 2023 Sébastien Gouëzel. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sébastien Gouëzel
 -/
+import Mathlib.Analysis.Convex.Contractible
 import Mathlib.Analysis.Convex.Topology
+import Mathlib.Analysis.Normed.Module.Convex
 import Mathlib.LinearAlgebra.Dimension.DivisionRing
 import Mathlib.Topology.Algebra.Module.Cardinality
 
@@ -121,6 +123,47 @@ end TopologicalVectorSpace
 section NormedSpace
 
 variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
+
+section Ball
+
+namespace Metric
+
+theorem ball_contracitble {x : E} {r : ℝ} (hr : 0 < r) :
+    ContractibleSpace (ball x r) :=
+  Convex.contractibleSpace (convex_ball _ _) (by simpa)
+
+theorem eball_contractible {x : E} {r : ENNReal} (hr : 0 < r) :
+    ContractibleSpace (EMetric.ball x r) := by
+  cases r with
+  | top =>
+    rw [eball_top_eq_univ, (Homeomorph.Set.univ E).contractibleSpace_iff]
+    exact RealTopologicalVectorSpace.contractibleSpace
+  | coe r =>
+    rw [emetric_ball_nnreal]
+    apply ball_contracitble
+    simpa using hr
+
+theorem ball_PathConnected {x : E} {r : ℝ} (hr : 0 < r) :
+    PathConnectedSpace (ball x r) :=
+  @ContractibleSpace.instPathConnectedSpace _ _ (ball_contracitble hr)
+
+theorem eball_PathConnected {x : E} {r : ENNReal} (hr : 0 < r) :
+    PathConnectedSpace (EMetric.ball x r) :=
+  @ContractibleSpace.instPathConnectedSpace _ _ (eball_contractible hr)
+
+theorem ball_connected {x : E} {r : ℝ} (hr : 0 < r) :
+    IsConnected (ball x r) := by
+  rw [isConnected_iff_connectedSpace]
+  exact @PathConnectedSpace.connectedSpace _ _ (ball_PathConnected hr)
+
+theorem eball_connected {x : E} {r : ENNReal} (hr : 0 < r) :
+    IsConnected (EMetric.ball x r) := by
+  rw [isConnected_iff_connectedSpace]
+  exact @PathConnectedSpace.connectedSpace _ _ (eball_PathConnected hr)
+
+end Metric
+
+end Ball
 
 /-- In a real vector space of dimension `> 1`, any sphere of nonnegative radius is
 path connected. -/

--- a/Mathlib/Analysis/NormedSpace/Connected.lean
+++ b/Mathlib/Analysis/NormedSpace/Connected.lean
@@ -143,23 +143,23 @@ theorem eball_contractible {x : E} {r : ENNReal} (hr : 0 < r) :
     apply ball_contractible
     simpa using hr
 
-theorem ball_pathConnectedSpace {x : E} {r : ℝ} (hr : 0 < r) :
-    PathConnectedSpace (ball x r) :=
-  @ContractibleSpace.instPathConnectedSpace _ _ (ball_contractible hr)
+theorem isPathConnected_ball {x : E} {r : ℝ} (hr : 0 < r) :
+    IsPathConnected (ball x r) := by
+  rw [isPathConnected_iff_pathConnectedSpace]
+  exact @ContractibleSpace.instPathConnectedSpace _ _ (ball_contractible hr)
 
-theorem eball_pathConnectedSpace {x : E} {r : ENNReal} (hr : 0 < r) :
-    PathConnectedSpace (EMetric.ball x r) :=
-  @ContractibleSpace.instPathConnectedSpace _ _ (eball_contractible hr)
+theorem isPathConnected_eball {x : E} {r : ENNReal} (hr : 0 < r) :
+    IsPathConnected (EMetric.ball x r) := by
+  rw [isPathConnected_iff_pathConnectedSpace]
+  exact @ContractibleSpace.instPathConnectedSpace _ _ (eball_contractible hr)
 
 theorem isConnected_ball {x : E} {r : ℝ} (hr : 0 < r) :
-    IsConnected (ball x r) := by
-  rw [isConnected_iff_connectedSpace]
-  exact @PathConnectedSpace.connectedSpace _ _ (ball_pathConnectedSpace hr)
+    IsConnected (ball x r) :=
+  (isPathConnected_ball hr).isConnected
 
 theorem isConnected_eball {x : E} {r : ENNReal} (hr : 0 < r) :
-    IsConnected (EMetric.ball x r) := by
-  rw [isConnected_iff_connectedSpace]
-  exact @PathConnectedSpace.connectedSpace _ _ (eball_pathConnectedSpace hr)
+    IsConnected (EMetric.ball x r) :=
+  (isPathConnected_eball hr).isConnected
 
 end Metric
 


### PR DESCRIPTION
Prove that balls (`Metric.ball` and `EMetric.ball`) in normed spaces over reals are contractible, path-connected and connected.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
