### PR TITLE
[Merged by Bors] - chore(LinearAlgebra): golf two proofs and remove porting notes

### DIFF
--- a/Mathlib/LinearAlgebra/Dimension/DivisionRing.lean
+++ b/Mathlib/LinearAlgebra/Dimension/DivisionRing.lean
@@ -84,12 +84,9 @@ theorem rank_add_rank_split (db : V₂ →ₗ[K] V) (eb : V₃ →ₗ[K] V) (cd 
     rw [← rank_prod', rank_eq_of_surjective hf]
   congr 1
   apply LinearEquiv.rank_eq
-  let L : V₁ →ₗ[K] ker (coprod db eb) := by -- Porting note: this is needed to avoid a timeout
-    refine LinearMap.codRestrict _ (prod cd (-ce)) ?_
-    · intro c
-      simp only [add_eq_zero_iff_eq_neg, LinearMap.prod_apply, mem_ker, Pi.prod, coprod_apply,
-        neg_neg, map_neg, neg_apply]
-      exact LinearMap.ext_iff.1 eq c
+  let L : V₁ →ₗ[K] ker (coprod db eb) :=
+    LinearMap.codRestrict _ (prod cd (-ce)) <| by
+      simpa [add_eq_zero_iff_eq_neg] using LinearMap.ext_iff.1 eq
   refine LinearEquiv.ofBijective L ⟨?_, ?_⟩
   · rw [← ker_eq_bot, ker_codRestrict, ker_prod, hgd, bot_inf_eq]
   · rw [← range_eq_top, eq_top_iff, range_codRestrict, ← map_le_iff_le_comap,

--- a/Mathlib/LinearAlgebra/LinearIndependent/Basic.lean
+++ b/Mathlib/LinearAlgebra/LinearIndependent/Basic.lean
@@ -513,89 +513,65 @@ theorem linearIndependent_monoidHom (G : Type*) [MulOneClass G] (L : Type*) [Com
   letI := Classical.decEq (G →* L)
   letI : MulAction L L := DistribMulAction.toMulAction
   -- We prove linear independence by showing that only the trivial linear combination vanishes.
-  exact linearIndependent_iff'.2
-    -- To do this, we use `Finset` induction,
-    -- Porting note: `False.elim` → `fun h => False.elim <| Finset.not_mem_empty _ h`
-    fun s =>
-      Finset.induction_on s
-        (fun g _hg i h => False.elim <| Finset.not_mem_empty _ h) fun a s has ih g hg =>
-        -- Here
-        -- * `a` is a new character we will insert into the `Finset` of characters `s`,
-        -- * `ih` is the fact that only the trivial linear combination of characters in `s` is zero
-        -- * `hg` is the fact that `g` are the coefficients of a linear combination summing to zero
-        -- and it remains to prove that `g` vanishes on `insert a s`.
-        -- We now make the key calculation:
-        -- For any character `i` in the original `Finset`, we have `g i • i = g i • a` as functions
-        -- on the monoid `G`.
-        have h1 : ∀ i ∈ s, (g i • (i : G → L)) = g i • (a : G → L) := fun i his =>
-          funext fun x : G =>
-            -- We prove these expressions are equal by showing
-            -- the differences of their values on each monoid element `x` is zero
-            eq_of_sub_eq_zero <|
-            ih (fun j => g j * j x - g j * a x)
-              (funext fun y : G => calc
-                -- After that, it's just a chase scene.
-                (∑ i ∈ s, ((g i * i x - g i * a x) • (i : G → L))) y =
-                    ∑ i ∈ s, (g i * i x - g i * a x) * i y :=
-                  Finset.sum_apply ..
-                _ = ∑ i ∈ s, (g i * i x * i y - g i * a x * i y) :=
-                  Finset.sum_congr rfl fun _ _ => sub_mul ..
-                _ = (∑ i ∈ s, g i * i x * i y) - ∑ i ∈ s, g i * a x * i y :=
-                  Finset.sum_sub_distrib
-                _ =
-                    (g a * a x * a y + ∑ i ∈ s, g i * i x * i y) -
-                      (g a * a x * a y + ∑ i ∈ s, g i * a x * i y) := by
-                  rw [add_sub_add_left_eq_sub]
-                _ =
-                    (∑ i ∈ insert a s, g i * i x * i y) -
-                      ∑ i ∈ insert a s, g i * a x * i y := by
-                  rw [Finset.sum_insert has, Finset.sum_insert has]
-                _ =
-                    (∑ i ∈ insert a s, g i * i (x * y)) -
-                      ∑ i ∈ insert a s, a x * (g i * i y) := by
-                  congrm ∑ i ∈ insert a s, ?_ - ∑ i ∈ insert a s, ?_
-                  · rw [map_mul, mul_assoc]
-                  · rw [mul_assoc, mul_left_comm]
-                _ =
-                    (∑ i ∈ insert a s, (g i • (i : G → L))) (x * y) -
-                      a x * (∑ i ∈ insert a s, (g i • (i : G → L))) y := by
-                  rw [Finset.sum_apply, Finset.sum_apply, Finset.mul_sum]; rfl
-                _ = 0 - a x * 0 := by rw [hg]; rfl
-                _ = 0 := by rw [mul_zero, sub_zero]
-                )
-              i his
-        -- On the other hand, since `a` is not already in `s`, for any character `i ∈ s`
-        -- there is some element of the monoid on which it differs from `a`.
-        have h2 : ∀ i : G →* L, i ∈ s → ∃ y, i y ≠ a y := fun i his =>
-          Classical.by_contradiction fun h =>
-            have hia : i = a := MonoidHom.ext fun y =>
-              Classical.by_contradiction fun hy => h ⟨y, hy⟩
-            has <| hia ▸ his
-        -- From these two facts we deduce that `g` actually vanishes on `s`,
-        have h3 : ∀ i ∈ s, g i = 0 := fun i his =>
-          let ⟨y, hy⟩ := h2 i his
-          have h : g i • i y = g i • a y := congr_fun (h1 i his) y
-          Or.resolve_right (mul_eq_zero.1 <| by rw [mul_sub, sub_eq_zero]; exact h)
-            (sub_ne_zero_of_ne hy)
-        -- And so, using the fact that the linear combination over `s` and over `insert a s` both
-        -- vanish, we deduce that `g a = 0`.
-        have h4 : g a = 0 :=
-          calc
-            g a = g a * 1 := (mul_one _).symm
-            _ = (g a • (a : G → L)) 1 := by rw [← a.map_one]; rfl
-            _ = (∑ i ∈ insert a s, (g i • (i : G → L))) 1 := by
-              rw [Finset.sum_eq_single a]
-              · intro i his hia
-                rw [Finset.mem_insert] at his
-                rw [h3 i (his.resolve_left hia), zero_smul]
-              · intro haas
-                exfalso
-                apply haas
-                exact Finset.mem_insert_self a s
-            _ = 0 := by rw [hg]; rfl
-        -- Now we're done; the last two facts together imply that `g` vanishes on every element
-        -- of `insert a s`.
-        (Finset.forall_mem_insert ..).2 ⟨h4, h3⟩
+  apply linearIndependent_iff'.2
+  intro s
+  induction s using Finset.induction_on with
+  | empty => simp
+  | insert has ih =>
+  rename_i a s
+  intro g hg
+  -- Here
+  -- * `a` is a new character we will insert into the `Finset` of characters `s`,
+  -- * `ih` is the fact that only the trivial linear combination of characters in `s` is zero
+  -- * `hg` is the fact that `g` are the coefficients of a linear combination summing to zero
+  -- and it remains to prove that `g` vanishes on `insert a s`.
+  -- We now make the key calculation:
+  -- For any character `i` in the original `Finset`, we have `g i • i = g i • a` as functions
+  -- on the monoid `G`.
+  have h1 (i) (his : i ∈ s) : (g i • (i : G → L)) = g i • (a : G → L) := by
+    ext x
+    rw [← sub_eq_zero]
+    apply ih (fun j => g j * j x - g j * a x) _ i his
+    ext y
+    -- After that, it's just a chase scene.
+    calc
+      (∑ i ∈ s, ((g i * i x - g i * a x) • (i : G → L))) y =
+          (∑ i ∈ s, g i * i x * i y) - ∑ i ∈ s, g i * a x * i y := by simp [sub_mul]
+      _ = (∑ i ∈ insert a s, g i * i x * i y) -
+            ∑ i ∈ insert a s, g i * a x * i y := by simp [Finset.sum_insert has]
+      _ = (∑ i ∈ insert a s, g i * (i x * i y)) -
+            ∑ i ∈ insert a s, a x * (g i * i y) := by
+        congrm ∑ i ∈ insert a s, ?_ - ∑ i ∈ insert a s, ?_
+        · rw [mul_assoc]
+        · rw [mul_assoc, mul_left_comm]
+      _ = (∑ i ∈ insert a s, (g i • (i : G → L))) (x * y) -
+            a x * (∑ i ∈ insert a s, (g i • (i : G → L))) y := by simp [Finset.mul_sum]
+      _ = 0 := by rw [hg]; simp
+  -- On the other hand, since `a` is not already in `s`, for any character `i ∈ s`
+  -- there is some element of the monoid on which it differs from `a`.
+  have h2 (i) (his : i ∈ s) : ∃ y, i y ≠ a y := by
+    by_contra! hia
+    obtain rfl : i = a := MonoidHom.ext hia
+    contradiction
+  -- From these two facts we deduce that `g` actually vanishes on `s`,
+  have h3 (i) (his : i ∈ s) : g i = 0 := by
+    let ⟨y, hy⟩ := h2 i his
+    have h : g i • i y = g i • a y := congr_fun (h1 i his) y
+    rw [← sub_eq_zero, ← smul_sub, smul_eq_zero] at h
+    exact h.resolve_right (sub_ne_zero_of_ne hy)
+  -- And so, using the fact that the linear combination over `s` and over `insert a s` both
+  -- vanish, we deduce that `g a = 0`.
+  have h4 : g a = 0 :=
+    calc
+      g a = g a * 1 := (mul_one _).symm
+      _ = (g a • (a : G → L)) 1 := by rw [← a.map_one]; rfl
+      _ = (∑ i ∈ insert a s, (g i • (i : G → L))) 1 := by
+        rw [Finset.sum_insert has, Finset.sum_eq_zero, add_zero]
+        simp +contextual [h3]
+      _ = 0 := by rw [hg]; rfl
+  -- Now we're done; the last two facts together imply that `g` vanishes on every element
+  -- of `insert a s`.
+  exact (Finset.forall_mem_insert ..).2 ⟨h4, h3⟩
 
 end Module
 

--- a/Mathlib/LinearAlgebra/LinearIndependent/Basic.lean
+++ b/Mathlib/LinearAlgebra/LinearIndependent/Basic.lean
@@ -517,8 +517,7 @@ theorem linearIndependent_monoidHom (G : Type*) [MulOneClass G] (L : Type*) [Com
   intro s
   induction s using Finset.induction_on with
   | empty => simp
-  | insert has ih =>
-  rename_i a s
+  | @insert a s has ih =>
   intro g hg
   -- Here
   -- * `a` is a new character we will insert into the `Finset` of characters `s`,


### PR DESCRIPTION

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
