### PR TITLE
[Merged by Bors] - chore(CStarAlgebra): remove `PositiveLinearMapClass`

### DIFF
--- a/Mathlib/Algebra/Order/Module/PositiveLinearMap.lean
+++ b/Mathlib/Algebra/Order/Module/PositiveLinearMap.lean
@@ -12,6 +12,12 @@ import Mathlib.Tactic.ContinuousFunctionalCalculus
 
 This file defines positive linear maps as a linear map that is also an order homomorphism.
 
+## Implementation notes
+
+We do not define `PositiveLinearMapClass` to avoid adding a class that mixes order and algebra.
+One can achieve the same effect by using a combination of `LinearMapClass` and `OrderHomClass`.
+We nevertheless use the namespace for lemmas using that combination of typeclasses.
+
 ## Notes
 
 More substantial results on positive maps such as their continuity can be found in
@@ -29,17 +35,12 @@ add_decl_doc PositiveLinearMap.toOrderHom
 /-- Notation for a `PositiveLinearMap`. -/
 notation:25 E " →ₚ[" R:25 "] " F:0 => PositiveLinearMap R E F
 
-/-- A positive linear map is a linear map that is also an order homomorphism. -/
-class PositiveLinearMapClass (F : Type*) (R : outParam Type*) (E₁ E₂ : Type*) [Semiring R]
-    [AddCommMonoid E₁] [PartialOrder E₁] [AddCommMonoid E₂] [PartialOrder E₂]
-    [Module R E₁] [Module R E₂]
-    [FunLike F E₁ E₂] extends LinearMapClass F R E₁ E₂, OrderHomClass F E₁ E₂
-
 namespace PositiveLinearMapClass
 
 variable {F R E₁ E₂ : Type*} [Semiring R]
   [AddCommMonoid E₁] [PartialOrder E₁] [AddCommMonoid E₂] [PartialOrder E₂]
-  [Module R E₁] [Module R E₂] [FunLike F E₁ E₂] [PositiveLinearMapClass F R E₁ E₂]
+  [Module R E₁] [Module R E₂] [FunLike F E₁ E₂] [LinearMapClass F R E₁ E₂]
+  [OrderHomClass F E₁ E₂]
 
 /-- Reinterpret an element of a type of positive linear maps as a positive linear map. -/
 def toPositiveLinearMap (f : F) : E₁ →ₚ[R] E₂ :=
@@ -68,12 +69,12 @@ instance : FunLike (E₁ →ₚ[R] E₂) E₁ E₂ where
     apply DFunLike.coe_injective'
     exact h
 
-instance : PositiveLinearMapClass (E₁ →ₚ[R] E₂) R E₁ E₂ where
+instance : LinearMapClass (E₁ →ₚ[R] E₂) R E₁ E₂ where
   map_add f := map_add f.toLinearMap
   map_smulₛₗ f := f.toLinearMap.map_smul'
+
+instance : OrderHomClass (E₁ →ₚ[R] E₂) E₁ E₂ where
   map_rel f := fun {_ _} hab => f.monotone' hab
-
-
 
 @[simp]
 lemma map_smul_of_tower {S : Type*} [SMul S E₁] [SMul S E₂]

--- a/Mathlib/Analysis/CStarAlgebra/PositiveLinearMap.lean
+++ b/Mathlib/Analysis/CStarAlgebra/PositiveLinearMap.lean
@@ -124,7 +124,7 @@ lemma exists_norm_apply_le (f : A₁ →ₚ[ℂ] A₂) : ∃ C : ℝ≥0, ∀ a,
     gcongr
     exact x_summable.le_tsum n fun m _ ↦ this m
 
-instance {F : Type*} [FunLike F A₁ A₂] [PositiveLinearMapClass F ℂ A₁ A₂] :
+instance {F : Type*} [FunLike F A₁ A₂] [LinearMapClass F ℂ A₁ A₂] [OrderHomClass F A₁ A₂] :
     ContinuousLinearMapClass F ℂ A₁ A₂ where
   map_continuous f := by
     have hbound : ∃ C : ℝ, ∀ a, ‖f a‖ ≤ C * ‖a‖ := by
@@ -132,7 +132,7 @@ instance {F : Type*} [FunLike F A₁ A₂] [PositiveLinearMapClass F ℂ A₁ A�
       exact ⟨C, h⟩
     exact (LinearMap.mkContinuousOfExistsBound (f : A₁ →ₗ[ℂ] A₂) hbound).continuous
 
-instance {F : Type*} [FunLike F A₁ A₂] [PositiveLinearMapClass F ℂ A₁ A₂] :
+instance {F : Type*} [FunLike F A₁ A₂] [LinearMapClass F ℂ A₁ A₂] [OrderHomClass F A₁ A₂] :
     StarHomClass F A₁ A₂ where
   map_star f a := by
     obtain ⟨y, hy_nonneg, hy_norm, hy⟩ := CStarAlgebra.exists_sum_four_nonneg a


### PR DESCRIPTION
This PR removes the typeclass `PositiveLinearMapClass`, meant as the morphism class corresponding to `PositiveLinearMap`. This class is equivalent to a combination of `LinearMapClass` and `OrderHomClass`, and it is probably best to remove it as it mixes algebra and order; in fact, it caused performance problems while I was experimenting with completely positive maps.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
