### PR TITLE
[Merged by Bors] - refactor(Convex/Cone): streamline duality

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1513,6 +1513,7 @@ import Mathlib.Analysis.Convex.Caratheodory
 import Mathlib.Analysis.Convex.Combination
 import Mathlib.Analysis.Convex.Cone.Basic
 import Mathlib.Analysis.Convex.Cone.Closure
+import Mathlib.Analysis.Convex.Cone.Dual
 import Mathlib.Analysis.Convex.Cone.Extension
 import Mathlib.Analysis.Convex.Cone.InnerDual
 import Mathlib.Analysis.Convex.Continuous
@@ -3639,6 +3640,7 @@ import Mathlib.FieldTheory.SplittingField.Construction
 import Mathlib.FieldTheory.SplittingField.IsSplittingField
 import Mathlib.FieldTheory.Tower
 import Mathlib.Geometry.Convex.Cone.Basic
+import Mathlib.Geometry.Convex.Cone.Dual
 import Mathlib.Geometry.Convex.Cone.Pointed
 import Mathlib.Geometry.Euclidean.Altitude
 import Mathlib.Geometry.Euclidean.Angle.Oriented.Affine

--- a/Mathlib/Analysis/Convex/Cone/Basic.lean
+++ b/Mathlib/Analysis/Convex/Cone/Basic.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Apurva Nakade, Yaël Dillies
 -/
 import Mathlib.Analysis.Convex.Cone.Closure
+import Mathlib.Geometry.Convex.Cone.Pointed
 import Mathlib.Topology.Algebra.Module.ClosedSubmodule
 import Mathlib.Topology.Algebra.Order.Module
 import Mathlib.Topology.Order.OrderClosed
@@ -79,6 +80,7 @@ lemma pointed_toConvexCone (C : ProperCone R E) : (C : ConvexCone R E).Pointed :
 
 protected lemma nonempty (C : ProperCone R E) : (C : Set E).Nonempty := C.toSubmodule.nonempty
 protected lemma isClosed (C : ProperCone R E) : IsClosed (C : Set E) := C.isClosed'
+protected lemma convex (C : ProperCone R E) : Convex R (C : Set E) := C.toPointedCone.convex
 
 protected nonrec lemma smul_mem (C : ProperCone R E) (hx : x ∈ C) (hr : 0 ≤ r) : r • x ∈ C :=
   C.smul_mem ⟨r, hr⟩ hx
@@ -132,8 +134,7 @@ lemma mem_map {f : E →L[R] F} {C : ProperCone R E} {y : F} :
 end Module
 
 section PositiveCone
-variable {E : Type*} [AddCommGroup E] [TopologicalSpace E] [Module R E] [PartialOrder E]
-  [IsOrderedAddMonoid E] [OrderedSMul R E] [OrderClosedTopology E] {x : E}
+variable [PartialOrder E] [IsOrderedAddMonoid E] [PosSMulMono R E] [OrderClosedTopology E] {x : E}
 
 variable (R E) in
 /-- The positive cone is the proper cone formed by the set of nonnegative elements in an ordered

--- a/Mathlib/Analysis/Convex/Cone/Dual.lean
+++ b/Mathlib/Analysis/Convex/Cone/Dual.lean
@@ -13,11 +13,12 @@ import Mathlib.Topology.Algebra.Module.PerfectPairing
 
 Given a continuous bilinear pairing `p` between two `R`-modules `M` and `N` and a set `s` in `M`,
 we define `ProperCone.dual p C` to be the proper cone in `N` consisting of all points `y` such that
-for all `x ∈ s` we have `0 ≤ p x y`.
+`0 ≤ p x y` for all `x ∈ s`.
 
-When the pairing is perfect, this gives us the algebraic dual of a cone. This is developed here.
+When the pairing is perfect, this gives us the algebraic dual of a cone.
+See `Mathlib/Geometry/Convex/Cone/Dual.lean` for that case.
 When the pairing is continuous and perfect (as a continuous pairing), this gives us the topological
-dual instead. See `Mathlib.Analysis.Convex.Cone.Dual` for that case.
+dual instead. This is developed here.
 
 We prove Farkas' lemma, which says that a proper cone `C` in a locally convex topological real
 vector space `E` and a point `x₀` not in `C` can be separated by a hyperplane. This is a geometric
@@ -27,8 +28,6 @@ As a corollary, we prove that the double dual of a proper cone is itself.
 ## Main statements
 
 We prove the following theorems:
-* `ConvexCone.innerDual_of_innerDual_eq_self`:
-  The `innerDual` of the `innerDual` of a proper convex cone is itself.
 * `ProperCone.hyperplane_separation`, `ProperCone.hyperplane_separation_point`: Farkas lemma.
 * `ProperCone.dual_dual_flip`, `ProperCone.dual_flip_dual`: The double dual of a proper cone.
 
@@ -96,10 +95,6 @@ lemma dual_iUnion {ι : Sort*} (f : ι → Set M) : dual p (⋃ i, f i) = ⨅ i,
 
 lemma dual_sUnion (S : Set (Set M)) : dual p (⋃₀ S) = sInf (dual p '' S) := by
   ext; simp [forall_swap (α := M)]
-
-/-- The dual cone of `s` equals the intersection of dual cones of the points in `s`. -/
-lemma dual_eq_iInter_dual_singleton (s : Set M) :
-    dual p s = ⋂ i : s, (dual p {i.val} : Set N) := by ext; simp
 
 /-- Any set is a subset of its double dual cone. -/
 lemma subset_dual_dual : s ⊆ dual p.flip (dual p s) := fun _x hx _y hy ↦ hy hx

