### PR TITLE
[Merged by Bors] - chore: rename `orthogonalProjection` to `Submodule.orthogonalProjection`

### DIFF
--- a/Mathlib/Analysis/InnerProductSpace/Adjoint.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Adjoint.lean
@@ -163,7 +163,7 @@ theorem adjoint_id :
   simp
 
 theorem _root_.Submodule.adjoint_subtypeL (U : Submodule 𝕜 E) [CompleteSpace U] :
-    U.subtypeL† = orthogonalProjection U := by
+    U.subtypeL† = U.orthogonalProjection := by
   symm
   rw [eq_adjoint_iff]
   intro x u
@@ -172,7 +172,7 @@ theorem _root_.Submodule.adjoint_subtypeL (U : Submodule 𝕜 E) [CompleteSpace 
   rfl
 
 theorem _root_.Submodule.adjoint_orthogonalProjection (U : Submodule 𝕜 E) [CompleteSpace U] :
-    (orthogonalProjection U : E →L[𝕜] U)† = U.subtypeL := by
+    (U.orthogonalProjection : E →L[𝕜] U)† = U.subtypeL := by
   rw [← U.adjoint_subtypeL, adjoint_adjoint]
 
 /-- `E →L[𝕜] E` is a star algebra with the adjoint as the star operation. -/
@@ -272,13 +272,13 @@ theorem _root_.LinearMap.IsSymmetric.isSelfAdjoint {A : E →L[𝕜] E}
 
 /-- The orthogonal projection is self-adjoint. -/
 theorem _root_.orthogonalProjection_isSelfAdjoint (U : Submodule 𝕜 E) [CompleteSpace U] :
-    IsSelfAdjoint (U.subtypeL ∘L orthogonalProjection U) :=
+    IsSelfAdjoint (U.subtypeL ∘L U.orthogonalProjection) :=
   (orthogonalProjection_isSymmetric U).isSelfAdjoint
 
 theorem conj_orthogonalProjection {T : E →L[𝕜] E} (hT : IsSelfAdjoint T) (U : Submodule 𝕜 E)
     [CompleteSpace U] :
     IsSelfAdjoint
-      (U.subtypeL ∘L orthogonalProjection U ∘L T ∘L U.subtypeL ∘L orthogonalProjection U) := by
+      (U.subtypeL ∘L U.orthogonalProjection ∘L T ∘L U.subtypeL ∘L U.orthogonalProjection) := by
   rw [← ContinuousLinearMap.comp_assoc]
   nth_rw 1 [← (orthogonalProjection_isSelfAdjoint U).adjoint_eq]
   exact hT.adjoint_conj _

--- a/Mathlib/Analysis/InnerProductSpace/Adjoint.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Adjoint.lean
@@ -167,8 +167,8 @@ theorem _root_.Submodule.adjoint_subtypeL (U : Submodule 𝕜 E) [CompleteSpace 
   symm
   rw [eq_adjoint_iff]
   intro x u
-  rw [U.coe_inner, inner_orthogonalProjection_left_eq_right,
-    orthogonalProjection_mem_subspace_eq_self]
+  rw [U.coe_inner, U.inner_orthogonalProjection_left_eq_right,
+    U.orthogonalProjection_mem_subspace_eq_self]
   rfl
 
 theorem _root_.Submodule.adjoint_orthogonalProjection (U : Submodule 𝕜 E) [CompleteSpace U] :
@@ -273,7 +273,7 @@ theorem _root_.LinearMap.IsSymmetric.isSelfAdjoint {A : E →L[𝕜] E}
 /-- The orthogonal projection is self-adjoint. -/
 theorem _root_.orthogonalProjection_isSelfAdjoint (U : Submodule 𝕜 E) [CompleteSpace U] :
     IsSelfAdjoint (U.subtypeL ∘L U.orthogonalProjection) :=
-  (orthogonalProjection_isSymmetric U).isSelfAdjoint
+  U.orthogonalProjection_isSymmetric.isSelfAdjoint
 
 theorem conj_orthogonalProjection {T : E →L[𝕜] E} (hT : IsSelfAdjoint T) (U : Submodule 𝕜 E)
     [CompleteSpace U] :

--- a/Mathlib/Analysis/InnerProductSpace/GramSchmidtOrtho.lean
+++ b/Mathlib/Analysis/InnerProductSpace/GramSchmidtOrtho.lean
@@ -47,17 +47,17 @@ local notation "⟪" x ", " y "⟫" => @inner 𝕜 _ _ x y
 /-- The Gram-Schmidt process takes a set of vectors as input
 and outputs a set of orthogonal vectors which have the same span. -/
 noncomputable def gramSchmidt [WellFoundedLT ι] (f : ι → E) (n : ι) : E :=
-  f n - ∑ i : Iio n, orthogonalProjection (𝕜 ∙ gramSchmidt f i) (f n)
+  f n - ∑ i : Iio n, (𝕜 ∙ gramSchmidt f i).orthogonalProjection (f n)
 termination_by n
 decreasing_by exact mem_Iio.1 i.2
 
 /-- This lemma uses `∑ i in` instead of `∑ i :`. -/
 theorem gramSchmidt_def (f : ι → E) (n : ι) :
-    gramSchmidt 𝕜 f n = f n - ∑ i ∈ Iio n, orthogonalProjection (𝕜 ∙ gramSchmidt 𝕜 f i) (f n) := by
+    gramSchmidt 𝕜 f n = f n - ∑ i ∈ Iio n, (𝕜 ∙ gramSchmidt 𝕜 f i).orthogonalProjection (f n) := by
   rw [← sum_attach, attach_eq_univ, gramSchmidt]
 
 theorem gramSchmidt_def' (f : ι → E) (n : ι) :
-    f n = gramSchmidt 𝕜 f n + ∑ i ∈ Iio n, orthogonalProjection (𝕜 ∙ gramSchmidt 𝕜 f i) (f n) := by
+    f n = gramSchmidt 𝕜 f n + ∑ i ∈ Iio n, (𝕜 ∙ gramSchmidt 𝕜 f i).orthogonalProjection (f n) := by
   rw [gramSchmidt_def, sub_add_cancel]
 
 theorem gramSchmidt_def'' (f : ι → E) (n : ι) :

--- a/Mathlib/Analysis/InnerProductSpace/MeanErgodic.lean
+++ b/Mathlib/Analysis/InnerProductSpace/MeanErgodic.lean
@@ -84,7 +84,7 @@ converge to the orthogonal projection of `x` to the subspace of fixed points of 
 theorem ContinuousLinearMap.tendsto_birkhoffAverage_orthogonalProjection (f : E →L[𝕜] E)
     (hf : ‖f‖ ≤ 1) (x : E) :
     Tendsto (birkhoffAverage 𝕜 f _root_.id · x) atTop
-      (𝓝 <| orthogonalProjection (LinearMap.eqLocus f 1) x) := by
+      (𝓝 <| (LinearMap.eqLocus f 1).orthogonalProjection x) := by
   /- Due to the previous theorem, it suffices to verify
   that the range of `f - 1` is dense in the orthogonal complement
   to the submodule of fixed points of `f`. -/

--- a/Mathlib/Analysis/InnerProductSpace/MeanErgodic.lean
+++ b/Mathlib/Analysis/InnerProductSpace/MeanErgodic.lean
@@ -89,12 +89,12 @@ theorem ContinuousLinearMap.tendsto_birkhoffAverage_orthogonalProjection (f : E 
   that the range of `f - 1` is dense in the orthogonal complement
   to the submodule of fixed points of `f`. -/
   apply (f : E →ₗ[𝕜] E).tendsto_birkhoffAverage_of_ker_subset_closure (f.lipschitz.weaken hf)
-  · exact orthogonalProjection_mem_subspace_eq_self (K := LinearMap.eqLocus f 1)
+  · exact (LinearMap.eqLocus f 1).orthogonalProjection_mem_subspace_eq_self
   · clear x
     /- In other words, we need to verify that any vector that is orthogonal to the range of `f - 1`
     is a fixed point of `f`. -/
-    rw [ker_orthogonalProjection, ← Submodule.topologicalClosure_coe, SetLike.coe_subset_coe,
-      ← Submodule.orthogonal_orthogonal_eq_closure]
+    rw [Submodule.ker_orthogonalProjection, ← Submodule.topologicalClosure_coe,
+      SetLike.coe_subset_coe, ← Submodule.orthogonal_orthogonal_eq_closure]
     /- To verify this, we verify `‖f x‖ ≤ ‖x‖` (because `‖f‖ ≤ 1`) and `⟪f x, x⟫ = ‖x‖²`. -/
     refine Submodule.orthogonal_le fun x hx ↦ eq_of_norm_le_re_inner_eq_norm_sq (𝕜 := 𝕜) ?_ ?_
     · simpa using f.le_of_opNorm_le hf x

--- a/Mathlib/Analysis/InnerProductSpace/PiL2.lean
+++ b/Mathlib/Analysis/InnerProductSpace/PiL2.lean
@@ -461,9 +461,9 @@ lemma norm_le_card_mul_iSup_norm_inner (b : OrthonormalBasis ι 𝕜 E) (x : E) 
 
 protected theorem orthogonalProjection_eq_sum {U : Submodule 𝕜 E} [CompleteSpace U]
     (b : OrthonormalBasis ι 𝕜 U) (x : E) :
-    orthogonalProjection U x = ∑ i, ⟪(b i : E), x⟫ • b i := by
+    U.orthogonalProjection x = ∑ i, ⟪(b i : E), x⟫ • b i := by
   simpa only [b.repr_apply_apply, inner_orthogonalProjection_eq_of_mem_left] using
-    (b.sum_repr (orthogonalProjection U x)).symm
+    (b.sum_repr (U.orthogonalProjection x)).symm
 
 /-- Mapping an orthonormal basis along a `LinearIsometryEquiv`. -/
 protected def map {G : Type*} [NormedAddCommGroup G] [InnerProductSpace 𝕜 G]
@@ -968,8 +968,8 @@ noncomputable def LinearIsometry.extend (L : S →ₗᵢ[𝕜] V) : V →ₗᵢ[
   -- Project onto S and Sᗮ
   haveI : CompleteSpace S := FiniteDimensional.complete 𝕜 S
   haveI : CompleteSpace V := FiniteDimensional.complete 𝕜 V
-  let p1 := (orthogonalProjection S).toLinearMap
-  let p2 := (orthogonalProjection Sᗮ).toLinearMap
+  let p1 := S.orthogonalProjection.toLinearMap
+  let p2 := Sᗮ.orthogonalProjection.toLinearMap
   -- Build a linear map from the isometries on S and Sᗮ
   let M := L.toLinearMap.comp p1 + L3.toLinearMap.comp p2
   -- Prove that M is an isometry

--- a/Mathlib/Analysis/InnerProductSpace/Positive.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Positive.lean
@@ -90,13 +90,13 @@ theorem IsPositive.adjoint_conj {T : E →L[𝕜] E} (hT : T.IsPositive) (S : F 
 theorem IsPositive.conj_orthogonalProjection (U : Submodule 𝕜 E) {T : E →L[𝕜] E} (hT : T.IsPositive)
     [CompleteSpace U] :
     (U.subtypeL ∘L
-        orthogonalProjection U ∘L T ∘L U.subtypeL ∘L orthogonalProjection U).IsPositive := by
-  have := hT.conj_adjoint (U.subtypeL ∘L orthogonalProjection U)
+        U.orthogonalProjection ∘L T ∘L U.subtypeL ∘L U.orthogonalProjection).IsPositive := by
+  have := hT.conj_adjoint (U.subtypeL ∘L U.orthogonalProjection)
   rwa [(orthogonalProjection_isSelfAdjoint U).adjoint_eq] at this
 
 theorem IsPositive.orthogonalProjection_comp {T : E →L[𝕜] E} (hT : T.IsPositive) (U : Submodule 𝕜 E)
-    [CompleteSpace U] : (orthogonalProjection U ∘L T ∘L U.subtypeL).IsPositive := by
-  have := hT.conj_adjoint (orthogonalProjection U : E →L[𝕜] U)
+    [CompleteSpace U] : (U.orthogonalProjection ∘L T ∘L U.subtypeL).IsPositive := by
+  have := hT.conj_adjoint (U.orthogonalProjection : E →L[𝕜] U)
   rwa [U.adjoint_orthogonalProjection] at this
 
 open scoped NNReal

--- a/Mathlib/Analysis/InnerProductSpace/Projection.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Projection.lean
@@ -1035,7 +1035,7 @@ theorem norm_sq_eq_add_norm_sq_projection (x : E) (S : Submodule 𝕜 E) [S.HasO
 complement sum to the identity. -/
 theorem id_eq_sum_orthogonalProjection_self_orthogonalComplement [K.HasOrthogonalProjection] :
     ContinuousLinearMap.id 𝕜 E =
-      K.subtypeL.comp K.orthogonalProjection + Kᗮ.subtypeL.comp (Kᗮ.orthogonalProjection) := by
+      K.subtypeL.comp K.orthogonalProjection + Kᗮ.subtypeL.comp Kᗮ.orthogonalProjection := by
   ext w
   exact (K.orthogonalProjection_add_orthogonalProjection_orthogonal w).symm
 

--- a/Mathlib/Analysis/InnerProductSpace/Projection.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Projection.lean
@@ -14,13 +14,13 @@ import Mathlib.Algebra.DirectSum.Decomposition
 # The orthogonal projection
 
 Given a nonempty complete subspace `K` of an inner product space `E`, this file constructs
-`orthogonalProjection K : E →L[𝕜] K`, the orthogonal projection of `E` onto `K`.  This map
-satisfies: for any point `u` in `E`, the point `v = orthogonalProjection K u` in `K` minimizes the
+`K.orthogonalProjection : E →L[𝕜] K`, the orthogonal projection of `E` onto `K`.  This map
+satisfies: for any point `u` in `E`, the point `v = K.orthogonalProjection u` in `K` minimizes the
 distance `‖u - v‖` to `u`.
 
 Also a linear isometry equivalence `reflection K : E ≃ₗᵢ[𝕜] E` is constructed, by choosing, for
 each `u : E`, the point `reflection K u` to satisfy
-`u + (reflection K u) = 2 • orthogonalProjection K u`.
+`u + (reflection K u) = 2 • K.orthogonalProjection u`.
 
 Basic API for `orthogonalProjection` and `reflection` is developed.
 
@@ -437,7 +437,7 @@ theorem orthogonalProjectionFn_norm_sq (v : E) :
   convert norm_add_sq_eq_norm_sq_add_norm_sq_of_inner_eq_zero (v - p) p h' using 2 <;> simp
 
 /-- The orthogonal projection onto a complete subspace. -/
-def orthogonalProjection : E →L[𝕜] K :=
+def Submodule.orthogonalProjection : E →L[𝕜] K :=
   LinearMap.mkContinuous
     { toFun := fun v => ⟨orthogonalProjectionFn K v, orthogonalProjectionFn_mem v⟩
       map_add' := fun x y => by
@@ -469,18 +469,18 @@ variable {K}
 
 @[simp]
 theorem orthogonalProjectionFn_eq (v : E) :
-    orthogonalProjectionFn K v = (orthogonalProjection K v : E) :=
+    orthogonalProjectionFn K v = (K.orthogonalProjection v : E) :=
   rfl
 
 /-- The characterization of the orthogonal projection. -/
 @[simp]
 theorem orthogonalProjection_inner_eq_zero (v : E) :
-    ∀ w ∈ K, ⟪v - orthogonalProjection K v, w⟫ = 0 :=
+    ∀ w ∈ K, ⟪v - K.orthogonalProjection v, w⟫ = 0 :=
   orthogonalProjectionFn_inner_eq_zero v
 
 /-- The difference of `v` from its orthogonal projection onto `K` is in `Kᗮ`. -/
 @[simp]
-theorem sub_orthogonalProjection_mem_orthogonal (v : E) : v - orthogonalProjection K v ∈ Kᗮ := by
+theorem sub_orthogonalProjection_mem_orthogonal (v : E) : v - K.orthogonalProjection v ∈ Kᗮ := by
   intro w hw
   rw [inner_eq_zero_symm]
   exact orthogonalProjection_inner_eq_zero _ _ hw
@@ -488,71 +488,71 @@ theorem sub_orthogonalProjection_mem_orthogonal (v : E) : v - orthogonalProjecti
 /-- The orthogonal projection is the unique point in `K` with the
 orthogonality property. -/
 theorem eq_orthogonalProjection_of_mem_of_inner_eq_zero {u v : E} (hvm : v ∈ K)
-    (hvo : ∀ w ∈ K, ⟪u - v, w⟫ = 0) : (orthogonalProjection K u : E) = v :=
+    (hvo : ∀ w ∈ K, ⟪u - v, w⟫ = 0) : (K.orthogonalProjection u : E) = v :=
   eq_orthogonalProjectionFn_of_mem_of_inner_eq_zero hvm hvo
 
 /-- A point in `K` with the orthogonality property (here characterized in terms of `Kᗮ`) must be the
 orthogonal projection. -/
 theorem eq_orthogonalProjection_of_mem_orthogonal {u v : E} (hv : v ∈ K)
-    (hvo : u - v ∈ Kᗮ) : (orthogonalProjection K u : E) = v :=
+    (hvo : u - v ∈ Kᗮ) : (K.orthogonalProjection u : E) = v :=
   eq_orthogonalProjectionFn_of_mem_of_inner_eq_zero hv <| (Submodule.mem_orthogonal' _ _).1 hvo
 
 /-- A point in `K` with the orthogonality property (here characterized in terms of `Kᗮ`) must be the
 orthogonal projection. -/
 theorem eq_orthogonalProjection_of_mem_orthogonal' {u v z : E}
-    (hv : v ∈ K) (hz : z ∈ Kᗮ) (hu : u = v + z) : (orthogonalProjection K u : E) = v :=
+    (hv : v ∈ K) (hz : z ∈ Kᗮ) (hu : u = v + z) : (K.orthogonalProjection u : E) = v :=
   eq_orthogonalProjection_of_mem_orthogonal hv (by simpa [hu] )
 
 @[simp]
 theorem orthogonalProjection_orthogonal_val (u : E) :
-    (orthogonalProjection Kᗮ u : E) = u - orthogonalProjection K u :=
+    (Kᗮ.orthogonalProjection u : E) = u - K.orthogonalProjection u :=
   eq_orthogonalProjection_of_mem_orthogonal' (sub_orthogonalProjection_mem_orthogonal _)
-    (K.le_orthogonal_orthogonal (orthogonalProjection K u).2) <| by simp
+    (K.le_orthogonal_orthogonal (K.orthogonalProjection u).2) <| by simp
 
 theorem orthogonalProjection_orthogonal (u : E) :
-    orthogonalProjection Kᗮ u =
-      ⟨u - orthogonalProjection K u, sub_orthogonalProjection_mem_orthogonal _⟩ :=
+    Kᗮ.orthogonalProjection u =
+      ⟨u - K.orthogonalProjection u, sub_orthogonalProjection_mem_orthogonal _⟩ :=
   Subtype.eq <| orthogonalProjection_orthogonal_val _
 
 /-- The orthogonal projection of `y` on `U` minimizes the distance `‖y - x‖` for `x ∈ U`. -/
 theorem orthogonalProjection_minimal {U : Submodule 𝕜 E} [HasOrthogonalProjection U] (y : E) :
-    ‖y - orthogonalProjection U y‖ = ⨅ x : U, ‖y - x‖ := by
+    ‖y - U.orthogonalProjection y‖ = ⨅ x : U, ‖y - x‖ := by
   rw [norm_eq_iInf_iff_inner_eq_zero _ (Submodule.coe_mem _)]
   exact orthogonalProjection_inner_eq_zero _
 
 /-- The orthogonal projections onto equal subspaces are coerced back to the same point in `E`. -/
 theorem eq_orthogonalProjection_of_eq_submodule {K' : Submodule 𝕜 E} [HasOrthogonalProjection K']
-    (h : K = K') (u : E) : (orthogonalProjection K u : E) = (orthogonalProjection K' u : E) := by
+    (h : K = K') (u : E) : (K.orthogonalProjection u : E) = (K'.orthogonalProjection u : E) := by
   subst h; rfl
 
 /-- The orthogonal projection sends elements of `K` to themselves. -/
 @[simp]
-theorem orthogonalProjection_mem_subspace_eq_self (v : K) : orthogonalProjection K v = v := by
+theorem orthogonalProjection_mem_subspace_eq_self (v : K) : K.orthogonalProjection v = v := by
   ext
   apply eq_orthogonalProjection_of_mem_of_inner_eq_zero <;> simp
 
 /-- A point equals its orthogonal projection if and only if it lies in the subspace. -/
-theorem orthogonalProjection_eq_self_iff {v : E} : (orthogonalProjection K v : E) = v ↔ v ∈ K := by
+theorem orthogonalProjection_eq_self_iff {v : E} : (K.orthogonalProjection v : E) = v ↔ v ∈ K := by
   refine ⟨fun h => ?_, fun h => eq_orthogonalProjection_of_mem_of_inner_eq_zero h ?_⟩
   · rw [← h]
     simp
   · simp
 
 @[simp]
-theorem orthogonalProjection_eq_zero_iff {v : E} : orthogonalProjection K v = 0 ↔ v ∈ Kᗮ := by
+theorem orthogonalProjection_eq_zero_iff {v : E} : K.orthogonalProjection v = 0 ↔ v ∈ Kᗮ := by
   refine ⟨fun h ↦ ?_, fun h ↦ Subtype.eq <| eq_orthogonalProjection_of_mem_orthogonal
     (zero_mem _) ?_⟩
   · simpa [h] using sub_orthogonalProjection_mem_orthogonal (K := K) v
   · simpa
 
 @[simp]
-theorem ker_orthogonalProjection : LinearMap.ker (orthogonalProjection K) = Kᗮ := by
+theorem ker_orthogonalProjection : LinearMap.ker (K.orthogonalProjection) = Kᗮ := by
   ext; exact orthogonalProjection_eq_zero_iff
 
 theorem LinearIsometry.map_orthogonalProjection {E E' : Type*} [NormedAddCommGroup E]
     [NormedAddCommGroup E'] [InnerProductSpace 𝕜 E] [InnerProductSpace 𝕜 E'] (f : E →ₗᵢ[𝕜] E')
     (p : Submodule 𝕜 E) [HasOrthogonalProjection p] [HasOrthogonalProjection (p.map f.toLinearMap)]
-    (x : E) : f (orthogonalProjection p x) = orthogonalProjection (p.map f.toLinearMap) (f x) := by
+    (x : E) : f (p.orthogonalProjection x) = (p.map f.toLinearMap).orthogonalProjection (f x) := by
   refine (eq_orthogonalProjection_of_mem_of_inner_eq_zero ?_ fun y hy => ?_).symm
   · refine Submodule.apply_coe_mem_map _ _
   rcases hy with ⟨x', hx', rfl : f x' = y⟩
@@ -561,7 +561,7 @@ theorem LinearIsometry.map_orthogonalProjection {E E' : Type*} [NormedAddCommGro
 theorem LinearIsometry.map_orthogonalProjection' {E E' : Type*} [NormedAddCommGroup E]
     [NormedAddCommGroup E'] [InnerProductSpace 𝕜 E] [InnerProductSpace 𝕜 E'] (f : E →ₗᵢ[𝕜] E')
     (p : Submodule 𝕜 E) [HasOrthogonalProjection p] [HasOrthogonalProjection (p.map f)] (x : E) :
-    f (orthogonalProjection p x) = orthogonalProjection (p.map f) (f x) :=
+    f (p.orthogonalProjection x) = (p.map f).orthogonalProjection (f x) :=
   have : HasOrthogonalProjection (p.map f.toLinearMap) := ‹_›
   f.map_orthogonalProjection p x
 
@@ -569,26 +569,26 @@ theorem LinearIsometry.map_orthogonalProjection' {E E' : Type*} [NormedAddCommGr
 theorem orthogonalProjection_map_apply {E E' : Type*} [NormedAddCommGroup E]
     [NormedAddCommGroup E'] [InnerProductSpace 𝕜 E] [InnerProductSpace 𝕜 E'] (f : E ≃ₗᵢ[𝕜] E')
     (p : Submodule 𝕜 E) [HasOrthogonalProjection p] (x : E') :
-    (orthogonalProjection (p.map (f.toLinearEquiv : E →ₗ[𝕜] E')) x : E') =
-      f (orthogonalProjection p (f.symm x)) := by
+    ((p.map (f.toLinearEquiv : E →ₗ[𝕜] E')).orthogonalProjection x : E') =
+      f (p.orthogonalProjection (f.symm x)) := by
   simpa only [f.coe_toLinearIsometry, f.apply_symm_apply] using
     (f.toLinearIsometry.map_orthogonalProjection' p (f.symm x)).symm
 
 /-- The orthogonal projection onto the trivial submodule is the zero map. -/
 @[simp]
-theorem orthogonalProjection_bot : orthogonalProjection (⊥ : Submodule 𝕜 E) = 0 := by ext
+theorem orthogonalProjection_bot : (⊥ : Submodule 𝕜 E).orthogonalProjection = 0 := by ext
 
 variable (K)
 
 /-- The orthogonal projection has norm `≤ 1`. -/
-theorem orthogonalProjection_norm_le : ‖orthogonalProjection K‖ ≤ 1 :=
+theorem orthogonalProjection_norm_le : ‖K.orthogonalProjection‖ ≤ 1 :=
   LinearMap.mkContinuous_norm_le _ (by norm_num) _
 
 variable (𝕜)
 
 theorem smul_orthogonalProjection_singleton {v : E} (w : E) :
-    ((‖v‖ ^ 2 : ℝ) : 𝕜) • (orthogonalProjection (𝕜 ∙ v) w : E) = ⟪v, w⟫ • v := by
-  suffices ((orthogonalProjection (𝕜 ∙ v) (((‖v‖ : 𝕜) ^ 2) • w)) : E) = ⟪v, w⟫ • v by
+    ((‖v‖ ^ 2 : ℝ) : 𝕜) • ((𝕜 ∙ v).orthogonalProjection w : E) = ⟪v, w⟫ • v := by
+  suffices (((𝕜 ∙ v).orthogonalProjection (((‖v‖ : 𝕜) ^ 2) • w)) : E) = ⟪v, w⟫ • v by
     simpa using this
   apply eq_orthogonalProjection_of_mem_of_inner_eq_zero
   · rw [Submodule.mem_span_singleton]
@@ -598,20 +598,20 @@ theorem smul_orthogonalProjection_singleton {v : E} (w : E) :
 
 /-- Formula for orthogonal projection onto a single vector. -/
 theorem orthogonalProjection_singleton {v : E} (w : E) :
-    (orthogonalProjection (𝕜 ∙ v) w : E) = (⟪v, w⟫ / ((‖v‖ ^ 2 : ℝ) : 𝕜)) • v := by
+    ((𝕜 ∙ v).orthogonalProjection w : E) = (⟪v, w⟫ / ((‖v‖ ^ 2 : ℝ) : 𝕜)) • v := by
   by_cases hv : v = 0
   · rw [hv, eq_orthogonalProjection_of_eq_submodule (Submodule.span_zero_singleton 𝕜)]
     simp
   have hv' : ‖v‖ ≠ 0 := ne_of_gt (norm_pos_iff.mpr hv)
   have key :
-    (((‖v‖ ^ 2 : ℝ) : 𝕜)⁻¹ * ((‖v‖ ^ 2 : ℝ) : 𝕜)) • ((orthogonalProjection (𝕜 ∙ v) w) : E) =
+    (((‖v‖ ^ 2 : ℝ) : 𝕜)⁻¹ * ((‖v‖ ^ 2 : ℝ) : 𝕜)) • (((𝕜 ∙ v).orthogonalProjection w) : E) =
       (((‖v‖ ^ 2 : ℝ) : 𝕜)⁻¹ * ⟪v, w⟫) • v := by
     simp [mul_smul, smul_orthogonalProjection_singleton 𝕜 w, -map_pow]
   convert key using 1 <;> field_simp [hv']
 
 /-- Formula for orthogonal projection onto a single unit vector. -/
 theorem orthogonalProjection_unit_singleton {v : E} (hv : ‖v‖ = 1) (w : E) :
-    (orthogonalProjection (𝕜 ∙ v) w : E) = ⟪v, w⟫ • v := by
+    ((𝕜 ∙ v).orthogonalProjection w : E) = ⟪v, w⟫ • v := by
   rw [← smul_orthogonalProjection_singleton 𝕜 w]
   simp [hv]
 
@@ -624,7 +624,7 @@ variable [HasOrthogonalProjection K]
 /-- Auxiliary definition for `reflection`: the reflection as a linear equivalence. -/
 def reflectionLinearEquiv : E ≃ₗ[𝕜] E :=
   LinearEquiv.ofInvolutive
-    (2 • (K.subtype.comp (orthogonalProjection K).toLinearMap) - LinearMap.id) fun x => by
+    (2 • (K.subtype.comp (K.orthogonalProjection).toLinearMap) - LinearMap.id) fun x => by
     simp [two_smul]
 
 /-- Reflection in a complete subspace of an inner product space.  The word "reflection" is
@@ -636,7 +636,7 @@ def reflection : E ≃ₗᵢ[𝕜] E :=
   { reflectionLinearEquiv K with
     norm_map' := by
       intro x
-      let w : K := orthogonalProjection K x
+      let w : K := K.orthogonalProjection x
       let v := x - w
       have : ⟪v, w⟫ = 0 := orthogonalProjection_inner_eq_zero x w w.2
       convert norm_sub_eq_norm_add this using 2
@@ -651,7 +651,7 @@ def reflection : E ≃ₗᵢ[𝕜] E :=
 variable {K}
 
 /-- The result of reflecting. -/
-theorem reflection_apply (p : E) : reflection K p = 2 • (orthogonalProjection K p : E) - p :=
+theorem reflection_apply (p : E) : reflection K p = 2 • (K.orthogonalProjection p : E) - p :=
   rfl
 
 /-- Reflection is its own inverse. -/
@@ -752,7 +752,7 @@ theorem Submodule.sup_orthogonal_of_completeSpace [HasOrthogonalProjection K] : 
 /-- If `K` is complete, any `v` in `E` can be expressed as a sum of elements of `K` and `Kᗮ`. -/
 theorem Submodule.exists_add_mem_mem_orthogonal [HasOrthogonalProjection K] (v : E) :
     ∃ y ∈ K, ∃ z ∈ Kᗮ, v = y + z :=
-  ⟨orthogonalProjection K v, Subtype.coe_prop _, v - orthogonalProjection K v,
+  ⟨K.orthogonalProjection v, Subtype.coe_prop _, v - K.orthogonalProjection v,
     sub_orthogonalProjection_mem_orthogonal _, by simp⟩
 
 /-- If `K` admits an orthogonal projection, then the orthogonal complement of its orthogonal
@@ -805,26 +805,26 @@ theorem Submodule.orthogonal_eq_bot_iff [HasOrthogonalProjection K] : Kᗮ = ⊥
 
 /-- The orthogonal projection onto `K` of an element of `Kᗮ` is zero. -/
 theorem orthogonalProjection_mem_subspace_orthogonalComplement_eq_zero [HasOrthogonalProjection K]
-    {v : E} (hv : v ∈ Kᗮ) : orthogonalProjection K v = 0 := by
+    {v : E} (hv : v ∈ Kᗮ) : K.orthogonalProjection v = 0 := by
   ext
   convert eq_orthogonalProjection_of_mem_orthogonal (K := K) _ _ <;> simp [hv]
 
 /-- The projection into `U` from an orthogonal submodule `V` is the zero map. -/
 theorem Submodule.IsOrtho.orthogonalProjection_comp_subtypeL {U V : Submodule 𝕜 E}
-    [HasOrthogonalProjection U] (h : U ⟂ V) : orthogonalProjection U ∘L V.subtypeL = 0 :=
+    [HasOrthogonalProjection U] (h : U ⟂ V) : U.orthogonalProjection ∘L V.subtypeL = 0 :=
   ContinuousLinearMap.ext fun v =>
     orthogonalProjection_mem_subspace_orthogonalComplement_eq_zero <| h.symm v.prop
 
 /-- The projection into `U` from `V` is the zero map if and only if `U` and `V` are orthogonal. -/
 theorem orthogonalProjection_comp_subtypeL_eq_zero_iff {U V : Submodule 𝕜 E}
-    [HasOrthogonalProjection U] : orthogonalProjection U ∘L V.subtypeL = 0 ↔ U ⟂ V :=
+    [HasOrthogonalProjection U] : U.orthogonalProjection ∘L V.subtypeL = 0 ↔ U ⟂ V :=
   ⟨fun h u hu v hv => by
     convert orthogonalProjection_inner_eq_zero v u hu using 2
-    have : orthogonalProjection U v = 0 := DFunLike.congr_fun h (⟨_, hv⟩ : V)
+    have : U.orthogonalProjection v = 0 := DFunLike.congr_fun h (⟨_, hv⟩ : V)
     rw [this, Submodule.coe_zero, sub_zero], Submodule.IsOrtho.orthogonalProjection_comp_subtypeL⟩
 
 theorem orthogonalProjection_eq_linear_proj [HasOrthogonalProjection K] (x : E) :
-    orthogonalProjection K x =
+    K.orthogonalProjection x =
       K.linearProjOfIsCompl _ Submodule.isCompl_orthogonal_of_completeSpace x := by
   have : IsCompl K Kᗮ := Submodule.isCompl_orthogonal_of_completeSpace
   conv_lhs => rw [← Submodule.linear_proj_add_linearProjOfIsCompl_eq_self this x]
@@ -832,7 +832,7 @@ theorem orthogonalProjection_eq_linear_proj [HasOrthogonalProjection K] (x : E) 
     orthogonalProjection_mem_subspace_orthogonalComplement_eq_zero (Submodule.coe_mem _), add_zero]
 
 theorem orthogonalProjection_coe_linearMap_eq_linearProj [HasOrthogonalProjection K] :
-    (orthogonalProjection K : E →ₗ[𝕜] K) =
+    (K.orthogonalProjection : E →ₗ[𝕜] K) =
       K.linearProjOfIsCompl _ Submodule.isCompl_orthogonal_of_completeSpace :=
   LinearMap.ext <| orthogonalProjection_eq_linear_proj
 
@@ -843,13 +843,13 @@ theorem reflection_mem_subspace_orthogonalComplement_eq_neg [HasOrthogonalProjec
 
 /-- The orthogonal projection onto `Kᗮ` of an element of `K` is zero. -/
 theorem orthogonalProjection_mem_subspace_orthogonal_precomplement_eq_zero
-    [HasOrthogonalProjection Kᗮ] {v : E} (hv : v ∈ K) : orthogonalProjection Kᗮ v = 0 :=
+    [HasOrthogonalProjection Kᗮ] {v : E} (hv : v ∈ K) : Kᗮ.orthogonalProjection v = 0 :=
   orthogonalProjection_mem_subspace_orthogonalComplement_eq_zero (K.le_orthogonal_orthogonal hv)
 
 /-- If `U ≤ V`, then projecting on `V` and then on `U` is the same as projecting on `U`. -/
 theorem orthogonalProjection_orthogonalProjection_of_le {U V : Submodule 𝕜 E}
     [HasOrthogonalProjection U] [HasOrthogonalProjection V] (h : U ≤ V) (x : E) :
-    orthogonalProjection U (orthogonalProjection V x) = orthogonalProjection U x :=
+    U.orthogonalProjection (V.orthogonalProjection x) = U.orthogonalProjection x :=
   Eq.symm <| by
     simpa only [sub_eq_zero, map_sub] using
       orthogonalProjection_mem_subspace_orthogonalComplement_eq_zero
@@ -861,15 +861,15 @@ the orthogonal projection of `x` on `U i` tends to the orthogonal projection of 
 theorem orthogonalProjection_tendsto_closure_iSup {ι : Type*} [Preorder ι]
     (U : ι → Submodule 𝕜 E) [∀ i, HasOrthogonalProjection (U i)]
     [HasOrthogonalProjection (⨆ i, U i).topologicalClosure] (hU : Monotone U) (x : E) :
-    Filter.Tendsto (fun i => (orthogonalProjection (U i) x : E)) atTop
-      (𝓝 (orthogonalProjection (⨆ i, U i).topologicalClosure x : E)) := by
+    Filter.Tendsto (fun i => ((U i).orthogonalProjection x : E)) atTop
+      (𝓝 ((⨆ i, U i).topologicalClosure.orthogonalProjection x : E)) := by
   refine .of_neBot_imp fun h ↦ ?_
   cases atTop_neBot_iff.mp h
-  let y := (orthogonalProjection (⨆ i, U i).topologicalClosure x : E)
-  have proj_x : ∀ i, orthogonalProjection (U i) x = orthogonalProjection (U i) y := fun i =>
+  let y := ((⨆ i, U i).topologicalClosure.orthogonalProjection x : E)
+  have proj_x : ∀ i, (U i).orthogonalProjection x = (U i).orthogonalProjection y := fun i =>
     (orthogonalProjection_orthogonalProjection_of_le
         ((le_iSup U i).trans (iSup U).le_topologicalClosure) _).symm
-  suffices ∀ ε > 0, ∃ I, ∀ i ≥ I, ‖(orthogonalProjection (U i) y : E) - y‖ < ε by
+  suffices ∀ ε > 0, ∃ I, ∀ i ≥ I, ‖((U i).orthogonalProjection y : E) - y‖ < ε by
     simpa only [proj_x, NormedAddCommGroup.tendsto_atTop] using this
   intro ε hε
   obtain ⟨a, ha, hay⟩ : ∃ a ∈ ⨆ i, U i, dist y a < ε := by
@@ -889,7 +889,7 @@ and a fixed `x : E`, the orthogonal projection of `x` on `U i` tends to `x` alon
 theorem orthogonalProjection_tendsto_self {ι : Type*} [Preorder ι]
     (U : ι → Submodule 𝕜 E) [∀ t, HasOrthogonalProjection (U t)] (hU : Monotone U) (x : E)
     (hU' : ⊤ ≤ (⨆ t, U t).topologicalClosure) :
-    Filter.Tendsto (fun t => (orthogonalProjection (U t) x : E)) atTop (𝓝 x) := by
+    Filter.Tendsto (fun t => ((U t).orthogonalProjection x : E)) atTop (𝓝 x) := by
   have : HasOrthogonalProjection (⨆ i, U i).topologicalClosure := by
     rw [top_unique hU']
     infer_instance
@@ -948,7 +948,7 @@ theorem reflection_mem_subspace_orthogonal_precomplement_eq_neg [HasOrthogonalPr
 
 /-- The orthogonal projection onto `(𝕜 ∙ v)ᗮ` of `v` is zero. -/
 theorem orthogonalProjection_orthogonalComplement_singleton_eq_zero (v : E) :
-    orthogonalProjection (𝕜 ∙ v)ᗮ v = 0 :=
+    (𝕜 ∙ v)ᗮ.orthogonalProjection v = 0 :=
   orthogonalProjection_mem_subspace_orthogonal_precomplement_eq_zero
     (Submodule.mem_span_singleton_self v)
 
@@ -1006,52 +1006,52 @@ end FiniteDimensional
 /-- If the orthogonal projection to `K` is well-defined, then a vector splits as the sum of its
 orthogonal projections onto a complete submodule `K` and onto the orthogonal complement of `K`. -/
 theorem orthogonalProjection_add_orthogonalProjection_orthogonal [HasOrthogonalProjection K]
-    (w : E) : (orthogonalProjection K w : E) + (orthogonalProjection Kᗮ w : E) = w := by
+    (w : E) : (K.orthogonalProjection w : E) + (Kᗮ.orthogonalProjection w : E) = w := by
   simp
 
 /-- The Pythagorean theorem, for an orthogonal projection. -/
 theorem norm_sq_eq_add_norm_sq_projection (x : E) (S : Submodule 𝕜 E) [HasOrthogonalProjection S] :
-    ‖x‖ ^ 2 = ‖orthogonalProjection S x‖ ^ 2 + ‖orthogonalProjection Sᗮ x‖ ^ 2 :=
+    ‖x‖ ^ 2 = ‖S.orthogonalProjection x‖ ^ 2 + ‖Sᗮ.orthogonalProjection x‖ ^ 2 :=
   calc
-    ‖x‖ ^ 2 = ‖(orthogonalProjection S x : E) + orthogonalProjection Sᗮ x‖ ^ 2 := by
+    ‖x‖ ^ 2 = ‖(S.orthogonalProjection x : E) + Sᗮ.orthogonalProjection x‖ ^ 2 := by
       rw [orthogonalProjection_add_orthogonalProjection_orthogonal]
-    _ = ‖orthogonalProjection S x‖ ^ 2 + ‖orthogonalProjection Sᗮ x‖ ^ 2 := by
+    _ = ‖S.orthogonalProjection x‖ ^ 2 + ‖Sᗮ.orthogonalProjection x‖ ^ 2 := by
       simp only [sq]
       exact norm_add_sq_eq_norm_sq_add_norm_sq_of_inner_eq_zero _ _ <|
-        (S.mem_orthogonal _).1 (orthogonalProjection Sᗮ x).2 _ (orthogonalProjection S x).2
+        (S.mem_orthogonal _).1 (Sᗮ.orthogonalProjection x).2 _ (S.orthogonalProjection x).2
 
 /-- In a complete space `E`, the projection maps onto a complete subspace `K` and its orthogonal
 complement sum to the identity. -/
 theorem id_eq_sum_orthogonalProjection_self_orthogonalComplement [HasOrthogonalProjection K] :
     ContinuousLinearMap.id 𝕜 E =
-      K.subtypeL.comp (orthogonalProjection K) + Kᗮ.subtypeL.comp (orthogonalProjection Kᗮ) := by
+      K.subtypeL.comp (K.orthogonalProjection) + Kᗮ.subtypeL.comp (Kᗮ.orthogonalProjection) := by
   ext w
   exact (orthogonalProjection_add_orthogonalProjection_orthogonal K w).symm
 
 -- Porting note: The priority should be higher than `Submodule.coe_inner`.
 @[simp high]
 theorem inner_orthogonalProjection_eq_of_mem_right [HasOrthogonalProjection K] (u : K) (v : E) :
-    ⟪orthogonalProjection K v, u⟫ = ⟪v, u⟫ :=
+    ⟪K.orthogonalProjection v, u⟫ = ⟪v, u⟫ :=
   calc
-    ⟪orthogonalProjection K v, u⟫ = ⟪(orthogonalProjection K v : E), u⟫ := K.coe_inner _ _
-    _ = ⟪(orthogonalProjection K v : E), u⟫ + ⟪v - orthogonalProjection K v, u⟫ := by
+    ⟪K.orthogonalProjection v, u⟫ = ⟪(K.orthogonalProjection v : E), u⟫ := K.coe_inner _ _
+    _ = ⟪(K.orthogonalProjection v : E), u⟫ + ⟪v - K.orthogonalProjection v, u⟫ := by
       rw [orthogonalProjection_inner_eq_zero _ _ (Submodule.coe_mem _), add_zero]
     _ = ⟪v, u⟫ := by rw [← inner_add_left, add_sub_cancel]
 
 -- Porting note: The priority should be higher than `Submodule.coe_inner`.
 @[simp high]
 theorem inner_orthogonalProjection_eq_of_mem_left [HasOrthogonalProjection K] (u : K) (v : E) :
-    ⟪u, orthogonalProjection K v⟫ = ⟪(u : E), v⟫ := by
+    ⟪u, K.orthogonalProjection v⟫ = ⟪(u : E), v⟫ := by
   rw [← inner_conj_symm, ← inner_conj_symm (u : E), inner_orthogonalProjection_eq_of_mem_right]
 
 /-- The orthogonal projection is self-adjoint. -/
 theorem inner_orthogonalProjection_left_eq_right [HasOrthogonalProjection K] (u v : E) :
-    ⟪↑(orthogonalProjection K u), v⟫ = ⟪u, orthogonalProjection K v⟫ := by
+    ⟪↑(K.orthogonalProjection u), v⟫ = ⟪u, K.orthogonalProjection v⟫ := by
   rw [← inner_orthogonalProjection_eq_of_mem_left, inner_orthogonalProjection_eq_of_mem_right]
 
 /-- The orthogonal projection is symmetric. -/
 theorem orthogonalProjection_isSymmetric [HasOrthogonalProjection K] :
-    (K.subtypeL ∘L orthogonalProjection K : E →ₗ[𝕜] E).IsSymmetric :=
+    (K.subtypeL ∘L K.orthogonalProjection : E →ₗ[𝕜] E).IsSymmetric :=
   inner_orthogonalProjection_left_eq_right K
 
 open Module
@@ -1229,7 +1229,7 @@ open DirectSum
 /-- If `x` lies within an orthogonal family `v`, it can be expressed as a sum of projections. -/
 theorem OrthogonalFamily.sum_projection_of_mem_iSup [Fintype ι] {V : ι → Submodule 𝕜 E}
     [∀ i, CompleteSpace (V i)] (hV : OrthogonalFamily 𝕜 (fun i => V i) fun i => (V i).subtypeₗᵢ)
-    (x : E) (hx : x ∈ iSup V) : (∑ i, (orthogonalProjection (V i) x : E)) = x := by
+    (x : E) (hx : x ∈ iSup V) : (∑ i, ((V i).orthogonalProjection x : E)) = x := by
   induction hx using Submodule.iSup_induction' with
   | mem i x hx =>
     refine
@@ -1248,7 +1248,7 @@ is just the coefficient of that direct sum. -/
 theorem OrthogonalFamily.projection_directSum_coeAddHom [DecidableEq ι] {V : ι → Submodule 𝕜 E}
     (hV : OrthogonalFamily 𝕜 (fun i => V i) fun i => (V i).subtypeₗᵢ) (x : ⨁ i, V i) (i : ι)
     [CompleteSpace (V i)] :
-    orthogonalProjection (V i) (DirectSum.coeAddMonoidHom V x) = x i := by
+    (V i).orthogonalProjection (DirectSum.coeAddMonoidHom V x) = x i := by
   induction x using DirectSum.induction_on with
   | zero => simp
   | of j x =>
@@ -1268,13 +1268,13 @@ theorem OrthogonalFamily.projection_directSum_coeAddHom [DecidableEq ι] {V : ι
 /-- If a family of submodules is orthogonal and they span the whole space, then the orthogonal
 projection provides a means to decompose the space into its submodules.
 
-The projection function is `decompose V x i = orthogonalProjection (V i) x`.
+The projection function is `decompose V x i = (V i).orthogonalProjection x`.
 
 See note [reducible non-instances]. -/
 abbrev OrthogonalFamily.decomposition [DecidableEq ι] [Fintype ι] {V : ι → Submodule 𝕜 E}
     [∀ i, CompleteSpace (V i)] (hV : OrthogonalFamily 𝕜 (fun i => V i) fun i => (V i).subtypeₗᵢ)
     (h : iSup V = ⊤) : DirectSum.Decomposition V where
-  decompose' x := DFinsupp.equivFunOnFintype.symm fun i => orthogonalProjection (V i) x
+  decompose' x := DFinsupp.equivFunOnFintype.symm fun i => (V i).orthogonalProjection x
   left_inv x := by
     dsimp only
     letI := fun i => Classical.decEq (V i)

--- a/Mathlib/Analysis/InnerProductSpace/Projection.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Projection.lean
@@ -18,9 +18,9 @@ Given a nonempty complete subspace `K` of an inner product space `E`, this file 
 satisfies: for any point `u` in `E`, the point `v = K.orthogonalProjection u` in `K` minimizes the
 distance `‖u - v‖` to `u`.
 
-Also a linear isometry equivalence `reflection K : E ≃ₗᵢ[𝕜] E` is constructed, by choosing, for
-each `u : E`, the point `reflection K u` to satisfy
-`u + (reflection K u) = 2 • K.orthogonalProjection u`.
+Also a linear isometry equivalence `K.reflection : E ≃ₗᵢ[𝕜] E` is constructed, by choosing, for
+each `u : E`, the point `K.reflection u` to satisfy
+`u + (K.reflection u) = 2 • K.orthogonalProjection u`.
 
 Basic API for `orthogonalProjection` and `reflection` is developed.
 
@@ -263,6 +263,8 @@ theorem norm_eq_iInf_iff_real_inner_le_zero {K : Set F} (h : Convex ℝ K) {u : 
 
 variable (K : Submodule 𝕜 E)
 
+namespace Submodule
+
 /-- Existence of projections on complete subspaces.
 Let `u` be a point in an inner product space, and let `K` be a nonempty complete subspace.
 Then there exists a (unique) `v` in `K` that minimizes the distance `‖u - v‖` to `u`.
@@ -331,7 +333,7 @@ theorem norm_eq_iInf_iff_inner_eq_zero {u : E} {v : E} (hv : v ∈ K) :
   let K' : Submodule ℝ E := K.restrictScalars ℝ
   constructor
   · intro H
-    have A : ∀ w ∈ K, re ⟪u - v, w⟫ = 0 := (norm_eq_iInf_iff_real_inner_eq_zero K' hv).1 H
+    have A : ∀ w ∈ K, re ⟪u - v, w⟫ = 0 := (K'.norm_eq_iInf_iff_real_inner_eq_zero hv).1 H
     intro w hw
     apply RCLike.ext
     · simp [A w hw]
@@ -346,7 +348,7 @@ theorem norm_eq_iInf_iff_inner_eq_zero {u : E} {v : E} (hv : v ∈ K) :
       intro w hw
       rw [real_inner_eq_re_inner, H w hw]
       exact zero_re'
-    exact (norm_eq_iInf_iff_real_inner_eq_zero K' hv).2 this
+    exact (K'.norm_eq_iInf_iff_real_inner_eq_zero hv).2 this
 
 /-- A subspace `K : Submodule 𝕜 E` has an orthogonal projection if every vector `v : E` admits an
 orthogonal projection to `K`. -/
@@ -356,10 +358,10 @@ class HasOrthogonalProjection (K : Submodule 𝕜 E) : Prop where
 instance (priority := 100) HasOrthogonalProjection.ofCompleteSpace [CompleteSpace K] :
     HasOrthogonalProjection K where
   exists_orthogonal v := by
-    rcases exists_norm_eq_iInf_of_complete_subspace K (completeSpace_coe_iff_isComplete.mp ‹_›) v
+    rcases K.exists_norm_eq_iInf_of_complete_subspace (completeSpace_coe_iff_isComplete.mp ‹_›) v
       with ⟨w, hwK, hw⟩
     refine ⟨w, hwK, (K.mem_orthogonal' _).2 ?_⟩
-    rwa [← norm_eq_iInf_iff_inner_eq_zero K hwK]
+    rwa [← K.norm_eq_iInf_iff_inner_eq_zero hwK]
 
 instance [HasOrthogonalProjection K] : HasOrthogonalProjection Kᗮ where
   exists_orthogonal v := by
@@ -399,14 +401,14 @@ variable {K}
 /-- The unbundled orthogonal projection is in the given subspace.
 This lemma is only intended for use in setting up the bundled version
 and should not be used once that is defined. -/
-theorem orthogonalProjectionFn_mem (v : E) : orthogonalProjectionFn K v ∈ K :=
+theorem orthogonalProjectionFn_mem (v : E) : K.orthogonalProjectionFn v ∈ K :=
   (HasOrthogonalProjection.exists_orthogonal (K := K) v).choose_spec.left
 
 /-- The characterization of the unbundled orthogonal projection.  This
 lemma is only intended for use in setting up the bundled version
 and should not be used once that is defined. -/
 theorem orthogonalProjectionFn_inner_eq_zero (v : E) :
-    ∀ w ∈ K, ⟪v - orthogonalProjectionFn K v, w⟫ = 0 :=
+    ∀ w ∈ K, ⟪v - K.orthogonalProjectionFn v, w⟫ = 0 :=
   (K.mem_orthogonal' _).1 (HasOrthogonalProjection.exists_orthogonal (K := K) v).choose_spec.right
 
 /-- The unbundled orthogonal projection is the unique point in `K`
@@ -414,14 +416,14 @@ with the orthogonality property.  This lemma is only intended for use
 in setting up the bundled version and should not be used once that is
 defined. -/
 theorem eq_orthogonalProjectionFn_of_mem_of_inner_eq_zero {u v : E} (hvm : v ∈ K)
-    (hvo : ∀ w ∈ K, ⟪u - v, w⟫ = 0) : orthogonalProjectionFn K u = v := by
+    (hvo : ∀ w ∈ K, ⟪u - v, w⟫ = 0) : K.orthogonalProjectionFn u = v := by
   rw [← sub_eq_zero, ← @inner_self_eq_zero 𝕜]
-  have hvs : orthogonalProjectionFn K u - v ∈ K :=
+  have hvs : K.orthogonalProjectionFn u - v ∈ K :=
     Submodule.sub_mem K (orthogonalProjectionFn_mem u) hvm
-  have huo : ⟪u - orthogonalProjectionFn K u, orthogonalProjectionFn K u - v⟫ = 0 :=
+  have huo : ⟪u - K.orthogonalProjectionFn u, K.orthogonalProjectionFn u - v⟫ = 0 :=
     orthogonalProjectionFn_inner_eq_zero u _ hvs
-  have huv : ⟪u - v, orthogonalProjectionFn K u - v⟫ = 0 := hvo _ hvs
-  have houv : ⟪u - v - (u - orthogonalProjectionFn K u), orthogonalProjectionFn K u - v⟫ = 0 := by
+  have huv : ⟪u - v, K.orthogonalProjectionFn u - v⟫ = 0 := hvo _ hvs
+  have houv : ⟪u - v - (u - K.orthogonalProjectionFn u), K.orthogonalProjectionFn u - v⟫ = 0 := by
     rw [inner_sub_left, huo, huv, sub_zero]
   rwa [sub_sub_sub_cancel_left] at houv
 
@@ -429,31 +431,31 @@ variable (K)
 
 theorem orthogonalProjectionFn_norm_sq (v : E) :
     ‖v‖ * ‖v‖ =
-      ‖v - orthogonalProjectionFn K v‖ * ‖v - orthogonalProjectionFn K v‖ +
-        ‖orthogonalProjectionFn K v‖ * ‖orthogonalProjectionFn K v‖ := by
-  set p := orthogonalProjectionFn K v
+      ‖v - K.orthogonalProjectionFn v‖ * ‖v - K.orthogonalProjectionFn v‖ +
+        ‖K.orthogonalProjectionFn v‖ * ‖K.orthogonalProjectionFn v‖ := by
+  set p := K.orthogonalProjectionFn v
   have h' : ⟪v - p, p⟫ = 0 :=
     orthogonalProjectionFn_inner_eq_zero _ _ (orthogonalProjectionFn_mem v)
   convert norm_add_sq_eq_norm_sq_add_norm_sq_of_inner_eq_zero (v - p) p h' using 2 <;> simp
 
 /-- The orthogonal projection onto a complete subspace. -/
-def Submodule.orthogonalProjection : E →L[𝕜] K :=
+def orthogonalProjection : E →L[𝕜] K :=
   LinearMap.mkContinuous
-    { toFun := fun v => ⟨orthogonalProjectionFn K v, orthogonalProjectionFn_mem v⟩
+    { toFun := fun v => ⟨K.orthogonalProjectionFn v, orthogonalProjectionFn_mem v⟩
       map_add' := fun x y => by
-        have hm : orthogonalProjectionFn K x + orthogonalProjectionFn K y ∈ K :=
+        have hm : K.orthogonalProjectionFn x + K.orthogonalProjectionFn y ∈ K :=
           Submodule.add_mem K (orthogonalProjectionFn_mem x) (orthogonalProjectionFn_mem y)
         have ho :
-          ∀ w ∈ K, ⟪x + y - (orthogonalProjectionFn K x + orthogonalProjectionFn K y), w⟫ = 0 := by
+          ∀ w ∈ K, ⟪x + y - (K.orthogonalProjectionFn x + K.orthogonalProjectionFn y), w⟫ = 0 := by
           intro w hw
           rw [add_sub_add_comm, inner_add_left, orthogonalProjectionFn_inner_eq_zero _ w hw,
             orthogonalProjectionFn_inner_eq_zero _ w hw, add_zero]
         ext
         simp [eq_orthogonalProjectionFn_of_mem_of_inner_eq_zero hm ho]
       map_smul' := fun c x => by
-        have hm : c • orthogonalProjectionFn K x ∈ K :=
+        have hm : c • K.orthogonalProjectionFn x ∈ K :=
           Submodule.smul_mem K _ (orthogonalProjectionFn_mem x)
-        have ho : ∀ w ∈ K, ⟪c • x - c • orthogonalProjectionFn K x, w⟫ = 0 := by
+        have ho : ∀ w ∈ K, ⟪c • x - c • K.orthogonalProjectionFn x, w⟫ = 0 := by
           intro w hw
           rw [← smul_sub, inner_smul_left, orthogonalProjectionFn_inner_eq_zero _ w hw,
             mul_zero]
@@ -462,14 +464,14 @@ def Submodule.orthogonalProjection : E →L[𝕜] K :=
     1 fun x => by
     simp only [one_mul, LinearMap.coe_mk]
     refine le_of_pow_le_pow_left₀ two_ne_zero (norm_nonneg _) ?_
-    change ‖orthogonalProjectionFn K x‖ ^ 2 ≤ ‖x‖ ^ 2
-    nlinarith [orthogonalProjectionFn_norm_sq K x]
+    change ‖K.orthogonalProjectionFn x‖ ^ 2 ≤ ‖x‖ ^ 2
+    nlinarith [K.orthogonalProjectionFn_norm_sq x]
 
 variable {K}
 
 @[simp]
 theorem orthogonalProjectionFn_eq (v : E) :
-    orthogonalProjectionFn K v = (K.orthogonalProjection v : E) :=
+    K.orthogonalProjectionFn v = (K.orthogonalProjection v : E) :=
   rfl
 
 /-- The characterization of the orthogonal projection. -/
@@ -517,7 +519,7 @@ theorem orthogonalProjection_orthogonal (u : E) :
 /-- The orthogonal projection of `y` on `U` minimizes the distance `‖y - x‖` for `x ∈ U`. -/
 theorem orthogonalProjection_minimal {U : Submodule 𝕜 E} [HasOrthogonalProjection U] (y : E) :
     ‖y - U.orthogonalProjection y‖ = ⨅ x : U, ‖y - x‖ := by
-  rw [norm_eq_iInf_iff_inner_eq_zero _ (Submodule.coe_mem _)]
+  rw [U.norm_eq_iInf_iff_inner_eq_zero (Submodule.coe_mem _)]
   exact orthogonalProjection_inner_eq_zero _
 
 /-- The orthogonal projections onto equal subspaces are coerced back to the same point in `E`. -/
@@ -546,10 +548,10 @@ theorem orthogonalProjection_eq_zero_iff {v : E} : K.orthogonalProjection v = 0 
   · simpa
 
 @[simp]
-theorem ker_orthogonalProjection : LinearMap.ker (K.orthogonalProjection) = Kᗮ := by
+theorem ker_orthogonalProjection : LinearMap.ker K.orthogonalProjection = Kᗮ := by
   ext; exact orthogonalProjection_eq_zero_iff
 
-theorem LinearIsometry.map_orthogonalProjection {E E' : Type*} [NormedAddCommGroup E]
+theorem _root_.LinearIsometry.map_orthogonalProjection {E E' : Type*} [NormedAddCommGroup E]
     [NormedAddCommGroup E'] [InnerProductSpace 𝕜 E] [InnerProductSpace 𝕜 E'] (f : E →ₗᵢ[𝕜] E')
     (p : Submodule 𝕜 E) [HasOrthogonalProjection p] [HasOrthogonalProjection (p.map f.toLinearMap)]
     (x : E) : f (p.orthogonalProjection x) = (p.map f.toLinearMap).orthogonalProjection (f x) := by
@@ -558,7 +560,7 @@ theorem LinearIsometry.map_orthogonalProjection {E E' : Type*} [NormedAddCommGro
   rcases hy with ⟨x', hx', rfl : f x' = y⟩
   rw [← f.map_sub, f.inner_map_map, orthogonalProjection_inner_eq_zero x x' hx']
 
-theorem LinearIsometry.map_orthogonalProjection' {E E' : Type*} [NormedAddCommGroup E]
+theorem _root_.LinearIsometry.map_orthogonalProjection' {E E' : Type*} [NormedAddCommGroup E]
     [NormedAddCommGroup E'] [InnerProductSpace 𝕜 E] [InnerProductSpace 𝕜 E'] (f : E →ₗᵢ[𝕜] E')
     (p : Submodule 𝕜 E) [HasOrthogonalProjection p] [HasOrthogonalProjection (p.map f)] (x : E) :
     f (p.orthogonalProjection x) = (p.map f).orthogonalProjection (f x) :=
@@ -624,7 +626,7 @@ variable [HasOrthogonalProjection K]
 /-- Auxiliary definition for `reflection`: the reflection as a linear equivalence. -/
 def reflectionLinearEquiv : E ≃ₗ[𝕜] E :=
   LinearEquiv.ofInvolutive
-    (2 • (K.subtype.comp (K.orthogonalProjection).toLinearMap) - LinearMap.id) fun x => by
+    (2 • (K.subtype.comp K.orthogonalProjection.toLinearMap) - LinearMap.id) fun x => by
     simp [two_smul]
 
 /-- Reflection in a complete subspace of an inner product space.  The word "reflection" is
@@ -633,7 +635,7 @@ more generally to cover operations such as reflection in a point.  The definitio
 reflection in a subspace, is a more general sense of the word that includes both those common
 cases. -/
 def reflection : E ≃ₗᵢ[𝕜] E :=
-  { reflectionLinearEquiv K with
+  { K.reflectionLinearEquiv with
     norm_map' := by
       intro x
       let w : K := K.orthogonalProjection x
@@ -651,45 +653,44 @@ def reflection : E ≃ₗᵢ[𝕜] E :=
 variable {K}
 
 /-- The result of reflecting. -/
-theorem reflection_apply (p : E) : reflection K p = 2 • (K.orthogonalProjection p : E) - p :=
+theorem reflection_apply (p : E) : K.reflection p = 2 • (K.orthogonalProjection p : E) - p :=
   rfl
 
 /-- Reflection is its own inverse. -/
 @[simp]
-theorem reflection_symm : (reflection K).symm = reflection K :=
+theorem reflection_symm : K.reflection.symm = K.reflection :=
   rfl
 
 /-- Reflection is its own inverse. -/
 @[simp]
-theorem reflection_inv : (reflection K)⁻¹ = reflection K :=
+theorem reflection_inv : K.reflection⁻¹ = K.reflection :=
   rfl
 
 variable (K)
 
 /-- Reflecting twice in the same subspace. -/
 @[simp]
-theorem reflection_reflection (p : E) : reflection K (reflection K p) = p :=
-  (reflection K).left_inv p
+theorem reflection_reflection (p : E) : K.reflection (K.reflection p) = p :=
+  K.reflection.left_inv p
 
 /-- Reflection is involutive. -/
-theorem reflection_involutive : Function.Involutive (reflection K) :=
-  reflection_reflection K
+theorem reflection_involutive : Function.Involutive K.reflection :=
+  K.reflection_reflection
 
 /-- Reflection is involutive. -/
 @[simp]
 theorem reflection_trans_reflection :
-    (reflection K).trans (reflection K) = LinearIsometryEquiv.refl 𝕜 E :=
+    K.reflection.trans K.reflection = LinearIsometryEquiv.refl 𝕜 E :=
   LinearIsometryEquiv.ext <| reflection_involutive K
 
 /-- Reflection is involutive. -/
 @[simp]
-theorem reflection_mul_reflection : reflection K * reflection K = 1 :=
+theorem reflection_mul_reflection : K.reflection * K.reflection = 1 :=
   reflection_trans_reflection _
-
-theorem reflection_orthogonal_apply (v : E) : reflection Kᗮ v = -reflection K v := by
+theorem reflection_orthogonal_apply (v : E) : Kᗮ.reflection v = -K.reflection v := by
   simp [reflection_apply]; abel
 
-theorem reflection_orthogonal : reflection Kᗮ = .trans (reflection K) (.neg _) := by
+theorem reflection_orthogonal : Kᗮ.reflection = .trans K.reflection (.neg _) := by
   ext; apply reflection_orthogonal_apply
 
 variable {K}
@@ -699,27 +700,27 @@ theorem reflection_singleton_apply (u v : E) :
   rw [reflection_apply, orthogonalProjection_singleton, ofReal_pow]
 
 /-- A point is its own reflection if and only if it is in the subspace. -/
-theorem reflection_eq_self_iff (x : E) : reflection K x = x ↔ x ∈ K := by
+theorem reflection_eq_self_iff (x : E) : K.reflection x = x ↔ x ∈ K := by
   rw [← orthogonalProjection_eq_self_iff, reflection_apply, sub_eq_iff_eq_add', ← two_smul 𝕜,
     two_smul ℕ, ← two_smul 𝕜]
   refine (smul_right_injective E ?_).eq_iff
   exact two_ne_zero
 
-theorem reflection_mem_subspace_eq_self {x : E} (hx : x ∈ K) : reflection K x = x :=
+theorem reflection_mem_subspace_eq_self {x : E} (hx : x ∈ K) : K.reflection x = x :=
   (reflection_eq_self_iff x).mpr hx
 
 /-- Reflection in the `Submodule.map` of a subspace. -/
 theorem reflection_map_apply {E E' : Type*} [NormedAddCommGroup E] [NormedAddCommGroup E']
     [InnerProductSpace 𝕜 E] [InnerProductSpace 𝕜 E'] (f : E ≃ₗᵢ[𝕜] E') (K : Submodule 𝕜 E)
     [HasOrthogonalProjection K] (x : E') :
-    reflection (K.map (f.toLinearEquiv : E →ₗ[𝕜] E')) x = f (reflection K (f.symm x)) := by
+    reflection (K.map (f.toLinearEquiv : E →ₗ[𝕜] E')) x = f (K.reflection (f.symm x)) := by
   simp [two_smul, reflection_apply, orthogonalProjection_map_apply f K x]
 
 /-- Reflection in the `Submodule.map` of a subspace. -/
 theorem reflection_map {E E' : Type*} [NormedAddCommGroup E] [NormedAddCommGroup E']
     [InnerProductSpace 𝕜 E] [InnerProductSpace 𝕜 E'] (f : E ≃ₗᵢ[𝕜] E') (K : Submodule 𝕜 E)
     [HasOrthogonalProjection K] :
-    reflection (K.map (f.toLinearEquiv : E →ₗ[𝕜] E')) = f.symm.trans ((reflection K).trans f) :=
+    reflection (K.map (f.toLinearEquiv : E →ₗ[𝕜] E')) = f.symm.trans (K.reflection.trans f) :=
   LinearIsometryEquiv.ext <| reflection_map_apply f K
 
 /-- Reflection through the trivial subspace {0} is just negation. -/
@@ -729,10 +730,14 @@ theorem reflection_bot : reflection (⊥ : Submodule 𝕜 E) = LinearIsometryEqu
 
 end reflection
 
+end Submodule
+
 section Orthogonal
 
+namespace Submodule
+
 /-- If `K₁` is complete and contained in `K₂`, `K₁` and `K₁ᗮ ⊓ K₂` span `K₂`. -/
-theorem Submodule.sup_orthogonal_inf_of_completeSpace {K₁ K₂ : Submodule 𝕜 E} (h : K₁ ≤ K₂)
+theorem sup_orthogonal_inf_of_completeSpace {K₁ K₂ : Submodule 𝕜 E} (h : K₁ ≤ K₂)
     [HasOrthogonalProjection K₁] : K₁ ⊔ K₁ᗮ ⊓ K₂ = K₂ := by
   ext x
   rw [Submodule.mem_sup]
@@ -745,12 +750,12 @@ theorem Submodule.sup_orthogonal_inf_of_completeSpace {K₁ K₂ : Submodule �
 
 variable {K} in
 /-- If `K` is complete, `K` and `Kᗮ` span the whole space. -/
-theorem Submodule.sup_orthogonal_of_completeSpace [HasOrthogonalProjection K] : K ⊔ Kᗮ = ⊤ := by
+theorem sup_orthogonal_of_completeSpace [HasOrthogonalProjection K] : K ⊔ Kᗮ = ⊤ := by
   convert Submodule.sup_orthogonal_inf_of_completeSpace (le_top : K ≤ ⊤) using 2
   simp
 
 /-- If `K` is complete, any `v` in `E` can be expressed as a sum of elements of `K` and `Kᗮ`. -/
-theorem Submodule.exists_add_mem_mem_orthogonal [HasOrthogonalProjection K] (v : E) :
+theorem exists_add_mem_mem_orthogonal [HasOrthogonalProjection K] (v : E) :
     ∃ y ∈ K, ∃ z ∈ Kᗮ, v = y + z :=
   ⟨K.orthogonalProjection v, Subtype.coe_prop _, v - K.orthogonalProjection v,
     sub_orthogonalProjection_mem_orthogonal _, by simp⟩
@@ -758,7 +763,7 @@ theorem Submodule.exists_add_mem_mem_orthogonal [HasOrthogonalProjection K] (v :
 /-- If `K` admits an orthogonal projection, then the orthogonal complement of its orthogonal
 complement is itself. -/
 @[simp]
-theorem Submodule.orthogonal_orthogonal [HasOrthogonalProjection K] : Kᗮᗮ = K := by
+theorem orthogonal_orthogonal [HasOrthogonalProjection K] : Kᗮᗮ = K := by
   ext v
   constructor
   · obtain ⟨y, hy, z, hz, rfl⟩ := K.exists_add_mem_mem_orthogonal v
@@ -777,7 +782,7 @@ is the topological closure of `K`.
 Note that the completeness assumption is necessary. Let `E` be the space `ℕ →₀ ℝ` with inner space
 structure inherited from `PiLp 2 (fun _ : ℕ ↦ ℝ)`. Let `K` be the subspace of sequences with the sum
 of all elements equal to zero. Then `Kᗮ = ⊥`, `Kᗮᗮ = ⊤`. -/
-theorem Submodule.orthogonal_orthogonal_eq_closure [CompleteSpace E] :
+theorem orthogonal_orthogonal_eq_closure [CompleteSpace E] :
     Kᗮᗮ = K.topologicalClosure := by
   refine le_antisymm ?_ ?_
   · convert Submodule.orthogonal_orthogonal_monotone K.le_topologicalClosure using 1
@@ -787,7 +792,7 @@ theorem Submodule.orthogonal_orthogonal_eq_closure [CompleteSpace E] :
 variable {K}
 
 /-- If `K` admits an orthogonal projection, `K` and `Kᗮ` are complements of each other. -/
-theorem Submodule.isCompl_orthogonal_of_completeSpace [HasOrthogonalProjection K] : IsCompl K Kᗮ :=
+theorem isCompl_orthogonal_of_completeSpace [HasOrthogonalProjection K] : IsCompl K Kᗮ :=
   ⟨K.orthogonal_disjoint, codisjoint_iff.2 Submodule.sup_orthogonal_of_completeSpace⟩
 
 @[simp]
@@ -797,7 +802,7 @@ theorem orthogonalComplement_eq_orthogonalComplement {L : Submodule 𝕜 E} [Has
     fun h ↦ congr(Submodule.orthogonal $(h))⟩
 
 @[simp]
-theorem Submodule.orthogonal_eq_bot_iff [HasOrthogonalProjection K] : Kᗮ = ⊥ ↔ K = ⊤ := by
+theorem orthogonal_eq_bot_iff [HasOrthogonalProjection K] : Kᗮ = ⊥ ↔ K = ⊤ := by
   refine ⟨?_, fun h => by rw [h, Submodule.top_orthogonal_eq_bot]⟩
   intro h
   have : K ⊔ Kᗮ = ⊤ := Submodule.sup_orthogonal_of_completeSpace
@@ -810,7 +815,7 @@ theorem orthogonalProjection_mem_subspace_orthogonalComplement_eq_zero [HasOrtho
   convert eq_orthogonalProjection_of_mem_orthogonal (K := K) _ _ <;> simp [hv]
 
 /-- The projection into `U` from an orthogonal submodule `V` is the zero map. -/
-theorem Submodule.IsOrtho.orthogonalProjection_comp_subtypeL {U V : Submodule 𝕜 E}
+theorem IsOrtho.orthogonalProjection_comp_subtypeL {U V : Submodule 𝕜 E}
     [HasOrthogonalProjection U] (h : U ⟂ V) : U.orthogonalProjection ∘L V.subtypeL = 0 :=
   ContinuousLinearMap.ext fun v =>
     orthogonalProjection_mem_subspace_orthogonalComplement_eq_zero <| h.symm v.prop
@@ -838,7 +843,7 @@ theorem orthogonalProjection_coe_linearMap_eq_linearProj [HasOrthogonalProjectio
 
 /-- The reflection in `K` of an element of `Kᗮ` is its negation. -/
 theorem reflection_mem_subspace_orthogonalComplement_eq_neg [HasOrthogonalProjection K] {v : E}
-    (hv : v ∈ Kᗮ) : reflection K v = -v := by
+    (hv : v ∈ Kᗮ) : K.reflection v = -v := by
   simp [reflection_apply, orthogonalProjection_mem_subspace_orthogonalComplement_eq_zero hv]
 
 /-- The orthogonal projection onto `Kᗮ` of an element of `K` is zero. -/
@@ -898,24 +903,26 @@ theorem orthogonalProjection_tendsto_self {ι : Type*} [Preorder ι]
   trivial
 
 /-- The orthogonal complement satisfies `Kᗮᗮᗮ = Kᗮ`. -/
-theorem Submodule.triorthogonal_eq_orthogonal [CompleteSpace E] : Kᗮᗮᗮ = Kᗮ := by
+theorem triorthogonal_eq_orthogonal [CompleteSpace E] : Kᗮᗮᗮ = Kᗮ := by
   rw [Kᗮ.orthogonal_orthogonal_eq_closure]
   exact K.isClosed_orthogonal.submodule_topologicalClosure_eq
 
 /-- The closure of `K` is the full space iff `Kᗮ` is trivial. -/
-theorem Submodule.topologicalClosure_eq_top_iff [CompleteSpace E] :
+theorem topologicalClosure_eq_top_iff [CompleteSpace E] :
     K.topologicalClosure = ⊤ ↔ Kᗮ = ⊥ := by
-  rw [← Submodule.orthogonal_orthogonal_eq_closure]
+  rw [← K.orthogonal_orthogonal_eq_closure]
   constructor <;> intro h
   · rw [← Submodule.triorthogonal_eq_orthogonal, h, Submodule.top_orthogonal_eq_bot]
   · rw [h, Submodule.bot_orthogonal_eq_top]
+
+end Submodule
 
 namespace Dense
 
 /- TODO: Move to another file? -/
 open Submodule
 
-variable {x y : E}
+variable {K} {x y : E}
 
 theorem eq_zero_of_inner_left (hK : Dense (K : Set E)) (h : ∀ v : K, ⟪x, v⟫ = 0) : x = 0 := by
   have : (⟪x, ·⟫) = 0 := (continuous_const.inner continuous_id).ext_on
@@ -941,9 +948,13 @@ theorem eq_zero_of_inner_right (hK : Dense (K : Set E)) (h : ∀ v : K, ⟪(v : 
 
 end Dense
 
+namespace Submodule
+
+variable {K}
+
 /-- The reflection in `Kᗮ` of an element of `K` is its negation. -/
 theorem reflection_mem_subspace_orthogonal_precomplement_eq_neg [HasOrthogonalProjection K] {v : E}
-    (hv : v ∈ K) : reflection Kᗮ v = -v :=
+    (hv : v ∈ K) : Kᗮ.reflection v = -v :=
   reflection_mem_subspace_orthogonalComplement_eq_neg (K.le_orthogonal_orthogonal hv)
 
 /-- The orthogonal projection onto `(𝕜 ∙ v)ᗮ` of `v` is zero. -/
@@ -980,14 +991,14 @@ open Module
 variable [FiniteDimensional 𝕜 K]
 
 @[simp]
-theorem det_reflection : LinearMap.det (reflection K).toLinearMap = (-1) ^ finrank 𝕜 Kᗮ := by
+theorem det_reflection : LinearMap.det K.reflection.toLinearMap = (-1) ^ finrank 𝕜 Kᗮ := by
   by_cases hK : FiniteDimensional 𝕜 Kᗮ
   swap
   · rw [finrank_of_infinite_dimensional hK, pow_zero, LinearMap.det_eq_one_of_finrank_eq_zero]
     exact finrank_of_infinite_dimensional fun h ↦ hK (h.finiteDimensional_submodule _)
   let e := K.prodEquivOfIsCompl _ K.isCompl_orthogonal_of_completeSpace
   let b := (finBasis 𝕜 K).prod (finBasis 𝕜 Kᗮ)
-  have : LinearMap.toMatrix b b (e.symm ∘ₗ (reflection K).toLinearMap ∘ₗ e.symm.symm) =
+  have : LinearMap.toMatrix b b (e.symm ∘ₗ K.reflection.toLinearMap ∘ₗ e.symm.symm) =
       Matrix.fromBlocks 1 0 0 (-1) := by
     ext (_ | _) (_ | _) <;>
     simp [LinearMap.toMatrix_apply, b, Matrix.one_apply, Finsupp.single_apply, e, eq_comm,
@@ -996,10 +1007,10 @@ theorem det_reflection : LinearMap.det (reflection K).toLinearMap = (-1) ^ finra
     Matrix.det_one, one_mul, Matrix.det_neg, Fintype.card_fin, Matrix.det_one, mul_one]
 
 @[simp]
-theorem linearEquiv_det_reflection : (reflection K).det = (-1) ^ finrank 𝕜 Kᗮ := by
+theorem linearEquiv_det_reflection : K.reflection.det = (-1) ^ finrank 𝕜 Kᗮ := by
   ext
   rw [LinearEquiv.coe_det, Units.val_pow_eq_pow_val]
-  exact det_reflection K
+  exact K.det_reflection
 
 end FiniteDimensional
 
@@ -1024,9 +1035,9 @@ theorem norm_sq_eq_add_norm_sq_projection (x : E) (S : Submodule 𝕜 E) [HasOrt
 complement sum to the identity. -/
 theorem id_eq_sum_orthogonalProjection_self_orthogonalComplement [HasOrthogonalProjection K] :
     ContinuousLinearMap.id 𝕜 E =
-      K.subtypeL.comp (K.orthogonalProjection) + Kᗮ.subtypeL.comp (Kᗮ.orthogonalProjection) := by
+      K.subtypeL.comp K.orthogonalProjection + Kᗮ.subtypeL.comp (Kᗮ.orthogonalProjection) := by
   ext w
-  exact (orthogonalProjection_add_orthogonalProjection_orthogonal K w).symm
+  exact (K.orthogonalProjection_add_orthogonalProjection_orthogonal w).symm
 
 -- Porting note: The priority should be higher than `Submodule.coe_inner`.
 @[simp high]
@@ -1059,7 +1070,7 @@ open Module
 /-- Given a finite-dimensional subspace `K₂`, and a subspace `K₁`
 contained in it, the dimensions of `K₁` and the intersection of its
 orthogonal subspace with `K₂` add to that of `K₂`. -/
-theorem Submodule.finrank_add_inf_finrank_orthogonal {K₁ K₂ : Submodule 𝕜 E}
+theorem finrank_add_inf_finrank_orthogonal {K₁ K₂ : Submodule 𝕜 E}
     [FiniteDimensional 𝕜 K₂] (h : K₁ ≤ K₂) :
     finrank 𝕜 K₁ + finrank 𝕜 (K₁ᗮ ⊓ K₂ : Submodule 𝕜 E) = finrank 𝕜 K₂ := by
   haveI : FiniteDimensional 𝕜 K₁ := Submodule.finiteDimensional_of_le h
@@ -1073,7 +1084,7 @@ theorem Submodule.finrank_add_inf_finrank_orthogonal {K₁ K₂ : Submodule 𝕜
 /-- Given a finite-dimensional subspace `K₂`, and a subspace `K₁`
 contained in it, the dimensions of `K₁` and the intersection of its
 orthogonal subspace with `K₂` add to that of `K₂`. -/
-theorem Submodule.finrank_add_inf_finrank_orthogonal' {K₁ K₂ : Submodule 𝕜 E}
+theorem finrank_add_inf_finrank_orthogonal' {K₁ K₂ : Submodule 𝕜 E}
     [FiniteDimensional 𝕜 K₂] (h : K₁ ≤ K₂) {n : ℕ} (h_dim : finrank 𝕜 K₁ + n = finrank 𝕜 K₂) :
     finrank 𝕜 (K₁ᗮ ⊓ K₂ : Submodule 𝕜 E) = n := by
   rw [← add_right_inj (finrank 𝕜 K₁)]
@@ -1081,7 +1092,7 @@ theorem Submodule.finrank_add_inf_finrank_orthogonal' {K₁ K₂ : Submodule �
 
 /-- Given a finite-dimensional space `E` and subspace `K`, the dimensions of `K` and `Kᗮ` add to
 that of `E`. -/
-theorem Submodule.finrank_add_finrank_orthogonal [FiniteDimensional 𝕜 E] (K : Submodule 𝕜 E) :
+theorem finrank_add_finrank_orthogonal [FiniteDimensional 𝕜 E] (K : Submodule 𝕜 E) :
     finrank 𝕜 K + finrank 𝕜 Kᗮ = finrank 𝕜 E := by
   convert Submodule.finrank_add_inf_finrank_orthogonal (le_top : K ≤ ⊤) using 1
   · rw [inf_top_eq]
@@ -1089,7 +1100,7 @@ theorem Submodule.finrank_add_finrank_orthogonal [FiniteDimensional 𝕜 E] (K :
 
 /-- Given a finite-dimensional space `E` and subspace `K`, the dimensions of `K` and `Kᗮ` add to
 that of `E`. -/
-theorem Submodule.finrank_add_finrank_orthogonal' [FiniteDimensional 𝕜 E] {K : Submodule 𝕜 E}
+theorem finrank_add_finrank_orthogonal' [FiniteDimensional 𝕜 E] {K : Submodule 𝕜 E}
     {n : ℕ} (h_dim : finrank 𝕜 K + n = finrank 𝕜 E) : finrank 𝕜 Kᗮ = n := by
   rw [← add_right_inj (finrank 𝕜 K)]
   simp [Submodule.finrank_add_finrank_orthogonal, h_dim]
@@ -1099,22 +1110,26 @@ span of a nonzero vector is one less than the dimension of the space. -/
 theorem finrank_orthogonal_span_singleton {n : ℕ} [_i : Fact (finrank 𝕜 E = n + 1)] {v : E}
     (hv : v ≠ 0) : finrank 𝕜 (𝕜 ∙ v)ᗮ = n := by
   haveI : FiniteDimensional 𝕜 E := .of_fact_finrank_eq_succ n
-  exact Submodule.finrank_add_finrank_orthogonal' <| by
+  exact finrank_add_finrank_orthogonal' <| by
     simp [finrank_span_singleton hv, _i.elim, add_comm]
+
+end Submodule
+
+open Module Submodule
 
 /-- An element `φ` of the orthogonal group of `F` can be factored as a product of reflections, and
 specifically at most as many reflections as the dimension of the complement of the fixed subspace
 of `φ`. -/
 theorem LinearIsometryEquiv.reflections_generate_dim_aux [FiniteDimensional ℝ F] {n : ℕ}
     (φ : F ≃ₗᵢ[ℝ] F) (hn : finrank ℝ (ker (ContinuousLinearMap.id ℝ F - φ))ᗮ ≤ n) :
-    ∃ l : List F, l.length ≤ n ∧ φ = (l.map fun v => reflection (ℝ ∙ v)ᗮ).prod := by
+    ∃ l : List F, l.length ≤ n ∧ φ = (l.map fun v => (ℝ ∙ v)ᗮ.reflection).prod := by
   -- We prove this by strong induction on `n`, the dimension of the orthogonal complement of the
   -- fixed subspace of the endomorphism `φ`
   induction' n with n IH generalizing φ
   · -- Base case: `n = 0`, the fixed subspace is the whole space, so `φ = id`
     refine ⟨[], rfl.le, show φ = 1 from ?_⟩
     have : ker (ContinuousLinearMap.id ℝ F - φ) = ⊤ := by
-      rwa [le_zero_iff, Submodule.finrank_eq_zero, Submodule.orthogonal_eq_bot_iff] at hn
+      rwa [le_zero_iff, finrank_eq_zero, orthogonal_eq_bot_iff] at hn
     symm
     ext x
     have := LinearMap.congr_fun (LinearMap.ker_eq_top.mp this) x
@@ -1136,10 +1151,10 @@ theorem LinearIsometryEquiv.reflections_generate_dim_aux [FiniteDimensional ℝ 
       exact v.prop w hw
     have hv' : (v : F) ∉ W := by
       intro h
-      exact hv ((Submodule.mem_left_iff_eq_zero_of_disjoint W.orthogonal_disjoint).mp h)
+      exact hv ((mem_left_iff_eq_zero_of_disjoint W.orthogonal_disjoint).mp h)
     -- Let `ρ` be the reflection in `v - φ v`; this is designed to swap `v` and `φ v`
     let x : F := v - φ v
-    let ρ := reflection (ℝ ∙ x)ᗮ
+    let ρ := (ℝ ∙ x)ᗮ.reflection
     -- Notation: Let `V` be the fixed subspace of `φ.trans ρ`
     let V := ker (ContinuousLinearMap.id ℝ F - φ.trans ρ)
     have hV : ∀ w, ρ (φ w) = w → w ∈ V := by
@@ -1152,7 +1167,7 @@ theorem LinearIsometryEquiv.reflections_generate_dim_aux [FiniteDimensional ℝ 
       apply hV
       rw [hW w hw]
       refine reflection_mem_subspace_eq_self ?_
-      rw [Submodule.mem_orthogonal_singleton_iff_inner_left]
+      rw [mem_orthogonal_singleton_iff_inner_left]
       exact Submodule.sub_mem _ v.prop hφv _ hw
     -- `v` is also fixed by `φ.trans ρ`
     have H₁V : (v : F) ∈ V := by
@@ -1165,7 +1180,7 @@ theorem LinearIsometryEquiv.reflections_generate_dim_aux [FiniteDimensional ℝ 
     have : finrank ℝ Vᗮ ≤ n := by
       change finrank ℝ Wᗮ ≤ n + 1 at hn
       have : finrank ℝ W + 1 ≤ finrank ℝ V :=
-        Submodule.finrank_lt_finrank_of_lt (SetLike.lt_iff_le_and_exists.2 ⟨H₂V, v, H₁V, hv'⟩)
+        finrank_lt_finrank_of_lt (SetLike.lt_iff_le_and_exists.2 ⟨H₂V, v, H₁V, hv'⟩)
       have : finrank ℝ V + finrank ℝ Vᗮ = finrank ℝ F := V.finrank_add_finrank_orthogonal
       have : finrank ℝ W + finrank ℝ Wᗮ = finrank ℝ F := W.finrank_add_finrank_orthogonal
       omega
@@ -1186,7 +1201,7 @@ Special case of the **Cartan–Dieudonné theorem**. -/
 theorem LinearIsometryEquiv.reflections_generate_dim [FiniteDimensional ℝ F] (φ : F ≃ₗᵢ[ℝ] F) :
     ∃ l : List F, l.length ≤ finrank ℝ F ∧ φ = (l.map fun v => reflection (ℝ ∙ v)ᗮ).prod :=
   let ⟨l, hl₁, hl₂⟩ := φ.reflections_generate_dim_aux le_rfl
-  ⟨l, hl₁.trans (Submodule.finrank_le _), hl₂⟩
+  ⟨l, hl₁.trans (finrank_le _), hl₂⟩
 
 /-- The orthogonal group of `F` is generated by reflections. -/
 theorem LinearIsometryEquiv.reflections_generate [FiniteDimensional ℝ F] :
@@ -1203,6 +1218,8 @@ end Orthogonal
 
 section OrthogonalFamily
 
+open Submodule
+
 variable {ι : Type*}
 
 /-- An orthogonal family of subspaces of `E` satisfies `DirectSum.IsInternal` (that is,
@@ -1213,7 +1230,7 @@ theorem OrthogonalFamily.isInternal_iff_of_isComplete [DecidableEq ι] {V : ι �
     (hc : IsComplete (↑(iSup V) : Set E)) : DirectSum.IsInternal V ↔ (iSup V)ᗮ = ⊥ := by
   haveI : CompleteSpace (↥(iSup V)) := hc.completeSpace_coe
   simp only [DirectSum.isInternal_submodule_iff_iSupIndep_and_iSup_eq_top, hV.independent,
-    true_and, Submodule.orthogonal_eq_bot_iff]
+    true_and, orthogonal_eq_bot_iff]
 
 /-- An orthogonal family of subspaces of `E` satisfies `DirectSum.IsInternal` (that is,
 they provide an internal direct sum decomposition of `E`) if and only if their span has trivial
@@ -1230,7 +1247,7 @@ open DirectSum
 theorem OrthogonalFamily.sum_projection_of_mem_iSup [Fintype ι] {V : ι → Submodule 𝕜 E}
     [∀ i, CompleteSpace (V i)] (hV : OrthogonalFamily 𝕜 (fun i => V i) fun i => (V i).subtypeₗᵢ)
     (x : E) (hx : x ∈ iSup V) : (∑ i, ((V i).orthogonalProjection x : E)) = x := by
-  induction hx using Submodule.iSup_induction' with
+  induction hx using iSup_induction' with
   | mem i x hx =>
     refine
       (Finset.sum_eq_single_of_mem i (Finset.mem_univ _) fun j _ hij => ?_).trans

--- a/Mathlib/Analysis/InnerProductSpace/Projection.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Projection.lean
@@ -356,38 +356,38 @@ class HasOrthogonalProjection (K : Submodule 𝕜 E) : Prop where
   exists_orthogonal (v : E) : ∃ w ∈ K, v - w ∈ Kᗮ
 
 instance (priority := 100) HasOrthogonalProjection.ofCompleteSpace [CompleteSpace K] :
-    HasOrthogonalProjection K where
+    K.HasOrthogonalProjection where
   exists_orthogonal v := by
     rcases K.exists_norm_eq_iInf_of_complete_subspace (completeSpace_coe_iff_isComplete.mp ‹_›) v
       with ⟨w, hwK, hw⟩
     refine ⟨w, hwK, (K.mem_orthogonal' _).2 ?_⟩
     rwa [← K.norm_eq_iInf_iff_inner_eq_zero hwK]
 
-instance [HasOrthogonalProjection K] : HasOrthogonalProjection Kᗮ where
+instance [K.HasOrthogonalProjection] : Kᗮ.HasOrthogonalProjection where
   exists_orthogonal v := by
     rcases HasOrthogonalProjection.exists_orthogonal (K := K) v with ⟨w, hwK, hw⟩
     refine ⟨_, hw, ?_⟩
     rw [sub_sub_cancel]
     exact K.le_orthogonal_orthogonal hwK
 
-instance HasOrthogonalProjection.map_linearIsometryEquiv [HasOrthogonalProjection K]
+instance HasOrthogonalProjection.map_linearIsometryEquiv [K.HasOrthogonalProjection]
     {E' : Type*} [NormedAddCommGroup E'] [InnerProductSpace 𝕜 E'] (f : E ≃ₗᵢ[𝕜] E') :
-    HasOrthogonalProjection (K.map (f.toLinearEquiv : E →ₗ[𝕜] E')) where
+    (K.map (f.toLinearEquiv : E →ₗ[𝕜] E')).HasOrthogonalProjection where
   exists_orthogonal v := by
     rcases HasOrthogonalProjection.exists_orthogonal (K := K) (f.symm v) with ⟨w, hwK, hw⟩
     refine ⟨f w, Submodule.mem_map_of_mem hwK, Set.forall_mem_image.2 fun u hu ↦ ?_⟩
     erw [← f.symm.inner_map_map, f.symm_apply_apply, map_sub, f.symm_apply_apply, hw u hu]
 
-instance HasOrthogonalProjection.map_linearIsometryEquiv' [HasOrthogonalProjection K]
+instance HasOrthogonalProjection.map_linearIsometryEquiv' [K.HasOrthogonalProjection]
     {E' : Type*} [NormedAddCommGroup E'] [InnerProductSpace 𝕜 E'] (f : E ≃ₗᵢ[𝕜] E') :
-    HasOrthogonalProjection (K.map f.toLinearIsometry) :=
+    (K.map f.toLinearIsometry).HasOrthogonalProjection :=
   HasOrthogonalProjection.map_linearIsometryEquiv K f
 
-instance : HasOrthogonalProjection (⊤ : Submodule 𝕜 E) := ⟨fun v ↦ ⟨v, trivial, by simp⟩⟩
+instance : (⊤ : Submodule 𝕜 E).HasOrthogonalProjection := ⟨fun v ↦ ⟨v, trivial, by simp⟩⟩
 
 section orthogonalProjection
 
-variable [HasOrthogonalProjection K]
+variable [K.HasOrthogonalProjection]
 
 /-- The orthogonal projection onto a complete subspace, as an
 unbundled function.  This definition is only intended for use in
@@ -517,13 +517,13 @@ theorem orthogonalProjection_orthogonal (u : E) :
   Subtype.eq <| orthogonalProjection_orthogonal_val _
 
 /-- The orthogonal projection of `y` on `U` minimizes the distance `‖y - x‖` for `x ∈ U`. -/
-theorem orthogonalProjection_minimal {U : Submodule 𝕜 E} [HasOrthogonalProjection U] (y : E) :
+theorem orthogonalProjection_minimal {U : Submodule 𝕜 E} [U.HasOrthogonalProjection] (y : E) :
     ‖y - U.orthogonalProjection y‖ = ⨅ x : U, ‖y - x‖ := by
   rw [U.norm_eq_iInf_iff_inner_eq_zero (Submodule.coe_mem _)]
   exact orthogonalProjection_inner_eq_zero _
 
 /-- The orthogonal projections onto equal subspaces are coerced back to the same point in `E`. -/
-theorem eq_orthogonalProjection_of_eq_submodule {K' : Submodule 𝕜 E} [HasOrthogonalProjection K']
+theorem eq_orthogonalProjection_of_eq_submodule {K' : Submodule 𝕜 E} [K'.HasOrthogonalProjection]
     (h : K = K') (u : E) : (K.orthogonalProjection u : E) = (K'.orthogonalProjection u : E) := by
   subst h; rfl
 
@@ -553,7 +553,7 @@ theorem ker_orthogonalProjection : LinearMap.ker K.orthogonalProjection = Kᗮ :
 
 theorem _root_.LinearIsometry.map_orthogonalProjection {E E' : Type*} [NormedAddCommGroup E]
     [NormedAddCommGroup E'] [InnerProductSpace 𝕜 E] [InnerProductSpace 𝕜 E'] (f : E →ₗᵢ[𝕜] E')
-    (p : Submodule 𝕜 E) [HasOrthogonalProjection p] [HasOrthogonalProjection (p.map f.toLinearMap)]
+    (p : Submodule 𝕜 E) [p.HasOrthogonalProjection] [(p.map f.toLinearMap).HasOrthogonalProjection]
     (x : E) : f (p.orthogonalProjection x) = (p.map f.toLinearMap).orthogonalProjection (f x) := by
   refine (eq_orthogonalProjection_of_mem_of_inner_eq_zero ?_ fun y hy => ?_).symm
   · refine Submodule.apply_coe_mem_map _ _
@@ -562,15 +562,15 @@ theorem _root_.LinearIsometry.map_orthogonalProjection {E E' : Type*} [NormedAdd
 
 theorem _root_.LinearIsometry.map_orthogonalProjection' {E E' : Type*} [NormedAddCommGroup E]
     [NormedAddCommGroup E'] [InnerProductSpace 𝕜 E] [InnerProductSpace 𝕜 E'] (f : E →ₗᵢ[𝕜] E')
-    (p : Submodule 𝕜 E) [HasOrthogonalProjection p] [HasOrthogonalProjection (p.map f)] (x : E) :
+    (p : Submodule 𝕜 E) [p.HasOrthogonalProjection] [(p.map f).HasOrthogonalProjection] (x : E) :
     f (p.orthogonalProjection x) = (p.map f).orthogonalProjection (f x) :=
-  have : HasOrthogonalProjection (p.map f.toLinearMap) := ‹_›
+  have : (p.map f.toLinearMap).HasOrthogonalProjection := ‹_›
   f.map_orthogonalProjection p x
 
 /-- Orthogonal projection onto the `Submodule.map` of a subspace. -/
 theorem orthogonalProjection_map_apply {E E' : Type*} [NormedAddCommGroup E]
     [NormedAddCommGroup E'] [InnerProductSpace 𝕜 E] [InnerProductSpace 𝕜 E'] (f : E ≃ₗᵢ[𝕜] E')
-    (p : Submodule 𝕜 E) [HasOrthogonalProjection p] (x : E') :
+    (p : Submodule 𝕜 E) [p.HasOrthogonalProjection] (x : E') :
     ((p.map (f.toLinearEquiv : E →ₗ[𝕜] E')).orthogonalProjection x : E') =
       f (p.orthogonalProjection (f.symm x)) := by
   simpa only [f.coe_toLinearIsometry, f.apply_symm_apply] using
@@ -621,7 +621,7 @@ end orthogonalProjection
 
 section reflection
 
-variable [HasOrthogonalProjection K]
+variable [K.HasOrthogonalProjection]
 
 /-- Auxiliary definition for `reflection`: the reflection as a linear equivalence. -/
 def reflectionLinearEquiv : E ≃ₗ[𝕜] E :=
@@ -712,14 +712,14 @@ theorem reflection_mem_subspace_eq_self {x : E} (hx : x ∈ K) : K.reflection x 
 /-- Reflection in the `Submodule.map` of a subspace. -/
 theorem reflection_map_apply {E E' : Type*} [NormedAddCommGroup E] [NormedAddCommGroup E']
     [InnerProductSpace 𝕜 E] [InnerProductSpace 𝕜 E'] (f : E ≃ₗᵢ[𝕜] E') (K : Submodule 𝕜 E)
-    [HasOrthogonalProjection K] (x : E') :
+    [K.HasOrthogonalProjection] (x : E') :
     reflection (K.map (f.toLinearEquiv : E →ₗ[𝕜] E')) x = f (K.reflection (f.symm x)) := by
   simp [two_smul, reflection_apply, orthogonalProjection_map_apply f K x]
 
 /-- Reflection in the `Submodule.map` of a subspace. -/
 theorem reflection_map {E E' : Type*} [NormedAddCommGroup E] [NormedAddCommGroup E']
     [InnerProductSpace 𝕜 E] [InnerProductSpace 𝕜 E'] (f : E ≃ₗᵢ[𝕜] E') (K : Submodule 𝕜 E)
-    [HasOrthogonalProjection K] :
+    [K.HasOrthogonalProjection] :
     reflection (K.map (f.toLinearEquiv : E →ₗ[𝕜] E')) = f.symm.trans (K.reflection.trans f) :=
   LinearIsometryEquiv.ext <| reflection_map_apply f K
 
@@ -738,7 +738,7 @@ namespace Submodule
 
 /-- If `K₁` is complete and contained in `K₂`, `K₁` and `K₁ᗮ ⊓ K₂` span `K₂`. -/
 theorem sup_orthogonal_inf_of_completeSpace {K₁ K₂ : Submodule 𝕜 E} (h : K₁ ≤ K₂)
-    [HasOrthogonalProjection K₁] : K₁ ⊔ K₁ᗮ ⊓ K₂ = K₂ := by
+    [K₁.HasOrthogonalProjection] : K₁ ⊔ K₁ᗮ ⊓ K₂ = K₂ := by
   ext x
   rw [Submodule.mem_sup]
   let v : K₁ := orthogonalProjection K₁ x
@@ -750,12 +750,12 @@ theorem sup_orthogonal_inf_of_completeSpace {K₁ K₂ : Submodule 𝕜 E} (h : 
 
 variable {K} in
 /-- If `K` is complete, `K` and `Kᗮ` span the whole space. -/
-theorem sup_orthogonal_of_completeSpace [HasOrthogonalProjection K] : K ⊔ Kᗮ = ⊤ := by
+theorem sup_orthogonal_of_completeSpace [K.HasOrthogonalProjection] : K ⊔ Kᗮ = ⊤ := by
   convert Submodule.sup_orthogonal_inf_of_completeSpace (le_top : K ≤ ⊤) using 2
   simp
 
 /-- If `K` is complete, any `v` in `E` can be expressed as a sum of elements of `K` and `Kᗮ`. -/
-theorem exists_add_mem_mem_orthogonal [HasOrthogonalProjection K] (v : E) :
+theorem exists_add_mem_mem_orthogonal [K.HasOrthogonalProjection] (v : E) :
     ∃ y ∈ K, ∃ z ∈ Kᗮ, v = y + z :=
   ⟨K.orthogonalProjection v, Subtype.coe_prop _, v - K.orthogonalProjection v,
     sub_orthogonalProjection_mem_orthogonal _, by simp⟩
@@ -763,7 +763,7 @@ theorem exists_add_mem_mem_orthogonal [HasOrthogonalProjection K] (v : E) :
 /-- If `K` admits an orthogonal projection, then the orthogonal complement of its orthogonal
 complement is itself. -/
 @[simp]
-theorem orthogonal_orthogonal [HasOrthogonalProjection K] : Kᗮᗮ = K := by
+theorem orthogonal_orthogonal [K.HasOrthogonalProjection] : Kᗮᗮ = K := by
   ext v
   constructor
   · obtain ⟨y, hy, z, hz, rfl⟩ := K.exists_add_mem_mem_orthogonal v
@@ -792,43 +792,43 @@ theorem orthogonal_orthogonal_eq_closure [CompleteSpace E] :
 variable {K}
 
 /-- If `K` admits an orthogonal projection, `K` and `Kᗮ` are complements of each other. -/
-theorem isCompl_orthogonal_of_completeSpace [HasOrthogonalProjection K] : IsCompl K Kᗮ :=
+theorem isCompl_orthogonal_of_completeSpace [K.HasOrthogonalProjection] : IsCompl K Kᗮ :=
   ⟨K.orthogonal_disjoint, codisjoint_iff.2 Submodule.sup_orthogonal_of_completeSpace⟩
 
 @[simp]
-theorem orthogonalComplement_eq_orthogonalComplement {L : Submodule 𝕜 E} [HasOrthogonalProjection K]
-    [HasOrthogonalProjection L] : Kᗮ = Lᗮ ↔ K = L :=
+theorem orthogonalComplement_eq_orthogonalComplement {L : Submodule 𝕜 E} [K.HasOrthogonalProjection]
+    [L.HasOrthogonalProjection] : Kᗮ = Lᗮ ↔ K = L :=
   ⟨fun h ↦ by simpa using congr(Submodule.orthogonal $(h)),
     fun h ↦ congr(Submodule.orthogonal $(h))⟩
 
 @[simp]
-theorem orthogonal_eq_bot_iff [HasOrthogonalProjection K] : Kᗮ = ⊥ ↔ K = ⊤ := by
+theorem orthogonal_eq_bot_iff [K.HasOrthogonalProjection] : Kᗮ = ⊥ ↔ K = ⊤ := by
   refine ⟨?_, fun h => by rw [h, Submodule.top_orthogonal_eq_bot]⟩
   intro h
   have : K ⊔ Kᗮ = ⊤ := Submodule.sup_orthogonal_of_completeSpace
   rwa [h, sup_comm, bot_sup_eq] at this
 
 /-- The orthogonal projection onto `K` of an element of `Kᗮ` is zero. -/
-theorem orthogonalProjection_mem_subspace_orthogonalComplement_eq_zero [HasOrthogonalProjection K]
+theorem orthogonalProjection_mem_subspace_orthogonalComplement_eq_zero [K.HasOrthogonalProjection]
     {v : E} (hv : v ∈ Kᗮ) : K.orthogonalProjection v = 0 := by
   ext
   convert eq_orthogonalProjection_of_mem_orthogonal (K := K) _ _ <;> simp [hv]
 
 /-- The projection into `U` from an orthogonal submodule `V` is the zero map. -/
 theorem IsOrtho.orthogonalProjection_comp_subtypeL {U V : Submodule 𝕜 E}
-    [HasOrthogonalProjection U] (h : U ⟂ V) : U.orthogonalProjection ∘L V.subtypeL = 0 :=
+    [U.HasOrthogonalProjection] (h : U ⟂ V) : U.orthogonalProjection ∘L V.subtypeL = 0 :=
   ContinuousLinearMap.ext fun v =>
     orthogonalProjection_mem_subspace_orthogonalComplement_eq_zero <| h.symm v.prop
 
 /-- The projection into `U` from `V` is the zero map if and only if `U` and `V` are orthogonal. -/
 theorem orthogonalProjection_comp_subtypeL_eq_zero_iff {U V : Submodule 𝕜 E}
-    [HasOrthogonalProjection U] : U.orthogonalProjection ∘L V.subtypeL = 0 ↔ U ⟂ V :=
+    [U.HasOrthogonalProjection] : U.orthogonalProjection ∘L V.subtypeL = 0 ↔ U ⟂ V :=
   ⟨fun h u hu v hv => by
     convert orthogonalProjection_inner_eq_zero v u hu using 2
     have : U.orthogonalProjection v = 0 := DFunLike.congr_fun h (⟨_, hv⟩ : V)
     rw [this, Submodule.coe_zero, sub_zero], Submodule.IsOrtho.orthogonalProjection_comp_subtypeL⟩
 
-theorem orthogonalProjection_eq_linear_proj [HasOrthogonalProjection K] (x : E) :
+theorem orthogonalProjection_eq_linear_proj [K.HasOrthogonalProjection] (x : E) :
     K.orthogonalProjection x =
       K.linearProjOfIsCompl _ Submodule.isCompl_orthogonal_of_completeSpace x := by
   have : IsCompl K Kᗮ := Submodule.isCompl_orthogonal_of_completeSpace
@@ -836,24 +836,24 @@ theorem orthogonalProjection_eq_linear_proj [HasOrthogonalProjection K] (x : E) 
   rw [map_add, orthogonalProjection_mem_subspace_eq_self,
     orthogonalProjection_mem_subspace_orthogonalComplement_eq_zero (Submodule.coe_mem _), add_zero]
 
-theorem orthogonalProjection_coe_linearMap_eq_linearProj [HasOrthogonalProjection K] :
+theorem orthogonalProjection_coe_linearMap_eq_linearProj [K.HasOrthogonalProjection] :
     (K.orthogonalProjection : E →ₗ[𝕜] K) =
       K.linearProjOfIsCompl _ Submodule.isCompl_orthogonal_of_completeSpace :=
   LinearMap.ext <| orthogonalProjection_eq_linear_proj
 
 /-- The reflection in `K` of an element of `Kᗮ` is its negation. -/
-theorem reflection_mem_subspace_orthogonalComplement_eq_neg [HasOrthogonalProjection K] {v : E}
+theorem reflection_mem_subspace_orthogonalComplement_eq_neg [K.HasOrthogonalProjection] {v : E}
     (hv : v ∈ Kᗮ) : K.reflection v = -v := by
   simp [reflection_apply, orthogonalProjection_mem_subspace_orthogonalComplement_eq_zero hv]
 
 /-- The orthogonal projection onto `Kᗮ` of an element of `K` is zero. -/
 theorem orthogonalProjection_mem_subspace_orthogonal_precomplement_eq_zero
-    [HasOrthogonalProjection Kᗮ] {v : E} (hv : v ∈ K) : Kᗮ.orthogonalProjection v = 0 :=
+    [Kᗮ.HasOrthogonalProjection] {v : E} (hv : v ∈ K) : Kᗮ.orthogonalProjection v = 0 :=
   orthogonalProjection_mem_subspace_orthogonalComplement_eq_zero (K.le_orthogonal_orthogonal hv)
 
 /-- If `U ≤ V`, then projecting on `V` and then on `U` is the same as projecting on `U`. -/
 theorem orthogonalProjection_orthogonalProjection_of_le {U V : Submodule 𝕜 E}
-    [HasOrthogonalProjection U] [HasOrthogonalProjection V] (h : U ≤ V) (x : E) :
+    [U.HasOrthogonalProjection] [V.HasOrthogonalProjection] (h : U ≤ V) (x : E) :
     U.orthogonalProjection (V.orthogonalProjection x) = U.orthogonalProjection x :=
   Eq.symm <| by
     simpa only [sub_eq_zero, map_sub] using
@@ -864,8 +864,8 @@ theorem orthogonalProjection_orthogonalProjection_of_le {U V : Submodule 𝕜 E}
 the orthogonal projection of `x` on `U i` tends to the orthogonal projection of `x` on
 `(⨆ i, U i).topologicalClosure` along `atTop`. -/
 theorem orthogonalProjection_tendsto_closure_iSup {ι : Type*} [Preorder ι]
-    (U : ι → Submodule 𝕜 E) [∀ i, HasOrthogonalProjection (U i)]
-    [HasOrthogonalProjection (⨆ i, U i).topologicalClosure] (hU : Monotone U) (x : E) :
+    (U : ι → Submodule 𝕜 E) [∀ i, (U i).HasOrthogonalProjection]
+    [(⨆ i, U i).topologicalClosure.HasOrthogonalProjection] (hU : Monotone U) (x : E) :
     Filter.Tendsto (fun i => ((U i).orthogonalProjection x : E)) atTop
       (𝓝 ((⨆ i, U i).topologicalClosure.orthogonalProjection x : E)) := by
   refine .of_neBot_imp fun h ↦ ?_
@@ -892,10 +892,10 @@ theorem orthogonalProjection_tendsto_closure_iSup {ι : Type*} [Preorder ι]
 /-- Given a monotone family `U` of complete submodules of `E` with dense span supremum,
 and a fixed `x : E`, the orthogonal projection of `x` on `U i` tends to `x` along `at_top`. -/
 theorem orthogonalProjection_tendsto_self {ι : Type*} [Preorder ι]
-    (U : ι → Submodule 𝕜 E) [∀ t, HasOrthogonalProjection (U t)] (hU : Monotone U) (x : E)
+    (U : ι → Submodule 𝕜 E) [∀ t, (U t).HasOrthogonalProjection] (hU : Monotone U) (x : E)
     (hU' : ⊤ ≤ (⨆ t, U t).topologicalClosure) :
     Filter.Tendsto (fun t => ((U t).orthogonalProjection x : E)) atTop (𝓝 x) := by
-  have : HasOrthogonalProjection (⨆ i, U i).topologicalClosure := by
+  have : (⨆ i, U i).topologicalClosure.HasOrthogonalProjection := by
     rw [top_unique hU']
     infer_instance
   convert orthogonalProjection_tendsto_closure_iSup U hU x
@@ -953,7 +953,7 @@ namespace Submodule
 variable {K}
 
 /-- The reflection in `Kᗮ` of an element of `K` is its negation. -/
-theorem reflection_mem_subspace_orthogonal_precomplement_eq_neg [HasOrthogonalProjection K] {v : E}
+theorem reflection_mem_subspace_orthogonal_precomplement_eq_neg [K.HasOrthogonalProjection] {v : E}
     (hv : v ∈ K) : Kᗮ.reflection v = -v :=
   reflection_mem_subspace_orthogonalComplement_eq_neg (K.le_orthogonal_orthogonal hv)
 
@@ -1016,12 +1016,12 @@ end FiniteDimensional
 
 /-- If the orthogonal projection to `K` is well-defined, then a vector splits as the sum of its
 orthogonal projections onto a complete submodule `K` and onto the orthogonal complement of `K`. -/
-theorem orthogonalProjection_add_orthogonalProjection_orthogonal [HasOrthogonalProjection K]
+theorem orthogonalProjection_add_orthogonalProjection_orthogonal [K.HasOrthogonalProjection]
     (w : E) : (K.orthogonalProjection w : E) + (Kᗮ.orthogonalProjection w : E) = w := by
   simp
 
 /-- The Pythagorean theorem, for an orthogonal projection. -/
-theorem norm_sq_eq_add_norm_sq_projection (x : E) (S : Submodule 𝕜 E) [HasOrthogonalProjection S] :
+theorem norm_sq_eq_add_norm_sq_projection (x : E) (S : Submodule 𝕜 E) [S.HasOrthogonalProjection] :
     ‖x‖ ^ 2 = ‖S.orthogonalProjection x‖ ^ 2 + ‖Sᗮ.orthogonalProjection x‖ ^ 2 :=
   calc
     ‖x‖ ^ 2 = ‖(S.orthogonalProjection x : E) + Sᗮ.orthogonalProjection x‖ ^ 2 := by
@@ -1033,7 +1033,7 @@ theorem norm_sq_eq_add_norm_sq_projection (x : E) (S : Submodule 𝕜 E) [HasOrt
 
 /-- In a complete space `E`, the projection maps onto a complete subspace `K` and its orthogonal
 complement sum to the identity. -/
-theorem id_eq_sum_orthogonalProjection_self_orthogonalComplement [HasOrthogonalProjection K] :
+theorem id_eq_sum_orthogonalProjection_self_orthogonalComplement [K.HasOrthogonalProjection] :
     ContinuousLinearMap.id 𝕜 E =
       K.subtypeL.comp K.orthogonalProjection + Kᗮ.subtypeL.comp (Kᗮ.orthogonalProjection) := by
   ext w
@@ -1041,7 +1041,7 @@ theorem id_eq_sum_orthogonalProjection_self_orthogonalComplement [HasOrthogonalP
 
 -- Porting note: The priority should be higher than `Submodule.coe_inner`.
 @[simp high]
-theorem inner_orthogonalProjection_eq_of_mem_right [HasOrthogonalProjection K] (u : K) (v : E) :
+theorem inner_orthogonalProjection_eq_of_mem_right [K.HasOrthogonalProjection] (u : K) (v : E) :
     ⟪K.orthogonalProjection v, u⟫ = ⟪v, u⟫ :=
   calc
     ⟪K.orthogonalProjection v, u⟫ = ⟪(K.orthogonalProjection v : E), u⟫ := K.coe_inner _ _
@@ -1051,17 +1051,17 @@ theorem inner_orthogonalProjection_eq_of_mem_right [HasOrthogonalProjection K] (
 
 -- Porting note: The priority should be higher than `Submodule.coe_inner`.
 @[simp high]
-theorem inner_orthogonalProjection_eq_of_mem_left [HasOrthogonalProjection K] (u : K) (v : E) :
+theorem inner_orthogonalProjection_eq_of_mem_left [K.HasOrthogonalProjection] (u : K) (v : E) :
     ⟪u, K.orthogonalProjection v⟫ = ⟪(u : E), v⟫ := by
   rw [← inner_conj_symm, ← inner_conj_symm (u : E), inner_orthogonalProjection_eq_of_mem_right]
 
 /-- The orthogonal projection is self-adjoint. -/
-theorem inner_orthogonalProjection_left_eq_right [HasOrthogonalProjection K] (u v : E) :
+theorem inner_orthogonalProjection_left_eq_right [K.HasOrthogonalProjection] (u v : E) :
     ⟪↑(K.orthogonalProjection u), v⟫ = ⟪u, K.orthogonalProjection v⟫ := by
   rw [← inner_orthogonalProjection_eq_of_mem_left, inner_orthogonalProjection_eq_of_mem_right]
 
 /-- The orthogonal projection is symmetric. -/
-theorem orthogonalProjection_isSymmetric [HasOrthogonalProjection K] :
+theorem orthogonalProjection_isSymmetric [K.HasOrthogonalProjection] :
     (K.subtypeL ∘L K.orthogonalProjection : E →ₗ[𝕜] E).IsSymmetric :=
   inner_orthogonalProjection_left_eq_right K
 

--- a/Mathlib/Analysis/InnerProductSpace/Spectrum.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Spectrum.lean
@@ -139,7 +139,7 @@ noncomputable instance directSumDecomposition [hT : Fact T.IsSymmetric] :
 
 theorem directSum_decompose_apply [_hT : Fact T.IsSymmetric] (x : E) (μ : Eigenvalues T) :
     DirectSum.decompose (fun μ : Eigenvalues T => eigenspace T μ) x μ =
-      orthogonalProjection (eigenspace T μ) x :=
+      (eigenspace T μ).orthogonalProjection x :=
   rfl
 
 /-- The eigenspaces of a self-adjoint operator on a finite-dimensional inner product space `E` gives

--- a/Mathlib/Analysis/InnerProductSpace/l2Space.lean
+++ b/Mathlib/Analysis/InnerProductSpace/l2Space.lean
@@ -487,9 +487,9 @@ theorem coe_toOrthonormalBasis [Fintype ι] (b : HilbertBasis ι 𝕜 E) :
 
 protected theorem hasSum_orthogonalProjection {U : Submodule 𝕜 E} [CompleteSpace U]
     (b : HilbertBasis ι 𝕜 U) (x : E) :
-    HasSum (fun i => ⟪(b i : E), x⟫ • b i) (orthogonalProjection U x) := by
+    HasSum (fun i => ⟪(b i : E), x⟫ • b i) (U.orthogonalProjection x) := by
   simpa only [b.repr_apply_apply, inner_orthogonalProjection_eq_of_mem_left] using
-    b.hasSum_repr (orthogonalProjection U x)
+    b.hasSum_repr (U.orthogonalProjection x)
 
 theorem finite_spans_dense [DecidableEq E] (b : HilbertBasis ι 𝕜 E) :
     (⨆ J : Finset ι, span 𝕜 (J.image b : Set E)).topologicalClosure = ⊤ :=

--- a/Mathlib/Geometry/Euclidean/Basic.lean
+++ b/Mathlib/Geometry/Euclidean/Basic.lean
@@ -291,7 +291,7 @@ theorem orthogonalProjectionFn_eq {s : AffineSubspace ℝ P} [Nonempty s]
 @[simp]
 theorem orthogonalProjection_linear {s : AffineSubspace ℝ P} [Nonempty s]
     [HasOrthogonalProjection s.direction] :
-    (orthogonalProjection s).linear = _root_.orthogonalProjection s.direction :=
+    (orthogonalProjection s).linear = s.direction.orthogonalProjection :=
   rfl
 
 /-- The intersection of the subspace and the orthogonal subspace
@@ -398,7 +398,7 @@ theorem vsub_orthogonalProjection_mem_direction_orthogonal (s : AffineSubspace �
 part of the orthogonal projection. -/
 theorem orthogonalProjection_vsub_orthogonalProjection (s : AffineSubspace ℝ P) [Nonempty s]
     [HasOrthogonalProjection s.direction] (p : P) :
-    _root_.orthogonalProjection s.direction (p -ᵥ orthogonalProjection s p) = 0 := by
+    s.direction.orthogonalProjection (p -ᵥ orthogonalProjection s p) = 0 := by
   apply orthogonalProjection_mem_subspace_orthogonalComplement_eq_zero
   intro c hc
   rw [← neg_vsub_eq_vsub_rev, inner_neg_right,
@@ -505,7 +505,7 @@ def reflection (s : AffineSubspace ℝ P) [Nonempty s] [HasOrthogonalProjection 
     (by
       intro p
       let v := p -ᵥ ↑(Classical.arbitrary s)
-      let a : V := _root_.orthogonalProjection s.direction v
+      let a : V := s.direction.orthogonalProjection v
       let b : P := ↑(Classical.arbitrary s)
       have key : ((a +ᵥ b) -ᵥ (v +ᵥ b)) +ᵥ (a +ᵥ b) = (a + a - v) +ᵥ (b -ᵥ b) +ᵥ b := by
         rw [← add_vadd, vsub_vadd_eq_vsub_sub, vsub_vadd, vadd_vsub]
@@ -531,7 +531,7 @@ theorem eq_reflection_of_eq_subspace {s s' : AffineSubspace ℝ P} [Nonempty s] 
 @[simp]
 theorem reflection_reflection (s : AffineSubspace ℝ P) [Nonempty s]
     [HasOrthogonalProjection s.direction] (p : P) : reflection s (reflection s p) = p := by
-  have : ∀ a : s, ∀ b : V, (_root_.orthogonalProjection s.direction) b = 0 →
+  have : ∀ a : s, ∀ b : V, (s.direction.orthogonalProjection) b = 0 →
       reflection s (reflection s (b +ᵥ (a : P))) = b +ᵥ (a : P) := by
     intro _ _ h
     simp [reflection, h]

--- a/Mathlib/Geometry/Euclidean/Basic.lean
+++ b/Mathlib/Geometry/Euclidean/Basic.lean
@@ -260,11 +260,11 @@ nonrec def orthogonalProjection (s : AffineSubspace ℝ P) [Nonempty s]
   toFun p := ⟨orthogonalProjectionFn s p, orthogonalProjectionFn_mem p⟩
   linear := s.direction.orthogonalProjection
   map_vadd' p v := by
-    have hs : ((s.direction.orthogonalProjection) v : V) +ᵥ orthogonalProjectionFn s p ∈ s :=
+    have hs : (s.direction.orthogonalProjection v : V) +ᵥ orthogonalProjectionFn s p ∈ s :=
       vadd_mem_of_mem_direction (s.direction.orthogonalProjection v).2
         (orthogonalProjectionFn_mem p)
     have ho :
-      ((s.direction.orthogonalProjection) v : V) +ᵥ orthogonalProjectionFn s p ∈
+      (s.direction.orthogonalProjection v : V) +ᵥ orthogonalProjectionFn s p ∈
         mk' (v +ᵥ p) s.directionᗮ := by
       rw [← vsub_right_mem_direction_iff_mem (self_mem_mk' _ _) _, direction_mk',
         vsub_vadd_eq_vsub_sub, vadd_vsub_assoc, add_comm, add_sub_assoc]
@@ -273,7 +273,7 @@ nonrec def orthogonalProjection (s : AffineSubspace ℝ P) [Nonempty s]
       intro w hw
       rw [← neg_sub, inner_neg_left, Submodule.orthogonalProjection_inner_eq_zero _ w hw, neg_zero]
     have hm :
-      ((s.direction.orthogonalProjection) v : V) +ᵥ orthogonalProjectionFn s p ∈
+      (s.direction.orthogonalProjection v : V) +ᵥ orthogonalProjectionFn s p ∈
         ({orthogonalProjectionFn s (v +ᵥ p)} : Set P) := by
       rw [← inter_eq_singleton_orthogonalProjectionFn (v +ᵥ p)]
       exact Set.mem_inter hs ho
@@ -532,7 +532,7 @@ theorem eq_reflection_of_eq_subspace {s s' : AffineSubspace ℝ P} [Nonempty s] 
 @[simp]
 theorem reflection_reflection (s : AffineSubspace ℝ P) [Nonempty s]
     [s.direction.HasOrthogonalProjection] (p : P) : reflection s (reflection s p) = p := by
-  have : ∀ a : s, ∀ b : V, (s.direction.orthogonalProjection) b = 0 →
+  have : ∀ a : s, ∀ b : V, s.direction.orthogonalProjection b = 0 →
       reflection s (reflection s (b +ᵥ (a : P))) = b +ᵥ (a : P) := by
     intro _ _ h
     simp [reflection, h]

--- a/Mathlib/Geometry/Euclidean/Basic.lean
+++ b/Mathlib/Geometry/Euclidean/Basic.lean
@@ -258,13 +258,13 @@ subspace being projected onto. -/
 nonrec def orthogonalProjection (s : AffineSubspace ℝ P) [Nonempty s]
     [HasOrthogonalProjection s.direction] : P →ᵃ[ℝ] s where
   toFun p := ⟨orthogonalProjectionFn s p, orthogonalProjectionFn_mem p⟩
-  linear := orthogonalProjection s.direction
+  linear := s.direction.orthogonalProjection
   map_vadd' p v := by
-    have hs : ((orthogonalProjection s.direction) v : V) +ᵥ orthogonalProjectionFn s p ∈ s :=
-      vadd_mem_of_mem_direction (orthogonalProjection s.direction v).2
+    have hs : ((s.direction.orthogonalProjection) v : V) +ᵥ orthogonalProjectionFn s p ∈ s :=
+      vadd_mem_of_mem_direction (s.direction.orthogonalProjection v).2
         (orthogonalProjectionFn_mem p)
     have ho :
-      ((orthogonalProjection s.direction) v : V) +ᵥ orthogonalProjectionFn s p ∈
+      ((s.direction.orthogonalProjection) v : V) +ᵥ orthogonalProjectionFn s p ∈
         mk' (v +ᵥ p) s.directionᗮ := by
       rw [← vsub_right_mem_direction_iff_mem (self_mem_mk' _ _) _, direction_mk',
         vsub_vadd_eq_vsub_sub, vadd_vsub_assoc, add_comm, add_sub_assoc]
@@ -273,7 +273,7 @@ nonrec def orthogonalProjection (s : AffineSubspace ℝ P) [Nonempty s]
       intro w hw
       rw [← neg_sub, inner_neg_left, orthogonalProjection_inner_eq_zero _ w hw, neg_zero]
     have hm :
-      ((orthogonalProjection s.direction) v : V) +ᵥ orthogonalProjectionFn s p ∈
+      ((s.direction.orthogonalProjection) v : V) +ᵥ orthogonalProjectionFn s p ∈
         ({orthogonalProjectionFn s (v +ᵥ p)} : Set P) := by
       rw [← inter_eq_singleton_orthogonalProjectionFn (v +ᵥ p)]
       exact Set.mem_inter hs ho

--- a/Mathlib/Geometry/Euclidean/Basic.lean
+++ b/Mathlib/Geometry/Euclidean/Basic.lean
@@ -197,7 +197,7 @@ definition is only intended for use in setting up the bundled version
 `orthogonalProjection` and should not be used once that is
 defined. -/
 def orthogonalProjectionFn (s : AffineSubspace ℝ P) [Nonempty s]
-    [HasOrthogonalProjection s.direction] (p : P) : P :=
+    [s.direction.HasOrthogonalProjection] (p : P) : P :=
   Classical.choose <|
     inter_eq_singleton_of_nonempty_of_isCompl (nonempty_subtype.mp ‹_›)
       (mk'_nonempty p s.directionᗮ)
@@ -211,7 +211,7 @@ point onto the subspace. This lemma is only intended for use in
 setting up the bundled version and should not be used once that is
 defined. -/
 theorem inter_eq_singleton_orthogonalProjectionFn {s : AffineSubspace ℝ P} [Nonempty s]
-    [HasOrthogonalProjection s.direction] (p : P) :
+    [s.direction.HasOrthogonalProjection] (p : P) :
     (s : Set P) ∩ mk' p s.directionᗮ = {orthogonalProjectionFn s p} :=
   Classical.choose_spec <|
     inter_eq_singleton_of_nonempty_of_isCompl (nonempty_subtype.mp ‹_›)
@@ -224,7 +224,7 @@ theorem inter_eq_singleton_orthogonalProjectionFn {s : AffineSubspace ℝ P} [No
 lemma is only intended for use in setting up the bundled version and
 should not be used once that is defined. -/
 theorem orthogonalProjectionFn_mem {s : AffineSubspace ℝ P} [Nonempty s]
-    [HasOrthogonalProjection s.direction] (p : P) : orthogonalProjectionFn s p ∈ s := by
+    [s.direction.HasOrthogonalProjection] (p : P) : orthogonalProjectionFn s p ∈ s := by
   rw [← mem_coe, ← Set.singleton_subset_iff, ← inter_eq_singleton_orthogonalProjectionFn]
   exact Set.inter_subset_left
 
@@ -232,7 +232,7 @@ theorem orthogonalProjectionFn_mem {s : AffineSubspace ℝ P} [Nonempty s]
 subspace. This lemma is only intended for use in setting up the
 bundled version and should not be used once that is defined. -/
 theorem orthogonalProjectionFn_mem_orthogonal {s : AffineSubspace ℝ P} [Nonempty s]
-    [HasOrthogonalProjection s.direction] (p : P) :
+    [s.direction.HasOrthogonalProjection] (p : P) :
     orthogonalProjectionFn s p ∈ mk' p s.directionᗮ := by
   rw [← mem_coe, ← Set.singleton_subset_iff, ← inter_eq_singleton_orthogonalProjectionFn]
   exact Set.inter_subset_right
@@ -242,7 +242,7 @@ result in the orthogonal direction. This lemma is only intended for
 use in setting up the bundled version and should not be used once that
 is defined. -/
 theorem orthogonalProjectionFn_vsub_mem_direction_orthogonal {s : AffineSubspace ℝ P} [Nonempty s]
-    [HasOrthogonalProjection s.direction] (p : P) :
+    [s.direction.HasOrthogonalProjection] (p : P) :
     orthogonalProjectionFn s p -ᵥ p ∈ s.directionᗮ :=
   direction_mk' p s.directionᗮ ▸
     vsub_mem_direction (orthogonalProjectionFn_mem_orthogonal p) (self_mem_mk' _ _)
@@ -256,7 +256,7 @@ points whose difference is that vector) is the `orthogonalProjection`
 for real inner product spaces, onto the direction of the affine
 subspace being projected onto. -/
 nonrec def orthogonalProjection (s : AffineSubspace ℝ P) [Nonempty s]
-    [HasOrthogonalProjection s.direction] : P →ᵃ[ℝ] s where
+    [s.direction.HasOrthogonalProjection] : P →ᵃ[ℝ] s where
   toFun p := ⟨orthogonalProjectionFn s p, orthogonalProjectionFn_mem p⟩
   linear := s.direction.orthogonalProjection
   map_vadd' p v := by
@@ -271,7 +271,7 @@ nonrec def orthogonalProjection (s : AffineSubspace ℝ P) [Nonempty s]
       refine Submodule.add_mem _ (orthogonalProjectionFn_vsub_mem_direction_orthogonal p) ?_
       rw [Submodule.mem_orthogonal']
       intro w hw
-      rw [← neg_sub, inner_neg_left, orthogonalProjection_inner_eq_zero _ w hw, neg_zero]
+      rw [← neg_sub, inner_neg_left, Submodule.orthogonalProjection_inner_eq_zero _ w hw, neg_zero]
     have hm :
       ((s.direction.orthogonalProjection) v : V) +ᵥ orthogonalProjectionFn s p ∈
         ({orthogonalProjectionFn s (v +ᵥ p)} : Set P) := by
@@ -283,14 +283,14 @@ nonrec def orthogonalProjection (s : AffineSubspace ℝ P) [Nonempty s]
 
 @[simp]
 theorem orthogonalProjectionFn_eq {s : AffineSubspace ℝ P} [Nonempty s]
-    [HasOrthogonalProjection s.direction] (p : P) :
+    [s.direction.HasOrthogonalProjection] (p : P) :
     orthogonalProjectionFn s p = orthogonalProjection s p :=
   rfl
 
 /-- The linear map corresponding to `orthogonalProjection`. -/
 @[simp]
 theorem orthogonalProjection_linear {s : AffineSubspace ℝ P} [Nonempty s]
-    [HasOrthogonalProjection s.direction] :
+    [s.direction.HasOrthogonalProjection] :
     (orthogonalProjection s).linear = s.direction.orthogonalProjection :=
   rfl
 
@@ -298,19 +298,19 @@ theorem orthogonalProjection_linear {s : AffineSubspace ℝ P} [Nonempty s]
 through the given point is the `orthogonalProjection` of that point
 onto the subspace. -/
 theorem inter_eq_singleton_orthogonalProjection {s : AffineSubspace ℝ P} [Nonempty s]
-    [HasOrthogonalProjection s.direction] (p : P) :
+    [s.direction.HasOrthogonalProjection] (p : P) :
     (s : Set P) ∩ mk' p s.directionᗮ = {↑(orthogonalProjection s p)} := by
   rw [← orthogonalProjectionFn_eq]
   exact inter_eq_singleton_orthogonalProjectionFn p
 
 /-- The `orthogonalProjection` lies in the given subspace. -/
 theorem orthogonalProjection_mem {s : AffineSubspace ℝ P} [Nonempty s]
-    [HasOrthogonalProjection s.direction] (p : P) : ↑(orthogonalProjection s p) ∈ s :=
+    [s.direction.HasOrthogonalProjection] (p : P) : ↑(orthogonalProjection s p) ∈ s :=
   (orthogonalProjection s p).2
 
 /-- The `orthogonalProjection` lies in the orthogonal subspace. -/
 theorem orthogonalProjection_mem_orthogonal (s : AffineSubspace ℝ P) [Nonempty s]
-    [HasOrthogonalProjection s.direction] (p : P) :
+    [s.direction.HasOrthogonalProjection] (p : P) :
     ↑(orthogonalProjection s p) ∈ mk' p s.directionᗮ :=
   orthogonalProjectionFn_mem_orthogonal p
 
@@ -318,21 +318,21 @@ theorem orthogonalProjection_mem_orthogonal (s : AffineSubspace ℝ P) [Nonempty
 `orthogonalProjection` produces a result in the direction of the
 given subspace. -/
 theorem orthogonalProjection_vsub_mem_direction {s : AffineSubspace ℝ P} [Nonempty s]
-    [HasOrthogonalProjection s.direction] {p₁ : P} (p₂ : P) (hp₁ : p₁ ∈ s) :
+    [s.direction.HasOrthogonalProjection] {p₁ : P} (p₂ : P) (hp₁ : p₁ ∈ s) :
     ↑(orthogonalProjection s p₂ -ᵥ ⟨p₁, hp₁⟩ : s.direction) ∈ s.direction :=
   (orthogonalProjection s p₂ -ᵥ ⟨p₁, hp₁⟩ : s.direction).2
 
 /-- Subtracting the `orthogonalProjection` from a point in the given
 subspace produces a result in the direction of the given subspace. -/
 theorem vsub_orthogonalProjection_mem_direction {s : AffineSubspace ℝ P} [Nonempty s]
-    [HasOrthogonalProjection s.direction] {p₁ : P} (p₂ : P) (hp₁ : p₁ ∈ s) :
+    [s.direction.HasOrthogonalProjection] {p₁ : P} (p₂ : P) (hp₁ : p₁ ∈ s) :
     ↑((⟨p₁, hp₁⟩ : s) -ᵥ orthogonalProjection s p₂ : s.direction) ∈ s.direction :=
   ((⟨p₁, hp₁⟩ : s) -ᵥ orthogonalProjection s p₂ : s.direction).2
 
 /-- A point equals its orthogonal projection if and only if it lies in
 the subspace. -/
 theorem orthogonalProjection_eq_self_iff {s : AffineSubspace ℝ P} [Nonempty s]
-    [HasOrthogonalProjection s.direction] {p : P} : ↑(orthogonalProjection s p) = p ↔ p ∈ s := by
+    [s.direction.HasOrthogonalProjection] {p : P} : ↑(orthogonalProjection s p) = p ↔ p ∈ s := by
   constructor
   · exact fun h => h ▸ orthogonalProjection_mem p
   · intro h
@@ -343,21 +343,21 @@ theorem orthogonalProjection_eq_self_iff {s : AffineSubspace ℝ P} [Nonempty s]
 
 @[simp]
 theorem orthogonalProjection_mem_subspace_eq_self {s : AffineSubspace ℝ P} [Nonempty s]
-    [HasOrthogonalProjection s.direction] (p : s) : orthogonalProjection s p = p := by
+    [s.direction.HasOrthogonalProjection] (p : s) : orthogonalProjection s p = p := by
   ext
   rw [orthogonalProjection_eq_self_iff]
   exact p.2
 
 /-- Orthogonal projection is idempotent. -/
 theorem orthogonalProjection_orthogonalProjection (s : AffineSubspace ℝ P) [Nonempty s]
-    [HasOrthogonalProjection s.direction] (p : P) :
+    [s.direction.HasOrthogonalProjection] (p : P) :
     orthogonalProjection s (orthogonalProjection s p) = orthogonalProjection s p := by
   ext
   rw [orthogonalProjection_eq_self_iff]
   exact orthogonalProjection_mem p
 
 theorem eq_orthogonalProjection_of_eq_subspace {s s' : AffineSubspace ℝ P} [Nonempty s]
-    [Nonempty s'] [HasOrthogonalProjection s.direction] [HasOrthogonalProjection s'.direction]
+    [Nonempty s'] [s.direction.HasOrthogonalProjection] [s'.direction.HasOrthogonalProjection]
     (h : s = s') (p : P) : (orthogonalProjection s p : P) = (orthogonalProjection s' p : P) := by
   subst h
   rfl
@@ -369,37 +369,37 @@ theorem eq_orthogonalProjection_of_eq_subspace {s s' : AffineSubspace ℝ P} [No
 
 /-- The distance to a point's orthogonal projection is 0 iff it lies in the subspace. -/
 theorem dist_orthogonalProjection_eq_zero_iff {s : AffineSubspace ℝ P} [Nonempty s]
-    [HasOrthogonalProjection s.direction] {p : P} :
+    [s.direction.HasOrthogonalProjection] {p : P} :
     dist p (orthogonalProjection s p) = 0 ↔ p ∈ s := by
   rw [dist_comm, dist_eq_zero, orthogonalProjection_eq_self_iff]
 
 /-- The distance between a point and its orthogonal projection is
 nonzero if it does not lie in the subspace. -/
 theorem dist_orthogonalProjection_ne_zero_of_not_mem {s : AffineSubspace ℝ P} [Nonempty s]
-    [HasOrthogonalProjection s.direction] {p : P} (hp : p ∉ s) :
+    [s.direction.HasOrthogonalProjection] {p : P} (hp : p ∉ s) :
     dist p (orthogonalProjection s p) ≠ 0 :=
   mt dist_orthogonalProjection_eq_zero_iff.mp hp
 
 /-- Subtracting `p` from its `orthogonalProjection` produces a result
 in the orthogonal direction. -/
 theorem orthogonalProjection_vsub_mem_direction_orthogonal (s : AffineSubspace ℝ P) [Nonempty s]
-    [HasOrthogonalProjection s.direction] (p : P) :
+    [s.direction.HasOrthogonalProjection] (p : P) :
     (orthogonalProjection s p : P) -ᵥ p ∈ s.directionᗮ :=
   orthogonalProjectionFn_vsub_mem_direction_orthogonal p
 
 /-- Subtracting the `orthogonalProjection` from `p` produces a result
 in the orthogonal direction. -/
 theorem vsub_orthogonalProjection_mem_direction_orthogonal (s : AffineSubspace ℝ P) [Nonempty s]
-    [HasOrthogonalProjection s.direction] (p : P) : p -ᵥ orthogonalProjection s p ∈ s.directionᗮ :=
+    [s.direction.HasOrthogonalProjection] (p : P) : p -ᵥ orthogonalProjection s p ∈ s.directionᗮ :=
   direction_mk' p s.directionᗮ ▸
     vsub_mem_direction (self_mem_mk' _ _) (orthogonalProjection_mem_orthogonal s p)
 
 /-- Subtracting the `orthogonalProjection` from `p` produces a result in the kernel of the linear
 part of the orthogonal projection. -/
 theorem orthogonalProjection_vsub_orthogonalProjection (s : AffineSubspace ℝ P) [Nonempty s]
-    [HasOrthogonalProjection s.direction] (p : P) :
+    [s.direction.HasOrthogonalProjection] (p : P) :
     s.direction.orthogonalProjection (p -ᵥ orthogonalProjection s p) = 0 := by
-  apply orthogonalProjection_mem_subspace_orthogonalComplement_eq_zero
+  apply Submodule.orthogonalProjection_mem_subspace_orthogonalComplement_eq_zero
   intro c hc
   rw [← neg_vsub_eq_vsub_rev, inner_neg_right,
     orthogonalProjection_vsub_mem_direction_orthogonal s p c hc, neg_zero]
@@ -408,7 +408,7 @@ theorem orthogonalProjection_vsub_orthogonalProjection (s : AffineSubspace ℝ P
 orthogonal projection, produces the original point if the vector was
 in the orthogonal direction. -/
 theorem orthogonalProjection_vadd_eq_self {s : AffineSubspace ℝ P} [Nonempty s]
-    [HasOrthogonalProjection s.direction] {p : P} (hp : p ∈ s) {v : V} (hv : v ∈ s.directionᗮ) :
+    [s.direction.HasOrthogonalProjection] {p : P} (hp : p ∈ s) {v : V} (hv : v ∈ s.directionᗮ) :
     orthogonalProjection s (v +ᵥ p) = ⟨p, hp⟩ := by
   have h := vsub_orthogonalProjection_mem_direction_orthogonal s (v +ᵥ p)
   rw [vadd_vsub_assoc, Submodule.add_mem_iff_right _ hv] at h
@@ -422,7 +422,7 @@ orthogonal projection, produces the original point if the vector is a
 multiple of the result of subtracting a point's orthogonal projection
 from that point. -/
 theorem orthogonalProjection_vadd_smul_vsub_orthogonalProjection {s : AffineSubspace ℝ P}
-    [Nonempty s] [HasOrthogonalProjection s.direction] {p₁ : P} (p₂ : P) (r : ℝ) (hp : p₁ ∈ s) :
+    [Nonempty s] [s.direction.HasOrthogonalProjection] {p₁ : P} (p₂ : P) (r : ℝ) (hp : p₁ ∈ s) :
     orthogonalProjection s (r • (p₂ -ᵥ orthogonalProjection s p₂ : V) +ᵥ p₁) = ⟨p₁, hp⟩ :=
   orthogonalProjection_vadd_eq_self hp
     (Submodule.smul_mem _ _ (vsub_orthogonalProjection_mem_direction_orthogonal s _))
@@ -431,7 +431,7 @@ theorem orthogonalProjection_vadd_smul_vsub_orthogonalProjection {s : AffineSubs
 sum of the squares of the distances of the two points to the
 `orthogonalProjection`. -/
 theorem dist_sq_eq_dist_orthogonalProjection_sq_add_dist_orthogonalProjection_sq
-    {s : AffineSubspace ℝ P} [Nonempty s] [HasOrthogonalProjection s.direction] {p₁ : P} (p₂ : P)
+    {s : AffineSubspace ℝ P} [Nonempty s] [s.direction.HasOrthogonalProjection] {p₁ : P} (p₂ : P)
     (hp₁ : p₁ ∈ s) :
     dist p₁ p₂ * dist p₁ p₂ =
       dist p₁ (orthogonalProjection s p₂) * dist p₁ (orthogonalProjection s p₂) +
@@ -448,7 +448,7 @@ depends on the context (if any calculations are to be done with the distance, th
 the orthogonal projection gives access to more lemmas about orthogonal projections that may be
 useful). -/
 lemma dist_orthogonalProjection_eq_infDist (s : AffineSubspace ℝ P) [Nonempty s]
-    [HasOrthogonalProjection s.direction] (p : P) :
+    [s.direction.HasOrthogonalProjection] (p : P) :
     dist p (orthogonalProjection s p) = Metric.infDist p s := by
   refine le_antisymm ?_ (Metric.infDist_le_dist_of_mem (orthogonalProjection_mem _))
   rw [Metric.infDist_eq_iInf]
@@ -464,7 +464,7 @@ the simplest form depends on the context (if any calculations are to be done wit
 the version with the orthogonal projection gives access to more lemmas about orthogonal
 projections that may be useful). -/
 lemma dist_orthogonalProjection_eq_infNndist (s : AffineSubspace ℝ P) [Nonempty s]
-    [HasOrthogonalProjection s.direction] (p : P) :
+    [s.direction.HasOrthogonalProjection] (p : P) :
     nndist p (orthogonalProjection s p) = Metric.infNndist p s := by
   rw [← NNReal.coe_inj]
   simp [dist_orthogonalProjection_eq_infDist]
@@ -497,11 +497,11 @@ specifically reflection in a codimension-one subspace, and sometimes
 more generally to cover operations such as reflection in a point. The
 definition here, of reflection in an affine subspace, is a more
 general sense of the word that includes both those common cases. -/
-def reflection (s : AffineSubspace ℝ P) [Nonempty s] [HasOrthogonalProjection s.direction] :
+def reflection (s : AffineSubspace ℝ P) [Nonempty s] [s.direction.HasOrthogonalProjection] :
     P ≃ᵃⁱ[ℝ] P :=
   AffineIsometryEquiv.mk'
     (fun p => (↑(orthogonalProjection s p) -ᵥ p) +ᵥ (orthogonalProjection s p : P))
-    (_root_.reflection s.direction) (↑(Classical.arbitrary s))
+    s.direction.reflection (↑(Classical.arbitrary s))
     (by
       intro p
       let v := p -ᵥ ↑(Classical.arbitrary s)
@@ -512,17 +512,18 @@ def reflection (s : AffineSubspace ℝ P) [Nonempty s] [HasOrthogonalProjection 
         congr 1
         abel
       dsimp only
-      rwa [reflection_apply, (vsub_vadd p b).symm, AffineMap.map_vadd, orthogonalProjection_linear,
-        vadd_vsub, orthogonalProjection_mem_subspace_eq_self, two_smul])
+      rwa [Submodule.reflection_apply, (vsub_vadd p b).symm, AffineMap.map_vadd,
+        orthogonalProjection_linear, vadd_vsub, orthogonalProjection_mem_subspace_eq_self,
+        two_smul])
 
 /-- The result of reflecting. -/
-theorem reflection_apply (s : AffineSubspace ℝ P) [Nonempty s] [HasOrthogonalProjection s.direction]
+theorem reflection_apply (s : AffineSubspace ℝ P) [Nonempty s] [s.direction.HasOrthogonalProjection]
     (p : P) :
     reflection s p = (↑(orthogonalProjection s p) -ᵥ p) +ᵥ (orthogonalProjection s p : P) :=
   rfl
 
 theorem eq_reflection_of_eq_subspace {s s' : AffineSubspace ℝ P} [Nonempty s] [Nonempty s']
-    [HasOrthogonalProjection s.direction] [HasOrthogonalProjection s'.direction] (h : s = s')
+    [s.direction.HasOrthogonalProjection] [s'.direction.HasOrthogonalProjection] (h : s = s')
     (p : P) : (reflection s p : P) = (reflection s' p : P) := by
   subst h
   rfl
@@ -530,7 +531,7 @@ theorem eq_reflection_of_eq_subspace {s s' : AffineSubspace ℝ P} [Nonempty s] 
 /-- Reflecting twice in the same subspace. -/
 @[simp]
 theorem reflection_reflection (s : AffineSubspace ℝ P) [Nonempty s]
-    [HasOrthogonalProjection s.direction] (p : P) : reflection s (reflection s p) = p := by
+    [s.direction.HasOrthogonalProjection] (p : P) : reflection s (reflection s p) = p := by
   have : ∀ a : s, ∀ b : V, (s.direction.orthogonalProjection) b = 0 →
       reflection s (reflection s (b +ᵥ (a : P))) = b +ᵥ (a : P) := by
     intro _ _ h
@@ -541,19 +542,19 @@ theorem reflection_reflection (s : AffineSubspace ℝ P) [Nonempty s]
 /-- Reflection is its own inverse. -/
 @[simp]
 theorem reflection_symm (s : AffineSubspace ℝ P) [Nonempty s]
-    [HasOrthogonalProjection s.direction] : (reflection s).symm = reflection s := by
+    [s.direction.HasOrthogonalProjection] : (reflection s).symm = reflection s := by
   ext
   rw [← (reflection s).injective.eq_iff]
   simp
 
 /-- Reflection is involutive. -/
 theorem reflection_involutive (s : AffineSubspace ℝ P) [Nonempty s]
-    [HasOrthogonalProjection s.direction] : Function.Involutive (reflection s) :=
+    [s.direction.HasOrthogonalProjection] : Function.Involutive (reflection s) :=
   reflection_reflection s
 
 /-- A point is its own reflection if and only if it is in the subspace. -/
 theorem reflection_eq_self_iff {s : AffineSubspace ℝ P} [Nonempty s]
-    [HasOrthogonalProjection s.direction] (p : P) : reflection s p = p ↔ p ∈ s := by
+    [s.direction.HasOrthogonalProjection] (p : P) : reflection s p = p ↔ p ∈ s := by
   rw [← orthogonalProjection_eq_self_iff, reflection_apply]
   constructor
   · intro h
@@ -568,7 +569,7 @@ theorem reflection_eq_self_iff {s : AffineSubspace ℝ P} [Nonempty s]
 and only if the point has the same orthogonal projection in each of
 those subspaces. -/
 theorem reflection_eq_iff_orthogonalProjection_eq (s₁ s₂ : AffineSubspace ℝ P) [Nonempty s₁]
-    [Nonempty s₂] [HasOrthogonalProjection s₁.direction] [HasOrthogonalProjection s₂.direction]
+    [Nonempty s₂] [s₁.direction.HasOrthogonalProjection] [s₂.direction.HasOrthogonalProjection]
     (p : P) :
     reflection s₁ p = reflection s₂ p ↔
       (orthogonalProjection s₁ p : P) = orthogonalProjection s₂ p := by
@@ -585,7 +586,7 @@ theorem reflection_eq_iff_orthogonalProjection_eq (s₁ s₂ : AffineSubspace �
 
 /-- The distance between `p₁` and the reflection of `p₂` equals that
 between the reflection of `p₁` and `p₂`. -/
-theorem dist_reflection (s : AffineSubspace ℝ P) [Nonempty s] [HasOrthogonalProjection s.direction]
+theorem dist_reflection (s : AffineSubspace ℝ P) [Nonempty s] [s.direction.HasOrthogonalProjection]
     (p₁ p₂ : P) : dist p₁ (reflection s p₂) = dist (reflection s p₁) p₂ := by
   conv_lhs => rw [← reflection_reflection s p₁]
   exact (reflection s).dist_map _ _
@@ -593,7 +594,7 @@ theorem dist_reflection (s : AffineSubspace ℝ P) [Nonempty s] [HasOrthogonalPr
 /-- A point in the subspace is equidistant from another point and its
 reflection. -/
 theorem dist_reflection_eq_of_mem (s : AffineSubspace ℝ P) [Nonempty s]
-    [HasOrthogonalProjection s.direction] {p₁ : P} (hp₁ : p₁ ∈ s) (p₂ : P) :
+    [s.direction.HasOrthogonalProjection] {p₁ : P} (hp₁ : p₁ ∈ s) (p₂ : P) :
     dist p₁ (reflection s p₂) = dist p₁ p₂ := by
   rw [← reflection_eq_self_iff p₁] at hp₁
   convert (reflection s).dist_map p₁ p₂
@@ -602,7 +603,7 @@ theorem dist_reflection_eq_of_mem (s : AffineSubspace ℝ P) [Nonempty s]
 /-- The reflection of a point in a subspace is contained in any larger
 subspace containing both the point and the subspace reflected in. -/
 theorem reflection_mem_of_le_of_mem {s₁ s₂ : AffineSubspace ℝ P} [Nonempty s₁]
-    [HasOrthogonalProjection s₁.direction] (hle : s₁ ≤ s₂) {p : P} (hp : p ∈ s₂) :
+    [s₁.direction.HasOrthogonalProjection] (hle : s₁ ≤ s₂) {p : P} (hp : p ∈ s₂) :
     reflection s₁ p ∈ s₂ := by
   rw [reflection_apply]
   have ho : ↑(orthogonalProjection s₁ p) ∈ s₂ := hle (orthogonalProjection_mem p)
@@ -611,7 +612,7 @@ theorem reflection_mem_of_le_of_mem {s₁ s₂ : AffineSubspace ℝ P} [Nonempty
 /-- Reflecting an orthogonal vector plus a point in the subspace
 produces the negation of that vector plus the point. -/
 theorem reflection_orthogonal_vadd {s : AffineSubspace ℝ P} [Nonempty s]
-    [HasOrthogonalProjection s.direction] {p : P} (hp : p ∈ s) {v : V} (hv : v ∈ s.directionᗮ) :
+    [s.direction.HasOrthogonalProjection] {p : P} (hp : p ∈ s) {v : V} (hv : v ∈ s.directionᗮ) :
     reflection s (v +ᵥ p) = -v +ᵥ p := by
   rw [reflection_apply, orthogonalProjection_vadd_eq_self hp hv, vsub_vadd_eq_vsub_sub]
   simp
@@ -621,7 +622,7 @@ negation of that vector plus the point if the vector is a multiple of
 the result of subtracting a point's orthogonal projection from that
 point. -/
 theorem reflection_vadd_smul_vsub_orthogonalProjection {s : AffineSubspace ℝ P} [Nonempty s]
-    [HasOrthogonalProjection s.direction] {p₁ : P} (p₂ : P) (r : ℝ) (hp₁ : p₁ ∈ s) :
+    [s.direction.HasOrthogonalProjection] {p₁ : P} (p₂ : P) (r : ℝ) (hp₁ : p₁ ∈ s) :
     reflection s (r • (p₂ -ᵥ orthogonalProjection s p₂) +ᵥ p₁) =
       -(r • (p₂ -ᵥ orthogonalProjection s p₂)) +ᵥ p₁ :=
   reflection_orthogonal_vadd hp₁

--- a/Mathlib/Geometry/Euclidean/Circumcenter.lean
+++ b/Mathlib/Geometry/Euclidean/Circumcenter.lean
@@ -41,7 +41,7 @@ open AffineSubspace
 /-- `p` is equidistant from two points in `s` if and only if its
 `orthogonalProjection` is. -/
 theorem dist_eq_iff_dist_orthogonalProjection_eq {s : AffineSubspace ℝ P} [Nonempty s]
-    [HasOrthogonalProjection s.direction] {p₁ p₂ : P} (p₃ : P) (hp₁ : p₁ ∈ s) (hp₂ : p₂ ∈ s) :
+    [s.direction.HasOrthogonalProjection] {p₁ p₂ : P} (p₃ : P) (hp₁ : p₁ ∈ s) (hp₂ : p₂ ∈ s) :
     dist p₁ p₃ = dist p₂ p₃ ↔
       dist p₁ (orthogonalProjection s p₃) = dist p₂ (orthogonalProjection s p₃) := by
   rw [← mul_self_inj_of_nonneg dist_nonneg dist_nonneg, ←
@@ -53,7 +53,7 @@ theorem dist_eq_iff_dist_orthogonalProjection_eq {s : AffineSubspace ℝ P} [Non
 /-- `p` is equidistant from a set of points in `s` if and only if its
 `orthogonalProjection` is. -/
 theorem dist_set_eq_iff_dist_orthogonalProjection_eq {s : AffineSubspace ℝ P} [Nonempty s]
-    [HasOrthogonalProjection s.direction] {ps : Set P} (hps : ps ⊆ s) (p : P) :
+    [s.direction.HasOrthogonalProjection] {ps : Set P} (hps : ps ⊆ s) (p : P) :
     (Set.Pairwise ps fun p₁ p₂ => dist p₁ p = dist p₂ p) ↔
       Set.Pairwise ps fun p₁ p₂ =>
         dist p₁ (orthogonalProjection s p) = dist p₂ (orthogonalProjection s p) :=
@@ -67,7 +67,7 @@ points of a set of points in `s` if and only if there exists (possibly
 different) `r` such that its `orthogonalProjection` has that distance
 from all the points in that set. -/
 theorem exists_dist_eq_iff_exists_dist_orthogonalProjection_eq {s : AffineSubspace ℝ P} [Nonempty s]
-    [HasOrthogonalProjection s.direction] {ps : Set P} (hps : ps ⊆ s) (p : P) :
+    [s.direction.HasOrthogonalProjection] {ps : Set P} (hps : ps ⊆ s) (p : P) :
     (∃ r, ∀ p₁ ∈ ps, dist p₁ p = r) ↔ ∃ r, ∀ p₁ ∈ ps, dist p₁ ↑(orthogonalProjection s p) = r := by
   have h := dist_set_eq_iff_dist_orthogonalProjection_eq hps p
   simp_rw [Set.pairwise_eq_iff_exists_eq] at h
@@ -81,7 +81,7 @@ and a point `p` not in that subspace, there is a unique (circumcenter,
 circumradius) pair for the set with `p` added, in the span of the
 subspace with `p` added. -/
 theorem existsUnique_dist_eq_of_insert {s : AffineSubspace ℝ P}
-    [HasOrthogonalProjection s.direction] {ps : Set P} (hnps : ps.Nonempty) {p : P} (hps : ps ⊆ s)
+    [s.direction.HasOrthogonalProjection] {ps : Set P} (hnps : ps.Nonempty) {p : P} (hps : ps ⊆ s)
     (hp : p ∉ s) (hu : ∃! cs : Sphere P, cs.center ∈ s ∧ ps ⊆ (cs : Set P)) :
     ∃! cs₂ : Sphere P,
       cs₂.center ∈ affineSpan ℝ (insert p (s : Set P)) ∧ insert p ps ⊆ (cs₂ : Set P) := by
@@ -676,7 +676,7 @@ variable {V : Type*} {P : Type*} [NormedAddCommGroup V] [InnerProductSpace ℝ V
 that contains a set of points, those points are cospherical if and
 only if they are equidistant from some point in that subspace. -/
 theorem cospherical_iff_exists_mem_of_complete {s : AffineSubspace ℝ P} {ps : Set P} (h : ps ⊆ s)
-    [Nonempty s] [HasOrthogonalProjection s.direction] :
+    [Nonempty s] [s.direction.HasOrthogonalProjection] :
     Cospherical ps ↔ ∃ center ∈ s, ∃ radius : ℝ, ∀ p ∈ ps, dist p center = radius := by
   constructor
   · rintro ⟨c, hcr⟩

--- a/Mathlib/Geometry/Euclidean/Inversion/Calculus.lean
+++ b/Mathlib/Geometry/Euclidean/Inversion/Calculus.lean
@@ -100,9 +100,9 @@ theorem hasFDerivAt_inversion (hx : x ≠ c) :
     (LinearMap.eqOn_span' ?_) fun y hy ↦ ?_)
   · have : ((‖x‖ ^ 2) ^ 2)⁻¹ * (‖x‖ ^ 2) = (‖x‖ ^ 2)⁻¹ := by
       rw [← div_eq_inv_mul, sq (‖x‖ ^ 2), div_self_mul_self']
-    simp [reflection_orthogonalComplement_singleton_eq_neg, real_inner_self_eq_norm_sq,
+    simp [Submodule.reflection_orthogonalComplement_singleton_eq_neg, real_inner_self_eq_norm_sq,
       two_mul, this, div_eq_mul_inv, mul_add, add_smul, mul_pow]
   · simp [Submodule.mem_orthogonal_singleton_iff_inner_right.1 hy,
-      reflection_mem_subspace_eq_self hy, div_eq_mul_inv, mul_pow]
+      Submodule.reflection_mem_subspace_eq_self hy, div_eq_mul_inv, mul_pow]
 
 end EuclideanGeometry

--- a/Mathlib/Geometry/Euclidean/Inversion/Calculus.lean
+++ b/Mathlib/Geometry/Euclidean/Inversion/Calculus.lean
@@ -86,7 +86,7 @@ variable {c x : F} {R : ℝ}
 /-- Formula for the Fréchet derivative of `EuclideanGeometry.inversion c R`. -/
 theorem hasFDerivAt_inversion (hx : x ≠ c) :
     HasFDerivAt (inversion c R)
-      ((R / dist x c) ^ 2 • (reflection (ℝ ∙ (x - c))ᗮ : F →L[ℝ] F)) x := by
+      ((R / dist x c) ^ 2 • ((ℝ ∙ (x - c))ᗮ.reflection : F →L[ℝ] F)) x := by
   rcases add_left_surjective c x with ⟨x, rfl⟩
   have : HasFDerivAt (inversion c R) (?_ : F →L[ℝ] F) (c + x) := by
     simp +unfoldPartialApp only [inversion]

--- a/Mathlib/Geometry/Euclidean/SignedDist.lean
+++ b/Mathlib/Geometry/Euclidean/SignedDist.lean
@@ -33,7 +33,7 @@ variable [NormedAddTorsor V P]
 
 namespace AffineSubspace
 
-variable (s : AffineSubspace ℝ P) [Nonempty s] [HasOrthogonalProjection s.direction] (p : P)
+variable (s : AffineSubspace ℝ P) [Nonempty s] [s.direction.HasOrthogonalProjection] (p : P)
 
 /-- The signed distance between `s` and a point, in the direction of the reference point `p`.
 This is expected to be used when `p` does not lie in `s` (in the degenerate case where `p` lies

--- a/Mathlib/Geometry/Euclidean/SignedDist.lean
+++ b/Mathlib/Geometry/Euclidean/SignedDist.lean
@@ -51,12 +51,12 @@ lemma signedInfDist_apply (x : P) :
 lemma signedInfDist_linear : (s.signedInfDist p).linear =
     (innerₗ V (‖p -ᵥ orthogonalProjection s p‖⁻¹ • (p -ᵥ orthogonalProjection s p))).comp
       (LinearMap.id (R := ℝ) (M := V) -
-        s.direction.subtype.comp (_root_.orthogonalProjection s.direction).toLinearMap) :=
+        s.direction.subtype.comp (s.direction.orthogonalProjection).toLinearMap) :=
   rfl
 
 lemma signedInfDist_linear_apply (v : V) : (s.signedInfDist p).linear v =
     ⟪‖p -ᵥ orthogonalProjection s p‖⁻¹ • (p -ᵥ orthogonalProjection s p),
-     v - _root_.orthogonalProjection s.direction v⟫ :=
+     v - s.direction.orthogonalProjection v⟫ :=
   rfl
 
 @[simp] lemma signedInfDist_apply_self : s.signedInfDist p p = ‖p -ᵥ orthogonalProjection s p‖ := by

--- a/Mathlib/Geometry/Euclidean/SignedDist.lean
+++ b/Mathlib/Geometry/Euclidean/SignedDist.lean
@@ -51,7 +51,7 @@ lemma signedInfDist_apply (x : P) :
 lemma signedInfDist_linear : (s.signedInfDist p).linear =
     (innerₗ V (‖p -ᵥ orthogonalProjection s p‖⁻¹ • (p -ᵥ orthogonalProjection s p))).comp
       (LinearMap.id (R := ℝ) (M := V) -
-        s.direction.subtype.comp (s.direction.orthogonalProjection).toLinearMap) :=
+        s.direction.subtype.comp s.direction.orthogonalProjection.toLinearMap) :=
   rfl
 
 lemma signedInfDist_linear_apply (v : V) : (s.signedInfDist p).linear v =

--- a/Mathlib/Geometry/Manifold/Instances/Sphere.lean
+++ b/Mathlib/Geometry/Manifold/Instances/Sphere.lean
@@ -205,8 +205,8 @@ theorem stereo_left_inv (hv : ‖v‖ = 1) {x : sphere (0 : E) 1} (hx : (x : E) 
   set a : ℝ := innerSL _ v x
   set y := (ℝ ∙ v)ᗮ.orthogonalProjection x
   have split : ↑x = a • v + ↑y := by
-    convert (orthogonalProjection_add_orthogonalProjection_orthogonal (ℝ ∙ v) x).symm
-    exact (orthogonalProjection_unit_singleton ℝ hv x).symm
+    convert ((ℝ ∙ v).orthogonalProjection_add_orthogonalProjection_orthogonal x).symm
+    exact (Submodule.orthogonalProjection_unit_singleton ℝ hv x).symm
   have hvy : ⟪v, y⟫_ℝ = 0 := Submodule.mem_orthogonal_singleton_iff_inner_right.mp y.2
   have pythag : 1 = a ^ 2 + ‖y‖ ^ 2 := by
     have hvy' : ⟪a • v, y⟫_ℝ = 0 := by simp only [inner_smul_left, hvy, mul_zero]
@@ -228,9 +228,9 @@ theorem stereo_left_inv (hv : ‖v‖ = 1) {x : sphere (0 : E) 1} (hx : (x : E) 
 
 theorem stereo_right_inv (hv : ‖v‖ = 1) (w : (ℝ ∙ v)ᗮ) : stereoToFun v (stereoInvFun hv w) = w := by
   simp only [stereoToFun, stereoInvFun, stereoInvFunAux, smul_add, map_add, map_smul, innerSL_apply,
-    orthogonalProjection_mem_subspace_eq_self]
+    Submodule.orthogonalProjection_mem_subspace_eq_self]
   have h₁ : (ℝ ∙ v)ᗮ.orthogonalProjection v = 0 :=
-    orthogonalProjection_orthogonalComplement_singleton_eq_zero v
+    Submodule.orthogonalProjection_orthogonalComplement_singleton_eq_zero v
   -- Porting note: was innerSL _ and now just inner
   have h₂ : inner v w = (0 : ℝ) := Submodule.mem_orthogonal_singleton_iff_inner_right.mp w.2
   -- Porting note: was innerSL _ and now just inner
@@ -283,7 +283,7 @@ theorem stereographic_target (hv : ‖v‖ = 1) : (stereographic hv).target = Se
 @[simp]
 theorem stereographic_apply_neg (v : sphere (0 : E) 1) :
     stereographic (norm_eq_of_mem_sphere v) (-v) = 0 := by
-  simp [stereographic_apply, orthogonalProjection_orthogonalComplement_singleton_eq_zero]
+  simp [stereographic_apply, Submodule.orthogonalProjection_orthogonalComplement_singleton_eq_zero]
 
 @[simp]
 theorem stereographic_neg_apply (v : sphere (0 : E) 1) :

--- a/Mathlib/Geometry/Manifold/Instances/Sphere.lean
+++ b/Mathlib/Geometry/Manifold/Instances/Sphere.lean
@@ -85,18 +85,18 @@ the orthogonal complement of an element `v` of `E`. It is smooth away from the a
 through `v` parallel to the orthogonal complement.  It restricts on the sphere to the stereographic
 projection. -/
 def stereoToFun (x : E) : (ℝ ∙ v)ᗮ :=
-  (2 / ((1 : ℝ) - innerSL ℝ v x)) • orthogonalProjection (ℝ ∙ v)ᗮ x
+  (2 / ((1 : ℝ) - innerSL ℝ v x)) • (ℝ ∙ v)ᗮ.orthogonalProjection x
 
 variable {v}
 
 @[simp]
 theorem stereoToFun_apply (x : E) :
-    stereoToFun v x = (2 / ((1 : ℝ) - innerSL ℝ v x)) • orthogonalProjection (ℝ ∙ v)ᗮ x :=
+    stereoToFun v x = (2 / ((1 : ℝ) - innerSL ℝ v x)) • (ℝ ∙ v)ᗮ.orthogonalProjection x :=
   rfl
 
 theorem contDiffOn_stereoToFun {n : WithTop ℕ∞} :
     ContDiffOn ℝ n (stereoToFun v) {x : E | innerSL _ v x ≠ (1 : ℝ)} := by
-  refine ContDiffOn.smul ?_ (orthogonalProjection (ℝ ∙ v)ᗮ).contDiff.contDiffOn
+  refine ContDiffOn.smul ?_ ((ℝ ∙ v)ᗮ.orthogonalProjection).contDiff.contDiffOn
   refine contDiff_const.contDiffOn.div ?_ ?_
   · exact (contDiff_const.sub (innerSL ℝ v).contDiff).contDiffOn
   · intro x h h'
@@ -203,7 +203,7 @@ theorem stereo_left_inv (hv : ‖v‖ = 1) {x : sphere (0 : E) 1} (hx : (x : E) 
   simp only [stereoToFun_apply, stereoInvFun_apply, smul_add]
   -- name two frequently-occurring quantities and write down their basic properties
   set a : ℝ := innerSL _ v x
-  set y := orthogonalProjection (ℝ ∙ v)ᗮ x
+  set y := (ℝ ∙ v)ᗮ.orthogonalProjection x
   have split : ↑x = a • v + ↑y := by
     convert (orthogonalProjection_add_orthogonalProjection_orthogonal (ℝ ∙ v) x).symm
     exact (orthogonalProjection_unit_singleton ℝ hv x).symm
@@ -229,7 +229,7 @@ theorem stereo_left_inv (hv : ‖v‖ = 1) {x : sphere (0 : E) 1} (hx : (x : E) 
 theorem stereo_right_inv (hv : ‖v‖ = 1) (w : (ℝ ∙ v)ᗮ) : stereoToFun v (stereoInvFun hv w) = w := by
   simp only [stereoToFun, stereoInvFun, stereoInvFunAux, smul_add, map_add, map_smul, innerSL_apply,
     orthogonalProjection_mem_subspace_eq_self]
-  have h₁ : orthogonalProjection (ℝ ∙ v)ᗮ v = 0 :=
+  have h₁ : (ℝ ∙ v)ᗮ.orthogonalProjection v = 0 :=
     orthogonalProjection_orthogonalComplement_singleton_eq_zero v
   -- Porting note: was innerSL _ and now just inner
   have h₂ : inner v w = (0 : ℝ) := Submodule.mem_orthogonal_singleton_iff_inner_right.mp w.2
@@ -269,7 +269,7 @@ def stereographic (hv : ‖v‖ = 1) : PartialHomeomorph (sphere (0 : E) 1) (ℝ
   continuousOn_invFun := (continuous_stereoInvFun hv).continuousOn
 
 theorem stereographic_apply (hv : ‖v‖ = 1) (x : sphere (0 : E) 1) :
-    stereographic hv x = (2 / ((1 : ℝ) - inner v x)) • orthogonalProjection (ℝ ∙ v)ᗮ x :=
+    stereographic hv x = (2 / ((1 : ℝ) - inner v x)) • (ℝ ∙ v)ᗮ.orthogonalProjection x :=
   rfl
 
 @[simp]

--- a/Mathlib/Geometry/Manifold/Instances/Sphere.lean
+++ b/Mathlib/Geometry/Manifold/Instances/Sphere.lean
@@ -96,7 +96,7 @@ theorem stereoToFun_apply (x : E) :
 
 theorem contDiffOn_stereoToFun {n : WithTop ℕ∞} :
     ContDiffOn ℝ n (stereoToFun v) {x : E | innerSL _ v x ≠ (1 : ℝ)} := by
-  refine ContDiffOn.smul ?_ ((ℝ ∙ v)ᗮ.orthogonalProjection).contDiff.contDiffOn
+  refine ContDiffOn.smul ?_ (ℝ ∙ v)ᗮ.orthogonalProjection.contDiff.contDiffOn
   refine contDiff_const.contDiffOn.div ?_ ?_
   · exact (contDiff_const.sub (innerSL ℝ v).contDiff).contDiffOn
   · intro x h h'

--- a/Mathlib/MeasureTheory/Function/ConditionalExpectation/CondexpL2.lean
+++ b/Mathlib/MeasureTheory/Function/ConditionalExpectation/CondexpL2.lean
@@ -65,9 +65,8 @@ variable (E 𝕜)
 
 /-- Conditional expectation of a function in L2 with respect to a sigma-algebra -/
 noncomputable def condExpL2 (hm : m ≤ m0) : (α →₂[μ] E) →L[𝕜] lpMeas E 𝕜 m 2 μ :=
-  @orthogonalProjection 𝕜 (α →₂[μ] E) _ _ _ (lpMeas E 𝕜 m 2 μ)
-    haveI : Fact (m ≤ m0) := ⟨hm⟩
-    inferInstance
+  haveI : Fact (m ≤ m0) := ⟨hm⟩
+  (lpMeas E 𝕜 m 2 μ).orthogonalProjection
 
 @[deprecated (since := "2025-01-21")] alias condexpL2 := condExpL2
 

--- a/Mathlib/MeasureTheory/Function/ConditionalExpectation/CondexpL2.lean
+++ b/Mathlib/MeasureTheory/Function/ConditionalExpectation/CondexpL2.lean
@@ -99,7 +99,7 @@ alias integrable_condexpL2_of_isFiniteMeasure := integrable_condExpL2_of_isFinit
 
 theorem norm_condExpL2_le_one (hm : m ≤ m0) : ‖@condExpL2 α E 𝕜 _ _ _ _ _ _ μ hm‖ ≤ 1 :=
   haveI : Fact (m ≤ m0) := ⟨hm⟩
-  orthogonalProjection_norm_le _
+  Submodule.orthogonalProjection_norm_le _
 
 @[deprecated (since := "2025-01-21")] alias norm_condexpL2_le_one := norm_condExpL2_le_one
 
@@ -127,7 +127,7 @@ theorem norm_condExpL2_coe_le (hm : m ≤ m0) (f : α →₂[μ] E) :
 theorem inner_condExpL2_left_eq_right (hm : m ≤ m0) {f g : α →₂[μ] E} :
     ⟪(condExpL2 E 𝕜 hm f : α →₂[μ] E), g⟫₂ = ⟪f, (condExpL2 E 𝕜 hm g : α →₂[μ] E)⟫₂ :=
   haveI : Fact (m ≤ m0) := ⟨hm⟩
-  inner_orthogonalProjection_left_eq_right _ f g
+  Submodule.inner_orthogonalProjection_left_eq_right _ f g
 
 @[deprecated (since := "2025-01-21")]
 alias inner_condexpL2_left_eq_right := inner_condExpL2_left_eq_right
@@ -142,7 +142,7 @@ theorem condExpL2_indicator_of_measurable (hm : m ≤ m0) (hs : MeasurableSet[m]
     mem_lpMeas_indicatorConstLp hm hs hμs
   let ind := (⟨indicatorConstLp 2 (hm s hs) hμs c, h_mem⟩ : lpMeas E 𝕜 m 2 μ)
   have h_coe_ind : (ind : α →₂[μ] E) = indicatorConstLp 2 (hm s hs) hμs c := rfl
-  have h_orth_mem := orthogonalProjection_mem_subspace_eq_self ind
+  have h_orth_mem := Submodule.orthogonalProjection_mem_subspace_eq_self ind
   rw [← h_coe_ind, h_orth_mem]
 
 @[deprecated (since := "2025-01-21")]
@@ -153,7 +153,8 @@ theorem inner_condExpL2_eq_inner_fun (hm : m ≤ m0) (f g : α →₂[μ] E)
     ⟪(condExpL2 E 𝕜 hm f : α →₂[μ] E), g⟫₂ = ⟪f, g⟫₂ := by
   symm
   rw [← sub_eq_zero, ← inner_sub_left, condExpL2]
-  simp only [mem_lpMeas_iff_aestronglyMeasurable.mpr hg, orthogonalProjection_inner_eq_zero f g]
+  simp only [mem_lpMeas_iff_aestronglyMeasurable.mpr hg,
+    Submodule.orthogonalProjection_inner_eq_zero f g]
 
 @[deprecated (since := "2025-01-21")]
 alias inner_condexpL2_eq_inner_fun := inner_condExpL2_eq_inner_fun

--- a/docs/overview.yaml
+++ b/docs/overview.yaml
@@ -284,7 +284,7 @@ Analysis:
     adjoint operator: 'LinearPMap.adjoint'
     self-adjoint operator: 'IsSelfAdjoint'
     orthogonal projection: 'Submodule.orthogonalProjection'
-    reflection: 'reflection'
+    reflection: 'Submodule.reflection'
     orthogonal complement: 'Submodule.orthogonal'
     existence of Hilbert basis: 'exists_hilbertBasis'
     eigenvalues from Rayleigh quotient: 'IsSelfAdjoint.hasEigenvector_of_isLocalExtrOn'

--- a/docs/overview.yaml
+++ b/docs/overview.yaml
@@ -283,7 +283,7 @@ Analysis:
     Cauchy-Schwarz inequality: 'inner_mul_inner_self_le'
     adjoint operator: 'LinearPMap.adjoint'
     self-adjoint operator: 'IsSelfAdjoint'
-    orthogonal projection: 'orthogonalProjection'
+    orthogonal projection: 'SubModule.orthogonalProjection'
     reflection: 'reflection'
     orthogonal complement: 'Submodule.orthogonal'
     existence of Hilbert basis: 'exists_hilbertBasis'

--- a/docs/overview.yaml
+++ b/docs/overview.yaml
@@ -283,7 +283,7 @@ Analysis:
     Cauchy-Schwarz inequality: 'inner_mul_inner_self_le'
     adjoint operator: 'LinearPMap.adjoint'
     self-adjoint operator: 'IsSelfAdjoint'
-    orthogonal projection: 'SubModule.orthogonalProjection'
+    orthogonal projection: 'Submodule.orthogonalProjection'
     reflection: 'reflection'
     orthogonal complement: 'Submodule.orthogonal'
     existence of Hilbert basis: 'exists_hilbertBasis'

--- a/docs/undergrad.yaml
+++ b/docs/undergrad.yaml
@@ -435,7 +435,7 @@ Topology:
     Arzela-Ascoli theorem: 'BoundedContinuousFunction.arzela_ascoli'
   Hilbert spaces:
     Hilbert projection theorem: 'exists_norm_eq_iInf_of_complete_convex'
-    orthogonal projection onto closed vector subspaces: 'orthogonalProjection'
+    orthogonal projection onto closed vector subspaces: 'Submodule.orthogonalProjection'
     dual space: 'NormedSpace.Dual'
     Riesz representation theorem: 'InnerProductSpace.toDual'
     inner product space $l^2$: 'lp.instInnerProductSpace'


### PR DESCRIPTION
This PR puts `orthogonalProjection`, `HasOrthogonalProjection` and `reflection` in the `Submodule` namespace. This allows us to use dot-notation with these definitions. It also removes the name ambiguity with `EuclideanGeometry.orthogonalProjection` and `EuclideanGeometry.reflection`. Those can be moved to the `AffineSubspace` namespace in a future PR.

As discussed here: [#lean4 > overloaded names can slow down elaboration](https://leanprover.zulipchat.com/#narrow/channel/270676-lean4/topic/overloaded.20names.20can.20slow.20down.20elaboration)


Moves:
- orthogonalProjection -> Submodule.orthogonalProjection
- HasOrthogonalProjection -> Submodule.HasOrthogonalProjection
- reflection -> Submodule.reflection

The definitions and many lemmas related to these have also been moved into the `Submodule` namespace.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
