### PR TITLE
[Merged by Bors] - chore(Data/List/Basic): deprecate duplicate lemma `erase_diff_erase_sublist_of_sublist`

### DIFF
--- a/Mathlib/Data/List/Basic.lean
+++ b/Mathlib/Data/List/Basic.lean
@@ -1189,18 +1189,8 @@ theorem map_diff [DecidableEq β] {f : α → β} (finj : Injective f) {l₁ l�
     map f (l₁.diff l₂) = (map f l₁).diff (map f l₂) := by
   simp only [diff_eq_foldl, foldl_map, map_foldl_erase finj]
 
-theorem erase_diff_erase_sublist_of_sublist {a : α} :
-    ∀ {l₁ l₂ : List α}, l₁ <+ l₂ → (l₂.erase a).diff (l₁.erase a) <+ l₂.diff l₁
-  | [], _, _ => erase_sublist
-  | b :: l₁, l₂, h =>
-    if heq : b = a then by simp only [heq, erase_cons_head, diff_cons]; rfl
-    else by
-      simp only [erase_cons_head, erase_cons_tail (not_beq_of_ne heq),
-        diff_cons ((List.erase l₂ a)) (List.erase l₁ a) b, diff_cons l₂ l₁ b,
-        erase_comm a]
-      have h' := h.erase b
-      rw [erase_cons_head] at h'
-      exact @erase_diff_erase_sublist_of_sublist _ l₁ (l₂.erase b) h'
+@[deprecated (since := "2025-04-10")]
+alias erase_diff_erase_sublist_of_sublist := Sublist.erase_diff_erase_sublist
 
 end Diff
 


### PR DESCRIPTION
Marks `erase_diff_erase_sublist_of_sublist` as a deprecated alias of [`Sublist.erase_diff_erase_sublist`](
https://github.com/leanprover-community/batteries/blob/f523fcb75db2b472cda7d94d6caa5d745b1a0c26/Batteries/Data/List/Lemmas.lean#L329-L337).

This duplication was found by [`tryAtEachStep`](https://github.com/dwrensha/tryAtEachStep).


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
