### PR TITLE
[Merged by Bors] - refactor: generalise the Plünnecke-Petridis inequality to non-abelian groups

### DIFF
--- a/Mathlib/Combinatorics/Additive/PluenneckeRuzsa.lean
+++ b/Mathlib/Combinatorics/Additive/PluenneckeRuzsa.lean
@@ -3,13 +3,13 @@ Copyright (c) 2022 Yaël Dillies, George Shakan. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies, George Shakan
 -/
-import Mathlib.Algebra.Group.Action.Pointwise.Finset
 import Mathlib.Algebra.Order.Field.Rat
 import Mathlib.Combinatorics.Enumerative.DoubleCounting
 import Mathlib.Tactic.FieldSimp
 import Mathlib.Tactic.GCongr
 import Mathlib.Tactic.Positivity
 import Mathlib.Tactic.Ring
+import Mathlib.Algebra.Group.Pointwise.Finset.Basic
 
 /-!
 # The Plünnecke-Ruzsa inequality

--- a/Mathlib/Combinatorics/Additive/PluenneckeRuzsa.lean
+++ b/Mathlib/Combinatorics/Additive/PluenneckeRuzsa.lean
@@ -3,13 +3,13 @@ Copyright (c) 2022 Yaël Dillies, George Shakan. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies, George Shakan
 -/
+import Mathlib.Algebra.Group.Action.Pointwise.Finset
 import Mathlib.Algebra.Order.Field.Rat
 import Mathlib.Combinatorics.Enumerative.DoubleCounting
 import Mathlib.Tactic.FieldSimp
 import Mathlib.Tactic.GCongr
 import Mathlib.Tactic.Positivity
 import Mathlib.Tactic.Ring
-import Mathlib.Algebra.Group.Pointwise.Finset.Basic
 
 /-!
 # The Plünnecke-Ruzsa inequality
@@ -112,43 +112,42 @@ theorem ruzsa_triangle_inequality_mul_mul_invMul (A B C : Finset G) :
     #(A * C) * #B ≤ #(A * B) * #(C⁻¹ * B) := by
   simpa using ruzsa_triangle_inequality_mulInv_mul_mul A B C⁻¹
 
