### PR TITLE
[Merged by Bors] - feat(Shake): autodetect the module(s) to shake

### DIFF
--- a/Shake/Main.lean
+++ b/Shake/Main.lean
@@ -3,8 +3,12 @@ Copyright (c) 2023 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
+import Lake.Util.Error
+import Lean.Environment
+import Lean.Parser.Module
 import Lean.Util.FoldConsts
-import Lean
+import Lean.Util.Paths
+import Lake.CLI.Main
 
 /-! # `lake exe shake` command
 
@@ -26,7 +30,7 @@ To mitigate this, the `scripts/noshake.json` file is used to suppress known fals
 
 -/
 
-def help : String := "Mathlib4 tree shaking tool
+def help : String := "Lean project tree shaking tool
 Usage: lake exe shake [OPTIONS] <MODULE>..
 
 Arguments:
@@ -449,12 +453,32 @@ def main (args : List String) : IO UInt32 := do
       IO.println "There are out of date oleans. Run `lake build` or `lake exe cache get` first"
       IO.Process.exit 1
 
+  -- Determine default module(s) to run shake on
+  let defaultTargetModules : Array Name ← try
+    let (elanInstall?, leanInstall?, lakeInstall?) ← Lake.findInstall?
+    let config ← Lake.MonadError.runEIO <| Lake.mkLoadConfig { elanInstall?, leanInstall?, lakeInstall? }
+    let some workspace ← Lake.loadWorkspace config |>.toBaseIO
+      | throw <| IO.userError "failed to load Lake workspace"
+    let defaultTargetModules := workspace.root.defaultTargets.flatMap fun target =>
+      if let some lib := workspace.root.findLeanLib? target then
+        lib.roots
+      else if let some exe := workspace.root.findLeanExe? target then
+        #[exe.config.root]
+      else
+        #[]
+    pure defaultTargetModules
+  catch _ =>
+    pure #[]
+
   -- Parse the `--cfg` argument
   let srcSearchPath ← initSrcSearchPath
   let cfgFile ← if let some cfg := args.cfg then
     pure (some ⟨cfg⟩)
-  else if let some path ← srcSearchPath.findModuleWithExt "lean" `Mathlib then
-    pure (some (path.parent.get! / "scripts" / "noshake.json"))
+  else if let some mod := defaultTargetModules[0]? then
+    if let some path ← srcSearchPath.findModuleWithExt "lean" mod then
+      pure (some (path.parent.get! / "scripts" / "noshake.json"))
+    else
+      pure none
   else pure none
 
   -- Read the config file
@@ -472,7 +496,7 @@ def main (args : List String) : IO UInt32 := do
     IO.Process.exit 1
   else
   -- the list of root modules
-  let mods := if args.mods.isEmpty then #[`Mathlib] else args.mods
+  let mods := if args.mods.isEmpty then defaultTargetModules else args.mods
   -- Only submodules of `pkg` will be edited or have info reported on them
   let pkg := mods[0]!.components.head!
 


### PR DESCRIPTION
There were still a few references to Mathlib in shake, in particular it had Mathlib hardcoded as the default module to shake. Instead ask Lake what the default targets are.

This is a back(?)port of https://github.com/leanprover-community/batteries/pull/1205. These changes themselves should probably be merged anyway, and do not depend on which repository shake ends up in.

(Also remove a reference to Mathlib from the help text. We still have Mathlib as an example usage, which I think is innocent enough and can stay.)


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
