### PR TITLE
chore: remove `[AtLeastTwo n]` hypothesis from the `NatCast` to `OfNat` instance

### DIFF
--- a/Mathlib/AlgebraicTopology/FundamentalGroupoid/Basic.lean
+++ b/Mathlib/AlgebraicTopology/FundamentalGroupoid/Basic.lean
@@ -143,8 +143,6 @@ theorem trans_refl_reparam (p : Path x₀ x₁) :
   simp only [Path.trans_apply, not_le, coe_reparam, Function.comp_apply, one_div, Path.refl_apply]
   split_ifs
   · rfl
-  · rfl
-  · simp
   · simp
 
 /-- For any path `p` from `x₀` to `x₁`, we have a homotopy from `p.trans (Path.refl x₁)` to `p`. -/

--- a/Mathlib/Data/Nat/Cast/Defs.lean
+++ b/Mathlib/Data/Nat/Cast/Defs.lean
@@ -54,7 +54,7 @@ instance is what makes things like `37 : R` type check.  Note that `0` and `1` a
 because they are recognized as terms of `R` (at least when `R` is an `AddMonoidWithOne`) through
 `Zero` and `One`, respectively. -/
 @[nolint unusedArguments]
-instance (priority := 100) instOfNatAtLeastTwo {n : ℕ} [NatCast R] [Nat.AtLeastTwo n] :
+instance (priority := 100) instOfNatAtLeastTwo {n : ℕ} [NatCast R] :
     OfNat R n where
   ofNat := n.cast
 

--- a/Mathlib/Data/Nat/Cast/Defs.lean
+++ b/Mathlib/Data/Nat/Cast/Defs.lean
@@ -54,7 +54,7 @@ instance is what makes things like `37 : R` type check.
 Note that this may conflict with the instance recognizing `0` and `1` via the `Zero` and `One`
 typeclasses (e.g. when `R` is an `AddMonoidWithOne`), so it is essential that these are defeq. -/
 @[nolint unusedArguments]
-instance (priority := 100) instOfNatAtLeastTwo {n : ℕ} [NatCast R] :
+instance (priority := 100) instOfNatOfNatCast {n : ℕ} [NatCast R] :
     OfNat R n where
   ofNat := n.cast
 

--- a/Mathlib/Data/Nat/Cast/Defs.lean
+++ b/Mathlib/Data/Nat/Cast/Defs.lean
@@ -51,7 +51,7 @@ end Nat.AtLeastTwo
 
 /-- Recognize numeric literals as terms of `R` via `Nat.cast`. This
 instance is what makes things like `37 : R` type check.
-Note that this may conflict with the instance recognizing `0` and `1` via the `Zero` and `One`
+Note that this may conflict with the instances recognizing `0` and `1` via the `Zero` and `One`
 typeclasses (e.g. when `R` is an `AddMonoidWithOne`), so it is essential that these are defeq. -/
 @[nolint unusedArguments]
 instance (priority := 100) instOfNatOfNatCast {n : ℕ} [NatCast R] :

--- a/Mathlib/Data/Nat/Cast/Defs.lean
+++ b/Mathlib/Data/Nat/Cast/Defs.lean
@@ -49,10 +49,10 @@ lemma ne_one : n ≠ 1 := Nat.ne_of_gt one_lt
 
 end Nat.AtLeastTwo
 
-/-- Recognize numeric literals which are at least `2` as terms of `R` via `Nat.cast`. This
-instance is what makes things like `37 : R` type check.  Note that `0` and `1` are not needed
-because they are recognized as terms of `R` (at least when `R` is an `AddMonoidWithOne`) through
-`Zero` and `One`, respectively. -/
+/-- Recognize numeric literals as terms of `R` via `Nat.cast`. This
+instance is what makes things like `37 : R` type check.
+Note that this may conflict with the instance recognizing `0` and `1` via the `Zero` and `One`
+typeclasses (e.g. when `R` is an `AddMonoidWithOne`), so it is essential that these are defeq. -/
 @[nolint unusedArguments]
 instance (priority := 100) instOfNatAtLeastTwo {n : ℕ} [NatCast R] :
     OfNat R n where

