### PR TITLE
feat(SetTheory/ZFC): add Boolean algebra in ZFC

### DIFF
--- a/Mathlib/SetTheory/ZFC/Basic.lean
+++ b/Mathlib/SetTheory/ZFC/Basic.lean
@@ -278,9 +278,22 @@ theorem nonempty_mk_iff {x : PSet} : (mk x).Nonempty ↔ x.Nonempty := by
 theorem eq_empty (x : ZFSet.{u}) : x = ∅ ↔ ∀ y : ZFSet.{u}, y ∉ x := by
   simp [ZFSet.ext_iff]
 
+theorem nonempty_exists_iff {n : ZFSet} : n ≠ ∅ ↔ ∃ m, m ∈ n := by
+  simp [ZFSet.ext_iff]
+
+@[simp] theorem not_nonempty_is_empty {x : ZFSet} : ¬ x.Nonempty ↔ x = ∅ := by
+  rw [nonempty_def, not_exists, eq_empty]
+
 theorem eq_empty_or_nonempty (u : ZFSet) : u = ∅ ∨ u.Nonempty := by
   rw [eq_empty, ← not_exists]
   apply em'
+
+@[simp]
+theorem subset_of_empty (x : ZFSet) : x ⊆ ∅ → x = ∅ := by
+  intro h
+  ext z
+  simp [subset_def] at h
+  simp_all only [not_mem_empty]
 
 /-- `Insert x y` is the set `{x} ∪ y` -/
 protected def Insert : ZFSet → ZFSet → ZFSet :=
@@ -318,6 +331,12 @@ theorem mem_insert (x y : ZFSet) : x ∈ insert x y :=
 theorem mem_insert_of_mem {y z : ZFSet} (x) (h : z ∈ y) : z ∈ insert x y :=
   mem_insert_iff.2 <| Or.inr h
 
+theorem insert_mem {x y : ZFSet} (h : x ∈ y) : insert x y = y := by
+  ext1
+  rw [mem_insert_iff, or_iff_right_iff_imp]
+  rintro rfl
+  trivial
+
 @[simp]
 theorem toSet_insert (x y : ZFSet) : (insert x y).toSet = insert x y.toSet := by
   ext
@@ -326,6 +345,14 @@ theorem toSet_insert (x y : ZFSet) : (insert x y).toSet = insert x y.toSet := by
 @[simp]
 theorem mem_singleton {x y : ZFSet.{u}} : x ∈ @singleton ZFSet.{u} ZFSet.{u} _ y ↔ x = y :=
   Quotient.inductionOn₂ x y fun _ _ => PSet.mem_singleton.trans eq.symm
+
+theorem insert_comm {x y : ZFSet} : ({x, y} : ZFSet) = {y, x} := by
+  ext1
+  rw [mem_insert_iff, mem_insert_iff, mem_singleton, mem_singleton]
+  exact Or.comm
+
+theorem singleton_subset_mem_iff {x y : ZFSet} : {x} ⊆ y ↔ x ∈ y := by
+  simp [subset_def]
 
 @[simp]
 theorem toSet_singleton (x : ZFSet) : ({x} : ZFSet).toSet = {x} := by
@@ -406,6 +433,35 @@ theorem toSet_sep (a : ZFSet) (p : ZFSet → Prop) :
     (ZFSet.sep p a).toSet = { x ∈ a.toSet | p x } := by
   ext
   simp
+
+@[simp]
+theorem sep_empty_iff {A : ZFSet} {P : ZFSet → Prop} : A.sep P = ∅ ↔ (A = ∅ ∨ ∀ x ∈ A, ¬ P x) where
+  mp h := by classical
+    by_cases A_emp : A = ∅
+    · left; assumption
+    · right
+      intros x mem_x_A
+      by_contra contr
+      have : x ∈ A.sep P := by
+        rw [mem_sep]
+        exact ⟨mem_x_A, contr⟩
+      rw [h] at this
+      nomatch this, not_mem_empty _
+  mpr h := by classical
+    rcases h with rfl | h
+    · exact sep_empty P
+    · ext1 z
+      constructor
+      · intro hz
+        rw [mem_sep] at hz
+        nomatch h _ hz.left, hz.right
+      · intro hz
+        nomatch not_mem_empty z, hz
+
+theorem sep_subset_self {P : ZFSet → Prop} {a : ZFSet} : a.sep P ⊆ a := by
+  intros x hx
+  rw [mem_sep] at hx
+  exact hx.left
 
 /-- The powerset operation, the collection of subsets of a ZFC set -/
 def powerset : ZFSet → ZFSet :=
