### PR TITLE
[Merged by Bors] - feat(Topology/Algebra/Valued): Add `IsClosed` and `IsClopen` lemmas

### DIFF
--- a/Mathlib/RingTheory/DedekindDomain/FiniteAdeleRing.lean
+++ b/Mathlib/RingTheory/DedekindDomain/FiniteAdeleRing.lean
@@ -129,7 +129,7 @@ section Topology
 instance : IsTopologicalRing (FiniteAdeleRing R K) :=
   haveI : Fact (∀ v : HeightOneSpectrum R,
       IsOpen (v.adicCompletionIntegers K : Set (v.adicCompletion K))) :=
-    ⟨fun _ ↦ Valued.valuationSubring_isOpen _⟩
+    ⟨fun _ ↦ Valued.isOpen_valuationSubring _⟩
   RestrictedProduct.isTopologicalRing (fun (v : HeightOneSpectrum R) ↦ v.adicCompletion K)
 
 end Topology

--- a/Mathlib/Topology/Algebra/Valued/ValuationTopology.lean
+++ b/Mathlib/Topology/Algebra/Valued/ValuationTopology.lean
@@ -165,6 +165,14 @@ theorem isOpen_ball (r : Γ₀) : IsOpen (X := R) {x | v x < r} := by
   exact ⟨Units.mk0 _ hr,
     fun y hy => (sub_add_cancel y x).symm ▸ (v.map_add _ x).trans_lt (max_lt hy hx)⟩
 
+/-- An open ball centred at the origin in a valued ring is closed. -/
+theorem isClosed_ball (r : Γ₀) : IsClosed (X := R) {x | v x < r} := by
+  rcases eq_or_ne r 0 with rfl|hr
+  · simp
+  exact AddSubgroup.isClosed_of_isOpen
+    (Valuation.ltAddSubgroup v (Units.mk0 r hr))
+    (isOpen_ball _ _)
+
 /-- A closed ball centred at the origin in a valued ring is open. -/
 theorem isOpen_closedball {r : Γ₀} (hr : r ≠ 0) : IsOpen (X := R) {x | v x ≤ r} := by
   rw [isOpen_iff_mem_nhds]
