### PR TITLE
[Merged by Bors] - chore(Analysis/Convex): drop unused arguments

### DIFF
--- a/Mathlib/Analysis/Convex/Basic.lean
+++ b/Mathlib/Analysis/Convex/Basic.lean
@@ -40,7 +40,7 @@ open scoped Convex Pointwise
 
 section OrderedSemiring
 
-variable [Semiring 𝕜] [PartialOrder 𝕜] [IsOrderedRing 𝕜]
+variable [Semiring 𝕜] [PartialOrder 𝕜]
 
 section AddCommMonoid
 
@@ -126,7 +126,7 @@ section Module
 
 variable [Module 𝕜 E] [Module 𝕜 F] {s : Set E} {x : E}
 
-theorem convex_iff_openSegment_subset :
+theorem convex_iff_openSegment_subset [ZeroLEOneClass 𝕜] :
     Convex 𝕜 s ↔ ∀ ⦃x⦄, x ∈ s → ∀ ⦃y⦄, y ∈ s → openSegment 𝕜 x y ⊆ s :=
   forall₂_congr fun _ => starConvex_iff_openSegment_subset
 
@@ -143,7 +143,8 @@ theorem convex_iff_pairwise_pos : Convex 𝕜 s ↔
   · rwa [Convex.combo_self hab]
   · exact h hx hy hxy ha hb hab
 
-theorem Convex.starConvex_iff (hs : Convex 𝕜 s) (h : s.Nonempty) : StarConvex 𝕜 x s ↔ x ∈ s :=
+theorem Convex.starConvex_iff [ZeroLEOneClass 𝕜] (hs : Convex 𝕜 s) (h : s.Nonempty) :
+    StarConvex 𝕜 x s ↔ x ∈ s :=
   ⟨fun hxs => hxs.mem h, hs.starConvex⟩
 
 protected theorem Set.Subsingleton.convex {s : Set E} (h : s.Subsingleton) : Convex 𝕜 s :=
@@ -155,7 +156,7 @@ protected theorem Set.Subsingleton.convex {s : Set E} (h : s.Subsingleton) : Con
 theorem convex_zero : Convex 𝕜 (0 : Set E) :=
   convex_singleton _
 
-theorem convex_segment (x y : E) : Convex 𝕜 [x -[𝕜] y] := by
+theorem convex_segment [IsOrderedRing 𝕜] (x y : E) : Convex 𝕜 [x -[𝕜] y] := by
   rintro p ⟨ap, bp, hap, hbp, habp, rfl⟩ q ⟨aq, bq, haq, hbq, habq, rfl⟩ a b ha hb hab
   refine
     ⟨a * ap + b * aq, a * bp + b * bq, add_nonneg (mul_nonneg ha hap) (mul_nonneg hb haq),
@@ -388,7 +389,7 @@ end OrderedSemiring
 
 section OrderedCommSemiring
 
-variable [CommSemiring 𝕜] [PartialOrder 𝕜] [IsOrderedRing 𝕜]
+variable [CommSemiring 𝕜] [PartialOrder 𝕜]
 
 section AddCommMonoid
 
@@ -423,7 +424,7 @@ end StrictOrderedCommSemiring
 
 section OrderedRing
 
-variable [Ring 𝕜] [PartialOrder 𝕜] [IsOrderedRing 𝕜]
+variable [Ring 𝕜] [PartialOrder 𝕜]
 
 section AddCommGroup
 
