### PR TITLE
[Merged by Bors] - chore: fix indentation of multi-line items in doc-strings

### DIFF
--- a/Archive/Imo/Imo1988Q6.lean
+++ b/Archive/Imo/Imo1988Q6.lean
@@ -38,7 +38,7 @@ under the following conditions:
 * `H_zero` : If an integral point `(x,0)` lies on the hyperbola `H`, then `claim` is true.
 * `H_diag` : If an integral point `(x,x)` lies on the hyperbola `H`, then `claim` is true.
 * `H_desc` : If `(x,y)` is an integral point on the hyperbola `H`,
-with `x < y` then there exists a “smaller” point on `H`: a point `(x',y')` with `x' < y' ≤ x`.
+  with `x < y` then there exists a “smaller” point on `H`: a point `(x',y')` with `x' < y' ≤ x`.
 
 For reasons of usability, the hyperbola `H` is implemented as an arbitrary predicate.
 (In question 6 of IMO1988, where this proof technique was first developed,

--- a/Cache/Hashing.lean
+++ b/Cache/Hashing.lean
@@ -89,6 +89,7 @@ Computes the root hash, which mixes the hashes of the content of:
 * `lakefile.lean`
 * `lean-toolchain`
 * `lake-manifest.json`
+
 and the hash of `Lean.githash`.
 
 (We hash `Lean.githash` in case the toolchain changes even though `lean-toolchain` hasn't.

--- a/Mathlib/Algebra/Category/Grp/Basic.lean
+++ b/Mathlib/Algebra/Category/Grp/Basic.lean
@@ -16,6 +16,7 @@ We introduce the bundled categories:
 * `AddGrp`
 * `CommGrp`
 * `AddCommGrp`
+
 along with the relevant forgetful functors between them, and to the bundled monoid categories.
 -/
 

--- a/Mathlib/Algebra/Category/ModuleCat/Sheaf/Free.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Sheaf/Free.lean
@@ -16,9 +16,9 @@ a type `I` to the coproduct of copies indexed by `I` of `unit R`.
 ## TODO
 
 * In case the category `C` has a terminal object `X`, promote `freeHomEquiv`
-into an adjunction between `freeFunctor` and the evaluation functor at `X`.
-(Alternatively, assuming specific universe parameters, we could show that
-`freeHomEquiv` is a left adjoint to `SheafOfModules.sectionsFunctor`.)
+  into an adjunction between `freeFunctor` and the evaluation functor at `X`.
+  (Alternatively, assuming specific universe parameters, we could show that
+  `freeHomEquiv` is a left adjoint to `SheafOfModules.sectionsFunctor`.)
 
 -/
 

--- a/Mathlib/Algebra/Category/MonCat/Basic.lean
+++ b/Mathlib/Algebra/Category/MonCat/Basic.lean
@@ -17,6 +17,7 @@ We introduce the bundled categories:
 * `AddMonCat`
 * `CommMonCat`
 * `AddCommMonCat`
+
 along with the relevant forgetful functors between them.
 -/
 

--- a/Mathlib/Algebra/Category/Ring/Basic.lean
+++ b/Mathlib/Algebra/Category/Ring/Basic.lean
@@ -16,6 +16,7 @@ We introduce the bundled categories:
 * `RingCat`
 * `CommSemiRingCat`
 * `CommRingCat`
+
 along with the relevant forgetful functors between them.
 -/
 

--- a/Mathlib/Algebra/Category/Semigrp/Basic.lean
+++ b/Mathlib/Algebra/Category/Semigrp/Basic.lean
@@ -16,6 +16,7 @@ We introduce the bundled categories:
 * `AddMagmaCat`
 * `Semigrp`
 * `AddSemigrp`
+
 along with the relevant forgetful functors between them.
 
 This closely follows `Mathlib.Algebra.Category.MonCat.Basic`.

--- a/Mathlib/Algebra/Colimit/Finiteness.lean
+++ b/Mathlib/Algebra/Colimit/Finiteness.lean
@@ -16,7 +16,7 @@ We show that every module is the direct limit of its finitely generated submodul
 * `Module.fgSystem`: the directed system of finitely generated submodules of a module.
 
 * `Module.fgSystem.equiv`: the isomorphism between a module and the direct limit of its
-finitely generated submodules.
+  finitely generated submodules.
 -/
 
 namespace Module

--- a/Mathlib/Algebra/Divisibility/Units.lean
+++ b/Mathlib/Algebra/Divisibility/Units.lean
@@ -13,7 +13,7 @@ import Mathlib.Algebra.Group.Units.Basic
 ## Main definition
 
 * `IsRelPrime x y`: that `x` and `y` are relatively prime, defined to mean that the only common
-divisors of `x` and `y` are the units.
+  divisors of `x` and `y` are the units.
 
 -/
 

--- a/Mathlib/Algebra/GCDMonoid/Basic.lean
+++ b/Mathlib/Algebra/GCDMonoid/Basic.lean
@@ -26,8 +26,8 @@ For the `NormalizedGCDMonoid` instances on `ℕ` and `ℤ`, see `Mathlib.Algebra
 ## Implementation Notes
 
 * `NormalizationMonoid` is defined by assigning to each element a `normUnit` such that multiplying
-by that unit normalizes the monoid, and `normalize` is an idempotent monoid homomorphism. This
-definition as currently implemented does casework on `0`.
+  by that unit normalizes the monoid, and `normalize` is an idempotent monoid homomorphism. This
+  definition as currently implemented does casework on `0`.
 
 * `GCDMonoid` contains the definitions of `gcd` and `lcm` with the usual properties. They are
   both determined up to a unit.

--- a/Mathlib/Algebra/Homology/DerivedCategory/SingleTriangle.lean
+++ b/Mathlib/Algebra/Homology/DerivedCategory/SingleTriangle.lean
@@ -14,8 +14,8 @@ the associated distinguished triangle in the derived category:
 
 ## TODO
 * when the canonical t-structure on the derived category is formalized, refactor
-this definition to make it a particular case of the triangle induced by a short
-exact sequence in the heart of a t-structure
+  this definition to make it a particular case of the triangle induced by a short
+  exact sequence in the heart of a t-structure
 
 -/
 

--- a/Mathlib/Algebra/Homology/Embedding/TruncGE.lean
+++ b/Mathlib/Algebra/Homology/Embedding/TruncGE.lean
@@ -35,7 +35,7 @@ We also construct the canonical epimorphism `K.πTruncGE e : K ⟶ K.truncGE e`.
 
 ## TODO
 * show that `K.πTruncGE e : K ⟶ K.truncGE e` induces an isomorphism
-in homology in degrees in the image of `e.f`.
+  in homology in degrees in the image of `e.f`.
 
 -/
 

--- a/Mathlib/Algebra/Homology/Factorizations/Basic.lean
+++ b/Mathlib/Algebra/Homology/Factorizations/Basic.lean
@@ -19,10 +19,10 @@ fibrations for a model category structure on the bounded below
 category of cochain complexes in `C`. In this folder, we intend to prove two factorization
 lemmas in the category of bounded below cochain complexes (TODO):
 * CM5a: any morphism `K ⟶ L` can be factored as `K ⟶ K' ⟶ L` where `i : K ⟶ K'` is a
-trivial cofibration (a mono that is also a quasi-isomorphisms) and `p : K' ⟶ L` is a fibration.
+  trivial cofibration (a mono that is also a quasi-isomorphisms) and `p : K' ⟶ L` is a fibration.
 * CM5b: any morphism `K ⟶ L` can be factored as `K ⟶ L' ⟶ L` where `i : K ⟶ L'` is a
-cofibration (i.e. a mono) and `p : L' ⟶ L` is a trivial fibration (i.e. a quasi-isomorphism
-which is also a fibration)
+  cofibration (i.e. a mono) and `p : L' ⟶ L` is a trivial fibration (i.e. a quasi-isomorphism
+  which is also a fibration)
 
 The difficult part is CM5a (whose proof uses CM5b). These lemmas shall be essential
 ingredients in the proof that the bounded below derived category of an abelian

--- a/Mathlib/Algebra/Homology/TotalComplexShift.lean
+++ b/Mathlib/Algebra/Homology/TotalComplexShift.lean
@@ -11,7 +11,7 @@ import Mathlib.Algebra.Homology.TotalComplex
 
 There are two ways to shift objects in `HomologicalComplex₂ C (up ℤ) (up ℤ)`:
 * by shifting the first indices (and changing signs of horizontal differentials),
-which corresponds to the shift by `ℤ` on `CochainComplex (CochainComplex C ℤ) ℤ`.
+  which corresponds to the shift by `ℤ` on `CochainComplex (CochainComplex C ℤ) ℤ`.
 * by shifting the second indices (and changing signs of vertical differentials).
 
 These two sorts of shift functors shall be abbreviated as

--- a/Mathlib/Algebra/Module/Presentation/Basic.lean
+++ b/Mathlib/Algebra/Module/Presentation/Basic.lean
@@ -32,8 +32,7 @@ generators and relations.
 
 ## TODO
 * Relate this to `Module.FinitePresentation`
-* Behaviour of presentations with respect to the extension of scalars and
-the restriction of scalars
+* Behaviour of presentations with respect to the extension of scalars and the restriction of scalars
 
 -/
 

--- a/Mathlib/Algebra/Module/Presentation/RestrictScalars.lean
+++ b/Mathlib/Algebra/Module/Presentation/RestrictScalars.lean
@@ -15,7 +15,7 @@ a presentation of `B` as a `A`-module (and some additional data).
 
 ## TODO
 * deduce that if `B` is a finitely presented as an `A`-module and `M` is
-finitely presented as an `B`-module, then `M` is finitely presented as an `A`-module
+  finitely presented as an `B`-module, then `M` is finitely presented as an `A`-module
 
 -/
 

--- a/Mathlib/Algebra/Module/ZLattice/Basic.lean
+++ b/Mathlib/Algebra/Module/ZLattice/Basic.lean
@@ -28,11 +28,11 @@ point of view are in the `ZLattice` namespace.
 ## Main results and definitions
 
 * `ZSpan.isAddFundamentalDomain`: for a ℤ-lattice `Submodule.span ℤ (Set.range b)`, proves that
-the set defined by `ZSpan.fundamentalDomain` is a fundamental domain.
+  the set defined by `ZSpan.fundamentalDomain` is a fundamental domain.
 * `ZLattice.module_free`: a `ℤ`-submodule of `E` that is discrete and spans `E` over `K` is a free
 `ℤ`-module
 * `ZLattice.rank`: a `ℤ`-submodule of `E` that is discrete and spans `E` over `K` is free
-of `ℤ`-rank equal to the `K`-rank of `E`
+  of `ℤ`-rank equal to the `K`-rank of `E`
 * `ZLattice.comap`: for `e : E → F` a linear map and `L : Submodule ℤ E`, define the pullback of
 `L` by `e`. If `L` is a `IsZLattice` and `e` is a continuous linear equiv, then it is also a
 `IsZLattice`, see `instIsZLatticeComap`.

--- a/Mathlib/Algebra/Order/Star/Basic.lean
+++ b/Mathlib/Algebra/Order/Star/Basic.lean
@@ -31,10 +31,10 @@ It is important to note that while a `StarOrderedRing` is an `OrderedAddCommMono
 ## TODO
 
 * In a Banach star algebra without a well-defined square root, the natural ordering is given by the
-positive cone which is the _closure_ of the sums of elements `star r * r`. A weaker version of
-`StarOrderedRing` could be defined for this case (again, see
-[*The positive cone in Banach algebras*][kelleyVaught1953]). Note that the current definition has
-the advantage of not requiring a topology.
+  positive cone which is the _closure_ of the sums of elements `star r * r`. A weaker version of
+  `StarOrderedRing` could be defined for this case (again, see
+  [*The positive cone in Banach algebras*][kelleyVaught1953]). Note that the current definition has
+  the advantage of not requiring a topology.
 -/
 
 open Set

--- a/Mathlib/Algebra/Polynomial/Lifts.lean
+++ b/Mathlib/Algebra/Polynomial/Lifts.lean
@@ -22,9 +22,9 @@ and that a monic polynomial that lifts can be lifted to a monic polynomial (of t
 ## Main results
 
 * `lifts_and_degree_eq` : A polynomial lifts if and only if it can be lifted to a polynomial
-of the same degree.
+  of the same degree.
 * `lifts_and_degree_eq_and_monic` : A monic polynomial lifts if and only if it can be lifted to a
-monic polynomial of the same degree.
+  monic polynomial of the same degree.
 * `lifts_iff_alg` : if `R` is commutative, a polynomial lifts if and only if it is in the image of
 `mapAlg`, where `mapAlg : R[X] →ₐ[R] S[X]` is the only `R`-algebra map
 that sends `X` to `X`.

--- a/Mathlib/Algebra/Ring/Submonoid/Pointwise.lean
+++ b/Mathlib/Algebra/Ring/Submonoid/Pointwise.lean
@@ -26,6 +26,7 @@ Additionally, it provides various degrees of monoid structure:
 * `AddSubmonoid.mulOneClass`
 * `AddSubmonoid.semigroup`
 * `AddSubmonoid.monoid`
+
 which is available globally to match the monoid structure implied by `Submodule.idemSemiring`.
 
 ## Implementation notes

--- a/Mathlib/AlgebraicGeometry/Modules/Tilde.lean
+++ b/Mathlib/AlgebraicGeometry/Modules/Tilde.lean
@@ -23,7 +23,7 @@ such that `M^~(U)` is the set of dependent functions that are locally fractions.
 * `ModuleCat.tildeInType` : `M^~` as a sheaf of types groups.
 * `ModuleCat.tilde` : `M^~` as a sheaf of `𝒪_{Spec R}`-modules.
 * `ModuleCat.tilde.stalkIso`: The isomorphism of `R`-modules from the stalk of `M^~` at `x` to
-the localization of `M` at the prime ideal corresponding to `x`.
+  the localization of `M` at the prime ideal corresponding to `x`.
 
 ## Technical note
 

--- a/Mathlib/AlgebraicGeometry/Sites/BigZariski.lean
+++ b/Mathlib/AlgebraicGeometry/Sites/BigZariski.lean
@@ -15,14 +15,14 @@ the Zariski topology on `Over X` can be obtained as `Scheme.zariskiTopology.over
 
 TODO:
 * If `Y : Scheme.{u}`, define a continuous functor from the category of opens of `Y`
-to `Over Y`, and show that a presheaf on `Over Y` is a sheaf for the Zariski topology
-iff its "restriction" to the topological space `Z` is a sheaf for all `Z : Over Y`.
+  to `Over Y`, and show that a presheaf on `Over Y` is a sheaf for the Zariski topology
+  iff its "restriction" to the topological space `Z` is a sheaf for all `Z : Over Y`.
 * We should have good notions of (pre)sheaves of `Type (u + 1)` (e.g. associated
-sheaf functor, pushforward, pullbacks) on `Scheme.{u}` for this topology. However,
-some constructions in the `CategoryTheory.Sites` folder currently assume that
-the site is a small category: this should be generalized. As a result,
-this big Zariski site can considered as a test case of the Grothendieck topology API
-for future applications to étale cohomology.
+  sheaf functor, pushforward, pullbacks) on `Scheme.{u}` for this topology. However,
+  some constructions in the `CategoryTheory.Sites` folder currently assume that
+  the site is a small category: this should be generalized. As a result,
+  this big Zariski site can considered as a test case of the Grothendieck topology API
+  for future applications to étale cohomology.
 
 -/
 

--- a/Mathlib/AlgebraicTopology/SimplicialCategory/Basic.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialCategory/Basic.lean
@@ -16,15 +16,15 @@ category of simplicial sets in such a way that morphisms in
 ## TODO
 
 * construct a simplicial category structure on simplicial objects, so
-that it applies in particular to simplicial sets
+  that it applies in particular to simplicial sets
 * obtain the adjunction property `(K ⊗ X ⟶ Y) ≃ (K ⟶ sHom X Y)` when `K`, `X`, and `Y`
-are simplicial sets
+  are simplicial sets
 * develop the notion of "simplicial tensor" `K ⊗ₛ X : C` with `K : SSet` and `X : C`
-an object in a simplicial category `C`
+  an object in a simplicial category `C`
 * define the notion of path between `0`-simplices of simplicial sets
 * deduce the notion of homotopy between morphisms in a simplicial category
 * obtain that homotopies in simplicial categories can be interpreted as given
-by morphisms `Δ[1] ⊗ X ⟶ Y`.
+  by morphisms `Δ[1] ⊗ X ⟶ Y`.
 
 ## References
 * [Daniel G. Quillen, *Homotopical algebra*, II §1][quillen-1967]

--- a/Mathlib/AlgebraicTopology/SimplicialSet/Degenerate.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/Degenerate.lean
@@ -13,9 +13,9 @@ and `X.nonDegenerate n` of degenerate or non-degenerate simplices of dimension `
 
 ## TODO (@joelriou)
 
-* `SSet.exists_nonDegenerate` shows that any `n`-simplex can be written
-as `X.map f.op y` for some epimorphism `f : ⦋n⦌ ⟶ ⦋m⦌` and some
-non-degenerate simplex `y`. Show that `f` and `y` are unique.
+* `SSet.exists_nonDegenerate` shows that any `n`-simplex can be written as `X.map f.op y`
+  for some epimorphism `f : ⦋n⦌ ⟶ ⦋m⦌` and some non-degenerate simplex `y`.
+  Show that `f` and `y` are unique.
 
 -/
 

--- a/Mathlib/Analysis/BoxIntegral/UnitPartition.lean
+++ b/Mathlib/Analysis/BoxIntegral/UnitPartition.lean
@@ -25,7 +25,7 @@ is its vertices are in `ι → ℤ`, then the corresponding prepartition is actu
 ## Main definitions and results
 
 * `BoxIntegral.hasIntegralVertices`: a `Prop` that states that the vertices of the box have
-coordinates in `ℤ`
+  coordinates in `ℤ`
 
 * `BoxIntegral.unitPartition.box`: a `BoxIntegral`, indexed by `ν : ι → ℤ`, with vertices
 `ν i / n` and of side length `1 / n`.
@@ -34,21 +34,21 @@ coordinates in `ℤ`
 `unitPartition.box` that are subsets of `B`. This is a finite set.
 
 * `BoxIntegral.unitPartition.prepartition_isPartition`: For `B : BoxIntegral.Box`, if `B`
-has integral vertices, then the prepartition of `unitPartition.box` admissible for `B` is a
-partition of `B`.
+  has integral vertices, then the prepartition of `unitPartition.box` admissible for `B` is a
+  partition of `B`.
 
 * `tendsto_tsum_div_pow_atTop_integral`: let `s` be a bounded, measurable set of `ι → ℝ`
-whose frontier has zero volume and let `F` be a continuous function. Then the limit as `n → ∞`
-of `∑ F x / n ^ card ι`, where the sum is over the points in `s ∩ n⁻¹ • (ι → ℤ)`, tends to the
-integral of `F` over `s`.
+  whose frontier has zero volume and let `F` be a continuous function. Then the limit as `n → ∞`
+  of `∑ F x / n ^ card ι`, where the sum is over the points in `s ∩ n⁻¹ • (ι → ℤ)`, tends to the
+  integral of `F` over `s`.
 
 * `tendsto_card_div_pow_atTop_volume`: let `s` be a bounded, measurable set of `ι → ℝ` whose
-frontier has zero volume. Then the limit as `n → ∞` of `card (s ∩ n⁻¹ • (ι → ℤ)) / n ^ card ι`
-tends to the volume of `s`.
+  frontier has zero volume. Then the limit as `n → ∞` of `card (s ∩ n⁻¹ • (ι → ℤ)) / n ^ card ι`
+  tends to the volume of `s`.
 
 * `tendsto_card_div_pow_atTop_volume'`: a version of `tendsto_card_div_pow_atTop_volume` where we
-assume in addition that `x • s ⊆ y • s` whenever `0 < x ≤ y`. Then we get the same limit
-`card (s ∩ x⁻¹ • (ι → ℤ)) / x ^ card ι → volume s` but the limit is over a real variable `x`.
+  assume in addition that `x • s ⊆ y • s` whenever `0 < x ≤ y`. Then we get the same limit
+  `card (s ∩ x⁻¹ • (ι → ℤ)) / x ^ card ι → volume s` but the limit is over a real variable `x`.
 
 -/
 

--- a/Mathlib/Analysis/Seminorm.lean
+++ b/Mathlib/Analysis/Seminorm.lean
@@ -469,19 +469,19 @@ section Classical
 open Classical in
 /-- We define the supremum of an arbitrary subset of `Seminorm 𝕜 E` as follows:
 * if `s` is `BddAbove` *as a set of functions `E → ℝ`* (that is, if `s` is pointwise bounded
-above), we take the pointwise supremum of all elements of `s`, and we prove that it is indeed a
-seminorm.
+  above), we take the pointwise supremum of all elements of `s`, and we prove that it is indeed a
+  seminorm.
 * otherwise, we take the zero seminorm `⊥`.
 
 There are two things worth mentioning here:
 * First, it is not trivial at first that `s` being bounded above *by a function* implies
