### PR TITLE
[Merged by Bors] - feat: modify Urysohn's lemma to let `P` depend on `U`

### DIFF
--- a/Mathlib/Topology/UrysohnsLemma.lean
+++ b/Mathlib/Topology/UrysohnsLemma.lean
@@ -111,7 +111,7 @@ structure CU {X : Type*} [TopologicalSpace X] (P : Set X → Set X → Sort*) wh
 
 namespace CU
 
-variable {P : Set X → Set X → Prop}
+variable {P : Set X → Set X → Sort*}
 
 /-- By assumption, for each `c : CU P` there exists an open set `u`
 such that `c.C ⊆ u` and `closure u ⊆ c.U`. `c.left` is the pair `(c.C, u)`. -/

--- a/Mathlib/Topology/UrysohnsLemma.lean
+++ b/Mathlib/Topology/UrysohnsLemma.lean
@@ -88,50 +88,53 @@ open scoped Pointwise
 namespace Urysohns
 
 
-/-- An auxiliary type for the proof of Urysohn's lemma: a pair of a closed set `C` and its
-open neighborhood `U`, together with the assumption that `C` satisfies the property `P C`. The
-latter assumption will make it possible to prove simultaneously both versions of Urysohn's lemma,
-in normal spaces (with `P` always true) and in locally compact spaces (with `P = IsCompact`).
-We put also in the structure the assumption that, for any such pair, one may find an intermediate
-pair in between satisfying `P`, to avoid carrying it around in the argument. -/
-structure CU {X : Type*} [TopologicalSpace X] (P : Set X → Prop) where
+/--
+An auxiliary type for the proof of Urysohn's lemma: a pair of a closed set `C` and its open
+neighborhood `U`, together with the assumption that `C` and `U` satisfy the property `P C U`.
+The latter assumption will make it possible to prove simultaneously both versions of Urysohn's
+lemma, in normal spaces (with `P` always true) and in locally compact spaces
+(with `P C U = IsCompact C`). We put also in the structure the assumption that, for any such pair,
+one may find an intermediate pair in between satisfying `P`,
+to avoid carrying it around in the argument.
+-/
+structure CU {X : Type*} [TopologicalSpace X] (P : Set X → Set X → Sort*) where
   /-- The inner set in the inductive construction towards Urysohn's lemma -/
   protected C : Set X
   /-- The outer set in the inductive construction towards Urysohn's lemma -/
   protected U : Set X
-  protected P_C : P C
+  protected P_C_U : P C U
   protected closed_C : IsClosed C
   protected open_U : IsOpen U
   protected subset : C ⊆ U
-  protected hP : ∀ {c u : Set X}, IsClosed c → P c → IsOpen u → c ⊆ u →
-    ∃ v, IsOpen v ∧ c ⊆ v ∧ closure v ⊆ u ∧ P (closure v)
+  protected hP : ∀ {c u : Set X}, IsClosed c → P c u → IsOpen u → c ⊆ u →
+    (v : Set X) ×' IsOpen v ×' c ⊆ v ×' closure v ⊆ u ×' P c v ×' P (closure v) u
 
 namespace CU
 
-variable {P : Set X → Prop}
+variable {P : Set X → Set X → Prop}
 
 /-- By assumption, for each `c : CU P` there exists an open set `u`
 such that `c.C ⊆ u` and `closure u ⊆ c.U`. `c.left` is the pair `(c.C, u)`. -/
 @[simps C]
 def left (c : CU P) : CU P where
   C := c.C
-  U := (c.hP c.closed_C c.P_C c.open_U c.subset).choose
+  U := (c.hP c.closed_C c.P_C_U c.open_U c.subset).1
   closed_C := c.closed_C
-  P_C := c.P_C
-  open_U := (c.hP c.closed_C c.P_C c.open_U c.subset).choose_spec.1
-  subset := (c.hP c.closed_C c.P_C c.open_U c.subset).choose_spec.2.1
+  P_C_U := (c.hP c.closed_C c.P_C_U c.open_U c.subset).2.2.2.2.1
+  open_U := (c.hP c.closed_C c.P_C_U c.open_U c.subset).2.1
+  subset := (c.hP c.closed_C c.P_C_U c.open_U c.subset).2.2.1
   hP := c.hP
 
 /-- By assumption, for each `c : CU P` there exists an open set `u`
 such that `c.C ⊆ u` and `closure u ⊆ c.U`. `c.right` is the pair `(closure u, c.U)`. -/
 @[simps U]
 def right (c : CU P) : CU P where
