### PR TITLE
[Merged by Bors] - chore(Algebra): remove `mid_assoc` from `IsMulCentral`

### DIFF
--- a/Mathlib/Algebra/Algebra/NonUnitalSubalgebra.lean
+++ b/Mathlib/Algebra/Algebra/NonUnitalSubalgebra.lean
@@ -1071,10 +1071,8 @@ variable [IsScalarTower R A A] [SMulCommClass R A A]
 
 theorem _root_.Set.smul_mem_center (r : R) {a : A} (ha : a ∈ Set.center A) :
     r • a ∈ Set.center A where
-  comm b := by rw [mul_smul_comm, smul_mul_assoc, ha.comm]
+  comm b := by rw [commute_iff_eq, mul_smul_comm, smul_mul_assoc, ha.comm]
   left_assoc b c := by rw [smul_mul_assoc, smul_mul_assoc, smul_mul_assoc, ha.left_assoc]
-  mid_assoc b c := by
-    rw [mul_smul_comm, smul_mul_assoc, smul_mul_assoc, mul_smul_comm, ha.mid_assoc]
   right_assoc b c := by
     rw [mul_smul_comm, mul_smul_comm, mul_smul_comm, ha.right_assoc]
 

--- a/Mathlib/Algebra/Group/Center.lean
+++ b/Mathlib/Algebra/Group/Center.lean
@@ -56,7 +56,7 @@ structure IsMulCentral [Mul M] (z : M) : Prop where
   comm (a : M) : Commute z a
   /-- associative property for left multiplication -/
   left_assoc (b c : M) : z * (b * c) = (z * b) * c
-  /-- middle associative multiplication property -/
+  /-- associative property for right multiplication -/
   right_assoc (a b : M) : (a * b) * z = a * (b * z)
 
 attribute [mk_iff] IsMulCentral IsAddCentral
@@ -170,8 +170,7 @@ variable [Semigroup M] {a b : M}
 @[to_additive]
 theorem _root_.Semigroup.mem_center_iff {z : M} :
     z ∈ Set.center M ↔ ∀ g, g * z = z * g := ⟨fun a g ↦ by rw [IsMulCentral.comm a g],
-  fun h ↦ ⟨fun _ ↦ (Commute.eq (h _)).symm,
-  fun _ _ ↦ (mul_assoc z _ _).symm, fun _ _ ↦ mul_assoc _ _ z⟩ ⟩
+  fun h ↦ ⟨fun _ ↦ (h _).symm, fun _ _ ↦ (mul_assoc z _ _).symm, fun _ _ ↦ mul_assoc _ _ z⟩ ⟩
 
 @[to_additive (attr := simp) add_mem_addCentralizer]
 lemma mul_mem_centralizer (ha : a ∈ centralizer S) (hb : b ∈ centralizer S) :

--- a/Mathlib/Algebra/Group/Center.lean
+++ b/Mathlib/Algebra/Group/Center.lean
@@ -43,11 +43,9 @@ variable {M : Type*} {S T : Set M}
 /-- Conditions for an element to be additively central -/
 structure IsAddCentral [Add M] (z : M) : Prop where
   /-- addition commutes -/
-  comm (a : M) : z + a = a + z
+  comm (a : M) : AddCommute z a
   /-- associative property for left addition -/
   left_assoc (b c : M) : z + (b + c) = (z + b) + c
-  /-- middle associative addition property -/
-  mid_assoc (a c : M) : (a + z) + c = a + (z + c)
   /-- associative property for right addition -/
   right_assoc (a b : M) : (a + b) + z = a + (b + z)
 
@@ -55,12 +53,10 @@ structure IsAddCentral [Add M] (z : M) : Prop where
 @[to_additive]
 structure IsMulCentral [Mul M] (z : M) : Prop where
   /-- multiplication commutes -/
