### PR TITLE
feat (Limits.FunctorCategory): limitIsoFlipCompLim and colimitIsoFlipCompColim are natural

### DIFF
--- a/Mathlib/CategoryTheory/Limits/FunctorCategory/Basic.lean
+++ b/Mathlib/CategoryTheory/Limits/FunctorCategory/Basic.lean
@@ -493,8 +493,8 @@ def limCompFlipIsoWhiskerLim [HasLimitsOfShape J C] :
     ext k
     apply limit_obj_ext
     intro j
-    simp [comp_evaluation, ← NatTrans.comp_app (limMap _)]
-  ).symm
+    simp [comp_evaluation, ← NatTrans.comp_app (limMap _)]).symm
+    
 /-- For a functor `G : J ⥤ K ⥤ C`, its limit `K ⥤ C` is given by `(G' : K ⥤ J ⥤ C) ⋙ lim`.
 Note that this does not require `K` to be small.
 -/

--- a/Mathlib/CategoryTheory/Limits/FunctorCategory/Basic.lean
+++ b/Mathlib/CategoryTheory/Limits/FunctorCategory/Basic.lean
@@ -487,6 +487,7 @@ def limitFlipIsoCompLim [HasLimitsOfShape J C] (F : K ⥤ J ⥤ C) : limit F.fli
 
 /-- `limitFlipIsoCompLim` is natural in `F`. -/
 @[simps!]
+def limCompFlipIsoWhiskerLim [HasLimitsOfShape J C] :
     flipFunctor K J C ⋙ lim ≅ (whiskeringRight _ _ _).obj lim :=
   (NatIso.ofComponents (limitFlipIsoCompLim · |>.symm) fun {F G} η ↦ by
     ext k

--- a/Mathlib/CategoryTheory/Limits/FunctorCategory/Basic.lean
+++ b/Mathlib/CategoryTheory/Limits/FunctorCategory/Basic.lean
@@ -487,7 +487,6 @@ def limitFlipIsoCompLim [HasLimitsOfShape J C] (F : K ⥤ J ⥤ C) : limit F.fli
 
 /-- `limitFlipIsoCompLim` is natural in `F`. -/
 @[simps!]
-def limCompFlipIsoWhiskerLim [HasLimitsOfShape J C] :
     flipFunctor K J C ⋙ lim ≅ (whiskeringRight _ _ _).obj lim :=
   (NatIso.ofComponents (limitFlipIsoCompLim · |>.symm) fun {F G} η ↦ by
     ext k

--- a/Mathlib/CategoryTheory/Limits/FunctorCategory/Basic.lean
+++ b/Mathlib/CategoryTheory/Limits/FunctorCategory/Basic.lean
@@ -467,6 +467,17 @@ the individual limits on objects. -/
 def limitIsoFlipCompLim [HasLimitsOfShape J C] (F : J ⥤ K ⥤ C) : limit F ≅ F.flip ⋙ lim :=
   NatIso.ofComponents (limitObjIsoLimitCompEvaluation F)
 
+/-- `limitIsoFlipCompLim` is natural in `F`. -/
+@[simps!]
+def limIsoFlipCompWhiskerLim [HasLimitsOfShape J C] :
+    lim ≅ flipFunctor J K C ⋙ (whiskeringRight _ _ _).obj lim :=
+  (NatIso.ofComponents (limitIsoFlipCompLim · |>.symm) fun {F G} η ↦ by
+    ext k
+    apply limit_obj_ext
+    intro j
+    simp [comp_evaluation, ← NatTrans.comp_app (limMap η)]
+  ).symm
+
 /-- A variant of `limitIsoFlipCompLim` where the arguments of `F` are flipped. -/
 @[simps!]
 def limitFlipIsoCompLim [HasLimitsOfShape J C] (F : K ⥤ J ⥤ C) : limit F.flip ≅ F ⋙ lim :=
@@ -474,6 +485,16 @@ def limitFlipIsoCompLim [HasLimitsOfShape J C] (F : K ⥤ J ⥤ C) : limit F.fli
     limitObjIsoLimitCompEvaluation F.flip k ≪≫ HasLimit.isoOfNatIso (flipCompEvaluation _ _)
   NatIso.ofComponents f
 
+/-- `limitFlipIsoCompLim` is natural in `F`. -/
+@[simps!]
+def limCompFlipIsoWhiskerLim [HasLimitsOfShape J C] :
+    flipFunctor K J C ⋙ lim ≅ (whiskeringRight _ _ _).obj lim :=
+  (NatIso.ofComponents (limitFlipIsoCompLim · |>.symm) fun {F G} η ↦ by
+    ext k
+    apply limit_obj_ext
+    intro j
+    simp [comp_evaluation, ← NatTrans.comp_app (limMap _)]
+  ).symm
 /-- For a functor `G : J ⥤ K ⥤ C`, its limit `K ⥤ C` is given by `(G' : K ⥤ J ⥤ C) ⋙ lim`.
 Note that this does not require `K` to be small.
 -/
@@ -488,12 +509,32 @@ the individual colimits on objects. -/
 def colimitIsoFlipCompColim [HasColimitsOfShape J C] (F : J ⥤ K ⥤ C) : colimit F ≅ F.flip ⋙ colim :=
   NatIso.ofComponents (colimitObjIsoColimitCompEvaluation F)
 
+/-- `colimitIsoFlipCompColim` is natural in `F`. -/
+@[simps!]
+def colimIsoFlipCompWhiskerColim [HasColimitsOfShape J C] :
+    colim ≅ flipFunctor J K C ⋙ (whiskeringRight _ _ _).obj colim :=
+  (NatIso.ofComponents (colimitIsoFlipCompColim) fun {F G} η ↦ by
+    ext k
+    apply colimit_obj_ext
+    intro j
+    simp [comp_evaluation, ← NatTrans.comp_app_assoc _ (colimMap η)])
+
 /-- A variant of `colimit_iso_flip_comp_colim` where the arguments of `F` are flipped. -/
 @[simps!]
 def colimitFlipIsoCompColim [HasColimitsOfShape J C] (F : K ⥤ J ⥤ C) : colimit F.flip ≅ F ⋙ colim :=
   let f := fun _ =>
       colimitObjIsoColimitCompEvaluation _ _ ≪≫ HasColimit.isoOfNatIso (flipCompEvaluation _ _)
   NatIso.ofComponents f
+
+/-- `colimitFlipIsoCompColim` is natural in `F`. -/
+@[simps!]
+def colimCompFlipIsoWhiskerColim [HasColimitsOfShape J C] :
+    flipFunctor K J C ⋙ colim ≅ (whiskeringRight _ _ _).obj colim :=
+  (NatIso.ofComponents (colimitFlipIsoCompColim) fun {F G} η ↦ by
+    ext k
+    apply colimit_obj_ext
+    intro j
+    simp [comp_evaluation, ← NatTrans.comp_app_assoc _ (colimMap _)])
 
 /-- For a functor `G : J ⥤ K ⥤ C`, its colimit `K ⥤ C` is given by `(G' : K ⥤ J ⥤ C) ⋙ colim`.
 Note that this does not require `K` to be small.


### PR DESCRIPTION
Add `limIsoFlipCompWhiskerLim`, `limCompFlipIsoWhiskerLim`, `colimIsoFlipCompWhiskerColim`, `colimCompFlipIsoWhiskerColim`, each witnessing that their corresponding families of isomorphisms are natural in the diagram $F$.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
