### PR TITLE
[Merged by Bors] - feat(NumberField/Discriminant): better lower bound for totally complex number fields

### DIFF
--- a/Mathlib/NumberTheory/NumberField/Discriminant/Basic.lean
+++ b/Mathlib/NumberTheory/NumberField/Discriminant/Basic.lean
@@ -153,10 +153,12 @@ theorem exists_ne_zero_mem_ringOfIntegers_of_norm_le_mul_sqrt_discr :
   simp_rw [Units.val_one, FractionalIdeal.absNorm_one, Rat.cast_one, one_mul] at h_nm
   exact h_nm
 
-variable {K}
-
-theorem abs_discr_ge (h : 1 < finrank ℚ K) :
-    (4 / 9 : ℝ) * (3 * π / 4) ^ finrank ℚ K ≤ |discr K| := by
+/--
+A stronger version of `abs_discr_ge` but probably less easy to use in practice.
+-/
+theorem abs_discr_ge' :
+    (finrank ℚ K) ^ (finrank ℚ K * 2) / ((4 / π) ^ (nrComplexPlaces K * 2) *
+      (finrank ℚ K).factorial ^ 2) ≤ |discr K| := by
   -- We use `exists_ne_zero_mem_ringOfIntegers_of_norm_le_mul_sqrt_discr` to get a nonzero
   -- algebraic integer `x` of small norm and the fact that `1 ≤ |Norm x|` to get a lower bound
   -- on `sqrt |discr K|`.
@@ -165,9 +167,21 @@ theorem abs_discr_ge (h : 1 < finrank ℚ K) :
     rw [← Algebra.coe_norm_int, ← Int.cast_one, ← Int.cast_abs, Rat.cast_intCast, Int.cast_le]
     exact Int.one_le_abs (Algebra.norm_ne_zero_iff.mpr h_nz)
   replace h_bd := le_trans h_nm h_bd
