### PR TITLE
feat(GroupTheory/GroupAction/Basic): group equivalence of stabilizers

### DIFF
--- a/Mathlib/GroupTheory/GroupAction/Basic.lean
+++ b/Mathlib/GroupTheory/GroupAction/Basic.lean
@@ -272,7 +272,7 @@ theorem stabilizerEquivStabilizer_one :
 theorem stabilizerEquivStabilizer_inv (hg : g • b = a) :
     stabilizerEquivStabilizer (inv_smul_eq_iff.2 hg.symm) =
       (stabilizerEquivStabilizer hg).symm := by
-  ext; simp [stabilizerEquivStabilizer_apply, stabilizerEquivStabilizer_symm_apply]
+  ext; simp [stabilizerEquivStabilizer]
 
 /-- A bijection between the stabilizers of two elements in the same orbit. -/
 noncomputable def stabilizerEquivStabilizerOfOrbitRel (h : orbitRel G α a b) :
@@ -313,7 +313,7 @@ theorem stabilizerEquivStabilizer_symm_apply (hg : g +ᵥ b = a) (x : stabilizer
 theorem stabilizerEquivStabilizer_trans {hg : g +ᵥ b = a} {hh : h +ᵥ c = b} (_ : k = g + h) :
     (stabilizerEquivStabilizer hh).trans (stabilizerEquivStabilizer hg)
       = (stabilizerEquivStabilizer (by rw [← hg, ←hh, ← vadd_vadd])) := by
-  ext; simp [stabilizerEquivStabilizer_apply]
+  ext; simp [stabilizerEquivStabilizer]
 
 theorem stabilizerEquivStabilizer_zero :
     stabilizerEquivStabilizer (zero_vadd G a) = AddEquiv.refl (stabilizer G a) := by
@@ -322,7 +322,7 @@ theorem stabilizerEquivStabilizer_zero :
 theorem stabilizerEquivStabilizer_neg (hg : g +ᵥ b = a) :
     stabilizerEquivStabilizer (neg_vadd_eq_iff.2 hg.symm) =
       (stabilizerEquivStabilizer hg).symm := by
-  ext; simp [stabilizerEquivStabilizer_apply, stabilizerEquivStabilizer_symm_apply]
+  ext; simp [stabilizerEquivStabilizer]
 
 
 /-- A bijection between the stabilizers of two elements in the same orbit. -/

--- a/Mathlib/GroupTheory/GroupAction/Basic.lean
+++ b/Mathlib/GroupTheory/GroupAction/Basic.lean
@@ -244,40 +244,42 @@ theorem stabilizer_smul_eq_stabilizer_map_conj (g : G) (a : α) :
   rw [mem_stabilizer_iff, ← smul_left_cancel_iff g⁻¹, smul_smul, smul_smul, smul_smul,
     inv_mul_cancel, one_smul, ← mem_stabilizer_iff, Subgroup.mem_map_equiv, MulAut.conj_symm_apply]
 
-variable {g h k : G} {a b c : α}
+variable (g h : G) (a : α)
 
 /-- The natural group equivalence between the stabilizers of two elements in the same orbit. -/
-def stabilizerEquivStabilizer (hg : g • b = a) : stabilizer G b ≃* stabilizer G a :=
-  ((MulAut.conj g).subgroupMap (stabilizer G b)).trans
-    (MulEquiv.subgroupCongr (by
-      simp [← hg, stabilizer_smul_eq_stabilizer_map_conj]))
+def stabilizerEquivStabilizer : stabilizer G a ≃* stabilizer G (g • a) :=
+  ((MulAut.conj g).subgroupMap (stabilizer G a)).trans
+    (MulEquiv.subgroupCongr (stabilizer_smul_eq_stabilizer_map_conj g a).symm)
 
-theorem stabilizerEquivStabilizer_apply (hg : g • b = a) (x : stabilizer G b) :
-    stabilizerEquivStabilizer hg x = MulAut.conj g x := by
+variable {a} in
+theorem stabilizerEquivStabilizer_apply (x : stabilizer G a) :
+    stabilizerEquivStabilizer g a x = MulAut.conj g x := by
   simp [stabilizerEquivStabilizer]
 
-theorem stabilizerEquivStabilizer_symm_apply (hg : g • b = a) (x : stabilizer G a) :
-    (stabilizerEquivStabilizer hg).symm x = MulAut.conj g⁻¹ x := by
+variable {a} in
+theorem stabilizerEquivStabilizer_symm_apply (x : stabilizer G (g • a)) :
+    (stabilizerEquivStabilizer g a).symm x = MulAut.conj g⁻¹ x := by
   simp [stabilizerEquivStabilizer]
 
-theorem stabilizerEquivStabilizer_trans {hg : g • b = a} {hh : h • c = b} :
-    (stabilizerEquivStabilizer hh).trans (stabilizerEquivStabilizer hg)
-      = (stabilizerEquivStabilizer (by rw [← hg, ←hh, ← smul_smul])) := by
-  ext x; simp [stabilizerEquivStabilizer_apply]
+theorem stabilizerEquivStabilizer_trans :
+    (stabilizerEquivStabilizer g a).trans (stabilizerEquivStabilizer h (g • a)) =
+      (stabilizerEquivStabilizer (h * g) a).trans (MulEquiv.subgroupCongr (by rw [mul_smul])) := by
+  ext x; simp [stabilizerEquivStabilizer]
 
 theorem stabilizerEquivStabilizer_one :
-    stabilizerEquivStabilizer (one_smul G a) = MulEquiv.refl (stabilizer G a) := by
-  ext; simp [stabilizerEquivStabilizer_apply]
+    stabilizerEquivStabilizer (1 : G) a = MulEquiv.subgroupCongr (by rw [one_smul]) := by
+  ext; simp [stabilizerEquivStabilizer]
 
-theorem stabilizerEquivStabilizer_inv (hg : g • b = a) :
-    stabilizerEquivStabilizer (inv_smul_eq_iff.2 hg.symm) =
-      (stabilizerEquivStabilizer hg).symm := by
+theorem stabilizerEquivStabilizer_inv :
+    stabilizerEquivStabilizer g⁻¹ a =
+      (MulEquiv.subgroupCongr (by simp only [smul_inv_smul])).trans
+        (stabilizerEquivStabilizer g (g⁻¹ • a)).symm := by
   ext; simp [stabilizerEquivStabilizer]
 
 /-- A bijection between the stabilizers of two elements in the same orbit. -/
-noncomputable def stabilizerEquivStabilizerOfOrbitRel (h : orbitRel G α a b) :
+noncomputable def stabilizerEquivStabilizerOfOrbitRel {a b : α} (h : orbitRel G α a b) :
     stabilizer G a ≃* stabilizer G b :=
-  (stabilizerEquivStabilizer (Classical.choose_spec h)).symm
+  (Classical.choose_spec h).symm ▸ (stabilizerEquivStabilizer  _ _).symm
 
 end Stabilizer
 
@@ -294,41 +296,43 @@ theorem stabilizer_vadd_eq_stabilizer_map_conj (g : G) (a : α) :
     neg_add_cancel, zero_vadd, ← mem_stabilizer_iff, AddSubgroup.mem_map_equiv,
     AddAut.conj_symm_apply]
 
