### PR TITLE
[Merged by Bors] - feat(MeasureTheory): characteristic function in an inner product space

### DIFF
--- a/Mathlib/Analysis/Complex/Circle.lean
+++ b/Mathlib/Analysis/Complex/Circle.lean
@@ -212,7 +212,7 @@ theorem fourierChar_ne_one : fourierChar ≠ 1 := by
   rw [mul_comm, ← mul_assoc, inv_mul_cancel₀ (by positivity), one_mul]
   exact Circle.exp_pi_ne_one
 
-/-- The additive character from `ℝ` onto the circle, given by `fun x ↦ exp (2 * I)`. This uses the
+/-- The additive character from `ℝ` onto the circle, given by `fun x ↦ exp (x * I)`. This uses the
 probabilist convention that there is no `2 * π` in the exponent. -/
 def probChar : AddChar ℝ Circle where
   toFun := Circle.exp

--- a/Mathlib/Analysis/Fourier/FourierTransform.lean
+++ b/Mathlib/Analysis/Fourier/FourierTransform.lean
@@ -222,7 +222,7 @@ end Fubini
 
 lemma fourierIntegral_probChar {V W : Type*} {_ : MeasurableSpace V}
     [AddCommGroup V] [Module ℝ V] [AddCommGroup W] [Module ℝ W]
-    (L : V →ₗ[ℝ] W →ₗ[ℝ] ℝ) (μ : MeasureTheory.Measure V) (f : V → E) (w : W) :
+    (L : V →ₗ[ℝ] W →ₗ[ℝ] ℝ) (μ : Measure V) (f : V → E) (w : W) :
     fourierIntegral Real.probChar μ L f w =
       ∫ v : V, Complex.exp (- L v w * Complex.I) • f v ∂μ := by
   simp_rw [fourierIntegral, Circle.smul_def, Real.probChar_apply, Complex.ofReal_neg]

--- a/Mathlib/Analysis/Fourier/FourierTransform.lean
+++ b/Mathlib/Analysis/Fourier/FourierTransform.lean
@@ -223,9 +223,9 @@ end Fubini
 lemma fourierIntegral_probChar {V W : Type*} {_ : MeasurableSpace V}
     [AddCommGroup V] [Module ℝ V] [AddCommGroup W] [Module ℝ W]
     (L : V →ₗ[ℝ] W →ₗ[ℝ] ℝ) (μ : MeasureTheory.Measure V) (f : V → E) (w : W) :
-    VectorFourier.fourierIntegral Real.probChar μ L f w =
+    fourierIntegral Real.probChar μ L f w =
       ∫ v : V, Complex.exp (- L v w * Complex.I) • f v ∂μ := by
-  simp_rw [VectorFourier.fourierIntegral, Circle.smul_def, Real.probChar_apply, Complex.ofReal_neg]
+  simp_rw [fourierIntegral, Circle.smul_def, Real.probChar_apply, Complex.ofReal_neg]
 
 end VectorFourier
 

--- a/Mathlib/Analysis/Fourier/FourierTransform.lean
+++ b/Mathlib/Analysis/Fourier/FourierTransform.lean
@@ -220,6 +220,13 @@ theorem integral_fourierIntegral_smul_eq_flip
 
 end Fubini
 
+lemma fourierIntegral_probChar {V W : Type*} {_ : MeasurableSpace V}
+    [AddCommGroup V] [Module ℝ V] [AddCommGroup W] [Module ℝ W]
+    (L : V →ₗ[ℝ] W →ₗ[ℝ] ℝ) (μ : MeasureTheory.Measure V) (f : V → E) (w : W) :
+    VectorFourier.fourierIntegral Real.probChar μ L f w =
+      ∫ v : V, Complex.exp (- L v w * Complex.I) • f v ∂μ := by
+  simp_rw [VectorFourier.fourierIntegral, Circle.smul_def, Real.probChar_apply, Complex.ofReal_neg]
+
 end VectorFourier
 
 namespace VectorFourier

--- a/Mathlib/MeasureTheory/Measure/CharacteristicFunction.lean
+++ b/Mathlib/MeasureTheory/Measure/CharacteristicFunction.lean
@@ -182,8 +182,7 @@ theorem Measure.ext_of_charFun {E : Type*} [MeasurableSpace E]
     [SecondCountableTopology E] {μ ν : Measure E} [IsFiniteMeasure μ] [IsFiniteMeasure ν]
     (h : charFun μ = charFun ν) :
     μ = ν := by
