### PR TITLE
[Merged by Bors] - feat(MeasureTheory): integral is monotone/convex if the integrand is monotone/convex

### DIFF
--- a/Mathlib/Analysis/Convex/Basic.lean
+++ b/Mathlib/Analysis/Convex/Basic.lean
@@ -79,6 +79,23 @@ theorem convex_iff_pointwise_add_subset :
       exact hA hu hv ha hb hab)
     fun h _ hx _ hy _ _ ha hb hab => (h ha hb hab) (Set.add_mem_add ⟨_, hx, rfl⟩ ⟨_, hy, rfl⟩)
 
+theorem Convex.iff_pointwise_add_mem : Convex 𝕜 s ↔
+    ∀ ⦃x⦄, x ∈ s → ∀ ⦃y⦄, y ∈ s → ∀ ⦃a b : 𝕜⦄, 0 ≤ a → 0 ≤ b → a + b = 1 → a • x + b • y ∈ s := by
+  rw [convex_iff_pointwise_add_subset]
+  constructor
+  case mp =>
+    intro hs x hx y hy a b ha hb hab
+    apply hs ha hb hab
+    rw [Set.mem_add]
+    exact ⟨a • x, smul_mem_smul_set hx, b • y, smul_mem_smul_set hy, rfl⟩
+  case mpr =>
+    intro h a b ha hb hab
+    intro z hz
+    rw [Set.mem_add] at hz
+    obtain ⟨z₁, hz₁, z₂, hz₂, hz₂'⟩ := hz
+
+    sorry
+
 alias ⟨Convex.set_combo_subset, _⟩ := convex_iff_pointwise_add_subset
 
 theorem convex_empty : Convex 𝕜 (∅ : Set E) := fun _ => False.elim

--- a/Mathlib/Analysis/Convex/Basic.lean
+++ b/Mathlib/Analysis/Convex/Basic.lean
@@ -70,6 +70,10 @@ theorem Convex.openSegment_subset (h : Convex 𝕜 s) {x y : E} (hx : x ∈ s) (
     openSegment 𝕜 x y ⊆ s :=
   (openSegment_subset_segment 𝕜 x y).trans (h.segment_subset hx hy)
 
+theorem convex_iff_add_mem : Convex 𝕜 s ↔
+    ∀ ⦃x⦄, x ∈ s → ∀ ⦃y⦄, y ∈ s → ∀ ⦃a b : 𝕜⦄, 0 ≤ a → 0 ≤ b → a + b = 1 → a • x + b • y ∈ s := by
+  simp_rw [convex_iff_segment_subset, segment_subset_iff]
+
 /-- Alternative definition of set convexity, in terms of pointwise set operations. -/
 theorem convex_iff_pointwise_add_subset :
     Convex 𝕜 s ↔ ∀ ⦃a b : 𝕜⦄, 0 ≤ a → 0 ≤ b → a + b = 1 → a • s + b • s ⊆ s :=
@@ -78,23 +82,6 @@ theorem convex_iff_pointwise_add_subset :
       rintro hA a b ha hb hab w ⟨au, ⟨u, hu, rfl⟩, bv, ⟨v, hv, rfl⟩, rfl⟩
       exact hA hu hv ha hb hab)
     fun h _ hx _ hy _ _ ha hb hab => (h ha hb hab) (Set.add_mem_add ⟨_, hx, rfl⟩ ⟨_, hy, rfl⟩)
-
-theorem Convex.iff_pointwise_add_mem : Convex 𝕜 s ↔
-    ∀ ⦃x⦄, x ∈ s → ∀ ⦃y⦄, y ∈ s → ∀ ⦃a b : 𝕜⦄, 0 ≤ a → 0 ≤ b → a + b = 1 → a • x + b • y ∈ s := by
-  rw [convex_iff_pointwise_add_subset]
-  constructor
-  case mp =>
-    intro hs x hx y hy a b ha hb hab
-    apply hs ha hb hab
-    rw [Set.mem_add]
-    exact ⟨a • x, smul_mem_smul_set hx, b • y, smul_mem_smul_set hy, rfl⟩
-  case mpr =>
-    intro h a b ha hb hab
-    intro z hz
-    rw [Set.mem_add] at hz
-    obtain ⟨z₁, hz₁, z₂, hz₂, hz₂'⟩ := hz
-
-    sorry
 
 alias ⟨Convex.set_combo_subset, _⟩ := convex_iff_pointwise_add_subset
 

