### PR TITLE
[Merged by Bors] - feat: cofinal sets

### DIFF
--- a/Mathlib/Order/Bounds/Basic.lean
+++ b/Mathlib/Order/Bounds/Basic.lean
@@ -133,8 +133,8 @@ theorem isGLB_congr (h : lowerBounds s = lowerBounds t) : IsGLB s a ↔ IsGLB t 
 alias HasSubset.Subset.dominated := Dominated.of_subset
 alias HasSubset.Subset.codominated := Codominated.of_subset
 
-@[simp, refl] protected lemma Dominated.rfl : Dominated s s := .of_subset .rfl
-@[simp, refl] protected lemma Codominated.rfl : Codominated s s := .of_subset .rfl
+@[refl] protected lemma Dominated.rfl : Dominated s s := .of_subset .rfl
+@[refl] protected lemma Codominated.rfl : Codominated s s := .of_subset .rfl
 
 protected lemma Dominated.trans (hst : Dominated s t) (htu : Dominated t u) :
     Dominated s u :=

--- a/Mathlib/Order/Bounds/Basic.lean
+++ b/Mathlib/Order/Bounds/Basic.lean
@@ -125,36 +125,37 @@ theorem isLUB_congr (h : upperBounds s = upperBounds t) : IsLUB s a ↔ IsLUB t 
 theorem isGLB_congr (h : lowerBounds s = lowerBounds t) : IsGLB s a ↔ IsGLB t a := by
   rw [IsGLB, IsGLB, h]
 
-@[simp] lemma Dominated.of_subset (hst : s ⊆ t) : Dominated s t := fun a ha ↦ ⟨a, hst ha, le_rfl⟩
-
-@[simp] lemma Codominated.of_subset (hst : s ⊆ t) : Codominated s t :=
+@[simp] lemma IsCofinalFor.of_subset (hst : s ⊆ t) : IsCofinalFor s t :=
   fun a ha ↦ ⟨a, hst ha, le_rfl⟩
 
-alias HasSubset.Subset.dominated := Dominated.of_subset
-alias HasSubset.Subset.codominated := Codominated.of_subset
+@[simp] lemma IsCoinitialFor.of_subset (hst : s ⊆ t) : IsCoinitialFor s t :=
+  fun a ha ↦ ⟨a, hst ha, le_rfl⟩
 
-@[refl] protected lemma Dominated.rfl : Dominated s s := .of_subset .rfl
-@[refl] protected lemma Codominated.rfl : Codominated s s := .of_subset .rfl
+alias HasSubset.Subset.iscofinalfor := IsCofinalFor.of_subset
+alias HasSubset.Subset.iscoinitialfor := IsCoinitialFor.of_subset
 
-protected lemma Dominated.trans (hst : Dominated s t) (htu : Dominated t u) :
-    Dominated s u :=
+@[refl] protected lemma IsCofinalFor.rfl : IsCofinalFor s s := .of_subset .rfl
+@[refl] protected lemma IsCoinitialFor.rfl : IsCoinitialFor s s := .of_subset .rfl
+
+protected lemma IsCofinalFor.trans (hst : IsCofinalFor s t) (htu : IsCofinalFor t u) :
+    IsCofinalFor s u :=
   fun _a ha ↦ let ⟨_b, hb, hab⟩ := hst ha; let ⟨c, hc, hbc⟩ := htu hb; ⟨c, hc, hab.trans hbc⟩
 
-protected lemma Codominated.trans (hst : Codominated s t) (htu : Codominated t u) :
-    Codominated s u :=
+protected lemma IsCoinitialFor.trans (hst : IsCoinitialFor s t) (htu : IsCoinitialFor t u) :
+    IsCoinitialFor s u :=
   fun _a ha ↦ let ⟨_b, hb, hba⟩ := hst ha; let ⟨c, hc, hcb⟩ := htu hb; ⟨c, hc, hcb.trans hba⟩
 
-protected lemma Dominated.mono_left (hst : s ⊆ t) (htu : Dominated t u) : Dominated s u :=
-  hst.dominated.trans htu
+protected lemma IsCofinalFor.mono_left (hst : s ⊆ t) (htu : IsCofinalFor t u) :
+    IsCofinalFor s u := hst.iscofinalfor.trans htu
 
