### PR TITLE
[Merged by Bors] - feat(Analysis/Analytic): characterization of order

### DIFF
--- a/Mathlib/Analysis/Analytic/Order.lean
+++ b/Mathlib/Analysis/Analytic/Order.lean
@@ -90,6 +90,31 @@ lemma apply_eq_zero_of_order_toNat_ne_zero (hf : AnalyticAt 𝕜 f z₀) :
   simp [hf.order_eq_zero_iff]
   tauto
 
+/-- Characterization of which natural numbers are `≤ hf.order`. Useful for avoiding case splits,
+since it applies whether or not the order is `∞`. -/
+lemma natCast_le_order_iff (hf : AnalyticAt 𝕜 f z₀) {n : ℕ} :
+    n ≤ hf.order ↔ ∃ g, AnalyticAt 𝕜 g z₀ ∧ ∀ᶠ z in 𝓝 z₀, f z = (z - z₀) ^ n • g z := by
+  unfold order
+  split_ifs with h
+  · simpa using ⟨0, analyticAt_const .., by simpa⟩
+  · let m := (hf.exists_eventuallyEq_pow_smul_nonzero_iff.mpr h).choose
+    obtain ⟨g, hg, hg_ne, hm⟩ : ∃ g, AnalyticAt 𝕜 g z₀ ∧ g z₀ ≠ 0 ∧
+        ∀ᶠ z in 𝓝 z₀, f z = (z - z₀) ^ m • g z :=
+      (hf.exists_eventuallyEq_pow_smul_nonzero_iff.mpr h).choose_spec
+    rw [ENat.coe_le_coe]
+    refine ⟨fun hmn ↦ ⟨fun z ↦ (z - z₀) ^ (m - n) • g z, by fun_prop, ?_⟩, fun ⟨h, hh, hfh⟩ ↦ ?_⟩
+    · filter_upwards [hm] with z hz using by rwa [← mul_smul, ← pow_add, Nat.add_sub_of_le hmn]
+    · contrapose! hg_ne
+      have : ContinuousAt (fun z ↦ (z - z₀) ^ (n - m) • h z) z₀ := by fun_prop
+      rw [tendsto_nhds_unique_of_eventuallyEq (l := 𝓝[≠] z₀)
+        hg.continuousAt.continuousWithinAt this.continuousWithinAt ?_]
+      · simp [m, Nat.sub_ne_zero_of_lt hg_ne]
+      · filter_upwards [self_mem_nhdsWithin, hm.filter_mono nhdsWithin_le_nhds,
+          hfh.filter_mono nhdsWithin_le_nhds] with z hz hf' hf''
+        rw [← inv_smul_eq_iff₀ (pow_ne_zero _ <| sub_ne_zero_of_ne hz), hf'', smul_comm,
+          ← mul_smul] at hf'
+        rw [pow_sub₀ _ (sub_ne_zero_of_ne hz) (by omega), ← hf']
+
 /-!
 ## Vanishing Order at a Point: Behaviour under Ring Operations
 
@@ -119,14 +144,12 @@ theorem order_mul {f g : 𝕜 → 𝕜} (hf : AnalyticAt 𝕜 f z₀) (hg : Anal
   obtain ⟨g₁, h₁g₁, h₂g₁, h₃g₁⟩ := hf.order_ne_top_iff.1 h₂f
   obtain ⟨g₂, h₁g₂, h₂g₂, h₃g₂⟩ := hg.order_ne_top_iff.1 h₂g
   rw [← ENat.coe_toNat h₂f, ← ENat.coe_toNat h₂g, ← ENat.coe_add, (hf.mul hg).order_eq_nat_iff]
-  use g₁ * g₂, by exact h₁g₁.mul h₁g₂
+  use g₁ * g₂, h₁g₁.mul h₁g₂
   constructor
-  · simp
-    tauto
-  · obtain ⟨t, h₁t, h₂t, h₃t⟩ := eventually_nhds_iff.1 h₃g₁
-    obtain ⟨s, h₁s, h₂s, h₃s⟩ := eventually_nhds_iff.1 h₃g₂
-    exact eventually_nhds_iff.2
-      ⟨t ∩ s, fun y hy ↦ (by simp [h₁t y hy.1, h₁s y hy.2]; ring), h₂t.inter h₂s, h₃t, h₃s⟩
+  · simp_all
+  · filter_upwards [h₃g₁, h₃g₂] with z hz₁ hz₂
+    simp [hz₁, hz₂, add_pow]
+    ring
 
 /-- The order multiplies by `n` when taking an analytic function to its `n`th power. -/
 theorem order_pow {f : 𝕜 → 𝕜} (hf : AnalyticAt 𝕜 f z₀) {n : ℕ} :

--- a/Mathlib/Analysis/Analytic/Order.lean
+++ b/Mathlib/Analysis/Analytic/Order.lean
@@ -98,9 +98,7 @@ lemma natCast_le_order_iff (hf : AnalyticAt 𝕜 f z₀) {n : ℕ} :
   split_ifs with h
   · simpa using ⟨0, analyticAt_const .., by simpa⟩
   · let m := (hf.exists_eventuallyEq_pow_smul_nonzero_iff.mpr h).choose
-    obtain ⟨g, hg, hg_ne, hm⟩ : ∃ g, AnalyticAt 𝕜 g z₀ ∧ g z₀ ≠ 0 ∧
-        ∀ᶠ z in 𝓝 z₀, f z = (z - z₀) ^ m • g z :=
-      (hf.exists_eventuallyEq_pow_smul_nonzero_iff.mpr h).choose_spec
+    obtain ⟨g, hg, hg_ne, hm⟩ := (hf.exists_eventuallyEq_pow_smul_nonzero_iff.mpr h).choose_spec
     rw [ENat.coe_le_coe]
     refine ⟨fun hmn ↦ ⟨fun z ↦ (z - z₀) ^ (m - n) • g z, by fun_prop, ?_⟩, fun ⟨h, hh, hfh⟩ ↦ ?_⟩
     · filter_upwards [hm] with z hz using by rwa [← mul_smul, ← pow_add, Nat.add_sub_of_le hmn]


### PR DESCRIPTION
Alternative characterization of the order of vanishing of analytic functions which avoids case splits on `ENat`. Also golf a proof using `filter_upwards`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
