### PR TITLE
[Merged by Bors] - doc(CategoryTheory/Comma/Basic): fix description of CategoryTheory.Comma.preRight

### DIFF
--- a/Mathlib/CategoryTheory/Comma/Basic.lean
+++ b/Mathlib/CategoryTheory/Comma/Basic.lean
@@ -427,7 +427,7 @@ instance (F : C ⥤ A) (L : A ⥤ T) (R : B ⥤ T) [F.EssSurj] : (preLeft F L R)
 instance isEquivalence_preLeft (F : C ⥤ A) (L : A ⥤ T) (R : B ⥤ T) [F.IsEquivalence] :
     (preLeft F L R).IsEquivalence where
 
-/-- The functor `(F ⋙ L, R) ⥤ (L, R)` -/
+/-- The functor `(L, F ⋙ R) ⥤ (L, R)` -/
 @[simps]
 def preRight (L : A ⥤ T) (F : C ⥤ B) (R : B ⥤ T) : Comma L (F ⋙ R) ⥤ Comma L R where
   obj X :=


### PR DESCRIPTION
The docstring for `CategoryTheory.Comma.preRight` was copied and pasted from `CategoryTheory.Comma.preLeft`.

---

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
