### PR TITLE
feat (Limits): limitSubobjectProduct and colimitQuotientCoproduct are canonical

### DIFF
--- a/Mathlib/CategoryTheory/Limits/Constructions/LimitsOfProductsAndEqualizers.lean
+++ b/Mathlib/CategoryTheory/Limits/Constructions/LimitsOfProductsAndEqualizers.lean
@@ -120,6 +120,23 @@ instance limitSubobjectProduct_mono [HasLimitsOfSize.{w, w} C] (F : J ⥤ C) :
     Mono (limitSubobjectProduct F) :=
   mono_comp _ _
 
+@[reassoc (attr := simp)]
+lemma limitSubobjectProduct_π {J : Type w} [Category.{w} J] {C : Type u} [Category.{v} C]
+    [HasLimitsOfSize.{w, w} C] (F : J ⥤ C) (j : J) :
+    limitSubobjectProduct F ≫ Pi.π F.obj j = limit.π F j := by
+  simp only [limitSubobjectProduct, limit.cone_x, Category.assoc]
+  rw [← Iso.eq_inv_comp]
+  simp [limitConeOfEqualizerAndProduct]
+
+/-- `limitSubobjectProduct` is indeed the canonical map from the limit to the product. -/
+@[simp]
+lemma limitSubobjectProduct_eq_lift {J : Type w} [Category.{w} J] {C : Type u} [Category.{v} C]
+    [HasLimitsOfSize.{w, w} C] (F : J ⥤ C) :
+    limitSubobjectProduct F = Pi.lift (limit.π F) := by
+  apply limit.hom_ext
+  intro ⟨j⟩
+  simp
+
 /-- Any category with products and equalizers has all limits. -/
 @[stacks 002N]
 theorem has_limits_of_hasEqualizers_and_products [HasProducts.{w} C] [HasEqualizers C] :
@@ -387,6 +404,23 @@ noncomputable def colimitQuotientCoproduct [HasColimitsOfSize.{w, w} C] (F : J �
 instance colimitQuotientCoproduct_epi [HasColimitsOfSize.{w, w} C] (F : J ⥤ C) :
     Epi (colimitQuotientCoproduct F) :=
   epi_comp _ _
+
+@[reassoc (attr := simp)]
+lemma colimitQuotientCoproduct_ι {J : Type w} [Category.{w} J] {C : Type u} [Category.{v} C]
+    [HasColimitsOfSize.{w, w} C] (F : J ⥤ C) (j : J) :
+    Sigma.ι F.obj j ≫ colimitQuotientCoproduct F = colimit.ι F j := by
+  simp only [colimitQuotientCoproduct, colimit.cocone_x, ← Category.assoc]
+  rw [Iso.comp_inv_eq]
+  simp [colimitCoconeOfCoequalizerAndCoproduct]
+
+/-- `colimitQuotientCoproduct` is indeed the canonical map from the coproduct to the colimit. -/
+@[simp]
+lemma colimitQuotientCoproduct_eq_desc {J : Type w} [Category.{w} J] {C : Type u} [Category.{v} C]
+    [HasColimitsOfSize.{w, w} C] (F : J ⥤ C) :
+    colimitQuotientCoproduct F = Sigma.desc (colimit.ι F) := by
+  apply colimit.hom_ext
+  intro ⟨j⟩
+  simp
 
 /-- Any category with coproducts and coequalizers has all colimits. -/
 @[stacks 002P]


### PR DESCRIPTION
Add API to work with `limitSubobjectProduct` and `colimitQuotientCoproduct` categorically without unfolding the definition:

- `limitSubobjectProduct_π` and `limitSubobjectProduct_eq_lift`: `limitSubobjectProduct` is indeed the canonical morphism from the limit given by the universal property of the product.
- `colimitQuotientCoproduct_ι` and `colimitQuotientCoproduct_eq_desc`: `colimitQuotientCoproduct` is indeed the canonical morphism to the colimit given by the universal property of the coproduct.


---

I'm not entirely sure why git diff has decided to delete and replace the entire file rather than a more precise diff, but if it needs fixing, I'll need help tracking down the problem. At any rate, the changelog is recorded above.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
