### PR TITLE
[Merged by Bors] - fix: delete CategoryTheory.pi'

### DIFF
--- a/Mathlib/CategoryTheory/Pi/Basic.lean
+++ b/Mathlib/CategoryTheory/Pi/Basic.lean
@@ -29,14 +29,6 @@ instance pi : Category.{max w₀ v₁} (∀ i, C i) where
   id X i := 𝟙 (X i)
   comp f g i := f i ≫ g i
 
-/-- This provides some assistance to typeclass search in a common situation,
-which otherwise fails. (Without this `CategoryTheory.Pi.has_limit_of_has_limit_comp_eval` fails.)
--/
-abbrev pi' {I : Type v₁} (C : I → Type u₁) [∀ i, Category.{v₁} (C i)] : Category.{v₁} (∀ i, C i) :=
-  CategoryTheory.pi C
-
-attribute [instance] pi'
-
 namespace Pi
 
 @[simp]


### PR DESCRIPTION
`CategoryTheory.pi'` looks a bit like a hack. It came from the mathlib3 port, and the justification of its existence in its docstring seems to refer to a mathlib3 declaration, which is presumably now [hasLimit_of_hasLimit_comp_eval](https://leanprover-community.github.io/mathlib4_docs/Mathlib/CategoryTheory/Limits/Pi.html#CategoryTheory.pi.hasLimit_of_hasLimit_comp_eval). In Lean 4 this latter declaration compiles just fine if `pi'` is deleted (with the same number of heartbeats). Furthermore, on current mathlib master this code causes a stack overflow:

```
import Mathlib.CategoryTheory.Endomorphism

#check CategoryTheory.End CategoryTheory.Functor.id
```
(which people might want to independently investigate) but deleting `CategoryTheory.pi'` fixes this problem (for reasons I don't understand). 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
