### PR TITLE
[Merged by Bors] - chore(AlgebraicTopology/ExtraDegeneracy): use `Matrix.vecCons`

### DIFF
--- a/Mathlib/AlgebraicTopology/ExtraDegeneracy.lean
+++ b/Mathlib/AlgebraicTopology/ExtraDegeneracy.lean
@@ -152,23 +152,22 @@ namespace Augmented
 
 namespace StandardSimplex
 
-/-- When `[HasZero X]`, the shift of a map `f : Fin n → X`
+/-- When `[Zero X]`, the shift of a map `f : Fin n → X`
 is a map `Fin (n+1) → X` which sends `0` to `0` and `i.succ` to `f i`. -/
 def shiftFun {n : ℕ} {X : Type*} [Zero X] (f : Fin n → X) (i : Fin (n + 1)) : X :=
-  dite (i = 0) (fun _ => 0) fun h => f (i.pred h)
+  Matrix.vecCons 0 f i
 
 @[simp]
-theorem shiftFun_0 {n : ℕ} {X : Type*} [Zero X] (f : Fin n → X) : shiftFun f 0 = 0 :=
+theorem shiftFun_zero {n : ℕ} {X : Type*} [Zero X] (f : Fin n → X) : shiftFun f 0 = 0 :=
   rfl
+
+@[deprecated (since := "2025-04-19")]
+alias shiftFun_0 := shiftFun_zero
 
 @[simp]
 theorem shiftFun_succ {n : ℕ} {X : Type*} [Zero X] (f : Fin n → X) (i : Fin n) :
-    shiftFun f i.succ = f i := by
-  dsimp [shiftFun]
-  split_ifs with h
-  · exfalso
-    simp only [Fin.ext_iff, Fin.val_succ, Fin.val_zero, add_eq_zero, and_false, reduceCtorEq] at h
-  · simp only [Fin.pred_succ]
+    shiftFun f i.succ = f i :=
+  rfl
 
 /-- The shift of a morphism `f : ⦋n⦌ → Δ` in `SimplexCategory` corresponds to
 the monotone map which sends `0` to `0` and `i.succ` to `f.toOrderHom i`. -/
@@ -179,7 +178,7 @@ def shift {n : ℕ} {Δ : SimplexCategory} (f : ⦋n⦌ ⟶ Δ) : ⦋n + 1⦌ �
       monotone' := fun i₁ i₂ hi => by
         by_cases h₁ : i₁ = 0
         · subst h₁
-          simp only [shiftFun_0, Fin.zero_le]
+          simp only [shiftFun_zero, Fin.zero_le]
         · have h₂ : i₂ ≠ 0 := by
             intro h₂
             subst h₂
@@ -212,7 +211,6 @@ protected noncomputable def extraDegeneracy (Δ : SimplexCategory) :
     ext i : 2
     dsimp [SimplicialObject.δ, SimplexCategory.δ, SSet.stdSimplex,
       objEquiv, Equiv.ulift, uliftFunctor]
-    simp only [shiftFun_succ]
   s_comp_δ n i := by
     ext1 φ
     apply objEquiv.injective
@@ -222,7 +220,7 @@ protected noncomputable def extraDegeneracy (Δ : SimplexCategory) :
       objEquiv, Equiv.ulift, uliftFunctor]
     by_cases h : j = 0
     · subst h
-      simp only [Fin.succ_succAbove_zero, shiftFun_0]
+      simp only [Fin.succ_succAbove_zero, shiftFun_zero]
     · obtain ⟨_, rfl⟩ := Fin.eq_succ_of_ne_zero <| h
       simp only [Fin.succ_succAbove_succ, shiftFun_succ, Function.comp_apply,
         Fin.succAboveOrderEmb_apply]


### PR DESCRIPTION
Cherry-picked from #24196

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)