@@ -559,6 +615,14 @@ theorem mem_union {x y z : ZFSet.{u}} : z ∈ x ∪ y ↔ z ∈ x ∨ z ∈ y :=
   rw [← mem_toSet]
   simp
 
+theorem insert_def {x y : ZFSet} : insert x y = {x} ∪ y := by
+  ext1 z
+  rw [mem_insert_iff, mem_union, mem_singleton]
+
+theorem sUnion_insert {x : ZFSet} : (⋃₀ (insert x x) : ZFSet) = x ∪ (⋃₀ x : ZFSet) := by
+  ext1
+  simp only [mem_sUnion, mem_insert_iff, exists_eq_or_imp, mem_union]
+
 @[simp]
 theorem mem_inter {x y z : ZFSet.{u}} : z ∈ x ∩ y ↔ z ∈ x ∧ z ∈ y :=
   @mem_sep (fun z : ZFSet.{u} => z ∈ y) x z
@@ -570,6 +634,18 @@ theorem mem_diff {x y z : ZFSet.{u}} : z ∈ x \ y ↔ z ∈ x ∧ z ∉ y :=
 @[simp]
 theorem sUnion_pair {x y : ZFSet.{u}} : ⋃₀ ({x, y} : ZFSet.{u}) = x ∪ y :=
   rfl
