### PR TITLE
[Merged by Bors] - feat: pull `Function.update` through recursors

### DIFF
--- a/Mathlib/Data/Option/Basic.lean
+++ b/Mathlib/Data/Option/Basic.lean
@@ -328,4 +328,14 @@ lemma eq_none_iff_forall_some_ne {o : Option α} : o = none ↔ ∀ a : α, some
 
 @[deprecated (since := "2025-03-19")] alias forall_some_ne_iff_eq_none := eq_none_iff_forall_some_ne
 
+open Function in
+@[simp]
+lemma _root_.Option.elim'_update {α : Type*} {β : Type*} [DecidableEq α]
+    (f : β) (g : α → β) (a : α) (x : β) :
+    Option.elim' f (update g a x) = update (Option.elim' f g) (.some a) x :=
+  -- Can't reuse `Option.rec_update` as `Option.elim'` is not defeq.
+  Function.rec_update (α := fun _ => β) (@Option.some.inj _) (Option.elim' f) (fun _ _ => rfl) (fun
+    | _, _, .some _, h => (h _ rfl).elim
+    | _, _, .none, _ => rfl) _ _ _
+
 end Option

--- a/Mathlib/Data/Option/Basic.lean
+++ b/Mathlib/Data/Option/Basic.lean
@@ -330,7 +330,7 @@ lemma eq_none_iff_forall_some_ne {o : Option α} : o = none ↔ ∀ a : α, some
 
 open Function in
 @[simp]
-lemma _root_.Option.elim'_update {α : Type*} {β : Type*} [DecidableEq α]
+lemma elim'_update {α : Type*} {β : Type*} [DecidableEq α]
     (f : β) (g : α → β) (a : α) (x : β) :
     Option.elim' f (update g a x) = update (Option.elim' f g) (.some a) x :=
   -- Can't reuse `Option.rec_update` as `Option.elim'` is not defeq.