-protected lemma Codominated.mono_left (hst : s ⊆ t) (htu : Codominated t u) : Codominated s u :=
-  hst.codominated.trans htu
+protected lemma IsCoinitialFor.mono_left (hst : s ⊆ t) (htu : IsCoinitialFor t u) :
+    IsCoinitialFor s u := hst.iscoinitialfor.trans htu
 
-protected lemma Dominated.mono_right (htu : t ⊆ u) (hst : Dominated s t) : Dominated s u :=
-  hst.trans htu.dominated
+protected lemma IsCofinalFor.mono_right (htu : t ⊆ u) (hst : IsCofinalFor s t) :
+    IsCofinalFor s u := hst.trans htu.iscofinalfor
 
-protected lemma Codominated.mono_right (htu : t ⊆ u) (hst : Codominated s t) : Codominated s u :=
-  hst.trans htu.codominated
+protected lemma IsCoinitialFor.mono_right (htu : t ⊆ u) (hst : IsCoinitialFor s t) :
+    IsCoinitialFor s u := hst.trans htu.iscoinitialfor
 
 /-!
 ### Monotonicity
@@ -168,11 +169,11 @@ theorem lowerBounds_mono_set ⦃s t : Set α⦄ (hst : s ⊆ t) : lowerBounds t 
   fun _ hb _ h => hb <| hst h
 
 @[gcongr]
-lemma upperBounds_mono_of_dominated (hst : Dominated s t) : upperBounds t ⊆ upperBounds s :=
+lemma upperBounds_mono_of_iscofinalfor (hst : IsCofinalFor s t) : upperBounds t ⊆ upperBounds s :=
   fun _a ha _b hb ↦ let ⟨_c, hc, hbc⟩ := hst hb; hbc.trans (ha hc)
 
 @[gcongr]
-lemma lowerBounds_mono_of_dominated (hst : Codominated s t) : lowerBounds t ⊆ lowerBounds s :=
+lemma lowerBounds_mono_of_iscofinalfor (hst : IsCoinitialFor s t) : lowerBounds t ⊆ lowerBounds s :=
   fun _a ha _b hb ↦ let ⟨_c, hc, hcb⟩ := hst hb; hcb.trans' (ha hc)
 
 theorem upperBounds_mono_mem ⦃a b⦄ (hab : a ≤ b) : a ∈ upperBounds s → b ∈ upperBounds s :=

--- a/Mathlib/Order/Bounds/Basic.lean
+++ b/Mathlib/Order/Bounds/Basic.lean
@@ -26,7 +26,7 @@ variable {α : Type u} {γ : Type v}
 
 section
 
-variable [Preorder α] {s t : Set α} {a b : α}
+variable [Preorder α] {s t u : Set α} {a b : α}
 
 theorem mem_upperBounds : a ∈ upperBounds s ↔ ∀ x ∈ s, x ≤ a :=
   Iff.rfl
@@ -125,6 +125,37 @@ theorem isLUB_congr (h : upperBounds s = upperBounds t) : IsLUB s a ↔ IsLUB t 
 theorem isGLB_congr (h : lowerBounds s = lowerBounds t) : IsGLB s a ↔ IsGLB t a := by
   rw [IsGLB, IsGLB, h]
 