-  rw [funext_iff] at h
-  simp_rw [charFun_eq_integral_innerProbChar] at h
+  simp_rw [funext_iff, charFun_eq_integral_innerProbChar] at h
   refine ext_of_integral_char_eq continuous_probChar probChar_ne_one (L := bilinFormOfRealInner)
     ?_ ?_ h
   · exact fun v hv ↦ DFunLike.ne_iff.mpr ⟨v, inner_self_ne_zero.mpr hv⟩

--- a/Mathlib/MeasureTheory/Measure/CharacteristicFunction.lean
+++ b/Mathlib/MeasureTheory/Measure/CharacteristicFunction.lean
@@ -25,7 +25,7 @@ and `L`.
 ## Main definitions
 
 * `innerProbChar`: the bounded continuous map `x ↦ exp(⟪x, t⟫ * I)` in an inner product space.
-  This is `char` for the inner product bilinear map and the additive character `e = Real.probChar`.
+  This is `char` for the inner product bilinear map and the additive character `e = probChar`.
 * `charFun μ t`: the characteristic function of a measure `μ` at `t` in an inner product space `E`.
   This is defined as `∫ x, exp (⟪x, t⟫ * I) ∂μ`, where `⟪x, t⟫` is the inner product on `E`.
   It is equal to `∫ v, innerProbChar w v ∂P` (see `charFun_eq_integral_innerProbChar`).
@@ -48,7 +48,7 @@ variable {E : Type*} [SeminormedAddCommGroup E] [InnerProductSpace ℝ E]
 /-- The bounded continuous map `x ↦ exp(⟪x, t⟫ * I)`. -/
 noncomputable
 def innerProbChar (t : E) : BoundedContinuousFunction E ℂ :=
-  char Real.continuous_probChar (L := bilinFormOfRealInner) continuous_inner t
+  char continuous_probChar (L := bilinFormOfRealInner) continuous_inner t
 
 lemma innerProbChar_apply (t x : E) : innerProbChar t x = exp (⟪x, t⟫ * I) := rfl
 
@@ -120,12 +120,12 @@ lemma charFun_neg (t : E) : charFun μ (-t) = conj (charFun μ t) := by
 lemma charFun_eq_integral_innerProbChar : charFun μ t = ∫ v, innerProbChar t v ∂μ := by
   simp [charFun_apply, innerProbChar_apply]
 
-lemma charFun_eq_integral_probChar (y : E) : charFun μ y = ∫ x, (Real.probChar ⟪x, y⟫ : ℂ) ∂μ := by
-  simp [charFun_apply, Real.probChar_apply]
+lemma charFun_eq_integral_probChar (y : E) : charFun μ y = ∫ x, (probChar ⟪x, y⟫ : ℂ) ∂μ := by
+  simp [charFun_apply, probChar_apply]
 
 /-- `charFun` is a Fourier integral for the inner product and the character `probChar`. -/
 lemma charFun_eq_fourierIntegral (t : E) :
-    charFun μ t = VectorFourier.fourierIntegral Real.probChar μ sesqFormOfInner 1 (-t) := by
+    charFun μ t = VectorFourier.fourierIntegral probChar μ sesqFormOfInner 1 (-t) := by
   simp only [charFun_apply, real_smul, VectorFourier.fourierIntegral_probChar, Pi.one_apply,
     smul_eq_mul, mul_one, map_neg, ofReal_neg, neg_neg]
   simp_rw [real_inner_comm t]
@@ -133,10 +133,10 @@ lemma charFun_eq_fourierIntegral (t : E) :
 
 /-- `charFun` is a Fourier integral for the inner product and the character `fourierChar`. -/
 lemma charFun_eq_fourierIntegral' (t : E) :
