### PR TITLE
[Merged by Bors] - feat(Prod/Lex): prove `Prod.Lex.covBy_iff`

### DIFF
--- a/Mathlib/Algebra/Module/LinearMap/Defs.lean
+++ b/Mathlib/Algebra/Module/LinearMap/Defs.lean
@@ -51,7 +51,7 @@ linear map
 -/
 
 
-assert_not_exists Star DomMulAct Pi.module WCovBy Field
+assert_not_exists Star DomMulAct Pi.module WCovBy.image Field
 
 open Function
 

--- a/Mathlib/Algebra/Module/Submodule/Map.lean
+++ b/Mathlib/Algebra/Module/Submodule/Map.lean
@@ -8,7 +8,6 @@ import Mathlib.Algebra.Group.Subgroup.Map
 import Mathlib.Algebra.Module.Submodule.Basic
 import Mathlib.Algebra.Module.Submodule.Lattice
 import Mathlib.Algebra.Module.Submodule.LinearMap
-import Mathlib.Order.Cover
 
 /-!
 # `map` and `comap` for `Submodule`s

--- a/Mathlib/Data/Fin/FlagRange.lean
+++ b/Mathlib/Data/Fin/FlagRange.lean
@@ -3,8 +3,8 @@ Copyright (c) 2023 Yury Kudryashov. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury Kudryashov
 -/
-import Mathlib.Order.Cover
 import Mathlib.Order.Fin.Basic
+import Mathlib.Order.Preorder.Chain
 
 /-!
 # Range of `f : Fin (n + 1) → α` as a `Flag`

--- a/Mathlib/Data/Prod/Lex.lean
+++ b/Mathlib/Data/Prod/Lex.lean
@@ -70,7 +70,7 @@ instance [LT α] [LT β] [WellFoundedLT α] [WellFoundedLT β] : WellFoundedRela
 /-- Dictionary / lexicographic preorder for pairs. -/
 instance instPreorder (α β : Type*) [Preorder α] [Preorder β] : Preorder (α ×ₗ β) where
   le_refl := refl_of <| Prod.Lex _ _
-  le_trans := fun _ _ _ => trans_of <| Prod.Lex _ _
+  le_trans _ _ _ := trans_of <| Prod.Lex _ _
   lt_iff_le_not_le x₁ x₂ := by aesop (add simp [le_iff, lt_iff, lt_iff_le_not_le])
 
 /-- See also `monotone_fst_ofLex` for a version stated in terms of `Monotone`. -/
@@ -151,7 +151,7 @@ end PartialOrderPreorder
 /-- Dictionary / lexicographic partial order for pairs. -/
 instance instPartialOrder (α β : Type*) [PartialOrder α] [PartialOrder β] :
     PartialOrder (α ×ₗ β) where
-  le_antisymm _ _ := antisymm (r := Prod.Lex _ _)
+  le_antisymm _ _ := antisymm_of (Prod.Lex _ _)
 
 instance instOrdLexProd [Ord α] [Ord β] : Ord (α ×ₗ β) := lexOrd
 

--- a/Mathlib/Data/Prod/Lex.lean
+++ b/Mathlib/Data/Prod/Lex.lean
@@ -68,42 +68,12 @@ instance [LT α] [LT β] [WellFoundedLT α] [WellFoundedLT β] : WellFoundedRela
   ⟨(· < ·), wellFounded_lt⟩
 
 /-- Dictionary / lexicographic preorder for pairs. -/
-instance preorder (α β : Type*) [Preorder α] [Preorder β] : Preorder (α ×ₗ β) :=
-  { Prod.Lex.instLE α β, Prod.Lex.instLT α β with
-    le_refl := refl_of <| Prod.Lex _ _,
-    le_trans := fun _ _ _ => trans_of <| Prod.Lex _ _,
-    lt_iff_le_not_le := fun x₁ x₂ =>
-      match x₁, x₂ with
-      | (a₁, b₁), (a₂, b₂) => by
-        constructor
-        · rintro (⟨_, _, hlt⟩ | ⟨_, hlt⟩)
-          · constructor
-            · exact left _ _ hlt
-            · rintro ⟨⟩
-              · apply lt_asymm hlt; assumption
-              · exact lt_irrefl _ hlt
-          · constructor
-            · right
-              rw [lt_iff_le_not_le] at hlt
-              exact hlt.1
-            · rintro ⟨⟩
-              · apply lt_irrefl a₁
-                assumption
-              · rw [lt_iff_le_not_le] at hlt
-                apply hlt.2
-                assumption
-        · rintro ⟨⟨⟩, h₂r⟩
-          · left
-            assumption
-          · right
-            rw [lt_iff_le_not_le]
-            constructor
-            · assumption
-            · intro h
-              apply h₂r
-              right
-              exact h }
+instance instPreorder (α β : Type*) [Preorder α] [Preorder β] : Preorder (α ×ₗ β) where
+  le_refl := refl_of <| Prod.Lex _ _
+  le_trans := fun _ _ _ => trans_of <| Prod.Lex _ _
+  lt_iff_le_not_le x₁ x₂ := by aesop (add simp [le_iff, lt_iff, lt_iff_le_not_le])
 
