### PR TITLE
[Merged by Bors] - feat: `p / r` and `q / r` are Hölder conjugate if `p, q, r` is a Hölder triple

### DIFF
--- a/Mathlib/Data/ENNReal/Holder.lean
+++ b/Mathlib/Data/ENNReal/Holder.lean
@@ -36,7 +36,7 @@ prevent Lean from using `HolderTriple p q r` and `HolderTriple p q r'`
 within a single proof, as may be occasionally convenient. -/
 @[mk_iff]
 class HolderTriple (p q : ℝ≥0∞) (r : semiOutParam ℝ≥0∞) : Prop where
-  inv_add_inv' : p⁻¹ + q⁻¹ = r⁻¹
+  inv_add_inv_eq_inv (p q r) : p⁻¹ + q⁻¹ = r⁻¹
 
 /-- An abbreviation for `ENNReal.HolderTriple p q 1`, this class states `p⁻¹ + q⁻¹ = 1`. -/
 abbrev HolderConjugate (p q : ℝ≥0∞) := HolderTriple p q 1
@@ -51,32 +51,27 @@ namespace HolderTriple
 /-- This is not marked as an instance so that Lean doesn't always find this one
 and a more canonical value of `r` can be used. -/
 lemma of (p q : ℝ≥0∞) : HolderTriple p q (p⁻¹ + q⁻¹)⁻¹ where
-  inv_add_inv' := inv_inv _ |>.symm
+  inv_add_inv_eq_inv := inv_inv _ |>.symm
 
 /- This instance causes a trivial loop, but this is exactly the kind of loop that
 Lean should be able to detect and avoid. -/
 instance symm {p q r : ℝ≥0∞} [hpqr : HolderTriple p q r] : HolderTriple q p r where
-  inv_add_inv' := add_comm p⁻¹ q⁻¹ ▸ hpqr.inv_add_inv'
+  inv_add_inv_eq_inv := add_comm p⁻¹ q⁻¹ ▸ hpqr.inv_add_inv_eq_inv
 
 instance instInfty (p : ℝ≥0∞) : HolderTriple p ∞ p where
-  inv_add_inv' := by simp
+  inv_add_inv_eq_inv := by simp
 
 instance instZero (p : ℝ≥0∞) : HolderTriple p 0 0 where
-  inv_add_inv' := by simp
+  inv_add_inv_eq_inv := by simp
 
 variable (p q r : ℝ≥0∞) [HolderTriple p q r]
 
