### PR TITLE
[Merged by Bors] - chore(Data/Matroid): fix some docstrings

### DIFF
--- a/Mathlib/Data/Matroid/Basic.lean
+++ b/Mathlib/Data/Matroid/Basic.lean
@@ -22,7 +22,7 @@ where the bases are required to obey certain axioms.
 
 This file gives a definition of a matroid `M` in terms of its bases,
 and some API relating independent sets (subsets of bases) and the notion of a
-isBasis of a set `X` (a maximal independent subset of `X`).
+basis of a set `X` (a maximal independent subset of `X`).
 
 ## Main definitions
 
@@ -154,16 +154,11 @@ There are a few design decisions worth discussing.
 
 ## References
 
-[1] The standard text on matroid theory
-[J. G. Oxley, Matroid Theory, Oxford University Press, New York, 2011.]
-
-[2] The robust axiomatic definition of infinite matroids
-[H. Bruhn, R. Diestel, M. Kriesell, R. Pendavingh, P. Wollan, Axioms for infinite matroids,
-  Adv. Math 239 (2013), 18-46]
-
-[3] Equicardinality of matroid bases is independent of ZFC.
-[N. Bowler, S. Geschke, Self-dual uniform matroids on infinite sets,
-  Proc. Amer. Math. Soc. 144 (2016), 459-471]
+* [J. Oxley, Matroid Theory][oxley2011]
+* [H. Bruhn, R. Diestel, M. Kriesell, R. Pendavingh, P. Wollan, Axioms for infinite matroids,
+  Adv. Math 239 (2013), 18-46][bruhnDiestelKriesselPendavinghWollan2013]
+* [N. Bowler, S. Geschke, Self-dual uniform matroids on infinite sets,
+  Proc. Amer. Math. Soc. 144 (2016), 459-471][bowlerGeschke2015]
 -/
 
 assert_not_exists Field

--- a/Mathlib/Data/Matroid/Circuit.lean
+++ b/Mathlib/Data/Matroid/Circuit.lean
@@ -19,7 +19,7 @@ In matroids arising from graphs, circuits correspond to graphical cycles.
 * For an `Indep`endent set `I` whose closure contains an element `e ∉ I`,
   `Matroid.fundCircuit M e I` is the unique circuit contained in `insert e I`.
 * `Matroid.Indep.fundCircuit_isCircuit` states that `Matroid.fundCircuit M e I` is indeed a circuit.
-* `Circuit.eq_fundCircuit_of_subset` states that `Matroid.fundCircuit M e I` is the
+* `Matroid.IsCircuit.eq_fundCircuit_of_subset` states that `Matroid.fundCircuit M e I` is the
   unique circuit contained in `insert e I`.
 * `Matroid.dep_iff_superset_isCircuit` states that the dependent subsets of the ground set
   are precisely those that contain a circuit.
@@ -33,8 +33,8 @@ In matroids arising from graphs, circuits correspond to graphical cycles.
   or equivalently that `M.E \ C` is a hyperplane of `M`.
 * `Matroid.fundCocircuit M B e` is the unique cocircuit that intersects the base `B` precisely
   in the element `e`.
-* `Base.mem_fundCocircuit_iff_mem_fundCircuit` : `e` is in the fundamental circuit for `B` and `f`
-  iff `f` is in the fundamental cocircuit for `B` and `e`.
+* `Matroid.IsBase.mem_fundCocircuit_iff_mem_fundCircuit` : `e` is in the fundamental circuit
+  for `B` and `f` iff `f` is in the fundamental cocircuit for `B` and `e`.
 
 # Implementation Details
 
@@ -53,7 +53,7 @@ open Set
 
 namespace Matroid
 
-/-- A `Circuit` of `M` is a minimal dependent set in `M` -/
+/-- `M.IsCircuit C` means that `C` is a minimal dependent set in `M`. -/
 def IsCircuit (M : Matroid α) := Minimal M.Dep
 
 @[deprecated (since := "2025-02-14")] alias Circuit := IsCircuit
@@ -189,8 +189,8 @@ lemma restrict_isCircuit_iff (hR : R ⊆ M.E := by aesop_mat) :
 /-! ### Fundamental IsCircuits -/
 
 /-- For an independent set `I` and some `e ∈ M.closure I \ I`,