--- a/Mathlib/Data/Nat/Cast/Order/Basic.lean
+++ b/Mathlib/Data/Nat/Cast/Order/Basic.lean
@@ -97,7 +97,6 @@ theorem cast_le_one : (n : α) ≤ 1 ↔ n ≤ 1 := by rw [← cast_one, cast_le
 @[simp] lemma cast_nonpos : (n : α) ≤ 0 ↔ n = 0 := by norm_cast; omega
 
 section
-variable [m.AtLeastTwo]
 
 @[simp]
 theorem ofNat_le_cast : (ofNat(m) : α) ≤ n ↔ (OfNat.ofNat m : ℕ) ≤ n :=
@@ -109,8 +108,6 @@ theorem ofNat_lt_cast : (ofNat(m) : α) < n ↔ (OfNat.ofNat m : ℕ) < n :=
 
 end
 
-variable [n.AtLeastTwo]
-
 @[simp]
 theorem cast_le_ofNat : (m : α) ≤ (ofNat(n) : α) ↔ m ≤ OfNat.ofNat n :=
   cast_le
@@ -118,6 +115,22 @@ theorem cast_le_ofNat : (m : α) ≤ (ofNat(n) : α) ↔ m ≤ OfNat.ofNat n :=
 @[simp]
 theorem cast_lt_ofNat : (m : α) < (ofNat(n) : α) ↔ m < OfNat.ofNat n :=
   cast_lt
+
+-- TODO: These lemmas need to be `@[simp]` for confluence in the presence of `cast_lt`, `cast_le`,
+-- and `Nat.cast_ofNat`, but their LHSs match literally every inequality, so they're too expensive.
+-- If https://github.com/leanprover/lean4/issues/2867 is fixed in a performant way, these can be made `@[simp]`.
+
+-- @[simp]
+theorem ofNat_le :
+    (ofNat(m) : α) ≤ (ofNat(n) : α) ↔ (OfNat.ofNat m : ℕ) ≤ OfNat.ofNat n :=
+  cast_le
+
+-- @[simp]
+theorem ofNat_lt :
+    (ofNat(m) : α) < (ofNat(n) : α) ↔ (OfNat.ofNat m : ℕ) < OfNat.ofNat n :=
+  cast_lt
+
+variable [n.AtLeastTwo]
 
 @[simp]
 theorem one_lt_ofNat : 1 < (ofNat(n) : α) :=
@@ -134,22 +147,6 @@ theorem not_ofNat_le_one : ¬(ofNat(n) : α) ≤ 1 :=
 @[simp]
 theorem not_ofNat_lt_one : ¬(ofNat(n) : α) < 1 :=
   mt le_of_lt not_ofNat_le_one
-
-variable [m.AtLeastTwo]
-
--- TODO: These lemmas need to be `@[simp]` for confluence in the presence of `cast_lt`, `cast_le`,
--- and `Nat.cast_ofNat`, but their LHSs match literally every inequality, so they're too expensive.
--- If https://github.com/leanprover/lean4/issues/2867 is fixed in a performant way, these can be made `@[simp]`.
-
--- @[simp]
-theorem ofNat_le :
-    (ofNat(m) : α) ≤ (ofNat(n) : α) ↔ (OfNat.ofNat m : ℕ) ≤ OfNat.ofNat n :=
-  cast_le
-
--- @[simp]
-theorem ofNat_lt :
-    (ofNat(m) : α) < (ofNat(n) : α) ↔ (OfNat.ofNat m : ℕ) < OfNat.ofNat n :=
-  cast_lt
 
 end OrderedSemiring
 


### PR DESCRIPTION
This PR observes that we can change
```
instance (priority := 100) instOfNatAtLeastTwo {n : ℕ} [NatCast R] [Nat.AtLeastTwo n] : OfNat R n
```    
to 
```
instance (priority := 100) instOfNatAtLeastTwo {n : ℕ} [NatCast R] : OfNat R n
```    
with minimal fall-out.

A follow-up PR #23867 then observes that we can remove nearly all the `[Nat.AtLeastTwo n]` hypotheses in Mathlib.

This is slightly dangerous -- it does make it more likely that we'll generate non-defeq instances, but it appears to happen very rarely.

However, it will make life slightly easier for something Leo and I are trying to do with `grind` and Grobner bases (we'd like to be able to assume types we consume have `[∀ n, OfNat α n]`, which is possible with this change, but not without...).

Zulip thread: [#PR reviews > #23866 and #23867, removing most &#96;&#91;Nat.AtLeastTwo n&#93;&#96; @ 💬](https://leanprover.zulipchat.com/#narrow/channel/144837-PR-reviews/topic/.2323866.20and.20.2323867.2C.20removing.20most.20.60.5BNat.2EAtLeastTwo.20n.5D.60/near/511157297)