### PR TITLE
[Merged by Bors] - style(Topology/Order/MonotoneConvergence): Don't use `CoeTC.coe`

### DIFF
--- a/Mathlib/Topology/Order/MonotoneConvergence.lean
+++ b/Mathlib/Topology/Order/MonotoneConvergence.lean
@@ -33,24 +33,24 @@ variable {α β : Type*}
 /-- We say that `α` is a `SupConvergenceClass` if the following holds. Let `f : ι → α` be a
 monotone function, let `a : α` be a least upper bound of `Set.range f`. Then `f x` tends to `𝓝 a`
  as `x → ∞` (formally, at the filter `Filter.atTop`). We require this for `ι = (s : Set α)`,
-`f = CoeTC.coe` in the definition, then prove it for any `f` in `tendsto_atTop_isLUB`.
+`f = (↑)` in the definition, then prove it for any `f` in `tendsto_atTop_isLUB`.
 
 This property holds for linear orders with order topology as well as their products. -/
 class SupConvergenceClass (α : Type*) [Preorder α] [TopologicalSpace α] : Prop where
   /-- proof that a monotone function tends to `𝓝 a` as `x → ∞` -/
   tendsto_coe_atTop_isLUB :
-    ∀ (a : α) (s : Set α), IsLUB s a → Tendsto (CoeTC.coe : s → α) atTop (𝓝 a)
+    ∀ (a : α) (s : Set α), IsLUB s a → Tendsto ((↑) : s → α) atTop (𝓝 a)
 
 /-- We say that `α` is an `InfConvergenceClass` if the following holds. Let `f : ι → α` be a
 monotone function, let `a : α` be a greatest lower bound of `Set.range f`. Then `f x` tends to `𝓝 a`
 as `x → -∞` (formally, at the filter `Filter.atBot`). We require this for `ι = (s : Set α)`,
-`f = CoeTC.coe` in the definition, then prove it for any `f` in `tendsto_atBot_isGLB`.
+`f = (↑)` in the definition, then prove it for any `f` in `tendsto_atBot_isGLB`.
 
 This property holds for linear orders with order topology as well as their products. -/
 class InfConvergenceClass (α : Type*) [Preorder α] [TopologicalSpace α] : Prop where
   /-- proof that a monotone function tends to `𝓝 a` as `x → -∞` -/
   tendsto_coe_atBot_isGLB :
-    ∀ (a : α) (s : Set α), IsGLB s a → Tendsto (CoeTC.coe : s → α) atBot (𝓝 a)
+    ∀ (a : α) (s : Set α), IsGLB s a → Tendsto ((↑) : s → α) atBot (𝓝 a)
 
 instance OrderDual.supConvergenceClass [Preorder α] [TopologicalSpace α] [InfConvergenceClass α] :
     SupConvergenceClass αᵒᵈ :=


### PR DESCRIPTION
Replaces `CoeTC.coe` by `(↑)` in `Topology/Order/MonotoneConvergence`

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