+/-- See also `monotone_fst_ofLex` for a version stated in terms of `Monotone`. -/
 theorem monotone_fst [Preorder α] [LE β] (t c : α ×ₗ β) (h : t ≤ c) :
     (ofLex t).1 ≤ (ofLex c).1 := by
   cases toLex_le_toLex.mp h with
@@ -111,6 +81,38 @@ theorem monotone_fst [Preorder α] [LE β] (t c : α ×ₗ β) (h : t ≤ c) :
   | inr h' => exact h'.1.le
 
 section Preorder
+
+variable [Preorder α] [Preorder β]
+
+theorem monotone_fst_ofLex : Monotone fun x : α ×ₗ β ↦ (ofLex x).1 := monotone_fst
+
+theorem toLex_covBy_toLex_iff {a₁ a₂ : α} {b₁ b₂ : β} :
+    toLex (a₁, b₁) ⋖ toLex (a₂, b₂) ↔ a₁ = a₂ ∧ b₁ ⋖ b₂ ∨ a₁ ⋖ a₂ ∧ IsMax b₁ ∧ IsMin b₂ := by
+  simp only [CovBy, toLex_lt_toLex, toLex.surjective.forall, Prod.forall, isMax_iff_forall_not_lt,
+    isMin_iff_forall_not_lt]
+  constructor
+  · rintro ⟨ha | ⟨rfl, hb⟩, h₂⟩
+    · refine .inr ⟨⟨ha, fun c hc₁ hc₂ ↦ ?_⟩, fun c hc ↦ ?_, fun c hc ↦ ?_⟩
+      · exact h₂ c b₁ (.inl hc₁) (.inl hc₂)
+      · exact h₂ a₁ c (.inr ⟨rfl, hc⟩) (.inl ha)
+      · exact h₂ a₂ c (.inl ha) (.inr ⟨rfl, hc⟩)
+    · exact .inl ⟨rfl, hb, fun c hc₁ hc₂ ↦ h₂ _ _ (.inr ⟨rfl, hc₁⟩) (.inr ⟨rfl, hc₂⟩)⟩
+  · rintro (⟨rfl, hb, h⟩ | ⟨⟨ha, h⟩, hb₁, hb₂⟩)
+    · refine ⟨.inr ⟨rfl, hb⟩, fun a b ↦ ?_⟩
+      rintro (hlt₁ | ⟨rfl, hlt₁⟩) (hlt₂ | ⟨heq, hlt₂⟩)
+      exacts [hlt₁.not_lt hlt₂, hlt₁.ne' heq, hlt₂.false, h hlt₁ hlt₂]
+    · refine ⟨.inl ha, fun a b ↦ ?_⟩
+      rintro (hlt₁ | ⟨rfl, hlt₁⟩) (hlt₂ | ⟨heq, hlt₂⟩)
+      exacts [h hlt₁ hlt₂, hb₂ _ hlt₂, hb₁ _ hlt₁, hb₁ _ hlt₁]
+
+theorem covBy_iff {a b : α ×ₗ β} :
+    a ⋖ b ↔ (ofLex a).1 = (ofLex b).1 ∧ (ofLex a).2 ⋖ (ofLex b).2 ∨
+      (ofLex a).1 ⋖ (ofLex b).1 ∧ IsMax (ofLex a).2 ∧ IsMin (ofLex b).2 :=
+  toLex_covBy_toLex_iff
+
+end Preorder
+
+section PartialOrderPreorder
 
 variable [PartialOrder α] [Preorder β] {x y : α × β}
 
@@ -144,14 +146,12 @@ theorem toLex_strictMono : StrictMono (toLex : α × β → α ×ₗ β) := by
   · exact right _ (Prod.mk_lt_mk_iff_right.1 h)
   · exact left _ _ ha
 
-end Preorder
+end PartialOrderPreorder
 
 /-- Dictionary / lexicographic partial order for pairs. -/
-instance partialOrder (α β : Type*) [PartialOrder α] [PartialOrder β] : PartialOrder (α ×ₗ β) where
-  le_antisymm _ _ := by
-    haveI : IsStrictOrder α (· < ·) := { irrefl := lt_irrefl, trans := fun _ _ _ => lt_trans }
-    haveI : IsAntisymm β (· ≤ ·) := ⟨fun _ _ => le_antisymm⟩
-    exact antisymm (r := Prod.Lex _ _)
+instance instPartialOrder (α β : Type*) [PartialOrder α] [PartialOrder β] :
+    PartialOrder (α ×ₗ β) where
+  le_antisymm _ _ := antisymm (r := Prod.Lex _ _)
 
 instance instOrdLexProd [Ord α] [Ord β] : Ord (α ×ₗ β) := lexOrd
 
@@ -169,8 +169,8 @@ instance [Ord α] [Ord β] [TransOrd α] [TransOrd β] : TransOrd (α ×ₗ β) 
   inferInstanceAs (TransCmp (compareLex _ _))
 
 /-- Dictionary / lexicographic linear order for pairs. -/
-instance linearOrder (α β : Type*) [LinearOrder α] [LinearOrder β] : LinearOrder (α ×ₗ β) :=
-  { Prod.Lex.partialOrder α β with
+instance instLinearOrder (α β : Type*) [LinearOrder α] [LinearOrder β] : LinearOrder (α ×ₗ β) :=
+  { Prod.Lex.instPartialOrder α β with
     le_total := total_of (Prod.Lex _ _)
     toDecidableLE := Prod.Lex.decidable _ _
     toDecidableLT := Prod.Lex.decidable _ _

--- a/Mathlib/Order/Cover.lean
+++ b/Mathlib/Order/Cover.lean
@@ -11,10 +11,11 @@ import Mathlib.Order.Interval.Set.WithBotTop
 /-!
 # The covering relation
 
-This file defines the covering relation in an order. `b` is said to cover `a` if `a < b` and there
-is no element in between. We say that `b` weakly covers `a` if `a ≤ b` and there is no element
-between `a` and `b`. In a partial order this is equivalent to `a ⋖ b ∨ a = b`, in a preorder this
-is equivalent to `a ⋖ b ∨ (a ≤ b ∧ b ≤ a)`
+This file proves properties of the covering relation in an order.
+We say that `b` *covers* `a` if `a < b` and there is no element in between.
+We say that `b` *weakly covers* `a` if `a ≤ b` and there is no element between `a` and `b`.
+In a partial order this is equivalent to `a ⋖ b ∨ a = b`,
+in a preorder this is equivalent to `a ⋖ b ∨ (a ≤ b ∧ b ≤ a)`
 
 ## Notation
 
@@ -32,15 +33,6 @@ section WeaklyCovers
 section Preorder
 
 variable [Preorder α] [Preorder β] {a b c : α}
-
-/-- `WCovBy a b` means that `a = b` or `b` covers `a`.
-This means that `a ≤ b` and there is no element in between.
--/
-def WCovBy (a b : α) : Prop :=
-  a ≤ b ∧ ∀ ⦃c⦄, a < c → ¬c < b
-
-/-- Notation for `WCovBy a b`. -/
-infixl:50 " ⩿ " => WCovBy
 
 theorem WCovBy.le (h : a ⩿ b) : a ≤ b :=
   h.1
@@ -196,13 +188,6 @@ end WeaklyCovers
 section LT
 
 variable [LT α] {a b : α}
-
-/-- `CovBy a b` means that `b` covers `a`: `a < b` and there is no element in between. -/
-def CovBy (a b : α) : Prop :=
-  a < b ∧ ∀ ⦃c⦄, a < c → ¬c < b
-
-/-- Notation for `CovBy a b`. -/
-infixl:50 " ⋖ " => CovBy
 
 theorem CovBy.lt (h : a ⋖ b) : a < b :=
   h.1

--- a/Mathlib/Order/Defs/PartialOrder.lean
+++ b/Mathlib/Order/Defs/PartialOrder.lean
@@ -14,6 +14,17 @@ import Mathlib.Tactic.TypeStar
 
 Defines classes for preorders and partial orders
 and proves some basic lemmas about them.
+
+We also define covering relations on a preorder.
+We say that `b` *covers* `a` if `a < b` and there is no element in between.
+We say that `b` *weakly covers* `a` if `a ≤ b` and there is no element between `a` and `b`.
+In a partial order this is equivalent to `a ⋖ b ∨ a = b`,
+in a preorder this is equivalent to `a ⋖ b ∨ (a ≤ b ∧ b ≤ a)`
+
+## Notation
+
+* `a ⋖ b` means that `b` covers `a`.
+* `a ⩿ b` means that `b` weakly covers `a`.
 -/
 
 variable {α : Type*}
@@ -99,6 +110,22 @@ def decidableLTOfDecidableLE [DecidableLE α] : DecidableLT α
       if hba : b ≤ a then isFalse fun hab' => not_le_of_gt hab' hba
       else isTrue <| lt_of_le_not_le hab hba
     else isFalse fun hab' => hab (le_of_lt hab')
+
+/-- `WCovBy a b` means that `a = b` or `b` covers `a`.
+This means that `a ≤ b` and there is no element in between.
+-/
+def WCovBy (a b : α) : Prop :=
+  a ≤ b ∧ ∀ ⦃c⦄, a < c → ¬c < b
+
+/-- Notation for `WCovBy a b`. -/
+infixl:50 " ⩿ " => WCovBy
+
+/-- `CovBy a b` means that `b` covers `a`: `a < b` and there is no element in between. -/
+def CovBy {α : Type*} [LT α] (a b : α) : Prop :=
+  a < b ∧ ∀ ⦃c⦄, a < c → ¬c < b
+
+/-- Notation for `CovBy a b`. -/
+infixl:50 " ⋖ " => CovBy
 
 end Preorder
 


### PR DESCRIPTION
Also

- move the definitions of `CovBy` and `WCovBy` to `Defs/PartialOrder`;
- rename instances to use `inst*`;
- golf a proof using `aesop`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
