### PR TITLE
[Merged by Bors] - feat: add lemma `Submodule.length_lt`

### DIFF
--- a/Mathlib/LinearAlgebra/Eigenspace/Pi.lean
+++ b/Mathlib/LinearAlgebra/Eigenspace/Pi.lean
@@ -157,7 +157,7 @@ lemma iSup_iInf_maxGenEigenspace_eq_top_of_forall_mapsTo [FiniteDimensional K M]
     simp_rw [eq_top_iff] at hχ ⊢
     exact le_trans hχ <| le_iSup (fun χ : ι → K ↦ ⨅ i, (f i).maxGenEigenspace (χ i)) χ
   · replace hy : ∀ φ, finrank K ((f i).maxGenEigenspace φ) < n := fun φ ↦ by
-      simp_rw [not_exists, ← lt_top_iff_ne_top] at hy; exact h_dim ▸ Submodule.finrank_lt (hy φ)
+      simp_rw [not_exists, ← lt_top_iff_ne_top] at hy; exact h_dim ▸ Submodule.finrank_lt (hy φ).ne
     have hi (j : ι) (φ : K) :
         MapsTo (f j) ((f i).maxGenEigenspace φ) ((f i).maxGenEigenspace φ) := by
       exact h j i φ

--- a/Mathlib/LinearAlgebra/FiniteDimensional/Lemmas.lean
+++ b/Mathlib/LinearAlgebra/FiniteDimensional/Lemmas.lean
@@ -39,10 +39,10 @@ variable [DivisionRing K] [AddCommGroup V] [Module K V]
 space.
 
 See also `Submodule.length_lt`. -/
-theorem finrank_lt [FiniteDimensional K V] {s : Submodule K V} (h : s < ⊤) :
+theorem finrank_lt [FiniteDimensional K V] {s : Submodule K V} (h : s ≠ ⊤) :
     finrank K s < finrank K V := by
   rw [← s.finrank_quotient_add_finrank, add_comm]
-  exact Nat.lt_add_of_pos_right (finrank_pos_iff.mpr (Quotient.nontrivial_of_lt_top _ h))
+  exact Nat.lt_add_of_pos_right (finrank_pos_iff.mpr (Quotient.nontrivial_of_lt_top _ h.lt_top))
 
 /-- The sum of the dimensions of s + t and s ∩ t is the sum of the dimensions of s and t -/
 theorem finrank_sup_add_finrank_inf_eq (s t : Submodule K V) [FiniteDimensional K s]
