### PR TITLE
[Merged by Bors] - fix(GroupTheory/GroupAction/Blocks): generalize one hypothesis

### DIFF
--- a/Mathlib/GroupTheory/GroupAction/Blocks.lean
+++ b/Mathlib/GroupTheory/GroupAction/Blocks.lean
@@ -350,7 +350,7 @@ lemma IsBlock.preimage {H Y : Type*} [Group H] [MulAction H Y]
 
 @[to_additive]
 theorem IsBlock.image {H Y : Type*} [MulOneClass H] [SMul H Y]
-    {φ : G →* H} (j : X →ₑ[φ] Y)
+    {φ : G → H} (j : X →ₑ[φ] Y)
     (hφ : Function.Surjective φ) (hj : Function.Injective j)
     (hB : IsBlock G B) :
     IsBlock H (j '' B) := by

--- a/Mathlib/GroupTheory/GroupAction/Blocks.lean
+++ b/Mathlib/GroupTheory/GroupAction/Blocks.lean
@@ -349,10 +349,8 @@ lemma IsBlock.preimage {H Y : Type*} [Group H] [MulAction H Y]
   exact (hB <| ne_of_apply_ne _ hg).preimage _
 
 @[to_additive]
-theorem IsBlock.image {H Y : Type*} [MulOneClass H] [SMul H Y]
-    {φ : G → H} (j : X →ₑ[φ] Y)
-    (hφ : Function.Surjective φ) (hj : Function.Injective j)
-    (hB : IsBlock G B) :
+theorem IsBlock.image {H Y : Type*} [SMul H Y] {φ : G → H} (j : X →ₑ[φ] Y)
+    (hφ : Function.Surjective φ) (hj : Function.Injective j) (hB : IsBlock G B) :
     IsBlock H (j '' B) := by
   simp only [IsBlock, hφ.forall, ← image_smul_setₛₗ]
   exact fun g₁ g₂ hg ↦ disjoint_image_of_injective hj <| hB <| ne_of_apply_ne _ hg


### PR DESCRIPTION
This relaxes one hypothesis in a lemma about blocks, from `->*` to `->`. 
Nothing else is changed.
 
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
