### PR TITLE
[Merged by Bors] - feat(CI): use `lean-action`'s "reinstall transient toolchain" step

### DIFF
--- a/.github/build.in.yml
+++ b/.github/build.in.yml
@@ -57,7 +57,7 @@ jobs:
           python-version: 3.8
 
       - name: Configure Lean
-        uses: leanprover/lean-action@f3ad22e9ca29cb9475bc9bee9afd1f39bb52bf6d # v1.1.2
+        uses: leanprover/lean-action@e18f2df7f0d4f30d11a4b963bff9b1140999480c # 2025-04-22
         with:
           auto-config: false
           use-github-cache: false
@@ -101,23 +101,12 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Configure Lean
-        uses: leanprover/lean-action@f3ad22e9ca29cb9475bc9bee9afd1f39bb52bf6d # v1.1.2
+        uses: leanprover/lean-action@e18f2df7f0d4f30d11a4b963bff9b1140999480c # 2025-04-22
         with:
           auto-config: false
           use-github-cache: false
           use-mathlib-cache: false
-
-      - name: If using a lean-pr-release toolchain, uninstall
-        run: |
-          if [[ $(cat lean-toolchain) =~ ^leanprover/lean4-pr-releases:pr-release-[0-9]+$ ]]; then
-            printf 'Uninstalling transient toolchain %s\n' "$(cat lean-toolchain)"
-            elan toolchain uninstall "$(cat lean-toolchain)"
-          fi
-
-      - name: print lean and lake versions
-        run: |
-          lean --version
-          lake --version
+          reinstall-transient-toolchain: true
 
       - name: cleanup .cache/mathlib
         run: |

--- a/.github/workflows/add_label_from_diff.yaml
+++ b/.github/workflows/add_label_from_diff.yaml
@@ -25,7 +25,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Configure Lean
-        uses: leanprover/lean-action@f3ad22e9ca29cb9475bc9bee9afd1f39bb52bf6d # v1.1.2
+        uses: leanprover/lean-action@e18f2df7f0d4f30d11a4b963bff9b1140999480c # 2025-04-22
         with:
           auto-config: false
           use-github-cache: false

--- a/.github/workflows/bench_summary_comment.yml
+++ b/.github/workflows/bench_summary_comment.yml
@@ -17,7 +17,7 @@ jobs:
             scripts/bench_summary.lean
 
       - name: Configure Lean
-        uses: leanprover/lean-action@f3ad22e9ca29cb9475bc9bee9afd1f39bb52bf6d # v1.1.2
+        uses: leanprover/lean-action@e18f2df7f0d4f30d11a4b963bff9b1140999480c # 2025-04-22
         with:
           auto-config: false
           use-github-cache: false

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -67,7 +67,7 @@ jobs:
           python-version: 3.8
 
       - name: Configure Lean
-        uses: leanprover/lean-action@f3ad22e9ca29cb9475bc9bee9afd1f39bb52bf6d # v1.1.2
+        uses: leanprover/lean-action@e18f2df7f0d4f30d11a4b963bff9b1140999480c # 2025-04-22
         with:
           auto-config: false
           use-github-cache: false
@@ -111,23 +111,12 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Configure Lean
-        uses: leanprover/lean-action@f3ad22e9ca29cb9475bc9bee9afd1f39bb52bf6d # v1.1.2
+        uses: leanprover/lean-action@e18f2df7f0d4f30d11a4b963bff9b1140999480c # 2025-04-22
         with:
           auto-config: false
           use-github-cache: false
           use-mathlib-cache: false
-
-      - name: If using a lean-pr-release toolchain, uninstall
-        run: |
-          if [[ $(cat lean-toolchain) =~ ^leanprover/lean4-pr-releases:pr-release-[0-9]+$ ]]; then
-            printf 'Uninstalling transient toolchain %s\n' "$(cat lean-toolchain)"
-            elan toolchain uninstall "$(cat lean-toolchain)"
-          fi
-
-      - name: print lean and lake versions
-        run: |
-          lean --version
-          lake --version
+          reinstall-transient-toolchain: true
 
       - name: cleanup .cache/mathlib
         run: |

--- a/.github/workflows/bot_fix_style.yaml
+++ b/.github/workflows/bot_fix_style.yaml
@@ -117,7 +117,7 @@ jobs:
           python-version: 3.8
 
       - name: Configure Lean
