### PR TITLE
[Merged by Bors] - feat(Algebra/Order/Field/Defs): generalize lemmas

### DIFF
--- a/Mathlib/Algebra/Order/Field/Defs.lean
+++ b/Mathlib/Algebra/Order/Field/Defs.lean
@@ -23,8 +23,6 @@ A linear ordered (semi)field is a (semi)field equipped with a linear order such 
 -- Guard against import creep.
 assert_not_exists MonoidHom
 
-variable {K : Type*}
-
 set_option linter.deprecated false in
 /-- A linear ordered semifield is a field with a linear order respecting the operations. -/
 @[deprecated "Use `[Semifield K] [LinearOrder K] [IsStrictOrderedRing K]` instead."
@@ -38,69 +36,3 @@ set_option linter.deprecated false in
 structure LinearOrderedField (K : Type*) extends LinearOrderedCommRing K, Field K
 
 attribute [nolint docBlame] LinearOrderedSemifield.toSemifield LinearOrderedField.toField
-
-variable [Semifield K] [LinearOrder K] {a b c : K}
-
-/-- Equality holds when `a ≠ 0`. See `mul_inv_cancel`. -/
-lemma mul_inv_le_one [ZeroLEOneClass K] : a * a⁻¹ ≤ 1 := by
-  obtain rfl | ha := eq_or_ne a 0 <;> simp [*]
-
-/-- Equality holds when `a ≠ 0`. See `inv_mul_cancel`. -/
-lemma inv_mul_le_one [ZeroLEOneClass K] : a⁻¹ * a ≤ 1 := by
-  obtain rfl | ha := eq_or_ne a 0 <;> simp [*]
-
-/-- Equality holds when `a ≠ 0`. See `mul_inv_cancel_left`. -/
-lemma mul_inv_left_le (hb : 0 ≤ b) : a * (a⁻¹ * b) ≤ b := by
-  obtain rfl | ha := eq_or_ne a 0 <;> simp [*]
-
-/-- Equality holds when `a ≠ 0`. See `mul_inv_cancel_left`. -/
-lemma le_mul_inv_left (hb : b ≤ 0) : b ≤ a * (a⁻¹ * b) := by
-  obtain rfl | ha := eq_or_ne a 0 <;> simp [*]
-
-/-- Equality holds when `a ≠ 0`. See `inv_mul_cancel_left`. -/
-lemma inv_mul_left_le (hb : 0 ≤ b) : a⁻¹ * (a * b) ≤ b := by
-  obtain rfl | ha := eq_or_ne a 0 <;> simp [*]
-
-/-- Equality holds when `a ≠ 0`. See `inv_mul_cancel_left`. -/
-lemma le_inv_mul_left (hb : b ≤ 0) : b ≤ a⁻¹ * (a * b) := by
-  obtain rfl | ha := eq_or_ne a 0 <;> simp [*]
-
-/-- Equality holds when `b ≠ 0`. See `mul_inv_cancel_right`. -/
-lemma mul_inv_right_le (ha : 0 ≤ a) : a * b * b⁻¹ ≤ a := by
-  obtain rfl | hb := eq_or_ne b 0 <;> simp [*]
-
-/-- Equality holds when `b ≠ 0`. See `mul_inv_cancel_right`. -/
-lemma le_mul_inv_right (ha : a ≤ 0) : a ≤ a * b * b⁻¹ := by
-  obtain rfl | hb := eq_or_ne b 0 <;> simp [*]
-
-/-- Equality holds when `b ≠ 0`. See `inv_mul_cancel_right`. -/
-lemma inv_mul_right_le (ha : 0 ≤ a) : a * b⁻¹ * b ≤ a := by
-  obtain rfl | hb := eq_or_ne b 0 <;> simp [*]
-
-/-- Equality holds when `b ≠ 0`. See `inv_mul_cancel_right`. -/
-lemma le_inv_mul_right (ha : a ≤ 0) : a ≤ a * b⁻¹ * b := by
-  obtain rfl | hb := eq_or_ne b 0 <;> simp [*]
-
-/-- Equality holds when `c ≠ 0`. See `mul_div_mul_left`. -/
-lemma mul_div_mul_left_le (h : 0 ≤ a / b) : c * a / (c * b) ≤ a / b := by
-  obtain rfl | hc := eq_or_ne c 0
-  · simpa
-  · rw [mul_div_mul_left _ _ hc]
-
-/-- Equality holds when `c ≠ 0`. See `mul_div_mul_left`. -/
-lemma le_mul_div_mul_left (h : a / b ≤ 0) : a / b ≤ c * a / (c * b) := by
-  obtain rfl | hc := eq_or_ne c 0
-  · simpa
-  · rw [mul_div_mul_left _ _ hc]
-
-/-- Equality holds when `c ≠ 0`. See `mul_div_mul_right`. -/
-lemma mul_div_mul_right_le (h : 0 ≤ a / b) : a * c / (b * c) ≤ a / b := by
-  obtain rfl | hc := eq_or_ne c 0
-  · simpa
-  · rw [mul_div_mul_right _ _ hc]
-
-/-- Equality holds when `c ≠ 0`. See `mul_div_mul_right`. -/
-lemma le_mul_div_mul_right (h : a / b ≤ 0) : a / b ≤ a * c / (b * c) := by
-  obtain rfl | hc := eq_or_ne c 0
-  · simpa
-  · rw [mul_div_mul_right _ _ hc]

--- a/Mathlib/Algebra/Order/GroupWithZero/Unbundled/Basic.lean
+++ b/Mathlib/Algebra/Order/GroupWithZero/Unbundled/Basic.lean
@@ -716,10 +716,65 @@ section GroupWithZero
 variable [GroupWithZero G₀]
 
 section Preorder
-variable [Preorder G₀] [ZeroLEOneClass G₀]
+variable [Preorder G₀] {a b c : G₀}
+
+/-- Equality holds when `a ≠ 0`. See `mul_inv_cancel_left`. -/
+lemma mul_inv_left_le (hb : 0 ≤ b) : a * (a⁻¹ * b) ≤ b := by
+  obtain rfl | ha := eq_or_ne a 0 <;> simp [*]
+
+/-- Equality holds when `a ≠ 0`. See `mul_inv_cancel_left`. -/
+lemma le_mul_inv_left (hb : b ≤ 0) : b ≤ a * (a⁻¹ * b) := by
+  obtain rfl | ha := eq_or_ne a 0 <;> simp [*]
+
+/-- Equality holds when `a ≠ 0`. See `inv_mul_cancel_left`. -/
+lemma inv_mul_left_le (hb : 0 ≤ b) : a⁻¹ * (a * b) ≤ b := by
+  obtain rfl | ha := eq_or_ne a 0 <;> simp [*]
+
+/-- Equality holds when `a ≠ 0`. See `inv_mul_cancel_left`. -/
+lemma le_inv_mul_left (hb : b ≤ 0) : b ≤ a⁻¹ * (a * b) := by
+  obtain rfl | ha := eq_or_ne a 0 <;> simp [*]
+
+/-- Equality holds when `b ≠ 0`. See `mul_inv_cancel_right`. -/
+lemma mul_inv_right_le (ha : 0 ≤ a) : a * b * b⁻¹ ≤ a := by
+  obtain rfl | hb := eq_or_ne b 0 <;> simp [*]
+
+/-- Equality holds when `b ≠ 0`. See `mul_inv_cancel_right`. -/
+lemma le_mul_inv_right (ha : a ≤ 0) : a ≤ a * b * b⁻¹ := by
+  obtain rfl | hb := eq_or_ne b 0 <;> simp [*]
+
+/-- Equality holds when `b ≠ 0`. See `inv_mul_cancel_right`. -/
+lemma inv_mul_right_le (ha : 0 ≤ a) : a * b⁻¹ * b ≤ a := by
+  obtain rfl | hb := eq_or_ne b 0 <;> simp [*]
+
+/-- Equality holds when `b ≠ 0`. See `inv_mul_cancel_right`. -/
+lemma le_inv_mul_right (ha : a ≤ 0) : a ≤ a * b⁻¹ * b := by
+  obtain rfl | hb := eq_or_ne b 0 <;> simp [*]
+
+/-- Equality holds when `c ≠ 0`. See `mul_div_mul_right`. -/
+lemma mul_div_mul_right_le (h : 0 ≤ a / b) : a * c / (b * c) ≤ a / b := by
+  obtain rfl | hc := eq_or_ne c 0
+  · simpa
+  · rw [mul_div_mul_right _ _ hc]
+
+/-- Equality holds when `c ≠ 0`. See `mul_div_mul_right`. -/
+lemma le_mul_div_mul_right (h : a / b ≤ 0) : a / b ≤ a * c / (b * c) := by
+  obtain rfl | hc := eq_or_ne c 0
+  · simpa
+  · rw [mul_div_mul_right _ _ hc]
+
+end Preorder
+
+section Preorder
+variable [Preorder G₀] [ZeroLEOneClass G₀] {a b c : G₀}
 
 /-- See `div_self` for the version with equality when `a ≠ 0`. -/
 lemma div_self_le_one (a : G₀) : a / a ≤ 1 := by obtain rfl | ha := eq_or_ne a 0 <;> simp [*]
+
+/-- Equality holds when `a ≠ 0`. See `mul_inv_cancel`. -/
+lemma mul_inv_le_one : a * a⁻¹ ≤ 1 := by simpa only [div_eq_mul_inv] using div_self_le_one a
+
+/-- Equality holds when `a ≠ 0`. See `inv_mul_cancel`. -/
+lemma inv_mul_le_one : a⁻¹ * a ≤ 1 := by obtain rfl | ha := eq_or_ne a 0 <;> simp [*]
 
 end Preorder
 
@@ -1236,6 +1291,24 @@ variable [MulPosStrictMono G₀]
 end GroupWithZero.LinearOrder
 
 section CommGroupWithZero
+
+section Preorder
+variable [CommGroupWithZero G₀] [Preorder G₀] {a b c : G₀}
+
+/-- Equality holds when `c ≠ 0`. See `mul_div_mul_left`. -/
+lemma mul_div_mul_left_le (h : 0 ≤ a / b) : c * a / (c * b) ≤ a / b := by
+  obtain rfl | hc := eq_or_ne c 0
+  · simpa
+  · rw [mul_div_mul_left _ _ hc]
+
+/-- Equality holds when `c ≠ 0`. See `mul_div_mul_left`. -/
+lemma le_mul_div_mul_left (h : a / b ≤ 0) : a / b ≤ c * a / (c * b) := by
+  obtain rfl | hc := eq_or_ne c 0
+  · simpa
+  · rw [mul_div_mul_left _ _ hc]
+
+end Preorder
+
 variable [CommGroupWithZero G₀] [PartialOrder G₀] [PosMulReflectLT G₀] {a b c d : G₀}
 
 attribute [local instance] PosMulReflectLT.toPosMulStrictMono PosMulMono.toMulPosMono


### PR DESCRIPTION
... from linear ordered semifields to (commutative) groups with zero.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
