### PR TITLE
[Merged by Bors] - feat(Topology/Algebra/InfiniteSum): lemmas about tprods in a GroupWithZero

### DIFF
--- a/Mathlib/Topology/Algebra/InfiniteSum/Basic.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/Basic.lean
@@ -607,3 +607,20 @@ theorem tprod_finset_bUnion_disjoint {ι} {s : Finset ι} {t : ι → Set β}
 end ContinuousMul
 
 end tprod
+
+section CommMonoidWithZero
+variable [CommMonoidWithZero α] [TopologicalSpace α] {f : β → α}
+
+lemma hasProd_zero_of_exists_eq_zero (hf : ∃ b, f b = 0) : HasProd f 0 := by
+  obtain ⟨b, hb⟩ := hf
+  apply tendsto_const_nhds.congr'
+  filter_upwards [eventually_ge_atTop {b}] with s hs
+  refine (Finset.prod_eq_zero (Finset.singleton_subset_iff.mp hs) hb).symm
+
+lemma multipliable_of_exists_eq_zero (hf : ∃ b, f b = 0) : Multipliable f :=
+  ⟨0, hasProd_zero_of_exists_eq_zero hf⟩
+
+lemma tprod_of_exists_eq_zero [T2Space α] (hf : ∃ b, f b = 0) : ∏' b, f b = 0 :=
+  (hasProd_zero_of_exists_eq_zero hf).tprod_eq
+
+end CommMonoidWithZero

--- a/Mathlib/Topology/Algebra/InfiniteSum/Basic.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/Basic.lean
@@ -615,7 +615,7 @@ lemma hasProd_zero_of_exists_eq_zero (hf : ∃ b, f b = 0) : HasProd f 0 := by
   obtain ⟨b, hb⟩ := hf
   apply tendsto_const_nhds.congr'
   filter_upwards [eventually_ge_atTop {b}] with s hs
-  refine (Finset.prod_eq_zero (Finset.singleton_subset_iff.mp hs) hb).symm
+  exact (Finset.prod_eq_zero (Finset.singleton_subset_iff.mp hs) hb).symm
 
 lemma multipliable_of_exists_eq_zero (hf : ∃ b, f b = 0) : Multipliable f :=
   ⟨0, hasProd_zero_of_exists_eq_zero hf⟩

