### PR TITLE
[Merged by Bors] - feat(Order/GroupWithZero): drop more TC assumptions

### DIFF
--- a/Mathlib/Algebra/Order/GroupWithZero/Unbundled/Basic.lean
+++ b/Mathlib/Algebra/Order/GroupWithZero/Unbundled/Basic.lean
@@ -647,25 +647,26 @@ lemma one_le_sq_iff₀ (ha : 0 ≤ a) : 1 ≤ a ^ 2 ↔ 1 ≤ a :=
 lemma one_lt_sq_iff₀ (ha : 0 ≤ a) : 1 < a ^ 2 ↔ 1 < a :=
   one_lt_pow_iff_of_nonneg ha (Nat.succ_ne_zero _)
 
-lemma lt_of_pow_lt_pow_left₀ [MulPosMono M₀] (n : ℕ) (hb : 0 ≤ b) (h : a ^ n < b ^ n) : a < b :=
+variable [MulPosMono M₀]
+
+lemma lt_of_pow_lt_pow_left₀ (n : ℕ) (hb : 0 ≤ b) (h : a ^ n < b ^ n) : a < b :=
   lt_of_not_ge fun hn => not_lt_of_ge (pow_le_pow_left₀ hb hn _) h
 
-lemma le_of_pow_le_pow_left₀ [MulPosMono M₀] (hn : n ≠ 0) (hb : 0 ≤ b) (h : a ^ n ≤ b ^ n) :
-    a ≤ b :=
+lemma le_of_pow_le_pow_left₀ (hn : n ≠ 0) (hb : 0 ≤ b) (h : a ^ n ≤ b ^ n) : a ≤ b :=
   le_of_not_lt fun h1 => not_le_of_lt (pow_lt_pow_left₀ h1 hb hn) h
 
 @[simp]
-lemma sq_eq_sq₀ [MulPosMono M₀] (ha : 0 ≤ a) (hb : 0 ≤ b) : a ^ 2 = b ^ 2 ↔ a = b :=
+lemma sq_eq_sq₀ (ha : 0 ≤ a) (hb : 0 ≤ b) : a ^ 2 = b ^ 2 ↔ a = b :=
   pow_left_inj₀ ha hb (by decide)
 
-lemma lt_of_mul_self_lt_mul_self₀ [MulPosMono M₀] (hb : 0 ≤ b) : a * a < b * b → a < b := by
+lemma lt_of_mul_self_lt_mul_self₀ (hb : 0 ≤ b) : a * a < b * b → a < b := by
   simp only [← sq]
   exact lt_of_pow_lt_pow_left₀ _ hb
 
-lemma sq_lt_sq₀ [MulPosMono M₀] (ha : 0 ≤ a) (hb : 0 ≤ b) : a ^ 2 < b ^ 2 ↔ a < b :=
+lemma sq_lt_sq₀ (ha : 0 ≤ a) (hb : 0 ≤ b) : a ^ 2 < b ^ 2 ↔ a < b :=
   pow_lt_pow_iff_left₀ ha hb two_ne_zero
 
-lemma sq_le_sq₀ [MulPosMono M₀] (ha : 0 ≤ a) (hb : 0 ≤ b) : a ^ 2 ≤ b ^ 2 ↔ a ≤ b :=
+lemma sq_le_sq₀ (ha : 0 ≤ a) (hb : 0 ≤ b) : a ^ 2 ≤ b ^ 2 ↔ a ≤ b :=
   pow_le_pow_iff_left₀ ha hb two_ne_zero
 
 end MonoidWithZero.LinearOrder

--- a/Mathlib/Algebra/Order/GroupWithZero/Unbundled/Basic.lean
+++ b/Mathlib/Algebra/Order/GroupWithZero/Unbundled/Basic.lean
@@ -359,19 +359,23 @@ lemma zero_pow_le_one [ZeroLEOneClass M₀] : ∀ n : ℕ, (0 : M₀) ^ n ≤ 1
   | 0 => (pow_zero _).le
   | n + 1 => by rw [zero_pow n.succ_ne_zero]; exact zero_le_one
 
