### PR TITLE
[Merged by Bors] - feat(Order/Interval): add strict inclusion lemmas for unbounded intervals

### DIFF
--- a/Mathlib/Order/Interval/Finset/Basic.lean
+++ b/Mathlib/Order/Interval/Finset/Basic.lean
@@ -357,9 +357,13 @@ theorem Ici_ssubset_Ici : Ici a ⊂ Ici b ↔ b < a := by
   simp [← coe_ssubset]
 
 @[gcongr]
+alias ⟨_, _root_.GCongr.Finset.Ici_ssubset_Ici⟩ := Ici_ssubset_Ici
+
+@[gcongr]
 theorem Ioi_subset_Ioi (h : a ≤ b) : Ioi b ⊆ Ioi a := by
   simpa [← coe_subset] using Set.Ioi_subset_Ioi h
 
+@[gcongr]
 theorem Ioi_ssubset_Ioi (h : a < b) : Ioi b ⊂ Ioi a := by
   simpa [← coe_ssubset] using Set.Ioi_ssubset_Ioi h
 
@@ -421,9 +425,13 @@ theorem Iic_ssubset_Iic : Iic a ⊂ Iic b ↔ a < b := by
   simp [← coe_ssubset]
 
 @[gcongr]
+alias ⟨_, _root_.GCongr.Finset.Iic_ssubset_Iic⟩ := Iic_ssubset_Iic
+
+@[gcongr]
 theorem Iio_subset_Iio (h : a ≤ b) : Iio a ⊆ Iio b := by
   simpa [← coe_subset] using Set.Iio_subset_Iio h
 
+@[gcongr]
 theorem Iio_ssubset_Iio (h : a < b) : Iio a ⊂ Iio b := by
   simpa [← coe_ssubset] using Set.Iio_ssubset_Iio h
 

--- a/Mathlib/Order/Interval/Finset/Basic.lean
+++ b/Mathlib/Order/Interval/Finset/Basic.lean
@@ -356,6 +356,9 @@ alias ⟨_, _root_.GCongr.Finset.Ici_subset_Ici⟩ := Ici_subset_Ici
 theorem Ioi_subset_Ioi (h : a ≤ b) : Ioi b ⊆ Ioi a := by
   simpa [← coe_subset] using Set.Ioi_subset_Ioi h
 
+theorem Ioi_ssubset_Ioi (h : a < b) : Ioi b ⊂ Ioi a := by
+  simpa [← coe_ssubset] using Set.Ioi_ssubset_Ioi h
+
 variable [LocallyFiniteOrder α]
 
 theorem Icc_subset_Ici_self : Icc a b ⊆ Ici a := by
@@ -412,6 +415,9 @@ alias ⟨_, _root_.GCongr.Finset.Iic_subset_Iic⟩ := Iic_subset_Iic
 @[gcongr]
 theorem Iio_subset_Iio (h : a ≤ b) : Iio a ⊆ Iio b := by
   simpa [← coe_subset] using Set.Iio_subset_Iio h
+
+theorem Iio_ssubset_Iio (h : a < b) : Iio a ⊂ Iio b := by
+  simpa [← coe_ssubset] using Set.Iio_ssubset_Iio h
 
 variable [LocallyFiniteOrder α]
 

--- a/Mathlib/Order/Interval/Finset/Basic.lean
+++ b/Mathlib/Order/Interval/Finset/Basic.lean
@@ -352,6 +352,10 @@ theorem Ici_subset_Ici : Ici a ⊆ Ici b ↔ b ≤ a := by
 @[gcongr]
 alias ⟨_, _root_.GCongr.Finset.Ici_subset_Ici⟩ := Ici_subset_Ici
 
+@[simp]
+theorem Ici_ssubset_Ici : Ici a ⊂ Ici b ↔ b < a := by
+  simp [← coe_ssubset]
+
 @[gcongr]
 theorem Ioi_subset_Ioi (h : a ≤ b) : Ioi b ⊆ Ioi a := by
   simpa [← coe_subset] using Set.Ioi_subset_Ioi h
@@ -411,6 +415,10 @@ theorem Iic_subset_Iic : Iic a ⊆ Iic b ↔ a ≤ b := by
 
 @[gcongr]
 alias ⟨_, _root_.GCongr.Finset.Iic_subset_Iic⟩ := Iic_subset_Iic
