### PR TITLE
[Merged by Bors] - refactor(Topology/UniformSpace): clarify def of TendstoLocallyUniformly

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -6240,6 +6240,7 @@ import Mathlib.Topology.UniformSpace.DiscreteUniformity
 import Mathlib.Topology.UniformSpace.Equicontinuity
 import Mathlib.Topology.UniformSpace.Equiv
 import Mathlib.Topology.UniformSpace.HeineCantor
+import Mathlib.Topology.UniformSpace.LocallyUniformConvergence
 import Mathlib.Topology.UniformSpace.Matrix
 import Mathlib.Topology.UniformSpace.OfCompactT2
 import Mathlib.Topology.UniformSpace.OfFun
@@ -6249,6 +6250,7 @@ import Mathlib.Topology.UniformSpace.Real
 import Mathlib.Topology.UniformSpace.Separation
 import Mathlib.Topology.UniformSpace.Ultra.Basic
 import Mathlib.Topology.UniformSpace.Ultra.Constructions
+import Mathlib.Topology.UniformSpace.UniformApproximation
 import Mathlib.Topology.UniformSpace.UniformConvergence
 import Mathlib.Topology.UniformSpace.UniformConvergenceTopology
 import Mathlib.Topology.UniformSpace.UniformEmbedding

--- a/Mathlib/Topology/EMetricSpace/Basic.lean
+++ b/Mathlib/Topology/EMetricSpace/Basic.lean
@@ -7,7 +7,7 @@ import Mathlib.Algebra.Order.BigOperators.Group.Finset
 import Mathlib.Order.Interval.Finset.Nat
 import Mathlib.Topology.EMetricSpace.Defs
 import Mathlib.Topology.UniformSpace.Compact
-import Mathlib.Topology.UniformSpace.UniformConvergence
+import Mathlib.Topology.UniformSpace.LocallyUniformConvergence
 import Mathlib.Topology.UniformSpace.UniformEmbedding
 
 /-!

