### PR TITLE
[Merged by Bors] - chore(Algebra/Module/PID): fix universe level

### DIFF
--- a/Mathlib/Algebra/Category/ModuleCat/Biproducts.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Biproducts.lean
@@ -132,7 +132,7 @@ theorem biproductIsoPi_inv_comp_π [Finite J] (f : J → ModuleCat.{v} R) (j : J
 end ModuleCat
 
 section SplitExact
-
+open ModuleCat
 section universe_monomorphic
 
 variable {R : Type u} {A M B : Type v} [Ring R] [AddCommGroup A] [Module R A] [AddCommGroup B]
@@ -140,11 +140,7 @@ variable {R : Type u} {A M B : Type v} [Ring R] [AddCommGroup A] [Module R A] [A
 
 variable {j : A →ₗ[R] M} {g : M →ₗ[R] B}
 
-open ModuleCat
 
-
-/-- The isomorphism `A × B ≃ₗ[R] M` coming from a right split exact sequence `0 ⟶ A ⟶ M ⟶ B ⟶ 0`
-of modules. -/
 private noncomputable def lequivProdOfRightSplitExact' {f : B →ₗ[R] M} (hj : Function.Injective j)
     (exac : LinearMap.range j = LinearMap.ker g) (h : g.comp f = LinearMap.id) : (A × B) ≃ₗ[R] M :=
   ((ShortComplex.Splitting.ofExactOfSection _
@@ -167,17 +163,16 @@ section universe_polymorphic
 
 universe uA uM uB
 variable {R : Type u} {A : Type uA} {M : Type uM} {B : Type uB}
-variable [Ring R] [AddCommGroup A] [Module R A] [AddCommGroup B]
-  [Module R B] [AddCommGroup M] [Module R M]
+variable [Ring R] [AddCommGroup A] [AddCommGroup B] [AddCommGroup M]
+variable [Module R A] [Module R B] [Module R M]
 
 variable {j : A →ₗ[R] M} {g : M →ₗ[R] B}
-
 
 /-- The isomorphism `A × B ≃ₗ[R] M` coming from a right split exact sequence `0 ⟶ A ⟶ M ⟶ B ⟶ 0`
 of modules. -/
 noncomputable def lequivProdOfRightSplitExact {f : B →ₗ[R] M} (hj : Function.Injective j)
     (exac : LinearMap.range j = LinearMap.ker g) (h : g.comp f = LinearMap.id) : (A × B) ≃ₗ[R] M :=
-  have := lequivProdOfRightSplitExact' (R := R)
+  have := lequivProdOfRightSplitExact'
     (A := ULift.{max uA uM uB} A) (M := ULift.{max uA uM uB} M) (B := ULift.{max uA uM uB} B)
     (f := ULift.moduleEquiv.symm.toLinearMap ∘ₗ f ∘ₗ ULift.moduleEquiv.toLinearMap)
     (j := ULift.moduleEquiv.symm.toLinearMap ∘ₗ j ∘ₗ ULift.moduleEquiv.toLinearMap)
@@ -191,7 +186,7 @@ noncomputable def lequivProdOfRightSplitExact {f : B →ₗ[R] M} (hj : Function
 of modules. -/
 noncomputable def lequivProdOfLeftSplitExact {f : M →ₗ[R] A} (hg : Function.Surjective g)
     (exac : LinearMap.range j = LinearMap.ker g) (h : f.comp j = LinearMap.id) : (A × B) ≃ₗ[R] M :=
-  have := lequivProdOfLeftSplitExact' (R := R)
+  have := lequivProdOfLeftSplitExact'
     (A := ULift.{max uA uM uB} A) (M := ULift.{max uA uM uB} M) (B := ULift.{max uA uM uB} B)
     (f := ULift.moduleEquiv.symm.toLinearMap ∘ₗ f ∘ₗ ULift.moduleEquiv.toLinearMap)
     (j := ULift.moduleEquiv.symm.toLinearMap ∘ₗ j ∘ₗ ULift.moduleEquiv.toLinearMap)

--- a/Mathlib/Algebra/Category/ModuleCat/Biproducts.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Biproducts.lean
@@ -133,6 +133,8 @@ end ModuleCat
 
 section SplitExact
 
+section universe_monomorphic
+
 variable {R : Type u} {A M B : Type v} [Ring R] [AddCommGroup A] [Module R A] [AddCommGroup B]
   [Module R B] [AddCommGroup M] [Module R M]
 
@@ -143,7 +145,7 @@ open ModuleCat
 
 /-- The isomorphism `A × B ≃ₗ[R] M` coming from a right split exact sequence `0 ⟶ A ⟶ M ⟶ B ⟶ 0`
 of modules. -/
-noncomputable def lequivProdOfRightSplitExact {f : B →ₗ[R] M} (hj : Function.Injective j)
+private noncomputable def lequivProdOfRightSplitExact' {f : B →ₗ[R] M} (hj : Function.Injective j)
     (exac : LinearMap.range j = LinearMap.ker g) (h : g.comp f = LinearMap.id) : (A × B) ≃ₗ[R] M :=
   ((ShortComplex.Splitting.ofExactOfSection _
     (ShortComplex.Exact.moduleCat_of_range_eq_ker (ModuleCat.ofHom j)
@@ -151,14 +153,54 @@ noncomputable def lequivProdOfRightSplitExact {f : B →ₗ[R] M} (hj : Function
     (by simpa only [ModuleCat.mono_iff_injective])).isoBinaryBiproduct ≪≫
     biprodIsoProd _ _ ).symm.toLinearEquiv
 
-/-- The isomorphism `A × B ≃ₗ[R] M` coming from a left split exact sequence `0 ⟶ A ⟶ M ⟶ B ⟶ 0`
-of modules. -/
-noncomputable def lequivProdOfLeftSplitExact {f : M →ₗ[R] A} (hg : Function.Surjective g)
+private noncomputable def lequivProdOfLeftSplitExact' {f : M →ₗ[R] A} (hg : Function.Surjective g)
     (exac : LinearMap.range j = LinearMap.ker g) (h : f.comp j = LinearMap.id) : (A × B) ≃ₗ[R] M :=
   ((ShortComplex.Splitting.ofExactOfRetraction _
     (ShortComplex.Exact.moduleCat_of_range_eq_ker (ModuleCat.ofHom j)
     (ModuleCat.ofHom g) exac) (ModuleCat.ofHom f) (hom_ext h)
     (by simpa only [ModuleCat.epi_iff_surjective] using hg)).isoBinaryBiproduct ≪≫
     biprodIsoProd _ _).symm.toLinearEquiv
+
+end universe_monomorphic
+
+section universe_polymorphic
+
+universe uA uM uB
+variable {R : Type u} {A : Type uA} {M : Type uM} {B : Type uB}
+variable [Ring R] [AddCommGroup A] [Module R A] [AddCommGroup B]
+  [Module R B] [AddCommGroup M] [Module R M]
+
+variable {j : A →ₗ[R] M} {g : M →ₗ[R] B}
+
+
+/-- The isomorphism `A × B ≃ₗ[R] M` coming from a right split exact sequence `0 ⟶ A ⟶ M ⟶ B ⟶ 0`
+of modules. -/
+noncomputable def lequivProdOfRightSplitExact {f : B →ₗ[R] M} (hj : Function.Injective j)
+    (exac : LinearMap.range j = LinearMap.ker g) (h : g.comp f = LinearMap.id) : (A × B) ≃ₗ[R] M :=
+  have := lequivProdOfRightSplitExact' (R := R)
+    (A := ULift.{max uA uM uB} A) (M := ULift.{max uA uM uB} M) (B := ULift.{max uA uM uB} B)
+    (f := ULift.moduleEquiv.symm.toLinearMap ∘ₗ f ∘ₗ ULift.moduleEquiv.toLinearMap)
+    (j := ULift.moduleEquiv.symm.toLinearMap ∘ₗ j ∘ₗ ULift.moduleEquiv.toLinearMap)
+    (g := ULift.moduleEquiv.symm.toLinearMap ∘ₗ g ∘ₗ ULift.moduleEquiv.toLinearMap)
+    (by simpa using hj)
+    (by simp [LinearMap.range_comp, LinearMap.ker_comp, exac, Submodule.comap_equiv_eq_map_symm])
+    (by ext x; simpa using congr($h x.down))
+  ULift.moduleEquiv.symm.prodCongr ULift.moduleEquiv.symm ≪≫ₗ this ≪≫ₗ ULift.moduleEquiv
+
+/-- The isomorphism `A × B ≃ₗ[R] M` coming from a left split exact sequence `0 ⟶ A ⟶ M ⟶ B ⟶ 0`
+of modules. -/
+noncomputable def lequivProdOfLeftSplitExact {f : M →ₗ[R] A} (hg : Function.Surjective g)
+    (exac : LinearMap.range j = LinearMap.ker g) (h : f.comp j = LinearMap.id) : (A × B) ≃ₗ[R] M :=
+  have := lequivProdOfLeftSplitExact' (R := R)
+    (A := ULift.{max uA uM uB} A) (M := ULift.{max uA uM uB} M) (B := ULift.{max uA uM uB} B)
+    (f := ULift.moduleEquiv.symm.toLinearMap ∘ₗ f ∘ₗ ULift.moduleEquiv.toLinearMap)
+    (j := ULift.moduleEquiv.symm.toLinearMap ∘ₗ j ∘ₗ ULift.moduleEquiv.toLinearMap)
+    (g := ULift.moduleEquiv.symm.toLinearMap ∘ₗ g ∘ₗ ULift.moduleEquiv.toLinearMap)
+    (by simpa using hg)
+    (by simp [LinearMap.range_comp, LinearMap.ker_comp, exac, Submodule.comap_equiv_eq_map_symm])
+    (by ext x; simpa using congr($h x.down))
+  ULift.moduleEquiv.symm.prodCongr ULift.moduleEquiv.symm ≪≫ₗ this ≪≫ₗ ULift.moduleEquiv
+
+end universe_polymorphic
 
 end SplitExact

--- a/Mathlib/Algebra/Module/PID.lean
+++ b/Mathlib/Algebra/Module/PID.lean
@@ -200,7 +200,8 @@ theorem torsion_by_prime_power_decomposition (hM : Module.IsTorsion' M (Submonoi
                 (LinearMap.toSpanSingleton _ _ _) (this i).choose_spec.left : R ⧸ _ →ₗ[R] _)))
               (R ∙ s j).injective_subtype ?_ ?_).symm ≪≫ₗ
           (((quotTorsionOfEquivSpanSingleton R M (s j)).symm ≪≫ₗ
-            (quotEquivOfEq (torsionOf R M (s j)) _  (Ideal.torsionOf_eq_span_pow_pOrder hp hM (s j)))).prodCongr (.refl _ _)) ≪≫ₗ
+            (quotEquivOfEq (torsionOf R M (s j)) _
+              (Ideal.torsionOf_eq_span_pow_pOrder hp hM (s j)))).prodCongr (.refl _ _)) ≪≫ₗ
           (@DirectSum.lequivProdDirectSum R _ _
             (fun i => R ⧸ R ∙ p ^ @Option.rec _ (fun _ => ℕ) (pOrder hM <| s j) k i) _ _).symm ≪≫ₗ
           (DirectSum.lequivCongrLeft R (finSuccEquiv d).symm)

--- a/Mathlib/Algebra/Module/PID.lean
+++ b/Mathlib/Algebra/Module/PID.lean
@@ -168,17 +168,7 @@ omit dec in
 theorem torsion_by_prime_power_decomposition (hM : Module.IsTorsion' M (Submonoid.powers p))
     [h' : Module.Finite R M] :
     ∃ (d : ℕ) (k : Fin d → ℕ), Nonempty <| M ≃ₗ[R] ⨁ i : Fin d, R ⧸ R ∙ p ^ (k i : ℕ) := by
-  suffices H : ∀ {N : Type max u v} [AddCommGroup N] [Module R N]
-      (hN : Module.IsTorsion' N (Submonoid.powers p)) [Module.Finite R N],
-      ∃ (d : ℕ) (k : Fin d → ℕ), Nonempty <| N ≃ₗ[R] ⨁ i : Fin d, R ⧸ R ∙ p ^ (k i : ℕ) by
-    have := Module.Finite.equiv (ULift.moduleEquiv.{u, v, u} (R := R) (M := M)).symm
-    have hM' : Module.IsTorsion' (ULift.{u} M) (Submonoid.powers p) := by
-      rw [IsTorsion'] at hM ⊢
-      rintro ⟨x⟩
-      obtain ⟨a, ha⟩ := @hM x
-      exact ⟨a, by ext1; exact ha⟩
-    obtain ⟨d, k, ⟨f⟩⟩ := H hM'
-    exact ⟨d, k, ⟨ULift.moduleEquiv.symm ≪≫ₗ f⟩⟩
+  revert M
   intro N _ _ hN h'
   obtain ⟨d, s, hs⟩ := @Module.Finite.exists_fin _ _ _ _ _ h'; use d; clear h'
   induction' d with d IH generalizing N

--- a/Mathlib/Algebra/Module/PID.lean
+++ b/Mathlib/Algebra/Module/PID.lean
@@ -24,8 +24,6 @@ import Mathlib.RingTheory.SimpleModule.Basic
 
 * `R` is a PID and `M` is a (finitely generated for main statements) `R`-module, with additional
   torsion hypotheses in the intermediate lemmas.
-* `N` is an `R`-module lying over a higher type universe than `R`. This assumption is needed on the
-  final statement for technical reasons.
 * `p` is an irreducible element of `R` or a tuple of these.
 
 ## Implementation details
@@ -55,7 +53,7 @@ universe u v
 
 variable {R : Type u} [CommRing R] [IsPrincipalIdealRing R]
 variable {M : Type v} [AddCommGroup M] [Module R M]
-variable {N : Type max u v} [AddCommGroup N] [Module R N]
+variable {N : Type v} [AddCommGroup N] [Module R N]
 
 open scoped DirectSum
 
@@ -170,6 +168,18 @@ open Finset Multiset
 theorem torsion_by_prime_power_decomposition (hN : Module.IsTorsion' N (Submonoid.powers p))
     [h' : Module.Finite R N] :
     ∃ (d : ℕ) (k : Fin d → ℕ), Nonempty <| N ≃ₗ[R] ⨁ i : Fin d, R ⧸ R ∙ p ^ (k i : ℕ) := by
+  suffices H : ∀ {N : Type max u v} [AddCommGroup N] [Module R N]
+      (hN : Module.IsTorsion' N (Submonoid.powers p)) [Module.Finite R N],
+      ∃ (d : ℕ) (k : Fin d → ℕ), Nonempty <| N ≃ₗ[R] ⨁ i : Fin d, R ⧸ R ∙ p ^ (k i : ℕ) by
+    have := Module.Finite.equiv (ULift.moduleEquiv.{u, v, u} (R := R) (M := N)).symm
+    have hN' : Module.IsTorsion' (ULift.{u} N) (Submonoid.powers p) := by
+      rw [IsTorsion'] at hN ⊢
+      rintro ⟨x⟩
+      obtain ⟨a, ha⟩ := @hN x
+      exact ⟨a, by ext1; exact ha⟩
+    obtain ⟨d, k, ⟨f⟩⟩ := H hN'
+    exact ⟨d, k, ⟨ULift.moduleEquiv.symm ≪≫ₗ f⟩⟩
+  intro N _ _ hN h'
   obtain ⟨d, s, hs⟩ := @Module.Finite.exists_fin _ _ _ _ _ h'; use d; clear h'
   induction' d with d IH generalizing N
   · use finZeroElim

--- a/Mathlib/Algebra/Module/PID.lean
+++ b/Mathlib/Algebra/Module/PID.lean
@@ -168,44 +168,42 @@ omit dec in
 theorem torsion_by_prime_power_decomposition (hM : Module.IsTorsion' M (Submonoid.powers p))
     [h' : Module.Finite R M] :
     ∃ (d : ℕ) (k : Fin d → ℕ), Nonempty <| M ≃ₗ[R] ⨁ i : Fin d, R ⧸ R ∙ p ^ (k i : ℕ) := by
-  revert M
-  intro N _ _ hN h'
   obtain ⟨d, s, hs⟩ := @Module.Finite.exists_fin _ _ _ _ _ h'; use d; clear h'
-  induction' d with d IH generalizing N
+  induction' d with d IH generalizing M
   · use finZeroElim
     rw [Set.range_eq_empty, Submodule.span_empty] at hs
-    haveI : Unique N :=
+    haveI : Unique M :=
       ⟨⟨0⟩, fun x => by dsimp; rw [← Submodule.mem_bot R, hs]; exact Submodule.mem_top⟩
     haveI : IsEmpty (Fin Nat.zero) := inferInstanceAs (IsEmpty (Fin 0))
     exact ⟨0⟩
-  · have : ∀ x : N, Decidable (x = 0) := fun _ => by classical infer_instance
-    obtain ⟨j, hj⟩ := exists_isTorsionBy hN d.succ d.succ_ne_zero s hs
-    let s' : Fin d → N ⧸ R ∙ s j := Submodule.Quotient.mk ∘ s ∘ j.succAbove
+  · have : ∀ x : M, Decidable (x = 0) := fun _ => by classical infer_instance
+    obtain ⟨j, hj⟩ := exists_isTorsionBy hM d.succ d.succ_ne_zero s hs
+    let s' : Fin d → M ⧸ R ∙ s j := Submodule.Quotient.mk ∘ s ∘ j.succAbove
     -- Porting note(https://github.com/leanprover-community/mathlib4/issues/5732):
     -- `obtain` doesn't work with placeholders.
     have := IH ?_ s' ?_
     · obtain ⟨k, ⟨f⟩⟩ := this
       clear IH
       have : ∀ i : Fin d,
-          ∃ x : N, p ^ k i • x = 0 ∧ f (Submodule.Quotient.mk x) = DirectSum.lof R _ _ i 1 := by
+          ∃ x : M, p ^ k i • x = 0 ∧ f (Submodule.Quotient.mk x) = DirectSum.lof R _ _ i 1 := by
         intro i
         let fi := f.symm.toLinearMap.comp (DirectSum.lof _ _ _ i)
-        obtain ⟨x, h0, h1⟩ := exists_smul_eq_zero_and_mk_eq hp hN hj fi; refine ⟨x, h0, ?_⟩; rw [h1]
+        obtain ⟨x, h0, h1⟩ := exists_smul_eq_zero_and_mk_eq hp hM hj fi; refine ⟨x, h0, ?_⟩; rw [h1]
         simp only [fi, LinearMap.coe_comp, f.symm.coe_toLinearMap, f.apply_symm_apply,
           Function.comp_apply]
       refine ⟨?_, ⟨?_⟩⟩
-      · exact fun a => (fun i => (Option.rec (pOrder hN (s j)) k i : ℕ)) (finSuccEquiv d a)
+      · exact fun a => (fun i => (Option.rec (pOrder hM (s j)) k i : ℕ)) (finSuccEquiv d a)
       · refine (((lequivProdOfRightSplitExact
           (g := (f.trans ULift.moduleEquiv.{u, u, v}.symm).toLinearMap.comp <| mkQ _)
           (f := (DirectSum.toModule _ _ _ fun i => (liftQSpanSingleton (p ^ k i)
               (LinearMap.toSpanSingleton _ _ _) (this i).choose_spec.left : R ⧸ _ →ₗ[R] _)).comp
             ULift.moduleEquiv.toLinearMap) (R ∙ s j).injective_subtype ?_ ?_).symm.trans
-          (((quotTorsionOfEquivSpanSingleton R N (s j)).symm.trans
-          (quotEquivOfEq (torsionOf R N (s j)) _
-          (Ideal.torsionOf_eq_span_pow_pOrder hp hN (s j)))).prodCongr
+          (((quotTorsionOfEquivSpanSingleton R M (s j)).symm.trans
+          (quotEquivOfEq (torsionOf R M (s j)) _
+          (Ideal.torsionOf_eq_span_pow_pOrder hp hM (s j)))).prodCongr
           (ULift.moduleEquiv))).trans
           (@DirectSum.lequivProdDirectSum R _ _
-          (fun i => R ⧸ R ∙ p ^ @Option.rec _ (fun _ => ℕ) (pOrder hN <| s j) k i) _ _).symm).trans
+          (fun i => R ⧸ R ∙ p ^ @Option.rec _ (fun _ => ℕ) (pOrder hM <| s j) k i) _ _).symm).trans
           (DirectSum.lequivCongrLeft R (finSuccEquiv d).symm)
         · rw [range_subtype, LinearEquiv.ker_comp, ker_mkQ]
         · rw [← f.comp_coe, LinearMap.comp_assoc, LinearMap.comp_assoc,
@@ -219,7 +217,7 @@ theorem torsion_by_prime_power_decomposition (hM : Module.IsTorsion' M (Submonoi
             liftQSpanSingleton_apply, LinearMap.toSpanSingleton_one, Ideal.Quotient.mk_eq_mk,
             map_one (Ideal.Quotient.mk _), (this i).choose_spec.right]
     · exact (mk_surjective _).forall.mpr fun x =>
-        ⟨(@hN x).choose, by rw [← Quotient.mk_smul, (@hN x).choose_spec, Quotient.mk_zero]⟩
+        ⟨(@hM x).choose, by rw [← Quotient.mk_smul, (@hM x).choose_spec, Quotient.mk_zero]⟩
     · have hs' := congr_arg (Submodule.map <| mkQ <| R ∙ s j) hs
       rw [Submodule.map_span, Submodule.map_top, range_mkQ] at hs'; simp only [mkQ_apply] at hs'
       simp only [s']; rw [← Function.comp_assoc, Set.range_comp (_ ∘ s), Fin.range_succAbove]

--- a/Mathlib/Algebra/Module/PID.lean
+++ b/Mathlib/Algebra/Module/PID.lean
@@ -193,17 +193,16 @@ theorem torsion_by_prime_power_decomposition (hM : Module.IsTorsion' M (Submonoi
           Function.comp_apply]
       refine ⟨?_, ⟨?_⟩⟩
       · exact fun a => (fun i => (Option.rec (pOrder hM (s j)) k i : ℕ)) (finSuccEquiv d a)
-      · refine (((lequivProdOfRightSplitExact
-          (g := f.toLinearMap.comp <| mkQ _)
-          (f := (DirectSum.toModule _ _ _ fun i => (liftQSpanSingleton (p ^ k i)
-              (LinearMap.toSpanSingleton _ _ _) (this i).choose_spec.left : R ⧸ _ →ₗ[R] _)))
-            (R ∙ s j).injective_subtype ?_ ?_).symm.trans
-          (((quotTorsionOfEquivSpanSingleton R M (s j)).symm.trans
-          (quotEquivOfEq (torsionOf R M (s j)) _
-          (Ideal.torsionOf_eq_span_pow_pOrder hp hM (s j)))).prodCongr
-          (.refl _ _))).trans
+      · refine
+          (lequivProdOfRightSplitExact
+            (g := f.toLinearMap.comp <| mkQ _)
+            (f := (DirectSum.toModule _ _ _ fun i => (liftQSpanSingleton (p ^ k i)
+                (LinearMap.toSpanSingleton _ _ _) (this i).choose_spec.left : R ⧸ _ →ₗ[R] _)))
+              (R ∙ s j).injective_subtype ?_ ?_).symm ≪≫ₗ
+          (((quotTorsionOfEquivSpanSingleton R M (s j)).symm ≪≫ₗ
+            (quotEquivOfEq (torsionOf R M (s j)) _  (Ideal.torsionOf_eq_span_pow_pOrder hp hM (s j)))).prodCongr (.refl _ _)) ≪≫ₗ
           (@DirectSum.lequivProdDirectSum R _ _
-          (fun i => R ⧸ R ∙ p ^ @Option.rec _ (fun _ => ℕ) (pOrder hM <| s j) k i) _ _).symm).trans
+            (fun i => R ⧸ R ∙ p ^ @Option.rec _ (fun _ => ℕ) (pOrder hM <| s j) k i) _ _).symm ≪≫ₗ
           (DirectSum.lequivCongrLeft R (finSuccEquiv d).symm)
         · rw [range_subtype, LinearEquiv.ker_comp, ker_mkQ]
         · rw [LinearMap.comp_assoc]

--- a/Mathlib/Algebra/Module/PID.lean
+++ b/Mathlib/Algebra/Module/PID.lean
@@ -194,23 +194,19 @@ theorem torsion_by_prime_power_decomposition (hM : Module.IsTorsion' M (Submonoi
       refine ⟨?_, ⟨?_⟩⟩
       · exact fun a => (fun i => (Option.rec (pOrder hM (s j)) k i : ℕ)) (finSuccEquiv d a)
       · refine (((lequivProdOfRightSplitExact
-          (g := (f.trans ULift.moduleEquiv.{u, u, v}.symm).toLinearMap.comp <| mkQ _)
+          (g := f.toLinearMap.comp <| mkQ _)
           (f := (DirectSum.toModule _ _ _ fun i => (liftQSpanSingleton (p ^ k i)
-              (LinearMap.toSpanSingleton _ _ _) (this i).choose_spec.left : R ⧸ _ →ₗ[R] _)).comp
-            ULift.moduleEquiv.toLinearMap) (R ∙ s j).injective_subtype ?_ ?_).symm.trans
+              (LinearMap.toSpanSingleton _ _ _) (this i).choose_spec.left : R ⧸ _ →ₗ[R] _)))
+            (R ∙ s j).injective_subtype ?_ ?_).symm.trans
           (((quotTorsionOfEquivSpanSingleton R M (s j)).symm.trans
           (quotEquivOfEq (torsionOf R M (s j)) _
           (Ideal.torsionOf_eq_span_pow_pOrder hp hM (s j)))).prodCongr
-          (ULift.moduleEquiv))).trans
+          (.refl _ _))).trans
           (@DirectSum.lequivProdDirectSum R _ _
           (fun i => R ⧸ R ∙ p ^ @Option.rec _ (fun _ => ℕ) (pOrder hM <| s j) k i) _ _).symm).trans
           (DirectSum.lequivCongrLeft R (finSuccEquiv d).symm)
         · rw [range_subtype, LinearEquiv.ker_comp, ker_mkQ]
-        · rw [← f.comp_coe, LinearMap.comp_assoc, LinearMap.comp_assoc,
-            LinearEquiv.toLinearMap_symm_comp_eq, LinearMap.comp_id, ← LinearMap.comp_assoc,
-            ← LinearMap.comp_assoc]
-          suffices (f.toLinearMap.comp (R ∙ s j).mkQ).comp _ = LinearMap.id by
-            rw [this, LinearMap.id_comp]
+        · rw [LinearMap.comp_assoc]
           ext i : 3
           simp only [LinearMap.coe_comp, Function.comp_apply, mkQ_apply]
           rw [LinearEquiv.coe_toLinearMap, LinearMap.id_apply, DirectSum.toModule_lof,

--- a/Mathlib/Algebra/Module/PID.lean
+++ b/Mathlib/Algebra/Module/PID.lean
@@ -53,7 +53,6 @@ universe u v
 
 variable {R : Type u} [CommRing R] [IsPrincipalIdealRing R]
 variable {M : Type v} [AddCommGroup M] [Module R M]
-variable {N : Type v} [AddCommGroup N] [Module R N]
 
 open scoped DirectSum
 
@@ -163,21 +162,22 @@ theorem exists_smul_eq_zero_and_mk_eq {z : M} (hz : Module.IsTorsionBy R M (p ^ 
 
 open Finset Multiset
 
+omit dec in
 /-- A finitely generated `p ^ ∞`-torsion module over a PID is isomorphic to a direct sum of some
   `R ⧸ R ∙ (p ^ e i)` for some `e i`. -/
-theorem torsion_by_prime_power_decomposition (hN : Module.IsTorsion' N (Submonoid.powers p))
-    [h' : Module.Finite R N] :
-    ∃ (d : ℕ) (k : Fin d → ℕ), Nonempty <| N ≃ₗ[R] ⨁ i : Fin d, R ⧸ R ∙ p ^ (k i : ℕ) := by
+theorem torsion_by_prime_power_decomposition (hM : Module.IsTorsion' M (Submonoid.powers p))
+    [h' : Module.Finite R M] :
+    ∃ (d : ℕ) (k : Fin d → ℕ), Nonempty <| M ≃ₗ[R] ⨁ i : Fin d, R ⧸ R ∙ p ^ (k i : ℕ) := by
   suffices H : ∀ {N : Type max u v} [AddCommGroup N] [Module R N]
       (hN : Module.IsTorsion' N (Submonoid.powers p)) [Module.Finite R N],
       ∃ (d : ℕ) (k : Fin d → ℕ), Nonempty <| N ≃ₗ[R] ⨁ i : Fin d, R ⧸ R ∙ p ^ (k i : ℕ) by
-    have := Module.Finite.equiv (ULift.moduleEquiv.{u, v, u} (R := R) (M := N)).symm
-    have hN' : Module.IsTorsion' (ULift.{u} N) (Submonoid.powers p) := by
-      rw [IsTorsion'] at hN ⊢
+    have := Module.Finite.equiv (ULift.moduleEquiv.{u, v, u} (R := R) (M := M)).symm
+    have hM' : Module.IsTorsion' (ULift.{u} M) (Submonoid.powers p) := by
+      rw [IsTorsion'] at hM ⊢
       rintro ⟨x⟩
-      obtain ⟨a, ha⟩ := @hN x
+      obtain ⟨a, ha⟩ := @hM x
       exact ⟨a, by ext1; exact ha⟩
-    obtain ⟨d, k, ⟨f⟩⟩ := H hN'
+    obtain ⟨d, k, ⟨f⟩⟩ := H hM'
     exact ⟨d, k, ⟨ULift.moduleEquiv.symm ≪≫ₗ f⟩⟩
   intro N _ _ hN h'
   obtain ⟨d, s, hs⟩ := @Module.Finite.exists_fin _ _ _ _ _ h'; use d; clear h'
@@ -241,16 +241,16 @@ end PTorsion
 
 /-- A finitely generated torsion module over a PID is isomorphic to a direct sum of some
   `R ⧸ R ∙ (p i ^ e i)` where the `p i ^ e i` are prime powers. -/
-theorem equiv_directSum_of_isTorsion [h' : Module.Finite R N] (hN : Module.IsTorsion R N) :
+theorem equiv_directSum_of_isTorsion [h' : Module.Finite R M] (hM : Module.IsTorsion R M) :
     ∃ (ι : Type u) (_ : Fintype ι) (p : ι → R) (_ : ∀ i, Irreducible <| p i) (e : ι → ℕ),
-      Nonempty <| N ≃ₗ[R] ⨁ i : ι, R ⧸ R ∙ p i ^ e i := by
-  obtain ⟨I, fI, _, p, hp, e, h⟩ := Submodule.exists_isInternal_prime_power_torsion_of_pid hN
+      Nonempty <| M ≃ₗ[R] ⨁ i : ι, R ⧸ R ∙ p i ^ e i := by
+  obtain ⟨I, fI, _, p, hp, e, h⟩ := Submodule.exists_isInternal_prime_power_torsion_of_pid hM
   haveI := fI
   have :
     ∀ i,
       ∃ (d : ℕ) (k : Fin d → ℕ),
-        Nonempty <| torsionBy R N (p i ^ e i) ≃ₗ[R] ⨁ j, R ⧸ R ∙ p i ^ k j := by
-    haveI := fun i => isNoetherian_submodule' (torsionBy R N <| p i ^ e i)
+        Nonempty <| torsionBy R M (p i ^ e i) ≃ₗ[R] ⨁ j, R ⧸ R ∙ p i ^ k j := by
+    haveI := fun i => isNoetherian_submodule' (torsionBy R M <| p i ^ e i)
     exact fun i =>
       torsion_by_prime_power_decomposition.{u, v} (hp i)
         ((isTorsion'_powers_iff <| p i).mpr fun x => ⟨e i, smul_torsionBy _ _⟩)
@@ -268,19 +268,19 @@ theorem equiv_directSum_of_isTorsion [h' : Module.Finite R N] (hN : Module.IsTor
 /-- **Structure theorem of finitely generated modules over a PID** : A finitely generated
   module over a PID is isomorphic to the product of a free module and a direct sum of some
   `R ⧸ R ∙ (p i ^ e i)` where the `p i ^ e i` are prime powers. -/
-theorem equiv_free_prod_directSum [h' : Module.Finite R N] :
+theorem equiv_free_prod_directSum [h' : Module.Finite R M] :
     ∃ (n : ℕ) (ι : Type u) (_ : Fintype ι) (p : ι → R) (_ : ∀ i, Irreducible <| p i) (e : ι → ℕ),
-      Nonempty <| N ≃ₗ[R] (Fin n →₀ R) × ⨁ i : ι, R ⧸ R ∙ p i ^ e i := by
-  haveI := isNoetherian_submodule' (torsion R N)
-  haveI := Module.Finite.of_surjective _ (torsion R N).mkQ_surjective
+      Nonempty <| M ≃ₗ[R] (Fin n →₀ R) × ⨁ i : ι, R ⧸ R ∙ p i ^ e i := by
+  haveI := isNoetherian_submodule' (torsion R M)
+  haveI := Module.Finite.of_surjective _ (torsion R M).mkQ_surjective
   obtain ⟨I, fI, p, hp, e, ⟨h⟩⟩ :=
-    equiv_directSum_of_isTorsion.{u, v} (@torsion_isTorsion R N _ _ _)
-  obtain ⟨n, ⟨g⟩⟩ := @Module.basisOfFiniteTypeTorsionFree' R _ (N ⧸ torsion R N) _ _ _ _ _ _
-  haveI : Module.Projective R (N ⧸ torsion R N) := Module.Projective.of_basis ⟨g⟩
-  obtain ⟨f, hf⟩ := Module.projective_lifting_property _ LinearMap.id (torsion R N).mkQ_surjective
+    equiv_directSum_of_isTorsion.{u, v} (@torsion_isTorsion R M _ _ _)
+  obtain ⟨n, ⟨g⟩⟩ := @Module.basisOfFiniteTypeTorsionFree' R _ (M ⧸ torsion R M) _ _ _ _ _ _
+  haveI : Module.Projective R (M ⧸ torsion R M) := Module.Projective.of_basis ⟨g⟩
+  obtain ⟨f, hf⟩ := Module.projective_lifting_property _ LinearMap.id (torsion R M).mkQ_surjective
   refine
     ⟨n, I, fI, p, hp, e,
-      ⟨(lequivProdOfRightSplitExact (torsion R N).injective_subtype ?_ hf).symm.trans <|
+      ⟨(lequivProdOfRightSplitExact (torsion R M).injective_subtype ?_ hf).symm.trans <|
           (h.prodCongr g).trans <| LinearEquiv.prodComm.{u, u} R _ (Fin n →₀ R) ⟩⟩
   rw [range_subtype, ker_mkQ]
 


### PR DESCRIPTION
Originally the structure theorem of finitely generated torsion modules `N` over PID `R : Type u` required that `N : Type max u v`. This PR fixes it to `M : Type v`.

Now that `lequivProdOfRightSplitExact` is universe polymorphic, we can also drop the use of `ULift.moduleEquiv` in the proofs.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]

-->
- [x] depends on: #24419

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

Discussions: [#mathlib4 > Universe question in Module.equiv_directSum_of_isTorsion](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Universe.20question.20in.20Module.2Eequiv_directSum_of_isTorsion)