### PR TITLE
[Merged by Bors] - feat(Algebra/Order/Ring/Unbundled/Basic): add (x - a) * (x - b)  positivity criterion

### DIFF
--- a/Mathlib/Algebra/Order/Ring/Unbundled/Basic.lean
+++ b/Mathlib/Algebra/Order/Ring/Unbundled/Basic.lean
@@ -825,23 +825,22 @@ lemma mul_self_le_mul_self_of_le_of_neg_le
 lemma sub_mul_sub_nonneg_iff [MulPosStrictMono R] [PosMulStrictMono R] [AddLeftMono R]
     (x : R) (h : a ≤ b) : 0 ≤ (x - a) * (x - b) ↔ x ≤ a ∨ b ≤ x := by
   rw [mul_nonneg_iff, sub_nonneg, sub_nonneg, sub_nonpos, sub_nonpos,
-    and_iff_right_of_imp (fun h' ↦ Preorder.le_trans a b x h h'),
-    and_iff_left_of_imp (fun h' ↦ Preorder.le_trans x a b h' h), or_comm]
+    and_iff_right_of_imp h.trans, and_iff_left_of_imp h.trans', or_comm]
 
 lemma sub_mul_sub_nonpos_iff [MulPosStrictMono R] [PosMulStrictMono R] [AddLeftMono R]
     (x : R) (h : a ≤ b) :  (x - a) * (x - b) ≤ 0 ↔ a ≤ x ∧ x ≤ b := by
-  rw [mul_nonpos_iff, sub_nonneg, sub_nonneg, sub_nonpos, sub_nonpos, or_iff_left_iff_imp]
-  exact fun ⟨hxa, hbx⟩ ↦ ⟨Preorder.le_trans a b x h hbx, Preorder.le_trans x a b hxa h⟩
+  rw [mul_nonpos_iff, sub_nonneg, sub_nonneg, sub_nonpos, sub_nonpos, or_iff_left_iff_imp, and_comm]
+  exact And.imp h.trans h.trans'
 
 lemma sub_mul_sub_pos_iff [MulPosStrictMono R] [PosMulStrictMono R] [AddLeftMono R]
     (x : R) (h : a ≤ b) : 0 < (x - a) * (x - b) ↔ x < a ∨ b < x := by
-  rw [mul_pos_iff, sub_pos, sub_pos, sub_neg, sub_neg, and_iff_right_of_imp (lt_of_le_of_lt h),
-    and_iff_left_of_imp (gt_of_ge_of_gt h), or_comm]
+  rw [mul_pos_iff, sub_pos, sub_pos, sub_neg, sub_neg, and_iff_right_of_imp h.trans_lt,
+    and_iff_left_of_imp h.trans_lt', or_comm]
 
 lemma sub_mul_sub_neg_iff [MulPosStrictMono R] [PosMulStrictMono R] [AddLeftMono R]
     (x : R) (h : a ≤ b) : (x - a) * (x - b) < 0 ↔ a < x ∧ x < b := by
-  rw [mul_neg_iff, sub_pos, sub_pos, sub_neg, sub_neg, or_iff_left_iff_imp]
-  exact fun ⟨hxa, hbx⟩ ↦ ⟨lt_of_le_of_lt h hbx, gt_of_ge_of_gt h hxa⟩
+  rw [mul_neg_iff, sub_pos, sub_pos, sub_neg, sub_neg, or_iff_left_iff_imp, and_comm]
+  exact And.imp h.trans_lt h.trans_lt'
 
 end LinearOrderedRing
 end OrderedCommRing

--- a/Mathlib/Algebra/Order/Ring/Unbundled/Basic.lean
+++ b/Mathlib/Algebra/Order/Ring/Unbundled/Basic.lean
@@ -822,5 +822,26 @@ lemma mul_self_le_mul_self_of_le_of_neg_le
     (neg_mul_neg a a).symm.trans_le <|
       mul_le_mul h₂ h₂ (neg_nonneg.2 h) <| (neg_nonneg.2 h).trans h₂
 
+lemma sub_mul_sub_nonneg_iff [MulPosStrictMono R] [PosMulStrictMono R] [AddLeftMono R]
+    (x : R) (h : a ≤ b) : 0 ≤ (x - a) * (x - b) ↔ x ≤ a ∨ b ≤ x := by
+  rw [mul_nonneg_iff, sub_nonneg, sub_nonneg, sub_nonpos, sub_nonpos,
+    and_iff_right_of_imp (fun h' ↦ Preorder.le_trans a b x h h'),
+    and_iff_left_of_imp (fun h' ↦ Preorder.le_trans x a b h' h), or_comm]
+
+lemma sub_mul_sub_nonpos_iff [MulPosStrictMono R] [PosMulStrictMono R] [AddLeftMono R]
+    (x : R) (h : a ≤ b) :  (x - a) * (x - b) ≤ 0 ↔ a ≤ x ∧ x ≤ b := by
+  rw [mul_nonpos_iff, sub_nonneg, sub_nonneg, sub_nonpos, sub_nonpos, or_iff_left_iff_imp]
+  exact fun ⟨hxa, hbx⟩ ↦ ⟨Preorder.le_trans a b x h hbx, Preorder.le_trans x a b hxa h⟩
+
+lemma sub_mul_sub_pos_iff [MulPosStrictMono R] [PosMulStrictMono R] [AddLeftMono R]
+    (x : R) (h : a ≤ b) : 0 < (x - a) * (x - b) ↔ x < a ∨ b < x := by
+  rw [mul_pos_iff, sub_pos, sub_pos, sub_neg, sub_neg, and_iff_right_of_imp (lt_of_le_of_lt h),
+    and_iff_left_of_imp (gt_of_ge_of_gt h), or_comm]
+
+lemma sub_mul_sub_neg_iff [MulPosStrictMono R] [PosMulStrictMono R] [AddLeftMono R]
+    (x : R) (h : a ≤ b) : (x - a) * (x - b) < 0 ↔ a < x ∧ x < b := by
+  rw [mul_neg_iff, sub_pos, sub_pos, sub_neg, sub_neg, or_iff_left_iff_imp]
+  exact fun ⟨hxa, hbx⟩ ↦ ⟨lt_of_le_of_lt h hbx, gt_of_ge_of_gt h hxa⟩
+
 end LinearOrderedRing
 end OrderedCommRing


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

The pr introduces inequalities that represent relation between (x - a) * (x - b) and 0. Quadratic expression inequalities generally use these lemmas. I was not sure where to put the lemmas, the LinearOrderedRing section felt like best

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
