### PR TITLE
[Merged by Bors] - feat(Topology/Algebra/AffineSubspace): `AffineSubspace.subtypeA`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -5723,6 +5723,7 @@ import Mathlib.Testing.Plausible.Sampleable
 import Mathlib.Testing.Plausible.Testable
 import Mathlib.Topology.AlexandrovDiscrete
 import Mathlib.Topology.Algebra.Affine
+import Mathlib.Topology.Algebra.AffineSubspace
 import Mathlib.Topology.Algebra.Algebra
 import Mathlib.Topology.Algebra.Algebra.Equiv
 import Mathlib.Topology.Algebra.Algebra.Rat

--- a/Mathlib/Topology/Algebra/AffineSubspace.lean
+++ b/Mathlib/Topology/Algebra/AffineSubspace.lean
@@ -1,0 +1,41 @@
+/-
+Copyright (c) 2025 Joseph Myers. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joseph Myers
+-/
+import Mathlib.LinearAlgebra.AffineSpace.AffineSubspace.Basic
+import Mathlib.Topology.Algebra.ContinuousAffineMap
+
+/-!
+# Topology of affine subspaces.
+
+This file defines the embedding map from an affine subspace to the ambient space as a continuous
+affine map.
+
+## Main definitions
+
+* `AffineSubspace.subtypeA` is `AffineSubspace.subtype` as a `ContinuousAffineMap`.
+
+-/
+
+
+namespace AffineSubspace
+
+variable {R V P : Type*} [Ring R] [AddCommGroup V] [Module R V] [TopologicalSpace P]
+  [AddTorsor V P]
+
+attribute [local instance] toAddTorsor
+
+/-- Embedding of an affine subspace to the ambient space, as a continuous affine map. -/
+def subtypeA (s : AffineSubspace R P) [Nonempty s] : s →ᴬ[R] P where
+  toAffineMap := s.subtype
+  cont := continuous_subtype_val
+
+@[simp] lemma coe_subtypeA (s : AffineSubspace R P) [Nonempty s] : ⇑s.subtypeA = Subtype.val :=
+  rfl
+
+@[simp] lemma subtypeA_toAffineMap (s : AffineSubspace R P) [Nonempty s] :
+    s.subtypeA.toAffineMap = s.subtype :=
+  rfl
+
+end AffineSubspace


### PR DESCRIPTION
Define the embedding map from an affine subspace to the ambient space as a continuous affine map, analogous to `Submodule.subtypeL`.  There wasn't an immediately obvious location importing both continuous affine maps and affine subspaces, so I put this in its own file.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
