### PR TITLE
[Merged by Bors] - chore(RingTheory/StandardSmooth): fix `SubmersivePresentation.basisCotangent`

### DIFF
--- a/Mathlib/RingTheory/Smooth/StandardSmoothCotangent.lean
+++ b/Mathlib/RingTheory/Smooth/StandardSmoothCotangent.lean
@@ -136,7 +136,15 @@ instance subsingleton_h1Cotangent : Subsingleton P.toExtension.H1Cotangent := by
 /-- The classes of `P.relation i` form a basis of `I ⧸ I ^ 2`. -/
 @[stacks 00T7 "(3)"]
 noncomputable def basisCotangent : Basis P.rels S P.toExtension.Cotangent :=
-  ⟨cotangentEquiv P ≪≫ₗ (Finsupp.linearEquivFunOnFinite S S P.rels).symm⟩
+  P.basisDeriv.map P.cotangentEquiv.symm
+
+lemma basisCotangent_apply (r : P.rels) :
+    P.basisCotangent r = Extension.Cotangent.mk ⟨P.relation r, P.relation_mem_ker r⟩ := by
+  symm
+  apply P.cotangentEquiv.injective
+  ext
+  simp_rw [basisCotangent, Basis.map_apply, LinearEquiv.apply_symm_apply, basisDeriv_apply]
+  apply P.toPreSubmersivePresentation.cotangentComplexAux_apply _ _
 
 @[stacks 00T7 "(3)"]
 instance free_cotangent : Module.Free S P.toExtension.Cotangent :=


### PR DESCRIPTION
The current basis is not what the docstring claims to be: It is the basis given by pre-images of the standard basis of `P.rels → S`, which don't agree with the images of `P.relation i` in `P.toExtension.Cotangent`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
