### PR TITLE
[Merged by Bors] - doc(Computability): expand explanations

### DIFF
--- a/Mathlib/Computability/DFA.lean
+++ b/Mathlib/Computability/DFA.lean
@@ -11,11 +11,26 @@ import Mathlib.Tactic.NormNum
 /-!
 # Deterministic Finite Automata
 
-This file contains the definition of a Deterministic Finite Automaton (DFA), a state machine which
-determines whether a string (implemented as a list over an arbitrary alphabet) is in a regular set
-in linear time.
-Note that this definition allows for Automaton with infinite states, a `Fintype` instance must be
-supplied for true DFA's.
+A Deterministic Finite Automaton (DFA) is a state machine which
+decides membership in a particular regular language, by following a path
+uniquely determined by an input string.
+
+We define regular languages to be ones for which a DFA exists, other formulations
+are then proved equivalent.
+
+Note that this definition allows for automata with infinite states,
+a `Fintype` instance must be supplied for true DFAs.
+
+## Main definitions
+
+- `DFA α σ` : automaton over alphabet `α` and set of states `σ`
+- `M.accepts` : language accepted by `M`
+- `Language.IsRegular L` : `L` is a regular language
+
+## Main theorems
+
+- `DFA.pumping_lemma` : every sufficiently long string accepted by the DFA has a substring that can
+  be repeated arbitrarily many times
 
 ## Implementation notes
 

--- a/Mathlib/Computability/DFA.lean
+++ b/Mathlib/Computability/DFA.lean
@@ -12,20 +12,21 @@ import Mathlib.Tactic.NormNum
 # Deterministic Finite Automata
 
 A Deterministic Finite Automaton (DFA) is a state machine which
-decides membership in a particular regular language, by following a path
+decides membership in a particular `Language`, by following a path
 uniquely determined by an input string.
 
 We define regular languages to be ones for which a DFA exists, other formulations
-are then proved equivalent.
+are later proved equivalent.
 
 Note that this definition allows for automata with infinite states,
 a `Fintype` instance must be supplied for true DFAs.
 
 ## Main definitions
 
-- `DFA α σ` : automaton over alphabet `α` and set of states `σ`
-- `M.accepts` : language accepted by `M`
-- `Language.IsRegular L` : `L` is a regular language
+- `DFA α σ`: automaton over alphabet `α` and set of states `σ`
+- `M.accepts`: the language accepted by the DFA `M`
+- `Language.IsRegular L`: a predicate stating that `L` is a regular language, i.e. there exists
+  a DFA that recognizes the language
 
 ## Main theorems
 

--- a/Mathlib/Computability/Partrec.lean
+++ b/Mathlib/Computability/Partrec.lean
@@ -14,13 +14,13 @@ The partial recursive functions are defined similarly to the primitive
 recursive functions, but now all functions are partial, implemented
 using the `Part` monad, and there is an additional operation, called
 μ-recursion, which performs unbounded minimization: `μ f` returns the
-least natural number `n` for which `f n = 0`, ot diverges if such `n` doesn't exist.
+least natural number `n` for which `f n = 0`, or diverges if such `n` doesn't exist.
 
 ## Main definitions
 
-- `Nat.Partrec f` : `f` is partial recursive, for functions `f : ℕ →. ℕ`
-- `Partrec f` : `f` is partial recursive, for partial functions between `Primcodable` types
-- `Computable f` : `f` is partial recursive, for total functions between `Primcodable` types
+- `Nat.Partrec f`: `f` is partial recursive, for functions `f : ℕ →. ℕ`
+- `Partrec f`: `f` is partial recursive, for partial functions between `Primcodable` types
+- `Computable f`: `f` is partial recursive, for total functions between `Primcodable` types
 
 ## References
 

--- a/Mathlib/Computability/Partrec.lean
+++ b/Mathlib/Computability/Partrec.lean
@@ -13,7 +13,14 @@ import Mathlib.Data.PFun
 The partial recursive functions are defined similarly to the primitive
 recursive functions, but now all functions are partial, implemented
 using the `Part` monad, and there is an additional operation, called
-μ-recursion, which performs unbounded minimization.
+μ-recursion, which performs unbounded minimization: `μ f` returns the
+least natural number `n` for which `f n = 0`, ot diverges if such `n` doesn't exist.
+
+## Main definitions
+
+- `Nat.Partrec f` : `f` is partial recursive, for functions `f : ℕ →. ℕ`
+- `Partrec f` : `f` is partial recursive, for partial functions between `Primcodable` types
+- `Computable f` : `f` is partial recursive, for total functions between `Primcodable` types
 
 ## References
 
