### PR TITLE
[Merged by Bors] - chore: remove TODO from docstring

### DIFF
--- a/Mathlib/Algebra/Algebra/Operations.lean
+++ b/Mathlib/Algebra/Algebra/Operations.lean
@@ -69,10 +69,10 @@ section Module
 variable {R : Type u} [Semiring R] {A : Type v} [Semiring A] [Module R A]
 
 -- TODO: Why is this in a file about `Algebra`?
-/-- `1 : Submodule R A` is the submodule `R ∙ 1` of A.
-TODO: potentially change this back to `LinearMap.range (Algebra.linearMap R A)`
-once a version of `Algebra` without the `commutes'` field is introduced.
-See issue https://github.com/leanprover-community/mathlib4/issues/18110.
+-- TODO: potentially change this back to `LinearMap.range (Algebra.linearMap R A)`
+-- once a version of `Algebra` without the `commutes'` field is introduced.
+-- See issue https://github.com/leanprover-community/mathlib4/issues/18110.
+/-- `1 : Submodule R A` is the submodule `R ∙ 1` of `A`.
 -/
 instance one : One (Submodule R A) :=
   ⟨LinearMap.range (LinearMap.toSpanSingleton R A 1)⟩


### PR DESCRIPTION
A docstring is surely not the place for a technical TODO involving an implementation issue.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

I've moved it outside. Also added single quotes around `A` in the docstring.
