### PR TITLE
[Merged by Bors] - feat: sliced adjoint functors

### DIFF
--- a/Mathlib/CategoryTheory/Comma/Over/Basic.lean
+++ b/Mathlib/CategoryTheory/Comma/Over/Basic.lean
@@ -399,7 +399,7 @@ def postAdjunctionRight {Y : D} {F : T ⥤ D} {G : D ⥤ T} (a : F ⊣ G) :
   unit.app A := homMk <| a.unit.app A.left
   counit.app A := homMk <| a.counit.app A.left
 
-instance post.instIsRightAdjoint {Y : D} {G : D ⥤ T} [G.IsRightAdjoint] :
+instance isRightAdjoint_post {Y : D} {G : D ⥤ T} [G.IsRightAdjoint] :
     (post (X := Y) G).IsRightAdjoint :=
   let ⟨F, ⟨a⟩⟩ := ‹G.IsRightAdjoint›; ⟨_, ⟨postAdjunctionRight a⟩⟩
 
@@ -766,7 +766,7 @@ def postAdjunctionLeft {X : T}{F : T ⥤ D} {G : D ⥤ T} (a : F ⊣ G) :
   unit.app A := homMk <| a.unit.app A.right
   counit.app A := homMk <| a.counit.app A.right
 
-instance post.instIsLeftAdjoint [F.IsLeftAdjoint] : (post (X := X) F).IsLeftAdjoint :=
+instance isLeftAdjoint_post [F.IsLeftAdjoint] : (post (X := X) F).IsLeftAdjoint :=
   let ⟨G, ⟨a⟩⟩ := ‹F.IsLeftAdjoint›; ⟨_, ⟨postAdjunctionLeft a⟩⟩
 
 /-- An equivalence of categories induces an equivalence on under categories. -/

--- a/Mathlib/CategoryTheory/Comma/Over/Basic.lean
+++ b/Mathlib/CategoryTheory/Comma/Over/Basic.lean
@@ -352,7 +352,7 @@ def postComp {E : Type*} [Category E] (F : T ⥤ D) (G : D ⥤ E) :
   NatIso.ofComponents (fun X ↦ Iso.refl _)
 
 /-- A natural transformation `F ⟶ G` induces a natural transformation on
-`Over X` up to `Under.map`. -/
+`Over X` up to `Over.map`. -/
 @[simps]
 def postMap {F G : T ⥤ D} (e : F ⟶ G) : post F ⋙ map (e.app X) ⟶ post G where
   app Y := Over.homMk (e.app Y.left)
@@ -388,6 +388,20 @@ instance [F.IsEquivalence] : (Over.post (X := X) F).IsEquivalence where
 def _root_.CategoryTheory.Functor.FullyFaithful.over (h : F.FullyFaithful) :
     (post (X := X) F).FullyFaithful where
   preimage {A B} f := Over.homMk (h.preimage f.left) <| h.map_injective (by simpa using Over.w f)
+
+/-- If `G` is right adjoint, then so is `post G : Over Y ⥤ Over (G Y)`.
+
+If the left adjoint of `G` is `F`, then the left adjoint of `post G` is given by
+`(X ⟶ G Y) ↦ (F X ⟶ F G Y ⟶ Y)`. -/
+@[simps]
+def postAdjunctionRight {Y : D} {F : T ⥤ D} {G : D ⥤ T} (a : F ⊣ G) :
+    post F ⋙ map (a.counit.app Y) ⊣ post G where
+  unit.app A := homMk <| a.unit.app A.left
+  counit.app A := homMk <| a.counit.app A.left
+
+instance post.instIsRightAdjoint {Y : D} {G : D ⥤ T} [G.IsRightAdjoint] :
+    (post (X := Y) G).IsRightAdjoint :=
+  let ⟨F, ⟨e⟩⟩ := ‹G.IsRightAdjoint›; ⟨_, ⟨postAdjunctionRight e⟩⟩
 
 /-- An equivalence of categories induces an equivalence on over categories. -/
 @[simps]
