### PR TITLE
[Merged by Bors] - chore: bump toolchain to v4.19.0-rc3

### DIFF
--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:v4.19.0-rc2
+leanprover/lean4:v4.19.0-rc3


### PR DESCRIPTION
Note that we are *not* bumping everything upstream, for this release candidate (which should not behave differently except for fewer crashes!)