### PR TITLE
[Merged by Bors] - chore: miscellaneous style fixes

### DIFF
--- a/Mathlib/Algebra/Group/Pointwise/Finset/BigOperators.lean
+++ b/Mathlib/Algebra/Group/Pointwise/Finset/BigOperators.lean
@@ -37,7 +37,7 @@ variable [CommMonoid α]
 variable [DecidableEq α]
 
 @[to_additive (attr := simp, norm_cast)]
-theorem coe_prod  (s : Finset ι) (f : ι → Finset α) :
+theorem coe_prod (s : Finset ι) (f : ι → Finset α) :
     ↑(∏ i ∈ s, f i) = ∏ i ∈ s, (f i : Set α) :=
   map_prod ((coeMonoidHom) : Finset α →* Set α) _ _
 

--- a/Mathlib/Algebra/Polynomial/ofFn.lean
+++ b/Mathlib/Algebra/Polynomial/ofFn.lean
@@ -101,7 +101,7 @@ theorem injective_ofFn (n : ℕ) : Function.Injective (ofFn (R := R) n) :=
 theorem surjective_toFn (n : ℕ) : Function.Surjective (toFn (R := R) n) :=
   Function.RightInverse.surjective <| toFn_comp_ofFn_eq_id n
 
-theorem ofFn_comp_toFn_eq_id_of_natDegree_lt {n : ℕ} {p : R [X]} (h_deg : p.natDegree < n) :
+theorem ofFn_comp_toFn_eq_id_of_natDegree_lt {n : ℕ} {p : R[X]} (h_deg : p.natDegree < n) :
     ofFn n (toFn n p) = p := by
   ext i
   by_cases h : i < n

--- a/Mathlib/AlgebraicTopology/SimplicialSet/Horn.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/Horn.lean
@@ -79,7 +79,7 @@ open SimplexCategory Finset Opposite
 
 section
 
-variable (n : ℕ) (i k : Fin (n+3))
+variable (n : ℕ) (i k : Fin (n + 3))
 
 /-- The (degenerate) subsimplex of `Λ[n+2, i]` concentrated in vertex `k`. -/
 def const (m : SimplexCategoryᵒᵖ) : Λ[n+2, i].obj m :=

--- a/Mathlib/Analysis/Calculus/FDeriv/Basic.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Basic.lean
@@ -1050,18 +1050,18 @@ theorem hasFDerivAtFilter_const (c : F) (x : E) (L : Filter E) :
 theorem hasFDerivAtFilter_zero (x : E) (L : Filter E) :
     HasFDerivAtFilter (0 : E → F) (0 : E →L[𝕜] F) x L := hasFDerivAtFilter_const _ _ _
 
-theorem hasFDerivAtFilter_one [One F]  (x : E) (L : Filter E) :
+theorem hasFDerivAtFilter_one [One F] (x : E) (L : Filter E) :
     HasFDerivAtFilter (1 : E → F) (0 : E →L[𝕜] F) x L := hasFDerivAtFilter_const _ _ _
 
-theorem hasFDerivAtFilter_natCast [NatCast F] (n : ℕ)  (x : E) (L : Filter E) :
+theorem hasFDerivAtFilter_natCast [NatCast F] (n : ℕ) (x : E) (L : Filter E) :
     HasFDerivAtFilter (n : E → F) (0 : E →L[𝕜] F) x L :=
   hasFDerivAtFilter_const _ _ _
 
-theorem hasFDerivAtFilter_intCast [IntCast F] (z : ℤ)  (x : E) (L : Filter E) :
+theorem hasFDerivAtFilter_intCast [IntCast F] (z : ℤ) (x : E) (L : Filter E) :
     HasFDerivAtFilter (z : E → F) (0 : E →L[𝕜] F) x L :=
   hasFDerivAtFilter_const _ _ _
 
-theorem hasFDerivAtFilter_ofNat (n : ℕ) [OfNat F n]  (x : E) (L : Filter E) :
+theorem hasFDerivAtFilter_ofNat (n : ℕ) [OfNat F n] (x : E) (L : Filter E) :
     HasFDerivAtFilter (ofNat(n) : E → F) (0 : E →L[𝕜] F) x L :=
   hasFDerivAtFilter_const _ _ _
 
