### PR TITLE
[Merged by Bors] - chore: drop prime from Irreducible.isUnit_or_isUnit' and use implicit arguments

### DIFF
--- a/Mathlib/Algebra/CharP/Algebra.lean
+++ b/Mathlib/Algebra/CharP/Algebra.lean
@@ -42,7 +42,7 @@ theorem CharP.of_ringHom_of_ne_zero {R A : Type*} [Ring R] [NoZeroDivisors R]
   have H := (CharP.char_is_prime_or_zero R p).resolve_right hp
   obtain ⟨q, hq⟩ := CharP.exists A
   obtain ⟨k, e⟩ := dvd_of_ringHom f p q
-  have := Nat.isUnit_iff.mp ((H.2 q k e).resolve_left (Nat.isUnit_iff.not.mpr (char_ne_one A q)))
+  have := Nat.isUnit_iff.mp ((H.2 e).resolve_left (Nat.isUnit_iff.not.mpr (char_ne_one A q)))
   rw [this, mul_one] at e
   exact e ▸ hq
 

--- a/Mathlib/Algebra/GroupWithZero/Associated.lean
+++ b/Mathlib/Algebra/GroupWithZero/Associated.lean
@@ -651,7 +651,7 @@ theorem irreducible_mk {a : M} : Irreducible (Associates.mk a) ↔ Irreducible a
   · rintro h x y rfl
     exact h _ _ <| .refl _
   · rintro h x y ⟨u, rfl⟩
-    simpa using h x (y * u) (mul_assoc _ _ _)
+    simpa using h (mul_assoc _ _ _)
 
 @[simp]
 theorem mk_dvdNotUnit_mk_iff {a b : M} :

--- a/Mathlib/Algebra/Polynomial/Monic.lean
+++ b/Mathlib/Algebra/Polynomial/Monic.lean
@@ -280,7 +280,7 @@ variable [NoZeroDivisors R] {p q : R[X]}
 lemma irreducible_of_monic (hp : p.Monic) (hp1 : p ≠ 1) :
     Irreducible p ↔ ∀ f g : R[X], f.Monic → g.Monic → f * g = p → f = 1 ∨ g = 1 := by
   refine
-    ⟨fun h f g hf hg hp => (h.2 f g hp.symm).imp hf.eq_one_of_isUnit hg.eq_one_of_isUnit, fun h =>
+    ⟨fun h f g hf hg hp => (h.2 hp.symm).imp hf.eq_one_of_isUnit hg.eq_one_of_isUnit, fun h =>
       ⟨hp1 ∘ hp.eq_one_of_isUnit, fun f g hfg =>
         (h (g * C f.leadingCoeff) (f * C g.leadingCoeff) ?_ ?_ ?_).symm.imp
           (isUnit_of_mul_eq_one f _)

--- a/Mathlib/Algebra/Prime/Defs.lean
+++ b/Mathlib/Algebra/Prime/Defs.lean
@@ -100,23 +100,20 @@ structure Irreducible [Monoid M] (p : M) : Prop where
   /-- `p` is not a unit -/
   not_isUnit : ¬IsUnit p
   /-- if `p` factors then one factor is a unit -/
-  isUnit_or_isUnit' : ∀ a b, p = a * b → IsUnit a ∨ IsUnit b
+  isUnit_or_isUnit ⦃a b⦄ : p = a * b → IsUnit a ∨ IsUnit b
 
 namespace Irreducible
 
 @[deprecated (since := "2025-04-09")] alias not_unit := not_isUnit
+@[deprecated (since := "2025-04-10")] alias isUnit_or_isUnit' := isUnit_or_isUnit
 
 theorem not_dvd_one [CommMonoid M] {p : M} (hp : Irreducible p) : ¬p ∣ 1 :=
   mt (isUnit_of_dvd_one ·) hp.not_isUnit
 
