### PR TITLE
[Merged by Bors] - fix(ByContra hover): hover over by_contra! gets its doc-string back

### DIFF
--- a/Mathlib/Tactic/ByContra.lean
+++ b/Mathlib/Tactic/ByContra.lean
@@ -40,8 +40,8 @@ example : 1 < 2 := by
 syntax (name := byContra!) "by_contra!" (ppSpace colGt binderIdent)? Term.optType : tactic
 
 macro_rules
-  | `(tactic| by_contra!%$tk $[_%$under]? $[: $ty]?) =>
-    `(tactic| by_contra! $(mkIdentFrom (under.getD tk) `this (canonical := true)):ident $[: $ty]?)
+  | `(tactic| by_contra! $[_%$under]? $[: $ty]?) =>
+    `(tactic| by_contra! $(mkIdent `this):ident $[: $ty]?)
   | `(tactic| by_contra! $e:ident) => `(tactic| (by_contra $e:ident; try push_neg at $e:ident))
   | `(tactic| by_contra! $e:ident : $y) => `(tactic|
        (by_contra! h

--- a/Mathlib/Tactic/ByContra.lean
+++ b/Mathlib/Tactic/ByContra.lean
@@ -40,8 +40,10 @@ example : 1 < 2 := by
 syntax (name := byContra!) "by_contra!" (ppSpace colGt binderIdent)? Term.optType : tactic
 
 macro_rules
-  | `(tactic| by_contra! $[_%$under]? $[: $ty]?) =>
+  | `(tactic| by_contra! $[: $ty]?) =>
     `(tactic| by_contra! $(mkIdent `this):ident $[: $ty]?)
+  | `(tactic| by_contra! _%$under $[: $ty]?) =>
+    `(tactic| by_contra! $(mkIdentFrom under `this):ident $[: $ty]?)
   | `(tactic| by_contra! $e:ident) => `(tactic| (by_contra $e:ident; try push_neg at $e:ident))
   | `(tactic| by_contra! $e:ident : $y) => `(tactic|
        (by_contra! h


### PR DESCRIPTION
Before this change, hovering over `by_contra!` showed `this : ¬?m.45`, i.e., the hover information coming from the implicit `this`.

With this change, the hover information over `by_contra!` is the `by_contra!` doc-string string.

The `by_contra` tactic from `Batteries` still suffers from a similar problem: the hover shows information about a `hole`, rather than the content of the `by_contra` doc-string.

[#mathlib4 > Hover on by_contra! is not helpful @ 💬](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Hover.20on.20by_contra!.20is.20not.20helpful/near/512334655)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