-  C := closure (c.hP c.closed_C c.P_C c.open_U c.subset).choose
+  C := closure (c.hP c.closed_C c.P_C_U c.open_U c.subset).1
   U := c.U
   closed_C := isClosed_closure
-  P_C := (c.hP c.closed_C c.P_C c.open_U c.subset).choose_spec.2.2.2
+  P_C_U := (c.hP c.closed_C c.P_C_U c.open_U c.subset).2.2.2.2.2
   open_U := c.open_U
-  subset := (c.hP c.closed_C c.P_C c.open_U c.subset).choose_spec.2.2.1
+  subset := (c.hP c.closed_C c.P_C_U c.open_U c.subset).2.2.2.1
   hP := c.hP
 
 theorem left_U_subset_right_C (c : CU P) : c.left.U ⊆ c.right.C :=
@@ -313,18 +316,18 @@ theorem exists_continuous_zero_one_of_isClosed [NormalSpace X]
     {s t : Set X} (hs : IsClosed s) (ht : IsClosed t)
     (hd : Disjoint s t) : ∃ f : C(X, ℝ), EqOn f 0 s ∧ EqOn f 1 t ∧ ∀ x, f x ∈ Icc (0 : ℝ) 1 := by
   -- The actual proof is in the code above. Here we just repack it into the expected format.
-  let P : Set X → Prop := fun _ ↦ True
+  let P : Set X → Set X → Prop := fun _ _ ↦ True
   set c : Urysohns.CU P :=
   { C := s
     U := tᶜ
-    P_C := trivial
+    P_C_U := trivial
     closed_C := hs
     open_U := ht.isOpen_compl
     subset := disjoint_left.1 hd
     hP := by
       rintro c u c_closed - u_open cu
-      rcases normal_exists_closure_subset c_closed u_open cu with ⟨v, v_open, cv, hv⟩
-      exact ⟨v, v_open, cv, hv, trivial⟩ }
+      choose v v_open cv hv using normal_exists_closure_subset c_closed u_open cu
+      exact ⟨v, v_open, cv, hv, trivial, trivial⟩ }
   exact ⟨⟨c.lim, c.continuous_lim⟩, c.lim_of_mem_C, fun x hx => c.lim_of_nmem_U _ fun h => h hx,
     c.lim_mem_Icc⟩
 
@@ -341,21 +344,21 @@ theorem exists_continuous_zero_one_of_isCompact [RegularSpace X] [LocallyCompact
     ∃ f : C(X, ℝ), EqOn f 0 s ∧ EqOn f 1 t ∧ ∀ x, f x ∈ Icc (0 : ℝ) 1 := by
   obtain ⟨k, k_comp, k_closed, sk, kt⟩ : ∃ k, IsCompact k ∧ IsClosed k ∧ s ⊆ interior k ∧ k ⊆ tᶜ :=
     exists_compact_closed_between hs ht.isOpen_compl hd.symm.subset_compl_left
-  let P : Set X → Prop := IsCompact
+  let P : Set X → Set X → Prop := fun c _ => IsCompact c
   set c : Urysohns.CU P :=
   { C := k
     U := tᶜ
-    P_C := k_comp
+    P_C_U := k_comp
     closed_C := k_closed
     open_U := ht.isOpen_compl
     subset := kt
     hP := by
       rintro c u - c_comp u_open cu
-      rcases exists_compact_closed_between c_comp u_open cu with ⟨k, k_comp, k_closed, ck, ku⟩
+      choose k k_comp k_closed ck ku using exists_compact_closed_between c_comp u_open cu
       have A : closure (interior k) ⊆ k :=
         (IsClosed.closure_subset_iff k_closed).2 interior_subset
-      refine ⟨interior k, isOpen_interior, ck, A.trans ku,
-        k_comp.of_isClosed_subset isClosed_closure A⟩ }
+      exact ⟨interior k, isOpen_interior, ck, A.trans ku,
+        c_comp, k_comp.of_isClosed_subset isClosed_closure A⟩ }
   exact ⟨⟨c.lim, c.continuous_lim⟩, fun x hx ↦ c.lim_of_mem_C _ (sk.trans interior_subset hx),
     fun x hx => c.lim_of_nmem_U _ fun h => h hx, c.lim_mem_Icc⟩
 
