### PR TITLE
[Merged by Bors] - feat(WithTerminal): `FinCategory` instance

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2509,7 +2509,8 @@ import Mathlib.CategoryTheory.Types
 import Mathlib.CategoryTheory.UnivLE
 import Mathlib.CategoryTheory.Whiskering
 import Mathlib.CategoryTheory.Widesubcategory
-import Mathlib.CategoryTheory.WithTerminal
+import Mathlib.CategoryTheory.WithTerminal.Basic
+import Mathlib.CategoryTheory.WithTerminal.FinCategory
 import Mathlib.CategoryTheory.Yoneda
 import Mathlib.Combinatorics.Additive.AP.Three.Behrend
 import Mathlib.Combinatorics.Additive.AP.Three.Defs

--- a/Mathlib/CategoryTheory/WithTerminal.lean
+++ b/Mathlib/CategoryTheory/WithTerminal.lean
@@ -3,9 +3,11 @@ Copyright (c) 2021 Adam Topaz. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Joseph Tooby-Smith, Adam Topaz
 -/
+import Mathlib.CategoryTheory.FinCategory.Basic
 import Mathlib.CategoryTheory.Limits.Shapes.IsTerminal
 import Mathlib.CategoryTheory.Limits.Shapes.Terminal
 import Mathlib.CategoryTheory.Bicategory.Functor.Pseudofunctor
+import Mathlib.Data.Fintype.Option
 
 /-!
 
@@ -123,6 +125,30 @@ instance : (incl : C ⥤ _).Full where
   map_surjective f := ⟨f, rfl⟩
 
 instance : (incl : C ⥤ _).Faithful where
+
+/-- The equivalence between `Option C` and `WithTerminal C` (they are both the
+type `C` plus an extra object `none` or `star`). -/
+def optionEquiv : Option C ≃ WithTerminal C where
+  toFun
+  | some a => of a
+  | none => star
+  invFun
+  | of a => some a
+  | star => none
+  left_inv a := by cases a <;> simp
+  right_inv a := by cases a <;> simp
+
+instance instFinType [Fintype C] : Fintype (WithTerminal C) :=
+  Fintype.ofEquiv (Option C) optionEquiv
+
+instance instFin [SmallCategory C] [FinCategory C] :
+    FinCategory (WithTerminal C) where
+  fintypeObj := inferInstance
+  fintypeHom
+  | star, star
+  | of _, star => (inferInstance : Fintype PUnit)
+  | star, of _ => (inferInstance : Fintype PEmpty)
+  | of a, of b => (inferInstance : Fintype (a ⟶ b))
 
 /-- Map `WithTerminal` with respect to a functor `F : C ⥤ D`. -/
 @[simps]
@@ -510,6 +536,30 @@ instance : (incl : C ⥤ _).Full where
   map_surjective f := ⟨f, rfl⟩
 
 instance : (incl : C ⥤ _).Faithful where
+
+/-- The equivalence between `Option C` and `WithInitial C` (they are both the
+type `C` plus an extra object `none` or `star`). -/
+def optionEquiv : Option C ≃ WithInitial C where
+  toFun
+  | some a => of a
+  | none => star
+  invFun
+  | of a => some a
+  | star => none
+  left_inv a := by cases a <;> simp
+  right_inv a := by cases a <;> simp
+
+instance instFinType [Fintype C] : Fintype (WithInitial C) :=
+  Fintype.ofEquiv (Option C) optionEquiv
+
+instance instFin [SmallCategory C] [FinCategory C] :
+    FinCategory (WithInitial C) where
+  fintypeObj := inferInstance
+  fintypeHom
+  | star, star
+  | star, of _ => (inferInstance : Fintype PUnit)
+  | of _, star => (inferInstance : Fintype PEmpty)
+  | of a, of b => (inferInstance : Fintype (a ⟶ b))
 
 /-- Map `WithInitial` with respect to a functor `F : C ⥤ D`. -/
 @[simps]

