### PR TITLE
feat(SetTheory/ZFC): add integers in ZFC

### DIFF
--- a/Mathlib/SetTheory/ZFC/Basic.lean
+++ b/Mathlib/SetTheory/ZFC/Basic.lean
@@ -278,9 +278,22 @@ theorem nonempty_mk_iff {x : PSet} : (mk x).Nonempty ↔ x.Nonempty := by
 theorem eq_empty (x : ZFSet.{u}) : x = ∅ ↔ ∀ y : ZFSet.{u}, y ∉ x := by
   simp [ZFSet.ext_iff]
 
+theorem nonempty_exists_iff {n : ZFSet} : n ≠ ∅ ↔ ∃ m, m ∈ n := by
+  simp [ZFSet.ext_iff]
+
+@[simp] theorem not_nonempty_is_empty {x : ZFSet} : ¬ x.Nonempty ↔ x = ∅ := by
+  rw [nonempty_def, not_exists, eq_empty]
+
 theorem eq_empty_or_nonempty (u : ZFSet) : u = ∅ ∨ u.Nonempty := by
   rw [eq_empty, ← not_exists]
   apply em'
+
+@[simp]
+theorem subset_of_empty (x : ZFSet) : x ⊆ ∅ → x = ∅ := by
+  intro h
+  ext z
+  simp [subset_def] at h
+  simp_all only [not_mem_empty]
 
 /-- `Insert x y` is the set `{x} ∪ y` -/
 protected def Insert : ZFSet → ZFSet → ZFSet :=
@@ -318,6 +331,12 @@ theorem mem_insert (x y : ZFSet) : x ∈ insert x y :=
 theorem mem_insert_of_mem {y z : ZFSet} (x) (h : z ∈ y) : z ∈ insert x y :=
   mem_insert_iff.2 <| Or.inr h
 
+theorem insert_mem {x y : ZFSet} (h : x ∈ y) : insert x y = y := by
+  ext1
+  rw [mem_insert_iff, or_iff_right_iff_imp]
+  rintro rfl
+  trivial
+
 @[simp]
 theorem toSet_insert (x y : ZFSet) : (insert x y).toSet = insert x y.toSet := by
   ext
@@ -326,6 +345,14 @@ theorem toSet_insert (x y : ZFSet) : (insert x y).toSet = insert x y.toSet := by
 @[simp]
 theorem mem_singleton {x y : ZFSet.{u}} : x ∈ @singleton ZFSet.{u} ZFSet.{u} _ y ↔ x = y :=
   Quotient.inductionOn₂ x y fun _ _ => PSet.mem_singleton.trans eq.symm
+
+theorem insert_comm {x y : ZFSet} : ({x, y} : ZFSet) = {y, x} := by
+  ext1
+  rw [mem_insert_iff, mem_insert_iff, mem_singleton, mem_singleton]
+  exact Or.comm
+
+theorem singleton_subset_mem_iff {x y : ZFSet} : {x} ⊆ y ↔ x ∈ y := by
+  simp [subset_def]
 
 @[simp]
 theorem toSet_singleton (x : ZFSet) : ({x} : ZFSet).toSet = {x} := by
@@ -406,6 +433,35 @@ theorem toSet_sep (a : ZFSet) (p : ZFSet → Prop) :
     (ZFSet.sep p a).toSet = { x ∈ a.toSet | p x } := by
   ext
   simp
+
+@[simp]
+theorem sep_empty_iff {A : ZFSet} {P : ZFSet → Prop} : A.sep P = ∅ ↔ (A = ∅ ∨ ∀ x ∈ A, ¬ P x) where
+  mp h := by classical
+    by_cases A_emp : A = ∅
+    · left; assumption
+    · right
+      intros x mem_x_A
+      by_contra contr
+      have : x ∈ A.sep P := by
+        rw [mem_sep]
+        exact ⟨mem_x_A, contr⟩
+      rw [h] at this
+      nomatch this, not_mem_empty _
+  mpr h := by classical
+    rcases h with rfl | h
+    · exact sep_empty P
+    · ext1 z
+      constructor
+      · intro hz
+        rw [mem_sep] at hz
+        nomatch h _ hz.left, hz.right
+      · intro hz
+        nomatch not_mem_empty z, hz
+
+theorem sep_subset_self {P : ZFSet → Prop} {a : ZFSet} : a.sep P ⊆ a := by
+  intros x hx
+  rw [mem_sep] at hx
+  exact hx.left
 
 /-- The powerset operation, the collection of subsets of a ZFC set -/
 def powerset : ZFSet → ZFSet :=
@@ -559,6 +615,14 @@ theorem mem_union {x y z : ZFSet.{u}} : z ∈ x ∪ y ↔ z ∈ x ∨ z ∈ y :=
   rw [← mem_toSet]
   simp
 
+theorem insert_def {x y : ZFSet} : insert x y = {x} ∪ y := by
+  ext1 z
+  rw [mem_insert_iff, mem_union, mem_singleton]
+
+theorem sUnion_insert {x : ZFSet} : (⋃₀ (insert x x) : ZFSet) = x ∪ (⋃₀ x : ZFSet) := by
+  ext1
+  simp only [mem_sUnion, mem_insert_iff, exists_eq_or_imp, mem_union]
+
 @[simp]
 theorem mem_inter {x y z : ZFSet.{u}} : z ∈ x ∩ y ↔ z ∈ x ∧ z ∈ y :=
   @mem_sep (fun z : ZFSet.{u} => z ∈ y) x z
@@ -570,6 +634,18 @@ theorem mem_diff {x y z : ZFSet.{u}} : z ∈ x \ y ↔ z ∈ x ∧ z ∉ y :=
 @[simp]
 theorem sUnion_pair {x y : ZFSet.{u}} : ⋃₀ ({x, y} : ZFSet.{u}) = x ∪ y :=
   rfl