-variable {g h k : G} {a b c : α}
+variable (g h : G) (a : α)
 
 /-- The natural group equivalence between the stabilizers of two elements in the same orbit. -/
-def stabilizerEquivStabilizer (hg : g +ᵥ b = a) : stabilizer G b ≃+ stabilizer G a := by
-  exact ((AddAut.conj g).toMul.addSubgroupMap (stabilizer G b)).trans
-    (AddEquiv.addSubgroupCongr (by
-      simp [← hg, stabilizer_vadd_eq_stabilizer_map_conj]))
+def stabilizerEquivStabilizer : stabilizer G a ≃+ stabilizer G (g +ᵥ a) :=
+  ((AddAut.conj g).toMul.addSubgroupMap (stabilizer G a)).trans
+    (AddEquiv.addSubgroupCongr (stabilizer_vadd_eq_stabilizer_map_conj g a).symm)
 
-theorem stabilizerEquivStabilizer_apply (hg : g +ᵥ b = a) (x : stabilizer G b) :
-    stabilizerEquivStabilizer hg x = (AddAut.conj g).toMul x := by
+variable {a} in
+theorem stabilizerEquivStabilizer_apply (x : stabilizer G a) :
+    stabilizerEquivStabilizer g a x = AddAut.conj g x := by
   simp [stabilizerEquivStabilizer]
 
-theorem stabilizerEquivStabilizer_symm_apply (hg : g +ᵥ b = a) (x : stabilizer G a) :
-    (stabilizerEquivStabilizer hg).symm x = (AddAut.conj (-g)).toMul x := by
+variable {a} in
+theorem stabilizerEquivStabilizer_symm_apply (x : stabilizer G (g +ᵥ a)) :
+    (stabilizerEquivStabilizer g a).symm x = AddAut.conj (-g) x := by
   simp [stabilizerEquivStabilizer]
 
-theorem stabilizerEquivStabilizer_trans {hg : g +ᵥ b = a} {hh : h +ᵥ c = b} :
-    (stabilizerEquivStabilizer hh).trans (stabilizerEquivStabilizer hg)
-      = (stabilizerEquivStabilizer (by rw [← hg, ←hh, ← vadd_vadd])) := by
-  ext; simp [stabilizerEquivStabilizer]
+theorem stabilizerEquivStabilizer_trans :
+    (stabilizerEquivStabilizer g a).trans (stabilizerEquivStabilizer h (g +ᵥ a)) =
+      (stabilizerEquivStabilizer (h + g) a).trans
+        (AddEquiv.addSubgroupCongr (by rw [add_vadd])) := by
+  ext x; simp [stabilizerEquivStabilizer]
 
 theorem stabilizerEquivStabilizer_zero :
-    stabilizerEquivStabilizer (zero_vadd G a) = AddEquiv.refl (stabilizer G a) := by
-  ext; simp [stabilizerEquivStabilizer_apply]
-
-theorem stabilizerEquivStabilizer_neg (hg : g +ᵥ b = a) :
-    stabilizerEquivStabilizer (neg_vadd_eq_iff.2 hg.symm) =
-      (stabilizerEquivStabilizer hg).symm := by
+    stabilizerEquivStabilizer (0 : G) a = AddEquiv.addSubgroupCongr (by rw [zero_vadd]) := by
   ext; simp [stabilizerEquivStabilizer]
 