@@ -741,6 +755,19 @@ instance [F.IsEquivalence] : (Under.post (X := X) F).IsEquivalence where
 def _root_.CategoryTheory.Functor.FullyFaithful.under (h : F.FullyFaithful) :
     (post (X := X) F).FullyFaithful where
   preimage {A B} f := Under.homMk (h.preimage f.right) <| h.map_injective (by simpa using Under.w f)
+
+/-- If `F` is left adjoint, then so is `post F : Under X ⥤ Under (F X)`.
+
+If the right adjoint of `F` is `G`, then the right adjoint of `post F` is given by
+`(F X ⟶ Y) ↦ (X ⟶ G F X ⟶ G Y)`. -/
+@[simps]
+def postAdjunctionLeft {X : T}{F : T ⥤ D} {G : D ⥤ T} (a : F ⊣ G) :
+    post F ⊣ post G ⋙ map (a.unit.app X) where
+  unit.app A := homMk <| a.unit.app A.right
+  counit.app A := homMk <| a.counit.app A.right
+
+instance post.instIsLeftAdjoint [F.IsLeftAdjoint] : (post (X := X) F).IsLeftAdjoint :=
+  let ⟨G, ⟨a⟩⟩ := ‹F.IsLeftAdjoint›; ⟨_, ⟨postAdjunctionLeft a⟩⟩
 
 /-- An equivalence of categories induces an equivalence on under categories. -/
 @[simps]

--- a/Mathlib/CategoryTheory/Comma/Over/Basic.lean
+++ b/Mathlib/CategoryTheory/Comma/Over/Basic.lean
@@ -401,7 +401,7 @@ def postAdjunctionRight {Y : D} {F : T ⥤ D} {G : D ⥤ T} (a : F ⊣ G) :
 
 instance post.instIsRightAdjoint {Y : D} {G : D ⥤ T} [G.IsRightAdjoint] :
     (post (X := Y) G).IsRightAdjoint :=
-  let ⟨F, ⟨e⟩⟩ := ‹G.IsRightAdjoint›; ⟨_, ⟨postAdjunctionRight e⟩⟩
+  let ⟨F, ⟨a⟩⟩ := ‹G.IsRightAdjoint›; ⟨_, ⟨postAdjunctionRight a⟩⟩
 
 /-- An equivalence of categories induces an equivalence on over categories. -/
 @[simps]

--- a/Mathlib/CategoryTheory/Comma/Over/Basic.lean
+++ b/Mathlib/CategoryTheory/Comma/Over/Basic.lean
@@ -389,7 +389,7 @@ def _root_.CategoryTheory.Functor.FullyFaithful.over (h : F.FullyFaithful) :
     (post (X := X) F).FullyFaithful where
   preimage {A B} f := Over.homMk (h.preimage f.left) <| h.map_injective (by simpa using Over.w f)
 
-/-- If `G` is right adjoint, then so is `post G : Over Y ⥤ Over (G Y)`.
+/-- If `G` is a right adjoint, then so is `post G : Over Y ⥤ Over (G Y)`.
 
 If the left adjoint of `G` is `F`, then the left adjoint of `post G` is given by
 `(X ⟶ G Y) ↦ (F X ⟶ F G Y ⟶ Y)`. -/
@@ -756,12 +756,12 @@ def _root_.CategoryTheory.Functor.FullyFaithful.under (h : F.FullyFaithful) :
     (post (X := X) F).FullyFaithful where
   preimage {A B} f := Under.homMk (h.preimage f.right) <| h.map_injective (by simpa using Under.w f)
 
-/-- If `F` is left adjoint, then so is `post F : Under X ⥤ Under (F X)`.
+/-- If `F` is a left adjoint, then so is `post F : Under X ⥤ Under (F X)`.
 
 If the right adjoint of `F` is `G`, then the right adjoint of `post F` is given by
 `(F X ⟶ Y) ↦ (X ⟶ G F X ⟶ G Y)`. -/
 @[simps]
-def postAdjunctionLeft {X : T}{F : T ⥤ D} {G : D ⥤ T} (a : F ⊣ G) :
+def postAdjunctionLeft {X : T} {F : T ⥤ D} {G : D ⥤ T} (a : F ⊣ G) :
     post F ⊣ post G ⋙ map (a.unit.app X) where
   unit.app A := homMk <| a.unit.app A.right
   counit.app A := homMk <| a.counit.app A.right

