### PR TITLE
DO NOT MERGE: lower long file limit to 1200

### DIFF
--- a/Mathlib/Tactic/Linter/Style.lean
+++ b/Mathlib/Tactic/Linter/Style.lean
@@ -30,7 +30,7 @@ This file defines the following linters:
   the `|>` symbol
 - the `lambdaSyntax` linter checks for uses of the `λ` symbol for anonymous functions,
   instead of the `fun` keyword: mathlib prefers the latter for reasons of readability
-- the `longFile` linter checks for files which have more than 1500 lines
+- the `longFile` linter checks for files which have more than 1200 lines
 - the `longLine` linter checks for lines which have more than 100 characters
 - the `openClassical` linter checks for `open (scoped) Classical` statements which are not
   scoped to a single declaration
@@ -319,7 +319,7 @@ end Style.lambdaSyntax
 #  The "longFile" linter
 
 The "longFile" linter emits a warning on files which are longer than a certain number of lines
-(1500 by default).
+(1200 by default).
 -/
 
 /--
@@ -335,7 +335,7 @@ register_option linter.style.longFile : Nat := {
 
 /-- The number of lines that the `longFile` linter considers the default. -/
 register_option linter.style.longFileDefValue : Nat := {
-  defValue := 1500
+  defValue := 1200
   descr := "a soft upper bound on the number of lines of each file"
 }
 

--- a/MathlibTest/LongFile.lean
+++ b/MathlibTest/LongFile.lean
@@ -17,12 +17,12 @@ section longFile
 
 /--
 warning: The default value of the `longFile` linter is 1500.
-The current value of 1500 does not exceed the allowed bound.
-Please, remove the `set_option linter.style.longFile 1500`.
+The current value of 1200 does not exceed the allowed bound.
+Please, remove the `set_option linter.style.longFile 1200`.
 -/
 #guard_msgs in
 -- Do not allow setting a `longFile` linter option if the file does not exceed the `defValue`
-set_option linter.style.longFile 1500
+set_option linter.style.longFile 1200
 
 /--
 warning: using 'exit' to interrupt Lean

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -37,7 +37,7 @@ abbrev mathlibOnlyLinters : Array LeanOption := #[
   ⟨`linter.style.header, true⟩,
   ⟨`linter.style.lambdaSyntax, true⟩,
   ⟨`linter.style.longLine, true⟩,
-  ⟨`linter.style.longFile, .ofNat 1500⟩,
+  ⟨`linter.style.longFile, .ofNat 1200⟩,
   ⟨`linter.style.maxHeartbeats, true⟩,
   -- `latest_import.yml` uses this comment: if you edit it, make sure that the workflow still works
   ⟨`linter.style.missingEnd, true⟩,


### PR DESCRIPTION
Not meant to be merged (or it at all, with extensive discussion). Meant to see which files are long. `PartialHomeomorph.lean` certainly is; I'm happy to split that one.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
