### PR TITLE
[Merged by Bors] - fix: autolabel Control as t-data

### DIFF
--- a/scripts/autolabel.lean
+++ b/scripts/autolabel.lean
@@ -99,7 +99,10 @@ def mathlibLabels : Array Label := #[
   { label := "t-combinatorics" },
   { label := "t-computability" },
   { label := "t-condensed" },
-  { label := "t-data" },
+  { label := "t-data"
+    dirs := #[
+      "Mathlib" / "Control",
+      "Mathlib" / "Data",] },
   { label := "t-differential-geometry",
     dirs := #["Mathlib" / "Geometry" / "Manifold"] },
   { label := "t-dynamics" },
@@ -120,7 +123,6 @@ def mathlibLabels : Array Label := #[
       "Mathlib" / "InformationTheory"] },
   { label := "t-meta",
     dirs := #[
-      "Mathlib" / "Control",
       "Mathlib" / "Lean",
       "Mathlib" / "Mathport",
       "Mathlib" / "Tactic",


### PR DESCRIPTION
Modifying files in `Control` will get the `t-data` autolabel, instead of `t-meta`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
