### PR TITLE
[Merged by Bors] - chore(CategoryTheory/Monoidal/Functor): remove `erw`s

### DIFF
--- a/Mathlib/CategoryTheory/Monoidal/Functor.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Functor.lean
@@ -851,30 +851,26 @@ def rightAdjointLaxMonoidal : G.LaxMonoidal where
   ε' := adj.homEquiv _ _ (η F)
   μ' X Y := adj.homEquiv _ _ (δ F _ _ ≫ (adj.counit.app X ⊗ adj.counit.app Y))
   μ'_natural_left {X Y} f X' := by
-    dsimp [Adjunction.homEquiv_apply]
-    erw [adj.unit.naturality_assoc]
-    dsimp
-    simp only [← G.map_comp, assoc, ← δ_natural_left_assoc F]
-    erw [NatTrans.whiskerRight_app_tensor_app adj.counit adj.counit]
-    dsimp
+    simp only [Adjunction.homEquiv_apply, ← adj.unit_naturality_assoc, ← G.map_comp, assoc,
+      ← δ_natural_left_assoc F]
+    suffices F.map (G.map f) ▷ F.obj (G.obj X') ≫ _ =
+      (adj.counit.app X ⊗ adj.counit.app X') ≫ _ from by rw [this]
+    simpa using NatTrans.whiskerRight_app_tensor_app adj.counit adj.counit (f := f) X'
   μ'_natural_right {X' Y'} X g := by
-    dsimp [Adjunction.homEquiv_apply]
-    erw [adj.unit.naturality_assoc]
-    dsimp
-    simp only [← G.map_comp, assoc, ← δ_natural_right_assoc F]
-    erw [NatTrans.whiskerLeft_app_tensor_app adj.counit adj.counit]
-    dsimp
+    simp only [Adjunction.homEquiv_apply, ← adj.unit_naturality_assoc, ← G.map_comp,
+      assoc, ← δ_natural_right_assoc F]
+    suffices F.obj (G.obj X) ◁ F.map (G.map g) ≫ _ =
+      (adj.counit.app X ⊗ adj.counit.app X') ≫ _ from by rw [this]
+    simpa using NatTrans.whiskerLeft_app_tensor_app adj.counit adj.counit (f := g) _
   associativity' X Y Z := (adj.homEquiv _ _).symm.injective (by
-    simp only [homEquiv_unit, homEquiv_counit, map_comp, assoc, comp_whiskerRight,
-      counit_naturality, counit_naturality_assoc, left_triangle_components_assoc,
+    simp only [homEquiv_unit, comp_obj, map_comp, comp_whiskerRight, assoc, homEquiv_counit,
+      counit_naturality, id_obj, counit_naturality_assoc, left_triangle_components_assoc,
       MonoidalCategory.whiskerLeft_comp]
-    dsimp
     rw [← δ_natural_left_assoc, ← δ_natural_left_assoc, ← δ_natural_left_assoc]
-    erw [NatTrans.whiskerRight_app_tensor_app_assoc adj.counit adj.counit,
-      NatTrans.whiskerRight_app_tensor_app_assoc adj.counit adj.counit]
-    rw [tensorHom_def, assoc]
-    dsimp
-    rw [← comp_whiskerRight_assoc, left_triangle_components, id_whiskerRight, id_comp,
+    haveI := @NatTrans.whiskerRight_app_tensor_app_assoc _ _ _ _ _ _ _ _ _ adj.counit adj.counit
+    dsimp only [id_obj, comp_obj, Functor.comp_map, Functor.id_map] at this
+    rw [this, this, tensorHom_def, assoc, ← comp_whiskerRight_assoc,
+      left_triangle_components, id_whiskerRight, id_comp,
       whisker_exchange_assoc, whisker_exchange_assoc, ← tensorHom_def_assoc,
       associator_naturality, OplaxMonoidal.associativity_assoc]
     rw [← δ_natural_right_assoc, ← δ_natural_right_assoc, ← δ_natural_right_assoc]
@@ -967,7 +963,8 @@ instance isMonoidal_comp {F' : D ⥤ E} {G' : E ⥤ D} (adj' : F' ⊣ G')
       ← adj'.unit_naturality_assoc, ← map_comp, ← map_comp]
   leftAdjoint_μ X Y := by
     apply ((adj.comp adj').homEquiv _ _).symm.injective
-    erw [Equiv.symm_apply_apply]
+    dsimp only [comp_obj, comp_μ, id_obj, comp_δ]
+    rw [Equiv.symm_apply_apply]
     dsimp [homEquiv]
     rw [comp_counit_app, comp_counit_app, comp_counit_app, assoc, tensor_comp, δ_natural_assoc]
     dsimp

--- a/Mathlib/CategoryTheory/Monoidal/Functor.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Functor.lean
@@ -854,13 +854,13 @@ def rightAdjointLaxMonoidal : G.LaxMonoidal where
     simp only [Adjunction.homEquiv_apply, ← adj.unit_naturality_assoc, ← G.map_comp, assoc,
       ← δ_natural_left_assoc F]
     suffices F.map (G.map f) ▷ F.obj (G.obj X') ≫ _ =
-      (adj.counit.app X ⊗ adj.counit.app X') ≫ _ from by rw [this]
+      (adj.counit.app X ⊗ adj.counit.app X') ≫ _ by rw [this]
     simpa using NatTrans.whiskerRight_app_tensor_app adj.counit adj.counit (f := f) X'
   μ'_natural_right {X' Y'} X g := by
     simp only [Adjunction.homEquiv_apply, ← adj.unit_naturality_assoc, ← G.map_comp,
       assoc, ← δ_natural_right_assoc F]
     suffices F.obj (G.obj X) ◁ F.map (G.map g) ≫ _ =
-      (adj.counit.app X ⊗ adj.counit.app X') ≫ _ from by rw [this]
+      (adj.counit.app X ⊗ adj.counit.app X') ≫ _ by rw [this]
     simpa using NatTrans.whiskerLeft_app_tensor_app adj.counit adj.counit (f := g) _
   associativity' X Y Z := (adj.homEquiv _ _).symm.injective (by
     simp only [homEquiv_unit, comp_obj, map_comp, comp_whiskerRight, assoc, homEquiv_counit,


### PR DESCRIPTION
Remove `erw`s in the file. Some offenders where ignoring simp lemmas `Adjunction.unit_naturality`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

Proof of associativity used `whiskerRight_app_tensor_assoc` with the counit twice and needed to erw with it, so I felt that a `have` might be justified here.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
