### PR TITLE
[Merged by Bors] - feat: add RingOfIntegers.isPrincipalIdealRing_of_isPrincipal_of_mem_primesOver

### DIFF
--- a/Mathlib/NumberTheory/NumberField/ClassNumber.lean
+++ b/Mathlib/NumberTheory/NumberField/ClassNumber.lean
@@ -134,9 +134,9 @@ theorem _root_.RingOfIntegers.isPrincipalIdealRing_of_abs_discr_lt
   rw [← Real.sqrt_lt (by positivity) (by positivity), mul_assoc, ← inv_mul_lt_iff₀' (by positivity),
     mul_inv, ← inv_pow, inv_div, inv_div, mul_assoc, Int.cast_abs] at h
   refine RingOfIntegers.isPrincipalIdealRing_of_isPrincipal_of_norm_le (fun I hI ↦ ?_)
-  convert top_isPrincipal
-  exact absNorm_eq_one_iff.mp <| le_antisymm (lt_succ.mp (cast_lt.mp
-    (lt_of_le_of_lt hI h))) <| one_le_iff_ne_zero.mpr (absNorm_ne_zero_of_nonZeroDivisors I)
+  rw [absNorm_eq_one_iff.mp <| le_antisymm (lt_succ.mp (cast_lt.mp
+    (lt_of_le_of_lt hI h))) <| one_le_iff_ne_zero.mpr (absNorm_ne_zero_of_nonZeroDivisors I)]
+  exact top_isPrincipal
 
 end NumberField
 

--- a/Mathlib/NumberTheory/NumberField/ClassNumber.lean
+++ b/Mathlib/NumberTheory/NumberField/ClassNumber.lean
@@ -20,7 +20,7 @@ on the class number.
 cardinality of the class group of its ring of integers
 - `RingOfIntegers.isPrincipalIdealRing_of_isPrincipal_of_mem_primesOver_of_le`: to show that the
 ring of integer of a number field is a PID it is enough to show that all ideals above any (natural)
-prime `p`  smaller than Minkowski bound are principal. This is the standard technique to prove that
+prime `p` smaller than Minkowski bound are principal. This is the standard technique to prove that
 `𝓞 K` is principal, see [marcus1977number], discussion after Theorem 37.
 -/
 

--- a/Mathlib/NumberTheory/NumberField/ClassNumber.lean
+++ b/Mathlib/NumberTheory/NumberField/ClassNumber.lean
@@ -18,6 +18,10 @@ on the class number.
 ## Main definitions
 - `NumberField.classNumber`: the class number of a number field is the (finite)
 cardinality of the class group of its ring of integers
+- `RingOfIntegers.isPrincipalIdealRing_of_isPrincipal_of_mem_primesOver_of_le`: to show that the
+ring of integer of a number field is a PID it is enough to show that all ideals above any (natural)
+prime `p`  smaller than Minkowski bound are principal. This is the standard technique to prove that
+`𝓞 K` is principal, see [marcus1977number], discussion after Theorem 37.
 -/
 
 namespace NumberField
@@ -97,24 +101,27 @@ theorem _root_.RingOfIntegers.isPrincipalIdealRing_of_isPrincipal_of_norm_le_of_
     absNorm_dvd_absNorm_of_le <| le_of_dvd <|
       UniqueFactorizationMonoid.dvd_of_mem_normalizedFactors hJ).trans hI
 
-theorem _root_.RingOfIntegers.isPrincipalIdealRing_of_isPrincipal_of_mem_primesOver
+/-- To show that the ring of integer of a number field is a PID it is enough to show that all ideals
+above any (natural) prime `p`  smaller than Minkowski bound are principal. -/
+theorem _root_.RingOfIntegers.isPrincipalIdealRing_of_isPrincipal_of_mem_primesOver_of_le
     (h : ∀ ⦃p : ℕ⦄, p.Prime → p ≤ (4 / π) ^ nrComplexPlaces K *
       ((finrank ℚ K)! / (finrank ℚ K) ^ (finrank ℚ K) * √|discr K|) →
       ∀ (I : Ideal (𝓞 K)), I ∈ Ideal.primesOver (span {(p : ℤ)}) (𝓞 K) →
       Submodule.IsPrincipal I) :
     IsPrincipalIdealRing (𝓞 K) := by
   refine RingOfIntegers.isPrincipalIdealRing_of_isPrincipal_of_norm_le_of_isPrime <|
-    fun P hP hPNorm ↦ ?_
-  obtain ⟨p, hp⟩ := IsPrincipalIdealRing.principal <| under ℤ P.1
-  have hp0 : p ≠ 0 := fun h ↦ nonZeroDivisors.coe_ne_zero P <|
+    fun ⟨P, HP⟩ hP hPNorm ↦ ?_
+  obtain ⟨p, hp⟩ := IsPrincipalIdealRing.principal <| under ℤ P
+  have hp0 : p ≠ 0 := fun h ↦ nonZeroDivisors.coe_ne_zero ⟨P, HP⟩ <|
     eq_bot_of_comap_eq_bot (R := ℤ) <| by simpa only [hp, submodule_span_eq, span_singleton_eq_bot]
   have hpprime := (span_singleton_prime hp0).mp
   rw [← submodule_span_eq, ← hp] at hpprime
-  have hle : algebraMap ℤ (𝓞 K) p ∈ P.1 := (mem_of_liesOver P.1 (under ℤ P.1) p).mp <|
+  have hle : algebraMap ℤ (𝓞 K) p ∈ P := (mem_of_liesOver P (under ℤ P) p).mp <|
     hp ▸ Submodule.mem_span_singleton_self p
   refine h (Int.prime_iff_natAbs_prime.mp (hpprime (hP.under _))) ?_ _ ⟨hP, ?_⟩
   · refine le_trans (cast_le.mpr <| Nat.le_of_dvd ?_ (Int.ofNat_dvd_right.mp ?_)) hPNorm
-    · exact Nat.pos_of_ne_zero <| fun h ↦ nonZeroDivisors.coe_ne_zero P <| absNorm_eq_zero_iff.mp h
+    · exact Nat.pos_of_ne_zero <| fun h ↦ nonZeroDivisors.coe_ne_zero ⟨P, HP⟩ <|
+        absNorm_eq_zero_iff.mp h
     suffices (Algebra.norm ℤ (algebraMap ℤ (𝓞 K) p)) = p ^ (Module.finrank ℚ K) by
       obtain ⟨i, -, hi⟩ := (dvd_prime_pow (hpprime (IsPrime.comap _)) _).mp
         (this ▸ absNorm_dvd_norm_of_mem hle)
