### PR TITLE
[Merged by Bors] - feat(Order/GroupWithZero): drop some `0 ≤ 1` assumptions

### DIFF
--- a/Mathlib/Algebra/Order/GroupWithZero/Finset.lean
+++ b/Mathlib/Algebra/Order/GroupWithZero/Finset.lean
@@ -49,7 +49,7 @@ set_option linter.docPrime false in
 lemma mul₀_sup' [PosMulMono G₀] [PosMulReflectLE G₀] (ha : 0 < a) (f : ι → G₀) (s : Finset ι) (hs) :
     a * s.sup' hs f = s.sup' hs fun i ↦ a * f i := map_finset_sup' (OrderIso.mulLeft₀ _ ha) hs f
 
-lemma sup'_div₀ [ZeroLEOneClass G₀] [MulPosStrictMono G₀] [MulPosReflectLE G₀] [PosMulReflectLT G₀]
+lemma sup'_div₀ [MulPosStrictMono G₀] [MulPosReflectLE G₀] [PosMulReflectLT G₀]
     (ha : 0 < a) (f : ι → G₀) (s : Finset ι) (hs) : s.sup' hs f / a = s.sup' hs fun i ↦ f i / a :=
   map_finset_sup' (OrderIso.divRight₀ _ ha) hs f
 

--- a/Mathlib/Algebra/Order/GroupWithZero/Unbundled/Basic.lean
+++ b/Mathlib/Algebra/Order/GroupWithZero/Unbundled/Basic.lean
@@ -716,11 +716,14 @@ lemma div_self_le_one (a : G₀) : a / a ≤ 1 := by obtain rfl | ha := eq_or_ne
 end Preorder
 
 section PartialOrder
-variable [PartialOrder G₀] [ZeroLEOneClass G₀] [PosMulReflectLT G₀] {a b c : G₀}
+variable [PartialOrder G₀] [PosMulReflectLT G₀] {a b c : G₀}
 
-@[simp] lemma inv_pos : 0 < a⁻¹ ↔ 0 < a :=
+@[simp] lemma inv_pos : 0 < a⁻¹ ↔ 0 < a := by
   suffices ∀ a : G₀, 0 < a → 0 < a⁻¹ from ⟨fun h ↦ inv_inv a ▸ this _ h, this a⟩
