### PR TITLE
[Merged by Bors] - feat(SimpleGraph/Walk): edge sets of walks

### DIFF
--- a/Mathlib/Combinatorics/SimpleGraph/Walk.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Walk.lean
@@ -819,11 +819,9 @@ theorem edgeSet_copy {u v u' v'} (p : G.Walk u v) (hu : u = u') (hv : v = v') :
   ext
   simp
 
-@[simp]
 theorem coe_edges_toFinset [DecidableEq V] {u v : V} (p : G.Walk u v) :
     (p.edges.toFinset : Set (Sym2 V)) = p.edgeSet := by
-  ext
-  simp
+  simp [edgeSet]
 
 /-- Predicate for the empty walk.
 

--- a/Mathlib/Combinatorics/SimpleGraph/Walk.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Walk.lean
@@ -780,6 +780,51 @@ theorem edges_injective {u v : V} : Function.Injective (Walk.edges : G.Walk u v 
 theorem darts_injective {u v : V} : Function.Injective (Walk.darts : G.Walk u v → List G.Dart) :=
   edges_injective.of_comp
 
+/-- The `Set` of edges of a walk. -/
+def edgeSet {u v : V} (p : G.Walk u v) : Set (Sym2 V) := {e | e ∈ p.edges}
+
+@[simp]
+lemma mem_edgeSet {u v : V} {p : G.Walk u v} {e : Sym2 V} : e ∈ p.edgeSet ↔ e ∈ p.edges := Iff.rfl
+
+@[simp]
+lemma edgeSet_nil (u : V) : (nil : G.Walk u u).edgeSet = ∅ := by
+  ext
+  simp
+
+@[simp]
+lemma edgeSet_reverse {u v : V} (p : G.Walk u v) : p.reverse.edgeSet = p.edgeSet := by
+  ext
+  simp
+
+@[simp]
+theorem edgeSet_cons {u v w : V} (h : G.Adj u v) (p : G.Walk v w) :
+    (cons h p).edgeSet = insert s(u, v) p.edgeSet := by
+  ext
+  simp
+
+@[simp]
+theorem edgeSet_concat {u v w : V} (p : G.Walk u v) (h : G.Adj v w) :
+    (p.concat h).edgeSet = insert s(v, w) p.edgeSet := by
+  ext
+  simp [or_comm]
+
+theorem edgeSet_append {u v w : V} (p : G.Walk u v) (q : G.Walk v w) :
+    (p.append q).edgeSet = p.edgeSet ∪ q.edgeSet := by
+  ext
+  simp
+
+@[simp]
+theorem edgeSet_copy {u v u' v'} (p : G.Walk u v) (hu : u = u') (hv : v = v') :
+    (p.copy hu hv).edgeSet = p.edgeSet := by
+  ext
+  simp
+
+@[simp]
+theorem coe_edges_toFinset [DecidableEq V] {u v : V} (p : G.Walk u v) :
+    (p.edges.toFinset : Set (Sym2 V)) = p.edgeSet := by
+  ext
+  simp
+
 /-- Predicate for the empty walk.
 
 Solves the dependent type problem where `p = G.Walk.nil` typechecks
@@ -1122,6 +1167,10 @@ theorem edges_map : (p.map f).edges = p.edges.map (Sym2.map f) := by
     simp only [Walk.map_cons, edges_cons, List.map_cons, Sym2.map_pair_eq, List.cons.injEq,
       true_and, ih]
 
+@[simp]
+theorem edgesSet_map : (p.map f).edgeSet = (Sym2.map f) '' p.edgeSet := by
+  simp [Set.ext_iff]
+
 theorem map_injective_of_injective {f : G →g G'} (hinj : Function.Injective f) (u v : V) :
     Function.Injective (Walk.map f : G.Walk u v → G'.Walk (f u) (f v)) := by
   intro p p' h
@@ -1170,6 +1219,11 @@ theorem transfer_eq_map_ofLE (hp) (GH : G ≤ H) : p.transfer H hp = p.map (.ofL
 @[simp]
 theorem edges_transfer (hp) : (p.transfer H hp).edges = p.edges := by
   induction p <;> simp [*]
+
+@[simp]
+theorem edgeSet_transfer (hp) : (p.transfer H hp).edgeSet = p.edgeSet := by
+  ext
+  simp
 
 @[simp]
 theorem support_transfer (hp) : (p.transfer H hp).support = p.support := by

--- a/Mathlib/Combinatorics/SimpleGraph/Walk.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Walk.lean
@@ -1168,7 +1168,7 @@ theorem edges_map : (p.map f).edges = p.edges.map (Sym2.map f) := by
       true_and, ih]
 
 @[simp]
-theorem edgesSet_map : (p.map f).edgeSet = (Sym2.map f) '' p.edgeSet := by
+theorem edgeSet_map : (p.map f).edgeSet = (Sym2.map f) '' p.edgeSet := by
   ext
   simp
 

--- a/Mathlib/Combinatorics/SimpleGraph/Walk.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Walk.lean
@@ -1169,7 +1169,8 @@ theorem edges_map : (p.map f).edges = p.edges.map (Sym2.map f) := by
 
 @[simp]
 theorem edgesSet_map : (p.map f).edgeSet = (Sym2.map f) '' p.edgeSet := by
-  simp [Set.ext_iff]
+  ext
+  simp
 
 theorem map_injective_of_injective {f : G →g G'} (hinj : Function.Injective f) (u v : V) :
     Function.Injective (Walk.map f : G.Walk u v → G'.Walk (f u) (f v)) := by

--- a/Mathlib/Combinatorics/SimpleGraph/Walk.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Walk.lean
@@ -787,37 +787,25 @@ def edgeSet {u v : V} (p : G.Walk u v) : Set (Sym2 V) := {e | e ∈ p.edges}
 lemma mem_edgeSet {u v : V} {p : G.Walk u v} {e : Sym2 V} : e ∈ p.edgeSet ↔ e ∈ p.edges := Iff.rfl
 
 @[simp]
-lemma edgeSet_nil (u : V) : (nil : G.Walk u u).edgeSet = ∅ := by
-  ext
-  simp
+lemma edgeSet_nil (u : V) : (nil : G.Walk u u).edgeSet = ∅ := by ext; simp
 
 @[simp]
-lemma edgeSet_reverse {u v : V} (p : G.Walk u v) : p.reverse.edgeSet = p.edgeSet := by
-  ext
-  simp
+lemma edgeSet_reverse {u v : V} (p : G.Walk u v) : p.reverse.edgeSet = p.edgeSet := by ext; simp
 
 @[simp]
 theorem edgeSet_cons {u v w : V} (h : G.Adj u v) (p : G.Walk v w) :
-    (cons h p).edgeSet = insert s(u, v) p.edgeSet := by
-  ext
-  simp
+    (cons h p).edgeSet = insert s(u, v) p.edgeSet := by ext; simp
 
 @[simp]
 theorem edgeSet_concat {u v w : V} (p : G.Walk u v) (h : G.Adj v w) :
-    (p.concat h).edgeSet = insert s(v, w) p.edgeSet := by
-  ext
-  simp [or_comm]
+    (p.concat h).edgeSet = insert s(v, w) p.edgeSet := by ext; simp [or_comm]
 
 theorem edgeSet_append {u v w : V} (p : G.Walk u v) (q : G.Walk v w) :
-    (p.append q).edgeSet = p.edgeSet ∪ q.edgeSet := by
-  ext
-  simp
+    (p.append q).edgeSet = p.edgeSet ∪ q.edgeSet := by ext; simp
 
 @[simp]
 theorem edgeSet_copy {u v u' v'} (p : G.Walk u v) (hu : u = u') (hv : v = v') :
-    (p.copy hu hv).edgeSet = p.edgeSet := by
-  ext
-  simp
+    (p.copy hu hv).edgeSet = p.edgeSet := by ext; simp
 
 theorem coe_edges_toFinset [DecidableEq V] {u v : V} (p : G.Walk u v) :
     (p.edges.toFinset : Set (Sym2 V)) = p.edgeSet := by
@@ -1166,9 +1154,7 @@ theorem edges_map : (p.map f).edges = p.edges.map (Sym2.map f) := by
       true_and, ih]
 
 @[simp]
-theorem edgeSet_map : (p.map f).edgeSet = (Sym2.map f) '' p.edgeSet := by
-  ext
-  simp
+theorem edgeSet_map : (p.map f).edgeSet = Sym2.map f '' p.edgeSet := by ext; simp
 
 theorem map_injective_of_injective {f : G →g G'} (hinj : Function.Injective f) (u v : V) :
     Function.Injective (Walk.map f : G.Walk u v → G'.Walk (f u) (f v)) := by
@@ -1220,9 +1206,7 @@ theorem edges_transfer (hp) : (p.transfer H hp).edges = p.edges := by
   induction p <;> simp [*]
 
 @[simp]
-theorem edgeSet_transfer (hp) : (p.transfer H hp).edgeSet = p.edgeSet := by
-  ext
-  simp
+theorem edgeSet_transfer (hp) : (p.transfer H hp).edgeSet = p.edgeSet := by ext; simp
 
 @[simp]
 theorem support_transfer (hp) : (p.transfer H hp).support = p.support := by


### PR DESCRIPTION
We introduce a definition `SimpleGraph.Walk.edgeSet (p : SimpleGraph.Walk G u v) : Set (Sym2 V)` for the edge set of a walk, and give a few very basic API lemmas. This allows us to avoid both decidability and the ugly `p.edges.toFinset.toSet` when talking about the set of edges of a walk. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