+theorem stabilizerEquivStabilizer_neg :
+    stabilizerEquivStabilizer (-g) a =
+      (AddEquiv.addSubgroupCongr (by simp only [vadd_neg_vadd])).trans
+        (stabilizerEquivStabilizer g ((-g) +ᵥ a)).symm := by
+  ext; simp [stabilizerEquivStabilizer]
 
 /-- A bijection between the stabilizers of two elements in the same orbit. -/
-noncomputable def stabilizerEquivStabilizerOfOrbitRel (h : orbitRel G α a b) :
+noncomputable def stabilizerEquivStabilizerOfOrbitRel {a b : α} (h : orbitRel G α a b) :
     stabilizer G a ≃+ stabilizer G b :=
-  (stabilizerEquivStabilizer (Classical.choose_spec h)).symm
+  (Classical.choose_spec h).symm ▸ (stabilizerEquivStabilizer  _ _).symm
 
 end AddAction
 

--- a/Mathlib/GroupTheory/GroupAction/Basic.lean
+++ b/Mathlib/GroupTheory/GroupAction/Basic.lean
@@ -260,7 +260,7 @@ theorem stabilizerEquivStabilizer_symm_apply (hg : g • b = a) (x : stabilizer 
     (stabilizerEquivStabilizer hg).symm x = MulAut.conj g⁻¹ x := by
   simp [stabilizerEquivStabilizer]
 
-theorem stabilizerEquivStabilizer_trans {hg : g • b = a} {hh : h • c = b} (_ : k = g * h) :
+theorem stabilizerEquivStabilizer_trans {hg : g • b = a} {hh : h • c = b} :
     (stabilizerEquivStabilizer hh).trans (stabilizerEquivStabilizer hg)
       = (stabilizerEquivStabilizer (by rw [← hg, ←hh, ← smul_smul])) := by
   ext x; simp [stabilizerEquivStabilizer_apply]
@@ -310,7 +310,7 @@ theorem stabilizerEquivStabilizer_symm_apply (hg : g +ᵥ b = a) (x : stabilizer
     (stabilizerEquivStabilizer hg).symm x = (AddAut.conj (-g)).toMul x := by
   simp [stabilizerEquivStabilizer]
 
-theorem stabilizerEquivStabilizer_trans {hg : g +ᵥ b = a} {hh : h +ᵥ c = b} (_ : k = g + h) :
+theorem stabilizerEquivStabilizer_trans {hg : g +ᵥ b = a} {hh : h +ᵥ c = b} :
     (stabilizerEquivStabilizer hh).trans (stabilizerEquivStabilizer hg)
       = (stabilizerEquivStabilizer (by rw [← hg, ←hh, ← vadd_vadd])) := by
   ext; simp [stabilizerEquivStabilizer]

--- a/Mathlib/GroupTheory/GroupAction/Basic.lean
+++ b/Mathlib/GroupTheory/GroupAction/Basic.lean
@@ -262,6 +262,22 @@ theorem stabilizerEquivStabilizer_symm_apply
     (stabilizerEquivStabilizer hg).symm x = MulAut.conj g⁻¹ x := by
   simp [stabilizerEquivStabilizer]
 
+theorem stabilizerEquivStabilizer_trans
+    {a b c : α} {g h k : G} {hg : g • b = a} {hh : h • c = b} {hk : k • c = a} (H : k = g * h) :
+    (stabilizerEquivStabilizer hh).trans (stabilizerEquivStabilizer hg)
+      = (stabilizerEquivStabilizer hk) := by
+  ext x; simp [stabilizerEquivStabilizer_apply, H]
+
+theorem stabilizerEquivStabilizer_one {a : α} :
+    stabilizerEquivStabilizer (one_smul G a) = MulEquiv.refl (stabilizer G a) := by
+  ext; simp [stabilizerEquivStabilizer_apply]
+
+theorem stabilizerEquivStabilizer_inv {a b : α} {g : G} (hg : g • b = a) :
+    let hg' : g⁻¹ • a = b := inv_smul_eq_iff.mpr (id (Eq.symm hg))
+    stabilizerEquivStabilizer hg' = (stabilizerEquivStabilizer hg).symm := by
+  ext
+  simp [stabilizerEquivStabilizer_apply, stabilizerEquivStabilizer_symm_apply]
+
 /-- A bijection between the stabilizers of two elements in the same orbit. -/
 noncomputable def stabilizerEquivStabilizerOfOrbitRel {a b : α} (h : orbitRel G α a b) :
     stabilizer G a ≃* stabilizer G b :=

--- a/Mathlib/GroupTheory/GroupAction/Basic.lean
+++ b/Mathlib/GroupTheory/GroupAction/Basic.lean
@@ -244,42 +244,39 @@ theorem stabilizer_smul_eq_stabilizer_map_conj (g : G) (a : α) :
   rw [mem_stabilizer_iff, ← smul_left_cancel_iff g⁻¹, smul_smul, smul_smul, smul_smul,
     inv_mul_cancel, one_smul, ← mem_stabilizer_iff, Subgroup.mem_map_equiv, MulAut.conj_symm_apply]
 
+variable {g h k : G} {a b c : α}
+
 /-- The natural group equivalence between the stabilizers of two elements in the same orbit. -/
-def stabilizerEquivStabilizer {a b : α} {g : G} (hg : g • b = a) :
-    stabilizer G b ≃* stabilizer G a :=
-  ((MulAut.conj g).subgroupMap <| stabilizer G b).trans
+def stabilizerEquivStabilizer (hg : g • b = a) : stabilizer G b ≃* stabilizer G a :=
+  ((MulAut.conj g).subgroupMap (stabilizer G b)).trans
     (MulEquiv.subgroupCongr (by
       simp [← hg, stabilizer_smul_eq_stabilizer_map_conj]))
 
-theorem stabilizerEquivStabilizer_apply {a b : α} {g : G} (hg : g • b = a) (x : stabilizer G b) :
+theorem stabilizerEquivStabilizer_apply (hg : g • b = a) (x : stabilizer G b) :
     stabilizerEquivStabilizer hg x = MulAut.conj g x := by
-  -- simp [stabilizerEquivStabilizer]
   simp only [stabilizerEquivStabilizer, MulEquiv.trans_apply, MulEquiv.subgroupCongr_apply,
     MulEquiv.coe_subgroupMap_apply, MulAut.conj_apply]
 
-theorem stabilizerEquivStabilizer_symm_apply
-    {a b : α} {g : G} (hg : g • b = a) (x : stabilizer G a) :
+theorem stabilizerEquivStabilizer_symm_apply (hg : g • b = a) (x : stabilizer G a) :
     (stabilizerEquivStabilizer hg).symm x = MulAut.conj g⁻¹ x := by
   simp [stabilizerEquivStabilizer]
 
-theorem stabilizerEquivStabilizer_trans
-    {a b c : α} {g h k : G} {hg : g • b = a} {hh : h • c = b} {hk : k • c = a} (H : k = g * h) :
+theorem stabilizerEquivStabilizer_trans {hg : g • b = a} {hh : h • c = b} (_ : k = g * h) :
     (stabilizerEquivStabilizer hh).trans (stabilizerEquivStabilizer hg)
-      = (stabilizerEquivStabilizer hk) := by
-  ext x; simp [stabilizerEquivStabilizer_apply, H]
+      = (stabilizerEquivStabilizer (by rw [← hg, ←hh, ← smul_smul])) := by
+  ext x; simp [stabilizerEquivStabilizer_apply]
 
-theorem stabilizerEquivStabilizer_one {a : α} :
+theorem stabilizerEquivStabilizer_one :
     stabilizerEquivStabilizer (one_smul G a) = MulEquiv.refl (stabilizer G a) := by
   ext; simp [stabilizerEquivStabilizer_apply]
 
-theorem stabilizerEquivStabilizer_inv {a b : α} {g : G} (hg : g • b = a) :
-    let hg' : g⁻¹ • a = b := inv_smul_eq_iff.mpr (id (Eq.symm hg))
-    stabilizerEquivStabilizer hg' = (stabilizerEquivStabilizer hg).symm := by
-  ext
-  simp [stabilizerEquivStabilizer_apply, stabilizerEquivStabilizer_symm_apply]
+theorem stabilizerEquivStabilizer_inv (hg : g • b = a) :
+    stabilizerEquivStabilizer (inv_smul_eq_iff.2 hg.symm) =
+      (stabilizerEquivStabilizer hg).symm := by
+  ext; simp [stabilizerEquivStabilizer_apply, stabilizerEquivStabilizer_symm_apply]
 
 /-- A bijection between the stabilizers of two elements in the same orbit. -/
-noncomputable def stabilizerEquivStabilizerOfOrbitRel {a b : α} (h : orbitRel G α a b) :
+noncomputable def stabilizerEquivStabilizerOfOrbitRel (h : orbitRel G α a b) :
     stabilizer G a ≃* stabilizer G b :=
   (stabilizerEquivStabilizer (Classical.choose_spec h)).symm
 
@@ -298,24 +295,39 @@ theorem stabilizer_vadd_eq_stabilizer_map_conj (g : G) (a : α) :
     neg_add_cancel, zero_vadd, ← mem_stabilizer_iff, AddSubgroup.mem_map_equiv,
     AddAut.conj_symm_apply]
 
+variable {g h k : G} {a b c : α}
+
 /-- The natural group equivalence between the stabilizers of two elements in the same orbit. -/
-def stabilizerEquivStabilizer {a b : α} {g : G} (hg : g +ᵥ b = a) :
-    stabilizer G b ≃+ stabilizer G a := by
+def stabilizerEquivStabilizer (hg : g +ᵥ b = a) : stabilizer G b ≃+ stabilizer G a := by
   exact ((AddAut.conj g).toMul.addSubgroupMap (stabilizer G b)).trans
     (AddEquiv.addSubgroupCongr (by
       simp [← hg, stabilizer_vadd_eq_stabilizer_map_conj]))
 
-theorem stabilizerEquivStabilizer_apply {a b : α} {g : G} (hg : g +ᵥ b = a) (x : stabilizer G b) :
+theorem stabilizerEquivStabilizer_apply (hg : g +ᵥ b = a) (x : stabilizer G b) :
     stabilizerEquivStabilizer hg x = (AddAut.conj g).toMul x := by
   simp [stabilizerEquivStabilizer]
 
-theorem stabilizerEquivStabilizer_symm_apply
-    {a b : α} {g : G} (hg : g +ᵥ b = a) (x : stabilizer G a) :
+theorem stabilizerEquivStabilizer_symm_apply (hg : g +ᵥ b = a) (x : stabilizer G a) :
     (stabilizerEquivStabilizer hg).symm x = (AddAut.conj (-g)).toMul x := by
   simp [stabilizerEquivStabilizer]
 
+theorem stabilizerEquivStabilizer_trans {hg : g +ᵥ b = a} {hh : h +ᵥ c = b} (_ : k = g + h) :
+    (stabilizerEquivStabilizer hh).trans (stabilizerEquivStabilizer hg)
+      = (stabilizerEquivStabilizer (by rw [← hg, ←hh, ← vadd_vadd])) := by
+  ext x; simp [stabilizerEquivStabilizer_apply]
+
+theorem stabilizerEquivStabilizer_zero :
+    stabilizerEquivStabilizer (zero_vadd G a) = AddEquiv.refl (stabilizer G a) := by
+  ext; simp [stabilizerEquivStabilizer_apply]
+
+theorem stabilizerEquivStabilizer_neg (hg : g +ᵥ b = a) :
+    stabilizerEquivStabilizer (neg_vadd_eq_iff.2 hg.symm) =
+      (stabilizerEquivStabilizer hg).symm := by
+  ext; simp [stabilizerEquivStabilizer_apply, stabilizerEquivStabilizer_symm_apply]
+
+
 /-- A bijection between the stabilizers of two elements in the same orbit. -/
-noncomputable def stabilizerEquivStabilizerOfOrbitRel {a b : α} (h : orbitRel G α a b) :
+noncomputable def stabilizerEquivStabilizerOfOrbitRel (h : orbitRel G α a b) :
     stabilizer G a ≃+ stabilizer G b :=
   (stabilizerEquivStabilizer (Classical.choose_spec h)).symm
 
@@ -324,6 +336,9 @@ end AddAction
 attribute [to_additive existing] MulAction.stabilizerEquivStabilizer
 attribute [to_additive existing] MulAction.stabilizerEquivStabilizer_apply
 attribute [to_additive existing] MulAction.stabilizerEquivStabilizer_symm_apply
+attribute [to_additive existing] MulAction.stabilizerEquivStabilizer_trans
+attribute [to_additive existing] MulAction.stabilizerEquivStabilizer_one
+attribute [to_additive existing] MulAction.stabilizerEquivStabilizer_inv
 attribute [to_additive existing] MulAction.stabilizer_smul_eq_stabilizer_map_conj
 attribute [to_additive existing] MulAction.stabilizerEquivStabilizerOfOrbitRel
 

--- a/Mathlib/GroupTheory/GroupAction/Basic.lean
+++ b/Mathlib/GroupTheory/GroupAction/Basic.lean
@@ -233,53 +233,61 @@ lemma orbitRel_le_snd :
 end Orbit
 
 section Stabilizer
-variable (G)
 
-variable {G}
+open MulEquiv(subgroupCongr)
+
+open MulAut
 
 /-- If the stabilizer of `a` is `S`, then the stabilizer of `g • a` is `gSg⁻¹`. -/
 theorem stabilizer_smul_eq_stabilizer_map_conj (g : G) (a : α) :
-    stabilizer G (g • a) = (stabilizer G a).map (MulAut.conj g).toMonoidHom := by
+    stabilizer G (g • a) = (stabilizer G a).map (conj g).toMonoidHom := by
   ext h
   rw [mem_stabilizer_iff, ← smul_left_cancel_iff g⁻¹, smul_smul, smul_smul, smul_smul,
-    inv_mul_cancel, one_smul, ← mem_stabilizer_iff, Subgroup.mem_map_equiv, MulAut.conj_symm_apply]
+    inv_mul_cancel, one_smul, ← mem_stabilizer_iff, Subgroup.mem_map_equiv, conj_symm_apply]
 
 variable (g h : G) (a : α)
 
 /-- The natural group equivalence between the stabilizers of two elements in the same orbit. -/
 def stabilizerEquivStabilizer : stabilizer G a ≃* stabilizer G (g • a) :=
