### PR TITLE
feat: MulSemiringAction.ofPowers

### DIFF
--- a/Mathlib/Algebra/Ring/Action/Basic.lean
+++ b/Mathlib/Algebra/Ring/Action/Basic.lean
@@ -98,12 +98,13 @@ abbrev MulSemiringAction.compHom (f : N →* M) [MulSemiringAction M R] : MulSem
 
 end
 
-/-- Given a a semiring homomorphism `φ` we can obtain a `MulSemiringAction` of
-`(Multiplicative ℕ)` on `R` by letting `Multiplicative.ofAdd n • r := φ ^ [n] a`.
+/-- Given a monoid `M` and a `MulSemiringAction M R`, we can obtain a
+`MulSemiringAction` of `(Multiplicative ℕ)` on `R` by
+choosing an element `φ : M` and letting `Multiplicative.ofAdd n • r := φ ^ n • a`.
 See note [reducible non-instances]. -/
-abbrev MulSemiringAction.ofRingHom (φ : R →+* R) :
+abbrev MulSemiringAction.ofRingHom [MulSemiringAction M R] (φ : M) :
     MulSemiringAction (Multiplicative ℕ) R :=
-  MulSemiringAction.compHom R (powersHom (R →+* R) φ)
+  MulSemiringAction.compHom R (powersHom M φ)
 
 section SimpLemmas
 

--- a/Mathlib/Algebra/Ring/Action/Basic.lean
+++ b/Mathlib/Algebra/Ring/Action/Basic.lean
@@ -102,7 +102,7 @@ end
 `MulSemiringAction` of `(Multiplicative ℕ)` on `R` by
 choosing an element `φ : M` and letting `Multiplicative.ofAdd n • r := φ ^ n • a`.
 See note [reducible non-instances]. -/
-abbrev MulSemiringAction.ofRingHom [MulSemiringAction M R] (φ : M) :
+abbrev MulSemiringAction.ofPowers [MulSemiringAction M R] (φ : M) :
     MulSemiringAction (Multiplicative ℕ) R :=
   MulSemiringAction.compHom R (powersHom M φ)
 

--- a/Mathlib/Algebra/Ring/Action/Basic.lean
+++ b/Mathlib/Algebra/Ring/Action/Basic.lean
@@ -6,6 +6,7 @@ Authors: Kenny Lau
 import Mathlib.Algebra.Group.Action.Basic
 import Mathlib.Algebra.GroupWithZero.Action.End
 import Mathlib.Algebra.Ring.Hom.Defs
+import Mathlib.Algebra.Group.Nat.Hom
 
 /-!
 # Group action on rings
@@ -96,6 +97,13 @@ abbrev MulSemiringAction.compHom (f : N →* M) [MulSemiringAction M R] : MulSem
   { DistribMulAction.compHom R f, MulDistribMulAction.compHom R f with }
 
 end
+
+/-- Given a a semiring homomorphism `φ` we can obtain a `MulSemiringAction` from
+`(Multiplicative ℕ)` to `R` by letting `Multiplicative.ofAdd n • r := φ ^ [n] a`.
+See note [reducible non-instances]. -/
+abbrev MulSemiringAction.ofRingHom (φ : R →+* R) :
+    MulSemiringAction (Multiplicative ℕ) R :=
+  MulSemiringAction.compHom R (powersHom (R →+* R) φ)
 
 section SimpLemmas
 

--- a/Mathlib/Algebra/Ring/Action/Basic.lean
+++ b/Mathlib/Algebra/Ring/Action/Basic.lean
@@ -98,8 +98,8 @@ abbrev MulSemiringAction.compHom (f : N →* M) [MulSemiringAction M R] : MulSem
 
 end
 
-/-- Given a a semiring homomorphism `φ` we can obtain a `MulSemiringAction` from
-`(Multiplicative ℕ)` to `R` by letting `Multiplicative.ofAdd n • r := φ ^ [n] a`.
+/-- Given a a semiring homomorphism `φ` we can obtain a `MulSemiringAction` of
+`(Multiplicative ℕ)` on `R` by letting `Multiplicative.ofAdd n • r := φ ^ [n] a`.
 See note [reducible non-instances]. -/
 abbrev MulSemiringAction.ofRingHom (φ : R →+* R) :
     MulSemiringAction (Multiplicative ℕ) R :=


### PR DESCRIPTION
Given a monoid `M` and a `MulSemiringAction M R`, we can obtain a `MulSemiringAction` of `(Multiplicative ℕ)` on `R` by choosing an element `φ : M` and letting `Multiplicative.ofAdd n • r := φ ^ n • a`.

In particular, this works with any semiring endomorphism `φ : R →+* R` where we get
`Multiplicative.ofAdd n • r := φ ^ [n] a`.

This is especially useful when using `SkewPolynomial` (see #23949) as one needs to introduce a
`MulSemiringAction` instance to the context for multiplication. The idea is to make the process of adding this instance as smooth as possible. My plan is to refer to this lemma in `SkewPolynomial` (with an example).

Co-authored-by: María Inés de Frutos Fernández <[mariaines.dff@gmail.com](mailto:mariaines.dff@gmail.com)>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
