### PR TITLE
[Merged by Bors] - doc: clarify that a normal field extension is by definition algebraic.

### DIFF
--- a/Mathlib/FieldTheory/Normal/Defs.lean
+++ b/Mathlib/FieldTheory/Normal/Defs.lean
@@ -24,8 +24,9 @@ open Polynomial IsScalarTower
 
 variable (F K : Type*) [Field F] [Field K] [Algebra F K]
 
-/-- Typeclass for normal field extension: `K` is a normal extension of `F` iff the minimal
-polynomial of every element `x` in `K` splits in `K`, i.e. every conjugate of `x` is in `K`. -/
+/-- Typeclass for normal field extensions: an algebraic extension of fields `K/F` `K` is *normal*
+if the minimal polynomial of every element `x` in `K` splits in `K`, i.e. every `F`-conjugate
+of `x` is in `K`. -/
 @[stacks 09HM]
 class Normal : Prop extends Algebra.IsAlgebraic F K where
   splits' (x : K) : Splits (algebraMap F K) (minpoly F x)

--- a/Mathlib/FieldTheory/Normal/Defs.lean
+++ b/Mathlib/FieldTheory/Normal/Defs.lean
@@ -24,7 +24,7 @@ open Polynomial IsScalarTower
 
 variable (F K : Type*) [Field F] [Field K] [Algebra F K]
 
-/-- Typeclass for normal field extensions: an algebraic extension of fields `K/F` `K` is *normal*
+/-- Typeclass for normal field extensions: an algebraic extension of fields `K/F` is *normal*
 if the minimal polynomial of every element `x` in `K` splits in `K`, i.e. every `F`-conjugate
 of `x` is in `K`. -/
 @[stacks 09HM]


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
