### PR TITLE
[Merged by Bors] - feat(Combinatorics): multigraphs

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2559,6 +2559,7 @@ import Mathlib.Combinatorics.Enumerative.IncidenceAlgebra
 import Mathlib.Combinatorics.Enumerative.InclusionExclusion
 import Mathlib.Combinatorics.Enumerative.Partition
 import Mathlib.Combinatorics.Extremal.RuzsaSzemeredi
+import Mathlib.Combinatorics.Graph.Basic
 import Mathlib.Combinatorics.HalesJewett
 import Mathlib.Combinatorics.Hall.Basic
 import Mathlib.Combinatorics.Hall.Finite

--- a/Mathlib/Combinatorics/Graph/Basic.lean
+++ b/Mathlib/Combinatorics/Graph/Basic.lean
@@ -188,6 +188,9 @@ lemma Inc.eq_or_eq_of_isLink (h : G.Inc e x) (h' : G.IsLink e y z) : x = y ∨ x
 lemma Inc.eq_of_isLink_of_ne_left (h : G.Inc e x) (h' : G.IsLink e y z) (hxy : x ≠ y) : x = z :=
   (h.eq_or_eq_of_isLink h').elim (False.elim ∘ hxy) id
 
+lemma IsLink.isLink_iff_eq (h : G.IsLink e x y) : G.IsLink e x z ↔ z = y :=
+  ⟨fun h' ↦ h'.right_unique h, fun h' ↦ h' ▸ h⟩
+
 /-- The binary incidence predicate can be expressed in terms of the unary one. -/
 lemma isLink_iff_inc : G.IsLink e x y ↔ G.Inc e x ∧ G.Inc e y ∧ ∀ z, G.Inc e z → z = x ∨ z = y := by
   refine ⟨fun h ↦ ⟨h.inc_left, h.inc_right, fun z h' ↦ h'.eq_or_eq_of_isLink h⟩, ?_⟩
@@ -279,8 +282,8 @@ def Adj (G : Graph α β) (x y : α) : Prop := ∃ e, G.IsLink e x y
 protected lemma Adj.symm (h : G.Adj x y) : G.Adj y x :=
   ⟨_, h.choose_spec.symm⟩
 
-lemma adj_comm : G.Adj x y ↔ G.Adj y x :=
-  ⟨Adj.symm, Adj.symm⟩
+lemma adj_comm (x y) : G.Adj x y ↔ G.Adj y x :=
+  ⟨.symm, .symm⟩
 
 @[simp]
 lemma Adj.left_mem (h : G.Adj x y) : x ∈ V(G) :=

--- a/Mathlib/Combinatorics/Graph/Basic.lean
+++ b/Mathlib/Combinatorics/Graph/Basic.lean
@@ -56,7 +56,6 @@ the vertex or edge set. This is an issue, but is likely amenable to automation.
 
 Reflecting written mathematics, we use the compact notations `V(G)` and `E(G)` to
 refer to the `vertexSet` and `edgeSet` of `G : Graph α β`.
-If `G.IsLink e x y` then we refer to `e` as `edge` and `x` and `y` as `left` and `right` in names.
 -/
 
 variable {α β : Type*} {x y z u v w : α} {e f : β}
@@ -73,15 +72,16 @@ structure Graph (α β : Type*) where
   vertexSet : Set α
   /-- The edge set. -/
   edgeSet : Set β
-  /-- The binary incidence predicate, stating that `x` and `y` are the ends of an edge `e`. -/
+  /-- The binary incidence predicate; `G.IsLink e x y` means the edge `e` has ends `x` and `y`.
+  If this holds, we refer to `e` as `edge` and `x` and `y` as `left` and `right` in lemma names. -/
   IsLink : β → α → α → Prop
   /-- If `e` goes from `x` to `y`, it goes from `y` to `x`. -/
   isLink_symm : ∀ ⦃e⦄, e ∈ edgeSet → (Symmetric <| IsLink e)
   /-- An edge is incident with at most one pair of vertices. -/
   eq_or_eq_of_isLink_of_isLink : ∀ ⦃e x y v w⦄, IsLink e x y → IsLink e v w → x = v ∨ x = w
-  /-- An edge `e` is incident to something if and only if `e` is in the edge set. -/
+  /-- An edge `e` is incident to some vertex if and only if `e` is in the edge set. -/
   edge_mem_iff_exists_isLink : ∀ e, e ∈ edgeSet ↔ ∃ x y, IsLink e x y
-  /-- If some edge `e` is incident to `x`, then `x ∈ V`. -/
+  /-- If some edge `e` is incident to the vertex `x`, then `x ∈ V`. -/
   left_mem_of_isLink : ∀ ⦃e x y⦄, IsLink e x y → x ∈ vertexSet
 
 namespace Graph
@@ -152,7 +152,8 @@ lemma IsLink.isLink_iff_sym2_eq (h : G.IsLink e x y) {x' y' : α} :
 
 /-! ### Edge-vertex incidence -/
 
-/-- The unary incidence predicate of `G`. `G.Inc e x` means that `x` is one of the ends of `e`. -/
+/-- The unary incidence predicate. `G.Inc e x` means that `x` is one of the ends of `e`.
+If `G.Inc e x`, then we refer to `e` as `edge` and `x` as `vertex` in lemma names. -/
 def Inc (G : Graph α β) (e : β) (x : α) : Prop := ∃ y, G.IsLink e x y
 
 @[simp]
@@ -262,7 +263,8 @@ lemma Inc.isLoopAt_or_isNonloopAt (h : G.Inc e x) : G.IsLoopAt e x ∨ G.IsNonlo
 
 /-! ### Adjacency -/
 
-/-- `G.Adj x y` means that `G` has an edge from `x` to `y`. -/
+/-- `G.Adj x y` means that `G` has an edge from `x` to `y`. We refer to `x` and `y` as `left`
+and `right` in lemma names. -/
 def Adj (G : Graph α β) (x y : α) : Prop := ∃ e, G.IsLink e x y
 
 lemma Adj.symm (h : G.Adj x y) : G.Adj y x :=

--- a/Mathlib/Combinatorics/Graph/Basic.lean
+++ b/Mathlib/Combinatorics/Graph/Basic.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Peter Nelson, Jun Kwon
 -/
 import Mathlib.Data.Set.Basic
+import Mathlib.Data.Sym.Sym2
 
 /-!
 # Multigraphs
@@ -16,18 +17,18 @@ and there may also be more than one edge `e` whose ends are the same pair `(x,y)
 A multigraph where neither of these occurs is 'simple',
 and these objects are described by `SimpleGraph`.
 
-This module defines `Graph α ε` for a vertex type `α` and an edge type `ε`,
+This module defines `Graph α β` for a vertex type `α` and an edge type `β`,
 and gives basic API for incidence, adjacency and extensionality.
 The design broadly follows [Chou1994].
 
 ## Main definitions
 
-For `G : Graph α ε`, ...
+For `G : Graph α β`, ...
 
-* `G.V` denotes the vertex set of `G` as a term in `Set α`.
-* `G.E` denotes the edge set of `G` as a term in `Set ε`.
-* `G.Inc₂ e x y` means that the edge `e : ε` has vertices `x : α` and `y : α` as its ends.
-* `G.Inc e x` means that the edge `e : ε` has `x` as one of its ends.
+* `V(G)` denotes the vertex set of `G` as a term in `Set α`.
+* `E(G)` denotes the edge set of `G` as a term in `Set β`.
+* `G.IsLink e x y` means that the edge `e : β` has vertices `x : α` and `y : α` as its ends.
+* `G.Inc e x` means that the edge `e : β` has `x` as one of its ends.
 * `G.Adj x y` means that there is an edge `e` having `x` and `y` as its ends.
 * `G.IsLoopAt e x` means that `e` is a loop edge with both ends equal to `x`.
 * `G.IsNonloopAt e x` means that `e` is a non-loop edge with one end equal to `x`.
@@ -35,124 +36,151 @@ For `G : Graph α ε`, ...
 ## Implementation notes
 
 Unlike the design of `SimpleGraph`, the vertex and edge sets of `G` are modelled as sets
-`G.V : Set α` and `G.E : Set ε`, within ambient types, rather than being types themselves.
+`V(G) : Set α` and `E(G) : Set β`, within ambient types, rather than being types themselves.
 This mimics the 'embedded set' design used in `Matroid`, which seems to be more convenient for
 formalizing real-world proofs in combinatorics.
 
-A specific advantage is that this will allow subgraphs of `G : Graph α ε` to also exist on
-an equal footing with `G` as terms in `Graph α ε`,
+A specific advantage is that this will allow subgraphs of `G : Graph α β` to also exist on
+an equal footing with `G` as terms in `Graph α β`,
 and so there is no need for an extensive `Graph.subgraph` API and all the associated
 definitions and canonical coercion maps. The same will go for minors and the various other
 partial orders on multigraphs.
 
 The main tradeoff is that parts of the API will require caring about whether a term
-`x : α` or `e : ε` is a 'real' vertex or edge of the graph, rather than something outside
+`x : α` or `e : β` is a 'real' vertex or edge of the graph, rather than something outside
 the vertex or edge set. This is an issue, but is likely amenable to automation.
 
 ## Notation
 
-Reflecting written mathematics, we use the compact notations `G.V` and `G.E` to describe
-vertex and edge sets formally, but use the longer terms `vxSet` and `edgeSet` within
-lemma names to refer to the same objects.
+Reflecting written mathematics, we use the compact notations `V(G)` and `E(G)` to
+refer to the `vertexSet` and `edgeSet` of `G : Graph α β`.
 
 -/
 
-variable {α ε : Type*} {x y z u v w : α} {e f : ε}
+variable {α β : Type*} {x y z u v w : α} {e f : β}
 
 open Set
 
-/-- A multigraph with vertex set `V : Set α` and edge set `E : Set ε`,
-as described by a predicate describing whether an edge `e : ε` has ends `x` and `y`.
+/-- A multigraph with vertex set `V : Set α` and edge set `E : Set β`,
+as described by a predicate describing whether an edge `e : β` has ends `x` and `y`.
 For definitional reasons, we include the edge set `E` as a structure field
-even though it can be inferred from `Inc₂` via `edge_mem_iff_exists_inc₂`;
+even though it can be inferred from `IsLink` via `edge_mem_iff_exists_isLink`;
 see `Graph.mk'` for a constructor that does not use `E`. -/
-structure Graph (α ε : Type*) where
+structure Graph (α β : Type*) where
   /-- The vertex set. -/
-  V : Set α
+  vertexSet : Set α
   /-- The edge set. -/
-  E : Set ε
+  edgeSet : Set β
   /-- The binary incidence predicate, stating that `x` and `y` are the ends of an edge `e` -/
-  Inc₂ : ε → α → α → Prop
+  IsLink : β → α → α → Prop
   /-- If `e` goes from `x` to `y`, it goes from `y` to `x`. -/
-  inc₂_symm : ∀ ⦃e⦄, e ∈ E → (Symmetric <| Inc₂ e)
+  isLink_symm : ∀ ⦃e⦄, e ∈ edgeSet → (Symmetric <| IsLink e)
   /-- An edge is incident with at most one pair of vertices. -/
-  eq_or_eq_of_inc₂_of_inc₂ : ∀ ⦃e x y v w⦄, Inc₂ e x y → Inc₂ e v w → x = v ∨ x = w
+  eq_or_eq_of_isLink_of_isLink : ∀ ⦃e x y v w⦄, IsLink e x y → IsLink e v w → x = v ∨ x = w
   /-- An edge `e` is incident to something if and only if `e` is in the edge set -/
-  edge_mem_iff_exists_inc₂ : ∀ e, e ∈ E ↔ ∃ x y, Inc₂ e x y
+  edge_mem_iff_exists_isLink : ∀ e, e ∈ edgeSet ↔ ∃ x y, IsLink e x y
   /-- If some edge `e` is incident to `x`, then `x ∈ V`. -/
-  vx_mem_left_of_inc₂ : ∀ ⦃e x y⦄, Inc₂ e x y → x ∈ V
+  vx_mem_left_of_isLink : ∀ ⦃e x y⦄, IsLink e x y → x ∈ vertexSet
 
 namespace Graph
 
-variable {G : Graph α ε}
+variable {G : Graph α β}
+
+/-- `V(G)` denotes the `vertexSet` of a graph `G`. -/
+scoped notation "V(" G ")" => Graph.vertexSet G
+
+/-- `E(G)` denotes the `edgeSet` of a graph `G`. -/
+scoped notation "E(" G ")" => Graph.edgeSet G
 
 /-! ### Edge-vertex-vertex incidence -/
 
-lemma Inc₂.edge_mem (h : G.Inc₂ e x y) : e ∈ G.E :=
-  (edge_mem_iff_exists_inc₂ ..).2 ⟨x, y, h⟩
+lemma IsLink.edge_mem (h : G.IsLink e x y) : e ∈ E(G) :=
+  (edge_mem_iff_exists_isLink ..).2 ⟨x, y, h⟩
 
-lemma Inc₂.symm (h : G.Inc₂ e x y) : G.Inc₂ e y x :=
-  G.inc₂_symm h.edge_mem h
+lemma IsLink.symm (h : G.IsLink e x y) : G.IsLink e y x :=
+  G.isLink_symm h.edge_mem h
 
-lemma Inc₂.vx_mem_left (h : G.Inc₂ e x y) : x ∈ G.V :=
-  G.vx_mem_left_of_inc₂ h
+lemma IsLink.vx_mem_left (h : G.IsLink e x y) : x ∈ V(G) :=
+  G.vx_mem_left_of_isLink h
 
-lemma Inc₂.vx_mem_right (h : G.Inc₂ e x y) : y ∈ G.V :=
+lemma IsLink.vx_mem_right (h : G.IsLink e x y) : y ∈ V(G) :=
   h.symm.vx_mem_left
 
-lemma inc₂_comm : G.Inc₂ e x y ↔ G.Inc₂ e y x :=
-  ⟨Inc₂.symm, Inc₂.symm⟩
+lemma isLink_comm : G.IsLink e x y ↔ G.IsLink e y x :=
+  ⟨IsLink.symm, IsLink.symm⟩
 
-lemma exists_inc₂_of_mem_edgeSet (h : e ∈ G.E) : ∃ x y, G.Inc₂ e x y :=
-  (edge_mem_iff_exists_inc₂ ..).1 h
+lemma exists_isLink_of_mem_edgeSet (h : e ∈ E(G)) : ∃ x y, G.IsLink e x y :=
+  (edge_mem_iff_exists_isLink ..).1 h
 
-lemma edgeSet_eq_setOf_exists_inc₂ : G.E = {e | ∃ x y, G.Inc₂ e x y} :=
-  Set.ext fun e ↦ G.edge_mem_iff_exists_inc₂ e
+lemma edgeSet_eq_setOf_exists_isLink : E(G) = {e | ∃ x y, G.IsLink e x y} :=
+  Set.ext fun e ↦ G.edge_mem_iff_exists_isLink e
 
-lemma Inc₂.left_eq_or_eq_of_inc₂ (h : G.Inc₂ e x y) (h' : G.Inc₂ e z w) : x = z ∨ x = w :=
-  G.eq_or_eq_of_inc₂_of_inc₂ h h'
+lemma IsLink.left_eq_or_eq_of_isLink (h : G.IsLink e x y) (h' : G.IsLink e z w) : x = z ∨ x = w :=
+  G.eq_or_eq_of_isLink_of_isLink h h'
 
-lemma Inc₂.left_eq_of_inc₂_of_ne (h : G.Inc₂ e x y) (h' : G.Inc₂ e z w) (hzx : x ≠ z) : x = w :=
-  (h.left_eq_or_eq_of_inc₂ h').elim (False.elim ∘ hzx) id
+lemma IsLink.left_eq_of_isLink_of_ne (h : G.IsLink e x y) (h' : G.IsLink e z w)
+    (hzx : x ≠ z) : x = w :=
+  (h.left_eq_or_eq_of_isLink h').elim (False.elim ∘ hzx) id
 
-lemma Inc₂.eq_of_inc₂ (h : G.Inc₂ e x y) (h' : G.Inc₂ e x z) : y = z := by
-  obtain rfl | rfl := h.symm.left_eq_or_eq_of_inc₂ h'.symm
+lemma IsLink.eq_of_isLink (h : G.IsLink e x y) (h' : G.IsLink e x z) : y = z := by
+  obtain rfl | rfl := h.symm.left_eq_or_eq_of_isLink h'.symm
   · rfl
-  obtain rfl | rfl := h'.symm.left_eq_or_eq_of_inc₂ h.symm <;> rfl
+  obtain rfl | rfl := h'.symm.left_eq_or_eq_of_isLink h.symm <;> rfl
+
+lemma IsLink.eq_and_eq_or_eq_and_eq_of_isLink {x' y' : α} (h : G.IsLink e x y)
+    (h' : G.IsLink e x' y') : (x = x' ∧ y = y') ∨ (x = y' ∧ y = x') := by
+  obtain rfl | rfl := h.left_eq_or_eq_of_isLink h'
+  · obtain rfl | rfl := h.symm.left_eq_or_eq_of_isLink h'
+    · obtain rfl | rfl := h'.symm.left_eq_or_eq_of_isLink h <;> simp
+    simp
+  obtain rfl | rfl := h.symm.left_eq_or_eq_of_isLink h'
+  · simp
+  obtain rfl | rfl := h'.left_eq_or_eq_of_isLink h <;> simp
+
+lemma IsLink.isLink_iff (h : G.IsLink e x y) {x' y' : α} :
+    G.IsLink e x' y' ↔ (x = x' ∧ y = y') ∨ (x = y' ∧ y = x') := by
+  refine ⟨h.eq_and_eq_or_eq_and_eq_of_isLink, ?_⟩
+  rintro (⟨rfl, rfl⟩ | ⟨rfl,rfl⟩)
+  · assumption
+  exact h.symm
+
+lemma IsLink.isLink_iff_sym2_eq (h : G.IsLink e x y) {x' y' : α} :
+    G.IsLink e x' y' ↔ s(x,y) = s(x',y') := by
+  rw [h.isLink_iff, Sym2.eq_iff]
 
 /-! ### Edge-vertex incidence -/
 
 /-- The unary incidence predicate of `G`. `G.Inc e x` means that `x` is one of the ends of `e`. -/
-def Inc (G : Graph α ε) (e : ε) (x : α) : Prop := ∃ y, G.Inc₂ e x y
+def Inc (G : Graph α β) (e : β) (x : α) : Prop := ∃ y, G.IsLink e x y
 
 @[simp]
-lemma Inc.edge_mem (h : G.Inc e x) : e ∈ G.E :=
+lemma Inc.edge_mem (h : G.Inc e x) : e ∈ E(G) :=
   h.choose_spec.edge_mem
 
 @[simp]
-lemma Inc.vx_mem (h : G.Inc e x) : x ∈ G.V :=
+lemma Inc.vx_mem (h : G.Inc e x) : x ∈ V(G) :=
   h.choose_spec.vx_mem_left
 
 @[simp]
-lemma Inc₂.inc_left (h : G.Inc₂ e x y) : G.Inc e x :=
+lemma IsLink.inc_left (h : G.IsLink e x y) : G.Inc e x :=
   ⟨y, h⟩
 
 @[simp]
-lemma Inc₂.inc_right (h : G.Inc₂ e x y) : G.Inc e y :=
+lemma IsLink.inc_right (h : G.IsLink e x y) : G.Inc e y :=
   ⟨x, h.symm⟩
 
-lemma Inc.eq_or_eq_of_inc₂ (h : G.Inc e x) (h' : G.Inc₂ e y z) : x = y ∨ x = z :=
-  h.choose_spec.left_eq_or_eq_of_inc₂ h'
+lemma Inc.eq_or_eq_of_isLink (h : G.Inc e x) (h' : G.IsLink e y z) : x = y ∨ x = z :=
+  h.choose_spec.left_eq_or_eq_of_isLink h'
 
-lemma Inc.eq_of_inc₂_of_ne_left (h : G.Inc e x) (h' : G.Inc₂ e y z) (hxy : x ≠ y) : x = z :=
-  (h.eq_or_eq_of_inc₂ h').elim (False.elim ∘ hxy) id
+lemma Inc.eq_of_isLink_of_ne_left (h : G.Inc e x) (h' : G.IsLink e y z) (hxy : x ≠ y) : x = z :=
+  (h.eq_or_eq_of_isLink h').elim (False.elim ∘ hxy) id
 
 /-- The binary incidence predicate can be expressed in terms of the unary one. -/
-lemma inc₂_iff_inc : G.Inc₂ e x y ↔ G.Inc e x ∧ G.Inc e y ∧ ∀ z, G.Inc e z → z = x ∨ z = y := by
-  refine ⟨fun h ↦ ⟨h.inc_left, h.inc_right, fun z h' ↦ h'.eq_or_eq_of_inc₂ h⟩, ?_⟩
+lemma isLink_iff_inc : G.IsLink e x y ↔ G.Inc e x ∧ G.Inc e y ∧ ∀ z, G.Inc e z → z = x ∨ z = y := by
+  refine ⟨fun h ↦ ⟨h.inc_left, h.inc_right, fun z h' ↦ h'.eq_or_eq_of_isLink h⟩, ?_⟩
   rintro ⟨⟨x', hx'⟩, ⟨y', hy'⟩, h⟩
   obtain rfl | rfl := h _ hx'.inc_right
-  · obtain rfl | rfl := hx'.left_eq_or_eq_of_inc₂ hy'
+  · obtain rfl | rfl := hx'.left_eq_or_eq_of_isLink hy'
     · assumption
     exact hy'.symm
   assumption
@@ -162,58 +190,58 @@ lemma inc₂_iff_inc : G.Inc₂ e x y ↔ G.Inc e x ∧ G.Inc e y ∧ ∀ z, G.I
 noncomputable def Inc.other (h : G.Inc e x) : α := h.choose
 
 @[simp]
-lemma Inc.inc₂_other (h : G.Inc e x) : G.Inc₂ e x h.other :=
+lemma Inc.isLink_other (h : G.Inc e x) : G.IsLink e x h.other :=
   h.choose_spec
 
 @[simp]
 lemma Inc.inc_other (h : G.Inc e x) : G.Inc e h.other :=
-  h.inc₂_other.inc_right
+  h.isLink_other.inc_right
 
 lemma Inc.eq_or_eq_or_eq_of_inc_of_inc (hx : G.Inc e x) (hy : G.Inc e y) (hz : G.Inc e z) :
     x = y ∨ x = z ∨ y = z := by
   by_contra! hcon
   obtain ⟨x', hx'⟩ := hx
-  obtain rfl := hy.eq_of_inc₂_of_ne_left hx' hcon.1.symm
-  obtain rfl := hz.eq_of_inc₂_of_ne_left hx' hcon.2.1.symm
+  obtain rfl := hy.eq_of_isLink_of_ne_left hx' hcon.1.symm
+  obtain rfl := hz.eq_of_isLink_of_ne_left hx' hcon.2.1.symm
   exact hcon.2.2 rfl
 
 /-- `G.IsLoopAt e x` means that both ends of `e` are equal to `x`. -/
-def IsLoopAt (G : Graph α ε) (e : ε) (x : α) : Prop := G.Inc₂ e x x
+def IsLoopAt (G : Graph α β) (e : β) (x : α) : Prop := G.IsLink e x x
 
 @[simp]
-lemma inc₂_self_iff : G.Inc₂ e x x ↔ G.IsLoopAt e x := Iff.rfl
+lemma isLink_self_iff : G.IsLink e x x ↔ G.IsLoopAt e x := Iff.rfl
 
 lemma IsLoopAt.inc (h : G.IsLoopAt e x) : G.Inc e x :=
-  Inc₂.inc_left h
+  IsLink.inc_left h
 
 lemma IsLoopAt.eq_of_inc (h : G.IsLoopAt e x) (h' : G.Inc e y) : x = y := by
-  obtain rfl | rfl := h'.eq_or_eq_of_inc₂ h <;> rfl
+  obtain rfl | rfl := h'.eq_or_eq_of_isLink h <;> rfl
 
 @[simp]
-lemma IsLoopAt.edge_mem (h : G.IsLoopAt e x) : e ∈ G.E :=
+lemma IsLoopAt.edge_mem (h : G.IsLoopAt e x) : e ∈ E(G) :=
   h.inc.edge_mem
 
 @[simp]
-lemma IsLoopAt.vx_mem (h : G.IsLoopAt e x) : x ∈ G.V :=
+lemma IsLoopAt.vx_mem (h : G.IsLoopAt e x) : x ∈ V(G) :=
   h.inc.vx_mem
 
 /-- `G.IsNonloopAt e x` means that `e` is an edge from `x` to some `y ≠ x`. -/
 @[mk_iff]
-structure IsNonloopAt (G : Graph α ε) (e : ε) (x : α) : Prop where
+structure IsNonloopAt (G : Graph α β) (e : β) (x : α) : Prop where
   inc : G.Inc e x
-  exists_inc₂_ne : ∃ y ≠ x, G.Inc₂ e x y
+  exists_isLink_ne : ∃ y ≠ x, G.IsLink e x y
 
 @[simp]
-lemma IsNonloopAt.edge_mem (h : G.IsNonloopAt e x) : e ∈ G.E :=
+lemma IsNonloopAt.edge_mem (h : G.IsNonloopAt e x) : e ∈ E(G) :=
   h.inc.edge_mem
 
 @[simp]
-lemma IsNonloopAt.vx_mem (h : G.IsNonloopAt e x) : x ∈ G.V :=
+lemma IsNonloopAt.vx_mem (h : G.IsNonloopAt e x) : x ∈ V(G) :=
   h.inc.vx_mem
 
 lemma IsLoopAt.not_isNonloop_at (h : G.IsLoopAt e x) (y : α) : ¬ G.IsNonloopAt e y := by
   intro h'
-  obtain ⟨z, hyz, hy⟩ := h'.exists_inc₂_ne
+  obtain ⟨z, hyz, hy⟩ := h'.exists_isLink_ne
   rw [← h.eq_of_inc hy.inc_left, ← h.eq_of_inc hy.inc_right] at hyz
   exact hyz rfl
 
@@ -229,7 +257,7 @@ lemma Inc.isLoopAt_or_isNonloopAt (h : G.Inc e x) : G.IsLoopAt e x ∨ G.IsNonlo
 /-! ### Adjacency -/
 
 /-- `G.Adj x y` means that `G` has an edge from `x` to `y`. -/
-def Adj (G : Graph α ε) (x y : α) : Prop := ∃ e, G.Inc₂ e x y
+def Adj (G : Graph α β) (x y : α) : Prop := ∃ e, G.IsLink e x y
 
 lemma Adj.symm (h : G.Adj x y) : G.Adj y x :=
   ⟨_, h.choose_spec.symm⟩
@@ -238,14 +266,14 @@ lemma adj_comm : G.Adj x y ↔ G.Adj y x :=
   ⟨Adj.symm, Adj.symm⟩
 
 @[simp]
-lemma Adj.mem_left (h : G.Adj x y) : x ∈ G.V :=
+lemma Adj.mem_left (h : G.Adj x y) : x ∈ V(G) :=
   h.choose_spec.vx_mem_left
 
 @[simp]
-lemma Adj.mem_right (h : G.Adj x y) : y ∈ G.V :=
+lemma Adj.mem_right (h : G.Adj x y) : y ∈ V(G) :=
   h.symm.mem_left
 
-lemma Inc₂.adj (h : G.Inc₂ e x y) : G.Adj x y :=
+lemma IsLink.adj (h : G.IsLink e x y) : G.Adj x y :=
   ⟨e, h⟩
 
 /-! ### Extensionality -/
@@ -253,30 +281,30 @@ lemma Inc₂.adj (h : G.Inc₂ e x y) : G.Adj x y :=
 /-- A constructor for `Graph` in which the edge set is inferred from the incidence predicate
 rather than supplied explicitly. -/
 @[simps]
-protected def mk' (V : Set α) (Inc₂ : ε → α → α → Prop)
-    (inc₂_symm : ∀ ⦃e x y⦄, Inc₂ e x y → Inc₂ e y x)
-    (eq_or_eq_of_inc₂_of_inc₂ : ∀ ⦃e x y v w⦄, Inc₂ e x y → Inc₂ e v w → x = v ∨ x = w)
-    (vx_mem_left_of_inc₂ : ∀ ⦃e x y⦄, Inc₂ e x y → x ∈ V) : Graph α ε where
-  V := V
-  E := {e | ∃ x y, Inc₂ e x y}
-  Inc₂ := Inc₂
-  inc₂_symm _ _ _ _ h := inc₂_symm h
-  eq_or_eq_of_inc₂_of_inc₂ := eq_or_eq_of_inc₂_of_inc₂
-  edge_mem_iff_exists_inc₂ _ := Iff.rfl
-  vx_mem_left_of_inc₂ := vx_mem_left_of_inc₂
+protected def mk' (vertexSet : Set α) (IsLink : β → α → α → Prop)
+    (isLink_symm : ∀ ⦃e x y⦄, IsLink e x y → IsLink e y x)
+    (eq_or_eq_of_isLink_of_isLink : ∀ ⦃e x y v w⦄, IsLink e x y → IsLink e v w → x = v ∨ x = w)
+    (vx_mem_left_of_isLink : ∀ ⦃e x y⦄, IsLink e x y → x ∈ vertexSet) : Graph α β where
+  vertexSet := vertexSet
+  edgeSet := {e | ∃ x y, IsLink e x y}
+  IsLink := IsLink
+  isLink_symm _ _ _ _ h := isLink_symm h
+  eq_or_eq_of_isLink_of_isLink := eq_or_eq_of_isLink_of_isLink
+  edge_mem_iff_exists_isLink _ := Iff.rfl
+  vx_mem_left_of_isLink := vx_mem_left_of_isLink
 
 @[simp]
-lemma mk'_eq_self (G : Graph α ε) : Graph.mk' G.V G.Inc₂ (fun _ _ _ ↦ Inc₂.symm)
-  (fun _ _ _ _ _ h h' ↦ h.left_eq_or_eq_of_inc₂ h') (fun _ _ _ ↦ Inc₂.vx_mem_left) = G := by
-  have h := G.edgeSet_eq_setOf_exists_inc₂
-  cases G with | mk V E Inc₂ _ _ _ => simpa [Graph.mk'] using h.symm
+lemma mk'_eq_self (G : Graph α β) : Graph.mk' V(G) G.IsLink (fun _ _ _ ↦ IsLink.symm)
+  (fun _ _ _ _ _ h h' ↦ h.left_eq_or_eq_of_isLink h') (fun _ _ _ ↦ IsLink.vx_mem_left) = G := by
+  have h := G.edgeSet_eq_setOf_exists_isLink
+  cases G with | mk V E IsLink _ _ _ => simpa [Graph.mk'] using h.symm
 
 /-- Two graphs with the same vertex set and binary incidences are equal.
 (We use this as the default extensionality lemma rather than adding `@[ext]`
 to the definition of `Graph`, so it doesn't require equality of the edge sets.) -/
 @[ext]
-protected lemma ext {G₁ G₂ : Graph α ε} (hV : G₁.V = G₂.V)
-    (h : ∀ e x y, G₁.Inc₂ e x y ↔ G₂.Inc₂ e x y) : G₁ = G₂ := by
+protected lemma ext {G₁ G₂ : Graph α β} (hV : V(G₁) = V(G₂))
+    (h : ∀ e x y, G₁.IsLink e x y ↔ G₂.IsLink e x y) : G₁ = G₂ := by
   rw [← G₁.mk'_eq_self, ← G₂.mk'_eq_self]
   simp_rw [hV]
   convert rfl using 2
@@ -285,8 +313,8 @@ protected lemma ext {G₁ G₂ : Graph α ε} (hV : G₁.V = G₂.V)
 
 /-- Two graphs with the same vertex set and unary incidences are equal. -/
 @[ext]
-lemma ext_inc {G₁ G₂ : Graph α ε} (hV : G₁.V = G₂.V) (h : ∀ e x, G₁.Inc e x ↔ G₂.Inc e x) :
+lemma ext_inc {G₁ G₂ : Graph α β} (hV : V(G₁) = V(G₂)) (h : ∀ e x, G₁.Inc e x ↔ G₂.Inc e x) :
     G₁ = G₂ :=
-  Graph.ext hV fun _ _ _ ↦ by simp_rw [inc₂_iff_inc, h]
+  Graph.ext hV fun _ _ _ ↦ by simp_rw [isLink_iff_inc, h]
 
 end Graph

--- a/Mathlib/Combinatorics/Graph/Basic.lean
+++ b/Mathlib/Combinatorics/Graph/Basic.lean
@@ -106,7 +106,7 @@ scoped notation "E(" G ")" => Graph.edgeSet G
 lemma IsLink.edge_mem (h : G.IsLink e x y) : e ∈ E(G) :=
   (edge_mem_iff_exists_isLink ..).2 ⟨x, y, h⟩
 
-lemma IsLink.symm (h : G.IsLink e x y) : G.IsLink e y x :=
+protected lemma IsLink.symm (h : G.IsLink e x y) : G.IsLink e y x :=<
   G.isLink_symm h.edge_mem h
 
 lemma IsLink.left_mem (h : G.IsLink e x y) : x ∈ V(G) :=

--- a/Mathlib/Combinatorics/Graph/Basic.lean
+++ b/Mathlib/Combinatorics/Graph/Basic.lean
@@ -106,7 +106,7 @@ scoped notation "E(" G ")" => Graph.edgeSet G
 lemma IsLink.edge_mem (h : G.IsLink e x y) : e ∈ E(G) :=
   (edge_mem_iff_exists_isLink ..).2 ⟨x, y, h⟩
 
-protected lemma IsLink.symm (h : G.IsLink e x y) : G.IsLink e y x :=<
+protected lemma IsLink.symm (h : G.IsLink e x y) : G.IsLink e y x :=
   G.isLink_symm h.edge_mem h
 
 lemma IsLink.left_mem (h : G.IsLink e x y) : x ∈ V(G) :=
@@ -116,7 +116,7 @@ lemma IsLink.right_mem (h : G.IsLink e x y) : y ∈ V(G) :=
   h.symm.left_mem
 
 lemma isLink_comm : G.IsLink e x y ↔ G.IsLink e y x :=
-  ⟨IsLink.symm, IsLink.symm⟩
+  ⟨.symm, .symm⟩
 
 lemma exists_isLink_of_mem_edgeSet (h : e ∈ E(G)) : ∃ x y, G.IsLink e x y :=
   (edge_mem_iff_exists_isLink ..).1 h
@@ -124,30 +124,33 @@ lemma exists_isLink_of_mem_edgeSet (h : e ∈ E(G)) : ∃ x y, G.IsLink e x y :=
 lemma edgeSet_eq_setOf_exists_isLink : E(G) = {e | ∃ x y, G.IsLink e x y} :=
   Set.ext G.edge_mem_iff_exists_isLink
 
-lemma IsLink.left_eq_or_eq_of_isLink (h : G.IsLink e x y) (h' : G.IsLink e z w) : x = z ∨ x = w :=
+lemma IsLink.left_eq_or_eq (h : G.IsLink e x y) (h' : G.IsLink e z w) : x = z ∨ x = w :=
   G.eq_or_eq_of_isLink_of_isLink h h'
 
-lemma IsLink.left_eq_of_isLink_of_ne (h : G.IsLink e x y) (h' : G.IsLink e z w) (hzx : x ≠ z) :
+lemma IsLink.right_eq_or_eq (h : G.IsLink e x y) (h' : G.IsLink e z w) : y = z ∨ y = w :=
+  h.symm.left_eq_or_eq h'
+
+lemma IsLink.left_eq_of_right_ne (h : G.IsLink e x y) (h' : G.IsLink e z w) (hzx : x ≠ z) :
     x = w :=
-  (h.left_eq_or_eq_of_isLink h').elim (False.elim ∘ hzx) id
+  (h.left_eq_or_eq h').elim (False.elim ∘ hzx) id
 
 lemma IsLink.right_unique (h : G.IsLink e x y) (h' : G.IsLink e x z) : y = z := by
-  obtain rfl | rfl := h.symm.left_eq_or_eq_of_isLink h'.symm
+  obtain rfl | rfl := h.right_eq_or_eq h'.symm
   · rfl
-  obtain rfl | rfl := h'.symm.left_eq_or_eq_of_isLink h.symm <;> rfl
+  obtain rfl | rfl := h'.right_eq_or_eq h.symm <;> rfl
 
 lemma IsLink.left_unique (h : G.IsLink e x z) (h' : G.IsLink e y z) : x = y :=
   h.symm.right_unique h'.symm
 
-lemma IsLink.eq_and_eq_or_eq_and_eq_of_isLink {x' y' : α} (h : G.IsLink e x y)
+lemma IsLink.eq_and_eq_or_eq_and_eq {x' y' : α} (h : G.IsLink e x y)
     (h' : G.IsLink e x' y') : (x = x' ∧ y = y') ∨ (x = y' ∧ y = x') := by
-  obtain rfl | rfl := h.left_eq_or_eq_of_isLink h'
+  obtain rfl | rfl := h.left_eq_or_eq h'
   · simp [h.right_unique h']
   simp [h'.symm.right_unique h]
 
 lemma IsLink.isLink_iff (h : G.IsLink e x y) {x' y' : α} :
     G.IsLink e x' y' ↔ (x = x' ∧ y = y') ∨ (x = y' ∧ y = x') := by
-  refine ⟨h.eq_and_eq_or_eq_and_eq_of_isLink, ?_⟩
+  refine ⟨h.eq_and_eq_or_eq_and_eq, ?_⟩
   rintro (⟨rfl, rfl⟩ | ⟨rfl,rfl⟩)
   · assumption
   exact h.symm
@@ -159,7 +162,8 @@ lemma IsLink.isLink_iff_sym2_eq (h : G.IsLink e x y) {x' y' : α} :
 /-! ### Edge-vertex incidence -/
 
 /-- The unary incidence predicate of `G`. `G.Inc e x` means that the vertex `x`
-is one or both of the ends of the edge `e`. -/
+is one or both of the ends of the edge `e`.
+In the `Inc` namespace, we use `edge` and `vertex` to refer to `e` and `x`. -/
 def Inc (G : Graph α β) (e : β) (x : α) : Prop := ∃ y, G.IsLink e x y
 
 @[simp]
@@ -179,7 +183,7 @@ lemma IsLink.inc_right (h : G.IsLink e x y) : G.Inc e y :=
   ⟨x, h.symm⟩
 
 lemma Inc.eq_or_eq_of_isLink (h : G.Inc e x) (h' : G.IsLink e y z) : x = y ∨ x = z :=
-  h.choose_spec.left_eq_or_eq_of_isLink h'
+  h.choose_spec.left_eq_or_eq h'
 
 lemma Inc.eq_of_isLink_of_ne_left (h : G.Inc e x) (h' : G.IsLink e y z) (hxy : x ≠ y) : x = z :=
   (h.eq_or_eq_of_isLink h').elim (False.elim ∘ hxy) id
@@ -189,14 +193,14 @@ lemma isLink_iff_inc : G.IsLink e x y ↔ G.Inc e x ∧ G.Inc e y ∧ ∀ z, G.I
   refine ⟨fun h ↦ ⟨h.inc_left, h.inc_right, fun z h' ↦ h'.eq_or_eq_of_isLink h⟩, ?_⟩
   rintro ⟨⟨x', hx'⟩, ⟨y', hy'⟩, h⟩
   obtain rfl | rfl := h _ hx'.inc_right
-  · obtain rfl | rfl := hx'.left_eq_or_eq_of_isLink hy'
+  · obtain rfl | rfl := hx'.left_eq_or_eq hy'
     · assumption
     exact hy'.symm
   assumption
 
 /-- Given a proof that the edge `e` is incident with the vertex `x` in `G`,
 noncomputably find the other end of `e`. (If `e` is a loop, this is equal to `x` itself). -/
-noncomputable def Inc.other (h : G.Inc e x) : α := h.choose
+protected noncomputable def Inc.other (h : G.Inc e x) : α := h.choose
 
 @[simp]
 lemma Inc.isLink_other (h : G.Inc e x) : G.IsLink e x h.other :=
@@ -206,7 +210,7 @@ lemma Inc.isLink_other (h : G.Inc e x) : G.IsLink e x h.other :=
 lemma Inc.inc_other (h : G.Inc e x) : G.Inc e h.other :=
   h.isLink_other.inc_right
 
-lemma Inc.eq_or_eq_or_eq_of_inc_of_inc (hx : G.Inc e x) (hy : G.Inc e y) (hz : G.Inc e z) :
+lemma Inc.eq_or_eq_or_eq (hx : G.Inc e x) (hy : G.Inc e y) (hz : G.Inc e z) :
     x = y ∨ x = z ∨ y = z := by
   by_contra! hcon
   obtain ⟨x', hx'⟩ := hx
@@ -250,13 +254,13 @@ lemma IsNonloopAt.edge_mem (h : G.IsNonloopAt e x) : e ∈ E(G) :=
 lemma IsNonloopAt.vertex_mem (h : G.IsNonloopAt e x) : x ∈ V(G) :=
   h.inc.vertex_mem
 
-lemma IsLoopAt.not_isNonloop_at (h : G.IsLoopAt e x) (y : α) : ¬ G.IsNonloopAt e y := by
+lemma IsLoopAt.not_isNonloopAt (h : G.IsLoopAt e x) (y : α) : ¬ G.IsNonloopAt e y := by
   rintro ⟨z, hyz, hy⟩
   rw [← h.eq_of_inc hy.inc_left, ← h.eq_of_inc hy.inc_right] at hyz
   exact hyz rfl
 
 lemma IsNonloopAt.not_isLoopAt (h : G.IsNonloopAt e x) (y : α) : ¬ G.IsLoopAt e y :=
-  fun h' ↦ h'.not_isNonloop_at x h
+  fun h' ↦ h'.not_isNonloopAt x h
 
 lemma isNonloopAt_iff_inc_not_isLoopAt : G.IsNonloopAt e x ↔ G.Inc e x ∧ ¬ G.IsLoopAt e x :=
   ⟨fun h ↦ ⟨h.inc, h.not_isLoopAt _⟩, fun ⟨⟨y, hy⟩, hn⟩ ↦ ⟨y, mt (fun h ↦ h ▸ hy) hn, hy⟩⟩
@@ -272,7 +276,7 @@ lemma Inc.isLoopAt_or_isNonloopAt (h : G.Inc e x) : G.IsLoopAt e x ∨ G.IsNonlo
 /-- `G.Adj x y` means that `G` has an edge whose ends are the vertices `x` and `y`. -/
 def Adj (G : Graph α β) (x y : α) : Prop := ∃ e, G.IsLink e x y
 
-lemma Adj.symm (h : G.Adj x y) : G.Adj y x :=
+protected lemma Adj.symm (h : G.Adj x y) : G.Adj y x :=
   ⟨_, h.choose_spec.symm⟩
 
 lemma adj_comm : G.Adj x y ↔ G.Adj y x :=
@@ -298,7 +302,7 @@ lemma mk_eq_self (G : Graph α β) {E : Set β} (hE : ∀ e, e ∈ E ↔ ∃ x y
     Graph.mk V(G) G.IsLink E
     (by simpa [show E = E(G) by simp [Set.ext_iff, hE, G.edge_mem_iff_exists_isLink]]
       using G.isLink_symm)
-    (fun _ _ _ _ _ h h' ↦ h.left_eq_or_eq_of_isLink h') hE
+    (fun _ _ _ _ _ h h' ↦ h.left_eq_or_eq h') hE
     (fun _ _ _ ↦ IsLink.left_mem) = G := by
   obtain rfl : E = E(G) := by simp [Set.ext_iff, hE, G.edge_mem_iff_exists_isLink]
   cases G with | _ _ _ _ _ _ h _ => simp [← h]

--- a/Mathlib/Combinatorics/Graph/Basic.lean
+++ b/Mathlib/Combinatorics/Graph/Basic.lean
@@ -16,18 +16,18 @@ and there may also be more than one edge `e` whose ends are the same pair `(x,y)
 A multigraph where neither of these occurs is 'simple',
 and these objects are described by `SimpleGraph`.
 
-This module defines `Graph α β` for a vertex type `α` and an edge type `β`,
+This module defines `Graph α ε` for a vertex type `α` and an edge type `ε`,
 and gives basic API for incidence, adjacency and extensionality.
 The design broadly follows [Chou1994].
 
 ## Main definitions
 
-For `G : Graph α β`, ...
+For `G : Graph α ε`, ...
 
 * `G.V` denotes the vertex set of `G` as a term in `Set α`.
-* `G.E` denotes the edge set of `G` as a term in `Set β`.
-* `G.Inc₂ e x y` means that the edge `e : β` has vertices `x : α` and `y : α` as its ends.
-* `G.Inc e x` means that the edge `e : β` has `x` as one of its ends.
+* `G.E` denotes the edge set of `G` as a term in `Set ε`.
+* `G.Inc₂ e x y` means that the edge `e : ε` has vertices `x : α` and `y : α` as its ends.
+* `G.Inc e x` means that the edge `e : ε` has `x` as one of its ends.
 * `G.Adj x y` means that there is an edge `e` having `x` and `y` as its ends.
 * `G.IsLoopAt e x` means that `e` is a loop edge with both ends equal to `x`.
 * `G.IsNonloopAt e x` means that `e` is a non-loop edge with one end equal to `x`.
@@ -35,18 +35,18 @@ For `G : Graph α β`, ...
 ## Implementation notes
 
 Unlike the design of `SimpleGraph`, the vertex and edge sets of `G` are modelled as sets
-`G.V : Set α` and `G.E : Set β`, within ambient types, rather than being types themselves.
+`G.V : Set α` and `G.E : Set ε`, within ambient types, rather than being types themselves.
 This mimics the 'embedded set' design used in `Matroid`, which seems to be more convenient for
 formalizing real-world proofs in combinatorics.
 
-A specific advantage is that this will allow subgraphs of `G : Graph α β` to also exist on
-an equal footing with `G` as terms in `Graph α β`,
+A specific advantage is that this will allow subgraphs of `G : Graph α ε` to also exist on
+an equal footing with `G` as terms in `Graph α ε`,
 and so there is no need for an extensive `Graph.subgraph` API and all the associated
 definitions and canonical coercion maps. The same will go for minors and the various other
 partial orders on multigraphs.
 
 The main tradeoff is that parts of the API will require caring about whether a term
-`x : α` or `e : β` is a 'real' vertex or edge of the graph, rather than something outside
+`x : α` or `e : ε` is a 'real' vertex or edge of the graph, rather than something outside
 the vertex or edge set. This is an issue, but is likely amenable to automation.
 
 ## Notation
@@ -57,21 +57,24 @@ lemma names to refer to the same objects.
 
 -/
 
-variable {α β : Type*} {x y z u v w : α} {e f : β}
+variable {α ε : Type*} {x y z u v w : α} {e f : ε}
 
 open Set
 
-/-- A multigraph with vertex set `V : Set α` and edge set `E : Set β`,
-as described by a predicate describing whether an edge `e : β` has ends `x` and `y`. -/
-structure Graph (α β : Type*) where
+/-- A multigraph with vertex set `V : Set α` and edge set `E : Set ε`,
+as described by a predicate describing whether an edge `e : ε` has ends `x` and `y`.
+For definitional reasons, we include the edge set `E` as a structure field
+even though it can be inferred from `Inc₂` via `edge_mem_iff_exists_inc₂`;
+see `Graph.mk'` for a constructor that does not use `E`. -/
+structure Graph (α ε : Type*) where
   /-- The vertex set. -/
   V : Set α
   /-- The edge set. -/
-  E : Set β
+  E : Set ε
   /-- The binary incidence predicate, stating that `x` and `y` are the ends of an edge `e` -/
-  Inc₂ : β → α → α → Prop
+  Inc₂ : ε → α → α → Prop
   /-- If `e` goes from `x` to `y`, it goes from `y` to `x`. -/
-  inc₂_symm : ∀ e, Symmetric <| Inc₂ e
+  inc₂_symm : ∀ ⦃e⦄, e ∈ E → (Symmetric <| Inc₂ e)
   /-- An edge is incident with at most one pair of vertices. -/
   eq_or_eq_of_inc₂_of_inc₂ : ∀ ⦃e x y v w⦄, Inc₂ e x y → Inc₂ e v w → x = v ∨ x = w
   /-- An edge `e` is incident to something if and only if `e` is in the edge set -/
@@ -81,24 +84,24 @@ structure Graph (α β : Type*) where
 
 namespace Graph
 
-variable {G : Graph α β}
+variable {G : Graph α ε}
 
 /-! ### Edge-vertex-vertex incidence -/
 
-lemma Inc₂.symm (h : G.Inc₂ e x y) : G.Inc₂ e y x :=
-  G.inc₂_symm e h
-
-lemma inc₂_comm : G.Inc₂ e x y ↔ G.Inc₂ e y x :=
-  ⟨Inc₂.symm, Inc₂.symm⟩
-
 lemma Inc₂.edge_mem (h : G.Inc₂ e x y) : e ∈ G.E :=
   (edge_mem_iff_exists_inc₂ ..).2 ⟨x, y, h⟩
+
+lemma Inc₂.symm (h : G.Inc₂ e x y) : G.Inc₂ e y x :=
+  G.inc₂_symm h.edge_mem h
 
 lemma Inc₂.vx_mem_left (h : G.Inc₂ e x y) : x ∈ G.V :=
   G.vx_mem_left_of_inc₂ h
 
 lemma Inc₂.vx_mem_right (h : G.Inc₂ e x y) : y ∈ G.V :=
   h.symm.vx_mem_left
+
+lemma inc₂_comm : G.Inc₂ e x y ↔ G.Inc₂ e y x :=
+  ⟨Inc₂.symm, Inc₂.symm⟩
 
 lemma exists_inc₂_of_mem_edgeSet (h : e ∈ G.E) : ∃ x y, G.Inc₂ e x y :=
   (edge_mem_iff_exists_inc₂ ..).1 h
@@ -120,7 +123,7 @@ lemma Inc₂.eq_of_inc₂ (h : G.Inc₂ e x y) (h' : G.Inc₂ e x z) : y = z := 
 /-! ### Edge-vertex incidence -/
 
 /-- The unary incidence predicate of `G`. `G.Inc e x` means that `x` is one of the ends of `e`. -/
-def Inc (G : Graph α β) (e : β) (x : α) : Prop := ∃ y, G.Inc₂ e x y
+def Inc (G : Graph α ε) (e : ε) (x : α) : Prop := ∃ y, G.Inc₂ e x y
 
 @[simp]
 lemma Inc.edge_mem (h : G.Inc e x) : e ∈ G.E :=
@@ -175,7 +178,7 @@ lemma Inc.eq_or_eq_or_eq_of_inc_of_inc (hx : G.Inc e x) (hy : G.Inc e y) (hz : G
   exact hcon.2.2 rfl
 
 /-- `G.IsLoopAt e x` means that both ends of `e` are equal to `x`. -/
-def IsLoopAt (G : Graph α β) (e : β) (x : α) : Prop := G.Inc₂ e x x
+def IsLoopAt (G : Graph α ε) (e : ε) (x : α) : Prop := G.Inc₂ e x x
 
 @[simp]
 lemma inc₂_self_iff : G.Inc₂ e x x ↔ G.IsLoopAt e x := Iff.rfl
@@ -196,7 +199,7 @@ lemma IsLoopAt.vx_mem (h : G.IsLoopAt e x) : x ∈ G.V :=
 
 /-- `G.IsNonloopAt e x` means that `e` is an edge from `x` to some `y ≠ x`. -/
 @[mk_iff]
-structure IsNonloopAt (G : Graph α β) (e : β) (x : α) : Prop where
+structure IsNonloopAt (G : Graph α ε) (e : ε) (x : α) : Prop where
   inc : G.Inc e x
   exists_inc₂_ne : ∃ y ≠ x, G.Inc₂ e x y
 
@@ -226,7 +229,7 @@ lemma Inc.isLoopAt_or_isNonloopAt (h : G.Inc e x) : G.IsLoopAt e x ∨ G.IsNonlo
 /-! ### Adjacency -/
 
 /-- `G.Adj x y` means that `G` has an edge from `x` to `y`. -/
-def Adj (G : Graph α β) (x y : α) : Prop := ∃ e, G.Inc₂ e x y
+def Adj (G : Graph α ε) (x y : α) : Prop := ∃ e, G.Inc₂ e x y
 
 lemma Adj.symm (h : G.Adj x y) : G.Adj y x :=
   ⟨_, h.choose_spec.symm⟩
@@ -250,20 +253,20 @@ lemma Inc₂.adj (h : G.Inc₂ e x y) : G.Adj x y :=
 /-- A constructor for `Graph` in which the edge set is inferred from the incidence predicate
 rather than supplied explicitly. -/
 @[simps]
-protected def mk' (V : Set α) (Inc₂ : β → α → α → Prop)
+protected def mk' (V : Set α) (Inc₂ : ε → α → α → Prop)
     (inc₂_symm : ∀ ⦃e x y⦄, Inc₂ e x y → Inc₂ e y x)
     (eq_or_eq_of_inc₂_of_inc₂ : ∀ ⦃e x y v w⦄, Inc₂ e x y → Inc₂ e v w → x = v ∨ x = w)
-    (vx_mem_left_of_inc₂ : ∀ ⦃e x y⦄, Inc₂ e x y → x ∈ V) : Graph α β where
+    (vx_mem_left_of_inc₂ : ∀ ⦃e x y⦄, Inc₂ e x y → x ∈ V) : Graph α ε where
   V := V
   E := {e | ∃ x y, Inc₂ e x y}
   Inc₂ := Inc₂
-  inc₂_symm := inc₂_symm
+  inc₂_symm _ _ _ _ h := inc₂_symm h
   eq_or_eq_of_inc₂_of_inc₂ := eq_or_eq_of_inc₂_of_inc₂
   edge_mem_iff_exists_inc₂ _ := Iff.rfl
   vx_mem_left_of_inc₂ := vx_mem_left_of_inc₂
 
 @[simp]
-lemma mk'_eq_self (G : Graph α β) : Graph.mk' G.V G.Inc₂ (fun _ _ _ ↦ Inc₂.symm)
+lemma mk'_eq_self (G : Graph α ε) : Graph.mk' G.V G.Inc₂ (fun _ _ _ ↦ Inc₂.symm)
   (fun _ _ _ _ _ h h' ↦ h.left_eq_or_eq_of_inc₂ h') (fun _ _ _ ↦ Inc₂.vx_mem_left) = G := by
   have h := G.edgeSet_eq_setOf_exists_inc₂
   cases G with | mk V E Inc₂ _ _ _ => simpa [Graph.mk'] using h.symm
@@ -272,7 +275,7 @@ lemma mk'_eq_self (G : Graph α β) : Graph.mk' G.V G.Inc₂ (fun _ _ _ ↦ Inc�
 (We use this as the default extensionality lemma rather than adding `@[ext]`
 to the definition of `Graph`, so it doesn't require equality of the edge sets.) -/
 @[ext]
-protected lemma ext {G₁ G₂ : Graph α β} (hV : G₁.V = G₂.V)
+protected lemma ext {G₁ G₂ : Graph α ε} (hV : G₁.V = G₂.V)
     (h : ∀ e x y, G₁.Inc₂ e x y ↔ G₂.Inc₂ e x y) : G₁ = G₂ := by
   rw [← G₁.mk'_eq_self, ← G₂.mk'_eq_self]
   simp_rw [hV]
@@ -282,7 +285,7 @@ protected lemma ext {G₁ G₂ : Graph α β} (hV : G₁.V = G₂.V)
 
 /-- Two graphs with the same vertex set and unary incidences are equal. -/
 @[ext]
-lemma ext_inc {G₁ G₂ : Graph α β} (hV : G₁.V = G₂.V) (h : ∀ e x, G₁.Inc e x ↔ G₂.Inc e x) :
+lemma ext_inc {G₁ G₂ : Graph α ε} (hV : G₁.V = G₂.V) (h : ∀ e x, G₁.Inc e x ↔ G₂.Inc e x) :
     G₁ = G₂ :=
   Graph.ext hV fun _ _ _ ↦ by simp_rw [inc₂_iff_inc, h]
 

--- a/Mathlib/Combinatorics/Graph/Basic.lean
+++ b/Mathlib/Combinatorics/Graph/Basic.lean
@@ -113,7 +113,7 @@ lemma exists_isLink_of_mem_edgeSet (h : e ∈ E(G)) : ∃ x y, G.IsLink e x y :=
   (edge_mem_iff_exists_isLink ..).1 h
 
 lemma edgeSet_eq_setOf_exists_isLink : E(G) = {e | ∃ x y, G.IsLink e x y} :=
-  Set.ext fun e ↦ G.edge_mem_iff_exists_isLink e
+  Set.ext G.edge_mem_iff_exists_isLink
 
 lemma IsLink.left_eq_or_eq_of_isLink (h : G.IsLink e x y) (h' : G.IsLink e z w) : x = z ∨ x = w :=
   G.eq_or_eq_of_isLink_of_isLink h h'

--- a/Mathlib/Combinatorics/Graph/Basic.lean
+++ b/Mathlib/Combinatorics/Graph/Basic.lean
@@ -65,9 +65,14 @@ open Set
 
 /-- A multigraph with vertex set `vertexSet : Set α` and edge set `edgeSet : Set β`,
 as described by a predicate `IsLink` describing whether an edge `e : β` has ends `x` and `y`.
-For definitional reasons, we include `edgeSet` as a structure field
-even though it can be inferred from `IsLink` via `edge_mem_iff_exists_isLink`;
-The default value for `edgeSet` infers its value in this way.
+
+The `edgeSet` structure field can be inferred from `IsLink`
+via `edge_mem_iff_exists_isLink` (and this structure provides default values
+for `edgeSet` and `edge_mem_iff_exists_isLink` that use `IsLink`).
+While the field is not strictly necessary, when defining a graph we often
+immediately know what the edge set should be,
+and furthermore having `edgeSet` separate can be convenient for
+definitional equality reasons.
 -/
 structure Graph (α β : Type*) where
   /-- The vertex set. -/

--- a/Mathlib/Combinatorics/Graph/Basic.lean
+++ b/Mathlib/Combinatorics/Graph/Basic.lean
@@ -56,9 +56,7 @@ the vertex or edge set. This is an issue, but is likely amenable to automation.
 
 Reflecting written mathematics, we use the compact notations `V(G)` and `E(G)` to
 refer to the `vertexSet` and `edgeSet` of `G : Graph α β`.
-If `G.IsLink e x y` is true, then we refer to `e` as `edge` and `x` and `y` as `vertex_left`
-and `vertex_right` in names.
-
+If `G.IsLink e x y` then we refer to `e` as `edge` and `x` and `y` as `left` and `right` in names.
 -/
 
 variable {α β : Type*} {x y z u v w : α} {e f : β}
@@ -122,11 +120,11 @@ lemma edgeSet_eq_setOf_exists_isLink : E(G) = {e | ∃ x y, G.IsLink e x y} :=
 lemma IsLink.left_eq_or_eq_of_isLink (h : G.IsLink e x y) (h' : G.IsLink e z w) : x = z ∨ x = w :=
   G.eq_or_eq_of_isLink_of_isLink h h'
 
-lemma IsLink.left_eq_of_isLink_of_ne (h : G.IsLink e x y) (h' : G.IsLink e z w)
-    (hzx : x ≠ z) : x = w :=
+lemma IsLink.left_eq_of_isLink_of_ne (h : G.IsLink e x y) (h' : G.IsLink e z w) (hzx : x ≠ z) :
+    x = w :=
   (h.left_eq_or_eq_of_isLink h').elim (False.elim ∘ hzx) id
 
-lemma IsLink.eq_of_isLink (h : G.IsLink e x y) (h' : G.IsLink e x z) : y = z := by
+lemma IsLink.right_eq_of_isLink (h : G.IsLink e x y) (h' : G.IsLink e x z) : y = z := by
   obtain rfl | rfl := h.symm.left_eq_or_eq_of_isLink h'.symm
   · rfl
   obtain rfl | rfl := h'.symm.left_eq_or_eq_of_isLink h.symm <;> rfl
@@ -230,7 +228,8 @@ lemma IsLoopAt.vertex_mem (h : G.IsLoopAt e x) : x ∈ V(G) :=
   h.inc.vertex_mem
 
 /-- `G.IsNonloopAt e x` means that `e` is an edge from `x` to some `y ≠ x`,
-or equivalently that `e` is incident with `x` but not a loop at `x`. -/
+or equivalently that `e` is incident with `x` but not a loop at `x` -
+see `Graph.isNonloopAt_iff_inc_not_isLoopAt`. -/
 def IsNonloopAt (G : Graph α β) (e : β) (x : α) : Prop := ∃ y ≠ x, G.IsLink e x y
 
 lemma IsNonloopAt.inc (h : G.IsNonloopAt e x) : G.Inc e x :=
@@ -273,12 +272,12 @@ lemma adj_comm : G.Adj x y ↔ G.Adj y x :=
   ⟨Adj.symm, Adj.symm⟩
 
 @[simp]
-lemma Adj.mem_left (h : G.Adj x y) : x ∈ V(G) :=
+lemma Adj.left_mem (h : G.Adj x y) : x ∈ V(G) :=
   h.choose_spec.left_mem
 
 @[simp]
-lemma Adj.mem_right (h : G.Adj x y) : y ∈ V(G) :=
-  h.symm.mem_left
+lemma Adj.right_mem (h : G.Adj x y) : y ∈ V(G) :=
+  h.symm.left_mem
 
 lemma IsLink.adj (h : G.IsLink e x y) : G.Adj x y :=
   ⟨e, h⟩
@@ -286,7 +285,7 @@ lemma IsLink.adj (h : G.IsLink e x y) : G.Adj x y :=
 /-! ### Extensionality -/
 
 /-- A constructor for `Graph` in which the edge set is inferred from the incidence predicate
-rather than supplied explicitly. -/
+rather than being supplied explicitly. -/
 @[simps]
 protected def mk' (vertexSet : Set α) (IsLink : β → α → α → Prop)
     (isLink_symm : ∀ ⦃e x y⦄, IsLink e x y → IsLink e y x)

--- a/Mathlib/Combinatorics/Graph/Basic.lean
+++ b/Mathlib/Combinatorics/Graph/Basic.lean
@@ -40,13 +40,13 @@ Unlike the design of `SimpleGraph`, the vertex and edge sets of `G` are modelled
 This mimics the 'embedded set' design used in `Matroid`, which seems to be more convenient for
 formalizing real-world proofs in combinatorics.
 
-A specific advantage is that this will allow subgraphs of `G : Graph α β` to also exist on
+A specific advantage is that this allows subgraphs of `G : Graph α β` to also exist on
 an equal footing with `G` as terms in `Graph α β`,
-and so there is no need for an extensive `Graph.subgraph` API and all the associated
+and so there is no need for a `Graph.subgraph` type and all the associated
 definitions and canonical coercion maps. The same will go for minors and the various other
 partial orders on multigraphs.
 
-The main tradeoff is that parts of the API will require caring about whether a term
+The main tradeoff is that parts of the API will need to care about whether a term
 `x : α` or `e : β` is a 'real' vertex or edge of the graph, rather than something outside
 the vertex or edge set. This is an issue, but is likely amenable to automation.
 
@@ -61,23 +61,23 @@ variable {α β : Type*} {x y z u v w : α} {e f : β}
 
 open Set
 
-/-- A multigraph with vertex set `V : Set α` and edge set `E : Set β`,
+/-- A multigraph with vertex set `vertexSet : Set α` and edge set `edgeSet : Set β`,
 as described by a predicate describing whether an edge `e : β` has ends `x` and `y`.
-For definitional reasons, we include the edge set `E` as a structure field
+For definitional reasons, we include `edgeSet` as a structure field
 even though it can be inferred from `IsLink` via `edge_mem_iff_exists_isLink`;
-see `Graph.mk'` for a constructor that does not use `E`. -/
+see `Graph.mk'` for a constructor that does not use `edgeSet`. -/
 structure Graph (α β : Type*) where
   /-- The vertex set. -/
   vertexSet : Set α
   /-- The edge set. -/
   edgeSet : Set β
-  /-- The binary incidence predicate, stating that `x` and `y` are the ends of an edge `e` -/
+  /-- The binary incidence predicate, stating that `x` and `y` are the ends of an edge `e`. -/
   IsLink : β → α → α → Prop
   /-- If `e` goes from `x` to `y`, it goes from `y` to `x`. -/
   isLink_symm : ∀ ⦃e⦄, e ∈ edgeSet → (Symmetric <| IsLink e)
   /-- An edge is incident with at most one pair of vertices. -/
   eq_or_eq_of_isLink_of_isLink : ∀ ⦃e x y v w⦄, IsLink e x y → IsLink e v w → x = v ∨ x = w
-  /-- An edge `e` is incident to something if and only if `e` is in the edge set -/
+  /-- An edge `e` is incident to something if and only if `e` is in the edge set. -/
   edge_mem_iff_exists_isLink : ∀ e, e ∈ edgeSet ↔ ∃ x y, IsLink e x y
   /-- If some edge `e` is incident to `x`, then `x ∈ V`. -/
   vx_mem_left_of_isLink : ∀ ⦃e x y⦄, IsLink e x y → x ∈ vertexSet

--- a/Mathlib/Combinatorics/Graph/Basic.lean
+++ b/Mathlib/Combinatorics/Graph/Basic.lean
@@ -63,8 +63,9 @@ variable {α β : Type*} {x y z u v w : α} {e f : β}
 
 open Set
 
-/-- A multigraph with vertex set `vertexSet : Set α` and edge set `edgeSet : Set β`,
-as described by a predicate `IsLink` describing whether an edge `e : β` has ends `x` and `y`.
+/-- A multigraph with vertices of type `α` and edges of type `β`,
+as described by vertex and edge sets `vertexSet : Set α` and `edgeSet : Set β`,
+and a predicate `IsLink` describing whether an edge `e : β` has vertices `x y : α` as its ends.
 
 The `edgeSet` structure field can be inferred from `IsLink`
 via `edge_mem_iff_exists_isLink` (and this structure provides default values

--- a/Mathlib/Combinatorics/Graph/Basic.lean
+++ b/Mathlib/Combinatorics/Graph/Basic.lean
@@ -112,6 +112,11 @@ lemma Inc₂.left_eq_or_eq_of_inc₂ (h : G.Inc₂ e x y) (h' : G.Inc₂ e z w) 
 lemma Inc₂.left_eq_of_inc₂_of_ne (h : G.Inc₂ e x y) (h' : G.Inc₂ e z w) (hzx : x ≠ z) : x = w :=
   (h.left_eq_or_eq_of_inc₂ h').elim (False.elim ∘ hzx) id
 
+lemma Inc₂.eq_of_inc₂ (h : G.Inc₂ e x y) (h' : G.Inc₂ e x z) : y = z := by
+  obtain rfl | rfl := h.symm.left_eq_or_eq_of_inc₂ h'.symm
+  · rfl
+  obtain rfl | rfl := h'.symm.left_eq_or_eq_of_inc₂ h.symm <;> rfl
+
 /-! ### Edge-vertex incidence -/
 
 /-- The unary incidence predicate of `G`. `G.Inc e x` means that `x` is one of the ends of `e`. -/

--- a/Mathlib/Combinatorics/Graph/Basic.lean
+++ b/Mathlib/Combinatorics/Graph/Basic.lean
@@ -1,5 +1,61 @@
+/-
+Copyright (c) 2025 Peter Nelson. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Peter Nelson, Jun Kwon
+-/
 import Mathlib.Data.Set.Basic
 
+/-!
+# Multigraphs
+
+A multigraph is a set of vertices and a set of edges,
+together with incidence data that associates each edge `e`
+with an unordered pair `(x,y)` of vertices called the 'ends' of `e`.
+`x` and `y` may be equal, in which case `e` is a 'loop',
+and there may also be more than one edge `e` whose ends are the same pair `(x,y)`.
+A multigraph where neither of these occurs is 'simple',
+and these objects are described by `SimpleGraph`.
+
+This module defines `Graph α β` for a vertex type `α` and an edge type `β`,
+and gives basic API for incidence, adjacency and extensionality.
+The design broadly follows [Chou1994].
+
+## Main definitions
+
+For `G : Graph α β`, ...
+
+* `G.V` denotes the vertex set of `G` as a term in `Set α`.
+* `G.E` denotes the edge set of `G` as a term in `Set β`.
+* `G.Inc₂ e x y` means that the edge `e : β` has vertices `x : α` and `y : α` as its ends.
+* `G.Inc e x` means that the edge `e : β` has `x` as one of its ends.
+* `G.Adj x y` means that there is an edge `e` having `x` and `y` as its ends.
+* `G.IsLoopAt e x` means that `e` is a loop edge with both ends equal to `x`.
+* `G.IsNonloopAt e x` means that `e` is a non-loop edge with one end equal to `x`.
+
+## Implementation notes
+
+Unlike the design of `SimpleGraph`, the vertex and edge sets of `G` are modelled as sets
+`G.V : Set α` and `G.E : Set β`, within ambient types, rather than being types themselves.
+This mimics the 'embedded set' design used in `Matroid`, which seems to be more convenient for
+formalizing real-world proofs in combinatorics.
+
+A specific advantage is that this will allow subgraphs of `G : Graph α β` to also exist on
+an equal footing with `G` as terms in `Graph α β`,
+and so there is no need for an extensive `Graph.subgraph` API and all the associated
+definitions and canonical coercion maps. The same will go for minors and the various other
+partial orders on multigraphs.
+
+The main tradeoff is that parts of the API will require caring about whether a term
+`x : α` or `e : β` is a 'real' vertex or edge of the graph, rather than something outside
+the vertex or edge set. This is an issue, but is likely amenable to automation.
+
+## Notation
+
+Relecting written mathematics, we use the compact notations `G.V` and `G.E` to describe
+vertex and edge sets formally, but use the longer terms `vxSet` and `edgeSet` within
+lemma names to refer to the same objects.
+
+-/
 
 variable {α β : Type*} {x y z u v w : α} {e f : β}
 
@@ -12,13 +68,13 @@ structure Graph (α β : Type*) where
   V : Set α
   /-- The edge set. -/
   E : Set β
-  /-- The predicate that an edge `e` goes from `x` to `y`. -/
+  /-- The binary incidence predicate, stating that `x` and `y` are the ends of an edge `e` -/
   Inc₂ : β → α → α → Prop
   /-- If `e` goes from `x` to `y`, it goes from `y` to `x`. -/
   inc₂_symm : ∀ ⦃e x y⦄, Inc₂ e x y → Inc₂ e y x
   /-- An edge is incident with at most one pair of vertices. -/
   eq_or_eq_of_inc₂_of_inc₂ : ∀ ⦃e x y v w⦄, Inc₂ e x y → Inc₂ e v w → x = v ∨ x = w
-  /-- If `e` is incident to something, then `e` is in the edge set -/
+  /-- An edge `e` is incident to something if and only if `e` is in the edge set -/
   edge_mem_iff_exists_inc₂ : ∀ e, e ∈ E ↔ ∃ x y, Inc₂ e x y
   /-- If some edge `e` is incident to `x`, then `x ∈ V`. -/
   vx_mem_left_of_inc₂ : ∀ ⦃e x y⦄, Inc₂ e x y → x ∈ V
@@ -26,6 +82,8 @@ structure Graph (α β : Type*) where
 namespace Graph
 
 variable {G H : Graph α β}
+
+/-! ### Edge-vertex-vertex incidence -/
 
 lemma Inc₂.symm (h : G.Inc₂ e x y) : G.Inc₂ e y x :=
   G.inc₂_symm h
@@ -42,8 +100,11 @@ lemma Inc₂.vx_mem_left (h : G.Inc₂ e x y) : x ∈ G.V :=
 lemma Inc₂.vx_mem_right (h : G.Inc₂ e x y) : y ∈ G.V :=
   h.symm.vx_mem_left
 
-lemma exists_inc₂_of_edge_mem (h : e ∈ G.E) : ∃ x y, G.Inc₂ e x y :=
+lemma exists_inc₂_of_mem_edgeSet (h : e ∈ G.E) : ∃ x y, G.Inc₂ e x y :=
   (edge_mem_iff_exists_inc₂ ..).1 h
+
+lemma edgeSet_eq_setOf_exists_inc₂ : G.E = {e | ∃ x y, G.Inc₂ e x y} :=
+  Set.ext fun e ↦ G.edge_mem_iff_exists_inc₂ e
 
 lemma Inc₂.left_eq_or_eq_of_inc₂ (h : G.Inc₂ e x y) (h' : G.Inc₂ e z w) : x = z ∨ x = w :=
   G.eq_or_eq_of_inc₂_of_inc₂ h h'
@@ -51,8 +112,18 @@ lemma Inc₂.left_eq_or_eq_of_inc₂ (h : G.Inc₂ e x y) (h' : G.Inc₂ e z w) 
 lemma Inc₂.left_eq_of_inc₂_of_ne (h : G.Inc₂ e x y) (h' : G.Inc₂ e z w) (hzx : x ≠ z) : x = w :=
   (h.left_eq_or_eq_of_inc₂ h').elim (False.elim ∘ hzx) id
 
-/-- `Inc e x` means that `x` is one of the ends of `e`. -/
+/-! ### Edge-vertex incidence -/
+
+/-- The unary incidence predicate of `G`. `G.Inc e x` means that `x` is one of the ends of `e`. -/
 def Inc (G : Graph α β) (e : β) (x : α) : Prop := ∃ y, G.Inc₂ e x y
+
+@[simp]
+lemma Inc.edge_mem (h : G.Inc e x) : e ∈ G.E :=
+  h.choose_spec.edge_mem
+
+@[simp]
+lemma Inc.vx_mem (h : G.Inc e x) : x ∈ G.V :=
+  h.choose_spec.vx_mem_left
 
 @[simp]
 lemma Inc₂.inc_left (h : G.Inc₂ e x y) : G.Inc e x :=
@@ -68,7 +139,29 @@ lemma Inc.eq_or_eq_of_inc₂ (h : G.Inc e x) (h' : G.Inc₂ e y z) : x = y ∨ x
 lemma Inc.eq_of_inc₂_of_ne_left (h : G.Inc e x) (h' : G.Inc₂ e y z) (hxy : x ≠ y) : x = z :=
   (h.eq_or_eq_of_inc₂ h').elim (False.elim ∘ hxy) id
 
-lemma eq_or_eq_or_eq_of_inc_of_inc_of_inc (hx : G.Inc e x) (hy : G.Inc e y) (hz : G.Inc e z) :
+/-- The binary incidence predicate can be expressed in terms of the unary one. -/
+lemma inc₂_iff_inc : G.Inc₂ e x y ↔ G.Inc e x ∧ G.Inc e y ∧ ∀ z, G.Inc e z → z = x ∨ z = y := by
+  refine ⟨fun h ↦ ⟨h.inc_left, h.inc_right, fun z h' ↦ h'.eq_or_eq_of_inc₂ h⟩, ?_⟩
+  rintro ⟨⟨x', hx'⟩, ⟨y', hy'⟩, h⟩
+  obtain rfl | rfl := h _ hx'.inc_right
+  · obtain rfl | rfl := hx'.left_eq_or_eq_of_inc₂ hy'
+    · assumption
+    exact hy'.symm
+  assumption
+
+/-- Given a proof that `e` is incident with `x`, noncomputably find the other end of `e`.
+(If `e` is a loop, this is equal to `x` itself). -/
+noncomputable def Inc.other (h : G.Inc e x) : α := h.choose
+
+@[simp]
+lemma Inc.inc₂_other (h : G.Inc e x) : G.Inc₂ e x h.other :=
+  h.choose_spec
+
+@[simp]
+lemma Inc.inc_other (h : G.Inc e x) : G.Inc e h.other :=
+  h.inc₂_other.inc_right
+
+lemma Inc.eq_or_eq_or_eq_of_inc_of_inc (hx : G.Inc e x) (hy : G.Inc e y) (hz : G.Inc e z) :
     x = y ∨ x = z ∨ y = z := by
   by_contra! hcon
   obtain ⟨x', hx'⟩ := hx
@@ -76,16 +169,39 @@ lemma eq_or_eq_or_eq_of_inc_of_inc_of_inc (hx : G.Inc e x) (hy : G.Inc e y) (hz 
   obtain rfl := hz.eq_of_inc₂_of_ne_left hx' hcon.2.1.symm
   exact hcon.2.2 rfl
 
-/-- `G.IsLoopAt e x` means that `e` is a loop edge at the vertex `x`. -/
+/-- `G.IsLoopAt e x` means that both ends of `e` are equal to `x`. -/
 def IsLoopAt (G : Graph α β) (e : β) (x : α) : Prop := G.Inc₂ e x x
+
+@[simp]
+lemma inc₂_self_iff : G.Inc₂ e x x ↔ G.IsLoopAt e x := Iff.rfl
+
+lemma IsLoopAt.inc (h : G.IsLoopAt e x) : G.Inc e x :=
+  Inc₂.inc_left h
 
 lemma IsLoopAt.eq_of_inc (h : G.IsLoopAt e x) (h' : G.Inc e y) : x = y := by
   obtain rfl | rfl := h'.eq_or_eq_of_inc₂ h <;> rfl
 
+@[simp]
+lemma IsLoopAt.edge_mem (h : G.IsLoopAt e x) : e ∈ G.E :=
+  h.inc.edge_mem
+
+@[simp]
+lemma IsLoopAt.vx_mem (h : G.IsLoopAt e x) : x ∈ G.V :=
+  h.inc.vx_mem
+
+/-- `G.IsNonloopAt e x` means that `e` is an edge from `x` to some `y ≠ x`. -/
 @[mk_iff]
 structure IsNonloopAt (G : Graph α β) (e : β) (x : α) : Prop where
   inc : G.Inc e x
   exists_inc₂_ne : ∃ y ≠ x, G.Inc₂ e x y
+
+@[simp]
+lemma IsNonloopAt.edge_mem (h : G.IsNonloopAt e x) : e ∈ G.E :=
+  h.inc.edge_mem
+
+@[simp]
+lemma IsNonloopAt.vx_mem (h : G.IsNonloopAt e x) : x ∈ G.V :=
+  h.inc.vx_mem
 
 lemma IsLoopAt.not_isNonloop_at (h : G.IsLoopAt e x) (y : α) : ¬ G.IsNonloopAt e y := by
   intro h'
@@ -96,41 +212,70 @@ lemma IsLoopAt.not_isNonloop_at (h : G.IsLoopAt e x) (y : α) : ¬ G.IsNonloopAt
 lemma IsNonloopAt.not_isLoopAt (h : G.IsNonloopAt e x) (y : α) : ¬ G.IsLoopAt e y :=
   fun h' ↦ h'.not_isNonloop_at x h
 
-lemm
+lemma Inc.isLoopAt_or_isNonloopAt (h : G.Inc e x) : G.IsLoopAt e x ∨ G.IsNonloopAt e x := by
+  obtain ⟨y, hy⟩ := h
+  obtain rfl | hne := eq_or_ne x y
+  · exact .inl hy
+  exact .inr ⟨hy.inc_left, y, hne.symm, hy⟩
 
+/-! ### Adjacency -/
 
-/-- Restrict `G : Graph α β` to the edges in a set `E₀` without removing vertices -/
-def edgeRestrict (G : Graph α β) (E₀ : Set β) : Graph α β where
-  V := G.V
-  E := E₀ ∩ G.E
-  Inc₂ e x y := e ∈ E₀ ∧ G.Inc₂ e x y
-  inc₂_symm e x y h := by rwa [G.inc₂_comm]
-  eq_or_eq_of_inc₂_of_inc₂ _ _ _ _ _ h h' := h.2.left_eq_or_eq_of_inc₂ h'.2
-  edge_mem_iff_exists_inc₂ e :=
-    ⟨fun h ↦ by simp [h, G.exists_inc₂_of_edge_mem h.2, h.1], fun ⟨x, y, h⟩ ↦ ⟨h.1, h.2.edge_mem⟩⟩
-  vx_mem_left_of_inc₂ _ _ _ h := h.2.vx_mem_left
+/-- `G.Adj x y` means that `G` has an edge from `x` to `y`. -/
+def Adj (G : Graph α β) (x y : α) : Prop := ∃ e, G.Inc₂ e x y
 
-/-- Map `G : Graph α β` to a `Graph α' β` with the same edge set
-by applying a function `f : α → α'` to each vertex.
-Edges between identified vertices become loops. -/
-def vxMap {α' : Type*} (G : Graph α β) (f : α → α') : Graph α' β where
-  V := f '' G.V
-  E := G.E
-  Inc₂ e x' y' := ∃ x y, G.Inc₂ e x y ∧ x' = f x ∧ y' = f y
-  inc₂_symm := by
-    rintro e - - ⟨x, y, h, rfl, rfl⟩
-    exact ⟨y, x, h.symm, rfl, rfl⟩
-  eq_or_eq_of_inc₂_of_inc₂ := by
-    rintro e - - - - ⟨x, y, hxy, rfl, rfl⟩ ⟨z, w, hzw, rfl, rfl⟩
-    obtain rfl | rfl := hxy.left_eq_or_eq_of_inc₂ hzw <;> simp
-  edge_mem_iff_exists_inc₂ e := by
-    refine ⟨fun h ↦ ?_, ?_⟩
-    · obtain ⟨x, y, hxy⟩ := exists_inc₂_of_edge_mem h
-      exact ⟨_, _, _, _, hxy, rfl, rfl⟩
-    rintro ⟨-, -, x, y, h, rfl, rfl⟩
-    exact h.edge_mem
-  vx_mem_left_of_inc₂ := by
-    rintro e - - ⟨x, y, h, rfl, rfl⟩
-    exact mem_image_of_mem _ h.vx_mem_left
+lemma Adj.symm (h : G.Adj x y) : G.Adj y x :=
+  ⟨_, h.choose_spec.symm⟩
+
+lemma adj_comm : G.Adj x y ↔ G.Adj y x :=
+  ⟨Adj.symm, Adj.symm⟩
+
+@[simp]
+lemma Adj.mem_left (h : G.Adj x y) : x ∈ G.V :=
+  h.choose_spec.vx_mem_left
+
+@[simp]
+lemma Adj.mem_right (h : G.Adj x y) : y ∈ G.V :=
+  h.symm.mem_left
+
+lemma Inc₂.adj (h : G.Inc₂ e x y) : G.Adj x y :=
+  ⟨e, h⟩
+
+/-! ### Extensionality -/
+
+/-- A constructor for `Graph` in which the edge set is inferred from the incidence predicate
+rather than supplied explicitly. -/
+@[simps]
+protected def mk' (V : Set α) (Inc₂ : β → α → α → Prop)
+    (inc₂_symm : ∀ ⦃e x y⦄, Inc₂ e x y → Inc₂ e y x)
+    (eq_or_eq_of_inc₂_of_inc₂ : ∀ ⦃e x y v w⦄, Inc₂ e x y → Inc₂ e v w → x = v ∨ x = w)
+    (vx_mem_left_of_inc₂ : ∀ ⦃e x y⦄, Inc₂ e x y → x ∈ V) : Graph α β where
+  V := V
+  E := {e | ∃ x y, Inc₂ e x y}
+  Inc₂ := Inc₂
+  inc₂_symm := inc₂_symm
+  eq_or_eq_of_inc₂_of_inc₂ := eq_or_eq_of_inc₂_of_inc₂
+  edge_mem_iff_exists_inc₂ _ := Iff.rfl
+  vx_mem_left_of_inc₂ := vx_mem_left_of_inc₂
+
+@[simp]
+lemma mk'_eq_self (G : Graph α β) : Graph.mk' G.V G.Inc₂ (fun _ _ _ ↦ Inc₂.symm)
+  (fun _ _ _ _ _ h h' ↦ h.left_eq_or_eq_of_inc₂ h') (fun _ _ _ ↦ Inc₂.vx_mem_left) = G := by
+  have h := G.edgeSet_eq_setOf_exists_inc₂
+  cases G with | mk V E Inc₂ _ _ _ => simpa [Graph.mk'] using h.symm
+
+/-- Two graphs with the same vertex set and binary incidences are equal. -/
+@[ext]
+protected lemma ext {G₁ G₂ : Graph α β} (hV : G₁.V = G₂.V)
+    (h : ∀ e x y, G₁.Inc₂ e x y ↔ G₂.Inc₂ e x y) : G₁ = G₂ := by
+  rw [← G₁.mk'_eq_self, ← G₂.mk'_eq_self]
+  simp_rw [hV]
+  convert rfl using 2
+  ext
+  rw [h]
+
+/-- Two graphs with the same vertex set and unary incidences are equal. -/
+lemma ext_inc {G₁ G₂ : Graph α β} (hV : G₁.V = G₂.V) (h : ∀ e x, G₁.Inc e x ↔ G₂.Inc e x) :
+    G₁ = G₂ :=
+  Graph.ext hV fun e x y ↦ by simp_rw [inc₂_iff_inc, h]
 
 end Graph

--- a/Mathlib/Combinatorics/Graph/Basic.lean
+++ b/Mathlib/Combinatorics/Graph/Basic.lean
@@ -71,7 +71,7 @@ structure Graph (α β : Type*) where
   /-- The binary incidence predicate, stating that `x` and `y` are the ends of an edge `e` -/
   Inc₂ : β → α → α → Prop
   /-- If `e` goes from `x` to `y`, it goes from `y` to `x`. -/
-  inc₂_symm : ∀ ⦃e x y⦄, Inc₂ e x y → Inc₂ e y x
+  inc₂_symm : ∀ e, Symmetric <| Inc₂ e
   /-- An edge is incident with at most one pair of vertices. -/
   eq_or_eq_of_inc₂_of_inc₂ : ∀ ⦃e x y v w⦄, Inc₂ e x y → Inc₂ e v w → x = v ∨ x = w
   /-- An edge `e` is incident to something if and only if `e` is in the edge set -/
@@ -86,7 +86,7 @@ variable {G H : Graph α β}
 /-! ### Edge-vertex-vertex incidence -/
 
 lemma Inc₂.symm (h : G.Inc₂ e x y) : G.Inc₂ e y x :=
-  G.inc₂_symm h
+  G.inc₂_symm e h
 
 lemma inc₂_comm : G.Inc₂ e x y ↔ G.Inc₂ e y x :=
   ⟨Inc₂.symm, Inc₂.symm⟩
@@ -270,7 +270,7 @@ lemma mk'_eq_self (G : Graph α β) : Graph.mk' G.V G.Inc₂ (fun _ _ _ ↦ Inc�
 
 /-- Two graphs with the same vertex set and binary incidences are equal.
 (We use this as the default extensionality lemma rather than adding `@[ext]`
-to the definition, so it doesn't require equality of the edge sets.) -/
+to the definition of `Graph`, so it doesn't require equality of the edge sets.) -/
 @[ext]
 protected lemma ext {G₁ G₂ : Graph α β} (hV : G₁.V = G₂.V)
     (h : ∀ e x y, G₁.Inc₂ e x y ↔ G₂.Inc₂ e x y) : G₁ = G₂ := by
@@ -281,6 +281,7 @@ protected lemma ext {G₁ G₂ : Graph α β} (hV : G₁.V = G₂.V)
   rw [h]
 
 /-- Two graphs with the same vertex set and unary incidences are equal. -/
+@[ext]
 lemma ext_inc {G₁ G₂ : Graph α β} (hV : G₁.V = G₂.V) (h : ∀ e x, G₁.Inc e x ↔ G₂.Inc e x) :
     G₁ = G₂ :=
   Graph.ext hV fun _ _ _ ↦ by simp_rw [inc₂_iff_inc, h]

--- a/Mathlib/Combinatorics/Graph/Basic.lean
+++ b/Mathlib/Combinatorics/Graph/Basic.lean
@@ -1,0 +1,136 @@
+import Mathlib.Data.Set.Basic
+
+
+variable {α β : Type*} {x y z u v w : α} {e f : β}
+
+open Set
+
+/-- A multigraph with vertex set `V : Set α` and edge set `E : Set β`,
+as described by a predicate describing whether an edge `e : β` has ends `x` and `y`. -/
+structure Graph (α β : Type*) where
+  /-- The vertex set. -/
+  V : Set α
+  /-- The edge set. -/
+  E : Set β
+  /-- The predicate that an edge `e` goes from `x` to `y`. -/
+  Inc₂ : β → α → α → Prop
+  /-- If `e` goes from `x` to `y`, it goes from `y` to `x`. -/
+  inc₂_symm : ∀ ⦃e x y⦄, Inc₂ e x y → Inc₂ e y x
+  /-- An edge is incident with at most one pair of vertices. -/
+  eq_or_eq_of_inc₂_of_inc₂ : ∀ ⦃e x y v w⦄, Inc₂ e x y → Inc₂ e v w → x = v ∨ x = w
+  /-- If `e` is incident to something, then `e` is in the edge set -/
+  edge_mem_iff_exists_inc₂ : ∀ e, e ∈ E ↔ ∃ x y, Inc₂ e x y
+  /-- If some edge `e` is incident to `x`, then `x ∈ V`. -/
+  vx_mem_left_of_inc₂ : ∀ ⦃e x y⦄, Inc₂ e x y → x ∈ V
+
+namespace Graph
+
+variable {G H : Graph α β}
+
+lemma Inc₂.symm (h : G.Inc₂ e x y) : G.Inc₂ e y x :=
+  G.inc₂_symm h
+
+lemma inc₂_comm : G.Inc₂ e x y ↔ G.Inc₂ e y x :=
+  ⟨Inc₂.symm, Inc₂.symm⟩
+
+lemma Inc₂.edge_mem (h : G.Inc₂ e x y) : e ∈ G.E :=
+  (edge_mem_iff_exists_inc₂ ..).2 ⟨x, y, h⟩
+
+lemma Inc₂.vx_mem_left (h : G.Inc₂ e x y) : x ∈ G.V :=
+  G.vx_mem_left_of_inc₂ h
+
+lemma Inc₂.vx_mem_right (h : G.Inc₂ e x y) : y ∈ G.V :=
+  h.symm.vx_mem_left
+
+lemma exists_inc₂_of_edge_mem (h : e ∈ G.E) : ∃ x y, G.Inc₂ e x y :=
+  (edge_mem_iff_exists_inc₂ ..).1 h
+
+lemma Inc₂.left_eq_or_eq_of_inc₂ (h : G.Inc₂ e x y) (h' : G.Inc₂ e z w) : x = z ∨ x = w :=
+  G.eq_or_eq_of_inc₂_of_inc₂ h h'
+
+lemma Inc₂.left_eq_of_inc₂_of_ne (h : G.Inc₂ e x y) (h' : G.Inc₂ e z w) (hzx : x ≠ z) : x = w :=
+  (h.left_eq_or_eq_of_inc₂ h').elim (False.elim ∘ hzx) id
+
+/-- `Inc e x` means that `x` is one of the ends of `e`. -/
+def Inc (G : Graph α β) (e : β) (x : α) : Prop := ∃ y, G.Inc₂ e x y
+
+@[simp]
+lemma Inc₂.inc_left (h : G.Inc₂ e x y) : G.Inc e x :=
+  ⟨y, h⟩
+
+@[simp]
+lemma Inc₂.inc_right (h : G.Inc₂ e x y) : G.Inc e y :=
+  ⟨x, h.symm⟩
+
+lemma Inc.eq_or_eq_of_inc₂ (h : G.Inc e x) (h' : G.Inc₂ e y z) : x = y ∨ x = z :=
+  h.choose_spec.left_eq_or_eq_of_inc₂ h'
+
+lemma Inc.eq_of_inc₂_of_ne_left (h : G.Inc e x) (h' : G.Inc₂ e y z) (hxy : x ≠ y) : x = z :=
+  (h.eq_or_eq_of_inc₂ h').elim (False.elim ∘ hxy) id
+
+lemma eq_or_eq_or_eq_of_inc_of_inc_of_inc (hx : G.Inc e x) (hy : G.Inc e y) (hz : G.Inc e z) :
+    x = y ∨ x = z ∨ y = z := by
+  by_contra! hcon
+  obtain ⟨x', hx'⟩ := hx
+  obtain rfl := hy.eq_of_inc₂_of_ne_left hx' hcon.1.symm
+  obtain rfl := hz.eq_of_inc₂_of_ne_left hx' hcon.2.1.symm
+  exact hcon.2.2 rfl
+
+/-- `G.IsLoopAt e x` means that `e` is a loop edge at the vertex `x`. -/
+def IsLoopAt (G : Graph α β) (e : β) (x : α) : Prop := G.Inc₂ e x x
+
+lemma IsLoopAt.eq_of_inc (h : G.IsLoopAt e x) (h' : G.Inc e y) : x = y := by
+  obtain rfl | rfl := h'.eq_or_eq_of_inc₂ h <;> rfl
+
+@[mk_iff]
+structure IsNonloopAt (G : Graph α β) (e : β) (x : α) : Prop where
+  inc : G.Inc e x
+  exists_inc₂_ne : ∃ y ≠ x, G.Inc₂ e x y
+
+lemma IsLoopAt.not_isNonloop_at (h : G.IsLoopAt e x) (y : α) : ¬ G.IsNonloopAt e y := by
+  intro h'
+  obtain ⟨z, hyz, hy⟩ := h'.exists_inc₂_ne
+  rw [← h.eq_of_inc hy.inc_left, ← h.eq_of_inc hy.inc_right] at hyz
+  exact hyz rfl
+
+lemma IsNonloopAt.not_isLoopAt (h : G.IsNonloopAt e x) (y : α) : ¬ G.IsLoopAt e y :=
+  fun h' ↦ h'.not_isNonloop_at x h
+
+lemm
+
+
+/-- Restrict `G : Graph α β` to the edges in a set `E₀` without removing vertices -/
+def edgeRestrict (G : Graph α β) (E₀ : Set β) : Graph α β where
+  V := G.V
+  E := E₀ ∩ G.E
+  Inc₂ e x y := e ∈ E₀ ∧ G.Inc₂ e x y
+  inc₂_symm e x y h := by rwa [G.inc₂_comm]
+  eq_or_eq_of_inc₂_of_inc₂ _ _ _ _ _ h h' := h.2.left_eq_or_eq_of_inc₂ h'.2
+  edge_mem_iff_exists_inc₂ e :=
+    ⟨fun h ↦ by simp [h, G.exists_inc₂_of_edge_mem h.2, h.1], fun ⟨x, y, h⟩ ↦ ⟨h.1, h.2.edge_mem⟩⟩
+  vx_mem_left_of_inc₂ _ _ _ h := h.2.vx_mem_left
+
+/-- Map `G : Graph α β` to a `Graph α' β` with the same edge set
+by applying a function `f : α → α'` to each vertex.
+Edges between identified vertices become loops. -/
+def vxMap {α' : Type*} (G : Graph α β) (f : α → α') : Graph α' β where
+  V := f '' G.V
+  E := G.E
+  Inc₂ e x' y' := ∃ x y, G.Inc₂ e x y ∧ x' = f x ∧ y' = f y
+  inc₂_symm := by
+    rintro e - - ⟨x, y, h, rfl, rfl⟩
+    exact ⟨y, x, h.symm, rfl, rfl⟩
+  eq_or_eq_of_inc₂_of_inc₂ := by
+    rintro e - - - - ⟨x, y, hxy, rfl, rfl⟩ ⟨z, w, hzw, rfl, rfl⟩
+    obtain rfl | rfl := hxy.left_eq_or_eq_of_inc₂ hzw <;> simp
+  edge_mem_iff_exists_inc₂ e := by
+    refine ⟨fun h ↦ ?_, ?_⟩
+    · obtain ⟨x, y, hxy⟩ := exists_inc₂_of_edge_mem h
+      exact ⟨_, _, _, _, hxy, rfl, rfl⟩
+    rintro ⟨-, -, x, y, h, rfl, rfl⟩
+    exact h.edge_mem
+  vx_mem_left_of_inc₂ := by
+    rintro e - - ⟨x, y, h, rfl, rfl⟩
+    exact mem_image_of_mem _ h.vx_mem_left
+
+end Graph

--- a/Mathlib/Combinatorics/Graph/Basic.lean
+++ b/Mathlib/Combinatorics/Graph/Basic.lean
@@ -268,7 +268,9 @@ lemma mk'_eq_self (G : Graph α β) : Graph.mk' G.V G.Inc₂ (fun _ _ _ ↦ Inc�
   have h := G.edgeSet_eq_setOf_exists_inc₂
   cases G with | mk V E Inc₂ _ _ _ => simpa [Graph.mk'] using h.symm
 
-/-- Two graphs with the same vertex set and binary incidences are equal. -/
+/-- Two graphs with the same vertex set and binary incidences are equal.
+(We use this as the default extensionality lemma rather than adding `@[ext]`
+to the definition, so it doesn't require equality of the edge sets.) -/
 @[ext]
 protected lemma ext {G₁ G₂ : Graph α β} (hV : G₁.V = G₂.V)
     (h : ∀ e x y, G₁.Inc₂ e x y ↔ G₂.Inc₂ e x y) : G₁ = G₂ := by

--- a/Mathlib/Combinatorics/Graph/Basic.lean
+++ b/Mathlib/Combinatorics/Graph/Basic.lean
@@ -81,7 +81,7 @@ structure Graph (α β : Type*) where
 
 namespace Graph
 
-variable {G H : Graph α β}
+variable {G : Graph α β}
 
 /-! ### Edge-vertex-vertex incidence -/
 

--- a/Mathlib/Combinatorics/Graph/Basic.lean
+++ b/Mathlib/Combinatorics/Graph/Basic.lean
@@ -276,6 +276,6 @@ protected lemma ext {G₁ G₂ : Graph α β} (hV : G₁.V = G₂.V)
 /-- Two graphs with the same vertex set and unary incidences are equal. -/
 lemma ext_inc {G₁ G₂ : Graph α β} (hV : G₁.V = G₂.V) (h : ∀ e x, G₁.Inc e x ↔ G₂.Inc e x) :
     G₁ = G₂ :=
-  Graph.ext hV fun e x y ↦ by simp_rw [inc₂_iff_inc, h]
+  Graph.ext hV fun _ _ _ ↦ by simp_rw [inc₂_iff_inc, h]
 
 end Graph

--- a/Mathlib/Combinatorics/Graph/Basic.lean
+++ b/Mathlib/Combinatorics/Graph/Basic.lean
@@ -51,7 +51,7 @@ the vertex or edge set. This is an issue, but is likely amenable to automation.
 
 ## Notation
 
-Relecting written mathematics, we use the compact notations `G.V` and `G.E` to describe
+Reflecting written mathematics, we use the compact notations `G.V` and `G.E` to describe
 vertex and edge sets formally, but use the longer terms `vxSet` and `edgeSet` within
 lemma names to refer to the same objects.
 

--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -452,6 +452,7 @@
   ["Mathlib.Algebra.Order.Field.Basic"],
   "Mathlib.Combinatorics.SetFamily.AhlswedeZhang":
   ["Mathlib.Algebra.Order.Field.Basic"],
+  "Mathlib.Combinatorics.Graph.Basic": ["Mathlib.Data.Set.Basic"],
   "Mathlib.Combinatorics.Additive.ApproximateSubgroup":
   ["Mathlib.Tactic.Bound"],
   "Mathlib.CategoryTheory.Sites.IsSheafFor":


### PR DESCRIPTION
This PR defines multigraphs via a structure `Graph a b` consisting of a vertex set, an edge set, and a 'binary incidence' predicate describing which edges are incident with which vertices. The definition uses the same 'embedded set' design as `Matroid`: the vertex and edge sets are modelled as `Set`s rather than types. 

We give basic API for incidence, adjacency and extensionality. 

[Zulip discussion.](https://leanprover.zulipchat.com/#narrow/stream/144837-PR-reviews/topic/.2324122.20Multigraphs)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