+
+@[simp]
+theorem Iic_ssubset_Iic : Iic a ⊂ Iic b ↔ a < b := by
+  simp [← coe_ssubset]
 
 @[gcongr]
 theorem Iio_subset_Iio (h : a ≤ b) : Iio a ⊆ Iio b := by

--- a/Mathlib/Order/Interval/Set/Basic.lean
+++ b/Mathlib/Order/Interval/Set/Basic.lean
@@ -296,6 +296,8 @@ theorem Ici_ssubset_Ici : Ici a ⊂ Ici b ↔ b < a where
   mpr h := (ssubset_iff_of_subset (Ici_subset_Ici.mpr h.le)).mpr
     ⟨b, right_mem_Iic, fun h' => h.not_le h'⟩
 
+@[gcongr] alias ⟨_, _root_.GCongr.Ici_ssubset_Ici_of_le⟩ := Ici_ssubset_Ici
+
 @[simp]
 theorem Iic_subset_Iic : Iic a ⊆ Iic b ↔ a ≤ b :=
   @Ici_subset_Ici αᵒᵈ _ _ _
@@ -306,6 +308,7 @@ theorem Iic_subset_Iic : Iic a ⊆ Iic b ↔ a ≤ b :=
 theorem Iic_ssubset_Iic : Iic a ⊂ Iic b ↔ a < b :=
   @Ici_ssubset_Ici αᵒᵈ _ _ _
 
+@[gcongr] alias ⟨_, _root_.GCongr.Iic_ssubset_Iic_of_le⟩ := Iic_ssubset_Iic
 
 @[simp]
 theorem Ici_subset_Ioi : Ici a ⊆ Ioi b ↔ b < a :=
@@ -456,6 +459,7 @@ theorem Ioi_subset_Ioi (h : a ≤ b) : Ioi b ⊆ Ioi a := fun _ hx => h.trans_lt
 
 /-- If `a < b`, then `(b, +∞) ⊂ (a, +∞)`. In preorders, this is just an implication. If you need
 the equivalence in linear orders, use `Ioi_ssubset_Ioi_iff`. -/
+@[gcongr]
 theorem Ioi_ssubset_Ioi (h : a < b) : Ioi b ⊂ Ioi a :=
   (ssubset_iff_of_subset (Ioi_subset_Ioi h.le)).mpr ⟨b, h, lt_irrefl b⟩
 
@@ -471,6 +475,7 @@ theorem Iio_subset_Iio (h : a ≤ b) : Iio a ⊆ Iio b := fun _ hx => lt_of_lt_o
 
 /-- If `a < b`, then `(-∞, a) ⊂ (-∞, b)`. In preorders, this is just an implication. If you need
 the equivalence in linear orders, use `Iio_ssubset_Iio_iff`. -/
+@[gcongr]
 theorem Iio_ssubset_Iio (h : a < b) : Iio a ⊂ Iio b :=
   (ssubset_iff_of_subset (Iio_subset_Iio h.le)).mpr ⟨a, h, lt_irrefl a⟩
 

--- a/Mathlib/Order/Interval/Set/Basic.lean
+++ b/Mathlib/Order/Interval/Set/Basic.lean
@@ -289,10 +289,23 @@ theorem Ici_subset_Ici : Ici a ⊆ Ici b ↔ b ≤ a :=
 @[gcongr] alias ⟨_, _root_.GCongr.Ici_subset_Ici_of_le⟩ := Ici_subset_Ici
 
 @[simp]
+theorem Ici_ssubset_Ici : Ici a ⊂ Ici b ↔ b < a where
+  mp h := by
+    obtain ⟨ab, c, cb, ac⟩ := ssubset_iff_exists.mp h
+    exact lt_of_le_not_le (Ici_subset_Ici.mp ab) (fun h' ↦ ac (h'.trans cb))
+  mpr h := (ssubset_iff_of_subset (Ici_subset_Ici.mpr h.le)).mpr
+    ⟨b, right_mem_Iic, fun h' => h.not_le h'⟩
+
+@[simp]
 theorem Iic_subset_Iic : Iic a ⊆ Iic b ↔ a ≤ b :=
   @Ici_subset_Ici αᵒᵈ _ _ _
 
 @[gcongr] alias ⟨_, _root_.GCongr.Iic_subset_Iic_of_le⟩ := Iic_subset_Iic
