### PR TITLE
[Merged by Bors] - feat(RingTheory/LocalRing): results for non-local rings

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -5076,6 +5076,7 @@ import Mathlib.RingTheory.LocalRing.LocalSubring
 import Mathlib.RingTheory.LocalRing.MaximalIdeal.Basic
 import Mathlib.RingTheory.LocalRing.MaximalIdeal.Defs
 import Mathlib.RingTheory.LocalRing.Module
+import Mathlib.RingTheory.LocalRing.NonLocalRing
 import Mathlib.RingTheory.LocalRing.Quotient
 import Mathlib.RingTheory.LocalRing.ResidueField.Basic
 import Mathlib.RingTheory.LocalRing.ResidueField.Defs

--- a/Mathlib/RingTheory/LocalRing/NonLocalRing.lean
+++ b/Mathlib/RingTheory/LocalRing/NonLocalRing.lean
@@ -21,10 +21,10 @@ This file gathers some results about non-local rings.
   `Π i, R i` is not local.
 - `not_isLocalRing_of_prod_of_nontrivial`: the product of two nontrivial (semi)rings is not
   local.
-- `not_isLocalRing_iff_nontrivial_maximalSpectrum`: a commutative (semi)ring is not local iff
-  it has nontrivial maximal spectrum.
-- `not_isLocalRing_iff_exist_maximal_ne`: a commutative (semi)ring is not local iff it has
-  two distinct maximal ideals.
+- `not_isLocalRing_tfae`: the following are equivalent for a commutative (semi)ring `R`:
+    * `R` is not local,
+    * `R` has nontrivial maximal spectrum,
+    * `R` has two distinct maximal ideals.
 - `exists_surjective_of_not_isLocalRing`: there exists a surjective ring homomorphism from
   a non-local commutative ring onto a product of two fields.
 
@@ -32,10 +32,13 @@ This file gathers some results about non-local rings.
 
 namespace IsLocalRing
 
+/-- If two non-units sum to 1 in a (semi)ring `R` then `R` is not local. -/
 theorem not_isLocalRing_def {R : Type*} [Semiring R] {a b : R} (ha : ¬IsUnit a) (hb : ¬IsUnit b)
     (hab : a + b = 1) : ¬IsLocalRing R :=
   fun _ ↦ hb <| (isUnit_or_isUnit_of_add_one hab).resolve_left ha
 
+/-- For an index type `ι` with at least two elements and an indexed family of (semi)rings
+`R : ι → Type*`, the indexed product (semi)ring `Π i, R i` is not local. -/
 theorem not_isLocalRing_of_nontrivial_pi {ι : Type*} [Nontrivial ι] [DecidableEq ι] (R : ι → Type*)
     [∀ i, Semiring (R i)] [∀ i, Nontrivial (R i)] : ¬IsLocalRing (Π i, R i) :=
   let ⟨i₁, i₂, hi⟩ := exists_pair_ne ι
