### PR TITLE
[Merged by Bors] - chore(RingTheory/SimpleRing): golf and cleanup

### DIFF
--- a/Mathlib/RingTheory/SimpleRing/Basic.lean
+++ b/Mathlib/RingTheory/SimpleRing/Basic.lean
@@ -15,7 +15,7 @@ A ring `R` is **simple** if it has only two two-sided ideals, namely `⊥` and `
 ## Main results
 
 - `IsSimpleRing.nontrivial`: simple rings are non-trivial.
-- `DivisionRing.IsSimpleRing`: division rings are simple.
+- `DivisionRing.isSimpleRing`: division rings are simple.
 - `RingHom.injective`: every ring homomorphism from a simple ring to a nontrivial ring is injective.
 - `IsSimpleRing.iff_injective_ringHom`: a ring is simple iff every ring homomorphism to a nontrivial
   ring is injective.
@@ -30,12 +30,9 @@ namespace IsSimpleRing
 
 variable {R}
 
-instance [IsSimpleRing R] : IsSimpleOrder (TwoSidedIdeal R) := IsSimpleRing.simple
-
-instance [simple : IsSimpleRing R] : Nontrivial R := by
-  obtain ⟨x, hx⟩ := SetLike.exists_of_lt (bot_lt_top : (⊥ : TwoSidedIdeal R) < ⊤)
-  have h (hx : x = 0) : False := by simp_all [TwoSidedIdeal.zero_mem]
-  use x, 0, h
+instance [IsSimpleRing R] : Nontrivial R := by
+  obtain ⟨x, _, hx⟩ := SetLike.exists_of_lt (bot_lt_top : (⊥ : TwoSidedIdeal R) < ⊤)
+  use x, 0, hx
 
 lemma one_mem_of_ne_bot {A : Type*} [NonAssocRing A] [IsSimpleRing A] (I : TwoSidedIdeal A)
     (hI : I ≠ ⊥) : (1 : A) ∈ I :=
@@ -47,7 +44,7 @@ lemma one_mem_of_ne_zero_mem {A : Type*} [NonAssocRing A] [IsSimpleRing A] (I : 
 
 lemma of_eq_bot_or_eq_top [Nontrivial R] (h : ∀ I : TwoSidedIdeal R, I = ⊥ ∨ I = ⊤) :
     IsSimpleRing R where
-  simple := { eq_bot_or_eq_top := h }
+  simple.eq_bot_or_eq_top := h
 
 instance _root_.DivisionRing.isSimpleRing (A : Type*) [DivisionRing A] : IsSimpleRing A :=
   .of_eq_bot_or_eq_top <| fun I ↦ by

--- a/Mathlib/RingTheory/SimpleRing/Defs.lean
+++ b/Mathlib/RingTheory/SimpleRing/Defs.lean
@@ -23,3 +23,5 @@ A ring `R` is **simple** if it has only two two-sided ideals, namely `⊥` and `
 -/
 class IsSimpleRing (R : Type*) [NonUnitalNonAssocRing R] : Prop where
   simple : IsSimpleOrder (TwoSidedIdeal R)
+
+attribute [instance] IsSimpleRing.simple


### PR DESCRIPTION
This fixes a typo in a docstring, removes an `instance` that can be replaced with `attribute [instance]`, and golfs some proofs.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
