### PR TITLE
[Merged by Bors] - chore: use `trichotomy_of_add_eq_add` to prove `MvPowerSeries.lexOrder_mul`

### DIFF
--- a/Mathlib/RingTheory/MvPowerSeries/LexOrder.lean
+++ b/Mathlib/RingTheory/MvPowerSeries/LexOrder.lean
@@ -119,32 +119,17 @@ theorem min_lexOrder_le {φ ψ : MvPowerSeries σ R} :
 theorem coeff_mul_of_add_lexOrder {φ ψ : MvPowerSeries σ R}
     {p q : σ →₀ ℕ} (hp : lexOrder φ = toLex p) (hq : lexOrder ψ = toLex q) :
     coeff R (p + q) (φ * ψ) = coeff R p φ * coeff R q ψ := by
-  rw [coeff_mul]
-  apply Finset.sum_eq_single (⟨p, q⟩ : (σ →₀ ℕ) × (σ →₀ ℕ))
-  · rintro ⟨u, v⟩ h h'
-    simp only [Finset.mem_antidiagonal] at h
-    simp only
-    by_cases hu : toLex u < toLex p
-    · rw [coeff_eq_zero_of_lt_lexOrder (R := R) (d := u), zero_mul]
-      simp only [hp, WithTop.coe_lt_coe, hu]
-    · rw [coeff_eq_zero_of_lt_lexOrder (d := v), mul_zero]
-      simp only [hq, WithTop.coe_lt_coe, ← not_le]
-      simp only [not_lt] at hu
-      intro hv
-      simp only [WithTop.coe_le_coe] at hv
-      apply h'
-      simp only [Prod.mk.injEq]
-      constructor
-      · apply toLex.injective
-        apply Or.resolve_right (eq_or_gt_of_le hu)
-        intro hu'
-        exact not_le.mpr (add_lt_add_of_lt_of_le hu' hv) (le_of_eq h)
-      · apply toLex.injective
-        apply Or.resolve_right (eq_or_gt_of_le hv)
-        intro hv'
-        exact not_le.mpr (add_lt_add_of_le_of_lt hu hv') (le_of_eq h)
-  · intro h
-    simp only [Finset.mem_antidiagonal, not_true_eq_false] at h
+  rw [coeff_mul, Finset.sum_eq_single_of_mem ⟨p, q⟩ (by simp)]
+  rintro ⟨u, v⟩ h h'
+  simp only [Finset.mem_antidiagonal] at h
+  rcases trichotomy_of_add_eq_add (congrArg toLex h) with h'' | h'' | h''
+  · exact False.elim (h' (by simp [Prod.ext_iff, h''.1, h''.2]))
+  · rw [coeff_eq_zero_of_lt_lexOrder (d := u), zero_mul]
+    rw [hp]
+    norm_cast
+  · rw [coeff_eq_zero_of_lt_lexOrder (d := v), mul_zero]
+    rw [hq]
+    norm_cast
 
 theorem le_lexOrder_mul (φ ψ : MvPowerSeries σ R) :
     lexOrder φ + lexOrder ψ ≤ lexOrder (φ * ψ) := by

--- a/Mathlib/RingTheory/MvPowerSeries/NoZeroDivisors.lean
+++ b/Mathlib/RingTheory/MvPowerSeries/NoZeroDivisors.lean
@@ -13,10 +13,11 @@ import Mathlib.RingTheory.MvPowerSeries.LexOrder
 a multivariate power series whose constant coefficient is not a zero divisor
 is itself not a zero divisor
 
-## TODO
+##  Instance
 
-* A subsequent PR https://github.com/leanprover-community/mathlib4/pull/14571 proves that if `R` has no zero divisors,
-then so does `MvPowerSeries σ R`.
+If `R` has `NoZeroDivisors`, then so does `MvPowerSeries σ R`.
+
+## TODO
 
 * Transfer/adapt these results to `HahnSeries`.
 


### PR DESCRIPTION


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
