### PR TITLE
[Merged by Bors] - feat: Ideal.count_associates_eq

### DIFF
--- a/Mathlib/RingTheory/DedekindDomain/Ideal.lean
+++ b/Mathlib/RingTheory/DedekindDomain/Ideal.lean
@@ -48,6 +48,7 @@ to add a `(h : ¬ IsField A)` assumption whenever this is explicitly needed.
 dedekind domain, dedekind ring
 -/
 
+set_option linter.style.longFile 1700
 
 variable (R A K : Type*) [CommRing R] [CommRing A] [Field K]
 

--- a/Mathlib/RingTheory/DedekindDomain/Ideal.lean
+++ b/Mathlib/RingTheory/DedekindDomain/Ideal.lean
@@ -1196,6 +1196,39 @@ theorem count_associates_factors_eq [DecidableEq (Ideal R)] [DecidableEq <| Asso
     rw [Associates.prime_pow_dvd_iff_le hI hJ']
   omega
 
+/-- Variant of `UniqueFactorizationMonoid.count_normalizedFactors_eq` for associated Ideals. -/
+theorem Ideal.count_associates_eq [DecidableEq (Associates (Ideal R))]
+    [(p : Associates (Ideal R)) → Decidable (Irreducible p)]
+    {a a₀ x : R} {n : ℕ} (hx : Prime x) (ha : ¬x ∣ a) (heq : a₀ = x ^ n * a) :
+    (Associates.mk (span {x})).count (Associates.mk (span {a₀})).factors = n := by
+  have hx0 : x ≠ 0 := Prime.ne_zero hx
+  classical
+  rw [count_associates_factors_eq, UniqueFactorizationMonoid.count_normalizedFactors_eq]
+  · exact (prime_span_singleton_iff.mpr hx).irreducible
+  · exact normalize_eq _
+  · simp only [span_singleton_pow, heq, dvd_span_singleton]
+    exact Ideal.mul_mem_right _ _ (mem_span_singleton_self (x ^ n))
+  · simp only [span_singleton_pow, heq, dvd_span_singleton, mem_span_singleton]
+    rw [pow_add, pow_one, mul_dvd_mul_iff_left (pow_ne_zero n hx0)]
+    exact ha
+  · simp only [Submodule.zero_eq_bot, ne_eq, span_singleton_eq_bot, not_false_eq_true]
+    aesop
+  · exact (span_singleton_prime hx0).mpr hx
+  · simp only [ne_eq, span_singleton_eq_bot]; exact hx0
+
+/-- Variant of `UniqueFactorizationMonoid.count_normalizedFactors_eq` for associated Ideals. -/
+theorem Ideal.count_associates_eq' [DecidableEq (Associates (Ideal R))]
+    [(p : Associates (Ideal R)) → Decidable (Irreducible p)]
+    {a x : R} (hx : Prime x) {n : ℕ} (hle : x ^ n ∣ a) (hlt : ¬x ^ (n + 1) ∣ a) :
+    (Associates.mk (span {x})).count (Associates.mk (span {a})).factors = n := by
+  obtain ⟨q, hq⟩ := hle
+  apply Ideal.count_associates_eq hx _ hq
+  contrapose! hlt with hdvd
+  obtain ⟨q', hq'⟩ := hdvd
+  use q'
+  rw [hq, hq']
+  ring
+
 end
 
 theorem Ideal.le_mul_of_no_prime_factors {I J K : Ideal R}

--- a/Mathlib/RingTheory/DedekindDomain/Ideal.lean
+++ b/Mathlib/RingTheory/DedekindDomain/Ideal.lean
@@ -1197,7 +1197,7 @@ theorem count_associates_factors_eq [DecidableEq (Ideal R)] [DecidableEq <| Asso
 
 /-- Variant of `UniqueFactorizationMonoid.count_normalizedFactors_eq` for associated Ideals. -/
 theorem Ideal.count_associates_eq [DecidableEq (Associates (Ideal R))]
-    [(p : Associates (Ideal R)) → Decidable (Irreducible p)]
+    [∀ (p : Associates <| Ideal R), Decidable (Irreducible p)]
     {a a₀ x : R} {n : ℕ} (hx : Prime x) (ha : ¬x ∣ a) (heq : a₀ = x ^ n * a) :
     (Associates.mk (span {x})).count (Associates.mk (span {a₀})).factors = n := by
   have hx0 : x ≠ 0 := Prime.ne_zero hx
@@ -1217,7 +1217,7 @@ theorem Ideal.count_associates_eq [DecidableEq (Associates (Ideal R))]
 
 /-- Variant of `UniqueFactorizationMonoid.count_normalizedFactors_eq` for associated Ideals. -/
 theorem Ideal.count_associates_eq' [DecidableEq (Associates (Ideal R))]
-    [(p : Associates (Ideal R)) → Decidable (Irreducible p)]
+    [∀ (p : Associates <| Ideal R), Decidable (Irreducible p)]
     {a x : R} (hx : Prime x) {n : ℕ} (hle : x ^ n ∣ a) (hlt : ¬x ^ (n + 1) ∣ a) :
     (Associates.mk (span {x})).count (Associates.mk (span {a})).factors = n := by
   obtain ⟨q, hq⟩ := hle

--- a/Mathlib/RingTheory/DedekindDomain/Ideal.lean
+++ b/Mathlib/RingTheory/DedekindDomain/Ideal.lean
@@ -48,8 +48,6 @@ to add a `(h : ¬ IsField A)` assumption whenever this is explicitly needed.
 dedekind domain, dedekind ring
 -/
 
-set_option linter.style.longFile 1700
-
 variable (R A K : Type*) [CommRing R] [CommRing A] [Field K]
 
 open scoped nonZeroDivisors Polynomial
@@ -1526,3 +1524,5 @@ theorem one_le_primesOver_ncard : 1 ≤ (primesOver p B).ncard :=
   Nat.one_le_iff_ne_zero.mpr (primesOver_ncard_ne_zero p B)
 
 end primesOverFinset
+
+set_option linter.style.longFile 1700


### PR DESCRIPTION
Add variant of `UniqueFactorizationMonoid.count_normalizedFactors_eq` for associated Ideals.

This is convenient when you need to talk about an element as `a₀ = x ^ n * a`.

Note the file is slightly over the 1500 lines limit, I hope that is ok.

Co-authored-by: María Inés de Frutos Fernández <[mariaines.dff@gmail.com](mailto:mariaines.dff@gmail.com)>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
