### PR TITLE
[Merged by Bors] - ci: some more `lean-action` usage

### DIFF
--- a/.github/workflows/discover-lean-pr-testing.yml
+++ b/.github/workflows/discover-lean-pr-testing.yml
@@ -24,12 +24,12 @@ jobs:
         git config --global user.name "github-actions"
         git config --global user.email "github-actions@github.com"
 
-    - name: Install elan
-      run: |
-        echo "Installing elan and lake..."
-        curl https://elan.lean-lang.org/elan-init.sh -sSf | sh
-        echo "$HOME/.elan/bin" >> $GITHUB_PATH
-        export PATH="$HOME/.elan/bin:$PATH"
+    - name: Configure Lean
+      uses: leanprover/lean-action@f3ad22e9ca29cb9475bc9bee9afd1f39bb52bf6d # v1.1.2
+      with:
+        auto-config: false
+        use-github-cache: false
+        use-mathlib-cache: false
 
     - name: Determine old and new lean-toolchain
       id: determine-toolchains

--- a/.github/workflows/nolints.yml
+++ b/.github/workflows/nolints.yml
@@ -42,12 +42,7 @@ jobs:
         with:
           auto-config: false
           use-github-cache: false
-          use-mathlib-cache: false
-
-      - name: get cache
-        run: |
-          lake exe cache clean
-          lake exe cache get
+          use-mathlib-cache: true
 
       - name: build mathlib
         id: build


### PR DESCRIPTION
One workflow was had an `elan-init` added, use `lean-action` there instead.

Also, use `lean-action` to get the Mathlib cache in the nolints workflow.

This seems to be the most we can easily do without adding features to `lean-action` (work in progress there!)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
