### PR TITLE
[Merged by Bors] - chore: add MultilinearMap.mk'

### DIFF
--- a/Mathlib/Analysis/Analytic/Composition.lean
+++ b/Mathlib/Analysis/Analytic/Composition.lean
@@ -176,13 +176,10 @@ applying the right coefficient of `p` to each block of the composition, and then
 the resulting vector. It is called `f.compAlongComposition p c`. -/
 def compAlongComposition {n : ℕ} (p : FormalMultilinearSeries 𝕜 E F) (c : Composition n)
     (f : F [×c.length]→L[𝕜] G) : E [×n]→L[𝕜] G where
-  toFun v := f (p.applyComposition c v)
-  map_update_add' v i x y := by
-    cases Subsingleton.elim ‹_› (instDecidableEqFin _)
-    simp only [applyComposition_update, ContinuousMultilinearMap.map_update_add]
-  map_update_smul' v i c x := by
-    cases Subsingleton.elim ‹_› (instDecidableEqFin _)
-    simp only [applyComposition_update, ContinuousMultilinearMap.map_update_smul]
+  toMultilinearMap :=
+    MultilinearMap.mk' (fun v ↦ f (p.applyComposition c v))
+      (fun v i x y ↦ by simp only [applyComposition_update, map_update_add])
+      (fun v i c x ↦ by simp only [applyComposition_update, map_update_smul])
   cont :=
     f.cont.comp <|
       continuous_pi fun _ => (coe_continuous _).comp <| continuous_pi fun _ => continuous_apply _

--- a/Mathlib/Analysis/Calculus/ContDiff/FaaDiBruno.lean
+++ b/Mathlib/Analysis/Calculus/ContDiff/FaaDiBruno.lean
@@ -749,13 +749,14 @@ variables by applying `p m` to each part of the partition, and then
 applying `f` to the resulting vector. It is called `c.compAlongOrderedFinpartition f p`. -/
 def compAlongOrderedFinpartition (f : F [×c.length]→L[𝕜] G) (p : ∀ i, E [×c.partSize i]→L[𝕜] F) :
     E[×n]→L[𝕜] G where
-  toFun v := f (c.applyOrderedFinpartition p v)
-  map_update_add' v i x y := by
-    cases Subsingleton.elim ‹_› (instDecidableEqFin _)
-    simp only [applyOrderedFinpartition_update_right, ContinuousMultilinearMap.map_update_add]
-  map_update_smul' v i c x := by
-    cases Subsingleton.elim ‹_› (instDecidableEqFin _)
-    simp only [applyOrderedFinpartition_update_right, ContinuousMultilinearMap.map_update_smul]
+  toMultilinearMap :=
+    MultilinearMap.mk' (fun v ↦ f (c.applyOrderedFinpartition p v))
+      (fun v i x y ↦ by
+        simp only [applyOrderedFinpartition_update_right,
+          ContinuousMultilinearMap.map_update_add])
+      (fun v i c x ↦ by
+        simp only [applyOrderedFinpartition_update_right,
+          ContinuousMultilinearMap.map_update_smul])
   cont := by
     apply f.cont.comp
     change Continuous (fun v m ↦ p m (v ∘ c.emb m))
@@ -775,22 +776,18 @@ theorem norm_compAlongOrderedFinpartition_le (f : F [×c.length]→L[𝕜] G)
 
 /-- Bundled version of `compAlongOrderedFinpartition`, depending linearly on `f`
 and multilinearly on `p`. -/
-@[simps apply_apply]
+@[simps! apply_apply]
 def compAlongOrderedFinpartitionₗ :
     (F [×c.length]→L[𝕜] G) →ₗ[𝕜]
       MultilinearMap 𝕜 (fun i : Fin c.length ↦ E[×c.partSize i]→L[𝕜] F) (E[×n]→L[𝕜] G) where
   toFun f :=
