### PR TITLE
[Merged by Bors] - refactor: don't expose the functor `(Over X)ᵒᵖ ⥤ Under (op X)`

### DIFF
--- a/Mathlib/CategoryTheory/Comma/Over/Basic.lean
+++ b/Mathlib/CategoryTheory/Comma/Over/Basic.lean
@@ -1013,7 +1013,7 @@ open Opposite
 
 variable (X : T)
 
-/-- `Over.opToOpUnder` is an equivalence of categories. -/
+/-- The canonical equivalence between over and under categories by reversing structure arrows. -/
 @[simps]
 def Over.opEquivOpUnder : Over (op X) ≌ (Under X)ᵒᵖ where
   functor.obj Y := ⟨Under.mk Y.hom.unop⟩
@@ -1023,7 +1023,7 @@ def Over.opEquivOpUnder : Over (op X) ≌ (Under X)ᵒᵖ where
   unitIso := Iso.refl _
   counitIso := Iso.refl _
 
-/-- `Under.opToOpOver` is an equivalence of categories. -/
+/-- The canonical equivalence between under and over categories by reversing structure arrows. -/
 @[simps]
 def Under.opEquivOpOver : Under (op X) ≌ (Over X)ᵒᵖ where
   functor.obj Y := ⟨Over.mk Y.hom.unop⟩

--- a/Mathlib/CategoryTheory/Comma/Over/Basic.lean
+++ b/Mathlib/CategoryTheory/Comma/Over/Basic.lean
@@ -1053,6 +1053,21 @@ def Under.opEquivOpOver : Under (op X) ≌ (Over X)ᵒᵖ where
   unitIso := Iso.refl _
   counitIso := Iso.refl _
 
+instance : (Over.opToOpUnder X).Full := (Over.opEquivOpUnder X).full_functor
+instance : (Under.opToOverOp X).Full := (Over.opEquivOpUnder X).full_inverse
+instance : (Under.opToOpOver X).Full := (Under.opEquivOpOver X).full_functor
+instance : (Over.opToUnderOp X).Full := (Under.opEquivOpOver X).full_inverse
+
+instance : (Over.opToOpUnder X).Faithful := (Over.opEquivOpUnder X).faithful_functor
+instance : (Under.opToOverOp X).Faithful := (Over.opEquivOpUnder X).faithful_inverse
+instance : (Under.opToOpOver X).Faithful := (Under.opEquivOpOver X).faithful_functor
+instance : (Over.opToUnderOp X).Faithful := (Under.opEquivOpOver X).faithful_inverse
+
+instance : (Over.opToOpUnder X).EssSurj := (Over.opEquivOpUnder X).essSurj_functor
+instance : (Under.opToOverOp X).EssSurj := (Over.opEquivOpUnder X).essSurj_inverse
+instance : (Under.opToOpOver X).EssSurj := (Under.opEquivOpOver X).essSurj_functor
+instance : (Over.opToUnderOp X).EssSurj := (Under.opEquivOpOver X).essSurj_inverse
+
 end Opposite
 
 end CategoryTheory

--- a/Mathlib/CategoryTheory/Comma/Over/Basic.lean
+++ b/Mathlib/CategoryTheory/Comma/Over/Basic.lean
@@ -1013,60 +1013,41 @@ open Opposite
 
 variable (X : T)
 
-/-- The canonical functor by reversing structure arrows. -/
-@[simps]
-def Over.opToOpUnder : Over (op X) ⥤ (Under X)ᵒᵖ where
-  obj Y := ⟨Under.mk Y.hom.unop⟩
-  map {Z Y} f := ⟨Under.homMk (f.left.unop) (by dsimp; rw [← unop_comp, Over.w])⟩
-
-/-- The canonical functor by reversing structure arrows. -/
-@[simps]
-def Under.opToOverOp : (Under X)ᵒᵖ ⥤ Over (op X) where
-  obj Y := Over.mk (Y.unop.hom.op)
-  map {Z Y} f := Over.homMk f.unop.right.op <| by dsimp; rw [← Under.w f.unop, op_comp]
-
 /-- `Over.opToOpUnder` is an equivalence of categories. -/
 @[simps]
 def Over.opEquivOpUnder : Over (op X) ≌ (Under X)ᵒᵖ where
