### PR TITLE
[Merged by Bors] - feat(Topology): Priestley spaces are totally separated

### DIFF
--- a/Mathlib/Topology/Order/Priestley.lean
+++ b/Mathlib/Topology/Order/Priestley.lean
@@ -72,8 +72,4 @@ instance (priority := 100) PriestleySpace.toTotallySeparatedSpace : TotallySepar
       ⟨U, Uᶜ, hU.isOpen, hU.compl.isOpen, hx, hy,
         union_compl_self U ▸ subset_rfl, disjoint_compl_right⟩
 
--- See note [lower instance priority]
-instance (priority := 100) PriestleySpace.toT2Space : T2Space α :=
-  inferInstance
-
 end PartialOrder

--- a/Mathlib/Topology/Order/Priestley.lean
+++ b/Mathlib/Topology/Order/Priestley.lean
@@ -3,7 +3,8 @@ Copyright (c) 2022 Yaël Dillies. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies
 -/
-import Mathlib.Topology.Connected.Separation
+import Mathlib.Order.UpperLower.Basic
+import Mathlib.Topology.Connected.TotallyDisconnected
 
 /-!
 # Priestley spaces

--- a/Mathlib/Topology/Order/Priestley.lean
+++ b/Mathlib/Topology/Order/Priestley.lean
@@ -3,8 +3,7 @@ Copyright (c) 2022 Yaël Dillies. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies
 -/
-import Mathlib.Topology.Separation.Hausdorff
-import Mathlib.Topology.Clopen
+import Mathlib.Topology.Connected.Separation
 
 /-!
 # Priestley spaces
@@ -65,6 +64,13 @@ theorem exists_isClopen_upper_or_lower_of_ne (h : x ≠ y) :
   · exact (exists_isClopen_upper_of_not_le h).imp fun _ ↦ And.imp_right <| And.imp_left Or.inl
   · obtain ⟨U, hU, hU', hy, hx⟩ := exists_isClopen_lower_of_not_le h
     exact ⟨U, hU, Or.inr hU', hx, hy⟩
+
+-- See note [lower instance priority]
+instance (priority := 100) PriestleySpace.toTotallySeparatedSpace : TotallySeparatedSpace α where
+  isTotallySeparated_univ _ _ _ _ h :=
+    (exists_isClopen_upper_or_lower_of_ne h).elim fun U ⟨hU, _, hx, hy⟩ =>
+      ⟨U, Uᶜ, hU.isOpen, hU.compl.isOpen, hx, hy,
+        union_compl_self U ▸ subset_rfl, disjoint_compl_right⟩
 
 -- See note [lower instance priority]
 instance (priority := 100) PriestleySpace.toT2Space : T2Space α :=

--- a/Mathlib/Topology/Order/Priestley.lean
+++ b/Mathlib/Topology/Order/Priestley.lean
@@ -74,8 +74,6 @@ instance (priority := 100) PriestleySpace.toTotallySeparatedSpace : TotallySepar
 
 -- See note [lower instance priority]
 instance (priority := 100) PriestleySpace.toT2Space : T2Space α :=
-  ⟨fun _ _ h ↦
-    let ⟨U, hU, _, hx, hy⟩ := exists_isClopen_upper_or_lower_of_ne h
-    ⟨U, Uᶜ, hU.isOpen, hU.compl.isOpen, hx, hy, disjoint_compl_right⟩⟩
+  inferInstance
 
 end PartialOrder


### PR DESCRIPTION
This generalizes `PriestleySpace.toT2Space`

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