--- a/Mathlib/Analysis/Convex/Cone/Dual.lean
+++ b/Mathlib/Analysis/Convex/Cone/Dual.lean
@@ -1,0 +1,151 @@
+/-
+Copyright (c) 2025 Yaël Dillies, Andrew Yang. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yaël Dillies, Andrew Yang
+-/
+import Mathlib.Analysis.Convex.Cone.Basic
+import Mathlib.Analysis.NormedSpace.HahnBanach.Separation
+import Mathlib.Geometry.Convex.Cone.Dual
+import Mathlib.Topology.Algebra.Module.PerfectPairing
+
+/-!
+# The topological dual of a cone and Farkas' lemma
+
+Given a continuous bilinear pairing `p` between two `R`-modules `M` and `N` and a set `s` in `M`,
+we define `ProperCone.dual p C` to be the proper cone in `N` consisting of all points `y` such that
+for all `x ∈ s` we have `0 ≤ p x y`.
+
+When the pairing is perfect, this gives us the algebraic dual of a cone. This is developed here.
+When the pairing is continuous and perfect (as a continuous pairing), this gives us the topological
+dual instead. See `Mathlib.Analysis.Convex.Cone.Dual` for that case.
+
+We prove Farkas' lemma, which says that a proper cone `C` in a locally convex topological real
+vector space `E` and a point `x₀` not in `C` can be separated by a hyperplane. This is a geometric
+interpretation of the Hahn-Banach separation theorem.
+As a corollary, we prove that the double dual of a proper cone is itself.
+
+## Main statements
+
+We prove the following theorems:
+* `ConvexCone.innerDual_of_innerDual_eq_self`:
+  The `innerDual` of the `innerDual` of a proper convex cone is itself.
+* `ProperCone.hyperplane_separation`, `ProperCone.hyperplane_separation_point`: Farkas lemma.
+* `ProperCone.dual_dual_flip`, `ProperCone.dual_flip_dual`: The double dual of a proper cone.
+
+## References
+
+* https://en.wikipedia.org/wiki/Hyperplane_separation_theorem
+* https://en.wikipedia.org/wiki/Farkas%27_lemma#Geometric_interpretation
+-/
+
+assert_not_exists InnerProductSpace
+
+open Set LinearMap Pointwise
+
+namespace PointedCone
+variable {R M N : Type*} [CommRing R] [PartialOrder R] [TopologicalSpace R] [ClosedIciTopology R]
+  [IsOrderedRing R] [AddCommGroup M] [AddCommGroup N] [Module R M] [Module R N] [TopologicalSpace N]
+  {p : M →ₗ[R] N →ₗ[R] R} {s : Set M}
+
+lemma isClosed_dual (hp : ∀ x, Continuous (p x)) : IsClosed (dual p s : Set N) := by
+  rw [← s.biUnion_of_singleton]
+  simp_rw [dual_iUnion, Submodule.iInf_coe, dual_singleton]
+  exact isClosed_biInter fun x hx ↦ isClosed_Ici.preimage <| hp _
+
+end PointedCone
+
+namespace ProperCone
+variable {R M N : Type*} [CommRing R] [PartialOrder R] [IsOrderedRing R] [TopologicalSpace R]
+  [ClosedIciTopology R]
+  [AddCommGroup M] [Module R M] [TopologicalSpace M]
+  [AddCommGroup N] [Module R N] [TopologicalSpace N]
+  {p : M →ₗ[R] N →ₗ[R] R} [p.IsContPerfPair] {s t : Set M} {y : N}
+
+variable (p s) in
+/-- The dual cone of a set `s` with respect to a perfect pairing `p` is the cone consisting of all
+points `y` such that for all points `x ∈ s` we have `0 ≤ p x y`. -/
+def dual (s : Set M) : ProperCone R N where
+  toSubmodule := PointedCone.dual p s
+  isClosed' := PointedCone.isClosed_dual fun _ ↦ p.continuous_of_isContPerfPair
+
+@[simp] lemma mem_dual : y ∈ dual p s ↔ ∀ ⦃x⦄, x ∈ s → 0 ≤ p x y := .rfl
+
+@[simp] lemma dual_empty : dual p ∅ = ⊤ := by ext; simp
+@[simp] lemma dual_zero : dual p 0 = ⊤ := by ext; simp
+
+@[simp] lemma dual_univ [IsTopologicalRing R] [T1Space N] : dual p univ = ⊥ := by
+  refine le_antisymm (fun y hy ↦ (_root_.map_eq_zero_iff _ p.flip.toContPerfPair.injective).1 ?_)
+    (by simp)
+  ext x
+  exact (hy <| mem_univ x).antisymm' <| by simpa using hy <| mem_univ (-x)
+
+@[gcongr] lemma dual_le_dual (h : t ⊆ s) : dual p s ≤ dual p t := fun _y hy _x hx ↦ hy (h hx)
+
+/-- The inner dual cone of a singleton is given by the preimage of the positive cone under the
+linear map `p x`. -/
+lemma dual_singleton [IsTopologicalRing R] [OrderClosedTopology R] (x : M) :
+    dual p {x} = (positive R R).comap (p.toContPerfPair x) := by ext; simp
+
+lemma dual_union (s t : Set M) : dual p (s ∪ t) = dual p s ⊓ dual p t := by aesop
+
+lemma dual_insert (x : M) (s : Set M) : dual p (insert x s) = dual p {x} ⊓ dual p s := by
+  rw [insert_eq, dual_union]
+
+lemma dual_iUnion {ι : Sort*} (f : ι → Set M) : dual p (⋃ i, f i) = ⨅ i, dual p (f i) := by
+  ext; simp [forall_swap (α := M)]
+
+lemma dual_sUnion (S : Set (Set M)) : dual p (⋃₀ S) = sInf (dual p '' S) := by
+  ext; simp [forall_swap (α := M)]
+
+/-- The dual cone of `s` equals the intersection of dual cones of the points in `s`. -/
+lemma dual_eq_iInter_dual_singleton (s : Set M) :
+    dual p s = ⋂ i : s, (dual p {i.val} : Set N) := by ext; simp
+
+/-- Any set is a subset of its double dual cone. -/
+lemma subset_dual_dual : s ⊆ dual p.flip (dual p s) := fun _x hx _y hy ↦ hy hx
+
+end ProperCone
+
+namespace ProperCone
+variable {E F : Type*}
+  [TopologicalSpace E] [AddCommGroup E] [IsTopologicalAddGroup E]
+  [TopologicalSpace F] [AddCommGroup F]
+  [Module ℝ E] [ContinuousSMul ℝ E] [LocallyConvexSpace ℝ E]
+  [Module ℝ F]
+  {K : Set E} {x₀ : E}
+
+open ConvexCone in
+/-- Geometric interpretation of **Farkas' lemma**. Also stronger version of the
+**Hahn-Banach separation theorem** for proper cones. -/
+theorem hyperplane_separation (C : ProperCone ℝ E) (hKconv : Convex ℝ K) (hKcomp : IsCompact K)
+    (hKC : Disjoint K C) : ∃ f : E →L[ℝ] ℝ, (∀ x ∈ C, 0 ≤ f x) ∧ ∀ x ∈ K, f x < 0 := by
+  obtain rfl | ⟨x₀, hx₀⟩ := K.eq_empty_or_nonempty
+  · exact ⟨0, by simp⟩
+  obtain ⟨f, u, v, hu, huv, hv⟩ :=
+    geometric_hahn_banach_compact_closed hKconv hKcomp C.convex C.isClosed hKC
+  have hv₀ : v < 0 := by simpa using hv 0 C.zero_mem
+  refine ⟨f, fun x hx ↦ ?_, fun x hx ↦ (hu x hx).trans_le <| huv.le.trans hv₀.le⟩
+  by_contra! hx₀
+  simpa [hx₀.ne] using hv ((v * (f x)⁻¹) • x)
+    (C.smul_mem hx <| le_of_lt <| mul_pos_of_neg_of_neg hv₀ <| inv_neg''.2 hx₀)
+
+open ConvexCone in
+/-- Geometric interpretation of **Farkas' lemma**. Also stronger version of the
+**Hahn-Banach separation theorem** for proper cones. -/
+theorem hyperplane_separation_point (C : ProperCone ℝ E) (hx₀ : x₀ ∉ C) :
+    ∃ f : E →L[ℝ] ℝ, (∀ x ∈ C, 0 ≤ f x) ∧ f x₀ < 0 := by
+  simpa [*] using C.hyperplane_separation (convex_singleton x₀)
+
+/-- The **double dual of a proper cone** is itself. -/
+@[simp] theorem dual_flip_dual (p : E →ₗ[ℝ] F →ₗ[ℝ] ℝ) [p.IsContPerfPair] (C : ProperCone ℝ E) :
+    dual p.flip (dual p (C : Set E)) = C := by
+  refine le_antisymm (fun x ↦ ?_) subset_dual_dual
+  simp only [mem_toPointedCone, mem_dual, SetLike.mem_coe]
+  contrapose!
+  simpa [p.flip.toContPerfPair.surjective.exists] using C.hyperplane_separation_point
+
+/-- The **double dual of a proper cone** is itself. -/
+@[simp] theorem dual_dual_flip (p : F →ₗ[ℝ] E →ₗ[ℝ] ℝ) [p.IsContPerfPair] (C : ProperCone ℝ E) :
+    dual p (dual p.flip (C : Set E)) = C := C.dual_flip_dual p.flip
+
+end ProperCone