+
+theorem sInter_pair {a b : ZFSet} : ⋂₀ {a, b} = a ∩ b := by
+  ext1 x
+  apply Iff.intro
+  · intro h
+    rw [mem_sInter (by simp only [nonempty_def, mem_insert_iff, exists_or_eq_left])] at h
+    simp only [mem_insert_iff, mem_singleton, forall_eq_or_imp, forall_eq] at h
+    rwa [← mem_inter] at h
+  · intro h
+    rw [mem_sInter (by simp only [nonempty_def, mem_insert_iff, exists_or_eq_left])]
+    simp only [mem_insert_iff, mem_singleton, forall_eq_or_imp, forall_eq]
+    rwa [← mem_inter]
 
 theorem mem_wf : @WellFounded ZFSet (· ∈ ·) :=
   (wellFounded_lift₂_iff (H := fun a b c d hx hy =>
@@ -705,6 +781,35 @@ theorem mem_prod {x y z : ZFSet.{u}} : z ∈ prod x y ↔ ∃ a ∈ x, ∃ b ∈
 
 theorem pair_mem_prod {x y a b : ZFSet.{u}} : pair a b ∈ prod x y ↔ a ∈ x ∧ b ∈ y := by
   simp
+
+@[simp]
+theorem prod_empty_right {x : ZFSet} : x.prod ∅ = ∅ := by
+  ext z; simp
+
+@[simp]
+theorem prod_empty_left {x : ZFSet} : ZFSet.prod ∅ x = ∅ := by
+  ext z; simp
+
+theorem prod_subset_prod_iff {A C B D: ZFSet} (hA : A ≠ ∅) (hC : C ≠ ∅) :
+  A.prod C ⊆ B.prod D ↔ A ⊆ B ∧ C ⊆ D := by
+  simp_rw [subset_def]
+  constructor
+  · intro h
+    and_intros
+    · intro z zA
+      obtain ⟨c, hc⟩ := nonempty_exists_iff.mp hC
+      specialize h <| pair_mem_prod.mpr ⟨zA, hc⟩
+      rw [pair_mem_prod] at h
+      exact h.1
+    · intro z zC
+      obtain ⟨a, ha⟩ := nonempty_exists_iff.mp hA
+      specialize h <| pair_mem_prod.mpr ⟨ha, zC⟩
+      rw [pair_mem_prod] at h
+      exact h.2
+  · rintro ⟨hAB, hCD⟩ z hz
+    rw [mem_prod] at hz
+    obtain ⟨a, ha, c, hc, rfl⟩ := hz
+    exact pair_mem_prod.mpr ⟨hAB ha, hCD hc⟩
 
 /-- `isFunc x y f` is the assertion that `f` is a subset of `x × y` which relates to each element
 of `x` a unique element of `y`, so that we can consider `f` as a ZFC function `x → y`. -/

--- a/Mathlib/SetTheory/ZFC/Booleans.lean
+++ b/Mathlib/SetTheory/ZFC/Booleans.lean
@@ -1,0 +1,515 @@
+/-
+Copyright (c) 2025 Vincent Trélat. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Vincent Trélat
+-/
+import Mathlib.SetTheory.ZFC.Basic
+
+/-!
+# Boolean algebra on `ZFSet`
+
+This file defines the boolean algebra on `ZFSet` and the type of booleans `ZFBool`.
+It defines the following operations:
+- `not` : negation
+- `and` : conjunction
+- `or` : disjunction
+- `true` : ZF true value
+- `false` : ZF false value
+- `𝔹` : set of ZF booleans
+- `toBool` : conversion from `ZFBool` to `Bool`
+- `ofBool` : conversion from `Bool` to `ZFBool`
+
+-/
+
+noncomputable section
+
+/-! ## Preliminary definitions -/
+
+namespace ZFSet
+
+/-- Symmetric difference of two sets, denoted by `Δ`. -/
+def symmDiff (p q : ZFSet) : ZFSet := (p \ q) ∪ (q \ p)
+infix:70 " Δ " => symmDiff
+
+@[simp]
+theorem mem_symmDiff (x p q : ZFSet) : x ∈ p Δ q ↔ (x ∈ p ∧ x ∉ q) ∨ (x ∈ q ∧ x ∉ p) := by
+  simp only [symmDiff, mem_union, mem_diff]
+
+@[simp]
+theorem symmDiff_empty (p : ZFSet) : p Δ ∅ = p := by
+  ext x
+  simp only [mem_symmDiff, not_mem_empty, not_false_eq_true, and_true, false_and, or_false]
+
+theorem symmDiff_comm (p q : ZFSet) : p Δ q = q Δ p := by
+  ext x
+  simp only [mem_symmDiff]
+  exact Or.comm
+
+@[simp]
+theorem symmDiff_self (p : ZFSet) : p Δ p = ∅ := by
+  ext x
+  simp only [mem_symmDiff, and_not_self, or_self, not_mem_empty]
+
+section Booleans
+
+/-! ## ZF Boolean Algebra -/
+
+/-- False value defined as the empty set. -/
+abbrev zffalse : ZFSet := ∅
+/-- True value defined as the singleton containing the empty set. -/
+abbrev zftrue : ZFSet := {zffalse}
+/-- Set of ZF booleans, defined as the set containing `zffalse` and `zftrue`. -/
+abbrev 𝔹 : ZFSet := {zffalse,zftrue}
+/-- Type of ZF booleans. -/
+abbrev ZFBool := { x // x ∈ 𝔹 }
+
+theorem zftrue_ne_zffalse : zftrue ≠ zffalse := by
+  intro h
+  rw [ZFSet.ext_iff, zffalse, zftrue] at h
+  specialize h ∅
+  rw [mem_singleton] at h
+  nomatch h.mp rfl
+
+namespace ZFBool
+
+theorem zftrue_mem_𝔹 : zftrue ∈ 𝔹 := by
+  rw [mem_insert_iff, mem_singleton]
+  exact Or.inr rfl
+
+theorem zffalse_mem_𝔹 : zffalse ∈ 𝔹 := by
+  rw [mem_insert_iff, mem_singleton]
+  exact Or.inl rfl
+
+lemma 𝔹.nonempty : ZFSet.𝔹 ≠ ∅ := by
+  intro h
+  rw [ZFSet.ext_iff] at h
+  simp only [ZFSet.not_mem_empty, iff_false] at h
+  nomatch h ZFSet.zffalse (ZFSet.ZFBool.zffalse_mem_𝔹)
+
+/-- False value, lifted on `ZFBool`. -/
+abbrev false : ZFBool := ⟨zffalse, zffalse_mem_𝔹⟩
+/-- True value, lifted on `ZFBool`. -/
+abbrev true : ZFBool := ⟨zftrue, zftrue_mem_𝔹⟩
+instance Bool_top : Top ZFBool := ⟨true⟩
+instance Bool_bot : Bot ZFBool := ⟨false⟩
+@[simp] theorem top_eq_true : ⊤ = true := rfl
+@[simp] theorem bot_eq_false : ⊥ = false := rfl
+theorem true_ne_false : (⊤ : ZFBool) ≠ ⊥ := by
+  intro h
+  rw [top_eq_true, bot_eq_false] at h
+  injection h with h
+  nomatch zftrue_ne_zffalse h
+
+@[simp]
+theorem mem_𝔹_iff (p : ZFSet) : p ∈ 𝔹 ↔ p = zffalse ∨ p = zftrue := by
+  rw [mem_insert_iff, mem_singleton]
+
+@[simp]
+theorem powerset_false : zffalse.powerset = zftrue := by
+  unfold zftrue zffalse
+  ext x
+  simp only [mem_powerset, mem_singleton]
+  apply Iff.intro
+  · exact ZFSet.subset_of_empty x
+  · exact (subset_of_subset_of_eq (fun _ a => a) ·)
+
+/--
+The enumeration of the powerset of `𝔹`.
+-/
+theorem powerset_𝔹_def :
+  ZFSet.𝔹.powerset = {∅, {ZFSet.zffalse}, {ZFSet.zftrue}, {ZFSet.zffalse, ZFSet.zftrue}} := by
+  ext1 x
+  constructor
+  · intro h
+    rw [ZFSet.mem_powerset, ZFSet.𝔹] at h
+    simp_rw [ZFSet.mem_insert_iff, ZFSet.mem_singleton]
+    by_cases hx : x = ∅
+    · left; exact hx
+    · right
+      by_cases hx' : ZFSet.zffalse ∈ x
+      · rw [← or_assoc, or_comm, ← or_assoc]
+        left
+        by_cases hx'' : ZFSet.zftrue ∈ x
+        · left
+          ext1 s
+          constructor
+          · intro hs; exact h hs
+          · intro hs; rcases (ZFSet.ZFBool.mem_𝔹_iff s).mp hs with rfl | rfl <;> assumption
+        · right
+          ext1 s
+          constructor
+          · intro hs
+            rw [ZFSet.mem_singleton]
+            rcases ZFSet.ZFBool.mem_𝔹_iff s |>.mp (h hs) with rfl | rfl <;> trivial
+          · intro hs
+            rcases ZFSet.mem_singleton.mp hs
+            exact hx'
+      · by_cases hx'' : ZFSet.zftrue ∈ x
+        · right
+          left
+          ext1 s
+          constructor
+          · intro hs
+            rw [ZFSet.mem_singleton]
+            rcases (ZFSet.ZFBool.mem_𝔹_iff s).mp (h hs) with rfl | rfl <;> trivial
+          · intro hs
+            rcases ZFSet.mem_singleton.mp hs
+            exact hx''
+        · simp_rw [ZFSet.subset_def, ZFSet.ZFBool.mem_𝔹_iff] at h
+          obtain ⟨w, hw⟩ := nonempty_exists_iff.mp hx
+          rcases h hw with rfl | rfl <;> contradiction
+  · intro hx
+    simp_rw [ZFSet.mem_insert_iff, ZFSet.mem_singleton] at hx
+    rcases hx with rfl | rfl | rfl | rfl <;> rw [ZFSet.mem_powerset]
+    · exact ZFSet.empty_subset ZFSet.𝔹
+    · intro _ hx
+      rw [ZFSet.ZFBool.mem_𝔹_iff]
+      rcases ZFSet.mem_singleton.mp hx
+      left; rfl
+    · intro _ hx
+      rw [ZFSet.ZFBool.mem_𝔹_iff]
+      rcases ZFSet.mem_singleton.mp hx
+      right; rfl
+
+/-- Boolean negation, defined as the symmetric difference with `true`. -/
+protected abbrev not (p : ZFBool) : ZFBool := ⟨true Δ p.1, by
+  let ⟨p, hp⟩ := p
+  rw [mem_𝔹_iff] at hp ⊢
+  rcases hp with rfl | rfl
+  · right
+    exact symmDiff_empty _
+  · left
+    exact symmDiff_self _⟩
+
+/-- Cases elimination for `ZFBool`. -/
+@[cases_eliminator]
+def casesOn {motive : ZFBool → Sort _}
+  (p : ZFBool)
+  (false : motive ⊥)
+  (true : motive ⊤) : motive p := by
+  obtain ⟨P, hP⟩ := p
+  have := mem_𝔹_iff P |>.mp hP
+  by_cases h : P = zffalse
+  · subst h
+    exact false
+  · have := Or.resolve_left this h
+    subst this
+    exact true
+
+/-- Boolean conjunction, defined as set intersection. -/
+protected abbrev and (p q : ZFBool) : ZFBool :=
+  let ⟨P, hP⟩ := p
+  let ⟨Q, hQ⟩ := q
+  ⟨P ∩ Q, by
+    rw [mem_𝔹_iff]
+    rw [mem_𝔹_iff] at hP hQ
+    cases hP <;> cases hQ <;> subst_eqs
+    · apply Or.inl
+      ext1
+      rw [mem_inter, and_self]
+    · apply Or.inl
+      ext1
+      simp only [mem_inter, not_mem_empty, false_and]
+    · apply Or.inl
+      ext1
+      simp only [mem_inter,  not_mem_empty, and_false]
+    · apply Or.inr
+      ext1
+      simp only [mem_inter, and_self]⟩
+
+infixl:55 " ⋀ " => ZFBool.and
+
+protected abbrev or (p q : ZFBool) : ZFBool :=
+  let ⟨P, hP⟩ := p
+  let ⟨Q, hQ⟩ := q
+  ⟨P ∪ Q,
+    by
+    rw [mem_𝔹_iff]
+    rw [mem_𝔹_iff] at hP hQ
+    cases hP <;> cases hQ <;> subst_eqs
+    · apply Or.inl
+      ext1
+      rw [mem_union, or_self]
+    · apply Or.inr
+      ext1
+      simp only [mem_union, not_mem_empty, mem_singleton, false_or]
+    · apply Or.inr
+      ext1
+      simp only [mem_union, not_mem_empty, or_false]
+    · apply Or.inr
+      ext1
+      simp only [mem_union, subset_of_empty, or_self]⟩
+
+infixl:55 " ⋁ " => ZFBool.or
+
+/-! ### Boolean algebra -/
+
+@[simp]
+theorem not_true_eq_false : ZFBool.not ⊤ = ⊥ := by
+  rw [Subtype.mk.injEq]
+  ext1
+  rw [mem_symmDiff]
+  constructor
+  · rintro (⟨l, r⟩ | ⟨l, r⟩) <;> nomatch r l
+  · intro h
+    nomatch not_mem_empty _ h
+
+@[simp]
+theorem not_false_eq_true : ZFBool.not ⊥ = ⊤ := by
+  rw [Subtype.mk.injEq]
+  ext1
+  rw [mem_symmDiff]
+  constructor
+  · rintro (⟨l, r⟩ | ⟨l, r⟩)
+    · exact l
+    · nomatch not_mem_empty _ l
+  · intro h
+    left
+    exact ⟨h, not_mem_empty _⟩
+
+theorem and_comm (p q : ZFBool) : p ⋀ q = q ⋀ p := by
+  obtain ⟨P, hP⟩ := p
+  obtain ⟨Q, hQ⟩ := q
+  rw [Subtype.mk.injEq]
+  ext1
+  repeat rw [mem_inter]
+  exact And.comm
+
+theorem and_assoc (p q r : ZFBool) : p ⋀ q ⋀ r = p ⋀ (q ⋀ r) := by
+  obtain ⟨P, hP⟩ := p
+  obtain ⟨Q, hQ⟩ := q
+  obtain ⟨R, hR⟩ := r
+  rw [Subtype.mk.injEq]
+  ext1
+  repeat rw [mem_inter]
+  exact _root_.and_assoc
+
+@[simp]
+theorem and_true (p : ZFBool) : p ⋀ ⊤ = p := by
+  obtain ⟨P, hP⟩ := p
+  rw [Subtype.mk.injEq]
+  ext1
+  rw [mem_inter]
+  rw [mem_𝔹_iff] at hP
+  rw [and_iff_left_iff_imp]
+  intro h
+  cases hP
+  · subst_eqs
+    simp only [not_mem_empty] at h
+  · subst_eqs
+    assumption
+
+@[simp]
+theorem and_false (p : ZFBool) : p ⋀ ⊥ = ⊥ := by
+  obtain ⟨P, hP⟩ := p
+  ext
+  rw [mem_inter]
+  rw [mem_𝔹_iff] at hP
+  rcases hP with rfl | rfl
+  · exact and_iff_left_of_imp id
+  · constructor
+    · rintro ⟨_, h⟩
+      exact h
+    · intro h
+      nomatch not_mem_empty _ h
+
+theorem and_iff (p q : ZFBool) : p ⋀ q = ⊤ ↔ p = ⊤ ∧ q = ⊤ := by
+  constructor
+  · intro h
+    cases q using casesOn with
+    | false =>
+      rw [and_false] at h
+      nomatch true_ne_false h.symm
+    | true => exact ⟨and_true p ▸ h, rfl⟩
+  · rintro (⟨rfl,rfl⟩)
+    rw [and_true]
+
+abbrev and_intro p q := and_iff p q |>.mpr
+
+theorem or_comm (p q : ZFBool) : p ⋁ q = q ⋁ p := by
+  obtain ⟨P, hP⟩ := p
+  obtain ⟨Q, hQ⟩ := q
+  rw [Subtype.mk.injEq]
+  ext1
+  repeat rw [mem_union]
+  exact Or.comm
+
+theorem or_assoc (p q r : ZFBool) : p ⋁ q ⋁ r = p ⋁ (q ⋁ r) := by
+  obtain ⟨P, hP⟩ := p
+  obtain ⟨Q, hQ⟩ := q
+  obtain ⟨R, hR⟩ := r
+  rw [Subtype.mk.injEq]
+  ext1
+  repeat rw [mem_union]
+  exact _root_.or_assoc
+
+theorem or_true (p : ZFBool) : p ⋁ ⊤ = ⊤ := by
+  obtain ⟨P, hP⟩ := p
+  rw [Subtype.mk.injEq]
+  ext1
+  rw [mem_union]
+  rw [mem_𝔹_iff] at hP
+  cases hP <;> subst_eqs
+  · simp only [not_mem_empty, mem_singleton, false_or, top_eq_true]
+  · exact or_iff_left_of_imp id
+
+theorem or_false (p : ZFBool) : p ⋁ ⊥ = p := by
+  obtain ⟨P, hP⟩ := p
+  rw [Subtype.mk.injEq]
+  ext1
+  rw [mem_union]
+  rw [mem_𝔹_iff] at hP
+  cases hP <;> subst_eqs
+  · rw [or_self]
+  · simp only [not_mem_empty, _root_.or_false]
+
+theorem or_iff (p q : ZFBool) : p ⋁ q = ⊤ ↔ p = ⊤ ∨ q = ⊤ := by
+  constructor
+  · intro h
+    cases p using casesOn with
+    | false =>
+      rw [or_comm, or_false] at h
+      exact Or.inr h
+    | true => exact Or.inl rfl
+  · intro h
+    rcases h with rfl | rfl
+    · rw [or_comm, or_true]
+    · rw [or_true]
+
+abbrev or_intro p q := or_iff p q |>.mpr
+
+open Classical in
+/-- Conversion of `ZFBool` to `Lean.Bool`. -/
+def toBool : ZFBool → Bool
+  | ⟨b, hb⟩ =>
+    if h : b = zftrue then Bool.true
+    else if h' : b = zffalse then Bool.false
+    else False.elim (by rcases (ZFBool.mem_𝔹_iff b |>.mp hb) <;> contradiction)
+
+theorem toBool_false : toBool ⊥ = Bool.false := by
+  rw [toBool]
+  split_ifs with h h'
+  · nomatch zftrue_ne_zffalse h.symm
+  · rfl
+  · nomatch h'
+
+theorem toBool_true : toBool ⊤ = Bool.true := by
+  rw [toBool]
+  split_ifs with h h'
+  · rfl
+  · nomatch h rfl
+  · nomatch h'
+
+theorem toBool_and (p q : ZFBool) : (p ⋀ q).toBool = (p.toBool && q.toBool) := by
+  cases p <;> cases q
+  · rw [and_false, toBool_false, Bool.false_and]
+  · rw [and_true, toBool_true, toBool_false, Bool.false_and]
+  · rw [and_false, toBool_true, toBool_false, Bool.and_false]
+  · rw [and_true, toBool_true, Bool.true_and]
+
+theorem toBool_or (p q : ZFBool) : (p ⋁ q).toBool = (p.toBool || q.toBool) := by
+  cases p <;> cases q
+  · rw [or_false, toBool_false, Bool.false_or]
+  · rw [or_true, toBool_true, toBool_false, Bool.or_true]
+  · rw [or_false, toBool_true, toBool_false, Bool.true_or]
+  · rw [or_true, toBool_true, Bool.true_or]
+
+theorem toBool_not (p : ZFBool) : toBool p.not = ¬ p.toBool := by
+  cases p
+  · rw [not_false_eq_true, toBool_true, toBool_false, Bool.false_eq_true, Bool.coe_sort_true]
+    exact _root_.not_false_eq_true.symm
+  · rw [not_true_eq_false, toBool_false, toBool_true, Bool.coe_false]
+    exact eq_false (fun h => h rfl) |>.symm
+
+theorem not_top_iff_bot {P : ZFBool} : P ≠ ⊤ ↔ P = ⊥ := by
+  constructor
+  · intro
+    cases P <;> trivial
+  · intro _ h
+    subst P
+    injections h
+    nomatch zftrue_ne_zffalse h.symm
+
+theorem not_bot_iff_top {P : ZFBool} : P ≠ ⊥ ↔ P = ⊤ := by
+  constructor
+  · intro
+    cases P <;> trivial
+  · intro _ h
+    subst P
+    injections h
+    nomatch zftrue_ne_zffalse h
+
+/-- Conversion of `Lean.Bool` to `ZFBool` -/
+def ofBool : Bool → ZFBool
+  | .true  => ⟨zftrue, ZFBool.zftrue_mem_𝔹⟩
+  | .false => ⟨zffalse, ZFBool.zffalse_mem_𝔹⟩
+
+theorem mem_ofBool_𝔹 (b : Bool) : (ofBool b).val ∈ 𝔹 := by
+  unfold 𝔹
+  rcases b <;> simp [ofBool]
+
+theorem sub_ofBool_singleton_𝔹 (b : Bool) : {(ofBool b).val} ⊆ 𝔹 := by
+  intro
+  rw [mem_singleton]
+  rintro rfl
+  exact mem_ofBool_𝔹 b
+
+theorem to_Bool_ofBool (b : Bool) : ZFBool.toBool (ofBool b) = b := by
+  cases b <;> rw [ofBool, ZFBool.toBool]
+  · split_ifs with h
+    · nomatch zftrue_ne_zffalse.symm h
+    · rfl
+    · generalize_proofs
+      contradiction
+  · split_ifs with h
+    · rfl
+    · contradiction
+    · generalize_proofs
+      contradiction
+
+theorem of_Bool_toBool (b : ZFBool) : ofBool b.toBool = b := by
+  obtain ⟨b, hb⟩ := b
+  rw [ZFBool.toBool, ofBool.eq_def]
+  split_ifs with h <;> (first | subst b | contradiction) <;> trivial
+
+theorem ofBool_decide_eq_true_iff {P : Prop} [Decidable P] : ofBool (decide P) = ⊤ ↔ P := by
+  constructor
+  · intro h
+    cases hP : decide P with
+    | false =>
+      rw [hP] at h
+      unfold ofBool at h
+      injection h with h
+      nomatch zftrue_ne_zffalse h.symm
+    | true => exact decide_eq_true_eq.mp hP
+  · intro h
+    cases hP : decide P with
+    | false =>
+      rw [Bool.decide_false_iff] at hP
+      contradiction
+    | true => rfl
+
+theorem ofBool_decide_eq_false_iff {P : Prop} [Decidable P] : ofBool (decide P) = ⊥ ↔ ¬P := by
+  constructor
+  · intro h
+    cases hP : decide P with
+    | false => exact decide_eq_false_iff_not.mp hP
+    | true =>
+      rw [hP] at h
+      unfold ofBool at h
+      injection h with h
+      nomatch zftrue_ne_zffalse h
+  · intro h
+    cases hP : decide P with
+    | false => rfl
+    | true =>
+      rw [Bool.decide_iff] at hP
+      contradiction
+
+end ZFBool
+
+end Booleans
+
+end ZFSet
+
+end

--- a/Mathlib/SetTheory/ZFC/Integers.lean
+++ b/Mathlib/SetTheory/ZFC/Integers.lean
@@ -1,0 +1,1318 @@
+/-
+Copyright (c) 2025 Vincent Trélat. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Vincent Trélat
+-/
+import Mathlib.SetTheory.ZFC.Naturals
+import Mathlib.Algebra.Order.Ring.Defs
+import Mathlib.Algebra.Order.Group.Defs
+import Mathlib.SetTheory.Cardinal.SchroederBernstein
+
+/-! # ZFC Integers
+
+This file provides a construction of the integers in ZFC based on the construction of natural
+numbers. It follows the usual construction of integers as equivalence classes of pairs of natural
+numbers.
+
+The theory also comes with usual theorems and arithmetic operations on integers and wraps everything
+in a commutative ring structure.
+
+Finally, we show that that the `ZFInt` type is isomorphic to the type of elements contained in
+`ZFSet.Int` type using the Schröder-Bernstein theorem.
+-/
+
+namespace ZFSet
+
+section Integers
+
+protected abbrev zrel (a b : ZFNat × ZFNat) : Prop := a.1 + b.2 = a.2 + b.1
+
+protected def zrel_eq : Equivalence ZFSet.zrel where
+  refl := fun _ => add_comm _ _
+  symm := by
+    unfold ZFSet.zrel
+    intro x y h
+    rw [add_comm, add_comm y.2]
+    symm
+    assumption
+  trans := by
+    unfold ZFSet.zrel
+    intro x y z hxy hyz
+    have : x.1 + y.2 + y.1 + z.2 = x.2 + y.1 + y.2 + z.1 := by
+      rw [hxy, ← ZFNat.add_assoc, hyz, ZFNat.add_assoc _ _ _]
+    rw [add_assoc x.1, add_comm _ (y.2 + y.1), add_assoc, add_assoc x.2, add_comm _ (y.1 + y.2),
+      add_comm y.1, ← add_assoc (y.2 + y.1)] at this
+    apply add_left_cancel (a := y.2 + y.1)
+    simpa only [add_assoc]
+
+protected instance instSetoidZFNatZFNat : Setoid (ZFNat × ZFNat) where
+  r := ZFSet.zrel
+  iseqv := ZFSet.zrel_eq
+
+abbrev ZFInt := Quotient ZFSet.instSetoidZFNatZFNat
+
+namespace ZFInt
+
+def mk : ZFNat × ZFNat → ZFInt := Quotient.mk''
+
+@[simp]
+theorem mk_eq (x : ZFNat × ZFNat) : @Eq ZFInt ⟦x⟧ (mk x) := rfl
+
+@[simp]
+theorem mk_out : ∀ x : ZFInt, mk x.out = x := Quotient.out_eq
+
+theorem eq {x y : ZFNat × ZFNat} : mk x = mk y ↔ ZFSet.zrel x y := Quotient.eq
+
+theorem sound {x y : ZFNat × ZFNat} (h : ZFSet.zrel x y) : mk x = mk y := Quotient.sound h
+
+theorem exact {x y : ZFNat × ZFNat} : mk x = mk y → ZFSet.zrel x y := Quotient.exact
+
+abbrev zero : ZFInt := mk (0, 0)
+abbrev one : ZFInt := mk (1, 0) -- (0,1) works too
+
+protected instance : Zero ZFInt := ⟨zero⟩
+protected instance : One ZFInt := ⟨one⟩
+
+theorem zero_eq : (0 : ZFInt) = mk (0, 0) := rfl
+theorem one_eq : (1 : ZFInt) = mk (1, 0) := rfl
+
+theorem mk_eq_zero_iff {n m} : ZFInt.mk (n,m) = 0 ↔ n = m := by
+  constructor
+  · intro h
+    rw [ZFInt.zero_eq, ZFInt.eq, ZFSet.zrel] at h
+    exact ZFNat.add_right_cancel.mp h
+  · rintro rfl
+    exact ZFInt.sound rfl
+
+open ZFNat in
+noncomputable abbrev add (n m : ZFInt) : ZFInt :=
+  Quotient.liftOn₂ n m (fun ⟨a, b⟩ ⟨c, d⟩ => mk (a + c, b + d)) fun x y x' y' hx hy => sound (by
+    have h1 : x.1 + x'.2 = x.2 + x'.1 := hx
+    have h2 : y.1 + y'.2 = y.2 + y'.1 := hy
+    simp only [ZFSet.zrel]
+    have : x.1 + x'.2 + y.1 + y'.2 = x.2 + x'.1 + y.2 + y'.1 := by
+      rw [h1, ← add_assoc, h2, add_assoc]
+    conv_lhs => rw [add_assoc, ← add_assoc, ← add_assoc, ZFNat.add_comm y.1, add_assoc, add_assoc,
+      ← add_assoc, ZFNat.add_comm y'.2, add_assoc, this]
+    conv_rhs => rw [add_assoc]; lhs; rw [← add_assoc]; rhs; rw [add_comm]
+    rw [add_assoc])
+
+protected noncomputable instance : Add ZFInt := ⟨ZFInt.add⟩
+theorem add_eq (n m : ZFNat × ZFNat) : mk n + mk m = mk (n.1 + m.1, n.2 + m.2) := rfl
+
+theorem add_assoc (n m k : ZFInt) : n + (m + k) = n + m + k := by
+  induction n using Quotient.ind
+  induction m using Quotient.ind
+  induction k using Quotient.ind
+  simp_rw [mk_eq, ZFInt.add_eq, ZFNat.add_assoc]
+
+theorem add_comm (n m : ZFInt) : n + m = m + n := by
+  induction n using Quotient.ind
+  induction m using Quotient.ind
+  simp_rw [mk_eq, ZFInt.add_eq, ZFNat.add_comm]
+
+lemma add_left_comm (n m k : ZFInt) : n + (m + k) = m + (n + k) := by
+  rw [add_assoc, add_assoc, add_comm n]
+
+lemma add_right_comm (n m k : ZFInt) : (n + m) + k = (n + k) + m := by
+  rw [← add_assoc, add_comm m, add_assoc]
+
+@[simp]
+theorem add_zero {x : ZFInt} : x + 0 = x := by
+  induction x using Quotient.ind
+  simp_rw [mk_eq, zero_eq, ZFInt.add_eq, ZFNat.add_zero]
+
+@[simp]
+theorem zero_add {x : ZFInt} : 0 + x = x := by
+  rw [add_comm, add_zero]
+
+protected abbrev neg (n : ZFInt) : ZFInt :=
+  Quotient.liftOn n (fun x => mk (x.2, x.1)) fun x y h => sound (ZFSet.zrel_eq.symm (by
+    simp only [ZFSet.zrel]
+    rw [ZFNat.add_comm, ZFNat.add_comm y.1, ← ZFSet.zrel]
+    assumption))
+protected instance : Neg ZFInt := ⟨ZFInt.neg⟩
+theorem neg_eq (n : ZFNat × ZFNat) : -mk n = mk (n.2, n.1) := rfl
+
+@[simp]
+theorem neg_neg (n : ZFInt) : -(-n) = n := by
+  induction n using Quotient.ind
+  rw [mk_eq, neg_eq, neg_eq]
+
+@[simp]
+theorem neg_zero : -(0 : ZFInt) = 0 := by
+  rw [zero_eq, neg_eq]
+
+theorem neg_inj {a b : ZFInt} : -a = -b ↔ a = b :=
+  ⟨fun h => by rw [← neg_neg a, ← neg_neg b, h], congrArg _⟩
+
+@[simp]
+theorem neg_eq_zero {a : ZFInt} : -a = 0 ↔ a = 0 := ZFInt.neg_inj (b := 0)
+
+theorem neg_ne_zero {a : ZFInt} : -a ≠ 0 ↔ a ≠ 0 := not_congr neg_eq_zero
+
+theorem add_left_neg {a : ZFInt} : -a + a = 0 := by
+  induction a using Quotient.ind
+  apply sound
+  rw [ZFNat.add_comm]
+
+theorem add_right_neg (a : ZFInt) : a + -a = 0 := by
+  rw [add_comm]
+  exact add_left_neg
+
+theorem neg_eq_of_add_eq_zero {a b : ZFInt} (h : a + b = 0) : -a = b := by
+  rw [← @add_zero (-a), ← h, add_assoc, add_left_neg, zero_add]
+
+theorem eq_neg_of_eq_neg {a b : ZFInt} (h : a = -b) : b = -a := by
+  rw [h, neg_neg]
+
+theorem eq_neg_comm {a b : ZFInt} : a = -b ↔ b = -a := ⟨eq_neg_of_eq_neg, eq_neg_of_eq_neg⟩
+
+theorem neg_eq_comm {a b : ZFInt} : -a = b ↔ -b = a := by
+  rw [eq_comm, eq_neg_comm, eq_comm]
+
+theorem neg_add_cancel_left (a b : ZFInt) : -a + (a + b) = b := by
+  rw [add_assoc, add_left_neg, zero_add]
+
+theorem add_neg_cancel_left (a b : ZFInt) : a + (-a + b) = b := by
+  rw [add_assoc, add_right_neg, zero_add]
+
+theorem add_neg_cancel_right (a b : ZFInt) : a + b + -b = a := by
+  rw [← add_assoc, add_right_neg, add_zero]
+
+theorem neg_add_cancel_right (a b : ZFInt) : a + -b + b = a := by
+  rw [← add_assoc, add_left_neg, add_zero]
+
+theorem add_left_cancel {a b c : ZFInt} (h : a + b = a + c) : b = c := by
+  have h₁ : -a + (a + b) = -a + (a + c) := by rw [h]
+  simp [add_assoc, add_left_neg, zero_add] at h₁
+  exact h₁
+
+@[simp]
+theorem neg_add {a b : ZFInt} : -(a + b) = -a + -b := by
+  apply add_left_cancel (a := a + b)
+  rw [add_right_neg, add_comm a, add_assoc, ← add_assoc b, add_right_neg, add_zero, add_right_neg]
+
+noncomputable abbrev sub (n m : ZFInt) : ZFInt := n + -m
+protected noncomputable instance : Sub ZFInt := ⟨ZFInt.sub⟩
+theorem sub_eq (n m : ZFNat × ZFNat) : mk n - mk m = mk (n.1 + m.2, n.2 + m.1) := rfl
+
+theorem sub_eq_add_neg {a b : ZFInt} : a - b = a + -b := rfl
+
+theorem add_neg_one (i : ZFInt) : i + -1 = i - 1 := rfl
+
+@[simp]
+theorem sub_self (a : ZFInt) : a - a = 0 := by rw [sub_eq_add_neg, add_right_neg]
+
+@[simp]
+theorem sub_zero (a : ZFInt) : a - 0 = a := by simp [sub_eq_add_neg]
+
+@[simp]
+theorem zero_sub (a : ZFInt) : 0 - a = -a := by simp [sub_eq_add_neg]
+
+theorem sub_eq_zero_of_eq {a b : ZFInt} (h : a = b) : a - b = 0 := by rw [h, sub_self]
+
+theorem eq_of_sub_eq_zero {a b : ZFInt} (h : a - b = 0) : a = b := by
+  have : 0 + b = b := by rw [zero_add]
+  have : a - b + b = b := by rwa [h]
+  rwa [sub_eq_add_neg, neg_add_cancel_right] at this
+
+theorem sub_eq_zero {a b : ZFInt} : a - b = 0 ↔ a = b := ⟨eq_of_sub_eq_zero, sub_eq_zero_of_eq⟩
+
+theorem sub_sub (a b c : ZFInt) : a - b - c = a - (b + c) := by
+  simp [sub_eq_add_neg, add_assoc]
+
+theorem neg_sub (a b : ZFInt) : -(a - b) = b - a := by
+  simp [sub_eq_add_neg, add_comm]
+
+theorem sub_sub_self (a b : ZFInt) : a - (a - b) = b := by
+  simp [sub_eq_add_neg, add_assoc, add_right_neg]
+
+@[simp]
+theorem sub_neg (a b : ZFInt) : a - -b = a + b := by simp [sub_eq_add_neg]
+
+@[simp]
+theorem sub_add_cancel (a b : ZFInt) : a - b + b = a := neg_add_cancel_right a b
+
+@[simp]
+theorem add_sub_cancel (a b : ZFInt) : a + b - b = a := add_neg_cancel_right a b
+
+theorem add_sub_assoc (a b c : ZFInt) : a + b - c = a + (b - c) := by
+  rw [sub_eq_add_neg, ← add_assoc, ← sub_eq_add_neg]
+
+theorem sub_left_cancel (a b c : ZFInt) : a - c = b - c → a = b := by
+  intro h
+  rwa [← sub_eq_zero, sub_sub, sub_eq_zero, ← add_sub_assoc, add_comm, add_sub_cancel] at h
+
+theorem sub_right_cancel (a b c : ZFInt) : c - a = c - b → a = b := by
+  rw [← neg_sub a, ← neg_sub b, neg_inj]
+  apply sub_left_cancel
+
+theorem add_eq_sub_iff {a b c : ZFInt} : a + b = c ↔ a = c - b where
+  mp := fun h => by rw [← h, add_sub_cancel]
+  mpr := fun h => by rw [h, sub_add_cancel]
+
+private noncomputable abbrev nsmul : ℕ → ZFInt → ZFInt
+  | 0, _ => 0
+  | n+1, m => m + nsmul n m
+
+private noncomputable abbrev zsmul (n : ℤ) (x : ZFInt) : ZFInt :=
+  match n with
+  | .ofNat n => nsmul n x
+  | .negSucc n => -nsmul (n+1) x
+
+instance : Std.Associative (α := ZFNat) (· + ·) := ⟨(ZFNat.add_assoc · · · |>.symm)⟩
+instance : Std.Commutative (α := ZFNat) (· + ·) := ⟨ZFNat.add_comm⟩
+
+instance : Std.Associative (α := ZFNat) (· * ·) := ⟨ZFNat.mul_assoc⟩
+instance : Std.Commutative (α := ZFNat) (· * ·) := ⟨ZFNat.mul_comm⟩
+
+private theorem mul_wf {a b c d s t u v : ZFNat}
+  (h₁ : ZFSet.zrel (a, b) (s,t)) (h₂ : ZFSet.zrel (c, d) (u, v)) :
+  ZFSet.zrel (a * c + b * d, a * d + b * c) (s * u + t * v, s * v + t * u) := by
+  dsimp [ZFSet.zrel] at *
+
+  suffices h₃ : t * c + a * c + b * d + s * v + t * u = a * d + b * c + s * u + t * v + t * c by
+    simp_rw [ZFNat.add_comm _ (t*c), ← ZFNat.add_assoc (t*c)] at h₃
+    apply ZFNat.add_left_cancel.mp at h₃
+    simp_rw [ZFNat.add_assoc, h₃]
+
+  conv in t*c + a*c => rw [← right_distrib, ZFNat.add_comm, h₁, right_distrib]
+  conv in _ + t*v + t*c => rw [← ZFNat.add_assoc, ← left_distrib, ZFNat.add_comm v c, h₂,
+    left_distrib, ZFNat.add_assoc]
+
+  apply ZFNat.add_right_cancel.mpr
+
+  conv_rhs =>
+    rw [ZFNat.add_comm, ZFNat.add_assoc, ZFNat.add_assoc, ← right_distrib, ZFNat.add_comm t a, h₁,
+      right_distrib]
+    rw [ZFNat.add_comm (b * d + s * d), ZFNat.add_assoc, ← ZFNat.add_assoc,  ← left_distrib s, ← h₂,
+      left_distrib]
+
+  ac_rfl
+
+noncomputable abbrev mul (n m : ZFInt) : ZFInt :=
+  Quotient.liftOn₂ n m
+    (fun ⟨a, b⟩ ⟨c, d⟩ => mk (a * c + b * d, a * d + b * c)) fun _ _ _ _ => (sound <| mul_wf · ·)
+
+noncomputable instance : Mul ZFInt := ⟨ZFInt.mul⟩
+theorem mul_eq (n m : ZFNat × ZFNat) :
+  mk n * mk m = mk (n.1 * m.1 + n.2 * m.2, n.1 * m.2 + n.2 * m.1) := rfl
+
+theorem mul_comm (n m : ZFInt) : n * m = m * n := by
+  induction n using Quotient.ind
+  induction m using Quotient.ind
+  apply sound
+  rw [ZFSet.zrel]
+  ac_rfl
+
+theorem left_distrib (a b c : ZFInt) : a * (b + c) = a * b + a * c := by
+  induction a using Quotient.ind
+  induction b using Quotient.ind
+  induction c using Quotient.ind
+  rename_i a b c
+  let ⟨a₁, a₂⟩ := a
+  let ⟨b₁, b₂⟩ := b
+  let ⟨c₁, c₂⟩ := c
+  apply sound
+  simp_rw [ZFNat.left_distrib, ZFSet.zrel]
+  ac_rfl
+
+theorem right_distrib (a b c : ZFInt) : (a + b) * c = a * c + b * c := by
+  rw [mul_comm, left_distrib, mul_comm, mul_comm b c]
+
+@[simp]
+theorem zero_mul (a : ZFInt) : 0 * a = 0 := by
+  induction a using Quotient.ind
+  apply sound
+  simp_rw [ZFNat.zero_mul]
+
+@[simp]
+theorem mul_zero (a : ZFInt) : a * 0 = 0 := by
+  rw [mul_comm, zero_mul]
+
+theorem mul_assoc (a b c : ZFInt) : a * b * c = a * (b * c) := by
+  induction a using Quotient.ind
+  induction b using Quotient.ind
+  induction c using Quotient.ind
+  apply sound
+  simp_rw [ZFSet.zrel, ZFNat.left_distrib, ZFNat.right_distrib]
+  ac_rfl
+
+@[simp]
+theorem one_mul (a : ZFInt) : 1 * a = a := by
+  induction a using Quotient.ind
+  apply sound
+  simp_rw [ZFNat.one_mul, ZFNat.zero_mul, ZFNat.add_zero]
+  apply ZFSet.zrel_eq.refl
+
+@[simp]
+theorem mul_one (a : ZFInt) : a * 1 = a := by
+  rw [mul_comm, one_mul]
+
+noncomputable instance : CommRing ZFInt where
+  zero := 0
+  one := 1
+  add := add
+  add_assoc _ _ _ := by rw [add_assoc]
+  zero_add _ := zero_add
+  add_zero _ := add_zero
+  nsmul := ZFSet.ZFInt.nsmul
+  nsmul_zero _ := rfl
+  nsmul_succ _ _ := add_comm _ _
+  add_comm := add_comm
+  left_distrib := left_distrib
+  right_distrib := right_distrib
+  zero_mul := zero_mul
+  mul_zero := mul_zero
+  mul_comm := mul_comm
+  mul_assoc := mul_assoc
+  one_mul := one_mul
+  mul_one := mul_one
+  zsmul := ZFSet.ZFInt.zsmul
+  zsmul_zero' _ := rfl
+  zsmul_succ' _ _ := add_comm _ _
+  zsmul_neg' _ _ := rfl
+  neg_add_cancel _ := add_left_neg
+
+section Inequalities
+
+instance int_lt : LT ZFInt where
+  lt x y := Quotient.liftOn₂ x y
+    (fun ⟨a, b⟩ ⟨c, d⟩ => a + d < b + c) fun ⟨a, b⟩ ⟨c, d⟩ ⟨s, t⟩ ⟨u, v⟩ h₁ h₂ => by
+      replace h₁ : a + t = b + s := h₁
+      replace h₂ : c + v = d + u := h₂
+      simp only [eq_iff_iff]
+      apply Iff.intro
+      · intro lt
+        rw [← ZFNat.add_lt_add_iff_right (k := t)] at lt
+        conv_lhs at lt => rw [← ZFNat.add_assoc, ZFNat.add_comm, ← ZFNat.add_assoc,
+          ZFNat.add_comm t, h₁, ZFNat.add_comm b, ZFNat.add_assoc]
+        conv_rhs at lt => rw [← ZFNat.add_assoc, ZFNat.add_comm]
+        rw [ZFNat.add_lt_add_iff_right, ← ZFNat.add_lt_add_iff_right (k := u)] at lt
+        conv_lhs at lt => rw [← ZFNat.add_assoc, ZFNat.add_comm, ← ZFNat.add_assoc,
+          ZFNat.add_comm u, ← h₂, ZFNat.add_assoc, ZFNat.add_comm, ZFNat.add_assoc]
+        conv_rhs at lt => rw [ZFNat.add_comm, ZFNat.add_comm c, ZFNat.add_assoc]
+        rwa [ZFNat.add_lt_add_iff_right, ZFNat.add_comm, ZFNat.add_comm u] at lt
+      · intro lt
+        rw [← ZFNat.add_lt_add_iff_right (k := b)] at lt
+        conv_lhs at lt => rw [← ZFNat.add_assoc, ZFNat.add_comm, ← ZFNat.add_assoc, ← h₁,
+          ZFNat.add_assoc]
+        conv_rhs at lt => rw [← ZFNat.add_assoc, ZFNat.add_comm]
+        rw [ZFNat.add_lt_add_iff_right, ← ZFNat.add_lt_add_iff_right (k := c)] at lt
+        conv_lhs at lt => rw [ZFNat.add_comm, ZFNat.add_assoc, h₂, ZFNat.add_comm, ZFNat.add_assoc]
+        conv_rhs at lt => rw [ZFNat.add_comm, ZFNat.add_comm u, ZFNat.add_assoc]
+        rwa [ZFNat.add_lt_add_iff_right, ZFNat.add_comm c] at lt
+
+instance int_le : LE ZFInt where
+  le x y := x < y ∨ x = y
+
+theorem lt_succ {n : ZFInt} : n < n + 1 := by
+  induction' n using Quotient.ind with n
+  obtain ⟨n, m⟩ := n
+  rw [ZFInt.mk_eq, ZFInt.one_eq, ZFInt.add_eq]
+  dsimp
+  rw [ZFNat.add_zero]
+  change n+m < m+(n+1)
+  rw [ZFNat.add_comm, ZFNat.add_lt_add_iff_left, ZFNat.add_one_eq_succ]
+  exact ZFNat.lt_succ
+
+theorem lt_trans {a b c : ZFInt} : a < b → b < c → a < c := by
+  induction' a using Quotient.ind with a
+  induction' b using Quotient.ind with b
+  induction' c using Quotient.ind with c
+  let ⟨a₁, a₂⟩ := a
+  let ⟨b₁, b₂⟩ := b
+  let ⟨c₁, c₂⟩ := c
+  intros h₁ h₂
+  let this := ZFNat.add_lt_trans h₁ h₂
+  conv at this =>
+    conv => lhs; rw [← ZFNat.add_assoc, ZFNat.add_comm b₂, ZFNat.add_comm b₁, ZFNat.add_assoc,
+      ZFNat.add_assoc]
+    conv => rhs; rw [← ZFNat.add_assoc, ZFNat.add_comm b₁, ZFNat.add_comm b₂, ← ZFNat.add_assoc,
+      ZFNat.add_comm b₂, ZFNat.add_assoc, ZFNat.add_assoc]
+    rw [ZFNat.add_lt_add_iff_right (k := b₂), ZFNat.add_lt_add_iff_right (k := b₁)]
+  assumption
+
+theorem lt_irrefl {a : ZFInt} : ¬ a < a := by
+  induction' a using Quotient.ind with a
+  let ⟨a₁, a₂⟩ := a
+  intro h
+  replace h : a₁ + a₂ < a₂ + a₁ := h
+  rw [ZFNat.add_comm] at h
+  nomatch ZFNat.lt_irrefl h
+
+theorem lt_zero_iff {n m : ZFNat} : m < n ↔ 0 < ZFInt.mk (n,m) := by
+  constructor
+  · intro h
+    induction n using ZFNat.induction generalizing m with
+    | zero =>
+      rw [ZFInt.zero_eq]
+      change 0 + m < 0 + 0
+      exact ZFNat.add_lt_add_left h 0
+    | succ n ih =>
+      rw [ZFInt.zero_eq]
+      change 0 + m < 0 + n.succ
+      exact ZFNat.add_lt_add_left h 0
+  · intro h
+    rw [ZFInt.zero_eq] at h
+    change 0 + m < 0 + n at h
+    exact ZFNat.add_lt_add_iff_left.mp h
+
+theorem neg_one_lt_zero : (-1 : ZFInt) < 0 := add_left_neg ▸ lt_succ (n := (-1))
+theorem zero_lt_one : (0 : ZFInt) < 1 := ZFInt.zero_add (x:=1) ▸ lt_succ
+
+theorem le_trans {a b c : ZFInt} : a ≤ b → b ≤ c → a ≤ c := by
+  intro h₁ h₂
+  rcases h₁ with h₁ | rfl
+  · rcases h₂ with h₂ | rfl
+    · left
+      exact lt_trans h₁ h₂
+    · left; assumption
+  · assumption
+
+theorem le_antisymm {a b : ZFInt} : a ≤ b → b ≤ a → a = b := by
+  intro h₁ h₂
+  rcases h₁ with h₁ | rfl
+  · rcases h₂ with h₂ | rfl
+    · nomatch lt_irrefl <| lt_trans h₁ h₂
+    · rfl
+  · rfl
+
+theorem le_total {a b : ZFInt} : a ≤ b ∨ b ≤ a := by
+  induction' a using Quotient.ind with a
+  induction' b using Quotient.ind with b
+  let ⟨a₁, a₂⟩ := a
+  let ⟨b₁, b₂⟩ := b
+  rcases @ZFNat.le_total (a₁ + b₂) (a₂ + b₁) with (_ | _) | (h | h)
+  · left; left; assumption
+  · left; right; apply sound; assumption
+  · right; left; rw [ZFNat.add_comm a₂, ZFNat.add_comm a₁] at h; assumption
+  · right; right; apply sound; rw [ZFNat.add_comm a₂, ZFNat.add_comm a₁] at h; assumption
+
+theorem lt_iff_le_not_le {x y : ZFInt} : x < y ↔ x ≤ y ∧ ¬y ≤ x := by
+  apply Iff.intro
+  · intro
+    apply And.intro
+    · left
+      assumption
+    · rintro (_ | rfl)
+      · nomatch lt_irrefl (lt_trans ‹_› ‹_›)
+      · nomatch lt_irrefl ‹_›
+  · rintro ⟨h | rfl, h'⟩
+    · assumption
+    · simp only [int_le, or_true] at h'
+      contradiction
+
+theorem lt_neg_iff {a b : ZFInt} : a < b ↔ -b < -a := by
+  constructor <;>
+  (
+    intro le
+    induction' a using Quotient.ind with a
+    induction' b using Quotient.ind with b
+    let ⟨a₁, a₂⟩ := a
+    let ⟨b₁, b₂⟩ := b
+    rw [ZFInt.mk_eq, ZFInt.mk_eq] at le ⊢
+  )
+  · change a₁ + b₂ < a₂ + b₁ at le
+    change b₂ + a₁ < b₁ + a₂
+    rwa [ZFNat.add_comm b₂, ZFNat.add_comm b₁]
+  · change b₂ + a₁ < b₁ + a₂ at le
+    change a₁ + b₂ < a₂ + b₁
+    rwa [ZFNat.add_comm a₂, ZFNat.add_comm a₁]
+
+theorem le_neg_iff {a b : ZFInt} : a ≤ b ↔ -b ≤ -a := by
+  constructor <;>
+  (
+    intro le
+    induction' a using Quotient.ind with a
+    induction' b using Quotient.ind with b
+    let ⟨a₁, a₂⟩ := a
+    let ⟨b₁, b₂⟩ := b
+    rw [ZFInt.mk_eq, ZFInt.mk_eq] at le ⊢
+  )
+  · rcases le with le | le
+    · left
+      exact lt_neg_iff.mp le
+    · rw [eq, ZFSet.zrel] at le
+      right
+      rwa [neg_eq, neg_eq, eq, ZFSet.zrel, ZFNat.add_comm b₂, ZFNat.add_comm b₁]
+  · rcases le with le | le
+    · left
+      exact lt_neg_iff.mpr le
+    · rw [neg_eq, neg_eq, eq, ZFSet.zrel] at le
+      right
+      rwa [eq, ZFSet.zrel, ZFNat.add_comm a₁, ZFNat.add_comm a₂]
+
+noncomputable instance : LinearOrder ZFInt where
+  le := int_le.le
+  le_refl x := Or.inr rfl
+  le_trans _ _ _ := le_trans
+  le_antisymm _ _ := le_antisymm
+  le_total _ _ := le_total
+  toDecidableLE := fun _ _ => Classical.propDecidable ((· ≤ ·) _ _)
+  lt_iff_le_not_le _ _ := lt_iff_le_not_le
+
+noncomputable instance : AddCommGroup ZFInt where
+  add := add
+  add_assoc := (add_assoc · · · |>.symm)
+  zero := zero
+  zero_add := @zero_add
+  add_zero := @add_zero
+  nsmul := nsmul
+  nsmul_succ x y := add_comm y (nsmul x y)
+  neg := ZFInt.neg
+  zsmul := zsmul
+  zsmul_succ' x y := add_comm y (nsmul x y)
+  neg_add_cancel := @add_left_neg
+  add_comm := @add_comm
+
+instance : PartialOrder ZFInt where
+  le := int_le.le
+  le_refl := le_refl
+  le_trans := @le_trans
+  lt_iff_le_not_le := @lt_iff_le_not_le
+  le_antisymm := @le_antisymm
+
+instance : IsOrderedAddMonoid ZFInt where
+  add_le_add_left x y h z := by
+    induction' x using Quotient.ind with x
+    induction' y using Quotient.ind with y
+    induction' z using Quotient.ind with z
+    let ⟨x₁, x₂⟩ := x
+    let ⟨y₁, y₂⟩ := y
+    let ⟨z₁, z₂⟩ := z
+    simp_rw [mk_eq] at h ⊢
+    rcases h with h | h
+    · change x₁ + y₂ < x₂ + y₁ at h
+      simp_rw [add_eq]
+      left
+      change z₁ + x₁ + (z₂ + y₂) < z₂ + x₂ + (z₁ + y₁)
+      conv_lhs => rw [← ZFNat.add_assoc, ZFNat.add_comm z₁, ZFNat.add_comm z₂, ZFNat.add_assoc,
+        ←ZFNat.add_assoc, ZFNat.add_comm z₂]
+      conv_rhs => rw [ZFNat.add_comm z₂, ←ZFNat.add_assoc, ZFNat.add_comm z₂, ZFNat.add_comm z₁,
+        ZFNat.add_assoc, ZFNat.add_assoc, ←ZFNat.add_assoc]
+      exact ZFNat.add_lt_add_iff_right.mpr h
+    · rw [eq, ZFSet.zrel] at h
+      dsimp at h
+      right
+      rw [add_eq, add_eq, eq, ZFSet.zrel]
+      dsimp
+      conv_lhs => rw [← ZFNat.add_assoc, ZFNat.add_comm z₁, ZFNat.add_comm z₂, ZFNat.add_assoc,
+        ←ZFNat.add_assoc, ZFNat.add_comm z₂, h]
+      conv_rhs => rw [ZFNat.add_comm z₂, ←ZFNat.add_assoc, ZFNat.add_comm z₂, ZFNat.add_comm z₁,
+        ZFNat.add_assoc, ZFNat.add_assoc, ←ZFNat.add_assoc]
+
+end Inequalities
+
+section Induction
+
+lemma ind {P : ZFNat → ZFNat → Prop} (n m : ZFNat) (zero : P 0 0)
+  (succ_l : ∀ n m, P n m → P (n+1) m) (succ_r : ∀ n m, P n m → P n (m+1)) : P n m := by
+  induction n using ZFNat.induction with
+  | zero =>
+    induction m using ZFNat.induction with
+    | zero => exact zero
+    | succ m ih =>
+      rw [←ZFNat.add_one_eq_succ]
+      exact succ_r 0 m ih
+  | succ n ih =>
+    rw [←ZFNat.add_one_eq_succ]
+    exact succ_l n m ih
+
+lemma induction_pos {P : ZFInt → Prop} (n : ZFInt) (n_pos : 0 ≤ n)
+  (zero : P 0) (succ : ∀ k, P k → P (k + 1)) : P n := by
+  induction' n using Quotient.ind with n
+  obtain ⟨n, m⟩ := n
+  rcases ZFNat.instIsStrictTotalOrderLt.trichotomous n m with h | rfl | h
+  · exfalso
+    rw [ZFInt.lt_zero_iff] at h
+    rcases n_pos with n_pos | eq
+    · rw [ZFInt.zero_eq] at h n_pos
+      change 0 + n < 0 + m at h
+      change 0 + m < 0 + n at n_pos
+      rw [ZFNat.zero_add, ZFNat.zero_add] at h n_pos
+      nomatch ZFNat.lt_irrefl <| ZFNat.lt_trans h n_pos
+    · rw [ZFInt.mk_eq] at eq
+      rcases ZFInt.mk_eq_zero_iff.mp eq.symm with rfl
+      rw [eq] at h
+      change n + n < n + n at h
+      nomatch ZFNat.lt_irrefl h
+  · rcases n_pos with n_pos | eq
+    · rw [ZFInt.zero_eq] at n_pos
+      change 0 + n < 0 + n at n_pos
+      nomatch ZFNat.lt_irrefl n_pos
+    · rwa [←eq]
+  · let k := n - m
+    have : n = k + m := by
+      apply ZFNat.eq_add_of_sub_eq _ rfl
+      left
+      exact h
+    rw [this]
+    induction k using ZFNat.induction with
+    | zero =>
+      rw [ZFInt.zero_eq] at zero
+      rwa [ZFNat.zero_add, ZFInt.mk_eq, ZFInt.eq (x := (m,m)) (y := (0,0)) |>.mpr rfl]
+    | succ k ih =>
+      rw [ZFNat.add_comm] at ih
+      rw [←ZFNat.add_one_eq_succ, ZFNat.add_comm, ZFNat.add_assoc]
+      specialize succ <| ZFInt.mk (m+k,m)
+      rw [ZFInt.one_eq, ZFInt.add_eq] at succ
+      dsimp at succ
+      rw [ZFNat.add_zero, ←ZFInt.mk_eq] at succ
+      exact succ ih
+
+lemma induction_neg {P : ZFInt → Prop} (n : ZFInt) (n_neg : n ≤ 0)
+  (zero : P 0) (succ : ∀ k, P k → P (k - 1)) : P n := by
+  have  : 0 ≤ -n := by rwa [← ZFInt.neg_zero, ZFInt.le_neg_iff, neg_neg n, neg_neg 0]
+  letI P' n := P (-n)
+  suffices P' (-n) by
+    unfold P' at this
+    rwa [ZFInt.neg_neg] at this
+  have succ' : ∀ k, P' k → P' (k + 1) := by
+    intro k hk
+    unfold P' at hk ⊢
+    rw [ZFInt.neg_add]
+    exact succ _ hk
+  exact induction_pos (P := P') (-n) this zero succ'
+
+@[induction_eliminator]
+theorem induction {P : ZFInt → Prop} (n : ZFInt)
+  (zero : P 0) (pos : ∀ k, P k → P (k + 1)) (neg : ∀ k, P k → P (k - 1)) : P n := by
+  rcases instIsStrictTotalOrderLt.trichotomous n 0 with h | rfl | h
+  · exact induction_neg n (Or.inl h) zero neg
+  · exact zero
+  · exact induction_pos n (Or.inl h) zero pos
+
+@[cases_eliminator]
+theorem sign_cases {P : ZFInt → Prop} (n : ZFInt)
+  (zero : P 0) (neg : n < 0 → P n) (pos : 0 < n → P n) : P n := by
+  induction n with
+  | zero => exact zero
+  | pos k ih =>
+    rcases lt_trichotomy (k+1) 0 with h | h | h
+    · exact neg h
+    · rwa [h]
+    · exact pos h
+  | neg k ih =>
+    rcases lt_trichotomy (k-1) 0 with h | h | h
+    · exact neg h
+    · rwa [h]
+    · exact pos h
+
+@[cases_eliminator]
+theorem cases {P : ZFInt → Prop} (n : ZFInt) (pos : 0 ≤ n → P n) (neg : n < 0 → P n) : P n := by
+  induction n with
+  | zero => exact pos (Or.inr rfl)
+  | pos n ih =>
+    generalize h : n + 1 = m at *
+    cases m using sign_cases with
+    | zero => exact pos (Or.inr rfl)
+    | neg h => exact neg h
+    | pos h => exact pos (Or.inl h)
+  | neg n ih =>
+    generalize h : n - 1 = m at *
+    cases m using sign_cases with
+    | zero => exact pos (Or.inr rfl)
+    | neg h => exact neg h
+    | pos h => exact pos (Or.inl h)
+
+end Induction
+
+theorem add_eq_add_sub_eq_sub {a b c d : ZFNat} : a + b = c + d → a - c = d - b := by
+  intro h
+  have : a = c + d - b := ZFNat.sub_eq_of_eq_add h.symm |>.symm
+  subst this
+  rw [←ZFNat.sub_add_distrib, ZFNat.add_comm b c, ZFNat.add_sub_add_left c d b]
+
+theorem le_of_lt_succ (n m : ZFInt) : n < m + 1 → n ≤ m := by
+  intro h
+  induction' n using Quotient.ind with n
+  induction' m using Quotient.ind with m
+  obtain ⟨a, b⟩ := n
+  obtain ⟨c, d⟩ := m
+  simp_rw [mk_eq] at h ⊢
+  rw [one_eq, add_eq, ZFNat.add_zero] at h
+  change a + d < b + (c + 1) at h
+  suffices a + d ≤ b + c by
+    rcases this with h | h
+    · left; exact h
+    · right; exact sound h
+  rwa [ZFNat.add_assoc, ZFNat.add_one_eq_succ, ←ZFNat.lt_le_iff] at h
+
+theorem lt_succ_of_le (n m : ZFInt) : n ≤ m → n < m + 1 := by
+  rintro (h | rfl)
+  · trans n+1
+    · exact lt_succ
+    · exact (add_lt_add_iff_right 1).mpr h
+  · exact lt_succ
+
+theorem lt_succ_of_le_iff (n m : ZFInt) : n ≤ m ↔ n < m + 1 where
+  mp := lt_succ_of_le n m
+  mpr := le_of_lt_succ n m
+
+theorem int_le.dest {n m : ZFInt} : n ≤ m → ∃ k, 0 ≤ k ∧ n + k = m := by
+  intro h
+  exists m - n
+  and_intros
+  · exact sub_nonneg_of_le h
+  · exact _root_.add_sub_cancel n m
+
+theorem mul_pos_pos_pos (a b : ZFInt) (ha : 0 < a) (hb : 0 < b) : 0 < a * b := by
+  induction' a using Quotient.ind with a
+  induction' b using Quotient.ind with b
+  obtain ⟨c, d⟩ := b
+  obtain ⟨a, b⟩ := a
+  simp_rw [mk_eq, zero_eq] at ha hb ⊢
+  rw [mul_eq]
+  change 0 + d < 0 + c at hb
+  change 0 + b < 0 + a at ha
+  change 0 + (a * d + b * c) < 0 + (a * c + b * d)
+  simp_rw [ZFNat.zero_add] at ha hb ⊢
+  rw [ZFNat.sub_add_cancel (Or.inl hb) |>.symm, ZFNat.left_distrib, ZFNat.left_distrib,
+    ZFNat.add_comm _ (b*d), ZFNat.add_assoc, ←ZFNat.right_distrib, ←ZFNat.add_assoc,
+    ←ZFNat.right_distrib, ZFNat.add_comm, ZFNat.add_lt_add_iff_right, ZFNat.mul_comm b,
+    ZFNat.mul_comm a]
+  apply ZFNat.mul_lt_mono
+  · exact ZFNat.pos_of_ne_zero (ZFNat.sub_ne_zero_of_lt hb).symm
+  · exact ha
+
+theorem neg_one_mul (a : ZFInt) : (-1 : ZFInt) * a = -a := by
+  induction' a using Quotient.ind with a
+  obtain ⟨a, b⟩ := a
+  rw [mk_eq, one_eq, neg_eq, mul_eq, neg_eq]
+  dsimp
+  rw [ZFNat.zero_mul, ZFNat.zero_mul, ZFNat.one_mul, ZFNat.one_mul, ZFNat.zero_add, ZFNat.zero_add]
+
+theorem neg_one_mul_neg_one : (-1 : ZFInt) * (-1) = 1 := by
+  rw [one_eq, neg_eq, mul_eq, ZFNat.mul_zero, ZFNat.zero_mul, ZFNat.zero_add, ZFNat.zero_add,
+    ZFNat.one_mul, ZFNat.one_mul]
+
+theorem mul_neg_neg (a b : ZFInt) : a * b = -a * -b := by
+  rw [←one_mul (a*b), ←neg_one_mul_neg_one, ←mul_assoc, mul_comm, mul_assoc, mul_comm, mul_assoc,
+    mul_comm (-1), mul_assoc, mul_comm b, neg_one_mul, neg_one_mul]
+
+theorem neg_mul_distrib (a b : ZFInt) : -(a * b) = -a * b := neg_mul_eq_neg_mul a b
+
+theorem mul_neg_neg_pos (a b : ZFInt) (ha : a < 0) (hb : b < 0) : 0 < a * b := by
+  rw [mul_neg_neg]
+  exact mul_pos_pos_pos _ _ (Left.neg_pos_iff.mpr ha) (Left.neg_pos_iff.mpr hb)
+
+theorem neg_flip_lt (a : ZFInt) : a < 0 ↔ 0 < -a := Iff.symm Left.neg_pos_iff
+theorem neg_flip_le (a : ZFInt) : a ≤ 0 ↔ 0 ≤ -a := Iff.symm neg_nonneg
+
+theorem mul_neg_pos_neg (a b : ZFInt) (ha : a < 0) (hb : 0 < b) : a * b < 0 := by
+  rw [neg_flip_lt, neg_mul_eq_neg_mul]
+  exact mul_pos_pos_pos _ _ ((neg_flip_lt a).mp ha) hb
+
+theorem mul_pos_neg_neg (a b : ZFInt) (ha : 0 < a) (hb : b < 0) : a * b < 0 := by
+  rw [mul_comm, neg_flip_lt, neg_mul_eq_neg_mul]
+  exact mul_pos_pos_pos _ _ ((neg_flip_lt b).mp hb) ha
+
+theorem mul_nonneg_nonneg_nonneg (a b : ZFInt) (ha : 0 ≤ a) (hb : 0 ≤ b) : 0 ≤ a * b := by
+  rcases ha with ha | rfl <;> rcases hb with hb | rfl
+  · left
+    exact mul_pos_pos_pos a b ha hb
+  · right
+    rw [mul_zero]
+  · right
+    rw [zero_mul]
+  · right
+    rw [zero_mul]
+
+theorem mul_nonpos_nonneg_nonpos (a b : ZFInt) (ha : a ≤ 0) (hb : 0 ≤ b) : a * b ≤ 0 := by
+  rw [neg_flip_le, neg_mul_eq_neg_mul]
+  exact mul_nonneg_nonneg_nonneg _ _ (neg_nonneg.mpr ha) hb
+
+theorem mul_nonneg_nonpos_nonpos (a b : ZFInt) (ha : 0 ≤ a) (hb : b ≤ 0) : a * b ≤ 0 := by
+  rw [mul_comm, neg_flip_le, neg_mul_eq_neg_mul]
+  exact mul_nonneg_nonneg_nonneg _ _ (neg_nonneg.mpr hb) ha
+
+theorem mul_nonpos_nonpos_nonneg (a b : ZFInt) (ha : a ≤ 0) (hb : b ≤ 0) : 0 ≤ a * b := by
+  rw [mul_neg_neg]
+  exact mul_nonneg_nonneg_nonneg _ _ (neg_nonneg.mpr ha) (neg_nonneg.mpr hb)
+
+theorem mul_le_mul_left {n m : ZFInt} (k : ZFInt) (h : n ≤ m) (h' : 0 ≤ k) : k * n ≤ k * m := by
+  obtain ⟨l, pos, hl⟩ := int_le.dest h
+  have : k * n + k * l = k * m := by rw [←hl, left_distrib]
+  rw [←this]
+  apply le_add_of_nonneg_right
+  exact mul_nonneg_nonneg_nonneg k l h' pos
+
+theorem mul_lt_mul_of_pos_left {n m k : ZFInt} (h : n < m) (hk : k > 0) : k * n < k * m := by
+  apply lt_of_lt_of_le (b := k*n+k)
+  · exact lt_add_of_pos_right _ hk
+  · conv =>
+      enter [1,2]
+      rw [←mul_one k]
+    rw [←left_distrib]
+    apply mul_le_mul_left k
+    · exact (lt_succ_of_le_iff (n + 1) m).mpr <| (add_lt_add_iff_right 1).mpr h
+    · exact le_of_lt hk
+
+theorem pos_of_mul_pos {a b : ZFInt} (h : 0 < a * b) (ha : 0 < a) : 0 < b := by
+  classical
+  by_contra hb
+  rw [not_lt_iff_eq_or_lt] at hb
+  rcases hb with rfl | hb
+  · rw [mul_zero] at h
+    exact lt_irrefl h
+  · rcases instIsStrictTotalOrderLt.trichotomous a b with h' | rfl | h'
+    · nomatch lt_irrefl <| lt_trans (lt_trans ha h') hb
+    · nomatch lt_irrefl <| lt_trans ha hb
+    · nomatch lt_irrefl <| lt_trans h <| mul_pos_neg_neg a b ha hb
+
+theorem mul_lt_mul_of_pos_right {n m k : ZFInt} (h : n < m) (hk : k > 0) : n * k < m * k := by
+  rw [mul_comm n, mul_comm m]
+  exact mul_lt_mul_of_pos_left h hk
+
+theorem mul_pos_iff {a b : ZFInt} : 0 < a * b ↔ (0 < a ∧ 0 < b) ∨ (a < 0 ∧ b < 0) := by
+  constructor
+  · intro h
+    cases a with
+    | pos pos =>
+      rcases pos with pos | rfl
+      · left
+        and_intros
+        · exact pos
+        · exact pos_of_mul_pos h pos
+      · rw [zero_mul] at h
+        nomatch lt_irrefl h
+    | neg neg =>
+      right
+      and_intros
+      · exact neg
+      · rw [mul_neg_neg] at h
+        rw [neg_flip_lt] at neg
+        have := pos_of_mul_pos h neg
+        rwa [←neg_flip_lt] at this
+  · rintro (⟨l, r⟩ | ⟨l, r⟩)
+    · exact mul_pos_pos_pos a b l r
+    · exact mul_neg_neg_pos a b l r
+
+theorem eq_le_iff {a b : ZFInt} : a = b ↔ a ≤ b ∧ b ≤ a := by
+  constructor
+  · rintro rfl
+    exact ⟨le_refl _, le_refl _⟩
+  · rintro ⟨h₁, h₂⟩
+    rcases h₁ with h₁ | rfl <;> rcases h₂ with h₂ | h₂
+    · nomatch lt_irrefl <| lt_trans h₁ h₂
+    · exact h₂.symm
+    · rfl
+    · rfl
+
+theorem mul_eq_zero_iff {a b : ZFInt} : a * b = 0 ↔ a = 0 ∨ b = 0 := by
+  constructor
+  · intro h
+    induction' a using Quotient.ind with a
+    induction' b using Quotient.ind with b
+    let ⟨a₁, a₂⟩ := a
+    let ⟨b₁, b₂⟩ := b
+    simp_rw [mk_eq, mul_eq, zero_eq, eq, ZFSet.zrel, ZFNat.add_zero] at h ⊢
+    rcases ZFNat.instIsStrictTotalOrderLt.trichotomous b₁ b₂ with h' | rfl | h'
+    · have := ZFNat.add_eq_add_sub_eq_sub h.symm
+      rw [←ZFNat.left_distrib_mul_sub, ←ZFNat.left_distrib_mul_sub] at this
+      have b₁b₂_ne_0 : b₂ - b₁ ≠ 0 := by
+        intro contr
+        rw [ZFNat.sub_eq_zero_imp_le] at contr
+        rcases contr with contr | rfl
+        · nomatch ZFNat.lt_irrefl <| ZFNat.lt_trans contr h'
+        · nomatch ZFNat.lt_irrefl h'
+      left
+      exact ZFNat.mul_right_cancel_iff b₁b₂_ne_0 |>.mp this
+    · right; rfl
+    · have := ZFNat.add_eq_add_sub_eq_sub h
+      rw [←ZFNat.left_distrib_mul_sub, ←ZFNat.left_distrib_mul_sub] at this
+      have b₁b₂_ne_0 : b₁ - b₂ ≠ 0 := by
+        intro contr
+        rw [ZFNat.sub_eq_zero_imp_le] at contr
+        rcases contr with contr | rfl
+        · nomatch ZFNat.lt_irrefl <| ZFNat.lt_trans contr h'
+        · nomatch ZFNat.lt_irrefl h'
+      left
+      exact ZFNat.mul_right_cancel_iff b₁b₂_ne_0 |>.mp this
+  · rintro (h | h)
+    · rw [h, zero_mul]
+    · rw [h, mul_zero]
+
+theorem mul_eq_zero_of_ne_zero {a b : ZFInt} : a * b = 0 → a ≠ 0 → b = 0 := by
+  intro h h'
+  rw [mul_eq_zero_iff] at h
+  exact Or.resolve_left h h'
+
+theorem mul_left_cancel_iff {a b n : ZFInt} (h : n ≠ 0) : n * a = n * b ↔ a = b := by
+  constructor
+  · intro eq
+    have : n*a - n*b = 0 := sub_eq_zero_of_eq eq
+    rw [ZFInt.sub_eq_add_neg, mul_comm n b, neg_mul_distrib, mul_comm _ n, ←left_distrib,
+      mul_eq_zero_iff] at this
+    rcases this with rfl | this
+    · nomatch h
+    · exact eq_of_sub_eq_zero this
+  · exact fun h => h ▸ rfl
+
+theorem mul_right_cancel_iff {a b n : ZFInt} (h : n ≠ 0) : a * n = b * n ↔ a = b := by
+  rw [mul_comm a n, mul_comm b n]
+  exact mul_left_cancel_iff h
+
+noncomputable instance : CommRing ZFInt where
+  add := add
+  add_assoc := (add_assoc · · · |>.symm)
+  add_comm := add_comm
+  zero_add _ := zero_add
+  add_zero _ := add_zero
+  nsmul := nsmul
+  nsmul_succ x y := add_comm y (nsmul x y)
+  left_distrib := left_distrib
+  right_distrib := right_distrib
+  zsmul := zsmul
+  zsmul_succ' x y := add_comm y (nsmul x y)
+  neg_add_cancel := @add_left_neg
+
+instance : PartialOrder ZFInt where
+  le := int_le.le
+  le_refl := le_refl
+  le_trans := @le_trans
+  le_antisymm := @le_antisymm
+  lt_iff_le_not_le := @lt_iff_le_not_le
+
+instance : IsOrderedRing ZFInt where
+  add_le_add_left _ _ h z := (add_le_add_iff_left z).mpr h
+  zero_le_one := Or.inl zero_lt_one
+  mul_le_mul_of_nonneg_left _ _ := (mul_le_mul_left · · ·)
+  mul_le_mul_of_nonneg_right a b c h h' := by
+    rw [mul_comm a, mul_comm b]
+    exact mul_le_mul_left c h h'
+
+end ZFInt
+
+noncomputable abbrev Int := Nat.prod {∅} ∪ ZFSet.prod {∅} Nat
+
+noncomputable def ofInt : ℤ → ZFSet
+  | .ofNat n => ZFSet.pair ∅ (n : ZFNat)
+  | .negSucc n => ZFSet.pair (n+1 : ZFNat) ∅
+
+noncomputable def toZFInt : ℤ → ZFInt
+  | .ofNat n => ZFInt.mk (0, ↑n)
+  | .negSucc n => ZFInt.mk (↑n+1, 0)
+
+example : ofInt 0 = {{∅}} := by
+  dsimp [ofInt, pair]
+  ext x
+  simp
+  intro
+  subst x
+  ext x
+  simp
+  exact id
+
+section -- could be another definition
+private def ofInt' : (n : ℤ) → PSet
+  | .ofNat 0 => {{∅}}
+  | .ofNat (n+1) => {{∅}, {∅, .ofNat n}} -- (0, n)
+  | .negSucc n => {{.ofNat (n+1)}, {∅, .ofNat (n+1)}} -- (n, 0)
+
+def PInt' : PSet := ⟨ULift ℤ, fun n => ofInt' n.down⟩
+def Int' : ZFSet := ZFSet.mk PInt'
+end
+
+theorem ZFNat.mem_lift_lift_Nat (n : ℕ) : ↑(↑n : ZFNat) ∈ Nat := by
+  induction n with
+  | zero => simp only [Nat.cast_zero, ZFNat.nat_zero_eq, ZFNat.zero_in_Nat]
+  | succ n ih =>
+    simp only [Nat.cast_succ, ZFNat.add_one_eq_succ, ZFNat.succ]
+    exact ZFNat.succ_mem_Nat' ih
+
+theorem mem_ofInt_Int (n : ℤ) : ofInt n ∈ Int := by
+  induction n using Int.recOn with
+  | ofNat n =>
+    rw [Int, mem_union, ofInt]
+    right
+    rw [pair_mem_prod]
+    exact ⟨singleton_subset_mem_iff.mp fun _ => id, ZFNat.mem_lift_lift_Nat n⟩
+  | negSucc n =>
+    rw [Int, mem_union, ofInt]
+    left
+    rw [pair_mem_prod]
+    exact ⟨ZFNat.mem_lift_lift_Nat (n+1), singleton_subset_mem_iff.mp fun _ => id⟩
+
+theorem sub_ofInt_singleton_Int (n : ℤ) : {ofInt n} ⊆ Int := by
+  intro
+  rw [mem_singleton]
+  rintro rfl
+  exact mem_ofInt_Int n
+
+lemma Int.nonempty : ZFSet.Int ≠ ∅ := by
+  intro h
+  rw [ZFSet.ext_iff] at h
+  simp only [ZFSet.not_mem_empty, iff_false] at h
+  nomatch h (ZFSet.ofInt 0) (ZFSet.mem_ofInt_Int 0)
+
+def π₁ (x : ZFSet) : ZFSet := ⋃₀ (⋂₀ x)
+
+open Classical in -- couldn't find another way
+noncomputable def π₂ (x : ZFSet) : ZFSet :=
+  let δ : ZFSet := (⋃₀ x \ ⋂₀ x)
+  if δ = ∅ then π₁ x else ⋃₀ δ
+
+@[simp] theorem π₁_pair (x y : ZFSet) : π₁ (x.pair y) = x := by
+  unfold π₁ pair
+  ext
+  rw [sInter_pair, mem_sUnion]
+  constructor
+  · rintro ⟨w, l, r⟩
+    rw [mem_inter, mem_singleton, mem_pair] at l
+    rw [l.1] at r
+    assumption
+  · intro h
+    exists x
+    rw [mem_inter, mem_singleton, mem_pair]
+    exact ⟨⟨rfl, .inl rfl⟩, h⟩
+
+@[simp] theorem pair_inter {x y : ZFSet} : {x} ∩ {x, y} = ({x} : ZFSet) := by
+    ext
+    rw [mem_inter, mem_singleton, mem_pair]
+    constructor
+    · rintro ⟨rfl, _ | rfl⟩ <;> rfl
+    · rintro rfl
+      exact ⟨rfl, .inl rfl⟩
+
+@[simp] theorem pair_union {x y : ZFSet} : {x} ∪ {x, y} = ({x, y} : ZFSet) := by
+    ext
+    rw [mem_union, mem_singleton, mem_pair]
+    exact or_self_left
+
+@[simp] theorem pair_minus {x y : ZFSet} : x ≠ y → {x, y} \ {x} = ({y} : ZFSet) := by
+  intro x_ne_y
+  ext z
+  rw [mem_diff, mem_pair, mem_singleton, mem_singleton]
+  constructor
+  · rintro ⟨rfl | rfl, r⟩
+    · contradiction
+    · rfl
+  · rintro rfl
+    exact ⟨.inr rfl, x_ne_y ∘ Eq.symm⟩
+
+@[simp] theorem π₂_pair (x y : ZFSet) : π₂ (x.pair y) = y := by
+  unfold π₂
+  dsimp
+  split_ifs with h
+  · rw [π₁_pair]
+    unfold pair at h
+    rw [sUnion_pair, pair_union, sInter_pair, pair_inter] at h
+    by_cases eq : x = y
+    · assumption
+    · rw [pair_minus eq, ZFSet.ext_iff] at h
+      simp only [mem_singleton, not_mem_empty, iff_false, forall_eq] at h
+  · unfold pair at *
+    rw [sUnion_pair, pair_union, sInter_pair, pair_inter] at h ⊢
+    rw [pair_minus]
+    · exact sUnion_singleton
+    · intro h'
+      rw [h'] at h
+      simp [ZFSet.ext_iff] at h
+
+theorem mem_Int_proj_iff {x : ZFSet} (h : x ∈ Int) :
+  ∃ n ∈ Nat, (x.π₁ = ∅ ∧ x.π₂ = n) ∨ (x.π₁ = n ∧ x.π₂ = ∅) := by
+  simp_rw [mem_union, mem_prod] at h
+  rcases h with ⟨a, ha, b, hb, x_eq⟩ | ⟨b, hb, a, ha, x_eq⟩
+    <;> (simp at hb; subst x_eq; rw [π₁_pair, π₂_pair]; exists a)
+  · exact ⟨ha, .inr ⟨rfl, hb⟩⟩
+  · exact ⟨ha, .inl ⟨hb, rfl⟩⟩
+
+theorem mem_Int_proj {x : ZFSet} : x ∈ Int → (x.π₁ = ∅ ∧ x.π₂ ∈ Nat) ∨ (x.π₁ ∈ Nat ∧ x.π₂ = ∅) := by
+  intro h
+  rcases mem_Int_proj_iff h with ⟨n, hn, ⟨l, r⟩ | ⟨l, r⟩⟩
+  · left
+    exact ⟨l, r ▸ hn⟩
+  · right
+    exact ⟨l ▸ hn, r⟩
+
+open Classical in
+private noncomputable def ZFInt.outof : {x // x ∈ Int} → ZFInt := fun ⟨n, hn⟩ =>
+  have := mem_Int_proj hn
+  if case : n.π₁ = ∅ ∧ n.π₂ ∈ Nat then
+    ZFInt.mk ⟨0, n.π₂, case.right⟩
+  else
+    ZFInt.mk ⟨⟨n.π₁, Or.resolve_left this case |>.left⟩, 0⟩
+
+theorem ZFInt.outof_inj (x y : {x // x ∈ Int}) : outof x = outof y → x = y := by
+  let ⟨x, hx⟩ := x
+  let ⟨y, hy⟩ := y
+  simp [outof]
+  intro outof_eq
+  split_ifs at outof_eq with h₁ h₂ h₂
+    <;> (
+      first
+      | obtain ⟨l₁, r₁⟩ := h₁
+      | obtain ⟨l₁, r₁⟩ := Or.resolve_left (mem_Int_proj hx) h₁
+      first
+      | obtain ⟨l₂, r₂⟩ := h₂
+      | obtain ⟨l₂, r₂⟩ := Or.resolve_left (mem_Int_proj hy) h₂
+    )
+  · apply exact at outof_eq
+    simp [ZFSet.zrel] at outof_eq
+    simp_rw [mem_union, mem_prod] at hx hy
+    rcases hx, hy with ⟨⟨_, _, _, _, rfl⟩|⟨_, _, _, _, rfl⟩,⟨_, _, _, _, rfl⟩|⟨_, _, _, _, rfl⟩⟩
+      <;> (simp [π₁_pair, π₂_pair] at l₁ r₁ l₂ r₂ outof_eq; subst_eqs; congr)
+  · apply exact at outof_eq
+    simp [ZFSet.zrel] at outof_eq
+    obtain ⟨l₃, r₃⟩ := ZFNat.eq_zero_of_add_eq_zero outof_eq.symm
+    injection l₃ with l₃
+    injection r₃ with r₃
+    simp_rw [mem_union, mem_prod] at hx hy
+    rcases hx, hy with ⟨⟨_, _, _, _, rfl⟩|⟨_, _, _, _, rfl⟩,⟨_, _, _, _, rfl⟩|⟨_, _, _, _, rfl⟩⟩
+      <;> (simp [π₁_pair, π₂_pair] at l₁ r₁ l₂ r₂ l₃ r₃ outof_eq; subst_eqs; congr)
+  · apply exact at outof_eq
+    simp [ZFSet.zrel] at outof_eq
+    obtain ⟨l₃, r₃⟩ := ZFNat.eq_zero_of_add_eq_zero outof_eq
+    injection l₃ with l₃
+    injection r₃ with r₃
+    simp_rw [mem_union, mem_prod] at hx hy
+    rcases hx, hy with ⟨⟨_, _, _, _, rfl⟩|⟨_, _, _, _, rfl⟩,⟨_, _, _, _, rfl⟩|⟨_, _, _, _, rfl⟩⟩
+      <;> (simp [π₁_pair, π₂_pair] at l₁ r₁ l₂ r₂ l₃ r₃ outof_eq; subst_eqs; congr)
+  · apply exact at outof_eq
+    simp [ZFSet.zrel] at outof_eq
+    simp_rw [mem_union, mem_prod] at hx hy
+    rcases hx, hy with ⟨⟨_, _, _, _, rfl⟩|⟨_, _, _, _, rfl⟩,⟨_, _, _, _, rfl⟩|⟨_, _, _, _, rfl⟩⟩
+      <;> (simp [π₁_pair, π₂_pair] at l₁ r₁ l₂ r₂ outof_eq; subst_eqs; congr)
+
+theorem ZFNat.mem_Nat_sub_one {n : ZFNat} : (n - 1).1 ∈ Nat := by
+  induction n with
+  | zero => rw [ZFNat.zero_sub]; exact ZFNat.zero_in_Nat
+  | succ n _ =>
+    rw [ZFNat.sub_one_eq_pred, ZFNat.add_one_eq_succ, ZFNat.pred_succ]
+    rcases n; simpa
+
+theorem ZFNat.mem_Nat_sub {n m : ZFNat} : (n - m).1 ∈ Nat := by
+  induction m with
+  | zero => rcases n; simpa
+  | succ m _ =>
+    rw [ZFNat.sub_add_distrib]
+    exact ZFNat.mem_Nat_sub_one
+
+theorem mem_Int_empty_not_mem {x : ZFSet} {h : x ∈ Int} : ∅ ∉ x := by
+  intro contr
+  simp_rw [mem_union, mem_prod] at h
+  rcases h with ⟨a, _, b, _, h⟩ | ⟨a, _, b, _, h⟩
+  all_goals
+    unfold pair at h
+    subst h
+    rw [mem_insert_iff, mem_singleton] at contr
+    rcases contr with contr | contr
+    all_goals
+      simp only [ZFSet.ext_iff, not_mem_empty, false_iff] at contr
+      specialize contr a
+      simp at contr
+
+/-! ## Well-definedness of `ZFInt` with respect to `ZFSet.Int` -/
+noncomputable section ZFIntEquivInt
+
+open Classical in
+
+/--
+This function maps `ZFInt` to `Int` by taking the first projection of the pair.
+-/
+def ZFInt.into (x : ZFInt) : {x // x ∈ Int} :=
+  let ⟨a,b⟩ := x.out
+  if a < b then
+    let n := ZFSet.pair ∅ (b-a).1
+    have : n ∈ Int := by
+      rw [mem_union]
+      right
+      rw [mem_prod]
+      exact ⟨∅, mem_singleton.mpr rfl, (b-a).1, ZFNat.mem_Nat_sub, rfl⟩
+    ⟨n, this⟩
+  else
+    let n := ZFSet.pair (a-b).1 ∅
+    have : n ∈ Int := by
+      rw [mem_union]
+      left
+      rw [mem_prod]
+      exact ⟨(a-b).1, ZFNat.mem_Nat_sub, ∅, mem_singleton.mpr rfl, rfl⟩
+    ⟨n, this⟩
+
+theorem ZFInt.into_inj_aux (x y : ZFInt) : into x = into y → x.out ≈ y.out := by
+  dsimp [into]
+  obtain ⟨a, b⟩ := Quotient.out x
+  obtain ⟨c, d⟩ := Quotient.out y
+  split_ifs with h₁ h₂ h₂ <;> (intro eq; simp at *)
+  · apply Subtype.eq at eq
+    have := ZFNat.eq_add_of_sub_eq (hle := .inl h₁) (h := eq)
+    rw [ZFNat.add_comm, ← ZFNat.add_sub_assoc (.inl h₂)] at this
+    apply ZFNat.eq_add_of_sub_eq (h := this.symm)
+    rw [ZFNat.add_comm]
+    exact ZFNat.le_trans (.inl h₂) (ZFNat.le_add_right d a)
+  · obtain ⟨eq₁, eq₂⟩ := eq
+    replace eq₁ : 0 = c - d := Subtype.eq eq₁
+    replace eq₂ : b - a = 0 := Subtype.eq eq₂
+    have := ZFNat.le_antisymm (ZFNat.sub_eq_zero_imp_le.mp (eq₁.symm)) h₂
+    subst this
+    rw [eq₁] at eq₂
+    apply ZFNat.eq_add_of_sub_eq (.inl h₁) at eq₂
+    rw [ZFNat.add_comm, ← ZFNat.add_sub_assoc h₂] at eq₂
+    symm at eq₂
+    apply ZFNat.eq_add_of_sub_eq (h := eq₂)
+    exact ZFNat.le_add_left c a
+  · obtain ⟨eq₁, eq₂⟩ := eq
+    replace eq₁ : a - b = 0 := Subtype.eq eq₁
+    replace eq₂ : 0 = d - c := Subtype.eq eq₂
+    have := ZFNat.le_antisymm (ZFNat.sub_eq_zero_imp_le.mp eq₁) h₁
+    subst this
+    rw [eq₂] at eq₁
+    apply ZFNat.eq_add_of_sub_eq h₁ at eq₁
+    rw [ZFNat.add_comm, ← ZFNat.add_sub_assoc (.inl h₂)] at eq₁
+    symm at eq₁
+    apply ZFNat.eq_add_of_sub_eq (h := eq₁)
+    left
+    rw [← @ZFNat.zero_add c]
+    apply ZFNat.add_lt_add_of_le_of_lt
+    · exact ZFNat.zero_le
+    · assumption
+  · apply Subtype.eq at eq
+    have := ZFNat.eq_add_of_sub_eq (hle := h₁) (h := eq)
+    rw [ZFNat.add_comm, ← ZFNat.add_sub_assoc h₂] at this
+    apply Eq.symm ∘ ZFNat.eq_add_of_sub_eq (h := this.symm)
+    exact ZFNat.le_trans h₂ (ZFNat.le_add_left c b)
+
+theorem ZFInt.into_inj (x y : ZFInt) : into x = into y → x = y := by
+  intro h
+  apply ZFInt.into_inj_aux at h
+  exact Quotient.out_equiv_out.mp h
+
+theorem ZFInt.into.injective : Function.Injective into := into_inj
+theorem ZFInt.outof.injective : Function.Injective outof := outof_inj
+
+def ZFInt.EmbeddingZFIntInt : ZFInt ↪ {x // x ∈ Int} where
+  toFun := into
+  inj' := into.injective
+def ZFInt.EmbeddingIntZFInt : {x // x ∈ Int} ↪ ZFInt where
+  toFun := outof
+  inj' := outof.injective
+
+/--
+The type `ZFInt` correctly represents the set `ZFSet.Int`.
+
+**NOTE**: There is a constructive proof of the Schröder-Bernstein theorem stating
+the equi-computability of sets. It is called the Myhill isomorphism and applies
+to countable sets only.
+-/
+instance instEquivZFIntInt : ZFInt ≃ {x // x ∈ Int} :=
+  Classical.choice (Function.Embedding.antisymm ZFInt.EmbeddingZFIntInt ZFInt.EmbeddingIntZFInt)
+
+instance : Coe ZFInt {x // x ∈ Int} := ⟨instEquivZFIntInt.toFun⟩
+instance : Coe {x // x ∈ Int} ZFInt := ⟨instEquivZFIntInt.invFun⟩
+
+instance : LinearOrder {x // x ∈ Int} where
+  le := (ZFInt.instLinearOrder.le · ·)
+  le_refl := (ZFInt.instLinearOrder.le_refl ·)
+  le_trans := (ZFInt.instLinearOrder.le_trans · · ·)
+  le_antisymm x y h h' := by
+    have := ZFInt.instLinearOrder.le_antisymm x y h h'
+    rwa [Equiv.invFun_as_coe, EmbeddingLike.apply_eq_iff_eq] at this
+  le_total := (ZFInt.instLinearOrder.le_total · ·)
+  toDecidableLE := (ZFInt.instLinearOrder.toDecidableLE · ·)
+
+end ZFIntEquivInt
+end Integers
+end ZFSet

--- a/Mathlib/SetTheory/ZFC/Naturals.lean
+++ b/Mathlib/SetTheory/ZFC/Naturals.lean
@@ -1,0 +1,1477 @@
+/-
+Copyright (c) 2025 Vicnent Trélat. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Vicnent Trélat
+-/
+import Mathlib.SetTheory.ZFC.Basic
+import Mathlib.Algebra.Ring.Defs
+
+/-! # ZFC Natural numbers
+
+This file defines the natural numbers in ZF set theory. The definition is based on the construction
+of the Von Neumann ordinals, where each natural number is represented as the set of all smaller
+natural numbers.
+
+The set of all natural numbers is defined as the smallest inductive set. Because of the axiom of
+separation, the definition relies on the existence of an infinite set, which is provided by the
+`some_inf` constant. It can be shown that the choice of `some_inf` does not affect the definition of
+the natural numbers and leads to isomorphic definitions.
+
+The file also includes the definition of the `ZFNat` type for ZF natural numbers, and provides
+various properties and usual arithmetic operations on natural numbers.
+
+-/
+
+noncomputable section
+
+namespace ZFSet
+
+/-! ## Preliminary definitions -/
+
+section Preamble
+
+/--
+A set `x` is transitive if every element of `x` is a subset of `x`:
+`∀ y ∈ x, y ⊆ x`.
+-/
+def transitive (x : ZFSet) := ∀ y ∈ x, y ⊆ x
+
+/--
+An inductive set is defined as a set that contains the empty set `∅` and is closed
+under successor.
+
+The "successor" of a set `x` is defined as the insertion of `x` into itself.
+-/
+def inductive_set (E : ZFSet) : Prop := ∅ ∈ E ∧ ∀ n, n ∈ E → insert n n ∈ E
+
+theorem trans_imp_insert_trans {x : ZFSet} : transitive x → transitive (insert x x) := by
+  intro trans
+  intro y
+  rw [mem_insert_iff]
+  rintro ⟨rfl | _⟩
+  · simp_rw [subset_def, mem_insert_iff]
+    exact fun _ => Or.inr
+  · simp_rw [subset_def, mem_insert_iff]
+    exact fun _ _ => Or.inr (trans y ‹_› ‹_›)
+
+theorem inductive_sep {S} (P : ZFSet → Prop) (ind : inductive_set S)
+  (h₀ : P ∅) (h₁ : ∀ n ∈ S, P n → P (insert n n)) : inductive_set <| S.sep P := by
+  unfold inductive_set at *
+  simp_rw [mem_sep]
+  apply And.intro
+  · exact ⟨ind.left, h₀⟩
+  · rintro n ⟨_,_⟩
+    apply And.intro
+    · exact ind.right n ‹_›
+    · exact h₁ n ‹_› ‹_›
+
+theorem inductive_imp_transitive {E : ZFSet} (h : inductive_set E) :
+  inductive_set (E.sep transitive) := by
+  unfold inductive_set
+  rcases h with ⟨_, hind⟩
+  apply And.intro <;> simp_rw [mem_sep]
+  · exact ⟨‹_›, by intro; rw [imp_iff_or_not]; exact Or.inr <| not_mem_empty _⟩
+  · rintro n ⟨_,_⟩
+    apply And.intro
+    · exact hind n ‹_›
+    · exact trans_imp_insert_trans ‹_›
+
+notation "ω" => omega
+
+/-- The first Von Neumann ordinal `ω` is an inductive set. -/
+theorem omega_inductive : inductive_set ω := ⟨omega_zero, fun _ => omega_succ⟩
+
+/-- Witness for an infinite set, meant to be used for definitional purpose only. -/
+private abbrev some_inf := @Classical.choose _ inductive_set ⟨_, omega_inductive⟩
+
+/-- The set `some_inf` is inductive. -/
+private lemma inductive_some_inf : inductive_set some_inf := Classical.choose_spec _
+
+private lemma some_inf_nonempty : some_inf ≠ ∅ := by
+  intro h
+  let h' := inductive_some_inf.left
+  rw [h] at h'
+  exact (ZFSet.not_mem_empty ∅) h'
+
+private lemma some_inf_mem_sep_inductive_set : some_inf ∈ some_inf.powerset.sep inductive_set := by
+  simp only [mem_sep, mem_powerset, subset_refl, true_and]
+  exact inductive_some_inf
+
+end Preamble
+
+/-! ## Natural numbers -/
+
+section Naturals
+
+/--
+The set of natural numbers `Nat` is defined as the smallest inductive set.
+This definition avoids the use of `ω`, even though `ω` may be thought of as `ℕ`.
+-/
+def Nat : ZFSet := ⋂₀ ((powerset some_inf).sep inductive_set)
+
+/-- The type of natural numbers `ZFNat` is defined as the subtype of `Nat`. -/
+abbrev ZFNat := {x // x ∈ Nat}
+
+namespace ZFNat
+
+/--
+`some_inf` is an inductive subset of `some_inf`:
+`some_inf ∈ { a ⊆ some_inf | inductive_set a }`.
+-/
+private theorem some_inf_mem_powerset_some_inf_ind :
+  some_inf ∈ some_inf.powerset.sep inductive_set :=
+  mem_sep.mpr ⟨mem_powerset.mpr fun _ => id, inductive_some_inf⟩
+
+/-- `Nat` is an infinite inductive set. -/
+theorem Nat_subset_some_inf : Nat ⊆ some_inf := by
+  intro n hn
+  unfold Nat at hn
+  rw [mem_sInter] at hn
+  · have aux :
+      n ∈ (⋃₀ (powerset some_inf).sep inductive_set : ZFSet) ∧
+      (fun b => ∀ c, c ∈ (powerset some_inf).sep inductive_set → b ∈ c) n := by
+        simp only [mem_sUnion, mem_sep, and_imp] at *
+        exact ⟨
+          ⟨some_inf,
+            ⟨mem_powerset.mpr fun _ => id, inductive_some_inf⟩,
+            hn some_inf (mem_powerset.mpr fun _ => id) (inductive_some_inf)⟩,
+          fun _ _ _ => hn _ ‹_› ‹_›⟩
+    simp only [mem_sep, mem_powerset, and_self, and_imp, implies_true, mem_sUnion] at aux
+    obtain ⟨⟨_, ⟨left, _⟩, _⟩, _⟩ := aux
+    apply left
+    assumption
+  · exact ⟨some_inf, some_inf_mem_powerset_some_inf_ind⟩
+
+theorem zero_in_Nat : ∅ ∈ Nat := by
+  unfold Nat
+  rw [mem_sInter]
+  · intro x hx
+    rw [mem_sep] at hx
+    exact hx.right.left
+  · exact ⟨some_inf, some_inf_mem_powerset_some_inf_ind⟩
+
+instance nat_zero : Zero ZFNat := ⟨∅, zero_in_Nat⟩
+lemma nat_zero_eq : (0 : ZFNat) = ⟨∅, zero_in_Nat⟩ := rfl
+
+instance nat_lt : LT ZFNat := ⟨fun x y => x.val ∈ y.val⟩
+instance nat_le : LE ZFNat := ⟨fun x y => x < y ∨ x = y⟩
+
+theorem not_lt_zero {n : ZFNat} : ¬ n < 0 := fun _ => not_mem_empty _ ‹_›
+theorem zero_lt_ne_zero {n : ZFNat} : 0 < n → n ≠ 0 := by
+  intro h h'
+  subst h'
+  absurd not_lt_zero h
+  trivial
+
+/-- Any inductive set contains zero. -/
+lemma zero_mem_inductive {a} (h : inductive_set a) : ↑(0 : ZFNat).val ∈ a := h.left
+
+/-- Any inductive set containing an element also contains its successor. -/
+theorem insert_mem_inductive {a n} (h : inductive_set a) (h' : n ∈ a) : insert n n ∈ a :=
+  h.right n h'
+
+theorem some_inf_powerset_sep_inductive_nonempty : (some_inf.powerset.sep inductive_set).Nonempty :=
+  ⟨some_inf, some_inf_mem_powerset_some_inf_ind⟩
+
+/-- Any inductive set is a subset of `some_inf`. -/
+theorem inductive_subset_some_inf_contains_Nat {a} (h : inductive_set a) (h' : a ⊆ some_inf) :
+  Nat ⊆ a := by
+  intro n hn
+  unfold Nat at hn
+  rw [mem_sInter] at hn
+  · have aux :
+      n ∈ (⋃₀ (powerset some_inf).sep inductive_set : ZFSet) ∧
+      (fun b => ∀ c, c ∈ (powerset some_inf).sep inductive_set → b ∈ c) n := by
+        simp only [mem_sUnion, mem_sep, and_imp] at *
+        exact ⟨
+          ⟨some_inf,
+            ⟨mem_powerset.mpr fun _ => id, inductive_some_inf⟩,
+            hn some_inf (mem_powerset.mpr fun _ => id) (inductive_some_inf)⟩,
+            fun _ _ _ => hn _ ‹_› ‹_›⟩
+    simp only [mem_sep, mem_powerset, and_self, and_imp, implies_true, mem_sUnion] at aux
+    exact aux.2 _ h' h
+  · exact some_inf_powerset_sep_inductive_nonempty
+
+theorem succ_mem_Nat' {n} (h : n ∈ Nat) : insert n n ∈ Nat := by
+  have all_sub_ind : ∀ a, a ∈ some_inf.powerset.sep inductive_set → insert n n ∈ a := by
+    intro a ha
+    rw [mem_sep] at ha
+    exact ha.2.2 n (inductive_subset_some_inf_contains_Nat ha.2 (mem_powerset.mp ha.1) h)
+  unfold Nat
+  rw [mem_sInter]
+  · exact (all_sub_ind · ·)
+  · exact some_inf_powerset_sep_inductive_nonempty
+
+/--
+The successor function `succ` is build from the insertion of a set into itself embedded into the
+`ZFNat` type.
+-/
+def succ (n : ZFNat) : ZFNat :=
+  let ⟨n, h⟩ := n
+  have p : insert n n ∈ Nat := succ_mem_Nat' h
+  ⟨insert n n, p⟩
+
+instance nat_one : One ZFNat := ⟨succ 0⟩
+
+theorem nat_one_eq : 1 = succ 0 := rfl
+
+theorem succ_ne_zero : ∀ n, succ n ≠ 0 := by
+  rintro ⟨n, hn⟩ h
+  rw [succ, nat_zero_eq, Subtype.mk.injEq, ZFSet.ext_iff] at h
+  simp only [mem_insert_iff, not_mem_empty, iff_false, not_or] at h
+  exact h n |>.1 rfl
+
+theorem succ_inj_aux {m n a : ZFSet} (h : insert m m = insert n n) (h' : a ∈ m) : a ∈ n := by
+  have d' : a ∈ m ∨ a = m ↔ a ∈ n ∨ a = n := by
+    have : a ∈ insert m m ↔ a ∈ n ∨ a = n := by
+      rw [h, mem_insert_iff]
+      exact Or.comm
+    rw [mem_insert_iff, _root_.or_comm] at this
+    assumption
+  let h'' := mem_insert m m
+  rw [h] at h''
+  simp only [mem_insert_iff] at h''
+  rcases h'' with rfl | h''
+  · assumption
+  · rcases d'.mp (Or.inl h') with _ | rfl
+    · assumption
+    · absurd mem_asymm h''
+      assumption
+
+theorem succ_inj_aux' {m n : ZFSet} (h : insert m m = insert n n) : m = n :=
+  ext fun _ => ⟨succ_inj_aux h, succ_inj_aux <| Eq.symm h⟩
+
+theorem succ_inj {m n} (h : succ m = succ n) : m = n := by
+  let ⟨m, hm⟩ := m
+  let ⟨n, hn⟩ := n
+  simp only [succ, Subtype.mk.injEq] at *
+  ext1
+  exact ⟨succ_inj_aux h, succ_inj_aux (Eq.symm h)⟩
+
+/-- Any inductive set `a` separated by an inductive predicate `P` is inductive. -/
+theorem sep_of_ind_is_ind (P : ZFSet → Prop) {a} (h : inductive_set a)
+  (h₀ : P ∅) (ih : ∀ n, n ∈ a → P n → P (insert n n)) : inductive_set (a.sep P) := by
+  unfold inductive_set at *
+  apply And.intro
+  · exact mem_sep.mpr ⟨h.left, h₀⟩
+  · simp only [mem_sep, and_imp]
+    intros
+    exact ⟨h.right _ ‹_›, ih _ ‹_› ‹_›⟩
+
+/-! ## Recursion on natural numbers -/
+
+section Recursion
+
+theorem succ_subrelation_mem' :
+  Subrelation (fun x y => insert x x = y) (fun x y : ZFSet => x ∈ y) := by
+  intro _ _ _
+  subst_eqs
+  rw [mem_insert_iff]
+  left
+  rfl
+
+theorem succ_wf' : @WellFounded ZFSet (fun x y => insert x x = y) := by
+  apply Subrelation.wf
+  · exact succ_subrelation_mem'
+  · exact mem_wf
+
+open Function in
+theorem mem_wf' : @WellFounded ZFNat (·.1 ∈ ·.1) := by
+  have : (fun x y : ZFNat => x.1 ∈ y.1) = ((fun x y : ZFSet => x ∈ y) on Subtype.val) := rfl
+  rw [this]
+  apply WellFounded.onFun
+  exact mem_wf
+
+/-- The relation built over the successor function is a subrelation of the membership relation. -/
+theorem succ_subrelation_mem : Subrelation (succ · = ·) (·.1 ∈ ·.1) := by
+  intro _ _ _
+  simp only [succ] at *
+  subst_eqs
+  rw [mem_insert_iff]
+  left
+  rfl
+
+theorem succ_wf : @WellFounded ZFNat (succ · = ·) := by
+  apply Subrelation.wf
+  · exact succ_subrelation_mem
+  · exact mem_wf'
+
+/--
+The induction principle for sets in `Nat`. This principle is meant to be used for definitional
+purposes only.
+-/
+lemma ind {P : ZFSet → Prop} (n : ZFSet)
+  (h : n ∈ Nat) (zero : P ∅) (succ : ∀ n ∈ Nat, P n → P (insert n n)) : P n := by
+  have : Nat.sep P |>.inductive_set := by
+    unfold inductive_set
+    apply And.intro
+    · exact mem_sep.mpr ⟨zero_in_Nat, ‹_›⟩
+    · simp only [mem_sep, and_imp]
+      intros
+      exact ⟨succ_mem_Nat' ‹_›, succ _ ‹_› ‹_›⟩
+  let p := inductive_subset_some_inf_contains_Nat this
+  let p' := fun x (_ : x ∈ Nat.sep P) => Nat_subset_some_inf (sep_subset_self ‹_›)
+  simp_rw [subset_def, mem_sep] at p
+  simp only [mem_sep] at p'
+  exact p p' h |>.right
+
+/-- The (weak) induction principle for natural numbers. -/
+theorem induction {P : ZFNat → Prop} (n : ZFNat)
+  (zero : P 0) (succ : ∀ n, P n → P (succ n)) : P n := by classical
+  let ⟨n, hn⟩ := n
+  let P' x := if hx : x ∈ Nat then P ⟨x, hx⟩ else unreachable!
+  have : P' n = P ⟨n, hn⟩ := dif_pos hn
+  rw [← this]
+  apply @ind P' n hn
+  · unfold P'
+    simpa [hn, zero_in_Nat, nat_zero_eq] using zero
+  · intro m hm hm'
+    unfold P' at *
+    simp [hm] at hm'
+    simp [succ_mem_Nat' hm]
+    exact succ ⟨m, hm⟩ hm'
+
+@[cases_eliminator]
+theorem cases {P : ZFNat → Prop} (n : ZFNat) (zero : P 0) (succ : ∀ n, P (succ n)) : P n :=
+  induction n zero fun n _ => succ n
+
+theorem every_nat_transitive {n : ZFSet} (h : n ∈ Nat) : transitive n := by
+  unfold transitive
+  apply ind _ h
+  · intros _ _
+    exact False.elim (not_mem_empty _ ‹_›)
+  · intros _ _ ih _ hy
+    intro _ _
+    rw [mem_insert_iff] at hy ⊢
+    rcases hy with rfl | _
+    · exact Or.inr ‹_›
+    · exact Or.inr (ih _ ‹_› ‹_›)
+
+theorem lt_succ {n : ZFNat} : n < succ n := mem_insert _ _
+theorem le_succ {n : ZFNat} : n ≤ succ n := Or.inl lt_succ
+
+theorem lt_trans {x y z : ZFNat} : x < y → y < z → x < z :=
+  fun _ _ => every_nat_transitive z.2 _ ‹_› ‹_›
+
+theorem lt_irrefl {n : ZFNat} : ¬ n < n := fun _ => mem_irrefl _ ‹_›
+theorem lt_imp_ne {n m : ZFNat} : n < m → n ≠ m := fun _ _ => by
+  subst_eqs
+  absurd lt_irrefl ‹_›
+  trivial
+
+theorem le_trans {x y z : ZFNat} : x ≤ y → y ≤ z → x ≤ z := by
+  rintro (_ | rfl)  (_ | rfl)
+  · left; exact lt_trans ‹_› ‹_›
+  · left; assumption
+  · left; assumption
+  · right; rfl
+
+theorem le_antisymm {x y : ZFNat} : x ≤ y → y ≤ x → x = y := by
+  rintro (h | rfl) (_ | _)
+  · absurd lt_irrefl <| lt_trans ‹_› ‹_›
+    trivial
+  · symm; assumption
+  · trivial
+  · trivial
+
+theorem lt_le_iff {n m} : n ≤ m ↔ n < succ m := by
+  dsimp [nat_le, ]
+  apply Iff.intro
+  · rintro (_ | rfl)
+    · exact lt_trans ‹_› lt_succ
+    · exact lt_succ
+  · intro h
+    let ⟨n, hn⟩ := n
+    let ⟨m, hm⟩ := m
+    dsimp [nat_lt, succ] at *
+    rw [mem_insert_iff] at h
+    rcases h with rfl | _
+    · right; rfl
+    · left; assumption
+
+theorem lt_mono {x y : ZFNat} : x < y → x.succ < y.succ := by
+  intro h
+  induction y using induction with
+  | zero =>
+    absurd not_lt_zero h
+    trivial
+  | succ y ih =>
+    rcases lt_le_iff.mpr h with (h | rfl)
+    · exact lt_trans (ih h) lt_succ
+    · exact lt_succ
+
+theorem succ_lt_mono {x y : ZFNat} : succ x < succ y → x < y := by
+  intro h
+  induction y using induction with
+  | zero =>
+    rcases lt_le_iff.mpr h with (h | h)
+    · absurd not_lt_zero h; trivial
+    · absurd succ_ne_zero x h; trivial
+  | succ y ih =>
+    rcases lt_le_iff.mpr h with (h | h)
+    · exact lt_trans (ih h) lt_succ
+    · replace h := succ_inj h
+      subst h
+      exact lt_succ
+
+theorem le_mono {x y : ZFNat} : x ≤ y → x.succ ≤ y.succ := by
+  rintro (h | rfl)
+  · left
+    induction y using induction with
+    | zero =>
+      absurd not_lt_zero h
+      trivial
+    | succ y ih =>
+      rcases lt_le_iff.mpr h with (h | rfl)
+      · exact lt_trans (ih h) lt_succ
+      · exact lt_succ
+  · right; rfl
+
+theorem succ_le_mono {x y : ZFNat} : x.succ ≤ y.succ → x ≤ y := by
+  rintro (h | h)
+  · left
+    induction y using induction with
+    | zero =>
+      rcases lt_le_iff.mpr h with (h | h)
+      · absurd not_lt_zero h; trivial
+      · absurd succ_ne_zero x h; trivial
+    | succ y ih =>
+      rcases lt_le_iff.mpr h with (h | h)
+      · exact lt_trans (ih h) lt_succ
+      · rw [← h]; exact lt_succ
+  · replace h := succ_inj h; subst h; right; rfl
+
+theorem le_lt_iff {n m} : succ n ≤ m ↔ n < m := by
+  rw [lt_le_iff]
+  apply Iff.intro
+  · intro; exact succ_lt_mono ‹_›
+  · exact lt_mono
+
+theorem le_total {x y : ZFNat} : x ≤ y ∨ y ≤ x := by
+  induction x using induction with
+  | zero =>
+    left
+    induction y using induction with
+    | zero => right; rfl
+    | succ _ ih => exact le_trans ih (le_succ)
+  | succ x ih =>
+    induction y using induction with
+    | zero =>
+      rcases ih with ((h | _) | (_ | _))
+      · absurd not_lt_zero h; trivial
+      · subst_eqs; right; exact le_succ
+      · right; left; exact lt_trans ‹_› lt_succ
+      · subst_eqs; right; left; exact lt_succ
+    | succ y ih' =>
+      rcases ih with (h | _) | (h | _)
+      · rcases ih' (Or.inl <| lt_le_iff.mpr h) with l | (r | rfl)
+        · left; left; exact lt_le_iff.mp l
+        · right; right; congr; exact le_antisymm (lt_le_iff.mpr r) (lt_le_iff.mpr h)
+        · replace h := lt_le_iff.mpr h
+          left
+          apply le_mono
+          exact h
+      · subst_eqs; right; exact le_succ
+      · right
+        simp only [lt_le_iff]
+        exact lt_trans (lt_trans h lt_succ) lt_succ
+      · subst_eqs
+        right
+        exact le_succ
+
+theorem lt_iff_le_not_le {x y : ZFNat} : x < y ↔ x ≤ y ∧ ¬ y ≤ x := by
+  apply Iff.intro
+  · intro
+    apply And.intro
+    · left
+      assumption
+    · rintro (_ | rfl)
+      · exact lt_irrefl (lt_trans ‹_› ‹_›)
+      · exact lt_irrefl ‹_›
+  · rintro ⟨h | rfl, h'⟩
+    · assumption
+    · simp only [nat_le, or_true] at h'
+      contradiction
+
+/-- The (strong) induction principle for natural numbers. -/
+theorem strong_induction {P : ZFNat → Prop} (n : ZFNat)
+  (ind : ∀ n, (∀ m, m < n → P m) → P n) : P n := by
+  let Q x := ∀ m < x, P m
+  have aux {x} : Q x := by
+    induction x using induction with
+    | zero =>
+      intros _ _
+      exact False.elim (not_lt_zero ‹_›)
+    | succ n ih =>
+      intros m hm
+      unfold Q at ih
+      by_cases h : m = n
+      · subst h
+        exact ind _ ih
+      · have h' : m < n := by
+          rcases lt_le_iff.mpr hm with (_ | rfl)
+          · assumption
+          · contradiction
+        exact ih m h'
+  exact ind _ aux
+
+theorem not_zero_imp_succ {n : ZFNat} : n ≠ 0 → ∃ m, n = succ m := by
+  induction n using induction with
+  | zero => intro h; contradiction
+  | succ n _ =>
+    intro
+    exact exists_apply_eq_apply' succ n
+
+lemma sUnion_insert_nat {x : ZFSet} (h : x ∈ Nat) : (⋃₀ (insert x x) : ZFSet) = x := by
+  apply ind _ h
+  · rw [sUnion_insert, sUnion_empty]
+    ext1
+    simp only [mem_union, not_mem_empty, or_self]
+  · intros n _ ih
+    rw [sUnion_insert, ih]
+    ext1
+    simp only [mem_union, mem_insert_iff, or_self_right]
+
+theorem pred_in_Nat' ⦃x : ZFSet⦄ (h : x ∈ Nat) : (⋃₀ x : ZFSet) ∈ Nat := by
+  apply ind _ h
+  · rw [sUnion_empty]
+    exact zero_in_Nat
+  · intros
+    rw [sUnion_insert_nat] <;> assumption
+
+/-- The predecessor function on natural numbers, defined directly as the union of a set. -/
+def pred (x : ZFNat) : ZFNat := x.map sUnion pred_in_Nat'
+
+theorem pred_eq (n : ZFNat) : pred n = ⟨⋃₀ n.val, pred_in_Nat' n.property⟩ := rfl
+
+@[simp]
+theorem pred_zero : pred 0 = 0 := by
+  unfold pred
+  rw [nat_zero_eq, Subtype.map, Subtype.mk.injEq, sUnion_empty]
+
+@[simp]
+theorem pred_one : pred 1 = 0 := by
+  unfold pred
+  rw [nat_one_eq, nat_zero_eq, Subtype.map, Subtype.mk.injEq]
+  dsimp [succ]
+  rw [LawfulSingleton.insert_empty_eq, sUnion_singleton]
+
+@[simp]
+theorem pred_succ {n : ZFNat} : pred (succ n) = n := by
+  let ⟨_, _⟩ := n
+  simp only [pred, succ, Subtype.map]
+  congr
+  exact sUnion_insert_nat ‹_›
+
+@[simp]
+theorem succ_pred {n : ZFNat} (h : n ≠ 0) : succ (pred n) = n := by
+  induction n using strong_induction with
+  | ind n ih =>
+    obtain ⟨m, hm⟩ := not_zero_imp_succ h
+    subst hm
+    by_cases h' : m = 0 <;> subst_eqs <;> rw [pred_succ]
+
+private theorem succ_lift_eq {x : ZFNat} : ↑(succ x) = insert x.val x.val := by rfl
+
+private theorem succ_eq (n : ZFSet) (n_Nat : n ∈ Nat) :
+  ⟨insert n n, succ_mem_Nat' n_Nat⟩ = succ ⟨n, n_Nat⟩ := by rfl
+
+/--
+The recursion principle for sets in `Nat`. This principle is meant to be used for definitional
+purposes only.
+-/
+def rec'.{u} {motive : ZFSet → Sort u} (n : ZFSet) (h : n ∈ Nat)
+  (zero : motive ∅) (succ : Π x ∈ Nat, motive x → motive (insert x x)) : motive n := by
+  apply succ_wf.fix (C := fun x => motive x.val) (x := ⟨n, h⟩)
+  intro x ih
+  by_cases x_eq_0 : x = 0
+  · subst x_eq_0
+    exact zero
+  · specialize ih _ (succ_pred x_eq_0)
+    specialize succ (pred x) (pred x).2 ih
+    conv at succ =>
+      arg 1
+      rw [← succ_lift_eq, succ_pred x_eq_0]
+    assumption
+
+/-- Provides the base case of the recursion principle for sets in `Nat`. -/
+theorem rec'_zero.{u} {motive : ZFSet → Sort u}
+  (zero : motive ∅) (succ : Π x ∈ Nat, motive x → motive (insert x x)) :
+  ZFNat.rec' ∅ zero_in_Nat zero succ = zero := by
+    unfold ZFNat.rec' WellFounded.fix
+    beta_reduce
+    rw [WellFounded.fixFEq, dite_cond_eq_true]
+    exact eq_self _
+
+
+/-- Provides the inductive step of the recursion principle for sets in `Nat`. -/
+theorem rec'_succ.{u} {motive : ZFSet → Sort u} (n : ZFSet) (n_Nat : n ∈ Nat)
+  (zero : motive ∅) (succ : Π x ∈ Nat, motive x → motive (insert x x)) :
+  rec' (insert n n) (succ_mem_Nat' n_Nat) zero succ = succ n n_Nat (rec' n n_Nat zero succ) := by
+    unfold ZFNat.rec' WellFounded.fix
+    beta_reduce
+    rw [WellFounded.fixFEq, dite_cond_eq_false]
+    · apply cast_eq_iff_heq.mpr
+      · congr
+        · conv => enter [1, 1]; rw [succ_eq _ n_Nat, pred_succ]
+        · exact proof_irrel_heq ..
+        · conv =>
+            left
+            conv => arg 1; rw [succ_eq _ n_Nat]
+            rw [pred_succ]
+        · exact proof_irrel_heq ..
+        · apply succ_pred
+          rw [succ_eq _ n_Nat]
+          exact succ_ne_zero _
+      · apply eq_false
+        intro h
+        rw [succ_eq _ n_Nat] at h
+        exact succ_ne_zero _ h
+
+/--
+The recursion principle for natural numbers. This recursor allows inductive
+definitions over natural numbers to be defined in a more natural way.
+-/
+@[induction_eliminator]
+def rec.{u} {motive : ZFNat → Sort u} (n : ZFNat)
+  (zero : motive 0) (succ : Π x, motive x → motive (succ x)) : motive n := by classical
+  let ⟨n, hn⟩ := n
+  let motive' (x : ZFSet) := if hx : x ∈ Nat then motive ⟨x, hx⟩ else unreachable!
+  have : motive' n = motive ⟨n, hn⟩ := dif_pos hn
+  rw [← this]
+  apply @ZFNat.rec' motive' n hn
+  · unfold motive'
+    simpa [hn, zero_in_Nat, nat_zero_eq] using zero
+  · intro m hm hm'
+    unfold motive' at *
+    simp [hm] at hm'
+    simp [succ_mem_Nat' hm]
+    exact succ ⟨m, hm⟩ hm'
+
+/--
+The induction principle of `ZFNat` is a universe-specialized version of the recursion principle.
+-/
+@[simp]
+theorem induction_is_rec_into_Prop {motive : ZFNat → Prop} :
+  induction = ZFNat.rec (motive := motive) := rfl
+
+theorem rec_zero.{u} {motive : ZFNat → Sort u}
+  (zero : motive 0) (succ : Π x, motive x → motive (succ x)) :
+  rec 0 zero succ = zero := by conv => arg 1; simp [ZFNat.rec, ZFNat.rec'_zero]
+
+theorem rec_succ.{u} {motive : ZFNat → Sort u} (n : ZFNat)
+  (zero : motive 0) (succ' : Π x, motive x → motive (succ x)) :
+  rec (succ n) zero succ' = succ' n (ZFNat.rec n zero succ') := by
+    simp [ZFNat.rec, succ, ZFNat.rec'_succ _ n.property]
+
+end Recursion
+
+/--
+The predecessor function `pred'` on natural numbers, defined inductively.
+This definition is equivalent to `pred`, as proven by `pred'_eq_pred`.
+-/
+protected abbrev pred' (m : ZFNat) : ZFNat := ZFNat.rec m 0 (fun x _ : ZFNat => x)
+
+/-- The definitions of `pred` and `pred'` are equivalent. -/
+lemma pred'_eq_pred : pred = ZFNat.pred' := by
+  ext1 n
+  induction n with
+  | zero => rw [pred_zero, ZFNat.pred', ZFNat.rec_zero]
+  | succ _ _ => rw [pred_succ, ZFNat.pred', ZFNat.rec_succ]
+
+/-! ## Arithmetic -/
+
+section Inequalities
+
+theorem zero_lt_succ {n : ZFNat} : 0 < n.succ := by
+  induction n with
+  | zero => exact lt_succ
+  | succ n ih => exact lt_trans ih lt_succ
+
+theorem pos_of_ne_zero {n : ZFNat} : 0 ≠ n → 0 < n := by
+  induction n with
+  | zero => intro h; nomatch h
+  | succ x ih =>
+    intro
+    exact zero_lt_succ
+
+instance : LinearOrder ZFNat where
+  le := nat_le.le
+  le_refl _ := Or.inr rfl
+  le_trans _ _ _ := le_trans
+  le_antisymm _ _ := le_antisymm
+  le_total _ _ := le_total
+  toDecidableLE := fun _ _ => Classical.propDecidable ((· ≤ ·) _ _)
+  lt_iff_le_not_le _ _ := lt_iff_le_not_le
+
+instance : IsStrictTotalOrder ZFNat (·<·) where
+  trichotomous x y := by
+    rcases @le_total x y with (h | rfl) | h | rfl
+    · left; assumption
+    · right; left; rfl
+    · right; right; assumption
+    · right; left; rfl
+  irrefl _ := lt_irrefl
+  trans _ _ _ := lt_trans
+
+end Inequalities
+
+section Arithmetic
+
+/-- The addition function on natural numbers, defined inductively. -/
+protected abbrev add (n m : ZFNat) : ZFNat := ZFNat.rec n m (fun _ : ZFNat => succ)
+
+instance add_inst : Add ZFNat := ⟨ZFNat.add⟩
+lemma add_inst_eq {n m : ZFNat} : n + m = n.add m := rfl
+
+lemma add_one_eq_succ {n : ZFNat} : n + 1 = succ n := by
+  dsimp [add_inst_eq]
+  induction n with
+  | zero => rw [ZFNat.add, ZFNat.rec_zero, nat_one_eq]
+  | succ _ ih => rw [ZFNat.add, ZFNat.rec_succ, ← ZFNat.add, ih]
+
+lemma add_one_eq_succ' {n : ZFNat} : 1 + n = succ n := by
+  rw [add_inst_eq, ZFNat.add, nat_one_eq, rec_succ, rec_zero]
+
+@[simp]
+lemma add_zero {n : ZFNat} : n + 0 = n := by
+  dsimp [add_inst_eq]
+  induction n with
+  | zero => rw [ZFNat.add, rec_zero]
+  | succ _ ih => rw [ZFNat.add, rec_succ, ← ZFNat.add, ih]
+
+@[simp]
+lemma zero_add {n : ZFNat} : 0 + n = n := by
+  rw [add_inst_eq, ZFNat.add, rec_zero]
+
+lemma add_succ {n m : ZFNat} : succ n + m = succ (n + m) := rec_succ n m fun _ => succ
+
+lemma succ_add {n m : ZFNat} : succ (n + m) = n + succ m := by
+  induction n with
+  | zero => rw [add_inst_eq, add_inst_eq, ZFNat.add, rec_zero, ZFNat.add, rec_zero]
+  | succ n ih =>
+    rw [add_succ, ih]
+    dsimp [add_inst_eq]
+    conv => rhs; rw [ZFNat.add, rec_succ]
+
+lemma add_comm (n m : ZFNat) : n + m = m + n := by
+  induction n with
+  | zero => rw [add_zero, add_inst_eq, ZFNat.add, rec_zero]
+  | succ n ih => rw [← succ_add, add_succ, ih]
+
+@[simp]
+lemma add_assoc (n m k : ZFNat) : n + (m + k) = n + m + k := by
+  induction n with
+  | zero => rw [zero_add, zero_add]
+  | succ _ ih => rw [add_succ, add_succ, add_succ, ih]
+
+lemma add_left_comm (n m k : ZFNat) : n + (m + k) = m + (n + k) := by
+  rw [add_assoc, add_assoc, add_comm n]
+
+lemma add_right_comm (n m k : ZFNat) : (n + m) + k = (n + k) + m := by
+  rw [← add_assoc, add_comm m, add_assoc]
+
+theorem add_left_cancel {n m k : ZFNat} : n + m = n + k ↔ m = k := by
+  induction n with
+  | zero => simp only [zero_add, imp_self]
+  | succ n ih =>
+    simp [add_succ]
+    apply Iff.intro
+    · intro h
+      exact ih.mp (succ_inj h)
+    · intro h
+      rw [h]
+
+theorem add_right_cancel {n m k : ZFNat} : n + m = k + m ↔ n = k := by
+  rw [add_comm n, add_comm k]
+  exact add_left_cancel
+
+theorem eq_zero_of_add_eq_zero : ∀ {n m : ZFNat}, n + m = 0 → n = 0 ∧ m = 0 := by
+  intro n m
+  induction n generalizing m with
+  | zero => simp only [zero_add, true_and, imp_self]
+  | succ n ih =>
+    intro h
+    rw [add_succ, succ_add] at h
+    absurd succ_ne_zero m (ih h).right
+    trivial
+
+theorem eq_zero_of_add_eq_zero_left {n m : ZFNat} (h : n + m = 0) : m = 0 :=
+  eq_zero_of_add_eq_zero h |>.right
+
+@[simp] theorem add_left_eq_self  {a b : ZFNat} : a + b = b ↔ a = 0 := by
+  conv => lhs; rhs; rw [← @zero_add b]
+  rw [add_right_cancel]
+@[simp] theorem add_right_eq_self {a b : ZFNat} : a + b = a ↔ b = 0 := by
+  conv => lhs; rhs; rw [← @add_zero a]
+  rw [add_left_cancel]
+@[simp] theorem self_eq_add_right {a b : ZFNat} : a = a + b ↔ b = 0 := by
+  conv => lhs; lhs; rw [← @add_zero a]
+  rw [add_left_cancel]
+  exact eq_comm
+@[simp] theorem self_eq_add_left  {a b : ZFNat} : a = b + a ↔ b = 0 := by
+  conv => lhs; lhs; rw [← @zero_add a]
+  rw [add_right_cancel]
+  exact eq_comm
+
+theorem lt_of_succ_le {n m : ZFNat} (h : succ n ≤ m) : n < m := le_lt_iff.mp ‹_›
+theorem succ_le_of_lt {n m : ZFNat} (h : n < m) : succ n ≤ m := le_lt_iff.mpr ‹_›
+
+theorem le.dest {n m : ZFNat} : n ≤ m → ∃ k, n + k = m := by
+  intro h
+  induction n with
+  | zero => exact ⟨m, zero_add⟩
+  | succ n ih =>
+    rcases h with h | rfl
+    · have : n < m := by
+        apply lt_trans (lt_succ)
+        assumption
+      let ⟨k, hk⟩ := ih (Or.inl this)
+      exact ⟨pred k, by
+        rwa [← add_one_eq_succ, ← add_assoc, add_one_eq_succ', ZFNat.succ_pred]
+        intro
+        subst_eqs
+        rw [add_zero] at this
+        exact lt_irrefl this⟩
+    · exact ⟨0, add_zero⟩
+
+theorem le_succ_of_le {n m : ZFNat} (h : n ≤ m) : n ≤ succ m := le_trans h le_succ
+
+@[simp] theorem le_add_right (n k : ZFNat) : n ≤ n + k := by
+  induction k with
+  | zero => rw [add_zero]
+  | succ _ ih =>
+    rw [add_comm, add_succ, ← add_comm]
+    exact le_succ_of_le ih
+
+@[simp] theorem le_add_left (n m : ZFNat): n ≤ m + n := add_comm .. ▸ le_add_right ..
+
+theorem le.intro {n m k : ZFNat} (h : n + k = m) : n ≤ m := h ▸ le_add_right n k
+
+theorem zero_le {n : ZFNat} : 0 ≤ n := by
+  induction n with
+  | zero => right; rfl
+  | succ n ih => exact le_trans ih le_succ
+
+theorem le_of_add_le_add_left {a b c : ZFNat} (h : a + b ≤ a + c) : b ≤ c := by
+  match le.dest h with
+  | ⟨d, hd⟩ =>
+    apply @le.intro _ _ d
+    rw [← add_assoc] at hd
+    exact add_left_cancel.mp hd
+
+theorem add_le_add_left {n m : ZFNat} (h : n ≤ m) (k : ZFNat) : k + n ≤ k + m :=
+  match le.dest h with
+  | ⟨w, hw⟩ =>
+    have : k + (n + w) = k + m     := congrArg _ hw
+    le.intro <| (Eq.symm <| add_assoc k n w).trans this
+
+@[simp] theorem add_le_add_iff_left {n m k : ZFNat} : n + m ≤ n + k ↔ m ≤ k :=
+  ⟨le_of_add_le_add_left, fun h => add_le_add_left h _⟩
+
+theorem lt_of_add_lt_add_right {n m k : ZFNat} : k + n < m + n → k < m := by
+  induction n with
+  | zero => simp_rw [add_zero]; exact id
+  | succ n ih =>
+    simp_rw [← succ_add]
+    intro h
+    apply succ_lt_mono at h
+    exact ih h
+
+theorem add_lt_add_left {n m : ZFNat} (h : n < m) (k : ZFNat) : k + n < k + m :=
+  lt_of_succ_le <| succ_add ▸ add_le_add_left (succ_le_of_lt h) k
+
+theorem add_lt_add_right {n m : ZFNat} (h : n < m) (k : ZFNat) : n + k < m + k :=
+  add_comm k m ▸ add_comm k n ▸ add_lt_add_left h k
+
+theorem lt_add_of_pos_right {n k : ZFNat} (h : 0 < k) : n < n + k := by
+  let this := add_zero ▸ add_lt_add_left h n;
+  exact this
+
+theorem lt_of_add_lt_add_left {n m k : ZFNat} : n + k < n + m → k < m := by
+  rw [add_comm n, add_comm n]; exact lt_of_add_lt_add_right
+
+@[simp] theorem add_lt_add_iff_left {k n m : ZFNat} : k + n < k + m ↔ n < m :=
+  ⟨lt_of_add_lt_add_left, fun _ => add_lt_add_left ‹_› _⟩
+
+@[simp] theorem add_lt_add_iff_right {k n m : ZFNat} : n + k < m + k ↔ n < m :=
+  ⟨lt_of_add_lt_add_right, fun _ => add_lt_add_right ‹_› _⟩
+
+theorem add_le_add_right {n m : ZFNat} (h : n ≤ m) (k : ZFNat) : n + k ≤ m + k :=
+  add_comm .. ▸ add_comm m k ▸ add_le_add_left h k
+
+theorem add_lt_add_of_le_of_lt {a b c d : ZFNat} (hle : a ≤ b) (hlt : c < d) : a + c < b + d :=
+  lt_of_le_of_lt (add_le_add_right hle _) (add_lt_add_left hlt _)
+
+theorem add_lt_add_of_lt_of_le {a b c d : ZFNat} (hlt : a < b) (hle : c ≤ d) : a + c < b + d :=
+  lt_of_le_of_lt (add_le_add_left hle _) (add_lt_add_right hlt _)
+
+theorem lt_add_of_pos_left {k n : ZFNat} : 0 < k → n < k + n :=
+  add_comm .. ▸ lt_add_of_pos_right
+
+theorem pos_of_lt_add_right {n k : ZFNat} (h : n < n + k) : 0 < k := by
+  apply lt_of_add_lt_add_left
+  rw [add_zero]
+  assumption
+
+theorem pos_of_lt_add_left {n k : ZFNat} : n < k + n → 0 < k := by
+  rw [add_comm]; exact pos_of_lt_add_right
+
+@[simp] theorem lt_add_right_iff_pos {n k : ZFNat} : n < n + k ↔ 0 < k :=
+  ⟨pos_of_lt_add_right, lt_add_of_pos_right⟩
+
+@[simp] theorem lt_add_left_iff_pos {n k : ZFNat} : n < k + n ↔ 0 < k :=
+  ⟨pos_of_lt_add_left, lt_add_of_pos_left⟩
+
+theorem add_pos_left {m : ZFNat} (h : 0 < m) (n : ZFNat) : 0 < m + n :=
+  lt_of_lt_of_le h (le_add_right ..)
+
+theorem add_pos_right {n : ZFNat} (m : ZFNat) (h : 0 < n) : 0 < m + n :=
+  lt_of_lt_of_le h (le_add_left ..)
+
+theorem pred_le_pred {n m : ZFNat} : n ≤ m → (pred n) ≤ (pred m) := by
+  intro h
+  induction n <;> induction m
+  · right; rfl
+  · simp only [pred_zero, pred_succ]
+    rcases h with (_ | _)
+    · exact lt_le_iff.mpr ‹_›
+    · absurd (succ_ne_zero _ (Eq.symm ‹_›))
+      trivial
+  · rcases h with (h | h)
+    · absurd not_lt_zero h
+      trivial
+    · rw [h]
+  · simp only [pred_succ]
+    exact succ_le_mono h
+
+theorem le_of_succ_le_succ {n m : ZFNat} : (succ n) ≤ (succ m) → n ≤ m := by
+  intro h
+  replace h := pred_le_pred h
+  simp only [pred_succ] at h
+  assumption
+
+theorem lt_of_succ_lt_succ {n m : ZFNat} : succ n < succ m → n < m := by
+  intro h
+  rcases le_of_succ_le_succ (Or.inl h) with (h | rfl)
+  · assumption
+  · absurd lt_irrefl h
+    trivial
+
+theorem add_self_ne_one {n : ZFNat} : n + n ≠ 1 := by
+  intro h
+  induction n with
+  | zero =>
+    simp only [zero_add, nat_one_eq] at h
+    absurd succ_ne_zero _ (Eq.symm h)
+    trivial
+  | succ n _ =>
+    rw [add_succ, ← succ_add, nat_one_eq] at h
+    absurd succ_ne_zero _ (succ_inj h)
+    trivial
+
+protected abbrev sub (n m : ZFNat) : ZFNat := ZFNat.rec m n (fun _ => pred)
+instance sub_inst : Sub ZFNat := ⟨ZFNat.sub⟩
+lemma sub_inst_eq {n m : ZFNat} : n - m = n.sub m := rfl
+
+@[simp]
+theorem sub_zero {n : ZFNat} : n - 0 = n := by
+  rw [sub_inst_eq, ZFNat.sub, ZFNat.rec_zero]
+
+theorem sub_one_eq_pred {n : ZFNat} : n - 1 = pred n := by
+  rw [sub_inst_eq, ZFNat.sub, nat_one_eq, ZFNat.rec_succ, ZFNat.rec_zero]
+
+theorem succ_mono {n m : ZFNat} : n < m ↔ succ n < succ m :=
+  ⟨lt_mono, lt_of_succ_lt_succ⟩
+
+theorem sub_succ (n m : ZFNat) : n - succ m = pred (n - m) := by
+  rw [sub_inst_eq, ZFNat.sub, ZFNat.rec_succ, ← ZFNat.sub]
+  rfl
+
+@[simp]
+theorem zero_sub {n : ZFNat} : 0 - n = 0 := by
+  induction n with
+  | zero => rw [sub_zero]
+  | succ n ih => rw [sub_succ, ih, pred_zero]
+
+theorem succ_sub_succ (n m : ZFNat) : succ n - succ m = n - m := by
+  induction m with
+  | zero      => rw [← nat_one_eq, sub_one_eq_pred, pred_succ, sub_zero]
+  | succ m ih => rw [sub_succ, ih, ← sub_succ]
+
+theorem succ_sub_self (n : ZFNat) : succ n - n = 1 := by
+  induction n with
+  | zero => rw [sub_zero, nat_one_eq]
+  | succ n ih => rw [succ_sub_succ, ih]
+
+theorem sub_self {n : ZFNat} : n - n = 0 := by
+  induction n with
+  | zero => rw [sub_zero]
+  | succ n _ => rw [sub_succ, succ_sub_self, pred_one]
+
+theorem sub_add_distrib {n m k : ZFNat} : n - (m + k) = n - m - k := by
+  induction k with
+  | zero => rw [add_zero, sub_zero]
+  | succ k ih => rw [← succ_add, sub_succ, ih, ← sub_succ]
+
+theorem sub_ne_zero_of_lt {a b : ZFNat} : a < b → b - a ≠ 0 := by
+  intro h
+  induction a generalizing b with
+  | zero => rw [sub_zero]; exact zero_lt_ne_zero h
+  | succ a ih =>
+    induction b with
+    | zero => exact absurd h not_lt_zero
+    | succ b _ => rw [succ_sub_succ]; exact ih <| succ_mono.mpr h
+
+theorem le_of_succ_le {n m : ZFNat} (_ : succ n ≤ m) : n ≤ m := le_trans le_succ ‹_›
+theorem lt_of_succ_lt {n m : ZFNat} (h : succ n < m) : n < m := by
+  rcases le_of_succ_le (.inl h) with (h | rfl)
+  · assumption
+  · absurd lt_irrefl (lt_trans lt_succ h); trivial
+theorem le_of_lt {n m : ZFNat} : n < m → n ≤ m := Or.inl
+
+theorem add_sub_of_le {a b : ZFNat} (h : a ≤ b) : a + (b - a) = b := by
+  induction a with
+  | zero => rw [sub_zero, zero_add]
+  | succ a ih =>
+    have hne : b - a ≠ 0 := by
+      apply sub_ne_zero_of_lt
+      exact lt_of_succ_le ‹_›
+    have : a ≤ b := le_of_succ_le ‹_›
+    rw [sub_succ, add_succ, succ_add, succ_pred hne, ih this]
+
+theorem sub_one_cancel {a b : ZFNat} : 0 < a → 0 < b → a - 1 = b - 1 → a = b := by
+  intro ha hb h
+  rw [← succ_pred (zero_lt_ne_zero ha), ← succ_pred (zero_lt_ne_zero hb)]
+  simpa only [← sub_one_eq_pred, ← add_one_eq_succ, add_right_cancel]
+
+@[simp]
+theorem sub_add_cancel {n m : ZFNat} (h : m ≤ n) : n - m + m = n := by
+  rw [add_comm, add_sub_of_le h]
+
+theorem add_sub_add_right (n k m : ZFNat) : (n + k) - (m + k) = n - m := by
+  induction k with
+  | zero => simp_rw [add_zero]
+  | succ k ih => rwa [← succ_add, ← succ_add, succ_sub_succ]
+
+theorem add_sub_add_left (k n m : ZFNat) : (k + n) - (k + m) = n - m := by
+  rw [add_comm k n, add_comm k m, add_sub_add_right]
+
+@[simp] theorem add_sub_cancel (n m : ZFNat) : n + m - m = n :=
+  suffices n + m - (0 + m) = n by rw [zero_add] at this; assumption
+  by rw [add_sub_add_right, sub_zero]
+
+theorem add_sub_cancel_left (n m : ZFNat) : n + m - n = m := by
+  have : n + m - (n + 0) = m := by rw [add_sub_add_left, sub_zero]
+  rwa [add_zero] at this
+
+theorem add_sub_assoc {m k : ZFNat} (h : k ≤ m) (n : ZFNat) : n + m - k = n + (m - k) := by
+ rcases le.dest h with ⟨l, rfl⟩
+ rw [add_assoc, add_comm n, ← add_assoc, add_sub_cancel_left k, add_comm k, add_sub_cancel]
+
+theorem eq_add_of_sub_eq {a b c : ZFNat} (hle : b ≤ a) (h : a - b = c) : a = c + b := by
+  rw [h.symm, sub_add_cancel hle]
+
+theorem sub_eq_of_eq_add {a b c : ZFNat} (h : a = c + b) : a - b = c := by
+  rw [h, add_sub_cancel]
+
+theorem add_eq_add_sub_eq_sub {a b c d : ZFNat} : a + b = c + d → a - c = d - b := by
+  intro h
+  have : a = c + d - b := ZFNat.sub_eq_of_eq_add h.symm |>.symm
+  subst this
+  rw [←ZFNat.sub_add_distrib, ZFNat.add_comm b c, ZFNat.add_sub_add_left c d b]
+
+theorem sub_factor {m k n : ZFNat} (_ : k ≤ m) (_ : m ≤ n) : n - m + k = n - (m - k) := by
+  symm
+  apply sub_eq_of_eq_add
+  rw [← add_assoc, ← add_sub_assoc, add_comm k, add_sub_assoc, sub_self, add_zero, add_comm,
+    ← add_sub_assoc, add_comm, add_sub_assoc, sub_self, add_zero]
+  · trivial
+  · assumption
+  · trivial
+  · assumption
+
+theorem sub_add_comm {m n k : ZFNat} (h : m ≤ n) : n - m + k = n + k - m := by
+  rw [add_comm, add_comm n k, add_sub_assoc h k]
+
+theorem succ_le_succ {n m : ZFNat} : n ≤ m → succ n ≤ succ m
+  | .inl _ => .inl <| succ_mono.mp ‹_›
+  | .inr _ => .inr <| congrArg succ ‹_›
+
+theorem succ_le_succ_iff {a b : ZFNat} : succ a ≤ succ b ↔ a ≤ b where
+  mp := le_of_succ_le_succ
+  mpr := succ_le_succ
+
+theorem le_zero_imp_eq {n : ZFNat} : n ≤ 0 → n = 0 := by
+  rintro (h | rfl)
+  · exact absurd h not_lt_zero
+  · rfl
+
+/-- The multiplication function on natural numbers, defined inductively. -/
+protected abbrev mul (n m : ZFNat) : ZFNat := ZFNat.rec n 0 (fun _ => (· + m))
+instance mul_inst : Mul ZFNat := ⟨ZFNat.mul⟩
+lemma mul_inst_eq {n m : ZFNat} : n * m = n.mul m := rfl
+
+@[simp]
+lemma mul_zero {n : ZFNat} : n * 0 = 0 := by
+  dsimp [mul_inst_eq]
+  induction n using induction with
+  | zero => rw [ZFNat.mul, rec_zero]
+  | succ _ ih => rw [ZFNat.mul, rec_succ, ← ZFNat.mul, ih, add_zero]
+
+@[simp]
+lemma zero_mul {n : ZFNat} : 0 * n = 0 := by
+  rw [mul_inst_eq, ZFNat.mul, rec_zero]
+
+@[simp]
+lemma mul_one {n : ZFNat} : n * 1 = n := by
+  dsimp [mul_inst_eq]
+  induction n using induction with
+  | zero => rw [ZFNat.mul, rec_zero]
+  | succ _ ih => rw [ZFNat.mul, rec_succ, ← ZFNat.mul, ih, add_one_eq_succ]
+
+@[simp]
+lemma one_mul {n : ZFNat} : 1 * n = n := by
+  rw [mul_inst_eq, ZFNat.mul, nat_one_eq, rec_succ, rec_zero, zero_add]
+
+lemma mul_succ {n m : ZFNat} : (n + 1) * m = n * m + m := by
+  induction n with
+  | zero => rw [zero_add, one_mul, zero_mul, zero_add]
+  | succ n ih => rw [add_one_eq_succ, mul_inst_eq, ZFNat.mul, rec_succ, rec_succ, ← ZFNat.mul,
+    ← mul_inst_eq, ← ih, add_one_eq_succ]
+
+lemma succ_mul {n m : ZFNat} : (succ n) * m = n * m + m := by
+  rw [← add_one_eq_succ, mul_succ]
+
+lemma left_distrib {n m k : ZFNat} : n * (m + k) = n * m + n * k := by
+  induction n with
+  | zero => rw [zero_mul, zero_mul, zero_add, zero_mul]
+  | succ n ih =>
+    rw [← add_one_eq_succ]
+    conv_rhs => rw [mul_succ, mul_succ, add_assoc, ← add_assoc, ← add_assoc, add_comm m, add_assoc,
+      add_assoc, ← ih, ← add_assoc, add_comm k m, ← mul_succ]
+
+lemma mul_comm (n m : ZFNat) : n * m = m * n := by
+  induction n using induction with
+  | zero => rw [zero_mul, mul_zero]
+  | succ n ih => rw [← add_one_eq_succ, mul_succ, ih, left_distrib, mul_one]
+
+lemma succ_mul' {n m : ZFNat} : m * (succ n) = m * n + m := by
+  rw [mul_comm, succ_mul, mul_comm]
+
+lemma right_distrib {n m k : ZFNat} : (n + m) * k = n * k + m * k := by
+  rw [mul_comm, left_distrib, mul_comm m, mul_comm k]
+
+lemma mul_assoc (n m k : ZFNat) : n * m * k = n * (m * k) := by
+  induction n using induction with
+  | zero => rw [zero_mul, zero_mul, zero_mul]
+  | succ n ih =>
+    rw [← add_one_eq_succ]
+    conv =>
+      rhs
+      rw [right_distrib, one_mul, ← ih, ← right_distrib, ← mul_succ]
+
+lemma mul_left_comm (n m k : ZFNat) : n * (m * k) = m * (n * k) := by
+  rw [← mul_assoc, mul_comm n m, mul_assoc]
+
+lemma two_mul (n : ZFNat) : (1 + 1) * n = n + n := by rw [mul_succ, one_mul]
+lemma mul_two (n : ZFNat) : n * (1 + 1) = n + n := by rw [mul_comm, two_mul]
+
+lemma sub_lt_eq_zero {n m : ZFNat} (h : n ≤ m) : n - m = 0 := by
+  induction m using induction with
+  | zero => rw [le_zero_imp_eq h, sub_zero]
+  | succ _ ih =>
+    rcases h with _ | rfl
+    · rw [sub_succ, ih]
+      · exact pred_zero
+      · exact lt_le_iff.mpr ‹_›
+    · rw [sub_self]
+
+theorem add_lt_trans {n m p q : ZFNat} : n < m → p < q → n + p < m + q := by
+  intros h h'
+  exact lt_trans (add_lt_add_left h' n) (add_lt_add_right h q)
+
+theorem pos_mul_pos {k n : ZFNat} (h : 0 < k) : 0 < k*n → 0 < n := by
+  intro h'
+  induction n with
+  | zero => rwa [mul_zero] at h'
+  | succ m ih =>
+    obtain ⟨l, rfl⟩ := not_zero_imp_succ (zero_lt_ne_zero h)
+    rcases lt_le_iff.mpr h with (_ | rfl)
+    · by_contra contr
+      rw [not_lt] at contr
+      replace contr := le_zero_imp_eq contr
+      nomatch succ_ne_zero m contr
+    · rw [← nat_one_eq, one_mul] at h'
+      assumption
+
+theorem mul_lt_mono {n m k : ZFNat} (h : 0 < k) : n < m → k*n < k*m := by
+  intro h'
+  induction m using induction with
+  | zero => nomatch not_lt_zero h'
+  | succ m ih =>
+    rw [← add_one_eq_succ, left_distrib, mul_one]
+    rcases lt_le_iff.mpr h' with (h' | rfl)
+    · let this := add_lt_add_of_le_of_lt (@zero_le k) (ih h')
+      rwa [zero_add, add_comm] at this
+    · conv => lhs; rw [← @zero_add (k*n), add_comm]
+      exact add_lt_add_left h (k*n)
+
+theorem mul_le_mono {k m n : ZFNat} : n ≤ m → k*n ≤ k*m := by
+  intro h
+  induction k using induction with
+  | zero => rw [zero_mul, zero_mul]
+  | succ k ih =>
+    rw [succ_mul, succ_mul]
+    by_contra contr
+    rw [not_le, add_comm, add_comm _ n] at contr
+    rcases ih with _ | l
+    · nomatch lt_irrefl <| lt_trans (add_lt_add_of_le_of_lt h ‹_›) contr
+    · rcases h with _ | rfl
+      · rw [l] at contr
+        nomatch lt_irrefl <| lt_trans (lt_of_add_lt_add_right contr) ‹_›
+      · nomatch lt_irrefl ‹_›
+
+theorem mul_lt_cancel {k m n : ZFNat} : k*n < k*m → n < m := by
+  contrapose
+  rw [not_lt, not_lt]
+  exact mul_le_mono
+
+lemma lt_mul_iff {n m k : ZFNat} : n < m ↔ (k+1)*n < (k+1)*m := by
+  apply Iff.intro
+  · induction k using induction with
+    | zero => rw [zero_add, one_mul, one_mul]; exact id
+    | succ k ih =>
+      intro
+      rw [← add_one_eq_succ, mul_succ, mul_succ (m:=m)]
+      exact add_lt_trans (ih ‹_›) ‹_›
+  · exact mul_lt_cancel
+
+lemma left_distrib_mul_sub_one {n m : ZFNat} : n * (m - 1) = n * m - n := by
+  induction m using induction with
+  | zero => rw [zero_sub, mul_zero, zero_sub]
+  | succ _ _ =>
+    rw [nat_one_eq, succ_sub_succ, sub_zero, succ_mul', add_sub_assoc, sub_self, add_zero]
+    right
+    rfl
+
+lemma left_distrib_mul_sub_aux {n m k : ZFNat} (h : k < m) : n * (m - k) = n * m - n * k := by
+  induction k with
+  | zero => rw [sub_zero, mul_zero, sub_zero]
+  | succ k ih =>
+    rw [mul_comm n k.succ, succ_mul, mul_comm k n, sub_add_distrib]
+    specialize ih (lt_trans lt_succ h)
+    rw [← ih, ← left_distrib_mul_sub_one, ← sub_add_distrib, add_one_eq_succ]
+
+lemma sub_eq_zero_imp_le {a b : ZFNat} : a - b = 0 ↔ a ≤ b := by
+  apply Iff.intro
+  · intro h
+    induction b with
+    | zero => rw [sub_zero] at h; right; assumption
+    | succ b ih =>
+      induction a with
+      | zero => exact zero_le
+      | succ a _ =>
+        apply le_mono
+        rw [succ_sub_succ] at h
+        by_contra contr
+        rw [not_le] at contr
+        absurd sub_ne_zero_of_lt contr
+        assumption
+  · intro
+    exact sub_lt_eq_zero ‹_›
+
+lemma sub_eq_zero_mul {n a b : ZFNat} : a - b = 0 → n * a - n * b = 0 := by
+  intro
+  induction n with
+  | zero => rw [zero_mul, zero_mul, sub_zero]
+  | succ _ _ => exact sub_eq_zero_imp_le.mpr (mul_le_mono (sub_eq_zero_imp_le.mp ‹_›))
+
+lemma left_distrib_mul_sub {n m k : ZFNat} : n * (m - k) = n * m - n * k := by
+  rcases @le_total m k with (h | rfl) | _ | rfl
+  · replace h := sub_lt_eq_zero (Or.inl h)
+    rw [h, mul_zero, sub_eq_zero_mul h]
+  · rw [sub_self, sub_self, mul_zero]
+  · exact left_distrib_mul_sub_aux ‹_›
+  · rw [sub_self, sub_self, mul_zero]
+
+lemma right_distrib_mul_sub {n m k : ZFNat} : (m - k)*n = m*n - k*n := by
+  rw [mul_comm, left_distrib_mul_sub, mul_comm, mul_comm k]
+
+lemma add_eq_zero_iff {n m : ZFNat} : n + m = 0 ↔ n = 0 ∧ m = 0 := by
+  constructor
+  · intro h
+    induction n with
+    | zero =>
+      rw [zero_add] at h
+      exact ⟨rfl, h⟩
+    | succ n ih =>
+      induction m with
+      | zero =>
+        rw [add_zero] at h
+        exact ⟨h, rfl⟩
+      | succ m ih' =>
+        rw [add_succ] at h
+        nomatch succ_ne_zero _ h
+  · rintro ⟨rfl, rfl⟩
+    rw [zero_add]
+
+lemma mul_eq_zero_iff {n m : ZFNat} : n * m = 0 ↔ n = 0 ∨ m = 0 := by
+  constructor
+  · intro h
+    induction n with
+    | zero => left; rfl
+    | succ n ih =>
+      induction m with
+      | zero => right; rfl
+      | succ m ih' =>
+        rw [←add_one_eq_succ, mul_succ, add_eq_zero_iff] at h
+        nomatch succ_ne_zero _ h.2
+  · rintro (rfl | rfl)
+    · rw [zero_mul]
+    · rw [mul_zero]
+
+lemma eq_le_le_iff {n m : ZFNat} : n = m ↔ n ≤ m ∧ m ≤ n := by
+  constructor
+  · rintro rfl
+    exact ⟨le_refl _, le_refl _⟩
+  · rintro ⟨n_le_m, m_le_n⟩
+    rcases n_le_m with n_le_m | rfl
+    · rcases m_le_n with m_le_n | rfl
+      · nomatch lt_irrefl <| lt_trans n_le_m m_le_n
+      · rfl
+    · rfl
+
+lemma mul_left_cancel_iff {n m k : ZFNat} (k_pos : k ≠ 0) : k * m = k * n ↔ m = n := by
+  constructor
+  · induction n generalizing m with
+    | zero =>
+      intro hm
+      rw [mul_zero, mul_eq_zero_iff] at hm
+      rcases hm with rfl | rfl
+      · contradiction
+      · rfl
+    | succ n ih =>
+      intro eq
+      cases m with
+      | zero =>
+        symm at eq
+        rw [mul_zero, mul_eq_zero_iff] at eq
+        rcases eq with rfl | eq
+        · contradiction
+        · nomatch succ_ne_zero _ eq
+      | succ m =>
+        congr
+        rw [eq_le_le_iff]
+        and_intros
+        · have := zero_add ▸ @ZFNat.sub_eq_of_eq_add (k * m.succ) (k * n.succ) 0 <| eq
+          rw [←left_distrib_mul_sub, mul_eq_zero_iff] at this
+          rcases this with rfl | this
+          · contradiction
+          · rwa [ZFNat.succ_sub_succ, ZFNat.sub_eq_zero_imp_le] at this
+        · have := zero_add ▸ @ZFNat.sub_eq_of_eq_add (k * n.succ) (k * m.succ) 0 <| eq.symm
+          rw [←left_distrib_mul_sub, mul_eq_zero_iff] at this
+          rcases this with rfl | this
+          · contradiction
+          · rwa [ZFNat.succ_sub_succ, ZFNat.sub_eq_zero_imp_le] at this
+  · rintro rfl
+    rfl
+
+lemma mul_right_cancel_iff {n m k : ZFNat} (k_pos : k ≠ 0) : m * k = n * k ↔ m = n := by
+  rw [mul_comm m k, mul_comm n k]
+  exact mul_left_cancel_iff k_pos
+
+/-- The power function on natural numbers, defined inductively. -/
+protected abbrev pow (n p : ZFNat) : ZFNat := ZFNat.rec p 1 (fun _  => (· * n))
+instance pow_inst : HomogeneousPow ZFNat := ⟨ZFNat.pow⟩
+lemma pow_inst_eq {n p : ZFNat} : n ^ p = n.pow p := rfl
+
+lemma pow_zero {n : ZFNat} : n ^ 0 = 1 := by
+  dsimp [pow_inst_eq]
+  rw [ZFNat.pow, rec_zero]
+
+lemma pow_one {n : ZFNat} : n ^ 1 = n := by
+  rw [pow_inst_eq, ZFNat.pow, nat_one_eq, rec_succ, rec_zero, ← nat_one_eq, one_mul]
+
+end Arithmetic
+
+/--
+Induction principle for `ZFNat`, using natural notations.
+
+Declared as an induction eliminator.
+-/
+@[induction_eliminator]
+theorem induction' {P : ZFNat → Prop} (n : ZFNat)
+  (zero : P 0) (succ : ∀ n, P n → P (n + 1)) : P n := by
+  induction n with
+  | zero => trivial
+  | succ n ih =>
+    rw [← add_one_eq_succ]
+    exact succ n ih
+
+private abbrev nsmul : ℕ → ZFNat → ZFNat
+  | 0, _ => 0
+  | n+1, m => m + nsmul n m
+
+instance : Semiring ZFNat where
+  add := .add
+  add_assoc _ _ _ := by rw [add_assoc]
+  zero := 0
+  zero_add _ := zero_add
+  add_zero _ := add_zero
+  nsmul := ZFSet.ZFNat.nsmul
+  nsmul_zero _ := rfl
+  nsmul_succ _ _ := add_comm _ _
+  add_comm := add_comm
+  mul := .mul
+  left_distrib _ _ _ := left_distrib
+  right_distrib _ _ _:= right_distrib
+  zero_mul _ := zero_mul
+  mul_zero _ := mul_zero
+  mul_assoc _ _ _ := by rw [mul_assoc]
+  one := 1
+  one_mul _ := one_mul
+  mul_one _ := mul_one
+
+instance : CommSemiring ZFNat where
+  mul_comm := mul_comm
+
+instance : IsLeftCancelAdd ZFNat where
+  add_left_cancel x y z := by rw [ZFNat.add_left_cancel]; intro; trivial
+
+def toNat (n : ZFNat) : ℕ := ZFNat.rec n 0 (fun _ => Nat.succ)
+def ofNat (n : ℕ) : ZFNat := nsmul n 1
+
+theorem toNat_sound {n : ℕ} : (n : ZFNat).toNat = n := by
+  induction n with
+  | zero => apply ZFNat.rec_zero
+  | succ n ih => rw [Nat.cast_add, Nat.cast_one, ZFNat.add_one_eq_succ, ZFNat.toNat,
+    ZFNat.rec_succ, ← ZFNat.toNat, ih]
+
+theorem ofNat_toNat {n : ℕ} : (ofNat n).toNat = n := by
+  induction n with
+  | zero => apply ZFNat.rec_zero
+  | succ n ih =>
+    rw [ofNat, ZFNat.nsmul, ← ofNat, add_comm, add_one_eq_succ, toNat, ZFNat.rec_succ, ← toNat, ih]
+
+end ZFNat
+
+theorem Nat.is_transitive : transitive Nat := by
+  intro n hn
+  apply ZFNat.rec' n hn
+  case zero => exact empty_subset Nat
+  case succ =>
+    intros x hx hx' z hz
+    rw [mem_insert_iff] at hz
+    rcases hz with rfl | hz
+    · assumption
+    · exact hx' hz
+
+/-- `Nat` is an inductive set. -/
+theorem Nat.is_inductive : inductive_set Nat where
+  left := ZFNat.zero_in_Nat
+  right := fun _ _ => ZFNat.succ_mem_Nat' ‹_›
+
+end Naturals
+end ZFSet
+end


### PR DESCRIPTION
The construction is the usual one built upon pairs of naturals.
- add usual arithmetic operations and theorems on integers
- define a proper (sub)type `ZFInt` for ZFC integers
- provide an isomorphism between the type `ZFInt` and the set `Int`

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

- [ ] depends on: #24286

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
