### PR TITLE
[Merged by Bors] - feat(setOption linter): warn on bare options containing maxHeartbeats

### DIFF
--- a/Mathlib/Tactic/Linter/Style.lean
+++ b/Mathlib/Tactic/Linter/Style.lean
@@ -19,20 +19,21 @@ Historically, some of these were ported from the `lint-style.py` Python script.
 
 This file defines the following linters:
 - the `setOption` linter checks for the presence of `set_option` commands activating
-options disallowed in mathlib: these are meant to be temporary, and not for polished code
+  options disallowed in mathlib: these are meant to be temporary, and not for polished code.
+  It also checks for `maxHeartbeats` options being present which are not scoped to single commands.
 - the `missingEnd` linter checks for sections or namespaces which are not closed by the end
-of the file: enforcing this invariant makes minimising files or moving code between files easier
+  of the file: enforcing this invariant makes minimising files or moving code between files easier
 - the `cdotLinter` linter checks for focusing dots `·` which are typed using a `.` instead:
-this is allowed Lean syntax, but it is nicer to be uniform
+  this is allowed Lean syntax, but it is nicer to be uniform
 - the `dollarSyntax` linter checks for use of the dollar sign `$` instead of the `<|` pipe operator:
-similarly, both symbols have the same meaning, but mathlib prefers `<|` for the symmetry with
-the `|>` symbol
+  similarly, both symbols have the same meaning, but mathlib prefers `<|` for the symmetry with
+  the `|>` symbol
 - the `lambdaSyntax` linter checks for uses of the `λ` symbol for anonymous functions,
-instead of the `fun` keyword: mathlib prefers the latter for reasons of readability
+  instead of the `fun` keyword: mathlib prefers the latter for reasons of readability
 - the `longFile` linter checks for files which have more than 1500 lines
 - the `longLine` linter checks for lines which have more than 100 characters
 - the `openClassical` linter checks for `open (scoped) Classical` statements which are not
-scoped to a single declaration
+  scoped to a single declaration
 
 All of these linters are enabled in mathlib by default, but disabled globally
 since they enforce conventions which are inherently subjective.
@@ -43,7 +44,9 @@ open Lean Parser Elab Command Meta
 namespace Mathlib.Linter
 
 /-- The `setOption` linter emits a warning on a `set_option` command, term or tactic
