### PR TITLE
perf(Normed.Field.Basic): change parent order for `Semifield` and `Field` and reduce priority `toComm(Semi)Ring`

### DIFF
--- a/Mathlib/Algebra/Field/Defs.lean
+++ b/Mathlib/Algebra/Field/Defs.lean
@@ -163,6 +163,9 @@ If the semifield has positive characteristic `p`, our division by zero conventio
 `nnratCast (1 / p) = 1 / 0 = 0`. -/
 class Semifield (K : Type*) extends DivisionSemiring K, CommSemiring K, CommGroupWithZero K
 
+-- see Note [lower instance priority]
+attribute [instance 100] Semifield.toCommSemiring
+
 /-- A `Field` is a `CommRing` with multiplicative inverses for nonzero elements.
 
 An instance of `Field K` includes maps `ratCast : ℚ → K` and `qsmul : ℚ → K → K`.
@@ -174,6 +177,9 @@ If the field has positive characteristic `p`, our division by zero convention fo
 `ratCast (1 / p) = 1 / 0 = 0`. -/
 @[stacks 09FD "first part"]
 class Field (K : Type u) extends DivisionRing K, CommRing K
+
+-- see Note [lower instance priority]
+attribute [instance 100] Field.toCommRing
 
 -- see Note [lower instance priority]
 instance (priority := 100) Field.toSemifield [Field K] : Semifield K := { ‹Field K› with }

--- a/Mathlib/Algebra/Field/Defs.lean
+++ b/Mathlib/Algebra/Field/Defs.lean
@@ -161,7 +161,7 @@ itself). See also note [forgetful inheritance].
 
 If the semifield has positive characteristic `p`, our division by zero convention forces
 `nnratCast (1 / p) = 1 / 0 = 0`. -/
-class Semifield (K : Type*) extends CommSemiring K, DivisionSemiring K, CommGroupWithZero K
+class Semifield (K : Type*) extends DivisionSemiring K, CommSemiring K, CommGroupWithZero K
 
 /-- A `Field` is a `CommRing` with multiplicative inverses for nonzero elements.
 
@@ -173,7 +173,7 @@ See also note [forgetful inheritance].
 If the field has positive characteristic `p`, our division by zero convention forces
 `ratCast (1 / p) = 1 / 0 = 0`. -/
 @[stacks 09FD "first part"]
-class Field (K : Type u) extends CommRing K, DivisionRing K
+class Field (K : Type u) extends DivisionRing K, CommRing K
 
 -- see Note [lower instance priority]
 instance (priority := 100) Field.toSemifield [Field K] : Semifield K := { ‹Field K› with }


### PR DESCRIPTION
Passing through the projection `toComm(Semi)Ring` should not be preferred.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
