### PR TITLE
[Merged by Bors] - feat: add `Finset.prod_toList` and rename existing `Finset.prod_to_list`

### DIFF
--- a/Mathlib/Algebra/BigOperators/Group/Finset/Defs.lean
+++ b/Mathlib/Algebra/BigOperators/Group/Finset/Defs.lean
@@ -327,8 +327,15 @@ theorem prod_map (s : Finset α) (e : α ↪ γ) (f : γ → β) :
 section ToList
 
 @[to_additive (attr := simp)]
-theorem prod_to_list (s : Finset α) (f : α → β) : (s.toList.map f).prod = s.prod f := by
+theorem prod_map_toList (s : Finset α) (f : α → β) : (s.toList.map f).prod = s.prod f := by
   rw [Finset.prod, ← Multiset.prod_coe, ← Multiset.map_coe, Finset.coe_toList]
+
+@[deprecated (since := "2025-04-09")] alias prod_to_list := prod_map_toList
+
+@[to_additive (attr := simp)]
+theorem prod_toList {α : Type*} [CommMonoid α] (s : Finset α) :
+    s.toList.prod = ∏ x ∈ s, x := by
+  simpa using s.prod_map_toList id
 
 end ToList
 

--- a/Mathlib/Algebra/BigOperators/Group/Finset/Defs.lean
+++ b/Mathlib/Algebra/BigOperators/Group/Finset/Defs.lean
@@ -331,6 +331,7 @@ theorem prod_map_toList (s : Finset α) (f : α → β) : (s.toList.map f).prod 
   rw [Finset.prod, ← Multiset.prod_coe, ← Multiset.map_coe, Finset.coe_toList]
 
 @[deprecated (since := "2025-04-09")] alias prod_to_list := prod_map_toList
+@[deprecated (since := "2025-04-09")] alias sum_to_list := sum_map_toList
 
 @[to_additive (attr := simp)]
 theorem prod_toList {α : Type*} [CommMonoid α] (s : Finset α) :

--- a/Mathlib/Algebra/Ring/Periodic.lean
+++ b/Mathlib/Algebra/Ring/Periodic.lean
@@ -76,7 +76,7 @@ theorem _root_.Multiset.periodic_prod [Add α] [CommMonoid β] (s : Multiset (α
 @[to_additive]
 theorem _root_.Finset.periodic_prod [Add α] [CommMonoid β] {ι : Type*} {f : ι → α → β}
     (s : Finset ι) (hs : ∀ i ∈ s, Periodic (f i) c) : Periodic (∏ i ∈ s, f i) c :=
-  s.prod_to_list f ▸ (s.toList.map f).periodic_prod (by simpa [-Periodic] )
+  s.prod_map_toList f ▸ (s.toList.map f).periodic_prod (by simpa [-Periodic] )
 
 @[to_additive]
 protected theorem Periodic.smul [Add α] [SMul γ β] (h : Periodic f c) (a : γ) :

--- a/Mathlib/GroupTheory/Transfer.lean
+++ b/Mathlib/GroupTheory/Transfer.lean
@@ -205,13 +205,13 @@ theorem transfer_eq_pow [FiniteIndex H] (g : G)
   classical
     letI := H.fintypeQuotientOfFiniteIndex
     change ∀ (k g₀) (hk : g₀⁻¹ * g ^ k * g₀ ∈ H), ↑(⟨g₀⁻¹ * g ^ k * g₀, hk⟩ : H) = g ^ k at key
-    rw [transfer_eq_prod_quotient_orbitRel_zpowers_quot, ← Finset.prod_to_list]
+    rw [transfer_eq_prod_quotient_orbitRel_zpowers_quot, ← Finset.prod_map_toList]
     refine (List.prod_map_hom _ _ _).trans ?_ -- Porting note: this used to be in the `rw`
     refine congrArg ϕ (Subtype.coe_injective ?_)
     dsimp only
     rw [H.coe_mk, ← (zpowers g).coe_mk g (mem_zpowers g), ← (zpowers g).coe_pow, index_eq_card,
       Nat.card_eq_fintype_card, Fintype.card_congr (selfEquivSigmaOrbits (zpowers g) (G ⧸ H)),
-      Fintype.card_sigma, ← Finset.prod_pow_eq_pow_sum, ← Finset.prod_to_list]
+      Fintype.card_sigma, ← Finset.prod_pow_eq_pow_sum, ← Finset.prod_map_toList]
     simp only [Subgroup.val_list_prod, List.map_map, ← minimalPeriod_eq_card]
     congr
     funext


### PR DESCRIPTION
I was disappointed to find that `(s : Finset α).toList.prod` didn't simplify, so I added the `simp` lemma. 

There was already an existing `simp` lemma for `(s.toList.map f).prod` which was misnamed `Finset.prod_to_list`. This updated the latter to `Finset.prod_map_toList` and deprecates the old name.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