-  ((MulAut.conj g).subgroupMap (stabilizer G a)).trans
-    (MulEquiv.subgroupCongr (stabilizer_smul_eq_stabilizer_map_conj g a).symm)
+  ((conj g).subgroupMap (stabilizer G a)).trans
+    (subgroupCongr (stabilizer_smul_eq_stabilizer_map_conj g a).symm)
 
 variable {a} in
 theorem stabilizerEquivStabilizer_apply (x : stabilizer G a) :
-    stabilizerEquivStabilizer g a x = MulAut.conj g x := by
+    stabilizerEquivStabilizer g a x = conj g x := by
   simp [stabilizerEquivStabilizer]
 
 variable {a} in
 theorem stabilizerEquivStabilizer_symm_apply (x : stabilizer G (g • a)) :
-    (stabilizerEquivStabilizer g a).symm x = MulAut.conj g⁻¹ x := by
+    (stabilizerEquivStabilizer g a).symm x = conj g⁻¹ x := by
   simp [stabilizerEquivStabilizer]
 
 theorem stabilizerEquivStabilizer_trans :
     (stabilizerEquivStabilizer g a).trans (stabilizerEquivStabilizer h (g • a)) =
-      (stabilizerEquivStabilizer (h * g) a).trans (MulEquiv.subgroupCongr (by rw [mul_smul])) := by
-  ext x; simp [stabilizerEquivStabilizer]
+      (stabilizerEquivStabilizer (h * g) a).trans (subgroupCongr (by rw [mul_smul])) := by
+  ext; simp [stabilizerEquivStabilizer]
+
+theorem stabilizerEquivStabilizer_mul :
+    (stabilizerEquivStabilizer (h * g) a) =
+      ((stabilizerEquivStabilizer g a).trans
+        (stabilizerEquivStabilizer h (g • a))).trans
+          (subgroupCongr (by rw [mul_smul])) := by
+  ext; simp [stabilizerEquivStabilizer]
 
 theorem stabilizerEquivStabilizer_one :
