### PR TITLE
[Merged by Bors] - refactor: prove `lintegral_eq_zero_iff'` without monotone convergence

### DIFF
--- a/Mathlib/MeasureTheory/Integral/Lebesgue/Basic.lean
+++ b/Mathlib/MeasureTheory/Integral/Lebesgue/Basic.lean
@@ -272,28 +272,7 @@ theorem setLIntegral_congr_fun {f g : α → ℝ≥0∞} {s : Set α} (hs : Meas
   rw [EventuallyEq]
   rwa [ae_restrict_iff' hs]
 
-section Markov
-
-/-- **Markov's inequality**, multiplication form for `AEMeasurable` functions. -/
-theorem mul_meas_ge_le_lintegral₀ {f : α → ℝ≥0∞} (hf : AEMeasurable f μ) (ε : ℝ≥0∞) :
-    ε * μ { x | ε ≤ f x } ≤ ∫⁻ a, f a ∂μ :=
-  calc
-    _ ≥ ∫⁻ a in {x | ε ≤ f x}, f a ∂μ := setLIntegral_le_lintegral _ _
-    _ ≥ ∫⁻ _ in {x | ε ≤ f x}, ε ∂μ :=
-      setLIntegral_mono_ae hf.restrict (ae_of_all μ fun _ ↦ id)
-    _ = _ := setLIntegral_const _ _
-
-/-- **Markov's inequality**, multiplication form for `Measurable` functions. -/
-theorem mul_meas_ge_le_lintegral {f : α → ℝ≥0∞} (hf : Measurable f) (ε : ℝ≥0∞) :
-    ε * μ { x | ε ≤ f x } ≤ ∫⁻ a, f a ∂μ :=
-  mul_meas_ge_le_lintegral₀ hf.aemeasurable ε
-
-/-- **Markov's inequality**, division form. -/
-theorem meas_ge_le_lintegral_div {f : α → ℝ≥0∞} (hf : AEMeasurable f μ) {ε : ℝ≥0∞} (hε : ε ≠ 0)
-    (hε' : ε ≠ ∞) : μ { x | ε ≤ f x } ≤ (∫⁻ a, f a ∂μ) / ε :=
-  (ENNReal.le_div_iff_mul_le (Or.inl hε) (Or.inl hε')).2 <| by
-    rw [mul_comm]
-    exact mul_meas_ge_le_lintegral₀ hf ε
+section
 
 @[simp]
 theorem lintegral_eq_zero_iff' {f : α → ℝ≥0∞} (hf : AEMeasurable f μ) :
@@ -301,7 +280,13 @@ theorem lintegral_eq_zero_iff' {f : α → ℝ≥0∞} (hf : AEMeasurable f μ) 
   refine ⟨fun h ↦ ?_, fun h ↦ (lintegral_congr_ae h).trans lintegral_zero⟩
   have meas_levels_0 : ∀ ε > 0, μ { x | ε ≤ f x } = 0 := fun ε εpos ↦ by
     by_contra! h'; rw [← zero_lt_iff] at h'
-    exact ((mul_pos_iff.mpr ⟨εpos, h'⟩).trans_le (mul_meas_ge_le_lintegral₀ hf ε)).ne' h
+    refine ((mul_pos_iff.mpr ⟨εpos, h'⟩).trans_le ?_).ne' h
+    -- This is just Markov's inequality, but we inline the proof for the sake of imports
+    calc
+      _ ≥ ∫⁻ a in {x | ε ≤ f x}, f a ∂μ := setLIntegral_le_lintegral _ _
+      _ ≥ ∫⁻ _ in {x | ε ≤ f x}, ε ∂μ :=
+        setLIntegral_mono_ae hf.restrict (ae_of_all μ fun _ ↦ id)
+      _ = _ := setLIntegral_const _ _
   obtain ⟨u, -, bu, tu⟩ := exists_seq_strictAnti_tendsto' (α := ℝ≥0∞) zero_lt_one
   have u_union : {x | f x ≠ 0} = ⋃ n, {x | u n ≤ f x} := by
     ext x; rw [mem_iUnion, mem_setOf_eq, ← zero_lt_iff]
@@ -333,7 +318,7 @@ theorem setLintegral_pos_iff {f : α → ℝ≥0∞} (hf : Measurable f) {s : Se
     0 < ∫⁻ a in s, f a ∂μ ↔ 0 < μ (Function.support f ∩ s) := by
   rw [lintegral_pos_iff_support hf, Measure.restrict_apply (measurableSet_support hf)]
 
-end Markov
+end
 
 /-- **Monotone convergence theorem** -- sometimes called **Beppo-Levi convergence**.
 See `lintegral_iSup_directed` for a more general form. -/
@@ -842,6 +827,20 @@ theorem lintegral_add_mul_meas_add_le_le_lintegral {f g : α → ℝ≥0∞} (hl
   simp only [indicator_apply]; split_ifs with hx₂
   exacts [hx₂, (add_zero _).trans_le <| (hφ_le x).trans hx₁]
 
+/-- **Markov's inequality**, multiplication form for `AEMeasurable` functions. -/
+theorem mul_meas_ge_le_lintegral₀ {f : α → ℝ≥0∞} (hf : AEMeasurable f μ) (ε : ℝ≥0∞) :
+    ε * μ { x | ε ≤ f x } ≤ ∫⁻ a, f a ∂μ :=
+  calc
+    _ ≥ ∫⁻ a in {x | ε ≤ f x}, f a ∂μ := setLIntegral_le_lintegral _ _
+    _ ≥ ∫⁻ _ in {x | ε ≤ f x}, ε ∂μ :=
+      setLIntegral_mono_ae hf.restrict (ae_of_all μ fun _ ↦ id)
+    _ = _ := setLIntegral_const _ _
+
+/-- **Markov's inequality**, multiplication form for `Measurable` functions. -/
+theorem mul_meas_ge_le_lintegral {f : α → ℝ≥0∞} (hf : Measurable f) (ε : ℝ≥0∞) :
+    ε * μ { x | ε ≤ f x } ≤ ∫⁻ a, f a ∂μ :=
+  mul_meas_ge_le_lintegral₀ hf.aemeasurable ε
+
 lemma meas_le_lintegral₀ {f : α → ℝ≥0∞} (hf : AEMeasurable f μ)
     {s : Set α} (hs : ∀ x ∈ s, 1 ≤ f x) : μ s ≤ ∫⁻ a, f a ∂μ := by
   apply le_trans _ (mul_meas_ge_le_lintegral₀ hf 1)
@@ -883,6 +882,13 @@ theorem measure_eq_top_of_setLintegral_ne_top {f : α → ℝ≥0∞} {s : Set �
     (hf : AEMeasurable f (μ.restrict s)) (hμf : ∫⁻ x in s, f x ∂μ ≠ ∞) :
     μ ({x ∈ s | f x = ∞}) = 0 :=
   of_not_not fun h => hμf <| setLintegral_eq_top_of_measure_eq_top_ne_zero hf h
+
+/-- **Markov's inequality**, division form for `AEMeasurable` functions. -/
+theorem meas_ge_le_lintegral_div {f : α → ℝ≥0∞} (hf : AEMeasurable f μ) {ε : ℝ≥0∞} (hε : ε ≠ 0)
+    (hε' : ε ≠ ∞) : μ { x | ε ≤ f x } ≤ (∫⁻ a, f a ∂μ) / ε :=
+  (ENNReal.le_div_iff_mul_le (Or.inl hε) (Or.inl hε')).2 <| by
+    rw [mul_comm]
+    exact mul_meas_ge_le_lintegral₀ hf ε
 
 theorem ae_eq_of_ae_le_of_lintegral_le {f g : α → ℝ≥0∞} (hfg : f ≤ᵐ[μ] g) (hf : ∫⁻ x, f x ∂μ ≠ ∞)
     (hg : AEMeasurable g μ) (hgf : ∫⁻ x, g x ∂μ ≤ ∫⁻ x, f x ∂μ) : f =ᵐ[μ] g := by

--- a/Mathlib/MeasureTheory/Integral/Lebesgue/Basic.lean
+++ b/Mathlib/MeasureTheory/Integral/Lebesgue/Basic.lean
@@ -303,14 +303,14 @@ theorem lintegral_eq_zero_iff' {f : α → ℝ≥0∞} (hf : AEMeasurable f μ) 
     by_contra! h'; rw [← zero_lt_iff] at h'
     exact ((mul_pos_iff.mpr ⟨εpos, h'⟩).trans_le (mul_meas_ge_le_lintegral₀ hf ε)).ne' h
   obtain ⟨u, -, bu, tu⟩ := exists_seq_strictAnti_tendsto' (α := ℝ≥0∞) zero_lt_one
-  have u_union : {x | 0 < f x} = ⋃ n : ℕ, {x | u n ≤ f x} := by
-    ext x; simp only [mem_setOf_eq, mem_iUnion]
+  have u_union : {x | f x ≠ 0} = ⋃ n, {x | u n ≤ f x} := by
+    ext x; rw [mem_iUnion, mem_setOf_eq, ← zero_lt_iff]
     rw [ENNReal.tendsto_atTop_zero] at tu
     constructor <;> intro h'
     · obtain ⟨n, hn⟩ := tu _ h'; use n, hn _ le_rfl
     · obtain ⟨n, hn⟩ := h'; exact (bu n).1.trans_le hn
   have res := measure_iUnion_null_iff.mpr fun n ↦ meas_levels_0 _ (bu n).1
-  simpa only [← u_union, zero_lt_iff] using res
+  rwa [← u_union] at res
 
 @[simp]
 theorem lintegral_eq_zero_iff {f : α → ℝ≥0∞} (hf : Measurable f) : ∫⁻ a, f a ∂μ = 0 ↔ f =ᵐ[μ] 0 :=

--- a/Mathlib/MeasureTheory/Integral/Lebesgue/Basic.lean
+++ b/Mathlib/MeasureTheory/Integral/Lebesgue/Basic.lean
@@ -827,7 +827,8 @@ theorem lintegral_add_mul_meas_add_le_le_lintegral {f g : α → ℝ≥0∞} (hl
   simp only [indicator_apply]; split_ifs with hx₂
   exacts [hx₂, (add_zero _).trans_le <| (hφ_le x).trans hx₁]
 
-/-- **Markov's inequality**, multiplication form for `AEMeasurable` functions. -/
+/-- **Markov's inequality** aka **Chebyshev's first inequality**.
+Multiplication form for `AEMeasurable` functions. -/
 theorem mul_meas_ge_le_lintegral₀ {f : α → ℝ≥0∞} (hf : AEMeasurable f μ) (ε : ℝ≥0∞) :
     ε * μ { x | ε ≤ f x } ≤ ∫⁻ a, f a ∂μ :=
   calc
@@ -836,7 +837,8 @@ theorem mul_meas_ge_le_lintegral₀ {f : α → ℝ≥0∞} (hf : AEMeasurable f
       setLIntegral_mono_ae hf.restrict (ae_of_all μ fun _ ↦ id)
     _ = _ := setLIntegral_const _ _
 
-/-- **Markov's inequality**, multiplication form for `Measurable` functions. -/
+/-- **Markov's inequality** aka **Chebyshev's first inequality**.
+Multiplication form for `Measurable` functions. -/
 theorem mul_meas_ge_le_lintegral {f : α → ℝ≥0∞} (hf : Measurable f) (ε : ℝ≥0∞) :
     ε * μ { x | ε ≤ f x } ≤ ∫⁻ a, f a ∂μ :=
   mul_meas_ge_le_lintegral₀ hf.aemeasurable ε
@@ -883,7 +885,8 @@ theorem measure_eq_top_of_setLintegral_ne_top {f : α → ℝ≥0∞} {s : Set �
     μ ({x ∈ s | f x = ∞}) = 0 :=
   of_not_not fun h => hμf <| setLintegral_eq_top_of_measure_eq_top_ne_zero hf h
 
-/-- **Markov's inequality**, division form for `AEMeasurable` functions. -/
+/-- **Markov's inequality** aka **Chebyshev's first inequality**.
+Division form for `AEMeasurable` functions. -/
 theorem meas_ge_le_lintegral_div {f : α → ℝ≥0∞} (hf : AEMeasurable f μ) {ε : ℝ≥0∞} (hε : ε ≠ 0)
     (hε' : ε ≠ ∞) : μ { x | ε ≤ f x } ≤ (∫⁻ a, f a ∂μ) / ε :=
   (ENNReal.le_div_iff_mul_le (Or.inl hε) (Or.inl hε')).2 <| by

--- a/Mathlib/MeasureTheory/Integral/Lebesgue/Basic.lean
+++ b/Mathlib/MeasureTheory/Integral/Lebesgue/Basic.lean
@@ -274,11 +274,11 @@ theorem setLIntegral_congr_fun {f g : α → ℝ≥0∞} {s : Set α} (hs : Meas
 
 section
 
-/-- The Lebesgue integral is zero iff the function is a.e. zero. The proof implicitly uses
-Markov's inequality, but it has been inlined for the sake of imports. -/
+/-- The Lebesgue integral is zero iff the function is a.e. zero. -/
 @[simp]
 theorem lintegral_eq_zero_iff' {f : α → ℝ≥0∞} (hf : AEMeasurable f μ) :
     ∫⁻ a, f a ∂μ = 0 ↔ f =ᵐ[μ] 0 := by
+  /- The proof implicitly uses Markov's inequality, but it has been inlined for the sake of imports. -/
   refine ⟨fun h ↦ ?_, fun h ↦ (lintegral_congr_ae h).trans lintegral_zero⟩
   have meas_levels_0 : ∀ ε > 0, μ { x | ε ≤ f x } = 0 := fun ε εpos ↦ by
     by_contra! h'; rw [← zero_lt_iff] at h'

--- a/Mathlib/MeasureTheory/Integral/Lebesgue/Basic.lean
+++ b/Mathlib/MeasureTheory/Integral/Lebesgue/Basic.lean
@@ -274,6 +274,8 @@ theorem setLIntegral_congr_fun {f g : α → ℝ≥0∞} {s : Set α} (hs : Meas
 
 section
 
+/-- The Lebesgue integral is zero iff the function is a.e. zero. The proof implicitly uses
+Markov's inequality, but it has been inlined for the sake of imports. -/
 @[simp]
 theorem lintegral_eq_zero_iff' {f : α → ℝ≥0∞} (hf : AEMeasurable f μ) :
     ∫⁻ a, f a ∂μ = 0 ↔ f =ᵐ[μ] 0 := by
@@ -281,7 +283,6 @@ theorem lintegral_eq_zero_iff' {f : α → ℝ≥0∞} (hf : AEMeasurable f μ) 
   have meas_levels_0 : ∀ ε > 0, μ { x | ε ≤ f x } = 0 := fun ε εpos ↦ by
     by_contra! h'; rw [← zero_lt_iff] at h'
     refine ((mul_pos_iff.mpr ⟨εpos, h'⟩).trans_le ?_).ne' h
-    -- This is just Markov's inequality, but we inline the proof for the sake of imports
     calc
       _ ≥ ∫⁻ a in {x | ε ≤ f x}, f a ∂μ := setLIntegral_le_lintegral _ _
       _ ≥ ∫⁻ _ in {x | ε ≤ f x}, ε ∂μ :=
@@ -827,18 +828,14 @@ theorem lintegral_add_mul_meas_add_le_le_lintegral {f g : α → ℝ≥0∞} (hl
   simp only [indicator_apply]; split_ifs with hx₂
   exacts [hx₂, (add_zero _).trans_le <| (hφ_le x).trans hx₁]
 
-/-- **Markov's inequality** aka **Chebyshev's first inequality**.
-Multiplication form for `AEMeasurable` functions. -/
+/-- **Markov's inequality** also known as **Chebyshev's first inequality**. -/
 theorem mul_meas_ge_le_lintegral₀ {f : α → ℝ≥0∞} (hf : AEMeasurable f μ) (ε : ℝ≥0∞) :
-    ε * μ { x | ε ≤ f x } ≤ ∫⁻ a, f a ∂μ :=
-  calc
-    _ ≥ ∫⁻ a in {x | ε ≤ f x}, f a ∂μ := setLIntegral_le_lintegral _ _
-    _ ≥ ∫⁻ _ in {x | ε ≤ f x}, ε ∂μ :=
-      setLIntegral_mono_ae hf.restrict (ae_of_all μ fun _ ↦ id)
-    _ = _ := setLIntegral_const _ _
+    ε * μ { x | ε ≤ f x } ≤ ∫⁻ a, f a ∂μ := by
+  simpa only [lintegral_zero, zero_add] using
+    lintegral_add_mul_meas_add_le_le_lintegral (ae_of_all _ fun x => zero_le (f x)) hf ε
 
-/-- **Markov's inequality** aka **Chebyshev's first inequality**.
-Multiplication form for `Measurable` functions. -/
+/-- **Markov's inequality** also known as **Chebyshev's first inequality**. For a version assuming
+`AEMeasurable`, see `mul_meas_ge_le_lintegral₀`. -/
 theorem mul_meas_ge_le_lintegral {f : α → ℝ≥0∞} (hf : Measurable f) (ε : ℝ≥0∞) :
     ε * μ { x | ε ≤ f x } ≤ ∫⁻ a, f a ∂μ :=
   mul_meas_ge_le_lintegral₀ hf.aemeasurable ε
@@ -885,8 +882,7 @@ theorem measure_eq_top_of_setLintegral_ne_top {f : α → ℝ≥0∞} {s : Set �
     μ ({x ∈ s | f x = ∞}) = 0 :=
   of_not_not fun h => hμf <| setLintegral_eq_top_of_measure_eq_top_ne_zero hf h
 
-/-- **Markov's inequality** aka **Chebyshev's first inequality**.
-Division form for `AEMeasurable` functions. -/
+/-- **Markov's inequality**, also known as **Chebyshev's first inequality**. -/
 theorem meas_ge_le_lintegral_div {f : α → ℝ≥0∞} (hf : AEMeasurable f μ) {ε : ℝ≥0∞} (hε : ε ≠ 0)
     (hε' : ε ≠ ∞) : μ { x | ε ≤ f x } ≤ (∫⁻ a, f a ∂μ) / ε :=
   (ENNReal.le_div_iff_mul_le (Or.inl hε) (Or.inl hε')).2 <| by

--- a/Mathlib/MeasureTheory/Integral/Lebesgue/Basic.lean
+++ b/Mathlib/MeasureTheory/Integral/Lebesgue/Basic.lean
@@ -278,7 +278,8 @@ section
 @[simp]
 theorem lintegral_eq_zero_iff' {f : α → ℝ≥0∞} (hf : AEMeasurable f μ) :
     ∫⁻ a, f a ∂μ = 0 ↔ f =ᵐ[μ] 0 := by
-  /- The proof implicitly uses Markov's inequality, but it has been inlined for the sake of imports. -/
+  -- The proof implicitly uses Markov's inequality,
+  -- but it has been inlined for the sake of imports
   refine ⟨fun h ↦ ?_, fun h ↦ (lintegral_congr_ae h).trans lintegral_zero⟩
   have meas_levels_0 : ∀ ε > 0, μ { x | ε ≤ f x } = 0 := fun ε εpos ↦ by
     by_contra! h'; rw [← zero_lt_iff] at h'


### PR DESCRIPTION
Currently `lintegral_eq_zero_iff'` is proved using a two-function variant of Markov's inequality, which in turn requires the additive property of Lebesgue integrals (`lintegral_add_left`), which in turn requires the monotone convergence theorem. This was causing some oddities in #23860, where a number of imports in other files had to be bumped because they used `lintegral_eq_zero_iff`.

It is however possible to prove `lintegral_eq_zero_iff'` with just the classical Markov's inequality, without additionally relying on monotone convergence. This PR does this and moves the six affected lemmas _before_ monotone convergence.