### PR TITLE
[Merged by Bors] - feat: closed submodules

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -5776,6 +5776,7 @@ import Mathlib.Topology.Algebra.Module.Alternating.Topology
 import Mathlib.Topology.Algebra.Module.Basic
 import Mathlib.Topology.Algebra.Module.Cardinality
 import Mathlib.Topology.Algebra.Module.CharacterSpace
+import Mathlib.Topology.Algebra.Module.ClosedSubmodule
 import Mathlib.Topology.Algebra.Module.Compact
 import Mathlib.Topology.Algebra.Module.Determinant
 import Mathlib.Topology.Algebra.Module.Equiv

--- a/Mathlib/Topology/Algebra/Module/ClosedSubmodule.lean
+++ b/Mathlib/Topology/Algebra/Module/ClosedSubmodule.lean
@@ -145,10 +145,6 @@ instance instOrderBot : OrderBot (ClosedSubmodule R M) where
   bot := ⟨⊥, isClosed_singleton⟩
   bot_le s := bot_le (a := s.toSubmodule)
 
-instance instZero : Zero (ClosedSubmodule R M) where zero := ⟨0, isClosed_singleton⟩
-
-@[simp] lemma zero_eq_bot : (0 : ClosedSubmodule R M) = ⊥ := rfl
-
 @[simp, norm_cast] lemma toSubmodule_bot : toSubmodule (⊥ : ClosedSubmodule R M) = ⊥ := rfl
 
 @[simp, norm_cast] lemma coe_bot : ((⊥ : ClosedSubmodule R M) : Set M) = {0} := rfl

--- a/Mathlib/Topology/Algebra/Module/ClosedSubmodule.lean
+++ b/Mathlib/Topology/Algebra/Module/ClosedSubmodule.lean
@@ -77,7 +77,7 @@ lemma isClosed (s : ClosedSubmodule R M) : IsClosed (s : Set M) := s.isClosed'
 
 initialize_simps_projections ClosedSubmodule (carrier → coe, as_prefix coe)
 
-/-- The preimage of a closed submodule under a continuous linear map as a proper cone. -/
+/-- The preimage of a closed submodule under a continuous linear map as a closed submodule. -/
 @[simps!]
 def comap (f : M →L[R] N) (s : ClosedSubmodule R N) : ClosedSubmodule R M where
   toSubmodule := .comap f s
@@ -130,7 +130,7 @@ lemma toSubmodule_inf (s t : ClosedSubmodule R M) :
 
 @[simp] lemma mem_inf : x ∈ s ⊓ t ↔ x ∈ s ∧ x ∈ t := .rfl
 
-instance insttop : Top (ClosedSubmodule R M) where top := ⟨⊤, isClosed_univ⟩
+instance instTop : Top (ClosedSubmodule R M) where top := ⟨⊤, isClosed_univ⟩
 
 @[simp, norm_cast] lemma toSubmodule_top : toSubmodule (⊤ : ClosedSubmodule R M) = ⊤ := rfl
 

--- a/Mathlib/Topology/Algebra/Module/ClosedSubmodule.lean
+++ b/Mathlib/Topology/Algebra/Module/ClosedSubmodule.lean
@@ -182,8 +182,8 @@ variable [ContinuousAdd N] [ContinuousConstSMul R N] {f : M →L[R] N}
 /-- The closure of the image of a closed submodule under a continuous linear map is a closed
 submodule.
 
-
-We use continuous maps here so that the `comap` of `f` is also a map between closed submodules. -/
+`ClosedSubmodule.map f` is left-adjoint to `ClosedSubmodule.comap f`.
+See `ClosedSubmodule.gc_map_comap`. -/
 def map (f : M →L[R] N) (s : ClosedSubmodule R M) : ClosedSubmodule R N :=
   (s.toSubmodule.map f).closure
 

--- a/Mathlib/Topology/Algebra/Module/ClosedSubmodule.lean
+++ b/Mathlib/Topology/Algebra/Module/ClosedSubmodule.lean
@@ -3,7 +3,6 @@ Copyright (c) 2025 Yaël Dillies. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies
 -/
-import Mathlib.Algebra.Module.Submodule.Pointwise
 import Mathlib.Topology.Algebra.Module.LinearMap
 import Mathlib.Topology.Sets.Closeds
 

--- a/Mathlib/Topology/Algebra/Module/ClosedSubmodule.lean
+++ b/Mathlib/Topology/Algebra/Module/ClosedSubmodule.lean
@@ -32,10 +32,16 @@ variable (R M) in
 @[ext]
 structure ClosedSubmodule extends Submodule R M, Closeds M where
 
-attribute [coe] ClosedSubmodule.toSubmodule
-
 namespace ClosedSubmodule
 variable {s t : ClosedSubmodule R M} {x : M}
