### PR TITLE
chore(Canonical): remove bad OrderBot instance

### DIFF
--- a/Mathlib/Algebra/Order/Antidiag/Prod.lean
+++ b/Mathlib/Algebra/Order/Antidiag/Prod.lean
@@ -185,7 +185,7 @@ def sigmaAntidiagonalEquivProd [AddMonoid A] [HasAntidiagonal A] :
 
 variable {A : Type*}
   [AddCommMonoid A] [PartialOrder A] [CanonicallyOrderedAdd A]
-  [LocallyFiniteOrder A] [DecidableEq A]
+  [LocallyFiniteOrder A] [DecidableEq A] [OrderBot A]
 
 /-- In a canonically ordered add monoid, the antidiagonal can be construct by filtering.
 

--- a/Mathlib/Algebra/Order/Group/Finset.lean
+++ b/Mathlib/Algebra/Order/Group/Finset.lean
@@ -98,15 +98,15 @@ lemma sup'_add' (s : Finset ι) (f : ι → M) (a : M) (hs : s.Nonempty) :
 lemma add_sup'' (hs : s.Nonempty) (f : ι → M) (a : M) :
     a + s.sup' hs f = s.sup' hs fun i ↦ a + f i := by simp_rw [add_comm a, Finset.sup'_add']
 
-protected lemma sup_add (hs : s.Nonempty) (f : ι → M) (a : M) :
+protected lemma sup_add [OrderBot M] (hs : s.Nonempty) (f : ι → M) (a : M) :
     s.sup f + a = s.sup fun i ↦ f i + a := by
   rw [← Finset.sup'_eq_sup hs, ← Finset.sup'_eq_sup hs, sup'_add']
 
-protected lemma add_sup (hs : s.Nonempty) (f : ι → M) (a : M) :
+protected lemma add_sup [OrderBot M] (hs : s.Nonempty) (f : ι → M) (a : M) :
     a + s.sup f = s.sup fun i ↦ a + f i := by
   rw [← Finset.sup'_eq_sup hs, ← Finset.sup'_eq_sup hs, add_sup'']
 
-lemma sup_add_sup (hs : s.Nonempty) (ht : t.Nonempty) (f : ι → M) (g : κ → M) :
+lemma sup_add_sup [OrderBot M] (hs : s.Nonempty) (ht : t.Nonempty) (f : ι → M) (g : κ → M) :
     s.sup f + t.sup g = (s ×ˢ t).sup fun ij ↦ f ij.1 + g ij.2 := by
   simp only [Finset.sup_add hs, Finset.add_sup ht, Finset.sup_product_left]
 

--- a/Mathlib/Algebra/Order/Group/Nat.lean
+++ b/Mathlib/Algebra/Order/Group/Nat.lean
@@ -30,6 +30,10 @@ instance instCanonicallyOrderedAdd : CanonicallyOrderedAdd ℕ where
   le_self_add := Nat.le_add_right
   exists_add_of_le := Nat.exists_eq_add_of_le
 
+instance orderBot : OrderBot ℕ where
+  bot := 0
+  bot_le := zero_le
+
 instance instOrderedSub : OrderedSub ℕ := by
   refine ⟨fun m n k ↦ ?_⟩
   induction n generalizing k with

--- a/Mathlib/Algebra/Order/Monoid/Canonical/Basic.lean
+++ b/Mathlib/Algebra/Order/Monoid/Canonical/Basic.lean
@@ -11,7 +11,7 @@ import Mathlib.Data.Finset.Lattice.Fold
 -/
 
 namespace Finset
