### PR TITLE
feat(Data/Matroid/Tutte): define the Tutte polynomial of a matroid

### DIFF
--- a/Mathlib/Algebra/BigOperators/Finprod.lean
+++ b/Mathlib/Algebra/BigOperators/Finprod.lean
@@ -949,16 +949,14 @@ lemma finprod_option {f : Option α → M} (hf : (mulSupport (f ∘ some)).Finit
   · rw [finprod_mem_range]
     exact Option.some_injective _
 
-@[to_additive]
 lemma finprod_mem_powerset_insert {f : Set α → M} {s : Set α} {a : α} (hs : s.Finite)
-    (has : a ∉ s) : ∏ᶠ t ∈ 𝒫 insert a s, f t = ∏ᶠ t ∈ 𝒫 s, f t * f (insert a t) := by
+    (has : a ∉ s) : ∏ᶠ t ∈ 𝒫 insert a s, f t = (∏ᶠ t ∈ 𝒫 s, f t) * ∏ᶠ t ∈ 𝒫 s, f (insert a t) := by
   rw [Set.powerset_insert, finprod_mem_union (powerset_insert_disjoint has) hs.powerset
-  (hs.powerset.image (insert a)), finprod_mem_image (powerset_insert_injOn has),
-  finprod_mem_mul_distrib hs.powerset]
+  (hs.powerset.image (insert a)), finprod_mem_image (powerset_insert_injOn has)]
 
-@[to_additive]
 lemma finprod_mem_powerset_diff_elem {f : Set α → M} {s : Set α} {a : α} (hs : s.Finite)
-    (has : a ∈ s) : ∏ᶠ t ∈ 𝒫 s, f t = ∏ᶠ t ∈ 𝒫 (s \ {a}), f t * f (insert a t) := by
+    (has : a ∈ s) : ∏ᶠ t ∈ 𝒫 s, f t = (∏ᶠ t ∈ 𝒫 (s \ {a}), f t)
+    * ∏ᶠ t ∈ 𝒫 (s \ {a}), f (insert a t) := by
   nth_rw 1 2 [← Set.insert_diff_self_of_mem has] -- second appearence hidden by notation
   exact finprod_mem_powerset_insert (hs.subset Set.diff_subset) (not_mem_diff_of_mem rfl)
 