+
+attribute [coe] toSubmodule toCloseds
+
+/-- Reinterpret a closed submodule as a submodule. -/
+add_decl_doc toSubmodule
+
+/-- Reinterpret a closed submodule as a closed set. -/
+add_decl_doc toCloseds
 
 lemma toSubmodule_injective : Injective (toSubmodule : ClosedSubmodule R M → Submodule R M) :=
   fun s t h ↦ by cases s; congr!

--- a/Mathlib/Topology/Algebra/Module/ClosedSubmodule.lean
+++ b/Mathlib/Topology/Algebra/Module/ClosedSubmodule.lean
@@ -1,0 +1,178 @@
+/-
+Copyright (c) 2025 Yaël Dillies. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yaël Dillies
+-/
+import Mathlib.Algebra.Module.Submodule.Pointwise
+import Mathlib.Topology.Algebra.Module.LinearMap
+import Mathlib.Topology.Sets.Closeds
+
+/-!
+# Closed submodules of a topological module
+
+This files builds the frame of closed `R`-submodules of a topological module `M`.
+
+One can turn `s : Submodule R E` + `hs : IsClosed s` into `s : ClosedSubmodule R E` in a tactic
+block by doing `lift s to ClosedSubmodule R E using hs`.
+
+## TODO
+
+Actually provide the `Order.Frame (ClosedSubmodule R M)` instance.
+-/
+
+open Function Order TopologicalSpace
+
+variable {ι : Sort*} {R M N O : Type*} [Semiring R]
+  [AddCommMonoid M] [TopologicalSpace M] [Module R M]
+  [AddCommMonoid N] [TopologicalSpace N] [Module R N]
+  [AddCommMonoid O] [TopologicalSpace O] [Module R O]
+
+variable (R M) in
+/-- The type of closed submodules of a topological module. -/
+@[ext]
+structure ClosedSubmodule extends Submodule R M, Closeds M where
+
+attribute [coe] ClosedSubmodule.toSubmodule
+
+namespace ClosedSubmodule
+variable {s t : ClosedSubmodule R M} {x : M}
+
+lemma toSubmodule_injective : Injective (toSubmodule : ClosedSubmodule R M → Submodule R M) :=
+  fun s t h ↦ by cases s; congr!
+
+instance : SetLike (ClosedSubmodule R M) M where
+  coe s := s.1
+  coe_injective' _ _ h := toSubmodule_injective <| SetLike.coe_injective h
+
+lemma toCloseds_injective : Injective (toCloseds : ClosedSubmodule R M → Closeds M) :=
+  fun _s _t h ↦ SetLike.coe_injective congr(($h : Set M))
+
+instance : AddSubmonoidClass (ClosedSubmodule R M) M where
+  zero_mem s := s.zero_mem
+  add_mem {s} := s.add_mem
+
+instance : SMulMemClass (ClosedSubmodule R M) R M where
+  smul_mem {s} r := s.smul_mem r
+
+instance : Coe (ClosedSubmodule R M) (Submodule R M) where
+  coe := toSubmodule
+
+@[simp] lemma carrier_eq_coe (s : ClosedSubmodule R M) : s.carrier = s := rfl
+
+@[simp] lemma mem_mk {s : Submodule R M} {hs} : x ∈ mk s hs ↔ x ∈ s := .rfl
+
+@[simp, norm_cast]
+lemma coe_toSubmodule (s : ClosedSubmodule R M) : (s.toSubmodule : Set M) = s := rfl
+
+@[simp]
+lemma coe_toCloseds (s : ClosedSubmodule R M) : (s.toCloseds : Set M) = s := rfl
+
+lemma isClosed (s : ClosedSubmodule R M) : IsClosed (s : Set M) := s.isClosed'
+
+initialize_simps_projections ClosedSubmodule (carrier → coe, as_prefix coe)
+
+/-- The preimage of a closed submodule under a continuous linear map as a proper cone. -/
+@[simps!]
+def comap (f : M →L[R] N) (s : ClosedSubmodule R N) : ClosedSubmodule R M where
+  toSubmodule := .comap f s
+  isClosed' := by simpa using s.isClosed.preimage f.continuous
+
+@[simp]
+lemma mem_comap {f : M →L[R] N} {s : ClosedSubmodule R N} {x : M} : x ∈ s.comap f ↔ f x ∈ s := .rfl
+
+@[simp] lemma comap_id (s : ClosedSubmodule R M) : s.comap (.id _ _) = s := rfl
+
+lemma comap_comap (g : N →L[R] O) (f : M →L[R] N) (s : ClosedSubmodule R O) :
+    (s.comap g).comap f = s.comap (g.comp f) := rfl
+
+instance instInf : Min (ClosedSubmodule R M) where
+  min s t := ⟨s ⊓ t, s.isClosed.inter t.isClosed⟩
+
+instance instInfSet : InfSet (ClosedSubmodule R M) where
+  sInf S := ⟨⨅ s ∈ S, s, by simpa using isClosed_biInter fun x hx ↦ x.isClosed⟩
+
+@[simp, norm_cast]
+lemma toSubmodule_sInf (S : Set (ClosedSubmodule R M)) :
+    toSubmodule (sInf S) = ⨅ s ∈ S, s.toSubmodule := rfl
+
+@[simp, norm_cast]
+lemma toSubmodule_iInf (f : ι → ClosedSubmodule R M) :
+    toSubmodule (⨅ i, f i) = ⨅ i, (f i).toSubmodule := by rw [iInf, toSubmodule_sInf, iInf_range]
+
+@[simp, norm_cast]
+lemma coe_sInf (S : Set (ClosedSubmodule R M)) : ↑(sInf S) = ⨅ s ∈ S, (s : Set M) := by
+  simp [← coe_toSubmodule]
+
+@[simp, norm_cast]
+lemma coe_iInf (f : ι → ClosedSubmodule R M) : ↑(⨅ i, f i) = ⨅ i, (f i : Set M) := by
+  simp [← coe_toSubmodule]
+
+@[simp] lemma mem_sInf {S : Set (ClosedSubmodule R M)} : x ∈ sInf S ↔ ∀ s ∈ S, x ∈ s := by
+  simp [← SetLike.mem_coe]
+
+@[simp] lemma mem_iInf {f : ι → ClosedSubmodule R M} : x ∈ ⨅ i, f i ↔ ∀ i, x ∈ f i := by
+  simp [← SetLike.mem_coe]
+
+instance instSemilatticeInf : SemilatticeInf (ClosedSubmodule R M) :=
+  toSubmodule_injective.semilatticeInf _ fun _ _ ↦ rfl
+
+@[simp, norm_cast]
+lemma toSubmodule_inf (s t : ClosedSubmodule R M) :
+    toSubmodule (s ⊓ t) = s.toSubmodule ⊓ t.toSubmodule := rfl
+
+@[simp, norm_cast] lemma coe_inf (s t : ClosedSubmodule R M) : ↑(s ⊓ t) = (s ⊓ t : Set M) := rfl
+
+@[simp] lemma mem_inf : x ∈ s ⊓ t ↔ x ∈ s ∧ x ∈ t := .rfl
+
+instance insttop : Top (ClosedSubmodule R M) where top := ⟨⊤, isClosed_univ⟩
+
+@[simp, norm_cast] lemma toSubmodule_top : toSubmodule (⊤ : ClosedSubmodule R M) = ⊤ := rfl
+
+@[simp, norm_cast] lemma coe_top : ((⊤ : ClosedSubmodule R M) : Set M) = .univ := rfl
+
+@[simp] lemma mem_top : x ∈ (⊤ : ClosedSubmodule R M) := trivial
+
+section T1Space
+variable [T1Space M]
+
+instance instOrderBot : OrderBot (ClosedSubmodule R M) where
+  bot := ⟨⊥, isClosed_singleton⟩
+  bot_le s := bot_le (a := s.toSubmodule)
+
+instance instZero : Zero (ClosedSubmodule R M) where zero := ⟨0, isClosed_singleton⟩
+
+@[simp] lemma zero_eq_bot : (0 : ClosedSubmodule R M) = ⊥ := rfl
+
+@[simp, norm_cast] lemma toSubmodule_bot : toSubmodule (⊥ : ClosedSubmodule R M) = ⊥ := rfl
+
+@[simp, norm_cast] lemma coe_bot : ((⊥ : ClosedSubmodule R M) : Set M) = {0} := rfl
+
+@[simp] lemma mem_bot : x ∈ (⊥ : ClosedSubmodule R M) ↔ x = 0 := .rfl
+
+end T1Space
+end ClosedSubmodule
+
+namespace Submodule
+variable [ContinuousAdd M] [ContinuousConstSMul R M]
+
+/-- The closure of a submodule as a closed submodule. -/
+@[simps!]
+protected def closure (s : Submodule R M) : ClosedSubmodule R M where
+  toSubmodule := s.topologicalClosure
+  isClosed' := isClosed_closure
+
+end Submodule
+
+namespace ClosedSubmodule
+variable [ContinuousAdd N] [ContinuousConstSMul R N]
+
+/-- The closure of image of a proper cone under a continuous `R`-linear map is a proper cone. We
+use continuous maps here so that the comap of f is also a map between proper cones. -/
+def map (f : M →L[R] N) (s : ClosedSubmodule R M) : ClosedSubmodule R N :=
+  (s.toSubmodule.map f).closure
+
+@[simp]
+lemma map_id [ContinuousAdd M] [ContinuousConstSMul R M] (s : ClosedSubmodule R M) :
+    s.map (.id _ _) = s := SetLike.coe_injective <| by simpa [map] using s.isClosed.closure_eq
+
+end ClosedSubmodule


### PR DESCRIPTION
Define closed `R`-submodules.

The plan is to redefine proper `R`-cones as closed `R≥0`-submodules.

From Toric

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->
- [x] depends on: #24230

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
