### PR TITLE
[Merged by Bors] - chore(RingTheory/TwoSidedIdeal/Operations): Add span_induction

### DIFF
--- a/Mathlib/RingTheory/TwoSidedIdeal/Operations.lean
+++ b/Mathlib/RingTheory/TwoSidedIdeal/Operations.lean
@@ -74,6 +74,36 @@ lemma span_mono {s t : Set R} (h : s ⊆ t) : span s ≤ span t := by
   rw [mem_span_iff] at hx ⊢
   exact fun I hI => hx I <| h.trans hI
 
+lemma span_le {s : Set R} {I : TwoSidedIdeal R} : span s ≤ I ↔ s ⊆ I := by
+  rw [TwoSidedIdeal.ringCon_le_iff, RingCon.gi _ |>.gc]
+  exact ⟨fun h x hx ↦ by aesop, fun h x y hxy ↦ (rel_iff I x y).mpr (h hxy)⟩
+
+/-- An induction principle for span membership.
+
+If `p` holds for 0 and all elements of `s`,
+and is preserved under addition and left and right multiplication,
+then `p` holds for all elements of the span of `s`. -/
+@[elab_as_elim]
+theorem span_induction {s : Set R}
+    {p : (x : R) → x ∈ TwoSidedIdeal.span s → Prop}
+    (mem : ∀ (x) (h : x ∈ s), p x (subset_span h))
+    (zero : p 0 (zero_mem _))
+    (add : ∀ x y hx hy, p x hx → p y hy → p (x + y) (add_mem _ hx hy))
+    (neg : ∀ x hx, p x hx → p (-x) (neg_mem _ hx))
+    (left_absorb : ∀ a x hx, p x hx → p (a * x) (mul_mem_left _ _ _ hx))
+    (right_absorb : ∀ b x hx, p x hx → p (x * b) (mul_mem_right _ _ _ hx))
+    {x : R} (hx : x ∈ span s) : p x hx :=
+  let J : TwoSidedIdeal R := .mk'
+    {x | ∃ hx, p x hx}
+    ⟨zero_mem _, zero⟩
+    (fun ⟨hx1, hx2⟩ ⟨hy1, hy2⟩ ↦ ⟨add_mem _ hx1 hy1, add _ _ hx1 hy1 hx2 hy2⟩)
+    (fun ⟨hx1, hx2⟩ ↦ ⟨neg_mem _ hx1, neg _ hx1 hx2⟩)
+    (fun {x' y'} ⟨hy1, hy2⟩ ↦ ⟨mul_mem_left _ _ _ hy1, left_absorb _ _ _ hy2⟩)
+    (fun {x' y'} ⟨hx1, hx2⟩ ↦ ⟨mul_mem_right _ _ _ hx1, right_absorb _ _ _ hx2⟩)
+  span_le (s := s) (I := J) |>.2
+    (fun x hx ↦ ⟨by simpa using (mem_span_iff.2 fun I a ↦ a hx), by simp_all⟩) hx
+      |>.elim fun _ ↦ by simp
+
 /--
 Pushout of a two-sided ideal. Defined as the span of the image of a two-sided ideal under a ring
 homomorphism.
