### PR TITLE
[Merged by Bors] - refactor(PerfectPairing): rename the structure fields

### DIFF
--- a/Mathlib/Algebra/Lie/Weights/RootSystem.lean
+++ b/Mathlib/Algebra/Lie/Weights/RootSystem.lean
@@ -389,9 +389,8 @@ def rootSystem :
     (fun ⟨α, hα⟩ ↦ by simpa using root_apply_coroot <| by simpa using hα)
     (by
       rintro ⟨α, hα⟩ - ⟨⟨β, hβ⟩, rfl⟩
-      simp only [Function.Embedding.coeFn_mk, IsReflexive.toPerfectPairingDual_toLin,
-        Function.comp_apply, Set.mem_range, Subtype.exists, exists_prop]
-      exact ⟨reflectRoot α β, (by simpa using reflectRoot_isNonZero α β <| by simpa using hβ), rfl⟩)
+      simpa using
+        ⟨reflectRoot α β, by simpa using reflectRoot_isNonZero α β <| by simpa using hβ, rfl⟩)
     (by convert span_weight_isNonZero_eq_top K L H; ext; simp)
     (fun α β ↦
       ⟨chainBotCoeff β.1 α.1 - chainTopCoeff β.1 α.1, by simp [apply_coroot_eq_cast β.1 α.1]⟩)

--- a/Mathlib/LinearAlgebra/PerfectPairing/Basic.lean
+++ b/Mathlib/LinearAlgebra/PerfectPairing/Basic.lean
@@ -48,6 +48,10 @@ variable {R M N}
 
 namespace PerfectPairing
 
+@[deprecated (since := "2025-04-20")] alias toLin := toLinearMap
+@[deprecated (since := "2025-04-20")] alias bijectiveLeft := bijective_left
+@[deprecated (since := "2025-04-20")] alias bijectiveRight := bijective_right
+
 /-- If the coefficients are a field, and one of the spaces is finite-dimensional, it is sufficient
 to check only injectivity instead of bijectivity of the bilinear form. -/
 def mkOfInjective {K V W : Type*}
@@ -82,6 +86,8 @@ instance instFunLike : FunLike (PerfectPairing R M N) M (N →ₗ[R] R) where
 
 @[simp]
 lemma toLinearMap_apply (p : PerfectPairing R M N) (x : M) : p.toLinearMap x = p x := rfl
+
+@[deprecated (since := "2025-04-20")] alias toLin_apply := toLinearMap_apply
 
 @[simp]
 lemma mk_apply_apply {f : M →ₗ[R] N →ₗ[R] R} {hl} {hr} {x : M} :

--- a/Mathlib/LinearAlgebra/PerfectPairing/Basic.lean
+++ b/Mathlib/LinearAlgebra/PerfectPairing/Basic.lean
@@ -37,12 +37,12 @@ noncomputable section
 variable (R M N : Type*) [CommRing R] [AddCommGroup M] [Module R M] [AddCommGroup N] [Module R N]
 
 /-- A perfect pairing of two (left) modules over a commutative ring. -/
-structure PerfectPairing where
-  toLin : M →ₗ[R] N →ₗ[R] R
-  bijectiveLeft : Bijective toLin
-  bijectiveRight : Bijective toLin.flip
+structure PerfectPairing extends M →ₗ[R] N →ₗ[R] R where
+  bijective_left : Bijective toLinearMap
+  bijective_right : Bijective toLinearMap.flip
 
-attribute [nolint docBlame] PerfectPairing.toLin
+/-- The underlying bilinear map of a perfect pairing. -/
+add_decl_doc PerfectPairing.toLinearMap
 
 variable {R M N}
 