-variable {ι α : Type*} [AddCommMonoid α] [LinearOrder α] [CanonicallyOrderedAdd α]
+variable {ι α : Type*} [AddCommMonoid α] [LinearOrder α] [CanonicallyOrderedAdd α] [OrderBot α]
   {s : Finset ι} {f : ι → α}
 
 @[simp] lemma sup_eq_zero : s.sup f = 0 ↔ ∀ i ∈ s, f i = 0 := by simp [← bot_eq_zero']

--- a/Mathlib/Algebra/Order/Monoid/Canonical/Defs.lean
+++ b/Mathlib/Algebra/Order/Monoid/Canonical/Defs.lean
@@ -167,13 +167,6 @@ variable [LE α] [CanonicallyOrderedMul α] {a b : α}
 theorem one_le (a : α) : 1 ≤ a :=
   le_self_mul.trans_eq (one_mul _)
 
-@[to_additive]
-instance (priority := 10) CanonicallyOrderedMul.toOrderBot : OrderBot α where
-  bot := 1
-  bot_le := one_le
-
-@[to_additive] theorem bot_eq_one : (⊥ : α) = 1 := rfl
-
 end LE
 
 section Preorder
@@ -181,7 +174,7 @@ variable [Preorder α] [CanonicallyOrderedMul α] {a b : α}
 
 @[to_additive (attr := simp)]
 theorem one_lt_of_gt (h : a < b) : 1 < b :=
-  h.bot_lt
+  (one_le _).trans_lt h
 
 alias LT.lt.pos := pos_of_gt
 @[to_additive existing] alias LT.lt.one_lt := one_lt_of_gt
@@ -191,11 +184,24 @@ end Preorder
 section PartialOrder
 variable [PartialOrder α] [CanonicallyOrderedMul α] {a b c : α}
 
-@[to_additive (attr := simp)] theorem le_one_iff_eq_one : a ≤ 1 ↔ a = 1 := le_bot_iff
-@[to_additive] theorem one_lt_iff_ne_one : 1 < a ↔ a ≠ 1 := bot_lt_iff_ne_bot
-@[to_additive] theorem one_lt_of_ne_one (h : a ≠ 1) : 1 < a := h.bot_lt
-@[to_additive] theorem eq_one_or_one_lt (a : α) : a = 1 ∨ 1 < a := eq_bot_or_bot_lt a
-@[to_additive] lemma one_not_mem_iff {s : Set α} : 1 ∉ s ↔ ∀ x ∈ s, 1 < x := bot_not_mem_iff
+@[to_additive] theorem bot_eq_one [OrderBot α] : (⊥ : α) = 1 :=
+  bot_le.antisymm <| one_le _
+
+@[to_additive (attr := simp)] theorem le_one_iff_eq_one : a ≤ 1 ↔ a = 1 :=
+  ⟨fun h ↦ h.antisymm (one_le _), Eq.le⟩
+
+@[to_additive] theorem one_lt_iff_ne_one : 1 < a ↔ a ≠ 1 :=
+  ⟨fun h ↦ h.ne.symm, (one_le _).lt_of_ne'⟩
+
+@[to_additive] theorem one_lt_of_ne_one (h : a ≠ 1) : 1 < a :=
+  (one_le _).lt_of_ne' h
+
+@[to_additive] theorem eq_one_or_one_lt (a : α) : a = 1 ∨ 1 < a := by
+  rw [one_lt_iff_ne_one]
+  apply em
+
+@[to_additive] lemma one_not_mem_iff {s : Set α} : 1 ∉ s ↔ ∀ x ∈ s, 1 < x :=
+  ⟨fun h _ h' ↦ one_lt_of_ne_one (fun hx ↦ h (hx ▸ h')), fun h h1s ↦ (h _ h1s).ne rfl⟩
 
 alias NE.ne.pos := pos_of_ne_zero
 @[to_additive existing] alias NE.ne.one_lt := one_lt_of_ne_one
@@ -345,7 +351,7 @@ theorem min_one (a : α) : min a 1 = 1 :=
 /-- In a linearly ordered monoid, we are happy for `bot_eq_one` to be a `@[simp]` lemma. -/
 @[to_additive (attr := simp)
   "In a linearly ordered monoid, we are happy for `bot_eq_zero` to be a `@[simp]` lemma"]
-theorem bot_eq_one' : (⊥ : α) = 1 :=
+theorem bot_eq_one' [OrderBot α] : (⊥ : α) = 1 :=
   bot_eq_one
 
 end CanonicallyLinearOrderedCommMonoid

--- a/Mathlib/Algebra/Order/Ring/Finset.lean
+++ b/Mathlib/Algebra/Order/Ring/Finset.lean
@@ -29,7 +29,7 @@ lemma cast_finsetInf' (f : ι → ℕ) (hs) : (↑(s.inf' hs f) : R) = s.inf' hs
   comp_inf'_eq_inf'_comp _ _ cast_min
 
 @[simp, norm_cast]
-lemma cast_finsetSup [CanonicallyOrderedAdd R] (s : Finset ι) (f : ι → ℕ) :
+lemma cast_finsetSup [CanonicallyOrderedAdd R] [OrderBot R] (s : Finset ι) (f : ι → ℕ) :
     (↑(s.sup f) : R) = s.sup fun i ↦ (f i : R) :=
   comp_sup_eq_sup_comp _ cast_max (by simp)
 

