### PR TITLE
[Merged by Bors] - feat: a continuous meromorphic function is analytic

### DIFF
--- a/Mathlib/Analysis/Analytic/Basic.lean
+++ b/Mathlib/Analysis/Analytic/Basic.lean
@@ -1322,6 +1322,14 @@ protected theorem AnalyticAt.continuousAt (hf : AnalyticAt 𝕜 f x) : Continuou
   let ⟨_, hp⟩ := hf
   hp.continuousAt
 
+protected theorem AnalyticAt.eventually_continuousAt (hf : AnalyticAt 𝕜 f x) :
+    ∀ᶠ y in 𝓝 x, ContinuousAt f y := by
+  rcases hf with ⟨g, r, hg⟩
+  have : EMetric.ball x r ∈ 𝓝 x := EMetric.ball_mem_nhds _ hg.r_pos
+  filter_upwards [this] with y hy
+  apply hg.continuousOn.continuousAt
+  exact EMetric.isOpen_ball.mem_nhds hy
+
 protected theorem AnalyticOnNhd.continuousOn {s : Set E} (hf : AnalyticOnNhd 𝕜 f s) :
     ContinuousOn f s :=
   fun x hx => (hf x hx).continuousAt.continuousWithinAt

--- a/Mathlib/Analysis/Meromorphic/Basic.lean
+++ b/Mathlib/Analysis/Meromorphic/Basic.lean
@@ -266,9 +266,13 @@ lemma const (e : E) {U : Set 𝕜} : MeromorphicOn (fun _ ↦ e) U :=
 
 section arithmetic
 
+theorem eventually_analyticAt [CompleteSpace E] {f : 𝕜 → E} {x : 𝕜}
+    (h : MeromorphicOn f U) : ∀ᶠ y in 𝓝[U \ {x}] x, AnalyticAt 𝕜 f y := by
+
+
 include hf in
 /-- Meromorphic functions on `U` are analytic on `U`, outside of a discrete subset. -/
-theorem analyticAt_mem_codiscreteWithin [CompleteSpace E] :
+theorem analyticAt_mem_codiscreteWithin :
     { x | AnalyticAt 𝕜 f x } ∈ Filter.codiscreteWithin U := by
   rw [mem_codiscreteWithin]
   intro x hx

--- a/Mathlib/Analysis/Meromorphic/Basic.lean
+++ b/Mathlib/Analysis/Meromorphic/Basic.lean
@@ -226,7 +226,7 @@ theorem eventually_continuousAt {f : 𝕜 → E} {x : 𝕜}
     nhdsWithin_le_nhds h.eventually_continuousAt
   filter_upwards [this, self_mem_nhdsWithin] with y hy h'y
   simp only [Set.mem_compl_iff, Set.mem_singleton_iff] at h'y
