### PR TITLE
[Merged by Bors] - chore: add missing rfl lemmas for the tensor product of coalgebras

### DIFF
--- a/Mathlib/Algebra/Category/CoalgebraCat/ComonEquivalence.lean
+++ b/Mathlib/Algebra/Category/CoalgebraCat/ComonEquivalence.lean
@@ -145,7 +145,7 @@ theorem comul_tensorObj :
       = Coalgebra.comul (A := M ⊗[R] N) := by
   rw [ofComonObjCoalgebraStruct_comul]
   dsimp only [Equivalence.symm_inverse, comonEquivalence_functor, toComon_obj,
-    instCoalgebraStruct_comul]
+    comul_def]
   simp only [Comon_.monoidal_tensorObj_comul, toComonObj_X,
     toComonObj_comul, tensorμ_eq_tensorTensorTensorComm]
   rfl
@@ -156,7 +156,7 @@ theorem comul_tensorObj_tensorObj_right :
       = Coalgebra.comul (A := M ⊗[R] N ⊗[R] P) := by
   rw [ofComonObjCoalgebraStruct_comul]
   dsimp only [Equivalence.symm_inverse, comonEquivalence_functor, toComon_obj,
-    instCoalgebraStruct_comul]
+    comul_def]
   simp only [Comon_.monoidal_tensorObj_comul, toComonObj_X, ModuleCat.of_coe, toComonObj_comul]
   rw [ofComonObjCoalgebraStruct_comul]
   dsimp only [Equivalence.symm_inverse, comonEquivalence_functor, toComon_obj]
@@ -171,7 +171,7 @@ theorem comul_tensorObj_tensorObj_left :
       = Coalgebra.comul (A := (M ⊗[R] N) ⊗[R] P) := by
   rw [ofComonObjCoalgebraStruct_comul]
   dsimp only [Equivalence.symm_inverse, comonEquivalence_functor, toComon_obj,
-    instCoalgebraStruct_comul]
+    comul_def]
   simp only [Comon_.monoidal_tensorObj_comul, toComonObj_X, ModuleCat.of_coe, toComonObj_comul]
   rw [ofComonObjCoalgebraStruct_comul]
   dsimp only [Equivalence.symm_inverse, comonEquivalence_functor, toComon_obj]

--- a/Mathlib/RingTheory/Coalgebra/Basic.lean
+++ b/Mathlib/RingTheory/Coalgebra/Basic.lean
@@ -397,6 +397,8 @@ lemma comul_def :
     tensorTensorTensorComm R A A B B ∘ₗ map comul comul :=
   rfl
 
+@[deprecated (since := "2025-04-09")] alias instCoalgebraStruct_comul := comul_def
+
 @[simp] lemma comul_tmul (a : A) (b : B) :
     comul (R := R) (a ⊗ₜ[R] b) =
       tensorTensorTensorComm _ _ _ _ _ (comul (R := R) a ⊗ₜ[R] comul (R := R) b) := rfl
@@ -404,6 +406,8 @@ lemma comul_def :
 lemma counit_def :
     Coalgebra.counit (R := R) (A := A ⊗[R] B) = TensorProduct.lid R R ∘ₗ map counit counit :=
   rfl
+
+@[deprecated (since := "2025-04-09")] alias instCoalgebraStruct_counit := counit_def
 
 @[simp] lemma counit_tmul (a : A) (b : B) :
     counit (R := R) (a ⊗ₜ[R] b) = counit a * counit b := rfl

--- a/Mathlib/RingTheory/Coalgebra/Basic.lean
+++ b/Mathlib/RingTheory/Coalgebra/Basic.lean
@@ -404,7 +404,7 @@ lemma comul_def :
       tensorTensorTensorComm _ _ _ _ _ (comul (R := R) a ⊗ₜ[R] comul (R := R) b) := rfl
 
 lemma counit_def :
-    Coalgebra.counit (R := R) (A := A ⊗[R] B) = TensorProduct.lid R R ∘ₗ map counit counit :=
+    Coalgebra.counit (R := R) (A := A ⊗[R] B) = LinearMap.mul' R R ∘ₗ map counit counit :=
   rfl
 
 @[deprecated (since := "2025-04-09")] alias instCoalgebraStruct_counit := counit_def

