### PR TITLE
feat: the `longFileHard` linter

### DIFF
--- a/MathlibTest/LongFile.lean
+++ b/MathlibTest/LongFile.lean
@@ -1,7 +1,7 @@
 import Mathlib.Tactic.Linter.Style
 
 /-
-# Testing the `longFile` linter
+# Testing the `longFile` and `longFileHard` linters
 
 Things to note:
 * `set_option linter.style.longFile 0` disables the linter, allowing us to set a value smaller than
@@ -124,3 +124,24 @@ Please, remove the `set_option linter.style.longFile 5000`.
 #guard_msgs in
 set_option linter.style.longFile 5000 in
 #exit
+
+/--
+error: It is forbidden to set the `longFileHard` option.
+-/
+#guard_msgs in
+set_option linter.style.longFileHard 100
+
+/--
+warning: using 'exit' to interrupt Lean
+---
+warning: This file is 141 lines long, but the limit is 100.
+Please split this file.
+-/
+#guard_msgs in
+#exit
+
+/--
+error: It is forbidden to set the `longFileHard` option.
+-/
+#guard_msgs in
+set_option linter.style.longFileHard 1500

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -38,6 +38,7 @@ abbrev mathlibOnlyLinters : Array LeanOption := #[
   ⟨`linter.style.lambdaSyntax, true⟩,
   ⟨`linter.style.longLine, true⟩,
   ⟨`linter.style.longFile, .ofNat 1500⟩,
+  ⟨`linter.style.longFileHard, .ofNat 1500⟩,
   ⟨`linter.style.maxHeartbeats, true⟩,
   -- `latest_import.yml` uses this comment: if you edit it, make sure that the workflow still works
   ⟨`linter.style.missingEnd, true⟩,


### PR DESCRIPTION
@kim-em [on Zulip](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/long.20files/near/510548946):
> Yes, we don't have a sustainable mechanism that will prevent long files creeping back, unless when we reach "no long file", we turn it into an non-overridable error...!
> 
> It would be great to have such a mechanism, of course, because I agree, of course, that this would be annoying to contributors (and doubly annoying to reviewers if they had to remind contributors not to "compress" things).