### PR TITLE
[Merged by Bors] - chore(Surreal): dedup instance

### DIFF
--- a/Mathlib/SetTheory/Surreal/Multiplication.lean
+++ b/Mathlib/SetTheory/Surreal/Multiplication.lean
@@ -517,16 +517,6 @@ instance : CommRing Surreal where
   zero_mul := by rintro ⟨_⟩; exact Quotient.sound (zero_mul_equiv _)
   mul_zero := by rintro ⟨_⟩; exact Quotient.sound (mul_zero_equiv _)
 
-noncomputable instance : LinearOrder Surreal where
-  le := lift₂ (fun x y _ _ ↦ x ≤ y) (fun _ _ _ _ hx hy ↦ propext <| le_congr hx hy)
-  lt := lift₂ (fun x y _ _ ↦ x < y) (fun _ _ _ _ hx hy ↦ propext <| lt_congr hx hy)
-  le_refl := by rintro ⟨_⟩; apply @le_rfl PGame
-  le_trans := by rintro ⟨_⟩ ⟨_⟩ ⟨_⟩; apply @le_trans PGame
-  lt_iff_le_not_le := by rintro ⟨_⟩ ⟨_⟩; exact lt_iff_le_not_le
-  le_antisymm := by rintro ⟨_⟩ ⟨_⟩ h₁ h₂; exact Quotient.sound ⟨h₁, h₂⟩
-  le_total := by rintro ⟨x⟩ ⟨y⟩; exact (le_or_gf x.1 y.1).imp id (fun h ↦ h.le y.2 x.2)
-  decidableLE := Classical.decRel _
-
 instance : ZeroLEOneClass Surreal where
   zero_le_one := PGame.zero_lt_one.le
 


### PR DESCRIPTION
Deduplicates the instance `LinearOrder Surreal`, which was defined in both `Surreal/Basic` and `Surreal/Multiplication`.
The duplicate originated in #14044.

The surviving instance is at

https://github.com/leanprover-community/mathlib4/blob/461b2e79dd4c923f26e435f770faeaf87208d0d9/Mathlib/SetTheory/Surreal/Basic.lean#L368-L373

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
