### PR TITLE
[Merged by Bors] - fix: warn if to_additive helper functions try to reorder lists that are too small

### DIFF
--- a/Mathlib/Tactic/ToAdditive/Frontend.lean
+++ b/Mathlib/Tactic/ToAdditive/Frontend.lean
@@ -687,7 +687,9 @@ def reorderForall (reorder : List (List Nat) := []) (src : Expr) : MetaM Expr :=
       if xs.size = maxReorder + 1 then
         mkForallFVars (xs.permute! reorder) e
       else
-        logInfo m!"reorderForall tried to reorder a list that was too small:\n\
+        logInfo m!"the permutation {reorder} provided by the reorder config option is too large, \
+          the type {src} has only {xs.size} arguments"
+        trace[to_additive_detail] "reorderForall tried to reorder a list that was too small:\n\
           {src}\n{xs}\n{reorder}"
         return src
   else
@@ -700,7 +702,9 @@ def reorderLambda (reorder : List (List Nat) := []) (src : Expr) : MetaM Expr :=
       if xs.size = maxReorder + 1 then
         mkLambdaFVars (xs.permute! reorder) e
       else
-        logInfo m!"reorderLambda tried to reorder a list that was too small:\n\
+        logInfo m!"the permutation {reorder} provided by the reorder config option is too large, \
+          the type {src} has only {xs.size} arguments"
+        trace[to_additive_detail] "reorderLambda tried to reorder a list that was too small:\n\
           {src}\n{xs}\n{reorder}"
         return src
   else

--- a/Mathlib/Tactic/ToAdditive/Frontend.lean
+++ b/Mathlib/Tactic/ToAdditive/Frontend.lean
@@ -687,10 +687,8 @@ def reorderForall (reorder : List (List Nat) := []) (src : Expr) : MetaM Expr :=
       if xs.size = maxReorder + 1 then
         mkForallFVars (xs.permute! reorder) e
       else
-        logInfo m!"the permutation {reorder} provided by the reorder config option is too large, \
-          the type {src} has only {xs.size} arguments"
-        trace[to_additive_detail] "reorderForall tried to reorder a list that was too small:\n\
-          {src}\n{xs}\n{reorder}"
+        throwError "the permutation\n{reorder}\nprovided by the reorder config option is too \
+          large, the type{indentExpr src}\nhas only {xs.size} arguments"
         return src
   else
     return src
@@ -702,10 +700,8 @@ def reorderLambda (reorder : List (List Nat) := []) (src : Expr) : MetaM Expr :=
       if xs.size = maxReorder + 1 then
         mkLambdaFVars (xs.permute! reorder) e
       else
-        logInfo m!"the permutation {reorder} provided by the reorder config option is too large, \
-          the type {src} has only {xs.size} arguments"
-        trace[to_additive_detail] "reorderLambda tried to reorder a list that was too small:\n\
-          {src}\n{xs}\n{reorder}"
+        throwError "the permutation\n{reorder}\nprovided by the reorder config option is too \
+          large, the type{indentExpr src}\nhas only {xs.size} arguments"
         return src
   else
     return src

--- a/Mathlib/Tactic/ToAdditive/Frontend.lean
+++ b/Mathlib/Tactic/ToAdditive/Frontend.lean
@@ -682,17 +682,29 @@ def expand (e : Expr) : MetaM Expr := do
 
 /-- Reorder pi-binders. See doc of `reorderAttr` for the interpretation of the argument -/
 def reorderForall (reorder : List (List Nat) := []) (src : Expr) : MetaM Expr := do
-  if reorder == [] then
+  if let some maxReorder := reorder.flatten.max? then
+    forallBoundedTelescope src (some (maxReorder + 1)) fun xs e => do
+      if xs.size = maxReorder + 1 then
+        mkForallFVars (xs.permute! reorder) e
+      else
+        logInfo m!"reorderForall tried to reorder a list that was too small:\n\
+          {src}\n{xs}\n{reorder}"
+        return src
+  else
     return src
-  forallTelescope src fun xs e => do
-    mkForallFVars (xs.permute! reorder) e
 
 /-- Reorder lambda-binders. See doc of `reorderAttr` for the interpretation of the argument -/
 def reorderLambda (reorder : List (List Nat) := []) (src : Expr) : MetaM Expr := do
-  if reorder == [] then
+  if let some maxReorder := reorder.flatten.max? then
+    lambdaBoundedTelescope src (maxReorder + 1) fun xs e => do
+      if xs.size = maxReorder + 1 then
+        mkLambdaFVars (xs.permute! reorder) e
+      else
+        logInfo m!"reorderLambda tried to reorder a list that was too small:\n\
+          {src}\n{xs}\n{reorder}"
+        return src
+  else
     return src
