### PR TITLE
[Merged by Bors] - feat: add `ULiftable.up'` and `ULiftable.down'`

### DIFF
--- a/Mathlib/Control/ULiftable.lean
+++ b/Mathlib/Control/ULiftable.lean
@@ -92,12 +92,12 @@ def downMap {F : Type max u₀ v₀ → Type u₁} {G : Type u₀ → Type v₁}
   down (Functor.map (ULift.up.{v₀} ∘ f) x : F (ULift β))
 
 /-- A version of `up` for a `PUnit` return type. -/
-abbrev up' {f : Type u₀ → Type u₁} {g : Type v₀ → Type v₁} [Functor g] [ULiftable f g] :
+abbrev up' {f : Type u₀ → Type u₁} {g : Type v₀ → Type v₁} [ULiftable f g] :
     f PUnit → g PUnit :=
   ULiftable.congr Equiv.punitEquivPUnit
 
 /-- A version of `down` for a `PUnit` return type. -/
-abbrev down' {f : Type u₀ → Type u₁} {g : Type v₀ → Type v₁} [Functor g] [ULiftable f g] :
+abbrev down' {f : Type u₀ → Type u₁} {g : Type v₀ → Type v₁} [ULiftable f g] :
     g PUnit → f PUnit :=
   (ULiftable.congr Equiv.punitEquivPUnit).symm
 

--- a/Mathlib/Control/ULiftable.lean
+++ b/Mathlib/Control/ULiftable.lean
@@ -92,14 +92,14 @@ def downMap {F : Type max u₀ v₀ → Type u₁} {G : Type u₀ → Type v₁}
   down (Functor.map (ULift.up.{v₀} ∘ f) x : F (ULift β))
 
 /-- A version of `up` for a `PUnit` return type. -/
-abbrev up' {f : Type u₀ → Type u₁} {g : Type max u₀ v → Type v₁} [Functor g] [ULiftable f g] :
+abbrev up' {f : Type u₀ → Type u₁} {g : Type v₀ → Type v₁} [Functor g] [ULiftable f g] :
     f PUnit → g PUnit :=
-  (discard <| up ·)
+  ULiftable.congr Equiv.punitEquivPUnit
 
 /-- A version of `down` for a `PUnit` return type. -/
-abbrev down' {f : Type u₀ → Type u₁} {g : Type max u₀ v → Type v₁} [Functor g] [ULiftable f g] :
+abbrev down' {f : Type u₀ → Type u₁} {g : Type v₀ → Type v₁} [Functor g] [ULiftable f g] :
     g PUnit → f PUnit :=
-  (down <| (fun _ => ⟨⟨⟩⟩) <$> ·)
+  (ULiftable.congr Equiv.punitEquivPUnit).symm
 
 theorem up_down {f : Type u₀ → Type u₁} {g : Type max u₀ v₀ → Type v₁} [ULiftable f g] {α}
     (x : g (ULift.{v₀} α)) : up (down x : f α) = x :=

--- a/Mathlib/Control/ULiftable.lean
+++ b/Mathlib/Control/ULiftable.lean
@@ -91,6 +91,16 @@ def downMap {F : Type max u₀ v₀ → Type u₁} {G : Type u₀ → Type v₁}
     [Functor F] {α β} (f : α → β) (x : F α) : G β :=
   down (Functor.map (ULift.up.{v₀} ∘ f) x : F (ULift β))
 
+/-- A version of `up` for a `PUnit` return type. -/
+abbrev up' {f : Type u₀ → Type u₁} {g : Type max u₀ v → Type v₁} [Functor g] [ULiftable f g] :
+    f PUnit → g PUnit :=
+  (discard <| up ·)
+
+/-- A version of `down` for a `PUnit` return type. -/
+abbrev down' {f : Type u₀ → Type u₁} {g : Type max u₀ v → Type v₁} [Functor g] [ULiftable f g] :
+    g PUnit → f PUnit :=
+  (down <| (fun _ => ⟨⟨⟩⟩) <$> ·)
+
 theorem up_down {f : Type u₀ → Type u₁} {g : Type max u₀ v₀ → Type v₁} [ULiftable f g] {α}
     (x : g (ULift.{v₀} α)) : up (down x : f α) = x :=
   (ULiftable.congr Equiv.ulift.symm).right_inv _


### PR DESCRIPTION
These are handy when working with `m PUnit`


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
