### PR TITLE
[Merged by Bors] - feat: more lemmas about torsion-free monoids

### DIFF
--- a/Mathlib/Algebra/Group/Pi/Lemmas.lean
+++ b/Mathlib/Algebra/Group/Pi/Lemmas.lean
@@ -36,11 +36,11 @@ theorem Set.preimage_one {α β : Type*} [One β] (s : Set β) [Decidable ((1 : 
     (1 : α → β) ⁻¹' s = if (1 : β) ∈ s then Set.univ else ∅ :=
   Set.preimage_const 1 s
 
-instance Pi.instIsMulTorsionFree [∀ i, Monoid (M i)] [∀ i, IsMulTorsionFree (M i)] :
+namespace Pi
+
+instance instIsMulTorsionFree [∀ i, Monoid (M i)] [∀ i, IsMulTorsionFree (M i)] :
     IsMulTorsionFree (∀ i, M i) where
   pow_left_injective n hn a b hab := by ext i; exact pow_left_injective hn <| congr_fun hab i
-
-namespace Pi
 
 variable {α β : Type*} [Preorder α] [Preorder β]
 

--- a/Mathlib/Algebra/Group/Pi/Lemmas.lean
+++ b/Mathlib/Algebra/Group/Pi/Lemmas.lean
@@ -6,6 +6,7 @@ Authors: Simon Hudon, Patrick Massot
 import Mathlib.Algebra.Group.Commute.Defs
 import Mathlib.Algebra.Group.Hom.Instances
 import Mathlib.Algebra.Group.Pi.Basic
+import Mathlib.Algebra.Group.Torsion
 import Mathlib.Data.Set.Piecewise
 import Mathlib.Logic.Pairwise
 
@@ -22,9 +23,7 @@ universe u v w
 
 variable {ι α : Type*}
 variable {I : Type u}
-
--- The indexing type
-variable {f : I → Type v}
+variable {f : I → Type v} {M : ι → Type*}
 
 variable (i : I)
 
@@ -36,6 +35,10 @@ theorem Set.range_one {α β : Type*} [One β] [Nonempty α] : Set.range (1 : α
 theorem Set.preimage_one {α β : Type*} [One β] (s : Set β) [Decidable ((1 : β) ∈ s)] :
     (1 : α → β) ⁻¹' s = if (1 : β) ∈ s then Set.univ else ∅ :=
   Set.preimage_const 1 s
+
+instance Pi.instIsMulTorsionFree [∀ i, Monoid (M i)] [∀ i, IsMulTorsionFree (M i)] :
+    IsMulTorsionFree (∀ i, M i) where
+  pow_left_injective n hn a b hab := by ext i; exact pow_left_injective hn <| congr_fun hab i
 
 namespace Pi
 

--- a/Mathlib/Algebra/Group/Prod.lean
+++ b/Mathlib/Algebra/Group/Prod.lean
@@ -7,9 +7,11 @@ import Mathlib.Algebra.Group.Equiv.Defs
 import Mathlib.Algebra.Group.Hom.Basic
 import Mathlib.Algebra.Group.Opposite
 import Mathlib.Algebra.Group.Pi.Basic
+import Mathlib.Algebra.Group.Torsion
 import Mathlib.Algebra.Group.Units.Hom
 import Mathlib.Algebra.Notation.Prod
 import Mathlib.Logic.Equiv.Prod
+import Mathlib.Tactic.TermCongr
 
 /-!
 # Monoid, group etc structures on `M × N`
@@ -80,6 +82,11 @@ instance instMonoid [Monoid M] [Monoid N] : Monoid (M × N) :=
     npow_succ := fun _ _ => Prod.ext (Monoid.npow_succ _ _) (Monoid.npow_succ _ _),
     one_mul := by simp,
     mul_one := by simp }
+
+instance instIsMulTorsionFree [Monoid M] [Monoid N] [IsMulTorsionFree M] [IsMulTorsionFree N] :
+    IsMulTorsionFree (M × N) where
+  pow_left_injective n hn a b hab := by
+    ext <;> apply pow_left_injective hn; exacts [congr(($hab).1), congr(($hab).2)]
 
 @[to_additive Prod.subNegMonoid]
 instance [DivInvMonoid G] [DivInvMonoid H] : DivInvMonoid (G × H) where

--- a/Mathlib/Algebra/Group/Subgroup/Basic.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Basic.lean
@@ -6,6 +6,7 @@ Authors: Kexing Ying
 import Mathlib.Algebra.Group.Conj
 import Mathlib.Algebra.Group.Pi.Lemmas
 import Mathlib.Algebra.Group.Subgroup.Ker
+import Mathlib.Algebra.Group.Torsion
 
 /-!
 # Basic results on subgroups
@@ -247,6 +248,12 @@ theorem pi_eq_bot_iff (H : ∀ i, Subgroup (f i)) : pi Set.univ H = ⊥ ↔ ∀ 
     · exact fun h x hx => funext fun i => h _ _ (hx i trivial)
 
 end Pi
+
+instance instIsMulTorsionFree [IsMulTorsionFree G] : IsMulTorsionFree H where
+  pow_left_injective n hn a b := by
+    have := pow_left_injective hn (M := G) (a₁ := a) (a₂ := b)
+    dsimp at *
+    norm_cast at this
 
 end Subgroup
 

--- a/Mathlib/Algebra/Group/Torsion.lean
+++ b/Mathlib/Algebra/Group/Torsion.lean
@@ -42,6 +42,9 @@ class IsMulTorsionFree where
 
 attribute [to_additive existing] isMulTorsionFree_iff
 
+@[to_additive] instance Subsingleton.to_isMulTorsionFree [Subsingleton M] : IsMulTorsionFree M where
+  pow_left_injective _ _ := injective_of_subsingleton _
+
 variable [IsMulTorsionFree M] {n : ℕ} {a b : M}
 
 @[to_additive nsmul_right_injective]

--- a/Mathlib/Algebra/Lie/Weights/Chain.lean
+++ b/Mathlib/Algebra/Lie/Weights/Chain.lean
@@ -5,8 +5,6 @@ Authors: Oliver Nash
 -/
 import Mathlib.Algebra.DirectSum.LinearMap
 import Mathlib.Algebra.Lie.Weights.Cartan
-import Mathlib.Data.Int.Interval
-import Mathlib.LinearAlgebra.Trace
 import Mathlib.RingTheory.Finiteness.Nilpotent
 
 /-!

--- a/Mathlib/Algebra/NoZeroSMulDivisors/Defs.lean
+++ b/Mathlib/Algebra/NoZeroSMulDivisors/Defs.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Anne Baanen, Yury Kudryashov, Joseph Myers, Heather Macbeth, Kim Morrison, Yaël Dillies
 -/
 import Mathlib.Algebra.GroupWithZero.Action.Defs
+import Mathlib.Algebra.Group.Torsion
 
 /-!
 # `NoZeroSMulDivisors`
@@ -14,13 +15,7 @@ for the vanishing of elements (especially in modules over division rings).
 
 assert_not_exists RelIso Multiset Set.indicator Pi.single_smul₀ Ring Module
 
-section NoZeroSMulDivisors
-
-/-! ### `NoZeroSMulDivisors`
-
--/
-
-variable {R M : Type*}
+variable {R M G : Type*}
 
 /-- `NoZeroSMulDivisors R M` states that a scalar multiple is `0` only if either argument is `0`.
 This is a version of saying that `M` is torsion free, without assuming `R` is zero-divisor free.
@@ -71,4 +66,33 @@ lemma smul_ne_zero_iff_right (hc : c ≠ 0) : c • x ≠ 0 ↔ x ≠ 0 := by si
 
 end SMulWithZero
 
-end NoZeroSMulDivisors
+instance IsAddTorsionFree.to_noZeroSMulDivisors_nat [AddMonoid M] [IsAddTorsionFree M] :
+    NoZeroSMulDivisors ℕ M where
+  eq_zero_or_eq_zero_of_smul_eq_zero {n x} hx := by
+    contrapose! hx; simpa using (nsmul_right_injective hx.1).ne hx.2
+
+instance IsAddTorsionFree.to_noZeroSMulDivisors_int [AddGroup G] [IsAddTorsionFree G] :
+    NoZeroSMulDivisors ℤ G where
+  eq_zero_or_eq_zero_of_smul_eq_zero {n x} hx := by
+    contrapose! hx; simpa using (zsmul_right_injective hx.1).ne hx.2
+
+@[simp]
+lemma noZeroSMulDivisors_nat_iff_isAddTorsionFree [AddCommGroup G] :
+    NoZeroSMulDivisors ℕ G ↔ IsAddTorsionFree G where
+  mp _ := by
+    refine ⟨fun n hn a b hab ↦ ?_⟩
+    simp only [← sub_eq_zero (a := n • a), ← nsmul_sub] at hab
+    simpa [sub_eq_zero] using (smul_eq_zero_iff_right hn).1 hab
+  mpr _ := inferInstance
+
+@[simp]
+lemma noZeroSMulDivisors_int_iff_isAddTorsionFree [AddCommGroup G] :
+    NoZeroSMulDivisors ℤ G ↔ IsAddTorsionFree G where
+  mp _ := by
+    refine ⟨fun n hn a b hab ↦ ?_⟩
+    simp only [← sub_eq_zero (a := (n : ℤ) • a), ← zsmul_sub, ← natCast_zsmul] at hab
+    simpa [sub_eq_zero] using (smul_eq_zero_iff_right <| Int.natCast_ne_zero.2 hn).1 hab
+  mpr _ := inferInstance
+
+alias ⟨IsAddTorsionFree.of_noZeroSMulDivisors_nat, _⟩ := noZeroSMulDivisors_nat_iff_isAddTorsionFree
+alias ⟨IsAddTorsionFree.of_noZeroSMulDivisors_int, _⟩ := noZeroSMulDivisors_int_iff_isAddTorsionFree

--- a/Mathlib/GroupTheory/OrderOfElement.lean
+++ b/Mathlib/GroupTheory/OrderOfElement.lean
@@ -122,6 +122,13 @@ lemma isOfFinOrder_pow {n : ℕ} : IsOfFinOrder (a ^ n) ↔ IsOfFinOrder a ∨ n
   · simp
   · exact ⟨fun h ↦ .inl <| h.of_pow hn, fun h ↦ (h.resolve_right hn).pow⟩
 
+@[to_additive]
+lemma not_isOfFinOrder_of_isMulTorsionFree [IsMulTorsionFree G] (ha : a ≠ 1) :
+    ¬ IsOfFinOrder a := by
+  rw [isOfFinOrder_iff_pow_eq_one]
+  rintro ⟨n, hn, han⟩
+  exact ha <| pow_left_injective hn.ne' <| by simpa using han
+
 /-- Elements of finite order are of finite order in submonoids. -/
 @[to_additive "Elements of finite order are of finite order in submonoids."]
 theorem Submonoid.isOfFinOrder_coe {H : Submonoid G} {x : H} :
@@ -710,6 +717,29 @@ theorem IsOfFinOrder.mul (hx : IsOfFinOrder x) (hy : IsOfFinOrder y) : IsOfFinOr
   (Commute.all x y).isOfFinOrder_mul hx hy
 
 end CommMonoid
+
+section CommGroup
+variable [CommGroup G]
+
+@[to_additive]
+lemma isMulTorsionFree_iff_not_isOfFinOrder :
+    IsMulTorsionFree G ↔ ∀ ⦃a : G⦄, a ≠ 1 → ¬ IsOfFinOrder a where
+  mp _ _ := not_isOfFinOrder_of_isMulTorsionFree
+  mpr hG := by
+    refine ⟨fun n hn a b hab ↦ ?_⟩
+    rw [← div_eq_one] at hab ⊢
+    simp only [← div_pow, isOfFinOrder_iff_pow_eq_one] at hab hG
+    exact of_not_not fun hab' ↦ hG hab' ⟨n, hn.bot_lt, hab⟩
+
+@[to_additive]
+alias ⟨_, IsMulTorsionFree.of_not_isOfFinOrder⟩ := isMulTorsionFree_iff_not_isOfFinOrder
+
+@[to_additive]
+lemma not_isMulTorsionFree_iff_isOfFinOrder :
+    ¬ IsMulTorsionFree G ↔ ∃ a ≠ (1 : G), IsOfFinOrder a := by
+  simp [isMulTorsionFree_iff_not_isOfFinOrder]
+
+end CommGroup
 
 section FiniteMonoid
 

--- a/Mathlib/GroupTheory/Torsion.lean
+++ b/Mathlib/GroupTheory/Torsion.lean
@@ -132,7 +132,7 @@ variable [CommGroup G]
 
 /-- A nontrivial torsion abelian group is not torsion-free. -/
 @[to_additive "A nontrivial additive torsion abelian group is not torsion-free."]
-lemma not_isMulTorsionFree_of_isTorsion [Nontrivial G] (hG : IsTorsion G) : ¬IsMulTorsionFree G :=
+lemma not_isMulTorsionFree_of_isTorsion [Nontrivial G] (hG : IsTorsion G) : ¬ IsMulTorsionFree G :=
   not_isMulTorsionFree_iff_isOfFinOrder.2 <| let ⟨x, hx⟩ := exists_ne (1 : G); ⟨x, hx, hG x⟩
 
 /-- A nontrivial torsion-free abelian group is not torsion. -/

--- a/Mathlib/GroupTheory/Torsion.lean
+++ b/Mathlib/GroupTheory/Torsion.lean
@@ -127,6 +127,21 @@ theorem isTorsion_of_finite [Finite G] : IsTorsion G :=
 
 end Group
 
+section CommGroup
+variable [CommGroup G]
+
+/-- A nontrivial torsion abelian group is not torsion-free. -/
+@[to_additive "A nontrivial additive torsion abelian group is not torsion-free."]
+lemma not_isMulTorsionFree_of_isTorsion [Nontrivial G] (hG : IsTorsion G) : ¬IsMulTorsionFree G :=
+  not_isMulTorsionFree_iff_isOfFinOrder.2 <| let ⟨x, hx⟩ := exists_ne (1 : G); ⟨x, hx, hG x⟩
+
+/-- A nontrivial torsion-free abelian group is not torsion. -/
+@[to_additive "A nontrivial additive torsion-free abelian group is not torsion."]
+lemma not_isTorsion_of_isMulTorsionFree [Nontrivial G] [IsMulTorsionFree G] : ¬ IsTorsion G :=
+  (not_isMulTorsionFree_of_isTorsion · ‹_›)
+
+end CommGroup
+
 section Module
 
 -- A (semi/)ring of scalars and a commutative monoid of elements
@@ -276,6 +291,11 @@ theorem torsion_eq_torsion_submonoid : CommMonoid.torsion G = (torsion G).toSubm
 @[to_additive]
 theorem mem_torsion (g : G) : g ∈ torsion G ↔ IsOfFinOrder g := Iff.rfl
 
+@[to_additive]
+lemma isMulTorsionFree_iff_torsion_eq_bot : IsMulTorsionFree G ↔ CommGroup.torsion G = ⊥ := by
+  rw [isMulTorsionFree_iff_not_isOfFinOrder, eq_bot_iff, SetLike.le_def]
+  simp [not_imp_not, CommGroup.mem_torsion]
+
 variable (p : ℕ) [hp : Fact p.Prime]
 
 /-- The `p`-primary component is the subgroup of elements with order prime-power of `p`. -/
@@ -371,6 +391,17 @@ open Monoid (IsTorsionFree)
 open CommGroup (torsion)
 
 variable (G) [CommGroup G]
+
+/-- Quotienting a group by its torsion subgroup yields a torsion-free group. -/
+@[to_additive
+"Quotienting a group by its additive torsion subgroup yields an additive torsion-free group."]
+instance _root_.QuotientGroup.instIsMulTorsionFree : IsMulTorsionFree <| G ⧸ torsion G := by
+  refine .of_not_isOfFinOrder fun g hne hfin ↦ hne ?_
+  induction' g using QuotientGroup.induction_on with g
+  obtain ⟨m, mpos, hm⟩ := hfin.exists_pow_eq_one
+  obtain ⟨n, npos, hn⟩ := ((QuotientGroup.eq_one_iff _).mp hm).exists_pow_eq_one
+  exact (QuotientGroup.eq_one_iff g).mpr
+    (isOfFinOrder_iff_pow_eq_one.mpr ⟨m * n, mul_pos mpos npos, (pow_mul g m n).symm ▸ hn⟩)
 
 /-- Quotienting a group by its torsion subgroup yields a torsion free group. -/
 @[to_additive

--- a/Mathlib/Topology/Instances/ZMultiples.lean
+++ b/Mathlib/Topology/Instances/ZMultiples.lean
@@ -3,12 +3,9 @@ Copyright (c) 2017 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Mario Carneiro
 -/
-import Mathlib.Algebra.Algebra.Rat
-import Mathlib.Algebra.Group.Subgroup.ZPowers.Lemmas
-import Mathlib.Algebra.Module.Rat
 import Mathlib.Algebra.Module.Submodule.Lattice
-import Mathlib.Topology.Algebra.Ring.Real
 import Mathlib.Topology.Algebra.IsUniformGroup.Basic
+import Mathlib.Topology.Algebra.Ring.Real
 import Mathlib.Topology.Metrizable.Basic
 
 /-!


### PR DESCRIPTION
The new imports just come from making `#min_imports` and `mk_iff` available earlier.

From Toric


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