--- a/Mathlib/Algebra/Order/Ring/Nat.lean
+++ b/Mathlib/Algebra/Order/Ring/Nat.lean
@@ -32,8 +32,6 @@ instance instIsStrictOrderedRing : IsStrictOrderedRing ℕ where
 instance instLinearOrderedCommMonoidWithZero : LinearOrderedCommMonoidWithZero ℕ where
   zero_le_one := zero_le_one
   mul_le_mul_left _ _ h c := Nat.mul_le_mul_left c h
-  bot := 0
-  bot_le := zero_le
 
 /-! ### Miscellaneous lemmas -/
 

--- a/Mathlib/Algebra/Order/Ring/Nat.lean
+++ b/Mathlib/Algebra/Order/Ring/Nat.lean
@@ -32,6 +32,8 @@ instance instIsStrictOrderedRing : IsStrictOrderedRing ℕ where
 instance instLinearOrderedCommMonoidWithZero : LinearOrderedCommMonoidWithZero ℕ where
   zero_le_one := zero_le_one
   mul_le_mul_left _ _ h c := Nat.mul_le_mul_left c h
+  bot := 0
+  bot_le := zero_le
 
 /-! ### Miscellaneous lemmas -/
 

--- a/Mathlib/Algebra/Order/Ring/Nat.lean
+++ b/Mathlib/Algebra/Order/Ring/Nat.lean
@@ -12,7 +12,7 @@ import Mathlib.Data.Set.Basic
 /-!
 # The natural numbers form an ordered semiring
 
-This file contains the commutative linear orderded semiring instance on the natural numbers.
+This file contains the commutative linear ordered semiring instance on the natural numbers.
 
 See note [foundational algebra order theory].
 -/

