### PR TITLE
[Merged by Bors] - chore: make some comments doc comments

### DIFF
--- a/Mathlib/Probability/StrongLaw.lean
+++ b/Mathlib/Probability/StrongLaw.lean
@@ -480,7 +480,7 @@ theorem strong_law_aux1 {c : ℝ} (c_one : 1 < c) {ε : ℝ} (εpos : 0 < ε) : 
   convert hω; simp only [Y, S, u, C, sum_apply]
 
 include hint hindep hident hnonneg in
-/- The truncation of `Xᵢ` up to `i` satisfies the strong law of large numbers
+/-- The truncation of `Xᵢ` up to `i` satisfies the strong law of large numbers
 (with respect to the truncated expectation) along the sequence
 `c^n`, for any `c > 1`. This follows from `strong_law_aux1` by varying `ε`. -/
 theorem strong_law_aux2 {c : ℝ} (c_one : 1 < c) :
@@ -513,7 +513,7 @@ theorem strong_law_aux3 :
   exact ((hident i).symm.integrable_snd hint).1.integrable_truncation
 
 include hint hindep hident hnonneg in
-/- The truncation of `Xᵢ` up to `i` satisfies the strong law of large numbers
+/-- The truncation of `Xᵢ` up to `i` satisfies the strong law of large numbers
 (with respect to the original expectation) along the sequence
 `c^n`, for any `c > 1`. This follows from the version from the truncated expectation, and the
 fact that the truncated and the original expectations have the same asymptotic behavior. -/
@@ -556,7 +556,7 @@ theorem strong_law_aux5 :
   rw [sum_sub_distrib]
 
 include hint hindep hident hnonneg in
-/- `Xᵢ` satisfies the strong law of large numbers along the sequence
+/-- `Xᵢ` satisfies the strong law of large numbers along the sequence
 `c^n`, for any `c > 1`. This follows from the version for the truncated `Xᵢ`, and the fact that
 `Xᵢ` and its truncated version have the same asymptotic behavior. -/
 theorem strong_law_aux6 {c : ℝ} (c_one : 1 < c) :

--- a/Mathlib/RingTheory/AdicCompletion/Exactness.lean
+++ b/Mathlib/RingTheory/AdicCompletion/Exactness.lean
@@ -147,7 +147,7 @@ private noncomputable def mapExactAuxDelta {n : ℕ} {d : N}
 open Submodule
 
 include hfg in
-/- Inductively construct preimage of cauchy sequence in kernel of `g.adicCompletion I`. -/
+/-- Inductively construct preimage of cauchy sequence in kernel of `g.adicCompletion I`. -/
 private noncomputable def mapExactAux :
     (n : ℕ) → { a : M | f a - x (k + n) ∈ (I ^ (k + n) • ⊤ : Submodule R N) }
   | .zero =>


### PR DESCRIPTION
Noticed by the linter in #22760: these seem useful as doc comments.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
