### PR TITLE
[Merged by Bors] - feat (Topology/Algebra/RestrictedProduct): add API

### DIFF
--- a/Mathlib/Topology/Algebra/RestrictedProduct.lean
+++ b/Mathlib/Topology/Algebra/RestrictedProduct.lean
@@ -299,6 +299,11 @@ def evalMonoidHom (j : ι) [Π i, Monoid (R i)] [∀ i, SubmonoidClass (S i) (R 
   map_one' := rfl
   map_mul' _ _ := rfl
 
+@[simp]
+lemma evalMonoidHom_apply [Π i, Monoid (R i)] [∀ i, SubmonoidClass (S i) (R i)]
+    (x : Πʳ i, [R i, B i]_[𝓕]) (j : ι) : evalMonoidHom R j x = x j :=
+  rfl
+
 /-- `RestrictedProduct.evalRingHom j` is the ring homomorphism from the restricted
 product `Πʳ i, [R i, B i]_[𝓕]` to the component `R j`.
 -/
@@ -306,6 +311,11 @@ def evalRingHom (j : ι) [Π i, Ring (R i)] [∀ i, SubringClass (S i) (R i)] :
     (Πʳ i, [R i, B i]_[𝓕]) →+* R j where
   __ := evalMonoidHom R j
   __ := evalAddMonoidHom R j
+
+@[simp]
+lemma evalRingHom_apply [Π i, Ring (R i)] [∀ i, SubringClass (S i) (R i)]
+    (x : Πʳ i, [R i, B i]_[𝓕]) (j : ι) : evalRingHom R j x = x j :=
+  rfl
 
 end eval
 
@@ -325,7 +335,7 @@ section set
 variable (φ : ∀ j, R₁ (f j) → R₂ j) (hφ : ∀ᶠ j in 𝓕₂, A₁ (f j) ⊆ φ j ⁻¹' A₂ j)
 
 /--
-Given two restricted products `Πʳ (i : ι₁), [R₁ i, B₁ i]_[𝓕₁]` and `Πʳ (j : ι₂), [R₂ j, B₂ j]_[𝓕₂]`,
+Given two restricted products `Πʳ (i : ι₁), [R₁ i, A₁ i]_[𝓕₁]` and `Πʳ (j : ι₂), [R₂ j, A₂ j]_[𝓕₂]`,
 `RestrictedProduct.map` gives a function between them. The data needed is a function `f : ι₂ → ι₁`
 such that `𝓕₂` tends to `𝓕₁` along `f`, and functions `φ j : R₁ (f j) → R₂ j`
 sending `A₁ (f j)` into `A₂ j` for an `𝓕₂`-large set of `j`'s.
@@ -334,6 +344,22 @@ See also `mapMonoidHom`, `mapAddMonoidHom` and `mapRingHom` for variants.
 -/
 def map (x : Πʳ i, [R₁ i, A₁ i]_[𝓕₁]) : Πʳ j, [R₂ j, A₂ j]_[𝓕₂] := ⟨fun j ↦ φ j (x (f j)), by
   filter_upwards [hf.eventually x.2, hφ] using fun _ h1 h2 ↦ h2 h1⟩
+
+lemma map_id (x : Πʳ i, [R₁ i, A₁ i]_[𝓕₁]) : map R₁ R₁ id
+  (fun ⦃_⦄ a ↦ a : Tendsto id 𝓕₁ 𝓕₁) (fun _ t ↦ t)
+  (Eventually.of_forall fun _ ↦ (fun ⦃_⦄ a ↦ a)) x = x := rfl
+
+lemma map_comp {ι₃} (R₃ : ι₃ → Type*) {𝓕₃ : Filter ι₃} {A₃ : (i : ι₃) → Set (R₃ i)} (g : ι₃ → ι₂)
+    (hg : Tendsto g 𝓕₃ 𝓕₂) (ψ : ∀ k, R₂ (g k) → R₃ k) (hψ : ∀ᶠ k in 𝓕₃, A₂ (g k) ⊆ ψ k ⁻¹' A₃ k) :
+    map R₁ R₃ (f ∘ g) (hf.comp hg) (fun k t ↦ ψ k (φ (g k) t)) (by
+      filter_upwards [hψ, hg hφ] with k h23 h12 t ht1
+      exact h23 (h12 ht1)) =
+    (map R₂ R₃ g hg ψ hψ) ∘ (map R₁ R₂ f hf φ hφ) := rfl
+
+@[simp]
+lemma map_apply (x : Πʳ i, [R₁ i, A₁ i]_[𝓕₁]) (j : ι₂) :
+    x.map R₁ R₂ f hf φ hφ j = φ j (x (f j)) :=
+  rfl
 
 end set
 
@@ -365,6 +391,11 @@ def mapMonoidHom : Πʳ i, [R₁ i, B₁ i]_[𝓕₁] →* Πʳ j, [R₂ j, B₂
     ext i
     exact map_mul (φ i) _ _
 
+@[to_additive (attr := simp)]
+lemma mapMonoidHom_apply (x : Πʳ i, [R₁ i, B₁ i]_[𝓕₁]) (j : ι₂) :
+    x.mapMonoidHom R₁ R₂ f hf φ hφ j = φ j (x (f j)) :=
+  rfl
+
 end monoid
 
 section ring
@@ -382,6 +413,11 @@ function `f : ι₂ → ι₁` such that `𝓕₂` tends to `𝓕₁` along `f`,
 def mapRingHom : Πʳ i, [R₁ i, B₁ i]_[𝓕₁] →+* Πʳ j, [R₂ j, B₂ j]_[𝓕₂] where
   __ := mapMonoidHom R₁ R₂ f hf (fun j ↦ φ j) hφ
   __ := mapAddMonoidHom R₁ R₂ f hf (fun j ↦ φ j) hφ
+
+@[simp]
+lemma mapRingHom_apply (x : Πʳ i, [R₁ i, B₁ i]_[𝓕₁]) (j : ι₂) :
+    x.mapRingHom R₁ R₂ f hf φ hφ j = φ j (x (f j)) :=
+  rfl
 
 end ring
 
@@ -713,7 +749,7 @@ theorem continuous_dom_prod_right {X Y : Type*} [TopologicalSpace X] [Topologica
   have hxS : ∀ i ∈ S, x i ∈ A i := fun i hi ↦ hi
   rcases exists_inclusion_eq_of_eventually R A hS hxS with ⟨x', hxx'⟩
   rw [← hxx', nhds_prod_eq, nhds_eq_map_inclusion hAopen hS x',
-    ← map_id (f := 𝓝 y), prod_map_map_eq, ← nhds_prod_eq, tendsto_map'_iff]
+    ← Filter.map_id (f := 𝓝 y), prod_map_map_eq, ← nhds_prod_eq, tendsto_map'_iff]
   exact H S hS |>.tendsto ⟨x', y⟩
 
 -- TODO: get from the previous one instead of copy-pasting
@@ -734,7 +770,7 @@ theorem continuous_dom_prod_left {X Y : Type*} [TopologicalSpace X] [Topological
   have hxS : ∀ i ∈ S, x i ∈ A i := fun i hi ↦ hi
   rcases exists_inclusion_eq_of_eventually R A hS hxS with ⟨x', hxx'⟩
   rw [← hxx', nhds_prod_eq, nhds_eq_map_inclusion hAopen hS x',
-    ← map_id (f := 𝓝 y), prod_map_map_eq, ← nhds_prod_eq, tendsto_map'_iff]
+    ← Filter.map_id (f := 𝓝 y), prod_map_map_eq, ← nhds_prod_eq, tendsto_map'_iff]
   exact H S hS |>.tendsto ⟨y, x'⟩
 
 include hAopen in

--- a/Mathlib/Topology/Algebra/RestrictedProduct.lean
+++ b/Mathlib/Topology/Algebra/RestrictedProduct.lean
@@ -345,17 +345,6 @@ See also `mapMonoidHom`, `mapAddMonoidHom` and `mapRingHom` for variants.
 def map (x : Πʳ i, [R₁ i, A₁ i]_[𝓕₁]) : Πʳ j, [R₂ j, A₂ j]_[𝓕₂] := ⟨fun j ↦ φ j (x (f j)), by
   filter_upwards [hf.eventually x.2, hφ] using fun _ h1 h2 ↦ h2 h1⟩
 
-lemma map_id (x : Πʳ i, [R₁ i, A₁ i]_[𝓕₁]) : map R₁ R₁ id
-  (fun ⦃_⦄ a ↦ a : Tendsto id 𝓕₁ 𝓕₁) (fun _ t ↦ t)
-  (Eventually.of_forall fun _ ↦ (fun ⦃_⦄ a ↦ a)) x = x := rfl
-
-lemma map_comp {ι₃} (R₃ : ι₃ → Type*) {𝓕₃ : Filter ι₃} {A₃ : (i : ι₃) → Set (R₃ i)} (g : ι₃ → ι₂)
-    (hg : Tendsto g 𝓕₃ 𝓕₂) (ψ : ∀ k, R₂ (g k) → R₃ k) (hψ : ∀ᶠ k in 𝓕₃, A₂ (g k) ⊆ ψ k ⁻¹' A₃ k) :
-    map R₁ R₃ (f ∘ g) (hf.comp hg) (fun k t ↦ ψ k (φ (g k) t)) (by
-      filter_upwards [hψ, hg hφ] with k h23 h12 t ht1
-      exact h23 (h12 ht1)) =
-    (map R₂ R₃ g hg ψ hψ) ∘ (map R₁ R₂ f hf φ hφ) := rfl
-
 @[simp]
 lemma map_apply (x : Πʳ i, [R₁ i, A₁ i]_[𝓕₁]) (j : ι₂) :
     x.map R₁ R₂ f hf φ hφ j = φ j (x (f j)) :=

--- a/Mathlib/Topology/Algebra/RestrictedProduct.lean
+++ b/Mathlib/Topology/Algebra/RestrictedProduct.lean
@@ -282,27 +282,27 @@ instance [Π i, Ring (R i)] [∀ i, SubringClass (S i) (R i)] :
 
 end Algebra
 
-section projection
+section eval
 
 variable {S : ι → Type*}
 variable [Π i, SetLike (S i) (R i)]
 variable {B : Π i, S i}
 
-def projection (j : ι) (x : Πʳ i, [R i, B i]_[𝓕]) : R j := x j
+def eval (j : ι) (x : Πʳ i, [R i, B i]_[𝓕]) : R j := x j
 
 @[to_additive]
-def projectionMonoidHom (j : ι) [Π i, Monoid (R i)] [∀ i, SubmonoidClass (S i) (R i)] :
+def evalMonoidHom (j : ι) [Π i, Monoid (R i)] [∀ i, SubmonoidClass (S i) (R i)] :
     (Πʳ i, [R i, B i]_[𝓕]) →* R j where
-      toFun := projection R j
+      toFun := eval R j
       map_one' := rfl
       map_mul' _ _ := rfl
 
-def projectionRingHom (j : ι) [Π i, Ring (R i)] [∀ i, SubringClass (S i) (R i)] :
+def evalRingHom (j : ι) [Π i, Ring (R i)] [∀ i, SubringClass (S i) (R i)] :
     (Πʳ i, [R i, B i]_[𝓕]) →+* R j where
-      __ := projectionMonoidHom R j
-      __ := projectionAddMonoidHom R j
+      __ := evalMonoidHom R j
+      __ := evalAddMonoidHom R j
 
-end projection
+end eval
 
 section map
 

--- a/Mathlib/Topology/Algebra/RestrictedProduct.lean
+++ b/Mathlib/Topology/Algebra/RestrictedProduct.lean
@@ -332,7 +332,7 @@ variable (f : ι₂ → ι₁) (hf : Tendsto f 𝓕₂ 𝓕₁)
 
 section set
 
-variable (φ : ∀ j, R₁ (f j) → R₂ j) (hφ : ∀ᶠ j in 𝓕₂, A₁ (f j) ⊆ φ j ⁻¹' A₂ j)
+variable (φ : ∀ j, R₁ (f j) → R₂ j) (hφ : ∀ᶠ j in 𝓕₂, (A₁ (f j)).MapsTo (φ j) (A₂ j))
 
 /--
 Given two restricted products `Πʳ (i : ι₁), [R₁ i, A₁ i]_[𝓕₁]` and `Πʳ (j : ι₂), [R₂ j, A₂ j]_[𝓕₂]`,

--- a/Mathlib/Topology/Algebra/RestrictedProduct.lean
+++ b/Mathlib/Topology/Algebra/RestrictedProduct.lean
@@ -149,17 +149,21 @@ namespace RestrictedProduct
 
 open scoped RestrictedProduct
 
-variable {𝓕 𝓖 : Filter ι} {S T : Set ι}
+variable {𝓕 𝓖 : Filter ι}
 
 instance : DFunLike (Πʳ i, [R i, A i]_[𝓕]) ι R where
   coe x i := x.1 i
   coe_injective' _ _ := Subtype.ext
 
+@[ext]
+lemma ext {x y :  Πʳ i, [R i, A i]_[𝓕]} (h : ∀ i, x i = y i) : x = y :=
+  Subtype.ext <| funext h
+
 lemma range_coe :
     range ((↑) : Πʳ i, [R i, A i]_[𝓕] → Π i, R i) = {x | ∀ᶠ i in 𝓕, x i ∈ A i} :=
   Subtype.range_val_subtype
 
-lemma range_coe_principal :
+lemma range_coe_principal {S : Set ι} :
     range ((↑) : Πʳ i, [R i, A i]_[𝓟 S] → Π i, R i) = S.pi A :=
   range_coe R A
 
@@ -236,6 +240,16 @@ instance [Π i, Monoid (R i)] [∀ i, SubmonoidClass (S i) (R i)] :
     Pow (Πʳ i, [R i, B i]_[𝓕]) ℕ where
   pow x n := ⟨fun i ↦ x i ^ n, x.2.mono fun _ hi ↦ pow_mem hi n⟩
 
+instance [Π i, AddMonoid (R i)] [∀ i, AddSubmonoidClass (S i) (R i)] :
+    AddMonoid (Πʳ i, [R i, B i]_[𝓕]) :=
+  haveI : ∀ i, SMulMemClass (S i) ℕ (R i) := fun _ ↦ AddSubmonoidClass.nsmulMemClass
+  DFunLike.coe_injective.addMonoid _ rfl (fun _ _ ↦ rfl) (fun _ _ ↦ rfl)
+
+@[to_additive existing]
+instance [Π i, Monoid (R i)] [∀ i, SubmonoidClass (S i) (R i)] :
+    Monoid (Πʳ i, [R i, B i]_[𝓕]) :=
+  DFunLike.coe_injective.monoid _ rfl (fun _ _ ↦ rfl) (fun _ _ ↦ rfl)
+
 instance [Π i, DivInvMonoid (R i)] [∀ i, SubgroupClass (S i) (R i)] :
     Pow (Πʳ i, [R i, B i]_[𝓕]) ℤ where
   pow x n := ⟨fun i ↦ x i ^ n, x.2.mono fun _ hi ↦ zpow_mem hi n⟩
@@ -267,6 +281,82 @@ instance [Π i, Ring (R i)] [∀ i, SubringClass (S i) (R i)] :
     (fun _ _ ↦ rfl) (fun _ _ ↦ rfl) (fun _ _ ↦ rfl) (fun _ _ ↦ rfl) (fun _ ↦ rfl) (fun _ ↦ rfl)
 
 end Algebra
+
+section projection
+
+variable {S : ι → Type*}
+variable [Π i, SetLike (S i) (R i)]
+variable {B : Π i, S i}
+
+def projection (j : ι) (x : Πʳ i, [R i, B i]_[𝓕]) : R j := x j
+
+@[to_additive]
+def projectionMonoidHom (j : ι) [Π i, Monoid (R i)] [∀ i, SubmonoidClass (S i) (R i)] :
+    (Πʳ i, [R i, B i]_[𝓕]) →* R j where
+      toFun := projection R j
+      map_one' := rfl
+      map_mul' _ _ := rfl
+
+def projectionRingHom (j : ι) [Π i, Ring (R i)] [∀ i, SubringClass (S i) (R i)] :
+    (Πʳ i, [R i, B i]_[𝓕]) →+* R j where
+      __ := projectionMonoidHom R j
+      __ := projectionAddMonoidHom R j
+
+end projection
+
+section map
+
+variable {ι₁ ι₂ : Type*}
+variable (R₁ : ι₁ → Type*) (R₂ : ι₂ → Type*)
+variable {𝓕₁ : Filter ι₁} {𝓕₂ : Filter ι₂}
+variable {S₁ : ι₁ → Type*} {S₂ : ι₂ → Type*}
+variable [Π i, SetLike (S₁ i) (R₁ i)] [Π j, SetLike (S₂ j) (R₂ j)]
+variable {B₁ : Π i, S₁ i} {B₂ : Π j, S₂ j}
+variable (f : ι₂ → ι₁) (hf : 𝓕₂.Tendsto f 𝓕₁)
+
+section set
+
+variable (φ : ∀ j, R₁ (f j) → R₂ j) (hφ : ∀ᶠ j in 𝓕₂, φ j '' B₁ (f j) ⊆ B₂ j)
+
+def map (x : Πʳ i, [R₁ i, B₁ i]_[𝓕₁]) : Πʳ j, [R₂ j, B₂ j]_[𝓕₂] := ⟨fun j ↦ φ j (x (f j)), by
+  apply mem_of_superset (𝓕₂.inter_mem hφ (hf x.2))
+  simp only [image_subset_iff, SetLike.mem_coe, preimage_setOf_eq]
+  rintro _ ⟨h1, h2⟩
+  exact h1 h2
+  ⟩
+end set
+
+section monoid
+
+variable [Π i, Monoid (R₁ i)] [Π i, Monoid (R₂ i)] [∀ i, SubmonoidClass (S₁ i) (R₁ i)]
+    [∀ i, SubmonoidClass (S₂ i) (R₂ i)] (φ : ∀ j, R₁ (f j) →* R₂ j)
+    (hφ : ∀ᶠ j in 𝓕₂, (φ j) '' (B₁ (f j)) ≤ B₂ j)
+
+@[to_additive]
+def mapMonoidHom : Πʳ i, [R₁ i, B₁ i]_[𝓕₁] →* Πʳ j, [R₂ j, B₂ j]_[𝓕₂] where
+  toFun := map R₁ R₂ f hf (fun j r ↦ φ j r) hφ
+  map_one' := by
+    ext i
+    exact map_one (φ i)
+  map_mul' x y := by
+    ext i
+    exact map_mul (φ i) _ _
+
+end monoid
+
+section ring
+
+variable [Π i, Ring (R₁ i)] [Π i, Ring (R₂ i)] [∀ i, SubringClass (S₁ i) (R₁ i)]
+    [∀ i, SubringClass (S₂ i) (R₂ i)] (φ : ∀ j, R₁ (f j) →+* R₂ j)
+    (hφ : ∀ᶠ j in 𝓕₂, (φ j) '' (B₁ (f j)) ≤ B₂ j)
+
+def mapRingHom : Πʳ i, [R₁ i, B₁ i]_[𝓕₁] →+* Πʳ j, [R₂ j, B₂ j]_[𝓕₂] where
+  __ := mapMonoidHom R₁ R₂ f hf (fun j ↦ φ j) hφ
+  __ := mapAddMonoidHom R₁ R₂ f hf (fun j ↦ φ j) hφ
+
+end ring
+
+end map
 
 section Topology
 /-!
@@ -545,13 +635,13 @@ theorem isOpenEmbedding_structureMap :
 include hAopen in
 theorem nhds_eq_map_inclusion {S : Set ι} (hS : cofinite ≤ 𝓟 S)
     (x : Πʳ i, [R i, A i]_[𝓟 S]) :
-    (𝓝 (inclusion R A hS x)) = map (inclusion R A hS) (𝓝 x) := by
+    (𝓝 (inclusion R A hS x)) = (𝓝 x).map (inclusion R A hS) := by
   rw [isOpenEmbedding_inclusion_principal hAopen hS |>.map_nhds_eq x]
 
 include hAopen in
 theorem nhds_eq_map_structureMap
     (x : Π i, A i) :
-    (𝓝 (structureMap R A cofinite x)) = map (structureMap R A cofinite) (𝓝 x) := by
+    (𝓝 (structureMap R A cofinite x)) = (𝓝 x).map (structureMap R A cofinite) := by
   rw [isOpenEmbedding_structureMap hAopen |>.map_nhds_eq x]
 
 include hAopen in
@@ -707,13 +797,13 @@ section cofinite
 
 theorem nhds_zero_eq_map_ofPre [Π i, Zero (R i)] [∀ i, ZeroMemClass (S i) (R i)]
     (hBopen : ∀ i, IsOpen (B i : Set (R i))) (hT : cofinite ≤ 𝓟 T) :
-    (𝓝 (inclusion R (fun i ↦ B i) hT 0)) = map (inclusion R (fun i ↦ B i) hT) (𝓝 0) :=
+    (𝓝 (inclusion R (fun i ↦ B i) hT 0)) = (𝓝 0).map (inclusion R (fun i ↦ B i) hT) :=
   nhds_eq_map_inclusion hBopen hT 0
 
 theorem nhds_zero_eq_map_structureMap [Π i, Zero (R i)] [∀ i, ZeroMemClass (S i) (R i)]
     (hBopen : ∀ i, IsOpen (B i : Set (R i))) :
     (𝓝 (structureMap R (fun i ↦ B i) cofinite 0)) =
-      map (structureMap R (fun i ↦ B i) cofinite) (𝓝 0) :=
+       (𝓝 0).map (structureMap R (fun i ↦ B i) cofinite) :=
   nhds_eq_map_structureMap hBopen 0
 
 -- TODO: Make `IsOpen` a class like `IsClosed` ?

--- a/Mathlib/Topology/Algebra/RestrictedProduct.lean
+++ b/Mathlib/Topology/Algebra/RestrictedProduct.lean
@@ -834,7 +834,7 @@ theorem nhds_zero_eq_map_ofPre [Π i, Zero (R i)] [∀ i, ZeroMemClass (S i) (R 
 theorem nhds_zero_eq_map_structureMap [Π i, Zero (R i)] [∀ i, ZeroMemClass (S i) (R i)]
     (hBopen : ∀ i, IsOpen (B i : Set (R i))) :
     (𝓝 (structureMap R (fun i ↦ B i) cofinite 0)) =
-       .map (structureMap R (fun i ↦ B i) cofinite) (𝓝 0) :=
+      .map (structureMap R (fun i ↦ B i) cofinite) (𝓝 0) :=
   nhds_eq_map_structureMap hBopen 0
 
 -- TODO: Make `IsOpen` a class like `IsClosed` ?

--- a/Mathlib/Topology/Algebra/RestrictedProduct.lean
+++ b/Mathlib/Topology/Algebra/RestrictedProduct.lean
@@ -288,13 +288,6 @@ variable {S : ι → Type*}
 variable [Π i, SetLike (S i) (R i)]
 variable {B : Π i, S i}
 
-/-- `RestrictedProduct.eval j` is the function from the restricted
-product `Πʳ i, [R i, B i]_[𝓕]` to the
-component `R j`. See also `evalMonoidHom`, `evalAddMonoidHom` and `evalRingHom` for
-evaluation as a monoid or ring homomorphism when `R i` is a monoid or ring.
--/
-def eval (j : ι) (x : Πʳ i, [R i, B i]_[𝓕]) : R j := x j
-
 /-- `RestrictedProduct.evalMonoidHom j` is the monoid homomorphism from the restricted
 product `Πʳ i, [R i, B i]_[𝓕]` to the component `R j`.
 -/
@@ -302,17 +295,17 @@ product `Πʳ i, [R i, B i]_[𝓕]` to the component `R j`.
 product `Πʳ i, [R i, B i]_[𝓕]` to the component `R j`."]
 def evalMonoidHom (j : ι) [Π i, Monoid (R i)] [∀ i, SubmonoidClass (S i) (R i)] :
     (Πʳ i, [R i, B i]_[𝓕]) →* R j where
-      toFun := eval R j
-      map_one' := rfl
-      map_mul' _ _ := rfl
+  toFun x := x j
+  map_one' := rfl
+  map_mul' _ _ := rfl
 
 /-- `RestrictedProduct.evalRingHom j` is the ring homomorphism from the restricted
 product `Πʳ i, [R i, B i]_[𝓕]` to the component `R j`.
 -/
 def evalRingHom (j : ι) [Π i, Ring (R i)] [∀ i, SubringClass (S i) (R i)] :
     (Πʳ i, [R i, B i]_[𝓕]) →+* R j where
-      __ := evalMonoidHom R j
-      __ := evalAddMonoidHom R j
+  __ := evalMonoidHom R j
+  __ := evalAddMonoidHom R j
 
 end eval
 
@@ -343,8 +336,8 @@ def map (x : Πʳ i, [R₁ i, A₁ i]_[𝓕₁]) : Πʳ j, [R₂ j, A₂ j]_[�
   apply mem_of_superset (𝓕₂.inter_mem hφ (hf x.2))
   simp only [SetLike.mem_coe, preimage_setOf_eq]
   rintro _ ⟨h1, h2⟩
-  exact h1 h2
-  ⟩
+  exact h1 h2⟩
+
 end set
 
 section monoid

--- a/Mathlib/Topology/Algebra/RestrictedProduct.lean
+++ b/Mathlib/Topology/Algebra/RestrictedProduct.lean
@@ -288,15 +288,27 @@ variable {S : ι → Type*}
 variable [Π i, SetLike (S i) (R i)]
 variable {B : Π i, S i}
 
+/-- `RestrictedProduct.eval j` is the function from the restricted
+product `Πʳ i, [R i, B i]_[𝓕]` to the
+component `R j`. See also `evalMonoidHom`, `evalAddMonoidHom` and `evalRingHom` for
+evaluation as a monoid or ring homomorphism when `R i` is a monoid or ring.
+-/
 def eval (j : ι) (x : Πʳ i, [R i, B i]_[𝓕]) : R j := x j
 
-@[to_additive]
+/-- `RestrictedProduct.evalMonoidHom j` is the monoid homomorphism from the restricted
+product `Πʳ i, [R i, B i]_[𝓕]` to the component `R j`.
+-/
+@[to_additive "`RestrictedProduct.evalAddMonoidHom j` is the monoid homomorphism from the restricted
+product `Πʳ i, [R i, B i]_[𝓕]` to the component `R j`."]
 def evalMonoidHom (j : ι) [Π i, Monoid (R i)] [∀ i, SubmonoidClass (S i) (R i)] :
     (Πʳ i, [R i, B i]_[𝓕]) →* R j where
       toFun := eval R j
       map_one' := rfl
       map_mul' _ _ := rfl
 
+/-- `RestrictedProduct.evalRingHom j` is the ring homomorphism from the restricted
+product `Πʳ i, [R i, B i]_[𝓕]` to the component `R j`.
+-/
 def evalRingHom (j : ι) [Π i, Ring (R i)] [∀ i, SubringClass (S i) (R i)] :
     (Πʳ i, [R i, B i]_[𝓕]) →+* R j where
       __ := evalMonoidHom R j
@@ -309,6 +321,7 @@ section map
 variable {ι₁ ι₂ : Type*}
 variable (R₁ : ι₁ → Type*) (R₂ : ι₂ → Type*)
 variable {𝓕₁ : Filter ι₁} {𝓕₂ : Filter ι₂}
+variable {A₁ : (i : ι₁) → Set (R₁ i)} {A₂ : (i : ι₂) → Set (R₂ i)}
 variable {S₁ : ι₁ → Type*} {S₂ : ι₂ → Type*}
 variable [Π i, SetLike (S₁ i) (R₁ i)] [Π j, SetLike (S₂ j) (R₂ j)]
 variable {B₁ : Π i, S₁ i} {B₂ : Π j, S₂ j}
@@ -316,11 +329,19 @@ variable (f : ι₂ → ι₁) (hf : 𝓕₂.Tendsto f 𝓕₁)
 
 section set
 
-variable (φ : ∀ j, R₁ (f j) → R₂ j) (hφ : ∀ᶠ j in 𝓕₂, φ j '' B₁ (f j) ⊆ B₂ j)
+variable (φ : ∀ j, R₁ (f j) → R₂ j) (hφ : ∀ᶠ j in 𝓕₂, A₁ (f j) ⊆ φ j ⁻¹' A₂ j)
 
-def map (x : Πʳ i, [R₁ i, B₁ i]_[𝓕₁]) : Πʳ j, [R₂ j, B₂ j]_[𝓕₂] := ⟨fun j ↦ φ j (x (f j)), by
+/--
+Given two restricted products `Πʳ (i : ι₁), [R₁ i, B₁ i]_[𝓕₁]` and `Πʳ (j : ι₂), [R₂ j, B₂ j]_[𝓕₂]`,
+`RestrictedProduct.map` gives a function between them. The data needed is a function `f : ι₂ → ι₁`
+such that `𝓕₂` tends to `𝓕₁` along `f`, and functions `φ j : R₁ (f j) → R₂ j`
+sending `A₁ (f j)` into `A₂ j` for an `𝓕₂`-large set of `j`'s.
+
+See also `mapMonoidHom`, `mapAddMonoidHom` and `mapRingHom` for variants.
+-/
+def map (x : Πʳ i, [R₁ i, A₁ i]_[𝓕₁]) : Πʳ j, [R₂ j, A₂ j]_[𝓕₂] := ⟨fun j ↦ φ j (x (f j)), by
   apply mem_of_superset (𝓕₂.inter_mem hφ (hf x.2))
-  simp only [image_subset_iff, SetLike.mem_coe, preimage_setOf_eq]
+  simp only [SetLike.mem_coe, preimage_setOf_eq]
   rintro _ ⟨h1, h2⟩
   exact h1 h2
   ⟩
@@ -330,9 +351,20 @@ section monoid
 
 variable [Π i, Monoid (R₁ i)] [Π i, Monoid (R₂ i)] [∀ i, SubmonoidClass (S₁ i) (R₁ i)]
     [∀ i, SubmonoidClass (S₂ i) (R₂ i)] (φ : ∀ j, R₁ (f j) →* R₂ j)
-    (hφ : ∀ᶠ j in 𝓕₂, (φ j) '' (B₁ (f j)) ≤ B₂ j)
+    (hφ : ∀ᶠ j in 𝓕₂, B₁ (f j) ≤ φ j ⁻¹' B₂ j)
 
-@[to_additive]
+/--
+Given two restricted products `Πʳ (i : ι₁), [R₁ i, B₁ i]_[𝓕₁]` and `Πʳ (j : ι₂), [R₂ j, B₂ j]_[𝓕₂]`,
+`RestrictedProduct.mapMonoidHom` gives a monoid homomorphism between them. The data needed is a
+function `f : ι₂ → ι₁` such that `𝓕₂` tends to `𝓕₁` along `f`, and functions `φ j : R₁ (f j) → R₂ j`
+sending `A₁ (f j)` into `A₂ j` for an `𝓕₂`-large set of `j`'s.
+-/
+@[to_additive "
+Given two restricted products `Πʳ (i : ι₁), [R₁ i, B₁ i]_[𝓕₁]` and `Πʳ (j : ι₂), [R₂ j, B₂ j]_[𝓕₂]`,
+`RestrictedProduct.mapAddMonoidHom` gives a additive monoid homomorphism between them. The data
+needed is a function `f : ι₂ → ι₁` such that `𝓕₂` tends to `𝓕₁` along `f`, and
+functions `φ j : R₁ (f j) → R₂ j` sending `A₁ (f j)` into `A₂ j` for an `𝓕₂`-large set of `j`'s.
+"]
 def mapMonoidHom : Πʳ i, [R₁ i, B₁ i]_[𝓕₁] →* Πʳ j, [R₂ j, B₂ j]_[𝓕₂] where
   toFun := map R₁ R₂ f hf (fun j r ↦ φ j r) hφ
   map_one' := by
@@ -348,8 +380,14 @@ section ring
 
 variable [Π i, Ring (R₁ i)] [Π i, Ring (R₂ i)] [∀ i, SubringClass (S₁ i) (R₁ i)]
     [∀ i, SubringClass (S₂ i) (R₂ i)] (φ : ∀ j, R₁ (f j) →+* R₂ j)
-    (hφ : ∀ᶠ j in 𝓕₂, (φ j) '' (B₁ (f j)) ≤ B₂ j)
+    (hφ : ∀ᶠ j in 𝓕₂, B₁ (f j) ≤ φ j ⁻¹' B₂ j)
 
+/--
+Given two restricted products `Πʳ (i : ι₁), [R₁ i, B₁ i]_[𝓕₁]` and `Πʳ (j : ι₂), [R₂ j, B₂ j]_[𝓕₂]`,
+`RestrictedProduct.mapRingHom` gives a ring homomorphism between them. The data needed is a
+function `f : ι₂ → ι₁` such that `𝓕₂` tends to `𝓕₁` along `f`, and functions `φ j : R₁ (f j) → R₂ j`
+sending `A₁ (f j)` into `A₂ j` for an `𝓕₂`-large set of `j`'s.
+-/
 def mapRingHom : Πʳ i, [R₁ i, B₁ i]_[𝓕₁] →+* Πʳ j, [R₂ j, B₂ j]_[𝓕₂] where
   __ := mapMonoidHom R₁ R₂ f hf (fun j ↦ φ j) hφ
   __ := mapAddMonoidHom R₁ R₂ f hf (fun j ↦ φ j) hφ

--- a/Mathlib/Topology/Algebra/RestrictedProduct.lean
+++ b/Mathlib/Topology/Algebra/RestrictedProduct.lean
@@ -318,7 +318,7 @@ variable {A₁ : (i : ι₁) → Set (R₁ i)} {A₂ : (i : ι₂) → Set (R₂
 variable {S₁ : ι₁ → Type*} {S₂ : ι₂ → Type*}
 variable [Π i, SetLike (S₁ i) (R₁ i)] [Π j, SetLike (S₂ j) (R₂ j)]
 variable {B₁ : Π i, S₁ i} {B₂ : Π j, S₂ j}
-variable (f : ι₂ → ι₁) (hf : 𝓕₂.Tendsto f 𝓕₁)
+variable (f : ι₂ → ι₁) (hf : Tendsto f 𝓕₂ 𝓕₁)
 
 section set
 
@@ -666,13 +666,13 @@ theorem isOpenEmbedding_structureMap :
 include hAopen in
 theorem nhds_eq_map_inclusion {S : Set ι} (hS : cofinite ≤ 𝓟 S)
     (x : Πʳ i, [R i, A i]_[𝓟 S]) :
-    (𝓝 (inclusion R A hS x)) = (𝓝 x).map (inclusion R A hS) := by
+    (𝓝 (inclusion R A hS x)) = .map (inclusion R A hS) (𝓝 x) := by
   rw [isOpenEmbedding_inclusion_principal hAopen hS |>.map_nhds_eq x]
 
 include hAopen in
 theorem nhds_eq_map_structureMap
     (x : Π i, A i) :
-    (𝓝 (structureMap R A cofinite x)) = (𝓝 x).map (structureMap R A cofinite) := by
+    (𝓝 (structureMap R A cofinite x)) = .map (structureMap R A cofinite) (𝓝 x) := by
   rw [isOpenEmbedding_structureMap hAopen |>.map_nhds_eq x]
 
 include hAopen in
@@ -828,13 +828,13 @@ section cofinite
 
 theorem nhds_zero_eq_map_ofPre [Π i, Zero (R i)] [∀ i, ZeroMemClass (S i) (R i)]
     (hBopen : ∀ i, IsOpen (B i : Set (R i))) (hT : cofinite ≤ 𝓟 T) :
-    (𝓝 (inclusion R (fun i ↦ B i) hT 0)) = (𝓝 0).map (inclusion R (fun i ↦ B i) hT) :=
+    (𝓝 (inclusion R (fun i ↦ B i) hT 0)) = .map (inclusion R (fun i ↦ B i) hT) (𝓝 0) :=
   nhds_eq_map_inclusion hBopen hT 0
 
 theorem nhds_zero_eq_map_structureMap [Π i, Zero (R i)] [∀ i, ZeroMemClass (S i) (R i)]
     (hBopen : ∀ i, IsOpen (B i : Set (R i))) :
     (𝓝 (structureMap R (fun i ↦ B i) cofinite 0)) =
-       (𝓝 0).map (structureMap R (fun i ↦ B i) cofinite) :=
+       .map (structureMap R (fun i ↦ B i) cofinite) (𝓝 0) :=
   nhds_eq_map_structureMap hBopen 0
 
 -- TODO: Make `IsOpen` a class like `IsClosed` ?

--- a/Mathlib/Topology/Algebra/RestrictedProduct.lean
+++ b/Mathlib/Topology/Algebra/RestrictedProduct.lean
@@ -333,10 +333,7 @@ sending `A₁ (f j)` into `A₂ j` for an `𝓕₂`-large set of `j`'s.
 See also `mapMonoidHom`, `mapAddMonoidHom` and `mapRingHom` for variants.
 -/
 def map (x : Πʳ i, [R₁ i, A₁ i]_[𝓕₁]) : Πʳ j, [R₂ j, A₂ j]_[𝓕₂] := ⟨fun j ↦ φ j (x (f j)), by
-  apply mem_of_superset (𝓕₂.inter_mem hφ (hf x.2))
-  simp only [SetLike.mem_coe, preimage_setOf_eq]
-  rintro _ ⟨h1, h2⟩
-  exact h1 h2⟩
+  filter_upwards [hf.eventually x.2, hφ] using fun _ h1 h2 ↦ h2 h1⟩
 
 end set
 
@@ -349,14 +346,15 @@ variable [Π i, Monoid (R₁ i)] [Π i, Monoid (R₂ i)] [∀ i, SubmonoidClass 
 /--
 Given two restricted products `Πʳ (i : ι₁), [R₁ i, B₁ i]_[𝓕₁]` and `Πʳ (j : ι₂), [R₂ j, B₂ j]_[𝓕₂]`,
 `RestrictedProduct.mapMonoidHom` gives a monoid homomorphism between them. The data needed is a
-function `f : ι₂ → ι₁` such that `𝓕₂` tends to `𝓕₁` along `f`, and functions `φ j : R₁ (f j) → R₂ j`
-sending `A₁ (f j)` into `A₂ j` for an `𝓕₂`-large set of `j`'s.
+function `f : ι₂ → ι₁` such that `𝓕₂` tends to `𝓕₁` along `f`, and monoid homomorphisms
+`φ j : R₁ (f j) → R₂ j` sending `B₁ (f j)` into `B₂ j` for an `𝓕₂`-large set of `j`'s.
 -/
 @[to_additive "
 Given two restricted products `Πʳ (i : ι₁), [R₁ i, B₁ i]_[𝓕₁]` and `Πʳ (j : ι₂), [R₂ j, B₂ j]_[𝓕₂]`,
 `RestrictedProduct.mapAddMonoidHom` gives a additive monoid homomorphism between them. The data
 needed is a function `f : ι₂ → ι₁` such that `𝓕₂` tends to `𝓕₁` along `f`, and
-functions `φ j : R₁ (f j) → R₂ j` sending `A₁ (f j)` into `A₂ j` for an `𝓕₂`-large set of `j`'s.
+additive monoid homomorphisms `φ j : R₁ (f j) → R₂ j` sending `B₁ (f j)` into `B₂ j` for
+an `𝓕₂`-large set of `j`'s.
 "]
 def mapMonoidHom : Πʳ i, [R₁ i, B₁ i]_[𝓕₁] →* Πʳ j, [R₂ j, B₂ j]_[𝓕₂] where
   toFun := map R₁ R₂ f hf (fun j r ↦ φ j r) hφ
@@ -378,8 +376,8 @@ variable [Π i, Ring (R₁ i)] [Π i, Ring (R₂ i)] [∀ i, SubringClass (S₁ 
 /--
 Given two restricted products `Πʳ (i : ι₁), [R₁ i, B₁ i]_[𝓕₁]` and `Πʳ (j : ι₂), [R₂ j, B₂ j]_[𝓕₂]`,
 `RestrictedProduct.mapRingHom` gives a ring homomorphism between them. The data needed is a
-function `f : ι₂ → ι₁` such that `𝓕₂` tends to `𝓕₁` along `f`, and functions `φ j : R₁ (f j) → R₂ j`
-sending `A₁ (f j)` into `A₂ j` for an `𝓕₂`-large set of `j`'s.
+function `f : ι₂ → ι₁` such that `𝓕₂` tends to `𝓕₁` along `f`, and ring homomorphisms
+`φ j : R₁ (f j) → R₂ j` sending `B₁ (f j)` into `B₂ j` for an `𝓕₂`-large set of `j`'s.
 -/
 def mapRingHom : Πʳ i, [R₁ i, B₁ i]_[𝓕₁] →+* Πʳ j, [R₂ j, B₂ j]_[𝓕₂] where
   __ := mapMonoidHom R₁ R₂ f hf (fun j ↦ φ j) hφ

--- a/Mathlib/Topology/Algebra/RestrictedProduct.lean
+++ b/Mathlib/Topology/Algebra/RestrictedProduct.lean
@@ -332,7 +332,7 @@ variable (f : ι₂ → ι₁) (hf : Tendsto f 𝓕₂ 𝓕₁)
 
 section set
 
-variable (φ : ∀ j, R₁ (f j) → R₂ j) (hφ : ∀ᶠ j in 𝓕₂, (A₁ (f j)).MapsTo (φ j) (A₂ j))
+variable (φ : ∀ j, R₁ (f j) → R₂ j) (hφ : ∀ᶠ j in 𝓕₂, Set.MapsTo (φ j) (A₁ (f j)) (A₂ j))
 
 /--
 Given two restricted products `Πʳ (i : ι₁), [R₁ i, A₁ i]_[𝓕₁]` and `Πʳ (j : ι₂), [R₂ j, A₂ j]_[𝓕₂]`,
@@ -356,7 +356,7 @@ section monoid
 
 variable [Π i, Monoid (R₁ i)] [Π i, Monoid (R₂ i)] [∀ i, SubmonoidClass (S₁ i) (R₁ i)]
     [∀ i, SubmonoidClass (S₂ i) (R₂ i)] (φ : ∀ j, R₁ (f j) →* R₂ j)
-    (hφ : ∀ᶠ j in 𝓕₂, B₁ (f j) ≤ φ j ⁻¹' B₂ j)
+    (hφ : ∀ᶠ j in 𝓕₂, Set.MapsTo (φ j) (B₁ (f j)) (B₂ j))
 
 /--
 Given two restricted products `Πʳ (i : ι₁), [R₁ i, B₁ i]_[𝓕₁]` and `Πʳ (j : ι₂), [R₂ j, B₂ j]_[𝓕₂]`,
@@ -391,7 +391,7 @@ section ring
 
 variable [Π i, Ring (R₁ i)] [Π i, Ring (R₂ i)] [∀ i, SubringClass (S₁ i) (R₁ i)]
     [∀ i, SubringClass (S₂ i) (R₂ i)] (φ : ∀ j, R₁ (f j) →+* R₂ j)
-    (hφ : ∀ᶠ j in 𝓕₂, B₁ (f j) ≤ φ j ⁻¹' B₂ j)
+    (hφ : ∀ᶠ j in 𝓕₂, Set.MapsTo (φ j) (B₁ (f j)) (B₂ j))
 
 /--
 Given two restricted products `Πʳ (i : ι₁), [R₁ i, B₁ i]_[𝓕₁]` and `Πʳ (j : ι₂), [R₂ j, B₂ j]_[𝓕₂]`,


### PR DESCRIPTION
In this PR we add `ext`, `eval` and `map` API for `RestrictedProduct`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

(I also remove the global {S T : Set \io} variables because S is reused later in the file to mean the subobject type, S the set is only used once and T isn't used at all)