### PR TITLE
[Merged by Bors] - feat(RingTheory): tensor product of l.i. families over domains

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4983,6 +4983,7 @@ import Mathlib.RingTheory.Finiteness.Subalgebra
 import Mathlib.RingTheory.Fintype
 import Mathlib.RingTheory.Flat.Basic
 import Mathlib.RingTheory.Flat.CategoryTheory
+import Mathlib.RingTheory.Flat.Domain
 import Mathlib.RingTheory.Flat.Equalizer
 import Mathlib.RingTheory.Flat.EquationalCriterion
 import Mathlib.RingTheory.Flat.FaithfullyFlat.Algebra

--- a/Mathlib/RingTheory/Flat/Basic.lean
+++ b/Mathlib/RingTheory/Flat/Basic.lean
@@ -248,24 +248,6 @@ theorem linearIndependent_one_tmul {S} [Semiring S] [Algebra R S] [Flat R S] {ι
     Finsupp.linearCombination_one_tmul]
   simpa using lTensor_preserves_injective_linearMap _ hv
 
-variable (p : Submodule R M) (q : Submodule R N)
-
-/-- If p and q are submodules of M and N respectively, and M and q are flat,
-then `p ⊗ q → M ⊗ N` is injective. -/
-theorem tensorProduct_mapIncl_injective_of_right
-    [Flat R M] [Flat R q] : Function.Injective (mapIncl p q) := by
-  rw [mapIncl, ← lTensor_comp_rTensor]
-  exact (lTensor_preserves_injective_linearMap _ q.injective_subtype).comp
-    (rTensor_preserves_injective_linearMap _ p.injective_subtype)
-
-/-- If p and q are submodules of M and N respectively, and N and p are flat,
-then `p ⊗ q → M ⊗ N` is injective. -/
-theorem tensorProduct_mapIncl_injective_of_left
-    [Flat R p] [Flat R N] : Function.Injective (mapIncl p q) := by
-  rw [mapIncl, ← rTensor_comp_lTensor]
-  exact (rTensor_preserves_injective_linearMap _ p.injective_subtype).comp
-    (lTensor_preserves_injective_linearMap _ q.injective_subtype)
-
 end Flat
 
 end Semiring
