### PR TITLE
[Merged by Bors] - feat (RingTheory/PowerSeries/Order) : compute order of power and generalize

### DIFF
--- a/Mathlib/Algebra/Order/Monoid/Unbundled/Basic.lean
+++ b/Mathlib/Algebra/Order/Monoid/Unbundled/Basic.lean
@@ -316,13 +316,15 @@ variable [LinearOrder α] {a b c d : α}
 
 @[to_additive]
 theorem trichotomy_of_mul_eq_mul
-    [MulLeftMono α] [MulLeftStrictMono α] [MulRightMono α] [MulRightStrictMono α]
+    [MulLeftStrictMono α] [MulRightStrictMono α]
     (h : a * b = c * d) : (a = c ∧ b = d) ∨ a < c ∨ b < d := by
   obtain hac | rfl | hca := lt_trichotomy a c
   · right; left; exact hac
   · left; simpa using mul_right_inj_of_comparable (LinearOrder.le_total d b)|>.1 h
-  · right; right; by_contra h'
-    exact (ne_of_lt (mul_lt_mul_of_lt_of_le hca (le_of_not_lt h'))) h.symm
+  · obtain hbd | rfl | hdb := lt_trichotomy b d
+    · right; right; exact hbd
+    · exact False.elim <| ne_of_lt (mul_lt_mul_right' hca b) h.symm
+    · exact False.elim <| ne_of_lt (mul_lt_mul_of_lt_of_lt hca hdb) h.symm
 
 @[to_additive]
 lemma mul_max [CovariantClass α α (· * ·) (· ≤ ·)] (a b c : α) :

--- a/Mathlib/Algebra/Order/Monoid/Unbundled/Basic.lean
+++ b/Mathlib/Algebra/Order/Monoid/Unbundled/Basic.lean
@@ -318,18 +318,11 @@ variable [LinearOrder α] {a b c d : α}
 theorem trichotomy_of_mul_eq_mul
     [MulLeftMono α] [MulLeftStrictMono α] [MulRightMono α] [MulRightStrictMono α]
     (h : a * b = c * d) : (a = c ∧ b = d) ∨ a < c ∨ b < d := by
-  by_cases hac : a < c
+  obtain hac | rfl | hca := lt_trichotomy a c
   · right; left; exact hac
-  · by_cases hbd : b < d
-    · right; right; exact hbd
-    · left
-      simp only [not_lt] at hac hbd
-      by_contra h'
-      apply ne_of_lt _ h.symm
-      rw [not_and_or] at h'
-      rcases h' with h' | h'
-      · exact mul_lt_mul_of_lt_of_le (lt_of_le_of_ne hac (Ne.symm h')) hbd
-      · exact mul_lt_mul_of_le_of_lt hac (lt_of_le_of_ne hbd (Ne.symm h'))
+  · left; simpa using mul_right_inj_of_comparable (LinearOrder.le_total d b)|>.1 h
+  · right; right; by_contra h'
+    exact (ne_of_lt (mul_lt_mul_of_lt_of_le hca (le_of_not_lt h'))) h.symm
 
 @[to_additive]
 lemma mul_max [CovariantClass α α (· * ·) (· ≤ ·)] (a b c : α) :

--- a/Mathlib/Algebra/Order/Monoid/Unbundled/Basic.lean
+++ b/Mathlib/Algebra/Order/Monoid/Unbundled/Basic.lean
@@ -315,6 +315,23 @@ section LinearOrder
 variable [LinearOrder α] {a b c d : α}
 
 @[to_additive]
+theorem trichotomy_of_mul_eq_mul
+    [MulLeftMono α] [MulLeftStrictMono α] [MulRightMono α] [MulRightStrictMono α]
+    (h : a * b = c * d) : (a = c ∧ b = d) ∨ a < c ∨ b < d := by
+  by_cases hac : a < c
+  · right; left; exact hac
+  · by_cases hbd : b < d
+    · right; right; exact hbd
+    · left
+      simp only [not_lt] at hac hbd
+      by_contra h'
+      apply ne_of_lt _ h.symm
+      rw [not_and_or] at h'
+      rcases h' with h' | h'
+      · exact mul_lt_mul_of_lt_of_le (lt_of_le_of_ne hac (Ne.symm h')) hbd
+      · exact mul_lt_mul_of_le_of_lt hac (lt_of_le_of_ne hbd (Ne.symm h'))
+
+@[to_additive]
 lemma mul_max [CovariantClass α α (· * ·) (· ≤ ·)] (a b c : α) :
     a * max b c = max (a * b) (a * c) := mul_left_mono.map_max
 

--- a/Mathlib/RingTheory/PowerSeries/Basic.lean
+++ b/Mathlib/RingTheory/PowerSeries/Basic.lean
@@ -527,47 +527,36 @@ theorem X_dvd_iff {φ : R⟦X⟧} : (X : R⟦X⟧) ∣ φ ↔ constantCoeff R φ
   · intro m hm
     rwa [Nat.eq_zero_of_le_zero (Nat.le_of_succ_le_succ hm)]
 
-theorem eq_zero_or_eq_zero_of_mul_eq_zero [NoZeroDivisors R] (φ ψ : R⟦X⟧) (h : φ * ψ = 0) :
-    φ = 0 ∨ ψ = 0 := by
-  classical
-  rw [or_iff_not_imp_left]
-  intro H
-  have ex : ∃ m, coeff R m φ ≠ 0 := by
-    contrapose! H
-    exact ext H
-  let m := Nat.find ex
-  have hm₁ : coeff R m φ ≠ 0 := Nat.find_spec ex
-  have hm₂ : ∀ k < m, ¬coeff R k φ ≠ 0 := fun k => Nat.find_min ex
-  ext n
-  rw [(coeff R n).map_zero]
-  induction' n using Nat.strong_induction_on with n ih
-  replace h := congr_arg (coeff R (m + n)) h
-  rw [LinearMap.map_zero, coeff_mul, Finset.sum_eq_single (m, n)] at h
-  · replace h := NoZeroDivisors.eq_zero_or_eq_zero_of_mul_eq_zero h
-    rw [or_iff_not_imp_left] at h
-    exact h hm₁
-  · rintro ⟨i, j⟩ hij hne
-    by_cases hj : j < n
-    · rw [ih j hj, mul_zero]
-    by_cases hi : i < m
-    · specialize hm₂ _ hi
-      push_neg at hm₂
-      rw [hm₂, zero_mul]
-    rw [mem_antidiagonal] at hij
-    push_neg at hi hj
-    suffices m < i by
-      have : m + n < i + j := add_lt_add_of_lt_of_le this hj
-      exfalso
-      exact ne_of_lt this hij.symm
-    contrapose! hne
-    obtain rfl := le_antisymm hi hne
-    simpa [Ne, Prod.mk_inj] using (add_right_inj m).mp hij
-  · contrapose!
-    intro
-    rw [mem_antidiagonal]
-
 instance [NoZeroDivisors R] : NoZeroDivisors R⟦X⟧ where
-  eq_zero_or_eq_zero_of_mul_eq_zero := eq_zero_or_eq_zero_of_mul_eq_zero _ _
+  eq_zero_or_eq_zero_of_mul_eq_zero {φ ψ} h := by
+    classical
+    rw [or_iff_not_imp_left]
+    intro H
+    have ex : ∃ m, coeff R m φ ≠ 0 := by
+      contrapose! H
+      exact ext H
+    let m := Nat.find ex
+    have hm₁ : coeff R m φ ≠ 0 := Nat.find_spec ex
+    have hm₂ : ∀ k < m, ¬coeff R k φ ≠ 0 := fun k => Nat.find_min ex
+    simp only [ne_eq, Decidable.not_not] at hm₂
+    ext n
+    rw [(coeff R n).map_zero]
+    induction' n using Nat.strong_induction_on with n ih
+    replace h := congr_arg (coeff R (m + n)) h
+    rw [LinearMap.map_zero, coeff_mul, Finset.sum_eq_single (m, n)] at h
+    · replace h := NoZeroDivisors.eq_zero_or_eq_zero_of_mul_eq_zero h
+      rw [or_iff_not_imp_left] at h
+      exact h hm₁
+    · rintro ⟨i, j⟩ hij hne
+      rw [mem_antidiagonal] at hij
+      rcases trichotomy_of_add_eq_add hij with h_eq | hi_lt | hj_lt
+      · apply False.elim (hne ?_)
+        simpa using h_eq
+      · rw [hm₂ i hi_lt, zero_mul]
+      · rw [ih j hj_lt, mul_zero]
+    · contrapose!
+      intro
+      rw [mem_antidiagonal]
 
 end Semiring
 

--- a/Mathlib/RingTheory/PowerSeries/Basic.lean
+++ b/Mathlib/RingTheory/PowerSeries/Basic.lean
@@ -211,6 +211,11 @@ def X : R⟦X⟧ :=
 theorem commute_X (φ : R⟦X⟧) : Commute φ X :=
   MvPowerSeries.commute_X _ _
 
+theorem mul_X_pow_eq_X_pow_mul {φ : R⟦X⟧} {n : ℕ} :
+    φ * X ^ n = X ^ n * φ := by
+  rw [← commute_iff_eq]
+  exact Commute.pow_right (commute_X φ) n
+
 @[simp]
 theorem coeff_zero_eq_constantCoeff : ⇑(coeff R 0) = constantCoeff R := by
   rw [coeff, Finsupp.single_zero]

--- a/Mathlib/RingTheory/PowerSeries/Basic.lean
+++ b/Mathlib/RingTheory/PowerSeries/Basic.lean
@@ -34,6 +34,10 @@ and the fact that power series over a local ring form a local ring;
 and application to the fact that power series over an integral domain
 form an integral domain.
 
+##  Instance
+
+If `R` has `NoZeroDivisors`, then so does `R⟦X⟧`.
+
 ## Implementation notes
 
 Because of its definition,
@@ -536,27 +540,24 @@ instance [NoZeroDivisors R] : NoZeroDivisors R⟦X⟧ where
       contrapose! H
       exact ext H
     let m := Nat.find ex
-    have hm₁ : coeff R m φ ≠ 0 := Nat.find_spec ex
-    have hm₂ : ∀ k < m, ¬coeff R k φ ≠ 0 := fun k => Nat.find_min ex
-    simp only [ne_eq, Decidable.not_not] at hm₂
     ext n
     rw [(coeff R n).map_zero]
     induction' n using Nat.strong_induction_on with n ih
     replace h := congr_arg (coeff R (m + n)) h
     rw [LinearMap.map_zero, coeff_mul, Finset.sum_eq_single (m, n)] at h
-    · replace h := NoZeroDivisors.eq_zero_or_eq_zero_of_mul_eq_zero h
-      rw [or_iff_not_imp_left] at h
-      exact h hm₁
+    · simp only [mul_eq_zero] at h
+      exact Or.resolve_left h (Nat.find_spec ex)
     · rintro ⟨i, j⟩ hij hne
       rw [mem_antidiagonal] at hij
       rcases trichotomy_of_add_eq_add hij with h_eq | hi_lt | hj_lt
       · apply False.elim (hne ?_)
         simpa using h_eq
-      · rw [hm₂ i hi_lt, zero_mul]
+      · suffices coeff  R i φ = 0 by -- have := Nat.find_min ex hi_lt
+          rw [this, zero_mul]
+        by_contra h;
+          exact Nat.find_min ex hi_lt h
       · rw [ih j hj_lt, mul_zero]
-    · contrapose!
-      intro
-      rw [mem_antidiagonal]
+    · simp
 
 end Semiring
 

--- a/Mathlib/RingTheory/PowerSeries/Basic.lean
+++ b/Mathlib/RingTheory/PowerSeries/Basic.lean
@@ -338,10 +338,16 @@ theorem mul_X_cancel {φ ψ : R⟦X⟧} (h : φ * X = ψ * X) : φ = ψ := by
   intro n
   simpa using h (n + 1)
 
+theorem mul_X_inj {φ ψ : R⟦X⟧} : φ * X = ψ * X ↔ φ = ψ := by
+  refine ⟨mul_X_cancel, fun h ↦ congrFun (congrArg HMul.hMul h) X⟩
+
 theorem X_mul_cancel {φ ψ : R⟦X⟧} (h : X * φ = X * ψ) : φ = ψ := by
   rw [PowerSeries.ext_iff] at h ⊢
   intro n
   simpa using h (n + 1)
+
+theorem X_mul_inj {φ ψ : R⟦X⟧} : X * φ = X * ψ ↔ φ = ψ := by
+  refine ⟨X_mul_cancel, fun h ↦ congrArg (HMul.hMul X) h⟩
 
 @[simp]
 theorem constantCoeff_C (a : R) : constantCoeff R (C R a) = a :=
@@ -414,11 +420,19 @@ theorem mul_X_pow_cancel {k : ℕ} {φ ψ : R⟦X⟧} (h : φ * X ^ k = ψ * X ^
   intro n
   simpa using h (n + k)
 
+theorem mul_X_pow_inj {k : ℕ} {φ ψ : R⟦X⟧} :
+      φ * X ^ k = ψ * X ^ k ↔ φ = ψ :=
+  ⟨mul_X_pow_cancel, fun h ↦ congrFun (congrArg HMul.hMul h) (X ^ k)⟩
+
 theorem X_pow_mul_cancel {k : ℕ} {φ ψ : R⟦X⟧} (h : X ^ k * φ = X ^ k * ψ) :
     φ = ψ := by
   rw [PowerSeries.ext_iff] at h ⊢
   intro n
   simpa using h (n + k)
+
+theorem X_mul_pow_inj {k : ℕ} {φ ψ : R⟦X⟧} :
+      X ^ k * φ = X ^ k * ψ ↔ φ = ψ :=
+  ⟨X_pow_mul_cancel, fun h ↦ congrArg (HMul.hMul (X ^ k)) h⟩
 
 theorem coeff_mul_X_pow' (p : R⟦X⟧) (n d : ℕ) :
     coeff R d (p * X ^ n) = ite (n ≤ d) (coeff R (d - n) p) 0 := by
@@ -552,10 +566,8 @@ instance [NoZeroDivisors R] : NoZeroDivisors R⟦X⟧ where
       rcases trichotomy_of_add_eq_add hij with h_eq | hi_lt | hj_lt
       · apply False.elim (hne ?_)
         simpa using h_eq
-      · suffices coeff  R i φ = 0 by -- have := Nat.find_min ex hi_lt
-          rw [this, zero_mul]
-        by_contra h;
-          exact Nat.find_min ex hi_lt h
+      · suffices coeff R i φ = 0 by rw [this, zero_mul]
+        by_contra h; exact Nat.find_min ex hi_lt h
       · rw [ih j hj_lt, mul_zero]
     · simp
 

--- a/Mathlib/RingTheory/PowerSeries/Basic.lean
+++ b/Mathlib/RingTheory/PowerSeries/Basic.lean
@@ -215,7 +215,7 @@ def X : R⟦X⟧ :=
 theorem commute_X (φ : R⟦X⟧) : Commute φ X :=
   MvPowerSeries.commute_X _ _
 
-theorem commute_X_pow {φ : R⟦X⟧} {n : ℕ} :
+theorem commute_X_pow (φ : R⟦X⟧) (n : ℕ) :
     Commute φ (X ^ n) := Commute.pow_right (commute_X φ) n
 
 @[simp]
@@ -338,16 +338,16 @@ theorem mul_X_cancel {φ ψ : R⟦X⟧} (h : φ * X = ψ * X) : φ = ψ := by
   intro n
   simpa using h (n + 1)
 
-theorem mul_X_inj {φ ψ : R⟦X⟧} : φ * X = ψ * X ↔ φ = ψ := by
-  refine ⟨mul_X_cancel, fun h ↦ congrFun (congrArg HMul.hMul h) X⟩
+theorem mul_X_inj {φ ψ : R⟦X⟧} : φ * X = ψ * X ↔ φ = ψ :=
+  ⟨mul_X_cancel, fun h ↦ congrFun (congrArg HMul.hMul h) X⟩
 
 theorem X_mul_cancel {φ ψ : R⟦X⟧} (h : X * φ = X * ψ) : φ = ψ := by
   rw [PowerSeries.ext_iff] at h ⊢
   intro n
   simpa using h (n + 1)
 
-theorem X_mul_inj {φ ψ : R⟦X⟧} : X * φ = X * ψ ↔ φ = ψ := by
-  refine ⟨X_mul_cancel, fun h ↦ congrArg (HMul.hMul X) h⟩
+theorem X_mul_inj {φ ψ : R⟦X⟧} : X * φ = X * ψ ↔ φ = ψ :=
+  ⟨X_mul_cancel, fun h ↦ congrArg (HMul.hMul X) h⟩
 
 @[simp]
 theorem constantCoeff_C (a : R) : constantCoeff R (C R a) = a :=

--- a/Mathlib/RingTheory/PowerSeries/Order.lean
+++ b/Mathlib/RingTheory/PowerSeries/Order.lean
@@ -377,11 +377,17 @@ theorem order_pow [Nontrivial R] (φ : R⟦X⟧) (n : ℕ) :
   | succ n hn =>
     simp only [add_smul, one_smul, pow_succ, order_mul, hn]
 
+theorem mul_X_pow_eq_X_pow_mul {R : Type*} [Semiring R] {f : R⟦X⟧} {n : ℕ} :
+    f * X ^ n = X ^ n * f := by
+  rw [← commute_iff_eq]
+  refine Commute.pow_right (commute_X f) n
+
 end NoZeroDivisors
 
 section OrderIsDomain
 
-variable [CommRing R] [IsDomain R]
+-- TODO : generalize to `[Semiring R] [NoZeroDivisors R]`
+variable [Ring R] [IsDomain R]
 
 -- Dividing `X` by the maximal power of `X` dividing it leaves `1`.
 @[simp]
@@ -404,7 +410,9 @@ theorem divided_by_X_pow_orderMul {f g : R⟦X⟧} (hf : f ≠ 0) (hg : g ≠ 0)
       f * g = X ^ df * divided_by_X_pow_order hf * (X ^ dg * divided_by_X_pow_order hg) := by
         rw [self_eq_X_pow_order_mul_divided_by_X_pow_order,
           self_eq_X_pow_order_mul_divided_by_X_pow_order]
-      _ = X ^ df * X ^ dg * divided_by_X_pow_order hf * divided_by_X_pow_order hg := by ring
+      _ = X ^ df * X ^ dg * divided_by_X_pow_order hf * divided_by_X_pow_order hg := by
+        rw [mul_assoc, ← mul_assoc _ (X ^ dg), mul_X_pow_eq_X_pow_mul]
+        simp [mul_assoc]
       _ = X ^ (df + dg) * divided_by_X_pow_order hf * divided_by_X_pow_order hg := by rw [pow_add]
       _ = X ^ dfg * divided_by_X_pow_order hf * divided_by_X_pow_order hg := by rw [H_add_d]
       _ = X ^ dfg * (divided_by_X_pow_order hf * divided_by_X_pow_order hg) := by rw [mul_assoc]

--- a/Mathlib/RingTheory/PowerSeries/Order.lean
+++ b/Mathlib/RingTheory/PowerSeries/Order.lean
@@ -350,22 +350,10 @@ theorem order_mul (φ ψ : R⟦X⟧) : order (φ * ψ) = order φ + order ψ := 
     rw [coeff_mul, Finset.sum_eq_single ⟨m, n⟩]
     · exact mul_ne_zero_iff.mpr ⟨hm.1, hn.1⟩
     · intro ij hij h
-      by_cases h' : ij.1 < m
+      rcases trichotomy_of_add_eq_add (mem_antidiagonal.mp hij) with h' | h' | h'
+      · exact False.elim (h (by simp [Prod.ext_iff, h'.1, h'.2]))
       · rw [hm.2 ij.1 h', zero_mul]
-      · rw [hn.2 ij.2]
-        · rw [mul_zero]
-        · simp only [mem_antidiagonal] at hij
-          apply Nat.lt_of_add_lt_add_left
-          rw [← hij]
-          refine Nat.add_lt_add_right ?_ ij.2
-          rw [lt_iff_le_and_ne]
-          refine ⟨not_lt.mp h', ?_⟩
-          intro h''
-          apply h
-          ext
-          · exact h''.symm
-          · dsimp
-            simpa only [h'', Nat.add_right_inj] using hij
+      · rw [hn.2 ij.2 h', mul_zero]
     · intro h
       apply False.elim (h _)
       simp [mem_antidiagonal]

--- a/Mathlib/RingTheory/PowerSeries/Order.lean
+++ b/Mathlib/RingTheory/PowerSeries/Order.lean
@@ -348,9 +348,9 @@ theorem order_mul (φ ψ : R⟦X⟧) : order (φ * ψ) = order φ + order ψ := 
       simp [mem_antidiagonal]
 
 theorem order_pow [Nontrivial R] (φ : R⟦X⟧) (n : ℕ) :
-    order (φ ^ n) = n • (order φ) := by
+    order (φ ^ n) = n • order φ := by
   rcases subsingleton_or_nontrivial R with hR | hR
-  · simp [Subsingleton.eq_zero φ]
+  · simp only [Subsingleton.eq_zero φ, order_zero, nsmul_eq_mul]
     by_cases hn : n = 0
     · simp [hn, pow_zero]
     · simp [zero_pow hn, ENat.mul_top', if_neg hn]

--- a/Mathlib/RingTheory/PowerSeries/Order.lean
+++ b/Mathlib/RingTheory/PowerSeries/Order.lean
@@ -375,7 +375,7 @@ theorem divided_by_X_pow_orderMul {f g : R⟦X⟧} (hf : f ≠ 0) (hg : g ≠ 0)
         rw [self_eq_X_pow_order_mul_divided_by_X_pow_order,
           self_eq_X_pow_order_mul_divided_by_X_pow_order]
       _ = X ^ df * X ^ dg * divided_by_X_pow_order hf * divided_by_X_pow_order hg := by
-        rw [mul_assoc, ← mul_assoc _ (X ^ dg), (commute_iff_eq _ _).mp commute_X_pow]
+        rw [mul_assoc, ← mul_assoc _ (X ^ dg), (commute_iff_eq _ _).mp (commute_X_pow _ _)];
         simp [mul_assoc]
       _ = X ^ (df + dg) * divided_by_X_pow_order hf * divided_by_X_pow_order hg := by rw [pow_add]
       _ = X ^ dfg * divided_by_X_pow_order hf * divided_by_X_pow_order hg := by rw [H_add_d]

--- a/Mathlib/RingTheory/PowerSeries/Order.lean
+++ b/Mathlib/RingTheory/PowerSeries/Order.lean
@@ -311,14 +311,12 @@ theorem order_X_pow (n : ℕ) : order ((X : R⟦X⟧) ^ n) = n := by
   rw [X_pow_eq, order_monomial_of_ne_zero]
   exact one_ne_zero
 
+@[simp]
 theorem divided_by_X_pow_order_of_X_eq_one :
     divided_by_X_pow_order X_ne_zero = (1 : R⟦X⟧) := by
   apply X_pow_mul_cancel
   rw [self_eq_X_pow_order_mul_divided_by_X_pow_order]
   simp
-
-example [NoZeroDivisors R] {f g : R⟦X⟧} (hf : f ≠ 0) (hg : g ≠ 0) : f * g ≠ 0 := by
-   exact (mul_ne_zero_iff_right hg).mpr hf
 
 end OrderZeroNeOne
 

--- a/Mathlib/RingTheory/PowerSeries/Order.lean
+++ b/Mathlib/RingTheory/PowerSeries/Order.lean
@@ -377,11 +377,6 @@ theorem order_pow [Nontrivial R] (φ : R⟦X⟧) (n : ℕ) :
   | succ n hn =>
     simp only [add_smul, one_smul, pow_succ, order_mul, hn]
 
-theorem mul_X_pow_eq_X_pow_mul {R : Type*} [Semiring R] {f : R⟦X⟧} {n : ℕ} :
-    f * X ^ n = X ^ n * f := by
-  rw [← commute_iff_eq]
-  refine Commute.pow_right (commute_X f) n
-
 end NoZeroDivisors
 
 section OrderIsDomain

--- a/Mathlib/RingTheory/PowerSeries/Order.lean
+++ b/Mathlib/RingTheory/PowerSeries/Order.lean
@@ -178,6 +178,29 @@ theorem le_order_mul (φ ψ : R⟦X⟧) : order φ + order ψ ≤ order (φ * ψ
   apply ne_of_lt (lt_of_lt_of_le hn <| add_le_add hi hj)
   rw [← Nat.cast_add, hij]
 
+theorem le_order_pow (φ : R⟦X⟧) (n : ℕ) : n • (order φ) ≤ order (φ ^ n) := by
+  induction n with
+  | zero => simp
+  | succ n hn =>
+    simp only [add_smul, one_smul, pow_succ]
+    apply le_trans _ (le_order_mul _ _)
+    exact add_le_add_right hn φ.order
+    /-
+    [IsDomain S]
+    (hf : constantCoeff S b = 0) {d n : ℕ} (hd : d < n) :
+    coeff S d (b ^ n) = 0 := by
+  suffices 1 ≤ b.order  by
+    apply PowerSeries.coeff_of_lt_order
+    rw [order_pow]
+    apply lt_of_lt_of_le  (b := (n : ℕ∞))
+    exact ENat.coe_lt_coe.mpr hd
+    simp
+    exact le_mul_of_one_le_right' this
+  apply le_order
+  intro i hi
+  simp only [cast_lt_one] at hi
+  simp [hi, hf] -/
+
 alias order_mul_ge := le_order_mul
 
 /-- The order of the monomial `a*X^n` is infinite if `a = 0` and `n` otherwise. -/
@@ -305,17 +328,60 @@ theorem order_X_pow (n : ℕ) : order ((X : R⟦X⟧) ^ n) = n := by
 
 end OrderZeroNeOne
 
-section OrderIsDomain
+section NoZeroDivisors
 
--- TODO: generalize to `[Semiring R] [NoZeroDivisors R]`
-variable [CommRing R] [IsDomain R]
+variable [Semiring R] [NoZeroDivisors R]
 
 /-- The order of the product of two formal power series over an integral domain
  is the sum of their orders. -/
 theorem order_mul (φ ψ : R⟦X⟧) : order (φ * ψ) = order φ + order ψ := by
-  classical
+/-   classical
   simp only [order_eq_emultiplicity_X]
-  exact emultiplicity_mul X_prime
+  exact emultiplicity_mul X_prime -/
+  apply le_antisymm _ (le_order_mul _ _)
+  by_cases h : φ.order = ⊤ ∨ ψ.order = ⊤
+  · rcases h with h | h <;> simp [h]
+  · simp only [not_or, ENat.ne_top_iff_exists] at h
+    obtain ⟨m, hm⟩ := h.1
+    obtain ⟨n, hn⟩ := h.2
+    rw [← hm, ← hn, ← ENat.coe_add]
+    rw [eq_comm, order_eq_nat] at hm hn
+    apply order_le
+    rw [coeff_mul, Finset.sum_eq_single ⟨m, n⟩]
+    · exact mul_ne_zero_iff.mpr ⟨hm.1, hn.1⟩
+    · intro ij hij h
+      by_cases h' : ij.1 < m
+      · rw [hm.2 ij.1 h', zero_mul]
+      · rw [hn.2 ij.2]
+        · rw [mul_zero]
+        · simp only [mem_antidiagonal] at hij
+          apply Nat.lt_of_add_lt_add_left
+          rw [← hij]
+          refine Nat.add_lt_add_right ?_ ij.2
+          rw [lt_iff_le_and_ne]
+          refine ⟨not_lt.mp h', ?_⟩
+          intro h''
+          apply h
+          ext
+          · exact h''.symm
+          · dsimp
+            simpa only [h'', Nat.add_right_inj] using hij
+    · intro h
+      apply False.elim (h _)
+      simp [mem_antidiagonal]
+
+theorem order_pow [Nontrivial R] (φ : R⟦X⟧) (n : ℕ) :
+    order (φ ^ n) = n • (order φ) := by
+  induction n with
+  | zero => simp
+  | succ n hn =>
+    simp only [add_smul, one_smul, pow_succ, order_mul, hn]
+
+end NoZeroDivisors
+
+section OrderIsDomain
+
+variable [CommRing R] [IsDomain R]
 
 -- Dividing `X` by the maximal power of `X` dividing it leaves `1`.
 @[simp]

--- a/Mathlib/RingTheory/PowerSeries/Order.lean
+++ b/Mathlib/RingTheory/PowerSeries/Order.lean
@@ -178,7 +178,7 @@ theorem le_order_mul (φ ψ : R⟦X⟧) : order φ + order ψ ≤ order (φ * ψ
   apply ne_of_lt (lt_of_lt_of_le hn <| add_le_add hi hj)
   rw [← Nat.cast_add, hij]
 
-theorem le_order_pow (φ : R⟦X⟧) (n : ℕ) : n • (order φ) ≤ order (φ ^ n) := by
+theorem le_order_pow (φ : R⟦X⟧) (n : ℕ) : n • order φ ≤ order (φ ^ n) := by
   induction n with
   | zero => simp
   | succ n hn =>


### PR DESCRIPTION
* compute order of power of power series
* generalize `order_mul`
* generalize lemmas at the end to `[Semiring R] [NoZeroDivisors R]` by proving (`PowerSeries.X_pow_mul_cancel`) that one can divide out by powers on `X` on both sides
of an equality.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