@@ -119,34 +149,6 @@ lemma _root_.RingEquiv.mapTwoSidedIdeal_apply (e : R ≃+* S) (I : TwoSidedIdeal
 
 lemma _root_.RingEquiv.mapTwoSidedIdeal_symm (e : R ≃+* S) :
     e.mapTwoSidedIdeal.symm = e.symm.mapTwoSidedIdeal := rfl
-
-lemma span_le {s : Set R} {I : TwoSidedIdeal R} : span s ≤ I ↔ s ⊆ I := by
-  rw [TwoSidedIdeal.ringCon_le_iff, RingCon.gi _ |>.gc]
-  exact ⟨fun h x hx ↦ by aesop, fun h x y hxy ↦ (rel_iff I x y).mpr (h hxy)⟩
-
-/-- An induction principle for span membership. If `J` holds for 0 and all elements of `s`, and is
-preserved under addition and left and right multiplication, then `p` holds for all elements of
-the span of `s`. -/
-@[elab_as_elim]
-theorem span_induction {s : Set R}
-    {p : (x : R) → x ∈ TwoSidedIdeal.span s → Prop}
-    (mem : ∀ (x) (h : x ∈ s), p x (subset_span h))
-    (zero : p 0 (zero_mem _))
-    (add : ∀ x y hx hy, p x hx → p y hy → p (x + y) (add_mem _ hx hy))
-    (neg : ∀ x hx, p x hx → p (-x) (neg_mem _ hx))
-    (left_absorb : ∀ a x hx, p x hx → p (a * x) (mul_mem_left _ _ _ hx))
-    (right_absorb : ∀ b x hx, p x hx → p (x * b) (mul_mem_right _ _ _ hx))
-    {x : R} (hx : x ∈ span s) : p x hx :=
-  let J : TwoSidedIdeal R := .mk'
-    {x | ∃ hx, p x hx}
-    ⟨zero_mem _, zero⟩
-    (fun ⟨hx1, hx2⟩ ⟨hy1, hy2⟩ ↦ ⟨add_mem _ hx1 hy1, add _ _ hx1 hy1 hx2 hy2⟩)
-    (fun ⟨hx1, hx2⟩ ↦ ⟨neg_mem _ hx1, neg _ hx1 hx2⟩)
-    (fun {x' y'} ⟨hy1, hy2⟩ ↦ ⟨mul_mem_left _ _ _ hy1, left_absorb _ _ _ hy2⟩)
-    (fun {x' y'} ⟨hx1, hx2⟩ ↦ ⟨mul_mem_right _ _ _ hx1, right_absorb _ _ _ hx2⟩)
-  span_le (s := s) (I := J) |>.2
-    (fun x hx ↦ ⟨by simpa using (mem_span_iff.2 fun I a ↦ a hx), by simp_all⟩) hx
-      |>.elim fun _ ↦ by simp
 
 end NonUnitalNonAssocRing
 

--- a/Mathlib/RingTheory/TwoSidedIdeal/Operations.lean
+++ b/Mathlib/RingTheory/TwoSidedIdeal/Operations.lean
@@ -120,6 +120,34 @@ lemma _root_.RingEquiv.mapTwoSidedIdeal_apply (e : R ≃+* S) (I : TwoSidedIdeal
 lemma _root_.RingEquiv.mapTwoSidedIdeal_symm (e : R ≃+* S) :
     e.mapTwoSidedIdeal.symm = e.symm.mapTwoSidedIdeal := rfl
 
+lemma span_le {s : Set R} {I : TwoSidedIdeal R} : span s ≤ I ↔ s ⊆ I := by
+  rw [TwoSidedIdeal.ringCon_le_iff, RingCon.gi _ |>.gc]
+  exact ⟨fun h x hx ↦ by aesop, fun h x y hxy ↦ (rel_iff I x y).mpr (h hxy)⟩
+
+/-- An induction principle for span membership. If `J` holds for 0 and all elements of `s`, and is
+preserved under addition and left and right multiplication, then `p` holds for all elements of
+the span of `s`. -/
+@[elab_as_elim]
+theorem span_induction {s : Set R}
+    {p : (x : R) → x ∈ TwoSidedIdeal.span s → Prop}
+    (mem : ∀ (x) (h : x ∈ s), p x (subset_span h))
+    (zero : p 0 (zero_mem _))
+    (add : ∀ x y hx hy, p x hx → p y hy → p (x + y) (add_mem _ hx hy))
+    (neg : ∀ x hx, p x hx → p (-x) (neg_mem _ hx))
+    (left_absorb : ∀ a x hx, p x hx → p (a * x) (mul_mem_left _ _ _ hx))
+    (right_absorb : ∀ b x hx, p x hx → p (x * b) (mul_mem_right _ _ _ hx))
+    {x : R} (hx : x ∈ span s) : p x hx :=
+  let J : TwoSidedIdeal R := .mk'
+    {x | ∃ hx, p x hx}
+    ⟨zero_mem _, zero⟩
+    (fun ⟨hx1, hx2⟩ ⟨hy1, hy2⟩ ↦ ⟨add_mem _ hx1 hy1, add _ _ hx1 hy1 hx2 hy2⟩)
+    (fun ⟨hx1, hx2⟩ ↦ ⟨neg_mem _ hx1, neg _ hx1 hx2⟩)
+    (fun {x' y'} ⟨hy1, hy2⟩ ↦ ⟨mul_mem_left _ _ _ hy1, left_absorb _ _ _ hy2⟩)
+    (fun {x' y'} ⟨hx1, hx2⟩ ↦ ⟨mul_mem_right _ _ _ hx1, right_absorb _ _ _ hx2⟩)
+  span_le (s := s) (I := J) |>.2
+    (fun x hx ↦ ⟨by simpa using (mem_span_iff.2 fun I a ↦ a hx), by simp_all⟩) hx
+      |>.elim fun _ ↦ by simp
+
 end NonUnitalNonAssocRing
 
 section NonAssocRing
@@ -211,10 +239,6 @@ end NonUnitalRing
 section Ring
 
 variable {R : Type*} [Ring R]
-
-lemma span_le {s : Set R} {I : TwoSidedIdeal R} : span s ≤ I ↔ s ⊆ I := by
-  rw [TwoSidedIdeal.ringCon_le_iff, RingCon.gi _ |>.gc]
-  exact ⟨fun h x hx ↦ by aesop, fun h x y hxy ↦ (rel_iff I x y).mpr (h hxy)⟩
 
 open Pointwise Set in
 lemma mem_span_iff_mem_addSubgroup_closure {s : Set R} {z : R} :


### PR DESCRIPTION
splitted from #23320 following @eric-wieser advice
Co-authored-by: Jujian Zhang <jujian.zhang19@imperial.ac.uk>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
