### PR TITLE
feat(CategoryTheory/Adjunction): more results on adjoint triples.

### DIFF
--- a/Mathlib/CategoryTheory/Adjunction/Triple.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Triple.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Dagur Asgeirsson, Ben Eltschig
 -/
 import Mathlib.CategoryTheory.Adjunction.Unique
-import Mathlib.CategoryTheory.Limits.FunctorCategory.EpiMono
 import Mathlib.CategoryTheory.Monad.Adjunction
 /-!
 
@@ -24,26 +23,22 @@ bundle the adjunctions in a structure `Triple F G H`.
   counits is also given.
 * `counit_unit_eq_whiskerRight`: when `G` is fully faithful, the natural transformation
   `H ⋙ G ⟶ F ⋙ G` given by `adj₂.counit ≫ adj₁.unit` is just `rightToLeft` whiskered with `G`.
-* `rightToLeft_epi_iff_whiskerRight_unit_epi`: assuming `D` has all pushouts, `rightToLeft : H ⟶ F`
-  is epic iff the whiskering `H ⟶ F ⋙ G ⋙ H` of `adj₁.unit` and `H` is. For the components this
-  holds even without assumptions on `D`.
-* `rightToLeft_epi_iff_counit_unit_epi`: assuming `D` has all pushouts, `rightToLeft : H ⟶ F` is
-  epic iff `adj₂.counit ≫ adj₁.unit : H ⋙ G ⟶ F ⋙ G` is. For the components this holds even without
-  assumptions on `D`.
+* `rightToLeft_app_epi_iff_map_unit_app_epi`: `rightToLeft : H ⟶ F` is epi at `X` iff the image of
+  `adj₁.unit.app X` under `H` is.
+* `rightToLeft_app_epi_iff_counit_unit_app_epi`: when `H` preserves epimorphisms,
+  `rightToLeft : H ⟶ F` is epic at `X` iff `adj₂.counit ≫ adj₁.unit : H ⋙ G ⟶ F ⋙ G` is.
 * `leftToRight`: the canonical natural transformation `F ⟶ H` that exists whenever `F` and `G` are
   fully faithful. This is defined in terms of the units of the adjunctions, but a formula in terms
   of the counits is also given.
 * `counit_unit_eq_whiskerLeft`: when `F` and `H` are fully faithful, the natural transformation
   `G ⋙ F ⟶ G ⋙ H` given by `adj₁.counit ≫ adj₂.unit` is just `G` whiskered with `leftToRight`.
-* `leftToRight_mono_iff_whiskerLeft_unit_mono`: assuming `D` has all pullbacks,
-  `leftToRight : F ⟶ H` is monic iff the whiskering `F ⟶ F ⋙ G ⋙ H` of `F` and `adj₂.unit` is.
-  For the components this holds even without assumptions on `D`.
-* `leftToRight_mono_iff_counit_unit_mono`: assuming `D` has all pullbacks, `leftToRight : H ⟶ F` is
-  monic iff `adj₁.counit ≫ adj₂.unit : G ⋙ F ⟶ G ⋙ H` is. For the components this holds even
-  without assumptions on `D`.
+* `leftToRight_app_mono_iff_unit_app_mono`: `leftToRight : F ⟶ H` is monic at `X` iff `adj₂.unit`
+  is monic at `F.obj X`.
+* `leftToRight_app_mono_iff_counit_unit_app_mono`: all components of `leftToRight : H ⟶ F` are
+  monic iff all components of `adj₁.counit ≫ adj₂.unit : G ⋙ F ⟶ G ⋙ H` are.
 -/
 
-open CategoryTheory Limits
+open CategoryTheory
 
 variable {C D : Type*} [Category C] [Category D]
 variable (F : C ⥤ D) (G : D ⥤ C) (H : C ⥤ D)
@@ -185,14 +180,6 @@ lemma rightToLeft_app_epi_iff_map_unit_app_epi {X : C} :
     ← H.map_comp, counit_unit_app_eq_map_rightToLeft]
   exact Functor.epi_map_congr_iso _ (asIso t.adj₂.unit)
 
-/-- For an adjoint triple `F ⊣ G ⊣ H` where `G` is fully faithful and its codomain has
-all pushouts, the natural transformation `H ⟶ F` is epic iff the unit of the adjunction `F ⊣ G`
-whiskered with `H` is. -/
-lemma rightToLeft_epi_iff_whiskerRight_unit_epi [HasPushouts D] :
-    Epi t.rightToLeft ↔ Epi (whiskerRight t.adj₁.unit H) := by
-  repeat rw [NatTrans.epi_iff_epi_app]
-  exact forall_congr' fun _ ↦ t.rightToLeft_app_epi_iff_map_unit_app_epi
-
 /-- For an adjoint triple `F ⊣ G ⊣ H` where `G` is fully faithful and `H` preserves epimorphisms
 (which is for example the case if `H` has a further right adjoint), the components of the natural
 transformation `H ⟶ F` are epic iff the respective components of the natural transformation
@@ -203,16 +190,6 @@ lemma rightToLeft_app_epi_iff_counit_unit_app_epi [H.PreservesEpimorphisms] {X :
   refine ⟨fun h ↦ by rw [counit_unit_app_eq_map_rightToLeft]; exact G.map_epi _, fun h ↦ ?_⟩
   rw [rightToLeft_app, ← t.homEquiv_counit_unit_app_eq_H_map_unit, t.adj₂.homEquiv_apply]
   infer_instance
-
-/-- For an adjoint triple `F ⊣ G ⊣ H` where `G` is fully faithful, `H` preserves epimorphisms
-(which is for example the case if `H` has a further right adjoint) and both categories have
-all pushouts, the natural transformation `H ⟶ F` is epic iff the natural transformation
-`H ⋙ G ⟶ F ⋙ G` obtained from the units and counits of the adjunctions is. -/
-lemma rightToLeft_epi_iff_counit_unit_epi [HasPushouts C] [HasPushouts D]
-    [H.PreservesEpimorphisms] :
-    Epi t.rightToLeft ↔ Epi (t.adj₂.counit ≫ t.adj₁.unit) := by
-  repeat rw [NatTrans.epi_iff_epi_app]
-  exact forall_congr' fun _ ↦ t.rightToLeft_app_epi_iff_counit_unit_app_epi
 
 end InnerFullyFaithful
 
@@ -285,15 +262,6 @@ lemma leftToRight_app_mono_iff_unit_app_mono {X : C} :
     counit_unit_app_eq_leftToRight_app]
   exact NatTrans.mono_app_congr_iso (asIso (t.adj₁.unit.app X))
 
-omit [H.Full] [H.Faithful] in
-/-- For an adjoint triple `F ⊣ G ⊣ H` where `F` and `H` are fully faithful and their codomain has
-all pullbacks, the natural transformation `F ⟶ H` is monic iff `F` whiskered with the unit of the
-adjunction `G ⊣ H` is. -/
-lemma leftToRight_mono_iff_whiskerLeft_unit_mono [HasPullbacks D] :
-    Mono t.leftToRight ↔ Mono (whiskerLeft F t.adj₂.unit) := by
-  repeat rw [NatTrans.mono_iff_mono_app]
-  exact forall_congr' fun _ ↦ t.leftToRight_app_mono_iff_unit_app_mono
-
 /-- For an adjoint triple `F ⊣ G ⊣ H` where `F` and `H` are fully faithful, all components of the
 natural transformation `F ⟶ H` are monic iff all components of the natural transformation
 `G ⋙ F ⟶ G ⋙ H` obtained from the units and counits of the adjunctions are.
@@ -306,14 +274,6 @@ lemma leftToRight_app_mono_iff_counit_unit_app_mono :
   specialize h (H.obj X)
   rw [counit_unit_app_eq_leftToRight_app] at h
   exact (NatTrans.mono_app_congr_iso (asIso (t.adj₂.counit.app X))).1 h
-
-/-- For an adjoint triple `F ⊣ G ⊣ H` where `F` and `H` are fully faithful and their codomain has
-all pullbacks, the natural transformation `F ⟶ H` is monic iff the natural transformation
-`G ⋙ F ⟶ G ⋙ H` obtained from the units and counits of the adjunctions is. -/
-lemma leftToRight_mono_iff_counit_unit_mono [HasPullbacks D] :
-    Mono t.leftToRight ↔ Mono (t.adj₁.counit ≫ t.adj₂.unit) := by
-  repeat rw [NatTrans.mono_iff_mono_app]
-  exact t.leftToRight_app_mono_iff_counit_unit_app_mono
 
 end OuterFullyFaithful
 

--- a/Mathlib/CategoryTheory/Adjunction/Triple.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Triple.lean
@@ -16,30 +16,31 @@ where `G` is fully faithful or `F` and `H` are.
 
 ## Main results
 
-All results are about an adjoint triple `F ⊣ G ⊣ H` where `adj₁ : F ⊣ G` and `adj₂ : G ⊣ H`.
+All results are about an adjoint triple `F ⊣ G ⊣ H` where `adj₁ : F ⊣ G` and `adj₂ : G ⊣ H`. We
+bundle the adjunctions in a structure `Triple F G H`.
 * `fullyFaithfulEquiv`: `F` is fully faithful iff `H` is.
-* `HToF`: the canonical natural transformation `H ⟶ F` that exists whenever `G` is fully faithful.
-  This is defined in terms of the units of the adjunctions, but a formula in terms of the counits
-  is also given.
-* `counit_unit_eq_whiskerRight`: when `G` is fully faithful, the natural transformation
-  `H ⋙ G ⟶ F ⋙ G` given by `adj₂.counit ≫ adj₁.unit` is just `HToF` whiskered with `G`.
-* `HToF_epi_iff_whiskerRight_unit_epi`: assuming `D` has all pushouts, `HToF : H ⟶ F` is epic iff
-  the whiskering `H ⟶ F ⋙ G ⋙ H` of `adj₁.unit` and `H` is. For the components this holds even
-  without assumptions on `D`.
-* `HToF_epi_iff_counit_unit_epi`: assuming `D` has all pushouts, `HToF : H ⟶ F` is epic iff
-  `adj₂.counit ≫ adj₁.unit : H ⋙ G ⟶ F ⋙ G` is. For the components this holds even without
-  assumptions on `D`.
-* `FToH`: the canonical natural transformation `F ⟶ H` that exists whenever `F` and `G` are fully
+* `rightToLeft`: the canonical natural transformation `H ⟶ F` that exists whenever `G` is fully
   faithful. This is defined in terms of the units of the adjunctions, but a formula in terms of the
   counits is also given.
-* `counit_unit_eq_whiskerLeft`: when `F` and `H` are fully faithful, the natural transformation
-  `G ⋙ F ⟶ G ⋙ H` given by `adj₁.counit ≫ adj₂.unit` is just `G` whiskered with `FToH`.
-* `FToH_mono_iff_whiskerLeft_unit_mono`: assuming `D` has all pullbacks, `FToH : F ⟶ H` is monic iff
-  the whiskering `F ⟶ F ⋙ G ⋙ H` of `F` and `adj₂.unit` is. For the components this holds even
-  without assumptions on `D`.
-* `FToH_mono_iff_counit_unit_mono`: assuming `D` has all pullbacks, `FToH : H ⟶ F` is monic iff
-  `adj₁.counit ≫ adj₂.unit : G ⋙ F ⟶ G ⋙ H` is. For the components this holds even without
+* `counit_unit_eq_whiskerRight`: when `G` is fully faithful, the natural transformation
+  `H ⋙ G ⟶ F ⋙ G` given by `adj₂.counit ≫ adj₁.unit` is just `rightToLeft` whiskered with `G`.
+* `rightToLeft_epi_iff_whiskerRight_unit_epi`: assuming `D` has all pushouts, `rightToLeft : H ⟶ F`
+  is epic iff the whiskering `H ⟶ F ⋙ G ⋙ H` of `adj₁.unit` and `H` is. For the components this
+  holds even without assumptions on `D`.
+* `rightToLeft_epi_iff_counit_unit_epi`: assuming `D` has all pushouts, `rightToLeft : H ⟶ F` is
+  epic iff `adj₂.counit ≫ adj₁.unit : H ⋙ G ⟶ F ⋙ G` is. For the components this holds even without
   assumptions on `D`.
+* `leftToRight`: the canonical natural transformation `F ⟶ H` that exists whenever `F` and `G` are
+  fully faithful. This is defined in terms of the units of the adjunctions, but a formula in terms
+  of the counits is also given.
+* `counit_unit_eq_whiskerLeft`: when `F` and `H` are fully faithful, the natural transformation
+  `G ⋙ F ⟶ G ⋙ H` given by `adj₁.counit ≫ adj₂.unit` is just `G` whiskered with `leftToRight`.
+* `leftToRight_mono_iff_whiskerLeft_unit_mono`: assuming `D` has all pullbacks,
+  `leftToRight : F ⟶ H` is monic iff the whiskering `F ⟶ F ⋙ G ⋙ H` of `F` and `adj₂.unit` is.
+  For the components this holds even without assumptions on `D`.
+* `leftToRight_mono_iff_counit_unit_mono`: assuming `D` has all pullbacks, `leftToRight : H ⟶ F` is
+  monic iff `adj₁.counit ≫ adj₂.unit : G ⋙ F ⟶ G ⋙ H` is. For the components this holds even
+  without assumptions on `D`.
 -/
 
 open CategoryTheory Limits
@@ -145,17 +146,17 @@ lemma whiskered_counit_unit_eq_of_inner :
 is fully faithful, given here as the whiskered unit `H ⟶ F ⋙ G ⋙ H` of the first adjunction
 followed by the inverse of the whiskered unit `F ⟶ F ⋙ G ⋙ H` of the second. -/
 @[simps!]
-noncomputable def HToF : H ⟶ F :=
+noncomputable def rightToLeft : H ⟶ F :=
   H.leftUnitor.inv ≫ whiskerRight t.adj₁.unit H ≫ (Functor.associator _ _ _).hom ≫
   inv (whiskerLeft F t.adj₂.unit) ≫ F.rightUnitor.hom
 
 /-- The natural transformation `H ⟶ F` for an adjoint triple `F ⊣ G ⊣ H` with `G` fully faithful
 is also equal to the inverse of the whiskered counit `H ⋙ G ⋙ F ⟶ H` of the first adjunction
 followed by the whiskered counit `H ⋙ G ⋙ F ⟶ F` of the second. -/
-lemma HToF_eq_counits :
-    t.HToF = H.rightUnitor.inv ≫ inv (whiskerLeft H t.adj₁.counit) ≫
+lemma rightToLeft_eq_counits :
+    t.rightToLeft = H.rightUnitor.inv ≫ inv (whiskerLeft H t.adj₁.counit) ≫
     (Functor.associator _ _ _).inv ≫ whiskerRight t.adj₂.counit F ≫ F.leftUnitor.hom := by
-  ext X; dsimp [HToF]
+  ext X; dsimp [rightToLeft]
   simp only [NatIso.isIso_inv_app, Functor.comp_obj, Category.comp_id, Category.id_comp]
   rw [IsIso.comp_inv_eq]
   simpa using congr_app t.whiskered_counit_unit_eq_of_inner X
@@ -163,54 +164,55 @@ lemma HToF_eq_counits :
 /-- For an adjoint triple `F ⊣ G ⊣ H` where `G` is fully faithful, the components of the natural
 transformation `H ⋙ G ⟶ F ⋙ G` obtained from the units and counits of the adjunctions are simply
 the images of the components of the natural transformation `H ⟶ F` under `G`. -/
