### PR TITLE
[Merged by Bors] - chore(Topology.Algebra.Valued.WithVal): clean up typeclass assumptions

### DIFF
--- a/Mathlib/Topology/Algebra/Valued/WithVal.lean
+++ b/Mathlib/Topology/Algebra/Valued/WithVal.lean
@@ -30,50 +30,56 @@ fractions of a Dedekind domain with respect to a height-one prime ideal of the d
 
 noncomputable section
 
-variable {R Γ₀ : Type*} [Ring R] [LinearOrderedCommGroupWithZero Γ₀]
+variable {R Γ₀ : Type*} [LinearOrderedCommGroupWithZero Γ₀]
 
 /-- Type synonym for a ring equipped with the topology coming from a valuation. -/
 @[nolint unusedArguments]
-def WithVal : Valuation R Γ₀ → Type _ := fun _ => R
+def WithVal [Ring R] : Valuation R Γ₀ → Type _ := fun _ => R
 
 namespace WithVal
 
-variable (v : Valuation R Γ₀)
+section Instances
 
-instance : Ring (WithVal v) := ‹Ring R›
+variable {P S : Type*} [LinearOrderedCommGroupWithZero Γ₀]
 
-instance [CommRing R] : CommRing (WithVal v) := ‹CommRing R›
+instance [Ring R] (v : Valuation R Γ₀) : Ring (WithVal v) := inferInstanceAs (Ring R)
 
-instance [Field R] : Field (WithVal v) := ‹Field R›
+instance [CommRing R] (v : Valuation R Γ₀) : CommRing (WithVal v) := inferInstanceAs (CommRing R)
 
-instance : Inhabited (WithVal v) := ⟨0⟩
+instance [Field R] (v : Valuation R Γ₀)  : Field (WithVal v) := inferInstanceAs (Field R)
 
-instance {S : Type*} [CommSemiring S] [CommRing R] [Algebra S R] : Algebra S (WithVal v) :=
-  ‹Algebra S R›
+instance [Ring R] (v : Valuation R Γ₀) : Inhabited (WithVal v) := ⟨0⟩
 
-instance {S : Type*} [CommRing S] [CommRing R] [Algebra S R] [IsFractionRing S R] :
-    IsFractionRing S (WithVal v) :=
-  ‹IsFractionRing S R›
+instance [CommSemiring S] [CommRing R] [Algebra S R] (v : Valuation R Γ₀) :
+    Algebra S (WithVal v) := inferInstanceAs (Algebra S R)
 
-instance {S : Type*} [SMul S R] : SMul S (WithVal v) :=
-  ‹SMul S R›
+instance [CommRing S] [CommRing R] [Algebra S R] [IsFractionRing S R] (v : Valuation R Γ₀) :
+    IsFractionRing S (WithVal v) := inferInstanceAs (IsFractionRing S R)
 
-instance {P S : Type*} [SMul P S] [SMul S R] [SMul P R] [IsScalarTower P S R] :
+instance [Ring R] [SMul S R] (v : Valuation R Γ₀) : SMul S (WithVal v) :=
+  inferInstanceAs (SMul S R)
+
+instance [Ring R] [SMul P S] [SMul S R] [SMul P R] [IsScalarTower P S R] (v : Valuation R Γ₀) :
     IsScalarTower P S (WithVal v) :=
-  ‹IsScalarTower P S R›
+  inferInstanceAs (IsScalarTower P S R)
 
-instance {S : Type*} [Ring S] [CommRing R] [Algebra R S] :
-    Algebra (WithVal v) S := ‹Algebra R S›
+variable [CommRing R] (v : Valuation R Γ₀)
 
-instance {S : Type*} [Ring S] [CommRing R] [Algebra R S] (w : Valuation S Γ₀) :
-    Algebra R (WithVal w) := ‹Algebra R S›
+instance {S : Type*} [Ring S] [Algebra R S] :
+    Algebra (WithVal v) S := inferInstanceAs (Algebra R S)
 
-instance {P S : Type*} [Ring S] [CommRing R] [Semiring P] [Module P R] [Module P S]
+instance {S : Type*} [Ring S] [Algebra R S] (w : Valuation S Γ₀) :
+    Algebra R (WithVal w) := inferInstanceAs (Algebra R S)
+
+instance {P S : Type*} [Ring S] [Semiring P] [Module P R] [Module P S]
     [Algebra R S] [IsScalarTower P R S] :
-    IsScalarTower P (WithVal v) S :=
-  ‹IsScalarTower P R S›
+    IsScalarTower P (WithVal v) S := inferInstanceAs (IsScalarTower P R S)
 
-instance (v : Valuation R Γ₀) : Valued (WithVal v) Γ₀ := Valued.mk' v
+instance {R} [Ring R] (v : Valuation R Γ₀) : Valued (WithVal v) Γ₀ := Valued.mk' v
+
+end Instances
+
+variable [Ring R] (v : Valuation R Γ₀)
 
 /-- Canonical ring equivalence between `WithVal v` and `R`. -/
 def equiv : WithVal v ≃+* R := RingEquiv.refl _


### PR DESCRIPTION
Currently `WithVal.instCommRing` has `Ring R` and `CommRing R` both in the context resulting in `Valuation` using the `Ring R` instance the statement and the `CommRing R` instance for the body after unwrapping `WithVal`. Other wrapper instances are fixed similarly. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
