### PR TITLE
feat(Topology): add API for Hereditarily Lindelof spaces

### DIFF
--- a/Mathlib/Topology/Compactness/Lindelof.lean
+++ b/Mathlib/Topology/Compactness/Lindelof.lean
@@ -743,9 +743,14 @@ instance (priority := 100) SecondCountableTopology.toHereditarilyLindelof
     use t, htc
     exact subset_of_subset_of_eq hcover (id htu.symm)
 
+theorem Set.Countable.isHereditarilyLindelof {s : Set X} (hs : s.Countable) :
+    IsHereditarilyLindelof s := fun _ hst =>
+  have := (hs.mono hst).to_subtype
+  isLindelof_iff_LindelofSpace.2 inferInstance
+
 instance (priority := 100) Countable.toHereditarilyLindelof [Countable X] :
     HereditarilyLindelofSpace X where
-  isHereditarilyLindelof_univ _ _ := isLindelof_iff_LindelofSpace.2 inferInstance
+  isHereditarilyLindelof_univ := Set.countable_univ.isHereditarilyLindelof
 
 lemma eq_open_union_countable [HereditarilyLindelofSpace X] {ι : Type u} (U : ι → Set X)
     (h : ∀ i, IsOpen (U i)) : ∃ t : Set ι, t.Countable ∧ ⋃ i∈t, U i = ⋃ i, U i := by

