### PR TITLE
[Merged by Bors] - refactor: generalise `ContinuousLinearMap.restrictScalars` to semirings

### DIFF
--- a/Mathlib/Topology/Algebra/Module/LinearMap.lean
+++ b/Mathlib/Topology/Algebra/Module/LinearMap.lean
@@ -1009,75 +1009,72 @@ end CommRing
 
 section RestrictScalars
 
-variable {A M M₂ : Type*} [Ring A] [AddCommGroup M] [AddCommGroup M₂] [Module A M] [Module A M₂]
-  [TopologicalSpace M] [TopologicalSpace M₂] (R : Type*) [Ring R] [Module R M] [Module R M₂]
-  [LinearMap.CompatibleSMul M M₂ R A]
+section Semiring
+variable {A M₁ M₂ R S : Type*} [Semiring A] [Semiring R] [Semiring S]
+  [AddCommMonoid M₁] [Module A M₁] [Module R M₁] [TopologicalSpace M₁]
+  [AddCommMonoid M₂] [Module A M₂] [Module R M₂] [TopologicalSpace M₂]
+  [LinearMap.CompatibleSMul M₁ M₂ R A]
 
+variable (R) in
 /-- If `A` is an `R`-algebra, then a continuous `A`-linear map can be interpreted as a continuous
-`R`-linear map. We assume `LinearMap.CompatibleSMul M M₂ R A` to match assumptions of
+`R`-linear map. We assume `LinearMap.CompatibleSMul M₁ M₂ R A` to match assumptions of
 `LinearMap.map_smul_of_tower`. -/
-def restrictScalars (f : M →L[A] M₂) : M →L[R] M₂ :=
-  ⟨(f : M →ₗ[A] M₂).restrictScalars R, f.continuous⟩
-
-variable {R}
+def restrictScalars (f : M₁ →L[A] M₂) : M₁ →L[R] M₂ :=
+  ⟨(f : M₁ →ₗ[A] M₂).restrictScalars R, f.continuous⟩
 
 @[simp]
-theorem coe_restrictScalars (f : M →L[A] M₂) :
-    (f.restrictScalars R : M →ₗ[R] M₂) = (f : M →ₗ[A] M₂).restrictScalars R :=
-  rfl
+theorem toLinearMap_restrictScalars (f : M₁ →L[A] M₂) :
+    (f.restrictScalars R : M₁ →ₗ[R] M₂) = (f : M₁ →ₗ[A] M₂).restrictScalars R := rfl
 
 @[simp]
-theorem coe_restrictScalars' (f : M →L[A] M₂) : ⇑(f.restrictScalars R) = f :=
-  rfl
+theorem coe_restrictScalars (f : M₁ →L[A] M₂) : ⇑(f.restrictScalars R) = f := rfl
 
 @[simp]
-theorem toContinuousAddMonoidHom_restrictScalars (f : M →L[A] M₂) :
-    ↑(f.restrictScalars R) = (f : ContinuousAddMonoidHom M M₂) := rfl
+theorem toContinuousAddMonoidHom_restrictScalars (f : M₁ →L[A] M₂) :
+    ↑(f.restrictScalars R) = (f : ContinuousAddMonoidHom M₁ M₂) := rfl
+
+@[simp] lemma restrictScalars_zero : (0 : M₁ →L[A] M₂).restrictScalars R = 0 := rfl
 
 @[simp]
-theorem restrictScalars_zero : (0 : M →L[A] M₂).restrictScalars R = 0 :=
-  rfl
+lemma restrictScalars_add [ContinuousAdd M₂] (f g : M₁ →L[A] M₂) :
+    (f + g).restrictScalars R = f.restrictScalars R + g.restrictScalars R := rfl
 
-section
-
-variable [IsTopologicalAddGroup M₂]
+variable [Module S M₂] [ContinuousConstSMul S M₂] [SMulCommClass A S M₂] [SMulCommClass R S M₂]
 
 @[simp]
-theorem restrictScalars_add (f g : M →L[A] M₂) :
-    (f + g).restrictScalars R = f.restrictScalars R + g.restrictScalars R :=
-  rfl
-
-@[simp]
-theorem restrictScalars_neg (f : M →L[A] M₂) : (-f).restrictScalars R = -f.restrictScalars R :=
-  rfl
-
-end
-
-variable {S : Type*}
-variable [Ring S] [Module S M₂] [ContinuousConstSMul S M₂] [SMulCommClass A S M₂]
-  [SMulCommClass R S M₂]
-
-@[simp]
-theorem restrictScalars_smul (c : S) (f : M →L[A] M₂) :
+theorem restrictScalars_smul (c : S) (f : M₁ →L[A] M₂) :
     (c • f).restrictScalars R = c • f.restrictScalars R :=
   rfl
 
