### PR TITLE
chore(*): fix `nmem` vs `not_mem` names

### DIFF
--- a/Mathlib/Algebra/BigOperators/Finprod.lean
+++ b/Mathlib/Algebra/BigOperators/Finprod.lean
@@ -173,7 +173,7 @@ theorem finprod_eq_prod_plift_of_mulSupport_toFinset_subset {f : α → M}
     ∏ᶠ i, f i = ∏ i ∈ s, f i.down := by
   rw [finprod, dif_pos]
   refine Finset.prod_subset hs fun x _ hxf => ?_
-  rwa [hf.mem_toFinset, nmem_mulSupport] at hxf
+  rwa [hf.mem_toFinset, not_mem_mulSupport] at hxf
 
 @[to_additive]
 theorem finprod_eq_prod_plift_of_mulSupport_subset {f : α → M} {s : Finset (PLift α)}
@@ -776,7 +776,7 @@ theorem finprod_mem_dvd {f : α → N} (a : α) (hf : (mulSupport f).Finite) : f
   by_cases ha : a ∈ mulSupport f
   · rw [finprod_eq_prod_of_mulSupport_toFinset_subset f hf (Set.Subset.refl _)]
     exact Finset.dvd_prod_of_mem f ((Finite.mem_toFinset hf).mpr ha)
-  · rw [nmem_mulSupport.mp ha]
+  · rw [not_mem_mulSupport.mp ha]
     exact one_dvd (finprod f)
 
 /-- The product of `f i` over `i ∈ {a, b}`, `a ≠ b`, is equal to `f a * f b`. -/

--- a/Mathlib/Algebra/BigOperators/Group/Finset/Lemmas.lean
+++ b/Mathlib/Algebra/BigOperators/Group/Finset/Lemmas.lean
@@ -39,7 +39,7 @@ open Function in
 @[to_additive]
 lemma mulSupport_prod (s : Finset ι) (f : ι → α → β) :
     mulSupport (fun x ↦ ∏ i ∈ s, f i x) ⊆ ⋃ i ∈ s, mulSupport (f i) := by
