### PR TITLE
[Merged by Bors] - feat: drop completeness assumption in two integral lemmas

### DIFF
--- a/Mathlib/MeasureTheory/Integral/Bochner/ContinuousLinearMap.lean
+++ b/Mathlib/MeasureTheory/Integral/Bochner/ContinuousLinearMap.lean
@@ -220,20 +220,24 @@ theorem integral_smul_const {𝕜 : Type*} [RCLike 𝕜] [NormedSpace 𝕜 E] [C
 Note that the integrability hypothesis in the two lemmas below is necessary: consider the case
 where `A = ℝ × ℝ`, `c = (1,0)`, and `f` is only integrable on the first component.
 -/
-lemma integral_const_mul_of_integrable {A : Type*} [NonUnitalNormedRing A] [CompleteSpace A]
+lemma integral_const_mul_of_integrable {A : Type*} [NonUnitalNormedRing A]
     [NormedSpace ℝ A] [IsScalarTower ℝ A A] [SMulCommClass ℝ A A] {f : X → A} (hf : Integrable f μ)
     {c : A} :
     ∫ x, c * f x ∂μ = c * ∫ x, f x ∂μ := by
-  show ∫ x, ContinuousLinearMap.mul ℝ _ c (f x) ∂μ = ContinuousLinearMap.mul ℝ _ c (∫ x, f x ∂μ)
-  rw [ContinuousLinearMap.integral_comp_comm _ hf]
+  by_cases hA : CompleteSpace A
+  · show ∫ x, ContinuousLinearMap.mul ℝ _ c (f x) ∂μ = ContinuousLinearMap.mul ℝ _ c (∫ x, f x ∂μ)
+    rw [ContinuousLinearMap.integral_comp_comm _ hf]
+  · simp [integral, hA]
 
 lemma integral_mul_const_of_integrable {A : Type*} [NonUnitalNormedRing A] [CompleteSpace A]
     [NormedSpace ℝ A] [IsScalarTower ℝ A A] [SMulCommClass ℝ A A] {f : X → A} (hf : Integrable f μ)
     {c : A} :
     ∫ x, f x * c ∂μ = (∫ x, f x ∂μ) * c := by
-  show ∫ x, (ContinuousLinearMap.mul ℝ _).flip c (f x) ∂μ
-    = (ContinuousLinearMap.mul ℝ _).flip c (∫ x, f x ∂μ)
-  rw [ContinuousLinearMap.integral_comp_comm _ hf]
+  by_cases hA : CompleteSpace A
+  · show ∫ x, (ContinuousLinearMap.mul ℝ _).flip c (f x) ∂μ
+      = (ContinuousLinearMap.mul ℝ _).flip c (∫ x, f x ∂μ)
+    rw [ContinuousLinearMap.integral_comp_comm _ hf]
+  · simp [integral, hA]
 
 theorem integral_withDensity_eq_integral_smul {f : X → ℝ≥0} (f_meas : Measurable f) (g : X → E) :
     ∫ x, g x ∂μ.withDensity (fun x => f x) = ∫ x, f x • g x ∂μ := by

--- a/Mathlib/MeasureTheory/Integral/Bochner/ContinuousLinearMap.lean
+++ b/Mathlib/MeasureTheory/Integral/Bochner/ContinuousLinearMap.lean
@@ -220,18 +220,16 @@ theorem integral_smul_const {𝕜 : Type*} [RCLike 𝕜] [NormedSpace 𝕜 E] [C
 Note that the integrability hypothesis in the two lemmas below is necessary: consider the case
 where `A = ℝ × ℝ`, `c = (1,0)`, and `f` is only integrable on the first component.
 -/
-lemma integral_const_mul_of_integrable {A : Type*} [NonUnitalNormedRing A]
-    [NormedSpace ℝ A] [IsScalarTower ℝ A A] [SMulCommClass ℝ A A] {f : X → A} (hf : Integrable f μ)
-    {c : A} :
+lemma integral_const_mul_of_integrable {A : Type*} [NonUnitalNormedRing A] [NormedSpace ℝ A]
+    [IsScalarTower ℝ A A] [SMulCommClass ℝ A A] {f : X → A} (hf : Integrable f μ) {c : A} :
     ∫ x, c * f x ∂μ = c * ∫ x, f x ∂μ := by
   by_cases hA : CompleteSpace A
   · show ∫ x, ContinuousLinearMap.mul ℝ _ c (f x) ∂μ = ContinuousLinearMap.mul ℝ _ c (∫ x, f x ∂μ)
     rw [ContinuousLinearMap.integral_comp_comm _ hf]
   · simp [integral, hA]
 
-lemma integral_mul_const_of_integrable {A : Type*} [NonUnitalNormedRing A] [CompleteSpace A]
-    [NormedSpace ℝ A] [IsScalarTower ℝ A A] [SMulCommClass ℝ A A] {f : X → A} (hf : Integrable f μ)
-    {c : A} :
+lemma integral_mul_const_of_integrable {A : Type*} [NonUnitalNormedRing A] [NormedSpace ℝ A]
+    [IsScalarTower ℝ A A] [SMulCommClass ℝ A A] {f : X → A} (hf : Integrable f μ) {c : A} :
     ∫ x, f x * c ∂μ = (∫ x, f x ∂μ) * c := by
   by_cases hA : CompleteSpace A
   · show ∫ x, (ContinuousLinearMap.mul ℝ _).flip c (f x) ∂μ


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