-being bounded above *as a seminorm*. We show this in `Seminorm.bddAbove_iff` by using
-that the `Sup s` as defined here is then a bounding seminorm for `s`. So it is important to make
-the case disjunction on `BddAbove ((↑) '' s : Set (E → ℝ))` and not `BddAbove s`.
+  being bounded above *as a seminorm*. We show this in `Seminorm.bddAbove_iff` by using
+  that the `Sup s` as defined here is then a bounding seminorm for `s`. So it is important to make
+  the case disjunction on `BddAbove ((↑) '' s : Set (E → ℝ))` and not `BddAbove s`.
 * Since the pointwise `Sup` already gives `0` at points where a family of functions is
-not bounded above, one could hope that just using the pointwise `Sup` would work here, without the
-need for an additional case disjunction. As discussed on Zulip, this doesn't work because this can
-give a function which does *not* satisfy the seminorm axioms (typically sub-additivity).
+  not bounded above, one could hope that just using the pointwise `Sup` would work here, without the
+  need for an additional case disjunction. As discussed on Zulip, this doesn't work because this can
+  give a function which does *not* satisfy the seminorm axioms (typically sub-additivity).
 -/
 noncomputable instance instSupSet : SupSet (Seminorm 𝕜 E) where
   sSup s :=

--- a/Mathlib/CategoryTheory/Abelian/Exact.lean
+++ b/Mathlib/CategoryTheory/Abelian/Exact.lean
@@ -27,7 +27,7 @@ true in more general settings.
 * `X ⟶ Y ⟶ Z ⟶ 0` is exact if and only if the second map is a cokernel of the first, and
   `0 ⟶ X ⟶ Y ⟶ Z` is exact if and only if the first map is a kernel of the second.
 * A functor `F` such that for all `S`, we have `S.Exact → (S.map F).Exact` preserves both
