### PR TITLE
[Merged by Bors] - feat(Algebra/Order/Group/Unbundled/Abs): `abs_ite`

### DIFF
--- a/Mathlib/Algebra/Order/Group/Unbundled/Abs.lean
+++ b/Mathlib/Algebra/Order/Group/Unbundled/Abs.lean
@@ -76,8 +76,8 @@ def abs.unexpander : Lean.PrettyPrinter.Unexpander
   apply_ite _ _ _ _
 
 @[to_additive] lemma mabs_dite (p : Prop) [Decidable p] (a : p → α) (b : ¬p → α) :
-    |if h : p then a h else b h|ₘ = if h : p then |a h|ₘ else |b h|ₘ := by
-  split_ifs <;> rfl
+    |if h : p then a h else b h|ₘ = if h : p then |a h|ₘ else |b h|ₘ :=
+  apply_dite _ _ _ _
 
 variable [MulLeftMono α]
 

--- a/Mathlib/Algebra/Order/Group/Unbundled/Abs.lean
+++ b/Mathlib/Algebra/Order/Group/Unbundled/Abs.lean
@@ -71,6 +71,14 @@ def abs.unexpander : Lean.PrettyPrinter.Unexpander
 
 @[to_additive] lemma mabs_div_comm (a b : α) : |a / b|ₘ = |b / a|ₘ := by rw [← mabs_inv, inv_div]
 
+@[to_additive] lemma mabs_ite (p : Prop) [Decidable p] :
+    |if p then a else b|ₘ = if p then |a|ₘ else |b|ₘ := by
+  split_ifs <;> rfl
+
+@[to_additive] lemma mabs_dite (p : Prop) [Decidable p] (a : p → α) (b : ¬p → α) :
+    |if h : p then a h else b h|ₘ = if h : p then |a h|ₘ else |b h|ₘ := by
+  split_ifs <;> rfl
+
 variable [MulLeftMono α]
 
 @[to_additive] lemma mabs_of_one_le (h : 1 ≤ a) : |a|ₘ = a :=

--- a/Mathlib/Algebra/Order/Group/Unbundled/Abs.lean
+++ b/Mathlib/Algebra/Order/Group/Unbundled/Abs.lean
@@ -72,8 +72,8 @@ def abs.unexpander : Lean.PrettyPrinter.Unexpander
 @[to_additive] lemma mabs_div_comm (a b : α) : |a / b|ₘ = |b / a|ₘ := by rw [← mabs_inv, inv_div]
 
 @[to_additive] lemma mabs_ite (p : Prop) [Decidable p] :
-    |if p then a else b|ₘ = if p then |a|ₘ else |b|ₘ := by
-  split_ifs <;> rfl
+    |if p then a else b|ₘ = if p then |a|ₘ else |b|ₘ :=
+  apply_ite _ _ _ _
 
 @[to_additive] lemma mabs_dite (p : Prop) [Decidable p] (a : p → α) (b : ¬p → α) :
     |if h : p then a h else b h|ₘ = if h : p then |a h|ₘ else |b h|ₘ := by


### PR DESCRIPTION
Add the trivial lemmas `abs_ite`, `abs_dite`, `mabs_ite` and `mabs_dite`.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
