### PR TITLE
feat(Types.Colimits): Quot is functorial and colimitEquivQuot is natural

### DIFF
--- a/Mathlib/CategoryTheory/Limits/Types/Colimits.lean
+++ b/Mathlib/CategoryTheory/Limits/Types/Colimits.lean
@@ -278,7 +278,7 @@ theorem colimitEquivQuot_apply (j : J) (x : F.obj j) :
 
 /-- `colimitEquivQuot` is natural in `F`. -/
 @[simps!]
-noncomputable def colimIsoQuotFunctor :
+noncomputable def colimNatIsoQuotFunctor :
     colim (J := J) (C := Type max v u) ≅ Functor.quotFunctor J :=
   NatIso.ofComponents (Types.colimitEquivQuot · |>.toIso) fun {F G} η ↦ by
     apply colimit.hom_ext

--- a/Mathlib/CategoryTheory/Limits/Types/Colimits.lean
+++ b/Mathlib/CategoryTheory/Limits/Types/Colimits.lean
@@ -43,6 +43,28 @@ def Quot.ι (F : J ⥤ Type u) (j : J) : F.obj j → Quot F :=
 lemma Quot.jointly_surjective {F : J ⥤ Type u} (x : Quot F) : ∃ j y, x = Quot.ι F j y :=
   Quot.ind (β := fun x => ∃ j y, x = Quot.ι F j y) (fun ⟨j, y⟩ => ⟨j, y, rfl⟩) x
 
+variable (J) in
+/-- `Quot` is functorial, so long as the universe levels work out. -/
+@[simps]
+noncomputable def _root_.CategoryTheory.Functor.quotFunctor [Small.{u} J] :
+    (J ⥤ Type u) ⥤ Type max u v where
+  obj F := Quot F
+  map {F G} η x := by
+    refine Quot.map (Sigma.map id η.app)
+      (fun ⟨j, x⟩ ⟨j', y⟩ ⟨(f : j ⟶ j'), (hf : y = F.map f x)⟩ ↦ ?h) x
+    subst hf
+    simp only [Sigma.map, id_eq]
+    simp_rw [← types_comp_apply, η.naturality, types_comp_apply]
+    exact ⟨f, rfl⟩
+
+  map_id F := by
+    ext ⟨j, x⟩
+    simp [Sigma.map, Quot.map]
+  map_comp {F G H} η ϑ := by
+    ext ⟨j, x⟩
+    simp [Sigma.map, Quot.map]
+
+
 section
 
 variable {F : J ⥤ Type u} (c : Cocone F)
@@ -253,6 +275,17 @@ theorem colimitEquivQuot_apply (j : J) (x : F.obj j) :
     (colimitEquivQuot F) (colimit.ι F j x) = Quot.mk _ ⟨j, x⟩ := by
   apply (colimitEquivQuot F).symm.injective
   simp
+
+/-- `colimitEquivQuot` is natural in `F`. -/
+@[simps!]
+noncomputable def colimIsoQuotFunctor :
+    colim (J := J) (C := Type max v u) ≅ Functor.quotFunctor J :=
+  NatIso.ofComponents (Types.colimitEquivQuot · |>.toIso) fun {F G} η ↦ by
+    apply colimit.hom_ext
+    intro j
+    ext x
+    simp_rw [← Category.assoc, colimit.ι_map]
+    simp [Sigma.map, Quot.map]
 
 -- Porting note (https://github.com/leanprover-community/mathlib4/issues/11119): @[simp] was removed because the linter said it was useless
 variable {F} in

--- a/Mathlib/CategoryTheory/Limits/Types/Colimits.lean
+++ b/Mathlib/CategoryTheory/Limits/Types/Colimits.lean
@@ -46,7 +46,7 @@ lemma Quot.jointly_surjective {F : J ⥤ Type u} (x : Quot F) : ∃ j y, x = Quo
 variable (J) in
 /-- `Quot` is functorial, so long as the universe levels work out. -/
 @[simps]
-noncomputable def _root_.CategoryTheory.Functor.quotFunctor [Small.{u} J] :
+noncomputable def _root_.CategoryTheory.Functor.quotFunctor :
     (J ⥤ Type u) ⥤ Type max u v where
   obj F := Quot F
   map {F G} η x := by


### PR DESCRIPTION
Add `Functor.quotFunctor` to parallel `Functor.sectionsFunctor`, witnessing that `Quot` is functorial; add `colimNatIsoQuotFunctor` to parallel `limNatIsoSectionsFunctor`, witnessing that `colimitEquivQuot` is natural in the diagram $F$.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
