### PR TITLE
[Merged by Bors] - feat(SimpleGraph): eccentricity, radius, and center

### DIFF
--- a/Mathlib/Combinatorics/SimpleGraph/Diam.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Diam.lean
@@ -278,9 +278,11 @@ end diam
 
 section radius
 
+/-- The radius of a simple graph is the minimum eccentricity of any vertex. -/
 noncomputable def radius (G : SimpleGraph α) : ℕ∞ :=
   ⨅ u, G.eccent u
 
+/-- The center of a simple graph is the set of vertices with eccentricity equal to the radius. -/
 def center (G : SimpleGraph α) : Set α :=
   {u | G.eccent u = G.radius}
 

--- a/Mathlib/Combinatorics/SimpleGraph/Diam.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Diam.lean
@@ -55,11 +55,20 @@ lemma eccent_eq_top_of_not_connected (h : ¬G.Connected) (u : α) :
   rw [eq_top_iff, ← edist_eq_top_of_not_reachable h]
   exact le_iSup (G.edist u) v
 
+lemma eccent_eq_zero_of_subsingleton [Subsingleton α] (u : α) : G.eccent u = 0 := by
+  simpa [eccent, edist_eq_zero_iff] using subsingleton_iff.mp ‹_› u
+
 lemma eccent_ne_zero [Nontrivial α] (u : α) : G.eccent u ≠ 0 := by
   obtain ⟨v, huv⟩ := exists_ne ‹_›
   contrapose! huv
   simp only [eccent, ENat.iSup_eq_zero, edist_eq_zero_iff] at huv
   exact (huv v).symm
+
+lemma eccent_eq_zero_iff (u : α) : G.eccent u = 0 ↔ Subsingleton α := by
+  refine ⟨fun h ↦ ?_, fun _ ↦ eccent_eq_zero_of_subsingleton u⟩
+  contrapose! h
+  rw [not_subsingleton_iff_nontrivial] at h
+  exact eccent_ne_zero u
 
 @[simp]
 lemma eccent_bot [Nontrivial α] (u : α) : (⊥ : SimpleGraph α).eccent u = ⊤ :=
@@ -327,7 +336,7 @@ lemma exists_edist_eq_radius_of_finite [Nonempty α] [Finite α] :
 lemma radius_le_ediam [Nonempty α] : G.radius ≤ G.ediam :=
   iInf_le_iSup
 
-lemma ediam_le_radius_mul_two [Finite α] : G.ediam ≤ 2 * G.radius := by
+lemma ediam_le_two_mul_radius [Finite α] : G.ediam ≤ 2 * G.radius := by
   cases isEmpty_or_nonempty α
   · rw [radius_eq_top_of_isEmpty]
     exact le_top

--- a/Mathlib/Combinatorics/SimpleGraph/Diam.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Diam.lean
@@ -13,10 +13,10 @@ This module defines the eccentricity of vertices, the diameter, and the radius o
 ## Main definitions
 
 - `SimpleGraph.eccent`: the eccentricity of a vertex in a simple graph, which is the maximum
-distances between it and the other vertices.
+  distances between it and the other vertices.
 
 - `SimpleGraph.ediam`: the graph extended diameter, which is the maximum eccentricity.
-It is `ℕ∞`-valued.
+  It is `ℕ∞`-valued.
 
 - `SimpleGraph.diam`: an `ℕ`-values version of `SimpleGraph.ediam`.
 
@@ -39,12 +39,12 @@ noncomputable def eccent (G : SimpleGraph α) (u : α) : ℕ∞ :=
 
 lemma eccent_def : G.eccent = fun u ↦ ⨆ v, G.edist u v := rfl
 
-lemma edist_le_ecc (u v : α) : G.edist u v ≤ G.eccent u :=
+lemma edist_le_eccent (u v : α) : G.edist u v ≤ G.eccent u :=
   le_iSup (G.edist u) v
 
 lemma exists_edist_eq_eccent_of_finite [Finite α] (u : α) :
     ∃ v, G.edist u v = G.eccent u :=