-lemma counit_unit_app_eq_map_HToF {X : C} :
-    t.adj₂.counit.app X ≫ t.adj₁.unit.app X = G.map (t.HToF.app X) := by
+lemma counit_unit_app_eq_map_rightToLeft {X : C} :
+    t.adj₂.counit.app X ≫ t.adj₁.unit.app X = G.map (t.rightToLeft.app X) := by
   refine ((t.adj₂.homEquiv _ _).symm_apply_apply _).symm.trans ?_
   rw [homEquiv_counit_unit_app_eq_H_map_unit]; dsimp
   rw [Adjunction.homEquiv_symm_apply, ← Adjunction.inv_map_unit, ← G.map_inv,
-    ← G.map_comp, HToF_app]
+    ← G.map_comp, rightToLeft_app]
 
 /-- For an adjoint triple `F ⊣ G ⊣ H` where `G` is fully faithful, the natural transformation
 `H ⋙ G ⟶ F ⋙ G` obtained from the units and counits of the adjunctions is simply the
 natural transformation `H ⟶ F` whiskered with `G`. -/
-lemma counit_unit_eq_whiskerRight : t.adj₂.counit ≫ t.adj₁.unit = whiskerRight t.HToF G := by
-  ext X; exact t.counit_unit_app_eq_map_HToF
+lemma counit_unit_eq_whiskerRight : t.adj₂.counit ≫ t.adj₁.unit = whiskerRight t.rightToLeft G := by
+  ext X; exact t.counit_unit_app_eq_map_rightToLeft
 
 /-- For an adjoint triple `F ⊣ G ⊣ H` where `G` is fully faithful, the natural transformation
 `H ⟶ F` is epic at `X` iff the image of the unit of the adjunction `F ⊣ G` under `H` is. -/
-lemma HToF_app_epi_iff_map_unit_app_epi {X : C} :
-    Epi (t.HToF.app X) ↔ Epi (H.map (t.adj₁.unit.app X)) := by
+lemma rightToLeft_app_epi_iff_map_unit_app_epi {X : C} :
+    Epi (t.rightToLeft.app X) ↔ Epi (H.map (t.adj₁.unit.app X)) := by
   rw [← epi_isIso_comp_iff (H.map (t.adj₂.counit.app _)) (H.map (t.adj₁.unit.app _)),
-    ← H.map_comp, counit_unit_app_eq_map_HToF]
+    ← H.map_comp, counit_unit_app_eq_map_rightToLeft]
   exact Functor.epi_map_congr_iso _ (asIso t.adj₂.unit)
 
 /-- For an adjoint triple `F ⊣ G ⊣ H` where `G` is fully faithful and its codomain has
 all pushouts, the natural transformation `H ⟶ F` is epic iff the unit of the adjunction `F ⊣ G`
 whiskered with `H` is. -/
-lemma HToF_epi_iff_whiskerRight_unit_epi [HasPushouts D] :
-    Epi t.HToF ↔ Epi (whiskerRight t.adj₁.unit H) := by
+lemma rightToLeft_epi_iff_whiskerRight_unit_epi [HasPushouts D] :
+    Epi t.rightToLeft ↔ Epi (whiskerRight t.adj₁.unit H) := by
   repeat rw [NatTrans.epi_iff_epi_app]
-  exact forall_congr' fun _ ↦ t.HToF_app_epi_iff_map_unit_app_epi
+  exact forall_congr' fun _ ↦ t.rightToLeft_app_epi_iff_map_unit_app_epi
 
 /-- For an adjoint triple `F ⊣ G ⊣ H` where `G` is fully faithful and `H` preserves epimorphisms
 (which is for example the case if `H` has a further right adjoint), the components of the natural
 transformation `H ⟶ F` are epic iff the respective components of the natural transformation
 `H ⋙ G ⟶ F ⋙ G` obtained from the units and counits of the adjunctions are. -/
-lemma HToF_app_epi_iff_counit_unit_app_epi [H.PreservesEpimorphisms] {X : C} :
-    Epi (t.HToF.app X) ↔ Epi (t.adj₂.counit.app X ≫ t.adj₁.unit.app X) := by
+lemma rightToLeft_app_epi_iff_counit_unit_app_epi [H.PreservesEpimorphisms] {X : C} :
+    Epi (t.rightToLeft.app X) ↔ Epi (t.adj₂.counit.app X ≫ t.adj₁.unit.app X) := by
   have _ := t.adj₂.isLeftAdjoint
-  refine ⟨fun h ↦ by rw [counit_unit_app_eq_map_HToF]; exact G.map_epi _, fun h ↦ ?_⟩
-  rw [HToF_app, ← t.homEquiv_counit_unit_app_eq_H_map_unit, t.adj₂.homEquiv_apply]
+  refine ⟨fun h ↦ by rw [counit_unit_app_eq_map_rightToLeft]; exact G.map_epi _, fun h ↦ ?_⟩
+  rw [rightToLeft_app, ← t.homEquiv_counit_unit_app_eq_H_map_unit, t.adj₂.homEquiv_apply]
   infer_instance
 
 /-- For an adjoint triple `F ⊣ G ⊣ H` where `G` is fully faithful, `H` preserves epimorphisms
 (which is for example the case if `H` has a further right adjoint) and both categories have
 all pushouts, the natural transformation `H ⟶ F` is epic iff the natural transformation
 `H ⋙ G ⟶ F ⋙ G` obtained from the units and counits of the adjunctions is. -/
-lemma HToF_epi_iff_counit_unit_epi [HasPushouts C] [HasPushouts D] [H.PreservesEpimorphisms] :
-    Epi t.HToF ↔ Epi (t.adj₂.counit ≫ t.adj₁.unit) := by
+lemma rightToLeft_epi_iff_counit_unit_epi [HasPushouts C] [HasPushouts D]
+    [H.PreservesEpimorphisms] :
+    Epi t.rightToLeft ↔ Epi (t.adj₂.counit ≫ t.adj₁.unit) := by
   repeat rw [NatTrans.epi_iff_epi_app]
-  exact forall_congr' fun _ ↦ t.HToF_app_epi_iff_counit_unit_app_epi
+  exact forall_congr' fun _ ↦ t.rightToLeft_app_epi_iff_counit_unit_app_epi
 
 end InnerFullyFaithful
 
@@ -240,17 +242,17 @@ lemma whiskered_counit_unit_eq_of_outer :
 and `H` are fully faithful, given here as the whiskered unit `F ⟶ F ⋙ G ⋙ H` of the second
 adjunction followed by the inverse of the whiskered unit `F ⋙ G ⋙ H ⟶ H` of the first. -/
 @[simps!]
-noncomputable def FToH : F ⟶ H :=
+noncomputable def leftToRight : F ⟶ H :=
   F.rightUnitor.inv ≫ whiskerLeft F t.adj₂.unit ≫ (Functor.associator _ _ _).inv ≫
   inv (whiskerRight t.adj₁.unit H) ≫ H.leftUnitor.hom
 
 /-- The natural transformation `F ⟶ H` for an adjoint triple `F ⊣ G ⊣ H` with `F` and `H`
 fully faithful is also equal to the inverse of the whiskered counit `H ⋙ G ⋙ F ⟶ F` of the second
 adjunction followed by the whiskered counit `H ⋙ G ⋙ F ⟶ H` of the first. -/
-lemma FToH_eq_counits :
-    t.FToH = F.leftUnitor.inv ≫ inv (whiskerRight t.adj₂.counit F) ≫
+lemma leftToRight_eq_counits :
+    t.leftToRight = F.leftUnitor.inv ≫ inv (whiskerRight t.adj₂.counit F) ≫
     (Functor.associator _ _ _).hom ≫ whiskerLeft H t.adj₁.counit ≫ H.rightUnitor.hom := by
-  ext X; dsimp [FToH]
+  ext X; dsimp [leftToRight]
   simp only [NatIso.isIso_inv_app, Functor.comp_obj, Category.comp_id, Category.id_comp]
   rw [IsIso.comp_inv_eq]
   simpa using congr_app t.whiskered_counit_unit_eq_of_outer.symm X
@@ -259,10 +261,10 @@ omit [H.Full] [H.Faithful] in
 /-- For an adjoint triple `F ⊣ G ⊣ H` where `F` and `H` are fully faithful, the components of the
 natural transformation `G ⋙ F ⟶ G ⋙ H` obtained from the units and counits of the adjunctions
 are simply the components of the natural transformation `F ⟶ H` at `G`. -/
-lemma counit_unit_app_eq_FToH_app {X : D} :
-    t.adj₁.counit.app X ≫ t.adj₂.unit.app X = t.FToH.app (G.obj X) := by
+lemma counit_unit_app_eq_leftToRight_app {X : D} :
+    t.adj₁.counit.app X ≫ t.adj₂.unit.app X = t.leftToRight.app (G.obj X) := by
   refine ((t.adj₂.homEquiv _ _).apply_symm_apply _).symm.trans ?_
-  rw [homEquiv_symm_counit_unit_app_eq_G_map_counit, t.adj₂.homEquiv_apply, FToH_app, ← H.map_inv]
+  rw [homEquiv_symm_counit_unit_app_eq_G_map_counit, homEquiv_apply, leftToRight_app, ← H.map_inv]
   congr
   exact IsIso.eq_inv_of_hom_inv_id (t.adj₁.right_triangle_components _)
 
@@ -270,47 +272,48 @@ omit [H.Full] [H.Faithful] in
 /-- For an adjoint triple `F ⊣ G ⊣ H` where `F` and `H` are fully faithful, the natural
 transformation `G ⋙ F ⟶ G ⋙ H` obtained from the units and counits of the adjunctions is simply
 the natural transformation `F ⟶ H` whiskered from the left with `G`. -/
-lemma counit_unit_eq_whiskerLeft : t.adj₁.counit ≫ t.adj₂.unit = whiskerLeft G t.FToH := by
-  ext X; exact t.counit_unit_app_eq_FToH_app
+lemma counit_unit_eq_whiskerLeft : t.adj₁.counit ≫ t.adj₂.unit = whiskerLeft G t.leftToRight := by
+  ext X; exact t.counit_unit_app_eq_leftToRight_app
 
 omit [H.Full] [H.Faithful] in
 /-- For an adjoint triple `F ⊣ G ⊣ H` where `F` and `H` are fully faithful, the natural
 transformation `F ⟶ H` is monic at `X` iff the unit of the adjunction `G ⊣ H` is monic
 at `F.obj X`. -/
-lemma FToH_app_mono_iff_unit_app_mono {X : C} :
-    Mono (t.FToH.app X) ↔ Mono (t.adj₂.unit.app (F.obj X)) := by
-  rw [← mono_isIso_comp_iff (t.adj₁.counit.app _) (t.adj₂.unit.app _), counit_unit_app_eq_FToH_app]
+lemma leftToRight_app_mono_iff_unit_app_mono {X : C} :
+    Mono (t.leftToRight.app X) ↔ Mono (t.adj₂.unit.app (F.obj X)) := by
+  rw [← mono_isIso_comp_iff (t.adj₁.counit.app _) (t.adj₂.unit.app _),
+    counit_unit_app_eq_leftToRight_app]
   exact NatTrans.mono_app_congr_iso (asIso (t.adj₁.unit.app X))
 
 omit [H.Full] [H.Faithful] in
 /-- For an adjoint triple `F ⊣ G ⊣ H` where `F` and `H` are fully faithful and their codomain has
 all pullbacks, the natural transformation `F ⟶ H` is monic iff `F` whiskered with the unit of the
 adjunction `G ⊣ H` is. -/
-lemma FToH_mono_iff_whiskerLeft_unit_mono [HasPullbacks D] :
-    Mono t.FToH ↔ Mono (whiskerLeft F t.adj₂.unit) := by
+lemma leftToRight_mono_iff_whiskerLeft_unit_mono [HasPullbacks D] :
+    Mono t.leftToRight ↔ Mono (whiskerLeft F t.adj₂.unit) := by
   repeat rw [NatTrans.mono_iff_mono_app]
-  exact forall_congr' fun _ ↦ t.FToH_app_mono_iff_unit_app_mono
+  exact forall_congr' fun _ ↦ t.leftToRight_app_mono_iff_unit_app_mono
 
 /-- For an adjoint triple `F ⊣ G ⊣ H` where `F` and `H` are fully faithful, all components of the
 natural transformation `F ⟶ H` are monic iff all components of the natural transformation
 `G ⋙ F ⟶ G ⋙ H` obtained from the units and counits of the adjunctions are.
-Note that unlike `HToF_app_epi_iff_counit_unit_app_epi`, this equivalence does not make sense on a
-per-object basis because the components of the two natural transformations are indexed by different
-categories. -/
-lemma FToH_app_mono_iff_counit_unit_app_mono :
-    (∀ X, Mono (t.FToH.app X)) ↔ ∀ X, Mono (t.adj₁.counit.app X ≫ t.adj₂.unit.app X) := by
-  refine ⟨fun h X ↦ by rw [counit_unit_app_eq_FToH_app]; exact h _, fun h X ↦ ?_⟩
+Note that unlike `rightToLeft_app_epi_iff_counit_unit_app_epi`, this equivalence does not make sense
+on a per-object basis because the components of the two natural transformations are indexed by
+different categories. -/
+lemma leftToRight_app_mono_iff_counit_unit_app_mono :
+    (∀ X, Mono (t.leftToRight.app X)) ↔ ∀ X, Mono (t.adj₁.counit.app X ≫ t.adj₂.unit.app X) := by
+  refine ⟨fun h X ↦ by rw [counit_unit_app_eq_leftToRight_app]; exact h _, fun h X ↦ ?_⟩
   specialize h (H.obj X)
-  rw [counit_unit_app_eq_FToH_app] at h
+  rw [counit_unit_app_eq_leftToRight_app] at h
   exact (NatTrans.mono_app_congr_iso (asIso (t.adj₂.counit.app X))).1 h
 
 /-- For an adjoint triple `F ⊣ G ⊣ H` where `F` and `H` are fully faithful and their codomain has
 all pullbacks, the natural transformation `F ⟶ H` is monic iff the natural transformation
 `G ⋙ F ⟶ G ⋙ H` obtained from the units and counits of the adjunctions is. -/
-lemma FToH_mono_iff_counit_unit_mono [HasPullbacks D] :
-    Mono t.FToH ↔ Mono (t.adj₁.counit ≫ t.adj₂.unit) := by
+lemma leftToRight_mono_iff_counit_unit_mono [HasPullbacks D] :
+    Mono t.leftToRight ↔ Mono (t.adj₁.counit ≫ t.adj₂.unit) := by
   repeat rw [NatTrans.mono_iff_mono_app]
-  exact t.FToH_app_mono_iff_counit_unit_app_mono
+  exact t.leftToRight_app_mono_iff_counit_unit_app_mono
 
 end OuterFullyFaithful
 

--- a/Mathlib/CategoryTheory/Adjunction/Triple.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Triple.lean
@@ -176,7 +176,7 @@ lemma counit_unit_eq_whiskerRight : t.adj₂.counit ≫ t.adj₁.unit = whiskerR
 `H ⟶ F` is epic at `X` iff the image of the unit of the adjunction `F ⊣ G` under `H` is. -/
 lemma rightToLeft_app_epi_iff_map_unit_app_epi {X : C} :
     Epi (t.rightToLeft.app X) ↔ Epi (H.map (t.adj₁.unit.app X)) := by