-finite limits and colimits.
+  finite limits and colimits.
 
 -/
 

--- a/Mathlib/CategoryTheory/Abelian/FreydMitchell.lean
+++ b/Mathlib/CategoryTheory/Abelian/FreydMitchell.lean
@@ -43,8 +43,8 @@ We put this all together in the file
 To prove (2), there are multiple options.
 
 * Some sources (for example Freyd's "Abelian Categories") choose `D := LeftExactFunctor C Ab`. The
-  main difficulty with this approach is that it is not obvious that `D` is abelian. This approach has
-  a very algebraic flavor and requires a relatively large armount of ad-hoc reasoning.
+  main difficulty with this approach is that it is not obvious that `D` is abelian. This approach
+  has a very algebraic flavor and requires a relatively large armount of ad-hoc reasoning.
 * In the Stacks project, it is suggested to choose `D := Sheaf J Ab` for a suitable Grothendieck
   topology on `Cᵒᵖ` and there are reasons to believe that this `D` is in fact equivalent to
   `LeftExactFunctor C Ab`. This approach translates many of the interesting properties along the

--- a/Mathlib/CategoryTheory/Abelian/FreydMitchell.lean
+++ b/Mathlib/CategoryTheory/Abelian/FreydMitchell.lean
@@ -43,16 +43,16 @@ We put this all together in the file
 To prove (2), there are multiple options.
 
 * Some sources (for example Freyd's "Abelian Categories") choose `D := LeftExactFunctor C Ab`. The
-main difficulty with this approach is that it is not obvious that `D` is abelian. This approach has
-a very algebraic flavor and requires a relatively large armount of ad-hoc reasoning.
+  main difficulty with this approach is that it is not obvious that `D` is abelian. This approach has
+  a very algebraic flavor and requires a relatively large armount of ad-hoc reasoning.
 * In the Stacks project, it is suggested to choose `D := Sheaf J Ab` for a suitable Grothendieck
-topology on `Cᵒᵖ` and there are reasons to believe that this `D` is in fact equivalent to
-`LeftExactFunctor C Ab`. This approach translates many of the interesting properties along the
-sheafification adjunction from a category of `Ab`-valued presheaves, which in turn inherits many
-interesting properties from the category of abelian groups.
+  topology on `Cᵒᵖ` and there are reasons to believe that this `D` is in fact equivalent to
+  `LeftExactFunctor C Ab`. This approach translates many of the interesting properties along the
+  sheafification adjunction from a category of `Ab`-valued presheaves, which in turn inherits many
+  interesting properties from the category of abelian groups.
 * Kashiwara and Schapira choose `D := Ind Cᵒᵖ`, which can be shown to be equivalent to
-`LeftExactFunctor C Ab` (see the file `Mathlib.CategoryTheory.Preadditive.Indization`).
-This approach deduces most interesting properties from the category of types.
+  `LeftExactFunctor C Ab` (see the file `Mathlib.CategoryTheory.Preadditive.Indization`).
+  This approach deduces most interesting properties from the category of types.
 
 When work on this theorem commenced in early 2022, all three approaches were quite out of reach.
 By the time the theorem was proved in early 2025, both the `Sheaf` approach and the `Ind` approach

--- a/Mathlib/CategoryTheory/Abelian/GrothendieckCategory/EnoughInjectives.lean
+++ b/Mathlib/CategoryTheory/Abelian/GrothendieckCategory/EnoughInjectives.lean
@@ -48,12 +48,10 @@ the ordered set of subobjects `A'` of `B` containing `A` equipped
 with a lifting `A' ⟶ X` is introduced. The existence of a lifting `B ⟶ X`
 is usually obtained by applying Zorn's lemma in this situation.
 Here, we split the argument into two separate facts:
-* any monomorphism `A ⟶ B` is a transfinite composition of
-pushouts of monomorphisms in `generatingMonomorphisms G`
-(see `generatingMonomorphisms.exists_transfiniteCompositionOfShape`);
-* the class of morphisms that have the left lifting property with
-respect to `p` is stable under transfinite composition
-(see the file `SmallObject.TransfiniteCompositionLifting`).
+* any monomorphism `A ⟶ B` is a transfinite composition of pushouts of monomorphisms in
+  `generatingMonomorphisms G` (see `generatingMonomorphisms.exists_transfiniteCompositionOfShape`);
+* the class of morphisms that have the left lifting property with respect to `p` is stable under
+  transfinite composition (see the file `SmallObject.TransfiniteCompositionLifting`).
 
 ## References
 

--- a/Mathlib/CategoryTheory/Abelian/LeftDerived.lean
+++ b/Mathlib/CategoryTheory/Abelian/LeftDerived.lean
@@ -38,11 +38,11 @@ and show how to compute the components.
 ## TODO
 
 * refactor `Functor.leftDerived` (and `Functor.rightDerived`) when the necessary
-material enters mathlib: derived categories, injective/projective derivability
-structures, existence of derived functors from derivability structures.
-Eventually, we shall get a right derived functor
-`F.leftDerivedFunctorMinus : DerivedCategory.Minus C ⥤ DerivedCategory.Minus D`,
-and `F.leftDerived` shall be redefined using `F.leftDerivedFunctorMinus`.
+  material enters mathlib: derived categories, injective/projective derivability
+  structures, existence of derived functors from derivability structures.
+  Eventually, we shall get a right derived functor
+  `F.leftDerivedFunctorMinus : DerivedCategory.Minus C ⥤ DerivedCategory.Minus D`,
+  and `F.leftDerived` shall be redefined using `F.leftDerivedFunctorMinus`.
 
 -/
 

--- a/Mathlib/CategoryTheory/Abelian/Refinements.lean
+++ b/Mathlib/CategoryTheory/Abelian/Refinements.lean
@@ -63,8 +63,8 @@ these morphisms and sometimes introducing an auxiliary epimorphism `A' ⟶ A`.
 
 ## References
 * George Bergman, A note on abelian categories – translating element-chasing proofs,
-and exact embedding in abelian groups (1974)
-http://math.berkeley.edu/~gbergman/papers/unpub/elem-chase.pdf
+  and exact embedding in abelian groups (1974)
+  http://math.berkeley.edu/~gbergman/papers/unpub/elem-chase.pdf
 
 -/
 

--- a/Mathlib/CategoryTheory/Abelian/RightDerived.lean
+++ b/Mathlib/CategoryTheory/Abelian/RightDerived.lean
@@ -38,11 +38,11 @@ and show how to compute the components.
 ## TODO
 
 * refactor `Functor.rightDerived` (and `Functor.leftDerived`) when the necessary
-material enters mathlib: derived categories, injective/projective derivability
-structures, existence of derived functors from derivability structures.
-Eventually, we shall get a right derived functor
-`F.rightDerivedFunctorPlus : DerivedCategory.Plus C ⥤ DerivedCategory.Plus D`,
-and `F.rightDerived` shall be redefined using `F.rightDerivedFunctorPlus`.
+  material enters mathlib: derived categories, injective/projective derivability
+  structures, existence of derived functors from derivability structures.
+  Eventually, we shall get a right derived functor
+  `F.rightDerivedFunctorPlus : DerivedCategory.Plus C ⥤ DerivedCategory.Plus D`,
+  and `F.rightDerived` shall be redefined using `F.rightDerivedFunctorPlus`.
 
 -/
 

--- a/Mathlib/CategoryTheory/Adjunction/Additive.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Additive.lean
@@ -12,9 +12,9 @@ This provides some results and constructions for adjunctions between functors on
 preadditive categories:
 * If one of the adjoint functors is additive, so is the other.
 * If one of the adjoint functors is additive, the equivalence `Adjunction.homEquiv` lifts to
-an additive equivalence `Adjunction.homAddEquiv`.
+  an additive equivalence `Adjunction.homAddEquiv`.
 * We also give a version of this additive equivalence as an isomorphism of `preadditiveYoneda`
-functors (analogous to `Adjunction.compYonedaIso`), in `Adjunction.compPreadditiveYonedaIso`.
+  functors (analogous to `Adjunction.compYonedaIso`), in `Adjunction.compPreadditiveYonedaIso`.
 
 -/
 

--- a/Mathlib/CategoryTheory/Bicategory/NaturalTransformation/Strong.lean
+++ b/Mathlib/CategoryTheory/Bicategory/NaturalTransformation/Strong.lean
@@ -56,7 +56,7 @@ More precisely, it consists of the following:
 * a 2-isomorphism `η.naturality f : F.map f ≫ app b ⟶ app a ≫ G.map f` for each 1-morphism
 `f : a ⟶ b`.
 * These 2-isomorphisms satisfy the naturality condition, and preserve the identities and the
-compositions modulo some adjustments of domains and codomains of 2-morphisms.
+  compositions modulo some adjustments of domains and codomains of 2-morphisms.
 -/
 structure StrongOplaxNatTrans (F G : OplaxFunctor B C) where
   app (a : B) : F.obj a ⟶ G.obj a

--- a/Mathlib/CategoryTheory/ComposableArrows.lean
+++ b/Mathlib/CategoryTheory/ComposableArrows.lean
@@ -33,10 +33,10 @@ like `mk₁ f`, `mk₂ f g`, `mk₃ f g h` for `ComposableArrows C n` for small 
 TODO (@joelriou):
 * redefine `Arrow C` as `ComposableArrow C 1`?
 * construct some elements in `ComposableArrows m (Fin (n + 1))` for small `n`
-the precomposition with which shall induce functors
-`ComposableArrows C n ⥤ ComposableArrows C m` which correspond to simplicial operations
-(specifically faces) with good definitional properties (this might be necessary for
-up to `n = 7` in order to formalize spectral sequences following Verdier)
+  the precomposition with which shall induce functors
+  `ComposableArrows C n ⥤ ComposableArrows C m` which correspond to simplicial operations
+  (specifically faces) with good definitional properties (this might be necessary for
+  up to `n = 7` in order to formalize spectral sequences following Verdier)
 
 -/
 

--- a/Mathlib/CategoryTheory/Limits/Shapes/Pullback/HasPullback.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Pullback/HasPullback.lean
@@ -33,7 +33,7 @@ pullback.snd f g                       g
 * `HasPushout f g`: this is an abbreviation for `HasColimit (span f g)`, and is a typeclass used to
   express the fact that a given pair of morphisms has a pushout.
 * `HasPushouts`: expresses the fact that `C` admits all pushouts, it is implemented as an
-abbreviation for `HasColimitsOfShape WalkingSpan C`
+  abbreviation for `HasColimitsOfShape WalkingSpan C`
 * `pushout f g`: Given a `HasPushout f g` instance, this function returns the choice of a colimit
   object corresponding to the pushout of `f` and `g`. It fits into the following diagram:
 ```

--- a/Mathlib/CategoryTheory/Limits/Shapes/Pullback/Mono.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Pullback/Mono.lean
@@ -18,7 +18,7 @@ the dual statements between pushouts and epimorphisms.
 API as `pullback.fst_of_mono` and `pullback.snd_of_mono`.
 
 * A pullback cone is a limit iff its composition with a monomorphism is a limit. This is available
-as `IsLimitOfCompMono` and `pullbackIsPullbackOfCompMono` respectively.
+  as `IsLimitOfCompMono` and `pullbackIsPullbackOfCompMono` respectively.
 
 * Monomorphisms admit kernel pairs, this is `has_kernel_pair_of_mono`.
 

--- a/Mathlib/CategoryTheory/Limits/Shapes/RegularMono.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/RegularMono.lean
@@ -16,6 +16,7 @@ A regular monomorphism is a morphism that is the equalizer of some parallel pair
 We give the constructions
 * `IsSplitMono → RegularMono` and
 * `RegularMono → Mono`
+
 as well as the dual constructions for regular epimorphisms. Additionally, we give the construction
 * `RegularEpi ⟶ StrongEpi`.
 

--- a/Mathlib/CategoryTheory/Localization/DerivabilityStructure/Basic.lean
+++ b/Mathlib/CategoryTheory/Localization/DerivabilityStructure/Basic.lean
@@ -41,13 +41,13 @@ not depend of the choice of the localization functors.
 * Construct derived functors using derivability structures
 * Define the notion of left derivability structures
 * Construct the injective derivability structure in order to derive functor from
-the bounded below homotopy category in an abelian category with enough injectives
+  the bounded below homotopy category in an abelian category with enough injectives
 * Construct the projective derivability structure in order to derive functor from
-the bounded above homotopy category in an abelian category with enough projectives
+  the bounded above homotopy category in an abelian category with enough projectives
 * Construct the flat derivability structure on the bounded above homotopy category
-of categories of modules (and categories of sheaves of modules)
+  of categories of modules (and categories of sheaves of modules)
 * Define the product derivability structure and formalize derived functors of
-functors in several variables
+  functors in several variables
 
 
 ## References

--- a/Mathlib/CategoryTheory/MorphismProperty/Representable.lean
+++ b/Mathlib/CategoryTheory/MorphismProperty/Representable.lean
@@ -55,7 +55,7 @@ Given `hf : relativelyRepresentable f`, with `f : X ⟶ Y` and `g : F.obj a ⟶ 
 * `hf.snd g` is the morphism `hf.pullback g ⟶ F.obj a`
 * `hf.fst g` is the morphism `F.obj (hf.pullback g) ⟶ X`
 *  If `F` is full, and `f` is of type `F.obj c ⟶ G`, we also have `hf.fst' g : hf.pullback g ⟶ X`
-which is the preimage under `F` of `hf.fst g`.
+  which is the preimage under `F` of `hf.fst g`.
 * `hom_ext`, `hom_ext'`, `lift`, `lift'` are variants of the universal property of
   `F.obj (hf.pullback g)`, where as much as possible has been formulated internally to `C`.
   For these theorems we also need that `F` is full and/or faithful.

--- a/Mathlib/CategoryTheory/Sites/Grothendieck.lean
+++ b/Mathlib/CategoryTheory/Sites/Grothendieck.lean
@@ -20,6 +20,7 @@ Alternate versions of the axioms (in arrow form) are also described.
 Two explicit examples of Grothendieck topologies are given:
 * The dense topology
 * The atomic topology
+
 as well as the complete lattice structure on Grothendieck topologies (which gives two additional
 explicit topologies: the discrete and trivial topologies.)
 

--- a/Mathlib/CategoryTheory/Subobject/Basic.lean
+++ b/Mathlib/CategoryTheory/Subobject/Basic.lean
@@ -27,6 +27,7 @@ We provide
 * `def pullback [HasPullbacks C] (f : X ⟶ Y) : Subobject Y ⥤ Subobject X`
 * `def map (f : X ⟶ Y) [Mono f] : Subobject X ⥤ Subobject Y`
 * `def «exists_» [HasImages C] (f : X ⟶ Y) : Subobject X ⥤ Subobject Y`
+
 and prove their basic properties and relationships.
 These are all easy consequences of the earlier development
 of the corresponding functors for `MonoOver`.

--- a/Mathlib/CategoryTheory/Subobject/MonoOver.lean
+++ b/Mathlib/CategoryTheory/Subobject/MonoOver.lean
@@ -25,6 +25,7 @@ We provide
 * `def pullback [HasPullbacks C] (f : X ⟶ Y) : MonoOver Y ⥤ MonoOver X`
 * `def map (f : X ⟶ Y) [Mono f] : MonoOver X ⥤ MonoOver Y`
 * `def «exists» [HasImages C] (f : X ⟶ Y) : MonoOver X ⥤ MonoOver Y`
+
 and prove their basic properties and relationships.
 
 ## Notes

--- a/docs/Conv/Guide.lean
+++ b/docs/Conv/Guide.lean
@@ -195,7 +195,7 @@ in Lean 4 core.
 * `whnf` reduces the expression to weak-head normal form.
 
 * `zeta` applies zeta reduction to the expression (i.e., substitutes all `let` expressions
-and expands all local variables).
+  and expands all local variables).
 
 * `reduce` reduces the expression like the `#reduce` command.
   (Documentation says "for debugging purposes only.")


### PR DESCRIPTION
Markdown syntax requires that subsequent lines of multi-line items in a list should be indented: for example, one should write
```
* show that `K.πTruncGE e : K ⟶ K.truncGE e` induces an isomorphism
  in homology in degrees in the image of `e.f`.
```
instead of
```
* show that `K.πTruncGE e : K ⟶ K.truncGE e` induces an isomorphism
in homology in degrees in the image of `e.f`.
```

If the bullet point contains several paragraphs, this leads to actual mis-renderings, such as [this one](https://leanprover-community.github.io/mathlib4_docs/Mathlib/CategoryTheory/Limits/Preserves/FunctorCategory.html): "The idea of the proof" should be part of the bullet point, but isn't. [Here](https://leanprover-community.github.io/mathlib4_docs/Mathlib/CategoryTheory/NatIso.html) is another example.

[Zulip discussion](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Style.20.3Abicycle.3A.20.3A.20indenting.20second.20lines.20in.20doc-strings/near/500682936)

This fixes about 100 doc-strings violating this. There are several hundred further doc-strings with the same issue.

This indicates that a linter catching this issue may be worthwhile. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
