### PR TITLE
[Merged by Bors] - feat(Tactic/SimpIntro): add support for introducing non-propositions

### DIFF
--- a/Mathlib/Tactic/SimpIntro.lean
+++ b/Mathlib/Tactic/SimpIntro.lean
@@ -30,7 +30,7 @@ partial def simpIntroCore (g : MVarId) (ctx : Simp.Context) (simprocs : Simp.Sim
   let n := if var.isIdent then var.getId else `_
   let withFVar := fun (fvar, g) ↦ g.withContext do
     Term.addLocalVarInfo var (mkFVar fvar)
-    let simpContext : Simp.Context ←
+    let ctx : Simp.Context ←
       if (← Meta.isProp <| ← fvar.getType) then
         let simpTheorems ← ctx.simpTheorems.addTheorem (.fvar fvar) (.fvar fvar)
         pure <| ctx.setSimpTheorems simpTheorems

--- a/Mathlib/Tactic/SimpIntro.lean
+++ b/Mathlib/Tactic/SimpIntro.lean
@@ -36,7 +36,7 @@ partial def simpIntroCore (g : MVarId) (ctx : Simp.Context) (simprocs : Simp.Sim
         pure <| ctx.setSimpTheorems simpTheorems
       else
         pure ctx
-    simpIntroCore g simpContext simprocs discharge? more ids'
+    simpIntroCore g ctx simprocs discharge? more ids'
   match t with
   | .letE .. => withFVar (← g.intro n)
   | .forallE (body := body) .. =>

--- a/Mathlib/Tactic/SimpIntro.lean
+++ b/Mathlib/Tactic/SimpIntro.lean
@@ -31,7 +31,7 @@ partial def simpIntroCore (g : MVarId) (ctx : Simp.Context) (simprocs : Simp.Sim
   let withFVar := fun (fvar, g) ↦ g.withContext do
     Term.addLocalVarInfo var (mkFVar fvar)
     let simpContext : Simp.Context ←
-      if (← instantiateMVars <| ← inferType <| ← fvar.getType).isProp then
+      if (← Meta.isProp <| ← fvar.getType) then
         let simpTheorems ← ctx.simpTheorems.addTheorem (.fvar fvar) (.fvar fvar)
         pure <| ctx.setSimpTheorems simpTheorems
       else

--- a/Mathlib/Tactic/SimpIntro.lean
+++ b/Mathlib/Tactic/SimpIntro.lean
@@ -30,8 +30,13 @@ partial def simpIntroCore (g : MVarId) (ctx : Simp.Context) (simprocs : Simp.Sim
   let n := if var.isIdent then var.getId else `_
   let withFVar := fun (fvar, g) ↦ g.withContext do
     Term.addLocalVarInfo var (mkFVar fvar)
-    let simpTheorems ← ctx.simpTheorems.addTheorem (.fvar fvar) (.fvar fvar)
-    simpIntroCore g (ctx.setSimpTheorems simpTheorems) simprocs discharge? more ids'
+    let simpContext : Simp.Context ←
+      if (← instantiateMVars <| ← inferType <| ← fvar.getType).isProp then
+        let simpTheorems ← ctx.simpTheorems.addTheorem (.fvar fvar) (.fvar fvar)
+        pure <| ctx.setSimpTheorems simpTheorems
+      else
+        pure ctx
+    simpIntroCore g simpContext simprocs discharge? more ids'
   match t with
   | .letE .. => withFVar (← g.intro n)
   | .forallE (body := body) .. =>

--- a/MathlibTest/simp_intro.lean
+++ b/MathlibTest/simp_intro.lean
@@ -14,3 +14,9 @@ example (h : y = z) : x + 0 = y → x = z := by
   simp_intro .. [h]
 
 example (h : y = z) : x + 0 = y → x = z := by simp_intro _; exact h
+
+example : ∀ (r : Nat → Prop), (∀ x, x > 0 → r x) → ∀ y z, y = 0 → z > y → r z := by
+  simp_intro ..
+
+example : ∀ (r : Nat → Prop), (∀ x, x > 0 → r x) → ∀ y z, y = 0 → z > y → r z := by
+  simp_intro r hr y z hy hz


### PR DESCRIPTION
This PR improves the `simp_intro` tactic so that it can be used when there are non-propositions. Non-propositions are not added to the simp set. This lets `simp_intro` be used in situations that previously needed manual `intro` and `simp`.

For example, the following one can be solved like this

```lean
example (r : Nat → Prop) : (∀ x, x > 0 → r x) → ∀ y z, y = 0 → z > y → r z := by
  simp
  intro hr
  try simp at hr -- does nothing
  try simp [hr] -- does nothing
  intro y z
  try simp [hr] -- does nothing
  intro hy
  try simp [hr] at hy -- does nothing
  simp [hr, hy]
  intro hyz
  try simp [hr, hy] at hyz
  simp [hr, hy, hyz] -- accomplish the goal successfully
```

while the previous `simp_intro` cannot introduce `y` and `z` here.

```lean
example (r : Nat → Prop) : (∀ x, x > 0 → r x) → ∀ y z, y = 0 → z > y → r z := by
  /- the previous `simp_intro` fails with message:
     invalid 'simp', proposition expected
       Nat  -/
  simp_intro ..   -- or `simp_intro hr y`

example (r : Nat → Prop) : (∀ x, x > 0 → r x) → ∀ y z, y = 0 → z > y → r z := by
  -- unsolved
  simp_intro hr
```

Now with this PR, the tactic is successful:
```lean
example (r : Nat → Prop) : (∀ x, x > 0 → r x) → ∀ y z, y = 0 → z > y → r z := by
  simp_intro ..   -- or `simp_intro hr y z hy hz`
```

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
