### PR TITLE
[Merged by Bors] - chore: clean up more Qq usage

### DIFF
--- a/Mathlib/Algebra/Order/Field/Basic.lean
+++ b/Mathlib/Algebra/Order/Field/Basic.lean
@@ -840,11 +840,11 @@ such that `positivity` successfully recognises both `a` and `b`. -/
   let .app (.app (f : Q($α → $α → $α)) (a : Q($α))) (b : Q($α)) ← withReducible (whnf e)
     | throwError "not /"
   let _e_eq : $e =Q $f $a $b := ⟨⟩
-  let _a ← synthInstanceQ (q(Semifield $α) : Q(Type u))
-  let _a ← synthInstanceQ (q(LinearOrder $α) : Q(Type u))
-  let _a ← synthInstanceQ (q(IsStrictOrderedRing $α) : Q(Prop))
+  let _a ← synthInstanceQ q(Semifield $α)
+  let _a ← synthInstanceQ q(LinearOrder $α)
+  let _a ← synthInstanceQ q(IsStrictOrderedRing $α)
   assumeInstancesCommute
-  let ⟨_f_eq⟩ ← withDefault <| withNewMCtxDepth <| assertDefEqQ (u := u.succ) f q(HDiv.hDiv)
+  let ⟨_f_eq⟩ ← withDefault <| withNewMCtxDepth <| assertDefEqQ q($f) q(HDiv.hDiv)
   let ra ← core zα pα a; let rb ← core zα pα b
   match ra, rb with
   | .positive pa, .positive pb => pure (.positive q(div_pos $pa $pb))
@@ -866,7 +866,7 @@ def evalInv : PositivityExt where eval {u α} zα pα e := do
   let _a ← synthInstanceQ q(LinearOrder $α)
   let _a ← synthInstanceQ q(IsStrictOrderedRing $α)
   assumeInstancesCommute
-  let ⟨_f_eq⟩ ← withDefault <| withNewMCtxDepth <| assertDefEqQ (u := u.succ) f q(Inv.inv)
+  let ⟨_f_eq⟩ ← withDefault <| withNewMCtxDepth <| assertDefEqQ q($f) q(Inv.inv)
   let ra ← core zα pα a
   match ra with
   | .positive pa => pure (.positive q(inv_pos_of_pos $pa))

--- a/Mathlib/Algebra/Order/Field/Power.lean
+++ b/Mathlib/Algebra/Order/Field/Power.lean
@@ -218,9 +218,9 @@ def evalZPow : PositivityExt where eval {u α} zα pα e := do
     match ra with
     | .positive pa =>
       try
-        let _a ← synthInstanceQ (q(Semifield $α) : Q(Type u))
-        let _a ← synthInstanceQ (q(LinearOrder $α) : Q(Type u))
-        let _a ← synthInstanceQ (q(IsStrictOrderedRing $α) : Q(Prop))
+        let _a ← synthInstanceQ q(Semifield $α)
+        let _a ← synthInstanceQ q(LinearOrder $α)
+        let _a ← synthInstanceQ q(IsStrictOrderedRing $α)
         haveI' : $e =Q $a ^ $b := ⟨⟩
         assumeInstancesCommute
         pure (.positive q(zpow_pos $pa $b))
@@ -231,8 +231,9 @@ def evalZPow : PositivityExt where eval {u α} zα pα e := do
         let iα ← synthInstanceQ q(IsStrictOrderedRing $α)
         orElse (← catchNone (ofNonneg q(le_of_lt $pa) sα oα iα))
           (ofNonzero q(ne_of_gt $pa) q(inferInstance))
-    | .nonnegative pa => ofNonneg pa (← synthInstanceQ (_ : Q(Type u)))
-                           (← synthInstanceQ (_ : Q(Type u))) (← synthInstanceQ (_ : Q(Prop)))
+    | .nonnegative pa =>
+      ofNonneg pa (← synthInstanceQ (_ : Q(Type u)))
+                  (← synthInstanceQ (_ : Q(Type u))) (← synthInstanceQ (_ : Q(Prop)))
     | .nonzero pa => ofNonzero pa (← synthInstanceQ (_ : Q(Type u)))
     | .none => pure .none
 