--- a/Mathlib/Topology/Algebra/InfiniteSum/Group.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/Group.lean
@@ -444,9 +444,7 @@ lemma Multipliable.congr_cofinite₀ (hf : Multipliable f) (hf' : ∀ a, f a ≠
     Multipliable g := by
   classical
   obtain ⟨c, hc⟩ := hf
-  obtain ⟨s, hs⟩ : ∃ s : Finset α, ∀ i ∉ s, f i = g i :=
-    ⟨hfg.toFinset, by simp only [Set.Finite.mem_toFinset, Set.mem_compl_iff, Set.mem_setOf_eq,
-      Decidable.not_not, imp_self, implies_true]⟩
+  obtain ⟨s, hs⟩ : ∃ s : Finset α, ∀ i ∉ s, f i = g i := ⟨hfg.toFinset, by simp⟩
   exact (hc.congr_cofinite₀ (fun a _ ↦ hf' a) hs).multipliable
 
 end CommGroupWithZero

--- a/Mathlib/Topology/Algebra/InfiniteSum/Group.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/Group.lean
@@ -397,3 +397,29 @@ theorem tprod_const [T2Space G] (a : G) : ∏' _ : β, a = a ^ (Nat.card β) := 
       simpa [multipliable_const_iff] using ha
 
 end IsTopologicalGroup
+
+section CommGroupWithZero
+variable {K : Type*} [CommGroupWithZero K] [TopologicalSpace K] [ContinuousMul K]
+
+open Finset in
+lemma Multipliable.congr_cofinite'
+    {f g : α → K} (hf : Multipliable f) (hf' : ∀ a, f a ≠ 0)
+    (hfg : ∀ᶠ a in cofinite, f a = g a) : Multipliable g := by
+  classical
+  obtain ⟨c, hc⟩ := hf
+  obtain ⟨s, hs⟩ : ∃ s : Finset α, ∀ i ∉ s, f i = g i :=
+    ⟨hfg.toFinset, by simp only [Set.Finite.mem_toFinset, Set.mem_compl_iff, Set.mem_setOf_eq,
+      Decidable.not_not, imp_self, implies_true]⟩
+  refine ⟨_, (Tendsto.mul_const ((∏ i ∈ s, g i) / ∏ i ∈ s, f i) hc).congr' ?_⟩
+  filter_upwards [eventually_ge_atTop s] with t ht
+  calc (∏ i ∈ t, f i) * ((∏ i ∈ s, g i) / ∏ i ∈ s, f i)
+  _ = ((∏ i ∈ s, f i) * ∏ i ∈ t \ s, g i) * _ := by
+    conv_lhs => rw [← union_sdiff_of_subset ht, prod_union disjoint_sdiff,
+      prod_congr rfl fun i hi ↦ hs i (mem_sdiff.mp hi).2]
+  _ = (∏ i ∈ s, g i) * ∏ i ∈ t \ s, g i := by
+    rw [← mul_div_assoc, ← div_mul_eq_mul_div, ← div_mul_eq_mul_div, div_self, one_mul, mul_comm]
+    exact prod_ne_zero_iff.mpr fun i _ ↦ hf' i
+  _ = ∏ i ∈ t, g i := by
+    rw [← prod_union disjoint_sdiff, union_sdiff_of_subset ht]
+
+end CommGroupWithZero

--- a/Mathlib/Topology/Algebra/InfiniteSum/Group.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/Group.lean
@@ -431,8 +431,8 @@ lemma HasProd.congr_cofinite₀ {c : K} (hc : HasProd f c) {s : Finset α}
 
 lemma tsum_congr_cofinite₀ [T2Space K] (hc : Multipliable f) {s : Finset α}
     (hs : ∀ a ∈ s, f a ≠ 0) (hs' : ∀ a ∉ s, f a = g a) :
-    ∏' i, g i = ((∏' i, f i) * ((∏ i ∈ s, g i) / ∏ i ∈ s, f i)) := by
-  refine (hc.hasProd.congr_cofinite₀ hs hs').tprod_eq
+    ∏' i, g i = ((∏' i, f i) * ((∏ i ∈ s, g i) / ∏ i ∈ s, f i)) :=
+  (hc.hasProd.congr_cofinite₀ hs hs').tprod_eq
 
 /--
 See also `Multipliable.congr_cofinite`, which does not have a non-vanishing condition, but instead

--- a/Mathlib/Topology/Algebra/InfiniteSum/Group.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/Group.lean
@@ -431,7 +431,7 @@ lemma HasProd.congr_cofinite₀ {c : K} (hc : HasProd f c) {s : Finset α}
 
 lemma tsum_congr_cofinite₀ [T2Space K] (hc : Multipliable f) {s : Finset α}
     (hs : ∀ a ∈ s, f a ≠ 0) (hs' : ∀ a ∉ s, f a = g a) :
-    ∏' i, g i =  ((∏' i, f i) * ((∏ i ∈ s, g i) / ∏ i ∈ s, f i)) := by
+    ∏' i, g i = ((∏' i, f i) * ((∏ i ∈ s, g i) / ∏ i ∈ s, f i)) := by
   refine (hc.hasProd.congr_cofinite₀ hs hs').tprod_eq
 
 /--

--- a/Mathlib/Topology/Algebra/InfiniteSum/Group.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/Group.lean
@@ -128,7 +128,12 @@ theorem hasProd_ite_div_hasProd [DecidableEq β] (hf : HasProd f a) (b : β) :
   · rw [div_mul_eq_mul_div, one_mul]
 
 /-- A more general version of `Multipliable.congr`, allowing the functions to
-disagree on a finite set. -/
+disagree on a finite set.
+
+Note that this requires the target to be a group, and hence fails for products valued
+in a ring. See `Multipliable.congr_cofinite₀` for a version applying in this case,
+with an additional non-vanishing hypothesis.
+-/
 @[to_additive "A more general version of `Summable.congr`, allowing the functions to
 disagree on a finite set."]
 theorem Multipliable.congr_cofinite (hf : Multipliable f) (hfg : f =ᶠ[cofinite] g) :
@@ -399,27 +404,49 @@ theorem tprod_const [T2Space G] (a : G) : ∏' _ : β, a = a ^ (Nat.card β) := 
 end IsTopologicalGroup
 
 section CommGroupWithZero
-variable {K : Type*} [CommGroupWithZero K] [TopologicalSpace K] [ContinuousMul K]
+variable {K : Type*} [CommGroupWithZero K] [TopologicalSpace K] [ContinuousMul K] {f g : α → K}
+/-!
+## Groups with a zero
+
+These lemmas apply to a `CommGroupWithZero`; the most familiar case is when `K` is a field. These
+are specific to the product setting and do not have a sensible additive analogue.
+-/
 
 open Finset in
-lemma Multipliable.congr_cofinite'
-    {f g : α → K} (hf : Multipliable f) (hf' : ∀ a, f a ≠ 0)
-    (hfg : ∀ᶠ a in cofinite, f a = g a) : Multipliable g := by
+lemma HasProd.congr_cofinite₀ {c : K} (hc : HasProd f c) {s : Finset α}
+    (hs : ∀ a ∈ s, f a ≠ 0) (hs' : ∀ a ∉ s, f a = g a) :
+    HasProd g (c * ((∏ i ∈ s, g i) / ∏ i ∈ s, f i)) := by
+  classical
+  refine (Tendsto.mul_const ((∏ i ∈ s, g i) / ∏ i ∈ s, f i) hc).congr' ?_
+  filter_upwards [eventually_ge_atTop s] with t ht
+  calc (∏ i ∈ t, f i) * ((∏ i ∈ s, g i) / ∏ i ∈ s, f i)
+  _ = ((∏ i ∈ s, f i) * ∏ i ∈ t \ s, g i) * _ := by
+    conv_lhs => rw [← union_sdiff_of_subset ht, prod_union disjoint_sdiff,
+      prod_congr rfl fun i hi ↦ hs' i (mem_sdiff.mp hi).2]
+  _ = (∏ i ∈ s, g i) * ∏ i ∈ t \ s, g i := by
+    rw [← mul_div_assoc, ← div_mul_eq_mul_div, ← div_mul_eq_mul_div, div_self, one_mul, mul_comm]
+    exact prod_ne_zero_iff.mpr hs
+  _ = ∏ i ∈ t, g i := by
+    rw [← prod_union disjoint_sdiff, union_sdiff_of_subset ht]
+
+lemma tsum_congr_cofinite₀ [T2Space K] (hc : Multipliable f) {s : Finset α}
+    (hs : ∀ a ∈ s, f a ≠ 0) (hs' : ∀ a ∉ s, f a = g a) :
+    ∏' i, g i =  ((∏' i, f i) * ((∏ i ∈ s, g i) / ∏ i ∈ s, f i)) := by
+  refine (hc.hasProd.congr_cofinite₀ hs hs').tprod_eq
+
+/--
+See also `Multipliable.congr_cofinite`, which does not have a non-vanishing condition, but instead
+requires the target to be a group under multiplication (and hence fails for infinite products in a
+ring).
+-/
+lemma Multipliable.congr_cofinite₀ (hf : Multipliable f) (hf' : ∀ a, f a ≠ 0)
+    (hfg : ∀ᶠ a in cofinite, f a = g a) :
+    Multipliable g := by
   classical
   obtain ⟨c, hc⟩ := hf
   obtain ⟨s, hs⟩ : ∃ s : Finset α, ∀ i ∉ s, f i = g i :=
     ⟨hfg.toFinset, by simp only [Set.Finite.mem_toFinset, Set.mem_compl_iff, Set.mem_setOf_eq,
       Decidable.not_not, imp_self, implies_true]⟩
-  refine ⟨_, (Tendsto.mul_const ((∏ i ∈ s, g i) / ∏ i ∈ s, f i) hc).congr' ?_⟩
-  filter_upwards [eventually_ge_atTop s] with t ht
-  calc (∏ i ∈ t, f i) * ((∏ i ∈ s, g i) / ∏ i ∈ s, f i)
-  _ = ((∏ i ∈ s, f i) * ∏ i ∈ t \ s, g i) * _ := by
-    conv_lhs => rw [← union_sdiff_of_subset ht, prod_union disjoint_sdiff,
-      prod_congr rfl fun i hi ↦ hs i (mem_sdiff.mp hi).2]
-  _ = (∏ i ∈ s, g i) * ∏ i ∈ t \ s, g i := by
-    rw [← mul_div_assoc, ← div_mul_eq_mul_div, ← div_mul_eq_mul_div, div_self, one_mul, mul_comm]
-    exact prod_ne_zero_iff.mpr fun i _ ↦ hf' i
-  _ = ∏ i ∈ t, g i := by
-    rw [← prod_union disjoint_sdiff, union_sdiff_of_subset ht]
+  exact (hc.congr_cofinite₀ (fun a _ ↦ hf' a) hs).multipliable
 
 end CommGroupWithZero


### PR DESCRIPTION
Show that a sequence with a zero term is always multipliable, and a congruence lemma for `Multipliable` for eventually-equal sequences. (We have [Multipliable.congr_cofinite](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Topology/Algebra/InfiniteSum/Group.html#Multipliable.congr_cofinite) but that requires the target to be a group under multiplication, which is never satisfied for the underlying multiplicative monoid of a ring; so this new lemma is useful for manipulating products valued in rings / fields.)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