-which sets a `pp`, `profiler` or `trace` option. -/
+which sets a `pp`, `profiler` or `trace` option.
+It also warns on an option containing `maxHeartbeats`
+(as these should be scoped as `set_option ... in` instead). -/
 register_option linter.style.setOption : Bool := {
   defValue := false
   descr := "enable the `setOption` linter"
@@ -73,12 +76,22 @@ def isSetOption : Syntax → Bool :=
 def is_set_option := @isSetOption
 
 /-- The `setOption` linter: this lints any `set_option` command, term or tactic
-which sets a `pp`, `profiler` or `trace` option.
+which sets a `debug`, `pp`, `profiler` or `trace` option.
+This also warns if an option containing `maxHeartbeats` (typically, the `maxHeartbeats` or
+`synthInstance.maxHeartbeats` option) is set.
 
-**Why is this bad?** These options are good for debugging, but should not be
-used in production code.
-**How to fix this?** Remove these options: usually, they are not necessary for production code.
-(Some tests will intentionally use one of these options; in this case, simply allow the linter.)
+**Why is this bad?** The `debug`, `pp`, `profiler` and `trace` options are good for debugging,
+but should not be used in production code.
+
+`maxHeartbeats` options should be scoped as `set_option opt in ...` (and be followed by a comment
+explaining the need for them; another linter enforces this).
+
+**How to fix this?** The `maxHeartbeats` options can be scoped to individual commands, if they
+are truly necessary.
+
+The `debug`, `pp`, `profiler` and `trace` are usually not necessary for production code,
+so you can simply remove them. (Some tests will intentionally use one of these options;
+in this case, simply allow the linter.)
 -/
 def setOptionLinter : Linter where run := withSetOptionIn fun stx => do
     unless Linter.getLinterValue linter.style.setOption (← getOptions) do
@@ -94,6 +107,10 @@ def setOptionLinter : Linter where run := withSetOptionIn fun stx => do
                is only intended for development and not for final code. \
                If you intend to submit this contribution to the Mathlib project, \
                please remove 'set_option {name}'."
+        else if name.components.contains `maxHeartbeats then
+          Linter.logLint linter.style.setOption head m!"Unscoped option {name} is not allowed:\n\
+          Please scope this to individual declarations, as in\nset_option {name} in\n\
+          -- comment explaining why this is necessary\n..."
 
 initialize addLinter setOptionLinter
 

--- a/Mathlib/Tactic/Linter/Style.lean
+++ b/Mathlib/Tactic/Linter/Style.lean
@@ -109,8 +109,9 @@ def setOptionLinter : Linter where run := withSetOptionIn fun stx => do
                please remove 'set_option {name}'."
         else if name.components.contains `maxHeartbeats then
           Linter.logLint linter.style.setOption head m!"Unscoped option {name} is not allowed:\n\
-          Please scope this to individual declarations, as in\nset_option {name} in\n\
-          -- comment explaining why this is necessary\n..."
+          Please scope this to individual declarations, as in\n```\nset_option {name} in\n\
+          -- comment explaining why this is necessary\n\
+          example : ... := ...\n```"
 
 initialize addLinter setOptionLinter
 

--- a/Mathlib/Util/CountHeartbeats.lean
+++ b/Mathlib/Util/CountHeartbeats.lean
@@ -24,6 +24,9 @@ open Lean Elab Command Meta
 
 namespace Mathlib.CountHeartbeats
 
+-- This file mentions bare `set_option maxHeartbeats` by design: do not warn about this.
+set_option linter.style.setOption false
+
 open Tactic
 
 /--

--- a/MathlibTest/LintStyle.lean
+++ b/MathlibTest/LintStyle.lean
@@ -119,6 +119,39 @@ lemma foo' : True := trivial
 
 -- TODO: add terms for the term form
 
+/--
+warning: Unscoped option maxHeartbeats is not allowed:
+Please scope this to individual declarations, as in
+set_option maxHeartbeats in
+-- comment explaining why this is necessary
+...
+note: this linter can be disabled with `set_option linter.style.setOption false`
+-/
+#guard_msgs in
+set_option maxHeartbeats 20
+
+#guard_msgs in
+set_option maxHeartbeats 20 in
+section
+end
+
+/--
+warning: Unscoped option synthInstance.maxHeartbeats is not allowed:
+Please scope this to individual declarations, as in
+set_option synthInstance.maxHeartbeats in
+-- comment explaining why this is necessary
+...
+note: this linter can be disabled with `set_option linter.style.setOption false`
+-/
+#guard_msgs in
+set_option synthInstance.maxHeartbeats 20
+
+#guard_msgs in
+set_option synthInstance.maxHeartbeats 20 in
+section
+end
+
+
 end setOption
 
 section cdotLinter

--- a/MathlibTest/LintStyle.lean
+++ b/MathlibTest/LintStyle.lean
@@ -122,9 +122,11 @@ lemma foo' : True := trivial
 /--
 warning: Unscoped option maxHeartbeats is not allowed:
 Please scope this to individual declarations, as in
+```
 set_option maxHeartbeats in
 -- comment explaining why this is necessary
-...
+example : ... := ...
+```
 note: this linter can be disabled with `set_option linter.style.setOption false`
 -/
 #guard_msgs in
@@ -138,9 +140,11 @@ end
 /--
 warning: Unscoped option synthInstance.maxHeartbeats is not allowed:
 Please scope this to individual declarations, as in
+```
 set_option synthInstance.maxHeartbeats in
 -- comment explaining why this is necessary
-...
+example : ... := ...
+```
 note: this linter can be disabled with `set_option linter.style.setOption false`
 -/
 #guard_msgs in


### PR DESCRIPTION
Instead, they should be scoped as `set_option <name> in` (or removed if superfluous). Complements #23816.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
