### PR TITLE
chore: remove outParam from Valued

### DIFF
--- a/Mathlib/Topology/Algebra/Valued/ValuationTopology.lean
+++ b/Mathlib/Topology/Algebra/Valued/ValuationTopology.lean
@@ -86,7 +86,7 @@ TODO: show that there always exists an equivalent valuation taking values in a t
 the same universe as the ring.
 
 See Note [forgetful inheritance] for why we extend `UniformSpace`, `IsUniformAddGroup`. -/
-class Valued (R : Type u) [Ring R] (Γ₀ : outParam (Type v))
+class Valued (R : Type u) [Ring R] (Γ₀ : Type v)
   [LinearOrderedCommGroupWithZero Γ₀] extends UniformSpace R, IsUniformAddGroup R where
   v : Valuation R Γ₀
   is_topological_valuation : ∀ s, s ∈ 𝓝 (0 : R) ↔ ∃ γ : Γ₀ˣ, { x : R | v x < γ } ⊆ s
@@ -118,7 +118,8 @@ theorem hasBasis_uniformity : (𝓤 R).HasBasis (fun _ => True)
   exact (hasBasis_nhds_zero R Γ₀).comap _
 
 theorem toUniformSpace_eq :
-    toUniformSpace = @IsTopologicalAddGroup.toUniformSpace R _ v.subgroups_basis.topology _ :=
+    toUniformSpace Γ₀ =
+    @IsTopologicalAddGroup.toUniformSpace R _ (v.subgroups_basis (Γ₀ := Γ₀)).topology _ :=
   UniformSpace.ext
     ((hasBasis_uniformity R Γ₀).eq_of_same_basis <| v.subgroups_basis.hasBasis_nhds_zero.comap _)
 
@@ -131,7 +132,7 @@ theorem mem_nhds {s : Set R} {x : R} : s ∈ 𝓝 x ↔ ∃ γ : Γ₀ˣ, { y | 
 theorem mem_nhds_zero {s : Set R} : s ∈ 𝓝 (0 : R) ↔ ∃ γ : Γ₀ˣ, { x | v x < (γ : Γ₀) } ⊆ s := by
   simp only [mem_nhds, sub_zero]
 
-theorem loc_const {x : R} (h : (v x : Γ₀) ≠ 0) : { y : R | v y = v x } ∈ 𝓝 x := by
+theorem loc_const {x : R} (h : (v x : Γ₀) ≠ 0) : { y : R | v y = (v x : Γ₀) } ∈ 𝓝 x := by
   rw [mem_nhds]
   use Units.mk0 _ h
   rw [Units.val_mk0]


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

Exploring the idea that Gamma_0 should not be an outParam in Valued.