@@ -432,6 +433,28 @@ variable [AddCommGroup E] [AddCommGroup F] [Module 𝕜 E] [Module 𝕜 F] {s t 
 @[simp]
 theorem convex_vadd (a : E) : Convex 𝕜 (a +ᵥ s) ↔ Convex 𝕜 s :=
   ⟨fun h ↦ by simpa using h.vadd (-a), fun h ↦ h.vadd _⟩
+
+/-- Affine subspaces are convex. -/
+theorem AffineSubspace.convex (Q : AffineSubspace 𝕜 E) : Convex 𝕜 (Q : Set E) :=
+  fun x hx y hy a b _ _ hab ↦ by simpa [Convex.combo_eq_smul_sub_add hab] using Q.2 _ hy hx hx
+
+/-- The preimage of a convex set under an affine map is convex. -/
+theorem Convex.affine_preimage (f : E →ᵃ[𝕜] F) {s : Set F} (hs : Convex 𝕜 s) : Convex 𝕜 (f ⁻¹' s) :=
+  fun _ hx => (hs hx).affine_preimage _
+
+/-- The image of a convex set under an affine map is convex. -/
+theorem Convex.affine_image (f : E →ᵃ[𝕜] F) (hs : Convex 𝕜 s) : Convex 𝕜 (f '' s) := by
+  rintro _ ⟨x, hx, rfl⟩
+  exact (hs hx).affine_image _
+
+theorem Convex.neg (hs : Convex 𝕜 s) : Convex 𝕜 (-s) :=
+  hs.is_linear_preimage IsLinearMap.isLinearMap_neg (𝕜₁ := 𝕜)
+
+theorem Convex.sub (hs : Convex 𝕜 s) (ht : Convex 𝕜 t) : Convex 𝕜 (s - t) := by
+  rw [sub_eq_add_neg]
+  exact hs.add ht.neg
+
+variable [AddRightMono 𝕜]
 
 theorem Convex.add_smul_mem (hs : Convex 𝕜 s) {x y : E} (hx : x ∈ s) (hy : x + y ∈ s) {t : 𝕜}
     (ht : t ∈ Icc (0 : 𝕜) 1) : x + t • y ∈ s := by
@@ -456,33 +479,13 @@ theorem Convex.add_smul_sub_mem (h : Convex 𝕜 s) {x y : E} (hx : x ∈ s) (hy
   rw [add_comm]
   exact h.lineMap_mem hx hy ht
 
-/-- Affine subspaces are convex. -/
-theorem AffineSubspace.convex (Q : AffineSubspace 𝕜 E) : Convex 𝕜 (Q : Set E) :=
-  fun x hx y hy a b _ _ hab ↦ by simpa [Convex.combo_eq_smul_sub_add hab] using Q.2 _ hy hx hx
-
-/-- The preimage of a convex set under an affine map is convex. -/
-theorem Convex.affine_preimage (f : E →ᵃ[𝕜] F) {s : Set F} (hs : Convex 𝕜 s) : Convex 𝕜 (f ⁻¹' s) :=
-  fun _ hx => (hs hx).affine_preimage _
-
-/-- The image of a convex set under an affine map is convex. -/
-theorem Convex.affine_image (f : E →ᵃ[𝕜] F) (hs : Convex 𝕜 s) : Convex 𝕜 (f '' s) := by
-  rintro _ ⟨x, hx, rfl⟩
-  exact (hs hx).affine_image _
-
-theorem Convex.neg (hs : Convex 𝕜 s) : Convex 𝕜 (-s) :=
-  hs.is_linear_preimage IsLinearMap.isLinearMap_neg (𝕜₁ := 𝕜)
-
-theorem Convex.sub (hs : Convex 𝕜 s) (ht : Convex 𝕜 t) : Convex 𝕜 (s - t) := by
-  rw [sub_eq_add_neg]
-  exact hs.add ht.neg
-
 end AddCommGroup
 
 end OrderedRing
 
 section LinearOrderedSemiring
 
-variable [Semiring 𝕜] [LinearOrder 𝕜] [IsStrictOrderedRing 𝕜] [AddCommMonoid E]
+variable [Semiring 𝕜] [LinearOrder 𝕜] [IsOrderedRing 𝕜] [AddCommMonoid E]
 
 theorem Convex_subadditive_le [SMul 𝕜 E] {f : E → 𝕜} (hf1 : ∀ x y, f (x + y) ≤ (f x) + (f y))
     (hf2 : ∀ ⦃c⦄ x, 0 ≤ c → f (c • x) ≤ c * f x) (B : 𝕜) :
@@ -491,8 +494,7 @@ theorem Convex_subadditive_le [SMul 𝕜 E] {f : E → 𝕜} (hf1 : ∀ x y, f (
   rintro x hx y hy z ⟨a, b, ha, hb, hs, rfl⟩
   calc
     _ ≤ a • (f x) + b • (f y) := le_trans (hf1 _ _) (add_le_add (hf2 x ha) (hf2 y hb))
-    _ ≤ a • B + b • B :=
-        add_le_add (smul_le_smul_of_nonneg_left hx ha) (smul_le_smul_of_nonneg_left hy hb)
+    _ ≤ a • B + b • B := by gcongr <;> assumption
     _ ≤ B := by rw [← add_smul, hs, one_smul]
 
 end LinearOrderedSemiring
@@ -549,7 +551,7 @@ Relates `Convex` and `OrdConnected`.
 
 section
 
-theorem Set.OrdConnected.convex_of_chain [Semiring 𝕜] [PartialOrder 𝕜] [IsOrderedRing 𝕜]
+theorem Set.OrdConnected.convex_of_chain [Semiring 𝕜] [PartialOrder 𝕜]
     [AddCommMonoid E] [PartialOrder E] [IsOrderedAddMonoid E] [Module 𝕜 E]
     [OrderedSMul 𝕜 E] {s : Set E} (hs : s.OrdConnected) (h : IsChain (· ≤ ·) s) : Convex 𝕜 s := by
   refine convex_iff_segment_subset.mpr fun x hx y hy => ?_
@@ -558,7 +560,7 @@ theorem Set.OrdConnected.convex_of_chain [Semiring 𝕜] [PartialOrder 𝕜] [Is
   · rw [segment_symm]
     exact (segment_subset_Icc hyx).trans (hs.out hy hx)
 
-theorem Set.OrdConnected.convex [Semiring 𝕜] [PartialOrder 𝕜] [IsOrderedRing 𝕜]
+theorem Set.OrdConnected.convex [Semiring 𝕜] [PartialOrder 𝕜]
     [AddCommMonoid E] [LinearOrder E] [IsOrderedAddMonoid E] [Module 𝕜 E]
     [OrderedSMul 𝕜 E] {s : Set E} (hs : s.OrdConnected) : Convex 𝕜 s :=
   hs.convex_of_chain <| isChain_of_trichotomous s
@@ -576,7 +578,7 @@ end
 
 namespace Submodule
 
-variable [Semiring 𝕜] [PartialOrder 𝕜] [IsOrderedRing 𝕜] [AddCommMonoid E] [Module 𝕜 E]
+variable [Semiring 𝕜] [PartialOrder 𝕜] [AddCommMonoid E] [Module 𝕜 E]
 
 protected theorem convex (K : Submodule 𝕜 E) : Convex 𝕜 (↑K : Set E) := by
   repeat' intro
@@ -594,48 +596,48 @@ section Simplex
 
 section OrderedSemiring
 
-variable (𝕜) (ι : Type*) [Semiring 𝕜] [PartialOrder 𝕜] [IsOrderedRing 𝕜] [Fintype ι]
+variable (𝕜) (ι : Type*) [Semiring 𝕜] [PartialOrder 𝕜] [Fintype ι]
 
 /-- The standard simplex in the space of functions `ι → 𝕜` is the set of vectors with non-negative
 coordinates with total sum `1`. This is the free object in the category of convex spaces. -/
 def stdSimplex : Set (ι → 𝕜) :=
   { f | (∀ x, 0 ≤ f x) ∧ ∑ x, f x = 1 }
 
-omit [IsOrderedRing 𝕜] in
 theorem stdSimplex_eq_inter : stdSimplex 𝕜 ι = (⋂ x, { f | 0 ≤ f x }) ∩ { f | ∑ x, f x = 1 } := by
   ext f
   simp only [stdSimplex, Set.mem_inter_iff, Set.mem_iInter, Set.mem_setOf_eq]
 
-theorem convex_stdSimplex : Convex 𝕜 (stdSimplex 𝕜 ι) := by
+theorem convex_stdSimplex [IsOrderedRing 𝕜] : Convex 𝕜 (stdSimplex 𝕜 ι) := by
   refine fun f hf g hg a b ha hb hab => ⟨fun x => ?_, ?_⟩
   · apply_rules [add_nonneg, mul_nonneg, hf.1, hg.1]
   · simp_rw [Pi.add_apply, Pi.smul_apply]
     rwa [Finset.sum_add_distrib, ← Finset.smul_sum, ← Finset.smul_sum, hf.2, hg.2, smul_eq_mul,
       smul_eq_mul, mul_one, mul_one]
 
-omit [IsOrderedRing 𝕜] in
 @[nontriviality] lemma stdSimplex_of_subsingleton [Subsingleton 𝕜] : stdSimplex 𝕜 ι = univ :=
   eq_univ_of_forall fun _ ↦ ⟨fun _ ↦ (Subsingleton.elim _ _).le, Subsingleton.elim _ _⟩
 
-omit [IsOrderedRing 𝕜] in
 /-- The standard simplex in the zero-dimensional space is empty. -/
 lemma stdSimplex_of_isEmpty_index [IsEmpty ι] [Nontrivial 𝕜] : stdSimplex 𝕜 ι = ∅ :=
   eq_empty_of_forall_not_mem <| by rintro f ⟨-, hf⟩; simp at hf
 
-lemma stdSimplex_unique [Nonempty ι] [Subsingleton ι] : stdSimplex 𝕜 ι = {fun _ ↦ 1} := by
+lemma stdSimplex_unique [ZeroLEOneClass 𝕜] [Nonempty ι] [Subsingleton ι] :
+    stdSimplex 𝕜 ι = {fun _ ↦ 1} := by
   cases nonempty_unique ι
   refine eq_singleton_iff_unique_mem.2 ⟨⟨fun _ ↦ zero_le_one, Fintype.sum_unique _⟩, ?_⟩
   rintro f ⟨-, hf⟩
   rw [Fintype.sum_unique] at hf
   exact funext (Unique.forall_iff.2 hf)
 
-variable {ι} [DecidableEq ι]
+variable {ι} [DecidableEq ι] [ZeroLEOneClass 𝕜]
 
 theorem single_mem_stdSimplex (i : ι) : Pi.single i 1 ∈ stdSimplex 𝕜 ι :=
   ⟨le_update_iff.2 ⟨zero_le_one, fun _ _ ↦ le_rfl⟩, by simp⟩
 
 theorem ite_eq_mem_stdSimplex (i : ι) : (if i = · then (1 : 𝕜) else 0) ∈ stdSimplex 𝕜 ι := by
   simpa only [@eq_comm _ i, ← Pi.single_apply] using single_mem_stdSimplex 𝕜 i
+
+variable [IsOrderedRing 𝕜]
 
 #adaptation_note /-- nightly-2024-03-11
 we need a type annotation on the segment in the following two lemmas. -/

--- a/Mathlib/Analysis/Convex/Between.lean
+++ b/Mathlib/Analysis/Convex/Between.lean
@@ -30,40 +30,16 @@ open AffineEquiv AffineMap
 
 section OrderedRing
 
--- TODO: remove `[IsOrderedRing R]` and `@[nolint unusedArguments]`.
 /-- The segment of points weakly between `x` and `y`. When convexity is refactored to support
 abstract affine combination spaces, this will no longer need to be a separate definition from
 `segment`. However, lemmas involving `+ᵥ` or `-ᵥ` will still be relevant after such a
 refactoring, as distinct from versions involving `+` or `-` in a module. -/
-@[nolint unusedArguments]
-def affineSegment [Ring R] [PartialOrder R] [IsOrderedRing R] [AddCommGroup V] [Module R V]
+def affineSegment [Ring R] [PartialOrder R] [AddCommGroup V] [Module R V]
     [AddTorsor V P] (x y : P) :=
   lineMap x y '' Set.Icc (0 : R) 1
 
-variable [Ring R] [PartialOrder R] [IsOrderedRing R] [AddCommGroup V] [Module R V] [AddTorsor V P]
+variable [Ring R] [PartialOrder R] [AddCommGroup V] [Module R V] [AddTorsor V P]
 variable [AddCommGroup V'] [Module R V'] [AddTorsor V' P']
-
-theorem affineSegment_eq_segment (x y : V) : affineSegment R x y = segment R x y := by
-  rw [segment_eq_image_lineMap, affineSegment]
-
-theorem affineSegment_comm (x y : P) : affineSegment R x y = affineSegment R y x := by
-  refine Set.ext fun z => ?_
-  constructor <;>
-    · rintro ⟨t, ht, hxy⟩
-      refine ⟨1 - t, ?_, ?_⟩
-      · rwa [Set.sub_mem_Icc_iff_right, sub_self, sub_zero]
-      · rwa [lineMap_apply_one_sub]
-
-theorem left_mem_affineSegment (x y : P) : x ∈ affineSegment R x y :=
-  ⟨0, Set.left_mem_Icc.2 zero_le_one, lineMap_apply_zero _ _⟩
-
-theorem right_mem_affineSegment (x y : P) : y ∈ affineSegment R x y :=
-  ⟨1, Set.right_mem_Icc.2 zero_le_one, lineMap_apply_one _ _⟩
-
-@[simp]
-theorem affineSegment_same (x : P) : affineSegment R x x = {x} := by
-  simp_rw [affineSegment, lineMap_same, AffineMap.coe_const, Function.const,
-    (Set.nonempty_Icc.mpr zero_le_one).image_const]
 
 variable {R} in
 @[simp]
@@ -116,6 +92,33 @@ theorem mem_vsub_const_affineSegment {x y z : P} (p : P) :
 
 variable (R)
 
+section OrderedRing
+variable [IsOrderedRing R]
+
+theorem affineSegment_eq_segment (x y : V) : affineSegment R x y = segment R x y := by
+  rw [segment_eq_image_lineMap, affineSegment]
+
+theorem affineSegment_comm (x y : P) : affineSegment R x y = affineSegment R y x := by
+  refine Set.ext fun z => ?_
+  constructor <;>
+    · rintro ⟨t, ht, hxy⟩
+      refine ⟨1 - t, ?_, ?_⟩
+      · rwa [Set.sub_mem_Icc_iff_right, sub_self, sub_zero]
+      · rwa [lineMap_apply_one_sub]
+
+theorem left_mem_affineSegment (x y : P) : x ∈ affineSegment R x y :=
+  ⟨0, Set.left_mem_Icc.2 zero_le_one, lineMap_apply_zero _ _⟩
+
+theorem right_mem_affineSegment (x y : P) : y ∈ affineSegment R x y :=
+  ⟨1, Set.right_mem_Icc.2 zero_le_one, lineMap_apply_one _ _⟩
+
+@[simp]
+theorem affineSegment_same (x : P) : affineSegment R x x = {x} := by
+  simp_rw [affineSegment, lineMap_same, AffineMap.coe_const, Function.const,
+    (Set.nonempty_Icc.mpr zero_le_one).image_const]
+
+end OrderedRing
+
 /-- The point `y` is weakly between `x` and `z`. -/
 def Wbtw (x y z : P) : Prop :=
   y ∈ affineSegment R x z
@@ -126,6 +129,10 @@ def Sbtw (x y z : P) : Prop :=
 
 variable {R}
 
+section OrderedRing
+
+variable [IsOrderedRing R]
+
 lemma mem_segment_iff_wbtw {x y z : V} : y ∈ segment R x z ↔ Wbtw R x y z := by
   rw [Wbtw, affineSegment_eq_segment]
 
@@ -133,6 +140,18 @@ alias ⟨_, Wbtw.mem_segment⟩ := mem_segment_iff_wbtw
 
 lemma Convex.mem_of_wbtw {p₀ p₁ p₂ : V} {s : Set V} (hs : Convex R s) (h₀₁₂ : Wbtw R p₀ p₁ p₂)
     (h₀ : p₀ ∈ s) (h₂ : p₂ ∈ s) : p₁ ∈ s := hs.segment_subset h₀ h₂ h₀₁₂.mem_segment
+
+theorem wbtw_comm {x y z : P} : Wbtw R x y z ↔ Wbtw R z y x := by
+  rw [Wbtw, Wbtw, affineSegment_comm]
+
+alias ⟨Wbtw.symm, _⟩ := wbtw_comm
+
+theorem sbtw_comm {x y z : P} : Sbtw R x y z ↔ Sbtw R z y x := by
+  rw [Sbtw, Sbtw, wbtw_comm, ← and_assoc, ← and_assoc, and_right_comm]
+
+alias ⟨Sbtw.symm, _⟩ := sbtw_comm
+
+end OrderedRing
 
 lemma AffineSubspace.mem_of_wbtw {s : AffineSubspace R P} {x y z : P} (hxyz : Wbtw R x y z)
     (hx : x ∈ s) (hz : z ∈ s) : y ∈ s := by obtain ⟨ε, -, rfl⟩ := hxyz; exact lineMap_mem _ hx hz
@@ -237,17 +256,11 @@ theorem Wbtw.mem_affineSpan {x y z : P} (h : Wbtw R x y z) : y ∈ line[R, x, z]
   rcases h with ⟨r, ⟨-, rfl⟩⟩
   exact lineMap_mem_affineSpan_pair _ _ _
 
-theorem wbtw_comm {x y z : P} : Wbtw R x y z ↔ Wbtw R z y x := by
-  rw [Wbtw, Wbtw, affineSegment_comm]
-
-alias ⟨Wbtw.symm, _⟩ := wbtw_comm
-
-theorem sbtw_comm {x y z : P} : Sbtw R x y z ↔ Sbtw R z y x := by
-  rw [Sbtw, Sbtw, wbtw_comm, ← and_assoc, ← and_assoc, and_right_comm]
-
-alias ⟨Sbtw.symm, _⟩ := sbtw_comm
-
 variable (R)
+
+section OrderedRing
+
+variable [IsOrderedRing R]
 
 @[simp]
 theorem wbtw_self_left (x y : P) : Wbtw R x x y :=
@@ -264,6 +277,8 @@ theorem wbtw_self_iff {x y : P} : Wbtw R x y x ↔ y = x := by
   · rw [h]
     exact wbtw_self_left R x x
 
+end OrderedRing
+
 @[simp]
 theorem not_sbtw_self_left (x y : P) : ¬Sbtw R x x y :=
   fun h => h.ne_left rfl
@@ -273,6 +288,7 @@ theorem not_sbtw_self_right (x y : P) : ¬Sbtw R x y y :=
   fun h => h.ne_right rfl
 
 variable {R}
+variable [IsOrderedRing R]
 
 theorem Wbtw.left_ne_right_of_ne_left {x y z : P} (h : Wbtw R x y z) (hne : y ≠ x) : x ≠ z := by
   rintro rfl
@@ -377,6 +393,7 @@ theorem sbtw_mul_sub_add_iff [NoZeroDivisors R] {x y r : R} :
     Sbtw R x (r * (y - x) + x) y ↔ x ≠ y ∧ r ∈ Set.Ioo (0 : R) 1 :=
   sbtw_lineMap_iff
 
+omit [IsOrderedRing R] in
 @[simp]
 theorem wbtw_zero_one_iff {x : R} : Wbtw R 0 x 1 ↔ x ∈ Set.Icc (0 : R) 1 := by
   rw [Wbtw, affineSegment, Set.mem_image]
@@ -387,6 +404,7 @@ theorem wbtw_zero_one_iff {x : R} : Wbtw R 0 x 1 ↔ x ∈ Set.Icc (0 : R) 1 := 
 theorem wbtw_one_zero_iff {x : R} : Wbtw R 1 x 0 ↔ x ∈ Set.Icc (0 : R) 1 := by
   rw [wbtw_comm, wbtw_zero_one_iff]
 
+omit [IsOrderedRing R] in
 @[simp]
 theorem sbtw_zero_one_iff {x : R} : Sbtw R 0 x 1 ↔ x ∈ Set.Ioo (0 : R) 1 := by
   rw [Sbtw, wbtw_zero_one_iff, Set.mem_Icc, Set.mem_Ioo]
@@ -675,6 +693,7 @@ theorem Sbtw.left_mem_image_Ioi {x y z : P} (h : Sbtw R x y z) :
 theorem Sbtw.left_mem_affineSpan {x y z : P} (h : Sbtw R x y z) : x ∈ line[R, z, y] :=
   h.symm.right_mem_affineSpan
 
+omit [IsStrictOrderedRing R] in
 lemma AffineSubspace.right_mem_of_wbtw {s : AffineSubspace R P} (hxyz : Wbtw R x y z) (hx : x ∈ s)
     (hy : y ∈ s) (hxy : x ≠ y) : z ∈ s := by
   obtain ⟨ε, -, rfl⟩ := hxyz
@@ -753,6 +772,7 @@ theorem Sbtw.trans_right_left {w x y z : P} (h₁ : Sbtw R w x z) (h₂ : Sbtw R
     Sbtw R w x y :=
   ⟨h₁.wbtw.trans_right_left h₂.wbtw, h₁.ne_left, h₂.left_ne⟩
 
+omit [IsStrictOrderedRing R] in
 theorem Wbtw.collinear {x y z : P} (h : Wbtw R x y z) : Collinear R ({x, y, z} : Set P) := by
   rw [collinear_iff_exists_forall_eq_smul_vadd]
   refine ⟨x, z -ᵥ x, ?_⟩

--- a/Mathlib/Analysis/Convex/BetweenList.lean
+++ b/Mathlib/Analysis/Convex/BetweenList.lean
@@ -27,7 +27,7 @@ namespace List
 
 section OrderedRing
 
-variable [Ring R] [PartialOrder R] [IsOrderedRing R] [AddCommGroup V] [Module R V] [AddTorsor V P]
+variable [Ring R] [PartialOrder R] [AddCommGroup V] [Module R V] [AddTorsor V P]
 variable [AddCommGroup V'] [Module R V'] [AddTorsor V' P']
 
 /-- The points in a list are weakly in that order on a line. -/
@@ -72,7 +72,8 @@ variable {R}
 @[simp] lemma wbtw_triple {p₁ p₂ p₃ : P} : [p₁, p₂, p₃].Wbtw R ↔ Wbtw R p₁ p₂ p₃ := by
   simp [List.Wbtw]
 
-@[simp] lemma sbtw_triple {p₁ p₂ p₃ : P} : [p₁, p₂, p₃].Sbtw R ↔ Sbtw R p₁ p₂ p₃ := by
+@[simp]
+lemma sbtw_triple [IsOrderedRing R] {p₁ p₂ p₃ : P} : [p₁, p₂, p₃].Sbtw R ↔ Sbtw R p₁ p₂ p₃ := by
   simp only [List.Sbtw, wbtw_triple, ne_eq, pairwise_cons, mem_cons, not_mem_nil, or_false,
     forall_eq_or_imp, forall_eq, IsEmpty.forall_iff, implies_true, Pairwise.nil, and_self, and_true]
   exact ⟨fun ⟨hw, ⟨h₁₂, h₁₃⟩, h₂₃⟩ ↦ ⟨hw, Ne.symm h₁₂, h₂₃⟩,
@@ -82,7 +83,7 @@ lemma wbtw_four {p₁ p₂ p₃ p₄ : P} : [p₁, p₂, p₃, p₄].Wbtw R ↔
     Wbtw R p₁ p₂ p₃ ∧ Wbtw R p₁ p₂ p₄ ∧ Wbtw R p₁ p₃ p₄ ∧ Wbtw R p₂ p₃ p₄ := by
   simp [List.Wbtw, triplewise_cons, and_assoc]
 
-lemma sbtw_four {p₁ p₂ p₃ p₄ : P} : [p₁, p₂, p₃, p₄].Sbtw R ↔
+lemma sbtw_four [IsOrderedRing R] {p₁ p₂ p₃ p₄ : P} : [p₁, p₂, p₃, p₄].Sbtw R ↔
     Sbtw R p₁ p₂ p₃ ∧ Sbtw R p₁ p₂ p₄ ∧ Sbtw R p₁ p₃ p₄ ∧ Sbtw R p₂ p₃ p₄ := by
   simp [List.Sbtw, List.Wbtw, triplewise_cons, Sbtw]
   aesop
@@ -93,7 +94,7 @@ protected lemma Sbtw.wbtw {l : List P} (h : l.Sbtw R) : l.Wbtw R :=
 lemma Sbtw.pairwise_ne {l : List P} (h : l.Sbtw R) : l.Pairwise (· ≠ ·) :=
   h.2
 
-lemma sbtw_iff_triplewise_and_ne_pair {l : List P} :
+lemma sbtw_iff_triplewise_and_ne_pair [IsOrderedRing R] {l : List P} :
     l.Sbtw R ↔ l.Triplewise (Sbtw R) ∧ ∀ a, l ≠ [a, a] := by
   rw [List.Sbtw]
   induction l with
@@ -141,7 +142,7 @@ lemma sbtw_iff_triplewise_and_ne_pair {l : List P} :
       · rintro rfl
         simp at hp
 
-lemma sbtw_cons {p : P} {l : List P} :
+lemma sbtw_cons [IsOrderedRing R] {p : P} {l : List P} :
     (p :: l).Sbtw R ↔ l.Pairwise (Sbtw R p) ∧ l.Sbtw R ∧ l ≠ [p] := by
   rw [sbtw_iff_triplewise_and_ne_pair, ← not_exists, triplewise_cons]
   simp only [cons.injEq, exists_eq_left', and_assoc, and_congr_right_iff, ne_eq, and_congr_left_iff]

--- a/Mathlib/Analysis/Convex/Function.lean
+++ b/Mathlib/Analysis/Convex/Function.lean
@@ -32,7 +32,7 @@ variable {𝕜 E F α β ι : Type*}
 
 section OrderedSemiring
 
-variable [Semiring 𝕜] [PartialOrder 𝕜] [IsOrderedRing 𝕜]
+variable [Semiring 𝕜] [PartialOrder 𝕜]
 
 section AddCommMonoid
 
@@ -549,12 +549,12 @@ theorem ConcaveOn.openSegment_subset_strict_hypograph (hf : ConcaveOn 𝕜 s f) 
     openSegment 𝕜 p q ⊆ { p : E × β | p.1 ∈ s ∧ p.2 < f p.1 } :=
   hf.dual.openSegment_subset_strict_epigraph p q hp hq
 
-theorem ConvexOn.convex_strict_epigraph (hf : ConvexOn 𝕜 s f) :
+theorem ConvexOn.convex_strict_epigraph [ZeroLEOneClass 𝕜] (hf : ConvexOn 𝕜 s f) :
     Convex 𝕜 { p : E × β | p.1 ∈ s ∧ f p.1 < p.2 } :=
   convex_iff_openSegment_subset.mpr fun p hp q hq =>
     hf.openSegment_subset_strict_epigraph p q hp ⟨hq.1, hq.2.le⟩
 
-theorem ConcaveOn.convex_strict_hypograph (hf : ConcaveOn 𝕜 s f) :
+theorem ConcaveOn.convex_strict_hypograph [ZeroLEOneClass 𝕜] (hf : ConcaveOn 𝕜 s f) :
     Convex 𝕜 { p : E × β | p.1 ∈ s ∧ p.2 < f p.1 } :=
   hf.dual.convex_strict_epigraph
 
@@ -893,7 +893,7 @@ end OrderedSemiring
 
 section OrderedCommSemiring
 
-variable [CommSemiring 𝕜] [PartialOrder 𝕜] [IsOrderedRing 𝕜] [AddCommMonoid E]
+variable [CommSemiring 𝕜] [PartialOrder 𝕜] [AddCommMonoid E]
 
 section OrderedAddCommMonoid
 
@@ -922,7 +922,7 @@ end OrderedCommSemiring
 
 section OrderedRing
 
-variable [Field 𝕜] [LinearOrder 𝕜] [IsStrictOrderedRing 𝕜] [AddCommGroup E] [AddCommGroup F]
+variable [Field 𝕜] [LinearOrder 𝕜] [AddCommGroup E] [AddCommGroup F]
 
 section OrderedAddCommMonoid
 
@@ -1007,7 +1007,7 @@ end LinearOrderedField
 
 section OrderIso
 
-variable [Semiring 𝕜] [PartialOrder 𝕜] [IsOrderedRing 𝕜]
+variable [Semiring 𝕜] [PartialOrder 𝕜]
   [AddCommMonoid α] [PartialOrder α] [SMul 𝕜 α]
   [AddCommMonoid β] [PartialOrder β] [SMul 𝕜 β]
 

--- a/Mathlib/Analysis/Convex/Hull.lean
+++ b/Mathlib/Analysis/Convex/Hull.lean
@@ -30,7 +30,7 @@ section convexHull
 
 section OrderedSemiring
 
-variable [Semiring 𝕜] [PartialOrder 𝕜] [IsOrderedRing 𝕜]
+variable [Semiring 𝕜] [PartialOrder 𝕜]
 
 section AddCommMonoid
 
@@ -105,7 +105,7 @@ theorem convexHull_zero : convexHull 𝕜 (0 : Set E) = 0 :=
   convexHull_singleton 0
 
 @[simp]
-theorem convexHull_pair (x y : E) : convexHull 𝕜 {x, y} = segment 𝕜 x y := by
+theorem convexHull_pair [IsOrderedRing 𝕜] (x y : E) : convexHull 𝕜 {x, y} = segment 𝕜 x y := by
   refine (convexHull_min ?_ <| convex_segment _ _).antisymm
     (segment_subset_convexHull (mem_insert _ _) <| subset_insert _ _ <| mem_singleton _)
   rw [insert_subset_iff, singleton_subset_iff]
@@ -157,18 +157,18 @@ end AddCommMonoid
 
 end OrderedSemiring
 
-section OrderedCommSemiring
+section CommSemiring
 
-variable [CommSemiring 𝕜] [PartialOrder 𝕜] [IsOrderedRing 𝕜] [AddCommMonoid E] [Module 𝕜 E]
+variable [CommSemiring 𝕜] [PartialOrder 𝕜] [AddCommMonoid E] [Module 𝕜 E]
 
 theorem convexHull_smul (a : 𝕜) (s : Set E) : convexHull 𝕜 (a • s) = a • convexHull 𝕜 s :=
   (LinearMap.lsmul _ _ a).image_convexHull _ |>.symm
 
-end OrderedCommSemiring
+end CommSemiring
 
 section OrderedRing
 
-variable [Ring 𝕜] [PartialOrder 𝕜] [IsOrderedRing 𝕜]
+variable [Ring 𝕜] [PartialOrder 𝕜]
 
 section AddCommGroup
 

--- a/Mathlib/Analysis/Convex/Independent.lean
+++ b/Mathlib/Analysis/Convex/Independent.lean
@@ -46,7 +46,7 @@ variable {𝕜 E ι : Type*}
 
 section OrderedSemiring
 
-variable (𝕜) [Semiring 𝕜] [PartialOrder 𝕜] [IsOrderedRing 𝕜] [AddCommGroup E] [Module 𝕜 E]
+variable (𝕜) [Semiring 𝕜] [PartialOrder 𝕜] [AddCommGroup E] [Module 𝕜 E]
 
 /-- An indexed family is said to be convex independent if every point only belongs to convex hulls
 of sets containing it. -/

--- a/Mathlib/Analysis/Convex/Join.lean
+++ b/Mathlib/Analysis/Convex/Join.lean
@@ -86,6 +86,7 @@ theorem convexJoin_iUnion_right (s : Set E) (t : ι → Set E) :
 theorem segment_subset_convexJoin (hx : x ∈ s) (hy : y ∈ t) : segment 𝕜 x y ⊆ convexJoin 𝕜 s t :=
   subset_iUnion₂_of_subset x hx <| subset_iUnion₂ (s := fun y _ ↦ segment 𝕜 x y) y hy
 
+section
 variable [IsOrderedRing 𝕜]
 
 theorem subset_convexJoin_left (h : t.Nonempty) : s ⊆ convexJoin 𝕜 s t := fun _x hx =>
@@ -94,6 +95,8 @@ theorem subset_convexJoin_left (h : t.Nonempty) : s ⊆ convexJoin 𝕜 s t := f
 
 theorem subset_convexJoin_right (h : s.Nonempty) : t ⊆ convexJoin 𝕜 s t :=
   convexJoin_comm (𝕜 := 𝕜) t s ▸ subset_convexJoin_left h
+
+end
 
 theorem convexJoin_subset (hs : s ⊆ u) (ht : t ⊆ u) (hu : Convex 𝕜 u) : convexJoin 𝕜 s t ⊆ u :=
   iUnion₂_subset fun _x hx => iUnion₂_subset fun _y hy => hu.segment_subset (hs hx) (ht hy)

--- a/Mathlib/Analysis/Convex/Piecewise.lean
+++ b/Mathlib/Analysis/Convex/Piecewise.lean
@@ -27,7 +27,7 @@ This file proves convex and concave theorems for piecewise functions.
 -/
 
 
-variable {𝕜 E β : Type*} [Semiring 𝕜] [PartialOrder 𝕜] [IsOrderedRing 𝕜]
+variable {𝕜 E β : Type*} [Semiring 𝕜] [PartialOrder 𝕜]
   [AddCommMonoid E] [LinearOrder E] [IsOrderedAddMonoid E] [Module 𝕜 E]
   [OrderedSMul 𝕜 E] [AddCommGroup β] [PartialOrder β] [IsOrderedAddMonoid β]
   [Module 𝕜 β] [PosSMulMono 𝕜 β] {e : E} {f g : E → β}

--- a/Mathlib/Analysis/Convex/Quasiconvex.lean
+++ b/Mathlib/Analysis/Convex/Quasiconvex.lean
@@ -33,7 +33,7 @@ variable {𝕜 E β : Type*}
 
 section OrderedSemiring
 
-variable [Semiring 𝕜] [PartialOrder 𝕜] [IsOrderedRing 𝕜]
+variable [Semiring 𝕜] [PartialOrder 𝕜]
 
 section AddCommMonoid_E
 

--- a/Mathlib/Analysis/Convex/Segment.lean
+++ b/Mathlib/Analysis/Convex/Segment.lean
@@ -98,7 +98,7 @@ open Convex
 section MulActionWithZero
 
 variable (𝕜)
-variable [IsOrderedRing 𝕜] [MulActionWithZero 𝕜 E]
+variable [ZeroLEOneClass 𝕜] [MulActionWithZero 𝕜 E]
 
 
 theorem left_mem_segment (x y : E) : x ∈ [x -[𝕜] y] :=
@@ -112,7 +112,7 @@ end MulActionWithZero
 section Module
 
 variable (𝕜)
-variable [IsOrderedRing 𝕜] [Module 𝕜 E] {s : Set E} {x y z : E}
+variable [ZeroLEOneClass 𝕜] [Module 𝕜 E] {s : Set E} {x y z : E}
 
 @[simp]
 theorem segment_same (x : E) : [x -[𝕜] x] = {x} :=
@@ -152,12 +152,12 @@ open Convex
 
 section OrderedRing
 
-variable (𝕜) [Ring 𝕜] [PartialOrder 𝕜] [IsOrderedRing 𝕜]
+variable (𝕜) [Ring 𝕜] [PartialOrder 𝕜] [AddRightMono 𝕜]
   [AddCommGroup E] [AddCommGroup F] [AddCommGroup G] [Module 𝕜 E] [Module 𝕜 F]
 
 section DenselyOrdered
 
-variable [Nontrivial 𝕜] [DenselyOrdered 𝕜]
+variable [ZeroLEOneClass 𝕜] [Nontrivial 𝕜] [DenselyOrdered 𝕜]
 
 @[simp]
 theorem openSegment_same (x : E) : openSegment 𝕜 x x = {x} :=
@@ -253,11 +253,9 @@ theorem openSegment_translate_image (a b c : E) :
     (fun x => a + x) '' openSegment 𝕜 b c = openSegment 𝕜 (a + b) (a + c) :=
   openSegment_translate_preimage 𝕜 a b c ▸ image_preimage_eq _ <| add_left_surjective a
 
-lemma segment_inter_eq_endpoint_of_linearIndependent_sub
+lemma segment_inter_subset_endpoint_of_linearIndependent_sub
     {c x y : E} (h : LinearIndependent 𝕜 ![x - c, y - c]) :
-    [c -[𝕜] x] ∩ [c -[𝕜] y] = {c} := by
-  apply Subset.antisymm; swap
-  · simp [singleton_subset_iff, left_mem_segment]
+    [c -[𝕜] x] ∩ [c -[𝕜] y] ⊆ {c} := by
   intro z ⟨hzt, hzs⟩
   rw [segment_eq_image, mem_image] at hzt hzs
   rcases hzt with ⟨p, ⟨p0, p1⟩, rfl⟩
@@ -269,6 +267,12 @@ lemma segment_inter_eq_endpoint_of_linearIndependent_sub
     convert H using 1 <;> simp [sub_smul]
   obtain ⟨rfl, rfl⟩ : p = 0 ∧ q = 0 := h.eq_zero_of_pair' ((add_right_inj c).1 this).symm
   simp
+
+lemma segment_inter_eq_endpoint_of_linearIndependent_sub [ZeroLEOneClass 𝕜]
+    {c x y : E} (h : LinearIndependent 𝕜 ![x - c, y - c]) :
+    [c -[𝕜] x] ∩ [c -[𝕜] y] = {c} := by
+  refine (segment_inter_subset_endpoint_of_linearIndependent_sub 𝕜 h).antisymm ?_
+  simp [singleton_subset_iff, left_mem_segment]
 
 end OrderedRing
 

--- a/Mathlib/Analysis/Convex/SimplicialComplex/Basic.lean
+++ b/Mathlib/Analysis/Convex/SimplicialComplex/Basic.lean
@@ -43,7 +43,7 @@ Simplicial complexes can be generalized to affine spaces once `ConvexHull` has b
 
 open Finset Set
 
-variable (𝕜 E : Type*) [Ring 𝕜] [PartialOrder 𝕜] [IsOrderedRing 𝕜] [AddCommGroup E] [Module 𝕜 E]
+variable (𝕜 E : Type*) [Ring 𝕜] [PartialOrder 𝕜] [AddCommGroup E] [Module 𝕜 E]
 
 namespace Geometry
 

--- a/Mathlib/Analysis/Convex/Star.lean
+++ b/Mathlib/Analysis/Convex/Star.lean
@@ -55,7 +55,7 @@ variable {𝕜 E F : Type*}
 
 section OrderedSemiring
 
-variable [Semiring 𝕜] [PartialOrder 𝕜] [IsOrderedRing 𝕜]
+variable [Semiring 𝕜] [PartialOrder 𝕜]
 
 section AddCommMonoid
 
@@ -65,11 +65,9 @@ section SMul
 
 variable (𝕜) [SMul 𝕜 E] [SMul 𝕜 F] (x : E) (s : Set E)
 
--- TODO: remove `[IsOrderedRing 𝕜]` and `@[nolint unusedArguments]`.
 /-- Star-convexity of sets. `s` is star-convex at `x` if every segment from `x` to a point in `s` is
 contained in `s`. -/
-@[nolint unusedArguments]
-def StarConvex (𝕜 : Type*) {E : Type*} [Semiring 𝕜] [PartialOrder 𝕜] [IsOrderedRing 𝕜]
+def StarConvex (𝕜 : Type*) {E : Type*} [Semiring 𝕜] [PartialOrder 𝕜]
     [AddCommMonoid E] [SMul 𝕜 E] (x : E) (s : Set E) : Prop :=
   ∀ ⦃y : E⦄, y ∈ s → ∀ ⦃a b : 𝕜⦄, 0 ≤ a → 0 ≤ b → a + b = 1 → a • x + b • y ∈ s
 
@@ -152,7 +150,7 @@ section Module
 
 variable [Module 𝕜 E] [Module 𝕜 F] {x y z : E} {s : Set E}
 
-theorem StarConvex.mem (hs : StarConvex 𝕜 x s) (h : s.Nonempty) : x ∈ s := by
+theorem StarConvex.mem [ZeroLEOneClass 𝕜] (hs : StarConvex 𝕜 x s) (h : s.Nonempty) : x ∈ s := by
   obtain ⟨y, hy⟩ := h
   convert hs hy zero_le_one le_rfl (add_zero 1)
   rw [one_smul, zero_smul, add_zero]
@@ -184,7 +182,7 @@ theorem starConvex_iff_forall_ne_pos (hx : x ∈ s) :
   · rwa [Convex.combo_self hab]
   exact h hy hxy ha' hb' hab
 
-theorem starConvex_iff_openSegment_subset (hx : x ∈ s) :
+theorem starConvex_iff_openSegment_subset [ZeroLEOneClass 𝕜] (hx : x ∈ s) :
     StarConvex 𝕜 x s ↔ ∀ ⦃y⦄, y ∈ s → openSegment 𝕜 x y ⊆ s :=
   starConvex_iff_segment_subset.trans <|
     forall₂_congr fun _ hy => (openSegment_subset_iff_segment_subset hx hy).symm
@@ -262,7 +260,7 @@ end OrderedSemiring
 
 section OrderedCommSemiring
 
-variable [CommSemiring 𝕜] [PartialOrder 𝕜] [IsOrderedRing 𝕜]
+variable [CommSemiring 𝕜] [PartialOrder 𝕜]
 
 section AddCommMonoid
 
@@ -289,11 +287,11 @@ end OrderedCommSemiring
 
 section OrderedRing
 
-variable [Ring 𝕜] [PartialOrder 𝕜] [IsOrderedRing 𝕜]
+variable [Ring 𝕜] [PartialOrder 𝕜]
 
 section AddCommMonoid
 
-variable [AddCommMonoid E] [SMulWithZero 𝕜 E] {s : Set E}
+variable [AddRightMono 𝕜] [AddCommMonoid E] [SMulWithZero 𝕜 E] {s : Set E}
 
 theorem starConvex_zero_iff :
     StarConvex 𝕜 0 s ↔ ∀ ⦃x : E⦄, x ∈ s → ∀ ⦃a : 𝕜⦄, 0 ≤ a → a ≤ 1 → a • x ∈ s := by
@@ -308,7 +306,10 @@ end AddCommMonoid
 
 section AddCommGroup
 
-variable [AddCommGroup E] [AddCommGroup F] [Module 𝕜 E] [Module 𝕜 F] {x y : E} {s t : Set E}
+section AddRightMono
+
+variable [AddRightMono 𝕜] [AddCommGroup E] [AddCommGroup F] [Module 𝕜 E] [Module 𝕜 F]
+  {x y : E} {s t : Set E}
 
 theorem StarConvex.add_smul_mem (hs : StarConvex 𝕜 x s) (hy : x + y ∈ s) {t : 𝕜} (ht₀ : 0 ≤ t)
     (ht₁ : t ≤ 1) : x + t • y ∈ s := by
@@ -325,6 +326,10 @@ theorem StarConvex.add_smul_sub_mem (hs : StarConvex 𝕜 x s) (hy : y ∈ s) {t
   apply hs.segment_subset hy
   rw [segment_eq_image']
   exact mem_image_of_mem _ ⟨ht₀, ht₁⟩
+
+end AddRightMono
+
+variable [AddCommGroup E] [AddCommGroup F] [Module 𝕜 E] [Module 𝕜 F] {x y : E} {s t : Set E}
 
 /-- The preimage of a star-convex set under an affine map is star-convex. -/
 theorem StarConvex.affine_preimage (f : E →ᵃ[𝕜] F) {s : Set F} (hs : StarConvex 𝕜 (f x) s) :
@@ -417,7 +422,7 @@ section OrdConnected
 
 /-- If `s` is an order-connected set in an ordered module over an ordered semiring
 and all elements of `s` are comparable with `x ∈ s`, then `s` is `StarConvex` at `x`. -/
-theorem Set.OrdConnected.starConvex [Semiring 𝕜] [PartialOrder 𝕜] [IsOrderedRing 𝕜]
+theorem Set.OrdConnected.starConvex [Semiring 𝕜] [PartialOrder 𝕜]
     [AddCommMonoid E] [PartialOrder E] [IsOrderedAddMonoid E] [Module 𝕜 E]
     [OrderedSMul 𝕜 E] {x : E} {s : Set E} (hs : s.OrdConnected) (hx : x ∈ s)
     (h : ∀ y ∈ s, x ≤ y ∨ y ≤ x) : StarConvex 𝕜 x s := by

--- a/Mathlib/Analysis/Convex/Strict.lean
+++ b/Mathlib/Analysis/Convex/Strict.lean
@@ -28,16 +28,13 @@ open Convex
 
 section OrderedSemiring
 
--- TODO: remove `[IsOrderedRing 𝕜]` and `@[nolint unusedArguments]`.
 /-- A set is strictly convex if the open segment between any two distinct points lies is in its
 interior. This basically means "convex and not flat on the boundary". -/
-@[nolint unusedArguments]
-def StrictConvex (𝕜 : Type*) {E : Type*}
-    [Semiring 𝕜] [PartialOrder 𝕜] [IsOrderedRing 𝕜] [TopologicalSpace E]
+def StrictConvex (𝕜 : Type*) {E : Type*} [Semiring 𝕜] [PartialOrder 𝕜] [TopologicalSpace E]
     [AddCommMonoid E] [SMul 𝕜 E] (s : Set E) : Prop :=
   s.Pairwise fun x y => ∀ ⦃a b : 𝕜⦄, 0 < a → 0 < b → a + b = 1 → a • x + b • y ∈ interior s
 
-variable [Semiring 𝕜] [PartialOrder 𝕜] [IsOrderedRing 𝕜] [TopologicalSpace E] [TopologicalSpace F]
+variable [Semiring 𝕜] [PartialOrder 𝕜] [TopologicalSpace E] [TopologicalSpace F]
 
 section AddCommMonoid
 
@@ -260,9 +257,9 @@ end AddCommGroup
 
 end OrderedSemiring
 
-section OrderedCommSemiring
+section CommSemiring
 
-variable [CommSemiring 𝕜] [PartialOrder 𝕜] [IsOrderedRing 𝕜] [TopologicalSpace E]
+variable [CommSemiring 𝕜] [PartialOrder 𝕜] [TopologicalSpace E]
 
 section AddCommGroup
 
@@ -283,17 +280,18 @@ theorem StrictConvex.preimage_smul (hs : StrictConvex 𝕜 s) (c : 𝕜) :
 
 end AddCommGroup
 
-end OrderedCommSemiring
+end CommSemiring
 
 section OrderedRing
 
-variable [Ring 𝕜] [PartialOrder 𝕜] [IsOrderedRing 𝕜] [TopologicalSpace E] [TopologicalSpace F]
+variable [Ring 𝕜] [PartialOrder 𝕜] [TopologicalSpace E] [TopologicalSpace F]
 
 section AddCommGroup
 
 variable [AddCommGroup E] [AddCommGroup F] [Module 𝕜 E] [Module 𝕜 F] {s t : Set E} {x y : E}
 
-theorem StrictConvex.eq_of_openSegment_subset_frontier [Nontrivial 𝕜] [DenselyOrdered 𝕜]
+theorem StrictConvex.eq_of_openSegment_subset_frontier
+    [IsOrderedRing 𝕜] [Nontrivial 𝕜] [DenselyOrdered 𝕜]
     (hs : StrictConvex 𝕜 s) (hx : x ∈ s) (hy : y ∈ s) (h : openSegment 𝕜 x y ⊆ frontier s) :
     x = y := by
   obtain ⟨a, ha₀, ha₁⟩ := DenselyOrdered.dense (0 : 𝕜) 1 zero_lt_one
@@ -303,18 +301,21 @@ theorem StrictConvex.eq_of_openSegment_subset_frontier [Nontrivial 𝕜] [Densel
       (h ⟨a, 1 - a, ha₀, sub_pos_of_lt ha₁, add_sub_cancel _ _, rfl⟩).2
         (hs hx hy hxy ha₀ (sub_pos_of_lt ha₁) <| add_sub_cancel _ _)
 
-theorem StrictConvex.add_smul_mem (hs : StrictConvex 𝕜 s) (hx : x ∈ s) (hxy : x + y ∈ s)
+theorem StrictConvex.add_smul_mem [AddRightStrictMono 𝕜]
+    (hs : StrictConvex 𝕜 s) (hx : x ∈ s) (hxy : x + y ∈ s)
     (hy : y ≠ 0) {t : 𝕜} (ht₀ : 0 < t) (ht₁ : t < 1) : x + t • y ∈ interior s := by
   have h : x + t • y = (1 - t) • x + t • (x + y) := by match_scalars <;> field_simp
   rw [h]
   exact hs hx hxy (fun h => hy <| add_left_cancel (a := x) (by rw [← h, add_zero]))
     (sub_pos_of_lt ht₁) ht₀ (sub_add_cancel 1 t)
 
-theorem StrictConvex.smul_mem_of_zero_mem (hs : StrictConvex 𝕜 s) (zero_mem : (0 : E) ∈ s)
+theorem StrictConvex.smul_mem_of_zero_mem [AddRightStrictMono 𝕜]
+    (hs : StrictConvex 𝕜 s) (zero_mem : (0 : E) ∈ s)
     (hx : x ∈ s) (hx₀ : x ≠ 0) {t : 𝕜} (ht₀ : 0 < t) (ht₁ : t < 1) : t • x ∈ interior s := by
   simpa using hs.add_smul_mem zero_mem (by simpa using hx) hx₀ ht₀ ht₁
 
-theorem StrictConvex.add_smul_sub_mem (h : StrictConvex 𝕜 s) (hx : x ∈ s) (hy : y ∈ s) (hxy : x ≠ y)
+theorem StrictConvex.add_smul_sub_mem [AddRightMono 𝕜]
+    (h : StrictConvex 𝕜 s) (hx : x ∈ s) (hy : y ∈ s) (hxy : x ≠ y)
     {t : 𝕜} (ht₀ : 0 < t) (ht₁ : t < 1) : x + t • (y - x) ∈ interior s := by
   apply h.openSegment_subset hx hy hxy
   rw [openSegment_eq_image']

--- a/Mathlib/Analysis/Convex/StrictConvexSpace.lean
+++ b/Mathlib/Analysis/Convex/StrictConvexSpace.lean
@@ -60,11 +60,11 @@ then prove that any closed ball is strictly convex in `strictConvex_closedBall` 
 
 See also `StrictConvexSpace.of_strictConvex_unitClosedBall`. -/
 @[mk_iff]
-class StrictConvexSpace (𝕜 E : Type*) [NormedField 𝕜] [LinearOrder 𝕜] [IsStrictOrderedRing 𝕜]
+class StrictConvexSpace (𝕜 E : Type*) [NormedField 𝕜] [PartialOrder 𝕜]
     [NormedAddCommGroup E] [NormedSpace 𝕜 E] : Prop where
   strictConvex_closedBall : ∀ r : ℝ, 0 < r → StrictConvex 𝕜 (closedBall (0 : E) r)
 
-variable (𝕜 : Type*) {E : Type*} [NormedField 𝕜] [LinearOrder 𝕜] [IsStrictOrderedRing 𝕜]
+variable (𝕜 : Type*) {E : Type*} [NormedField 𝕜] [PartialOrder 𝕜]
   [NormedAddCommGroup E] [NormedSpace 𝕜 E]
 
 /-- A closed ball in a strictly convex space is strictly convex. -/

--- a/Mathlib/Analysis/Convex/StrictConvexSpace.lean
+++ b/Mathlib/Analysis/Convex/StrictConvexSpace.lean
@@ -59,6 +59,7 @@ require balls of positive radius with center at the origin to be strictly convex
 then prove that any closed ball is strictly convex in `strictConvex_closedBall` below.
 
 See also `StrictConvexSpace.of_strictConvex_unitClosedBall`. -/
+@[mk_iff]
 class StrictConvexSpace (𝕜 E : Type*) [NormedField 𝕜] [LinearOrder 𝕜] [IsStrictOrderedRing 𝕜]
     [NormedAddCommGroup E] [NormedSpace 𝕜 E] : Prop where
   strictConvex_closedBall : ∀ r : ℝ, 0 < r → StrictConvex 𝕜 (closedBall (0 : E) r)

--- a/Mathlib/Analysis/Convex/Topology.lean
+++ b/Mathlib/Analysis/Convex/Topology.lean
@@ -122,7 +122,7 @@ end PseudoMetricSpace
 
 section ContinuousConstSMul
 
-variable [Field 𝕜] [LinearOrder 𝕜] [IsStrictOrderedRing 𝕜]
+variable [Field 𝕜] [LinearOrder 𝕜]
   [AddCommGroup E] [Module 𝕜 E] [TopologicalSpace E]
   [IsTopologicalAddGroup E] [ContinuousConstSMul 𝕜 E]
 
@@ -201,6 +201,10 @@ theorem Convex.openSegment_self_interior_subset_interior {s : Set E} (hs : Conve
     (hx : x ∈ s) (hy : y ∈ interior s) : openSegment 𝕜 x y ⊆ interior s :=
   hs.openSegment_closure_interior_subset_interior (subset_closure hx) hy
 
+section
+
+variable [AddRightMono 𝕜]
+
 /-- If `x ∈ closure s` and `y ∈ interior s`, then the segment `(x, y]` is included in `interior s`.
 -/
 theorem Convex.add_smul_sub_mem_interior' {s : Set E} (hs : Convex 𝕜 s) {x y : E}
@@ -225,8 +229,11 @@ theorem Convex.add_smul_mem_interior {s : Set E} (hs : Convex 𝕜 s) {x y : E} 
     (hy : x + y ∈ interior s) {t : 𝕜} (ht : t ∈ Ioc (0 : 𝕜) 1) : x + t • y ∈ interior s :=
   hs.add_smul_mem_interior' (subset_closure hx) hy ht
 
+end
+
 /-- In a topological vector space, the interior of a convex set is convex. -/
-protected theorem Convex.interior {s : Set E} (hs : Convex 𝕜 s) : Convex 𝕜 (interior s) :=
+protected theorem Convex.interior [ZeroLEOneClass 𝕜] {s : Set E} (hs : Convex 𝕜 s) :
+    Convex 𝕜 (interior s) :=
   convex_iff_openSegment_subset.mpr fun _ hx _ hy =>
     hs.openSegment_closure_interior_subset_interior (interior_subset_closure hx) hy
 
@@ -239,6 +246,8 @@ protected theorem Convex.closure {s : Set E} (hs : Convex 𝕜 s) : Convex 𝕜 
   show f x y ∈ closure s from map_mem_closure₂ hf hx hy fun _ hx' _ hy' => hs hx' hy' ha hb hab
 
 open AffineMap
+
+variable [IsStrictOrderedRing 𝕜]
 
 /-- A convex set `s` is strictly convex provided that for any two distinct points of
 `s \ interior s`, the line passing through these points has nonempty intersection with
@@ -300,7 +309,7 @@ end ContinuousSMul
 
 section TopologicalSpace
 
-variable [Semiring 𝕜] [PartialOrder 𝕜] [IsOrderedRing 𝕜]
+variable [Semiring 𝕜] [PartialOrder 𝕜]
   [AddCommGroup E] [Module 𝕜 E] [TopologicalSpace E]
 
 theorem convex_closed_sInter {S : Set (Set E)} (h : ∀ s ∈ S, Convex 𝕜 s ∧ IsClosed s) :
@@ -345,7 +354,7 @@ end TopologicalSpace
 
 section ContinuousConstSMul
 
-variable [Field 𝕜] [LinearOrder 𝕜] [IsStrictOrderedRing 𝕜]
+variable [Field 𝕜] [LinearOrder 𝕜]
   [AddCommGroup E] [Module 𝕜 E] [TopologicalSpace E]
   [IsTopologicalAddGroup E] [ContinuousConstSMul 𝕜 E]
 

--- a/Mathlib/Analysis/Convex/Visible.lean
+++ b/Mathlib/Analysis/Convex/Visible.lean
@@ -29,10 +29,11 @@ open scoped Cardinal Pointwise Topology
 variable {𝕜 V P : Type*}
 
 section AddTorsor
-variable [Field 𝕜] [LinearOrder 𝕜] [IsStrictOrderedRing 𝕜]
+variable [Field 𝕜] [LinearOrder 𝕜] [IsOrderedRing 𝕜]
   [AddCommGroup V] [Module 𝕜 V] [AddTorsor V P]
   {s t : Set P} {x y z : P}
 
+omit [IsOrderedRing 𝕜] in
 variable (𝕜) in
 /-- Two points are visible to each other through a set if no point of that set lies strictly
 between them.
@@ -40,12 +41,15 @@ between them.
 By convention, a point `x` sees itself through any set `s`, even when `x ∈ s`. -/
 def IsVisible (s : Set P) (x y : P) : Prop := ∀ ⦃z⦄, z ∈ s → ¬ Sbtw 𝕜 x z y
 
-@[simp, refl] lemma IsVisible.rfl : IsVisible 𝕜 s x x := by simp [IsVisible]
+@[simp, refl]
+lemma IsVisible.rfl : IsVisible 𝕜 s x x := by simp [IsVisible]
 
-lemma isVisible_comm : IsVisible 𝕜 s x y ↔ IsVisible 𝕜 s y x := by simp [IsVisible, sbtw_comm]
+lemma isVisible_comm : IsVisible 𝕜 s x y ↔ IsVisible 𝕜 s y x := by
+  simp [IsVisible, sbtw_comm]
 
 @[symm] alias ⟨IsVisible.symm, _⟩ := isVisible_comm
 
+omit [IsOrderedRing 𝕜] in
 lemma IsVisible.mono (hst : s ⊆ t) (ht : IsVisible 𝕜 t x y) : IsVisible 𝕜 s x y :=
   fun _z hz ↦ ht <| hst hz
 


### PR DESCRIPTION
Also weaken typeclass assumptions here and there.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