@@ -481,24 +484,24 @@ lemma exists_tsupport_one_of_isOpen_isClosed [T2Space X] {s t : Set X}
 -- although `sᶜ` is not compact, `closure s` is compact and we can apply
 -- `SeparatedNhds.of_isClosed_isCompact_closure_compl_isClosed`. To apply the condition
 -- recursively, we need to make sure that `sᶜ ⊆ C`.
-  let P : Set X → Prop := fun C => sᶜ ⊆ C
+  let P : Set X → Set X → Prop := fun C _ => sᶜ ⊆ C
   set c : Urysohns.CU P :=
   { C := closure u
     U := tᶜ
-    P_C := hscompl_subset_u.trans subset_closure
+    P_C_U := hscompl_subset_u.trans subset_closure
     closed_C := isClosed_closure
     open_U := ht.isOpen_compl
     subset := subset_compl_comm.mp
       (Subset.trans ht_subset_v (subset_compl_comm.mp huvc))
     hP := by
       intro c u0 cIsClosed Pc u0IsOpen csubu0
-      obtain ⟨u1, hu1⟩ := SeparatedNhds.of_isClosed_isCompact_closure_compl_isClosed cIsClosed
+      choose u1 hu1 using SeparatedNhds.of_isClosed_isCompact_closure_compl_isClosed cIsClosed
         (IsCompact.of_isClosed_subset hscp isClosed_closure
         (closure_mono (compl_subset_compl.mpr Pc)))
         (isClosed_compl_iff.mpr u0IsOpen) (HasSubset.Subset.disjoint_compl_right csubu0)
       simp_rw [← subset_compl_iff_disjoint_right, compl_subset_comm (s := u0)] at hu1
-      obtain ⟨v1, hu1, hv1, hcu1, hv1u, hu1v1⟩ := hu1
-      refine ⟨u1, hu1, hcu1, ?_, (Pc.trans hcu1).trans subset_closure⟩
+      choose v1 hu1 hv1 hcu1 hv1u hu1v1 using hu1
+      refine ⟨u1, hu1, hcu1, ?_, Pc, (Pc.trans hcu1).trans subset_closure⟩
       exact closure_minimal hu1v1 hv1.isClosed_compl |>.trans hv1u }
 -- `c.lim = 0` on `closure u` and `c.lim = 1` on `t`, so that `tsupport c.lim ⊆ s`.
   use ⟨c.lim, c.continuous_lim⟩

--- a/Mathlib/Topology/UrysohnsLemma.lean
+++ b/Mathlib/Topology/UrysohnsLemma.lean
@@ -97,7 +97,7 @@ lemma, in normal spaces (with `P` always true) and in locally compact spaces
 one may find an intermediate pair in between satisfying `P`,
 to avoid carrying it around in the argument.
 -/
-structure CU {X : Type*} [TopologicalSpace X] (P : Set X → Set X → Sort*) where
+structure CU {X : Type*} [TopologicalSpace X] (P : Set X → Set X → Prop) where
   /-- The inner set in the inductive construction towards Urysohn's lemma -/
   protected C : Set X
   /-- The outer set in the inductive construction towards Urysohn's lemma -/
@@ -109,34 +109,34 @@ structure CU {X : Type*} [TopologicalSpace X] (P : Set X → Set X → Sort*) wh
   protected subset : C ⊆ U
   /-- The proof that we can divide `CU` pairs in half -/
   protected hP : ∀ {c u : Set X}, IsClosed c → P c u → IsOpen u → c ⊆ u →
-    (v : Set X) ×' IsOpen v ×' c ⊆ v ×' closure v ⊆ u ×' P c v ×' P (closure v) u
+    ∃ (v : Set X), IsOpen v ∧ c ⊆ v ∧ closure v ⊆ u ∧ P c v ∧ P (closure v) u
 
 namespace CU
 
-variable {P : Set X → Set X → Sort*}
+variable {P : Set X → Set X → Prop}
 
 /-- By assumption, for each `c : CU P` there exists an open set `u`
 such that `c.C ⊆ u` and `closure u ⊆ c.U`. `c.left` is the pair `(c.C, u)`. -/
 @[simps C]
 def left (c : CU P) : CU P where
   C := c.C
-  U := (c.hP c.closed_C c.P_C_U c.open_U c.subset).1
+  U := (c.hP c.closed_C c.P_C_U c.open_U c.subset).choose
   closed_C := c.closed_C