-  comm (a : M) : z * a = a * z
+  comm (a : M) : Commute z a
   /-- associative property for left multiplication -/
   left_assoc (b c : M) : z * (b * c) = (z * b) * c
   /-- middle associative multiplication property -/
-  mid_assoc (a c : M) : (a * z) * c = a * (z * c)
-  /-- associative property for right multiplication -/
   right_assoc (a b : M) : (a * b) * z = a * (b * z)
 
 attribute [mk_iff] IsMulCentral IsAddCentral
@@ -70,15 +66,19 @@ namespace IsMulCentral
 
 variable {a c : M} [Mul M]
 
+@[to_additive]
+protected theorem mid_assoc {z : M} (h : IsMulCentral z) (a c) : a * z * c = a * (z * c) := by
+  rw [h.comm, ← h.right_assoc, ← h.comm, ← h.left_assoc, h.comm]
+
 -- cf. `Commute.left_comm`
 @[to_additive]
 protected theorem left_comm (h : IsMulCentral a) (b c) : a * (b * c) = b * (a * c) := by
-  simp only [h.comm, h.right_assoc]
+  simp only [(h.comm _).eq, h.right_assoc]
 
 -- cf. `Commute.right_comm`
 @[to_additive]
 protected theorem right_comm (h : IsMulCentral c) (a b) : a * b * c = a * c * b := by
-  simp only [h.right_assoc, h.mid_assoc, h.comm]
+  simp only [h.right_assoc, h.mid_assoc, (h.comm _).eq]
 
 end IsMulCentral
 
