### PR TITLE
feat(Order): `NoBotOrder α` implies `NoMinOrder α` under `IsDirected α (· ≥ ·)`

### DIFF
--- a/Mathlib/Order/Directed.lean
+++ b/Mathlib/Order/Directed.lean
@@ -232,6 +232,20 @@ protected theorem IsMin.isBot [IsDirected α (· ≥ ·)] (h : IsMin a) : IsBot 
 protected theorem IsMax.isTop [IsDirected α (· ≤ ·)] (h : IsMax a) : IsTop a :=
   h.toDual.isBot
 
+theorem NoBotOrder.noMinOrder_of_isDirected [IsDirected α (· ≥ ·)] [NoBotOrder α] :
+    NoMinOrder α where
+  exists_lt x := by
+    obtain ⟨y, hxy⟩ := exists_not_ge x
+    obtain ⟨z, hzx, hzy⟩ := exists_le_le x y
+    exact ⟨z, lt_of_le_not_le hzx fun hxz => hxy (hxz.trans hzy)⟩
+
+theorem NoTopOrder.noMaxOrder_of_isDirected [IsDirected α (· ≤ ·)] [NoTopOrder α] :
+    NoMaxOrder α where
+  exists_gt x := by
+    obtain ⟨y, hyx⟩ := exists_not_le x
+    obtain ⟨z, hxz, hyz⟩ := exists_ge_ge x y
+    exact ⟨z, lt_of_le_not_le hxz fun hzx => hyx (hyz.trans hzx)⟩
+
 lemma DirectedOn.is_bot_of_is_min {s : Set α} (hd : DirectedOn (· ≥ ·) s)
     {m} (hm : m ∈ s) (hmin : ∀ a ∈ s, a ≤ m → m ≤ a) : ∀ a ∈ s, m ≤ a := fun a as =>
   let ⟨x, xs, xm, xa⟩ := hd m hm a as


### PR DESCRIPTION
Proves that `NoBotOrder α` implies `NoMinOrder α` under `IsDirected α (· ≥ ·)`, and also the dual theorem.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
