### PR TITLE
[Merged by Bors] - feat: a discrete monoid has compact Pontryagin dual

### DIFF
--- a/Mathlib/Topology/Algebra/Group/CompactOpen.lean
+++ b/Mathlib/Topology/Algebra/Group/CompactOpen.lean
@@ -107,8 +107,7 @@ theorem continuous_comp_right (f : ContinuousMonoidHom B C) :
   (isInducing_toContinuousMap A C).continuous_iff.2 <|
     f.toContinuousMap.continuous_postcomp.comp (isInducing_toContinuousMap A B).continuous
 
-variable (E)
-
+variable (E) in
 /-- `ContinuousMonoidHom _ f` is a functor. -/
 @[to_additive "`ContinuousAddMonoidHom _ f` is a functor."]
 def compLeft (f : ContinuousMonoidHom A B) :
@@ -118,8 +117,7 @@ def compLeft (f : ContinuousMonoidHom A B) :
   map_mul' _g _h := rfl
   continuous_toFun := f.continuous_comp_left
 
-variable (A) {E}
-
+variable (A) in
 /-- `ContinuousMonoidHom f _` is a functor. -/
 @[to_additive "`ContinuousAddMonoidHom f _` is a functor."]
 def compRight {B : Type*} [CommGroup B] [TopologicalSpace B] [IsTopologicalGroup B]
