### PR TITLE
[Merged by Bors] - chore(Finsupp/Interval): remove `open scoped Classical`

### DIFF
--- a/Mathlib/Data/Finsupp/Interval.lean
+++ b/Mathlib/Data/Finsupp/Interval.lean
@@ -51,9 +51,9 @@ end RangeSingleton
 
 section RangeIcc
 
-variable [Zero α] [PartialOrder α] [LocallyFiniteOrder α] {f g : ι →₀ α} {i : ι} {a : α}
+variable [Zero α] [PartialOrder α] [LocallyFiniteOrder α] [DecidableEq ι]
+variable {f g : ι →₀ α} {i : ι} {a : α}
 
-open scoped Classical in
 /-- Pointwise `Finset.Icc` bundled as a `Finsupp`. -/
 @[simps toFun]
 def rangeIcc (f g : ι →₀ α) : ι →₀ Finset α where
@@ -65,7 +65,6 @@ def rangeIcc (f g : ι →₀ α) : ι →₀ Finset α where
 
 lemma coe_rangeIcc (f g : ι →₀ α) : rangeIcc f g i = Icc (f i) (g i) := rfl
 
-open scoped Classical in
 @[simp]
 theorem rangeIcc_support (f g : ι →₀ α) :
     (rangeIcc f g).support = f.support ∪ g.support := rfl
@@ -76,9 +75,9 @@ end RangeIcc
 
 section PartialOrder
 
-variable [PartialOrder α] [Zero α] [LocallyFiniteOrder α] (f g : ι →₀ α)
+variable [PartialOrder α] [Zero α] [LocallyFiniteOrder α] [DecidableEq ι] [DecidableEq α]
+variable (f g : ι →₀ α)
 
-open scoped Classical in
 instance instLocallyFiniteOrder : LocallyFiniteOrder (ι →₀ α) :=
   LocallyFiniteOrder.ofIcc (ι →₀ α) (fun f g => (f.support ∪ g.support).finsupp <| f.rangeIcc g)
     fun f g x => by
@@ -87,22 +86,17 @@ instance instLocallyFiniteOrder : LocallyFiniteOrder (ι →₀ α) :=
       simp_rw [mem_rangeIcc_apply_iff]
       exact forall_and
 
-open scoped Classical in
 theorem Icc_eq : Icc f g = (f.support ∪ g.support).finsupp (f.rangeIcc g) := rfl
 
-open scoped Classical in
 theorem card_Icc : #(Icc f g) = ∏ i ∈ f.support ∪ g.support, #(Icc (f i) (g i)):= by
   simp_rw [Icc_eq, card_finsupp, coe_rangeIcc]
 
-open scoped Classical in
 theorem card_Ico : #(Ico f g) = ∏ i ∈ f.support ∪ g.support, #(Icc (f i) (g i)) - 1 := by
   rw [card_Ico_eq_card_Icc_sub_one, card_Icc]
 
-open scoped Classical in
 theorem card_Ioc : #(Ioc f g) = ∏ i ∈ f.support ∪ g.support, #(Icc (f i) (g i)) - 1 := by
   rw [card_Ioc_eq_card_Icc_sub_one, card_Icc]
 
-open scoped Classical in
 theorem card_Ioo : #(Ioo f g) = ∏ i ∈ f.support ∪ g.support, #(Icc (f i) (g i)) - 2 := by
   rw [card_Ioo_eq_card_Icc_sub_two, card_Icc]
 
@@ -121,7 +115,7 @@ end Lattice
 section CanonicallyOrdered
 
 variable [AddCommMonoid α] [PartialOrder α] [CanonicallyOrderedAdd α] [LocallyFiniteOrder α]
-variable (f : ι →₀ α)
+variable [DecidableEq ι] [DecidableEq α] (f : ι →₀ α)
 
 theorem card_Iic : #(Iic f) = ∏ i ∈ f.support, #(Iic (f i)) := by
   classical simp_rw [Iic_eq_Icc, card_Icc, Finsupp.bot_eq_zero, support_zero, empty_union,

--- a/Mathlib/RingTheory/MvPowerSeries/Evaluation.lean
+++ b/Mathlib/RingTheory/MvPowerSeries/Evaluation.lean
@@ -117,6 +117,7 @@ theorem mem_hasEvalIdeal_iff {a : σ → S} :
 /-- The inclusion of polynomials into power series has dense image -/
 theorem _root_.MvPolynomial.toMvPowerSeries_denseRange :
     DenseRange (toMvPowerSeries (R := R) (σ := σ)) := fun f => by
+  classical
   have : Tendsto (fun d ↦ (trunc' R d f : MvPowerSeries σ R)) atTop (𝓝 f) := by
     rw [tendsto_iff_coeff_tendsto]
     refine fun d ↦ tendsto_atTop_of_eventually_const fun n (hdn : d ≤ n) ↦ ?_
@@ -160,6 +161,7 @@ theorem _root_.MvPolynomial.toMvPowerSeries_uniformContinuous
     [IsUniformAddGroup R] [IsUniformAddGroup S] [IsLinearTopology S S]
     (hφ : Continuous φ) (ha : HasEval a) :
     UniformContinuous (MvPolynomial.eval₂Hom φ a) := by
+  classical
   apply uniformContinuous_of_continuousAt_zero
   rw [ContinuousAt, map_zero, IsLinearTopology.hasBasis_ideal.tendsto_right_iff]
   intro I hI

--- a/Mathlib/RingTheory/MvPowerSeries/LinearTopology.lean
+++ b/Mathlib/RingTheory/MvPowerSeries/LinearTopology.lean
@@ -114,6 +114,7 @@ lemma hasBasis_nhds_zero [IsLinearTopology R R] [IsLinearTopology Rᵐᵒᵖ R] 
     (𝓝 0 : Filter (MvPowerSeries σ R)).HasBasis
       (fun Id : TwoSidedIdeal R × (σ →₀ ℕ) ↦ (Id.1 : Set R) ∈ 𝓝 0)
       (fun Id ↦ basis _ _ Id) := by
+  classical
   rw [nhds_pi]
   refine IsLinearTopology.hasBasis_twoSidedIdeal.pi_self.to_hasBasis ?_ ?_
   · intro ⟨D, I⟩ ⟨hD, hI⟩

--- a/Mathlib/RingTheory/MvPowerSeries/Trunc.lean
+++ b/Mathlib/RingTheory/MvPowerSeries/Trunc.lean
@@ -62,7 +62,7 @@ variable {σ R S : Type*}
 
 section TruncLT
 
-variable [CommSemiring R] (n : σ →₀ ℕ)
+variable [DecidableEq σ] [CommSemiring R] (n : σ →₀ ℕ)
 
 /-- Auxiliary definition for the truncation function. -/
 def truncFun (φ : MvPowerSeries σ R) : MvPolynomial σ R :=
@@ -136,7 +136,7 @@ end TruncLT
 
 section TruncLE
 
-variable [CommSemiring R] (n : σ →₀ ℕ)
+variable [DecidableEq σ] [CommSemiring R] (n : σ →₀ ℕ)
 
 /-- Auxiliary definition for the truncation function. -/
 def truncFun' (φ : MvPowerSeries σ R) : MvPolynomial σ R :=


### PR DESCRIPTION
Removing it from the definitions is easier than adding it to all the theorems and adding `convert`s as appropriate. This has a knock-on effect on `MvPowerSeries`, but "you must be able to tell which variable is which" is hardly demanding\!


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
