### PR TITLE
[Merged by Bors] - feat(RingTheory/LocalRing): `IsLocalRing.of_singleton_maximalSpectrum`

### DIFF
--- a/Mathlib/RingTheory/LocalRing/MaximalIdeal/Basic.lean
+++ b/Mathlib/RingTheory/LocalRing/MaximalIdeal/Basic.lean
@@ -62,9 +62,9 @@ omit [IsLocalRing R] in
 /-- If the maximal spectrum of a ring is a singleton, then the ring is local. -/
 theorem of_singleton_maximalSpectrum [Subsingleton (MaximalSpectrum R)]
     [Nonempty (MaximalSpectrum R)] : IsLocalRing R :=
-  let inst : Unique (MaximalSpectrum R) := uniqueOfSubsingleton Classical.ofNonempty
-  .of_unique_max_ideal ⟨inst.default.asIdeal, ⟨inst.default.isMaximal,
-    fun I hI ↦ MaximalSpectrum.mk.inj <| inst.eq_default ⟨I, hI⟩⟩⟩
+  let m := Classical.arbitrary (MaximalSpectrum R)
+  .of_unique_max_ideal ⟨m.asIdeal, m.isMaximal,
+    fun I hI ↦ MaximalSpectrum.mk.inj <| Subsingleton.elim ⟨I, hI⟩ m⟩
 
 theorem le_maximalIdeal {J : Ideal R} (hJ : J ≠ ⊤) : J ≤ maximalIdeal R := by
   rcases Ideal.exists_le_maximal J hJ with ⟨M, hM1, hM2⟩

--- a/Mathlib/RingTheory/LocalRing/MaximalIdeal/Basic.lean
+++ b/Mathlib/RingTheory/LocalRing/MaximalIdeal/Basic.lean
@@ -59,8 +59,10 @@ instance : Unique (MaximalSpectrum R) where
   uniq := fun I ↦ MaximalSpectrum.ext_iff.mpr <| eq_maximalIdeal I.isMaximal
 
 omit [IsLocalRing R] in
-/-- If a ring has a singleton maximal spectrum, then it is local. -/
-theorem of_unique_maximalSpectrum [inst : Unique (MaximalSpectrum R)] : IsLocalRing R :=
+/-- If the maximal spectrum of a ring is a singleton, then the ring is local. -/
+theorem of_singleton_maximalSpectrum [Subsingleton (MaximalSpectrum R)]
+    [Nonempty (MaximalSpectrum R)] : IsLocalRing R :=
+  let inst : Unique (MaximalSpectrum R) := uniqueOfSubsingleton Classical.ofNonempty
   .of_unique_max_ideal ⟨inst.default.asIdeal, ⟨inst.default.isMaximal,
     fun I hI ↦ MaximalSpectrum.mk.inj <| inst.eq_default ⟨I, hI⟩⟩⟩
 

--- a/Mathlib/RingTheory/LocalRing/MaximalIdeal/Basic.lean
+++ b/Mathlib/RingTheory/LocalRing/MaximalIdeal/Basic.lean
@@ -58,6 +58,12 @@ instance : Unique (MaximalSpectrum R) where
   default := ⟨maximalIdeal R, maximalIdeal.isMaximal R⟩
   uniq := fun I ↦ MaximalSpectrum.ext_iff.mpr <| eq_maximalIdeal I.isMaximal
 
+omit [IsLocalRing R] in
+/-- If a ring has a singleton maximal spectrum, then it is local. -/
+theorem of_unique_maximalSpectrum [inst : Unique (MaximalSpectrum R)] : IsLocalRing R :=
+  .of_unique_max_ideal ⟨inst.default.asIdeal, ⟨inst.default.isMaximal,
+    fun I hI ↦ MaximalSpectrum.mk.inj <| inst.eq_default ⟨I, hI⟩⟩⟩
+
 theorem le_maximalIdeal {J : Ideal R} (hJ : J ≠ ⊤) : J ≤ maximalIdeal R := by
   rcases Ideal.exists_le_maximal J hJ with ⟨M, hM1, hM2⟩
   rwa [← eq_maximalIdeal hM1]


### PR DESCRIPTION
Add the fact that a ring with `MaximalSpectrum` that is a singleton is local.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