-  rw [← inv_mul_le_iff₀ (by positivity), inv_div, mul_one, Real.le_sqrt (by positivity)
+  rwa [← inv_mul_le_iff₀, inv_div, mul_one, Real.le_sqrt (by positivity)
     (by positivity), ← Int.cast_abs, div_pow, mul_pow, ← pow_mul, ← pow_mul] at h_bd
-  refine le_trans ?_ h_bd
+  exact div_pos (by positivity) <| pow_pos (Nat.cast_pos.mpr finrank_pos) (finrank ℚ K)
+
+theorem abs_discr_ge_of_isTotallyComplex [IsTotallyComplex K] :
+    (finrank ℚ K) ^ (finrank ℚ K * 2) / ((4 / π) ^ (finrank ℚ K) *
+      (finrank ℚ K).factorial ^ 2) ≤ |discr K| := by
+  have := abs_discr_ge' K
+  rwa [mul_comm (nrComplexPlaces K), ← IsTotallyComplex.finrank] at this
+
+variable {K}
+
+theorem abs_discr_ge (h : 1 < finrank ℚ K) :
+    (4 / 9 : ℝ) * (3 * π / 4) ^ finrank ℚ K ≤ |discr K| := by
+  refine le_trans ?_ (abs_discr_ge' K)
   -- The sequence `a n` is a lower bound for `|discr K|`. We prove below by induction an uniform
   -- lower bound for this sequence from which we deduce the result.
   let a : ℕ → ℝ := fun n => (n : ℝ) ^ (n * 2) / ((4 / π) ^ n * (n.factorial : ℝ) ^ 2)

--- a/Mathlib/NumberTheory/NumberField/Discriminant/Basic.lean
+++ b/Mathlib/NumberTheory/NumberField/Discriminant/Basic.lean
@@ -154,10 +154,11 @@ theorem exists_ne_zero_mem_ringOfIntegers_of_norm_le_mul_sqrt_discr :
   exact h_nm
 
 /--
-A stronger version of `abs_discr_ge` but probably less easy to use in practice.
+The Minkowski lower bound `n^{2n}/((4/pi)^{2r_2}*n!^2)` for the absolute value of the discriminant
+of a number field of degree n.
 -/
 theorem abs_discr_ge' :
-    (finrank ℚ K) ^ (finrank ℚ K * 2) / ((4 / π) ^ (nrComplexPlaces K * 2) *
+    (finrank ℚ K) ^ (2 * finrank ℚ K) / ((4 / π) ^ (2 * nrComplexPlaces K) *
       (finrank ℚ K).factorial ^ 2) ≤ |discr K| := by
   -- We use `exists_ne_zero_mem_ringOfIntegers_of_norm_le_mul_sqrt_discr` to get a nonzero
   -- algebraic integer `x` of small norm and the fact that `1 ≤ |Norm x|` to get a lower bound
@@ -167,15 +168,26 @@ theorem abs_discr_ge' :
     rw [← Algebra.coe_norm_int, ← Int.cast_one, ← Int.cast_abs, Rat.cast_intCast, Int.cast_le]
     exact Int.one_le_abs (Algebra.norm_ne_zero_iff.mpr h_nz)
   replace h_bd := le_trans h_nm h_bd
-  rwa [← inv_mul_le_iff₀, inv_div, mul_one, Real.le_sqrt (by positivity)
-    (by positivity), ← Int.cast_abs, div_pow, mul_pow, ← pow_mul, ← pow_mul] at h_bd
+  rwa [← inv_mul_le_iff₀, inv_div, mul_one, Real.le_sqrt (by positivity) (by positivity),
+    ← Int.cast_abs, div_pow, mul_pow, ← pow_mul, mul_comm _ 2, ← pow_mul, mul_comm _ 2] at h_bd
   exact div_pos (by positivity) <| pow_pos (Nat.cast_pos.mpr finrank_pos) (finrank ℚ K)
 
 theorem abs_discr_ge_of_isTotallyComplex [IsTotallyComplex K] :
-    (finrank ℚ K) ^ (finrank ℚ K * 2) / ((4 / π) ^ (finrank ℚ K) *
+    (finrank ℚ K) ^ (2 * finrank ℚ K) / ((4 / π) ^ (finrank ℚ K) *
       (finrank ℚ K).factorial ^ 2) ≤ |discr K| := by
   have := abs_discr_ge' K
-  rwa [mul_comm (nrComplexPlaces K), ← IsTotallyComplex.finrank] at this
+  rwa [← IsTotallyComplex.finrank] at this
+
+theorem abs_discr_rpow_ge_of_isTotallyComplex [IsTotallyComplex K] :
+    (finrank ℚ K) ^ 2 / ((4 / π) * (finrank ℚ K).factorial ^ (2 *(finrank ℚ K : ℝ)⁻¹)) ≤
+        |discr K| ^ (finrank ℚ K : ℝ)⁻¹ := by
+  have h : 0 < (finrank ℚ K : ℝ) := Nat.cast_pos.mpr finrank_pos
+  rw [← Real.rpow_le_rpow_iff (z := finrank ℚ K) (by positivity) (by positivity) h, Real.div_rpow
+    (by positivity) (by positivity), ← Real.rpow_mul (by positivity), inv_mul_cancel₀ h.ne',
+    Real.rpow_one, Real.mul_rpow (by positivity) (by positivity), Real.rpow_natCast,
+    Real.rpow_natCast, ← pow_mul, ← Real.rpow_mul (by positivity),
+    inv_mul_cancel_right₀ h.ne', Real.rpow_two]
+  exact abs_discr_ge_of_isTotallyComplex K
 
 variable {K}
 
@@ -184,6 +196,7 @@ theorem abs_discr_ge (h : 1 < finrank ℚ K) :
   refine le_trans ?_ (abs_discr_ge' K)
   -- The sequence `a n` is a lower bound for `|discr K|`. We prove below by induction an uniform
   -- lower bound for this sequence from which we deduce the result.
+  rw [mul_comm 2 _]
   let a : ℕ → ℝ := fun n => (n : ℝ) ^ (n * 2) / ((4 / π) ^ n * (n.factorial : ℝ) ^ 2)
   suffices ∀ n, 2 ≤ n → (4 / 9 : ℝ) * (3 * π / 4) ^ n ≤ a n by
     refine le_trans (this (finrank ℚ K) h) ?_

--- a/Mathlib/NumberTheory/NumberField/Discriminant/Basic.lean
+++ b/Mathlib/NumberTheory/NumberField/Discriminant/Basic.lean
@@ -179,7 +179,7 @@ theorem abs_discr_ge_of_isTotallyComplex [IsTotallyComplex K] :
   rwa [← IsTotallyComplex.finrank] at this
 
 theorem abs_discr_rpow_ge_of_isTotallyComplex [IsTotallyComplex K] :
-    (finrank ℚ K) ^ 2 / ((4 / π) * (finrank ℚ K).factorial ^ (2 *(finrank ℚ K : ℝ)⁻¹)) ≤
+    (finrank ℚ K) ^ 2 / ((4 / π) * (finrank ℚ K).factorial ^ (2 * (finrank ℚ K : ℝ)⁻¹)) ≤
         |discr K| ^ (finrank ℚ K : ℝ)⁻¹ := by
   have h : 0 < (finrank ℚ K : ℝ) := Nat.cast_pos.mpr finrank_pos
   rw [← Real.rpow_le_rpow_iff (z := finrank ℚ K) (by positivity) (by positivity) h, Real.div_rpow

--- a/Mathlib/NumberTheory/NumberField/Embeddings.lean
+++ b/Mathlib/NumberTheory/NumberField/Embeddings.lean
@@ -1148,23 +1148,81 @@ lemma isReal_infinitePlace : InfinitePlace.IsReal (infinitePlace) :=
 
 end Rat
 
+namespace NumberField
+
+open InfinitePlace Module
+
+section TotallyRealField
+
 /-
 
 ## Totally real number fields
 
 -/
 
-namespace NumberField
-
 /-- A number field `K` is totally real if all of its infinite places
-are real. In other words, the image of every ring homomorphism `K → ℂ`
-is a subset of `ℝ`. -/
-class IsTotallyReal (K : Type*) [Field K] [NumberField K] where
+ are real. In other words, the image of every ring homomorphism `K → ℂ`
+ is a subset of `ℝ`. -/
+@[mk_iff] class IsTotallyReal (K : Type*) [Field K] [NumberField K] where
   isReal : ∀ v : InfinitePlace K, v.IsReal
+
+variable {K : Type*} [Field K] [NumberField K]
+
+theorem nrComplexPlaces_eq_zero_iff :
+     nrComplexPlaces K = 0 ↔ IsTotallyReal K := by
+   classical
+   simp [Fintype.card_eq_zero_iff, isEmpty_subtype, isTotallyReal_iff]
+
+variable (K)
+
+@[simp]
+theorem IsTotallyReal.nrComplexPlaces_eq_zero [h : IsTotallyReal K] :
+    nrComplexPlaces K = 0 :=
+  nrComplexPlaces_eq_zero_iff.mpr h
+
+protected theorem IsTotallyReal.finrank [h : IsTotallyReal K] :
+    finrank ℚ K = nrRealPlaces K := by
+  rw [← card_add_two_mul_card_eq_rank, nrComplexPlaces_eq_zero_iff.mpr h, mul_zero, add_zero]
 
 instance : IsTotallyReal ℚ where
   isReal v := by
     rw [Subsingleton.elim v Rat.infinitePlace]
     exact Rat.isReal_infinitePlace
+
+end TotallyRealField
+
+section TotallyComplexField
+
+/-
+## Totally complex number fields
+-/
+
+open InfinitePlace
+
+/--
+A number field `K` is totally complex if all of its infinite places are complex.
+-/
+@[mk_iff] class IsTotallyComplex (K : Type*) [Field K] [NumberField K] where
+  isComplex : ∀ v : InfinitePlace K, v.IsComplex
+
+variable {K : Type*} [Field K] [NumberField K]
+
+theorem nrRealPlaces_eq_zero_iff :
+    nrRealPlaces K = 0 ↔ IsTotallyComplex K := by
+  classical
+  simp [Fintype.card_eq_zero_iff, isEmpty_subtype, isTotallyComplex_iff]
+
+variable (K)
+
+@[simp]
+theorem IsTotallyComplex.nrRealPlaces_eq_zero [h : IsTotallyComplex K] :
+    nrRealPlaces K = 0 :=
+  nrRealPlaces_eq_zero_iff.mpr h
+
+protected theorem IsTotallyComplex.finrank [h : IsTotallyComplex K] :
+    finrank ℚ K = 2 * nrComplexPlaces K := by
+  rw [← card_add_two_mul_card_eq_rank, nrRealPlaces_eq_zero_iff.mpr h, zero_add]
+
+end TotallyComplexField
 
 end NumberField

--- a/Mathlib/NumberTheory/NumberField/Embeddings.lean
+++ b/Mathlib/NumberTheory/NumberField/Embeddings.lean
@@ -1161,17 +1161,17 @@ section TotallyRealField
 -/
 
 /-- A number field `K` is totally real if all of its infinite places
- are real. In other words, the image of every ring homomorphism `K → ℂ`
- is a subset of `ℝ`. -/
+are real. In other words, the image of every ring homomorphism `K → ℂ`
+is a subset of `ℝ`. -/
 @[mk_iff] class IsTotallyReal (K : Type*) [Field K] [NumberField K] where
   isReal : ∀ v : InfinitePlace K, v.IsReal
 
 variable {K : Type*} [Field K] [NumberField K]
 
 theorem nrComplexPlaces_eq_zero_iff :
-     nrComplexPlaces K = 0 ↔ IsTotallyReal K := by
-   classical
-   simp [Fintype.card_eq_zero_iff, isEmpty_subtype, isTotallyReal_iff]
+    nrComplexPlaces K = 0 ↔ IsTotallyReal K := by
+  classical
+  simp [Fintype.card_eq_zero_iff, isEmpty_subtype, isTotallyReal_iff]
 
 variable (K)
 

--- a/Mathlib/NumberTheory/NumberField/Embeddings.lean
+++ b/Mathlib/NumberTheory/NumberField/Embeddings.lean
@@ -1170,7 +1170,6 @@ variable {K : Type*} [Field K] [NumberField K]
 
 theorem nrComplexPlaces_eq_zero_iff :
     nrComplexPlaces K = 0 ↔ IsTotallyReal K := by
-  classical
   simp [Fintype.card_eq_zero_iff, isEmpty_subtype, isTotallyReal_iff]
 
 variable (K)
@@ -1209,7 +1208,6 @@ variable {K : Type*} [Field K] [NumberField K]
 
 theorem nrRealPlaces_eq_zero_iff :
     nrRealPlaces K = 0 ↔ IsTotallyComplex K := by
-  classical
   simp [Fintype.card_eq_zero_iff, isEmpty_subtype, isTotallyComplex_iff]
 
 variable (K)


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