+@[simp] lemma Dominated.of_subset (hst : s ⊆ t) : Dominated s t := fun a ha ↦ ⟨a, hst ha, le_rfl⟩
+
+@[simp] lemma Codominated.of_subset (hst : s ⊆ t) : Codominated s t :=
+  fun a ha ↦ ⟨a, hst ha, le_rfl⟩
+
+alias HasSubset.Subset.dominated := Dominated.of_subset
+alias HasSubset.Subset.codominated := Codominated.of_subset
+
+@[simp, refl] protected lemma Dominated.rfl : Dominated s s := .of_subset .rfl
+@[simp, refl] protected lemma Codominated.rfl : Codominated s s := .of_subset .rfl
+
+protected lemma Dominated.trans (hst : Dominated s t) (htu : Dominated t u) :
+    Dominated s u :=
+  fun _a ha ↦ let ⟨_b, hb, hab⟩ := hst ha; let ⟨c, hc, hbc⟩ := htu hb; ⟨c, hc, hab.trans hbc⟩
+
+protected lemma Codominated.trans (hst : Codominated s t) (htu : Codominated t u) :
+    Codominated s u :=
+  fun _a ha ↦ let ⟨_b, hb, hba⟩ := hst ha; let ⟨c, hc, hcb⟩ := htu hb; ⟨c, hc, hcb.trans hba⟩
+
+protected lemma Dominated.mono_left (hst : s ⊆ t) (htu : Dominated t u) : Dominated s u :=
+  hst.dominated.trans htu
+
+protected lemma Codominated.mono_left (hst : s ⊆ t) (htu : Codominated t u) : Codominated s u :=
+  hst.codominated.trans htu
+
+protected lemma Dominated.mono_right (htu : t ⊆ u) (hst : Dominated s t) : Dominated s u :=
+  hst.trans htu.dominated
+
+protected lemma Codominated.mono_right (htu : t ⊆ u) (hst : Codominated s t) : Codominated s u :=
+  hst.trans htu.codominated
+
 /-!
 ### Monotonicity
 -/
@@ -135,6 +166,14 @@ theorem upperBounds_mono_set ⦃s t : Set α⦄ (hst : s ⊆ t) : upperBounds t 
 
 theorem lowerBounds_mono_set ⦃s t : Set α⦄ (hst : s ⊆ t) : lowerBounds t ⊆ lowerBounds s :=
   fun _ hb _ h => hb <| hst h
+
+@[gcongr]
+lemma upperBounds_mono_of_dominated (hst : Dominated s t) : upperBounds t ⊆ upperBounds s :=
+  fun _a ha _b hb ↦ let ⟨_c, hc, hbc⟩ := hst hb; hbc.trans (ha hc)
+
+@[gcongr]
+lemma lowerBounds_mono_of_dominated (hst : Codominated s t) : lowerBounds t ⊆ lowerBounds s :=
+  fun _a ha _b hb ↦ let ⟨_c, hc, hcb⟩ := hst hb; hcb.trans' (ha hc)
 
 theorem upperBounds_mono_mem ⦃a b⦄ (hab : a ≤ b) : a ∈ upperBounds s → b ∈ upperBounds s :=
   fun ha _ h => le_trans (ha h) hab

--- a/Mathlib/Order/Bounds/Defs.lean
+++ b/Mathlib/Order/Bounds/Defs.lean
@@ -18,8 +18,8 @@ In this file we define:
 * `IsLUB s a`, `IsGLB s a` : `a` is a least upper bound (resp., a greatest lower bound)
   of `s`; for a partial order, it is unique if exists.
 * `IsCofinal s`: for every `a`, there exists a member of `s` greater or equal to it.
-* `Dominated s t` : for all `a ∈ s` there exists `b ∈ t` such that `a ≤ b`
-* `Codominated s t` : for all `a ∈ s` there exists `b ∈ t` such that `b ≤ a`
+* `IsCofinalFor s t` : for all `a ∈ s` there exists `b ∈ t` such that `a ≤ b`
+* `IsCoinitialFor s t` : for all `a ∈ s` there exists `b ∈ t` such that `b ≤ a`
 -/
 
 variable {α : Type*} [LE α]
@@ -56,14 +56,14 @@ def IsLUB (s : Set α) : α → Prop :=
 def IsGLB (s : Set α) : α → Prop :=
   IsGreatest (lowerBounds s)
 
+/-- A set `s` is said to be cofinal for a set `t` if, for all `a ∈ s` there exists `b ∈ t`
+such that `a ≤ b`. -/
+def IsCofinalFor (s t : Set α) := ∀ ⦃a⦄, a ∈ s → ∃ b ∈ t, a ≤ b
+
+/-- A set `s` is said to be coinitial for a set `t` if, for all `a ∈ s` there exists `b ∈ t`
+such that `b ≤ a`. -/
+def IsCoinitialFor (s t : Set α) := ∀ ⦃a⦄, a ∈ s → ∃ b ∈ t, b ≤ a
+
 /-- A set is cofinal when for every `x : α` there exists `y ∈ s` with `x ≤ y`. -/
 def IsCofinal (s : Set α) : Prop :=
   ∀ x, ∃ y ∈ s, x ≤ y