--- a/Mathlib/CategoryTheory/WithTerminal/Basic.lean
+++ b/Mathlib/CategoryTheory/WithTerminal/Basic.lean
@@ -3,11 +3,9 @@ Copyright (c) 2021 Adam Topaz. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Joseph Tooby-Smith, Adam Topaz
 -/
-import Mathlib.CategoryTheory.FinCategory.Basic
 import Mathlib.CategoryTheory.Limits.Shapes.IsTerminal
 import Mathlib.CategoryTheory.Limits.Shapes.Terminal
 import Mathlib.CategoryTheory.Bicategory.Functor.Pseudofunctor
-import Mathlib.Data.Fintype.Option
 
 /-!
 
@@ -125,30 +123,6 @@ instance : (incl : C ⥤ _).Full where
   map_surjective f := ⟨f, rfl⟩
 
 instance : (incl : C ⥤ _).Faithful where
-
-/-- The equivalence between `Option C` and `WithTerminal C` (they are both the
-type `C` plus an extra object `none` or `star`). -/
-def optionEquiv : Option C ≃ WithTerminal C where
-  toFun
-  | some a => of a
-  | none => star
-  invFun
-  | of a => some a
-  | star => none
-  left_inv a := by cases a <;> simp
-  right_inv a := by cases a <;> simp
-
-instance instFinType [Fintype C] : Fintype (WithTerminal C) :=
-  Fintype.ofEquiv (Option C) optionEquiv
-
-instance instFin [SmallCategory C] [FinCategory C] :
-    FinCategory (WithTerminal C) where
-  fintypeObj := inferInstance
-  fintypeHom
-  | star, star
-  | of _, star => (inferInstance : Fintype PUnit)
-  | star, of _ => (inferInstance : Fintype PEmpty)
-  | of a, of b => (inferInstance : Fintype (a ⟶ b))
 
 /-- Map `WithTerminal` with respect to a functor `F : C ⥤ D`. -/
 @[simps]
@@ -536,30 +510,6 @@ instance : (incl : C ⥤ _).Full where
   map_surjective f := ⟨f, rfl⟩
 
 instance : (incl : C ⥤ _).Faithful where
-
-/-- The equivalence between `Option C` and `WithInitial C` (they are both the
-type `C` plus an extra object `none` or `star`). -/
-def optionEquiv : Option C ≃ WithInitial C where
-  toFun
-  | some a => of a
-  | none => star
-  invFun
-  | of a => some a
-  | star => none
-  left_inv a := by cases a <;> simp
-  right_inv a := by cases a <;> simp
-
-instance instFinType [Fintype C] : Fintype (WithInitial C) :=
-  Fintype.ofEquiv (Option C) optionEquiv
-
-instance instFin [SmallCategory C] [FinCategory C] :
-    FinCategory (WithInitial C) where
-  fintypeObj := inferInstance
-  fintypeHom
-  | star, star
-  | star, of _ => (inferInstance : Fintype PUnit)
-  | of _, star => (inferInstance : Fintype PEmpty)
-  | of a, of b => (inferInstance : Fintype (a ⟶ b))
 
 /-- Map `WithInitial` with respect to a functor `F : C ⥤ D`. -/
 @[simps]

--- a/Mathlib/CategoryTheory/WithTerminal/FinCategory.lean
+++ b/Mathlib/CategoryTheory/WithTerminal/FinCategory.lean
@@ -35,10 +35,10 @@ def optionEquiv : Option C ≃ WithTerminal C where
   left_inv a := by cases a <;> simp
   right_inv a := by cases a <;> simp
 
-instance instFinType [Fintype C] : Fintype (WithTerminal C) :=
+instance instFintype [Fintype C] : Fintype (WithTerminal C) :=
   .ofEquiv (Option C) <| optionEquiv C
 