@@ -129,6 +127,19 @@ def compRight {B : Type*} [CommGroup B] [TopologicalSpace B] [IsTopologicalGroup
   map_one' := ext fun _a => map_one f
   map_mul' g h := ext fun a => map_mul f (g a) (h a)
   continuous_toFun := f.continuous_comp_right
+
+section DiscreteTopology
+variable [DiscreteTopology A] [ContinuousMul B] [T2Space B]
+
+@[to_additive]
+lemma isClosedEmbedding_coe : IsClosedEmbedding ((⇑) : (A →ₜ* B) → A → B) :=
+  ContinuousMap.isHomeomorph_coe.isClosedEmbedding.comp <| isClosedEmbedding_toContinuousMap ..
+
+@[to_additive]
+instance [CompactSpace B] : CompactSpace (A →ₜ* B) :=
+  ContinuousMonoidHom.isClosedEmbedding_coe.compactSpace
+
+end DiscreteTopology
 
 section LocallyCompact
 

--- a/Mathlib/Topology/Algebra/PontryaginDual.lean
+++ b/Mathlib/Topology/Algebra/PontryaginDual.lean
@@ -91,8 +91,8 @@ noncomputable instance instMonoidHomClass : MonoidHomClass (PontryaginDual A) A 
   ContinuousMonoidHom.instMonoidHomClass
 
 /-- A discrete monoid has compact Pontryagin dual. -/
-instance [DiscreteTopology A] : CompactSpace (PontryaginDual A) :=
-  ContinuousMonoidHom.isClosedEmbedding_coe.compactSpace
+instance [DiscreteTopology A] : CompactSpace (PontryaginDual A) := 
+  ContinuousMonoidHom.instCompactSpace
 
 /-- `PontryaginDual` is a contravariant functor. -/
 noncomputable def map (f : A →ₜ* B) :

--- a/Mathlib/Topology/Algebra/PontryaginDual.lean
+++ b/Mathlib/Topology/Algebra/PontryaginDual.lean
@@ -90,6 +90,10 @@ noncomputable instance instContinuousMapClass : ContinuousMapClass (PontryaginDu
 noncomputable instance instMonoidHomClass : MonoidHomClass (PontryaginDual A) A Circle :=
   ContinuousMonoidHom.instMonoidHomClass
 
+/-- A discrete monoid has compact Pontryagin dual. -/
+instance [DiscreteTopology A] : CompactSpace (PontryaginDual A) :=
+  ContinuousMonoidHom.isClosedEmbedding_coe.compactSpace
+
 /-- `PontryaginDual` is a contravariant functor. -/
 noncomputable def map (f : A →ₜ* B) :
     (PontryaginDual B) →ₜ* (PontryaginDual A) :=

--- a/Mathlib/Topology/Algebra/PontryaginDual.lean
+++ b/Mathlib/Topology/Algebra/PontryaginDual.lean
@@ -91,7 +91,7 @@ noncomputable instance instMonoidHomClass : MonoidHomClass (PontryaginDual A) A 
   ContinuousMonoidHom.instMonoidHomClass
 
 /-- A discrete monoid has compact Pontryagin dual. -/
-instance [DiscreteTopology A] : CompactSpace (PontryaginDual A) := 
+instance [DiscreteTopology A] : CompactSpace (PontryaginDual A) :=
   ContinuousMonoidHom.instCompactSpace
 
 /-- `PontryaginDual` is a contravariant functor. -/

--- a/Mathlib/Topology/CompactOpen.lean
+++ b/Mathlib/Topology/CompactOpen.lean
@@ -281,6 +281,25 @@ instance [T3Space Y] : T3Space C(X, Y) := inferInstance
 
 end Ev
 
+section DiscreteTopology
+variable [DiscreteTopology X]
+
+/-- The continuous functions from `X` to `Y` are the same as the plain functions when `X` is
+discrete. -/
+@[simps!]
+def homeoFnOfDiscrete : C(X, Y) ≃ₜ (X → Y) where
+  __ := equivFnOfDiscrete
+  continuous_invFun :=
+    continuous_compactOpen.2 fun K hK U hU ↦ isOpen_set_pi hK.finite_of_discrete fun _ _ ↦ hU
+
+@[simp] lemma coe_homeoFnOfDiscrete : ⇑homeoFnOfDiscrete = (DFunLike.coe : C(X, Y) → X → Y) := rfl
+
+@[simp] lemma homeoFnOfDiscrete_symm_apply (f : X → Y) : homeoFnOfDiscrete.symm f = f := rfl
+
+lemma isHomeomorph_coe : IsHomeomorph ((⇑) : C(X, Y) → X → Y) := homeoFnOfDiscrete.isHomeomorph
+
+end DiscreteTopology
+
 section InfInduced
 
 /-- For any subset `s` of `X`, the restriction of continuous functions to `s` is continuous

--- a/Mathlib/Topology/CompactOpen.lean
+++ b/Mathlib/Topology/CompactOpen.lean
@@ -286,7 +286,7 @@ variable [DiscreteTopology X]
 
 /-- The continuous functions from `X` to `Y` are the same as the plain functions when `X` is
 discrete. -/
-@[simps!]
+@[simps toEquiv]
 def homeoFnOfDiscrete : C(X, Y) ≃ₜ (X → Y) where
   __ := equivFnOfDiscrete
   continuous_invFun :=

--- a/Mathlib/Topology/CompactOpen.lean
+++ b/Mathlib/Topology/CompactOpen.lean
@@ -292,6 +292,8 @@ def homeoFnOfDiscrete : C(X, Y) ≃ₜ (X → Y) where
   continuous_invFun :=
     continuous_compactOpen.2 fun K hK U hU ↦ isOpen_set_pi hK.finite_of_discrete fun _ _ ↦ hU
 
+attribute [simps! -isSimp] homeoFnOfDiscrete
+
 @[simp] lemma coe_homeoFnOfDiscrete : ⇑homeoFnOfDiscrete = (DFunLike.coe : C(X, Y) → X → Y) := rfl
 
 @[simp] lemma homeoFnOfDiscrete_symm_apply (f : X → Y) : homeoFnOfDiscrete.symm f = f := rfl

--- a/Mathlib/Topology/ContinuousMap/Basic.lean
+++ b/Mathlib/Topology/ContinuousMap/Basic.lean
@@ -50,21 +50,24 @@ protected theorem continuousAt (f : C(α, β)) (x : α) : ContinuousAt f x :=
 theorem map_specializes (f : C(α, β)) {x y : α} (h : x ⤳ y) : f x ⤳ f y :=
   h.map f.2
 
-section
-
-variable (α β)
+section DiscreteTopology
+variable [DiscreteTopology α]
 
 /--
 The continuous functions from `α` to `β` are the same as the plain functions when `α` is discrete.
 -/
 @[simps]
-def equivFnOfDiscrete [DiscreteTopology α] : C(α, β) ≃ (α → β) :=
+def equivFnOfDiscrete : C(α, β) ≃ (α → β) :=
   ⟨fun f => f,
     fun f => ⟨f, continuous_of_discreteTopology⟩,
     fun _ => by ext; rfl,
     fun _ => by ext; rfl⟩
 
-end
+@[simp] lemma coe_equivFnOfDiscrete : ⇑equivFnOfDiscrete = (DFunLike.coe : C(α, β) → α → β) := rfl
+
+@[simp] lemma equivFnOfDiscrete_symm_apply (f : α → β) : equivFnOfDiscrete.symm f = f := rfl
+
+end DiscreteTopology
 
 variable (α)
 

--- a/Mathlib/Topology/Separation/NotNormal.lean
+++ b/Mathlib/Topology/Separation/NotNormal.lean
@@ -34,7 +34,7 @@ theorem IsClosed.mk_lt_continuum [NormalSpace X] {s : Set X} (hs : IsClosed s)
   calc
     -- Any function `s → ℝ` is continuous, hence `2 ^ 𝔠 ≤ #C(s, ℝ)`
     2 ^ 𝔠 ≤ #C(s, ℝ) := by
-      rw [(ContinuousMap.equivFnOfDiscrete _ _).cardinal_eq, mk_arrow, mk_real, lift_continuum,
+      rw [ContinuousMap.equivFnOfDiscrete.cardinal_eq, mk_arrow, mk_real, lift_continuum,
         lift_uzero]
       exact (power_le_power_left two_ne_zero h).trans (power_le_power_right (nat_lt_continuum 2).le)
     -- By the Tietze Extension Theorem, any function `f : C(s, ℝ)` can be extended to `C(X, ℝ)`,


### PR DESCRIPTION
From LeanAPAP


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
