### PR TITLE
[Merged by Bors] - fix(Linter/DeprecatedModule): tweak `deprecated_module` syntax

### DIFF
--- a/Mathlib/Algebra/Order/Floor.lean
+++ b/Mathlib/Algebra/Order/Floor.lean
@@ -7,4 +7,4 @@ import Mathlib.Algebra.Order.Floor.Defs
 import Mathlib.Algebra.Order.Floor.Ring
 import Mathlib.Algebra.Order.Floor.Semiring
 
-deprecated_module (since "2025-04-13")
+deprecated_module (since := "2025-04-13")

--- a/Mathlib/Algebra/Order/Floor.lean
+++ b/Mathlib/Algebra/Order/Floor.lean
@@ -7,6 +7,4 @@ import Mathlib.Algebra.Order.Floor.Defs
 import Mathlib.Algebra.Order.Floor.Ring
 import Mathlib.Algebra.Order.Floor.Semiring
 
-set_option linter.style.header false
-
 deprecated_module (since "2025-04-13")

--- a/Mathlib/Algebra/Order/GroupWithZero/Unbundled.lean
+++ b/Mathlib/Algebra/Order/GroupWithZero/Unbundled.lean
@@ -7,4 +7,4 @@ import Mathlib.Algebra.Order.GroupWithZero.Unbundled.Basic
 import Mathlib.Algebra.Order.GroupWithZero.Unbundled.Defs
 import Mathlib.Tactic.Linter.DeprecatedModule
 
-deprecated_module (since "2025-04-13")
+deprecated_module (since := "2025-04-13")

--- a/Mathlib/Algebra/Order/GroupWithZero/Unbundled.lean
+++ b/Mathlib/Algebra/Order/GroupWithZero/Unbundled.lean
@@ -7,6 +7,4 @@ import Mathlib.Algebra.Order.GroupWithZero.Unbundled.Basic
 import Mathlib.Algebra.Order.GroupWithZero.Unbundled.Defs
 import Mathlib.Tactic.Linter.DeprecatedModule
 
-set_option linter.style.header false
-
 deprecated_module (since "2025-04-13")

--- a/Mathlib/Algebra/Order/GroupWithZero/Unbundled/Lemmas.lean
+++ b/Mathlib/Algebra/Order/GroupWithZero/Unbundled/Lemmas.lean
@@ -6,6 +6,4 @@ Authors: Eric Wieser
 import Mathlib.Algebra.Order.GroupWithZero.Unbundled.OrderIso
 import Mathlib.Tactic.Linter.DeprecatedModule
 
-set_option linter.style.header false
-
 deprecated_module (since "2025-04-13")

--- a/Mathlib/Algebra/Order/GroupWithZero/Unbundled/Lemmas.lean
+++ b/Mathlib/Algebra/Order/GroupWithZero/Unbundled/Lemmas.lean
@@ -6,4 +6,4 @@ Authors: Eric Wieser
 import Mathlib.Algebra.Order.GroupWithZero.Unbundled.OrderIso
 import Mathlib.Tactic.Linter.DeprecatedModule
 
-deprecated_module (since "2025-04-13")
+deprecated_module (since := "2025-04-13")

--- a/Mathlib/Data/ENNReal/Order.lean
+++ b/Mathlib/Data/ENNReal/Order.lean
@@ -5,4 +5,4 @@ Authors: Johannes Hölzl, Yury Kudryashov
 -/
 import Mathlib.Data.ENNReal.Operations
 
-deprecated_module (since "2025-04-13")
+deprecated_module (since := "2025-04-13")

--- a/Mathlib/Data/ENNReal/Order.lean
+++ b/Mathlib/Data/ENNReal/Order.lean
@@ -5,6 +5,4 @@ Authors: Johannes Hölzl, Yury Kudryashov
 -/
 import Mathlib.Data.ENNReal.Operations
 
-set_option linter.style.header false
-
 deprecated_module (since "2025-04-13")

--- a/Mathlib/Data/Real/EReal.lean
+++ b/Mathlib/Data/Real/EReal.lean
@@ -5,4 +5,4 @@ Authors: Kevin Buzzard
 -/
 import Mathlib.Data.EReal.Basic
 
-deprecated_module (since "2025-04-13")
+deprecated_module (since := "2025-04-13")

--- a/Mathlib/Data/Real/EReal.lean
+++ b/Mathlib/Data/Real/EReal.lean
@@ -5,6 +5,4 @@ Authors: Kevin Buzzard
 -/
 import Mathlib.Data.EReal.Basic
 