-theorem isUnit_or_isUnit [Monoid M] {p : M} (hp : Irreducible p) {a b : M} (h : p = a * b) :
-    IsUnit a ∨ IsUnit b :=
-  hp.isUnit_or_isUnit' a b h
-
 end Irreducible
 
 theorem irreducible_iff [Monoid M] {p : M} :
-    Irreducible p ↔ ¬IsUnit p ∧ ∀ a b, p = a * b → IsUnit a ∨ IsUnit b :=
+    Irreducible p ↔ ¬IsUnit p ∧ ∀ ⦃a b⦄, p = a * b → IsUnit a ∨ IsUnit b :=
   ⟨fun h => ⟨h.1, h.2⟩, fun h => ⟨h.1, h.2⟩⟩
 
 @[simp]
@@ -128,14 +125,14 @@ theorem Irreducible.ne_one [Monoid M] : ∀ {p : M}, Irreducible p → p ≠ 1
 @[simp]
 theorem not_irreducible_zero [MonoidWithZero M] : ¬Irreducible (0 : M)
   | ⟨hn0, h⟩ =>
-    have : IsUnit (0 : M) ∨ IsUnit (0 : M) := h 0 0 (mul_zero 0).symm
+    have : IsUnit (0 : M) ∨ IsUnit (0 : M) := h (mul_zero 0).symm
     this.elim hn0 hn0
 
 theorem Irreducible.ne_zero [MonoidWithZero M] : ∀ {p : M}, Irreducible p → p ≠ 0
   | _, hp, rfl => not_irreducible_zero hp
 
 theorem of_irreducible_mul {M} [Monoid M] {x y : M} : Irreducible (x * y) → IsUnit x ∨ IsUnit y
-  | ⟨_, h⟩ => h _ _ rfl
+  | ⟨_, h⟩ => h rfl
 
 theorem irreducible_or_factor {M} [Monoid M] (x : M) (h : ¬IsUnit x) :
     Irreducible x ∨ ∃ a b, ¬IsUnit a ∧ ¬IsUnit b ∧ a * b = x := by

--- a/Mathlib/Algebra/Prime/Lemmas.lean
+++ b/Mathlib/Algebra/Prime/Lemmas.lean
@@ -123,7 +123,7 @@ theorem not_irreducible_pow {M} [Monoid M] {x : M} {n : ℕ} (hn : n ≠ 1) :
   | zero => simp
   | succ n =>
     intro ⟨h₁, h₂⟩
-    have := h₂ _ _ (pow_succ _ _)
+    have := h₂ (pow_succ _ _)
     rw [isUnit_pow_iff (Nat.succ_ne_succ.mp hn), or_self] at this
     exact h₁ (this.pow _)
 
@@ -241,7 +241,7 @@ section CommMonoidWithZero
 theorem DvdNotUnit.isUnit_of_irreducible_right [CommMonoidWithZero M] {p q : M}
     (h : DvdNotUnit p q) (hq : Irreducible q) : IsUnit p := by
   obtain ⟨_, x, hx, hx'⟩ := h
