### PR TITLE
[Merged by Bors] - feat(Topology/DerivedSet): closure_eq_self_union_derivedSet

### DIFF
--- a/Mathlib/Topology/DerivedSet.lean
+++ b/Mathlib/Topology/DerivedSet.lean
@@ -65,7 +65,7 @@ lemma isClosed_iff_derivedSet_subset (A : Set X) : IsClosed A ↔ derivedSet A �
     exact nh (h ha)
 
 lemma closure_eq_self_union_derivedSet (A : Set X) : closure A = A ∪ derivedSet A := by
-  show _ = {a | a ∈ A ∨ a ∈ derivedSet A}
+  ext
   simp [closure_eq_cluster_pts, clusterPt_principal]
 
 /-- In a `T1Space`, the `derivedSet` of the closure of a set is equal to the derived set of the

--- a/Mathlib/Topology/DerivedSet.lean
+++ b/Mathlib/Topology/DerivedSet.lean
@@ -64,6 +64,10 @@ lemma isClosed_iff_derivedSet_subset (A : Set X) : IsClosed A ↔ derivedSet A �
     rw [this, ← acc_principal_iff_cluster] at ha
     exact nh (h ha)
 
+lemma closure_eq_self_union_derivedSet (A : Set X) : closure A = A ∪ derivedSet A := by
+  show _ = {a | a ∈ A ∨ a ∈ derivedSet A}
+  simp [closure_eq_cluster_pts, clusterPt_principal]
+
 /-- In a `T1Space`, the `derivedSet` of the closure of a set is equal to the derived set of the
 set itself.
 


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