@@ -193,7 +193,7 @@ variable [DivisionRing K] [AddCommGroup V] [Module K V] {V₂ : Type v'} [AddCom
 theorem finrank_lt_finrank_of_lt {s t : Submodule K V} [FiniteDimensional K t] (hst : s < t) :
     finrank K s < finrank K t :=
   (comapSubtypeEquivOfLe hst.le).finrank_eq.symm.trans_lt <|
-    finrank_lt (le_top.lt_of_ne <| hst.not_le ∘ comap_subtype_eq_top.1)
+    finrank_lt <| by simp [not_le_of_lt hst]
 
 theorem finrank_strictMono [FiniteDimensional K V] :
     StrictMono fun s : Submodule K V => finrank K s := fun _ _ => finrank_lt_finrank_of_lt
@@ -219,7 +219,7 @@ theorem LinearIndependent.span_eq_top_of_card_eq_finrank' {ι : Type*}
     (card_eq : Fintype.card ι = finrank K V) : span K (Set.range b) = ⊤ := by
   by_contra ne_top
   rw [← finrank_span_eq_card lin_ind] at card_eq
-  exact ne_of_lt (Submodule.finrank_lt <| lt_top_iff_ne_top.2 ne_top) card_eq
+  exact ne_of_lt (Submodule.finrank_lt ne_top) card_eq
 
 theorem LinearIndependent.span_eq_top_of_card_eq_finrank {ι : Type*} [Nonempty ι]
     [Fintype ι] {b : ι → V} (lin_ind : LinearIndependent K b)

--- a/Mathlib/LinearAlgebra/FiniteDimensional/Lemmas.lean
+++ b/Mathlib/LinearAlgebra/FiniteDimensional/Lemmas.lean
@@ -36,7 +36,9 @@ section DivisionRing
 variable [DivisionRing K] [AddCommGroup V] [Module K V]
 
 /-- The dimension of a strict submodule is strictly bounded by the dimension of the ambient
-space. -/
+space.
+
+See also `Submodule.length_lt`. -/
 theorem finrank_lt [FiniteDimensional K V] {s : Submodule K V} (h : s < ⊤) :
     finrank K s < finrank K V := by
   rw [← s.finrank_quotient_add_finrank, add_comm]

--- a/Mathlib/RingTheory/Length.lean
+++ b/Mathlib/RingTheory/Length.lean
@@ -134,7 +134,7 @@ lemma Submodule.height_strictMono [IsArtinian R M] [IsNoetherian R M] :
     StrictMono fun N : Submodule R M ↦ Order.height N :=
   fun N _ h ↦ Order.height_strictMono h N.height_lt_top
 
-lemma Submodule.length_lt [IsArtinian R M] [IsNoetherian R M] (N : Submodule R M) (h : N < ⊤) :
+lemma Submodule.length_lt [IsArtinian R M] [IsNoetherian R M] {N : Submodule R M} (h : N < ⊤) :
     Module.length R N < Module.length R M := by
   simpa only [← Module.length_top (M := M), Module.length_submodule] using height_strictMono h
 

--- a/Mathlib/RingTheory/Length.lean
+++ b/Mathlib/RingTheory/Length.lean
@@ -131,7 +131,7 @@ lemma Submodule.height_lt_top [IsArtinian R M] [IsNoetherian R M] (N : Submodule
   simpa only [← Module.length_submodule] using Module.length_ne_top.lt_top
 
 lemma Submodule.height_strictMono [IsArtinian R M] [IsNoetherian R M] :
-    StrictMono fun N : Submodule R M ↦ Order.height N :=
+    StrictMono (Order.height : Submodule R M → ℕ∞) :=
   fun N _ h ↦ Order.height_strictMono h N.height_lt_top
 
 lemma Submodule.length_lt [IsArtinian R M] [IsNoetherian R M] {N : Submodule R M} (h : N ≠ ⊤) :

--- a/Mathlib/RingTheory/Length.lean
+++ b/Mathlib/RingTheory/Length.lean
@@ -126,6 +126,18 @@ lemma Module.length_bot :
     Module.length R (⊤ : Submodule R M) = Module.length R M := by
   rw [Module.length_submodule, Module.length_eq_height]
 
+lemma Submodule.height_lt_top [IsArtinian R M] [IsNoetherian R M] (N : Submodule R M) :
+    Order.height N < ⊤ := by
+  simpa only [← Module.length_submodule] using Module.length_ne_top.lt_top
+
+lemma Submodule.height_strictMono [IsArtinian R M] [IsNoetherian R M] :
+    StrictMono fun N : Submodule R M ↦ Order.height N :=
+  fun N _ h ↦ Order.height_strictMono h N.height_lt_top
+
+lemma Submodule.length_lt [IsArtinian R M] [IsNoetherian R M] (N : Submodule R M) (h : N < ⊤) :
+    Module.length R N < Module.length R M := by
+  simpa only [← Module.length_top (M := M), Module.length_submodule] using height_strictMono h
+
 variable {N P : Type*} [AddCommGroup N] [AddCommGroup P] [Module R N] [Module R P]
 variable (f : N →ₗ[R] M) (g : M →ₗ[R] P) (hf : Function.Injective f) (hg : Function.Surjective g)
 variable (H : Function.Exact f g)

--- a/Mathlib/RingTheory/Length.lean
+++ b/Mathlib/RingTheory/Length.lean
@@ -134,9 +134,9 @@ lemma Submodule.height_strictMono [IsArtinian R M] [IsNoetherian R M] :
     StrictMono fun N : Submodule R M ↦ Order.height N :=
   fun N _ h ↦ Order.height_strictMono h N.height_lt_top
 
-lemma Submodule.length_lt [IsArtinian R M] [IsNoetherian R M] {N : Submodule R M} (h : N < ⊤) :
+lemma Submodule.length_lt [IsArtinian R M] [IsNoetherian R M] {N : Submodule R M} (h : N ≠ ⊤) :
     Module.length R N < Module.length R M := by
-  simpa only [← Module.length_top (M := M), Module.length_submodule] using height_strictMono h
+  simpa [← Module.length_top (M := M), Module.length_submodule] using height_strictMono h.lt_top
 
 variable {N P : Type*} [AddCommGroup N] [AddCommGroup P] [Module R N] [Module R P]
 variable (f : N →ₗ[R] M) (g : M →ₗ[R] P) (hf : Function.Injective f) (hg : Function.Surjective g)


### PR DESCRIPTION
This lemma is useful for reasoning inductively based on module length (in combination with a natural-number-valued length function for finite-length modules).


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
