### PR TITLE
[Merged by Bors] - refactor(FieldTheory/IntermediateField): remove instance `IntermediateField.instCoeOutSubtypeMem`

### DIFF
--- a/Mathlib/FieldTheory/Galois/Infinite.lean
+++ b/Mathlib/FieldTheory/Galois/Infinite.lean
@@ -232,27 +232,24 @@ theorem isOpen_iff_finite (L : IntermediateField k K) [IsGalois k K] :
 theorem normal_iff_isGalois (L : IntermediateField k K) [IsGalois k K] :
     L.fixingSubgroup.Normal ↔ IsGalois k L := by
   refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
-  · let f : L → IntermediateField k K := fun x => IntermediateField.lift <|
-      IntermediateField.fixedField <| Subgroup.map (restrictNormalHom (adjoin k {x.1}))
-      L.fixingSubgroup
-    have h' (x : K) : (Subgroup.map (restrictNormalHom (adjoin k {x})) L.fixingSubgroup).Normal :=
+  · let g (x : K) := L.fixingSubgroup.map (restrictNormalHom (adjoin k {x}))
+    let f (x : L) : IntermediateField k K := IntermediateField.lift <|
+      IntermediateField.fixedField <| g x.1
+    have (x : K) : (g x).Normal :=
       Subgroup.Normal.map h (restrictNormalHom (adjoin k {x})) (restrictNormalHom_surjective K)
-    have n' (l : L) : IsGalois k (IntermediateField.fixedField <| Subgroup.map
-      (restrictNormalHom (adjoin k {l.1})) L.fixingSubgroup) := by
-      let _ := IsGalois.of_fixedField_normal_subgroup (Subgroup.map (restrictNormalHom
-        (adjoin k {l.1})) L.fixingSubgroup)
-      let cH := (Subgroup.map (restrictNormalHom (adjoin k {l.1})) L.fixingSubgroup)
-      exact IsGalois.of_algEquiv <| IntermediateField.liftAlgEquiv (IntermediateField.fixedField cH)
-    have n : Normal k ↥(⨆ (l : L), f l) := IntermediateField.normal_iSup k K f
-    have : (⨆ (l : L), f l) = L := by
+    have (l : L) := IsGalois.of_fixedField_normal_subgroup (g l.1)
+    have (l : L) : Normal k (f l) :=
+      Normal.of_algEquiv <| IntermediateField.liftAlgEquiv <| IntermediateField.fixedField (g l.1)
+    have n : Normal k ↥(⨆ l : L, f l) := IntermediateField.normal_iSup k K f
+    have : (⨆ l : L, f l) = L := by
       apply le_antisymm
       · apply iSup_le
         intro l
-        simpa only [f, ← restrict_fixedField L.fixingSubgroup (adjoin k {l.1}),
+        simpa only [f, g, ← restrict_fixedField L.fixingSubgroup (adjoin k {l.1}),
           fixedField_fixingSubgroup L] using inf_le_left
       · intro l hl
-        apply le_iSup f ⟨l,hl⟩
-        simpa only [f, ← restrict_fixedField L.fixingSubgroup (adjoin k {l}),
+        apply le_iSup f ⟨l, hl⟩
+        simpa only [f, g, ← restrict_fixedField L.fixingSubgroup (adjoin k {l}),
           fixedField_fixingSubgroup L, IntermediateField.mem_inf, hl, true_and]
           using adjoin_simple_le_iff.mp le_rfl
     rw [this] at n

--- a/Mathlib/FieldTheory/Galois/Profinite.lean
+++ b/Mathlib/FieldTheory/Galois/Profinite.lean
@@ -148,8 +148,7 @@ theorem restrictNormalHom_continuous (L : IntermediateField k K) [Normal k L] :
   intro N hN
   rw [map_one, krullTopology_mem_nhds_one_iff] at hN
   obtain ⟨L', _, hO⟩ := hN
-  let _ : FiniteDimensional k L' :=
-    Module.Finite.equiv <| AlgEquiv.toLinearEquiv <| IntermediateField.liftAlgEquiv L'
+  have := Module.Finite.equiv <| AlgEquiv.toLinearEquiv <| IntermediateField.liftAlgEquiv L'
   apply mem_nhds_iff.mpr
   use (IntermediateField.lift L').fixingSubgroup
   constructor

--- a/Mathlib/FieldTheory/IntermediateField/Basic.lean
+++ b/Mathlib/FieldTheory/IntermediateField/Basic.lean
@@ -607,10 +607,6 @@ section Tower
 def lift {F : IntermediateField K L} (E : IntermediateField K F) : IntermediateField K L :=
   E.map (val F)
 
-instance {F : IntermediateField K L} :
-    CoeOut (IntermediateField K F) (IntermediateField K L) :=
-  ⟨lift⟩
-
 theorem lift_injective (F : IntermediateField K L) : Function.Injective F.lift :=
   map_injective F.val
 


### PR DESCRIPTION
Zulip discussion: [Working with intermediate fields of intermediate fields](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/.E2.9C.94.20Working.20with.20intermediate.20fields.20of.20intermediate.20fields)


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
