### PR TITLE
[Merged by Bors] - fix: remove notation hacks in monoidal categories

### DIFF
--- a/Mathlib/CategoryTheory/Monoidal/Category.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Category.lean
@@ -90,7 +90,7 @@ class MonoidalCategoryStruct (C : Type u) [𝒞 : Category.{v} C] where
   tensorHom {X₁ Y₁ X₂ Y₂ : C} (f : X₁ ⟶ Y₁) (g : X₂ ⟶ Y₂) : (tensorObj X₁ X₂ ⟶ tensorObj Y₁ Y₂) :=
     whiskerRight f X₂ ≫ whiskerLeft Y₁ g
   /-- The tensor unity in the monoidal structure `𝟙_ C` -/
-  tensorUnit : C
+  tensorUnit (C) : C
   /-- The associator isomorphism `(X ⊗ Y) ⊗ Z ≃ X ⊗ (Y ⊗ Z)` -/
   associator : ∀ X Y Z : C, tensorObj (tensorObj X Y) Z ≅ tensorObj X (tensorObj Y Z)
   /-- The left unitor: `𝟙_ C ⊗ X ≃ X` -/
@@ -120,16 +120,7 @@ scoped infixl:81 " ▷ " => MonoidalCategoryStruct.whiskerRight
 scoped infixr:70 " ⊗ " => MonoidalCategoryStruct.tensorHom
 
 /-- Notation for `tensorUnit`, the two-sided identity of `⊗` -/
-scoped notation "𝟙_ " C:max => (MonoidalCategoryStruct.tensorUnit : C)
-
-open Lean PrettyPrinter.Delaborator SubExpr in
-/-- Used to ensure that `𝟙_` notation is used, as the ascription makes this not automatic. -/
-@[app_delab CategoryTheory.MonoidalCategoryStruct.tensorUnit]
-def delabTensorUnit : Delab := whenPPOption getPPNotation <| withOverApp 3 do
-  let e ← getExpr
-  guard <| e.isAppOfArity ``MonoidalCategoryStruct.tensorUnit 3
-  let C ← withNaryArg 0 delab
-  `(𝟙_ $C)
+scoped notation "𝟙_ " C:arg => MonoidalCategoryStruct.tensorUnit C
 
 /-- Notation for the monoidal `associator`: `(X ⊗ Y) ⊗ Z ≃ X ⊗ (Y ⊗ Z)` -/
 scoped notation "α_" => MonoidalCategoryStruct.associator
@@ -710,11 +701,11 @@ abbrev ofTensorHom [MonoidalCategoryStruct C]
             aesop_cat)
     (leftUnitor_naturality :
       ∀ {X Y : C} (f : X ⟶ Y),
-        tensorHom (𝟙 tensorUnit) f ≫ (leftUnitor Y).hom = (leftUnitor X).hom ≫ f := by
+        tensorHom (𝟙 (𝟙_ C)) f ≫ (leftUnitor Y).hom = (leftUnitor X).hom ≫ f := by
           aesop_cat)
     (rightUnitor_naturality :
       ∀ {X Y : C} (f : X ⟶ Y),
-        tensorHom f (𝟙 tensorUnit) ≫ (rightUnitor Y).hom = (rightUnitor X).hom ≫ f := by
+        tensorHom f (𝟙 (𝟙_ C)) ≫ (rightUnitor Y).hom = (rightUnitor X).hom ≫ f := by
           aesop_cat)
     (pentagon :
       ∀ W X Y Z : C,
@@ -724,7 +715,7 @@ abbrev ofTensorHom [MonoidalCategoryStruct C]
             aesop_cat)
     (triangle :
       ∀ X Y : C,
-        (associator X tensorUnit Y).hom ≫ tensorHom (𝟙 X) (leftUnitor Y).hom =
+        (associator X (𝟙_ C) Y).hom ≫ tensorHom (𝟙 X) (leftUnitor Y).hom =
           tensorHom (rightUnitor X).hom (𝟙 Y) := by
             aesop_cat) :
       MonoidalCategory C where

--- a/Mathlib/Tactic/CategoryTheory/Monoidal/Datatypes.lean
+++ b/Mathlib/Tactic/CategoryTheory/Monoidal/Datatypes.lean
@@ -89,7 +89,7 @@ instance : MonadMor₁ MonoidalM where
   id₁M a := do
     let ctx ← read
     let .some _monoidal := ctx.instMonoidal? | synthMonoidalError
-    return .id (q(MonoidalCategory.tensorUnit) : Q($ctx.C)) a
+    return .id (q(𝟙_ _) : Q($ctx.C)) a
   comp₁M f g := do
     let ctx ← read
     let .some _monoidal := ctx.instMonoidal? | synthMonoidalError
@@ -404,7 +404,7 @@ def id₁? (e : Expr) : MonoidalM (Option Obj) := do
   let ctx ← read
   match ctx.instMonoidal? with
   | .some _monoidal => do
-    if ← withDefault <| isDefEq e (q(MonoidalCategory.tensorUnit) : Q($ctx.C)) then
+    if ← withDefault <| isDefEq e (q(𝟙_ _) : Q($ctx.C)) then
       return some ⟨none⟩
     else
       return none

--- a/Mathlib/Tactic/CategoryTheory/Monoidal/PureCoherence.lean
+++ b/Mathlib/Tactic/CategoryTheory/Monoidal/PureCoherence.lean
@@ -249,12 +249,12 @@ instance : MkEqOfNaturality MonoidalM where
     have θ : Q($f ⟶ $g) := θ
     have η'_e : Q($f ≅ $g) := η'.e
     have θ'_e : Q($f ≅ $g) := θ'.e
-    have η_f : Q(tensorUnit ⊗ $f ≅ $f') := η_f.e
-    have η_g : Q(tensorUnit ⊗ $g ≅ $f') := η_g.e
+    have η_f : Q(𝟙_ _ ⊗ $f ≅ $f') := η_f.e
+    have η_g : Q(𝟙_ _ ⊗ $g ≅ $f') := η_g.e
     have η_hom : Q(Iso.hom $η'_e = $η) := ηIso.eq
     have Θ_hom : Q(Iso.hom $θ'_e = $θ) := θIso.eq
-    have Hη : Q(whiskerLeftIso tensorUnit $η'_e ≪≫ $η_g = $η_f) := Hη
-    have Hθ : Q(whiskerLeftIso tensorUnit $θ'_e ≪≫ $η_g = $η_f) := Hθ
+    have Hη : Q(whiskerLeftIso (𝟙_ _) $η'_e ≪≫ $η_g = $η_f) := Hη
+    have Hθ : Q(whiskerLeftIso (𝟙_ _) $θ'_e ≪≫ $η_g = $η_f) := Hθ
     return q(mk_eq_of_naturality $η_f $η_g $η_hom $Θ_hom $Hη $Hθ)
 
 open Elab.Tactic


### PR DESCRIPTION
Now that we can adjust argument explicitness in fields, we no longer need a custom delaborator.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
