### PR TITLE
feat(Data/Finsupp/Pointwise): generalise pointwise scalar multiplication of finsupps

### DIFF
--- a/Mathlib/Data/Finsupp/Pointwise.lean
+++ b/Mathlib/Data/Finsupp/Pointwise.lean
@@ -93,8 +93,8 @@ instance [NonUnitalCommRing β] : NonUnitalCommRing (α →₀ β) :=
     (fun _ _ ↦ rfl) fun _ _ ↦ rfl
 
 -- TODO(Paul-Lez): add a `DFinsupp` version of this.
-instance pointwiseScalar {M : Type*} [Zero M] [SMulZeroClass β M] [Semiring β] :
-    SMul (α → β) (α →₀ M) where
+--Note: this creates an instance diamond with `SMul (α → β) (α →₀ (α → β))`
+instance pointwiseScalar {M : Type*} [Zero M] [SMulZeroClass β M] : SMul (α → β) (α →₀ M) where
   smul f g :=
     Finsupp.ofSupportFinite (fun a ↦ f a • g a) (by
       apply Set.Finite.subset g.finite_support

--- a/Mathlib/Data/Finsupp/Pointwise.lean
+++ b/Mathlib/Data/Finsupp/Pointwise.lean
@@ -93,8 +93,9 @@ instance [NonUnitalCommRing β] : NonUnitalCommRing (α →₀ β) :=
     (fun _ _ ↦ rfl) fun _ _ ↦ rfl
 
 -- TODO(Paul-Lez): add a `DFinsupp` version of this.
---Note: this creates an instance diamond with `SMul (α → β) (α →₀ (α → β))`
-instance pointwiseScalar {M : Type*} [Zero M] [SMulZeroClass β M] : SMul (α → β) (α →₀ M) where
+-- Note: this creates an instance diamond with `SMul (α → β) (α →₀ (α → β))`, so this is an
+-- abbrev rather than an instance.
+abbrev pointwiseScalar {M : Type*} [Zero M] [SMulZeroClass β M] : SMul (α → β) (α →₀ M) where
   smul f g :=
     Finsupp.ofSupportFinite (fun a ↦ f a • g a) (by
       apply Set.Finite.subset g.finite_support
@@ -103,6 +104,8 @@ instance pointwiseScalar {M : Type*} [Zero M] [SMulZeroClass β M] : SMul (α �
       intro x hx h
       apply hx
       rw [h, smul_zero])
+
+instance pointwiseScalarSemiring [Semiring β] : SMul (α → β) (α →₀ β) := pointwiseScalar
 
 @[simp]
 theorem coe_pointwise_smul [Semiring β] (f : α → β) (g : α →₀ β) : ⇑(f • g) = f • ⇑g :=

--- a/Mathlib/Data/Finsupp/Pointwise.lean
+++ b/Mathlib/Data/Finsupp/Pointwise.lean
@@ -95,6 +95,7 @@ instance [NonUnitalCommRing β] : NonUnitalCommRing (α →₀ β) :=
 -- TODO(Paul-Lez): add a `DFinsupp` version of this.
 -- Note: this creates an instance diamond with `SMul (α → β) (α →₀ (α → β))`, so this is an
 -- abbrev rather than an instance.
+/-- The pointwise scalar multiplication of a function `α → β` on a finsupp `α →₀ β`. -/
 abbrev pointwiseScalar {M : Type*} [Zero M] [SMulZeroClass β M] : SMul (α → β) (α →₀ M) where
   smul f g :=
     Finsupp.ofSupportFinite (fun a ↦ f a • g a) (by

--- a/Mathlib/Data/Finsupp/Pointwise.lean
+++ b/Mathlib/Data/Finsupp/Pointwise.lean
@@ -92,9 +92,7 @@ instance [NonUnitalCommRing β] : NonUnitalCommRing (α →₀ β) :=
   DFunLike.coe_injective.nonUnitalCommRing _ coe_zero coe_add coe_mul coe_neg coe_sub
     (fun _ _ ↦ rfl) fun _ _ ↦ rfl
 
--- TODO can this be generalized in the direction of `Pi.smul'`
--- (i.e. dependent functions and finsupps)
--- TODO in theory this could be generalised, we only really need `smul_zero` for the definition
+-- TODO(Paul-Lez): add a `DFinsupp` version of this.
 instance pointwiseScalar {M : Type*} [Zero M] [SMulZeroClass β M] [Semiring β] :
     SMul (α → β) (α →₀ M) where
   smul f g :=

--- a/Mathlib/Data/Finsupp/Pointwise.lean
+++ b/Mathlib/Data/Finsupp/Pointwise.lean
@@ -95,7 +95,8 @@ instance [NonUnitalCommRing β] : NonUnitalCommRing (α →₀ β) :=
 -- TODO can this be generalized in the direction of `Pi.smul'`
 -- (i.e. dependent functions and finsupps)
 -- TODO in theory this could be generalised, we only really need `smul_zero` for the definition
-instance pointwiseScalar [Semiring β] : SMul (α → β) (α →₀ β) where
+instance pointwiseScalar {M : Type*} [Zero M] [SMulZeroClass β M] [Semiring β] :
+    SMul (α → β) (α →₀ M) where
   smul f g :=
     Finsupp.ofSupportFinite (fun a ↦ f a • g a) (by
       apply Set.Finite.subset g.finite_support


### PR DESCRIPTION
As pointed out by @eric-wieser, this creates an instance diamond with `SMul (α → β) (α →₀ (α → β))`

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
