### PR TITLE
[Merged by Bors] - feat(Matroid): loopless matroids

### DIFF
--- a/Mathlib/Data/Matroid/Loop.lean
+++ b/Mathlib/Data/Matroid/Loop.lean
@@ -756,7 +756,7 @@ class Loopless (M : Matroid α) : Prop where
 lemma loops_eq_empty (M : Matroid α) [Loopless M] : M.loops = ∅ :=
   ‹Loopless M›.loops_eq_empty
 
-lemma toIsNonloop [Loopless M] (he : e ∈ M.E := by aesop_mat) :
+lemma isNonloop_of_loopless [Loopless M] (he : e ∈ M.E := by aesop_mat) :
     M.IsNonloop e := by
   rw [← not_isLoop_iff, isLoop_iff, loops_eq_empty]; exact not_mem_empty _
 

--- a/Mathlib/Data/Matroid/Loop.lean
+++ b/Mathlib/Data/Matroid/Loop.lean
@@ -793,7 +793,7 @@ lemma IsRestriction.loopless [M.Loopless] (hR : N ≤r M) : N.Loopless := by
   obtain ⟨R, hR, rfl⟩ := hR
   rw [loopless_iff, restrict_loops_eq hR, M.loops_eq_empty, empty_inter]
 
-instance {M : Matroid α} [Matroid.Nonempty M] [Loopless M] : RankPos M :=
+instance {M : Matroid α} [M.Nonempty] [Loopless M] : RankPos M :=
   M.ground_nonempty.elim fun _ he ↦ (isNonloop_of_loopless he).rankPos
 
 @[simp] lemma loopyOn_isLoopless_iff {E : Set α} : Loopless (loopyOn E) ↔ E = ∅ := by

--- a/Mathlib/Data/Matroid/Loop.lean
+++ b/Mathlib/Data/Matroid/Loop.lean
@@ -272,6 +272,9 @@ attribute [aesop unsafe 20% (rule_sets := [Matroid])] IsNonloop.mem_ground
 lemma IsLoop.not_isNonloop (he : M.IsLoop e) : ¬M.IsNonloop e :=
   fun h ↦ h.not_isLoop he
 
+lemma compl_loops_eq (M : Matroid α) : M.E \ M.loops = {e | M.IsNonloop e} := by
+  simp [Set.ext_iff, isNonloop_iff, and_comm, isLoop_iff]
+
 lemma isNonloop_of_not_isLoop (he : e ∈ M.E := by aesop_mat) (h : ¬ M.IsLoop e) : M.IsNonloop e :=
   ⟨h,he⟩
 

--- a/Mathlib/Data/Matroid/Loop.lean
+++ b/Mathlib/Data/Matroid/Loop.lean
@@ -774,7 +774,7 @@ lemma loopless_iff_forall_isNonloop : M.Loopless ↔ ∀ e ∈ M.E, M.IsNonloop 
   ⟨fun _ _ he ↦ isNonloop_of_loopless he,
     fun h ↦ ⟨subset_empty_iff.1 (fun e (he : M.IsLoop e) ↦ (h e he.mem_ground).not_isLoop he)⟩⟩
 
-lemma loopless_iff_forall_not_isLoop : M.Loopless ↔ ∀ e ∈ M.E, ¬M.IsLoop e :=
+lemma loopless_iff_forall_not_isLoop : M.Loopless ↔ ∀ e ∈ M.E, ¬ M.IsLoop e :=
   ⟨fun _ e _ ↦ M.not_isLoop e,
     fun h ↦ loopless_iff_forall_isNonloop.2 fun e he ↦ (not_isLoop_iff he).1 (h e he)⟩
 

--- a/Mathlib/Data/Matroid/Minor/Basic.lean
+++ b/Mathlib/Data/Matroid/Minor/Basic.lean
@@ -218,8 +218,8 @@ lemma IsNonloop.of_delete (h : (M ＼ D).IsNonloop e) : M.IsNonloop e :=
 lemma isNonloop_iff_delete_of_not_mem (he : e ∉ D) : M.IsNonloop e ↔ (M ＼ D).IsNonloop e :=
   ⟨fun h ↦ delete_isNonloop_iff.2 ⟨h, he⟩, fun h ↦ h.of_delete⟩
 
-lemma delete_loops_eq (M : Matroid α) : M ＼ M.loops = M.removeLoops := by
-  _
+lemma delete_loops_eq_removeLoops (M : Matroid α) : M ＼ M.loops = M.removeLoops := by
+  rw [removeLoops, delete_eq_restrict, compl_loops_eq]
 
 @[simp]
 lemma delete_isCircuit_iff {C : Set α} :

--- a/Mathlib/Data/Matroid/Minor/Basic.lean
+++ b/Mathlib/Data/Matroid/Minor/Basic.lean
@@ -218,6 +218,9 @@ lemma IsNonloop.of_delete (h : (M ＼ D).IsNonloop e) : M.IsNonloop e :=
 lemma isNonloop_iff_delete_of_not_mem (he : e ∉ D) : M.IsNonloop e ↔ (M ＼ D).IsNonloop e :=
   ⟨fun h ↦ delete_isNonloop_iff.2 ⟨h, he⟩, fun h ↦ h.of_delete⟩
 
+lemma delete_loops_eq (M : Matroid α) : M ＼ M.loops = M.removeLoops := by
+  _
+
 @[simp]
 lemma delete_isCircuit_iff {C : Set α} :
     (M ＼ D).IsCircuit C ↔ M.IsCircuit C ∧ Disjoint C D := by


### PR DESCRIPTION
We define and give API for a `Loopless` typeclass for matroids and a `removeLoops` operation that deletes the loops of a matroid `M`. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