-
-/-- A set `s` is said to be dominated by a set `t` if, for all `a` in `s` there exists `b` in
-`t` such that `a ≤ b`. -/
-def Dominated (s t : Set α) := ∀  ⦃a⦄, a ∈ s → ∃ b ∈ t, a ≤ b
-
-/-- A set `s` is said to be dominated by a set `t` if, for all `a` in `s` there exists `b` in
-`t` such that `b ≤ a`. -/
-def Codominated (s t : Set α) := ∀ ⦃a⦄, a ∈ s → ∃ b ∈ t, b ≤ a

--- a/Mathlib/Order/Bounds/Defs.lean
+++ b/Mathlib/Order/Bounds/Defs.lean
@@ -18,6 +18,8 @@ In this file we define:
 * `IsLUB s a`, `IsGLB s a` : `a` is a least upper bound (resp., a greatest lower bound)
   of `s`; for a partial order, it is unique if exists.
 * `IsCofinal s`: for every `a`, there exists a member of `s` greater or equal to it.
+* `Dominated s t` : for all `a ∈ s` there exists `b ∈ t` such that `a ≤ b`
+* `Codominated s t` : for all `a ∈ s` there exists `b ∈ t` such that `b ≤ a`
 -/
 
 variable {α : Type*} [LE α]
@@ -57,3 +59,11 @@ def IsGLB (s : Set α) : α → Prop :=
 /-- A set is cofinal when for every `x : α` there exists `y ∈ s` with `x ≤ y`. -/
 def IsCofinal (s : Set α) : Prop :=
   ∀ x, ∃ y ∈ s, x ≤ y
+
+/-- A set `s` is said to be dominated by a set `t` if, for all `a` in `s` there exists `b` in
+`t` such that `a ≤ b`. -/
+def Dominated (s t : Set α) := ∀  ⦃a⦄, a ∈ s → ∃ b ∈ t, a ≤ b
+
+/-- A set `s` is said to be dominated by a set `t` if, for all `a` in `s` there exists `b` in
+`t` such that `b ≤ a`. -/
+def Codominated (s t : Set α) := ∀ ⦃a⦄, a ∈ s → ∃ b ∈ t, b ≤ a

--- a/Mathlib/Order/Bounds/Image.lean
+++ b/Mathlib/Order/Bounds/Image.lean
@@ -420,38 +420,38 @@ end AntitoneMonotone
 
 end Image2
 
-section Dominated
+section IsCofinalFor
 variable {α β : Type*} [Preorder α] [Preorder β] {s t : Set α} {f : α → β}
 
-lemma Dominated.image_of_monotone (hst : Dominated s t) (hf : Monotone f) :
-    Dominated (f '' s) (f '' t) := by
-  simp only [Dominated, forall_mem_image, exists_mem_image]
+lemma IsCofinalFor.image_of_monotone (hst : IsCofinalFor s t) (hf : Monotone f) :
+    IsCofinalFor (f '' s) (f '' t) := by
+  simp only [IsCofinalFor, forall_mem_image, exists_mem_image]
   rintro a ha
   obtain ⟨b, hb, hab⟩ := hst ha
   exact ⟨b, hb, hf hab⟩
 
-lemma Dominated.image_of_antitone (hst : Dominated s t) (hf : Antitone f) :
-    Codominated (f '' s) (f '' t) := by
-  simp only [Codominated, forall_mem_image, exists_mem_image]
+lemma IsCofinalFor.image_of_antitone (hst : IsCofinalFor s t) (hf : Antitone f) :
+    IsCoinitialFor (f '' s) (f '' t) := by
+  simp only [IsCoinitialFor, forall_mem_image, exists_mem_image]
   rintro a ha
   obtain ⟨b, hb, hab⟩ := hst ha
   exact ⟨b, hb, hf hab⟩
 