+
+theorem sInter_pair {a b : ZFSet} : ⋂₀ {a, b} = a ∩ b := by
+  ext1 x
+  apply Iff.intro
+  · intro h
+    rw [mem_sInter (by simp only [nonempty_def, mem_insert_iff, exists_or_eq_left])] at h
+    simp only [mem_insert_iff, mem_singleton, forall_eq_or_imp, forall_eq] at h
+    rwa [← mem_inter] at h
+  · intro h
+    rw [mem_sInter (by simp only [nonempty_def, mem_insert_iff, exists_or_eq_left])]
+    simp only [mem_insert_iff, mem_singleton, forall_eq_or_imp, forall_eq]
+    rwa [← mem_inter]
 
 theorem mem_wf : @WellFounded ZFSet (· ∈ ·) :=
   (wellFounded_lift₂_iff (H := fun a b c d hx hy =>
@@ -705,6 +781,35 @@ theorem mem_prod {x y z : ZFSet.{u}} : z ∈ prod x y ↔ ∃ a ∈ x, ∃ b ∈
 
 theorem pair_mem_prod {x y a b : ZFSet.{u}} : pair a b ∈ prod x y ↔ a ∈ x ∧ b ∈ y := by
   simp
+
+@[simp]
+theorem prod_empty_right {x : ZFSet} : x.prod ∅ = ∅ := by
+  ext z; simp
+
+@[simp]
+theorem prod_empty_left {x : ZFSet} : ZFSet.prod ∅ x = ∅ := by
+  ext z; simp
+
+theorem prod_subset_prod_iff {A C B D: ZFSet} (hA : A ≠ ∅) (hC : C ≠ ∅) :
+  A.prod C ⊆ B.prod D ↔ A ⊆ B ∧ C ⊆ D := by
+  simp_rw [subset_def]
+  constructor
+  · intro h
+    and_intros
+    · intro z zA
+      obtain ⟨c, hc⟩ := nonempty_exists_iff.mp hC
+      specialize h <| pair_mem_prod.mpr ⟨zA, hc⟩
+      rw [pair_mem_prod] at h
+      exact h.1
+    · intro z zC
+      obtain ⟨a, ha⟩ := nonempty_exists_iff.mp hA
+      specialize h <| pair_mem_prod.mpr ⟨ha, zC⟩
+      rw [pair_mem_prod] at h
+      exact h.2
+  · rintro ⟨hAB, hCD⟩ z hz
+    rw [mem_prod] at hz
+    obtain ⟨a, ha, c, hc, rfl⟩ := hz
+    exact pair_mem_prod.mpr ⟨hAB ha, hCD hc⟩
 
 /-- `isFunc x y f` is the assertion that `f` is a subset of `x × y` which relates to each element
 of `x` a unique element of `y`, so that we can consider `f` as a ZFC function `x → y`. -/

--- a/Mathlib/SetTheory/ZFC/Booleans.lean
+++ b/Mathlib/SetTheory/ZFC/Booleans.lean
@@ -1,0 +1,515 @@
+/-
+Copyright (c) 2025 Vincent Trélat. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Vincent Trélat
+-/
+import Mathlib.SetTheory.ZFC.Basic
+
+/-!
+# Boolean algebra on `ZFSet`
+
+This file defines the boolean algebra on `ZFSet` and the type of booleans `ZFBool`.
+It defines the following operations:
+- `not` : negation
+- `and` : conjunction
+- `or` : disjunction
+- `true` : ZF true value
+- `false` : ZF false value
+- `𝔹` : set of ZF booleans
+- `toBool` : conversion from `ZFBool` to `Bool`
+- `ofBool` : conversion from `Bool` to `ZFBool`
+
+-/
+
+noncomputable section
+
+/-! ## Preliminary definitions -/
+
+namespace ZFSet
+
+/-- Symmetric difference of two sets, denoted by `Δ`. -/
+def symmDiff (p q : ZFSet) : ZFSet := (p \ q) ∪ (q \ p)
+infix:70 " Δ " => symmDiff
+
+@[simp]
+theorem mem_symmDiff (x p q : ZFSet) : x ∈ p Δ q ↔ (x ∈ p ∧ x ∉ q) ∨ (x ∈ q ∧ x ∉ p) := by
+  simp only [symmDiff, mem_union, mem_diff]
+
+@[simp]
+theorem symmDiff_empty (p : ZFSet) : p Δ ∅ = p := by
+  ext x
+  simp only [mem_symmDiff, not_mem_empty, not_false_eq_true, and_true, false_and, or_false]
+
+theorem symmDiff_comm (p q : ZFSet) : p Δ q = q Δ p := by
+  ext x
+  simp only [mem_symmDiff]
+  exact Or.comm
+
+@[simp]
+theorem symmDiff_self (p : ZFSet) : p Δ p = ∅ := by
+  ext x
+  simp only [mem_symmDiff, and_not_self, or_self, not_mem_empty]
+
+section Booleans
+
+/-! ## ZF Boolean Algebra -/
+
+/-- False value defined as the empty set. -/
+abbrev zffalse : ZFSet := ∅
+/-- True value defined as the singleton containing the empty set. -/
+abbrev zftrue : ZFSet := {zffalse}
+/-- Set of ZF booleans, defined as the set containing `zffalse` and `zftrue`. -/
+abbrev 𝔹 : ZFSet := {zffalse,zftrue}
+/-- Type of ZF booleans. -/
+abbrev ZFBool := { x // x ∈ 𝔹 }
+
+theorem zftrue_ne_zffalse : zftrue ≠ zffalse := by
+  intro h
+  rw [ZFSet.ext_iff, zffalse, zftrue] at h
+  specialize h ∅
+  rw [mem_singleton] at h
+  nomatch h.mp rfl
+
+namespace ZFBool
+
+theorem zftrue_mem_𝔹 : zftrue ∈ 𝔹 := by
+  rw [mem_insert_iff, mem_singleton]
+  exact Or.inr rfl
+
+theorem zffalse_mem_𝔹 : zffalse ∈ 𝔹 := by
+  rw [mem_insert_iff, mem_singleton]
+  exact Or.inl rfl
+
+lemma 𝔹.nonempty : ZFSet.𝔹 ≠ ∅ := by
+  intro h
+  rw [ZFSet.ext_iff] at h
+  simp only [ZFSet.not_mem_empty, iff_false] at h
+  nomatch h ZFSet.zffalse (ZFSet.ZFBool.zffalse_mem_𝔹)
+
+/-- False value, lifted on `ZFBool`. -/
+abbrev false : ZFBool := ⟨zffalse, zffalse_mem_𝔹⟩
+/-- True value, lifted on `ZFBool`. -/
+abbrev true : ZFBool := ⟨zftrue, zftrue_mem_𝔹⟩
+instance Bool_top : Top ZFBool := ⟨true⟩
+instance Bool_bot : Bot ZFBool := ⟨false⟩
+@[simp] theorem top_eq_true : ⊤ = true := rfl
+@[simp] theorem bot_eq_false : ⊥ = false := rfl
+theorem true_ne_false : (⊤ : ZFBool) ≠ ⊥ := by
+  intro h
+  rw [top_eq_true, bot_eq_false] at h
+  injection h with h
+  nomatch zftrue_ne_zffalse h
+
+@[simp]
+theorem mem_𝔹_iff (p : ZFSet) : p ∈ 𝔹 ↔ p = zffalse ∨ p = zftrue := by
+  rw [mem_insert_iff, mem_singleton]
+
+@[simp]
+theorem powerset_false : zffalse.powerset = zftrue := by
+  unfold zftrue zffalse
+  ext x
+  simp only [mem_powerset, mem_singleton]
+  apply Iff.intro
+  · exact ZFSet.subset_of_empty x
+  · exact (subset_of_subset_of_eq (fun _ a => a) ·)
+
+/--
+The enumeration of the powerset of `𝔹`.
+-/
+theorem powerset_𝔹_def :
+  ZFSet.𝔹.powerset = {∅, {ZFSet.zffalse}, {ZFSet.zftrue}, {ZFSet.zffalse, ZFSet.zftrue}} := by
+  ext1 x
+  constructor
+  · intro h
+    rw [ZFSet.mem_powerset, ZFSet.𝔹] at h
+    simp_rw [ZFSet.mem_insert_iff, ZFSet.mem_singleton]
+    by_cases hx : x = ∅
+    · left; exact hx
+    · right
+      by_cases hx' : ZFSet.zffalse ∈ x
+      · rw [← or_assoc, or_comm, ← or_assoc]
+        left
+        by_cases hx'' : ZFSet.zftrue ∈ x
+        · left
+          ext1 s
+          constructor
+          · intro hs; exact h hs
+          · intro hs; rcases (ZFSet.ZFBool.mem_𝔹_iff s).mp hs with rfl | rfl <;> assumption
+        · right
+          ext1 s
+          constructor
+          · intro hs
+            rw [ZFSet.mem_singleton]
+            rcases ZFSet.ZFBool.mem_𝔹_iff s |>.mp (h hs) with rfl | rfl <;> trivial
+          · intro hs
+            rcases ZFSet.mem_singleton.mp hs
+            exact hx'
+      · by_cases hx'' : ZFSet.zftrue ∈ x
+        · right
+          left
+          ext1 s
+          constructor
+          · intro hs
+            rw [ZFSet.mem_singleton]
+            rcases (ZFSet.ZFBool.mem_𝔹_iff s).mp (h hs) with rfl | rfl <;> trivial
+          · intro hs
+            rcases ZFSet.mem_singleton.mp hs
+            exact hx''
+        · simp_rw [ZFSet.subset_def, ZFSet.ZFBool.mem_𝔹_iff] at h
+          obtain ⟨w, hw⟩ := nonempty_exists_iff.mp hx
+          rcases h hw with rfl | rfl <;> contradiction
+  · intro hx
+    simp_rw [ZFSet.mem_insert_iff, ZFSet.mem_singleton] at hx
+    rcases hx with rfl | rfl | rfl | rfl <;> rw [ZFSet.mem_powerset]
+    · exact ZFSet.empty_subset ZFSet.𝔹
+    · intro _ hx
+      rw [ZFSet.ZFBool.mem_𝔹_iff]
+      rcases ZFSet.mem_singleton.mp hx
+      left; rfl
+    · intro _ hx
+      rw [ZFSet.ZFBool.mem_𝔹_iff]
+      rcases ZFSet.mem_singleton.mp hx
+      right; rfl
+
+/-- Boolean negation, defined as the symmetric difference with `true`. -/
+protected abbrev not (p : ZFBool) : ZFBool := ⟨true Δ p.1, by
+  let ⟨p, hp⟩ := p
+  rw [mem_𝔹_iff] at hp ⊢
+  rcases hp with rfl | rfl
+  · right
+    exact symmDiff_empty _
+  · left
+    exact symmDiff_self _⟩
+
+/-- Cases elimination for `ZFBool`. -/
+@[cases_eliminator]
+def casesOn {motive : ZFBool → Sort _}
+  (p : ZFBool)
+  (false : motive ⊥)
+  (true : motive ⊤) : motive p := by
+  obtain ⟨P, hP⟩ := p
+  have := mem_𝔹_iff P |>.mp hP
+  by_cases h : P = zffalse
+  · subst h
+    exact false
+  · have := Or.resolve_left this h
+    subst this
+    exact true
+
+/-- Boolean conjunction, defined as set intersection. -/
+protected abbrev and (p q : ZFBool) : ZFBool :=
+  let ⟨P, hP⟩ := p
+  let ⟨Q, hQ⟩ := q
+  ⟨P ∩ Q, by
+    rw [mem_𝔹_iff]
+    rw [mem_𝔹_iff] at hP hQ
+    cases hP <;> cases hQ <;> subst_eqs
+    · apply Or.inl
+      ext1
+      rw [mem_inter, and_self]
+    · apply Or.inl
+      ext1
+      simp only [mem_inter, not_mem_empty, false_and]
+    · apply Or.inl
+      ext1
+      simp only [mem_inter,  not_mem_empty, and_false]
+    · apply Or.inr
+      ext1
+      simp only [mem_inter, and_self]⟩
+
+infixl:55 " ⋀ " => ZFBool.and
+
+protected abbrev or (p q : ZFBool) : ZFBool :=
+  let ⟨P, hP⟩ := p
+  let ⟨Q, hQ⟩ := q
+  ⟨P ∪ Q,
+    by
+    rw [mem_𝔹_iff]
+    rw [mem_𝔹_iff] at hP hQ
+    cases hP <;> cases hQ <;> subst_eqs
+    · apply Or.inl
+      ext1
+      rw [mem_union, or_self]
+    · apply Or.inr
+      ext1
+      simp only [mem_union, not_mem_empty, mem_singleton, false_or]
+    · apply Or.inr
+      ext1
+      simp only [mem_union, not_mem_empty, or_false]
+    · apply Or.inr
+      ext1
+      simp only [mem_union, subset_of_empty, or_self]⟩
+
+infixl:55 " ⋁ " => ZFBool.or
+
+/-! ### Boolean algebra -/
+
+@[simp]
+theorem not_true_eq_false : ZFBool.not ⊤ = ⊥ := by
+  rw [Subtype.mk.injEq]
+  ext1
+  rw [mem_symmDiff]
+  constructor
+  · rintro (⟨l, r⟩ | ⟨l, r⟩) <;> nomatch r l
+  · intro h
+    nomatch not_mem_empty _ h
+
+@[simp]
+theorem not_false_eq_true : ZFBool.not ⊥ = ⊤ := by
+  rw [Subtype.mk.injEq]
+  ext1
+  rw [mem_symmDiff]
+  constructor
+  · rintro (⟨l, r⟩ | ⟨l, r⟩)
+    · exact l
+    · nomatch not_mem_empty _ l
+  · intro h
+    left
+    exact ⟨h, not_mem_empty _⟩
+
+theorem and_comm (p q : ZFBool) : p ⋀ q = q ⋀ p := by
+  obtain ⟨P, hP⟩ := p
+  obtain ⟨Q, hQ⟩ := q
+  rw [Subtype.mk.injEq]
+  ext1
+  repeat rw [mem_inter]
+  exact And.comm
+
+theorem and_assoc (p q r : ZFBool) : p ⋀ q ⋀ r = p ⋀ (q ⋀ r) := by
+  obtain ⟨P, hP⟩ := p
+  obtain ⟨Q, hQ⟩ := q
+  obtain ⟨R, hR⟩ := r
+  rw [Subtype.mk.injEq]
+  ext1
+  repeat rw [mem_inter]
+  exact _root_.and_assoc
+
+@[simp]
+theorem and_true (p : ZFBool) : p ⋀ ⊤ = p := by
+  obtain ⟨P, hP⟩ := p
+  rw [Subtype.mk.injEq]
+  ext1
+  rw [mem_inter]
+  rw [mem_𝔹_iff] at hP
+  rw [and_iff_left_iff_imp]
+  intro h
+  cases hP
+  · subst_eqs
+    simp only [not_mem_empty] at h
+  · subst_eqs
+    assumption
+
+@[simp]
+theorem and_false (p : ZFBool) : p ⋀ ⊥ = ⊥ := by
+  obtain ⟨P, hP⟩ := p
+  ext
+  rw [mem_inter]
+  rw [mem_𝔹_iff] at hP
+  rcases hP with rfl | rfl
+  · exact and_iff_left_of_imp id
+  · constructor
+    · rintro ⟨_, h⟩
+      exact h
+    · intro h
+      nomatch not_mem_empty _ h
+
+theorem and_iff (p q : ZFBool) : p ⋀ q = ⊤ ↔ p = ⊤ ∧ q = ⊤ := by
+  constructor
+  · intro h
+    cases q using casesOn with
+    | false =>
+      rw [and_false] at h
+      nomatch true_ne_false h.symm
+    | true => exact ⟨and_true p ▸ h, rfl⟩
+  · rintro (⟨rfl,rfl⟩)
+    rw [and_true]
+
+abbrev and_intro p q := and_iff p q |>.mpr
+
+theorem or_comm (p q : ZFBool) : p ⋁ q = q ⋁ p := by
+  obtain ⟨P, hP⟩ := p
+  obtain ⟨Q, hQ⟩ := q
+  rw [Subtype.mk.injEq]
+  ext1
+  repeat rw [mem_union]
+  exact Or.comm
+
+theorem or_assoc (p q r : ZFBool) : p ⋁ q ⋁ r = p ⋁ (q ⋁ r) := by
+  obtain ⟨P, hP⟩ := p
+  obtain ⟨Q, hQ⟩ := q
+  obtain ⟨R, hR⟩ := r
+  rw [Subtype.mk.injEq]
+  ext1
+  repeat rw [mem_union]
+  exact _root_.or_assoc
+
+theorem or_true (p : ZFBool) : p ⋁ ⊤ = ⊤ := by
+  obtain ⟨P, hP⟩ := p
+  rw [Subtype.mk.injEq]
+  ext1
+  rw [mem_union]
+  rw [mem_𝔹_iff] at hP
+  cases hP <;> subst_eqs
+  · simp only [not_mem_empty, mem_singleton, false_or, top_eq_true]
+  · exact or_iff_left_of_imp id
+
+theorem or_false (p : ZFBool) : p ⋁ ⊥ = p := by
+  obtain ⟨P, hP⟩ := p
+  rw [Subtype.mk.injEq]
+  ext1
+  rw [mem_union]
+  rw [mem_𝔹_iff] at hP
+  cases hP <;> subst_eqs
+  · rw [or_self]
+  · simp only [not_mem_empty, _root_.or_false]
+
+theorem or_iff (p q : ZFBool) : p ⋁ q = ⊤ ↔ p = ⊤ ∨ q = ⊤ := by
+  constructor
+  · intro h
+    cases p using casesOn with
+    | false =>
+      rw [or_comm, or_false] at h
+      exact Or.inr h
+    | true => exact Or.inl rfl
+  · intro h
+    rcases h with rfl | rfl
+    · rw [or_comm, or_true]
+    · rw [or_true]
+
+abbrev or_intro p q := or_iff p q |>.mpr
+
+open Classical in
+/-- Conversion of `ZFBool` to `Lean.Bool`. -/
+def toBool : ZFBool → Bool
+  | ⟨b, hb⟩ =>
+    if h : b = zftrue then Bool.true
+    else if h' : b = zffalse then Bool.false
+    else False.elim (by rcases (ZFBool.mem_𝔹_iff b |>.mp hb) <;> contradiction)
+
+theorem toBool_false : toBool ⊥ = Bool.false := by
+  rw [toBool]
+  split_ifs with h h'
+  · nomatch zftrue_ne_zffalse h.symm
+  · rfl
+  · nomatch h'
+
+theorem toBool_true : toBool ⊤ = Bool.true := by
+  rw [toBool]
+  split_ifs with h h'
+  · rfl
+  · nomatch h rfl
+  · nomatch h'
+
+theorem toBool_and (p q : ZFBool) : (p ⋀ q).toBool = (p.toBool && q.toBool) := by
+  cases p <;> cases q
+  · rw [and_false, toBool_false, Bool.false_and]
+  · rw [and_true, toBool_true, toBool_false, Bool.false_and]
+  · rw [and_false, toBool_true, toBool_false, Bool.and_false]
+  · rw [and_true, toBool_true, Bool.true_and]
+
+theorem toBool_or (p q : ZFBool) : (p ⋁ q).toBool = (p.toBool || q.toBool) := by
+  cases p <;> cases q
+  · rw [or_false, toBool_false, Bool.false_or]
+  · rw [or_true, toBool_true, toBool_false, Bool.or_true]
+  · rw [or_false, toBool_true, toBool_false, Bool.true_or]
+  · rw [or_true, toBool_true, Bool.true_or]
+
+theorem toBool_not (p : ZFBool) : toBool p.not = ¬ p.toBool := by
+  cases p
+  · rw [not_false_eq_true, toBool_true, toBool_false, Bool.false_eq_true, Bool.coe_sort_true]
+    exact _root_.not_false_eq_true.symm
+  · rw [not_true_eq_false, toBool_false, toBool_true, Bool.coe_false]
+    exact eq_false (fun h => h rfl) |>.symm
+
+theorem not_top_iff_bot {P : ZFBool} : P ≠ ⊤ ↔ P = ⊥ := by
+  constructor
+  · intro
+    cases P <;> trivial
+  · intro _ h
+    subst P
+    injections h
+    nomatch zftrue_ne_zffalse h.symm
+
+theorem not_bot_iff_top {P : ZFBool} : P ≠ ⊥ ↔ P = ⊤ := by
+  constructor
+  · intro
+    cases P <;> trivial
+  · intro _ h
+    subst P
+    injections h
+    nomatch zftrue_ne_zffalse h
+
+/-- Conversion of `Lean.Bool` to `ZFBool` -/
+def ofBool : Bool → ZFBool
+  | .true  => ⟨zftrue, ZFBool.zftrue_mem_𝔹⟩
+  | .false => ⟨zffalse, ZFBool.zffalse_mem_𝔹⟩
+
+theorem mem_ofBool_𝔹 (b : Bool) : (ofBool b).val ∈ 𝔹 := by
+  unfold 𝔹
+  rcases b <;> simp [ofBool]
+
+theorem sub_ofBool_singleton_𝔹 (b : Bool) : {(ofBool b).val} ⊆ 𝔹 := by
+  intro
+  rw [mem_singleton]
+  rintro rfl
+  exact mem_ofBool_𝔹 b
+
+theorem to_Bool_ofBool (b : Bool) : ZFBool.toBool (ofBool b) = b := by
+  cases b <;> rw [ofBool, ZFBool.toBool]
+  · split_ifs with h
+    · nomatch zftrue_ne_zffalse.symm h
+    · rfl
+    · generalize_proofs
+      contradiction
+  · split_ifs with h
+    · rfl
+    · contradiction
+    · generalize_proofs
+      contradiction
+
+theorem of_Bool_toBool (b : ZFBool) : ofBool b.toBool = b := by
+  obtain ⟨b, hb⟩ := b
+  rw [ZFBool.toBool, ofBool.eq_def]
+  split_ifs with h <;> (first | subst b | contradiction) <;> trivial
+
+theorem ofBool_decide_eq_true_iff {P : Prop} [Decidable P] : ofBool (decide P) = ⊤ ↔ P := by
+  constructor
+  · intro h
+    cases hP : decide P with
+    | false =>
+      rw [hP] at h
+      unfold ofBool at h
+      injection h with h
+      nomatch zftrue_ne_zffalse h.symm
+    | true => exact decide_eq_true_eq.mp hP
+  · intro h
+    cases hP : decide P with
+    | false =>
+      rw [Bool.decide_false_iff] at hP
+      contradiction
+    | true => rfl
+
+theorem ofBool_decide_eq_false_iff {P : Prop} [Decidable P] : ofBool (decide P) = ⊥ ↔ ¬P := by
+  constructor
+  · intro h
+    cases hP : decide P with
+    | false => exact decide_eq_false_iff_not.mp hP
+    | true =>
+      rw [hP] at h
+      unfold ofBool at h
+      injection h with h
+      nomatch zftrue_ne_zffalse h
+  · intro h
+    cases hP : decide P with
+    | false => rfl
+    | true =>
+      rw [Bool.decide_iff] at hP
+      contradiction
+
+end ZFBool
+
+end Booleans
+
+end ZFSet
+
+end


### PR DESCRIPTION
Add Boolean algebra implementation in ZFC set theory:
* Define a proper (sub)type `ZFBool` constructed above `ZFSet`
* Implement standard Boolean operations (conjunction, disjunction, negation)
* Prove standard Boolean algebra theorems and properties
* Add (sound) Boolean conversion functions (toBool/ofBool)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

- [ ] depends on: #24281

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