-set_option linter.style.header false
-
 deprecated_module (since "2025-04-13")

--- a/Mathlib/Data/Seq/WSeq.lean
+++ b/Mathlib/Data/Seq/WSeq.lean
@@ -8,6 +8,4 @@ import Mathlib.Data.WSeq.Defs
 import Mathlib.Data.WSeq.Productive
 import Mathlib.Data.WSeq.Relation
 
-set_option linter.style.header false
-
 deprecated_module (since "2025-04-13")

--- a/Mathlib/Data/Seq/WSeq.lean
+++ b/Mathlib/Data/Seq/WSeq.lean
@@ -8,4 +8,4 @@ import Mathlib.Data.WSeq.Defs
 import Mathlib.Data.WSeq.Productive
 import Mathlib.Data.WSeq.Relation
 
-deprecated_module (since "2025-04-13")
+deprecated_module (since := "2025-04-13")

--- a/Mathlib/MeasureTheory/Integral/Bochner.lean
+++ b/Mathlib/MeasureTheory/Integral/Bochner.lean
@@ -7,4 +7,4 @@ import Mathlib.MeasureTheory.Integral.Bochner.Basic
 import Mathlib.MeasureTheory.Integral.Bochner.L1
 import Mathlib.MeasureTheory.Integral.Bochner.VitaliCaratheodory
 
-deprecated_module (since "2025-04-13")
+deprecated_module (since := "2025-04-13")

--- a/Mathlib/MeasureTheory/Integral/Bochner.lean
+++ b/Mathlib/MeasureTheory/Integral/Bochner.lean
@@ -7,6 +7,4 @@ import Mathlib.MeasureTheory.Integral.Bochner.Basic
 import Mathlib.MeasureTheory.Integral.Bochner.L1
 import Mathlib.MeasureTheory.Integral.Bochner.VitaliCaratheodory
 
-set_option linter.style.header false
-
 deprecated_module (since "2025-04-13")

--- a/Mathlib/MeasureTheory/Integral/IntervalIntegral.lean
+++ b/Mathlib/MeasureTheory/Integral/IntervalIntegral.lean
@@ -7,6 +7,4 @@ import Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic
 import Mathlib.MeasureTheory.Integral.IntervalIntegral.FundThmCalculus
 import Mathlib.MeasureTheory.Integral.IntervalIntegral.IntegrationByParts
 
-set_option linter.style.header false
-
 deprecated_module (since "2025-04-13")

--- a/Mathlib/MeasureTheory/Integral/IntervalIntegral.lean
+++ b/Mathlib/MeasureTheory/Integral/IntervalIntegral.lean
@@ -7,4 +7,4 @@ import Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic
 import Mathlib.MeasureTheory.Integral.IntervalIntegral.FundThmCalculus
 import Mathlib.MeasureTheory.Integral.IntervalIntegral.IntegrationByParts
 
-deprecated_module (since "2025-04-13")
+deprecated_module (since := "2025-04-13")

--- a/Mathlib/MeasureTheory/Integral/Lebesgue.lean
+++ b/Mathlib/MeasureTheory/Integral/Lebesgue.lean
@@ -8,4 +8,4 @@ import Mathlib.MeasureTheory.Integral.Lebesgue.Countable
 import Mathlib.MeasureTheory.Integral.Lebesgue.MeasurePreserving
 import Mathlib.MeasureTheory.Integral.Lebesgue.Norm
 
-deprecated_module (since "2025-04-13")
+deprecated_module (since := "2025-04-13")

--- a/Mathlib/MeasureTheory/Integral/Lebesgue.lean
+++ b/Mathlib/MeasureTheory/Integral/Lebesgue.lean
@@ -8,6 +8,4 @@ import Mathlib.MeasureTheory.Integral.Lebesgue.Countable
 import Mathlib.MeasureTheory.Integral.Lebesgue.MeasurePreserving
 import Mathlib.MeasureTheory.Integral.Lebesgue.Norm
 
-set_option linter.style.header false
-
 deprecated_module (since "2025-04-13")

--- a/Mathlib/MeasureTheory/Integral/Periodic.lean
+++ b/Mathlib/MeasureTheory/Integral/Periodic.lean
@@ -5,4 +5,4 @@ Authors: Yury Kudryashov, Alex Kontorovich, Heather Macbeth
 -/
 import Mathlib.MeasureTheory.Integral.IntervalIntegral.Periodic
 
-deprecated_module (since "2025-04-13")
+deprecated_module (since := "2025-04-13")

