### PR TITLE
[Merged by Bors] - feat(Equiv) : sigmas indexed by products are sigmas; pinning down the base of a sigma gives the fiber

### DIFF
--- a/Mathlib/Logic/Equiv/Basic.lean
+++ b/Mathlib/Logic/Equiv/Basic.lean
@@ -436,6 +436,15 @@ def sigmaAssocProd {α β : Type*} {γ : α → β → Type*} :
     (ab : α × β) × γ ab.1 ab.2 ≃ (a : α) × (b : β) × γ a b :=
   sigmaCongrLeft' (sigmaEquivProd _ _).symm |>.trans <| sigmaAssoc γ
 
+/-- A subtype of a sigma which pins down the base of the sigma is equivalent to
+the respective fiber. -/
+@[simps]
+def sigmaSubtype {α : Type*} {β : α → Type*} (a : α) :
+    {s : Sigma β // s.1 = a} ≃ β a where
+  toFun := fun ⟨⟨_, b⟩, h⟩ => h ▸ b
+  invFun b := ⟨⟨a, b⟩, rfl⟩
+  left_inv := fun ⟨a, h⟩ ↦ by cases h; simp
+  right_inv b := by simp
 
 /-- A subtype of a dependent triple which pins down both bases is equivalent to the
 respective fiber. -/

--- a/Mathlib/Logic/Equiv/Basic.lean
+++ b/Mathlib/Logic/Equiv/Basic.lean
@@ -942,11 +942,9 @@ end
   left_inv f := rfl
   right_inv f := rfl
 
-lemma eq_conj {α α' β β' : Type*} (ε₁ : α ≃ α') (ε₂ : β' ≃ β)
-    (f : α → β) (f' : α' → β') : f = ε₂ ∘ f' ∘ ε₁ ↔ ε₂.symm ∘ f ∘ ε₁.symm = f' := by
-  constructor <;> (intro h; ext)
-  · simp [h]
-  · simp [← h]
+lemma eq_conj {α α' β β' : Sort*} (ε₁ : α ≃ α') (ε₂ : β' ≃ β)
+    (f : α → β) (f' : α' → β') : ε₂.symm ∘ f ∘ ε₁.symm = f' ↔ f = ε₂ ∘ f' ∘ ε₁ := by
+  rw [Equiv.symm_comp_eq, Equiv.comp_symm_eq, Function.comp_assoc]
 
 section BinaryOp
 

--- a/Mathlib/Logic/Equiv/Basic.lean
+++ b/Mathlib/Logic/Equiv/Basic.lean
@@ -429,6 +429,39 @@ def subtypePiEquivPi {β : α → Sort v} {p : ∀ a, β a → Prop} :
     funext a
     exact Subtype.ext_val rfl
 
+/-- A sigma of a sigma whose second base does not depend on the first is equivalent
+to a sigma whose base is a product. -/
+@[simps!]
+def sigmaAssocProd {α β : Type*} {γ : α → β → Type*} :
+    (ab : α × β) × γ ab.1 ab.2 ≃ (a : α) × (b : β) × γ a b :=
+  sigmaCongrLeft' (sigmaEquivProd _ _).symm |>.trans <| sigmaAssoc γ
+
+
+/-- A subtype of a dependent triple which pins down both bases is equivalent to the
+respective fiber. -/
+@[simps! (config := {simpRhs := true})]
+def sigmaSigmaSubtype {α : Type*} {β : α → Type*} {γ : (a : α) → β a → Type*}
+    (p : (a : α) × β a → Prop) [uniq : Unique {ab // p ab}] (a : α) (b : β a) (h : p ⟨a, b⟩) :
+    {s : (a : α) × (b : β a) × γ a b // p ⟨s.1, s.2.1⟩} ≃ γ a b := by
+  calc {s : (a : α) × (b : β a) × γ a b // p ⟨s.1, s.2.1⟩}
+  _ ≃ _ := subtypeEquiv (p := fun ⟨a, b, c⟩ ↦ p ⟨a, b⟩) (q := (p ·.1))
+    (sigmaAssoc γ).symm fun s ↦ by simp [sigmaAssoc]
+  _ ≃ _ := subtypeSigmaEquiv _ _
+  _ ≃ _ := uniqueSigma (fun ab ↦ γ (Sigma.fst <| Subtype.val ab) (Sigma.snd <| Subtype.val ab))
+  _ ≃ γ a b := by rw [ ← show ⟨⟨a, b⟩, h⟩ = uniq.default from uniq.uniq _]
+
+/-- A specialization of `sigmaSigmaSubtype` to the case where the second base
+does not depend on the first, and the property being checked for is simple
+equality. Useful for e.g. hom-types. -/
+@[simps!]
+def sigmaSigmaSubtypeEq {α β : Type*} {γ : α → β → Type*} (a : α) (b : β) :
+    {s : (a : α) × (b : β) × γ a b // s.1 = a ∧ s.2.1 = b} ≃ γ a b :=
+  have : Unique (@Subtype ((_ : α) × β) (fun ⟨a', b'⟩ ↦ a' = a ∧ b' = b)) := {
+    default := ⟨⟨a, b⟩, ⟨rfl, rfl⟩⟩
+    uniq := by rintro ⟨⟨a', b'⟩, ⟨rfl, rfl⟩⟩; rfl
+  }
+  sigmaSigmaSubtype (fun ⟨a', b'⟩ ↦ a' = a ∧ b' = b) a b ⟨rfl, rfl⟩
+
 end
 
 section subtypeEquivCodomain
@@ -899,6 +932,12 @@ end
   invFun f i := f ⟨i, h.symm ▸ i.2⟩
   left_inv f := rfl
   right_inv f := rfl
+
+lemma eq_conj {α α' β β' : Type*} (ε₁ : α ≃ α') (ε₂ : β' ≃ β)
+    (f : α → β) (f' : α' → β') : f = ε₂ ∘ f' ∘ ε₁ ↔ ε₂.symm ∘ f ∘ ε₁.symm = f' := by
+  constructor <;> (intro h; ext)
+  · simp [h]
+  · simp [← h]
 
 section BinaryOp
 

--- a/Mathlib/Logic/Equiv/Sum.lean
+++ b/Mathlib/Logic/Equiv/Sum.lean
@@ -341,16 +341,6 @@ def sumSigmaDistrib {α β} (t : α ⊕ β → Type*) :
   by rintro ⟨x|x,y⟩ <;> simp,
   by rintro (⟨x,y⟩|⟨x,y⟩) <;> simp⟩
 
-/-- A subtype of a sigma which pins down the base of the sigma is equivalent to
-the respective fiber. -/
-@[simps]
-def sigmaSubtype {α : Type*} {β : α → Type*} (a : α) :
-    {s : Sigma β // s.1 = a} ≃ β a where
-  toFun := fun ⟨⟨_, b⟩, h⟩ => h ▸ b
-  invFun b := ⟨⟨a, b⟩, rfl⟩
-  left_inv := fun ⟨a, h⟩ ↦ by cases h; simp
-  right_inv b := by simp
-
 end
 
 end Equiv

--- a/Mathlib/Logic/Equiv/Sum.lean
+++ b/Mathlib/Logic/Equiv/Sum.lean
@@ -341,6 +341,16 @@ def sumSigmaDistrib {α β} (t : α ⊕ β → Type*) :
   by rintro ⟨x|x,y⟩ <;> simp,
   by rintro (⟨x,y⟩|⟨x,y⟩) <;> simp⟩
 
+/-- A subtype of a sigma which pins down the base of the sigma is equivalent to
+the respective fiber. -/
+@[simps]
+def sigmaSubtype {α : Type*} {β : α → Type*} (a : α) :
+    {s : Sigma β // s.1 = a} ≃ β a where
+  toFun := fun ⟨⟨_, b⟩, h⟩ => h ▸ b
+  invFun b := ⟨⟨a, b⟩, rfl⟩
+  left_inv := fun ⟨a, h⟩ ↦ by cases h; simp
+  right_inv b := by simp
+
 end
 
 end Equiv


### PR DESCRIPTION
Add some convenience defs for working with sigma types that appear frequently when working with hom-like objects:

- `Equiv.sigmaAssocProd`, for sigmas of the form `(a : α) × (b : β) × γ a b`
- `Equiv.sigmaSubtype` and `Equiv.sigmaSigmaSubtype`, for subtypes of sigmas that "cancel"

Also add a convenience lemma for moving conjugations ( $\varepsilon\^{-1} f \varepsilon$ ) from one side of an equation of functions to the other.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