@@ -120,11 +120,6 @@ theorem mul_mem_center {z₁ z₂ : M} (hz₁ : z₁ ∈ Set.center M) (hz₂ : 
     _ = z₁ * ((z₂ * b) * c) := by rw [hz₂.left_assoc]
     _ = (z₁ * (z₂ * b)) * c := by rw [hz₁.left_assoc]
     _ = z₁ * z₂ * b * c := by rw [hz₂.mid_assoc]
-  mid_assoc (a c : M) := calc
-    a * (z₁ * z₂) * c = ((a * z₁) * z₂) * c := by rw [hz₁.mid_assoc]
-    _ = (a * z₁) * (z₂ * c) := by rw [hz₂.mid_assoc]
-    _ = a * (z₁ * (z₂ * c)) := by rw [hz₁.mid_assoc]
-    _ = a * (z₁ * z₂ * c) := by rw [hz₂.mid_assoc]
   right_assoc (a b : M) := calc
     a * b * (z₁ * z₂) = ((a * b) * z₁) * z₂ := by rw [hz₂.right_assoc]
     _ = (a * (b * z₁)) * z₂ := by rw [hz₁.right_assoc]
@@ -175,8 +170,8 @@ variable [Semigroup M] {a b : M}
 @[to_additive]
 theorem _root_.Semigroup.mem_center_iff {z : M} :
     z ∈ Set.center M ↔ ∀ g, g * z = z * g := ⟨fun a g ↦ by rw [IsMulCentral.comm a g],
-  fun h ↦ ⟨fun _ ↦ (Commute.eq (h _)).symm, fun _ _ ↦ (mul_assoc z _ _).symm,
-  fun _ _ ↦ mul_assoc _ z _, fun _ _ ↦ mul_assoc _ _ z⟩ ⟩
+  fun h ↦ ⟨fun _ ↦ (Commute.eq (h _)).symm,
+  fun _ _ ↦ (mul_assoc z _ _).symm, fun _ _ ↦ mul_assoc _ _ z⟩ ⟩
 
 @[to_additive (attr := simp) add_mem_addCentralizer]
 lemma mul_mem_centralizer (ha : a ∈ centralizer S) (hb : b ∈ centralizer S) :
@@ -222,9 +217,8 @@ variable [MulOneClass M]
 
 @[to_additive (attr := simp) zero_mem_addCenter]
 theorem one_mem_center : (1 : M) ∈ Set.center M where
-  comm _  := by rw [one_mul, mul_one]
+  comm _ := by rw [commute_iff_eq, one_mul, mul_one]
   left_assoc _ _ := by rw [one_mul, one_mul]
-  mid_assoc _ _ := by rw [mul_one, one_mul]
   right_assoc _ _ := by rw [mul_one, mul_one]
 
 @[to_additive (attr := simp) zero_mem_addCentralizer]

--- a/Mathlib/Algebra/GroupWithZero/Center.lean
+++ b/Mathlib/Algebra/GroupWithZero/Center.lean
@@ -19,9 +19,8 @@ section MulZeroClass
 variable [MulZeroClass M₀] {s : Set M₀}
 
 @[simp] lemma zero_mem_center : (0 : M₀) ∈ center M₀ where
-  comm _ := by rw [zero_mul, mul_zero]
+  comm _ := by rw [commute_iff_eq, zero_mul, mul_zero]
   left_assoc _ _ := by rw [zero_mul, zero_mul, zero_mul]
-  mid_assoc _ _ := by rw [mul_zero, zero_mul, mul_zero]
   right_assoc _ _ := by rw [mul_zero, mul_zero, mul_zero]
 
 @[simp] lemma zero_mem_centralizer : (0 : M₀) ∈ centralizer s := by simp [mem_centralizer_iff]

--- a/Mathlib/Algebra/Ring/Center.lean
+++ b/Mathlib/Algebra/Ring/Center.lean
@@ -21,15 +21,11 @@ variable (M)
 
 @[simp]
 theorem natCast_mem_center [NonAssocSemiring M] (n : ℕ) : (n : M) ∈ Set.center M where
-  comm _ := by rw [Nat.commute_cast]
+  comm _ := by rw [commute_iff_eq, Nat.commute_cast]
   left_assoc _ _ := by
     induction n with
     | zero => rw [Nat.cast_zero, zero_mul, zero_mul, zero_mul]
     | succ n ihn => rw [Nat.cast_succ, add_mul, one_mul, ihn, add_mul, add_mul, one_mul]
-  mid_assoc _ _ := by
-    induction n with
-    | zero => rw [Nat.cast_zero, zero_mul, mul_zero, zero_mul]
-    | succ n ihn => rw [Nat.cast_succ, add_mul, mul_add, add_mul, ihn, mul_add, one_mul, mul_one]
   right_assoc _ _ := by
     induction n with
     | zero => rw [Nat.cast_zero, mul_zero, mul_zero, mul_zero]
@@ -42,21 +38,13 @@ theorem ofNat_mem_center [NonAssocSemiring M] (n : ℕ) [n.AtLeastTwo] :
 
 @[simp]
 theorem intCast_mem_center [NonAssocRing M] (n : ℤ) : (n : M) ∈ Set.center M where
-  comm _ := by rw [Int.commute_cast]
+  comm _ := by rw [commute_iff_eq, Int.commute_cast]
   left_assoc _ _ := match n with
     | (n : ℕ) => by rw [Int.cast_natCast, (natCast_mem_center _ n).left_assoc _ _]
     | Int.negSucc n => by
       rw [Int.cast_negSucc, Nat.cast_add, Nat.cast_one, neg_add_rev, add_mul, add_mul, add_mul,
         neg_mul, one_mul, neg_mul 1, one_mul, ← neg_mul, add_right_inj, neg_mul,
         (natCast_mem_center _ n).left_assoc _ _, neg_mul, neg_mul]
-  mid_assoc _ _ := match n with
-    | (n : ℕ) => by rw [Int.cast_natCast, (natCast_mem_center _ n).mid_assoc _ _]
-    | Int.negSucc n => by
-        simp only [Int.cast_negSucc, Nat.cast_add, Nat.cast_one, neg_add_rev]
-        rw [add_mul, mul_add, add_mul, mul_add, neg_mul, one_mul]
-        rw [neg_mul, mul_neg, mul_one, mul_neg, neg_mul, neg_mul]
-        rw [(natCast_mem_center _ n).mid_assoc _ _]
-        simp only [mul_neg]
   right_assoc _ _ := match n with
     | (n : ℕ) => by rw [Int.cast_natCast, (natCast_mem_center _ n).right_assoc _ _]
     | Int.negSucc n => by
@@ -69,17 +57,15 @@ variable {M}
 @[simp]
 theorem add_mem_center [Distrib M] {a b : M} (ha : a ∈ Set.center M) (hb : b ∈ Set.center M) :
     a + b ∈ Set.center M  where
-  comm _ := by rw [add_mul, mul_add, ha.comm, hb.comm]
+  comm _ := by rw [commute_iff_eq, add_mul, mul_add, ha.comm, hb.comm]
   left_assoc _ _ := by rw [add_mul, ha.left_assoc, hb.left_assoc, ← add_mul, ← add_mul]
-  mid_assoc _ _ := by rw [mul_add, add_mul, ha.mid_assoc, hb.mid_assoc, ← mul_add, ← add_mul]
   right_assoc _ _ := by rw [mul_add, ha.right_assoc, hb.right_assoc, ← mul_add, ← mul_add]
 
 @[simp]
 theorem neg_mem_center [NonUnitalNonAssocRing M] {a : M} (ha : a ∈ Set.center M) :
     -a ∈ Set.center M where
-  comm _ := by rw [← neg_mul_comm, ← ha.comm, neg_mul_comm]
+  comm _ := by rw [commute_iff_eq, ← neg_mul_comm, ← ha.comm, neg_mul_comm]
   left_assoc _ _ := by rw [neg_mul, ha.left_assoc, neg_mul, neg_mul]
-  mid_assoc _ _ := by rw [← neg_mul_comm, ha.mid_assoc, neg_mul_comm, neg_mul]
   right_assoc _ _ := by rw [mul_neg, ha.right_assoc, mul_neg, mul_neg]
 
 end Set

--- a/Mathlib/Algebra/Ring/CentroidHom.lean
+++ b/Mathlib/Algebra/Ring/CentroidHom.lean
@@ -521,7 +521,7 @@ variable [NonAssocSemiring α]
 def centerIsoCentroid : Subsemiring.center α ≃+* CentroidHom α :=
   { centerToCentroid with
     invFun := fun T ↦
-      ⟨T 1, by refine ⟨?_, ?_, ?_, ?_⟩; all_goals simp [← map_mul_left, ← map_mul_right]⟩
+      ⟨T 1, by constructor <;> simp [commute_iff_eq, ← map_mul_left, ← map_mul_right]⟩
     left_inv := fun z ↦ Subtype.ext <| by simp only [MulHom.toFun_eq_coe,
       NonUnitalRingHom.coe_toMulHom, centerToCentroid_apply, mul_one]
     right_inv := fun T ↦ CentroidHom.ext <| fun _ => by rw [MulHom.toFun_eq_coe,

--- a/Mathlib/Algebra/Ring/CentroidHom.lean
+++ b/Mathlib/Algebra/Ring/CentroidHom.lean
@@ -492,8 +492,6 @@ lemma _root_.NonUnitalNonAssocSemiring.mem_center_iff (a : α) :
     constructor
     case comm => exact (congr($hc.symm ·))
     case left_assoc => simpa [e1] using (map_mul_right T · ·)
-    case mid_assoc => exact fun b c ↦ by simpa [e1 c, e2 b] using
-      (map_mul_right T b c).symm.trans <| map_mul_left T b c
     case right_assoc => simpa [e2] using (map_mul_left T · ·)
 
 end NonUnitalNonAssocSemiring

--- a/Mathlib/Algebra/Star/Center.lean
+++ b/Mathlib/Algebra/Star/Center.lean
@@ -21,11 +21,6 @@ theorem Set.star_mem_center (ha : a ∈ Set.center R) : star a ∈ Set.center R 
     _ = star (star c * (star b * a)) := by rw [ha.right_assoc]
     _ = star (star b * a) * c := by rw [star_mul, star_star]
     _ = (star a * b) * c := by rw [star_mul, star_star]
-  mid_assoc b c := calc
-    b * star a * c = star (star c * star (b * star a)) := by rw [← star_mul, star_star]
-    _ = star (star c * (a * star b)) := by rw [star_mul b, star_star]
-    _ = star ((star c * a) * star b) := by rw [ha.mid_assoc]
-    _ = b * (star a * c) := by rw [star_mul, star_star, star_mul (star c), star_star]
   right_assoc b c := calc
     b * c * star a = star (a * star (b * c)) := by rw [star_mul, star_star]
     _ = star (a * (star c * star b)) := by rw [star_mul b]

--- a/Mathlib/Algebra/Star/CentroidHom.lean
+++ b/Mathlib/Algebra/Star/CentroidHom.lean
@@ -124,7 +124,7 @@ variable [NonAssocSemiring α] [StarRing α]
 def starCenterIsoCentroid : StarSubsemiring.center α ≃⋆+* CentroidHom α where
   __ := starCenterToCentroid
   invFun T :=
-    ⟨T 1, by refine ⟨?_, ?_, ?_, ?_⟩; all_goals simp [← map_mul_left, ← map_mul_right]⟩
+    ⟨T 1, by constructor <;> simp [commute_iff_eq, ← map_mul_left, ← map_mul_right]⟩
   left_inv z := Subtype.ext <| by simp only [MulHom.toFun_eq_coe,
     NonUnitalRingHom.coe_toMulHom, NonUnitalStarRingHom.coe_toNonUnitalRingHom,
     starCenterToCentroid_apply, mul_one]

--- a/Mathlib/GroupTheory/Submonoid/Center.lean
+++ b/Mathlib/GroupTheory/Submonoid/Center.lean
@@ -135,11 +135,9 @@ variable {M} {N : Type*}
     [MulEquivClass F M N] (e : F) {x : M} (hx : x ∈ Set.center M) : e x ∈ Set.center N := by
   let e := MulEquivClass.toMulEquiv e
   show e x ∈ Set.center N
-  have := (isMulCentral_iff _).mp hx
-  simp_rw [commute_iff_eq] at this
   constructor <;>
-  (intros; apply e.symm.injective;
-    simp only [map_mul, e.symm_apply_apply, this, ← hx.right_comm])
+  (intros; apply e.symm.injective; simp only
+    [map_mul, e.symm_apply_apply, (hx.comm _).eq, (isMulCentral_iff _).mp hx, ← hx.right_comm])
 
 @[to_additive] theorem _root_.MulEquivClass.apply_mem_center_iff {F} [EquivLike F M N]
     [Mul M] [Mul N] [MulEquivClass F M N] (e : F) {x : M} :

--- a/Mathlib/GroupTheory/Submonoid/Center.lean
+++ b/Mathlib/GroupTheory/Submonoid/Center.lean
@@ -135,9 +135,11 @@ variable {M} {N : Type*}
     [MulEquivClass F M N] (e : F) {x : M} (hx : x ∈ Set.center M) : e x ∈ Set.center N := by
   let e := MulEquivClass.toMulEquiv e
   show e x ∈ Set.center N
+  have := (isMulCentral_iff _).mp hx
+  simp_rw [commute_iff_eq] at this
   constructor <;>
   (intros; apply e.symm.injective;
-    simp only [map_mul, e.symm_apply_apply, (isMulCentral_iff _).mp hx])
+    simp only [map_mul, e.symm_apply_apply, this, ← hx.right_comm])
 
 @[to_additive] theorem _root_.MulEquivClass.apply_mem_center_iff {F} [EquivLike F M N]
     [Mul M] [Mul N] [MulEquivClass F M N] (e : F) {x : M} :

--- a/Mathlib/LinearAlgebra/Basis/Submodule.lean
+++ b/Mathlib/LinearAlgebra/Basis/Submodule.lean
@@ -123,7 +123,6 @@ lemma Basis.mem_center_iff {A}
     z ∈ Set.center A ↔
       (∀ i, Commute (b i) z) ∧ ∀ i j,
         z * (b i * b j) = (z * b i) * b j
-          ∧ (b i * z) * b j = b i * (z * b j)
           ∧ (b i * b j) * z = b i * (b j * z) := by
   constructor
   · intro h
@@ -131,14 +130,14 @@ lemma Basis.mem_center_iff {A}
     · intro i
       apply (h.1 (b i)).symm
     · intros
-      exact ⟨h.2 _ _, ⟨h.3 _ _, h.4 _ _⟩⟩
+      exact ⟨h.2 _ _, h.3 _ _⟩
   · intro h
     rw [center, mem_setOf_eq]
     constructor
     case comm =>
       intro y
-      rw [← b.linearCombination_repr y, linearCombination_apply, sum, Finset.sum_mul,
-          Finset.mul_sum]
+      rw [← b.linearCombination_repr y, linearCombination_apply, sum, commute_iff_eq,
+        Finset.sum_mul, Finset.mul_sum]
       simp_rw [mul_smul_comm, smul_mul_assoc, (h.1 _).eq]
     case left_assoc =>
       intro c d
@@ -149,19 +148,13 @@ lemma Basis.mem_center_iff {A}
         Finset.smul_sum, smul_mul_assoc, mul_smul_comm, (h.2 _ _).1,
         (@SMulCommClass.smul_comm R R A)]
       rw [Finset.sum_comm]
-    case mid_assoc =>
-      intro c d
-      rw [← b.linearCombination_repr c, ← b.linearCombination_repr d, linearCombination_apply,
-          linearCombination_apply, sum, sum, Finset.sum_mul, Finset.mul_sum, Finset.mul_sum,
-          Finset.mul_sum]
-      simp_rw [smul_mul_assoc, Finset.sum_mul, mul_smul_comm, smul_mul_assoc, (h.2 _ _).2.1]
     case right_assoc =>
       intro c d
       rw [← b.linearCombination_repr c, ← b.linearCombination_repr d, linearCombination_apply,
           linearCombination_apply, sum, Finsupp.sum, Finset.sum_mul]
       simp_rw [smul_mul_assoc, Finset.mul_sum, Finset.sum_mul, mul_smul_comm, Finset.mul_sum,
                Finset.smul_sum, smul_mul_assoc, mul_smul_comm, Finset.sum_mul, smul_mul_assoc,
-               (h.2 _ _).2.2]
+               (h.2 _ _).2]
 
 section RestrictScalars
 

