### PR TITLE
[Merged by Bors] - feat: relation-separated sets

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3679,6 +3679,7 @@ import Mathlib.Data.Real.Sqrt
 import Mathlib.Data.Real.Star
 import Mathlib.Data.Real.StarOrdered
 import Mathlib.Data.Rel
+import Mathlib.Data.Rel.Separated
 import Mathlib.Data.SProd
 import Mathlib.Data.Semiquot
 import Mathlib.Data.Seq.Basic

--- a/Mathlib/Data/Rel/Separated.lean
+++ b/Mathlib/Data/Rel/Separated.lean
@@ -12,7 +12,7 @@ import Mathlib.Data.Rel
 This file defines a notion of separation of a set relative to an relation.
 
 For a relation `R`, a `R`-separated set `s` is a set such that every pair of elements of `s` is
-`R`-far.
+`R`-unrelated.
 
 The concept of uniformly separated sets is used to define two further notions of separation:
 * Metric separation: `Metric.IsSeparated`, defined using the small distance relation.
@@ -29,7 +29,7 @@ open Set
 namespace SetRel
 variable {X : Type*} {R S : SetRel X X} {s t : Set X} {x : X}
 
-/-- Given a relation `R`, a set `s` is `R`-separated if its elements are pairwise `R`-far from
+/-- Given a relation `R`, a set `s` is `R`-separated if its elements are pairwise `R`-unrelated from
 each other. -/
 def IsSeparated (R : SetRel X X) (s : Set X) : Prop := s.Pairwise fun x y ↦ ¬ x ~[R] y
 
@@ -38,7 +38,7 @@ protected lemma IsSeparated.singleton : IsSeparated R {x} := pairwise_singleton 
 
 @[simp] lemma IsSeparated.of_subsingleton (hs : s.Subsingleton) : IsSeparated R s := hs.pairwise _
 
-alias _root_.Set.Subsingleton.uniformSpaceIsSeparated := IsSeparated.of_subsingleton
+alias _root_.Set.Subsingleton.relIsSeparated := IsSeparated.of_subsingleton
 
 nonrec lemma IsSeparated.mono_left (hUV : R ⊆ S) (hs : IsSeparated S s) : IsSeparated R s :=
   hs.mono' fun _x _y hxy h ↦ hxy <| hUV h

--- a/Mathlib/Data/Rel/Separated.lean
+++ b/Mathlib/Data/Rel/Separated.lean
@@ -1,0 +1,65 @@
+/-
+Copyright (c) 2025 Yaël Dillies. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yaël Dillies
+-/
+import Mathlib.Data.Set.Pairwise.Basic
+import Mathlib.Data.Rel
+
+/-!
+# Uniform separation
+
+This file defines a notion of separation of a set relative to an relation.
+
+For a relation `R`, a `R`-separated set `s` is a set such that every pair of elements of `s` is
+`R`-far.
+
+The concept of uniformly separated sets is used to define two further notions of separation:
+* Metric separation: `Metric.IsSeparated`, defined using the small distance relation.
+* Dynamical nets: `Dynamics.IsDynNetIn`, defined using the dynamical relation.
+
+## TODO
+
+* Actually use `SetRel.IsSeparated` to define the above two notions.
+* Link to the notion of separation given by pairwise disjoint balls.
+-/
+
+open Set
+
+namespace SetRel
+variable {X : Type*} {R S : SetRel X X} {s t : Set X} {x : X}
+
+/-- Given a relation `R`, a set `s` is `R`-separated if its elements are pairwise `R`-far from
+each other. -/
+def IsSeparated (R : SetRel X X) (s : Set X) : Prop := s.Pairwise fun x y ↦ ¬ x ~[R] y
+
+protected lemma IsSeparated.empty : IsSeparated R (∅ : Set X) := pairwise_empty _
+protected lemma IsSeparated.singleton : IsSeparated R {x} := pairwise_singleton ..
+
+@[simp] lemma IsSeparated.of_subsingleton (hs : s.Subsingleton) : IsSeparated R s := hs.pairwise _
+
+alias _root_.Set.Subsingleton.uniformSpaceIsSeparated := IsSeparated.of_subsingleton
+
+nonrec lemma IsSeparated.mono_left (hUV : R ⊆ S) (hs : IsSeparated S s) : IsSeparated R s :=
+  hs.mono' fun _x _y hxy h ↦ hxy <| hUV h
+
+lemma IsSeparated.mono_right (hst : s ⊆ t) (ht : IsSeparated R t) : IsSeparated R s := ht.mono hst
+
+lemma isSeparated_insert' :
+    IsSeparated R (insert x s) ↔ IsSeparated R s ∧ (∀ y ∈ s, x ~[R] y → x = y) ∧
+        ∀ y ∈ s, y ~[R] x → x = y := by
+  simp [IsSeparated, pairwise_insert, not_imp_comm (a := _ = _), -not_and, forall_and]
+
+lemma isSeparated_insert [R.IsSymm] :
+    IsSeparated R (insert x s) ↔ IsSeparated R s ∧ ∀ y ∈ s, x ~[R] y → x = y := by
+  simpa [not_imp_not, IsSeparated] using pairwise_insert_of_symmetric fun _ _ ↦ mt R.symm
+
+lemma isSeparated_insert_of_notMem [R.IsSymm] (hx : x ∉ s) :
+    IsSeparated R (insert x s) ↔ IsSeparated R s ∧ ∀ y ∈ s, ¬ x ~[R] y :=
+  pairwise_insert_of_symmetric_of_notMem (fun _ _ ↦ mt R.symm) hx
+
+protected lemma IsSeparated.insert [R.IsSymm] (hs : IsSeparated R s)
+    (h : ∀ y ∈ s, x ~[R] y → x = y) : IsSeparated R (insert x s) :=
+  isSeparated_insert.2 ⟨hs, h⟩
+
+end SetRel


### PR DESCRIPTION
Define a notion of separation of a set relative to a relation. This will be used to unify metric and dynamical separation.

From MiscYD and LeanAPAP


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->
- [x] depends on: #26988

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
