### PR TITLE
[Merged by Bors] - chore(Topology/Algebra/ClosedSubgroup): deprecate module

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -5725,6 +5725,7 @@ import Mathlib.Topology.Algebra.Algebra.Rat
 import Mathlib.Topology.Algebra.Category.ProfiniteGrp.Basic
 import Mathlib.Topology.Algebra.Category.ProfiniteGrp.Limits
 import Mathlib.Topology.Algebra.ClopenNhdofOne
+import Mathlib.Topology.Algebra.ClosedSubgroup
 import Mathlib.Topology.Algebra.ConstMulAction
 import Mathlib.Topology.Algebra.Constructions
 import Mathlib.Topology.Algebra.Constructions.DomMulAct

--- a/Mathlib/Topology/Algebra/ClosedSubgroup.lean
+++ b/Mathlib/Topology/Algebra/ClosedSubgroup.lean
@@ -1,0 +1,3 @@
+import Mathlib.Topology.Algebra.Group.ClosedSubgroup
+
+deprecated_module (since := "2025-04-21")


### PR DESCRIPTION

---

- [ ] depends on: #24233


[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
