### PR TITLE
[Merged by Bors] - chore(Algebra): modify the class `IsQuadraticExtension`

### DIFF
--- a/Mathlib/FieldTheory/Galois/Basic.lean
+++ b/Mathlib/FieldTheory/Galois/Basic.lean
@@ -33,7 +33,7 @@ Together, these two results prove the Galois correspondence.
 
 ## Additional results
 
-- Instances for `IsQuadraticAlgebra`: a quadratic extension is Galois (if separable) with cyclic
+- Instances for `IsQuadraticModule`: a quadratic extension is Galois (if separable) with cyclic
   and thus abelian Galois group.
 
 -/
@@ -516,19 +516,19 @@ instance (priority := 100) IsAlgClosure.isGalois (k K : Type*) [Field k] [Field 
 
 end IsAlgClosure
 
-noncomputable section IsQuadraticAlgebra
+noncomputable section IsQuadraticModule
 
-variable (F K : Type*) [Field F] [Field K] [Algebra F K] [IsQuadraticAlgebra F K]
+variable (F K : Type*) [Field F] [Field K] [Algebra F K] [IsQuadraticModule F K]
 
 /--
 A quadratic separable extension is Galois.
 -/
-instance IsQuadraticAlgebra.isGalois[Algebra.IsSeparable F K] : IsGalois F K where
+instance IsQuadraticModule.isGalois [Algebra.IsSeparable F K] : IsGalois F K where
 
 /--
 A quadratic extension has cyclic Galois group.
 -/
-instance IsQuadraticAlgebra.isCyclic : IsCyclic (K ≃ₐ[F] K) := by
+instance IsQuadraticModule.isCyclic : IsCyclic (K ≃ₐ[F] K) := by
   have := finrank_eq_two F K ▸ AlgEquiv.card_le
   interval_cases h : Fintype.card (K ≃ₐ[F] K)
   · simp_all
@@ -539,7 +539,7 @@ instance IsQuadraticAlgebra.isCyclic : IsCyclic (K ≃ₐ[F] K) := by
 /--
 A quadratic extension has abelian Galois group.
 -/
-instance IsQuadraticAlgebra.isMulCommutative_galoisGroup :
+instance IsQuadraticModule.isMulCommutative_galoisGroup :
     IsMulCommutative (K ≃ₐ[F] K) := ⟨IsCyclic.commutative⟩
 
-end IsQuadraticAlgebra
+end IsQuadraticModule

--- a/Mathlib/FieldTheory/Galois/Basic.lean
+++ b/Mathlib/FieldTheory/Galois/Basic.lean
@@ -33,8 +33,8 @@ Together, these two results prove the Galois correspondence.
 
 ## Additional results
 
-- Instances for `IsQuadraticModule`: a quadratic extension is Galois (if separable) with cyclic
-  and thus abelian Galois group.
+- Instances for `Algebra.IsQuadraticExtension`: a quadratic extension is Galois (if separable)
+  with cyclic and thus abelian Galois group.
 
 -/
 
@@ -516,19 +516,19 @@ instance (priority := 100) IsAlgClosure.isGalois (k K : Type*) [Field k] [Field 
 
 end IsAlgClosure
 
-noncomputable section IsQuadraticModule
+namespace Algebra
 
-variable (F K : Type*) [Field F] [Field K] [Algebra F K] [IsQuadraticModule F K]
+variable (F K : Type*) [Field F] [Field K] [Algebra F K] [IsQuadraticExtension F K]
 
 /--
 A quadratic separable extension is Galois.
 -/
-instance IsQuadraticModule.isGalois [Algebra.IsSeparable F K] : IsGalois F K where
+instance IsQuadraticExtension.isGalois [Algebra.IsSeparable F K] : IsGalois F K where
 
 /--
 A quadratic extension has cyclic Galois group.
 -/
-instance IsQuadraticModule.isCyclic : IsCyclic (K ≃ₐ[F] K) := by
+instance IsQuadraticExtension.isCyclic : IsCyclic (K ≃ₐ[F] K) := by
   have := finrank_eq_two F K ▸ AlgEquiv.card_le
   interval_cases h : Fintype.card (K ≃ₐ[F] K)
   · simp_all
@@ -539,7 +539,7 @@ instance IsQuadraticModule.isCyclic : IsCyclic (K ≃ₐ[F] K) := by
 /--
 A quadratic extension has abelian Galois group.
 -/
-instance IsQuadraticModule.isMulCommutative_galoisGroup :
+instance IsQuadraticExtension.isMulCommutative_galoisGroup :
     IsMulCommutative (K ≃ₐ[F] K) := ⟨IsCyclic.commutative⟩
 
-end IsQuadraticModule
+end Algebra

--- a/Mathlib/FieldTheory/Galois/Basic.lean
+++ b/Mathlib/FieldTheory/Galois/Basic.lean
@@ -516,20 +516,19 @@ instance (priority := 100) IsAlgClosure.isGalois (k K : Type*) [Field k] [Field 
 
 end IsAlgClosure
 
-section IsQuadraticAlgebra
+noncomputable section IsQuadraticAlgebra
+
+variable (F K : Type*) [Field F] [Field K] [Algebra F K] [IsQuadraticAlgebra F K]
 
 /--
 A quadratic separable extension is Galois.
 -/
-instance IsQuadraticAlgebra.isGalois (F K : Type*) [Field F] [Field K] [Algebra F K]
-    [IsQuadraticAlgebra F K] [Algebra.IsSeparable F K] : IsGalois F K where
+instance IsQuadraticAlgebra.isGalois[Algebra.IsSeparable F K] : IsGalois F K where
 
 /--
 A quadratic extension has cyclic Galois group.
 -/
-instance IsQuadraticAlgebra.isCyclic (F K : Type*) [Field F] [Field K] [Algebra F K]
-    [IsQuadraticAlgebra F K] :
-    IsCyclic (K ≃ₐ[F] K) := by
+instance IsQuadraticAlgebra.isCyclic : IsCyclic (K ≃ₐ[F] K) := by
   have := finrank_eq_two F K ▸ AlgEquiv.card_le
   interval_cases h : Fintype.card (K ≃ₐ[F] K)
   · simp_all
@@ -540,8 +539,13 @@ instance IsQuadraticAlgebra.isCyclic (F K : Type*) [Field F] [Field K] [Algebra 
 /--
 A quadratic extension has abelian Galois group.
 -/
-instance IsQuadraticAlgebra.isMulCommutative_galoisGroup (F K : Type*) [Field F] [Field K]
-    [Algebra F K] [IsQuadraticAlgebra F K] :
+instance IsQuadraticAlgebra.isMulCommutative_galoisGroup :
     IsMulCommutative (K ≃ₐ[F] K) := ⟨IsCyclic.commutative⟩
+
+def IsQuadraticAlgebra.mulEquivZModTwo [Algebra.IsSeparable F K] :
+    (K ≃ₐ[F] K) ≃* Multiplicative (ZMod 2) := by
+  refine (mulEquivOfCyclicCardEq ?_).symm
+  rw [Nat.card_eq_fintype_card, Fintype.card_multiplicative, ZMod.card, Nat.card_eq_fintype_card,
+    IsGalois.card_aut_eq_finrank, IsQuadraticAlgebra.finrank_eq_two]
 
 end IsQuadraticAlgebra

--- a/Mathlib/FieldTheory/Galois/Basic.lean
+++ b/Mathlib/FieldTheory/Galois/Basic.lean
@@ -542,6 +542,9 @@ A quadratic extension has abelian Galois group.
 instance IsQuadraticAlgebra.isMulCommutative_galoisGroup :
     IsMulCommutative (K ≃ₐ[F] K) := ⟨IsCyclic.commutative⟩
 
+/--
+The isomorphism between the Galois group of a quadratic separable extension and `ℤ/2ℤ`.
+-/
 def IsQuadraticAlgebra.mulEquivZModTwo [Algebra.IsSeparable F K] :
     (K ≃ₐ[F] K) ≃* Multiplicative (ZMod 2) := by
   refine (mulEquivOfCyclicCardEq ?_).symm

--- a/Mathlib/FieldTheory/Galois/Basic.lean
+++ b/Mathlib/FieldTheory/Galois/Basic.lean
@@ -33,7 +33,7 @@ Together, these two results prove the Galois correspondence.
 
 ## Additional results
 
-- Instances for `IsQuadraticExtension`: a quadratic extension is Galois (if separable) with cyclic
+- Instances for `IsQuadraticAlgebra`: a quadratic extension is Galois (if separable) with cyclic
   and thus abelian Galois group.
 
 -/
@@ -516,18 +516,18 @@ instance (priority := 100) IsAlgClosure.isGalois (k K : Type*) [Field k] [Field 
 
 end IsAlgClosure
 
-section IsQuadraticExtension
+section IsQuadraticAlgebra
 
 /--
 A quadratic separable extension is Galois.
 -/
-instance (F K : Type*) [Field F] [Field K] [IsQuadraticExtension F K] [Algebra.IsSeparable F K] :
-    IsGalois F K where
+instance (F K : Type*) [Field F] [Field K] [Algebra F K] [IsQuadraticAlgebra F K]
+    [Algebra.IsSeparable F K] : IsGalois F K where
 
 /--
 A quadratic extension has cyclic Galois group.
 -/
-instance (F K : Type*) [Field F] [Field K] [h : IsQuadraticExtension F K] :
+instance (F K : Type*) [Field F] [Field K] [Algebra F K] [h : IsQuadraticAlgebra F K] :
     IsCyclic (K ≃ₐ[F] K) := by
   have := h.finrank_eq_two ▸ AlgEquiv.card_le
   interval_cases h : Fintype.card (K ≃ₐ[F] K)
@@ -539,7 +539,7 @@ instance (F K : Type*) [Field F] [Field K] [h : IsQuadraticExtension F K] :
 /--
 A quadratic extension has abelian Galois group.
 -/
-instance (F K : Type*) [Field F] [Field K] [IsQuadraticExtension F K] :
+instance (F K : Type*) [Field F] [Field K] [Algebra F K] [h : IsQuadraticAlgebra F K] :
     IsMulCommutative (K ≃ₐ[F] K) := ⟨IsCyclic.commutative⟩
 
-end IsQuadraticExtension
+end IsQuadraticAlgebra

--- a/Mathlib/FieldTheory/Galois/Basic.lean
+++ b/Mathlib/FieldTheory/Galois/Basic.lean
@@ -521,15 +521,16 @@ section IsQuadraticAlgebra
 /--
 A quadratic separable extension is Galois.
 -/
-instance (F K : Type*) [Field F] [Field K] [Algebra F K] [IsQuadraticAlgebra F K]
-    [Algebra.IsSeparable F K] : IsGalois F K where
+instance IsQuadraticAlgebra.isGalois (F K : Type*) [Field F] [Field K] [Algebra F K]
+    [IsQuadraticAlgebra F K] [Algebra.IsSeparable F K] : IsGalois F K where
 
 /--
 A quadratic extension has cyclic Galois group.
 -/
-instance (F K : Type*) [Field F] [Field K] [Algebra F K] [h : IsQuadraticAlgebra F K] :
+instance IsQuadraticAlgebra.isCyclic (F K : Type*) [Field F] [Field K] [Algebra F K]
+    [IsQuadraticAlgebra F K] :
     IsCyclic (K ≃ₐ[F] K) := by
-  have := h.finrank_eq_two ▸ AlgEquiv.card_le
+  have := finrank_eq_two F K ▸ AlgEquiv.card_le
   interval_cases h : Fintype.card (K ≃ₐ[F] K)
   · simp_all
   · exact @isCyclic_of_subsingleton _ _ (Fintype.card_le_one_iff_subsingleton.mp h.le)
@@ -539,7 +540,8 @@ instance (F K : Type*) [Field F] [Field K] [Algebra F K] [h : IsQuadraticAlgebra
 /--
 A quadratic extension has abelian Galois group.
 -/
-instance (F K : Type*) [Field F] [Field K] [Algebra F K] [h : IsQuadraticAlgebra F K] :
+instance IsQuadraticAlgebra.isMulCommutative_galoisGroup (F K : Type*) [Field F] [Field K]
+    [Algebra F K] [IsQuadraticAlgebra F K] :
     IsMulCommutative (K ≃ₐ[F] K) := ⟨IsCyclic.commutative⟩
 
 end IsQuadraticAlgebra

--- a/Mathlib/FieldTheory/Galois/Basic.lean
+++ b/Mathlib/FieldTheory/Galois/Basic.lean
@@ -542,13 +542,4 @@ A quadratic extension has abelian Galois group.
 instance IsQuadraticAlgebra.isMulCommutative_galoisGroup :
     IsMulCommutative (K ≃ₐ[F] K) := ⟨IsCyclic.commutative⟩
 
-/--
-The isomorphism between the Galois group of a quadratic separable extension and `ℤ/2ℤ`.
--/
-def IsQuadraticAlgebra.mulEquivZModTwo [Algebra.IsSeparable F K] :
-    (K ≃ₐ[F] K) ≃* Multiplicative (ZMod 2) := by
-  refine (mulEquivOfCyclicCardEq ?_).symm
-  rw [Nat.card_eq_fintype_card, Fintype.card_multiplicative, ZMod.card, Nat.card_eq_fintype_card,
-    IsGalois.card_aut_eq_finrank, IsQuadraticAlgebra.finrank_eq_two]
-
 end IsQuadraticAlgebra

--- a/Mathlib/FieldTheory/KummerExtension.lean
+++ b/Mathlib/FieldTheory/KummerExtension.lean
@@ -40,7 +40,7 @@ Criteria for `X ^ n - C a` to be irreducible is given:
 
 TODO: criteria for even `n`. See [serge_lang_algebra] VI,§9.
 
-TODO: relate Kummer extensions of degree 2 with the class `IsQuadraticAlgebra`.
+TODO: relate Kummer extensions of degree 2 with the class `IsQuadraticModule`.
 -/
 universe u
 

--- a/Mathlib/FieldTheory/KummerExtension.lean
+++ b/Mathlib/FieldTheory/KummerExtension.lean
@@ -40,7 +40,7 @@ Criteria for `X ^ n - C a` to be irreducible is given:
 
 TODO: criteria for even `n`. See [serge_lang_algebra] VI,§9.
 
-TODO: relate Kummer extensions of degree 2 with the class `IsQuadraticModule`.
+TODO: relate Kummer extensions of degree 2 with the class `Algebra.IsQuadraticExtension`.
 -/
 universe u
 

--- a/Mathlib/FieldTheory/KummerExtension.lean
+++ b/Mathlib/FieldTheory/KummerExtension.lean
@@ -40,7 +40,7 @@ Criteria for `X ^ n - C a` to be irreducible is given:
 
 TODO: criteria for even `n`. See [serge_lang_algebra] VI,§9.
 
-TODO: relate Kummer extensions of degree 2 with the class `IsQuadraticExtension`.
+TODO: relate Kummer extensions of degree 2 with the class `IsQuadraticAlgebra`.
 -/
 universe u
 

--- a/Mathlib/FieldTheory/Normal/Basic.lean
+++ b/Mathlib/FieldTheory/Normal/Basic.lean
@@ -17,8 +17,8 @@ is the same as being a splitting field (`Normal.of_isSplittingField` and
 
 ## Additional Results
 
-* `IsQuadraticModule.normal`: a quadratic extension, given as a class
-  `IsQuadraticModule`, is normal.
+* `Algebra.IsQuadraticExtension.normal`: the instance that a quadratic extension, given as a class
+  `Algebra.IsQuadraticExtension`, is normal.
 
 -/
 
@@ -283,8 +283,8 @@ end minpoly
 /--
 A quadratic extension is normal.
 -/
-instance IsQuadraticModule.normal (F K : Type*) [Field F] [Field K] [Algebra F K]
-    [IsQuadraticModule F K] :
+instance Algebra.IsQuadraticExtension.normal (F K : Type*) [Field F] [Field K] [Algebra F K]
+    [IsQuadraticExtension F K] :
     Normal F K where
   splits' := by
     intro x
@@ -293,4 +293,4 @@ instance IsQuadraticModule.normal (F K : Type*) [Field F] [Field K] [Algebra F K
     · exact splits_of_natDegree_eq_two _ h (minpoly.aeval F x)
 
 @[deprecated (since := "2025-04-17")] alias normal_of_finrank_eq_two :=
-  IsQuadraticModule.normal
+  Algebra.IsQuadraticExtension.normal

--- a/Mathlib/FieldTheory/Normal/Basic.lean
+++ b/Mathlib/FieldTheory/Normal/Basic.lean
@@ -284,11 +284,11 @@ end minpoly
 A quadratic extension is normal.
 -/
 instance IsQuadraticAlgebra.Normal (F K : Type*) [Field F] [Field K] [Algebra F K]
-    [h : IsQuadraticAlgebra F K] :
+    [IsQuadraticAlgebra F K] :
     Normal F K where
   splits' := by
     intro x
-    obtain h | h := le_iff_lt_or_eq.mp (h.finrank_eq_two ▸ minpoly.natDegree_le x)
+    obtain h | h := le_iff_lt_or_eq.mp (finrank_eq_two F K ▸ minpoly.natDegree_le x)
     · exact splits_of_natDegree_le_one _ (by rwa [Nat.le_iff_lt_add_one])
     · exact splits_of_natDegree_eq_two _ h (minpoly.aeval F x)
 

--- a/Mathlib/FieldTheory/Normal/Basic.lean
+++ b/Mathlib/FieldTheory/Normal/Basic.lean
@@ -17,7 +17,7 @@ is the same as being a splitting field (`Normal.of_isSplittingField` and
 
 ## Additional Results
 
-* `IsQuadraticAlgebra.Normal`: a quadratic extension, given as a class
+* `IsQuadraticAlgebra.normal`: a quadratic extension, given as a class
   `IsQuadraticAlgebra`, is normal.
 
 -/
@@ -283,7 +283,7 @@ end minpoly
 /--
 A quadratic extension is normal.
 -/
-instance IsQuadraticAlgebra.Normal (F K : Type*) [Field F] [Field K] [Algebra F K]
+instance IsQuadraticAlgebra.normal (F K : Type*) [Field F] [Field K] [Algebra F K]
     [IsQuadraticAlgebra F K] :
     Normal F K where
   splits' := by

--- a/Mathlib/FieldTheory/Normal/Basic.lean
+++ b/Mathlib/FieldTheory/Normal/Basic.lean
@@ -17,8 +17,8 @@ is the same as being a splitting field (`Normal.of_isSplittingField` and
 
 ## Additional Results
 
-* `IsQuadraticAlgebra.normal`: a quadratic extension, given as a class
-  `IsQuadraticAlgebra`, is normal.
+* `IsQuadraticModule.normal`: a quadratic extension, given as a class
+  `IsQuadraticModule`, is normal.
 
 -/
 
@@ -283,8 +283,8 @@ end minpoly
 /--
 A quadratic extension is normal.
 -/
-instance IsQuadraticAlgebra.normal (F K : Type*) [Field F] [Field K] [Algebra F K]
-    [IsQuadraticAlgebra F K] :
+instance IsQuadraticModule.normal (F K : Type*) [Field F] [Field K] [Algebra F K]
+    [IsQuadraticModule F K] :
     Normal F K where
   splits' := by
     intro x
@@ -293,4 +293,4 @@ instance IsQuadraticAlgebra.normal (F K : Type*) [Field F] [Field K] [Algebra F 
     · exact splits_of_natDegree_eq_two _ h (minpoly.aeval F x)
 
 @[deprecated (since := "2025-04-17")] alias normal_of_finrank_eq_two :=
-  IsQuadraticAlgebra.normal
+  IsQuadraticModule.normal

--- a/Mathlib/FieldTheory/Normal/Basic.lean
+++ b/Mathlib/FieldTheory/Normal/Basic.lean
@@ -293,4 +293,4 @@ instance IsQuadraticAlgebra.normal (F K : Type*) [Field F] [Field K] [Algebra F 
     · exact splits_of_natDegree_eq_two _ h (minpoly.aeval F x)
 
 @[deprecated (since := "2025-04-17")] alias normal_of_finrank_eq_two :=
-  IsQuadraticAlgebra.Normal
+  IsQuadraticAlgebra.normal

--- a/Mathlib/FieldTheory/Normal/Basic.lean
+++ b/Mathlib/FieldTheory/Normal/Basic.lean
@@ -17,8 +17,8 @@ is the same as being a splitting field (`Normal.of_isSplittingField` and
 
 ## Additional Results
 
-* `IsQuadraticExtension.Normal`: a quadratic extension, given as a class
-  `IsQuadraticExtension`, is normal.
+* `IsQuadraticAlgebra.Normal`: a quadratic extension, given as a class
+  `IsQuadraticAlgebra`, is normal.
 
 -/
 
@@ -283,8 +283,8 @@ end minpoly
 /--
 A quadratic extension is normal.
 -/
-instance IsQuadraticExtension.Normal (F K : Type*) [Field F] [Field K]
-    [h : IsQuadraticExtension F K] :
+instance IsQuadraticAlgebra.Normal (F K : Type*) [Field F] [Field K] [Algebra F K]
+    [h : IsQuadraticAlgebra F K] :
     Normal F K where
   splits' := by
     intro x
@@ -293,4 +293,4 @@ instance IsQuadraticExtension.Normal (F K : Type*) [Field F] [Field K]
     · exact splits_of_natDegree_eq_two _ h (minpoly.aeval F x)
 
 @[deprecated (since := "2025-04-17")] alias normal_of_finrank_eq_two :=
-  IsQuadraticExtension.Normal
+  IsQuadraticAlgebra.Normal

--- a/Mathlib/LinearAlgebra/Dimension/Finrank.lean
+++ b/Mathlib/LinearAlgebra/Dimension/Finrank.lean
@@ -129,15 +129,3 @@ variable (R M)
 theorem finrank_top : finrank R (⊤ : Submodule R M) = finrank R M := by
   unfold finrank
   simp
-
-section Algebra
-
-/--
-An extension of rings `R ⊆ S` is quadratic if `S` is a `R`-module of rank `2`.
--/
--- TODO. use this in connection with `NumberTheory.Zsqrtd`
-class IsQuadraticExtension (R S : Type*) [CommSemiring R] [Semiring S]
-  extends Algebra R S where
-  finrank_eq_two : Module.finrank R S = 2
-
-end Algebra

--- a/Mathlib/LinearAlgebra/Dimension/Free.lean
+++ b/Mathlib/LinearAlgebra/Dimension/Free.lean
@@ -226,7 +226,6 @@ end Module
 section IsQuadraticAlgebra
 
 instance (R S : Type*) [CommSemiring R] [Semiring S] [Algebra R S] [IsQuadraticAlgebra R S] :
-    Module.Finite R S := by
-  exact Module.finite_of_finrank_eq_succ IsQuadraticAlgebra.finrank_eq_two
+    Module.Finite R S := finite_of_finrank_eq_succ IsQuadraticAlgebra.finrank_eq_two
 
 end IsQuadraticAlgebra

--- a/Mathlib/LinearAlgebra/Dimension/Free.lean
+++ b/Mathlib/LinearAlgebra/Dimension/Free.lean
@@ -222,3 +222,11 @@ theorem basisUnique_repr_eq_zero_iff {ι : Type*} [Unique ι]
     fun hv => by rw [hv, LinearEquiv.map_zero, Finsupp.zero_apply]⟩
 
 end Module
+
+section IsQuadraticAlgebra
+
+instance (R S : Type*) [CommSemiring R] [Semiring S] [Algebra R S] [IsQuadraticAlgebra R S] :
+    Module.Finite R S := by
+  exact Module.finite_of_finrank_eq_succ IsQuadraticAlgebra.finrank_eq_two
+
+end IsQuadraticAlgebra

--- a/Mathlib/LinearAlgebra/Dimension/Free.lean
+++ b/Mathlib/LinearAlgebra/Dimension/Free.lean
@@ -225,7 +225,8 @@ end Module
 
 section IsQuadraticAlgebra
 
-instance (R S : Type*) [CommSemiring R] [Semiring S] [Algebra R S] [IsQuadraticAlgebra R S] :
+instance (R S : Type*) [CommSemiring R] [StrongRankCondition R] [Semiring S] [Algebra R S]
+    [IsQuadraticAlgebra R S] :
     Module.Finite R S := finite_of_finrank_eq_succ <| IsQuadraticAlgebra.finrank_eq_two R S
 
 end IsQuadraticAlgebra

--- a/Mathlib/LinearAlgebra/Dimension/Free.lean
+++ b/Mathlib/LinearAlgebra/Dimension/Free.lean
@@ -223,10 +223,10 @@ theorem basisUnique_repr_eq_zero_iff {ι : Type*} [Unique ι]
 
 end Module
 
-section IsQuadraticAlgebra
+section IsQuadraticModule
 
-instance (R S : Type*) [CommSemiring R] [StrongRankCondition R] [Semiring S] [Algebra R S]
-    [IsQuadraticAlgebra R S] :
-    Module.Finite R S := finite_of_finrank_eq_succ <| IsQuadraticAlgebra.finrank_eq_two R S
+instance (R S : Type*) [CommSemiring R] [StrongRankCondition R] [Semiring S] [Module R S]
+    [IsQuadraticModule R S] :
+    Module.Finite R S := finite_of_finrank_eq_succ <| IsQuadraticModule.finrank_eq_two R S
 
-end IsQuadraticAlgebra
+end IsQuadraticModule

--- a/Mathlib/LinearAlgebra/Dimension/Free.lean
+++ b/Mathlib/LinearAlgebra/Dimension/Free.lean
@@ -226,6 +226,6 @@ end Module
 section IsQuadraticAlgebra
 
 instance (R S : Type*) [CommSemiring R] [Semiring S] [Algebra R S] [IsQuadraticAlgebra R S] :
-    Module.Finite R S := finite_of_finrank_eq_succ IsQuadraticAlgebra.finrank_eq_two
+    Module.Finite R S := finite_of_finrank_eq_succ <| IsQuadraticAlgebra.finrank_eq_two R S
 
 end IsQuadraticAlgebra

--- a/Mathlib/LinearAlgebra/Dimension/Free.lean
+++ b/Mathlib/LinearAlgebra/Dimension/Free.lean
@@ -223,10 +223,10 @@ theorem basisUnique_repr_eq_zero_iff {ι : Type*} [Unique ι]
 
 end Module
 
-section IsQuadraticModule
+namespace Algebra
 
-instance (R S : Type*) [CommSemiring R] [StrongRankCondition R] [Semiring S] [Module R S]
-    [IsQuadraticModule R S] :
-    Module.Finite R S := finite_of_finrank_eq_succ <| IsQuadraticModule.finrank_eq_two R S
+instance (R S : Type*) [CommSemiring R] [StrongRankCondition R] [Semiring S] [Algebra R S]
+    [IsQuadraticExtension R S] :
+    Module.Finite R S := finite_of_finrank_eq_succ <| IsQuadraticExtension.finrank_eq_two R S
 
-end IsQuadraticModule
+end Algebra

--- a/Mathlib/LinearAlgebra/Dimension/StrongRankCondition.lean
+++ b/Mathlib/LinearAlgebra/Dimension/StrongRankCondition.lean
@@ -37,7 +37,7 @@ For modules over rings with invariant basis number
 
 ## Additional definition
 
-* `IsQuadraticAlgebra`: An extension of rings `R ⊆ S` is quadratic if `S` is a free `R`-algebra
+* `IsQuadraticModule`: An extension of rings `R ⊆ S` is quadratic if `S` is a free `R`-module
   of rank `2`.
 
 -/
@@ -548,18 +548,18 @@ theorem mem_span_set_iff_exists_finsupp_le_finrank :
 
 end Submodule
 
-section IsQuadraticAlgebra
+section IsQuadraticModule
 
 /--
-An extension of rings `R ⊆ S` is quadratic if `S` is a free `R`-algebra of rank `2`.
+An extension of rings `R ⊆ S` is quadratic if `S` is a free `R`-module of rank `2`.
 -/
 -- TODO. use this in connection with `NumberTheory.Zsqrtd`
-class IsQuadraticAlgebra (R S : Type*) [CommSemiring R] [StrongRankCondition R] [Semiring S]
-    [Algebra R S] extends Module.Free R S where
+class IsQuadraticModule (R S : Type*) [CommSemiring R] [StrongRankCondition R] [Semiring S]
+    [Module R S] extends Module.Free R S where
   finrank_eq_two' : Module.finrank R S = 2
 
-theorem IsQuadraticAlgebra.finrank_eq_two (R S : Type*) [CommSemiring R] [StrongRankCondition R]
-    [Semiring S] [Algebra R S] [IsQuadraticAlgebra R S] :
+theorem IsQuadraticModule.finrank_eq_two (R S : Type*) [CommSemiring R] [StrongRankCondition R]
+    [Semiring S] [Module R S] [IsQuadraticModule R S] :
     Module.finrank R S = 2 := finrank_eq_two'
 
-end IsQuadraticAlgebra
+end IsQuadraticModule

--- a/Mathlib/LinearAlgebra/Dimension/StrongRankCondition.lean
+++ b/Mathlib/LinearAlgebra/Dimension/StrongRankCondition.lean
@@ -542,3 +542,15 @@ theorem mem_span_set_iff_exists_finsupp_le_finrank :
     exact mem_span_set.mpr ⟨c, hcs, hx⟩
 
 end Submodule
+
+section IsQuadraticAlgebra
+
+/--
+An extension of rings `R ⊆ S` is quadratic if `S` is a free `R`-module of rank `2`.
+-/
+-- TODO. use this in connection with `NumberTheory.Zsqrtd`
+class IsQuadraticAlgebra (R S : Type*) [CommSemiring R] [Semiring S] [Algebra R S]
+  extends StrongRankCondition R, Module.Free R S where
+  finrank_eq_two : Module.finrank R S = 2
+
+end IsQuadraticAlgebra

--- a/Mathlib/LinearAlgebra/Dimension/StrongRankCondition.lean
+++ b/Mathlib/LinearAlgebra/Dimension/StrongRankCondition.lean
@@ -35,6 +35,11 @@ For modules over rings with invariant basis number
 * `mk_eq_mk_of_basis`: the dimension theorem, any two bases of the same vector space have the same
   cardinality.
 
+## Additional definition
+
+* `IsQuadraticAlgebra`: An extension of rings `R ⊆ S` is quadratic if `S` is a free `R`-algebra
+  of rank `2`.
+
 -/
 
 
@@ -542,6 +547,7 @@ theorem mem_span_set_iff_exists_finsupp_le_finrank :
     exact mem_span_set.mpr ⟨c, hcs, hx⟩
 
 end Submodule
+
 section IsQuadraticAlgebra
 
 /--

--- a/Mathlib/LinearAlgebra/Dimension/StrongRankCondition.lean
+++ b/Mathlib/LinearAlgebra/Dimension/StrongRankCondition.lean
@@ -37,8 +37,8 @@ For modules over rings with invariant basis number
 
 ## Additional definition
 
-* `IsQuadraticModule`: An extension of rings `R ⊆ S` is quadratic if `S` is a free `R`-module
-  of rank `2`.
+* `Algebra.IsQuadraticExtension`: An extension of rings `R ⊆ S` is quadratic if `S` is a
+  free `R`-algebra of rank `2`.
 
 -/
 
@@ -548,18 +548,18 @@ theorem mem_span_set_iff_exists_finsupp_le_finrank :
 
 end Submodule
 
-section IsQuadraticModule
+namespace Algebra
 
 /--
-An extension of rings `R ⊆ S` is quadratic if `S` is a free `R`-module of rank `2`.
+An extension of rings `R ⊆ S` is quadratic if `S` is a free `R`-algebra of rank `2`.
 -/
 -- TODO. use this in connection with `NumberTheory.Zsqrtd`
-class IsQuadraticModule (R S : Type*) [CommSemiring R] [StrongRankCondition R] [Semiring S]
-    [Module R S] extends Module.Free R S where
+class IsQuadraticExtension (R S : Type*) [CommSemiring R] [StrongRankCondition R] [Semiring S]
+    [Algebra R S] extends Module.Free R S where
   finrank_eq_two' : Module.finrank R S = 2
 
-theorem IsQuadraticModule.finrank_eq_two (R S : Type*) [CommSemiring R] [StrongRankCondition R]
-    [Semiring S] [Module R S] [IsQuadraticModule R S] :
+theorem IsQuadraticExtension.finrank_eq_two (R S : Type*) [CommSemiring R] [StrongRankCondition R]
+    [Semiring S] [Algebra R S] [IsQuadraticExtension R S] :
     Module.finrank R S = 2 := finrank_eq_two'
 
-end IsQuadraticModule
+end Algebra

--- a/Mathlib/LinearAlgebra/Dimension/StrongRankCondition.lean
+++ b/Mathlib/LinearAlgebra/Dimension/StrongRankCondition.lean
@@ -551,6 +551,10 @@ An extension of rings `R ⊆ S` is quadratic if `S` is a free `R`-module of rank
 -- TODO. use this in connection with `NumberTheory.Zsqrtd`
 class IsQuadraticAlgebra (R S : Type*) [CommSemiring R] [Semiring S] [Algebra R S]
   extends StrongRankCondition R, Module.Free R S where
-  finrank_eq_two : Module.finrank R S = 2
+  finrank_eq_two' : Module.finrank R S = 2
+
+theorem IsQuadraticAlgebra.finrank_eq_two (R S : Type*) [CommSemiring R] [Semiring S] [Algebra R S]
+    [IsQuadraticAlgebra R S] :
+    Module.finrank R S = 2 := finrank_eq_two'
 
 end IsQuadraticAlgebra

--- a/Mathlib/LinearAlgebra/Dimension/StrongRankCondition.lean
+++ b/Mathlib/LinearAlgebra/Dimension/StrongRankCondition.lean
@@ -542,19 +542,18 @@ theorem mem_span_set_iff_exists_finsupp_le_finrank :
     exact mem_span_set.mpr ⟨c, hcs, hx⟩
 
 end Submodule
-
 section IsQuadraticAlgebra
 
 /--
-An extension of rings `R ⊆ S` is quadratic if `S` is a free `R`-module of rank `2`.
+An extension of rings `R ⊆ S` is quadratic if `S` is a free `R`-algebra of rank `2`.
 -/
 -- TODO. use this in connection with `NumberTheory.Zsqrtd`
-class IsQuadraticAlgebra (R S : Type*) [CommSemiring R] [Semiring S] [Algebra R S]
-  extends StrongRankCondition R, Module.Free R S where
+class IsQuadraticAlgebra (R S : Type*) [CommSemiring R] [StrongRankCondition R] [Semiring S]
+    [Algebra R S] extends Module.Free R S where
   finrank_eq_two' : Module.finrank R S = 2
 
-theorem IsQuadraticAlgebra.finrank_eq_two (R S : Type*) [CommSemiring R] [Semiring S] [Algebra R S]
-    [IsQuadraticAlgebra R S] :
+theorem IsQuadraticAlgebra.finrank_eq_two (R S : Type*) [CommSemiring R] [StrongRankCondition R]
+    [Semiring S] [Algebra R S] [IsQuadraticAlgebra R S] :
     Module.finrank R S = 2 := finrank_eq_two'
 
 end IsQuadraticAlgebra

--- a/Mathlib/LinearAlgebra/FiniteDimensional/Basic.lean
+++ b/Mathlib/LinearAlgebra/FiniteDimensional/Basic.lean
@@ -582,10 +582,3 @@ theorem ker_pow_constant {f : End K V} {k : ℕ}
 end End
 
 end Module
-
-section IsQuadraticExtension
-
-instance (R : Type*) [Field K] [CommRing R] [h : IsQuadraticExtension K R] :
-    FiniteDimensional K R := Module.finite_of_finrank_eq_succ h.finrank_eq_two
-
-end IsQuadraticExtension


### PR DESCRIPTION
The class `IsQuadraticExtension` that was added in a recent PR is modified in the following way: 
- Moved it to `Algebra` namespace
- Add the conditions `Module.Free R S` and `StrongRankCondition R` (for `IsQuadraticExtension R S`); these conditions ensure that `Module.Finite R S` (added as an instance)
- Unbundle the hypothesis `Algebra R S`, thus it is truly a `Prop` as the `Is` indicates. 

Note. since the class  `IsQuadraticExtension`  was just added, no deprecation aliases have been added. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
