### PR TITLE
[Merged by Bors] - feat(AlgebraicGeometry): `Proj` is proper

### DIFF
--- a/Mathlib/AlgebraicGeometry/ProjectiveSpectrum/Basic.lean
+++ b/Mathlib/AlgebraicGeometry/ProjectiveSpectrum/Basic.lean
@@ -72,7 +72,7 @@ theorem isBasis_basicOpen :
   convert ProjectiveSpectrum.isTopologicalBasis_basic_opens 𝒜
   exact (Set.range_comp _ _).symm
 
-/-- If `{ xᵢ }` spans `A` as an ideal, then `D₊(xᵢ)` covers `Proj A`. -/
+/-- If `{ xᵢ }` spans the irrelevant ideal of `A`, then `D₊(xᵢ)` covers `Proj A`. -/
 lemma iSup_basicOpen_eq_top {ι : Type*} (f : ι → A)
     (hf : (HomogeneousIdeal.irrelevant 𝒜).toIdeal ≤ Ideal.span (Set.range f)) :
     ⨆ i, Proj.basicOpen 𝒜 (f i) = ⊤ := by
@@ -83,7 +83,7 @@ lemma iSup_basicOpen_eq_top {ι : Type*} (f : ι → A)
   refine x.not_irrelevant_le (hf.trans ?_)
   rwa [Ideal.span_le, Set.range_subset_iff]
 
-/-- If `{ xᵢ }` spans `A` as an `A₀` algebra, then `D₊(xᵢ)` covers `Proj A`. -/
+/-- If `{ xᵢ }` are homogeneous and span `A` as an `A₀` algebra, then `D₊(xᵢ)` covers `Proj A`. -/
 lemma iSup_basicOpen_eq_top' {ι : Type*} (f : ι → A)
     (hfn : ∀ i, ∃ n, f i ∈ 𝒜 n)
     (hf : Algebra.adjoin (𝒜 0) (Set.range f) = ⊤) :

--- a/Mathlib/AlgebraicGeometry/ProjectiveSpectrum/Basic.lean
+++ b/Mathlib/AlgebraicGeometry/ProjectiveSpectrum/Basic.lean
@@ -72,6 +72,7 @@ theorem isBasis_basicOpen :
   convert ProjectiveSpectrum.isTopologicalBasis_basic_opens 𝒜
   exact (Set.range_comp _ _).symm
 
+/-- If `{ xᵢ }` spans `A` as an ideal, then `D₊(xᵢ)` covers `Proj A`. -/
 lemma iSup_basicOpen_eq_top {ι : Type*} (f : ι → A)
     (hf : (HomogeneousIdeal.irrelevant 𝒜).toIdeal ≤ Ideal.span (Set.range f)) :
     ⨆ i, Proj.basicOpen 𝒜 (f i) = ⊤ := by
@@ -81,6 +82,42 @@ lemma iSup_basicOpen_eq_top {ι : Type*} (f : ι → A)
   simp only [mem_basicOpen, Decidable.not_not] at H
   refine x.not_irrelevant_le (hf.trans ?_)
   rwa [Ideal.span_le, Set.range_subset_iff]
