### PR TITLE
fix(Algebra): `MulMemClass.mul_mem` should not be `aesop safe`

### DIFF
--- a/Mathlib/Algebra/Group/Subsemigroup/Defs.lean
+++ b/Mathlib/Algebra/Group/Subsemigroup/Defs.lean
@@ -70,7 +70,9 @@ export AddMemClass (add_mem)
 
 attribute [to_additive] MulMemClass
 
-attribute [aesop safe apply (rule_sets := [SetLike])] mul_mem add_mem
+-- `mul_mem` is not the only way to prove `a * b ∈ s` (counterexample: `Ideal.mul_mem_left`)
+-- so we have to add a `unsafe apply` attribute for `aesop`.
+attribute [aesop unsafe apply (rule_sets := [SetLike])] mul_mem add_mem
 
 /-- A subsemigroup of a magma `M` is a subset closed under multiplication. -/
 structure Subsemigroup (M : Type*) [Mul M] where

--- a/Mathlib/RingTheory/Ideal/Defs.lean
+++ b/Mathlib/RingTheory/Ideal/Defs.lean
@@ -54,9 +54,11 @@ protected theorem add_mem : a ∈ I → b ∈ I → a + b ∈ I :=
 
 variable (a)
 
+@[aesop unsafe apply (rule_sets := [SetLike])]
 theorem mul_mem_left : b ∈ I → a * b ∈ I :=
   Submodule.smul_mem I a
 
+@[aesop unsafe apply (rule_sets := [SetLike])]
 theorem mul_mem_right {α} {a : α} (b : α) [Semiring α] (I : Ideal α) [I.IsTwoSided]
     (h : a ∈ I) : a * b ∈ I :=
   IsTwoSided.mul_mem_of_left b h


### PR DESCRIPTION
The `@[aesop safe apply]` attribute only applies to implications that preserve provability. So for `mul_mem (ha : a ∈ s) (hb : b ∈ s) : a * b ∈ s`, there are ways to prove `a * b ∈ s` while `b ∉ s`, such as when `s` is an ideal and `a ∈ s`.

So, instead give `MulMemClass.mul_mem` and `AddMemClass.add_mem` the unsafe attribute, and add `Ideal.mul_mem_left` and `Ideal.mul_mem_right` to the aesop with the same `unsafe` attribute. Now we can prove membership of ideals a bit more easily.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
