### PR TITLE
[Merged by Bors] - feat(RingTheory/Coalgebra/Equiv, RingTheory/Bialgebra/Equiv): constructors for coalgebra and bialgebra equivalences

### DIFF
--- a/Mathlib/RingTheory/Bialgebra/Equiv.lean
+++ b/Mathlib/RingTheory/Bialgebra/Equiv.lean
@@ -282,8 +282,9 @@ theorem ofBialgHom_symm (f : A →ₐc[R] B) (g : B →ₐc[R] A) (h₁ h₂) :
   rfl
 
 /-- Promotes a bijective coalgebra homomorphism to a coalgebra equivalence. -/
-noncomputable def ofBijective (f : A →ₐc[R] B) (hf : Function.Bijective f) : A ≃ₐc[R] B :=
-  { AlgEquiv.ofBijective (f : A →ₐ[R] B) hf, f with }
+noncomputable def ofBijective (f : A →ₐc[R] B) (hf : Function.Bijective f) : A ≃ₐc[R] B where
+  __ := f
+  __ := AlgEquiv.ofBijective (f : A →ₐ[R] B) hf
 
 @[simp]
 theorem coe_ofBijective {f : A →ₐc[R] B} {hf : Function.Bijective f} :

--- a/Mathlib/RingTheory/Bialgebra/Equiv.lean
+++ b/Mathlib/RingTheory/Bialgebra/Equiv.lean
@@ -287,7 +287,7 @@ noncomputable def ofBijective {f : A →ₐc[R] B} (hf : Function.Bijective f) :
   __ := AlgEquiv.ofBijective (f : A →ₐ[R] B) hf
 
 @[simp]
-theorem coe_ofBijective {f : A →ₐc[R] B} {hf : Function.Bijective f} :
+theorem coe_ofBijective {f : A →ₐc[R] B} (hf : Function.Bijective f) :
     (BialgEquiv.ofBijective hf : A → B) = f :=
   rfl
 

