### PR TITLE
[Merged by Bors] - feat(LinearAlgebra/RootSystem): Generalize RootPairing.pairing_zero_iff

### DIFF
--- a/Mathlib/LinearAlgebra/RootSystem/CartanMatrix.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/CartanMatrix.lean
@@ -59,13 +59,13 @@ lemma cartanMatrix_apply_same (i : b.support) :
     b.cartanMatrix i i = 2 :=
   b.cartanMatrixIn_apply_same ℤ i
 
-lemma cartanMatrix_le_zero_of_ne [Finite ι] [NoZeroDivisors R]
+lemma cartanMatrix_le_zero_of_ne [Finite ι] [IsDomain R]
     [NoZeroSMulDivisors R M] [NoZeroSMulDivisors R N]
     (i j : b.support) (h : i ≠ j) :
     b.cartanMatrix i j ≤ 0 :=
   b.pairingIn_le_zero_of_ne (by rwa [ne_eq, ← Subtype.ext_iff]) i.property j.property
 
-lemma cartanMatrix_mem_of_ne [Finite ι] [NoZeroDivisors R] [NoZeroSMulDivisors R M]
+lemma cartanMatrix_mem_of_ne [Finite ι] [IsDomain R] [NoZeroSMulDivisors R M]
     [NoZeroSMulDivisors R N] {i j : b.support} (hij : i ≠ j) :
     b.cartanMatrix i j ∈ ({-3, -2, -1, 0} : Set ℤ) := by
   simp only [cartanMatrix, cartanMatrixIn_def]