-  rw [← epi_isIso_comp_iff (H.map (t.adj₂.counit.app _)) (H.map (t.adj₁.unit.app _)),
+  rw [← epi_comp_iff_of_epi (H.map (t.adj₂.counit.app _)) (H.map (t.adj₁.unit.app _)),
     ← H.map_comp, counit_unit_app_eq_map_rightToLeft]
   exact Functor.epi_map_congr_iso _ (asIso t.adj₂.unit)
 
@@ -258,7 +258,7 @@ transformation `F ⟶ H` is monic at `X` iff the unit of the adjunction `G ⊣ H
 at `F.obj X`. -/
 lemma leftToRight_app_mono_iff_unit_app_mono {X : C} :
     Mono (t.leftToRight.app X) ↔ Mono (t.adj₂.unit.app (F.obj X)) := by
-  rw [← mono_isIso_comp_iff (t.adj₁.counit.app _) (t.adj₂.unit.app _),
+  rw [← mono_comp_iff_of_isIso (t.adj₁.counit.app _) (t.adj₂.unit.app _),
     counit_unit_app_eq_leftToRight_app]
   exact NatTrans.mono_app_congr_iso (asIso (t.adj₁.unit.app X))
 

--- a/Mathlib/CategoryTheory/Adjunction/Triple.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Triple.lean
@@ -277,5 +277,4 @@ lemma leftToRight_app_mono_iff_counit_unit_app_mono :
 
 end OuterFullyFaithful
 
-#check (⟨t.adj₁, t.adj₂⟩ : Triple F G H).adj₁
 end CategoryTheory.Adjunction.Triple

--- a/Mathlib/CategoryTheory/Adjunction/Triple.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Triple.lean
@@ -45,9 +45,9 @@ variable (F : C ⥤ D) (G : D ⥤ C) (H : C ⥤ D)
 
 /-- Structure containing the two adjunctions of an adjoint triple `F ⊣ G ⊣ H`. -/
 structure CategoryTheory.Adjunction.Triple where
-  /- Adjunction `F ⊣ G` of the adjoint triple `F ⊣ G ⊣ H`. -/
+  /-- Adjunction `F ⊣ G` of the adjoint triple `F ⊣ G ⊣ H`. -/
   adj₁ : F ⊣ G
-  /- Adjunction `G ⊣ H` of the adjoint triple `F ⊣ G ⊣ H`. -/
+  /-- Adjunction `G ⊣ H` of the adjoint triple `F ⊣ G ⊣ H`. -/
   adj₂ : G ⊣ H
 
 namespace CategoryTheory.Adjunction.Triple
@@ -277,4 +277,5 @@ lemma leftToRight_app_mono_iff_counit_unit_app_mono :
 
 end OuterFullyFaithful
 
+#check (⟨t.adj₁, t.adj₂⟩ : Triple F G H).adj₁
 end CategoryTheory.Adjunction.Triple

--- a/Mathlib/CategoryTheory/Adjunction/Triple.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Triple.lean
@@ -44,21 +44,29 @@ All results are about an adjoint triple `F ⊣ G ⊣ H` where `adj₁ : F ⊣ G`
 
 open CategoryTheory Limits
 
-namespace CategoryTheory.Adjunction
-
 variable {C D : Type*} [Category C] [Category D]
-variable {F H : C ⥤ D} {G : D ⥤ C}
-variable (adj₁ : F ⊣ G) (adj₂ : G ⊣ H)
+variable (F : C ⥤ D) (G : D ⥤ C) (H : C ⥤ D)
 
-lemma isIso_unit_iff_isIso_counit : IsIso adj₁.unit ↔ IsIso adj₂.counit := by
-  let adj : F ⋙ G ⊣ H ⋙ G := adj₁.comp adj₂
+/-- Structure containing the two adjunctions of an adjoint triple `F ⊣ G ⊣ H`. -/
+structure CategoryTheory.Adjunction.Triple where
+  /- Adjunction `F ⊣ G` of the adjoint triple `F ⊣ G ⊣ H`. -/
+  adj₁ : F ⊣ G
+  /- Adjunction `G ⊣ H` of the adjoint triple `F ⊣ G ⊣ H`. -/
+  adj₂ : G ⊣ H
+
+namespace CategoryTheory.Adjunction.Triple
+
+variable {F G H} (t : Triple F G H)
+
+lemma isIso_unit_iff_isIso_counit : IsIso t.adj₁.unit ↔ IsIso t.adj₂.counit := by
+  let adj : F ⋙ G ⊣ H ⋙ G := t.adj₁.comp t.adj₂
   constructor
   · intro h
-    let idAdj : 𝟭 C ⊣ H ⋙ G := adj.ofNatIsoLeft (asIso adj₁.unit).symm
-    exact adj₂.isIso_counit_of_iso (idAdj.rightAdjointUniq id)
+    let idAdj : 𝟭 C ⊣ H ⋙ G := adj.ofNatIsoLeft (asIso t.adj₁.unit).symm
+    exact t.adj₂.isIso_counit_of_iso (idAdj.rightAdjointUniq id)
   · intro h
-    let adjId : F ⋙ G ⊣ 𝟭 C := adj.ofNatIsoRight (asIso adj₂.counit)
-    exact adj₁.isIso_unit_of_iso (adjId.leftAdjointUniq id)
+    let adjId : F ⋙ G ⊣ 𝟭 C := adj.ofNatIsoRight (asIso t.adj₂.counit)
+    exact t.adj₁.isIso_unit_of_iso (adjId.leftAdjointUniq id)
 
 /--
 Given an adjoint triple `F ⊣ G ⊣ H`, the left adjoint `F` is fully faithful if and only if the
@@ -68,17 +76,17 @@ noncomputable def fullyFaithfulEquiv : F.FullyFaithful ≃ H.FullyFaithful where
   toFun h :=
     haveI := h.full
     haveI := h.faithful
-    haveI : IsIso adj₂.counit := by
-      rw [← adj₁.isIso_unit_iff_isIso_counit adj₂]
+    haveI : IsIso t.adj₂.counit := by
+      rw [← t.isIso_unit_iff_isIso_counit]
       infer_instance
-    adj₂.fullyFaithfulROfIsIsoCounit
+    t.adj₂.fullyFaithfulROfIsIsoCounit
   invFun h :=
     haveI := h.full
     haveI := h.faithful
-    haveI : IsIso adj₁.unit := by
-      rw [adj₁.isIso_unit_iff_isIso_counit adj₂]
+    haveI : IsIso t.adj₁.unit := by
+      rw [t.isIso_unit_iff_isIso_counit]
       infer_instance
-    adj₁.fullyFaithfulLOfIsIsoUnit
+    t.adj₁.fullyFaithfulLOfIsIsoUnit
   left_inv _ := Subsingleton.elim _ _
   right_inv _ := Subsingleton.elim _ _
 
@@ -86,28 +94,30 @@ noncomputable def fullyFaithfulEquiv : F.FullyFaithful ≃ H.FullyFaithful where
 `H ⋙ G ⟶ F ⋙ G` obtained from the units and counits of the adjunctions are
 under the second adjunction adjunct to the image of the unit of the first adjunction under `H`. -/
 lemma homEquiv_counit_unit_app_eq_H_map_unit {X : C} :
-    adj₂.homEquiv _ _ (adj₂.counit.app X ≫ adj₁.unit.app X) = H.map (adj₁.unit.app X) := by
+    t.adj₂.homEquiv _ _ (t.adj₂.counit.app X ≫ t.adj₁.unit.app X) = H.map (t.adj₁.unit.app X) := by
   simp [Adjunction.homEquiv_apply]
 
 /-- For an adjoint triple `F ⊣ G ⊣ H`, the components of the natural transformation
 `H ⋙ G ⟶ F ⋙ G` obtained from the units and counits of the adjunctions are
 under the first adjunction adjunct to the image of the counit of the second adjunction under `F`. -/
 lemma homEquiv_symm_counit_unit_app_eq_F_map_counit {X : C} :
-    (adj₁.homEquiv _ _).symm (adj₂.counit.app X ≫ adj₁.unit.app X) = F.map (adj₂.counit.app X) := by
+    (t.adj₁.homEquiv _ _).symm (t.adj₂.counit.app X ≫ t.adj₁.unit.app X) =
+      F.map (t.adj₂.counit.app X) := by
   simp [Adjunction.homEquiv_symm_apply]
 
 /-- For an adjoint triple `F ⊣ G ⊣ H`, the components of the natural transformation
 `G ⋙ F ⟶ G ⋙ H` obtained from the units and counits of the adjunctions are
 under the first adjunction adjunct to the image of the unit of the second adjunction under `G`. -/
 lemma homEquiv_counit_unit_app_eq_G_map_unit {X : D} :
-    adj₁.homEquiv _ _ (adj₁.counit.app X ≫ adj₂.unit.app X) = G.map (adj₂.unit.app X) := by
+    t.adj₁.homEquiv _ _ (t.adj₁.counit.app X ≫ t.adj₂.unit.app X) = G.map (t.adj₂.unit.app X) := by
   simp [homEquiv_apply]
 
 /-- For an adjoint triple `F ⊣ G ⊣ H`, the components of the natural transformation
 `G ⋙ F ⟶ G ⋙ H` obtained from the units and counits of the adjunctions are
 under the second adjunction adjunct to the image of the counit of the first adjunction under `G`. -/
 lemma homEquiv_symm_counit_unit_app_eq_G_map_counit {X : D} :
-    (adj₂.homEquiv _ _).symm (adj₁.counit.app X ≫ adj₂.unit.app X) = G.map (adj₁.counit.app X) := by
+    (t.adj₂.homEquiv _ _).symm (t.adj₁.counit.app X ≫ t.adj₂.unit.app X) =
+      G.map (t.adj₁.counit.app X) := by
   simp [homEquiv_symm_apply]
 
 section InnerFullyFaithful
@@ -119,16 +129,16 @@ variable [G.Full] [G.Faithful]
 adjunction agree. Note that this is also true when `F` and `H` are fully faithful instead of `G`;
 see `whiskered_counit_unit_eq_of_outer` for the corresponding variant of this lemma. -/
 lemma whiskered_counit_unit_eq_of_inner :
-    whiskerLeft H adj₁.counit ≫ H.rightUnitor.hom ≫ H.leftUnitor.inv ≫
-    whiskerRight adj₁.unit H ≫ (Functor.associator _ _ _).hom =
-    (Functor.associator _ _ _).inv ≫ whiskerRight adj₂.counit F ≫ F.leftUnitor.hom ≫
-    F.rightUnitor.inv ≫ whiskerLeft F adj₂.unit := by
+    whiskerLeft H t.adj₁.counit ≫ H.rightUnitor.hom ≫ H.leftUnitor.inv ≫
+    whiskerRight t.adj₁.unit H ≫ (Functor.associator _ _ _).hom =
+    (Functor.associator _ _ _).inv ≫ whiskerRight t.adj₂.counit F ≫ F.leftUnitor.hom ≫
+    F.rightUnitor.inv ≫ whiskerLeft F t.adj₂.unit := by
   ext X
   dsimp; simp only [Category.id_comp, Category.comp_id]
-  refine (adj₁.counit_naturality <| (whiskerRight adj₁.unit H).app X).symm.trans ?_
-  rw [whiskerRight_app, (asIso (adj₂.counit.app (G.obj _))).eq_comp_inv.2
-      (adj₂.counit_naturality (adj₁.unit.app X)),
-    ← (asIso _).comp_hom_eq_id.1 <| adj₂.left_triangle_components (F.obj X)]
+  refine (t.adj₁.counit_naturality <| (whiskerRight t.adj₁.unit H).app X).symm.trans ?_
+  rw [whiskerRight_app, (asIso (t.adj₂.counit.app (G.obj _))).eq_comp_inv.2
+      (t.adj₂.counit_naturality (t.adj₁.unit.app X)),
+    ← (asIso _).comp_hom_eq_id.1 <| t.adj₂.left_triangle_components (F.obj X)]
   simp
 
 /-- The natural transformation `H ⟶ F` that exists for every adjoint triple `F ⊣ G ⊣ H` where `G`
@@ -136,26 +146,26 @@ is fully faithful, given here as the whiskered unit `H ⟶ F ⋙ G ⋙ H` of the
 followed by the inverse of the whiskered unit `F ⟶ F ⋙ G ⋙ H` of the second. -/
 @[simps!]
 noncomputable def HToF : H ⟶ F :=
-  H.leftUnitor.inv ≫ whiskerRight adj₁.unit H ≫ (Functor.associator _ _ _).hom ≫
-  inv (whiskerLeft F adj₂.unit) ≫ F.rightUnitor.hom
+  H.leftUnitor.inv ≫ whiskerRight t.adj₁.unit H ≫ (Functor.associator _ _ _).hom ≫
+  inv (whiskerLeft F t.adj₂.unit) ≫ F.rightUnitor.hom
 
 /-- The natural transformation `H ⟶ F` for an adjoint triple `F ⊣ G ⊣ H` with `G` fully faithful
 is also equal to the inverse of the whiskered counit `H ⋙ G ⋙ F ⟶ H` of the first adjunction
 followed by the whiskered counit `H ⋙ G ⋙ F ⟶ F` of the second. -/
 lemma HToF_eq_counits :
-    HToF adj₁ adj₂ = H.rightUnitor.inv ≫ inv (whiskerLeft H adj₁.counit) ≫
-    (Functor.associator _ _ _).inv ≫ whiskerRight adj₂.counit F ≫ F.leftUnitor.hom := by
+    t.HToF = H.rightUnitor.inv ≫ inv (whiskerLeft H t.adj₁.counit) ≫
+    (Functor.associator _ _ _).inv ≫ whiskerRight t.adj₂.counit F ≫ F.leftUnitor.hom := by
   ext X; dsimp [HToF]
   simp only [NatIso.isIso_inv_app, Functor.comp_obj, Category.comp_id, Category.id_comp]
   rw [IsIso.comp_inv_eq]
-  simpa using congr_app (whiskered_counit_unit_eq_of_inner adj₁ adj₂) X
+  simpa using congr_app t.whiskered_counit_unit_eq_of_inner X
 
 /-- For an adjoint triple `F ⊣ G ⊣ H` where `G` is fully faithful, the components of the natural
 transformation `H ⋙ G ⟶ F ⋙ G` obtained from the units and counits of the adjunctions are simply
 the images of the components of the natural transformation `H ⟶ F` under `G`. -/
 lemma counit_unit_app_eq_map_HToF {X : C} :
-    adj₂.counit.app X ≫ adj₁.unit.app X = G.map ((HToF adj₁ adj₂).app X) := by
-  refine ((adj₂.homEquiv _ _).symm_apply_apply _).symm.trans ?_
+    t.adj₂.counit.app X ≫ t.adj₁.unit.app X = G.map (t.HToF.app X) := by
+  refine ((t.adj₂.homEquiv _ _).symm_apply_apply _).symm.trans ?_
   rw [homEquiv_counit_unit_app_eq_H_map_unit]; dsimp
   rw [Adjunction.homEquiv_symm_apply, ← Adjunction.inv_map_unit, ← G.map_inv,
     ← G.map_comp, HToF_app]
@@ -163,34 +173,34 @@ lemma counit_unit_app_eq_map_HToF {X : C} :
 /-- For an adjoint triple `F ⊣ G ⊣ H` where `G` is fully faithful, the natural transformation
 `H ⋙ G ⟶ F ⋙ G` obtained from the units and counits of the adjunctions is simply the
 natural transformation `H ⟶ F` whiskered with `G`. -/
-lemma counit_unit_eq_whiskerRight : adj₂.counit ≫ adj₁.unit = whiskerRight (HToF adj₁ adj₂) G := by
-  ext X; exact counit_unit_app_eq_map_HToF adj₁ adj₂
+lemma counit_unit_eq_whiskerRight : t.adj₂.counit ≫ t.adj₁.unit = whiskerRight t.HToF G := by
+  ext X; exact t.counit_unit_app_eq_map_HToF
 
 /-- For an adjoint triple `F ⊣ G ⊣ H` where `G` is fully faithful, the natural transformation
 `H ⟶ F` is epic at `X` iff the image of the unit of the adjunction `F ⊣ G` under `H` is. -/
 lemma HToF_app_epi_iff_map_unit_app_epi {X : C} :
-    Epi ((HToF adj₁ adj₂).app X) ↔ Epi (H.map (adj₁.unit.app X)) := by
-  rw [← epi_isIso_comp_iff (H.map (adj₂.counit.app _)) (H.map (adj₁.unit.app _)),
+    Epi (t.HToF.app X) ↔ Epi (H.map (t.adj₁.unit.app X)) := by
+  rw [← epi_isIso_comp_iff (H.map (t.adj₂.counit.app _)) (H.map (t.adj₁.unit.app _)),
     ← H.map_comp, counit_unit_app_eq_map_HToF]
-  exact Functor.epi_map_congr_iso _ (asIso (adj₂.unit))
+  exact Functor.epi_map_congr_iso _ (asIso t.adj₂.unit)
 
 /-- For an adjoint triple `F ⊣ G ⊣ H` where `G` is fully faithful and its codomain has
 all pushouts, the natural transformation `H ⟶ F` is epic iff the unit of the adjunction `F ⊣ G`
 whiskered with `H` is. -/
 lemma HToF_epi_iff_whiskerRight_unit_epi [HasPushouts D] :
-    Epi (HToF adj₁ adj₂) ↔ Epi (whiskerRight adj₁.unit H) := by
+    Epi t.HToF ↔ Epi (whiskerRight t.adj₁.unit H) := by
   repeat rw [NatTrans.epi_iff_epi_app]
-  exact forall_congr' fun _ ↦ adj₁.HToF_app_epi_iff_map_unit_app_epi adj₂
+  exact forall_congr' fun _ ↦ t.HToF_app_epi_iff_map_unit_app_epi
 
 /-- For an adjoint triple `F ⊣ G ⊣ H` where `G` is fully faithful and `H` preserves epimorphisms
 (which is for example the case if `H` has a further right adjoint), the components of the natural
 transformation `H ⟶ F` are epic iff the respective components of the natural transformation
 `H ⋙ G ⟶ F ⋙ G` obtained from the units and counits of the adjunctions are. -/
 lemma HToF_app_epi_iff_counit_unit_app_epi [H.PreservesEpimorphisms] {X : C} :
-    Epi ((HToF adj₁ adj₂).app X) ↔ Epi (adj₂.counit.app X ≫ adj₁.unit.app X) := by
-  have _ := adj₂.isLeftAdjoint
+    Epi (t.HToF.app X) ↔ Epi (t.adj₂.counit.app X ≫ t.adj₁.unit.app X) := by
+  have _ := t.adj₂.isLeftAdjoint
   refine ⟨fun h ↦ by rw [counit_unit_app_eq_map_HToF]; exact G.map_epi _, fun h ↦ ?_⟩
-  rw [HToF_app, ← homEquiv_counit_unit_app_eq_H_map_unit adj₁ adj₂, adj₂.homEquiv_apply]
+  rw [HToF_app, ← t.homEquiv_counit_unit_app_eq_H_map_unit, t.adj₂.homEquiv_apply]
   infer_instance
 
 /-- For an adjoint triple `F ⊣ G ⊣ H` where `G` is fully faithful, `H` preserves epimorphisms
@@ -198,9 +208,9 @@ lemma HToF_app_epi_iff_counit_unit_app_epi [H.PreservesEpimorphisms] {X : C} :
 all pushouts, the natural transformation `H ⟶ F` is epic iff the natural transformation
 `H ⋙ G ⟶ F ⋙ G` obtained from the units and counits of the adjunctions is. -/
 lemma HToF_epi_iff_counit_unit_epi [HasPushouts C] [HasPushouts D] [H.PreservesEpimorphisms] :
-    Epi (HToF adj₁ adj₂) ↔ Epi (adj₂.counit ≫ adj₁.unit) := by
+    Epi t.HToF ↔ Epi (t.adj₂.counit ≫ t.adj₁.unit) := by
   repeat rw [NatTrans.epi_iff_epi_app]
-  exact forall_congr' fun _ ↦ adj₁.HToF_app_epi_iff_counit_unit_app_epi adj₂
+  exact forall_congr' fun _ ↦ t.HToF_app_epi_iff_counit_unit_app_epi
 
 end InnerFullyFaithful
 
@@ -214,16 +224,16 @@ transformations `H ⋙ G ⋙ F ⟶ F ⋙ G ⋙ H` obtained by following the whis
 of either adjunction agree. Note that this is also true when `G` is fully faithful instead of `F`
 and `H`; see `whiskered_counit_unit_eq_of_inner` for the corresponding variant of this lemma. -/
 lemma whiskered_counit_unit_eq_of_outer :
-    whiskerLeft H adj₁.counit ≫ H.rightUnitor.hom ≫ H.leftUnitor.inv ≫
-    whiskerRight adj₁.unit H ≫ (Functor.associator _ _ _).hom =
-    (Functor.associator _ _ _).inv ≫ whiskerRight adj₂.counit F ≫ F.leftUnitor.hom ≫
-    F.rightUnitor.inv ≫ whiskerLeft F adj₂.unit := by
+    whiskerLeft H t.adj₁.counit ≫ H.rightUnitor.hom ≫ H.leftUnitor.inv ≫
+    whiskerRight t.adj₁.unit H ≫ (Functor.associator _ _ _).hom =
+    (Functor.associator _ _ _).inv ≫ whiskerRight t.adj₂.counit F ≫ F.leftUnitor.hom ≫
+    F.rightUnitor.inv ≫ whiskerLeft F t.adj₂.unit := by
   ext X
   dsimp; simp only [Category.id_comp, Category.comp_id]
-  refine (adj₁.counit_naturality <| (whiskerRight adj₁.unit H).app X).symm.trans ?_
-  rw [whiskerRight_app, (asIso (adj₂.counit.app (G.obj _))).eq_comp_inv.2
-      (adj₂.counit_naturality (adj₁.unit.app X)),
-    ← (asIso _).comp_hom_eq_id.1 <| adj₂.left_triangle_components (F.obj X)]
+  refine (t.adj₁.counit_naturality <| (whiskerRight t.adj₁.unit H).app X).symm.trans ?_
+  rw [whiskerRight_app, (asIso (t.adj₂.counit.app (G.obj _))).eq_comp_inv.2
+      (t.adj₂.counit_naturality (t.adj₁.unit.app X)),
+    ← (asIso _).comp_hom_eq_id.1 <| t.adj₂.left_triangle_components (F.obj X)]
   simp
 
 /-- The natural transformation `F ⟶ H` that exists for every adjoint triple `F ⊣ G ⊣ H` where `F`
@@ -231,55 +241,55 @@ and `H` are fully faithful, given here as the whiskered unit `F ⟶ F ⋙ G ⋙ 
 adjunction followed by the inverse of the whiskered unit `F ⋙ G ⋙ H ⟶ H` of the first. -/
 @[simps!]
 noncomputable def FToH : F ⟶ H :=
-  F.rightUnitor.inv ≫ whiskerLeft F adj₂.unit ≫ (Functor.associator _ _ _).inv ≫
-  inv (whiskerRight adj₁.unit H) ≫ H.leftUnitor.hom
+  F.rightUnitor.inv ≫ whiskerLeft F t.adj₂.unit ≫ (Functor.associator _ _ _).inv ≫
+  inv (whiskerRight t.adj₁.unit H) ≫ H.leftUnitor.hom
 
 /-- The natural transformation `F ⟶ H` for an adjoint triple `F ⊣ G ⊣ H` with `F` and `H`
 fully faithful is also equal to the inverse of the whiskered counit `H ⋙ G ⋙ F ⟶ F` of the second
 adjunction followed by the whiskered counit `H ⋙ G ⋙ F ⟶ H` of the first. -/
 lemma FToH_eq_counits :
-    FToH adj₁ adj₂ = F.leftUnitor.inv ≫ inv (whiskerRight adj₂.counit F) ≫
-    (Functor.associator _ _ _).hom ≫ whiskerLeft H adj₁.counit ≫ H.rightUnitor.hom := by
+    t.FToH = F.leftUnitor.inv ≫ inv (whiskerRight t.adj₂.counit F) ≫
+    (Functor.associator _ _ _).hom ≫ whiskerLeft H t.adj₁.counit ≫ H.rightUnitor.hom := by
   ext X; dsimp [FToH]
   simp only [NatIso.isIso_inv_app, Functor.comp_obj, Category.comp_id, Category.id_comp]
   rw [IsIso.comp_inv_eq]
-  simpa using congr_app (whiskered_counit_unit_eq_of_outer adj₁ adj₂).symm X
+  simpa using congr_app t.whiskered_counit_unit_eq_of_outer.symm X
 
 omit [H.Full] [H.Faithful] in
 /-- For an adjoint triple `F ⊣ G ⊣ H` where `F` and `H` are fully faithful, the components of the
 natural transformation `G ⋙ F ⟶ G ⋙ H` obtained from the units and counits of the adjunctions
 are simply the components of the natural transformation `F ⟶ H` at `G`. -/
 lemma counit_unit_app_eq_FToH_app {X : D} :
-    adj₁.counit.app X ≫ adj₂.unit.app X = (FToH adj₁ adj₂).app (G.obj X) := by
-  refine ((adj₂.homEquiv _ _).apply_symm_apply _).symm.trans ?_
-  rw [homEquiv_symm_counit_unit_app_eq_G_map_counit, adj₂.homEquiv_apply, FToH_app, ← H.map_inv]
+    t.adj₁.counit.app X ≫ t.adj₂.unit.app X = t.FToH.app (G.obj X) := by
+  refine ((t.adj₂.homEquiv _ _).apply_symm_apply _).symm.trans ?_
+  rw [homEquiv_symm_counit_unit_app_eq_G_map_counit, t.adj₂.homEquiv_apply, FToH_app, ← H.map_inv]
   congr
-  exact IsIso.eq_inv_of_hom_inv_id (adj₁.right_triangle_components _)
+  exact IsIso.eq_inv_of_hom_inv_id (t.adj₁.right_triangle_components _)
 
 omit [H.Full] [H.Faithful] in
 /-- For an adjoint triple `F ⊣ G ⊣ H` where `F` and `H` are fully faithful, the natural
 transformation `G ⋙ F ⟶ G ⋙ H` obtained from the units and counits of the adjunctions is simply
 the natural transformation `F ⟶ H` whiskered from the left with `G`. -/
-lemma counit_unit_eq_whiskerLeft : adj₁.counit ≫ adj₂.unit = whiskerLeft G (FToH adj₁ adj₂) := by
-  ext X; exact counit_unit_app_eq_FToH_app adj₁ adj₂
+lemma counit_unit_eq_whiskerLeft : t.adj₁.counit ≫ t.adj₂.unit = whiskerLeft G t.FToH := by
+  ext X; exact t.counit_unit_app_eq_FToH_app
 
 omit [H.Full] [H.Faithful] in
 /-- For an adjoint triple `F ⊣ G ⊣ H` where `F` and `H` are fully faithful, the natural
 transformation `F ⟶ H` is monic at `X` iff the unit of the adjunction `G ⊣ H` is monic
 at `F.obj X`. -/
 lemma FToH_app_mono_iff_unit_app_mono {X : C} :
-    Mono ((FToH adj₁ adj₂).app X) ↔ Mono (adj₂.unit.app (F.obj X)) := by
-  rw [← mono_isIso_comp_iff (adj₁.counit.app _) (adj₂.unit.app _), counit_unit_app_eq_FToH_app]
-  exact NatTrans.mono_app_congr_iso (asIso (adj₁.unit.app X))
+    Mono (t.FToH.app X) ↔ Mono (t.adj₂.unit.app (F.obj X)) := by
+  rw [← mono_isIso_comp_iff (t.adj₁.counit.app _) (t.adj₂.unit.app _), counit_unit_app_eq_FToH_app]
+  exact NatTrans.mono_app_congr_iso (asIso (t.adj₁.unit.app X))
 
 omit [H.Full] [H.Faithful] in
 /-- For an adjoint triple `F ⊣ G ⊣ H` where `F` and `H` are fully faithful and their codomain has
 all pullbacks, the natural transformation `F ⟶ H` is monic iff `F` whiskered with the unit of the
 adjunction `G ⊣ H` is. -/
 lemma FToH_mono_iff_whiskerLeft_unit_mono [HasPullbacks D] :
-    Mono (FToH adj₁ adj₂) ↔ Mono (whiskerLeft F adj₂.unit) := by
+    Mono t.FToH ↔ Mono (whiskerLeft F t.adj₂.unit) := by
   repeat rw [NatTrans.mono_iff_mono_app]
-  exact forall_congr' fun _ ↦ adj₁.FToH_app_mono_iff_unit_app_mono adj₂
+  exact forall_congr' fun _ ↦ t.FToH_app_mono_iff_unit_app_mono
 
 /-- For an adjoint triple `F ⊣ G ⊣ H` where `F` and `H` are fully faithful, all components of the
 natural transformation `F ⟶ H` are monic iff all components of the natural transformation
@@ -288,20 +298,20 @@ Note that unlike `HToF_app_epi_iff_counit_unit_app_epi`, this equivalence does n
 per-object basis because the components of the two natural transformations are indexed by different
 categories. -/
 lemma FToH_app_mono_iff_counit_unit_app_mono :
-    (∀ X, Mono ((FToH adj₁ adj₂).app X)) ↔ ∀ X, Mono (adj₁.counit.app X ≫ adj₂.unit.app X) := by
+    (∀ X, Mono (t.FToH.app X)) ↔ ∀ X, Mono (t.adj₁.counit.app X ≫ t.adj₂.unit.app X) := by
   refine ⟨fun h X ↦ by rw [counit_unit_app_eq_FToH_app]; exact h _, fun h X ↦ ?_⟩
   specialize h (H.obj X)
   rw [counit_unit_app_eq_FToH_app] at h
-  exact (NatTrans.mono_app_congr_iso (asIso (adj₂.counit.app X))).1 h
+  exact (NatTrans.mono_app_congr_iso (asIso (t.adj₂.counit.app X))).1 h
 
 /-- For an adjoint triple `F ⊣ G ⊣ H` where `F` and `H` are fully faithful and their codomain has
 all pullbacks, the natural transformation `F ⟶ H` is monic iff the natural transformation
 `G ⋙ F ⟶ G ⋙ H` obtained from the units and counits of the adjunctions is. -/
 lemma FToH_mono_iff_counit_unit_mono [HasPullbacks D] :
-    Mono (FToH adj₁ adj₂) ↔ Mono (adj₁.counit ≫ adj₂.unit) := by
+    Mono t.FToH ↔ Mono (t.adj₁.counit ≫ t.adj₂.unit) := by
   repeat rw [NatTrans.mono_iff_mono_app]
-  exact adj₁.FToH_app_mono_iff_counit_unit_app_mono adj₂
+  exact t.FToH_app_mono_iff_counit_unit_app_mono
 
 end OuterFullyFaithful
 
-end CategoryTheory.Adjunction
+end CategoryTheory.Adjunction.Triple

--- a/Mathlib/CategoryTheory/Adjunction/Triple.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Triple.lean
@@ -19,23 +19,27 @@ All results are about an adjoint triple `F ⊣ G ⊣ H` where `adj₁ : F ⊣ G`
 bundle the adjunctions in a structure `Triple F G H`.
 * `fullyFaithfulEquiv`: `F` is fully faithful iff `H` is.
 * `rightToLeft`: the canonical natural transformation `H ⟶ F` that exists whenever `G` is fully
-  faithful. This is defined in terms of the units of the adjunctions, but a formula in terms of the
-  counits is also given.
-* `counit_unit_eq_whiskerRight`: when `G` is fully faithful, the natural transformation
-  `H ⋙ G ⟶ F ⋙ G` given by `adj₂.counit ≫ adj₁.unit` is just `rightToLeft` whiskered with `G`.
-* `rightToLeft_app_epi_iff_map_unit_app_epi`: `rightToLeft : H ⟶ F` is epi at `X` iff the image of
-  `adj₁.unit.app X` under `H` is.
-* `rightToLeft_app_epi_iff_counit_unit_app_epi`: when `H` preserves epimorphisms,
-  `rightToLeft : H ⟶ F` is epic at `X` iff `adj₂.counit ≫ adj₁.unit : H ⋙ G ⟶ F ⋙ G` is.
-* `leftToRight`: the canonical natural transformation `F ⟶ H` that exists whenever `F` and `G` are
+  faithful. This is defined as the preimage of `adj₂.counit ≫ adj₁.unit` under whiskering with `G`,
+  but formulas in terms of the units resp. counits of the adjunctions are also given.
+* `whiskerRight_rightToLeft`: whiskering `rightToLeft : H ⟶ F` with `G` yields
+  `adj₂.counit ≫ adj₁.unit : H ⋙ G ⟶ F ⋙ G`.
+* `epi_rightToLeft_app_iff_epi_map_adj₁_unit_app`: `rightToLeft : H ⟶ F` is epic at `X` iff the
+  image of `adj₁.unit.app X` under `H` is.
+* `epi_rightToLeft_app_iff_epi_map_adj₂_counit_app`: `rightToLeft : H ⟶ F` is epic at `X` iff the
+  image of `adj₂.counit.app X` under `F` is.
+* `epi_rightToLeft_app_iff`: when `H` preserves epimorphisms, `rightToLeft : H ⟶ F` is epic at `X`
+  iff `adj₂.counit ≫ adj₁.unit : H ⋙ G ⟶ F ⋙ G` is.
+* `leftToRight`: the canonical natural transformation `F ⟶ H` that exists whenever `F` and `H` are
   fully faithful. This is defined in terms of the units of the adjunctions, but a formula in terms
   of the counits is also given.
-* `counit_unit_eq_whiskerLeft`: when `F` and `H` are fully faithful, the natural transformation
-  `G ⋙ F ⟶ G ⋙ H` given by `adj₁.counit ≫ adj₂.unit` is just `G` whiskered with `leftToRight`.
-* `leftToRight_app_mono_iff_unit_app_mono`: `leftToRight : F ⟶ H` is monic at `X` iff `adj₂.unit`
-  is monic at `F.obj X`.
-* `leftToRight_app_mono_iff_counit_unit_app_mono`: all components of `leftToRight : H ⟶ F` are
-  monic iff all components of `adj₁.counit ≫ adj₂.unit : G ⋙ F ⟶ G ⋙ H` are.
+* `whiskerLeft_leftToRight`: whiskering `G` with `leftToRight : F ⟶ H` yields
+  `adj₁.counit ≫ adj₂.unit : G ⋙ F ⟶ G ⋙ H`.
+* `mono_leftToRight_app_iff_mono_adj₂_unit_app`: `leftToRight : F ⟶ H` is monic at `X` iff
+  `adj₂.unit` is monic at `F.obj X`.
+* `mono_leftToRight_app_iff_mono_adj₁_counit_app`: `leftToRight : F ⟶ H` is monic at `X` iff
+  `adj₁.unit` is monic at `H.obj X`.
+* `mono_leftToRight_app_iff`: `leftToRight : H ⟶ F` is componentwise monic iff
+  `adj₁.counit ≫ adj₂.unit : G ⋙ F ⟶ G ⋙ H` is.
 -/
 
 open CategoryTheory Functor

--- a/Mathlib/CategoryTheory/Adjunction/Triple.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Triple.lean
@@ -173,10 +173,14 @@ variable [F.Full] [F.Faithful] [H.Full] [H.Faithful]
 /-- The natural transformation `F ⟶ H` that exists for every adjoint triple `F ⊣ G ⊣ H` where `F`
 and `H` are fully faithful, given here as the whiskered unit `F ⟶ F ⋙ G ⋙ H` of the second
 adjunction followed by the inverse of the whiskered unit `F ⋙ G ⋙ H ⟶ H` of the first. -/
-@[simps!]
 noncomputable def leftToRight : F ⟶ H :=
   F.rightUnitor.inv ≫ whiskerLeft F t.adj₂.unit ≫ (Functor.associator _ _ _).inv ≫
   inv (whiskerRight t.adj₁.unit H) ≫ H.leftUnitor.hom
+
+omit [H.Full] [H.Faithful] in
+lemma leftToRight_app {X : C} :
+    t.leftToRight.app X = t.adj₂.unit.app (F.obj X) ≫ inv (H.map (t.adj₁.unit.app X)) := by
+  simp [leftToRight]
 
 /-- The natural transformation `F ⟶ H` for an adjoint triple `F ⊣ G ⊣ H` with `F` and `H`
 fully faithful is also equal to the inverse of the whiskered counit `H ⋙ G ⋙ F ⟶ F` of the second
@@ -222,7 +226,7 @@ omit [H.Full] [H.Faithful] in
 @[reassoc (attr := simp)]
 lemma leftToRight_app_map_adj₁_unit_app (X : C) :
     t.leftToRight.app X ≫ H.map (t.adj₁.unit.app X) = t.adj₂.unit.app (F.obj X) := by
-  simp
+  simp [leftToRight_app]
 
 omit [H.Full] [H.Faithful] in
 /-- For an adjoint triple `F ⊣ G ⊣ H` where `F` and `H` are fully faithful, the natural

--- a/Mathlib/CategoryTheory/Adjunction/Triple.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Triple.lean
@@ -217,10 +217,10 @@ the unit of the second adjunction. -/
 lemma whiskerLeft_leftToRight : whiskerLeft G t.leftToRight = t.adj₁.counit ≫ t.adj₂.unit := by
   ext X; exact t.leftToRight_app_obj
 
-@[reassoc (attr := simp)]
+omit [H.Full] [H.Faithful] in
 lemma map_adj₂_counit_app_leftToRight_app (X : C) :
     F.map (t.adj₂.counit.app X) ≫ t.leftToRight.app X = t.adj₁.counit.app (H.obj X) := by
-  simp [leftToRight_eq_counits]
+  simp
 
 omit [H.Full] [H.Faithful] in
 @[reassoc (attr := simp)]

--- a/Mathlib/CategoryTheory/Adjunction/Triple.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Triple.lean
@@ -15,6 +15,8 @@ This file concerns adjoint triples `F ⊣ G ⊣ H` of functors `F H : C ⥤ D`, 
 Currently, the only result is that `F` is fully faithful if and only if `H` is fully faithful.
 -/
 
+open CategoryTheory Limits
+
 namespace CategoryTheory.Adjunction
 
 variable {C D : Type*} [Category C] [Category D]
@@ -52,79 +54,6 @@ noncomputable def fullyFaithfulEquiv : F.FullyFaithful ≃ H.FullyFaithful where
     adj₁.fullyFaithfulLOfIsIsoUnit
   left_inv _ := Subsingleton.elim _ _
   right_inv _ := Subsingleton.elim _ _
-
-end CategoryTheory.Adjunction
-
-open CategoryTheory Limits
-
--- TODO: move these somewhere else
-section Misc
-
-/-- When `f` is an isomorphism, `f ≫ g` is epic iff `g` is.
-TODO: should this and the following lemmas be simp lemmas? might cause slowdowns because it triggers
-instance searches for `IsIso` whenever `simp` is used on a goal containing `Mono (f ≫ g)`. -/
-lemma CategoryTheory.epi_isIso_comp_iff {C : Type*} [Category C] {X Y Z : C} (f : X ⟶ Y) [IsIso f]
-    (g : Y ⟶ Z) : Epi (f ≫ g) ↔ Epi g := by
-  refine ⟨fun h ↦ ?_, fun h ↦ inferInstance⟩
-  simpa using (inferInstance : Epi (inv f ≫ f ≫ g))
-
-/-- When `g` is an isomorphism, `f ≫ g` is epic iff `f` is. -/
-lemma CategoryTheory.epi_comp_isIso_iff {C : Type*} [Category C] {X Y Z : C} (f : X ⟶ Y) (g : Y ⟶ Z)
-    [IsIso g] : Epi (f ≫ g) ↔ Epi f := by
-  refine ⟨fun h ↦ ?_, fun h ↦ inferInstance⟩
-  simpa using (inferInstance : Epi ((f ≫ g) ≫ inv g ))
-
-/-- When `f` is an isomorphism, `f ≫ g` is monic iff `g` is. -/
-lemma CategoryTheory.mono_isIso_comp_iff {C : Type*} [Category C] {X Y Z : C} (f : X ⟶ Y) [IsIso f]
-    (g : Y ⟶ Z) : Mono (f ≫ g) ↔ Mono g := by
-  refine ⟨fun h ↦ ?_, fun h ↦ inferInstance⟩
-  simpa using (inferInstance : Mono (inv f ≫ f ≫ g))
-
-/-- When `g` is an isomorphism, `f ≫ g` is monic iff `f` is. -/
-lemma CategoryTheory.mono_comp_isIso_iff {C : Type*} [Category C] {X Y Z : C} (f : X ⟶ Y)
-    (g : Y ⟶ Z) [IsIso g] : Mono (f ≫ g) ↔ Mono f := by
-  refine ⟨fun h ↦ ?_, fun h ↦ inferInstance⟩
-  simpa using (inferInstance : Mono ((f ≫ g) ≫ inv g ))
-
-/-- For any natural transformation `f : F ⟶ G`, if `X` and `Y` are isomorphic, the component of
-`f` at `X` is epic iff the component of `f` at `Y` is. -/
-lemma CategoryTheory.NatTrans.epi_app_congr_iso {C D : Type*} [Category C] [Category D]
-    {F G : C ⥤ D} {f : F ⟶ G} {X Y : C} (α : X ≅ Y) : Epi (f.app X) ↔ Epi (f.app Y) := by
-  refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
-  · rw [(IsIso.eq_inv_comp _).2 <| f.naturality α.hom]; infer_instance
-  · rw [(IsIso.eq_inv_comp _).2 <| f.naturality α.inv]; infer_instance
-
-/-- For any natural transformation `f : F ⟶ G`, if `X` and `Y` are isomorphic, the component of
-`f` at `X` is monic iff the component of `f` at `Y` is. -/
-lemma CategoryTheory.NatTrans.mono_app_congr_iso {C D : Type*} [Category C] [Category D]
-    {F G : C ⥤ D} {f : F ⟶ G} {X Y : C} (α : X ≅ Y) : Mono (f.app X) ↔ Mono (f.app Y) := by
-  refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
-  · rw [(IsIso.eq_inv_comp _).2 <| f.naturality α.hom]; infer_instance
-  · rw [(IsIso.eq_inv_comp _).2 <| f.naturality α.inv]; infer_instance
-
-/-- For any natural isomorphism `α : F ≅ G` and morphism `f : X ⟶ Y`, `F.map f` is epic
-iff `G.map f` is. -/
-lemma CategoryTheory.Functor.epi_map_congr_iso {C D : Type*} [Category C] [Category D]
-    {F G : C ⥤ D} {X Y : C} (f : X ⟶ Y) (α : F ≅ G) : Epi (F.map f) ↔ Epi (G.map f) := by
-  refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
-  · rw [← (IsIso.inv_comp_eq _).2 <| α.hom.naturality f]; infer_instance
-  · rw [← (IsIso.inv_comp_eq _).2 <| α.inv.naturality f]; infer_instance
-
-/-- For any natural isomorphism `α : F ≅ G` and morphism `f : X ⟶ Y`, `F.map f` is monic
-iff `G.map f` is. -/
-lemma CategoryTheory.Functor.mono_map_congr_iso {C D : Type*} [Category C] [Category D]
-    {F G : C ⥤ D} {X Y : C} (f : X ⟶ Y) (α : F ≅ G) : Mono (F.map f) ↔ Mono (G.map f) := by
-  refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
-  · rw [← (IsIso.inv_comp_eq _).2 <| α.hom.naturality f]; infer_instance
-  · rw [← (IsIso.inv_comp_eq _).2 <| α.inv.naturality f]; infer_instance
-
-end Misc
-
-namespace CategoryTheory.Adjunction
-
-variable {C D : Type*} [Category C] [Category D]
-variable {F H : C ⥤ D} {G : D ⥤ C}
-variable (adj₁ : F ⊣ G) (adj₂ : G ⊣ H)
 
 section InnerFullyFaithful
 

--- a/Mathlib/CategoryTheory/Adjunction/Triple.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Triple.lean
@@ -1,9 +1,10 @@
 /-
 Copyright (c) 2024 Dagur Asgeirsson. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Dagur Asgeirsson
+Authors: Dagur Asgeirsson, Ben Eltschig
 -/
 import Mathlib.CategoryTheory.Adjunction.Unique
+import Mathlib.CategoryTheory.Limits.FunctorCategory.EpiMono
 import Mathlib.CategoryTheory.Monad.Adjunction
 /-!
 
@@ -51,5 +52,304 @@ noncomputable def fullyFaithfulEquiv : F.FullyFaithful ≃ H.FullyFaithful where
     adj₁.fullyFaithfulLOfIsIsoUnit
   left_inv _ := Subsingleton.elim _ _
   right_inv _ := Subsingleton.elim _ _
+
+end CategoryTheory.Adjunction
+
+open CategoryTheory Limits
+
+-- TODO: move these somewhere else
+section Misc
+
+/-- When `f` is an isomorphism, `f ≫ g` is epic iff `g` is.
+TODO: should this and the following lemmas be simp lemmas? might cause slowdowns because it triggers
+instance searches for `IsIso` whenever `simp` is used on a goal containing `Mono (f ≫ g)`. -/
+lemma CategoryTheory.epi_isIso_comp_iff {C : Type*} [Category C] {X Y Z : C} (f : X ⟶ Y) [IsIso f]
+    (g : Y ⟶ Z) : Epi (f ≫ g) ↔ Epi g := by
+  refine ⟨fun h ↦ ?_, fun h ↦ inferInstance⟩
+  simpa using (inferInstance : Epi (inv f ≫ f ≫ g))
+
+/-- When `g` is an isomorphism, `f ≫ g` is epic iff `f` is. -/
+lemma CategoryTheory.epi_comp_isIso_iff {C : Type*} [Category C] {X Y Z : C} (f : X ⟶ Y) (g : Y ⟶ Z)
+    [IsIso g] : Epi (f ≫ g) ↔ Epi f := by
+  refine ⟨fun h ↦ ?_, fun h ↦ inferInstance⟩
+  simpa using (inferInstance : Epi ((f ≫ g) ≫ inv g ))
+
+/-- When `f` is an isomorphism, `f ≫ g` is monic iff `g` is. -/
+lemma CategoryTheory.mono_isIso_comp_iff {C : Type*} [Category C] {X Y Z : C} (f : X ⟶ Y) [IsIso f]
+    (g : Y ⟶ Z) : Mono (f ≫ g) ↔ Mono g := by
+  refine ⟨fun h ↦ ?_, fun h ↦ inferInstance⟩
+  simpa using (inferInstance : Mono (inv f ≫ f ≫ g))
+
+/-- When `g` is an isomorphism, `f ≫ g` is monic iff `f` is. -/
+lemma CategoryTheory.mono_comp_isIso_iff {C : Type*} [Category C] {X Y Z : C} (f : X ⟶ Y)
+    (g : Y ⟶ Z) [IsIso g] : Mono (f ≫ g) ↔ Mono f := by
+  refine ⟨fun h ↦ ?_, fun h ↦ inferInstance⟩
+  simpa using (inferInstance : Mono ((f ≫ g) ≫ inv g ))
+
+/-- For any natural transformation `f : F ⟶ G`, if `X` and `Y` are isomorphic, the component of
+`f` at `X` is epic iff the component of `f` at `Y` is. -/
+lemma CategoryTheory.NatTrans.epi_app_congr_iso {C D : Type*} [Category C] [Category D]
+    {F G : C ⥤ D} {f : F ⟶ G} {X Y : C} (α : X ≅ Y) : Epi (f.app X) ↔ Epi (f.app Y) := by
+  refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
+  · rw [(IsIso.eq_inv_comp _).2 <| f.naturality α.hom]; infer_instance
+  · rw [(IsIso.eq_inv_comp _).2 <| f.naturality α.inv]; infer_instance
+
+/-- For any natural transformation `f : F ⟶ G`, if `X` and `Y` are isomorphic, the component of
+`f` at `X` is monic iff the component of `f` at `Y` is. -/
+lemma CategoryTheory.NatTrans.mono_app_congr_iso {C D : Type*} [Category C] [Category D]
+    {F G : C ⥤ D} {f : F ⟶ G} {X Y : C} (α : X ≅ Y) : Mono (f.app X) ↔ Mono (f.app Y) := by
+  refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
+  · rw [(IsIso.eq_inv_comp _).2 <| f.naturality α.hom]; infer_instance
+  · rw [(IsIso.eq_inv_comp _).2 <| f.naturality α.inv]; infer_instance
+
+/-- For any natural isomorphism `α : F ≅ G` and morphism `f : X ⟶ Y`, `F.map f` is epic
+iff `G.map f` is. -/
+lemma CategoryTheory.Functor.epi_map_congr_iso {C D : Type*} [Category C] [Category D]
+    {F G : C ⥤ D} {X Y : C} (f : X ⟶ Y) (α : F ≅ G) : Epi (F.map f) ↔ Epi (G.map f) := by
+  refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
+  · rw [← (IsIso.inv_comp_eq _).2 <| α.hom.naturality f]; infer_instance
+  · rw [← (IsIso.inv_comp_eq _).2 <| α.inv.naturality f]; infer_instance
+
+/-- For any natural isomorphism `α : F ≅ G` and morphism `f : X ⟶ Y`, `F.map f` is monic
+iff `G.map f` is. -/
+lemma CategoryTheory.Functor.mono_map_congr_iso {C D : Type*} [Category C] [Category D]
+    {F G : C ⥤ D} {X Y : C} (f : X ⟶ Y) (α : F ≅ G) : Mono (F.map f) ↔ Mono (G.map f) := by
+  refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
+  · rw [← (IsIso.inv_comp_eq _).2 <| α.hom.naturality f]; infer_instance
+  · rw [← (IsIso.inv_comp_eq _).2 <| α.inv.naturality f]; infer_instance
+
+end Misc
+
+namespace CategoryTheory.Adjunction
+
+variable {C D : Type*} [Category C] [Category D]
+variable {F H : C ⥤ D} {G : D ⥤ C}
+variable (adj₁ : F ⊣ G) (adj₂ : G ⊣ H)
+
+section InnerFullyFaithful
+
+variable [G.Full] [G.Faithful]
+
+/-- For an adjoint triple `F ⊣ G ⊣ H` where `G` is fully faithful, the two natural transformations
+`H ⋙ G ⋙ F ⟶ F ⋙ G ⋙ H` obtained by following the whiskered counit and units of either
+adjunction agree. Note that this is also true when `F` and `H` are fully faithful instead of `G`;
+see `whiskered_counit_unit_eq_of_outer` for the corresponding variant of this lemma. -/
+lemma whiskered_counit_unit_eq_of_inner :
+    whiskerLeft H adj₁.counit ≫ H.rightUnitor.hom ≫ H.leftUnitor.inv ≫
+    whiskerRight adj₁.unit H ≫ (Functor.associator _ _ _).hom =
+    (Functor.associator _ _ _).inv ≫ whiskerRight adj₂.counit F ≫ F.leftUnitor.hom ≫
+    F.rightUnitor.inv ≫ whiskerLeft F adj₂.unit := by
+  ext X
+  dsimp; simp only [Category.id_comp, Category.comp_id]
+  refine (adj₁.counit_naturality <| (whiskerRight adj₁.unit H).app X).symm.trans ?_
+  rw [whiskerRight_app, (asIso (adj₂.counit.app (G.obj _))).eq_comp_inv.2
+      (adj₂.counit_naturality (adj₁.unit.app X)),
+    ← (asIso _).comp_hom_eq_id.1 <| adj₂.left_triangle_components (F.obj X)]
+  simp
+
+/-- The natural transformation `H ⟶ F` that exists for every adjoint triple `F ⊣ G ⊣ H` where `G`
+is fully faithful, given here as the whiskered unit `H ⟶ F ⋙ G ⋙ H` of the first adjunction
+followed by the inverse of the whiskered unit `F ⟶ F ⋙ G ⋙ H` of the second. -/
+@[simps!]
+noncomputable def HToF : H ⟶ F :=
+  H.leftUnitor.inv ≫ whiskerRight adj₁.unit H ≫ (Functor.associator _ _ _).hom ≫
+  inv (whiskerLeft F adj₂.unit) ≫ F.rightUnitor.hom
+
+/-- The natural transformation `H ⟶ F` for an adjoint triple `F ⊣ G ⊣ H` with `G` fully faithful
+is also equal to the inverse of the whiskered counit `H ⋙ G ⋙ F ⟶ H` of the first adjunction
+followed by the whiskered counit `H ⋙ G ⋙ F ⟶ F` of the second. -/
+lemma HToF_eq :
+    HToF adj₁ adj₂ = H.rightUnitor.inv ≫ inv (whiskerLeft H adj₁.counit) ≫
+    (Functor.associator _ _ _).inv ≫ whiskerRight adj₂.counit F ≫ F.leftUnitor.hom := by
+  ext X; dsimp [HToF]
+  simp only [NatIso.isIso_inv_app, Functor.comp_obj, Category.comp_id, Category.id_comp]
+  rw [IsIso.comp_inv_eq]
+  simpa using congr_app (whiskered_counit_unit_eq_of_inner adj₁ adj₂) X
+
+omit [G.Full] [G.Faithful] in
+/-- For an adjoint triple `F ⊣ G ⊣ H`, the components of the natural transformation
+`H ⋙ G ⟶ F ⋙ G` obtained from the units and counits of the adjunctions are
+under the second adjunction adjunct to the image of the unit of the first adjunction under `H`. -/
+lemma homEquiv_counit_unit_app_eq_H_map_unit {X : C} :
+    adj₂.homEquiv _ _ (adj₂.counit.app X ≫ adj₁.unit.app X) = H.map (adj₁.unit.app X) := by
+  simp [Adjunction.homEquiv_apply]
+
+omit [G.Full] [G.Faithful] in
+/-- For an adjoint triple `F ⊣ G ⊣ H`, the components of the natural transformation
+`H ⋙ G ⟶ F ⋙ G` obtained from the units and counits of the adjunctions are
+under the first adjunction adjunct to the image of the counit of the second adjunction under `F`. -/
+lemma homEquiv_symm_counit_unit_app_eq_F_map_counit {X : C} :
+    (adj₁.homEquiv _ _).symm (adj₂.counit.app X ≫ adj₁.unit.app X) = F.map (adj₂.counit.app X) := by
+  simp [Adjunction.homEquiv_symm_apply]
+
+/-- For an adjoint triple `F ⊣ G ⊣ H` where `G` is fully faithful, the components of the natural
+transformation `H ⋙ G ⟶ F ⋙ G` obtained from the units and counits of the adjunctions are simply
+the images of the components of the natural transformation `H ⟶ F` under `G`. -/
+lemma counit_unit_app_eq_map_HToF {X : C} :
+    adj₂.counit.app X ≫ adj₁.unit.app X = G.map ((HToF adj₁ adj₂).app X) := by
+  refine ((adj₂.homEquiv _ _).symm_apply_apply _).symm.trans ?_
+  rw [homEquiv_counit_unit_app_eq_H_map_unit]; dsimp
+  rw [Adjunction.homEquiv_symm_apply, ← Adjunction.inv_map_unit, ← G.map_inv,
+    ← G.map_comp, HToF_app]
+
+/-- For an adjoint triple `F ⊣ G ⊣ H` where `G` is fully faithful, the natural transformation
+`H ⋙ G ⟶ F ⋙ G` obtained from the units and counits of the adjunctions is simply the
+natural transformation `H ⟶ F` whiskered with `G`. -/
+lemma counit_unit_eq_whiskerRight : adj₂.counit ≫ adj₁.unit = whiskerRight (HToF adj₁ adj₂) G := by
+  ext X; exact counit_unit_app_eq_map_HToF adj₁ adj₂
+
+/-- For an adjoint triple `F ⊣ G ⊣ H` where `G` is fully faithful, the natural transformation
+`H ⟶ F` is epic at `X` iff the image of the unit of the adjunction `F ⊣ G` under `H` is. -/
+lemma HToF_app_epi_iff_map_unit_app_epi {X : C} :
+    Epi ((HToF adj₁ adj₂).app X) ↔ Epi (H.map (adj₁.unit.app X)) := by
+  rw [← epi_isIso_comp_iff (H.map (adj₂.counit.app _)) (H.map (adj₁.unit.app _)),
+    ← H.map_comp, counit_unit_app_eq_map_HToF]
+  exact Functor.epi_map_congr_iso _ (asIso (adj₂.unit))
+
+/-- For an adjoint triple `F ⊣ G ⊣ H` where `G` is fully faithful and its codomain has
+all pushouts, the natural transformation `H ⟶ F` is epic iff the unit of the adjunction `F ⊣ G`
+whiskered with `H` is. -/
+lemma HToF_epi_iff_whiskerRight_unit_epi [HasPushouts D] :
+    Epi (HToF adj₁ adj₂) ↔ Epi (whiskerRight adj₁.unit H) := by
+  repeat rw [NatTrans.epi_iff_epi_app]
+  exact forall_congr' fun _ ↦ adj₁.HToF_app_epi_iff_map_unit_app_epi adj₂
+
+/-- For an adjoint triple `F ⊣ G ⊣ H` where `G` is fully faithful and `H` preserves epimorphisms
+(which is for example the case if `H` has a further right adjoint), the components of the natural
+transformation `H ⟶ F` are epic iff the respective components of the natural transformation
+`H ⋙ G ⟶ F ⋙ G` obtained from the units and counits of the adjunctions are. -/
+lemma HToF_app_epi_iff_counit_unit_app_epi [H.PreservesEpimorphisms] {X : C} :
+    Epi ((HToF adj₁ adj₂).app X) ↔ Epi (adj₂.counit.app X ≫ adj₁.unit.app X) := by
+  have _ := adj₂.isLeftAdjoint
+  refine ⟨fun h ↦ by rw [counit_unit_app_eq_map_HToF]; exact G.map_epi _, fun h ↦ ?_⟩
+  rw [HToF_app, ← homEquiv_counit_unit_app_eq_H_map_unit adj₁ adj₂, adj₂.homEquiv_apply]
+  infer_instance
+
+/-- For an adjoint triple `F ⊣ G ⊣ H` where `G` is fully faithful, `H` preserves epimorphisms
+(which is for example the case if `H` has a further right adjoint) and both categories have
+all pushouts, the natural transformation `H ⟶ F` is epic iff the natural transformation
+`H ⋙ G ⟶ F ⋙ G` obtained from the units and counits of the adjunctions is. -/
+lemma HToF_epi_iff_counit_unit_epi [HasPushouts C] [HasPushouts D] [H.PreservesEpimorphisms] :
+    Epi (HToF adj₁ adj₂) ↔ Epi (adj₂.counit ≫ adj₁.unit) := by
+  repeat rw [NatTrans.epi_iff_epi_app]
+  exact forall_congr' fun _ ↦ adj₁.HToF_app_epi_iff_counit_unit_app_epi adj₂
+
+end InnerFullyFaithful
+
+section OuterFullyFaithful
+
+variable [F.Full] [F.Faithful] [H.Full] [H.Faithful]
+
+omit [F.Full] [F.Faithful] in
+/-- For an adjoint triple `F ⊣ G ⊣ H` where `F` and `H` are fully faithful, the two natural
+transformations `H ⋙ G ⋙ F ⟶ F ⋙ G ⋙ H` obtained by following the whiskered counit and unit
+of either adjunction agree. Note that this is also true when `G` is fully faithful instead of `F`
+and `H`; see `whiskered_counit_unit_eq_of_inner` for the corresponding variant of this lemma. -/
+lemma whiskered_counit_unit_eq_of_outer :
+    whiskerLeft H adj₁.counit ≫ H.rightUnitor.hom ≫ H.leftUnitor.inv ≫
+    whiskerRight adj₁.unit H ≫ (Functor.associator _ _ _).hom =
+    (Functor.associator _ _ _).inv ≫ whiskerRight adj₂.counit F ≫ F.leftUnitor.hom ≫
+    F.rightUnitor.inv ≫ whiskerLeft F adj₂.unit := by
+  ext X
+  dsimp; simp only [Category.id_comp, Category.comp_id]
+  refine (adj₁.counit_naturality <| (whiskerRight adj₁.unit H).app X).symm.trans ?_
+  rw [whiskerRight_app, (asIso (adj₂.counit.app (G.obj _))).eq_comp_inv.2
+      (adj₂.counit_naturality (adj₁.unit.app X)),
+    ← (asIso _).comp_hom_eq_id.1 <| adj₂.left_triangle_components (F.obj X)]
+  simp
+
+/-- The natural transformation `F ⟶ H` that exists for every adjoint triple `F ⊣ G ⊣ H` where `F`
+and `H` are fully faithful, given here as the whiskered unit `F ⟶ F ⋙ G ⋙ H` of the second
+adjunction followed by the inverse of the whiskered unit `F ⋙ G ⋙ H ⟶ H` of the first. -/
+@[simps!]
+noncomputable def FToH : F ⟶ H :=
+  F.rightUnitor.inv ≫ whiskerLeft F adj₂.unit ≫ (Functor.associator _ _ _).inv ≫
+  inv (whiskerRight adj₁.unit H) ≫ H.leftUnitor.hom
+
+/-- The natural transformation `F ⟶ H` for an adjoint triple `F ⊣ G ⊣ H` with `F` and `H`
+fully faithful is also equal to the inverse of the whiskered counit `H ⋙ G ⋙ F ⟶ F` of the second
+adjunction followed by the whiskered counit `H ⋙ G ⋙ F ⟶ H` of the first. -/
+lemma FToH_eq :
+    FToH adj₁ adj₂ = F.leftUnitor.inv ≫ inv (whiskerRight adj₂.counit F) ≫
+    (Functor.associator _ _ _).hom ≫ whiskerLeft H adj₁.counit ≫ H.rightUnitor.hom := by
+  ext X; dsimp [FToH]
+  simp only [NatIso.isIso_inv_app, Functor.comp_obj, Category.comp_id, Category.id_comp]
+  rw [IsIso.comp_inv_eq]
+  simpa using congr_app (whiskered_counit_unit_eq_of_outer adj₁ adj₂).symm X
+
+omit [F.Full] [F.Faithful] [H.Full] [H.Faithful] in
+/-- For an adjoint triple `F ⊣ G ⊣ H`, the components of the natural transformation
+`G ⋙ F ⟶ G ⋙ H` obtained from the units and counits of the adjunctions are
+under the first adjunction adjunct to the image of the unit of the second adjunction under `G`. -/
+lemma homEquiv_counit_unit_app_eq_G_map_unit {X : D} :
+    adj₁.homEquiv _ _ (adj₁.counit.app X ≫ adj₂.unit.app X) = G.map (adj₂.unit.app X) := by
+  simp [homEquiv_apply]
+
+omit [F.Full] [F.Faithful] [H.Full] [H.Faithful] in
+/-- For an adjoint triple `F ⊣ G ⊣ H`, the components of the natural transformation
+`G ⋙ F ⟶ G ⋙ H` obtained from the units and counits of the adjunctions are
+under the second adjunction adjunct to the image of the counit of the first adjunction under `G`. -/
+lemma homEquiv_symm_counit_unit_app_eq_G_map_counit {X : D} :
+    (adj₂.homEquiv _ _).symm (adj₁.counit.app X ≫ adj₂.unit.app X) = G.map (adj₁.counit.app X) := by
+  simp [homEquiv_symm_apply]
+
+omit [H.Full] [H.Faithful] in
+/-- For an adjoint triple `F ⊣ G ⊣ H` where `F` and `H` are fully faithful, the components of the
+natural transformation `G ⋙ F ⟶ G ⋙ H` obtained from the units and counits of the adjunctions
+are simply the components of the natural transformation `F ⟶ H` at `G`. -/
+lemma counit_unit_app_eq_FToH_app {X : D} :
+    adj₁.counit.app X ≫ adj₂.unit.app X = (FToH adj₁ adj₂).app (G.obj X) := by
+  refine ((adj₂.homEquiv _ _).apply_symm_apply _).symm.trans ?_
+  rw [homEquiv_symm_counit_unit_app_eq_G_map_counit, adj₂.homEquiv_apply, FToH_app, ← H.map_inv]
+  congr
+  exact IsIso.eq_inv_of_hom_inv_id (adj₁.right_triangle_components _)
+
+omit [H.Full] [H.Faithful] in
+/-- For an adjoint triple `F ⊣ G ⊣ H` where `F` and `H` are fully faithful, the natural
+transformation `G ⋙ F ⟶ G ⋙ H` obtained from the units and counits of the adjunctions is simply
+the natural transformation `F ⟶ H` whiskered from the left with `G`. -/
+lemma counit_unit_eq_whiskerLeft : adj₁.counit ≫ adj₂.unit = whiskerLeft G (FToH adj₁ adj₂) := by
+  ext X; exact counit_unit_app_eq_FToH_app adj₁ adj₂
+
+omit [H.Full] [H.Faithful] in
+/-- For an adjoint triple `F ⊣ G ⊣ H` where `F` and `H` are fully faithful, the natural
+transformation `F ⟶ H` is monic at `X` iff the unit of the adjunction `G ⊣ H` is monic
+at `F.obj X`. -/
+lemma FToH_app_mono_iff_unit_app_mono {X : C} :
+    Mono ((FToH adj₁ adj₂).app X) ↔ Mono (adj₂.unit.app (F.obj X)) := by
+  rw [← mono_isIso_comp_iff (adj₁.counit.app _) (adj₂.unit.app _), counit_unit_app_eq_FToH_app]
+  exact NatTrans.mono_app_congr_iso (asIso (adj₁.unit.app X))
+
+omit [H.Full] [H.Faithful] in
+/-- For an adjoint triple `F ⊣ G ⊣ H` where `F` and `H` are fully faithful and their codomain has
+all pullbacks, the natural transformation `F ⟶ H` is monic iff `F` whiskered with the unit of the
+adjunction `G ⊣ H` is. -/
+lemma FToH_mono_iff_whiskerLeft_unit_mono [HasPullbacks D] :
+    Mono (FToH adj₁ adj₂) ↔ Mono (whiskerLeft F adj₂.unit) := by
+  repeat rw [NatTrans.mono_iff_mono_app]
+  exact forall_congr' fun _ ↦ adj₁.FToH_app_mono_iff_unit_app_mono adj₂
+
+/-- For an adjoint triple `F ⊣ G ⊣ H` where `F` and `H` are fully faithful, all components of the
+natural transformation `F ⟶ H` are monic iff all components of the natural transformation
+`G ⋙ F ⟶ G ⋙ H` obtained from the units and counits of the adjunctions are.
+Note that unlike `HToF_app_epi_iff_counit_unit_app_epi`, this equivalence does not make sense on a
+per-object basis because the components of the two natural transformations are indexed by different
+categories. -/
+lemma FToH_app_mono_iff_counit_unit_app_mono :
+    (∀ X, Mono ((FToH adj₁ adj₂).app X)) ↔ ∀ X, Mono (adj₁.counit.app X ≫ adj₂.unit.app X) := by
+  refine ⟨fun h X ↦ by rw [counit_unit_app_eq_FToH_app]; exact h _, fun h X ↦ ?_⟩
+  specialize h (H.obj X)
+  rw [counit_unit_app_eq_FToH_app] at h
+  exact (NatTrans.mono_app_congr_iso (asIso (adj₂.counit.app X))).1 h
+
+/-- For an adjoint triple `F ⊣ G ⊣ H` where `F` and `H` are fully faithful and their codomain has
+all pullbacks, the natural transformation `F ⟶ H` is monic iff the natural transformation
+`G ⋙ F ⟶ G ⋙ H` obtained from the units and counits of the adjunctions is. -/
+lemma FToH_mono_iff_counit_unit_mono [HasPullbacks D] :
+    Mono (FToH adj₁ adj₂) ↔ Mono (adj₁.counit ≫ adj₂.unit) := by
+  repeat rw [NatTrans.mono_iff_mono_app]
+  exact adj₁.FToH_app_mono_iff_counit_unit_app_mono adj₂
+
+end OuterFullyFaithful
 
 end CategoryTheory.Adjunction

--- a/Mathlib/CategoryTheory/Adjunction/Triple.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Triple.lean
@@ -10,9 +10,36 @@ import Mathlib.CategoryTheory.Monad.Adjunction
 
 # Adjoint triples
 
-This file concerns adjoint triples `F ⊣ G ⊣ H` of functors `F H : C ⥤ D`, `G : D ⥤ C`.
+This file concerns adjoint triples `F ⊣ G ⊣ H` of functors `F H : C ⥤ D`, `G : D ⥤ C`. We first
+prove that `F` is fully faithful iff `H` is, and then prove results about the two special cases
+where `G` is fully faithful or `F` and `H` are.
 
-Currently, the only result is that `F` is fully faithful if and only if `H` is fully faithful.
+## Main results
+
+All results are about an adjoint triple `F ⊣ G ⊣ H` where `adj₁ : F ⊣ G` and `adj₂ : G ⊣ H`.
+* `fullyFaithfulEquiv`: `F` is fully faithful iff `H` is.
+* `HToF`: the canonical natural transformation `H ⟶ F` that exists whenever `G` is fully faithful.
+  This is defined in terms of the units of the adjunctions, but a formula in terms of the counits
+  is also given.
+* `counit_unit_eq_whiskerRight`: when `G` is fully faithful, the natural transformation
+  `H ⋙ G ⟶ F ⋙ G` given by `adj₂.counit ≫ adj₁.unit` is just `HToF` whiskered with `G`.
+* `HToF_epi_iff_whiskerRight_unit_epi`: assuming `D` has all pushouts, `HToF : H ⟶ F` is epic iff
+  the whiskering `H ⟶ F ⋙ G ⋙ H` of `adj₁.unit` and `H` is. For the components this holds even
+  without assumptions on `D`.
+* `HToF_epi_iff_counit_unit_epi`: assuming `D` has all pushouts, `HToF : H ⟶ F` is epic iff
+  `adj₂.counit ≫ adj₁.unit : H ⋙ G ⟶ F ⋙ G` is. For the components this holds even without
+  assumptions on `D`.
+* `FToH`: the canonical natural transformation `F ⟶ H` that exists whenever `F` and `G` are fully
+  faithful. This is defined in terms of the units of the adjunctions, but a formula in terms of the
+  counits is also given.
+* `counit_unit_eq_whiskerLeft`: when `F` and `H` are fully faithful, the natural transformation
+  `G ⋙ F ⟶ G ⋙ H` given by `adj₁.counit ≫ adj₂.unit` is just `G` whiskered with `FToH`.
+* `FToH_mono_iff_whiskerLeft_unit_mono`: assuming `D` has all pullbacks, `FToH : F ⟶ H` is monic iff
+  the whiskering `F ⟶ F ⋙ G ⋙ H` of `F` and `adj₂.unit` is. For the components this holds even
+  without assumptions on `D`.
+* `FToH_mono_iff_counit_unit_mono`: assuming `D` has all pullbacks, `FToH : H ⟶ F` is monic iff
+  `adj₁.counit ≫ adj₂.unit : G ⋙ F ⟶ G ⋙ H` is. For the components this holds even without
+  assumptions on `D`.
 -/
 
 open CategoryTheory Limits
@@ -55,6 +82,34 @@ noncomputable def fullyFaithfulEquiv : F.FullyFaithful ≃ H.FullyFaithful where
   left_inv _ := Subsingleton.elim _ _
   right_inv _ := Subsingleton.elim _ _
 
+/-- For an adjoint triple `F ⊣ G ⊣ H`, the components of the natural transformation
+`H ⋙ G ⟶ F ⋙ G` obtained from the units and counits of the adjunctions are
+under the second adjunction adjunct to the image of the unit of the first adjunction under `H`. -/
+lemma homEquiv_counit_unit_app_eq_H_map_unit {X : C} :
+    adj₂.homEquiv _ _ (adj₂.counit.app X ≫ adj₁.unit.app X) = H.map (adj₁.unit.app X) := by
+  simp [Adjunction.homEquiv_apply]
+
+/-- For an adjoint triple `F ⊣ G ⊣ H`, the components of the natural transformation
+`H ⋙ G ⟶ F ⋙ G` obtained from the units and counits of the adjunctions are
+under the first adjunction adjunct to the image of the counit of the second adjunction under `F`. -/
+lemma homEquiv_symm_counit_unit_app_eq_F_map_counit {X : C} :
+    (adj₁.homEquiv _ _).symm (adj₂.counit.app X ≫ adj₁.unit.app X) = F.map (adj₂.counit.app X) := by
+  simp [Adjunction.homEquiv_symm_apply]
+
+/-- For an adjoint triple `F ⊣ G ⊣ H`, the components of the natural transformation
+`G ⋙ F ⟶ G ⋙ H` obtained from the units and counits of the adjunctions are
+under the first adjunction adjunct to the image of the unit of the second adjunction under `G`. -/
+lemma homEquiv_counit_unit_app_eq_G_map_unit {X : D} :
+    adj₁.homEquiv _ _ (adj₁.counit.app X ≫ adj₂.unit.app X) = G.map (adj₂.unit.app X) := by
+  simp [homEquiv_apply]
+
+/-- For an adjoint triple `F ⊣ G ⊣ H`, the components of the natural transformation
+`G ⋙ F ⟶ G ⋙ H` obtained from the units and counits of the adjunctions are
+under the second adjunction adjunct to the image of the counit of the first adjunction under `G`. -/
+lemma homEquiv_symm_counit_unit_app_eq_G_map_counit {X : D} :
+    (adj₂.homEquiv _ _).symm (adj₁.counit.app X ≫ adj₂.unit.app X) = G.map (adj₁.counit.app X) := by
+  simp [homEquiv_symm_apply]
+
 section InnerFullyFaithful
 
 variable [G.Full] [G.Faithful]
@@ -87,29 +142,13 @@ noncomputable def HToF : H ⟶ F :=
 /-- The natural transformation `H ⟶ F` for an adjoint triple `F ⊣ G ⊣ H` with `G` fully faithful
 is also equal to the inverse of the whiskered counit `H ⋙ G ⋙ F ⟶ H` of the first adjunction
 followed by the whiskered counit `H ⋙ G ⋙ F ⟶ F` of the second. -/
-lemma HToF_eq :
+lemma HToF_eq_counits :
     HToF adj₁ adj₂ = H.rightUnitor.inv ≫ inv (whiskerLeft H adj₁.counit) ≫
     (Functor.associator _ _ _).inv ≫ whiskerRight adj₂.counit F ≫ F.leftUnitor.hom := by
   ext X; dsimp [HToF]
   simp only [NatIso.isIso_inv_app, Functor.comp_obj, Category.comp_id, Category.id_comp]
   rw [IsIso.comp_inv_eq]
   simpa using congr_app (whiskered_counit_unit_eq_of_inner adj₁ adj₂) X
-
-omit [G.Full] [G.Faithful] in
-/-- For an adjoint triple `F ⊣ G ⊣ H`, the components of the natural transformation
-`H ⋙ G ⟶ F ⋙ G` obtained from the units and counits of the adjunctions are
-under the second adjunction adjunct to the image of the unit of the first adjunction under `H`. -/
-lemma homEquiv_counit_unit_app_eq_H_map_unit {X : C} :
-    adj₂.homEquiv _ _ (adj₂.counit.app X ≫ adj₁.unit.app X) = H.map (adj₁.unit.app X) := by
-  simp [Adjunction.homEquiv_apply]
-
-omit [G.Full] [G.Faithful] in
-/-- For an adjoint triple `F ⊣ G ⊣ H`, the components of the natural transformation
-`H ⋙ G ⟶ F ⋙ G` obtained from the units and counits of the adjunctions are
-under the first adjunction adjunct to the image of the counit of the second adjunction under `F`. -/
-lemma homEquiv_symm_counit_unit_app_eq_F_map_counit {X : C} :
-    (adj₁.homEquiv _ _).symm (adj₂.counit.app X ≫ adj₁.unit.app X) = F.map (adj₂.counit.app X) := by
-  simp [Adjunction.homEquiv_symm_apply]
 
 /-- For an adjoint triple `F ⊣ G ⊣ H` where `G` is fully faithful, the components of the natural
 transformation `H ⋙ G ⟶ F ⋙ G` obtained from the units and counits of the adjunctions are simply
@@ -198,29 +237,13 @@ noncomputable def FToH : F ⟶ H :=
 /-- The natural transformation `F ⟶ H` for an adjoint triple `F ⊣ G ⊣ H` with `F` and `H`
 fully faithful is also equal to the inverse of the whiskered counit `H ⋙ G ⋙ F ⟶ F` of the second
 adjunction followed by the whiskered counit `H ⋙ G ⋙ F ⟶ H` of the first. -/
-lemma FToH_eq :
+lemma FToH_eq_counits :
     FToH adj₁ adj₂ = F.leftUnitor.inv ≫ inv (whiskerRight adj₂.counit F) ≫
     (Functor.associator _ _ _).hom ≫ whiskerLeft H adj₁.counit ≫ H.rightUnitor.hom := by
   ext X; dsimp [FToH]
   simp only [NatIso.isIso_inv_app, Functor.comp_obj, Category.comp_id, Category.id_comp]
   rw [IsIso.comp_inv_eq]
   simpa using congr_app (whiskered_counit_unit_eq_of_outer adj₁ adj₂).symm X
-
-omit [F.Full] [F.Faithful] [H.Full] [H.Faithful] in
-/-- For an adjoint triple `F ⊣ G ⊣ H`, the components of the natural transformation
-`G ⋙ F ⟶ G ⋙ H` obtained from the units and counits of the adjunctions are
-under the first adjunction adjunct to the image of the unit of the second adjunction under `G`. -/
-lemma homEquiv_counit_unit_app_eq_G_map_unit {X : D} :
-    adj₁.homEquiv _ _ (adj₁.counit.app X ≫ adj₂.unit.app X) = G.map (adj₂.unit.app X) := by
-  simp [homEquiv_apply]
-
-omit [F.Full] [F.Faithful] [H.Full] [H.Faithful] in
-/-- For an adjoint triple `F ⊣ G ⊣ H`, the components of the natural transformation
-`G ⋙ F ⟶ G ⋙ H` obtained from the units and counits of the adjunctions are
-under the second adjunction adjunct to the image of the counit of the first adjunction under `G`. -/
-lemma homEquiv_symm_counit_unit_app_eq_G_map_counit {X : D} :
-    (adj₂.homEquiv _ _).symm (adj₁.counit.app X ≫ adj₂.unit.app X) = G.map (adj₁.counit.app X) := by
-  simp [homEquiv_symm_apply]
 
 omit [H.Full] [H.Faithful] in
 /-- For an adjoint triple `F ⊣ G ⊣ H` where `F` and `H` are fully faithful, the components of the

--- a/Mathlib/CategoryTheory/EpiMono.lean
+++ b/Mathlib/CategoryTheory/EpiMono.lean
@@ -244,27 +244,29 @@ end
 
 section
 
-/-- When `f` is an isomorphism, `f ≫ g` is epic iff `g` is.
-TODO: should this and the following lemmas be simp lemmas? might cause slowdowns because it triggers
-instance searches for `IsIso` whenever `simp` is used on a goal containing `Mono (f ≫ g)`. -/
+/-- When `f` is an isomorphism, `f ≫ g` is epic iff `g` is. -/
+@[simp]
 lemma epi_isIso_comp_iff {X Y Z : C} (f : X ⟶ Y) [IsIso f] (g : Y ⟶ Z) :
     Epi (f ≫ g) ↔ Epi g := by
   refine ⟨fun h ↦ ?_, fun h ↦ inferInstance⟩
   simpa using (inferInstance : Epi (inv f ≫ f ≫ g))
 
 /-- When `g` is an isomorphism, `f ≫ g` is epic iff `f` is. -/
+@[simp]
 lemma epi_comp_isIso_iff {X Y Z : C} (f : X ⟶ Y) (g : Y ⟶ Z) [IsIso g] :
     Epi (f ≫ g) ↔ Epi f := by
   refine ⟨fun h ↦ ?_, fun h ↦ inferInstance⟩
   simpa using (inferInstance : Epi ((f ≫ g) ≫ inv g ))
 
 /-- When `f` is an isomorphism, `f ≫ g` is monic iff `g` is. -/
+@[simp]
 lemma mono_isIso_comp_iff {X Y Z : C} (f : X ⟶ Y) [IsIso f] (g : Y ⟶ Z) :
     Mono (f ≫ g) ↔ Mono g := by
   refine ⟨fun h ↦ ?_, fun h ↦ inferInstance⟩
   simpa using (inferInstance : Mono (inv f ≫ f ≫ g))
 
 /-- When `g` is an isomorphism, `f ≫ g` is monic iff `f` is. -/
+@[simp]
 lemma mono_comp_isIso_iff {X Y Z : C} (f : X ⟶ Y) (g : Y ⟶ Z) [IsIso g] :
     Mono (f ≫ g) ↔ Mono f := by
   refine ⟨fun h ↦ ?_, fun h ↦ inferInstance⟩

--- a/Mathlib/CategoryTheory/EpiMono.lean
+++ b/Mathlib/CategoryTheory/EpiMono.lean
@@ -244,33 +244,31 @@ end
 
 section
 
-/-- When `f` is an isomorphism, `f ≫ g` is epic iff `g` is. -/
+/-- When `f` is an epimorphism, `f ≫ g` is epic iff `g` is. -/
 @[simp]
-lemma epi_isIso_comp_iff {X Y Z : C} (f : X ⟶ Y) [IsIso f] (g : Y ⟶ Z) :
+lemma epi_comp_iff_of_epi {X Y Z : C} (f : X ⟶ Y) [Epi f] (g : Y ⟶ Z) :
     Epi (f ≫ g) ↔ Epi g := by
-  refine ⟨fun h ↦ ?_, fun h ↦ inferInstance⟩
-  simpa using (inferInstance : Epi (inv f ≫ f ≫ g))
+  refine ⟨fun h ↦ epi_of_epi f _, fun h ↦ inferInstance⟩
 
 /-- When `g` is an isomorphism, `f ≫ g` is epic iff `f` is. -/
 @[simp]
-lemma epi_comp_isIso_iff {X Y Z : C} (f : X ⟶ Y) (g : Y ⟶ Z) [IsIso g] :
+lemma epi_comp_iff_of_isIso {X Y Z : C} (f : X ⟶ Y) (g : Y ⟶ Z) [IsIso g] :
     Epi (f ≫ g) ↔ Epi f := by
   refine ⟨fun h ↦ ?_, fun h ↦ inferInstance⟩
   simpa using (inferInstance : Epi ((f ≫ g) ≫ inv g ))
 
 /-- When `f` is an isomorphism, `f ≫ g` is monic iff `g` is. -/
 @[simp]
-lemma mono_isIso_comp_iff {X Y Z : C} (f : X ⟶ Y) [IsIso f] (g : Y ⟶ Z) :
+lemma mono_comp_iff_of_isIso {X Y Z : C} (f : X ⟶ Y) [IsIso f] (g : Y ⟶ Z) :
     Mono (f ≫ g) ↔ Mono g := by
   refine ⟨fun h ↦ ?_, fun h ↦ inferInstance⟩
   simpa using (inferInstance : Mono (inv f ≫ f ≫ g))
 
-/-- When `g` is an isomorphism, `f ≫ g` is monic iff `f` is. -/
+/-- When `g` is a monomorphism, `f ≫ g` is monic iff `f` is. -/
 @[simp]
-lemma mono_comp_isIso_iff {X Y Z : C} (f : X ⟶ Y) (g : Y ⟶ Z) [IsIso g] :
+lemma mono_comp_iff_of_mono {X Y Z : C} (f : X ⟶ Y) (g : Y ⟶ Z) [Mono g] :
     Mono (f ≫ g) ↔ Mono f := by
-  refine ⟨fun h ↦ ?_, fun h ↦ inferInstance⟩
-  simpa using (inferInstance : Mono ((f ≫ g) ≫ inv g ))
+  refine ⟨fun h ↦ mono_of_mono _ g, fun h ↦ inferInstance⟩
 
 /-- For any natural transformation `f : F ⟶ G`, if `X` and `Y` are isomorphic, the component of
 `f` at `X` is epic iff the component of `f` at `Y` is. -/

--- a/Mathlib/CategoryTheory/EpiMono.lean
+++ b/Mathlib/CategoryTheory/EpiMono.lean
@@ -270,38 +270,6 @@ lemma mono_comp_iff_of_mono {X Y Z : C} (f : X ⟶ Y) (g : Y ⟶ Z) [Mono g] :
     Mono (f ≫ g) ↔ Mono f := by
   refine ⟨fun h ↦ mono_of_mono _ g, fun h ↦ inferInstance⟩
 
-/-- For any natural transformation `f : F ⟶ G`, if `X` and `Y` are isomorphic, the component of
-`f` at `X` is epic iff the component of `f` at `Y` is. -/
-lemma NatTrans.epi_app_congr_iso {C D : Type*} [Category C] [Category D]
-    {F G : C ⥤ D} {f : F ⟶ G} {X Y : C} (α : X ≅ Y) : Epi (f.app X) ↔ Epi (f.app Y) := by
-  refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
-  · rw [(IsIso.eq_inv_comp _).2 <| f.naturality α.hom]; infer_instance
-  · rw [(IsIso.eq_inv_comp _).2 <| f.naturality α.inv]; infer_instance
-
-/-- For any natural transformation `f : F ⟶ G`, if `X` and `Y` are isomorphic, the component of
-`f` at `X` is monic iff the component of `f` at `Y` is. -/
-lemma NatTrans.mono_app_congr_iso {C D : Type*} [Category C] [Category D]
-    {F G : C ⥤ D} {f : F ⟶ G} {X Y : C} (α : X ≅ Y) : Mono (f.app X) ↔ Mono (f.app Y) := by
-  refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
-  · rw [(IsIso.eq_inv_comp _).2 <| f.naturality α.hom]; infer_instance
-  · rw [(IsIso.eq_inv_comp _).2 <| f.naturality α.inv]; infer_instance
-
-/-- For any natural isomorphism `α : F ≅ G` and morphism `f : X ⟶ Y`, `F.map f` is epic
-iff `G.map f` is. -/
-lemma Functor.epi_map_congr_iso {C D : Type*} [Category C] [Category D]
-    {F G : C ⥤ D} {X Y : C} (f : X ⟶ Y) (α : F ≅ G) : Epi (F.map f) ↔ Epi (G.map f) := by
-  refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
-  · rw [← (IsIso.inv_comp_eq _).2 <| α.hom.naturality f]; infer_instance
-  · rw [← (IsIso.inv_comp_eq _).2 <| α.inv.naturality f]; infer_instance
-
-/-- For any natural isomorphism `α : F ≅ G` and morphism `f : X ⟶ Y`, `F.map f` is monic
-iff `G.map f` is. -/
-lemma Functor.mono_map_congr_iso {C D : Type*} [Category C] [Category D]
-    {F G : C ⥤ D} {X Y : C} (f : X ⟶ Y) (α : F ≅ G) : Mono (F.map f) ↔ Mono (G.map f) := by
-  refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
-  · rw [← (IsIso.inv_comp_eq _).2 <| α.hom.naturality f]; infer_instance
-  · rw [← (IsIso.inv_comp_eq _).2 <| α.inv.naturality f]; infer_instance
-
 end
 
 end CategoryTheory

--- a/Mathlib/CategoryTheory/EpiMono.lean
+++ b/Mathlib/CategoryTheory/EpiMono.lean
@@ -242,4 +242,66 @@ instance {X Y : C} (f : X ⟶ Y) [hf : IsSplitEpi f] (F : C ⥤ D) : IsSplitEpi 
 
 end
 
+section
+
+/-- When `f` is an isomorphism, `f ≫ g` is epic iff `g` is.
+TODO: should this and the following lemmas be simp lemmas? might cause slowdowns because it triggers
+instance searches for `IsIso` whenever `simp` is used on a goal containing `Mono (f ≫ g)`. -/
+lemma epi_isIso_comp_iff {X Y Z : C} (f : X ⟶ Y) [IsIso f] (g : Y ⟶ Z) :
+    Epi (f ≫ g) ↔ Epi g := by
+  refine ⟨fun h ↦ ?_, fun h ↦ inferInstance⟩
+  simpa using (inferInstance : Epi (inv f ≫ f ≫ g))
+
+/-- When `g` is an isomorphism, `f ≫ g` is epic iff `f` is. -/
+lemma epi_comp_isIso_iff {X Y Z : C} (f : X ⟶ Y) (g : Y ⟶ Z) [IsIso g] :
+    Epi (f ≫ g) ↔ Epi f := by
+  refine ⟨fun h ↦ ?_, fun h ↦ inferInstance⟩
+  simpa using (inferInstance : Epi ((f ≫ g) ≫ inv g ))
+
+/-- When `f` is an isomorphism, `f ≫ g` is monic iff `g` is. -/
+lemma mono_isIso_comp_iff {X Y Z : C} (f : X ⟶ Y) [IsIso f] (g : Y ⟶ Z) :
+    Mono (f ≫ g) ↔ Mono g := by
+  refine ⟨fun h ↦ ?_, fun h ↦ inferInstance⟩
+  simpa using (inferInstance : Mono (inv f ≫ f ≫ g))
+
+/-- When `g` is an isomorphism, `f ≫ g` is monic iff `f` is. -/
+lemma mono_comp_isIso_iff {X Y Z : C} (f : X ⟶ Y) (g : Y ⟶ Z) [IsIso g] :
+    Mono (f ≫ g) ↔ Mono f := by
+  refine ⟨fun h ↦ ?_, fun h ↦ inferInstance⟩
+  simpa using (inferInstance : Mono ((f ≫ g) ≫ inv g ))
+
+/-- For any natural transformation `f : F ⟶ G`, if `X` and `Y` are isomorphic, the component of
+`f` at `X` is epic iff the component of `f` at `Y` is. -/
+lemma NatTrans.epi_app_congr_iso {C D : Type*} [Category C] [Category D]
+    {F G : C ⥤ D} {f : F ⟶ G} {X Y : C} (α : X ≅ Y) : Epi (f.app X) ↔ Epi (f.app Y) := by
+  refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
+  · rw [(IsIso.eq_inv_comp _).2 <| f.naturality α.hom]; infer_instance
+  · rw [(IsIso.eq_inv_comp _).2 <| f.naturality α.inv]; infer_instance
+
+/-- For any natural transformation `f : F ⟶ G`, if `X` and `Y` are isomorphic, the component of
+`f` at `X` is monic iff the component of `f` at `Y` is. -/
+lemma NatTrans.mono_app_congr_iso {C D : Type*} [Category C] [Category D]
+    {F G : C ⥤ D} {f : F ⟶ G} {X Y : C} (α : X ≅ Y) : Mono (f.app X) ↔ Mono (f.app Y) := by
+  refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
+  · rw [(IsIso.eq_inv_comp _).2 <| f.naturality α.hom]; infer_instance
+  · rw [(IsIso.eq_inv_comp _).2 <| f.naturality α.inv]; infer_instance
+
+/-- For any natural isomorphism `α : F ≅ G` and morphism `f : X ⟶ Y`, `F.map f` is epic
+iff `G.map f` is. -/
+lemma Functor.epi_map_congr_iso {C D : Type*} [Category C] [Category D]
+    {F G : C ⥤ D} {X Y : C} (f : X ⟶ Y) (α : F ≅ G) : Epi (F.map f) ↔ Epi (G.map f) := by
+  refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
+  · rw [← (IsIso.inv_comp_eq _).2 <| α.hom.naturality f]; infer_instance
+  · rw [← (IsIso.inv_comp_eq _).2 <| α.inv.naturality f]; infer_instance
+
+/-- For any natural isomorphism `α : F ≅ G` and morphism `f : X ⟶ Y`, `F.map f` is monic
+iff `G.map f` is. -/
+lemma Functor.mono_map_congr_iso {C D : Type*} [Category C] [Category D]
+    {F G : C ⥤ D} {X Y : C} (f : X ⟶ Y) (α : F ≅ G) : Mono (F.map f) ↔ Mono (G.map f) := by
+  refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
+  · rw [← (IsIso.inv_comp_eq _).2 <| α.hom.naturality f]; infer_instance
+  · rw [← (IsIso.inv_comp_eq _).2 <| α.inv.naturality f]; infer_instance
+
+end
+
 end CategoryTheory


### PR DESCRIPTION
Lemmas about adjoint triples `F ⊣ G ⊣ H` where either `G` is fully faithful or `F` and `H` are.

From [lean-orbifolds](https://github.com/peabrainiac/lean-orbifolds/blob/387fe778f3cc1ed3c5e60f390842333ecc9eda67/Orbifolds/ForMathlib/Triple.lean).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
