### PR TITLE
[Merged by Bors] - feat(LinearAlgebra/Span/Defs): span (s \ {0}) is equal to span s

### DIFF
--- a/Mathlib/LinearAlgebra/Span/Defs.lean
+++ b/Mathlib/LinearAlgebra/Span/Defs.lean
@@ -98,7 +98,7 @@ theorem span_insert_zero : span R (insert (0 : M) s) = span R s := by
 @[simp]
 lemma span_sdiff_singleton_zero : span R (s \ {0}) = span R s := by
   by_cases h : 0 ∈ s
-  · rw [←span_insert_zero, (by simp [h] : insert 0 (s \ {0}) = s)]
+  · rw [←span_insert_zero, show insert 0 (s \ {0}) = s by simp [h]]
   · simp [h]
 
 theorem closure_subset_span {s : Set M} : (AddSubmonoid.closure s : Set M) ⊆ span R s :=

--- a/Mathlib/LinearAlgebra/Span/Defs.lean
+++ b/Mathlib/LinearAlgebra/Span/Defs.lean
@@ -95,6 +95,12 @@ theorem span_insert_zero : span R (insert (0 : M) s) = span R s := by
   rw [span_le, Set.insert_subset_iff]
   exact ⟨by simp only [SetLike.mem_coe, Submodule.zero_mem], Submodule.subset_span⟩
 
+@[simp]
+lemma span_sdiff_singleton_zero : span R (s \ {0}) = span R s := by
+  by_cases h : 0 ∈ s
+  · rw [←span_insert_zero, (by simp [h] : insert 0 (s \ {0}) = s)]
+  · simp [h]
+
 theorem closure_subset_span {s : Set M} : (AddSubmonoid.closure s : Set M) ⊆ span R s :=
   (@AddSubmonoid.closure_le _ _ _ (span R s).toAddSubmonoid).mpr subset_span
 

--- a/Mathlib/LinearAlgebra/Span/Defs.lean
+++ b/Mathlib/LinearAlgebra/Span/Defs.lean
@@ -98,7 +98,7 @@ theorem span_insert_zero : span R (insert (0 : M) s) = span R s := by
 @[simp]
 lemma span_sdiff_singleton_zero : span R (s \ {0}) = span R s := by
   by_cases h : 0 ∈ s
-  · rw [←span_insert_zero, show insert 0 (s \ {0}) = s by simp [h]]
+  · rw [← span_insert_zero, show insert 0 (s \ {0}) = s by simp [h]]
   · simp [h]
 
 theorem closure_subset_span {s : Set M} : (AddSubmonoid.closure s : Set M) ⊆ span R s :=


### PR DESCRIPTION
`simp` would be able to solve `Submodule.span (s \ {0}) = Submodule.span s`.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
