### PR TITLE
[Merged by Bors] - feat(Order/Nucleus): The image of a nucleus is a frame

### DIFF
--- a/Mathlib/Order/Nucleus.lean
+++ b/Mathlib/Order/Nucleus.lean
@@ -242,16 +242,7 @@ def frameHom (n : Nucleus X) : FrameHom X (range n) where
   map_inf' a b := by
     ext
     simp [n.gi.gc.u_inf]
-  map_top' := by
-    simp [Top.top, n.gi.choice_eq]
-  map_sSup' s := by
-    ext
-    apply le_antisymm
-    · apply n.monotone
-      simp only [le_sSup_iff, upperBounds, mem_image, exists_exists_and_eq_and,
-        val_codRestrict_apply, forall_exists_index, and_imp, forall_apply_eq_imp_iff₂, mem_setOf_eq,
-        sSup_le_iff]
-      exact fun _ h1 c h2 ↦ le_trans n.le_apply (h1 c h2)
-    · rw [n.gi.gc.l_sSup, sSup_image]
+  map_top' := n.gi.l_top
+  map_sSup' s := by rw [n.gi.gc.l_sSup, sSup_image]
 
 end Nucleus

--- a/Mathlib/Order/Nucleus.lean
+++ b/Mathlib/Order/Nucleus.lean
@@ -215,7 +215,10 @@ lemma mem_range_iff (n : Nucleus X) (x : X) : x ∈ range n ↔ n x = x := by
 
 lemma coe_range_fixpoint (n : Nucleus X) (x : range n) : n x = x :=
   (n.mem_range_iff x).mp x.coe_prop
-
+/--
+The Nucleus restricted to its image together with the canoncial map backwards form a
+GaloisInsertion.
+-/
 def gi (n : Nucleus X) : GaloisInsertion (n.restrict) Subtype.val :=
   GaloisInsertion.monotoneIntro
   (fun ⦃a b⦄ a ↦ a)

--- a/Mathlib/Order/Nucleus.lean
+++ b/Mathlib/Order/Nucleus.lean
@@ -292,6 +292,9 @@ instance range_instMinAx : Order.Frame.MinimalAxioms (range n) where
 
 instance : Order.Frame (range n) := Order.Frame.ofMinimalAxioms range_instMinAx
 
+/--
+A Nucleus is a morphism of frames from the frame it lives in to the range of the nucleus.
+-/
 def embedding_frameHom (n : Nucleus X) : FrameHom X (range n) where
   toFun := n.embedding
   map_inf' a b := by

--- a/Mathlib/Order/Nucleus.lean
+++ b/Mathlib/Order/Nucleus.lean
@@ -230,8 +230,7 @@ instance range_instCompleteLattice : CompleteLattice (range n) where
   sup_le a b c h1 h2 := by
     simp only [← Subtype.coe_le_coe, val_codRestrict_apply]
     rw [← range_fixpoint c]
-    apply n.monotone
-    exact sup_le h1 h2
+    exact n.monotone (sup_le h1 h2)
   inf a b := n.embedding (a ⊓ b)
   inf_le_left a b := by
     simp only [← Subtype.coe_le_coe, val_codRestrict_apply, InfHomClass.map_inf]
@@ -249,29 +248,25 @@ instance range_instCompleteLattice : CompleteLattice (range n) where
     simp_all only [← Subtype.coe_le_coe, val_codRestrict_apply, InfHomClass.map_inf, le_inf_iff,
       Subtype.forall, mem_range, forall_exists_index, forall_apply_eq_imp_iff, idempotent, and_true]
     intro c h1 h2
-    apply le_trans h1 n.le_apply
+    exact le_trans h1 n.le_apply
   sSup s := n.embedding (⨆ x ∈ s, x)
   le_sSup s x h := by
     simp only [← Subtype.coe_le_coe, val_codRestrict_apply]
     rw [← range_fixpoint x]