-  P_C_U := (c.hP c.closed_C c.P_C_U c.open_U c.subset).2.2.2.2.1
-  open_U := (c.hP c.closed_C c.P_C_U c.open_U c.subset).2.1
-  subset := (c.hP c.closed_C c.P_C_U c.open_U c.subset).2.2.1
+  P_C_U := (c.hP c.closed_C c.P_C_U c.open_U c.subset).choose_spec.2.2.2.1
+  open_U := (c.hP c.closed_C c.P_C_U c.open_U c.subset).choose_spec.1
+  subset := (c.hP c.closed_C c.P_C_U c.open_U c.subset).choose_spec.2.1
   hP := c.hP
 
 /-- By assumption, for each `c : CU P` there exists an open set `u`
 such that `c.C ⊆ u` and `closure u ⊆ c.U`. `c.right` is the pair `(closure u, c.U)`. -/
 @[simps U]
 def right (c : CU P) : CU P where
-  C := closure (c.hP c.closed_C c.P_C_U c.open_U c.subset).1
+  C := closure (c.hP c.closed_C c.P_C_U c.open_U c.subset).choose
   U := c.U
   closed_C := isClosed_closure
-  P_C_U := (c.hP c.closed_C c.P_C_U c.open_U c.subset).2.2.2.2.2
+  P_C_U := (c.hP c.closed_C c.P_C_U c.open_U c.subset).choose_spec.2.2.2.2
   open_U := c.open_U
-  subset := (c.hP c.closed_C c.P_C_U c.open_U c.subset).2.2.2.1
+  subset := (c.hP c.closed_C c.P_C_U c.open_U c.subset).choose_spec.2.2.1
   hP := c.hP
 
 theorem left_U_subset_right_C (c : CU P) : c.left.U ⊆ c.right.C :=
@@ -328,7 +328,7 @@ theorem exists_continuous_zero_one_of_isClosed [NormalSpace X]
     subset := disjoint_left.1 hd
     hP := by
       rintro c u c_closed - u_open cu
-      choose v v_open cv hv using normal_exists_closure_subset c_closed u_open cu
+      rcases normal_exists_closure_subset c_closed u_open cu with ⟨v, v_open, cv, hv⟩
       exact ⟨v, v_open, cv, hv, trivial, trivial⟩ }
   exact ⟨⟨c.lim, c.continuous_lim⟩, c.lim_of_mem_C, fun x hx => c.lim_of_nmem_U _ fun h => h hx,
     c.lim_mem_Icc⟩