-lemma inv_add_inv_eq_inv : p⁻¹ + q⁻¹ = r⁻¹ :=
-  inv_add_inv'
-
-lemma inv_eq : r⁻¹ = p⁻¹ + q⁻¹ :=
-  inv_add_inv'.symm
+lemma inv_eq : r⁻¹ = p⁻¹ + q⁻¹ := (inv_add_inv_eq_inv ..).symm
 
 lemma unique (r' : ℝ≥0∞) [hr' : HolderTriple p q r'] : r = r' := by
   rw [← inv_inj, inv_eq p q r, inv_eq p q r']
 
-lemma one_div_add_one_div : 1 / p + 1 / q = 1 / r := by
-  simpa using inv_add_inv'
+lemma one_div_add_one_div : 1 / p + 1 / q = 1 / r := by simpa using inv_add_inv_eq_inv ..
 
 lemma one_div_eq : 1 / r = 1 / p + 1 / q :=
   one_div_add_one_div p q r |>.symm
@@ -115,6 +110,11 @@ variable {r} in
 lemma unique_of_ne_zero (q' : ℝ≥0∞) (hr : r ≠ 0) [HolderTriple p q' r] : q = q' := by
   rw [← inv_inj, ← inv_sub_inv_eq_inv q p hr, ← inv_sub_inv_eq_inv q' p hr]
 
+lemma holderConjugate_div_div (hr₀ : r ≠ 0) (hr : r ≠ ∞) : HolderConjugate (p / r) (q / r) where
+  inv_add_inv_eq_inv := by
+    rw [ENNReal.inv_div (.inl hr) (.inl hr₀), ENNReal.inv_div (.inl hr) (.inl hr₀), div_eq_mul_inv,
+      div_eq_mul_inv, ← mul_add, inv_add_inv_eq_inv p q r, ENNReal.mul_inv_cancel hr₀ hr, inv_one]
+
 end HolderTriple
 
 /-! ### Hölder conjugates -/
@@ -127,7 +127,7 @@ instance symm {p q : ℝ≥0∞} [hpq : HolderConjugate p q] : HolderConjugate q
   inferInstance
 
 instance instTwoTwo : HolderConjugate 2 2 where
-  inv_add_inv' := by
+  inv_add_inv_eq_inv := by
     rw [← two_mul, ENNReal.mul_inv_cancel]
     all_goals norm_num
 

--- a/Mathlib/Data/Real/ConjExponents.lean
+++ b/Mathlib/Data/Real/ConjExponents.lean
@@ -42,7 +42,7 @@ namespace Real
 and `p⁻¹ + q⁻¹ = r⁻¹`. -/
 @[mk_iff]
 structure HolderTriple (p q r : ℝ) : Prop where
-  inv_add_inv' : p⁻¹ + q⁻¹ = r⁻¹
+  inv_add_inv_eq_inv : p⁻¹ + q⁻¹ = r⁻¹
   left_pos : 0 < p
   right_pos : 0 < q
 
@@ -61,18 +61,16 @@ variable {a b p q r : ℝ}
 namespace HolderTriple
 
 lemma of_pos (hp : 0 < p) (hq : 0 < q) : HolderTriple p q (p⁻¹ + q⁻¹)⁻¹ where
-  inv_add_inv' := inv_inv _ |>.symm
+  inv_add_inv_eq_inv := inv_inv _ |>.symm
   left_pos := hp
   right_pos := hq
 
 variable (h : p.HolderTriple q r)
 include h
 
-lemma inv_add_inv_eq_inv : p⁻¹ + q⁻¹ = r⁻¹ := h.inv_add_inv'
-
 @[symm]
 protected lemma symm : q.HolderTriple p r where
-  inv_add_inv' := add_comm p⁻¹ q⁻¹ ▸ h.inv_add_inv_eq_inv
+  inv_add_inv_eq_inv := add_comm p⁻¹ q⁻¹ ▸ h.inv_add_inv_eq_inv
   left_pos := h.right_pos
   right_pos := h.left_pos
 
@@ -117,12 +115,18 @@ protected lemma inv_lt_inv : p⁻¹ < r⁻¹ := calc
 lemma lt : r < p := by simpa using inv_strictAnti₀ h.inv_pos h.inv_lt_inv
 lemma inv_sub_inv_eq_inv : r⁻¹ - q⁻¹ = p⁻¹ := sub_eq_of_eq_add h.inv_eq
 
+lemma holderConjugate_div_div : (p / r).HolderConjugate (q / r) where
+  inv_add_inv_eq_inv := by
+    simp [inv_div, div_eq_mul_inv, ← mul_add, h.inv_add_inv_eq_inv, h.ne_zero']
+  left_pos := by have := h.left_pos; have := h.pos'; positivity
+  right_pos := by have := h.right_pos; have := h.pos'; positivity
+
 end HolderTriple
 
 namespace HolderConjugate
 
 lemma two_two : HolderConjugate 2 2 where
-  inv_add_inv' := by norm_num
+  inv_add_inv_eq_inv := by norm_num
   left_pos := zero_lt_two
   right_pos := zero_lt_two
 
@@ -173,7 +177,7 @@ lemma _root_.Real.holderConjugate_iff : p.HolderConjugate q ↔ 1 < p ∧ p⁻¹
   exact inv_pos.mp <| eq_sub_of_add_eq' h ▸ hp
 
 protected lemma inv_inv (ha : 0 < a) (hb : 0 < b) (hab : a + b = 1) : a⁻¹.HolderConjugate b⁻¹ where
-  inv_add_inv' := by simpa using hab
+  inv_add_inv_eq_inv := by simpa using hab
   left_pos := inv_pos.mpr ha
   right_pos := inv_pos.mpr hb
 
@@ -204,7 +208,7 @@ namespace NNReal
 positive and `p⁻¹ + q⁻¹ = r⁻¹`. -/
 @[mk_iff]
 structure HolderTriple (p q r : ℝ≥0) : Prop where
-  inv_add_inv' : p⁻¹ + q⁻¹ = r⁻¹
+  inv_add_inv_eq_inv : p⁻¹ + q⁻¹ = r⁻¹
   left_pos : 0 < p
   right_pos : 0 < q
 
@@ -237,18 +241,16 @@ variable {a b p q r : ℝ≥0}
 namespace HolderTriple
 
 lemma of_pos (hp : 0 < p) (hq : 0 < q) : HolderTriple p q (p⁻¹ + q⁻¹)⁻¹ where
-  inv_add_inv' := inv_inv _ |>.symm
+  inv_add_inv_eq_inv := inv_inv _ |>.symm
   left_pos := hp
   right_pos := hq
 
 variable (h : p.HolderTriple q r)
 include h
 
-lemma inv_add_inv_eq_inv : p⁻¹ + q⁻¹ = r⁻¹ := h.inv_add_inv'
-
 @[symm]
 protected lemma symm : q.HolderTriple p r where
-  inv_add_inv' := add_comm p⁻¹ q⁻¹ ▸ h.inv_add_inv_eq_inv
+  inv_add_inv_eq_inv := add_comm p⁻¹ q⁻¹ ▸ h.inv_add_inv_eq_inv
   left_pos := h.right_pos
   right_pos := h.left_pos
 
@@ -292,12 +294,18 @@ lemma inv_sub_inv_eq_inv : r⁻¹ - q⁻¹ = p⁻¹ := by
   have := h.symm.inv_lt_inv.le
   exact_mod_cast h.coe.inv_sub_inv_eq_inv
 
+lemma holderConjugate_div_div : (p / r).HolderConjugate (q / r) where
+  inv_add_inv_eq_inv := by
+    simp [inv_div, div_eq_mul_inv, ← mul_add, h.inv_add_inv_eq_inv, h.ne_zero']
+  left_pos := by have := h.left_pos; have := h.pos'; positivity
+  right_pos := by have := h.right_pos; have := h.pos'; positivity
+
 end HolderTriple
 
 namespace HolderConjugate
 
 lemma two_two : HolderConjugate 2 2 where
-  inv_add_inv' := by simpa using add_halves (1 : ℝ≥0)
+  inv_add_inv_eq_inv := by simpa using add_halves (1 : ℝ≥0)
   left_pos := zero_lt_two
   right_pos := zero_lt_two
 
@@ -340,7 +348,7 @@ lemma _root_.NNReal.holderConjugate_iff : p.HolderConjugate q ↔ 1 < p ∧ p⁻
   exact_mod_cast Iff.rfl
 
 protected lemma inv_inv (ha : 0 < a) (hb : 0 < b) (hab : a + b = 1) : a⁻¹.HolderConjugate b⁻¹ where
-  inv_add_inv' := by simpa using hab
+  inv_add_inv_eq_inv := by simpa using hab
   left_pos := inv_pos.mpr ha
   right_pos := inv_pos.mpr hb
 
@@ -548,7 +556,7 @@ lemma div_conj_eq_sub_one : p / q = p - 1 := by
 end
 
 protected lemma inv_inv (hab : a + b = 1) : a⁻¹.HolderConjugate b⁻¹ where
-  inv_add_inv' := by simpa [inv_inv] using hab
+  inv_add_inv_eq_inv := by simpa [inv_inv] using hab
 
 lemma inv_one_sub_inv (ha : a ≤ 1) : a⁻¹.HolderConjugate (1 - a)⁻¹ :=
   .inv_inv <| add_tsub_cancel_of_le ha


### PR DESCRIPTION
Also rename the `inv_add_inv'` field to `inv_add_inv_eq_inv` since we can let it have the correct explicit arguments since v4.19.0-rc1

From LeanAPAP

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