-  fun a ha ↦ flip lt_of_mul_lt_mul_left ha.le <| by simp [ne_of_gt ha, zero_lt_one]
+  intro a ha
+  apply lt_of_mul_lt_mul_left _ ha.le
+  apply lt_of_mul_lt_mul_left _ ha.le
+  simpa [ha.ne']
 
 alias ⟨_, inv_pos_of_pos⟩ := inv_pos
 
@@ -740,11 +743,11 @@ lemma div_nonneg [PosMulMono G₀] (ha : 0 ≤ a) (hb : 0 ≤ b) : 0 ≤ a / b :
 lemma div_nonpos_of_nonpos_of_nonneg [MulPosMono G₀] (ha : a ≤ 0) (hb : 0 ≤ b) : a / b ≤ 0 := by
   rw [div_eq_mul_inv]; exact mul_nonpos_of_nonpos_of_nonneg ha (inv_nonneg.2 hb)
 
-lemma zpow_nonneg [PosMulMono G₀] (ha : 0 ≤ a) : ∀ n : ℤ, 0 ≤ a ^ n
+lemma zpow_nonneg [ZeroLEOneClass G₀] [PosMulMono G₀] (ha : 0 ≤ a) : ∀ n : ℤ, 0 ≤ a ^ n
   | (n : ℕ) => by rw [zpow_natCast]; exact pow_nonneg ha _
   |-(n + 1 : ℕ) => by rw [zpow_neg, inv_nonneg, zpow_natCast]; exact pow_nonneg ha _
 
-lemma zpow_pos [PosMulStrictMono G₀] (ha : 0 < a) : ∀ n : ℤ, 0 < a ^ n
+lemma zpow_pos [ZeroLEOneClass G₀] [PosMulStrictMono G₀] (ha : 0 < a) : ∀ n : ℤ, 0 < a ^ n
   | (n : ℕ) => by rw [zpow_natCast]; exact pow_pos ha _
   |-(n + 1 : ℕ) => by rw [zpow_neg, inv_pos, zpow_natCast]; exact pow_pos ha _
 
@@ -776,9 +779,10 @@ lemma inv_le_one₀ (ha : 0 < a) : a⁻¹ ≤ 1 ↔ 1 ≤ a := by simpa using in
 @[bound] alias ⟨_, Bound.one_le_inv₀⟩ := one_le_inv₀
 
 @[bound]
-lemma inv_le_one_of_one_le₀ (ha : 1 ≤ a) : a⁻¹ ≤ 1 := (inv_le_one₀ <| zero_lt_one.trans_le ha).2 ha
+lemma inv_le_one_of_one_le₀ [ZeroLEOneClass G₀] (ha : 1 ≤ a) : a⁻¹ ≤ 1 :=
+  (inv_le_one₀ <| zero_lt_one.trans_le ha).2 ha
 
-lemma one_le_inv_iff₀ : 1 ≤ a⁻¹ ↔ 0 < a ∧ a ≤ 1 where
+lemma one_le_inv_iff₀ [ZeroLEOneClass G₀] : 1 ≤ a⁻¹ ↔ 0 < a ∧ a ≤ 1 where
   mp h := ⟨inv_pos.1 (zero_lt_one.trans_le h),
     inv_inv a ▸ (inv_le_one₀ <| zero_lt_one.trans_le h).2 h⟩
   mpr h := (one_le_inv₀ h.1).2 h.2
@@ -796,6 +800,8 @@ lemma inv_mul_le_of_le_mul₀ (hb : 0 ≤ b) (hc : 0 ≤ c) (h : a ≤ b * c) : 
   obtain rfl | hb := hb.eq_or_lt
   · simp [hc]
   · rwa [inv_mul_le_iff₀ hb]
+
+variable [ZeroLEOneClass G₀]
 
 @[bound]
 lemma inv_mul_le_one_of_le₀ (h : a ≤ b) (hb : 0 ≤ b) : b⁻¹ * a ≤ 1 :=
@@ -882,11 +888,11 @@ lemma div_le_of_le_mul₀ (hb : 0 ≤ b) (hc : 0 ≤ c) (h : a ≤ c * b) : a / 
   div_eq_mul_inv a _ ▸ mul_inv_le_of_le_mul₀ hb hc h
 
 @[bound]
-lemma mul_inv_le_one_of_le₀ (h : a ≤ b) (hb : 0 ≤ b) : a * b⁻¹ ≤ 1 :=
+lemma mul_inv_le_one_of_le₀ [ZeroLEOneClass G₀] (h : a ≤ b) (hb : 0 ≤ b) : a * b⁻¹ ≤ 1 :=
   mul_inv_le_of_le_mul₀ hb zero_le_one <| by rwa [one_mul]
 
 @[bound]
-lemma div_le_one_of_le₀ (h : a ≤ b) (hb : 0 ≤ b) : a / b ≤ 1 :=
+lemma div_le_one_of_le₀ [ZeroLEOneClass G₀] (h : a ≤ b) (hb : 0 ≤ b) : a / b ≤ 1 :=
   div_le_of_le_mul₀ hb zero_le_one <| by rwa [one_mul]
 
 @[mono, gcongr, bound]
@@ -947,6 +953,8 @@ lemma inv_mul_lt_one₀ (ha : 0 < a) : a⁻¹ * b < 1 ↔ b < a := by rw [inv_mu
 
 lemma one_lt_inv₀ (ha : 0 < a) : 1 < a⁻¹ ↔ a < 1 := by simpa using one_lt_inv_mul₀ ha (b := 1)
 lemma inv_lt_one₀ (ha : 0 < a) : a⁻¹ < 1 ↔ 1 < a := by simpa using inv_mul_lt_one₀ ha (b := 1)
+
+variable [ZeroLEOneClass G₀]
 
 @[bound]
 lemma inv_lt_one_of_one_lt₀ (ha : 1 < a) : a⁻¹ < 1 := (inv_lt_one₀ <| zero_lt_one.trans ha).2 ha
@@ -1086,7 +1094,7 @@ end MulPosStrictMono
 end PartialOrder
 
 section LinearOrder
-variable [LinearOrder G₀] [ZeroLEOneClass G₀] {a b c d : G₀}
+variable [LinearOrder G₀] {a b c d : G₀}
 
 section PosMulMono
 variable [PosMulMono G₀]
@@ -1117,6 +1125,10 @@ end PosMulMono
 
 variable [PosMulStrictMono G₀] {m n : ℤ}
 
+section ZeroLEOne
+
+variable [ZeroLEOneClass G₀]
+
 lemma inv_lt_one_iff₀ : a⁻¹ < 1 ↔ a ≤ 0 ∨ 1 < a := by
   simp_rw [← not_le, one_le_inv_iff₀, not_and_or, not_lt]
 
@@ -1135,6 +1147,8 @@ lemma zpow_eq_one_iff_right₀ (ha₀ : 0 ≤ a) (ha₁ : a ≠ 1) {n : ℤ} : a
   obtain rfl | ha₀ := ha₀.eq_or_lt
   · exact zero_zpow_eq_one₀
   simpa using zpow_right_inj₀ ha₀ ha₁ (n := 0)
+
+end ZeroLEOne
 
 variable [MulPosStrictMono G₀]
 
@@ -1170,7 +1184,7 @@ lemma div_lt_div₀' (hac : a ≤ c) (hdb : d < b) (hc : 0 < c) (hd : 0 < d) : a
 end GroupWithZero.LinearOrder
 
 section CommGroupWithZero
-variable [CommGroupWithZero G₀] [PartialOrder G₀] [ZeroLEOneClass G₀] [PosMulReflectLT G₀]
+variable [CommGroupWithZero G₀] [PartialOrder G₀] [PosMulReflectLT G₀]
 
 section PosMulMono
 variable [PosMulMono G₀] {a b c d : G₀}

--- a/Mathlib/Algebra/Order/GroupWithZero/Unbundled/OrderIso.lean
+++ b/Mathlib/Algebra/Order/GroupWithZero/Unbundled/OrderIso.lean
@@ -23,8 +23,6 @@ def mulLeft₀ (a : G₀) (ha : 0 < a) : G₀ ≃o G₀ where
   toEquiv := .mulLeft₀ a ha.ne'
   map_rel_iff' := mul_le_mul_left ha
 
-variable [ZeroLEOneClass G₀]
-
 lemma mulLeft₀_symm (a : G₀) (ha : 0 < a) : (mulLeft₀ a ha).symm = mulLeft₀ a⁻¹ (inv_pos.2 ha) := by
   ext; rfl
 
@@ -39,7 +37,7 @@ def mulRight₀ (a : G₀) (ha : 0 < a) : G₀ ≃o G₀ where
   toEquiv := .mulRight₀ a ha.ne'
   map_rel_iff' := mul_le_mul_right ha
 
-variable [ZeroLEOneClass G₀] [PosMulReflectLT G₀]
+variable [PosMulReflectLT G₀]
 
 lemma mulRight₀_symm (a : G₀) (ha : 0 < a) :
     (mulRight₀ a ha).symm = mulRight₀ a⁻¹ (inv_pos.2 ha) := by ext; rfl
@@ -48,7 +46,7 @@ end right
 
 /-- `Equiv.divRight₀` as an order isomorphism. -/
 @[simps! (config := { simpRhs := true })]
-def divRight₀ [ZeroLEOneClass G₀] [MulPosStrictMono G₀] [MulPosReflectLE G₀] [PosMulReflectLT G₀]
+def divRight₀ [MulPosStrictMono G₀] [MulPosReflectLE G₀] [PosMulReflectLT G₀]
     (a : G₀) (ha : 0 < a) : G₀ ≃o G₀ where
   toEquiv := .divRight₀ a ha.ne'
   map_rel_iff' {b c} := by

--- a/Mathlib/Analysis/SpecialFunctions/ContinuousFunctionalCalculus/Rpow/Basic.lean
+++ b/Mathlib/Analysis/SpecialFunctions/ContinuousFunctionalCalculus/Rpow/Basic.lean
@@ -7,7 +7,6 @@ Authors: Frédéric Dupuis
 import Mathlib.Analysis.SpecialFunctions.Pow.Real
 import Mathlib.Analysis.CStarAlgebra.ContinuousFunctionalCalculus.Unique
 import Mathlib.Analysis.SpecialFunctions.Pow.Continuity
-import Mathlib.Data.Real.StarOrdered
 
 /-!
 # Real powers defined via the continuous functional calculus

--- a/Mathlib/Combinatorics/Additive/PluenneckeRuzsa.lean
+++ b/Mathlib/Combinatorics/Additive/PluenneckeRuzsa.lean
@@ -183,10 +183,7 @@ theorem ruzsa_triangle_inequality_mul_mul_mul (A B C : Finset G) :
   refine le_trans ?_
     (mul_le_mul (hUA _ hB') (cast_le.2 <| card_le_card <| mul_subset_mul_right hU.2)
       (zero_le _) (zero_le _))
-  #adaptation_note /-- 2024-11-01
-  `le_div_iff₀` is synthesizing wrong `GroupWithZero` without `@` -/
-  rw [← mul_div_right_comm, ← mul_assoc,
-    @le_div_iff₀ _ (_) _ _ _ _ _ _ _ (cast_pos.2 hU.1.card_pos)]
+  rw [← mul_div_right_comm, ← mul_assoc, le_div_iff₀ (cast_pos.2 hU.1.card_pos)]
   exact mod_cast pluennecke_petridis_inequality_mul C (mul_aux hU.1 hU.2 hUA)
 
 /-- **Ruzsa's triangle inequality**. Mul-div-div version. -/


### PR DESCRIPTION
In these lemmas, the assumptions imply `0 < 1`, so we don't need to assume that.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
