### PR TITLE
[Merged by Bors] - chore(FreeModule): clean up

### DIFF
--- a/Mathlib/LinearAlgebra/FreeModule/Basic.lean
+++ b/Mathlib/LinearAlgebra/FreeModule/Basic.lean
@@ -28,38 +28,40 @@ universe u v w z
 
 variable {ι : Type*} (R : Type u) (M : Type v) (N : Type z)
 
+namespace Module
 section Basic
 
 variable [Semiring R] [AddCommMonoid M] [Module R M]
 
 /-- `Module.Free R M` is the statement that the `R`-module `M` is free. -/
-class Module.Free : Prop where
-  exists_basis : Nonempty <| (I : Type v) × Basis I R M
+class Free (R : Type u) (M : Type v) [Semiring R] [AddCommMonoid M] [Module R M] : Prop where
+  exists_basis (R M) : Nonempty <| (I : Type v) × Basis I R M
 
-theorem Module.free_iff_set : Module.Free R M ↔ ∃ S : Set M, Nonempty (Basis S R M) :=
-  ⟨fun h => ⟨Set.range h.exists_basis.some.2, ⟨Basis.reindexRange h.exists_basis.some.2⟩⟩,
-    fun ⟨S, hS⟩ => ⟨nonempty_sigma.2 ⟨S, hS⟩⟩⟩
+lemma Free.exists_set [Free R M] : ∃ S : Set M, Nonempty (Basis S R M) :=
+  let ⟨_I, b⟩ := exists_basis R M; ⟨Set.range b, ⟨b.reindexRange⟩⟩
+
+theorem free_iff_set : Free R M ↔ ∃ S : Set M, Nonempty (Basis S R M) :=
+  ⟨fun _ ↦ Free.exists_set .., fun ⟨S, hS⟩ ↦ ⟨nonempty_sigma.2 ⟨S, hS⟩⟩⟩
 
 /-- If `M` fits in universe `w`, then freeness is equivalent to existence of a basis in that
 universe.
 
 Note that if `M` does not fit in `w`, the reverse direction of this implication is still true as
 `Module.Free.of_basis`. -/
-theorem Module.free_def [Small.{w,v} M] :
-    Module.Free R M ↔ ∃ I : Type w, Nonempty (Basis I R M) :=
-  ⟨fun h =>
+theorem free_def [Small.{w,v} M] : Free R M ↔ ∃ I : Type w, Nonempty (Basis I R M) where
+  mp h :=
     ⟨Shrink (Set.range h.exists_basis.some.2),
-      ⟨(Basis.reindexRange h.exists_basis.some.2).reindex (equivShrink _)⟩⟩,
-    fun h => ⟨(nonempty_sigma.2 h).map fun ⟨_, b⟩ => ⟨Set.range b, b.reindexRange⟩⟩⟩
+      ⟨(Basis.reindexRange h.exists_basis.some.2).reindex (equivShrink _)⟩⟩
+  mpr h := ⟨(nonempty_sigma.2 h).map fun ⟨_, b⟩ => ⟨Set.range b, b.reindexRange⟩⟩
 
 variable {R M}
 
-theorem Module.Free.of_basis {ι : Type w} (b : Basis ι R M) : Module.Free R M :=
-  (Module.free_def R M).2 ⟨Set.range b, ⟨b.reindexRange⟩⟩
+theorem Free.of_basis {ι : Type w} (b : Basis ι R M) : Free R M :=
+  (free_def R M).2 ⟨Set.range b, ⟨b.reindexRange⟩⟩
 
 end Basic
 
-namespace Module.Free
+namespace Free
 
 section Semiring
 


### PR DESCRIPTION
Make `R` and `M` explicit in `Free.exists_basis`. Open the `Module` namespace. Add `Free.exists_set` as a convenience lemma.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
