### PR TITLE
[Merged by Bors] - chore(Data/Finsupp/MonomialOrder/DegLex): dedup instance

### DIFF
--- a/Mathlib/Data/Finsupp/MonomialOrder/DegLex.lean
+++ b/Mathlib/Data/Finsupp/MonomialOrder/DegLex.lean
@@ -147,12 +147,6 @@ instance : IsOrderedCancelAddMonoid (DegLex (α →₀ ℕ)) where
     rw [le_iff] at h ⊢
     simpa [ofDegLex_add, degree_add] using h
 
-/-- The linear order on `Finsupp`s obtained by the homogeneous lexicographic ordering. -/
-noncomputable instance : LinearOrder (DegLex (α →₀ ℕ)) where
-  le_total := instLinearOrderDegLexNat.le_total
-  decidableLE := instLinearOrderDegLexNat.decidableLE
-  compare_eq_compareOfLessAndEq := instLinearOrderDegLexNat.compare_eq_compareOfLessAndEq
-
 theorem single_strictAnti : StrictAnti (fun (a : α) ↦ toDegLex (single a 1)) := by
   intro _ _ h
   simp only [lt_iff, ofDegLex_toDegLex, degree_single, lt_self_iff_false, Lex.single_lt_iff, h,


### PR DESCRIPTION
Split from #23976

The remaining instance is at https://github.com/leanprover-community/mathlib4/blob/03e9f15f2acafae1d9d3b7e0674ba87ae3cd499c/Mathlib/Data/Finsupp/MonomialOrder/DegLex.lean#L125-L129

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
