### PR TITLE
[Merged by Bors] - feat(Data/List/Sort): ext lemma for strictly sorted lists

### DIFF
--- a/Mathlib/Data/List/Sort.lean
+++ b/Mathlib/Data/List/Sort.lean
@@ -127,33 +127,15 @@ theorem eq_of_perm_of_sorted [IsAntisymm α r] {l₁ l₂ : List α} (hp : l₁ 
       simp [iff_true_intro this, or_comm]
 
 theorem Sorted.eq_of_mem_iff [IsAntisymm α r] [IsIrrefl α r] {l₁ l₂ : List α}
-    (h₁ : Sorted r l₁) (h₂ : Sorted r l₂) (h : ∀ a : α, a ∈ l₁ ↔ a ∈ l₂) : l₁ = l₂ := by
-  induction h₂ generalizing l₁ with
-  | nil => simpa [List.eq_nil_iff_forall_not_mem] using h
-  | @cons a l₂ hr hs₁ IH =>
-    cases l₁ with
-    | nil => simpa using h a
-    | cons b l₁ =>
-      suffices h : b = a by
-        subst h
-        simp only [cons.injEq, true_and]
-        apply IH (sorted_cons.mp h₁).2
-        intro x
-        haveI : x = b ∨ x ∈ l₁ ↔ x = b ∨ x ∈ l₂ := by simpa using h x
-        constructor
-        · intro hxl₁
-          obtain rfl | _ := this.mp (Or.inr hxl₁)
-          · exact (IsIrrefl.irrefl x <| (sorted_cons.mp h₁).1 x hxl₁).elim
-          · assumption
-        · intro hxl₂
-          obtain rfl | _ := this.mpr (Or.inr hxl₂)
-          · exact (IsIrrefl.irrefl x <| hr x hxl₂).elim
-          · assumption
-      obtain rfl | hbl₂ : b = a ∨ b ∈ l₂ := by simpa using h b
-      · rfl
-      · obtain rfl | hal₁ : a = b ∨ a ∈ l₁ := by simpa using h a
-        · rfl
-        · exact IsAntisymm.antisymm b a ((sorted_cons.mp h₁).1 _ hal₁) (hr _ hbl₂)
+    (h₁ : Sorted r l₁) (h₂ : Sorted r l₂) (h : ∀ a : α, a ∈ l₁ ↔ a ∈ l₂) : l₁ = l₂ :=
+  letI : DecidableEq α := Classical.decEq α
+  eq_of_perm_of_sorted (r := r)
+    (List.perm_iff_count.mpr (fun a ↦ by
+      rw [List.count_eq_of_nodup h₁.nodup, List.count_eq_of_nodup h₂.nodup]
+      by_cases ha : a ∈ l₁
+      · simpa [(h a).mp ha]
+      · simpa [(h a).not.mp ha]))
+    h₁ h₂
 
 theorem sublist_of_subperm_of_sorted [IsAntisymm α r] {l₁ l₂ : List α} (hp : l₁ <+~ l₂)
     (hs₁ : l₁.Sorted r) (hs₂ : l₂.Sorted r) : l₁ <+ l₂ := by

--- a/Mathlib/Data/List/Sort.lean
+++ b/Mathlib/Data/List/Sort.lean
@@ -128,14 +128,7 @@ theorem eq_of_perm_of_sorted [IsAntisymm α r] {l₁ l₂ : List α} (hp : l₁ 
 
 theorem Sorted.eq_of_mem_iff [IsAntisymm α r] [IsIrrefl α r] {l₁ l₂ : List α}
     (h₁ : Sorted r l₁) (h₂ : Sorted r l₂) (h : ∀ a : α, a ∈ l₁ ↔ a ∈ l₂) : l₁ = l₂ :=
-  letI : DecidableEq α := Classical.decEq α
-  eq_of_perm_of_sorted (r := r)
-    (List.perm_iff_count.mpr (fun a ↦ by
-      rw [List.count_eq_of_nodup h₁.nodup, List.count_eq_of_nodup h₂.nodup]
-      by_cases ha : a ∈ l₁
-      · simpa [(h a).mp ha]
-      · simpa [(h a).not.mp ha]))
-    h₁ h₂
+  eq_of_perm_of_sorted ((perm_ext_iff_of_nodup h₁.nodup h₂.nodup).2 h) h₁ h₂ 
 
 theorem sublist_of_subperm_of_sorted [IsAntisymm α r] {l₁ l₂ : List α} (hp : l₁ <+~ l₂)
     (hs₁ : l₁.Sorted r) (hs₂ : l₂.Sorted r) : l₁ <+ l₂ := by

--- a/Mathlib/Data/List/Sort.lean
+++ b/Mathlib/Data/List/Sort.lean
@@ -128,7 +128,7 @@ theorem eq_of_perm_of_sorted [IsAntisymm α r] {l₁ l₂ : List α} (hp : l₁ 
 
 theorem Sorted.eq_of_mem_iff [IsAntisymm α r] [IsIrrefl α r] {l₁ l₂ : List α}
     (h₁ : Sorted r l₁) (h₂ : Sorted r l₂) (h : ∀ a : α, a ∈ l₁ ↔ a ∈ l₂) : l₁ = l₂ :=
-  eq_of_perm_of_sorted ((perm_ext_iff_of_nodup h₁.nodup h₂.nodup).2 h) h₁ h₂ 
+  eq_of_perm_of_sorted ((perm_ext_iff_of_nodup h₁.nodup h₂.nodup).2 h) h₁ h₂
 
 theorem sublist_of_subperm_of_sorted [IsAntisymm α r] {l₁ l₂ : List α} (hp : l₁ <+~ l₂)
     (hs₁ : l₁.Sorted r) (hs₂ : l₂.Sorted r) : l₁ <+ l₂ := by

--- a/Mathlib/Data/List/Sort.lean
+++ b/Mathlib/Data/List/Sort.lean
@@ -126,6 +126,35 @@ theorem eq_of_perm_of_sorted [IsAntisymm α r] {l₁ l₂ : List α} (hp : l₁ 
         constructor <;>
       simp [iff_true_intro this, or_comm]
 
+theorem Sorted.eq_of_mem_iff [IsAntisymm α r] [IsIrrefl α r] {l₁ l₂ : List α}
+    (h₁ : Sorted r l₁) (h₂ : Sorted r l₂) (h : ∀ a : α, a ∈ l₁ ↔ a ∈ l₂) : l₁ = l₂ := by
+  induction h₂ generalizing l₁ with
+  | nil => simpa [List.eq_nil_iff_forall_not_mem] using h
+  | @cons a l₂ hr hs₁ IH =>
+    cases l₁ with
+    | nil => simpa using h a
+    | cons b l₁ =>
+      suffices h : b = a by
+        subst h
+        simp only [cons.injEq, true_and]
+        apply IH (sorted_cons.mp h₁).2
+        intro x
+        haveI : x = b ∨ x ∈ l₁ ↔ x = b ∨ x ∈ l₂ := by simpa using h x
+        constructor
+        · intro hxl₁
+          obtain rfl | _ := this.mp (Or.inr hxl₁)
+          · exact (IsIrrefl.irrefl x <| (sorted_cons.mp h₁).1 x hxl₁).elim
+          · assumption
+        · intro hxl₂
+          obtain rfl | _ := this.mpr (Or.inr hxl₂)
+          · exact (IsIrrefl.irrefl x <| hr x hxl₂).elim
+          · assumption
+      obtain rfl | hbl₂ : b = a ∨ b ∈ l₂ := by simpa using h b
+      · rfl
+      · obtain rfl | hal₁ : a = b ∨ a ∈ l₁ := by simpa using h a
+        · rfl
+        · exact IsAntisymm.antisymm b a ((sorted_cons.mp h₁).1 _ hal₁) (hr _ hbl₂)
+
 theorem sublist_of_subperm_of_sorted [IsAntisymm α r] {l₁ l₂ : List α} (hp : l₁ <+~ l₂)
     (hs₁ : l₁.Sorted r) (hs₂ : l₂.Sorted r) : l₁ <+ l₂ := by
   let ⟨_, h, h'⟩ := hp

--- a/Mathlib/Data/List/Sort.lean
+++ b/Mathlib/Data/List/Sort.lean
@@ -3,7 +3,7 @@ Copyright (c) 2016 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad
 -/
-import Batteries.Data.List.Pairwise
+import Batteries.Data.List.Perm
 import Mathlib.Data.List.OfFn
 import Mathlib.Data.List.Nodup
 import Mathlib.Data.List.TakeWhile


### PR DESCRIPTION
Add a theorem stating that two strictly sorted lists are equal if they have the same set of elements.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

Suggested by @joelriou in #21744.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
