### PR TITLE
refactor(Topology/Algebra/Module/WeakDual): Clean up

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -5789,6 +5789,7 @@ import Mathlib.Topology.Algebra.Module.Cardinality
 import Mathlib.Topology.Algebra.Module.CharacterSpace
 import Mathlib.Topology.Algebra.Module.Compact
 import Mathlib.Topology.Algebra.Module.Determinant
+import Mathlib.Topology.Algebra.Module.Dual
 import Mathlib.Topology.Algebra.Module.Equiv
 import Mathlib.Topology.Algebra.Module.FiniteDimension
 import Mathlib.Topology.Algebra.Module.LinearMap

--- a/Mathlib/Analysis/Fourier/RiemannLebesgueLemma.lean
+++ b/Mathlib/Analysis/Fourier/RiemannLebesgueLemma.lean
@@ -11,7 +11,6 @@ import Mathlib.MeasureTheory.Group.Integral
 import Mathlib.MeasureTheory.Integral.Bochner.Set
 import Mathlib.Topology.EMetricSpace.Paracompact
 import Mathlib.MeasureTheory.Measure.Haar.Unique
-import Mathlib.Topology.Algebra.Module.WeakDual
 
 /-!
 # The Riemann-Lebesgue Lemma

--- a/Mathlib/Analysis/Fourier/RiemannLebesgueLemma.lean
+++ b/Mathlib/Analysis/Fourier/RiemannLebesgueLemma.lean
@@ -269,14 +269,12 @@ theorem tendsto_integral_exp_smul_cocompact (μ : Measure V) [μ.IsAddHaarMeasur
     exact (ContinuousLinearEquiv.symm_apply_apply A v).symm
   · exact (ContinuousLinearEquiv.symm_apply_apply A v).symm
 
-open ContinuousLinearMap
-
 /-- The Riemann-Lebesgue lemma, formulated in terms of `VectorFourier.fourierIntegral` (with the
 pairing in the definition of `fourierIntegral` taken to be the canonical pairing between `V` and
 its dual space). -/
 theorem Real.zero_at_infty_vector_fourierIntegral (μ : Measure V) [μ.IsAddHaarMeasure] :
-    Tendsto (VectorFourier.fourierIntegral 𝐞 μ (dualPairing ℝ V).flip f) (cocompact (V →L[ℝ] ℝ))
-      (𝓝 0) :=
+    Tendsto (VectorFourier.fourierIntegral 𝐞 μ (ContinuousLinearMap.dualPairing ℝ V).flip f)
+      (cocompact (V →L[ℝ] ℝ)) (𝓝 0) :=
   _root_.tendsto_integral_exp_smul_cocompact f μ
 
 end NoInnerProduct

--- a/Mathlib/Analysis/Fourier/RiemannLebesgueLemma.lean
+++ b/Mathlib/Analysis/Fourier/RiemannLebesgueLemma.lean
@@ -269,11 +269,13 @@ theorem tendsto_integral_exp_smul_cocompact (μ : Measure V) [μ.IsAddHaarMeasur
     exact (ContinuousLinearEquiv.symm_apply_apply A v).symm
   · exact (ContinuousLinearEquiv.symm_apply_apply A v).symm
 
+open ContinuousLinearMap
+
 /-- The Riemann-Lebesgue lemma, formulated in terms of `VectorFourier.fourierIntegral` (with the
-pairing in the definition of `fourier_integral` taken to be the canonical pairing between `V` and
+pairing in the definition of `fourierIntegral` taken to be the canonical pairing between `V` and
 its dual space). -/
 theorem Real.zero_at_infty_vector_fourierIntegral (μ : Measure V) [μ.IsAddHaarMeasure] :
-    Tendsto (VectorFourier.fourierIntegral 𝐞 μ (topDualPairing ℝ V).flip f) (cocompact (V →L[ℝ] ℝ))
+    Tendsto (VectorFourier.fourierIntegral 𝐞 μ (dualPairing ℝ V).flip f) (cocompact (V →L[ℝ] ℝ))
       (𝓝 0) :=
   _root_.tendsto_integral_exp_smul_cocompact f μ
 

--- a/Mathlib/Analysis/InnerProductSpace/Adjoint.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Adjoint.lean
@@ -65,12 +65,11 @@ variable [CompleteSpace E] [CompleteSpace G]
 definition for the main definition `adjoint`, where this is bundled as a conjugate-linear isometric
 equivalence. -/
 noncomputable def adjointAux : (E →L[𝕜] F) →L⋆[𝕜] F →L[𝕜] E :=
-  (ContinuousLinearMap.compSL _ _ _ _ _ ((toDual 𝕜 E).symm : NormedSpace.Dual 𝕜 E →L⋆[𝕜] E)).comp
-    (toSesqForm : (E →L[𝕜] F) →L[𝕜] F →L⋆[𝕜] NormedSpace.Dual 𝕜 E)
+  (ContinuousLinearMap.compSL _ _ _ _ _ (toDual 𝕜 E).symm).comp (toSesqForm (𝕜 := 𝕜) (E := E))
 
 @[simp]
 theorem adjointAux_apply (A : E →L[𝕜] F) (x : F) :
-    adjointAux A x = ((toDual 𝕜 E).symm : NormedSpace.Dual 𝕜 E → E) ((toSesqForm A) x) :=
+    adjointAux A x = (toDual 𝕜 E).symm (toSesqForm A x) :=
   rfl
 
 theorem adjointAux_inner_left (A : E →L[𝕜] F) (x : E) (y : F) : ⟪adjointAux A y, x⟫ = ⟪y, A x⟫ := by

--- a/Mathlib/Analysis/InnerProductSpace/Dual.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Dual.lean
@@ -4,8 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Frédéric Dupuis
 -/
 import Mathlib.Analysis.InnerProductSpace.Projection
-import Mathlib.Analysis.Normed.Module.Dual
 import Mathlib.Analysis.Normed.Group.NullSubmodule
+import Mathlib.Topology.Algebra.Module.Dual
 
 /-!
 # The Fréchet-Riesz representation theorem

--- a/Mathlib/Analysis/InnerProductSpace/Dual.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Dual.lean
@@ -56,11 +56,11 @@ local postfix:90 "†" => starRingEnd _
 
 /-- An element `x` of an inner product space `E` induces an element of the dual space `Dual 𝕜 E`,
 the map `fun y => ⟪x, y⟫`; moreover this operation is a conjugate-linear isometric embedding of `E`
-into `Dual 𝕜 E`.
+into `ContinuousLinearMap.Dual 𝕜 E`.
 If `E` is complete, this operation is surjective, hence a conjugate-linear isometric equivalence;
 see `toDual`.
 -/
-def toDualMap : E →ₗᵢ⋆[𝕜] NormedSpace.Dual 𝕜 E :=
+def toDualMap : E →ₗᵢ⋆[𝕜] Dual 𝕜 E :=
   { innerSL 𝕜 with norm_map' := innerSL_apply_norm _ }
 
 variable {E}
@@ -121,7 +121,7 @@ variable [CompleteSpace E]
 /-- **Fréchet-Riesz representation**: any `ℓ` in the dual of a Hilbert space `E` is of the form
 `fun u => ⟪y, u⟫` for some `y : E`, i.e. `toDualMap` is surjective.
 -/
-def toDual : E ≃ₗᵢ⋆[𝕜] NormedSpace.Dual 𝕜 E :=
+def toDual : E ≃ₗᵢ⋆[𝕜] Dual 𝕜 E :=
   LinearIsometryEquiv.ofSurjective (toDualMap 𝕜 E)
     (by
       intro ℓ
@@ -168,12 +168,12 @@ theorem toDual_apply {x y : E} : toDual 𝕜 E x y = ⟪x, y⟫ :=
   rfl
 
 @[simp]
-theorem toDual_symm_apply {x : E} {y : NormedSpace.Dual 𝕜 E} : ⟪(toDual 𝕜 E).symm y, x⟫ = y x := by
+theorem toDual_symm_apply {x : E} {y : Dual 𝕜 E} : ⟪(toDual 𝕜 E).symm y, x⟫ = y x := by
   rw [← toDual_apply]
   simp only [LinearIsometryEquiv.apply_symm_apply]
 
 /-- Maps a bounded sesquilinear form to its continuous linear map,
-given by interpreting the form as a map `B : E →L⋆[𝕜] NormedSpace.Dual 𝕜 E`
+given by interpreting the form as a map `B : E →L⋆[𝕜] ContinuousLinearMap.Dual 𝕜 E`
 and dualizing the result using `toDual`.
 -/
 def continuousLinearMapOfBilin (B : E →L⋆[𝕜] E →L[𝕜] 𝕜) : E →L[𝕜] E :=

--- a/Mathlib/Analysis/LocallyConvex/WeakSpace.lean
+++ b/Mathlib/Analysis/LocallyConvex/WeakSpace.lean
@@ -43,7 +43,7 @@ theorem Convex.toWeakSpace_closure {s : Set E} (hs : Convex ℝ s) :
     hs.closure isClosed_closure (by simpa using hx)
   let f' : WeakSpace 𝕜 E →L[𝕜] 𝕜 :=
     { toLinearMap := (f : E →ₗ[𝕜] 𝕜).comp ((toWeakSpace 𝕜 E).symm : WeakSpace 𝕜 E →ₗ[𝕜] E)
-      cont := WeakBilin.eval_continuous (topDualPairing 𝕜 E).flip _ }
+      cont := WeakBilin.eval_continuous (ContinuousLinearMap.dualPairing 𝕜 E).flip _ }
   have hux' : u < RCLike.reCLM.comp (f'.restrictScalars ℝ) (toWeakSpace 𝕜 E x) := by simpa [f']
   have hus' : closure (toWeakSpace 𝕜 E '' s) ⊆
       {y | RCLike.reCLM.comp (f'.restrictScalars ℝ) y ≤ u} := by

--- a/Mathlib/Analysis/Normed/Module/Dual.lean
+++ b/Mathlib/Analysis/Normed/Module/Dual.lean
@@ -9,17 +9,17 @@ import Mathlib.Analysis.NormedSpace.RCLike
 import Mathlib.Data.Set.Finite.Lemmas
 import Mathlib.Analysis.LocallyConvex.AbsConvex
 import Mathlib.Analysis.Normed.Module.Convex
+import Mathlib.Topology.Algebra.Module.Dual
 
 /-!
 # The topological dual of a normed space
 
-In this file we define the topological dual `NormedSpace.Dual` of a normed space, and the
-continuous linear map `NormedSpace.inclusionInDoubleDual` from a normed space into its double
-dual.
+In this file we define the continuous linear map `NormedSpace.inclusionInDoubleDual` from a normed
+space into its double dual.
 
 For base field `𝕜 = ℝ` or `𝕜 = ℂ`, this map is actually an isometric embedding; we provide a
 version `NormedSpace.inclusionInDoubleDualLi` of the map which is of type a bundled linear
-isometric embedding, `E →ₗᵢ[𝕜] (Dual 𝕜 (Dual 𝕜 E))`.
+isometric embedding, `E →ₗᵢ[𝕜] (ContinuousLinearMap.Dual 𝕜 (ContinuousLinearMap.Dual 𝕜 E))`.
 
 Since a lot of elementary properties don't require `eq_of_dist_eq_zero` we start setting up the
 theory for `SeminormedAddCommGroup` and we specialize to `NormedAddCommGroup` when needed.
@@ -43,7 +43,7 @@ dual, polar
 
 noncomputable section
 
-open Topology Bornology
+open Topology Bornology ContinuousLinearMap
 
 universe u v
 
@@ -54,9 +54,6 @@ section General
 variable (𝕜 : Type*) [NontriviallyNormedField 𝕜]
 variable (E : Type*) [SeminormedAddCommGroup E] [NormedSpace 𝕜 E]
 variable (F : Type*) [NormedAddCommGroup F] [NormedSpace 𝕜 F]
-
-/-- The topological dual of a seminormed space `E`. -/
-abbrev Dual : Type _ := E →L[𝕜] 𝕜
 
 /-- The inclusion of a normed space in its double (topological) dual, considered
    as a bounded linear map. -/
@@ -77,18 +74,6 @@ theorem inclusionInDoubleDual_norm_le : ‖inclusionInDoubleDual 𝕜 E‖ ≤ 1
 
 theorem double_dual_bound (x : E) : ‖(inclusionInDoubleDual 𝕜 E) x‖ ≤ ‖x‖ := by
   simpa using ContinuousLinearMap.le_of_opNorm_le _ (inclusionInDoubleDual_norm_le 𝕜 E) x
-
-/-- The dual pairing as a bilinear form. -/
-def dualPairing : Dual 𝕜 E →ₗ[𝕜] E →ₗ[𝕜] 𝕜 :=
-  ContinuousLinearMap.coeLM 𝕜
-
-@[simp]
-theorem dualPairing_apply {v : Dual 𝕜 E} {x : E} : dualPairing 𝕜 E v x = v x :=
-  rfl
-
-theorem dualPairing_separatingLeft : (dualPairing 𝕜 E).SeparatingLeft := by
-  rw [LinearMap.separatingLeft_iff_ker_eq_bot, LinearMap.ker_eq_bot]
-  exact ContinuousLinearMap.coe_injective
 
 end General
 

--- a/Mathlib/Analysis/Normed/Module/WeakDual.lean
+++ b/Mathlib/Analysis/Normed/Module/WeakDual.lean
@@ -15,9 +15,9 @@ topology on the dual of `E`. By the dual, we mean either of the type synonyms
 `ContinuousLinearMap.Dual 𝕜 E` or `WeakDual 𝕜 E`, depending on whether it is viewed as equipped with
 its usual operator norm topology or the weak-* topology.
 
-It is shown that the canonical mapping `NormedSpace.Dual 𝕜 E → WeakDual 𝕜 E` is continuous, and
-as a consequence the weak-* topology is coarser than the topology obtained from the operator norm
-(dual norm).
+It is shown that the canonical mapping `ContinuousLinearMap.Dual 𝕜 E → WeakDual 𝕜 E` is continuous,
+and as a consequence the weak-* topology is coarser than the topology obtained from the operator
+norm (dual norm).
 
 In this file, we also establish the Banach-Alaoglu theorem about the compactness of closed balls
 in the dual of `E` (as well as sets of somewhat more general form) with respect to the weak-*
@@ -105,7 +105,7 @@ by the dual-norm (i.e. the operator-norm).
 variable {𝕜 : Type*} [NontriviallyNormedField 𝕜]
 variable {E : Type*} [SeminormedAddCommGroup E] [NormedSpace 𝕜 E]
 
-namespace NormedSpace
+namespace ContinuousLinearMap
 
 namespace Dual
 
@@ -125,34 +125,35 @@ theorem toWeakDual_inj (x' y' : Dual 𝕜 E) : toWeakDual x' = toWeakDual y' ↔
 @[deprecated (since := "2024-12-29")] alias toWeakDual_eq_iff := toWeakDual_inj
 
 theorem toWeakDual_continuous : Continuous fun x' : Dual 𝕜 E => toWeakDual x' :=
-  WeakBilin.continuous_of_continuous_eval _ fun z => (inclusionInDoubleDual 𝕜 E z).continuous
+  WeakBilin.continuous_of_continuous_eval _ fun z =>
+    (NormedSpace.inclusionInDoubleDual 𝕜 E z).continuous
 
 /-- For a normed space `E`, according to `toWeakDual_continuous` the "identity mapping"
-`Dual 𝕜 E → WeakDual 𝕜 E` is continuous. This definition implements it as a continuous linear
-map. -/
+`ContinuousLinearMap.Dual 𝕜 E → WeakDual 𝕜 E` is continuous. This definition implements it as a
+continuous linear map. -/
 def continuousLinearMapToWeakDual : Dual 𝕜 E →L[𝕜] WeakDual 𝕜 E :=
   { toWeakDual with cont := toWeakDual_continuous }
 
 /-- The weak-star topology is coarser than the dual-norm topology. -/
 theorem dual_norm_topology_le_weak_dual_topology :
     (UniformSpace.toTopologicalSpace : TopologicalSpace (Dual 𝕜 E)) ≤
-      (WeakDual.instTopologicalSpace : TopologicalSpace (WeakDual 𝕜 E)) := by
+      (WeakBilin.instTopologicalSpace _ : TopologicalSpace (WeakDual 𝕜 E)) := by
   convert (@toWeakDual_continuous _ _ _ _ (by assumption)).le_induced
   exact induced_id.symm
 
 end Dual
 
-end NormedSpace
+end ContinuousLinearMap
 
 namespace WeakDual
 
-open NormedSpace
+open ContinuousLinearMap NormedSpace
 
-/-- For normed spaces `E`, there is a canonical map `WeakDual 𝕜 E → Dual 𝕜 E` (the "identity"
-mapping). It is a linear equivalence. Here it is implemented as the inverse of the linear
-equivalence `NormedSpace.Dual.toWeakDual` in the other direction. -/
+/-- For normed spaces `E`, there is a canonical map `WeakDual 𝕜 E → ContinuousLinearMap.Dual 𝕜 E`
+(the "identity" mapping). It is a linear equivalence. Here it is implemented as the inverse of the
+linear equivalence `ContinuousLinearMap.Dual.toWeakDual` in the other direction. -/
 def toNormedDual : WeakDual 𝕜 E ≃ₗ[𝕜] Dual 𝕜 E :=
-  NormedSpace.Dual.toWeakDual.symm
+  Dual.toWeakDual.symm
 
 theorem toNormedDual_apply (x : WeakDual 𝕜 E) (y : E) : (toNormedDual x) y = x y :=
   rfl

--- a/Mathlib/Analysis/Normed/Module/WeakDual.lean
+++ b/Mathlib/Analysis/Normed/Module/WeakDual.lean
@@ -12,8 +12,8 @@ import Mathlib.Topology.Algebra.Module.WeakDual
 
 Let `E` be a normed space over a field `𝕜`. This file is concerned with properties of the weak-*
 topology on the dual of `E`. By the dual, we mean either of the type synonyms
-`NormedSpace.Dual 𝕜 E` or `WeakDual 𝕜 E`, depending on whether it is viewed as equipped with its
-usual operator norm topology or the weak-* topology.
+`ContinuousLinearMap.Dual 𝕜 E` or `WeakDual 𝕜 E`, depending on whether it is viewed as equipped with
+its usual operator norm topology or the weak-* topology.
 
 It is shown that the canonical mapping `NormedSpace.Dual 𝕜 E → WeakDual 𝕜 E` is continuous, and
 as a consequence the weak-* topology is coarser than the topology obtained from the operator norm
@@ -27,10 +27,10 @@ topology.
 
 The main definitions concern the canonical mapping `Dual 𝕜 E → WeakDual 𝕜 E`.
 
-* `NormedSpace.Dual.toWeakDual` and `WeakDual.toNormedDual`: Linear equivalences from
-  `dual 𝕜 E` to `WeakDual 𝕜 E` and in the converse direction.
-* `NormedSpace.Dual.continuousLinearMapToWeakDual`: A continuous linear mapping from
-  `Dual 𝕜 E` to `WeakDual 𝕜 E` (same as `NormedSpace.Dual.toWeakDual` but different bundled
+* `ContinuousLinearMap.Dual.toWeakDual` and `WeakDual.toNormedDual`: Linear equivalences from
+  `Dual 𝕜 E` to `WeakDual 𝕜 E` and in the converse direction.
+* `ContinuousLinearMap.Dual.continuousLinearMapToWeakDual`: A continuous linear mapping from
+  `Dual 𝕜 E` to `WeakDual 𝕜 E` (same as `ContinuousLinearMap.Dual.toWeakDual` but different bundled
   data).
 
 ## Main results

--- a/Mathlib/Analysis/VonNeumannAlgebra/Basic.lean
+++ b/Mathlib/Analysis/VonNeumannAlgebra/Basic.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kim Morrison
 -/
 import Mathlib.Analysis.CStarAlgebra.ContinuousLinearMap
-import Mathlib.Analysis.Normed.Module.Dual
 
 /-!
 # Von Neumann algebras

--- a/Mathlib/Analysis/VonNeumannAlgebra/Basic.lean
+++ b/Mathlib/Analysis/VonNeumannAlgebra/Basic.lean
@@ -25,6 +25,8 @@ that the concrete definition is equivalent to a *-closed subalgebra which is wea
 
 universe u v
 
+open ContinuousLinearMap
+
 /-- Sakai's definition of a von Neumann algebra as a C^* algebra with a Banach space predual.
 
 So that we can unambiguously talk about these "abstract" von Neumann algebras
@@ -43,7 +45,7 @@ class WStarAlgebra (M : Type u) [CStarAlgebra M] : Prop where
   to the `WStarAlgebra`. -/
   exists_predual :
     ∃ (X : Type u) (_ : NormedAddCommGroup X) (_ : NormedSpace ℂ X) (_ : CompleteSpace X),
-      Nonempty (NormedSpace.Dual ℂ X ≃ₗᵢ⋆[ℂ] M)
+      Nonempty (Dual ℂ X ≃ₗᵢ⋆[ℂ] M)
 
 -- TODO: Without this, `VonNeumannAlgebra` times out. Why?
 /-- The double commutant definition of a von Neumann algebra,

--- a/Mathlib/MeasureTheory/Function/AEEqOfIntegral.lean
+++ b/Mathlib/MeasureTheory/Function/AEEqOfIntegral.lean
@@ -4,11 +4,12 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Rémy Degenne
 -/
 import Mathlib.Analysis.InnerProductSpace.Continuous
-import Mathlib.Analysis.Normed.Module.Dual
+import Mathlib.Analysis.NormedSpace.HahnBanach.Extension
 import Mathlib.MeasureTheory.Function.AEEqOfLIntegral
 import Mathlib.MeasureTheory.Function.StronglyMeasurable.Lp
 import Mathlib.MeasureTheory.Integral.Bochner.ContinuousLinearMap
 import Mathlib.Order.Filter.Ring
+import Mathlib.Topology.Algebra.Module.Dual
 
 /-! # From equality of integrals to equality of functions
 
@@ -43,7 +44,7 @@ Generally useful lemmas which are not related to integrals:
 -/
 
 
-open MeasureTheory TopologicalSpace NormedSpace Filter
+open MeasureTheory ContinuousLinearMap TopologicalSpace NormedSpace Filter
 
 open scoped ENNReal NNReal MeasureTheory Topology
 

--- a/Mathlib/MeasureTheory/Measure/FiniteMeasure.lean
+++ b/Mathlib/MeasureTheory/Measure/FiniteMeasure.lean
@@ -479,7 +479,7 @@ theorem tendsto_iff_forall_toWeakDualBCNN_tendsto {γ : Type*} {F : Filter γ}
     {μs : γ → FiniteMeasure Ω} {μ : FiniteMeasure Ω} :
     Tendsto μs F (𝓝 μ) ↔
       ∀ f : Ω →ᵇ ℝ≥0, Tendsto (fun i ↦ (μs i).toWeakDualBCNN f) F (𝓝 (μ.toWeakDualBCNN f)) := by
-  rw [tendsto_iff_weakDual_tendsto, WeakDual.tendsto_iff_forall_eval_tendsto_dualPairing]
+  rw [tendsto_iff_weakDual_tendsto, WeakDual.tendsto_iff_forall_eval_tendsto_dualPairing]; rfl
 
 theorem tendsto_iff_forall_testAgainstNN_tendsto {γ : Type*} {F : Filter γ}
     {μs : γ → FiniteMeasure Ω} {μ : FiniteMeasure Ω} :

--- a/Mathlib/MeasureTheory/Measure/FiniteMeasure.lean
+++ b/Mathlib/MeasureTheory/Measure/FiniteMeasure.lean
@@ -450,7 +450,7 @@ from the weak-* topology on `WeakDual ℝ≥0 (Ω →ᵇ ℝ≥0)` via the funct
 instance instTopologicalSpace : TopologicalSpace (FiniteMeasure Ω) :=
   TopologicalSpace.induced toWeakDualBCNN inferInstance
 
-theorem toWeakDualBCNN_continuous : Continuous (@toWeakDualBCNN Ω _ _ _) :=
+theorem toWeakDualBCNN_continuous : Continuous (toWeakDualBCNN (Ω := Ω)) :=
   continuous_induced_dom
 
 /-- Integration of (nonnegative bounded continuous) test functions against finite Borel measures
@@ -479,7 +479,7 @@ theorem tendsto_iff_forall_toWeakDualBCNN_tendsto {γ : Type*} {F : Filter γ}
     {μs : γ → FiniteMeasure Ω} {μ : FiniteMeasure Ω} :
     Tendsto μs F (𝓝 μ) ↔
       ∀ f : Ω →ᵇ ℝ≥0, Tendsto (fun i ↦ (μs i).toWeakDualBCNN f) F (𝓝 (μ.toWeakDualBCNN f)) := by
-  rw [tendsto_iff_weakDual_tendsto, tendsto_iff_forall_eval_tendsto_topDualPairing]; rfl
+  rw [tendsto_iff_weakDual_tendsto, WeakDual.tendsto_iff_forall_eval_tendsto_dualPairing]
 
 theorem tendsto_iff_forall_testAgainstNN_tendsto {γ : Type*} {F : Filter γ}
     {μs : γ → FiniteMeasure Ω} {μ : FiniteMeasure Ω} :

--- a/Mathlib/Topology/Algebra/Module/Dual.lean
+++ b/Mathlib/Topology/Algebra/Module/Dual.lean
@@ -1,0 +1,69 @@
+/-
+Copyright (c) 2024 Moritz Doll. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Moritz Doll, Kalle Kytölä
+-/
+import Mathlib.LinearAlgebra.SesquilinearForm
+import Mathlib.Topology.Algebra.Module.Basic
+import Mathlib.Topology.Algebra.Module.LinearMap
+
+/-!
+# Topological dual
+
+In a topological vector space `E` the topological dual `ContinuousLinearMap.Dual 𝕜 E` is the space
+of all continuous linear functions into `𝕜`, `E →L[𝕜] 𝕜`. We define the as an abbreviation, so that
+it automatically inherits the strong topology (the topology of bounded convergence). In particular,
+if `E` is a normed space, then `ContinuousLinearMap.Dual 𝕜 E` is a normed space as well.
+
+## Main definitions
+
+* `ContinuousLinearMap.Dual`: abbreviation for `E →L[𝕜] 𝕜`.
+* `ContinuousLinearMap.dualPairing`: the canonical pairing
+`ContinuousLinearMap.Dual 𝕜 E →ₗ[𝕜] E →ₗ[𝕜] 𝕜`.
+
+## Main statements
+
+* `ContinuousLinearMap.dualPairing_separatingLeft`: the dual pairing is always left separating
+
+-/
+
+noncomputable section
+
+open Filter Topology
+
+variable {𝕜 E F ι : Type*}
+
+namespace ContinuousLinearMap
+
+section CommSemiring
+
+variable [CommSemiring 𝕜] [TopologicalSpace 𝕜] [ContinuousAdd 𝕜] [AddCommMonoid E]
+    [Module 𝕜 E] [TopologicalSpace E] [ContinuousConstSMul 𝕜 𝕜]
+
+variable (𝕜 E) in
+/-- The topological dual of a topological vector space `E`. -/
+abbrev Dual : Type _ := E →L[𝕜] 𝕜
+
+variable (𝕜 E) in
+/-- The canonical pairing of a vector space and its topological dual. -/
+def dualPairing : (Dual 𝕜 E) →ₗ[𝕜] E →ₗ[𝕜] 𝕜 := ContinuousLinearMap.coeLM 𝕜
+
+@[simp]
+theorem dualPairing_apply (v : E →L[𝕜] 𝕜) (x : E) : dualPairing 𝕜 E v x = v x :=
+  rfl
+
+end CommSemiring
+
+section Ring
+
+variable [CommRing 𝕜] [TopologicalSpace 𝕜] [IsTopologicalAddGroup 𝕜] [AddCommGroup E]
+    [Module 𝕜 E] [TopologicalSpace E] [ContinuousConstSMul 𝕜 𝕜]
+
+variable (𝕜 E) in
+theorem dualPairing_separatingLeft : (dualPairing 𝕜 E).SeparatingLeft := by
+  rw [LinearMap.separatingLeft_iff_ker_eq_bot, LinearMap.ker_eq_bot]
+  exact ContinuousLinearMap.coe_injective
+
+end Ring
+
+end ContinuousLinearMap

--- a/Mathlib/Topology/Algebra/Module/WeakDual.lean
+++ b/Mathlib/Topology/Algebra/Module/WeakDual.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kalle Kytölä, Moritz Doll
 -/
 import Mathlib.LinearAlgebra.BilinearMap
-import Mathlib.Topology.Algebra.Module.LinearMap
+import Mathlib.Topology.Algebra.Module.Dual
 import Mathlib.Topology.Algebra.Module.WeakBilin
 
 /-!
@@ -13,7 +13,7 @@ import Mathlib.Topology.Algebra.Module.WeakBilin
 We continue in the setting of `Mathlib.Topology.Algebra.Module.WeakBilin`,
 which defines the weak topology given two vector spaces `E` and `F` over a commutative semiring
 `𝕜` and a bilinear form `B : E →ₗ[𝕜] F →ₗ[𝕜] 𝕜`. The weak topology on `E` is the coarsest topology
-such that for all `y : F` every map `fun x => B x y` is continuous.
+such that for all `y : F` every map `fun x ↦ B x y` is continuous.
 
 In this file, we consider two special cases.
 In the case that `F = E →L[𝕜] 𝕜` and `B` being the canonical pairing, we obtain the weak-* topology,
@@ -25,13 +25,13 @@ weak topology `WeakSpace 𝕜 E := E`.
 The main definitions are the types `WeakDual 𝕜 E` and `WeakSpace 𝕜 E`,
 with the respective topology instances on it.
 
-* `WeakDual 𝕜 E` is a type synonym for `Dual 𝕜 E` (when the latter is defined): both are equal to
-  the type `E →L[𝕜] 𝕜` of continuous linear maps from a module `E` over `𝕜` to the ring `𝕜`.
+* `WeakDual 𝕜 E` is a type synonym for `ContinuousLinearMap.Dual 𝕜 E`: both are equal to the type
+  `E →L[𝕜] 𝕜` of continuous linear maps from a module `E` over `𝕜` to the ring `𝕜`.
 * The instance `WeakDual.instTopologicalSpace` is the weak-* topology on `WeakDual 𝕜 E`, i.e., the
   coarsest topology making the evaluation maps at all `z : E` continuous.
-* `WeakSpace 𝕜 E` is a type synonym for `E` (when the latter is defined).
+* `WeakSpace 𝕜 E` is a type synonym for `E`.
 * The instance `WeakSpace.instTopologicalSpace` is the weak topology on `E`, i.e., the
-  coarsest topology such that all `v : dual 𝕜 E` remain continuous.
+  coarsest topology such that all `v : ContinuousLinearMap.Dual 𝕜 E` remain continuous.
 
 ## Notations
 
@@ -52,25 +52,15 @@ noncomputable section
 
 open Filter
 
-open Topology
+open Topology ContinuousLinearMap
 
 variable {α 𝕜 𝕝 E F : Type*}
 
-/-- The canonical pairing of a vector space and its topological dual. -/
-def topDualPairing (𝕜 E) [CommSemiring 𝕜] [TopologicalSpace 𝕜] [ContinuousAdd 𝕜] [AddCommMonoid E]
-    [Module 𝕜 E] [TopologicalSpace E] [ContinuousConstSMul 𝕜 𝕜] : (E →L[𝕜] 𝕜) →ₗ[𝕜] E →ₗ[𝕜] 𝕜 :=
-  ContinuousLinearMap.coeLM 𝕜
-
-theorem topDualPairing_apply [CommSemiring 𝕜] [TopologicalSpace 𝕜] [ContinuousAdd 𝕜]
-    [AddCommMonoid E] [Module 𝕜 E] [TopologicalSpace E] [ContinuousConstSMul 𝕜 𝕜] (v : E →L[𝕜] 𝕜)
-    (x : E) : topDualPairing 𝕜 E v x = v x :=
-  rfl
-
+variable (𝕜 E : Type*) [CommSemiring 𝕜] [TopologicalSpace 𝕜] [ContinuousAdd 𝕜]
+    [ContinuousConstSMul 𝕜 𝕜] [AddCommMonoid E] [Module 𝕜 E] [TopologicalSpace E] in
 /-- The weak star topology is the topology coarsest topology on `E →L[𝕜] 𝕜` such that all
 functionals `fun v => v x` are continuous. -/
-def WeakDual (𝕜 E : Type*) [CommSemiring 𝕜] [TopologicalSpace 𝕜] [ContinuousAdd 𝕜]
-    [ContinuousConstSMul 𝕜 𝕜] [AddCommMonoid E] [Module 𝕜 E] [TopologicalSpace E] :=
-  WeakBilin (topDualPairing 𝕜 E)
+abbrev WeakDual := WeakBilin (dualPairing 𝕜 E)
 
 namespace WeakDual
 
@@ -79,21 +69,6 @@ section Semiring
 variable [CommSemiring 𝕜] [TopologicalSpace 𝕜] [ContinuousAdd 𝕜]
 variable [ContinuousConstSMul 𝕜 𝕜]
 variable [AddCommMonoid E] [Module 𝕜 E] [TopologicalSpace E]
-
--- The following instances should be constructed by a deriving handler.
--- https://github.com/leanprover-community/mathlib4/issues/380
-
-instance instAddCommMonoid : AddCommMonoid (WeakDual 𝕜 E) :=
-  WeakBilin.instAddCommMonoid (topDualPairing 𝕜 E)
-
-instance instModule : Module 𝕜 (WeakDual 𝕜 E) :=
-  WeakBilin.instModule (topDualPairing 𝕜 E)
-
-instance instTopologicalSpace : TopologicalSpace (WeakDual 𝕜 E) :=
-  WeakBilin.instTopologicalSpace (topDualPairing 𝕜 E)
-
-instance instContinuousAdd : ContinuousAdd (WeakDual 𝕜 E) :=
-  WeakBilin.instContinuousAdd (topDualPairing 𝕜 E)
 
 instance instInhabited : Inhabited (WeakDual 𝕜 E) :=
   ContinuousLinearMap.inhabited
@@ -125,14 +100,14 @@ instance instModule' (R) [Semiring R] [Module R 𝕜] [SMulCommClass 𝕜 R 𝕜
 instance instContinuousConstSMul (M) [Monoid M] [DistribMulAction M 𝕜] [SMulCommClass 𝕜 M 𝕜]
     [ContinuousConstSMul M 𝕜] : ContinuousConstSMul M (WeakDual 𝕜 E) :=
   ⟨fun m =>
-    continuous_induced_rng.2 <| (WeakBilin.coeFn_continuous (topDualPairing 𝕜 E)).const_smul m⟩
+    continuous_induced_rng.2 <| (WeakBilin.coeFn_continuous (dualPairing 𝕜 E)).const_smul m⟩
 
 /-- If a monoid `M` distributively continuously acts on `𝕜` and this action commutes with
 multiplication on `𝕜`, then it continuously acts on `WeakDual 𝕜 E`. -/
 instance instContinuousSMul (M) [Monoid M] [DistribMulAction M 𝕜] [SMulCommClass 𝕜 M 𝕜]
     [TopologicalSpace M] [ContinuousSMul M 𝕜] : ContinuousSMul M (WeakDual 𝕜 E) :=
   ⟨continuous_induced_rng.2 <|
-      continuous_fst.smul ((WeakBilin.coeFn_continuous (topDualPairing 𝕜 E)).comp continuous_snd)⟩
+      continuous_fst.smul ((WeakBilin.coeFn_continuous (dualPairing 𝕜 E)).comp continuous_snd)⟩
 
 theorem coeFn_continuous : Continuous fun (x : WeakDual 𝕜 E) y => x y :=
   continuous_induced_dom
@@ -149,26 +124,13 @@ instance instT2Space [T2Space 𝕜] : T2Space (WeakDual 𝕜 E) :=
 
 end Semiring
 
-section Ring
-
-variable [CommRing 𝕜] [TopologicalSpace 𝕜] [IsTopologicalAddGroup 𝕜] [ContinuousConstSMul 𝕜 𝕜]
-variable [AddCommGroup E] [Module 𝕜 E] [TopologicalSpace E] [IsTopologicalAddGroup E]
-
-instance instAddCommGroup : AddCommGroup (WeakDual 𝕜 E) :=
-  WeakBilin.instAddCommGroup (topDualPairing 𝕜 E)
-
-instance instIsTopologicalAddGroup : IsTopologicalAddGroup (WeakDual 𝕜 E) :=
-  WeakBilin.instIsTopologicalAddGroup (topDualPairing 𝕜 E)
-
-end Ring
-
 end WeakDual
 
+variable (𝕜 E) [CommSemiring 𝕜] [TopologicalSpace 𝕜] [ContinuousAdd 𝕜]
+    [ContinuousConstSMul 𝕜 𝕜] [AddCommMonoid E] [Module 𝕜 E] [TopologicalSpace E] in
 /-- The weak topology is the topology coarsest topology on `E` such that all functionals
-`fun x => v x` are continuous. -/
-def WeakSpace (𝕜 E) [CommSemiring 𝕜] [TopologicalSpace 𝕜] [ContinuousAdd 𝕜]
-    [ContinuousConstSMul 𝕜 𝕜] [AddCommMonoid E] [Module 𝕜 E] [TopologicalSpace E] :=
-  WeakBilin (topDualPairing 𝕜 E).flip
+`x ↦ v x` are continuous. -/
+abbrev WeakSpace := WeakBilin (dualPairing 𝕜 E).flip
 
 section Semiring
 
@@ -177,28 +139,6 @@ variable [ContinuousConstSMul 𝕜 𝕜]
 variable [AddCommMonoid E] [Module 𝕜 E] [TopologicalSpace E]
 
 namespace WeakSpace
-
--- The following instances should be constructed by a deriving handler.
--- https://github.com/leanprover-community/mathlib4/issues/380
-
-instance instAddCommMonoid : AddCommMonoid (WeakSpace 𝕜 E) :=
-  WeakBilin.instAddCommMonoid (topDualPairing 𝕜 E).flip
-
-instance instModule : Module 𝕜 (WeakSpace 𝕜 E) :=
-  WeakBilin.instModule (topDualPairing 𝕜 E).flip
-
-instance instTopologicalSpace : TopologicalSpace (WeakSpace 𝕜 E) :=
-  WeakBilin.instTopologicalSpace (topDualPairing 𝕜 E).flip
-
-instance instContinuousAdd : ContinuousAdd (WeakSpace 𝕜 E) :=
-  WeakBilin.instContinuousAdd (topDualPairing 𝕜 E).flip
-
-instance instModule' [CommSemiring 𝕝] [Module 𝕝 E] : Module 𝕝 (WeakSpace 𝕜 E) :=
-  WeakBilin.instModule' (topDualPairing 𝕜 E).flip
-
-instance instIsScalarTower [CommSemiring 𝕝] [Module 𝕝 𝕜] [Module 𝕝 E] [IsScalarTower 𝕝 𝕜 E] :
-    IsScalarTower 𝕝 𝕜 (WeakSpace 𝕜 E) :=
-  WeakBilin.instIsScalarTower (topDualPairing 𝕜 E).flip
 
 variable [AddCommMonoid F] [Module 𝕜 F] [TopologicalSpace F]
 
@@ -251,27 +191,10 @@ theorem WeakSpace.isOpen_of_isOpen (V : Set E)
     (hV : IsOpen ((toWeakSpaceCLM 𝕜 E) '' V : Set (WeakSpace 𝕜 E))) : IsOpen V := by
   simpa [Set.image_image] using isOpenMap_toWeakSpace_symm _ hV
 
-theorem tendsto_iff_forall_eval_tendsto_topDualPairing {l : Filter α} {f : α → WeakDual 𝕜 E}
+theorem tendsto_iff_forall_eval_tendsto_dualPairing {l : Filter α} {f : α → WeakDual 𝕜 E}
     {x : WeakDual 𝕜 E} :
     Tendsto f l (𝓝 x) ↔
-      ∀ y, Tendsto (fun i => topDualPairing 𝕜 E (f i) y) l (𝓝 (topDualPairing 𝕜 E x y)) :=
+      ∀ y, Tendsto (fun i => dualPairing 𝕜 E (f i) y) l (𝓝 (dualPairing 𝕜 E x y)) :=
   WeakBilin.tendsto_iff_forall_eval_tendsto _ ContinuousLinearMap.coe_injective
 
 end Semiring
-
-section Ring
-
-namespace WeakSpace
-
-variable [CommRing 𝕜] [TopologicalSpace 𝕜] [IsTopologicalAddGroup 𝕜] [ContinuousConstSMul 𝕜 𝕜]
-variable [AddCommGroup E] [Module 𝕜 E] [TopologicalSpace E] [IsTopologicalAddGroup E]
-
-instance instAddCommGroup : AddCommGroup (WeakSpace 𝕜 E) :=
-  WeakBilin.instAddCommGroup (topDualPairing 𝕜 E).flip
-
-instance instIsTopologicalAddGroup : IsTopologicalAddGroup (WeakSpace 𝕜 E) :=
-  WeakBilin.instIsTopologicalAddGroup (topDualPairing 𝕜 E).flip
-
-end WeakSpace
-
-end Ring

--- a/Mathlib/Topology/Algebra/Module/WeakDual.lean
+++ b/Mathlib/Topology/Algebra/Module/WeakDual.lean
@@ -121,9 +121,8 @@ theorem continuous_of_continuous_eval [TopologicalSpace α] {g : α → WeakDual
 
 variable (𝕜 E) in
 /-- The coercion `WeakDual 𝕜 E → (E → 𝕜)` is an embedding. -/
-theorem embedding : Embedding fun (x : WeakDual 𝕜 E) y ↦ x y :=
-  Function.Injective.embedding_induced <| LinearMap.coe_injective.comp
-    ContinuousLinearMap.coe_injective
+theorem isEmbedding : IsEmbedding fun (x : WeakDual 𝕜 E) y ↦ x y :=
+  WeakBilin.isEmbedding ContinuousLinearMap.coe_injective
 
 theorem tendsto_iff_forall_eval_tendsto_dualPairing {l : Filter α} {f : α → WeakDual 𝕜 E}
     {x : WeakDual 𝕜 E} :
@@ -132,7 +131,7 @@ theorem tendsto_iff_forall_eval_tendsto_dualPairing {l : Filter α} {f : α → 
   WeakBilin.tendsto_iff_forall_eval_tendsto _ ContinuousLinearMap.coe_injective
 
 instance instT2Space [T2Space 𝕜] : T2Space (WeakDual 𝕜 E) :=
-   (WeakDual.embedding _ _).t2Space
+   (WeakDual.isEmbedding _ _).t2Space
 
 end Semiring
 

--- a/Mathlib/Topology/Algebra/Module/WeakDual.lean
+++ b/Mathlib/Topology/Algebra/Module/WeakDual.lean
@@ -119,8 +119,20 @@ theorem continuous_of_continuous_eval [TopologicalSpace α] {g : α → WeakDual
     (h : ∀ y, Continuous fun a => (g a) y) : Continuous g :=
   continuous_induced_rng.2 (continuous_pi_iff.mpr h)
 
+variable (𝕜 E) in
+/-- The coercion `WeakDual 𝕜 E → (E → 𝕜)` is an embedding. -/
+theorem embedding : Embedding fun (x : WeakDual 𝕜 E) y ↦ x y :=
+  Function.Injective.embedding_induced <| LinearMap.coe_injective.comp
+    ContinuousLinearMap.coe_injective
+
+theorem tendsto_iff_forall_eval_tendsto_dualPairing {l : Filter α} {f : α → WeakDual 𝕜 E}
+    {x : WeakDual 𝕜 E} :
+    Tendsto f l (𝓝 x) ↔
+      ∀ y, Tendsto (fun i => dualPairing 𝕜 E (f i) y) l (𝓝 (dualPairing 𝕜 E x y)) :=
+  WeakBilin.tendsto_iff_forall_eval_tendsto _ ContinuousLinearMap.coe_injective
+
 instance instT2Space [T2Space 𝕜] : T2Space (WeakDual 𝕜 E) :=
-   (WeakBilin.isEmbedding ContinuousLinearMap.coe_injective).t2Space
+   (WeakDual.embedding _ _).t2Space
 
 end Semiring
 
@@ -190,11 +202,5 @@ theorem isOpenMap_toWeakSpace_symm : IsOpenMap (toWeakSpace 𝕜 E).symm :=
 theorem WeakSpace.isOpen_of_isOpen (V : Set E)
     (hV : IsOpen ((toWeakSpaceCLM 𝕜 E) '' V : Set (WeakSpace 𝕜 E))) : IsOpen V := by
   simpa [Set.image_image] using isOpenMap_toWeakSpace_symm _ hV
-
-theorem tendsto_iff_forall_eval_tendsto_dualPairing {l : Filter α} {f : α → WeakDual 𝕜 E}
-    {x : WeakDual 𝕜 E} :
-    Tendsto f l (𝓝 x) ↔
-      ∀ y, Tendsto (fun i => dualPairing 𝕜 E (f i) y) l (𝓝 (dualPairing 𝕜 E x y)) :=
-  WeakBilin.tendsto_iff_forall_eval_tendsto _ ContinuousLinearMap.coe_injective
 
 end Semiring

--- a/docs/overview.yaml
+++ b/docs/overview.yaml
@@ -262,6 +262,7 @@ Analysis:
     local convexity: 'LocallyConvexSpace'
     Bornology: 'Bornology'
     weak-* topology for dualities: 'WeakBilin.instTopologicalSpace'
+    Topological dual: 'ContinuousLinearMap.Dual'
 
   Normed vector spaces/Banach spaces:
     normed vector space over a normed field: 'NormedSpace'
@@ -274,7 +275,6 @@ Analysis:
     Banach open mapping theorem: 'ContinuousLinearMap.isOpenMap'
     absolutely convergent series in Banach spaces: 'Summable.of_norm'
     Hahn-Banach theorem: 'exists_extension_norm_eq'
-    dual of a normed space: 'NormedSpace.Dual'
     isometric inclusion in double dual: 'NormedSpace.inclusionInDoubleDualLi'
     completeness of spaces of bounded continuous functions: 'BoundedContinuousFunction.instCompleteSpace'
 

--- a/docs/undergrad.yaml
+++ b/docs/undergrad.yaml
@@ -436,7 +436,7 @@ Topology:
   Hilbert spaces:
     Hilbert projection theorem: 'exists_norm_eq_iInf_of_complete_convex'
     orthogonal projection onto closed vector subspaces: 'Submodule.orthogonalProjection'
-    dual space: 'NormedSpace.Dual'
+    dual space: 'ContinuousLinearMap.Dual'
     Riesz representation theorem: 'InnerProductSpace.toDual'
     inner product space $l^2$: 'lp.instInnerProductSpace'
     completeness of $l^2$: 'lp.completeSpace'


### PR DESCRIPTION
- Move `Dual` and `dualPairing` lower in the import-hierachy
- deduplicate `dualPairing`
- Make `WeakDual` and `WeakSpace` reducible

---

New version of #11500

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
