### PR TITLE
chore(MeasureTheory): use `0` instead of `const _ 0`

### DIFF
--- a/Mathlib/MeasureTheory/Function/SimpleFunc.lean
+++ b/Mathlib/MeasureTheory/Function/SimpleFunc.lean
@@ -136,6 +136,17 @@ theorem range_const (α) [MeasurableSpace α] [Nonempty α] (b : β) : (const α
 theorem range_const_subset (α) [MeasurableSpace α] (b : β) : (const α b).range ⊆ {b} :=
   Finset.coe_subset.1 <| by simp
 
+@[to_additive]
+instance instOne [One β] : One (α →ₛ β) :=
+  ⟨const α 1⟩
+
+@[to_additive (attr := simp)]
+theorem const_one [One β] : const α (1 : β) = 1 :=
+  rfl
+
+@[to_additive (attr := simp)]
+theorem one_apply [One β] (a : α) : (1 : α →ₛ β) a = 1 := rfl
+
 theorem simpleFunc_bot {α} (f : @SimpleFunc α ⊥ β) [Nonempty β] : ∃ c, ∀ x, f x = c := by
   have hf_meas := @SimpleFunc.measurableSet_fiber α _ ⊥ f
   simp_rw [MeasurableSpace.measurableSet_bot_iff] at hf_meas
@@ -218,7 +229,7 @@ theorem piecewise_same (f : α →ₛ β) {s : Set α} (hs : MeasurableSet s) :
   coe_injective <| Set.piecewise_same _ _
 
 theorem support_indicator [Zero β] {s : Set α} (hs : MeasurableSet s) (f : α →ₛ β) :
-    Function.support (f.piecewise s hs (SimpleFunc.const α 0)) = s ∩ Function.support f :=
+    Function.support (f.piecewise s hs (0 : α →ₛ β)) = s ∩ Function.support f :=
   Set.support_indicator
 
 open scoped Classical in
@@ -266,6 +277,10 @@ theorem range_map [DecidableEq γ] (g : β → γ) (f : α →ₛ β) : (f.map g
 
 @[simp]
 theorem map_const (g : β → γ) (b : β) : (const α b).map g = const α (g b) :=
+  rfl
+
+@[to_additive (attr := simp)]
+theorem map_one [One β] (g : β → γ) : (1 : α →ₛ β).map g = const α (g 1) :=
   rfl
 
 open scoped Classical in
@@ -362,10 +377,6 @@ theorem pair_preimage_singleton (f : α →ₛ β) (g : α →ₛ γ) (b : β) (
 theorem bind_const (f : α →ₛ β) : f.bind (const α) = f := by ext; simp
 
 @[to_additive]
-instance instOne [One β] : One (α →ₛ β) :=
-  ⟨const α 1⟩
-
-@[to_additive]
 instance instMul [Mul β] : Mul (α →ₛ β) :=
   ⟨fun f g => (f.map (· * ·)).seq g⟩
 
@@ -386,9 +397,6 @@ instance instInf [Min β] : Min (α →ₛ β) :=
 instance instLE [LE β] : LE (α →ₛ β) :=
   ⟨fun f g => ∀ a, f a ≤ g a⟩
 
-@[to_additive (attr := simp)]
-theorem const_one [One β] : const α (1 : β) = 1 :=
-  rfl
 
 @[to_additive (attr := simp, norm_cast)]
 theorem coe_one [One β] : ⇑(1 : α →ₛ β) = 1 :=
@@ -621,7 +629,7 @@ variable [Zero β]
 
 open scoped Classical in
 /-- Restrict a simple function `f : α →ₛ β` to a set `s`. If `s` is measurable,
-then `f.restrict s a = if a ∈ s then f a else 0`, otherwise `f.restrict s = const α 0`. -/
+then `f.restrict s a = if a ∈ s then f a else 0`, otherwise `f.restrict s = 0`. -/
 def restrict (f : α →ₛ β) (s : Set α) : α →ₛ β :=
   if hs : MeasurableSet s then piecewise s hs f 0 else 0
 
@@ -961,6 +969,9 @@ theorem const_lintegral (c : ℝ≥0∞) : (const α c).lintegral μ = c * μ un
   · simp only [range_const, coe_const, Finset.sum_singleton]
     unfold Function.const; rw [preimage_const_of_mem (mem_singleton c)]
 
+theorem one_lintegral : (1 : α →ₛ ℝ≥0∞).lintegral μ = μ univ := by
+  rw [← const_one, const_lintegral, one_mul]
+
 theorem const_lintegral_restrict (c : ℝ≥0∞) (s : Set α) :
     (const α c).lintegral (μ.restrict s) = c * μ s := by
   rw [const_lintegral, Measure.restrict_apply MeasurableSet.univ, univ_inter]
@@ -1145,7 +1156,7 @@ To use in an induction proof, the syntax is `induction f using SimpleFunc.induct
 protected theorem induction {α γ} [MeasurableSpace α] [AddZeroClass γ]
     {motive : SimpleFunc α γ → Prop}
     (const : ∀ (c) {s} (hs : MeasurableSet s),
-      motive (SimpleFunc.piecewise s hs (SimpleFunc.const _ c) (SimpleFunc.const _ 0)))
+      motive (SimpleFunc.piecewise s hs (SimpleFunc.const _ c) 0))
     (add : ∀ ⦃f g : SimpleFunc α γ⦄,
       Disjoint (support f) (support g) → motive f → motive g → motive (f + g))
     (f : SimpleFunc α γ) : motive f := by

--- a/Mathlib/MeasureTheory/Function/SimpleFuncDense.lean
+++ b/Mathlib/MeasureTheory/Function/SimpleFuncDense.lean
@@ -55,7 +55,7 @@ variable [MeasurableSpace α] [PseudoEMetricSpace α] [OpensMeasurableSpace α]
 points `e 0`, ..., `e N`. If more than one point are at the same distance from `x`, then
 `nearestPtInd e N x` returns the least of their indexes. -/
 noncomputable def nearestPtInd (e : ℕ → α) : ℕ → α →ₛ ℕ
-  | 0 => const α 0
+  | 0 => 0
   | N + 1 =>
     piecewise (⋂ k ≤ N, { x | edist (e (N + 1)) x < edist (e k) x })
       (MeasurableSet.iInter fun _ =>
@@ -70,7 +70,7 @@ noncomputable def nearestPt (e : ℕ → α) (N : ℕ) : α →ₛ α :=
   (nearestPtInd e N).map e
 
 @[simp]
-theorem nearestPtInd_zero (e : ℕ → α) : nearestPtInd e 0 = const α 0 :=
+theorem nearestPtInd_zero (e : ℕ → α) : nearestPtInd e 0 = 0 :=
   rfl
 
 @[simp]

--- a/Mathlib/MeasureTheory/Function/SimpleFuncDenseLp.lean
+++ b/Mathlib/MeasureTheory/Function/SimpleFuncDenseLp.lean
@@ -359,7 +359,7 @@ theorem measure_support_lt_top_of_integrable (f : α →ₛ E) (hf : Integrable 
   f.measure_support_lt_top (integrable_iff.mp hf)
 
 theorem measure_lt_top_of_memLp_indicator (hp_pos : p ≠ 0) (hp_ne_top : p ≠ ∞) {c : E} (hc : c ≠ 0)
-    {s : Set α} (hs : MeasurableSet s) (hcs : MemLp ((const α c).piecewise s hs (const α 0)) p μ) :
+    {s : Set α} (hs : MeasurableSet s) (hcs : MemLp ((const α c).piecewise s hs 0) p μ) :
     μ s < ⊤ := by
   have : Function.support (const α c) = Set.univ := Function.support_const hc
   simpa only [memLp_iff_finMeasSupp hp_pos hp_ne_top, finMeasSupp_iff_support,
@@ -599,7 +599,7 @@ variable (p) in
 -/
 def indicatorConst {s : Set α} (hs : MeasurableSet s) (hμs : μ s ≠ ∞) (c : E) :
     Lp.simpleFunc E p μ :=
-  toLp ((SimpleFunc.const _ c).piecewise s hs (SimpleFunc.const _ 0))
+  toLp ((SimpleFunc.const _ c).piecewise s hs 0)
     (memLp_indicator_const p hs c (Or.inr hμs))
 
 @[simp]
@@ -609,7 +609,7 @@ theorem coe_indicatorConst {s : Set α} (hs : MeasurableSet s) (hμs : μ s ≠ 
 
 theorem toSimpleFunc_indicatorConst {s : Set α} (hs : MeasurableSet s) (hμs : μ s ≠ ∞) (c : E) :
     toSimpleFunc (indicatorConst p hs hμs c) =ᵐ[μ]
-      (SimpleFunc.const _ c).piecewise s hs (SimpleFunc.const _ 0) :=
+      (SimpleFunc.const _ c).piecewise s hs 0 :=
   Lp.simpleFunc.toSimpleFunc_toLp _ _
 
 /-- To prove something for an arbitrary `Lp` simple function, with `0 < p < ∞`, it suffices to show

--- a/Mathlib/MeasureTheory/Integral/Bochner/VitaliCaratheodory.lean
+++ b/Mathlib/MeasureTheory/Integral/Bochner/VitaliCaratheodory.lean
@@ -94,7 +94,7 @@ theorem SimpleFunc.exists_le_lowerSemicontinuous_lintegral_ge (f : α →ₛ ℝ
       (∫⁻ x, g x ∂μ) ≤ (∫⁻ x, f x ∂μ) + ε := by
   induction f using MeasureTheory.SimpleFunc.induction generalizing ε with
   | @const c s hs =>
-    let f := SimpleFunc.piecewise s hs (SimpleFunc.const α c) (SimpleFunc.const α 0)
+    let f := SimpleFunc.piecewise s hs (SimpleFunc.const α c) 0
     by_cases h : ∫⁻ x, f x ∂μ = ⊤
     · refine
         ⟨fun _ => c, fun x => ?_, lowerSemicontinuous_const, by

--- a/Mathlib/MeasureTheory/Integral/Lebesgue/Countable.lean
+++ b/Mathlib/MeasureTheory/Integral/Lebesgue/Countable.lean
@@ -295,7 +295,7 @@ theorem SimpleFunc.exists_lt_lintegral_simpleFunc_of_lt_lintegral {m : Measurabl
     obtain ⟨t, ht, ts, mlt, t_top⟩ :
       ∃ t : Set α, MeasurableSet t ∧ t ⊆ s ∧ L / ↑c < μ t ∧ μ t < ∞ :=
       Measure.exists_subset_measure_lt_top hs this
-    refine ⟨piecewise t ht (const α c) (const α 0), fun x => ?_, ?_, ?_⟩
+    refine ⟨piecewise t ht (const α c) 0, fun x => ?_, ?_, ?_⟩
     · refine indicator_le_indicator_of_subset ts (fun x => ?_) x
       exact zero_le _
     · simp only [ht, const_zero, coe_piecewise, coe_const, SimpleFunc.coe_zero, univ_inter,

--- a/Mathlib/MeasureTheory/Integral/SetToL1.lean
+++ b/Mathlib/MeasureTheory/Integral/SetToL1.lean
@@ -559,7 +559,7 @@ theorem norm_setToSimpleFunc_le_sum_mul_norm_of_integrable (T : Set α → E →
 theorem setToSimpleFunc_indicator (T : Set α → F →L[ℝ] F') (hT_empty : T ∅ = 0)
     {m : MeasurableSpace α} {s : Set α} (hs : MeasurableSet s) (x : F) :
     SimpleFunc.setToSimpleFunc T
-        (SimpleFunc.piecewise s hs (SimpleFunc.const α x) (SimpleFunc.const α 0)) =
+        (SimpleFunc.piecewise s hs (SimpleFunc.const α x) 0) =
       T s x := by
   classical
   obtain rfl | hs_empty := s.eq_empty_or_nonempty

--- a/Mathlib/Probability/StrongLaw.lean
+++ b/Mathlib/Probability/StrongLaw.lean
@@ -673,8 +673,7 @@ lemma strong_law_ae_simpleFunc_comp (X : ℕ → Ω → E) (h' : Measurable (X 0
       simp only [Function.const_one, smul_eq_mul, ← div_eq_inv_mul]
       apply strong_law_ae_real
       · exact SimpleFunc.integrable_of_isFiniteMeasure
-          ((SimpleFunc.piecewise s hs (SimpleFunc.const _ (1 : ℝ))
-            (SimpleFunc.const _ (0 : ℝ))).comp (X 0) h')
+          ((SimpleFunc.piecewise s hs (1 : α →ₛ ℝ) (0 : α →ₛ ℝ)).comp (X 0) h')
       · exact fun i j hij ↦ IndepFun.comp (hindep hij) F_meas F_meas
       · exact fun i ↦ (hident i).comp F_meas
     filter_upwards [this] with ω hω


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
