### PR TITLE
[Merged by Bors] - feat: the index of the scaling of a subgroup

### DIFF
--- a/Mathlib/GroupTheory/Index.lean
+++ b/Mathlib/GroupTheory/Index.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Thomas Browning
 -/
 import Mathlib.Algebra.BigOperators.GroupWithZero.Finset
+import Mathlib.Algebra.GroupWithZero.Subgroup
 import Mathlib.Data.Finite.Card
 import Mathlib.Data.Finite.Prod
 import Mathlib.Data.Set.Card
@@ -37,9 +38,11 @@ Several theorems proved in this file are known as Lagrange's theorem.
 
 assert_not_exists Field
 
+open scoped Pointwise
+
 namespace Subgroup
 
-open Cardinal
+open Cardinal Function
 
 variable {G G' : Type*} [Group G] [Group G'] (H K L : Subgroup G)
 
@@ -175,7 +178,7 @@ theorem mul_self_mem_of_index_two (h : H.index = 2) (a : G) : a * a ∈ H := by
 theorem sq_mem_of_index_two (h : H.index = 2) (a : G) : a ^ 2 ∈ H :=
   (pow_two a).symm ▸ mul_self_mem_of_index_two h a
 
-variable (H K)
+variable (H K) {f : G →* G'}
 
 @[to_additive (attr := simp)]
 theorem index_top : (⊤ : Subgroup G).index = 1 :=
@@ -248,9 +251,12 @@ theorem dvd_index_map {f : G →* G'} (hf : f.ker ≤ H) :
   apply dvd_mul_right
 
 @[to_additive]
-theorem index_map_eq {f : G →* G'} (hf1 : Function.Surjective f)
-    (hf2 : f.ker ≤ H) : (H.map f).index = H.index :=
+theorem index_map_eq (hf1 : Surjective f) (hf2 : f.ker ≤ H) : (H.map f).index = H.index :=
   Nat.dvd_antisymm (H.index_map_dvd hf1) (H.dvd_index_map hf2)
+
+@[to_additive]
+lemma index_map_of_bijective (hf : Bijective f) (H : Subgroup G) : (H.map f).index = H.index :=
+  index_map_eq _ hf.2 (by rw [f.ker_eq_bot_iff.2 hf.1]; exact bot_le)
 
 @[to_additive]
 theorem index_map_of_injective {f : G →* G'} (hf : Function.Injective f) :
@@ -637,3 +643,12 @@ lemma card_fiber_eq_of_mem_range (f : F) {x y : M} (hx : x ∈ Set.range f) (hy 
   rw [← f'.coe_toHomUnits y⁻¹, map_inv, Units.mul_inv_eq_iff_eq_mul, f'.coe_toHomUnits]
 
 end MonoidHom
+
+namespace AddSubgroup
+variable {G A : Type*} [Group G] [AddGroup A] [DistribMulAction G A]
+
+@[simp]
+lemma index_smul (a : G) (S : AddSubgroup A) : (a • S).index = S.index :=
+  index_map_of_bijective (MulAction.bijective _) _
+
+end AddSubgroup


### PR DESCRIPTION
From FLT


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