-    stabilizerEquivStabilizer (1 : G) a = MulEquiv.subgroupCongr (by rw [one_smul]) := by
+    stabilizerEquivStabilizer (1 : G) a = subgroupCongr (by rw [one_smul]) := by
   ext; simp [stabilizerEquivStabilizer]
 
 theorem stabilizerEquivStabilizer_inv :
     stabilizerEquivStabilizer g⁻¹ a =
-      (MulEquiv.subgroupCongr (by simp only [smul_inv_smul])).trans
+      (subgroupCongr (by simp only [smul_inv_smul])).trans
         (stabilizerEquivStabilizer g (g⁻¹ • a)).symm := by
   ext; simp [stabilizerEquivStabilizer]
 
 /-- A bijection between the stabilizers of two elements in the same orbit. -/
 noncomputable def stabilizerEquivStabilizerOfOrbitRel {a b : α} (h : orbitRel G α a b) :
     stabilizer G a ≃* stabilizer G b :=
-  (Classical.choose_spec h).symm ▸ (stabilizerEquivStabilizer  _ _).symm
+  (subgroupCongr (by rw [← Classical.choose_spec h])).trans (stabilizerEquivStabilizer _ b).symm
 
 end Stabilizer
 
@@ -288,61 +296,72 @@ end MulAction
 namespace AddAction
 variable {G α : Type*} [AddGroup G] [AddAction G α]
 