-end Group
-
-section CommGroup
-variable [CommGroup G] {A B C : Finset G}
-
 /-! ### Plünnecke-Petridis inequality -/
 
 @[to_additive]
 theorem pluennecke_petridis_inequality_mul (C : Finset G)
     (hA : ∀ A' ⊆ A, #(A * B) * #A' ≤ #(A' * B) * #A) :
-    #(A * B * C) * #A ≤ #(A * B) * #(A * C) := by
+    #(C * A * B) * #A ≤ #(A * B) * #(C * A) := by
   induction C using Finset.induction_on with
   | empty => simp
   | insert _ ih =>
     rename_i x C _
-    set A' := A ∩ (A * C / {x}) with hA'
+    set A' := A ∩ ({x}⁻¹ * C * A) with hA'
     set C' := insert x C with hC'
-    have h₀ : A' * {x} = A * {x} ∩ (A * C) := by
-      rw [hA', inter_mul_singleton, (isUnit_singleton x).div_mul_cancel]
-    have h₁ : A * B * C' = A * B * C ∪ (A * B * {x}) \ (A' * B * {x}) := by
-      rw [hC', insert_eq, union_comm, mul_union]
+    have h₀ : {x} * A' = {x} * A ∩ (C * A) := by
+      rw [hA', mul_assoc, singleton_mul_inter, (isUnit_singleton x).mul_inv_cancel_left]
+    have h₁ : C' * A * B = C * A * B ∪ ({x} * A * B) \ ({x} * A' * B) := by
+      rw [hC', insert_eq, union_comm, union_mul, union_mul]
       refine (sup_sdiff_eq_sup ?_).symm
-      rw [mul_right_comm, mul_right_comm A, h₀]
-      exact mul_subset_mul_right inter_subset_right
-    have h₂ : A' * B * {x} ⊆ A * B * {x} :=
-      mul_subset_mul_right (mul_subset_mul_right inter_subset_left)
-    have h₃ : #(A * B * C') ≤ #(A * B * C) + #(A * B) - #(A' * B) := by
+      rw [h₀]
+      gcongr
+      exact inter_subset_right
+    have h₂ : {x} * A' * B ⊆ {x} * A * B := by gcongr; exact inter_subset_left
+    have h₃ : #(C' * A * B) ≤ #(C * A * B) + #(A * B) - #(A' * B) := by
       rw [h₁]
       refine (card_union_le _ _).trans_eq ?_
-      rw [card_sdiff h₂, ← add_tsub_assoc_of_le (card_le_card h₂), card_mul_singleton,
-        card_mul_singleton]
+      rw [card_sdiff h₂, ← add_tsub_assoc_of_le (card_le_card h₂), mul_assoc {_}, mul_assoc {_},
+        card_singleton_mul, card_singleton_mul]
     refine (mul_le_mul_right' h₃ _).trans ?_
     rw [tsub_mul, add_mul]
     refine (tsub_le_tsub (add_le_add_right ih _) <| hA _ inter_subset_left).trans_eq ?_
-    rw [← mul_add, ← mul_tsub, ← hA', hC', insert_eq, mul_union, ← card_mul_singleton A x, ←
-      card_mul_singleton A' x, add_comm #_, h₀,
-      eq_tsub_of_add_eq (card_union_add_card_inter _ _)]
+    rw [← mul_add, ← mul_tsub, ← hA', hC', insert_eq, union_mul, ← card_singleton_mul x A, ←
+      card_singleton_mul x A', add_comm #_, h₀, eq_tsub_of_add_eq (card_union_add_card_inter _ _)]
+
+end Group
+
+section CommGroup
+variable [CommGroup G] {A B C : Finset G}
 
 /-! ### Commutative Ruzsa triangle inequality -/
 
@@ -183,7 +182,8 @@ theorem ruzsa_triangle_inequality_mul_mul_mul (A B C : Finset G) :
   refine le_trans ?_
     (mul_le_mul (hUA _ hB') (cast_le.2 <| card_le_card <| mul_subset_mul_right hU.2)
       (zero_le _) (zero_le _))
-  rw [← mul_div_right_comm, ← mul_assoc, le_div_iff₀ (cast_pos.2 hU.1.card_pos)]
+  rw [← mul_div_right_comm, ← mul_assoc, le_div_iff₀ (cast_pos.2 hU.1.card_pos), mul_comm _ C,
+    ← mul_assoc, mul_comm _ C]
   exact mod_cast pluennecke_petridis_inequality_mul C (mul_aux hU.1 hU.2 hUA)
 
 /-- **Ruzsa's triangle inequality**. Mul-div-div version. -/
@@ -219,9 +219,9 @@ private lemma card_mul_pow_le (hAB : ∀ A' ⊆ A, #(A * B) * #A' ≤ #(A' * B) 
     refine le_of_mul_le_mul_right ?_ (by positivity : (0 : ℚ≥0) < #A)
     calc
       ((#(A * B ^ (n + 1))) * #A : ℚ≥0)
-        = #(A * B * B ^ n) * #A := by rw [_root_.pow_succ', ← mul_assoc]
-      _ ≤ #(A * B) * #(A * B ^ n) := mod_cast pluennecke_petridis_inequality_mul _ hAB
-      _ ≤ #(A * B) * ((#(A * B) / #A) ^ n * #A) := by gcongr
+        = #(B ^ n * A * B) * #A := by rw [pow_succ, mul_left_comm, mul_assoc]
+      _ ≤ #(A * B) * #(B ^ n * A) := mod_cast pluennecke_petridis_inequality_mul _ hAB
+      _ ≤ #(A * B) * ((#(A * B) / #A) ^ n * #A) := by rw [mul_comm _ A]; gcongr
       _ = (#(A * B) / #A) ^ (n + 1) * #A * #A := by field_simp; ring
 
 /-- The **Plünnecke-Ruzsa inequality**. Multiplication version. Note that this is genuinely harder


### PR DESCRIPTION
Kudos to Thomas Bloom for spotting that I wrote an overspecialised result.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