-  have : ContinuousAt (fun z ↦ ((z - x)^n)⁻¹) y :=
+  have : ContinuousAt (fun z ↦ ((z - x) ^ n)⁻¹) y :=
     ContinuousAt.inv₀ (by fun_prop) (by simp [sub_eq_zero, h'y])
   apply (this.smul hy).congr
   filter_upwards [eventually_ne_nhds h'y] with z hz

--- a/Mathlib/Analysis/Meromorphic/Basic.lean
+++ b/Mathlib/Analysis/Meromorphic/Basic.lean
@@ -218,12 +218,19 @@ lemma zpow' {f : 𝕜 → 𝕜} {x : 𝕜} (hf : MeromorphicAt f x) (n : ℤ) :
     MeromorphicAt (fun z ↦ (f z) ^ n) x :=
   hf.zpow n
 
+/-- If a function is meromorphic at a point, then it is continuous at nearby points. -/
 theorem eventually_continuousAt {f : 𝕜 → E} {x : 𝕜}
     (h : MeromorphicAt f x) : ∀ᶠ y in 𝓝[≠] x, ContinuousAt f y := by
   obtain ⟨n, h⟩ := h
-  apply AnalyticAt.eventually_continuousAt at h
-
-
+  have : ∀ᶠ y in 𝓝[≠] x, ContinuousAt (fun z ↦ (z - x) ^ n • f z) y :=
+    nhdsWithin_le_nhds h.eventually_continuousAt
+  filter_upwards [this, self_mem_nhdsWithin] with y hy h'y
+  simp only [Set.mem_compl_iff, Set.mem_singleton_iff] at h'y
+  have : ContinuousAt (fun z ↦ ((z - x)^n)⁻¹) y :=
+    ContinuousAt.inv₀ (by fun_prop) (by simp [sub_eq_zero, h'y])
+  apply (this.smul hy).congr
+  filter_upwards [eventually_ne_nhds h'y] with z hz
+  simp [smul_smul, hz, sub_eq_zero]
 
 /-- In a complete space, a function which is meromorphic at a point is analytic at all nearby
 points. The completeness assumption can be dispensed with if one assumes that `f` is meromorphic

--- a/Mathlib/Analysis/Meromorphic/Basic.lean
+++ b/Mathlib/Analysis/Meromorphic/Basic.lean
@@ -218,9 +218,18 @@ lemma zpow' {f : 𝕜 → 𝕜} {x : 𝕜} (hf : MeromorphicAt f x) (n : ℤ) :
     MeromorphicAt (fun z ↦ (f z) ^ n) x :=
   hf.zpow n
 
+theorem eventually_continuousAt {f : 𝕜 → E} {x : 𝕜}
+    (h : MeromorphicAt f x) : ∀ᶠ y in 𝓝[≠] x, ContinuousAt f y := by
+  obtain ⟨n, h⟩ := h
+  apply AnalyticAt.eventually_continuousAt at h
+
+
+
+/-- In a complete space, a function which is meromorphic at a point is analytic at all nearby
+points. The completeness assumption can be dispensed with if one assumes that `f` is meromorphic
+on a set around `x`, see `MeromorphicOn.eventually_analyticAt`. -/
 theorem eventually_analyticAt [CompleteSpace E] {f : 𝕜 → E} {x : 𝕜}
     (h : MeromorphicAt f x) : ∀ᶠ y in 𝓝[≠] x, AnalyticAt 𝕜 f y := by
-  rw [MeromorphicAt] at h
   obtain ⟨n, h⟩ := h
   apply AnalyticAt.eventually_analyticAt at h
   refine (h.filter_mono ?_).mp ?_

--- a/Mathlib/Analysis/Meromorphic/Basic.lean
+++ b/Mathlib/Analysis/Meromorphic/Basic.lean
@@ -266,21 +266,6 @@ lemma const (e : E) {U : Set 𝕜} : MeromorphicOn (fun _ ↦ e) U :=
 
 section arithmetic
 
-theorem eventually_analyticAt [CompleteSpace E] {f : 𝕜 → E} {x : 𝕜}
-    (h : MeromorphicOn f U) : ∀ᶠ y in 𝓝[U \ {x}] x, AnalyticAt 𝕜 f y := by
-
-
-include hf in
-/-- Meromorphic functions on `U` are analytic on `U`, outside of a discrete subset. -/
-theorem analyticAt_mem_codiscreteWithin :
-    { x | AnalyticAt 𝕜 f x } ∈ Filter.codiscreteWithin U := by
-  rw [mem_codiscreteWithin]
-  intro x hx
-  rw [Filter.disjoint_principal_right, ← Filter.eventually_mem_set]
-  apply (hf x hx).eventually_analyticAt.mono
-  simp only [Set.mem_compl_iff, Set.mem_diff, Set.mem_setOf_eq, not_and, not_not]
-  tauto
-
 include hf in
 lemma mono_set {V : Set 𝕜} (hv : V ⊆ U) : MeromorphicOn f V := fun x hx ↦ hf x (hv hx)
 

--- a/Mathlib/Analysis/Meromorphic/Divisor.lean
+++ b/Mathlib/Analysis/Meromorphic/Divisor.lean
@@ -19,7 +19,7 @@ divisors.
 -/
 
 variable {𝕜 : Type*} [NontriviallyNormedField 𝕜] {U : Set 𝕜} {z : 𝕜}
-  {E : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E] [CompleteSpace E]
+  {E : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E]
 
 namespace MeromorphicOn
 
@@ -90,7 +90,7 @@ See `MeromorphicOn.exists_order_ne_top_iff_forall` and
 `MeromorphicOn.order_ne_top_of_isPreconnected` for two convenient criteria to guarantee conditions
 `h₂f₁` and `h₂f₂`.
 -/
-theorem divisor_smul [CompleteSpace 𝕜] {f₁ : 𝕜 → 𝕜} {f₂ : 𝕜 → E} (h₁f₁ : MeromorphicOn f₁ U)
+theorem divisor_smul {f₁ : 𝕜 → 𝕜} {f₂ : 𝕜 → E} (h₁f₁ : MeromorphicOn f₁ U)
     (h₁f₂ : MeromorphicOn f₂ U) (h₂f₁ : ∀ z, (hz : z ∈ U) → (h₁f₁ z hz).order ≠ ⊤)
     (h₂f₂ : ∀ z, (hz : z ∈ U) → (h₁f₂ z hz).order ≠ ⊤) :
     divisor (f₁ • f₂) U = divisor f₁ U + divisor f₂ U := by
@@ -110,7 +110,7 @@ See `MeromorphicOn.exists_order_ne_top_iff_forall` and
 `MeromorphicOn.order_ne_top_of_isPreconnected` for two convenient criteria to guarantee conditions
 `h₂f₁` and `h₂f₂`.
 -/
-theorem divisor_mul [CompleteSpace 𝕜] {f₁ f₂ : 𝕜 → 𝕜} (h₁f₁ : MeromorphicOn f₁ U)
+theorem divisor_mul {f₁ f₂ : 𝕜 → 𝕜} (h₁f₁ : MeromorphicOn f₁ U)
     (h₁f₂ : MeromorphicOn f₂ U) (h₂f₁ : ∀ z, (hz : z ∈ U) → (h₁f₁ z hz).order ≠ ⊤)
     (h₂f₂ : ∀ z, (hz : z ∈ U) → (h₁f₂ z hz).order ≠ ⊤) :
     divisor (f₁ * f₂) U = divisor f₁ U + divisor f₂ U :=
@@ -118,7 +118,7 @@ theorem divisor_mul [CompleteSpace 𝕜] {f₁ f₂ : 𝕜 → 𝕜} (h₁f₁ :
 
 /-- The divisor of the inverse is the negative of the divisor. -/
 @[simp]
-theorem divisor_inv [CompleteSpace 𝕜] {f : 𝕜 → 𝕜} :
+theorem divisor_inv {f : 𝕜 → 𝕜} :
     divisor f⁻¹ U = -divisor f U := by
   ext z
   by_cases h : MeromorphicOn f U ∧ z ∈ U

--- a/Mathlib/Analysis/Meromorphic/NormalForm.lean
+++ b/Mathlib/Analysis/Meromorphic/NormalForm.lean
@@ -171,7 +171,7 @@ theorem MeromorphicNFAt.order_eq_zero_iff (hf : MeromorphicNFAt f x) :
 /-- **Local identity theorem**: two meromorphic functions in normal form agree in a
 neighborhood iff they agree in a pointed neighborhood.
 
-See `ContinuousAt.eventuallyEq_nhdN_iff_eventuallyEq_nhdNE` for the analogous
+See `ContinuousAt.eventuallyEq_nhd_iff_eventuallyEq_nhdNE` for the analogous
 statement for continuous functions.
 -/
 theorem MeromorphicNFAt.eventuallyEq_nhdNE_iff_eventuallyEq_nhd {g : 𝕜 → E}

--- a/Mathlib/Analysis/Meromorphic/NormalForm.lean
+++ b/Mathlib/Analysis/Meromorphic/NormalForm.lean
@@ -171,7 +171,7 @@ theorem MeromorphicNFAt.order_eq_zero_iff (hf : MeromorphicNFAt f x) :
 /-- **Local identity theorem**: two meromorphic functions in normal form agree in a
 neighborhood iff they agree in a pointed neighborhood.
 
-See `ContinuousAt.eventuallyEq_nhdNE_iff_eventuallyEq_nhd` for the analogous
+See `ContinuousAt.eventuallyEq_nhdN_iff_eventuallyEq_nhdNE` for the analogous
 statement for continuous functions.
 -/
 theorem MeromorphicNFAt.eventuallyEq_nhdNE_iff_eventuallyEq_nhd {g : 𝕜 → E}

--- a/Mathlib/Analysis/Meromorphic/NormalForm.lean
+++ b/Mathlib/Analysis/Meromorphic/NormalForm.lean
@@ -127,7 +127,7 @@ theorem AnalyticAt.meromorphicNFAt (hf : AnalyticAt 𝕜 f x) :
 
 /-- Meromorphic functions have normal form outside of a discrete subset in the domain of
 meromorphicity. -/
-theorem MeromorphicOn.meromorphicNFAt_mem_codiscreteWithin [CompleteSpace E] {U : Set 𝕜}
+theorem MeromorphicOn.meromorphicNFAt_mem_codiscreteWithin {U : Set 𝕜}
     (hf : MeromorphicOn f U) :
     { x | MeromorphicNFAt f x } ∈ Filter.codiscreteWithin U := by
   filter_upwards [hf.analyticAt_mem_codiscreteWithin] with _ ha
@@ -427,7 +427,7 @@ theorem MeromorphicNFOn.meromorphicOn (hf : MeromorphicNFOn f U) :
 If a function is meromorphic in normal form on `U`, then its divisor is
 non-negative iff it is analytic.
 -/
-theorem MeromorphicNFOn.divisor_nonneg_iff_analyticOnNhd [CompleteSpace E]
+theorem MeromorphicNFOn.divisor_nonneg_iff_analyticOnNhd
     (h₁f : MeromorphicNFOn f U) :
     0 ≤ MeromorphicOn.divisor f U ↔ AnalyticOnNhd 𝕜 f U := by
   constructor <;> intro h x
@@ -455,7 +455,7 @@ theorem AnalyticOnNhd.meromorphicNFOn (h₁f : AnalyticOnNhd 𝕜 f U) :
 If `f` is meromorphic in normal form on `U` and nowhere locally constant zero,
 then its zero set equals the support of the associated divisor.
 -/
-theorem MeromorphicNFOn.zero_set_eq_divisor_support [CompleteSpace E] (h₁f : MeromorphicNFOn f U)
+theorem MeromorphicNFOn.zero_set_eq_divisor_support (h₁f : MeromorphicNFOn f U)
     (h₂f : ∀ u : U, (h₁f u.2).meromorphicAt.order ≠ ⊤) :
     U ∩ f⁻¹' {0} = Function.support (MeromorphicOn.divisor f U) := by
   ext u
@@ -559,7 +559,7 @@ Conversion to normal form on `U` does not change values outside of `U`.
 Conversion to normal form on `U` changes the value only along a discrete subset
 of `U`.
 -/
-theorem toMeromorphicNFOn_eqOn_codiscrete [CompleteSpace E] (hf : MeromorphicOn f U) :
+theorem toMeromorphicNFOn_eqOn_codiscrete (hf : MeromorphicOn f U) :
     f =ᶠ[Filter.codiscreteWithin U] toMeromorphicNFOn f U := by
   have : U ∈ Filter.codiscreteWithin U := by
     simp [mem_codiscreteWithin.2]
@@ -570,17 +570,20 @@ theorem toMeromorphicNFOn_eqOn_codiscrete [CompleteSpace E] (hf : MeromorphicOn 
 If `f` is meromorphic on `U` and `x ∈ U`, then `f` and its conversion to normal
 form on `U` agree in a punctured neighborhood of `x`.
 -/
-theorem MeromorphicOn.toMeromorphicNFOn_eq_self_on_nhdNE [CompleteSpace E]
+theorem MeromorphicOn.toMeromorphicNFOn_eq_self_on_nhdNE
     (hf : MeromorphicOn f U) (hx : x ∈ U) :
     toMeromorphicNFOn f U =ᶠ[𝓝[≠] x] f := by
-  filter_upwards [(hf x hx).eventually_analyticAt] with a ha
-  simp [toMeromorphicNFOn, hf, ← (toMeromorphicNFAt_eq_self.2 ha.meromorphicNFAt).symm]
+  filter_upwards [hf.eventually_analyticAt_or_mem_compl hx] with a ha
+  rcases ha with ha | ha
+  · simp [toMeromorphicNFOn, hf, ← (toMeromorphicNFAt_eq_self.2 ha.meromorphicNFAt).symm]
+  · simp only [Set.mem_compl_iff] at ha
+    simp [toMeromorphicNFOn, ha, hf]
 
 /--
 If `f` is meromorphic on `U` and `x ∈ U`, then conversion to normal form at `x`
 and conversion to normal form on `U` agree in a neighborhood of `x`.
 -/
-theorem toMeromorphicNFOn_eq_toMeromorphicNFAt_on_nhd [CompleteSpace E] (hf : MeromorphicOn f U)
+theorem toMeromorphicNFOn_eq_toMeromorphicNFAt_on_nhd (hf : MeromorphicOn f U)
     (hx : x ∈ U) :
     toMeromorphicNFOn f U =ᶠ[𝓝 x] toMeromorphicNFAt f x := by
   apply eventuallyEq_nhds_of_eventuallyEq_nhdsNE
@@ -591,7 +594,7 @@ theorem toMeromorphicNFOn_eq_toMeromorphicNFAt_on_nhd [CompleteSpace E] (hf : Me
 If `f` is meromorphic on `U` and `x ∈ U`, then conversion to normal form at `x`
 and conversion to normal form on `U` agree at `x`.
 -/
-theorem toMeromorphicNFOn_eq_toMeromorphicNFAt [CompleteSpace E] (hf : MeromorphicOn f U)
+theorem toMeromorphicNFOn_eq_toMeromorphicNFAt (hf : MeromorphicOn f U)
     (hx : x ∈ U) :
     toMeromorphicNFOn f U x = toMeromorphicNFAt f x x := by
   apply Filter.EventuallyEq.eq_of_nhds (g := toMeromorphicNFAt f x)
@@ -601,7 +604,7 @@ variable (f U) in
 /--
 After conversion to normal form on `U`, the function has normal form.
 -/
-theorem meromorphicNFOn_toMeromorphicNFOn [CompleteSpace E] :
+theorem meromorphicNFOn_toMeromorphicNFOn :
     MeromorphicNFOn (toMeromorphicNFOn f U) U := by
   by_cases hf : MeromorphicOn f U
   · intro z hz
@@ -614,7 +617,7 @@ theorem meromorphicNFOn_toMeromorphicNFOn [CompleteSpace E] :
 /--
 If `f` has normal form on `U`, then `f` equals `toMeromorphicNFOn f U`.
 -/
-@[simp] theorem toMeromorphicNFOn_eq_self [CompleteSpace E] :
+@[simp] theorem toMeromorphicNFOn_eq_self :
     toMeromorphicNFOn f U = f ↔ MeromorphicNFOn f U := by
   constructor <;> intro h
   · rw [h.symm]
@@ -628,7 +631,7 @@ If `f` has normal form on `U`, then `f` equals `toMeromorphicNFOn f U`.
 /--
 Conversion of normal form does not affect orders.
 -/
-@[simp] theorem order_toMeromorphicNFOn [CompleteSpace E] (hf : MeromorphicOn f U) (hx : x ∈ U) :
+@[simp] theorem order_toMeromorphicNFOn (hf : MeromorphicOn f U) (hx : x ∈ U) :
     ((meromorphicNFOn_toMeromorphicNFOn f U) hx).meromorphicAt.order = (hf x hx).order := by
   apply MeromorphicAt.order_congr
   exact hf.toMeromorphicNFOn_eq_self_on_nhdNE hx
@@ -636,8 +639,7 @@ Conversion of normal form does not affect orders.
 /--
 Conversion of normal form does not affect divisors.
 -/
-@[simp] theorem MeromorphicOn.divisor_of_toMeromorphicNFOn [CompleteSpace E]
-    (hf : MeromorphicOn f U) :
+@[simp] theorem MeromorphicOn.divisor_of_toMeromorphicNFOn (hf : MeromorphicOn f U) :
     divisor (toMeromorphicNFOn f U) U = divisor f U := by
   ext z
   by_cases hz : z ∈ U <;> simp [hf, (meromorphicNFOn_toMeromorphicNFOn f U).meromorphicOn, hz]

--- a/Mathlib/Analysis/Meromorphic/Order.lean
+++ b/Mathlib/Analysis/Meromorphic/Order.lean
@@ -87,8 +87,8 @@ lemma order_eq_int_iff {n : ℤ} (hf : MeromorphicAt f x) : hf.order = n ↔
     exact ⟨fun h ↦ ⟨g, hg_an, hg_ne, h ▸ hg_eq⟩,
       AnalyticAt.unique_eventuallyEq_zpow_smul_nonzero ⟨g, hg_an, hg_ne, hg_eq⟩⟩
 
-/-- If the order of a meromorphic is negative, then this function converges to infinity at this
-point. See also the iff version `tendsto_cobounded_iff_order_neg`. -/
+/-- If the order of a meromorphic function is negative, then this function converges to infinity
+at this point. See also the iff version `tendsto_cobounded_iff_order_neg`. -/
 lemma tendsto_cobounded_of_order_neg (hf : MeromorphicAt f x) (ho : hf.order < 0) :
     Tendsto f (𝓝[≠] x) (Bornology.cobounded E) := by
   simp only [← tendsto_norm_atTop_iff_cobounded]
@@ -112,7 +112,7 @@ lemma tendsto_cobounded_of_order_neg (hf : MeromorphicAt f x) (ho : hf.order < 0
   filter_upwards [hg] with z hz using by simp [hz]
 
 /-- If the order of a meromorphic function is zero, then this function converges to a nonzero
-constant at this point. See also the iff version `tendsto_ne_zero_iff_order_eq_zero`. -/
+limit at this point. See also the iff version `tendsto_ne_zero_iff_order_eq_zero`. -/
 lemma tendsto_ne_zero_of_order_eq_zero (hf : MeromorphicAt f x) (ho : hf.order = 0) :
     ∃ c ≠ 0, Tendsto f (𝓝[≠] x) (𝓝 c) := by
   rcases hf.order_eq_int_iff.1 ho with ⟨g, g_an, gx, hg⟩
@@ -157,7 +157,7 @@ lemma tendsto_cobounded_iff_order_neg (hf : MeromorphicAt f x) :
     obtain ⟨c, hc⟩ := hf.tendsto_nhds_of_order_nonneg ho
     exact not_tendsto_atTop_of_tendsto_nhds hc.norm
 
-/-- A meromorphic function converges to a point iff its is order if nonnegative. -/
+/-- A meromorphic function converges to a limit iff its is order if nonnegative. -/
 lemma tendsto_nhds_iff_order_nonneg (hf : MeromorphicAt f x) :
     (∃ c, Tendsto f (𝓝[≠] x) (𝓝 c)) ↔ 0 ≤ hf.order := by
   rcases lt_or_le hf.order 0 with ho | ho
@@ -168,7 +168,7 @@ lemma tendsto_nhds_iff_order_nonneg (hf : MeromorphicAt f x) :
     exact hf.tendsto_cobounded_of_order_neg ho
   · simp [ho, hf.tendsto_nhds_of_order_nonneg ho]
 
-/-- A meromorphic function converges to a nonzero point iff its order is zero. -/
+/-- A meromorphic function converges to a nonzero limit iff its order is zero. -/
 lemma tendsto_ne_zero_iff_order_eq_zero (hf : MeromorphicAt f x) :
     (∃ c ≠ 0, Tendsto f (𝓝[≠] x) (𝓝 c)) ↔ hf.order = 0 := by
   rcases eq_or_ne hf.order 0 with ho | ho
@@ -460,30 +460,19 @@ theorem order_ne_top_of_isPreconnected {y : 𝕜} (hU : IsPreconnected U) (h₁x
     (hf y hy).order ≠ ⊤ :=
   (hf.exists_order_ne_top_iff_forall ⟨nonempty_of_mem h₁x, hU⟩).1 (by use ⟨x, h₁x⟩) ⟨y, hy⟩
 
+/-- If a function is meromorphic on a set `U`, then for each point in `U`, it is analytic at nearby
+points in `U`. When the target space is complete, this can be strengthened to analyticity at all
+nearby points, see `MeromorphicAt.eventually_analyticAt`. -/
 theorem eventually_analyticAt {f : 𝕜 → E} {x : 𝕜}
     (h : MeromorphicOn f U) (hx : x ∈ U) : ∀ᶠ y in 𝓝[U \ {x}] x, AnalyticAt 𝕜 f y := by
-  /- At neighboring points in `U`, the function `f` is both meromorphic (by meromorphy on `U`)
+  /- At neighboring points in `U`, the function `f` is both meromorphic (by meromorphicity on `U`)
   and continuous (thanks to the formula for a meromorphic function around the point `x`), so it is
   analytic. -/
-  rcases h x hx with ⟨n, g, r, hgr⟩
-  have : U \ {x} ∩ EMetric.ball x r ∈ 𝓝[U \ {x}] x :=
-    inter_mem_nhdsWithin _ (EMetric.ball_mem_nhds _ hgr.r_pos)
-  filter_upwards [this] with y ⟨hy, h'y⟩
-  have hyx : y ≠ x := by simpa using hy.2
-  have : ContinuousAt f y := by
-    have A : ContinuousAt (fun z ↦ (z - x) ^ n • f z) y := by
-      apply hgr.continuousOn.continuousAt
-      exact EMetric.isOpen_ball.mem_nhds h'y
-    have B : ContinuousAt (fun z ↦ (z - x) ^ (-(n : ℤ))) y := by
-      apply ContinuousAt.zpow₀ (by fun_prop)
-      simp [sub_eq_zero, hyx]
-    apply (B.smul A).congr
-    have : {x}ᶜ ∈ 𝓝 y := by simp [hyx]
-    filter_upwards [this] with z hz
-    rw [smul_smul, ← zpow_natCast, ← zpow_add₀]
-    · simp
-    · simpa [sub_eq_zero] using hz
-  exact (h y hy.1).analyticAt this
+  have : ∀ᶠ y in 𝓝[U \ {x}] x, ContinuousAt f y := by
+    have : U \ {x} ⊆ {x}ᶜ := by simp
+    exact nhdsWithin_mono _ this (h x hx).eventually_continuousAt
+  filter_upwards [this, self_mem_nhdsWithin] with y hy h'y
+  exact (h y h'y.1).analyticAt hy
 
 theorem eventually_analyticAt_or_mem_compl {f : 𝕜 → E} {x : 𝕜}
     (h : MeromorphicOn f U) (hx : x ∈ U) : ∀ᶠ y in 𝓝[≠] x, AnalyticAt 𝕜 f y ∨ y ∈ Uᶜ := by

--- a/Mathlib/Analysis/Meromorphic/Order.lean
+++ b/Mathlib/Analysis/Meromorphic/Order.lean
@@ -159,7 +159,7 @@ lemma tendsto_cobounded_iff_order_neg (hf : MeromorphicAt f x) :
     obtain ⟨c, hc⟩ := hf.tendsto_nhds_of_order_nonneg ho
     exact not_tendsto_atTop_of_tendsto_nhds hc.norm
 
-/-- A meromorphic function converges to a limit iff its is order if nonnegative. -/
+/-- A meromorphic function converges to a limit iff its order is nonnegative. -/
 lemma tendsto_nhds_iff_order_nonneg (hf : MeromorphicAt f x) :
     (∃ c, Tendsto f (𝓝[≠] x) (𝓝 c)) ↔ 0 ≤ hf.order := by
   rcases lt_or_le hf.order 0 with ho | ho

--- a/Mathlib/Analysis/Meromorphic/Order.lean
+++ b/Mathlib/Analysis/Meromorphic/Order.lean
@@ -12,6 +12,9 @@ import Mathlib.Analysis.Meromorphic.Basic
 This file defines the order of a meromorphic function `f` at a point `z₀`, as an element of
 `ℤ ∪ {∞}`.
 
+We characterize the order being `< 0`, or `= 0`, or `> 0`, as the convergence of the function
+to infinity, resp. a nonzero constant, resp. zero.
+
 TODO: Uniformize API between analytic and meromorphic functions
 -/
 
@@ -92,15 +95,14 @@ at this point. See also the iff version `tendsto_cobounded_iff_order_neg`. -/
 lemma tendsto_cobounded_of_order_neg (hf : MeromorphicAt f x) (ho : hf.order < 0) :
     Tendsto f (𝓝[≠] x) (Bornology.cobounded E) := by
   simp only [← tendsto_norm_atTop_iff_cobounded]
-  have : hf.order ≠ ⊤ := ho.ne_top
-  obtain ⟨m, hm⟩ := WithTop.ne_top_iff_exists.mp this
+  obtain ⟨m, hm⟩ := WithTop.ne_top_iff_exists.mp ho.ne_top
   have m_neg : m < 0 := by simpa [← hm] using ho
   rcases hf.order_eq_int_iff.1 hm.symm with ⟨g, g_an, gx, hg⟩
   have A : Tendsto (fun z ↦ ‖(z - x) ^ m • g z‖) (𝓝[≠] x) atTop := by
     simp only [norm_smul]
     apply Filter.Tendsto.atTop_mul_pos (C := ‖g x‖) (by simp [gx]) _
       g_an.continuousAt.continuousWithinAt.tendsto.norm
-    have : Tendsto (fun z ↦ (z - x)) (𝓝[≠] x) (𝓝[≠] 0) := by
+    have : Tendsto (fun z ↦ z - x) (𝓝[≠] x) (𝓝[≠] 0) := by
       refine tendsto_nhdsWithin_iff.2 ⟨?_, ?_⟩
       · have : ContinuousWithinAt (fun z ↦ z - x) ({x}ᶜ) x :=
           ContinuousAt.continuousWithinAt (by fun_prop)
@@ -243,7 +245,9 @@ protected theorem analyticAt {f : 𝕜 → E} {x : 𝕜} (h : MeromorphicAt f x)
     filter_upwards [h.order_eq_top_iff.1 ho] with y hy using by simp [hy]
   | coe n =>
     /- If the order is finite, then the order has to be nonnegative, as otherwise the norm of `f`
-    would tend to infinity at `x`.-/
+    would tend to infinity at `x`. Then the local expression of `f` coming from its meromorphicity
+    shows that it coincides with an analytic function close to `x`, except maybe at `x`. By
+    continuity of `f`, the two functions also coincide at `x`. -/
     rcases h.order_eq_int_iff.1 ho with ⟨g, g_an, gx, hg⟩
     have : 0 ≤ h.order := by
       apply h.tendsto_nhds_iff_order_nonneg.1
@@ -252,8 +256,7 @@ protected theorem analyticAt {f : 𝕜 → E} {x : 𝕜} (h : MeromorphicAt f x)
     have A : ∀ᶠ (z : 𝕜) in 𝓝 x, (z - x) ^ n • g z = f z := by
       apply (ContinuousAt.eventuallyEq_nhd_iff_eventuallyEq_nhdNE (by fun_prop) h').1
       filter_upwards [hg] with z hz using by simpa using hz.symm
-    have : AnalyticAt 𝕜 (fun z ↦ (z - x) ^ n • g z) x := by fun_prop
-    apply this.congr A
+    exact AnalyticAt.congr (by fun_prop) A
 
 /-!
 ## Order at a Point: Behaviour under Ring Operations
@@ -476,7 +479,7 @@ theorem eventually_analyticAt {f : 𝕜 → E} {x : 𝕜}
 
 theorem eventually_analyticAt_or_mem_compl {f : 𝕜 → E} {x : 𝕜}
     (h : MeromorphicOn f U) (hx : x ∈ U) : ∀ᶠ y in 𝓝[≠] x, AnalyticAt 𝕜 f y ∨ y ∈ Uᶜ := by
-  have : {x}ᶜ = (U \ {x}) ∪ (Uᶜ) := by aesop (add simp Classical.em)
+  have : {x}ᶜ = (U \ {x}) ∪ Uᶜ := by aesop (add simp Classical.em)
   rw [this, nhdsWithin_union]
   simp only [mem_compl_iff, eventually_sup]
   refine ⟨?_, ?_⟩
@@ -493,7 +496,7 @@ theorem analyticAt_mem_codiscreteWithin (hf : MeromorphicOn f U) :
   simp
   tauto
 
-/-- The set where a mermorphic function has zero or infinite
+/-- The set where a meromorphic function has zero or infinite
 order is codiscrete within its domain of meromorphicity. -/
 theorem codiscrete_setOf_order_eq_zero_or_top :
     {u : U | (hf u u.2).order = 0 ∨ (hf u u.2).order = ⊤} ∈ Filter.codiscrete U := by

--- a/Mathlib/Analysis/Meromorphic/Order.lean
+++ b/Mathlib/Analysis/Meromorphic/Order.lean
@@ -87,33 +87,115 @@ lemma order_eq_int_iff {n : ℤ} (hf : MeromorphicAt f x) : hf.order = n ↔
     exact ⟨fun h ↦ ⟨g, hg_an, hg_ne, h ▸ hg_eq⟩,
       AnalyticAt.unique_eventuallyEq_zpow_smul_nonzero ⟨g, hg_an, hg_ne, hg_eq⟩⟩
 
-lemma order_neg_iff_tendsto_cobounded (hf : MeromorphicAt f x) :
-    hf.order < 0 ↔ Tendsto f (𝓝[≠] x) (Bornology.cobounded E) := by
-  rcases lt_or_le hf.order 0 with h'f | h'f
-  · simp only [h'f, ← tendsto_norm_atTop_iff_cobounded, true_iff]
-    have : hf.order ≠ ⊤ := h'f.ne_top
-    obtain ⟨m, ho⟩ := WithTop.ne_top_iff_exists.mp this
-    have m_neg : m < 0 := by simpa [← ho] using h'f
-    rcases hf.order_eq_int_iff.1 ho.symm with ⟨g, g_an, gx, hg⟩
-    have A : Tendsto (fun z ↦ ‖(z - x) ^ m • g z‖) (𝓝[≠] x) atTop := by
-      simp only [norm_smul]
-      apply Filter.Tendsto.atTop_mul_pos (C := ‖g x‖) (by simp [gx]) _
-        g_an.continuousAt.continuousWithinAt.tendsto.norm
-      have : Tendsto (fun z ↦ (z - x)) (𝓝[≠] x) (𝓝[≠] 0) := by
-        refine tendsto_nhdsWithin_iff.2 ⟨?_, ?_⟩
-        · have : ContinuousWithinAt (fun z ↦ z - x) ({x}ᶜ) x :=
-            ContinuousAt.continuousWithinAt (by fun_prop)
-          simpa using this.tendsto
-        · filter_upwards [self_mem_nhdsWithin] with y hy
-          simpa [sub_eq_zero] using hy
-      apply Tendsto.comp (NormedField.tendsto_norm_zpow_nhdsNE_zero_atTop m_neg) this
-    apply A.congr'
-    filter_upwards [hg] with z hz using by simp [hz]
-  · simp only [lt_iff_not_ge, ge_iff_le, h'f, not_true_eq_false, false_iff]
+/-- If the order of a meromorphic is negative, then this function converges to infinity at this
+point. See also the iff version `tendsto_cobounded_iff_order_neg`. -/
+lemma tendsto_cobounded_of_order_neg (hf : MeromorphicAt f x) (ho : hf.order < 0) :
+    Tendsto f (𝓝[≠] x) (Bornology.cobounded E) := by
+  simp only [← tendsto_norm_atTop_iff_cobounded]
+  have : hf.order ≠ ⊤ := ho.ne_top
+  obtain ⟨m, hm⟩ := WithTop.ne_top_iff_exists.mp this
+  have m_neg : m < 0 := by simpa [← hm] using ho
+  rcases hf.order_eq_int_iff.1 hm.symm with ⟨g, g_an, gx, hg⟩
+  have A : Tendsto (fun z ↦ ‖(z - x) ^ m • g z‖) (𝓝[≠] x) atTop := by
+    simp only [norm_smul]
+    apply Filter.Tendsto.atTop_mul_pos (C := ‖g x‖) (by simp [gx]) _
+      g_an.continuousAt.continuousWithinAt.tendsto.norm
+    have : Tendsto (fun z ↦ (z - x)) (𝓝[≠] x) (𝓝[≠] 0) := by
+      refine tendsto_nhdsWithin_iff.2 ⟨?_, ?_⟩
+      · have : ContinuousWithinAt (fun z ↦ z - x) ({x}ᶜ) x :=
+          ContinuousAt.continuousWithinAt (by fun_prop)
+        simpa using this.tendsto
+      · filter_upwards [self_mem_nhdsWithin] with y hy
+        simpa [sub_eq_zero] using hy
+    apply Tendsto.comp (NormedField.tendsto_norm_zpow_nhdsNE_zero_atTop m_neg) this
+  apply A.congr'
+  filter_upwards [hg] with z hz using by simp [hz]
 
+/-- If the order of a meromorphic function is zero, then this function converges to a nonzero
+constant at this point. See also the iff version `tendsto_ne_zero_iff_order_eq_zero`. -/
+lemma tendsto_ne_zero_of_order_eq_zero (hf : MeromorphicAt f x) (ho : hf.order = 0) :
+    ∃ c ≠ 0, Tendsto f (𝓝[≠] x) (𝓝 c) := by
+  rcases hf.order_eq_int_iff.1 ho with ⟨g, g_an, gx, hg⟩
+  refine ⟨g x, gx, ?_⟩
+  apply g_an.continuousAt.continuousWithinAt.tendsto.congr'
+  filter_upwards [hg] with y hy using by simp [hy]
 
+/-- If the order of a meromorphic function is positive, then this function converges to zero
+at this point. See also the iff version `tendsto_zero_iff_order_pos`. -/
+lemma tendsto_zero_of_order_pos (hf : MeromorphicAt f x) (ho : 0 < hf.order) :
+    Tendsto f (𝓝[≠] x) (𝓝 0) := by
+  cases h'o : hf.order with
+  | top =>
+    apply tendsto_const_nhds.congr'
+    filter_upwards [hf.order_eq_top_iff.1 h'o] with y hy using hy.symm
+  | coe n =>
+    rcases hf.order_eq_int_iff.1 h'o with ⟨g, g_an, gx, hg⟩
+    lift n to ℕ using by simpa [h'o] using ho.le
+    have : (0 : E) = (x - x) ^ n • g x := by
+      have : 0 < n := by simpa [h'o] using ho
+      simp [zero_pow_eq_zero.2 this.ne']
+    rw [this]
+    have : ContinuousAt (fun z ↦ (z - x) ^ n • g z) x := by fun_prop
+    apply this.continuousWithinAt.tendsto.congr'
+    filter_upwards [hg] with y hy using by simp [hy]
 
-#exit
+/-- If the order of a meromorphic function is nonnegative, then this function converges
+at this point. See also the iff version `tendsto_nhds_iff_order_nonneg`. -/
+lemma tendsto_nhds_of_order_nonneg (hf : MeromorphicAt f x) (ho : 0 ≤ hf.order) :
+    ∃ c, Tendsto f (𝓝[≠] x) (𝓝 c) := by
+  rcases ho.eq_or_lt with ho | ho
+  · rcases hf.tendsto_ne_zero_of_order_eq_zero ho.symm with ⟨c, -, hc⟩
+    exact ⟨c, hc⟩
+  · exact ⟨0, hf.tendsto_zero_of_order_pos ho⟩
+
+/-- A meromorphic function converges to infinity iff its order is negative. -/
+lemma tendsto_cobounded_iff_order_neg (hf : MeromorphicAt f x) :
+    Tendsto f (𝓝[≠] x) (Bornology.cobounded E) ↔ hf.order < 0 := by
+  rcases lt_or_le hf.order 0 with ho | ho
+  · simp [ho, hf.tendsto_cobounded_of_order_neg]
+  · simp only [lt_iff_not_le, ho, not_true_eq_false, iff_false, ← tendsto_norm_atTop_iff_cobounded]
+    obtain ⟨c, hc⟩ := hf.tendsto_nhds_of_order_nonneg ho
+    exact not_tendsto_atTop_of_tendsto_nhds hc.norm
+
+/-- A meromorphic function converges to a point iff its is order if nonnegative. -/
+lemma tendsto_nhds_iff_order_nonneg (hf : MeromorphicAt f x) :
+    (∃ c, Tendsto f (𝓝[≠] x) (𝓝 c)) ↔ 0 ≤ hf.order := by
+  rcases lt_or_le hf.order 0 with ho | ho
+  · simp only [← not_lt, ho, not_true_eq_false, iff_false, not_exists]
+    intro c hc
+    apply not_tendsto_atTop_of_tendsto_nhds hc.norm
+    rw [tendsto_norm_atTop_iff_cobounded]
+    exact hf.tendsto_cobounded_of_order_neg ho
+  · simp [ho, hf.tendsto_nhds_of_order_nonneg ho]
+
+/-- A meromorphic function converges to a nonzero point iff its order is zero. -/
+lemma tendsto_ne_zero_iff_order_eq_zero (hf : MeromorphicAt f x) :
+    (∃ c ≠ 0, Tendsto f (𝓝[≠] x) (𝓝 c)) ↔ hf.order = 0 := by
+  rcases eq_or_ne hf.order 0 with ho | ho
+  · simp [ho, hf.tendsto_ne_zero_of_order_eq_zero ho]
+  simp only [ne_eq, ho, iff_false, not_exists, not_and]
+  intro c c_ne hc
+  rcases ho.lt_or_lt with ho | ho
+  · apply not_tendsto_atTop_of_tendsto_nhds hc.norm
+    rw [tendsto_norm_atTop_iff_cobounded]
+    exact hf.tendsto_cobounded_of_order_neg ho
+  · apply c_ne
+    exact tendsto_nhds_unique hc (hf.tendsto_zero_of_order_pos ho)
+
+/-- A meromorphic function converges to zero iff its order is positive. -/
+lemma tendsto_zero_iff_order_pos (hf : MeromorphicAt f x) :
+    (Tendsto f (𝓝[≠] x) (𝓝 0)) ↔ 0 < hf.order := by
+  rcases lt_or_le 0 hf.order with ho | ho
+  · simp [ho, hf.tendsto_zero_of_order_pos ho]
+  simp only [← not_le, ho, not_true_eq_false, iff_false]
+  intro hc
+  rcases ho.eq_or_lt with ho | ho
+  · obtain ⟨c, c_ne, h'c⟩ := hf.tendsto_ne_zero_of_order_eq_zero ho
+    apply c_ne
+    exact tendsto_nhds_unique h'c hc
+  · apply not_tendsto_atTop_of_tendsto_nhds hc.norm
+    rw [tendsto_norm_atTop_iff_cobounded]
+    exact hf.tendsto_cobounded_of_order_neg ho
 
 /-- Meromorphic functions that agree in a punctured neighborhood of `z₀` have the same order at
 `z₀`. -/
@@ -147,6 +229,31 @@ When seen as meromorphic functions, analytic functions have nonnegative order.
 theorem _root_.AnalyticAt.meromorphicAt_order_nonneg (hf : AnalyticAt 𝕜 f x) :
     0 ≤ hf.meromorphicAt.order := by
   simp [hf.meromorphicAt_order]
+
+/-- If a function is both meromorphic and continuous at a point, then it is analytic there. -/
+protected theorem analyticAt {f : 𝕜 → E} {x : 𝕜} (h : MeromorphicAt f x) (h' : ContinuousAt f x) :
+    AnalyticAt 𝕜 f x := by
+  cases ho : h.order with
+  | top =>
+    /- If the order is infinite, then `f` vanishes on a pointed neighborhood of `x`. By continuity,
+    it also vanishes at `x`.-/
+    have : AnalyticAt 𝕜 (fun _ ↦ (0 : E)) x := analyticAt_const
+    apply this.congr
+    rw [← ContinuousAt.eventuallyEq_nhd_iff_eventuallyEq_nhdNE continuousAt_const h']
+    filter_upwards [h.order_eq_top_iff.1 ho] with y hy using by simp [hy]
+  | coe n =>
+    /- If the order is finite, then the order has to be nonnegative, as otherwise the norm of `f`
+    would tend to infinity at `x`.-/
+    rcases h.order_eq_int_iff.1 ho with ⟨g, g_an, gx, hg⟩
+    have : 0 ≤ h.order := by
+      apply h.tendsto_nhds_iff_order_nonneg.1
+      exact ⟨f x, h'.continuousWithinAt.tendsto⟩
+    lift n to ℕ using by simpa [ho] using this
+    have A : ∀ᶠ (z : 𝕜) in 𝓝 x, (z - x) ^ n • g z = f z := by
+      apply (ContinuousAt.eventuallyEq_nhd_iff_eventuallyEq_nhdNE (by fun_prop) h').1
+      filter_upwards [hg] with z hz using by simpa using hz.symm
+    have : AnalyticAt 𝕜 (fun z ↦ (z - x) ^ n • g z) x := by fun_prop
+    apply this.congr A
 
 /-!
 ## Order at a Point: Behaviour under Ring Operations
@@ -268,48 +375,6 @@ theorem order_add_of_unequal_order (hf₁ : MeromorphicAt f₁ x) (hf₂ : Merom
   · simpa [h.le] using hf₁.order_add_of_order_lt_order hf₂ h
   · simpa [h.le, add_comm] using hf₂.order_add_of_order_lt_order hf₁ h
 
-/-- If a function is both meromorphic and continuous at a point, then it is analytic there. -/
-protected theorem analyticAt {f : 𝕜 → E} {x : 𝕜} (h : MeromorphicAt f x) (h' : ContinuousAt f x) :
-    AnalyticAt 𝕜 f x := by
-  cases ho : h.order with
-  | top =>
-    /- If the order is infinite, then `f` vanishes on a pointed neighborhood of `x`. By continuity,
-    it also vanishes at `x`.-/
-    have : AnalyticAt 𝕜 (fun _ ↦ (0 : E)) x := analyticAt_const
-    apply this.congr
-    rw [← ContinuousAt.eventuallyEq_nhd_iff_eventuallyEq_nhdNE continuousAt_const h']
-    filter_upwards [h.order_eq_top_iff.1 ho] with y hy using by simp [hy]
-  | coe n =>
-    /- If the order is finite, then the order has to be nonnegative, as otherwise the norm of `f`
-    would tend to infinity at `x`.-/
-    rcases h.order_eq_int_iff.1 ho with ⟨g, g_an, gx, hg⟩
-    have : 0 ≤ n := by
-      by_contra! hn
-      have A : Tendsto (fun z ↦ ‖(z - x) ^ n • g z‖) (𝓝[≠] x) atTop := by
-        simp only [norm_smul]
-        apply Filter.Tendsto.atTop_mul_pos (C := ‖g x‖) (by simp [gx]) _
-          g_an.continuousAt.continuousWithinAt.tendsto.norm
-        have : Tendsto (fun z ↦ (z - x)) (𝓝[≠] x) (𝓝[≠] 0) := by
-          refine tendsto_nhdsWithin_iff.2 ⟨?_, ?_⟩
-          · have : ContinuousWithinAt (fun z ↦ z - x) ({x}ᶜ) x :=
-              ContinuousAt.continuousWithinAt (by fun_prop)
-            simpa using this.tendsto
-          · filter_upwards [self_mem_nhdsWithin] with y hy
-            simpa [sub_eq_zero] using hy
-        apply Tendsto.comp (NormedField.tendsto_norm_zpow_nhdsNE_zero_atTop hn) this
-      have A' : Tendsto (fun z ↦ ‖f z‖) (𝓝[≠] x) atTop := by
-        apply A.congr'
-        filter_upwards [hg] with z hz using by simp [hz]
-      have B : Tendsto (fun z ↦ ‖f z‖) (𝓝[≠] x) (𝓝 (‖f x‖)) :=
-        h'.continuousWithinAt.tendsto.norm
-      exact not_tendsto_atTop_of_tendsto_nhds B A'
-    lift n to ℕ using this
-    have A : ∀ᶠ (z : 𝕜) in 𝓝 x, (z - x) ^ n • g z = f z := by
-      apply (ContinuousAt.eventuallyEq_nhd_iff_eventuallyEq_nhdNE (by fun_prop) h').1
-      filter_upwards [hg] with z hz using by simpa using hz.symm
-    have : AnalyticAt 𝕜 (fun z ↦ (z - x) ^ n • g z) x := by fun_prop
-    apply this.congr A
-
 end MeromorphicAt
 
 /-!
@@ -397,6 +462,9 @@ theorem order_ne_top_of_isPreconnected {y : 𝕜} (hU : IsPreconnected U) (h₁x
 
 theorem eventually_analyticAt {f : 𝕜 → E} {x : 𝕜}
     (h : MeromorphicOn f U) (hx : x ∈ U) : ∀ᶠ y in 𝓝[U \ {x}] x, AnalyticAt 𝕜 f y := by
+  /- At neighboring points in `U`, the function `f` is both meromorphic (by meromorphy on `U`)
+  and continuous (thanks to the formula for a meromorphic function around the point `x`), so it is
+  analytic. -/
   rcases h x hx with ⟨n, g, r, hgr⟩
   have : U \ {x} ∩ EMetric.ball x r ∈ 𝓝[U \ {x}] x :=
     inter_mem_nhdsWithin _ (EMetric.ball_mem_nhds _ hgr.r_pos)


### PR DESCRIPTION
We also characterize the order of a meromorphic function being `< 0`, or `= 0`, or `> 0`, as the convergence of the function
to infinity, resp. a nonzero constant, resp. zero.

This is used to generalize `analyticAt_mem_codiscreteWithin`, and from there remove completeness assumptions throughout the meromorphic functions theory.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
