### PR TITLE
[Merged by Bors] - fix(deprecated module): automatically disable the header linter

### DIFF
--- a/Mathlib/Tactic/Linter/DeprecatedModule.lean
+++ b/Mathlib/Tactic/Linter/DeprecatedModule.lean
@@ -86,7 +86,8 @@ elab (name := deprecated_modules)
     throwError "Invalid date: the expected format is \"{← Std.Time.PlainDate.now}\""
   addModuleDeprecation <| msg?.map (·.getString)
   -- Disable the linter, so that it does not complain in the file with the deprecation.
-  elabCommand (← `(set_option linter.deprecated.module false))
+  elabCommand <| mkNullNode #[← `(set_option linter.style.header false),
+                              ← `(set_option linter.deprecated.module false)]
 
 /--
 A utility command to show the current entries of the `deprecatedModuleExt` in the format:


### PR DESCRIPTION
This PR makes the `header` linter silent if the first non-import command of a file is `deprecated_module`.

[Zulip#mathlib4 > &#96;Deprecated&#96; folder @ 💬](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/.60Deprecated.60.20folder/near/511986519)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
