### PR TITLE
[Merged by Bors] - doc(Computability): expand docs for Language

### DIFF
--- a/Mathlib/Computability/Language.lean
+++ b/Mathlib/Computability/Language.lean
@@ -13,10 +13,36 @@ import Mathlib.Tactic.DeriveFintype
 
 This file contains the definition and operations on formal languages over an alphabet.
 Note that "strings" are implemented as lists over the alphabet.
+
 Union and concatenation define a [Kleene algebra](https://en.wikipedia.org/wiki/Kleene_algebra)
 over the languages.
+
 In addition to that, we define a reversal of a language and prove that it behaves well
 with respect to other language operations.
+
+## Notation
+
+* `l + m`: union of languages `l` and `m`
+* `l * m`: language of strings `x ++ y` such that `x ∈ l` and `y ∈ m`
+* `l ^ n`: language of strings consisting of `n` members of `l` concatenated together
+* `1`: language consisting of only the empty string.
+  This is because it is the unit of the `*` operator.
+* `l∗`: Kleene's star – language of strings consisting of arbitrarily many
+  members of `l` concatenated together
+  (Note that this is the Unicode asterisk `∗`, and not the more common star `*`)
+
+## Main definitions
+
+* `Language α`: a set of strings over the alphabet `α`
+* `l.map f`: transform a language `l` over `α` into a language over `β`
+  by translating through `f : α → β`
+
+## Main theorems
+
+* `Language.self_eq_mul_add_iff`: Arden's lemma – if a language `l` satisfies the equation
+  `l = m * l + n`, and `m` doesn't contain the empty string,
+  then `l` is the language `m∗ * n`
+
 -/
 
 
@@ -363,7 +389,7 @@ end Language
 inductive Symbol (T N : Type*)
   /-- Terminal symbols (of the same type as the language) -/
   | terminal    (t : T) : Symbol T N
-  /-- Nonterminal symbols (must not be present at the end of word being generated) -/
+  /-- Nonterminal symbols (must not be present when the word being generated is finalized) -/
   | nonterminal (n : N) : Symbol T N
 deriving
   DecidableEq, Repr, Fintype


### PR DESCRIPTION
This is mostly motivated by wanting to highlight the non-trivial Arden's lemma in the file.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