@@ -173,6 +181,19 @@ theorem isOpen_closedball {r : Γ₀} (hr : r ≠ 0) : IsOpen (X := R) {x | v x 
   simp only [setOf_subset_setOf]
   exact ⟨Units.mk0 _ hr,
     fun y hy => (sub_add_cancel y x).symm ▸ le_trans (v.map_add _ _) (max_le (le_of_lt hy) hx)⟩
+
+/-- A closed ball centred at the origin in a valued ring is closed. -/
+theorem isClosed_closedBall (r : Γ₀) : IsClosed (X := R) {x | v x ≤ r} := by
+  rw [← isOpen_compl_iff, isOpen_iff_mem_nhds]
+  intro x hx
+  rw [mem_nhds]
+  simp only [le_zero_iff, mem_compl_iff, mem_setOf_eq] at hx ⊢
+  have hx' : v x ≠ 0 := by
+    intro hz
+    simp [hz] at hx
+  refine ⟨Units.mk0 _ hx', fun y hy hy' => ne_of_lt hy ?_⟩
+  rw [map_sub_swap]
+  exact Valuation.map_sub_eq_of_lt_left _ <| lt_of_le_of_lt hy' (lt_of_not_ge hx)
 
 /-- A sphere centred at the origin in a valued ring is open. -/
 theorem isOpen_sphere {r : Γ₀} (hr : r ≠ 0) : IsOpen (X := R) {x | v x = r} := by
@@ -192,5 +213,14 @@ theorem integer_isOpen : IsOpen (_i.v.integer : Set R) :=
 theorem valuationSubring_isOpen (K : Type u) [Field K] [hv : Valued K Γ₀] :
     IsOpen (hv.v.valuationSubring : Set K) :=
   integer_isOpen K
+
+/-- The closed unit ball of a valued ring is closed. -/
+theorem integer_isClosed : IsClosed (_i.v.integer : Set R) :=
+  isClosed_closedBall _ _
+
+/-- The valuation subring of a valued field is closed. -/
+theorem valuationSubring_isClosed (K : Type u) [Field K] [hv : Valued K Γ₀] :
+    IsClosed (hv.v.valuationSubring : Set K) :=
+  integer_isClosed K
 
 end Valued

--- a/Mathlib/Topology/Algebra/Valued/ValuationTopology.lean
+++ b/Mathlib/Topology/Algebra/Valued/ValuationTopology.lean
@@ -173,6 +173,10 @@ theorem isClosed_ball (r : Γ₀) : IsClosed (X := R) {x | v x < r} := by
     (Valuation.ltAddSubgroup v (Units.mk0 r hr))
     (isOpen_ball _ _)
 
+/-- An open ball centred at the origin in a valued ring is clopen. -/
+theorem isClopen_ball (r : Γ₀) : IsClopen (X := R) {x | v x < r} :=
+  ⟨isClosed_ball _ _, isOpen_ball _ _⟩
+
 /-- A closed ball centred at the origin in a valued ring is open. -/
 theorem isOpen_closedball {r : Γ₀} (hr : r ≠ 0) : IsOpen (X := R) {x | v x ≤ r} := by
   rw [isOpen_iff_mem_nhds]
@@ -191,30 +195,59 @@ theorem isClosed_closedBall (r : Γ₀) : IsClosed (X := R) {x | v x ≤ r} := b
   exact ⟨Units.mk0 _ hx', fun y hy hy' => ne_of_lt hy <| map_sub_swap v x y ▸
       (Valuation.map_sub_eq_of_lt_left _ <| lt_of_le_of_lt hy' (lt_of_not_ge hx))⟩
 
-/-- A sphere centred at the origin in a valued ring is open. -/
-theorem isOpen_sphere {r : Γ₀} (hr : r ≠ 0) : IsOpen (X := R) {x | v x = r} := by
+/-- A closed ball centred at the origin in a valued ring is clopen. -/
+theorem isClopen_closedBall {r : Γ₀} (hr : r ≠ 0) : IsClopen (X := R) {x | v x ≤ r} :=
+  ⟨isClosed_closedBall _ _, isOpen_closedball _ hr⟩
+
+/-- A sphere centred at the origin in a valued ring is clopen. -/
+theorem isClopen_sphere {r : Γ₀} (hr : r ≠ 0) : IsClopen (X := R) {x | v x = r} := by
   have h : {x : R | v x = r} = {x | v x ≤ r} \ {x | v x < r} := by
     ext x
     simp [← le_antisymm_iff]
   rw [h]
-  exact IsOpen.sdiff (isOpen_closedball _ hr) (isClosed_ball _ _)
+  exact IsClopen.diff (isClopen_closedBall _ hr) (isClopen_ball _ _)
+
+/-- A sphere centred at the origin in a valued ring is open. -/
+theorem isOpen_sphere {r : Γ₀} (hr : r ≠ 0) : IsOpen (X := R) {x | v x = r} :=
+  isClopen_sphere _ hr |>.isOpen
+
+/-- A sphere centred at the origin in a valued ring is closed. -/
+theorem isClosed_sphere (r : Γ₀) : IsClosed (X := R) {x | v x = r} := by
+  rcases eq_or_ne r 0 with rfl|hr
+  · simpa using isClosed_closedBall R 0
+  exact isClopen_sphere _ hr |>.isClosed
 
 /-- The closed unit ball in a valued ring is open. -/
-theorem integer_isOpen : IsOpen (_i.v.integer : Set R) :=
+theorem isOpen_integer : IsOpen (_i.v.integer : Set R) :=
   isOpen_closedball _ one_ne_zero
 
-/-- The valuation subring of a valued field is open. -/
-theorem valuationSubring_isOpen (K : Type u) [Field K] [hv : Valued K Γ₀] :
-    IsOpen (hv.v.valuationSubring : Set K) :=
-  integer_isOpen K
+@[deprecated (since := "2025-04-25")]
+alias integer_isOpen := isOpen_integer
 
 /-- The closed unit ball of a valued ring is closed. -/
-theorem integer_isClosed : IsClosed (_i.v.integer : Set R) :=
+theorem isClosed_integer : IsClosed (_i.v.integer : Set R) :=
   isClosed_closedBall _ _
 
+/-- The closed unit ball of a valued ring is clopen. -/
+theorem isClopen_integer : IsClopen (_i.v.integer : Set R) :=
+  ⟨isClosed_integer _, isOpen_integer _⟩
+
+/-- The valuation subring of a valued field is open. -/
+theorem isOpen_valuationSubring (K : Type u) [Field K] [hv : Valued K Γ₀] :
+    IsOpen (hv.v.valuationSubring : Set K) :=
+  isOpen_integer K
+
+@[deprecated (since := "2025-04-25")]
+alias valuationSubring_isOpen := isOpen_valuationSubring
+
 /-- The valuation subring of a valued field is closed. -/
-theorem valuationSubring_isClosed (K : Type u) [Field K] [hv : Valued K Γ₀] :
+theorem isClosed_valuationSubring (K : Type u) [Field K] [hv : Valued K Γ₀] :
     IsClosed (hv.v.valuationSubring : Set K) :=
-  integer_isClosed K
+  isClosed_integer K
+
+/-- The valuation subring of a valued field is clopen. -/
+theorem isClopen_valuationSubring (K : Type u) [Field K] [hv : Valued K Γ₀] :
+    IsClopen (hv.v.valuationSubring : Set K) :=
+  isClopen_integer K
 
 end Valued

--- a/Mathlib/Topology/Algebra/Valued/ValuationTopology.lean
+++ b/Mathlib/Topology/Algebra/Valued/ValuationTopology.lean
@@ -187,23 +187,17 @@ theorem isClosed_closedBall (r : Γ₀) : IsClosed (X := R) {x | v x ≤ r} := b
   rw [← isOpen_compl_iff, isOpen_iff_mem_nhds]
   intro x hx
   rw [mem_nhds]
-  simp only [le_zero_iff, mem_compl_iff, mem_setOf_eq] at hx ⊢
-  have hx' : v x ≠ 0 := by
-    intro hz
-    simp [hz] at hx
-  refine ⟨Units.mk0 _ hx', fun y hy hy' => ne_of_lt hy ?_⟩
-  rw [map_sub_swap]
-  exact Valuation.map_sub_eq_of_lt_left _ <| lt_of_le_of_lt hy' (lt_of_not_ge hx)
+  have hx' : v x ≠ 0 := ne_of_gt <| lt_of_le_of_lt zero_le' <| lt_of_not_ge hx
+  exact ⟨Units.mk0 _ hx', fun y hy hy' => ne_of_lt hy <| map_sub_swap v x y ▸
+      (Valuation.map_sub_eq_of_lt_left _ <| lt_of_le_of_lt hy' (lt_of_not_ge hx))⟩
 
 /-- A sphere centred at the origin in a valued ring is open. -/
 theorem isOpen_sphere {r : Γ₀} (hr : r ≠ 0) : IsOpen (X := R) {x | v x = r} := by
-  rw [isOpen_iff_mem_nhds]
-  intro x hx
-  rw [mem_nhds]
-  simp only [mem_setOf_eq, setOf_subset_setOf] at hx ⊢
-  refine ⟨Units.mk0 _ hr, fun y hy => (sub_add_cancel y x).symm ▸ ?_⟩
-  rwa [v.map_add_eq_of_lt_right]
-  simpa [hx] using hy
+  have h : {x : R | v x = r} = {x | v x ≤ r} \ {x | v x < r} := by
+    ext x
+    simp [← le_antisymm_iff]
+  rw [h]
+  exact IsOpen.sdiff (isOpen_closedball _ hr) (isClosed_ball _ _)
 
 /-- The closed unit ball in a valued ring is open. -/
 theorem integer_isOpen : IsOpen (_i.v.integer : Set R) :=


### PR DESCRIPTION
Add lemmas that open balls, closed balls, spheres and the integers of a valued ring are closed and clopen.
Rename `integer_isOpen` and  `valuationSubring_isOpen` to `isOpen_integer` and `isOpen_valuationSubring`
and deprecate the old names.

---
Upstreaming from FLT

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
