### PR TITLE
feat(Combinatorics/SimpleGraph): cycle graph implementation for generic vertex types

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2677,6 +2677,7 @@ import Mathlib.Combinatorics.SimpleGraph.Connectivity.Subgraph
 import Mathlib.Combinatorics.SimpleGraph.Connectivity.WalkCounting
 import Mathlib.Combinatorics.SimpleGraph.Connectivity.WalkDecomp
 import Mathlib.Combinatorics.SimpleGraph.Copy
+import Mathlib.Combinatorics.SimpleGraph.Cycle
 import Mathlib.Combinatorics.SimpleGraph.Dart
 import Mathlib.Combinatorics.SimpleGraph.DegreeSum
 import Mathlib.Combinatorics.SimpleGraph.DeleteEdges

--- a/Mathlib/Combinatorics/SimpleGraph/Cycle.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Cycle.lean
@@ -158,11 +158,16 @@ lemma cycle_walk_contains_all_edges {p : G.Walk v v} (c : G.IsCycle) (h : p.IsCy
   simp_all
 
 theorem IsEulerian (c : G.IsCycle) : ∃ (v : V) (p : G.Walk v v), p.IsEulerian := by
-  simp only [Walk.isEulerian_iff]
   obtain ⟨v, p, hpc⟩ := c.isCyclic
   use v
   use p
-  simp only [hpc.isCircuit.isTrail, true_and]
+  simp only [Walk.isEulerian_iff, hpc.isCircuit.isTrail, true_and]
+  exact c.cycle_walk_contains_all_edges G hpc
+
+theorem IsEulerian_forall (c : G.IsCycle) : ∃ (p : G.Walk v v), p.IsEulerian := by
+  obtain ⟨p, hpc⟩ := c.all_vertices_form_a_cycle
+  use p
+  simp only [Walk.isEulerian_iff, hpc.isCircuit.isTrail, true_and]
   exact c.cycle_walk_contains_all_edges G hpc
 
 lemma IsHamiltonian (c : G.IsCycle) : G.IsHamiltonian := by

--- a/Mathlib/Combinatorics/SimpleGraph/Cycle.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Cycle.lean
@@ -47,8 +47,7 @@ lemma vertex_card_eq_edge_card (c : G.IsCycle) : Fintype.card V = Fintype.card G
     simp only [Finset.mem_univ, forall_const]
     exact c.2
   have h_e_card : ∑ (v : V), G.degree v = 2*(Fintype.card G.edgeSet) := by
-    have hhl : ∑ (v : V), G.degree v = 2*G.edgeFinset.card := G.sum_degrees_eq_twice_card_edges
-    simp_all
+    simp_all [G.sum_degrees_eq_twice_card_edges]
   simp_all
 
 lemma three_le_card (c : G.IsCycle) : 3 ≤ Fintype.card V := by
@@ -64,8 +63,7 @@ variable {v w : V}
 lemma IsCycles (c : G.IsCycle) : G.IsCycles := by
   intro v hv
   have h_n_card : Fintype.card (G.neighborSet v) = 2 := by
-    simp only [G.card_neighborSet_eq_degree]
-    apply c.2
+    rw [G.card_neighborSet_eq_degree, c.2]
   simp only [Fintype.card_ofFinset, mem_neighborSet] at h_n_card
   simp [Set.ncard_eq_toFinset_card', h_n_card]
 
@@ -160,10 +158,10 @@ lemma cycle_walk_contains_all_edges {p : G.Walk v v} (c : G.IsCycle) (h : p.IsCy
   have he : p.edges.toFinset ⊆ G.edgeFinset := by
     simp only [Set.subset_toFinset, List.coe_toFinset]
     apply Walk.edges_subset_edgeSet
-  have : ∀ e ∈  G.edgeSet, e ∈ p.edgeSet := by
+  have : ∀ e ∈ G.edgeSet, e ∈ p.edgeSet := by
     have : p.edgeSet = G.edgeSet := by
       have : p.edges.toFinset = G.edgeFinset :=
-        Finset.eq_of_subset_of_card_le he (Eq.ge h_support_length)
+        Finset.eq_of_subset_of_card_le he h_support_length.ge
       calc
         p.edgeSet = ↑p.edges.toFinset := by rw [Walk.coe_edges_toFinset]
         _ = ↑G.edgeFinset := by rw [this]
@@ -176,7 +174,7 @@ theorem IsEulerian (c : G.IsCycle) : ∃ (v : V) (p : G.Walk v v), p.IsEulerian 
   obtain ⟨v, p, hpc⟩ := c.isCyclic
   use v
   use p
-  have h_trail := Walk.IsCircuit.isTrail (Walk.IsCycle.isCircuit hpc)
+  have h_trail := hpc.isCircuit.isTrail
   simp only [h_trail, true_and]
   exact c.cycle_walk_contains_all_edges G hpc
 

--- a/Mathlib/Combinatorics/SimpleGraph/Cycle.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Cycle.lean
@@ -44,7 +44,7 @@ lemma vertex_card_eq_edge_card (c : G.IsCycle) : Fintype.card V = Fintype.card G
     have hd : ∀ v ∈ (Finset.univ : Finset V), G.degree v ≤ 2 := by simp [c.2]
     rw [← Finset.card_univ, Finset.card_eq_sum_ones, Finset.mul_sum, mul_one,
       Finset.sum_eq_sum_iff_of_le hd]
-    simp
+    simp only [Finset.mem_univ, forall_const]
     exact c.2
   have h_e_card : ∑ (v : V), G.degree v = 2*(Fintype.card G.edgeSet) := by
     have hhl : ∑ (v : V), G.degree v = 2*G.edgeFinset.card := G.sum_degrees_eq_twice_card_edges
@@ -64,16 +64,16 @@ variable {v w : V}
 lemma IsCycles (c : G.IsCycle) : G.IsCycles := by
   intro v hv
   have h_n_card : Fintype.card (G.neighborSet v) = 2 := by
-    simp [G.card_neighborSet_eq_degree]
+    simp only [G.card_neighborSet_eq_degree]
     apply c.2
-  simp at h_n_card
+  simp only [Fintype.card_ofFinset, mem_neighborSet] at h_n_card
   simp [Set.ncard_eq_toFinset_card', h_n_card]
 
 lemma exists_adj (c : G.IsCycle) : ∃ (w : V), G.Adj v w := by
   have hd : G.degree v > 0 := by
     rw [c.2]
     trivial
-exact (G.degree_pos_iff_exists_adj v).mp hd
+  exact (G.degree_pos_iff_exists_adj v).mp hd
 
 lemma neighborSet_nonempty (c : G.IsCycle) : (G.neighborSet v).Nonempty := by
   obtain ⟨w, hw⟩ := c.exists_adj
@@ -81,7 +81,7 @@ lemma neighborSet_nonempty (c : G.IsCycle) : (G.neighborSet v).Nonempty := by
   use w
 
 lemma no_bridges (c : G.IsCycle) (hadj : G.Adj v w) : ¬G.IsBridge s(v, w) := by
-  simp [isBridge_iff, hadj]
+  simp only [isBridge_iff, hadj, true_and, not_not]
   exact IsCycles.reachable_deleteEdges hadj c.IsCycles
 
 lemma notTree (c : G.IsCycle) : ¬G.IsTree := by
@@ -89,7 +89,7 @@ lemma notTree (c : G.IsCycle) : ¬G.IsTree := by
 
 lemma notAcyclic (c : G.IsCycle) : ¬G.IsAcyclic := by
   have h_not_tree := c.notTree
-  simp [G.isTree_iff, c.1] at h_not_tree
+  simp only [G.isTree_iff, c.1, true_and] at h_not_tree
   exact h_not_tree
 
 lemma isCyclic (c : G.IsCycle) : ∃ (v : V) (p : G.Walk v v), p.IsCycle := by
@@ -132,14 +132,14 @@ lemma cycle_walk_tail_contains_all_vertices {p : G.Walk v v} (c : G.IsCycle) (hp
     · intro
       have : p.support ≠ [] := by simp
       by_cases h : w = p.support.head this
-      · simp at h
+      · simp only [Walk.head_support] at h
         rw [h]
         exact Walk.end_mem_tail_support hpc.not_nil
       · cases hs : p.support with
         | nil => contradiction
         | cons head tail => simp_all
     · exact List.mem_of_mem_tail
-  simp [← this]
+  simp only [← this]
   exact c.cycle_walk_contains_all_vertices G hpc
 
 variable [DecidableEq V]
@@ -158,7 +158,7 @@ lemma cycle_walk_contains_all_edges {p : G.Walk v v} (c : G.IsCycle) (h : p.IsCy
   rw [c.vertex_card_eq_edge_card, h_stl_tsl, p.tail.length_support, p.length_tail_add_one h.not_nil,
     ← p.length_edges, ← List.toFinset_card_of_nodup h.edges_nodup, h_e_card] at h_support_length
   have he : p.edges.toFinset ⊆ G.edgeFinset := by
-    simp
+    simp only [Set.subset_toFinset, List.coe_toFinset]
     apply Walk.edges_subset_edgeSet
   have : ∀ e ∈  G.edgeSet, e ∈ p.edgeSet := by
     have : p.edgeSet = G.edgeSet := by
@@ -172,22 +172,22 @@ lemma cycle_walk_contains_all_edges {p : G.Walk v v} (c : G.IsCycle) (h : p.IsCy
   simp_all
 
 theorem IsEulerian (c : G.IsCycle) : ∃ (v : V) (p : G.Walk v v), p.IsEulerian := by
-  simp [Walk.isEulerian_iff]
+  simp only [Walk.isEulerian_iff]
   obtain ⟨v, p, hpc⟩ := c.isCyclic
   use v
   use p
   have h_trail := Walk.IsCircuit.isTrail (Walk.IsCycle.isCircuit hpc)
-  simp [h_trail]
+  simp only [h_trail, true_and]
   exact c.cycle_walk_contains_all_edges G hpc
 
 lemma IsHamiltonian (c : G.IsCycle) : G.IsHamiltonian := by
   unfold SimpleGraph.IsHamiltonian
   intro
-  simp [Walk.isHamiltonianCycle_iff_isCycle_and_support_count_tail_eq_one]
+  simp only [Walk.isHamiltonianCycle_iff_isCycle_and_support_count_tail_eq_one]
   obtain ⟨v, p, hcyc⟩ := c.isCyclic
   use v
   use p
-  simp [hcyc]
+  simp only [hcyc, true_and]
   intro v
   have : v ∈ p.support.tail := by apply c.cycle_walk_tail_contains_all_vertices G hcyc
   apply List.count_eq_one_of_mem hcyc.support_nodup this

--- a/Mathlib/Combinatorics/SimpleGraph/Cycle.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Cycle.lean
@@ -1,0 +1,207 @@
+/-
+Copyright (c) 2025 Yunge Yu. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yunge Yu
+-/
+import Mathlib.Combinatorics.SimpleGraph.Acyclic
+import Mathlib.Combinatorics.SimpleGraph.Hamiltonian
+import Mathlib.Combinatorics.SimpleGraph.Matching
+import Mathlib.Combinatorics.SimpleGraph.Path
+import Mathlib.Combinatorics.SimpleGraph.Trails
+
+/-!
+
+# Cycle Graphs
+
+This module introduces *cycle graphs*.
+
+## Main definitions
+
+* `SimpleGraph.IsCycle` is a predicate for a graph being a cycle graph
+
+## Tags
+
+cycle graphs
+-/
+
+namespace SimpleGraph
+
+variable {V : Type*} (G : SimpleGraph V)
+
+variable [Fintype V] [DecidableRel G.Adj]
+
+/-- A graph is a *cycle* if it is connected, and every vertex has degree 2. -/
+def IsCycle : Prop := G.Connected ∧ (∀ (v : V), G.degree v = 2)
+
+namespace IsCycle
+
+lemma Connected (c : G.IsCycle) : G.Connected := c.1
+
+lemma all_vertices_degree_two (c : G.IsCycle) : ∀ (v : V), G.degree v = 2 := c.2
+
+lemma vertex_card_eq_edge_card (c : G.IsCycle) : Fintype.card V = Fintype.card G.edgeSet := by
+  have h_v_card : ∑ (v : V), G.degree v = 2*(Fintype.card V) := by
+    have hd : ∀ v ∈ (Finset.univ : Finset V), G.degree v ≤ 2 := by simp [c.2]
+    rw [← Finset.card_univ, Finset.card_eq_sum_ones, Finset.mul_sum, mul_one,
+      Finset.sum_eq_sum_iff_of_le hd]
+    simp
+    exact c.2
+  have h_e_card : ∑ (v : V), G.degree v = 2*(Fintype.card G.edgeSet) := by
+    have hhl : ∑ (v : V), G.degree v = 2*G.edgeFinset.card := G.sum_degrees_eq_twice_card_edges
+    simp_all
+  simp_all
+
+lemma three_le_card (c : G.IsCycle) : 3 ≤ Fintype.card V := by
+  obtain ⟨hc, hd⟩ := c
+  rw [connected_iff] at hc
+  obtain ⟨_, ⟨v⟩⟩ := hc
+  have h_n_card := Finset.card_lt_univ_of_not_mem (G.not_mem_neighborFinset_self v)
+  rw [G.card_neighborFinset_eq_degree, hd] at h_n_card
+  simp [Nat.add_one_le_iff, h_n_card]
+
+variable {v w : V}
+
+lemma IsCycles (c : G.IsCycle) : G.IsCycles := by
+  intro v hv
+  have h_n_card : Fintype.card (G.neighborSet v) = 2 := by
+    have : ∀ (v : V), Fintype.card (G.neighborSet v) = 2 := by
+      simp [G.card_neighborSet_eq_degree]
+      exact c.2
+    apply this
+  simp at h_n_card
+  simp [Set.ncard_eq_toFinset_card', h_n_card]
+
+lemma exists_adj (c : G.IsCycle) : ∃ (w : V), G.Adj v w := by
+  have hd : G.degree v > 0 := by
+    rw [c.2]
+    trivial
+  simp [G.degree_pos_iff_exists_adj] at hd
+  exact hd
+
+lemma neighborSet_nonempty (c : G.IsCycle) : (G.neighborSet v).Nonempty := by
+  obtain ⟨w, hw⟩ := c.exists_adj
+  have : w ∈ G.neighborSet v := hw
+  use w
+
+lemma no_bridges (c : G.IsCycle) (hadj : G.Adj v w) : ¬G.IsBridge s(v, w) := by
+  simp [isBridge_iff, hadj]
+  exact IsCycles.reachable_deleteEdges hadj c.IsCycles
+
+lemma notTree (c : G.IsCycle) : ¬G.IsTree := by
+  simp [G.isTree_iff_connected_and_card, c.vertex_card_eq_edge_card]
+
+lemma notAcyclic (c : G.IsCycle) : ¬G.IsAcyclic := by
+  have h_not_tree := c.notTree
+  simp [G.isTree_iff, c.1] at h_not_tree
+  exact h_not_tree
+
+lemma isCyclic (c : G.IsCycle) : ∃ (v : V) (p : G.Walk v v), p.IsCycle := by
+  have h_not_acyclic := c.notAcyclic
+  unfold IsAcyclic at h_not_acyclic
+  simp_all
+
+lemma all_vertices_form_a_cycle (c : G.IsCycle) : ∃ (p : G.Walk v v), p.IsCycle := by
+  have hv : v ∈ G.connectedComponentMk v := ConnectedComponent.connectedComponentMk_mem
+  obtain ⟨p, hpc, _⟩ := IsCycles.exists_cycle_toSubgraph_verts_eq_connectedComponentSupp
+    c.IsCycles hv c.neighborSet_nonempty
+  use p
+
+lemma cycle_walk_contains_all_vertices {p : G.Walk v v} (c : G.IsCycle) (hpc : p.IsCycle) :
+    ∀ (v : V), v ∈ p.support := by
+  intro w
+  have hvw_reachable : G.Reachable v w := by
+    have : ∀ (v w : V), G.Reachable v w := c.1
+    apply this
+  have hpv : p.toSubgraph.verts = (G.connectedComponentMk v).supp := by
+    have : ∀ v ∈ p.toSubgraph.verts, ∀ (w : V), G.Adj v w → p.toSubgraph.Adj v w := by
+      intro v hv w hvw
+      refine (Subgraph.adj_iff_of_neighborSet_equiv ?_ (Set.toFinite _)).mpr hvw
+      refine @Classical.ofNonempty _ ?_
+      rw [← Cardinal.eq, ← Set.cast_ncard (Set.toFinite _), ← Set.cast_ncard (Set.toFinite _),
+        c.IsCycles G c.exists_adj,
+        hpc.ncard_neighborSet_toSubgraph_eq_two (p.mem_verts_toSubgraph.mp hv)]
+    obtain ⟨cc, hcc⟩ := p.toSubgraph_connected.exists_verts_eq_connectedComponentSupp this
+    rw [hcc]
+    have : v ∈ cc.supp := by simp [← hcc]
+    simp_all
+  rw [← Walk.mem_verts_toSubgraph, hpv]
+  have hw : w ∈ (G.connectedComponentMk w) := ConnectedComponent.connectedComponentMk_mem
+  have hvw : G.connectedComponentMk v = G.connectedComponentMk w := by
+    apply ConnectedComponent.sound
+    exact hvw_reachable
+  simp [hvw, hw]
+
+lemma cycle_walk_tail_contains_all_vertices {p : G.Walk v v} (c : G.IsCycle) (hpc : p.IsCycle) :
+    ∀ (v : V), v ∈ p.support.tail := by
+  have : ∀ (v : V), v ∈ p.support ↔ v ∈ p.support.tail := by
+    intro w
+    constructor
+    · intro
+      have : p.support ≠ [] := by simp
+      by_cases h : w = p.support.head this
+      · simp at h
+        rw [h]
+        exact Walk.end_mem_tail_support hpc.not_nil
+      · cases hs : p.support with
+        | nil => contradiction
+        | cons head tail => simp_all
+    · exact List.mem_of_mem_tail
+  simp [← this]
+  exact c.cycle_walk_contains_all_vertices G hpc
+
+variable [DecidableEq V]
+
+lemma cycle_walk_contains_all_edges {p : G.Walk v v} (c : G.IsCycle) (h : p.IsCycle) :
+    ∀ e ∈ G.edgeSet, e ∈ p.edges := by
+  have h_stl_tsl : p.support.tail.length = p.tail.support.length := by
+    simp [p.support_tail h.not_nil]
+  have h_e_card : Fintype.card G.edgeSet = G.edgeFinset.card := by simp
+  have h_support_length : p.support.tail.length = Fintype.card V := by
+    rw [← List.toFinset_card_of_nodup h.support_nodup]
+    have : p.support.tail.toFinset.card = Fintype.card V := by
+      have : ∀ (v : V), v ∈ p.support.tail.toFinset := by
+        simp [c.cycle_walk_tail_contains_all_vertices G h]
+      rw [← Finset.eq_univ_iff_forall] at this
+      simp [this]
+    exact this
+  rw [c.vertex_card_eq_edge_card, h_stl_tsl, p.tail.length_support, p.length_tail_add_one h.not_nil,
+    ← p.length_edges, ← List.toFinset_card_of_nodup h.edges_nodup, h_e_card] at h_support_length
+  have he : p.edges.toFinset ⊆ G.edgeFinset := by
+    simp
+    apply Walk.edges_subset_edgeSet
+  have : ∀ e ∈  G.edgeSet, e ∈ p.edgeSet := by
+    have : p.edgeSet = G.edgeSet := by
+      have : p.edges.toFinset = G.edgeFinset :=
+        Finset.eq_of_subset_of_card_le he (Eq.ge h_support_length)
+      calc
+        p.edgeSet = ↑p.edges.toFinset := by rw [Walk.coe_edges_toFinset]
+        _ = ↑G.edgeFinset := by rw [this]
+        _ = G.edgeSet := by rw [coe_edgeFinset]
+    simp [this]
+  simp_all
+
+theorem IsEulerian (c : G.IsCycle) : ∃ (v : V) (p : G.Walk v v), p.IsEulerian
+    := by
+  simp [Walk.isEulerian_iff]
+  obtain ⟨v, p, hpc⟩ := c.isCyclic
+  use v
+  use p
+  have h_trail := by apply Walk.IsCircuit.isTrail (Walk.IsCycle.isCircuit hpc)
+  simp [h_trail]
+  exact c.cycle_walk_contains_all_edges G hpc
+
+lemma IsHamiltonian (c : G.IsCycle) : G.IsHamiltonian := by
+  unfold SimpleGraph.IsHamiltonian
+  intro
+  simp [Walk.isHamiltonianCycle_iff_isCycle_and_support_count_tail_eq_one]
+  obtain ⟨v, p, hcyc⟩ := c.isCyclic
+  use v
+  use p
+  simp [hcyc]
+  intro v
+  have : v ∈ p.support.tail := by apply c.cycle_walk_tail_contains_all_vertices G hcyc
+  apply List.count_eq_one_of_mem hcyc.support_nodup this
+
+end IsCycle
+
+end SimpleGraph

--- a/Mathlib/Combinatorics/SimpleGraph/Cycle.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Cycle.lean
@@ -41,9 +41,7 @@ lemma all_vertices_degree_two (c : G.IsCycle) : ∀ (v : V), G.degree v = 2 := c
 
 lemma vertex_card_eq_edge_card (c : G.IsCycle) : Fintype.card V = Fintype.card G.edgeSet := by
   have h_v_card : ∑ (v : V), G.degree v = 2*(Fintype.card V) := by
-    have hd : ∀ v ∈ (Finset.univ : Finset V), G.degree v ≤ 2 := by simp [c.2]
-    simp only [← Finset.card_univ, Finset.card_eq_sum_ones, Finset.mul_sum, mul_one,
-      Finset.sum_eq_sum_iff_of_le hd, Finset.mem_univ, forall_const, c.2]
+    simp only [← Finset.card_univ, Finset.card_eq_sum_ones, Finset.mul_sum, mul_one, c.2]
   simp_all [G.sum_degrees_eq_twice_card_edges]
 
 lemma three_le_card (c : G.IsCycle) : 3 ≤ Fintype.card V := by

--- a/Mathlib/Combinatorics/SimpleGraph/Cycle.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Cycle.lean
@@ -64,10 +64,8 @@ variable {v w : V}
 lemma IsCycles (c : G.IsCycle) : G.IsCycles := by
   intro v hv
   have h_n_card : Fintype.card (G.neighborSet v) = 2 := by
-    have : ∀ (v : V), Fintype.card (G.neighborSet v) = 2 := by
-      simp [G.card_neighborSet_eq_degree]
-      exact c.2
-    apply this
+    simp [G.card_neighborSet_eq_degree]
+    apply c.2
   simp at h_n_card
   simp [Set.ncard_eq_toFinset_card', h_n_card]
 
@@ -75,8 +73,7 @@ lemma exists_adj (c : G.IsCycle) : ∃ (w : V), G.Adj v w := by
   have hd : G.degree v > 0 := by
     rw [c.2]
     trivial
-  simp [G.degree_pos_iff_exists_adj] at hd
-  exact hd
+exact (G.degree_pos_iff_exists_adj v).mp hd
 
 lemma neighborSet_nonempty (c : G.IsCycle) : (G.neighborSet v).Nonempty := by
   obtain ⟨w, hw⟩ := c.exists_adj
@@ -107,11 +104,9 @@ lemma all_vertices_form_a_cycle (c : G.IsCycle) : ∃ (p : G.Walk v v), p.IsCycl
   use p
 
 lemma cycle_walk_contains_all_vertices {p : G.Walk v v} (c : G.IsCycle) (hpc : p.IsCycle) :
-    ∀ (v : V), v ∈ p.support := by
+    ∀ (w : V), w ∈ p.support := by
   intro w
-  have hvw_reachable : G.Reachable v w := by
-    have : ∀ (v w : V), G.Reachable v w := c.1
-    apply this
+  have hvw_reachable : G.Reachable v w := c.1 v w
   have hpv : p.toSubgraph.verts = (G.connectedComponentMk v).supp := by
     have : ∀ v ∈ p.toSubgraph.verts, ∀ (w : V), G.Adj v w → p.toSubgraph.Adj v w := by
       intro v hv w hvw
@@ -125,14 +120,13 @@ lemma cycle_walk_contains_all_vertices {p : G.Walk v v} (c : G.IsCycle) (hpc : p
     have : v ∈ cc.supp := by simp [← hcc]
     simp_all
   rw [← Walk.mem_verts_toSubgraph, hpv]
-  have hvw : G.connectedComponentMk v = G.connectedComponentMk w := by
-    apply ConnectedComponent.sound
-    exact hvw_reachable
+  have hvw : G.connectedComponentMk v = G.connectedComponentMk w :=
+    ConnectedComponent.sound hvw_reachable
   simp [hvw]
 
 lemma cycle_walk_tail_contains_all_vertices {p : G.Walk v v} (c : G.IsCycle) (hpc : p.IsCycle) :
-    ∀ (v : V), v ∈ p.support.tail := by
-  have : ∀ (v : V), v ∈ p.support ↔ v ∈ p.support.tail := by
+    ∀ (w : V), w ∈ p.support.tail := by
+  have : ∀ (w : V), w ∈ p.support ↔ w ∈ p.support.tail := by
     intro w
     constructor
     · intro
@@ -157,12 +151,10 @@ lemma cycle_walk_contains_all_edges {p : G.Walk v v} (c : G.IsCycle) (h : p.IsCy
   have h_e_card : Fintype.card G.edgeSet = G.edgeFinset.card := by simp
   have h_support_length : p.support.tail.length = Fintype.card V := by
     rw [← List.toFinset_card_of_nodup h.support_nodup]
-    have : p.support.tail.toFinset.card = Fintype.card V := by
-      have : ∀ (v : V), v ∈ p.support.tail.toFinset := by
-        simp [c.cycle_walk_tail_contains_all_vertices G h]
-      rw [← Finset.eq_univ_iff_forall] at this
-      simp [this]
-    exact this
+    have : ∀ (v : V), v ∈ p.support.tail.toFinset := by
+      simp [c.cycle_walk_tail_contains_all_vertices G h]
+    rw [← Finset.eq_univ_iff_forall] at this
+    simp [this]
   rw [c.vertex_card_eq_edge_card, h_stl_tsl, p.tail.length_support, p.length_tail_add_one h.not_nil,
     ← p.length_edges, ← List.toFinset_card_of_nodup h.edges_nodup, h_e_card] at h_support_length
   have he : p.edges.toFinset ⊆ G.edgeFinset := by
@@ -179,13 +171,12 @@ lemma cycle_walk_contains_all_edges {p : G.Walk v v} (c : G.IsCycle) (h : p.IsCy
     simp [this]
   simp_all
 
-theorem IsEulerian (c : G.IsCycle) : ∃ (v : V) (p : G.Walk v v), p.IsEulerian
-    := by
+theorem IsEulerian (c : G.IsCycle) : ∃ (v : V) (p : G.Walk v v), p.IsEulerian := by
   simp [Walk.isEulerian_iff]
   obtain ⟨v, p, hpc⟩ := c.isCyclic
   use v
   use p
-  have h_trail := by apply Walk.IsCircuit.isTrail (Walk.IsCycle.isCircuit hpc)
+  have h_trail := Walk.IsCircuit.isTrail (Walk.IsCycle.isCircuit hpc)
   simp [h_trail]
   exact c.cycle_walk_contains_all_edges G hpc
 

--- a/Mathlib/Combinatorics/SimpleGraph/Cycle.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Cycle.lean
@@ -125,11 +125,10 @@ lemma cycle_walk_contains_all_vertices {p : G.Walk v v} (c : G.IsCycle) (hpc : p
     have : v ∈ cc.supp := by simp [← hcc]
     simp_all
   rw [← Walk.mem_verts_toSubgraph, hpv]
-  have hw : w ∈ (G.connectedComponentMk w) := ConnectedComponent.connectedComponentMk_mem
   have hvw : G.connectedComponentMk v = G.connectedComponentMk w := by
     apply ConnectedComponent.sound
     exact hvw_reachable
-  simp [hvw, hw]
+  simp [hvw]
 
 lemma cycle_walk_tail_contains_all_vertices {p : G.Walk v v} (c : G.IsCycle) (hpc : p.IsCycle) :
     ∀ (v : V), v ∈ p.support.tail := by


### PR DESCRIPTION
The existing `cycleGraph` implementation under Combinatorics/SimpleGraph/Circulant.lean only operates over `Fin n`. This PR implements a cycle graph implementation over any generic vertex type. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