--- a/Mathlib/RingTheory/Bialgebra/Equiv.lean
+++ b/Mathlib/RingTheory/Bialgebra/Equiv.lean
@@ -260,12 +260,12 @@ theorem coe_toEquiv_trans : (e₁₂ : A ≃ B).trans e₂₃ = (e₁₂.trans e
 
 /-- If an coalgebra morphism has an inverse, it is an coalgebra isomorphism. -/
 def ofBialgHom (f : A →ₐc[R] B) (g : B →ₐc[R] A) (h₁ : f.comp g = BialgHom.id R B)
-    (h₂ : g.comp f = BialgHom.id R A) : A ≃ₐc[R] B :=
-  { f with
-    toFun := f
-    invFun := g
-    left_inv := BialgHom.ext_iff.1 h₂
-    right_inv := BialgHom.ext_iff.1 h₁ }
+    (h₂ : g.comp f = BialgHom.id R A) : A ≃ₐc[R] B where
+  __ := f
+  toFun := f
+  invFun := g
+  left_inv := BialgHom.ext_iff.1 h₂
+  right_inv := BialgHom.ext_iff.1 h₁
 
 @[simp]
 theorem coe_bialgHom_ofBialgHom (f : A →ₐc[R] B) (g : B →ₐc[R] A) (h₁ h₂) :

--- a/Mathlib/RingTheory/Bialgebra/Equiv.lean
+++ b/Mathlib/RingTheory/Bialgebra/Equiv.lean
@@ -281,18 +281,18 @@ theorem ofBialgHom_symm (f : A →ₐc[R] B) (g : B →ₐc[R] A) (h₁ h₂) :
     (ofBialgHom f g h₁ h₂).symm = ofBialgHom g f h₂ h₁ :=
   rfl
 
+variable {f : A →ₐc[R] B} (hf : Function.Bijective f)
+
 /-- Promotes a bijective coalgebra homomorphism to a coalgebra equivalence. -/
-noncomputable def ofBijective {f : A →ₐc[R] B} (hf : Function.Bijective f) : A ≃ₐc[R] B where
+noncomputable def ofBijective : A ≃ₐc[R] B where
   __ := f
   __ := AlgEquiv.ofBijective (f : A →ₐ[R] B) hf
 
 @[simp]
-theorem coe_ofBijective {f : A →ₐc[R] B} (hf : Function.Bijective f) :
-    (BialgEquiv.ofBijective hf : A → B) = f :=
+theorem coe_ofBijective : (BialgEquiv.ofBijective hf : A → B) = f :=
   rfl
 
-theorem ofBijective_apply {f : A →ₐc[R] B} {hf : Function.Bijective f} (a : A) :
-    (BialgEquiv.ofBijective hf) a = f a :=
+theorem ofBijective_apply (a : A) : (BialgEquiv.ofBijective hf) a = f a :=
   rfl
 
 end

--- a/Mathlib/RingTheory/Bialgebra/Equiv.lean
+++ b/Mathlib/RingTheory/Bialgebra/Equiv.lean
@@ -289,8 +289,5 @@ noncomputable def ofBijective : A ≃ₐc[R] B where
 theorem coe_ofBijective : (BialgEquiv.ofBijective hf : A → B) = f :=
   rfl
 
-theorem ofBijective_apply (a : A) : (BialgEquiv.ofBijective hf) a = f a :=
-  rfl
-
 end
 end BialgEquiv

--- a/Mathlib/RingTheory/Bialgebra/Equiv.lean
+++ b/Mathlib/RingTheory/Bialgebra/Equiv.lean
@@ -282,17 +282,17 @@ theorem ofBialgHom_symm (f : A →ₐc[R] B) (g : B →ₐc[R] A) (h₁ h₂) :
   rfl
 
 /-- Promotes a bijective coalgebra homomorphism to a coalgebra equivalence. -/
-noncomputable def ofBijective (f : A →ₐc[R] B) (hf : Function.Bijective f) : A ≃ₐc[R] B where
+noncomputable def ofBijective {f : A →ₐc[R] B} (hf : Function.Bijective f) : A ≃ₐc[R] B where
   __ := f
   __ := AlgEquiv.ofBijective (f : A →ₐ[R] B) hf
 
 @[simp]
 theorem coe_ofBijective {f : A →ₐc[R] B} {hf : Function.Bijective f} :
-    (BialgEquiv.ofBijective f hf : A → B) = f :=
+    (BialgEquiv.ofBijective hf : A → B) = f :=
   rfl
 
 theorem ofBijective_apply {f : A →ₐc[R] B} {hf : Function.Bijective f} (a : A) :
-    (BialgEquiv.ofBijective f hf) a = f a :=
+    (BialgEquiv.ofBijective hf) a = f a :=
   rfl
 
 end

--- a/Mathlib/RingTheory/Bialgebra/Equiv.lean
+++ b/Mathlib/RingTheory/Bialgebra/Equiv.lean
@@ -274,7 +274,7 @@ theorem coe_bialgHom_ofBialgHom (f : A →ₐc[R] B) (g : B →ₐc[R] A) (h₁ 
 
 @[simp]
 theorem ofBialgHom_coe_bialgHom (f : A →ₐc[R] B) (g : B →ₐc[R] A) (h₁ h₂) :
-    ofBialgHom (↑f) g h₁ h₂ = f := by
+    ofBialgHom f g h₁ h₂ = f := by
   ext; simp
 
 theorem ofBialgHom_symm (f : A →ₐc[R] B) (g : B →ₐc[R] A) (h₁ h₂) :

--- a/Mathlib/RingTheory/Bialgebra/Equiv.lean
+++ b/Mathlib/RingTheory/Bialgebra/Equiv.lean
@@ -268,14 +268,9 @@ def ofBialgHom (f : A →ₐc[R] B) (g : B →ₐc[R] A) (h₁ : f.comp g = Bial
   right_inv := BialgHom.ext_iff.1 h₁
 
 @[simp]
-theorem coe_bialgHom_ofBialgHom (f : A →ₐc[R] B) (g : B →ₐc[R] A) (h₁ h₂) :
-    ↑(ofBialgHom f g h₁ h₂) = f :=
+theorem coe_ofBialgHom (f : A →ₐc[R] B) (g : B →ₐc[R] A) (h₁ h₂) :
+    ofBialgHom f g h₁ h₂ = f :=
   rfl
-
-@[simp]
-theorem ofBialgHom_coe_bialgHom (f : A →ₐc[R] B) (g : B →ₐc[R] A) (h₁ h₂) :
-    ofBialgHom f g h₁ h₂ = f := by
-  ext; simp
 
 theorem ofBialgHom_symm (f : A →ₐc[R] B) (g : B →ₐc[R] A) (h₁ h₂) :
     (ofBialgHom f g h₁ h₂).symm = ofBialgHom g f h₂ h₁ :=

--- a/Mathlib/RingTheory/Bialgebra/Equiv.lean
+++ b/Mathlib/RingTheory/Bialgebra/Equiv.lean
@@ -279,7 +279,9 @@ theorem ofBialgHom_symm (f : A →ₐc[R] B) (g : B →ₐc[R] A) (h₁ h₂) :
 variable {f : A →ₐc[R] B} (hf : Function.Bijective f)
 
 /-- Promotes a bijective coalgebra homomorphism to a coalgebra equivalence. -/
+@[simps apply]
 noncomputable def ofBijective : A ≃ₐc[R] B where
+  toFun := f
   __ := f
   __ := AlgEquiv.ofBijective (f : A →ₐ[R] B) hf
 

--- a/Mathlib/RingTheory/Bialgebra/Equiv.lean
+++ b/Mathlib/RingTheory/Bialgebra/Equiv.lean
@@ -259,7 +259,6 @@ theorem coe_toEquiv_trans : (e₁₂ : A ≃ B).trans e₂₃ = (e₁₂.trans e
   rfl
 
 /-- If an coalgebra morphism has an inverse, it is an coalgebra isomorphism. -/
-@[simps]
 def ofBialgHom (f : A →ₐc[R] B) (g : B →ₐc[R] A) (h₁ : f.comp g = BialgHom.id R B)
     (h₂ : g.comp f = BialgHom.id R A) : A ≃ₐc[R] B :=
   { f with
@@ -268,6 +267,7 @@ def ofBialgHom (f : A →ₐc[R] B) (g : B →ₐc[R] A) (h₁ : f.comp g = Bial
     left_inv := BialgHom.ext_iff.1 h₂
     right_inv := BialgHom.ext_iff.1 h₁ }
 
+@[simp]
 theorem coe_bialgHom_ofBialgHom (f : A →ₐc[R] B) (g : B →ₐc[R] A) (h₁ h₂) :
     ↑(ofBialgHom f g h₁ h₂) = f :=
   rfl

--- a/Mathlib/RingTheory/Bialgebra/Equiv.lean
+++ b/Mathlib/RingTheory/Bialgebra/Equiv.lean
@@ -258,5 +258,41 @@ theorem trans_toBialgHom :
 theorem coe_toEquiv_trans : (e₁₂ : A ≃ B).trans e₂₃ = (e₁₂.trans e₂₃ : A ≃ C) :=
   rfl
 
+/-- If an coalgebra morphism has an inverse, it is an coalgebra isomorphism. -/
+@[simps]
+def ofBialgHom (f : A →ₐc[R] B) (g : B →ₐc[R] A) (h₁ : f.comp g = BialgHom.id R B)
+    (h₂ : g.comp f = BialgHom.id R A) : A ≃ₐc[R] B :=
+  { f with
+    toFun := f
+    invFun := g
+    left_inv := BialgHom.ext_iff.1 h₂
+    right_inv := BialgHom.ext_iff.1 h₁ }
+
+theorem coe_bialgHom_ofBialgHom (f : A →ₐc[R] B) (g : B →ₐc[R] A) (h₁ h₂) :
+    ↑(ofBialgHom f g h₁ h₂) = f :=
+  rfl
+
+@[simp]
+theorem ofBialgHom_coe_bialgHom (f : A →ₐc[R] B) (g : B →ₐc[R] A) (h₁ h₂) :
+    ofBialgHom (↑f) g h₁ h₂ = f := by
+  ext; simp
+
+theorem ofBialgHom_symm (f : A →ₐc[R] B) (g : B →ₐc[R] A) (h₁ h₂) :
+    (ofBialgHom f g h₁ h₂).symm = ofBialgHom g f h₂ h₁ :=
+  rfl
+
+/-- Promotes a bijective coalgebra homomorphism to a coalgebra equivalence. -/
+noncomputable def ofBijective (f : A →ₐc[R] B) (hf : Function.Bijective f) : A ≃ₐc[R] B :=
+  { AlgEquiv.ofBijective (f : A →ₐ[R] B) hf, f with }
+
+@[simp]
+theorem coe_ofBijective {f : A →ₐc[R] B} {hf : Function.Bijective f} :
+    (BialgEquiv.ofBijective f hf : A → B) = f :=
+  rfl
+
+theorem ofBijective_apply {f : A →ₐc[R] B} {hf : Function.Bijective f} (a : A) :
+    (BialgEquiv.ofBijective f hf) a = f a :=
+  rfl
+
 end
 end BialgEquiv

--- a/Mathlib/RingTheory/Coalgebra/Equiv.lean
+++ b/Mathlib/RingTheory/Coalgebra/Equiv.lean
@@ -267,7 +267,9 @@ theorem ofCoalgHom_symm (f : A →ₗc[R] B) (g : B →ₗc[R] A) (h₁ h₂) :
 variable {f : A →ₗc[R] B} (hf : Function.Bijective f)
 
 /-- Promotes a bijective coalgebra homomorphism to a coalgebra equivalence. -/
+@[simps apply]
 noncomputable def ofBijective : A ≃ₗc[R] B where
+  toFun := f
   __ := f
   __ := LinearEquiv.ofBijective (f : A →ₗ[R] B) hf
 

--- a/Mathlib/RingTheory/Coalgebra/Equiv.lean
+++ b/Mathlib/RingTheory/Coalgebra/Equiv.lean
@@ -249,12 +249,12 @@ theorem coe_toEquiv_trans : (e₁₂ : A ≃ B).trans e₂₃ = (e₁₂.trans e
 /-- If an coalgebra morphism has an inverse, it is an coalgebra isomorphism. -/
 @[simps]
 def ofCoalgHom (f : A →ₗc[R] B) (g : B →ₗc[R] A) (h₁ : f.comp g = CoalgHom.id R B)
-    (h₂ : g.comp f = CoalgHom.id R A) : A ≃ₗc[R] B :=
-  { f with
-    toFun := f
-    invFun := g
-    left_inv := CoalgHom.ext_iff.1 h₂
-    right_inv := CoalgHom.ext_iff.1 h₁ }
+    (h₂ : g.comp f = CoalgHom.id R A) : A ≃ₗc[R] B where
+  __ := f
+  toFun := f
+  invFun := g
+  left_inv := CoalgHom.ext_iff.1 h₂
+  right_inv := CoalgHom.ext_iff.1 h₁
 
 theorem coe_coalgHom_ofCoalgHom (f : A →ₗc[R] B) (g : B →ₗc[R] A) (h₁ h₂) :
     ↑(ofCoalgHom f g h₁ h₂) = f :=

--- a/Mathlib/RingTheory/Coalgebra/Equiv.lean
+++ b/Mathlib/RingTheory/Coalgebra/Equiv.lean
@@ -247,7 +247,6 @@ theorem coe_toEquiv_trans : (e₁₂ : A ≃ B).trans e₂₃ = (e₁₂.trans e
   rfl
 
 /-- If an coalgebra morphism has an inverse, it is an coalgebra isomorphism. -/
-@[simps]
 def ofCoalgHom (f : A →ₗc[R] B) (g : B →ₗc[R] A) (h₁ : f.comp g = CoalgHom.id R B)
     (h₂ : g.comp f = CoalgHom.id R A) : A ≃ₗc[R] B where
   __ := f
@@ -256,30 +255,27 @@ def ofCoalgHom (f : A →ₗc[R] B) (g : B →ₗc[R] A) (h₁ : f.comp g = Coal
   left_inv := CoalgHom.ext_iff.1 h₂
   right_inv := CoalgHom.ext_iff.1 h₁
 
-theorem coe_coalgHom_ofCoalgHom (f : A →ₗc[R] B) (g : B →ₗc[R] A) (h₁ h₂) :
-    ↑(ofCoalgHom f g h₁ h₂) = f :=
-  rfl
-
 @[simp]
-theorem ofCoalgHom_coe_coalgHom (f : A →ₗc[R] B) (g : B →ₗc[R] A) (h₁ h₂) :
-    ofCoalgHom (↑f) g h₁ h₂ = f := by
-  ext; simp
+theorem coe_ofCoalgHom (f : A →ₗc[R] B) (g : B →ₗc[R] A) (h₁ h₂) :
+    ofCoalgHom f g h₁ h₂ = f :=
+  rfl
 
 theorem ofCoalgHom_symm (f : A →ₗc[R] B) (g : B →ₗc[R] A) (h₁ h₂) :
     (ofCoalgHom f g h₁ h₂).symm = ofCoalgHom g f h₂ h₁ :=
   rfl
 
+variable {f : A →ₗc[R] B} (hf : Function.Bijective f)
+
 /-- Promotes a bijective coalgebra homomorphism to a coalgebra equivalence. -/
-noncomputable def ofBijective (f : A →ₗc[R] B) (hf : Function.Bijective f) : A ≃ₗc[R] B :=
-  { LinearEquiv.ofBijective (f : A →ₗ[R] B) hf, f with }
+noncomputable def ofBijective : A ≃ₗc[R] B where
+  __ := f
+  __ := LinearEquiv.ofBijective (f : A →ₗ[R] B) hf
 
 @[simp]
-theorem coe_ofBijective {f : A →ₗc[R] B} {hf : Function.Bijective f} :
-    (CoalgEquiv.ofBijective f hf : A → B) = f :=
+theorem coe_ofBijective : (CoalgEquiv.ofBijective hf : A → B) = f :=
   rfl
 
-theorem ofBijective_apply {f : A →ₗc[R] B} {hf : Function.Bijective f} (a : A) :
-    (CoalgEquiv.ofBijective f hf) a = f a :=
+theorem ofBijective_apply (a : A) : (CoalgEquiv.ofBijective hf) a = f a :=
   rfl
 
 end

--- a/Mathlib/RingTheory/Coalgebra/Equiv.lean
+++ b/Mathlib/RingTheory/Coalgebra/Equiv.lean
@@ -277,9 +277,6 @@ noncomputable def ofBijective : A ≃ₗc[R] B where
 theorem coe_ofBijective : (CoalgEquiv.ofBijective hf : A → B) = f :=
   rfl
 
-theorem ofBijective_apply (a : A) : (CoalgEquiv.ofBijective hf) a = f a :=
-  rfl
-
 end
 variable [CommSemiring R] [AddCommMonoid A] [Module R A] [Coalgebra R A]
   [AddCommMonoid B] [Module R B] [CoalgebraStruct R B]

--- a/Mathlib/RingTheory/Coalgebra/Equiv.lean
+++ b/Mathlib/RingTheory/Coalgebra/Equiv.lean
@@ -246,6 +246,42 @@ theorem trans_toCoalgHom :
 theorem coe_toEquiv_trans : (e₁₂ : A ≃ B).trans e₂₃ = (e₁₂.trans e₂₃ : A ≃ C) :=
   rfl
 
+/-- If an coalgebra morphism has an inverse, it is an coalgebra isomorphism. -/
+@[simps]
+def ofCoalgHom (f : A →ₗc[R] B) (g : B →ₗc[R] A) (h₁ : f.comp g = CoalgHom.id R B)
+    (h₂ : g.comp f = CoalgHom.id R A) : A ≃ₗc[R] B :=
+  { f with
+    toFun := f
+    invFun := g
+    left_inv := CoalgHom.ext_iff.1 h₂
+    right_inv := CoalgHom.ext_iff.1 h₁ }
+
+theorem coe_coalgHom_ofCoalgHom (f : A →ₗc[R] B) (g : B →ₗc[R] A) (h₁ h₂) :
+    ↑(ofCoalgHom f g h₁ h₂) = f :=
+  rfl
+
+@[simp]
+theorem ofCoalgHom_coe_coalgHom (f : A →ₗc[R] B) (g : B →ₗc[R] A) (h₁ h₂) :
+    ofCoalgHom (↑f) g h₁ h₂ = f := by
+  ext; simp
+
+theorem ofCoalgHom_symm (f : A →ₗc[R] B) (g : B →ₗc[R] A) (h₁ h₂) :
+    (ofCoalgHom f g h₁ h₂).symm = ofCoalgHom g f h₂ h₁ :=
+  rfl
+
+/-- Promotes a bijective coalgebra homomorphism to a coalgebra equivalence. -/
+noncomputable def ofBijective (f : A →ₗc[R] B) (hf : Function.Bijective f) : A ≃ₗc[R] B :=
+  { LinearEquiv.ofBijective (f : A →ₗ[R] B) hf, f with }
+
+@[simp]
+theorem coe_ofBijective {f : A →ₗc[R] B} {hf : Function.Bijective f} :
+    (CoalgEquiv.ofBijective f hf : A → B) = f :=
+  rfl
+
+theorem ofBijective_apply {f : A →ₗc[R] B} {hf : Function.Bijective f} (a : A) :
+    (CoalgEquiv.ofBijective f hf) a = f a :=
+  rfl
+
 end
 variable [CommSemiring R] [AddCommMonoid A] [Module R A] [Coalgebra R A]
   [AddCommMonoid B] [Module R B] [CoalgebraStruct R B]


### PR DESCRIPTION
Add constructors for equivalences of coalgebras and bialgebras, similar to what already exists for equivalences of algebras:
- `CoalgEquiv.ofCoalgHom` constructs a `CoalgEquiv` from a `CoalgHom` that has an inverse;
- `CoalgEquiv.ofBijective` constructs a `CoalgEquiv` from a bijective `CoalgHom`;
- `BialgEquiv.ofBialgHom` constructs a `BialgEquiv` from a `CoalgHom` that has an inverse;
- `BialgEquiv.ofBijective` constructs a `BialgEquiv` from a bijective `BialgHom`.

Also add some `apply` and `coe` lemmas, following the same model as for `AlgEquiv`s.

From Toric

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