-lemma Codominated.image_of_monotone (hst : Codominated s t) (hf : Monotone f) :
-    Codominated (f '' s) (f '' t) := by
-  simp only [Codominated, forall_mem_image, exists_mem_image]
+lemma IsCoinitialFor.image_of_monotone (hst : IsCoinitialFor s t) (hf : Monotone f) :
+    IsCoinitialFor (f '' s) (f '' t) := by
+  simp only [IsCoinitialFor, forall_mem_image, exists_mem_image]
   rintro a ha
   obtain ⟨b, hb, hba⟩ := hst ha
   exact ⟨b, hb, hf hba⟩
 
-lemma Codominated.image_of_antitone (hst : Codominated s t) (hf : Antitone f) :
-    Dominated (f '' s) (f '' t) := by
-  simp only [Dominated, forall_mem_image, exists_mem_image]
+lemma IsCoinitialFor.image_of_antitone (hst : IsCoinitialFor s t) (hf : Antitone f) :
+    IsCofinalFor (f '' s) (f '' t) := by
+  simp only [IsCofinalFor, forall_mem_image, exists_mem_image]
   rintro a ha
   obtain ⟨b, hb, hba⟩ := hst ha
   exact ⟨b, hb, hf hba⟩
 
-end Dominated
+end IsCofinalFor
 
 section Prod
 

--- a/Mathlib/Order/Bounds/Image.lean
+++ b/Mathlib/Order/Bounds/Image.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Yury Kudryashov, Paul Lezeau
 -/
 import Mathlib.Data.Set.NAry
-import Mathlib.Order.Bounds.Basic
+import Mathlib.Order.Bounds.Defs
 
 /-!
 

--- a/Mathlib/Order/Bounds/Image.lean
+++ b/Mathlib/Order/Bounds/Image.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Yury Kudryashov, Paul Lezeau
 -/
 import Mathlib.Data.Set.NAry
-import Mathlib.Order.Bounds.Defs
+import Mathlib.Order.Bounds.Basic
 
 /-!
 
@@ -419,6 +419,39 @@ theorem IsGreatest.isLeast_image2_of_isLeast (ha : IsGreatest s a) (hb : IsLeast
 end AntitoneMonotone
 
 end Image2
+
+section Dominated
+variable {α β : Type*} [Preorder α] [Preorder β] {s t : Set α} {f : α → β}
+
+lemma Dominated.image_of_monotone (hst : Dominated s t) (hf : Monotone f) :
+    Dominated (f '' s) (f '' t) := by
+  simp only [Dominated, forall_mem_image, exists_mem_image]
+  rintro a ha
+  obtain ⟨b, hb, hab⟩ := hst ha
+  exact ⟨b, hb, hf hab⟩
+
+lemma Dominated.image_of_antitone (hst : Dominated s t) (hf : Antitone f) :
+    Codominated (f '' s) (f '' t) := by
+  simp only [Codominated, forall_mem_image, exists_mem_image]
+  rintro a ha
+  obtain ⟨b, hb, hab⟩ := hst ha
+  exact ⟨b, hb, hf hab⟩
+
+lemma Codominated.image_of_monotone (hst : Codominated s t) (hf : Monotone f) :
+    Codominated (f '' s) (f '' t) := by
+  simp only [Codominated, forall_mem_image, exists_mem_image]
+  rintro a ha
+  obtain ⟨b, hb, hba⟩ := hst ha
+  exact ⟨b, hb, hf hba⟩
+
+lemma Codominated.image_of_antitone (hst : Codominated s t) (hf : Antitone f) :
+    Dominated (f '' s) (f '' t) := by
+  simp only [Dominated, forall_mem_image, exists_mem_image]
+  rintro a ha
+  obtain ⟨b, hb, hba⟩ := hst ha
+  exact ⟨b, hb, hf hba⟩
+
+end Dominated
 
 section Prod
 


### PR DESCRIPTION
A set `s` is dominated by a set `t` if for all `a ∈ s` there exists `b ∈ t` such that `a ≤ b`.

This naturally occuring condition is equivalent to `s ⊆ lowerClosure t`, but it is difficult to prove things like transitivity from that definition alone. Better to have API.

The import increase is immaterial.

Co-authored-by: Chris Hoskin


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