-        uses: leanprover/lean-action@f3ad22e9ca29cb9475bc9bee9afd1f39bb52bf6d # v1.1.2
+        uses: leanprover/lean-action@e18f2df7f0d4f30d11a4b963bff9b1140999480c # 2025-04-22
         with:
           auto-config: false
           use-github-cache: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,7 +74,7 @@ jobs:
           python-version: 3.8
 
       - name: Configure Lean
-        uses: leanprover/lean-action@f3ad22e9ca29cb9475bc9bee9afd1f39bb52bf6d # v1.1.2
+        uses: leanprover/lean-action@e18f2df7f0d4f30d11a4b963bff9b1140999480c # 2025-04-22
         with:
           auto-config: false
           use-github-cache: false
@@ -118,23 +118,12 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Configure Lean
-        uses: leanprover/lean-action@f3ad22e9ca29cb9475bc9bee9afd1f39bb52bf6d # v1.1.2
+        uses: leanprover/lean-action@e18f2df7f0d4f30d11a4b963bff9b1140999480c # 2025-04-22
         with:
           auto-config: false
           use-github-cache: false
           use-mathlib-cache: false
-
-      - name: If using a lean-pr-release toolchain, uninstall
-        run: |
-          if [[ $(cat lean-toolchain) =~ ^leanprover/lean4-pr-releases:pr-release-[0-9]+$ ]]; then
-            printf 'Uninstalling transient toolchain %s\n' "$(cat lean-toolchain)"
-            elan toolchain uninstall "$(cat lean-toolchain)"
-          fi
-
-      - name: print lean and lake versions
-        run: |
-          lean --version
-          lake --version
+          reinstall-transient-toolchain: true
 
       - name: cleanup .cache/mathlib
         run: |

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -71,7 +71,7 @@ jobs:
           python-version: 3.8
 
       - name: Configure Lean
-        uses: leanprover/lean-action@f3ad22e9ca29cb9475bc9bee9afd1f39bb52bf6d # v1.1.2
+        uses: leanprover/lean-action@e18f2df7f0d4f30d11a4b963bff9b1140999480c # 2025-04-22
         with:
           auto-config: false
           use-github-cache: false
@@ -115,23 +115,12 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Configure Lean
-        uses: leanprover/lean-action@f3ad22e9ca29cb9475bc9bee9afd1f39bb52bf6d # v1.1.2
+        uses: leanprover/lean-action@e18f2df7f0d4f30d11a4b963bff9b1140999480c # 2025-04-22
         with:
           auto-config: false
           use-github-cache: false
           use-mathlib-cache: false
-
-      - name: If using a lean-pr-release toolchain, uninstall
-        run: |
-          if [[ $(cat lean-toolchain) =~ ^leanprover/lean4-pr-releases:pr-release-[0-9]+$ ]]; then
-            printf 'Uninstalling transient toolchain %s\n' "$(cat lean-toolchain)"
-            elan toolchain uninstall "$(cat lean-toolchain)"
-          fi
-
-      - name: print lean and lake versions
-        run: |
-          lean --version
-          lake --version
+          reinstall-transient-toolchain: true
 
       - name: cleanup .cache/mathlib
         run: |

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -56,23 +56,12 @@ jobs:
           ref: ${{ env.BRANCH_REF }}
 
       - name: Configure Lean
-        uses: leanprover/lean-action@f3ad22e9ca29cb9475bc9bee9afd1f39bb52bf6d # v1.1.2
+        uses: leanprover/lean-action@e18f2df7f0d4f30d11a4b963bff9b1140999480c # 2025-04-22
         with:
           auto-config: false
           use-github-cache: false
           use-mathlib-cache: false
-
-      - name: If using a lean-pr-release toolchain, uninstall
-        run: |
-          if [[ "$(cat lean-toolchain)" =~ ^leanprover/lean4-pr-releases:pr-release-[0-9]+$ ]]; then
-            printf 'Uninstalling transient toolchain %s\n' "$(cat lean-toolchain)"
-            elan toolchain uninstall "$(cat lean-toolchain)"
-          fi
-
-      - name: Print Lean and Lake versions
-        run: |
-          lean --version
-          lake --version
+          reinstall-transient-toolchain: true
 
       - name: Run lake exe cache get
         run: |

--- a/.github/workflows/discover-lean-pr-testing.yml
+++ b/.github/workflows/discover-lean-pr-testing.yml
@@ -25,7 +25,7 @@ jobs:
         git config --global user.email "github-actions@github.com"
 
     - name: Configure Lean
