### PR TITLE
[Merged by Bors] - chore(Data): remove erw

### DIFF
--- a/Mathlib/Data/Multiset/Fintype.lean
+++ b/Mathlib/Data/Multiset/Fintype.lean
@@ -190,9 +190,15 @@ theorem map_univ_coe (m : Multiset α) :
     Function.comp_apply] using this
 
 @[simp]
+theorem map_univ_comp_coe {β : Type*} (m : Multiset α) (f : α → β) :
+    ((Finset.univ : Finset m).val.map (f ∘ (fun x : m ↦ (x : α)))) = m.map f := by
+  rw [← Multiset.map_map, Multiset.map_univ_coe]
+
+@[simp]
 theorem map_univ {β : Type*} (m : Multiset α) (f : α → β) :
     ((Finset.univ : Finset m).val.map fun (x : m) ↦ f (x : α)) = m.map f := by
-  erw [← Multiset.map_map, Multiset.map_univ_coe]
+  simp_rw [← Function.comp_apply (f := f)]
+  exact map_univ_comp_coe m f
 
 @[simp]
 theorem card_toEnumFinset (m : Multiset α) : m.toEnumFinset.card = Multiset.card m := by

--- a/Mathlib/Data/Multiset/Fintype.lean
+++ b/Mathlib/Data/Multiset/Fintype.lean
@@ -189,7 +189,6 @@ theorem map_univ_coe (m : Multiset α) :
   simpa only [Finset.map_val, Multiset.coeEmbedding_apply, Multiset.map_map,
     Function.comp_apply] using this
 
-@[simp]
 theorem map_univ_comp_coe {β : Type*} (m : Multiset α) (f : α → β) :
     ((Finset.univ : Finset m).val.map (f ∘ (fun x : m ↦ (x : α)))) = m.map f := by
   rw [← Multiset.map_map, Multiset.map_univ_coe]

--- a/Mathlib/Data/TypeVec.lean
+++ b/Mathlib/Data/TypeVec.lean
@@ -412,8 +412,9 @@ def ofRepeat {α : Sort _} : ∀ {n i}, «repeat» n α i → α
 theorem const_iff_true {α : TypeVec n} {i x p} : ofRepeat (TypeVec.const p α i x) ↔ p := by
   induction i with
   | fz      => rfl
-  | fs _ ih => erw [TypeVec.const, @ih (drop α) x]
-
+  | fs _ ih =>
+    rw [TypeVec.const]
+    exact ih
 
 section
 variable {α β : TypeVec.{u} n}
@@ -492,7 +493,9 @@ theorem repeatEq_iff_eq {α : TypeVec n} {i x y} :
     ofRepeat (repeatEq α i (prod.mk _ x y)) ↔ x = y := by
   induction i with
   | fz => rfl
-  | fs _ i_ih => erw [repeatEq, i_ih]
+  | fs _ i_ih =>
+    rw [repeatEq]
+    exact i_ih
 
 /-- given a predicate vector `p` over vector `α`, `Subtype_ p` is the type of vectors
 that contain an `α` that satisfies `p` -/


### PR DESCRIPTION

Removes three instances of `erw` in `Data`

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