--- a/Mathlib/Data/Sum/Basic.lean
+++ b/Mathlib/Data/Sum/Basic.lean
@@ -112,6 +112,34 @@ theorem update_inr_apply_inr [DecidableEq β] [DecidableEq (α ⊕ β)] {f : α 
   rw [← update_inr_comp_inr, Function.comp_apply]
 
 @[simp]
+lemma rec_update_left {γ : α ⊕ β → Sort*} [DecidableEq α] [DecidableEq β]
+    (f : ∀ a, γ (.inl a)) (g : ∀ b, γ (.inr b)) (a : α) (x : γ (.inl a)) :
+    Sum.rec (update f a x) g = update (Sum.rec f g) (.inl a) x :=
+  Function.rec_update Sum.inl_injective (Sum.rec · g) (fun _ _ => rfl) (fun
+    | _, _, .inl _, h => (h _ rfl).elim
+    | _, _, .inr _, _ => rfl) _ _ _
+
+@[simp]
+lemma rec_update_right {γ : α ⊕ β → Sort*} [DecidableEq α] [DecidableEq β]
+    (f : ∀ a, γ (.inl a)) (g : ∀ b, γ (.inr b)) (b : β) (x : γ (.inr b)) :
+    Sum.rec f (update g b x) = update (Sum.rec f g) (.inr b) x :=
+  Function.rec_update Sum.inr_injective (Sum.rec f) (fun _ _ => rfl) (fun
+    | _, _, .inr _, h => (h _ rfl).elim
+    | _, _, .inl _, _ => rfl) _ _ _
+
+@[simp]
+lemma elim_update_left {γ : Sort*} [DecidableEq α] [DecidableEq β]
+    (f : α → γ) (g : β → γ) (a : α) (x : γ) :
+    Sum.elim (update f a x) g = update (Sum.elim f g) (.inl a) x :=
+  rec_update_left _ _ _ _
+
+@[simp]
+lemma elim_update_right {γ : Sort*} [DecidableEq α] [DecidableEq β]
+    (f : α → γ) (g : β → γ) (b : β) (x : γ) :
+    Sum.elim f (update g b x) = update (Sum.elim f g) (.inr b) x :=
+  rec_update_right _ _ _ _
+
+@[simp]
 theorem swap_leftInverse : Function.LeftInverse (@swap α β) swap :=
   swap_swap
 
@@ -226,26 +254,6 @@ theorem map_surjective {f : α → γ} {g : β → δ} :
 theorem map_bijective {f : α → γ} {g : β → δ} :
     Bijective (Sum.map f g) ↔ Bijective f ∧ Bijective g :=
   (map_injective.and map_surjective).trans <| and_and_and_comm
-
-theorem elim_update_left [DecidableEq α] [DecidableEq β] (f : α → γ) (g : β → γ) (i : α) (c : γ) :
-    Sum.elim (Function.update f i c) g = Function.update (Sum.elim f g) (inl i) c := by
-  ext x
-  rcases x with x | x
-  · by_cases h : x = i
-    · subst h
-      simp
-    · simp [h]
-  · simp
-
-theorem elim_update_right [DecidableEq α] [DecidableEq β] (f : α → γ) (g : β → γ) (i : β) (c : γ) :
-    Sum.elim f (Function.update g i c) = Function.update (Sum.elim f g) (inr i) c := by
-  ext x
-  rcases x with x | x
-  · simp
-  · by_cases h : x = i
-    · subst h
-      simp
-    · simp [h]
 
 end Sum
 

--- a/Mathlib/Data/ULift.lean
+++ b/Mathlib/Data/ULift.lean
@@ -131,4 +131,11 @@ theorem «exists» {p : ULift α → Prop} : (∃ x, p x) ↔ ∃ x : α, p (ULi
 theorem ext (x y : ULift α) (h : x.down = y.down) : x = y :=
   congrArg up h
 
+@[simp]
+lemma rec_update {β : ULift α → Type*} [DecidableEq α]
+    (f : ∀ a, β (.up a)) (a : α) (x : β (.up a)) :
+    ULift.rec (update f a x) = update (ULift.rec f) (.up a) x :=
+  Function.rec_update up_injective (ULift.rec ·) (fun _ _ => rfl) (fun
+    | _, _, .up _, h => (h _ rfl).elim) _ _ _
+
 end ULift

--- a/Mathlib/Logic/Function/Basic.lean
+++ b/Mathlib/Logic/Function/Basic.lean
@@ -566,6 +566,10 @@ theorem update_comp_eq_of_injective {β : Sort*} (g : α' → β) {f : α → α
 
 /-- Recursors can be pushed inside `Function.update`.
 
+The `ctor` argument should be a one-argument constructor like `Sum.inl`,
+and `recursor` should be an inductive recursor partially applied in all but that constructor,
+such as `(Sum.rec · g)`.
+
 In future, we should build some automation to generate applications like `Option.rec_update` for all
 inductive types. -/
 lemma rec_update {ι κ : Sort*} {α : κ → Sort*} [DecidableEq ι] [DecidableEq κ]

--- a/Mathlib/Logic/Function/Basic.lean
+++ b/Mathlib/Logic/Function/Basic.lean
@@ -564,6 +564,36 @@ theorem update_comp_eq_of_injective {β : Sort*} (g : α' → β) {f : α → α
     Function.update g (f i) a ∘ f = Function.update (g ∘ f) i a :=
   update_comp_eq_of_injective' g hf i a
 
+/-- Recursors can be pushed inside `Function.update`.
+
+In future, we should build some automation to generate applications like `Option.rec_update` for all
+inductive types. -/
+lemma rec_update {ι κ : Sort*} {α : κ → Sort*} [DecidableEq ι] [DecidableEq κ]
+    {ctor : ι → κ} (hctor : Function.Injective ctor)
+    (recursor : ((i : ι) → α (ctor i)) → ((i : κ) → α i))
+    (h : ∀ f i, recursor f (ctor i) = f i)
+    (h2 : ∀ f₁ f₂ k, (∀ i, ctor i ≠ k) → recursor f₁ k = recursor f₂ k)
+    (f : (i : ι) → α (ctor i)) (i : ι) (x : α (ctor i)) :
+    recursor (update f i x) = update (recursor f) (ctor i) x := by
+  ext k
+  by_cases h : ∃ i, ctor i = k
+  · obtain ⟨i', rfl⟩ := h
+    obtain rfl | hi := eq_or_ne i' i
+    · simp [h]
+    · have hk := hctor.ne hi
+      simp [h, hi, hk, Function.update_of_ne]
+  · rw [not_exists] at h
+    rw [h2 _ f _ h]
+    rw [Function.update_of_ne (Ne.symm <| h i)]
+
+@[simp]
+lemma _root_.Option.rec_update {α : Type*} {β : Option α → Sort*} [DecidableEq α]
+    (f : β none) (g : ∀ a, β (.some a)) (a : α) (x : β (.some a)) :
+    Option.rec f (update g a x) = update (Option.rec f g) (.some a) x :=
+  Function.rec_update (@Option.some.inj _) (Option.rec f) (fun _ _ => rfl) (fun
+    | _, _, .some _, h => (h _ rfl).elim
+    | _, _, .none, _ => rfl) _ _ _
+
 theorem apply_update {ι : Sort*} [DecidableEq ι] {α β : ι → Sort*} (f : ∀ i, α i → β i)
     (g : ∀ i, α i) (i : ι) (v : α i) (j : ι) :
     f j (update g i v j) = update (fun k ↦ f k (g k)) i (f i v) j := by


### PR DESCRIPTION
This adds a quite technical lemma that can be used to generalize some existing lemmas for `Sum`

The general version would in principle work for any enumerative inductive type, though only after currying the constructor arguments first.

These are `simp` (in the direction pulling `update` to the outside) since that seemed to be useful for #18534, though I could see it either way.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
