### PR TITLE
[Merged by Bors] - feat: add LinearEquiv.ofInjectiveOfFinrankEq

### DIFF
--- a/Mathlib/LinearAlgebra/FiniteDimensional/Basic.lean
+++ b/Mathlib/LinearAlgebra/FiniteDimensional/Basic.lean
@@ -409,10 +409,10 @@ noncomputable def ofInjectiveOfFinrankEq (f : V →ₗ[K] V') (hinj : Function.I
   (ofInjective f hinj).trans (ofTop (LinearMap.range f) this)
 
 @[simp]
-lemma ofInjectiveOfFinrankEq_coe (f : V →ₗ[K] V') (hinj : Function.Injective f)
+lemma coe_ofInjectiveOfFinrankEq (f : V →ₗ[K] V') (hinj : Function.Injective f)
     (hrank : Module.finrank K V = Module.finrank K V') :
-    (ofInjectiveOfFinrankEq f hinj hrank).toLinearMap = f := rfl
-
+    (ofInjectiveOfFinrankEq f hinj hrank).toLinearMap = f :=
+  rfl
 end LinearEquiv
 
 namespace LinearMap

--- a/Mathlib/LinearAlgebra/FiniteDimensional/Basic.lean
+++ b/Mathlib/LinearAlgebra/FiniteDimensional/Basic.lean
@@ -399,7 +399,7 @@ omit [FiniteDimensional K V]
 /-- An injective linear map between finite-dimensional modules of equal rank
 is a linear equivalence.
 
-Unlike `LinearEquiv.ofFinrankEq` (which creates an *abstract* linear equivalence between `V` and `V'`),
+Unlike `LinearEquiv.ofFinrankEq` (which creates an *abstract* linear equivalence from `V` to `V'`),
 this lemma improves a *given* injective linear map to a linear equivalence.
 -/
 noncomputable def ofInjectiveOfFinrankEq (f : V →ₗ[K] V') (hinj : Function.Injective f)

--- a/Mathlib/LinearAlgebra/FiniteDimensional/Basic.lean
+++ b/Mathlib/LinearAlgebra/FiniteDimensional/Basic.lean
@@ -398,7 +398,7 @@ omit [FiniteDimensional K V]
 
 /-- An injective linear map between finite-dimensional space of equal rank
 is a linear equivalence. -/
-noncomputable def of_injective_finrank_eq (f : V →ₗ[K] V') (hinj : Function.Injective f)
+noncomputable def ofInjectiveOfFinrankEq (f : V →ₗ[K] V') (hinj : Function.Injective f)
     (hrank : Module.finrank K V = Module.finrank K V') : V ≃ₗ[K] V' :=
   haveI : LinearMap.range f = ⊤ :=
     Submodule.eq_top_of_finrank_eq ((LinearMap.finrank_range_of_inj hinj).trans hrank)

--- a/Mathlib/LinearAlgebra/FiniteDimensional/Basic.lean
+++ b/Mathlib/LinearAlgebra/FiniteDimensional/Basic.lean
@@ -393,6 +393,22 @@ theorem ofInjectiveEndo_left_inv (f : V →ₗ[K] V) (h_inj : Injective f) :
     ((ofInjectiveEndo f h_inj).symm : V →ₗ[K] V) * f = 1 :=
   LinearMap.ext <| (ofInjectiveEndo f h_inj).symm_apply_apply
 
+variable {V' : Type*} [AddCommGroup V'] [Module K V'] [FiniteDimensional K V']
+omit [FiniteDimensional K V]
+
+/-- An injective linear map between finite-dimensional space of equal rank
+is a linear equivalence. -/
+noncomputable def of_injective_finrank_eq (f : V →ₗ[K] V') (hinj : Function.Injective f)
+    (hrank : Module.finrank K V = Module.finrank K V') : V ≃ₗ[K] V' :=
+  haveI : LinearMap.range f = ⊤ :=
+    Submodule.eq_top_of_finrank_eq ((LinearMap.finrank_range_of_inj hinj).trans hrank)
+  (ofInjective f hinj).trans (ofTop (LinearMap.range f) this)
+
+@[simp]
+lemma of_injective_finrank_eq_coe (f : V →ₗ[K] V') (hinj : Function.Injective f)
+    (hrank : Module.finrank K V = Module.finrank K V') :
+    (of_injective_finrank_eq f hinj hrank).toLinearMap = f := rfl
+
 end LinearEquiv
 
 namespace LinearMap

--- a/Mathlib/LinearAlgebra/FiniteDimensional/Basic.lean
+++ b/Mathlib/LinearAlgebra/FiniteDimensional/Basic.lean
@@ -405,9 +405,9 @@ noncomputable def ofInjectiveOfFinrankEq (f : V →ₗ[K] V') (hinj : Function.I
   (ofInjective f hinj).trans (ofTop (LinearMap.range f) this)
 
 @[simp]
-lemma of_injective_finrank_eq_coe (f : V →ₗ[K] V') (hinj : Function.Injective f)
+lemma ofInjectiveOfFinrankEq_coe (f : V →ₗ[K] V') (hinj : Function.Injective f)
     (hrank : Module.finrank K V = Module.finrank K V') :
-    (of_injective_finrank_eq f hinj hrank).toLinearMap = f := rfl
+    (ofInjectiveOfFinrankEq f hinj hrank).toLinearMap = f := rfl
 
 end LinearEquiv
 

--- a/Mathlib/LinearAlgebra/FiniteDimensional/Basic.lean
+++ b/Mathlib/LinearAlgebra/FiniteDimensional/Basic.lean
@@ -398,6 +398,7 @@ omit [FiniteDimensional K V]
 
 /-- An injective linear map between finite-dimensional modules of equal rank
 is a linear equivalence.
+
 Unlike `LinearEquiv.ofFinrankEq` (which creates an *abstract* linear equivalence between `V` and `V'`),
 this lemma improves a *given* injective linear map to a linear equivalence.
 -/

--- a/Mathlib/LinearAlgebra/FiniteDimensional/Basic.lean
+++ b/Mathlib/LinearAlgebra/FiniteDimensional/Basic.lean
@@ -396,8 +396,11 @@ theorem ofInjectiveEndo_left_inv (f : V →ₗ[K] V) (h_inj : Injective f) :
 variable {V' : Type*} [AddCommGroup V'] [Module K V'] [FiniteDimensional K V']
 omit [FiniteDimensional K V]
 
-/-- An injective linear map between finite-dimensional space of equal rank
-is a linear equivalence. -/
+/-- An injective linear map between finite-dimensional modules of equal rank
+is a linear equivalence.
+Unlike `LinearEquiv.ofFinrankEq` (which creates an *abstract* linear equivalence between `V` and `V'`),
+this lemma improves a *given* injective linear map to a linear equivalence.
+-/
 noncomputable def ofInjectiveOfFinrankEq (f : V →ₗ[K] V') (hinj : Function.Injective f)
     (hrank : Module.finrank K V = Module.finrank K V') : V ≃ₗ[K] V' :=
   haveI : LinearMap.range f = ⊤ :=

--- a/Mathlib/LinearAlgebra/FiniteDimensional/Defs.lean
+++ b/Mathlib/LinearAlgebra/FiniteDimensional/Defs.lean
@@ -238,20 +238,4 @@ protected theorem finiteDimensional (f : V ≃ₗ[K] V₂) [FiniteDimensional K 
     FiniteDimensional K V₂ :=
   Module.Finite.equiv f
 
-variable {R R₂ M M₂ : Type*} [DivisionRing R] [Semiring R₂] [AddCommMonoid M] [AddCommGroup M₂]
-  [Module R M] [Module R M₂] [FiniteDimensional R M₂]
-
-/-- An injective linear map between finite-dimensional space of equal rank
-is a linear equivalence. -/
-noncomputable def of_injective_finrank_eq (f : M →ₗ[R] M₂) (hinj : Function.Injective f)
-    (hrank : Module.finrank R M = Module.finrank R M₂) : M ≃ₗ[R] M₂ :=
-  haveI : LinearMap.range f = ⊤ :=
-    Submodule.eq_top_of_finrank_eq ((LinearMap.finrank_range_of_inj hinj).trans hrank)
-  (ofInjective f hinj).trans (ofTop (LinearMap.range f) this)
-
-@[simp]
-lemma of_injective_finrank_eq_coe (f : M →ₗ[R] M₂) (hinj : Function.Injective f)
-    (hrank : Module.finrank R M = Module.finrank R M₂) :
-    (of_injective_finrank_eq f hinj hrank).toLinearMap = f := rfl
-
 end LinearEquiv

--- a/Mathlib/LinearAlgebra/FiniteDimensional/Defs.lean
+++ b/Mathlib/LinearAlgebra/FiniteDimensional/Defs.lean
@@ -238,4 +238,20 @@ protected theorem finiteDimensional (f : V ≃ₗ[K] V₂) [FiniteDimensional K 
     FiniteDimensional K V₂ :=
   Module.Finite.equiv f
 
+variable {R R₂ M M₂ : Type*} [DivisionRing R] [Semiring R₂] [AddCommMonoid M] [AddCommGroup M₂]
+  [Module R M] [Module R M₂] [FiniteDimensional R M₂]
+
+/-- An injective linear map between finite-dimensional space of equal rank
+is a linear equivalence. -/
+noncomputable def of_injective_finrank_eq (f : M →ₗ[R] M₂) (hinj : Function.Injective f)
+    (hrank : Module.finrank R M = Module.finrank R M₂) : M ≃ₗ[R] M₂ :=
+  haveI : LinearMap.range f = ⊤ :=
+    Submodule.eq_top_of_finrank_eq ((LinearMap.finrank_range_of_inj hinj).trans hrank)
+  (ofInjective f hinj).trans (ofTop (LinearMap.range f) this)
+
+@[simp]
+lemma of_injective_finrank_eq_coe (f : M →ₗ[R] M₂) (hinj : Function.Injective f)
+    (hrank : Module.finrank R M = Module.finrank R M₂) :
+    (of_injective_finrank_eq f hinj hrank).toLinearMap = f := rfl
+
 end LinearEquiv


### PR DESCRIPTION
This is used in #22611.

---

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