@@ -56,9 +56,9 @@ def mkOfInjective {K V W : Type*}
     (h : Injective B)
     (h' : Injective B.flip) :
     PerfectPairing K V W where
-  toLin := B
-  bijectiveLeft := ⟨h, by rwa [← B.flip_injective_iff₁]⟩
-  bijectiveRight := ⟨h', by
+  toLinearMap := B
+  bijective_left := ⟨h, by rwa [← B.flip_injective_iff₁]⟩
+  bijective_right := ⟨h', by
     have : FiniteDimensional K W := FiniteDimensional.of_injective B.flip h'
     rwa [← B.flip.flip_injective_iff₁, LinearMap.flip_flip]⟩
 
@@ -70,19 +70,18 @@ def mkOfInjective' {K V W : Type*}
     (h : Injective B)
     (h' : Injective B.flip) :
     PerfectPairing K V W where
-  toLin := B
-  bijectiveLeft := ⟨h, by
+  toLinearMap := B
+  bijective_left := ⟨h, by
     have : FiniteDimensional K V := FiniteDimensional.of_injective B h
     rwa [← B.flip_injective_iff₁]⟩
-  bijectiveRight := ⟨h', by rwa [← B.flip.flip_injective_iff₁, LinearMap.flip_flip]⟩
+  bijective_right := ⟨h', by rwa [← B.flip.flip_injective_iff₁, LinearMap.flip_flip]⟩
 
 instance instFunLike : FunLike (PerfectPairing R M N) M (N →ₗ[R] R) where
-  coe f := f.toLin
+  coe f := f.toLinearMap
   coe_injective' x y h := by cases x; cases y; simpa using h
 
 @[simp]
-lemma toLin_apply (p : PerfectPairing R M N) {x : M} : p.toLin x = p x := by
-  rfl
+lemma toLinearMap_apply (p : PerfectPairing R M N) (x : M) : p.toLinearMap x = p x := rfl
 
 @[simp]
 lemma mk_apply_apply {f : M →ₗ[R] N →ₗ[R] R} {hl} {hr} {x : M} :
@@ -93,9 +92,9 @@ variable (p : PerfectPairing R M N)
 
 /-- Given a perfect pairing between `M` and `N`, we may interchange the roles of `M` and `N`. -/
 protected def flip : PerfectPairing R N M where
-  toLin := p.toLin.flip
-  bijectiveLeft := p.bijectiveRight
-  bijectiveRight := p.bijectiveLeft
+  toLinearMap := p.toLinearMap.flip
+  bijective_left := p.bijective_right
+  bijective_right := p.bijective_left
 
 @[simp]
 lemma flip_apply_apply {x : M} {y : N} : p.flip y x = p x y :=
@@ -107,7 +106,7 @@ lemma flip_flip : p.flip.flip = p :=
 
 /-- The linear equivalence from `M` to `Dual R N` induced by a perfect pairing. -/
 def toDualLeft : M ≃ₗ[R] Dual R N :=
-  LinearEquiv.ofBijective p.toLin p.bijectiveLeft
+  LinearEquiv.ofBijective p.toLinearMap p.bijective_left
 
 @[simp]
 theorem toDualLeft_apply (a : M) : p.toDualLeft a = p a :=
@@ -179,8 +178,8 @@ instance : EquivLike (PerfectPairing R M N) M (Dual R N) where
     exact LinearMap.congr_fun (LinearEquiv.congr_fun h m) n
 
 instance : LinearEquivClass (PerfectPairing R M N) R M (Dual R N) where
-  map_add p m₁ m₂ := p.toLin.map_add m₁ m₂
-  map_smulₛₗ p t m := p.toLin.map_smul t m
+  map_add p m₁ m₂ := p.toLinearMap.map_add m₁ m₂
+  map_smulₛₗ p t m := p.toLinearMap.map_smul t m
 
 include p in
 theorem finrank_eq [Module.Finite R M] [Module.Free R M] :
@@ -232,11 +231,11 @@ end PerfectPairing
 variable [IsReflexive R M]
 
 /-- A reflexive module has a perfect pairing with its dual. -/
-@[simps]
+@[simps!]
 def IsReflexive.toPerfectPairingDual : PerfectPairing R (Dual R M) M where
-  toLin := LinearMap.id
-  bijectiveLeft := bijective_id
-  bijectiveRight := bijective_dual_eval R M
+  toLinearMap := .id
+  bijective_left := bijective_id
+  bijective_right := bijective_dual_eval R M
 
 @[simp]
 lemma IsReflexive.toPerfectPairingDual_apply {f : Dual R M} {x : M} :
@@ -273,11 +272,10 @@ lemma isReflexive_of_equiv_dual_of_isReflexive : IsReflexive R N := by
   ext; rfl
 
 /-- If `M` is reflexive then a linear equivalence `N ≃ Dual R M` is a perfect pairing. -/
-@[simps]
 def toPerfectPairing : PerfectPairing R N M where
-  toLin := e
-  bijectiveLeft := e.bijective
-  bijectiveRight := e.flip.bijective
+  toLinearMap := e
+  bijective_left := e.bijective
+  bijective_right := e.flip.bijective
 
 end LinearEquiv
 

--- a/Mathlib/LinearAlgebra/PerfectPairing/Restrict.lean
+++ b/Mathlib/LinearAlgebra/PerfectPairing/Restrict.lean
@@ -72,8 +72,8 @@ definitional control). -/
 def restrict :
     PerfectPairing R M' N' where
   toLin := p.toLin.compl₁₂ i j
-  bijectiveLeft := p.restrict_aux i j hi hj hij
-  bijectiveRight := p.flip.restrict_aux j i hj hi hij.flip
+  bijective_left := p.restrict_aux i j hi hj hij
+  bijective_right := p.flip.restrict_aux j i hj hi hij.flip
 
 @[simp]
 lemma restrict_apply_apply (x : M') (y : N') :
@@ -115,7 +115,7 @@ private lemma restrictScalarsAux_injective
     | zero => simp
     | add => rw [← p.toLin_apply, map_add]; aesop
     | smul => rw [← p.toLin_apply, map_smul]; aesop
-  rw [← i.map_eq_zero_iff hi, ← p.toLin.map_eq_zero_iff p.bijectiveLeft.injective]
+  rw [← i.map_eq_zero_iff hi, ← p.toLin.map_eq_zero_iff p.bijective_left.injective]
   ext n
   simpa using hx n
 
@@ -145,9 +145,9 @@ def restrictScalars
     (hp : ∀ m n, p (i m) (j n) ∈ (algebraMap S R).range) :
     PerfectPairing S M' N' :=
   { toLin := p.restrictScalarsAux i j hp
-    bijectiveLeft := ⟨p.restrictScalarsAux_injective i j hi hN hp,
+    bijective_left := ⟨p.restrictScalarsAux_injective i j hi hN hp,
       p.restrictScalarsAux_surjective i j h₁ hp⟩
-    bijectiveRight := ⟨p.flip.restrictScalarsAux_injective j i hj hM (fun m n ↦ hp n m),
+    bijective_right := ⟨p.flip.restrictScalarsAux_injective j i hj hM (fun m n ↦ hp n m),
       p.flip.restrictScalarsAux_surjective j i h₂ (fun m n ↦ hp n m)⟩}
 
 end RestrictScalars

--- a/Mathlib/LinearAlgebra/PerfectPairing/Restrict.lean
+++ b/Mathlib/LinearAlgebra/PerfectPairing/Restrict.lean
@@ -41,8 +41,7 @@ variable {M' N' : Type*} [AddCommGroup M'] [Module R M'] [AddCommGroup N'] [Modu
 
 include hi hj hij
 
-private lemma restrict_aux :
-    Bijective (p.toLin.compl₁₂ i j) := by
+private lemma restrict_aux : Bijective (p.toLinearMap.compl₁₂ i j) := by
   refine ⟨LinearMap.ker_eq_bot.mp <| eq_bot_iff.mpr fun m hm ↦ ?_, fun f ↦ ?_⟩
   · replace hm : i m ∈ (LinearMap.range j).dualAnnihilator.map p.toDualLeft.symm := by
       simp only [Submodule.mem_map, Submodule.mem_dualAnnihilator]
@@ -68,10 +67,9 @@ private lemma restrict_aux :
 
 /-- The restriction of a perfect pairing to submodules (expressed as injections to provide
 definitional control). -/
-@[simps]
-def restrict :
-    PerfectPairing R M' N' where
-  toLin := p.toLin.compl₁₂ i j
+@[simps!]
+def restrict : PerfectPairing R M' N' where
+  toLinearMap := p.toLinearMap.compl₁₂ i j
   bijective_left := p.restrict_aux i j hi hj hij
   bijective_right := p.flip.restrict_aux j i hj hi hij.flip
 
@@ -95,7 +93,7 @@ private def restrictScalarsAux
     (hp : ∀ m n, p (i m) (j n) ∈ (algebraMap S R).range) :
     M' →ₗ[S] N' →ₗ[S] S :=
  LinearMap.restrictScalarsRange i j (Algebra.linearMap S R)
-    (FaithfulSMul.algebraMap_injective S R) p.toLin hp
+    (FaithfulSMul.algebraMap_injective S R) p.toLinearMap hp
 
 private lemma restrictScalarsAux_injective
     (hi : Injective i)
@@ -103,7 +101,7 @@ private lemma restrictScalarsAux_injective
     (hp : ∀ m n, p (i m) (j n) ∈ (algebraMap S R).range) :
     Injective (p.restrictScalarsAux i j hp) := by
   let f := LinearMap.restrictScalarsRange i j (Algebra.linearMap S R)
-      (FaithfulSMul.algebraMap_injective S R) p.toLin hp
+      (FaithfulSMul.algebraMap_injective S R) p.toLinearMap hp
   rw [← LinearMap.ker_eq_bot]
   refine (Submodule.eq_bot_iff _).mpr fun x (hx : f x = 0) ↦ ?_
   replace hx (n : N) : p (i x) n = 0 := by
@@ -113,9 +111,9 @@ private lemma restrictScalarsAux_injective
       obtain ⟨n', rfl⟩ := hz
       simpa [f] using LinearMap.congr_fun hx n'
     | zero => simp
-    | add => rw [← p.toLin_apply, map_add]; aesop
-    | smul => rw [← p.toLin_apply, map_smul]; aesop
-  rw [← i.map_eq_zero_iff hi, ← p.toLin.map_eq_zero_iff p.bijective_left.injective]
+    | add => rw [← p.toLinearMap_apply, map_add]; aesop
+    | smul => rw [← p.toLinearMap_apply, map_smul]; aesop
+  rw [← i.map_eq_zero_iff hi, ← p.toLinearMap.map_eq_zero_iff p.bijective_left.injective]
   ext n
   simpa using hx n
 
@@ -144,7 +142,7 @@ def restrictScalars
       (p.toDualRight (j n)).restrictScalars S ∘ₗ i = Algebra.linearMap S R ∘ₗ g)
     (hp : ∀ m n, p (i m) (j n) ∈ (algebraMap S R).range) :
     PerfectPairing S M' N' :=
-  { toLin := p.restrictScalarsAux i j hp
+  { toLinearMap := p.restrictScalarsAux i j hp
     bijective_left := ⟨p.restrictScalarsAux_injective i j hi hN hp,
       p.restrictScalarsAux_surjective i j h₁ hp⟩
     bijective_right := ⟨p.flip.restrictScalarsAux_injective j i hj hM (fun m n ↦ hp n m),
@@ -251,7 +249,7 @@ def restrictScalarsField
         exact (LinearMap.range j).span_range_inclusionSpan L)
     (fun x y ↦ LinearMap.BilinMap.apply_apply_mem_of_mem_span
       (LinearMap.range <| Algebra.linearMap K L) (range i) (range j)
-      ((LinearMap.restrictScalarsₗ K L _ _ _).comp (p.toLin.restrictScalars K))
+      ((LinearMap.restrictScalarsₗ K L _ _ _).comp (p.toLinearMap.restrictScalars K))
       (by simpa) (i x) (j y) (subset_span (mem_range_self x)) (subset_span (mem_range_self y)))
 
 @[simp] lemma restrictScalarsField_apply_apply
@@ -260,7 +258,7 @@ def restrictScalarsField
     (x : M') (y : N') :
     algebraMap K L (p.restrictScalarsField i j hi hj hij hp x y) = p (i x) (j y) :=
   LinearMap.restrictScalarsRange_apply i j (Algebra.linearMap K L)
-    (FaithfulSMul.algebraMap_injective K L) p.toLin hp x y
+    (FaithfulSMul.algebraMap_injective K L) p.toLinearMap hp x y
 
 end Field
 

--- a/Mathlib/LinearAlgebra/RootSystem/BaseChange.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/BaseChange.lean
@@ -70,7 +70,7 @@ def restrictScalars' :
       (injective_subtype _) (injective_subtype _) (by simpa using IsBalanced.isPerfectCompl)
       (fun x y ↦ LinearMap.BilinMap.apply_apply_mem_of_mem_span
         (LinearMap.range (Algebra.linearMap K L)) (range P.root) (range P.coroot)
-        ((LinearMap.restrictScalarsₗ K L _ _ _) ∘ₗ (P.toPerfectPairing.toLin.restrictScalars K))
+        (LinearMap.restrictScalarsₗ K L _ _ _ ∘ₗ P.toPerfectPairing.toLinearMap.restrictScalars K)
         (by rintro - ⟨i, rfl⟩ - ⟨j, rfl⟩; exact hP i j) _ _ x.property y.property))
     root := ⟨fun i ↦ ⟨_, subset_span (mem_range_self i)⟩, fun i j h ↦ by simpa using h⟩
     coroot := ⟨fun i ↦ ⟨_, subset_span (mem_range_self i)⟩, fun i j h ↦ by simpa using h⟩

--- a/Mathlib/LinearAlgebra/RootSystem/Basic.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Basic.lean
@@ -81,7 +81,7 @@ lemma injOn_dualMap_subtype_span_root_coroot [NoZeroSMulDivisors ℤ M] :
   have := injOn_dualMap_subtype_span_range_range (finite_range P.root)
     (c := P.toLin.flip ∘ P.coroot) P.root_coroot_two P.mapsTo_reflection_root
   rintro - ⟨i, rfl⟩ - ⟨j, rfl⟩ hij
-  exact P.bijectiveRight.injective <| this (mem_range_self i) (mem_range_self j) hij
+  exact P.bijective_right.injective <| this (mem_range_self i) (mem_range_self j) hij
 
 /-- In characteristic zero if there is no torsion, the correspondence between roots and coroots is
 unique.
@@ -143,7 +143,7 @@ private lemma coroot_eq_coreflection_of_root_eq' [CharZero R] [NoZeroSMulDivisor
       LinearMap.smul_apply]
     rw [mul_comm (p (root i) (coroot j))]
     abel
