### PR TITLE
[Merged by Bors] - chore(RingTheory/TensorProduct): more product compatibilities

### DIFF
--- a/Mathlib/RingTheory/TensorProduct/Pi.lean
+++ b/Mathlib/RingTheory/TensorProduct/Pi.lean
@@ -61,9 +61,13 @@ noncomputable def piScalarRight : A ⊗[R] (ι → R) ≃ₐ[S] ι → A :=
   (piRight R S A (fun _ : ι ↦ R)).trans <|
     AlgEquiv.piCongrRight (fun _ ↦ Algebra.TensorProduct.rid R S A)
 
-@[simp]
 lemma piScalarRight_tmul (x : A) (y : ι → R) :
     piScalarRight R S A ι (x ⊗ₜ y) = fun i ↦ y i • x :=
+  rfl
+
+@[simp]
+lemma piScalarRight_tmul_apply (x : A) (y : ι → R) (i : ι) :
+    piScalarRight R S A ι (x ⊗ₜ y) i = y i • x :=
   rfl
 
 section
@@ -76,15 +80,22 @@ noncomputable nonrec def prodRight : A ⊗[R] (B × C) ≃ₐ[S] A ⊗[R] B × A
     (by simp [Algebra.TensorProduct.one_def])
     (LinearMap.map_mul_of_map_mul_tmul (fun _ _ _ _ ↦ by simp))
 
-@[simp]
 lemma prodRight_tmul (a : A) (x : B × C) : prodRight R S A B C (a ⊗ₜ x) = (a ⊗ₜ x.1, a ⊗ₜ x.2) :=
+  rfl
+
+@[simp]
+lemma prodRight_tmul_fst (a : A) (x : B × C) : (prodRight R S A B C (a ⊗ₜ x)).fst = a ⊗ₜ x.1 :=
+  rfl
+
+@[simp]
+lemma prodRight_tmul_snd (a : A) (x : B × C) : (prodRight R S A B C (a ⊗ₜ x)).snd = a ⊗ₜ x.2 :=
   rfl
 
 @[simp]
 lemma prodRight_symm_tmul (a : A) (b : B) (c : C) :
     (prodRight R S A B C).symm (a ⊗ₜ b, a ⊗ₜ c) = a ⊗ₜ (b, c) := by
   apply (prodRight R S A B C).injective
-  simp
+  simp [prodRight_tmul]
 
 end
 

--- a/Mathlib/RingTheory/TensorProduct/Pi.lean
+++ b/Mathlib/RingTheory/TensorProduct/Pi.lean
@@ -5,6 +5,7 @@ Authors: Christian Merten
 -/
 import Mathlib.Algebra.Algebra.Pi
 import Mathlib.LinearAlgebra.TensorProduct.Pi
+import Mathlib.LinearAlgebra.TensorProduct.Prod
 import Mathlib.RingTheory.TensorProduct.Basic
 
 /-!
@@ -17,7 +18,7 @@ is a direct application of `Mathlib.LinearAlgebra.TensorProduct.Pi` to the algeb
 
 open TensorProduct
 
-section
+namespace Algebra.TensorProduct
 
 variable (R S A : Type*) [CommSemiring R] [CommSemiring S] [Algebra R S] [CommSemiring A]
   [Algebra R A] [Algebra S A] [IsScalarTower R S A]
@@ -47,12 +48,44 @@ noncomputable def piRightHom : A ⊗[R] (∀ i, B i) →ₐ[S] ∀ i, A ⊗[R] B
 variable [Fintype ι] [DecidableEq ι]
 
 /-- Tensor product of rings commutes with finite products on the right. -/
-noncomputable def Algebra.TensorProduct.piRight :
-    A ⊗[R] (∀ i, B i) ≃ₐ[S] ∀ i, A ⊗[R] B i :=
+noncomputable def piRight : A ⊗[R] (∀ i, B i) ≃ₐ[S] ∀ i, A ⊗[R] B i :=
   AlgEquiv.ofLinearEquiv (_root_.TensorProduct.piRight R S A B) (by simp) (by simp)
 
 @[simp]
-lemma Algebra.TensorProduct.piRight_tmul (x : A) (f : ∀ i, B i) :
+lemma piRight_tmul (x : A) (f : ∀ i, B i) :
     piRight R S A B (x ⊗ₜ f) = (fun j ↦ x ⊗ₜ f j) := rfl
 
+variable (ι) in
+/-- Variant of `Algebra.TensorProduct.piRight` with constant factors. -/
+noncomputable def piScalarRight : A ⊗[R] (ι → R) ≃ₐ[S] ι → A :=
+  (piRight R S A (fun _ : ι ↦ R)).trans <|
+    AlgEquiv.piCongrRight (fun _ ↦ Algebra.TensorProduct.rid R S A)
+
+@[simp]
+lemma piScalarRight_tmul (x : A) (y : ι → R) :
+    piScalarRight R S A ι (x ⊗ₜ y) = fun i ↦ y i • x :=
+  rfl
+
+section
+
+variable (B C : Type*) [Semiring B] [Semiring C] [Algebra R B] [Algebra R C]
+
+/-- Tensor product of rings commutes with binary products on the right. -/
+noncomputable nonrec def prodRight : A ⊗[R] (B × C) ≃ₐ[S] A ⊗[R] B × A ⊗[R] C :=
+  AlgEquiv.ofLinearEquiv (TensorProduct.prodRight R S A B C)
+    (by simp [Algebra.TensorProduct.one_def])
+    (LinearMap.map_mul_of_map_mul_tmul (fun _ _ _ _ ↦ by simp))
+
+@[simp]
+lemma prodRight_tmul (a : A) (x : B × C) : prodRight R S A B C (a ⊗ₜ x) = (a ⊗ₜ x.1, a ⊗ₜ x.2) :=
+  rfl
+
+@[simp]
+lemma prodRight_symm_tmul (a : A) (b : B) (c : C) :
+    (prodRight R S A B C).symm (a ⊗ₜ b, a ⊗ₜ c) = a ⊗ₜ (b, c) := by
+  apply (prodRight R S A B C).injective
+  simp
+
 end
+
+end Algebra.TensorProduct


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
