### PR TITLE
[Merged by Bors] - chore: move and rename `eval_of_algHom`

### DIFF
--- a/Mathlib/LinearAlgebra/StdBasis.lean
+++ b/Mathlib/LinearAlgebra/StdBasis.lean
@@ -3,10 +3,10 @@ Copyright (c) 2017 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl
 -/
+import Mathlib.Algebra.Algebra.Pi
 import Mathlib.LinearAlgebra.Finsupp.SumProd
 import Mathlib.LinearAlgebra.FreeModule.Basic
 import Mathlib.LinearAlgebra.LinearIndependent.Lemmas
-import Mathlib.LinearAlgebra.Pi
 
 /-!
 # The standard basis
@@ -162,6 +162,29 @@ end
 end Module
 
 end Pi
+
+/-- Let `k` be an integral domain and `G` an arbitrary finite set.
+Then any algebra morphism `φ : (G → k) →ₐ[k] k` is an evaluation map. -/
+lemma eval_of_algHom' {k G : Type*} [CommSemiring k] [NoZeroDivisors k] [Nontrivial k]
+    [Finite G] (φ : (G → k) →ₐ[k] k) : ∃ (s : G), φ = Pi.evalAlgHom _ _ s := by
+  have h1 := map_one φ
+  classical
+  have := Fintype.ofFinite G
+  simp only [← Finset.univ_sum_single (1 : G → k), Pi.one_apply, map_sum] at h1
+  obtain ⟨s, hs⟩ : ∃ (s : G), φ (Pi.single s 1) ≠ 0 := by
+    by_contra
+    simp_all
+  have h2 : ∀ t ≠ s, φ (Pi.single t 1) = 0 := by
+    refine fun _ _ ↦ (eq_zero_or_eq_zero_of_mul_eq_zero ?_).resolve_left hs
+    rw [← map_mul]
+    convert map_zero φ
+    ext u
+    by_cases u = s <;> simp_all
+  have h3 : φ (Pi.single s 1) = 1 := by
+    rwa [Fintype.sum_eq_single s h2] at h1
+  use s
+  refine AlgHom.toLinearMap_injective ((Pi.basisFun k G).ext fun t ↦ ?_)
+  by_cases t = s <;> simp_all
 
 namespace Module
 

--- a/Mathlib/LinearAlgebra/StdBasis.lean
+++ b/Mathlib/LinearAlgebra/StdBasis.lean
@@ -165,7 +165,7 @@ end Pi
 
 /-- Let `k` be an integral domain and `G` an arbitrary finite set.
 Then any algebra morphism `φ : (G → k) →ₐ[k] k` is an evaluation map. -/
-lemma eval_of_algHom' {k G : Type*} [CommSemiring k] [NoZeroDivisors k] [Nontrivial k]
+lemma AlgHom.eq_piEvalAlgHom {k G : Type*} [CommSemiring k] [NoZeroDivisors k] [Nontrivial k]
     [Finite G] (φ : (G → k) →ₐ[k] k) : ∃ (s : G), φ = Pi.evalAlgHom _ _ s := by
   have h1 := map_one φ
   classical

--- a/Mathlib/LinearAlgebra/StdBasis.lean
+++ b/Mathlib/LinearAlgebra/StdBasis.lean
@@ -186,6 +186,8 @@ lemma AlgHom.eq_piEvalAlgHom {k G : Type*} [CommSemiring k] [NoZeroDivisors k] [
   refine AlgHom.toLinearMap_injective ((Pi.basisFun k G).ext fun t ↦ ?_)
   by_cases t = s <;> simp_all
 
+@[deprecated (since := "2025-04-15")] alias eval_of_algHom := AlgHom.eq_piEvalAlgHom
+
 namespace Module
 
 variable (ι R M N : Type*) [Finite ι] [CommSemiring R]

--- a/Mathlib/RepresentationTheory/Tannaka.lean
+++ b/Mathlib/RepresentationTheory/Tannaka.lean
@@ -152,25 +152,3 @@ end FiniteGroup
 end TannakaDuality
 
 end
-
-/-- Let `k` be an integral domain and `G` an arbitrary finite set.
-Then any algebra morphism `φ : (G → k) →ₐ[k] k` is an evaluation map. -/
-lemma eval_of_algHom {k G : Type*} [CommRing k] [IsDomain k] [DecidableEq G] [Fintype G]
-    (φ : (G → k) →ₐ[k] k) : ∃ (s : G), φ = Pi.evalAlgHom _ _ s := by
-  have h1 := map_one φ
-  simp only [← Finset.univ_sum_single (1 : G → k), Pi.one_apply, map_sum] at h1
-  obtain ⟨s, hs⟩ : ∃ (s : G), φ (Pi.single s 1) ≠ 0 := by
-    by_contra
-    simp_all
-  have h2 : ∀ t ≠ s, φ (Pi.single t 1) = 0 := by
-    intros
-    apply eq_zero_of_ne_zero_of_mul_right_eq_zero hs
-    rw [← map_mul]
-    convert map_zero φ
-    ext u
-    by_cases u = s <;> simp_all
-  have h3 : φ (Pi.single s 1) = 1 := by
-    rwa [Fintype.sum_eq_single s h2] at h1
-  use s
-  refine AlgHom.toLinearMap_injective (Basis.ext (Pi.basisFun k G) (fun t ↦ ?_))
-  by_cases t = s <;> simp_all


### PR DESCRIPTION
Also generalize slightly and turn `[Fintype] [DecidableEq]` to `[Finite]`.

I think the correct condition on `k` is that it's nontrivial and not a direct product of two nontrivial semirings, i.e. its PrimeSpectrum is connected. If this is violated, we get counterexamples like `(R₁ × R₂) × (R₁ × R₂) → R₁ × R₂` given by `(r₁₁, r₁₂), (r₂₁, r₂₂)) ↦ (r₁₁, r₂₂)`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
