### PR TITLE
[Merged by Bors] - doc: expand `Module.finrank` docstring

### DIFF
--- a/Mathlib/LinearAlgebra/Dimension/Basic.lean
+++ b/Mathlib/LinearAlgebra/Dimension/Basic.lean
@@ -55,7 +55,11 @@ For a free module over any ring satisfying the strong rank condition
 (e.g. left-noetherian rings, commutative rings, and in particular division rings and fields),
 this is the same as the dimension of the space (i.e. the cardinality of any basis).
 
-In particular this agrees with the usual notion of the dimension of a vector space. -/
+In particular this agrees with the usual notion of the dimension of a vector space.
+
+See also `Module.finrank` for a `ℕ`-valued function which returns the correct value
+for a finite-dimensional vector space (but 0 for an infinite-dimensional vector space).
+-/
 @[stacks 09G3 "first part"]
 protected irreducible_def Module.rank : Cardinal :=
   ⨆ ι : { s : Set M // LinearIndepOn R id s }, (#ι.1)

--- a/Mathlib/LinearAlgebra/Dimension/Finrank.lean
+++ b/Mathlib/LinearAlgebra/Dimension/Finrank.lean
@@ -47,12 +47,12 @@ section Semiring
 For a finite-dimensional vector space `V` over a field `k`, `Module.finrank k V` is equal to
 the dimension of `V` over `k`.
 
-In general, `Module.finrank R M` is defined to be the supremum of the cardinalities of
-the `R`-linearly independent subsets of `M`, if this supremum is finite. It is defined by convention
-to be `0` if the space has infinite rank. See `Module.rank` for a cardinal-valued version where
-infinite rank modules have rank an infinite cardinal.
+For a general module `M` over a ring `R`, `Module.finrank R M` is defined to be the supremum of the
+cardinalities of the `R`-linearly independent subsets of `M`, if this supremum is finite. It is
+defined by convention to be `0` if this supremum is infinite. See `Module.rank` for a
+cardinal-valued version where infinite rank modules have rank an infinite cardinal.
 
-Note that if `R` is not a field then there can exist `M` with `¬(Module.Finite R M)` but
+Note that if `R` is not a field then there can exist modules `M` with `¬(Module.Finite R M)` but
 `finrank R M ≠ 0`. For example `ℤ × ℚ/ℤ` has `finrank` equal to `1` over `ℤ`. -/
 noncomputable def finrank (R M : Type*) [Semiring R] [AddCommMonoid M] [Module R M] : ℕ :=
   Cardinal.toNat (Module.rank R M)

--- a/Mathlib/LinearAlgebra/Dimension/Finrank.lean
+++ b/Mathlib/LinearAlgebra/Dimension/Finrank.lean
@@ -44,13 +44,16 @@ section Semiring
 
 /-- The rank of a module as a natural number.
 
-Defined by convention to be `0` if the space has infinite rank.
+For a finite-dimensional vector space `V` over a field `k`, `Module.finrank k V` is equal to
+the dimension of `V` over `k`.
 
-For a vector space `M` over a field `R`, this is the same as the finite dimension
-of `M` over `R`.
+In general, `Module.finrank R M` is defined to be the supremum of the cardinalities of
+the `R`-linearly independent subsets of `M`, if this supremum is finite. It is defined by convention
+to be `0` if the space has infinite rank. See `Module.rank` for a cardinal-valued version where
+infinite rank modules have rank an infinite cardinal.
 
-Note that it is possible to have `M` with `¬(Module.Finite R M)` but `finrank R M ≠ 0`, for example
-`ℤ × ℚ/ℤ` has `finrank` equal to `1`. -/
+Note that if `R` is not a field then there can exist `M` with `¬(Module.Finite R M)` but
+`finrank R M ≠ 0`. For example `ℤ × ℚ/ℤ` has `finrank` equal to `1` over `ℤ`. -/
 noncomputable def finrank (R M : Type*) [Semiring R] [AddCommMonoid M] [Module R M] : ℕ :=
   Cardinal.toNat (Module.rank R M)
 


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

The definition of `finrank` is not currently given, other than it's the "rank of the module", which it seems has several definitions in the literature away from the finite free case so seems to me to be very ambiguous. The definition we're using *is* however given in `Module.rank` so we copy it over and add some hopefully illuminating comments.