### PR TITLE
[Merged by Bors] - ci: automate nightly adaptation PR creation

### DIFF
--- a/.github/workflows/nightly_detect_failure.yml
+++ b/.github/workflows/nightly_detect_failure.yml
@@ -212,16 +212,19 @@ jobs:
         BUMP_BRANCH: ${{ steps.latest_bump_branch.outputs.result }}
         SHA: ${{ env.SHA }}
       run: |
-        # Install zulip-send for the script
+        echo "Installing zulip-send..."
         pip install zulip-send
-        # Configure git for the bot
+        echo "Configuring git identity for mathlib4-bot..."
         git config --global user.name "mathlib4-bot"
         git config --global user.email "github-mathlib4-bot@leanprover.zulipchat.com"
-        # Store credentials for zulip-send
-        echo "ZULIP_EMAIL=github-mathlib4-bot@leanprover.zulipchat.com" >> ~/.zuliprc
-        echo "ZULIP_API_KEY=${{ secrets.ZULIP_API_KEY }}" >> ~/.zuliprc
-        echo "ZULIP_SITE=https://leanprover.zulipchat.com" >> ~/.zuliprc
+        echo "Setting up zulip credentials..."
+        {
+          echo "ZULIP_EMAIL=github-mathlib4-bot@leanprover.zulipchat.com"
+          echo "ZULIP_API_KEY=${{ secrets.ZULIP_API_KEY }}"
+          echo "ZULIP_SITE=https://leanprover.zulipchat.com"
+        } > ~/.zuliprc
         chmod 600 ~/.zuliprc
+        echo "Setup complete"
 
     - name: Attempt automatic PR creation
       id: auto_pr
@@ -234,8 +237,15 @@ jobs:
         GH_TOKEN: ${{ secrets.NIGHTLY_TESTING }}
         ZULIP_API_KEY: ${{ secrets.ZULIP_API_KEY }}
       run: |
+        echo "Current version: ${NIGHTLY}"
+        echo "Target bump branch: ${BUMP_BRANCH}"
+        echo "Using commit SHA: ${SHA}"
         current_version="${NIGHTLY}"
         bump_branch_suffix="${BUMP_BRANCH#bump/}"
+        echo "Running create-adaptation-pr.sh with:"
+        echo "  bumpversion: ${bump_branch_suffix}"
+        echo "  nightlydate: ${current_version}"
+        echo "  nightlysha: ${SHA}"
         ./scripts/create-adaptation-pr.sh --bumpversion="${bump_branch_suffix}" --nightlydate="${current_version}" --nightlysha="${SHA}" --auto=yes
 
     - name: Fallback to manual instructions

--- a/.github/workflows/nightly_detect_failure.yml
+++ b/.github/workflows/nightly_detect_failure.yml
@@ -205,7 +205,41 @@ jobs:
           Current content: ${{ steps.bump_version.outputs.toolchain_content }}
           This needs to be fixed for the nightly testing process to work correctly.
 
-    - name: Compare versions and post a reminder.
+    - name: Setup for automatic PR creation
+      if: steps.check_branch.outputs.result == 'false'
+      env:
+        BUMP_VERSION: ${{ steps.bump_version.outputs.result }}
+        BUMP_BRANCH: ${{ steps.latest_bump_branch.outputs.result }}
+        SHA: ${{ env.SHA }}
+      run: |
+        # Install zulip-send for the script
+        pip install zulip-send
+        # Configure git for the bot
+        git config --global user.name "mathlib4-bot"
+        git config --global user.email "github-mathlib4-bot@leanprover.zulipchat.com"
+        # Store credentials for zulip-send
+        echo "ZULIP_EMAIL=github-mathlib4-bot@leanprover.zulipchat.com" >> ~/.zuliprc
+        echo "ZULIP_API_KEY=${{ secrets.ZULIP_API_KEY }}" >> ~/.zuliprc
+        echo "ZULIP_SITE=https://leanprover.zulipchat.com" >> ~/.zuliprc
+        chmod 600 ~/.zuliprc
+
+    - name: Attempt automatic PR creation
+      id: auto_pr
+      if: steps.check_branch.outputs.result == 'false'
+      continue-on-error: true
+      env:
+        BUMP_VERSION: ${{ steps.bump_version.outputs.result }}
+        BUMP_BRANCH: ${{ steps.latest_bump_branch.outputs.result }}
+        SHA: ${{ env.SHA }}
+        GH_TOKEN: ${{ secrets.NIGHTLY_TESTING }}
+        ZULIP_API_KEY: ${{ secrets.ZULIP_API_KEY }}
+      run: |
+        current_version="${NIGHTLY}"
+        bump_branch_suffix="${BUMP_BRANCH#bump/}"
+        ./scripts/create-adaptation-pr.sh --bumpversion="${bump_branch_suffix}" --nightlydate="${current_version}" --nightlysha="${SHA}" --auto=yes
+
+    - name: Fallback to manual instructions
+      if: steps.auto_pr.outcome == 'failure' && steps.check_branch.outputs.result == 'false'
       env:
         BUMP_VERSION: ${{ steps.bump_version.outputs.result }}
         BUMP_BRANCH: ${{ steps.latest_bump_branch.outputs.result }}
@@ -234,7 +268,7 @@ jobs:
             response = client.get_messages(request)
             messages = response['messages']
             bump_branch_suffix = bump_branch.replace('bump/', '')
-            payload = f"🛠️: it looks like it's time to create a new bump/nightly-{current_version} branch from nightly-testing (specifically {sha}), and then PR that to {bump_branch}. "
+            payload = f"🛠️: Automatic PR creation failed. Please create a new bump/nightly-{current_version} branch from nightly-testing (specifically {sha}), and then PR that to {bump_branch}. "
             payload += "To do so semi-automatically, run the following script from mathlib root:\n\n"
             payload += f"```bash\n./scripts/create-adaptation-pr.sh --bumpversion={bump_branch_suffix} --nightlydate={current_version} --nightlysha={sha}\n```\n"
             # Only post if the message is different


### PR DESCRIPTION
The workflow now attempts to automatically create adaptation PRs when needed, falling back to manual instructions if the automatic creation fails.

* Add automatic PR creation using create-adaptation-pr.sh --auto=yes

* Set up necessary git and zulip credentials for the script

* Update Zulip message to indicate when automatic creation fails


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
