### PR TITLE
feat(MeasureTheory): A set is pi-measurable if it belongs to the set that generates the σ-algebra

### DIFF
--- a/Mathlib/MeasureTheory/MeasurableSpace/Constructions.lean
+++ b/Mathlib/MeasureTheory/MeasurableSpace/Constructions.lean
@@ -525,7 +525,7 @@ variable {X : δ → Type*} [MeasurableSpace α]
 instance MeasurableSpace.pi [m : ∀ a, MeasurableSpace (X a)] : MeasurableSpace (∀ a, X a) :=
   ⨆ a, (m a).comap fun b => b a
 
-variable [∀ a, MeasurableSpace (X a)] [MeasurableSpace γ]
+variable [m : ∀ a, MeasurableSpace (X a)] [MeasurableSpace γ]
 
 theorem measurable_pi_iff {g : α → ∀ a, X a} : Measurable g ↔ ∀ a, Measurable fun x => g x a := by
   simp_rw [measurable_iff_comap_le, MeasurableSpace.pi, MeasurableSpace.comap_iSup,
@@ -652,6 +652,13 @@ protected theorem MeasurableSet.pi {s : Set δ} {t : ∀ i : δ, Set (X i)} (hs 
     (ht : ∀ i ∈ s, MeasurableSet (t i)) : MeasurableSet (s.pi t) := by
   rw [pi_def]
   exact MeasurableSet.biInter hs fun i hi => measurable_pi_apply _ (ht i hi)
+
+@[measurability]
+theorem measurableSet_pi_of_single {A : Set (∀ a, X a)} {a : δ}
+    (h : @MeasurableSet _ ((m a).comap (fun b => b a)) A) : MeasurableSet A := by
+  unfold MeasurableSpace.pi
+  rw [MeasurableSpace.measurableSpace_iSup_eq _]
+  exact MeasurableSpace.measurableSet_generateFrom ⟨a, h⟩
 
 protected theorem MeasurableSet.univ_pi [Countable δ] {t : ∀ i : δ, Set (X i)}
     (ht : ∀ i, MeasurableSet (t i)) : MeasurableSet (pi univ t) :=


### PR DESCRIPTION
Small result on measurability of pi-sets that uses the fact that the infimum of σ-algebras is a σ-algebra generated by the set of sets that are measurable by atleast one σ-algebra.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