--- a/Mathlib/Topology/UniformSpace/LocallyUniformConvergence.lean
+++ b/Mathlib/Topology/UniformSpace/LocallyUniformConvergence.lean
@@ -1,0 +1,224 @@
+/-
+Copyright (c) 2020 Sébastien Gouëzel. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sébastien Gouëzel
+-/
+import Mathlib.Topology.UniformSpace.UniformConvergence
+
+/-!
+# Locally uniform convergence
+
+We define a sequence of functions `Fₙ` to *converge locally uniformly* to a limiting function `f`
+with respect to a filter `p`, spelled `TendstoLocallyUniformly F f p`, if for any `x ∈ s` and any
+entourage of the diagonal `u`, there is a neighbourhood `v` of `x` such that `p`-eventually we have
+`(f y, Fₙ y) ∈ u` for all `y ∈ v`.
+
+It is important to note that this definition is somewhat non-standard; it is **not** in general
+equivalent to "every point has a neighborhood on which the convergence is uniform", which is the
+definition more commonly encountered in the literature. The reason is that in our definition the
+neighborhood `v` of `x` can depend on the entourage `u`; so our condition is *a priori* weaker than
+the usual one, although the two conditions are equivalent if the domain is locally compact.
+
+We adopt this weaker condition because it is more general but apppears to be sufficient for
+the standard applications of locally-uniform convergence (in particular, for proving that a
+locally-uniform limit of continuous functions is continuous).
+
+We also define variants for locally uniform convergence on a subset, called
+`TendstoLocallyUniformlyOn F f p s`.
+
+## Tags
+
+Uniform limit, uniform convergence, tends uniformly to
+ -/
+
+noncomputable section
+
+open Topology Uniformity Filter Set Uniform
+
+variable {α β γ ι : Type*} [TopologicalSpace α] [UniformSpace β]
+variable {F : ι → α → β} {f : α → β} {s s' : Set α} {x : α} {p : Filter ι}
+
+/-- A sequence of functions `Fₙ` converges locally uniformly on a set `s` to a limiting function
+`f` with respect to a filter `p` if, for any entourage of the diagonal `u`, for any `x ∈ s`, one
+has `p`-eventually `(f y, Fₙ y) ∈ u` for all `y` in a neighborhood of `x` in `s`. -/
+def TendstoLocallyUniformlyOn (F : ι → α → β) (f : α → β) (p : Filter ι) (s : Set α) :=
+  ∀ u ∈ 𝓤 β, ∀ x ∈ s, ∃ t ∈ 𝓝[s] x, ∀ᶠ n in p, ∀ y ∈ t, (f y, F n y) ∈ u
+
+/-- A sequence of functions `Fₙ` converges locally uniformly to a limiting function `f` with respect
+to a filter `p` if, for any entourage of the diagonal `u`, for any `x`, one has `p`-eventually
+`(f y, Fₙ y) ∈ u` for all `y` in a neighborhood of `x`. -/
+def TendstoLocallyUniformly (F : ι → α → β) (f : α → β) (p : Filter ι) :=
+  ∀ u ∈ 𝓤 β, ∀ x : α, ∃ t ∈ 𝓝 x, ∀ᶠ n in p, ∀ y ∈ t, (f y, F n y) ∈ u
+
+theorem tendstoLocallyUniformlyOn_univ :
+    TendstoLocallyUniformlyOn F f p univ ↔ TendstoLocallyUniformly F f p := by
+  simp [TendstoLocallyUniformlyOn, TendstoLocallyUniformly, nhdsWithin_univ]
+
+theorem tendstoLocallyUniformlyOn_iff_forall_tendsto :
+    TendstoLocallyUniformlyOn F f p s ↔
+      ∀ x ∈ s, Tendsto (fun y : ι × α => (f y.2, F y.1 y.2)) (p ×ˢ 𝓝[s] x) (𝓤 β) :=
+  forall₂_swap.trans <| forall₄_congr fun _ _ _ _ => by
+    rw [mem_map, mem_prod_iff_right]; rfl
+
+nonrec theorem IsOpen.tendstoLocallyUniformlyOn_iff_forall_tendsto (hs : IsOpen s) :
+    TendstoLocallyUniformlyOn F f p s ↔
+      ∀ x ∈ s, Tendsto (fun y : ι × α => (f y.2, F y.1 y.2)) (p ×ˢ 𝓝 x) (𝓤 β) :=
+  tendstoLocallyUniformlyOn_iff_forall_tendsto.trans <| forall₂_congr fun x hx => by
+    rw [hs.nhdsWithin_eq hx]
+
+theorem tendstoLocallyUniformly_iff_forall_tendsto :
+    TendstoLocallyUniformly F f p ↔
+      ∀ x, Tendsto (fun y : ι × α => (f y.2, F y.1 y.2)) (p ×ˢ 𝓝 x) (𝓤 β) := by
+  simp [← tendstoLocallyUniformlyOn_univ, isOpen_univ.tendstoLocallyUniformlyOn_iff_forall_tendsto]
+
+theorem tendstoLocallyUniformlyOn_iff_tendstoLocallyUniformly_comp_coe :
+    TendstoLocallyUniformlyOn F f p s ↔
+      TendstoLocallyUniformly (fun i (x : s) => F i x) (f ∘ (↑)) p := by
+  simp only [tendstoLocallyUniformly_iff_forall_tendsto, Subtype.forall', tendsto_map'_iff,
+    tendstoLocallyUniformlyOn_iff_forall_tendsto, ← map_nhds_subtype_val, prod_map_right]; rfl
+
+protected theorem TendstoUniformlyOn.tendstoLocallyUniformlyOn (h : TendstoUniformlyOn F f p s) :
+    TendstoLocallyUniformlyOn F f p s := fun u hu _ _ =>
+  ⟨s, self_mem_nhdsWithin, by simpa using h u hu⟩
+
+protected theorem TendstoUniformly.tendstoLocallyUniformly (h : TendstoUniformly F f p) :
+    TendstoLocallyUniformly F f p := fun u hu _ => ⟨univ, univ_mem, by simpa using h u hu⟩
+
+theorem TendstoLocallyUniformlyOn.mono (h : TendstoLocallyUniformlyOn F f p s) (h' : s' ⊆ s) :
+    TendstoLocallyUniformlyOn F f p s' := by
+  intro u hu x hx
+  rcases h u hu x (h' hx) with ⟨t, ht, H⟩
+  exact ⟨t, nhdsWithin_mono x h' ht, H.mono fun n => id⟩
+
+theorem tendstoLocallyUniformlyOn_iUnion {ι' : Sort*} {S : ι' → Set α} (hS : ∀ i, IsOpen (S i))
+    (h : ∀ i, TendstoLocallyUniformlyOn F f p (S i)) :
+    TendstoLocallyUniformlyOn F f p (⋃ i, S i) :=
+  (isOpen_iUnion hS).tendstoLocallyUniformlyOn_iff_forall_tendsto.2 fun _x hx =>
+    let ⟨i, hi⟩ := mem_iUnion.1 hx
+    (hS i).tendstoLocallyUniformlyOn_iff_forall_tendsto.1 (h i) _ hi
+
+theorem tendstoLocallyUniformlyOn_biUnion {s : Set γ} {S : γ → Set α} (hS : ∀ i ∈ s, IsOpen (S i))
+    (h : ∀ i ∈ s, TendstoLocallyUniformlyOn F f p (S i)) :
+    TendstoLocallyUniformlyOn F f p (⋃ i ∈ s, S i) :=
+  tendstoLocallyUniformlyOn_iUnion (fun i => isOpen_iUnion (hS i)) fun i =>
+   tendstoLocallyUniformlyOn_iUnion (hS i) (h i)
+
+theorem tendstoLocallyUniformlyOn_sUnion (S : Set (Set α)) (hS : ∀ s ∈ S, IsOpen s)
+    (h : ∀ s ∈ S, TendstoLocallyUniformlyOn F f p s) : TendstoLocallyUniformlyOn F f p (⋃₀ S) := by
+  rw [sUnion_eq_biUnion]
+  exact tendstoLocallyUniformlyOn_biUnion hS h
+
+theorem TendstoLocallyUniformlyOn.union (hs₁ : IsOpen s) (hs₂ : IsOpen s')
+    (h₁ : TendstoLocallyUniformlyOn F f p s) (h₂ : TendstoLocallyUniformlyOn F f p s') :
+    TendstoLocallyUniformlyOn F f p (s ∪ s') := by
+  rw [← sUnion_pair]
+  refine tendstoLocallyUniformlyOn_sUnion _ ?_ ?_ <;> simp [*]
+
+protected theorem TendstoLocallyUniformly.tendstoLocallyUniformlyOn
+    (h : TendstoLocallyUniformly F f p) : TendstoLocallyUniformlyOn F f p s :=
+  (tendstoLocallyUniformlyOn_univ.mpr h).mono (subset_univ _)
+
+/-- On a compact space, locally uniform convergence is just uniform convergence. -/
+theorem tendstoLocallyUniformly_iff_tendstoUniformly_of_compactSpace [CompactSpace α] :
+    TendstoLocallyUniformly F f p ↔ TendstoUniformly F f p := by
+  refine ⟨fun h V hV => ?_, TendstoUniformly.tendstoLocallyUniformly⟩
+  choose U hU using h V hV
+  obtain ⟨t, ht⟩ := isCompact_univ.elim_nhds_subcover' (fun k _ => U k) fun k _ => (hU k).1
+  replace hU := fun x : t => (hU x).2
+  rw [← eventually_all] at hU
+  refine hU.mono fun i hi x => ?_
+  specialize ht (mem_univ x)
+  simp only [exists_prop, mem_iUnion, SetCoe.exists, exists_and_right, Subtype.coe_mk] at ht
+  obtain ⟨y, ⟨hy₁, hy₂⟩, hy₃⟩ := ht
+  exact hi ⟨⟨y, hy₁⟩, hy₂⟩ x hy₃
+
+/-- For a compact set `s`, locally uniform convergence on `s` is just uniform convergence on `s`. -/
+theorem tendstoLocallyUniformlyOn_iff_tendstoUniformlyOn_of_compact (hs : IsCompact s) :
+    TendstoLocallyUniformlyOn F f p s ↔ TendstoUniformlyOn F f p s := by
+  haveI : CompactSpace s := isCompact_iff_compactSpace.mp hs
+  refine ⟨fun h => ?_, TendstoUniformlyOn.tendstoLocallyUniformlyOn⟩
+  rwa [tendstoLocallyUniformlyOn_iff_tendstoLocallyUniformly_comp_coe,
+    tendstoLocallyUniformly_iff_tendstoUniformly_of_compactSpace, ←
+    tendstoUniformlyOn_iff_tendstoUniformly_comp_coe] at h
+
+theorem TendstoLocallyUniformlyOn.comp [TopologicalSpace γ] {t : Set γ}
+    (h : TendstoLocallyUniformlyOn F f p s) (g : γ → α) (hg : MapsTo g t s)
+    (cg : ContinuousOn g t) : TendstoLocallyUniformlyOn (fun n => F n ∘ g) (f ∘ g) p t := by
+  intro u hu x hx
+  rcases h u hu (g x) (hg hx) with ⟨a, ha, H⟩
+  have : g ⁻¹' a ∈ 𝓝[t] x :=
+    (cg x hx).preimage_mem_nhdsWithin' (nhdsWithin_mono (g x) hg.image_subset ha)
+  exact ⟨g ⁻¹' a, this, H.mono fun n hn y hy => hn _ hy⟩
+
+theorem TendstoLocallyUniformly.comp [TopologicalSpace γ] (h : TendstoLocallyUniformly F f p)
+    (g : γ → α) (cg : Continuous g) : TendstoLocallyUniformly (fun n => F n ∘ g) (f ∘ g) p := by
+  rw [← tendstoLocallyUniformlyOn_univ] at h ⊢
+  rw [continuous_iff_continuousOn_univ] at cg
+  exact h.comp _ (mapsTo_univ _ _) cg
+
+theorem tendstoLocallyUniformlyOn_TFAE [LocallyCompactSpace α] (G : ι → α → β) (g : α → β)
+    (p : Filter ι) (hs : IsOpen s) :
+    List.TFAE [
+      TendstoLocallyUniformlyOn G g p s,
+      ∀ K, K ⊆ s → IsCompact K → TendstoUniformlyOn G g p K,
+      ∀ x ∈ s, ∃ v ∈ 𝓝[s] x, TendstoUniformlyOn G g p v] := by
+  tfae_have 1 → 2
+  | h, K, hK1, hK2 =>
+    (tendstoLocallyUniformlyOn_iff_tendstoUniformlyOn_of_compact hK2).mp (h.mono hK1)
+  tfae_have 2 → 3
+  | h, x, hx => by
+    obtain ⟨K, ⟨hK1, hK2⟩, hK3⟩ := (compact_basis_nhds x).mem_iff.mp (hs.mem_nhds hx)
+    exact ⟨K, nhdsWithin_le_nhds hK1, h K hK3 hK2⟩
+  tfae_have 3 → 1
+  | h, u, hu, x, hx => by
+    obtain ⟨v, hv1, hv2⟩ := h x hx
+    exact ⟨v, hv1, hv2 u hu⟩
+  tfae_finish
+
+theorem tendstoLocallyUniformlyOn_iff_forall_isCompact [LocallyCompactSpace α] (hs : IsOpen s) :
+    TendstoLocallyUniformlyOn F f p s ↔ ∀ K, K ⊆ s → IsCompact K → TendstoUniformlyOn F f p K :=
+  (tendstoLocallyUniformlyOn_TFAE F f p hs).out 0 1
+
+lemma tendstoLocallyUniformly_iff_forall_isCompact [LocallyCompactSpace α]  :
+    TendstoLocallyUniformly F f p ↔ ∀ K : Set α, IsCompact K → TendstoUniformlyOn F f p K := by
+  simp only [← tendstoLocallyUniformlyOn_univ,
+    tendstoLocallyUniformlyOn_iff_forall_isCompact isOpen_univ, Set.subset_univ, forall_true_left]
+
+theorem tendstoLocallyUniformlyOn_iff_filter :
+    TendstoLocallyUniformlyOn F f p s ↔ ∀ x ∈ s, TendstoUniformlyOnFilter F f p (𝓝[s] x) := by
+  simp only [TendstoUniformlyOnFilter, eventually_prod_iff]
+  constructor
+  · rintro h x hx u hu
+    obtain ⟨s, hs1, hs2⟩ := h u hu x hx
+    exact ⟨_, hs2, _, eventually_of_mem hs1 fun x => id, fun hi y hy => hi y hy⟩
+  · rintro h u hu x hx
+    obtain ⟨pa, hpa, pb, hpb, h⟩ := h x hx u hu
+    exact ⟨pb, hpb, eventually_of_mem hpa fun i hi y hy => h hi hy⟩
+
+theorem tendstoLocallyUniformly_iff_filter :
+    TendstoLocallyUniformly F f p ↔ ∀ x, TendstoUniformlyOnFilter F f p (𝓝 x) := by
+  simpa [← tendstoLocallyUniformlyOn_univ, ← nhdsWithin_univ] using
+    @tendstoLocallyUniformlyOn_iff_filter _ _ _ _ _ F f univ p
+
+theorem TendstoLocallyUniformlyOn.tendsto_at (hf : TendstoLocallyUniformlyOn F f p s) {a : α}
+    (ha : a ∈ s) : Tendsto (fun i => F i a) p (𝓝 (f a)) := by
+  refine ((tendstoLocallyUniformlyOn_iff_filter.mp hf) a ha).tendsto_at ?_
+  simpa only [Filter.principal_singleton] using pure_le_nhdsWithin ha
+
+theorem TendstoLocallyUniformlyOn.unique [p.NeBot] [T2Space β] {g : α → β}
+    (hf : TendstoLocallyUniformlyOn F f p s) (hg : TendstoLocallyUniformlyOn F g p s) :
+    s.EqOn f g := fun _a ha => tendsto_nhds_unique (hf.tendsto_at ha) (hg.tendsto_at ha)
+
+theorem TendstoLocallyUniformlyOn.congr {G : ι → α → β} (hf : TendstoLocallyUniformlyOn F f p s)
+    (hg : ∀ n, s.EqOn (F n) (G n)) : TendstoLocallyUniformlyOn G f p s := by
+  rintro u hu x hx
+  obtain ⟨t, ht, h⟩ := hf u hu x hx
+  refine ⟨s ∩ t, inter_mem self_mem_nhdsWithin ht, ?_⟩
+  filter_upwards [h] with i hi y hy using hg i hy.1 ▸ hi y hy.2
+
+theorem TendstoLocallyUniformlyOn.congr_right {g : α → β} (hf : TendstoLocallyUniformlyOn F f p s)
+    (hg : s.EqOn f g) : TendstoLocallyUniformlyOn F g p s := by
+  rintro u hu x hx
+  obtain ⟨t, ht, h⟩ := hf u hu x hx
+  refine ⟨s ∩ t, inter_mem self_mem_nhdsWithin ht, ?_⟩
+  filter_upwards [h] with i hi y hy using hg hy.1 ▸ hi y hy.2

--- a/Mathlib/Topology/UniformSpace/UniformApproximation.lean
+++ b/Mathlib/Topology/UniformSpace/UniformApproximation.lean
@@ -1,0 +1,180 @@
+/-
+Copyright (c) 2020 Sébastien Gouëzel. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sébastien Gouëzel
+-/
+import Mathlib.Topology.UniformSpace.LocallyUniformConvergence
+
+/-!
+# Uniform approximation
+
+In this file, we give lemmas ensuring that a function is continuous if it can be approximated
+uniformly by continuous functions. We give various versions, within a set or the whole space, at
+a single point or at all points, with locally uniform approximation or uniform approximation. All
+the statements are derived from a statement about locally uniform approximation within a set at
+a point, called `continuousWithinAt_of_locally_uniform_approx_of_continuousWithinAt`.
+
+## Implementation notes
+
+Most results hold under weaker assumptions of locally uniform approximation. In a first section,
+we prove the results under these weaker assumptions. Then, we derive the results on uniform
+convergence from them.
+
+## Tags
+
+Uniform limit, uniform convergence, tends uniformly to
+ -/
+
+
+noncomputable section
+
+open Topology Uniformity Filter Set Uniform
+
+variable {α β ι : Type*} [TopologicalSpace α] [UniformSpace β]
+variable {F : ι → α → β} {f : α → β} {s s' : Set α} {x : α} {p : Filter ι} {g : ι → α}
+
+/-- A function which can be locally uniformly approximated by functions which are continuous
+within a set at a point is continuous within this set at this point. -/
+theorem continuousWithinAt_of_locally_uniform_approx_of_continuousWithinAt (hx : x ∈ s)
+    (L : ∀ u ∈ 𝓤 β, ∃ t ∈ 𝓝[s] x, ∃ F : α → β, ContinuousWithinAt F s x ∧ ∀ y ∈ t, (f y, F y) ∈ u) :
+    ContinuousWithinAt f s x := by
+  refine Uniform.continuousWithinAt_iff'_left.2 fun u₀ hu₀ => ?_
+  obtain ⟨u₁, h₁, u₁₀⟩ : ∃ u ∈ 𝓤 β, u ○ u ⊆ u₀ := comp_mem_uniformity_sets hu₀
+  obtain ⟨u₂, h₂, hsymm, u₂₁⟩ : ∃ u ∈ 𝓤 β, (∀ {a b}, (a, b) ∈ u → (b, a) ∈ u) ∧ u ○ u ⊆ u₁ :=
+    comp_symm_of_uniformity h₁
+  rcases L u₂ h₂ with ⟨t, tx, F, hFc, hF⟩
+  have A : ∀ᶠ y in 𝓝[s] x, (f y, F y) ∈ u₂ := Eventually.mono tx hF
+  have B : ∀ᶠ y in 𝓝[s] x, (F y, F x) ∈ u₂ := Uniform.continuousWithinAt_iff'_left.1 hFc h₂
+  have C : ∀ᶠ y in 𝓝[s] x, (f y, F x) ∈ u₁ :=
+    (A.and B).mono fun y hy => u₂₁ (prodMk_mem_compRel hy.1 hy.2)
+  have : (F x, f x) ∈ u₁ :=
+    u₂₁ (prodMk_mem_compRel (refl_mem_uniformity h₂) (hsymm (A.self_of_nhdsWithin hx)))
+  exact C.mono fun y hy => u₁₀ (prodMk_mem_compRel hy this)
+
+/-- A function which can be locally uniformly approximated by functions which are continuous at
+a point is continuous at this point. -/
+theorem continuousAt_of_locally_uniform_approx_of_continuousAt
+    (L : ∀ u ∈ 𝓤 β, ∃ t ∈ 𝓝 x, ∃ F, ContinuousAt F x ∧ ∀ y ∈ t, (f y, F y) ∈ u) :
+    ContinuousAt f x := by
+  rw [← continuousWithinAt_univ]
+  apply continuousWithinAt_of_locally_uniform_approx_of_continuousWithinAt (mem_univ _) _
+  simpa only [exists_prop, nhdsWithin_univ, continuousWithinAt_univ] using L
+
+/-- A function which can be locally uniformly approximated by functions which are continuous
+on a set is continuous on this set. -/
+theorem continuousOn_of_locally_uniform_approx_of_continuousWithinAt
+    (L : ∀ x ∈ s, ∀ u ∈ 𝓤 β, ∃ t ∈ 𝓝[s] x, ∃ F,
+      ContinuousWithinAt F s x ∧ ∀ y ∈ t, (f y, F y) ∈ u) :
+    ContinuousOn f s := fun x hx =>
+  continuousWithinAt_of_locally_uniform_approx_of_continuousWithinAt hx (L x hx)
+
+/-- A function which can be uniformly approximated by functions which are continuous on a set
+is continuous on this set. -/
+theorem continuousOn_of_uniform_approx_of_continuousOn
+    (L : ∀ u ∈ 𝓤 β, ∃ F, ContinuousOn F s ∧ ∀ y ∈ s, (f y, F y) ∈ u) : ContinuousOn f s :=
+  continuousOn_of_locally_uniform_approx_of_continuousWithinAt fun _x hx u hu =>
+    ⟨s, self_mem_nhdsWithin, (L u hu).imp fun _F hF => ⟨hF.1.continuousWithinAt hx, hF.2⟩⟩
+
+/-- A function which can be locally uniformly approximated by continuous functions is continuous. -/
+theorem continuous_of_locally_uniform_approx_of_continuousAt
+    (L : ∀ x : α, ∀ u ∈ 𝓤 β, ∃ t ∈ 𝓝 x, ∃ F, ContinuousAt F x ∧ ∀ y ∈ t, (f y, F y) ∈ u) :
+    Continuous f :=
+  continuous_iff_continuousAt.2 fun x =>
+    continuousAt_of_locally_uniform_approx_of_continuousAt (L x)
+
+/-- A function which can be uniformly approximated by continuous functions is continuous. -/
+theorem continuous_of_uniform_approx_of_continuous
+    (L : ∀ u ∈ 𝓤 β, ∃ F, Continuous F ∧ ∀ y, (f y, F y) ∈ u) : Continuous f :=
+  continuous_iff_continuousOn_univ.mpr <|
+    continuousOn_of_uniform_approx_of_continuousOn <| by
+      simpa [continuous_iff_continuousOn_univ] using L
+
+/-!
+### Uniform limits
+
+From the previous statements on uniform approximation, we deduce continuity results for uniform
+limits.
+-/
+
+
+/-- A locally uniform limit on a set of functions which are continuous on this set is itself
+continuous on this set. -/
+protected theorem TendstoLocallyUniformlyOn.continuousOn (h : TendstoLocallyUniformlyOn F f p s)
+    (hc : ∀ᶠ n in p, ContinuousOn (F n) s) [NeBot p] : ContinuousOn f s := by
+  refine continuousOn_of_locally_uniform_approx_of_continuousWithinAt fun x hx u hu => ?_
+  rcases h u hu x hx with ⟨t, ht, H⟩
+  rcases (hc.and H).exists with ⟨n, hFc, hF⟩
+  exact ⟨t, ht, ⟨F n, hFc.continuousWithinAt hx, hF⟩⟩
+
+/-- A uniform limit on a set of functions which are continuous on this set is itself continuous
+on this set. -/
+protected theorem TendstoUniformlyOn.continuousOn (h : TendstoUniformlyOn F f p s)
+    (hc : ∀ᶠ n in p, ContinuousOn (F n) s) [NeBot p] : ContinuousOn f s :=
+  h.tendstoLocallyUniformlyOn.continuousOn hc
+
+/-- A locally uniform limit of continuous functions is continuous. -/
+protected theorem TendstoLocallyUniformly.continuous (h : TendstoLocallyUniformly F f p)
+    (hc : ∀ᶠ n in p, Continuous (F n)) [NeBot p] : Continuous f :=
+  continuous_iff_continuousOn_univ.mpr <|
+    h.tendstoLocallyUniformlyOn.continuousOn <| hc.mono fun _n hn => hn.continuousOn
+
+/-- A uniform limit of continuous functions is continuous. -/
+protected theorem TendstoUniformly.continuous (h : TendstoUniformly F f p)
+    (hc : ∀ᶠ n in p, Continuous (F n)) [NeBot p] : Continuous f :=
+  h.tendstoLocallyUniformly.continuous hc
+
+/-!
+### Composing limits under uniform convergence
+
+In general, if `Fₙ` converges pointwise to a function `f`, and `gₙ` tends to `x`, it is not true
+that `Fₙ gₙ` tends to `f x`. It is true however if the convergence of `Fₙ` to `f` is uniform. In
+this paragraph, we prove variations around this statement.
+-/
+
+
+/-- If `Fₙ` converges locally uniformly on a neighborhood of `x` within a set `s` to a function `f`
+which is continuous at `x` within `s`, and `gₙ` tends to `x` within `s`, then `Fₙ (gₙ)` tends
+to `f x`. -/
+theorem tendsto_comp_of_locally_uniform_limit_within (h : ContinuousWithinAt f s x)
+    (hg : Tendsto g p (𝓝[s] x))
+    (hunif : ∀ u ∈ 𝓤 β, ∃ t ∈ 𝓝[s] x, ∀ᶠ n in p, ∀ y ∈ t, (f y, F n y) ∈ u) :
+    Tendsto (fun n => F n (g n)) p (𝓝 (f x)) := by
+  refine Uniform.tendsto_nhds_right.2 fun u₀ hu₀ => ?_
+  obtain ⟨u₁, h₁, u₁₀⟩ : ∃ u ∈ 𝓤 β, u ○ u ⊆ u₀ := comp_mem_uniformity_sets hu₀
+  rcases hunif u₁ h₁ with ⟨s, sx, hs⟩
+  have A : ∀ᶠ n in p, g n ∈ s := hg sx
+  have B : ∀ᶠ n in p, (f x, f (g n)) ∈ u₁ := hg (Uniform.continuousWithinAt_iff'_right.1 h h₁)
+  exact B.mp <| A.mp <| hs.mono fun y H1 H2 H3 => u₁₀ (prodMk_mem_compRel H3 (H1 _ H2))
+
+/-- If `Fₙ` converges locally uniformly on a neighborhood of `x` to a function `f` which is
+continuous at `x`, and `gₙ` tends to `x`, then `Fₙ (gₙ)` tends to `f x`. -/
+theorem tendsto_comp_of_locally_uniform_limit (h : ContinuousAt f x) (hg : Tendsto g p (𝓝 x))
+    (hunif : ∀ u ∈ 𝓤 β, ∃ t ∈ 𝓝 x, ∀ᶠ n in p, ∀ y ∈ t, (f y, F n y) ∈ u) :
+    Tendsto (fun n => F n (g n)) p (𝓝 (f x)) := by
+  rw [← continuousWithinAt_univ] at h
+  rw [← nhdsWithin_univ] at hunif hg
+  exact tendsto_comp_of_locally_uniform_limit_within h hg hunif
+
+/-- If `Fₙ` tends locally uniformly to `f` on a set `s`, and `gₙ` tends to `x` within `s`, then
+`Fₙ gₙ` tends to `f x` if `f` is continuous at `x` within `s` and `x ∈ s`. -/
+theorem TendstoLocallyUniformlyOn.tendsto_comp (h : TendstoLocallyUniformlyOn F f p s)
+    (hf : ContinuousWithinAt f s x) (hx : x ∈ s) (hg : Tendsto g p (𝓝[s] x)) :
+    Tendsto (fun n => F n (g n)) p (𝓝 (f x)) :=
+  tendsto_comp_of_locally_uniform_limit_within hf hg fun u hu => h u hu x hx
+
+/-- If `Fₙ` tends uniformly to `f` on a set `s`, and `gₙ` tends to `x` within `s`, then `Fₙ gₙ`
+tends to `f x` if `f` is continuous at `x` within `s`. -/
+theorem TendstoUniformlyOn.tendsto_comp (h : TendstoUniformlyOn F f p s)
+    (hf : ContinuousWithinAt f s x) (hg : Tendsto g p (𝓝[s] x)) :
+    Tendsto (fun n => F n (g n)) p (𝓝 (f x)) :=
+  tendsto_comp_of_locally_uniform_limit_within hf hg fun u hu => ⟨s, self_mem_nhdsWithin, h u hu⟩
+
+/-- If `Fₙ` tends locally uniformly to `f`, and `gₙ` tends to `x`, then `Fₙ gₙ` tends to `f x`. -/
+theorem TendstoLocallyUniformly.tendsto_comp (h : TendstoLocallyUniformly F f p)
+    (hf : ContinuousAt f x) (hg : Tendsto g p (𝓝 x)) : Tendsto (fun n => F n (g n)) p (𝓝 (f x)) :=
+  tendsto_comp_of_locally_uniform_limit hf hg fun u hu => h u hu x
+
+/-- If `Fₙ` tends uniformly to `f`, and `gₙ` tends to `x`, then `Fₙ gₙ` tends to `f x`. -/
+theorem TendstoUniformly.tendsto_comp (h : TendstoUniformly F f p) (hf : ContinuousAt f x)
+    (hg : Tendsto g p (𝓝 x)) : Tendsto (fun n => F n (g n)) p (𝓝 (f x)) :=
+  h.tendstoLocallyUniformly.tendsto_comp hf hg

--- a/Mathlib/Topology/UniformSpace/UniformConvergence.lean
+++ b/Mathlib/Topology/UniformSpace/UniformConvergence.lean
@@ -32,10 +32,6 @@ Let `α` be a topological space, `β` a uniform space, `Fₙ` and `f` be functio
 * `TendstoUniformly.tendsto_comp`: If `Fₙ` tends uniformly to `f`, and `gₙ` tends to `x`, then
   `Fₙ gₙ` tends to `f x`.
 
-We also define notions where the convergence is locally uniform, called
-`TendstoLocallyUniformlyOn F f p s` and `TendstoLocallyUniformly F f p`. The previous theorems
-all have corresponding versions under locally uniform convergence.
-
 Finally, we introduce the notion of a uniform Cauchy sequence, which is to uniform
 convergence what a Cauchy sequence is to the usual notion of convergence.
 
@@ -48,31 +44,23 @@ Still, while this may be the "correct" definition (see
 `tendstoUniformlyOn_iff_tendstoUniformlyOnFilter`), it is somewhat unwieldy to work with in
 practice. Thus, we provide the more traditional definition in `TendstoUniformlyOn`.
 
-Most results hold under weaker assumptions of locally uniform approximation. In a first section,
-we prove the results under these weaker assumptions. Then, we derive the results on uniform
-convergence from them.
-
 ## Tags
 
 Uniform limit, uniform convergence, tends uniformly to
  -/
 
-
 noncomputable section
 
 open Topology Uniformity Filter Set Uniform
 
-universe u v w x
-variable {α : Type u} {β : Type v} {γ : Type w} {ι : Type x} [UniformSpace β]
+variable {α β γ ι : Type*} [UniformSpace β]
 variable {F : ι → α → β} {f : α → β} {s s' : Set α} {x : α} {p : Filter ι} {p' : Filter α}
-  {g : ι → α}
 
 /-!
 ### Different notions of uniform convergence
 
-We define uniform convergence and locally uniform convergence, on a set or in the whole space.
+We define uniform convergence, on a set or in the whole space.
 -/
-
 
 /-- A sequence of functions `Fₙ` converges uniformly on a filter `p'` to a limiting function `f`
 with respect to the filter `p` if, for any entourage of the diagonal `u`, one has
@@ -103,7 +91,6 @@ theorem tendstoUniformlyOn_iff_tendstoUniformlyOnFilter :
   simp_rw [eventually_prod_principal_iff]
   simp
 
-
 alias ⟨TendstoUniformlyOn.tendstoUniformlyOnFilter, TendstoUniformlyOnFilter.tendstoUniformlyOn⟩ :=
   tendstoUniformlyOn_iff_tendstoUniformlyOnFilter
 
@@ -111,7 +98,7 @@ alias ⟨TendstoUniformlyOn.tendstoUniformlyOnFilter, TendstoUniformlyOnFilter.t
 filter `p` iff the function `(n, x) ↦ (f x, Fₙ x)` converges along `p ×ˢ 𝓟 s` to the uniformity.
 In other words: one knows nothing about the behavior of `x` in this limit besides it being in `s`.
 -/
-theorem tendstoUniformlyOn_iff_tendsto {F : ι → α → β} {f : α → β} {p : Filter ι} {s : Set α} :
+theorem tendstoUniformlyOn_iff_tendsto :
     TendstoUniformlyOn F f p s ↔
     Tendsto (fun q : ι × α => (f q.2, F q.1 q.2)) (p ×ˢ 𝓟 s) (𝓤 β) := by
   simp [tendstoUniformlyOn_iff_tendstoUniformlyOnFilter, tendstoUniformlyOnFilter_iff_tendsto]
@@ -140,11 +127,11 @@ theorem tendstoUniformlyOn_iff_tendstoUniformly_comp_coe :
 filter `p` iff the function `(n, x) ↦ (f x, Fₙ x)` converges along `p ×ˢ ⊤` to the uniformity.
 In other words: one knows nothing about the behavior of `x` in this limit.
 -/
-theorem tendstoUniformly_iff_tendsto {F : ι → α → β} {f : α → β} {p : Filter ι} :
+theorem tendstoUniformly_iff_tendsto :
     TendstoUniformly F f p ↔ Tendsto (fun q : ι × α => (f q.2, F q.1 q.2)) (p ×ˢ ⊤) (𝓤 β) := by
   simp [tendstoUniformly_iff_tendstoUniformlyOnFilter, tendstoUniformlyOnFilter_iff_tendsto]
 
-/-- Uniform converence implies pointwise convergence. -/
+/-- Uniform convergence implies pointwise convergence. -/
 theorem TendstoUniformlyOnFilter.tendsto_at (h : TendstoUniformlyOnFilter F f p p')
     (hx : 𝓟 {x} ≤ p') : Tendsto (fun n => F n x) p <| 𝓝 (f x) := by
   refine Uniform.tendsto_nhds_right.mpr fun u hu => mem_map.mpr ?_
@@ -152,13 +139,13 @@ theorem TendstoUniformlyOnFilter.tendsto_at (h : TendstoUniformlyOnFilter F f p 
   intro i h
   simpa using h.filter_mono hx
 
-/-- Uniform converence implies pointwise convergence. -/
-theorem TendstoUniformlyOn.tendsto_at (h : TendstoUniformlyOn F f p s) {x : α} (hx : x ∈ s) :
+/-- Uniform convergence implies pointwise convergence. -/
+theorem TendstoUniformlyOn.tendsto_at (h : TendstoUniformlyOn F f p s) (hx : x ∈ s) :
     Tendsto (fun n => F n x) p <| 𝓝 (f x) :=
   h.tendstoUniformlyOnFilter.tendsto_at
     (le_principal_iff.mpr <| mem_principal.mpr <| singleton_subset_iff.mpr <| hx)
 
-/-- Uniform converence implies pointwise convergence. -/
+/-- Uniform convergence implies pointwise convergence. -/
 theorem TendstoUniformly.tendsto_at (h : TendstoUniformly F f p) (x : α) :
     Tendsto (fun n => F n x) p <| 𝓝 (f x) :=
   h.tendstoUniformlyOnFilter.tendsto_at le_top
@@ -171,7 +158,7 @@ theorem TendstoUniformlyOnFilter.mono_right {p'' : Filter α} (h : TendstoUnifor
     (hp : p'' ≤ p') : TendstoUniformlyOnFilter F f p p'' := fun u hu =>
   (h u hu).filter_mono (p.prod_mono_right hp)
 
-theorem TendstoUniformlyOn.mono {s' : Set α} (h : TendstoUniformlyOn F f p s) (h' : s' ⊆ s) :
+theorem TendstoUniformlyOn.mono (h : TendstoUniformlyOn F f p s) (h' : s' ⊆ s) :
     TendstoUniformlyOn F f p s' :=
   tendstoUniformlyOn_iff_tendstoUniformlyOnFilter.mpr
     (h.tendstoUniformlyOnFilter.mono_right (le_principal_iff.mpr <| mem_principal.mpr h'))
@@ -191,7 +178,7 @@ theorem TendstoUniformlyOn.congr {F' : ι → α → β} (hf : TendstoUniformlyO
   simp only [Set.EqOn] at hff'
   simp only [mem_prod_principal, hff', mem_setOf_eq]
 
-lemma tendstoUniformly_congr {F F' : ι → α → β} {f : α → β} (hF : F =ᶠ[p] F') :
+lemma tendstoUniformly_congr {F' : ι → α → β} (hF : F =ᶠ[p] F') :
     TendstoUniformly F f p ↔ TendstoUniformly F' f p := by
   simp_rw [← tendstoUniformlyOn_univ] at *
   have HF := EventuallyEq.exists_mem hF
@@ -342,7 +329,7 @@ theorem Filter.Tendsto.tendstoUniformlyOn_const {g : ι → β} {b : β} (hg : T
     (s : Set α) : TendstoUniformlyOn (fun n : ι => fun _ : α => g n) (fun _ : α => b) p s :=
   tendstoUniformlyOn_iff_tendstoUniformlyOnFilter.mpr (hg.tendstoUniformlyOnFilter_const (𝓟 s))
 
-theorem UniformContinuousOn.tendstoUniformlyOn [UniformSpace α] [UniformSpace γ] {x : α} {U : Set α}
+theorem UniformContinuousOn.tendstoUniformlyOn [UniformSpace α] [UniformSpace γ] {U : Set α}
     {V : Set β} {F : α → β → γ} (hF : UniformContinuousOn (↿F) (U ×ˢ V)) (hU : x ∈ U) :
     TendstoUniformlyOn F (F x) (𝓝[U] x) V := by
   set φ := fun q : α × β => ((x, q.2), q)
@@ -354,14 +341,14 @@ theorem UniformContinuousOn.tendstoUniformlyOn [UniformSpace α] [UniformSpace �
     nhds_eq_comap_uniformity, comap_comap]
   exact tendsto_comap.prodMk (tendsto_diag_uniformity _ _)
 
-theorem UniformContinuousOn.tendstoUniformly [UniformSpace α] [UniformSpace γ] {x : α} {U : Set α}
+theorem UniformContinuousOn.tendstoUniformly [UniformSpace α] [UniformSpace γ] {U : Set α}
     (hU : U ∈ 𝓝 x) {F : α → β → γ} (hF : UniformContinuousOn (↿F) (U ×ˢ (univ : Set β))) :
     TendstoUniformly F (F x) (𝓝 x) := by
   simpa only [tendstoUniformlyOn_univ, nhdsWithin_eq_nhds.2 hU]
     using hF.tendstoUniformlyOn (mem_of_mem_nhds hU)
 
 theorem UniformContinuous₂.tendstoUniformly [UniformSpace α] [UniformSpace γ] {f : α → β → γ}
-    (h : UniformContinuous₂ f) {x : α} : TendstoUniformly f (f x) (𝓝 x) :=
+    (h : UniformContinuous₂ f) : TendstoUniformly f (f x) (𝓝 x) :=
   UniformContinuousOn.tendstoUniformly univ_mem <| by rwa [univ_prod_univ, uniformContinuousOn_univ]
 
 /-- A sequence is uniformly Cauchy if eventually all of its pairwise differences are
@@ -448,7 +435,7 @@ theorem UniformCauchySeqOnFilter.mono_right {p'' : Filter α} (hf : UniformCauch
   have := (hf u hu).filter_mono ((p ×ˢ p).prod_mono_right hp)
   this.mono (by simp)
 
-theorem UniformCauchySeqOn.mono {s' : Set α} (hf : UniformCauchySeqOn F p s) (hss' : s' ⊆ s) :
+theorem UniformCauchySeqOn.mono (hf : UniformCauchySeqOn F p s) (hss' : s' ⊆ s) :
     UniformCauchySeqOn F p s' := by
   rw [uniformCauchySeqOn_iff_uniformCauchySeqOnFilter] at hf ⊢
   exact hf.mono_right (le_principal_iff.mpr <| mem_principal.mpr hss')
@@ -570,346 +557,3 @@ theorem TendstoUniformly.tendsto_of_eventually_tendsto
   (h1.tendstoUniformlyOnFilter.mono_right le_top).tendsto_of_eventually_tendsto h2 h3
 
 end
-
-variable [TopologicalSpace α]
-
-/-- A sequence of functions `Fₙ` converges locally uniformly on a set `s` to a limiting function
-`f` with respect to a filter `p` if, for any entourage of the diagonal `u`, for any `x ∈ s`, one
-has `p`-eventually `(f y, Fₙ y) ∈ u` for all `y` in a neighborhood of `x` in `s`. -/
-def TendstoLocallyUniformlyOn (F : ι → α → β) (f : α → β) (p : Filter ι) (s : Set α) :=
-  ∀ u ∈ 𝓤 β, ∀ x ∈ s, ∃ t ∈ 𝓝[s] x, ∀ᶠ n in p, ∀ y ∈ t, (f y, F n y) ∈ u
-
-/-- A sequence of functions `Fₙ` converges locally uniformly to a limiting function `f` with respect
-to a filter `p` if, for any entourage of the diagonal `u`, for any `x`, one has `p`-eventually
-`(f y, Fₙ y) ∈ u` for all `y` in a neighborhood of `x`. -/
-def TendstoLocallyUniformly (F : ι → α → β) (f : α → β) (p : Filter ι) :=
-  ∀ u ∈ 𝓤 β, ∀ x : α, ∃ t ∈ 𝓝 x, ∀ᶠ n in p, ∀ y ∈ t, (f y, F n y) ∈ u
-
-theorem tendstoLocallyUniformlyOn_univ :
-    TendstoLocallyUniformlyOn F f p univ ↔ TendstoLocallyUniformly F f p := by
-  simp [TendstoLocallyUniformlyOn, TendstoLocallyUniformly, nhdsWithin_univ]
-
-theorem tendstoLocallyUniformlyOn_iff_forall_tendsto :
-    TendstoLocallyUniformlyOn F f p s ↔
-      ∀ x ∈ s, Tendsto (fun y : ι × α => (f y.2, F y.1 y.2)) (p ×ˢ 𝓝[s] x) (𝓤 β) :=
-  forall₂_swap.trans <| forall₄_congr fun _ _ _ _ => by
-    rw [mem_map, mem_prod_iff_right]; rfl
-
-nonrec theorem IsOpen.tendstoLocallyUniformlyOn_iff_forall_tendsto (hs : IsOpen s) :
-    TendstoLocallyUniformlyOn F f p s ↔
-      ∀ x ∈ s, Tendsto (fun y : ι × α => (f y.2, F y.1 y.2)) (p ×ˢ 𝓝 x) (𝓤 β) :=
-  tendstoLocallyUniformlyOn_iff_forall_tendsto.trans <| forall₂_congr fun x hx => by
-    rw [hs.nhdsWithin_eq hx]
-
-theorem tendstoLocallyUniformly_iff_forall_tendsto :
-    TendstoLocallyUniformly F f p ↔
-      ∀ x, Tendsto (fun y : ι × α => (f y.2, F y.1 y.2)) (p ×ˢ 𝓝 x) (𝓤 β) := by
-  simp [← tendstoLocallyUniformlyOn_univ, isOpen_univ.tendstoLocallyUniformlyOn_iff_forall_tendsto]
-
-theorem tendstoLocallyUniformlyOn_iff_tendstoLocallyUniformly_comp_coe :
-    TendstoLocallyUniformlyOn F f p s ↔
-      TendstoLocallyUniformly (fun i (x : s) => F i x) (f ∘ (↑)) p := by
-  simp only [tendstoLocallyUniformly_iff_forall_tendsto, Subtype.forall', tendsto_map'_iff,
-    tendstoLocallyUniformlyOn_iff_forall_tendsto, ← map_nhds_subtype_val, prod_map_right]; rfl
-
-protected theorem TendstoUniformlyOn.tendstoLocallyUniformlyOn (h : TendstoUniformlyOn F f p s) :
-    TendstoLocallyUniformlyOn F f p s := fun u hu _ _ =>
-  ⟨s, self_mem_nhdsWithin, by simpa using h u hu⟩
-
-protected theorem TendstoUniformly.tendstoLocallyUniformly (h : TendstoUniformly F f p) :
-    TendstoLocallyUniformly F f p := fun u hu _ => ⟨univ, univ_mem, by simpa using h u hu⟩
-
-theorem TendstoLocallyUniformlyOn.mono (h : TendstoLocallyUniformlyOn F f p s) (h' : s' ⊆ s) :
-    TendstoLocallyUniformlyOn F f p s' := by
-  intro u hu x hx
-  rcases h u hu x (h' hx) with ⟨t, ht, H⟩
-  exact ⟨t, nhdsWithin_mono x h' ht, H.mono fun n => id⟩
-
-theorem tendstoLocallyUniformlyOn_iUnion {ι' : Sort*} {S : ι' → Set α} (hS : ∀ i, IsOpen (S i))
-    (h : ∀ i, TendstoLocallyUniformlyOn F f p (S i)) :
-    TendstoLocallyUniformlyOn F f p (⋃ i, S i) :=
-  (isOpen_iUnion hS).tendstoLocallyUniformlyOn_iff_forall_tendsto.2 fun _x hx =>
-    let ⟨i, hi⟩ := mem_iUnion.1 hx
-    (hS i).tendstoLocallyUniformlyOn_iff_forall_tendsto.1 (h i) _ hi
-
-theorem tendstoLocallyUniformlyOn_biUnion {s : Set γ} {S : γ → Set α} (hS : ∀ i ∈ s, IsOpen (S i))
-    (h : ∀ i ∈ s, TendstoLocallyUniformlyOn F f p (S i)) :
-    TendstoLocallyUniformlyOn F f p (⋃ i ∈ s, S i) :=
-  tendstoLocallyUniformlyOn_iUnion (fun i => isOpen_iUnion (hS i)) fun i =>
-   tendstoLocallyUniformlyOn_iUnion (hS i) (h i)
-
-theorem tendstoLocallyUniformlyOn_sUnion (S : Set (Set α)) (hS : ∀ s ∈ S, IsOpen s)
-    (h : ∀ s ∈ S, TendstoLocallyUniformlyOn F f p s) : TendstoLocallyUniformlyOn F f p (⋃₀ S) := by
-  rw [sUnion_eq_biUnion]
-  exact tendstoLocallyUniformlyOn_biUnion hS h
-
-theorem TendstoLocallyUniformlyOn.union {s₁ s₂ : Set α} (hs₁ : IsOpen s₁) (hs₂ : IsOpen s₂)
-    (h₁ : TendstoLocallyUniformlyOn F f p s₁) (h₂ : TendstoLocallyUniformlyOn F f p s₂) :
-    TendstoLocallyUniformlyOn F f p (s₁ ∪ s₂) := by
-  rw [← sUnion_pair]
-  refine tendstoLocallyUniformlyOn_sUnion _ ?_ ?_ <;> simp [*]
-
-protected theorem TendstoLocallyUniformly.tendstoLocallyUniformlyOn
-    (h : TendstoLocallyUniformly F f p) : TendstoLocallyUniformlyOn F f p s :=
-  (tendstoLocallyUniformlyOn_univ.mpr h).mono (subset_univ _)
-
-/-- On a compact space, locally uniform convergence is just uniform convergence. -/
-theorem tendstoLocallyUniformly_iff_tendstoUniformly_of_compactSpace [CompactSpace α] :
-    TendstoLocallyUniformly F f p ↔ TendstoUniformly F f p := by
-  refine ⟨fun h V hV => ?_, TendstoUniformly.tendstoLocallyUniformly⟩
-  choose U hU using h V hV
-  obtain ⟨t, ht⟩ := isCompact_univ.elim_nhds_subcover' (fun k _ => U k) fun k _ => (hU k).1
-  replace hU := fun x : t => (hU x).2
-  rw [← eventually_all] at hU
-  refine hU.mono fun i hi x => ?_
-  specialize ht (mem_univ x)
-  simp only [exists_prop, mem_iUnion, SetCoe.exists, exists_and_right, Subtype.coe_mk] at ht
-  obtain ⟨y, ⟨hy₁, hy₂⟩, hy₃⟩ := ht
-  exact hi ⟨⟨y, hy₁⟩, hy₂⟩ x hy₃
-
-/-- For a compact set `s`, locally uniform convergence on `s` is just uniform convergence on `s`. -/
-theorem tendstoLocallyUniformlyOn_iff_tendstoUniformlyOn_of_compact (hs : IsCompact s) :
-    TendstoLocallyUniformlyOn F f p s ↔ TendstoUniformlyOn F f p s := by
-  haveI : CompactSpace s := isCompact_iff_compactSpace.mp hs
-  refine ⟨fun h => ?_, TendstoUniformlyOn.tendstoLocallyUniformlyOn⟩
-  rwa [tendstoLocallyUniformlyOn_iff_tendstoLocallyUniformly_comp_coe,
-    tendstoLocallyUniformly_iff_tendstoUniformly_of_compactSpace, ←
-    tendstoUniformlyOn_iff_tendstoUniformly_comp_coe] at h
-
-theorem TendstoLocallyUniformlyOn.comp [TopologicalSpace γ] {t : Set γ}
-    (h : TendstoLocallyUniformlyOn F f p s) (g : γ → α) (hg : MapsTo g t s)
-    (cg : ContinuousOn g t) : TendstoLocallyUniformlyOn (fun n => F n ∘ g) (f ∘ g) p t := by
-  intro u hu x hx
-  rcases h u hu (g x) (hg hx) with ⟨a, ha, H⟩
-  have : g ⁻¹' a ∈ 𝓝[t] x :=
-    (cg x hx).preimage_mem_nhdsWithin' (nhdsWithin_mono (g x) hg.image_subset ha)
-  exact ⟨g ⁻¹' a, this, H.mono fun n hn y hy => hn _ hy⟩
-
-theorem TendstoLocallyUniformly.comp [TopologicalSpace γ] (h : TendstoLocallyUniformly F f p)
-    (g : γ → α) (cg : Continuous g) : TendstoLocallyUniformly (fun n => F n ∘ g) (f ∘ g) p := by
-  rw [← tendstoLocallyUniformlyOn_univ] at h ⊢
-  rw [continuous_iff_continuousOn_univ] at cg
-  exact h.comp _ (mapsTo_univ _ _) cg
-
-theorem tendstoLocallyUniformlyOn_TFAE [LocallyCompactSpace α] (G : ι → α → β) (g : α → β)
-    (p : Filter ι) (hs : IsOpen s) :
-    List.TFAE [
-      TendstoLocallyUniformlyOn G g p s,
-      ∀ K, K ⊆ s → IsCompact K → TendstoUniformlyOn G g p K,
-      ∀ x ∈ s, ∃ v ∈ 𝓝[s] x, TendstoUniformlyOn G g p v] := by
-  tfae_have 1 → 2
-  | h, K, hK1, hK2 =>
-    (tendstoLocallyUniformlyOn_iff_tendstoUniformlyOn_of_compact hK2).mp (h.mono hK1)
-  tfae_have 2 → 3
-  | h, x, hx => by
-    obtain ⟨K, ⟨hK1, hK2⟩, hK3⟩ := (compact_basis_nhds x).mem_iff.mp (hs.mem_nhds hx)
-    exact ⟨K, nhdsWithin_le_nhds hK1, h K hK3 hK2⟩
-  tfae_have 3 → 1
-  | h, u, hu, x, hx => by
-    obtain ⟨v, hv1, hv2⟩ := h x hx
-    exact ⟨v, hv1, hv2 u hu⟩
-  tfae_finish
-
-theorem tendstoLocallyUniformlyOn_iff_forall_isCompact [LocallyCompactSpace α] (hs : IsOpen s) :
-    TendstoLocallyUniformlyOn F f p s ↔ ∀ K, K ⊆ s → IsCompact K → TendstoUniformlyOn F f p K :=
-  (tendstoLocallyUniformlyOn_TFAE F f p hs).out 0 1
-
-lemma tendstoLocallyUniformly_iff_forall_isCompact [LocallyCompactSpace α]  :
-    TendstoLocallyUniformly F f p ↔ ∀ K : Set α, IsCompact K → TendstoUniformlyOn F f p K := by
-  simp only [← tendstoLocallyUniformlyOn_univ,
-    tendstoLocallyUniformlyOn_iff_forall_isCompact isOpen_univ, Set.subset_univ, forall_true_left]
-
-theorem tendstoLocallyUniformlyOn_iff_filter :
-    TendstoLocallyUniformlyOn F f p s ↔ ∀ x ∈ s, TendstoUniformlyOnFilter F f p (𝓝[s] x) := by
-  simp only [TendstoUniformlyOnFilter, eventually_prod_iff]
-  constructor
-  · rintro h x hx u hu
-    obtain ⟨s, hs1, hs2⟩ := h u hu x hx
-    exact ⟨_, hs2, _, eventually_of_mem hs1 fun x => id, fun hi y hy => hi y hy⟩
-  · rintro h u hu x hx
-    obtain ⟨pa, hpa, pb, hpb, h⟩ := h x hx u hu
-    exact ⟨pb, hpb, eventually_of_mem hpa fun i hi y hy => h hi hy⟩
-
-theorem tendstoLocallyUniformly_iff_filter :
-    TendstoLocallyUniformly F f p ↔ ∀ x, TendstoUniformlyOnFilter F f p (𝓝 x) := by
-  simpa [← tendstoLocallyUniformlyOn_univ, ← nhdsWithin_univ] using
-    @tendstoLocallyUniformlyOn_iff_filter _ _ _ _ F f univ p _
-
-theorem TendstoLocallyUniformlyOn.tendsto_at (hf : TendstoLocallyUniformlyOn F f p s) {a : α}
-    (ha : a ∈ s) : Tendsto (fun i => F i a) p (𝓝 (f a)) := by
-  refine ((tendstoLocallyUniformlyOn_iff_filter.mp hf) a ha).tendsto_at ?_
-  simpa only [Filter.principal_singleton] using pure_le_nhdsWithin ha
-
-theorem TendstoLocallyUniformlyOn.unique [p.NeBot] [T2Space β] {g : α → β}
-    (hf : TendstoLocallyUniformlyOn F f p s) (hg : TendstoLocallyUniformlyOn F g p s) :
-    s.EqOn f g := fun _a ha => tendsto_nhds_unique (hf.tendsto_at ha) (hg.tendsto_at ha)
-
-theorem TendstoLocallyUniformlyOn.congr {G : ι → α → β} (hf : TendstoLocallyUniformlyOn F f p s)
-    (hg : ∀ n, s.EqOn (F n) (G n)) : TendstoLocallyUniformlyOn G f p s := by
-  rintro u hu x hx
-  obtain ⟨t, ht, h⟩ := hf u hu x hx
-  refine ⟨s ∩ t, inter_mem self_mem_nhdsWithin ht, ?_⟩
-  filter_upwards [h] with i hi y hy using hg i hy.1 ▸ hi y hy.2
-
-theorem TendstoLocallyUniformlyOn.congr_right {g : α → β} (hf : TendstoLocallyUniformlyOn F f p s)
-    (hg : s.EqOn f g) : TendstoLocallyUniformlyOn F g p s := by
-  rintro u hu x hx
-  obtain ⟨t, ht, h⟩ := hf u hu x hx
-  refine ⟨s ∩ t, inter_mem self_mem_nhdsWithin ht, ?_⟩
-  filter_upwards [h] with i hi y hy using hg hy.1 ▸ hi y hy.2
-
-/-!
-### Uniform approximation
-
-In this section, we give lemmas ensuring that a function is continuous if it can be approximated
-uniformly by continuous functions. We give various versions, within a set or the whole space, at
-a single point or at all points, with locally uniform approximation or uniform approximation. All
-the statements are derived from a statement about locally uniform approximation within a set at
-a point, called `continuousWithinAt_of_locally_uniform_approx_of_continuousWithinAt`. -/
-
-
-/-- A function which can be locally uniformly approximated by functions which are continuous
-within a set at a point is continuous within this set at this point. -/
-theorem continuousWithinAt_of_locally_uniform_approx_of_continuousWithinAt (hx : x ∈ s)
-    (L : ∀ u ∈ 𝓤 β, ∃ t ∈ 𝓝[s] x, ∃ F : α → β, ContinuousWithinAt F s x ∧ ∀ y ∈ t, (f y, F y) ∈ u) :
-    ContinuousWithinAt f s x := by
-  refine Uniform.continuousWithinAt_iff'_left.2 fun u₀ hu₀ => ?_
-  obtain ⟨u₁, h₁, u₁₀⟩ : ∃ u ∈ 𝓤 β, u ○ u ⊆ u₀ := comp_mem_uniformity_sets hu₀
-  obtain ⟨u₂, h₂, hsymm, u₂₁⟩ : ∃ u ∈ 𝓤 β, (∀ {a b}, (a, b) ∈ u → (b, a) ∈ u) ∧ u ○ u ⊆ u₁ :=
-    comp_symm_of_uniformity h₁
-  rcases L u₂ h₂ with ⟨t, tx, F, hFc, hF⟩
-  have A : ∀ᶠ y in 𝓝[s] x, (f y, F y) ∈ u₂ := Eventually.mono tx hF
-  have B : ∀ᶠ y in 𝓝[s] x, (F y, F x) ∈ u₂ := Uniform.continuousWithinAt_iff'_left.1 hFc h₂
-  have C : ∀ᶠ y in 𝓝[s] x, (f y, F x) ∈ u₁ :=
-    (A.and B).mono fun y hy => u₂₁ (prodMk_mem_compRel hy.1 hy.2)
-  have : (F x, f x) ∈ u₁ :=
-    u₂₁ (prodMk_mem_compRel (refl_mem_uniformity h₂) (hsymm (A.self_of_nhdsWithin hx)))
-  exact C.mono fun y hy => u₁₀ (prodMk_mem_compRel hy this)
-
-/-- A function which can be locally uniformly approximated by functions which are continuous at
-a point is continuous at this point. -/
-theorem continuousAt_of_locally_uniform_approx_of_continuousAt
-    (L : ∀ u ∈ 𝓤 β, ∃ t ∈ 𝓝 x, ∃ F, ContinuousAt F x ∧ ∀ y ∈ t, (f y, F y) ∈ u) :
-    ContinuousAt f x := by
-  rw [← continuousWithinAt_univ]
-  apply continuousWithinAt_of_locally_uniform_approx_of_continuousWithinAt (mem_univ _) _
-  simpa only [exists_prop, nhdsWithin_univ, continuousWithinAt_univ] using L
-
-/-- A function which can be locally uniformly approximated by functions which are continuous
-on a set is continuous on this set. -/
-theorem continuousOn_of_locally_uniform_approx_of_continuousWithinAt
-    (L : ∀ x ∈ s, ∀ u ∈ 𝓤 β, ∃ t ∈ 𝓝[s] x, ∃ F,
-      ContinuousWithinAt F s x ∧ ∀ y ∈ t, (f y, F y) ∈ u) :
-    ContinuousOn f s := fun x hx =>
-  continuousWithinAt_of_locally_uniform_approx_of_continuousWithinAt hx (L x hx)
-
-/-- A function which can be uniformly approximated by functions which are continuous on a set
-is continuous on this set. -/
-theorem continuousOn_of_uniform_approx_of_continuousOn
-    (L : ∀ u ∈ 𝓤 β, ∃ F, ContinuousOn F s ∧ ∀ y ∈ s, (f y, F y) ∈ u) : ContinuousOn f s :=
-  continuousOn_of_locally_uniform_approx_of_continuousWithinAt fun _x hx u hu =>
-    ⟨s, self_mem_nhdsWithin, (L u hu).imp fun _F hF => ⟨hF.1.continuousWithinAt hx, hF.2⟩⟩
-
-/-- A function which can be locally uniformly approximated by continuous functions is continuous. -/
-theorem continuous_of_locally_uniform_approx_of_continuousAt
-    (L : ∀ x : α, ∀ u ∈ 𝓤 β, ∃ t ∈ 𝓝 x, ∃ F, ContinuousAt F x ∧ ∀ y ∈ t, (f y, F y) ∈ u) :
-    Continuous f :=
-  continuous_iff_continuousAt.2 fun x =>
-    continuousAt_of_locally_uniform_approx_of_continuousAt (L x)
-
-/-- A function which can be uniformly approximated by continuous functions is continuous. -/
-theorem continuous_of_uniform_approx_of_continuous
-    (L : ∀ u ∈ 𝓤 β, ∃ F, Continuous F ∧ ∀ y, (f y, F y) ∈ u) : Continuous f :=
-  continuous_iff_continuousOn_univ.mpr <|
-    continuousOn_of_uniform_approx_of_continuousOn <| by
-      simpa [continuous_iff_continuousOn_univ] using L
-
-/-!
-### Uniform limits
-
-From the previous statements on uniform approximation, we deduce continuity results for uniform
-limits.
--/
-
-
-/-- A locally uniform limit on a set of functions which are continuous on this set is itself
-continuous on this set. -/
-protected theorem TendstoLocallyUniformlyOn.continuousOn (h : TendstoLocallyUniformlyOn F f p s)
-    (hc : ∀ᶠ n in p, ContinuousOn (F n) s) [NeBot p] : ContinuousOn f s := by
-  refine continuousOn_of_locally_uniform_approx_of_continuousWithinAt fun x hx u hu => ?_
-  rcases h u hu x hx with ⟨t, ht, H⟩
-  rcases (hc.and H).exists with ⟨n, hFc, hF⟩
-  exact ⟨t, ht, ⟨F n, hFc.continuousWithinAt hx, hF⟩⟩
-
-/-- A uniform limit on a set of functions which are continuous on this set is itself continuous
-on this set. -/
-protected theorem TendstoUniformlyOn.continuousOn (h : TendstoUniformlyOn F f p s)
-    (hc : ∀ᶠ n in p, ContinuousOn (F n) s) [NeBot p] : ContinuousOn f s :=
-  h.tendstoLocallyUniformlyOn.continuousOn hc
-
-/-- A locally uniform limit of continuous functions is continuous. -/
-protected theorem TendstoLocallyUniformly.continuous (h : TendstoLocallyUniformly F f p)
-    (hc : ∀ᶠ n in p, Continuous (F n)) [NeBot p] : Continuous f :=
-  continuous_iff_continuousOn_univ.mpr <|
-    h.tendstoLocallyUniformlyOn.continuousOn <| hc.mono fun _n hn => hn.continuousOn
-
-/-- A uniform limit of continuous functions is continuous. -/
-protected theorem TendstoUniformly.continuous (h : TendstoUniformly F f p)
-    (hc : ∀ᶠ n in p, Continuous (F n)) [NeBot p] : Continuous f :=
-  h.tendstoLocallyUniformly.continuous hc
-
-/-!
-### Composing limits under uniform convergence
-
-In general, if `Fₙ` converges pointwise to a function `f`, and `gₙ` tends to `x`, it is not true
-that `Fₙ gₙ` tends to `f x`. It is true however if the convergence of `Fₙ` to `f` is uniform. In
-this paragraph, we prove variations around this statement.
--/
-
-
-/-- If `Fₙ` converges locally uniformly on a neighborhood of `x` within a set `s` to a function `f`
-which is continuous at `x` within `s`, and `gₙ` tends to `x` within `s`, then `Fₙ (gₙ)` tends
-to `f x`. -/
-theorem tendsto_comp_of_locally_uniform_limit_within (h : ContinuousWithinAt f s x)
-    (hg : Tendsto g p (𝓝[s] x))
-    (hunif : ∀ u ∈ 𝓤 β, ∃ t ∈ 𝓝[s] x, ∀ᶠ n in p, ∀ y ∈ t, (f y, F n y) ∈ u) :
-    Tendsto (fun n => F n (g n)) p (𝓝 (f x)) := by
-  refine Uniform.tendsto_nhds_right.2 fun u₀ hu₀ => ?_
-  obtain ⟨u₁, h₁, u₁₀⟩ : ∃ u ∈ 𝓤 β, u ○ u ⊆ u₀ := comp_mem_uniformity_sets hu₀
-  rcases hunif u₁ h₁ with ⟨s, sx, hs⟩
-  have A : ∀ᶠ n in p, g n ∈ s := hg sx
-  have B : ∀ᶠ n in p, (f x, f (g n)) ∈ u₁ := hg (Uniform.continuousWithinAt_iff'_right.1 h h₁)
-  exact B.mp <| A.mp <| hs.mono fun y H1 H2 H3 => u₁₀ (prodMk_mem_compRel H3 (H1 _ H2))
-
-/-- If `Fₙ` converges locally uniformly on a neighborhood of `x` to a function `f` which is
-continuous at `x`, and `gₙ` tends to `x`, then `Fₙ (gₙ)` tends to `f x`. -/
-theorem tendsto_comp_of_locally_uniform_limit (h : ContinuousAt f x) (hg : Tendsto g p (𝓝 x))
-    (hunif : ∀ u ∈ 𝓤 β, ∃ t ∈ 𝓝 x, ∀ᶠ n in p, ∀ y ∈ t, (f y, F n y) ∈ u) :
-    Tendsto (fun n => F n (g n)) p (𝓝 (f x)) := by
-  rw [← continuousWithinAt_univ] at h
-  rw [← nhdsWithin_univ] at hunif hg
-  exact tendsto_comp_of_locally_uniform_limit_within h hg hunif
-
-/-- If `Fₙ` tends locally uniformly to `f` on a set `s`, and `gₙ` tends to `x` within `s`, then
-`Fₙ gₙ` tends to `f x` if `f` is continuous at `x` within `s` and `x ∈ s`. -/
-theorem TendstoLocallyUniformlyOn.tendsto_comp (h : TendstoLocallyUniformlyOn F f p s)
-    (hf : ContinuousWithinAt f s x) (hx : x ∈ s) (hg : Tendsto g p (𝓝[s] x)) :
-    Tendsto (fun n => F n (g n)) p (𝓝 (f x)) :=
-  tendsto_comp_of_locally_uniform_limit_within hf hg fun u hu => h u hu x hx
-
-/-- If `Fₙ` tends uniformly to `f` on a set `s`, and `gₙ` tends to `x` within `s`, then `Fₙ gₙ`
-tends to `f x` if `f` is continuous at `x` within `s`. -/
-theorem TendstoUniformlyOn.tendsto_comp (h : TendstoUniformlyOn F f p s)
-    (hf : ContinuousWithinAt f s x) (hg : Tendsto g p (𝓝[s] x)) :
-    Tendsto (fun n => F n (g n)) p (𝓝 (f x)) :=
-  tendsto_comp_of_locally_uniform_limit_within hf hg fun u hu => ⟨s, self_mem_nhdsWithin, h u hu⟩
-
-/-- If `Fₙ` tends locally uniformly to `f`, and `gₙ` tends to `x`, then `Fₙ gₙ` tends to `f x`. -/
-theorem TendstoLocallyUniformly.tendsto_comp (h : TendstoLocallyUniformly F f p)
-    (hf : ContinuousAt f x) (hg : Tendsto g p (𝓝 x)) : Tendsto (fun n => F n (g n)) p (𝓝 (f x)) :=
-  tendsto_comp_of_locally_uniform_limit hf hg fun u hu => h u hu x
-
-/-- If `Fₙ` tends uniformly to `f`, and `gₙ` tends to `x`, then `Fₙ gₙ` tends to `f x`. -/
-theorem TendstoUniformly.tendsto_comp (h : TendstoUniformly F f p) (hf : ContinuousAt f x)
-    (hg : Tendsto g p (𝓝 x)) : Tendsto (fun n => F n (g n)) p (𝓝 (f x)) :=
-  h.tendstoLocallyUniformly.tendsto_comp hf hg

--- a/Mathlib/Topology/UniformSpace/UniformConvergenceTopology.lean
+++ b/Mathlib/Topology/UniformSpace/UniformConvergenceTopology.lean
@@ -3,10 +3,10 @@ Copyright (c) 2022 Anatole Dedecker. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Anatole Dedecker
 -/
-import Mathlib.Topology.UniformSpace.UniformConvergence
-import Mathlib.Topology.UniformSpace.Pi
-import Mathlib.Topology.UniformSpace.Equiv
 import Mathlib.Topology.Coherent
+import Mathlib.Topology.UniformSpace.Equiv
+import Mathlib.Topology.UniformSpace.Pi
+import Mathlib.Topology.UniformSpace.UniformApproximation
 
 /-!
 # Topology and uniform structure of uniform convergence


### PR DESCRIPTION
Split `Mathlib.Topology.UniformSpace.UniformConvergence` into 3 files, and add a detailed explanation of how our
definition of `TendstoLocallyUniformly` differs from the one usually found in the literature.

See discussion on Zulip: https://leanprover.zulipchat.com/#narrow/channel/116395-maths/topic/Locally.20uniform.20convergence/with/514097469

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->
This PR makes no changes to actual code (I have some lemmas to add about relating the various definitions, but that can come in a subsequent PR for ease of reviewing). The only thing that is actually new in this PR is the file-level docstring of `LocallyUniformConvergence.lean`.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
