### PR TITLE
[Merged by Bors] - feat(BigOperators/Ring): add `Finset.prod_neg`

### DIFF
--- a/Mathlib/Algebra/BigOperators/Ring/Finset.lean
+++ b/Mathlib/Algebra/BigOperators/Ring/Finset.lean
@@ -26,7 +26,6 @@ variable {ι ι' α β γ : Type*} {κ : ι → Type*} {s s₁ s₂ : Finset ι}
 
 namespace Finset
 
-@[simp]
 lemma prod_neg [CommMonoid α] [HasDistribNeg α] : ∏ x ∈ s, -f x = (-1) ^ #s * ∏ x ∈ s, f x := by
   simpa using (s.1.map f).prod_map_neg
 
@@ -247,7 +246,7 @@ variable [CommRing α]
 `g` over a subset `t` times the product of `f` over the complement of `t` times `(-1) ^ #t`. -/
 lemma prod_sub [DecidableEq ι] (f g : ι → α) (s : Finset ι) :
     ∏ i ∈ s, (f i - g i) = ∑ t ∈ s.powerset, (-1) ^ #t * (∏ i ∈ s \ t, f i) * ∏ i ∈ t, g i := by
-  simp [sub_eq_neg_add, prod_add, mul_right_comm]
+  simp [sub_eq_neg_add, prod_add, prod_neg, mul_right_comm]
 
 /-- `∏ i, (f i - g i) = (∏ i, f i) - ∑ i, g i * (∏ j < i, f j - g j) * (∏ j > i, f j)`. -/
 lemma prod_sub_ordered [LinearOrder ι] (s : Finset ι) (f g : ι → α) :

--- a/Mathlib/Algebra/BigOperators/Ring/Finset.lean
+++ b/Mathlib/Algebra/BigOperators/Ring/Finset.lean
@@ -27,7 +27,7 @@ variable {ι ι' α β γ : Type*} {κ : ι → Type*} {s s₁ s₂ : Finset ι}
 namespace Finset
 
 @[simp]
-lemma prod_neg [CommMonoid α] [HasDistribNeg α] : ∏ x ∈ s, (-f x) = (-1) ^ #s * ∏ x ∈ s, f x := by
+lemma prod_neg [CommMonoid α] [HasDistribNeg α] : ∏ x ∈ s, -f x = (-1) ^ #s * ∏ x ∈ s, f x := by
   simpa using (s.1.map f).prod_map_neg
 
 section AddCommMonoidWithOne

--- a/Mathlib/Algebra/BigOperators/Ring/Finset.lean
+++ b/Mathlib/Algebra/BigOperators/Ring/Finset.lean
@@ -247,7 +247,7 @@ variable [CommRing α]
 `g` over a subset `t` times the product of `f` over the complement of `t` times `(-1) ^ #t`. -/
 lemma prod_sub [DecidableEq ι] (f g : ι → α) (s : Finset ι) :
     ∏ i ∈ s, (f i - g i) = ∑ t ∈ s.powerset, (-1) ^ #t * (∏ i ∈ s \ t, f i) * ∏ i ∈ t, g i := by
-  simp [sub_eq_neg_add, prod_add, ← prod_const, ← prod_mul_distrib, mul_right_comm]
+  simp [sub_eq_neg_add, prod_add, mul_right_comm]
 
 /-- `∏ i, (f i - g i) = (∏ i, f i) - ∑ i, g i * (∏ j < i, f j - g j) * (∏ j > i, f j)`. -/
 lemma prod_sub_ordered [LinearOrder ι] (s : Finset ι) (f g : ι → α) :

--- a/Mathlib/Algebra/BigOperators/Ring/Finset.lean
+++ b/Mathlib/Algebra/BigOperators/Ring/Finset.lean
@@ -26,6 +26,10 @@ variable {ι ι' α β γ : Type*} {κ : ι → Type*} {s s₁ s₂ : Finset ι}
 
 namespace Finset
 
+@[simp]
+lemma prod_neg [CommMonoid α] [HasDistribNeg α] : ∏ x ∈ s, (-f x) = (-1) ^ #s * ∏ x ∈ s, f x := by
+  simpa using (s.1.map f).prod_map_neg
+
 section AddCommMonoidWithOne
 variable [AddCommMonoidWithOne α]
 


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