-instance instFin [SmallCategory C] [FinCategory C] :
+instance instFinCategory [SmallCategory C] [FinCategory C] :
     FinCategory (WithTerminal C) where
   fintypeObj := inferInstance
   fintypeHom
@@ -63,10 +63,10 @@ def optionEquiv : Option C ≃ WithInitial C where
   left_inv a := by cases a <;> simp
   right_inv a := by cases a <;> simp
 
-instance instFinType [Fintype C] : Fintype (WithInitial C) :=
+instance instFintype [Fintype C] : Fintype (WithInitial C) :=
   .ofEquiv (Option C) <| optionEquiv C
 
-instance instFin [SmallCategory C] [FinCategory C] :
+instance instFinCategory [SmallCategory C] [FinCategory C] :
     FinCategory (WithInitial C) where
   fintypeObj := inferInstance
   fintypeHom

--- a/Mathlib/CategoryTheory/WithTerminal/FinCategory.lean
+++ b/Mathlib/CategoryTheory/WithTerminal/FinCategory.lean
@@ -1,0 +1,78 @@
+/-
+Copyright (c) 2025 Moisés Herradón Cueto. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Moisés Herradón Cueto
+-/
+import Mathlib.CategoryTheory.FinCategory.Basic
+import Mathlib.CategoryTheory.WithTerminal.Basic
+import Mathlib.Data.Fintype.Option
+
+/-!
+
+# `WithTerminal C` and `WithInitial C` are finite whenever `C` is
+
+If `C` has finitely many objects, then so do `WithTerminal C` and `WithInitial C`,
+and likewise if `C` has finitely many morphisms as well.
+
+-/
+
+
+universe v u
+
+variable (C : Type u) [CategoryTheory.Category.{v} C]
+
+namespace CategoryTheory.WithTerminal
+
+/-- The equivalence between `Option C` and `WithTerminal C` (they are both the
+type `C` plus an extra object `none` or `star`). -/
+def optionEquiv : Option C ≃ WithTerminal C where
+  toFun
+  | some a => of a
+  | none => star
+  invFun
+  | of a => some a
+  | star => none
+  left_inv a := by cases a <;> simp
+  right_inv a := by cases a <;> simp
+
+instance instFinType [Fintype C] : Fintype (WithTerminal C) :=
+  .ofEquiv (Option C) <| optionEquiv C
+
+instance instFin [SmallCategory C] [FinCategory C] :
+    FinCategory (WithTerminal C) where
+  fintypeObj := inferInstance
+  fintypeHom
+  | star, star
+  | of _, star => (inferInstance : Fintype PUnit)
+  | star, of _ => (inferInstance : Fintype PEmpty)
+  | of a, of b => (inferInstance : Fintype (a ⟶ b))
+
+end CategoryTheory.WithTerminal
+
+namespace CategoryTheory.WithInitial
+
+/-- The equivalence between `Option C` and `WithInitial C` (they are both the
+type `C` plus an extra object `none` or `star`). -/
+def optionEquiv : Option C ≃ WithInitial C where
+  toFun
+  | some a => of a
+  | none => star
+  invFun
+  | of a => some a
+  | star => none
+  left_inv a := by cases a <;> simp
+  right_inv a := by cases a <;> simp
+
+instance instFinType [Fintype C] : Fintype (WithInitial C) :=
+  .ofEquiv (Option C) <| optionEquiv C
+
+instance instFin [SmallCategory C] [FinCategory C] :
+    FinCategory (WithInitial C) where
+  fintypeObj := inferInstance
+  fintypeHom
+  | star, star
+  | star, of _ => (inferInstance : Fintype PUnit)
+  | of _, star => (inferInstance : Fintype PEmpty)
+  | of a, of b => (inferInstance : Fintype (a ⟶ b))
+
+end CategoryTheory.WithInitial


### PR DESCRIPTION
Showing that `WithTerminal C` and `WithInitial C` are finite whenever the starting category `C` is.

From Toric

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
