### PR TITLE
[Merged by Bors] - chore(Data/Finset): deprecate Finset.fin

### DIFF
--- a/Mathlib/Data/Finset/Fin.lean
+++ b/Mathlib/Data/Finset/Fin.lean
@@ -76,27 +76,35 @@ lemma attachFin_ssubset_attachFin {s t : Finset ℕ} (hst : s ⊂ t) (ht : ∀ m
 
 /-- Given a finset `s` of natural numbers and a bound `n`,
 `s.fin n` is the finset of all elements of `s` less than `n`.
+
+This definition was introduced to define a `LocallyFiniteOrder` instance on `Fin n`.
+Later, this instance was rewritten using a more efficient `attachFin`.
+Since this definition had no other uses in the library, it was deprecated.
 -/
+@[deprecated attachFin (since := "2025-04-08")]
 protected def fin (n : ℕ) (s : Finset ℕ) : Finset (Fin n) :=
   (s.subtype _).map Fin.equivSubtype.symm.toEmbedding
 
-@[simp]
-theorem mem_fin {n} {s : Finset ℕ} : ∀ a : Fin n, a ∈ s.fin n ↔ (a : ℕ) ∈ s
+set_option linter.deprecated false
+
+@[simp, deprecated mem_attachFin (since := "2025-04-08")]
+theorem mem_fin {s : Finset ℕ} : ∀ a : Fin n, a ∈ s.fin n ↔ (a : ℕ) ∈ s
   | ⟨a, ha⟩ => by simp [Finset.fin, ha, and_comm]
 
-@[simp]
+@[simp, deprecated coe_attachFin (since := "2025-04-08")]
 theorem coe_fin (n : ℕ) (s : Finset ℕ) : (s.fin n : Set (Fin n)) = Fin.val ⁻¹' s := by ext; simp
 
-@[mono]
-theorem fin_mono {n} : Monotone (Finset.fin n) := fun s t h x => by simpa using @h x
+@[mono, deprecated attachFin_subset_attachFin (since := "2025-04-08")]
+theorem fin_mono : Monotone (Finset.fin n) := fun s t h x => by simpa using @h x
 
-@[gcongr]
+@[gcongr, deprecated attachFin_subset_attachFin (since := "2025-04-08")]
 theorem fin_subset_fin (n : ℕ) {s t : Finset ℕ} (h : s ⊆ t) : s.fin n ⊆ t.fin n := fin_mono h
 
-@[simp]
+@[simp, deprecated map_valEmbedding_attachFin (since := "2025-04-08")]
 theorem fin_map {n} {s : Finset ℕ} : (s.fin n).map Fin.valEmbedding = s.filter (· < n) := by
   simp [Finset.fin, Finset.map_map]
 
+@[deprecated "No replacement" (since := "2025-04-08")]
 theorem attachFin_eq_fin {s : Finset ℕ} (h : ∀ m ∈ s, m < n) :
     attachFin s h = s.fin n := by
   ext

--- a/Mathlib/Data/Finset/Fin.lean
+++ b/Mathlib/Data/Finset/Fin.lean
@@ -101,7 +101,7 @@ theorem fin_mono : Monotone (Finset.fin n) := fun s t h x => by simpa using @h x
 theorem fin_subset_fin (n : ℕ) {s t : Finset ℕ} (h : s ⊆ t) : s.fin n ⊆ t.fin n := fin_mono h
 
 @[simp, deprecated map_valEmbedding_attachFin (since := "2025-04-08")]
-theorem fin_map {n} {s : Finset ℕ} : (s.fin n).map Fin.valEmbedding = s.filter (· < n) := by
+theorem fin_map {s : Finset ℕ} : (s.fin n).map Fin.valEmbedding = s.filter (· < n) := by
   simp [Finset.fin, Finset.map_map]
 
 @[deprecated "No replacement" (since := "2025-04-08")]

--- a/Mathlib/Order/Interval/Finset/Fin.lean
+++ b/Mathlib/Order/Interval/Finset/Fin.lean
@@ -89,17 +89,19 @@ theorem attachFin_Ioo_eq_Ioi : attachFin (Ioo a n) (fun _x hx ↦ (mem_Ioo.mp hx
 
 section deprecated
 
-set_option linter.deprecated false
-
+set_option linter.deprecated false in
 @[deprecated attachFin_Icc (since := "2025-04-06")]
 theorem Icc_eq_finset_subtype : Icc a b = (Icc (a : ℕ) b).fin n := attachFin_eq_fin _
 
+set_option linter.deprecated false in
 @[deprecated attachFin_Ico (since := "2025-04-06")]
 theorem Ico_eq_finset_subtype : Ico a b = (Ico (a : ℕ) b).fin n := attachFin_eq_fin _
 
+set_option linter.deprecated false in
 @[deprecated attachFin_Ioc (since := "2025-04-06")]
 theorem Ioc_eq_finset_subtype : Ioc a b = (Ioc (a : ℕ) b).fin n := attachFin_eq_fin _
 
+set_option linter.deprecated false in
 @[deprecated attachFin_Ioo (since := "2025-04-06")]
 theorem Ioo_eq_finset_subtype : Ioo a b = (Ioo (a : ℕ) b).fin n := attachFin_eq_fin _
 
@@ -107,15 +109,19 @@ set_option linter.deprecated false in
 @[deprecated attachFin_uIcc (since := "2025-04-06")]
 theorem uIcc_eq_finset_subtype : uIcc a b = (uIcc (a : ℕ) b).fin n := Icc_eq_finset_subtype _ _
 
+set_option linter.deprecated false in
 @[deprecated attachFin_Ico_eq_Ici (since := "2025-04-06")]
 theorem Ici_eq_finset_subtype : Ici a = (Ico (a : ℕ) n).fin n := by ext; simp
 
+set_option linter.deprecated false in
 @[deprecated attachFin_Ioo_eq_Ioi (since := "2025-04-06")]
 theorem Ioi_eq_finset_subtype : Ioi a = (Ioo (a : ℕ) n).fin n := by ext; simp
 
+set_option linter.deprecated false in
 @[deprecated attachFin_Iic (since := "2025-04-06")]
 theorem Iic_eq_finset_subtype : Iic b = (Iic (b : ℕ)).fin n := by ext; simp
 
+set_option linter.deprecated false in
 @[deprecated attachFin_Iio (since := "2025-04-06")]
 theorem Iio_eq_finset_subtype : Iio b = (Iio (b : ℕ)).fin n := by ext; simp
 

--- a/Mathlib/Order/Interval/Finset/Fin.lean
+++ b/Mathlib/Order/Interval/Finset/Fin.lean
@@ -87,6 +87,7 @@ theorem attachFin_Iio : attachFin (Iio a) (fun _x hx ↦ (mem_Iio.mp hx).trans a
 theorem attachFin_Ioo_eq_Ioi : attachFin (Ioo a n) (fun _x hx ↦ (mem_Ioo.mp hx).2) = Ioi a := by
   ext; simp
 
+set_option linter.deprecated false in
 section deprecated
 
 @[deprecated attachFin_Icc (since := "2025-04-06")]

--- a/Mathlib/Order/Interval/Finset/Fin.lean
+++ b/Mathlib/Order/Interval/Finset/Fin.lean
@@ -87,8 +87,9 @@ theorem attachFin_Iio : attachFin (Iio a) (fun _x hx ↦ (mem_Iio.mp hx).trans a
 theorem attachFin_Ioo_eq_Ioi : attachFin (Ioo a n) (fun _x hx ↦ (mem_Ioo.mp hx).2) = Ioi a := by
   ext; simp
 
-set_option linter.deprecated false in
 section deprecated
+
+set_option linter.deprecated false
 
 @[deprecated attachFin_Icc (since := "2025-04-06")]
 theorem Icc_eq_finset_subtype : Icc a b = (Icc (a : ℕ) b).fin n := attachFin_eq_fin _


### PR DESCRIPTION
---

I'm not 100% sure that we can do this, but the def is trivial and we no longer use it.
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