+open AddEquiv(addSubgroupCongr)
+
+open AddAut
+
 /-- If the stabilizer of `x` is `S`, then the stabilizer of `g +ᵥ x` is `g + S + (-g)`. -/
 theorem stabilizer_vadd_eq_stabilizer_map_conj (g : G) (a : α) :
-    stabilizer G (g +ᵥ a) = (stabilizer G a).map (AddAut.conj g).toMul.toAddMonoidHom := by
+    stabilizer G (g +ᵥ a) = (stabilizer G a).map (conj g).toMul.toAddMonoidHom := by
   ext h
   rw [mem_stabilizer_iff, ← vadd_left_cancel_iff (-g), vadd_vadd, vadd_vadd, vadd_vadd,
     neg_add_cancel, zero_vadd, ← mem_stabilizer_iff, AddSubgroup.mem_map_equiv,
-    AddAut.conj_symm_apply]
+    conj_symm_apply]
 
 variable (g h : G) (a : α)
 
 /-- The natural group equivalence between the stabilizers of two elements in the same orbit. -/
 def stabilizerEquivStabilizer : stabilizer G a ≃+ stabilizer G (g +ᵥ a) :=
-  ((AddAut.conj g).toMul.addSubgroupMap (stabilizer G a)).trans
-    (AddEquiv.addSubgroupCongr (stabilizer_vadd_eq_stabilizer_map_conj g a).symm)
+  ((conj g).toMul.addSubgroupMap (stabilizer G a)).trans
+    (addSubgroupCongr (stabilizer_vadd_eq_stabilizer_map_conj g a).symm)
 
 variable {a} in
 theorem stabilizerEquivStabilizer_apply (x : stabilizer G a) :
-    stabilizerEquivStabilizer g a x = AddAut.conj g x := by
+    stabilizerEquivStabilizer g a x = conj g x := by
   simp [stabilizerEquivStabilizer]
 
 variable {a} in
 theorem stabilizerEquivStabilizer_symm_apply (x : stabilizer G (g +ᵥ a)) :
-    (stabilizerEquivStabilizer g a).symm x = AddAut.conj (-g) x := by
+    (stabilizerEquivStabilizer g a).symm x = conj (-g) x := by
   simp [stabilizerEquivStabilizer]
 
 theorem stabilizerEquivStabilizer_trans :
     (stabilizerEquivStabilizer g a).trans (stabilizerEquivStabilizer h (g +ᵥ a)) =