-lemma pow_le_pow_of_le_one [ZeroLEOneClass M₀] [PosMulMono M₀] [MulPosMono M₀] (ha₀ : 0 ≤ a)
-    (ha₁ : a ≤ 1) : ∀ {m n : ℕ}, m ≤ n → a ^ n ≤ a ^ m
-  | _, _, Nat.le.refl => le_rfl
-  | _, _, Nat.le.step h => by
-    rw [pow_succ']
-    exact (mul_le_of_le_one_left (pow_nonneg ha₀ _) ha₁).trans <| pow_le_pow_of_le_one ha₀ ha₁ h
+lemma pow_right_anti₀ [PosMulMono M₀] (ha₀ : 0 ≤ a) (ha₁ : a ≤ 1) : Antitone (fun n : ℕ ↦ a ^ n) :=
+  antitone_nat_of_succ_le fun n ↦ by
+    have : ZeroLEOneClass M₀ := ⟨ha₀.trans ha₁⟩
+    rw [← mul_one (a ^ n), pow_succ]
+    exact mul_le_mul_of_nonneg_left ha₁ (pow_nonneg ha₀ n)
 
-lemma pow_le_of_le_one [ZeroLEOneClass M₀] [PosMulMono M₀] [MulPosMono M₀] (h₀ : 0 ≤ a) (h₁ : a ≤ 1)
-    (hn : n ≠ 0) : a ^ n ≤ a :=
+lemma pow_le_pow_of_le_one [PosMulMono M₀] (ha₀ : 0 ≤ a) (ha₁ : a ≤ 1) {m n : ℕ}
+    (hmn : m ≤ n) : a ^ n ≤ a ^ m := pow_right_anti₀ ha₀ ha₁ hmn
+
+lemma pow_le_of_le_one [PosMulMono M₀] (h₀ : 0 ≤ a) (h₁ : a ≤ 1) (hn : n ≠ 0) : a ^ n ≤ a :=
   (pow_one a).subst (pow_le_pow_of_le_one h₀ h₁ (Nat.pos_of_ne_zero hn))
 
-lemma sq_le [ZeroLEOneClass M₀] [PosMulMono M₀] [MulPosMono M₀] (h₀ : 0 ≤ a) (h₁ : a ≤ 1) :
-    a ^ 2 ≤ a := pow_le_of_le_one h₀ h₁ two_ne_zero
+lemma sq_le [PosMulMono M₀] (h₀ : 0 ≤ a) (h₁ : a ≤ 1) : a ^ 2 ≤ a :=
+  pow_le_of_le_one h₀ h₁ two_ne_zero
+
+lemma pow_le_one₀ [PosMulMono M₀] {n : ℕ} (ha₀ : 0 ≤ a) (ha₁ : a ≤ 1) : a ^ n ≤ 1 :=
+  pow_zero a ▸ pow_right_anti₀ ha₀ ha₁ (Nat.zero_le n)
 
 lemma one_le_mul_of_one_le_of_one_le [ZeroLEOneClass M₀] [PosMulMono M₀] (ha : 1 ≤ a) (hb : 1 ≤ b) :
     (1 : M₀) ≤ a * b := ha.trans <| le_mul_of_one_le_right (zero_le_one.trans ha) hb
@@ -390,68 +394,63 @@ lemma mul_lt_one_of_nonneg_of_lt_one_left [PosMulMono M₀] (ha₀ : 0 ≤ a) (h
 lemma mul_lt_one_of_nonneg_of_lt_one_right [MulPosMono M₀] (ha : a ≤ 1) (hb₀ : 0 ≤ b) (hb : b < 1) :
     a * b < 1 := (mul_le_of_le_one_left hb₀ ha).trans_lt hb
 
-section
-variable [ZeroLEOneClass M₀] [PosMulMono M₀] [MulPosMono M₀]
-
 @[bound]
-protected lemma Bound.one_lt_mul : 1 ≤ a ∧ 1 < b ∨ 1 < a ∧ 1 ≤ b → 1 < a * b := by
+protected lemma Bound.one_lt_mul [ZeroLEOneClass M₀] [PosMulMono M₀] [MulPosMono M₀] :
+    1 ≤ a ∧ 1 < b ∨ 1 < a ∧ 1 ≤ b → 1 < a * b := by
   rintro (⟨ha, hb⟩ | ⟨ha, hb⟩); exacts [one_lt_mul ha hb, one_lt_mul_of_lt_of_le ha hb]
 
 @[bound]
-lemma mul_le_one₀ (ha : a ≤ 1) (hb₀ : 0 ≤ b) (hb : b ≤ 1) : a * b ≤ 1 :=
-  one_mul (1 : M₀) ▸ mul_le_mul ha hb hb₀ zero_le_one
+lemma mul_le_one₀ [MulPosMono M₀] (ha : a ≤ 1) (hb₀ : 0 ≤ b) (hb : b ≤ 1) : a * b ≤ 1 :=
+  (mul_le_mul_of_nonneg_right ha hb₀).trans <| by rwa [one_mul]
 
-lemma pow_le_one₀ : ∀ {n : ℕ}, 0 ≤ a → a ≤ 1 → a ^ n ≤ 1
-  | 0, _, _ => (pow_zero a).le
-  | n + 1, h₀, h₁ => (pow_succ a n).le.trans (mul_le_one₀ (pow_le_one₀ h₀ h₁) h₀ h₁)
-
-lemma pow_lt_one₀ (h₀ : 0 ≤ a) (h₁ : a < 1) : ∀ {n : ℕ}, n ≠ 0 → a ^ n < 1
+lemma pow_lt_one₀ [PosMulMono M₀] (h₀ : 0 ≤ a) (h₁ : a < 1) : ∀ {n : ℕ}, n ≠ 0 → a ^ n < 1
   | 0, h => (h rfl).elim
   | n + 1, _ => by
     rw [pow_succ']; exact mul_lt_one_of_nonneg_of_lt_one_left h₀ h₁ (pow_le_one₀ h₀ h₁.le)
 
-lemma one_le_pow₀ (ha : 1 ≤ a) : ∀ {n : ℕ}, 1 ≤ a ^ n
-  | 0 => by rw [pow_zero]
-  | n + 1 => by
-    simpa only [pow_succ', mul_one]
-      using mul_le_mul ha (one_le_pow₀ ha) zero_le_one (zero_le_one.trans ha)
+lemma pow_right_mono₀ [ZeroLEOneClass M₀] [PosMulMono M₀] (h : 1 ≤ a) : Monotone (a ^ ·) :=
+  monotone_nat_of_le_succ fun n => by
+    rw [pow_succ]; exact le_mul_of_one_le_right (pow_nonneg (zero_le_one.trans h) _) h
 
-lemma one_lt_pow₀ (ha : 1 < a) : ∀ {n : ℕ}, n ≠ 0 → 1 < a ^ n
+lemma one_le_pow₀ [ZeroLEOneClass M₀] [PosMulMono M₀] (ha : 1 ≤ a) {n : ℕ} : 1 ≤ a ^ n :=
+  pow_zero a ▸ pow_right_mono₀ ha n.zero_le
+
+lemma one_lt_pow₀ [ZeroLEOneClass M₀] [PosMulMono M₀] (ha : 1 < a) : ∀ {n : ℕ}, n ≠ 0 → 1 < a ^ n
   | 0, h => (h rfl).elim
   | n + 1, _ => by rw [pow_succ']; exact one_lt_mul_of_lt_of_le ha (one_le_pow₀ ha.le)
 
-lemma pow_right_mono₀ (h : 1 ≤ a) : Monotone (a ^ ·) :=
-  monotone_nat_of_le_succ fun n => by
-    rw [pow_succ']; exact le_mul_of_one_le_left (pow_nonneg (zero_le_one.trans h) _) h
-
 /-- `bound` lemma for branching on `1 ≤ a ∨ a ≤ 1` when proving `a ^ n ≤ a ^ m` -/
 @[bound]
-lemma Bound.pow_le_pow_right_of_le_one_or_one_le (h : 1 ≤ a ∧ n ≤ m ∨ 0 ≤ a ∧ a ≤ 1 ∧ m ≤ n) :
+lemma Bound.pow_le_pow_right_of_le_one_or_one_le [ZeroLEOneClass M₀] [PosMulMono M₀]
+    (h : 1 ≤ a ∧ n ≤ m ∨ 0 ≤ a ∧ a ≤ 1 ∧ m ≤ n) :
     a ^ n ≤ a ^ m := by
   obtain ⟨a1, nm⟩ | ⟨a0, a1, mn⟩ := h
   · exact pow_right_mono₀ a1 nm
   · exact pow_le_pow_of_le_one a0 a1 mn
 
 @[gcongr]
-lemma pow_le_pow_right₀ (ha : 1 ≤ a) (hmn : m ≤ n) : a ^ m ≤ a ^ n := pow_right_mono₀ ha hmn
+lemma pow_le_pow_right₀ [ZeroLEOneClass M₀] [PosMulMono M₀] (ha : 1 ≤ a) (hmn : m ≤ n) :
+    a ^ m ≤ a ^ n :=
+  pow_right_mono₀ ha hmn
 
-lemma le_self_pow₀ (ha : 1 ≤ a) (hn : n ≠ 0) : a ≤ a ^ n := by
+lemma le_self_pow₀ [ZeroLEOneClass M₀] [PosMulMono M₀] (ha : 1 ≤ a) (hn : n ≠ 0) : a ≤ a ^ n := by
   simpa only [pow_one] using pow_le_pow_right₀ ha <| Nat.pos_iff_ne_zero.2 hn
 
 /-- The `bound` tactic can't handle `m ≠ 0` goals yet, so we express as `0 < m` -/
 @[bound]
-lemma Bound.le_self_pow_of_pos (ha : 1 ≤ a) (hn : 0 < n) : a ≤ a ^ n := le_self_pow₀ ha hn.ne'
+lemma Bound.le_self_pow_of_pos [ZeroLEOneClass M₀] [PosMulMono M₀] (ha : 1 ≤ a) (hn : 0 < n) :
+    a ≤ a ^ n := le_self_pow₀ ha hn.ne'
 
 @[mono, gcongr, bound]
-theorem pow_le_pow_left₀ (ha : 0 ≤ a) (hab : a ≤ b) : ∀ n, a ^ n ≤ b ^ n
+theorem pow_le_pow_left₀ [ZeroLEOneClass M₀] [PosMulMono M₀] [MulPosMono M₀]
+    (ha : 0 ≤ a) (hab : a ≤ b) : ∀ n, a ^ n ≤ b ^ n
   | 0 => by simp
   | n + 1 => by simpa only [pow_succ']
       using mul_le_mul hab (pow_le_pow_left₀ ha hab _) (pow_nonneg ha _) (ha.trans hab)
 
-lemma pow_left_monotoneOn : MonotoneOn (fun a : M₀ ↦ a ^ n) {x | 0 ≤ x} :=
+lemma pow_left_monotoneOn [ZeroLEOneClass M₀] [PosMulMono M₀] [MulPosMono M₀] :
+    MonotoneOn (fun a : M₀ ↦ a ^ n) {x | 0 ≤ x} :=
   fun _a ha _b _ hab ↦ pow_le_pow_left₀ ha hab _
-
-end
 
 variable [Preorder α] {f g : α → M₀}
 
@@ -503,6 +502,9 @@ lemma lt_mul_right [PosMulStrictMono M₀] (ha : 0 < a) (hb : 1 < b) : a < a * b
 lemma lt_mul_self [ZeroLEOneClass M₀] [MulPosStrictMono M₀] (ha : 1 < a) : a < a * a :=
   lt_mul_left (ha.trans_le' zero_le_one) ha
 
+lemma sq_pos_of_pos [PosMulStrictMono M₀] (ha : 0 < a) : 0 < a ^ 2 := by
+  simpa only [sq] using mul_pos ha ha
+
 section strict_mono
 variable [ZeroLEOneClass M₀] [PosMulStrictMono M₀]
 
@@ -510,26 +512,22 @@ variable [ZeroLEOneClass M₀] [PosMulStrictMono M₀]
   | 0 => by nontriviality; rw [pow_zero]; exact zero_lt_one
   | _ + 1 => pow_succ a _ ▸ mul_pos (pow_pos ha _) ha
 
-lemma sq_pos_of_pos (ha : 0 < a) : 0 < a ^ 2 := pow_pos ha _
-
-variable [MulPosStrictMono M₀]
-
 @[gcongr, bound]
-lemma pow_lt_pow_left₀ (hab : a < b)
+lemma pow_lt_pow_left₀ [MulPosMono M₀] (hab : a < b)
     (ha : 0 ≤ a) : ∀ {n : ℕ}, n ≠ 0 → a ^ n < b ^ n
   | n + 1, _ => by
     simpa only [pow_succ] using mul_lt_mul_of_le_of_lt_of_nonneg_of_pos
       (pow_le_pow_left₀ ha hab.le _) hab ha (pow_pos (ha.trans_lt hab) _)
 
 /-- See also `pow_left_strictMono₀` and `Nat.pow_left_strictMono`. -/
-lemma pow_left_strictMonoOn₀ (hn : n ≠ 0) : StrictMonoOn (· ^ n : M₀ → M₀) {a | 0 ≤ a} :=
+lemma pow_left_strictMonoOn₀ [MulPosMono M₀] (hn : n ≠ 0) :
+    StrictMonoOn (· ^ n : M₀ → M₀) {a | 0 ≤ a} :=
   fun _a ha _b _ hab ↦ pow_lt_pow_left₀ hab ha hn
 
 /-- See also `pow_right_strictMono'`. -/
 lemma pow_right_strictMono₀ (h : 1 < a) : StrictMono (a ^ ·) :=
-  have : 0 < a := zero_le_one.trans_lt h
   strictMono_nat_of_lt_succ fun n => by
-    simpa only [one_mul, pow_succ'] using mul_lt_mul h (le_refl (a ^ n)) (pow_pos this _) this.le
+    simpa only [one_mul, pow_succ] using lt_mul_right (pow_pos (zero_le_one.trans_lt h) _) h
 
 @[gcongr]
 lemma pow_lt_pow_right₀ (h : 1 < a) (hmn : m < n) : a ^ m < a ^ n := pow_right_strictMono₀ h hmn
@@ -545,7 +543,7 @@ lemma lt_self_pow₀ (h : 1 < a) (hm : 1 < m) : a < a ^ m := by
 
 lemma pow_right_strictAnti₀ (h₀ : 0 < a) (h₁ : a < 1) : StrictAnti (a ^ ·) :=
   strictAnti_nat_of_succ_lt fun n => by
-    simpa only [pow_succ', one_mul] using mul_lt_mul h₁ le_rfl (pow_pos h₀ n) zero_le_one
+    simpa only [pow_succ, mul_one] using mul_lt_mul_of_pos_left h₁ (pow_pos h₀ n)
 
 lemma pow_lt_pow_iff_right_of_lt_one₀ (h₀ : 0 < a) (h₁ : a < 1) : a ^ m < a ^ n ↔ n < m :=
   (pow_right_strictAnti₀ h₀ h₁).lt_iff_lt
@@ -593,17 +591,20 @@ lemma StrictMono.mul [PosMulStrictMono M₀] [MulPosStrictMono M₀] (hf : Stric
 end PartialOrder
 
 section LinearOrder
-variable [LinearOrder M₀] [ZeroLEOneClass M₀] [PosMulStrictMono M₀] [MulPosStrictMono M₀] {a b : M₀}
+variable [LinearOrder M₀] [ZeroLEOneClass M₀] [PosMulStrictMono M₀] {a b : M₀}
   {m n : ℕ}
 
-lemma pow_le_pow_iff_left₀ (ha : 0 ≤ a) (hb : 0 ≤ b) (hn : n ≠ 0) : a ^ n ≤ b ^ n ↔ a ≤ b :=
+lemma pow_le_pow_iff_left₀ [MulPosMono M₀] (ha : 0 ≤ a) (hb : 0 ≤ b) (hn : n ≠ 0) :
+    a ^ n ≤ b ^ n ↔ a ≤ b :=
   (pow_left_strictMonoOn₀ hn).le_iff_le ha hb
 
-lemma pow_lt_pow_iff_left₀ (ha : 0 ≤ a) (hb : 0 ≤ b) (hn : n ≠ 0) : a ^ n < b ^ n ↔ a < b :=
+lemma pow_lt_pow_iff_left₀ [MulPosMono M₀] (ha : 0 ≤ a) (hb : 0 ≤ b) (hn : n ≠ 0) :
+    a ^ n < b ^ n ↔ a < b :=
   (pow_left_strictMonoOn₀ hn).lt_iff_lt ha hb
 
 @[simp]
-lemma pow_left_inj₀ (ha : 0 ≤ a) (hb : 0 ≤ b) (hn : n ≠ 0) : a ^ n = b ^ n ↔ a = b :=
+lemma pow_left_inj₀ [MulPosMono M₀] (ha : 0 ≤ a) (hb : 0 ≤ b) (hn : n ≠ 0) :
+    a ^ n = b ^ n ↔ a = b :=
   (pow_left_strictMonoOn₀ hn).eq_iff_eq ha hb
 
 lemma pow_right_injective₀ (ha₀ : 0 < a) (ha₁ : a ≠ 1) : Injective (a ^ ·) := by
@@ -616,19 +617,23 @@ lemma pow_right_inj₀ (ha₀ : 0 < a) (ha₁ : a ≠ 1) : a ^ m = a ^ n ↔ m =
   (pow_right_injective₀ ha₀ ha₁).eq_iff
 
 lemma pow_le_one_iff_of_nonneg (ha : 0 ≤ a) (hn : n ≠ 0) : a ^ n ≤ 1 ↔ a ≤ 1 := by
-  simpa only [one_pow] using pow_le_pow_iff_left₀ ha zero_le_one hn
+  refine ⟨fun h ↦ ?_, pow_le_one₀ ha⟩
+  contrapose! h
+  exact one_lt_pow₀ h hn
 
 lemma one_le_pow_iff_of_nonneg (ha : 0 ≤ a) (hn : n ≠ 0) : 1 ≤ a ^ n ↔ 1 ≤ a := by
-  simpa only [one_pow] using pow_le_pow_iff_left₀ zero_le_one ha hn
+  refine ⟨fun h ↦ ?_, fun h ↦ one_le_pow₀ h⟩
+  contrapose! h
+  exact pow_lt_one₀ ha h hn
 
 lemma pow_lt_one_iff_of_nonneg (ha : 0 ≤ a) (hn : n ≠ 0) : a ^ n < 1 ↔ a < 1 :=
   lt_iff_lt_of_le_iff_le (one_le_pow_iff_of_nonneg ha hn)
 
 lemma one_lt_pow_iff_of_nonneg (ha : 0 ≤ a) (hn : n ≠ 0) : 1 < a ^ n ↔ 1 < a := by
-  simpa only [one_pow] using pow_lt_pow_iff_left₀ zero_le_one ha hn
+  simp only [← not_le, pow_le_one_iff_of_nonneg ha hn]
 
 lemma pow_eq_one_iff_of_nonneg (ha : 0 ≤ a) (hn : n ≠ 0) : a ^ n = 1 ↔ a = 1 := by
-  simpa only [one_pow] using pow_left_inj₀ ha zero_le_one hn
+  simp only [le_antisymm_iff, pow_le_one_iff_of_nonneg ha hn, one_le_pow_iff_of_nonneg ha hn]
 
 lemma sq_le_one_iff₀ (ha : 0 ≤ a) : a ^ 2 ≤ 1 ↔ a ≤ 1 :=
   pow_le_one_iff_of_nonneg ha (Nat.succ_ne_zero _)
@@ -642,23 +647,25 @@ lemma one_le_sq_iff₀ (ha : 0 ≤ a) : 1 ≤ a ^ 2 ↔ 1 ≤ a :=
 lemma one_lt_sq_iff₀ (ha : 0 ≤ a) : 1 < a ^ 2 ↔ 1 < a :=
   one_lt_pow_iff_of_nonneg ha (Nat.succ_ne_zero _)
 
-lemma lt_of_pow_lt_pow_left₀ (n : ℕ) (hb : 0 ≤ b) (h : a ^ n < b ^ n) : a < b :=
+lemma lt_of_pow_lt_pow_left₀ [MulPosMono M₀] (n : ℕ) (hb : 0 ≤ b) (h : a ^ n < b ^ n) : a < b :=
   lt_of_not_ge fun hn => not_lt_of_ge (pow_le_pow_left₀ hb hn _) h
 
-lemma le_of_pow_le_pow_left₀ (hn : n ≠ 0) (hb : 0 ≤ b) (h : a ^ n ≤ b ^ n) : a ≤ b :=
+lemma le_of_pow_le_pow_left₀ [MulPosMono M₀] (hn : n ≠ 0) (hb : 0 ≤ b) (h : a ^ n ≤ b ^ n) :
+    a ≤ b :=
   le_of_not_lt fun h1 => not_le_of_lt (pow_lt_pow_left₀ h1 hb hn) h
 
 @[simp]
-lemma sq_eq_sq₀ (ha : 0 ≤ a) (hb : 0 ≤ b) : a ^ 2 = b ^ 2 ↔ a = b := pow_left_inj₀ ha hb (by decide)
+lemma sq_eq_sq₀ [MulPosMono M₀] (ha : 0 ≤ a) (hb : 0 ≤ b) : a ^ 2 = b ^ 2 ↔ a = b :=
+  pow_left_inj₀ ha hb (by decide)
 
-lemma lt_of_mul_self_lt_mul_self₀ (hb : 0 ≤ b) : a * a < b * b → a < b := by
-  simp_rw [← sq]
+lemma lt_of_mul_self_lt_mul_self₀ [MulPosMono M₀] (hb : 0 ≤ b) : a * a < b * b → a < b := by
+  simp only [← sq]
   exact lt_of_pow_lt_pow_left₀ _ hb
 
-lemma sq_lt_sq₀ (ha : 0 ≤ a) (hb : 0 ≤ b) : a ^ 2 < b ^ 2 ↔ a < b :=
+lemma sq_lt_sq₀ [MulPosMono M₀] (ha : 0 ≤ a) (hb : 0 ≤ b) : a ^ 2 < b ^ 2 ↔ a < b :=
   pow_lt_pow_iff_left₀ ha hb two_ne_zero
 
-lemma sq_le_sq₀ (ha : 0 ≤ a) (hb : 0 ≤ b) : a ^ 2 ≤ b ^ 2 ↔ a ≤ b :=
+lemma sq_le_sq₀ [MulPosMono M₀] (ha : 0 ≤ a) (hb : 0 ≤ b) : a ^ 2 ≤ b ^ 2 ↔ a ≤ b :=
   pow_le_pow_iff_left₀ ha hb two_ne_zero
 
 end MonoidWithZero.LinearOrder


### PR DESCRIPTION
---

I used the following steps to ensure that all new lemmas have fewer TC assumptions.

- Run the following script at the end of the file, both on `master` and on the new branch.

```lean
open Lean

-- Pure version of a function from Batteries; I still don't know how to switch between monads
def isAutoDecl (env : Environment) (decl : Name) : Bool := Id.run do
  if decl.hasMacroScopes then return true
  if decl.isInternal then return true
  if isReservedName env decl then return true
  if let Name.str n s := decl then
    if s.startsWith "proof_" || s.startsWith "match_" || s.startsWith "unsafe_" then return true
    if env.isConstructor n && ["injEq", "inj", "sizeOf_spec"].any (· == s) then
      return true
    if let ConstantInfo.inductInfo _ := env.find? n then
      if s.startsWith "brecOn_" || s.startsWith "below_" || s.startsWith "binductionOn_"
        || s.startsWith "ibelow_" then return true
      if [casesOnSuffix, recOnSuffix, brecOnSuffix, binductionOnSuffix, belowSuffix, "ibelow",
          "ndrec", "ndrecOn", "noConfusionType", "noConfusion", "ofNat", "toCtorIdx"
        ].any (· == s) then
        return true
      if let some _ := isSubobjectField? env n (.mkSimple s) then
        return true
  pure false

run_cmd do
  let e ← getEnv
  let names :=
    e.constants.map₂.foldl (init := #[]) fun r k _ => if isAutoDecl e k then r else r.push k
  let names := names.qsort ((· < ·) on Name.toString)
  for n in names.map Lean.mkIdent do
    Lean.Elab.Command.elabCommand (← `(
      #check $n
    ))
```

- run the following command and look at the highlighted changes.
```bash
$ diff -u old.lean new.lean | diff-so-fancy | less
```

<details><summary>Details</summary>
<p>

```diff
--- old.lean	2025-04-09 23:28:41.271594367 -0500
+++ new.lean	2025-04-09 23:24:10.051153414 -0500
@@ -3,13 +3,13 @@
 Antitone.mul_const.{u_1, u_2} {α : Type u_1} {M₀ : Type u_2} [MonoidWithZero M₀] [Preorder M₀] {a : M₀} [Preorder α]
   {f : α → M₀} [MulPosMono M₀] (hf : Antitone f) (ha : 0 ≤ a) : Antitone fun x => f x * a
 Bound.le_self_pow_of_pos.{u_2} {M₀ : Type u_2} [MonoidWithZero M₀] [Preorder M₀] {a : M₀} {n : ℕ} [ZeroLEOneClass M₀]
-  [PosMulMono M₀] [MulPosMono M₀] (ha : 1 ≤ a) (hn : 0 < n) : a ≤ a ^ n
+  [PosMulMono M₀] (ha : 1 ≤ a) (hn : 0 < n) : a ≤ a ^ n
 Bound.one_le_inv₀.{u_3} {G₀ : Type u_3} [GroupWithZero G₀] [PartialOrder G₀] [PosMulReflectLT G₀] {a : G₀}
   [PosMulMono G₀] (ha : 0 < a) : a ≤ 1 → 1 ≤ a⁻¹
 Bound.one_lt_mul.{u_2} {M₀ : Type u_2} [MonoidWithZero M₀] [Preorder M₀] {a b : M₀} [ZeroLEOneClass M₀] [PosMulMono M₀]
   [MulPosMono M₀] : 1 ≤ a ∧ 1 < b ∨ 1 < a ∧ 1 ≤ b → 1 < a * b
 Bound.pow_le_pow_right_of_le_one_or_one_le.{u_2} {M₀ : Type u_2} [MonoidWithZero M₀] [Preorder M₀] {a : M₀} {m n : ℕ}
-  [ZeroLEOneClass M₀] [PosMulMono M₀] [MulPosMono M₀] (h : 1 ≤ a ∧ n ≤ m ∨ 0 ≤ a ∧ a ≤ 1 ∧ m ≤ n) : a ^ n ≤ a ^ m
+  [ZeroLEOneClass M₀] [PosMulMono M₀] (h : 1 ≤ a ∧ n ≤ m ∨ 0 ≤ a ∧ a ≤ 1 ∧ m ≤ n) : a ^ n ≤ a ^ m
 Decidable.mul_lt_mul''.{u_2} {M₀ : Type u_2} [MonoidWithZero M₀] [PartialOrder M₀] {a b c d : M₀} [PosMulMono M₀]
   [PosMulStrictMono M₀] [MulPosStrictMono M₀] [DecidableLE M₀] (h1 : a < c) (h2 : b < d) (h3 : 0 ≤ a) (h4 : 0 ≤ b) :
   a * b < c * d
@@ -216,9 +216,9 @@
 le_mul_of_one_le_right.{u_1} {α : Type u_1} [MulOneClass α] [Zero α] {a b : α} [Preorder α] [PosMulMono α] (ha : 0 ≤ a)
   (h : 1 ≤ b) : a ≤ a * b
 le_of_pow_le_pow_left₀.{u_2} {M₀ : Type u_2} [MonoidWithZero M₀] [LinearOrder M₀] [ZeroLEOneClass M₀]
-  [PosMulStrictMono M₀] [MulPosStrictMono M₀] {a b : M₀} {n : ℕ} (hn : n ≠ 0) (hb : 0 ≤ b) (h : a ^ n ≤ b ^ n) : a ≤ b
+  [PosMulStrictMono M₀] {a b : M₀} {n : ℕ} [MulPosMono M₀] (hn : n ≠ 0) (hb : 0 ≤ b) (h : a ^ n ≤ b ^ n) : a ≤ b
 le_self_pow₀.{u_2} {M₀ : Type u_2} [MonoidWithZero M₀] [Preorder M₀] {a : M₀} {n : ℕ} [ZeroLEOneClass M₀]
-  [PosMulMono M₀] [MulPosMono M₀] (ha : 1 ≤ a) (hn : n ≠ 0) : a ≤ a ^ n
+  [PosMulMono M₀] (ha : 1 ≤ a) (hn : n ≠ 0) : a ≤ a ^ n
 lt_div_comm₀.{u_3} {G₀ : Type u_3} [CommGroupWithZero G₀] [PartialOrder G₀] [PosMulReflectLT G₀] [PosMulStrictMono G₀]
   {a b c : G₀} (ha : 0 < a) (hc : 0 < c) : a < b / c ↔ c < b / a
 lt_div_iff₀.{u_3} {G₀ : Type u_3} [GroupWithZero G₀] [PartialOrder G₀] [PosMulReflectLT G₀] {a b c : G₀}
@@ -252,11 +252,11 @@
 lt_mul_self.{u_2} {M₀ : Type u_2} [MonoidWithZero M₀] [PartialOrder M₀] {a : M₀} [ZeroLEOneClass M₀]
   [MulPosStrictMono M₀] (ha : 1 < a) : a < a * a
 lt_of_mul_self_lt_mul_self₀.{u_2} {M₀ : Type u_2} [MonoidWithZero M₀] [LinearOrder M₀] [ZeroLEOneClass M₀]
-  [PosMulStrictMono M₀] [MulPosStrictMono M₀] {a b : M₀} (hb : 0 ≤ b) : a * a < b * b → a < b
+  [PosMulStrictMono M₀] {a b : M₀} [MulPosMono M₀] (hb : 0 ≤ b) : a * a < b * b → a < b
 lt_of_pow_lt_pow_left₀.{u_2} {M₀ : Type u_2} [MonoidWithZero M₀] [LinearOrder M₀] [ZeroLEOneClass M₀]
-  [PosMulStrictMono M₀] [MulPosStrictMono M₀] {a b : M₀} (n : ℕ) (hb : 0 ≤ b) (h : a ^ n < b ^ n) : a < b
+  [PosMulStrictMono M₀] {a b : M₀} [MulPosMono M₀] (n : ℕ) (hb : 0 ≤ b) (h : a ^ n < b ^ n) : a < b
 lt_self_pow₀.{u_2} {M₀ : Type u_2} [MonoidWithZero M₀] [PartialOrder M₀] {a : M₀} {m : ℕ} [ZeroLEOneClass M₀]
-  [PosMulStrictMono M₀] [MulPosStrictMono M₀] (h : 1 < a) (hm : 1 < m) : a < a ^ m
+  [PosMulStrictMono M₀] (h : 1 < a) (hm : 1 < m) : a < a ^ m
 monotone_mul_left_of_nonneg.{u_2} {M₀ : Type u_2} [MonoidWithZero M₀] [Preorder M₀] {a : M₀} [PosMulMono M₀]
   (ha : 0 ≤ a) : Monotone fun x => a * x
 monotone_mul_right_of_nonneg.{u_2} {M₀ : Type u_2} [MonoidWithZero M₀] [Preorder M₀] {a : M₀} [MulPosMono M₀]
@@ -301,8 +301,8 @@
   (h : a ≤ 1) : a * b ≤ b
 mul_le_of_le_one_right.{u_1} {α : Type u_1} [MulOneClass α] [Zero α] {a b : α} [Preorder α] [PosMulMono α] (ha : 0 ≤ a)
   (h : b ≤ 1) : a * b ≤ a
-mul_le_one₀.{u_2} {M₀ : Type u_2} [MonoidWithZero M₀] [Preorder M₀] {a b : M₀} [ZeroLEOneClass M₀] [PosMulMono M₀]
-  [MulPosMono M₀] (ha : a ≤ 1) (hb₀ : 0 ≤ b) (hb : b ≤ 1) : a * b ≤ 1
+mul_le_one₀.{u_2} {M₀ : Type u_2} [MonoidWithZero M₀] [Preorder M₀] {a b : M₀} [MulPosMono M₀] (ha : a ≤ 1)
+  (hb₀ : 0 ≤ b) (hb : b ≤ 1) : a * b ≤ 1
 mul_left_cancel_iff_of_pos.{u_1} {α : Type u_1} [MulZeroClass α] {a b c : α} [PartialOrder α] [PosMulReflectLE α]
   (a0 : 0 < a) : a * b = a * c ↔ b = c
 mul_lt_iff_lt_one_left.{u_1} {α : Type u_1} [MulOneClass α] [Zero α] {a b : α} [Preorder α] [MulPosStrictMono α]
@@ -377,11 +377,11 @@
 one_le_of_le_mul_right₀.{u_1} {α : Type u_1} [MulOneClass α] [Zero α] {a b : α} [Preorder α] [MulPosReflectLE α]
   (hb : 0 < b) (h : b ≤ a * b) : 1 ≤ a
 one_le_pow_iff_of_nonneg.{u_2} {M₀ : Type u_2} [MonoidWithZero M₀] [LinearOrder M₀] [ZeroLEOneClass M₀]
-  [PosMulStrictMono M₀] [MulPosStrictMono M₀] {a : M₀} {n : ℕ} (ha : 0 ≤ a) (hn : n ≠ 0) : 1 ≤ a ^ n ↔ 1 ≤ a
+  [PosMulStrictMono M₀] {a : M₀} {n : ℕ} (ha : 0 ≤ a) (hn : n ≠ 0) : 1 ≤ a ^ n ↔ 1 ≤ a
 one_le_pow₀.{u_2} {M₀ : Type u_2} [MonoidWithZero M₀] [Preorder M₀] {a : M₀} [ZeroLEOneClass M₀] [PosMulMono M₀]
-  [MulPosMono M₀] (ha : 1 ≤ a) {n : ℕ} : 1 ≤ a ^ n
+  (ha : 1 ≤ a) {n : ℕ} : 1 ≤ a ^ n
 one_le_sq_iff₀.{u_2} {M₀ : Type u_2} [MonoidWithZero M₀] [LinearOrder M₀] [ZeroLEOneClass M₀] [PosMulStrictMono M₀]
-  [MulPosStrictMono M₀] {a : M₀} (ha : 0 ≤ a) : 1 ≤ a ^ 2 ↔ 1 ≤ a
+  {a : M₀} (ha : 0 ≤ a) : 1 ≤ a ^ 2 ↔ 1 ≤ a
 one_le_zpow_iff_right_of_lt_one₀.{u_3} {G₀ : Type u_3} [GroupWithZero G₀] [PartialOrder G₀] [PosMulReflectLT G₀]
   {a : G₀} [PosMulStrictMono G₀] {n : ℤ} [ZeroLEOneClass G₀] (ha₀ : 0 < a) (ha₁ : a < 1) : 1 ≤ a ^ n ↔ n ≤ 0
 one_le_zpow_iff_right₀.{u_3} {G₀ : Type u_3} [GroupWithZero G₀] [PartialOrder G₀] [PosMulReflectLT G₀] {a : G₀}
@@ -407,11 +407,11 @@
 one_lt_of_lt_mul_right₀.{u_1} {α : Type u_1} [MulOneClass α] [Zero α] {a b : α} [Preorder α] [MulPosReflectLT α]
   (hb : 0 ≤ b) (h : b < a * b) : 1 < a
 one_lt_pow_iff_of_nonneg.{u_2} {M₀ : Type u_2} [MonoidWithZero M₀] [LinearOrder M₀] [ZeroLEOneClass M₀]
-  [PosMulStrictMono M₀] [MulPosStrictMono M₀] {a : M₀} {n : ℕ} (ha : 0 ≤ a) (hn : n ≠ 0) : 1 < a ^ n ↔ 1 < a
+  [PosMulStrictMono M₀] {a : M₀} {n : ℕ} (ha : 0 ≤ a) (hn : n ≠ 0) : 1 < a ^ n ↔ 1 < a
 one_lt_pow₀.{u_2} {M₀ : Type u_2} [MonoidWithZero M₀] [Preorder M₀] {a : M₀} [ZeroLEOneClass M₀] [PosMulMono M₀]
-  [MulPosMono M₀] (ha : 1 < a) {n : ℕ} : n ≠ 0 → 1 < a ^ n
+  (ha : 1 < a) {n : ℕ} : n ≠ 0 → 1 < a ^ n
 one_lt_sq_iff₀.{u_2} {M₀ : Type u_2} [MonoidWithZero M₀] [LinearOrder M₀] [ZeroLEOneClass M₀] [PosMulStrictMono M₀]
-  [MulPosStrictMono M₀] {a : M₀} (ha : 0 ≤ a) : 1 < a ^ 2 ↔ 1 < a
+  {a : M₀} (ha : 0 ≤ a) : 1 < a ^ 2 ↔ 1 < a
 one_lt_zpow_iff_right_of_lt_one₀.{u_3} {G₀ : Type u_3} [GroupWithZero G₀] [PartialOrder G₀] [PosMulReflectLT G₀]
   {a : G₀} [PosMulStrictMono G₀] {n : ℤ} [ZeroLEOneClass G₀] (ha₀ : 0 < a) (ha₁ : a < 1) : 1 < a ^ n ↔ n < 0
 one_lt_zpow_iff_right₀.{u_3} {G₀ : Type u_3} [GroupWithZero G₀] [PartialOrder G₀] [PosMulReflectLT G₀] {a : G₀}
@@ -437,78 +437,79 @@
 pos_of_mul_pos_right.{u_1} {α : Type u_1} [MulZeroClass α] {a b : α} [Preorder α] [PosMulReflectLT α] (h : 0 < a * b)
   (ha : 0 ≤ a) : 0 < b
 pow_eq_one_iff_of_nonneg.{u_2} {M₀ : Type u_2} [MonoidWithZero M₀] [LinearOrder M₀] [ZeroLEOneClass M₀]
-  [PosMulStrictMono M₀] [MulPosStrictMono M₀] {a : M₀} {n : ℕ} (ha : 0 ≤ a) (hn : n ≠ 0) : a ^ n = 1 ↔ a = 1
-pow_le_of_le_one.{u_2} {M₀ : Type u_2} [MonoidWithZero M₀] [Preorder M₀] {a : M₀} {n : ℕ} [ZeroLEOneClass M₀]
-  [PosMulMono M₀] [MulPosMono M₀] (h₀ : 0 ≤ a) (h₁ : a ≤ 1) (hn : n ≠ 0) : a ^ n ≤ a
+  [PosMulStrictMono M₀] {a : M₀} {n : ℕ} (ha : 0 ≤ a) (hn : n ≠ 0) : a ^ n = 1 ↔ a = 1
+pow_le_of_le_one.{u_2} {M₀ : Type u_2} [MonoidWithZero M₀] [Preorder M₀] {a : M₀} {n : ℕ} [PosMulMono M₀] (h₀ : 0 ≤ a)
+  (h₁ : a ≤ 1) (hn : n ≠ 0) : a ^ n ≤ a
 pow_le_one_iff_of_nonneg.{u_2} {M₀ : Type u_2} [MonoidWithZero M₀] [LinearOrder M₀] [ZeroLEOneClass M₀]
-  [PosMulStrictMono M₀] [MulPosStrictMono M₀] {a : M₀} {n : ℕ} (ha : 0 ≤ a) (hn : n ≠ 0) : a ^ n ≤ 1 ↔ a ≤ 1
-pow_le_one₀.{u_2} {M₀ : Type u_2} [MonoidWithZero M₀] [Preorder M₀] {a : M₀} [ZeroLEOneClass M₀] [PosMulMono M₀]
-  [MulPosMono M₀] {n : ℕ} : 0 ≤ a → a ≤ 1 → a ^ n ≤ 1
+  [PosMulStrictMono M₀] {a : M₀} {n : ℕ} (ha : 0 ≤ a) (hn : n ≠ 0) : a ^ n ≤ 1 ↔ a ≤ 1
+pow_le_one₀.{u_2} {M₀ : Type u_2} [MonoidWithZero M₀] [Preorder M₀] {a : M₀} [PosMulMono M₀] {n : ℕ} (ha₀ : 0 ≤ a)
+  (ha₁ : a ≤ 1) : a ^ n ≤ 1
 pow_le_pow_iff_left₀.{u_2} {M₀ : Type u_2} [MonoidWithZero M₀] [LinearOrder M₀] [ZeroLEOneClass M₀]
-  [PosMulStrictMono M₀] [MulPosStrictMono M₀] {a b : M₀} {n : ℕ} (ha : 0 ≤ a) (hb : 0 ≤ b) (hn : n ≠ 0) :
+  [PosMulStrictMono M₀] {a b : M₀} {n : ℕ} [MulPosMono M₀] (ha : 0 ≤ a) (hb : 0 ≤ b) (hn : n ≠ 0) :
   a ^ n ≤ b ^ n ↔ a ≤ b
 pow_le_pow_iff_right₀.{u_2} {M₀ : Type u_2} [MonoidWithZero M₀] [PartialOrder M₀] {a : M₀} {m n : ℕ} [ZeroLEOneClass M₀]
-  [PosMulStrictMono M₀] [MulPosStrictMono M₀] (h : 1 < a) : a ^ n ≤ a ^ m ↔ n ≤ m
+  [PosMulStrictMono M₀] (h : 1 < a) : a ^ n ≤ a ^ m ↔ n ≤ m
 pow_le_pow_left₀.{u_2} {M₀ : Type u_2} [MonoidWithZero M₀] [Preorder M₀] {a b : M₀} [ZeroLEOneClass M₀] [PosMulMono M₀]
   [MulPosMono M₀] (ha : 0 ≤ a) (hab : a ≤ b) (n : ℕ) : a ^ n ≤ b ^ n
-pow_le_pow_of_le_one.{u_2} {M₀ : Type u_2} [MonoidWithZero M₀] [Preorder M₀] {a : M₀} [ZeroLEOneClass M₀]
-  [PosMulMono M₀] [MulPosMono M₀] (ha₀ : 0 ≤ a) (ha₁ : a ≤ 1) {m n : ℕ} : m ≤ n → a ^ n ≤ a ^ m
+pow_le_pow_of_le_one.{u_2} {M₀ : Type u_2} [MonoidWithZero M₀] [Preorder M₀] {a : M₀} [PosMulMono M₀] (ha₀ : 0 ≤ a)
+  (ha₁ : a ≤ 1) {m n : ℕ} (hmn : m ≤ n) : a ^ n ≤ a ^ m
 pow_le_pow_right₀.{u_2} {M₀ : Type u_2} [MonoidWithZero M₀] [Preorder M₀] {a : M₀} {m n : ℕ} [ZeroLEOneClass M₀]
-  [PosMulMono M₀] [MulPosMono M₀] (ha : 1 ≤ a) (hmn : m ≤ n) : a ^ m ≤ a ^ n
+  [PosMulMono M₀] (ha : 1 ≤ a) (hmn : m ≤ n) : a ^ m ≤ a ^ n
 pow_left_inj₀.{u_2} {M₀ : Type u_2} [MonoidWithZero M₀] [LinearOrder M₀] [ZeroLEOneClass M₀] [PosMulStrictMono M₀]
-  [MulPosStrictMono M₀] {a b : M₀} {n : ℕ} (ha : 0 ≤ a) (hb : 0 ≤ b) (hn : n ≠ 0) : a ^ n = b ^ n ↔ a = b
+  {a b : M₀} {n : ℕ} [MulPosMono M₀] (ha : 0 ≤ a) (hb : 0 ≤ b) (hn : n ≠ 0) : a ^ n = b ^ n ↔ a = b
 pow_left_monotoneOn.{u_2} {M₀ : Type u_2} [MonoidWithZero M₀] [Preorder M₀] {n : ℕ} [ZeroLEOneClass M₀] [PosMulMono M₀]
   [MulPosMono M₀] : MonotoneOn (fun a => a ^ n) {x | 0 ≤ x}
 pow_left_strictMonoOn₀.{u_2} {M₀ : Type u_2} [MonoidWithZero M₀] [PartialOrder M₀] {n : ℕ} [ZeroLEOneClass M₀]
-  [PosMulStrictMono M₀] [MulPosStrictMono M₀] (hn : n ≠ 0) : StrictMonoOn (fun x => x ^ n) {a | 0 ≤ a}
+  [PosMulStrictMono M₀] [MulPosMono M₀] (hn : n ≠ 0) : StrictMonoOn (fun x => x ^ n) {a | 0 ≤ a}
 pow_lt_one_iff_of_nonneg.{u_2} {M₀ : Type u_2} [MonoidWithZero M₀] [LinearOrder M₀] [ZeroLEOneClass M₀]
-  [PosMulStrictMono M₀] [MulPosStrictMono M₀] {a : M₀} {n : ℕ} (ha : 0 ≤ a) (hn : n ≠ 0) : a ^ n < 1 ↔ a < 1
-pow_lt_one₀.{u_2} {M₀ : Type u_2} [MonoidWithZero M₀] [Preorder M₀] {a : M₀} [ZeroLEOneClass M₀] [PosMulMono M₀]
-  [MulPosMono M₀] (h₀ : 0 ≤ a) (h₁ : a < 1) {n : ℕ} : n ≠ 0 → a ^ n < 1
+  [PosMulStrictMono M₀] {a : M₀} {n : ℕ} (ha : 0 ≤ a) (hn : n ≠ 0) : a ^ n < 1 ↔ a < 1
+pow_lt_one₀.{u_2} {M₀ : Type u_2} [MonoidWithZero M₀] [Preorder M₀] {a : M₀} [PosMulMono M₀] (h₀ : 0 ≤ a) (h₁ : a < 1)
+  {n : ℕ} : n ≠ 0 → a ^ n < 1
 pow_lt_pow_iff_left₀.{u_2} {M₀ : Type u_2} [MonoidWithZero M₀] [LinearOrder M₀] [ZeroLEOneClass M₀]
-  [PosMulStrictMono M₀] [MulPosStrictMono M₀] {a b : M₀} {n : ℕ} (ha : 0 ≤ a) (hb : 0 ≤ b) (hn : n ≠ 0) :
+  [PosMulStrictMono M₀] {a b : M₀} {n : ℕ} [MulPosMono M₀] (ha : 0 ≤ a) (hb : 0 ≤ b) (hn : n ≠ 0) :
   a ^ n < b ^ n ↔ a < b
 pow_lt_pow_iff_right_of_lt_one₀.{u_2} {M₀ : Type u_2} [MonoidWithZero M₀] [PartialOrder M₀] {a : M₀} {m n : ℕ}
-  [ZeroLEOneClass M₀] [PosMulStrictMono M₀] [MulPosStrictMono M₀] (h₀ : 0 < a) (h₁ : a < 1) : a ^ m < a ^ n ↔ n < m
+  [ZeroLEOneClass M₀] [PosMulStrictMono M₀] (h₀ : 0 < a) (h₁ : a < 1) : a ^ m < a ^ n ↔ n < m
 pow_lt_pow_iff_right₀.{u_2} {M₀ : Type u_2} [MonoidWithZero M₀] [PartialOrder M₀] {a : M₀} {m n : ℕ} [ZeroLEOneClass M₀]
-  [PosMulStrictMono M₀] [MulPosStrictMono M₀] (h : 1 < a) : a ^ n < a ^ m ↔ n < m
+  [PosMulStrictMono M₀] (h : 1 < a) : a ^ n < a ^ m ↔ n < m
 pow_lt_pow_left₀.{u_2} {M₀ : Type u_2} [MonoidWithZero M₀] [PartialOrder M₀] {a b : M₀} [ZeroLEOneClass M₀]
-  [PosMulStrictMono M₀] [MulPosStrictMono M₀] (hab : a < b) (ha : 0 ≤ a) {n : ℕ} : n ≠ 0 → a ^ n < b ^ n
+  [PosMulStrictMono M₀] [MulPosMono M₀] (hab : a < b) (ha : 0 ≤ a) {n : ℕ} : n ≠ 0 → a ^ n < b ^ n
 pow_lt_pow_right_of_lt_one₀.{u_2} {M₀ : Type u_2} [MonoidWithZero M₀] [PartialOrder M₀] {a : M₀} {m n : ℕ}
-  [ZeroLEOneClass M₀] [PosMulStrictMono M₀] [MulPosStrictMono M₀] (h₀ : 0 < a) (h₁ : a < 1) (hmn : m < n) :
-  a ^ n < a ^ m
+  [ZeroLEOneClass M₀] [PosMulStrictMono M₀] (h₀ : 0 < a) (h₁ : a < 1) (hmn : m < n) : a ^ n < a ^ m
 pow_lt_pow_right₀.{u_2} {M₀ : Type u_2} [MonoidWithZero M₀] [PartialOrder M₀] {a : M₀} {m n : ℕ} [ZeroLEOneClass M₀]
-  [PosMulStrictMono M₀] [MulPosStrictMono M₀] (h : 1 < a) (hmn : m < n) : a ^ m < a ^ n
+  [PosMulStrictMono M₀] (h : 1 < a) (hmn : m < n) : a ^ m < a ^ n
 pow_lt_self_of_lt_one₀.{u_2} {M₀ : Type u_2} [MonoidWithZero M₀] [PartialOrder M₀] {a : M₀} {n : ℕ} [ZeroLEOneClass M₀]
-  [PosMulStrictMono M₀] [MulPosStrictMono M₀] (h₀ : 0 < a) (h₁ : a < 1) (hn : 1 < n) : a ^ n < a
+  [PosMulStrictMono M₀] (h₀ : 0 < a) (h₁ : a < 1) (hn : 1 < n) : a ^ n < a
 pow_nonneg.{u_2} {M₀ : Type u_2} [MonoidWithZero M₀] [Preorder M₀] {a : M₀} [ZeroLEOneClass M₀] [PosMulMono M₀]
   (ha : 0 ≤ a) (n : ℕ) : 0 ≤ a ^ n
 pow_pos.{u_2} {M₀ : Type u_2} [MonoidWithZero M₀] [PartialOrder M₀] {a : M₀} [ZeroLEOneClass M₀] [PosMulStrictMono M₀]
   (ha : 0 < a) (n : ℕ) : 0 < a ^ n
+pow_right_anti₀.{u_2} {M₀ : Type u_2} [MonoidWithZero M₀] [Preorder M₀] {a : M₀} [PosMulMono M₀] (ha₀ : 0 ≤ a)
+  (ha₁ : a ≤ 1) : Antitone fun n => a ^ n
 pow_right_injective₀.{u_2} {M₀ : Type u_2} [MonoidWithZero M₀] [LinearOrder M₀] [ZeroLEOneClass M₀]
-  [PosMulStrictMono M₀] [MulPosStrictMono M₀] {a : M₀} (ha₀ : 0 < a) (ha₁ : a ≠ 1) : Injective fun x => a ^ x
+  [PosMulStrictMono M₀] {a : M₀} (ha₀ : 0 < a) (ha₁ : a ≠ 1) : Injective fun x => a ^ x
 pow_right_inj₀.{u_2} {M₀ : Type u_2} [MonoidWithZero M₀] [LinearOrder M₀] [ZeroLEOneClass M₀] [PosMulStrictMono M₀]
-  [MulPosStrictMono M₀] {a : M₀} {m n : ℕ} (ha₀ : 0 < a) (ha₁ : a ≠ 1) : a ^ m = a ^ n ↔ m = n
+  {a : M₀} {m n : ℕ} (ha₀ : 0 < a) (ha₁ : a ≠ 1) : a ^ m = a ^ n ↔ m = n
 pow_right_mono₀.{u_2} {M₀ : Type u_2} [MonoidWithZero M₀] [Preorder M₀] {a : M₀} [ZeroLEOneClass M₀] [PosMulMono M₀]
-  [MulPosMono M₀] (h : 1 ≤ a) : Monotone fun x => a ^ x
+  (h : 1 ≤ a) : Monotone fun x => a ^ x
 pow_right_strictAnti₀.{u_2} {M₀ : Type u_2} [MonoidWithZero M₀] [PartialOrder M₀] {a : M₀} [ZeroLEOneClass M₀]
-  [PosMulStrictMono M₀] [MulPosStrictMono M₀] (h₀ : 0 < a) (h₁ : a < 1) : StrictAnti fun x => a ^ x
+  [PosMulStrictMono M₀] (h₀ : 0 < a) (h₁ : a < 1) : StrictAnti fun x => a ^ x
 pow_right_strictMono₀.{u_2} {M₀ : Type u_2} [MonoidWithZero M₀] [PartialOrder M₀] {a : M₀} [ZeroLEOneClass M₀]
-  [PosMulStrictMono M₀] [MulPosStrictMono M₀] (h : 1 < a) : StrictMono fun x => a ^ x
+  [PosMulStrictMono M₀] (h : 1 < a) : StrictMono fun x => a ^ x
 sq_eq_sq₀.{u_2} {M₀ : Type u_2} [MonoidWithZero M₀] [LinearOrder M₀] [ZeroLEOneClass M₀] [PosMulStrictMono M₀]
-  [MulPosStrictMono M₀] {a b : M₀} (ha : 0 ≤ a) (hb : 0 ≤ b) : a ^ 2 = b ^ 2 ↔ a = b
-sq_le.{u_2} {M₀ : Type u_2} [MonoidWithZero M₀] [Preorder M₀] {a : M₀} [ZeroLEOneClass M₀] [PosMulMono M₀]
-  [MulPosMono M₀] (h₀ : 0 ≤ a) (h₁ : a ≤ 1) : a ^ 2 ≤ a
+  {a b : M₀} [MulPosMono M₀] (ha : 0 ≤ a) (hb : 0 ≤ b) : a ^ 2 = b ^ 2 ↔ a = b
+sq_le.{u_2} {M₀ : Type u_2} [MonoidWithZero M₀] [Preorder M₀] {a : M₀} [PosMulMono M₀] (h₀ : 0 ≤ a) (h₁ : a ≤ 1) :
+  a ^ 2 ≤ a
 sq_le_one_iff₀.{u_2} {M₀ : Type u_2} [MonoidWithZero M₀] [LinearOrder M₀] [ZeroLEOneClass M₀] [PosMulStrictMono M₀]
-  [MulPosStrictMono M₀] {a : M₀} (ha : 0 ≤ a) : a ^ 2 ≤ 1 ↔ a ≤ 1
+  {a : M₀} (ha : 0 ≤ a) : a ^ 2 ≤ 1 ↔ a ≤ 1
 sq_le_sq₀.{u_2} {M₀ : Type u_2} [MonoidWithZero M₀] [LinearOrder M₀] [ZeroLEOneClass M₀] [PosMulStrictMono M₀]
-  [MulPosStrictMono M₀] {a b : M₀} (ha : 0 ≤ a) (hb : 0 ≤ b) : a ^ 2 ≤ b ^ 2 ↔ a ≤ b
+  {a b : M₀} [MulPosMono M₀] (ha : 0 ≤ a) (hb : 0 ≤ b) : a ^ 2 ≤ b ^ 2 ↔ a ≤ b
 sq_lt_one_iff₀.{u_2} {M₀ : Type u_2} [MonoidWithZero M₀] [LinearOrder M₀] [ZeroLEOneClass M₀] [PosMulStrictMono M₀]
-  [MulPosStrictMono M₀] {a : M₀} (ha : 0 ≤ a) : a ^ 2 < 1 ↔ a < 1
+  {a : M₀} (ha : 0 ≤ a) : a ^ 2 < 1 ↔ a < 1
 sq_lt_sq₀.{u_2} {M₀ : Type u_2} [MonoidWithZero M₀] [LinearOrder M₀] [ZeroLEOneClass M₀] [PosMulStrictMono M₀]
-  [MulPosStrictMono M₀] {a b : M₀} (ha : 0 ≤ a) (hb : 0 ≤ b) : a ^ 2 < b ^ 2 ↔ a < b
-sq_pos_of_pos.{u_2} {M₀ : Type u_2} [MonoidWithZero M₀] [PartialOrder M₀] {a : M₀} [ZeroLEOneClass M₀]
-  [PosMulStrictMono M₀] (ha : 0 < a) : 0 < a ^ 2
+  {a b : M₀} [MulPosMono M₀] (ha : 0 ≤ a) (hb : 0 ≤ b) : a ^ 2 < b ^ 2 ↔ a < b
+sq_pos_of_pos.{u_2} {M₀ : Type u_2} [MonoidWithZero M₀] [PartialOrder M₀] {a : M₀} [PosMulStrictMono M₀] (ha : 0 < a) :
+  0 < a ^ 2
 strictMonoOn_mul_self.{u_2} {M₀ : Type u_2} [MonoidWithZero M₀] [PartialOrder M₀] [PosMulStrictMono M₀]
   [MulPosMono M₀] : StrictMonoOn (fun x => x * x) {x | 0 ≤ x}
 strictMono_mul_left_of_pos.{u_2} {M₀ : Type u_2} [MonoidWithZero M₀] [PartialOrder M₀] {a : M₀} [PosMulStrictMono M₀]
```

</p>
</details> 

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