--- a/Mathlib/MeasureTheory/Integral/Periodic.lean
+++ b/Mathlib/MeasureTheory/Integral/Periodic.lean
@@ -5,6 +5,4 @@ Authors: Yury Kudryashov, Alex Kontorovich, Heather Macbeth
 -/
 import Mathlib.MeasureTheory.Integral.IntervalIntegral.Periodic
 
-set_option linter.style.header false
-
 deprecated_module (since "2025-04-13")

--- a/Mathlib/MeasureTheory/Measure/Typeclasses.lean
+++ b/Mathlib/MeasureTheory/Measure/Typeclasses.lean
@@ -8,4 +8,4 @@ import Mathlib.MeasureTheory.Measure.Typeclasses.NoAtoms
 import Mathlib.MeasureTheory.Measure.Typeclasses.Probability
 import Mathlib.MeasureTheory.Measure.Typeclasses.SFinite
 
-deprecated_module (since "2025-04-13")
+deprecated_module (since := "2025-04-13")

--- a/Mathlib/MeasureTheory/Measure/Typeclasses.lean
+++ b/Mathlib/MeasureTheory/Measure/Typeclasses.lean
@@ -8,6 +8,4 @@ import Mathlib.MeasureTheory.Measure.Typeclasses.NoAtoms
 import Mathlib.MeasureTheory.Measure.Typeclasses.Probability
 import Mathlib.MeasureTheory.Measure.Typeclasses.SFinite
 
-set_option linter.style.header false
-
 deprecated_module (since "2025-04-13")

--- a/Mathlib/Order/Chain.lean
+++ b/Mathlib/Order/Chain.lean
@@ -6,6 +6,4 @@ Authors: Johannes Hölzl
 import Mathlib.Order.Preorder.Chain
 import Mathlib.Tactic.Linter.DeprecatedModule
 
-set_option linter.style.header false
-
 deprecated_module (since "2025-04-13")

--- a/Mathlib/Order/Chain.lean
+++ b/Mathlib/Order/Chain.lean
@@ -6,4 +6,4 @@ Authors: Johannes Hölzl
 import Mathlib.Order.Preorder.Chain
 import Mathlib.Tactic.Linter.DeprecatedModule
 
-deprecated_module (since "2025-04-13")
+deprecated_module (since := "2025-04-13")

--- a/Mathlib/Tactic/Linter/DeprecatedModule.lean
+++ b/Mathlib/Tactic/Linter/DeprecatedModule.lean
@@ -86,7 +86,8 @@ elab (name := deprecated_modules)
     throwError "Invalid date: the expected format is \"{← Std.Time.PlainDate.now}\""
   addModuleDeprecation <| msg?.map (·.getString)
   -- Disable the linter, so that it does not complain in the file with the deprecation.
