### PR TITLE
[Merged by Bors] - fix(Tactic/Polyrith): correct `Quote ℤ` instance

### DIFF
--- a/Mathlib/Tactic/Polyrith.lean
+++ b/Mathlib/Tactic/Polyrith.lean
@@ -102,7 +102,7 @@ instance : Inhabited Poly := ⟨Poly.const 0⟩
 
 instance : Quote ℤ where quote
   | .ofNat n => quote n
-  | .negSucc n => Unhygienic.run `(-$(quote n))
+  | .negSucc n => Unhygienic.run `(-$(quote (n + 1)))
 
 instance : Quote ℚ where
   quote q :=


### PR DESCRIPTION
Fixes the `Quote ℤ` instance to make it return the correct value on negatives. This doesn't actually break anything yet, but could become problematic in the future.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
