### PR TITLE
[Merged by Bors] - feat: sort eigenvalues in Analysis.InnerProductSpace.Spectrum

### DIFF
--- a/Mathlib/Analysis/InnerProductSpace/Spectrum.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Spectrum.lean
@@ -233,10 +233,9 @@ noncomputable irreducible_def eigenvalues: Fin n → ℝ :=
 finite-dimensional inner product space `E`.  Eigenvectors are sorted in increasing
 order of their eigenvalues. -/
 noncomputable irreducible_def eigenvectorBasis : OrthonormalBasis (Fin n) 𝕜 E :=
-  let perm := Tuple.sort (hT.unsortedEigenvalues hn) * @Fin.revPerm n
   (hT.direct_sum_isInternal.subordinateOrthonormalBasis
     hn hT.orthogonalFamily_eigenspaces').reindex
-      perm.symm
+      (Tuple.sort (hT.unsortedEigenvalues hn) * @Fin.revPerm n).symm
 
 theorem hasEigenvector_eigenvectorBasis (i : Fin n) :
     HasEigenvector T (hT.eigenvalues hn i) (hT.eigenvectorBasis hn i) := by

--- a/Mathlib/Analysis/InnerProductSpace/Spectrum.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Spectrum.lean
@@ -226,7 +226,7 @@ private theorem hasEigenvector_eigenvectorBasis_helper (i : Fin n) :
 
 /-- The eigenvalues for a self-adjoint operator `T` on a
 finite-dimensional inner product space `E`, sorted in decreasing order -/
-noncomputable irreducible_def eigenvalues: Fin n → ℝ :=
+noncomputable irreducible_def eigenvalues : Fin n → ℝ :=
   (hT.unsortedEigenvalues hn) ∘ Tuple.sort (hT.unsortedEigenvalues hn) ∘ @Fin.revPerm n
 
 /-- A choice of orthonormal basis of eigenvectors for self-adjoint operator `T` on a

--- a/Mathlib/Analysis/InnerProductSpace/Spectrum.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Spectrum.lean
@@ -195,7 +195,7 @@ variable {n : ℕ}
 
 /--
 Unsorted eigenvalues and eigenvectors.  These private definitions should not be used directly. 
-Instead use the functions eigenvalues and eigenvectorBasis defined below.  -/
+Instead use the functions eigenvalues and eigenvectorBasis defined below. -/
 private noncomputable def unsortedEigenvalues (hT : T.IsSymmetric) (hn : Module.finrank 𝕜 E = n)
     (i : Fin n) : ℝ :=
   @RCLike.re 𝕜 _ <| (hT.direct_sum_isInternal.subordinateOrthonormalBasisIndex hn i

--- a/Mathlib/Analysis/InnerProductSpace/Spectrum.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Spectrum.lean
@@ -245,7 +245,7 @@ theorem hasEigenvector_eigenvectorBasis (i : Fin n) :
 /--
 Eigenvalues are sorted in decreasing order. -/
 theorem eigenvalues_antitone : Antitone (hT.eigenvalues hn) := by
-  rw[eigenvalues_def, ←Function.comp_assoc]
+  rw [eigenvalues_def, ← Function.comp_assoc]
   refine Monotone.comp_antitone ?_ ?_
   · apply Tuple.monotone_sort
   intro _ _ h

--- a/Mathlib/Analysis/InnerProductSpace/Spectrum.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Spectrum.lean
@@ -40,7 +40,7 @@ Letting `T` be a self-adjoint operator on a finite-dimensional inner product spa
   eigenvalues in decreasing (but not increasing) order since they converge to zero. (iii) This
   simplifies several theorem statements. For example the Schur-Horn theorem states that the diagonal
   of the matrix representation of a selfadjoint linear map is majorized by the eigenvalue sequence
-  listed in decreasing order).
+  listed in decreasing order.
 
 These are forms of the *diagonalization theorem* for self-adjoint operators on finite-dimensional
 inner product spaces.

--- a/Mathlib/Analysis/InnerProductSpace/Spectrum.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Spectrum.lean
@@ -235,10 +235,10 @@ noncomputable irreducible_def eigenvalues (hT : T.IsSymmetric) (hn : Module.finr
 finite-dimensional inner product space `E`.  Eigenvectors are sorted in decreasing
 order of their eigenvalues. -/
 noncomputable irreducible_def eigenvectorBasis (hT : T.IsSymmetric) (hn : Module.finrank 𝕜 E = n) :
-  OrthonormalBasis (Fin n) 𝕜 E :=
-    (hT.direct_sum_isInternal.subordinateOrthonormalBasis
-      hn hT.orthogonalFamily_eigenspaces').reindex
-        (Tuple.sort (hT.unsortedEigenvalues hn) * @Fin.revPerm n).symm
+    OrthonormalBasis (Fin n) 𝕜 E :=
+  (hT.direct_sum_isInternal.subordinateOrthonormalBasis
+    hn hT.orthogonalFamily_eigenspaces').reindex
+      (Tuple.sort (hT.unsortedEigenvalues hn) * @Fin.revPerm n).symm
 
 theorem hasEigenvector_eigenvectorBasis (hT : T.IsSymmetric) (hn : Module.finrank 𝕜 E = n)
     (i : Fin n) : HasEigenvector T (hT.eigenvalues hn i) (hT.eigenvectorBasis hn i) := by

--- a/Mathlib/Analysis/InnerProductSpace/Spectrum.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Spectrum.lean
@@ -242,8 +242,7 @@ theorem hasEigenvector_eigenvectorBasis (i : Fin n) :
   rw [eigenvalues_def, eigenvectorBasis_def, OrthonormalBasis.reindex_apply]
   apply hasEigenvector_eigenvectorBasis_helper
 
-/--
-Eigenvalues are sorted in decreasing order. -/
+/-- Eigenvalues are sorted in decreasing order. -/
 theorem eigenvalues_antitone : Antitone (hT.eigenvalues hn) := by
   rw [eigenvalues_def, ← Function.comp_assoc]
   refine Monotone.comp_antitone ?_ ?_

--- a/Mathlib/Analysis/InnerProductSpace/Spectrum.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Spectrum.lean
@@ -52,6 +52,7 @@ Spectral theory for compact self-adjoint operators, bounded self-adjoint operato
 ## Tags
 
 self-adjoint operator, spectral theorem, diagonalization theorem
+
 -/
 
 variable {𝕜 : Type*} [RCLike 𝕜]
@@ -192,8 +193,7 @@ section Version2
 
 variable {n : ℕ}
 
-/--
-Unsorted eigenvalues and eigenvectors.  These private definitions should not be used directly.
+/-- Unsorted eigenvalues and eigenvectors.  These private definitions should not be used directly.
 Instead use the functions eigenvalues and eigenvectorBasis defined below. -/
 private noncomputable def unsortedEigenvalues (hT : T.IsSymmetric) (hn : Module.finrank 𝕜 E = n)
     (i : Fin n) : ℝ :=

--- a/Mathlib/Analysis/InnerProductSpace/Spectrum.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Spectrum.lean
@@ -194,7 +194,8 @@ section Version2
 variable {n : ℕ}
 
 /--
-Unsorted eigenvalues and eigenvectors.  These are composed with a permutation below. -/
+Unsorted eigenvalues and eigenvectors.  These private definitions should not be used directly. 
+Instead use the functions eigenvalues and eigenvectorBasis defined below.  -/
 private noncomputable def unsortedEigenvalues (hT : T.IsSymmetric) (hn : Module.finrank 𝕜 E = n)
     (i : Fin n) : ℝ :=
   @RCLike.re 𝕜 _ <| (hT.direct_sum_isInternal.subordinateOrthonormalBasisIndex hn i

--- a/Mathlib/Analysis/InnerProductSpace/Spectrum.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Spectrum.lean
@@ -196,17 +196,17 @@ variable {n : ℕ}
 /--
 Unsorted eigenvalues and eigenvectors.  These are composed with a permutation below. -/
 private noncomputable def unsortedEigenvalues (hT : T.IsSymmetric) (hn : Module.finrank 𝕜 E = n)
-  (i : Fin n) : ℝ := @RCLike.re 𝕜 _ <|
-    (hT.direct_sum_isInternal.subordinateOrthonormalBasisIndex hn i
-      hT.orthogonalFamily_eigenspaces').val
+    (i : Fin n) : ℝ :=
+  @RCLike.re 𝕜 _ <| (hT.direct_sum_isInternal.subordinateOrthonormalBasisIndex hn i
+    hT.orthogonalFamily_eigenspaces').val
 
 private noncomputable def unsortedEigenvectorBasis (hT : T.IsSymmetric)
-  (hn : Module.finrank 𝕜 E = n) : OrthonormalBasis (Fin n) 𝕜 E :=
-    hT.direct_sum_isInternal.subordinateOrthonormalBasis hn hT.orthogonalFamily_eigenspaces'
+    (hn : Module.finrank 𝕜 E = n) : OrthonormalBasis (Fin n) 𝕜 E :=
+  hT.direct_sum_isInternal.subordinateOrthonormalBasis hn hT.orthogonalFamily_eigenspaces'
 
 private theorem hasEigenvector_eigenvectorBasis_helper (hT : T.IsSymmetric)
     (hn : Module.finrank 𝕜 E = n) (i : Fin n) :
-        HasEigenvector T (hT.unsortedEigenvalues hn i) (hT.unsortedEigenvectorBasis hn i) := by
+    HasEigenvector T (hT.unsortedEigenvalues hn i) (hT.unsortedEigenvectorBasis hn i) := by
   let v : E := hT.unsortedEigenvectorBasis hn i
   let μ : 𝕜 :=
     (hT.direct_sum_isInternal.subordinateOrthonormalBasisIndex hn i
@@ -235,10 +235,10 @@ noncomputable irreducible_def eigenvalues (hT : T.IsSymmetric) (hn : Module.finr
 finite-dimensional inner product space `E`.  Eigenvectors are sorted in decreasing
 order of their eigenvalues. -/
 noncomputable irreducible_def eigenvectorBasis (hT : T.IsSymmetric) (hn : Module.finrank 𝕜 E = n) :
-  OrthonormalBasis (Fin n) 𝕜 E :=
-    (hT.direct_sum_isInternal.subordinateOrthonormalBasis
-      hn hT.orthogonalFamily_eigenspaces').reindex
-        (Tuple.sort (hT.unsortedEigenvalues hn) * @Fin.revPerm n).symm
+    OrthonormalBasis (Fin n) 𝕜 E :=
+  (hT.direct_sum_isInternal.subordinateOrthonormalBasis
+    hn hT.orthogonalFamily_eigenspaces').reindex
+      (Tuple.sort (hT.unsortedEigenvalues hn) * @Fin.revPerm n).symm
 
 theorem hasEigenvector_eigenvectorBasis (hT : T.IsSymmetric) (hn : Module.finrank 𝕜 E = n)
     (i : Fin n) : HasEigenvector T (hT.eigenvalues hn i) (hT.eigenvectorBasis hn i) := by

--- a/Mathlib/Analysis/InnerProductSpace/Spectrum.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Spectrum.lean
@@ -52,7 +52,6 @@ Spectral theory for compact self-adjoint operators, bounded self-adjoint operato
 ## Tags
 
 self-adjoint operator, spectral theorem, diagonalization theorem
-
 -/
 
 variable {𝕜 : Type*} [RCLike 𝕜]
@@ -194,7 +193,7 @@ section Version2
 variable {n : ℕ}
 
 /--
-Unsorted eigenvalues and eigenvectors.  These private definitions should not be used directly. 
+Unsorted eigenvalues and eigenvectors.  These private definitions should not be used directly.
 Instead use the functions eigenvalues and eigenvectorBasis defined below. -/
 private noncomputable def unsortedEigenvalues (hT : T.IsSymmetric) (hn : Module.finrank 𝕜 E = n)
     (i : Fin n) : ℝ :=

--- a/Mathlib/Analysis/InnerProductSpace/Spectrum.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Spectrum.lean
@@ -191,19 +191,20 @@ end Version1
 
 section Version2
 
-variable {n : ℕ} (hn : Module.finrank 𝕜 E = n)
+variable {n : ℕ}
 
 /--
 Unsorted eigenvalues and eigenvectors.  These are composed with a permutation below. -/
-private noncomputable def unsortedEigenvalues (i : Fin n) : ℝ :=
+private noncomputable def unsortedEigenvalues (hn : Module.finrank 𝕜 E = n) (i : Fin n) : ℝ :=
   @RCLike.re 𝕜 _ <|
     (hT.direct_sum_isInternal.subordinateOrthonormalBasisIndex hn i
       hT.orthogonalFamily_eigenspaces').val
 
-private noncomputable def unsortedEigenvectorBasis : OrthonormalBasis (Fin n) 𝕜 E :=
+private noncomputable def unsortedEigenvectorBasis (hn : Module.finrank 𝕜 E = n) :
+    OrthonormalBasis (Fin n) 𝕜 E :=
   hT.direct_sum_isInternal.subordinateOrthonormalBasis hn hT.orthogonalFamily_eigenspaces'
 
-private theorem hasEigenvector_eigenvectorBasis_helper (i : Fin n) :
+private theorem hasEigenvector_eigenvectorBasis_helper (hn : Module.finrank 𝕜 E = n) (i : Fin n) :
     HasEigenvector T (hT.unsortedEigenvalues hn i) (hT.unsortedEigenvectorBasis hn i) := by
   let v : E := hT.unsortedEigenvectorBasis hn i
   let μ : 𝕜 :=
@@ -226,42 +227,44 @@ private theorem hasEigenvector_eigenvectorBasis_helper (i : Fin n) :
 
 /-- The eigenvalues for a self-adjoint operator `T` on a
 finite-dimensional inner product space `E`, sorted in decreasing order -/
-noncomputable irreducible_def eigenvalues : Fin n → ℝ :=
+noncomputable irreducible_def eigenvalues (hn : Module.finrank 𝕜 E = n) : Fin n → ℝ :=
   (hT.unsortedEigenvalues hn) ∘ Tuple.sort (hT.unsortedEigenvalues hn) ∘ @Fin.revPerm n
 
 /-- A choice of orthonormal basis of eigenvectors for self-adjoint operator `T` on a
 finite-dimensional inner product space `E`.  Eigenvectors are sorted in decreasing
 order of their eigenvalues. -/
-noncomputable irreducible_def eigenvectorBasis : OrthonormalBasis (Fin n) 𝕜 E :=
+noncomputable irreducible_def eigenvectorBasis (hn : Module.finrank 𝕜 E = n) :
+    OrthonormalBasis (Fin n) 𝕜 E :=
   (hT.direct_sum_isInternal.subordinateOrthonormalBasis
     hn hT.orthogonalFamily_eigenspaces').reindex
       (Tuple.sort (hT.unsortedEigenvalues hn) * @Fin.revPerm n).symm
 
-theorem hasEigenvector_eigenvectorBasis (i : Fin n) :
+theorem hasEigenvector_eigenvectorBasis (hn : Module.finrank 𝕜 E = n) (i : Fin n) :
     HasEigenvector T (hT.eigenvalues hn i) (hT.eigenvectorBasis hn i) := by
   rw [eigenvalues_def, eigenvectorBasis_def, OrthonormalBasis.reindex_apply]
   apply hasEigenvector_eigenvectorBasis_helper
 
 /-- Eigenvalues are sorted in decreasing order. -/
-theorem eigenvalues_antitone : Antitone (hT.eigenvalues hn) := by
+theorem eigenvalues_antitone (hn : Module.finrank 𝕜 E = n) : Antitone (hT.eigenvalues hn) := by
   rw [eigenvalues_def, ← Function.comp_assoc]
   refine Monotone.comp_antitone ?_ ?_
   · apply Tuple.monotone_sort
   intro _ _ h
   exact Fin.rev_le_rev.mpr h
 
-theorem hasEigenvalue_eigenvalues (i : Fin n) : HasEigenvalue T (hT.eigenvalues hn i) :=
+theorem hasEigenvalue_eigenvalues (hn : Module.finrank 𝕜 E = n) (i : Fin n) :
+    HasEigenvalue T (hT.eigenvalues hn i) :=
   Module.End.hasEigenvalue_of_hasEigenvector (hT.hasEigenvector_eigenvectorBasis hn i)
 
 @[simp]
-theorem apply_eigenvectorBasis (i : Fin n) :
+theorem apply_eigenvectorBasis (hn : Module.finrank 𝕜 E = n) (i : Fin n) :
     T (hT.eigenvectorBasis hn i) = (hT.eigenvalues hn i : 𝕜) • hT.eigenvectorBasis hn i :=
   mem_eigenspace_iff.mp (hT.hasEigenvector_eigenvectorBasis hn i).1
 
 /-- *Diagonalization theorem*, *spectral theorem*; version 2: A self-adjoint operator `T` on a
 finite-dimensional inner product space `E` acts diagonally on the identification of `E` with
 Euclidean space induced by an orthonormal basis of eigenvectors of `T`. -/
-theorem eigenvectorBasis_apply_self_apply (v : E) (i : Fin n) :
+theorem eigenvectorBasis_apply_self_apply (hn : Module.finrank 𝕜 E = n) (v : E) (i : Fin n) :
     (hT.eigenvectorBasis hn).repr (T v) i =
       hT.eigenvalues hn i * (hT.eigenvectorBasis hn).repr v i := by
   suffices

--- a/Mathlib/Analysis/InnerProductSpace/Spectrum.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Spectrum.lean
@@ -158,25 +158,25 @@ theorem direct_sum_isInternal (hT : T.IsSymmetric) :
   hT.orthogonalFamily_eigenspaces'.isInternal_iff.mpr
     hT.orthogonalComplement_iSup_eigenspaces_eq_bot'
 
-variable (hT : T.IsSymmetric)
-
 section Version1
 
 /-- Isometry from an inner product space `E` to the direct sum of the eigenspaces of some
 self-adjoint operator `T` on `E`. -/
-noncomputable def diagonalization : E ≃ₗᵢ[𝕜] PiLp 2 fun μ : Eigenvalues T => eigenspace T μ :=
+noncomputable def diagonalization (hT : T.IsSymmetric) : E ≃ₗᵢ[𝕜] PiLp 2 fun μ :
+    Eigenvalues T => eigenspace T μ :=
   hT.direct_sum_isInternal.isometryL2OfOrthogonalFamily hT.orthogonalFamily_eigenspaces'
 
 @[simp]
-theorem diagonalization_symm_apply (w : PiLp 2 fun μ : Eigenvalues T => eigenspace T μ) :
-    hT.diagonalization.symm w = ∑ μ, w μ :=
+theorem diagonalization_symm_apply (hT : T.IsSymmetric)
+    (w : PiLp 2 fun μ : Eigenvalues T => eigenspace T μ) :
+        hT.diagonalization.symm w = ∑ μ, w μ :=
   hT.direct_sum_isInternal.isometryL2OfOrthogonalFamily_symm_apply
     hT.orthogonalFamily_eigenspaces' w
 
 /-- *Diagonalization theorem*, *spectral theorem*; version 1: A self-adjoint operator `T` on a
 finite-dimensional inner product space `E` acts diagonally on the decomposition of `E` into the
 direct sum of the eigenspaces of `T`. -/
-theorem diagonalization_apply_self_apply (v : E) (μ : Eigenvalues T) :
+theorem diagonalization_apply_self_apply (hT : T.IsSymmetric) (v : E) (μ : Eigenvalues T) :
     hT.diagonalization (T v) μ = (μ : 𝕜) • hT.diagonalization v μ := by
   suffices
     ∀ w : PiLp 2 fun μ : Eigenvalues T => eigenspace T μ,
@@ -195,17 +195,18 @@ variable {n : ℕ}
 
 /--
 Unsorted eigenvalues and eigenvectors.  These are composed with a permutation below. -/
-private noncomputable def unsortedEigenvalues (hn : Module.finrank 𝕜 E = n) (i : Fin n) : ℝ :=
-  @RCLike.re 𝕜 _ <|
+private noncomputable def unsortedEigenvalues (hT : T.IsSymmetric) (hn : Module.finrank 𝕜 E = n)
+  (i : Fin n) : ℝ := @RCLike.re 𝕜 _ <|
     (hT.direct_sum_isInternal.subordinateOrthonormalBasisIndex hn i
       hT.orthogonalFamily_eigenspaces').val
 
-private noncomputable def unsortedEigenvectorBasis (hn : Module.finrank 𝕜 E = n) :
-    OrthonormalBasis (Fin n) 𝕜 E :=
-  hT.direct_sum_isInternal.subordinateOrthonormalBasis hn hT.orthogonalFamily_eigenspaces'
+private noncomputable def unsortedEigenvectorBasis (hT : T.IsSymmetric)
+  (hn : Module.finrank 𝕜 E = n) : OrthonormalBasis (Fin n) 𝕜 E :=
+    hT.direct_sum_isInternal.subordinateOrthonormalBasis hn hT.orthogonalFamily_eigenspaces'
 
-private theorem hasEigenvector_eigenvectorBasis_helper (hn : Module.finrank 𝕜 E = n) (i : Fin n) :
-    HasEigenvector T (hT.unsortedEigenvalues hn i) (hT.unsortedEigenvectorBasis hn i) := by
+private theorem hasEigenvector_eigenvectorBasis_helper (hT : T.IsSymmetric)
+    (hn : Module.finrank 𝕜 E = n) (i : Fin n) :
+        HasEigenvector T (hT.unsortedEigenvalues hn i) (hT.unsortedEigenvectorBasis hn i) := by
   let v : E := hT.unsortedEigenvectorBasis hn i
   let μ : 𝕜 :=
     (hT.direct_sum_isInternal.subordinateOrthonormalBasisIndex hn i
@@ -227,46 +228,47 @@ private theorem hasEigenvector_eigenvectorBasis_helper (hn : Module.finrank 𝕜
 
 /-- The eigenvalues for a self-adjoint operator `T` on a
 finite-dimensional inner product space `E`, sorted in decreasing order -/
-noncomputable irreducible_def eigenvalues (hn : Module.finrank 𝕜 E = n) : Fin n → ℝ :=
-  (hT.unsortedEigenvalues hn) ∘ Tuple.sort (hT.unsortedEigenvalues hn) ∘ @Fin.revPerm n
+noncomputable irreducible_def eigenvalues (hT : T.IsSymmetric) (hn : Module.finrank 𝕜 E = n) :
+  Fin n → ℝ := (hT.unsortedEigenvalues hn) ∘ Tuple.sort (hT.unsortedEigenvalues hn) ∘ @Fin.revPerm n
 
 /-- A choice of orthonormal basis of eigenvectors for self-adjoint operator `T` on a
 finite-dimensional inner product space `E`.  Eigenvectors are sorted in decreasing
 order of their eigenvalues. -/
-noncomputable irreducible_def eigenvectorBasis (hn : Module.finrank 𝕜 E = n) :
-    OrthonormalBasis (Fin n) 𝕜 E :=
-  (hT.direct_sum_isInternal.subordinateOrthonormalBasis
-    hn hT.orthogonalFamily_eigenspaces').reindex
-      (Tuple.sort (hT.unsortedEigenvalues hn) * @Fin.revPerm n).symm
+noncomputable irreducible_def eigenvectorBasis (hT : T.IsSymmetric) (hn : Module.finrank 𝕜 E = n) :
+  OrthonormalBasis (Fin n) 𝕜 E :=
+    (hT.direct_sum_isInternal.subordinateOrthonormalBasis
+      hn hT.orthogonalFamily_eigenspaces').reindex
+        (Tuple.sort (hT.unsortedEigenvalues hn) * @Fin.revPerm n).symm
 
-theorem hasEigenvector_eigenvectorBasis (hn : Module.finrank 𝕜 E = n) (i : Fin n) :
-    HasEigenvector T (hT.eigenvalues hn i) (hT.eigenvectorBasis hn i) := by
+theorem hasEigenvector_eigenvectorBasis (hT : T.IsSymmetric) (hn : Module.finrank 𝕜 E = n)
+    (i : Fin n) : HasEigenvector T (hT.eigenvalues hn i) (hT.eigenvectorBasis hn i) := by
   rw [eigenvalues_def, eigenvectorBasis_def, OrthonormalBasis.reindex_apply]
   apply hasEigenvector_eigenvectorBasis_helper
 
 /-- Eigenvalues are sorted in decreasing order. -/
-theorem eigenvalues_antitone (hn : Module.finrank 𝕜 E = n) : Antitone (hT.eigenvalues hn) := by
+theorem eigenvalues_antitone (hT : T.IsSymmetric) (hn : Module.finrank 𝕜 E = n) :
+    Antitone (hT.eigenvalues hn) := by
   rw [eigenvalues_def, ← Function.comp_assoc]
   refine Monotone.comp_antitone ?_ ?_
   · apply Tuple.monotone_sort
   intro _ _ h
   exact Fin.rev_le_rev.mpr h
 
-theorem hasEigenvalue_eigenvalues (hn : Module.finrank 𝕜 E = n) (i : Fin n) :
+theorem hasEigenvalue_eigenvalues (hT : T.IsSymmetric) (hn : Module.finrank 𝕜 E = n) (i : Fin n) :
     HasEigenvalue T (hT.eigenvalues hn i) :=
   Module.End.hasEigenvalue_of_hasEigenvector (hT.hasEigenvector_eigenvectorBasis hn i)
 
 @[simp]
-theorem apply_eigenvectorBasis (hn : Module.finrank 𝕜 E = n) (i : Fin n) :
+theorem apply_eigenvectorBasis (hT : T.IsSymmetric) (hn : Module.finrank 𝕜 E = n) (i : Fin n) :
     T (hT.eigenvectorBasis hn i) = (hT.eigenvalues hn i : 𝕜) • hT.eigenvectorBasis hn i :=
   mem_eigenspace_iff.mp (hT.hasEigenvector_eigenvectorBasis hn i).1
 
 /-- *Diagonalization theorem*, *spectral theorem*; version 2: A self-adjoint operator `T` on a
 finite-dimensional inner product space `E` acts diagonally on the identification of `E` with
 Euclidean space induced by an orthonormal basis of eigenvectors of `T`. -/
-theorem eigenvectorBasis_apply_self_apply (hn : Module.finrank 𝕜 E = n) (v : E) (i : Fin n) :
-    (hT.eigenvectorBasis hn).repr (T v) i =
-      hT.eigenvalues hn i * (hT.eigenvectorBasis hn).repr v i := by
+theorem eigenvectorBasis_apply_self_apply (hT : T.IsSymmetric) (hn : Module.finrank 𝕜 E = n)
+    (v : E) (i : Fin n) : (hT.eigenvectorBasis hn).repr (T v) i =
+        hT.eigenvalues hn i * (hT.eigenvectorBasis hn).repr v i := by
   suffices
     ∀ w : EuclideanSpace 𝕜 (Fin n),
       T ((hT.eigenvectorBasis hn).repr.symm w) =

--- a/Mathlib/Analysis/InnerProductSpace/Spectrum.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Spectrum.lean
@@ -33,6 +33,14 @@ Letting `T` be a self-adjoint operator on a finite-dimensional inner product spa
   from `E` to Euclidean space, and the theorem
   `LinearMap.IsSymmetric.eigenvectorBasis_apply_self_apply` states that, when `T` is
   transferred via this equivalence to an operator on Euclidean space, it acts diagonally.
+* `LinearMap.IsSymmetric.eigenvalues` gives the eigenvalues in decreasing order.  This is
+  done for several reasons: (i) This agrees with the standard convention of listing singular
+  values in decreasing order, with the operator norm as the first singular value
+  (ii) For positive compact operators on an infinite dimensional space, one can list the nonzero
+  eigenvalues in decreasing (but not increasing) order since they converge to zero. (iii) This
+  simplifies several theorem statements. For example the Schur-Horn theorem states that the diagonal
+  of the matrix representation of a selfadjoint linear map is majorized by the eigenvalue sequence
+  listed in decreasing order).
 
 These are forms of the *diagonalization theorem* for self-adjoint operators on finite-dimensional
 inner product spaces.
@@ -187,7 +195,6 @@ variable {n : ℕ} (hn : Module.finrank 𝕜 E = n)
 
 /--
 Unsorted eigenvalues and eigenvectors.  These are composed with a permutation below. -/
-
 private noncomputable def unsortedEigenvalues (i : Fin n) : ℝ :=
   @RCLike.re 𝕜 _ <|
     (hT.direct_sum_isInternal.subordinateOrthonormalBasisIndex hn i

--- a/Mathlib/Analysis/InnerProductSpace/Spectrum.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Spectrum.lean
@@ -218,17 +218,18 @@ private theorem hasEigenvector_eigenvectorBasis_helper (i : Fin n) :
   simpa [re_μ] using key
 
 /-- The eigenvalues for a self-adjoint operator `T` on a
-finite-dimensional inner product space `E`, sorted in increasing order. -/
-noncomputable irreducible_def eigenvalues : Fin n → ℝ :=
-  (hT.unsortedEigenvalues hn) ∘ (Tuple.sort (hT.unsortedEigenvalues hn))
+finite-dimensional inner product space `E`, sorted in decreasing order -/
+noncomputable irreducible_def eigenvalues: Fin n → ℝ :=
+  (hT.unsortedEigenvalues hn) ∘ Tuple.sort (hT.unsortedEigenvalues hn) ∘ @Fin.revPerm n
 
 /-- A choice of orthonormal basis of eigenvectors for self-adjoint operator `T` on a
 finite-dimensional inner product space `E`.  Eigenvectors are sorted in increasing
 order of their eigenvalues. -/
 noncomputable irreducible_def eigenvectorBasis : OrthonormalBasis (Fin n) 𝕜 E :=
+  let perm := Tuple.sort (hT.unsortedEigenvalues hn) * @Fin.revPerm n
   (hT.direct_sum_isInternal.subordinateOrthonormalBasis
     hn hT.orthogonalFamily_eigenspaces').reindex
-      (Tuple.sort (hT.unsortedEigenvalues hn)).symm
+      perm.symm
 
 theorem hasEigenvector_eigenvectorBasis (i : Fin n) :
     HasEigenvector T (hT.eigenvalues hn i) (hT.eigenvectorBasis hn i) := by
@@ -236,10 +237,13 @@ theorem hasEigenvector_eigenvectorBasis (i : Fin n) :
   apply hasEigenvector_eigenvectorBasis_helper
 
 /--
-Eigenvalues are sorted in increasing order. -/
-theorem eigenvalues_monotone : Monotone (hT.eigenvalues hn) := by
-  rw[eigenvalues_def]
-  apply Tuple.monotone_sort
+Eigenvalues are sorted in decreasing order. -/
+theorem eigenvalues_antitone : Antitone (hT.eigenvalues hn) := by
+  rw[eigenvalues_def, ←Function.comp_assoc]
+  refine Monotone.comp_antitone ?_ ?_
+  · apply Tuple.monotone_sort
+  intro _ _ h
+  exact Fin.rev_le_rev.mpr h
 
 theorem hasEigenvalue_eigenvalues (i : Fin n) : HasEigenvalue T (hT.eigenvalues hn i) :=
   Module.End.hasEigenvalue_of_hasEigenvector (hT.hasEigenvector_eigenvectorBasis hn i)

--- a/Mathlib/Analysis/InnerProductSpace/Spectrum.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Spectrum.lean
@@ -230,7 +230,7 @@ noncomputable irreducible_def eigenvalues : Fin n → ℝ :=
   (hT.unsortedEigenvalues hn) ∘ Tuple.sort (hT.unsortedEigenvalues hn) ∘ @Fin.revPerm n
 
 /-- A choice of orthonormal basis of eigenvectors for self-adjoint operator `T` on a
-finite-dimensional inner product space `E`.  Eigenvectors are sorted in increasing
+finite-dimensional inner product space `E`.  Eigenvectors are sorted in decreasing
 order of their eigenvalues. -/
 noncomputable irreducible_def eigenvectorBasis : OrthonormalBasis (Fin n) 𝕜 E :=
   (hT.direct_sum_isInternal.subordinateOrthonormalBasis

--- a/Mathlib/Analysis/InnerProductSpace/Spectrum.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Spectrum.lean
@@ -218,8 +218,8 @@ private theorem hasEigenvector_eigenvectorBasis_helper (i : Fin n) :
     exact hT.conj_eigenvalue_eq_self (hasEigenvalue_of_hasEigenvector key)
   simpa [re_μ] using key
 
-/-- A choice of orthonormal basis of eigenvectors for self-adjoint operator `T` on a
-finite-dimensional inner product space `E`. -/
+/-- The eigenvalues for a self-adjoint operator `T` on a
+finite-dimensional inner product space `E`, sorted in increasing order. -/
 noncomputable irreducible_def eigenvalues : Fin n → ℝ :=
   (hT.unsortedEigenvalues hn) ∘ (Tuple.sort (hT.unsortedEigenvalues hn))
 

--- a/Mathlib/Analysis/InnerProductSpace/Spectrum.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Spectrum.lean
@@ -9,7 +9,6 @@ import Mathlib.Algebra.DirectSum.Decomposition
 import Mathlib.LinearAlgebra.Eigenspace.Minpoly
 import Mathlib.Data.Fin.Tuple.Sort
 
-
 /-! # Spectral theory of self-adjoint operators
 
 This file covers the spectral theory of self-adjoint operators on an inner product space.

--- a/Mathlib/Analysis/InnerProductSpace/Spectrum.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Spectrum.lean
@@ -238,7 +238,7 @@ theorem hasEigenvector_eigenvectorBasis (i : Fin n) :
 
 /--
 Eigenvalues are sorted in increasing order. -/
-theorem monotoneEigenvalues : Monotone (hT.eigenvalues hn) := by
+theorem eigenvalues_monotone : Monotone (hT.eigenvalues hn) := by
   rw[eigenvalues_def]
   apply Tuple.monotone_sort
 

--- a/Mathlib/Analysis/InnerProductSpace/Spectrum.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Spectrum.lean
@@ -232,14 +232,9 @@ noncomputable irreducible_def eigenvectorBasis : OrthonormalBasis (Fin n) 𝕜 E
       (Tuple.sort (hT.unsortedEigenvalues hn)).symm
 
 theorem hasEigenvector_eigenvectorBasis (i : Fin n) :
-  HasEigenvector T (hT.eigenvalues hn i) (hT.eigenvectorBasis hn i) := by
-    let p : Equiv.Perm (Fin n) :=  Tuple.sort (hT.unsortedEigenvalues hn)
-    have h1 : hT.eigenvalues hn i = (hT.unsortedEigenvalues hn) (p i) := by
-      rw[eigenvalues_def]; rfl
-    have h2 : hT.eigenvectorBasis hn i = (hT.unsortedEigenvectorBasis hn) (p i) := by
-      rw[eigenvectorBasis_def, OrthonormalBasis.reindex_apply]; rfl
-    rw[h1, h2]
-    apply hasEigenvector_eigenvectorBasis_helper
+    HasEigenvector T (hT.eigenvalues hn i) (hT.eigenvectorBasis hn i) := by
+  rw [eigenvalues_def, eigenvectorBasis_def, OrthonormalBasis.reindex_apply]
+  apply hasEigenvector_eigenvectorBasis_helper
 
 /--
 Eigenvalues are sorted in increasing order. -/


### PR DESCRIPTION
Spectrum.eigenvalues and Spectrum.eigenvectorBasis now give the eigenvalues and eigenvectors in increasing order of eigenvalues, which clears a prior TODO. The new theorem eigenvalues_monotone allows the monotonicity to be used downstream.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
