### PR TITLE
[Merged by Bors] - chore(CategoryTheory/Over): fix name of `Under.pullbackComp`

### DIFF
--- a/Mathlib/CategoryTheory/Comma/Over/Pullback.lean
+++ b/Mathlib/CategoryTheory/Comma/Over/Pullback.lean
@@ -163,6 +163,9 @@ def pushoutComp {X Y Z : C} (f : X ⟶ Y) (g : Y ⟶ Z) : pushout (f ≫ g) ≅ 
   (conjugateIsoEquiv ((mapPushoutAdj _).comp (mapPushoutAdj _)) (mapPushoutAdj _) ).symm
     (mapComp f g).symm
 
+@[deprecated (since := "2025-04-15")]
+alias pullbackComp := pushoutComp 
+
 instance pushoutIsLeftAdjoint {X Y : C} (f : X ⟶ Y) : (pushout f).IsLeftAdjoint  :=
   ⟨_, ⟨mapPushoutAdj f⟩⟩
 

--- a/Mathlib/CategoryTheory/Comma/Over/Pullback.lean
+++ b/Mathlib/CategoryTheory/Comma/Over/Pullback.lean
@@ -164,7 +164,7 @@ def pushoutComp {X Y Z : C} (f : X ⟶ Y) (g : Y ⟶ Z) : pushout (f ≫ g) ≅ 
     (mapComp f g).symm
 
 @[deprecated (since := "2025-04-15")]
-alias pullbackComp := pushoutComp 
+noncomputable alias pullbackComp := pushoutComp 
 
 instance pushoutIsLeftAdjoint {X Y : C} (f : X ⟶ Y) : (pushout f).IsLeftAdjoint  :=
   ⟨_, ⟨mapPushoutAdj f⟩⟩

--- a/Mathlib/CategoryTheory/Comma/Over/Pullback.lean
+++ b/Mathlib/CategoryTheory/Comma/Over/Pullback.lean
@@ -164,7 +164,7 @@ def pushoutComp {X Y Z : C} (f : X ⟶ Y) (g : Y ⟶ Z) : pushout (f ≫ g) ≅ 
     (mapComp f g).symm
 
 @[deprecated (since := "2025-04-15")]
-noncomputable alias pullbackComp := pushoutComp 
+noncomputable alias pullbackComp := pushoutComp
 
 instance pushoutIsLeftAdjoint {X Y : C} (f : X ⟶ Y) : (pushout f).IsLeftAdjoint  :=
   ⟨_, ⟨mapPushoutAdj f⟩⟩

--- a/Mathlib/CategoryTheory/Comma/Over/Pullback.lean
+++ b/Mathlib/CategoryTheory/Comma/Over/Pullback.lean
@@ -159,7 +159,7 @@ def pushoutId {X : C} : pushout (𝟙 X) ≅ 𝟭 _ :=
     (Under.mapId X).symm
 
 /-- pushout commutes with composition (up to natural isomorphism). -/
-def pullbackComp {X Y Z : C} (f : X ⟶ Y) (g : Y ⟶ Z) : pushout (f ≫ g) ≅ pushout f ⋙ pushout g :=
+def pushoutComp {X Y Z : C} (f : X ⟶ Y) (g : Y ⟶ Z) : pushout (f ≫ g) ≅ pushout f ⋙ pushout g :=
   (conjugateIsoEquiv ((mapPushoutAdj _).comp (mapPushoutAdj _)) (mapPushoutAdj _) ).symm
     (mapComp f g).symm
 


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