--- a/Mathlib/LinearAlgebra/QuadraticForm/Basic.lean
+++ b/Mathlib/LinearAlgebra/QuadraticForm/Basic.lean
@@ -840,7 +840,7 @@ variable [Semiring R] [AddCommMonoid M] [Module R M]
 
 instance : SMulCommClass R (Submonoid.center R) M where
   smul_comm r r' m := by
-    simp_rw [Submonoid.smul_def, smul_smul, (Set.mem_center_iff.1 r'.prop).1]
+    simp_rw [Submonoid.smul_def, smul_smul, ((Set.mem_center_iff.1 r'.prop).1 _).eq]
 
 /-- If `2` is invertible in `R`, then it is also invertible in `End R M`. -/
 instance [Invertible (2 : R)] : Invertible (2 : Module.End R M) where

--- a/Mathlib/RingTheory/Idempotents.lean
+++ b/Mathlib/RingTheory/Idempotents.lean
@@ -473,11 +473,11 @@ lemma mem_corner_iff_mul_right (hc : IsMulCentral e) {r : R} : r ∈ corner e �
 
 lemma mem_corner_iff_mem_range_mul_left (hc : IsMulCentral e) {r : R} :
     r ∈ corner e ↔ r ∈ Set.range (e * ·) := by
-  simp_rw [corner, mem_mk, Set.mem_range, ← hc.comm, ← mul_assoc, idem.eq]
+  simp_rw [corner, mem_mk, Set.mem_range, ← (hc.comm _).eq, ← mul_assoc, idem.eq]
 
 lemma mem_corner_iff_mem_range_mul_right (hc : IsMulCentral e) {r : R} :
     r ∈ corner e ↔ r ∈ Set.range (· * e) := by
-  simp_rw [mem_corner_iff_mem_range_mul_left idem hc, hc.comm]
+  simp_rw [mem_corner_iff_mem_range_mul_left idem hc, (hc.comm _).eq]
 
 /-- The corner associated to an idempotent `e` in a semiring without 1
 is the semiring with `e` as 1 consisting of all element of the form `e * r * e`. -/
@@ -527,7 +527,7 @@ def CompleteOrthogonalIdempotents.ringEquivOfIsMulCentral [Semiring R]
   toFun r i := ⟨_, r, rfl⟩
   invFun r := ∑ i, (r i).1
   left_inv r := by
-    simp_rw [(hc _).comm, mul_assoc, (he.idem _).eq, ← Finset.mul_sum, he.complete, mul_one]
+    simp_rw [((hc _).comm _).eq, mul_assoc, (he.idem _).eq, ← Finset.mul_sum, he.complete, mul_one]
   right_inv r := funext fun i ↦ Subtype.ext <| by
     simp_rw [Finset.mul_sum, Finset.sum_mul]
     rw [Finset.sum_eq_single i _ (by simp at ·)]
@@ -537,7 +537,8 @@ def CompleteOrthogonalIdempotents.ringEquivOfIsMulCentral [Semiring R]
       rw [← eq]; simp_rw [← mul_assoc, he.ortho ne.symm, zero_mul]
   map_mul' r₁ r₂ := funext fun i ↦ Subtype.ext <|
     calc e i * (r₁ * r₂) * e i
-     _ = e i * (r₁ * e i * r₂) * e i := by simp_rw [← (hc i).comm r₁, ← mul_assoc, (he.idem i).eq]
+     _ = e i * (r₁ * e i * r₂) * e i := by
+       simp_rw [← ((hc i).comm r₁).eq, ← mul_assoc, (he.idem i).eq]
      _ = e i * r₁ * e i * (e i * r₂ * e i) := by
       conv in (r₁ * _ * r₂) => rw [← (he.idem i).eq]
       simp_rw [mul_assoc]

--- a/Mathlib/RingTheory/NonUnitalSubsemiring/Basic.lean
+++ b/Mathlib/RingTheory/NonUnitalSubsemiring/Basic.lean
@@ -243,10 +243,9 @@ lemma _root_.Set.mem_center_iff_addMonoidHom (a : R) :
     a ∈ Set.center R ↔
       AddMonoidHom.mulLeft a = .mulRight a ∧
       AddMonoidHom.compr₂ .mul (.mulLeft a) = .comp .mul (.mulLeft a) ∧
-      AddMonoidHom.comp .mul (.mulRight a) = .compl₂ .mul (.mulLeft a) ∧
       AddMonoidHom.compr₂ .mul (.mulRight a) = .compl₂ .mul (.mulRight a) := by
   rw [Set.mem_center_iff, isMulCentral_iff]
-  simp [DFunLike.ext_iff]
+  simp [DFunLike.ext_iff, commute_iff_eq]
 
 variable {R}
 


### PR DESCRIPTION
as it is a consequence of left and right associativity in the presence of commutativity. Also change the commutativity condition to use `Commute`.

---

Even without commutativity, left and right associativity of an element `e` in a magma is sufficient to prove that elements of the form `e * x * e` (the "corner" of `e`) form a submagma.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
