### PR TITLE
[Merged by Bors] - chore(Algebra/Group/Ext): use hMul rather than mul for group extensionality

### DIFF
--- a/Mathlib/Algebra/Group/Ext.lean
+++ b/Mathlib/Algebra/Group/Ext.lean
@@ -134,7 +134,9 @@ lemma Group.toDivInvMonoid_injective {G : Type*} : Injective (@Group.toDivInvMon
   rintro ⟨⟩ ⟨⟩ ⟨⟩; rfl
 
 @[to_additive (attr := ext)]
-theorem Group.ext {G : Type*} ⦃g₁ g₂ : Group G⦄ (h_mul : g₁.mul = g₂.mul) : g₁ = g₂ := by
+theorem Group.ext {G : Type*} ⦃g₁ g₂ : Group G⦄
+    (h_mul : (letI := g₁; HMul.hMul : G → G → G) = (letI := g₂; HMul.hMul : G → G → G)) :
+    g₁ = g₂ := by
   have h₁ : g₁.one = g₂.one := congr_arg (·.one) (Monoid.ext h_mul)
   let f : @MonoidHom G G g₁.toMulOneClass g₂.toMulOneClass :=
     @MonoidHom.mk _ _ (_) _ (@OneHom.mk _ _ (_) _ id h₁)
@@ -149,5 +151,6 @@ lemma CommGroup.toGroup_injective {G : Type*} : Injective (@CommGroup.toGroup G)
   rintro ⟨⟩ ⟨⟩ ⟨⟩; rfl
 
 @[to_additive (attr := ext)]
-theorem CommGroup.ext {G : Type*} ⦃g₁ g₂ : CommGroup G⦄ (h_mul : g₁.mul = g₂.mul) : g₁ = g₂ :=
+theorem CommGroup.ext {G : Type*} ⦃g₁ g₂ : CommGroup G⦄
+    (h_mul : (letI := g₁; HMul.hMul : G → G → G) = (letI := g₂; HMul.hMul : G → G → G)) : g₁ = g₂ :=
   CommGroup.toGroup_injective <| Group.ext h_mul


### PR DESCRIPTION
Each of the other extensionality principles use hMul rather than mul in this way, as described and explained in the module docstring. However, Group and CommGroup were omitted from this pattern, which is corrected here.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