--- a/Mathlib/CategoryTheory/Comma/Over/Pullback.lean
+++ b/Mathlib/CategoryTheory/Comma/Over/Pullback.lean
@@ -94,7 +94,7 @@ def postAdjunctionLeft {X : C} {F : C ⥤ D} {G : D ⥤ C} (a : F ⊣ G) :
   ((mapPullbackAdj (a.unit.app X)).comp (postAdjunctionRight a)).ofNatIsoLeft <|
     NatIso.ofComponents fun Y ↦ isoMk (.refl _)
 
-instance post.instIsLeftAdjoint {F : C ⥤ D} [F.IsLeftAdjoint] : (post (X := X) F).IsLeftAdjoint :=
+instance isLeftAdjoint_post {F : C ⥤ D} [F.IsLeftAdjoint] : (post (X := X) F).IsLeftAdjoint :=
   let ⟨G, ⟨a⟩⟩ := ‹F.IsLeftAdjoint›; ⟨_, ⟨postAdjunctionLeft a⟩⟩
 
 open Limits
@@ -193,7 +193,7 @@ def postAdjunctionRight [HasPushouts D] {Y : D} {F : C ⥤ D} {G : D ⥤ C} (a :
 
 omit [HasPushouts C] in
 open pushout in
-instance post.instIsRightAdjoint [HasPushouts D] {Y : D} {G : D ⥤ C} [G.IsRightAdjoint] :
+instance isRightAdjoint_post [HasPushouts D] {Y : D} {G : D ⥤ C} [G.IsRightAdjoint] :
     (post (X := Y) G).IsRightAdjoint :=
   let ⟨F, ⟨a⟩⟩ := ‹G.IsRightAdjoint›; ⟨_, ⟨postAdjunctionRight a⟩⟩
 

--- a/Mathlib/CategoryTheory/Comma/Over/Pullback.lean
+++ b/Mathlib/CategoryTheory/Comma/Over/Pullback.lean
@@ -87,7 +87,11 @@ instance pullbackIsRightAdjoint {X Y : C} (f : X ⟶ Y) : (pullback f).IsRightAd
   ⟨_, ⟨mapPullbackAdj f⟩⟩
 
 open pullback in
-/-- A functor `F : T ⥤ D` induces a functor `Over X ⥤ Over (F.obj X)` in the obvious way. -/
+/-- If `F` is a left adjoint and its source category has pullbacks, then so is
+`post F : Over Y ⥤ Over (G Y)`.
+
+If the right adjoint of `F` is `G`, then the right adjoint of `post F` is given by
+`(Y ⟶ F X) ↦ (G Y ⟶ X ×_{G F X} G Y ⟶ X)`. -/
 @[simps!]
 def postAdjunctionLeft {X : C} {F : C ⥤ D} {G : D ⥤ C} (a : F ⊣ G) :
     post F ⊣ post G ⋙ pullback (a.unit.app X) :=
@@ -183,8 +187,11 @@ instance pushoutIsLeftAdjoint {X Y : C} (f : X ⟶ Y) : (pushout f).IsLeftAdjoin
 
 omit [HasPushouts C] in
 open pushout in
-/-- If `F` is left adjoint and its source category has pullbacks, then so is
-`post F : Over X ⥤ Over (F X)`. -/
+/-- If `G` is a right adjoint and its source category has pushouts, then so is
+`post G : Under Y ⥤ Under (G Y)`.
+
+If the left adjoint of `G` is `F`, then the left adjoint of `post G` is given by
+`(G Y ⟶ X) ↦ (Y ⟶ Y ⨿_{F G Y} F X ⟶ F X)`. -/
 @[simps!]
 def postAdjunctionRight [HasPushouts D] {Y : D} {F : C ⥤ D} {G : D ⥤ C} (a : F ⊣ G) :
     post F ⋙ pushout (a.counit.app Y) ⊣ post G :=


### PR DESCRIPTION
This is Proposition 3.8 in https://ncatlab.org/nlab/show/adjoint+functor.

From Toric

Co-authored-by: Michał Mrugała <kiolterino@gmail.com>


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
