### PR TITLE
[Merged by Bors] - feat(Analysis/InnerProductSpace): Add `HilbertSpace` variable alias

### DIFF
--- a/Mathlib/Analysis/InnerProductSpace/Defs.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Defs.lean
@@ -10,9 +10,9 @@ import Mathlib.Data.Complex.Basic
 /-!
 # Inner product spaces
 
-This file defines inner product spaces.  We do not formally define Hilbert spaces, but they can be
-obtained using the set of assumptions
-`[NormedAddCommGroup E] [InnerProductSpace 𝕜 E] [CompleteSpace E]`.
+This file defines inner product spaces. For Hilbert spaces `HilbertSpace` is a typeclass alias, so
+that one can write `variable? [HilbertSpace 𝕜 E]` and get suggested
+`[RCLike 𝕜] [NormedAddCommGroup E] [InnerProductSpace 𝕜 E] [CompleteSpace E]`.
 
 An inner product space is a vector space endowed with an inner product. It generalizes the notion of
 dot product in `ℝ^n` and provides the means of defining the length of a vector and the angle between
@@ -502,5 +502,14 @@ def InnerProductSpace.ofCore [AddCommGroup F] [Module 𝕜 F] (cd : InnerProduct
       simp [h₁, sq_sqrt, h₂] }
 
 end
+
+section HilbertSpace
+
+/-- A Hilbert space is a complete normed inner product space. -/
+@[variable_alias]
+structure HilbertSpace (𝕜 E : Type*) [RCLike 𝕜]
+  [NormedAddCommGroup E] [InnerProductSpace 𝕜 E] [CompleteSpace E]
+
+end HilbertSpace
 
 end

--- a/Mathlib/Analysis/InnerProductSpace/Defs.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Defs.lean
@@ -10,9 +10,11 @@ import Mathlib.Data.Complex.Basic
 /-!
 # Inner product spaces
 
-This file defines inner product spaces. For Hilbert spaces `HilbertSpace` is a typeclass alias, so
-that one can write `variable? [HilbertSpace 𝕜 E]` and get suggested
+This file defines inner product spaces.
+Hilbert spaces can be obtained using the set of assumptions
 `[RCLike 𝕜] [NormedAddCommGroup E] [InnerProductSpace 𝕜 E] [CompleteSpace E]`.
+For convenience, a variable alias `HilbertSpace` is provided so that one can write
+`variable? [HilbertSpace 𝕜 E]` and get this as a suggestion.
 
 An inner product space is a vector space endowed with an inner product. It generalizes the notion of
 dot product in `ℝ^n` and provides the means of defining the length of a vector and the angle between
@@ -503,13 +505,9 @@ def InnerProductSpace.ofCore [AddCommGroup F] [Module 𝕜 F] (cd : InnerProduct
 
 end
 
-section HilbertSpace
-
 /-- A Hilbert space is a complete normed inner product space. -/
 @[variable_alias]
 structure HilbertSpace (𝕜 E : Type*) [RCLike 𝕜]
   [NormedAddCommGroup E] [InnerProductSpace 𝕜 E] [CompleteSpace E]
-
-end HilbertSpace
 
 end


### PR DESCRIPTION
See [Zulip discussion](https://leanprover.zulipchat.com/#narrow/channel/217875-Is-there-code-for-X.3F/topic/Is.20there.20code.20for.20Hilbert.20Spaces.3F/with/510364826).


---

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

I'm not sure how to document this. I looked at the documentation of some other variable alias.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
