### PR TITLE
[Merged by Bors] - fix(nolints.yml): move `print Lean version` step after the installation of Lean

### DIFF
--- a/.github/workflows/nolints.yml
+++ b/.github/workflows/nolints.yml
@@ -23,11 +23,6 @@ jobs:
           ## fetch the whole repository, as we want to push to it later
           fetch-depth: 0
 
-      - name: print lean and lake versions
-        run: |
-          lean --version
-          lake --version
-
       - name: prune ProofWidgets .lake
         run: |
           # The ProofWidgets release contains not just the `.js` (which we need in order to build)
@@ -43,6 +38,11 @@ jobs:
           auto-config: false
           use-github-cache: false
           use-mathlib-cache: true
+
+      - name: print lean and lake versions
+        run: |
+          lean --version
+          lake --version
 
       - name: build mathlib
         id: build


### PR DESCRIPTION
Fixes an oversight from #23868, which [made the workflow fail](https://github.com/leanprover-community/mathlib4/actions/runs/14424502470/job/40451294006).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