--- a/Mathlib/Algebra/Order/Floor/Defs.lean
+++ b/Mathlib/Algebra/Order/Floor/Defs.lean
@@ -327,7 +327,7 @@ private theorem nat_ceil_pos [LinearOrderedSemiring α] [FloorSemiring α] {a : 
 def evalNatCeil : PositivityExt where eval {u α} _zα _pα e := do
   match u, α, e with
   | 0, ~q(ℕ), ~q(@Nat.ceil $α' $i $j $a) =>
-    let _i : Q(LinearOrderedSemiring $α') ← synthInstanceQ (u := u_1) _
+    let _i ← synthInstanceQ q(LinearOrderedSemiring $α')
     assertInstancesCommute
     match ← core q(inferInstance) q(inferInstance) a with
     | .positive pa =>

--- a/Mathlib/Algebra/Order/Module/Algebra.lean
+++ b/Mathlib/Algebra/Order/Module/Algebra.lean
@@ -78,7 +78,7 @@ open Lean Meta Qq Function
 @[positivity algebraMap _ _ _]
 def evalAlgebraMap : PositivityExt where eval {u β} _zβ _pβ e := do
   let ~q(@algebraMap $α _ $instα $instβ $instαβ $a) := e | throwError "not `algebraMap`"
-  let pα ← synthInstanceQ (q(PartialOrder $α) : Q(Type u_1))
+  let pα ← synthInstanceQ q(PartialOrder $α)
   match ← core q(inferInstance) pα a with
   | .positive pa =>
     let _instαSemiring ← synthInstanceQ q(Semiring $α)

--- a/Mathlib/Tactic/FieldSimp.lean
+++ b/Mathlib/Tactic/FieldSimp.lean
@@ -45,7 +45,7 @@ partial def discharge (prop : Expr) : SimpM (Option Expr) :=
     let pf? ← match prop with
     | ~q(($e : $α) ≠ $b) =>
         try
-          let res ← Mathlib.Meta.NormNum.derive (α := (q(Prop) : Q(Type))) prop
+          let res ← Mathlib.Meta.NormNum.derive prop
           match res with
           | .isTrue pf => pure (some pf)
           | _ => pure none

--- a/Mathlib/Tactic/ITauto.lean
+++ b/Mathlib/Tactic/ITauto.lean
@@ -540,8 +540,8 @@ partial def applyProof (g : MVarId) (Γ : NameMap Expr) (p : Proof) : MetaM Unit
   | .andIntro .and p q => do
     let A ← mkFreshExprMVarQ q(Prop)
     let B ← mkFreshExprMVarQ q(Prop)
-    let t₁ ← mkFreshExprMVarQ (u := .zero) A
-    let t₂ ← mkFreshExprMVarQ (u := .zero) B
+    let t₁ ← mkFreshExprMVarQ q($A)
+    let t₂ ← mkFreshExprMVarQ q($B)
     g.assignIfDefeq q(And.intro $t₁ $t₂)
     applyProof t₁.mvarId! Γ p
     applyProof t₂.mvarId! Γ q
@@ -565,20 +565,20 @@ partial def applyProof (g : MVarId) (Γ : NameMap Expr) (p : Proof) : MetaM Unit
     let A ← mkFreshExprMVarQ q(Prop)
     let B ← mkFreshExprMVarQ q(Prop)
     let t₁ ← mkFreshExprMVarQ q($A → $B)
-    let t₂ ← mkFreshExprMVarQ (u := .zero) A
+    let t₂ ← mkFreshExprMVarQ q($A)
     g.assignIfDefeq q($t₁ $t₂)
     applyProof t₁.mvarId! Γ p
     applyProof t₂.mvarId! Γ q
   | .orInL p => do
     let A ← mkFreshExprMVarQ q(Prop)
     let B ← mkFreshExprMVarQ q(Prop)
-    let t ← mkFreshExprMVarQ (u := .zero) A
+    let t ← mkFreshExprMVarQ q($A)
     g.assignIfDefeq q(@Or.inl $A $B $t)
     applyProof t.mvarId! Γ p
   | .orInR p => do
     let A ← mkFreshExprMVarQ q(Prop)
     let B ← mkFreshExprMVarQ q(Prop)
-    let t ← mkFreshExprMVarQ (u := .zero) B
+    let t ← mkFreshExprMVarQ q($B)
     g.assignIfDefeq q(@Or.inr $A $B $t)
     applyProof t.mvarId! Γ p
   | .orElim' p x p₁ p₂ => do

--- a/Mathlib/Tactic/IntervalCases.lean
+++ b/Mathlib/Tactic/IntervalCases.lean
@@ -215,8 +215,8 @@ This tells `interval_cases` how to work on natural numbers. -/
 def natMethods : Methods where
   initLB (e : Q(ℕ)) :=
     pure (.le 0, q(0), q(Nat.zero_le $e))
-  eval e := do
-    let ⟨z, e, p⟩ := (← NormNum.derive e).toRawIntEq.get!
+  eval (e : Q(ℕ)) := do
+    let ⟨z, e, p⟩ := (← NormNum.derive q($e)).toRawIntEq.get!
     pure (z, e, p)
   proveLE (lhs rhs : Q(ℕ)) := mkDecideProofQ q($lhs ≤ $rhs)
   proveLT (lhs rhs : Q(ℕ)) := mkDecideProofQ q(¬$rhs ≤ $lhs)
@@ -234,8 +234,8 @@ theorem _root_.Int.le_sub_one_of_not_le {a b : ℤ} (h : ¬b ≤ a) : a ≤ b - 
 /-- A `Methods` implementation for `ℤ`.
 This tells `interval_cases` how to work on integers. -/
 def intMethods : Methods where
-  eval e := do
-    let ⟨z, e, p⟩ := (← NormNum.derive e).toRawIntEq.get!
+  eval (e : Q(ℤ)) := do
+    let ⟨z, e, p⟩ := (← NormNum.derive q($e)).toRawIntEq.get!
     pure (z, e, p)
   proveLE (lhs rhs : Q(ℤ)) := mkDecideProofQ q($lhs ≤ $rhs)
   proveLT (lhs rhs : Q(ℤ)) := mkDecideProofQ q(¬$rhs ≤ $lhs)

--- a/Mathlib/Tactic/IntervalCases.lean
+++ b/Mathlib/Tactic/IntervalCases.lean
@@ -216,7 +216,7 @@ def natMethods : Methods where
   initLB (e : Q(ℕ)) :=
     pure (.le 0, q(0), q(Nat.zero_le $e))
   eval e := do
-    let ⟨z, e, p⟩ := (← NormNum.derive (α := (q(ℕ) : Q(Type))) e).toRawIntEq.get!
+    let ⟨z, e, p⟩ := (← NormNum.derive e).toRawIntEq.get!
     pure (z, e, p)
   proveLE (lhs rhs : Q(ℕ)) := mkDecideProofQ q($lhs ≤ $rhs)
   proveLT (lhs rhs : Q(ℕ)) := mkDecideProofQ q(¬$rhs ≤ $lhs)
@@ -235,7 +235,7 @@ theorem _root_.Int.le_sub_one_of_not_le {a b : ℤ} (h : ¬b ≤ a) : a ≤ b - 
 This tells `interval_cases` how to work on integers. -/
 def intMethods : Methods where
   eval e := do
-    let ⟨z, e, p⟩ := (← NormNum.derive (α := (q(ℤ) : Q(Type))) e).toRawIntEq.get!
+    let ⟨z, e, p⟩ := (← NormNum.derive e).toRawIntEq.get!
     pure (z, e, p)
   proveLE (lhs rhs : Q(ℤ)) := mkDecideProofQ q($lhs ≤ $rhs)
   proveLT (lhs rhs : Q(ℤ)) := mkDecideProofQ q(¬$rhs ≤ $lhs)

--- a/Mathlib/Tactic/NormNum/Basic.lean
+++ b/Mathlib/Tactic/NormNum/Basic.lean
@@ -434,7 +434,7 @@ theorem isRat_div {α : Type u} [DivisionRing α] : {a b : α} → {cn : ℤ} �
 
 /-- Helper function to synthesize a typed `DivisionRing α` expression. -/
 def inferDivisionRing {u : Level} (α : Q(Type u)) : MetaM Q(DivisionRing $α) :=
-  return ← synthInstanceQ (q(DivisionRing $α) : Q(Type u)) <|> throwError "not a division ring"
+  return ← synthInstanceQ q(DivisionRing $α) <|> throwError "not a division ring"
 
 attribute [local instance] monadLiftOptionMetaM in
 /-- The `norm_num` extension which identifies expressions of the form `a / b`,

--- a/Mathlib/Tactic/NormNum/Core.lean
+++ b/Mathlib/Tactic/NormNum/Core.lean
@@ -123,7 +123,7 @@ def deriveRat {α : Q(Type u)} (e : Q($α))
 /-- Run each registered `norm_num` extension on a typed expression `p : Prop`,
 and returning the truth or falsity of `p' : Prop` from an equivalence `p ↔ p'`. -/
 def deriveBool (p : Q(Prop)) : MetaM ((b : Bool) × BoolResult p b) := do
-  let .isBool b prf ← derive (α := (q(Prop) : Q(Type))) p | failure
+  let .isBool b prf ← derive q($p) | failure
   pure ⟨b, prf⟩
 
 /-- Run each registered `norm_num` extension on a typed expression `p : Prop`,

--- a/Mathlib/Tactic/NormNum/Ineq.lean
+++ b/Mathlib/Tactic/NormNum/Ineq.lean
@@ -21,16 +21,16 @@ variable {u : Level}
 
 /-- Helper function to synthesize a typed `OrderedSemiring α` expression. -/
 def inferOrderedSemiring (α : Q(Type u)) : MetaM Q(OrderedSemiring $α) :=
-  return ← synthInstanceQ (q(OrderedSemiring $α) : Q(Type u)) <|>
+  return ← synthInstanceQ q(OrderedSemiring $α) <|>
     throwError "not an ordered semiring"
 
 /-- Helper function to synthesize a typed `OrderedRing α` expression. -/
 def inferOrderedRing (α : Q(Type u)) : MetaM Q(OrderedRing $α) :=
-  return ← synthInstanceQ (q(OrderedRing $α) : Q(Type u)) <|> throwError "not an ordered ring"
+  return ← synthInstanceQ q(OrderedRing $α) <|> throwError "not an ordered ring"
 
 /-- Helper function to synthesize a typed `LinearOrderedField α` expression. -/
 def inferLinearOrderedField (α : Q(Type u)) : MetaM Q(LinearOrderedField $α) :=
-  return ← synthInstanceQ (q(LinearOrderedField $α) : Q(Type u)) <|>
+  return ← synthInstanceQ q(LinearOrderedField $α) <|>
     throwError "not a linear ordered field"
 
 variable {α : Type*}
@@ -127,7 +127,7 @@ where
     if decide (za ≤ zb) then
       let r : Q(decide ($na ≤ $nb) = true) := (q(Eq.refl true) : Expr)
       return .isTrue q(isInt_le_true $pa $pb $r)
-    else if let .some _i ← trySynthInstanceQ (q(@Nontrivial $α) : Q(Prop)) then
+    else if let .some _i ← trySynthInstanceQ q(Nontrivial $α) then
       let r : Q(decide ($nb < $na) = true) := (q(Eq.refl true) : Expr)
       return .isFalse q(isInt_le_false $pa $pb $r)
     else
@@ -159,7 +159,7 @@ where
     if na.natLit! ≤ nb.natLit! then
       let r : Q(Nat.ble $na $nb = true) := (q(Eq.refl true) : Expr)
       return .isTrue q(isNat_le_true $pa $pb $r)
-    else if let .some _i ← trySynthInstanceQ (q(CharZero $α) : Q(Prop)) then
+    else if let .some _i ← trySynthInstanceQ q(CharZero $α) then
       let r : Q(Nat.ble $na $nb = false) := (q(Eq.refl false) : Expr)
       return .isFalse q(isNat_le_false $pa $pb $r)
     else -- Nats can appear in an `OrderedRing` without `CharZero`.
@@ -190,7 +190,7 @@ where
     let ⟨zb, nb, pb⟩ ← rb.toInt q(OrderedRing.toRing)
     assumeInstancesCommute
     if za < zb then
-      if let .some _i ← trySynthInstanceQ (q(@Nontrivial $α) : Q(Prop)) then
+      if let .some _i ← trySynthInstanceQ q(Nontrivial $α) then
         let r : Q(decide ($na < $nb) = true) := (q(Eq.refl true) : Expr)
         return .isTrue q(isInt_lt_true $pa $pb $r)
       else

--- a/Mathlib/Tactic/NormNum/Inv.lean
+++ b/Mathlib/Tactic/NormNum/Inv.lean
@@ -20,18 +20,18 @@ open Lean.Meta Qq
 /-- Helper function to synthesize a typed `CharZero α` expression given `Ring α`. -/
 def inferCharZeroOfRing {α : Q(Type u)} (_i : Q(Ring $α) := by with_reducible assumption) :
     MetaM Q(CharZero $α) :=
-  return ← synthInstanceQ (q(CharZero $α) : Q(Prop)) <|>
+  return ← synthInstanceQ q(CharZero $α) <|>
     throwError "not a characteristic zero ring"
 
 /-- Helper function to synthesize a typed `CharZero α` expression given `Ring α`, if it exists. -/
 def inferCharZeroOfRing? {α : Q(Type u)} (_i : Q(Ring $α) := by with_reducible assumption) :
     MetaM (Option Q(CharZero $α)) :=
-  return (← trySynthInstanceQ (q(CharZero $α) : Q(Prop))).toOption
+  return (← trySynthInstanceQ q(CharZero $α)).toOption
 
 /-- Helper function to synthesize a typed `CharZero α` expression given `AddMonoidWithOne α`. -/
 def inferCharZeroOfAddMonoidWithOne {α : Q(Type u)}
     (_i : Q(AddMonoidWithOne $α) := by with_reducible assumption) : MetaM Q(CharZero $α) :=
-  return ← synthInstanceQ (q(CharZero $α) : Q(Prop)) <|>
+  return ← synthInstanceQ q(CharZero $α) <|>
     throwError "not a characteristic zero AddMonoidWithOne"
 
 /-- Helper function to synthesize a typed `CharZero α` expression given `AddMonoidWithOne α`, if it
@@ -39,19 +39,19 @@ exists. -/
 def inferCharZeroOfAddMonoidWithOne? {α : Q(Type u)}
     (_i : Q(AddMonoidWithOne $α) := by with_reducible assumption) :
       MetaM (Option Q(CharZero $α)) :=
-  return (← trySynthInstanceQ (q(CharZero $α) : Q(Prop))).toOption
+  return (← trySynthInstanceQ q(CharZero $α)).toOption
 
 /-- Helper function to synthesize a typed `CharZero α` expression given `DivisionRing α`. -/
 def inferCharZeroOfDivisionRing {α : Q(Type u)}
     (_i : Q(DivisionRing $α) := by with_reducible assumption) : MetaM Q(CharZero $α) :=
-  return ← synthInstanceQ (q(CharZero $α) : Q(Prop)) <|>
+  return ← synthInstanceQ q(CharZero $α) <|>
     throwError "not a characteristic zero division ring"
 
 /-- Helper function to synthesize a typed `CharZero α` expression given `DivisionRing α`, if it
 exists. -/
 def inferCharZeroOfDivisionRing? {α : Q(Type u)}
     (_i : Q(DivisionRing $α) := by with_reducible assumption) : MetaM (Option Q(CharZero $α)) :=
-  return (← trySynthInstanceQ (q(CharZero $α) : Q(Prop))).toOption
+  return (← trySynthInstanceQ q(CharZero $α)).toOption
 
 theorem isRat_mkRat : {a na n : ℤ} → {b nb d : ℕ} → IsInt a na → IsNat b nb →
     IsRat (na / nb : ℚ) n d → IsRat (mkRat a b) n d

--- a/Mathlib/Tactic/NormNum/Result.lean
+++ b/Mathlib/Tactic/NormNum/Result.lean
@@ -42,16 +42,16 @@ def instAddMonoidWithOne {α : Type u} [Ring α] : AddMonoidWithOne α := inferI
 
 /-- Helper function to synthesize a typed `AddMonoidWithOne α` expression. -/
 def inferAddMonoidWithOne (α : Q(Type u)) : MetaM Q(AddMonoidWithOne $α) :=
-  return ← synthInstanceQ (q(AddMonoidWithOne $α) : Q(Type u)) <|>
+  return ← synthInstanceQ q(AddMonoidWithOne $α) <|>
     throwError "not an AddMonoidWithOne"
 
 /-- Helper function to synthesize a typed `Semiring α` expression. -/
 def inferSemiring (α : Q(Type u)) : MetaM Q(Semiring $α) :=
-  return ← synthInstanceQ (q(Semiring $α) : Q(Type u)) <|> throwError "not a semiring"
+  return ← synthInstanceQ q(Semiring $α) <|> throwError "not a semiring"
 
 /-- Helper function to synthesize a typed `Ring α` expression. -/
 def inferRing (α : Q(Type u)) : MetaM Q(Ring $α) :=
-  return ← synthInstanceQ (q(Ring $α) : Q(Type u)) <|> throwError "not a ring"
+  return ← synthInstanceQ q(Ring $α) <|> throwError "not a ring"
 
 /--
 Represent an integer as a "raw" typed expression.
@@ -263,11 +263,11 @@ instance {α : Q(Type u)} {x : Q($α)} : Inhabited (Result x) := inferInstanceAs
 
 /-- The result is `proof : x`, where `x` is a (true) proposition. -/
 @[match_pattern, inline] def Result.isTrue {x : Q(Prop)} :
-    ∀ (proof : Q($x)), @Result _ (q(Prop) : Q(Type)) x := Result'.isBool true
+    ∀ (proof : Q($x)), Result q($x) := Result'.isBool true
 
 /-- The result is `proof : ¬x`, where `x` is a (false) proposition. -/
 @[match_pattern, inline] def Result.isFalse {x : Q(Prop)} :
-    ∀ (proof : Q(¬$x)), @Result _ (q(Prop) : Q(Type)) x := Result'.isBool false
+    ∀ (proof : Q(¬$x)), Result q($x) := Result'.isBool false
 
 /-- The result is `lit : ℕ` (a raw nat literal) and `proof : isNat x lit`. -/
 @[match_pattern, inline] def Result.isNat {α : Q(Type u)} {x : Q($α)} :

--- a/Mathlib/Tactic/Polyrith.lean
+++ b/Mathlib/Tactic/Polyrith.lean
@@ -168,7 +168,7 @@ def parseContext (only : Bool) (hyps : Array Expr) (target : Expr) :
   let some v := u.dec | throwError "not a type{indentExpr α}"
   have α : Q(Type v) := α
   have e₁ : Q($α) := e₁; have e₂ : Q($α) := e₂
-  let sα ← synthInstanceQ (q(CommSemiring $α) : Q(Type v))
+  let sα ← synthInstanceQ q(CommSemiring $α)
   let c ← mkCache sα
   let target := (← parse sα c e₁).sub (← parse sα c e₂)
   let rec

--- a/Mathlib/Tactic/Positivity/Basic.lean
+++ b/Mathlib/Tactic/Positivity/Basic.lean
@@ -105,9 +105,9 @@ such that `positivity` successfully recognises both `a` and `b`. -/
   let .app (.app (f : Q($α → $α → $α)) (a : Q($α))) (b : Q($α)) ← withReducible (whnf e)
     | throwError "not min"
   let _e_eq : $e =Q $f $a $b := ⟨⟩
-  let _a ← synthInstanceQ (q(LinearOrder $α) : Q(Type u))
+  let _a ← synthInstanceQ q(LinearOrder $α)
   assumeInstancesCommute
-  let ⟨_f_eq⟩ ← withDefault <| withNewMCtxDepth <| assertDefEqQ (u := u.succ) f q(min)
+  let ⟨_f_eq⟩ ← withDefault <| withNewMCtxDepth <| assertDefEqQ q($f) q(min)
   match ← core zα pα a, ← core zα pα b with
   | .positive pa, .positive pb => pure (.positive q(lt_min $pa $pb))
   | .positive pa, .nonnegative pb => pure (.nonnegative q(le_min_of_lt_of_le $pa $pb))
@@ -124,9 +124,9 @@ is nonnegative, strictly positive if at least one is positive, and nonzero if bo
   let .app (.app (f : Q($α → $α → $α)) (a : Q($α))) (b : Q($α)) ← withReducible (whnf e)
     | throwError "not max"
   let _e_eq : $e =Q $f $a $b := ⟨⟩
-  let _a ← synthInstanceQ (q(LinearOrder $α) : Q(Type u))
+  let _a ← synthInstanceQ q(LinearOrder $α)
   assumeInstancesCommute
-  let ⟨_f_eq⟩ ← withDefault <| withNewMCtxDepth <| assertDefEqQ (u := u.succ) f q(max)
+  let ⟨_f_eq⟩ ← withDefault <| withNewMCtxDepth <| assertDefEqQ q($f) q(max)
   let result : Strictness zα pα e ← catchNone do
     let ra ← core zα pα a
     match ra with
@@ -153,22 +153,22 @@ such that `positivity` successfully recognises both `a` and `b`. -/
   let .app (.app (f : Q($α → $α → $α)) (a : Q($α))) (b : Q($α)) ← withReducible (whnf e)
     | throwError "not +"
   let _e_eq : $e =Q $f $a $b := ⟨⟩
-  let _a ← synthInstanceQ (q(AddZeroClass $α) : Q(Type u))
+  let _a ← synthInstanceQ q(AddZeroClass $α)
   assumeInstancesCommute
-  let ⟨_f_eq⟩ ← withDefault <| withNewMCtxDepth <| assertDefEqQ (u := u.succ) f q(HAdd.hAdd)
+  let ⟨_f_eq⟩ ← withDefault <| withNewMCtxDepth <| assertDefEqQ q($f) q(HAdd.hAdd)
   let ra ← core zα pα a; let rb ← core zα pα b
   match ra, rb with
   | .positive pa, .positive pb =>
-    let _a ← synthInstanceQ (q(AddLeftStrictMono $α) : Q(Prop))
+    let _a ← synthInstanceQ q(AddLeftStrictMono $α)
     pure (.positive q(add_pos $pa $pb))
   | .positive pa, .nonnegative pb =>
-    let _a ← synthInstanceQ (q(AddRightStrictMono $α) : Q(Prop))
+    let _a ← synthInstanceQ q(AddRightStrictMono $α)
     pure (.positive q(lt_add_of_pos_of_le $pa $pb))
   | .nonnegative pa, .positive pb =>
-    let _a ← synthInstanceQ (q(AddLeftStrictMono $α) : Q(Prop))
+    let _a ← synthInstanceQ q(AddLeftStrictMono $α)
     pure (.positive q(lt_add_of_le_of_pos $pa $pb))
   | .nonnegative pa, .nonnegative pb =>
-    let _a ← synthInstanceQ (q(AddLeftMono $α) : Q(Prop))
+    let _a ← synthInstanceQ q(AddLeftMono $α)
     pure (.nonnegative q(add_nonneg $pa $pb))
   | _, _ => failure
 
@@ -202,7 +202,7 @@ such that `positivity` successfully recognises both `a` and `b`. -/
   let _a ← synthInstanceQ q(PartialOrder $α)
   let _a ← synthInstanceQ q(IsStrictOrderedRing $α)
   assumeInstancesCommute
-  let ⟨_f_eq⟩ ← withDefault <| withNewMCtxDepth <| assertDefEqQ (u := u.succ) f q(HMul.hMul)
+  let ⟨_f_eq⟩ ← withDefault <| withNewMCtxDepth <| assertDefEqQ q($f) q(HMul.hMul)
   let ra ← core zα pα a; let rb ← core zα pα b
   match ra, rb with
   | .positive pa, .positive pb => pure (.positive q(mul_pos $pa $pb))
@@ -210,13 +210,13 @@ such that `positivity` successfully recognises both `a` and `b`. -/
   | .nonnegative pa, .positive pb => pure (.nonnegative q(mul_nonneg_of_nonneg_of_pos $pa $pb))
   | .nonnegative pa, .nonnegative pb => pure (.nonnegative q(mul_nonneg $pa $pb))
   | .positive pa, .nonzero pb =>
-    let _a ← synthInstanceQ (q(NoZeroDivisors $α) : Q(Prop))
+    let _a ← synthInstanceQ q(NoZeroDivisors $α)
     pure (.nonzero q(mul_ne_zero_of_pos_of_ne_zero $pa $pb))
   | .nonzero pa, .positive pb =>
-    let _a ← synthInstanceQ (q(NoZeroDivisors $α) : Q(Prop))
+    let _a ← synthInstanceQ q(NoZeroDivisors $α)
     pure (.nonzero q(mul_ne_zero_of_ne_zero_of_pos $pa $pb))
   | .nonzero pa, .nonzero pb =>
-    let _a ← synthInstanceQ (q(NoZeroDivisors $α) : Q(Prop))
+    let _a ← synthInstanceQ q(NoZeroDivisors $α)
     pure (.nonzero q(mul_ne_zero $pa $pb))
   | _, _ => pure .none
 
@@ -268,7 +268,7 @@ def evalPowZeroNat : PositivityExt where eval {u α} _zα _pα e := do
   let _a ← synthInstanceQ q(Semiring $α)
   let _a ← synthInstanceQ q(PartialOrder $α)
   let _a ← synthInstanceQ q(IsOrderedRing $α)
-  _ ← synthInstanceQ (q(Nontrivial $α) : Q(Prop))
+  _ ← synthInstanceQ q(Nontrivial $α)
   pure (.positive (q(pow_zero_pos $a) : Expr))
 
 /-- The `positivity` extension which identifies expressions of the form `a ^ (b : ℕ)`,
@@ -304,20 +304,24 @@ def evalPow : PositivityExt where eval {u α} zα pα e := do
     match ra with
     | .positive pa =>
       try
-        let _a ← synthInstanceQ (q(Semiring $α) : Q(Type u))
-        let _a ← synthInstanceQ (q(IsStrictOrderedRing $α) : Q(Prop))
+        let _a ← synthInstanceQ q(Semiring $α)
+        let _a ← synthInstanceQ q(IsStrictOrderedRing $α)
         haveI' : $e =Q $a ^ $b := ⟨⟩
         assumeInstancesCommute
         pure (.positive q(pow_pos $pa $b))
       catch e : Exception =>
         trace[Tactic.positivity.failure] "{e.toMessageData}"
-        let rα ← synthInstanceQ (q(Semiring $α) : Q(Type u))
-        let oα ← synthInstanceQ (q(IsOrderedRing $α) : Q(Prop))
+        let rα ← synthInstanceQ q(Semiring $α)
+        let oα ← synthInstanceQ q(IsOrderedRing $α)
         orElse (← catchNone (ofNonneg q(le_of_lt $pa) rα oα)) (ofNonzero q(ne_of_gt $pa) rα oα)
     | .nonnegative pa =>
-        ofNonneg pa (← synthInstanceQ (_ : Q(Type u))) (← synthInstanceQ (_ : Q(Prop)))
+        let sα ← synthInstanceQ q(Semiring $α)
+        let oα ← synthInstanceQ q(IsOrderedRing $α)
+        ofNonneg q($pa) q($sα) q($oα)
     | .nonzero pa =>
-        ofNonzero pa (← synthInstanceQ (_ : Q(Type u))) (← synthInstanceQ (_ : Q(Prop)))
+        let sα ← synthInstanceQ q(Semiring $α)
+        let oα ← synthInstanceQ q(IsOrderedRing $α)
+        ofNonzero q($pa) q($sα) q($oα)
     | .none => pure .none
 
 private theorem abs_pos_of_ne_zero {α : Type*} [AddGroup α] [LinearOrder α]
@@ -325,7 +329,7 @@ private theorem abs_pos_of_ne_zero {α : Type*} [AddGroup α] [LinearOrder α]
 
 /-- The `positivity` extension which identifies expressions of the form `|a|`. -/
 @[positivity |_|]
-def evalAbs : PositivityExt where eval {u} (α : Q(Type u)) zα pα (e : Q($α)) := do
+def evalAbs : PositivityExt where eval {_u} (α zα pα) (e : Q($α)) := do
   let ~q(@abs _ (_) (_) $a) := e | throwError "not |·|"
   try
     match ← core zα pα a with
@@ -394,20 +398,20 @@ def evalIntCast : PositivityExt where eval {u α} _zα _pα e := do
   let ra ← core zα' pα' a
   match ra with
   | .positive pa =>
-    let _rα ← synthInstanceQ (q(Ring $α) : Q(Type u))
-    let _oα ← synthInstanceQ (q(IsOrderedRing $α) : Q(Prop))
+    let _rα ← synthInstanceQ q(Ring $α)
+    let _oα ← synthInstanceQ q(IsOrderedRing $α)
     let _nt ← synthInstanceQ q(Nontrivial $α)
     assumeInstancesCommute
     pure (.positive q(Int.cast_pos.mpr $pa))
   | .nonnegative pa =>
-    let _rα ← synthInstanceQ (q(Ring $α) : Q(Type u))
-    let _oα ← synthInstanceQ (q(IsOrderedRing $α) : Q(Prop))
+    let _rα ← synthInstanceQ q(Ring $α)
+    let _oα ← synthInstanceQ q(IsOrderedRing $α)
     let _nt ← synthInstanceQ q(Nontrivial $α)
     assumeInstancesCommute
     pure (.nonnegative q(Int.cast_nonneg.mpr $pa))
   | .nonzero pa =>
-    let _oα ← synthInstanceQ (q(AddGroupWithOne $α) : Q(Type $u))
-    let _nt ← synthInstanceQ (q(CharZero $α) : Q(Prop))
+    let _oα ← synthInstanceQ q(AddGroupWithOne $α)
+    let _nt ← synthInstanceQ q(CharZero $α)
     assumeInstancesCommute
     pure (.nonzero q(Int.cast_ne_zero.mpr $pa))
   | .none =>

--- a/Mathlib/Tactic/Positivity/Core.lean
+++ b/Mathlib/Tactic/Positivity/Core.lean
@@ -223,9 +223,9 @@ def normNumPositivity (e : Q($α)) : MetaM (Strictness zα pα e) := catchNone d
 
 /-- Attempts to prove that `e ≥ 0` using `zero_le` in a `CanonicallyOrderedAdd` monoid. -/
 def positivityCanon (e : Q($α)) : MetaM (Strictness zα pα e) := do
-  let _add ← synthInstanceQ (q(AddMonoid $α) : Q(Type u))
-  let _le ← synthInstanceQ (q(PartialOrder $α) : Q(Type u))
-  let _i ← synthInstanceQ (q(CanonicallyOrderedAdd $α) : Q(Prop))
+  let _add ← synthInstanceQ q(AddMonoid $α)
+  let _le ← synthInstanceQ q(PartialOrder $α)
+  let _i ← synthInstanceQ q(CanonicallyOrderedAdd $α)
   assumeInstancesCommute
   pure (.nonnegative q(zero_le $e))
 
@@ -400,7 +400,7 @@ def solve (t : Q(Prop)) : MetaM Expr := do
   | ~q(@LE.le $α $_a $z $e) => rest α z e .le
   | ~q(@LT.lt $α $_a $z $e) => rest α z e .lt
   | ~q($a ≠ ($b : ($α : Type _))) =>
-    let _zα ← synthInstanceQ (q(Zero $α) : Q(Type u_1))
+    let _zα ← synthInstanceQ q(Zero $α)
     if ← isDefEq b q((0 : $α)) then
       rest α b a .ne
     else

--- a/Mathlib/Tactic/Ring/RingNF.lean
+++ b/Mathlib/Tactic/Ring/RingNF.lean
@@ -97,7 +97,7 @@ def rewrite (parent : Expr) (root := true) : M Simp.Result :=
         let e ← withReducible <| whnf e
         guard e.isApp -- all interesting ring expressions are applications
         let ⟨u, α, e⟩ ← inferTypeQ' e
-        let sα ← synthInstanceQ (q(CommSemiring $α) : Q(Type u))
+        let sα ← synthInstanceQ q(CommSemiring $α)
         let c ← mkCache sα
         let ⟨a, _, pa⟩ ← match ← isAtomOrDerivable sα c e rctx s with
         | none => eval sα c e rctx s -- `none` indicates that `eval` will find something algebraic.

--- a/Mathlib/Tactic/Ring/RingNF.lean
+++ b/Mathlib/Tactic/Ring/RingNF.lean
@@ -99,7 +99,7 @@ def rewrite (parent : Expr) (root := true) : M Simp.Result :=
         let ⟨u, α, e⟩ ← inferTypeQ' e
         let sα ← synthInstanceQ q(CommSemiring $α)
         let c ← mkCache sα
-        let ⟨a, _, pa⟩ ← match ← isAtomOrDerivable sα c e rctx s with
+        let ⟨a, _, pa⟩ ← match ← isAtomOrDerivable q($sα) c q($e) rctx s with
         | none => eval sα c e rctx s -- `none` indicates that `eval` will find something algebraic.
         | some none => failure -- No point rewriting atoms
         | some (some r) => pure r -- Nothing algebraic for `eval` to use, but `norm_num` simplifies.

--- a/Mathlib/Tactic/Tauto.lean
+++ b/Mathlib/Tactic/Tauto.lean
@@ -46,36 +46,36 @@ def distribNotOnceAt (hypFVar : Expr) (g : MVarId) : MetaM AssertAfterResult := 
     replace q(Eq.to_iff $h')
   | ~q(¬ (($a : Prop) ∧ $b)) => do
     let h' : Q(¬($a ∧ $b)) := h.toExpr
-    let _inst ← synthInstanceQ (q(Decidable $b) : Q(Type))
+    let _inst ← synthInstanceQ q(Decidable $b)
     replace q(Decidable.not_and_iff_not_or_not'.mp $h')
   | ~q(¬ (($a : Prop) ∨ $b)) => do
     let h' : Q(¬($a ∨ $b)) := h.toExpr
     replace q(not_or.mp $h')
   | ~q(¬ (($a : Prop) ≠ $b)) => do
     let h' : Q(¬($a ≠ $b)) := h.toExpr
-    let _inst ← synthInstanceQ (q(Decidable ($a = $b)) : Q(Type))
+    let _inst ← synthInstanceQ q(Decidable ($a = $b))
     replace q(Decidable.of_not_not $h')
   | ~q(¬¬ ($a : Prop)) => do
     let h' : Q(¬¬$a) := h.toExpr
-    let _inst ← synthInstanceQ (q(Decidable $a) : Q(Type))
+    let _inst ← synthInstanceQ q(Decidable $a)
     replace q(Decidable.of_not_not $h')
   | ~q(¬ ((($a : Prop)) → $b)) => do
     let h' : Q(¬($a → $b)) := h.toExpr
-    let _inst ← synthInstanceQ (q(Decidable $a) : Q(Type))
+    let _inst ← synthInstanceQ q(Decidable $a)
     replace q(Decidable.not_imp_iff_and_not.mp $h')
   | ~q(¬ (($a : Prop) ↔ $b)) => do
     let h' : Q(¬($a ↔ $b)) := h.toExpr
-    let _inst ← synthInstanceQ (q(Decidable $b) : Q(Type))
+    let _inst ← synthInstanceQ q(Decidable $b)
     replace q(Decidable.not_iff.mp $h')
   | ~q(($a : Prop) ↔ $b) => do
     let h' : Q($a ↔ $b) := h.toExpr
-    let _inst ← synthInstanceQ (q(Decidable $b) : Q(Type))
+    let _inst ← synthInstanceQ q(Decidable $b)
     replace q(Decidable.iff_iff_and_or_not_and_not.mp $h')
   | ~q((((($a : Prop)) → False) : Prop)) =>
     throwError "distribNot found nothing to work on with negation"
   | ~q((((($a : Prop)) → $b) : Prop)) => do
     let h' : Q($a → $b) := h.toExpr
-    let _inst ← synthInstanceQ (q(Decidable $a) : Q(Type))
+    let _inst ← synthInstanceQ q(Decidable $a)
     replace q(Decidable.not_or_of_imp $h')
   | _ => throwError "distribNot found nothing to work on"
 


### PR DESCRIPTION
Either all these annotations were needed in an earlier version, or they were left from debugging and have been cargo-culted since.

In most cases this removes a type ascription with no replacement.
When this doesn't work, replacing `x` with `q($x)` usually does, as this allows Qq to participate in unification.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

Follows from #23744 