-  simp only [mulSupport_subset_iff', Set.mem_iUnion, not_exists, nmem_mulSupport]
+  simp only [mulSupport_subset_iff', Set.mem_iUnion, not_exists, not_mem_mulSupport]
   exact fun x ↦ prod_eq_one
 
 @[to_additive]

--- a/Mathlib/Algebra/Group/Indicator.lean
+++ b/Mathlib/Algebra/Group/Indicator.lean
@@ -348,14 +348,14 @@ theorem mulIndicator_self_mul_compl (s : Set α) (f : α → M) :
 theorem mulIndicator_mul_eq_left {f g : α → M} (h : Disjoint (mulSupport f) (mulSupport g)) :
     (mulSupport f).mulIndicator (f * g) = f := by
   refine (mulIndicator_congr fun x hx => ?_).trans mulIndicator_mulSupport
-  have : g x = 1 := nmem_mulSupport.1 (disjoint_left.1 h hx)
+  have : g x = 1 := not_mem_mulSupport.1 (disjoint_left.1 h hx)
   rw [Pi.mul_apply, this, mul_one]
 
 @[to_additive]
 theorem mulIndicator_mul_eq_right {f g : α → M} (h : Disjoint (mulSupport f) (mulSupport g)) :
     (mulSupport g).mulIndicator (f * g) = g := by
   refine (mulIndicator_congr fun x hx => ?_).trans mulIndicator_mulSupport
-  have : f x = 1 := nmem_mulSupport.1 (disjoint_right.1 h hx)
+  have : f x = 1 := not_mem_mulSupport.1 (disjoint_right.1 h hx)
   rw [Pi.mul_apply, this, one_mul]
 
 @[to_additive]

--- a/Mathlib/Algebra/Group/Support.lean
+++ b/Mathlib/Algebra/Group/Support.lean
@@ -35,12 +35,14 @@ theorem mulSupport_eq_preimage (f : α → M) : mulSupport f = f ⁻¹' {1}ᶜ :
   rfl
 
 @[to_additive]
-theorem nmem_mulSupport {f : α → M} {x : α} : x ∉ mulSupport f ↔ f x = 1 :=
+theorem not_mem_mulSupport {f : α → M} {x : α} : x ∉ mulSupport f ↔ f x = 1 :=
   not_not
+
+@[deprecated (since := "2025-04-27")] alias nmem_mulSupport := not_mem_mulSupport
 
 @[to_additive]
 theorem compl_mulSupport {f : α → M} : (mulSupport f)ᶜ = { x | f x = 1 } :=
-  ext fun _ => nmem_mulSupport
+  ext fun _ => not_mem_mulSupport
 
 @[to_additive (attr := simp)]
 theorem mem_mulSupport {f : α → M} {x : α} : x ∈ mulSupport f ↔ f x ≠ 1 :=
@@ -66,7 +68,7 @@ theorem ext_iff_mulSupport {f g : α → M} :
     f = g ↔ f.mulSupport = g.mulSupport ∧ ∀ x ∈ f.mulSupport, f x = g x :=
   ⟨fun h ↦ h ▸ ⟨rfl, fun _ _ ↦ rfl⟩, fun ⟨h₁, h₂⟩ ↦ funext fun x ↦ by
     if hx : x ∈ f.mulSupport then exact h₂ x hx
-    else rw [nmem_mulSupport.1 hx, nmem_mulSupport.1 (mt (Set.ext_iff.1 h₁ x).2 hx)]⟩
+    else rw [not_mem_mulSupport.1 hx, not_mem_mulSupport.1 (mt (Set.ext_iff.1 h₁ x).2 hx)]⟩
 
 @[to_additive]
 theorem mulSupport_update_of_ne_one [DecidableEq α] (f : α → M) (x : α) {y : M} (hy : y ≠ 1) :
@@ -88,7 +90,7 @@ theorem mulSupport_extend_one_subset {f : α → M'} {g : α → N} :
     mulSupport (f.extend g 1) ⊆ f '' mulSupport g :=
   mulSupport_subset_iff'.mpr fun x hfg ↦ by
     by_cases hf : ∃ a, f a = x
-    · rw [extend, dif_pos hf, ← nmem_mulSupport]
+    · rw [extend, dif_pos hf, ← not_mem_mulSupport]
       rw [← Classical.choose_spec hf] at hfg
       exact fun hg ↦ hfg ⟨_, hg, rfl⟩
     · rw [extend_apply' _ _ _ hf]; rfl

--- a/Mathlib/Algebra/Group/Support.lean
+++ b/Mathlib/Algebra/Group/Support.lean
@@ -38,7 +38,10 @@ theorem mulSupport_eq_preimage (f : α → M) : mulSupport f = f ⁻¹' {1}ᶜ :
 theorem not_mem_mulSupport {f : α → M} {x : α} : x ∉ mulSupport f ↔ f x = 1 :=
   not_not
 
-@[deprecated (since := "2025-04-27")] alias nmem_mulSupport := not_mem_mulSupport
+@[deprecated (since := "2025-04-27")] alias nmem_support := not_mem_support
+
+@[to_additive existing, deprecated (since := "2025-04-27")]
+alias nmem_mulSupport := not_mem_mulSupport
 
 @[to_additive]
 theorem compl_mulSupport {f : α → M} : (mulSupport f)ᶜ = { x | f x = 1 } :=

--- a/Mathlib/Algebra/GroupWithZero/NonZeroDivisors.lean
+++ b/Mathlib/Algebra/GroupWithZero/NonZeroDivisors.lean
@@ -44,9 +44,12 @@ def nonZeroDivisorsLeft : Submonoid M₀ where
 @[simp]
 lemma mem_nonZeroDivisorsLeft_iff : x ∈ nonZeroDivisorsLeft M₀ ↔ ∀ y, y * x = 0 → y = 0 := .rfl
 
-lemma nmem_nonZeroDivisorsLeft_iff :
+lemma not_mem_nonZeroDivisorsLeft_iff :
     x ∉ nonZeroDivisorsLeft M₀ ↔ {y | y * x = 0 ∧ y ≠ 0}.Nonempty := by
   simpa [mem_nonZeroDivisorsLeft_iff] using Set.nonempty_def.symm
+
+@[deprecated (since := "2025-04-27")]
+alias nmem_nonZeroDivisorsLeft_iff := not_mem_nonZeroDivisorsLeft_iff
 
 /-- The collection of elements of a `MonoidWithZero` that are not right zero divisors form a
 `Submonoid`. -/
@@ -58,9 +61,12 @@ def nonZeroDivisorsRight : Submonoid M₀ where
 @[simp]
 lemma mem_nonZeroDivisorsRight_iff : x ∈ nonZeroDivisorsRight M₀ ↔ ∀ y, x * y = 0 → y = 0 := .rfl
 
-lemma nmem_nonZeroDivisorsRight_iff :
+lemma not_mem_nonZeroDivisorsRight_iff :
     x ∉ nonZeroDivisorsRight M₀ ↔ {y | x * y = 0 ∧ y ≠ 0}.Nonempty := by
   simpa [mem_nonZeroDivisorsRight_iff] using Set.nonempty_def.symm
+
+@[deprecated (since := "2025-04-27")]
+alias nmem_nonZeroDivisorsRight_iff := not_mem_nonZeroDivisorsRight_iff
 
 lemma nonZeroDivisorsLeft_eq_right (M₀ : Type*) [CommMonoidWithZero M₀] :
     nonZeroDivisorsLeft M₀ = nonZeroDivisorsRight M₀ := by
@@ -122,8 +128,10 @@ lemma nonZeroDivisorsRight_eq_nonZeroSMulDivisors :
 
 theorem mem_nonZeroDivisors_iff : r ∈ M₀⁰ ↔ ∀ x, x * r = 0 → x = 0 := Iff.rfl
 
-lemma nmem_nonZeroDivisors_iff : r ∉ M₀⁰ ↔ {s | s * r = 0 ∧ s ≠ 0}.Nonempty := by
+lemma not_mem_nonZeroDivisors_iff : r ∉ M₀⁰ ↔ {s | s * r = 0 ∧ s ≠ 0}.Nonempty := by
   simpa [mem_nonZeroDivisors_iff] using Set.nonempty_def.symm
+
+@[deprecated (since := "2025-04-27")] alias nmem_nonZeroDivisors_iff := not_mem_nonZeroDivisors_iff
 
 theorem mul_right_mem_nonZeroDivisors_eq_zero_iff (hr : r ∈ M₀⁰) : x * r = 0 ↔ x = 0 :=
   ⟨hr _, by simp +contextual⟩

--- a/Mathlib/Algebra/Order/Group/Indicator.lean
+++ b/Mathlib/Algebra/Order/Group/Indicator.lean
@@ -45,7 +45,7 @@ lemma mulSupport_min [LinearOrder M] (f g : α → M) :
 @[to_additive]
 lemma mulSupport_iSup [ConditionallyCompleteLattice M] [Nonempty ι] (f : ι → α → M) :
     mulSupport (fun x ↦ ⨆ i, f i x) ⊆ ⋃ i, mulSupport (f i) := by
-  simp only [mulSupport_subset_iff', mem_iUnion, not_exists, nmem_mulSupport]
+  simp only [mulSupport_subset_iff', mem_iUnion, not_exists, not_mem_mulSupport]
   intro x hx
   simp only [hx, ciSup_const]
 

--- a/Mathlib/Algebra/Polynomial/AlgebraMap.lean
+++ b/Mathlib/Algebra/Polynomial/AlgebraMap.lean
@@ -674,16 +674,18 @@ open nonZeroDivisors
 
 /-- *McCoy theorem*: a polynomial `P : R[X]` is a zerodivisor if and only if there is `a : R`
 such that `a ≠ 0` and `a • P = 0`. -/
-theorem nmem_nonZeroDivisors_iff {P : R[X]} : P ∉ R[X]⁰ ↔ ∃ a : R, a ≠ 0 ∧ a • P = 0 := by
+theorem not_mem_nonZeroDivisors_iff {P : R[X]} : P ∉ R[X]⁰ ↔ ∃ a : R, a ≠ 0 ∧ a • P = 0 := by
   refine ⟨fun hP ↦ ?_, fun ⟨a, ha, h⟩ h1 ↦ ha <| C_eq_zero.1 <| (h1 _) <| smul_eq_C_mul a ▸ h⟩
   by_contra! h
-  obtain ⟨Q, hQ⟩ := _root_.nmem_nonZeroDivisors_iff.1 hP
+  obtain ⟨Q, hQ⟩ := _root_.not_mem_nonZeroDivisors_iff.1 hP
   refine hQ.2 (eq_zero_of_mul_eq_zero_of_smul P (fun a ha ↦ ?_) Q (mul_comm P _ ▸ hQ.1))
   contrapose! ha
   exact h a ha
 
+@[deprecated (since := "2025-04-27")] alias nmem_nonZeroDivisors_iff := not_mem_nonZeroDivisors_iff
+
 protected lemma mem_nonZeroDivisors_iff {P : R[X]} : P ∈ R[X]⁰ ↔ ∀ a : R, a • P = 0 → a = 0 := by
-  simpa [not_imp_not] using (nmem_nonZeroDivisors_iff (P := P)).not
+  simpa [not_imp_not] using (not_mem_nonZeroDivisors_iff (P := P)).not
 
 lemma mem_nonzeroDivisors_of_coeff_mem {p : R[X]} (n : ℕ) (hp : p.coeff n ∈ R⁰) :
     p ∈ R[X]⁰ :=

--- a/Mathlib/Algebra/Polynomial/Degree/Operations.lean
+++ b/Mathlib/Algebra/Polynomial/Degree/Operations.lean
@@ -620,10 +620,13 @@ theorem X_pow_add_C_ne_zero {n : ℕ} (hn : 0 < n) (a : R) : (X : R[X]) ^ n + C 
 theorem X_add_C_ne_zero (r : R) : X + C r ≠ 0 :=
   pow_one (X : R[X]) ▸ X_pow_add_C_ne_zero zero_lt_one r
 
-theorem zero_nmem_multiset_map_X_add_C {α : Type*} (m : Multiset α) (f : α → R) :
+theorem zero_not_mem_multiset_map_X_add_C {α : Type*} (m : Multiset α) (f : α → R) :
     (0 : R[X]) ∉ m.map fun a => X + C (f a) := fun mem =>
   let ⟨_a, _, ha⟩ := Multiset.mem_map.mp mem
   X_add_C_ne_zero _ ha
+
+@[deprecated (since := "2025-04-27")]
+alias zero_nmem_multiset_map_X_add_C := zero_not_mem_multiset_map_X_add_C
 
 theorem natDegree_X_pow_add_C {n : ℕ} {r : R} : (X ^ n + C r).natDegree = n := by
   by_cases hn : n = 0
@@ -770,10 +773,13 @@ theorem X_pow_sub_C_ne_zero {n : ℕ} (hn : 0 < n) (a : R) : (X : R[X]) ^ n - C 
 theorem X_sub_C_ne_zero (r : R) : X - C r ≠ 0 :=
   pow_one (X : R[X]) ▸ X_pow_sub_C_ne_zero zero_lt_one r
 
-theorem zero_nmem_multiset_map_X_sub_C {α : Type*} (m : Multiset α) (f : α → R) :
+theorem zero_not_mem_multiset_map_X_sub_C {α : Type*} (m : Multiset α) (f : α → R) :
     (0 : R[X]) ∉ m.map fun a => X - C (f a) := fun mem =>
   let ⟨_a, _, ha⟩ := Multiset.mem_map.mp mem
   X_sub_C_ne_zero _ ha
+
+@[deprecated (since := "2025-04-27")]
+alias zero_nmem_multiset_map_X_sub_C := zero_not_mem_multiset_map_X_sub_C
 
 theorem natDegree_X_pow_sub_C {n : ℕ} {r : R} : (X ^ n - C r).natDegree = n := by
   rw [sub_eq_add_neg, ← map_neg C r, natDegree_X_pow_add_C]

--- a/Mathlib/Analysis/Calculus/BumpFunction/Basic.lean
+++ b/Mathlib/Analysis/Calculus/BumpFunction/Basic.lean
@@ -157,7 +157,7 @@ theorem pos_of_mem_ball (hx : x ∈ ball c f.rOut) : 0 < f x :=
   f.nonneg.lt_of_ne' <| by rwa [← support_eq, mem_support] at hx
 
 theorem zero_of_le_dist (hx : f.rOut ≤ dist x c) : f x = 0 := by
-  rwa [← nmem_support, support_eq, mem_ball, not_lt]
+  rwa [← not_mem_support, support_eq, mem_ball, not_lt]
 
 protected theorem hasCompactSupport [FiniteDimensional ℝ E] : HasCompactSupport f := by
   simp_rw [HasCompactSupport, f.tsupport_eq, isCompact_closedBall]

--- a/Mathlib/Analysis/Calculus/DSlope.lean
+++ b/Mathlib/Analysis/Calculus/DSlope.lean
@@ -132,10 +132,13 @@ theorem differentiableWithinAt_dslope_of_ne (h : b ≠ a) :
   refine (eqOn_dslope_slope _ _).eventuallyEq_of_mem ?_
   exact mem_nhdsWithin_of_mem_nhds (isOpen_ne.mem_nhds h)
 
-theorem differentiableOn_dslope_of_nmem (h : a ∉ s) :
+theorem differentiableOn_dslope_of_not_mem (h : a ∉ s) :
     DifferentiableOn 𝕜 (dslope f a) s ↔ DifferentiableOn 𝕜 f s :=
   forall_congr' fun _ =>
     forall_congr' fun hx => differentiableWithinAt_dslope_of_ne <| ne_of_mem_of_not_mem hx h
+
+@[deprecated (since := "2025-04-27")]
+alias differentiableOn_dslope_of_nmem := differentiableOn_dslope_of_not_mem
 
 theorem differentiableAt_dslope_of_ne (h : b ≠ a) :
     DifferentiableAt 𝕜 (dslope f a) b ↔ DifferentiableAt 𝕜 f b := by

--- a/Mathlib/Analysis/Calculus/Deriv/Basic.lean
+++ b/Mathlib/Analysis/Calculus/Deriv/Basic.lean
@@ -242,8 +242,11 @@ set_option linter.deprecated false in
 theorem derivWithin_zero_of_isolated (h : 𝓝[s \ {x}] x = ⊥) : derivWithin f s x = 0 := by
   rw [derivWithin, fderivWithin_zero_of_isolated h, ContinuousLinearMap.zero_apply]
 
-theorem derivWithin_zero_of_nmem_closure (h : x ∉ closure s) : derivWithin f s x = 0 := by
-  rw [derivWithin, fderivWithin_zero_of_nmem_closure h, ContinuousLinearMap.zero_apply]
+theorem derivWithin_zero_of_not_mem_closure (h : x ∉ closure s) : derivWithin f s x = 0 := by
+  rw [derivWithin, fderivWithin_zero_of_not_mem_closure h, ContinuousLinearMap.zero_apply]
+
+@[deprecated (since := "2025-04-27")]
+alias derivWithin_zero_of_nmem_closure := derivWithin_zero_of_not_mem_closure
 
 theorem deriv_zero_of_not_differentiableAt (h : ¬DifferentiableAt 𝕜 f x) : deriv f x = 0 := by
   unfold deriv

--- a/Mathlib/Analysis/Calculus/Deriv/Support.lean
+++ b/Mathlib/Analysis/Calculus/Deriv/Support.lean
@@ -36,7 +36,7 @@ theorem support_deriv_subset : support (deriv f) ⊆ tsupport f := by
   rw [← not_imp_not]
   intro h2x
   rw [not_mem_tsupport_iff_eventuallyEq] at h2x
-  exact nmem_support.mpr (h2x.deriv_eq.trans (deriv_const x 0))
+  exact not_mem_support.mpr (h2x.deriv_eq.trans (deriv_const x 0))
 
 protected theorem HasCompactSupport.deriv (hf : HasCompactSupport f) :
     HasCompactSupport (deriv f) :=

--- a/Mathlib/Analysis/Calculus/FDeriv/Basic.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Basic.lean
@@ -500,10 +500,7 @@ theorem HasFDerivWithinAt.of_not_mem_closure (h : x ∉ closure s) : HasFDerivWi
   .of_not_accPt (h ·.clusterPt.mem_closure)
 
 @[deprecated (since := "2025-04-20")]
-alias hasFDerivWithinAt_of_not_mem_closure := HasFDerivWithinAt.of_not_mem_closure
-
-@[deprecated (since := "2025-04-27")]
-alias hasFDerivWithinAt_of_nmem_closure := hasFDerivWithinAt_of_not_mem_closure
+alias hasFDerivWithinAt_of_nmem_closure := HasFDerivWithinAt.of_not_mem_closure
 
 theorem fderivWithin_zero_of_not_accPt (h : ¬AccPt x (𝓟 s)) : fderivWithin 𝕜 f s x = 0 := by
   rw [fderivWithin, if_pos (.of_not_accPt h)]

--- a/Mathlib/Analysis/Calculus/FDeriv/Basic.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Basic.lean
@@ -500,7 +500,10 @@ theorem HasFDerivWithinAt.of_not_mem_closure (h : x ∉ closure s) : HasFDerivWi
   .of_not_accPt (h ·.clusterPt.mem_closure)
 
 @[deprecated (since := "2025-04-20")]
-alias hasFDerivWithinAt_of_nmem_closure := HasFDerivWithinAt.of_not_mem_closure
+alias hasFDerivWithinAt_of_not_mem_closure := HasFDerivWithinAt.of_not_mem_closure
+
+@[deprecated (since := "2025-04-27")]
+alias hasFDerivWithinAt_of_nmem_closure := hasFDerivWithinAt_of_not_mem_closure
 
 theorem fderivWithin_zero_of_not_accPt (h : ¬AccPt x (𝓟 s)) : fderivWithin 𝕜 f s x = 0 := by
   rw [fderivWithin, if_pos (.of_not_accPt h)]
@@ -510,8 +513,11 @@ set_option linter.deprecated false in
 theorem fderivWithin_zero_of_isolated (h : 𝓝[s \ {x}] x = ⊥) : fderivWithin 𝕜 f s x = 0 := by
   rw [fderivWithin, if_pos (.of_nhdsWithin_eq_bot h)]
 
-theorem fderivWithin_zero_of_nmem_closure (h : x ∉ closure s) : fderivWithin 𝕜 f s x = 0 :=
+theorem fderivWithin_zero_of_not_mem_closure (h : x ∉ closure s) : fderivWithin 𝕜 f s x = 0 :=
   fderivWithin_zero_of_not_accPt (h ·.clusterPt.mem_closure)
+
+@[deprecated (since := "2025-04-27")]
+alias fderivWithin_zero_of_nmem_closure := fderivWithin_zero_of_not_mem_closure
 
 theorem DifferentiableWithinAt.hasFDerivWithinAt (h : DifferentiableWithinAt 𝕜 f s x) :
     HasFDerivWithinAt f (fderivWithin 𝕜 f s x) s x := by
@@ -1389,24 +1395,30 @@ open Function
 variable (𝕜 : Type*) {E F : Type*} [NontriviallyNormedField 𝕜] [NormedAddCommGroup E]
   [NormedSpace 𝕜 E] [NormedAddCommGroup F] [NormedSpace 𝕜 F] {f : E → F} {x : E}
 
-theorem HasStrictFDerivAt.of_nmem_tsupport (h : x ∉ tsupport f) :
+theorem HasStrictFDerivAt.of_not_mem_tsupport (h : x ∉ tsupport f) :
     HasStrictFDerivAt f (0 : E →L[𝕜] F) x := by
   rw [not_mem_tsupport_iff_eventuallyEq] at h
   exact (hasStrictFDerivAt_const (0 : F) x).congr_of_eventuallyEq h.symm
 
-theorem HasFDerivAt.of_nmem_tsupport (h : x ∉ tsupport f) :
+@[deprecated (since := "2025-04-27")]
+alias HasStrictFDerivAt.of_nmem_tsupport := HasStrictFDerivAt.of_not_mem_tsupport
+
+theorem HasFDerivAt.of_not_mem_tsupport (h : x ∉ tsupport f) :
     HasFDerivAt f (0 : E →L[𝕜] F) x :=
-  (HasStrictFDerivAt.of_nmem_tsupport 𝕜 h).hasFDerivAt
+  (HasStrictFDerivAt.of_not_mem_tsupport 𝕜 h).hasFDerivAt
+
+@[deprecated (since := "2025-04-27")]
+alias HasFDerivAt.of_nmem_tsupport := HasFDerivAt.of_not_mem_tsupport
 
 theorem HasFDerivWithinAt.of_not_mem_tsupport {s : Set E} {x : E} (h : x ∉ tsupport f) :
     HasFDerivWithinAt f (0 : E →L[𝕜] F) s x :=
-  (HasFDerivAt.of_nmem_tsupport 𝕜 h).hasFDerivWithinAt
+  (HasFDerivAt.of_not_mem_tsupport 𝕜 h).hasFDerivWithinAt
 
 theorem fderiv_of_not_mem_tsupport (h : x ∉ tsupport f) : fderiv 𝕜 f x = 0 :=
-  (HasFDerivAt.of_nmem_tsupport 𝕜 h).fderiv
+  (HasFDerivAt.of_not_mem_tsupport 𝕜 h).fderiv
 
 theorem support_fderiv_subset : support (fderiv 𝕜 f) ⊆ tsupport f := fun x ↦ by
-  rw [← not_imp_not, nmem_support]
+  rw [← not_imp_not, not_mem_support]
   exact fderiv_of_not_mem_tsupport _
 
 theorem tsupport_fderiv_subset : tsupport (fderiv 𝕜 f) ⊆ tsupport f :=

--- a/Mathlib/Analysis/Calculus/Rademacher.lean
+++ b/Mathlib/Analysis/Calculus/Rademacher.lean
@@ -148,11 +148,11 @@ theorem integral_inv_smul_sub_mul_tendsto_integral_lineDeriv_mul'
       _ = (C * ‖v‖) *‖g x‖ := by field_simp [norm_smul, abs_of_nonneg t_pos.le]; ring
       _ = K.indicator (fun x ↦ (C * ‖v‖) * ‖g x‖) x := by rw [indicator_of_mem hx]
     · have A : f x = 0 := by
-        rw [← Function.nmem_support]
+        rw [← Function.not_mem_support]
         contrapose! hx
         exact self_subset_cthickening _ (subset_tsupport _ hx)
       have B : f (x + t • v) = 0 := by
-        rw [← Function.nmem_support]
+        rw [← Function.not_mem_support]
         contrapose! hx
         apply mem_cthickening_of_dist_le _ _ (‖v‖) (tsupport f) (subset_tsupport _ hx)
         simp only [dist_eq_norm, sub_add_cancel_left, norm_neg, norm_smul, Real.norm_eq_abs,

--- a/Mathlib/Analysis/Complex/RemovableSingularity.lean
+++ b/Mathlib/Analysis/Complex/RemovableSingularity.lean
@@ -57,7 +57,7 @@ theorem differentiableOn_dslope {f : ℂ → E} {s : Set ℂ} {c : ℂ} (hc : s 
     DifferentiableOn ℂ (dslope f c) s ↔ DifferentiableOn ℂ f s :=
   ⟨fun h => h.of_dslope, fun h =>
     (differentiableOn_compl_singleton_and_continuousAt_iff hc).mp <|
-      ⟨Iff.mpr (differentiableOn_dslope_of_nmem fun h => h.2 rfl) (h.mono diff_subset),
+      ⟨Iff.mpr (differentiableOn_dslope_of_not_mem fun h => h.2 rfl) (h.mono diff_subset),
         continuousAt_dslope_same.2 <| h.differentiableAt hc⟩⟩
 
 /-- **Removable singularity** theorem: if `s` is a neighborhood of `c : ℂ`, a function `f : ℂ → E`

--- a/Mathlib/Analysis/Convex/Cone/InnerDual.lean
+++ b/Mathlib/Analysis/Convex/Cone/InnerDual.lean
@@ -17,7 +17,7 @@ all points `x` in a given set `0 ≤ ⟪ x, y ⟫`.
 We prove the following theorems:
 * `ConvexCone.innerDualCone_of_innerDualCone_eq_self`:
   The `innerDualCone` of the `innerDualCone` of a nonempty, closed, convex cone is itself.
-* `ConvexCone.hyperplane_separation_of_nonempty_of_isClosed_of_nmem`:
+* `ConvexCone.hyperplane_separation_of_nonempty_of_isClosed_of_not_mem`:
   This variant of the
   [hyperplane separation theorem](https://en.wikipedia.org/wiki/Hyperplane_separation_theorem)
   states that given a nonempty, closed, convex cone `K` in a complete, real inner product space `H`
@@ -147,7 +147,7 @@ variable [CompleteSpace H]
 open scoped InnerProductSpace in
 /-- This is a stronger version of the Hahn-Banach separation theorem for closed convex cones. This
 is also the geometric interpretation of Farkas' lemma. -/
-theorem ConvexCone.hyperplane_separation_of_nonempty_of_isClosed_of_nmem (K : ConvexCone ℝ H)
+theorem ConvexCone.hyperplane_separation_of_nonempty_of_isClosed_of_not_mem (K : ConvexCone ℝ H)
     (ne : (K : Set H).Nonempty) (hc : IsClosed (K : Set H)) {b : H} (disj : b ∉ K) :
     ∃ y : H, (∀ x : H, x ∈ K → 0 ≤ ⟪x, y⟫_ℝ) ∧ ⟪y, b⟫_ℝ < 0 := by
   -- let `z` be the point in `K` closest to `b`
@@ -179,6 +179,10 @@ theorem ConvexCone.hyperplane_separation_of_nonempty_of_isClosed_of_nmem (K : Co
       _ = ⟪b - z, b - z + z⟫_ℝ := (inner_add_right _ _ _).symm
       _ = ⟪b - z, b⟫_ℝ := by rw [sub_add_cancel]
 
+@[deprecated (since := "2025-04-27")]
+alias ConvexCone.hyperplane_separation_of_nonempty_of_isClosed_of_nmem :=
+  ConvexCone.hyperplane_separation_of_nonempty_of_isClosed_of_not_mem
+
 /-- The inner dual of inner dual of a non-empty, closed convex cone is itself. -/
 theorem ConvexCone.innerDualCone_of_innerDualCone_eq_self (K : ConvexCone ℝ H)
     (ne : (K : Set H).Nonempty) (hc : IsClosed (K : Set H)) :
@@ -187,7 +191,7 @@ theorem ConvexCone.innerDualCone_of_innerDualCone_eq_self (K : ConvexCone ℝ H)
   constructor
   · rw [mem_innerDualCone, ← SetLike.mem_coe]
     contrapose!
-    exact K.hyperplane_separation_of_nonempty_of_isClosed_of_nmem ne hc
+    exact K.hyperplane_separation_of_nonempty_of_isClosed_of_not_mem ne hc
   · rintro hxK y h
     specialize h x hxK
     rwa [real_inner_comm]

--- a/Mathlib/Analysis/Convex/Cone/Proper.lean
+++ b/Mathlib/Analysis/Convex/Cone/Proper.lean
@@ -211,7 +211,7 @@ theorem dual_dual (K : ProperCone ℝ E) : K.dual.dual = K :=
     (K : ConvexCone ℝ E).innerDualCone_of_innerDualCone_eq_self K.nonempty K.isClosed
 
 /-- This is a relative version of
-`ConvexCone.hyperplane_separation_of_nonempty_of_isClosed_of_nmem`, which we recover by setting
+`ConvexCone.hyperplane_separation_of_nonempty_of_isClosed_of_not_mem`, which we recover by setting
 `f` to be the identity map. This is also a geometric interpretation of the Farkas' lemma
 stated using proper cones. -/
 theorem hyperplane_separation (K : ProperCone ℝ E) {f : E →L[ℝ] F} {b : F} :
@@ -242,7 +242,7 @@ theorem hyperplane_separation (K : ProperCone ℝ E) {f : E →L[ℝ] F} {b : F}
       -- as `b ∉ K.map f`, there is a hyperplane `y` separating `b` from `K.map f`
       let C := PointedCone.toConvexCone (𝕜 := ℝ) (E := F) (K.map f)
       obtain ⟨y, hxy, hyb⟩ :=
-        @ConvexCone.hyperplane_separation_of_nonempty_of_isClosed_of_nmem
+        @ConvexCone.hyperplane_separation_of_nonempty_of_isClosed_of_not_mem
         _ _ _ _ C (K.map f).nonempty (K.map f).isClosed b h
 
       -- the rest of the proof is a straightforward algebraic manipulation
@@ -256,9 +256,12 @@ theorem hyperplane_separation (K : ProperCone ℝ E) {f : E →L[ℝ] F} {b : F}
         SetLike.mem_coe]
       exact ⟨x, hxK, rfl⟩)
 
-theorem hyperplane_separation_of_nmem (K : ProperCone ℝ E) {f : E →L[ℝ] F} {b : F}
+theorem hyperplane_separation_of_not_mem (K : ProperCone ℝ E) {f : E →L[ℝ] F} {b : F}
     (disj : b ∉ K.map f) : ∃ y : F, adjoint f y ∈ K.dual ∧ ⟪y, b⟫_ℝ < 0 := by
   contrapose! disj; rwa [K.hyperplane_separation]
+
+@[deprecated (since := "2025-04-27")]
+alias hyperplane_separation_of_nmem := hyperplane_separation_of_not_mem
 
 end CompleteSpace
 

--- a/Mathlib/Analysis/Convolution.lean
+++ b/Mathlib/Analysis/Convolution.lean
@@ -122,7 +122,7 @@ theorem convolution_integrand_bound_right_of_le_of_subset {C : ℝ} (hC : ∀ i,
       refine mt (fun hxt => hu ?_) ht
       refine ⟨_, Set.neg_mem_neg.mpr (subset_closure hxt), _, hx, ?_⟩
       simp only [neg_sub, sub_add_cancel]
-    simp only [nmem_support.mp this, (L _).map_zero, norm_zero, le_rfl]
+    simp only [not_mem_support.mp this, (L _).map_zero, norm_zero, le_rfl]
 
 theorem _root_.HasCompactSupport.convolution_integrand_bound_right_of_subset
     (hcg : HasCompactSupport g) (hg : Continuous g)
@@ -215,7 +215,7 @@ theorem _root_.BddAbove.convolutionExistsAt' {x₀ : G} {s : Set G}
       refine (le_ciSup_set hbg <| mem_preimage.mpr ?_)
       rwa [neg_sub, sub_add_cancel]
     · have : t ∉ support fun t => L (f t) (g (x₀ - t)) := mt (fun h => h2s h) ht
-      rw [nmem_support.mp this, norm_zero]
+      rw [not_mem_support.mp this, norm_zero]
   refine Integrable.mono' ?_ ?_ this
   · rw [integrable_indicator_iff hs]; exact ((hf.norm.const_mul _).mul_const _).integrableOn
   · exact hf.aestronglyMeasurable.convolution_integrand_snd' L hmg
@@ -515,7 +515,7 @@ theorem support_convolution_subset_swap : support (f ⋆[L, μ] g) ⊆ support g
   intro x h2x
   by_contra hx
   apply h2x
-  simp_rw [Set.mem_add, ← exists_and_left, not_exists, not_and_or, nmem_support] at hx
+  simp_rw [Set.mem_add, ← exists_and_left, not_exists, not_and_or, not_mem_support] at hx
   rw [convolution_def]
   convert integral_zero G F using 2
   ext t
@@ -617,7 +617,7 @@ theorem _root_.HasCompactSupport.continuous_convolution_right (hcg : HasCompactS
   have : ContinuousOn (↿g') (univ ×ˢ univ) := (hg.comp continuous_snd).continuousOn
   exact continuousOn_convolution_right_with_param_comp L
     (continuous_iff_continuousOn_univ.1 continuous_id) hcg
-    (fun p x _ hx => image_eq_zero_of_nmem_tsupport hx) hf this
+    (fun p x _ hx => image_eq_zero_of_not_mem_tsupport hx) hf this
 
 /-- The convolution is continuous if one function is integrable and the other is bounded and
 continuous. -/
@@ -724,7 +724,7 @@ theorem convolution_eq_right' {x₀ : G} {R : ℝ} (hf : support f ⊆ ball (0 :
       specialize hg (x₀ - t)
       rw [sub_eq_add_neg, add_mem_ball_iff_norm, norm_neg, ← sub_eq_add_neg] at hg
       rw [hg h2t]
-    · rw [nmem_support] at ht
+    · rw [not_mem_support] at ht
       simp_rw [ht, L.map_zero₂]
   simp_rw [convolution_def, h2]
 
@@ -757,7 +757,7 @@ theorem dist_convolution_le' {x₀ : G} {R ε : ℝ} {z₀ : E'} (hε : 0 ≤ ε
       rw [sub_eq_add_neg, add_mem_ball_iff_norm, norm_neg, ← sub_eq_add_neg] at hg
       refine ((L (f t)).dist_le_opNorm _ _).trans ?_
       exact mul_le_mul_of_nonneg_left (hg h2t) (norm_nonneg _)
-    · rw [nmem_support] at ht
+    · rw [not_mem_support] at ht
       simp_rw [ht, L.map_zero₂, L.map_zero, norm_zero, zero_mul, dist_self]
       rfl
   simp_rw [convolution_def]

--- a/Mathlib/Analysis/Distribution/AEEqOfIntegralContDiff.lean
+++ b/Mathlib/Analysis/Distribution/AEEqOfIntegralContDiff.lean
@@ -86,7 +86,7 @@ theorem ae_eq_zero_of_integral_smooth_smul_eq_zero [SigmaCompactSpace M]
           rw [Real.norm_of_nonneg this.1]
           exact this.2
         exact mul_le_of_le_one_left (norm_nonneg _) this
-      · have : g n x = 0 := by rw [← nmem_support, g_supp]; contrapose! hxK; exact vK n hxK
+      · have : g n x = 0 := by rw [← not_mem_support, g_supp]; contrapose! hxK; exact vK n hxK
         simp [this]
     have D : ∀ᵐ x ∂μ, Tendsto (fun n => g n x • f x) atTop (𝓝 (s.indicator f x)) := by
       filter_upwards with x
@@ -101,7 +101,7 @@ theorem ae_eq_zero_of_integral_smooth_smul_eq_zero [SigmaCompactSpace M]
           rw [← hs.isClosed.closure_eq, closure_eq_iInter_thickening s] at hxs
           simpa using hxs
         filter_upwards [(tendsto_order.1 u_lim).2 _ εpos] with n hn
-        rw [← nmem_support, g_supp]
+        rw [← not_mem_support, g_supp]
         contrapose! hε
         exact thickening_mono hn.le s hε
     exact tendsto_integral_of_dominated_convergence bound A B C D

--- a/Mathlib/Data/LocallyFinsupp.lean
+++ b/Mathlib/Data/LocallyFinsupp.lean
@@ -99,7 +99,7 @@ Simplifier lemma: Functions with locally finite support within `U` evaluate to z
 @[simp]
 lemma apply_eq_zero_of_not_mem [Zero Y] {z : X} (D : locallyFinsuppWithin U Y)
     (hz : z ∉ U) :
-    D z = 0 := nmem_support.mp fun a ↦ hz (D.supportWithinDomain a)
+    D z = 0 := not_mem_support.mp fun a ↦ hz (D.supportWithinDomain a)
 
 /--
 On a T1 space, the support of a functions with locally finite support within `U` is discrete.
@@ -165,7 +165,7 @@ protected def addSubgroup [AddCommGroup Y] : AddSubgroup (X → Y) where
     constructor
     · intro x hx
       contrapose! hx
-      simp [nmem_support.1 fun a ↦ hx (hf.1 a), nmem_support.1 fun a ↦ hx (hg.1 a)]
+      simp [not_mem_support.1 fun a ↦ hx (hf.1 a), not_mem_support.1 fun a ↦ hx (hg.1 a)]
     · intro z hz
       obtain ⟨t₁, ht₁⟩ := hf.2 z hz
       obtain ⟨t₂, ht₂⟩ := hg.2 z hz
@@ -245,8 +245,8 @@ instance [SemilatticeSup Y] [Zero Y] : Max (locallyFinsuppWithin U Y) where
       intro x
       contrapose
       intro hx
-      simp [nmem_support.1 fun a ↦ hx (D₁.supportWithinDomain a),
-        nmem_support.1 fun a ↦ hx (D₂.supportWithinDomain a)]
+      simp [not_mem_support.1 fun a ↦ hx (D₁.supportWithinDomain a),
+        not_mem_support.1 fun a ↦ hx (D₂.supportWithinDomain a)]
     supportLocallyFiniteWithinDomain' := by
       intro z hz
       obtain ⟨t₁, ht₁⟩ := D₁.supportLocallyFiniteWithinDomain z hz
@@ -270,8 +270,8 @@ instance [SemilatticeInf Y] [Zero Y] : Min (locallyFinsuppWithin U Y) where
       intro x
       contrapose
       intro hx
-      simp [nmem_support.1 fun a ↦ hx (D₁.supportWithinDomain a),
-        nmem_support.1 fun a ↦ hx (D₂.supportWithinDomain a)]
+      simp [not_mem_support.1 fun a ↦ hx (D₁.supportWithinDomain a),
+        not_mem_support.1 fun a ↦ hx (D₂.supportWithinDomain a)]
     supportLocallyFiniteWithinDomain' := by
       intro z hz
       obtain ⟨t₁, ht₁⟩ := D₁.supportLocallyFiniteWithinDomain z hz

--- a/Mathlib/Data/Set/Basic.lean
+++ b/Mathlib/Data/Set/Basic.lean
@@ -215,8 +215,10 @@ argument to `simp`. -/
 theorem _root_.Membership.mem.out {p : α → Prop} {a : α} (h : a ∈ { x | p x }) : p a :=
   h
 
-theorem nmem_setOf_iff {a : α} {p : α → Prop} : a ∉ { x | p x } ↔ ¬p a :=
+theorem not_mem_setOf_iff {a : α} {p : α → Prop} : a ∉ { x | p x } ↔ ¬p a :=
   Iff.rfl
+
+@[deprecated (since := "2025-04-27")] alias nmem_setOf_iff := not_mem_setOf_iff
 
 @[simp]
 theorem setOf_mem_eq {s : Set α} : { x | x ∈ s } = s :=

--- a/Mathlib/Data/Set/Insert.lean
+++ b/Mathlib/Data/Set/Insert.lean
@@ -251,8 +251,10 @@ theorem singleton_inter_eq_empty : {a} ∩ s = ∅ ↔ a ∉ s :=
 theorem inter_singleton_eq_empty : s ∩ {a} = ∅ ↔ a ∉ s := by
   rw [inter_comm, singleton_inter_eq_empty]
 
-theorem nmem_singleton_empty {s : Set α} : s ∉ ({∅} : Set (Set α)) ↔ s.Nonempty :=
+theorem not_mem_singleton_empty {s : Set α} : s ∉ ({∅} : Set (Set α)) ↔ s.Nonempty :=
   nonempty_iff_ne_empty.symm
+
+@[deprecated (since := "2025-04-27")] alias nmem_singleton_empty := not_mem_singleton_empty
 
 instance uniqueSingleton (a : α) : Unique (↥({a} : Set α)) :=
   ⟨⟨⟨a, mem_singleton a⟩⟩, fun ⟨_, h⟩ => Subtype.eq h⟩

--- a/Mathlib/Dynamics/Ergodic/Conservative.lean
+++ b/Mathlib/Dynamics/Ergodic/Conservative.lean
@@ -154,7 +154,8 @@ theorem ae_mem_imp_frequently_image_mem (hf : Conservative f μ) (hs : NullMeasu
     ∀ᵐ x ∂μ, x ∈ s → ∃ᶠ n in atTop, f^[n] x ∈ s := by
   simp only [frequently_atTop, @forall_swap (_ ∈ s), ae_all_iff]
   intro n
-  filter_upwards [measure_zero_iff_ae_not_mem.1 (hf.measure_mem_forall_ge_image_not_mem_eq_zero hs n)]
+  filter_upwards [measure_zero_iff_ae_not_mem.1
+    (hf.measure_mem_forall_ge_image_not_mem_eq_zero hs n)]
   simp
 
 theorem inter_frequently_image_mem_ae_eq (hf : Conservative f μ) (hs : NullMeasurableSet s μ) :

--- a/Mathlib/Dynamics/Ergodic/Conservative.lean
+++ b/Mathlib/Dynamics/Ergodic/Conservative.lean
@@ -154,7 +154,7 @@ theorem ae_mem_imp_frequently_image_mem (hf : Conservative f μ) (hs : NullMeasu
     ∀ᵐ x ∂μ, x ∈ s → ∃ᶠ n in atTop, f^[n] x ∈ s := by
   simp only [frequently_atTop, @forall_swap (_ ∈ s), ae_all_iff]
   intro n
-  filter_upwards [measure_zero_iff_ae_nmem.1 (hf.measure_mem_forall_ge_image_not_mem_eq_zero hs n)]
+  filter_upwards [measure_zero_iff_ae_not_mem.1 (hf.measure_mem_forall_ge_image_not_mem_eq_zero hs n)]
   simp
 
 theorem inter_frequently_image_mem_ae_eq (hf : Conservative f μ) (hs : NullMeasurableSet s μ) :

--- a/Mathlib/Dynamics/Ergodic/Ergodic.lean
+++ b/Mathlib/Dynamics/Ergodic/Ergodic.lean
@@ -63,9 +63,11 @@ theorem measure_self_or_compl_eq_zero (hf : PreErgodic f μ) (hs : MeasurableSet
     (hs' : f ⁻¹' s = s) : μ s = 0 ∨ μ sᶜ = 0 := by
   simpa using hf.ae_empty_or_univ hs hs'
 
-theorem ae_mem_or_ae_nmem (hf : PreErgodic f μ) (hsm : MeasurableSet s) (hs : f ⁻¹' s = s) :
+theorem ae_mem_or_ae_not_mem (hf : PreErgodic f μ) (hsm : MeasurableSet s) (hs : f ⁻¹' s = s) :
     (∀ᵐ x ∂μ, x ∈ s) ∨ ∀ᵐ x ∂μ, x ∉ s :=
   eventuallyConst_set.1 <| hf.aeconst_set hsm hs
+
+@[deprecated (since := "2025-04-27")] alias ae_mem_or_ae_nmem := ae_mem_or_ae_not_mem
 
 /-- On a probability space, the (pre)ergodicity condition is a zero one law. -/
 theorem prob_eq_zero_or_one [IsProbabilityMeasure μ] (hf : PreErgodic f μ) (hs : MeasurableSet s)
@@ -128,10 +130,12 @@ theorem ae_empty_or_univ₀ (hf : QuasiErgodic f μ) (hsm : NullMeasurableSet s 
 
 /-- For a quasi ergodic map, sets that are almost invariant (rather than strictly invariant) are
 still either almost empty or full. -/
-theorem ae_mem_or_ae_nmem₀ (hf : QuasiErgodic f μ) (hsm : NullMeasurableSet s μ)
+theorem ae_mem_or_ae_not_mem₀ (hf : QuasiErgodic f μ) (hsm : NullMeasurableSet s μ)
     (hs : f ⁻¹' s =ᵐ[μ] s) :
     (∀ᵐ x ∂μ, x ∈ s) ∨ ∀ᵐ x ∂μ, x ∉ s :=
   eventuallyConst_set.mp <| hf.aeconst_set₀ hsm hs
+
+@[deprecated (since := "2025-04-27")] alias ae_mem_or_ae_nmem₀ := ae_mem_or_ae_not_mem₀
 
 theorem smul_measure {R : Type*} [SMul R ℝ≥0∞] [IsScalarTower R ℝ≥0∞ ℝ≥0∞]
     (hf : QuasiErgodic f μ) (c : R) : QuasiErgodic f (c • μ) :=

--- a/Mathlib/Dynamics/Ergodic/Function.lean
+++ b/Mathlib/Dynamics/Ergodic/Function.lean
@@ -30,7 +30,7 @@ theorem QuasiErgodic.ae_eq_const_of_ae_eq_comp_of_ae_range₀ [Nonempty X] [Meas
     (hg_eq : g ∘ f =ᵐ[μ] g) :
     ∃ c, g =ᵐ[μ] const α c := by
   refine exists_eventuallyEq_const_of_eventually_mem_of_forall_separating MeasurableSet hs ?_
-  refine fun U hU ↦ h.ae_mem_or_ae_nmem₀ (s := g ⁻¹' U) (hgm hU) ?_b
+  refine fun U hU ↦ h.ae_mem_or_ae_not_mem₀ (s := g ⁻¹' U) (hgm hU) ?_b
   refine (hg_eq.mono fun x hx ↦ ?_).set_eq
   rw [← preimage_comp, mem_preimage, mem_preimage, hx]
 
@@ -46,7 +46,7 @@ If `g` is invariant under `f`, then `g` is a.e. constant. -/
 theorem PreErgodic.ae_eq_const_of_ae_eq_comp (h : PreErgodic f μ) (hgm : Measurable g)
     (hg_eq : g ∘ f = g) : ∃ c, g =ᵐ[μ] const α c :=
   exists_eventuallyEq_const_of_forall_separating MeasurableSet fun U hU ↦
-    h.ae_mem_or_ae_nmem (s := g ⁻¹' U) (hgm hU) <| by rw [← preimage_comp, hg_eq]
+    h.ae_mem_or_ae_not_mem (s := g ⁻¹' U) (hgm hU) <| by rw [← preimage_comp, hg_eq]
 
 /-- Let `f : α → α` be a quasi ergodic map.
 Let `g : α → X` be a null-measurable function from `α` to a nonempty measurable space

--- a/Mathlib/Dynamics/PeriodicPts/Defs.lean
+++ b/Mathlib/Dynamics/PeriodicPts/Defs.lean
@@ -264,8 +264,11 @@ theorem minimalPeriod_pos_of_mem_periodicPts (hx : x ∈ periodicPts f) : 0 < mi
   classical
   simp only [minimalPeriod, dif_pos hx, (Nat.find_spec hx).1.lt]
 
-theorem minimalPeriod_eq_zero_of_nmem_periodicPts (hx : x ∉ periodicPts f) :
+theorem minimalPeriod_eq_zero_of_not_mem_periodicPts (hx : x ∉ periodicPts f) :
     minimalPeriod f x = 0 := by simp only [minimalPeriod, dif_neg hx]
+
+@[deprecated (since := "2025-04-27")]
+alias minimalPeriod_eq_zero_of_nmem_periodicPts := minimalPeriod_eq_zero_of_not_mem_periodicPts
 
 theorem IsPeriodicPt.minimalPeriod_pos (hn : 0 < n) (hx : IsPeriodicPt f n x) :
     0 < minimalPeriod f x :=
@@ -275,8 +278,11 @@ theorem minimalPeriod_pos_iff_mem_periodicPts : 0 < minimalPeriod f x ↔ x ∈ 
   ⟨not_imp_not.1 fun h => by simp only [minimalPeriod, dif_neg h, lt_irrefl 0, not_false_iff],
     minimalPeriod_pos_of_mem_periodicPts⟩
 
-theorem minimalPeriod_eq_zero_iff_nmem_periodicPts : minimalPeriod f x = 0 ↔ x ∉ periodicPts f := by
+theorem minimalPeriod_eq_zero_iff_not_mem_periodicPts : minimalPeriod f x = 0 ↔ x ∉ periodicPts f := by
   rw [← minimalPeriod_pos_iff_mem_periodicPts, not_lt, nonpos_iff_eq_zero]
+
+@[deprecated (since := "2025-04-27")]
+alias minimalPeriod_eq_zero_iff_nmem_periodicPts := minimalPeriod_eq_zero_iff_not_mem_periodicPts
 
 theorem IsPeriodicPt.minimalPeriod_le (hn : 0 < n) (hx : IsPeriodicPt f n x) :
     minimalPeriod f x ≤ n := by
@@ -410,7 +416,7 @@ theorem periodicOrbit_length : (periodicOrbit f x).length = minimalPeriod f x :=
 theorem periodicOrbit_eq_nil_iff_not_periodic_pt :
     periodicOrbit f x = Cycle.nil ↔ x ∉ periodicPts f := by
   simp only [periodicOrbit.eq_1, Cycle.coe_eq_nil, List.map_eq_nil_iff, List.range_eq_nil]
-  exact minimalPeriod_eq_zero_iff_nmem_periodicPts
+  exact minimalPeriod_eq_zero_iff_not_mem_periodicPts
 
 theorem periodicOrbit_eq_nil_of_not_periodic_pt (h : x ∉ periodicPts f) :
     periodicOrbit f x = Cycle.nil :=
@@ -465,7 +471,7 @@ theorem periodicOrbit_chain (r : α → α → Prop) {f : α → α} {x : α} :
       nth_rw 3 [← @iterate_minimalPeriod α f x]
       nth_rw 2 [← hM]
       exact H _ (Nat.lt_succ_self _)
-  · rw [periodicOrbit_eq_nil_of_not_periodic_pt hx, minimalPeriod_eq_zero_of_nmem_periodicPts hx]
+  · rw [periodicOrbit_eq_nil_of_not_periodic_pt hx, minimalPeriod_eq_zero_of_not_mem_periodicPts hx]
     simp
 
 theorem periodicOrbit_chain' (r : α → α → Prop) {f : α → α} {x : α} (hx : x ∈ periodicPts f) :

--- a/Mathlib/Dynamics/PeriodicPts/Defs.lean
+++ b/Mathlib/Dynamics/PeriodicPts/Defs.lean
@@ -278,7 +278,8 @@ theorem minimalPeriod_pos_iff_mem_periodicPts : 0 < minimalPeriod f x ↔ x ∈ 
   ⟨not_imp_not.1 fun h => by simp only [minimalPeriod, dif_neg h, lt_irrefl 0, not_false_iff],
     minimalPeriod_pos_of_mem_periodicPts⟩
 
-theorem minimalPeriod_eq_zero_iff_not_mem_periodicPts : minimalPeriod f x = 0 ↔ x ∉ periodicPts f := by
+theorem minimalPeriod_eq_zero_iff_not_mem_periodicPts :
+    minimalPeriod f x = 0 ↔ x ∉ periodicPts f := by
   rw [← minimalPeriod_pos_iff_mem_periodicPts, not_lt, nonpos_iff_eq_zero]
 
 @[deprecated (since := "2025-04-27")]

--- a/Mathlib/Geometry/Manifold/ContMDiff/Basic.lean
+++ b/Mathlib/Geometry/Manifold/ContMDiff/Basic.lean
@@ -279,7 +279,7 @@ theorem contMDiffWithinAt_of_not_mem_mulTSupport {f : M → M'} [One M'] {x : M}
     (hx : x ∉ mulTSupport f) (n : WithTop ℕ∞) (s : Set M) : ContMDiffWithinAt I I' n f s x := by
   apply contMDiffWithinAt_const.congr_of_eventuallyEq
     (eventually_nhdsWithin_of_eventually_nhds <| not_mem_mulTSupport_iff_eventuallyEq.mp hx)
-    (image_eq_one_of_nmem_mulTSupport hx)
+    (image_eq_one_of_not_mem_mulTSupport hx)
 
 /-- `f` is continuously differentiable at each point outside of its `mulTSupport`. -/
 @[to_additive contMDiffAt_of_not_mem]

--- a/Mathlib/Geometry/Manifold/PartitionOfUnity.lean
+++ b/Mathlib/Geometry/Manifold/PartitionOfUnity.lean
@@ -505,7 +505,7 @@ theorem exists_smooth_zero_one_of_isClosed [T2Space M] [SigmaCompactSpace M] {s 
       ⟨g.sum_nonneg x, g.sum_le_one x⟩⟩
   suffices ∀ i, g i x = 0 by simp only [this, ContMDiffMap.coeFn_mk, finsum_zero, Pi.zero_apply]
   refine fun i => f.toSmoothPartitionOfUnity_zero_of_zero ?_
-  exact nmem_support.1 (subset_compl_comm.1 (hf.support_subset i) hx)
+  exact not_mem_support.1 (subset_compl_comm.1 (hf.support_subset i) hx)
 
 /-- Given two disjoint closed sets `s, t` in a Hausdorff normal σ-compact finite dimensional
 manifold `M`, there exists a smooth function `f : M → [0,1]` that vanishes in a neighbourhood of `s`
@@ -698,12 +698,12 @@ theorem IsOpen.exists_msmooth_support_eq {s : Set M} (hs : IsOpen s) :
       intro c
       by_cases Hx : x ∈ tsupport (f c)
       · suffices g c (chartAt H c x) = 0 by simp only [this, mul_zero]
-        rw [← nmem_support, g_supp, ← mem_preimage, preimage_inter]
+        rw [← not_mem_support, g_supp, ← mem_preimage, preimage_inter]
         contrapose! hx
         simp only [mem_inter_iff, mem_preimage, (chartAt H c).left_inv (hf c Hx)] at hx
         exact hx.2
       · have : x ∉ support (f c) := by contrapose! Hx; exact subset_tsupport _ Hx
-        rw [nmem_support] at this
+        rw [not_mem_support] at this
         simp [this]
   · apply SmoothPartitionOfUnity.contMDiff_finsum_smul
     intro c x hx
@@ -749,7 +749,7 @@ theorem exists_msmooth_support_eq_eq_one_iff
     simp only [support_div, f_supp, B, inter_univ]
   -- show that the function equals one exactly on `t`
   · intro x
-    simp [div_eq_one_iff_eq (A x).ne', left_eq_add, ← nmem_support, g_supp]
+    simp [div_eq_one_iff_eq (A x).ne', left_eq_add, ← not_mem_support, g_supp]
 
 /-- Given two disjoint closed sets `s, t` in a Hausdorff σ-compact finite dimensional manifold,
 there exists an infinitely smooth function that is equal to `0` exactly on `s` and to `1`
@@ -761,4 +761,4 @@ theorem exists_msmooth_zero_iff_one_iff_of_isClosed {s t : Set M}
   rcases exists_msmooth_support_eq_eq_one_iff I hs.isOpen_compl ht hd.subset_compl_left with
     ⟨f, f_diff, f_range, fs, ft⟩
   refine ⟨f, f_diff, f_range, ?_, ft⟩
-  simp [← nmem_support, fs]
+  simp [← not_mem_support, fs]

--- a/Mathlib/GroupTheory/CosetCover.lean
+++ b/Mathlib/GroupTheory/CosetCover.lean
@@ -370,7 +370,7 @@ variable {k E : Type*} [DivisionRing k] [Infinite k] [AddCommGroup E] [Module k 
     {s : Finset (Subspace k E)}
 
 /- A vector space over an infinite field cannot be a finite union of proper subspaces. -/
-theorem Subspace.biUnion_ne_univ_of_top_nmem (hs : ⊤ ∉ s) :
+theorem Subspace.biUnion_ne_univ_of_top_not_mem (hs : ⊤ ∉ s) :
     ⋃ p ∈ s, (p : Set E) ≠ Set.univ := by
   intro hcovers
   have ⟨p, hp, hfi⟩ := Submodule.exists_finiteIndex_of_cover hcovers
@@ -380,14 +380,17 @@ theorem Subspace.biUnion_ne_univ_of_top_nmem (hs : ⊤ ∉ s) :
   have : Infinite (E ⧸ p) := Module.Free.infinite k (E ⧸ p)
   exact not_finite (E ⧸ p)
 
+@[deprecated (since := "2025-04-27")]
+alias Subspace.biUnion_ne_univ_of_top_nmem := Subspace.biUnion_ne_univ_of_top_not_mem
+
 /- A vector space over an infinite field cannot be a finite union of proper subspaces. -/
 theorem Subspace.top_mem_of_biUnion_eq_univ (hcovers : ⋃ p ∈ s, (p : Set E) = Set.univ) :
     ⊤ ∈ s := by
   contrapose! hcovers
-  exact Subspace.biUnion_ne_univ_of_top_nmem hcovers
+  exact Subspace.biUnion_ne_univ_of_top_not_mem hcovers
 
 @[deprecated (since := "2024-10-29")]
-alias Subspace.biUnion_ne_univ_of_ne_top := Subspace.biUnion_ne_univ_of_top_nmem
+alias Subspace.biUnion_ne_univ_of_ne_top := Subspace.biUnion_ne_univ_of_top_not_mem
 @[deprecated (since := "2024-10-29")]
 alias Subspace.exists_eq_top_of_biUnion_eq_univ := Subspace.top_mem_of_biUnion_eq_univ
 

--- a/Mathlib/LinearAlgebra/Dual/Lemmas.lean
+++ b/Mathlib/LinearAlgebra/Dual/Lemmas.lean
@@ -296,17 +296,20 @@ theorem dualCoannihilator_top [Projective R M] :
     (⊤ : Submodule R (Module.Dual R M)).dualCoannihilator = ⊥ := by
   rw [dualCoannihilator, dualAnnihilator_top, comap_bot, Module.eval_ker]
 
-theorem exists_dual_map_eq_bot_of_nmem {x : M} (hx : x ∉ p) (hp' : Free R (M ⧸ p)) :
+theorem exists_dual_map_eq_bot_of_not_mem {x : M} (hx : x ∉ p) (hp' : Free R (M ⧸ p)) :
     ∃ f : Dual R M, f x ≠ 0 ∧ p.map f = ⊥ := by
   suffices ∃ f : Dual R (M ⧸ p), f (p.mkQ x) ≠ 0 by
     obtain ⟨f, hf⟩ := this; exact ⟨f.comp p.mkQ, hf, by simp [Submodule.map_comp]⟩
   rwa [← Submodule.Quotient.mk_eq_zero, ← Submodule.mkQ_apply,
     ← forall_dual_apply_eq_zero_iff (K := R), not_forall] at hx
 
+@[deprecated (since := "2025-04-27")]
+alias exists_dual_map_eq_bot_of_nmem := exists_dual_map_eq_bot_of_not_mem
+
 theorem exists_dual_map_eq_bot_of_lt_top (hp : p < ⊤) (hp' : Free R (M ⧸ p)) :
     ∃ f : Dual R M, f ≠ 0 ∧ p.map f = ⊥ := by
   obtain ⟨x, hx⟩ : ∃ x : M, x ∉ p := by rw [lt_top_iff_ne_top] at hp; contrapose! hp; ext; simp [hp]
-  obtain ⟨f, hf, hf'⟩ := p.exists_dual_map_eq_bot_of_nmem hx hp'
+  obtain ⟨f, hf, hf'⟩ := p.exists_dual_map_eq_bot_of_not_mem hx hp'
   exact ⟨f, by aesop, hf'⟩
 
 /-- Consider a reflexive module and a set `s` of linear forms. If for any `z ≠ 0` there exists
@@ -331,7 +334,7 @@ theorem _root_.FiniteDimensional.mem_span_of_iInf_ker_le_ker [FiniteDimensional 
     {L : ι → E →ₗ[𝕜] 𝕜} {K : E →ₗ[𝕜] 𝕜}
     (h : ⨅ i, LinearMap.ker (L i) ≤ ker K) : K ∈ span 𝕜 (range L) := by
   by_contra hK
-  rcases exists_dual_map_eq_bot_of_nmem hK inferInstance with ⟨φ, φne, hφ⟩
+  rcases exists_dual_map_eq_bot_of_not_mem hK inferInstance with ⟨φ, φne, hφ⟩
   let φs := (Module.evalEquiv 𝕜 E).symm φ
   have : K φs = 0 := by
     refine h <| (Submodule.mem_iInf _).2 fun i ↦ (mem_bot 𝕜).1 ?_

--- a/Mathlib/LinearAlgebra/FreeModule/PID.lean
+++ b/Mathlib/LinearAlgebra/FreeModule/PID.lean
@@ -428,16 +428,22 @@ namespace Basis.SmithNormalForm
 
 variable {n : ℕ} {N : Submodule R M} (snf : Basis.SmithNormalForm N ι n) (m : N)
 
-lemma repr_eq_zero_of_nmem_range {i : ι} (hi : i ∉ Set.range snf.f) :
+lemma repr_eq_zero_of_not_mem_range {i : ι} (hi : i ∉ Set.range snf.f) :
     snf.bM.repr m i = 0 := by
   obtain ⟨m, hm⟩ := m
   obtain ⟨c, rfl⟩ := snf.bN.mem_submodule_iff.mp hm
   replace hi : ∀ j, snf.f j ≠ i := by simpa using hi
   simp [Finsupp.single_apply, hi, snf.snf, map_finsuppSum]
 
-lemma le_ker_coord_of_nmem_range {i : ι} (hi : i ∉ Set.range snf.f) :
+@[deprecated (since := "2025-04-27")]
+alias repr_eq_zero_of_nmem_range := repr_eq_zero_of_not_mem_range
+
+lemma le_ker_coord_of_not_mem_range {i : ι} (hi : i ∉ Set.range snf.f) :
     N ≤ LinearMap.ker (snf.bM.coord i) :=
-  fun m hm ↦ snf.repr_eq_zero_of_nmem_range ⟨m, hm⟩ hi
+  fun m hm ↦ snf.repr_eq_zero_of_not_mem_range ⟨m, hm⟩ hi
+
+@[deprecated (since := "2025-04-27")]
+alias le_ker_coord_of_nmem_range := le_ker_coord_of_not_mem_range
 
 @[simp] lemma repr_apply_embedding_eq_repr_smul {i : Fin n} :
     snf.bM.repr m (snf.f i) = snf.bN.repr (snf.a i • m) i := by

--- a/Mathlib/LinearAlgebra/PID.lean
+++ b/Mathlib/LinearAlgebra/PID.lean
@@ -38,7 +38,7 @@ lemma trace_restrict_eq_of_forall_mem [IsDomain R] [IsPrincipalIdealRing R]
   set A : Matrix (Fin n) (Fin n) R := toMatrix snf.bN snf.bN (f.restrict hf')
   set B : Matrix ι ι R := toMatrix snf.bM snf.bM f
   have aux : ∀ i, B i i ≠ 0 → i ∈ Set.range snf.f := fun i hi ↦ by
-    contrapose! hi; exact snf.repr_eq_zero_of_nmem_range ⟨_, (hf _)⟩ hi
+    contrapose! hi; exact snf.repr_eq_zero_of_not_mem_range ⟨_, (hf _)⟩ hi
   change ∑ i, A i i = ∑ i, B i i
   rw [← Finset.sum_filter_of_ne (p := fun j ↦ j ∈ Set.range snf.f) (by simpa using aux)]
   simp [A, B]

--- a/Mathlib/LinearAlgebra/RootSystem/Base.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Base.lean
@@ -186,7 +186,7 @@ lemma pos_or_neg_of_sum_smul_root_mem [CharZero R] [Fintype ι] (f : ι → ℤ)
   · replace hi : i ∉ f.support := by contrapose! hi; exact hf₀ hi
     aesop
 
-lemma sub_nmem_range_root [CharZero R] [Finite ι]
+lemma sub_not_mem_range_root [CharZero R] [Finite ι]
     {i j : ι} (hi : i ∈ b.support) (hj : j ∈ b.support) :
     P.root i - P.root j ∉ range P.root := by
   rcases eq_or_ne j i with rfl | hij
@@ -203,10 +203,14 @@ lemma sub_nmem_range_root [CharZero R] [Finite ι]
   · simpa [hij, f] using pos j
   · simpa [hij, f] using neg i
 
-lemma sub_nmem_range_coroot [CharZero R] [Finite ι]
+@[deprecated (since := "2025-04-27")] alias sub_nmem_range_root := sub_not_mem_range_root
+
+lemma sub_not_mem_range_coroot [CharZero R] [Finite ι]
     {i j : ι} (hi : i ∈ b.support) (hj : j ∈ b.support) :
     P.coroot i - P.coroot j ∉ range P.coroot :=
-  b.flip.sub_nmem_range_root hi hj
+  b.flip.sub_not_mem_range_root hi hj
+
+@[deprecated (since := "2025-04-27")] alias sub_nmem_range_coroot := sub_not_mem_range_coroot
 
 end RootPairing
 

--- a/Mathlib/LinearAlgebra/RootSystem/Finite/Lemmas.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Finite/Lemmas.lean
@@ -291,7 +291,7 @@ variable {i j} in
 lemma pairingIn_le_zero_of_ne :
     P.pairingIn ℤ i j ≤ 0 := by
   by_contra! h
-  exact b.sub_nmem_range_root hi hj <| P.root_sub_root_mem_of_pairingIn_pos h hij
+  exact b.sub_not_mem_range_root hi hj <| P.root_sub_root_mem_of_pairingIn_pos h hij
 
 /-- This is Lemma 2.5 (a) from [Geck](Geck2017). -/
 lemma root_sub_root_mem_of_mem_of_mem (hk : α k + α i - α j ∈ Φ)
@@ -314,7 +314,7 @@ lemma root_sub_root_mem_of_mem_of_mem (hk : α k + α i - α j ∈ Φ)
     suffices α l - α k ∉ Φ by contrapose! this; exact P.root_sub_root_mem_of_pairingIn_pos this hkl
     replace hl : α l - α k = α i - α j := by rw [hl]; module
     rw [hl]
-    exact b.sub_nmem_range_root hi hj
+    exact b.sub_not_mem_range_root hi hj
   have hki : P.pairingIn ℤ i k ≤ -2 := by
     suffices P.pairingIn ℤ l k = 2 + P.pairingIn ℤ i k - P.pairingIn ℤ j k by linarith
     apply algebraMap_injective ℤ R

--- a/Mathlib/MeasureTheory/Function/ContinuousMapDense.lean
+++ b/Mathlib/MeasureTheory/Function/ContinuousMapDense.lean
@@ -179,7 +179,7 @@ theorem MemLp.exists_hasCompactSupport_eLpNorm_sub_le
           I2 I1).le using 2
     simp only [sub_add_sub_cancel]
   refine ⟨f, I3, f_cont, f_mem, HasCompactSupport.intro k_compact fun x hx => ?_⟩
-  rw [← Function.nmem_support]
+  rw [← Function.not_mem_support]
   contrapose! hx
   exact interior_subset (f_support hx)
 

--- a/Mathlib/MeasureTheory/Function/ConvergenceInMeasure.lean
+++ b/Mathlib/MeasureTheory/Function/ConvergenceInMeasure.lean
@@ -136,7 +136,7 @@ theorem tendstoInMeasure_of_tendsto_ae_of_stronglyMeasurable [IsFiniteMeasure μ
   suffices { x : α | ε ≤ dist (f n x) (g x) } ⊆ t from (measure_mono this).trans ht
   rw [← Set.compl_subset_compl]
   intro x hx
-  rw [Set.mem_compl_iff, Set.nmem_setOf_iff, dist_comm, not_le]
+  rw [Set.mem_compl_iff, Set.not_mem_setOf_iff, dist_comm, not_le]
   exact hN n hn x hx
 
 /-- Convergence a.e. implies convergence in measure in a finite measure space. -/
@@ -269,7 +269,7 @@ theorem exists_seq_tendstoInMeasure_atTop_iff [IsFiniteMeasure μ]
   obtain ⟨ε, hε, h2⟩ := h1
   obtain ⟨δ, ns, hδ, hns, h3⟩ : ∃ (δ : ℝ≥0) (ns : ℕ → ℕ), 0 < δ ∧ StrictMono ns ∧
       ∀ n, δ ≤ (μ {x | ε ≤ dist (f (ns n) x) (g x)}).toNNReal := by
-    obtain ⟨s, hs, h4⟩ := not_tendsto_iff_exists_frequently_nmem.1 h2
+    obtain ⟨s, hs, h4⟩ := not_tendsto_iff_exists_frequently_not_mem.1 h2
     obtain ⟨δ, hδ, h5⟩ := NNReal.nhds_zero_basis.mem_iff.1 hs
     obtain ⟨ns, hns, h6⟩ := extraction_of_frequently_atTop h4
     exact ⟨δ, ns, hδ, hns, fun n ↦ Set.not_mem_Iio.1 (Set.not_mem_subset h5 (h6 n))⟩

--- a/Mathlib/MeasureTheory/Function/L2Space.lean
+++ b/Mathlib/MeasureTheory/Function/L2Space.lean
@@ -234,7 +234,7 @@ theorem inner_indicatorConstLp_eq_setIntegral_inner (f : Lp E 2 μ) (hs : Measur
         simp
       exact setIntegral_congr_ae hs.compl h_ae_eq
     have h_indicator : ∀ᵐ x : α ∂μ, x ∉ s → indicatorConstLp 2 hs hμs c x = 0 :=
-      indicatorConstLp_coeFn_nmem
+      indicatorConstLp_coeFn_not_mem
     refine h_indicator.mono fun x hx hxs => ?_
     rw [hx hxs]
     exact inner_zero_left _

--- a/Mathlib/MeasureTheory/Function/LocallyIntegrable.lean
+++ b/Mathlib/MeasureTheory/Function/LocallyIntegrable.lean
@@ -325,7 +325,7 @@ theorem LocallyIntegrable.integrable_smul_left_of_hasCompactSupport
     apply indicator_eq_self.2
     apply support_subset_iff'.2
     intros x hx
-    simp [image_eq_zero_of_nmem_tsupport hx]
+    simp [image_eq_zero_of_not_mem_tsupport hx]
   rw [← this, indicator_smul]
   apply Integrable.smul_of_top_right
   · rw [integrable_indicator_iff hK.measurableSet]
@@ -344,7 +344,7 @@ theorem LocallyIntegrable.integrable_smul_right_of_hasCompactSupport
     apply indicator_eq_self.2
     apply support_subset_iff'.2
     intros x hx
-    simp [image_eq_zero_of_nmem_tsupport hx]
+    simp [image_eq_zero_of_not_mem_tsupport hx]
   rw [← this, indicator_smul_left]
   apply Integrable.smul_of_top_left
   · rw [integrable_indicator_iff hK.measurableSet]

--- a/Mathlib/MeasureTheory/Function/LpSpace/Indicator.lean
+++ b/Mathlib/MeasureTheory/Function/LpSpace/Indicator.lean
@@ -64,7 +64,7 @@ theorem _root_.HasCompactSupport.memLp_of_bound {f : X → E} (hf : HasCompactSu
     (h2f : AEStronglyMeasurable f μ) (C : ℝ) (hfC : ∀ᵐ x ∂μ, ‖f x‖ ≤ C) : MemLp f p μ := by
   have := memLp_top_of_bound h2f C hfC
   exact this.mono_exponent_of_measure_support_ne_top
-    (fun x ↦ image_eq_zero_of_nmem_tsupport) (hf.measure_lt_top.ne) le_top
+    (fun x ↦ image_eq_zero_of_not_mem_tsupport) (hf.measure_lt_top.ne) le_top
 
 @[deprecated (since := "2025-02-21")]
 alias _root_.HasCompactSupport.memℒp_of_bound := _root_.HasCompactSupport.memLp_of_bound
@@ -74,7 +74,7 @@ theorem _root_.Continuous.memLp_of_hasCompactSupport [OpensMeasurableSpace X]
     {f : X → E} (hf : Continuous f) (h'f : HasCompactSupport f) : MemLp f p μ := by
   have := hf.memLp_top_of_hasCompactSupport h'f μ
   exact this.mono_exponent_of_measure_support_ne_top
-    (fun x ↦ image_eq_zero_of_nmem_tsupport) (h'f.measure_lt_top.ne) le_top
+    (fun x ↦ image_eq_zero_of_not_mem_tsupport) (h'f.measure_lt_top.ne) le_top
 
 @[deprecated (since := "2025-02-21")]
 alias _root_.Continuous.memℒp_of_hasCompactSupport := _root_.Continuous.memLp_of_hasCompactSupport
@@ -111,8 +111,11 @@ theorem indicatorConstLp_coeFn : ⇑(indicatorConstLp p hs hμs c) =ᵐ[μ] s.in
 theorem indicatorConstLp_coeFn_mem : ∀ᵐ x : α ∂μ, x ∈ s → indicatorConstLp p hs hμs c x = c :=
   indicatorConstLp_coeFn.mono fun _x hx hxs => hx.trans (Set.indicator_of_mem hxs _)
 
-theorem indicatorConstLp_coeFn_nmem : ∀ᵐ x : α ∂μ, x ∉ s → indicatorConstLp p hs hμs c x = 0 :=
+theorem indicatorConstLp_coeFn_not_mem : ∀ᵐ x : α ∂μ, x ∉ s → indicatorConstLp p hs hμs c x = 0 :=
   indicatorConstLp_coeFn.mono fun _x hx hxs => hx.trans (Set.indicator_of_not_mem hxs _)
+
+@[deprecated (since := "2025-04-27")]
+alias indicatorConstLp_coeFn_nmem := indicatorConstLp_coeFn_not_mem
 
 theorem norm_indicatorConstLp (hp_ne_zero : p ≠ 0) (hp_ne_top : p ≠ ∞) :
     ‖indicatorConstLp p hs hμs c‖ = ‖c‖ * μ.real s ^ (1 / p.toReal) := by

--- a/Mathlib/MeasureTheory/Integral/Average.lean
+++ b/Mathlib/MeasureTheory/Integral/Average.lean
@@ -801,7 +801,7 @@ theorem tendsto_integral_smul_of_tendsto_average_norm_sub
     simp_rw [average_eq, smul_eq_mul, ← integral_mul_left, norm_smul, ← mul_assoc, ← div_eq_mul_inv]
     have : ∀ x, x ∉ a i → ‖g i x‖ * ‖(f x - c)‖ = 0 := by
       intro x hx
-      have : g i x = 0 := by rw [← Function.nmem_support]; exact fun h ↦ hx (hi h)
+      have : g i x = 0 := by rw [← Function.not_mem_support]; exact fun h ↦ hx (hi h)
       simp [this]
     rw [← setIntegral_eq_integral_of_forall_compl_eq_zero this (μ := μ)]
     refine integral_mono_of_nonneg (Eventually.of_forall (fun x ↦ by positivity)) ?_

--- a/Mathlib/MeasureTheory/Integral/Bochner/Set.lean
+++ b/Mathlib/MeasureTheory/Integral/Bochner/Set.lean
@@ -284,7 +284,7 @@ theorem integral_union_eq_left_of_ae_aux (ht_eq : ∀ᵐ x ∂μ.restrict t, f x
   apply setIntegral_congr_set
   rw [union_ae_eq_right]
   apply measure_mono_null diff_subset
-  rw [measure_zero_iff_ae_nmem]
+  rw [measure_zero_iff_ae_not_mem]
   filter_upwards [ae_imp_of_ae_restrict ht_eq] with x hx h'x using h'x.2 (hx h'x.1)
 
 theorem integral_union_eq_left_of_ae (ht_eq : ∀ᵐ x ∂μ.restrict t, f x = 0) :
@@ -413,7 +413,7 @@ theorem integral_norm_eq_pos_sub_neg {f : X → ℝ} (hfi : Integrable f μ) :
       refine setIntegral_congr_fun₀ h_meas.compl fun x hx => ?_
       dsimp only
       rw [Real.norm_eq_abs, abs_eq_neg_self.mpr _]
-      rw [Set.mem_compl_iff, Set.nmem_setOf_iff] at hx
+      rw [Set.mem_compl_iff, Set.not_mem_setOf_iff] at hx
       linarith
     _ = ∫ x in {x | 0 ≤ f x}, f x ∂μ - ∫ x in {x | f x ≤ 0}, f x ∂μ := by
       rw [← setIntegral_neg_eq_setIntegral_nonpos hfi.1, compl_setOf]; simp only [not_le]
@@ -899,13 +899,13 @@ variable {M : Type*} [NormedAddCommGroup M] [NormedSpace ℝ M] {mX : Measurable
 theorem MeasureTheory.setIntegral_support : ∫ x in support F, F x ∂ν = ∫ x, F x ∂ν := by
   nth_rw 2 [← setIntegral_univ]
   rw [setIntegral_eq_of_subset_of_forall_diff_eq_zero MeasurableSet.univ (subset_univ (support F))]
-  exact fun _ hx => nmem_support.mp <| not_mem_of_mem_diff hx
+  exact fun _ hx => not_mem_support.mp <| not_mem_of_mem_diff hx
 
 theorem MeasureTheory.setIntegral_tsupport [TopologicalSpace X] :
     ∫ x in tsupport F, F x ∂ν = ∫ x, F x ∂ν := by
   nth_rw 2 [← setIntegral_univ]
   rw [setIntegral_eq_of_subset_of_forall_diff_eq_zero MeasurableSet.univ (subset_univ (tsupport F))]
-  exact fun _ hx => image_eq_zero_of_nmem_tsupport <| not_mem_of_mem_diff hx
+  exact fun _ hx => image_eq_zero_of_not_mem_tsupport <| not_mem_of_mem_diff hx
 
 end Support
 

--- a/Mathlib/MeasureTheory/Integral/Layercake.lean
+++ b/Mathlib/MeasureTheory/Integral/Layercake.lean
@@ -550,7 +550,7 @@ lemma Integrable.integral_eq_integral_Ioc_meas_le {f : α → ℝ} {M : ℝ}
   apply Eventually.of_forall (fun t ht ↦ ?_)
   have htM : M < t := by simp_all only [mem_diff, mem_Ioi, mem_Ioc, not_and, not_le]
   have obs : μ {a | M < f a} = 0 := by
-    rw [measure_zero_iff_ae_nmem]
+    rw [measure_zero_iff_ae_not_mem]
     filter_upwards [f_bdd] with a ha using not_lt.mpr ha
   rw [measureReal_def, ENNReal.toReal_eq_zero_iff]
   exact Or.inl <| measure_mono_null (fun a ha ↦ lt_of_lt_of_le htM ha) obs

--- a/Mathlib/MeasureTheory/Integral/Lebesgue/Add.lean
+++ b/Mathlib/MeasureTheory/Integral/Lebesgue/Add.lean
@@ -127,7 +127,7 @@ theorem lintegral_iSup_ae {f : ℕ → α → ℝ≥0∞} (hf : ∀ n, Measurabl
   let ⟨s, hs⟩ := exists_measurable_superset_of_null (ae_iff.1 (ae_all_iff.2 h_mono))
   let g n a := if a ∈ s then 0 else f n a
   have g_eq_f : ∀ᵐ a ∂μ, ∀ n, g n a = f n a :=
-    (measure_zero_iff_ae_nmem.1 hs.2.2).mono fun a ha n => if_neg ha
+    (measure_zero_iff_ae_not_mem.1 hs.2.2).mono fun a ha n => if_neg ha
   calc
     ∫⁻ a, ⨆ n, f n a ∂μ = ∫⁻ a, ⨆ n, g n a ∂μ :=
       lintegral_congr_ae <| g_eq_f.mono fun a ha => by simp only [ha]

--- a/Mathlib/MeasureTheory/Integral/Lebesgue/Basic.lean
+++ b/Mathlib/MeasureTheory/Integral/Lebesgue/Basic.lean
@@ -156,7 +156,7 @@ theorem lintegral_eq_nnreal {m : MeasurableSpace α} (f : α → ℝ≥0∞) (μ
     replace h : ψ.map ((↑) : ℝ≥0 → ℝ≥0∞) =ᵐ[μ] φ := h.mono fun a => ENNReal.coe_toNNReal
     have : ∀ x, ↑(ψ x) ≤ f x := fun x => le_trans ENNReal.coe_toNNReal_le_self (hφ x)
     exact le_iSup₂_of_le (φ.map ENNReal.toNNReal) this (ge_of_eq <| lintegral_congr h)
-  · have h_meas : μ (φ ⁻¹' {∞}) ≠ 0 := mt measure_zero_iff_ae_nmem.1 h
+  · have h_meas : μ (φ ⁻¹' {∞}) ≠ 0 := mt measure_zero_iff_ae_not_mem.1 h
     refine le_trans le_top (ge_of_eq <| (iSup_eq_top _).2 fun b hb => ?_)
     obtain ⟨n, hn⟩ : ∃ n : ℕ, b < n * μ (φ ⁻¹' {∞}) := exists_nat_mul_gt h_meas (ne_of_lt hb)
     use (const α (n : ℝ≥0)).restrict (φ ⁻¹' {∞})
@@ -208,7 +208,7 @@ theorem le_iInf₂_lintegral {ι : Sort*} {ι' : ι → Sort*} (f : ∀ i, ι' i
 theorem lintegral_mono_ae {f g : α → ℝ≥0∞} (h : ∀ᵐ a ∂μ, f a ≤ g a) :
     ∫⁻ a, f a ∂μ ≤ ∫⁻ a, g a ∂μ := by
   rcases exists_measurable_superset_of_null h with ⟨t, hts, ht, ht0⟩
-  have : ∀ᵐ x ∂μ, x ∉ t := measure_zero_iff_ae_nmem.1 ht0
+  have : ∀ᵐ x ∂μ, x ∉ t := measure_zero_iff_ae_not_mem.1 ht0
   rw [lintegral, lintegral]
   refine iSup₂_le fun s hfs ↦ le_iSup₂_of_le (s.restrict tᶜ) ?_ ?_
   · intro a

--- a/Mathlib/MeasureTheory/Integral/RieszMarkovKakutani/Basic.lean
+++ b/Mathlib/MeasureTheory/Integral/RieszMarkovKakutani/Basic.lean
@@ -196,7 +196,7 @@ lemma exists_continuous_add_one_of_isCompact_nnreal
     simp only [Fin.isValue, nnrealPart_apply,
       CompactlySupportedContinuousMap.coe_mk, Pi.one_apply, Real.toNNReal_eq_one]
     have : (f 0) x = 0 := by
-      rw [← nmem_support]
+      rw [← not_mem_support]
       have : s₀ ⊆ (tsupport (f 0))ᶜ := by
         apply subset_trans _ (compl_subset_compl.mpr (f_supp_in_so 0))
         rw [hso]
@@ -211,7 +211,7 @@ lemma exists_continuous_add_one_of_isCompact_nnreal
     simp only [Fin.isValue, nnrealPart_apply,
       CompactlySupportedContinuousMap.coe_mk, Pi.one_apply, Real.toNNReal_eq_one]
     have : (f 1) x = 0 := by
-      rw [← nmem_support]
+      rw [← not_mem_support]
       have : s₁ ⊆ (tsupport (f 1))ᶜ := by
         apply subset_trans _ (compl_subset_compl.mpr (f_supp_in_so 1))
         rw [hso]
@@ -342,7 +342,7 @@ lemma le_rieszMeasure_of_isCompact_tsupport_subset {f : C_c(X, ℝ≥0)} (hf : �
   simp only [ContinuousMap.toFun_eq_coe, CompactlySupportedContinuousMap.coe_toContinuousMap]
   by_cases hx : x ∈ tsupport f
   · exact le_trans (hf x) (hg.1 x (Set.mem_of_subset_of_mem h hx))
-  · rw [image_eq_zero_of_nmem_tsupport hx]
+  · rw [image_eq_zero_of_not_mem_tsupport hx]
     exact zero_le (g x)
 
 lemma le_rieszMeasure_of_tsupport_subset {f : C_c(X, ℝ≥0)} (hf : ∀ x, f x ≤ 1) {V : Set X}

--- a/Mathlib/MeasureTheory/Integral/RieszMarkovKakutani/Real.lean
+++ b/Mathlib/MeasureTheory/Integral/RieszMarkovKakutani/Real.lean
@@ -70,7 +70,7 @@ lemma le_rieszMeasure_tsupport_subset {f : C_c(X, ℝ)} (hf : ∀ (x : X), 0 ≤
   intro x
   by_cases hx : x ∈ tsupport f
   · simpa using le_trans (hf x).2 (hg.1 x hx)
-  · simp [image_eq_zero_of_nmem_tsupport hx]
+  · simp [image_eq_zero_of_not_mem_tsupport hx]
 
 /-- If `f` assumes the value `1` on a compact set `K` then `rieszMeasure K ≤ Λ f`. -/
 lemma rieszMeasure_le_of_eq_one {f : C_c(X, ℝ)} (hf : ∀ x, 0 ≤ f x) {K : Set X}
@@ -241,7 +241,7 @@ private lemma integral_riesz_aux (f : C_c(X, ℝ)) : Λ f ≤ ∫ x, f x ∂(rie
       ← Finset.sum_mul, ← Finset.sum_apply]
     by_cases hx : x ∈ tsupport f
     · simp [hg.2.1 hx]
-    · simp [image_eq_zero_of_nmem_tsupport hx]
+    · simp [image_eq_zero_of_not_mem_tsupport hx]
   · -- Use that `f ≤ y n + ε'` on `V n`
     gcongr with n hn
     apply monotone_of_nonneg hΛ
@@ -250,7 +250,7 @@ private lemma integral_riesz_aux (f : C_c(X, ℝ)) : Λ f ≤ ∫ x, f x ∂(rie
     · rw [smul_eq_mul, mul_comm]
       apply mul_le_mul_of_nonneg_right ?_ (hg.2.2.1 n x).1
       exact le_of_lt <| (hV n).2.1 x <| mem_of_subset_of_mem (hg.1 n) hx
-    · simp [image_eq_zero_of_nmem_tsupport hx]
+    · simp [image_eq_zero_of_not_mem_tsupport hx]
   · -- Use that `Λ (g n) ≤ μ (V n)).toReal ≤ μ (E n)).toReal + ε' / N`
     gcongr with n hn
     · calc

--- a/Mathlib/MeasureTheory/Measure/AbsolutelyContinuous.lean
+++ b/Mathlib/MeasureTheory/Measure/AbsolutelyContinuous.lean
@@ -150,7 +150,7 @@ lemma absolutelyContinuous_smul {c : ℝ≥0∞} (hc : c ≠ 0) : μ ≪ c • �
 
 theorem ae_le_iff_absolutelyContinuous : ae μ ≤ ae ν ↔ μ ≪ ν :=
   ⟨fun h s => by
-    rw [measure_zero_iff_ae_nmem, measure_zero_iff_ae_nmem]
+    rw [measure_zero_iff_ae_not_mem, measure_zero_iff_ae_not_mem]
     exact fun hs => h hs, fun h _ hs => h hs⟩
 
 alias ⟨_root_.LE.le.absolutelyContinuous_of_ae, AbsolutelyContinuous.ae_le⟩ :=

--- a/Mathlib/MeasureTheory/Measure/AddContent.lean
+++ b/Mathlib/MeasureTheory/Measure/AddContent.lean
@@ -165,7 +165,7 @@ theorem eq_add_disjointOfDiff_of_subset (hC : IsSetSemiring C)
   conv_lhs => rw [← hC.sUnion_insert_disjointOfDiff ht hs hst]
   rw [← coe_insert, addContent_sUnion]
   · rw [sum_insert]
-    exact hC.nmem_disjointOfDiff ht hs
+    exact hC.not_mem_disjointOfDiff ht hs
   · rw [coe_insert]
     exact Set.insert_subset hs (hC.subset_disjointOfDiff ht hs)
   · rw [coe_insert]

--- a/Mathlib/MeasureTheory/Measure/DiracProba.lean
+++ b/Mathlib/MeasureTheory/Measure/DiracProba.lean
@@ -99,7 +99,7 @@ lemma not_tendsto_diracProba_of_not_tendsto [CompletelyRegularSpace X] {x : X} (
   use f
   simp only [diracProba, ProbabilityMeasure.coe_mk, fx_eq_one,
              lintegral_dirac' _ (measurable_coe_nnreal_ennreal_iff.mpr f.continuous.measurable)]
-  apply not_tendsto_iff_exists_frequently_nmem.mpr
+  apply not_tendsto_iff_exists_frequently_not_mem.mpr
   refine ⟨Ioi 0, Ioi_mem_nhds (by simp only [ENNReal.coe_one, zero_lt_one]),
           hU.mp (Eventually.of_forall ?_)⟩
   intro x x_notin_U

--- a/Mathlib/MeasureTheory/Measure/Haar/Unique.lean
+++ b/Mathlib/MeasureTheory/Measure/Haar/Unique.lean
@@ -187,9 +187,9 @@ lemma integral_isMulLeftInvariant_isMulRightInvariant_combo
         have : ∀ (p : G × G), p ∉ K ×ˢ closure M → f p.1 * (D p.1)⁻¹ * g (p.2⁻¹ * p.1) = 0 := by
           rintro ⟨x, y⟩ hxy
           by_cases H : x ∈ K; swap
-          · simp [image_eq_zero_of_nmem_tsupport H]
+          · simp [image_eq_zero_of_not_mem_tsupport H]
           have : g (y⁻¹ * x) = 0 := by
-            apply image_eq_zero_of_nmem_tsupport
+            apply image_eq_zero_of_not_mem_tsupport
             contrapose! hxy
             simp only [mem_prod, H, true_and]
             apply subset_closure
@@ -219,9 +219,9 @@ lemma integral_isMulLeftInvariant_isMulRightInvariant_combo
             f (p.2 * p.1) * (D (p.2 * p.1))⁻¹ * g p.1 = 0 := by
           rintro ⟨x, y⟩ hxy
           by_cases H : x ∈ L; swap
-          · simp [image_eq_zero_of_nmem_tsupport H]
+          · simp [image_eq_zero_of_not_mem_tsupport H]
           have : f (y * x) = 0 := by
-            apply image_eq_zero_of_nmem_tsupport
+            apply image_eq_zero_of_not_mem_tsupport
             contrapose! hxy
             simp only [mem_prod, H, true_and]
             apply subset_closure
@@ -472,7 +472,7 @@ lemma measure_preimage_isMulLeftInvariant_eq_smul_of_hasCompactSupport
       · simp only [v, Real.norm_eq_abs, NNReal.abs_eq, hx, not_false_eq_true, indicator_of_not_mem]
         rw [thickenedIndicator_zero]
         · simp
-        · simpa [image_eq_zero_of_nmem_tsupport hx] using (u_mem n).2.le
+        · simpa [image_eq_zero_of_not_mem_tsupport hx] using (u_mem n).2.le
     · filter_upwards with x
       have T := tendsto_pi_nhds.1 (thickenedIndicator_tendsto_indicator_closure
         (fun n ↦ (u_mem n).1) u_lim ({1} : Set ℝ)) (f x)

--- a/Mathlib/MeasureTheory/Measure/Restrict.lean
+++ b/Mathlib/MeasureTheory/Measure/Restrict.lean
@@ -911,12 +911,15 @@ theorem mem_map_indicator_ae_iff_mem_map_restrict_ae_of_zero_mem [Zero β] {t : 
     Set.preimage_const]
   simp_rw [Set.union_inter_distrib_right, Set.compl_inter_self s, Set.union_empty]
 
-theorem mem_map_indicator_ae_iff_of_zero_nmem [Zero β] {t : Set β} (ht : (0 : β) ∉ t) :
+theorem mem_map_indicator_ae_iff_of_zero_not_mem [Zero β] {t : Set β} (ht : (0 : β) ∉ t) :
     t ∈ Filter.map (s.indicator f) (ae μ) ↔ μ ((f ⁻¹' t)ᶜ ∪ sᶜ) = 0 := by
   classical
   rw [mem_map, mem_ae_iff, Set.indicator_preimage, Set.ite, Set.compl_union, Set.compl_inter]
   change μ (((f ⁻¹' t)ᶜ ∪ sᶜ) ∩ ((fun _ => (0 : β)) ⁻¹' t \ s)ᶜ) = 0 ↔ μ ((f ⁻¹' t)ᶜ ∪ sᶜ) = 0
   simp only [ht, if_false, Set.compl_empty, Set.empty_diff, Set.inter_univ, Set.preimage_const]
+
+@[deprecated (since := "2025-04-27")]
+alias mem_map_indicator_ae_iff_of_zero_nmem := mem_map_indicator_ae_iff_of_zero_not_mem
 
 theorem map_restrict_ae_le_map_indicator_ae [Zero β] (hs : MeasurableSet s) :
     Filter.map f (ae <| μ.restrict s) ≤ Filter.map (s.indicator f) (ae μ) := by
@@ -924,7 +927,7 @@ theorem map_restrict_ae_le_map_indicator_ae [Zero β] (hs : MeasurableSet s) :
   by_cases ht : (0 : β) ∈ t
   · rw [mem_map_indicator_ae_iff_mem_map_restrict_ae_of_zero_mem ht hs]
     exact id
-  rw [mem_map_indicator_ae_iff_of_zero_nmem ht, mem_map_restrict_ae_iff hs]
+  rw [mem_map_indicator_ae_iff_of_zero_not_mem ht, mem_map_restrict_ae_iff hs]
   exact fun h => measure_mono_null (Set.inter_subset_left.trans Set.subset_union_left) h
 
 variable [Zero β]

--- a/Mathlib/MeasureTheory/Measure/WithDensity.lean
+++ b/Mathlib/MeasureTheory/Measure/WithDensity.lean
@@ -316,7 +316,7 @@ theorem aemeasurable_withDensity_ennreal_iff' {f : α → ℝ≥0}
       rw [ha this]
     · rw [ae_restrict_iff' A.compl]
       filter_upwards [hf'_ae] with a ha ha_null
-      have ha_null : f' a = 0 := Function.nmem_support.mp ha_null
+      have ha_null : f' a = 0 := Function.not_mem_support.mp ha_null
       rw [ha_null] at ha ⊢
       rw [ha]
       simp only [ENNReal.coe_zero, zero_mul]

--- a/Mathlib/MeasureTheory/OuterMeasure/AE.lean
+++ b/Mathlib/MeasureTheory/OuterMeasure/AE.lean
@@ -81,8 +81,10 @@ theorem frequently_ae_iff {p : α → Prop} : (∃ᵐ a ∂μ, p a) ↔ μ { a |
 theorem frequently_ae_mem_iff {s : Set α} : (∃ᵐ a ∂μ, a ∈ s) ↔ μ s ≠ 0 :=
   not_congr compl_mem_ae_iff
 
-theorem measure_zero_iff_ae_nmem {s : Set α} : μ s = 0 ↔ ∀ᵐ a ∂μ, a ∉ s :=
+theorem measure_zero_iff_ae_not_mem {s : Set α} : μ s = 0 ↔ ∀ᵐ a ∂μ, a ∉ s :=
   compl_mem_ae_iff.symm
+
+@[deprecated (since := "2025-04-27")] alias measure_zero_iff_ae_nmem := measure_zero_iff_ae_not_mem
 
 theorem ae_of_all {p : α → Prop} (μ : F) : (∀ a, p a) → ∀ᵐ a ∂μ, p a :=
   Eventually.of_forall

--- a/Mathlib/MeasureTheory/SetSemiring.lean
+++ b/Mathlib/MeasureTheory/SetSemiring.lean
@@ -78,11 +78,14 @@ noncomputable def disjointOfDiff (hC : IsSetSemiring C) (hs : s ∈ C) (ht : t �
     Finset (Set α) :=
   (hC.diff_eq_sUnion' s hs t ht).choose \ {∅}
 
-lemma empty_nmem_disjointOfDiff (hC : IsSetSemiring C) (hs : s ∈ C) (ht : t ∈ C) :
+lemma empty_not_mem_disjointOfDiff (hC : IsSetSemiring C) (hs : s ∈ C) (ht : t ∈ C) :
     ∅ ∉ hC.disjointOfDiff hs ht := by
   classical
   simp only [disjointOfDiff, mem_sdiff, Finset.mem_singleton, eq_self_iff_true,
     not_true, and_false, not_false_iff]
+
+@[deprecated (since := "2025-04-27")]
+alias empty_nmem_disjointOfDiff := empty_not_mem_disjointOfDiff
 
 lemma subset_disjointOfDiff (hC : IsSetSemiring C) (hs : s ∈ C) (ht : t ∈ C) :
     ↑(hC.disjointOfDiff hs ht) ⊆ C := by
@@ -104,17 +107,19 @@ lemma sUnion_disjointOfDiff (hC : IsSetSemiring C) (hs : s ∈ C) (ht : t ∈ C)
   simp only [disjointOfDiff, coe_sdiff, coe_singleton, diff_singleton_subset_iff]
   rw [sUnion_diff_singleton_empty]
 
-lemma nmem_disjointOfDiff (hC : IsSetSemiring C) (hs : s ∈ C) (ht : t ∈ C) :
+lemma not_mem_disjointOfDiff (hC : IsSetSemiring C) (hs : s ∈ C) (ht : t ∈ C) :
     t ∉ hC.disjointOfDiff hs ht := by
   intro hs_mem
   suffices t ⊆ s \ t by
     have h := @disjoint_sdiff_self_right _ t s _
     specialize h le_rfl this
     simp only [Set.bot_eq_empty, Set.le_eq_subset, subset_empty_iff] at h
-    refine hC.empty_nmem_disjointOfDiff hs ht ?_
+    refine hC.empty_not_mem_disjointOfDiff hs ht ?_
     rwa [← h]
   rw [← hC.sUnion_disjointOfDiff hs ht]
   exact subset_sUnion_of_mem hs_mem
+
+@[deprecated (since := "2025-04-27")] alias nmem_disjointOfDiff := not_mem_disjointOfDiff
 
 lemma sUnion_insert_disjointOfDiff (hC : IsSetSemiring C) (hs : s ∈ C)
     (ht : t ∈ C) (hst : t ⊆ s) :
@@ -131,7 +136,7 @@ lemma pairwiseDisjoint_insert_disjointOfDiff (hC : IsSetSemiring C) (hs : s ∈ 
     (ht : t ∈ C) :
     PairwiseDisjoint (insert t (hC.disjointOfDiff hs ht) : Set (Set α)) id := by
   have h := hC.pairwiseDisjoint_disjointOfDiff hs ht
-  refine PairwiseDisjoint.insert_of_not_mem h (hC.nmem_disjointOfDiff hs ht) fun u hu ↦ ?_
+  refine PairwiseDisjoint.insert_of_not_mem h (hC.not_mem_disjointOfDiff hs ht) fun u hu ↦ ?_
   simp_rw [id]
   refine Disjoint.mono_right ?_ (hC.disjoint_sUnion_disjointOfDiff hs ht)
   simp only [Set.le_eq_subset]
@@ -220,12 +225,15 @@ noncomputable def disjointOfDiffUnion (hC : IsSetSemiring C) (hs : s ∈ C)
   (hI : ↑I ⊆ C) : Finset (Set α) :=
   (hC.exists_disjoint_finset_diff_eq hs hI).choose \ {∅}
 
-lemma empty_nmem_disjointOfDiffUnion (hC : IsSetSemiring C) (hs : s ∈ C)
+lemma empty_not_mem_disjointOfDiffUnion (hC : IsSetSemiring C) (hs : s ∈ C)
     (hI : ↑I ⊆ C) :
     ∅ ∉ hC.disjointOfDiffUnion hs hI := by
   classical
   simp only [disjointOfDiffUnion, mem_sdiff, Finset.mem_singleton, eq_self_iff_true,
     not_true, and_false, not_false_iff]
+
+@[deprecated (since := "2025-04-27")]
+alias empty_nmem_disjointOfDiffUnion := empty_not_mem_disjointOfDiffUnion
 
 lemma disjointOfDiffUnion_subset (hC : IsSetSemiring C) (hs : s ∈ C) (hI : ↑I ⊆ C) :
     ↑(hC.disjointOfDiffUnion hs hI) ⊆ C := by
@@ -279,7 +287,7 @@ lemma disjoint_disjointOfDiffUnion (hC : IsSetSemiring C) (hs : s ∈ C) (hI : �
     hC.disjoint_sUnion_disjointOfDiffUnion hs hI (subset_sUnion_of_mem huI)
     (subset_sUnion_of_mem hu_disjointOfDiffUnion)
   simp only [Set.bot_eq_empty, Set.le_eq_subset, subset_empty_iff] at h_disj
-  refine hC.empty_nmem_disjointOfDiffUnion hs hI ?_
+  refine hC.empty_not_mem_disjointOfDiffUnion hs hI ?_
   rwa [h_disj] at hu_disjointOfDiffUnion
 
 lemma pairwiseDisjoint_union_disjointOfDiffUnion (hC : IsSetSemiring C) (hs : s ∈ C)
@@ -353,7 +361,7 @@ theorem disjointOfUnion_props (hC : IsSetSemiring C) (h1 : ↑J ⊆ C) :
           refine disjoint_of_sSup_disjoint_of_le_of_le
             (hC.subset_of_diffUnion_disjointOfDiffUnion h1.1 h1.2) ?_
             (@disjoint_sdiff_left _ (⋃₀ J) s) (Or.inl
-              (hC.empty_nmem_disjointOfDiffUnion h1.1 h1.2))
+              (hC.empty_not_mem_disjointOfDiffUnion h1.1 h1.2))
           simp only [mem_coe, Set.le_eq_subset]
           apply sUnion_subset_iff.mp
           exact (hK3 i hi).trans (subset_sUnion_of_mem hi)
@@ -383,7 +391,7 @@ theorem disjointOfUnion_props (hC : IsSetSemiring C) (h1 : ↑J ⊆ C) :
       change ∀ t' ∈ (K a : Set (Set α)), t' ⊆ a
       rw [← sUnion_subset_iff]
       exact hK3 a ha
-    · refine ⟨hC.empty_nmem_disjointOfDiffUnion h1.1 h1.2, ?_⟩
+    · refine ⟨hC.empty_not_mem_disjointOfDiffUnion h1.1 h1.2, ?_⟩
       intros a ha
       rw [ht1' a ha]
       exact hK4 a ha
@@ -425,9 +433,12 @@ lemma subset_of_mem_disjointOfUnion (hC : IsSetSemiring C) (hJ : ↑J ⊆ C) (hj
     (hx : x ∈ (hC.disjointOfUnion hJ) j) : x ⊆ j :=
   sUnion_subset_iff.mp (hC.disjointOfUnion_subset_of_mem hJ hj) x hx
 
-lemma empty_nmem_disjointOfUnion (hC : IsSetSemiring C) (hJ : ↑J ⊆ C) (hj : j ∈ J) :
+lemma empty_not_mem_disjointOfUnion (hC : IsSetSemiring C) (hJ : ↑J ⊆ C) (hj : j ∈ J) :
     ∅ ∉ hC.disjointOfUnion hJ j :=
   (Exists.choose_spec (hC.disjointOfUnion_props hJ)).2.2.2.2.1 j hj
+
+@[deprecated (since := "2025-04-27")]
+alias empty_nmem_disjointOfUnion := empty_not_mem_disjointOfUnion
 
 lemma sUnion_disjointOfUnion (hC : IsSetSemiring C) (hJ : ↑J ⊆ C) :
     ⋃₀ ⋃ x ∈ J, (hC.disjointOfUnion hJ x : Set (Set α)) = ⋃₀ J :=

--- a/Mathlib/Order/Filter/AtTopBot/CountablyGenerated.lean
+++ b/Mathlib/Order/Filter/AtTopBot/CountablyGenerated.lean
@@ -138,7 +138,7 @@ theorem tendsto_of_subseq_tendsto {ι : Type*} {x : ι → α} {f : Filter α} {
     Tendsto x l f := by
   contrapose! hxy
   obtain ⟨s, hs, hfreq⟩ : ∃ s ∈ f, ∃ᶠ n in l, x n ∉ s := by
-    rwa [not_tendsto_iff_exists_frequently_nmem] at hxy
+    rwa [not_tendsto_iff_exists_frequently_not_mem] at hxy
   obtain ⟨y, hy_tendsto, hy_freq⟩ := exists_seq_forall_of_frequently hfreq
   refine ⟨y, hy_tendsto, fun ms hms_tendsto ↦ ?_⟩
   rcases (hms_tendsto.eventually_mem hs).exists with ⟨n, hn⟩

--- a/Mathlib/Order/Filter/Cocardinal.lean
+++ b/Mathlib/Order/Filter/Cocardinal.lean
@@ -92,7 +92,7 @@ alias eventually_cocardinal_nmem_of_card_lt := eventually_cocardinal_not_mem_of_
 
 theorem _root_.Finset.eventually_cocardinal_not_mem (s : Finset α) :
     ∀ᶠ x in cocardinal α hreg, x ∉ s :=
-  eventually_cocardinal_not_mem_of_card_lt <| lt_of_lt_of_le (finset_card_lt_aleph0 s) (hreg.aleph0_le)
+  eventually_cocardinal_not_mem_of_card_lt <| (finset_card_lt_aleph0 s).trans_le hreg.aleph0_le
 
 @[deprecated (since := "2025-04-27")]
 alias _root_.Finset.eventually_cocardinal_nmem := _root_.Finset.eventually_cocardinal_not_mem

--- a/Mathlib/Order/Filter/Cocardinal.lean
+++ b/Mathlib/Order/Filter/Cocardinal.lean
@@ -83,13 +83,19 @@ theorem _root_.Set.Finite.compl_mem_cocardinal {s : Set α} (hs : s.Finite) :
     sᶜ ∈ cocardinal α hreg :=
   compl_mem_cocardinal_of_card_lt <| lt_of_lt_of_le (Finite.lt_aleph0 hs) (hreg.aleph0_le)
 
-theorem eventually_cocardinal_nmem_of_card_lt {s : Set α} (hs : #s < c) :
+theorem eventually_cocardinal_not_mem_of_card_lt {s : Set α} (hs : #s < c) :
     ∀ᶠ x in cocardinal α hreg, x ∉ s :=
   compl_mem_cocardinal_of_card_lt hs
 
-theorem _root_.Finset.eventually_cocardinal_nmem (s : Finset α) :
+@[deprecated (since := "2025-04-27")]
+alias eventually_cocardinal_nmem_of_card_lt := eventually_cocardinal_not_mem_of_card_lt
+
+theorem _root_.Finset.eventually_cocardinal_not_mem (s : Finset α) :
     ∀ᶠ x in cocardinal α hreg, x ∉ s :=
-  eventually_cocardinal_nmem_of_card_lt <| lt_of_lt_of_le (finset_card_lt_aleph0 s) (hreg.aleph0_le)
+  eventually_cocardinal_not_mem_of_card_lt <| lt_of_lt_of_le (finset_card_lt_aleph0 s) (hreg.aleph0_le)
+
+@[deprecated (since := "2025-04-27")]
+alias _root_.Finset.eventually_cocardinal_nmem := _root_.Finset.eventually_cocardinal_not_mem
 
 theorem eventually_cocardinal_ne (x : α) : ∀ᶠ a in cocardinal α hreg, a ≠ x := by
   simpa [Set.finite_singleton x] using hreg.nat_lt 1

--- a/Mathlib/Order/Filter/Cofinite.lean
+++ b/Mathlib/Order/Filter/Cofinite.lean
@@ -78,19 +78,25 @@ alias ⟨_, _root_.Set.Infinite.cofinite_inf_principal_neBot⟩ := cofinite_inf_
 theorem _root_.Set.Finite.compl_mem_cofinite {s : Set α} (hs : s.Finite) : sᶜ ∈ @cofinite α :=
   mem_cofinite.2 <| (compl_compl s).symm ▸ hs
 
-theorem _root_.Set.Finite.eventually_cofinite_nmem {s : Set α} (hs : s.Finite) :
+theorem _root_.Set.Finite.eventually_cofinite_not_mem {s : Set α} (hs : s.Finite) :
     ∀ᶠ x in cofinite, x ∉ s :=
   hs.compl_mem_cofinite
 
-theorem _root_.Finset.eventually_cofinite_nmem (s : Finset α) : ∀ᶠ x in cofinite, x ∉ s :=
-  s.finite_toSet.eventually_cofinite_nmem
+@[deprecated (since := "2025-04-27")]
+alias _root_.Set.Finite.eventually_cofinite_nmem := _root_.Set.Finite.eventually_cofinite_not_mem
+
+theorem _root_.Finset.eventually_cofinite_not_mem (s : Finset α) : ∀ᶠ x in cofinite, x ∉ s :=
+  s.finite_toSet.eventually_cofinite_not_mem
+
+@[deprecated (since := "2025-04-27")]
+alias _root_.Finset.eventually_cofinite_nmem := _root_.Finset.eventually_cofinite_not_mem
 
 theorem _root_.Set.infinite_iff_frequently_cofinite {s : Set α} :
     Set.Infinite s ↔ ∃ᶠ x in cofinite, x ∈ s :=
   frequently_cofinite_iff_infinite.symm
 
 theorem eventually_cofinite_ne (x : α) : ∀ᶠ a in cofinite, a ≠ x :=
-  (Set.finite_singleton x).eventually_cofinite_nmem
+  (Set.finite_singleton x).eventually_cofinite_not_mem
 
 theorem le_cofinite_iff_compl_singleton_mem : l ≤ cofinite ↔ ∀ x, {x}ᶜ ∈ l := by
   refine ⟨fun h x => h (finite_singleton x).compl_mem_cofinite, fun h s (hs : sᶜ.Finite) => ?_⟩

--- a/Mathlib/Order/Filter/Tendsto.lean
+++ b/Mathlib/Order/Filter/Tendsto.lean
@@ -44,9 +44,12 @@ theorem Tendsto.eventually {f : α → β} {l₁ : Filter α} {l₂ : Filter β}
     (hf : Tendsto f l₁ l₂) (h : ∀ᶠ y in l₂, p y) : ∀ᶠ x in l₁, p (f x) :=
   hf h
 
-theorem not_tendsto_iff_exists_frequently_nmem {f : α → β} {l₁ : Filter α} {l₂ : Filter β} :
+theorem not_tendsto_iff_exists_frequently_not_mem {f : α → β} {l₁ : Filter α} {l₂ : Filter β} :
     ¬Tendsto f l₁ l₂ ↔ ∃ s ∈ l₂, ∃ᶠ x in l₁, f x ∉ s := by
   simp only [tendsto_iff_forall_eventually_mem, not_forall, exists_prop, not_eventually]
+
+@[deprecated (since := "2025-04-27")]
+alias not_tendsto_iff_exists_frequently_nmem := not_tendsto_iff_exists_frequently_not_mem
 
 theorem Tendsto.frequently {f : α → β} {l₁ : Filter α} {l₂ : Filter β} {p : β → Prop}
     (hf : Tendsto f l₁ l₂) (h : ∃ᶠ x in l₁, p (f x)) : ∃ᶠ y in l₂, p y :=

--- a/Mathlib/Order/Filter/Ultrafilter/Basic.lean
+++ b/Mathlib/Order/Filter/Ultrafilter/Basic.lean
@@ -106,13 +106,19 @@ theorem _root_.Nat.hyperfilter_le_atTop : (hyperfilter ℕ).toFilter ≤ atTop :
 theorem bot_ne_hyperfilter : (⊥ : Filter α) ≠ hyperfilter α :=
   (NeBot.ne inferInstance).symm
 
-theorem nmem_hyperfilter_of_finite {s : Set α} (hf : s.Finite) : s ∉ hyperfilter α := fun hy =>
+theorem not_mem_hyperfilter_of_finite {s : Set α} (hf : s.Finite) : s ∉ hyperfilter α := fun hy =>
   compl_not_mem hy <| hyperfilter_le_cofinite hf.compl_mem_cofinite
 
-alias _root_.Set.Finite.nmem_hyperfilter := nmem_hyperfilter_of_finite
+@[deprecated (since := "2025-04-27")]
+alias nmem_hyperfilter_of_finite := not_mem_hyperfilter_of_finite
+
+alias _root_.Set.Finite.not_mem_hyperfilter := not_mem_hyperfilter_of_finite
+
+@[deprecated (since := "2025-04-27")]
+alias _root_.Set.Finite.nmem_hyperfilter := _root_.Set.Finite.not_mem_hyperfilter
 
 theorem compl_mem_hyperfilter_of_finite {s : Set α} (hf : Set.Finite s) : sᶜ ∈ hyperfilter α :=
-  compl_mem_iff_not_mem.2 hf.nmem_hyperfilter
+  compl_mem_iff_not_mem.2 hf.not_mem_hyperfilter
 
 alias _root_.Set.Finite.compl_mem_hyperfilter := compl_mem_hyperfilter_of_finite
 

--- a/Mathlib/Probability/Distributions/Uniform.lean
+++ b/Mathlib/Probability/Distributions/Uniform.lean
@@ -121,7 +121,7 @@ theorem pdf_eq {X : Ω → E} {s : Set E} (hms : MeasurableSet s)
   by_cases hnt : μ s = ∞
   · simp [pdf_eq_zero_of_measure_eq_zero_or_top hu (Or.inr hnt), hnt]
   by_cases hns : μ s = 0
-  · filter_upwards [measure_zero_iff_ae_nmem.mp hns,
+  · filter_upwards [measure_zero_iff_ae_not_mem.mp hns,
       pdf_eq_zero_of_measure_eq_zero_or_top hu (Or.inl hns)] with x hx h'x
     simp [hx, h'x, hns]
   have : HasPDF X ℙ μ := hasPDF hns hnt hu

--- a/Mathlib/Probability/Kernel/Basic.lean
+++ b/Mathlib/Probability/Kernel/Basic.lean
@@ -401,7 +401,7 @@ lemma exists_ae_eq_isMarkovKernel {μ : Measure α}
   obtain ⟨a, ha⟩ : sᶜ.Nonempty := by
     contrapose! h'; simpa [μs, h'] using measure_univ_le_add_compl s (μ := μ)
   refine ⟨Kernel.piecewise s_meas (Kernel.const _ (κ a)) κ, ?_, ?_⟩
-  · filter_upwards [measure_zero_iff_ae_nmem.1 μs] with b hb
+  · filter_upwards [measure_zero_iff_ae_not_mem.1 μs] with b hb
     simp [hb, piecewise]
   · refine ⟨fun b ↦ ?_⟩
     by_cases hb : b ∈ s

--- a/Mathlib/Probability/Kernel/Composition/MeasureCompProd.lean
+++ b/Mathlib/Probability/Kernel/Composition/MeasureCompProd.lean
@@ -286,7 +286,7 @@ lemma AbsolutelyContinuous.compProd_of_compProd [SFinite ν] [IsSFiniteKernel η
   swap; · rw [compProd_of_not_sfinite _ _ hμ]; simp
   refine AbsolutelyContinuous.mk fun s hs hs_zero ↦ ?_
   suffices (μ ⊗ₘ η) s = 0 from hκη this
-  rw [measure_zero_iff_ae_nmem, ae_compProd_iff hs.compl] at hs_zero ⊢
+  rw [measure_zero_iff_ae_not_mem, ae_compProd_iff hs.compl] at hs_zero ⊢
   exact hμν.ae_le hs_zero
 
 end AbsolutelyContinuous

--- a/Mathlib/RingTheory/AdicCompletion/LocalRing.lean
+++ b/Mathlib/RingTheory/AdicCompletion/LocalRing.lean
@@ -19,7 +19,7 @@ variable {R : Type*} [CommRing R] (m : Ideal R) [hmax : m.IsMaximal]
 
 open Ideal Quotient
 
-lemma isUnit_iff_nmem_of_isAdicComplete_maximal [IsAdicComplete m R] (r : R) :
+lemma isUnit_iff_not_mem_of_isAdicComplete_maximal [IsAdicComplete m R] (r : R) :
     IsUnit r ↔ r ∉ m := by
   refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
   · by_contra mem
@@ -69,11 +69,14 @@ lemma isUnit_iff_nmem_of_isAdicComplete_maximal [IsAdicComplete m R] (r : R) :
     use inv
     exact sub_eq_zero.mp <| IsHausdorff.haus IsAdicComplete.toIsHausdorff (inv * r - 1) eq
 
+@[deprecated (since := "2025-04-27")]
+alias isUnit_iff_nmem_of_isAdicComplete_maximal := isUnit_iff_not_mem_of_isAdicComplete_maximal
+
 theorem isLocalRing_of_isAdicComplete_maximal [IsAdicComplete m R] : IsLocalRing R where
   exists_pair_ne := ⟨0, 1, ne_of_mem_of_not_mem m.zero_mem
     (m.ne_top_iff_one.mp (Ideal.IsMaximal.ne_top hmax))⟩
   isUnit_or_isUnit_of_add_one {a b} hab := by
-    simp only [isUnit_iff_nmem_of_isAdicComplete_maximal m]
+    simp only [isUnit_iff_not_mem_of_isAdicComplete_maximal m]
     by_contra! h
     absurd m.add_mem h.1 h.2
     simpa [hab] using m.ne_top_iff_one.mp (Ideal.IsMaximal.ne_top hmax)

--- a/Mathlib/RingTheory/Ideal/Maximal.lean
+++ b/Mathlib/RingTheory/Ideal/Maximal.lean
@@ -197,8 +197,8 @@ theorem exists_le_prime_disjoint (S : Submonoid α) (disjoint : Disjoint (I : Se
   have ⟨p, hp⟩ := (Submodule.mem_iSup_of_directed _ hc'.directed).mp (sSup_eq_iSup' c ▸ hx)
   exact Set.disjoint_left.mp (hc p.2) hp
 
-theorem exists_le_prime_not_mem_of_isIdempotentElem (a : α) (ha : IsIdempotentElem a) (haI : a ∉ I) :
-    ∃ p : Ideal α, p.IsPrime ∧ I ≤ p ∧ a ∉ p :=
+theorem exists_le_prime_not_mem_of_isIdempotentElem (a : α) (ha : IsIdempotentElem a)
+    (haI : a ∉ I) : ∃ p : Ideal α, p.IsPrime ∧ I ≤ p ∧ a ∉ p :=
   have : Disjoint (I : Set α) (Submonoid.powers a) := Set.disjoint_right.mpr <| by
     rw [ha.coe_powers]
     rintro _ (rfl|rfl)

--- a/Mathlib/RingTheory/Ideal/Maximal.lean
+++ b/Mathlib/RingTheory/Ideal/Maximal.lean
@@ -197,7 +197,7 @@ theorem exists_le_prime_disjoint (S : Submonoid α) (disjoint : Disjoint (I : Se
   have ⟨p, hp⟩ := (Submodule.mem_iSup_of_directed _ hc'.directed).mp (sSup_eq_iSup' c ▸ hx)
   exact Set.disjoint_left.mp (hc p.2) hp
 
-theorem exists_le_prime_nmem_of_isIdempotentElem (a : α) (ha : IsIdempotentElem a) (haI : a ∉ I) :
+theorem exists_le_prime_not_mem_of_isIdempotentElem (a : α) (ha : IsIdempotentElem a) (haI : a ∉ I) :
     ∃ p : Ideal α, p.IsPrime ∧ I ≤ p ∧ a ∉ p :=
   have : Disjoint (I : Set α) (Submonoid.powers a) := Set.disjoint_right.mpr <| by
     rw [ha.coe_powers]
@@ -205,6 +205,9 @@ theorem exists_le_prime_nmem_of_isIdempotentElem (a : α) (ha : IsIdempotentElem
     exacts [I.ne_top_iff_one.mp (ne_of_mem_of_not_mem' Submodule.mem_top haI).symm, haI]
   have ⟨p, h1, h2, h3⟩ := exists_le_prime_disjoint _ _ this
   ⟨p, h1, h2, Set.disjoint_right.mp h3 (Submonoid.mem_powers a)⟩
+
+@[deprecated (since := "2025-04-27")]
+alias exists_le_prime_nmem_of_isIdempotentElem := exists_le_prime_not_mem_of_isIdempotentElem
 
 end Ideal
 

--- a/Mathlib/RingTheory/LaurentSeries.lean
+++ b/Mathlib/RingTheory/LaurentSeries.lean
@@ -770,7 +770,7 @@ lemma Cauchy.exists_lb_eventual_support {ℱ : Filter K⸨X⸩} (hℱ : Cauchy �
       exact (valuation_le_iff_coeff_lt_eq_zero K).mp hg
     · refine ⟨min (f.2.isWF.min (HahnSeries.support_nonempty_iff.mpr hf)) 0 - 1, fun _ hg n hn ↦ ?_⟩
       rw [eq_coeff_of_valuation_sub_lt K hg (d := 0)]
-      · exact Function.nmem_support.mp fun h ↦
+      · exact Function.not_mem_support.mp fun h ↦
         f.2.isWF.not_lt_min (HahnSeries.support_nonempty_iff.mpr hf) h
         <| lt_trans hn <| Int.sub_one_lt_iff.mpr <| min_le_left _ _
       exact lt_of_lt_of_le hn <| le_of_lt (Int.sub_one_lt_of_le <| min_le_right _ _)

--- a/Mathlib/RingTheory/MvPolynomial/Symmetric/NewtonIdentities.lean
+++ b/Mathlib/RingTheory/MvPolynomial/Symmetric/NewtonIdentities.lean
@@ -69,9 +69,11 @@ private lemma pairMap_of_snd_mem_fst {t : Finset σ × σ} (h : t.snd ∈ t.fst)
     pairMap σ t = (t.fst.erase t.snd, t.snd) := by
   simp [pairMap, h]
 
-private lemma pairMap_of_snd_nmem_fst {t : Finset σ × σ} (h : t.snd ∉ t.fst) :
+private lemma pairMap_of_snd_not_mem_fst {t : Finset σ × σ} (h : t.snd ∉ t.fst) :
     pairMap σ t = (t.fst.cons t.snd h, t.snd) := by
   simp [pairMap, h]
+
+@[deprecated (since := "2025-04-27")] alias pairMap_of_snd_nmem_fst := pairMap_of_snd_not_mem_fst
 
 @[simp]
 private theorem pairMap_involutive : (pairMap σ).Involutive := by
@@ -108,7 +110,7 @@ private theorem pairMap_mem_pairs {k : ℕ} (t : Finset σ × σ) (h : t ∈ pai
     simp only [not_true_eq_false, and_true, not_forall, not_false_eq_true, exists_prop] at h2
     rw [← h2] at h
     exact not_le_of_lt (sub_lt (card_pos.mpr ⟨t.snd, h1⟩) zero_lt_one) h
-  · rw [pairMap_of_snd_nmem_fst σ h1]
+  · rw [pairMap_of_snd_not_mem_fst σ h1]
     simp only [h1] at h
     simp only [card_cons, mem_cons, true_or, implies_true, and_true]
     exact (le_iff_eq_or_lt.mp h.left).resolve_left h.right
@@ -129,7 +131,7 @@ private theorem weight_add_weight_pairMap {k : ℕ} (t : Finset σ × σ) (h : t
     rw [← tsub_tsub_assoc h.left h3, ← neg_neg ((-1 : MvPolynomial σ R) ^ (#t.1 - 1)),
       h2 (#t.1 - 1), Nat.sub_add_cancel h3]
     simp
-  · rw [pairMap_of_snd_nmem_fst σ h1]
+  · rw [pairMap_of_snd_not_mem_fst σ h1]
     simp only [mul_comm, mul_assoc (∏ a ∈ t.fst, X a), card_cons, prod_cons]
     nth_rewrite 2 [← pow_one (X t.snd)]
     simp only [← pow_add, ← Nat.add_sub_assoc (Nat.lt_of_le_of_ne h.left (mt h.right h1)), add_comm,

--- a/Mathlib/RingTheory/MvPowerSeries/NoZeroDivisors.lean
+++ b/Mathlib/RingTheory/MvPowerSeries/NoZeroDivisors.lean
@@ -23,7 +23,7 @@ If `R` has `NoZeroDivisors`, then so does `MvPowerSeries σ R`.
 
 ## Remark
 
-The analogue of `Polynomial.nmem_nonZeroDivisors_iff`
+The analogue of `Polynomial.not_mem_nonZeroDivisors_iff`
 (McCoy theorem) holds for power series over a noetherian ring,
 but not in general. See [Fields1971]
 -/

--- a/Mathlib/RingTheory/Spectrum/Maximal/Localization.lean
+++ b/Mathlib/RingTheory/Spectrum/Maximal/Localization.lean
@@ -120,7 +120,7 @@ variable {ι} (R : ι → Type*) [∀ i, CommSemiring (R i)] [∀ i, Nontrivial 
 theorem toPiLocalization_not_surjective_of_infinite [Infinite ι] :
     ¬ Function.Surjective (toPiLocalization (Π i, R i)) := fun surj ↦ by
   classical
-  have ⟨J, max, nmem⟩ := PrimeSpectrum.exists_maximal_nmem_range_sigmaToPi_of_infinite R
+  have ⟨J, max, nmem⟩ := PrimeSpectrum.exists_maximal_not_mem_range_sigmaToPi_of_infinite R
   obtain ⟨r, hr⟩ := surj (Function.update 0 ⟨J, max⟩ 1)
   have : r = 0 := funext fun i ↦ toPiLocalization_injective _ <| funext fun I ↦ by
     replace hr := congr_fun hr ⟨_, I.2.comap_piEvalRingHom⟩

--- a/Mathlib/RingTheory/Spectrum/Prime/RingHom.lean
+++ b/Mathlib/RingTheory/Spectrum/Prime/RingHom.lean
@@ -111,7 +111,7 @@ variable [Infinite ι] [∀ i, Nontrivial (R i)]
 range of `sigmaToPi`, i.e. is not of the form `πᵢ⁻¹(𝔭)` for some prime `𝔭 ⊂ R i`, where
 `πᵢ : (Π i, R i) →+* R i` is the projection. For a complete description of all prime ideals,
 see https://math.stackexchange.com/a/1563190. -/
-theorem exists_maximal_nmem_range_sigmaToPi_of_infinite :
+theorem exists_maximal_not_mem_range_sigmaToPi_of_infinite :
     ∃ (I : Ideal (Π i, R i)) (_ : I.IsMaximal), ⟨I, inferInstance⟩ ∉ Set.range (sigmaToPi R) := by
   classical
   let J : Ideal (Π i, R i) := -- `J := Π₀ i, R i` is an ideal in `Π i, R i`
@@ -134,8 +134,12 @@ theorem exists_maximal_nmem_range_sigmaToPi_of_infinite :
   rw [eq] at this
   exact this (le ⟨.single i 1, rfl⟩)
 
+@[deprecated (since := "2025-04-27")]
+alias exists_maximal_nmem_range_sigmaToPi_of_infinite :=
+  exists_maximal_not_mem_range_sigmaToPi_of_infinite
+
 theorem sigmaToPi_not_surjective_of_infinite : ¬ (sigmaToPi R).Surjective := fun surj ↦
-  have ⟨_, _, nmem⟩ := exists_maximal_nmem_range_sigmaToPi_of_infinite R
+  have ⟨_, _, nmem⟩ := exists_maximal_not_mem_range_sigmaToPi_of_infinite R
   (Set.range_eq_univ.mpr surj ▸ nmem) ⟨⟩
 
 lemma exists_comap_evalRingHom_eq

--- a/Mathlib/RingTheory/Spectrum/Prime/Topology.lean
+++ b/Mathlib/RingTheory/Spectrum/Prime/Topology.lean
@@ -968,7 +968,7 @@ lemma basicOpen_injOn_isIdempotentElem :
   have : x ∉ Ideal.span {y} := fun mem ↦ ne' <| by
     obtain ⟨r, rfl⟩ := Ideal.mem_span_singleton'.mp mem
     rw [mul_assoc, hy]
-  have ⟨p, prime, le, nmem⟩ := Ideal.exists_le_prime_nmem_of_isIdempotentElem _ x hx this
+  have ⟨p, prime, le, nmem⟩ := Ideal.exists_le_prime_not_mem_of_isIdempotentElem _ x hx this
   exact ne_of_mem_of_not_mem' (a := ⟨p, prime⟩) nmem
     (not_not.mpr <| p.span_singleton_le_iff_mem.mp le) eq
 

--- a/Mathlib/Topology/Algebra/InfiniteSum/Group.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/Group.lean
@@ -385,7 +385,7 @@ theorem Multipliable.tendsto_cofinite_one (hf : Multipliable f) : Tendsto f cofi
   intro e he
   rw [Filter.mem_map]
   rcases hf.vanishing he with ⟨s, hs⟩
-  refine s.eventually_cofinite_nmem.mono fun x hx ↦ ?_
+  refine s.eventually_cofinite_not_mem.mono fun x hx ↦ ?_
   · simpa using hs {x} (disjoint_singleton_left.2 hx)
 
 @[to_additive]

--- a/Mathlib/Topology/Algebra/Module/Cardinality.lean
+++ b/Mathlib/Topology/Algebra/Module/Cardinality.lean
@@ -135,6 +135,6 @@ theorem Set.Countable.dense_compl
   calc
     (ℵ₀ : Cardinal.{u}) < 𝔠 := aleph0_lt_continuum
     _ ≤ #(interior s) :=
-      continuum_le_cardinal_of_isOpen 𝕜 isOpen_interior (nmem_singleton_empty.1 H)
+      continuum_le_cardinal_of_isOpen 𝕜 isOpen_interior (not_mem_singleton_empty.1 H)
     _ ≤ #s := mk_le_mk_of_subset interior_subset
     _ ≤ ℵ₀ := le_aleph0 hs

--- a/Mathlib/Topology/Algebra/Support.lean
+++ b/Mathlib/Topology/Algebra/Support.lean
@@ -57,8 +57,11 @@ theorem mulTSupport_eq_empty_iff {f : X → α} : mulTSupport f = ∅ ↔ f = 1 
   rw [mulTSupport, closure_empty_iff, mulSupport_eq_empty_iff]
 
 @[to_additive]
-theorem image_eq_one_of_nmem_mulTSupport {f : X → α} {x : X} (hx : x ∉ mulTSupport f) : f x = 1 :=
+theorem image_eq_one_of_not_mem_mulTSupport {f : X → α} {x : X} (hx : x ∉ mulTSupport f) : f x = 1 :=
   mulSupport_subset_iff'.mp (subset_mulTSupport f) x hx
+
+@[deprecated (since := "2025-04-27")]
+alias image_eq_one_of_nmem_mulTSupport := image_eq_one_of_not_mem_mulTSupport
 
 @[to_additive]
 theorem range_subset_insert_image_mulTSupport (f : X → α) :
@@ -143,7 +146,7 @@ theorem hasCompactMulSupport_def : HasCompactMulSupport f ↔ IsCompact (closure
 @[to_additive]
 theorem exists_compact_iff_hasCompactMulSupport [R1Space α] :
     (∃ K : Set α, IsCompact K ∧ ∀ x, x ∉ K → f x = 1) ↔ HasCompactMulSupport f := by
-  simp_rw [← nmem_mulSupport, ← mem_compl_iff, ← subset_def, compl_subset_compl,
+  simp_rw [← not_mem_mulSupport, ← mem_compl_iff, ← subset_def, compl_subset_compl,
     hasCompactMulSupport_def, exists_isCompact_superset_iff]
 
 namespace HasCompactMulSupport
@@ -275,7 +278,7 @@ theorem is_one_at_infty {f : α → γ} [TopologicalSpace γ]
   refine ⟨mulTSupport f, h.isCompact, ?_⟩
   rw [compl_subset_comm]
   intro v hv
-  rw [mem_preimage, image_eq_one_of_nmem_mulTSupport hv]
+  rw [mem_preimage, image_eq_one_of_not_mem_mulTSupport hv]
   exact mem_of_mem_nhds hN
 
 end HasCompactMulSupport

--- a/Mathlib/Topology/Algebra/Support.lean
+++ b/Mathlib/Topology/Algebra/Support.lean
@@ -57,10 +57,14 @@ theorem mulTSupport_eq_empty_iff {f : X → α} : mulTSupport f = ∅ ↔ f = 1 
   rw [mulTSupport, closure_empty_iff, mulSupport_eq_empty_iff]
 
 @[to_additive]
-theorem image_eq_one_of_not_mem_mulTSupport {f : X → α} {x : X} (hx : x ∉ mulTSupport f) : f x = 1 :=
+theorem image_eq_one_of_not_mem_mulTSupport {f : X → α} {x : X} (hx : x ∉ mulTSupport f) :
+    f x = 1 :=
   mulSupport_subset_iff'.mp (subset_mulTSupport f) x hx
 
 @[deprecated (since := "2025-04-27")]
+alias image_eq_zero_of_nmem_tsupport := image_eq_zero_of_not_mem_tsupport
+
+@[to_additive existing, deprecated (since := "2025-04-27")]
 alias image_eq_one_of_nmem_mulTSupport := image_eq_one_of_not_mem_mulTSupport
 
 @[to_additive]

--- a/Mathlib/Topology/Bases.lean
+++ b/Mathlib/Topology/Bases.lean
@@ -727,8 +727,11 @@ theorem countable_countableBasis [SecondCountableTopology α] : (countableBasis 
 instance encodableCountableBasis [SecondCountableTopology α] : Encodable (countableBasis α) :=
   (countable_countableBasis α).toEncodable
 
-theorem empty_nmem_countableBasis [SecondCountableTopology α] : ∅ ∉ countableBasis α :=
+theorem empty_not_mem_countableBasis [SecondCountableTopology α] : ∅ ∉ countableBasis α :=
   (exists_countable_basis α).choose_spec.2.1
+
+@[deprecated (since := "2025-04-27")]
+alias empty_nmem_countableBasis := empty_not_mem_countableBasis
 
 theorem isBasis_countableBasis [SecondCountableTopology α] :
     IsTopologicalBasis (countableBasis α) :=
@@ -746,7 +749,7 @@ theorem isOpen_of_mem_countableBasis [SecondCountableTopology α] {s : Set α}
 
 theorem nonempty_of_mem_countableBasis [SecondCountableTopology α] {s : Set α}
     (hs : s ∈ countableBasis α) : s.Nonempty :=
-  nonempty_iff_ne_empty.2 <| ne_of_mem_of_not_mem hs <| empty_nmem_countableBasis α
+  nonempty_iff_ne_empty.2 <| ne_of_mem_of_not_mem hs <| empty_not_mem_countableBasis α
 
 variable (α)
 

--- a/Mathlib/Topology/ContinuousMap/BoundedCompactlySupported.lean
+++ b/Mathlib/Topology/ContinuousMap/BoundedCompactlySupported.lean
@@ -39,7 +39,7 @@ lemma exist_norm_eq [c : Nonempty α] {f : α →ᵇ γ} (h : f ∈ C_cb(α, γ)
     refine ⟨x, le_antisymm (norm_coe_le_norm f x) (norm_le (norm_nonneg _) |>.mpr fun y ↦ ?_)⟩
     by_cases hy : y ∈ tsupport f
     · exact hmax hy
-    · simp [image_eq_zero_of_nmem_tsupport hy]
+    · simp [image_eq_zero_of_not_mem_tsupport hy]
   · suffices f = 0 by simp [this]
     rwa [not_nonempty_iff_eq_empty, tsupport_eq_empty_iff, ← coe_zero, ← DFunLike.ext'_iff] at hs
 
@@ -86,7 +86,7 @@ def ofCompactSupport (g : α → γ) (hg₁ : Continuous g) (hg₂ : HasCompactS
       refine ⟨2 * ‖g z‖, dist_le_two_norm' fun x ↦ ?_⟩
       by_cases hx : x ∈ tsupport g
       · exact isMaxOn_iff.mp hmax x hx
-      · simp [image_eq_zero_of_nmem_tsupport hx]
+      · simp [image_eq_zero_of_not_mem_tsupport hx]
 
 lemma ofCompactSupport_mem (g : α → γ) (hg₁ : Continuous g) (hg₂ : HasCompactSupport g) :
     ofCompactSupport g hg₁ hg₂ ∈ C_cb(α, γ) := mem_compactlySupported.mpr hg₂

--- a/Mathlib/Topology/Order/Basic.lean
+++ b/Mathlib/Topology/Order/Basic.lean
@@ -655,7 +655,7 @@ instance instIsCountablyGenerated_atTop [OrderTopology α] [SecondCountableTopol
         apply b_ne
         convert s.2
         exact H.symm
-      exact Iff.mp nmem_singleton_empty this
+      exact Iff.mp not_mem_singleton_empty this
     choose a ha using A
     have : (atTop : Filter α) = (generate (Ici '' (range a))) := by
       apply atTop_eq_generate_of_not_bddAbove

--- a/Mathlib/Topology/UrysohnsLemma.lean
+++ b/Mathlib/Topology/UrysohnsLemma.lean
@@ -162,7 +162,7 @@ theorem approx_of_mem_C (c : CU P) (n : ℕ) {x : X} (hx : x ∈ c.C) : c.approx
     rw [ihn, ihn, midpoint_self]
     exacts [c.subset_right_C hx, hx]
 
-theorem approx_of_nmem_U (c : CU P) (n : ℕ) {x : X} (hx : x ∉ c.U) : c.approx n x = 1 := by
+theorem approx_of_not_mem_U (c : CU P) (n : ℕ) {x : X} (hx : x ∉ c.U) : c.approx n x = 1 := by
   induction n generalizing c with
   | zero =>
     rw [← mem_compl_iff] at hx
@@ -171,6 +171,8 @@ theorem approx_of_nmem_U (c : CU P) (n : ℕ) {x : X} (hx : x ∉ c.U) : c.appro
     simp only [approx]
     rw [ihn, ihn, midpoint_self]
     exacts [hx, fun hU => hx <| c.left_U_subset hU]
+
+@[deprecated (since := "2025-04-27")] alias approx_of_nmem_U := approx_of_not_mem_U
 
 theorem approx_nonneg (c : CU P) (n : ℕ) (x : X) : 0 ≤ c.approx n x := by
   induction n generalizing c with
@@ -199,7 +201,7 @@ theorem approx_le_approx_of_U_sub_C {c₁ c₂ : CU P} (h : c₁.U ⊆ c₂.C) (
       _ ≤ approx n₁ c₁ x := approx_nonneg _ _ _
   · calc
       approx n₂ c₂ x ≤ 1 := approx_le_one _ _ _
-      _ = approx n₁ c₁ x := (approx_of_nmem_U _ _ hx).symm
+      _ = approx n₁ c₁ x := (approx_of_not_mem_U _ _ hx).symm
 
 theorem approx_mem_Icc_right_left (c : CU P) (n : ℕ) (x : X) :
     c.approx n x ∈ Icc (c.right.approx n x) (c.left.approx n x) := by
@@ -243,8 +245,10 @@ theorem lim_of_mem_C (c : CU P) (x : X) (h : x ∈ c.C) : c.lim x = 0 := by
 theorem disjoint_C_support_lim (c : CU P) : Disjoint c.C (Function.support c.lim) :=
   Function.disjoint_support_iff.mpr (fun x hx => lim_of_mem_C c x hx)
 
-theorem lim_of_nmem_U (c : CU P) (x : X) (h : x ∉ c.U) : c.lim x = 1 := by
-  simp only [CU.lim, approx_of_nmem_U c _ h, ciSup_const]
+theorem lim_of_not_mem_U (c : CU P) (x : X) (h : x ∉ c.U) : c.lim x = 1 := by
+  simp only [CU.lim, approx_of_not_mem_U c _ h, ciSup_const]
+
+@[deprecated (since := "2025-04-27")] alias lim_of_nmem_U := lim_of_not_mem_U
 
 theorem lim_eq_midpoint (c : CU P) (x : X) :
     c.lim x = midpoint ℝ (c.left.lim x) (c.right.lim x) := by
@@ -294,7 +298,7 @@ theorem continuous_lim (c : CU P) : Continuous c.lim := by
       replace hyl : y ∉ c.left.left.U :=
         compl_subset_compl.2 c.left.left_U_subset_right_C hyl
       simp only [pow_succ, c.lim_eq_midpoint, c.left.lim_eq_midpoint,
-        c.left.left.lim_of_nmem_U _ hxl, c.left.left.lim_of_nmem_U _ hyl]
+        c.left.left.lim_of_not_mem_U _ hxl, c.left.left.lim_of_not_mem_U _ hyl]
       refine (dist_midpoint_midpoint_le _ _ _ _).trans ?_
       refine (div_le_div_of_nonneg_right (add_le_add_right (dist_midpoint_midpoint_le _ _ _ _) _)
         zero_le_two).trans ?_
@@ -330,7 +334,7 @@ theorem exists_continuous_zero_one_of_isClosed [NormalSpace X]
       rintro c u c_closed - u_open cu
       rcases normal_exists_closure_subset c_closed u_open cu with ⟨v, v_open, cv, hv⟩
       exact ⟨v, v_open, cv, hv, trivial, trivial⟩ }
-  exact ⟨⟨c.lim, c.continuous_lim⟩, c.lim_of_mem_C, fun x hx => c.lim_of_nmem_U _ fun h => h hx,
+  exact ⟨⟨c.lim, c.continuous_lim⟩, c.lim_of_mem_C, fun x hx => c.lim_of_not_mem_U _ fun h => h hx,
     c.lim_mem_Icc⟩
 
 /-- Urysohn's lemma: if `s` and `t` are two disjoint sets in a regular locally compact topological
@@ -362,7 +366,7 @@ theorem exists_continuous_zero_one_of_isCompact [RegularSpace X] [LocallyCompact
       refine ⟨interior k, isOpen_interior, ck, A.trans ku, c_comp,
         k_comp.of_isClosed_subset isClosed_closure A⟩ }
   exact ⟨⟨c.lim, c.continuous_lim⟩, fun x hx ↦ c.lim_of_mem_C _ (sk.trans interior_subset hx),
-    fun x hx => c.lim_of_nmem_U _ fun h => h hx, c.lim_mem_Icc⟩
+    fun x hx => c.lim_of_not_mem_U _ fun h => h hx, c.lim_mem_Icc⟩
 
 /-- Urysohn's lemma: if `s` and `t` are two disjoint sets in a regular locally compact topological
 space `X`, with `s` compact and `t` closed, then there exists a continuous
@@ -515,7 +519,7 @@ lemma exists_tsupport_one_of_isOpen_isClosed [T2Space X] {s t : Set X}
     exact Disjoint.subset_compl_right (disjoint_of_subset_right subset_closure
       (Disjoint.symm (Urysohns.CU.disjoint_C_support_lim c)))
   · intro x hx
-    apply Urysohns.CU.lim_of_nmem_U
+    apply Urysohns.CU.lim_of_not_mem_U
     exact not_mem_compl_iff.mpr hx
 
 theorem exists_continuous_nonneg_pos [RegularSpace X] [LocallyCompactSpace X] (x : X) :


### PR DESCRIPTION
---
There are some missing/buggy deprecations, I'm going to fix them later today or tomorrow.
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