-      (stabilizerEquivStabilizer (h + g) a).trans
-        (AddEquiv.addSubgroupCongr (by rw [add_vadd])) := by
-  ext x; simp [stabilizerEquivStabilizer]
+      (stabilizerEquivStabilizer (h + g) a).trans (addSubgroupCongr (by rw [add_vadd])) := by
+  ext; simp [stabilizerEquivStabilizer]
+
+theorem stabilizerEquivStabilizer_add :
+    (stabilizerEquivStabilizer (h + g) a) =
+      ((stabilizerEquivStabilizer g a).trans
+        (stabilizerEquivStabilizer h (g +ᵥ a))).trans
+          (addSubgroupCongr (by rw [add_vadd])) := by
+  ext; simp [stabilizerEquivStabilizer]
 
 theorem stabilizerEquivStabilizer_zero :
-    stabilizerEquivStabilizer (0 : G) a = AddEquiv.addSubgroupCongr (by rw [zero_vadd]) := by
+    stabilizerEquivStabilizer (0 : G) a = addSubgroupCongr (by rw [zero_vadd]) := by
   ext; simp [stabilizerEquivStabilizer]
 
 theorem stabilizerEquivStabilizer_neg :
     stabilizerEquivStabilizer (-g) a =
-      (AddEquiv.addSubgroupCongr (by simp only [vadd_neg_vadd])).trans
+      (addSubgroupCongr (by simp only [vadd_neg_vadd])).trans
         (stabilizerEquivStabilizer g ((-g) +ᵥ a)).symm := by
   ext; simp [stabilizerEquivStabilizer]
 
 /-- A bijection between the stabilizers of two elements in the same orbit. -/
 noncomputable def stabilizerEquivStabilizerOfOrbitRel {a b : α} (h : orbitRel G α a b) :
     stabilizer G a ≃+ stabilizer G b :=
-  (Classical.choose_spec h).symm ▸ (stabilizerEquivStabilizer  _ _).symm
+  (addSubgroupCongr (by rw [← Classical.choose_spec h])).trans (stabilizerEquivStabilizer  _ b).symm
 
 end AddAction
 
+attribute [to_additive existing] MulAction.stabilizer_smul_eq_stabilizer_map_conj
 attribute [to_additive existing] MulAction.stabilizerEquivStabilizer
 attribute [to_additive existing] MulAction.stabilizerEquivStabilizer_apply
 attribute [to_additive existing] MulAction.stabilizerEquivStabilizer_symm_apply
 attribute [to_additive existing] MulAction.stabilizerEquivStabilizer_trans
+attribute [to_additive existing] MulAction.stabilizerEquivStabilizer_mul
 attribute [to_additive existing] MulAction.stabilizerEquivStabilizer_one
 attribute [to_additive existing] MulAction.stabilizerEquivStabilizer_inv
-attribute [to_additive existing] MulAction.stabilizer_smul_eq_stabilizer_map_conj
 attribute [to_additive existing] MulAction.stabilizerEquivStabilizerOfOrbitRel
 
 theorem Equiv.swap_mem_stabilizer {α : Type*} [DecidableEq α] {S : Set α} {a b : α} :

--- a/Mathlib/GroupTheory/GroupAction/Basic.lean
+++ b/Mathlib/GroupTheory/GroupAction/Basic.lean
@@ -244,14 +244,28 @@ theorem stabilizer_smul_eq_stabilizer_map_conj (g : G) (a : α) :
   rw [mem_stabilizer_iff, ← smul_left_cancel_iff g⁻¹, smul_smul, smul_smul, smul_smul,
     inv_mul_cancel, one_smul, ← mem_stabilizer_iff, Subgroup.mem_map_equiv, MulAut.conj_symm_apply]
 
+/-- The natural group equivalence between the stabilizers of two elements in the same orbit. -/
+def stabilizerEquivStabilizer {a b : α} {g : G} (hg : g • b = a) :
+    stabilizer G b ≃* stabilizer G a :=
+  ((MulAut.conj g).subgroupMap <| stabilizer G b).trans
+    (MulEquiv.subgroupCongr (by
+      simp [← hg, stabilizer_smul_eq_stabilizer_map_conj]))
+
+theorem stabilizerEquivStabilizer_apply {a b : α} {g : G} (hg : g • b = a) (x : stabilizer G b) :
+    stabilizerEquivStabilizer hg x = MulAut.conj g x := by
+  -- simp [stabilizerEquivStabilizer]
+  simp only [stabilizerEquivStabilizer, MulEquiv.trans_apply, MulEquiv.subgroupCongr_apply,
+    MulEquiv.coe_subgroupMap_apply, MulAut.conj_apply]
+
+theorem stabilizerEquivStabilizer_symm_apply
+    {a b : α} {g : G} (hg : g • b = a) (x : stabilizer G a) :
+    (stabilizerEquivStabilizer hg).symm x = MulAut.conj g⁻¹ x := by
+  simp [stabilizerEquivStabilizer]
+
 /-- A bijection between the stabilizers of two elements in the same orbit. -/
 noncomputable def stabilizerEquivStabilizerOfOrbitRel {a b : α} (h : orbitRel G α a b) :
     stabilizer G a ≃* stabilizer G b :=