-  functor := Over.opToOpUnder X
-  inverse := Under.opToOverOp X
+  functor.obj Y := ⟨Under.mk Y.hom.unop⟩
+  functor.map {Z Y} f := ⟨Under.homMk (f.left.unop) (by dsimp; rw [← unop_comp, Over.w])⟩
+  inverse.obj Y := Over.mk (Y.unop.hom.op)
+  inverse.map {Z Y} f := Over.homMk f.unop.right.op <| by dsimp; rw [← Under.w f.unop, op_comp]
   unitIso := Iso.refl _
   counitIso := Iso.refl _
-
-/-- The canonical functor by reversing structure arrows. -/
-@[simps]
-def Under.opToOpOver : Under (op X) ⥤ (Over X)ᵒᵖ where
-  obj Y := ⟨Over.mk Y.hom.unop⟩
-  map {Z Y} f := ⟨Over.homMk (f.right.unop) (by dsimp; rw [← unop_comp, Under.w])⟩
-
-/-- The canonical functor by reversing structure arrows. -/
-@[simps]
-def Over.opToUnderOp : (Over X)ᵒᵖ ⥤ Under (op X) where
-  obj Y := Under.mk (Y.unop.hom.op)
-  map {Z Y} f := Under.homMk f.unop.left.op <| by dsimp; rw [← Over.w f.unop, op_comp]
 
 /-- `Under.opToOpOver` is an equivalence of categories. -/
 @[simps]
 def Under.opEquivOpOver : Under (op X) ≌ (Over X)ᵒᵖ where
-  functor := Under.opToOpOver X
-  inverse := Over.opToUnderOp X
+  functor.obj Y := ⟨Over.mk Y.hom.unop⟩
+  functor.map {Z Y} f := ⟨Over.homMk (f.right.unop) (by dsimp; rw [← unop_comp, Under.w])⟩
+  inverse.obj Y := Under.mk (Y.unop.hom.op)
+  inverse.map {Z Y} f := Under.homMk f.unop.left.op <| by dsimp; rw [← Over.w f.unop, op_comp]
   unitIso := Iso.refl _
   counitIso := Iso.refl _
 
-instance : (Over.opToOpUnder X).Full := (Over.opEquivOpUnder X).full_functor
-instance : (Under.opToOverOp X).Full := (Over.opEquivOpUnder X).full_inverse
-instance : (Under.opToOpOver X).Full := (Under.opEquivOpOver X).full_functor
-instance : (Over.opToUnderOp X).Full := (Under.opEquivOpOver X).full_inverse
+/-- The canonical functor by reversing structure arrows. -/
+@[deprecated Over.opEquivOpUnder (since := "2025-04-08")]
+def Over.opToOpUnder : Over (op X) ⥤ (Under X)ᵒᵖ := (Over.opEquivOpUnder X).functor
 
-instance : (Over.opToOpUnder X).Faithful := (Over.opEquivOpUnder X).faithful_functor
-instance : (Under.opToOverOp X).Faithful := (Over.opEquivOpUnder X).faithful_inverse
-instance : (Under.opToOpOver X).Faithful := (Under.opEquivOpOver X).faithful_functor
-instance : (Over.opToUnderOp X).Faithful := (Under.opEquivOpOver X).faithful_inverse
+/-- The canonical functor by reversing structure arrows. -/
+@[deprecated Over.opEquivOpUnder (since := "2025-04-08")]
+def Under.opToOverOp : (Under X)ᵒᵖ ⥤ Over (op X) := (Over.opEquivOpUnder X).inverse
 
-instance : (Over.opToOpUnder X).EssSurj := (Over.opEquivOpUnder X).essSurj_functor
-instance : (Under.opToOverOp X).EssSurj := (Over.opEquivOpUnder X).essSurj_inverse
-instance : (Under.opToOpOver X).EssSurj := (Under.opEquivOpOver X).essSurj_functor
-instance : (Over.opToUnderOp X).EssSurj := (Under.opEquivOpOver X).essSurj_inverse
+/-- The canonical functor by reversing structure arrows. -/
+@[deprecated Under.opEquivOpOver (since := "2025-04-08")]
+def Under.opToOpOver : Under (op X) ⥤ (Over X)ᵒᵖ := (Under.opEquivOpOver X).functor
+
+/-- The canonical functor by reversing structure arrows. -/
+@[deprecated Under.opEquivOpOver (since := "2025-04-08")]
+def Over.opToUnderOp : (Over X)ᵒᵖ ⥤ Under (op X) := (Under.opEquivOpOver X).inverse
 
 end Opposite
 


### PR DESCRIPTION
Instead only expose the equivalence.

From Toric

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
