### PR TITLE
[Merged by Bors] - feat(Algebra/Algebra/Subalgebra): `Algebra.adjoin_singleton_le`

### DIFF
--- a/Mathlib/Algebra/Algebra/Subalgebra/Lattice.lean
+++ b/Mathlib/Algebra/Algebra/Subalgebra/Lattice.lean
@@ -426,6 +426,9 @@ theorem subset_adjoin : s ⊆ adjoin R s :=
 theorem adjoin_le {S : Subalgebra R A} (H : s ⊆ S) : adjoin R s ≤ S :=
   Algebra.gc.l_le H
 
+theorem adjoin_singleton_le {S : Subalgebra R A} {a : A} (H : a ∈ S) : adjoin R {a} ≤ S :=
+  adjoin_le (Set.singleton_subset_iff.mpr H)
+
 theorem adjoin_eq_sInf : adjoin R s = sInf { p : Subalgebra R A | s ⊆ p } :=
   le_antisymm (le_sInf fun _ h => adjoin_le h) (sInf_le subset_adjoin)
 
@@ -530,7 +533,7 @@ theorem adjoin_univ : adjoin R (Set.univ : Set A) = ⊤ := Algebra.gi.l_top
 variable {R} in
 @[simp]
 theorem adjoin_singleton_algebraMap (x : R) : adjoin R {algebraMap R A x} = ⊥ :=
-  bot_unique <| adjoin_le <| Set.singleton_subset_iff.mpr <| Subalgebra.algebraMap_mem _ _
+  bot_unique <| adjoin_singleton_le <| Subalgebra.algebraMap_mem _ _
 
 @[simp]
 theorem adjoin_singleton_natCast (n : ℕ) : adjoin R {(n : A)} = ⊥ := by


### PR DESCRIPTION
Special case of `Algebra.adjoin_le` for a singleton.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