-  exact Or.resolve_right ((irreducible_iff.1 hq).right p x hx') hx
+  exact ((irreducible_iff.1 hq).right hx').resolve_right hx
 
 theorem not_irreducible_of_not_unit_dvdNotUnit [CommMonoidWithZero M] {p q : M} (hp : ¬IsUnit p)
     (h : DvdNotUnit p q) : ¬Irreducible q :=

--- a/Mathlib/Data/Nat/Prime/Defs.lean
+++ b/Mathlib/Data/Nat/Prime/Defs.lean
@@ -96,13 +96,11 @@ theorem Prime.eq_one_or_self_of_dvd {p : ℕ} (pp : p.Prime) (m : ℕ) (hm : m �
 theorem prime_def {p : ℕ} : Prime p ↔ 2 ≤ p ∧ ∀ m, m ∣ p → m = 1 ∨ m = p := by
   refine ⟨fun h => ⟨h.two_le, h.eq_one_or_self_of_dvd⟩, fun h => ?_⟩
   have h1 := Nat.one_lt_two.trans_le h.1
-  refine ⟨mt Nat.isUnit_iff.mp h1.ne', fun a b hab => ?_⟩
+  refine ⟨mt Nat.isUnit_iff.mp h1.ne', ?_⟩
+  rintro a b rfl
   simp only [Nat.isUnit_iff]
-  apply Or.imp_right _ (h.2 a _)
-  · rintro rfl
-    rw [← mul_right_inj' (Nat.ne_zero_of_lt h1), ← hab, mul_one]
-  · rw [hab]
-    exact dvd_mul_right _ _
+  refine (h.2 a <| dvd_mul_right ..).imp_right fun hab ↦ ?_
+  rw [← mul_right_inj' (Nat.ne_zero_of_lt h1), ← hab, ← hab, mul_one]
 
 @[deprecated (since := "2024-11-19")]
 alias prime_def_lt'' := prime_def

--- a/Mathlib/FieldTheory/KummerPolynomial.lean
+++ b/Mathlib/FieldTheory/KummerPolynomial.lean
@@ -80,7 +80,7 @@ theorem pow_ne_of_irreducible_X_pow_sub_C {n : ℕ} {a : K}
   rw [mul_comm, pow_mul, map_pow, hq] at H
   have : degree q = 0 := by
     simpa [isUnit_iff_degree_eq_zero, degree_X_pow_sub_C,
-      Nat.pos_iff_ne_zero, (mul_ne_zero_iff.mp hn).2] using H.2 _ q rfl
+      Nat.pos_iff_ne_zero, (mul_ne_zero_iff.mp hn).2] using H.2 rfl
   apply_fun degree at hq
   simp only [this, ← pow_mul, mul_comm k m, degree_X_pow_sub_C, Nat.pos_iff_ne_zero.mpr hn,
     Nat.pos_iff_ne_zero.mpr (mul_ne_zero_iff.mp hn).2, degree_mul, ← map_pow, add_zero,

--- a/Mathlib/RingTheory/Polynomial/IrreducibleRing.lean
+++ b/Mathlib/RingTheory/Polynomial/IrreducibleRing.lean
@@ -44,7 +44,7 @@ theorem Polynomial.Monic.irreducible_of_irreducible_map_of_isPrime_nilradical
   refine ⟨fun h ↦ hi.1 <| (mapRingHom ι).isUnit_map h, fun a b h ↦ ?_⟩
   wlog hb : IsUnit (b.map ι) generalizing a b
   · exact (this b a (mul_comm a b ▸ h)
-      (hi.2 _ _ (by rw [h, Polynomial.map_mul]) |>.resolve_right hb)).symm
+      (hi.2 (by rw [h, Polynomial.map_mul]) |>.resolve_right hb)).symm
   have hn (i : ℕ) (hi : i ≠ 0) : IsNilpotent (b.coeff i) := by
     obtain ⟨_, _, h⟩ := Polynomial.isUnit_iff.1 hb
     simpa only [coeff_map, coeff_C, hi, ite_false, ← RingHom.mem_ker,

--- a/Mathlib/SetTheory/Cardinal/Divisibility.lean
+++ b/Mathlib/SetTheory/Cardinal/Divisibility.lean
@@ -85,7 +85,7 @@ theorem not_irreducible_of_aleph0_le (ha : ℵ₀ ≤ a) : ¬Irreducible a := by
   rw [irreducible_iff, not_and_or]
   refine Or.inr fun h => ?_
   simpa [mul_aleph0_eq ha, isUnit_iff, (one_lt_aleph0.trans_le ha).ne', one_lt_aleph0.ne'] using
-    h a ℵ₀
+    @h a ℵ₀
 
 @[simp, norm_cast]
 theorem nat_coe_dvd_iff : (n : Cardinal) ∣ m ↔ n ∣ m := by


### PR DESCRIPTION
Co-authored-by: Yaël Dillies <yael.dillies@gmail.com>


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

From  #22904

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
