### PR TITLE
[Merged by Bors] - feat(FieldTheory/Finitness): add `Module.natCard_eq_pow`

### DIFF
--- a/Mathlib/FieldTheory/Finiteness.lean
+++ b/Mathlib/FieldTheory/Finiteness.lean
@@ -91,6 +91,11 @@ theorem _root_.Module.card_eq_pow_finrank [Fintype K] [Fintype V] :
 
 @[deprecated (since := "2025-03-14")] alias _root_.card_eq_pow_finrank := Module.card_eq_pow_finrank
 
+theorem _root_.Module.natCard_eq_pow [Module.Finite K V] :
+    Nat.card V = Nat.card K ^ finrank K V := by
+  let b := IsNoetherian.finsetBasis K V
+  rw [Nat.card_congr b.equivFun.toEquiv, Nat.card_fun, finrank_eq_nat_card_basis b]
+
 /-- A module over a division ring is noetherian if and only if it is finitely generated. -/
 theorem iff_fg : IsNoetherian K V ↔ Module.Finite K V := by
   constructor

--- a/Mathlib/FieldTheory/Finiteness.lean
+++ b/Mathlib/FieldTheory/Finiteness.lean
@@ -91,7 +91,7 @@ theorem _root_.Module.card_eq_pow_finrank [Fintype K] [Fintype V] :
 
 @[deprecated (since := "2025-03-14")] alias _root_.card_eq_pow_finrank := Module.card_eq_pow_finrank
 
-theorem _root_.Module.natCard_eq_pow [Module.Finite K V] :
+theorem _root_.Module.natCard_eq_pow_finrank [Module.Finite K V] :
     Nat.card V = Nat.card K ^ finrank K V := by
   let b := IsNoetherian.finsetBasis K V
   rw [Nat.card_congr b.equivFun.toEquiv, Nat.card_fun, finrank_eq_nat_card_basis b]


### PR DESCRIPTION
Unblocks #22994

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
