### PR TITLE
[Merged by Bors] - chore(Fin/Parity): move `{n : ℕ} {k : Fin n}` to `variable`

### DIFF
--- a/Mathlib/Data/Fin/Parity.lean
+++ b/Mathlib/Data/Fin/Parity.lean
@@ -18,35 +18,37 @@ open Fin
 
 namespace Fin
 
-lemma even_of_val {n : ℕ} {k : Fin n} (h : Even k.val) : Even k := by
+variable {n : ℕ} {k : Fin n}
+
+lemma even_of_val (h : Even k.val) : Even k := by
   have : NeZero n := ⟨k.pos.ne'⟩
   rw [← Fin.cast_val_eq_self k]
   exact h.natCast
 
-lemma odd_of_val {n : ℕ} [NeZero n] {k : Fin n} (h : Odd k.val) : Odd k := by
+lemma odd_of_val [NeZero n] (h : Odd k.val) : Odd k := by
   rw [← Fin.cast_val_eq_self k]
   exact h.natCast
 
-lemma even_of_odd {n : ℕ} (hn : Odd n) (k : Fin n) : Even k := by
+lemma even_of_odd (hn : Odd n) (k : Fin n) : Even k := by
   have : NeZero n := ⟨k.pos.ne'⟩
   rcases k.val.even_or_odd with hk | hk
   · exact even_of_val hk
   · simpa using (hk.add_odd hn).natCast (α := Fin n)
 
 
-lemma odd_of_odd {n : ℕ} [NeZero n] (hn : Odd n) (k : Fin n) : Odd k := by
+lemma odd_of_odd [NeZero n] (hn : Odd n) (k : Fin n) : Odd k := by
   rcases k.val.even_or_odd with hk | hk
   · simpa using (Even.add_odd hk hn).natCast (R := Fin n)
   · exact odd_of_val hk
 
-lemma even_iff_of_even {n : ℕ} (hn : Even n) {k : Fin n} : Even k ↔ Even k.val := by
+lemma even_iff_of_even (hn : Even n) : Even k ↔ Even k.val := by
   rcases hn with ⟨n, rfl⟩
   refine ⟨?_, even_of_val⟩
   rintro ⟨l, rfl⟩
   rw [val_add_eq_ite]
   split_ifs with h <;> simp [Nat.even_sub, *]
 
-lemma odd_iff_of_even {n : ℕ} [NeZero n] (hn : Even n) {k : Fin n} : Odd k ↔ Odd k.val := by
+lemma odd_iff_of_even [NeZero n] (hn : Even n) : Odd k ↔ Odd k.val := by
   rcases hn with ⟨n, rfl⟩
   refine ⟨?_, odd_of_val⟩
   rintro ⟨l, rfl⟩
@@ -58,46 +60,46 @@ lemma odd_iff_of_even {n : ℕ} [NeZero n] (hn : Even n) {k : Fin n} : Odd k ↔
 
 /-- In `Fin n`, all elements are even for odd `n`,
 otherwise an element is even iff its `Fin.val` value is even. -/
-lemma even_iff {n : ℕ} {k : Fin n} : Even k ↔ (Odd n ∨ Even k.val) := by
+lemma even_iff : Even k ↔ (Odd n ∨ Even k.val) := by
   refine ⟨fun hk ↦ ?_, or_imp.mpr ⟨(even_of_odd · k), even_of_val⟩⟩
   rw [← Nat.not_even_iff_odd, ← imp_iff_not_or]
   exact fun hn ↦ (even_iff_of_even hn).mp hk
 
-lemma even_iff_imp {n : ℕ} {k : Fin n} : Even k ↔ (Even n → Even k.val) := by
+lemma even_iff_imp : Even k ↔ (Even n → Even k.val) := by
   rw [imp_iff_not_or, Nat.not_even_iff_odd]
   exact even_iff
 
 /-- In `Fin n`, all elements are odd for odd `n`,
 otherwise an element is odd iff its `Fin.val` value is odd. -/
-lemma odd_iff {n : ℕ} [NeZero n] {k : Fin n} : Odd k ↔ Odd n ∨ Odd k.val := by
+lemma odd_iff [NeZero n] : Odd k ↔ Odd n ∨ Odd k.val := by
   refine ⟨fun hk ↦ ?_, or_imp.mpr ⟨(odd_of_odd · k), odd_of_val⟩⟩
   rw [← Nat.not_even_iff_odd, ← imp_iff_not_or]
   exact fun hn ↦ (odd_iff_of_even hn).mp hk
 
-lemma odd_iff_imp {n : ℕ} [NeZero n] {k : Fin n} : Odd k ↔ (Even n → Odd k.val) := by
+lemma odd_iff_imp [NeZero n] : Odd k ↔ (Even n → Odd k.val) := by
   rw [imp_iff_not_or, Nat.not_even_iff_odd]
   exact odd_iff
 
-lemma even_iff_mod_of_even {n : ℕ} (hn : Even n) {k : Fin n} : Even k ↔ k.val % 2 = 0 := by
+lemma even_iff_mod_of_even (hn : Even n) : Even k ↔ k.val % 2 = 0 := by
   rw [even_iff_of_even hn]
   exact Nat.even_iff
 
-lemma odd_iff_mod_of_even {n : ℕ} [NeZero n] (hn : Even n) {k : Fin n} : Odd k ↔ k.val % 2 = 1 := by
+lemma odd_iff_mod_of_even [NeZero n] (hn : Even n) : Odd k ↔ k.val % 2 = 1 := by
   rw [odd_iff_of_even hn]
   exact Nat.odd_iff
 
-lemma not_odd_iff_even_of_even {n : ℕ} [NeZero n] (hn : Even n) {k : Fin n} : ¬Odd k ↔ Even k := by
+lemma not_odd_iff_even_of_even [NeZero n] (hn : Even n) : ¬Odd k ↔ Even k := by
   rw [even_iff_of_even hn, odd_iff_of_even hn]
   exact Nat.not_odd_iff_even
 
-lemma not_even_iff_odd_of_even {n : ℕ} [NeZero n] (hn : Even n) {k : Fin n} : ¬Even k ↔ Odd k := by
+lemma not_even_iff_odd_of_even [NeZero n] (hn : Even n) : ¬Even k ↔ Odd k := by
   rw [even_iff_of_even hn, odd_iff_of_even hn]
   exact Nat.not_even_iff_odd
 
-lemma odd_add_one_iff_even {n : ℕ} [NeZero n] {k : Fin n} : Odd (k + 1) ↔ Even k :=
+lemma odd_add_one_iff_even [NeZero n] : Odd (k + 1) ↔ Even k :=
   ⟨fun ⟨k, hk⟩ ↦ add_right_cancel hk ▸ even_two_mul k, Even.add_one⟩
 
-lemma even_add_one_iff_odd {n : ℕ} [NeZero n] {k : Fin n} : Even (k + 1) ↔ Odd k :=
+lemma even_add_one_iff_odd [NeZero n] : Even (k + 1) ↔ Odd k :=
   ⟨fun ⟨k, hk⟩ ↦ eq_sub_iff_add_eq.mpr hk ▸ (Even.add_self k).sub_odd odd_one, Odd.add_one⟩
 
 end Fin


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
