### PR TITLE
[Merged by Bors] - feat(RingTheory/Bialgebra/Basic): injectivity of `algebraMap` and nontriviality of bialgebras

### DIFF
--- a/Mathlib/RingTheory/Bialgebra/Basic.lean
+++ b/Mathlib/RingTheory/Bialgebra/Basic.lean
@@ -47,6 +47,7 @@ suppress_compilation
 
 universe u v w
 
+open Function
 open scoped TensorProduct
 
 /-- A bialgebra over a commutative (semi)ring `R` is both an algebra and a coalgebra over `R`, such

--- a/Mathlib/RingTheory/Bialgebra/Basic.lean
+++ b/Mathlib/RingTheory/Bialgebra/Basic.lean
@@ -197,7 +197,7 @@ variable {R A : Type*} [CommSemiring R] [Semiring A] [Bialgebra R A]
 variable (A) in
 lemma algebraMap_injective : Injective (algebraMap R A) := RightInverse.injective counit_algebraMap
 
-lemma counit_surjective : Surjective (counit : A →ₗ[R] R) :=
+lemma counit_surjective : Surjective (Coalgebra.counit : A →ₗ[R] R) :=
   RightInverse.surjective counit_algebraMap
 
 include R in

--- a/Mathlib/RingTheory/Bialgebra/Basic.lean
+++ b/Mathlib/RingTheory/Bialgebra/Basic.lean
@@ -189,3 +189,19 @@ abbrev ofAlgHom (comul : A →ₐ[R] (A ⊗[R] A)) (counit : A →ₐ[R] R)
   .mk' _ _ (map_one counit) (map_mul counit _ _) (map_one comul) (map_mul comul _ _)
 
 end Bialgebra
+
+namespace Bialgebra
+
+variable (R : Type u) (A : Type v)
+variable [CommSemiring R] [Semiring A] [Bialgebra R A] [Nontrivial R]
+
+/--
+A bialgebra over a nontrivial ring is nontrivial.
+-/
+def nontrivial : Nontrivial A where
+  exists_pair_ne := by
+    refine ⟨0, 1, fun eq ↦ ?_⟩
+    apply_fun Coalgebra.counit (R := R) (A := A) at eq
+    simp only [map_zero, counit_one, zero_ne_one] at eq
+
+end Bialgebra

--- a/Mathlib/RingTheory/Bialgebra/Basic.lean
+++ b/Mathlib/RingTheory/Bialgebra/Basic.lean
@@ -192,14 +192,17 @@ end Bialgebra
 
 namespace Bialgebra
 
+variable (R : Type u) (A : Type v) [CommSemiring R] [Semiring A] [Bialgebra R A]
+
+lemma algebraMap_injective : Function.Injective (algebraMap R A) :=
+  fun a b eq  ↦ by rw [← counit_algebraMap (A := A) a, ← counit_algebraMap (A := A) b, eq]
+
+include R in
 /--
 A bialgebra over a nontrivial ring is nontrivial.
 -/
-lemma nontrivial (R : Type u) (A : Type v) [CommSemiring R] [Semiring A] [Bialgebra R A]
-    [Nontrivial R] : Nontrivial A where
-  exists_pair_ne := by
-    refine ⟨0, 1, fun eq ↦ ?_⟩
-    apply_fun Coalgebra.counit (R := R) (A := A) at eq
-    simp only [map_zero, counit_one, zero_ne_one] at eq
+lemma nontrivial [Nontrivial R] : Nontrivial A :=
+  Set.nontrivial_of_nontrivial (s := (algebraMap R A) '' ⊤) ((Set.image_nontrivial
+  (algebraMap_injective R A)).mpr Set.nontrivial_univ)
 
 end Bialgebra

--- a/Mathlib/RingTheory/Bialgebra/Basic.lean
+++ b/Mathlib/RingTheory/Bialgebra/Basic.lean
@@ -192,13 +192,11 @@ end Bialgebra
 
 namespace Bialgebra
 
-variable (R : Type u) (A : Type v)
-variable [CommSemiring R] [Semiring A] [Bialgebra R A] [Nontrivial R]
-
 /--
 A bialgebra over a nontrivial ring is nontrivial.
 -/
-def nontrivial : Nontrivial A where
+lemma nontrivial (R : Type u) (A : Type v) [CommSemiring R] [Semiring A] [Bialgebra R A]
+    [Nontrivial R] : Nontrivial A where
   exists_pair_ne := by
     refine ⟨0, 1, fun eq ↦ ?_⟩
     apply_fun Coalgebra.counit (R := R) (A := A) at eq

--- a/Mathlib/RingTheory/Bialgebra/Basic.lean
+++ b/Mathlib/RingTheory/Bialgebra/Basic.lean
@@ -191,18 +191,17 @@ abbrev ofAlgHom (comul : A →ₐ[R] (A ⊗[R] A)) (counit : A →ₐ[R] R)
 end Bialgebra
 
 namespace Bialgebra
+variable {R A : Type*} [CommSemiring R] [Semiring A] [Bialgebra R A]
 
-variable (R : Type u) (A : Type v) [CommSemiring R] [Semiring A] [Bialgebra R A]
+variable (A) in
+lemma algebraMap_injective : Injective (algebraMap R A) := RightInverse.injective counit_algebraMap
 
-lemma algebraMap_injective : Function.Injective (algebraMap R A) :=
-  fun a b eq  ↦ by rw [← counit_algebraMap (A := A) a, ← counit_algebraMap (A := A) b, eq]
+lemma counit_surjective : Surjective (counit : A →ₗ[R] R) :=
+  RightInverse.surjective counit_algebraMap
 
 include R in
-/--
-A bialgebra over a nontrivial ring is nontrivial.
--/
-lemma nontrivial [Nontrivial R] : Nontrivial A :=
-  Set.nontrivial_of_nontrivial (s := (algebraMap R A) '' ⊤) ((Set.image_nontrivial
-  (algebraMap_injective R A)).mpr Set.nontrivial_univ)
+variable (R) in
+/-- A bialgebra over a nontrivial ring is nontrivial. -/
+lemma nontrivial [Nontrivial R] : Nontrivial A := (algebraMap_injective (R := R) _).nontrivial
 
 end Bialgebra


### PR DESCRIPTION
If `A` is a bialgebra over a commutative semiring `R`, prove that `algebraMap R A` is injective. Deduce that `A` is nontrivial if `R` is nontrivial.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
