### PR TITLE
[Merged by Bors] - feat: the counting measure on a countable discrete space is sigma-finite

### DIFF
--- a/Mathlib/MeasureTheory/Measure/Count.lean
+++ b/Mathlib/MeasureTheory/Measure/Count.lean
@@ -148,6 +148,9 @@ theorem count_injective_image [MeasurableSingletonClass α] [MeasurableSingleton
   rw [← finite_image_iff hf.injOn] at hs
   rw [count_apply_infinite hs]
 
+instance count.instSigmaFinite [MeasurableSingletonClass α] [Countable α] :
+    SigmaFinite (count : Measure α) := by simp [sigmaFinite_iff_measure_singleton_lt_top]
+
 instance count.isFiniteMeasure [Finite α] :
     IsFiniteMeasure (Measure.count : Measure α) :=
   ⟨by cases nonempty_fintype α; simp [Measure.count_apply, finite_univ]⟩

--- a/Mathlib/MeasureTheory/Measure/Typeclasses/SFinite.lean
+++ b/Mathlib/MeasureTheory/Measure/Typeclasses/SFinite.lean
@@ -542,7 +542,9 @@ instance (priority := 100) IsFiniteMeasure.toSigmaFinite {_m0 : MeasurableSpace 
     [IsFiniteMeasure μ] : SigmaFinite μ :=
   ⟨⟨⟨fun _ => univ, fun _ => trivial, fun _ => measure_lt_top μ _, iUnion_const _⟩⟩⟩
 
-/-- A measure on a countable space is sigma-finite iff it gives finite mass to every singleton. -/
+/-- A measure on a countable space is sigma-finite iff it gives finite mass to every singleton.
+
+See `measure_singleton_lt_top` for the forward direction without the countability assumption. -/
 lemma Measure.sigmaFinite_iff_measure_singleton_lt_top [Countable α] :
     SigmaFinite μ ↔ ∀ a, μ {a} < ∞ where
   mp _ a := measure_singleton_lt_top

--- a/Mathlib/MeasureTheory/Measure/Typeclasses/SFinite.lean
+++ b/Mathlib/MeasureTheory/Measure/Typeclasses/SFinite.lean
@@ -20,7 +20,7 @@ namespace MeasureTheory
 open Set Filter Function Measure MeasurableSpace NNReal ENNReal
 
 variable {α β ι : Type*} {m0 : MeasurableSpace α} [MeasurableSpace β] {μ ν : Measure α}
-  {s t : Set α}
+  {s t : Set α} {a : α}
 
 section SFinite
 
@@ -187,6 +187,10 @@ theorem mem_spanningSets_of_index_le (μ : Measure α) [SigmaFinite μ] (x : α)
 theorem eventually_mem_spanningSets (μ : Measure α) [SigmaFinite μ] (x : α) :
     ∀ᶠ n in atTop, x ∈ spanningSets μ n :=
   eventually_atTop.2 ⟨spanningSetsIndex μ x, fun _ => mem_spanningSets_of_index_le μ x⟩
+
+lemma measure_singleton_lt_top [SigmaFinite μ] : μ {a} < ∞ :=
+  measure_lt_top_mono (singleton_subset_iff.2 <| mem_spanningSetsIndex ..)
+    (measure_spanningSets_lt_top _ _)
 
 theorem sum_restrict_disjointed_spanningSets (μ ν : Measure α) [SigmaFinite ν] :
     sum (fun n ↦ μ.restrict (disjointed (spanningSets ν) n)) = μ := by
@@ -537,6 +541,17 @@ end Measure
 instance (priority := 100) IsFiniteMeasure.toSigmaFinite {_m0 : MeasurableSpace α} (μ : Measure α)
     [IsFiniteMeasure μ] : SigmaFinite μ :=
   ⟨⟨⟨fun _ => univ, fun _ => trivial, fun _ => measure_lt_top μ _, iUnion_const _⟩⟩⟩
+
+/-- A measure on a countable space is sigma-finite iff it gives finite mass to every singleton. -/
+lemma Measure.sigmaFinite_iff_measure_singleton_lt_top [Countable α] :
+    SigmaFinite μ ↔ ∀ a, μ {a} < ∞ where
+  mp _ a := measure_singleton_lt_top
+  mpr hμ := by
+    cases isEmpty_or_nonempty α
+    · rw [Subsingleton.elim μ 0]
+      infer_instance
+    · obtain ⟨f, hf⟩ := exists_surjective_nat α
+      exact ⟨⟨⟨fun n ↦ {f n}, by simp, by simpa [hf.forall] using hμ, by simp [hf.range_eq]⟩⟩⟩
 
 theorem sigmaFinite_bot_iff (μ : @Measure α ⊥) : SigmaFinite μ ↔ IsFiniteMeasure μ := by
   refine

--- a/Mathlib/MeasureTheory/OuterMeasure/Basic.lean
+++ b/Mathlib/MeasureTheory/OuterMeasure/Basic.lean
@@ -53,6 +53,9 @@ theorem measure_mono (h : s ⊆ t) : μ s ≤ μ t :=
 theorem measure_mono_null (h : s ⊆ t) (ht : μ t = 0) : μ s = 0 :=
   eq_bot_mono (measure_mono h) ht
 
+lemma measure_eq_top_mono (h : s ⊆ t) (hs : μ s = ∞) : μ t = ∞ := eq_top_mono (measure_mono h) hs
+lemma measure_lt_top_mono (h : s ⊆ t) (ht : μ t < ∞) : μ s < ∞ := (measure_mono h).trans_lt ht
+
 theorem measure_pos_of_superset (h : s ⊆ t) (hs : μ s ≠ 0) : 0 < μ t :=
   hs.bot_lt.trans_le (measure_mono h)
 


### PR DESCRIPTION
From LeanAPAP


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