@@ -346,7 +346,7 @@ theorem exists_continuous_zero_one_of_isCompact [RegularSpace X] [LocallyCompact
     ∃ f : C(X, ℝ), EqOn f 0 s ∧ EqOn f 1 t ∧ ∀ x, f x ∈ Icc (0 : ℝ) 1 := by
   obtain ⟨k, k_comp, k_closed, sk, kt⟩ : ∃ k, IsCompact k ∧ IsClosed k ∧ s ⊆ interior k ∧ k ⊆ tᶜ :=
     exists_compact_closed_between hs ht.isOpen_compl hd.symm.subset_compl_left
-  let P : Set X → Set X → Prop := fun c _ => IsCompact c
+  let P : Set X → Set X → Prop := fun C _ => IsCompact C
   set c : Urysohns.CU P :=
   { C := k
     U := tᶜ
@@ -356,11 +356,11 @@ theorem exists_continuous_zero_one_of_isCompact [RegularSpace X] [LocallyCompact
     subset := kt
     hP := by
       rintro c u - c_comp u_open cu
-      choose k k_comp k_closed ck ku using exists_compact_closed_between c_comp u_open cu
+      rcases exists_compact_closed_between c_comp u_open cu with ⟨k, k_comp, k_closed, ck, ku⟩
       have A : closure (interior k) ⊆ k :=
         (IsClosed.closure_subset_iff k_closed).2 interior_subset
-      exact ⟨interior k, isOpen_interior, ck, A.trans ku,
-        c_comp, k_comp.of_isClosed_subset isClosed_closure A⟩ }
+      refine ⟨interior k, isOpen_interior, ck, A.trans ku, c_comp,
+        k_comp.of_isClosed_subset isClosed_closure A⟩ }
   exact ⟨⟨c.lim, c.continuous_lim⟩, fun x hx ↦ c.lim_of_mem_C _ (sk.trans interior_subset hx),
     fun x hx => c.lim_of_nmem_U _ fun h => h hx, c.lim_mem_Icc⟩
 
@@ -478,11 +478,11 @@ lemma exists_tsupport_one_of_isOpen_isClosed [T2Space X] {s t : Set X}
     ∃ f : C(X, ℝ), tsupport f ⊆ s ∧ EqOn f 1 t ∧ ∀ x, f x ∈ Icc (0 : ℝ) 1 := by
 -- separate `sᶜ` and `t` by `u` and `v`.
   rw [← compl_compl s] at hscp
-  obtain ⟨u, v, huIsOpen, hvIsOpen, hscompl_subset_u, ht_subset_v, hDjsjointuv⟩ :=
+  obtain ⟨u, v, huIsOpen, hvIsOpen, hscompl_subset_u, ht_subset_v, hDisjointuv⟩ :=
     SeparatedNhds.of_isClosed_isCompact_closure_compl_isClosed (isClosed_compl_iff.mpr hs)
     hscp ht (HasSubset.Subset.disjoint_compl_left hst)
-  rw [← subset_compl_iff_disjoint_right] at hDjsjointuv
-  have huvc : closure u ⊆ vᶜ := closure_minimal hDjsjointuv hvIsOpen.isClosed_compl
+  rw [← subset_compl_iff_disjoint_right] at hDisjointuv
+  have huvc : closure u ⊆ vᶜ := closure_minimal hDisjointuv hvIsOpen.isClosed_compl
 -- although `sᶜ` is not compact, `closure s` is compact and we can apply
 -- `SeparatedNhds.of_isClosed_isCompact_closure_compl_isClosed`. To apply the condition
 -- recursively, we need to make sure that `sᶜ ⊆ C`.
@@ -497,12 +497,12 @@ lemma exists_tsupport_one_of_isOpen_isClosed [T2Space X] {s t : Set X}
       (Subset.trans ht_subset_v (subset_compl_comm.mp huvc))
     hP := by
       intro c u0 cIsClosed Pc u0IsOpen csubu0
-      choose u1 hu1 using SeparatedNhds.of_isClosed_isCompact_closure_compl_isClosed cIsClosed
+      obtain ⟨u1, hu1⟩ := SeparatedNhds.of_isClosed_isCompact_closure_compl_isClosed cIsClosed
         (IsCompact.of_isClosed_subset hscp isClosed_closure
         (closure_mono (compl_subset_compl.mpr Pc)))
         (isClosed_compl_iff.mpr u0IsOpen) (HasSubset.Subset.disjoint_compl_right csubu0)
       simp_rw [← subset_compl_iff_disjoint_right, compl_subset_comm (s := u0)] at hu1
-      choose v1 hu1 hv1 hcu1 hv1u hu1v1 using hu1
+      obtain ⟨v1, hu1, hv1, hcu1, hv1u, hu1v1⟩ := hu1
       refine ⟨u1, hu1, hcu1, ?_, Pc, (Pc.trans hcu1).trans subset_closure⟩
       exact closure_minimal hu1v1 hv1.isClosed_compl |>.trans hv1u }
 -- `c.lim = 0` on `closure u` and `c.lim = 1` on `t`, so that `tsupport c.lim ⊆ s`.

--- a/Mathlib/Topology/UrysohnsLemma.lean
+++ b/Mathlib/Topology/UrysohnsLemma.lean
@@ -102,10 +102,12 @@ structure CU {X : Type*} [TopologicalSpace X] (P : Set X → Set X → Sort*) wh
   protected C : Set X
   /-- The outer set in the inductive construction towards Urysohn's lemma -/
   protected U : Set X
+  /-- The proof that `C` and `U` satisfy the property `P C U` -/
   protected P_C_U : P C U
   protected closed_C : IsClosed C
   protected open_U : IsOpen U
   protected subset : C ⊆ U
+  /-- The proof that we can divide `CU` pairs in half -/
   protected hP : ∀ {c u : Set X}, IsClosed c → P c u → IsOpen u → c ⊆ u →
     (v : Set X) ×' IsOpen v ×' c ⊆ v ×' closure v ⊆ u ×' P c v ×' P (closure v) u
 


### PR DESCRIPTION
Modifies Urysohn's lemma to let `P`, the additional property satisfied by the closed set, to also depend on the open set. This is needed for #24096, where it is used to prove that uniform spaces are completely regular, and `P` says that some entourage in the uniformity, when composed with the closed set on both sides, is smaller than the open set.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
