### PR TITLE
[Merged by Bors] - feat: drop measurability assumption in `norm_setIntegral_le_of_norm_le_const_ae'`

### DIFF
--- a/Mathlib/Analysis/Fourier/RiemannLebesgueLemma.lean
+++ b/Mathlib/Analysis/Fourier/RiemannLebesgueLemma.lean
@@ -167,10 +167,7 @@ theorem tendsto_integral_exp_inner_smul_cocompact_of_continuous_compact_support 
     rw [sub_add_cancel_left, norm_neg, hw'_nm, ← div_div, div_lt_iff₀ (norm_pos_iff.mpr hw_ne), ←
       div_lt_iff₀' hδ1, div_div]
     exact (lt_add_of_pos_left _ one_half_pos).trans_le hw_bd
-  have bdA2 := norm_setIntegral_le_of_norm_le_const (hB_vol.trans_lt ENNReal.coe_lt_top) bdA ?_
-  swap
-  · apply Continuous.aestronglyMeasurable
-    exact continuous_norm.comp <| hf1.sub <| hf1.comp <| continuous_id'.add continuous_const
+  have bdA2 := norm_setIntegral_le_of_norm_le_const (hB_vol.trans_lt ENNReal.coe_lt_top) bdA
   have : ‖_‖ = ∫ v : V in A, ‖f v - f (v + i w)‖ :=
     Real.norm_of_nonneg (setIntegral_nonneg mA fun x _ => norm_nonneg _)
   rw [this] at bdA2

--- a/Mathlib/Analysis/SpecialFunctions/MulExpNegMulSqIntegral.lean
+++ b/Mathlib/Analysis/SpecialFunctions/MulExpNegMulSqIntegral.lean
@@ -142,11 +142,9 @@ theorem abs_setIntegral_mulExpNegMulSq_comp_sub_le_mul_measure {K : Set E} (hK :
     |∫ x in K, mulExpNegMulSq ε (g x) ∂P - ∫ x in K, mulExpNegMulSq ε (f x) ∂P|
       ≤ δ * (P K).toReal := by
   rw [← (integral_sub (integrable_mulExpNegMulSq_comp_restrict_of_isCompact hK hKmeas g)
-      (integrable_mulExpNegMulSq_comp_restrict_of_isCompact hK hKmeas f))]
-  apply norm_setIntegral_le_of_norm_le_const hK.measure_lt_top
+      (integrable_mulExpNegMulSq_comp_restrict_of_isCompact hK hKmeas f)), ← norm_eq_abs]
+  exact norm_setIntegral_le_of_norm_le_const hK.measure_lt_top
     (fun x hxK => le_trans (dist_mulExpNegMulSq_le_dist hε) (hfg x hxK).le)
-    (StronglyMeasurable.aestronglyMeasurable (Continuous.stronglyMeasurable
-    (Continuous.sub g.continuous.mulExpNegMulSq f.continuous.mulExpNegMulSq)))
 
 variable {E : Type*} [MeasurableSpace E] [PseudoEMetricSpace E] [BorelSpace E] [CompleteSpace E]
     [SecondCountableTopology E]

--- a/Mathlib/MeasureTheory/Integral/Bochner/FundThmCalculus.lean
+++ b/Mathlib/MeasureTheory/Integral/Bochner/FundThmCalculus.lean
@@ -54,7 +54,7 @@ theorem Filter.Tendsto.integral_sub_linear_isLittleO_ae
   intro s hμs h_integrable hfm h_norm
   rw [← setIntegral_const, ← integral_sub h_integrable (integrableOn_const.2 <| Or.inr hμs),
     Real.norm_eq_abs, abs_of_nonneg ENNReal.toReal_nonneg]
-  exact norm_setIntegral_le_of_norm_le_const_ae' hμs h_norm (hfm.sub aestronglyMeasurable_const)
+  exact norm_setIntegral_le_of_norm_le_const_ae' hμs h_norm
 
 /-- Fundamental theorem of calculus for set integrals, `nhdsWithin` version: if `μ` is a locally
 finite measure and `f` is an almost everywhere measurable function that is continuous at a point `a`