@@ -123,8 +130,7 @@ theorem _root_.RingOfIntegers.isPrincipalIdealRing_of_isPrincipal_of_mem_primesO
       exact ZMod.eq_one_of_isUnit_natCast hi
     exact Rat.intCast_injective (by simp [Algebra.coe_norm_int, ← Algebra.norm_algebraMap])
   · rcases abs_choice p with h | h <;>
-    simpa [h, span_singleton_neg p, ← submodule_span_eq, ← hp] using over_under P.1
-
+    simpa [h, span_singleton_neg p, ← submodule_span_eq, ← hp] using over_under P
 
 theorem _root_.RingOfIntegers.isPrincipalIdealRing_of_abs_discr_lt
     (h : |discr K| < (2 * (π / 4) ^ nrComplexPlaces K *

--- a/Mathlib/NumberTheory/NumberField/ClassNumber.lean
+++ b/Mathlib/NumberTheory/NumberField/ClassNumber.lean
@@ -92,10 +92,10 @@ theorem _root_.RingOfIntegers.isPrincipalIdealRing_of_isPrincipal_of_norm_le_of_
   by_cases hJ0 : J = 0
   · simpa [hJ0] using bot_isPrincipal
   rw [← Subtype.coe_mk J (mem_nonZeroDivisors_of_ne_zero hJ0)]
-  refine h (((mem_normalizedFactors_iff (nonZeroDivisors.coe_ne_zero I)).mp hJ).1) ?_
+  apply h (((mem_normalizedFactors_iff (nonZeroDivisors.coe_ne_zero I)).mp hJ).1)
   exact (cast_le.mpr <| le_of_dvd (absNorm_pos_of_nonZeroDivisors I) <|
-    absNorm_dvd_absNorm_of_le (le_of_dvd (UniqueFactorizationMonoid.dvd_of_mem_normalizedFactors
-    hJ))).trans hI
+    absNorm_dvd_absNorm_of_le <| le_of_dvd <|
+      UniqueFactorizationMonoid.dvd_of_mem_normalizedFactors hJ).trans hI
 
 theorem _root_.RingOfIntegers.isPrincipalIdealRing_of_isPrincipal_of_mem_primesOver
     (h : ∀ ⦃p : ℕ⦄, p.Prime → p ≤ (4 / π) ^ nrComplexPlaces K *

--- a/Mathlib/NumberTheory/NumberField/ClassNumber.lean
+++ b/Mathlib/NumberTheory/NumberField/ClassNumber.lean
@@ -97,21 +97,22 @@ theorem _root_.RingOfIntegers.isPrincipalIdealRing_of_isPrincipal_of_norm_le_of_
     absNorm_dvd_absNorm_of_le (le_of_dvd (UniqueFactorizationMonoid.dvd_of_mem_normalizedFactors
     hJ))).trans hI
 
-theorem _root_.RingOfIntegers.isPrincipalIdealRing_of_isPrincipal_of_mem_normalizedFactors
+theorem _root_.RingOfIntegers.isPrincipalIdealRing_of_isPrincipal_of_mem_primesOver
     (h : ∀ ⦃p : ℕ⦄, p.Prime → p ≤ (4 / π) ^ nrComplexPlaces K *
       ((finrank ℚ K)! / (finrank ℚ K) ^ (finrank ℚ K) * √|discr K|) →
-      ∀ (I : Ideal (𝓞 K)), I ∈ UniqueFactorizationMonoid.normalizedFactors (Ideal.span ({↑p})) →
+      ∀ (I : Ideal (𝓞 K)), I ∈ Ideal.primesOver (span {(p : ℤ)}) (𝓞 K) →
       Submodule.IsPrincipal I) :
     IsPrincipalIdealRing (𝓞 K) := by
   refine RingOfIntegers.isPrincipalIdealRing_of_isPrincipal_of_norm_le_of_isPrime <|
     fun P hP hPNorm ↦ ?_
-  obtain ⟨p, hp⟩ := IsPrincipalIdealRing.principal <| P.1.comap (algebraMap ℤ (𝓞 K))
-  have hp0 : p ≠ 0 := fun h ↦ nonZeroDivisors.coe_ne_zero P <| eq_bot_of_comap_eq_bot (R := ℤ) <|
-    by rw [hp, h, submodule_span_eq, span_singleton_eq_bot]
+  obtain ⟨p, hp⟩ := IsPrincipalIdealRing.principal <| under ℤ P.1
+  have hp0 : p ≠ 0 := fun h ↦ nonZeroDivisors.coe_ne_zero P <|
+    eq_bot_of_comap_eq_bot (R := ℤ) <| by simpa only [hp, submodule_span_eq, span_singleton_eq_bot]
   have hpprime := (span_singleton_prime hp0).mp
   rw [← submodule_span_eq, ← hp] at hpprime
-  have hle := map_comap_le (mem_map_of_mem _ <| hp ▸ Submodule.mem_span_singleton_self p)
-  refine h (Int.prime_iff_natAbs_prime.mp (hpprime (IsPrime.comap _))) ?_ _ ?_
+  have hle : algebraMap ℤ (𝓞 K) p ∈ P.1 := (mem_of_liesOver P.1 (under ℤ P.1) p).mp <|
+    hp ▸ Submodule.mem_span_singleton_self p
+  refine h (Int.prime_iff_natAbs_prime.mp (hpprime (hP.under _))) ?_ _ ⟨hP, ?_⟩
   · refine le_trans (cast_le.mpr <| Nat.le_of_dvd ?_ (Int.ofNat_dvd_right.mp ?_)) hPNorm
     · exact Nat.pos_of_ne_zero <| fun h ↦ nonZeroDivisors.coe_ne_zero P <| absNorm_eq_zero_iff.mp h
     suffices (Algebra.norm ℤ (algebraMap ℤ (𝓞 K) p)) = p ^ (Module.finrank ℚ K) by
@@ -121,9 +122,10 @@ theorem _root_.RingOfIntegers.isPrincipalIdealRing_of_isPrincipal_of_mem_normali
       simp only [h, pow_zero, associated_one_iff_isUnit] at hi
       exact ZMod.eq_one_of_isUnit_natCast hi
     exact Rat.intCast_injective (by simp [Algebra.coe_norm_int, ← Algebra.norm_algebraMap])
-  · refine (Ideal.mem_normalizedFactors_iff (by simpa using hp0)).mpr ⟨hP, span_le.mpr ?_⟩
+  · convert over_under P.1
     rcases abs_choice p with h|h <;>
-    simpa [cast_natAbs, h]
+    simp [hp, h]
+
 
 theorem _root_.RingOfIntegers.isPrincipalIdealRing_of_abs_discr_lt
     (h : |discr K| < (2 * (π / 4) ^ nrComplexPlaces K *

--- a/Mathlib/NumberTheory/NumberField/ClassNumber.lean
+++ b/Mathlib/NumberTheory/NumberField/ClassNumber.lean
@@ -92,7 +92,7 @@ theorem _root_.RingOfIntegers.isPrincipalIdealRing_of_isPrincipal_of_norm_le_of_
   by_cases hJ0 : J = 0
   · simpa [hJ0] using bot_isPrincipal
   rw [← Subtype.coe_mk J (mem_nonZeroDivisors_of_ne_zero hJ0)]
-  apply h (((mem_normalizedFactors_iff (nonZeroDivisors.coe_ne_zero I)).mp hJ).1)
+  refine h (((mem_normalizedFactors_iff (nonZeroDivisors.coe_ne_zero I)).mp hJ).1) ?_
   exact (cast_le.mpr <| le_of_dvd (absNorm_pos_of_nonZeroDivisors I) <|
     absNorm_dvd_absNorm_of_le <| le_of_dvd <|
       UniqueFactorizationMonoid.dvd_of_mem_normalizedFactors hJ).trans hI
@@ -122,9 +122,8 @@ theorem _root_.RingOfIntegers.isPrincipalIdealRing_of_isPrincipal_of_mem_primesO
       simp only [h, pow_zero, associated_one_iff_isUnit] at hi
       exact ZMod.eq_one_of_isUnit_natCast hi
     exact Rat.intCast_injective (by simp [Algebra.coe_norm_int, ← Algebra.norm_algebraMap])
-  · convert over_under P.1
-    rcases abs_choice p with h|h <;>
-    simp [hp, h]
+  · rcases abs_choice p with h | h <;>
+    simpa [h, span_singleton_neg p, ← submodule_span_eq, ← hp] using over_under P.1
 
 
 theorem _root_.RingOfIntegers.isPrincipalIdealRing_of_abs_discr_lt

--- a/Mathlib/NumberTheory/NumberField/ClassNumber.lean
+++ b/Mathlib/NumberTheory/NumberField/ClassNumber.lean
@@ -77,8 +77,7 @@ theorem _root_.RingOfIntegers.isPrincipalIdealRing_of_isPrincipal_of_norm_le
   rw [← classNumber_eq_one_iff, classNumber, Fintype.card_eq_one_iff]
   refine ⟨1, fun C ↦ ?_⟩
   obtain ⟨I, rfl, hI⟩ := exists_ideal_in_class_of_norm_le C
-  rw [ClassGroup.mk0_eq_one_iff]
-  exact h _ hI
+  simpa [← ClassGroup.mk0_eq_one_iff] using h _ hI
 
 theorem _root_.RingOfIntegers.isPrincipalIdealRing_of_abs_discr_lt
     (h : |discr K| < (2 * (π / 4) ^ nrComplexPlaces K *

--- a/Mathlib/NumberTheory/NumberField/ClassNumber.lean
+++ b/Mathlib/NumberTheory/NumberField/ClassNumber.lean
@@ -69,6 +69,17 @@ theorem exists_ideal_in_class_of_norm_le (C : ClassGroup (𝓞 K)) :
     refine le_of_mul_le_mul_of_pos_left h_nm ?_
     exact Nat.cast_pos.mpr <| Nat.pos_of_ne_zero <| Ideal.absNorm_ne_zero_of_nonZeroDivisors J
 
+theorem _root_.RingOfIntegers.isPrincipalIdealRing_of_isPrincipal_of_norm_le
+    (h : ∀ I : (Ideal (𝓞 K))⁰, Ideal.absNorm (I : Ideal (𝓞 K)) ≤ (4 / π) ^ nrComplexPlaces K *
+        ((finrank ℚ K).factorial / (finrank ℚ K) ^ (finrank ℚ K) * Real.sqrt |discr K|) →
+        Submodule.IsPrincipal (I : Ideal (𝓞 K))) :
+    IsPrincipalIdealRing (𝓞 K) := by
+  rw [← classNumber_eq_one_iff, classNumber, Fintype.card_eq_one_iff]
+  refine ⟨1, fun C ↦ ?_⟩
+  obtain ⟨I, rfl, hI⟩ := exists_ideal_in_class_of_norm_le C
+  rw [ClassGroup.mk0_eq_one_iff]
+  exact h _ hI
+
 theorem _root_.RingOfIntegers.isPrincipalIdealRing_of_abs_discr_lt
     (h : |discr K| < (2 * (π / 4) ^ nrComplexPlaces K *
       ((finrank ℚ K) ^ (finrank ℚ K) / (finrank ℚ K).factorial)) ^ 2) :
@@ -76,15 +87,11 @@ theorem _root_.RingOfIntegers.isPrincipalIdealRing_of_abs_discr_lt
   have : 0 < finrank ℚ K := finrank_pos -- Lean needs to know that for positivity to succeed
   rw [← Real.sqrt_lt (by positivity) (by positivity), mul_assoc, ← inv_mul_lt_iff₀' (by positivity),
     mul_inv, ← inv_pow, inv_div, inv_div, mul_assoc, Int.cast_abs] at h
-  rw [← classNumber_eq_one_iff, classNumber, Fintype.card_eq_one_iff]
-  refine ⟨1, fun C ↦ ?_⟩
-  obtain ⟨I, rfl, hI⟩ := exists_ideal_in_class_of_norm_le C
-  have : Ideal.absNorm I.1 = 1 := by
-    refine le_antisymm (Nat.lt_succ.mp ?_) (Nat.one_le_iff_ne_zero.mpr
-      (Ideal.absNorm_ne_zero_of_nonZeroDivisors I))
-    exact Nat.cast_lt.mp <| lt_of_le_of_lt hI h
-  rw [ClassGroup.mk0_eq_one_iff, Ideal.absNorm_eq_one_iff.mp this]
-  exact top_isPrincipal
+  refine RingOfIntegers.isPrincipalIdealRing_of_isPrincipal_of_norm_le (fun I hI ↦ ?_)
+  convert top_isPrincipal
+  exact Ideal.absNorm_eq_one_iff.mp (le_antisymm (Nat.lt_succ.mp ((Nat.cast_lt (α := ℝ)).mp
+    (lt_of_le_of_lt hI h))) (Nat.one_le_iff_ne_zero.mpr
+    (Ideal.absNorm_ne_zero_of_nonZeroDivisors I)))
 
 end NumberField
 

--- a/Mathlib/NumberTheory/NumberField/ClassNumber.lean
+++ b/Mathlib/NumberTheory/NumberField/ClassNumber.lean
@@ -51,7 +51,7 @@ theorem exists_ideal_in_class_of_norm_le (C : ClassGroup (𝓞 K)) :
   obtain ⟨J, hJ⟩ := ClassGroup.mk0_surjective C⁻¹
   obtain ⟨_, ⟨a, ha, rfl⟩, h_nz, h_nm⟩ :=
     exists_ne_zero_mem_ideal_of_norm_le_mul_sqrt_discr K (FractionalIdeal.mk0 K J)
-  obtain ⟨I₀, hI⟩ := dvd_iff_le.mpr ((span_singleton_le_iff_mem J).mpr (by convert ha))
+  obtain ⟨I₀, hI⟩ := dvd_iff_le.mpr ((span_singleton_le_iff_mem J).mpr (by exact ha))
   have : I₀ ≠ 0 := by
     contrapose! h_nz
     rw [h_nz, mul_zero, zero_eq_bot, span_singleton_eq_bot] at hI

--- a/Mathlib/NumberTheory/NumberField/ClassNumber.lean
+++ b/Mathlib/NumberTheory/NumberField/ClassNumber.lean
@@ -47,7 +47,7 @@ open scoped nonZeroDivisors Real
 theorem exists_ideal_in_class_of_norm_le (C : ClassGroup (𝓞 K)) :
     ∃ I : (Ideal (𝓞 K))⁰, ClassGroup.mk0 I = C ∧
       absNorm (I : Ideal (𝓞 K)) ≤ (4 / π) ^ nrComplexPlaces K *
-        ((finrank ℚ K)! / (finrank ℚ K) ^ (finrank ℚ K) * Real.sqrt |discr K|) := by
+        ((finrank ℚ K)! / (finrank ℚ K) ^ (finrank ℚ K) * √|discr K|) := by
   obtain ⟨J, hJ⟩ := ClassGroup.mk0_surjective C⁻¹
   obtain ⟨_, ⟨a, ha, rfl⟩, h_nz, h_nm⟩ :=
     exists_ne_zero_mem_ideal_of_norm_le_mul_sqrt_discr K (FractionalIdeal.mk0 K J)
@@ -70,7 +70,7 @@ theorem exists_ideal_in_class_of_norm_le (C : ClassGroup (𝓞 K)) :
 
 theorem _root_.RingOfIntegers.isPrincipalIdealRing_of_isPrincipal_of_norm_le
     (h : ∀ I : (Ideal (𝓞 K))⁰, absNorm (I : Ideal (𝓞 K)) ≤ (4 / π) ^ nrComplexPlaces K *
-        ((finrank ℚ K)! / (finrank ℚ K) ^ (finrank ℚ K) * Real.sqrt |discr K|) →
+        ((finrank ℚ K)! / (finrank ℚ K) ^ (finrank ℚ K) * √|discr K|) →
         Submodule.IsPrincipal (I : Ideal (𝓞 K))) :
     IsPrincipalIdealRing (𝓞 K) := by
   rw [← classNumber_eq_one_iff, classNumber, Fintype.card_eq_one_iff]

--- a/Mathlib/NumberTheory/NumberField/ClassNumber.lean
+++ b/Mathlib/NumberTheory/NumberField/ClassNumber.lean
@@ -97,6 +97,34 @@ theorem _root_.RingOfIntegers.isPrincipalIdealRing_of_isPrincipal_of_norm_le_of_
     absNorm_dvd_absNorm_of_le (le_of_dvd (UniqueFactorizationMonoid.dvd_of_mem_normalizedFactors
     hJ))).trans hI
 
+theorem _root_.RingOfIntegers.isPrincipalIdealRing_of_isPrincipal_of_mem_normalizedFactors
+    (h : ∀ ⦃p : ℕ⦄, p.Prime → p ≤ (4 / π) ^ nrComplexPlaces K *
+      ((finrank ℚ K)! / (finrank ℚ K) ^ (finrank ℚ K) * √|discr K|) →
+      ∀ (I : Ideal (𝓞 K)), I ∈ UniqueFactorizationMonoid.normalizedFactors (Ideal.span ({↑p})) →
+      Submodule.IsPrincipal I) :
+    IsPrincipalIdealRing (𝓞 K) := by
+  refine RingOfIntegers.isPrincipalIdealRing_of_isPrincipal_of_norm_le_of_isPrime <|
+    fun P hP hPNorm ↦ ?_
+  obtain ⟨p, hp⟩ := IsPrincipalIdealRing.principal <| P.1.comap (algebraMap ℤ (𝓞 K))
+  have hp0 : p ≠ 0 := fun h ↦ nonZeroDivisors.coe_ne_zero P <| eq_bot_of_comap_eq_bot (R := ℤ) <|
+    by rw [hp, h, submodule_span_eq, span_singleton_eq_bot]
+  have hpprime := (span_singleton_prime hp0).mp
+  rw [← submodule_span_eq, ← hp] at hpprime
+  have hle := map_comap_le (mem_map_of_mem _ <| hp ▸ Submodule.mem_span_singleton_self p)
+  refine h (Int.prime_iff_natAbs_prime.mp (hpprime (IsPrime.comap _))) ?_ _ ?_
+  · refine le_trans (cast_le.mpr <| Nat.le_of_dvd ?_ (Int.ofNat_dvd_right.mp ?_)) hPNorm
+    · exact Nat.pos_of_ne_zero <| fun h ↦ nonZeroDivisors.coe_ne_zero P <| absNorm_eq_zero_iff.mp h
+    suffices (Algebra.norm ℤ (algebraMap ℤ (𝓞 K) p)) = p ^ (Module.finrank ℚ K) by
+      obtain ⟨i, -, hi⟩ := (dvd_prime_pow (hpprime (IsPrime.comap _)) _).mp
+        (this ▸ absNorm_dvd_norm_of_mem hle)
+      refine dvd_trans (dvd_pow_self p (fun h ↦ hP.ne_top (absNorm_eq_one_iff.mp ?_))) hi.dvd'
+      simp only [h, pow_zero, associated_one_iff_isUnit] at hi
+      exact ZMod.eq_one_of_isUnit_natCast hi
+    exact Rat.intCast_injective (by simp [Algebra.coe_norm_int, ← Algebra.norm_algebraMap])
+  · refine (Ideal.mem_normalizedFactors_iff (by simpa using hp0)).mpr ⟨hP, span_le.mpr ?_⟩
+    rcases abs_choice p with h|h <;>
+    simpa [cast_natAbs, h]
+
 theorem _root_.RingOfIntegers.isPrincipalIdealRing_of_abs_discr_lt
     (h : |discr K| < (2 * (π / 4) ^ nrComplexPlaces K *
       ((finrank ℚ K) ^ (finrank ℚ K) / (finrank ℚ K)!)) ^ 2) :

--- a/Mathlib/NumberTheory/NumberField/ClassNumber.lean
+++ b/Mathlib/NumberTheory/NumberField/ClassNumber.lean
@@ -54,7 +54,7 @@ theorem exists_ideal_in_class_of_norm_le (C : ClassGroup (𝓞 K)) :
   obtain ⟨I₀, hI⟩ := dvd_iff_le.mpr ((span_singleton_le_iff_mem J).mpr (by convert ha))
   have : I₀ ≠ 0 := by
     contrapose! h_nz
-    rw [h_nz, mul_zero, show 0 = (⊥ : Ideal (𝓞 K)) by rfl, span_singleton_eq_bot] at hI
+    rw [h_nz, mul_zero, zero_eq_bot, span_singleton_eq_bot] at hI
     rw [Algebra.linearMap_apply, hI, map_zero]
   let I := (⟨I₀, mem_nonZeroDivisors_iff_ne_zero.mpr this⟩ : (Ideal (𝓞 K))⁰)
   refine ⟨I, ?_, ?_⟩
@@ -62,10 +62,9 @@ theorem exists_ideal_in_class_of_norm_le (C : ClassGroup (𝓞 K)) :
     exact ClassGroup.mk0_eq_mk0_inv_iff.mpr ⟨a, Subtype.coe_ne_coe.1 h_nz, by rw [mul_comm, hI]⟩
   · rw [← FractionalIdeal.absNorm_span_singleton (𝓞 K), Algebra.linearMap_apply,
       ← FractionalIdeal.coeIdeal_span_singleton, FractionalIdeal.coeIdeal_absNorm, hI, map_mul,
-      cast_mul, Rat.cast_mul, show absNorm I₀ = Ideal.absNorm (I : Ideal (𝓞 K)) by rfl,
-      Rat.cast_natCast, Rat.cast_natCast, FractionalIdeal.coe_mk0,
-      FractionalIdeal.coeIdeal_absNorm, Rat.cast_natCast, mul_div_assoc, mul_assoc, mul_assoc]
-      at h_nm
+      cast_mul, Rat.cast_mul, absNorm_apply, Rat.cast_natCast, Rat.cast_natCast,
+      FractionalIdeal.coe_mk0, FractionalIdeal.coeIdeal_absNorm, Rat.cast_natCast, mul_div_assoc,
+      mul_assoc, mul_assoc] at h_nm
     refine le_of_mul_le_mul_of_pos_left h_nm ?_
     exact cast_pos.mpr <| pos_of_ne_zero <| absNorm_ne_zero_of_nonZeroDivisors J
 

--- a/Mathlib/NumberTheory/NumberField/ClassNumber.lean
+++ b/Mathlib/NumberTheory/NumberField/ClassNumber.lean
@@ -93,9 +93,9 @@ theorem _root_.RingOfIntegers.isPrincipalIdealRing_of_isPrincipal_of_isPrime_of_
   · simpa [hJ0] using bot_isPrincipal
   rw [← Subtype.coe_mk J (mem_nonZeroDivisors_of_ne_zero hJ0)]
   refine h (((mem_normalizedFactors_iff (nonZeroDivisors.coe_ne_zero I)).mp hJ).1) ?_
-  · exact (cast_le.mpr <| le_of_dvd (absNorm_pos_of_nonZeroDivisors I) <|
-      absNorm_dvd_absNorm_of_le (le_of_dvd (UniqueFactorizationMonoid.dvd_of_mem_normalizedFactors
-      hJ))).trans hI
+  exact (cast_le.mpr <| le_of_dvd (absNorm_pos_of_nonZeroDivisors I) <|
+    absNorm_dvd_absNorm_of_le (le_of_dvd (UniqueFactorizationMonoid.dvd_of_mem_normalizedFactors
+    hJ))).trans hI
 
 theorem _root_.RingOfIntegers.isPrincipalIdealRing_of_abs_discr_lt
     (h : |discr K| < (2 * (π / 4) ^ nrComplexPlaces K *

--- a/Mathlib/NumberTheory/NumberField/ClassNumber.lean
+++ b/Mathlib/NumberTheory/NumberField/ClassNumber.lean
@@ -97,8 +97,7 @@ namespace Rat
 open NumberField
 
 theorem classNumber_eq : NumberField.classNumber ℚ = 1 :=
-  classNumber_eq_one_iff.mpr <| by
-    convert IsPrincipalIdealRing.of_surjective
-      (Rat.ringOfIntegersEquiv.symm : ℤ →+* 𝓞 ℚ) Rat.ringOfIntegersEquiv.symm.surjective
+  classNumber_eq_one_iff.mpr <| IsPrincipalIdealRing.of_surjective
+    Rat.ringOfIntegersEquiv.symm Rat.ringOfIntegersEquiv.symm.surjective
 
 end Rat

--- a/Mathlib/NumberTheory/NumberField/ClassNumber.lean
+++ b/Mathlib/NumberTheory/NumberField/ClassNumber.lean
@@ -47,7 +47,7 @@ open scoped nonZeroDivisors Real
 theorem exists_ideal_in_class_of_norm_le (C : ClassGroup (𝓞 K)) :
     ∃ I : (Ideal (𝓞 K))⁰, ClassGroup.mk0 I = C ∧
       absNorm (I : Ideal (𝓞 K)) ≤ (4 / π) ^ nrComplexPlaces K *
-        ((finrank ℚ K).factorial / (finrank ℚ K) ^ (finrank ℚ K) * Real.sqrt |discr K|) := by
+        ((finrank ℚ K)! / (finrank ℚ K) ^ (finrank ℚ K) * Real.sqrt |discr K|) := by
   obtain ⟨J, hJ⟩ := ClassGroup.mk0_surjective C⁻¹
   obtain ⟨_, ⟨a, ha, rfl⟩, h_nz, h_nm⟩ :=
     exists_ne_zero_mem_ideal_of_norm_le_mul_sqrt_discr K (FractionalIdeal.mk0 K J)
@@ -71,7 +71,7 @@ theorem exists_ideal_in_class_of_norm_le (C : ClassGroup (𝓞 K)) :
 
 theorem _root_.RingOfIntegers.isPrincipalIdealRing_of_isPrincipal_of_norm_le
     (h : ∀ I : (Ideal (𝓞 K))⁰, absNorm (I : Ideal (𝓞 K)) ≤ (4 / π) ^ nrComplexPlaces K *
-        ((finrank ℚ K).factorial / (finrank ℚ K) ^ (finrank ℚ K) * Real.sqrt |discr K|) →
+        ((finrank ℚ K)! / (finrank ℚ K) ^ (finrank ℚ K) * Real.sqrt |discr K|) →
         Submodule.IsPrincipal (I : Ideal (𝓞 K))) :
     IsPrincipalIdealRing (𝓞 K) := by
   rw [← classNumber_eq_one_iff, classNumber, Fintype.card_eq_one_iff]
@@ -81,7 +81,7 @@ theorem _root_.RingOfIntegers.isPrincipalIdealRing_of_isPrincipal_of_norm_le
 
 theorem _root_.RingOfIntegers.isPrincipalIdealRing_of_abs_discr_lt
     (h : |discr K| < (2 * (π / 4) ^ nrComplexPlaces K *
-      ((finrank ℚ K) ^ (finrank ℚ K) / (finrank ℚ K).factorial)) ^ 2) :
+      ((finrank ℚ K) ^ (finrank ℚ K) / (finrank ℚ K)!)) ^ 2) :
     IsPrincipalIdealRing (𝓞 K) := by
   have : 0 < finrank ℚ K := finrank_pos -- Lean needs to know that for positivity to succeed
   rw [← Real.sqrt_lt (by positivity) (by positivity), mul_assoc, ← inv_mul_lt_iff₀' (by positivity),

--- a/Mathlib/NumberTheory/NumberField/ClassNumber.lean
+++ b/Mathlib/NumberTheory/NumberField/ClassNumber.lean
@@ -79,7 +79,7 @@ theorem _root_.RingOfIntegers.isPrincipalIdealRing_of_isPrincipal_of_norm_le
   obtain ⟨I, rfl, hI⟩ := exists_ideal_in_class_of_norm_le C
   simpa [← ClassGroup.mk0_eq_one_iff] using h _ hI
 
-theorem _root_.RingOfIntegers.isPrincipalIdealRing_of_isPrincipal_of_norm_le_of_prime
+theorem _root_.RingOfIntegers.isPrincipalIdealRing_of_isPrincipal_of_isPrime_of_norm_le
     (h : ∀ (I : (Ideal (𝓞 K))⁰), (I : Ideal (𝓞 K)).IsPrime →
       absNorm (I : Ideal (𝓞 K)) ≤ (4 / π) ^ nrComplexPlaces K *
         ((finrank ℚ K)! / (finrank ℚ K) ^ (finrank ℚ K) * √|discr K|) →

--- a/Mathlib/NumberTheory/NumberField/ClassNumber.lean
+++ b/Mathlib/NumberTheory/NumberField/ClassNumber.lean
@@ -48,7 +48,7 @@ open scoped nonZeroDivisors Real
 theorem exists_ideal_in_class_of_norm_le (C : ClassGroup (𝓞 K)) :
     ∃ I : (Ideal (𝓞 K))⁰, ClassGroup.mk0 I = C ∧
       absNorm (I : Ideal (𝓞 K)) ≤ (4 / π) ^ nrComplexPlaces K *
-        ((finrank ℚ K)! / (finrank ℚ K) ^ (finrank ℚ K) * √|discr K|) := by
+      ((finrank ℚ K)! / (finrank ℚ K) ^ (finrank ℚ K) * √|discr K|) := by
   obtain ⟨J, hJ⟩ := ClassGroup.mk0_surjective C⁻¹
   obtain ⟨_, ⟨a, ha, rfl⟩, h_nz, h_nm⟩ :=
     exists_ne_zero_mem_ideal_of_norm_le_mul_sqrt_discr K (FractionalIdeal.mk0 K J)
@@ -71,18 +71,18 @@ theorem exists_ideal_in_class_of_norm_le (C : ClassGroup (𝓞 K)) :
 
 theorem _root_.RingOfIntegers.isPrincipalIdealRing_of_isPrincipal_of_norm_le
     (h : ∀ ⦃I : (Ideal (𝓞 K))⁰⦄, absNorm (I : Ideal (𝓞 K)) ≤ (4 / π) ^ nrComplexPlaces K *
-        ((finrank ℚ K)! / (finrank ℚ K) ^ (finrank ℚ K) * √|discr K|) →
-        Submodule.IsPrincipal (I : Ideal (𝓞 K))) :
+      ((finrank ℚ K)! / (finrank ℚ K) ^ (finrank ℚ K) * √|discr K|) →
+      Submodule.IsPrincipal (I : Ideal (𝓞 K))) :
     IsPrincipalIdealRing (𝓞 K) := by
   rw [← classNumber_eq_one_iff, classNumber, Fintype.card_eq_one_iff]
   refine ⟨1, fun C ↦ ?_⟩
   obtain ⟨I, rfl, hI⟩ := exists_ideal_in_class_of_norm_le C
   simpa [← ClassGroup.mk0_eq_one_iff] using h hI
 
-theorem _root_.RingOfIntegers.isPrincipalIdealRing_of_isPrincipal_of_isPrime_of_norm_le
+theorem _root_.RingOfIntegers.isPrincipalIdealRing_of_isPrincipal_of_norm_le_of_isPrime
     (h : ∀ ⦃I : (Ideal (𝓞 K))⁰⦄, (I : Ideal (𝓞 K)).IsPrime →
       absNorm (I : Ideal (𝓞 K)) ≤ (4 / π) ^ nrComplexPlaces K *
-        ((finrank ℚ K)! / (finrank ℚ K) ^ (finrank ℚ K) * √|discr K|) →
+      ((finrank ℚ K)! / (finrank ℚ K) ^ (finrank ℚ K) * √|discr K|) →
       Submodule.IsPrincipal (I : Ideal (𝓞 K))) :
     IsPrincipalIdealRing (𝓞 K) := by
   refine RingOfIntegers.isPrincipalIdealRing_of_isPrincipal_of_norm_le (fun I hI ↦ ?_)
@@ -101,7 +101,7 @@ theorem _root_.RingOfIntegers.isPrincipalIdealRing_of_abs_discr_lt
     (h : |discr K| < (2 * (π / 4) ^ nrComplexPlaces K *
       ((finrank ℚ K) ^ (finrank ℚ K) / (finrank ℚ K)!)) ^ 2) :
     IsPrincipalIdealRing (𝓞 K) := by
-  have : 0 < finrank ℚ K := finrank_pos -- Lean needs to know that for `positivity` to succeed
+  have : 0 < finrank ℚ K := finrank_pos -- Lean needs to know this for `positivity` to succeed
   rw [← Real.sqrt_lt (by positivity) (by positivity), mul_assoc, ← inv_mul_lt_iff₀' (by positivity),
     mul_inv, ← inv_pow, inv_div, inv_div, mul_assoc, Int.cast_abs] at h
   refine RingOfIntegers.isPrincipalIdealRing_of_isPrincipal_of_norm_le (fun I hI ↦ ?_)

--- a/Mathlib/NumberTheory/NumberField/ClassNumber.lean
+++ b/Mathlib/NumberTheory/NumberField/ClassNumber.lean
@@ -6,6 +6,7 @@ Authors: Anne Baanen
 import Mathlib.NumberTheory.ClassNumber.AdmissibleAbs
 import Mathlib.NumberTheory.ClassNumber.Finite
 import Mathlib.NumberTheory.NumberField.Discriminant.Basic
+import Mathlib.RingTheory.Ideal.IsPrincipal
 
 /-!
 # Class numbers of number fields
@@ -77,6 +78,25 @@ theorem _root_.RingOfIntegers.isPrincipalIdealRing_of_isPrincipal_of_norm_le
   refine ⟨1, fun C ↦ ?_⟩
   obtain ⟨I, rfl, hI⟩ := exists_ideal_in_class_of_norm_le C
   simpa [← ClassGroup.mk0_eq_one_iff] using h _ hI
+
+theorem _root_.RingOfIntegers.isPrincipalIdealRing_of_isPrincipal_of_norm_le_of_prime
+    (h : ∀ (I : (Ideal (𝓞 K))⁰), (I : Ideal (𝓞 K)).IsPrime →
+      absNorm (I : Ideal (𝓞 K)) ≤ (4 / π) ^ nrComplexPlaces K *
+        ((finrank ℚ K)! / (finrank ℚ K) ^ (finrank ℚ K) * √|discr K|) →
+      Submodule.IsPrincipal (I : Ideal (𝓞 K))) :
+    IsPrincipalIdealRing (𝓞 K) := by
+  refine RingOfIntegers.isPrincipalIdealRing_of_isPrincipal_of_norm_le (fun I hI ↦ ?_)
+  rw [← mem_isPrincipalSubmonoid_iff,
+    ← prod_normalizedFactors_eq_self (nonZeroDivisors.coe_ne_zero I)]
+  refine Submonoid.multiset_prod_mem _ _ (fun J hJ ↦ mem_isPrincipalSubmonoid_iff.mp ?_)
+  by_cases hJ0 : J = 0
+  · simpa [hJ0] using bot_isPrincipal
+  rw [← Subtype.coe_mk J (mem_nonZeroDivisors_of_ne_zero hJ0)]
+  refine h _ ?_ ?_
+  · exact ((mem_normalizedFactors_iff (nonZeroDivisors.coe_ne_zero I)).mp hJ).1
+  · exact (cast_le.mpr <| le_of_dvd (absNorm_pos_of_nonZeroDivisors I) <|
+      absNorm_dvd_absNorm_of_le (le_of_dvd (UniqueFactorizationMonoid.dvd_of_mem_normalizedFactors
+      hJ))).trans hI
 
 theorem _root_.RingOfIntegers.isPrincipalIdealRing_of_abs_discr_lt
     (h : |discr K| < (2 * (π / 4) ^ nrComplexPlaces K *

--- a/Mathlib/NumberTheory/NumberField/ClassNumber.lean
+++ b/Mathlib/NumberTheory/NumberField/ClassNumber.lean
@@ -70,17 +70,17 @@ theorem exists_ideal_in_class_of_norm_le (C : ClassGroup (𝓞 K)) :
     exact cast_pos.mpr <| pos_of_ne_zero <| absNorm_ne_zero_of_nonZeroDivisors J
 
 theorem _root_.RingOfIntegers.isPrincipalIdealRing_of_isPrincipal_of_norm_le
-    (h : ∀ I : (Ideal (𝓞 K))⁰, absNorm (I : Ideal (𝓞 K)) ≤ (4 / π) ^ nrComplexPlaces K *
+    (h : ∀ ⦃I : (Ideal (𝓞 K))⁰⦄, absNorm (I : Ideal (𝓞 K)) ≤ (4 / π) ^ nrComplexPlaces K *
         ((finrank ℚ K)! / (finrank ℚ K) ^ (finrank ℚ K) * √|discr K|) →
         Submodule.IsPrincipal (I : Ideal (𝓞 K))) :
     IsPrincipalIdealRing (𝓞 K) := by
   rw [← classNumber_eq_one_iff, classNumber, Fintype.card_eq_one_iff]
   refine ⟨1, fun C ↦ ?_⟩
   obtain ⟨I, rfl, hI⟩ := exists_ideal_in_class_of_norm_le C
-  simpa [← ClassGroup.mk0_eq_one_iff] using h _ hI
+  simpa [← ClassGroup.mk0_eq_one_iff] using h hI
 
 theorem _root_.RingOfIntegers.isPrincipalIdealRing_of_isPrincipal_of_isPrime_of_norm_le
-    (h : ∀ (I : (Ideal (𝓞 K))⁰), (I : Ideal (𝓞 K)).IsPrime →
+    (h : ∀ ⦃I : (Ideal (𝓞 K))⁰⦄, (I : Ideal (𝓞 K)).IsPrime →
       absNorm (I : Ideal (𝓞 K)) ≤ (4 / π) ^ nrComplexPlaces K *
         ((finrank ℚ K)! / (finrank ℚ K) ^ (finrank ℚ K) * √|discr K|) →
       Submodule.IsPrincipal (I : Ideal (𝓞 K))) :
@@ -92,8 +92,7 @@ theorem _root_.RingOfIntegers.isPrincipalIdealRing_of_isPrincipal_of_isPrime_of_
   by_cases hJ0 : J = 0
   · simpa [hJ0] using bot_isPrincipal
   rw [← Subtype.coe_mk J (mem_nonZeroDivisors_of_ne_zero hJ0)]
-  refine h _ ?_ ?_
-  · exact ((mem_normalizedFactors_iff (nonZeroDivisors.coe_ne_zero I)).mp hJ).1
+  refine h (((mem_normalizedFactors_iff (nonZeroDivisors.coe_ne_zero I)).mp hJ).1) ?_
   · exact (cast_le.mpr <| le_of_dvd (absNorm_pos_of_nonZeroDivisors I) <|
       absNorm_dvd_absNorm_of_le (le_of_dvd (UniqueFactorizationMonoid.dvd_of_mem_normalizedFactors
       hJ))).trans hI

--- a/Mathlib/NumberTheory/NumberField/ClassNumber.lean
+++ b/Mathlib/NumberTheory/NumberField/ClassNumber.lean
@@ -40,21 +40,21 @@ variable {K}
 theorem classNumber_eq_one_iff : classNumber K = 1 ↔ IsPrincipalIdealRing (𝓞 K) :=
   card_classGroup_eq_one_iff
 
-open Module NumberField.InfinitePlace
+open Module NumberField.InfinitePlace Ideal Nat
 
 open scoped nonZeroDivisors Real
 
 theorem exists_ideal_in_class_of_norm_le (C : ClassGroup (𝓞 K)) :
     ∃ I : (Ideal (𝓞 K))⁰, ClassGroup.mk0 I = C ∧
-      Ideal.absNorm (I : Ideal (𝓞 K)) ≤ (4 / π) ^ nrComplexPlaces K *
+      absNorm (I : Ideal (𝓞 K)) ≤ (4 / π) ^ nrComplexPlaces K *
         ((finrank ℚ K).factorial / (finrank ℚ K) ^ (finrank ℚ K) * Real.sqrt |discr K|) := by
   obtain ⟨J, hJ⟩ := ClassGroup.mk0_surjective C⁻¹
   obtain ⟨_, ⟨a, ha, rfl⟩, h_nz, h_nm⟩ :=
     exists_ne_zero_mem_ideal_of_norm_le_mul_sqrt_discr K (FractionalIdeal.mk0 K J)
-  obtain ⟨I₀, hI⟩ := Ideal.dvd_iff_le.mpr ((Ideal.span_singleton_le_iff_mem J).mpr (by convert ha))
+  obtain ⟨I₀, hI⟩ := dvd_iff_le.mpr ((span_singleton_le_iff_mem J).mpr (by convert ha))
   have : I₀ ≠ 0 := by
     contrapose! h_nz
-    rw [h_nz, mul_zero, show 0 = (⊥ : Ideal (𝓞 K)) by rfl, Ideal.span_singleton_eq_bot] at hI
+    rw [h_nz, mul_zero, show 0 = (⊥ : Ideal (𝓞 K)) by rfl, span_singleton_eq_bot] at hI
     rw [Algebra.linearMap_apply, hI, map_zero]
   let I := (⟨I₀, mem_nonZeroDivisors_iff_ne_zero.mpr this⟩ : (Ideal (𝓞 K))⁰)
   refine ⟨I, ?_, ?_⟩
@@ -62,15 +62,15 @@ theorem exists_ideal_in_class_of_norm_le (C : ClassGroup (𝓞 K)) :
     exact ClassGroup.mk0_eq_mk0_inv_iff.mpr ⟨a, Subtype.coe_ne_coe.1 h_nz, by rw [mul_comm, hI]⟩
   · rw [← FractionalIdeal.absNorm_span_singleton (𝓞 K), Algebra.linearMap_apply,
       ← FractionalIdeal.coeIdeal_span_singleton, FractionalIdeal.coeIdeal_absNorm, hI, map_mul,
-      Nat.cast_mul, Rat.cast_mul, show Ideal.absNorm I₀ = Ideal.absNorm (I : Ideal (𝓞 K)) by rfl,
+      cast_mul, Rat.cast_mul, show absNorm I₀ = Ideal.absNorm (I : Ideal (𝓞 K)) by rfl,
       Rat.cast_natCast, Rat.cast_natCast, FractionalIdeal.coe_mk0,
       FractionalIdeal.coeIdeal_absNorm, Rat.cast_natCast, mul_div_assoc, mul_assoc, mul_assoc]
       at h_nm
     refine le_of_mul_le_mul_of_pos_left h_nm ?_
-    exact Nat.cast_pos.mpr <| Nat.pos_of_ne_zero <| Ideal.absNorm_ne_zero_of_nonZeroDivisors J
+    exact cast_pos.mpr <| pos_of_ne_zero <| absNorm_ne_zero_of_nonZeroDivisors J
 
 theorem _root_.RingOfIntegers.isPrincipalIdealRing_of_isPrincipal_of_norm_le
-    (h : ∀ I : (Ideal (𝓞 K))⁰, Ideal.absNorm (I : Ideal (𝓞 K)) ≤ (4 / π) ^ nrComplexPlaces K *
+    (h : ∀ I : (Ideal (𝓞 K))⁰, absNorm (I : Ideal (𝓞 K)) ≤ (4 / π) ^ nrComplexPlaces K *
         ((finrank ℚ K).factorial / (finrank ℚ K) ^ (finrank ℚ K) * Real.sqrt |discr K|) →
         Submodule.IsPrincipal (I : Ideal (𝓞 K))) :
     IsPrincipalIdealRing (𝓞 K) := by
@@ -88,9 +88,8 @@ theorem _root_.RingOfIntegers.isPrincipalIdealRing_of_abs_discr_lt
     mul_inv, ← inv_pow, inv_div, inv_div, mul_assoc, Int.cast_abs] at h
   refine RingOfIntegers.isPrincipalIdealRing_of_isPrincipal_of_norm_le (fun I hI ↦ ?_)
   convert top_isPrincipal
-  exact Ideal.absNorm_eq_one_iff.mp (le_antisymm (Nat.lt_succ.mp ((Nat.cast_lt (α := ℝ)).mp
-    (lt_of_le_of_lt hI h))) (Nat.one_le_iff_ne_zero.mpr
-    (Ideal.absNorm_ne_zero_of_nonZeroDivisors I)))
+  exact absNorm_eq_one_iff.mp <| le_antisymm (lt_succ.mp (cast_lt.mp
+    (lt_of_le_of_lt hI h))) <| one_le_iff_ne_zero.mpr (absNorm_ne_zero_of_nonZeroDivisors I)
 
 end NumberField
 

--- a/Mathlib/NumberTheory/NumberField/ClassNumber.lean
+++ b/Mathlib/NumberTheory/NumberField/ClassNumber.lean
@@ -101,7 +101,7 @@ theorem _root_.RingOfIntegers.isPrincipalIdealRing_of_abs_discr_lt
     (h : |discr K| < (2 * (π / 4) ^ nrComplexPlaces K *
       ((finrank ℚ K) ^ (finrank ℚ K) / (finrank ℚ K)!)) ^ 2) :
     IsPrincipalIdealRing (𝓞 K) := by
-  have : 0 < finrank ℚ K := finrank_pos -- Lean needs to know that for positivity to succeed
+  have : 0 < finrank ℚ K := finrank_pos -- Lean needs to know that for `positivity` to succeed
   rw [← Real.sqrt_lt (by positivity) (by positivity), mul_assoc, ← inv_mul_lt_iff₀' (by positivity),
     mul_inv, ← inv_pow, inv_div, inv_div, mul_assoc, Int.cast_abs] at h
   refine RingOfIntegers.isPrincipalIdealRing_of_isPrincipal_of_norm_le (fun I hI ↦ ?_)


### PR DESCRIPTION
We add `RingOfIntegers.isPrincipalIdealRing_of_isPrincipal_of_mem_primesOver`, the standard formulation of Kummer's criterion to prove that the ring of integers of a number field is a principal ideal domain.

---
I also improved the file a bit.


<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
