### PR TITLE
[Merged by Bors] - chore(RingTheory/Polynomial/Eisenstein/Distinguished): fix namespace

### DIFF
--- a/Mathlib/RingTheory/Polynomial/Eisenstein/Distinguished.lean
+++ b/Mathlib/RingTheory/Polynomial/Eisenstein/Distinguished.lean
@@ -29,9 +29,9 @@ structure Polynomial.IsDistinguishedAt (f : R[X]) (I : Ideal R) : Prop
     extends f.IsWeaklyEisensteinAt I where
   monic : f.Monic
 
-namespace IsDistinguishedAt
+namespace Polynomial.IsDistinguishedAt
 
-lemma map_eq_X_pow (f : R[X]) {I : Ideal R} (distinguish : f.IsDistinguishedAt I) :
+lemma map_eq_X_pow {f : R[X]} {I : Ideal R} (distinguish : f.IsDistinguishedAt I) :
     f.map (Ideal.Quotient.mk I) = Polynomial.X ^ f.natDegree := by
   ext i
   by_cases ne : i = f.natDegree
@@ -41,9 +41,9 @@ lemma map_eq_X_pow (f : R[X]) {I : Ideal R} (distinguish : f.IsDistinguishedAt I
     · simp [ne, Polynomial.coeff_eq_zero_of_natDegree_lt gt]
 
 lemma degree_eq_order_map {I : Ideal R} (f : PowerSeries R)
-    (h : R⟦X⟧) (g : R[X]) (distinguish : g.IsDistinguishedAt I) (nmem : ¬ constantCoeff R h ∈ I)
+    (h : R⟦X⟧) {g : R[X]} (distinguish : g.IsDistinguishedAt I) (nmem : ¬ constantCoeff R h ∈ I)
     (eq : f = g * h) : g.degree = (f.map (Ideal.Quotient.mk I)).order := by
-  let _ : Nontrivial R := nontrivial_iff.mpr
+  have : Nontrivial R := nontrivial_iff.mpr
     ⟨0, constantCoeff R h, ne_of_mem_of_not_mem I.zero_mem nmem⟩
   rw [Polynomial.degree_eq_natDegree distinguish.monic.ne_zero, Eq.comm, PowerSeries.order_eq_nat]
   have mapf : f.map (Ideal.Quotient.mk I) = (Polynomial.X ^ g.natDegree : (R ⧸ I)[X]) *
@@ -54,4 +54,4 @@ lemma degree_eq_order_map {I : Ideal R} (f : PowerSeries R)
   · intro i hi
     simp [mapf, coeff_X_pow_mul', hi]
 
-end IsDistinguishedAt
+end Polynomial.IsDistinguishedAt

--- a/Mathlib/RingTheory/Polynomial/Eisenstein/Distinguished.lean
+++ b/Mathlib/RingTheory/Polynomial/Eisenstein/Distinguished.lean
@@ -41,17 +41,18 @@ lemma map_eq_X_pow {f : R[X]} {I : Ideal R} (distinguish : f.IsDistinguishedAt I
     · simp [ne, Polynomial.coeff_eq_zero_of_natDegree_lt gt]
 
 lemma degree_eq_order_map {I : Ideal R} (f : PowerSeries R)
-    (h : R⟦X⟧) {g : R[X]} (distinguish : g.IsDistinguishedAt I) (nmem : ¬ constantCoeff R h ∈ I)
+    (h : R⟦X⟧) {g : R[X]} (distinguish : g.IsDistinguishedAt I)
+    (nmem : PowerSeries.constantCoeff R h ∉ I)
     (eq : f = g * h) : g.degree = (f.map (Ideal.Quotient.mk I)).order := by
-  have : Nontrivial R := nontrivial_iff.mpr
-    ⟨0, constantCoeff R h, ne_of_mem_of_not_mem I.zero_mem nmem⟩
+  have : Nontrivial R := _root_.nontrivial_iff.mpr
+    ⟨0, PowerSeries.constantCoeff R h, ne_of_mem_of_not_mem I.zero_mem nmem⟩
   rw [Polynomial.degree_eq_natDegree distinguish.monic.ne_zero, Eq.comm, PowerSeries.order_eq_nat]
   have mapf : f.map (Ideal.Quotient.mk I) = (Polynomial.X ^ g.natDegree : (R ⧸ I)[X]) *
     h.map (Ideal.Quotient.mk I) := by
-    simp only [← map_eq_X_pow g distinguish, Polynomial.polynomial_map_coe, eq, _root_.map_mul]
+    simp only [← map_eq_X_pow distinguish, Polynomial.polynomial_map_coe, eq, _root_.map_mul]
   constructor
-  · simp [mapf, coeff_X_pow_mul', eq_zero_iff_mem, nmem]
+  · simp [mapf, PowerSeries.coeff_X_pow_mul', eq_zero_iff_mem, nmem]
   · intro i hi
-    simp [mapf, coeff_X_pow_mul', hi]
+    simp [mapf, PowerSeries.coeff_X_pow_mul', hi]
 
 end Polynomial.IsDistinguishedAt

--- a/Mathlib/RingTheory/Polynomial/Eisenstein/Distinguished.lean
+++ b/Mathlib/RingTheory/Polynomial/Eisenstein/Distinguished.lean
@@ -40,6 +40,9 @@ lemma map_eq_X_pow {f : R[X]} {I : Ideal R} (distinguish : f.IsDistinguishedAt I
     · simpa [ne, eq_zero_iff_mem] using (distinguish.mem lt)
     · simp [ne, Polynomial.coeff_eq_zero_of_natDegree_lt gt]
 
+@[deprecated (since := "2025-04-27")]
+alias _root_.IsDistinguishedAt.map_eq_X_pow := map_eq_X_pow
+
 lemma degree_eq_order_map {I : Ideal R} (f : PowerSeries R)
     (h : R⟦X⟧) {g : R[X]} (distinguish : g.IsDistinguishedAt I)
     (nmem : PowerSeries.constantCoeff R h ∉ I)
@@ -54,5 +57,8 @@ lemma degree_eq_order_map {I : Ideal R} (f : PowerSeries R)
   · simp [mapf, PowerSeries.coeff_X_pow_mul', eq_zero_iff_mem, nmem]
   · intro i hi
     simp [mapf, PowerSeries.coeff_X_pow_mul', hi]
+
+@[deprecated (since := "2025-04-27")]
+alias _root_.IsDistinguishedAt.degree_eq_order_map := degree_eq_order_map
 
 end Polynomial.IsDistinguishedAt


### PR DESCRIPTION
From `IsDistinguishedAt.XXX` to `Polynomial.IsDistinguishedAt.XXX` which enables dot notation. Also changed some variables into implicit.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
