### PR TITLE
[Merged by Bors] - feat: add {Alg,Linear}Equiv.{prodUnique,uniqueProd}

### DIFF
--- a/Mathlib/Algebra/Algebra/Prod.lean
+++ b/Mathlib/Algebra/Algebra/Prod.lean
@@ -3,6 +3,7 @@ Copyright (c) 2018 Kenny Lau. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kenny Lau, Yury Kudryashov
 -/
+import Mathlib.Algebra.Algebra.Equiv
 import Mathlib.Algebra.Algebra.Hom
 import Mathlib.Algebra.Module.Prod
 
@@ -17,6 +18,7 @@ The R-algebra structure on `(i : I) → A i` when each `A i` is an R-algebra.
 * `AlgHom.fst`
 * `AlgHom.snd`
 * `AlgHom.prod`
+* `AlgEquiv.prodUnique` and `AlgEquiv.uniqueProd`
 -/
 
 
@@ -111,3 +113,26 @@ def prodMap {D : Type*} [Semiring D] [Algebra R D] (f : A →ₐ[R] B) (g : C �
     commutes' := fun r => by simp [commutes] }
 
 end AlgHom
+
+namespace AlgEquiv
+
+/-- Multiplying by the trivial algebra from the right does not change the structure.
+This is the `AlgEquiv` version of `LinearEquiv.prodUnique` and `RingEquiv.prodZeroRing.symm`. -/
+@[simps!]
+def prodUnique [Unique B] : (A × B) ≃ₐ[R] A where
+  toFun := Prod.fst
+  invFun x := (x, 0)
+  __ := (RingEquiv.prodZeroRing A B).symm
+  commutes' _ := rfl
+
+/-- Multiplying by the trivial algebra from the left does not change the structure.
+This is the `AlgEquiv` version of `LinearEquiv.uniqueProd` and `RingEquiv.zeroRingProd.symm`.
+-/
+@[simps!]
+def uniqueProd [Unique B] : (B × A) ≃ₐ[R] A where
+  toFun := Prod.snd
+  invFun x := (0, x)
+  __ := (RingEquiv.zeroRingProd A B).symm
+  commutes' _ := rfl
+
+end AlgEquiv

--- a/Mathlib/Algebra/Group/Prod.lean
+++ b/Mathlib/Algebra/Group/Prod.lean
@@ -547,13 +547,21 @@ def prodCongr (f : M ≃* M') (g : N ≃* N') : M × N ≃* M' × N' :=
   { f.toEquiv.prodCongr g.toEquiv with
     map_mul' := fun _ _ => Prod.ext (map_mul f _ _) (map_mul g _ _) }
 
-/-- Multiplying by the trivial monoid doesn't change the structure. -/
-@[to_additive uniqueProd "Multiplying by the trivial monoid doesn't change the structure."]
+/-- Multiplying by the trivial monoid doesn't change the structure.
+
+This is the `MulEquiv` version of `Equiv.uniqueProd`. -/
+@[to_additive uniqueProd "Multiplying by the trivial monoid doesn't change the structure.
+
+This is the `AddEquiv` version of `Equiv.uniqueProd`."]
 def uniqueProd [Unique N] : N × M ≃* M :=
   { Equiv.uniqueProd M N with map_mul' := fun _ _ => rfl }
 
-/-- Multiplying by the trivial monoid doesn't change the structure. -/
-@[to_additive prodUnique "Multiplying by the trivial monoid doesn't change the structure."]
+/-- Multiplying by the trivial monoid doesn't change the structure.
+
+This is the `MulEquiv` version of `Equiv.prodUnique`. -/
+@[to_additive prodUnique "Multiplying by the trivial monoid doesn't change the structure.
+
+This is the `AddEquiv` version of `Equiv.prodUnique`."]
 def prodUnique [Unique N] : M × N ≃* M :=
   { Equiv.prodUnique M N with map_mul' := fun _ _ => rfl }
 

--- a/Mathlib/LinearAlgebra/Prod.lean
+++ b/Mathlib/LinearAlgebra/Prod.lean
@@ -29,6 +29,9 @@ It contains theorems relating these to each other, as well as to `Submodule.prod
   - `LinearMap.prodMap`
   - `LinearEquiv.prodMap`
   - `LinearEquiv.skewProd`
+- product with one trivial factor:
+  - `LinearEquiv.prodUnique`
+  - `LinearEquiv.uniqueProd`
 -/
 
 
@@ -753,6 +756,26 @@ theorem skewProd_symm_apply (f : M →ₗ[R] M₄) (x) :
   rfl
 
 end
+
+section Unique
+
+variable [Semiring R]
+variable [AddCommMonoid M] [AddCommMonoid M₂]
+variable [Module R M] [Module R M₂]
+
+/-- Multiplying by the trivial module from the left does not change the structure.
+This is the `LinearEquiv` version of `AddEquiv.uniqueProd`. -/
+@[simps!]
+def uniqueProd [Unique M₂] : (M₂ × M) ≃ₗ[R] M :=
+  AddEquiv.uniqueProd.toLinearEquiv (by simp [AddEquiv.uniqueProd])
+
+/-- Multiplying by the trivial module from the right does not change the structure.
+This is the `LinearEquiv` version of `AddEquiv.prodUnique`. -/
+@[simps!]
+def prodUnique [Unique M₂] : (M × M₂) ≃ₗ[R] M :=
+  AddEquiv.prodUnique.toLinearEquiv (by simp [AddEquiv.prodUnique])
+
+end Unique
 
 end LinearEquiv
 

--- a/Mathlib/LinearAlgebra/Prod.lean
+++ b/Mathlib/LinearAlgebra/Prod.lean
@@ -29,7 +29,7 @@ It contains theorems relating these to each other, as well as to `Submodule.prod
   - `LinearMap.prodMap`
   - `LinearEquiv.prodMap`
   - `LinearEquiv.skewProd`
-- product with one trivial factor:
+- product with the trivial module:
   - `LinearEquiv.prodUnique`
   - `LinearEquiv.uniqueProd`
 -/

--- a/Mathlib/Logic/Equiv/Defs.lean
+++ b/Mathlib/Logic/Equiv/Defs.lean
@@ -391,6 +391,7 @@ def equivEmptyEquiv (α : Sort u) : α ≃ Empty ≃ IsEmpty α :=
 def propEquivPEmpty {p : Prop} (h : ¬p) : p ≃ PEmpty := @equivPEmpty p <| IsEmpty.prop_iff.2 h
 
 /-- If both `α` and `β` have a unique element, then `α ≃ β`. -/
+@[simps]
 def ofUnique (α β : Sort _) [Unique.{u} α] [Unique.{v} β] : α ≃ β where
   toFun := default
   invFun := default
@@ -400,6 +401,7 @@ def ofUnique (α β : Sort _) [Unique.{u} α] [Unique.{v} β] : α ≃ β where
 @[deprecated (since := "2024-12-26")] alias equivOfUnique := ofUnique
 
 /-- If `α` has a unique element, then it is equivalent to any `PUnit`. -/
+@[simps!]
 def equivPUnit (α : Sort u) [Unique α] : α ≃ PUnit.{v} := ofUnique α _
 
 /-- The `Sort` of proofs of a true proposition is equivalent to `PUnit`. -/


### PR DESCRIPTION
Adds definitions of linear equivalences for modules M with their left-/right-product with a trivial module M \times 0 and 0 \times M, and analogous statements for Algebras.

Rebased version of #9105.
Co-authored-by: @LukasMias

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
