### PR TITLE
[Merged by Bors] - fix: missing `noWs` in  notations

### DIFF
--- a/Mathlib/Algebra/Module/Torsion.lean
+++ b/Mathlib/Algebra/Module/Torsion.lean
@@ -911,8 +911,15 @@ variable (A : Type*) [AddCommGroup A] (n : ℤ)
 def torsionBy : AddSubgroup A :=
   (Submodule.torsionBy ℤ A n).toAddSubgroup
 
-@[inherit_doc]
-scoped notation:max (priority := high) A"["n"]" => torsionBy A n
+@[inherit_doc torsionBy]
+scoped syntax:max (name := torsionByStx) (priority := high) term noWs "[" term "]" : term
+
+macro_rules | `($A[$n]) => `(torsionBy $A $n)
+
+@[app_unexpander torsionBy]
+def torsionByUnexpander : Lean.PrettyPrinter.Unexpander
+  | `($_ $A $n) => `($A[$n])
+  | _ => throw ()
 
 lemma torsionBy.neg : A[-n] = A[n] := by
   ext a

--- a/Mathlib/Algebra/Module/Torsion.lean
+++ b/Mathlib/Algebra/Module/Torsion.lean
@@ -916,6 +916,7 @@ scoped syntax:max (name := torsionByStx) (priority := high) term noWs "[" term "
 
 macro_rules | `($A[$n]) => `(torsionBy $A $n)
 
+/-- Unexpander for `torsionBy`. -/
 @[app_unexpander torsionBy]
 def torsionByUnexpander : Lean.PrettyPrinter.Unexpander
   | `($_ $A $n) => `($A[$n])

--- a/Mathlib/Algebra/Module/Torsion.lean
+++ b/Mathlib/Algebra/Module/Torsion.lean
@@ -917,7 +917,7 @@ scoped syntax:max (name := torsionByStx) (priority := high) term noWs "[" term "
 macro_rules | `($A[$n]) => `(torsionBy $A $n)
 
 /-- Unexpander for `torsionBy`. -/
-@[app_unexpander torsionBy]
+@[scoped app_unexpander torsionBy]
 def torsionByUnexpander : Lean.PrettyPrinter.Unexpander
   | `($_ $A $n) => `($A[$n])
   | _ => throw ()

--- a/Mathlib/Algebra/MonoidAlgebra/Defs.lean
+++ b/Mathlib/Algebra/MonoidAlgebra/Defs.lean
@@ -816,10 +816,17 @@ endowed with the convolution product.
 def AddMonoidAlgebra :=
   G →₀ k
 
-@[inherit_doc]
-scoped[AddMonoidAlgebra] notation:9000 R:max "[" A "]" => AddMonoidAlgebra R A
-
 namespace AddMonoidAlgebra
+
+@[inherit_doc AddMonoidAlgebra]
+scoped syntax:max (priority := high) term noWs "[" term "]" : term
+
+macro_rules | `($k[$g]) => `(AddMonoidAlgebra $k $g)
+
+@[app_unexpander AddMonoidAlgebra]
+def unexpander : Lean.PrettyPrinter.Unexpander
+  | `($_ $k $g) => `($k[$g])
+  | _ => throw ()
 
 instance inhabited : Inhabited k[G] :=
   inferInstanceAs (Inhabited (G →₀ k))

--- a/Mathlib/Algebra/MonoidAlgebra/Defs.lean
+++ b/Mathlib/Algebra/MonoidAlgebra/Defs.lean
@@ -823,6 +823,7 @@ scoped syntax:max (priority := high) term noWs "[" term "]" : term
 
 macro_rules | `($k[$g]) => `(AddMonoidAlgebra $k $g)
 
+/-- Unexpander for `AddMonoidAlgebra`. -/
 @[app_unexpander AddMonoidAlgebra]
 def unexpander : Lean.PrettyPrinter.Unexpander
   | `($_ $k $g) => `($k[$g])

--- a/Mathlib/Algebra/MonoidAlgebra/Defs.lean
+++ b/Mathlib/Algebra/MonoidAlgebra/Defs.lean
@@ -824,7 +824,7 @@ scoped syntax:max (priority := high) term noWs "[" term "]" : term
 macro_rules | `($k[$g]) => `(AddMonoidAlgebra $k $g)
 
 /-- Unexpander for `AddMonoidAlgebra`. -/
-@[app_unexpander AddMonoidAlgebra]
+@[scoped app_unexpander AddMonoidAlgebra]
 def unexpander : Lean.PrettyPrinter.Unexpander
   | `($_ $k $g) => `($k[$g])
   | _ => throw ()


### PR DESCRIPTION
Also removed the `9000` priority, since this was probably chosen randomly, and there is no comment justifying it.

This somewhat follows on from #19900.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