+
+@[simp]
+theorem Iic_ssubset_Iic : Iic a ⊂ Iic b ↔ a < b :=
+  @Ici_ssubset_Ici αᵒᵈ _ _ _
+
 
 @[simp]
 theorem Ici_subset_Ioi : Ici a ⊆ Ioi b ↔ b < a :=

--- a/Mathlib/Order/Interval/Set/Basic.lean
+++ b/Mathlib/Order/Interval/Set/Basic.lean
@@ -441,6 +441,8 @@ the equivalence in linear orders, use `Ioi_subset_Ioi_iff`. -/
 @[gcongr]
 theorem Ioi_subset_Ioi (h : a ≤ b) : Ioi b ⊆ Ioi a := fun _ hx => h.trans_lt hx
 
+/-- If `a < b`, then `(b, +∞) ⊂ (a, +∞)`. In preorders, this is just an implication. If you need
+the equivalence in linear orders, use `Ioi_ssubset_Ioi_iff`. -/
 theorem Ioi_ssubset_Ioi (h : a < b) : Ioi b ⊂ Ioi a :=
   (ssubset_iff_of_subset (Ioi_subset_Ioi h.le)).mpr ⟨b, h, lt_irrefl b⟩
 
@@ -454,6 +456,8 @@ the equivalence in linear orders, use `Iio_subset_Iio_iff`. -/
 @[gcongr]
 theorem Iio_subset_Iio (h : a ≤ b) : Iio a ⊆ Iio b := fun _ hx => lt_of_lt_of_le hx h
 
+/-- If `a < b`, then `(-∞, a) ⊂ (-∞, b)`. In preorders, this is just an implication. If you need
+the equivalence in linear orders, use `Iio_ssubset_Iio_iff`. -/
 theorem Iio_ssubset_Iio (h : a < b) : Iio a ⊂ Iio b :=
   (ssubset_iff_of_subset (Iio_subset_Iio h.le)).mpr ⟨a, h, lt_irrefl a⟩
 

--- a/Mathlib/Order/Interval/Set/Basic.lean
+++ b/Mathlib/Order/Interval/Set/Basic.lean
@@ -441,6 +441,9 @@ the equivalence in linear orders, use `Ioi_subset_Ioi_iff`. -/
 @[gcongr]
 theorem Ioi_subset_Ioi (h : a ≤ b) : Ioi b ⊆ Ioi a := fun _ hx => h.trans_lt hx
 
+theorem Ioi_ssubset_Ioi (h : a < b) : Ioi b ⊂ Ioi a :=
+  (ssubset_iff_of_subset (Ioi_subset_Ioi h.le)).mpr ⟨b, h, lt_irrefl b⟩
+
 /-- If `a ≤ b`, then `(b, +∞) ⊆ [a, +∞)`. In preorders, this is just an implication. If you need
 the equivalence in dense linear orders, use `Ioi_subset_Ici_iff`. -/
 theorem Ioi_subset_Ici (h : a ≤ b) : Ioi b ⊆ Ici a :=
@@ -450,6 +453,9 @@ theorem Ioi_subset_Ici (h : a ≤ b) : Ioi b ⊆ Ici a :=
 the equivalence in linear orders, use `Iio_subset_Iio_iff`. -/
 @[gcongr]
 theorem Iio_subset_Iio (h : a ≤ b) : Iio a ⊆ Iio b := fun _ hx => lt_of_lt_of_le hx h
+
+theorem Iio_ssubset_Iio (h : a < b) : Iio a ⊂ Iio b :=
+  (ssubset_iff_of_subset (Iio_subset_Iio h.le)).mpr ⟨a, h, lt_irrefl a⟩
 
 /-- If `a ≤ b`, then `(-∞, a) ⊆ (-∞, b]`. In preorders, this is just an implication. If you need
 the equivalence in dense linear orders, use `Iio_subset_Iic_iff`. -/

--- a/Mathlib/Order/Interval/Set/LinearOrder.lean
+++ b/Mathlib/Order/Interval/Set/LinearOrder.lean
@@ -129,34 +129,34 @@ lemma Ici_eq_singleton_iff_isTop {x : α} : (Ici x = {x}) ↔ IsTop x := by
 
 @[simp]
 theorem Ioi_subset_Ioi_iff : Ioi b ⊆ Ioi a ↔ a ≤ b := by