-  lambdaTelescope src fun xs e => do
-    mkLambdaFVars (xs.permute! reorder) e
 
 /-- Unfold auxlemmas in the type and value. -/
 def declUnfoldAuxLemmas (decl : ConstantInfo) : MetaM ConstantInfo := do

--- a/MathlibTest/toAdditive.lean
+++ b/MathlibTest/toAdditive.lean
@@ -316,15 +316,11 @@ def reorderMulThree {α : Type _} [Mul α] (x y z : α) : α := x * y * z
 
 /-! Test a permutation that is too big for the list of arguments. -/
 /--
-info: the permutation [[2,
-  3,
-  50]] provided by the reorder config option is too large, the type {α : Type u_1} →
-  [inst : Mul α] → α → α → α → α has only 5 arguments
----
-info: the permutation [[2,
-  3,
-  50]] provided by the reorder config option is too large, the type fun {α} [Mul α] x y z =>
-  x * y * z has only 5 arguments
+error: the permutation
+[[2, 3, 50]]
+provided by the reorder config option is too large, the type
+  {α : Type u_1} → [inst : Mul α] → α → α → α → α
+has only 5 arguments
 -/
 #guard_msgs in
 @[to_additive (reorder := 3 4 51)]

--- a/MathlibTest/toAdditive.lean
+++ b/MathlibTest/toAdditive.lean
@@ -314,6 +314,22 @@ theorem isUnit'_iff_exists_inv' [CommMonoid M] {a : M} : IsUnit' a ↔ ∃ b, b 
 @[to_additive (reorder := 3 4 5)]
 def reorderMulThree {α : Type _} [Mul α] (x y z : α) : α := x * y * z
 
+/-! Test a permutation that is too big for the list of arguments. -/
+/--
+info: reorderForall tried to reorder a list that was too small:
+{α : Type u_1} → [inst : Mul α] → α → α → α → α
+[α, inst✝, x, y, z]
+[[2, 3, 50]]
+---
+info: reorderLambda tried to reorder a list that was too small:
+fun {α} [Mul α] x y z => x * y * z
+[α, inst✝, x, y, z]
+[[2, 3, 50]]
+-/
+#guard_msgs in
+@[to_additive (reorder := 3 4 51)]
+def reorderMulThree' {α : Type _} [Mul α] (x y z : α) : α := x * y * z
+
 example {α : Type _} [Add α] (x y z : α) : reorderAddThree z x y = x + y + z := rfl
 
 

--- a/MathlibTest/toAdditive.lean
+++ b/MathlibTest/toAdditive.lean
@@ -316,15 +316,15 @@ def reorderMulThree {α : Type _} [Mul α] (x y z : α) : α := x * y * z
 
 /-! Test a permutation that is too big for the list of arguments. -/
 /--
-info: reorderForall tried to reorder a list that was too small:
-{α : Type u_1} → [inst : Mul α] → α → α → α → α
-[α, inst✝, x, y, z]
-[[2, 3, 50]]
+info: the permutation [[2,
+  3,
+  50]] provided by the reorder config option is too large, the type {α : Type u_1} →
+  [inst : Mul α] → α → α → α → α has only 5 arguments
 ---
-info: reorderLambda tried to reorder a list that was too small:
-fun {α} [Mul α] x y z => x * y * z
-[α, inst✝, x, y, z]
-[[2, 3, 50]]
+info: the permutation [[2,
+  3,
+  50]] provided by the reorder config option is too large, the type fun {α} [Mul α] x y z =>
+  x * y * z has only 5 arguments
 -/
 #guard_msgs in
 @[to_additive (reorder := 3 4 51)]


### PR DESCRIPTION
Currently, code like the following, which attempts to permute arguments out of the range of the argument list, causes a panic in the helper functions `reorderForall` and `reorderLambda`:
```lean
@[to_additive (reorder := 3 4 51)]
def reorderMulThree' {α : Type _} [Mul α] (x y z : α) : α := x * y * z
```

We change from using `forallTelescope` and `lambdaTelescope` to their bounded versions `forallBoundedTelescope` and `lambdaBoundedTelescope` with an explicit bound which ensures that we always expand as much as possible, and also add a warning if the bound does not match the size of the argument list.

Extracted from #21719 

Co-authored-by: JovanGerb <jovan.gerbscheid@gmail.com>

---

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