-  haveI : Nonempty α := Nonempty.intro u
+  have : Nonempty α := Nonempty.intro u
   exists_eq_ciSup_of_finite
 
 lemma eccent_eq_top_of_not_connected (h : ¬G.Connected) (u : α) :

--- a/Mathlib/Combinatorics/SimpleGraph/Diam.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Diam.lean
@@ -76,7 +76,7 @@ lemma eq_top_iff_forall_eccent_eq_one [Nontrivial α] :
     G = ⊤ ↔ ∀ u, G.eccent u = 1 := by
   refine ⟨fun h ↦ h ▸ eccent_top, fun h ↦ ?_⟩
   ext u v
-  exact ⟨Adj.ne, fun huv ↦ edist_eq_one_iff_adj.mp <| le_antisymm ((h u).symm ▸ edist_le_ecc u v)
+  exact ⟨Adj.ne, fun huv ↦ edist_eq_one_iff_adj.mp <| le_antisymm ((h u).symm ▸ edist_le_eccent u v)
   <| Order.one_le_iff_pos.mpr <| pos_iff_ne_zero.mpr <| edist_eq_zero_iff.ne.mpr huv.ne⟩
 
 end eccent
@@ -334,8 +334,9 @@ lemma ediam_le_radius_mul_two [Finite α] : G.ediam ≤ 2 * G.radius := by
   · by_cases h : G.Connected
     · obtain ⟨u, v, h⟩ := G.exists_edist_eq_ediam_of_ne_top (connected_iff_ediam_ne_top.mp h)
       obtain ⟨w, hw⟩ := G.center_nonempty
-      exact le_trans (h.symm ▸ G.edist_triangle (v := w))
-      <| two_mul G.radius ▸ hw ▸ add_le_add (G.edist_comm ▸ G.edist_le_ecc w u) (G.edist_le_ecc w v)
+      apply le_trans (h ▸ G.edist_triangle (v := w))
+      rw [two_mul]
+      exact hw ▸ add_le_add (G.edist_comm ▸ G.edist_le_eccent w u) (G.edist_le_eccent w v)
     · rw [G.radius_eq_top_of_not_connected h]
       exact le_top
 

--- a/Mathlib/Combinatorics/SimpleGraph/Diam.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Diam.lean
@@ -8,19 +8,21 @@ import Mathlib.Combinatorics.SimpleGraph.Metric
 /-!
 # Diameter of a simple graph
 
-This module defines the diameter of a simple graph, which measures the maximum distance between
-vertices.
+This module defines the eccentricity of vertices, the diameter, and the radius of a simple graph.
 
 ## Main definitions
 
-- `SimpleGraph.ediam` is the graph extended diameter.
+- `SimpleGraph.eccent`: the eccentricity of a vertex in a simple graph, which is the maximum
+distances between it and the other vertices.
 
-- `SimpleGraph.diam` is the graph diameter.
+- `SimpleGraph.ediam`: the graph extended diameter, which is the maximum eccentricity.
+It is `ℕ∞`-valued.
 
-## Todo
+- `SimpleGraph.diam`: an `ℕ`-values version of `SimpleGraph.ediam`.
 
-- Prove that `G.egirth ≤ 2 * G.ediam + 1` and `G.girth ≤ 2 * G.diam + 1` when the diameter is
-  non-zero.
+- `SimpleGraph.radius`: the graph radius, which is the minimum eccentricity. It is `ℕ∞`-valued.
+
+- `SimpleGraph.center`: the set of vertices with eccentricity equal to the graph's radius.
 
 -/
 
