### PR TITLE
[Merged by Bors] - chore(tprod): move tprod lemmas to protected namespace

### DIFF
--- a/Mathlib/Analysis/Analytic/Basic.lean
+++ b/Mathlib/Analysis/Analytic/Basic.lean
@@ -920,7 +920,7 @@ theorem HasFPowerSeriesWithinOnBall.tendsto_partialSum_prod {y : E}
     _ ≤ ∑ i ∈ range (n - k), ‖p (i + k)‖ * ↑r' ^ (i + k) := by
         gcongr with i _hi; simpa [← coe_nnnorm] using hw.le
     _ ≤ ∑' i, ‖p (i + k)‖ * ↑r' ^ (i + k) := by
-        apply sum_le_tsum _ (fun i _hi ↦ by positivity)
+        apply Summable.sum_le_tsum _ (fun i _hi ↦ by positivity)
         apply ((_root_.summable_nat_add_iff k).2 S)
     _ ≤ ε / 4 := hk.le
   calc

--- a/Mathlib/Analysis/Analytic/Basic.lean
+++ b/Mathlib/Analysis/Analytic/Basic.lean
@@ -138,7 +138,7 @@ theorem le_radius_of_eventually_le (C) (h : ∀ᶠ n in atTop, ‖p n‖ * (r : 
   p.le_radius_of_isBigO <| IsBigO.of_bound C <| h.mono fun n hn => by simpa
 
 theorem le_radius_of_summable_nnnorm (h : Summable fun n => ‖p n‖₊ * r ^ n) : ↑r ≤ p.radius :=
-  p.le_radius_of_bound_nnreal (∑' n, ‖p n‖₊ * r ^ n) fun _ => le_tsum' h _
+  p.le_radius_of_bound_nnreal (∑' n, ‖p n‖₊ * r ^ n) fun _ => h.le_tsum' _
 
 theorem le_radius_of_summable (h : Summable fun n => ‖p n‖ * (r : ℝ) ^ n) : ↑r ≤ p.radius :=
   p.le_radius_of_summable_nnnorm <| by

--- a/Mathlib/Analysis/CStarAlgebra/PositiveLinearMap.lean
+++ b/Mathlib/Analysis/CStarAlgebra/PositiveLinearMap.lean
@@ -122,7 +122,7 @@ lemma exists_norm_apply_le (f : A₁ →ₚ[ℂ] A₂) : ∃ C : ℝ≥0, ∀ a,
   · have (m : ℕ) : 0 ≤ ((2 : ℝ) ^ (-(m : ℤ)) • x m) := smul_nonneg (by positivity) (hx_nonneg m)
     refine CStarAlgebra.norm_le_norm_of_nonneg_of_le (f.map_nonneg (this n)) ?_
     gcongr
-    exact le_tsum x_summable n fun m _ ↦ this m
+    exact x_summable.le_tsum n fun m _ ↦ this m
 
 instance {F : Type*} [FunLike F A₁ A₂] [PositiveLinearMapClass F ℂ A₁ A₂] :
     ContinuousLinearMapClass F ℂ A₁ A₂ where

--- a/Mathlib/Analysis/Calculus/BumpFunction/FiniteDimension.lean
+++ b/Mathlib/Analysis/Calculus/BumpFunction/FiniteDimension.lean
@@ -183,7 +183,7 @@ theorem IsOpen.exists_smooth_support_eq {s : Set E} (hs : IsOpen s) :
     refine ⟨tsum_nonneg fun n => mul_nonneg (rpos n).le (g_nonneg n y), le_trans ?_ c_lt.le⟩
     have A : HasSum (fun n => (δ n : ℝ)) c := NNReal.hasSum_coe.2 δc
     simp only [Pi.smul_apply, smul_eq_mul, NNReal.val_eq_coe, ← A.tsum_eq]
-    apply tsum_le_tsum _ (S y) A.summable
+    apply Summable.tsum_le_tsum _ (S y) A.summable
     intro n
     apply (le_abs_self _).trans
     simpa only [norm_iteratedFDeriv_zero] using hr n 0 (zero_le n) y

--- a/Mathlib/Analysis/Calculus/BumpFunction/FiniteDimension.lean
+++ b/Mathlib/Analysis/Calculus/BumpFunction/FiniteDimension.lean
@@ -171,7 +171,7 @@ theorem IsOpen.exists_smooth_support_eq {s : Set E} (hs : IsOpen s) :
     · intro x hx
       obtain ⟨n, hn⟩ : ∃ n, x ∈ support (g n) := s_g x hx
       have I : 0 < r n * g n x := mul_pos (rpos n) (lt_of_le_of_ne (g_nonneg n x) (Ne.symm hn))
-      exact ne_of_gt (tsum_pos (S x) (fun i => mul_nonneg (rpos i).le (g_nonneg i x)) n I)
+      exact ne_of_gt ((S x).tsum_pos (fun i => mul_nonneg (rpos i).le (g_nonneg i x)) n I)
   · refine
       contDiff_tsum_of_eventually (fun n => (g_smooth n).const_smul (r n))
         (fun k _ => (NNReal.hasSum_coe.2 δc).summable) ?_

--- a/Mathlib/Analysis/Calculus/SmoothSeries.lean
+++ b/Mathlib/Analysis/Calculus/SmoothSeries.lean
@@ -267,7 +267,7 @@ theorem contDiff_tsum_of_eventually (hf : ∀ i, ContDiff 𝕜 N (f i))
     have : (fun x => ∑' i, f i x) = (fun x => ∑ i ∈ T, f i x) +
         fun x => ∑' i : { i // i ∉ T }, f i x := by
       ext1 x
-      refine (sum_add_tsum_subtype_compl ?_ T).symm
+      refine (Summable.sum_add_tsum_subtype_compl ?_ T).symm
       refine .of_norm_bounded_eventually _ (hv 0 (zero_le _)) ?_
       filter_upwards [h'f 0 (zero_le _)] with i hi
       simpa only [norm_iteratedFDeriv_zero] using hi x

--- a/Mathlib/Analysis/Complex/AbelLimit.lean
+++ b/Mathlib/Analysis/Complex/AbelLimit.lean
@@ -221,7 +221,7 @@ theorem tendsto_tsum_powerSeries_nhdsWithin_stolzSet
         rw [← mul_sum, ← mul_assoc]
       _ ≤ ‖1 - z‖ * (ε / 4 / M) * ∑' i, ‖z‖ ^ i := by
         gcongr
-        exact sum_le_tsum _ (fun _ _ ↦ by positivity)
+        exact Summable.sum_le_tsum _ (fun _ _ ↦ by positivity)
           (summable_geometric_of_lt_one (by positivity) zn)
       _ = ‖1 - z‖ * (ε / 4 / M) / (1 - ‖z‖) := by
         rw [tsum_geometric_of_lt_one (by positivity) zn, ← div_eq_mul_inv]

--- a/Mathlib/Analysis/InnerProductSpace/Orthonormal.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Orthonormal.lean
@@ -442,7 +442,7 @@ theorem Orthonormal.sum_inner_products_le {s : Finset ι} (hv : Orthonormal 𝕜
 /-- Bessel's inequality. -/
 theorem Orthonormal.tsum_inner_products_le (hv : Orthonormal 𝕜 v) :
     ∑' i, ‖⟪v i, x⟫‖ ^ 2 ≤ ‖x‖ ^ 2 := by
-  refine tsum_le_of_sum_le' ?_ fun s => hv.sum_inner_products_le x
+  refine Summable.tsum_le_of_sum_le' ?_ fun s => hv.sum_inner_products_le x
   simp only [norm_nonneg, pow_nonneg]
 
 /-- The sum defined in Bessel's inequality is summable. -/

--- a/Mathlib/Analysis/InnerProductSpace/Orthonormal.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Orthonormal.lean
@@ -442,7 +442,7 @@ theorem Orthonormal.sum_inner_products_le {s : Finset ι} (hv : Orthonormal 𝕜
 /-- Bessel's inequality. -/
 theorem Orthonormal.tsum_inner_products_le (hv : Orthonormal 𝕜 v) :
     ∑' i, ‖⟪v i, x⟫‖ ^ 2 ≤ ‖x‖ ^ 2 := by
-  refine Summable.tsum_le_of_sum_le' ?_ fun s => hv.sum_inner_products_le x
+  refine tsum_le_of_sum_le' ?_ fun s => hv.sum_inner_products_le x
   simp only [norm_nonneg, pow_nonneg]
 
 /-- The sum defined in Bessel's inequality is summable. -/

--- a/Mathlib/Analysis/InnerProductSpace/l2Space.lean
+++ b/Mathlib/Analysis/InnerProductSpace/l2Space.lean
@@ -190,7 +190,7 @@ protected def linearIsometry (hV : OrthogonalFamily 𝕜 G V) : lp G 2 →ₗᵢ
       LinearIsometry.map_add]
   map_smul' c f := by
     simpa only [LinearIsometry.map_smul, Pi.smul_apply, lp.coeFn_smul] using
-      tsum_const_smul c (hV.summable_of_lp f)
+      (hV.summable_of_lp f).tsum_const_smul c
   norm_map' f := by
     classical
       -- needed for lattice instance on `Finset ι`, for `Filter.atTop_neBot`

--- a/Mathlib/Analysis/InnerProductSpace/l2Space.lean
+++ b/Mathlib/Analysis/InnerProductSpace/l2Space.lean
@@ -130,7 +130,7 @@ instance instInnerProductSpace : InnerProductSpace 𝕜 (lp G 2) :=
         _ = ∑' i, ⟪(f₁ + f₂) i, g i⟫ := ?_
         _ = ∑' i, (⟪f₁ i, g i⟫ + ⟪f₂ i, g i⟫) := by
           simp only [inner_add_left, Pi.add_apply, coeFn_add]
-        _ = (∑' i, ⟪f₁ i, g i⟫) + ∑' i, ⟪f₂ i, g i⟫ := tsum_add ?_ ?_
+        _ = (∑' i, ⟪f₁ i, g i⟫) + ∑' i, ⟪f₂ i, g i⟫ := Summable.tsum_add ?_ ?_
         _ = _ := by congr
       · congr
       · exact summable_inner f₁ g
@@ -186,7 +186,7 @@ subspaces into `E`. -/
 protected def linearIsometry (hV : OrthogonalFamily 𝕜 G V) : lp G 2 →ₗᵢ[𝕜] E where
   toFun f := ∑' i, V i (f i)
   map_add' f g := by
-    simp only [tsum_add (hV.summable_of_lp f) (hV.summable_of_lp g), lp.coeFn_add, Pi.add_apply,
+    simp only [(hV.summable_of_lp f).tsum_add (hV.summable_of_lp g), lp.coeFn_add, Pi.add_apply,
       LinearIsometry.map_add]
   map_smul' c f := by
     simpa only [LinearIsometry.map_smul, Pi.smul_apply, lp.coeFn_smul] using

--- a/Mathlib/Analysis/MeanInequalities.lean
+++ b/Mathlib/Analysis/MeanInequalities.lean
@@ -656,7 +656,7 @@ theorem Lp_add_le_tsum {f g : ι → ℝ≥0} {p : ℝ} (hp : 1 ≤ p) (hf : Sum
     rw [one_div, ← NNReal.rpow_inv_le_iff pos, ← one_div]
     refine le_trans (Lp_add_le s f g hp) (add_le_add ?_ ?_) <;>
         rw [NNReal.rpow_le_rpow_iff (one_div_pos.mpr pos)] <;>
-      refine sum_le_tsum _ (fun _ _ => zero_le _) ?_
+      refine Summable.sum_le_tsum _ (fun _ _ => zero_le _) ?_
     exacts [hf, hg]
   have bdd : BddAbove (Set.range fun s => ∑ i ∈ s, (f i + g i) ^ p) := by
     refine ⟨((∑' i, f i ^ p) ^ (1 / p) + (∑' i, g i ^ p) ^ (1 / p)) ^ p, ?_⟩
@@ -665,7 +665,7 @@ theorem Lp_add_le_tsum {f g : ι → ℝ≥0} {p : ℝ} (hp : 1 ≤ p) (hf : Sum
   have H₂ : Summable _ := (hasSum_of_isLUB _ (isLUB_ciSup bdd)).summable
   refine ⟨H₂, ?_⟩
   rw [one_div, NNReal.rpow_inv_le_iff pos, ← one_div]
-  exact tsum_le_of_sum_le H₂ H₁
+  exact H₂.tsum_le_of_sum_le H₁
 
 theorem summable_Lp_add {f g : ι → ℝ≥0} {p : ℝ} (hp : 1 ≤ p) (hf : Summable fun i => f i ^ p)
     (hg : Summable fun i => g i ^ p) : Summable fun i => (f i + g i) ^ p :=

--- a/Mathlib/Analysis/MeanInequalities.lean
+++ b/Mathlib/Analysis/MeanInequalities.lean
@@ -548,15 +548,15 @@ theorem inner_le_Lp_mul_Lq_tsum {f g : ι → ℝ≥0} {p q : ℝ} (hpq : p.Hold
     intro s
     refine le_trans (inner_le_Lp_mul_Lq s f g hpq) (mul_le_mul ?_ ?_ bot_le bot_le)
     · rw [NNReal.rpow_le_rpow_iff (one_div_pos.mpr hpq.pos)]
-      exact sum_le_tsum _ (fun _ _ => zero_le _) hf
+      exact hf.sum_le_tsum _ (fun _ _ => zero_le _)
     · rw [NNReal.rpow_le_rpow_iff (one_div_pos.mpr hpq.symm.pos)]
-      exact sum_le_tsum _ (fun _ _ => zero_le _) hg
+      exact hg.sum_le_tsum _ (fun _ _ => zero_le _)
   have bdd : BddAbove (Set.range fun s => ∑ i ∈ s, f i * g i) := by
     refine ⟨(∑' i, f i ^ p) ^ (1 / p) * (∑' i, g i ^ q) ^ (1 / q), ?_⟩
     rintro a ⟨s, rfl⟩
     exact H₁ s
   have H₂ : Summable _ := (hasSum_of_isLUB _ (isLUB_ciSup bdd)).summable
-  exact ⟨H₂, tsum_le_of_sum_le H₂ H₁⟩
+  exact ⟨H₂, H₂.tsum_le_of_sum_le H₁⟩
 
 theorem summable_mul_of_Lp_Lq {f g : ι → ℝ≥0} {p q : ℝ} (hpq : p.HolderConjugate q)
     (hf : Summable fun i => f i ^ p) (hg : Summable fun i => g i ^ q) :

--- a/Mathlib/Analysis/Normed/Algebra/Spectrum.lean
+++ b/Mathlib/Analysis/Normed/Algebra/Spectrum.lean
@@ -487,7 +487,7 @@ theorem exp_mem_exp [RCLike 𝕜] [NormedRing A] [NormedAlgebra 𝕜 A] [Complet
     simpa only [pow_succ, Algebra.smul_mul_assoc] using hb.tsum_mul_right (a - ↑ₐ z)
   have h₃ : exp 𝕜 (a - ↑ₐ z) = 1 + (a - ↑ₐ z) * b := by
     rw [exp_eq_tsum]
-    convert tsum_eq_zero_add (expSeries_summable' (𝕂 := 𝕜) (a - ↑ₐ z))
+    convert (expSeries_summable' (𝕂 := 𝕜) (a - ↑ₐ z)).tsum_eq_zero_add
     · simp only [Nat.factorial_zero, Nat.cast_one, inv_one, pow_zero, one_smul]
     · exact h₀.symm
   rw [spectrum.mem_iff, IsUnit.sub_iff, ← one_mul (↑ₐ (exp 𝕜 z)), hexpmul, ← _root_.sub_mul,

--- a/Mathlib/Analysis/Normed/Group/Tannery.lean
+++ b/Mathlib/Analysis/Normed/Group/Tannery.lean
@@ -64,18 +64,18 @@ lemma tendsto_tsum_of_dominated_convergence {α β G : Type*} {𝓕 : Filter α}
     calc _ ≤ ‖∑' (k : (Tᶜ : Set β)), bound k‖ := Real.le_norm_self _
          _ = ‖S - ∑ b ∈ T, bound b‖          := congrArg _ ?_
          _ < ε / 3                            := by rwa [dist_eq_norm, norm_sub_rev] at hT
-    simpa only [sum_add_tsum_compl h_sum, eq_sub_iff_add_eq'] using hS.tsum_eq
+    simpa only [h_sum.sum_add_tsum_compl, eq_sub_iff_add_eq'] using hS.tsum_eq
   have h2 : Tendsto (∑ k ∈ T, f · k) 𝓕 (𝓝 (T.sum g)) := tendsto_finset_sum _ (fun i _ ↦ hab i)
   rw [Metric.tendsto_nhds] at h2
   filter_upwards [h2 (ε / 3) (by positivity), h_suma, h_bound] with n hn h_suma h_bound
-  rw [dist_eq_norm, ← tsum_sub h_suma.of_norm h_sumg.of_norm,
-    ← sum_add_tsum_compl (s := T) (h_suma.of_norm.sub h_sumg.of_norm),
+  rw [dist_eq_norm, ← h_suma.of_norm.tsum_sub h_sumg.of_norm,
+    ← (h_suma.of_norm.sub h_sumg.of_norm).sum_add_tsum_compl (s := T),
     (by ring : ε = ε / 3 + (ε / 3 + ε / 3))]
   refine (norm_add_le _ _).trans_lt (add_lt_add ?_ ?_)
   · simpa only [dist_eq_norm, Finset.sum_sub_distrib] using hn
-  · rw [tsum_sub (h_suma.subtype _).of_norm (h_sumg.subtype _).of_norm]
+  · rw [(h_suma.subtype _).of_norm.tsum_sub (h_sumg.subtype _).of_norm]
     refine (norm_sub_le _ _).trans_lt (add_lt_add ?_ ?_)
     · refine ((norm_tsum_le_tsum_norm (h_suma.subtype _)).trans ?_).trans_lt h1
-      exact tsum_le_tsum (h_bound ·) (h_suma.subtype _) (h_sum.subtype _)
+      exact (h_suma.subtype _).tsum_le_tsum (h_bound ·) (h_sum.subtype _)
     · refine ((norm_tsum_le_tsum_norm <| h_sumg.subtype _).trans ?_).trans_lt h1
-      exact tsum_le_tsum (h_g_le ·) (h_sumg.subtype _) (h_sum.subtype _)
+      exact (h_sumg.subtype _).tsum_le_tsum (h_g_le ·) (h_sum.subtype _)

--- a/Mathlib/Analysis/Normed/Lp/lpSpace.lean
+++ b/Mathlib/Analysis/Normed/Lp/lpSpace.lean
@@ -541,7 +541,7 @@ theorem norm_le_of_tsum_le (hp : 0 < p.toReal) {C : ℝ} (hC : 0 ≤ C) {f : lp 
 
 theorem norm_le_of_forall_sum_le (hp : 0 < p.toReal) {C : ℝ} (hC : 0 ≤ C) {f : lp E p}
     (hf : ∀ s : Finset α, ∑ i ∈ s, ‖f i‖ ^ p.toReal ≤ C ^ p.toReal) : ‖f‖ ≤ C :=
-  norm_le_of_tsum_le hp hC (tsum_le_of_sum_le ((lp.memℓp f).summable hp) hf)
+  norm_le_of_tsum_le hp hC (((lp.memℓp f).summable hp).tsum_le_of_sum_le hf)
 
 end ComparePointwise
 

--- a/Mathlib/Analysis/Normed/Lp/lpSpace.lean
+++ b/Mathlib/Analysis/Normed/Lp/lpSpace.lean
@@ -519,7 +519,7 @@ theorem sum_rpow_le_norm_rpow (hp : 0 < p.toReal) (f : lp E p) (s : Finset α) :
     ∑ i ∈ s, ‖f i‖ ^ p.toReal ≤ ‖f‖ ^ p.toReal := by
   rw [lp.norm_rpow_eq_tsum hp f]
   have : ∀ i, 0 ≤ ‖f i‖ ^ p.toReal := fun i => Real.rpow_nonneg (norm_nonneg _) _
-  refine sum_le_tsum _ (fun i _ => this i) ?_
+  refine Summable.sum_le_tsum _ (fun i _ => this i) ?_
   exact (lp.memℓp f).summable hp
 
 theorem norm_le_of_forall_le' [Nonempty α] {f : lp E ∞} (C : ℝ) (hCf : ∀ i, ‖f i‖ ≤ C) :

--- a/Mathlib/Analysis/Normed/Operator/Banach.lean
+++ b/Mathlib/Analysis/Normed/Operator/Banach.lean
@@ -198,7 +198,7 @@ theorem exists_preimage_norm_le (surj : Surjective f) :
     calc
       ‖x‖ ≤ ∑' n, ‖u n‖ := norm_tsum_le_tsum_norm sNu
       _ ≤ ∑' n, (1 / 2) ^ n * (C * ‖y‖) :=
-        tsum_le_tsum ule sNu (Summable.mul_right _ summable_geometric_two)
+        sNu.tsum_le_tsum ule <| Summable.mul_right _ summable_geometric_two
       _ = (∑' n, (1 / 2) ^ n) * (C * ‖y‖) := tsum_mul_right
       _ = 2 * C * ‖y‖ := by rw [tsum_geometric_two, mul_assoc]
       _ ≤ 2 * C * ‖y‖ + ‖y‖ := le_add_of_nonneg_right (norm_nonneg y)

--- a/Mathlib/Analysis/Normed/Ring/InfiniteSum.lean
+++ b/Mathlib/Analysis/Normed/Ring/InfiniteSum.lean
@@ -64,13 +64,13 @@ theorem summable_mul_of_summable_norm' {f : ι → R} {g : ι' → R}
 theorem tsum_mul_tsum_of_summable_norm [CompleteSpace R] {f : ι → R} {g : ι' → R}
     (hf : Summable fun x => ‖f x‖) (hg : Summable fun x => ‖g x‖) :
     ((∑' x, f x) * ∑' y, g y) = ∑' z : ι × ι', f z.1 * g z.2 :=
-  tsum_mul_tsum hf.of_norm hg.of_norm (summable_mul_of_summable_norm hf hg)
+  hf.of_norm.tsum_mul_tsum hg.of_norm (summable_mul_of_summable_norm hf hg)
 
 theorem tsum_mul_tsum_of_summable_norm' {f : ι → R} {g : ι' → R}
     (hf : Summable fun x => ‖f x‖) (h'f : Summable f)
     (hg : Summable fun x => ‖g x‖) (h'g : Summable g) :
     ((∑' x, f x) * ∑' y, g y) = ∑' z : ι × ι', f z.1 * g z.2 :=
-  tsum_mul_tsum h'f h'g (summable_mul_of_summable_norm' hf h'f hg h'g)
+  h'f.tsum_mul_tsum h'g (summable_mul_of_summable_norm' hf h'f hg h'g)
 
 /-! ### `ℕ`-indexed families (Cauchy product)
 
@@ -112,13 +112,13 @@ theorem summable_sum_mul_antidiagonal_of_summable_norm' {f g : ℕ → R}
 theorem tsum_mul_tsum_eq_tsum_sum_antidiagonal_of_summable_norm [CompleteSpace R] {f g : ℕ → R}
     (hf : Summable fun x => ‖f x‖) (hg : Summable fun x => ‖g x‖) :
     ((∑' n, f n) * ∑' n, g n) = ∑' n, ∑ kl ∈ antidiagonal n, f kl.1 * g kl.2 :=
-  tsum_mul_tsum_eq_tsum_sum_antidiagonal hf.of_norm hg.of_norm (summable_mul_of_summable_norm hf hg)
+  hf.of_norm.tsum_mul_tsum_eq_tsum_sum_antidiagonal hg.of_norm (summable_mul_of_summable_norm hf hg)
 
 theorem tsum_mul_tsum_eq_tsum_sum_antidiagonal_of_summable_norm' {f g : ℕ → R}
     (hf : Summable fun x => ‖f x‖) (h'f : Summable f)
     (hg : Summable fun x => ‖g x‖) (h'g : Summable g) :
     ((∑' n, f n) * ∑' n, g n) = ∑' n, ∑ kl ∈ antidiagonal n, f kl.1 * g kl.2 :=
-  tsum_mul_tsum_eq_tsum_sum_antidiagonal h'f h'g (summable_mul_of_summable_norm' hf h'f hg h'g)
+  h'f.tsum_mul_tsum_eq_tsum_sum_antidiagonal  h'g (summable_mul_of_summable_norm' hf h'f hg h'g)
 
 theorem summable_norm_sum_mul_range_of_summable_norm {f g : ℕ → R} (hf : Summable fun x => ‖f x‖)
     (hg : Summable fun x => ‖g x‖) : Summable fun n => ‖∑ k ∈ range (n + 1), f k * g (n - k)‖ := by

--- a/Mathlib/Analysis/Normed/Ring/Units.lean
+++ b/Mathlib/Analysis/Normed/Ring/Units.lean
@@ -108,7 +108,7 @@ theorem inverse_one_sub_nth_order' (n : ℕ) {t : R} (ht : ‖t‖ < 1) :
     inverse ((1 : R) - t) = (∑ i ∈ range n, t ^ i) + t ^ n * inverse (1 - t) :=
   have := _root_.summable_geometric_of_norm_lt_one ht
   calc inverse (1 - t) = ∑' i : ℕ, t ^ i := inverse_one_sub t ht
-    _ = ∑ i ∈ range n, t ^ i + ∑' i : ℕ, t ^ (i + n) := (sum_add_tsum_nat_add _ this).symm
+    _ = ∑ i ∈ range n, t ^ i + ∑' i : ℕ, t ^ (i + n) := (this.sum_add_tsum_nat_add _).symm
     _ = (∑ i ∈ range n, t ^ i) + t ^ n * inverse (1 - t) := by
       simp only [inverse_one_sub t ht, add_comm _ n, pow_add, this.tsum_mul_left]; rfl
 

--- a/Mathlib/Analysis/NormedSpace/FunctionSeries.lean
+++ b/Mathlib/Analysis/NormedSpace/FunctionSeries.lean
@@ -31,10 +31,10 @@ theorem tendstoUniformlyOn_tsum {f : α → β → F} (hu : Summable u) {s : Set
   filter_upwards [(tendsto_order.1 (tendsto_tsum_compl_atTop_zero u)).2 _ εpos] with t ht x hx
   have A : Summable fun n => ‖f n x‖ :=
     .of_nonneg_of_le (fun _ ↦ norm_nonneg _) (fun n => hfu n x hx) hu
-  rw [dist_eq_norm, ← sum_add_tsum_subtype_compl A.of_norm t, add_sub_cancel_left]
+  rw [dist_eq_norm, ← A.of_norm.sum_add_tsum_subtype_compl t, add_sub_cancel_left]
   apply lt_of_le_of_lt _ ht
   apply (norm_tsum_le_tsum_norm (A.subtype _)).trans
-  exact tsum_le_tsum (fun n => hfu _ _ hx) (A.subtype _) (hu.subtype _)
+  exact (A.subtype _).tsum_le_tsum (fun n => hfu _ _ hx) (hu.subtype _)
 
 /-- An infinite sum of functions with summable sup norm is the uniform limit of its partial sums.
 Version relative to a set, with index set `ℕ`. -/
@@ -63,10 +63,10 @@ theorem tendstoUniformlyOn_tsum_of_cofinite_eventually {ι : Type*} {f : ι → 
     apply Summable.of_nonneg_of_le (fun _ ↦ norm_nonneg _) _ (hu.subtype _)
     simp only [comp_apply, Subtype.forall, Set.mem_compl_iff, Finset.mem_coe]
     aesop
-  rw [dist_eq_norm, ← sum_add_tsum_subtype_compl A.of_norm n, add_sub_cancel_left]
+  rw [dist_eq_norm, ← A.of_norm.sum_add_tsum_subtype_compl n, add_sub_cancel_left]
   apply lt_of_le_of_lt _ (ht n (Finset.union_subset_right hn))
   apply (norm_tsum_le_tsum_norm (A.subtype _)).trans
-  apply tsum_le_tsum _ (A.subtype _) (hu.subtype _)
+  apply (A.subtype _).tsum_le_tsum _ (hu.subtype _)
   simp only [comp_apply, Subtype.forall, imp_false]
   apply fun i hi => HN i ?_ x hx
   have : ¬ i ∈ hN.toFinset := fun hg ↦ hi (Finset.union_subset_left hn hg)

--- a/Mathlib/Analysis/SpecialFunctions/Stirling.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Stirling.lean
@@ -140,7 +140,7 @@ theorem log_stirlingSeq_bounded_aux :
     convert log_stirlingSeq_sub_log_stirlingSeq_succ k using 1; field_simp
   have h₂ : (∑ k ∈ range n, 1 / (↑(k + 1) : ℝ) ^ 2) ≤ d := by
     have := (summable_nat_add_iff 1).mpr <| Real.summable_one_div_nat_pow.mpr one_lt_two
-    exact sum_le_tsum (range n) (fun k _ => by positivity) this
+    exact this.sum_le_tsum (range n) (fun k _ => by positivity)
   calc
     log (stirlingSeq 1) - log (stirlingSeq (n + 1)) = log_stirlingSeq' 0 - log_stirlingSeq' n :=
       rfl

--- a/Mathlib/Analysis/SpecialFunctions/Trigonometric/Series.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Trigonometric/Series.lean
@@ -147,7 +147,7 @@ lemma sinh_eq_tsum (r : ℝ) : sinh r = ∑' n, r ^ (2 * n + 1) / ↑(2 * n + 1)
 
 lemma cosh_le_exp_half_sq (x : ℝ) : cosh x ≤ exp (x ^ 2 / 2) := by
   rw [cosh_eq_tsum, exp_eq_exp_ℝ, exp_eq_tsum]
-  refine tsum_le_tsum (fun i ↦ ?_) x.hasSum_cosh.summable <| expSeries_summable' (x ^ 2 / 2)
+  refine x.hasSum_cosh.summable.tsum_le_tsum (fun i ↦ ?_) <| expSeries_summable' (x ^ 2 / 2)
   simp only [div_pow, pow_mul, smul_eq_mul, inv_mul_eq_div, div_div]
   gcongr
   norm_cast

--- a/Mathlib/Analysis/SpecificLimits/Basic.lean
+++ b/Mathlib/Analysis/SpecificLimits/Basic.lean
@@ -323,7 +323,7 @@ theorem sum_geometric_two_le (n : ℕ) : (∑ i ∈ range n, (1 / (2 : ℝ)) ^ i
     intro i
     apply pow_nonneg
     norm_num
-  convert sum_le_tsum (range n) (fun i _ ↦ this i) summable_geometric_two
+  convert summable_geometric_two.sum_le_tsum (range n) (fun i _ ↦ this i)
   exact tsum_geometric_two.symm
 
 theorem tsum_geometric_inv_two : (∑' n : ℕ, (2 : ℝ)⁻¹ ^ n) = 2 :=
@@ -338,7 +338,7 @@ theorem tsum_geometric_inv_two_ge (n : ℕ) :
   have B : ((Finset.range n).sum fun i : ℕ ↦ ite (n ≤ i) ((2⁻¹ : ℝ) ^ i) 0) = 0 :=
     Finset.sum_eq_zero fun i hi ↦
       ite_eq_right_iff.2 fun h ↦ (lt_irrefl _ ((Finset.mem_range.1 hi).trans_le h)).elim
-  simp only [← _root_.sum_add_tsum_nat_add n A, B, if_true, zero_add, zero_le',
+  simp only [← Summable.sum_add_tsum_nat_add n A, B, if_true, zero_add, zero_le',
     le_add_iff_nonneg_left, pow_add, _root_.tsum_mul_right, tsum_geometric_inv_two]
 
 theorem hasSum_geometric_two' (a : ℝ) : HasSum (fun n : ℕ ↦ a / 2 / 2 ^ n) a := by

--- a/Mathlib/Analysis/SpecificLimits/Normed.lean
+++ b/Mathlib/Analysis/SpecificLimits/Normed.lean
@@ -226,7 +226,7 @@ normed ring satisfies the axiom `‖1‖ = 1`. -/
 theorem tsum_geometric_le_of_norm_lt_one (x : R) (h : ‖x‖ < 1) :
     ‖∑' n : ℕ, x ^ n‖ ≤ ‖(1 : R)‖ - 1 + (1 - ‖x‖)⁻¹ := by
   by_cases hx : Summable (fun n ↦ x ^ n)
-  · rw [tsum_eq_zero_add hx]
+  · rw [hx.tsum_eq_zero_add]
     simp only [_root_.pow_zero]
     refine le_trans (norm_add_le _ _) ?_
     have : ‖∑' b : ℕ, (fun n ↦ x ^ (n + 1)) b‖ ≤ (1 - ‖x‖)⁻¹ - 1 := by
@@ -259,7 +259,7 @@ theorem mul_neg_geom_series (x : R) (h : ‖x‖ < 1) : (1 - x) * ∑' i : ℕ, 
   rw [← mul_neg_geom_sum, Finset.mul_sum]
 
 theorem geom_series_succ (x : R) (h : ‖x‖ < 1) : ∑' i : ℕ, x ^ (i + 1) = ∑' i : ℕ, x ^ i - 1 := by
-  rw [eq_sub_iff_add_eq, tsum_eq_zero_add (summable_geometric_of_norm_lt_one h),
+  rw [eq_sub_iff_add_eq, (summable_geometric_of_norm_lt_one h).tsum_eq_zero_add,
     pow_zero, add_comm]
 
 theorem geom_series_mul_shift (x : R) (h : ‖x‖ < 1) :

--- a/Mathlib/Analysis/SumOverResidueClass.lean
+++ b/Mathlib/Analysis/SumOverResidueClass.lean
@@ -100,6 +100,6 @@ summing each residue class mod `N` separately. -/
 lemma Nat.sumByResidueClasses {R : Type*} [AddCommGroup R] [UniformSpace R] [IsUniformAddGroup R]
     [CompleteSpace R] [T0Space R] {f : ℕ → R} (hf : Summable f) (N : ℕ) [NeZero N] :
     ∑' n, f n = ∑ j : ZMod N, ∑' m, f (j.val + N * m) := by
-  rw [← (residueClassesEquiv N).symm.tsum_eq f, tsum_prod, tsum_fintype, residueClassesEquiv,
-    Equiv.coe_fn_symm_mk]
+  rw [← (residueClassesEquiv N).symm.tsum_eq f, Summable.tsum_prod, tsum_fintype,
+    residueClassesEquiv, Equiv.coe_fn_symm_mk]
   exact hf.comp_injective (residueClassesEquiv N).symm.injective

--- a/Mathlib/Data/Real/Cardinality.lean
+++ b/Mathlib/Data/Real/Cardinality.lean
@@ -94,14 +94,14 @@ def cantorFunction (c : ℝ) (f : ℕ → Bool) : ℝ :=
 
 theorem cantorFunction_le (h1 : 0 ≤ c) (h2 : c < 1) (h3 : ∀ n, f n → g n) :
     cantorFunction c f ≤ cantorFunction c g := by
-  apply tsum_le_tsum _ (summable_cantor_function f h1 h2) (summable_cantor_function g h1 h2)
+  apply (summable_cantor_function f h1 h2).tsum_le_tsum _ (summable_cantor_function g h1 h2)
   intro n; cases h : f n
   · simp [h, cantorFunctionAux_nonneg h1]
   replace h3 : g n = true := h3 n h; simp [h, h3]
 
 theorem cantorFunction_succ (f : ℕ → Bool) (h1 : 0 ≤ c) (h2 : c < 1) :
     cantorFunction c f = cond (f 0) 1 0 + c * cantorFunction c fun n => f (n + 1) := by
-  rw [cantorFunction, tsum_eq_zero_add (summable_cantor_function f h1 h2)]
+  rw [cantorFunction, (summable_cantor_function f h1 h2).tsum_eq_zero_add]
   rw [cantorFunctionAux_succ, tsum_mul_left, cantorFunctionAux, _root_.pow_zero]
   rfl
 

--- a/Mathlib/MeasureTheory/Function/LpSpace/Complete.lean
+++ b/Mathlib/MeasureTheory/Function/LpSpace/Complete.lean
@@ -197,7 +197,7 @@ private theorem eLpNorm'_sum_norm_sub_le_tsum_of_cauchy_eLpNorm' {f : ℕ → α
   rw [hgf_norm_diff]
   refine (eLpNorm'_sum_le (fun i _ => ((hf (i + 1)).sub (hf i)).norm) hp1).trans ?_
   simp_rw [eLpNorm'_norm]
-  refine (Finset.sum_le_sum ?_).trans (sum_le_tsum _ (fun m _ => zero_le _) ENNReal.summable)
+  refine (Finset.sum_le_sum ?_).trans <| ENNReal.sum_le_tsum _
   exact fun m _ => (h_cau m (m + 1) m (Nat.le_succ m) (le_refl m)).le
 
 private theorem lintegral_rpow_sum_enorm_sub_le_rpow_tsum

--- a/Mathlib/MeasureTheory/Integral/DominatedConvergence.lean
+++ b/Mathlib/MeasureTheory/Integral/DominatedConvergence.lean
@@ -86,7 +86,7 @@ theorem hasSum_integral_of_dominated_convergence {ι} [Countable ι] {F : ι →
   have hb_le_tsum : ∀ n, bound n ≤ᵐ[μ] fun a => ∑' n, bound n a := by
     intro n
     filter_upwards [hb_nonneg, bound_summable]
-      with _ ha0 ha_sum using le_tsum ha_sum _ fun i _ => ha0 i
+      with _ ha0 ha_sum using ha_sum.le_tsum _ fun i _ => ha0 i
   have hF_integrable : ∀ n, Integrable (F n) μ := by
     refine fun n => bound_integrable.mono' (hF_meas n) ?_
     exact EventuallyLE.trans (h_bound n) (hb_le_tsum n)
@@ -99,7 +99,7 @@ theorem hasSum_integral_of_dominated_convergence {ι} [Countable ι] {F : ι →
       with a hFa ha0 has
     calc
       ‖∑ n ∈ s, F n a‖ ≤ ∑ n ∈ s, bound n a := norm_sum_le_of_le _ fun n _ => hFa n
-      _ ≤ ∑' n, bound n a := sum_le_tsum _ (fun n _ => ha0 n) has
+      _ ≤ ∑' n, bound n a := has.sum_le_tsum _ (fun n _ => ha0 n)
 
 theorem integral_tsum {ι} [Countable ι] {f : ι → α → G} (hf : ∀ i, AEStronglyMeasurable (f i) μ)
     (hf' : ∑' i, ∫⁻ a : α, ‖f i a‖ₑ ∂μ ≠ ∞) :

--- a/Mathlib/MeasureTheory/Measure/AddContent.lean
+++ b/Mathlib/MeasureTheory/Measure/AddContent.lean
@@ -229,7 +229,7 @@ theorem addContent_iUnion_eq_tsum_of_disjoint_of_addContent_iUnion_le {m : AddCo
     (hf_disj : Pairwise (Disjoint on f)) :
     m (⋃ i, f i) = ∑' i, m (f i) := by
   refine le_antisymm (m_subadd f hf hf_Union hf_disj) ?_
-  refine tsum_le_of_sum_le ENNReal.summable fun I ↦ ?_
+  refine  ENNReal.summable.tsum_le_of_sum_le fun I ↦ ?_
   classical
   rw [← Finset.sum_image_of_disjoint addContent_empty (hf_disj.pairwiseDisjoint _)]
   refine sum_addContent_le_of_subset hC (I := I.image f) ?_ ?_ hf_Union ?_

--- a/Mathlib/MeasureTheory/Measure/MeasureSpace.lean
+++ b/Mathlib/MeasureTheory/Measure/MeasureSpace.lean
@@ -1033,7 +1033,7 @@ lemma inf_apply {s : Set α} (hs : MeasurableSet s) :
         simp [hx, hxt]
     · simp only [iInf_image, coe_toOuterMeasure, iInf_pair]
       rw [tsum_eq_add_tsum_ite 0, tsum_eq_add_tsum_ite 1, if_neg zero_ne_one.symm,
-        (tsum_eq_zero_iff ENNReal.summable).2 _, add_zero]
+        ENNReal.summable.tsum_eq_zero_iff.2 _, add_zero]
       · exact add_le_add (inf_le_left.trans <| by simp [ht']) (inf_le_right.trans <| by simp [ht'])
       · simp only [ite_eq_left_iff]
         intro n hn₁ hn₀
@@ -1064,7 +1064,7 @@ lemma inf_apply {s : Set α} (hs : MeasurableSet s) :
     have heq : {k | μ (t' k) ≤ ν (t' k)} ∪ {k | ν (t' k) < μ (t' k)} = univ := by
       ext k; simp [le_or_lt]
     conv in ∑' (n : ℕ), μ (t' n) ⊓ ν (t' n) => rw [← tsum_univ, ← heq]
-    rw [tsum_union_disjoint (f := fun n ↦ μ (t' n) ⊓ ν (t' n)) ?_ ENNReal.summable ENNReal.summable]
+    rw [ENNReal.summable.tsum_union_disjoint (f := fun n ↦ μ (t' n) ⊓ ν (t' n)) ?_ ENNReal.summable]
     · refine add_le_add (tsum_congr ?_).le (tsum_congr ?_).le
       · rw [Subtype.forall]
         intro n hn; simpa
@@ -1228,7 +1228,7 @@ theorem sum_add_sum_compl (s : Set ι) (μ : ι → Measure α) :
     ((sum fun i : s => μ i) + sum fun i : ↥sᶜ => μ i) = sum μ := by
   ext1 t ht
   simp only [add_apply, sum_apply _ ht]
-  exact tsum_add_tsum_compl (f := fun i => μ i t) ENNReal.summable ENNReal.summable
+  exact ENNReal.summable.tsum_add_tsum_compl (f := fun i => μ i t) ENNReal.summable
 
 theorem sum_congr {μ ν : ℕ → Measure α} (h : ∀ n, μ n = ν n) : sum μ = sum ν :=
   congr_arg sum (funext h)
@@ -1236,7 +1236,7 @@ theorem sum_congr {μ ν : ℕ → Measure α} (h : ∀ n, μ n = ν n) : sum μ
 theorem sum_add_sum {ι : Type*} (μ ν : ι → Measure α) : sum μ + sum ν = sum fun n => μ n + ν n := by
   ext1 s hs
   simp only [add_apply, sum_apply _ hs, Pi.add_apply, coe_add,
-    tsum_add ENNReal.summable ENNReal.summable]
+    ENNReal.summable.tsum_add ENNReal.summable]
 
 @[simp] lemma sum_comp_equiv {ι ι' : Type*} (e : ι' ≃ ι) (m : ι → Measure α) :
     sum (m ∘ e) = sum m := by

--- a/Mathlib/MeasureTheory/Measure/MutuallySingular.lean
+++ b/Mathlib/MeasureTheory/Measure/MutuallySingular.lean
@@ -194,8 +194,8 @@ lemma exists_null_set_measure_lt_of_disjoint (h : Disjoint μ ν) {ε : ℝ≥0}
   · rw [compl_iInter, (by simp [ENNReal.tsum_mul_left, mul_comm] :
       2 * (ε : ℝ≥0∞) = ∑' (n : ℕ), ε * (1 / 2 : ℝ≥0∞) ^ n)]
     refine (measure_iUnion_le _).trans ?_
-    exact tsum_le_tsum (fun n ↦ (le_add_left le_rfl).trans (ht₂ n).le)
-      ENNReal.summable ENNReal.summable
+    exact ENNReal.summable.tsum_le_tsum (fun n ↦ (le_add_left le_rfl).trans (ht₂ n).le)
+      ENNReal.summable
 
 lemma mutuallySingular_of_disjoint (h : Disjoint μ ν) : μ ⟂ₘ ν := by
   have h' (n : ℕ) : ∃ s, μ s = 0 ∧ ν sᶜ ≤ (1 / 2) ^ n := by

--- a/Mathlib/MeasureTheory/OuterMeasure/OfAddContent.lean
+++ b/Mathlib/MeasureTheory/OuterMeasure/OfAddContent.lean
@@ -92,7 +92,7 @@ theorem isCaratheodory_ofFunction_of_mem (hC : IsSetSemiring C) (m : AddContent 
   have h_m_eq i : m (f i) = m (f i ∩ s) + ∑ u ∈ A i, m u :=
     eq_add_disjointOfDiff_of_subset hC (hC.inter_mem (f i) (hf i) s hs) (hf i) inter_subset_left
   simp_rw [h_m_eq]
-  rw [tsum_add ENNReal.summable ENNReal.summable]
+  rw [ENNReal.tsum_add]
   refine add_le_add ?_ ?_
   · refine iInf_le_of_le (fun i ↦ f i ∩ s) <| iInf_le_of_le ?_ le_rfl
     rw [← iUnion_inter]

--- a/Mathlib/MeasureTheory/OuterMeasure/OfAddContent.lean
+++ b/Mathlib/MeasureTheory/OuterMeasure/OfAddContent.lean
@@ -60,7 +60,7 @@ theorem ofFunction_eq (hC : IsSetSemiring C) (m : AddContent C)
       refine m_sigma_subadd (fun i ↦ hC.inter_mem _ hs _ (hf i)) ?_
       rwa [← inter_iUnion, inter_eq_self_of_subset_left hs_subset]
     _ ≤ ∑' i, m (f i) := by
-      refine tsum_le_tsum (fun i ↦ ?_) ENNReal.summable ENNReal.summable
+      refine  ENNReal.summable.tsum_le_tsum (fun i ↦ ?_) ENNReal.summable
       exact addContent_mono hC (hC.inter_mem _ hs _ (hf i)) (hf i) Set.inter_subset_right
 
 /-- For `m : AddContent C` sigma-sub-additive, finite on `C`, the `inducedOuterMeasure` given by `m`

--- a/Mathlib/MeasureTheory/OuterMeasure/OfFunction.lean
+++ b/Mathlib/MeasureTheory/OuterMeasure/OfFunction.lean
@@ -178,10 +178,10 @@ theorem ofFunction_union_of_top_of_nonempty_inter {s t : Set α}
     μ s + μ t ≤ (∑' i : I s, μ (f i)) + ∑' i : I t, μ (f i) :=
       add_le_add (hI _ subset_union_left) (hI _ subset_union_right)
     _ = ∑' i : ↑(I s ∪ I t), μ (f i) :=
-      (tsum_union_disjoint (f := fun i => μ (f i)) hd ENNReal.summable ENNReal.summable).symm
+      (ENNReal.summable.tsum_union_disjoint (f := fun i => μ (f i)) hd ENNReal.summable).symm
     _ ≤ ∑' i, μ (f i) :=
-      (tsum_le_tsum_of_inj (↑) Subtype.coe_injective (fun _ _ => zero_le _) (fun _ => le_rfl)
-        ENNReal.summable ENNReal.summable)
+      (ENNReal.summable.tsum_le_tsum_of_inj (↑) Subtype.coe_injective (fun _ _ => zero_le _)
+        (fun _ => le_rfl) ENNReal.summable)
     _ ≤ ∑' i, m (f i) := ENNReal.tsum_le_tsum fun i => ofFunction_le _
 
 theorem comap_ofFunction {β} (f : β → α) (h : Monotone m ∨ Surjective f) :

--- a/Mathlib/MeasureTheory/VectorMeasure/Basic.lean
+++ b/Mathlib/MeasureTheory/VectorMeasure/Basic.lean
@@ -792,7 +792,8 @@ theorem restrict_le_restrict_iUnion {f : ℕ → Set α} (hf₁ : ∀ n, Measura
   have ha₄ : Pairwise (Disjoint on fun n => a ∩ disjointed f n) :=
     (disjoint_disjointed _).mono fun i j => Disjoint.mono inf_le_right inf_le_right
   rw [← ha₃, v.of_disjoint_iUnion _ ha₄, w.of_disjoint_iUnion _ ha₄]
-  · refine tsum_le_tsum (fun n => (restrict_le_restrict_iff v w (hf₁ n)).1 (hf₂ n) ?_ ?_) ?_ ?_
+  · refine Summable.tsum_le_tsum (fun n => (restrict_le_restrict_iff v w (hf₁ n)).1 (hf₂ n) ?_ ?_)
+      ?_ ?_
     · exact ha₁.inter (MeasurableSet.disjointed hf₁ n)
     · exact Set.Subset.trans Set.inter_subset_right (disjointed_subset _ _)
     · refine (v.m_iUnion (fun n => ?_) ?_).summable

--- a/Mathlib/NumberTheory/EulerProduct/Basic.lean
+++ b/Mathlib/NumberTheory/EulerProduct/Basic.lean
@@ -127,7 +127,7 @@ lemma norm_tsum_factoredNumbers_sub_tsum_lt (hsum : Summable f) (hf₀ : f 0 = 0
   simp_rw [mem_ball_zero_iff] at hN
   refine ⟨N, fun s hs ↦ ?_⟩
   have := hN _ <| factoredNumbers_compl hs
-  rwa [← tsum_subtype_add_tsum_subtype_compl hsum (factoredNumbers s),
+  rwa [← hsum.tsum_subtype_add_tsum_subtype_compl (factoredNumbers s),
     add_sub_cancel_left, tsum_eq_tsum_diff_singleton (factoredNumbers s)ᶜ hf₀]
 
 -- Versions of the three lemmas above for `smoothNumbers N`

--- a/Mathlib/NumberTheory/EulerProduct/DirichletLSeries.lean
+++ b/Mathlib/NumberTheory/EulerProduct/DirichletLSeries.lean
@@ -181,7 +181,7 @@ lemma DirichletCharacter.LSeries_changeLevel {M N : ℕ} [NeZero N]
   -- convert to a form suitable for `tprod_subtype`
   have (f : Primes → ℂ) : ∏' (p : Primes), f p = ∏' (p : ↑{p : ℕ | p.Prime}), f p := rfl
   rw [this, tprod_subtype _ fun p : ℕ ↦ (1 - (changeLevel hMN χ) p * p ^ (-s))⁻¹,
-    this, tprod_subtype _ fun p : ℕ ↦ (1 - χ p * p ^ (-s))⁻¹, ← tprod_mul]
+    this, tprod_subtype _ fun p : ℕ ↦ (1 - χ p * p ^ (-s))⁻¹, ← Multipliable.tprod_mul]
   rotate_left -- deal with convergence goals first
   · exact multipliable_subtype_iff_mulIndicator.mp
       (DirichletCharacter.LSeries_eulerProduct_hasProd χ hs).multipliable

--- a/Mathlib/NumberTheory/EulerProduct/DirichletLSeries.lean
+++ b/Mathlib/NumberTheory/EulerProduct/DirichletLSeries.lean
@@ -61,7 +61,7 @@ lemma summable_riemannZetaSummand (hs : 1 < s.re) :
 lemma tsum_riemannZetaSummand (hs : 1 < s.re) :
     ∑' (n : ℕ), riemannZetaSummandHom (ne_zero_of_one_lt_re hs) n = riemannZeta s := by
   have hsum := summable_riemannZetaSummand hs
-  rw [zeta_eq_tsum_one_div_nat_add_one_cpow hs, tsum_eq_zero_add hsum.of_norm, map_zero, zero_add]
+  rw [zeta_eq_tsum_one_div_nat_add_one_cpow hs, hsum.of_norm.tsum_eq_zero_add, map_zero, zero_add]
   simp only [riemannZetaSummandHom, cpow_neg, MonoidWithZeroHom.coe_mk, ZeroHom.coe_mk,
     Nat.cast_add, Nat.cast_one, one_div]
 

--- a/Mathlib/NumberTheory/LSeries/Basic.lean
+++ b/Mathlib/NumberTheory/LSeries/Basic.lean
@@ -319,7 +319,7 @@ lemma LSeriesSummable.le_const_mul_rpow {f : ℕ → ℂ} {s : ℂ} (h : LSeries
   replace h := h.norm
   by_contra! H
   obtain ⟨n, hn₀, hn⟩ := H (tsum fun n ↦ ‖term f s n‖)
-  have := le_tsum h n fun _ _ ↦ norm_nonneg _
+  have := h.le_tsum n fun _ _ ↦ norm_nonneg _
   rw [norm_term_eq, if_neg hn₀,
     div_le_iff₀ <| Real.rpow_pos_of_pos (Nat.cast_pos.mpr <| Nat.pos_of_ne_zero hn₀) _] at this
   exact (this.trans_lt hn).false.elim

--- a/Mathlib/NumberTheory/LSeries/Injectivity.lean
+++ b/Mathlib/NumberTheory/LSeries/Injectivity.lean
@@ -70,7 +70,7 @@ lemma LSeries.tendsto_cpow_mul_atTop {f : ℕ → ℂ} {n : ℕ} (h : ∀ m ≤ 
   -- we can write `(n+1)^x * LSeries f x` as `f (n+1)` plus the series over `F x`
   have key : ∀ x ≥ y, (n + 1) ^ (x : ℂ) * LSeries f x = f (n + 1) + ∑' m : ℕ, F x m := by
     intro x hx
-    rw [LSeries, ← tsum_mul_left, tsum_eq_add_tsum_ite (hs hx) (n + 1), pow_mul_term_eq f x n]
+    rw [LSeries, ← tsum_mul_left, (hs hx).tsum_eq_add_tsum_ite (n + 1), pow_mul_term_eq f x n]
     congr
     ext1 m
     rcases eq_or_ne m (n + 1) with rfl | hm

--- a/Mathlib/NumberTheory/LSeries/Linearity.lean
+++ b/Mathlib/NumberTheory/LSeries/Linearity.lean
@@ -40,7 +40,7 @@ lemma LSeriesSummable.add {f g : ℕ → ℂ} {s : ℂ} (hf : LSeriesSummable f 
 @[simp]
 lemma LSeries_add {f g : ℕ → ℂ} {s : ℂ} (hf : LSeriesSummable f s) (hg : LSeriesSummable g s) :
     LSeries (f + g) s = LSeries f s + LSeries g s := by
-  simpa [LSeries, term_add] using tsum_add hf hg
+  simpa [LSeries, term_add] using hf.tsum_add hg
 
 /-!
 ### Negation
@@ -94,7 +94,7 @@ lemma LSeriesSummable.sub {f g : ℕ → ℂ} {s : ℂ} (hf : LSeriesSummable f 
 @[simp]
 lemma LSeries_sub {f g : ℕ → ℂ} {s : ℂ} (hf : LSeriesSummable f s) (hg : LSeriesSummable g s) :
     LSeries (f - g) s = LSeries f s - LSeries g s := by
-  simpa [LSeries, term_sub] using tsum_sub hf hg
+  simpa [LSeries, term_sub] using hf.tsum_sub hg
 
 /-!
 ### Scalar multiplication
@@ -158,6 +158,6 @@ lemma LSeriesSummable.sum (hf : ∀ i ∈ S, LSeriesSummable (f i) s) :
 @[simp]
 lemma LSeries_sum (hf : ∀ i ∈ S, LSeriesSummable (f i) s) :
     LSeries (∑ i ∈ S, f i) s = ∑ i ∈ S, LSeries (f i) s := by
-  simpa [LSeries, term_sum] using tsum_finsetSum hf
+  simpa [LSeries, term_sum] using Summable.tsum_finsetSum hf
 
 end sum

--- a/Mathlib/NumberTheory/LSeries/Nonvanishing.lean
+++ b/Mathlib/NumberTheory/LSeries/Nonvanishing.lean
@@ -293,7 +293,7 @@ lemma norm_LSeries_product_ge_one {x : ℝ} (hx : 0 < x) (y : ℝ) :
   simp only [← exp_nat_mul, Nat.cast_ofNat, ← exp_add, norm_exp, add_re, mul_re,
     re_ofNat, im_ofNat, zero_mul, sub_zero, Real.one_le_exp_iff]
   rw [re_tsum H₀, re_tsum H₁, re_tsum H₂, ← tsum_mul_left, ← tsum_mul_left,
-    ← tsum_add hsum₀ hsum₁, ← tsum_add (hsum₀.add hsum₁) hsum₂]
+    ← hsum₀.tsum_add hsum₁, ← (hsum₀.add hsum₁).tsum_add hsum₂]
   simpa only [neg_add_rev, neg_re, mul_neg, χ.pow_apply' two_ne_zero, ge_iff_le, add_re, one_re,
     ofReal_re, ofReal_add, ofReal_one] using
       tsum_nonneg fun (p : Nat.Primes) ↦ χ.re_log_comb_nonneg p.prop.two_le h₀ y

--- a/Mathlib/NumberTheory/LSeries/Positivity.lean
+++ b/Mathlib/NumberTheory/LSeries/Positivity.lean
@@ -55,7 +55,7 @@ then `L a x` is positive real for all real `x` larger than `abscissaOfAbsConv a`
 lemma positive {a : ℕ → ℂ} (ha₀ : 0 ≤ a) (ha₁ : 0 < a 1) {x : ℝ} (hx : abscissaOfAbsConv a < x) :
     0 < LSeries a x := by
   rw [LSeries]
-  refine tsum_pos ?_ (fun n ↦ term_nonneg (ha₀ n) x) 1 <| term_pos one_ne_zero ha₁ x
+  refine Summable.tsum_pos ?_ (fun n ↦ term_nonneg (ha₀ n) x) 1 <| term_pos one_ne_zero ha₁ x
   exact LSeriesSummable_of_abscissaOfAbsConv_lt_re <| by simpa only [ofReal_re] using hx
 
 /-- If all values of `a : ℕ → ℂ` are nonnegative reals and `a 1`

--- a/Mathlib/NumberTheory/LSeries/PrimesInAP.lean
+++ b/Mathlib/NumberTheory/LSeries/PrimesInAP.lean
@@ -88,7 +88,7 @@ lemma tprod_eq_tprod_primes_of_mulSupport_subset_prime_powers {f : ℕ → α}
       simpa only [← coe_prodNatEquiv_apply, Prod.eta, Function.comp_def, Equiv.apply_symm_apply]
         using hfm.subtype _
   simp only [← tprod_subtype_eq_of_mulSupport_subset hf, Set.coe_setOf, ← prodNatEquiv.tprod_eq,
-    ← tprod_prod hfm']
+    ← hfm'.tprod_prod]
   refine tprod_congr fun (p, k) ↦ congrArg f <| coe_prodNatEquiv_apply ..
 
 @[to_additive tsum_eq_tsum_primes_add_tsum_primes_of_support_subset_prime_powers]
@@ -100,9 +100,9 @@ lemma tprod_eq_tprod_primes_mul_tprod_primes_of_mulSupport_subset_prime_powers {
     hfm.comp_injective <| (strictMono_nat_of_lt_succ
       fun k ↦ pow_lt_pow_right₀ p.prop.one_lt <| lt_add_one (k + 1)).injective
   conv_lhs =>
-    enter [1, p]; rw [tprod_eq_zero_mul (hfs' p), zero_add, pow_one]
+    enter [1, p]; rw [(hfs' p).tprod_eq_zero_mul , zero_add, pow_one]
     enter [2, 1, k]; rw [add_assoc, one_add_one_eq_two]
-  exact tprod_mul (Multipliable.subtype hfm _) <|
+  exact (Multipliable.subtype hfm _).tprod_mul <|
     Multipliable.prod (f := fun (pk : Nat.Primes × ℕ) ↦ f (pk.1 ^ (pk.2 + 2))) <|
     hfm.comp_injective <| Subtype.val_injective |>.comp
     Nat.Primes.prodNatEquiv.injective |>.comp <|

--- a/Mathlib/NumberTheory/LSeries/PrimesInAP.lean
+++ b/Mathlib/NumberTheory/LSeries/PrimesInAP.lean
@@ -428,7 +428,7 @@ lemma not_summable_residueClass_prime_div (ha : IsUnit a) :
     simp only [← add_div, ite_add_ite, zero_add, add_zero, ite_self]
   let C := ∑' n, residueClass a n / n
   have H₁ {x : ℝ} (hx : 1 < x) : ∑' n, residueClass a n / (n : ℝ) ^ x ≤ C := by
-    refine tsum_le_tsum (fun n ↦ ?_) ?_ key
+    refine Summable.tsum_le_tsum (fun n ↦ ?_) ?_ key
     · rcases n.eq_zero_or_pos with rfl | hn
       · simp only [Nat.cast_zero, Real.zero_rpow (zero_lt_one.trans hx).ne', div_zero, le_refl]
       · refine div_le_div_of_nonneg_left (residueClass_nonneg a _) (mod_cast hn) ?_

--- a/Mathlib/NumberTheory/LSeries/RiemannZeta.lean
+++ b/Mathlib/NumberTheory/LSeries/RiemannZeta.lean
@@ -185,7 +185,7 @@ on mathlib's conventions for `0 ^ s`). -/
 theorem zeta_eq_tsum_one_div_nat_add_one_cpow {s : ℂ} (hs : 1 < re s) :
     riemannZeta s = ∑' n : ℕ, 1 / (n + 1 : ℂ) ^ s := by
   have := zeta_eq_tsum_one_div_nat_cpow hs
-  rw [tsum_eq_zero_add] at this
+  rw [Summable.tsum_eq_zero_add] at this
   · simpa [zero_cpow (Complex.ne_zero_of_one_lt_re hs)]
   · rwa [Complex.summable_one_div_nat_cpow]
 

--- a/Mathlib/NumberTheory/ModularForms/EisensteinSeries/IsBoundedAtImInfty.lean
+++ b/Mathlib/NumberTheory/ModularForms/EisensteinSeries/IsBoundedAtImInfty.lean
@@ -46,7 +46,7 @@ lemma norm_le_tsum_norm (N : ℕ) (a : Fin 2 → ZMod N) (k : ℤ) (hk : 3 ≤ k
     ‖eisensteinSeries a k z‖  ≤ ∑' (x : Fin 2 → ℤ), ‖eisSummand k x z‖ := by
   simp_rw [eisensteinSeries]
   apply le_trans (norm_tsum_le_tsum_norm ((summable_norm_eisSummand hk z).subtype _))
-    (tsum_subtype_le (fun (x : Fin 2 → ℤ) ↦ ‖(eisSummand k x z)‖) _ (fun _ ↦ norm_nonneg _)
+    (Summable.tsum_subtype_le (fun (x : Fin 2 → ℤ) ↦ ‖(eisSummand k x z)‖) _ (fun _ ↦ norm_nonneg _)
       (summable_norm_eisSummand hk z))
 
 @[deprecated (since := "2025-02-17")] alias abs_le_tsum_abs := norm_le_tsum_norm
@@ -62,7 +62,7 @@ theorem isBoundedAtImInfty_eisensteinSeries_SIF {N : ℕ+} (a : Fin 2 → ZMod N
     ← T_zpow_width_invariant N k n (eisensteinSeries_SIF (a ᵥ* A) k) z]
   apply le_trans (norm_le_tsum_norm N (a ᵥ* A) k hk _)
   have hk' : (2 : ℝ) < k := by norm_cast
-  apply tsum_le_tsum _ (summable_norm_eisSummand hk _)
+  apply (summable_norm_eisSummand hk _).tsum_le_tsum _
   · exact_mod_cast (summable_one_div_norm_rpow hk').mul_left <| r ⟨⟨N, 2⟩, Nat.ofNat_pos⟩ ^ (-k)
   · intro x
     simp_rw [eisSummand, norm_zpow]

--- a/Mathlib/NumberTheory/ModularForms/JacobiTheta/Bounds.lean
+++ b/Mathlib/NumberTheory/ModularForms/JacobiTheta/Bounds.lean
@@ -122,7 +122,7 @@ lemma F_nat_zero_le {a : ℝ} (ha : 0 ≤ a) {t : ℝ} (ht : 0 < t) :
 lemma F_nat_zero_zero_sub_le {t : ℝ} (ht : 0 < t) :
     ‖F_nat 0 0 t - 1‖ ≤ rexp (-π * t) / (1 - rexp (-π * t)) := by
   convert F_nat_zero_le zero_le_one ht using 2
-  · rw [F_nat, tsum_eq_zero_add (summable_f_nat 0 0 ht), f_nat, Nat.cast_zero, add_zero, pow_zero,
+  · rw [F_nat, (summable_f_nat 0 0 ht).tsum_eq_zero_add, f_nat, Nat.cast_zero, add_zero, pow_zero,
       one_mul, pow_two, mul_zero, mul_zero, zero_mul, exp_zero, add_comm, add_sub_cancel_right]
     simp_rw [F_nat, f_nat, Nat.cast_add, Nat.cast_one, add_zero]
   · rw [one_pow, mul_one]

--- a/Mathlib/NumberTheory/ModularForms/JacobiTheta/OneVariable.lean
+++ b/Mathlib/NumberTheory/ModularForms/JacobiTheta/OneVariable.lean
@@ -102,7 +102,7 @@ theorem norm_jacobiTheta_sub_one_le {τ : ℂ} (hτ : 0 < im τ) :
       (exp_lt_one_iff.mpr <| mul_neg_of_neg_of_pos (neg_lt_zero.mpr pi_pos) hτ)
   have aux : Summable fun n : ℕ => ‖cexp (π * I * ((n : ℂ) + 1) ^ 2 * τ)‖ :=
     .of_nonneg_of_le (fun n => norm_nonneg _) this s.summable
-  exact (norm_tsum_le_tsum_norm aux).trans ((tsum_mono aux s.summable this).trans_eq s.tsum_eq)
+  exact (norm_tsum_le_tsum_norm aux).trans ((aux.tsum_mono s.summable this).trans_eq s.tsum_eq)
 
 /-- The norm of `jacobiTheta τ - 1` decays exponentially as `im τ → ∞`. -/
 theorem isBigO_at_im_infty_jacobiTheta_sub_one :

--- a/Mathlib/NumberTheory/ModularForms/JacobiTheta/TwoVariable.lean
+++ b/Mathlib/NumberTheory/ModularForms/JacobiTheta/TwoVariable.lean
@@ -443,7 +443,7 @@ lemma jacobiTheta₂'_add_left' (z τ : ℂ) :
     ring
   rw [jacobiTheta₂', funext this, tsum_mul_left, ← (Equiv.subRight (1 : ℤ)).tsum_eq]
   simp only [jacobiTheta₂, jacobiTheta₂', Equiv.subRight_apply, sub_add_cancel,
-    tsum_sub (hasSum_jacobiTheta₂'_term z hτ).summable
+    (hasSum_jacobiTheta₂'_term z hτ).summable.tsum_sub
     ((hasSum_jacobiTheta₂_term z hτ).summable.mul_left _), tsum_mul_left]
 
 lemma jacobiTheta₂'_neg_left (z τ : ℂ) : jacobiTheta₂' (-z) τ = -jacobiTheta₂' z τ := by

--- a/Mathlib/NumberTheory/Padics/MahlerBasis.lean
+++ b/Mathlib/NumberTheory/Padics/MahlerBasis.lean
@@ -297,7 +297,7 @@ lemma mahlerSeries_apply_nat (ha : Tendsto a atTop (𝓝 0)) {m n : ℕ} (hmn : 
   have aux : Summable fun i ↦ m.choose (i + (n + 1)) • a (i + (n + 1)) := by
     simpa only [h_van, zero_smul] using summable_zero
   simp only [mahlerSeries_apply ha, mahler_natCast_eq, Nat.cast_smul_eq_nsmul, add_zero,
-    ← sum_add_tsum_nat_add' (f := fun i ↦ m.choose i • a i) aux, h_van, zero_smul, tsum_zero]
+    ← aux.sum_add_tsum_nat_add' (f := fun i ↦ m.choose i • a i), h_van, zero_smul, tsum_zero]
 
 /--
 The coefficients of a Mahler series can be recovered from the sum by taking forward differences at

--- a/Mathlib/NumberTheory/SumPrimeReciprocals.lean
+++ b/Mathlib/NumberTheory/SumPrimeReciprocals.lean
@@ -72,7 +72,7 @@ theorem not_summable_one_div_on_primes :
     convert h.indicator {n : ℕ | k ≤ n} using 1
     simp only [indicator_indicator, inter_comm]
   refine ((one_half_le_sum_primes_ge_one_div k).trans_lt <| LE.le.trans_lt ?_ hk).false
-  convert sum_le_tsum (primesBelow ((4 ^ (k.primesBelow.card + 1)).succ) \ primesBelow k)
+  convert Summable.sum_le_tsum (primesBelow ((4 ^ (k.primesBelow.card + 1)).succ) \ primesBelow k)
     (fun n _ ↦ indicator_nonneg (fun p _ ↦ by positivity) _) h' using 2 with p hp
   obtain ⟨hp₁, hp₂⟩ := mem_setOf_eq ▸ Finset.mem_sdiff.mp hp
   have hpp := prime_of_mem_primesBelow hp₁

--- a/Mathlib/NumberTheory/Transcendental/Liouville/LiouvilleNumber.lean
+++ b/Mathlib/NumberTheory/Transcendental/Liouville/LiouvilleNumber.lean
@@ -80,7 +80,7 @@ theorem remainder_summable {m : ℝ} (hm : 1 < m) (k : ℕ) :
   convert (summable_nat_add_iff (k + 1)).2 (LiouvilleNumber.summable hm)
 
 theorem remainder_pos {m : ℝ} (hm : 1 < m) (k : ℕ) : 0 < remainder m k :=
-  tsum_pos (remainder_summable hm k) (fun _ => by positivity) 0 (by positivity)
+  (remainder_summable hm k).tsum_pos (fun _ => by positivity) 0 (by positivity)
 
 theorem partialSum_succ (m : ℝ) (n : ℕ) :
     partialSum m (n + 1) = partialSum m n + 1 / m ^ (n + 1)! :=

--- a/Mathlib/NumberTheory/Transcendental/Liouville/LiouvilleNumber.lean
+++ b/Mathlib/NumberTheory/Transcendental/Liouville/LiouvilleNumber.lean
@@ -89,7 +89,7 @@ theorem partialSum_succ (m : ℝ) (n : ℕ) :
 /-- Split the sum defining a Liouville number into the first `k` terms and the rest. -/
 theorem partialSum_add_remainder {m : ℝ} (hm : 1 < m) (k : ℕ) :
     partialSum m k + remainder m k = liouvilleNumber m :=
-  sum_add_tsum_nat_add _ (LiouvilleNumber.summable hm)
+  (LiouvilleNumber.summable hm).sum_add_tsum_nat_add _
 
 /-! We now prove two useful inequalities, before collecting everything together. -/
 

--- a/Mathlib/NumberTheory/Transcendental/Liouville/LiouvilleNumber.lean
+++ b/Mathlib/NumberTheory/Transcendental/Liouville/LiouvilleNumber.lean
@@ -106,7 +106,7 @@ theorem remainder_lt' (n : ℕ) {m : ℝ} (m1 : 1 < m) :
   calc
     (∑' i, 1 / m ^ (i + (n + 1))!) < ∑' i, 1 / m ^ (i + (n + 1)!) :=
         -- 1. the second series dominates the first
-        tsum_lt_tsum (fun b => one_div_pow_le_one_div_pow_of_le m1.le
+        Summable.tsum_lt_tsum (fun b => one_div_pow_le_one_div_pow_of_le m1.le
           (b.add_factorial_succ_le_factorial_add_succ n))
         -- 2. the term with index `i = 2` of the first series is strictly smaller than
         -- the corresponding term of the second series

--- a/Mathlib/Probability/Kernel/Defs.lean
+++ b/Mathlib/Probability/Kernel/Defs.lean
@@ -287,7 +287,7 @@ theorem sum_add [Countable ι] (κ η : ι → Kernel α β) :
     (Kernel.sum fun n => κ n + η n) = Kernel.sum κ + Kernel.sum η := by
   ext a s hs
   simp only [coe_add, Pi.add_apply, sum_apply, Measure.sum_apply _ hs, Pi.add_apply,
-    Measure.coe_add, tsum_add ENNReal.summable ENNReal.summable]
+    Measure.coe_add, ENNReal.summable.tsum_add ENNReal.summable]
 
 end Sum
 

--- a/Mathlib/Probability/Kernel/Defs.lean
+++ b/Mathlib/Probability/Kernel/Defs.lean
@@ -355,7 +355,7 @@ theorem isSFiniteKernel_sum_of_denumerable [Denumerable ι] {κs : ι → Kernel
   simp_rw [Kernel.sum_apply' _ _ hs]
   change (∑' i, ∑' m, seq (κs i) m a s) = ∑' n, (fun im : ι × ℕ => seq (κs im.fst) im.snd a s) (e n)
   rw [e.tsum_eq (fun im : ι × ℕ => seq (κs im.fst) im.snd a s),
-    tsum_prod' ENNReal.summable fun _ => ENNReal.summable]
+    ENNReal.summable.tsum_prod' fun _ => ENNReal.summable]
 
 instance isSFiniteKernel_sum [Countable ι] {κs : ι → Kernel α β}
     [hκs : ∀ n, IsSFiniteKernel (κs n)] : IsSFiniteKernel (Kernel.sum κs) := by

--- a/Mathlib/Probability/ProbabilityMassFunction/Basic.lean
+++ b/Mathlib/Probability/ProbabilityMassFunction/Basic.lean
@@ -100,7 +100,7 @@ theorem apply_eq_one_iff (p : PMF α) (a : α) : p a = 1 ↔ p.support = {a} := 
   suffices 1 < ∑' a, p a from ne_of_lt this p.tsum_coe.symm
   classical
   have : 0 < ∑' b, ite (b = a) 0 (p b) := lt_of_le_of_ne' zero_le'
-    ((tsum_ne_zero_iff ENNReal.summable).2
+    (ENNReal.summable.tsum_ne_zero_iff.2
       ⟨a', ite_ne_left_iff.2 ⟨ha, Ne.symm <| (p.mem_support_iff a').2 ha'⟩⟩)
   calc
     1 = 1 + 0 := (add_zero 1).symm

--- a/Mathlib/Probability/ProbabilityMassFunction/Basic.lean
+++ b/Mathlib/Probability/ProbabilityMassFunction/Basic.lean
@@ -63,8 +63,7 @@ theorem tsum_coe_ne_top (p : PMF α) : ∑' a, p a ≠ ∞ :=
 
 theorem tsum_coe_indicator_ne_top (p : PMF α) (s : Set α) : ∑' a, s.indicator p a ≠ ∞ :=
   ne_of_lt (lt_of_le_of_lt
-    (tsum_le_tsum (fun _ => Set.indicator_apply_le fun _ => le_rfl) ENNReal.summable
-      ENNReal.summable)
+    (ENNReal.tsum_le_tsum (fun _ => Set.indicator_apply_le fun _ => le_rfl))
     (lt_of_le_of_ne le_top p.tsum_coe_ne_top))
 
 @[simp]

--- a/Mathlib/Probability/ProbabilityMassFunction/Monad.lean
+++ b/Mathlib/Probability/ProbabilityMassFunction/Monad.lean
@@ -158,8 +158,7 @@ theorem toOuterMeasure_bind_apply :
     (p.bind f).toOuterMeasure s = ∑' b, if b ∈ s then ∑' a, p a * f a b else 0 := by
       simp [toOuterMeasure_apply, Set.indicator_apply]
     _ = ∑' (b) (a), p a * if b ∈ s then f a b else 0 := tsum_congr fun b => by split_ifs <;> simp
-    _ = ∑' (a) (b), p a * if b ∈ s then f a b else 0 :=
-      (tsum_comm' ENNReal.summable (fun _ => ENNReal.summable) fun _ => ENNReal.summable)
+    _ = ∑' (a) (b), p a * if b ∈ s then f a b else 0 := ENNReal.tsum_comm
     _ = ∑' a, p a * ∑' b, if b ∈ s then f a b else 0 := tsum_congr fun _ => ENNReal.tsum_mul_left
     _ = ∑' a, p a * ∑' b, if b ∈ s then f a b else 0 :=
       (tsum_congr fun a => (congr_arg fun x => p a * x) <| tsum_congr fun b => by split_ifs <;> rfl)

--- a/Mathlib/Topology/Algebra/InfiniteSum/Basic.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/Basic.lean
@@ -563,7 +563,8 @@ protected theorem Multipliable.tprod_mul (hf : Multipliable f) (hg : Multipliabl
     ∏' b, (f b * g b) = (∏' b, f b) * ∏' b, g b :=
   (hf.hasProd.mul hg.hasProd).tprod_eq
 
-@[to_additive, deprecated (since := "2025-04-11")] alias tprod_mul := Multipliable.tprod_mul
+@[deprecated (since := "2025-04-11")] alias tsum_add := Summable.tsum_add
+@[to_additive existing, deprecated (since := "2025-04-11")] alias tprod_mul := Multipliable.tprod_mul
 
 @[to_additive]
 protected theorem Multipliable.tprod_finsetProd {f : γ → β → α} {s : Finset γ}

--- a/Mathlib/Topology/Algebra/InfiniteSum/Basic.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/Basic.lean
@@ -559,51 +559,70 @@ section ContinuousMul
 variable [ContinuousMul α]
 
 @[to_additive]
-theorem tprod_mul (hf : Multipliable f) (hg : Multipliable g) :
+protected theorem Multipliable.tprod_mul (hf : Multipliable f) (hg : Multipliable g) :
     ∏' b, (f b * g b) = (∏' b, f b) * ∏' b, g b :=
   (hf.hasProd.mul hg.hasProd).tprod_eq
 
+@[to_additive, deprecated (since := "2025-04-11")] alias tprod_mul := Multipliable.tprod_mul
+
 @[to_additive]
-theorem tprod_finsetProd {f : γ → β → α} {s : Finset γ} (hf : ∀ i ∈ s, Multipliable (f i)) :
-    ∏' b, ∏ i ∈ s, f i b = ∏ i ∈ s, ∏' b, f i b :=
+protected theorem Multipliable.tprod_finsetProd {f : γ → β → α} {s : Finset γ}
+    (hf : ∀ i ∈ s, Multipliable (f i)) : ∏' b, ∏ i ∈ s, f i b = ∏ i ∈ s, ∏' b, f i b :=
   (hasProd_prod fun i hi ↦ (hf i hi).hasProd).tprod_eq
 
-@[deprecated (since := "2025-02-13")] alias tprod_of_prod := tprod_finsetProd
+@[to_additive, deprecated (since := "2025-02-13")]
+  alias tprod_of_prod := Multipliable.tprod_finsetProd
+
+@[to_additive, deprecated (since := "2025-04-11")]
+  alias tprod_finsetProd := Multipliable.tprod_finsetProd
 
 /-- Version of `tprod_eq_mul_tprod_ite` for `CommMonoid` rather than `CommGroup`.
 Requires a different convergence assumption involving `Function.update`. -/
 @[to_additive "Version of `tsum_eq_add_tsum_ite` for `AddCommMonoid` rather than `AddCommGroup`.
 Requires a different convergence assumption involving `Function.update`."]
-theorem tprod_eq_mul_tprod_ite' [DecidableEq β] {f : β → α} (b : β)
+protected theorem Multipliable.tprod_eq_mul_tprod_ite' [DecidableEq β] {f : β → α} (b : β)
     (hf : Multipliable (update f b 1)) :
     ∏' x, f x = f b * ∏' x, ite (x = b) 1 (f x) :=
   calc
     ∏' x, f x = ∏' x, (ite (x = b) (f x) 1 * update f b 1 x) :=
       tprod_congr fun n ↦ by split_ifs with h <;> simp [update_apply, h]
     _ = (∏' x, ite (x = b) (f x) 1) * ∏' x, update f b 1 x :=
-      tprod_mul ⟨ite (b = b) (f b) 1, hasProd_single b fun _ hb ↦ if_neg hb⟩ hf
+      Multipliable.tprod_mul ⟨ite (b = b) (f b) 1, hasProd_single b fun _ hb ↦ if_neg hb⟩ hf
     _ = ite (b = b) (f b) 1 * ∏' x, update f b 1 x := by
       congr
       exact tprod_eq_mulSingle b fun b' hb' ↦ if_neg hb'
     _ = f b * ∏' x, ite (x = b) 1 (f x) := by
       simp only [update, eq_self_iff_true, if_true, eq_rec_constant, dite_eq_ite]
 
-@[to_additive]
-theorem tprod_mul_tprod_compl {s : Set β} (hs : Multipliable (f ∘ (↑) : s → α))
-    (hsc : Multipliable (f ∘ (↑) : ↑sᶜ → α)) : (∏' x : s, f x) * ∏' x : ↑sᶜ, f x = ∏' x, f x :=
-  (hs.hasProd.mul_compl hsc.hasProd).tprod_eq.symm
+@[to_additive, deprecated (since := "2025-04-11")] alias tprod_eq_mul_tprod_ite' :=
+  Multipliable.tprod_eq_mul_tprod_ite'
 
 @[to_additive]
-theorem tprod_union_disjoint {s t : Set β} (hd : Disjoint s t) (hs : Multipliable (f ∘ (↑) : s → α))
-    (ht : Multipliable (f ∘ (↑) : t → α)) :
+protected theorem Multipliable.tprod_mul_tprod_compl {s : Set β}
+    (hs : Multipliable (f ∘ (↑) : s → α)) (hsc : Multipliable (f ∘ (↑) : ↑sᶜ → α)) :
+    (∏' x : s, f x) * ∏' x : ↑sᶜ, f x = ∏' x, f x :=
+  (hs.hasProd.mul_compl hsc.hasProd).tprod_eq.symm
+
+@[to_additive, deprecated (since := "2025-04-11")] alias tprod_mul_tprod_compl :=
+    Multipliable.tprod_mul_tprod_compl
+
+@[to_additive]
+protected theorem Multipliable.tprod_union_disjoint {s t : Set β} (hd : Disjoint s t)
+    (hs : Multipliable (f ∘ (↑) : s → α)) (ht : Multipliable (f ∘ (↑) : t → α)) :
     ∏' x : ↑(s ∪ t), f x = (∏' x : s, f x) * ∏' x : t, f x :=
   (hs.hasProd.mul_disjoint hd ht.hasProd).tprod_eq
 
+@[to_additive, deprecated (since := "2025-04-11")] alias tprod_union_disjoint :=
+    Multipliable.tprod_union_disjoint
+
 @[to_additive]
-theorem tprod_finset_bUnion_disjoint {ι} {s : Finset ι} {t : ι → Set β}
+protected theorem Multipliable.tprod_finset_bUnion_disjoint {ι} {s : Finset ι} {t : ι → Set β}
     (hd : (s : Set ι).Pairwise (Disjoint on t)) (hf : ∀ i ∈ s, Multipliable (f ∘ (↑) : t i → α)) :
     ∏' x : ⋃ i ∈ s, t i, f x = ∏ i ∈ s, ∏' x : t i, f x :=
   (hasProd_prod_disjoint _ hd fun i hi ↦ (hf i hi).hasProd).tprod_eq
+
+@[to_additive, deprecated (since := "2025-04-11")] alias tprod_finset_bUnion_disjoint :=
+    Multipliable.tprod_finset_bUnion_disjoint
 
 end ContinuousMul
 

--- a/Mathlib/Topology/Algebra/InfiniteSum/Basic.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/Basic.lean
@@ -563,19 +563,21 @@ protected theorem Multipliable.tprod_mul (hf : Multipliable f) (hg : Multipliabl
     ∏' b, (f b * g b) = (∏' b, f b) * ∏' b, g b :=
   (hf.hasProd.mul hg.hasProd).tprod_eq
 
-@[deprecated (since := "2025-04-11")] alias tsum_add := Summable.tsum_add
-@[to_additive existing, deprecated (since := "2025-04-11")] alias tprod_mul := Multipliable.tprod_mul
+@[deprecated (since := "2025-04-12")] alias tsum_add := Summable.tsum_add
+@[to_additive existing, deprecated (since := "2025-04-12")] alias
+  tprod_mul := Multipliable.tprod_mul
 
 @[to_additive]
 protected theorem Multipliable.tprod_finsetProd {f : γ → β → α} {s : Finset γ}
     (hf : ∀ i ∈ s, Multipliable (f i)) : ∏' b, ∏ i ∈ s, f i b = ∏ i ∈ s, ∏' b, f i b :=
   (hasProd_prod fun i hi ↦ (hf i hi).hasProd).tprod_eq
 
-@[to_additive, deprecated (since := "2025-02-13")]
+@[deprecated (since := "2025-02-13")]
   alias tprod_of_prod := Multipliable.tprod_finsetProd
 
-@[to_additive, deprecated (since := "2025-04-11")]
-  alias tprod_finsetProd := Multipliable.tprod_finsetProd
+@[deprecated (since := "2025-04-12")] alias tsum_finsetSum := Summable.tsum_finsetSum
+@[to_additive existing, deprecated (since := "2025-04-12")] alias tprod_finsetProd :=
+  Multipliable.tprod_finsetProd
 
 /-- Version of `tprod_eq_mul_tprod_ite` for `CommMonoid` rather than `CommGroup`.
 Requires a different convergence assumption involving `Function.update`. -/
@@ -595,7 +597,9 @@ protected theorem Multipliable.tprod_eq_mul_tprod_ite' [DecidableEq β] {f : β 
     _ = f b * ∏' x, ite (x = b) 1 (f x) := by
       simp only [update, eq_self_iff_true, if_true, eq_rec_constant, dite_eq_ite]
 
-@[to_additive, deprecated (since := "2025-04-11")] alias tprod_eq_mul_tprod_ite' :=
+@[deprecated (since := "2025-04-12")] alias tsum_eq_add_tsum_ite' :=
+  Summable.tsum_eq_add_tsum_ite'
+@[to_additive existing, deprecated (since := "2025-04-12")] alias tprod_eq_mul_tprod_ite' :=
   Multipliable.tprod_eq_mul_tprod_ite'
 
 @[to_additive]
@@ -604,7 +608,8 @@ protected theorem Multipliable.tprod_mul_tprod_compl {s : Set β}
     (∏' x : s, f x) * ∏' x : ↑sᶜ, f x = ∏' x, f x :=
   (hs.hasProd.mul_compl hsc.hasProd).tprod_eq.symm
 
-@[to_additive, deprecated (since := "2025-04-11")] alias tprod_mul_tprod_compl :=
+@[deprecated (since := "2025-04-12")] alias tsum_add_tsum_compl := Summable.tsum_add_tsum_compl
+@[to_additive existing, deprecated (since := "2025-04-12")] alias tprod_mul_tprod_compl :=
     Multipliable.tprod_mul_tprod_compl
 
 @[to_additive]
@@ -613,7 +618,8 @@ protected theorem Multipliable.tprod_union_disjoint {s t : Set β} (hd : Disjoin
     ∏' x : ↑(s ∪ t), f x = (∏' x : s, f x) * ∏' x : t, f x :=
   (hs.hasProd.mul_disjoint hd ht.hasProd).tprod_eq
 
-@[to_additive, deprecated (since := "2025-04-11")] alias tprod_union_disjoint :=
+@[deprecated (since := "2025-04-12")] alias tsum_union_disjoint := Summable.tsum_union_disjoint
+@[to_additive existing, deprecated (since := "2025-04-12")] alias tprod_union_disjoint :=
     Multipliable.tprod_union_disjoint
 
 @[to_additive]
@@ -622,7 +628,9 @@ protected theorem Multipliable.tprod_finset_bUnion_disjoint {ι} {s : Finset ι}
     ∏' x : ⋃ i ∈ s, t i, f x = ∏ i ∈ s, ∏' x : t i, f x :=
   (hasProd_prod_disjoint _ hd fun i hi ↦ (hf i hi).hasProd).tprod_eq
 
-@[to_additive, deprecated (since := "2025-04-11")] alias tprod_finset_bUnion_disjoint :=
+@[deprecated (since := "2025-04-12")] alias tsum_finset_bUnion_disjoint :=
+    Summable.tsum_finset_bUnion_disjoint
+@[to_additive existing, deprecated (since := "2025-04-12")] alias tprod_finset_bUnion_disjoint :=
     Multipliable.tprod_finset_bUnion_disjoint
 
 end ContinuousMul

--- a/Mathlib/Topology/Algebra/InfiniteSum/Constructions.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/Constructions.lean
@@ -92,11 +92,14 @@ lemma HasProd.sum {α β M : Type*} [CommMonoid M] [TopologicalSpace M] [Continu
     simp
   simpa [Tendsto, ← Filter.map_map] using this
 
-@[to_additive "For the statement that `tsum` commutes with `Finset.sum`, see `tsum_finsetSum`."]
-lemma tprod_sum {α β M : Type*} [CommMonoid M] [TopologicalSpace M] [ContinuousMul M] [T2Space M]
-    {f : α ⊕ β → M} (h₁ : Multipliable (f ∘ .inl)) (h₂ : Multipliable (f ∘ .inr)) :
-    ∏' i, f i = (∏' i, f (.inl i)) * (∏' i, f (.inr i)) :=
+@[to_additive "For the statement that `tsum` commutes with `Finset.sum`,
+  see `Summable.tsum_finsetSum`."]
+protected lemma Multipliable.tprod_sum {α β M : Type*} [CommMonoid M] [TopologicalSpace M]
+    [ContinuousMul M] [T2Space M] {f : α ⊕ β → M} (h₁ : Multipliable (f ∘ .inl))
+    (h₂ : Multipliable (f ∘ .inr)) : ∏' i, f i = (∏' i, f (.inl i)) * (∏' i, f (.inr i)) :=
   (h₁.hasProd.sum h₂.hasProd).tprod_eq
+
+@[to_additive, deprecated (since := "2025-04-11")] alias tprod_sum := Multipliable.tprod_sum
 
 @[to_additive]
 lemma Multipliable.sum {α β M : Type*} [CommMonoid M] [TopologicalSpace M] [ContinuousMul M]
@@ -155,10 +158,12 @@ theorem HasProd.sigma_of_hasProd {γ : β → Type*} {f : (Σ b : β, γ b) → 
     HasProd f a := by simpa [(hf'.hasProd.sigma hf).unique ha] using hf'.hasProd
 
 @[to_additive]
-theorem tprod_sigma' {γ : β → Type*} {f : (Σ b : β, γ b) → α}
+protected theorem Multipliable.tprod_sigma' {γ : β → Type*} {f : (Σ b : β, γ b) → α}
     (h₁ : ∀ b, Multipliable fun c ↦ f ⟨b, c⟩) (h₂ : Multipliable f) :
     ∏' p, f p = ∏' (b) (c), f ⟨b, c⟩ :=
   (h₂.hasProd.sigma fun b ↦ (h₁ b).hasProd).tprod_eq.symm
+
+@[to_additive, deprecated (since := "2025-04-11")] alias tprod_sigma' := Multipliable.tprod_sigma'
 
 @[to_additive tsum_prod']
 theorem tprod_prod' {f : β × γ → α} (h : Multipliable f)
@@ -249,19 +254,26 @@ section CompleteT0Space
 variable [T0Space α]
 
 @[to_additive]
-theorem tprod_sigma {γ : β → Type*} {f : (Σ b : β, γ b) → α} (ha : Multipliable f) :
-    ∏' p, f p = ∏' (b) (c), f ⟨b, c⟩ :=
-  tprod_sigma' (fun b ↦ ha.sigma_factor b) ha
+protected theorem Multipliable.tprod_sigma {γ : β → Type*} {f : (Σ b : β, γ b) → α}
+    (ha : Multipliable f) : ∏' p, f p = ∏' (b) (c), f ⟨b, c⟩ :=
+  Multipliable.tprod_sigma' (fun b ↦ ha.sigma_factor b) ha
 
-@[to_additive tsum_prod]
-theorem tprod_prod {f : β × γ → α} (h : Multipliable f) :
+@[to_additive, deprecated (since := "2025-04-11")] alias tprod_sigma := Multipliable.tprod_sigma
+
+@[to_additive Summable.tsum_prod]
+protected theorem Multipliable.tprod_prod {f : β × γ → α} (h : Multipliable f) :
     ∏' p, f p = ∏' (b) (c), f ⟨b, c⟩ :=
   tprod_prod' h h.prod_factor
 
+@[to_additive tsum_prod, deprecated (since := "2025-04-11")]
+  alias tprod_prod := Multipliable.tprod_prod
+
 @[to_additive]
-theorem tprod_comm {f : β → γ → α} (h : Multipliable (Function.uncurry f)) :
+protected theorem Multipliable.tprod_comm {f : β → γ → α} (h : Multipliable (Function.uncurry f)) :
     ∏' (c) (b), f b c = ∏' (b) (c), f b c :=
   tprod_comm' h h.prod_factor h.prod_symm.prod_factor
+
+@[to_additive, deprecated (since := "2025-04-11")] alias tprod_comm := Multipliable.tprod_comm
 
 end CompleteT0Space
 

--- a/Mathlib/Topology/Algebra/InfiniteSum/Constructions.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/Constructions.lean
@@ -99,7 +99,9 @@ protected lemma Multipliable.tprod_sum {α β M : Type*} [CommMonoid M] [Topolog
     (h₂ : Multipliable (f ∘ .inr)) : ∏' i, f i = (∏' i, f (.inl i)) * (∏' i, f (.inr i)) :=
   (h₁.hasProd.sum h₂.hasProd).tprod_eq
 
-@[to_additive, deprecated (since := "2025-04-11")] alias tprod_sum := Multipliable.tprod_sum
+@[deprecated (since := "2025-04-12")] alias tsum_sum := Summable.tsum_sum
+@[to_additive existing, deprecated (since := "2025-04-12")] alias tprod_sum :=
+  Multipliable.tprod_sum
 
 @[to_additive]
 lemma Multipliable.sum {α β M : Type*} [CommMonoid M] [TopologicalSpace M] [ContinuousMul M]
@@ -163,7 +165,9 @@ protected theorem Multipliable.tprod_sigma' {γ : β → Type*} {f : (Σ b : β,
     ∏' p, f p = ∏' (b) (c), f ⟨b, c⟩ :=
   (h₂.hasProd.sigma fun b ↦ (h₁ b).hasProd).tprod_eq.symm
 
-@[to_additive, deprecated (since := "2025-04-11")] alias tprod_sigma' := Multipliable.tprod_sigma'
+@[deprecated (since := "2025-04-12")] alias tsum_sigma' := Summable.tsum_sigma'
+@[to_additive existing, deprecated (since := "2025-04-12")] alias tprod_sigma' :=
+  Multipliable.tprod_sigma'
 
 @[to_additive tsum_prod']
 theorem tprod_prod' {f : β × γ → α} (h : Multipliable f)
@@ -258,14 +262,17 @@ protected theorem Multipliable.tprod_sigma {γ : β → Type*} {f : (Σ b : β, 
     (ha : Multipliable f) : ∏' p, f p = ∏' (b) (c), f ⟨b, c⟩ :=
   Multipliable.tprod_sigma' (fun b ↦ ha.sigma_factor b) ha
 
-@[to_additive, deprecated (since := "2025-04-11")] alias tprod_sigma := Multipliable.tprod_sigma
+@[deprecated (since := "2025-04-12")] alias tsum_sigma := Summable.tsum_sigma
+@[to_additive existing, deprecated (since := "2025-04-12")] alias
+  tprod_sigma := Multipliable.tprod_sigma
 
 @[to_additive Summable.tsum_prod]
 protected theorem Multipliable.tprod_prod {f : β × γ → α} (h : Multipliable f) :
     ∏' p, f p = ∏' (b) (c), f ⟨b, c⟩ :=
   tprod_prod' h h.prod_factor
 
-@[to_additive tsum_prod, deprecated (since := "2025-04-11")]
+@[deprecated (since := "2025-04-12")] alias tsum_prod := Summable.tsum_prod
+@[to_additive existing tsum_prod, deprecated (since := "2025-04-12")]
   alias tprod_prod := Multipliable.tprod_prod
 
 @[to_additive]
@@ -273,7 +280,9 @@ protected theorem Multipliable.tprod_comm {f : β → γ → α} (h : Multipliab
     ∏' (c) (b), f b c = ∏' (b) (c), f b c :=
   tprod_comm' h h.prod_factor h.prod_symm.prod_factor
 
-@[to_additive, deprecated (since := "2025-04-11")] alias tprod_comm := Multipliable.tprod_comm
+@[deprecated (since := "2025-04-12")] alias tsum_comm := Summable.tsum_comm
+@[to_additive existing, deprecated (since := "2025-04-12")] alias tprod_comm :=
+  Multipliable.tprod_comm
 
 end CompleteT0Space
 

--- a/Mathlib/Topology/Algebra/InfiniteSum/Constructions.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/Constructions.lean
@@ -169,25 +169,38 @@ protected theorem Multipliable.tprod_sigma' {γ : β → Type*} {f : (Σ b : β,
 @[to_additive existing, deprecated (since := "2025-04-12")] alias tprod_sigma' :=
   Multipliable.tprod_sigma'
 
-@[to_additive tsum_prod']
-theorem tprod_prod' {f : β × γ → α} (h : Multipliable f)
+@[to_additive Summable.tsum_prod']
+protected theorem Multipliable.tprod_prod' {f : β × γ → α} (h : Multipliable f)
     (h₁ : ∀ b, Multipliable fun c ↦ f (b, c)) :
     ∏' p, f p = ∏' (b) (c), f (b, c) :=
   (h.hasProd.prod_fiberwise fun b ↦ (h₁ b).hasProd).tprod_eq.symm
 
-@[to_additive tsum_prod_uncurry]
-theorem tprod_prod_uncurry {f : β → γ → α} (h : Multipliable (Function.uncurry f))
-    (h₁ : ∀ b, Multipliable fun c ↦ f b c) :
+@[deprecated (since := "2025-04-12")] alias tsum_prod' := Summable.tsum_prod'
+@[to_additive existing Summable.tsum_prod', deprecated (since := "2025-04-12")] alias tprod_prod' :=
+  Multipliable.tprod_prod'
+
+@[to_additive Summable.tsum_prod_uncurry]
+protected theorem Multipliable.tprod_prod_uncurry {f : β → γ → α}
+    (h : Multipliable (Function.uncurry f)) (h₁ : ∀ b, Multipliable fun c ↦ f b c) :
     ∏' p : β × γ, uncurry f p = ∏' (b) (c), f b c :=
   (h.hasProd.prod_fiberwise fun b ↦ (h₁ b).hasProd).tprod_eq.symm
 
+@[deprecated (since := "2025-04-12")] alias tsum_prod_uncurry :=
+  Summable.tsum_prod_uncurry
+@[to_additive existing Summable.tsum_prod_uncurry, deprecated (since := "2025-04-12")] alias
+  tprod_prod_uncurry := Multipliable.tprod_prod_uncurry
+
 @[to_additive]
-theorem tprod_comm' {f : β → γ → α} (h : Multipliable (Function.uncurry f))
+protected theorem Multipliable.tprod_comm' {f : β → γ → α} (h : Multipliable (Function.uncurry f))
     (h₁ : ∀ b, Multipliable (f b)) (h₂ : ∀ c, Multipliable fun b ↦ f b c) :
     ∏' (c) (b), f b c = ∏' (b) (c), f b c := by
-  rw [← tprod_prod_uncurry h h₁, ← tprod_prod_uncurry h.prod_symm h₂,
+  rw [← h.tprod_prod_uncurry h₁, ← h.prod_symm.tprod_prod_uncurry h₂,
     ← (Equiv.prodComm γ β).tprod_eq (uncurry f)]
   rfl
+
+@[deprecated (since := "2025-04-12")] alias tsum_comm':= Summable.tsum_comm'
+@[to_additive existing, deprecated (since := "2025-04-12")] alias
+  tprod_comm' := Multipliable.tprod_comm'
 
 end T3Space
 
@@ -269,7 +282,7 @@ protected theorem Multipliable.tprod_sigma {γ : β → Type*} {f : (Σ b : β, 
 @[to_additive Summable.tsum_prod]
 protected theorem Multipliable.tprod_prod {f : β × γ → α} (h : Multipliable f) :
     ∏' p, f p = ∏' (b) (c), f ⟨b, c⟩ :=
-  tprod_prod' h h.prod_factor
+  h.tprod_prod' h.prod_factor
 
 @[deprecated (since := "2025-04-12")] alias tsum_prod := Summable.tsum_prod
 @[to_additive existing tsum_prod, deprecated (since := "2025-04-12")]
@@ -278,7 +291,7 @@ protected theorem Multipliable.tprod_prod {f : β × γ → α} (h : Multipliabl
 @[to_additive]
 protected theorem Multipliable.tprod_comm {f : β → γ → α} (h : Multipliable (Function.uncurry f)) :
     ∏' (c) (b), f b c = ∏' (b) (c), f b c :=
-  tprod_comm' h h.prod_factor h.prod_symm.prod_factor
+  h.tprod_comm' h.prod_factor h.prod_symm.prod_factor
 
 @[deprecated (since := "2025-04-12")] alias tsum_comm := Summable.tsum_comm
 @[to_additive existing, deprecated (since := "2025-04-12")] alias tprod_comm :=

--- a/Mathlib/Topology/Algebra/InfiniteSum/Field.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/Field.lean
@@ -25,7 +25,9 @@ nonrec theorem HasProd.norm (hfx : HasProd f x) : HasProd (‖f ·‖) ‖x‖ :
 theorem Multipliable.norm (hf : Multipliable f) : Multipliable (‖f ·‖) :=
   let ⟨x, hx⟩ := hf; ⟨‖x‖, hx.norm⟩
 
-theorem norm_tprod (hf : Multipliable f) : ‖∏' i, f i‖ = ∏' i, ‖f i‖ :=
+protected theorem Multipliable.norm_tprod (hf : Multipliable f) : ‖∏' i, f i‖ = ∏' i, ‖f i‖ :=
   hf.hasProd.norm.tprod_eq.symm
+
+@[deprecated (since := "2025-04-11")] alias norm_tprod := Multipliable.norm_tprod
 
 end NormedField

--- a/Mathlib/Topology/Algebra/InfiniteSum/Field.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/Field.lean
@@ -28,6 +28,6 @@ theorem Multipliable.norm (hf : Multipliable f) : Multipliable (‖f ·‖) :=
 protected theorem Multipliable.norm_tprod (hf : Multipliable f) : ‖∏' i, f i‖ = ∏' i, ‖f i‖ :=
   hf.hasProd.norm.tprod_eq.symm
 
-@[deprecated (since := "2025-04-11")] alias norm_tprod := Multipliable.norm_tprod
+@[deprecated (since := "2025-04-12")] alias norm_tprod := Multipliable.norm_tprod
 
 end NormedField

--- a/Mathlib/Topology/Algebra/InfiniteSum/Group.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/Group.lean
@@ -168,14 +168,19 @@ theorem tprod_inv : ∏' b, (f b)⁻¹ = (∏' b, f b)⁻¹ := by
       tprod_eq_one_of_not_multipliable (mt Multipliable.of_inv hf)]
 
 @[to_additive]
-theorem tprod_div (hf : Multipliable f) (hg : Multipliable g) :
+protected theorem Multipliable.tprod_div (hf : Multipliable f) (hg : Multipliable g) :
     ∏' b, (f b / g b) = (∏' b, f b) / ∏' b, g b :=
   (hf.hasProd.div hg.hasProd).tprod_eq
 
+@[to_additive, deprecated (since := "2025-04-11")] alias tprod_div := Multipliable.tprod_div
+
 @[to_additive]
-theorem prod_mul_tprod_compl {s : Finset β} (hf : Multipliable f) :
+protected theorem Multipliable.prod_mul_tprod_compl {s : Finset β} (hf : Multipliable f) :
     (∏ x ∈ s, f x) * ∏' x : ↑(s : Set β)ᶜ, f x = ∏' x, f x :=
   ((s.hasProd f).mul_compl (s.multipliable_compl_iff.2 hf).hasProd).tprod_eq.symm
+
+@[to_additive, deprecated (since := "2025-04-11")] alias prod_mul_tprod_compl :=
+  Multipliable.prod_mul_tprod_compl
 
 /-- Let `f : β → α` be a multipliable function and let `b ∈ β` be an index.
 Lemma `tprod_eq_mul_tprod_ite` writes `∏ n, f n` as `f b` times the product of the
@@ -183,10 +188,13 @@ remaining terms. -/
 @[to_additive "Let `f : β → α` be a summable function and let `b ∈ β` be an index.
 Lemma `tsum_eq_add_tsum_ite` writes `Σ' n, f n` as `f b` plus the sum of the
 remaining terms."]
-theorem tprod_eq_mul_tprod_ite [DecidableEq β] (hf : Multipliable f) (b : β) :
-    ∏' n, f n = f b * ∏' n, ite (n = b) 1 (f n) := by
+protected theorem Multipliable.tprod_eq_mul_tprod_ite [DecidableEq β] (hf : Multipliable f)
+    (b : β) : ∏' n, f n = f b * ∏' n, ite (n = b) 1 (f n) := by
   rw [(hasProd_ite_div_hasProd hf.hasProd b).tprod_eq]
   exact (mul_div_cancel _ _).symm
+
+@[to_additive, deprecated (since := "2025-04-11")] alias tprod_eq_mul_tprod_ite :=
+  Multipliable.tprod_eq_mul_tprod_ite
 
 end tprod
 
@@ -305,16 +313,23 @@ theorem multipliable_subtype_and_compl {s : Set β} :
   ⟨and_imp.2 Multipliable.mul_compl, fun h ↦ ⟨h.subtype s, h.subtype sᶜ⟩⟩
 
 @[to_additive]
-theorem tprod_subtype_mul_tprod_subtype_compl [T2Space α] {f : β → α} (hf : Multipliable f)
-    (s : Set β) : (∏' x : s, f x) * ∏' x : ↑sᶜ, f x = ∏' x, f x :=
+protected theorem Multipliable.tprod_subtype_mul_tprod_subtype_compl [T2Space α] {f : β → α}
+    (hf : Multipliable f) (s : Set β) : (∏' x : s, f x) * ∏' x : ↑sᶜ, f x = ∏' x, f x :=
   ((hf.subtype s).hasProd.mul_compl (hf.subtype { x | x ∉ s }).hasProd).unique hf.hasProd
 
+@[to_additive, deprecated (since := "2025-04-11")] alias tprod_subtype_mul_tprod_subtype_compl :=
+  Multipliable.tprod_subtype_mul_tprod_subtype_compl
+
 @[to_additive]
-theorem prod_mul_tprod_subtype_compl [T2Space α] {f : β → α} (hf : Multipliable f) (s : Finset β) :
+protected theorem Multipliable.prod_mul_tprod_subtype_compl [T2Space α] {f : β → α}
+    (hf : Multipliable f) (s : Finset β) :
     (∏ x ∈ s, f x) * ∏' x : { x // x ∉ s }, f x = ∏' x, f x := by
-  rw [← tprod_subtype_mul_tprod_subtype_compl hf s]
+  rw [← hf.tprod_subtype_mul_tprod_subtype_compl s]
   simp only [Finset.tprod_subtype', mul_right_inj]
   rfl
+
+@[to_additive, deprecated (since := "2025-04-11")] alias prod_mul_tprod_subtype_compl :=
+  Multipliable.prod_mul_tprod_subtype_compl
 
 end IsUniformGroup
 
@@ -429,10 +444,12 @@ lemma HasProd.congr_cofinite₀ {c : K} (hc : HasProd f c) {s : Finset α}
   _ = ∏ i ∈ t, g i := by
     rw [← prod_union disjoint_sdiff, union_sdiff_of_subset ht]
 
-lemma tsum_congr_cofinite₀ [T2Space K] (hc : Multipliable f) {s : Finset α}
+protected lemma Multipliable.tsum_congr_cofinite₀ [T2Space K] (hc : Multipliable f) {s : Finset α}
     (hs : ∀ a ∈ s, f a ≠ 0) (hs' : ∀ a ∉ s, f a = g a) :
     ∏' i, g i = ((∏' i, f i) * ((∏ i ∈ s, g i) / ∏ i ∈ s, f i)) :=
   (hc.hasProd.congr_cofinite₀ hs hs').tprod_eq
+
+@[deprecated (since := "2025-04-11")] alias tsum_congr_cofinite := Multipliable.tsum_congr_cofinite₀
 
 /--
 See also `Multipliable.congr_cofinite`, which does not have a non-vanishing condition, but instead

--- a/Mathlib/Topology/Algebra/InfiniteSum/Group.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/Group.lean
@@ -172,14 +172,17 @@ protected theorem Multipliable.tprod_div (hf : Multipliable f) (hg : Multipliabl
     ∏' b, (f b / g b) = (∏' b, f b) / ∏' b, g b :=
   (hf.hasProd.div hg.hasProd).tprod_eq
 
-@[to_additive, deprecated (since := "2025-04-11")] alias tprod_div := Multipliable.tprod_div
+@[deprecated (since := "2025-04-12")] alias tsum_sub := Summable.tsum_sub
+@[to_additive existing, deprecated (since := "2025-04-12")] alias tprod_div :=
+  Multipliable.tprod_div
 
 @[to_additive]
 protected theorem Multipliable.prod_mul_tprod_compl {s : Finset β} (hf : Multipliable f) :
     (∏ x ∈ s, f x) * ∏' x : ↑(s : Set β)ᶜ, f x = ∏' x, f x :=
   ((s.hasProd f).mul_compl (s.multipliable_compl_iff.2 hf).hasProd).tprod_eq.symm
 
-@[to_additive, deprecated (since := "2025-04-11")] alias prod_mul_tprod_compl :=
+@[deprecated (since := "2025-04-12")] alias sum_add_tsum_compl := Summable.sum_add_tsum_compl
+@[to_additive existing, deprecated (since := "2025-04-12")] alias prod_mul_tprod_compl :=
   Multipliable.prod_mul_tprod_compl
 
 /-- Let `f : β → α` be a multipliable function and let `b ∈ β` be an index.
@@ -193,7 +196,8 @@ protected theorem Multipliable.tprod_eq_mul_tprod_ite [DecidableEq β] (hf : Mul
   rw [(hasProd_ite_div_hasProd hf.hasProd b).tprod_eq]
   exact (mul_div_cancel _ _).symm
 
-@[to_additive, deprecated (since := "2025-04-11")] alias tprod_eq_mul_tprod_ite :=
+@[deprecated (since := "2025-04-12")] alias tsum_eq_add_tsum_ite := Summable.tsum_eq_add_tsum_ite
+@[to_additive existing, deprecated (since := "2025-04-12")] alias tprod_eq_mul_tprod_ite :=
   Multipliable.tprod_eq_mul_tprod_ite
 
 end tprod
@@ -317,8 +321,10 @@ protected theorem Multipliable.tprod_subtype_mul_tprod_subtype_compl [T2Space α
     (hf : Multipliable f) (s : Set β) : (∏' x : s, f x) * ∏' x : ↑sᶜ, f x = ∏' x, f x :=
   ((hf.subtype s).hasProd.mul_compl (hf.subtype { x | x ∉ s }).hasProd).unique hf.hasProd
 
-@[to_additive, deprecated (since := "2025-04-11")] alias tprod_subtype_mul_tprod_subtype_compl :=
-  Multipliable.tprod_subtype_mul_tprod_subtype_compl
+@[deprecated (since := "2025-04-12")] alias tsum_subtype_add_tsum_subtype_compl :=
+  Summable.tsum_subtype_add_tsum_subtype_compl
+@[to_additive existing, deprecated (since := "2025-04-12")] alias
+  tprod_subtype_mul_tprod_subtype_compl := Multipliable.tprod_subtype_mul_tprod_subtype_compl
 
 @[to_additive]
 protected theorem Multipliable.prod_mul_tprod_subtype_compl [T2Space α] {f : β → α}
@@ -328,7 +334,9 @@ protected theorem Multipliable.prod_mul_tprod_subtype_compl [T2Space α] {f : β
   simp only [Finset.tprod_subtype', mul_right_inj]
   rfl
 
-@[to_additive, deprecated (since := "2025-04-11")] alias prod_mul_tprod_subtype_compl :=
+@[deprecated (since := "2025-04-12")] alias sum_add_tsum_subtype_compl :=
+  Summable.sum_add_tsum_subtype_compl
+@[to_additive existing, deprecated (since := "2025-04-12")] alias prod_mul_tprod_subtype_compl :=
   Multipliable.prod_mul_tprod_subtype_compl
 
 end IsUniformGroup
@@ -449,7 +457,7 @@ protected lemma Multipliable.tsum_congr_cofinite₀ [T2Space K] (hc : Multipliab
     ∏' i, g i = ((∏' i, f i) * ((∏ i ∈ s, g i) / ∏ i ∈ s, f i)) :=
   (hc.hasProd.congr_cofinite₀ hs hs').tprod_eq
 
-@[deprecated (since := "2025-04-11")] alias tsum_congr_cofinite := Multipliable.tsum_congr_cofinite₀
+@[deprecated (since := "2025-04-12")] alias tsum_congr_cofinite := Multipliable.tsum_congr_cofinite₀
 
 /--
 See also `Multipliable.congr_cofinite`, which does not have a non-vanishing condition, but instead

--- a/Mathlib/Topology/Algebra/InfiniteSum/Module.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/Module.lean
@@ -25,15 +25,18 @@ theorem Summable.const_smul (b : γ) (hf : Summable f) : Summable fun i ↦ b �
 
 /-- Infinite sums commute with scalar multiplication. Version for scalars living in a `Monoid`, but
   requiring a summability hypothesis. -/
-theorem tsum_const_smul [T2Space α] (b : γ) (hf : Summable f) : ∑' i, b • f i = b • ∑' i, f i :=
+protected theorem Summable.tsum_const_smul [T2Space α] (b : γ) (hf : Summable f) :
+    ∑' i, b • f i = b • ∑' i, f i :=
   (hf.hasSum.const_smul _).tsum_eq
+
+@[deprecated (since := "2025-04-11")] alias tsum_const_smul := Summable.tsum_const_smul
 
 /-- Infinite sums commute with scalar multiplication. Version for scalars living in a `Group`, but
   not requiring any summability hypothesis. -/
 lemma tsum_const_smul' {γ : Type*} [Group γ] [DistribMulAction γ α] [ContinuousConstSMul γ α]
     [T2Space α] (g : γ) : ∑' (i : β), g • f i = g • ∑' (i : β), f i := by
   by_cases hf : Summable f
-  · exact tsum_const_smul g hf
+  · exact hf.tsum_const_smul g
   rw [tsum_eq_zero_of_not_summable hf]
   simp only [smul_zero]
   let mul_g : α ≃+ α := DistribMulAction.toAddEquiv α g
@@ -69,8 +72,11 @@ theorem HasSum.smul_const {r : R} (hf : HasSum f r) (a : M) : HasSum (fun z ↦ 
 theorem Summable.smul_const (hf : Summable f) (a : M) : Summable fun z ↦ f z • a :=
   (hf.hasSum.smul_const _).summable
 
-theorem tsum_smul_const [T2Space M] (hf : Summable f) (a : M) : ∑' z, f z • a = (∑' z, f z) • a :=
+protected theorem Summable.tsum_smul_const [T2Space M] (hf : Summable f) (a : M) :
+    ∑' z, f z • a = (∑' z, f z) • a :=
   (hf.hasSum.smul_const _).tsum_eq
+
+@[deprecated (since := "2025-04-11")] alias tsum_smul_const := Summable.tsum_smul_const
 
 end SMulConst
 

--- a/Mathlib/Topology/Algebra/InfiniteSum/Module.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/Module.lean
@@ -29,7 +29,7 @@ protected theorem Summable.tsum_const_smul [T2Space α] (b : γ) (hf : Summable 
     ∑' i, b • f i = b • ∑' i, f i :=
   (hf.hasSum.const_smul _).tsum_eq
 
-@[deprecated (since := "2025-04-11")] alias tsum_const_smul := Summable.tsum_const_smul
+@[deprecated (since := "2025-04-12")] alias tsum_const_smul := Summable.tsum_const_smul
 
 /-- Infinite sums commute with scalar multiplication. Version for scalars living in a `Group`, but
   not requiring any summability hypothesis. -/
@@ -76,7 +76,7 @@ protected theorem Summable.tsum_smul_const [T2Space M] (hf : Summable f) (a : M)
     ∑' z, f z • a = (∑' z, f z) • a :=
   (hf.hasSum.smul_const _).tsum_eq
 
-@[deprecated (since := "2025-04-11")] alias tsum_smul_const := Summable.tsum_smul_const
+@[deprecated (since := "2025-04-12")] alias tsum_smul_const := Summable.tsum_smul_const
 
 end SMulConst
 

--- a/Mathlib/Topology/Algebra/InfiniteSum/NatInt.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/NatInt.lean
@@ -232,14 +232,20 @@ theorem hasProd_nat_add_iff' {f : ℕ → G} (k : ℕ) :
   simp [hasProd_nat_add_iff]
 
 @[to_additive]
-theorem prod_mul_tprod_nat_add [T2Space G] {f : ℕ → G} (k : ℕ) (h : Multipliable f) :
-    ((∏ i ∈ range k, f i) * ∏' i, f (i + k)) = ∏' i, f i :=
+protected theorem Multipliable.prod_mul_tprod_nat_add [T2Space G] {f : ℕ → G} (k : ℕ)
+    (h : Multipliable f) : ((∏ i ∈ range k, f i) * ∏' i, f (i + k)) = ∏' i, f i :=
   prod_mul_tprod_nat_mul' <| (multipliable_nat_add_iff k).2 h
 
+@[to_additive, deprecated (since := "2025-04-11")] alias prod_mul_tprod_nat_add :=
+  Multipliable.prod_mul_tprod_nat_add
+
 @[to_additive]
-theorem tprod_eq_zero_mul [T2Space G] {f : ℕ → G} (hf : Multipliable f) :
+protected theorem Multipliable.tprod_eq_zero_mul [T2Space G] {f : ℕ → G} (hf : Multipliable f) :
     ∏' b, f b = f 0 * ∏' b, f (b + 1) :=
   tprod_eq_zero_mul' <| (multipliable_nat_add_iff 1).2 hf
+
+@[to_additive, deprecated (since := "2025-04-11")] alias tprod_eq_zero_mul :=
+  Multipliable.tprod_eq_zero_mul
 
 /-- For `f : ℕ → G`, the product `∏' k, f (k + i)` tends to one. This does not require a
 multipliability assumption on `f`, as otherwise all such products are one. -/
@@ -250,7 +256,7 @@ theorem tendsto_prod_nat_add [T2Space G] (f : ℕ → G) :
   by_cases hf : Multipliable f
   · have h₀ : (fun i ↦ (∏' i, f i) / ∏ j ∈ range i, f j) = fun i ↦ ∏' k : ℕ, f (k + i) := by
       ext1 i
-      rw [div_eq_iff_eq_mul, mul_comm, prod_mul_tprod_nat_add i hf]
+      rw [div_eq_iff_eq_mul, mul_comm, hf.prod_mul_tprod_nat_add i]
     have h₁ : Tendsto (fun _ : ℕ ↦ ∏' i, f i) atTop (𝓝 (∏' i, f i)) := tendsto_const_nhds
     simpa only [h₀, div_self'] using Tendsto.div' h₁ hf.hasProd.tendsto_prod_nat
   · refine tendsto_const_nhds.congr fun n ↦ (tprod_eq_one_of_not_multipliable ?_).symm
@@ -488,10 +494,13 @@ lemma Multipliable.of_nat_of_neg {f : ℤ → G} (hf₁ : Multipliable fun n : �
   (hf₁.hasProd.of_nat_of_neg hf₂.hasProd).multipliable
 
 @[to_additive]
-lemma tprod_of_nat_of_neg [T2Space G] {f : ℤ → G}
+protected lemma Multipliable.tprod_of_nat_of_neg [T2Space G] {f : ℤ → G}
     (hf₁ : Multipliable fun n : ℕ ↦ f n) (hf₂ : Multipliable fun n : ℕ ↦ f (-n)) :
     ∏' n : ℤ, f n = (∏' n : ℕ, f n) * (∏' n : ℕ, f (-n)) / f 0 :=
   (hf₁.hasProd.of_nat_of_neg hf₂.hasProd).tprod_eq
+
+@[to_additive, deprecated (since := "2025-04-11")] alias tprod_of_nat_of_neg :=
+  Multipliable.tprod_of_nat_of_neg
 
 end IsTopologicalGroup
 

--- a/Mathlib/Topology/Algebra/InfiniteSum/NatInt.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/NatInt.lean
@@ -236,7 +236,9 @@ protected theorem Multipliable.prod_mul_tprod_nat_add [T2Space G] {f : ℕ → G
     (h : Multipliable f) : ((∏ i ∈ range k, f i) * ∏' i, f (i + k)) = ∏' i, f i :=
   prod_mul_tprod_nat_mul' <| (multipliable_nat_add_iff k).2 h
 
-@[to_additive, deprecated (since := "2025-04-11")] alias prod_mul_tprod_nat_add :=
+@[deprecated (since := "2025-04-12")] alias sum_add_tsum_nat_add :=
+  Summable.sum_add_tsum_nat_add
+@[to_additive existing, deprecated (since := "2025-04-12")] alias prod_mul_tprod_nat_add :=
   Multipliable.prod_mul_tprod_nat_add
 
 @[to_additive]
@@ -244,7 +246,8 @@ protected theorem Multipliable.tprod_eq_zero_mul [T2Space G] {f : ℕ → G} (hf
     ∏' b, f b = f 0 * ∏' b, f (b + 1) :=
   tprod_eq_zero_mul' <| (multipliable_nat_add_iff 1).2 hf
 
-@[to_additive, deprecated (since := "2025-04-11")] alias tprod_eq_zero_mul :=
+@[deprecated (since := "2025-04-12")] alias tsum_eq_zero_add := Summable.tsum_eq_zero_add
+@[to_additive existing, deprecated (since := "2025-04-12")] alias tprod_eq_zero_mul :=
   Multipliable.tprod_eq_zero_mul
 
 /-- For `f : ℕ → G`, the product `∏' k, f (k + i)` tends to one. This does not require a
@@ -499,7 +502,9 @@ protected lemma Multipliable.tprod_of_nat_of_neg [T2Space G] {f : ℤ → G}
     ∏' n : ℤ, f n = (∏' n : ℕ, f n) * (∏' n : ℕ, f (-n)) / f 0 :=
   (hf₁.hasProd.of_nat_of_neg hf₂.hasProd).tprod_eq
 
-@[to_additive, deprecated (since := "2025-04-11")] alias tprod_of_nat_of_neg :=
+@[deprecated (since := "2025-04-12")] alias tsum_of_nat_of_neg :=
+  Summable.tsum_of_nat_of_neg
+@[to_additive existing, deprecated (since := "2025-04-12")] alias tprod_of_nat_of_neg :=
   Multipliable.tprod_of_nat_of_neg
 
 end IsTopologicalGroup

--- a/Mathlib/Topology/Algebra/InfiniteSum/NatInt.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/NatInt.lean
@@ -186,16 +186,20 @@ section ContinuousMul
 variable [T2Space M] [ContinuousMul M]
 
 @[to_additive]
-theorem prod_mul_tprod_nat_mul'
+protected theorem Multipliable.prod_mul_tprod_nat_mul'
     {f : ℕ → M} {k : ℕ} (h : Multipliable (fun n ↦ f (n + k))) :
     ((∏ i ∈ range k, f i) * ∏' i, f (i + k)) = ∏' i, f i :=
   h.hasProd.prod_range_mul.tprod_eq.symm
+
+@[deprecated (since := "2025-04-12")] alias sum_add_tsum_nat_add' := Summable.sum_add_tsum_nat_add'
+@[to_additive existing, deprecated (since := "2025-04-12")] alias prod_mul_tprod_nat_mul' :=
+  Multipliable.prod_mul_tprod_nat_mul'
 
 @[to_additive]
 theorem tprod_eq_zero_mul'
     {f : ℕ → M} (hf : Multipliable (fun n ↦ f (n + 1))) :
     ∏' b, f b = f 0 * ∏' b, f (b + 1) := by
-  simpa only [prod_range_one] using (prod_mul_tprod_nat_mul' hf).symm
+  simpa only [prod_range_one] using hf.prod_mul_tprod_nat_mul'.symm
 
 @[to_additive]
 theorem tprod_even_mul_odd {f : ℕ → M} (he : Multipliable fun k ↦ f (2 * k))
@@ -234,7 +238,7 @@ theorem hasProd_nat_add_iff' {f : ℕ → G} (k : ℕ) :
 @[to_additive]
 protected theorem Multipliable.prod_mul_tprod_nat_add [T2Space G] {f : ℕ → G} (k : ℕ)
     (h : Multipliable f) : ((∏ i ∈ range k, f i) * ∏' i, f (i + k)) = ∏' i, f i :=
-  prod_mul_tprod_nat_mul' <| (multipliable_nat_add_iff k).2 h
+  Multipliable.prod_mul_tprod_nat_mul' <| (multipliable_nat_add_iff k).2 h
 
 @[deprecated (since := "2025-04-12")] alias sum_add_tsum_nat_add :=
   Summable.sum_add_tsum_nat_add

--- a/Mathlib/Topology/Algebra/InfiniteSum/Order.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/Order.lean
@@ -234,13 +234,14 @@ protected theorem Multipliable.tprod_strict_mono (hf : Multipliable f) (hg : Mul
 @[to_additive (attr := mono), deprecated (since := "2025-04-11")] alias tprod_strict_mono :=
   Multipliable.tprod_strict_mono
 
-@[to_additive tsum_pos]
+@[to_additive Summable.tsum_pos]
 protected theorem Multipliable.one_lt_tprod (hsum : Multipliable g) (hg : ∀ i, 1 ≤ g i) (i : ι)
     (hi : 1 < g i) : 1 < ∏' i, g i := by
   rw [← tprod_one]
   exact Multipliable.tprod_lt_tprod hg hi multipliable_one hsum
 
-@[to_additive, deprecated (since := "2025-04-11")] alias one_lt_tprod := Multipliable.one_lt_tprod
+@[to_additive tsum_pos, deprecated (since := "2025-04-11")] alias one_lt_tprod :=
+  Multipliable.one_lt_tprod
 
 end OrderedCommGroup
 

--- a/Mathlib/Topology/Algebra/InfiniteSum/Order.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/Order.lean
@@ -34,9 +34,12 @@ theorem le_hasProd_of_le_prod [ClosedIciTopology α]
   ge_of_tendsto' hf h
 
 @[to_additive]
-theorem tprod_le_of_prod_range_le [ClosedIicTopology α] {f : ℕ → α} (hf : Multipliable f)
-    (h : ∀ n, ∏ i ∈ range n, f i ≤ c) : ∏' n, f n ≤ c :=
+protected theorem Multipliable.tprod_le_of_prod_range_le [ClosedIicTopology α] {f : ℕ → α}
+    (hf : Multipliable f) (h : ∀ n, ∏ i ∈ range n, f i ≤ c) : ∏' n, f n ≤ c :=
   le_of_tendsto' hf.hasProd.tendsto_prod_nat h
+
+@[to_additive, deprecated (since := "2025-04-11")] alias tprod_le_of_prod_range_le :=
+  Multipliable.tprod_le_of_prod_range_le
 
 end Preorder
 
@@ -67,22 +70,28 @@ theorem hasProd_le_inj {g : κ → α} (e : ι → κ) (he : Injective e)
     exact hs _ h
 
 @[to_additive]
-theorem tprod_le_tprod_of_inj {g : κ → α} (e : ι → κ) (he : Injective e)
+protected theorem Multipliable.tprod_le_tprod_of_inj {g : κ → α} (e : ι → κ) (he : Injective e)
     (hs : ∀ c, c ∉ Set.range e → 1 ≤ g c) (h : ∀ i, f i ≤ g (e i)) (hf : Multipliable f)
     (hg : Multipliable g) : tprod f ≤ tprod g :=
   hasProd_le_inj _ he hs h hf.hasProd hg.hasProd
 
+@[to_additive, deprecated (since := "2025-04-11")] alias tprod_le_tprod_of_inj :=
+  Multipliable.tprod_le_tprod_of_inj
+
 @[to_additive]
-lemma tprod_subtype_le {κ γ : Type*} [CommGroup γ] [PartialOrder γ] [IsOrderedMonoid γ]
-    [UniformSpace γ] [IsUniformGroup γ]
-    [OrderClosedTopology γ] [CompleteSpace γ] (f : κ → γ) (β : Set κ) (h : ∀ a : κ, 1 ≤ f a)
-    (hf : Multipliable f) : (∏' (b : β), f b) ≤ (∏' (a : κ), f a) := by
-  apply tprod_le_tprod_of_inj _
+protected lemma Multipliable.tprod_subtype_le {κ γ : Type*} [CommGroup γ] [PartialOrder γ]
+    [IsOrderedMonoid γ] [UniformSpace γ] [IsUniformGroup γ] [OrderClosedTopology γ]
+    [CompleteSpace γ] (f : κ → γ) (β : Set κ) (h : ∀ a : κ, 1 ≤ f a) (hf : Multipliable f) :
+    (∏' (b : β), f b) ≤ (∏' (a : κ), f a) := by
+  apply Multipliable.tprod_le_tprod_of_inj _
     (Subtype.coe_injective)
     (by simp only [Subtype.range_coe_subtype, Set.setOf_mem_eq, h, implies_true])
     (by simp only [le_refl, Subtype.forall, implies_true])
     (by apply hf.subtype)
   apply hf
+
+@[to_additive, deprecated (since := "2025-04-11")] alias tprod_subtype_le :=
+  Multipliable.tprod_subtype_le
 
 @[to_additive]
 theorem prod_le_hasProd (s : Finset ι) (hs : ∀ i, i ∉ s → 1 ≤ f i) (hf : HasProd f a) :
@@ -113,34 +122,49 @@ theorem lt_hasProd [MulRightStrictMono α] (hf : HasProd f a) (i : ι)
     _ ≤ a := prod_le_hasProd _ (fun k hk ↦ hi k (hk ∘ mem_insert_of_mem ∘ mem_singleton.mpr)) hf
 
 @[to_additive]
-theorem prod_le_tprod {f : ι → α} (s : Finset ι) (hs : ∀ i, i ∉ s → 1 ≤ f i) (hf : Multipliable f) :
-    ∏ i ∈ s, f i ≤ ∏' i, f i :=
+protected theorem Multipliable.prod_le_tprod {f : ι → α} (s : Finset ι) (hs : ∀ i, i ∉ s → 1 ≤ f i)
+    (hf : Multipliable f) : ∏ i ∈ s, f i ≤ ∏' i, f i :=
   prod_le_hasProd s hs hf.hasProd
 
+@[to_additive, deprecated (since := "2025-04-11")] alias prod_le_tprod := Multipliable.prod_le_tprod
+
 @[to_additive]
-theorem le_tprod (hf : Multipliable f) (i : ι) (hb : ∀ j, j ≠ i → 1 ≤ f j) : f i ≤ ∏' i, f i :=
+protected theorem Multipliable.le_tprod (hf : Multipliable f) (i : ι) (hb : ∀ j, j ≠ i → 1 ≤ f j) :
+    f i ≤ ∏' i, f i :=
   le_hasProd hf.hasProd i hb
 
+@[to_additive, deprecated (since := "2025-04-11")] alias le_tprod := Multipliable.le_tprod
+
 @[to_additive]
-theorem tprod_le_tprod (h : ∀ i, f i ≤ g i) (hf : Multipliable f) (hg : Multipliable g) :
-    ∏' i, f i ≤ ∏' i, g i :=
+protected theorem Multipliable.tprod_le_tprod (h : ∀ i, f i ≤ g i) (hf : Multipliable f)
+    (hg : Multipliable g) : ∏' i, f i ≤ ∏' i, g i :=
   hasProd_le h hf.hasProd hg.hasProd
 
+@[to_additive, deprecated (since := "2025-04-11")] alias tprod_le_tprod :=
+  Multipliable.tprod_le_tprod
+
 @[to_additive (attr := mono)]
-theorem tprod_mono (hf : Multipliable f) (hg : Multipliable g) (h : f ≤ g) :
+protected theorem Multipliable.tprod_mono (hf : Multipliable f) (hg : Multipliable g) (h : f ≤ g) :
     ∏' n, f n ≤ ∏' n, g n :=
-  tprod_le_tprod h hf hg
+  hf.tprod_le_tprod h hg
+
+@[to_additive (attr := mono), deprecated (since := "2025-04-11")] alias tprod_mono :=
+  Multipliable.tprod_mono
 
 omit [IsOrderedMonoid α] in
 @[to_additive]
-theorem tprod_le_of_prod_le (hf : Multipliable f) (h : ∀ s, ∏ i ∈ s, f i ≤ a₂) : ∏' i, f i ≤ a₂ :=
+protected theorem Multipliable.tprod_le_of_prod_le (hf : Multipliable f)
+    (h : ∀ s, ∏ i ∈ s, f i ≤ a₂) : ∏' i, f i ≤ a₂ :=
   hasProd_le_of_prod_le hf.hasProd h
+
+@[to_additive, deprecated (since := "2025-04-11")] alias tprod_le_of_prod_le :=
+  Multipliable.tprod_le_of_prod_le
 
 omit [IsOrderedMonoid α] in
 @[to_additive]
 theorem tprod_le_of_prod_le' (ha₂ : 1 ≤ a₂) (h : ∀ s, ∏ i ∈ s, f i ≤ a₂) : ∏' i, f i ≤ a₂ := by
   by_cases hf : Multipliable f
-  · exact tprod_le_of_prod_le hf h
+  · exact hf.tprod_le_of_prod_le h
   · rw [tprod_eq_one_of_not_multipliable hf]
     exact ha₂
 
@@ -194,21 +218,29 @@ theorem hasProd_strict_mono (hf : HasProd f a₁) (hg : HasProd g a₂) (h : f <
   hasProd_lt hle hi hf hg
 
 @[to_additive]
-theorem tprod_lt_tprod (h : f ≤ g) (hi : f i < g i) (hf : Multipliable f) (hg : Multipliable g) :
-    ∏' n, f n < ∏' n, g n :=
+protected theorem Multipliable.tprod_lt_tprod (h : f ≤ g) (hi : f i < g i) (hf : Multipliable f)
+    (hg : Multipliable g) : ∏' n, f n < ∏' n, g n :=
   hasProd_lt h hi hf.hasProd hg.hasProd
 
+@[to_additive, deprecated (since := "2025-04-11")] alias tprod_lt_tprod :=
+  Multipliable.tprod_lt_tprod
+
 @[to_additive (attr := mono)]
-theorem tprod_strict_mono (hf : Multipliable f) (hg : Multipliable g) (h : f < g) :
-    ∏' n, f n < ∏' n, g n :=
+protected theorem Multipliable.tprod_strict_mono (hf : Multipliable f) (hg : Multipliable g)
+    (h : f < g) : ∏' n, f n < ∏' n, g n :=
   let ⟨hle, _i, hi⟩ := Pi.lt_def.mp h
-  tprod_lt_tprod hle hi hf hg
+  hf.tprod_lt_tprod hle hi hg
+
+@[to_additive (attr := mono), deprecated (since := "2025-04-11")] alias tprod_strict_mono :=
+  Multipliable.tprod_strict_mono
 
 @[to_additive tsum_pos]
-theorem one_lt_tprod (hsum : Multipliable g) (hg : ∀ i, 1 ≤ g i) (i : ι) (hi : 1 < g i) :
-    1 < ∏' i, g i := by
+protected theorem Multipliable.one_lt_tprod (hsum : Multipliable g) (hg : ∀ i, 1 ≤ g i) (i : ι)
+    (hi : 1 < g i) : 1 < ∏' i, g i := by
   rw [← tprod_one]
-  exact tprod_lt_tprod hg hi multipliable_one hsum
+  exact Multipliable.tprod_lt_tprod hg hi multipliable_one hsum
+
+@[to_additive, deprecated (since := "2025-04-11")] alias one_lt_tprod := Multipliable.one_lt_tprod
 
 end OrderedCommGroup
 
@@ -223,20 +255,30 @@ theorem le_hasProd' (hf : HasProd f a) (i : ι) : f i ≤ a :=
   le_hasProd hf i fun _ _ ↦ one_le _
 
 @[to_additive]
-theorem le_tprod' (hf : Multipliable f) (i : ι) : f i ≤ ∏' i, f i :=
-  le_tprod hf i fun _ _ ↦ one_le _
+protected theorem Multipliable.le_tprod' (hf : Multipliable f) (i : ι) : f i ≤ ∏' i, f i :=
+  hf.le_tprod i fun _ _ ↦ one_le _
+
+@[to_additive, deprecated (since := "2025-04-11")] alias le_tprod' := Multipliable.le_tprod'
 
 @[to_additive]
 theorem hasProd_one_iff : HasProd f 1 ↔ ∀ x, f x = 1 :=
   (hasProd_one_iff_of_one_le fun _ ↦ one_le _).trans funext_iff
 
 @[to_additive]
-theorem tprod_eq_one_iff (hf : Multipliable f) : ∏' i, f i = 1 ↔ ∀ x, f x = 1 := by
+protected theorem Multipliable.tprod_eq_one_iff (hf : Multipliable f) :
+    ∏' i, f i = 1 ↔ ∀ x, f x = 1 := by
   rw [← hasProd_one_iff, hf.hasProd_iff]
 
+@[to_additive, deprecated (since := "2025-04-11")] alias tprod_eq_one_iff :=
+  Multipliable.tprod_eq_one_iff
+
 @[to_additive]
-theorem tprod_ne_one_iff (hf : Multipliable f) : ∏' i, f i ≠ 1 ↔ ∃ x, f x ≠ 1 := by
-  rw [Ne, tprod_eq_one_iff hf, not_forall]
+protected theorem Multipliable.tprod_ne_one_iff (hf : Multipliable f) :
+    ∏' i, f i ≠ 1 ↔ ∃ x, f x ≠ 1 := by
+  rw [Ne, hf.tprod_eq_one_iff, not_forall]
+
+@[to_additive, deprecated (since := "2025-04-11")] alias tprod_ne_one_iff :=
+  Multipliable.tprod_ne_one_iff
 
 @[to_additive]
 theorem isLUB_hasProd' (hf : HasProd f a) : IsLUB (Set.range fun s ↦ ∏ i ∈ s, f i) a := by
@@ -316,8 +358,10 @@ nonrec theorem HasProd.abs (hfx : HasProd f x) : HasProd (|f ·|) |x| := by
 theorem Multipliable.abs (hf : Multipliable f) : Multipliable (|f ·|) :=
   let ⟨x, hx⟩ := hf; ⟨|x|, hx.abs⟩
 
-theorem abs_tprod (hf : Multipliable f) : |∏' i, f i| = ∏' i, |f i| :=
+protected theorem Multipliable.abs_tprod (hf : Multipliable f) : |∏' i, f i| = ∏' i, |f i| :=
   hf.hasProd.abs.tprod_eq.symm
+
+@[deprecated (since := "2025-04-11")] alias abs_tprod := Multipliable.abs_tprod
 
 end LinearOrderedCommRing
 

--- a/Mathlib/Topology/Algebra/InfiniteSum/Order.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/Order.lean
@@ -250,7 +250,7 @@ protected theorem Multipliable.tprod_strict_mono (hf : Multipliable f) (hg : Mul
 protected theorem Multipliable.one_lt_tprod (hsum : Multipliable g) (hg : ∀ i, 1 ≤ g i) (i : ι)
     (hi : 1 < g i) : 1 < ∏' i, g i := by
   rw [← tprod_one]
-  exact Multipliable.tprod_lt_tprod hg hi multipliable_one hsum
+  exact multipliable_one.tprod_lt_tprod hg hi hsum
 
 @[deprecated (since := "2025-04-12")] alias tsum_pos := Summable.tsum_pos
 @[to_additive existing tsum_pos, deprecated (since := "2025-04-12")] alias one_lt_tprod :=

--- a/Mathlib/Topology/Algebra/InfiniteSum/Order.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/Order.lean
@@ -38,7 +38,9 @@ protected theorem Multipliable.tprod_le_of_prod_range_le [ClosedIicTopology α] 
     (hf : Multipliable f) (h : ∀ n, ∏ i ∈ range n, f i ≤ c) : ∏' n, f n ≤ c :=
   le_of_tendsto' hf.hasProd.tendsto_prod_nat h
 
-@[to_additive, deprecated (since := "2025-04-11")] alias tprod_le_of_prod_range_le :=
+@[deprecated (since := "2025-04-12")] alias tsum_le_of_sum_range_le :=
+  Summable.tsum_le_of_sum_range_le
+@[to_additive existing, deprecated (since := "2025-04-12")] alias tprod_le_of_prod_range_le :=
   Multipliable.tprod_le_of_prod_range_le
 
 end Preorder
@@ -75,7 +77,8 @@ protected theorem Multipliable.tprod_le_tprod_of_inj {g : κ → α} (e : ι →
     (hg : Multipliable g) : tprod f ≤ tprod g :=
   hasProd_le_inj _ he hs h hf.hasProd hg.hasProd
 
-@[to_additive, deprecated (since := "2025-04-11")] alias tprod_le_tprod_of_inj :=
+@[deprecated (since := "2025-04-12")] alias tsum_le_tsum_of_inj := Summable.tsum_le_tsum_of_inj
+@[to_additive existing, deprecated (since := "2025-04-12")] alias tprod_le_tprod_of_inj :=
   Multipliable.tprod_le_tprod_of_inj
 
 @[to_additive]
@@ -90,7 +93,8 @@ protected lemma Multipliable.tprod_subtype_le {κ γ : Type*} [CommGroup γ] [Pa
     (by apply hf.subtype)
   apply hf
 
-@[to_additive, deprecated (since := "2025-04-11")] alias tprod_subtype_le :=
+@[deprecated (since := "2025-04-12")] alias tsum_subtype_le := Summable.tsum_subtype_le
+@[to_additive existing, deprecated (since := "2025-04-12")] alias tprod_subtype_le :=
   Multipliable.tprod_subtype_le
 
 @[to_additive]
@@ -126,21 +130,25 @@ protected theorem Multipliable.prod_le_tprod {f : ι → α} (s : Finset ι) (hs
     (hf : Multipliable f) : ∏ i ∈ s, f i ≤ ∏' i, f i :=
   prod_le_hasProd s hs hf.hasProd
 
-@[to_additive, deprecated (since := "2025-04-11")] alias prod_le_tprod := Multipliable.prod_le_tprod
+@[deprecated (since := "2025-04-12")] alias sum_le_tsum := Summable.sum_le_tsum
+@[to_additive existing, deprecated (since := "2025-04-12")] alias prod_le_tprod :=
+  Multipliable.prod_le_tprod
 
 @[to_additive]
 protected theorem Multipliable.le_tprod (hf : Multipliable f) (i : ι) (hb : ∀ j, j ≠ i → 1 ≤ f j) :
     f i ≤ ∏' i, f i :=
   le_hasProd hf.hasProd i hb
 
-@[to_additive, deprecated (since := "2025-04-11")] alias le_tprod := Multipliable.le_tprod
+@[deprecated (since := "2025-04-12")] alias le_tsum := Summable.le_tsum
+@[to_additive existing, deprecated (since := "2025-04-12")] alias le_tprod := Multipliable.le_tprod
 
 @[to_additive]
 protected theorem Multipliable.tprod_le_tprod (h : ∀ i, f i ≤ g i) (hf : Multipliable f)
     (hg : Multipliable g) : ∏' i, f i ≤ ∏' i, g i :=
   hasProd_le h hf.hasProd hg.hasProd
 
-@[to_additive, deprecated (since := "2025-04-11")] alias tprod_le_tprod :=
+@[deprecated (since := "2025-04-12")] alias tsum_le_tsum := Summable.tsum_le_tsum
+@[to_additive existing, deprecated (since := "2025-04-12")] alias tprod_le_tprod :=
   Multipliable.tprod_le_tprod
 
 @[to_additive (attr := mono)]
@@ -148,7 +156,8 @@ protected theorem Multipliable.tprod_mono (hf : Multipliable f) (hg : Multipliab
     ∏' n, f n ≤ ∏' n, g n :=
   hf.tprod_le_tprod h hg
 
-@[to_additive (attr := mono), deprecated (since := "2025-04-11")] alias tprod_mono :=
+@[deprecated (since := "2025-04-12")] alias tsum_mono := Summable.tsum_mono
+@[to_additive existing (attr := mono), deprecated (since := "2025-04-12")] alias tprod_mono :=
   Multipliable.tprod_mono
 
 omit [IsOrderedMonoid α] in
@@ -157,7 +166,8 @@ protected theorem Multipliable.tprod_le_of_prod_le (hf : Multipliable f)
     (h : ∀ s, ∏ i ∈ s, f i ≤ a₂) : ∏' i, f i ≤ a₂ :=
   hasProd_le_of_prod_le hf.hasProd h
 
-@[to_additive, deprecated (since := "2025-04-11")] alias tprod_le_of_prod_le :=
+@[deprecated (since := "2025-04-12")] alias tsum_le_of_sum_le := Summable.tsum_le_of_sum_le
+@[to_additive existing, deprecated (since := "2025-04-12")] alias tprod_le_of_prod_le :=
   Multipliable.tprod_le_of_prod_le
 
 omit [IsOrderedMonoid α] in
@@ -222,7 +232,8 @@ protected theorem Multipliable.tprod_lt_tprod (h : f ≤ g) (hi : f i < g i) (hf
     (hg : Multipliable g) : ∏' n, f n < ∏' n, g n :=
   hasProd_lt h hi hf.hasProd hg.hasProd
 
-@[to_additive, deprecated (since := "2025-04-11")] alias tprod_lt_tprod :=
+@[deprecated (since := "2025-04-12")] alias tsum_lt_tsum := Summable.tsum_lt_tsum
+@[to_additive existing, deprecated (since := "2025-04-12")] alias tprod_lt_tprod :=
   Multipliable.tprod_lt_tprod
 
 @[to_additive (attr := mono)]
@@ -231,8 +242,9 @@ protected theorem Multipliable.tprod_strict_mono (hf : Multipliable f) (hg : Mul
   let ⟨hle, _i, hi⟩ := Pi.lt_def.mp h
   hf.tprod_lt_tprod hle hi hg
 
-@[to_additive (attr := mono), deprecated (since := "2025-04-11")] alias tprod_strict_mono :=
-  Multipliable.tprod_strict_mono
+@[deprecated (since := "2025-04-12")] alias tsum_strict_mono := Summable.tsum_strict_mono
+@[to_additive existing (attr := mono), deprecated (since := "2025-04-12")] alias
+  tprod_strict_mono := Multipliable.tprod_strict_mono
 
 @[to_additive Summable.tsum_pos]
 protected theorem Multipliable.one_lt_tprod (hsum : Multipliable g) (hg : ∀ i, 1 ≤ g i) (i : ι)
@@ -240,7 +252,8 @@ protected theorem Multipliable.one_lt_tprod (hsum : Multipliable g) (hg : ∀ i,
   rw [← tprod_one]
   exact Multipliable.tprod_lt_tprod hg hi multipliable_one hsum
 
-@[to_additive tsum_pos, deprecated (since := "2025-04-11")] alias one_lt_tprod :=
+@[deprecated (since := "2025-04-12")] alias tsum_pos := Summable.tsum_pos
+@[to_additive existing tsum_pos, deprecated (since := "2025-04-12")] alias one_lt_tprod :=
   Multipliable.one_lt_tprod
 
 end OrderedCommGroup
@@ -259,7 +272,9 @@ theorem le_hasProd' (hf : HasProd f a) (i : ι) : f i ≤ a :=
 protected theorem Multipliable.le_tprod' (hf : Multipliable f) (i : ι) : f i ≤ ∏' i, f i :=
   hf.le_tprod i fun _ _ ↦ one_le _
 
-@[to_additive, deprecated (since := "2025-04-11")] alias le_tprod' := Multipliable.le_tprod'
+@[deprecated (since := "2025-04-12")] alias le_tsum' := Summable.le_tsum'
+@[to_additive existing, deprecated (since := "2025-04-12")] alias le_tprod' :=
+  Multipliable.le_tprod'
 
 @[to_additive]
 theorem hasProd_one_iff : HasProd f 1 ↔ ∀ x, f x = 1 :=
@@ -270,7 +285,8 @@ protected theorem Multipliable.tprod_eq_one_iff (hf : Multipliable f) :
     ∏' i, f i = 1 ↔ ∀ x, f x = 1 := by
   rw [← hasProd_one_iff, hf.hasProd_iff]
 
-@[to_additive, deprecated (since := "2025-04-11")] alias tprod_eq_one_iff :=
+@[deprecated (since := "2025-04-12")] alias tsum_eq_zero_iff := Summable.tsum_eq_zero_iff
+@[to_additive existing, deprecated (since := "2025-04-12")] alias tprod_eq_one_iff :=
   Multipliable.tprod_eq_one_iff
 
 @[to_additive]
@@ -278,7 +294,8 @@ protected theorem Multipliable.tprod_ne_one_iff (hf : Multipliable f) :
     ∏' i, f i ≠ 1 ↔ ∃ x, f x ≠ 1 := by
   rw [Ne, hf.tprod_eq_one_iff, not_forall]
 
-@[to_additive, deprecated (since := "2025-04-11")] alias tprod_ne_one_iff :=
+@[deprecated (since := "2025-04-12")] alias tsum_ne_zero_iff := Summable.tsum_ne_zero_iff
+@[to_additive existing, deprecated (since := "2025-04-12")] alias tprod_ne_one_iff :=
   Multipliable.tprod_ne_one_iff
 
 @[to_additive]
@@ -362,7 +379,7 @@ theorem Multipliable.abs (hf : Multipliable f) : Multipliable (|f ·|) :=
 protected theorem Multipliable.abs_tprod (hf : Multipliable f) : |∏' i, f i| = ∏' i, |f i| :=
   hf.hasProd.abs.tprod_eq.symm
 
-@[deprecated (since := "2025-04-11")] alias abs_tprod := Multipliable.abs_tprod
+@[deprecated (since := "2025-04-12")] alias abs_tprod := Multipliable.abs_tprod
 
 end LinearOrderedCommRing
 

--- a/Mathlib/Topology/Algebra/InfiniteSum/Real.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/Real.lean
@@ -36,7 +36,7 @@ theorem dist_le_tsum_of_dist_le_of_tendsto (d : ℕ → ℝ) (hf : ∀ n, dist (
   refine le_of_tendsto (tendsto_const_nhds.dist ha) (eventually_atTop.2 ⟨n, fun m hnm ↦ ?_⟩)
   refine le_trans (dist_le_Ico_sum_of_dist_le hnm fun _ _ ↦ hf _) ?_
   rw [sum_Ico_eq_sum_range]
-  refine sum_le_tsum (range _) (fun _ _ ↦ le_trans dist_nonneg (hf _)) ?_
+  refine Summable.sum_le_tsum (range _) (fun _ _ ↦ le_trans dist_nonneg (hf _)) ?_
   exact hd.comp_injective (add_right_injective n)
 
 theorem dist_le_tsum_of_dist_le_of_tendsto₀ (d : ℕ → ℝ) (hf : ∀ n, dist (f n) (f n.succ) ≤ d n)
@@ -90,13 +90,16 @@ theorem summable_of_sum_range_le {f : ℕ → ℝ} {c : ℝ} (hf : ∀ n, 0 ≤ 
 
 theorem Real.tsum_le_of_sum_range_le {f : ℕ → ℝ} {c : ℝ} (hf : ∀ n, 0 ≤ f n)
     (h : ∀ n, ∑ i ∈ Finset.range n, f i ≤ c) : ∑' n, f n ≤ c :=
-  _root_.tsum_le_of_sum_range_le (summable_of_sum_range_le hf h) h
+  (summable_of_sum_range_le hf h).tsum_le_of_sum_range_le h
 
 /-- If a sequence `f` with non-negative terms is dominated by a sequence `g` with summable
 series and at least one term of `f` is strictly smaller than the corresponding term in `g`,
 then the series of `f` is strictly smaller than the series of `g`. -/
-theorem tsum_lt_tsum_of_nonneg {i : ℕ} {f g : ℕ → ℝ} (h0 : ∀ b : ℕ, 0 ≤ f b)
+protected theorem Summable.tsum_lt_tsum_of_nonneg {i : ℕ} {f g : ℕ → ℝ} (h0 : ∀ b : ℕ, 0 ≤ f b)
     (h : ∀ b : ℕ, f b ≤ g b) (hi : f i < g i) (hg : Summable g) : ∑' n, f n < ∑' n, g n :=
-  tsum_lt_tsum h hi (.of_nonneg_of_le h0 h hg) hg
+  Summable.tsum_lt_tsum h hi (.of_nonneg_of_le h0 h hg) hg
+
+@[deprecated (since := "2025-04-12")] alias tsum_lt_tsum_of_nonneg :=
+  Summable.tsum_lt_tsum_of_nonneg
 
 end summable

--- a/Mathlib/Topology/Algebra/InfiniteSum/Ring.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/Ring.lean
@@ -42,10 +42,10 @@ section tsum
 
 variable [T2Space α]
 
-theorem Summable.tsum_mul_left (a) (hf : Summable f) : ∑' i, a * f i = a * ∑' i, f i :=
+protected theorem Summable.tsum_mul_left (a) (hf : Summable f) : ∑' i, a * f i = a * ∑' i, f i :=
   (hf.hasSum.mul_left _).tsum_eq
 
-theorem Summable.tsum_mul_right (a) (hf : Summable f) : ∑' i, f i * a = (∑' i, f i) * a :=
+protected theorem Summable.tsum_mul_right (a) (hf : Summable f) : ∑' i, f i * a = (∑' i, f i) * a :=
   (hf.hasSum.mul_right _).tsum_eq
 
 theorem Commute.tsum_right (a) (h : ∀ i, Commute a (f i)) : Commute a (∑' i, f i) := by
@@ -161,10 +161,12 @@ theorem HasSum.mul (hf : HasSum f s) (hg : HasSum g t)
 
 /-- Product of two infinites sums indexed by arbitrary types.
     See also `tsum_mul_tsum_of_summable_norm` if `f` and `g` are absolutely summable. -/
-theorem tsum_mul_tsum (hf : Summable f) (hg : Summable g)
+protected theorem Summable.tsum_mul_tsum (hf : Summable f) (hg : Summable g)
     (hfg : Summable fun x : ι × κ ↦ f x.1 * g x.2) :
     ((∑' x, f x) * ∑' y, g y) = ∑' z : ι × κ, f z.1 * g z.2 :=
   hf.hasSum.mul_eq hg.hasSum hfg.hasSum
+
+@[deprecated (since := "2025-04-11")] alias tsum_mul_tsum := Summable.tsum_mul_tsum
 
 end tsum_mul_tsum
 
@@ -208,14 +210,17 @@ by summing on `Finset.antidiagonal`.
 
 See also `tsum_mul_tsum_eq_tsum_sum_antidiagonal_of_summable_norm` if `f` and `g` are absolutely
 summable. -/
-theorem tsum_mul_tsum_eq_tsum_sum_antidiagonal (hf : Summable f) (hg : Summable g)
-    (hfg : Summable fun x : A × A ↦ f x.1 * g x.2) :
+protected theorem Summable.tsum_mul_tsum_eq_tsum_sum_antidiagonal (hf : Summable f)
+    (hg : Summable g) (hfg : Summable fun x : A × A ↦ f x.1 * g x.2) :
     ((∑' n, f n) * ∑' n, g n) = ∑' n, ∑ kl ∈ antidiagonal n, f kl.1 * g kl.2 := by
   conv_rhs => congr; ext; rw [← Finset.sum_finset_coe, ← tsum_fintype]
-  rw [tsum_mul_tsum hf hg hfg, ← sigmaAntidiagonalEquivProd.tsum_eq (_ : A × A → α)]
+  rw [hf.tsum_mul_tsum hg hfg, ← sigmaAntidiagonalEquivProd.tsum_eq (_ : A × A → α)]
   exact
     tsum_sigma' (fun n ↦ (hasSum_fintype _).summable)
       (summable_mul_prod_iff_summable_mul_sigma_antidiagonal.mp hfg)
+
+@[deprecated (since := "2025-04-11")] alias tsum_mul_tsum_eq_tsum_sum_antidiagonal :=
+  Summable.tsum_mul_tsum_eq_tsum_sum_antidiagonal
 
 end HasAntidiagonal
 
@@ -234,11 +239,14 @@ by summing on `Finset.range`.
 
 See also `tsum_mul_tsum_eq_tsum_sum_range_of_summable_norm` if `f` and `g` are absolutely summable.
 -/
-theorem tsum_mul_tsum_eq_tsum_sum_range (hf : Summable f) (hg : Summable g)
+protected theorem Summable.tsum_mul_tsum_eq_tsum_sum_range (hf : Summable f) (hg : Summable g)
     (hfg : Summable fun x : ℕ × ℕ ↦ f x.1 * g x.2) :
     ((∑' n, f n) * ∑' n, g n) = ∑' n, ∑ k ∈ range (n + 1), f k * g (n - k) := by
   simp_rw [← Nat.sum_antidiagonal_eq_sum_range_succ fun k l ↦ f k * g l]
-  exact tsum_mul_tsum_eq_tsum_sum_antidiagonal hf hg hfg
+  exact hf.tsum_mul_tsum_eq_tsum_sum_antidiagonal hg hfg
+
+@[deprecated (since := "2025-04-11")] alias tsum_mul_tsum_eq_tsum_sum_range :=
+  Summable.tsum_mul_tsum_eq_tsum_sum_range
 
 end Nat
 

--- a/Mathlib/Topology/Algebra/InfiniteSum/Ring.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/Ring.lean
@@ -166,7 +166,7 @@ protected theorem Summable.tsum_mul_tsum (hf : Summable f) (hg : Summable g)
     ((∑' x, f x) * ∑' y, g y) = ∑' z : ι × κ, f z.1 * g z.2 :=
   hf.hasSum.mul_eq hg.hasSum hfg.hasSum
 
-@[deprecated (since := "2025-04-11")] alias tsum_mul_tsum := Summable.tsum_mul_tsum
+@[deprecated (since := "2025-04-12")] alias tsum_mul_tsum := Summable.tsum_mul_tsum
 
 end tsum_mul_tsum
 
@@ -219,7 +219,7 @@ protected theorem Summable.tsum_mul_tsum_eq_tsum_sum_antidiagonal (hf : Summable
     tsum_sigma' (fun n ↦ (hasSum_fintype _).summable)
       (summable_mul_prod_iff_summable_mul_sigma_antidiagonal.mp hfg)
 
-@[deprecated (since := "2025-04-11")] alias tsum_mul_tsum_eq_tsum_sum_antidiagonal :=
+@[deprecated (since := "2025-04-12")] alias tsum_mul_tsum_eq_tsum_sum_antidiagonal :=
   Summable.tsum_mul_tsum_eq_tsum_sum_antidiagonal
 
 end HasAntidiagonal
@@ -245,7 +245,7 @@ protected theorem Summable.tsum_mul_tsum_eq_tsum_sum_range (hf : Summable f) (hg
   simp_rw [← Nat.sum_antidiagonal_eq_sum_range_succ fun k l ↦ f k * g l]
   exact hf.tsum_mul_tsum_eq_tsum_sum_antidiagonal hg hfg
 
-@[deprecated (since := "2025-04-11")] alias tsum_mul_tsum_eq_tsum_sum_range :=
+@[deprecated (since := "2025-04-12")] alias tsum_mul_tsum_eq_tsum_sum_range :=
   Summable.tsum_mul_tsum_eq_tsum_sum_range
 
 end Nat

--- a/Mathlib/Topology/Algebra/InfiniteSum/Ring.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/Ring.lean
@@ -215,9 +215,9 @@ protected theorem Summable.tsum_mul_tsum_eq_tsum_sum_antidiagonal (hf : Summable
     ((∑' n, f n) * ∑' n, g n) = ∑' n, ∑ kl ∈ antidiagonal n, f kl.1 * g kl.2 := by
   conv_rhs => congr; ext; rw [← Finset.sum_finset_coe, ← tsum_fintype]
   rw [hf.tsum_mul_tsum hg hfg, ← sigmaAntidiagonalEquivProd.tsum_eq (_ : A × A → α)]
-  exact
-    tsum_sigma' (fun n ↦ (hasSum_fintype _).summable)
-      (summable_mul_prod_iff_summable_mul_sigma_antidiagonal.mp hfg)
+  exact (summable_mul_prod_iff_summable_mul_sigma_antidiagonal.mp hfg).tsum_sigma'
+    (fun n ↦ (hasSum_fintype _).summable)
+
 
 @[deprecated (since := "2025-04-12")] alias tsum_mul_tsum_eq_tsum_sum_antidiagonal :=
   Summable.tsum_mul_tsum_eq_tsum_sum_antidiagonal

--- a/Mathlib/Topology/Instances/ENNReal/Lemmas.lean
+++ b/Mathlib/Topology/Instances/ENNReal/Lemmas.lean
@@ -601,11 +601,11 @@ protected theorem tsum_eq_iSup_sum' {ι : Type*} (s : ι → Finset α) (hs : �
 
 protected theorem tsum_sigma {β : α → Type*} (f : ∀ a, β a → ℝ≥0∞) :
     ∑' p : Σ a, β a, f p.1 p.2 = ∑' (a) (b), f a b :=
-  tsum_sigma' (fun _ => ENNReal.summable) ENNReal.summable
+  ENNReal.summable.tsum_sigma' (fun _ => ENNReal.summable)
 
 protected theorem tsum_sigma' {β : α → Type*} (f : (Σ a, β a) → ℝ≥0∞) :
     ∑' p : Σ a, β a, f p = ∑' (a) (b), f ⟨a, b⟩ :=
-  tsum_sigma' (fun _ => ENNReal.summable) ENNReal.summable
+  ENNReal.summable.tsum_sigma' (fun _ => ENNReal.summable)
 
 protected theorem tsum_prod {f : α → β → ℝ≥0∞} : ∑' p : α × β, f p.1 p.2 = ∑' (a) (b), f a b :=
   tsum_prod' ENNReal.summable fun _ => ENNReal.summable
@@ -649,11 +649,11 @@ protected theorem tsum_eq_limsup_sum_nat {f : ℕ → ℝ≥0∞} :
   ENNReal.summable.hasSum.tendsto_sum_nat.limsup_eq.symm
 
 protected theorem le_tsum (a : α) : f a ≤ ∑' a, f a :=
-  le_tsum' ENNReal.summable a
+  ENNReal.summable.le_tsum' a
 
 @[simp]
 protected theorem tsum_eq_zero : ∑' i, f i = 0 ↔ ∀ i, f i = 0 :=
-  tsum_eq_zero_iff ENNReal.summable
+  ENNReal.summable.tsum_eq_zero_iff
 
 protected theorem tsum_eq_top_of_eq_top : (∃ a, f a = ∞) → ∑' a, f a = ∞
   | ⟨a, ha⟩ => top_unique <| ha ▸ ENNReal.le_tsum a

--- a/Mathlib/Topology/Instances/ENNReal/Lemmas.lean
+++ b/Mathlib/Topology/Instances/ENNReal/Lemmas.lean
@@ -601,33 +601,33 @@ protected theorem tsum_eq_iSup_sum' {ι : Type*} (s : ι → Finset α) (hs : �
 
 protected theorem tsum_sigma {β : α → Type*} (f : ∀ a, β a → ℝ≥0∞) :
     ∑' p : Σ a, β a, f p.1 p.2 = ∑' (a) (b), f a b :=
-  ENNReal.summable.tsum_sigma' (fun _ => ENNReal.summable)
+  ENNReal.summable.tsum_sigma' fun _ => ENNReal.summable
 
 protected theorem tsum_sigma' {β : α → Type*} (f : (Σ a, β a) → ℝ≥0∞) :
     ∑' p : Σ a, β a, f p = ∑' (a) (b), f ⟨a, b⟩ :=
-  ENNReal.summable.tsum_sigma' (fun _ => ENNReal.summable)
+  ENNReal.summable.tsum_sigma' fun _ => ENNReal.summable
 
 protected theorem tsum_prod {f : α → β → ℝ≥0∞} : ∑' p : α × β, f p.1 p.2 = ∑' (a) (b), f a b :=
-  tsum_prod' ENNReal.summable fun _ => ENNReal.summable
+  ENNReal.summable.tsum_prod' fun _ => ENNReal.summable
 
 protected theorem tsum_prod' {f : α × β → ℝ≥0∞} : ∑' p : α × β, f p = ∑' (a) (b), f (a, b) :=
-  tsum_prod' ENNReal.summable fun _ => ENNReal.summable
+  ENNReal.summable.tsum_prod' fun _ => ENNReal.summable
 
 protected theorem tsum_comm {f : α → β → ℝ≥0∞} : ∑' a, ∑' b, f a b = ∑' b, ∑' a, f a b :=
-  tsum_comm' ENNReal.summable (fun _ => ENNReal.summable) fun _ => ENNReal.summable
+  ENNReal.summable.tsum_comm' (fun _ => ENNReal.summable) fun _ => ENNReal.summable
 
 protected theorem tsum_add : ∑' a, (f a + g a) = ∑' a, f a + ∑' a, g a :=
-  tsum_add ENNReal.summable ENNReal.summable
+  ENNReal.summable.tsum_add ENNReal.summable
 
 protected theorem tsum_le_tsum (h : ∀ a, f a ≤ g a) : ∑' a, f a ≤ ∑' a, g a :=
-  tsum_le_tsum h ENNReal.summable ENNReal.summable
+  ENNReal.summable.tsum_le_tsum h ENNReal.summable
 
 @[gcongr]
 protected theorem _root_.GCongr.ennreal_tsum_le_tsum (h : ∀ a, f a ≤ g a) : tsum f ≤ tsum g :=
   ENNReal.tsum_le_tsum h
 
 protected theorem sum_le_tsum {f : α → ℝ≥0∞} (s : Finset α) : ∑ x ∈ s, f x ≤ ∑' x, f x :=
-  sum_le_tsum s (fun _ _ => zero_le _) ENNReal.summable
+  ENNReal.summable.sum_le_tsum s (fun _ _ => zero_le _)
 
 protected theorem tsum_eq_iSup_nat' {f : ℕ → ℝ≥0∞} {N : ℕ → ℕ} (hN : Tendsto N atTop atTop) :
     ∑' i : ℕ, f i = ⨆ i : ℕ, ∑ a ∈ Finset.range (N i), f a :=
@@ -754,7 +754,7 @@ theorem tsum_sub {f : ℕ → ℝ≥0∞} {g : ℕ → ℝ≥0∞} (h₁ : ∑' 
 
 theorem tsum_comp_le_tsum_of_injective {f : α → β} (hf : Injective f) (g : β → ℝ≥0∞) :
     ∑' x, g (f x) ≤ ∑' y, g y :=
-  tsum_le_tsum_of_inj f hf (fun _ _ => zero_le _) (fun _ => le_rfl) ENNReal.summable
+  ENNReal.summable.tsum_le_tsum_of_inj f hf (fun _ _ => zero_le _) (fun _ => le_rfl)
     ENNReal.summable
 
 theorem tsum_le_tsum_comp_of_surjective {f : α → β} (hf : Surjective f) (g : β → ℝ≥0∞) :
@@ -794,7 +794,7 @@ theorem tsum_union_le (f : α → ℝ≥0∞) (s t : Set α) :
 open Classical in
 theorem tsum_eq_add_tsum_ite {f : β → ℝ≥0∞} (b : β) :
     ∑' x, f x = f b + ∑' x, ite (x = b) 0 (f x) :=
-  tsum_eq_add_tsum_ite' b ENNReal.summable
+  ENNReal.summable.tsum_eq_add_tsum_ite' b
 
 theorem tsum_add_one_eq_top {f : ℕ → ℝ≥0∞} (hf : ∑' n, f n = ∞) (hf0 : f 0 ≠ ∞) :
     ∑' n, f (n + 1) = ∞ := by
@@ -809,8 +809,8 @@ theorem finite_const_le_of_tsum_ne_top {ι : Type*} {a : ι → ℝ≥0∞} (tsu
   have := Infinite.to_subtype h
   refine tsum_ne_top (top_unique ?_)
   calc ∞ = ∑' _ : { i | ε ≤ a i }, ε := (tsum_const_eq_top_of_ne_zero ε_ne_zero).symm
-  _ ≤ ∑' i, a i := tsum_le_tsum_of_inj (↑) Subtype.val_injective (fun _ _ => zero_le _)
-    (fun i => i.2) ENNReal.summable ENNReal.summable
+  _ ≤ ∑' i, a i := ENNReal.summable.tsum_le_tsum_of_inj (↑)
+    Subtype.val_injective (fun _ _ => zero_le _) (fun i => i.2) ENNReal.summable
 
 /-- Markov's inequality for `Finset.card` and `tsum` in `ℝ≥0∞`. -/
 theorem finset_card_const_le_le_of_tsum_le {ι : Type*} {a : ι → ℝ≥0∞} {c : ℝ≥0∞} (c_ne_top : c ≠ ∞)
@@ -918,11 +918,11 @@ theorem summable_of_sum_range_le {f : ℕ → ℝ≥0} {c : ℝ≥0}
 
 theorem tsum_le_of_sum_range_le {f : ℕ → ℝ≥0} {c : ℝ≥0}
     (h : ∀ n, ∑ i ∈ Finset.range n, f i ≤ c) : ∑' n, f n ≤ c :=
-  _root_.tsum_le_of_sum_range_le (summable_of_sum_range_le h) h
+  (summable_of_sum_range_le h).tsum_le_of_sum_range_le h
 
 theorem tsum_comp_le_tsum_of_inj {β : Type*} {f : α → ℝ≥0} (hf : Summable f) {i : β → α}
     (hi : Function.Injective i) : (∑' x, f (i x)) ≤ ∑' x, f x :=
-  tsum_le_tsum_of_inj i hi (fun _ _ => zero_le _) (fun _ => le_rfl) (summable_comp_injective hf hi)
+  (summable_comp_injective hf hi).tsum_le_tsum_of_inj i hi (fun _ _ => zero_le _) (fun _ => le_rfl)
     hf
 
 theorem summable_sigma {β : α → Type*} {f : (Σ x, β x) → ℝ≥0} :
@@ -946,7 +946,7 @@ theorem tsum_indicator_ne_zero {f : α → ℝ≥0} (hf : Summable f) {s : Set �
     (∑' x, (s.indicator f) x) ≠ 0 := fun h' =>
   let ⟨a, ha, hap⟩ := h
   hap ((Set.indicator_apply_eq_self.mpr (absurd ha)).symm.trans
-    ((tsum_eq_zero_iff (indicator_summable hf s)).1 h' a))
+    ((indicator_summable hf s).tsum_eq_zero_iff.1 h' a))
 
 open Finset
 
@@ -985,7 +985,7 @@ theorem tsum_pos {g : α → ℝ≥0} (hg : Summable g) (i : α) (hi : 0 < g i) 
 open Classical in
 theorem tsum_eq_add_tsum_ite {f : α → ℝ≥0} (hf : Summable f) (i : α) :
     ∑' x, f x = f i + ∑' x, ite (x = i) 0 (f x) := by
-  refine tsum_eq_add_tsum_ite' i (NNReal.summable_of_le (fun i' => ?_) hf)
+  refine (NNReal.summable_of_le (fun i' => ?_) hf).tsum_eq_add_tsum_ite' i
   rw [Function.update_apply]
   split_ifs <;> simp only [zero_le', le_rfl]
 
@@ -1011,7 +1011,7 @@ theorem tendsto_sum_nat_add (f : ℕ → ℝ≥0∞) (hf : ∑' i, f i ≠ ∞) 
 
 theorem tsum_le_of_sum_range_le {f : ℕ → ℝ≥0∞} {c : ℝ≥0∞}
     (h : ∀ n, ∑ i ∈ Finset.range n, f i ≤ c) : ∑' n, f n ≤ c :=
-  _root_.tsum_le_of_sum_range_le ENNReal.summable h
+  ENNReal.summable.tsum_le_of_sum_range_le h
 
 theorem hasSum_lt {f g : α → ℝ≥0∞} {sf sg : ℝ≥0∞} {i : α} (h : ∀ a : α, f a ≤ g a) (hi : f i < g i)
     (hsf : sf ≠ ∞) (hf : HasSum f sf) (hg : HasSum g sg) : sf < sg := by
@@ -1274,7 +1274,7 @@ theorem edist_le_tsum_of_edist_le_of_tendsto {f : ℕ → α} (d : ℕ → ℝ�
   change edist _ _ ≤ _
   refine le_trans (edist_le_Ico_sum_of_edist_le hnm fun _ _ => hf _) ?_
   rw [Finset.sum_Ico_eq_sum_range]
-  exact sum_le_tsum _ (fun _ _ => zero_le _) ENNReal.summable
+  exact ENNReal.summable.sum_le_tsum _ (fun _ _ => zero_le _)
 
 /-- If `edist (f n) (f (n+1))` is bounded above by a function `d : ℕ → ℝ≥0∞`,
 then the distance from `f 0` to the limit is bounded by `∑'_{k=0}^∞ d k`. -/

--- a/Mathlib/Topology/Instances/NNReal/Lemmas.lean
+++ b/Mathlib/Topology/Instances/NNReal/Lemmas.lean
@@ -172,7 +172,7 @@ nonrec theorem hasSum_nat_add_iff {f : ℕ → ℝ≥0} (k : ℕ) {a : ℝ≥0} 
 
 theorem sum_add_tsum_nat_add {f : ℕ → ℝ≥0} (k : ℕ) (hf : Summable f) :
     ∑' i, f i = (∑ i ∈ range k, f i) + ∑' i, f (i + k) :=
-  (sum_add_tsum_nat_add' <| (summable_nat_add_iff k).2 hf).symm
+  (((summable_nat_add_iff k).2 hf).sum_add_tsum_nat_add').symm
 
 theorem iInf_real_pos_eq_iInf_nnreal_pos [CompleteLattice α] {f : ℝ → α} :
     ⨅ (n : ℝ) (_ : 0 < n), f n = ⨅ (n : ℝ≥0) (_ : 0 < n), f n :=

--- a/Mathlib/Topology/MetricSpace/PiNat.lean
+++ b/Mathlib/Topology/MetricSpace/PiNat.lean
@@ -787,7 +787,7 @@ theorem dist_summable (x y : ∀ i, F i) :
 
 theorem min_dist_le_dist_pi (x y : ∀ i, F i) (i : ι) :
     min ((1 / 2) ^ encode i : ℝ) (dist (x i) (y i)) ≤ dist x y :=
-  le_tsum (dist_summable x y) i fun j _ => le_min (by simp) dist_nonneg
+  (dist_summable x y).le_tsum i fun j _ => le_min (by simp) dist_nonneg
 
 theorem dist_le_dist_pi_of_dist_lt {x y : ∀ i, F i} {i : ι} (h : dist x y < (1 / 2) ^ encode i) :
     dist (x i) (y i) ≤ dist x y := by
@@ -822,8 +822,8 @@ protected def metricSpace : MetricSpace (∀ i, F i) where
           min_le_right _ _
     calc dist x z ≤ ∑' i, (min ((1 / 2) ^ encode i : ℝ) (dist (x i) (y i)) +
           min ((1 / 2) ^ encode i : ℝ) (dist (y i) (z i))) :=
-        tsum_le_tsum I (dist_summable x z) ((dist_summable x y).add (dist_summable y z))
-      _ = dist x y + dist y z := tsum_add (dist_summable x y) (dist_summable y z)
+        (dist_summable x z).tsum_le_tsum I ((dist_summable x y).add (dist_summable y z))
+      _ = dist x y + dist y z := (dist_summable x y).tsum_add (dist_summable y z)
   eq_of_dist_eq_zero hxy := by
     ext1 n
     rw [← dist_le_zero, ← hxy]
@@ -855,11 +855,11 @@ protected def metricSpace : MetricSpace (∀ i, F i) where
           dist x y = ∑' i : ι, min ((1 / 2) ^ encode i : ℝ) (dist (x i) (y i)) := rfl
           _ = (∑ i ∈ K, min ((1 / 2) ^ encode i : ℝ) (dist (x i) (y i))) +
                 ∑' i : ↑(K : Set ι)ᶜ, min ((1 / 2) ^ encode (i : ι) : ℝ) (dist (x i) (y i)) :=
-            (sum_add_tsum_compl (dist_summable _ _)).symm
+            (Summable.sum_add_tsum_compl (dist_summable _ _)).symm
           _ ≤ (∑ i ∈ K, dist (x i) (y i)) +
                 ∑' i : ↑(K : Set ι)ᶜ, ((1 / 2) ^ encode (i : ι) : ℝ) := by
             refine add_le_add (Finset.sum_le_sum fun i _ => min_le_right _ _) ?_
-            refine tsum_le_tsum (fun i => min_le_left _ _) ?_ ?_
+            refine Summable.tsum_le_tsum (fun i => min_le_left _ _) ?_ ?_
             · apply Summable.subtype (dist_summable x y) (↑K : Set ι)ᶜ
             · apply Summable.subtype summable_geometric_two_encode (↑K : Set ι)ᶜ
           _ < (∑ _i ∈ K, δ) + ε / 2 := by

--- a/Mathlib/Topology/UrysohnsLemma.lean
+++ b/Mathlib/Topology/UrysohnsLemma.lean
@@ -457,13 +457,13 @@ theorem exists_continuous_one_zero_of_isCompact_of_isGδ [RegularSpace X] [Local
     have fnx : f n x = 0 := fm _ (by simp [hn])
     have : g x < 1 := by
       apply lt_of_lt_of_le ?_ hu.le
-      exact tsum_lt_tsum (i := n) (fun i ↦ I i x) (by simp [fnx, u_pos n]) (S x) u_sum
+      exact (S x).tsum_lt_tsum (i := n) (fun i ↦ I i x) (by simp [fnx, u_pos n]) u_sum
     simpa using this.ne
   · exact HasCompactSupport.of_support_subset_isCompact m_comp
       (Function.support_subset_iff'.mpr hgmc)
   · exact tsum_nonneg (fun n ↦ mul_nonneg (u_pos n).le (f_range n x).1)
   · apply le_trans _ hu.le
-    exact tsum_le_tsum (fun n ↦ I n x) (S x) u_sum
+    exact (S x).tsum_le_tsum (fun n ↦ I n x) u_sum
 
 /-- A variation of Urysohn's lemma. In a `T2Space X`, for a closed set `t` and a relatively
 compact open set `s` such that `t ⊆ s`, there is a continuous function `f` supported in `s`,


### PR DESCRIPTION
As per [zulip discussion](https://leanprover.zulipchat.com/#narrow/channel/144837-PR-reviews/topic/.2323503.20ENat.20and.20tsum), this PR renames lemmas of the form 

`theorem tprod_foo {f : a -> b} (Multipliable f) : _` 

to 

`protected theorem Multipliable.tprod_foo {f : a -> b} (Multipliable f) : _`,

and similar for `tsum`/`Summable`, usually via `to_additive`. This is so the name `tprod_foo` (and by extension `tsum_foo`) is freed up for planned versions of the lemmas in settings where multipliabilty/summability automatically holds (such as `ENat` and `ENNReal` for summability). 

We also deprecate all the old names. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