@@ -1075,21 +1075,21 @@ theorem hasFDerivWithinAt_zero (x : E) (s : Set E) :
     HasFDerivWithinAt (0 : E → F) (0 : E →L[𝕜] F) s x := hasFDerivWithinAt_const _ _ _
 
 @[fun_prop]
-theorem hasFDerivWithinAt_one [One F]  (x : E) (s : Set E) :
+theorem hasFDerivWithinAt_one [One F] (x : E) (s : Set E) :
     HasFDerivWithinAt (1 : E → F) (0 : E →L[𝕜] F) s x := hasFDerivWithinAt_const _ _ _
 
 @[fun_prop]
-theorem hasFDerivWithinAt_natCast [NatCast F] (n : ℕ)  (x : E) (s : Set E) :
+theorem hasFDerivWithinAt_natCast [NatCast F] (n : ℕ) (x : E) (s : Set E) :
     HasFDerivWithinAt (n : E → F) (0 : E →L[𝕜] F) s x :=
   hasFDerivWithinAt_const _ _ _
 
 @[fun_prop]
-theorem hasFDerivWithinAt_intCast [IntCast F] (z : ℤ)  (x : E) (s : Set E) :
+theorem hasFDerivWithinAt_intCast [IntCast F] (z : ℤ) (x : E) (s : Set E) :
     HasFDerivWithinAt (z : E → F) (0 : E →L[𝕜] F) s x :=
   hasFDerivWithinAt_const _ _ _
 
 @[fun_prop]
-theorem hasFDerivWithinAt_ofNat (n : ℕ) [OfNat F n]  (x : E) (s : Set E) :
+theorem hasFDerivWithinAt_ofNat (n : ℕ) [OfNat F n] (x : E) (s : Set E) :
     HasFDerivWithinAt (ofNat(n) : E → F) (0 : E →L[𝕜] F) s x :=
   hasFDerivWithinAt_const _ _ _
 

--- a/Mathlib/CategoryTheory/Core.lean
+++ b/Mathlib/CategoryTheory/Core.lean
@@ -40,8 +40,8 @@ instance coreCategory : Groupoid.{v₁} (Core C) where
 
 namespace Core
 
-@[simp]
 /- Porting note: abomination -/
+@[simp]
 theorem id_hom (X : C) : Iso.hom (coreCategory.id X) = @CategoryStruct.id C _ X := by
   rfl
 

--- a/Mathlib/CategoryTheory/Discrete/SumsProducts.lean
+++ b/Mathlib/CategoryTheory/Discrete/SumsProducts.lean
@@ -61,7 +61,7 @@ end Discrete
 
 namespace IsDiscrete
 
