### PR TITLE
[Merged by Bors] - chore(Algebra): remove @[simp] from Prod.mk_one_one/mk_zero_zero

### DIFF
--- a/Mathlib/Algebra/Notation/Prod.lean
+++ b/Mathlib/Algebra/Notation/Prod.lean
@@ -40,7 +40,7 @@ theorem snd_one : (1 : M × N).2 = 1 :=
 theorem one_eq_mk : (1 : M × N) = (1, 1) :=
   rfl
 
-@[to_additive (attr := simp)]
+@[to_additive]
 theorem mk_one_one : ((1 : M), (1 : N)) = 1 := rfl
 
 @[to_additive (attr := simp)]

--- a/Mathlib/Algebra/Polynomial/CoeffMem.lean
+++ b/Mathlib/Algebra/Polynomial/CoeffMem.lean
@@ -40,7 +40,7 @@ lemma coeff_divModByMonicAux_mem_span_pow_mul_span : ∀ (p q : S[X]) (hq : q.Mo
     generalize hr : (p - q * (C p.leadingCoeff * X ^ (deg(p) - deg(q)))) = r
     by_cases hr' : r = 0
     · simp only [mul_ite, mul_one, mul_zero, hr', divModByMonicAux, degree_zero, le_bot_iff,
-        degree_eq_bot, ne_eq, not_true_eq_false, and_false, ↓reduceDIte, Prod.mk_zero_zero,
+        degree_eq_bot, ne_eq, not_true_eq_false, and_false, ↓reduceDIte,
         Prod.fst_zero, coeff_zero, add_zero, Prod.snd_zero, Submodule.zero_mem, and_true]
       split_ifs
       exacts [H₀ _, zero_mem _]

--- a/Mathlib/Algebra/Polynomial/Div.lean
+++ b/Mathlib/Algebra/Polynomial/Div.lean
@@ -171,7 +171,7 @@ theorem zero_modByMonic (p : R[X]) : 0 %ₘ p = 0 := by
   unfold modByMonic divModByMonicAux
   dsimp
   by_cases hp : Monic p
-  · rw [dif_pos hp, if_neg (mt And.right (not_not_intro rfl)), Prod.snd_zero]
+  · rw [dif_pos hp, if_neg (mt And.right (not_not_intro rfl))]
   · rw [dif_neg hp]
 
 @[simp]
@@ -180,7 +180,7 @@ theorem zero_divByMonic (p : R[X]) : 0 /ₘ p = 0 := by
   unfold divByMonic divModByMonicAux
   dsimp
   by_cases hp : Monic p
-  · rw [dif_pos hp, if_neg (mt And.right (not_not_intro rfl)), Prod.fst_zero]
+  · rw [dif_pos hp, if_neg (mt And.right (not_not_intro rfl))]
   · rw [dif_neg hp]
 
 @[simp]

--- a/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Pi.lean
+++ b/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Pi.lean
@@ -80,7 +80,7 @@ lemma cfcₙ_map_prod (f : R → R) (a : A) (b : B)
       let φ := NonUnitalStarAlgHom.snd S A B
       exact φ.map_cfcₙ f (a, b) (by rwa [Prod.quasispectrum_eq]) hf₀ continuous_snd hab hb
   case neg =>
-    simp [cfcₙ_apply_of_not_map_zero _ hf₀]
+    simpa [cfcₙ_apply_of_not_map_zero _ hf₀] using Prod.mk_zero_zero.symm
 
 end nonunital_prod
 

--- a/Mathlib/Topology/Algebra/IsOpenUnits.lean
+++ b/Mathlib/Topology/Algebra/IsOpenUnits.lean
@@ -63,8 +63,7 @@ lemma IsOpenUnits.of_isAdic {R : Type*} [CommRing R] [TopologicalSpace R] [IsTop
   refine ⟨.of_continuous_injective_isOpenMap Units.continuous_val Units.ext ?_⟩
   refine (TopologicalGroup.isOpenMap_iff_nhds_one (f := Units.coeHom R)).mpr ?_
   rw [nhds_induced, nhds_prod_eq]
-  simp only [Units.embedProduct_apply, Units.val_one, inv_one, MulOpposite.op_one,
-    Prod.mk_one_one, Prod.fst_one, Prod.snd_one]
+  simp only [Units.embedProduct_apply, Units.val_one, inv_one, MulOpposite.op_one]
   intro s hs
   have H := hR ▸ Ideal.hasBasis_nhds_adic I 1
   have := (H.prod (H.comap MulOpposite.opHomeomorph.symm))

--- a/Mathlib/Topology/Algebra/IsUniformGroup/Defs.lean
+++ b/Mathlib/Topology/Algebra/IsUniformGroup/Defs.lean
@@ -457,7 +457,7 @@ theorem isUniformGroup_of_commGroup : IsUniformGroup G := by
   constructor
   simp only [UniformContinuous, uniformity_prod_eq_prod, uniformity_eq_comap_nhds_one',
     tendsto_comap_iff, tendsto_map'_iff, prod_comap_comap_eq, Function.comp_def,
-    div_div_div_comm _ (Prod.snd (Prod.snd _)), ← nhds_prod_eq, Prod.mk_one_one]
+    div_div_div_comm _ (Prod.snd (Prod.snd _)), ← nhds_prod_eq]
   exact (continuous_div'.tendsto' 1 1 (div_one 1)).comp tendsto_comap
 
 @[deprecated (since := "2025-02-28")]


### PR DESCRIPTION
From discussion in https://leanprover.zulipchat.com/#narrow/channel/113489-new-members/topic/simp.20doesn't.20work.20until.20I.20remove.20certain.20theorem/near/514566036

Reasons to remove these from simp lemmas:
 - Confluence problem. For example `example : ¬(0, 0) = (0, 1):= by simp [-Prod.mk_zero_zero]` doesn't work with a simple `by simp`.
 - It causes confusion. When one works with tuples in a non-algebra context, it is surprising to see a pair of numbers (1, 1) "collapse" into a single number 1, and it is not immediately obvious how to go back to the pair.

After the change, the only places that explicitly use these two theorems are
 - https://github.com/leanprover-community/mathlib4/blob/a569d4850c7a997eb018903d0f4d3d27589b7b77/Mathlib/LinearAlgebra/CliffordAlgebra/Prod.lean#L154-L156
 - https://github.com/leanprover-community/mathlib4/blob/a569d4850c7a997eb018903d0f4d3d27589b7b77/Mathlib/Algebra/Algebra/NonUnitalHom.lean#L370
 - the new one added in `cfcₙ_map_prod`

These look genuine good use to me

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
