### PR TITLE
[Merged by Bors] - chore(RingTheory/Etale/Field): shorten proof of iff_exists_algEquiv_prod

### DIFF
--- a/Mathlib/RingTheory/Etale/Field.lean
+++ b/Mathlib/RingTheory/Etale/Field.lean
@@ -177,14 +177,7 @@ theorem iff_exists_algEquiv_prod [EssFiniteType K A] :
     exact ⟨_, inferInstance, _, _, _, e, fun I ↦ (iff_isSeparable _ _).mp inferInstance⟩
   · intro ⟨I, _, Ai, _, _, e, _⟩
     rw [FormallyEtale.iff_of_equiv e, FormallyEtale.pi_iff]
-    have (i) : EssFiniteType K (Ai i) := by
-      letI := ((Pi.evalRingHom Ai i).comp e.toRingHom).toAlgebra
-      have : IsScalarTower K A (Ai i) :=
-        .of_algebraMap_eq fun r ↦ by simp [RingHom.algebraMap_toAlgebra]
-      have : Algebra.FiniteType A (Ai i) := .of_surjective inferInstance (Algebra.ofId _ _)
-        (RingHomSurjective.is_surjective (σ := Pi.evalRingHom Ai i).comp e.surjective)
-      exact EssFiniteType.comp K A (Ai i)
-    exact fun I ↦ (iff_isSeparable _ _).mpr inferInstance
+    exact fun I ↦ of_isSeparable K (Ai I)
 
 end Algebra.FormallyEtale
 


### PR DESCRIPTION
Shortens the proof of `iff_exists_algEquiv_prod` via [`of_isSeparable`](https://github.com/leanprover-community/mathlib4/blob/9c2b8e16b7f76e608ef6c265fbc6f814b3f0230a/Mathlib/RingTheory/Etale/Field.lean#L91), avoiding an unneeded detour through `EssFiniteType K (Ai i)`.

Found by [`tryAtEachStep`](https://github.com/dwrensha/tryAtEachStep).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