--- a/Mathlib/Algebra/Order/Ring/WithTop.lean
+++ b/Mathlib/Algebra/Order/Ring/WithTop.lean
@@ -223,7 +223,7 @@ variable [CommSemiring α] [PartialOrder α] [CanonicallyOrderedAdd α] [PosMulS
   {a a₁ a₂ b₁ b₂ : WithTop α}
 
 @[gcongr]
-protected lemma mul_lt_mul (ha : a₁ < a₂) (hb : b₁ < b₂) : a₁ * b₁ < a₂ * b₂ := by
+protected lemma mul_lt_mul [OrderBot α] (ha : a₁ < a₂) (hb : b₁ < b₂) : a₁ * b₁ < a₂ * b₂ := by
   have := posMulStrictMono_iff_mulPosStrictMono.1 ‹_›
   lift a₁ to α using ha.lt_top.ne
   lift b₁ to α using hb.lt_top.ne
@@ -243,14 +243,16 @@ protected lemma mul_lt_mul (ha : a₁ < a₂) (hb : b₁ < b₂) : a₁ * b₁ <
 
 variable [NoZeroDivisors α] [Nontrivial α] {a b : WithTop α}
 
-protected lemma pow_right_strictMono : ∀ {n : ℕ}, n ≠ 0 → StrictMono fun a : WithTop α ↦ a ^ n
+protected lemma pow_right_strictMono [OrderBot α] :
+    ∀ {n : ℕ}, n ≠ 0 → StrictMono fun a : WithTop α ↦ a ^ n
   | 0, h => absurd rfl h
   | 1, _ => by simpa only [pow_one] using strictMono_id
   | n + 2, _ => fun x y h ↦ by
     simp_rw [pow_succ _ (n + 1)]
     exact WithTop.mul_lt_mul (WithTop.pow_right_strictMono n.succ_ne_zero h) h
 
-@[gcongr] protected lemma pow_lt_pow_left (hab : a < b) {n : ℕ} (hn : n ≠ 0) : a ^ n < b ^ n :=
+@[gcongr] protected lemma pow_lt_pow_left [OrderBot α] (hab : a < b) {n : ℕ} (hn : n ≠ 0) :
+    a ^ n < b ^ n :=
   WithTop.pow_right_strictMono hn hab
 
 end WithTop

--- a/Mathlib/Algebra/Order/SuccPred.lean
+++ b/Mathlib/Algebra/Order/SuccPred.lean
@@ -181,16 +181,16 @@ theorem IsPredLimit.lt_sub_natCast [AddCommGroupWithOne α] [PredSubOrder α]
   hx.isPredPrelimit.lt_sub_natCast hy
 
 theorem IsSuccLimit.natCast_lt [AddMonoidWithOne α] [SuccAddOrder α] [CanonicallyOrderedAdd α]
-    (hx : IsSuccLimit x) : ∀ n : ℕ, n < x := by
+    [OrderBot α] (hx : IsSuccLimit x) : ∀ n : ℕ, n < x := by
   simpa [bot_eq_zero] using hx.add_natCast_lt hx.bot_lt
 
 theorem not_isSuccLimit_natCast [AddMonoidWithOne α] [SuccAddOrder α] [CanonicallyOrderedAdd α]
-    (n : ℕ) : ¬ IsSuccLimit (n : α) :=
+    [OrderBot α] (n : ℕ) : ¬ IsSuccLimit (n : α) :=
   fun h ↦ (h.natCast_lt n).false
 
 @[simp]
 theorem succ_eq_zero [AddZeroClass α] [CanonicallyOrderedAdd α] [One α] [NoMaxOrder α]
-    [SuccAddOrder α] {a : WithBot α} : WithBot.succ a = 0 ↔ a = ⊥ := by
+    [SuccAddOrder α] [OrderBot α] {a : WithBot α} : WithBot.succ a = 0 ↔ a = ⊥ := by
   cases a
   · simp [bot_eq_zero]
   · rename_i a

--- a/Mathlib/Data/DFinsupp/Order.lean
+++ b/Mathlib/Data/DFinsupp/Order.lean
@@ -283,9 +283,9 @@ theorem support_inf : (f ⊓ g).support = f.support ∩ g.support := by
 
 @[simp]
 theorem support_sup : (f ⊔ g).support = f.support ∪ g.support := by
-  ext
-  simp only [Finset.mem_union, mem_support_iff, sup_apply, Ne, ← bot_eq_zero]
-  rw [_root_.sup_eq_bot_iff, not_and_or]
+  ext a
+  simp only [Finset.mem_union, mem_support_iff, sup_apply, Ne, ← nonpos_iff_eq_zero, sup_le_iff,
+    Classical.not_and_iff_not_or_not]
 
 nonrec theorem disjoint_iff : Disjoint f g ↔ Disjoint f.support g.support := by
   rw [disjoint_iff, disjoint_iff, DFinsupp.bot_eq_zero, ← DFinsupp.support_eq_empty,

--- a/Mathlib/Data/Finsupp/Order.lean
+++ b/Mathlib/Data/Finsupp/Order.lean
@@ -294,10 +294,11 @@ theorem support_inf [DecidableEq ι] (f g : ι →₀ α) : (f ⊓ g).support = 
   simp only [← nonpos_iff_eq_zero, min_le_iff, not_or]
 
 @[simp]
-theorem support_sup [DecidableEq ι] (f g : ι →₀ α) : (f ⊔ g).support = f.support ∪ g.support := by
-  ext
-  simp only [Finset.mem_union, mem_support_iff, sup_apply, Ne, ← bot_eq_zero]
-  rw [_root_.sup_eq_bot_iff, not_and_or]
+theorem support_sup [DecidableEq ι] (f g : ι →₀ α) :
+    (f ⊔ g).support = f.support ∪ g.support := by
+  ext a
+  simp only [mem_support_iff, Ne, sup_apply, ← nonpos_iff_eq_zero, sup_le_iff, mem_union,
+    Classical.not_and_iff_not_or_not]
 
 nonrec theorem disjoint_iff {f g : ι →₀ α} : Disjoint f g ↔ Disjoint f.support g.support := by
   classical

--- a/Mathlib/SetTheory/Cardinal/Order.lean
+++ b/Mathlib/SetTheory/Cardinal/Order.lean
@@ -300,7 +300,9 @@ instance canonicallyOrderedAdd : CanonicallyOrderedAdd Cardinal.{u} where
 instance isOrderedRing : IsOrderedRing Cardinal.{u} :=
   CanonicallyOrderedAdd.toIsOrderedRing
 
-instance orderBot : OrderBot Cardinal.{u} := inferInstance
+instance orderBot : OrderBot Cardinal.{u} where
+  bot := 0
+  bot_le := zero_le
 
 instance noZeroDivisors : NoZeroDivisors Cardinal.{u} where
   eq_zero_or_eq_zero_of_mul_eq_zero := fun {a b} =>


### PR DESCRIPTION
We remove the bad `CanonicallyOrderedMul.toOrderBot` instance and make necessary changes. (See [Zulip](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/bot_eq_zero.20in.20complete.20lattice/with/512332408))

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
