### PR TITLE
[Merged by Bors] - fix(CompletelyRegularSpace): fix lemmas

### DIFF
--- a/Mathlib/Topology/Separation/CompletelyRegular.lean
+++ b/Mathlib/Topology/Separation/CompletelyRegular.lean
@@ -26,7 +26,7 @@ This file defines `CompletelyRegularSpace` and `T35Space`.
 ### Completely regular spaces
 
 * `CompletelyRegularSpace.regularSpace`: A completely regular space is a regular space.
-* `NormalSpace.completelyRegularSpace`: A normal space is a completely regular space.
+* `NormalSpace.completelyRegularSpace`: A normal R0 space is a completely regular space.
 
 ### T₃.₅ spaces
 
@@ -54,7 +54,7 @@ noncomputable section
 
 open Set Topology Filter unitInterval
 
-variable {X : Type u} [TopologicalSpace X] [T1Space X]
+variable {X : Type u} [TopologicalSpace X]
 
 /-- A space is completely regular if points can be separated from closed sets via
   continuous functions to the unit interval. -/
@@ -63,7 +63,8 @@ class CompletelyRegularSpace (X : Type u) [TopologicalSpace X] : Prop where
   completely_regular : ∀ (x : X), ∀ K : Set X, IsClosed K → x ∉ K →
     ∃ f : X → I, Continuous f ∧ f x = 0 ∧ EqOn f 1 K
 
-instance CompletelyRegularSpace.instRegularSpace [CompletelyRegularSpace X] : RegularSpace X := by
+instance CompletelyRegularSpace.instRegularSpace [CompletelyRegularSpace X] :
+    RegularSpace X := by
   rw [regularSpace_iff]
   intro s a hs ha
   obtain ⟨f, cf, hf, hhf⟩ := CompletelyRegularSpace.completely_regular a s hs ha
@@ -71,15 +72,19 @@ instance CompletelyRegularSpace.instRegularSpace [CompletelyRegularSpace X] : Re
   apply Disjoint.mono (cf.tendsto_nhdsSet_nhds hhf) cf.continuousAt
   exact disjoint_nhds_nhds.mpr (hf.symm ▸ zero_ne_one).symm
 
-instance NormalSpace.instCompletelyRegularSpace [NormalSpace X] : CompletelyRegularSpace X := by
+instance NormalSpace.instCompletelyRegularSpace [NormalSpace X] [R0Space X] :
+    CompletelyRegularSpace X := by
   rw [completelyRegularSpace_iff]
   intro x K hK hx
-  have cx : IsClosed {x} := T1Space.t1 x
-  have d : Disjoint {x} K := by rwa [Set.disjoint_iff, subset_empty_iff, singleton_inter_eq_empty]
+  have cx : IsClosed (closure {x}) := isClosed_closure
+  have d : Disjoint (closure {x}) K := by
+    rw [Set.disjoint_iff]
+    intro a ⟨hax, haK⟩
+    exact hx ((specializes_iff_mem_closure.mpr hax).symm.mem_closed hK haK)
   let ⟨⟨f, cf⟩, hfx, hfK, hficc⟩ := exists_continuous_zero_one_of_isClosed cx hK d
   let g : X → I := fun x => ⟨f x, hficc x⟩
   have cg : Continuous g := cf.subtype_mk hficc
-  have hgx : g x = 0 := Subtype.ext (hfx (mem_singleton_iff.mpr (Eq.refl x)))
+  have hgx : g x = 0 := Subtype.ext (hfx (subset_closure (mem_singleton x)))
   have hgK : EqOn g 1 K := fun k hk => Subtype.ext (hfK hk)
   exact ⟨g, cg, hgx, hgK⟩
 
@@ -87,37 +92,37 @@ instance NormalSpace.instCompletelyRegularSpace [NormalSpace X] : CompletelyRegu
 @[mk_iff]
 class T35Space (X : Type u) [TopologicalSpace X] : Prop extends T1Space X, CompletelyRegularSpace X
 
-instance T35Space.instT3space [T35Space X] : T3Space X := {}
+instance T35Space.instT3space [T35Space X] : T3Space X where
 
-instance T4Space.instT35Space [T4Space X] : T35Space X := {}
+instance T4Space.instT35Space [T4Space X] : T35Space X where
 
-lemma separatesPoints_continuous_of_completelyRegularSpace [CompletelyRegularSpace X] :
+lemma separatesPoints_continuous_of_t35Space [T35Space X] :
     SeparatesPoints (Continuous : Set (X → ℝ)) := by
   intro x y x_ne_y
   obtain ⟨f, f_cont, f_zero, f_one⟩ :=
     CompletelyRegularSpace.completely_regular x {y} isClosed_singleton x_ne_y
   exact ⟨fun x ↦ f x, continuous_subtype_val.comp f_cont, by aesop⟩
 
-@[deprecated (since := "2025-03-21")]
-alias separatesPoints_continuous_of_t35Space := separatesPoints_continuous_of_completelyRegularSpace
+@[deprecated (since := "2025-04-13")]
+alias separatesPoints_continuous_of_completelyRegularSpace := separatesPoints_continuous_of_t35Space
 
-lemma separatesPoints_continuous_of_completelyRegularSpace_Icc [CompletelyRegularSpace X] :
+lemma separatesPoints_continuous_of_t35Space_Icc [T35Space X] :
     SeparatesPoints (Continuous : Set (X → I)) := by
   intro x y x_ne_y
   obtain ⟨f, f_cont, f_zero, f_one⟩ :=
     CompletelyRegularSpace.completely_regular x {y} isClosed_singleton x_ne_y
   exact ⟨f, f_cont, by aesop⟩
 
-@[deprecated (since := "2025-03-21")]
-alias separatesPoints_continuous_of_t35Space_Icc :=
-  separatesPoints_continuous_of_completelyRegularSpace_Icc
+@[deprecated (since := "2025-04-13")]
+alias separatesPoints_continuous_of_completelyRegularSpace_Icc :=
+  separatesPoints_continuous_of_t35Space_Icc
 
-lemma injective_stoneCechUnit_of_completelyRegularSpace [CompletelyRegularSpace X] :
+lemma injective_stoneCechUnit_of_t35Space [T35Space X] :
     Function.Injective (stoneCechUnit : X → StoneCech X) := by
   intros a b hab
   contrapose hab
-  obtain ⟨f, fc, fab⟩ := separatesPoints_continuous_of_completelyRegularSpace_Icc hab
+  obtain ⟨f, fc, fab⟩ := separatesPoints_continuous_of_t35Space_Icc hab
   exact fun q ↦ fab (eq_if_stoneCechUnit_eq fc q)
 
-@[deprecated (since := "2025-03-21")]
-alias injective_stoneCechUnit_of_t35Space := injective_stoneCechUnit_of_completelyRegularSpace
+@[deprecated (since := "2025-04-13")]
+alias injective_stoneCechUnit_of_completelyRegularSpace := injective_stoneCechUnit_of_t35Space


### PR DESCRIPTION
Fix some oddities caused by a rogue section variable. For example, `separatesPoints_continuous_of_completelyRegularSpace` assumes `[CompletelyRegularSpace X] [T1Space X]`, which is just equivalent to `[T35Space X]`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