-  let g : G := Classical.choose h
-  have hg : g • b = a := Classical.choose_spec h
-  have this : stabilizer G a = (stabilizer G b).map (MulAut.conj g).toMonoidHom := by
-    rw [← hg, stabilizer_smul_eq_stabilizer_map_conj]
-  (MulEquiv.subgroupCongr this).trans ((MulAut.conj g).subgroupMap <| stabilizer G b).symm
+  (stabilizerEquivStabilizer (Classical.choose_spec h)).symm
 
 end Stabilizer
 
@@ -268,17 +282,32 @@ theorem stabilizer_vadd_eq_stabilizer_map_conj (g : G) (a : α) :
     neg_add_cancel, zero_vadd, ← mem_stabilizer_iff, AddSubgroup.mem_map_equiv,
     AddAut.conj_symm_apply]
 
+/-- The natural group equivalence between the stabilizers of two elements in the same orbit. -/
+def stabilizerEquivStabilizer {a b : α} {g : G} (hg : g +ᵥ b = a) :
+    stabilizer G b ≃+ stabilizer G a := by
+  exact ((AddAut.conj g).toMul.addSubgroupMap (stabilizer G b)).trans
+    (AddEquiv.addSubgroupCongr (by
+      simp [← hg, stabilizer_vadd_eq_stabilizer_map_conj]))
+
+theorem stabilizerEquivStabilizer_apply {a b : α} {g : G} (hg : g +ᵥ b = a) (x : stabilizer G b) :
+    stabilizerEquivStabilizer hg x = (AddAut.conj g).toMul x := by
+  simp [stabilizerEquivStabilizer]
+
+theorem stabilizerEquivStabilizer_symm_apply
+    {a b : α} {g : G} (hg : g +ᵥ b = a) (x : stabilizer G a) :
+    (stabilizerEquivStabilizer hg).symm x = (AddAut.conj (-g)).toMul x := by
+  simp [stabilizerEquivStabilizer]
+
 /-- A bijection between the stabilizers of two elements in the same orbit. -/
 noncomputable def stabilizerEquivStabilizerOfOrbitRel {a b : α} (h : orbitRel G α a b) :
     stabilizer G a ≃+ stabilizer G b :=
-  let g : G := Classical.choose h
-  have hg : g +ᵥ b = a := Classical.choose_spec h
-  have this : stabilizer G a = (stabilizer G b).map (AddAut.conj g).toMul.toAddMonoidHom := by
-    rw [← hg, stabilizer_vadd_eq_stabilizer_map_conj]
-  (AddEquiv.addSubgroupCongr this).trans ((AddAut.conj g).addSubgroupMap <| stabilizer G b).symm
+  (stabilizerEquivStabilizer (Classical.choose_spec h)).symm
 
 end AddAction
 
+attribute [to_additive existing] MulAction.stabilizerEquivStabilizer
+attribute [to_additive existing] MulAction.stabilizerEquivStabilizer_apply
+attribute [to_additive existing] MulAction.stabilizerEquivStabilizer_symm_apply
 attribute [to_additive existing] MulAction.stabilizer_smul_eq_stabilizer_map_conj
 attribute [to_additive existing] MulAction.stabilizerEquivStabilizerOfOrbitRel
 

--- a/Mathlib/GroupTheory/GroupAction/Basic.lean
+++ b/Mathlib/GroupTheory/GroupAction/Basic.lean
@@ -254,8 +254,7 @@ def stabilizerEquivStabilizer (hg : g • b = a) : stabilizer G b ≃* stabilize
 
 theorem stabilizerEquivStabilizer_apply (hg : g • b = a) (x : stabilizer G b) :
     stabilizerEquivStabilizer hg x = MulAut.conj g x := by
-  simp only [stabilizerEquivStabilizer, MulEquiv.trans_apply, MulEquiv.subgroupCongr_apply,
-    MulEquiv.coe_subgroupMap_apply, MulAut.conj_apply]
+  simp [stabilizerEquivStabilizer]
 
 theorem stabilizerEquivStabilizer_symm_apply (hg : g • b = a) (x : stabilizer G a) :
     (stabilizerEquivStabilizer hg).symm x = MulAut.conj g⁻¹ x := by
@@ -314,7 +313,7 @@ theorem stabilizerEquivStabilizer_symm_apply (hg : g +ᵥ b = a) (x : stabilizer
 theorem stabilizerEquivStabilizer_trans {hg : g +ᵥ b = a} {hh : h +ᵥ c = b} (_ : k = g + h) :
     (stabilizerEquivStabilizer hh).trans (stabilizerEquivStabilizer hg)
       = (stabilizerEquivStabilizer (by rw [← hg, ←hh, ← vadd_vadd])) := by
-  ext x; simp [stabilizerEquivStabilizer_apply]
+  ext; simp [stabilizerEquivStabilizer_apply]
 
 theorem stabilizerEquivStabilizer_zero :
     stabilizerEquivStabilizer (zero_vadd G a) = AddEquiv.refl (stabilizer G a) := by


### PR DESCRIPTION
Define `stabilizerEquivStabilizer {a b : α} {g : G} (hg : g • b = a) : stabilizer G b ≃* stabilizer G a`

Add the `trans`, `inv`,  and `one`properties.

Refactors `MulAction.stabilizerEquivStabilizerOfOrbitRel` using it.

This is a concurrent PR to #24107 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
