### PR TITLE
[Merged by Bors] - chore: replace `Monoid.IsTorsionFree` with `IsMulTorsionFree`

### DIFF
--- a/Mathlib/Algebra/Group/Pi/Lemmas.lean
+++ b/Mathlib/Algebra/Group/Pi/Lemmas.lean
@@ -36,6 +36,10 @@ theorem Set.preimage_one {α β : Type*} [One β] (s : Set β) [Decidable ((1 : 
     (1 : α → β) ⁻¹' s = if (1 : β) ∈ s then Set.univ else ∅ :=
   Set.preimage_const 1 s
 
+instance Pi.instIsMulTorsionFree [∀ i, Monoid (M i)] [∀ i, IsMulTorsionFree (M i)] :
+    IsMulTorsionFree (∀ i, M i) where
+  pow_left_injective n hn a b hab := by ext i; exact pow_left_injective hn <| congr_fun hab i
+
 namespace Pi
 
 instance instIsMulTorsionFree [∀ i, Monoid (M i)] [∀ i, IsMulTorsionFree (M i)] :

--- a/Mathlib/Algebra/Group/Pi/Lemmas.lean
+++ b/Mathlib/Algebra/Group/Pi/Lemmas.lean
@@ -36,10 +36,6 @@ theorem Set.preimage_one {α β : Type*} [One β] (s : Set β) [Decidable ((1 : 
     (1 : α → β) ⁻¹' s = if (1 : β) ∈ s then Set.univ else ∅ :=
   Set.preimage_const 1 s
 
-instance Pi.instIsMulTorsionFree [∀ i, Monoid (M i)] [∀ i, IsMulTorsionFree (M i)] :
-    IsMulTorsionFree (∀ i, M i) where
-  pow_left_injective n hn a b hab := by ext i; exact pow_left_injective hn <| congr_fun hab i
-
 namespace Pi
 
 instance instIsMulTorsionFree [∀ i, Monoid (M i)] [∀ i, IsMulTorsionFree (M i)] :

--- a/Mathlib/Algebra/Group/Torsion.lean
+++ b/Mathlib/Algebra/Group/Torsion.lean
@@ -11,12 +11,6 @@ import Mathlib.Tactic.MkIffOfInductiveProp
 
 This file defines torsion-free monoids as those monoids `M` for which `n • · : M → M` is injective
 for all non-zero natural number `n`.
-
-## TODO
-
-Replace `Monoid.IsTorsionFree`, which is mathematically incorrect for monoids which are not groups.
-This probably means we also want to get rid of `NoZeroSMulDivisors`, which is mathematically
-incorrect for the same reason.
 -/
 
 open Function

--- a/Mathlib/Algebra/NoZeroSMulDivisors/Defs.lean
+++ b/Mathlib/Algebra/NoZeroSMulDivisors/Defs.lean
@@ -11,6 +11,12 @@ import Mathlib.Algebra.Group.Torsion
 
 This file defines the `NoZeroSMulDivisors` class, and includes some tests
 for the vanishing of elements (especially in modules over division rings).
+
+## TODO
+
+`NoZeroSMulDivisors` is mathematically incorrect for semimodules. Replace it with a new typeclass
+`Module.IsTorsionFree`, cf https://github.com/kbuzzard/ClassFieldTheory. Torsion-free monoids have
+seen the same change happen already.
 -/
 
 assert_not_exists RelIso Multiset Set.indicator Pi.single_smul₀ Ring Module

--- a/Mathlib/Combinatorics/Additive/CauchyDavenport.lean
+++ b/Mathlib/Combinatorics/Additive/CauchyDavenport.lean
@@ -52,7 +52,7 @@ additive combinatorics, number theory, sumset, cauchy-davenport
 open Finset Function Monoid MulOpposite Subgroup
 open scoped Pointwise
 
-variable {α : Type*}
+variable {G α : Type*}
 
 /-! ### General case -/
 
@@ -176,17 +176,20 @@ lemma cauchy_davenport_minOrder_mul (hs : s.Nonempty) (ht : t.Nonempty) :
       (WithTop.coe_le_coe.2 aux2).trans' fun h ↦
         hstg.le.trans <| h.trans <| add_le_add_right aux2 _
 
+end General
+
 /-- The **Cauchy-Davenport Theorem** for torsion-free groups. The size of `s * t` is lower-bounded
 by `|s| + |t| - 1`. -/
 @[to_additive
 "The **Cauchy-Davenport theorem** for torsion-free groups. The size of `s + t` is lower-bounded
 by `|s| + |t| - 1`."]
-lemma cauchy_davenport_mul_of_isTorsionFree (h : IsTorsionFree α)
-    (hs : s.Nonempty) (ht : t.Nonempty) : #s + #t - 1 ≤ #(s * t) := by
-  simpa only [h.minOrder, min_eq_right, le_top, Nat.cast_le]
+lemma cauchy_davenport_of_isMulTorsionFree [DecidableEq G] [CommGroup G] [IsMulTorsionFree G]
+    {s t : Finset G} (hs : s.Nonempty) (ht : t.Nonempty) : #s + #t - 1 ≤ #(s * t) := by
+  simpa only [Monoid.minOrder_eq_top, min_eq_right, le_top, Nat.cast_le]
     using cauchy_davenport_minOrder_mul hs ht
 
-end General
+@[to_additive (attr := deprecated cauchy_davenport_of_isMulTorsionFree (since := "2025-04-23"))]
+alias cauchy_davenport_mul_of_isTorsionFree := cauchy_davenport_of_isMulTorsionFree
 
 /-! ### $$ℤ/nℤ$$ -/
 

--- a/Mathlib/Combinatorics/Additive/CauchyDavenport.lean
+++ b/Mathlib/Combinatorics/Additive/CauchyDavenport.lean
@@ -183,7 +183,7 @@ by `|s| + |t| - 1`. -/
 @[to_additive
 "The **Cauchy-Davenport theorem** for torsion-free groups. The size of `s + t` is lower-bounded
 by `|s| + |t| - 1`."]
-lemma cauchy_davenport_of_isMulTorsionFree [DecidableEq G] [CommGroup G] [IsMulTorsionFree G]
+lemma cauchy_davenport_of_isMulTorsionFree [DecidableEq G] [Group G] [IsMulTorsionFree G]
     {s t : Finset G} (hs : s.Nonempty) (ht : t.Nonempty) : #s + #t - 1 ≤ #(s * t) := by
   simpa only [Monoid.minOrder_eq_top, min_eq_right, le_top, Nat.cast_le]
     using cauchy_davenport_minOrder_mul hs ht

--- a/Mathlib/GroupTheory/Order/Min.lean
+++ b/Mathlib/GroupTheory/Order/Min.lean
@@ -47,11 +47,11 @@ lemma minOrder_le_orderOf (ha : a ≠ 1) (ha' : IsOfFinOrder a) : minOrder α �
 end Monoid
 
 section Group
-variable [Group α] {s : Subgroup α}
+variable [Group G] {s : Subgroup G}
 
 @[to_additive]
 lemma le_minOrder_iff_forall_subgroup {n : ℕ∞} :
-    n ≤ minOrder α ↔ ∀ ⦃s : Subgroup α⦄, s ≠ ⊥ → (s : Set α).Finite → n ≤ Nat.card s := by
+    n ≤ minOrder G ↔ ∀ ⦃s : Subgroup G⦄, s ≠ ⊥ → (s : Set G).Finite → n ≤ Nat.card s := by
   rw [le_minOrder]
   refine ⟨fun h s hs hs' ↦ ?_, fun h a ha ha' ↦ ?_⟩
   · obtain ⟨a, has, ha⟩ := s.bot_or_exists_ne_one.resolve_left hs
@@ -61,8 +61,12 @@ lemma le_minOrder_iff_forall_subgroup {n : ℕ∞} :
   · simpa using h (zpowers_ne_bot.2 ha) ha'.finite_zpowers
 
 @[to_additive]
-lemma minOrder_le_natCard (hs : s ≠ ⊥) (hs' : (s : Set α).Finite) : minOrder α ≤ Nat.card s :=
+lemma minOrder_le_natCard (hs : s ≠ ⊥) (hs' : (s : Set G).Finite) : minOrder G ≤ Nat.card s :=
   le_minOrder_iff_forall_subgroup.1 le_rfl hs hs'
+
+@[to_additive (attr := simp)]
+lemma minOrder_eq_top [IsMulTorsionFree G] : minOrder G = ⊤ := by
+  simpa [minOrder] using fun _ ↦ not_isOfFinOrder_of_isMulTorsionFree
 
 end Group
 
@@ -72,9 +76,6 @@ variable [CommGroup G] {s : Subgroup G}
 @[to_additive (attr := simp)]
 lemma minOrder_eq_top_iff : minOrder G = ⊤ ↔ IsMulTorsionFree G := by
   simp [minOrder, isMulTorsionFree_iff_not_isOfFinOrder]
-
-@[to_additive (attr := simp)]
-lemma minOrder_eq_top [IsMulTorsionFree G] : minOrder G = ⊤ := minOrder_eq_top_iff.2 ‹_›
 
 end CommGroup
 end Monoid

--- a/Mathlib/GroupTheory/Order/Min.lean
+++ b/Mathlib/GroupTheory/Order/Min.lean
@@ -3,8 +3,9 @@ Copyright (c) 2023 Yaël Dillies. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies
 -/
-import Mathlib.GroupTheory.Torsion
+import Mathlib.Algebra.Group.Torsion
 import Mathlib.Data.ENat.Lattice
+import Mathlib.Data.ZMod.QuotientGroup
 
 /-!
 # Minimum order of an element
@@ -20,7 +21,7 @@ This file defines the minimum order of an element of a monoid.
 
 open Subgroup
 
-variable {α : Type*}
+variable {G α : Type*}
 
 namespace Monoid
 section Monoid
@@ -36,11 +37,6 @@ noncomputable def minOrder : ℕ∞ := ⨅ (a : α) (_ha : a ≠ 1) (_ha' : IsOf
 variable {α} {a : α}
 
 @[to_additive (attr := simp)]
-lemma minOrder_eq_top : minOrder α = ⊤ ↔ IsTorsionFree α := by simp [minOrder, IsTorsionFree]
-
-@[to_additive (attr := simp)] protected alias ⟨_, IsTorsionFree.minOrder⟩ := minOrder_eq_top
-
-@[to_additive (attr := simp)]
 lemma le_minOrder {n : ℕ∞} :
     n ≤ minOrder α ↔ ∀ ⦃a : α⦄, a ≠ 1 → IsOfFinOrder a → n ≤ orderOf a := by simp [minOrder]
 
@@ -50,6 +46,7 @@ lemma minOrder_le_orderOf (ha : a ≠ 1) (ha' : IsOfFinOrder a) : minOrder α �
 
 end Monoid
 
+section Group
 variable [Group α] {s : Subgroup α}
 
 @[to_additive]
@@ -67,6 +64,19 @@ lemma le_minOrder_iff_forall_subgroup {n : ℕ∞} :
 lemma minOrder_le_natCard (hs : s ≠ ⊥) (hs' : (s : Set α).Finite) : minOrder α ≤ Nat.card s :=
   le_minOrder_iff_forall_subgroup.1 le_rfl hs hs'
 
+end Group
+
+section CommGroup
+variable [CommGroup G] {s : Subgroup G}
+
+@[to_additive (attr := simp)]
+lemma minOrder_eq_top_iff : minOrder G = ⊤ ↔ IsMulTorsionFree G := by
+  simp [minOrder, isMulTorsionFree_iff_not_isOfFinOrder]
+
+@[to_additive (attr := simp)]
+lemma minOrder_eq_top [IsMulTorsionFree G] : minOrder G = ⊤ := minOrder_eq_top_iff.2 ‹_›
+
+end CommGroup
 end Monoid
 
 open AddMonoid AddSubgroup Nat Set

--- a/Mathlib/GroupTheory/Torsion.lean
+++ b/Mathlib/GroupTheory/Torsion.lean
@@ -332,19 +332,26 @@ Please use `IsAddTorsionFree` instead. "]
 def IsTorsionFree :=
   ∀ g : G, g ≠ 1 → ¬IsOfFinOrder g
 
+attribute [deprecated IsMulTorsionFree (since := "2025-04-23")] Monoid.IsTorsionFree
+attribute [deprecated IsAddTorsionFree (since := "2025-04-23")] AddMonoid.IsTorsionFree
+
 variable {G}
 
+set_option linter.deprecated false in
 /-- A nontrivial monoid is not torsion-free if any nontrivial element has finite order. -/
-@[to_additive (attr := simp) "An additive monoid is not torsion free if any
-  nontrivial element has finite order."]
+@[to_additive (attr := deprecated not_isMulTorsionFree_iff_isOfFinOrder (since := "2025-04-23"))
+"An additive monoid is not torsion free if any nontrivial element has finite order."]
 theorem not_isTorsionFree_iff : ¬IsTorsionFree G ↔ ∃ g : G, g ≠ 1 ∧ IsOfFinOrder g := by
   simp_rw [IsTorsionFree, Ne, not_forall, Classical.not_not, exists_prop]
 
-@[to_additive (attr := simp)]
+set_option linter.deprecated false in
+@[to_additive (attr := deprecated IsMulTorsionFree.of_subsingleton (since := "2025-04-23"))]
 lemma isTorsionFree_of_subsingleton [Subsingleton G] : IsTorsionFree G :=
   fun _a ha _ => ha <| Subsingleton.elim _ _
 
-@[to_additive]
+set_option linter.deprecated false in
+@[to_additive
+  (attr := deprecated CommGroup.isMulTorsionFree_iff_torsion_eq_bot (since := "2025-04-23"))]
 lemma isTorsionFree_iff_torsion_eq_bot {G} [CommGroup G] :
     IsTorsionFree G ↔ CommGroup.torsion G = ⊥ := by
   rw [IsTorsionFree, eq_bot_iff, SetLike.le_def]
@@ -355,27 +362,35 @@ end Monoid
 section Group
 variable [Group G]
 
+set_option linter.deprecated false in
 /-- A nontrivial torsion group is not torsion-free. -/
-@[to_additive "A nontrivial additive torsion group is not torsion-free."]
+@[to_additive (attr := deprecated not_isMulTorsionFree_of_isTorsion (since := "2025-04-23"))
+"A nontrivial additive torsion group is not torsion-free."]
 theorem IsTorsion.not_torsion_free [hN : Nontrivial G] : IsTorsion G → ¬IsTorsionFree G := fun tG =>
   not_isTorsionFree_iff.mpr <| by
     obtain ⟨x, hx⟩ := (nontrivial_iff_exists_ne (1 : G)).mp hN
     exact ⟨x, hx, tG x⟩
 
+set_option linter.deprecated false in
 /-- A nontrivial torsion-free group is not torsion. -/
-@[to_additive "A nontrivial torsion-free additive group is not torsion."]
+@[to_additive (attr := deprecated not_isTorsion_of_isMulTorsionFree (since := "2025-04-23"))
+"A nontrivial torsion-free additive group is not torsion."]
 theorem IsTorsionFree.not_torsion [hN : Nontrivial G] : IsTorsionFree G → ¬IsTorsion G := fun tfG =>
   (not_isTorsion_iff _).mpr <| by
     obtain ⟨x, hx⟩ := (nontrivial_iff_exists_ne (1 : G)).mp hN
     exact ⟨x, (tfG x) hx⟩
 
+set_option linter.deprecated false in
 /-- Subgroups of torsion-free groups are torsion-free. -/
-@[to_additive "Subgroups of additive torsion-free groups are additively torsion-free."]
+@[to_additive (attr := deprecated Subgroup.instIsMulTorsionFree (since := "2025-04-23"))
+"Subgroups of additive torsion-free groups are additively torsion-free."]
 theorem IsTorsionFree.subgroup (tG : IsTorsionFree G) (H : Subgroup G) : IsTorsionFree H :=
   fun h hne ↦ Submonoid.isOfFinOrder_coe.not.1 <| tG h <| by norm_cast
 
+set_option linter.deprecated false in
 /-- Direct products of torsion free groups are torsion free. -/
-@[to_additive AddMonoid.IsTorsionFree.prod
+@[to_additive (attr := deprecated Pi.instIsMulTorsionFree (since := "2025-04-23"))
+  AddMonoid.IsTorsionFree.prod
       "Direct products of additive torsion free groups are torsion free."]
 theorem IsTorsionFree.prod {η : Type*} {Gs : η → Type*} [∀ i, Group (Gs i)]
     (tfGs : ∀ i, IsTorsionFree (Gs i)) : IsTorsionFree <| ∀ i, Gs i := fun w hne h =>
@@ -406,6 +421,19 @@ instance _root_.QuotientGroup.instIsMulTorsionFree : IsMulTorsionFree <| G ⧸ t
 /-- Quotienting a group by its torsion subgroup yields a torsion free group. -/
 @[to_additive
 "Quotienting a group by its additive torsion subgroup yields an additive torsion free group."]
+theorem _root_.QuotientGroup.instIsMulTorsionFree : IsMulTorsionFree <| G ⧸ torsion G := by
+  refine .of_not_isOfFinOrder fun g hne hfin ↦ hne ?_
+  induction' g using QuotientGroup.induction_on with g
+  obtain ⟨m, mpos, hm⟩ := hfin.exists_pow_eq_one
+  obtain ⟨n, npos, hn⟩ := ((QuotientGroup.eq_one_iff _).mp hm).exists_pow_eq_one
+  exact (QuotientGroup.eq_one_iff g).mpr
+    (isOfFinOrder_iff_pow_eq_one.mpr ⟨m * n, mul_pos mpos npos, (pow_mul g m n).symm ▸ hn⟩)
+
+set_option linter.deprecated false in
+/-- Quotienting a group by its torsion subgroup yields a torsion free group. -/
+@[to_additive
+  (attr := deprecated QuotientGroup.instIsMulTorsionFree (since := "2025-04-23"))
+"Quotienting a group by its additive torsion subgroup yields an additive torsion free group."]
 theorem IsTorsionFree.quotient_torsion : IsTorsionFree <| G ⧸ torsion G := fun g hne hfin =>
   hne <| by
     induction' g using QuotientGroup.induction_on with g
@@ -420,22 +448,30 @@ end Monoid
 
 namespace AddMonoid
 
+set_option linter.deprecated false in
+@[deprecated noZeroSMulDivisors_nat_iff_isAddTorsionFree (since := "2025-04-23")]
 lemma isTorsionFree_iff_noZeroSMulDivisors_nat {M : Type*} [AddMonoid M] :
     IsTorsionFree M ↔ NoZeroSMulDivisors ℕ M := by
   simp_rw [AddMonoid.IsTorsionFree, isOfFinAddOrder_iff_nsmul_eq_zero, not_exists, not_and,
     pos_iff_ne_zero, noZeroSMulDivisors_iff, forall_swap (β := ℕ)]
   exact forall₂_congr fun _ _ ↦ by tauto
 
+set_option linter.deprecated false in
+@[deprecated noZeroSMulDivisors_int_iff_isAddTorsionFree (since := "2025-04-23")]
 lemma isTorsionFree_iff_noZeroSMulDivisors_int [SubtractionMonoid G] :
     IsTorsionFree G ↔ NoZeroSMulDivisors ℤ G := by
   simp_rw [AddMonoid.IsTorsionFree, isOfFinAddOrder_iff_zsmul_eq_zero, not_exists, not_and,
     noZeroSMulDivisors_iff, forall_swap (β := ℤ)]
   exact forall₂_congr fun _ _ ↦ by tauto
 
+set_option linter.deprecated false in
+@[deprecated IsAddTorsionFree.of_noZeroSMulDivisors_nat (since := "2025-04-23")]
 lemma IsTorsionFree.of_noZeroSMulDivisors {M : Type*} [AddMonoid M] [NoZeroSMulDivisors ℕ M] :
     IsTorsionFree M := isTorsionFree_iff_noZeroSMulDivisors_nat.2 ‹_›
 
+@[deprecated IsAddTorsionFree.to_noZeroSMulDivisors_nat (since := "2025-04-23")]
 alias ⟨IsTorsionFree.noZeroSMulDivisors_nat, _⟩ := isTorsionFree_iff_noZeroSMulDivisors_nat
+@[deprecated IsAddTorsionFree.to_noZeroSMulDivisors_int (since := "2025-04-23")]
 alias ⟨IsTorsionFree.noZeroSMulDivisors_int, _⟩ := isTorsionFree_iff_noZeroSMulDivisors_int
 
 end AddMonoid

--- a/Mathlib/GroupTheory/Torsion.lean
+++ b/Mathlib/GroupTheory/Torsion.lean
@@ -345,7 +345,7 @@ theorem not_isTorsionFree_iff : ¬IsTorsionFree G ↔ ∃ g : G, g ≠ 1 ∧ IsO
   simp_rw [IsTorsionFree, Ne, not_forall, Classical.not_not, exists_prop]
 
 set_option linter.deprecated false in
-@[to_additive (attr := deprecated IsMulTorsionFree.of_subsingleton (since := "2025-04-23"))]
+@[to_additive (attr := deprecated Subsingleton.to_isMulTorsionFree (since := "2025-04-23"))]
 lemma isTorsionFree_of_subsingleton [Subsingleton G] : IsTorsionFree G :=
   fun _a ha _ => ha <| Subsingleton.elim _ _
 
@@ -411,17 +411,6 @@ variable (G) [CommGroup G]
 @[to_additive
 "Quotienting a group by its additive torsion subgroup yields an additive torsion-free group."]
 instance _root_.QuotientGroup.instIsMulTorsionFree : IsMulTorsionFree <| G ⧸ torsion G := by
-  refine .of_not_isOfFinOrder fun g hne hfin ↦ hne ?_
-  induction' g using QuotientGroup.induction_on with g
-  obtain ⟨m, mpos, hm⟩ := hfin.exists_pow_eq_one
-  obtain ⟨n, npos, hn⟩ := ((QuotientGroup.eq_one_iff _).mp hm).exists_pow_eq_one
-  exact (QuotientGroup.eq_one_iff g).mpr
-    (isOfFinOrder_iff_pow_eq_one.mpr ⟨m * n, mul_pos mpos npos, (pow_mul g m n).symm ▸ hn⟩)
-
-/-- Quotienting a group by its torsion subgroup yields a torsion free group. -/
-@[to_additive
-"Quotienting a group by its additive torsion subgroup yields an additive torsion free group."]
-theorem _root_.QuotientGroup.instIsMulTorsionFree : IsMulTorsionFree <| G ⧸ torsion G := by
   refine .of_not_isOfFinOrder fun g hne hfin ↦ hne ?_
   induction' g using QuotientGroup.induction_on with g
   obtain ⟨m, mpos, hm⟩ := hfin.exists_pow_eq_one

--- a/Mathlib/Topology/Instances/ZMultiples.lean
+++ b/Mathlib/Topology/Instances/ZMultiples.lean
@@ -3,6 +3,7 @@ Copyright (c) 2017 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Mario Carneiro
 -/
+import Mathlib.Algebra.Group.Subgroup.ZPowers.Lemmas
 import Mathlib.Algebra.Module.Submodule.Lattice
 import Mathlib.Topology.Algebra.IsUniformGroup.Basic
 import Mathlib.Topology.Algebra.Ring.Real


### PR DESCRIPTION
From Toric

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->
- [x] depends on: #24312

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
