### PR TITLE
[Merged by Bors] - feat(Matroid/Rank): more rank API

### DIFF
--- a/Mathlib/Data/Matroid/Rank/ENat.lean
+++ b/Mathlib/Data/Matroid/Rank/ENat.lean
@@ -333,9 +333,8 @@ lemma eRk_eq_top_iff : M.eRk X = ⊤ ↔ ¬ M.IsRkFinite X := by
   obtain ⟨I, hI⟩ := M.exists_isBasis' X
   rw [hI.eRk_eq_encard, encard_eq_top_iff, ← hI.finite_iff_isRkFinite, Set.Infinite]
 
-@[simp]
 lemma eRk_ne_top_iff : M.eRk X ≠ ⊤ ↔ M.IsRkFinite X := by
-  rw [ne_eq, eRk_eq_top_iff, not_not]
+  simp
 
 @[simp]
 lemma eRk_lt_top_iff : M.eRk X < ⊤ ↔ M.IsRkFinite X := by
@@ -367,14 +366,6 @@ lemma eRk_comap_eq {β : Type*} {f : α → β} (M : Matroid β) (X : Set α) :
   obtain ⟨I, hI⟩ := (M.comap f).exists_isBasis' X
   obtain ⟨hI', hinj, -⟩ := comap_isBasis'_iff.1 hI
   rw [← hI.encard_eq_eRk, ← hI'.encard_eq_eRk, hinj.encard_image]
-
-@[simp]
-lemma eRank_loopyOn (X : Set α) : (loopyOn X).eRank = 0 := by
-  simp [← (show (loopyOn X).IsBase ∅ by simp).encard_eq_eRank]
-
-@[simp]
-lemma eRank_emptyOn (α : Type*) : (emptyOn α).eRank = 0 := by
-  simp [← (show (emptyOn α).IsBase ∅ by simp).encard_eq_eRank]
 
 @[simp]
 lemma loopyOn_eRk_eq (X Y : Set α) : (loopyOn Y).eRk X = 0 := by

--- a/Mathlib/Data/Matroid/Rank/ENat.lean
+++ b/Mathlib/Data/Matroid/Rank/ENat.lean
@@ -123,9 +123,6 @@ lemma eRk_inter_ground (M : Matroid α) (X : Set α) : M.eRk (X ∩ M.E) = M.eRk
 lemma eRk_ground_inter (M : Matroid α) (X : Set α) : M.eRk (M.E ∩ X) = M.eRk X := by
   rw [inter_comm, eRk_inter_ground]
 
-lemma eRk_eq_eRank (hX : M.E ⊆ X) : M.eRk X = M.eRank := by
-  rw [← eRk_inter_ground, inter_eq_self_of_subset_right hX, eRank_def]
-
 @[simp]
 lemma eRk_union_ground (M : Matroid α) (X : Set α) : M.eRk (X ∪ M.E) = M.eRank := by
   rw [← eRk_inter_ground, inter_eq_self_of_subset_right subset_union_right, eRank_def]
@@ -136,6 +133,9 @@ lemma eRk_ground_union (M : Matroid α) (X : Set α) : M.eRk (M.E ∪ X) = M.eRa
 
 lemma eRk_insert_of_not_mem_ground (X : Set α) (he : e ∉ M.E) : M.eRk (insert e X) = M.eRk X := by
   rw [← eRk_inter_ground, insert_inter_of_not_mem he, eRk_inter_ground]
+
+lemma eRk_eq_eRank (hX : M.E ⊆ X) : M.eRk X = M.eRank := by
+  rw [← eRk_inter_ground, inter_eq_self_of_subset_right hX, eRank_def]
 
 lemma eRk_compl_union_of_disjoint (M : Matroid α) (hXY : Disjoint X Y) :
     M.eRk (M.E \ X ∪ Y) = M.eRk (M.E \ X) := by
@@ -353,7 +353,7 @@ lemma IsRkFinite.eRk_lt_top (h : M.IsRkFinite X) : M.eRk X < ⊤ :=
 /-! ### Constructions -/
 
 @[simp]
-lemma eRank_map {β : Type*} (M : Matroid α) (f : α → β) (hf : InjOn f M.E) :
+lemma eRank_map {β : Type*} {f : α → β} (M : Matroid α) (hf : InjOn f M.E) :
     (M.map f hf).eRank = M.eRank := by
   obtain ⟨B, hB⟩ := M.exists_isBase
   rw [← (hB.map hf).encard_eq_eRank, ← hB.encard_eq_eRank, (hf.mono hB.subset_ground).encard_image]

--- a/Mathlib/Data/Matroid/Rank/ENat.lean
+++ b/Mathlib/Data/Matroid/Rank/ENat.lean
@@ -319,8 +319,12 @@ lemma eRank_ne_top_iff (M : Matroid α) : M.eRank ≠ ⊤ ↔ M.RankFinite := by
   rw [← hB.encard_eq_eRank, encard_ne_top_iff]
   exact ⟨fun h ↦ hB.rankFinite_of_finite h, fun h ↦ hB.finite⟩
 
+@[deprecated (since := "2025-04-13")] alias rankFinite_iff_eRk_ne_top := eRank_ne_top_iff
+
 lemma eRank_eq_top_iff (M : Matroid α) : M.eRank = ⊤ ↔ M.RankInfinite := by
   rw [← not_rankFinite_iff, ← eRank_ne_top_iff, not_not]
+
+@[deprecated (since := "2025-04-13")] alias rankInfinite_iff_eRk_eq_top := eRank_eq_top_iff
 
 @[simp]
 lemma eRank_eq_top [RankInfinite M] : M.eRank = ⊤ :=

--- a/Mathlib/Data/Matroid/Rank/ENat.lean
+++ b/Mathlib/Data/Matroid/Rank/ENat.lean
@@ -187,11 +187,6 @@ lemma restrict_eRk_eq' (M : Matroid α) (R X : Set α) : (M ↾ R).eRk X = M.eRk
 lemma restrict_eRk_eq (M : Matroid α) {R : Set α} (h : X ⊆ R) : (M ↾ R).eRk X = M.eRk X := by
   rw [restrict_eRk_eq', inter_eq_self_of_subset_left h]
 
-lemma eRk_lt_top_of_finite (M : Matroid α) (hX : X.Finite) : M.eRk X < ⊤ := by
-  obtain ⟨I, hI⟩ := M.exists_isBasis' X
-  rw [hI.eRk_eq_encard, encard_lt_top_iff]
-  exact hX.subset hI.subset
-
 lemma IsBasis'.eRk_eq_eRk_union (hIX : M.IsBasis' I X) (Y : Set α) :
     M.eRk (I ∪ Y) = M.eRk (X ∪ Y) := by
   rw [← eRk_union_closure_left_eq, hIX.closure_eq_closure, eRk_union_closure_left_eq]
@@ -293,10 +288,12 @@ lemma eRk_eq_eRk_union_eRk_le_zero (X : Set α) (hY : M.eRk Y ≤ 0) : M.eRk (X 
 lemma eRk_eq_eRk_diff_eRk_le_zero (X : Set α) (hY : M.eRk Y ≤ 0) : M.eRk (X \ Y) = M.eRk X := by
   rw [← eRk_eq_eRk_union_eRk_le_zero (X \ Y) hY, diff_union_self, eRk_eq_eRk_union_eRk_le_zero _ hY]
 
-lemma eRk_le_eRk_inter_add_eRk_diff (X Y : Set α) : M.eRk X ≤ M.eRk (X ∩ Y) + M.eRk (X \ Y) := by
+lemma eRk_le_eRk_inter_add_eRk_diff (M : Matroid α) (X Y : Set α) :
+    M.eRk X ≤ M.eRk (X ∩ Y) + M.eRk (X \ Y) := by
   nth_rw 1 [← inter_union_diff X Y]; apply eRk_union_le_eRk_add_eRk
 
-lemma eRk_le_eRk_add_eRk_diff (h : Y ⊆ X) : M.eRk X ≤ M.eRk Y + M.eRk (X \ Y) := by
+lemma eRk_le_eRk_add_eRk_diff (M : Matroid α) (h : Y ⊆ X) :
+    M.eRk X ≤ M.eRk Y + M.eRk (X \ Y) := by
   nth_rw 1 [← union_diff_cancel h]; apply eRk_union_le_eRk_add_eRk
 
 lemma eRk_union_le_encard_add_eRk (M : Matroid α) (X Y : Set α) :
@@ -316,17 +313,18 @@ end Basic
 
 /-! ### Finiteness -/
 
-lemma rankFinite_iff_eRank_ne_top (M : Matroid α) : M.RankFinite ↔ M.eRank ≠ ⊤ := by
+@[simp]
+lemma eRank_ne_top_iff (M : Matroid α) : M.eRank ≠ ⊤ ↔ M.RankFinite := by
   obtain ⟨B, hB⟩ := M.exists_isBase
   rw [← hB.encard_eq_eRank, encard_ne_top_iff]
-  exact ⟨fun h ↦ hB.finite, fun h ↦ hB.rankFinite_of_finite h⟩
+  exact ⟨fun h ↦ hB.rankFinite_of_finite h, fun h ↦ hB.finite⟩
 
-lemma rankInfinite_iff_eRank_eq_top (M : Matroid α) : M.RankInfinite ↔ M.eRank = ⊤ := by
-  rw [← not_rankFinite_iff, rankFinite_iff_eRank_ne_top, not_not]
+lemma eRank_eq_top_iff (M : Matroid α) : M.eRank = ⊤ ↔ M.RankInfinite := by
+  rw [← not_rankFinite_iff, ← eRank_ne_top_iff, not_not]
 
 @[simp]
-lemma eRank_eq_top_iff [RankInfinite M] : M.eRank = ⊤ :=
-  (rankInfinite_iff_eRank_eq_top _).1 <| by assumption
+lemma eRank_eq_top [RankInfinite M] : M.eRank = ⊤ :=
+  (eRank_eq_top_iff _).2 <| by assumption
 
 @[simp]
 lemma eRk_eq_top_iff : M.eRk X = ⊤ ↔ ¬ M.IsRkFinite X := by
@@ -342,6 +340,8 @@ lemma eRk_lt_top_iff : M.eRk X < ⊤ ↔ M.IsRkFinite X := by
 
 lemma IsRkFinite.eRk_lt_top (h : M.IsRkFinite X) : M.eRk X < ⊤ :=
   eRk_lt_top_iff.2 h
+
+@[deprecated (since := "2025-04-13")] alias eRk_lt_top_of_finite := IsRkFinite.eRk_lt_top
 
 lemma IsRkFinite.eRk_ne_top (h : M.IsRkFinite X) : M.eRk X ≠ ⊤ :=
   h.eRk_lt_top.ne

--- a/Mathlib/Data/Matroid/Rank/Finite.lean
+++ b/Mathlib/Data/Matroid/Rank/Finite.lean
@@ -94,6 +94,7 @@ lemma Indep.isRkFinite_iff_finite (hI : M.Indep I) : M.IsRkFinite I ↔ I.Finite
 
 alias ⟨Indep.finite_of_isRkFinite, _⟩ := Indep.isRkFinite_iff_finite
 
+@[simp]
 lemma isRkFinite_of_finite (M : Matroid α) (hX : X.Finite) : M.IsRkFinite X :=
   let ⟨_, hI⟩ := M.exists_isBasis' X
   hI.isRkFinite_of_finite (hX.subset hI.subset)
@@ -106,9 +107,8 @@ lemma Indep.subset_finite_isBasis_of_subset_of_isRkFinite (hI : M.Indep I) (hIX 
     (hX : M.IsRkFinite X) (hXE : X ⊆ M.E := by aesop_mat) : ∃ J, M.IsBasis J X ∧ I ⊆ J ∧ J.Finite :=
   (hI.subset_isBasis_of_subset hIX).imp fun _ hJ => ⟨hJ.1, hJ.2, hJ.1.finite_of_isRkFinite hX⟩
 
-@[simp]
-lemma isRkFinite_singleton : M.IsRkFinite {e} :=
-  isRkFinite_of_finite M (finite_singleton e)
+lemma isRkFinite_singleton : M.IsRkFinite {e} := by
+  simp
 
 @[simp]
 lemma IsRkFinite.empty (M : Matroid α) : M.IsRkFinite ∅ :=

--- a/Mathlib/Data/Matroid/Rank/Finite.lean
+++ b/Mathlib/Data/Matroid/Rank/Finite.lean
@@ -31,6 +31,9 @@ def IsRkFinite (M : Matroid α) (X : Set α) : Prop := (M ↾ X).RankFinite
 lemma IsRkFinite.rankFinite (hX : M.IsRkFinite X) : (M ↾ X).RankFinite :=
   hX
 
+@[simp] lemma RankFinite.isRkFinite [RankFinite M] (X : Set α) : M.IsRkFinite X :=
+  inferInstanceAs (M ↾ X).RankFinite
+
 lemma IsBasis'.finite_iff_isRkFinite (hI : M.IsBasis' I X) : I.Finite ↔ M.IsRkFinite X :=
   ⟨fun h ↦ ⟨I, hI, h⟩, fun (_ : (M ↾ X).RankFinite) ↦ hI.isBase_restrict.finite⟩
 
@@ -103,6 +106,7 @@ lemma Indep.subset_finite_isBasis_of_subset_of_isRkFinite (hI : M.Indep I) (hIX 
     (hX : M.IsRkFinite X) (hXE : X ⊆ M.E := by aesop_mat) : ∃ J, M.IsBasis J X ∧ I ⊆ J ∧ J.Finite :=
   (hI.subset_isBasis_of_subset hIX).imp fun _ hJ => ⟨hJ.1, hJ.2, hJ.1.finite_of_isRkFinite hX⟩
 
+@[simp]
 lemma isRkFinite_singleton : M.IsRkFinite {e} :=
   isRkFinite_of_finite M (finite_singleton e)
 

--- a/Mathlib/Data/Matroid/Rank/Finite.lean
+++ b/Mathlib/Data/Matroid/Rank/Finite.lean
@@ -110,7 +110,6 @@ lemma Indep.subset_finite_isBasis_of_subset_of_isRkFinite (hI : M.Indep I) (hIX 
 lemma isRkFinite_singleton : M.IsRkFinite {e} := by
   simp
 
-@[simp]
 lemma IsRkFinite.empty (M : Matroid α) : M.IsRkFinite ∅ :=
   isRkFinite_of_finite M finite_empty
 

--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -418,6 +418,7 @@
   "Mathlib.Data.Nat.Init": ["Batteries.Tactic.Init"],
   "Mathlib.Data.Nat.Find": ["Batteries.WF"],
   "Mathlib.Data.Multiset.Bind": ["Mathlib.Algebra.GroupWithZero.Action.Defs"],
+  "Mathlib.Data.Matroid.Rank.ENat": ["Mathlib.Tactic.TautoSet"],
   "Mathlib.Data.Matroid.Minor.Contract": ["Mathlib.Tactic.TautoSet"],
   "Mathlib.Data.Matroid.Minor.Basic": ["Mathlib.Tactic.TautoSet"],
   "Mathlib.Data.List.Sigma": ["Batteries.Tactic.Congr"],


### PR DESCRIPTION
We add some more API for matroid rank and its interactions with monotonicity, duality, finiteness and submodularity. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
