### PR TITLE
[Merged by Bors] - feat(NumberField): add `ComplexEmbedding.lift`

### DIFF
--- a/Mathlib/NumberTheory/NumberField/Embeddings.lean
+++ b/Mathlib/NumberTheory/NumberField/Embeddings.lean
@@ -164,7 +164,7 @@ theorem lift_comp_algebraMap [Algebra k K] [Algebra.IsAlgebraic k K] (φ : k →
   rw [AlgHom.toRingHom_eq_coe, AlgHom.comp_algebraMap_of_tower, RingHom.algebraMap_toAlgebra']
 
 @[simp]
-theorem lift_comp_algebraMap_apply [Algebra k K] [Algebra.IsAlgebraic k K] (φ : k →+* ℂ) (x : k) :
+theorem lift_algebraMap_apply [Algebra k K] [Algebra.IsAlgebraic k K] (φ : k →+* ℂ) (x : k) :
     lift K φ (algebraMap k K x) = φ x :=
   RingHom.congr_fun (lift_comp_algebraMap φ) x
 

--- a/Mathlib/NumberTheory/NumberField/Embeddings.lean
+++ b/Mathlib/NumberTheory/NumberField/Embeddings.lean
@@ -149,6 +149,9 @@ open scoped ComplexConjugate
 variable {K : Type*} [Field K] {k : Type*} [Field k]
 
 variable (K) in
+/--
+A (random) lift of the complex embedding `φ : k →+* ℂ` to an extension `K` of `k`.
+-/
 noncomputable def lift [Algebra k K] [Algebra.IsAlgebraic k K] (φ : k →+* ℂ) : K →+* ℂ := by
   letI := φ.toAlgebra
   exact (IsAlgClosed.lift (R := k)).toRingHom

--- a/Mathlib/NumberTheory/NumberField/Embeddings.lean
+++ b/Mathlib/NumberTheory/NumberField/Embeddings.lean
@@ -163,6 +163,11 @@ theorem lift_comp_algebraMap [Algebra k K] [Algebra.IsAlgebraic k K] (φ : k →
   letI := φ.toAlgebra
   rw [AlgHom.toRingHom_eq_coe, AlgHom.comp_algebraMap_of_tower, RingHom.algebraMap_toAlgebra']
 
+@[simp]
+theorem lift_comp_algebraMap_apply [Algebra k K] [Algebra.IsAlgebraic k K] (φ : k →+* ℂ) (x : k) :
+    lift K φ (algebraMap k K x) = φ x :=
+  RingHom.congr_fun (lift_comp_algebraMap φ (K := K)) x
+
 /-- The conjugate of a complex embedding as a complex embedding. -/
 abbrev conjugate (φ : K →+* ℂ) : K →+* ℂ := star φ
 

--- a/Mathlib/NumberTheory/NumberField/Embeddings.lean
+++ b/Mathlib/NumberTheory/NumberField/Embeddings.lean
@@ -683,10 +683,8 @@ lemma comap_id (w : InfinitePlace K) : w.comap (RingHom.id K) = w := rfl
 lemma comap_comp (w : InfinitePlace K) (f : F →+* K) (g : k →+* F) :
     w.comap (f.comp g) = (w.comap f).comap g := rfl
 
-@[simp]
 lemma comap_mk_lift [Algebra k K] [Algebra.IsAlgebraic k K] (φ : k →+* ℂ) :
-    (mk (ComplexEmbedding.lift K φ)).comap (algebraMap k K) = mk φ := by
-  rw [comap_mk, ComplexEmbedding.lift_comp_algebraMap]
+    (mk (ComplexEmbedding.lift K φ)).comap (algebraMap k K) = mk φ := by simp
 
 lemma IsReal.comap (f : k →+* K) {w : InfinitePlace K} (hφ : IsReal w) :
     IsReal (w.comap f) := by

--- a/Mathlib/NumberTheory/NumberField/Embeddings.lean
+++ b/Mathlib/NumberTheory/NumberField/Embeddings.lean
@@ -166,7 +166,7 @@ theorem lift_comp_algebraMap [Algebra k K] [Algebra.IsAlgebraic k K] (φ : k →
 @[simp]
 theorem lift_comp_algebraMap_apply [Algebra k K] [Algebra.IsAlgebraic k K] (φ : k →+* ℂ) (x : k) :
     lift K φ (algebraMap k K x) = φ x :=
-  RingHom.congr_fun (lift_comp_algebraMap φ (K := K)) x
+  RingHom.congr_fun (lift_comp_algebraMap φ) x
 
 /-- The conjugate of a complex embedding as a complex embedding. -/
 abbrev conjugate (φ : K →+* ℂ) : K →+* ℂ := star φ

--- a/Mathlib/NumberTheory/NumberField/Embeddings.lean
+++ b/Mathlib/NumberTheory/NumberField/Embeddings.lean
@@ -148,6 +148,18 @@ open scoped ComplexConjugate
 
 variable {K : Type*} [Field K] {k : Type*} [Field k]
 
+variable (K) in
+noncomputable def lift [Algebra k K] [Algebra.IsAlgebraic k K] (φ : k →+* ℂ) : K →+* ℂ := by
+  letI := φ.toAlgebra
+  exact (IsAlgClosed.lift (R := k)).toRingHom
+
+@[simp]
+theorem lift_comp_algebraMap [Algebra k K] [Algebra.IsAlgebraic k K] (φ : k →+* ℂ) :
+    (lift K φ).comp (algebraMap k K) = φ := by
+  unfold lift
+  letI := φ.toAlgebra
+  rw [AlgHom.toRingHom_eq_coe, AlgHom.comp_algebraMap_of_tower, RingHom.algebraMap_toAlgebra']
+
 /-- The conjugate of a complex embedding as a complex embedding. -/
 abbrev conjugate (φ : K →+* ℂ) : K →+* ℂ := star φ
 
@@ -668,6 +680,11 @@ lemma comap_id (w : InfinitePlace K) : w.comap (RingHom.id K) = w := rfl
 lemma comap_comp (w : InfinitePlace K) (f : F →+* K) (g : k →+* F) :
     w.comap (f.comp g) = (w.comap f).comap g := rfl
 
+@[simp]
+lemma comap_mk_lift [Algebra k K] [Algebra.IsAlgebraic k K] (φ : k →+* ℂ) :
+    (mk (ComplexEmbedding.lift K φ)).comap (algebraMap k K) = mk φ := by
+  rw [comap_mk, ComplexEmbedding.lift_comp_algebraMap]
+
 lemma IsReal.comap (f : k →+* K) {w : InfinitePlace K} (hφ : IsReal w) :
     IsReal (w.comap f) := by
   rw [← mk_embedding w, comap_mk, isReal_mk_iff]
@@ -680,9 +697,7 @@ lemma isReal_comap_iff (f : k ≃+* K) {w : InfinitePlace K} :
 
 lemma comap_surjective [Algebra k K] [Algebra.IsAlgebraic k K] :
     Function.Surjective (comap · (algebraMap k K)) := fun w ↦
-  letI := w.embedding.toAlgebra
-  ⟨mk (IsAlgClosed.lift (M := ℂ) (R := k)).toRingHom,
-    by simp [this, comap_mk, RingHom.algebraMap_toAlgebra]⟩
+  ⟨(mk (ComplexEmbedding.lift K  w.embedding)), by simp⟩
 
 lemma mult_comap_le (f : k →+* K) (w : InfinitePlace K) : mult (w.comap f) ≤ mult w := by
   rw [mult, mult]


### PR DESCRIPTION
A (random) lift of a complex embedding `φ : k →+* ℂ` to an extension `K` of `k`. 



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