-      uses: leanprover/lean-action@f3ad22e9ca29cb9475bc9bee9afd1f39bb52bf6d # v1.1.2
+      uses: leanprover/lean-action@e18f2df7f0d4f30d11a4b963bff9b1140999480c # 2025-04-22
       with:
         auto-config: false
         use-github-cache: false

--- a/.github/workflows/latest_import.yml
+++ b/.github/workflows/latest_import.yml
@@ -28,23 +28,12 @@ jobs:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
     - name: Configure Lean
-      uses: leanprover/lean-action@f3ad22e9ca29cb9475bc9bee9afd1f39bb52bf6d # v1.1.2
+      uses: leanprover/lean-action@e18f2df7f0d4f30d11a4b963bff9b1140999480c # 2025-04-22
       with:
         auto-config: false
         use-github-cache: false
         use-mathlib-cache: false
-
-    - name: If using a lean-pr-release toolchain, uninstall
-      run: |
-        if [[ $(cat lean-toolchain) =~ ^leanprover/lean4-pr-releases:pr-release-[0-9]+$ ]]; then
-          printf 'Uninstalling transient toolchain %s\n' "$(cat lean-toolchain)"
-          elan toolchain uninstall "$(cat lean-toolchain)"
-        fi
-
-    - name: print lean and lake versions
-      run: |
-        lean --version
-        lake --version
+        reinstall-transient-toolchain: true
 
     - name: add minImports linter option
       run: |

--- a/.github/workflows/lint_and_suggest_pr.yml
+++ b/.github/workflows/lint_and_suggest_pr.yml
@@ -22,7 +22,7 @@ jobs:
           python-version: 3.8
 
       - name: Configure Lean
-        uses: leanprover/lean-action@f3ad22e9ca29cb9475bc9bee9afd1f39bb52bf6d # v1.1.2
+        uses: leanprover/lean-action@e18f2df7f0d4f30d11a4b963bff9b1140999480c # 2025-04-22
         with:
           auto-config: false
           use-github-cache: false
@@ -66,7 +66,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Configure Lean
-        uses: leanprover/lean-action@f3ad22e9ca29cb9475bc9bee9afd1f39bb52bf6d # v1.1.2
+        uses: leanprover/lean-action@e18f2df7f0d4f30d11a4b963bff9b1140999480c # 2025-04-22
         with:
           auto-config: false
           use-github-cache: false

--- a/.github/workflows/nightly_merge_master.yml
+++ b/.github/workflows/nightly_merge_master.yml
@@ -18,7 +18,7 @@ jobs:
           token: ${{ secrets.NIGHTLY_TESTING }}
 
       - name: Configure Lean
-        uses: leanprover/lean-action@f3ad22e9ca29cb9475bc9bee9afd1f39bb52bf6d # v1.1.2
+        uses: leanprover/lean-action@e18f2df7f0d4f30d11a4b963bff9b1140999480c # 2025-04-22
         with:
           auto-config: false
           use-github-cache: false

--- a/.github/workflows/nolints.yml
+++ b/.github/workflows/nolints.yml
@@ -33,16 +33,11 @@ jobs:
           rm -rf .lake/packages/proofwidgets/.lake/build/ir
 
       - name: Configure Lean
-        uses: leanprover/lean-action@f3ad22e9ca29cb9475bc9bee9afd1f39bb52bf6d # v1.1.2
+        uses: leanprover/lean-action@e18f2df7f0d4f30d11a4b963bff9b1140999480c # 2025-04-22
         with:
           auto-config: false
           use-github-cache: false
           use-mathlib-cache: true
-
-      - name: print lean and lake versions
-        run: |
-          lean --version
-          lake --version
 
       - name: build mathlib
         id: build

--- a/.github/workflows/update_dependencies.yml
+++ b/.github/workflows/update_dependencies.yml
@@ -16,7 +16,7 @@ jobs:
           token: "${{ secrets.UPDATE_DEPENDENCIES_TOKEN }}"
 
       - name: Configure Lean
-        uses: leanprover/lean-action@f3ad22e9ca29cb9475bc9bee9afd1f39bb52bf6d # v1.1.2
+        uses: leanprover/lean-action@e18f2df7f0d4f30d11a4b963bff9b1140999480c # 2025-04-22
         with:
           auto-config: false
           use-github-cache: false


### PR DESCRIPTION
We had a hand-coded "reinstall transient toolchain" step in a few workflows. I added this to `lean-action` so we can call it directly from that action. We can also skip the "print lean and lake versions" step since `lean-action` does that too.

This PR also upgrades the `lean-action` version to the latest `main` branch.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
