### PR TITLE
[Merged by Bors] - chore: remove erw from WSeq.bind_assoc

### DIFF
--- a/Mathlib/Data/WSeq/Relation.lean
+++ b/Mathlib/Data/WSeq/Relation.lean
@@ -545,8 +545,7 @@ theorem join_join (SS : WSeq (WSeq (WSeq α))) : join (join SS) ~ʷ join (map jo
 theorem bind_assoc_comp (s : WSeq α) (f : α → WSeq β) (g : β → WSeq γ) :
     bind (bind s f) g ~ʷ bind s ((fun y : WSeq β => bind y g) ∘ f) := by
   simp only [bind, map_join]
-  rw [← map_comp f (map g), show (fun y ↦ (map g y).join) = join ∘ map g by rfl,
-      comp_assoc, map_comp (map g ∘ f) join s]
+  rw [← map_comp f (map g), ← Function.comp_def, comp_assoc, map_comp (map g ∘ f) join s]
   exact join_join (map (map g ∘ f) s)
 
 @[simp]

--- a/Mathlib/Data/WSeq/Relation.lean
+++ b/Mathlib/Data/WSeq/Relation.lean
@@ -542,9 +542,16 @@ theorem join_join (SS : WSeq (WSeq (WSeq α))) : join (join SS) ~ʷ join (map jo
       · exact ⟨s, S, SS, rfl, rfl⟩
 
 @[simp]
+theorem bind_assoc_comp (s : WSeq α) (f : α → WSeq β) (g : β → WSeq γ) :
+    bind (bind s f) g ~ʷ bind s ((fun y : WSeq β => bind y g) ∘ f) := by
+  simp only [bind, map_join]
+  rw [← map_comp f (map g), show (fun y ↦ (map g y).join) = join ∘ map g by rfl,
+      comp_assoc, map_comp (map g ∘ f) join s]
+  exact join_join (map (map g ∘ f) s)
+
+@[simp]
 theorem bind_assoc (s : WSeq α) (f : α → WSeq β) (g : β → WSeq γ) :
     bind (bind s f) g ~ʷ bind s fun x : α => bind (f x) g := by
-  simp only [bind, map_join]; erw [← map_comp f (map g), map_comp (map g ∘ f) join]
-  apply join_join
+  exact bind_assoc_comp s f g
 
 end Stream'.WSeq


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