@@ -141,7 +148,7 @@ theorem rfindOpt_mono {α} {f : ℕ → Option α} (H : ∀ {a m n}, m ≤ n →
     have := (H (le_max_left _ _) h).symm.trans (H (le_max_right _ _) hk)
     simp at this; simp [this, get_mem]⟩
 
-/-- `PartRec f` means that the partial function `f : ℕ → ℕ` is partially recursive. -/
+/-- `Partrec f` means that the partial function `f : ℕ → ℕ` is partially recursive. -/
 inductive Partrec : (ℕ →. ℕ) → Prop
   | zero : Partrec (pure 0)
   | succ : Partrec succ

--- a/Mathlib/Computability/Primrec.lean
+++ b/Mathlib/Computability/Primrec.lean
@@ -26,13 +26,14 @@ In the above, the pairing function is primitive recursive by definition.
 This deviates from the textbook definition of primitive recursive functions,
 which instead work with *`n`-ary* functions. We formalize the textbook
 definition in `Nat.Primrec'`. `Nat.Primrec'.prim_iff` then proves it is
-equivalent to our chosen formulation.
+equivalent to our chosen formulation. For more discussionn of this and
+other design choices in this formalization, see [carneiro2019].
 
 ## Main definitions
 
-- `Nat.Primrec f` : `f` is primitive recursive, for functions `f : ℕ → ℕ`
-- `Primrec f` : `f` is primitive recursive, for functions between `Primcodable` types
-- `Primcodable α` : well-behaved encoding of `α` into `ℕ`, i.e. one such that roundtripping through
+- `Nat.Primrec f`: `f` is primitive recursive, for functions `f : ℕ → ℕ`
+- `Primrec f`: `f` is primitive recursive, for functions between `Primcodable` types
+- `Primcodable α`: well-behaved encoding of `α` into `ℕ`, i.e. one such that roundtripping through
   the encoding functions adds no computational power
 
 ## References
@@ -117,15 +118,15 @@ end Primrec
 end Nat
 
 /-- A `Primcodable` type is, essentially, an `Encodable` type for which
-  the encode/decode functions are primitive recursive.
-  However, such a definition is circular.
+the encode/decode functions are primitive recursive.
+However, such a definition is circular.
 
-  Instead, we ask that the composition of `decode : ℕ → option α` with
-  `encode : option α → ℕ` is primitive recursive. Said composition is
-  the identity function, restricted to the image of `encode`.
-  Thus, in a way, the added requirement ensures that no predicates
-  can be smuggled in through a cunning choice of the subset of `ℕ` into
-  which the type is encoded. -/
+Instead, we ask that the composition of `decode : ℕ → option α` with
+`encode : option α → ℕ` is primitive recursive. Said composition is
+the identity function, restricted to the image of `encode`.
+Thus, in a way, the added requirement ensures that no predicates
+can be smuggled in through a cunning choice of the subset of `ℕ` into
+which the type is encoded. -/
 class Primcodable (α : Type*) extends Encodable α where
   -- Porting note: was `prim [] `.
   -- This means that `prim` does not take the type explicitly in Lean 4

--- a/Mathlib/Computability/Primrec.lean
+++ b/Mathlib/Computability/Primrec.lean
@@ -22,6 +22,19 @@ we need that the composition of encode with decode yields a
 primitive recursive function, so we have the `Primcodable` type class
 for this.)
 
+In the above, the pairing function is primitive recursive by definition.
+This deviates from the textbook definition of primitive recursive functions,
+which instead work with *`n`-ary* functions. We formalize the textbook
+definition in `Nat.Primrec'`. `Nat.Primrec'.prim_iff` then proves it is
+equivalent to our chosen formulation.
+
+## Main definitions
+
+- `Nat.Primrec f` : `f` is primitive recursive, for functions `f : ℕ → ℕ`
+- `Primrec f` : `f` is primitive recursive, for functions between `Primcodable` types
+- `Primcodable α` : well-behaved encoding of `α` into `ℕ`, i.e. one such that roundtripping through
+  the encoding functions adds no computational power
+
 ## References
 
 * [Mario Carneiro, *Formalizing computability theory via partial recursive functions*][carneiro2019]
@@ -103,8 +116,16 @@ end Primrec
 
 end Nat
 
-/-- A `Primcodable` type is an `Encodable` type for which
-  the encode/decode functions are primitive recursive. -/
+/-- A `Primcodable` type is, essentially, an `Encodable` type for which
+  the encode/decode functions are primitive recursive.
+  However, such a definition is circular.
+
+  Instead, we ask that the composition of `decode : ℕ → option α` with
+  `encode : option α → ℕ` is primitive recursive. Said composition is
+  the identity function, restricted to the image of `encode`.
+  Thus, in a way, the added requirement ensures that no predicates
+  can be smuggled in through a cunning choice of the subset of `ℕ` into
+  which the type is encoded. -/
 class Primcodable (α : Type*) extends Encodable α where
   -- Porting note: was `prim [] `.
   -- This means that `prim` does not take the type explicitly in Lean 4


### PR DESCRIPTION
I have found some parts of the Computability development hard to follow without referencing the linked paper. This is my attempt at expanding the documentation to make the development easier to follow on its own.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
