### PR TITLE
[Merged by Bors] - chore(CategoryTheory/Whiskering): more lemmas about `isoWhisker`

### DIFF
--- a/Mathlib/CategoryTheory/Whiskering.lean
+++ b/Mathlib/CategoryTheory/Whiskering.lean
@@ -225,6 +225,11 @@ lemma isoWhiskerLeft_symm (F : C ⥤ D) {G H : D ⥤ E} (α : G ≅ H) :
     (isoWhiskerLeft F α).symm = isoWhiskerLeft F α.symm :=
   rfl
 
+@[simp]
+lemma isoWhiskerLeft_refl (F : C ⥤ D) (G : D ⥤ E) :
+    isoWhiskerLeft F (Iso.refl G) = Iso.refl _ :=
+  rfl
+
 /-- If `α : G ≅ H` then
 `isoWhiskerRight α F : (G ⋙ F) ≅ (H ⋙ F)` has components `F.map_iso (α.app X)`.
 -/
@@ -244,6 +249,11 @@ theorem isoWhiskerRight_inv {G H : C ⥤ D} (α : G ≅ H) (F : D ⥤ E) :
 lemma isoWhiskerRight_symm {G H : C ⥤ D} (α : G ≅ H) (F : D ⥤ E) :
     (isoWhiskerRight α F).symm = isoWhiskerRight α.symm F :=
   rfl
+
+@[simp]
+lemma isoWhiskerRight_refl (F : C ⥤ D) (G : D ⥤ E) :
+    isoWhiskerRight (Iso.refl F) G = Iso.refl _ := by
+  aesop_cat
 
 instance isIso_whiskerLeft (F : C ⥤ D) {G H : D ⥤ E} (α : G ⟶ H) [IsIso α] :
     IsIso (whiskerLeft F α) :=

