### PR TITLE
[Merged by Bors] - chore(RingTheory): add Stacks project tags attribute to `RingHom.Finite`, `RingHom.Finite.to_isIntegral`, `RingHom.IsIntegral`

### DIFF
--- a/Mathlib/RingTheory/Finiteness/Defs.lean
+++ b/Mathlib/RingTheory/Finiteness/Defs.lean
@@ -149,7 +149,7 @@ namespace RingHom
 variable {A B C : Type*} [CommRing A] [CommRing B] [CommRing C]
 
 /-- A ring morphism `A →+* B` is `RingHom.Finite` if `B` is finitely generated as `A`-module. -/
-@[algebraize Module.Finite]
+@[algebraize Module.Finite, stacks 0563]
 def Finite (f : A →+* B) : Prop :=
   letI : Algebra A B := f.toAlgebra
   Module.Finite A B

--- a/Mathlib/RingTheory/IntegralClosure/Algebra/Basic.lean
+++ b/Mathlib/RingTheory/IntegralClosure/Algebra/Basic.lean
@@ -122,6 +122,7 @@ theorem isIntegral_of_smul_mem_submodule {M : Type*} [AddCommGroup M] [Module R 
 
 variable {f}
 
+@[stacks 00GK]
 theorem RingHom.Finite.to_isIntegral (h : f.Finite) : f.IsIntegral :=
   letI := f.toAlgebra
   fun _ ↦ IsIntegral.of_mem_of_fg ⊤ h.1 _ trivial

--- a/Mathlib/RingTheory/IntegralClosure/IsIntegral/Defs.lean
+++ b/Mathlib/RingTheory/IntegralClosure/IsIntegral/Defs.lean
@@ -37,7 +37,7 @@ def RingHom.IsIntegralElem (f : R →+* A) (x : A) :=
 
 /-- A ring homomorphism `f : R →+* A` is said to be integral
 if every element `A` is integral with respect to the map `f` -/
-@[algebraize Algebra.IsIntegral.mk, stacks 00GI]
+@[algebraize Algebra.IsIntegral.mk, stacks 00GI "(2)"]
 def RingHom.IsIntegral (f : R →+* A) :=
   ∀ x : A, f.IsIntegralElem x
 

--- a/Mathlib/RingTheory/IntegralClosure/IsIntegral/Defs.lean
+++ b/Mathlib/RingTheory/IntegralClosure/IsIntegral/Defs.lean
@@ -37,7 +37,7 @@ def RingHom.IsIntegralElem (f : R →+* A) (x : A) :=
 
 /-- A ring homomorphism `f : R →+* A` is said to be integral
 if every element `A` is integral with respect to the map `f` -/
-@[algebraize Algebra.IsIntegral.mk]
+@[algebraize Algebra.IsIntegral.mk, stacks 00GI]
 def RingHom.IsIntegral (f : R →+* A) :=
   ∀ x : A, f.IsIntegralElem x
 


### PR DESCRIPTION
`RingHom.Finite`, covered in the Stacks Project tag [0563](https://stacks.math.columbia.edu/tag/0563).
 `RingHom.Finite.to_isIntegral`, covered in the Stacks Project tag [00GK](https://stacks.math.columbia.edu/tag/00GK).
`RingHom.IsIntegral`, covered in the Stacks Project tag [00GI](https://stacks.math.columbia.edu/tag/00GI).

Part of the [ICERM Workshop on Autoformalization](https://icerm.brown.edu/program/hot_topics_workshop/htw-25-aftwm).

Co-authored-by: Baran Zadeoglu bz333@cornell.edu
Co-authored-by: Lenny Taelman l.d.j.taelman@uva.nl
Co-authored-by: Jarod Alper jarod.alper@gmail.com
Co-authored-by: Jason Starr jstarr@math.sunysb.edu
co-authored-by:  Matthew R. Ballard mrb@mattrobball.com


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
