### PR TITLE
[Merged by Bors] - feat: continuous perfect pairings

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -6014,6 +6014,7 @@ import Mathlib.Topology.Algebra.Module.ModuleTopology
 import Mathlib.Topology.Algebra.Module.Multilinear.Basic
 import Mathlib.Topology.Algebra.Module.Multilinear.Bounded
 import Mathlib.Topology.Algebra.Module.Multilinear.Topology
+import Mathlib.Topology.Algebra.Module.PerfectPairing
 import Mathlib.Topology.Algebra.Module.PerfectSpace
 import Mathlib.Topology.Algebra.Module.Simple
 import Mathlib.Topology.Algebra.Module.Star

--- a/Mathlib/Topology/Algebra/Module/PerfectPairing.lean
+++ b/Mathlib/Topology/Algebra/Module/PerfectPairing.lean
@@ -1,0 +1,70 @@
+/-
+Copyright (c) 2025 Yaël Dillies, Andrew Yang. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yaël Dillies, Andrew Yang
+-/
+import Mathlib.LinearAlgebra.BilinearMap
+import Mathlib.Topology.Algebra.Module.LinearMap
+
+/-!
+# Continuous perfect pairings
+
+This file defines continuous perfect pairings.
+
+For a topological ring `R` and two topological modules `M` and `N`, a continuous perfect pairing is
+a continuous bilinear map `M × N → R` that is bijective in both arguments.
+
+Note that this does **not** imply that the continuous dual of `M` is `N` and vice-versa (one would
+instead need "homeomorphic in both arguments").
+
+## TODO
+
+Adapt `PerfectPairing` to this Prop-valued typeclass paradigm
+-/
+
+open Function
+
+namespace LinearMap
+variable {R M N : Type*}
+  [CommRing R] [TopologicalSpace R] [AddCommGroup M] [Module R M] [TopologicalSpace M]
+  [AddCommGroup N] [Module R N] [TopologicalSpace N] (p : M →ₗ[R] N →ₗ[R] R) {x : M} {y : N}
+
+/-- For a topological ring `R` and two topological modules `M` and `N`, a continuous perfect pairing
+is a continuous bilinear map `M × N → R` that is bijective in both arguments.
+
+Note that this does **not** imply that the dual of `M` is `N` and vice-versa (one would instead need
+"homeomorphic in both arguments"). -/
+@[ext]
+class IsContPerfPair (p : M →ₗ[R] N →ₗ[R] R) where
+  continuous_uncurry (p) : Continuous fun (x, y) ↦ p x y
+  bijective_left (p) :
+    Bijective fun x ↦ ContinuousLinearMap.mk (p x) <| continuous_uncurry.comp <| .prodMk_right x
+  bijective_right (p) :
+    Bijective fun y ↦ ContinuousLinearMap.mk (p.flip y) <| continuous_uncurry.comp <| .prodMk_left y
+
+variable [p.IsContPerfPair]
+
+alias continuous_uncurry_of_isContPerfPair :=
+  IsContPerfPair.continuous_uncurry
+
+/-- Given a perfect pairing between `M`and `N`, we may interchange the roles of `M` and `N`. -/
+instance flip.instIsContPerfPair : p.flip.IsContPerfPair where
+  continuous_uncurry := p.continuous_uncurry_of_isContPerfPair.comp continuous_swap
+  bijective_left := IsContPerfPair.bijective_right p
+  bijective_right := IsContPerfPair.bijective_left p
+
+lemma continuous_of_isContPerfPair : Continuous (p x) :=
+  p.continuous_uncurry_of_isContPerfPair.comp <| .prodMk_right x
+
+variable [IsTopologicalRing R]
+
+/-- Turn a continuous perfect pairing between `M` and `N` into a map from `M` to continuous linear
+maps `N → R`. -/
+noncomputable def toContPerfPair : M ≃ₗ[R] (N →L[R] R) :=
+  .ofBijective { toFun := _, map_add' x y := by ext; simp, map_smul' r x := by ext; simp } <|
+    IsContPerfPair.bijective_left p
+
+@[simp] lemma toLinearMap_toContPerfPair (x : M) : p.toContPerfPair x = p x := rfl
+@[simp] lemma toContPerfPair_apply (x : M) (y : N) : p.toContPerfPair x y = p x y := rfl
+
+end LinearMap

--- a/Mathlib/Topology/Algebra/Module/PerfectPairing.lean
+++ b/Mathlib/Topology/Algebra/Module/PerfectPairing.lean
@@ -14,9 +14,8 @@ This file defines continuous perfect pairings.
 For a topological ring `R` and two topological modules `M` and `N`, a continuous perfect pairing is
 a continuous bilinear map `M × N → R` that is bijective in both arguments.
 
