### PR TITLE
[Merged by Bors] - doc: better example in Module.finrank docstring

### DIFF
--- a/Mathlib/LinearAlgebra/Dimension/Finrank.lean
+++ b/Mathlib/LinearAlgebra/Dimension/Finrank.lean
@@ -53,7 +53,8 @@ defined by convention to be `0` if this supremum is infinite. See `Module.rank` 
 cardinal-valued version where infinite rank modules have rank an infinite cardinal.
 
 Note that if `R` is not a field then there can exist modules `M` with `¬(Module.Finite R M)` but
-`finrank R M ≠ 0`. For example `ℤ × ℚ/ℤ` has `finrank` equal to `1` over `ℤ`. -/
+`finrank R M ≠ 0`. For example `ℚ` has `finrank` equal to `1` over `ℤ`, because the nonempty
+`ℤ`-linearly independent subsets of `ℚ` are precisely the nonzero singletons. -/
 noncomputable def finrank (R M : Type*) [Semiring R] [AddCommMonoid M] [Module R M] : ℕ :=
   Cardinal.toNat (Module.rank R M)
 


### PR DESCRIPTION
Q has finrank 1 over Z but isn't finitely-generated as a Z-module.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