--- a/Mathlib/Topology/Compactness/Lindelof.lean
+++ b/Mathlib/Topology/Compactness/Lindelof.lean
@@ -915,12 +915,16 @@ theorem HereditarilyLindelofSpace.of_continuous_surjective {f : X → Y} [Heredi
     rw [← Set.image_univ_of_surjective hsur]
     exact IsHereditarilyLindelof.image isHereditarilyLindelof_univ hf
 
-lemma eq_open_union_countable [HereditarilyLindelofSpace X] {ι : Type u} (U : ι → Set X)
-    (h : ∀ i, IsOpen (U i)) : ∃ t : Set ι, t.Countable ∧ ⋃ i ∈ t, U i = ⋃ i, U i := by
+lemma open_union_eq_countable_union [HereditarilyLindelofSpace X] {ι : Type u} (U : ι → Set X)
+    (h : ∀ i, IsOpen (U i)) : ∃ t : Set ι, t.Countable ∧ ⋃ i, U i = ⋃ i ∈ t, U i := by
   have := isHereditarilyLindelof_univ.isLindelof_subset (subset_univ (⋃ i, U i))
   rcases isLindelof_iff_countable_subcover.mp this U h (Eq.subset rfl) with ⟨t, ⟨htc, htu⟩⟩
-  use t, htc
-  apply eq_of_subset_of_subset (iUnion₂_subset_iUnion (fun i ↦ i ∈ t) fun i ↦ U i) htu
+  exact ⟨t, htc, htu.antisymm (iUnion₂_subset_iUnion (· ∈ t) U)⟩
+
+@[deprecated open_union_eq_countable_union (since := "2025-04-20")]
+lemma eq_open_union_countable [HereditarilyLindelofSpace X] {ι : Type u} (U : ι → Set X)
+    (h : ∀ i, IsOpen (U i)) : ∃ t : Set ι, t.Countable ∧ ⋃ i ∈ t, U i = ⋃ i, U i := by
+  simpa only [eq_comm] using open_union_eq_countable_union U h
 
 instance Subtype.HereditarilyLindelofSpace
     [HereditarilyLindelofSpace X] (p : X → Prop) : HereditarilyLindelofSpace {x // p x} := by

--- a/Mathlib/Topology/Compactness/Lindelof.lean
+++ b/Mathlib/Topology/Compactness/Lindelof.lean
@@ -730,7 +730,7 @@ theorem IsHereditarilyLindelof.image_of_continuousOn {f : X → Y} (hs : IsHered
 
 /-- A continuous image of a Hereditraily Lindelöf set is a
 Hereditarily Lindelöf set within the codomain. -/
-theorem IsHereditarilyLindelof.image {f : X → Y} (hs : IsHereditarilyLindelof s)
+protected theorem IsHereditarilyLindelof.image {f : X → Y} (hs : IsHereditarilyLindelof s)
     (hf : Continuous f) : IsHereditarilyLindelof (f '' s) :=
   hs.image_of_continuousOn hf.continuousOn
 
@@ -739,12 +739,12 @@ theorem Set.Subsingleton.isHereditarilyLindelof (hs : s.Subsingleton) : IsHeredi
 
 /-- The empty set is a Hereditarily Lindelof set. -/
 @[simp]
-theorem isHereditarilyLindelof_empty : IsHereditarilyLindelof (∅ : Set X) :=
+protected theorem IsHereditarilyLindelof.empty : IsHereditarilyLindelof (∅ : Set X) :=
   subsingleton_empty.isHereditarilyLindelof
 
 /-- A singleton set is a Lindelof set. -/
 @[simp]
-theorem isHereditarilyLindelof_singleton {x : X} : IsHereditarilyLindelof ({x} : Set X) :=
+protected theorem IsHereditarilyLindelof.singleton {x : X} : IsHereditarilyLindelof ({x} : Set X) :=
   subsingleton_singleton.isHereditarilyLindelof
 
 theorem Set.Countable.isHereditarilyLindelof_biUnion {s : Set ι} {f : ι → Set X} (hs : s.Countable)
@@ -752,6 +752,8 @@ theorem Set.Countable.isHereditarilyLindelof_biUnion {s : Set ι} {f : ι → Se
   intro t hst
   rw [← inter_eq_left.mpr hst, inter_iUnion₂]
   exact hs.isLindelof_biUnion fun i hi => (hf i hi).isLindelof_subset inter_subset_right
+
+protected alias IsHereditarilyLindelof.biUnion := Set.Countable.isHereditarilyLindelof_biUnion
 
 theorem Set.Finite.isHereditarilyLindelof_biUnion {s : Set ι} {f : ι → Set X} (hs : s.Finite)
     (hf : ∀ i ∈ s, IsHereditarilyLindelof (f i)) : IsHereditarilyLindelof (⋃ i ∈ s, f i) :=
@@ -761,7 +763,7 @@ theorem Finset.isHereditarilyLindelof_biUnion (s : Finset ι) {f : ι → Set X}
     (hf : ∀ i ∈ s, IsHereditarilyLindelof (f i)) : IsHereditarilyLindelof (⋃ i ∈ s, f i) :=
   s.finite_toSet.isHereditarilyLindelof_biUnion hf
 
-theorem isHereditrailyLindelof_accumulate {K : ℕ → Set X}
+protected theorem IsHereditrailyLindelof.accumulate {K : ℕ → Set X}
     (hK : ∀ n, IsHereditarilyLindelof (K n)) (n : ℕ) : IsHereditarilyLindelof (Accumulate K n) :=
   (finite_le_nat n).isHereditarilyLindelof_biUnion fun k _ => hK k
 
@@ -769,17 +771,18 @@ theorem Set.Countable.isHereditarilyLindelof_sUnion {S : Set (Set X)} (hf : S.Co
     (hc : ∀ s ∈ S, IsHereditarilyLindelof s) : IsHereditarilyLindelof (⋃₀ S) := by
   rw [sUnion_eq_biUnion]; exact hf.isHereditarilyLindelof_biUnion hc
 
+protected alias IsHereditarilyLindelof.sUnion := Set.Countable.isHereditarilyLindelof_sUnion
+
 theorem Set.Finite.isHereditarilyLindelof_sUnion {S : Set (Set X)} (hf : S.Finite)
     (hc : ∀ s ∈ S, IsHereditarilyLindelof s) : IsHereditarilyLindelof (⋃₀ S) := by
   rw [sUnion_eq_biUnion]; exact hf.isHereditarilyLindelof_biUnion hc
 
-theorem isHereditarilyLindelof_iUnion {ι : Sort*} {f : ι → Set X} [Countable ι]
+protected theorem IsHereditarilyLindelof.iUnion {ι : Sort*} {f : ι → Set X} [Countable ι]
     (h : ∀ i, IsHereditarilyLindelof (f i)) : IsHereditarilyLindelof (⋃ i, f i) :=
   (countable_range f).isHereditarilyLindelof_sUnion (forall_mem_range.2 h)
 
 theorem Set.Countable.isHereditarilyLindelof (hs : s.Countable) : IsHereditarilyLindelof s :=
-  biUnion_of_singleton s ▸ hs.isHereditarilyLindelof_biUnion
-    fun _ _ => isHereditarilyLindelof_singleton
+  biUnion_of_singleton s ▸ hs.isHereditarilyLindelof_biUnion fun _ _ => .singleton
 
 theorem Set.Finite.isHereditarilyLindelof (hs : s.Finite) : IsHereditarilyLindelof s :=
   hs.countable.isHereditarilyLindelof
@@ -790,11 +793,11 @@ theorem isHereditarilyLindelof_iff_countable [DiscreteTopology X] :
 
 theorem IsHereditarilyLindelof.union (hs : IsHereditarilyLindelof s)
     (ht : IsHereditarilyLindelof t) : IsHereditarilyLindelof (s ∪ t) := by
-  rw [union_eq_iUnion]; exact isHereditarilyLindelof_iUnion fun b => by cases b <;> assumption
+  rw [union_eq_iUnion]; exact .iUnion fun b => by cases b <;> assumption
 
 protected theorem IsHereditarilyLindelof.insert (hs : IsHereditarilyLindelof s) (a) :
     IsHereditarilyLindelof (insert a s) :=
-  isHereditarilyLindelof_singleton.union hs
+  .union .singleton hs
 
 /-- If `f : X → Y` is an inducing map, the image `f '' s` of a set `s` is Hereditarily Lindelöf
   if and only if `s` is Hereditarily Lindelöf. -/
@@ -815,7 +818,7 @@ an inducing map is a Hereditarily Lindelöf set. -/
 theorem Topology.IsInducing.isHereditarilyLindelof_preimage {f : X → Y} (hf : IsInducing f)
     {K : Set Y} (hK : IsHereditarilyLindelof K) : IsHereditarilyLindelof (f ⁻¹' K) := by
   rw [hf.isHereditarilyLindelof_iff, image_preimage_eq_inter_range]
-  exact hK.isHereditarilyLindelof_subset inter_subset_left
+  exact hK.subset inter_subset_left
 
 /-- The preimage of a Lindelöf set under a closed embedding is a Lindelöf set. -/
 theorem Topology.IsEmbedding.isHereditarilyLindelof_preimage {f : X → Y} (hf : IsEmbedding f)
@@ -844,13 +847,15 @@ class HereditarilyLindelofSpace (X : Type*) [TopologicalSpace X] : Prop where
 
 export HereditarilyLindelofSpace (isHereditarilyLindelof_univ)
 
+protected alias IsHereditarilyLindelof.univ := isHereditarilyLindelof_univ
+
 theorem isHereditarilyLindelof_univ_iff :
     IsHereditarilyLindelof (univ : Set X) ↔ HereditarilyLindelofSpace X :=
   ⟨fun h => ⟨h⟩, fun h => h.1⟩
 
 theorem isHereditarilyLindelof_range [HereditarilyLindelofSpace X] {f : X → Y} (hf : Continuous f) :
     IsHereditarilyLindelof (range f) := by
-  rw [← image_univ]; exact isHereditarilyLindelof_univ.image hf
+  rw [← image_univ]; exact .image .univ hf
 
 theorem isHereditarilyLindelof_iff_HereditarilyLindelofSpace :
     IsHereditarilyLindelof s ↔ HereditarilyLindelofSpace s :=
@@ -864,7 +869,7 @@ protected theorem Topology.IsEmbedding.HereditarilyLindelofSpace
     (hf : IsEmbedding f) : HereditarilyLindelofSpace X where
   isHereditarilyLindelof_univ := by
     rw [hf.isInducing.isHereditarilyLindelof_iff]
-    exact isHereditarilyLindelof_univ.isHereditarilyLindelof_subset (subset_univ (f '' univ))
+    exact .subset .univ (subset_univ (f '' univ))
 
 /-- The disjoint union of two Hereditarily Lindelöf spaces is Hereditarily Lindelöf. -/
 instance [HereditarilyLindelofSpace X] [HereditarilyLindelofSpace Y] :
@@ -876,7 +881,7 @@ instance [HereditarilyLindelofSpace X] [HereditarilyLindelofSpace Y] :
 
 instance (priority := 100) HereditarilyLindelof.to_Lindelof [HereditarilyLindelofSpace X] :
     LindelofSpace X where
-  isLindelof_univ := HereditarilyLindelofSpace.isHereditarilyLindelof_univ.isLindelof
+  isLindelof_univ := isHereditarilyLindelof_univ.isLindelof
 
 @[deprecated "Use `isHereditarilyLindelof_univ` and `IsHereditarilyLindelof.isLindelof_subset`"
   (since := "2025-04-19")]
@@ -913,7 +918,7 @@ theorem HereditarilyLindelofSpace.of_continuous_surjective {f : X → Y} [Heredi
     (hf : Continuous f) (hsur : Function.Surjective f) : HereditarilyLindelofSpace Y where
   isHereditarilyLindelof_univ := by
     rw [← Set.image_univ_of_surjective hsur]
-    exact IsHereditarilyLindelof.image isHereditarilyLindelof_univ hf
+    exact .image .univ hf
 
 lemma exists_countable_biUnion_eq_iUnion_of_forall_isOpen [HereditarilyLindelofSpace X]
     {ι : Type u} (U : ι → Set X) (h : ∀ i, IsOpen (U i)) :
@@ -928,6 +933,6 @@ alias eq_open_union_countable := exists_countable_biUnion_eq_iUnion_of_forall_is
 instance Subtype.instHereditarilyLindelofSpace
     [HereditarilyLindelofSpace X] (p : X → Prop) : HereditarilyLindelofSpace {x // p x} := by
   apply isHereditarilyLindelof_iff_HereditarilyLindelofSpace.mp
-  exact isHereditarilyLindelof_univ.isHereditarilyLindelof_subset (subset_univ {x | p x})
+  exact .subset .univ (subset_univ {x | p x})
 
 end Lindelof

--- a/Mathlib/Topology/Compactness/Lindelof.lean
+++ b/Mathlib/Topology/Compactness/Lindelof.lean
@@ -692,13 +692,13 @@ instance {X : ι → Type*} [Countable ι] [∀ i, TopologicalSpace (X i)] [∀ 
     rw [Sigma.univ]
     exact isLindelof_iUnion fun i => isLindelof_range continuous_sigmaMk
 
-instance Quot.LindelofSpace {r : X → X → Prop} [LindelofSpace X] : LindelofSpace (Quot r) where
+instance Quot.instLindelofSpace {r : X → X → Prop} [LindelofSpace X] : LindelofSpace (Quot r) where
   isLindelof_univ := by
     rw [← range_quot_mk]
     exact isLindelof_range continuous_quot_mk
 
-instance Quotient.LindelofSpace {s : Setoid X} [LindelofSpace X] : LindelofSpace (Quotient s) :=
-  Quot.LindelofSpace
+instance Quotient.instLindelofSpace {s : Setoid X} [LindelofSpace X] : LindelofSpace (Quotient s) :=
+  Quot.instLindelofSpace
 
 /-- A continuous image of a Lindelöf set is a Lindelöf set within the codomain. -/
 theorem LindelofSpace.of_continuous_surjective {f : X → Y} [LindelofSpace X] (hf : Continuous f)
@@ -898,15 +898,15 @@ instance (priority := 100) Countable.toHereditarilyLindelofSpace [Countable X] :
     HereditarilyLindelofSpace X where
   isHereditarilyLindelof_univ := Set.countable_univ.isHereditarilyLindelof
 
-instance Quot.HereditarilyLindelofSpace {r : X → X → Prop} [HereditarilyLindelofSpace X] :
+instance Quot.instHereditarilyLindelofSpace {r : X → X → Prop} [HereditarilyLindelofSpace X] :
     HereditarilyLindelofSpace (Quot r) where
   isHereditarilyLindelof_univ := by
     rw [← range_quot_mk]
     exact isHereditarilyLindelof_range continuous_quot_mk
 
-instance Quotient.HereditarilyLindelofSpace {s : Setoid X} [HereditarilyLindelofSpace X] :
+instance Quotient.instHereditarilyLindelofSpace {s : Setoid X} [HereditarilyLindelofSpace X] :
     HereditarilyLindelofSpace (Quotient s) :=
-  Quot.HereditarilyLindelofSpace
+  Quot.instHereditarilyLindelofSpace
 
 /-- A continuous image of a Hereditarily Lindelöf space is a Hereditarily Lindelöf space. -/
 theorem HereditarilyLindelofSpace.of_continuous_surjective {f : X → Y} [HereditarilyLindelofSpace X]
@@ -925,7 +925,7 @@ lemma exists_countable_biUnion_eq_iUnion_of_forall_isOpen [HereditarilyLindelofS
 @[deprecated (since := "2025-04-20")]
 alias eq_open_union_countable := exists_countable_biUnion_eq_iUnion_of_forall_isOpen
 
-instance Subtype.HereditarilyLindelofSpace
+instance Subtype.instHereditarilyLindelofSpace
     [HereditarilyLindelofSpace X] (p : X → Prop) : HereditarilyLindelofSpace {x // p x} := by
   apply isHereditarilyLindelof_iff_HereditarilyLindelofSpace.mp
   exact isHereditarilyLindelof_univ.isHereditarilyLindelof_subset (subset_univ {x | p x})

--- a/Mathlib/Topology/Compactness/Lindelof.lean
+++ b/Mathlib/Topology/Compactness/Lindelof.lean
@@ -915,16 +915,15 @@ theorem HereditarilyLindelofSpace.of_continuous_surjective {f : X → Y} [Heredi
     rw [← Set.image_univ_of_surjective hsur]
     exact IsHereditarilyLindelof.image isHereditarilyLindelof_univ hf
 
-lemma open_union_eq_countable_union [HereditarilyLindelofSpace X] {ι : Type u} (U : ι → Set X)
-    (h : ∀ i, IsOpen (U i)) : ∃ t : Set ι, t.Countable ∧ ⋃ i, U i = ⋃ i ∈ t, U i := by
+lemma exists_countable_biUnion_eq_iUnion_of_forall_isOpen [HereditarilyLindelofSpace X]
+    {ι : Type u} (U : ι → Set X) (h : ∀ i, IsOpen (U i)) :
+    ∃ t : Set ι, t.Countable ∧ ⋃ i ∈ t, U i = ⋃ i, U i := by
   have := isHereditarilyLindelof_univ.isLindelof_subset (subset_univ (⋃ i, U i))
   rcases isLindelof_iff_countable_subcover.mp this U h (Eq.subset rfl) with ⟨t, ⟨htc, htu⟩⟩
-  exact ⟨t, htc, htu.antisymm (iUnion₂_subset_iUnion (· ∈ t) U)⟩
+  exact ⟨t, htc, (iUnion₂_subset_iUnion (· ∈ t) U).antisymm htu⟩
 
-@[deprecated open_union_eq_countable_union (since := "2025-04-20")]
-lemma eq_open_union_countable [HereditarilyLindelofSpace X] {ι : Type u} (U : ι → Set X)
-    (h : ∀ i, IsOpen (U i)) : ∃ t : Set ι, t.Countable ∧ ⋃ i ∈ t, U i = ⋃ i, U i := by
-  simpa only [eq_comm] using open_union_eq_countable_union U h
+@[deprecated (since := "2025-04-20")]
+alias eq_open_union_countable := exists_countable_biUnion_eq_iUnion_of_forall_isOpen
 
 instance Subtype.HereditarilyLindelofSpace
     [HereditarilyLindelofSpace X] (p : X → Prop) : HereditarilyLindelofSpace {x // p x} := by

--- a/Mathlib/Topology/Compactness/Lindelof.lean
+++ b/Mathlib/Topology/Compactness/Lindelof.lean
@@ -714,7 +714,7 @@ def IsHereditarilyLindelof (s : Set X) :=
 lemma IsHereditarilyLindelof.isLindelof_subset (hs : IsHereditarilyLindelof s) (ht : t ⊆ s) :
     IsLindelof t := hs t ht
 
-lemma IsHereditarilyLindelof.isHereditarilyLindelof_subset (hs : IsHereditarilyLindelof s)
+protected lemma IsHereditarilyLindelof.subset (hs : IsHereditarilyLindelof s)
     (ht : t ⊆ s) : IsHereditarilyLindelof t := fun u hu => hs u (hu.trans ht)
 
 lemma IsHereditarilyLindelof.isLindelof (hs : IsHereditarilyLindelof s) :

--- a/Mathlib/Topology/Compactness/Lindelof.lean
+++ b/Mathlib/Topology/Compactness/Lindelof.lean
@@ -919,7 +919,7 @@ lemma exists_countable_biUnion_eq_iUnion_of_forall_isOpen [HereditarilyLindelofS
     {ι : Type u} (U : ι → Set X) (h : ∀ i, IsOpen (U i)) :
     ∃ t : Set ι, t.Countable ∧ ⋃ i ∈ t, U i = ⋃ i, U i := by
   have := isHereditarilyLindelof_univ.isLindelof_subset (subset_univ (⋃ i, U i))
-  rcases isLindelof_iff_countable_subcover.mp this U h (Eq.subset rfl) with ⟨t, ⟨htc, htu⟩⟩
+  rcases isLindelof_iff_countable_subcover.mp this U h subset_rfl with ⟨t, htc, htu⟩
   exact ⟨t, htc, (iUnion₂_subset_iUnion (· ∈ t) U).antisymm htu⟩
 
 @[deprecated (since := "2025-04-20")]

--- a/Mathlib/Topology/Compactness/Lindelof.lean
+++ b/Mathlib/Topology/Compactness/Lindelof.lean
@@ -743,6 +743,10 @@ instance (priority := 100) SecondCountableTopology.toHereditarilyLindelof
     use t, htc
     exact subset_of_subset_of_eq hcover (id htu.symm)
 
+instance (priority := 100) Countable.toHereditarilyLindelof [Countable X] :
+    HereditarilyLindelofSpace X where
+  isHereditarilyLindelof_univ _ _ := isLindelof_iff_LindelofSpace.2 inferInstance
+
 lemma eq_open_union_countable [HereditarilyLindelofSpace X] {ι : Type u} (U : ι → Set X)
     (h : ∀ i, IsOpen (U i)) : ∃ t : Set ι, t.Countable ∧ ⋃ i∈t, U i = ⋃ i, U i := by
   have : IsLindelof (⋃ i, U i) := HereditarilyLindelof_LindelofSets (⋃ i, U i)


### PR DESCRIPTION
Copies the stuff about Lindelof spaces to Hereditarily Lindelof spaces.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