--- a/Mathlib/MeasureTheory/Function/L1Space/Integrable.lean
+++ b/Mathlib/MeasureTheory/Function/L1Space/Integrable.lean
@@ -826,6 +826,11 @@ theorem Integrable.smul [NormedAddCommGroup 𝕜] [SMulZeroClass 𝕜 β] [IsBou
     {f : α → β} (hf : Integrable f μ) : Integrable (c • f) μ :=
   ⟨hf.aestronglyMeasurable.const_smul c, hf.hasFiniteIntegral.smul c⟩
 
+@[fun_prop]
+theorem Integrable.fun_smul [NormedAddCommGroup 𝕜] [SMulZeroClass 𝕜 β] [IsBoundedSMul 𝕜 β] (c : 𝕜)
+    {f : α → β} (hf : Integrable f μ) : Integrable (fun x ↦ c • f x) μ :=
+  hf.smul c
+
 theorem _root_.IsUnit.integrable_smul_iff [NormedRing 𝕜] [MulActionWithZero 𝕜 β]
     [IsBoundedSMul 𝕜 β] {c : 𝕜} (hc : IsUnit c) (f : α → β) :
     Integrable (c • f) μ ↔ Integrable f μ :=

--- a/Mathlib/MeasureTheory/Integral/Bochner/Basic.lean
+++ b/Mathlib/MeasureTheory/Integral/Bochner/Basic.lean
@@ -645,15 +645,13 @@ lemma integral_convexOn_of_integrand_ae {β : Type*} [AddCommMonoid β]
                     refine hf_int _ ?_
                     rw [convex_iff_add_mem] at hs
                     exact hs ha hb hp hq hpq
-                  case rhs =>
-                    exact Integrable.add
-                        (Integrable.smul _ (hf_int a ha)) (Integrable.smul _ (hf_int b hb))
+                  case rhs => fun_prop (disch := aesop)
                   case ae_le =>
                     filter_upwards [hf_conv] with x hx
                     exact hx.2 ha hb hp hq hpq
             _ = ∫ x, p • f x a ∂μ + ∫ x, q • f x b ∂μ := by
-                  exact integral_add
-                    (Integrable.smul _ (hf_int a ha)) (Integrable.smul _ (hf_int b hb))
+                  apply integral_add
+                  all_goals fun_prop (disch := aesop)
             _ = p • ∫ x, f x a ∂μ + q • ∫ x, f x b ∂μ := by simp [integral_smul]
 
 lemma integral_concaveOn_of_integrand_ae {β : Type*} [AddCommMonoid β]
@@ -661,10 +659,8 @@ lemma integral_concaveOn_of_integrand_ae {β : Type*} [AddCommMonoid β]
     (hf_conc : ∀ᵐ x ∂μ, ConcaveOn ℝ s (f x)) (hf_int : ∀ a ∈ s, Integrable (f · a) μ) :
     ConcaveOn ℝ s (fun b => ∫ x, f x b ∂μ) := by
   simp_rw [← neg_convexOn_iff] at hf_conc ⊢
-  have hf_int' : ∀ a ∈ s,  Integrable ((-f) · a) μ := fun a ha => Integrable.neg <| hf_int a ha
-  change ConvexOn ℝ s (fun b ↦ -∫ (x : α), f x b ∂μ)
-  simp_rw [← integral_neg]
-  exact integral_convexOn_of_integrand_ae hs hf_conc hf_int'
+  simpa only [Pi.neg_apply, integral_neg] using
+    integral_convexOn_of_integrand_ae hs hf_conc (hf_int · · |>.neg)
 
 end Order
 

--- a/Mathlib/MeasureTheory/Integral/Bochner/Basic.lean
+++ b/Mathlib/MeasureTheory/Integral/Bochner/Basic.lean
@@ -633,7 +633,6 @@ lemma integral_antitoneOn_of_integrand_ae {β : Type*} [Preorder β] {f : α →
   filter_upwards [hf_anti] with x hx
   exact hx ha hb hab
 
-open Pointwise in
 lemma integral_convexOn_of_integrand_ae {β : Type*} [AddCommMonoid β] [PartialOrder β]
     [Module ℝ β] [IsOrderedAddMonoid β] {f : α → β → E} {s : Set β} (hs : Convex ℝ s)
     (hf_conv : ∀ᵐ x ∂μ, ConvexOn ℝ s (f x)) (hf_int : ∀ a ∈ s, Integrable (f · a) μ) :
@@ -644,13 +643,8 @@ lemma integral_convexOn_of_integrand_ae {β : Type*} [AddCommMonoid β] [Partial
                   refine integral_mono_ae ?lhs ?rhs ?ae_le
                   case lhs =>
                     refine hf_int _ ?_
-                    --rw [convex_iff_pointwise_add_subset] at hs
-
-                    --refine hs hp hq hpq ?_
-                    --apply Set.add_smul_subset
-                    --simp [hpq]
-
-                    sorry
+                    rw [convex_iff_add_mem] at hs
+                    exact hs ha hb hp hq hpq
                   case rhs =>
                     exact Integrable.add
                         (Integrable.smul _ (hf_int a ha)) (Integrable.smul _ (hf_int b hb))
@@ -661,6 +655,16 @@ lemma integral_convexOn_of_integrand_ae {β : Type*} [AddCommMonoid β] [Partial
                   exact integral_add
                     (Integrable.smul _ (hf_int a ha)) (Integrable.smul _ (hf_int b hb))
             _ = p • ∫ x, f x a ∂μ + q • ∫ x, f x b ∂μ := by simp [integral_smul]
+
+lemma integral_concaveOn_of_integrand_ae {β : Type*} [AddCommMonoid β] [PartialOrder β]
+    [Module ℝ β] [IsOrderedAddMonoid β] {f : α → β → E} {s : Set β} (hs : Convex ℝ s)
+    (hf_conc : ∀ᵐ x ∂μ, ConcaveOn ℝ s (f x)) (hf_int : ∀ a ∈ s, Integrable (f · a) μ) :
+    ConcaveOn ℝ s (fun b => ∫ x, f x b ∂μ) := by
+  simp_rw [← neg_convexOn_iff] at hf_conc ⊢
+  have hf_int' : ∀ a ∈ s,  Integrable ((-f) · a) μ := fun a ha => Integrable.neg <| hf_int a ha
+  change ConvexOn ℝ s (fun b ↦ -∫ (x : α), f x b ∂μ)
+  simp_rw [← integral_neg]
+  exact integral_convexOn_of_integrand_ae hs hf_conc hf_int'
 
 end Order
 

--- a/Mathlib/MeasureTheory/Integral/Bochner/Basic.lean
+++ b/Mathlib/MeasureTheory/Integral/Bochner/Basic.lean
@@ -633,8 +633,8 @@ lemma integral_antitoneOn_of_integrand_ae {β : Type*} [Preorder β] {f : α →
   filter_upwards [hf_anti] with x hx
   exact hx ha hb hab
 
-lemma integral_convexOn_of_integrand_ae {β : Type*} [AddCommMonoid β] [PartialOrder β]
-    [Module ℝ β] [IsOrderedAddMonoid β] {f : α → β → E} {s : Set β} (hs : Convex ℝ s)
+lemma integral_convexOn_of_integrand_ae {β : Type*} [AddCommMonoid β]
+    [Module ℝ β] {f : α → β → E} {s : Set β} (hs : Convex ℝ s)
     (hf_conv : ∀ᵐ x ∂μ, ConvexOn ℝ s (f x)) (hf_int : ∀ a ∈ s, Integrable (f · a) μ) :
     ConvexOn ℝ s (fun b => ∫ x, f x b ∂μ) := by
   refine ⟨hs, ?_⟩
@@ -656,8 +656,8 @@ lemma integral_convexOn_of_integrand_ae {β : Type*} [AddCommMonoid β] [Partial
                     (Integrable.smul _ (hf_int a ha)) (Integrable.smul _ (hf_int b hb))
             _ = p • ∫ x, f x a ∂μ + q • ∫ x, f x b ∂μ := by simp [integral_smul]
 
-lemma integral_concaveOn_of_integrand_ae {β : Type*} [AddCommMonoid β] [PartialOrder β]
-    [Module ℝ β] [IsOrderedAddMonoid β] {f : α → β → E} {s : Set β} (hs : Convex ℝ s)
+lemma integral_concaveOn_of_integrand_ae {β : Type*} [AddCommMonoid β]
+    [Module ℝ β] {f : α → β → E} {s : Set β} (hs : Convex ℝ s)
     (hf_conc : ∀ᵐ x ∂μ, ConcaveOn ℝ s (f x)) (hf_int : ∀ a ∈ s, Integrable (f · a) μ) :
     ConcaveOn ℝ s (fun b => ∫ x, f x b ∂μ) := by
   simp_rw [← neg_convexOn_iff] at hf_conc ⊢


### PR DESCRIPTION
This PR shows that the function `fun b => ∫ x, f x b ∂μ` is monotone/antitone/convex/concave whenever the integrand `f x` is monotone/antitone/convex/concave ae.

This will be needed to show that various functions are operator monotone or convex.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
