### PR TITLE
refactor(Mathlib/FieldTheory/IntermediateField): generalize IntermediateField

### DIFF
--- a/Mathlib/FieldTheory/AbelRuffini.lean
+++ b/Mathlib/FieldTheory/AbelRuffini.lean
@@ -208,7 +208,8 @@ def solvableByRad : IntermediateField F E where
     change IsSolvableByRad F 1
     convert IsSolvableByRad.base (E := E) (1 : F); rw [RingHom.map_one]
   mul_mem' := by apply IsSolvableByRad.mul
-  inv_mem' := IsSolvableByRad.inv
+  mul_comm' _ _ _ _ := mul_comm _ _
+  inv_mem' x hx hx0 := ⟨x⁻¹, IsSolvableByRad.inv _ hx, mul_inv_cancel₀ hx0⟩
   algebraMap_mem' := IsSolvableByRad.base
 
 namespace solvableByRad

--- a/Mathlib/FieldTheory/Galois/Basic.lean
+++ b/Mathlib/FieldTheory/Galois/Basic.lean
@@ -176,6 +176,8 @@ def FixedPoints.intermediateField (M : Type*) [Monoid M] [MulSemiringAction M E]
     [SMulCommClass M F E] : IntermediateField F E :=
   { FixedPoints.subfield M E with
     carrier := MulAction.fixedPoints M E
+    mul_comm' _ _ _ _ := mul_comm _ _
+    inv_mem' x hx hx0 := ⟨x⁻¹, by simpa, mul_inv_cancel₀ hx0⟩
     algebraMap_mem' := fun a g => smul_algebraMap g a }
 
 namespace IntermediateField

--- a/Mathlib/FieldTheory/Galois/GaloisClosure.lean
+++ b/Mathlib/FieldTheory/Galois/GaloisClosure.lean
@@ -90,7 +90,7 @@ instance : Lattice (FiniteGaloisIntermediateField k K) :=
 
 instance : OrderBot (FiniteGaloisIntermediateField k K) where
   bot := .mk ⊥
-  bot_le _ := bot_le (α := IntermediateField _ _)
+  bot_le _ := bot_le (α := IntermediateField k K)
 
 @[simp]
 lemma le_iff (L₁ L₂ : FiniteGaloisIntermediateField k K) :

--- a/Mathlib/FieldTheory/IntermediateField/Adjoin/Algebra.lean
+++ b/Mathlib/FieldTheory/IntermediateField/Adjoin/Algebra.lean
@@ -29,7 +29,8 @@ theorem adjoin_eq_algebra_adjoin (inv_mem : ∀ x ∈ Algebra.adjoin F S, x⁻¹
   le_antisymm
     (show adjoin F S ≤
         { Algebra.adjoin F S with
-          inv_mem' := inv_mem }
+          mul_comm' _ _ _ _ := mul_comm _ _
+          inv_mem' x hx hx0 := ⟨x⁻¹, inv_mem x hx, mul_inv_cancel₀ hx0⟩}
       from adjoin_le_iff.mpr Algebra.subset_adjoin)
     (algebra_adjoin_le_adjoin _ _)
 
@@ -39,7 +40,10 @@ theorem eq_adjoin_of_eq_algebra_adjoin (K : IntermediateField F E)
   rw [h]
   refine (adjoin_eq_algebra_adjoin F _ fun x ↦ ?_).symm
   rw [← h]
-  exact K.inv_mem
+  intro hx
+  if h : x = 0 then subst h; simp [zero_mem] else
+  rw [← inv_unique (K.3 x hx h).choose_spec.2 (mul_inv_cancel₀ h)]
+  exact K.3 x hx h|>.choose_spec.1
 
 theorem adjoin_eq_top_of_algebra (hS : Algebra.adjoin F S = ⊤) : adjoin F S = ⊤ :=
   top_le_iff.mp (hS.symm.trans_le <| algebra_adjoin_le_adjoin F S)

--- a/Mathlib/FieldTheory/IntermediateField/Adjoin/Basic.lean
+++ b/Mathlib/FieldTheory/IntermediateField/Adjoin/Basic.lean
@@ -95,8 +95,14 @@ theorem coe_iSup_of_directed [Nonempty ι] (dir : Directed (· ≤ ·) t) :
     ↑(iSup t) = ⋃ i, (t i : Set L) :=
   let M : IntermediateField K L :=
     { __ := Subalgebra.copy _ _ (Subalgebra.coe_iSup_of_directed dir).symm
-      inv_mem' := fun _ hx ↦ have ⟨i, hi⟩ := Set.mem_iUnion.mp hx
-        Set.mem_iUnion.mpr ⟨i, (t i).inv_mem hi⟩ }
+      mul_comm' _ _ _ _ := mul_comm _ _
+      inv_mem' x hx hx0 := ⟨x⁻¹, by
+        obtain ⟨i, hi⟩ := Set.mem_iUnion.mp hx
+        have : x⁻¹ ∈ (t i) := by
+          rw [inv_unique (mul_inv_cancel₀ hx0) ((t i).3 x hi hx0).choose_spec.2]
+          exact (t i).3 x hi hx0|>.choose_spec.1
+        exact Set.mem_iUnion.mpr ⟨i, this⟩, mul_inv_cancel₀ hx0⟩
+        }
   have : iSup t = M := le_antisymm
     (iSup_le fun i ↦ le_iSup (fun i ↦ (t i : Set L)) i) (Set.iUnion_subset fun _ ↦ le_iSup t _)
   this.symm ▸ rfl

--- a/Mathlib/FieldTheory/IntermediateField/Adjoin/Defs.lean
+++ b/Mathlib/FieldTheory/IntermediateField/Adjoin/Defs.lean
@@ -29,6 +29,8 @@ variable (F : Type*) [Field F] {E : Type*} [Field E] [Algebra F E] (S : Set E)
 @[stacks 09FZ "first part"]
 def adjoin : IntermediateField F E :=
   { Subfield.closure (Set.range (algebraMap F E) ∪ S) with
+    mul_comm' _ _ _ _ := mul_comm _ _
+    inv_mem' x hx hx0 := ⟨x⁻¹, Subfield.inv_mem _ hx, mul_inv_cancel₀ hx0⟩
     algebraMap_mem' := fun x => Subfield.subset_closure (Or.inl (Set.mem_range_self x)) }
 
 @[simp]
@@ -63,7 +65,9 @@ instance : CompleteLattice (IntermediateField F E) where
   __ := GaloisInsertion.liftCompleteLattice IntermediateField.gi
   bot :=
     { toSubalgebra := ⊥
-      inv_mem' := by rintro x ⟨r, rfl⟩; exact ⟨r⁻¹, map_inv₀ _ _⟩ }
+      mul_comm' _ _ _ _ := mul_comm _ _
+      inv_mem' x hx hx0 := ⟨x⁻¹, ⟨hx.choose⁻¹, by simpa using hx.choose_spec⟩,
+        mul_inv_cancel₀ hx0⟩ }
   bot_le x := (bot_le : ⊥ ≤ x.toSubalgebra)
 
 theorem sup_def (S T : IntermediateField F E) : S ⊔ T = adjoin F (S ∪ T : Set E) := rfl

--- a/Mathlib/FieldTheory/IntermediateField/Algebraic.lean
+++ b/Mathlib/FieldTheory/IntermediateField/Algebraic.lean
@@ -26,8 +26,9 @@ theorem IntermediateField.coe_isIntegral_iff {R : Type*} [CommRing R] [Algebra R
 def Subalgebra.IsAlgebraic.toIntermediateField {S : Subalgebra K L} (hS : S.IsAlgebraic) :
     IntermediateField K L where
   toSubalgebra := S
-  inv_mem' x hx := Algebra.adjoin_le_iff.mpr
-    (Set.singleton_subset_iff.mpr hx) (hS x hx).isIntegral.inv_mem_adjoin
+  mul_comm' _ _ _ _ := mul_comm _ _
+  inv_mem' x hx hx0 := ⟨x⁻¹, Algebra.adjoin_le_iff.mpr
+    (Set.singleton_subset_iff.mpr hx) (hS x hx).isIntegral.inv_mem_adjoin, mul_inv_cancel₀ hx0⟩
 
 /-- Turn an algebraic subalgebra into an intermediate field, `Algebra.IsAlgebraic` version. -/
 abbrev Algebra.IsAlgebraic.toIntermediateField (S : Subalgebra K L) [Algebra.IsAlgebraic K S] :

--- a/Mathlib/FieldTheory/IntermediateField/Basic.lean
+++ b/Mathlib/FieldTheory/IntermediateField/Basic.lean
@@ -45,8 +45,9 @@ variable (K L L' : Type*) [Field K] [Field L] [Field L'] [Algebra K L] [Algebra 
 /-- `S : IntermediateField K L` is a subset of `L` such that `S` is a field and
 `L / S / K` is a tower of ring extensions.
 
-This is a generalization of field towers: if `L` and `K` are fields, then `L / S / K` is a field tower.
- -/
+This is a generalization of field towers: if `L` and `K` are fields,
+then `L / S / K` is a field tower.
+-/
 structure IntermediateField (K L : Type*) [CommSemiring K] [Semiring L] [Algebra K L] extends
     Subalgebra K L where
   mul_comm' : ∀ x y : L, x ∈ carrier → y ∈ carrier → x * y = y * x
@@ -68,7 +69,7 @@ instance : SetLike (IntermediateField K L) L :=
 protected theorem neg_mem {x : L} (hx : x ∈ S) : -x ∈ S := by
   show -x ∈S.toSubalgebra; simpa
 
-protected theorem inv_mem (x : L) (hx : x ∈ S) : x⁻¹ ∈ S := by
+protected theorem inv_mem {x : L} (hx : x ∈ S) : x⁻¹ ∈ S := by
   if h : x = 0 then subst h; simp [*] else
   obtain ⟨y, hy1, hy2⟩ := S.3 x hx h
   suffices y = x⁻¹ by simpa [← this]
@@ -79,7 +80,12 @@ protected theorem inv_mem (x : L) (hx : x ∈ S) : x⁻¹ ∈ S := by
 def toSubfield : Subfield L :=
   { S.toSubalgebra with
     neg_mem' := S.neg_mem,
-    inv_mem' := S.inv_mem}
+    inv_mem' _ := S.inv_mem}
+
+def mkOfInv (S : Subalgebra K L) (hS : ∀ x ∈ S, x⁻¹ ∈ S): IntermediateField K L := {
+  __ := S
+  mul_comm' _ _ _ _ := mul_comm _ _
+  inv_mem' x hx hx0 := ⟨x⁻¹, hS x hx, mul_inv_cancel₀ hx0⟩ }
 
 instance : SubfieldClass (IntermediateField K L) L where
   add_mem {s} := s.add_mem'
@@ -87,7 +93,7 @@ instance : SubfieldClass (IntermediateField K L) L where
   neg_mem {s} := s.neg_mem
   mul_mem {s} := s.mul_mem'
   one_mem {s} := s.one_mem'
-  inv_mem {s} := s.inv_mem _
+  inv_mem {s} := s.inv_mem
 
 theorem mem_carrier {s : IntermediateField K L} {x : L} : x ∈ s.carrier ↔ x ∈ s :=
   Iff.rfl
@@ -266,7 +272,7 @@ theorem toSubalgebra_toIntermediateField (S : Subalgebra K L) (inv_mem : ∀ x �
 
 @[simp]
 theorem toIntermediateField_toSubalgebra (S : IntermediateField K L) :
-    (S.toSubalgebra.toIntermediateField fun _ => S.inv_mem _) = S := by
+    (S.toSubalgebra.toIntermediateField fun _ => S.inv_mem) = S := by
   ext
   rfl
 

--- a/Mathlib/FieldTheory/IntermediateField/Basic.lean
+++ b/Mathlib/FieldTheory/IntermediateField/Basic.lean
@@ -42,8 +42,11 @@ open Polynomial
 
 variable (K L L' : Type*) [Field K] [Field L] [Field L'] [Algebra K L] [Algebra K L']
 
-/-- `S : IntermediateField K L` is a subset of `L` such that there is a field
-tower `L / S / K`. -/
+/-- `S : IntermediateField K L` is a subset of `L` such that `S` is a field and
+`L / S / K` is a tower of ring extensions.
+
+This is a generalization of field towers: if `L` and `K` are fields, then `L / S / K` is a field tower.
+ -/
 structure IntermediateField (K L : Type*) [CommSemiring K] [Semiring L] [Algebra K L] extends
     Subalgebra K L where
   mul_comm' : ∀ x y : L, x ∈ carrier → y ∈ carrier → x * y = y * x

--- a/Mathlib/FieldTheory/IntermediateField/Basic.lean
+++ b/Mathlib/FieldTheory/IntermediateField/Basic.lean
@@ -82,6 +82,8 @@ def toSubfield : Subfield L :=
     neg_mem' := S.neg_mem,
     inv_mem' _ := S.inv_mem}
 
+/-- An `IntermediateField` could be make from a subalgebra `S` with an assumption that `S` is
+  closed under `inv`. -/
 def mkOfInv (S : Subalgebra K L) (hS : ∀ x ∈ S, x⁻¹ ∈ S): IntermediateField K L := {
   __ := S
   mul_comm' _ _ _ _ := mul_comm _ _

--- a/Mathlib/FieldTheory/IntermediateField/Basic.lean
+++ b/Mathlib/FieldTheory/IntermediateField/Basic.lean
@@ -180,10 +180,6 @@ protected theorem add_mem {x y : L} : x ∈ S → y ∈ S → x + y ∈ S :=
 protected theorem sub_mem {x y : L} : x ∈ S → y ∈ S → x - y ∈ S :=
   sub_mem
 
--- /-- An intermediate field is closed under inverses. -/
--- protected theorem inv_mem {x : L} : x ∈ S → x⁻¹ ∈ S :=
---   inv_mem
-
 /-- An intermediate field is closed under division. -/
 protected theorem div_mem {x y : L} : x ∈ S → y ∈ S → x / y ∈ S :=
   div_mem

--- a/Mathlib/FieldTheory/PurelyInseparable/PerfectClosure.lean
+++ b/Mathlib/FieldTheory/PurelyInseparable/PerfectClosure.lean
@@ -67,10 +67,9 @@ def perfectClosure : IntermediateField F E where
     use n + m
     rw [mul_pow, pow_add, pow_mul, mul_comm (_ ^ n), pow_mul]
     exact mul_mem (pow_mem hx _) (pow_mem hy _)
-  inv_mem' := by
-    rintro x ⟨n, hx⟩
-    use n; rw [inv_pow]
-    apply inv_mem (id hx : _ ∈ (⊥ : IntermediateField F E))
+  mul_comm' _ _ _ _ := mul_comm _ _
+  inv_mem' x hx hx0:= ⟨x⁻¹, ⟨hx.choose, ⟨hx.choose_spec.choose⁻¹, by
+    simp [hx.choose_spec.choose_spec]⟩⟩, mul_inv_cancel₀ hx0⟩
   algebraMap_mem' := fun x ↦ ⟨0, by rw [pow_zero, pow_one]; exact ⟨x, rfl⟩⟩
 
 variable {F E}

--- a/Mathlib/FieldTheory/SeparableClosure.lean
+++ b/Mathlib/FieldTheory/SeparableClosure.lean
@@ -79,7 +79,8 @@ def separableClosure : IntermediateField F E where
   mul_mem' := isSeparable_mul
   add_mem' := isSeparable_add
   algebraMap_mem' := isSeparable_algebraMap E
-  inv_mem' _ := isSeparable_inv
+  mul_comm' _ _ _ _ := mul_comm _ _
+  inv_mem' x hx hx0 := ⟨x⁻¹, isSeparable_inv hx, mul_inv_cancel₀ hx0⟩
 
 variable {F E K}
 

--- a/Mathlib/FieldTheory/SeparableDegree.lean
+++ b/Mathlib/FieldTheory/SeparableDegree.lean
@@ -891,7 +891,7 @@ theorem isSeparable_sub {x y : E} (hx : IsSeparable F x) (hy : IsSeparable F y) 
 /-- If `x` is a separable element, then `x⁻¹` is also a separable element. -/
 theorem isSeparable_inv {x : E} (hx : IsSeparable F x) : IsSeparable F x⁻¹ :=
   haveI := (isSeparable_adjoin_simple_iff_isSeparable F E).2 hx
-  isSeparable_of_mem_isSeparable F E <| F⟮x⟯.inv_mem <| mem_adjoin_simple_self F x
+  isSeparable_of_mem_isSeparable F E <| F⟮x⟯.inv_mem _ <| mem_adjoin_simple_self F x
 
 end Field
 

--- a/Mathlib/FieldTheory/SeparableDegree.lean
+++ b/Mathlib/FieldTheory/SeparableDegree.lean
@@ -891,7 +891,7 @@ theorem isSeparable_sub {x y : E} (hx : IsSeparable F x) (hy : IsSeparable F y) 
 /-- If `x` is a separable element, then `x⁻¹` is also a separable element. -/
 theorem isSeparable_inv {x : E} (hx : IsSeparable F x) : IsSeparable F x⁻¹ :=
   haveI := (isSeparable_adjoin_simple_iff_isSeparable F E).2 hx
-  isSeparable_of_mem_isSeparable F E <| F⟮x⟯.inv_mem _ <| mem_adjoin_simple_self F x
+  isSeparable_of_mem_isSeparable F E <| F⟮x⟯.inv_mem <| mem_adjoin_simple_self F x
 
 end Field
 


### PR DESCRIPTION
In this PR I generalize IntermediateField to a subalgebra with mul_comm and inv_mem, more results and move/split files will be done in next PR.

This change means that subdivision rings are no longer `IntermediateField`s

Zulip thread: [#mathlib4 > Refactor Subfield @ 💬](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Refactor.20Subfield/near/510555957)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