-variable (A M M₂ R S)
-variable [IsTopologicalAddGroup M₂]
+variable [ContinuousAdd M₂]
 
+variable (A R S M₁ M₂) in
 /-- `ContinuousLinearMap.restrictScalars` as a `LinearMap`. See also
 `ContinuousLinearMap.restrictScalarsL`. -/
-def restrictScalarsₗ : (M →L[A] M₂) →ₗ[S] M →L[R] M₂ where
+def restrictScalarsₗ : (M₁ →L[A] M₂) →ₗ[S] M₁ →L[R] M₂ where
   toFun := restrictScalars R
   map_add' := restrictScalars_add
   map_smul' := restrictScalars_smul
 
-variable {A M M₂ R S}
+@[simp]
+theorem coe_restrictScalarsₗ : ⇑(restrictScalarsₗ A M₁ M₂ R S) = restrictScalars R := rfl
+
+end Semiring
+
+section Ring
+variable {A R S M₁ M₂ : Type*} [Ring A] [Ring R] [Ring S]
+  [AddCommGroup M₁] [Module A M₁] [Module R M₁] [TopologicalSpace M₁]
+  [AddCommGroup M₂] [Module A M₂] [Module R M₂] [TopologicalSpace M₂]
+  [LinearMap.CompatibleSMul M₁ M₂ R A] [IsTopologicalAddGroup M₂]
 
 @[simp]
-theorem coe_restrictScalarsₗ : ⇑(restrictScalarsₗ A M M₂ R S) = restrictScalars R :=
-  rfl
+lemma restrictScalars_sub (f g : M₁ →L[A] M₂) :
+    (f - g).restrictScalars R = f.restrictScalars R - g.restrictScalars R := rfl
 
+@[simp]
+lemma restrictScalars_neg (f : M₁ →L[A] M₂) : (-f).restrictScalars R = -f.restrictScalars R := rfl
+
+end Ring
 end RestrictScalars
 
 end ContinuousLinearMap

--- a/Mathlib/Topology/Algebra/Module/LinearMap.lean
+++ b/Mathlib/Topology/Algebra/Module/LinearMap.lean
@@ -1023,13 +1023,11 @@ def restrictScalars (f : M₁ →L[A] M₂) : M₁ →L[R] M₂ :=
   ⟨(f : M₁ →ₗ[A] M₂).restrictScalars R, f.continuous⟩
 
 @[simp]
-theorem toLinearMap_restrictScalars (f : M₁ →L[A] M₂) :
+theorem coe_restrictScalars (f : M₁ →L[A] M₂) :
     (f.restrictScalars R : M₁ →ₗ[R] M₂) = (f : M₁ →ₗ[A] M₂).restrictScalars R := rfl
 
 @[simp]
-theorem coe_restrictScalars (f : M₁ →L[A] M₂) : ⇑(f.restrictScalars R) = f := rfl
-
-@[deprecated (since := "2025-04-21")] alias coe_restrictScalars' := coe_restrictScalars
+theorem coe_restrictScalars' (f : M₁ →L[A] M₂) : ⇑(f.restrictScalars R) = f := rfl
 
 @[simp]
 theorem toContinuousAddMonoidHom_restrictScalars (f : M₁ →L[A] M₂) :

--- a/Mathlib/Topology/Algebra/Module/LinearMap.lean
+++ b/Mathlib/Topology/Algebra/Module/LinearMap.lean
@@ -1029,6 +1029,8 @@ theorem toLinearMap_restrictScalars (f : M₁ →L[A] M₂) :
 @[simp]
 theorem coe_restrictScalars (f : M₁ →L[A] M₂) : ⇑(f.restrictScalars R) = f := rfl
 
+@[deprecated (since := "2025-04-21")] alias coe_restrictScalars' := coe_restrictScalars
+
 @[simp]
 theorem toContinuousAddMonoidHom_restrictScalars (f : M₁ →L[A] M₂) :
     ↑(f.restrictScalars R) = (f : ContinuousAddMonoidHom M₁ M₂) := rfl


### PR DESCRIPTION
The motivation here is to restrict scalars from `R` to `R≥0`, which happens when considering pointed cones as submodules.

Also rename the pair `M`, `M₂` to `M₁`, `M₂` for consistency.

From Toric

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