-variable (C C': Type*) [Category C] [Category C'] (D : Type*) [Category D]
+variable (C C' : Type*) [Category C] [Category C'] (D : Type*) [Category D]
   [IsDiscrete C] [IsDiscrete C'] [IsDiscrete D]
 
 /-- A product of discrete categories is discrete. -/

--- a/Mathlib/CategoryTheory/Sums/Basic.lean
+++ b/Mathlib/CategoryTheory/Sums/Basic.lean
@@ -198,7 +198,7 @@ theorem sum_map_inr (F : A ⥤ B) (G : C ⥤ D) {c c' : C} (f : c ⟶ c') :
 
 section
 
-variable {F G: A ⊕ B ⥤ C}
+variable {F G : A ⊕ B ⥤ C}
   (e₁ : Sum.inl_ A B ⋙ F ≅ Sum.inl_ A B ⋙ G)
   (e₂ : Sum.inr_ A B ⋙ F ≅ Sum.inr_ A B ⋙ G)
 

--- a/Mathlib/Data/LocallyFinsupp.lean
+++ b/Mathlib/Data/LocallyFinsupp.lean
@@ -288,7 +288,7 @@ instance [SemilatticeInf Y] [Zero Y] : Min (locallyFinsuppWithin U Y) where
 lemma min_apply [SemilatticeInf Y] [Zero Y] {D₁ D₂ : locallyFinsuppWithin U Y} {x : X} :
     min D₁ D₂ x = min (D₁ x) (D₂ x) := rfl
 
-instance  [Lattice Y] [Zero Y] : Lattice (locallyFinsuppWithin U Y) where
+instance [Lattice Y] [Zero Y] : Lattice (locallyFinsuppWithin U Y) where
   le := (· ≤ ·)
   lt := (· < ·)
   le_refl := by simp [le_def]

--- a/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/Basic.lean
+++ b/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/Basic.lean
@@ -1219,7 +1219,7 @@ theorem normAtComplexPlaces_normAtAllPlaces (x : mixedSpace K) :
   normAtComplexPlaces_mixedSpaceOfRealSpace fun _ _ ↦ (normAtAllPlaces_nonneg _ _)
 
 theorem normAtAllPlaces_eq_of_normAtComplexPlaces_eq {x y : mixedSpace K}
-    (h: normAtComplexPlaces x = normAtComplexPlaces y) :
+    (h : normAtComplexPlaces x = normAtComplexPlaces y) :
     normAtAllPlaces x = normAtAllPlaces y := by
   ext w
   obtain hw | hw := isReal_or_isComplex w

--- a/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/PolarCoord.lean
+++ b/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/PolarCoord.lean
@@ -347,7 +347,7 @@ variable {K}
 
 variable {A : Set (mixedSpace K)}
 
-theorem normAtComplexPlaces_polarSpaceCoord_symm  [NumberField K] (x : polarSpace K) :
+theorem normAtComplexPlaces_polarSpaceCoord_symm [NumberField K] (x : polarSpace K) :
     normAtComplexPlaces ((polarSpaceCoord K).symm x) =
       normAtComplexPlaces (mixedSpaceOfRealSpace x.1) := by
   ext w

--- a/Mathlib/RingTheory/PolynomialLaw/Basic.lean
+++ b/Mathlib/RingTheory/PolynomialLaw/Basic.lean
@@ -70,7 +70,7 @@ notation:25 M " →ₚₗ[" R:25 "] " N:0 => PolynomialLaw R M N
 @[local simp]
 theorem PolynomialLaw.isCompat_apply'
     {R : Type u} [CommSemiring R] {M : Type*} [AddCommMonoid M] [Module R M]
-    {N : Type*} [AddCommMonoid N] [Module R N]{f : M →ₚₗ[R] N}
+    {N : Type*} [AddCommMonoid N] [Module R N] {f : M →ₚₗ[R] N}
     {S : Type u} [CommSemiring S] [Algebra R S] {S' : Type u} [CommSemiring S'] [Algebra R S']
     (φ : S →ₐ[R] S') (x : S ⊗[R] M) :
     (φ.toLinearMap.rTensor N) ((f.toFun' S) x) = (f.toFun' S') (φ.toLinearMap.rTensor M x) := by

--- a/Mathlib/Topology/Algebra/UniformField.lean
+++ b/Mathlib/Topology/Algebra/UniformField.lean
@@ -89,11 +89,11 @@ theorem continuous_hatInv [CompletableTopField K] {x : hat K} (h : x ≠ 0) :
     rw [eq_bot]
     exact comap_bot
 
-open Classical in
 /-
 The value of `hat_inv` at zero is not really specified, although it's probably zero.
 Here we explicitly enforce the `inv_zero` axiom.
 -/
+open Classical in
 instance instInvCompletion : Inv (hat K) :=
   ⟨fun x => if x = 0 then 0 else hatInv x⟩
 

--- a/Mathlib/Topology/Algebra/UniformField.lean
+++ b/Mathlib/Topology/Algebra/UniformField.lean
@@ -89,11 +89,11 @@ theorem continuous_hatInv [CompletableTopField K] {x : hat K} (h : x ≠ 0) :
     rw [eq_bot]
     exact comap_bot
 
-/-
+open Classical in
+/--
 The value of `hat_inv` at zero is not really specified, although it's probably zero.
 Here we explicitly enforce the `inv_zero` axiom.
 -/
-open Classical in
 instance instInvCompletion : Inv (hat K) :=
   ⟨fun x => if x = 0 then 0 else hatInv x⟩
 

--- a/Mathlib/Topology/Homotopy/Lifting.lean
+++ b/Mathlib/Topology/Homotopy/Lifting.lean
@@ -204,7 +204,7 @@ variable (cov : IsCoveringMap p)
 include cov
 
 section path_lifting
-variable (γ : C(I,X)) (e : E) (γ_0 : γ 0 = p e)
+variable (γ : C(I, X)) (e : E) (γ_0 : γ 0 = p e)
 include γ_0
 
 /-- The path lifting property (existence) for covering maps. -/


### PR DESCRIPTION
Prompted by the linter in #22760.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
