### PR TITLE
chore: remove unnecessary `[AtLeastTwo n]` hypotheses

### DIFF
--- a/Mathlib/Algebra/AddConstMap/Basic.lean
+++ b/Mathlib/Algebra/AddConstMap/Basic.lean
@@ -86,7 +86,7 @@ theorem map_add_one [AddMonoidWithOne G] [Add H] [AddConstMapClass F G H 1 b]
 
 @[scoped simp]
 theorem map_add_ofNat' [AddMonoidWithOne G] [AddMonoid H] [AddConstMapClass F G H 1 b]
-    (f : F) (x : G) (n : ℕ) [n.AtLeastTwo] :
+    (f : F) (x : G) (n : ℕ) :
     f (x + ofNat(n)) = f x + (ofNat(n) : ℕ) • b :=
   map_add_nat' f x n
 
@@ -94,7 +94,7 @@ theorem map_add_nat [AddMonoidWithOne G] [AddMonoidWithOne H] [AddConstMapClass 
     (f : F) (x : G) (n : ℕ) : f (x + n) = f x + n := by simp
 
 theorem map_add_ofNat [AddMonoidWithOne G] [AddMonoidWithOne H] [AddConstMapClass F G H 1 1]
-    (f : F) (x : G) (n : ℕ) [n.AtLeastTwo] :
+    (f : F) (x : G) (n : ℕ) :
     f (x + ofNat(n)) = f x + ofNat(n) := map_add_nat f x n
 
 @[scoped simp]
@@ -117,7 +117,7 @@ theorem map_nat' [AddMonoidWithOne G] [AddMonoid H] [AddConstMapClass F G H 1 b]
   simpa using map_add_nat' f 0 n
 
 theorem map_ofNat' [AddMonoidWithOne G] [AddMonoid H] [AddConstMapClass F G H 1 b]
-    (f : F) (n : ℕ) [n.AtLeastTwo] :
+    (f : F) (n : ℕ) :
     f (ofNat(n)) = f 0 + (ofNat(n) : ℕ) • b :=
   map_nat' f n
 
@@ -125,7 +125,7 @@ theorem map_nat [AddMonoidWithOne G] [AddMonoidWithOne H] [AddConstMapClass F G 
     (f : F) (n : ℕ) : f n = f 0 + n := by simp
 
 theorem map_ofNat [AddMonoidWithOne G] [AddMonoidWithOne H] [AddConstMapClass F G H 1 1]
-    (f : F) (n : ℕ) [n.AtLeastTwo] :
+    (f : F) (n : ℕ) :
     f ofNat(n) = f 0 + ofNat(n) := map_nat f n
 
 @[scoped simp]
@@ -147,7 +147,7 @@ theorem map_nat_add' [AddCommMonoidWithOne G] [AddMonoid H] [AddConstMapClass F 
   simpa using map_nsmul_add f n x
 
 theorem map_ofNat_add' [AddCommMonoidWithOne G] [AddMonoid H] [AddConstMapClass F G H 1 b]
-    (f : F) (n : ℕ) [n.AtLeastTwo] (x : G) :
+    (f : F) (n : ℕ) (x : G) :
     f (ofNat(n) + x) = f x + ofNat(n) • b :=
   map_nat_add' f n x
 
@@ -155,7 +155,7 @@ theorem map_nat_add [AddCommMonoidWithOne G] [AddMonoidWithOne H] [AddConstMapCl
     (f : F) (n : ℕ) (x : G) : f (↑n + x) = f x + n := by simp
 
 theorem map_ofNat_add [AddCommMonoidWithOne G] [AddMonoidWithOne H] [AddConstMapClass F G H 1 1]
-    (f : F) (n : ℕ) [n.AtLeastTwo] (x : G) :
+    (f : F) (n : ℕ) (x : G) :
     f (ofNat(n) + x) = f x + ofNat(n) :=
   map_nat_add f n x
 
@@ -180,7 +180,7 @@ theorem map_sub_nat' [AddGroupWithOne G] [AddGroup H] [AddConstMapClass F G H 1 
 
 @[scoped simp]
 theorem map_sub_ofNat' [AddGroupWithOne G] [AddGroup H] [AddConstMapClass F G H 1 b]
-    (f : F) (x : G) (n : ℕ) [n.AtLeastTwo] :
+    (f : F) (x : G) (n : ℕ) :
     f (x - ofNat(n)) = f x - ofNat(n) • b :=
   map_sub_nat' f x n
 

--- a/Mathlib/Algebra/CharP/Defs.lean
+++ b/Mathlib/Algebra/CharP/Defs.lean
@@ -57,7 +57,7 @@ lemma congr {q : ℕ} (h : p = q) : CharP R q := h ▸ ‹CharP R p›
 -- is too expensive. If https://github.com/leanprover/lean4/issues/2867 is fixed in a performant way, this can be made `@[simp]`.
 --
 -- @[simp]
-lemma ofNat_eq_zero [p.AtLeastTwo] : (ofNat(p) : R) = 0 := cast_eq_zero R p
+lemma ofNat_eq_zero : (ofNat(p) : R) = 0 := cast_eq_zero R p
 
 lemma eq {p q : ℕ} (_hp : CharP R p) (_hq : CharP R q) : p = q :=
   Nat.dvd_antisymm ((cast_eq_zero_iff R p q).1 (cast_eq_zero _ _))

--- a/Mathlib/Algebra/CharP/Invertible.lean
+++ b/Mathlib/Algebra/CharP/Invertible.lean
@@ -56,7 +56,7 @@ theorem CharP.isUnit_natCast_iff {n : ℕ} (hp : p.Prime) : IsUnit (n : R) ↔ �
     letI := invertibleOfCoprime (R := R) (hp.coprime_iff_not_dvd.2 not_dvd).symm
     isUnit_of_invertible _
 
-theorem CharP.isUnit_ofNat_iff {n : ℕ} [n.AtLeastTwo] (hp : p.Prime) :
+theorem CharP.isUnit_ofNat_iff {n : ℕ} (hp : p.Prime) :
     IsUnit (ofNat(n) : R) ↔ ¬p ∣ ofNat(n) :=
   CharP.isUnit_natCast_iff hp
 

--- a/Mathlib/Algebra/DirectSum/Internal.lean
+++ b/Mathlib/Algebra/DirectSum/Internal.lean
@@ -337,7 +337,7 @@ instance instSemiring : Semiring (A 0) := (subsemiring A).toSemiring
 
 @[simp, norm_cast] theorem coe_natCast (n : ℕ) : (n : A 0) = (n : R) := rfl
 
-@[simp, norm_cast] theorem coe_ofNat (n : ℕ) [n.AtLeastTwo] :
+@[simp, norm_cast] theorem coe_ofNat (n : ℕ) :
     (ofNat(n) : A 0) = (ofNat(n) : R) := rfl
 
 end Semiring

--- a/Mathlib/Algebra/DirectSum/Ring.lean
+++ b/Mathlib/Algebra/DirectSum/Ring.lean
@@ -425,7 +425,7 @@ theorem of_natCast (n : ℕ) : of A 0 n = n :=
   rfl
 
 @[simp]
-theorem of_zero_ofNat (n : ℕ) [n.AtLeastTwo] : of A 0 ofNat(n) = ofNat(n) :=
+theorem of_zero_ofNat (n : ℕ) : of A 0 ofNat(n) = ofNat(n) :=
   of_natCast A n
 
 /-- The `Semiring` structure derived from `GSemiring A`. -/

--- a/Mathlib/Algebra/Group/Hom/End.lean
+++ b/Mathlib/Algebra/Group/Hom/End.lean
@@ -34,7 +34,7 @@ instance instAddMonoidWithOne (M) [AddCommMonoid M] : AddMonoidWithOne (AddMonoi
 @[simp]
 lemma natCast_apply [AddCommMonoid M] (n : ℕ) (m : M) : (↑n : AddMonoid.End M) m = n • m := rfl
 
-@[simp] lemma ofNat_apply [AddCommMonoid M] (n : ℕ) [n.AtLeastTwo] (m : M) :
+@[simp] lemma ofNat_apply [AddCommMonoid M] (n : ℕ) (m : M) :
     (ofNat(n) : AddMonoid.End M) m = n • m := rfl
 
 instance instSemiring [AddCommMonoid M] : Semiring (AddMonoid.End M) :=

--- a/Mathlib/Algebra/Group/Opposite.lean
+++ b/Mathlib/Algebra/Group/Opposite.lean
@@ -206,7 +206,7 @@ theorem op_natCast [NatCast α] (n : ℕ) : op (n : α) = n :=
   rfl
 
 @[to_additive (attr := simp)]
-theorem op_ofNat [NatCast α] (n : ℕ) [n.AtLeastTwo] :
+theorem op_ofNat [NatCast α] (n : ℕ) :
     op (ofNat(n) : α) = ofNat(n) :=
   rfl
 
@@ -219,7 +219,7 @@ theorem unop_natCast [NatCast α] (n : ℕ) : unop (n : αᵐᵒᵖ) = n :=
   rfl
 
 @[to_additive (attr := simp)]
-theorem unop_ofNat [NatCast α] (n : ℕ) [n.AtLeastTwo] :
+theorem unop_ofNat [NatCast α] (n : ℕ) :
     unop (ofNat(n) : αᵐᵒᵖ) = ofNat(n) :=
   rfl
 

--- a/Mathlib/Algebra/Group/ULift.lean
+++ b/Mathlib/Algebra/Group/ULift.lean
@@ -107,7 +107,7 @@ theorem up_natCast [NatCast α] (n : ℕ) : up (n : α) = n :=
   rfl
 
 @[simp]
-theorem up_ofNat [NatCast α] (n : ℕ) [n.AtLeastTwo] :
+theorem up_ofNat [NatCast α] (n : ℕ) :
     up (ofNat(n) : α) = ofNat(n) :=
   rfl
 
@@ -120,7 +120,7 @@ theorem down_natCast [NatCast α] (n : ℕ) : down (n : ULift α) = n :=
   rfl
 
 @[simp]
-theorem down_ofNat [NatCast α] (n : ℕ) [n.AtLeastTwo] :
+theorem down_ofNat [NatCast α] (n : ℕ) :
     down (ofNat(n) : ULift α) = ofNat(n) :=
   rfl
 

--- a/Mathlib/Algebra/Module/LinearMap/End.lean
+++ b/Mathlib/Algebra/Module/LinearMap/End.lean
@@ -86,7 +86,7 @@ instance _root_.Module.End.semiring : Semiring (Module.End R M) :=
 theorem _root_.Module.End.natCast_apply (n : ℕ) (m : M) : (↑n : Module.End R M) m = n • m := rfl
 
 @[simp]
-theorem _root_.Module.End.ofNat_apply (n : ℕ) [n.AtLeastTwo] (m : M) :
+theorem _root_.Module.End.ofNat_apply (n : ℕ) (m : M) :
     (ofNat(n) : Module.End R M) m = ofNat(n) • m := rfl
 
 instance _root_.Module.End.ring : Ring (Module.End R N₁) :=

--- a/Mathlib/Algebra/Module/NatInt.lean
+++ b/Mathlib/Algebra/Module/NatInt.lean
@@ -95,7 +95,7 @@ lemma Nat.cast_smul_eq_nsmul (n : ℕ) (b : M) : (n : R) • b = n • b := by
   | succ n ih => rw [Nat.cast_succ, add_smul, add_smul, one_smul, ih, one_smul]
 
 /-- `nsmul` is equal to any other module structure via a cast. -/
-lemma ofNat_smul_eq_nsmul (n : ℕ) [n.AtLeastTwo] (b : M) :
+lemma ofNat_smul_eq_nsmul (n : ℕ) (b : M) :
     (ofNat(n) : R) • b = ofNat(n) • b := Nat.cast_smul_eq_nsmul ..
 
 end

--- a/Mathlib/Algebra/MonoidAlgebra/ToDirectSum.lean
+++ b/Mathlib/Algebra/MonoidAlgebra/ToDirectSum.lean
@@ -124,7 +124,7 @@ theorem toDirectSum_natCast [DecidableEq ι] [AddMonoid ι] [Semiring M] (n : �
   Finsupp.toDFinsupp_single _ _
 
 @[simp]
-theorem toDirectSum_ofNat [DecidableEq ι] [AddMonoid ι] [Semiring M] (n : ℕ) [n.AtLeastTwo] :
+theorem toDirectSum_ofNat [DecidableEq ι] [AddMonoid ι] [Semiring M] (n : ℕ) :
     (ofNat(n) : AddMonoidAlgebra M ι).toDirectSum = ofNat(n) :=
   Finsupp.toDFinsupp_single _ _
 
@@ -183,8 +183,7 @@ theorem toAddMonoidAlgebra_natCast [AddMonoid ι] [Semiring M] [∀ m : M, Decid
   DFinsupp.toFinsupp_single _ _
 
 @[simp]
-theorem toAddMonoidAlgebra_ofNat [AddMonoid ι] [Semiring M] [∀ m : M, Decidable (m ≠ 0)] (n : ℕ)
-    [n.AtLeastTwo] :
+theorem toAddMonoidAlgebra_ofNat [AddMonoid ι] [Semiring M] [∀ m : M, Decidable (m ≠ 0)] (n : ℕ) :
     (ofNat(n) : ⨁ _ : ι, M).toAddMonoidAlgebra = ofNat(n) :=
   DFinsupp.toFinsupp_single _ _
 

--- a/Mathlib/Algebra/Order/Floor/Ring.lean
+++ b/Mathlib/Algebra/Order/Floor/Ring.lean
@@ -73,7 +73,7 @@ theorem floor_zero : ⌊(0 : α)⌋ = 0 := by rw [← cast_zero, floor_intCast]
 @[simp]
 theorem floor_one : ⌊(1 : α)⌋ = 1 := by rw [← cast_one, floor_intCast]
 
-@[simp] theorem floor_ofNat (n : ℕ) [n.AtLeastTwo] : ⌊(ofNat(n) : α)⌋ = ofNat(n) :=
+@[simp] theorem floor_ofNat (n : ℕ) : ⌊(ofNat(n) : α)⌋ = ofNat(n) :=
   floor_natCast n
 
 @[mono]
@@ -121,7 +121,7 @@ theorem floor_add_natCast (a : α) (n : ℕ) : ⌊a + n⌋ = ⌊a⌋ + n := by
 @[deprecated (since := "2025-04-01")] alias floor_add_nat := floor_add_natCast
 
 @[simp]
-theorem floor_add_ofNat (a : α) (n : ℕ) [n.AtLeastTwo] :
+theorem floor_add_ofNat (a : α) (n : ℕ) :
     ⌊a + ofNat(n)⌋ = ⌊a⌋ + ofNat(n) :=
   floor_add_natCast a n
 
@@ -132,7 +132,7 @@ theorem floor_natCast_add (n : ℕ) (a : α) : ⌊↑n + a⌋ = n + ⌊a⌋ := b
 @[deprecated (since := "2025-04-01")] alias floor_nat_add := floor_natCast_add
 
 @[simp]
-theorem floor_ofNat_add (n : ℕ) [n.AtLeastTwo] (a : α) :
+theorem floor_ofNat_add (n : ℕ) (a : α) :
     ⌊ofNat(n) + a⌋ = ofNat(n) + ⌊a⌋ :=
   floor_natCast_add n a
 
@@ -151,7 +151,7 @@ theorem floor_sub_natCast (a : α) (n : ℕ) : ⌊a - n⌋ = ⌊a⌋ - n := by
 @[simp] theorem floor_sub_one (a : α) : ⌊a - 1⌋ = ⌊a⌋ - 1 := mod_cast floor_sub_natCast a 1
 
 @[simp]
-theorem floor_sub_ofNat (a : α) (n : ℕ) [n.AtLeastTwo] :
+theorem floor_sub_ofNat (a : α) (n : ℕ) :
     ⌊a - ofNat(n)⌋ = ⌊a⌋ - ofNat(n) :=
   floor_sub_natCast a n
 
@@ -215,7 +215,7 @@ theorem fract_add_natCast (a : α) (m : ℕ) : fract (a + m) = fract a := by
 theorem fract_add_one (a : α) : fract (a + 1) = fract a := mod_cast fract_add_natCast a 1
 
 @[simp]
-theorem fract_add_ofNat (a : α) (n : ℕ) [n.AtLeastTwo] :
+theorem fract_add_ofNat (a : α) (n : ℕ) :
     fract (a + ofNat(n)) = fract a :=
   fract_add_natCast a n
 
@@ -233,7 +233,7 @@ theorem fract_natCast_add (n : ℕ) (a : α) : fract (↑n + a) = fract a := by
 theorem fract_one_add (a : α) : fract (1 + a) = fract a := mod_cast fract_natCast_add 1 a
 
 @[simp]
-theorem fract_ofNat_add (n : ℕ) [n.AtLeastTwo] (a : α) :
+theorem fract_ofNat_add (n : ℕ) (a : α) :
     fract (ofNat(n) + a) = fract a :=
   fract_natCast_add n a
 
@@ -253,7 +253,7 @@ theorem fract_sub_natCast (a : α) (n : ℕ) : fract (a - n) = fract a := by
 theorem fract_sub_one (a : α) : fract (a - 1) = fract a := mod_cast fract_sub_natCast a 1
 
 @[simp]
-theorem fract_sub_ofNat (a : α) (n : ℕ) [n.AtLeastTwo] :
+theorem fract_sub_ofNat (a : α) (n : ℕ) :
     fract (a - ofNat(n)) = fract a :=
   fract_sub_natCast a n
 
@@ -309,7 +309,7 @@ theorem fract_intCast (z : ℤ) : fract (z : α) = 0 := by
 theorem fract_natCast (n : ℕ) : fract (n : α) = 0 := by simp [fract]
 
 @[simp]
-theorem fract_ofNat (n : ℕ) [n.AtLeastTwo] :
+theorem fract_ofNat (n : ℕ) :
     fract (ofNat(n) : α) = 0 :=
   fract_natCast n
 
@@ -497,7 +497,7 @@ theorem ceil_natCast (n : ℕ) : ⌈(n : α)⌉ = n :=
   eq_of_forall_ge_iff fun a => by rw [ceil_le, ← cast_natCast, cast_le]
 
 @[simp]
-theorem ceil_ofNat (n : ℕ) [n.AtLeastTwo] : ⌈(ofNat(n) : α)⌉ = ofNat(n) := ceil_natCast n
+theorem ceil_ofNat (n : ℕ) : ⌈(ofNat(n) : α)⌉ = ofNat(n) := ceil_natCast n
 
 theorem ceil_mono : Monotone (ceil : α → ℤ) :=
   gc_ceil_coe.monotone_l
@@ -521,7 +521,7 @@ theorem ceil_add_one (a : α) : ⌈a + 1⌉ = ⌈a⌉ + 1 := by
   rw [← ceil_add_intCast a (1 : ℤ), cast_one]
 
 @[simp]
-theorem ceil_add_ofNat (a : α) (n : ℕ) [n.AtLeastTwo] :
+theorem ceil_add_ofNat (a : α) (n : ℕ) :
     ⌈a + ofNat(n)⌉ = ⌈a⌉ + ofNat(n) :=
   ceil_add_natCast a n
 
@@ -543,7 +543,7 @@ theorem ceil_sub_one (a : α) : ⌈a - 1⌉ = ⌈a⌉ - 1 := by
   rw [eq_sub_iff_add_eq, ← ceil_add_one, sub_add_cancel]
 
 @[simp]
-theorem ceil_sub_ofNat (a : α) (n : ℕ) [n.AtLeastTwo] :
+theorem ceil_sub_ofNat (a : α) (n : ℕ) :
     ⌈a - ofNat(n)⌉ = ⌈a⌉ - ofNat(n) :=
   ceil_sub_natCast a n
 

--- a/Mathlib/Algebra/Order/Floor/Semiring.lean
+++ b/Mathlib/Algebra/Order/Floor/Semiring.lean
@@ -66,7 +66,7 @@ theorem floor_zero : ⌊(0 : α)⌋₊ = 0 := by rw [← Nat.cast_zero, floor_na
 theorem floor_one : ⌊(1 : α)⌋₊ = 1 := by rw [← Nat.cast_one, floor_natCast]
 
 @[simp]
-theorem floor_ofNat (n : ℕ) [n.AtLeastTwo] : ⌊(ofNat(n) : α)⌋₊ = ofNat(n) :=
+theorem floor_ofNat (n : ℕ) : ⌊(ofNat(n) : α)⌋₊ = ofNat(n) :=
   Nat.floor_natCast _
 
 theorem floor_of_nonpos (ha : a ≤ 0) : ⌊a⌋₊ = 0 :=
@@ -181,7 +181,7 @@ theorem ceil_zero : ⌈(0 : α)⌉₊ = 0 := by rw [← Nat.cast_zero, ceil_natC
 theorem ceil_one : ⌈(1 : α)⌉₊ = 1 := by rw [← Nat.cast_one, ceil_natCast]
 
 @[simp]
-theorem ceil_ofNat (n : ℕ) [n.AtLeastTwo] : ⌈(ofNat(n) : α)⌉₊ = ofNat(n) := ceil_natCast n
+theorem ceil_ofNat (n : ℕ) : ⌈(ofNat(n) : α)⌉₊ = ofNat(n) := ceil_natCast n
 
 @[simp]
 theorem ceil_eq_zero : ⌈a⌉₊ = 0 ↔ a ≤ 0 := by rw [← Nat.le_zero, ceil_le, Nat.cast_zero]
@@ -279,7 +279,7 @@ theorem floor_add_natCast (ha : 0 ≤ a) (n : ℕ) : ⌊a + n⌋₊ = ⌊a⌋₊
 theorem floor_add_one (ha : 0 ≤ a) : ⌊a + 1⌋₊ = ⌊a⌋₊ + 1 := by
   rw [← cast_one, floor_add_natCast ha 1]
 
-theorem floor_add_ofNat (ha : 0 ≤ a) (n : ℕ) [n.AtLeastTwo] :
+theorem floor_add_ofNat (ha : 0 ≤ a) (n : ℕ) :
     ⌊a + ofNat(n)⌋₊ = ⌊a⌋₊ + ofNat(n) :=
   floor_add_natCast ha n
 
@@ -301,7 +301,7 @@ theorem floor_sub_one [Sub α] [OrderedSub α] [ExistsAddOfLE α] (a : α) : ⌊
   mod_cast floor_sub_natCast a 1
 
 @[simp]
-theorem floor_sub_ofNat [Sub α] [OrderedSub α] [ExistsAddOfLE α] (a : α) (n : ℕ) [n.AtLeastTwo] :
+theorem floor_sub_ofNat [Sub α] [OrderedSub α] [ExistsAddOfLE α] (a : α) (n : ℕ) :
     ⌊a - ofNat(n)⌋₊ = ⌊a⌋₊ - ofNat(n) :=
   floor_sub_natCast a n
 
@@ -319,7 +319,7 @@ theorem ceil_add_natCast (ha : 0 ≤ a) (n : ℕ) : ⌈a + n⌉₊ = ⌈a⌉₊ 
 theorem ceil_add_one (ha : 0 ≤ a) : ⌈a + 1⌉₊ = ⌈a⌉₊ + 1 := by
   rw [cast_one.symm, ceil_add_natCast ha 1]
 
-theorem ceil_add_ofNat (ha : 0 ≤ a) (n : ℕ) [n.AtLeastTwo] :
+theorem ceil_add_ofNat (ha : 0 ≤ a) (n : ℕ) :
     ⌈a + ofNat(n)⌉₊ = ⌈a⌉₊ + ofNat(n) :=
   ceil_add_natCast ha n
 
@@ -367,7 +367,7 @@ theorem floor_div_natCast (a : α) (n : ℕ) : ⌊a / n⌋₊ = ⌊a⌋₊ / n :
 
 @[deprecated (since := "2025-04-01")] alias floor_div_nat := floor_div_natCast
 
-theorem floor_div_ofNat (a : α) (n : ℕ) [n.AtLeastTwo] :
+theorem floor_div_ofNat (a : α) (n : ℕ) :
     ⌊a / ofNat(n)⌋₊ = ⌊a⌋₊ / ofNat(n) :=
   floor_div_natCast a n
 

--- a/Mathlib/Algebra/Order/Kleene.lean
+++ b/Mathlib/Algebra/Order/Kleene.lean
@@ -133,8 +133,8 @@ lemma natCast_eq_one {n : ℕ} (nezero : n ≠ 0) : (n : α) = 1 := by
   | base => exact Nat.cast_one
   | succ x _ hx => rw [Nat.cast_add, hx, Nat.cast_one, add_idem 1]
 
-lemma ofNat_eq_one {n : ℕ} [n.AtLeastTwo] : (ofNat(n) : α) = 1 :=
-  natCast_eq_one <| Nat.ne_zero_of_lt Nat.AtLeastTwo.prop
+lemma ofNat_eq_one {n : ℕ} [NeZero n] : (ofNat(n) : α) = 1 :=
+  natCast_eq_one <| NeZero.ne n
 
 theorem nsmul_eq_self : ∀ {n : ℕ} (_ : n ≠ 0) (a : α), n • a = a
   | 0, h => (h rfl).elim

--- a/Mathlib/Algebra/Order/Monoid/Unbundled/WithTop.lean
+++ b/Mathlib/Algebra/Order/Monoid/Unbundled/WithTop.lean
@@ -274,29 +274,29 @@ instance addMonoidWithOne : AddMonoidWithOne (WithTop α) :=
 @[simp] lemma natCast_ne_top (n : ℕ) : (n : WithTop α) ≠ ⊤ := coe_ne_top
 @[simp] lemma natCast_lt_top [LT α] (n : ℕ) : (n : WithTop α) < ⊤ := coe_lt_top _
 
-@[simp] lemma coe_ofNat (n : ℕ) [n.AtLeastTwo] :
+@[simp] lemma coe_ofNat (n : ℕ) :
     ((ofNat(n) : α) : WithTop α) = ofNat(n) := rfl
-@[simp] lemma coe_eq_ofNat (n : ℕ) [n.AtLeastTwo] (m : α) :
+@[simp] lemma coe_eq_ofNat (n : ℕ) (m : α) :
     (m : WithTop α) = ofNat(n) ↔ m = ofNat(n) :=
   coe_eq_coe
-@[simp] lemma ofNat_eq_coe (n : ℕ) [n.AtLeastTwo] (m : α) :
+@[simp] lemma ofNat_eq_coe (n : ℕ) (m : α) :
     ofNat(n) = (m : WithTop α) ↔ ofNat(n) = m :=
   coe_eq_coe
-@[simp] lemma ofNat_ne_top (n : ℕ) [n.AtLeastTwo] : (ofNat(n) : WithTop α) ≠ ⊤ :=
+@[simp] lemma ofNat_ne_top (n : ℕ) : (ofNat(n) : WithTop α) ≠ ⊤ :=
   natCast_ne_top n
-@[simp] lemma top_ne_ofNat (n : ℕ) [n.AtLeastTwo] : (⊤ : WithTop α) ≠ ofNat(n) :=
+@[simp] lemma top_ne_ofNat (n : ℕ) : (⊤ : WithTop α) ≠ ofNat(n) :=
   top_ne_natCast n
 
-@[simp] lemma map_ofNat {f : α → β} (n : ℕ) [n.AtLeastTwo] :
+@[simp] lemma map_ofNat {f : α → β} (n : ℕ) :
     WithTop.map f (ofNat(n) : WithTop α) = f (ofNat(n)) := map_coe f n
 
 @[simp] lemma map_natCast {f : α → β} (n : ℕ) :
     WithTop.map f (n : WithTop α) = f n := map_coe f n
 
-lemma map_eq_ofNat_iff {f : β → α} {n : ℕ} [n.AtLeastTwo] {a : WithTop β} :
+lemma map_eq_ofNat_iff {f : β → α} {n : ℕ} {a : WithTop β} :
     a.map f = ofNat(n) ↔ ∃ x, a = .some x ∧ f x = n := map_eq_some_iff
 
-lemma ofNat_eq_map_iff {f : β → α} {n : ℕ} [n.AtLeastTwo] {a : WithTop β} :
+lemma ofNat_eq_map_iff {f : β → α} {n : ℕ} {a : WithTop β} :
     ofNat(n) = a.map f ↔ ∃ x, a = .some x ∧ f x = n := some_eq_map_iff
 
 lemma map_eq_natCast_iff {f : β → α} {n : ℕ} {a : WithTop β} :
@@ -606,29 +606,29 @@ instance addMonoidWithOne : AddMonoidWithOne (WithBot α) := WithTop.addMonoidWi
 
 @[simp] lemma bot_ne_natCast (n : ℕ) : (⊥ : WithBot α) ≠ n := bot_ne_coe
 
-@[simp] lemma coe_ofNat (n : ℕ) [n.AtLeastTwo] :
+@[simp] lemma coe_ofNat (n : ℕ) :
     ((ofNat(n) : α) : WithBot α) = ofNat(n) := rfl
-@[simp] lemma coe_eq_ofNat (n : ℕ) [n.AtLeastTwo] (m : α) :
+@[simp] lemma coe_eq_ofNat (n : ℕ) (m : α) :
     (m : WithBot α) = ofNat(n) ↔ m = ofNat(n) :=
   coe_eq_coe
-@[simp] lemma ofNat_eq_coe (n : ℕ) [n.AtLeastTwo] (m : α) :
+@[simp] lemma ofNat_eq_coe (n : ℕ) (m : α) :
     ofNat(n) = (m : WithBot α) ↔ ofNat(n) = m :=
   coe_eq_coe
-@[simp] lemma ofNat_ne_bot (n : ℕ) [n.AtLeastTwo] : (ofNat(n) : WithBot α) ≠ ⊥ :=
+@[simp] lemma ofNat_ne_bot (n : ℕ) : (ofNat(n) : WithBot α) ≠ ⊥ :=
   natCast_ne_bot n
-@[simp] lemma bot_ne_ofNat (n : ℕ) [n.AtLeastTwo] : (⊥ : WithBot α) ≠ ofNat(n) :=
+@[simp] lemma bot_ne_ofNat (n : ℕ) : (⊥ : WithBot α) ≠ ofNat(n) :=
   bot_ne_natCast n
 
-@[simp] lemma map_ofNat {f : α → β} (n : ℕ) [n.AtLeastTwo] :
+@[simp] lemma map_ofNat {f : α → β} (n : ℕ) :
     WithBot.map f (ofNat(n) : WithBot α) = f ofNat(n) := map_coe f n
 
 @[simp] lemma map_natCast {f : α → β} (n : ℕ) :
     WithBot.map f (n : WithBot α) = f n := map_coe f n
 
-lemma map_eq_ofNat_iff {f : β → α} {n : ℕ} [n.AtLeastTwo] {a : WithBot β} :
+lemma map_eq_ofNat_iff {f : β → α} {n : ℕ} {a : WithBot β} :
     a.map f = ofNat(n) ↔ ∃ x, a = .some x ∧ f x = n := map_eq_some_iff
 
-lemma ofNat_eq_map_iff {f : β → α} {n : ℕ} [n.AtLeastTwo] {a : WithBot β} :
+lemma ofNat_eq_map_iff {f : β → α} {n : ℕ} {a : WithBot β} :
     ofNat(n) = a.map f ↔ ∃ x, a = .some x ∧ f x = n := some_eq_map_iff
 
 lemma map_eq_natCast_iff {f : β → α} {n : ℕ} {a : WithBot β} :

--- a/Mathlib/Algebra/Order/Round.lean
+++ b/Mathlib/Algebra/Order/Round.lean
@@ -51,7 +51,7 @@ theorem round_one : round (1 : α) = 1 := by simp [round]
 theorem round_natCast (n : ℕ) : round (n : α) = n := by simp [round]
 
 @[simp]
-theorem round_ofNat (n : ℕ) [n.AtLeastTwo] : round (ofNat(n) : α) = ofNat(n) :=
+theorem round_ofNat (n : ℕ) : round (ofNat(n) : α) = ofNat(n) :=
   round_natCast n
 
 @[simp]
@@ -90,7 +90,7 @@ theorem round_add_natCast (x : α) (y : ℕ) : round (x + y) = round x + y :=
 alias round_add_nat := round_add_natCast
 
 @[simp]
-theorem round_add_ofNat (x : α) (n : ℕ) [n.AtLeastTwo] :
+theorem round_add_ofNat (x : α) (n : ℕ) :
     round (x + ofNat(n)) = round x + ofNat(n) :=
   round_add_natCast x n
 
@@ -102,7 +102,7 @@ theorem round_sub_natCast (x : α) (y : ℕ) : round (x - y) = round x - y :=
 alias round_sub_nat := round_sub_natCast
 
 @[simp]
-theorem round_sub_ofNat (x : α) (n : ℕ) [n.AtLeastTwo] :
+theorem round_sub_ofNat (x : α) (n : ℕ) :
     round (x - ofNat(n)) = round x - ofNat(n) :=
   round_sub_natCast x n
 
@@ -121,7 +121,7 @@ theorem round_natCast_add (x : α) (y : ℕ) : round ((y : α) + x) = y + round 
 alias round_nat_add := round_natCast_add
 
 @[simp]
-theorem round_ofNat_add (n : ℕ) [n.AtLeastTwo] (x : α) :
+theorem round_ofNat_add (n : ℕ) (x : α) :
     round (ofNat(n) + x) = ofNat(n) + round x :=
   round_natCast_add x n
 

--- a/Mathlib/Algebra/Order/SuccPred/WithBot.lean
+++ b/Mathlib/Algebra/Order/SuccPred/WithBot.lean
@@ -23,7 +23,7 @@ lemma succ_natCast (n : ℕ) : succ (n : WithBot α) = n + 1 := by
 lemma succ_one : succ (1 : WithBot α) = 2 := by simpa [one_add_one_eq_two] using succ_natCast 1
 
 @[simp]
-lemma succ_ofNat (n : ℕ) [n.AtLeastTwo] :
+lemma succ_ofNat (n : ℕ) :
     succ (ofNat(n) : WithBot α) = ofNat(n) + 1 := succ_natCast n
 
 lemma one_le_iff_pos {α : Type*} [PartialOrder α] [AddMonoidWithOne α]

--- a/Mathlib/Algebra/Polynomial/Basic.lean
+++ b/Mathlib/Algebra/Polynomial/Basic.lean
@@ -275,10 +275,10 @@ theorem ofFinsupp_natCast (n : ℕ) : (⟨n⟩ : R[X]) = n := rfl
 theorem toFinsupp_natCast (n : ℕ) : (n : R[X]).toFinsupp = n := rfl
 
 @[simp]
-theorem ofFinsupp_ofNat (n : ℕ) [n.AtLeastTwo] : (⟨ofNat(n)⟩ : R[X]) = ofNat(n) := rfl
+theorem ofFinsupp_ofNat (n : ℕ) : (⟨ofNat(n)⟩ : R[X]) = ofNat(n) := rfl
 
 @[simp]
-theorem toFinsupp_ofNat (n : ℕ) [n.AtLeastTwo] : (ofNat(n) : R[X]).toFinsupp = ofNat(n) := rfl
+theorem toFinsupp_ofNat (n : ℕ) : (ofNat(n) : R[X]).toFinsupp = ofNat(n) := rfl
 
 instance semiring : Semiring R[X] :=
   fast_instance% Function.Injective.semiring toFinsupp toFinsupp_injective toFinsupp_zero
@@ -655,7 +655,7 @@ theorem coeff_natCast_ite : (Nat.cast m : R[X]).coeff n = ite (n = 0) m 0 := by
   simp only [← C_eq_natCast, coeff_C, Nat.cast_ite, Nat.cast_zero]
 
 @[simp]
-theorem coeff_ofNat_zero (a : ℕ) [a.AtLeastTwo] :
+theorem coeff_ofNat_zero (a : ℕ) :
     coeff (ofNat(a) : R[X]) 0 = ofNat(a) :=
   coeff_monomial
 

--- a/Mathlib/Algebra/Polynomial/Coeff.lean
+++ b/Mathlib/Algebra/Polynomial/Coeff.lean
@@ -166,10 +166,10 @@ theorem coeff_mul_C (p : R[X]) (n : ℕ) (a : R) : coeff (p * C a) n = coeff p n
 @[simp] lemma coeff_natCast_mul {a k : ℕ} :
   coeff ((a : R[X]) * p) k = a * coeff p k := coeff_C_mul _
 
-@[simp] lemma coeff_mul_ofNat {a k : ℕ} [Nat.AtLeastTwo a] :
+@[simp] lemma coeff_mul_ofNat {a k : ℕ} :
   coeff (p * (ofNat(a) : R[X])) k = coeff p k * ofNat(a) := coeff_mul_C _ _ _
 
-@[simp] lemma coeff_ofNat_mul {a k : ℕ} [Nat.AtLeastTwo a] :
+@[simp] lemma coeff_ofNat_mul {a k : ℕ} :
   coeff ((ofNat(a) : R[X]) * p) k = ofNat(a) * coeff p k := coeff_C_mul _
 
 @[simp] lemma coeff_mul_intCast [Ring S] {p : S[X]} {a : ℤ} {k : ℕ} :

--- a/Mathlib/Algebra/Polynomial/Degree/Definitions.lean
+++ b/Mathlib/Algebra/Polynomial/Degree/Definitions.lean
@@ -176,7 +176,7 @@ theorem natDegree_natCast (n : ℕ) : natDegree (n : R[X]) = 0 := by
   simp only [← C_eq_natCast, natDegree_C]
 
 @[simp]
-theorem natDegree_ofNat (n : ℕ) [Nat.AtLeastTwo n] :
+theorem natDegree_ofNat (n : ℕ) :
     natDegree (ofNat(n) : R[X]) = 0 :=
   natDegree_natCast _
 

--- a/Mathlib/Algebra/Polynomial/Derivative.lean
+++ b/Mathlib/Algebra/Polynomial/Derivative.lean
@@ -198,7 +198,7 @@ theorem derivative_natCast {n : ℕ} : derivative (n : R[X]) = 0 := by
   exact derivative_C
 
 @[simp]
-theorem derivative_ofNat (n : ℕ) [n.AtLeastTwo] :
+theorem derivative_ofNat (n : ℕ) :
     derivative (ofNat(n) : R[X]) = 0 :=
   derivative_natCast
 

--- a/Mathlib/Algebra/Polynomial/Eval/Defs.lean
+++ b/Mathlib/Algebra/Polynomial/Eval/Defs.lean
@@ -101,7 +101,7 @@ theorem eval₂_natCast (n : ℕ) : (n : R[X]).eval₂ f x = n := by
   | succ n ih => rw [n.cast_succ, eval₂_add, ih, eval₂_one, n.cast_succ]
 
 @[simp]
-lemma eval₂_ofNat {S : Type*} [Semiring S] (n : ℕ) [n.AtLeastTwo] (f : R →+* S) (a : S) :
+lemma eval₂_ofNat {S : Type*} [Semiring S] (n : ℕ) (f : R →+* S) (a : S) :
     (ofNat(n) : R[X]).eval₂ f a = ofNat(n) := by
   simp [OfNat.ofNat]
 
@@ -258,7 +258,7 @@ theorem eval₂_at_natCast {S : Type*} [Semiring S] (f : R →+* S) (n : ℕ) :
   simp
 
 @[simp]
-theorem eval₂_at_ofNat {S : Type*} [Semiring S] (f : R →+* S) (n : ℕ) [n.AtLeastTwo] :
+theorem eval₂_at_ofNat {S : Type*} [Semiring S] (f : R →+* S) (n : ℕ) :
     p.eval₂ f ofNat(n) = f (p.eval (ofNat(n))) := by
   simp [OfNat.ofNat]
 
@@ -270,7 +270,7 @@ theorem eval_C : (C a).eval x = a :=
 theorem eval_natCast {n : ℕ} : (n : R[X]).eval x = n := by simp only [← C_eq_natCast, eval_C]
 
 @[simp]
-lemma eval_ofNat (n : ℕ) [n.AtLeastTwo] (a : R) :
+lemma eval_ofNat (n : ℕ) (a : R) :
     (ofNat(n) : R[X]).eval a = ofNat(n) := by
   simp only [OfNat.ofNat, eval_natCast]
 
@@ -378,7 +378,7 @@ theorem C_comp : (C a).comp p = C a :=
 theorem natCast_comp {n : ℕ} : (n : R[X]).comp p = n := by rw [← C_eq_natCast, C_comp]
 
 @[simp]
-theorem ofNat_comp (n : ℕ) [n.AtLeastTwo] : (ofNat(n) : R[X]).comp p = n :=
+theorem ofNat_comp (n : ℕ) : (ofNat(n) : R[X]).comp p = n :=
   natCast_comp
 
 @[simp]
@@ -518,7 +518,7 @@ protected theorem map_natCast (n : ℕ) : (n : R[X]).map f = n :=
   map_natCast (mapRingHom f) n
 
 @[simp]
-protected theorem map_ofNat (n : ℕ) [n.AtLeastTwo] :
+protected theorem map_ofNat (n : ℕ) :
     (ofNat(n) : R[X]).map f = ofNat(n) :=
   show (n : R[X]).map f = n by rw [Polynomial.map_natCast]
 

--- a/Mathlib/Algebra/Quaternion.lean
+++ b/Mathlib/Algebra/Quaternion.lean
@@ -426,19 +426,19 @@ theorem intCast_re (z : ℤ) : (z : ℍ[R,c₁,c₂,c₃]).re = z :=
   rfl
 
 @[scoped simp]
-theorem ofNat_re (n : ℕ) [n.AtLeastTwo] : (ofNat(n) : ℍ[R,c₁,c₂,c₃]).re = ofNat(n) := rfl
+theorem ofNat_re (n : ℕ) : (ofNat(n) : ℍ[R,c₁,c₂,c₃]).re = ofNat(n) := rfl
 
 @[scoped simp]
-theorem ofNat_imI (n : ℕ) [n.AtLeastTwo] : (ofNat(n) : ℍ[R,c₁,c₂,c₃]).imI = 0 := rfl
+theorem ofNat_imI (n : ℕ) : (ofNat(n) : ℍ[R,c₁,c₂,c₃]).imI = 0 := rfl
 
 @[scoped simp]
-theorem ofNat_imJ (n : ℕ) [n.AtLeastTwo] : (ofNat(n) : ℍ[R,c₁,c₂,c₃]).imJ = 0 := rfl
+theorem ofNat_imJ (n : ℕ) : (ofNat(n) : ℍ[R,c₁,c₂,c₃]).imJ = 0 := rfl
 
 @[scoped simp]
-theorem ofNat_imK (n : ℕ) [n.AtLeastTwo] : (ofNat(n) : ℍ[R,c₁,c₂,c₃]).imK = 0 := rfl
+theorem ofNat_imK (n : ℕ) : (ofNat(n) : ℍ[R,c₁,c₂,c₃]).imK = 0 := rfl
 
 @[scoped simp]
-theorem ofNat_im (n : ℕ) [n.AtLeastTwo] : (ofNat(n) : ℍ[R,c₁,c₂,c₃]).im = 0 := rfl
+theorem ofNat_im (n : ℕ) : (ofNat(n) : ℍ[R,c₁,c₂,c₃]).im = 0 := rfl
 
 @[simp, norm_cast]
 theorem intCast_imI (z : ℤ) : (z : ℍ[R,c₁,c₂,c₃]).imI = 0 :=
@@ -479,7 +479,7 @@ instance instRing : Ring ℍ[R,c₁,c₂,c₃] where
 theorem coe_mul : ((x * y : R) : ℍ[R,c₁,c₂,c₃]) = x * y := by ext <;> simp
 
 @[norm_cast, simp]
-lemma coe_ofNat {n : ℕ} [n.AtLeastTwo]:
+lemma coe_ofNat {n : ℕ} :
     ((ofNat(n) : R) : ℍ[R,c₁,c₂,c₃]) = (ofNat(n) : ℍ[R,c₁,c₂,c₃]) := by
   rfl
 

--- a/Mathlib/Algebra/Ring/Center.lean
+++ b/Mathlib/Algebra/Ring/Center.lean
@@ -36,7 +36,7 @@ theorem natCast_mem_center [NonAssocSemiring M] (n : ℕ) : (n : M) ∈ Set.cent
     | succ n ihn => rw [Nat.cast_succ, mul_add, ihn, mul_add, mul_add, mul_one, mul_one]
 
 @[simp]
-theorem ofNat_mem_center [NonAssocSemiring M] (n : ℕ) [n.AtLeastTwo] :
+theorem ofNat_mem_center [NonAssocSemiring M] (n : ℕ) :
     ofNat(n) ∈ Set.center M :=
   natCast_mem_center M n
 

--- a/Mathlib/Algebra/Star/Basic.lean
+++ b/Mathlib/Algebra/Star/Basic.lean
@@ -282,7 +282,7 @@ theorem star_natCast [NonAssocSemiring R] [StarRing R] (n : ℕ) : star (n : R) 
   (congr_arg unop (map_natCast (starRingEquiv : R ≃+* Rᵐᵒᵖ) n)).trans (unop_natCast _)
 
 @[simp]
-theorem star_ofNat [NonAssocSemiring R] [StarRing R] (n : ℕ) [n.AtLeastTwo] :
+theorem star_ofNat [NonAssocSemiring R] [StarRing R] (n : ℕ) :
     star (ofNat(n) : R) = ofNat(n) :=
   star_natCast _
 

--- a/Mathlib/Algebra/Star/SelfAdjoint.lean
+++ b/Mathlib/Algebra/Star/SelfAdjoint.lean
@@ -194,7 +194,7 @@ protected theorem natCast (n : ℕ) : IsSelfAdjoint (n : R) :=
   star_natCast _
 
 @[simp]
-protected theorem ofNat (n : ℕ) [n.AtLeastTwo] : IsSelfAdjoint (ofNat(n) : R) :=
+protected theorem ofNat (n : ℕ) : IsSelfAdjoint (ofNat(n) : R) :=
   .natCast n
 
 end Semiring

--- a/Mathlib/AlgebraicTopology/FundamentalGroupoid/Basic.lean
+++ b/Mathlib/AlgebraicTopology/FundamentalGroupoid/Basic.lean
@@ -143,8 +143,6 @@ theorem trans_refl_reparam (p : Path x₀ x₁) :
   simp only [Path.trans_apply, not_le, coe_reparam, Function.comp_apply, one_div, Path.refl_apply]
   split_ifs
   · rfl
-  · rfl
-  · simp
   · simp
 
 /-- For any path `p` from `x₀` to `x₁`, we have a homotopy from `p.trans (Path.refl x₁)` to `p`. -/

--- a/Mathlib/Analysis/Complex/Basic.lean
+++ b/Mathlib/Analysis/Complex/Basic.lean
@@ -573,7 +573,7 @@ lemma natCast_mem_slitPlane {n : ℕ} : ↑n ∈ slitPlane ↔ n ≠ 0 := by
   simpa [pos_iff_ne_zero] using @ofReal_mem_slitPlane n
 
 @[simp]
-lemma ofNat_mem_slitPlane (n : ℕ) [n.AtLeastTwo] : ofNat(n) ∈ slitPlane :=
+lemma ofNat_mem_slitPlane (n : ℕ) [NeZero n] : ofNat(n) ∈ slitPlane :=
   natCast_mem_slitPlane.2 (NeZero.ne n)
 
 lemma mem_slitPlane_iff_not_le_zero {z : ℂ} : z ∈ slitPlane ↔ ¬z ≤ 0 :=

--- a/Mathlib/Analysis/Normed/Group/Basic.lean
+++ b/Mathlib/Analysis/Normed/Group/Basic.lean
@@ -1029,10 +1029,10 @@ theorem le_norm_self (r : ℝ) : r ≤ ‖r‖ :=
 @[simp 1100] lemma nnnorm_natCast (n : ℕ) : ‖(n : ℝ)‖₊ = n := NNReal.eq <| norm_natCast _
 @[simp 1100] lemma enorm_natCast (n : ℕ) : ‖(n : ℝ)‖ₑ = n := by simp [enorm]
 
-@[simp 1100] lemma norm_ofNat (n : ℕ) [n.AtLeastTwo] :
+@[simp 1100] lemma norm_ofNat (n : ℕ) :
     ‖(ofNat(n) : ℝ)‖ = ofNat(n) := norm_natCast n
 
-@[simp 1100] lemma nnnorm_ofNat (n : ℕ) [n.AtLeastTwo] :
+@[simp 1100] lemma nnnorm_ofNat (n : ℕ) :
     ‖(ofNat(n) : ℝ)‖₊ = ofNat(n) := nnnorm_natCast n
 
 lemma norm_two : ‖(2 : ℝ)‖ = 2 := abs_of_pos zero_lt_two

--- a/Mathlib/Analysis/RCLike/Basic.lean
+++ b/Mathlib/Analysis/RCLike/Basic.lean
@@ -297,7 +297,7 @@ theorem conj_ofReal (r : ℝ) : conj (r : K) = (r : K) := by
 
 theorem conj_nat_cast (n : ℕ) : conj (n : K) = n := map_natCast _ _
 
-theorem conj_ofNat (n : ℕ) [n.AtLeastTwo] : conj (ofNat(n) : K) = ofNat(n) :=
+theorem conj_ofNat (n : ℕ) : conj (ofNat(n) : K) = ofNat(n) :=
   map_ofNat _ _
 
 @[rclike_simps, simp]
@@ -541,21 +541,21 @@ theorem natCast_re (n : ℕ) : re (n : K) = n := by rw [← ofReal_natCast, ofRe
 @[simp, rclike_simps, norm_cast]
 theorem natCast_im (n : ℕ) : im (n : K) = 0 := by rw [← ofReal_natCast, ofReal_im]
 @[simp, rclike_simps]
-theorem ofNat_re (n : ℕ) [n.AtLeastTwo] : re (ofNat(n) : K) = ofNat(n) :=
+theorem ofNat_re (n : ℕ) : re (ofNat(n) : K) = ofNat(n) :=
   natCast_re n
 @[simp, rclike_simps]
-theorem ofNat_im (n : ℕ) [n.AtLeastTwo] : im (ofNat(n) : K) = 0 :=
+theorem ofNat_im (n : ℕ) : im (ofNat(n) : K) = 0 :=
   natCast_im n
 
 @[rclike_simps, norm_cast]
-theorem ofReal_ofNat (n : ℕ) [n.AtLeastTwo] : ((ofNat(n) : ℝ) : K) = ofNat(n) :=
+theorem ofReal_ofNat (n : ℕ) : ((ofNat(n) : ℝ) : K) = ofNat(n) :=
   ofReal_natCast n
 
-theorem ofNat_mul_re (n : ℕ) [n.AtLeastTwo] (z : K) :
+theorem ofNat_mul_re (n : ℕ) (z : K) :
     re (ofNat(n) * z) = ofNat(n) * re z := by
   rw [← ofReal_ofNat, re_ofReal_mul]
 
-theorem ofNat_mul_im (n : ℕ) [n.AtLeastTwo] (z : K) :
+theorem ofNat_mul_im (n : ℕ) (z : K) :
     im (ofNat(n) * z) = ofNat(n) * im z := by
   rw [← ofReal_ofNat, im_ofReal_mul]
 
@@ -592,11 +592,11 @@ theorem norm_natCast (n : ℕ) : ‖(n : K)‖ = n := by
 @[simp, rclike_simps, norm_cast] lemma nnnorm_natCast (n : ℕ) : ‖(n : K)‖₊ = n := by simp [nnnorm]
 
 @[simp, rclike_simps]
-theorem norm_ofNat (n : ℕ) [n.AtLeastTwo] : ‖(ofNat(n) : K)‖ = ofNat(n) :=
+theorem norm_ofNat (n : ℕ) : ‖(ofNat(n) : K)‖ = ofNat(n) :=
   norm_natCast n
 
 @[simp, rclike_simps]
-lemma nnnorm_ofNat (n : ℕ) [n.AtLeastTwo] : ‖(ofNat(n) : K)‖₊ = ofNat(n) :=
+lemma nnnorm_ofNat (n : ℕ) : ‖(ofNat(n) : K)‖₊ = ofNat(n) :=
   nnnorm_natCast n
 
 lemma norm_two : ‖(2 : K)‖ = 2 := norm_ofNat 2

--- a/Mathlib/Analysis/SpecialFunctions/Complex/Arg.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Complex/Arg.lean
@@ -212,7 +212,7 @@ lemma natCast_arg {n : ℕ} : arg n = 0 :=
   ofReal_natCast n ▸ arg_ofReal_of_nonneg n.cast_nonneg
 
 @[simp]
-lemma ofNat_arg {n : ℕ} [n.AtLeastTwo] : arg ofNat(n) = 0 :=
+lemma ofNat_arg {n : ℕ} : arg ofNat(n) = 0 :=
   natCast_arg
 
 theorem arg_eq_zero_iff {z : ℂ} : arg z = 0 ↔ 0 ≤ z.re ∧ z.im = 0 := by

--- a/Mathlib/Analysis/SpecialFunctions/Complex/Log.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Complex/Log.lean
@@ -63,7 +63,7 @@ theorem ofReal_log {x : ℝ} (hx : 0 ≤ x) : (x.log : ℂ) = log x :=
 lemma natCast_log {n : ℕ} : Real.log n = log n := ofReal_natCast n ▸ ofReal_log n.cast_nonneg
 
 @[simp]
-lemma ofNat_log {n : ℕ} [n.AtLeastTwo] :
+lemma ofNat_log {n : ℕ} :
     Real.log ofNat(n) = log (OfNat.ofNat n) :=
   natCast_log
 

--- a/Mathlib/Analysis/SpecialFunctions/Gamma/Basic.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Gamma/Basic.lean
@@ -329,7 +329,7 @@ theorem Gamma_nat_eq_factorial (n : ℕ) : Gamma (n + 1) = n ! := by
     congr
 
 @[simp]
-theorem Gamma_ofNat_eq_factorial (n : ℕ) [(n + 1).AtLeastTwo] :
+theorem Gamma_ofNat_eq_factorial (n : ℕ) :
     Gamma (ofNat(n + 1) : ℂ) = n ! :=
   mod_cast Gamma_nat_eq_factorial (n : ℕ)
 
@@ -433,7 +433,7 @@ theorem Gamma_nat_eq_factorial (n : ℕ) : Gamma (n + 1) = n ! := by
     Complex.Gamma_nat_eq_factorial, ← Complex.ofReal_natCast, Complex.ofReal_re]
 
 @[simp]
-theorem Gamma_ofNat_eq_factorial (n : ℕ) [(n + 1).AtLeastTwo] :
+theorem Gamma_ofNat_eq_factorial (n : ℕ) :
     Gamma (ofNat(n + 1) : ℝ) = n ! :=
   mod_cast Gamma_nat_eq_factorial (n : ℕ)
 

--- a/Mathlib/Analysis/SpecialFunctions/Pow/Complex.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Pow/Complex.lean
@@ -112,14 +112,14 @@ lemma cpow_mul_int (x y : ℂ) (n : ℤ) : x ^ (y * n) = (x ^ y) ^ n := by rw [m
 lemma cpow_nat_mul (x : ℂ) (n : ℕ) (y : ℂ) : x ^ (n * y) = (x ^ y) ^ n :=
   mod_cast cpow_int_mul x n y
 
-lemma cpow_ofNat_mul (x : ℂ) (n : ℕ) [n.AtLeastTwo] (y : ℂ) :
+lemma cpow_ofNat_mul (x : ℂ) (n : ℕ) (y : ℂ) :
     x ^ (ofNat(n) * y) = (x ^ y) ^ ofNat(n) :=
   cpow_nat_mul x n y
 
 lemma cpow_mul_nat (x y : ℂ) (n : ℕ) : x ^ (y * n) = (x ^ y) ^ n := by
   rw [mul_comm, cpow_nat_mul]
 
-lemma cpow_mul_ofNat (x y : ℂ) (n : ℕ) [n.AtLeastTwo] :
+lemma cpow_mul_ofNat (x y : ℂ) (n : ℕ) :
     x ^ (y * ofNat(n)) = (x ^ y) ^ ofNat(n) :=
   cpow_mul_nat x y n
 
@@ -127,7 +127,7 @@ lemma cpow_mul_ofNat (x y : ℂ) (n : ℕ) [n.AtLeastTwo] :
 theorem cpow_natCast (x : ℂ) (n : ℕ) : x ^ (n : ℂ) = x ^ n := by simpa using cpow_nat_mul x n 1
 
 @[simp]
-lemma cpow_ofNat (x : ℂ) (n : ℕ) [n.AtLeastTwo] :
+lemma cpow_ofNat (x : ℂ) (n : ℕ) :
     x ^ (ofNat(n) : ℂ) = x ^ ofNat(n) :=
   cpow_natCast x n
 
@@ -142,7 +142,7 @@ theorem cpow_nat_inv_pow (x : ℂ) {n : ℕ} (hn : n ≠ 0) : (x ^ (n⁻¹ : ℂ
   assumption_mod_cast
 
 @[simp]
-lemma cpow_ofNat_inv_pow (x : ℂ) (n : ℕ) [n.AtLeastTwo] :
+lemma cpow_ofNat_inv_pow (x : ℂ) (n : ℕ) [NeZero n] :
     (x ^ ((ofNat(n) : ℂ)⁻¹)) ^ (ofNat(n) : ℕ) = x :=
   cpow_nat_inv_pow _ (NeZero.ne n)
 
@@ -163,7 +163,7 @@ lemma cpow_nat_mul' {x : ℂ} {n : ℕ} (hlt : -π < n * x.arg) (hle : n * x.arg
     x ^ (n * y) = (x ^ n) ^ y :=
   cpow_int_mul' hlt hle y
 
-lemma cpow_ofNat_mul' {x : ℂ} {n : ℕ} [n.AtLeastTwo] (hlt : -π < OfNat.ofNat n * x.arg)
+lemma cpow_ofNat_mul' {x : ℂ} {n : ℕ} (hlt : -π < OfNat.ofNat n * x.arg)
     (hle : OfNat.ofNat n * x.arg ≤ π) (y : ℂ) :
     x ^ (OfNat.ofNat n * y) = (x ^ ofNat(n)) ^ y :=
   cpow_nat_mul' hlt hle y
@@ -174,7 +174,7 @@ lemma pow_cpow_nat_inv {x : ℂ} {n : ℕ} (h₀ : n ≠ 0) (hlt : -(π / n) < x
   · rwa [← div_lt_iff₀' (Nat.cast_pos.2 h₀.bot_lt), neg_div]
   · rwa [← le_div_iff₀' (Nat.cast_pos.2 h₀.bot_lt)]
 
-lemma pow_cpow_ofNat_inv {x : ℂ} {n : ℕ} [n.AtLeastTwo] (hlt : -(π / OfNat.ofNat n) < x.arg)
+lemma pow_cpow_ofNat_inv {x : ℂ} {n : ℕ} [NeZero n] (hlt : -(π / OfNat.ofNat n) < x.arg)
     (hle : x.arg ≤ π / OfNat.ofNat n) :
     (x ^ ofNat(n)) ^ ((OfNat.ofNat n : ℂ)⁻¹) = x :=
   pow_cpow_nat_inv (NeZero.ne n) hlt hle

--- a/Mathlib/Analysis/SpecialFunctions/Pow/NNReal.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Pow/NNReal.lean
@@ -172,7 +172,7 @@ theorem sqrt_eq_rpow (x : ℝ≥0) : sqrt x = x ^ (1 / (2 : ℝ)) := by
   exact Real.sqrt_eq_rpow x.1
 
 @[simp]
-lemma rpow_ofNat (x : ℝ≥0) (n : ℕ) [n.AtLeastTwo] :
+lemma rpow_ofNat (x : ℝ≥0) (n : ℕ) :
     x ^ (ofNat(n) : ℝ) = x ^ (OfNat.ofNat n : ℕ) :=
   rpow_natCast x n
 
@@ -624,7 +624,7 @@ theorem rpow_natCast (x : ℝ≥0∞) (n : ℕ) : x ^ (n : ℝ) = x ^ n := by
   · simp [← coe_rpow_of_nonneg _ (Nat.cast_nonneg n)]
 
 @[simp]
-lemma rpow_ofNat (x : ℝ≥0∞) (n : ℕ) [n.AtLeastTwo] :
+lemma rpow_ofNat (x : ℝ≥0∞) (n : ℕ) :
     x ^ (ofNat(n) : ℝ) = x ^ (OfNat.ofNat n) :=
   rpow_natCast x n
 

--- a/Mathlib/Data/Complex/Basic.lean
+++ b/Mathlib/Data/Complex/Basic.lean
@@ -409,15 +409,15 @@ end
 instance instNNRatCast : NNRatCast ℂ where nnratCast q := ofReal q
 instance instRatCast : RatCast ℂ where ratCast q := ofReal q
 
-@[simp, norm_cast] lemma ofReal_ofNat (n : ℕ) [n.AtLeastTwo] : ofReal ofNat(n) = ofNat(n) := rfl
+@[simp, norm_cast] lemma ofReal_ofNat (n : ℕ) : ofReal ofNat(n) = ofNat(n) := rfl
 @[simp, norm_cast] lemma ofReal_natCast (n : ℕ) : ofReal n = n := rfl
 @[simp, norm_cast] lemma ofReal_intCast (n : ℤ) : ofReal n = n := rfl
 @[simp, norm_cast] lemma ofReal_nnratCast (q : ℚ≥0) : ofReal q = q := rfl
 @[simp, norm_cast] lemma ofReal_ratCast (q : ℚ) : ofReal q = q := rfl
 
 @[simp]
-lemma re_ofNat (n : ℕ) [n.AtLeastTwo] : (ofNat(n) : ℂ).re = ofNat(n) := rfl
-@[simp] lemma im_ofNat (n : ℕ) [n.AtLeastTwo] : (ofNat(n) : ℂ).im = 0 := rfl
+lemma re_ofNat (n : ℕ) : (ofNat(n) : ℂ).re = ofNat(n) := rfl
+@[simp] lemma im_ofNat (n : ℕ) : (ofNat(n) : ℂ).im = 0 := rfl
 @[simp, norm_cast] lemma natCast_re (n : ℕ) : (n : ℂ).re = n := rfl
 @[simp, norm_cast] lemma natCast_im (n : ℕ) : (n : ℂ).im = 0 := rfl
 @[simp, norm_cast] lemma intCast_re (n : ℤ) : (n : ℂ).re = n := rfl
@@ -469,7 +469,7 @@ theorem conj_I : conj I = -I :=
 
 theorem conj_natCast (n : ℕ) : conj (n : ℂ) = n := map_natCast _ _
 
-theorem conj_ofNat (n : ℕ) [n.AtLeastTwo] : conj (ofNat(n) : ℂ) = ofNat(n) :=
+theorem conj_ofNat (n : ℕ) : conj (ofNat(n) : ℂ) = ofNat(n) :=
   map_ofNat _ _
 
 theorem conj_neg_I : conj (-I) = I := by simp
@@ -519,7 +519,7 @@ theorem normSq_intCast (z : ℤ) : normSq z = z * z := normSq_ofReal _
 theorem normSq_ratCast (q : ℚ) : normSq q = q * q := normSq_ofReal _
 
 @[simp]
-theorem normSq_ofNat (n : ℕ) [n.AtLeastTwo] :
+theorem normSq_ofNat (n : ℕ) :
     normSq (ofNat(n) : ℂ) = ofNat(n) * ofNat(n) :=
   normSq_natCast _
 
@@ -732,7 +732,7 @@ lemma div_intCast (z : ℂ) (n : ℤ) : z / n = ⟨z.re / n, z.im / n⟩ :=
 lemma div_ratCast (z : ℂ) (x : ℚ) : z / x = ⟨z.re / x, z.im / x⟩ :=
   mod_cast div_ofReal z x
 
-lemma div_ofNat (z : ℂ) (n : ℕ) [n.AtLeastTwo] :
+lemma div_ofNat (z : ℂ) (n : ℕ) :
     z / ofNat(n) = ⟨z.re / ofNat(n), z.im / ofNat(n)⟩ :=
   div_natCast z n
 
@@ -746,11 +746,11 @@ lemma div_ofNat (z : ℂ) (n : ℕ) [n.AtLeastTwo] :
 @[simp] lemma div_ratCast_im (z : ℂ) (x : ℚ) : (z / x).im = z.im / x := by rw [div_ratCast]
 
 @[simp]
-lemma div_ofNat_re (z : ℂ) (n : ℕ) [n.AtLeastTwo] :
+lemma div_ofNat_re (z : ℂ) (n : ℕ) :
     (z / ofNat(n)).re = z.re / ofNat(n) := div_natCast_re z n
 
 @[simp]
-lemma div_ofNat_im (z : ℂ) (n : ℕ) [n.AtLeastTwo] :
+lemma div_ofNat_im (z : ℂ) (n : ℕ) :
     (z / ofNat(n)).im = z.im / ofNat(n) := div_natCast_im z n
 
 /-! ### Characteristic zero -/

--- a/Mathlib/Data/Complex/Norm.lean
+++ b/Mathlib/Data/Complex/Norm.lean
@@ -129,7 +129,7 @@ lemma nnnorm_real (r : ℝ) : ‖(r : ℂ)‖₊ = ‖r‖₊ := by ext; exact n
 lemma norm_natCast (n : ℕ) : ‖(n : ℂ)‖ = n := Complex.norm_of_nonneg n.cast_nonneg
 
 @[simp 1100]
-lemma norm_ofNat (n : ℕ) [n.AtLeastTwo] :
+lemma norm_ofNat (n : ℕ) :
     ‖(ofNat(n) : ℂ)‖ = OfNat.ofNat n := norm_natCast n
 
 protected lemma norm_two : ‖(2 : ℂ)‖ = 2 := norm_ofNat 2
@@ -138,7 +138,7 @@ protected lemma norm_two : ‖(2 : ℂ)‖ = 2 := norm_ofNat 2
 lemma nnnorm_natCast (n : ℕ) : ‖(n : ℂ)‖₊ = n := Subtype.ext <| by simp
 
 @[simp 1100]
-lemma nnnorm_ofNat (n : ℕ) [n.AtLeastTwo] :
+lemma nnnorm_ofNat (n : ℕ) :
     ‖(ofNat(n) : ℂ)‖₊ = OfNat.ofNat n := nnnorm_natCast n
 
 @[deprecated (since := "2025-02-16")] alias abs_natCast := norm_natCast

--- a/Mathlib/Data/ENNReal/Basic.lean
+++ b/Mathlib/Data/ENNReal/Basic.lean
@@ -388,7 +388,7 @@ lemma coe_ne_one : (r : ℝ≥0∞) ≠ 1 ↔ r ≠ 1 := coe_eq_one.not
 @[simp, norm_cast] lemma coe_pow (x : ℝ≥0) (n : ℕ) : (↑(x ^ n) : ℝ≥0∞) = x ^ n := rfl
 
 @[simp, norm_cast]
-theorem coe_ofNat (n : ℕ) [n.AtLeastTwo] : ((ofNat(n) : ℝ≥0) : ℝ≥0∞) = ofNat(n) := rfl
+theorem coe_ofNat (n : ℕ) : ((ofNat(n) : ℝ≥0) : ℝ≥0∞) = ofNat(n) := rfl
 
 -- TODO: add lemmas about `OfNat.ofNat` and `<`/`≤`
 
@@ -487,7 +487,7 @@ theorem coe_natCast (n : ℕ) : ((n : ℝ≥0) : ℝ≥0∞) = n := rfl
 
 @[simp, norm_cast] lemma ofReal_natCast (n : ℕ) : ENNReal.ofReal n = n := by simp [ENNReal.ofReal]
 
-@[simp] theorem ofReal_ofNat (n : ℕ) [n.AtLeastTwo] : ENNReal.ofReal ofNat(n) = ofNat(n) :=
+@[simp] theorem ofReal_ofNat (n : ℕ) : ENNReal.ofReal ofNat(n) = ofNat(n) :=
   ofReal_natCast n
 
 @[simp, aesop (rule_sets := [finiteness]) safe apply]
@@ -496,14 +496,14 @@ theorem natCast_ne_top (n : ℕ) : (n : ℝ≥0∞) ≠ ∞ := WithTop.natCast_n
 @[simp] theorem natCast_lt_top (n : ℕ) : (n : ℝ≥0∞) < ∞ := WithTop.natCast_lt_top n
 
 @[simp, aesop (rule_sets := [finiteness]) safe apply]
-lemma ofNat_ne_top {n : ℕ} [Nat.AtLeastTwo n] : ofNat(n) ≠ ∞ := natCast_ne_top n
+lemma ofNat_ne_top {n : ℕ} : ofNat(n) ≠ ∞ := natCast_ne_top n
 
 @[simp]
-lemma ofNat_lt_top {n : ℕ} [Nat.AtLeastTwo n] : ofNat(n) < ∞ := natCast_lt_top n
+lemma ofNat_lt_top {n : ℕ} : ofNat(n) < ∞ := natCast_lt_top n
 
 @[simp] theorem top_ne_natCast (n : ℕ) : ∞ ≠ n := WithTop.top_ne_natCast n
 
-@[simp] theorem top_ne_ofNat {n : ℕ} [n.AtLeastTwo] : ∞ ≠ ofNat(n) :=
+@[simp] theorem top_ne_ofNat {n : ℕ} : ∞ ≠ ofNat(n) :=
   ofNat_ne_top.symm
 
 @[deprecated ofNat_ne_top (since := "2025-01-21")] lemma two_ne_top : (2 : ℝ≥0∞) ≠ ∞ := coe_ne_top
@@ -517,7 +517,7 @@ theorem toNNReal_natCast (n : ℕ) : (n : ℝ≥0∞).toNNReal = n := by
 
 @[deprecated (since := "2025-02-19")] alias toNNReal_nat := toNNReal_natCast
 
-theorem toNNReal_ofNat (n : ℕ) [n.AtLeastTwo] : ENNReal.toNNReal ofNat(n) = ofNat(n) :=
+theorem toNNReal_ofNat (n : ℕ) : ENNReal.toNNReal ofNat(n) = ofNat(n) :=
   toNNReal_natCast n
 
 @[simp, norm_cast]
@@ -526,7 +526,7 @@ theorem toReal_natCast (n : ℕ) : (n : ℝ≥0∞).toReal = n := by
 
 @[deprecated (since := "2025-02-19")] alias toReal_nat := toReal_natCast
 
-@[simp] theorem toReal_ofNat (n : ℕ) [n.AtLeastTwo] : ENNReal.toReal ofNat(n) = ofNat(n) :=
+@[simp] theorem toReal_ofNat (n : ℕ) : ENNReal.toReal ofNat(n) = ofNat(n) :=
   toReal_natCast n
 
 lemma toNNReal_natCast_eq_toNNReal (n : ℕ) :

--- a/Mathlib/Data/ENNReal/Real.lean
+++ b/Mathlib/Data/ENNReal/Real.lean
@@ -185,7 +185,7 @@ lemma ofReal_lt_one {p : ℝ} : ENNReal.ofReal p < 1 ↔ p < 1 := by
   exact mod_cast ofReal_lt_natCast one_ne_zero
 
 @[simp]
-lemma ofReal_lt_ofNat {p : ℝ} {n : ℕ} [n.AtLeastTwo] :
+lemma ofReal_lt_ofNat {p : ℝ} {n : ℕ} [NeZero n] :
     ENNReal.ofReal p < ofNat(n) ↔ p < OfNat.ofNat n :=
   ofReal_lt_natCast (NeZero.ne n)
 
@@ -198,7 +198,7 @@ lemma one_le_ofReal {p : ℝ} : 1 ≤ ENNReal.ofReal p ↔ 1 ≤ p := by
   exact mod_cast natCast_le_ofReal one_ne_zero
 
 @[simp]
-lemma ofNat_le_ofReal {n : ℕ} [n.AtLeastTwo] {p : ℝ} :
+lemma ofNat_le_ofReal {n : ℕ} [NeZero n] {p : ℝ} :
     ofNat(n) ≤ ENNReal.ofReal p ↔ OfNat.ofNat n ≤ p :=
   natCast_le_ofReal (NeZero.ne n)
 
@@ -211,7 +211,7 @@ lemma ofReal_le_one {r : ℝ} : ENNReal.ofReal r ≤ 1 ↔ r ≤ 1 :=
   coe_le_coe.trans Real.toNNReal_le_one
 
 @[simp]
-lemma ofReal_le_ofNat {r : ℝ} {n : ℕ} [n.AtLeastTwo] :
+lemma ofReal_le_ofNat {r : ℝ} {n : ℕ} :
     ENNReal.ofReal r ≤ ofNat(n) ↔ r ≤ OfNat.ofNat n :=
   ofReal_le_natCast
 
@@ -223,7 +223,7 @@ lemma natCast_lt_ofReal {n : ℕ} {r : ℝ} : n < ENNReal.ofReal r ↔ n < r :=
 lemma one_lt_ofReal {r : ℝ} : 1 < ENNReal.ofReal r ↔ 1 < r := coe_lt_coe.trans Real.one_lt_toNNReal
 
 @[simp]
-lemma ofNat_lt_ofReal {n : ℕ} [n.AtLeastTwo] {r : ℝ} :
+lemma ofNat_lt_ofReal {n : ℕ} {r : ℝ} :
     ofNat(n) < ENNReal.ofReal r ↔ OfNat.ofNat n < r :=
   natCast_lt_ofReal
 
@@ -236,7 +236,7 @@ lemma ofReal_eq_one {r : ℝ} : ENNReal.ofReal r = 1 ↔ r = 1 :=
   ENNReal.coe_inj.trans Real.toNNReal_eq_one
 
 @[simp]
-lemma ofReal_eq_ofNat {r : ℝ} {n : ℕ} [n.AtLeastTwo] :
+lemma ofReal_eq_ofNat {r : ℝ} {n : ℕ} [NeZero n] :
     ENNReal.ofReal r = ofNat(n) ↔ r = OfNat.ofNat n :=
   ofReal_eq_natCast (NeZero.ne n)
 

--- a/Mathlib/Data/ENat/Basic.lean
+++ b/Mathlib/Data/ENat/Basic.lean
@@ -107,7 +107,7 @@ def lift (x : ℕ∞) (h : x < ⊤) : ℕ := WithTop.untop x (WithTop.lt_top_iff
 
 @[simp] theorem lift_zero : lift 0 (WithTop.coe_lt_top 0) = 0 := rfl
 @[simp] theorem lift_one : lift 1 (WithTop.coe_lt_top 1) = 1 := rfl
-@[simp] theorem lift_ofNat (n : ℕ) [n.AtLeastTwo] :
+@[simp] theorem lift_ofNat (n : ℕ) :
     lift ofNat(n) (WithTop.coe_lt_top n) = OfNat.ofNat n := rfl
 
 @[simp] theorem add_lt_top {a b : ℕ∞} : a + b < ⊤ ↔ a < ⊤ ∧ b < ⊤ := WithTop.add_lt_top
@@ -150,7 +150,7 @@ theorem toNat_one : toNat 1 = 1 :=
   rfl
 
 @[simp]
-theorem toNat_ofNat (n : ℕ) [n.AtLeastTwo] : toNat ofNat(n) = n :=
+theorem toNat_ofNat (n : ℕ) : toNat ofNat(n) = n :=
   rfl
 
 @[simp]
@@ -168,7 +168,7 @@ theorem recTopCoe_one {C : ℕ∞ → Sort*} (d : C ⊤) (f : ∀ a : ℕ, C a) 
   rfl
 
 @[simp]
-theorem recTopCoe_ofNat {C : ℕ∞ → Sort*} (d : C ⊤) (f : ∀ a : ℕ, C a) (x : ℕ) [x.AtLeastTwo] :
+theorem recTopCoe_ofNat {C : ℕ∞ → Sort*} (d : C ⊤) (f : ∀ a : ℕ, C a) (x : ℕ) :
     @recTopCoe C d f ofNat(x) = f (OfNat.ofNat x) :=
   rfl
 
@@ -177,7 +177,7 @@ theorem top_ne_coe (a : ℕ) : ⊤ ≠ (a : ℕ∞) :=
   nofun
 
 @[simp]
-theorem top_ne_ofNat (a : ℕ) [a.AtLeastTwo] : ⊤ ≠ (ofNat(a) : ℕ∞) :=
+theorem top_ne_ofNat (a : ℕ) : ⊤ ≠ (ofNat(a) : ℕ∞) :=
   nofun
 
 @[simp] lemma top_ne_zero : (⊤ : ℕ∞) ≠ 0 := nofun
@@ -188,7 +188,7 @@ theorem coe_ne_top (a : ℕ) : (a : ℕ∞) ≠ ⊤ :=
   nofun
 
 @[simp]
-theorem ofNat_ne_top (a : ℕ) [a.AtLeastTwo] : (ofNat(a) : ℕ∞) ≠ ⊤ :=
+theorem ofNat_ne_top (a : ℕ) : (ofNat(a) : ℕ∞) ≠ ⊤ :=
   nofun
 
 @[simp] lemma zero_ne_top : 0 ≠ (⊤ : ℕ∞) := nofun
@@ -203,7 +203,7 @@ theorem top_sub_one : (⊤ : ℕ∞) - 1 = ⊤ :=
   top_sub_coe 1
 
 @[simp]
-theorem top_sub_ofNat (a : ℕ) [a.AtLeastTwo] : (⊤ : ℕ∞) - ofNat(a) = ⊤ :=
+theorem top_sub_ofNat (a : ℕ) : (⊤ : ℕ∞) - ofNat(a) = ⊤ :=
   top_sub_coe a
 
 @[simp]
@@ -441,7 +441,7 @@ protected theorem map_zero (f : ℕ → α) : map f 0 = f 0 := rfl
 protected theorem map_one (f : ℕ → α) : map f 1 = f 1 := rfl
 
 @[simp]
-theorem map_ofNat (f : ℕ → α) (n : ℕ) [n.AtLeastTwo] : map f ofNat(n) = f n := rfl
+theorem map_ofNat (f : ℕ → α) (n : ℕ) : map f ofNat(n) = f n := rfl
 
 @[simp]
 lemma map_eq_top_iff {f : ℕ → α} : map f n = ⊤ ↔ n = ⊤ := WithTop.map_eq_top_iff

--- a/Mathlib/Data/Int/Log.lean
+++ b/Mathlib/Data/Int/Log.lean
@@ -73,7 +73,7 @@ theorem log_natCast (b : ℕ) (n : ℕ) : log b (n : R) = Nat.log b n := by
     simp
 
 @[simp]
-theorem log_ofNat (b : ℕ) (n : ℕ) [n.AtLeastTwo] :
+theorem log_ofNat (b : ℕ) (n : ℕ) :
     log b (ofNat(n) : R) = Nat.log b ofNat(n) :=
   log_natCast b n
 
@@ -217,7 +217,7 @@ theorem clog_natCast (b : ℕ) (n : ℕ) : clog b (n : R) = Nat.clog b n := by
   · rw [clog_of_one_le_right, (Nat.ceil_eq_iff (Nat.succ_ne_zero n)).mpr] <;> simp
 
 @[simp]
-theorem clog_ofNat (b : ℕ) (n : ℕ) [n.AtLeastTwo] :
+theorem clog_ofNat (b : ℕ) (n : ℕ) :
     clog b (ofNat(n) : R) = Nat.clog b ofNat(n) :=
   clog_natCast b n
 

--- a/Mathlib/Data/Matrix/ConjTranspose.lean
+++ b/Mathlib/Data/Matrix/ConjTranspose.lean
@@ -173,13 +173,13 @@ theorem conjTranspose_eq_natCast [DecidableEq n] [NonAssocSemiring α] [StarRing
     by rw [conjTranspose_natCast]
 
 @[simp]
-theorem conjTranspose_ofNat [DecidableEq n] [NonAssocSemiring α] [StarRing α] (d : ℕ)
-    [d.AtLeastTwo] : (ofNat(d) : Matrix n n α)ᴴ = OfNat.ofNat d :=
+theorem conjTranspose_ofNat [DecidableEq n] [NonAssocSemiring α] [StarRing α] (d : ℕ) :
+    (ofNat(d) : Matrix n n α)ᴴ = OfNat.ofNat d :=
   conjTranspose_natCast _
 
 @[simp]
 theorem conjTranspose_eq_ofNat [DecidableEq n] [Semiring α] [StarRing α]
-    {M : Matrix n n α} {d : ℕ} [d.AtLeastTwo] :
+    {M : Matrix n n α} {d : ℕ} :
     Mᴴ = ofNat(d) ↔ M = OfNat.ofNat d :=
   conjTranspose_eq_natCast
 
@@ -248,7 +248,7 @@ theorem conjTranspose_natCast_smul [Semiring R] [AddCommMonoid α] [StarAddMonoi
 
 @[simp]
 theorem conjTranspose_ofNat_smul [Semiring R] [AddCommMonoid α] [StarAddMonoid α] [Module R α]
-    (c : ℕ) [c.AtLeastTwo] (M : Matrix m n α) :
+    (c : ℕ) (M : Matrix m n α) :
     ((ofNat(c) : R) • M)ᴴ = (OfNat.ofNat c : R) • Mᴴ :=
   conjTranspose_natCast_smul c M
 
@@ -264,7 +264,7 @@ theorem conjTranspose_inv_natCast_smul [DivisionSemiring R] [AddCommMonoid α] [
 
 @[simp]
 theorem conjTranspose_inv_ofNat_smul [DivisionSemiring R] [AddCommMonoid α] [StarAddMonoid α]
-    [Module R α] (c : ℕ) [c.AtLeastTwo] (M : Matrix m n α) :
+    [Module R α] (c : ℕ) (M : Matrix m n α) :
     ((ofNat(c) : R)⁻¹ • M)ᴴ = (OfNat.ofNat c : R)⁻¹ • Mᴴ :=
   conjTranspose_inv_natCast_smul c M
 

--- a/Mathlib/Data/Matrix/Diagonal.lean
+++ b/Mathlib/Data/Matrix/Diagonal.lean
@@ -116,10 +116,10 @@ theorem diagonal_natCast [Zero α] [NatCast α] (m : ℕ) : diagonal (fun _ : n 
 @[norm_cast]
 theorem diagonal_natCast' [Zero α] [NatCast α] (m : ℕ) : diagonal ((m : n → α)) = m := rfl
 
-theorem diagonal_ofNat [Zero α] [NatCast α] (m : ℕ) [m.AtLeastTwo] :
+theorem diagonal_ofNat [Zero α] [NatCast α] (m : ℕ) :
     diagonal (fun _ : n => (ofNat(m) : α)) = OfNat.ofNat m := rfl
 
-theorem diagonal_ofNat' [Zero α] [NatCast α] (m : ℕ) [m.AtLeastTwo] :
+theorem diagonal_ofNat' [Zero α] [NatCast α] (m : ℕ) :
     diagonal (ofNat(m) : n → α) = OfNat.ofNat m := rfl
 
 instance [Zero α] [IntCast α] : IntCast (Matrix n n α) where
@@ -144,7 +144,7 @@ protected theorem map_natCast [AddMonoidWithOne α] [Zero β]
   diagonal_map h
 
 protected theorem map_ofNat [AddMonoidWithOne α] [Zero β]
-    {f : α → β} (h : f 0 = 0) (d : ℕ) [d.AtLeastTwo] :
+    {f : α → β} (h : f 0 = 0) (d : ℕ) :
     (ofNat(d) : Matrix n n α).map f = diagonal (fun _ => f (OfNat.ofNat d)) :=
   diagonal_map h
 
@@ -303,13 +303,13 @@ theorem transpose_eq_natCast [DecidableEq n] [AddMonoidWithOne α] {M : Matrix n
   transpose_eq_diagonal
 
 @[simp]
-theorem transpose_ofNat [DecidableEq n] [AddMonoidWithOne α] (d : ℕ) [d.AtLeastTwo] :
+theorem transpose_ofNat [DecidableEq n] [AddMonoidWithOne α] (d : ℕ) :
     (ofNat(d) : Matrix n n α)ᵀ = OfNat.ofNat d :=
   transpose_natCast _
 
 @[simp]
 theorem transpose_eq_ofNat [DecidableEq n] [AddMonoidWithOne α]
-    {M : Matrix n n α} {d : ℕ} [d.AtLeastTwo] :
+    {M : Matrix n n α} {d : ℕ} :
     Mᵀ = ofNat(d) ↔ M = OfNat.ofNat d :=
   transpose_eq_diagonal
 

--- a/Mathlib/Data/Matrix/Kronecker.lean
+++ b/Mathlib/Data/Matrix/Kronecker.lean
@@ -331,12 +331,12 @@ theorem natCast_kronecker [NonAssocSemiring α] [DecidableEq l] (a : ℕ) (B : M
     ext
     simp [(Nat.cast_commute a _).eq]
 
-theorem kronecker_ofNat [NonAssocSemiring α] [DecidableEq n] (A : Matrix l m α) (b : ℕ)
-    [b.AtLeastTwo] : A ⊗ₖ (ofNat(b) : Matrix n n α) =
+theorem kronecker_ofNat [NonAssocSemiring α] [DecidableEq n] (A : Matrix l m α) (b : ℕ) :
+    A ⊗ₖ (ofNat(b) : Matrix n n α) =
       blockDiagonal fun _ => A <• (ofNat(b) : α) :=
   kronecker_diagonal _ _
 
-theorem ofNat_kronecker [NonAssocSemiring α] [DecidableEq l] (a : ℕ) [a.AtLeastTwo]
+theorem ofNat_kronecker [NonAssocSemiring α] [DecidableEq l] (a : ℕ)
     (B : Matrix m n α) : (ofNat(a) : Matrix l l α) ⊗ₖ B =
       Matrix.reindex (.prodComm _ _) (.prodComm _ _)
         (blockDiagonal fun _ => (ofNat(a) : α) • B) :=

--- a/Mathlib/Data/Matrix/Mul.lean
+++ b/Mathlib/Data/Matrix/Mul.lean
@@ -836,12 +836,12 @@ theorem vecMul_natCast (x : ℕ) (v : m → α) : v ᵥ* x = MulOpposite.op (x :
 
 
 @[simp]
-theorem ofNat_mulVec (x : ℕ) [x.AtLeastTwo] (v : m → α) :
+theorem ofNat_mulVec (x : ℕ) (v : m → α) :
     ofNat(x) *ᵥ v = (OfNat.ofNat x : α) • v :=
   natCast_mulVec _ _
 
 @[simp]
-theorem vecMul_ofNat (x : ℕ) [x.AtLeastTwo] (v : m → α) :
+theorem vecMul_ofNat (x : ℕ) (v : m → α) :
     v ᵥ* ofNat(x) = MulOpposite.op (OfNat.ofNat x : α) • v :=
   vecMul_natCast _ _
 

--- a/Mathlib/Data/Matrix/Notation.lean
+++ b/Mathlib/Data/Matrix/Notation.lean
@@ -427,12 +427,12 @@ theorem natCast_fin_three (n : ℕ) :
   ext i j
   fin_cases i <;> fin_cases j <;> rfl
 
-theorem ofNat_fin_two (n : ℕ) [n.AtLeastTwo] :
+theorem ofNat_fin_two (n : ℕ) :
     (ofNat(n) : Matrix (Fin 2) (Fin 2) α) =
       !![ofNat(n), 0; 0, ofNat(n)] :=
   natCast_fin_two _
 
-theorem ofNat_fin_three (n : ℕ) [n.AtLeastTwo] :
+theorem ofNat_fin_three (n : ℕ) :
     (ofNat(n) : Matrix (Fin 3) (Fin 3) α) =
       !![ofNat(n), 0, 0; 0, ofNat(n), 0; 0, 0, ofNat(n)] :=
   natCast_fin_three _

--- a/Mathlib/Data/NNRat/Defs.lean
+++ b/Mathlib/Data/NNRat/Defs.lean
@@ -333,9 +333,9 @@ lemma coprime_num_den (q : ℚ≥0) : q.num.Coprime q.den := by simpa [num, den]
 @[simp, norm_cast] lemma num_natCast (n : ℕ) : num n = n := rfl
 @[simp, norm_cast] lemma den_natCast (n : ℕ) : den n = 1 := rfl
 
-@[simp] lemma num_ofNat (n : ℕ) [n.AtLeastTwo] : num ofNat(n) = OfNat.ofNat n :=
+@[simp] lemma num_ofNat (n : ℕ) : num ofNat(n) = OfNat.ofNat n :=
   rfl
-@[simp] lemma den_ofNat (n : ℕ) [n.AtLeastTwo] : den ofNat(n) = 1 := rfl
+@[simp] lemma den_ofNat (n : ℕ) : den ofNat(n) = 1 := rfl
 
 theorem ext_num_den (hn : p.num = q.num) (hd : p.den = q.den) : p = q := by
   refine ext <| Rat.ext ?_ hd

--- a/Mathlib/Data/NNReal/Defs.lean
+++ b/Mathlib/Data/NNReal/Defs.lean
@@ -267,7 +267,7 @@ protected theorem coe_natCast (n : ℕ) : (↑(↑n : ℝ≥0) : ℝ) = n :=
   map_natCast toRealHom n
 
 @[simp, norm_cast]
-protected theorem coe_ofNat (n : ℕ) [n.AtLeastTwo] : ((ofNat(n) : ℝ≥0) : ℝ) = ofNat(n) :=
+protected theorem coe_ofNat (n : ℕ) : ((ofNat(n) : ℝ≥0) : ℝ) = ofNat(n) :=
   rfl
 
 @[simp, norm_cast]
@@ -319,7 +319,7 @@ theorem _root_.Real.toNNReal_coe_nat (n : ℕ) : Real.toNNReal n = n :=
 alias toNNReal_coe_nat := Real.toNNReal_coe_nat
 
 @[simp]
-theorem _root_.Real.toNNReal_ofNat (n : ℕ) [n.AtLeastTwo] :
+theorem _root_.Real.toNNReal_ofNat (n : ℕ) :
     Real.toNNReal ofNat(n) = OfNat.ofNat n :=
   Real.toNNReal_coe_nat n
 
@@ -524,7 +524,7 @@ lemma toNNReal_eq_natCast {r : ℝ} {n : ℕ} (hn : n ≠ 0) : r.toNNReal = n �
   mod_cast toNNReal_eq_iff_eq_coe <| Nat.cast_ne_zero.2 hn
 
 @[simp]
-lemma toNNReal_eq_ofNat {r : ℝ} {n : ℕ} [n.AtLeastTwo] :
+lemma toNNReal_eq_ofNat {r : ℝ} {n : ℕ} [NeZero n]:
     r.toNNReal = ofNat(n) ↔ r = OfNat.ofNat n :=
   toNNReal_eq_natCast (NeZero.ne n)
 
@@ -549,12 +549,12 @@ lemma natCast_lt_toNNReal {r : ℝ} {n : ℕ} : n < r.toNNReal ↔ n < r := by
   simpa only [not_le] using toNNReal_le_natCast.not
 
 @[simp]
-lemma toNNReal_le_ofNat {r : ℝ} {n : ℕ} [n.AtLeastTwo] :
+lemma toNNReal_le_ofNat {r : ℝ} {n : ℕ} :
     r.toNNReal ≤ ofNat(n) ↔ r ≤ n :=
   toNNReal_le_natCast
 
 @[simp]
-lemma ofNat_lt_toNNReal {r : ℝ} {n : ℕ} [n.AtLeastTwo] :
+lemma ofNat_lt_toNNReal {r : ℝ} {n : ℕ} :
     ofNat(n) < r.toNNReal ↔ n < r :=
   natCast_lt_toNNReal
 
@@ -603,12 +603,12 @@ lemma natCast_le_toNNReal {n : ℕ} {r : ℝ} (hn : n ≠ 0) : ↑n ≤ r.toNNRe
 lemma toNNReal_lt_natCast {r : ℝ} {n : ℕ} (hn : n ≠ 0) : r.toNNReal < n ↔ r < n := by simp [hn]
 
 @[simp]
-lemma toNNReal_lt_ofNat {r : ℝ} {n : ℕ} [n.AtLeastTwo] :
+lemma toNNReal_lt_ofNat {r : ℝ} {n : ℕ} [NeZero n] :
     r.toNNReal < ofNat(n) ↔ r < OfNat.ofNat n :=
   toNNReal_lt_natCast (NeZero.ne n)
 
 @[simp]
-lemma ofNat_le_toNNReal {n : ℕ} {r : ℝ} [n.AtLeastTwo] :
+lemma ofNat_le_toNNReal {n : ℕ} {r : ℝ} [NeZero n] :
     ofNat(n) ≤ r.toNNReal ↔ OfNat.ofNat n ≤ r :=
   natCast_le_toNNReal (NeZero.ne n)
 

--- a/Mathlib/Data/Nat/Cast/Basic.lean
+++ b/Mathlib/Data/Nat/Cast/Basic.lean
@@ -101,7 +101,7 @@ theorem map_natCast' {A} [AddMonoidWithOne A] [FunLike F A B] [AddMonoidHomClass
   eq_natCast' ((f : A →+ B).comp <| Nat.castAddMonoidHom _) (by simpa)
 
 theorem map_ofNat' {A} [AddMonoidWithOne A] [FunLike F A B] [AddMonoidHomClass F A B]
-    (f : F) (h : f 1 = 1) (n : ℕ) [n.AtLeastTwo] : f (OfNat.ofNat n) = OfNat.ofNat n :=
+    (f : F) (h : f 1 = 1) (n : ℕ) : f (OfNat.ofNat n) = OfNat.ofNat n :=
   map_natCast' f h n
 
 end AddMonoidHomClass
@@ -141,7 +141,7 @@ be `DFunLike.coe _ _`, due to the `ofNat` that https://github.com/leanprover/lea
 forces us to include, and therefore it would negatively impact performance.
 
 If that issue is resolved, this can be marked `@[simp]`. -/
-theorem map_ofNat [FunLike F R S] [RingHomClass F R S] (f : F) (n : ℕ) [Nat.AtLeastTwo n] :
+theorem map_ofNat [FunLike F R S] [RingHomClass F R S] (f : F) (n : ℕ) :
     (f ofNat(n) : S) = OfNat.ofNat n :=
   map_natCast f n
 

--- a/Mathlib/Data/Nat/Cast/Commute.lean
+++ b/Mathlib/Data/Nat/Cast/Commute.lean
@@ -24,7 +24,7 @@ theorem cast_commute (n : ℕ) (x : α) : Commute (n : α) x := by
   | zero => rw [Nat.cast_zero]; exact Commute.zero_left x
   | succ n ihn => rw [Nat.cast_succ]; exact ihn.add_left (Commute.one_left x)
 
-theorem _root_.Commute.ofNat_left (n : ℕ) [n.AtLeastTwo] (x : α) : Commute (OfNat.ofNat n) x :=
+theorem _root_.Commute.ofNat_left (n : ℕ) (x : α) : Commute (OfNat.ofNat n) x :=
   n.cast_commute x
 
 theorem cast_comm (n : ℕ) (x : α) : (n : α) * x = x * n :=
@@ -33,7 +33,7 @@ theorem cast_comm (n : ℕ) (x : α) : (n : α) * x = x * n :=
 theorem commute_cast (x : α) (n : ℕ) : Commute x n :=
   (n.cast_commute x).symm
 
-theorem _root_.Commute.ofNat_right (x : α) (n : ℕ) [n.AtLeastTwo] : Commute x (OfNat.ofNat n) :=
+theorem _root_.Commute.ofNat_right (x : α) (n : ℕ) : Commute x (OfNat.ofNat n) :=
   n.commute_cast x
 
 end Commute

--- a/Mathlib/Data/Nat/Cast/Defs.lean
+++ b/Mathlib/Data/Nat/Cast/Defs.lean
@@ -54,7 +54,7 @@ instance is what makes things like `37 : R` type check.  Note that `0` and `1` a
 because they are recognized as terms of `R` (at least when `R` is an `AddMonoidWithOne`) through
 `Zero` and `One`, respectively. -/
 @[nolint unusedArguments]
-instance (priority := 100) instOfNatAtLeastTwo {n : ℕ} [NatCast R] [Nat.AtLeastTwo n] :
+instance (priority := 100) instOfNatAtLeastTwo {n : ℕ} [NatCast R] :
     OfNat R n where
   ofNat := n.cast
 

--- a/Mathlib/Data/Nat/Cast/Defs.lean
+++ b/Mathlib/Data/Nat/Cast/Defs.lean
@@ -54,7 +54,7 @@ instance is what makes things like `37 : R` type check.
 Note that this may conflict with the instance recognizing `0` and `1` via the `Zero` and `One`
 typeclasses (e.g. when `R` is an `AddMonoidWithOne`), so it is essential that these are defeq. -/
 @[nolint unusedArguments]
-instance (priority := 100) instOfNatAtLeastTwo {n : ℕ} [NatCast R] :
+instance (priority := 100) instOfNatOfNatCast {n : ℕ} [NatCast R] :
     OfNat R n where
   ofNat := n.cast
 

--- a/Mathlib/Data/Nat/Cast/Defs.lean
+++ b/Mathlib/Data/Nat/Cast/Defs.lean
@@ -51,7 +51,7 @@ end Nat.AtLeastTwo
 
 /-- Recognize numeric literals as terms of `R` via `Nat.cast`. This
 instance is what makes things like `37 : R` type check.
-Note that this may conflict with the instance recognizing `0` and `1` via the `Zero` and `One`
+Note that this may conflict with the instances recognizing `0` and `1` via the `Zero` and `One`
 typeclasses (e.g. when `R` is an `AddMonoidWithOne`), so it is essential that these are defeq. -/
 @[nolint unusedArguments]
 instance (priority := 100) instOfNatOfNatCast {n : ℕ} [NatCast R] :

--- a/Mathlib/Data/Nat/Cast/Defs.lean
+++ b/Mathlib/Data/Nat/Cast/Defs.lean
@@ -49,10 +49,10 @@ lemma ne_one : n ≠ 1 := Nat.ne_of_gt one_lt
 
 end Nat.AtLeastTwo
 
-/-- Recognize numeric literals which are at least `2` as terms of `R` via `Nat.cast`. This
-instance is what makes things like `37 : R` type check.  Note that `0` and `1` are not needed
-because they are recognized as terms of `R` (at least when `R` is an `AddMonoidWithOne`) through
-`Zero` and `One`, respectively. -/
+/-- Recognize numeric literals as terms of `R` via `Nat.cast`. This
+instance is what makes things like `37 : R` type check.
+Note that this may conflict with the instance recognizing `0` and `1` via the `Zero` and `One`
+typeclasses (e.g. when `R` is an `AddMonoidWithOne`), so it is essential that these are defeq. -/
 @[nolint unusedArguments]
 instance (priority := 100) instOfNatAtLeastTwo {n : ℕ} [NatCast R] :
     OfNat R n where

--- a/Mathlib/Data/Nat/Cast/Order/Basic.lean
+++ b/Mathlib/Data/Nat/Cast/Order/Basic.lean
@@ -43,7 +43,7 @@ theorem cast_nonneg' (n : ℕ) : 0 ≤ (n : α) :=
 
 /-- See also `Nat.ofNat_nonneg`, specialised for an `OrderedSemiring`. -/
 @[simp low]
-theorem ofNat_nonneg' (n : ℕ) [n.AtLeastTwo] : 0 ≤ (ofNat(n) : α) := cast_nonneg' n
+theorem ofNat_nonneg' (n : ℕ) : 0 ≤ (ofNat(n) : α) := cast_nonneg' n
 
 section Nontrivial
 

--- a/Mathlib/Data/Nat/Cast/Order/Basic.lean
+++ b/Mathlib/Data/Nat/Cast/Order/Basic.lean
@@ -97,7 +97,6 @@ theorem cast_le_one : (n : α) ≤ 1 ↔ n ≤ 1 := by rw [← cast_one, cast_le
 @[simp] lemma cast_nonpos : (n : α) ≤ 0 ↔ n = 0 := by norm_cast; omega
 
 section
-variable [m.AtLeastTwo]
 
 @[simp]
 theorem ofNat_le_cast : (ofNat(m) : α) ≤ n ↔ (OfNat.ofNat m : ℕ) ≤ n :=
@@ -109,8 +108,6 @@ theorem ofNat_lt_cast : (ofNat(m) : α) < n ↔ (OfNat.ofNat m : ℕ) < n :=
 
 end
 
-variable [n.AtLeastTwo]
-
 @[simp]
 theorem cast_le_ofNat : (m : α) ≤ (ofNat(n) : α) ↔ m ≤ OfNat.ofNat n :=
   cast_le
@@ -118,6 +115,22 @@ theorem cast_le_ofNat : (m : α) ≤ (ofNat(n) : α) ↔ m ≤ OfNat.ofNat n :=
 @[simp]
 theorem cast_lt_ofNat : (m : α) < (ofNat(n) : α) ↔ m < OfNat.ofNat n :=
   cast_lt
+
+-- TODO: These lemmas need to be `@[simp]` for confluence in the presence of `cast_lt`, `cast_le`,
+-- and `Nat.cast_ofNat`, but their LHSs match literally every inequality, so they're too expensive.
+-- If https://github.com/leanprover/lean4/issues/2867 is fixed in a performant way, these can be made `@[simp]`.
+
+-- @[simp]
+theorem ofNat_le :
+    (ofNat(m) : α) ≤ (ofNat(n) : α) ↔ (OfNat.ofNat m : ℕ) ≤ OfNat.ofNat n :=
+  cast_le
+
+-- @[simp]
+theorem ofNat_lt :
+    (ofNat(m) : α) < (ofNat(n) : α) ↔ (OfNat.ofNat m : ℕ) < OfNat.ofNat n :=
+  cast_lt
+
+variable [n.AtLeastTwo]
 
 @[simp]
 theorem one_lt_ofNat : 1 < (ofNat(n) : α) :=
@@ -134,22 +147,6 @@ theorem not_ofNat_le_one : ¬(ofNat(n) : α) ≤ 1 :=
 @[simp]
 theorem not_ofNat_lt_one : ¬(ofNat(n) : α) < 1 :=
   mt le_of_lt not_ofNat_le_one
-
-variable [m.AtLeastTwo]
-
--- TODO: These lemmas need to be `@[simp]` for confluence in the presence of `cast_lt`, `cast_le`,
--- and `Nat.cast_ofNat`, but their LHSs match literally every inequality, so they're too expensive.
--- If https://github.com/leanprover/lean4/issues/2867 is fixed in a performant way, these can be made `@[simp]`.
-
--- @[simp]
-theorem ofNat_le :
-    (ofNat(m) : α) ≤ (ofNat(n) : α) ↔ (OfNat.ofNat m : ℕ) ≤ OfNat.ofNat n :=
-  cast_le
-
--- @[simp]
-theorem ofNat_lt :
-    (ofNat(m) : α) < (ofNat(n) : α) ↔ (OfNat.ofNat m : ℕ) < OfNat.ofNat n :=
-  cast_lt
 
 end OrderedSemiring
 

--- a/Mathlib/Data/Nat/Cast/Order/Ring.lean
+++ b/Mathlib/Data/Nat/Cast/Order/Ring.lean
@@ -32,7 +32,7 @@ theorem cast_nonneg {α} [Semiring α] [PartialOrder α] [IsOrderedRing α] (n :
 
 /-- Specialisation of `Nat.ofNat_nonneg'`, which seems to be easier for Lean to use. -/
 @[simp]
-theorem ofNat_nonneg {α} [Semiring α] [PartialOrder α] [IsOrderedRing α] (n : ℕ) [n.AtLeastTwo] :
+theorem ofNat_nonneg {α} [Semiring α] [PartialOrder α] [IsOrderedRing α] (n : ℕ) :
     0 ≤ (ofNat(n) : α) :=
   ofNat_nonneg' n
 
@@ -89,7 +89,7 @@ variable [Ring R] [LinearOrder R] [IsStrictOrderedRing R] {m n : ℕ} {m n : ℕ
 theorem abs_cast (n : ℕ) : |(n : R)| = n := abs_of_nonneg n.cast_nonneg
 
 @[simp]
-theorem abs_ofNat (n : ℕ) [n.AtLeastTwo] : |(ofNat(n) : R)| = ofNat(n) := abs_cast n
+theorem abs_ofNat (n : ℕ) : |(ofNat(n) : R)| = ofNat(n) := abs_cast n
 
 @[simp, norm_cast] lemma neg_cast_eq_cast : (-m : R) = n ↔ m = 0 ∧ n = 0 := by
   simp [neg_eq_iff_add_eq_zero, ← cast_add]

--- a/Mathlib/Data/Nat/Cast/Prod.lean
+++ b/Mathlib/Data/Nat/Cast/Prod.lean
@@ -27,7 +27,7 @@ instance instAddMonoidWithOne : AddMonoidWithOne (α × β) :=
 theorem fst_natCast (n : ℕ) : (n : α × β).fst = n := by induction n <;> simp [*]
 
 @[simp]
-theorem fst_ofNat (n : ℕ) [n.AtLeastTwo] :
+theorem fst_ofNat (n : ℕ) :
     (ofNat(n) : α × β).1 = (ofNat(n) : α) :=
   rfl
 
@@ -35,7 +35,7 @@ theorem fst_ofNat (n : ℕ) [n.AtLeastTwo] :
 theorem snd_natCast (n : ℕ) : (n : α × β).snd = n := by induction n <;> simp [*]
 
 @[simp]
-theorem snd_ofNat (n : ℕ) [n.AtLeastTwo] :
+theorem snd_ofNat (n : ℕ) :
     (ofNat(n) : α × β).2 = (ofNat(n) : β) :=
   rfl
 

--- a/Mathlib/Data/Nat/Cast/Synonym.lean
+++ b/Mathlib/Data/Nat/Cast/Synonym.lean
@@ -34,7 +34,7 @@ theorem toDual_natCast [NatCast α] (n : ℕ) : toDual (n : α) = n :=
   rfl
 
 @[simp]
-theorem toDual_ofNat [NatCast α] (n : ℕ) [n.AtLeastTwo] :
+theorem toDual_ofNat [NatCast α] (n : ℕ) :
     (toDual (ofNat(n) : α)) = ofNat(n) :=
   rfl
 
@@ -43,7 +43,7 @@ theorem ofDual_natCast [NatCast α] (n : ℕ) : (ofDual n : α) = n :=
   rfl
 
 @[simp]
-theorem ofDual_ofNat [NatCast α] (n : ℕ) [n.AtLeastTwo] :
+theorem ofDual_ofNat [NatCast α] (n : ℕ) :
     (ofDual (ofNat(n) : αᵒᵈ)) = ofNat(n) :=
   rfl
 
@@ -64,7 +64,7 @@ theorem toLex_natCast [NatCast α] (n : ℕ) : toLex (n : α) = n :=
   rfl
 
 @[simp]
-theorem toLex_ofNat [NatCast α] (n : ℕ) [n.AtLeastTwo] :
+theorem toLex_ofNat [NatCast α] (n : ℕ) :
     toLex (ofNat(n) : α) = OfNat.ofNat n :=
   rfl
 
@@ -73,6 +73,6 @@ theorem ofLex_natCast [NatCast α] (n : ℕ) : (ofLex n : α) = n :=
   rfl
 
 @[simp]
-theorem ofLex_ofNat [NatCast α] (n : ℕ) [n.AtLeastTwo] :
+theorem ofLex_ofNat [NatCast α] (n : ℕ) :
     ofLex (ofNat(n) : Lex α) = OfNat.ofNat n :=
   rfl

--- a/Mathlib/Data/Nat/PartENat.lean
+++ b/Mathlib/Data/Nat/PartENat.lean
@@ -115,7 +115,7 @@ theorem dom_natCast (x : ℕ) : (x : PartENat).Dom :=
   trivial
 
 @[simp]
-theorem dom_ofNat (x : ℕ) [x.AtLeastTwo] : (ofNat(x) : PartENat).Dom :=
+theorem dom_ofNat (x : ℕ) : (ofNat(x) : PartENat).Dom :=
   trivial
 
 @[simp]
@@ -189,7 +189,7 @@ theorem get_one (h : (1 : PartENat).Dom) : (1 : PartENat).get h = 1 :=
   rfl
 
 @[simp]
-theorem get_ofNat' (x : ℕ) [x.AtLeastTwo] (h : (ofNat(x) : PartENat).Dom) :
+theorem get_ofNat' (x : ℕ) (h : (ofNat(x) : PartENat).Dom) :
     Part.get (ofNat(x) : PartENat) h = ofNat(x) :=
   get_natCast' x h
 
@@ -324,7 +324,7 @@ theorem one_lt_top : (1 : PartENat) < ⊤ :=
   natCast_lt_top 1
 
 @[simp]
-theorem ofNat_lt_top (x : ℕ) [x.AtLeastTwo] : (ofNat(x) : PartENat) < ⊤ :=
+theorem ofNat_lt_top (x : ℕ) : (ofNat(x) : PartENat) < ⊤ :=
   natCast_lt_top x
 
 @[simp]
@@ -340,7 +340,7 @@ theorem one_ne_top : (1 : PartENat) ≠ ⊤ :=
   natCast_ne_top 1
 
 @[simp]
-theorem ofNat_ne_top (x : ℕ) [x.AtLeastTwo] : (ofNat(x) : PartENat) ≠ ⊤ :=
+theorem ofNat_ne_top (x : ℕ) : (ofNat(x) : PartENat) ≠ ⊤ :=
   natCast_ne_top x
 
 theorem not_isMax_natCast (x : ℕ) : ¬IsMax (x : PartENat) :=
@@ -537,7 +537,7 @@ theorem toWithTop_natCast' (n : ℕ) {_ : Decidable (n : PartENat).Dom} :
   rw [toWithTop_natCast n]
 
 @[simp]
-theorem toWithTop_ofNat (n : ℕ) [n.AtLeastTwo] {_ : Decidable (OfNat.ofNat n : PartENat).Dom} :
+theorem toWithTop_ofNat (n : ℕ) {_ : Decidable (OfNat.ofNat n : PartENat).Dom} :
     toWithTop (ofNat(n) : PartENat) = OfNat.ofNat n := toWithTop_natCast' n
 
 @[simp]
@@ -580,7 +580,7 @@ theorem ofENat_zero : ofENat 0 = 0 := rfl
 theorem ofENat_one : ofENat 1 = 1 := rfl
 
 @[simp, norm_cast]
-theorem ofENat_ofNat (n : Nat) [n.AtLeastTwo] : ofENat ofNat(n) = OfNat.ofNat n :=
+theorem ofENat_ofNat (n : Nat) : ofENat ofNat(n) = OfNat.ofNat n :=
   rfl
 
 @[simp, norm_cast]
@@ -633,7 +633,7 @@ theorem withTopEquiv_zero : withTopEquiv 0 = 0 := by
 theorem withTopEquiv_one : withTopEquiv 1 = 1 := by
   simp
 
-theorem withTopEquiv_ofNat (n : Nat) [n.AtLeastTwo] :
+theorem withTopEquiv_ofNat (n : Nat) :
     withTopEquiv ofNat(n) = OfNat.ofNat n := by
   simp
 
@@ -655,7 +655,7 @@ theorem withTopEquiv_symm_zero : withTopEquiv.symm 0 = 0 := by
 theorem withTopEquiv_symm_one : withTopEquiv.symm 1 = 1 := by
   simp
 
-theorem withTopEquiv_symm_ofNat (n : Nat) [n.AtLeastTwo] :
+theorem withTopEquiv_symm_ofNat (n : Nat) :
     withTopEquiv.symm ofNat(n) = OfNat.ofNat n := by
   simp
 

--- a/Mathlib/Data/Rat/Lemmas.lean
+++ b/Mathlib/Data/Rat/Lemmas.lean
@@ -262,7 +262,7 @@ theorem inv_natCast_num (a : ℕ) : (a : ℚ)⁻¹.num = Int.sign a :=
   inv_intCast_num a
 
 @[simp]
-theorem inv_ofNat_num (a : ℕ) [a.AtLeastTwo] : (ofNat(a) : ℚ)⁻¹.num = 1 :=
+theorem inv_ofNat_num (a : ℕ) [NeZero a] : (ofNat(a) : ℚ)⁻¹.num = 1 :=
   inv_natCast_num_of_pos (Nat.pos_of_neZero a)
 
 @[simp]
@@ -284,7 +284,7 @@ theorem inv_natCast_den (a : ℕ) : (a : ℚ)⁻¹.den = if a = 0 then 1 else a 
   simpa [-inv_intCast_den, ofInt_eq_cast] using inv_intCast_den a
 
 @[simp]
-theorem inv_ofNat_den (a : ℕ) [a.AtLeastTwo] :
+theorem inv_ofNat_den (a : ℕ) [NeZero a] :
     (ofNat(a) : ℚ)⁻¹.den = OfNat.ofNat a :=
   inv_natCast_den_of_pos (Nat.pos_of_neZero a)
 

--- a/Mathlib/Data/Real/Hyperreal.lean
+++ b/Mathlib/Data/Real/Hyperreal.lean
@@ -73,7 +73,7 @@ theorem coe_add (x y : ℝ) : ↑(x + y) = (x + y : ℝ*) :=
   rfl
 
 @[simp, norm_cast]
-theorem coe_ofNat (n : ℕ) [n.AtLeastTwo] :
+theorem coe_ofNat (n : ℕ) :
     ((ofNat(n) : ℝ) : ℝ*) = OfNat.ofNat n :=
   rfl
 

--- a/Mathlib/Data/Real/Irrational.lean
+++ b/Mathlib/Data/Real/Irrational.lean
@@ -122,7 +122,7 @@ theorem irrational_sqrt_natCast_iff {n : ℕ} : Irrational (√n) ↔ ¬IsSquare
   rw [← Rat.isSquare_natCast_iff, ← irrational_sqrt_ratCast_iff_of_nonneg n.cast_nonneg,
     Rat.cast_natCast]
 
-theorem irrational_sqrt_ofNat_iff {n : ℕ} [n.AtLeastTwo] :
+theorem irrational_sqrt_ofNat_iff {n : ℕ} :
     Irrational √(ofNat(n)) ↔ ¬IsSquare ofNat(n) :=
   irrational_sqrt_natCast_iff
 
@@ -140,7 +140,7 @@ unseal Nat.sqrt.iter in
 example : Irrational √24 := by decide
 ```
 -/
-instance {n : ℕ} [n.AtLeastTwo] : Decidable (Irrational √(ofNat(n))) :=
+instance {n : ℕ} : Decidable (Irrational √(ofNat(n))) :=
   decidable_of_iff' _ irrational_sqrt_ofNat_iff
 
 instance (n : ℕ) : Decidable (Irrational (√n)) :=
@@ -181,7 +181,7 @@ theorem ne_zero (h : Irrational x) : x ≠ 0 := mod_cast h.ne_nat 0
 
 theorem ne_one (h : Irrational x) : x ≠ 1 := by simpa only [Nat.cast_one] using h.ne_nat 1
 
-@[simp] theorem ne_ofNat (h : Irrational x) (n : ℕ) [n.AtLeastTwo] : x ≠ ofNat(n) :=
+@[simp] theorem ne_ofNat (h : Irrational x) (n : ℕ) : x ≠ ofNat(n) :=
   h.ne_nat n
 
 end Irrational
@@ -195,7 +195,7 @@ theorem Int.not_irrational (m : ℤ) : ¬Irrational m := fun h => h.ne_int m rfl
 @[simp]
 theorem Nat.not_irrational (m : ℕ) : ¬Irrational m := fun h => h.ne_nat m rfl
 
-@[simp] theorem not_irrational_ofNat (n : ℕ) [n.AtLeastTwo] : ¬Irrational ofNat(n) :=
+@[simp] theorem not_irrational_ofNat (n : ℕ) : ¬Irrational ofNat(n) :=
   n.not_irrational
 namespace Irrational
 

--- a/Mathlib/Data/ZMod/Basic.lean
+++ b/Mathlib/Data/ZMod/Basic.lean
@@ -88,9 +88,9 @@ theorem val_natCast (n a : ℕ) : (a : ZMod n).val = a % n := by
 lemma val_natCast_of_lt {n a : ℕ} (h : a < n) : (a : ZMod n).val = a := by
   rwa [val_natCast, Nat.mod_eq_of_lt]
 
-lemma val_ofNat (n a : ℕ) [a.AtLeastTwo] : (ofNat(a) : ZMod n).val = ofNat(a) % n := val_natCast ..
+lemma val_ofNat (n a : ℕ) : (ofNat(a) : ZMod n).val = ofNat(a) % n := val_natCast ..
 
-lemma val_ofNat_of_lt {n a : ℕ} [a.AtLeastTwo] (han : a < n) : (ofNat(a) : ZMod n).val = ofNat(a) :=
+lemma val_ofNat_of_lt {n a : ℕ} (han : a < n) : (ofNat(a) : ZMod n).val = ofNat(a) :=
   val_natCast_of_lt han
 
 theorem val_unit' {n : ZMod 0} : IsUnit n ↔ n.val = 1 := by

--- a/Mathlib/Data/ZMod/IntUnitsPower.lean
+++ b/Mathlib/Data/ZMod/IntUnitsPower.lean
@@ -73,7 +73,7 @@ example : Int.instUnitsPow = DivInvMonoid.toZPow := rfl
   change ((n : R) • Additive.ofMul u).toMul = _
   rw [Nat.cast_smul_eq_nsmul, toMul_nsmul, toMul_ofMul]
 
-lemma uzpow_coe_nat (s : ℤˣ) (n : ℕ) [n.AtLeastTwo] :
+lemma uzpow_coe_nat (s : ℤˣ) (n : ℕ) :
     s ^ (ofNat(n) : R) = s ^ (ofNat(n) : ℕ) :=
   uzpow_natCast _ _
 

--- a/Mathlib/Geometry/Manifold/IsManifold/Basic.lean
+++ b/Mathlib/Geometry/Manifold/IsManifold/Basic.lean
@@ -724,7 +724,7 @@ class _root_.ENat.LEInfty (m : WithTop ℕ∞) where
 open ENat
 
 instance (n : ℕ) : LEInfty (n : WithTop ℕ∞) := ⟨mod_cast le_top⟩
-instance (n : ℕ) [n.AtLeastTwo] : LEInfty (no_index (OfNat.ofNat n) : WithTop ℕ∞) :=
+instance (n : ℕ) : LEInfty (no_index (OfNat.ofNat n) : WithTop ℕ∞) :=
   inferInstanceAs (LEInfty (n : WithTop ℕ∞))
 instance : LEInfty (1 : WithTop ℕ∞) := inferInstanceAs (LEInfty ((1 : ℕ) : WithTop ℕ∞))
 instance : LEInfty (0 : WithTop ℕ∞) := inferInstanceAs (LEInfty ((0 : ℕ) : WithTop ℕ∞))

--- a/Mathlib/Geometry/Manifold/VectorField/Pullback.lean
+++ b/Mathlib/Geometry/Manifold/VectorField/Pullback.lean
@@ -60,7 +60,7 @@ variable {𝕜 : Type*} [NontriviallyNormedField 𝕜]
   {M'' : Type*} [TopologicalSpace M''] [ChartedSpace H'' M'']
   {f : M → M'} {s t : Set M} {x x₀ : M}
 
-instance {n : ℕ} [n.AtLeastTwo] [IsManifold I (minSmoothness 𝕜 (ofNat(n))) M] :
+instance {n : ℕ} [IsManifold I (minSmoothness 𝕜 (ofNat(n))) M] :
     IsManifold I (ofNat(n)) M :=
   IsManifold.of_le (n := minSmoothness 𝕜 n) le_minSmoothness
 

--- a/Mathlib/LinearAlgebra/Dimension/Finrank.lean
+++ b/Mathlib/LinearAlgebra/Dimension/Finrank.lean
@@ -65,8 +65,8 @@ theorem finrank_eq_of_rank_eq {n : ℕ} (h : Module.rank R M = ↑n) : finrank R
 lemma rank_eq_one_iff_finrank_eq_one : Module.rank R M = 1 ↔ finrank R M = 1 :=
   Cardinal.toNat_eq_one.symm
 
-/-- This is like `rank_eq_one_iff_finrank_eq_one` but works for `2`, `3`, `4`, ... -/
-lemma rank_eq_ofNat_iff_finrank_eq_ofNat (n : ℕ) [Nat.AtLeastTwo n] :
+/-- This is like `rank_eq_one_iff_finrank_eq_one` but works for `1`, `2`, `3`, `4`, ... -/
+lemma rank_eq_ofNat_iff_finrank_eq_ofNat (n : ℕ) [NeZero n] :
     Module.rank R M = OfNat.ofNat n ↔ finrank R M = OfNat.ofNat n :=
   Cardinal.toNat_eq_ofNat.symm
 

--- a/Mathlib/LinearAlgebra/Matrix/PosDef.lean
+++ b/Mathlib/LinearAlgebra/Matrix/PosDef.lean
@@ -108,7 +108,7 @@ protected theorem natCast [StarOrderedRing R] [DecidableEq n] (d : ℕ) :
     rw [Nat.cast_smul_eq_nsmul]
     exact nsmul_nonneg (dotProduct_star_self_nonneg _) _⟩
 
-protected theorem ofNat [StarOrderedRing R] [DecidableEq n] (d : ℕ) [d.AtLeastTwo] :
+protected theorem ofNat [StarOrderedRing R] [DecidableEq n] (d : ℕ) :
     PosSemidef (ofNat(d) : Matrix n n R) :=
   .natCast d
 
@@ -386,7 +386,7 @@ theorem _root_.Matrix.posDef_natCast_iff [StarOrderedRing R] [DecidableEq n] [No
   posDef_diagonal_iff.trans <| by simp
 
 protected theorem ofNat [StarOrderedRing R] [DecidableEq n] [NoZeroDivisors R]
-    (d : ℕ) [d.AtLeastTwo] :
+    (d : ℕ) [NeZero d]:
     PosDef (ofNat(d) : Matrix n n R) :=
   .natCast d (NeZero.ne _)
 

--- a/Mathlib/MeasureTheory/Function/ConditionalExpectation/Basic.lean
+++ b/Mathlib/MeasureTheory/Function/ConditionalExpectation/Basic.lean
@@ -452,7 +452,7 @@ section NormedRing
 variable {R : Type*} [NormedRing R] [NormedSpace ℝ R] [CompleteSpace R]
 
 @[simp]
-lemma condExp_ofNat (n : ℕ) [n.AtLeastTwo] (f : α → R) :
+lemma condExp_ofNat (n : ℕ) (f : α → R) :
     μ[ofNat(n) * f|m] =ᵐ[μ] ofNat(n) * μ[f|m] := by
   simpa [Nat.cast_smul_eq_nsmul] using condExp_smul (μ := μ) (m := m) (n : ℝ) f
 

--- a/Mathlib/NumberTheory/LucasLehmer.lean
+++ b/Mathlib/NumberTheory/LucasLehmer.lean
@@ -264,11 +264,11 @@ instance : NatCast (X q) where
 
 @[simp] theorem snd_natCast (n : ℕ) : (n : X q).snd = (0 : ZMod q) := rfl
 
-@[simp] theorem ofNat_fst (n : ℕ) [n.AtLeastTwo] :
+@[simp] theorem ofNat_fst (n : ℕ) :
     (ofNat(n) : X q).fst = OfNat.ofNat n :=
   rfl
 
-@[simp] theorem ofNat_snd (n : ℕ) [n.AtLeastTwo] :
+@[simp] theorem ofNat_snd (n : ℕ) :
     (ofNat(n) : X q).snd = 0 :=
   rfl
 

--- a/Mathlib/NumberTheory/Padics/PadicNumbers.lean
+++ b/Mathlib/NumberTheory/Padics/PadicNumbers.lean
@@ -970,7 +970,7 @@ lemma valuation_natCast (n : ℕ) : valuation (n : ℚ_[p]) = padicValNat p n :=
   rw [← Rat.cast_natCast, valuation_ratCast, padicValRat.of_nat]
 
 @[simp]
-lemma valuation_ofNat (n : ℕ) [n.AtLeastTwo] :
+lemma valuation_ofNat (n : ℕ) :
     valuation (ofNat(n) : ℚ_[p]) = padicValNat p n :=
   valuation_natCast n
 

--- a/Mathlib/NumberTheory/Zsqrtd/Basic.lean
+++ b/Mathlib/NumberTheory/Zsqrtd/Basic.lean
@@ -232,7 +232,7 @@ theorem natCast_re (n : ℕ) : (n : ℤ√d).re = n :=
   rfl
 
 @[simp]
-theorem ofNat_re (n : ℕ) [n.AtLeastTwo] : (ofNat(n) : ℤ√d).re = n :=
+theorem ofNat_re (n : ℕ) : (ofNat(n) : ℤ√d).re = n :=
   rfl
 
 @[simp]
@@ -240,7 +240,7 @@ theorem natCast_im (n : ℕ) : (n : ℤ√d).im = 0 :=
   rfl
 
 @[simp]
-theorem ofNat_im (n : ℕ) [n.AtLeastTwo] : (ofNat(n) : ℤ√d).im = 0 :=
+theorem ofNat_im (n : ℕ) : (ofNat(n) : ℤ√d).im = 0 :=
   rfl
 
 theorem natCast_val (n : ℕ) : (n : ℤ√d) = ⟨n, 0⟩ :=

--- a/Mathlib/Order/Filter/Germ/Basic.lean
+++ b/Mathlib/Order/Filter/Germ/Basic.lean
@@ -429,12 +429,12 @@ theorem natCast_def [NatCast M] (n : ℕ) : ((fun _ ↦ n : α → M) : Germ l M
 theorem const_nat [NatCast M] (n : ℕ) : ((n : M) : Germ l M) = n := rfl
 
 @[simp, norm_cast]
-theorem coe_ofNat [NatCast M] (n : ℕ) [n.AtLeastTwo] :
+theorem coe_ofNat [NatCast M] (n : ℕ) :
     ((ofNat(n) : α → M) : Germ l M) = OfNat.ofNat n :=
   rfl
 
 @[simp, norm_cast]
-theorem const_ofNat [NatCast M] (n : ℕ) [n.AtLeastTwo] :
+theorem const_ofNat [NatCast M] (n : ℕ) :
     ((ofNat(n) : M) : Germ l M) = OfNat.ofNat n :=
   rfl
 

--- a/Mathlib/RingTheory/Multiplicity.lean
+++ b/Mathlib/RingTheory/Multiplicity.lean
@@ -353,7 +353,7 @@ theorem FiniteMultiplicity.multiplicity_eq_iff (hf : FiniteMultiplicity a b) {n 
     multiplicity a b = n ↔ a ^ n ∣ b ∧ ¬a ^ (n + 1) ∣ b := by
   simp [← emultiplicity_eq_coe, hf.emultiplicity_eq_multiplicity]
 
-theorem emultiplicity_eq_ofNat {a b n : ℕ} [n.AtLeastTwo] :
+theorem emultiplicity_eq_ofNat {a b n : ℕ} :
     emultiplicity a b = (ofNat(n) : ℕ∞) ↔ a ^ ofNat(n) ∣ b ∧ ¬a ^ (ofNat(n) + 1) ∣ b :=
   emultiplicity_eq_coe
 

--- a/Mathlib/SetTheory/Cardinal/Aleph.lean
+++ b/Mathlib/SetTheory/Cardinal/Aleph.lean
@@ -141,7 +141,7 @@ theorem preOmega_natCast (n : ℕ) : preOmega n = n := by
     exact lt_succ n
 
 @[simp]
-theorem preOmega_ofNat (n : ℕ) [n.AtLeastTwo] : preOmega ofNat(n) = n :=
+theorem preOmega_ofNat (n : ℕ) : preOmega ofNat(n) = n :=
   preOmega_natCast n
 
 theorem preOmega_le_of_forall_lt {o a : Ordinal} (ha : IsInitial a) (H : ∀ b < o, preOmega b < a) :

--- a/Mathlib/SetTheory/Cardinal/Basic.lean
+++ b/Mathlib/SetTheory/Cardinal/Basic.lean
@@ -564,11 +564,11 @@ theorem nat_mul_aleph0 {n : ℕ} (hn : n ≠ 0) : ↑n * ℵ₀ = ℵ₀ :=
 theorem aleph0_mul_nat {n : ℕ} (hn : n ≠ 0) : ℵ₀ * n = ℵ₀ := by rw [mul_comm, nat_mul_aleph0 hn]
 
 @[simp]
-theorem ofNat_mul_aleph0 {n : ℕ} [Nat.AtLeastTwo n] : ofNat(n) * ℵ₀ = ℵ₀ :=
+theorem ofNat_mul_aleph0 {n : ℕ} [NeZero n] : ofNat(n) * ℵ₀ = ℵ₀ :=
   nat_mul_aleph0 (NeZero.ne n)
 
 @[simp]
-theorem aleph0_mul_ofNat {n : ℕ} [Nat.AtLeastTwo n] : ℵ₀ * ofNat(n) = ℵ₀ :=
+theorem aleph0_mul_ofNat {n : ℕ} [NeZero n] : ℵ₀ * ofNat(n) = ℵ₀ :=
   aleph0_mul_nat (NeZero.ne n)
 
 @[simp]
@@ -584,11 +584,11 @@ theorem aleph0_add_nat (n : ℕ) : ℵ₀ + n = ℵ₀ :=
 theorem nat_add_aleph0 (n : ℕ) : ↑n + ℵ₀ = ℵ₀ := by rw [add_comm, aleph0_add_nat]
 
 @[simp]
-theorem ofNat_add_aleph0 {n : ℕ} [Nat.AtLeastTwo n] : ofNat(n) + ℵ₀ = ℵ₀ :=
+theorem ofNat_add_aleph0 {n : ℕ} : ofNat(n) + ℵ₀ = ℵ₀ :=
   nat_add_aleph0 n
 
 @[simp]
-theorem aleph0_add_ofNat {n : ℕ} [Nat.AtLeastTwo n] : ℵ₀ + ofNat(n) = ℵ₀ :=
+theorem aleph0_add_ofNat {n : ℕ} : ℵ₀ + ofNat(n) = ℵ₀ :=
   aleph0_add_nat n
 
 theorem exists_nat_eq_of_le_nat {c : Cardinal} {n : ℕ} (h : c ≤ n) : ∃ m, m ≤ n ∧ c = m := by

--- a/Mathlib/SetTheory/Cardinal/Continuum.lean
+++ b/Mathlib/SetTheory/Cardinal/Continuum.lean
@@ -116,11 +116,11 @@ theorem continuum_add_nat (n : ℕ) : 𝔠 + n = 𝔠 :=
   (add_comm _ _).trans (nat_add_continuum n)
 
 @[simp]
-theorem ofNat_add_continuum {n : ℕ} [Nat.AtLeastTwo n] : ofNat(n) + 𝔠 = 𝔠 :=
+theorem ofNat_add_continuum {n : ℕ} : ofNat(n) + 𝔠 = 𝔠 :=
   nat_add_continuum n
 
 @[simp]
-theorem continuum_add_ofNat {n : ℕ} [Nat.AtLeastTwo n] : 𝔠 + ofNat(n) = 𝔠 :=
+theorem continuum_add_ofNat {n : ℕ} : 𝔠 + ofNat(n) = 𝔠 :=
   continuum_add_nat n
 
 /-!
@@ -149,12 +149,12 @@ theorem continuum_mul_nat {n : ℕ} (hn : n ≠ 0) : 𝔠 * n = 𝔠 :=
   (mul_comm _ _).trans (nat_mul_continuum hn)
 
 @[simp]
-theorem ofNat_mul_continuum {n : ℕ} [Nat.AtLeastTwo n] : ofNat(n) * 𝔠 = 𝔠 :=
-  nat_mul_continuum (OfNat.ofNat_ne_zero n)
+theorem ofNat_mul_continuum {n : ℕ} [NeZero n] : ofNat(n) * 𝔠 = 𝔠 :=
+  nat_mul_continuum (NeZero.ne n)
 
 @[simp]
-theorem continuum_mul_ofNat {n : ℕ} [Nat.AtLeastTwo n] : 𝔠 * ofNat(n) = 𝔠 :=
-  continuum_mul_nat (OfNat.ofNat_ne_zero n)
+theorem continuum_mul_ofNat {n : ℕ} [NeZero n] : 𝔠 * ofNat(n) = 𝔠 :=
+  continuum_mul_nat (NeZero.ne n)
 
 /-!
 ### Power

--- a/Mathlib/SetTheory/Cardinal/ENat.lean
+++ b/Mathlib/SetTheory/Cardinal/ENat.lean
@@ -49,7 +49,7 @@ instance : Coe ENat Cardinal := ⟨Cardinal.ofENat⟩
 @[simp, norm_cast] lemma ofENat_zero : ofENat 0 = 0 := rfl
 @[simp, norm_cast] lemma ofENat_one : ofENat 1 = 1 := rfl
 
-@[simp, norm_cast] lemma ofENat_ofNat (n : ℕ) [n.AtLeastTwo] :
+@[simp, norm_cast] lemma ofENat_ofNat (n : ℕ) :
     ((ofNat(n) : ℕ∞) : Cardinal) = OfNat.ofNat n :=
   rfl
 
@@ -68,14 +68,14 @@ lemma ofENat_lt_aleph0 {m : ℕ∞} : (m : Cardinal) < ℵ₀ ↔ m < ⊤ :=
 
 @[simp] lemma ofENat_lt_nat {m : ℕ∞} {n : ℕ} : ofENat m < n ↔ m < n := by norm_cast
 
-@[simp] lemma ofENat_lt_ofNat {m : ℕ∞} {n : ℕ} [n.AtLeastTwo] :
+@[simp] lemma ofENat_lt_ofNat {m : ℕ∞} {n : ℕ} :
     ofENat m < ofNat(n) ↔ m < OfNat.ofNat n := ofENat_lt_nat
 
 @[simp] lemma nat_lt_ofENat {m : ℕ} {n : ℕ∞} : (m : Cardinal) < n ↔ m < n := by norm_cast
 @[simp] lemma ofENat_pos {m : ℕ∞} : 0 < (m : Cardinal) ↔ 0 < m := by norm_cast
 @[simp] lemma one_lt_ofENat {m : ℕ∞} : 1 < (m : Cardinal) ↔ 1 < m := by norm_cast
 
-@[simp, norm_cast] lemma ofNat_lt_ofENat {m : ℕ} [m.AtLeastTwo] {n : ℕ∞} :
+@[simp, norm_cast] lemma ofNat_lt_ofENat {m : ℕ} {n : ℕ∞} :
   (ofNat(m) : Cardinal) < n ↔ OfNat.ofNat m < n := nat_lt_ofENat
 
 lemma ofENat_mono : Monotone ofENat := ofENat_strictMono.monotone
@@ -89,14 +89,14 @@ lemma ofENat_le_ofENat {m n : ℕ∞} : (m : Cardinal) ≤ n ↔ m ≤ n := ofEN
 @[simp] lemma ofENat_le_nat {m : ℕ∞} {n : ℕ} : ofENat m ≤ n ↔ m ≤ n := by norm_cast
 @[simp] lemma ofENat_le_one {m : ℕ∞} : ofENat m ≤ 1 ↔ m ≤ 1 := by norm_cast
 
-@[simp] lemma ofENat_le_ofNat {m : ℕ∞} {n : ℕ} [n.AtLeastTwo] :
+@[simp] lemma ofENat_le_ofNat {m : ℕ∞} {n : ℕ} :
     ofENat m ≤ ofNat(n) ↔ m ≤ OfNat.ofNat n := ofENat_le_nat
 
 @[simp] lemma nat_le_ofENat {m : ℕ} {n : ℕ∞} : (m : Cardinal) ≤ n ↔ m ≤ n := by norm_cast
 @[simp] lemma one_le_ofENat {n : ℕ∞} : 1 ≤ (n : Cardinal) ↔ 1 ≤ n := by norm_cast
 
 @[simp]
-lemma ofNat_le_ofENat {m : ℕ} [m.AtLeastTwo] {n : ℕ∞} :
+lemma ofNat_le_ofENat {m : ℕ} {n : ℕ∞} :
     (ofNat(m) : Cardinal) ≤ n ↔ OfNat.ofNat m ≤ n := nat_le_ofENat
 
 lemma ofENat_injective : Injective ofENat := ofENat_strictMono.injective
@@ -113,10 +113,10 @@ lemma ofENat_inj {m n : ℕ∞} : (m : Cardinal) = n ↔ m = n := ofENat_injecti
 @[simp] lemma ofENat_eq_one {m : ℕ∞} : (m : Cardinal) = 1 ↔ m = 1 := by norm_cast
 @[simp] lemma one_eq_ofENat {m : ℕ∞} : 1 = (m : Cardinal) ↔ m = 1 := by norm_cast; apply eq_comm
 
-@[simp] lemma ofENat_eq_ofNat {m : ℕ∞} {n : ℕ} [n.AtLeastTwo] :
+@[simp] lemma ofENat_eq_ofNat {m : ℕ∞} {n : ℕ} :
     (m : Cardinal) = ofNat(n) ↔ m = OfNat.ofNat n := ofENat_eq_nat
 
-@[simp] lemma ofNat_eq_ofENat {m : ℕ} {n : ℕ∞} [m.AtLeastTwo] :
+@[simp] lemma ofNat_eq_ofENat {m : ℕ} {n : ℕ∞} :
     ofNat(m) = (n : Cardinal) ↔ OfNat.ofNat m = n := nat_eq_ofENat
 
 @[simp, norm_cast] lemma lift_ofENat : ∀ m : ℕ∞, lift.{u, v} m = m
@@ -248,10 +248,10 @@ lemma toENat_nat (n : ℕ) : toENat n = n := map_natCast _ n
 @[simp] lemma toENat_le_one {a : Cardinal} : toENat a ≤ 1 ↔ a ≤ 1 := toENat_le_nat
 @[simp] lemma toENat_eq_one {a : Cardinal} : toENat a = 1 ↔ a = 1 := toENat_eq_nat
 
-@[simp] lemma toENat_le_ofNat {a : Cardinal} {n : ℕ} [n.AtLeastTwo] :
+@[simp] lemma toENat_le_ofNat {a : Cardinal} {n : ℕ} :
     toENat a ≤ ofNat(n) ↔ a ≤ OfNat.ofNat n := toENat_le_nat
 
-@[simp] lemma toENat_eq_ofNat {a : Cardinal} {n : ℕ} [n.AtLeastTwo] :
+@[simp] lemma toENat_eq_ofNat {a : Cardinal} {n : ℕ} :
     toENat a = ofNat(n) ↔ a = OfNat.ofNat n := toENat_eq_nat
 
 @[simp] lemma toENat_eq_top {a : Cardinal} : toENat a = ⊤ ↔ ℵ₀ ≤ a := enat_gc.u_eq_top

--- a/Mathlib/SetTheory/Cardinal/Order.lean
+++ b/Mathlib/SetTheory/Cardinal/Order.lean
@@ -631,7 +631,7 @@ theorem mk_fin (n : ℕ) : #(Fin n) = n := by simp
 theorem lift_natCast (n : ℕ) : lift.{u} (n : Cardinal.{v}) = n := by induction n <;> simp [*]
 
 @[simp]
-theorem lift_ofNat (n : ℕ) [n.AtLeastTwo] :
+theorem lift_ofNat (n : ℕ) :
     lift.{u} (ofNat(n) : Cardinal.{v}) = OfNat.ofNat n :=
   lift_natCast n
 
@@ -640,7 +640,7 @@ theorem lift_eq_nat_iff {a : Cardinal.{u}} {n : ℕ} : lift.{v} a = n ↔ a = n 
   lift_injective.eq_iff' (lift_natCast n)
 
 @[simp]
-theorem lift_eq_ofNat_iff {a : Cardinal.{u}} {n : ℕ} [n.AtLeastTwo] :
+theorem lift_eq_ofNat_iff {a : Cardinal.{u}} {n : ℕ} :
     lift.{v} a = ofNat(n) ↔ a = OfNat.ofNat n :=
   lift_eq_nat_iff
 
@@ -660,7 +660,7 @@ theorem one_eq_lift_iff {a : Cardinal.{u}} :
   simpa using nat_eq_lift_iff (n := 1)
 
 @[simp]
-theorem ofNat_eq_lift_iff {a : Cardinal.{u}} {n : ℕ} [n.AtLeastTwo] :
+theorem ofNat_eq_lift_iff {a : Cardinal.{u}} {n : ℕ} :
     (ofNat(n) : Cardinal) = lift.{v} a ↔ (OfNat.ofNat n : Cardinal) = a :=
   nat_eq_lift_iff
 
@@ -674,7 +674,7 @@ theorem lift_le_one_iff {a : Cardinal.{u}} :
   simpa using lift_le_nat_iff (n := 1)
 
 @[simp]
-theorem lift_le_ofNat_iff {a : Cardinal.{u}} {n : ℕ} [n.AtLeastTwo] :
+theorem lift_le_ofNat_iff {a : Cardinal.{u}} {n : ℕ} :
     lift.{v} a ≤ ofNat(n) ↔ a ≤ OfNat.ofNat n :=
   lift_le_nat_iff
 
@@ -688,7 +688,7 @@ theorem one_le_lift_iff {a : Cardinal.{u}} :
   simpa using nat_le_lift_iff (n := 1)
 
 @[simp]
-theorem ofNat_le_lift_iff {a : Cardinal.{u}} {n : ℕ} [n.AtLeastTwo] :
+theorem ofNat_le_lift_iff {a : Cardinal.{u}} {n : ℕ} :
     (ofNat(n) : Cardinal) ≤ lift.{v} a ↔ (OfNat.ofNat n : Cardinal) ≤ a :=
   nat_le_lift_iff
 
@@ -697,7 +697,7 @@ theorem lift_lt_nat_iff {a : Cardinal.{u}} {n : ℕ} : lift.{v} a < n ↔ a < n 
   rw [← lift_natCast.{v,u}, lift_lt]
 
 @[simp]
-theorem lift_lt_ofNat_iff {a : Cardinal.{u}} {n : ℕ} [n.AtLeastTwo] :
+theorem lift_lt_ofNat_iff {a : Cardinal.{u}} {n : ℕ} :
     lift.{v} a < ofNat(n) ↔ a < OfNat.ofNat n :=
   lift_lt_nat_iff
 
@@ -716,7 +716,7 @@ theorem one_lt_lift_iff {a : Cardinal.{u}} :
   simpa using nat_lt_lift_iff (n := 1)
 
 @[simp]
-theorem ofNat_lt_lift_iff {a : Cardinal.{u}} {n : ℕ} [n.AtLeastTwo] :
+theorem ofNat_lt_lift_iff {a : Cardinal.{u}} {n : ℕ} :
     (ofNat(n) : Cardinal) < lift.{v} a ↔ (OfNat.ofNat n : Cardinal) < a :=
   nat_lt_lift_iff
 

--- a/Mathlib/SetTheory/Cardinal/ToNat.lean
+++ b/Mathlib/SetTheory/Cardinal/ToNat.lean
@@ -95,7 +95,7 @@ theorem toNat_lt_toNat (hcd : c < d) (hd : d < ℵ₀) : toNat c < toNat d :=
   toNat_strictMonoOn (hcd.trans hd) hd hcd
 
 @[simp]
-theorem toNat_ofNat (n : ℕ) [n.AtLeastTwo] :
+theorem toNat_ofNat (n : ℕ) :
     Cardinal.toNat ofNat(n) = OfNat.ofNat n :=
   toNat_natCast n
 
@@ -124,9 +124,9 @@ theorem toNat_eq_iff {n : ℕ} (hn : n ≠ 0) : toNat c = n ↔ c = n := by
   rw [← toNat_toENat, ENat.toNat_eq_iff hn, toENat_eq_nat]
 
 /-- A version of `toNat_eq_iff` for literals -/
-theorem toNat_eq_ofNat {n : ℕ} [Nat.AtLeastTwo n] :
+theorem toNat_eq_ofNat {n : ℕ} [NeZero n] :
     toNat c = OfNat.ofNat n ↔ c = OfNat.ofNat n :=
-  toNat_eq_iff <| OfNat.ofNat_ne_zero n
+  toNat_eq_iff <| NeZero.ne n
 
 @[simp]
 theorem toNat_eq_one : toNat c = 1 ↔ c = 1 := by

--- a/Mathlib/SetTheory/Game/Birthday.lean
+++ b/Mathlib/SetTheory/Game/Birthday.lean
@@ -217,7 +217,7 @@ theorem birthday_natCast (n : ℕ) : birthday n = n := by
   exact birthday_ordinalToGame _
 
 @[simp]
-theorem birthday_ofNat (n : ℕ) [n.AtLeastTwo] :
+theorem birthday_ofNat (n : ℕ) :
     birthday ofNat(n) = OfNat.ofNat n :=
   birthday_natCast n
 

--- a/Mathlib/SetTheory/Game/Short.lean
+++ b/Mathlib/SetTheory/Game/Short.lean
@@ -209,7 +209,7 @@ instance shortNat : ∀ n : ℕ, Short n
   | 0 => PGame.short0
   | n + 1 => @PGame.shortAdd _ _ (shortNat n) PGame.short1
 
-instance shortOfNat (n : ℕ) [Nat.AtLeastTwo n] : Short ofNat(n) := shortNat n
+instance shortOfNat (n : ℕ) : Short ofNat(n) := shortNat n
 
 instance shortBit0 (x : PGame.{u}) [Short x] : Short (x + x) := by infer_instance
 

--- a/Mathlib/SetTheory/Ordinal/Arithmetic.lean
+++ b/Mathlib/SetTheory/Ordinal/Arithmetic.lean
@@ -1070,7 +1070,7 @@ theorem one_add_natCast (m : ℕ) : 1 + (m : Ordinal) = succ m := by
   rfl
 
 @[simp]
-theorem one_add_ofNat (m : ℕ) [m.AtLeastTwo] :
+theorem one_add_ofNat (m : ℕ) :
     1 + (ofNat(m) : Ordinal) = Order.succ (OfNat.ofNat m : Ordinal) :=
   one_add_natCast m
 
@@ -1127,7 +1127,7 @@ theorem lift_natCast : ∀ n : ℕ, lift.{u, v} n = n
   | n + 1 => by simp [lift_natCast n]
 
 @[simp]
-theorem lift_ofNat (n : ℕ) [n.AtLeastTwo] :
+theorem lift_ofNat (n : ℕ) :
     lift.{u, v} ofNat(n) = OfNat.ofNat n :=
   lift_natCast n
 

--- a/Mathlib/SetTheory/Ordinal/Basic.lean
+++ b/Mathlib/SetTheory/Ordinal/Basic.lean
@@ -842,7 +842,7 @@ theorem card_nat (n : ℕ) : card.{u} n = n := by
   induction n <;> [simp; simp only [card_add, card_one, Nat.cast_succ, *]]
 
 @[simp]
-theorem card_ofNat (n : ℕ) [n.AtLeastTwo] :
+theorem card_ofNat (n : ℕ) :
     card.{u} ofNat(n) = OfNat.ofNat n :=
   card_nat n
 
@@ -1153,7 +1153,7 @@ theorem ord_nat (n : ℕ) : ord n = n :=
 theorem ord_one : ord 1 = 1 := by simpa using ord_nat 1
 
 @[simp]
-theorem ord_ofNat (n : ℕ) [n.AtLeastTwo] : ord ofNat(n) = OfNat.ofNat n :=
+theorem ord_ofNat (n : ℕ) : ord ofNat(n) = OfNat.ofNat n :=
   ord_nat n
 
 @[simp]
@@ -1350,7 +1350,7 @@ theorem card_lt_nat {o} {n : ℕ} : card o < n ↔ o < n :=
   lt_iff_lt_of_le_iff_le nat_le_card
 
 @[simp]
-theorem card_lt_ofNat {o} {n : ℕ} [n.AtLeastTwo] :
+theorem card_lt_ofNat {o} {n : ℕ} :
     card o < ofNat(n) ↔ o < OfNat.ofNat n :=
   card_lt_nat
 
@@ -1363,7 +1363,7 @@ theorem card_le_one {o} : card o ≤ 1 ↔ o ≤ 1 := by
   simpa using card_le_nat (n := 1)
 
 @[simp]
-theorem card_le_ofNat {o} {n : ℕ} [n.AtLeastTwo] :
+theorem card_le_ofNat {o} {n : ℕ} :
     card o ≤ ofNat(n) ↔ o ≤ OfNat.ofNat n :=
   card_le_nat
 
@@ -1390,7 +1390,7 @@ theorem lift_down' {a : Cardinal.{u}} {b : Ordinal.{max u v}}
   mem_range_lift_of_card_le h
 
 @[simp]
-theorem card_eq_ofNat {o} {n : ℕ} [n.AtLeastTwo] :
+theorem card_eq_ofNat {o} {n : ℕ} :
     card o = ofNat(n) ↔ o = OfNat.ofNat n :=
   card_eq_nat
 

--- a/Mathlib/Tactic/ENatToNat.lean
+++ b/Mathlib/Tactic/ENatToNat.lean
@@ -38,7 +38,7 @@ attribute [enat_to_nat_top] top_add ENat.sub_top ENat.top_sub_coe ENat.mul_top E
 @[enat_to_nat_coe] lemma coe_mul (m n : ℕ) :
     (m : ENat) * (n : ENat) = ((m * n : ℕ) : ENat) := rfl
 
-@[enat_to_nat_coe] lemma coe_ofNat (n : ℕ) [n.AtLeastTwo] :
+@[enat_to_nat_coe] lemma coe_ofNat (n : ℕ) :
     (OfNat.ofNat n : ENat) = (OfNat.ofNat n : ℕ) := rfl
 
 @[enat_to_nat_coe] lemma coe_zero : (0 : ENat) = ((0 : ℕ) : ENat) := rfl

--- a/Mathlib/Topology/Algebra/Module/LinearMap.lean
+++ b/Mathlib/Topology/Algebra/Module/LinearMap.lean
@@ -530,7 +530,7 @@ theorem natCast_apply [ContinuousAdd M₁] (n : ℕ) (m : M₁) : (↑n : M₁ �
   rfl
 
 @[simp]
-theorem ofNat_apply [ContinuousAdd M₁] (n : ℕ) [n.AtLeastTwo] (m : M₁) :
+theorem ofNat_apply [ContinuousAdd M₁] (n : ℕ) (m : M₁) :
     (ofNat(n) : M₁ →L[R₁] M₁) m = OfNat.ofNat n • m :=
   rfl
 

--- a/Mathlib/Topology/Algebra/SeparationQuotient/Basic.lean
+++ b/Mathlib/Topology/Algebra/SeparationQuotient/Basic.lean
@@ -277,7 +277,7 @@ instance instNatCast [NatCast R] : NatCast (SeparationQuotient R) where
 theorem mk_natCast [NatCast R] (n : ℕ) : mk (n : R) = n := rfl
 
 @[simp]
-theorem mk_ofNat [NatCast R] (n : ℕ) [n.AtLeastTwo] :
+theorem mk_ofNat [NatCast R] (n : ℕ) :
     mk (ofNat(n) : R) = OfNat.ofNat n :=
   rfl
 

--- a/Mathlib/Topology/ContinuousMap/Bounded/Normed.lean
+++ b/Mathlib/Topology/ContinuousMap/Bounded/Normed.lean
@@ -334,7 +334,7 @@ instance : NatCast (α →ᵇ R) :=
 theorem coe_natCast (n : ℕ) : ((n : α →ᵇ R) : α → R) = n := rfl
 
 @[simp, norm_cast]
-theorem coe_ofNat (n : ℕ) [n.AtLeastTwo] :
+theorem coe_ofNat (n : ℕ) :
     ((ofNat(n) : α →ᵇ R) : α → R) = ofNat(n) :=
   rfl
 

--- a/Mathlib/Topology/Instances/ENNReal/Lemmas.lean
+++ b/Mathlib/Topology/Instances/ENNReal/Lemmas.lean
@@ -192,7 +192,7 @@ theorem nhdsGT_coe_neBot {r : ℝ≥0} : (𝓝[>] (r : ℝ≥0∞)).NeBot :=
 @[deprecated (since := "2024-12-22")] alias nhdsWithin_Ioi_nat_neBot := nhdsGT_nat_neBot
 
 @[instance]
-theorem nhdsGT_ofNat_neBot (n : ℕ) [n.AtLeastTwo] : (𝓝[>] (OfNat.ofNat n : ℝ≥0∞)).NeBot :=
+theorem nhdsGT_ofNat_neBot (n : ℕ) : (𝓝[>] (OfNat.ofNat n : ℝ≥0∞)).NeBot :=
   nhdsGT_coe_neBot
 
 @[deprecated (since := "2024-12-22")] alias nhdsWithin_Ioi_ofNat_nebot := nhdsGT_ofNat_neBot


### PR DESCRIPTION
This PR is a follow-up to #23866, demonstrating that we can remove nearly all the `[AtLeastTwo n]` hypotheses across Mathlib.