-  elabCommand (← `(set_option linter.deprecated.module false))
+  elabCommand <| mkNullNode #[← `(set_option linter.style.header false),
+                              ← `(set_option linter.deprecated.module false)]
 
 /--
 A utility command to show the current entries of the `deprecatedModuleExt` in the format:

--- a/Mathlib/Tactic/Linter/DeprecatedModule.lean
+++ b/Mathlib/Tactic/Linter/DeprecatedModule.lean
@@ -18,7 +18,7 @@ import B
 ...
 import Z
 
-deprecated_module "Optional string here with further details" (since "yyyy-mm-dd")
+deprecated_module "Optional string here with further details" (since := "yyyy-mm-dd")
 ```
 in module `A` with the expectation that `A` contains nothing else.
 This triggers the `deprecated.module` linter to notify every file with `import A`
@@ -75,7 +75,7 @@ def addModuleDeprecation {m : Type → Type} [Monad m] [MonadEnv m] [MonadQuotat
          i.module == `Mathlib.Tactic.Linter.DeprecatedModule then none else i.module, msg?))
 
 /--
-`deprecated_module "Optional string" (since "yyyy-mm-dd")` deprecates the current module `A`
+`deprecated_module "Optional string" (since := "yyyy-mm-dd")` deprecates the current module `A`
 in favour of its direct imports.
 This means that any file that directly imports `A` will get a notification on the `import A` line
 suggesting to instead import the *direct imports* of `A`.

--- a/Mathlib/Tactic/Linter/DeprecatedModule.lean
+++ b/Mathlib/Tactic/Linter/DeprecatedModule.lean
@@ -81,7 +81,7 @@ This means that any file that directly imports `A` will get a notification on th
 suggesting to instead import the *direct imports* of `A`.
 -/
 elab (name := deprecated_modules)
-    "deprecated_module " msg?:(str)? "(" &"since " date:str ")" : command => do
+    "deprecated_module " msg?:(str)? "(" &"since " ":= " date:str ")" : command => do
   if let .error _parsedDate := Std.Time.PlainDate.fromLeanDateString date.getString then
     throwError "Invalid date: the expected format is \"{← Std.Time.PlainDate.now}\""
   addModuleDeprecation <| msg?.map (·.getString)

--- a/Mathlib/Topology/Category/Profinite/Nobeling.lean
+++ b/Mathlib/Topology/Category/Profinite/Nobeling.lean
@@ -9,4 +9,4 @@ import Mathlib.Topology.Category.Profinite.Nobeling.Span
 import Mathlib.Topology.Category.Profinite.Nobeling.Successor
 import Mathlib.Topology.Category.Profinite.Nobeling.ZeroLimit
 
-deprecated_module (since "2025-04-13")
+deprecated_module (since := "2025-04-13")

--- a/Mathlib/Topology/Category/Profinite/Nobeling.lean
+++ b/Mathlib/Topology/Category/Profinite/Nobeling.lean
@@ -9,6 +9,4 @@ import Mathlib.Topology.Category.Profinite.Nobeling.Span
 import Mathlib.Topology.Category.Profinite.Nobeling.Successor
 import Mathlib.Topology.Category.Profinite.Nobeling.ZeroLimit
 
-set_option linter.style.header false
-
 deprecated_module (since "2025-04-13")

--- a/MathlibTest/CountHeartbeats.lean
+++ b/MathlibTest/CountHeartbeats.lean
@@ -1,8 +1,6 @@
 import Mathlib.Util.CountHeartbeats
 import Mathlib.Util.SleepHeartbeats
 
-set_option linter.style.header false
-
 /-- info: Used approximately 0 heartbeats, which is less than the current maximum of 200000. -/
 #guard_msgs in
 #count_heartbeats approximately in

--- a/MathlibTest/DeprecatedModule.lean
+++ b/MathlibTest/DeprecatedModule.lean
@@ -17,6 +17,7 @@ with no message
 -- Deprecating the current module is possible and allows to add more deprecation information.
 deprecated_module "We can also give more details about the deprecation" (since := "2025-04-10")
 
+
 /--
 info: Deprecated modules
 

--- a/MathlibTest/DeprecatedModule.lean
+++ b/MathlibTest/DeprecatedModule.lean
@@ -17,7 +17,6 @@ with no message
 -- Deprecating the current module is possible and allows to add more deprecation information.
 deprecated_module "We can also give more details about the deprecation" (since := "2025-04-10")
 
-
 /--
 info: Deprecated modules
 

--- a/MathlibTest/DeprecatedModule.lean
+++ b/MathlibTest/DeprecatedModule.lean
@@ -2,7 +2,7 @@ import Mathlib.Tactic.Linter.DeprecatedModule
 import Mathlib.Tactic.Linter.DocPrime
 import Mathlib.Tactic.Linter.DocString
 
-deprecated_module (since "2025-04-10")
+deprecated_module (since := "2025-04-10")
 
 /--
 info: Deprecated modules
@@ -15,7 +15,7 @@ with no message
 #show_deprecated_modules
 
 -- Deprecating the current module is possible and allows to add more deprecation information.
-deprecated_module "We can also give more details about the deprecation" (since "2025-04-10")
+deprecated_module "We can also give more details about the deprecation" (since := "2025-04-10")
 
 /--
 info: Deprecated modules

--- a/MathlibTest/DeprecatedModule.lean
+++ b/MathlibTest/DeprecatedModule.lean
@@ -32,9 +32,11 @@ with no message
 #show_deprecated_modules
 
 /- Commenting out the following test, since it does not work in CI
-/-- error: Invalid date: the expected format is "2025-04-13" -/
+besides, it suggests the current date, so it should *not* be uncommented
+until that is also fixed!
+/-- error: Invalid date: the expected format is "2025-04-14" -/
 #guard_msgs in
-deprecated_module "Text" (since "2025-02-31")
+deprecated_module "Text" (since := "2025-02-31")
 -/
 
 /--


### PR DESCRIPTION
I forgot the `:=` part of the `deprecated` syntax: the new syntax
`deprecated_module "Optional string here with further details" (since := "yyyy-mm-dd")`
matches the syntax of the `deprecated` attribute.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