-  suffices p.flip (coroot k) = p.flip (coroot l) from p.bijectiveRight.injective this
+  suffices p.flip (coroot k) = p.flip (coroot l) from p.bijective_right.injective this
   have _i : NoZeroSMulDivisors ℤ M := NoZeroSMulDivisors.int_of_charZero R M
   have := injOn_dualMap_subtype_span_range_range (finite_range root)
     (c := p.flip ∘ coroot) hp hr
@@ -202,7 +202,7 @@ protected lemma ext [CharZero R] [NoZeroSMulDivisors R M]
   clear! P₁ P₂
   rintro P₁ P₂ he hr - ⟨i, rfl⟩
   use i
-  apply P₁.bijectiveRight.injective
+  apply P₁.bijective_right.injective
   apply Dual.eq_of_preReflection_mapsTo (finite_range P₁.root) P₁.span_root_eq_top
   · exact hr ▸ he ▸ P₂.coroot_root_two i
   · exact hr ▸ he ▸ P₂.mapsTo_reflection_root i
@@ -231,7 +231,7 @@ private lemma coroot_eq_coreflection_of_root_eq_of_span_eq_top [CharZero R] [NoZ
     simp [α, β, α', β', sα, sβ, sα', ← preReflection_preReflection β (p.flip β') hpi,
       preReflection_apply] -- v4.7.0-rc1 issues
   have hk₀ : root k ≠ 0 := fun h ↦ by simpa [h, ← PerfectPairing.toLin_apply] using hp k
