### PR TITLE
[Merged by Bors] - chore: clean up Mathlib/Control/Combinators

### DIFF
--- a/Mathlib/Control/Combinators.lean
+++ b/Mathlib/Control/Combinators.lean
@@ -77,12 +77,12 @@ def sequence' {m : Type → Type u} [Monad m] {α : Type} : List (m α) → m Un
 /-- Executes `t` if `b` is `true`, doing nothing otherwise.
 
 See also `when` and `whenM`. -/
-@[deprecated "No replacement in Mathlib." (since := "2025-04-07")]
+@[deprecated "Use `if ... then` without `else` in `do` notation instead." (since := "2025-04-07")]
 def whenb {m : Type → Type} [Monad m] (b : Bool) (t : m Unit) : m Unit :=
   _root_.cond b t (return ())
 
 /-- Executes `t` if `b` is `false`, doing nothing otherwise. -/
-@[deprecated "No replacement in Mathlib." (since := "2025-04-07")]
+@[deprecated "Use `unless` in `do` notation instead." (since := "2025-04-07")]
 def unlessb {m : Type → Type} [Monad m] (b : Bool) (t : m Unit) : m Unit :=
   _root_.cond b (return ()) t
 

--- a/Mathlib/Control/Combinators.lean
+++ b/Mathlib/Control/Combinators.lean
@@ -17,7 +17,7 @@ def joinM {m : Type u → Type u} [Monad m] {α : Type u} (a : m (m α)) : m α 
   bind a id
 
 /-- Executes `t` conditional on `c` holding true, doing nothing otherwise. -/
-@[deprecated "No replacement in Mathlib; was unused when deprecated." (since := "2025-04-07")]
+@[deprecated "Use `if ... then` without `else` in `do` notation instead." (since := "2025-04-07")]
 def when {m : Type → Type} [Monad m] (c : Prop) [Decidable c] (t : m Unit) : m Unit :=
   ite c t (pure ())
 

--- a/Mathlib/Control/Combinators.lean
+++ b/Mathlib/Control/Combinators.lean
@@ -17,7 +17,7 @@ def joinM {m : Type u → Type u} [Monad m] {α : Type u} (a : m (m α)) : m α 
   bind a id
 
 /-- Executes `t` conditional on `c` holding true, doing nothing otherwise. -/
-@[deprecated "Use `if ... then` without `else` in `do` notation instead." (since := "2025-04-07")]
+@[deprecated "Use `if c then t` without `else` in `do` notation instead." (since := "2025-04-07")]
 def when {m : Type → Type} [Monad m] (c : Prop) [Decidable c] (t : m Unit) : m Unit :=
   ite c t (pure ())
 
@@ -29,7 +29,7 @@ def condM {m : Type → Type} [Monad m] {α : Type} (mbool : m Bool) (tm fm : m 
 
 set_option linter.deprecated false in
 /-- Executes `t` if `c` results in `true`, doing nothing otherwise. -/
-@[deprecated "No replacement in Mathlib; was unused when deprecated." (since := "2025-04-07")]
+@[deprecated "Use `if ← c then t` without `else` in `do` notation instead." (since := "2025-04-07")]
 def whenM {m : Type → Type} [Monad m] (c : m Bool) (t : m Unit) : m Unit :=
   condM c t (return ())
 

--- a/Mathlib/Control/Combinators.lean
+++ b/Mathlib/Control/Combinators.lean
@@ -17,6 +17,7 @@ def joinM {m : Type u → Type u} [Monad m] {α : Type u} (a : m (m α)) : m α 
   bind a id
 
 /-- Executes `t` conditional on `c` holding true, doing nothing otherwise. -/
+@[deprecated "No replacement in Mathlib; was unused when deprecated." (since := "2025-04-07")]
 def when {m : Type → Type} [Monad m] (c : Prop) [Decidable c] (t : m Unit) : m Unit :=
   ite c t (pure ())
 
@@ -26,40 +27,40 @@ def condM {m : Type → Type} [Monad m] {α : Type} (mbool : m Bool) (tm fm : m 
   let b ← mbool
   cond b tm fm
 
+set_option linter.deprecated false in
 /-- Executes `t` if `c` results in `true`, doing nothing otherwise. -/
+@[deprecated "No replacement in Mathlib; was unused when deprecated." (since := "2025-04-07")]
 def whenM {m : Type → Type} [Monad m] (c : m Bool) (t : m Unit) : m Unit :=
   condM c t (return ())
 
-
-export List (mapM mapM' filterM foldlM)
-
 namespace Monad
 
-@[inherit_doc List.mapM]
+@[deprecated List.mapM (since := "2025-04-07"), inherit_doc List.mapM]
 def mapM :=
   @List.mapM
 
-@[inherit_doc List.mapM']
+@[deprecated List.mapM' (since := "2025-04-07"), inherit_doc List.mapM']
 def mapM' :=
   @List.mapM'
 
-@[inherit_doc joinM]
+@[deprecated joinM (since := "2025-04-07"), inherit_doc joinM]
 def join :=
   @joinM
 
-@[inherit_doc List.filterM]
+@[deprecated List.filterM (since := "2025-04-07"), inherit_doc List.filterM]
 def filter :=
-  @filterM
+  @List.filterM
 
-@[inherit_doc List.foldlM]
+@[deprecated List.filterM (since := "2025-04-07"), inherit_doc List.foldlM]
 def foldl :=
-  @List.foldlM
+  @List.filterM
 
-@[inherit_doc condM]
+@[deprecated condM (since := "2025-04-07"), inherit_doc condM]
 def cond :=
   @condM
 
 /-- Executes a list of monadic actions in sequence, collecting the results. -/
+@[deprecated "Use `_root_.sequence` instead." (since := "2025-04-07")]
 def sequence {m : Type u → Type v} [Monad m] {α : Type u} : List (m α) → m (List α)
   | [] => return []
   | h :: t => do
@@ -68,6 +69,7 @@ def sequence {m : Type u → Type v} [Monad m] {α : Type u} : List (m α) → m
     return (h' :: t')
 
 /-- Executes a list of monadic actions in sequence, discarding the results. -/
+@[deprecated "Use `_root_.sequence` instead." (since := "2025-04-07")]
 def sequence' {m : Type → Type u} [Monad m] {α : Type} : List (m α) → m Unit
   | [] => return ()
   | h :: t => h *> sequence' t
@@ -75,10 +77,12 @@ def sequence' {m : Type → Type u} [Monad m] {α : Type} : List (m α) → m Un
 /-- Executes `t` if `b` is `true`, doing nothing otherwise.
 
 See also `when` and `whenM`. -/
+@[deprecated "No replacement in Mathlib." (since := "2025-04-07")]
 def whenb {m : Type → Type} [Monad m] (b : Bool) (t : m Unit) : m Unit :=
   _root_.cond b t (return ())
 
 /-- Executes `t` if `b` is `false`, doing nothing otherwise. -/
+@[deprecated "No replacement in Mathlib." (since := "2025-04-07")]
 def unlessb {m : Type → Type} [Monad m] (b : Bool) (t : m Unit) : m Unit :=
   _root_.cond b (return ()) t
 


### PR DESCRIPTION
This deprecates some unused functions from Mathlib/Control/Combinators. If there's evidence these are used by anyone downstream, I propose we ask Batteries to adopt them.