### PR TITLE
[Merged by Bors] - chore(NumberTheory/Harmonic/EulerMascheroni): shorten proof of tendsto_eulerMascheroniSeq'

### DIFF
--- a/Mathlib/NumberTheory/Harmonic/EulerMascheroni.lean
+++ b/Mathlib/NumberTheory/Harmonic/EulerMascheroni.lean
@@ -142,12 +142,7 @@ lemma tendsto_eulerMascheroniSeq' :
     apply (this.comp tendsto_natCast_atTop_atTop).congr'
     filter_upwards [eventually_ne_atTop 0] with n hn
     simp [eulerMascheroniSeq, eulerMascheroniSeq', eq_false_intro hn]
-  suffices Tendsto (fun x : ℝ ↦ log (1 + 1 / x)) atTop (𝓝 0) by
-    apply this.congr'
-    filter_upwards [eventually_gt_atTop 0] with x hx
-    rw [← log_div (by positivity) (by positivity), add_div, div_self hx.ne']
-  simpa only [add_zero, log_one] using
-    ((tendsto_const_nhds.div_atTop tendsto_id).const_add 1).log (by positivity)
+  exact tendsto_log_comp_add_sub_log 1
 
 lemma tendsto_harmonic_sub_log :
     Tendsto (fun n : ℕ ↦ harmonic n - log n) atTop (𝓝 eulerMascheroniConstant) := by


### PR DESCRIPTION
Replaces 6 lines of the proof of `tendsto_eulerMascheroniSeq'` with an invocation of [`tendsto_log_comp_add_sub_log`](https://github.com/leanprover-community/mathlib4/blob/be41d01fc2b49f941ba389a98c13fcfb5721dea8/Mathlib/Analysis/SpecialFunctions/Log/Basic.lean#L462-L469).

Found by [`tryAtEachStep`](https://github.com/dwrensha/tryAtEachStep).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