--- a/Mathlib/LinearAlgebra/RootSystem/Defs.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Defs.lean
@@ -749,4 +749,18 @@ lemma isFixedPt_reflection_of_isOrthogonal {s : Set ι} (hj : ∀ i ∈ s, P.IsO
       obtain ⟨i, his, rfl⟩ := hu
       exact IsOrthogonal.reflection_apply_right <| hj i his
 
+lemma pairing_zero_iff [NeZero (2 : R)] [NoZeroSMulDivisors R N] :
+    (P.pairing i j = 0) ↔ (P.pairing j i = 0) := by
+  have aux (a b : ι) : P.pairing a b = 0 → P.pairing b a = 0 := by
+    intro h
+    have h₁ : P.toPerfectPairing (P.root a) (P.coroot b) = 0 := h
+    have root_swap := P.reflection_perm_root b a
+    rw [h₁, zero_smul, sub_zero, EmbeddingLike.apply_eq_iff_eq] at root_swap
+    have coroot_swap := P.reflection_perm_coroot b a
+    rw [← root_swap, root_coroot_eq_pairing, sub_eq_self, smul_eq_zero] at coroot_swap
+    rcases coroot_swap with h₂ | h₂
+    · exact h₂
+    exact False.elim (P.ne_zero' b h₂)
+  exact ⟨aux i j, aux j i⟩
+
 end RootPairing

--- a/Mathlib/LinearAlgebra/RootSystem/Defs.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Defs.lean
@@ -749,19 +749,27 @@ lemma isFixedPt_reflection_of_isOrthogonal {s : Set ι} (hj : ∀ i ∈ s, P.IsO
       obtain ⟨i, his, rfl⟩ := hu
       exact IsOrthogonal.reflection_apply_right <| hj i his
 
-lemma pairing_zero_iff [NeZero (2 : R)] [NoZeroSMulDivisors R N] :
-    (P.pairing i j = 0) ↔ (P.pairing j i = 0) := by
-  have aux (a b : ι) : P.pairing a b = 0 → P.pairing b a = 0 := by
-    intro h
-    have h₁ : P.toPerfectPairing (P.root a) (P.coroot b) = 0 := h
-    have root_swap := P.reflection_perm_root b a
-    rw [h₁, zero_smul, sub_zero, EmbeddingLike.apply_eq_iff_eq] at root_swap
-    have coroot_swap := P.reflection_perm_coroot b a
-    rw [← root_swap, root_coroot_eq_pairing, sub_eq_self, smul_eq_zero] at coroot_swap
-    rcases coroot_swap with h₂ | h₂
-    · exact h₂
-    exact False.elim (P.ne_zero' b h₂)
-  exact ⟨aux i j, aux j i⟩
+lemma reflection_perm_eq_of_pairing_eq_zero (h : P.pairing j i = 0) :
+    P.reflection_perm i j = j :=
+  P.root.injective <| by simp [reflection_apply, h]
+
+lemma reflection_perm_eq_of_pairing_eq_zero' (h : P.pairing i j = 0) :
+    P.reflection_perm i j = j :=
+  P.flip.reflection_perm_eq_of_pairing_eq_zero h
+
+lemma smul_root_eq_zero_of_pairing_eq_zero (h : P.pairing i j = 0) :
+    P.pairing j i • P.root i = 0 := by
+  simpa [P.reflection_perm_eq_of_pairing_eq_zero' h] using P.reflection_perm_root i j
+
+lemma smul_coroot_eq_zero_of_pairing_eq_zero (h : P.pairing i j = 0) :
+    P.pairing j i • P.coroot j = 0 :=
+  P.flip.smul_root_eq_zero_of_pairing_eq_zero h
+
+lemma pairing_zero_iff [NeZero (2 : R)] [NoZeroSMulDivisors R M] :
+    P.pairing i j = 0 ↔ P.pairing j i = 0 := by
+  suffices ∀ {i j : ι}, P.pairing i j = 0 → P.pairing j i = 0 from ⟨this, this⟩
+  intro i j h
+  simpa [P.ne_zero i] using P.smul_root_eq_zero_of_pairing_eq_zero h
 
 lemma pairing_zero_iff' [NeZero (2 : R)] [IsDomain R] :
     P.pairing i j = 0 ↔ P.pairing j i = 0 := by

--- a/Mathlib/LinearAlgebra/RootSystem/Defs.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Defs.lean
@@ -774,8 +774,8 @@ lemma coxeterWeight_zero_iff_isOrthogonal [NeZero (2 : R)] [NoZeroDivisors R] :
     P.coxeterWeight i j = 0 ↔ P.IsOrthogonal i j := by
   simp [coxeterWeight, IsOrthogonal, P.pairing_zero_iff' (i := i) (j := j)]
 
-lemma isOrthogonal_iff_pairing_eq_zero [NeZero (2 : R)] [NoZeroDivisors R] :
-    P.IsOrthogonal i j ↔ P.pairing i j = 0 := by
-  simp [← coxeterWeight_zero_iff_isOrthogonal, coxeterWeight, P.pairing_zero_iff' (i := j) (j := i)]
+lemma isOrthogonal_iff_pairing_eq_zero [NeZero (2 : R)] [NoZeroSMulDivisors R N] :
+    P.IsOrthogonal i j ↔ P.pairing i j = 0 :=
+  ⟨fun h ↦ h.1, fun h ↦ ⟨h, pairing_zero_iff.mp h⟩⟩
 
 end RootPairing

--- a/Mathlib/LinearAlgebra/RootSystem/Defs.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Defs.lean
@@ -757,32 +757,39 @@ lemma reflection_perm_eq_of_pairing_eq_zero' (h : P.pairing i j = 0) :
     P.reflection_perm i j = j :=
   P.flip.reflection_perm_eq_of_pairing_eq_zero h
 
-lemma smul_root_eq_zero_of_pairing_eq_zero (h : P.pairing i j = 0) :
-    P.pairing j i • P.root i = 0 := by
-  simpa [P.reflection_perm_eq_of_pairing_eq_zero' h] using P.reflection_perm_root i j
+lemma reflection_perm_eq_iff_smul_root :
+    P.reflection_perm i j = j ↔ P.pairing j i • P.root i = 0 :=
+  ⟨fun h ↦ by simpa [h] using P.reflection_perm_root i j,
+    fun h ↦ P.root.injective <| by simp [reflection_apply, h]⟩
 
-lemma smul_coroot_eq_zero_of_pairing_eq_zero (h : P.pairing i j = 0) :
-    P.pairing j i • P.coroot j = 0 :=
-  P.flip.smul_root_eq_zero_of_pairing_eq_zero h
+lemma reflection_perm_eq_iff_smul_coroot :
+    P.reflection_perm i j = j ↔ P.pairing i j • P.coroot i = 0 :=
+  P.flip.reflection_perm_eq_iff_smul_root
 
 lemma pairing_zero_iff [NeZero (2 : R)] [NoZeroSMulDivisors R M] :
     P.pairing i j = 0 ↔ P.pairing j i = 0 := by
   suffices ∀ {i j : ι}, P.pairing i j = 0 → P.pairing j i = 0 from ⟨this, this⟩
   intro i j h
-  simpa [P.ne_zero i] using P.smul_root_eq_zero_of_pairing_eq_zero h
+  simpa [P.ne_zero i, reflection_perm_eq_iff_smul_root] using
+    P.reflection_perm_eq_of_pairing_eq_zero' h
 
 lemma pairing_zero_iff' [NeZero (2 : R)] [IsDomain R] :
     P.pairing i j = 0 ↔ P.pairing j i = 0 := by
-  have := P.reflexive_right
+  have := P.reflexive_left
   exact pairing_zero_iff
 
 lemma coxeterWeight_zero_iff_isOrthogonal [NeZero (2 : R)] [IsDomain R] :
     P.coxeterWeight i j = 0 ↔ P.IsOrthogonal i j := by
-  have := P.reflexive_right
+  have := P.reflexive_left
   simp [coxeterWeight, IsOrthogonal, P.pairing_zero_iff (i := i) (j := j)]
 
-lemma isOrthogonal_iff_pairing_eq_zero [NeZero (2 : R)] [NoZeroSMulDivisors R N] :
+lemma isOrthogonal_iff_pairing_eq_zero [NeZero (2 : R)] [NoZeroSMulDivisors R M] :
     P.IsOrthogonal i j ↔ P.pairing i j = 0 :=
   ⟨fun h ↦ h.1, fun h ↦ ⟨h, pairing_zero_iff.mp h⟩⟩
+
+lemma isFixedPt_reflection_perm_iff [NeZero (2 : R)] [NoZeroSMulDivisors R M] :
+    IsFixedPt (P.reflection_perm i) j ↔ P.pairing i j = 0 := by
+  refine ⟨fun h ↦ ?_, P.reflection_perm_eq_of_pairing_eq_zero'⟩
+  simpa [P.ne_zero i, pairing_zero_iff, IsFixedPt, reflection_perm_eq_iff_smul_root] using h
 
 end RootPairing

--- a/Mathlib/LinearAlgebra/RootSystem/Defs.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Defs.lean
@@ -767,9 +767,10 @@ lemma pairing_zero_iff' [NeZero (2 : R)] [IsDomain R] :
     P.pairing i j = 0 ↔ P.pairing j i = 0 := by
   have := P.reflexive_right
   exact pairing_zero_iff
-lemma coxeterWeight_zero_iff_isOrthogonal [NeZero (2 : R)] [NoZeroDivisors R] :
+lemma coxeterWeight_zero_iff_isOrthogonal [NeZero (2 : R)] [IsDomain R] :
     P.coxeterWeight i j = 0 ↔ P.IsOrthogonal i j := by
-  simp [coxeterWeight, IsOrthogonal, P.pairing_zero_iff' (i := i) (j := j)]
+  have := P.reflexive_right
+  simp [coxeterWeight, IsOrthogonal, P.pairing_zero_iff (i := i) (j := j)]
 
 lemma isOrthogonal_iff_pairing_eq_zero [NeZero (2 : R)] [NoZeroSMulDivisors R N] :
     P.IsOrthogonal i j ↔ P.pairing i j = 0 :=

--- a/Mathlib/LinearAlgebra/RootSystem/Defs.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Defs.lean
@@ -749,7 +749,9 @@ lemma isFixedPt_reflection_of_isOrthogonal {s : Set ι} (hj : ∀ i ∈ s, P.IsO
       obtain ⟨i, his, rfl⟩ := hu
       exact IsOrthogonal.reflection_apply_right <| hj i his
 
-lemma pairing_zero_iff [NeZero (2 : R)] [NoZeroSMulDivisors R N] :
+variable [NeZero (2 : R)] [NoZeroSMulDivisors R N]
+
+lemma pairing_zero_iff :
     (P.pairing i j = 0) ↔ (P.pairing j i = 0) := by
   have aux (a b : ι) : P.pairing a b = 0 → P.pairing b a = 0 := by
     intro h
@@ -762,5 +764,13 @@ lemma pairing_zero_iff [NeZero (2 : R)] [NoZeroSMulDivisors R N] :
     · exact h₂
     exact False.elim (P.ne_zero' b h₂)
   exact ⟨aux i j, aux j i⟩
+
+lemma coxeterWeight_zero_iff_isOrthogonal [NoZeroDivisors R] :
+    P.coxeterWeight i j = 0 ↔ P.IsOrthogonal i j := by
+  simp [coxeterWeight, IsOrthogonal, P.pairing_zero_iff (i := i) (j := j)]
+
+lemma isOrthogonal_iff_pairing_eq_zero [NoZeroDivisors R] :
+    P.IsOrthogonal i j ↔ P.pairing i j = 0 := by
+  simp [← coxeterWeight_zero_iff_isOrthogonal, coxeterWeight, P.pairing_zero_iff (i := j) (j := i)]
 
 end RootPairing

--- a/Mathlib/LinearAlgebra/RootSystem/Defs.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Defs.lean
@@ -767,6 +767,7 @@ lemma pairing_zero_iff' [NeZero (2 : R)] [IsDomain R] :
     P.pairing i j = 0 ↔ P.pairing j i = 0 := by
   have := P.reflexive_right
   exact pairing_zero_iff
+
 lemma coxeterWeight_zero_iff_isOrthogonal [NeZero (2 : R)] [IsDomain R] :
     P.coxeterWeight i j = 0 ↔ P.IsOrthogonal i j := by
   have := P.reflexive_right

--- a/Mathlib/LinearAlgebra/RootSystem/Defs.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Defs.lean
@@ -763,13 +763,10 @@ lemma pairing_zero_iff [NeZero (2 : R)] [NoZeroSMulDivisors R N] :
     exact False.elim (P.ne_zero' b h₂)
   exact ⟨aux i j, aux j i⟩
 
-lemma pairing_zero_iff' [NeZero (2 : R)] [NoZeroDivisors R] :
-    (P.pairing i j = 0) ↔ (P.pairing j i = 0) := by
+lemma pairing_zero_iff' [NeZero (2 : R)] [IsDomain R] :
+    P.pairing i j = 0 ↔ P.pairing j i = 0 := by
   have := P.reflexive_right
-  have : Nontrivial R := ⟨2, 0, two_ne_zero⟩
-  have : IsDomain R := IsDomain.mk
   exact pairing_zero_iff
-
 lemma coxeterWeight_zero_iff_isOrthogonal [NeZero (2 : R)] [NoZeroDivisors R] :
     P.coxeterWeight i j = 0 ↔ P.IsOrthogonal i j := by
   simp [coxeterWeight, IsOrthogonal, P.pairing_zero_iff' (i := i) (j := j)]

--- a/Mathlib/LinearAlgebra/RootSystem/Defs.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Defs.lean
@@ -749,9 +749,7 @@ lemma isFixedPt_reflection_of_isOrthogonal {s : Set ι} (hj : ∀ i ∈ s, P.IsO
       obtain ⟨i, his, rfl⟩ := hu
       exact IsOrthogonal.reflection_apply_right <| hj i his
 
-variable [NeZero (2 : R)] [NoZeroSMulDivisors R N]
-
-lemma pairing_zero_iff :
+lemma pairing_zero_iff [NeZero (2 : R)] [NoZeroSMulDivisors R N] :
     (P.pairing i j = 0) ↔ (P.pairing j i = 0) := by
   have aux (a b : ι) : P.pairing a b = 0 → P.pairing b a = 0 := by
     intro h
@@ -765,12 +763,19 @@ lemma pairing_zero_iff :
     exact False.elim (P.ne_zero' b h₂)
   exact ⟨aux i j, aux j i⟩
 
-lemma coxeterWeight_zero_iff_isOrthogonal [NoZeroDivisors R] :
-    P.coxeterWeight i j = 0 ↔ P.IsOrthogonal i j := by
-  simp [coxeterWeight, IsOrthogonal, P.pairing_zero_iff (i := i) (j := j)]
+lemma pairing_zero_iff' [NeZero (2 : R)] [NoZeroDivisors R] :
+    (P.pairing i j = 0) ↔ (P.pairing j i = 0) := by
+  have := P.reflexive_right
+  have : Nontrivial R := ⟨2, 0, two_ne_zero⟩
+  have : IsDomain R := IsDomain.mk
+  exact pairing_zero_iff
 
-lemma isOrthogonal_iff_pairing_eq_zero [NoZeroDivisors R] :
+lemma coxeterWeight_zero_iff_isOrthogonal [NeZero (2 : R)] [NoZeroDivisors R] :
+    P.coxeterWeight i j = 0 ↔ P.IsOrthogonal i j := by
+  simp [coxeterWeight, IsOrthogonal, P.pairing_zero_iff' (i := i) (j := j)]
+
+lemma isOrthogonal_iff_pairing_eq_zero [NeZero (2 : R)] [NoZeroDivisors R] :
     P.IsOrthogonal i j ↔ P.pairing i j = 0 := by
-  simp [← coxeterWeight_zero_iff_isOrthogonal, coxeterWeight, P.pairing_zero_iff (i := j) (j := i)]
+  simp [← coxeterWeight_zero_iff_isOrthogonal, coxeterWeight, P.pairing_zero_iff' (i := j) (j := i)]
 
 end RootPairing

--- a/Mathlib/LinearAlgebra/RootSystem/Finite/Lemmas.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Finite/Lemmas.lean
@@ -146,7 +146,7 @@ lemma coxeterWeightIn_eq_zero_iff [NoZeroSMulDivisors R N]:
     P.coxeterWeightIn ℤ i j = 0 ↔ P.pairingIn ℤ i j = 0 := by
   refine ⟨fun h ↦ ?_, fun h ↦ by rw [coxeterWeightIn, h, zero_mul]⟩
   rwa [← (algebraMap_injective ℤ R).eq_iff, map_zero, algebraMap_coxeterWeightIn,
-    RootPairing.InvariantForm.coxeterWeight_zero_iff_isOrthogonal, IsOrthogonal,
+    RootPairing.coxeterWeight_zero_iff_isOrthogonal, IsOrthogonal,
     P.pairing_zero_iff (i := j) (j := i), and_self, ← P.algebraMap_pairingIn ℤ,
     FaithfulSMul.algebraMap_eq_zero_iff] at h
 

--- a/Mathlib/LinearAlgebra/RootSystem/Finite/Lemmas.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Finite/Lemmas.lean
@@ -139,12 +139,12 @@ lemma pairingIn_pairingIn_mem_set_of_length_eq_of_ne [NoZeroSMulDivisors R M] {B
   aesop
 
 omit [Finite ι] in
-lemma coxeterWeightIn_eq_zero_iff [NoZeroSMulDivisors R N]:
+lemma coxeterWeightIn_eq_zero_iff :
     P.coxeterWeightIn ℤ i j = 0 ↔ P.pairingIn ℤ i j = 0 := by
   refine ⟨fun h ↦ ?_, fun h ↦ by rw [coxeterWeightIn, h, zero_mul]⟩
   rwa [← (algebraMap_injective ℤ R).eq_iff, map_zero, algebraMap_coxeterWeightIn,
     RootPairing.coxeterWeight_zero_iff_isOrthogonal, IsOrthogonal,
-    P.pairing_zero_iff (i := j) (j := i), and_self, ← P.algebraMap_pairingIn ℤ,
+    P.pairing_zero_iff' (i := j) (j := i), and_self, ← P.algebraMap_pairingIn ℤ,
     FaithfulSMul.algebraMap_eq_zero_iff] at h
 
 variable [NoZeroSMulDivisors R M] [NoZeroSMulDivisors R N]

--- a/Mathlib/LinearAlgebra/RootSystem/Finite/Lemmas.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Finite/Lemmas.lean
@@ -98,7 +98,10 @@ lemma pairingIn_pairingIn_mem_set_of_isCrystallographic :
   refine (Int.mul_mem_zero_one_two_three_four_iff ?_).mp
     (P.coxeterWeightIn_mem_set_of_isCrystallographic i j)
   have : Fintype ι := Fintype.ofFinite ι
-  simpa [← P.algebraMap_pairingIn ℤ] using (P.posRootForm ℤ).toInvariantForm.pairing_zero_iff i j
+  have := P.reflexive_right
+  have : Nontrivial R := ⟨2, 0, two_ne_zero⟩
+  have : IsDomain R := IsDomain.mk
+  simpa [← P.algebraMap_pairingIn ℤ] using P.pairing_zero_iff (i := i) (j := j)
 
 lemma pairingIn_pairingIn_mem_set_of_isCrystal_of_isRed
     [P.IsReduced] [NoZeroSMulDivisors R M] :
@@ -143,9 +146,12 @@ lemma coxeterWeightIn_eq_zero_iff :
     P.coxeterWeightIn ℤ i j = 0 ↔ P.pairingIn ℤ i j = 0 := by
   refine ⟨fun h ↦ ?_, fun h ↦ by rw [coxeterWeightIn, h, zero_mul]⟩
   have : Fintype ι := Fintype.ofFinite ι
+  have := P.reflexive_right
+  have : Nontrivial R := ⟨2, 0, two_ne_zero⟩
+  have : IsDomain R := IsDomain.mk
   rwa [← (algebraMap_injective ℤ R).eq_iff, map_zero, algebraMap_coxeterWeightIn,
-    (P.posRootForm ℤ).toInvariantForm.coxeterWeight_zero_iff_isOrthogonal, IsOrthogonal,
-    (P.posRootForm ℤ).toInvariantForm.pairing_zero_iff j i, and_self, ← P.algebraMap_pairingIn ℤ,
+    RootPairing.InvariantForm.coxeterWeight_zero_iff_isOrthogonal, IsOrthogonal,
+    P.pairing_zero_iff (i := j) (j := i), and_self, ← P.algebraMap_pairingIn ℤ,
     FaithfulSMul.algebraMap_eq_zero_iff] at h
 
 variable [NoZeroSMulDivisors R M] [NoZeroSMulDivisors R N]

--- a/Mathlib/LinearAlgebra/RootSystem/Finite/Lemmas.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Finite/Lemmas.lean
@@ -97,7 +97,6 @@ lemma pairingIn_pairingIn_mem_set_of_isCrystallographic :
         (-3, -1), (4, 1), (1, 4), (-4, -1), (-1, -4), (2, 2), (-2, -2)} : Set (ℤ × ℤ)) := by
   refine (Int.mul_mem_zero_one_two_three_four_iff ?_).mp
     (P.coxeterWeightIn_mem_set_of_isCrystallographic i j)
-  have : Fintype ι := Fintype.ofFinite ι
   have := P.reflexive_right
   have : Nontrivial R := ⟨2, 0, two_ne_zero⟩
   have : IsDomain R := IsDomain.mk
@@ -142,13 +141,10 @@ lemma pairingIn_pairingIn_mem_set_of_length_eq_of_ne [NoZeroSMulDivisors R M] {B
   have := P.pairingIn_pairingIn_mem_set_of_length_eq len_eq
   aesop
 
-lemma coxeterWeightIn_eq_zero_iff :
+omit [Finite ι] in
+lemma coxeterWeightIn_eq_zero_iff [NoZeroSMulDivisors R N]:
     P.coxeterWeightIn ℤ i j = 0 ↔ P.pairingIn ℤ i j = 0 := by
   refine ⟨fun h ↦ ?_, fun h ↦ by rw [coxeterWeightIn, h, zero_mul]⟩
-  have : Fintype ι := Fintype.ofFinite ι
-  have := P.reflexive_right
-  have : Nontrivial R := ⟨2, 0, two_ne_zero⟩
-  have : IsDomain R := IsDomain.mk
   rwa [← (algebraMap_injective ℤ R).eq_iff, map_zero, algebraMap_coxeterWeightIn,
     RootPairing.InvariantForm.coxeterWeight_zero_iff_isOrthogonal, IsOrthogonal,
     P.pairing_zero_iff (i := j) (j := i), and_self, ← P.algebraMap_pairingIn ℤ,

--- a/Mathlib/LinearAlgebra/RootSystem/Finite/Lemmas.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Finite/Lemmas.lean
@@ -89,7 +89,7 @@ lemma coxeterWeightIn_mem_set_of_isCrystallographic :
   norm_cast at this ⊢
   omega
 
-variable [NoZeroDivisors R]
+variable [IsDomain R]
 
 lemma pairingIn_pairingIn_mem_set_of_isCrystallographic :
     (P.pairingIn ℤ i j, P.pairingIn ℤ j i) ∈

--- a/Mathlib/LinearAlgebra/RootSystem/Finite/Lemmas.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Finite/Lemmas.lean
@@ -97,10 +97,7 @@ lemma pairingIn_pairingIn_mem_set_of_isCrystallographic :
         (-3, -1), (4, 1), (1, 4), (-4, -1), (-1, -4), (2, 2), (-2, -2)} : Set (ℤ × ℤ)) := by
   refine (Int.mul_mem_zero_one_two_three_four_iff ?_).mp
     (P.coxeterWeightIn_mem_set_of_isCrystallographic i j)
-  have := P.reflexive_right
-  have : Nontrivial R := ⟨2, 0, two_ne_zero⟩
-  have : IsDomain R := IsDomain.mk
-  simpa [← P.algebraMap_pairingIn ℤ] using P.pairing_zero_iff (i := i) (j := j)
+  simpa [← P.algebraMap_pairingIn ℤ] using P.pairing_zero_iff' (i := i) (j := j)
 
 lemma pairingIn_pairingIn_mem_set_of_isCrystal_of_isRed
     [P.IsReduced] [NoZeroSMulDivisors R M] :

--- a/Mathlib/LinearAlgebra/RootSystem/Finite/Nondegenerate.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Finite/Nondegenerate.lean
@@ -93,8 +93,11 @@ instance instIsAnisotropicOfIsCrystallographic [CharZero R] [P.IsCrystallographi
 lemma pairingIn_zero_iff {S : Type*} [CommRing S] [Algebra S R] [FaithfulSMul S R]
     [P.IsValuedIn S] [P.IsAnisotropic] [NoZeroDivisors R] [NeZero (2 : R)] {i j : ι} :
     P.pairingIn S i j = 0 ↔ P.pairingIn S j i = 0 := by
+  have := P.reflexive_right
+  have : Nontrivial R := ⟨2, 0, two_ne_zero⟩
+  have : IsDomain R := IsDomain.mk
   simp only [← FaithfulSMul.algebraMap_eq_zero_iff S R, algebraMap_pairingIn,
-    P.toInvariantForm.pairing_zero_iff i j]
+    P.pairing_zero_iff (i := i) (j := j)]
 
 end CommRing
 

--- a/Mathlib/LinearAlgebra/RootSystem/Finite/Nondegenerate.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Finite/Nondegenerate.lean
@@ -92,7 +92,7 @@ instance instIsAnisotropicOfIsCrystallographic [CharZero R] [P.IsCrystallographi
 
 omit [Fintype ι] in
 lemma pairingIn_zero_iff {S : Type*} [CommRing S] [Algebra S R] [FaithfulSMul S R]
-    [P.IsValuedIn S] [NoZeroDivisors R] [NeZero (2 : R)] {i j : ι} :
+    [P.IsValuedIn S] [IsDomain R] [NeZero (2 : R)] {i j : ι} :
     P.pairingIn S i j = 0 ↔ P.pairingIn S j i = 0 := by
   simp only [← FaithfulSMul.algebraMap_eq_zero_iff S R, algebraMap_pairingIn,
     P.pairing_zero_iff' (i := i) (j := j)]

--- a/Mathlib/LinearAlgebra/RootSystem/Finite/Nondegenerate.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Finite/Nondegenerate.lean
@@ -90,8 +90,9 @@ instance instIsAnisotropicOfIsCrystallographic [CharZero R] [P.IsCrystallographi
   ne_zero := IsAnisotropic.rootForm_root_ne_zero
   isOrthogonal_reflection := P.rootForm_reflection_reflection_apply
 
+omit [Fintype ι] in
 lemma pairingIn_zero_iff {S : Type*} [CommRing S] [Algebra S R] [FaithfulSMul S R]
-    [P.IsValuedIn S] [P.IsAnisotropic] [NoZeroDivisors R] [NeZero (2 : R)] {i j : ι} :
+    [P.IsValuedIn S] [NoZeroDivisors R] [NeZero (2 : R)] {i j : ι} :
     P.pairingIn S i j = 0 ↔ P.pairingIn S j i = 0 := by
   have := P.reflexive_right
   have : Nontrivial R := ⟨2, 0, two_ne_zero⟩

--- a/Mathlib/LinearAlgebra/RootSystem/Finite/Nondegenerate.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Finite/Nondegenerate.lean
@@ -94,11 +94,8 @@ omit [Fintype ι] in
 lemma pairingIn_zero_iff {S : Type*} [CommRing S] [Algebra S R] [FaithfulSMul S R]
     [P.IsValuedIn S] [NoZeroDivisors R] [NeZero (2 : R)] {i j : ι} :
     P.pairingIn S i j = 0 ↔ P.pairingIn S j i = 0 := by
-  have := P.reflexive_right
-  have : Nontrivial R := ⟨2, 0, two_ne_zero⟩
-  have : IsDomain R := IsDomain.mk
   simp only [← FaithfulSMul.algebraMap_eq_zero_iff S R, algebraMap_pairingIn,
-    P.pairing_zero_iff (i := i) (j := j)]
+    P.pairing_zero_iff' (i := i) (j := j)]
 
 end CommRing
 

--- a/Mathlib/LinearAlgebra/RootSystem/Finite/g2.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Finite/g2.lean
@@ -379,7 +379,7 @@ private lemma isOrthogonal_short_and_long_aux {a b c d e f a' b' c' d' e' f' : �
 lemma isOrthogonal_short_and_long {i : ι} (hi : P.root i ∉ allRoots P) :
     P.IsOrthogonal i (short P) ∧ P.IsOrthogonal i (long P) := by
   suffices P.pairingIn ℤ i (short P) = 0 ∧ P.pairingIn ℤ i (long P) = 0 by
-    simpa [InvariantForm.isOrthogonal_iff_pairing_eq_zero, ← P.algebraMap_pairingIn ℤ]
+    simpa [isOrthogonal_iff_pairing_eq_zero, ← P.algebraMap_pairingIn ℤ]
   simp only [mem_cons, not_mem_nil, or_false, not_or] at hi
   obtain ⟨h₁, h₂, h₃, h₄, h₅, h₆, h₇, h₈, h₉, h₁₀, h₁₁, h₁₂⟩ := hi
   have ha := P.pairingIn_pairingIn_mem_set_of_isCrystal_of_isRed' i (short P) ‹_› ‹_›
@@ -410,7 +410,7 @@ lemma mem_allRoots (i : ι) :
   obtain ⟨h₁, h₂⟩ := isOrthogonal_short_and_long P hi
   have : Fintype ι := Fintype.ofFinite ι
   have B := (P.posRootForm ℤ).toInvariantForm
-  rw [InvariantForm.isOrthogonal_iff_pairing_eq_zero, ← B.apply_root_root_zero_iff] at h₁ h₂
+  rw [isOrthogonal_iff_pairing_eq_zero, ← B.apply_root_root_zero_iff] at h₁ h₂
   have key : B.form (P.root i) = 0 := by
     ext x
     have hx : x ∈ span R {longRoot P, shortRoot P} := by simp

--- a/Mathlib/LinearAlgebra/RootSystem/Finite/g2.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Finite/g2.lean
@@ -379,7 +379,6 @@ private lemma isOrthogonal_short_and_long_aux {a b c d e f a' b' c' d' e' f' : �
 lemma isOrthogonal_short_and_long {i : ι} (hi : P.root i ∉ allRoots P) :
     P.IsOrthogonal i (short P) ∧ P.IsOrthogonal i (long P) := by
   suffices P.pairingIn ℤ i (short P) = 0 ∧ P.pairingIn ℤ i (long P) = 0 by
-    have : Fintype ι := Fintype.ofFinite ι
     simpa [InvariantForm.isOrthogonal_iff_pairing_eq_zero, ← P.algebraMap_pairingIn ℤ]
   simp only [mem_cons, not_mem_nil, or_false, not_or] at hi
   obtain ⟨h₁, h₂, h₃, h₄, h₅, h₆, h₇, h₈, h₉, h₁₀, h₁₁, h₁₂⟩ := hi

--- a/Mathlib/LinearAlgebra/RootSystem/Finite/g2.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Finite/g2.lean
@@ -410,9 +410,6 @@ lemma mem_allRoots (i : ι) :
   obtain ⟨h₁, h₂⟩ := isOrthogonal_short_and_long P hi
   have : Fintype ι := Fintype.ofFinite ι
   have B := (P.posRootForm ℤ).toInvariantForm
-  have := P.reflexive_right
-  have : Nontrivial R := ⟨2, 0, two_ne_zero⟩
-  have : IsDomain R := IsDomain.mk
   rw [isOrthogonal_iff_pairing_eq_zero, ← B.apply_root_root_zero_iff] at h₁ h₂
   have key : B.form (P.root i) = 0 := by
     ext x

--- a/Mathlib/LinearAlgebra/RootSystem/Finite/g2.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Finite/g2.lean
@@ -379,6 +379,9 @@ private lemma isOrthogonal_short_and_long_aux {a b c d e f a' b' c' d' e' f' : �
 lemma isOrthogonal_short_and_long {i : ι} (hi : P.root i ∉ allRoots P) :
     P.IsOrthogonal i (short P) ∧ P.IsOrthogonal i (long P) := by
   suffices P.pairingIn ℤ i (short P) = 0 ∧ P.pairingIn ℤ i (long P) = 0 by
+    have := P.reflexive_right
+    have : Nontrivial R := ⟨2, 0, two_ne_zero⟩
+    have : IsDomain R := IsDomain.mk
     simpa [isOrthogonal_iff_pairing_eq_zero, ← P.algebraMap_pairingIn ℤ]
   simp only [mem_cons, not_mem_nil, or_false, not_or] at hi
   obtain ⟨h₁, h₂, h₃, h₄, h₅, h₆, h₇, h₈, h₉, h₁₀, h₁₁, h₁₂⟩ := hi
@@ -410,6 +413,9 @@ lemma mem_allRoots (i : ι) :
   obtain ⟨h₁, h₂⟩ := isOrthogonal_short_and_long P hi
   have : Fintype ι := Fintype.ofFinite ι
   have B := (P.posRootForm ℤ).toInvariantForm
+  have := P.reflexive_right
+  have : Nontrivial R := ⟨2, 0, two_ne_zero⟩
+  have : IsDomain R := IsDomain.mk
   rw [isOrthogonal_iff_pairing_eq_zero, ← B.apply_root_root_zero_iff] at h₁ h₂
   have key : B.form (P.root i) = 0 := by
     ext x

--- a/Mathlib/LinearAlgebra/RootSystem/Finite/g2.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Finite/g2.lean
@@ -379,6 +379,7 @@ private lemma isOrthogonal_short_and_long_aux {a b c d e f a' b' c' d' e' f' : �
 lemma isOrthogonal_short_and_long {i : ι} (hi : P.root i ∉ allRoots P) :
     P.IsOrthogonal i (short P) ∧ P.IsOrthogonal i (long P) := by
   suffices P.pairingIn ℤ i (short P) = 0 ∧ P.pairingIn ℤ i (long P) = 0 by
+    have := P.reflexive_right
     simpa [isOrthogonal_iff_pairing_eq_zero, ← P.algebraMap_pairingIn ℤ]
   simp only [mem_cons, not_mem_nil, or_false, not_or] at hi
   obtain ⟨h₁, h₂, h₃, h₄, h₅, h₆, h₇, h₈, h₉, h₁₀, h₁₁, h₁₂⟩ := hi
@@ -410,6 +411,7 @@ lemma mem_allRoots (i : ι) :
   obtain ⟨h₁, h₂⟩ := isOrthogonal_short_and_long P hi
   have : Fintype ι := Fintype.ofFinite ι
   have B := (P.posRootForm ℤ).toInvariantForm
+  have := P.reflexive_right
   rw [isOrthogonal_iff_pairing_eq_zero, ← B.apply_root_root_zero_iff] at h₁ h₂
   have key : B.form (P.root i) = 0 := by
     ext x

--- a/Mathlib/LinearAlgebra/RootSystem/Finite/g2.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Finite/g2.lean
@@ -379,9 +379,6 @@ private lemma isOrthogonal_short_and_long_aux {a b c d e f a' b' c' d' e' f' : �
 lemma isOrthogonal_short_and_long {i : ι} (hi : P.root i ∉ allRoots P) :
     P.IsOrthogonal i (short P) ∧ P.IsOrthogonal i (long P) := by
   suffices P.pairingIn ℤ i (short P) = 0 ∧ P.pairingIn ℤ i (long P) = 0 by
-    have := P.reflexive_right
-    have : Nontrivial R := ⟨2, 0, two_ne_zero⟩
-    have : IsDomain R := IsDomain.mk
     simpa [isOrthogonal_iff_pairing_eq_zero, ← P.algebraMap_pairingIn ℤ]
   simp only [mem_cons, not_mem_nil, or_false, not_or] at hi
   obtain ⟨h₁, h₂, h₃, h₄, h₅, h₆, h₇, h₈, h₉, h₁₀, h₁₁, h₁₂⟩ := hi

--- a/Mathlib/LinearAlgebra/RootSystem/Finite/g2.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Finite/g2.lean
@@ -380,7 +380,6 @@ lemma isOrthogonal_short_and_long {i : ι} (hi : P.root i ∉ allRoots P) :
     P.IsOrthogonal i (short P) ∧ P.IsOrthogonal i (long P) := by
   suffices P.pairingIn ℤ i (short P) = 0 ∧ P.pairingIn ℤ i (long P) = 0 by
     have : Fintype ι := Fintype.ofFinite ι
-    have B := (P.posRootForm ℤ).toInvariantForm
     simpa [InvariantForm.isOrthogonal_iff_pairing_eq_zero, ← P.algebraMap_pairingIn ℤ]
   simp only [mem_cons, not_mem_nil, or_false, not_or] at hi
   obtain ⟨h₁, h₂, h₃, h₄, h₅, h₆, h₇, h₈, h₉, h₁₀, h₁₁, h₁₂⟩ := hi

--- a/Mathlib/LinearAlgebra/RootSystem/Finite/g2.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Finite/g2.lean
@@ -379,7 +379,6 @@ private lemma isOrthogonal_short_and_long_aux {a b c d e f a' b' c' d' e' f' : �
 lemma isOrthogonal_short_and_long {i : ι} (hi : P.root i ∉ allRoots P) :
     P.IsOrthogonal i (short P) ∧ P.IsOrthogonal i (long P) := by
   suffices P.pairingIn ℤ i (short P) = 0 ∧ P.pairingIn ℤ i (long P) = 0 by
-    have := P.reflexive_right
     simpa [isOrthogonal_iff_pairing_eq_zero, ← P.algebraMap_pairingIn ℤ]
   simp only [mem_cons, not_mem_nil, or_false, not_or] at hi
   obtain ⟨h₁, h₂, h₃, h₄, h₅, h₆, h₇, h₈, h₉, h₁₀, h₁₁, h₁₂⟩ := hi
@@ -411,7 +410,6 @@ lemma mem_allRoots (i : ι) :
   obtain ⟨h₁, h₂⟩ := isOrthogonal_short_and_long P hi
   have : Fintype ι := Fintype.ofFinite ι
   have B := (P.posRootForm ℤ).toInvariantForm
-  have := P.reflexive_right
   rw [isOrthogonal_iff_pairing_eq_zero, ← B.apply_root_root_zero_iff] at h₁ h₂
   have key : B.form (P.root i) = 0 := by
     ext x

--- a/Mathlib/LinearAlgebra/RootSystem/Finite/g2.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Finite/g2.lean
@@ -381,7 +381,7 @@ lemma isOrthogonal_short_and_long {i : ι} (hi : P.root i ∉ allRoots P) :
   suffices P.pairingIn ℤ i (short P) = 0 ∧ P.pairingIn ℤ i (long P) = 0 by
     have : Fintype ι := Fintype.ofFinite ι
     have B := (P.posRootForm ℤ).toInvariantForm
-    simpa [B.isOrthogonal_iff_pairing_eq_zero, ← P.algebraMap_pairingIn ℤ]
+    simpa [InvariantForm.isOrthogonal_iff_pairing_eq_zero, ← P.algebraMap_pairingIn ℤ]
   simp only [mem_cons, not_mem_nil, or_false, not_or] at hi
   obtain ⟨h₁, h₂, h₃, h₄, h₅, h₆, h₇, h₈, h₉, h₁₀, h₁₁, h₁₂⟩ := hi
   have ha := P.pairingIn_pairingIn_mem_set_of_isCrystal_of_isRed' i (short P) ‹_› ‹_›
@@ -412,7 +412,7 @@ lemma mem_allRoots (i : ι) :
   obtain ⟨h₁, h₂⟩ := isOrthogonal_short_and_long P hi
   have : Fintype ι := Fintype.ofFinite ι
   have B := (P.posRootForm ℤ).toInvariantForm
-  rw [B.isOrthogonal_iff_pairing_eq_zero, ← B.apply_root_root_zero_iff] at h₁ h₂
+  rw [InvariantForm.isOrthogonal_iff_pairing_eq_zero, ← B.apply_root_root_zero_iff] at h₁ h₂
   have key : B.form (P.root i) = 0 := by
     ext x
     have hx : x ∈ span R {longRoot P, shortRoot P} := by simp

--- a/Mathlib/LinearAlgebra/RootSystem/Reduced.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Reduced.lean
@@ -186,13 +186,13 @@ lemma pairing_neg_one_neg_four_iff' (h2 : IsSMulRegular R (2 : R)) :
 
 /-- See also `RootPairing.pairingIn_one_four_iff`. -/
 @[simp]
-lemma pairing_one_four_iff [NoZeroDivisors R] :
+lemma pairing_one_four_iff [IsDomain R] :
     P.pairing i j = 1 ∧ P.pairing j i = 4 ↔ P.root j = (2 : R) • P.root i :=
   P.pairing_one_four_iff' i j <| smul_right_injective R two_ne_zero
 
 /-- See also `RootPairing.pairingIn_neg_one_neg_four_iff`. -/
 @[simp]
-lemma pairing_neg_one_neg_four_iff [NoZeroDivisors R] :
+lemma pairing_neg_one_neg_four_iff [IsDomain R] :
     P.pairing i j = -1 ∧ P.pairing j i = -4 ↔ P.root j = (-2 : R) • P.root i :=
   P.pairing_neg_one_neg_four_iff' i j <| smul_right_injective R two_ne_zero
 
@@ -234,13 +234,13 @@ lemma pairingIn_neg_two_neg_two_iff :
 
 variable [NoZeroSMulDivisors R N]
 
-lemma pairingIn_one_four_iff [NoZeroDivisors R] :
+lemma pairingIn_one_four_iff [IsDomain R] :
     P.pairingIn S i j = 1 ∧ P.pairingIn S j i = 4 ↔ P.root j = (2 : R) • P.root i := by
   rw [← P.pairing_one_four_iff, ← P.algebraMap_pairingIn S, ← P.algebraMap_pairingIn S,
     ← map_one (algebraMap S R), ← map_ofNat (algebraMap S R), (algebraMap_injective S R).eq_iff,
     (algebraMap_injective S R).eq_iff]
 
-lemma pairingIn_neg_one_neg_four_iff [NoZeroDivisors R] :
+lemma pairingIn_neg_one_neg_four_iff [IsDomain R] :
     P.pairingIn S i j = -1 ∧ P.pairingIn S j i = -4 ↔ P.root j = (-2 : R) • P.root i := by
   rw [← P.pairing_neg_one_neg_four_iff, ← P.algebraMap_pairingIn S, ← P.algebraMap_pairingIn S,
     ← map_one (algebraMap S R), ← map_ofNat (algebraMap S R), ← map_neg, ← map_neg,

--- a/Mathlib/LinearAlgebra/RootSystem/RootPositive.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/RootPositive.lean
@@ -97,26 +97,6 @@ lemma apply_root_root_zero_iff [NoZeroDivisors R] [NeZero (2 : R)]:
 
 end InvariantForm
 
-section Orthogonal
-
-variable {P : RootPairing ι R M N} (i j : ι) [NoZeroDivisors R] [NeZero (2 : R)]
-
-lemma coxeterWeight_zero_iff_isOrthogonal :
-    P.coxeterWeight i j = 0 ↔ P.IsOrthogonal i j := by
-  have := P.reflexive_right
-  have : Nontrivial R := ⟨2, 0, two_ne_zero⟩
-  have : IsDomain R := IsDomain.mk
-  simp [coxeterWeight, IsOrthogonal, P.pairing_zero_iff (i := i) (j := j)]
-
-lemma isOrthogonal_iff_pairing_eq_zero :
-    P.IsOrthogonal i j ↔ P.pairing i j = 0 := by
-  have := P.reflexive_right
-  have : Nontrivial R := ⟨2, 0, two_ne_zero⟩
-  have : IsDomain R := IsDomain.mk
-  simp [← coxeterWeight_zero_iff_isOrthogonal, coxeterWeight, P.pairing_zero_iff (i := j) (j := i)]
-
-end Orthogonal
-
 variable (S) in
 /-- Given a root pairing, this is an invariant symmetric bilinear form satisfying a positivity
 condition. -/

--- a/Mathlib/LinearAlgebra/RootSystem/RootPositive.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/RootPositive.lean
@@ -87,15 +87,19 @@ lemma apply_weylGroup_smul (g : P.weylGroup) (x y : M) :
     intro x y
     rw [← Submonoid.mk_mul_mk _ _ _ hg₁ hg₂, mul_smul, mul_smul, hg₁', hg₂']
 
-variable [NoZeroDivisors R] [NeZero (2 : R)]
-
 @[simp]
-lemma apply_root_root_zero_iff :
+lemma apply_root_root_zero_iff [NoZeroDivisors R] [NeZero (2 : R)]:
     B.form (P.root i) (P.root j) = 0 ↔ P.pairing i j = 0 := by
   calc B.form (P.root i) (P.root j) = 0
       ↔ 2 * B.form (P.root i) (P.root j) = 0 := by simp [two_ne_zero]
     _ ↔ P.pairing i j * B.form (P.root j) (P.root j) = 0 := by rw [B.two_mul_apply_root_root i j]
     _ ↔ P.pairing i j = 0 := by simp [B.ne_zero j]
+
+end InvariantForm
+
+section Orthogonal
+
+variable {P : RootPairing ι R M N} (i j : ι) [NoZeroDivisors R] [NeZero (2 : R)]
 
 lemma coxeterWeight_zero_iff_isOrthogonal :
     P.coxeterWeight i j = 0 ↔ P.IsOrthogonal i j := by
@@ -111,7 +115,7 @@ lemma isOrthogonal_iff_pairing_eq_zero :
   have : IsDomain R := IsDomain.mk
   simp [← coxeterWeight_zero_iff_isOrthogonal, coxeterWeight, P.pairing_zero_iff (i := j) (j := i)]
 
-end InvariantForm
+end Orthogonal
 
 variable (S) in
 /-- Given a root pairing, this is an invariant symmetric bilinear form satisfying a positivity

--- a/Mathlib/LinearAlgebra/RootSystem/RootPositive.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/RootPositive.lean
@@ -88,7 +88,7 @@ lemma apply_weylGroup_smul (g : P.weylGroup) (x y : M) :
     rw [← Submonoid.mk_mul_mk _ _ _ hg₁ hg₂, mul_smul, mul_smul, hg₁', hg₂']
 
 @[simp]
-lemma apply_root_root_zero_iff [NoZeroDivisors R] [NeZero (2 : R)]:
+lemma apply_root_root_zero_iff [IsDomain R] [NeZero (2 : R)]:
     B.form (P.root i) (P.root j) = 0 ↔ P.pairing i j = 0 := by
   calc B.form (P.root i) (P.root j) = 0
       ↔ 2 * B.form (P.root i) (P.root j) = 0 := by simp [two_ne_zero]

--- a/Mathlib/LinearAlgebra/RootSystem/RootPositive.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/RootPositive.lean
@@ -97,19 +97,19 @@ lemma apply_root_root_zero_iff :
     _ ↔ P.pairing i j * B.form (P.root j) (P.root j) = 0 := by rw [B.two_mul_apply_root_root i j]
     _ ↔ P.pairing i j = 0 := by simp [B.ne_zero j]
 
-include B
-
-lemma pairing_zero_iff :
-    P.pairing i j = 0 ↔ P.pairing j i = 0 := by
-  rw [← B.apply_root_root_zero_iff, ← B.apply_root_root_zero_iff, ← B.symm.eq, RingHom.id_apply]
-
 lemma coxeterWeight_zero_iff_isOrthogonal :
     P.coxeterWeight i j = 0 ↔ P.IsOrthogonal i j := by
-  simp [coxeterWeight, IsOrthogonal, B.pairing_zero_iff i j]
+  have := P.reflexive_right
+  have : Nontrivial R := ⟨2, 0, two_ne_zero⟩
+  have : IsDomain R := IsDomain.mk
+  simp [coxeterWeight, IsOrthogonal, P.pairing_zero_iff (i := i) (j := j)]
 
 lemma isOrthogonal_iff_pairing_eq_zero :
     P.IsOrthogonal i j ↔ P.pairing i j = 0 := by
-  simp [← B.coxeterWeight_zero_iff_isOrthogonal, coxeterWeight, B.pairing_zero_iff j i]
+  have := P.reflexive_right
+  have : Nontrivial R := ⟨2, 0, two_ne_zero⟩
+  have : IsDomain R := IsDomain.mk
+  simp [← coxeterWeight_zero_iff_isOrthogonal, coxeterWeight, P.pairing_zero_iff (i := j) (j := i)]
 
 end InvariantForm
 


### PR DESCRIPTION
Generalize RootPairing.pairing_zero_iff
---
This PR proves that if RootPairing.pairing i j = 0, then RootPairing.pairing j i = 0 for NoZeroSMulDivisors modules. This strictly generalizes the theorem RootPairing.InvariantForm.pairing_zero_iff.
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
