### PR TITLE
[Merged by Bors] - feat(Combinatorics/SimpleGraph): add IsCompleteMultipartite definition and related results

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2597,6 +2597,7 @@ import Mathlib.Combinatorics.SimpleGraph.Bipartite
 import Mathlib.Combinatorics.SimpleGraph.Circulant
 import Mathlib.Combinatorics.SimpleGraph.Clique
 import Mathlib.Combinatorics.SimpleGraph.Coloring
+import Mathlib.Combinatorics.SimpleGraph.CompleteMultipartite
 import Mathlib.Combinatorics.SimpleGraph.ConcreteColorings
 import Mathlib.Combinatorics.SimpleGraph.Connectivity.Represents
 import Mathlib.Combinatorics.SimpleGraph.Connectivity.Subgraph

--- a/Mathlib/Combinatorics/SimpleGraph/CompleteMultipartite.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/CompleteMultipartite.lean
@@ -1,0 +1,107 @@
+/-
+Copyright (c) 2024 John Talbot and Lian Bremner Tattersall. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: John Talbot, Lian Bremner Tattersall
+-/
+import Mathlib.Combinatorics.SimpleGraph.Coloring
+
+/-!
+# Complete Multipartite Graphs
+
+A graph is complete multipartite iff non-adjacency is transitive.
+
+## Main declarations
+
+* `SimpleGraph.IsCompleteMultipartite`: predicate for a graph to be complete-multi-partite.
+
+* `SimpleGraph.IsCompleteMultipartite.setoid`: the `Setoid` given by non-adjacency.
+
+* `SimpleGraph.IsCompleteMultipartite.iso`: the graph isomorphism from a graph that
+  `IsCompleteMultipartite` to the corresponding `completeMultipartiteGraph`.
+
+* `SimpleGraph.IsP2Complement`: predicate for three vertices to be a witness to
+   non-complete-multi-partite-ness of a graph G. (The name refers to the fact that the three
+   vertices form the complement of a path of length two.)
+-/
+
+universe u
+namespace SimpleGraph
+variable {α : Type u}
+
+/-- `G` is `IsCompleteMultipartite` iff non-adjacency is transitive -/
+abbrev IsCompleteMultipartite (G : SimpleGraph α) : Prop := Transitive (¬ G.Adj · ·)
+
+variable {G : SimpleGraph α}
+/-- The setoid given by non-adjacency -/
+abbrev IsCompleteMultipartite.setoid (h : G.IsCompleteMultipartite) : Setoid α :=
+    ⟨(¬ G.Adj · ·), ⟨G.loopless , fun h' ↦ by rwa [adj_comm] at h', fun h1 h2 ↦ h h1 h2⟩⟩
+
+lemma completeMultipartiteGraph.isCompleteMultipartite {ι : Type*} (V : ι → Type*) :
+    (completeMultipartiteGraph V).IsCompleteMultipartite := by
+  intro
+  aesop
+
+/-- The graph isomorphism from a graph `G` that `IsCompleteMultipartite` to the corresponding
+`completeMultipartiteGraph` -/
+def IsCompleteMultipartite.iso (h : G.IsCompleteMultipartite) :
+    G ≃g completeMultipartiteGraph (fun (c : Quotient h.setoid) ↦ {x // h.setoid.r c.out x}) where
+  toFun := fun x ↦ ⟨_, ⟨_, Quotient.mk_out x⟩⟩
+  invFun := fun ⟨_, x⟩ ↦  x.1
+  left_inv := fun _ ↦ rfl
+  right_inv := fun ⟨_, x⟩ ↦ Sigma.subtype_ext (Quotient.mk_eq_iff_out.2 <| h.setoid.symm x.2) rfl
+  map_rel_iff' := by
+    simp_rw [Equiv.coe_fn_mk, comap_adj, top_adj, ne_eq, Quotient.eq]
+    intros
+    change ¬¬ G.Adj _ _ ↔ _
+    rw [not_not]
+
+lemma isCompleteMultipartite_iff : G.IsCompleteMultipartite ↔ ∃ (ι : Type u) (V : ι → Type u)
+    (_ : ∀ i, Nonempty (V i)), Nonempty (G ≃g (completeMultipartiteGraph V)) := by
+  constructor <;> intro h
+  · exact ⟨_, _, fun _ ↦ ⟨_, h.setoid.refl _⟩, ⟨h.iso⟩⟩
+  · obtain ⟨_, _, _, ⟨e⟩⟩ := h
+    intro _ _ _ h1 h2
+    rw [← e.map_rel_iff] at *
+    exact (completeMultipartiteGraph.isCompleteMultipartite _) h1 h2
+
+lemma IsCompleteMultipartite.colorable_of_cliqueFree {n : ℕ} (h : G.IsCompleteMultipartite)
+    (hc : G.CliqueFree n) : G.Colorable (n - 1) :=
+    (completeMultipartiteGraph.colorable_of_cliqueFree _ (fun _ ↦ ⟨_, h.setoid.refl _⟩)
+          <| hc.comap h.iso.symm.toEmbedding).of_embedding h.iso.toEmbedding
+
+variable (G) in
+/--
+The vertices `v, w₁, w₂` form an `IsP2Complement` in `G` iff `w₁w₂` is the only edge present between
+these three vertices. It is a witness to the non-complete-multipartite-ness of `G`
+-/
+structure IsP2Complement (v w₁ w₂ : α) : Prop where
+  adj : G.Adj w₁ w₂
+  not_adj : ¬ G.Adj v w₁ ∧ ¬ G.Adj v w₂
+
+namespace IsP2Complement
+
+variable {v w₁ w₂ : α}
+
+lemma ne (h2 : G.IsP2Complement v w₁ w₂) : v ≠ w₁ ∧ v ≠ w₂ :=
+  ⟨fun h ↦ h2.not_adj.2 (h.symm ▸ h2.adj), fun h ↦ h2.not_adj.1 (h ▸ h2.adj.symm)⟩
+
+lemma symm (h : G.IsP2Complement v w₁ w₂) : G.IsP2Complement v w₂ w₁ := by
+  obtain ⟨h1, ⟨h2, h3⟩⟩ := h
+  exact ⟨h1.symm, ⟨h3, h2⟩⟩
+
+end IsP2Complement
+
+lemma exists_isP2Complement_of_not_isCompleteMultipartite (h : ¬ IsCompleteMultipartite G) :
+    ∃ v w₁ w₂, G.IsP2Complement v w₁ w₂ := by
+  rw [IsCompleteMultipartite, Transitive] at h
+  push_neg at h
+  obtain ⟨_, _, _, h1, h2, h3⟩ := h
+  rw [adj_comm] at h1
+  exact ⟨_, _, _, h3, h1, h2⟩
+
+lemma not_isCompleteMultipartite_iff_exists_isP2Complement :
+    ¬ IsCompleteMultipartite G ↔ ∃ v w₁ w₂, G.IsP2Complement v w₁ w₂ :=
+  ⟨fun h ↦ G.exists_isP2Complement_of_not_isCompleteMultipartite h,
+      fun ⟨_, _, _, h1, h2, h3⟩ ↦ fun h ↦ h (by rwa [adj_comm] at h2) h3 h1⟩
+
+end SimpleGraph

--- a/Mathlib/Combinatorics/SimpleGraph/CompleteMultipartite.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/CompleteMultipartite.lean
@@ -116,17 +116,17 @@ def IsPathGraph3Compl.pathGraph3ComplEmbedding {v w₁ w₂ : α} (h : G.IsPathG
     | 1 => v
     | 2 => w₂
   inj' := by
-    intro x y _
+    intro _ _ _
     have := h.ne
     have := h.adj.ne
     aesop
   map_rel_iff' := by
-    intro x y
+    intro _ _
     simp_rw [Function.Embedding.coeFn_mk, compl_adj, ne_eq, pathGraph_adj, not_or]
-    have h1 := h.adj
-    have ⟨h2, h3⟩ := h.not_adj
-    have ⟨h4, h5⟩: ¬ G.Adj w₁ v ∧ ¬ G.Adj w₂ v := by rw [adj_comm] at h2 h3; exact ⟨h2, h3⟩
-    have h6 := h1.symm
+    have := h.adj
+    have := h.adj.symm
+    have ⟨h1, h2⟩ := h.not_adj
+    have ⟨_, _⟩ : ¬ G.Adj w₁ v ∧ ¬ G.Adj w₂ v := by rw [adj_comm] at h1 h2; exact ⟨h1, h2⟩
     aesop
 
 /-- Embedding of `pathGraph 3` into `G` that is not complete-multipartite. -/

--- a/Mathlib/Combinatorics/SimpleGraph/CompleteMultipartite.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/CompleteMultipartite.lean
@@ -129,6 +129,7 @@ def IsPathGraph3Compl.pathGraph3ComplEmbedding {v w₁ w₂ : α} (h : G.IsPathG
     have h6 := h1.symm
     aesop
 
+/-- Embedding of `pathGraph 3` into `G` that is not complete-multipartite. -/
 noncomputable def pathGraph3ComplEmbeddingOf (h : ¬ G.IsCompleteMultipartite) :
     (pathGraph 3)ᶜ ↪g G :=
   IsPathGraph3Compl.pathGraph3ComplEmbedding

--- a/Mathlib/Combinatorics/SimpleGraph/CompleteMultipartite.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/CompleteMultipartite.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: John Talbot, Lian Bremner Tattersall
 -/
 import Mathlib.Combinatorics.SimpleGraph.Coloring
+import Mathlib.Combinatorics.SimpleGraph.Hasse
 
 /-!
 # Complete Multipartite Graphs
@@ -19,9 +20,9 @@ A graph is complete multipartite iff non-adjacency is transitive.
 * `SimpleGraph.IsCompleteMultipartite.iso`: the graph isomorphism from a graph that
   `IsCompleteMultipartite` to the corresponding `completeMultipartiteGraph`.
 
-* `SimpleGraph.IsP2Complement`: predicate for three vertices to be a witness to
+* `SimpleGraph.IsPathGraph3Compl`: predicate for three vertices to be a witness to
    non-complete-multi-partite-ness of a graph G. (The name refers to the fact that the three
-   vertices form the complement of a path of length two.)
+   vertices form the complement of `pathGraph 3`.)
 -/
 
 universe u
@@ -29,12 +30,12 @@ namespace SimpleGraph
 variable {α : Type u}
 
 /-- `G` is `IsCompleteMultipartite` iff non-adjacency is transitive -/
-abbrev IsCompleteMultipartite (G : SimpleGraph α) : Prop := Transitive (¬ G.Adj · ·)
+def IsCompleteMultipartite (G : SimpleGraph α) : Prop := Transitive (¬ G.Adj · ·)
 
 variable {G : SimpleGraph α}
 /-- The setoid given by non-adjacency -/
-abbrev IsCompleteMultipartite.setoid (h : G.IsCompleteMultipartite) : Setoid α :=
-    ⟨(¬ G.Adj · ·), ⟨G.loopless , fun h' ↦ by rwa [adj_comm] at h', fun h1 h2 ↦ h h1 h2⟩⟩
+def IsCompleteMultipartite.setoid (h : G.IsCompleteMultipartite) : Setoid α :=
+    ⟨(¬ G.Adj · ·), ⟨G.loopless, fun h' ↦ by rwa [adj_comm] at h', fun h1 h2 ↦ h h1 h2⟩⟩
 
 lemma completeMultipartiteGraph.isCompleteMultipartite {ι : Type*} (V : ι → Type*) :
     (completeMultipartiteGraph V).IsCompleteMultipartite := by
@@ -62,7 +63,7 @@ lemma isCompleteMultipartite_iff : G.IsCompleteMultipartite ↔ ∃ (ι : Type u
   · obtain ⟨_, _, _, ⟨e⟩⟩ := h
     intro _ _ _ h1 h2
     rw [← e.map_rel_iff] at *
-    exact (completeMultipartiteGraph.isCompleteMultipartite _) h1 h2
+    exact completeMultipartiteGraph.isCompleteMultipartite _ h1 h2
 
 lemma IsCompleteMultipartite.colorable_of_cliqueFree {n : ℕ} (h : G.IsCompleteMultipartite)
     (hc : G.CliqueFree n) : G.Colorable (n - 1) :=
@@ -71,37 +72,80 @@ lemma IsCompleteMultipartite.colorable_of_cliqueFree {n : ℕ} (h : G.IsComplete
 
 variable (G) in
 /--
-The vertices `v, w₁, w₂` form an `IsP2Complement` in `G` iff `w₁w₂` is the only edge present between
-these three vertices. It is a witness to the non-complete-multipartite-ness of `G`
+The vertices `v, w₁, w₂` form an `IsPathGraph3Compl` in `G` iff `w₁w₂` is the only edge present
+between these three vertices. It is a witness to the non-complete-multipartite-ness of `G`
 -/
-structure IsP2Complement (v w₁ w₂ : α) : Prop where
+structure IsPathGraph3Compl (v w₁ w₂ : α) : Prop where
   adj : G.Adj w₁ w₂
   not_adj : ¬ G.Adj v w₁ ∧ ¬ G.Adj v w₂
 
-namespace IsP2Complement
+namespace IsPathGraph3Compl
 
 variable {v w₁ w₂ : α}
 
-lemma ne (h2 : G.IsP2Complement v w₁ w₂) : v ≠ w₁ ∧ v ≠ w₂ :=
+lemma ne (h2 : G.IsPathGraph3Compl v w₁ w₂) : v ≠ w₁ ∧ v ≠ w₂ :=
   ⟨fun h ↦ h2.not_adj.2 (h.symm ▸ h2.adj), fun h ↦ h2.not_adj.1 (h ▸ h2.adj.symm)⟩
 
-lemma symm (h : G.IsP2Complement v w₁ w₂) : G.IsP2Complement v w₂ w₁ := by
+lemma symm (h : G.IsPathGraph3Compl v w₁ w₂) : G.IsPathGraph3Compl v w₂ w₁ := by
   obtain ⟨h1, ⟨h2, h3⟩⟩ := h
   exact ⟨h1.symm, ⟨h3, h2⟩⟩
 
-end IsP2Complement
+end IsPathGraph3Compl
 
-lemma exists_isP2Complement_of_not_isCompleteMultipartite (h : ¬ IsCompleteMultipartite G) :
-    ∃ v w₁ w₂, G.IsP2Complement v w₁ w₂ := by
+lemma exists_isPathGraph3Compl_of_not_isCompleteMultipartite (h : ¬ IsCompleteMultipartite G) :
+    ∃ v w₁ w₂, G.IsPathGraph3Compl v w₁ w₂ := by
   rw [IsCompleteMultipartite, Transitive] at h
   push_neg at h
   obtain ⟨_, _, _, h1, h2, h3⟩ := h
   rw [adj_comm] at h1
   exact ⟨_, _, _, h3, h1, h2⟩
 
-lemma not_isCompleteMultipartite_iff_exists_isP2Complement :
-    ¬ IsCompleteMultipartite G ↔ ∃ v w₁ w₂, G.IsP2Complement v w₁ w₂ :=
-  ⟨fun h ↦ G.exists_isP2Complement_of_not_isCompleteMultipartite h,
-      fun ⟨_, _, _, h1, h2, h3⟩ ↦ fun h ↦ h (by rwa [adj_comm] at h2) h3 h1⟩
+lemma not_isCompleteMultipartite_iff_exists_isPathGraph3Compl :
+    ¬ IsCompleteMultipartite G ↔ ∃ v w₁ w₂, G.IsPathGraph3Compl v w₁ w₂ :=
+  ⟨fun h ↦ G.exists_isPathGraph3Compl_of_not_isCompleteMultipartite h,
+   fun ⟨_, _, _, h1, h2, h3⟩ ↦ fun h ↦ h (by rwa [adj_comm] at h2) h3 h1⟩
+
+/--
+Any `IsPathGraph3Compl` in `G` gives rise to a graph embedding of the complement of the path graph
+-/
+def IsPathGraph3Compl.pathGraph3ComplEmbedding {v w₁ w₂ : α} (h : G.IsPathGraph3Compl v w₁ w₂) :
+    (pathGraph 3)ᶜ ↪g G where
+  toFun := fun x ↦
+    match x with
+    | 0 => w₁
+    | 1 => v
+    | 2 => w₂
+  inj' := by
+    intro x y _
+    have := h.ne
+    have := h.adj.ne
+    aesop
+  map_rel_iff' := by
+    intro x y
+    simp_rw [Function.Embedding.coeFn_mk, compl_adj, ne_eq, pathGraph_adj, not_or]
+    have h1 := h.adj
+    have ⟨h2, h3⟩ := h.not_adj
+    have ⟨h4, h5⟩: ¬ G.Adj w₁ v ∧ ¬ G.Adj w₂ v := by rw [adj_comm] at h2 h3; exact ⟨h2, h3⟩
+    have h6 := h1.symm
+    aesop
+
+noncomputable def pathGraph3ComplEmbeddingOf (h : ¬ G.IsCompleteMultipartite) :
+    (pathGraph 3)ᶜ ↪g G :=
+  IsPathGraph3Compl.pathGraph3ComplEmbedding
+    (exists_isPathGraph3Compl_of_not_isCompleteMultipartite h).choose_spec.choose_spec.choose_spec
+
+lemma not_isCompleteMultipartite_of_pathGraph3ComplEmbedding (e : (pathGraph 3)ᶜ ↪g G) :
+    ¬ IsCompleteMultipartite G := by
+  intro h
+  have h0 : ¬ G.Adj (e 0) (e 1) := by simp [pathGraph_adj]
+  have h1 : ¬ G.Adj (e 1) (e 2) := by simp [pathGraph_adj]
+  have h2 : G.Adj (e 0) (e 2) := by simp [pathGraph_adj]
+  exact h h0 h1 h2
+
+theorem IsCompleteMultipartite.comap {β : Type*} {H : SimpleGraph β} (f : H ↪g G) :
+    G.IsCompleteMultipartite → H.IsCompleteMultipartite := by
+  intro h; contrapose h
+  exact not_isCompleteMultipartite_of_pathGraph3ComplEmbedding
+          <| f.comp (pathGraph3ComplEmbeddingOf h)
 
 end SimpleGraph


### PR DESCRIPTION
A graph is complete multipartite if non-adjacency is transitive. 

We add this definition, the associated Setoid, and the graph isomorphism to the corresponding completeMultipartiteGraph. 

We also add the definition of a minimal witness to non-complete-multipartiteness: IsP2Complement. 

We will need this for our proof of the Andrásfai–Erdős–Sós theorem, where the interesting case is when the graph is not complete-multipartite.


Co-authored-by: Lian Tattersall <lian.tattersall.20@alumni.ucl.ac.uk>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
