### PR TITLE
[Merged by Bors] - feat: any function from a countable discrete domain is strongly measurable

### DIFF
--- a/Mathlib/MeasureTheory/Function/L1Space/Integrable.lean
+++ b/Mathlib/MeasureTheory/Function/L1Space/Integrable.lean
@@ -114,11 +114,11 @@ theorem integrable_const [IsFiniteMeasure μ] (c : β) : Integrable (fun _ : α 
 
 @[simp]
 lemma Integrable.of_finite [Finite α] [MeasurableSingletonClass α] [IsFiniteMeasure μ] {f : α → β} :
-    Integrable f μ := ⟨.of_finite, .of_finite⟩
+    Integrable f μ := ⟨.of_discrete, .of_finite⟩
 
 /-- This lemma is a special case of `Integrable.of_finite`. -/
 -- Eternal deprecation for discoverability, don't remove
-@[deprecated Integrable.of_finite (since := "2024-10-05"), nolint deprecatedNoSince]
+@[deprecated Integrable.of_finite (since := "2025-04-09"), nolint deprecatedNoSince]
 lemma Integrable.of_isEmpty [IsEmpty α] {f : α → β} : Integrable f μ := .of_finite
 
 theorem MemLp.integrable_norm_rpow {f : α → β} {p : ℝ≥0∞} (hf : MemLp f p μ) (hp_ne_zero : p ≠ 0)

--- a/Mathlib/MeasureTheory/Function/LpSeminorm/Basic.lean
+++ b/Mathlib/MeasureTheory/Function/LpSeminorm/Basic.lean
@@ -993,7 +993,7 @@ lemma eLpNorm_lt_top_of_finite [Finite α] [IsFiniteMeasure μ] : eLpNorm f p μ
 
 @[simp] lemma MemLp.of_discrete [DiscreteMeasurableSpace α] [Finite α] [IsFiniteMeasure μ] :
     MemLp f p μ :=
-  let ⟨C, hC⟩ := Finite.exists_le (‖f ·‖₊); .of_bound .of_finite C <| .of_forall hC
+  let ⟨C, hC⟩ := Finite.exists_le (‖f ·‖₊); .of_bound .of_discrete C <| .of_forall hC
 
 @[deprecated (since := "2025-02-21")]
 alias Memℒp.of_discrete := MemLp.of_discrete

--- a/Mathlib/MeasureTheory/Function/StronglyMeasurable/AEStronglyMeasurable.lean
+++ b/Mathlib/MeasureTheory/Function/StronglyMeasurable/AEStronglyMeasurable.lean
@@ -107,17 +107,19 @@ theorem aestronglyMeasurable_const {b : β} : AEStronglyMeasurable[m] (fun _ : �
 theorem aestronglyMeasurable_one [One β] : AEStronglyMeasurable[m] (1 : α → β) μ :=
   stronglyMeasurable_one.aestronglyMeasurable
 
-@[simp]
+@[simp, nontriviality]
 lemma AEStronglyMeasurable.of_subsingleton_dom [Subsingleton α] : AEStronglyMeasurable[m] f μ :=
-  (Subsingleton.stronglyMeasurable' f).aestronglyMeasurable
+  StronglyMeasurable.of_subsingleton_dom.aestronglyMeasurable
 
-@[simp]
+@[simp, nontriviality]
 lemma AEStronglyMeasurable.of_subsingleton_cod [Subsingleton β] : AEStronglyMeasurable[m] f μ :=
-  (Subsingleton.stronglyMeasurable f).aestronglyMeasurable
+  StronglyMeasurable.of_subsingleton_cod.aestronglyMeasurable
 
+@[deprecated AEStronglyMeasurable.of_subsingleton_cod (since := "2025-04-09")]
 theorem Subsingleton.aestronglyMeasurable [Subsingleton β] (f : α → β) : AEStronglyMeasurable f μ :=
   .of_subsingleton_cod
 
+@[deprecated AEStronglyMeasurable.of_subsingleton_dom (since := "2025-04-09")]
 lemma Subsingleton.aestronglyMeasurable' [Subsingleton α] (f : α → β) : AEStronglyMeasurable f μ :=
   .of_subsingleton_dom
 
@@ -134,8 +136,11 @@ theorem SimpleFunc.aestronglyMeasurable (f : α →ₛ β) : AEStronglyMeasurabl
 
 namespace AEStronglyMeasurable
 
-lemma of_finite [DiscreteMeasurableSpace α] [Finite α] : AEStronglyMeasurable f μ :=
-  ⟨_, .of_finite, ae_eq_rfl⟩
+lemma of_discrete [Countable α] [MeasurableSingletonClass α] : AEStronglyMeasurable f μ :=
+  StronglyMeasurable.of_discrete.aestronglyMeasurable
+
+@[deprecated of_discrete (since := "2025-04-09")]
+lemma of_finite [DiscreteMeasurableSpace α] [Finite α] : AEStronglyMeasurable f μ := .of_discrete
 
 section Mk
 

--- a/Mathlib/MeasureTheory/Function/StronglyMeasurable/Basic.lean
+++ b/Mathlib/MeasureTheory/Function/StronglyMeasurable/Basic.lean
@@ -75,25 +75,29 @@ open MeasureTheory
 /-! ## Strongly measurable functions -/
 
 section StronglyMeasurable
-variable {_ : MeasurableSpace α} [TopologicalSpace β] {f : α → β} {μ : Measure α}
+variable {_ : MeasurableSpace α} {μ : Measure α} {f : α → β} {b : β} {g : ℕ → α} {m : ℕ}
 
-@[simp]
-theorem Subsingleton.stronglyMeasurable [Subsingleton β] (f : α → β) : StronglyMeasurable f := by
-  let f_sf : α →ₛ β := ⟨f, fun x => ?_, Set.Subsingleton.finite Set.subsingleton_of_subsingleton⟩
-  · exact ⟨fun _ => f_sf, fun x => tendsto_const_nhds⟩
-  · have h_univ : f ⁻¹' {x} = Set.univ := by
-      ext1 y
-      simp [eq_iff_true_of_subsingleton]
-    rw [h_univ]
-    exact MeasurableSet.univ
+variable [TopologicalSpace β]
 
 theorem SimpleFunc.stronglyMeasurable (f : α →ₛ β) : StronglyMeasurable f :=
   ⟨fun _ => f, fun _ => tendsto_const_nhds⟩
 
-@[nontriviality]
-theorem StronglyMeasurable.of_finite [Finite α] [MeasurableSingletonClass α]
-    {f : α → β} : StronglyMeasurable f :=
+@[simp, nontriviality]
+lemma StronglyMeasurable.of_subsingleton_dom [Subsingleton α] (f : α → β) : StronglyMeasurable f :=
   ⟨fun _ => SimpleFunc.ofFinite f, fun _ => tendsto_const_nhds⟩
+
+@[simp, nontriviality]
+lemma StronglyMeasurable.of_subsingleton_cod [Subsingleton β] (f : α → β) :
+    StronglyMeasurable f := by
+  let f_sf : α →ₛ β := ⟨f, fun x => ?_, Set.Subsingleton.finite Set.subsingleton_of_subsingleton⟩
+  · exact ⟨fun _ => f_sf, fun x => tendsto_const_nhds⟩
+  · simp [Set.preimage, eq_iff_true_of_subsingleton]
+
+@[deprecated (since := "2025-04-09")]
+alias Subsingleton.stronglyMeasurable := StronglyMeasurable.of_subsingleton_cod
+
+@[deprecated (since := "2025-04-09")]
+alias Subsingleton.stronglyMeasurable' := StronglyMeasurable.of_subsingleton_dom
 
 theorem stronglyMeasurable_const {b : β} : StronglyMeasurable fun _ : α => b :=
   ⟨fun _ => SimpleFunc.const α b, fun _ => tendsto_const_nhds⟩
@@ -109,9 +113,39 @@ theorem stronglyMeasurable_const' (hf : ∀ x y, f x = f y) : StronglyMeasurable
   convert stronglyMeasurable_const (β := β) using 1
   exact funext fun x => hf x default
 
-@[simp]
-theorem Subsingleton.stronglyMeasurable' [Subsingleton α] (f : α → β) : StronglyMeasurable f :=
-  stronglyMeasurable_const' fun x y => by rw [Subsingleton.elim x y]
+variable [MeasurableSingletonClass α]
+
+section aux
+omit [TopologicalSpace β]
+
+/-- Auxiliary definition for `StronglyMeasurable.of_discrete`. -/
+private noncomputable def simpleFuncAux (f : α → β) (b : β) (g : ℕ → α) : ℕ → SimpleFunc α β
+  | 0 => .const _ b
+  | n + 1 => .piecewise {g n} (.singleton _) (.const _ <| f (g n)) (simpleFuncAux f b g n)
+
+private lemma simpleFuncAux_eq_of_lt : ∀ n > m, simpleFuncAux f b g n (g m) = f (g m)
+  | _, .refl => by simp [simpleFuncAux]
+  | _, Nat.le.step (m := n) hmn => by
+    obtain hnm | hnm := eq_or_ne (g n) (g m) <;>
+      simp [simpleFuncAux, Set.piecewise_eq_of_not_mem , hnm.symm, simpleFuncAux_eq_of_lt _ hmn]
+
+private lemma simpleFuncAux_eventuallyEq : ∀ᶠ n in atTop, simpleFuncAux f b g n (g m) = f (g m) :=
+  eventually_atTop.2 ⟨_, simpleFuncAux_eq_of_lt⟩
+
+end aux
+
+@[nontriviality]
+lemma StronglyMeasurable.of_discrete [Countable α] : StronglyMeasurable f := by
+  cases isEmpty_or_nonempty α
+  · exact .of_subsingleton_dom _
+  obtain _ | ⟨⟨b⟩⟩ := isEmpty_or_nonempty β
+  · exact .of_subsingleton_cod _
+  obtain ⟨g, hg⟩ := exists_surjective_nat α
+  exact ⟨simpleFuncAux f b g, hg.forall.2 fun m ↦
+    tendsto_nhds_of_eventually_eq simpleFuncAux_eventuallyEq⟩
+
+@[deprecated StronglyMeasurable.of_discrete (since := "2025-04-09")]
+theorem StronglyMeasurable.of_finite [Finite α] : StronglyMeasurable f := .of_discrete
 
 end StronglyMeasurable
 
@@ -198,8 +232,7 @@ theorem norm_approxBounded_le {β} {f : α → β} [SeminormedAddCommGroup β] [
 theorem _root_.stronglyMeasurable_bot_iff [Nonempty β] [T2Space β] :
     StronglyMeasurable[⊥] f ↔ ∃ c, f = fun _ => c := by
   rcases isEmpty_or_nonempty α with hα | hα
-  · simp only [@Subsingleton.stronglyMeasurable' _ _ ⊥ _ _ f,
-      eq_iff_true_of_subsingleton, exists_const]
+  · simp [eq_iff_true_of_subsingleton]
   refine ⟨fun hf => ?_, fun hf_eq => ?_⟩
   · refine ⟨f hα.some, ?_⟩
     let fs := hf.approx


### PR DESCRIPTION
Also deprecate `StronglyMeasurable.of_finite`, which has become a corollary, and rename `Subsingleton.stronglyMeasurable`/`Subsingleton.stronglyMeasurable'` to `StronglyMeasurable.of_subsingleton_cod`/`StronglyMeasurable.of_subsingleton_dom` for clarity.

From LeanAPAP


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
