### PR TITLE
[Merged by Bors] - feat(to_additive (reorder := ..)): reorder arguments in `Prod.pow_mk`

### DIFF
--- a/Mathlib/Algebra/Notation/Prod.lean
+++ b/Mathlib/Algebra/Notation/Prod.lean
@@ -157,11 +157,8 @@ lemma pow_fst (p : α × β) (c : E) : (p ^ c).fst = p.fst ^ c := rfl
 @[to_additive existing (attr := simp) (reorder := 6 7) smul_snd]
 lemma pow_snd (p : α × β) (c : E) : (p ^ c).snd = p.snd ^ c := rfl
 
-/- Note that the `c` arguments to this lemmas cannot be in the more natural right-most positions due
-to limitations in `to_additive` and `to_additive_reorder`, which will silently fail to reorder more
-than two adjacent arguments -/
-@[to_additive existing (attr := simp) (reorder := 6 7) smul_mk]
-lemma pow_mk (c : E) (a : α) (b : β) : Prod.mk a b ^ c = Prod.mk (a ^ c) (b ^ c) := rfl
+@[to_additive existing (attr := simp) (reorder := 6 7 8) smul_mk]
+lemma pow_mk (a : α) (b : β) (c : E) : Prod.mk a b ^ c = Prod.mk (a ^ c) (b ^ c) := rfl
 
 @[to_additive existing (reorder := 6 7) smul_def]
 lemma pow_def (p : α × β) (c : E) : p ^ c = (p.1 ^ c, p.2 ^ c) := rfl


### PR DESCRIPTION
In #3632, to_additive gained the ability to reorder cycles of arguments. Thus `Prod.pow_mk` can now have the desired ordering of its arguments.

Actually, the `(reorder := 6 7)` that was there previously was incorrect. We should employ a check that `to_additive existing` does the correct thing, such as in #21719.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