@@ -29,6 +31,56 @@ assert_not_exists Field
 namespace SimpleGraph
 variable {α : Type*} {G G' : SimpleGraph α}
 
+section eccent
+
+/-- The eccentricity of a vertex is the greatest distance between it and any other vertex. -/
+noncomputable def eccent (G : SimpleGraph α) (u : α) : ℕ∞ :=
+  ⨆ v, G.edist u v
+
+lemma eccent_def : G.eccent = fun u ↦ ⨆ v, G.edist u v := rfl
+
+lemma edist_le_ecc (u v : α) : G.edist u v ≤ G.eccent u :=
+  le_iSup (G.edist u) v
+
+lemma exists_edist_eq_eccent_of_finite [Finite α] (u : α) :
+    ∃ v, G.edist u v = G.eccent u :=
+  haveI : Nonempty α := Nonempty.intro u
+  exists_eq_ciSup_of_finite
+
+lemma eccent_eq_top_of_not_connected (h : ¬G.Connected) (u : α) :
+    G.eccent u = ⊤ := by
+  rw [connected_iff_exists_forall_reachable] at h
+  push_neg at h
+  obtain ⟨v, h⟩ := h u
+  rw [eq_top_iff, ← edist_eq_top_of_not_reachable h]
+  exact le_iSup (G.edist u) v
+
+lemma eccent_ne_zero [Nontrivial α] (u : α) : G.eccent u ≠ 0 := by
+  obtain ⟨v, huv⟩ := exists_ne ‹_›
+  contrapose! huv
+  simp only [eccent, ENat.iSup_eq_zero, edist_eq_zero_iff] at huv
+  exact (huv v).symm
+
+@[simp]
+lemma eccent_bot [Nontrivial α] (u : α) : (⊥ : SimpleGraph α).eccent u = ⊤ :=
+  eccent_eq_top_of_not_connected bot_not_connected u
+
+@[simp]
+lemma eccent_top [Nontrivial α] (u : α) : (⊤ : SimpleGraph α).eccent u = 1 := by
+  apply le_antisymm ?_ <| Order.one_le_iff_pos.mpr <| pos_iff_ne_zero.mpr <| eccent_ne_zero u
+  rw [eccent, iSup_le_iff]
+  intro v
+  cases eq_or_ne u v <;> simp_all [edist_top_of_ne]
+
+lemma eq_top_iff_forall_eccent_eq_one [Nontrivial α] :
+    G = ⊤ ↔ ∀ u, G.eccent u = 1 := by
+  refine ⟨fun h ↦ h ▸ eccent_top, fun h ↦ ?_⟩
+  ext u v
+  exact ⟨Adj.ne, fun huv ↦ edist_eq_one_iff_adj.mp <| le_antisymm ((h u).symm ▸ edist_le_ecc u v)
+  <| Order.one_le_iff_pos.mpr <| pos_iff_ne_zero.mpr <| edist_eq_zero_iff.ne.mpr huv.ne⟩
+
+end eccent
+
 section ediam
 
 /--
@@ -36,22 +88,28 @@ The extended diameter is the greatest distance between any two vertices, with th
 case the distances are not bounded above, or the graph is not connected.
 -/
 noncomputable def ediam (G : SimpleGraph α) : ℕ∞ :=
-  ⨆ u, ⨆ v, G.edist u v
+  ⨆ u, G.eccent u
+
+lemma ediam_eq_iSup_iSup_edist : G.ediam = ⨆ u, ⨆ v, G.edist u v :=
+  rfl
 
 lemma ediam_def : G.ediam = ⨆ p : α × α, G.edist p.1 p.2 := by
-  rw [ediam, iSup_prod]
+  rw [ediam, eccent_def, iSup_prod]
+
+lemma eccent_le_ediam (u : α) : G.eccent u ≤ G.ediam :=
+  le_iSup G.eccent u
 
 lemma edist_le_ediam {u v : α} : G.edist u v ≤ G.ediam :=
   le_iSup₂ (f := G.edist) u v
 
-lemma ediam_le_of_edist_le {k : ℕ∞} (h : ∀ u v, G.edist u v ≤ k ) : G.ediam ≤ k :=
+lemma ediam_le_of_edist_le {k : ℕ∞} (h : ∀ u v, G.edist u v ≤ k) : G.ediam ≤ k :=
   iSup₂_le h
 
 lemma ediam_le_iff {k : ℕ∞} : G.ediam ≤ k ↔ ∀ u v, G.edist u v ≤ k :=
   iSup₂_le_iff
 
 lemma ediam_eq_top : G.ediam = ⊤ ↔ ∀ b < ⊤, ∃ u v, b < G.edist u v := by
-  simp only [ediam, iSup_eq_top, lt_iSup_iff]
+  simp only [ediam, eccent, iSup_eq_top, lt_iSup_iff]
 
 lemma ediam_eq_zero_of_subsingleton [Subsingleton α] : G.ediam = 0 := by
   rw [ediam_def, ENat.iSup_eq_zero]
@@ -65,7 +123,7 @@ lemma nontrivial_of_ediam_ne_zero (h : G.ediam ≠ 0) : Nontrivial α := by
 lemma ediam_ne_zero [Nontrivial α] : G.ediam ≠ 0 := by
   obtain ⟨u, v, huv⟩ := exists_pair_ne ‹_›
   contrapose! huv
-  simp only [ediam, nonpos_iff_eq_zero, ENat.iSup_eq_zero, edist_eq_zero_iff] at huv
+  simp only [ediam, eccent, nonpos_iff_eq_zero, ENat.iSup_eq_zero, edist_eq_zero_iff] at huv
   exact huv u v
 
 lemma subsingleton_of_ediam_eq_zero (h : G.ediam = 0) : Subsingleton α := by
@@ -131,22 +189,12 @@ lemma ediam_bot [Nontrivial α] : (⊥ : SimpleGraph α).ediam = ⊤ :=
 
 @[simp]
 lemma ediam_top [Nontrivial α] : (⊤ : SimpleGraph α).ediam = 1 := by
-  apply le_antisymm ?_ <| Order.one_le_iff_pos.mpr <| pos_iff_ne_zero.mpr ediam_ne_zero
-  apply ediam_def ▸ iSup_le_iff.mpr
-  intro p
-  by_cases h : (⊤ : SimpleGraph α).Adj p.1 p.2
-  · apply le_of_eq <| edist_eq_one_iff_adj.mpr h
-  · simp_all
+  simp [ediam]
 
 @[simp]
-lemma ediam_eq_one [Nontrivial α] : G.ediam = 1 ↔ G = ⊤ := by
-  refine ⟨fun h₁ ↦ ?_, fun h ↦ h ▸ ediam_top⟩
-  ext u v
-  refine ⟨fun h ↦ h.ne, fun h₂ ↦ ?_⟩
-  apply G.edist_pos_of_ne at h₂
-  apply le_of_eq at h₁
-  rw [ediam_def, iSup_le_iff] at h₁
-  exact edist_eq_one_iff_adj.mp <| le_antisymm (h₁ (u, v)) <| Order.one_le_iff_pos.mpr h₂
+lemma ediam_eq_one [Nontrivial α] : G.ediam = 1 ↔ G = ⊤ :=
+  ⟨fun h ↦ eq_top_iff_forall_eccent_eq_one.mpr fun u ↦ le_antisymm (h.symm ▸ eccent_le_ediam u)
+  <| Order.one_le_iff_pos.mpr <| pos_iff_ne_zero.mpr <| eccent_ne_zero u, fun h ↦ h ▸ ediam_top⟩
 
 end ediam
 
@@ -227,5 +275,76 @@ lemma connected_iff_diam_ne_zero [Fintype α] [Nontrivial α] : G.Connected ↔ 
   rw [connected_iff_ediam_ne_top, not_iff_not, diam_eq_zero_iff_ediam_eq_top]
 
 end diam
+
+section radius
+
+noncomputable def radius (G : SimpleGraph α) : ℕ∞ :=
+  ⨅ u, G.eccent u
+
+def center (G : SimpleGraph α) : Set α :=
+  {u | G.eccent u = G.radius}
+
+lemma center_nonempty [Nonempty α] : G.center.Nonempty :=
+  ENat.exists_eq_iInf G.eccent
+
+lemma radius_eq_iInf_iSup_edist : G.radius = ⨅ u, ⨆ v, G.edist u v :=
+  rfl
+
+lemma radius_le_eccent (u : α) : G.radius ≤ G.eccent u :=
+  iInf_le G.eccent u
+
+lemma radius_eq_top_of_not_connected (h : ¬G.Connected) :
+    G.radius = ⊤ := by
+  simp [radius, eccent_eq_top_of_not_connected h]
+
+lemma radius_eq_top_of_isEmpty [IsEmpty α] : G.radius = ⊤ :=
+  iInf_of_empty G.eccent
+
+lemma radius_ne_zero_of_nontrivial [Nontrivial α] : G.radius ≠ 0 := by
+  rw [← ENat.one_le_iff_ne_zero]
+  apply le_iInf
+  simp [ENat.one_le_iff_ne_zero, G.eccent_ne_zero]
+
+lemma radius_eq_zero_iff : G.radius = 0 ↔ Nonempty α ∧ Subsingleton α := by
+  refine ⟨fun h ↦ ⟨?_, ?_⟩, fun ⟨_, _⟩ ↦ ?_⟩
+  · contrapose! h
+    simp [radius, not_nonempty_iff.mp h]
+  · contrapose! h
+    simp [not_subsingleton_iff_nontrivial.mp h, radius_ne_zero_of_nontrivial]
+  · rw [radius, ENat.iInf_eq_zero]
+    use Classical.ofNonempty
+    simpa [eccent] using Subsingleton.elim _
+
+lemma exists_edist_eq_radius_of_finite [Nonempty α] [Finite α] :
+    ∃ u v, G.edist u v = G.radius := by
+  obtain ⟨w, hw⟩ := G.center_nonempty
+  obtain ⟨v, hv⟩ := G.exists_edist_eq_eccent_of_finite w
+  use w, v
+  rw [hv, hw]
+
+lemma radius_le_ediam [Nonempty α] : G.radius ≤ G.ediam :=
+  iInf_le_iSup
+
+lemma ediam_le_radius_mul_two [Finite α] : G.ediam ≤ 2 * G.radius := by
+  cases isEmpty_or_nonempty α
+  · rw [radius_eq_top_of_isEmpty]
+    exact le_top
+  · by_cases h : G.Connected
+    · obtain ⟨u, v, h⟩ := G.exists_edist_eq_ediam_of_ne_top (connected_iff_ediam_ne_top.mp h)
+      obtain ⟨w, hw⟩ := G.center_nonempty
+      exact le_trans (h.symm ▸ G.edist_triangle (v := w))
+      <| two_mul G.radius ▸ hw ▸ add_le_add (G.edist_comm ▸ G.edist_le_ecc w u) (G.edist_le_ecc w v)
+    · rw [G.radius_eq_top_of_not_connected h]
+      exact le_top
+
+@[simp]
+lemma radius_bot [Nontrivial α] : (⊥ : SimpleGraph α).radius = ⊤ :=
+  radius_eq_top_of_not_connected bot_not_connected
+
+@[simp]
+lemma radius_top [Nontrivial α] : (⊤ : SimpleGraph α).radius = 1 := by
+  simp [radius]
+
+end radius
 
 end SimpleGraph

--- a/Mathlib/Combinatorics/SimpleGraph/Diam.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Diam.lean
@@ -189,6 +189,7 @@ lemma exists_edist_eq_ediam_of_ne_top [Nonempty α] (h : G.ediam ≠ ⊤) :
     ∃ u v, G.edist u v = G.ediam :=
   ENat.exists_eq_iSup₂_of_lt_top h.lt_top
 
+-- Note: Neither `Finite α` nor `G.ediam ≠ ⊤` implies the other.
 lemma exists_edist_eq_ediam_of_finite [Nonempty α] [Finite α] :
     ∃ u v, G.edist u v = G.ediam :=
   Prod.exists'.mp <| ediam_def ▸ exists_eq_ciSup_of_finite

--- a/Mathlib/Combinatorics/SimpleGraph/Diam.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Diam.lean
@@ -368,7 +368,7 @@ lemma ediam_le_two_mul_radius [Finite α] : G.ediam ≤ 2 * G.radius := by
     · rw [G.radius_eq_top_of_not_connected h]
       exact le_top
 
-lemma radius_eq_ediam_iff [Nonempty α] [Finite α] :
+lemma radius_eq_ediam_iff [Nonempty α] :
     G.radius = G.ediam ↔ ∃ e, ∀ u, G.eccent u = e := by
   refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
   · use G.radius
@@ -402,7 +402,7 @@ lemma center_nonempty [Nonempty α] : G.center.Nonempty :=
 lemma mem_center_iff (u : α) : u ∈ G.center ↔ G.eccent u = G.radius :=
   Set.mem_def
 
-lemma center_eq_univ_iff_radius_eq_ediam [Nonempty α] [Finite α] :
+lemma center_eq_univ_iff_radius_eq_ediam [Nonempty α] :
     G.center = Set.univ ↔ G.radius = G.ediam := by
   rw [radius_eq_ediam_iff, ← Set.univ_subset_iff]
   refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩

--- a/Mathlib/Combinatorics/SimpleGraph/Diam.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Diam.lean
@@ -18,7 +18,7 @@ This module defines the eccentricity of vertices, the diameter, and the radius o
 - `SimpleGraph.ediam`: the graph extended diameter, which is the maximum eccentricity.
   It is `ℕ∞`-valued.
 
-- `SimpleGraph.diam`: an `ℕ`-values version of `SimpleGraph.ediam`.
+- `SimpleGraph.diam`: the graph diameter, an `ℕ`-valued version of `SimpleGraph.ediam`.
 
 - `SimpleGraph.radius`: the graph radius, which is the minimum eccentricity. It is `ℕ∞`-valued.
 
@@ -39,7 +39,7 @@ noncomputable def eccent (G : SimpleGraph α) (u : α) : ℕ∞ :=
 
 lemma eccent_def : G.eccent = fun u ↦ ⨆ v, G.edist u v := rfl
 
-lemma edist_le_eccent (u v : α) : G.edist u v ≤ G.eccent u :=
+lemma edist_le_eccent {u v : α} : G.edist u v ≤ G.eccent u :=
   le_iSup (G.edist u) v
 
 lemma exists_edist_eq_eccent_of_finite [Finite α] (u : α) :
@@ -47,7 +47,7 @@ lemma exists_edist_eq_eccent_of_finite [Finite α] (u : α) :
   have : Nonempty α := Nonempty.intro u
   exists_eq_ciSup_of_finite
 
-lemma eccent_eq_top_of_not_connected (h : ¬G.Connected) (u : α) :
+lemma eccent_eq_top_of_not_connected (h : ¬ G.Connected) (u : α) :
     G.eccent u = ⊤ := by
   rw [connected_iff_exists_forall_reachable] at h
   push_neg at h
@@ -105,7 +105,7 @@ lemma ediam_eq_iSup_iSup_edist : G.ediam = ⨆ u, ⨆ v, G.edist u v :=
 lemma ediam_def : G.ediam = ⨆ p : α × α, G.edist p.1 p.2 := by
   rw [ediam, eccent_def, iSup_prod]
 
-lemma eccent_le_ediam (u : α) : G.eccent u ≤ G.ediam :=
+lemma eccent_le_ediam {u : α} : G.eccent u ≤ G.ediam :=
   le_iSup G.eccent u
 
 lemma edist_le_ediam {u v : α} : G.edist u v ≤ G.ediam :=
@@ -301,10 +301,10 @@ lemma center_nonempty [Nonempty α] : G.center.Nonempty :=
 lemma radius_eq_iInf_iSup_edist : G.radius = ⨅ u, ⨆ v, G.edist u v :=
   rfl
 
-lemma radius_le_eccent (u : α) : G.radius ≤ G.eccent u :=
+lemma radius_le_eccent {u : α} : G.radius ≤ G.eccent u :=
   iInf_le G.eccent u
 
-lemma radius_eq_top_of_not_connected (h : ¬G.Connected) :
+lemma radius_eq_top_of_not_connected (h : ¬ G.Connected) :
     G.radius = ⊤ := by
   simp [radius, eccent_eq_top_of_not_connected h]
 

--- a/Mathlib/Combinatorics/SimpleGraph/Diam.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Diam.lean
@@ -368,6 +368,18 @@ lemma ediam_le_two_mul_radius [Finite α] : G.ediam ≤ 2 * G.radius := by
     · rw [G.radius_eq_top_of_not_connected h]
       exact le_top
 
+lemma radius_eq_ediam_iff [Nonempty α] [Finite α] :
+    G.radius = G.ediam ↔ ∃ e, ∀ u, G.eccent u = e := by
+  refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
+  · use G.radius
+    intro u
+    exact le_antisymm (h ▸ eccent_le_ediam) radius_le_eccent
+  · obtain ⟨e, h⟩ := h
+    have ediam_eq : G.ediam = e :=
+      le_antisymm (iSup_le fun u ↦ (h u).le) ((h Classical.ofNonempty) ▸ eccent_le_ediam)
+    rw [ediam_eq]
+    exact le_antisymm ((h Classical.ofNonempty) ▸ radius_le_eccent) (le_iInf fun u ↦ (h u).ge)
+
 @[simp]
 lemma radius_bot [Nontrivial α] : (⊥ : SimpleGraph α).radius = ⊤ :=
   radius_eq_top_of_not_connected bot_not_connected
@@ -389,6 +401,17 @@ lemma center_nonempty [Nonempty α] : G.center.Nonempty :=
 
 lemma mem_center_iff (u : α) : u ∈ G.center ↔ G.eccent u = G.radius :=
   Set.mem_def
+
+lemma center_eq_univ_iff_radius_eq_ediam [Nonempty α] [Finite α] :
+    G.center = Set.univ ↔ G.radius = G.ediam := by
+  rw [radius_eq_ediam_iff, ← Set.univ_subset_iff]
+  refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
+  · use G.radius
+    exact fun _ ↦ h trivial
+  · obtain ⟨e, h⟩ := h
+    intro u hu
+    rw [mem_center_iff, h u]
+    exact le_antisymm (le_iInf fun u ↦ (h u).ge) ((h Classical.ofNonempty) ▸ radius_le_eccent)
 
 lemma center_eq_univ_of_subsingleton [Subsingleton α] : G.center = Set.univ := by
   rw [← Set.univ_subset_iff]

--- a/Mathlib/Combinatorics/SimpleGraph/Girth.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Girth.lean
@@ -11,6 +11,12 @@ import Mathlib.Data.ENat.Lattice
 
 This file defines the girth and the extended girth of a simple graph as the length of its smallest
 cycle, they give `0` or `∞` respectively if the graph is acyclic.
+
+## TODO
+
+- Prove that `G.egirth ≤ 2 * G.ediam + 1` and `G.girth ≤ 2 * G.diam + 1` when the diameter is
+  non-zero.
+
 -/
 
 namespace SimpleGraph


### PR DESCRIPTION
This PR defines the eccentricity of a vertex, the radius, and the center of a simple graph, and provides an API for them. They are placed in the `Diam.lean` file because they are closely related and have a similar API. Also this PR redefines `SimpleGraph.ediam` in terms of eccentricity, which shortens some of its proofs.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
