### PR TITLE
[Merged by Bors] - refactor(Order/Heyting): convert toBiheytingHomClass from lemma to instance

### DIFF
--- a/Mathlib/Order/Heyting/Hom.lean
+++ b/Mathlib/Order/Heyting/Hom.lean
@@ -172,9 +172,7 @@ end Equiv
 
 variable [FunLike F α β]
 
--- Porting note: Revisit this issue to see if it works in Lean 4.
-/-- This can't be an instance because of typeclass loops. -/
-lemma BoundedLatticeHomClass.toBiheytingHomClass [BooleanAlgebra α] [BooleanAlgebra β]
+instance BoundedLatticeHomClass.toBiheytingHomClass [BooleanAlgebra α] [BooleanAlgebra β]
     [BoundedLatticeHomClass F α β] : BiheytingHomClass F α β :=
   { ‹BoundedLatticeHomClass F α β› with
     map_himp := fun f a b => by rw [himp_eq, himp_eq, map_sup, (isCompl_compl.map _).compl_eq]


### PR DESCRIPTION
Previously toBiheytingHomClass was a lemma due to concerns about typeclass loops. These concerns are no longer relevant in Lean 4, so we can now make it a proper instance. Remove the outdated porting note as well.