### PR TITLE
feat: delaborator for `inner`

### DIFF
--- a/Mathlib/Analysis/InnerProductSpace/Defs.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Defs.lean
@@ -88,6 +88,12 @@ scoped[RealInnerProductSpace] notation "⟪" x ", " y "⟫" => @inner ℝ _ _ x 
 /-- The inner product with values in `ℂ`. -/
 scoped[ComplexInnerProductSpace] notation "⟪" x ", " y "⟫" => @inner ℂ _ _ x y
 
+/--
+Delaborator for the inner product. It delaborates as follows:
+- `@inner ℝ _ _ x y` => `⟪x, y⟫`
+- `@inner ℂ _ _ x y` => `⟪x, y⟫`
+- `@inner 𝕜 _ _ x y` => `⟪x, y⟫_𝕜`
+-/
 @[delab app.Inner.inner]
 def Lean.PrettyPrinter.Delaborator.delabInner : Lean.PrettyPrinter.Delaborator.Delab :=
   Lean.PrettyPrinter.Delaborator.whenPPOption Lean.getPPNotation do
@@ -95,10 +101,10 @@ def Lean.PrettyPrinter.Delaborator.delabInner : Lean.PrettyPrinter.Delaborator.D
     let_expr Inner.inner 𝕜 _ _ _ _ := ← SubExpr.getExpr | failure
     let stx_x ← SubExpr.withNaryArg 3 delab
     let stx_y ← SubExpr.withNaryArg 4 delab
-    if 𝕜.isAppOf ``Real then
+    if 𝕜.isConstOf ``Real then
       Mathlib.Notation3.withHeadRefIfTagAppFns <|
         open scoped RealInnerProductSpace in `(⟪$stx_x, $stx_y⟫)
-    else if 𝕜.isAppOf ``Complex then
+    else if 𝕜.isConstOf ``Complex then
       Mathlib.Notation3.withHeadRefIfTagAppFns <|
         open scoped ComplexInnerProductSpace in `(⟪$stx_x, $stx_y⟫)
     else

--- a/Mathlib/Analysis/InnerProductSpace/Defs.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Defs.lean
@@ -78,7 +78,7 @@ class Inner (𝕜 E : Type*) where
 export Inner (inner)
 
 /-- The inner product with values in `𝕜`. -/
-scoped[InnerProductSpace] notation3:max "⟪" x ", " y "⟫_" 𝕜:max => @inner 𝕜 _ _ x y
+scoped[InnerProductSpace] notation:max "⟪" x ", " y "⟫_" 𝕜:max => @inner 𝕜 _ _ x y
 
 section Notations
 
@@ -87,6 +87,24 @@ scoped[RealInnerProductSpace] notation "⟪" x ", " y "⟫" => @inner ℝ _ _ x 
 
 /-- The inner product with values in `ℂ`. -/
 scoped[ComplexInnerProductSpace] notation "⟪" x ", " y "⟫" => @inner ℂ _ _ x y
+
+@[delab app.Inner.inner]
+def Lean.PrettyPrinter.Delaborator.delabInner : Lean.PrettyPrinter.Delaborator.Delab :=
+  Lean.PrettyPrinter.Delaborator.whenPPOption Lean.getPPNotation do
+  Lean.PrettyPrinter.Delaborator.whenNotPPOption Lean.getPPExplicit do
+    let_expr Inner.inner 𝕜 _ _ _ _ := ← SubExpr.getExpr | failure
+    let stx_x ← SubExpr.withNaryArg 3 delab
+    let stx_y ← SubExpr.withNaryArg 4 delab
+    if 𝕜.isAppOf ``Real then
+      Mathlib.Notation3.withHeadRefIfTagAppFns <|
+        open scoped RealInnerProductSpace in `(⟪$stx_x, $stx_y⟫)
+    else if 𝕜.isAppOf ``Complex then
+      Mathlib.Notation3.withHeadRefIfTagAppFns <|
+        open scoped ComplexInnerProductSpace in `(⟪$stx_x, $stx_y⟫)
+    else
+      let stx_𝕜 ← SubExpr.withNaryArg 0 delab
+      Mathlib.Notation3.withHeadRefIfTagAppFns <|
+        open scoped InnerProductSpace in `(⟪$stx_x, $stx_y⟫_$stx_𝕜)
 
 end Notations
 

--- a/MathlibTest/Delab/Inner.lean
+++ b/MathlibTest/Delab/Inner.lean
@@ -1,0 +1,20 @@
+import Mathlib.Analysis.InnerProductSpace.Defs
+import Mathlib.Analysis.Complex.Basic
+
+variable {V₁} [SeminormedAddCommGroup V₁] [InnerProductSpace ℝ V₁] (v₁ w₁ : V₁)
+variable {V₂} [SeminormedAddCommGroup V₂] [InnerProductSpace ℂ V₂] (v₂ w₂ : V₂)
+variable {V₃ 𝕜} [RCLike 𝕜] [SeminormedAddCommGroup V₃] [InnerProductSpace 𝕜 V₃] (v₃ w₃ : V₃)
+
+open InnerProductSpace
+
+/-- info: ⟪v₁, w₁⟫ : ℝ -/
+#guard_msgs in
+#check ⟪v₁, w₁⟫_ℝ
+
+/-- info: ⟪v₂, w₂⟫ : ℂ -/
+#guard_msgs in
+#check ⟪v₂, w₂⟫_ℂ
+
+/-- info: ⟪v₃, w₃⟫_𝕜 : 𝕜 -/
+#guard_msgs in
+#check ⟪v₃, w₃⟫_𝕜


### PR DESCRIPTION
See [#mathlib4 > Pretty printing &#96;inner&#96;, and argument explicitness](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Pretty.20printing.20.60inner.60.2C.20and.20argument.20explicitness)

Previously, there was only a scoped delaborator for the `⟪x, y⟫_𝕜` notation. This PR defines a global delaborator, which switches to the `⟪x, y⟫` notation whenever `x` and `y` live in `ℝ` or `ℂ`. In that case, hovering over the notation shows a docstrict that says which of `ℝ` or `ℂ` it represents (e.g. "The inner product with values in `ℝ`.")  .

Since it is global, this should also show up on docGen.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