--- a/Mathlib/Analysis/Convex/Cone/InnerDual.lean
+++ b/Mathlib/Analysis/Convex/Cone/InnerDual.lean
@@ -10,7 +10,7 @@ import Mathlib.Analysis.InnerProductSpace.Adjoint
 # Inner dual cone of a set
 
 We define the inner dual cone of a set `s` in an inner product space to be the proper cone
-consisting of all points `y` such that for all `x ∈ s` we have `0 ≤ ⟪x, y⟫`.
+consisting of all points `y` such that `0 ≤ ⟪x, y⟫` for all `x ∈ s`.
 
 ## Main statements
 
@@ -19,11 +19,18 @@ We prove the following theorems:
 * `ProperCone.hyperplane_separation'`:
   This variant of the
   [hyperplane separation theorem](https://en.wikipedia.org/wiki/Hyperplane_separation_theorem)
-  states that given a nonempty, closed, convex cone `C` in a complete, real inner product space E``
+  states that given a nonempty, closed, convex cone `C` in a complete, real inner product space `E`
   and a point `b` disjoint from it, there is a vector `y` which separates `b` from `K` in the sense
   that for all points `x` in `K`, `0 ≤ ⟪x, y⟫_ℝ` and `⟪y, b⟫_ℝ < 0`. This is also a geometric
   interpretation of the
   [Farkas lemma](https://en.wikipedia.org/wiki/Farkas%27_lemma#Geometric_interpretation).
+
+## Implementation notes
+
+We do not provide `ConvexCone`- nor `PointedCone`-valued versions of `ProperCone.innerDual` since
+the inner dual cone of any set is always closed and contains `0`, ie is a proper cone.
+Furthermore, the strict version `{y | ∀ x ∈ s, 0 < ⟪x, y⟫}` is a candidate to the name
+`ConvexCone.innerDual`.
 -/
 
 open Set LinearMap Pointwise

--- a/Mathlib/Analysis/Convex/Cone/InnerDual.lean
+++ b/Mathlib/Analysis/Convex/Cone/InnerDual.lean
@@ -1,27 +1,25 @@
 /-
 Copyright (c) 2021 Alexander Bentkamp. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Alexander Bentkamp
+Authors: Alexander Bentkamp, Yaël Dillies
 -/
-import Mathlib.Analysis.Convex.Cone.Basic
+import Mathlib.Analysis.Convex.Cone.Dual
 import Mathlib.Analysis.InnerProductSpace.Adjoint
-import Mathlib.Analysis.InnerProductSpace.Projection
 
 /-!
-# Convex cones in inner product spaces
+# Inner dual cone of a set
 
-We define `Set.innerDualCone` to be the cone consisting of all points `y` such that for
-all points `x` in a given set `0 ≤ ⟪ x, y ⟫`.
+We define the inner dual cone of a set `s` in an inner product space to be the proper cone
+consisting of all points `y` such that for all `x ∈ s` we have `0 ≤ ⟪x, y⟫`.
 
 ## Main statements
 
 We prove the following theorems:
-* `ConvexCone.innerDualCone_of_innerDualCone_eq_self`:
-  The `innerDualCone` of the `innerDualCone` of a nonempty, closed, convex cone is itself.
-* `ConvexCone.hyperplane_separation_of_nonempty_of_isClosed_of_notMem`:
+* `ProperCone.innerDual_innerDual`: The double inner dual of a proper convex cone is itself.
+* `ProperCone.hyperplane_separation'`:
   This variant of the
   [hyperplane separation theorem](https://en.wikipedia.org/wiki/Hyperplane_separation_theorem)
-  states that given a nonempty, closed, convex cone `K` in a complete, real inner product space `H`
+  states that given a nonempty, closed, convex cone `C` in a complete, real inner product space E``
   and a point `b` disjoint from it, there is a vector `y` which separates `b` from `K` in the sense
   that for all points `x` in `K`, `0 ≤ ⟪x, y⟫_ℝ` and `⟪y, b⟫_ℝ < 0`. This is also a geometric
   interpretation of the
@@ -29,9 +27,110 @@ We prove the following theorems:
 -/
 
 open Set LinearMap Pointwise
+open scoped RealInnerProductSpace
 
-/-! ### The dual cone -/
+variable {R E F : Type*}
+  [NormedAddCommGroup E] [InnerProductSpace ℝ E] [CompleteSpace E]
+  [NormedAddCommGroup F] [InnerProductSpace ℝ F] [CompleteSpace F]
+  {s t : Set E} {x x₀ y : E}
 
+open Function
+
+namespace ProperCone
+
+/-- The dual cone of a set `s` is the cone consisting of all points `y` such that for all points
+`x ∈ s` we have `0 ≤ ⟪x, y⟫`. -/
+@[simps! toSubmodule]
+def innerDual (s : Set E) : ProperCone ℝ E := .dual (innerₗ E) s
+
+@[simp] lemma mem_innerDual : y ∈ innerDual s ↔ ∀ ⦃x⦄, x ∈ s → 0 ≤ ⟪x, y⟫ := .rfl
+
+@[simp] lemma innerDual_empty : innerDual (∅ : Set E) = ⊤ := by ext; simp
+
+/-- Dual cone of the convex cone `{0}` is the total space. -/
+@[simp] lemma innerDual_zero : innerDual (0 : Set E) = ⊤ := by ext; simp
+
+/-- Dual cone of the total space is the convex cone `{0}`. -/
+@[simp]
+lemma innerDual_univ : innerDual (univ : Set E) = ⊥ :=
+  le_antisymm (fun x hx ↦ by simpa [← real_inner_self_nonpos] using hx (mem_univ (-x))) (by simp)
+
+@[gcongr] lemma innerDual_le_innerDual (h : t ⊆ s) : innerDual s ≤ innerDual t :=
+  fun _y hy _x hx ↦ hy (h hx)
+
+/-- The inner dual cone of a singleton is given by the preimage of the positive cone under the
+linear map `fun y ↦ ⟪x, y⟫`. -/
+lemma innerDual_singleton (x : E) :
+    innerDual ({x} : Set E) = (positive ℝ ℝ).comap (innerSL ℝ x) := by ext; simp
+
+lemma innerDual_union (s t : Set E) : innerDual (s ∪ t) = innerDual s ⊓ innerDual t :=
+  le_antisymm (le_inf (fun _ hx _ hy ↦ hx <| .inl hy) fun _ hx _ hy ↦ hx <| .inr hy)
+    fun _ hx _ => Or.rec (fun h ↦ hx.1 h) (fun h ↦ hx.2 h)
+
+lemma innerDual_insert (x : E) (s : Set E) :
+    innerDual (insert x s) = innerDual {x} ⊓ innerDual s := by
+  rw [insert_eq, innerDual_union]
+
+lemma innerDual_iUnion {ι : Sort*} (f : ι → Set E) :
+    innerDual (⋃ i, f i) = ⨅ i, innerDual (f i) := by
+  ext; simp [forall_swap (α := E)]
+
+lemma innerDual_sUnion (S : Set (Set E)) : innerDual (⋃₀ S) = sInf (innerDual '' S) := by
+  ext; simp [forall_swap (α := E)]
+
+/-! ### Farkas' lemma and double dual of a cone in a Hilbert space -/
+
+/-- Geometric interpretation of **Farkas' lemma**. Also stronger version of the
+**Hahn-Banach separation theorem** for proper cones. -/
+theorem hyperplane_separation' (C : ProperCone ℝ E) (hx₀ : x₀ ∉ C) :
+    ∃ y, (∀ x ∈ C, 0 ≤ ⟪x, y⟫) ∧ ⟪x₀, y⟫ < 0 := by
+  obtain ⟨f, hf, hf₀⟩ := C.hyperplane_separation_point hx₀
+  refine ⟨(InnerProductSpace.toDual ℝ E).symm f, ?_⟩
+  simpa [← real_inner_comm _ ((InnerProductSpace.toDual ℝ E).symm f), *]
+
+/-- The inner dual of inner dual of a proper cone is itself. -/
+@[simp] theorem innerDual_innerDual (C : ProperCone ℝ E) :
+    innerDual (innerDual (C : Set E)) = C := by
+  simpa using C.dual_flip_dual (innerₗ E)
+
+open scoped InnerProductSpace
+
+/-- Relative geometric interpretation of **Farkas' lemma**. Also stronger version of the
+**Hahn-Banach separation theorem** for proper cones. -/
+theorem relative_hyperplane_separation {C : ProperCone ℝ E} {f : E →L[ℝ] F} {b : F} :
+    b ∈ C.map f ↔ ∀ y : F, f.adjoint y ∈ innerDual C → 0 ≤ ⟪b, y⟫_ℝ where
+  mp := by
+    -- suppose `b ∈ C.map f`
+    simp only [map, ClosedSubmodule.map, Submodule.closure, Submodule.topologicalClosure,
+      AddSubmonoid.topologicalClosure, Submodule.coe_toAddSubmonoid, Submodule.map_coe,
+      ContinuousLinearMap.coe_restrictScalars', ClosedSubmodule.coe_toSubmodule,
+      ClosedSubmodule.mem_mk, Submodule.mem_mk, AddSubmonoid.mem_mk, AddSubsemigroup.mem_mk,
+      mem_closure_iff_seq_limit, mem_image, SetLike.mem_coe, Classical.skolem, forall_and,
+      mem_innerDual, ContinuousLinearMap.adjoint_inner_right, forall_exists_index, and_imp]
+          -- there is a sequence `seq : ℕ → F` in the image of `f` that converges to `b`
+    rintro x seq hmem hx htends y hinner
+    obtain rfl : f ∘ seq = x := funext hx
+    have h n : 0 ≤ ⟪f (seq n), y⟫_ℝ := by simpa [real_inner_comm] using hinner (hmem n)
+    exact ge_of_tendsto' ((continuous_id.inner continuous_const).seqContinuous htends) h
+  mpr h := by
+    -- By contradiction, suppose `b ∉ C.map f`.
+    contrapose! h
+    -- as `b ∉ C.map f`, there is a hyperplane `y` separating `b` from `C.map f`
+    obtain ⟨y, hxy, hyb⟩ := (C.map f).hyperplane_separation' h
+    -- the rest of the proof is a straightforward algebraic manipulation
+    refine ⟨y, fun x hx ↦ ?_, hyb⟩
+    simpa [ContinuousLinearMap.adjoint_inner_right]
+      using hxy (f x) (subset_closure <| mem_image_of_mem _ hx)
+
+theorem hyperplane_separation_of_notMem (K : ProperCone ℝ E) {f : E →L[ℝ] F} {b : F}
+    (disj : b ∉ K.map f) :
+    ∃ y : F, ContinuousLinearMap.adjoint f y ∈ innerDual K ∧ ⟪b, y⟫_ℝ < 0 := by
+  contrapose! disj; rwa [K.relative_hyperplane_separation]
+
+@[deprecated (since := "2025-05-24")]
+alias hyperplane_separation_of_nmem := ProperCone.hyperplane_separation_of_notMem
+
+end ProperCone
 
 section Dual
 
@@ -41,6 +140,7 @@ open RealInnerProductSpace
 
 /-- The dual cone is the cone consisting of all points `y` such that for
 all points `x` in a given set `0 ≤ ⟪ x, y ⟫`. -/
+@[deprecated ProperCone.innerDual (since := "2025-07-06")]
 def Set.innerDualCone (s : Set H) : ConvexCone ℝ H where
   carrier := { y | ∀ x ∈ s, 0 ≤ ⟪x, y⟫ }
   smul_mem' c hc y hy x hx := by
@@ -50,21 +150,24 @@ def Set.innerDualCone (s : Set H) : ConvexCone ℝ H where
     rw [inner_add_right]
     exact add_nonneg (hu x hx) (hv x hx)
 
-@[simp]
+set_option linter.deprecated false in
+@[deprecated ProperCone.mem_innerDual (since := "2025-07-06")]
 theorem mem_innerDualCone (y : H) (s : Set H) : y ∈ s.innerDualCone ↔ ∀ x ∈ s, 0 ≤ ⟪x, y⟫ :=
   Iff.rfl
 
-@[simp]
+set_option linter.deprecated false in
+@[deprecated ProperCone.innerDual_empty (since := "2025-07-06")]
 theorem innerDualCone_empty : (∅ : Set H).innerDualCone = ⊤ :=
   eq_top_iff.mpr fun _ _ _ => False.elim
 
-/-- Dual cone of the convex cone {0} is the total space. -/
-@[simp]
+set_option linter.deprecated false in
+@[deprecated ProperCone.innerDual_zero (since := "2025-07-06")]
 theorem innerDualCone_zero : (0 : Set H).innerDualCone = ⊤ :=
   eq_top_iff.mpr fun _ _ y (hy : y = 0) => hy.symm ▸ (inner_zero_left _).ge
 
+set_option linter.deprecated false in
 /-- Dual cone of the total space is the convex cone {0}. -/
-@[simp]
+@[deprecated ProperCone.innerDual_univ (since := "2025-07-06")]
 theorem innerDualCone_univ : (univ : Set H).innerDualCone = 0 := by
   suffices ∀ x : H, x ∈ (univ : Set H).innerDualCone → x = 0 by
     apply SetLike.coe_injective
@@ -72,27 +175,38 @@ theorem innerDualCone_univ : (univ : Set H).innerDualCone = 0 := by
   exact fun x hx => by simpa [← real_inner_self_nonpos] using hx (-x) (mem_univ _)
 
 variable {s t} in
-@[gcongr]
+set_option linter.deprecated false in
+@[deprecated ProperCone.innerDual_le_innerDual (since := "2025-07-06")]
 theorem innerDualCone_le_innerDualCone (h : t ⊆ s) : s.innerDualCone ≤ t.innerDualCone :=
   fun _ hy x hx => hy x (h hx)
 
+set_option linter.deprecated false in
+@[deprecated ProperCone.pointed_toConvexCone (since := "2025-07-06")]
 theorem pointed_innerDualCone : s.innerDualCone.Pointed := fun x _ => by rw [inner_zero_right]
 
+set_option linter.deprecated false in
 /-- The inner dual cone of a singleton is given by the preimage of the positive cone under the
 linear map `fun y ↦ ⟪x, y⟫`. -/
+@[deprecated ProperCone.innerDual_singleton (since := "2025-07-06")]
 theorem innerDualCone_singleton (x : H) :
     ({x} : Set H).innerDualCone = (ConvexCone.positive ℝ ℝ).comap (innerₛₗ ℝ x) :=
   ConvexCone.ext fun _ => forall_eq
 
+set_option linter.deprecated false in
+@[deprecated ProperCone.innerDual_union (since := "2025-07-06")]
 theorem innerDualCone_union (s t : Set H) :
     (s ∪ t).innerDualCone = s.innerDualCone ⊓ t.innerDualCone :=
   le_antisymm (le_inf (fun _ hx _ hy => hx _ <| Or.inl hy) fun _ hx _ hy => hx _ <| Or.inr hy)
     fun _ hx _ => Or.rec (hx.1 _) (hx.2 _)
 
+set_option linter.deprecated false in
+@[deprecated ProperCone.innerDual_insert (since := "2025-07-06")]
 theorem innerDualCone_insert (x : H) (s : Set H) :
     (insert x s).innerDualCone = Set.innerDualCone {x} ⊓ s.innerDualCone := by
   rw [insert_eq, innerDualCone_union]
 
+set_option linter.deprecated false in
+@[deprecated ProperCone.innerDual_iUnion (since := "2025-07-06")]
 theorem innerDualCone_iUnion {ι : Sort*} (f : ι → Set H) :
     (⋃ i, f i).innerDualCone = ⨅ i, (f i).innerDualCone := by
   refine le_antisymm (le_iInf fun i x hx y hy => hx _ <| mem_iUnion_of_mem _ hy) ?_
@@ -101,15 +215,21 @@ theorem innerDualCone_iUnion {ι : Sort*} (f : ι → Set H) :
   obtain ⟨j, hj⟩ := mem_iUnion.mp hy
   exact hx _ _ hj
 
+set_option linter.deprecated false in
+@[deprecated ProperCone.innerDual_sUnion (since := "2025-07-06")]
 theorem innerDualCone_sUnion (S : Set (Set H)) :
     (⋃₀ S).innerDualCone = sInf (Set.innerDualCone '' S) := by
   simp_rw [sInf_image, sUnion_eq_biUnion, innerDualCone_iUnion]
 
+set_option linter.deprecated false in
 /-- The dual cone of `s` equals the intersection of dual cones of the points in `s`. -/
+@[deprecated "No replacement" (since := "2025-07-06")]
 theorem innerDualCone_eq_iInter_innerDualCone_singleton :
     (s.innerDualCone : Set H) = ⋂ i : s, (({↑i} : Set H).innerDualCone : Set H) := by
   rw [← ConvexCone.coe_iInf, ← innerDualCone_iUnion, iUnion_of_singleton_coe]
 
+set_option linter.deprecated false in
+@[deprecated ProperCone.isClosed (since := "2025-07-06")]
 theorem isClosed_innerDualCone : IsClosed (s.innerDualCone : Set H) := by
   -- reduce the problem to showing that dual cone of a singleton `{x}` is closed
   rw [innerDualCone_eq_iInter_innerDualCone_singleton]
@@ -143,32 +263,19 @@ theorem ConvexCone.pointed_of_nonempty_of_isClosed (K : ConvexCone ℝ H) (ne : 
 
 namespace PointedCone
 
-/-- The inner dual cone of a pointed cone is a pointed cone. -/
-def dual (C : PointedCone ℝ H) : PointedCone ℝ H :=
-  ((C : Set H).innerDualCone).toPointedCone <| pointed_innerDualCone (C : Set H)
-
-@[simp, norm_cast]
-lemma toConvexCone_dual (C : PointedCone ℝ H) : ↑(dual C) = (C : Set H).innerDualCone := rfl
-
-open InnerProductSpace in
-@[simp]
-lemma mem_dual {C : PointedCone ℝ H} {y : H} : y ∈ dual C ↔ ∀ ⦃x⦄, x ∈ C → 0 ≤ ⟪x, y⟫_ℝ := .rfl
+set_option linter.deprecated false in
+@[deprecated "Now irrelevant" (since := "2025-07-06")]
+lemma toConvexCone_dual (C : PointedCone ℝ H) :
+    (dual (innerₗ H) (C : Set H)).toConvexCone = (C : Set H).innerDualCone := rfl
 
 end PointedCone
 
 namespace ProperCone
 
-/-- The inner dual cone of a proper cone is a proper cone. -/
-def dual (C : ProperCone ℝ H) : ProperCone ℝ H where
-  toSubmodule := PointedCone.dual (C : PointedCone ℝ H)
-  isClosed' := isClosed_innerDualCone _
-
-@[simp, norm_cast]
-lemma coe_dual (C : ProperCone ℝ H) : C.dual = (C : Set H).innerDualCone := rfl
-
-open scoped InnerProductSpace in
-@[simp]
-lemma mem_dual {C : ProperCone ℝ H} {y : H} : y ∈ dual C ↔ ∀ ⦃x⦄, x ∈ C → 0 ≤ ⟪x, y⟫_ℝ := .rfl
+set_option linter.deprecated false in
+@[deprecated "Now irrelevant" (since := "2025-07-06")]
+lemma coe_dual [CompleteSpace H] (C : ProperCone ℝ H) :
+    dual (innerₗ H) C = (C : Set H).innerDualCone := rfl
 
 end ProperCone
 
@@ -215,7 +322,9 @@ theorem ConvexCone.hyperplane_separation_of_nonempty_of_isClosed_of_notMem (K : 
 alias ConvexCone.hyperplane_separation_of_nonempty_of_isClosed_of_nmem :=
   ConvexCone.hyperplane_separation_of_nonempty_of_isClosed_of_notMem
 
+set_option linter.deprecated false in
 /-- The inner dual of inner dual of a non-empty, closed convex cone is itself. -/
+@[deprecated ProperCone.innerDual_innerDual (since := "2025-07-06")]
 theorem ConvexCone.innerDualCone_of_innerDualCone_eq_self (K : ConvexCone ℝ H)
     (ne : (K : Set H).Nonempty) (hc : IsClosed (K : Set H)) :
     ((K : Set H).innerDualCone : Set H).innerDualCone = K := by
@@ -231,57 +340,12 @@ theorem ConvexCone.innerDualCone_of_innerDualCone_eq_self (K : ConvexCone ℝ H)
 namespace ProperCone
 variable {F : Type*} [NormedAddCommGroup F] [InnerProductSpace ℝ F]
 
+set_option linter.deprecated false in
 /-- The dual of the dual of a proper cone is itself. -/
-@[simp]
-theorem dual_dual (K : ProperCone ℝ H) : K.dual.dual = K :=
+@[deprecated ProperCone.innerDual_innerDual (since := "2025-07-06")]
+theorem dual_dual (K : ProperCone ℝ H) : innerDual (innerDual (K : Set H)) = K :=
   ProperCone.toPointedCone_injective <| PointedCone.toConvexCone_injective <|
     (K : ConvexCone ℝ H).innerDualCone_of_innerDualCone_eq_self K.nonempty K.isClosed
-
-variable [CompleteSpace F]
-
-open scoped InnerProductSpace
-
-/-- This is a relative version of
-`ConvexCone.hyperplane_separation_of_nonempty_of_isClosed_of_notMem`, which we recover by setting
-`f` to be the identity map. This is also a geometric interpretation of the Farkas' lemma
-stated using proper cones. -/
-theorem hyperplane_separation (K : ProperCone ℝ H) {f : H →L[ℝ] F} {b : F} :
-    b ∈ K.map f ↔ ∀ y : F, f.adjoint y ∈ K.dual → 0 ≤ ⟪y, b⟫_ℝ where
-  mp := by
-    -- suppose `b ∈ K.map f`
-    simp only [mem_map, PointedCone.mem_closure, PointedCone.coe_map, ContinuousLinearMap.coe_coe,
-      mem_closure_iff_seq_limit, mem_image, SetLike.mem_coe, mem_dual,
-      ContinuousLinearMap.adjoint_inner_right, forall_exists_index, and_imp]
-    -- there is a sequence `seq : ℕ → F` in the image of `f` that converges to `b`
-    rintro seq hmem htends y hinner
-    suffices h : ∀ n, 0 ≤ ⟪y, seq n⟫_ℝ from
-      ge_of_tendsto' (Continuous.seqContinuous (Continuous.inner (@continuous_const _ _ _ _ y)
-        continuous_id) htends) h
-    intro n
-    obtain ⟨_, h, hseq⟩ := hmem n
-    simpa only [← hseq, real_inner_comm] using hinner h
-  mpr := by
-    -- proof by contradiction
-    -- suppose `b ∉ K.map f`
-    intro h
-    contrapose! h
-    -- as `b ∉ K.map f`, there is a hyperplane `y` separating `b` from `K.map f`
-    let C := PointedCone.toConvexCone (R := ℝ) (E := F) (K.map f)
-    obtain ⟨y, hxy, hyb⟩ :=
-      @ConvexCone.hyperplane_separation_of_nonempty_of_isClosed_of_notMem
-      _ _ _ _ C (K.map f).nonempty (K.map f).isClosed b h
-    -- the rest of the proof is a straightforward algebraic manipulation
-    refine ⟨y, ?_, hyb⟩
-    simp only [mem_dual, ContinuousLinearMap.adjoint_inner_right]
-    intro x hxK
-    exact hxy (f x) <| subset_closure <| Set.mem_image_of_mem _ hxK
-
-theorem hyperplane_separation_of_notMem (K : ProperCone ℝ H) {f : H →L[ℝ] F} {b : F}
-    (disj : b ∉ K.map f) : ∃ y : F, ContinuousLinearMap.adjoint f y ∈ K.dual ∧ ⟪y, b⟫_ℝ < 0 := by
-  contrapose! disj; rwa [K.hyperplane_separation]
-
-@[deprecated (since := "2025-05-24")]
-alias hyperplane_separation_of_nmem := hyperplane_separation_of_notMem
 
 end ProperCone
 

--- a/Mathlib/Analysis/InnerProductSpace/Dual.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Dual.lean
@@ -6,6 +6,7 @@ Authors: Frédéric Dupuis
 import Mathlib.Analysis.InnerProductSpace.Projection
 import Mathlib.Analysis.Normed.Module.Dual
 import Mathlib.Analysis.Normed.Group.NullSubmodule
+import Mathlib.Topology.Algebra.Module.PerfectPairing
 
 /-!
 # The Fréchet-Riesz representation theorem
@@ -196,5 +197,14 @@ theorem unique_continuousLinearMapOfBilin {v f : E} (is_lax_milgram : ∀ w, ⟪
   exact is_lax_milgram w
 
 end Normed
+
+instance [NormedAddCommGroup E] [CompleteSpace E] [InnerProductSpace ℝ E] :
+    (innerₗ E).IsContPerfPair where
+  continuous_uncurry := continuous_inner
+  bijective_left := (InnerProductSpace.toDual ℝ E).bijective
+  bijective_right := by
+    convert (InnerProductSpace.toDual ℝ E).bijective
+    ext y
+    simp
 
 end InnerProductSpace

--- a/Mathlib/Geometry/Convex/Cone/Dual.lean
+++ b/Mathlib/Geometry/Convex/Cone/Dual.lean
@@ -1,0 +1,90 @@
+/-
+Copyright (c) 2025 Yaël Dillies. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yaël Dillies
+-/
+import Mathlib.Algebra.Module.Submodule.Pointwise
+import Mathlib.Geometry.Convex.Cone.Pointed
+
+/-!
+# The algebraic dual of a cone
+
+Given a bilinear pairing `p` between two `R`-modules `M` and `N` and a set `s` in `M`, we define
+`PointedCone.dual p C` to be the pointed cone in `N` consisting of all points `y` such that for all
+`x ∈ s` we have `0 ≤ p x y`.
+
+When the pairing is perfect, this gives us the algebraic dual of a cone. This is developed here.
+When the pairing is continuous and perfect (as a continuous pairing), this gives us the topological
+dual instead. See `Mathlib.Analysis.Convex.Cone.Dual` for that case.
+-/
+
+assert_not_exists TopologicalSpace Real Cardinal
+
+open Function LinearMap Pointwise Set
+
+namespace PointedCone
+variable {R M N : Type*} [CommRing R] [PartialOrder R] [IsOrderedRing R] [AddCommGroup M]
+  [AddCommGroup N] [Module R M] [Module R N] {p : M →ₗ[R] N →ₗ[R] R} {s t : Set M} {y : N}
+
+local notation3 "R≥0" => {c : R // 0 ≤ c}
+
+variable (p s) in
+/-- The dual cone of a set `s` with respect to a bilinear pairing `p` is the cone consisting of all
+points `y` such that for all points `x ∈ s` we have `0 ≤ p x y`. -/
+def dual (s : Set M) : PointedCone R N where
+  carrier := {y | ∀ ⦃x⦄, x ∈ s → 0 ≤ p x y}
+  zero_mem' := by simp
+  add_mem' {u v} hu hv x hx := by rw [map_add]; exact add_nonneg (hu hx) (hv hx)
+  smul_mem' c y hy x hx := by rw [← Nonneg.coe_smul, map_smul]; exact mul_nonneg c.2 (hy hx)
+
+@[simp] lemma mem_dual : y ∈ dual p s ↔ ∀ ⦃x⦄, x ∈ s → 0 ≤ p x y := .rfl
+
+@[simp] lemma dual_empty : dual p ∅ = ⊤ := by ext; simp
+@[simp] lemma dual_zero : dual p 0 = ⊤ := by ext; simp
+
+lemma dual_univ (hp : Injective p.flip) : dual p univ = 0 := by
+  refine le_antisymm (fun y hy ↦ (_root_.map_eq_zero_iff p.flip hp).1 ?_) (by simp)
+  ext x
+  exact (hy <| mem_univ x).antisymm' <| by simpa using hy <| mem_univ (-x)
+
+@[gcongr] lemma dual_le_dual (h : t ⊆ s) : dual p s ≤ dual p t := fun _y hy _x hx ↦ hy (h hx)
+
+/-- The inner dual cone of a singleton is given by the preimage of the positive cone under the
+linear map `p x`. -/
+lemma dual_singleton (x : M) : dual p {x} = (positive R R).comap (p x) := by ext; simp
+
+lemma dual_union (s t : Set M) : dual p (s ∪ t) = dual p s ⊓ dual p t := by aesop
+
+lemma dual_insert (x : M) (s : Set M) : dual p (insert x s) = dual p {x} ⊓ dual p s := by
+  rw [insert_eq, dual_union]
+
+lemma dual_iUnion {ι : Sort*} (f : ι → Set M) : dual p (⋃ i, f i) = ⨅ i, dual p (f i) := by
+  ext; simp [forall_swap (α := M)]
+
+lemma dual_sUnion (S : Set (Set M)) : dual p (⋃₀ S) = sInf (dual p '' S) := by
+  ext; simp [forall_swap (α := M)]
+
+/-- The dual cone of `s` equals the intersection of dual cones of the points in `s`. -/
+lemma dual_eq_iInter_dual_singleton (s : Set M) :
+    dual p s = ⋂ i : s, (dual p {i.val} : Set N) := by ext; simp
+
+/-- Any set is a subset of its double dual cone. -/
+lemma subset_dual_dual : s ⊆ dual p.flip (dual p s) := fun _x hx _y hy ↦ hy hx
+
+variable (s) in
+@[simp] lemma dual_dual_flip_dual : dual p (dual p.flip (dual p s)) = dual p s :=
+  le_antisymm (dual_le_dual subset_dual_dual) subset_dual_dual
+
+@[simp] lemma dual_flip_dual_dual_flip (s : Set N) :
+    dual p.flip (dual p (dual p.flip s)) = dual p.flip s := dual_dual_flip_dual _
+
+@[simp]
+lemma dual_span (s : Set M) : dual p (Submodule.span R≥0 s) = dual p s := by
+  refine le_antisymm (dual_le_dual Submodule.subset_span) (fun x hx y hy => ?_)
+  induction hy using Submodule.span_induction with
+  | mem _y h => exact hx h
+  | zero => simp
+  | add y z _hy _hz hy hz => rw [map_add, add_apply]; exact add_nonneg hy hz
+  | smul t y _hy hy => rw [map_smul_of_tower, Nonneg.mk_smul, smul_apply]; exact mul_nonneg t.2 hy
+
+end PointedCone

--- a/Mathlib/Geometry/Convex/Cone/Dual.lean
+++ b/Mathlib/Geometry/Convex/Cone/Dual.lean
@@ -10,12 +10,12 @@ import Mathlib.Geometry.Convex.Cone.Pointed
 # The algebraic dual of a cone
 
 Given a bilinear pairing `p` between two `R`-modules `M` and `N` and a set `s` in `M`, we define
-`PointedCone.dual p C` to be the pointed cone in `N` consisting of all points `y` such that for all
-`x ∈ s` we have `0 ≤ p x y`.
+`PointedCone.dual p C` to be the pointed cone in `N` consisting of all points `y` such that
+`0 ≤ p x y` for all `x ∈ s`.
 
 When the pairing is perfect, this gives us the algebraic dual of a cone. This is developed here.
 When the pairing is continuous and perfect (as a continuous pairing), this gives us the topological
-dual instead. See `Mathlib.Analysis.Convex.Cone.Dual` for that case.
+dual instead. See `Mathlib/Analysis/Convex/Cone/Dual.lean` for that case.
 -/
 
 assert_not_exists TopologicalSpace Real Cardinal

--- a/Mathlib/Geometry/Convex/Cone/Dual.lean
+++ b/Mathlib/Geometry/Convex/Cone/Dual.lean
@@ -16,6 +16,13 @@ Given a bilinear pairing `p` between two `R`-modules `M` and `N` and a set `s` i
 When the pairing is perfect, this gives us the algebraic dual of a cone. This is developed here.
 When the pairing is continuous and perfect (as a continuous pairing), this gives us the topological
 dual instead. See `Mathlib/Analysis/Convex/Cone/Dual.lean` for that case.
+
+## Implementation notes
+
+We do not provide a `ConvexCone`-valued version of `PointedCone.dual` since the dual cone of any set
+always contains `0`, ie is a pointed cone.
+Furthermore, the strict version `{y | ∀ x ∈ s, 0 < p x y}` is a candidate to the name
+`ConvexCone.dual`.
 -/
 
 assert_not_exists TopologicalSpace Real Cardinal

--- a/Mathlib/Geometry/Convex/Cone/Dual.lean
+++ b/Mathlib/Geometry/Convex/Cone/Dual.lean
@@ -23,6 +23,10 @@ We do not provide a `ConvexCone`-valued version of `PointedCone.dual` since the 
 always contains `0`, ie is a pointed cone.
 Furthermore, the strict version `{y | ∀ x ∈ s, 0 < p x y}` is a candidate to the name
 `ConvexCone.dual`.
+
+## TODO
+
+Deduce from `dual_flip_dual_dual_flip` that polyhedral cones are invariant under taking double duals
 -/
 
 assert_not_exists TopologicalSpace Real Cardinal

--- a/Mathlib/Geometry/Convex/Cone/README.md
+++ b/Mathlib/Geometry/Convex/Cone/README.md
@@ -10,3 +10,4 @@ See the `Mathlib.Analysis.Convex.Cone` folder for the topological results.
 The convex cone topics currently covered are:
 * Convex cones
 * Pointed cones
+* Dual cone along a bilinear pairing


### PR DESCRIPTION
Replace the three dual cones definitions we have:
  * `Set.innerDualCone : Set H → ConvexCone ℝ H`
  * `PointedCone.dual : PointedCone ℝ H → PointedCone ℝ H`
  * `ProperCone.dual : ProperCone ℝ H → ProperCone ℝ H`
  
  by three new ones:
  * `PointedCone.dual : Set M → PointedCone R N` for a bilinear pairing `p : M →ₗ[R] N →ₗ[R] R`
  * `ProperCone.dual : Set M → ProperCone R N` for a continuous perfect pairing `p : M →ₗ[R] N →ₗ[R] R`
  * `ProperCone.innerDual : Set H → ProperCone ℝ H` for an inner product space `H`
 
Also generalise the cone hyperplane separation theorem from real inner product spaces to locally convex real vector spaces.

## Motivation

The current library on cones is very centered around normed and Hilbert spaces.

This is inconvenient for us in Toric where we have two spaces $M$, and $N$ that are non-canonically isomorphic to $ℝ^n$ (for the same $n$). Although we could identify $M$ and $N$ with $ℝ^n$ and get an inner product on $M = N = ℝ^n$ this way, we would lose the contravariance (resp. covariance) of $M$ (resp. $N$) in the group scheme that indexes them.

We would instead like to have results that apply to perfect pairings $p : M → N → ℝ$ out of the box.

Not all the theory can be generalised, of course. So, in terms of file structure, we need to draw the line somewhere. We propose to draw it at the import of `NormedAddCommGroup`, as this is the time where the scalars suddenly get fixed to the reals, instead of an arbitrary ordered ring. This line passes through individual files, which therefore need to be split.

We operate this separation by moving the cone content that doesn't require a norm under a new folder `Geometry.Convex.Cone`. The content that does require it stays in `Analysis.Convex.Cone`. A similar operation could be performed for the rest of the `Analysis.Convex`, but it seems wiser to do so simultaneously with the convexity refactor.

## Previous changes performed as part of the refactor

* Rename the variable `𝕜` to `R` when it is merely a ring
* Split files according to normless normful parts
* Complete the existing APIs
* Redefine `ProperCone R M` as an `abbrev` for `ClosedSubmodule R≥0 M`, similarly to how `PointedCone R M` is an `abbrev` for `Submodule R≥0 M`.

From Toric

---

- [x] depends on: #24229
- [x] depends on: #24230
- [x] depends on: #24231
- [x] depends on: #24232
- [x] depends on: #24233
- [x] depends on: #24234
- [x] depends on: #24235
- [x] depends on: #24236
- [x] depends on: #24237
- [x] depends on: #24304
- [x] depends on: #25204
- [x] depends on: #25251
- [x] depends on: #25252

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