+
+/-- If `{ xᵢ }` spans `A` as an `A₀` algebra, then `D₊(xᵢ)` covers `Proj A`. -/
+lemma iSup_basicOpen_eq_top' {ι : Type*} (f : ι → A)
+    (hfn : ∀ i, ∃ n, f i ∈ 𝒜 n)
+    (hf : Algebra.adjoin (𝒜 0) (Set.range f) = ⊤) :
+    ⨆ i, Proj.basicOpen 𝒜 (f i) = ⊤ := by
+  classical
+  apply Proj.iSup_basicOpen_eq_top
+  intro x hx
+  convert_to x - GradedRing.projZeroRingHom 𝒜 x ∈ _
+  · rw [GradedRing.projZeroRingHom_apply, ← GradedRing.proj_apply,
+      (HomogeneousIdeal.mem_irrelevant_iff _ _).mp hx, sub_zero]
+  clear hx
+  have := (eq_iff_iff.mp congr(x ∈ $hf)).mpr trivial
+  induction this using Algebra.adjoin_induction with
+  | mem x hx =>
+    obtain ⟨i, rfl⟩ := hx
+    obtain ⟨n, hn⟩ := hfn i
+    rw [GradedRing.projZeroRingHom_apply]
+    by_cases hn' : n = 0
+    · rw [DirectSum.decompose_of_mem_same 𝒜 (hn' ▸ hn), sub_self]
+      exact zero_mem _
+    · rw [DirectSum.decompose_of_mem_ne 𝒜 hn hn', sub_zero]
+      exact Ideal.subset_span ⟨_, rfl⟩
+  | algebraMap r =>
+    convert zero_mem (Ideal.span _)
+    rw [sub_eq_zero]
+    exact (DirectSum.decompose_of_mem_same 𝒜 r.2).symm
+  | add x y hx hy _ _ =>
+    rw [map_add, add_sub_add_comm]
+    exact add_mem ‹_› ‹_›
+  | mul x y hx hy hx' hy' =>
+    convert add_mem (Ideal.mul_mem_left _ x hy')
+      (Ideal.mul_mem_right (GradedRing.projZeroRingHom 𝒜 y) _ hx') using 1
+    rw [map_mul]
+    ring
 
 /-- The canonical map `(A_f)₀ ⟶ Γ(Proj A, D₊(f))`.
 This is an isomorphism when `f` is homogeneous of positive degree. See `basicOpenIsoAway` below. -/

--- a/Mathlib/AlgebraicGeometry/ProjectiveSpectrum/Proper.lean
+++ b/Mathlib/AlgebraicGeometry/ProjectiveSpectrum/Proper.lean
@@ -195,74 +195,71 @@ theorem valuativeCriterion_existence_aux
     (j : ι) (φ : Away 𝒜 (x j) →+* K)
     (hcomm : (algebraMap O K).comp φ₀ = φ.comp (fromZeroRingHom 𝒜 _))
     (d : ι → ℕ) (hdi : ∀ i, 0 < d i) (hxdi : ∀ i, x i ∈ 𝒜 (d i)) :
-    ∃ (x₀ : A) (e : ℕ) (_he : 0 < e) (h₀ : x₀ ∈ 𝒜 e)
-      (φ' : Away 𝒜 (x j * x₀) →+* K), φ'.comp (awayMap 𝒜 h₀ rfl) = φ ∧
-      (φ'.comp (awayMap 𝒜 (hxdi j) (mul_comm (x j) x₀))).range ≤ (algebraMap O K).range := by
+    ∃ (j₀ : ι) (φ' : Away 𝒜 (x j * x j₀) →+* K), φ'.comp (awayMap 𝒜 (hxdi j₀) rfl) = φ ∧
+      (φ'.comp (awayMap 𝒜 (hxdi j) (mul_comm (x j) (x j₀)))).range ≤ (algebraMap O K).range := by
   classical
   let ψ (i : ι) : ValueGroup O K :=
     valuation O K ((φ (Away.isLocalizationElem (hxdi j) (hxdi i))) ^ ∏ k ∈ Finset.univ.erase i, d k)
   have : Nonempty ι := ⟨j⟩
   let Kmax := (Finset.univ.image ψ).max' (by simp)
-  have ⟨i₀, hi1⟩ : ∃ a, ψ a = Kmax := by
-    simpa using Finset.max'_mem (Finset.univ.image ψ)
+  have ⟨i₀, hi1⟩ : ∃ a, ψ a = Kmax := by simpa using Finset.max'_mem (Finset.univ.image ψ)
   have hi₀ (j) : ψ j ≤ ψ i₀ := hi1 ▸ (Finset.univ.image ψ).le_max' (ψ j) (by simp)
-  use x i₀, d i₀, hdi i₀, hxdi i₀
   have hKmax : 0 < Kmax := by
     refine zero_lt_iff.mpr fun hKmax ↦ ?_
     have (i) : ψ i = 0 := le_zero_iff.mp (hKmax ▸ Finset.le_max' _ _ (by simp))
     simp only [ψ, map_pow, pow_eq_zero_iff', map_eq_zero, ne_eq] at this
-    suffices φ 1 = 0 by simp only [map_one, one_ne_zero] at this
-    convert (this j).1
-    ext
-    simp only [val_one, val_mk, Away.val_mk]
-    convert (Localization.mk_self _).symm
-    rfl
+    have : φ 1 = 0 := by convert (this j).1; ext; simp
+    simp only [map_one, one_ne_zero] at this
   letI := (awayMap 𝒜 (f := x j) (hxdi i₀) rfl).toAlgebra
   have := Away.isLocalization_mul (hxdi j) (hxdi i₀) rfl (hdi _).ne'
-  have hunit : IsUnit (φ (Away.isLocalizationElem (hxdi j) (hxdi i₀))) := by
-    refine isUnit_iff_ne_zero.mpr fun rid ↦ ?_
-    simp only [ψ, rid, map_pow, map_zero] at hi1
-    rw [zero_pow] at hi1
-    · exact hKmax.ne' hi1.symm
-    simp [Finset.prod_eq_zero_iff, (hdi _).ne', ψ]
-  let φ' := IsLocalization.Away.lift (S := Away 𝒜 (x j * x i₀)) _ foounit
-  have hφ'1 (s) : φ' (awayMap 𝒜 (hxdi i₀) rfl s) = φ s :=
-    IsLocalization.Away.lift_eq (S := Away 𝒜 (x j * x i₀)) _ foounit s
-  use φ', IsLocalization.Away.lift_comp ..
+  have hunit : IsUnit (φ (Away.isLocalizationElem (hxdi j) (hxdi i₀))) := isUnit_iff_ne_zero.mpr
+    fun rid ↦ hKmax.ne' (.symm (by simpa [ψ, rid, Finset.prod_eq_zero_iff, (hdi _).ne'] using hi1))
+  let φ' := IsLocalization.Away.lift (S := Away 𝒜 (x j * x i₀)) _ hunit
+  have hφ'1 (s) : φ' (awayMap 𝒜 (hxdi i₀) rfl s) = φ s := IsLocalization.Away.lift_eq _ hunit s
+  use i₀, φ', IsLocalization.Away.lift_comp ..
   rintro _ ⟨sx, rfl⟩
   rw [RingHom.mem_range, ← ValuationRing.mem_integer_iff, Valuation.mem_integer_iff]
   have := (Away.span_mk_prod_pow_eq_top (hxdi i₀) x h2 d hxdi).ge (Submodule.mem_top (x := sx))
   induction this using Submodule.span_induction with
+  | zero => simp
+  | add x y hx hy hhx hhy =>
+    simp only [RingHom.coe_comp, Function.comp_apply, map_add, ge_iff_le]
+    exact ((valuation O K).map_add _ _).trans <| sup_le_iff.mpr ⟨hhx, hhy⟩
+  | smul a x₀ hx hx1 =>
+    simp only [Algebra.smul_def, RingHom.coe_comp, Function.comp_apply, map_mul, ge_iff_le]
+    refine mul_le_one' ?_ hx1
+    rw [RingHom.algebraMap_toAlgebra, awayMap_fromZeroRingHom 𝒜 (hxdi j) (mul_comm (x j) (x i₀)),
+      ← awayMap_fromZeroRingHom 𝒜 (hxdi i₀) rfl a, hφ'1]
+    change valuation O K (φ.comp (fromZeroRingHom 𝒜 (.powers (x j))) a) ≤ 1
+    simp only [← hcomm, RingHom.coe_comp, Function.comp_apply, ← Valuation.mem_integer_iff,
+      IsFractionRing.coe_inj, exists_eq, mem_integer_iff]
   | mem x1 h =>
     obtain ⟨a, ai, hai, rfl⟩ := h
     simp only [smul_eq_mul] at hai
     have H : (∏ i, x i ^ ai i) * x i₀ ^ (a * (d j - 1)) ∈ 𝒜 ((a * d i₀) • d j) := by
-      convert SetLike.mul_mem_graded
-        (SetLike.prod_pow_mem_graded 𝒜 d x (F := .univ) ai (fun _ _ ↦ hxdi _))
-        (SetLike.pow_mem_graded (A := 𝒜) (a * (d j - 1)) (hxdi i₀)) using 2
+      convert SetLike.mul_mem_graded (SetLike.prod_pow_mem_graded 𝒜 d x ai fun _ _ ↦ hxdi _)
+        (SetLike.pow_mem_graded (a * (d j - 1)) (hxdi i₀)) using 2
       simp only [smul_eq_mul, hai]
       cases h : d j
       · cases (hdi j).ne' h
       · simp only [add_tsub_cancel_right]; ring
     suffices valuation O K (φ (Away.mk 𝒜 (hxdi j) _ _ H) /
-          (φ (Away.isLocalizationElem (hxdi j) (hxdi i₀))) ^ a) ≤ 1 by
+          φ (Away.isLocalizationElem (hxdi j) (hxdi i₀)) ^ a) ≤ 1 by
       convert this
-      rw [eq_div_iff (pow_ne_zero _ foounit.ne_zero), ← hφ'1, ← hφ'1, RingHom.comp_apply,
+      rw [eq_div_iff (pow_ne_zero _ hunit.ne_zero), ← hφ'1, ← hφ'1, RingHom.comp_apply,
         ← map_pow, ← map_mul]
       congr
       ext
-      rw [val_mul]
       simp only [awayMap_mk, Away.val_mk, val_pow, Localization.mk_pow, Localization.mk_mul,
-        Localization.mk_eq_mk_iff, Localization.r_iff_exists]
+        Localization.mk_eq_mk_iff, Localization.r_iff_exists, val_mul]
       use 1
       simp only [OneMemClass.coe_one, one_mul, Submonoid.coe_mul, SubmonoidClass.coe_pow]
       cases h : d j
       · cases (hdi j).ne' h
       · rw [Nat.add_sub_cancel]; ring
-    rw [map_div₀, div_le_iff₀ ((pow_pos ((Valuation.pos_iff _).mpr foounit.ne_zero) _).trans_eq
-      (Valuation.map_pow _ _ _).symm), one_mul,
-      ← pow_le_pow_iff_left₀ (n := d j * ∏ i, d i) zero_le' zero_le' <|
-      (mul_pos (hdi j) (Finset.prod_pos (fun i _ => hdi i))).ne.symm]
+    rw [map_div₀, div_le_iff₀ ((pow_pos ((Valuation.pos_iff _).mpr hunit.ne_zero) _).trans_eq
+      (Valuation.map_pow _ _ _).symm), one_mul, ← pow_le_pow_iff_left₀ zero_le' zero_le'
+        (mul_pos (hdi j) (Finset.prod_pos fun i _ => hdi i)).ne.symm]
     calc
       _ = (∏ i, ψ i ^ (d i * ai i)) * ψ i₀ ^ (d i₀ * a * (d j - 1)) := by
           simp only [ψ, ← map_pow, ← map_prod, ← map_mul]
@@ -276,12 +273,10 @@ theorem valuativeCriterion_existence_aux
           use 1
           simp only [OneMemClass.coe_one, SubmonoidClass.mk_pow, ← pow_mul, Submonoid.coe_mul,
             SubmonoidClass.coe_finset_prod, one_mul]
-          simp_rw [← mul_assoc, Finset.prod_erase_mul Finset.univ d (h := Finset.mem_univ _),
-            mul_assoc, ← mul_assoc (Finset.prod ..),
-            Finset.prod_erase_mul Finset.univ d (h := Finset.mem_univ _), SubmonoidClass.coe_pow,
-            ← pow_mul]
-          rw [Finset.prod_pow_eq_pow_sum, ← pow_add, mul_pow, ← Finset.prod_pow]
-          simp_rw [← pow_mul]
+          simp_rw [← mul_assoc, Finset.prod_erase_mul _ d (h := Finset.mem_univ _), mul_assoc,
+            ← mul_assoc (Finset.prod ..), Finset.prod_erase_mul _ d (h := Finset.mem_univ _),
+            SubmonoidClass.coe_pow, ← pow_mul, Finset.prod_pow_eq_pow_sum,
+            ← pow_add, mul_pow, ← Finset.prod_pow, ← pow_mul]
           congr 3
           · simp only [mul_comm _ (∏ i, d i), mul_assoc, mul_left_comm _ (∏ i, d i),
               mul_comm (d _) (ai _), ← Finset.mul_sum, hai]
@@ -290,40 +285,20 @@ theorem valuativeCriterion_existence_aux
             · simp; ring
           · ext i; congr 1; ring
           · ring
-      _ ≤ (∏ i : ι, ψ i₀ ^ (d i * ai i)) * ψ i₀ ^ (d i₀ * a * (d j - 1)) := by
-          gcongr
-          · exact zero_le'
-          · exact hi₀ _
+      _ ≤ (∏ i : ι, ψ i₀ ^ (d i * ai i)) * ψ i₀ ^ (d i₀ * a * (d j - 1)) :=
+          mul_le_mul_right' (Finset.prod_le_prod' fun i a ↦ pow_le_pow_left₀ zero_le' (hi₀ i) _) _
       _ = ψ i₀ ^ (d i₀ * a * d j) := by
           rw [Finset.prod_pow_eq_pow_sum, ← pow_add]
-          congr 1
           simp_rw [mul_comm (d _) (ai _), hai]
           cases h : d j
           · cases (hdi j).ne' h
-          · simp; ring
+          · simp; ring_nf
       _ = valuation O K ((φ _) ^ a) ^ (d j * ∏ i, d i) := by
           · simp only [ψ, ← map_pow, ← map_prod, ← map_mul]
             congr 2
             rw [← pow_mul, ← pow_mul, ← mul_assoc, ← mul_assoc, ← mul_assoc,
               Finset.univ.prod_erase_mul d (h := Finset.mem_univ _),
               mul_comm _ a, mul_right_comm]
-  | zero => simp
-  | add x y hx hy hhx hhy =>
-    simp only [RingHom.coe_comp, Function.comp_apply, map_add, ge_iff_le]
-    exact (Valuation.map_add (ValuationRing.valuation O K) _ _).trans <| sup_le_iff.mpr ⟨hhx, hhy⟩
-  | smul a x₀ hx hx1 =>
-    simp only [Algebra.smul_def, RingHom.coe_comp, Function.comp_apply, map_mul, ge_iff_le]
-    refine mul_le_one' ?_ hx1
-    rw [RingHom.algebraMap_toAlgebra, awayMap_fromZeroRingHom 𝒜 (hxdi j) (mul_comm (x j) (x i₀))]
-    suffices fromZeroRingHom 𝒜 (Submonoid.powers (x j * x i₀)) a =
-        awayMap 𝒜 (hxdi i₀) rfl ((fromZeroRingHom 𝒜 (Submonoid.powers (x j))) a) by
-      simp only [this, φ', hφ'1]
-      change (ValuationRing.valuation O K)
-        (φ.comp (fromZeroRingHom 𝒜 (Submonoid.powers (x j))) a) ≤ 1
-      rw [← hcomm, RingHom.coe_comp, Function.comp_apply, ← Valuation.mem_integer_iff,
-        ValuationRing.mem_integer_iff]
-      use φ₀ a
-    exact (awayMap_fromZeroRingHom 𝒜 (hxdi i₀) rfl a).symm
 
 @[stacks 01MF]
 lemma valuativeCriterion_existence [Algebra.FiniteType (𝒜 0) A] :
@@ -346,7 +321,7 @@ lemma valuativeCriterion_existence [Algebra.FiniteType (𝒜 0) A] :
     apply Spec.map_injective
     simp only [Spec.map_comp, Spec.map_preimage, ← w.w]
     rw [← Proj.awayι_toSpecZero, IsOpenImmersion.lift_fac_assoc]
-  obtain ⟨x₀, e, he, hxe, φ', hφ, hφ'⟩ :=
+  obtain ⟨i₀, φ', hφ, hφ'⟩ :=
     valuativeCriterion_existence_aux 𝒜 (Spec.preimage i₂).hom x (↑) (by simpa using hx) i
       (O := O) (K := K) (Spec.preimage φ).hom congr(($H).hom)
       (fun i ↦ d _ i.2) (fun i ↦ (hd _ i.2).bot_lt) (fun i ↦ hxd _ i.2)
@@ -356,7 +331,7 @@ lemma valuativeCriterion_existence [Algebra.FiniteType (𝒜 0) A] :
   have hφ'' : (algebraMap O K).comp φ'' = φ'.comp (awayMap 𝒜 (hxd _ i.2) (mul_comm _ _)) := by
     ext x
     exact congr_arg Subtype.val (e.apply_symm_apply _)
-  refine ⟨⟨Spec.map (CommRingCat.ofHom φ'') ≫ Proj.awayι 𝒜 _ hxe he, ?_, ?_⟩⟩
+  refine ⟨⟨Spec.map (CommRingCat.ofHom φ'') ≫ Proj.awayι 𝒜 _ (hxd _ i₀.2) (hd _ _).bot_lt, ?_, ?_⟩⟩
   · rw [← Spec.map_comp_assoc]
     convert IsOpenImmersion.lift_fac _ _ this using 1
     show _ = φ ≫ _
@@ -370,7 +345,7 @@ lemma valuativeCriterion_existence [Algebra.FiniteType (𝒜 0) A] :
     apply IsFractionRing.injective O K
     refine (DFunLike.congr_fun hφ'' (fromZeroRingHom 𝒜 _ _)).trans ?_
     simp only [RingHom.coe_comp, Function.comp_apply]
-    rw [awayMap_fromZeroRingHom, ← awayMap_fromZeroRingHom 𝒜 hxe rfl, ← RingHom.comp_apply, hφ]
+    rw [awayMap_fromZeroRingHom, ← awayMap_fromZeroRingHom 𝒜 _ rfl, ← RingHom.comp_apply, hφ]
     exact congr($(H.symm) x)
 
 instance [Algebra.FiniteType (𝒜 0) A] : UniversallyClosed (Proj.toSpecZero 𝒜) := by

--- a/Mathlib/AlgebraicGeometry/ProjectiveSpectrum/Proper.lean
+++ b/Mathlib/AlgebraicGeometry/ProjectiveSpectrum/Proper.lean
@@ -179,12 +179,12 @@ such that these two diagrams exist and commute.
     φ'                      φ'
 K ←--- 𝒜_{(x x₀)}       K ←--- 𝒜_{(x x₀)}
 ↑       ↑                 ↖       ↑
-|       |                 φ ⟍    |
-|       |                     ⟍  |
+|       |                 φ ⟍     |
+|       |                     ⟍   |
 O ←---- 𝒜_{(x₀)}                𝒜_{(x)}
     φₗ
 ```
-This is the underlying algebraic statement of the valuative criterion for `Proj A`.
+This is the underlying algebraic statement of the valuative criterion for `Proj 𝒜`.
 -/
 @[stacks 01MF "algebraic part"]
 theorem valuativeCriterion_existence_aux
@@ -201,14 +201,7 @@ theorem valuativeCriterion_existence_aux
   classical
   let ψ (i : ι) : ValueGroup O K :=
     valuation O K ((φ (Away.isLocalizationElem (hxdi j) (hxdi i))) ^ ∏ k ∈ Finset.univ.erase i, d k)
-  have : Nonempty ι := by
-    refine not_isEmpty_iff.mp fun _ ↦ (hdi j).ne' (DirectSum.degree_eq_of_mem_mem 𝒜 (hxdi j) ?_ ?_)
-    · have : (⊥ : Subalgebra (𝒜 0) A) = ⊤ := by simpa [show Set.range x = ∅ by simpa] using h2
-      obtain ⟨⟨g, hg1⟩, e⟩ : x j ∈ _ := this.ge trivial
-      exact e ▸ hg1
-    · intro H
-      have : Subsingleton (Away 𝒜 (x j)) := HomogeneousLocalization.subsingleton _ (by simp [H])
-      exact not_subsingleton _ (RingHom.codomain_trivial φ)
+  have : Nonempty ι := ⟨j⟩
   let Kmax := (Finset.univ.image ψ).max' (by simp)
   have ⟨i₀, hi1⟩ : ∃ a, ψ a = Kmax := by
     simpa using Finset.max'_mem (Finset.univ.image ψ)
@@ -226,7 +219,7 @@ theorem valuativeCriterion_existence_aux
     rfl
   letI := (awayMap 𝒜 (f := x j) (hxdi i₀) rfl).toAlgebra
   have := Away.isLocalization_mul (hxdi j) (hxdi i₀) rfl (hdi _).ne'
-  have foounit : IsUnit (φ (Away.isLocalizationElem (hxdi j) (hxdi i₀))) := by
+  have hunit : IsUnit (φ (Away.isLocalizationElem (hxdi j) (hxdi i₀))) := by
     refine isUnit_iff_ne_zero.mpr fun rid ↦ ?_
     simp only [ψ, rid, map_pow, map_zero] at hi1
     rw [zero_pow] at hi1
@@ -317,30 +310,20 @@ theorem valuativeCriterion_existence_aux
   | zero => simp
   | add x y hx hy hhx hhy =>
     simp only [RingHom.coe_comp, Function.comp_apply, map_add, ge_iff_le]
-    transitivity
-    · refine Valuation.map_add (ValuationRing.valuation O K) _ _
-    · rw [sup_le_iff]
-      exact ⟨hhx, hhy⟩
+    exact (Valuation.map_add (ValuationRing.valuation O K) _ _).trans <| sup_le_iff.mpr ⟨hhx, hhy⟩
   | smul a x₀ hx hx1 =>
-    rw [Algebra.smul_def]
-    simp only [RingHom.coe_comp, Function.comp_apply, map_mul, ge_iff_le]
+    simp only [Algebra.smul_def, RingHom.coe_comp, Function.comp_apply, map_mul, ge_iff_le]
     refine mul_le_one' ?_ hx1
-    have foo1 : algebraMap (↥(𝒜 0)) (Away 𝒜 (x i₀)) = fromZeroRingHom 𝒜 (.powers (x i₀)) := rfl
-    rw [foo1]
-    rw [awayMap_fromZeroRingHom 𝒜 (hxdi j) (mul_comm (x j) (x i₀))]
+    rw [RingHom.algebraMap_toAlgebra, awayMap_fromZeroRingHom 𝒜 (hxdi j) (mul_comm (x j) (x i₀))]
     suffices fromZeroRingHom 𝒜 (Submonoid.powers (x j * x i₀)) a =
         awayMap 𝒜 (hxdi i₀) rfl ((fromZeroRingHom 𝒜 (Submonoid.powers (x j))) a) by
-      rw [this]
-      unfold φ'
-      rw [hφ'1]
+      simp only [this, φ', hφ'1]
       change (ValuationRing.valuation O K)
         (φ.comp (fromZeroRingHom 𝒜 (Submonoid.powers (x j))) a) ≤ 1
-      rw [← hcomm]
-      simp only [RingHom.coe_comp, Function.comp_apply]
-      rw [← Valuation.mem_integer_iff, ValuationRing.mem_integer_iff]
+      rw [← hcomm, RingHom.coe_comp, Function.comp_apply, ← Valuation.mem_integer_iff,
+        ValuationRing.mem_integer_iff]
       use φ₀ a
-    symm
-    exact awayMap_fromZeroRingHom 𝒜 (hxdi i₀) rfl a
+    exact (awayMap_fromZeroRingHom 𝒜 (hxdi i₀) rfl a).symm
 
 @[stacks 01MF]
 lemma valuativeCriterion_existence [Algebra.FiniteType (𝒜 0) A] :
@@ -378,10 +361,8 @@ lemma valuativeCriterion_existence [Algebra.FiniteType (𝒜 0) A] :
     convert IsOpenImmersion.lift_fac _ _ this using 1
     show _ = φ ≫ _
     rw [← Spec.map_preimage φ, ← CommRingCat.ofHom_hom (Spec.preimage φ), ← hφ,
-      ← CommRingCat.ofHom_comp, hφ'', CommRingCat.ofHom_comp, Spec.map_comp,
-      CommRingCat.ofHom_comp, Spec.map_comp, Category.assoc, Category.assoc,
-      SpecMap_awayMap_awayι, SpecMap_awayMap_awayι]
-    rfl
+      ← CommRingCat.ofHom_comp]
+    simp [hφ'', SpecMap_awayMap_awayι, add_comm]
   · simp only [Category.assoc, Proj.awayι_toSpecZero, ← Spec.map_comp]
     conv_rhs => rw [← Spec.map_preimage i₂]
     congr 1

--- a/Mathlib/AlgebraicGeometry/ProjectiveSpectrum/Proper.lean
+++ b/Mathlib/AlgebraicGeometry/ProjectiveSpectrum/Proper.lean
@@ -4,16 +4,13 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Patience Ablett, Kevin Buzzard, Harald Carlens, Wayne Ng Kwing King, Michael Schlößer,
   Justus Springer, Andrew Yang, Jujian Zhang
 -/
-import Mathlib.AlgebraicGeometry.Morphisms.Separated
 import Mathlib.AlgebraicGeometry.ProjectiveSpectrum.Basic
+import Mathlib.AlgebraicGeometry.ValuativeCriterion
 
 /-!
 # Properness of `Proj A`
 
-We show that `Proj 𝒜` is a separated scheme.
-
-## TODO
-- Show that `Proj 𝒜` satisfies the valuative criterion.
+We show that `Proj 𝒜` is proper over `Spec 𝒜₀`.
 
 ## Notes
 This contribution was created as part of the Durham Computational Algebraic Geometry Workshop
@@ -28,6 +25,8 @@ variable (𝒜 : ℕ → Submodule R A)
 variable [GradedAlgebra 𝒜]
 
 open Scheme CategoryTheory Limits pullback HomogeneousLocalization
+
+section IsSeparated
 
 lemma lift_awayMapₐ_awayMapₐ_surjective {d e : ℕ} {f : A} (hf : f ∈ 𝒜 d)
     {g : A} (hg : g ∈ 𝒜 e) {x : A} (hx : x = f * g) (hd : 0 < d) :
@@ -122,5 +121,282 @@ instance isSeparated : IsSeparated (toSpecZero 𝒜) := by
 @[stacks 01MC]
 instance : Scheme.IsSeparated (Proj 𝒜) :=
   (HasAffineProperty.iff_of_isAffine (P := @IsSeparated)).mp (isSeparated 𝒜)
+
+end IsSeparated
+
+section LocallyOfFiniteType
+
+instance [Algebra.FiniteType (𝒜 0) A] : LocallyOfFiniteType (Proj.toSpecZero 𝒜) := by
+  obtain ⟨x, hx, hx'⟩ := GradedAlgebra.exists_finset_adjoin_eq_top_and_homogeneous_ne_zero 𝒜
+  choose d hd hxd using hx'
+  rw [IsLocalAtSource.iff_of_iSup_eq_top (P := @LocallyOfFiniteType) _
+    (Proj.iSup_basicOpen_eq_top' 𝒜 (ι := x) (↑) (fun i ↦ ⟨_, hxd _ i.2⟩) (by simpa using hx))]
+  intro i
+  rw [← MorphismProperty.cancel_left_of_respectsIso (P := @LocallyOfFiniteType)
+    (Proj.basicOpenIsoSpec 𝒜 i (hxd _ i.2) (hd _ i.2).bot_lt).inv, ← Category.assoc, ← Proj.awayι,
+    Proj.awayι_toSpecZero, HasRingHomProperty.Spec_iff (P := @LocallyOfFiniteType)]
+  exact HomogeneousLocalization.Away.finiteType _ _ (hxd _ i.2)
+
+end LocallyOfFiniteType
+
+section QuasiCompact
+
+instance [Algebra.FiniteType (𝒜 0) A] : QuasiCompact (Proj.toSpecZero 𝒜) := by
+  rw [HasAffineProperty.iff_of_isAffine (P := @QuasiCompact)]
+  obtain ⟨x, hx, hx'⟩ := GradedAlgebra.exists_finset_adjoin_eq_top_and_homogeneous_ne_zero 𝒜
+  choose d hd hxd using hx'
+  have H (i : x) : IsCompact (Proj.basicOpen 𝒜 i).1 := by
+    rw [← Proj.opensRange_awayι _ _ (hxd _ i.2) (hd _ i.2).bot_lt]
+    exact isCompact_range (Proj.awayι _ _ (hxd _ i.2) (hd _ i.2).bot_lt).continuous
+  have := congr($(Proj.iSup_basicOpen_eq_top' 𝒜
+    (ι := x) (↑) (fun i ↦ ⟨_, hxd _ i.2⟩) (by simpa using hx)).1)
+  simp only [TopologicalSpace.Opens.iSup_mk, TopologicalSpace.Opens.carrier_eq_coe,
+    TopologicalSpace.Opens.coe_mk, TopologicalSpace.Opens.coe_top] at this
+  rw [← isCompact_univ_iff, ← this]
+  exact isCompact_iUnion H
+
+end QuasiCompact
+
+section UniversallyClosed
+
+open ValuationRing in
+/--
+Let `𝒜` be a graded ring generated over `𝒜₀` by finitely many homogeneous elements.
+Suppose we have the following diagram for some homogeneous `x`
+with `O` a valuation ring and `K = Frac(O)`.
+```
+    φ
+K ←--- 𝒜_{(x)}
+↑       ↑
+|       |
+|       |
+O ←---- 𝒜₀
+    φ₀
+```
+Then there exists a lift `φₗ : 𝒜_{(x₀)} →+* O` for some `x₀`
+such that these two diagrams exist and commute.
+```
+    φ'                      φ'
+K ←--- 𝒜_{(x x₀)}       K ←--- 𝒜_{(x x₀)}
+↑       ↑                 ↖       ↑
+|       |                 φ ⟍    |
+|       |                     ⟍  |
+O ←---- 𝒜_{(x₀)}                𝒜_{(x)}
+    φₗ
+```
+This is the underlying algebraic statement of the valuative criterion for `Proj A`.
+-/
+theorem valuativeCriterion_existence_aux
+    {O : Type*} [CommRing O] [IsDomain O] [ValuationRing O]
+    {K : Type*} [Field K] [Algebra O K] [IsFractionRing O K]
+    (φ₀ : (𝒜 0) →+* O)
+    (ι : Type*) [Fintype ι] (x : ι → A) (h2 : Algebra.adjoin (𝒜 0) (Set.range x) = ⊤)
+    (j : ι) (φ : Away 𝒜 (x j) →+* K)
+    (hcomm : (algebraMap O K).comp φ₀ = φ.comp (fromZeroRingHom 𝒜 _))
+    (d : ι → ℕ) (hdi : ∀ i, 0 < d i) (hxdi : ∀ i, x i ∈ 𝒜 (d i)) :
+    ∃ (x₀ : A) (e : ℕ) (_he : 0 < e) (h₀ : x₀ ∈ 𝒜 e)
+      (φ' : Away 𝒜 (x j * x₀) →+* K), φ'.comp (awayMap 𝒜 h₀ rfl) = φ ∧
+      (φ'.comp (awayMap 𝒜 (hxdi j) (mul_comm (x j) x₀))).range ≤ (algebraMap O K).range := by
+  classical
+  let ψ (i : ι) : ValueGroup O K :=
+    valuation O K ((φ (Away.isLocalizationElem (hxdi j) (hxdi i))) ^ ∏ k ∈ Finset.univ.erase i, d k)
+  have : Nonempty ι := by
+    refine not_isEmpty_iff.mp fun _ ↦ (hdi j).ne' (DirectSum.degree_eq_of_mem_mem 𝒜 (hxdi j) ?_ ?_)
+    · have : (⊥ : Subalgebra (𝒜 0) A) = ⊤ := by simpa [show Set.range x = ∅ by simpa] using h2
+      obtain ⟨⟨g, hg1⟩, e⟩ : x j ∈ _ := this.ge trivial
+      exact e ▸ hg1
+    · intro H
+      have : Subsingleton (Away 𝒜 (x j)) := HomogeneousLocalization.subsingleton _ (by simp [H])
+      exact not_subsingleton _ (RingHom.codomain_trivial φ)
+  let Kmax := (Finset.univ.image ψ).max' (by simp)
+  have ⟨i₀, hi1⟩ : ∃ a, ψ a = Kmax := by
+    simpa using Finset.max'_mem (Finset.univ.image ψ)
+  have hi₀ (j) : ψ j ≤ ψ i₀ := hi1 ▸ (Finset.univ.image ψ).le_max' (ψ j) (by simp)
+  use x i₀, d i₀, hdi i₀, hxdi i₀
+  have hKmax : 0 < Kmax := by
+    refine zero_lt_iff.mpr fun hKmax ↦ ?_
+    have (i) : ψ i = 0 := le_zero_iff.mp (hKmax ▸ Finset.le_max' _ _ (by simp))
+    simp only [ψ, map_pow, pow_eq_zero_iff', map_eq_zero, ne_eq] at this
+    suffices φ 1 = 0 by simp only [map_one, one_ne_zero] at this
+    convert (this j).1
+    ext
+    simp only [val_one, val_mk, Away.val_mk]
+    convert (Localization.mk_self _).symm
+    rfl
+  letI := (awayMap 𝒜 (f := x j) (hxdi i₀) rfl).toAlgebra
+  have := Away.isLocalization_mul (hxdi j) (hxdi i₀) rfl (hdi _).ne'
+  have foounit : IsUnit (φ (Away.isLocalizationElem (hxdi j) (hxdi i₀))) := by
+    refine isUnit_iff_ne_zero.mpr fun rid ↦ ?_
+    simp only [ψ, rid, map_pow, map_zero] at hi1
+    rw [zero_pow] at hi1
+    · exact hKmax.ne' hi1.symm
+    simp [Finset.prod_eq_zero_iff, (hdi _).ne', ψ]
+  let φ' := IsLocalization.Away.lift (S := Away 𝒜 (x j * x i₀)) _ foounit
+  have hφ'1 (s) : φ' (awayMap 𝒜 (hxdi i₀) rfl s) = φ s :=
+    IsLocalization.Away.lift_eq (S := Away 𝒜 (x j * x i₀)) _ foounit s
+  use φ', IsLocalization.Away.lift_comp ..
+  rintro _ ⟨sx, rfl⟩
+  rw [RingHom.mem_range, ← ValuationRing.mem_integer_iff, Valuation.mem_integer_iff]
+  have := (Away.span_mk_prod_pow_eq_top (hxdi i₀) x h2 d hxdi).ge (Submodule.mem_top (x := sx))
+  induction this using Submodule.span_induction with
+  | mem x1 h =>
+    obtain ⟨a, ai, hai, rfl⟩ := h
+    simp only [smul_eq_mul] at hai
+    have H : (∏ i, x i ^ ai i) * x i₀ ^ (a * (d j - 1)) ∈ 𝒜 ((a * d i₀) • d j) := by
+      convert SetLike.mul_mem_graded
+        (SetLike.prod_pow_mem_graded 𝒜 d x (F := .univ) ai (fun _ _ ↦ hxdi _))
+        (SetLike.pow_mem_graded (A := 𝒜) (a * (d j - 1)) (hxdi i₀)) using 2
+      simp only [smul_eq_mul, hai]
+      cases h : d j
+      · cases (hdi j).ne' h
+      · simp only [add_tsub_cancel_right]; ring
+    suffices valuation O K (φ (Away.mk 𝒜 (hxdi j) _ _ H) /
+          (φ (Away.isLocalizationElem (hxdi j) (hxdi i₀))) ^ a) ≤ 1 by
+      convert this
+      rw [eq_div_iff (pow_ne_zero _ foounit.ne_zero), ← hφ'1, ← hφ'1, RingHom.comp_apply,
+        ← map_pow, ← map_mul]
+      congr
+      ext
+      rw [val_mul]
+      simp only [awayMap_mk, Away.val_mk, val_pow, Localization.mk_pow, Localization.mk_mul,
+        Localization.mk_eq_mk_iff, Localization.r_iff_exists]
+      use 1
+      simp only [OneMemClass.coe_one, one_mul, Submonoid.coe_mul, SubmonoidClass.coe_pow]
+      cases h : d j
+      · cases (hdi j).ne' h
+      · rw [Nat.add_sub_cancel]; ring
+    rw [map_div₀, div_le_iff₀ ((pow_pos ((Valuation.pos_iff _).mpr foounit.ne_zero) _).trans_eq
+      (Valuation.map_pow _ _ _).symm), one_mul,
+      ← pow_le_pow_iff_left₀ (n := d j * ∏ i, d i) zero_le' zero_le' <|
+      (mul_pos (hdi j) (Finset.prod_pos (fun i _ => hdi i))).ne.symm]
+    calc
+      _ = (∏ i, ψ i ^ (d i * ai i)) * ψ i₀ ^ (d i₀ * a * (d j - 1)) := by
+          simp only [ψ, ← map_pow, ← map_prod, ← map_mul]
+          congr 2
+          apply (show Function.Injective (algebraMap (Away 𝒜 (x j)) (Localization.Away (x j)))
+            from val_injective _)
+          simp only [map_pow, map_prod, map_mul]
+          simp only [HomogeneousLocalization.algebraMap_apply, Away.val_mk, Localization.mk_pow,
+            Localization.mk_prod, Localization.mk_mul, ψ]
+          rw [Localization.mk_eq_mk_iff, Localization.r_iff_exists]
+          use 1
+          simp only [OneMemClass.coe_one, SubmonoidClass.mk_pow, ← pow_mul, Submonoid.coe_mul,
+            SubmonoidClass.coe_finset_prod, one_mul]
+          simp_rw [← mul_assoc, Finset.prod_erase_mul Finset.univ d (h := Finset.mem_univ _),
+            mul_assoc, ← mul_assoc (Finset.prod ..),
+            Finset.prod_erase_mul Finset.univ d (h := Finset.mem_univ _), SubmonoidClass.coe_pow,
+            ← pow_mul]
+          rw [Finset.prod_pow_eq_pow_sum, ← pow_add, mul_pow, ← Finset.prod_pow]
+          simp_rw [← pow_mul]
+          congr 3
+          · simp only [mul_comm _ (∏ i, d i), mul_assoc, mul_left_comm _ (∏ i, d i),
+              mul_comm (d _) (ai _), ← Finset.mul_sum, hai]
+            cases h : d j
+            · cases (hdi j).ne' h
+            · simp; ring
+          · ext i; congr 1; ring
+          · ring
+      _ ≤ (∏ i : ι, ψ i₀ ^ (d i * ai i)) * ψ i₀ ^ (d i₀ * a * (d j - 1)) := by
+          gcongr
+          · exact zero_le'
+          · exact hi₀ _
+      _ = ψ i₀ ^ (d i₀ * a * d j) := by
+          rw [Finset.prod_pow_eq_pow_sum, ← pow_add]
+          congr 1
+          simp_rw [mul_comm (d _) (ai _), hai]
+          cases h : d j
+          · cases (hdi j).ne' h
+          · simp; ring
+      _ = valuation O K ((φ _) ^ a) ^ (d j * ∏ i, d i) := by
+          · simp only [ψ, ← map_pow, ← map_prod, ← map_mul]
+            congr 2
+            rw [← pow_mul, ← pow_mul, ← mul_assoc, ← mul_assoc, ← mul_assoc,
+              Finset.univ.prod_erase_mul d (h := Finset.mem_univ _),
+              mul_comm _ a, mul_right_comm]
+  | zero => simp
+  | add x y hx hy hhx hhy =>
+    simp only [RingHom.coe_comp, Function.comp_apply, map_add, ge_iff_le]
+    transitivity
+    · refine Valuation.map_add (ValuationRing.valuation O K) _ _
+    · rw [sup_le_iff]
+      exact ⟨hhx, hhy⟩
+  | smul a x₀ hx hx1 =>
+    rw [Algebra.smul_def]
+    simp only [RingHom.coe_comp, Function.comp_apply, map_mul, ge_iff_le]
+    refine mul_le_one' ?_ hx1
+    have foo1 : algebraMap (↥(𝒜 0)) (Away 𝒜 (x i₀)) = fromZeroRingHom 𝒜 (.powers (x i₀)) := rfl
+    rw [foo1]
+    rw [awayMap_fromZeroRingHom 𝒜 (hxdi j) (mul_comm (x j) (x i₀))]
+    suffices fromZeroRingHom 𝒜 (Submonoid.powers (x j * x i₀)) a =
+        awayMap 𝒜 (hxdi i₀) rfl ((fromZeroRingHom 𝒜 (Submonoid.powers (x j))) a) by
+      rw [this]
+      unfold φ'
+      rw [hφ'1]
+      change (ValuationRing.valuation O K)
+        (φ.comp (fromZeroRingHom 𝒜 (Submonoid.powers (x j))) a) ≤ 1
+      rw [← hcomm]
+      simp only [RingHom.coe_comp, Function.comp_apply]
+      rw [← Valuation.mem_integer_iff, ValuationRing.mem_integer_iff]
+      use φ₀ a
+    symm
+    exact awayMap_fromZeroRingHom 𝒜 (hxdi i₀) rfl a
+
+open HomogeneousLocalization in
+lemma valuativeCriterion_existence [Algebra.FiniteType (𝒜 0) A] :
+    ValuativeCriterion.Existence (Proj.toSpecZero 𝒜) := by
+  rintro ⟨O, K, i₁, i₂, w⟩
+  obtain ⟨x, hx, hx'⟩ := GradedAlgebra.exists_finset_adjoin_eq_top_and_homogeneous_ne_zero 𝒜
+  choose d hd hxd using hx'
+  have : i₁.base (IsLocalRing.closedPoint K) ∈ (⊤ : (Proj 𝒜).Opens) := trivial
+  rw [← Proj.iSup_basicOpen_eq_top' 𝒜 (ι := x) (↑) (fun i ↦ ⟨_, hxd _ i.2⟩) (by simpa using hx),
+    TopologicalSpace.Opens.mem_iSup] at this
+  obtain ⟨i, hi⟩ := this
+  have : Set.range i₁.base ⊆ (Proj.awayι 𝒜 _ (hxd i i.2) (hd i i.2).bot_lt).opensRange := by
+    rw [Proj.opensRange_awayι]
+    rintro _ ⟨x, rfl⟩
+    obtain rfl := Subsingleton.elim x (IsLocalRing.closedPoint K)
+    exact hi
+  let φ : Spec (.of K) ⟶ _ := IsOpenImmersion.lift _ _ this
+  have H : Spec.preimage i₂ ≫ CommRingCat.ofHom (algebraMap O K) =
+      CommRingCat.ofHom (fromZeroRingHom 𝒜 _) ≫ Spec.preimage φ := by
+    apply Spec.map_injective
+    simp only [Spec.map_comp, Spec.map_preimage, ← w.w]
+    rw [← Proj.awayι_toSpecZero, IsOpenImmersion.lift_fac_assoc]
+  obtain ⟨x₀, e, he, hxe, φ', hφ, hφ'⟩ :=
+    valuativeCriterion_existence_aux 𝒜 (Spec.preimage i₂).hom x (↑) (by simpa using hx) i
+      (O := O) (K := K) (Spec.preimage φ).hom congr(($H).hom)
+      (fun i ↦ d _ i.2) (fun i ↦ (hd _ i.2).bot_lt) (fun i ↦ hxd _ i.2)
+  let e : O ≃+* (algebraMap O K).range :=
+    (AlgEquiv.ofInjective (Algebra.ofId O K) (IsFractionRing.injective _ _)).toRingEquiv
+  let φ'' := e.symm.toRingHom.comp ((Subring.inclusion hφ').comp (RingHom.rangeRestrict _))
+  have hφ'' : (algebraMap O K).comp φ'' = φ'.comp (awayMap 𝒜 (hxd _ i.2) (mul_comm _ _)) := by
+    ext x
+    exact congr_arg Subtype.val (e.apply_symm_apply _)
+  refine ⟨⟨Spec.map (CommRingCat.ofHom φ'') ≫ Proj.awayι 𝒜 _ hxe he, ?_, ?_⟩⟩
+  · rw [← Spec.map_comp_assoc]
+    convert IsOpenImmersion.lift_fac _ _ this using 1
+    show _ = φ ≫ _
+    rw [← Spec.map_preimage φ, ← CommRingCat.ofHom_hom (Spec.preimage φ), ← hφ,
+      ← CommRingCat.ofHom_comp, hφ'', CommRingCat.ofHom_comp, Spec.map_comp,
+      CommRingCat.ofHom_comp, Spec.map_comp, Category.assoc, Category.assoc,
+      SpecMap_awayMap_awayι, SpecMap_awayMap_awayι]
+    rfl
+  · simp only [Category.assoc, Proj.awayι_toSpecZero, ← Spec.map_comp]
+    conv_rhs => rw [← Spec.map_preimage i₂]
+    congr 1
+    ext x
+    apply IsFractionRing.injective O K
+    refine (DFunLike.congr_fun hφ'' (fromZeroRingHom 𝒜 _ _)).trans ?_
+    simp only [RingHom.coe_comp, Function.comp_apply]
+    rw [awayMap_fromZeroRingHom, ← awayMap_fromZeroRingHom 𝒜 hxe rfl, ← RingHom.comp_apply, hφ]
+    exact congr($(H.symm) x)
+
+instance [Algebra.FiniteType (𝒜 0) A] : UniversallyClosed (Proj.toSpecZero 𝒜) := by
+  rw [UniversallyClosed.eq_valuativeCriterion]
+  refine ⟨valuativeCriterion_existence 𝒜, inferInstance⟩
+
+end UniversallyClosed
+
+instance [Algebra.FiniteType (𝒜 0) A] : IsProper (Proj.toSpecZero 𝒜) where
 
 end AlgebraicGeometry.Proj

--- a/Mathlib/AlgebraicGeometry/ProjectiveSpectrum/Proper.lean
+++ b/Mathlib/AlgebraicGeometry/ProjectiveSpectrum/Proper.lean
@@ -186,6 +186,7 @@ O ←---- 𝒜_{(x₀)}                𝒜_{(x)}
 ```
 This is the underlying algebraic statement of the valuative criterion for `Proj A`.
 -/
+@[stacks 01MF "algebraic part"]
 theorem valuativeCriterion_existence_aux
     {O : Type*} [CommRing O] [IsDomain O] [ValuationRing O]
     {K : Type*} [Field K] [Algebra O K] [IsFractionRing O K]
@@ -341,7 +342,7 @@ theorem valuativeCriterion_existence_aux
     symm
     exact awayMap_fromZeroRingHom 𝒜 (hxdi i₀) rfl a
 
-open HomogeneousLocalization in
+@[stacks 01MF]
 lemma valuativeCriterion_existence [Algebra.FiniteType (𝒜 0) A] :
     ValuativeCriterion.Existence (Proj.toSpecZero 𝒜) := by
   rintro ⟨O, K, i₁, i₂, w⟩

--- a/Mathlib/AlgebraicGeometry/ProjectiveSpectrum/Proper.lean
+++ b/Mathlib/AlgebraicGeometry/ProjectiveSpectrum/Proper.lean
@@ -394,7 +394,7 @@ lemma valuativeCriterion_existence [Algebra.FiniteType (𝒜 0) A] :
 
 instance [Algebra.FiniteType (𝒜 0) A] : UniversallyClosed (Proj.toSpecZero 𝒜) := by
   rw [UniversallyClosed.eq_valuativeCriterion]
-  refine ⟨valuativeCriterion_existence 𝒜, inferInstance⟩
+  exact ⟨valuativeCriterion_existence 𝒜, inferInstance⟩
 
 end UniversallyClosed
 

--- a/Mathlib/GroupTheory/MonoidLocalization/Basic.lean
+++ b/Mathlib/GroupTheory/MonoidLocalization/Basic.lean
@@ -329,6 +329,10 @@ theorem mk_self (a : S) : mk (a : M) a = 1 := by
   rw [← mk_one, mk_eq_mk_iff]
   exact one_rel a
 
+@[to_additive (attr := simp)]
+lemma mk_self_mk (a : M) (haS : a ∈ S) : mk a ⟨a, haS⟩ = 1 :=
+  mk_self ⟨a, haS⟩
+
 section Scalar
 
 variable {R R₁ R₂ : Type*}


### PR DESCRIPTION
Co-authored-by: Patience Ablett
Co-authored-by: Kevin Buzzard
Co-authored-by: Harald Carlens
Co-authored-by: Wayne Ng Kwing King
Co-authored-by: Michael Schlößer
Co-authored-by: Justus Springer
Co-authored-by: Jujian Zhang

This contribution was created as part of the Durham Computational Algebraic Geometry Workshop

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