-    charFun μ t = VectorFourier.fourierIntegral Real.fourierChar μ
-      sesqFormOfInner 1 (-(2 * π)⁻¹ • t) := by
-  have h : (2 : ℂ) * π ≠ 0 := by simp [Real.pi_ne_zero]
-  simp only [charFun_apply, real_smul, VectorFourier.fourierIntegral, Real.fourierChar, neg_smul,
+    charFun μ t
+      = VectorFourier.fourierIntegral fourierChar μ sesqFormOfInner 1 (-(2 * π)⁻¹ • t) := by
+  have h : (2 : ℂ) * π ≠ 0 := by simp [pi_ne_zero]
+  simp only [charFun_apply, real_smul, VectorFourier.fourierIntegral, fourierChar, neg_smul,
     map_neg, _root_.map_smul, smul_eq_mul, neg_neg, AddChar.coe_mk, ← mul_assoc, Pi.one_apply,
     Circle.smul_def, Circle.coe_exp, ofReal_mul, ofReal_ofNat, ofReal_inv, mul_inv_cancel₀ h,
     one_mul, mul_one]

--- a/Mathlib/MeasureTheory/Measure/CharacteristicFunction.lean
+++ b/Mathlib/MeasureTheory/Measure/CharacteristicFunction.lean
@@ -120,7 +120,7 @@ lemma charFun_neg (t : E) : charFun μ (-t) = conj (charFun μ t) := by
 lemma charFun_eq_integral_innerProbChar : charFun μ t = ∫ v, innerProbChar t v ∂μ := by
   simp [charFun_apply, innerProbChar_apply]
 
-lemma charFun_eq_integral_probChar (y : E) : charFun μ y = ∫ x, (probChar ⟪x, y⟫ : ℂ) ∂μ := by
+lemma charFun_eq_integral_probChar (t : E) : charFun μ t = ∫ x, (probChar ⟪x, t⟫ : ℂ) ∂μ := by
   simp [charFun_apply, probChar_apply]
 
 /-- `charFun` is a Fourier integral for the inner product and the character `probChar`. -/

--- a/Mathlib/MeasureTheory/Measure/CharacteristicFunction.lean
+++ b/Mathlib/MeasureTheory/Measure/CharacteristicFunction.lean
@@ -125,23 +125,19 @@ lemma charFun_eq_integral_probChar (y : E) : charFun μ y = ∫ x, (probChar ⟪
 
 /-- `charFun` is a Fourier integral for the inner product and the character `probChar`. -/
 lemma charFun_eq_fourierIntegral (t : E) :
-    charFun μ t = VectorFourier.fourierIntegral probChar μ sesqFormOfInner 1 (-t) := by
-  simp only [charFun_apply, real_smul, VectorFourier.fourierIntegral_probChar, Pi.one_apply,
-    smul_eq_mul, mul_one, map_neg, ofReal_neg, neg_neg]
-  simp_rw [real_inner_comm t]
-  congr
+    charFun μ t = VectorFourier.fourierIntegral probChar μ bilinFormOfRealInner 1 (-t) := by
+  simp [charFun_apply, VectorFourier.fourierIntegral_probChar]
 
 /-- `charFun` is a Fourier integral for the inner product and the character `fourierChar`. -/
 lemma charFun_eq_fourierIntegral' (t : E) :
     charFun μ t
-      = VectorFourier.fourierIntegral fourierChar μ sesqFormOfInner 1 (-(2 * π)⁻¹ • t) := by
-  have h : (2 : ℂ) * π ≠ 0 := by simp [pi_ne_zero]
-  simp only [charFun_apply, real_smul, VectorFourier.fourierIntegral, fourierChar, neg_smul,
-    map_neg, _root_.map_smul, smul_eq_mul, neg_neg, AddChar.coe_mk, ← mul_assoc, Pi.one_apply,
-    Circle.smul_def, Circle.coe_exp, ofReal_mul, ofReal_ofNat, ofReal_inv, mul_inv_cancel₀ h,
-    one_mul, mul_one]
-  simp_rw [real_inner_comm t]
-  congr
+      = VectorFourier.fourierIntegral fourierChar μ bilinFormOfRealInner 1 (-(2 * π)⁻¹ • t) := by
+  simp only [charFun_apply, VectorFourier.fourierIntegral, neg_smul,
+    bilinFormOfRealInner_apply_apply, inner_neg_right, inner_smul_right, neg_neg,
+    fourierChar_apply', Pi.ofNat_apply, Circle.smul_def, Circle.coe_exp, ofReal_mul, ofReal_ofNat,
+    ofReal_inv, smul_eq_mul, mul_one]
+  congr with x
+  rw [← mul_assoc, mul_inv_cancel₀ (by simp [pi_ne_zero]), one_mul]
 
 lemma norm_charFun_le (t : E) : ‖charFun μ t‖ ≤ (μ Set.univ).toReal := by
   rw [charFun_eq_fourierIntegral]

--- a/Mathlib/MeasureTheory/Measure/CharacteristicFunction.lean
+++ b/Mathlib/MeasureTheory/Measure/CharacteristicFunction.lean
@@ -1,9 +1,10 @@
 /-
 Copyright (c) 2024 Jakob Stiefel. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Jakob Stiefel
+Authors: Jakob Stiefel, Rémy Degenne, Thomas Zhu
 -/
 import Mathlib.Analysis.Fourier.BoundedContinuousFunctionChar
+import Mathlib.Analysis.Fourier.FourierTransform
 import Mathlib.MeasureTheory.Measure.FiniteMeasureExt
 
 /-!
@@ -21,18 +22,40 @@ The integral is expressed as `∫ v, char he hL w v ∂P`, where `char he hL w` 
 bounded continuous function `fun v ↦ e (L v w)` and `he`, `hL` are continuity hypotheses on `e`
 and `L`.
 
-## Main definition
+## Main definitions
 
-TODO: give a definition of the characteristic function for standard choices of `e` and `L`.
+* `innerProbChar`: the bounded continuous map `x ↦ exp(⟪x, t⟫ * I)` in an inner product space.
+  This is `char` for the inner product bilinear map and the additive character `e = Real.probChar`.
+* `charFun μ t`: the characteristic function of a measure `μ` at `t` in an inner product space `E`.
+  This is defined as `∫ x, exp (⟪x, t⟫ * I) ∂μ`, where `⟪x, t⟫` is the inner product on `E`.
+  It is equal to `∫ v, innerProbChar w v ∂P` (see `charFun_eq_integral_innerProbChar`).
 
 ## Main statements
 
-- `ext_of_integral_char_eq`: Assume `e` and `L` are non-trivial. If the integrals of `char`
+* `ext_of_integral_char_eq`: Assume `e` and `L` are non-trivial. If the integrals of `char`
   with respect to two finite measures `P` and `P'` coincide, then `P = P'`.
+* `Measure.ext_of_charFun`: If the characteristic functions `charFun` of two finite measures
+  `μ` and `ν` on a complete second-countable inner product space coincide, then `μ = ν`.
 
 -/
 
-open BoundedContinuousFunction
+open BoundedContinuousFunction RealInnerProductSpace Real Complex ComplexConjugate
+
+namespace BoundedContinuousFunction
+
+variable {E : Type*} [SeminormedAddCommGroup E] [InnerProductSpace ℝ E]
+
+/-- The bounded continuous map `x ↦ exp(⟪x, t⟫ * I)`. -/
+noncomputable
+def innerProbChar (t : E) : BoundedContinuousFunction E ℂ :=
+  char Real.continuous_probChar (L := bilinFormOfRealInner) continuous_inner t
+
+lemma innerProbChar_apply (t x : E) : innerProbChar t x = exp (⟪x, t⟫ * I) := rfl
+
+@[simp]
+lemma innerProbChar_zero : innerProbChar (0 : E) = 1 := by simp [innerProbChar]
+
+end BoundedContinuousFunction
 
 namespace MeasureTheory
 
@@ -67,5 +90,109 @@ theorem ext_of_integral_char_eq (he : Continuous e) (he' : e ≠ 1)
   exact Or.inl (h i)
 
 end ext
+
+section InnerProductSpace
+
+variable {E : Type*} [MeasurableSpace E] {μ : Measure E} {t : E}
+
+/-- The characteristic function of a measure in an inner product space. -/
+noncomputable def charFun [Inner ℝ E] (μ : Measure E) (t : E) : ℂ := ∫ x, exp (⟪x, t⟫ * I) ∂μ
+
+lemma charFun_apply [Inner ℝ E] (t : E) : charFun μ t = ∫ x, exp (⟪x, t⟫ * I) ∂μ := rfl
+
+lemma charFun_apply_real {μ : Measure ℝ} {t : ℝ} :
+    charFun μ t = ∫ x, exp (t * x * I) ∂μ := by simp [charFun_apply]
+
+variable [SeminormedAddCommGroup E] [InnerProductSpace ℝ E]
+
+@[simp]
+lemma charFun_zero (μ : Measure E) : charFun μ 0 = (μ Set.univ).toReal := by
+  simp [charFun_apply]
+
+@[simp]
+lemma charFun_zero_measure : charFun (0 : Measure E) t = 0 := by simp [charFun_apply]
+
+@[simp]
+lemma charFun_neg (t : E) : charFun μ (-t) = conj (charFun μ t) := by
+  simp [charFun_apply, ← integral_conj, ← exp_conj]
+
+/-- `charFun` as the integral of a bounded continuous function. -/
+lemma charFun_eq_integral_innerProbChar : charFun μ t = ∫ v, innerProbChar t v ∂μ := by
+  simp [charFun_apply, innerProbChar_apply]
+
+lemma charFun_eq_integral_probChar (y : E) : charFun μ y = ∫ x, (Real.probChar ⟪x, y⟫ : ℂ) ∂μ := by
+  simp [charFun_apply, Real.probChar_apply]
+
+/-- `charFun` is a Fourier integral for the inner product and the character `probChar`. -/
+lemma charFun_eq_fourierIntegral (t : E) :
+    charFun μ t = VectorFourier.fourierIntegral Real.probChar μ sesqFormOfInner 1 (-t) := by
+  simp only [charFun_apply, real_smul, VectorFourier.fourierIntegral_probChar, Pi.one_apply,
+    smul_eq_mul, mul_one, map_neg, ofReal_neg, neg_neg]
+  simp_rw [real_inner_comm t]
+  congr
+
+/-- `charFun` is a Fourier integral for the inner product and the character `fourierChar`. -/
+lemma charFun_eq_fourierIntegral' (t : E) :
+    charFun μ t = VectorFourier.fourierIntegral Real.fourierChar μ
+      sesqFormOfInner 1 (-(2 * π)⁻¹ • t) := by
+  have h : (2 : ℂ) * π ≠ 0 := by simp [Real.pi_ne_zero]
+  simp only [charFun_apply, real_smul, VectorFourier.fourierIntegral, Real.fourierChar, neg_smul,
+    map_neg, _root_.map_smul, smul_eq_mul, neg_neg, AddChar.coe_mk, ← mul_assoc, Pi.one_apply,
+    Circle.smul_def, Circle.coe_exp, ofReal_mul, ofReal_ofNat, ofReal_inv, mul_inv_cancel₀ h,
+    one_mul, mul_one]
+  simp_rw [real_inner_comm t]
+  congr
+
+lemma norm_charFun_le (t : E) : ‖charFun μ t‖ ≤ (μ Set.univ).toReal := by
+  rw [charFun_eq_fourierIntegral]
+  exact (VectorFourier.norm_fourierIntegral_le_integral_norm _ _ _ _ _).trans_eq (by simp)
+
+lemma norm_charFun_le_one [IsProbabilityMeasure μ] (t : E) : ‖charFun μ t‖ ≤ 1 :=
+  (norm_charFun_le _).trans_eq (by simp)
+
+lemma norm_one_sub_charFun_le_two [IsProbabilityMeasure μ] : ‖1 - charFun μ t‖ ≤ 2 :=
+  calc ‖1 - charFun μ t‖
+  _ ≤ ‖(1 : ℂ)‖ + ‖charFun μ t‖ := norm_sub_le _ _
+  _ ≤ 1 + 1 := by simp [norm_charFun_le_one]
+  _ = 2 := by norm_num
+
+lemma stronglyMeasurable_charFun [OpensMeasurableSpace E] [SecondCountableTopology E] [SFinite μ] :
+    StronglyMeasurable (charFun μ) :=
+  (Measurable.stronglyMeasurable (by fun_prop)).integral_prod_left
+
+@[fun_prop]
+lemma measurable_charFun [OpensMeasurableSpace E] [SecondCountableTopology E] [SFinite μ] :
+    Measurable (charFun μ) :=
+  stronglyMeasurable_charFun.measurable
+
+lemma intervalIntegrable_charFun {μ : Measure ℝ} [IsFiniteMeasure μ] {a b : ℝ} :
+    IntervalIntegrable (charFun μ) volume a b :=
+  IntervalIntegrable.mono_fun' (g := fun _ ↦ (μ Set.univ).toReal) (by simp)
+    stronglyMeasurable_charFun.aestronglyMeasurable (ae_of_all _ norm_charFun_le)
+
+lemma charFun_map_smul [BorelSpace E] [SecondCountableTopology E] (r : ℝ) (t : E) :
+    charFun (μ.map (r • ·)) t = charFun μ (r • t) := by
+  rw [charFun_apply, charFun_apply,
+    integral_map (by fun_prop) (Measurable.aestronglyMeasurable <| by fun_prop)]
+  simp_rw [inner_smul_right, ← real_inner_smul_left]
+
+lemma charFun_map_mul {μ : Measure ℝ} (r t : ℝ) :
+    charFun (μ.map (r * ·)) t = charFun μ (r * t) := charFun_map_smul r t
+
+/-- If the characteristic functions `charFun` of two finite measures `μ` and `ν` on
+a complete second-countable inner product space coincide, then `μ = ν`. -/
+theorem Measure.ext_of_charFun {E : Type*} [MeasurableSpace E]
+    [NormedAddCommGroup E] [InnerProductSpace ℝ E] [CompleteSpace E] [BorelSpace E]
+    [SecondCountableTopology E] {μ ν : Measure E} [IsFiniteMeasure μ] [IsFiniteMeasure ν]
+    (h : charFun μ = charFun ν) :
+    μ = ν := by
+  rw [funext_iff] at h
+  simp_rw [charFun_eq_integral_innerProbChar] at h
+  refine ext_of_integral_char_eq continuous_probChar probChar_ne_one (L := bilinFormOfRealInner)
+    ?_ ?_ h
+  · exact fun v hv ↦ DFunLike.ne_iff.mpr ⟨v, inner_self_ne_zero.mpr hv⟩
+  · exact continuous_inner
+
+end InnerProductSpace
 
 end MeasureTheory

--- a/Mathlib/MeasureTheory/Measure/CharacteristicFunction.lean
+++ b/Mathlib/MeasureTheory/Measure/CharacteristicFunction.lean
@@ -152,11 +152,12 @@ lemma norm_one_sub_charFun_le_two [IsProbabilityMeasure μ] : ‖1 - charFun μ 
   _ ≤ 1 + 1 := by simp [norm_charFun_le_one]
   _ = 2 := by norm_num
 
+@[measurability]
 lemma stronglyMeasurable_charFun [OpensMeasurableSpace E] [SecondCountableTopology E] [SFinite μ] :
     StronglyMeasurable (charFun μ) :=
   (Measurable.stronglyMeasurable (by fun_prop)).integral_prod_left
 
-@[fun_prop]
+@[fun_prop, measurability]
 lemma measurable_charFun [OpensMeasurableSpace E] [SecondCountableTopology E] [SFinite μ] :
     Measurable (charFun μ) :=
   stronglyMeasurable_charFun.measurable

--- a/Mathlib/MeasureTheory/Measure/CharacteristicFunction.lean
+++ b/Mathlib/MeasureTheory/Measure/CharacteristicFunction.lean
@@ -93,7 +93,7 @@ end ext
 
 section InnerProductSpace
 
-variable {E : Type*} [MeasurableSpace E] {μ : Measure E} {t : E}
+variable {E : Type*} {mE : MeasurableSpace E} {μ : Measure E} {t : E}
 
 /-- The characteristic function of a measure in an inner product space. -/
 noncomputable def charFun [Inner ℝ E] (μ : Measure E) (t : E) : ℂ := ∫ x, exp (⟪x, t⟫ * I) ∂μ

--- a/Mathlib/MeasureTheory/Measure/CharacteristicFunction.lean
+++ b/Mathlib/MeasureTheory/Measure/CharacteristicFunction.lean
@@ -47,7 +47,7 @@ variable {E : Type*} [SeminormedAddCommGroup E] [InnerProductSpace ℝ E]
 
 /-- The bounded continuous map `x ↦ exp(⟪x, t⟫ * I)`. -/
 noncomputable
-def innerProbChar (t : E) : BoundedContinuousFunction E ℂ :=
+def innerProbChar (t : E) : E →ᵇ ℂ :=
   char continuous_probChar (L := bilinFormOfRealInner) continuous_inner t
 
 lemma innerProbChar_apply (t x : E) : innerProbChar t x = exp (⟪x, t⟫ * I) := rfl

--- a/Mathlib/MeasureTheory/Measure/CharacteristicFunction.lean
+++ b/Mathlib/MeasureTheory/Measure/CharacteristicFunction.lean
@@ -100,7 +100,7 @@ noncomputable def charFun [Inner ℝ E] (μ : Measure E) (t : E) : ℂ := ∫ x,
 
 lemma charFun_apply [Inner ℝ E] (t : E) : charFun μ t = ∫ x, exp (⟪x, t⟫ * I) ∂μ := rfl
 
-lemma charFun_apply_real {μ : Measure ℝ} {t : ℝ} :
+lemma charFun_apply_real {μ : Measure ℝ} (t : ℝ) :
     charFun μ t = ∫ x, exp (t * x * I) ∂μ := by simp [charFun_apply]
 
 variable [SeminormedAddCommGroup E] [InnerProductSpace ℝ E]


### PR DESCRIPTION
Add a definition of a characteristic function, which is equal to the integral of `BoundedContinuousFunction.char` for the inner product bilinear map and the additive character `e = Real.probChar`.

Co-authored-by: Thomas Zhu (@hanwenzhu)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