--- a/Mathlib/RingTheory/Coalgebra/Basic.lean
+++ b/Mathlib/RingTheory/Coalgebra/Basic.lean
@@ -388,9 +388,24 @@ variable {R A B : Type*} [CommSemiring R] [AddCommMonoid A] [AddCommMonoid B]
   [Module R A] [Module R B] [CoalgebraStruct R A] [CoalgebraStruct R B]
 
 /-- See `Mathlib.RingTheory.Coalgebra.TensorProduct` for the `Coalgebra` instance. -/
-@[simps] instance instCoalgebraStruct :
-    CoalgebraStruct R (A ⊗[R] B) where
+instance instCoalgebraStruct : CoalgebraStruct R (A ⊗[R] B) where
   comul := TensorProduct.tensorTensorTensorComm R A A B B ∘ₗ TensorProduct.map comul comul
   counit := LinearMap.mul' R R ∘ₗ TensorProduct.map counit counit
+
+lemma comul_def :
+    Coalgebra.comul (R := R) (A := A ⊗[R] B) =
+    tensorTensorTensorComm R A A B B ∘ₗ map comul comul :=
+  rfl
+
+@[simp] lemma comul_tmul (a : A) (b : B) :
+    comul (R := R) (a ⊗ₜ[R] b) =
+      tensorTensorTensorComm _ _ _ _ _ (comul (R := R) a ⊗ₜ[R] comul (R := R) b) := rfl
+
+lemma counit_def :
+    Coalgebra.counit (R := R) (A := A ⊗[R] B) = TensorProduct.lid R R ∘ₗ map counit counit :=
+  rfl
+
+@[simp] lemma counit_tmul (a : A) (b : B) :
+    counit (R := R) (a ⊗ₜ[R] b) = counit a * counit b := rfl
 
 end TensorProduct

--- a/Mathlib/RingTheory/Coalgebra/TensorProduct.lean
+++ b/Mathlib/RingTheory/Coalgebra/TensorProduct.lean
@@ -58,7 +58,7 @@ noncomputable instance TensorProduct.instCoalgebra : Coalgebra R (M ⊗[R] N) :=
         rw [CoalgebraCat.ofComonObjCoalgebraStruct_comul]
         simp [-Mon_.monMonoidalStruct_tensorObj_X,
           ModuleCat.MonoidalCategory.instMonoidalCategoryStruct_tensorHom,
-          ModuleCat.hom_comp, ModuleCat.of, ModuleCat.ofHom,
+          ModuleCat.hom_comp, ModuleCat.of, ModuleCat.ofHom, comul_def,
           ModuleCat.MonoidalCategory.tensorμ_eq_tensorTensorTensorComm] }
 
 end

--- a/Mathlib/RingTheory/HopfAlgebra/TensorProduct.lean
+++ b/Mathlib/RingTheory/HopfAlgebra/TensorProduct.lean
@@ -22,13 +22,13 @@ open HopfAlgebra
 noncomputable instance instHopfAlgebra : HopfAlgebra R (A ⊗[R] B) :=
   { antipode := map antipode antipode
     mul_antipode_rTensor_comul := by
-      simp only [instCoalgebraStruct_comul, instCoalgebraStruct_counit, LinearMap.rTensor_def,
+      simp only [comul_def, counit_def, LinearMap.rTensor_def,
         ← map_id, ← LinearMap.comp_assoc (map _ _), ← tensorTensorTensorComm_comp_map,
         Algebra.mul'_comp_tensorTensorTensorComm, ← map_comp]
       simp only [← LinearMap.rTensor_def, LinearMap.comp_assoc, mul_antipode_rTensor_comul,
         map_comp, Algebra.linearMap_comp_mul']
     mul_antipode_lTensor_comul := by
-      simp only [instCoalgebraStruct_comul, instCoalgebraStruct_counit, LinearMap.lTensor_def,
+      simp only [comul_def, counit_def, LinearMap.lTensor_def,
         ← map_id, ← LinearMap.comp_assoc (map _ _), ← tensorTensorTensorComm_comp_map,
         Algebra.mul'_comp_tensorTensorTensorComm, ← map_comp]
       simp only [← LinearMap.lTensor_def, LinearMap.comp_assoc, mul_antipode_lTensor_comul,


### PR DESCRIPTION
These are taken from https://github.com/ImperialCollegeLondon/FLT/blob/eef74b4538c8852363936dfaad23e6ffba72eca5/FLT/mathlibExperiments/Coalgebra/TensorProduct.lean

`simps` previously generated the `def` lemmas, but they were badly-named, and probably not actually convenient as `simp` lemmas.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