-  refine ⟨fun h => ?_, fun h => Ioi_subset_Ioi h⟩
+  refine ⟨fun h => ?_, Ioi_subset_Ioi⟩
   by_contra ba
   exact lt_irrefl _ (h (not_le.mp ba))
 
 @[simp]
 theorem Ioi_ssubset_Ioi_iff : Ioi b ⊂ Ioi a ↔ a < b := by
-  refine ⟨fun h => ?_, fun h => Ioi_ssubset_Ioi h⟩
+  refine ⟨fun h => ?_, Ioi_ssubset_Ioi⟩
   obtain ⟨_, c, ac, cb⟩ := ssubset_iff_exists.mp h
-  exact lt_of_lt_of_le (by simpa using ac) (by simpa using cb)
+  exact ac.trans_le (le_of_not_lt cb)
 
 @[simp]
 theorem Ioi_subset_Ici_iff [DenselyOrdered α] : Ioi b ⊆ Ici a ↔ a ≤ b := by
-  refine ⟨fun h => ?_, fun h => Ioi_subset_Ici h⟩
+  refine ⟨fun h => ?_, Ioi_subset_Ici⟩
   by_contra ba
   obtain ⟨c, bc, ca⟩ : ∃ c, b < c ∧ c < a := exists_between (not_le.mp ba)
   exact lt_irrefl _ (ca.trans_le (h bc))
 
 @[simp]
 theorem Iio_subset_Iio_iff : Iio a ⊆ Iio b ↔ a ≤ b := by
-  refine ⟨fun h => ?_, fun h => Iio_subset_Iio h⟩
+  refine ⟨fun h => ?_, Iio_subset_Iio⟩
   by_contra ab
   exact lt_irrefl _ (h (not_le.mp ab))
 
 @[simp]
 theorem Iio_ssubset_Iio_iff : Iio a ⊂ Iio b ↔ a < b := by
-  refine ⟨fun h => ?_, fun h => Iio_ssubset_Iio h⟩
+  refine ⟨fun h => ?_, Iio_ssubset_Iio⟩
   obtain ⟨_, c, cb, ac⟩ := ssubset_iff_exists.mp h
-  exact lt_of_le_of_lt (by simpa using ac) (by simpa using cb)
+  exact (le_of_not_lt ac).trans_lt cb
 
 @[simp]
 theorem Iio_subset_Iic_iff [DenselyOrdered α] : Iio a ⊆ Iic b ↔ a ≤ b := by

--- a/Mathlib/Order/Interval/Set/LinearOrder.lean
+++ b/Mathlib/Order/Interval/Set/LinearOrder.lean
@@ -134,6 +134,12 @@ theorem Ioi_subset_Ioi_iff : Ioi b ⊆ Ioi a ↔ a ≤ b := by
   exact lt_irrefl _ (h (not_le.mp ba))
 
 @[simp]
+theorem Ioi_ssubset_Ioi_iff : Ioi b ⊂ Ioi a ↔ a < b := by
+  refine ⟨fun h => ?_, fun h => Ioi_ssubset_Ioi h⟩
+  obtain ⟨_, c, ac, cb⟩ := ssubset_iff_exists.mp h
+  exact lt_of_lt_of_le (by simpa using ac) (by simpa using cb)
+
+@[simp]
 theorem Ioi_subset_Ici_iff [DenselyOrdered α] : Ioi b ⊆ Ici a ↔ a ≤ b := by
   refine ⟨fun h => ?_, fun h => Ioi_subset_Ici h⟩
   by_contra ba
@@ -145,6 +151,12 @@ theorem Iio_subset_Iio_iff : Iio a ⊆ Iio b ↔ a ≤ b := by
   refine ⟨fun h => ?_, fun h => Iio_subset_Iio h⟩
   by_contra ab
   exact lt_irrefl _ (h (not_le.mp ab))
+
+@[simp]
+theorem Iio_ssubset_Iio_iff : Iio a ⊂ Iio b ↔ a < b := by
+  refine ⟨fun h => ?_, fun h => Iio_ssubset_Iio h⟩
+  obtain ⟨_, c, cb, ac⟩ := ssubset_iff_exists.mp h
+  exact lt_of_le_of_lt (by simpa using ac) (by simpa using cb)
 
 @[simp]
 theorem Iio_subset_Iic_iff [DenselyOrdered α] : Iio a ⊆ Iic b ↔ a ≤ b := by


### PR DESCRIPTION
This PR adds several lemmas relating the strict containment of one-sided intervals to the strict inequality of their boundary.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