-    { toFun := fun p ↦ c.compAlongOrderedFinpartition f p
-      map_update_add' := by
-        intro inst p m q q'
-        cases Subsingleton.elim ‹_› (instDecidableEqFin _)
+    MultilinearMap.mk' (fun p ↦ c.compAlongOrderedFinpartition f p)
+      (fun p m q q' ↦ by
         ext v
-        simp [applyOrderedFinpartition_update_left]
-      map_update_smul' := by
-        intro inst p m a q
-        cases Subsingleton.elim ‹_› (instDecidableEqFin _)
+        simp [applyOrderedFinpartition_update_left])
+      (fun p m a q ↦ by
         ext v
-        simp [applyOrderedFinpartition_update_left] }
+        simp [applyOrderedFinpartition_update_left])
   map_add' _ _ := rfl
   map_smul' _ _ :=  rfl
 

--- a/Mathlib/LinearAlgebra/Determinant.lean
+++ b/Mathlib/LinearAlgebra/Determinant.lean
@@ -490,20 +490,16 @@ theorem LinearMap.associated_det_comp_equiv {N : Type*} [AddCommGroup N] [Module
 /-- The determinant of a family of vectors with respect to some basis, as an alternating
 multilinear map. -/
 nonrec def Basis.det : M [⋀^ι]→ₗ[R] R where
-  toFun v := det (e.toMatrix v)
-  map_update_add' := by
-    rename_i hι _
-    intro inst v i x y
-    cases Subsingleton.elim inst hι
-    simp only [e.toMatrix_update, LinearEquiv.map_add, Finsupp.coe_add, det_updateCol_add]
-  map_update_smul' := by
-    rename_i hι _
-    intro inst u i c x
-    cases Subsingleton.elim inst hι
-    simp only [e.toMatrix_update, Algebra.id.smul_eq_mul, LinearEquiv.map_smul]
-    apply det_updateCol_smul
+  toMultilinearMap :=
+    MultilinearMap.mk' (fun v ↦ det (e.toMatrix v))
+      (fun v i x y ↦ by
+        simp only [e.toMatrix_update, map_add, Finsupp.coe_add, det_updateCol_add])
+      (fun u i c x ↦ by
+        simp only [e.toMatrix_update, Algebra.id.smul_eq_mul, LinearEquiv.map_smul]
+        apply det_updateCol_smul)
   map_eq_zero_of_eq' := by
     intro v i j h hij
+    dsimp
     rw [← Function.update_eq_self i v, h, ← det_transpose, e.toMatrix_update, ← updateRow_transpose,
       ← e.toMatrix_transpose_apply]
     apply det_zero_of_row_eq hij

--- a/Mathlib/LinearAlgebra/Multilinear/Basic.lean
+++ b/Mathlib/LinearAlgebra/Multilinear/Basic.lean
@@ -106,6 +106,19 @@ instance : FunLike (MultilinearMap R M₁ M₂) (∀ i, M₁ i) M₂ where
 
 initialize_simps_projections MultilinearMap (toFun → apply)
 
+/-- Constructor for `MultilinearMap R M₁ M₂` when the
+index type `ι` is already endowed with a `DecidableEq` instance. -/
+@[simps]
+def mk' [DecidableEq ι] (f : (∀ i, M₁ i) → M₂)
+    (h₁ : ∀ (m : ∀ i, M₁ i) (i : ι) (x y : M₁ i),
+      f (update m i (x + y)) = f (update m i x) + f (update m i y) := by aesop)
+    (h₂ : ∀ (m : ∀ i, M₁ i) (i : ι) (c : R) (x : M₁ i),
+      f (update m i (c • x)) = c • f (update m i x) := by aesop) :
+    MultilinearMap R M₁ M₂ where
+  toFun := f
+  map_update_add' m i x y := by convert h₁ m i x y
+  map_update_smul' m i c x := by convert h₂ m i c x
+
 @[simp]
 theorem toFun_eq_coe : f.toFun = ⇑f :=
   rfl
@@ -1137,19 +1150,15 @@ to `m` the product of all the `m i`.
 
 See also `MultilinearMap.mkPiAlgebra` for a version that assumes `[CommSemiring A]` but works
 for `A^ι` with any finite type `ι`. -/
-protected def mkPiAlgebraFin : MultilinearMap R (fun _ : Fin n => A) A where
-  toFun m := (List.ofFn m).prod
-  map_update_add' {dec} m i x y := by
-    rw [Subsingleton.elim dec (by infer_instance)]
-    have : (List.finRange n).idxOf i < n := by
-      simpa using List.idxOf_lt_length_iff.2 (List.mem_finRange i)
-    simp [List.ofFn_eq_map, (List.nodup_finRange n).map_update, List.prod_set, add_mul, this,
-      mul_add, add_mul]
-  map_update_smul' {dec} m i c x := by
-    rw [Subsingleton.elim dec (by infer_instance)]
-    have : (List.finRange n).idxOf i < n := by
-      simpa using List.idxOf_lt_length_iff.2 (List.mem_finRange i)
-    simp [List.ofFn_eq_map, (List.nodup_finRange n).map_update, List.prod_set, this]
+protected def mkPiAlgebraFin : MultilinearMap R (fun _ : Fin n => A) A :=
+  MultilinearMap.mk' (fun m ↦ (List.ofFn m).prod)
+    (fun m i x y ↦ by
+      have : (List.finRange n).idxOf i < n := by simp
+      simp [List.ofFn_eq_map, (List.nodup_finRange n).map_update, List.prod_set, add_mul, this,
+        mul_add, add_mul])
+    (fun m i c x ↦ by
+      have : (List.finRange n).idxOf i < n := by simp
+      simp [List.ofFn_eq_map, (List.nodup_finRange n).map_update, List.prod_set, this])
 
 variable {R A n}
 

--- a/Mathlib/LinearAlgebra/Multilinear/Curry.lean
+++ b/Mathlib/LinearAlgebra/Multilinear/Curry.lean
@@ -54,30 +54,26 @@ variable [CommSemiring R] [∀ i, AddCommMonoid (M i)] [AddCommMonoid M'] [AddCo
 construct the corresponding multilinear map on `n+1` variables obtained by concatenating
 the variables, given by `m ↦ f (m 0) (tail m)` -/
 def LinearMap.uncurryLeft (f : M 0 →ₗ[R] MultilinearMap R (fun i : Fin n => M i.succ) M₂) :
-    MultilinearMap R M M₂ where
-  toFun m := f (m 0) (tail m)
-  map_update_add' := @fun dec m i x y => by
-    -- Porting note: `clear` not necessary in Lean 3 due to not being in the instance cache
-    rw [Subsingleton.elim dec (by clear dec; infer_instance)]; clear dec
-    by_cases h : i = 0
-    · subst i
-      simp only [update_self, map_add, tail_update_zero, MultilinearMap.add_apply]
-    · simp_rw [update_of_ne (Ne.symm h)]
-      revert x y
-      rw [← succ_pred i h]
-      intro x y
-      rw [tail_update_succ, MultilinearMap.map_update_add, tail_update_succ, tail_update_succ]
-  map_update_smul' := @fun dec m i c x => by
-    -- Porting note: `clear` not necessary in Lean 3 due to not being in the instance cache
-    rw [Subsingleton.elim dec (by clear dec; infer_instance)]; clear dec
-    by_cases h : i = 0
-    · subst i
-      simp only [update_self, map_smul, tail_update_zero, MultilinearMap.smul_apply]
-    · simp_rw [update_of_ne (Ne.symm h)]
-      revert x
-      rw [← succ_pred i h]
-      intro x
-      rw [tail_update_succ, tail_update_succ, MultilinearMap.map_update_smul]
+    MultilinearMap R M M₂ :=
+  MultilinearMap.mk' (fun m ↦ f (m 0) (tail m))
+    (fun m i x y ↦ by
+      by_cases h : i = 0
+      · subst i
+        simp only [update_self, map_add, tail_update_zero, MultilinearMap.add_apply]
+      · simp_rw [update_of_ne (Ne.symm h)]
+        revert x y
+        rw [← succ_pred i h]
+        intro x y
+        rw [tail_update_succ, MultilinearMap.map_update_add, tail_update_succ, tail_update_succ])
+    (fun m i c x ↦ by
+      by_cases h : i = 0
+      · subst i
+        simp only [update_self, map_smul, tail_update_zero, MultilinearMap.smul_apply]
+      · simp_rw [update_of_ne (Ne.symm h)]
+        revert x
+        rw [← succ_pred i h]
+        intro x
+        rw [tail_update_succ, tail_update_succ, MultilinearMap.map_update_smul])
 
 @[simp]
 theorem LinearMap.uncurryLeft_apply (f : M 0 →ₗ[R] MultilinearMap R (fun i : Fin n => M i.succ) M₂)
@@ -88,16 +84,7 @@ theorem LinearMap.uncurryLeft_apply (f : M 0 →ₗ[R] MultilinearMap R (fun i :
 a linear map into multilinear maps in `n` variables, given by `x ↦ (m ↦ f (cons x m))`. -/
 def MultilinearMap.curryLeft (f : MultilinearMap R M M₂) :
     M 0 →ₗ[R] MultilinearMap R (fun i : Fin n => M i.succ) M₂ where
-  toFun x :=
-    { toFun := fun m => f (cons x m)
-      map_update_add' := @fun dec m i y y' => by
-        -- Porting note: `clear` not necessary in Lean 3 due to not being in the instance cache
-        rw [Subsingleton.elim dec (by clear dec; infer_instance)]
-        simp
-      map_update_smul' := @fun dec m i y c => by
-        -- Porting note: `clear` not necessary in Lean 3 due to not being in the instance cache
-        rw [Subsingleton.elim dec (by clear dec; infer_instance)]
-        simp }
+  toFun x := MultilinearMap.mk' (fun m => f (cons x m))
   map_add' x y := by
     ext m
     exact cons_add f m x y
@@ -151,36 +138,34 @@ variable {R M M₂}
 the variables, given by `m ↦ f (init m) (m (last n))` -/
 def MultilinearMap.uncurryRight
     (f : MultilinearMap R (fun i : Fin n => M (castSucc i)) (M (last n) →ₗ[R] M₂)) :
-    MultilinearMap R M M₂ where
-  toFun m := f (init m) (m (last n))
-  map_update_add' {dec} m i x y := by
-    rw [Subsingleton.elim dec (by clear dec; infer_instance)]; clear dec
-    by_cases h : i.val < n
-    · have : last n ≠ i := Ne.symm (ne_of_lt h)
-      simp_rw [update_of_ne this]
-      revert x y
-      rw [(castSucc_castLT i h).symm]
-      intro x y
-      rw [init_update_castSucc, MultilinearMap.map_update_add, init_update_castSucc,
-        init_update_castSucc, LinearMap.add_apply]
-    · revert x y
-      rw [eq_last_of_not_lt h]
-      intro x y
-      simp_rw [init_update_last, update_self, LinearMap.map_add]
-  map_update_smul' {dec} m i c x := by
-    rw [Subsingleton.elim dec (by clear dec; infer_instance)]; clear dec
-    by_cases h : i.val < n
-    · have : last n ≠ i := Ne.symm (ne_of_lt h)
-      simp_rw [update_of_ne this]
-      revert x
-      rw [(castSucc_castLT i h).symm]
-      intro x
-      rw [init_update_castSucc, init_update_castSucc, MultilinearMap.map_update_smul,
-        LinearMap.smul_apply]
-    · revert x
-      rw [eq_last_of_not_lt h]
-      intro x
-      simp_rw [update_self, init_update_last, map_smul]
+    MultilinearMap R M M₂ :=
+  MultilinearMap.mk' (fun m ↦ f (init m) (m (last n)))
+    (fun m i x y ↦ by
+      by_cases h : i.val < n
+      · have : last n ≠ i := Ne.symm (ne_of_lt h)
+        simp_rw [update_of_ne this]
+        revert x y
+        rw [(castSucc_castLT i h).symm]
+        intro x y
+        rw [init_update_castSucc, MultilinearMap.map_update_add, init_update_castSucc,
+          init_update_castSucc, LinearMap.add_apply]
+      · revert x y
+        rw [eq_last_of_not_lt h]
+        intro x y
+        simp_rw [init_update_last, update_self, LinearMap.map_add])
+    (fun m i c x ↦ by
+      by_cases h : i.val < n
+      · have : last n ≠ i := Ne.symm (ne_of_lt h)
+        simp_rw [update_of_ne this]
+        revert x
+        rw [(castSucc_castLT i h).symm]
+        intro x
+        rw [init_update_castSucc, init_update_castSucc, MultilinearMap.map_update_smul,
+          LinearMap.smul_apply]
+      · revert x
+        rw [eq_last_of_not_lt h]
+        intro x
+        simp_rw [update_self, init_update_last, map_smul])
 
 @[simp]
 theorem MultilinearMap.uncurryRight_apply
@@ -192,19 +177,11 @@ theorem MultilinearMap.uncurryRight_apply
 a multilinear map in `n` variables taking values in linear maps from `M (last n)` to `M₂`, given by
 `m ↦ (x ↦ f (snoc m x))`. -/
 def MultilinearMap.curryRight (f : MultilinearMap R M M₂) :
-    MultilinearMap R (fun i : Fin n => M (Fin.castSucc i)) (M (last n) →ₗ[R] M₂) where
-  toFun m :=
+    MultilinearMap R (fun i : Fin n => M (Fin.castSucc i)) (M (last n) →ₗ[R] M₂) :=
+  MultilinearMap.mk' (fun m ↦
     { toFun := fun x => f (snoc m x)
       map_add' := fun x y => by simp_rw [f.snoc_add]
-      map_smul' := fun c x => by simp only [f.snoc_smul, RingHom.id_apply] }
-  map_update_add' := @fun dec m i x y => by
-    rw [Subsingleton.elim dec (by clear dec; infer_instance)]; clear dec
-    ext z
-    simp
-  map_update_smul' := @fun dec m i c x => by
-    rw [Subsingleton.elim dec (by clear dec; infer_instance)]; clear dec
-    ext z
-    simp
+      map_smul' := fun c x => by simp only [f.snoc_smul, RingHom.id_apply] })
 
 @[simp]
 theorem MultilinearMap.curryRight_apply (f : MultilinearMap R M M₂)

--- a/Mathlib/LinearAlgebra/Multilinear/DFinsupp.lean
+++ b/Mathlib/LinearAlgebra/Multilinear/DFinsupp.lean
@@ -98,11 +98,9 @@ def dfinsuppFamily
         refine ⟨fun i _ => p i, fun i => (s i).prop _ |>.resolve_right ?_, rfl⟩
         exact mt ((f p).map_coord_zero (m := fun i => x i _) i) h⟩}
   map_update_add' {dec} m i x y := DFinsupp.ext fun p => by
-    cases Subsingleton.elim dec (by infer_instance)
     dsimp
     simp_rw [Function.apply_update (fun i m => m (p i)) m, DFinsupp.add_apply, (f p).map_update_add]
   map_update_smul' {dec} m i c x := DFinsupp.ext fun p => by
-    cases Subsingleton.elim dec (by infer_instance)
     dsimp
     simp_rw [Function.apply_update (fun i m => m (p i)) m, DFinsupp.smul_apply,
       (f p).map_update_smul]

--- a/Mathlib/LinearAlgebra/Multilinear/Pi.lean
+++ b/Mathlib/LinearAlgebra/Multilinear/Pi.lean
@@ -74,11 +74,9 @@ def piFamily (f : Π (p : Π i, κ i), MultilinearMap R (fun i ↦ M i (p i)) (N
     MultilinearMap R (fun i => Π j : κ i, M i j) (Π t : Π i, κ i, N t) where
   toFun x := fun p => f p (fun i => x i (p i))
   map_update_add' {dec} m i x y := funext fun p => by
-    cases Subsingleton.elim dec (by infer_instance)
     dsimp
     simp_rw [Function.apply_update (fun i m => m (p i)) m, Pi.add_apply, (f p).map_update_add]
   map_update_smul' {dec} m i c x := funext fun p => by
-    cases Subsingleton.elim dec (by infer_instance)
     dsimp
     simp_rw [Function.apply_update (fun i m => m (p i)) m, Pi.smul_apply, (f p).map_update_smul]
 


### PR DESCRIPTION
This PR adds a constructor `MultilinearMap.mk'` for multilinear maps when the index type is already equipped with a `DecidableEq` instances. Some awkward proofs are fixed.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