@@ -498,6 +480,75 @@ theorem nontrivial_of_linearMap_injective_of_flat_right (f : R →ₗ[R] M) (h :
     [Module.Flat R N] [Nontrivial N] : Nontrivial (M ⊗[R] N) :=
   Module.Flat.rTensor_preserves_injective_linearMap (M := N) f h |>.comp
     (TensorProduct.lid R N).symm.injective |>.nontrivial
+
+variable {R M N}
+variable {P Q : Type*} [AddCommMonoid P] [Module R P] [AddCommMonoid Q] [Module R Q]
+
+/-- Tensor product of injective maps are injective under some flatness conditions.
+Also see `TensorProduct.map_injective_of_flat_flat'` and
+`TensorProduct.map_injective_of_flat_flat_of_isDomain` for different flatness conditions. -/
+lemma map_injective_of_flat_flat
+    (f : P →ₗ[R] M) (g : Q →ₗ[R] N) [Module.Flat R M] [Module.Flat R Q]
+    (hf : Function.Injective f) (hg : Function.Injective g) :
+    Function.Injective (TensorProduct.map f g) := by
+  rw [← LinearMap.lTensor_comp_rTensor]
+  exact (Module.Flat.lTensor_preserves_injective_linearMap g hg).comp
+    (Module.Flat.rTensor_preserves_injective_linearMap f hf)
+
+/-- Tensor product of injective maps are injective under some flatness conditions.
+Also see `TensorProduct.map_injective_of_flat_flat` and
+`TensorProduct.map_injective_of_flat_flat_of_isDomain` for different flatness conditions. -/
+lemma map_injective_of_flat_flat'
+    (f : P →ₗ[R] M) (g : Q →ₗ[R] N) [Module.Flat R P] [Module.Flat R N]
+    (hf : Function.Injective f) (hg : Function.Injective g) :
+    Function.Injective (TensorProduct.map f g) := by
+  rw [← LinearMap.rTensor_comp_lTensor]
+  exact (Module.Flat.rTensor_preserves_injective_linearMap f hf).comp
+    (Module.Flat.lTensor_preserves_injective_linearMap g hg)
+
+/-- Tensor product of linearly independent families is linearly
+independent under some flatness conditions.
+
+The flatness condition could be removed over domains.
+See `LinearIndependent.tensorProduct_of_isDomain`. -/
+lemma _root_.LinearIndependent.tensorProduct_of_flat_left [Module.Flat R M]
+    {ι ι' : Type*} {v : ι → M} (hv : LinearIndependent R v)
+    {w : ι' → N} (hw : LinearIndependent R w) :
+    LinearIndependent R fun i : ι × ι' ↦ v i.1 ⊗ₜ[R] w i.2 := by
+  rw [LinearIndependent]
+  convert (TensorProduct.map_injective_of_flat_flat _ _ hv hw).comp
+    (finsuppTensorFinsupp' _ _ _).symm.injective
+  rw [← LinearEquiv.coe_toLinearMap, ← LinearMap.coe_comp]
+  congr!
+  ext i
+  simp [finsuppTensorFinsupp'_symm_single_eq_single_one_tmul]
+
+/-- Tensor product of linearly independent families is linearly
+independent under some flatness conditions.
+
+The flatness condition could be removed over domains.
+See `LinearIndependent.tensorProduct_of_isDomain`. -/
+lemma _root_.LinearIndependent.tensorProduct_of_flat_right [Module.Flat R N]
+    {ι ι' : Type*} {v : ι → M} (hv : LinearIndependent R v)
+    {w : ι' → N} (hw : LinearIndependent R w) :
+    LinearIndependent R fun i : ι × ι' ↦ v i.1 ⊗ₜ[R] w i.2 :=
+  (((TensorProduct.comm R N M).toLinearMap.linearIndependent_iff_of_injOn
+    (TensorProduct.comm R N M).injective.injOn).mpr
+      (hw.tensorProduct_of_flat_left hv)).comp Prod.swap Prod.swap_bijective.injective
+
+variable (p : Submodule R M) (q : Submodule R N)
+
+/-- If p and q are submodules of M and N respectively, and M and q are flat,
+then `p ⊗ q → M ⊗ N` is injective. -/
+theorem _root_.Module.Flat.tensorProduct_mapIncl_injective_of_right
+    [Module.Flat R M] [Module.Flat R q] : Function.Injective (mapIncl p q) :=
+  TensorProduct.map_injective_of_flat_flat _ _ p.subtype_injective q.subtype_injective
+
+/-- If p and q are submodules of M and N respectively, and N and p are flat,
+then `p ⊗ q → M ⊗ N` is injective. -/
+theorem _root_.Module.Flat.tensorProduct_mapIncl_injective_of_left
+    [Module.Flat R p] [Module.Flat R N] : Function.Injective (mapIncl p q) :=
+  TensorProduct.map_injective_of_flat_flat' _ _ p.subtype_injective q.subtype_injective
 
 end TensorProduct
 

--- a/Mathlib/RingTheory/Flat/Basic.lean
+++ b/Mathlib/RingTheory/Flat/Basic.lean
@@ -510,8 +510,8 @@ lemma map_injective_of_flat_flat'
 independent under some flatness conditions.
 
 The flatness condition could be removed over domains.
-See `LinearIndependent.tensorProduct_of_isDomain`. -/
-lemma _root_.LinearIndependent.tensorProduct_of_flat_left [Module.Flat R M]
+See `LinearIndependent.tmul_of_isDomain`. -/
+lemma _root_.LinearIndependent.tmul_of_flat_left [Module.Flat R M]
     {ι ι' : Type*} {v : ι → M} (hv : LinearIndependent R v)
     {w : ι' → N} (hw : LinearIndependent R w) :
     LinearIndependent R fun i : ι × ι' ↦ v i.1 ⊗ₜ[R] w i.2 := by
@@ -527,8 +527,8 @@ lemma _root_.LinearIndependent.tensorProduct_of_flat_left [Module.Flat R M]
 independent under some flatness conditions.
 
 The flatness condition could be removed over domains.
-See `LinearIndependent.tensorProduct_of_isDomain`. -/
-lemma _root_.LinearIndependent.tensorProduct_of_flat_right [Module.Flat R N]
+See `LinearIndependent.tmul_of_isDomain`. -/
+lemma _root_.LinearIndependent.tmul_of_flat_right [Module.Flat R N]
     {ι ι' : Type*} {v : ι → M} (hv : LinearIndependent R v)
     {w : ι' → N} (hw : LinearIndependent R w) :
     LinearIndependent R fun i : ι × ι' ↦ v i.1 ⊗ₜ[R] w i.2 :=

--- a/Mathlib/RingTheory/Flat/Basic.lean
+++ b/Mathlib/RingTheory/Flat/Basic.lean
@@ -534,7 +534,7 @@ lemma _root_.LinearIndependent.tmul_of_flat_right [Module.Flat R N]
     LinearIndependent R fun i : ι × ι' ↦ v i.1 ⊗ₜ[R] w i.2 :=
   (((TensorProduct.comm R N M).toLinearMap.linearIndependent_iff_of_injOn
     (TensorProduct.comm R N M).injective.injOn).mpr
-      (hw.tensorProduct_of_flat_left hv)).comp Prod.swap Prod.swap_bijective.injective
+      (hw.tmul_of_flat_left hv)).comp Prod.swap Prod.swap_bijective.injective
 
 variable (p : Submodule R M) (q : Submodule R N)
 

--- a/Mathlib/RingTheory/Flat/Domain.lean
+++ b/Mathlib/RingTheory/Flat/Domain.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2025 Andrew Yang. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Andrew Yang, Christian Merten
+Authors: Andrew Yang
 -/
 import Mathlib.LinearAlgebra.Basis.VectorSpace
 import Mathlib.RingTheory.Flat.Localization

--- a/Mathlib/RingTheory/Flat/Domain.lean
+++ b/Mathlib/RingTheory/Flat/Domain.lean
@@ -7,20 +7,19 @@ import Mathlib.LinearAlgebra.Basis.VectorSpace
 import Mathlib.RingTheory.Flat.Localization
 
 /-!
-
 # Flat modules in domains
 
 We show that the tensor product of two injective linear maps is injective if the sources are flat
 and the ring is an integral domain.
-
 -/
+
 universe u
 
 variable {R M N : Type*} [CommRing R] [AddCommGroup M] [Module R M]
 variable [AddCommGroup N] [Module R N]
 variable {P Q : Type*} [AddCommGroup P] [Module R P] [AddCommGroup Q] [Module R Q]
 
-open TensorProduct
+open TensorProduct Function
 
 attribute [local instance 1100] Module.Free.of_divisionRing Module.Flat.of_free in
 /-- Tensor product of injective maps over domains are injective under some flatness conditions.
@@ -28,8 +27,7 @@ Also see `TensorProduct.map_injective_of_flat_flat`
 for different flatness conditions but without the domain assumption. -/
 lemma TensorProduct.map_injective_of_flat_flat_of_isDomain [IsDomain R]
     (f : P →ₗ[R] M) (g : Q →ₗ[R] N) [H : Module.Flat R P] [Module.Flat R Q]
-    (hf : Function.Injective f) (hg : Function.Injective g) :
-    Function.Injective (TensorProduct.map f g) := by
+    (hf : Injective f) (hg : Injective g) : Injective (TensorProduct.map f g) := by
   let K := FractionRing R
   refine .of_comp (f := TensorProduct.mk R K _ 1) ?_
   have H₁ := TensorProduct.map_injective_of_flat_flat (f.baseChange K) (g.baseChange K)
@@ -54,8 +52,8 @@ lemma TensorProduct.map_injective_of_flat_flat_of_isDomain [IsDomain R]
 
 /-- Tensor product of linearly independent families is linearly independent over domains.
 This is true over non-domains if one of the modules is flat.
-See `LinearIndependent.tensorProduct_of_flat_left`. -/
-lemma LinearIndependent.tensorProduct_of_isDomain [IsDomain R]
+See `LinearIndependent.tmul_of_flat_left`. -/
+lemma LinearIndependent.tmul_of_isDomain [IsDomain R]
     {ι ι' : Type*} {v : ι → M} (hv : LinearIndependent R v)
     {w : ι' → N} (hw : LinearIndependent R w) :
     LinearIndependent R fun i : ι × ι' ↦ v i.1 ⊗ₜ[R] w i.2 := by

--- a/Mathlib/RingTheory/Flat/Domain.lean
+++ b/Mathlib/RingTheory/Flat/Domain.lean
@@ -1,0 +1,68 @@
+/-
+Copyright (c) 2025 Andrew Yang. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Andrew Yang, Christian Merten
+-/
+import Mathlib.LinearAlgebra.Basis.VectorSpace
+import Mathlib.RingTheory.Flat.Localization
+
+/-!
+
+# Flat modules in domains
+
+We show that the tensor product of two injective linear maps is injective if the sources are flat
+and the ring is an integral domain.
+
+-/
+universe u
+
+variable {R M N : Type*} [CommRing R] [AddCommGroup M] [Module R M]
+variable [AddCommGroup N] [Module R N]
+variable {P Q : Type*} [AddCommGroup P] [Module R P] [AddCommGroup Q] [Module R Q]
+
+open TensorProduct
+
+attribute [local instance 1100] Module.Free.of_divisionRing Module.Flat.of_free in
+/-- Tensor product of injective maps over domains are injective under some flatness conditions.
+Also see `TensorProduct.map_injective_of_flat_flat`
+for different flatness conditions but without the domain assumption. -/
+lemma TensorProduct.map_injective_of_flat_flat_of_isDomain [IsDomain R]
+    (f : P →ₗ[R] M) (g : Q →ₗ[R] N) [H : Module.Flat R P] [Module.Flat R Q]
+    (hf : Function.Injective f) (hg : Function.Injective g) :
+    Function.Injective (TensorProduct.map f g) := by
+  let K := FractionRing R
+  refine .of_comp (f := TensorProduct.mk R K _ 1) ?_
+  have H₁ := TensorProduct.map_injective_of_flat_flat (f.baseChange K) (g.baseChange K)
+    (Module.Flat.lTensor_preserves_injective_linearMap f hf)
+    (Module.Flat.lTensor_preserves_injective_linearMap g hg)
+  have H₂ := (AlgebraTensorModule.cancelBaseChange R K K (K ⊗[R] P) Q).symm.injective
+  have H₃ := (AlgebraTensorModule.cancelBaseChange R K K (K ⊗[R] M) N).injective
+  have H₄ := (AlgebraTensorModule.assoc R R K K P Q).symm.injective
+  have H₅ := (AlgebraTensorModule.assoc R R K K M N).injective
+  have H₆ := Module.Flat.rTensor_preserves_injective_linearMap (M := P ⊗[R] Q)
+    (Algebra.linearMap R K) (FaithfulSMul.algebraMap_injective R K)
+  have H₇ := (TensorProduct.lid R (P ⊗[R] Q)).symm.injective
+  convert H₅.comp <| H₃.comp <| H₁.comp <| H₂.comp <| H₄.comp <| H₆.comp <| H₇
+  dsimp only [← LinearMap.coe_comp, ← LinearEquiv.coe_toLinearMap,
+    ← @LinearMap.coe_restrictScalars R K]
+  congr! 1
+  ext p q
+  -- `simp` solves the goal but it times out
+  change (1 : K) ⊗ₜ[R] f p ⊗ₜ[R] g q = (AlgebraTensorModule.assoc R R K K M N)
+    (((1 : K) • (algebraMap R K) 1 ⊗ₜ[R] f p) ⊗ₜ[R] g q)
+  simp only [map_one, one_smul, AlgebraTensorModule.assoc_tmul]
+
+/-- Tensor product of linearly independent families is linearly independent over domains.
+This is true over non-domains if one of the modules is flat.
+See `LinearIndependent.tensorProduct_of_flat_left`. -/
+lemma LinearIndependent.tensorProduct_of_isDomain [IsDomain R]
+    {ι ι' : Type*} {v : ι → M} (hv : LinearIndependent R v)
+    {w : ι' → N} (hw : LinearIndependent R w) :
+    LinearIndependent R fun i : ι × ι' ↦ v i.1 ⊗ₜ[R] w i.2 := by
+  rw [LinearIndependent]
+  convert (TensorProduct.map_injective_of_flat_flat_of_isDomain _ _ hv hw).comp
+    (finsuppTensorFinsupp' _ _ _).symm.injective
+  rw [← LinearEquiv.coe_toLinearMap, ← LinearMap.coe_comp]
+  congr!
+  ext i
+  simp [finsuppTensorFinsupp'_symm_single_eq_single_one_tmul]


### PR DESCRIPTION
There are also different conditions where the result is true. But I have yet to find a more general statement that encompasses all these results.

See #24219 or https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Tensor.20product.20of.20linearly.20independent.20families/near/513258021

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
