### PR TITLE
[Merged by Bors] - ci(discover-lean-pr-testing): fix multiline output syntax

### DIFF
--- a/.github/workflows/discover-lean-pr-testing.yml
+++ b/.github/workflows/discover-lean-pr-testing.yml
@@ -187,7 +187,7 @@ jobs:
           MESSAGE+=$'### ✅ Successfully merged branches:\n\n'
           for MERGE_INFO in $SUCCESSFUL_MERGES; do
             IFS='|' read -r PR_NUMBER GITHUB_DIFF BRANCH <<< "$MERGE_INFO"
-            MESSAGE+=$(printf '- lean#%s ([diff](%s))\n' "$PR_NUMBER" "$GITHUB_DIFF")
+            MESSAGE+=$(printf -- '- lean#%s ([diff](%s))\n' "$PR_NUMBER" "$GITHUB_DIFF")
           done
           MESSAGE+=$'\n'
         else
@@ -208,9 +208,7 @@ jobs:
         fi
 
         # Output the message using the correct GitHub Actions syntax
-        echo "msg<<EOF" >> "$GITHUB_OUTPUT"
-        echo "$MESSAGE" >> "$GITHUB_OUTPUT"
-        echo "EOF" >> "$GITHUB_OUTPUT"
+        printf 'msg<<EOF\n%s\nEOF' "$MESSAGE" >> "$GITHUB_OUTPUT"
 
     - name: Send message on Zulip
       if: env.branches_exist == 'true'

--- a/.github/workflows/discover-lean-pr-testing.yml
+++ b/.github/workflows/discover-lean-pr-testing.yml
@@ -179,36 +179,38 @@ jobs:
         SUCCESSFUL_MERGES="${{ steps.execute-merges.outputs.successful_merges }}"
         FAILED_MERGES="${{ steps.execute-merges.outputs.failed_merges }}"
 
-        {
-          printf $'msg<<EOF\n'
+        # Start building the message
+        MESSAGE=""
 
-          # Report successful merges
-          if [ -n "$SUCCESSFUL_MERGES" ]; then
-            printf $'### ✅ Successfully merged branches:\n\n'
-            for MERGE_INFO in $SUCCESSFUL_MERGES; do
-              IFS='|' read -r PR_NUMBER GITHUB_DIFF BRANCH <<< "$MERGE_INFO"
-              printf $'- lean#%s ([diff](%s))\n' "$PR_NUMBER" "$GITHUB_DIFF"
-            done
-            printf $'\n'
-          else
-            printf $'No branches were successfully merged.\n\n'
-          fi
+        # Report successful merges
+        if [ -n "$SUCCESSFUL_MERGES" ]; then
+          MESSAGE+=$'### ✅ Successfully merged branches:\n\n'
+          for MERGE_INFO in $SUCCESSFUL_MERGES; do
+            IFS='|' read -r PR_NUMBER GITHUB_DIFF BRANCH <<< "$MERGE_INFO"
+            MESSAGE+=$(printf '- lean#%s ([diff](%s))\n' "$PR_NUMBER" "$GITHUB_DIFF")
+          done
+          MESSAGE+=$'\n'
+        else
+          MESSAGE+=$'No branches were successfully merged.\n\n'
+        fi
 
-          # Report failed merges
-          if [ -n "$FAILED_MERGES" ]; then
-            printf $'### ❌ Failed merges:\n\nThe following branches need to be merged manually:\n\n```bash\n'
-            for MERGE_INFO in $FAILED_MERGES; do
-              IFS='|' read -r PR_NUMBER GITHUB_DIFF BRANCH <<< "$MERGE_INFO"
-              printf $'# Diff: %s\n' "$GITHUB_DIFF"
-              printf $'scripts/merge-lean-testing-pr.sh %s   # %s\n\n' "$PR_NUMBER" "$BRANCH"
-            done
-            printf $'```\n'
-          else
-            printf $'All branches were successfully merged! 🎉\n'
-          fi
+        # Report failed merges
+        if [ -n "$FAILED_MERGES" ]; then
+          MESSAGE+=$'### ❌ Failed merges:\n\nThe following branches need to be merged manually:\n\n```bash\n'
+          for MERGE_INFO in $FAILED_MERGES; do
+            IFS='|' read -r PR_NUMBER GITHUB_DIFF BRANCH <<< "$MERGE_INFO"
+            MESSAGE+=$(printf '# Diff: %s\n' "$GITHUB_DIFF")
+            MESSAGE+=$(printf 'scripts/merge-lean-testing-pr.sh %s   # %s\n\n' "$PR_NUMBER" "$BRANCH")
+          done
+          MESSAGE+=$'```\n'
+        else
+          MESSAGE+=$'All branches were successfully merged! 🎉\n'
+        fi
 
-          printf "EOF"
-        } >> "$GITHUB_OUTPUT"
+        # Output the message using the correct GitHub Actions syntax
+        echo "msg<<EOF" >> "$GITHUB_OUTPUT"
+        echo "$MESSAGE" >> "$GITHUB_OUTPUT"
+        echo "EOF" >> "$GITHUB_OUTPUT"
 
     - name: Send message on Zulip
       if: env.branches_exist == 'true'


### PR DESCRIPTION
Use standard GitHub Actions output syntax for multiline messages


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