-    apply n.monotone
-    exact le_biSup Subtype.val h
+    exact n.monotone (le_biSup Subtype.val h)
   sSup_le s x h := by
     simp only [← Subtype.coe_le_coe, val_codRestrict_apply]
     rw [← range_fixpoint x]
-    apply n.monotone
-    exact iSup₂_le_iff.mpr h
+    exact n.monotone (iSup₂_le_iff.mpr h)
   sInf s := n.embedding (⨅ x ∈ s, x)
   le_sInf s x h := by
     simp only [← Subtype.coe_le_coe, val_codRestrict_apply]
     rw [← range_fixpoint x]
-    apply n.monotone
-    exact le_iInf₂ h
+    exact n.monotone (le_iInf₂ h)
   sInf_le s x h := by
     simp only [← Subtype.coe_le_coe, val_codRestrict_apply]
     rw [← range_fixpoint x]
-    apply n.monotone
-    exact biInf_le Subtype.val h
+    exact n.monotone (biInf_le Subtype.val h)
   __ := Nucleus.range_instBoundedOrder
 
 -- TODO is there a better way to expand these definitions than defining these lemmas?

--- a/Mathlib/Order/Nucleus.lean
+++ b/Mathlib/Order/Nucleus.lean
@@ -5,7 +5,6 @@ Authors: Chriara Cimino, Christian Krause
 -/
 import Mathlib.Order.Closure
 import Mathlib.Order.Hom.CompleteLattice
-import Mathlib.Tactic.MinImports
 
 /-!
 # Nucleus
@@ -201,7 +200,7 @@ lemma mem_range : x ∈ range n ↔ n x = x where
   mpr h := ⟨x, h⟩
 
 /-- See `Nucleus.giRestrict` for the public-facing version. -/
-private def giAux (n : Nucleus X) : GaloisInsertion (Set.rangeFactorization n) Subtype.val where
+private def giAux (n : Nucleus X) : GaloisInsertion (rangeFactorization n) Subtype.val where
   choice x hx := ⟨x, mem_range.2 <| hx.antisymm n.le_apply⟩
   gc x y := ClosureOperator.IsClosed.closure_le_iff (c := n.toClosureOperator) <| mem_range.1 y.2
   le_l_u x := le_apply
@@ -221,14 +220,14 @@ instance : Frame (range n) := .ofMinimalAxioms range.instFrameMinimalAxioms
 
 /-- Restrict a nucleus to its range. -/
 @[simps] def restrict (n : Nucleus X) : FrameHom X (range n) where
-  toFun := Set.rangeFactorization n
+  toFun := rangeFactorization n
   map_inf' a b := by ext; exact map_inf
   map_top' := by ext; exact map_top n
   map_sSup' s := by rw [n.giAux.gc.l_sSup, sSup_image]
 
 /-- The restriction of a nucleus to its range forms a Galois insertion with the forgetful map from
 the range to the original frame. -/
-def giRestrict (n : Nucleus X) : GaloisInsertion (Set.rangeFactorization n) Subtype.val := n.giAux
+def giRestrict (n : Nucleus X) : GaloisInsertion (restrict n) Subtype.val := n.giAux
 
 end Frame
 end Nucleus

--- a/Mathlib/Order/Nucleus.lean
+++ b/Mathlib/Order/Nucleus.lean
@@ -227,7 +227,7 @@ instance : Frame (range n) := .ofMinimalAxioms range.instFrameMinimalAxioms
 
 /-- The restriction of a nucleus to its range forms a Galois insertion with the forgetful map from
 the range to the original frame. -/
-def giRestrict (n : Nucleus X) : GaloisInsertion (restrict n) Subtype.val := n.giAux
+def giRestrict (n : Nucleus X) : GaloisInsertion n.restrict Subtype.val := n.giAux
 
 end Frame
 end Nucleus


### PR DESCRIPTION
The image of a nucleus is a frame (which is the sublocale corresponding to this nucleus). If we restrict the codomain of a nucleus to its image, it is a FrameHom.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