--- a/Mathlib/Algebra/BigOperators/Finprod.lean
+++ b/Mathlib/Algebra/BigOperators/Finprod.lean
@@ -949,11 +949,13 @@ lemma finprod_option {f : Option α → M} (hf : (mulSupport (f ∘ some)).Finit
   · rw [finprod_mem_range]
     exact Option.some_injective _
 
+@[to_additive]
 lemma finprod_mem_powerset_insert {f : Set α → M} {s : Set α} {a : α} (hs : s.Finite)
     (has : a ∉ s) : ∏ᶠ t ∈ 𝒫 insert a s, f t = (∏ᶠ t ∈ 𝒫 s, f t) * ∏ᶠ t ∈ 𝒫 s, f (insert a t) := by
   rw [Set.powerset_insert, finprod_mem_union (powerset_insert_disjoint has) hs.powerset
   (hs.powerset.image (insert a)), finprod_mem_image (powerset_insert_injOn has)]
 
+@[to_additive]
 lemma finprod_mem_powerset_diff_elem {f : Set α → M} {s : Set α} {a : α} (hs : s.Finite)
     (has : a ∈ s) : ∏ᶠ t ∈ 𝒫 s, f t = (∏ᶠ t ∈ 𝒫 (s \ {a}), f t)
     * ∏ᶠ t ∈ 𝒫 (s \ {a}), f (insert a t) := by

--- a/Mathlib/Algebra/BigOperators/Finprod.lean
+++ b/Mathlib/Algebra/BigOperators/Finprod.lean
@@ -1047,9 +1047,17 @@ theorem mul_finsum {R : Type*} [Semiring R] (f : α → R) (r : R) (h : (support
     (r * ∑ᶠ a : α, f a) = ∑ᶠ a : α, r * f a :=
   (AddMonoidHom.mulLeft r).map_finsum h
 
+theorem mul_finsum_mem {R : Type*} [Semiring R] {s : Set α} (f : α → R) (r : R) (hs : s.Finite) :
+    (r * ∑ᶠ a ∈ s, f a) = ∑ᶠ a ∈ s, r * f a :=
+  (AddMonoidHom.mulLeft r).map_finsum_mem f hs
+
 theorem finsum_mul {R : Type*} [Semiring R] (f : α → R) (r : R) (h : (support f).Finite) :
     (∑ᶠ a : α, f a) * r = ∑ᶠ a : α, f a * r :=
   (AddMonoidHom.mulRight r).map_finsum h
+
+theorem finsum_mem_mul {R : Type*} [Semiring R] {s : Set α} (f : α → R) (r : R) (hs : s.Finite) :
+    (∑ᶠ a ∈ s, f a) * r = ∑ᶠ a ∈ s, f a * r :=
+  (AddMonoidHom.mulRight r).map_finsum_mem f hs
 
 @[to_additive (attr := simp)]
 lemma finprod_apply {α ι : Type*} {f : ι → α → N} (hf : (mulSupport f).Finite) (a : α) :

--- a/Mathlib/Algebra/BigOperators/Finprod.lean
+++ b/Mathlib/Algebra/BigOperators/Finprod.lean
@@ -950,6 +950,19 @@ lemma finprod_option {f : Option α → M} (hf : (mulSupport (f ∘ some)).Finit
     exact Option.some_injective _
 
 @[to_additive]
+lemma finprod_mem_powerset_insert {f : Set α → M} {s : Set α} {a : α} (hs : s.Finite)
+    (has : a ∉ s) : ∏ᶠ t ∈ 𝒫 insert a s, f t = ∏ᶠ t ∈ 𝒫 s, f t * f (insert a t) := by
+  rw [Set.powerset_insert, finprod_mem_union (powerset_insert_disjoint has) hs.powerset
+  (hs.powerset.image (insert a)), finprod_mem_image (powerset_insert_injOn has),
+  finprod_mem_mul_distrib hs.powerset]
+
+@[to_additive]
+lemma finprod_mem_powerset_diff_elem {f : Set α → M} {s : Set α} {a : α} (hs : s.Finite)
+    (has : a ∈ s) : ∏ᶠ t ∈ 𝒫 s, f t = ∏ᶠ t ∈ 𝒫 (s \ {a}), f t * f (insert a t) := by
+  nth_rw 1 2 [← Set.insert_diff_self_of_mem has] -- second appearence hidden by notation
+  exact finprod_mem_powerset_insert (hs.subset Set.diff_subset) (not_mem_diff_of_mem rfl)
+
+@[to_additive]
 theorem mul_finprod_cond_ne (a : α) (hf : (mulSupport f).Finite) :
     (f a * ∏ᶠ (i) (_ : i ≠ a), f i) = ∏ᶠ i, f i := by
   classical

--- a/Mathlib/Data/Matroid/Tutte/Basic.lean
+++ b/Mathlib/Data/Matroid/Tutte/Basic.lean
@@ -1,0 +1,73 @@
+/-
+Copyright (c) 2025 Bernhard Reinke. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Bernhard Reinke
+-/
+
+import Mathlib.Algebra.BigOperators.Finprod
+import Mathlib.Data.Matroid.Basic
+import Mathlib.Data.Matroid.Minor.Basic
+import Mathlib.Data.Matroid.Rank.ENat
+import Mathlib.Data.Set.Finite.Powerset
+import Mathlib.Tactic.Ring
+
+namespace Matroid
+variable {α : Type*} {M : Matroid α} [M.Finite] {R : Type*} [CommRing R] (x y : R) {e : α}
+
+variable (M) in
+noncomputable def tutte.summand (s : Set α) : R :=
+  (x - 1)^(M.eRank.toNat - (M.eRk s).toNat) * (y - 1)^(s.ncard - (M.eRk s).toNat)
+-- probably there is a nicer way to define the summands using `relRank`, but this is not yet in
+-- mathlib
+
+
+variable (M) in
+noncomputable def tutte : R := ∑ᶠ s ∈ M.E.powerset, tutte.summand M x y s
+
+namespace tutte
+
+theorem summand.contract_isNonloop (h : M.IsNonloop e) (s : Set α) (hs : s ∈ 𝒫 (M.E \ {e})) :
+    summand M x y (insert e s) = summand (M ／ {e}) x y s := sorry
+
+theorem summand.contract_isLoop (h : M.IsLoop e) (s : Set α) (hs : s ∈ 𝒫 (M.E \ {e})) :
+    summand M x y (insert e s) = (y - 1) * summand (M ／ {e}) x y s := sorry
+
+theorem summand.delete_not_isColoop (h : ¬ M.IsColoop e) (s : Set α) (hs : s ∈ 𝒫 (M.E \ {e})) :
+    summand M x y s = summand (M ＼ {e}) x y s := sorry
+
+theorem summand.delete_isColoop (h : M.IsColoop e) (s : Set α) (hs : s ∈ 𝒫 (M.E \ {e})) :
+    summand M x y s = (x - 1) * summand (M ＼ {e}) x y s := sorry
+
+
+theorem delete_isLoop (h : M.IsLoop e) : tutte M x y = y * (tutte (M ＼ {e}) x y) := by
+  simp_rw [tutte, finsum_mem_powerset_diff_elem M.ground_finite h.mem_ground]
+  rw [finsum_mem_congr rfl (summand.contract_isLoop x y h),
+    finsum_mem_congr rfl (summand.delete_not_isColoop x y h.not_isColoop)]
+  rw [contract_eq_delete_of_subset_loops, ← mul_finsum_mem]
+  · rw [delete_ground]
+    ring1
+  · exact (M.ground_finite.subset Set.diff_subset).powerset
+  · simpa only [Set.singleton_subset_iff] using h
+
+theorem contract_isColoop (h : M.IsColoop e) : tutte M x y = x * (tutte (M ／ {e}) x y) := by
+  simp_rw [tutte, finsum_mem_powerset_diff_elem M.ground_finite h.mem_ground]
+  rw [finsum_mem_congr rfl (summand.delete_isColoop x y h),
+    finsum_mem_congr rfl (summand.contract_isNonloop x y h.isNonloop)]
+  rw [contract_eq_delete_of_subset_coloops, ← mul_finsum_mem]
+  · rw [delete_ground]
+    ring1
+  · exact (M.ground_finite.subset Set.diff_subset).powerset
+  · simpa only [Set.singleton_subset_iff] using h
+
+theorem delete_contract (h₁ : M.IsNonloop e) (h₂ : ¬ M.IsColoop e) :
+    tutte M x y = tutte (M ＼ {e}) x y + (tutte (M ／ {e}) x y) := by
+  simp_rw [tutte, finsum_mem_powerset_diff_elem M.ground_finite h₁.mem_ground]
+  rw [finsum_mem_congr rfl (summand.contract_isNonloop x y h₁),
+    finsum_mem_congr rfl (summand.delete_not_isColoop x y h₂),
+    delete_ground, contract_ground]
+
+theorem emptyOn : tutte (emptyOn α) x y = 1 := by simp [tutte, summand, eRank_emptyOn]
+
+
+end tutte
+end Matroid

--- a/Mathlib/Data/Set/Image.lean
+++ b/Mathlib/Data/Set/Image.lean
@@ -564,6 +564,23 @@ theorem powerset_insert (s : Set α) (a : α) : 𝒫 insert a s = 𝒫 s ∪ ins
     · exact subset_trans h (subset_insert a s)
     · exact insert_subset_insert h₁
 
+theorem powerset_insert_disjoint {s : Set α} {a : α} (h : a ∉ s) :
+    Disjoint (𝒫 s) (insert a '' 𝒫 s) := by
+  rw [Set.disjoint_iff_forall_ne]
+  intros u u_mem v v_mem uv
+  have au : a ∉ u := Set.not_mem_subset (Set.subset_of_mem_powerset u_mem) h
+  have av : a ∈ v := by
+    simp only [mem_powerset_iff, mem_image] at v_mem
+    obtain ⟨_, _, eq⟩ := v_mem
+    simp [← eq]
+  exact au (uv ▸ av)
+
+theorem powerset_insert_injOn {s : Set α} {a : α} (h : a ∉ s) :
+    Set.InjOn (insert a) (𝒫 s) := fun u u_mem v v_mem eq ↦ by
+  rw [Subset.antisymm_iff] at eq ⊢
+  rwa [Set.insert_subset_insert_iff <| Set.not_mem_subset ((mem_powerset_iff _ _).mp v_mem) h,
+  Set.insert_subset_insert_iff <| Set.not_mem_subset ((mem_powerset_iff _ _).mp u_mem) h] at eq
+
 /-! ### Lemmas about range of a function. -/
 
 


### PR DESCRIPTION
This PR defines the Tutte polynomial of a matroid and shows basic properties.

- [x] depends on: #23926
- [ ] depends on #24336 
- [ ] depends on: #23951

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