--- a/Mathlib/MeasureTheory/Integral/Bochner/Set.lean
+++ b/Mathlib/MeasureTheory/Integral/Bochner/Set.lean
@@ -532,10 +532,6 @@ theorem norm_setIntegral_le_of_norm_le_const {C : ℝ} (hs : μ s < ∞) (hC : �
     ‖∫ x in s, f x ∂μ‖ ≤ C * (μ s).toReal :=
   norm_setIntegral_le_of_norm_le_const_ae' hs (Eventually.of_forall hC)
 
-theorem norm_setIntegral_le_of_norm_le_const' {C : ℝ} (hs : μ s < ∞) (hsm : MeasurableSet s)
-    (hC : ∀ x ∈ s, ‖f x‖ ≤ C) : ‖∫ x in s, f x ∂μ‖ ≤ C * (μ s).toReal :=
-  norm_setIntegral_le_of_norm_le_const_ae'' hs hsm <| Eventually.of_forall hC
-
 theorem norm_integral_sub_setIntegral_le [IsFiniteMeasure μ] {C : ℝ}
     (hf : ∀ᵐ (x : X) ∂μ, ‖f x‖ ≤ C) {s : Set X} (hs : MeasurableSet s) (hf1 : Integrable f μ) :
     ‖∫ (x : X), f x ∂μ - ∫ x in s, f x ∂μ‖ ≤ (μ sᶜ).toReal * C := by
@@ -779,21 +775,21 @@ section IntegrableUnion
 variable {ι : Type*} [Countable ι] {μ : Measure X} [NormedAddCommGroup E]
 
 theorem integrableOn_iUnion_of_summable_integral_norm {f : X → E} {s : ι → Set X}
-    (hs : ∀ i : ι, MeasurableSet (s i)) (hi : ∀ i : ι, IntegrableOn f (s i) μ)
+    (hi : ∀ i : ι, IntegrableOn f (s i) μ)
     (h : Summable fun i : ι => ∫ x : X in s i, ‖f x‖ ∂μ) : IntegrableOn f (iUnion s) μ := by
   refine ⟨AEStronglyMeasurable.iUnion fun i => (hi i).1, (lintegral_iUnion_le _ _).trans_lt ?_⟩
   have B := fun i => lintegral_coe_eq_integral (fun x : X => ‖f x‖₊) (hi i).norm
   simp_rw [enorm_eq_nnnorm, tsum_congr B]
   have S' :
     Summable fun i : ι =>
-      (⟨∫ x : X in s i, ‖f x‖₊ ∂μ, setIntegral_nonneg (hs i) fun x _ => NNReal.coe_nonneg _⟩ :
+      (⟨∫ x : X in s i, ‖f x‖₊ ∂μ, integral_nonneg fun x => NNReal.coe_nonneg _⟩ :
         NNReal) := by
     rw [← NNReal.summable_coe]; exact h
   have S'' := ENNReal.tsum_coe_eq S'.hasSum
   simp_rw [ENNReal.coe_nnreal_eq, NNReal.coe_mk, coe_nnnorm] at S''
   convert ENNReal.ofReal_lt_top
 
-variable [TopologicalSpace X] [BorelSpace X] [MetrizableSpace X] [IsLocallyFiniteMeasure μ]
+variable [TopologicalSpace X] [BorelSpace X] [T2Space X] [IsLocallyFiniteMeasure μ]
 
 /-- If `s` is a countable family of compact sets, `f` is a continuous function, and the sequence
 `‖f.restrict (s i)‖ * μ (s i)` is summable, then `f` is integrable on the union of the `s i`. -/
@@ -801,14 +797,13 @@ theorem integrableOn_iUnion_of_summable_norm_restrict {f : C(X, E)} {s : ι → 
     (hf : Summable fun i : ι => ‖f.restrict (s i)‖ * ENNReal.toReal (μ <| s i)) :
     IntegrableOn f (⋃ i : ι, s i) μ := by
   refine
-    integrableOn_iUnion_of_summable_integral_norm (fun i => (s i).isCompact.isClosed.measurableSet)
+    integrableOn_iUnion_of_summable_integral_norm
       (fun i => (map_continuous f).continuousOn.integrableOn_compact (s i).isCompact)
       (.of_nonneg_of_le (fun ι => integral_nonneg fun x => norm_nonneg _) (fun i => ?_) hf)
   rw [← (Real.norm_of_nonneg (integral_nonneg fun x => norm_nonneg _) : ‖_‖ = ∫ x in s i, ‖f x‖ ∂μ)]
   exact
-    norm_setIntegral_le_of_norm_le_const' (s i).isCompact.measure_lt_top
-      (s i).isCompact.isClosed.measurableSet fun x hx =>
-      (norm_norm (f x)).symm ▸ (f.restrict (s i : Set X)).norm_coe_le_norm ⟨x, hx⟩
+    norm_setIntegral_le_of_norm_le_const (s i).isCompact.measure_lt_top
+      fun x hx => (norm_norm (f x)).symm ▸ (f.restrict (s i : Set X)).norm_coe_le_norm ⟨x, hx⟩
 
 /-- If `s` is a countable family of compact sets covering `X`, `f` is a continuous function, and
 the sequence `‖f.restrict (s i)‖ * μ (s i)` is summable, then `f` is integrable. -/

--- a/Mathlib/MeasureTheory/Integral/Bochner/Set.lean
+++ b/Mathlib/MeasureTheory/Integral/Bochner/Set.lean
@@ -507,8 +507,7 @@ theorem norm_setIntegral_le_of_norm_le_const_ae {C : ℝ} (hs : μ s < ∞)
   exact norm_integral_le_of_norm_le_const hC
 
 theorem norm_setIntegral_le_of_norm_le_const_ae' {C : ℝ} (hs : μ s < ∞)
-    (hC : ∀ᵐ x ∂μ, x ∈ s → ‖f x‖ ≤ C) :
-    ‖∫ x in s, f x ∂μ‖ ≤ C * (μ s).toReal := by
+    (hC : ∀ᵐ x ∂μ, x ∈ s → ‖f x‖ ≤ C) : ‖∫ x in s, f x ∂μ‖ ≤ C * (μ s).toReal := by
   by_cases hfm : AEStronglyMeasurable f (μ.restrict s)
   · apply norm_setIntegral_le_of_norm_le_const_ae hs
     have A : ∀ᵐ x : X ∂μ, x ∈ s → ‖AEStronglyMeasurable.mk f hfm x‖ ≤ C := by
@@ -528,11 +527,6 @@ theorem norm_setIntegral_le_of_norm_le_const_ae' {C : ℝ} (hs : μ s < ∞)
     have : 0 ≤ C := (norm_nonneg _).trans (h'x hx)
     simp only [norm_zero, ge_iff_le]
     positivity
-
-theorem norm_setIntegral_le_of_norm_le_const_ae'' {C : ℝ} (hs : μ s < ∞) (hsm : MeasurableSet s)
-    (hC : ∀ᵐ x ∂μ, x ∈ s → ‖f x‖ ≤ C) : ‖∫ x in s, f x ∂μ‖ ≤ C * (μ s).toReal :=
-  norm_setIntegral_le_of_norm_le_const_ae hs <| by
-    rwa [ae_restrict_eq hsm, eventually_inf_principal]
 
 theorem norm_setIntegral_le_of_norm_le_const {C : ℝ} (hs : μ s < ∞) (hC : ∀ x ∈ s, ‖f x‖ ≤ C) :
     ‖∫ x in s, f x ∂μ‖ ≤ C * (μ s).toReal :=

--- a/Mathlib/MeasureTheory/Integral/Bochner/Set.lean
+++ b/Mathlib/MeasureTheory/Integral/Bochner/Set.lean
@@ -507,26 +507,36 @@ theorem norm_setIntegral_le_of_norm_le_const_ae {C : ℝ} (hs : μ s < ∞)
   exact norm_integral_le_of_norm_le_const hC
 
 theorem norm_setIntegral_le_of_norm_le_const_ae' {C : ℝ} (hs : μ s < ∞)
-    (hC : ∀ᵐ x ∂μ, x ∈ s → ‖f x‖ ≤ C) (hfm : AEStronglyMeasurable f (μ.restrict s)) :
+    (hC : ∀ᵐ x ∂μ, x ∈ s → ‖f x‖ ≤ C) :
     ‖∫ x in s, f x ∂μ‖ ≤ C * (μ s).toReal := by
-  apply norm_setIntegral_le_of_norm_le_const_ae hs
-  have A : ∀ᵐ x : X ∂μ, x ∈ s → ‖AEStronglyMeasurable.mk f hfm x‖ ≤ C := by
-    filter_upwards [hC, hfm.ae_mem_imp_eq_mk] with _ h1 h2 h3
-    rw [← h2 h3]
-    exact h1 h3
-  have B : MeasurableSet {x | ‖hfm.mk f x‖ ≤ C} :=
-    hfm.stronglyMeasurable_mk.norm.measurable measurableSet_Iic
-  filter_upwards [hfm.ae_eq_mk, (ae_restrict_iff B).2 A] with _ h1 _
-  rwa [h1]
+  by_cases hfm : AEStronglyMeasurable f (μ.restrict s)
+  · apply norm_setIntegral_le_of_norm_le_const_ae hs
+    have A : ∀ᵐ x : X ∂μ, x ∈ s → ‖AEStronglyMeasurable.mk f hfm x‖ ≤ C := by
+      filter_upwards [hC, hfm.ae_mem_imp_eq_mk] with _ h1 h2 h3
+      rw [← h2 h3]
+      exact h1 h3
+    have B : MeasurableSet {x | ‖hfm.mk f x‖ ≤ C} :=
+      hfm.stronglyMeasurable_mk.norm.measurable measurableSet_Iic
+    filter_upwards [hfm.ae_eq_mk, (ae_restrict_iff B).2 A] with _ h1 _
+    rwa [h1]
+  · rw [integral_non_aestronglyMeasurable hfm]
+    have : ∃ᵐ (x : X) ∂μ, x ∈ s := by
+      apply frequently_ae_mem_iff.mpr
+      contrapose! hfm
+      simp [Measure.restrict_eq_zero.mpr hfm]
+    rcases (this.and_eventually hC).exists with ⟨x, hx, h'x⟩
+    have : 0 ≤ C := (norm_nonneg _).trans (h'x hx)
+    simp only [norm_zero, ge_iff_le]
+    positivity
 
 theorem norm_setIntegral_le_of_norm_le_const_ae'' {C : ℝ} (hs : μ s < ∞) (hsm : MeasurableSet s)
     (hC : ∀ᵐ x ∂μ, x ∈ s → ‖f x‖ ≤ C) : ‖∫ x in s, f x ∂μ‖ ≤ C * (μ s).toReal :=
   norm_setIntegral_le_of_norm_le_const_ae hs <| by
     rwa [ae_restrict_eq hsm, eventually_inf_principal]
 
-theorem norm_setIntegral_le_of_norm_le_const {C : ℝ} (hs : μ s < ∞) (hC : ∀ x ∈ s, ‖f x‖ ≤ C)
-    (hfm : AEStronglyMeasurable f (μ.restrict s)) : ‖∫ x in s, f x ∂μ‖ ≤ C * (μ s).toReal :=
-  norm_setIntegral_le_of_norm_le_const_ae' hs (Eventually.of_forall hC) hfm
+theorem norm_setIntegral_le_of_norm_le_const {C : ℝ} (hs : μ s < ∞) (hC : ∀ x ∈ s, ‖f x‖ ≤ C) :
+    ‖∫ x in s, f x ∂μ‖ ≤ C * (μ s).toReal :=
+  norm_setIntegral_le_of_norm_le_const_ae' hs (Eventually.of_forall hC)
 
 theorem norm_setIntegral_le_of_norm_le_const' {C : ℝ} (hs : μ s < ∞) (hsm : MeasurableSet s)
     (hC : ∀ x ∈ s, ‖f x‖ ≤ C) : ‖∫ x in s, f x ∂μ‖ ≤ C * (μ s).toReal :=

--- a/Mathlib/MeasureTheory/Integral/Bochner/Set.lean
+++ b/Mathlib/MeasureTheory/Integral/Bochner/Set.lean
@@ -528,9 +528,15 @@ theorem norm_setIntegral_le_of_norm_le_const_ae' {C : ℝ} (hs : μ s < ∞)
     simp only [norm_zero, ge_iff_le]
     positivity
 
+@[deprecated (since := "2025-04-17")]
+alias norm_setIntegral_le_of_norm_le_const_ae'' := norm_setIntegral_le_of_norm_le_const_ae'
+
 theorem norm_setIntegral_le_of_norm_le_const {C : ℝ} (hs : μ s < ∞) (hC : ∀ x ∈ s, ‖f x‖ ≤ C) :
     ‖∫ x in s, f x ∂μ‖ ≤ C * (μ s).toReal :=
   norm_setIntegral_le_of_norm_le_const_ae' hs (Eventually.of_forall hC)
+
+@[deprecated (since := "2025-04-17")]
+alias norm_setIntegral_le_of_norm_le_const' := norm_setIntegral_le_of_norm_le_const
 
 theorem norm_integral_sub_setIntegral_le [IsFiniteMeasure μ] {C : ℝ}
     (hf : ∀ᵐ (x : X) ∂μ, ‖f x‖ ≤ C) {s : Set X} (hs : MeasurableSet s) (hf1 : Integrable f μ) :

--- a/Mathlib/MeasureTheory/Integral/DivergenceTheorem.lean
+++ b/Mathlib/MeasureTheory/Integral/DivergenceTheorem.lean
@@ -224,8 +224,8 @@ theorem integral_divergence_of_hasFDerivWithinAt_off_countable_aux₂ (I : Box (
     ‖∫ x in Box.Icc ((J k).face i), f (i.insertNth d x) i - f (i.insertNth (c k) x) i‖ ≤
         (ε / ∏ j, ((I.face i).upper j - (I.face i).lower j)) *
           (volume (Box.Icc ((J k).face i))).toReal := by
-      refine norm_setIntegral_le_of_norm_le_const' (((J k).face i).measure_Icc_lt_top _)
-        ((J k).face i).measurableSet_Icc fun x hx => ?_
+      refine norm_setIntegral_le_of_norm_le_const (((J k).face i).measure_Icc_lt_top _)
+        fun x hx => ?_
       rw [← dist_eq_norm]
       calc
         dist (f (i.insertNth d x) i) (f (i.insertNth (c k) x) i) ≤

--- a/Mathlib/MeasureTheory/Integral/IntervalIntegral/Basic.lean
+++ b/Mathlib/MeasureTheory/Integral/IntervalIntegral/Basic.lean
@@ -604,8 +604,8 @@ nonrec theorem norm_integral_le_of_norm_le {g : ℝ → ℝ} (h : ∀ᵐ t ∂μ
 
 theorem norm_integral_le_of_norm_le_const_ae {a b C : ℝ} {f : ℝ → E}
     (h : ∀ᵐ x, x ∈ Ι a b → ‖f x‖ ≤ C) : ‖∫ x in a..b, f x‖ ≤ C * |b - a| := by
-  rw [norm_integral_eq_norm_integral_Ioc]
-  convert norm_setIntegral_le_of_norm_le_const_ae'' _ measurableSet_Ioc h using 1
+  simp only [norm_integral_eq_norm_integral_Ioc, uIoc] at h ⊢
+  convert norm_setIntegral_le_of_norm_le_const_ae' _ h using 1
   · rw [Real.volume_Ioc, max_sub_min_eq_abs, ENNReal.toReal_ofReal (abs_nonneg _)]
   · simp only [Real.volume_Ioc, ENNReal.ofReal_lt_top]
 

--- a/Mathlib/MeasureTheory/Integral/TorusIntegral.lean
+++ b/Mathlib/MeasureTheory/Integral/TorusIntegral.lean
@@ -173,7 +173,7 @@ theorem norm_torusIntegral_le_of_norm_le_const {C : ℝ} (hf : ∀ θ, ‖f (tor
     ‖∯ x in T(c, R), f x‖ ≤ ((2 * π) ^ (n : ℕ) * ∏ i, |R i|) * C :=
   calc
     ‖∯ x in T(c, R), f x‖ ≤ (∏ i, |R i|) * C * (volume (Icc (0 : ℝⁿ) fun _ => 2 * π)).toReal :=
-      norm_setIntegral_le_of_norm_le_const' measure_Icc_lt_top measurableSet_Icc fun θ _ =>
+      norm_setIntegral_le_of_norm_le_const measure_Icc_lt_top fun θ _ =>
         calc
           ‖(∏ i : Fin n, R i * exp (θ i * I) * I : ℂ) • f (torusMap c R θ)‖ =
               (∏ i : Fin n, |R i|) * ‖f (torusMap c R θ)‖ := by simp [norm_smul]

--- a/Mathlib/NumberTheory/Transcendental/Lindemann/AnalyticalPart.lean
+++ b/Mathlib/NumberTheory/Transcendental/Lindemann/AnalyticalPart.lean
@@ -71,10 +71,9 @@ private theorem P_le_aux (f : ℕ → ℂ[X]) (s : ℂ) (c : ℝ)
   rw [P_eq_integral_exp_mul_eval (f p) s, mul_comm s, norm_mul, norm_mul, norm_exp]
   gcongr
   rw [intervalIntegral.integral_of_le zero_le_one, ← mul_one (_ * _)]
-  convert MeasureTheory.norm_setIntegral_le_of_norm_le_const' _ _ _
+  convert MeasureTheory.norm_setIntegral_le_of_norm_le_const _ _
   · rw [Real.volume_Ioc, sub_zero, ENNReal.toReal_ofReal zero_le_one]
   · rw [Real.volume_Ioc, sub_zero]; exact ENNReal.ofReal_lt_top
-  · exact measurableSet_Ioc
   intro x hx
   rw [norm_mul, norm_exp]
   gcongr


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