-Note that this does **not** imply that the (strong) continuous dual of `M` is `N` and vice-versa.
-(one would instead need "homeomorphic in both arguments"). This is useful to cover other kinds of
-duals, like the weak dual or weak-* dual.
+We require continuity in the forward direction only so that we can put several different topologies
+on the continuous dual: strong, weak, weak-* topology...
 
 ## TODO
 
@@ -33,9 +32,8 @@ variable {R M N : Type*}
 /-- For a topological ring `R` and two topological modules `M` and `N`, a continuous perfect pairing
 is a continuous bilinear map `M × N → R` that is bijective in both arguments.
 
-Note that this does **not** imply that the (strong) continuous dual of `M` is `N` and vice-versa.
-(one would instead need "homeomorphic in both arguments"). This is useful to cover other kinds of
-duals, like the weak dual or weak-* dual. -/
+We require continuity in the forward direction only so that we can put several different topologies
+on the continuous dual: strong, weak, weak-* topology... -/
 @[ext]
 class IsContPerfPair (p : M →ₗ[R] N →ₗ[R] R) where
   continuous_uncurry (p) : Continuous fun (x, y) ↦ p x y

--- a/Mathlib/Topology/Algebra/Module/PerfectPairing.lean
+++ b/Mathlib/Topology/Algebra/Module/PerfectPairing.lean
@@ -15,7 +15,10 @@ For a topological ring `R` and two topological modules `M` and `N`, a continuous
 a continuous bilinear map `M × N → R` that is bijective in both arguments.
 
 We require continuity in the forward direction only so that we can put several different topologies
-on the continuous dual: strong, weak, weak-* topology...
+on the continuous dual (e.g., strong, weak, weak-*). For example, if `M` is weakly reflexive then
+there is a continuous perfect pairing between `M` and `WeakDual R M`, even though the map
+`WeakDual R M ≃ₗ[R] (M →L[R] R)` (where `M →L[R] R` is equipped with its strong topology) is not in
+general a homeomorphism.
 
 ## TODO
 

--- a/Mathlib/Topology/Algebra/Module/PerfectPairing.lean
+++ b/Mathlib/Topology/Algebra/Module/PerfectPairing.lean
@@ -14,8 +14,9 @@ This file defines continuous perfect pairings.
 For a topological ring `R` and two topological modules `M` and `N`, a continuous perfect pairing is
 a continuous bilinear map `M × N → R` that is bijective in both arguments.
 
-Note that this does **not** imply that the continuous dual of `M` is `N` and vice-versa (one would
-instead need "homeomorphic in both arguments").
+Note that this does **not** imply that the (strong) continuous dual of `M` is `N` and vice-versa.
+(one would instead need "homeomorphic in both arguments"). This is useful to cover other kinds of
+duals, like the weak dual or weak-* dual.
 
 ## TODO
 
@@ -32,8 +33,9 @@ variable {R M N : Type*}
 /-- For a topological ring `R` and two topological modules `M` and `N`, a continuous perfect pairing
 is a continuous bilinear map `M × N → R` that is bijective in both arguments.
 
-Note that this does **not** imply that the dual of `M` is `N` and vice-versa (one would instead need
-"homeomorphic in both arguments"). -/
+Note that this does **not** imply that the (strong) continuous dual of `M` is `N` and vice-versa.
+(one would instead need "homeomorphic in both arguments"). This is useful to cover other kinds of
+duals, like the weak dual or weak-* dual. -/
 @[ext]
 class IsContPerfPair (p : M →ₗ[R] N →ₗ[R] R) where
   continuous_uncurry (p) : Continuous fun (x, y) ↦ p x y


### PR DESCRIPTION
Define continuous perfect pairings using a Prop-valued typeclass `IsContPerfPair` on a bilinear pairing `p : M →ₗ[R] N →ₗ[R] R`, and a function to turn `p : M →ₗ[R] N →ₗ[R] R` + `p.IsContPerfPair` into `M ≃ₗ[R] (N →ₗ[R] R)`.

The name `IsContPerfPair` is kept short because it shows up in lemma and definition names.

Mathematically, there are many topological notions of perfect pairing: one per topology on `N →ₗ[R] R`/`N →L[R] R`. It is therefore better for `IsContPerfPair` not to require `p x` to be a homeo, and to instead extend it to new classes like `IsWeakTopPerfPair`, `IsCompactOpenPerfPair`, etc... whenever we need it to imply some reflexivity result for a particular norm on linear maps.

There's also the question of continuity. Most applications need only continuity in either argument, but currently we are requiring continuity in both arguments simultaneously, ie as a map `M × N → R`. This is an easy way to ensure we get a map `N → M →L[R] R`.

From Toric

Co-authored-by: Andrew Yang <the.erd.one@gmail.com>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

`PerfectPairing` can be similarly refactored. See #25239. 

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
