### PR TITLE
[Merged by Bors] - chore(RingTheory/DedekindDomain): fix namespace inconsistency

### DIFF
--- a/Mathlib/NumberTheory/NumberField/AdeleRing.lean
+++ b/Mathlib/NumberTheory/NumberField/AdeleRing.lean
@@ -37,7 +37,7 @@ noncomputable section
 
 namespace NumberField
 
-open InfinitePlace AbsoluteValue.Completion InfinitePlace.Completion DedekindDomain IsDedekindDomain
+open InfinitePlace AbsoluteValue.Completion InfinitePlace.Completion IsDedekindDomain
 
 /-! ## The infinite adele ring
 

--- a/Mathlib/RingTheory/DedekindDomain/FiniteAdeleRing.lean
+++ b/Mathlib/RingTheory/DedekindDomain/FiniteAdeleRing.lean
@@ -65,15 +65,11 @@ end IsDedekindDomain
 
 noncomputable section
 
-open Function Set IsDedekindDomain IsDedekindDomain.HeightOneSpectrum
+open Function Set IsDedekindDomain.HeightOneSpectrum
 
-variable (R : Type*) [CommRing R] [IsDedekindDomain R] {K : Type*}
-    [Field K] [Algebra R K] [IsFractionRing R K]
+namespace IsDedekindDomain
 
-namespace DedekindDomain
-
-variable (R K : Type*) [CommRing R] [IsDedekindDomain R] [Field K] [Algebra R K]
-  [IsFractionRing R K] (v : HeightOneSpectrum R)
+variable (K)
 
 open scoped RestrictedProduct
 
@@ -128,12 +124,7 @@ instance : DFunLike (FiniteAdeleRing R K) (HeightOneSpectrum R) (adicCompletion 
   coe a := a.1
   coe_injective' _a _b h := ext K (congrFun h)
 
-open scoped algebraMap -- coercion from R to `FiniteAdeleRing R K`
-
 section Topology
-
-open nonZeroDivisors
-open scoped Multiplicative
 
 instance : IsTopologicalRing (FiniteAdeleRing R K) :=
     haveI : Fact (∀ (v : HeightOneSpectrum R),
@@ -145,4 +136,4 @@ end Topology
 
 end FiniteAdeleRing
 
-end DedekindDomain
+end IsDedekindDomain


### PR DESCRIPTION
We have some lemmas in the namespace `IsDedekindDomain` and others in `DedekindDomain`. Standardize on the `Is` version (and remove some redundant variable re-declarations).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

(I'm guessing the namespace got renamed at some point to add the `Is` prefix, but the change didn't get propagated to  some PR's that were in progress at the time of the rename.)

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