@@ -45,6 +48,7 @@ theorem not_isLocalRing_of_nontrivial_pi {ι : Type*} [Nontrivial ι] [Decidable
     fun h ↦ not_isUnit_zero (M₀ := R i₂) (by simpa [hi.symm] using h.map (Pi.evalRingHom R i₂))
   not_isLocalRing_def ha hb (by ext; dsimp; split <;> simp)
 
+/-- The product of two nontrivial (semi)rings is not local. -/
 theorem not_isLocalRing_of_prod_of_nontrivial (R₁ R₂ : Type*) [Semiring R₁] [Semiring R₂]
     [Nontrivial R₁] [Nontrivial R₂] : ¬IsLocalRing (R₁ × R₂) :=
   have ha : ¬IsUnit ((1, 0) : R₁ × R₂) :=
@@ -53,43 +57,19 @@ theorem not_isLocalRing_of_prod_of_nontrivial (R₁ R₂ : Type*) [Semiring R₁
     fun h ↦ not_isUnit_zero (M₀ := R₂) (by simpa using h.map (RingHom.fst R₁ R₂))
   not_isLocalRing_def ha hb (by simp)
 
-section CommSemiring
-
-variable {R : Type*} [CommSemiring R]
-
-/-- For a non-local, nontrivial, commutative (semi)ring, the maximal spectrum is non-trivial. -/
-theorem nontrivial_maximalSpectrum_of_not_isLocalRing [Nontrivial R]
-    (h : ¬IsLocalRing R) : Nontrivial (MaximalSpectrum R) :=
-  not_subsingleton_iff_nontrivial.mp fun _ ↦ h of_singleton_maximalSpectrum
-
-/-- If the maximal spectrum of a commutative (semi)ring `R` is nontrivial then `R` is not local. -/
-theorem not_isLocalRing_of_nontrivial_maximalSpectrum [Nontrivial (MaximalSpectrum R)] :
-    ¬IsLocalRing R := fun _ ↦ not_subsingleton_iff_nontrivial.mpr ‹_› inferInstance
-
-/-- A nontrivial commutative (semi)ring is not local if and only if it has a nontrivial
-maximal spectrum. -/
-theorem not_isLocalRing_iff_nontrivial_maximalSpectrum [Nontrivial R] :
-    ¬IsLocalRing R ↔ Nontrivial (MaximalSpectrum R) :=
-  ⟨nontrivial_maximalSpectrum_of_not_isLocalRing,
-    by apply not_isLocalRing_of_nontrivial_maximalSpectrum⟩
-
-/-- A non-local commutative (semi)ring has two distinct maximal ideals. -/
-theorem exist_maximal_ne_of_not_isLocalRing [Nontrivial R] (h : ¬IsLocalRing R) :
-    ∃ m₁ m₂ : Ideal R, m₁.IsMaximal ∧ m₂.IsMaximal ∧ m₁ ≠ m₂ :=
-  let ⟨⟨m₁, hm₁⟩, ⟨m₂, hm₂⟩, hm₁m₂⟩ := nontrivial_maximalSpectrum_of_not_isLocalRing h
-  ⟨m₁, m₂, ⟨hm₁, hm₂, by by_contra; apply hm₁m₂; congr⟩⟩
-
-/-- A commutative (semi)ring is not local if it has two distinct maximal ideals. -/
-theorem not_isLocalRing_of_exist_maximal_ne {m₁ m₂ : Ideal R}
-    [h₁ : m₁.IsMaximal] [h₂ : m₂.IsMaximal] (h : m₁ ≠ m₂) : ¬IsLocalRing R :=
-  fun _ ↦ h <| (eq_maximalIdeal h₁).trans (eq_maximalIdeal h₂).symm
-
-/-- A commutative (semi)ring is not local if and only if it has two distinct maximal ideals. -/
-theorem not_isLocalRing_iff_exist_maximal_ne [Nontrivial R] :
-    ¬IsLocalRing R ↔ ∃ m₁ m₂ : Ideal R, m₁.IsMaximal ∧ m₂.IsMaximal ∧ m₁ ≠ m₂ :=
-  ⟨exist_maximal_ne_of_not_isLocalRing, fun ⟨_, _, _, _, h⟩ ↦ not_isLocalRing_of_exist_maximal_ne h⟩
-
-end CommSemiring
+/-- Conditions equivalent to a commutative (semi)ring being non-local. -/
+theorem not_isLocalRing_tfae {R : Type*} [CommSemiring R] [Nontrivial R] :
+    List.TFAE [
+      ¬IsLocalRing R,
+      Nontrivial (MaximalSpectrum R),
+      ∃ m₁ m₂ : Ideal R, m₁.IsMaximal ∧ m₂.IsMaximal ∧ m₁ ≠ m₂] := by
+  tfae_have 1 → 2
+  | h => not_subsingleton_iff_nontrivial.mp fun _ ↦ h of_singleton_maximalSpectrum
+  tfae_have 2 → 3
+  | ⟨⟨m₁, hm₁⟩, ⟨m₂, hm₂⟩, h⟩ => ⟨m₁, m₂, ⟨hm₁, hm₂, fun _ ↦ h (by congr)⟩⟩
+  tfae_have 3 → 1
+  | ⟨m₁, m₂, ⟨hm₁, hm₂, h⟩⟩ => fun _ ↦ h <| (eq_maximalIdeal hm₁).trans (eq_maximalIdeal hm₂).symm
+  tfae_finish
 
 /-- There exists a surjective ring homomorphism from a non-local commutative ring onto a product
 of two fields. -/
@@ -98,7 +78,7 @@ theorem exists_surjective_of_not_isLocalRing.{u} {R : Type u} [CommRing R] [Nont
     ∃ (K₁ K₂ : Type u) (_ : Field K₁) (_ : Field K₂) (f : R →+* K₁ × K₂),
       Function.Surjective f := by
   /- get two different maximal ideals and project on the product of quotients -/
-  obtain ⟨m₁, m₂, _, _, hm₁m₂⟩ := exist_maximal_ne_of_not_isLocalRing h
+  obtain ⟨m₁, m₂, _, _, hm₁m₂⟩ := (not_isLocalRing_tfae.out 0 2).mp h
   let e := Ideal.quotientInfEquivQuotientProd m₁ m₂ <| Ideal.isCoprime_of_isMaximal hm₁m₂
   let f := e.toRingHom.comp <| Ideal.Quotient.mk (m₁ ⊓ m₂)
   use R ⧸ m₁, R ⧸ m₂, Ideal.Quotient.field m₁, Ideal.Quotient.field m₂, f

--- a/Mathlib/RingTheory/LocalRing/NonLocalRing.lean
+++ b/Mathlib/RingTheory/LocalRing/NonLocalRing.lean
@@ -12,7 +12,7 @@ import Mathlib.RingTheory.Spectrum.Maximal.Basic
 
 # Non-local rings
 
-This file we gather some results about non-local rings.
+This file gathers some results about non-local rings.
 
 ## Main results
 

--- a/Mathlib/RingTheory/LocalRing/NonLocalRing.lean
+++ b/Mathlib/RingTheory/LocalRing/NonLocalRing.lean
@@ -38,20 +38,19 @@ theorem not_isLocalRing_def {R : Type*} [Semiring R] {a b : R} (ha : ¬IsUnit a)
 
 theorem not_isLocalRing_of_nontrivial_pi {ι : Type*} [Nontrivial ι] [DecidableEq ι] (R : ι → Type*)
     [∀ i, Semiring (R i)] [∀ i, Nontrivial (R i)] : ¬IsLocalRing (Π i, R i) :=
-  let ⟨i₁, i₂, hi₁i₂⟩ := exists_pair_ne ι
+  let ⟨i₁, i₂, hi⟩ := exists_pair_ne ι
   have ha : ¬IsUnit (fun i ↦ if i = i₁ then 0 else 1 : Π i, R i) :=
-    fun h ↦ not_isUnit_zero (M₀ := R i₁) (by simpa using IsUnit.map (Pi.evalRingHom R i₁) h)
+    fun h ↦ not_isUnit_zero (M₀ := R i₁) (by simpa using h.map (Pi.evalRingHom R i₁))
   have hb : ¬IsUnit (fun i ↦ if i = i₁ then 1 else 0 : Π i, R i) :=
-    fun h ↦ not_isUnit_zero (M₀ := R i₂)
-      (by simpa [hi₁i₂.symm] using IsUnit.map (Pi.evalRingHom R i₂) h)
-  not_isLocalRing_def ha hb (by ext i; dsimp; split <;> simp)
+    fun h ↦ not_isUnit_zero (M₀ := R i₂) (by simpa [hi.symm] using h.map (Pi.evalRingHom R i₂))
+  not_isLocalRing_def ha hb (by ext; dsimp; split <;> simp)
 
 theorem not_isLocalRing_of_prod_of_nontrivial (R₁ R₂ : Type*) [Semiring R₁] [Semiring R₂]
     [Nontrivial R₁] [Nontrivial R₂] : ¬IsLocalRing (R₁ × R₂) :=
   have ha : ¬IsUnit ((1, 0) : R₁ × R₂) :=
-    fun h ↦ not_isUnit_zero (M₀ := R₁) (by simpa using IsUnit.map (RingHom.snd R₁ R₂) h)
+    fun h ↦ not_isUnit_zero (M₀ := R₁) (by simpa using h.map (RingHom.snd R₁ R₂))
   have hb : ¬IsUnit ((0, 1) : R₁ × R₂) :=
-    fun h ↦ not_isUnit_zero (M₀ := R₂) (by simpa using IsUnit.map (RingHom.fst R₁ R₂) h)
+    fun h ↦ not_isUnit_zero (M₀ := R₂) (by simpa using h.map (RingHom.fst R₁ R₂))
   not_isLocalRing_def ha hb (by simp)
 
 section CommSemiring

--- a/Mathlib/RingTheory/LocalRing/NonLocalRing.lean
+++ b/Mathlib/RingTheory/LocalRing/NonLocalRing.lean
@@ -21,9 +21,9 @@ This file gathers some results about non-local rings.
   `Π i, R i` is not local.
 - `not_isLocalRing_of_prod_of_nontrivial`: the product of two nontrivial (semi)rings is not
   local.
-- `not_isLocalRing_tfae`: the following are equivalent for a commutative (semi)ring `R`:
+- `not_isLocalRing_tfae`: the following conditions are equivalent for a commutative (semi)ring `R`:
     * `R` is not local,
-    * `R` has nontrivial maximal spectrum,
+    * the maximal spectrum of `R` is nontrivial,
     * `R` has two distinct maximal ideals.
 - `exists_surjective_of_not_isLocalRing`: there exists a surjective ring homomorphism from
   a non-local commutative ring onto a product of two fields.
@@ -57,7 +57,11 @@ theorem not_isLocalRing_of_prod_of_nontrivial (R₁ R₂ : Type*) [Semiring R₁
     fun h ↦ not_isUnit_zero (M₀ := R₂) (by simpa using h.map (RingHom.fst R₁ R₂))
   not_isLocalRing_def ha hb (by simp)
 
-/-- Conditions equivalent to a commutative (semi)ring being non-local. -/
+/-- The following conditions are equivalent for a commutative (semi)ring `R`:
+    * `R` is not local,
+    * the maximal spectrum of `R` is nontrivial,
+    * `R` has two distinct maximal ideals.
+-/
 theorem not_isLocalRing_tfae {R : Type*} [CommSemiring R] [Nontrivial R] :
     List.TFAE [
       ¬IsLocalRing R,

--- a/Mathlib/RingTheory/LocalRing/NonLocalRing.lean
+++ b/Mathlib/RingTheory/LocalRing/NonLocalRing.lean
@@ -37,27 +37,22 @@ theorem not_isLocalRing_def {R : Type*} [Semiring R] {a b : R} (ha : ¬IsUnit a)
   fun _ ↦ hb <| (isUnit_or_isUnit_of_add_one hab).resolve_left ha
 
 theorem not_isLocalRing_of_nontrivial_pi {ι : Type*} [Nontrivial ι] [DecidableEq ι] (R : ι → Type*)
-    [∀ i, Semiring (R i)] [∀ i, Nontrivial (R i)] : ¬IsLocalRing (Π i, R i) := by
-  obtain ⟨i₁, i₂, hi₁i₂⟩ := exists_pair_ne ι
-  let a : Π i, R i := fun i ↦ if i = i₁ then 0 else 1
-  let b : Π i, R i := fun i ↦ if i = i₁ then 1 else 0
-  have ha0 : Pi.evalRingHom R i₁ a = 0 := by simp [a]
-  have hb0 : Pi.evalRingHom R i₂ b = 0 := by simp [b]; exact hi₁i₂.symm
-  have ha : ¬IsUnit a := by
-    exact fun h ↦ not_isUnit_zero (ha0 ▸ IsUnit.map (Pi.evalRingHom R i₁) h)
-  have hb : ¬IsUnit b := by
-    exact fun h ↦ not_isUnit_zero (hb0 ▸ IsUnit.map (Pi.evalRingHom R i₂) h)
-  exact not_isLocalRing_def ha hb (by ext i; simp [a, b]; split <;> simp)
+    [∀ i, Semiring (R i)] [∀ i, Nontrivial (R i)] : ¬IsLocalRing (Π i, R i) :=
+  let ⟨i₁, i₂, hi₁i₂⟩ := exists_pair_ne ι
+  have ha : ¬IsUnit (fun i ↦ if i = i₁ then 0 else 1 : Π i, R i) :=
+    fun h ↦ not_isUnit_zero (M₀ := R i₁) (by simpa using IsUnit.map (Pi.evalRingHom R i₁) h)
+  have hb : ¬IsUnit (fun i ↦ if i = i₁ then 1 else 0 : Π i, R i) :=
+    fun h ↦ not_isUnit_zero (M₀ := R i₂)
+      (by simpa [hi₁i₂.symm] using IsUnit.map (Pi.evalRingHom R i₂) h)
+  not_isLocalRing_def ha hb (by ext i; dsimp; split <;> simp)
 
 theorem not_isLocalRing_of_prod_of_nontrivial (R₁ R₂ : Type*) [Semiring R₁] [Semiring R₂]
-    [Nontrivial R₁] [Nontrivial R₂] : ¬IsLocalRing (R₁ × R₂) := by
-  let a : R₁ × R₂ := (1, 0)
-  let b : R₁ × R₂ := (0, 1)
-  have ha0 : RingHom.snd R₁ R₂ a = 0 := by simp [a]
-  have hb0 : RingHom.fst R₁ R₂ b = 0 := by simp [b]
-  have ha : ¬IsUnit a := fun h ↦ not_isUnit_zero (ha0 ▸ IsUnit.map (RingHom.snd R₁ R₂) h)
-  have hb : ¬IsUnit b := fun h ↦ not_isUnit_zero (hb0 ▸ IsUnit.map (RingHom.fst R₁ R₂) h)
-  exact not_isLocalRing_def ha hb (by simp [a, b])
+    [Nontrivial R₁] [Nontrivial R₂] : ¬IsLocalRing (R₁ × R₂) :=
+  have ha : ¬IsUnit ((1, 0) : R₁ × R₂) :=
+    fun h ↦ not_isUnit_zero (M₀ := R₁) (by simpa using IsUnit.map (RingHom.snd R₁ R₂) h)
+  have hb : ¬IsUnit ((0, 1) : R₁ × R₂) :=
+    fun h ↦ not_isUnit_zero (M₀ := R₂) (by simpa using IsUnit.map (RingHom.fst R₁ R₂) h)
+  not_isLocalRing_def ha hb (by simp)
 
 section CommSemiring
 

--- a/Mathlib/RingTheory/LocalRing/NonLocalRing.lean
+++ b/Mathlib/RingTheory/LocalRing/NonLocalRing.lean
@@ -16,7 +16,7 @@ This file gathers some results about non-local rings.
 
 ## Main results
 
-- `not_isLocalRing_of_nontrivial_pi`: for an index type `ι` with least two elements and
+- `not_isLocalRing_of_nontrivial_pi`: for an index type `ι` with at least two elements and
   an indexed family of (semi)rings `R : ι → Type*`, the indexed product (semi)ring
   `Π i, R i` is not local.
 - `not_isLocalRing_of_prod_of_nontrivial`: the product of two nontrivial (semi)rings is not

--- a/Mathlib/RingTheory/LocalRing/NonLocalRing.lean
+++ b/Mathlib/RingTheory/LocalRing/NonLocalRing.lean
@@ -1,0 +1,113 @@
+/-
+Copyright (c) 2025 Michal Staromiejski. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Michal Staromiejski
+-/
+import Mathlib.Algebra.Ring.Pi
+import Mathlib.Algebra.Ring.Prod
+import Mathlib.RingTheory.LocalRing.MaximalIdeal.Basic
+import Mathlib.RingTheory.Spectrum.Maximal.Basic
+
+/-!
+
+# Non-local rings
+
+This file we gather some results about non-local rings.
+
+## Main results
+
+- `not_isLocalRing_of_nontrivial_pi`: for an index type `ι` with least two elements and
+  an indexed family of (semi)rings `R : ι → Type*`, the indexed product (semi)ring
+  `Π i, R i` is not local.
+- `not_isLocalRing_of_prod_of_nontrivial`: the product of two nontrivial (semi)rings is not
+  local.
+- `not_isLocalRing_iff_nontrivial_maximalSpectrum`: a commutative (semi)ring is not local iff
+  it has nontrivial maximal spectrum.
+- `not_isLocalRing_iff_exist_maximal_ne`: a commutative (semi)ring is not local iff it has
+  two distinct maximal ideals.
+- `exists_surjective_of_not_isLocalRing`: there exists a surjective ring homomorphism from
+  a non-local commutative ring onto a product of two fields.
+
+-/
+
+namespace IsLocalRing
+
+theorem not_isLocalRing_def {R : Type*} [Semiring R] {a b : R} (ha : ¬IsUnit a) (hb : ¬IsUnit b)
+    (hab : a + b = 1) : ¬IsLocalRing R :=
+  fun _ ↦ hb <| (isUnit_or_isUnit_of_add_one hab).resolve_left ha
+
+theorem not_isLocalRing_of_nontrivial_pi {ι : Type*} [Nontrivial ι] [DecidableEq ι] (R : ι → Type*)
+    [∀ i, Semiring (R i)] [∀ i, Nontrivial (R i)] : ¬IsLocalRing (Π i, R i) := by
+  obtain ⟨i₁, i₂, hi₁i₂⟩ := exists_pair_ne ι
+  let a : Π i, R i := fun i ↦ if i = i₁ then 0 else 1
+  let b : Π i, R i := fun i ↦ if i = i₁ then 1 else 0
+  have ha0 : Pi.evalRingHom R i₁ a = 0 := by simp [a]
+  have hb0 : Pi.evalRingHom R i₂ b = 0 := by simp [b]; exact hi₁i₂.symm
+  have ha : ¬IsUnit a := by
+    exact fun h ↦ not_isUnit_zero (ha0 ▸ IsUnit.map (Pi.evalRingHom R i₁) h)
+  have hb : ¬IsUnit b := by
+    exact fun h ↦ not_isUnit_zero (hb0 ▸ IsUnit.map (Pi.evalRingHom R i₂) h)
+  exact not_isLocalRing_def ha hb (by ext i; simp [a, b]; split <;> simp)
+
+theorem not_isLocalRing_of_prod_of_nontrivial (R₁ R₂ : Type*) [Semiring R₁] [Semiring R₂]
+    [Nontrivial R₁] [Nontrivial R₂] : ¬IsLocalRing (R₁ × R₂) := by
+  let a : R₁ × R₂ := (1, 0)
+  let b : R₁ × R₂ := (0, 1)
+  have ha0 : RingHom.snd R₁ R₂ a = 0 := by simp [a]
+  have hb0 : RingHom.fst R₁ R₂ b = 0 := by simp [b]
+  have ha : ¬IsUnit a := fun h ↦ not_isUnit_zero (ha0 ▸ IsUnit.map (RingHom.snd R₁ R₂) h)
+  have hb : ¬IsUnit b := fun h ↦ not_isUnit_zero (hb0 ▸ IsUnit.map (RingHom.fst R₁ R₂) h)
+  exact not_isLocalRing_def ha hb (by simp [a, b])
+
+section CommSemiring
+
+variable {R : Type*} [CommSemiring R]
+
+/-- For a non-local, nontrivial, commutative (semi)ring, the maximal spectrum is non-trivial. -/
+theorem nontrivial_maximalSpectrum_of_not_isLocalRing [Nontrivial R]
+    (h : ¬IsLocalRing R) : Nontrivial (MaximalSpectrum R) :=
+  not_subsingleton_iff_nontrivial.mp fun _ ↦ h of_singleton_maximalSpectrum
+
+/-- If the maximal spectrum of a commutative (semi)ring `R` is nontrivial then `R` is not local. -/
+theorem not_isLocalRing_of_nontrivial_maximalSpectrum [Nontrivial (MaximalSpectrum R)] :
+    ¬IsLocalRing R := fun _ ↦ not_subsingleton_iff_nontrivial.mpr ‹_› inferInstance
+
+/-- A nontrivial commutative (semi)ring is not local if and only if it has a nontrivial
+maximal spectrum. -/
+theorem not_isLocalRing_iff_nontrivial_maximalSpectrum [Nontrivial R] :
+    ¬IsLocalRing R ↔ Nontrivial (MaximalSpectrum R) :=
+  ⟨nontrivial_maximalSpectrum_of_not_isLocalRing,
+    by apply not_isLocalRing_of_nontrivial_maximalSpectrum⟩
+
+/-- A non-local commutative (semi)ring has two distinct maximal ideals. -/
+theorem exist_maximal_ne_of_not_isLocalRing [Nontrivial R] (h : ¬IsLocalRing R) :
+    ∃ m₁ m₂ : Ideal R, m₁.IsMaximal ∧ m₂.IsMaximal ∧ m₁ ≠ m₂ :=
+  let ⟨⟨m₁, hm₁⟩, ⟨m₂, hm₂⟩, hm₁m₂⟩ := nontrivial_maximalSpectrum_of_not_isLocalRing h
+  ⟨m₁, m₂, ⟨hm₁, hm₂, by by_contra; apply hm₁m₂; congr⟩⟩
+
+/-- A commutative (semi)ring is not local if it has two distinct maximal ideals. -/
+theorem not_isLocalRing_of_exist_maximal_ne {m₁ m₂ : Ideal R}
+    [h₁ : m₁.IsMaximal] [h₂ : m₂.IsMaximal] (h : m₁ ≠ m₂) : ¬IsLocalRing R :=
+  fun _ ↦ h <| (eq_maximalIdeal h₁).trans (eq_maximalIdeal h₂).symm
+
+/-- A commutative (semi)ring is not local if and only if it has two distinct maximal ideals. -/
+theorem not_isLocalRing_iff_exist_maximal_ne [Nontrivial R] :
+    ¬IsLocalRing R ↔ ∃ m₁ m₂ : Ideal R, m₁.IsMaximal ∧ m₂.IsMaximal ∧ m₁ ≠ m₂ :=
+  ⟨exist_maximal_ne_of_not_isLocalRing, fun ⟨_, _, _, _, h⟩ ↦ not_isLocalRing_of_exist_maximal_ne h⟩
+
+end CommSemiring
+
+/-- There exists a surjective ring homomorphism from a non-local commutative ring onto a product
+of two fields. -/
+theorem exists_surjective_of_not_isLocalRing.{u} {R : Type u} [CommRing R] [Nontrivial R]
+    (h : ¬IsLocalRing R) :
+    ∃ (K₁ K₂ : Type u) (_ : Field K₁) (_ : Field K₂) (f : R →+* K₁ × K₂),
+      Function.Surjective f := by
+  /- get two different maximal ideals and project on the product of quotients -/
+  obtain ⟨m₁, m₂, _, _, hm₁m₂⟩ := exist_maximal_ne_of_not_isLocalRing h
+  let e := Ideal.quotientInfEquivQuotientProd m₁ m₂ <| Ideal.isCoprime_of_isMaximal hm₁m₂
+  let f := e.toRingHom.comp <| Ideal.Quotient.mk (m₁ ⊓ m₂)
+  use R ⧸ m₁, R ⧸ m₂, Ideal.Quotient.field m₁, Ideal.Quotient.field m₂, f
+  apply Function.Surjective.comp e.surjective Ideal.Quotient.mk_surjective
+
+end IsLocalRing


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
