### PR TITLE
[Merged by Bors] - feat(NumberTheory/Padics): leftovers from PR 24141

### DIFF
--- a/Mathlib/NumberTheory/Padics/AddChar.lean
+++ b/Mathlib/NumberTheory/Padics/AddChar.lean
@@ -10,13 +10,29 @@ import Mathlib.Analysis.SpecificLimits.Normed
 /-!
 # Additive characters of `ℤ_[p]`
 
-We show that for any normed `ℤ_[p]`-algebra `R`, there is a bijection between continuous additive
-characters `ℤ_[p] → R` and topologically nilpotent elements of `R`, given by sending `κ` to the
-element `κ 1 - 1`. This is used to define the Mahler transform for `p`-adic measures.
+We show that for any complete, ultrametric normed `ℤ_[p]`-algebra `R`, there is a bijection between
+continuous additive characters `ℤ_[p] → R` and topologically nilpotent elements of `R`, given by
+sending `κ` to the element `κ 1 - 1`. This is used to define the Mahler transform for `p`-adic
+measures.
 
 Note that if the norm on `R` is not strictly multiplicative, then the condition that `κ 1 - 1` be
-topologically nilpotent is strictly weaker than assuming `‖κ 1 - 1‖ < 1`, although they are of
-course equivalent if `NormMulClass R` holds.
+topologically nilpotent is strictly weaker than assuming `‖κ 1 - 1‖ < 1`, although they are
+equivalent if `NormMulClass R` holds.
+
+## Main definitions and theorems:
+
+* `addChar_of_value_at_one`: given a topologically nilpotent `r : R`, construct a continuous
+  additive character of `ℤ_[p]` mapping `1` to `1 + r`.
+* `continuousAddCharEquiv`: for any complete, ultrametric normed `ℤ_[p]`-algebra `R`, the map
+  `addChar_of_value_at_one` defines a bijection between continuous additive characters `ℤ_[p] → R`
+  and topologically nilpotent elements of `R`.
+* `continuousAddCharEquiv_of_norm_mul`: if the norm on `R` is strictly multiplicative (not just
+  sub-multiplicative), then `addChar_of_value_at_one` is a bijection between continuous additive
+  characters `ℤ_[p] → R` and elements of `R` with `‖r‖ < 1`.
+
+## TODO:
+
+* Show that the above equivalences are homeomorphisms, for appropriate choices of the topology.
 -/
 
 open scoped fwdDiff
@@ -27,7 +43,7 @@ variable {p : ℕ} [Fact p.Prime]
 variable {R : Type*} [NormedRing R] [Algebra ℤ_[p] R] [IsBoundedSMul ℤ_[p] R]
   [IsUltrametricDist R]
 
-lemma AddChar.tendsto_apply_one_sub_pow {κ : AddChar ℤ_[p] R} (hκ : Continuous κ) :
+lemma AddChar.tendsto_eval_one_sub_pow {κ : AddChar ℤ_[p] R} (hκ : Continuous κ) :
     Tendsto (fun n ↦ (κ 1 - 1) ^ n) atTop (𝓝 0) := by
   refine (PadicInt.fwdDiff_tendsto_zero ⟨κ, hκ⟩).congr fun n ↦ ?_
   simpa only [AddChar.map_zero_eq_one, mul_one] using fwdDiff_addChar_eq κ 0 1 n
@@ -75,18 +91,15 @@ lemma addChar_of_value_at_one_def {r : R} (hr : Tendsto (r ^ ·) atTop (𝓝 0))
 lemma eq_addChar_of_value_at_one {r : R} (hr : Tendsto (r ^ ·) atTop (𝓝 0))
     {κ : AddChar ℤ_[p] R} (hκ : Continuous κ) (hκ' : κ 1 = 1 + r) :
     κ = addChar_of_value_at_one r hr :=
-  denseRange_natCast.addChar_eq_of_apply_one_eq hκ (by fun_prop) (by simp [hκ'])
+  denseRange_natCast.addChar_eq_of_eval_one_eq hκ (by fun_prop) (by simp [hκ'])
 
 variable (p R) in
 /-- Equivalence between continuous additive characters `ℤ_[p] → R`, and `r ∈ R` with `r ^ n → 0`. -/
 noncomputable def continuousAddCharEquiv :
     {κ : AddChar ℤ_[p] R // Continuous κ} ≃ {r : R // Tendsto (r ^ ·) atTop (𝓝 0)} where
-  toFun := fun ⟨κ, hκ⟩ ↦ ⟨κ 1 - 1, κ.tendsto_apply_one_sub_pow hκ⟩
+  toFun := fun ⟨κ, hκ⟩ ↦ ⟨κ 1 - 1, κ.tendsto_eval_one_sub_pow hκ⟩
   invFun := fun ⟨r, hr⟩ ↦ ⟨_, continuous_addChar_of_value_at_one hr⟩
-  left_inv := fun ⟨κ, hκ⟩ ↦ by
-    apply Subtype.coe_injective
-    apply denseRange_natCast.addChar_eq_of_apply_one_eq (continuous_addChar_of_value_at_one _) hκ
-    rw [addChar_of_value_at_one_def (κ.tendsto_apply_one_sub_pow hκ), add_sub_cancel]
+  left_inv := fun ⟨κ, hκ⟩ ↦ by simpa using (eq_addChar_of_value_at_one _ hκ (by abel)).symm
   right_inv := fun ⟨r, hr⟩ ↦ by simp [addChar_of_value_at_one_def hr]
 
 @[simp] lemma continuousAddCharEquiv_apply {κ : AddChar ℤ_[p] R} (hκ : Continuous κ) :

--- a/Mathlib/Topology/Algebra/Monoid/AddChar.lean
+++ b/Mathlib/Topology/Algebra/Monoid/AddChar.lean
@@ -10,7 +10,7 @@ import Mathlib.Topology.DenseEmbedding
 # Additive characters of topological monoids
 -/
 
-lemma DenseRange.addChar_eq_of_apply_one_eq {A M : Type*} [TopologicalSpace A] [AddMonoidWithOne A]
+lemma DenseRange.addChar_eq_of_eval_one_eq {A M : Type*} [TopologicalSpace A] [AddMonoidWithOne A]
     [Monoid M] [TopologicalSpace M] [T2Space M] (hdr : DenseRange ((↑) : ℕ → A))
     {κ₁ κ₂ : AddChar A M} (hκ₁ : Continuous κ₁) (hκ₂ : Continuous κ₂) (h : κ₁ 1 = κ₂ 1) :
     κ₁ = κ₂ := by


### PR DESCRIPTION
Rename some lemmas, add a TODO note

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->
These were some suggestions from @faenuccio which accidentally got left out when #24141 was merged. In implementing these, I also spotted that one of the lemmas Filippo had suggested adding in the review process allowed a proof further down to be golfed somewhat.

(NB: I'm deliberately not allowing github to linkify the previous PR number in the commit message, to avoid a ton of junk notifications.)

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