-  apply p.bijectiveRight.injective
+  apply p.bijective_right.injective
   apply Dual.eq_of_preReflection_mapsTo (finite_range root) hsp (hp k) (hs k)
   · simp [map_sub, α, β, α', β', sα, sβ, sα', hk, preReflection_apply, hp i, hp j, mul_two,
       mul_comm (p α β')]

--- a/Mathlib/LinearAlgebra/RootSystem/Basic.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Basic.lean
@@ -41,14 +41,15 @@ namespace RootPairing
 section reflection_perm
 
 variable (p : PerfectPairing R M N) (root : ι ↪ M) (coroot : ι ↪ N) (i j : ι)
-  (h : ∀ i, MapsTo (preReflection (root i) (p.toLin.flip (coroot i))) (range root) (range root))
+  (h : ∀ i, MapsTo (preReflection (root i) (p.toLinearMap.flip (coroot i)))
+    (range root) (range root))
 include h
 
 private theorem exist_eq_reflection_of_mapsTo :
     ∃ k, root k = (preReflection (root i) (p.flip (coroot i))) (root j) :=
   h i (mem_range_self j)
 
-variable (hp : ∀ i, p.toLin (root i) (coroot i) = 2)
+variable (hp : ∀ i, p.toLinearMap (root i) (coroot i) = 2)
 include hp
 
 private theorem choose_choose_eq_of_mapsTo :
@@ -77,9 +78,9 @@ roots. The proof depends crucially on the fact that there are finitely-many root
 
 Modulo trivial generalisations, this statement is exactly Lemma 1.1.4 on page 87 of SGA 3 XXI. -/
 lemma injOn_dualMap_subtype_span_root_coroot [NoZeroSMulDivisors ℤ M] :
-    InjOn ((span R (range P.root)).subtype.dualMap ∘ₗ P.toLin.flip) (range P.coroot) := by
+    InjOn ((span R (range P.root)).subtype.dualMap ∘ₗ P.toLinearMap.flip) (range P.coroot) := by
   have := injOn_dualMap_subtype_span_range_range (finite_range P.root)
-    (c := P.toLin.flip ∘ P.coroot) P.root_coroot_two P.mapsTo_reflection_root
+    (c := P.toLinearMap.flip ∘ P.coroot) P.root_coroot_two P.mapsTo_reflection_root
   rintro - ⟨i, rfl⟩ - ⟨j, rfl⟩ hij
   exact P.bijective_right.injective <| this (mem_range_self i) (mem_range_self j) hij
 
@@ -134,7 +135,7 @@ private lemma coroot_eq_coreflection_of_root_eq' [CharZero R] [NoZeroSMulDivisor
     have hpi : (p.flip (coroot i)) (root i) = 2 := by rw [PerfectPairing.flip_apply_apply, hp i]
     simp [α, β, α', β', sα, sβ, sα', ← preReflection_preReflection β (p.flip β') hpi,
       preReflection_apply]
-  have hk₀ : root k ≠ 0 := fun h ↦ by simpa [h, ← PerfectPairing.toLin_apply] using hp k
+  have hk₀ : root k ≠ 0 := fun h ↦ by simpa [h, ← PerfectPairing.toLinearMap_apply] using hp k
   obtain ⟨l, hl⟩ := hc i (mem_range_self j)
   rw [← hl]
   have hkl : (p.flip (coroot l)) (root k) = 2 := by
@@ -225,12 +226,12 @@ private lemma coroot_eq_coreflection_of_root_eq_of_span_eq_top [CharZero R] [NoZ
   set sα := preReflection α (p.flip α')
   set sβ := preReflection β (p.flip β')
   let sα' := preReflection α' (p α)
-  have hij : preReflection (sα β) (p.toLin.flip (sα' β')) = sα ∘ₗ sβ ∘ₗ sα := by
+  have hij : preReflection (sα β) (p.toLinearMap.flip (sα' β')) = sα ∘ₗ sβ ∘ₗ sα := by
     ext
     have hpi : (p.flip (coroot i)) (root i) = 2 := by rw [PerfectPairing.flip_apply_apply, hp i]
     simp [α, β, α', β', sα, sβ, sα', ← preReflection_preReflection β (p.flip β') hpi,
       preReflection_apply] -- v4.7.0-rc1 issues
-  have hk₀ : root k ≠ 0 := fun h ↦ by simpa [h, ← PerfectPairing.toLin_apply] using hp k
+  have hk₀ : root k ≠ 0 := fun h ↦ by simpa [h, ← PerfectPairing.toLinearMap_apply] using hp k
   apply p.bijective_right.injective
   apply Dual.eq_of_preReflection_mapsTo (finite_range root) hsp (hp k) (hs k)
   · simp [map_sub, α, β, α', β', sα, sβ, sα', hk, preReflection_apply, hp i, hp j, mul_two,
@@ -247,8 +248,9 @@ def mk' {k : Type*} [Field k] [CharZero k] [Module k M] [Module k N]
     (p : PerfectPairing k M N)
     (root : ι ↪ M)
     (coroot : ι ↪ N)
-    (hp : ∀ i, p.toLin (root i) (coroot i) = 2)
-    (hs : ∀ i, MapsTo (preReflection (root i) (p.toLin.flip (coroot i))) (range root) (range root))
+    (hp : ∀ i, p.toLinearMap (root i) (coroot i) = 2)
+    (hs : ∀ i, MapsTo (preReflection (root i) (p.toLinearMap.flip (coroot i)))
+      (range root) (range root))
     (hsp : span k (range root) = ⊤)
     (h_int : ∀ i j, ∃ z : ℤ, z = p (root i) (coroot j)) :
     RootSystem ι k M N :=

--- a/Mathlib/LinearAlgebra/RootSystem/Finite/CanonicalBilinear.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Finite/CanonicalBilinear.lean
@@ -106,11 +106,11 @@ lemma toPerfectPairing_apply_CoPolarization (x : N) :
   exact P.flip.toPerfectPairing_apply_apply_Polarization x y
 
 lemma flip_comp_polarization_eq_rootForm :
-    P.flip.toLin ∘ₗ P.Polarization = P.RootForm := by
+    P.flip.toLinearMap ∘ₗ P.Polarization = P.RootForm := by
   ext; simp [rootForm_apply_apply, RootPairing.flip]
 
 lemma self_comp_coPolarization_eq_corootForm :
-    P.toLin ∘ₗ P.CoPolarization = P.CorootForm := by
+    P.toLinearMap ∘ₗ P.CoPolarization = P.CorootForm := by
   ext; simp [corootForm_apply_apply]
 
 lemma polarization_apply_eq_zero_iff (m : M) :

--- a/Mathlib/LinearAlgebra/RootSystem/Hom.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Hom.lean
@@ -609,9 +609,9 @@ def reflection (P : RootPairing ι R M N) (i : ι) : Aut P where
       PerfectPairing.toDualRight_apply, LinearMap.dualMap_apply, PerfectPairing.flip_apply_apply,
       LinearEquiv.comp_coe, LinearEquiv.trans_apply]
     rw [RootPairing.reflection_apply, RootPairing.coreflection_apply]
-    simp only [← PerfectPairing.toLin_apply, map_sub, map_smul, LinearMap.sub_apply,
-      toLin_toPerfectPairing, LinearMap.smul_apply, smul_eq_mul, sub_right_inj]
-    simp only [PerfectPairing.toLin_apply, PerfectPairing.flip_apply_apply, mul_comm]
+    simp only [← PerfectPairing.toLinearMap_apply, map_sub, map_smul, LinearMap.sub_apply,
+      toLinearMap_eq_toPerfectPairing, LinearMap.smul_apply, smul_eq_mul, sub_right_inj]
+    simp [mul_comm]
   root_weightMap := by ext; simp
   coroot_coweightMap := by ext; simp
   bijective_weightMap := by

--- a/Mathlib/LinearAlgebra/RootSystem/OfBilinear.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/OfBilinear.lean
@@ -144,8 +144,8 @@ def ofBilinear [IsReflexive R M] (B : M →ₗ[R] M →ₗ[R] R) (hNB : LinearMa
         dsimp only
         rw [h2x z, ← h2y z, hxy, h2xy] }
   root_coroot_two x := by
-    dsimp only [coe_setOf, Embedding.coe_subtype, PerfectPairing.toLin_apply, mem_setOf_eq, id_eq,
-      eq_mp_eq_cast, RingHom.id_apply, eq_mpr_eq_cast, cast_eq, LinearMap.sub_apply,
+    dsimp only [coe_setOf, Embedding.coe_subtype, PerfectPairing.toLinearMap_apply, mem_setOf_eq,
+      id_eq, eq_mp_eq_cast, RingHom.id_apply, eq_mpr_eq_cast, cast_eq, LinearMap.sub_apply,
       Embedding.coeFn_mk, PerfectPairing.flip_apply_apply]
     exact coroot_apply_self B x.2
   reflection_perm x :=


### PR DESCRIPTION
That way, they match the naming convention.

From Toric


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