-`M.fundCircuit e I` is the unique isCircuit contained in `insert e I`.
-For the fact that this is a isCircuit, see `Matroid.Indep.fundCircuit_isCircuit`,
+`M.fundCircuit e I` is the unique circuit contained in `insert e I`.
+For the fact that this is a circuit, see `Matroid.Indep.fundCircuit_isCircuit`,
 and the fact that it is unique, see `Matroid.IsCircuit.eq_fundCircuit_of_subset`.
 Has the junk value `{e}` if `e ∈ I` or `e ∉ M.E`, and `insert e I` if `e ∈ M.E \ M.closure I`. -/
 def fundCircuit (M : Matroid α) (e : α) (I : Set α) : Set α :=
@@ -411,7 +411,7 @@ lemma IsCircuit.strong_multi_elimination_insert (x : ι → α) (I : ι → Set 
   exact union_subset_union_left _ diff_subset
 
 /-- A generalization of the strong circuit elimination axiom `Matroid.IsCircuit.strong_elimination`
-to an infinite collection of isCircuits.
+to an infinite collection of circuits.
 
 It states that, given a circuit `C₀`, a arbitrary collection `C : ι → Set α` of circuits,
 an element `x i` of `C₀ ∩ C i` for each `i`, and an element `z ∈ C₀` outside all the `C i`,
@@ -473,7 +473,7 @@ lemma IsCircuit.strong_elimination (hC₁ : M.IsCircuit C₁) (hC₂ : M.IsCircu
     (by simpa) (by simpa) (by simpa) (by simp) (by simpa) (by simpa)
   exact ⟨C, hCs.trans (diff_subset_diff (by simp) (by simp)), hC, hfC⟩
 
-/-- The circuit elimination axiom : for any pair of distinct isCircuits `C₁, C₂` and any `e`,
+/-- The circuit elimination axiom : for any pair of distinct circuits `C₁, C₂` and any `e`,
 some circuit is contained in `(C₁ ∪ C₂) \ {e}`.
 
 This is one of the axioms when defining a finitary matroid via circuits;
@@ -599,8 +599,8 @@ lemma IsBase.compl_closure_diff_singleton_isCocircuit (hB : M.IsBase B) (he : e 
     apply closure_subset_ground
   exact hB.exchange_base_of_not_mem_closure he fcl
 
-/-- A version of `cocircuit_iff_minimal_compl_nonspanning` with a support assumption
-in the minimality -/
+/-- A version of `Matroid.isCocircuit_iff_minimal_compl_nonspanning` with a support assumption
+in the minimality. -/
 lemma isCocircuit_iff_minimal_compl_nonspanning' :
     M.IsCocircuit K ↔ Minimal (fun X ↦ ¬ M.Spanning (M.E \ X) ∧ X ⊆ M.E) K := by
   rw [isCocircuit_iff_minimal_compl_nonspanning]

--- a/Mathlib/Data/Matroid/Closure.lean
+++ b/Mathlib/Data/Matroid/Closure.lean
@@ -11,8 +11,8 @@ import Mathlib.Order.CompleteLatticeIntervals
 # Matroid Closure
 
 A flat (`IsFlat`) of a matroid `M` is a combinatorial analogue of a subspace of a vector space,
-and is defined to be a subset `F` of the ground set of `M` such that for each isBasis
-`I` for `M`, every set having `I` as a isBasis is contained in `F`.
+and is defined to be a subset `F` of the ground set of `M` such that for each basis
+`I` for `F`, every set having `I` as a basis is contained in `F`.
 
 The *closure* of a set `X` in a matroid `M` is the intersection of all flats of `M` containing `X`.
 This is a combinatorial analogue of the linear span of a set of vectors.

--- a/Mathlib/Data/Matroid/Dual.lean
+++ b/Mathlib/Data/Matroid/Dual.lean
@@ -21,8 +21,8 @@ This is an abbreviation for `M✶.Indep X`, but has its own name for the sake of
 
 ## Main Definitions
 
-* `M.Dual`, written `M✶`, is the matroid in which a set `B` is a base if and only if `B ⊆ M.E`
-  and `M.E \ B` is a base for `M`.
+* `M.Dual`, written `M✶`, is the matroid on `M.E` which a set `B ⊆ M.E` is a base if and only if
+  `M.E \ B` is a base for `M`.
 
 * `M.Coindep X` means `M✶.Indep X`, or equivalently that `X` is contained in `M.E \ B` for some
   base `B` of `M`.

--- a/Mathlib/Data/Matroid/Loop.lean
+++ b/Mathlib/Data/Matroid/Loop.lean
@@ -29,7 +29,7 @@ and provides API for interacting with them.
 The dual notion of a loop is a 'coloop'. Geometrically, these can be thought of elements that are
 skew to the remainder of the matroid. Coloops in graphic matroids are 'bridge' edges of the graph,
 and coloops in linearly representable matroids are vectors not spanned by the other vectors
-in the elements of the matroid.
+in the matroid.
 Coloops also have many equivalent definitions in abstract matroid language;
 a coloop is an element of `M.E` if any of the following equivalent conditions holds :
 * `e` is a loop of `M✶`;
@@ -48,6 +48,8 @@ For `M` : Matroid `α`:
 * `M.IsColoop e ` means that `e` is a loop of `M✶`.
 * `M.coloops` is the set of coloops of `M✶`.
 * `M.isColoop_tfae` gives a number of properties that are equivalent to `IsColoop`.
+* `M.Loopless` is a typeclass meaning `M` has no loops.
+* `M.removeLoops` is the matroid obtained from `M` by restricting to its set of nonloop elements.
 -/
 
 variable {α β : Type*} {M N : Matroid α} {e f : α} {F X C I : Set α}

--- a/Mathlib/Data/Matroid/Map.lean
+++ b/Mathlib/Data/Matroid/Map.lean
@@ -57,8 +57,8 @@ In the definitions below, `M` and `N` are matroids on `α` and `β` respectively
 * `Matroid.mapSetEquiv f` is a version of `Matroid.map` where `f : M.E ≃ E` is an equivalence on
   subtypes. It gives a matroid on `β` with ground set `E`.
 
-* For `X : Set α`, `Matroid.restrictSubtype M X` is the `Matroid X` with ground set
-  `univ : Set X` that is isomorphic to `M ↾ X`.
+* For `X : Set α`, `Matroid.restrictSubtype M X` is the `Matroid ↥X` with ground set
+  `univ : Set ↥X`. This matroid is isomorphic to `M ↾ X`.
 
 ## Implementation details
 
@@ -78,7 +78,7 @@ we define `mapEmbedding` and `mapEquiv` separately from `map`.
 For finite matroids, both maps and comaps are a special case of a construction of
 Perfect [perfect1969matroid] in which a matroid structure can be transported across an arbitrary
 bipartite graph that may not correspond to a function at all (See [oxley2011], Theorem 11.2.12).
-It would have been nice to use this more general construction as a isBasis for the definition
+It would have been nice to use this more general construction as a basis for the definition
 of both `Matroid.map` and `Matroid.comap`.
 
 Unfortunately, we can't do this, because the construction doesn't extend to infinite matroids.

--- a/Mathlib/Data/Matroid/Minor/Contract.lean
+++ b/Mathlib/Data/Matroid/Minor/Contract.lean
@@ -57,7 +57,7 @@ a proof that its independent sets are the claimed ones. -/
 def contract (M : Matroid α) (C : Set α) : Matroid α := (M✶ ＼ C)✶
 
 /-- `M ／ C` refers to the contraction of a set `C` from the matroid `M`. -/
-infixl:75 " ／ " => Matroid.contract
+scoped infixl:75 " ／ " => Matroid.contract
 
 @[simp] lemma contract_ground (M : Matroid α) (C : Set α) : (M ／ C).E = M.E \ C := rfl
 

--- a/Mathlib/Data/Matroid/Minor/Contract.lean
+++ b/Mathlib/Data/Matroid/Minor/Contract.lean
@@ -42,7 +42,7 @@ to refer to the contraction `M ／ {e}` of a single element `e : α` from `M : M
 
 open Set
 
-variable {α : Type*} {M M' N : Matroid α} {e f : α} {I J R D  B X Y Z K S : Set α}
+variable {α : Type*} {M M' N : Matroid α} {e f : α} {I J R D B X Y Z K : Set α}
 
 namespace Matroid
 

--- a/Mathlib/Data/Matroid/Minor/Delete.lean
+++ b/Mathlib/Data/Matroid/Minor/Delete.lean
@@ -23,7 +23,8 @@ This is often quite convenient.
 
 # Main Declarations
 
-* `Matroid.delete M D`, written `M ＼ D`, is the restriction of `M` to the set `M.E \ D`.
+* `Matroid.delete M D`, written `M ＼ D`, is the restriction of `M` to the set `M.E \ D`,
+  or equivalently the matroid on `M.E \ D` whose independent sets are the `M`-independent sets.
 
 # Naming conventions
 

--- a/Mathlib/Data/Matroid/Minor/Order.lean
+++ b/Mathlib/Data/Matroid/Minor/Order.lean
@@ -8,8 +8,8 @@ import Mathlib.Data.Matroid.Minor.Contract
 /-!
 # Matroid Minors
 
-A matroid `N = M ／ C ＼ D` obtained from a matroid `M` by a deletion then a contraction,
-(or equivalently, by any number of deletions/contractions in any order) is a *minor* of `M`.
+A matroid `N = M ／ C ＼ D` obtained from a matroid `M` by a contraction then a delete,
+(or equivalently, by any number of contractions/deletions in any order) is a *minor* of `M`.
 This gives a partial order on `Matroid α` that is ubiquitous in matroid theory,
 and interacts nicely with duality and linear representations.
 

--- a/Mathlib/Data/Matroid/Minor/Restrict.lean
+++ b/Mathlib/Data/Matroid/Minor/Restrict.lean
@@ -48,7 +48,7 @@ We could instead define this matroid to always be 'smaller' than `M` by setting
 
 This makes it possible to actually restrict a matroid 'upwards'; for instance, if `M : Matroid α`
 satisfies `M.E = ∅`, then `M ↾ Set.univ` is the matroid on `α` whose ground set is all of `α`,
-where the empty set is only the independent set.
+where the empty set is the only independent set.
 (In general, elements of `R \ M.E` are all 'loops' of the matroid `M ↾ R`;
 see `Matroid.loops` and `Matroid.restrict_loops_eq'` for a precise version of this statement.)
 This is mathematically strange, but is useful for API building.
@@ -61,7 +61,7 @@ can often be automatically provided by `aesop_mat`.
 
 We define the restriction order `≤r` to give a `PartialOrder` instance on the type synonym
 `Matroidᵣ α` rather than `Matroid α` itself, because the `PartialOrder (Matroid α)` instance is
-reserved for the more mathematically important 'minor' order.
+reserved for the more mathematically important 'minor' order; see `Matroid.IsMinor`.
 -/
 
 assert_not_exists Field

--- a/Mathlib/Data/Matroid/Rank/Cardinal.lean
+++ b/Mathlib/Data/Matroid/Rank/Cardinal.lean
@@ -241,7 +241,7 @@ theorem IsBase.cardinalMk_eq_cRank (hB : M.IsBase B) : #B = M.cRank := by
   have hrw : ∀ B' : {B : Set α // M.IsBase B}, #B' = #B := fun B' ↦ B'.2.cardinalMk_eq hB
   simp [cRank, hrw]
 
-/-- Restrictions of matroids with cardinal rank functions have cardinal rank functions- -/
+/-- Restrictions of matroids with cardinal rank functions have cardinal rank functions. -/
 instance invariantCardinalRank_restrict [InvariantCardinalRank M] :
     InvariantCardinalRank (M ↾ X) := by
   refine ⟨fun I J Y hI hJ ↦ ?_⟩

--- a/Mathlib/Data/Matroid/Rank/ENat.lean
+++ b/Mathlib/Data/Matroid/Rank/ENat.lean
@@ -21,6 +21,7 @@ The rank function `Matroid.eRk` satisfies three properties, often known as (R1),
 * `M.eRk X ≤ Set.encard X`,
 * `M.eRk X ≤ M.eRk Y` for all `X ⊆ Y`,
 * `M.eRk X + M.eRk Y ≥ M.eRk (X ∪ Y) + M.eRk (X ∩ Y)` for all `X, Y`.
+
 In fact, if `α` is finite, then any function `Set α → ℕ∞` satisfying these these properties
 is the rank function of a `Matroid α`; in other words, properties (R1) - (R3) give an alternative
 definition of finite matroids, and a finite matroid is determined by its rank function.


### PR DESCRIPTION
We fix typos and add small clarifying tweaks to matroid-related docstrings in twelve files. 

We make two small changes outside docstrings in `Matroid.contract`: scoping the `Matroid.contract` notation to match `Matroid.delete` as originally intended, and removing a redundant `variable` in the preamble. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