--- a/Mathlib/CategoryTheory/Whiskering.lean
+++ b/Mathlib/CategoryTheory/Whiskering.lean
@@ -194,6 +194,12 @@ theorem whiskerRight_comp {G H K : C ⥤ D} (α : G ⟶ H) (β : H ⟶ K) (F : D
     whiskerRight (α ≫ β) F = whiskerRight α F ≫ whiskerRight β F :=
   ((whiskeringRight C D E).obj F).map_comp α β
 
+@[reassoc]
+theorem whiskerLeft_comp_whiskerRight {F G : C ⥤ D} {H K : D ⥤ E} (α : F ⟶ G) (β : H ⟶ K) :
+    whiskerLeft F β ≫ whiskerRight α K = whiskerRight α H ≫ whiskerLeft G β := by
+  ext
+  simp
+
 lemma NatTrans.hcomp_eq_whiskerLeft_comp_whiskerRight {F G : C ⥤ D} {H K : D ⥤ E}
     (α : F ⟶ G) (β : H ⟶ K) : α ◫ β = whiskerLeft F β ≫ whiskerRight α K := by
   ext

--- a/Mathlib/CategoryTheory/Whiskering.lean
+++ b/Mathlib/CategoryTheory/Whiskering.lean
@@ -252,7 +252,6 @@ theorem isoWhiskerLeft_trans (F : C ⥤ D) {G H K : D ⥤ E} (α : G ≅ H) (β 
     isoWhiskerLeft F (α ≪≫ β) = isoWhiskerLeft F α ≪≫ isoWhiskerLeft F β :=
   rfl
 
-@[simp]
 theorem isoWhiskerLeft_trans_assoc (F : C ⥤ D) {G H K : D ⥤ E} (α : G ≅ H) (β : H ≅ K)
     {K' : C ⥤ E} (γ : F ⋙ K ≅ K') :
     isoWhiskerLeft F (α ≪≫ β) ≪≫ γ = isoWhiskerLeft F α ≪≫ isoWhiskerLeft F β ≪≫ γ := by
@@ -263,7 +262,6 @@ theorem isoWhiskerRight_trans {G H K : C ⥤ D} (α : G ≅ H) (β : H ≅ K) (F
     isoWhiskerRight (α ≪≫ β) F = isoWhiskerRight α F ≪≫ isoWhiskerRight β F :=
   ((whiskeringRight C D E).obj F).mapIso_trans α β
 
-@[simp]
 theorem isoWhiskerRight_trans_assoc {G H K : C ⥤ D} (α : G ≅ H) (β : H ≅ K) (F : D ⥤ E)
     {K' : C ⥤ E} (γ : K ⋙ F ≅ K'):
     isoWhiskerRight (α ≪≫ β) F ≪≫ γ = isoWhiskerRight α F ≪≫ isoWhiskerRight β F ≪≫ γ := by

--- a/Mathlib/CategoryTheory/Whiskering.lean
+++ b/Mathlib/CategoryTheory/Whiskering.lean
@@ -268,31 +268,15 @@ theorem isoWhiskerLeft_trans (F : C ⥤ D) {G H K : D ⥤ E} (α : G ≅ H) (β 
     isoWhiskerLeft F (α ≪≫ β) = isoWhiskerLeft F α ≪≫ isoWhiskerLeft F β :=
   rfl
 
-theorem isoWhiskerLeft_trans_assoc (F : C ⥤ D) {G H K : D ⥤ E} (α : G ≅ H) (β : H ≅ K)
-    {K' : C ⥤ E} (γ : F ⋙ K ≅ K') :
-    isoWhiskerLeft F (α ≪≫ β) ≪≫ γ = isoWhiskerLeft F α ≪≫ isoWhiskerLeft F β ≪≫ γ := by
-  rw [← Iso.trans_assoc, isoWhiskerLeft_trans]
-
 @[simp]
 theorem isoWhiskerRight_trans {G H K : C ⥤ D} (α : G ≅ H) (β : H ≅ K) (F : D ⥤ E) :
     isoWhiskerRight (α ≪≫ β) F = isoWhiskerRight α F ≪≫ isoWhiskerRight β F :=
   ((whiskeringRight C D E).obj F).mapIso_trans α β
 
-theorem isoWhiskerRight_trans_assoc {G H K : C ⥤ D} (α : G ≅ H) (β : H ≅ K) (F : D ⥤ E)
-    {K' : C ⥤ E} (γ : K ⋙ F ≅ K'):
-    isoWhiskerRight (α ≪≫ β) F ≪≫ γ = isoWhiskerRight α F ≪≫ isoWhiskerRight β F ≪≫ γ := by
-  rw [← Iso.trans_assoc, isoWhiskerRight_trans]
-
 theorem isoWhiskerLeft_trans_isoWhiskerRight {F G : C ⥤ D} {H K : D ⥤ E} (α : F ≅ G) (β : H ≅ K) :
     isoWhiskerLeft F β ≪≫ isoWhiskerRight α K = isoWhiskerRight α H ≪≫ isoWhiskerLeft G β := by
   ext
   simp
-
-theorem isoWhiskerLeft_trans_whiskerRight_assoc {F G : C ⥤ D} {H K : D ⥤ E}
-    (α : F ≅ G) (β : H ≅ K) {K' : C ⥤ E} (γ : G ⋙ K ≅ K') :
-    isoWhiskerLeft F β ≪≫ isoWhiskerRight α K ≪≫ γ =
-    isoWhiskerRight α H ≪≫ isoWhiskerLeft G β ≪≫ γ := by
-  rw [← Iso.trans_assoc, isoWhiskerLeft_trans_isoWhiskerRight, Iso.trans_assoc]
 
 variable {B : Type u₄} [Category.{v₄} B]
 

--- a/Mathlib/CategoryTheory/Whiskering.lean
+++ b/Mathlib/CategoryTheory/Whiskering.lean
@@ -194,12 +194,6 @@ theorem whiskerRight_comp {G H K : C ⥤ D} (α : G ⟶ H) (β : H ⟶ K) (F : D
     whiskerRight (α ≫ β) F = whiskerRight α F ≫ whiskerRight β F :=
   ((whiskeringRight C D E).obj F).map_comp α β
 
-@[reassoc]
-theorem whiskerLeft_comp_whiskerRight {F G : C ⥤ D} {H K : D ⥤ E} (α : F ⟶ G) (β : H ⟶ K) :
-    whiskerLeft F β ≫ whiskerRight α K = whiskerRight α H ≫ whiskerLeft G β := by
-  ext
-  simp
-
 lemma NatTrans.hcomp_eq_whiskerLeft_comp_whiskerRight {F G : C ⥤ D} {H K : D ⥤ E}
     (α : F ⟶ G) (β : H ⟶ K) : α ◫ β = whiskerLeft F β ≫ whiskerRight α K := by
   ext
@@ -221,6 +215,10 @@ theorem isoWhiskerLeft_inv (F : C ⥤ D) {G H : D ⥤ E} (α : G ≅ H) :
     (isoWhiskerLeft F α).inv = whiskerLeft F α.inv :=
   rfl
 
+lemma isoWhiskerLeft_symm (F : C ⥤ D) {G H : D ⥤ E} (α : G ≅ H) :
+    (isoWhiskerLeft F α).symm = isoWhiskerLeft F α.symm :=
+  rfl
+
 /-- If `α : G ≅ H` then
 `isoWhiskerRight α F : (G ⋙ F) ≅ (H ⋙ F)` has components `F.map_iso (α.app X)`.
 -/
@@ -237,6 +235,10 @@ theorem isoWhiskerRight_inv {G H : C ⥤ D} (α : G ≅ H) (F : D ⥤ E) :
     (isoWhiskerRight α F).inv = whiskerRight α.inv F :=
   rfl
 
+lemma isoWhiskerRight_symm {G H : C ⥤ D} (α : G ≅ H) (F : D ⥤ E) :
+    (isoWhiskerRight α F).symm = isoWhiskerRight α.symm F :=
+  rfl
+
 instance isIso_whiskerLeft (F : C ⥤ D) {G H : D ⥤ E} (α : G ⟶ H) [IsIso α] :
     IsIso (whiskerLeft F α) :=
   (isoWhiskerLeft F (asIso α)).isIso_hom
@@ -244,6 +246,39 @@ instance isIso_whiskerLeft (F : C ⥤ D) {G H : D ⥤ E} (α : G ⟶ H) [IsIso �
 instance isIso_whiskerRight {G H : C ⥤ D} (α : G ⟶ H) (F : D ⥤ E) [IsIso α] :
     IsIso (whiskerRight α F) :=
   (isoWhiskerRight (asIso α) F).isIso_hom
+
+@[simp]
+theorem isoWhiskerLeft_trans (F : C ⥤ D) {G H K : D ⥤ E} (α : G ≅ H) (β : H ≅ K) :
+    isoWhiskerLeft F (α ≪≫ β) = isoWhiskerLeft F α ≪≫ isoWhiskerLeft F β :=
+  rfl
+
+@[simp]
+theorem isoWhiskerLeft_trans_assoc (F : C ⥤ D) {G H K : D ⥤ E} (α : G ≅ H) (β : H ≅ K)
+    {K' : C ⥤ E} (γ : F ⋙ K ≅ K') :
+    isoWhiskerLeft F (α ≪≫ β) ≪≫ γ = isoWhiskerLeft F α ≪≫ isoWhiskerLeft F β ≪≫ γ := by
+  rw [← Iso.trans_assoc, isoWhiskerLeft_trans]
+
+@[simp]
+theorem isoWhiskerRight_trans {G H K : C ⥤ D} (α : G ≅ H) (β : H ≅ K) (F : D ⥤ E) :
+    isoWhiskerRight (α ≪≫ β) F = isoWhiskerRight α F ≪≫ isoWhiskerRight β F :=
+  ((whiskeringRight C D E).obj F).mapIso_trans α β
+
+@[simp]
+theorem isoWhiskerRight_trans_assoc {G H K : C ⥤ D} (α : G ≅ H) (β : H ≅ K) (F : D ⥤ E)
+    {K' : C ⥤ E} (γ : K ⋙ F ≅ K'):
+    isoWhiskerRight (α ≪≫ β) F ≪≫ γ = isoWhiskerRight α F ≪≫ isoWhiskerRight β F ≪≫ γ := by
+  rw [← Iso.trans_assoc, isoWhiskerRight_trans]
+
+theorem isoWhiskerLeft_trans_isoWhiskerRight {F G : C ⥤ D} {H K : D ⥤ E} (α : F ≅ G) (β : H ≅ K) :
+    isoWhiskerLeft F β ≪≫ isoWhiskerRight α K = isoWhiskerRight α H ≪≫ isoWhiskerLeft G β := by
+  ext
+  simp
+
+theorem isoWhiskerLeft_trans_whiskerRight_assoc {F G : C ⥤ D} {H K : D ⥤ E}
+    (α : F ≅ G) (β : H ≅ K) {K' : C ⥤ E} (γ : G ⋙ K ≅ K') :
+    isoWhiskerLeft F β ≪≫ isoWhiskerRight α K ≪≫ γ =
+    isoWhiskerRight α H ≪≫ isoWhiskerLeft G β ≪≫ γ := by
+  rw [← Iso.trans_assoc, isoWhiskerLeft_trans_isoWhiskerRight, Iso.trans_assoc]
 
 variable {B : Type u₄} [Category.{v₄} B]
 
@@ -265,6 +300,30 @@ theorem whiskerRight_left (F : B ⥤ C) {G H : C ⥤ D} (α : G ⟶ H) (K : D �
       (Functor.associator _ _ _).inv := by
   aesop_cat
 
+@[simp]
+theorem isoWhiskerLeft_twice (F : B ⥤ C) (G : C ⥤ D) {H K : D ⥤ E} (α : H ≅ K) :
+    isoWhiskerLeft F (isoWhiskerLeft G α) =
+    (Functor.associator _ _ _).symm ≪≫ isoWhiskerLeft (F ⋙ G) α ≪≫ Functor.associator _ _ _ := by
+  aesop_cat
+
+@[simp]
+theorem isoWhiskerRight_twice {H K : B ⥤ C} (F : C ⥤ D) (G : D ⥤ E) (α : H ≅ K) :
+    isoWhiskerRight (isoWhiskerRight α F) G =
+    Functor.associator _ _ _ ≪≫ isoWhiskerRight α (F ⋙ G) ≪≫ (Functor.associator _ _ _).symm := by
+  aesop_cat
+
+theorem isoWhiskerRight_left (F : B ⥤ C) {G H : C ⥤ D} (α : G ≅ H) (K : D ⥤ E) :
+    isoWhiskerRight (isoWhiskerLeft F α) K =
+    Functor.associator _ _ _ ≪≫ isoWhiskerLeft F (isoWhiskerRight α K) ≪≫
+      Functor.associator _ _ _ := by
+  aesop_cat
+
+theorem isoWhiskerLeft_right (F : B ⥤ C) {G H : C ⥤ D} (α : G ≅ H) (K : D ⥤ E) :
+    isoWhiskerLeft F (isoWhiskerRight α K) =
+    (Functor.associator _ _ _).symm ≪≫ isoWhiskerRight (isoWhiskerLeft F α) K ≪≫
+      (Functor.associator _ _ _).symm := by
+  aesop_cat
+
 end
 
 namespace Functor
@@ -274,6 +333,15 @@ universe u₅ v₅
 variable {A : Type u₁} [Category.{v₁} A] {B : Type u₂} [Category.{v₂} B]
   {C : Type u₃} [Category.{v₃} C] {D : Type u₄} [Category.{v₄} D] {E : Type u₅} [Category.{v₅} E]
   (F : A ⥤ B) (G : B ⥤ C) (H : C ⥤ D) (K : D ⥤ E)
+
+theorem triangleIso :
+    associator F (𝟭 B) G ≪≫ isoWhiskerLeft F (leftUnitor G) =
+      isoWhiskerRight (rightUnitor F) G := by aesop_cat
+
+theorem pentagonIso :
+    isoWhiskerRight (associator F G H) K ≪≫
+        associator F (G ⋙ H) K ≪≫ isoWhiskerLeft F (associator G H K) =
+      associator (F ⋙ G) H K ≪≫ associator F G (H ⋙ K) := by aesop_cat
 
 theorem triangle :
     (associator F (𝟭 B) G).hom ≫ whiskerLeft F (leftUnitor G).hom =


### PR DESCRIPTION
Duplicate some of the `whiskerLeft`/`whiskerRight` lemmas for `isoWhiskerLeft`/`isoWhiskerRight`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

These are useful if one intends to work with compositions of natural isomorphisms "purely formally", without calling `ext` or `ext1`. 

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
