### PR TITLE
[Merged by Bors] - chore(Tactic/Linter): use logLint instead of logWarning

### DIFF
--- a/Mathlib/Tactic/CategoryTheory/Bicategory/PureCoherence.lean
+++ b/Mathlib/Tactic/CategoryTheory/Bicategory/PureCoherence.lean
@@ -262,7 +262,7 @@ instance : MkEqOfNaturality BicategoryM where
 
 open Elab.Tactic
 
-/-- Close the goal of the form `η = θ`, where `η` and `θ` are 2-isomorphisms made up only of
+/-- Close the goal of the form `η.hom = θ.hom`, where `η` and `θ` are 2-isomorphisms made up only of
 associators, unitors, and identities.
 ```lean
 example {B : Type} [Bicategory B] {a : B} :

--- a/Mathlib/Tactic/CategoryTheory/Coherence/Datatypes.lean
+++ b/Mathlib/Tactic/CategoryTheory/Coherence/Datatypes.lean
@@ -113,7 +113,7 @@ class MonadMor₁ (m : Type → Type) where
   comp₁M (f g : Mor₁) : m Mor₁
 
 /-- Expressions for coherence isomorphisms (i.e., structural 2-morphisms
-giveb by `BicategorycalCoherence.iso`). -/
+given by `BicategoricalCoherence.iso`). -/
 structure CoherenceHom where
   /-- The underlying lean expression of a coherence isomorphism. -/
   e : Expr

--- a/Mathlib/Tactic/DeclarationNames.lean
+++ b/Mathlib/Tactic/DeclarationNames.lean
@@ -47,3 +47,9 @@ def getAliasSyntax {m} [Monad m] [MonadResolveName m] (stx : Syntax) : m (Array 
       aliases := aliases.push
         (mkIdentFrom (.ofRange (idStx.raw.getRange?.getD default)) (currNamespace ++ id))
   return aliases
+
+/-- Used for linters which use `0` instead of `false` for disabling. -/
+def logLint0Disable {m} [Monad m] [MonadLog m] [AddMessageContext m] [MonadOptions m]
+    (linterOption : Lean.Option Nat) (stx : Syntax) (msg : MessageData) : m Unit :=
+  let disable := m!"note: this linter can be disabled with `set_option {linterOption.name} 0`"
+  logWarningAt stx (.tagged linterOption.name m!"{msg}\n{disable}")

--- a/Mathlib/Tactic/Linter/HaveLetLinter.lean
+++ b/Mathlib/Tactic/Linter/HaveLetLinter.lean
@@ -7,6 +7,7 @@ Authors: Damiano Testa
 import Mathlib.Init
 import Lean.Elab.Command
 import Lean.Server.InfoUtils
+import Mathlib.Tactic.DeclarationNames
 
 /-!
 #  The `have` vs `let` linter
@@ -117,11 +118,8 @@ def haveLetLinter : Linter where run := withSetOptionIn fun _stx => do
     let trees ← getInfoTrees
     for t in trees do
       for (s, fmt) in ← nonPropHaves t do
-        -- Since the linter option is not in `Bool`, the standard `Linter.logLint` does not work.
-        -- We emulate it with `logWarningAt`
-        logWarningAt s <| .tagged linter.haveLet.name
-          m!"'{fmt}' is a Type and not a Prop. Consider using 'let' instead of 'have'.\n\
-          You can disable this linter using `set_option linter.haveLet 0`"
+        logLint0Disable linter.haveLet s
+          m!"'{fmt}' is a Type and not a Prop. Consider using 'let' instead of 'have'."
 
 initialize addLinter haveLetLinter
 

--- a/Mathlib/Tactic/Linter/Style.lean
+++ b/Mathlib/Tactic/Linter/Style.lean
@@ -221,7 +221,7 @@ def cdotLinter : Linter where run := withSetOptionIn fun stx ↦ do
       match cdot.find? (·.isOfKind `token.«· ») with
       | some (.node _ _ #[.atom (.original _ _ afterCDot _) _]) =>
         if (afterCDot.takeWhile (·.isWhitespace)).contains '\n' then
-          logWarningAt cdot <| .tagged linter.style.cdot.name
+          Linter.logLint linter.style.cdot cdot
             m!"This central dot `·` is isolated; please merge it with the next line."
       | _ => return
 
@@ -351,7 +351,7 @@ def longFileLinter : Linter where run := withSetOptionIn fun stx ↦ do
       | `(set_option linter.style.longFile $x) => TSyntax.getNat ⟨x.raw⟩ ≤ defValue
       | _ => false
   if smallOption then
-    logWarningAt stx <| .tagged linter.style.longFile.name
+    logLint0Disable linter.style.longFile stx
       m!"The default value of the `longFile` linter is {defValue}.\n\
         The current value of {linterBound} does not exceed the allowed bound.\n\
         Please, remove the `set_option linter.style.longFile {linterBound}`."
@@ -369,7 +369,7 @@ def longFileLinter : Linter where run := withSetOptionIn fun stx ↦ do
     let lastLine := ((← getFileMap).toPosition init).line
     -- In this case, the file has an allowed length, and the linter option is unnecessarily set.
     if lastLine ≤ defValue && defValue < linterBound then
-      logWarningAt stx <| .tagged linter.style.longFile.name
+      logLint0Disable linter.style.longFile stx
         m!"The default value of the `longFile` linter is {defValue}.\n\
           This file is {lastLine} lines long which does not exceed the allowed bound.\n\
           Please, remove the `set_option linter.style.longFile {linterBound}`."
@@ -381,7 +381,7 @@ def longFileLinter : Linter where run := withSetOptionIn fun stx ↦ do
     let candidate := max candidate defValue
     -- In this case, the file is longer than the default and also than what the option says.
     if defValue ≤ linterBound && linterBound < lastLine then
-      logWarningAt stx <| .tagged linter.style.longFile.name
+      logLint0Disable linter.style.longFile stx
         m!"This file is {lastLine} lines long, but the limit is {linterBound}.\n\n\
           You can extend the allowed length of the file using \
           `set_option linter.style.longFile {candidate}`.\n\
@@ -392,7 +392,7 @@ def longFileLinter : Linter where run := withSetOptionIn fun stx ↦ do
     -- In particular, this flags any option that is set to an unnecessarily high value.
     if linterBound == candidate || linterBound + 100 == candidate then return
     else
-      logWarningAt stx <| .tagged linter.style.longFile.name
+      logLint0Disable linter.style.longFile stx
         m!"This file is {lastLine} lines long. \
           The current limit is {linterBound}, but it is expected to be {candidate}:\n\
           `set_option linter.style.longFile {candidate}`."

--- a/MathlibTest/HaveLetLinter.lean
+++ b/MathlibTest/HaveLetLinter.lean
@@ -30,7 +30,7 @@ example : True := by
 warning: declaration uses 'sorry'
 ---
 warning: '_zero : ℕ' is a Type and not a Prop. Consider using 'let' instead of 'have'.
-You can disable this linter using `set_option linter.haveLet 0`
+note: this linter can be disabled with `set_option linter.haveLet 0`
 -/
 #guard_msgs in
 example : True := by
@@ -40,7 +40,7 @@ example : True := by
 
 /--
 warning: '_zero : ℕ' is a Type and not a Prop. Consider using 'let' instead of 'have'.
-You can disable this linter using `set_option linter.haveLet 0`
+note: this linter can be disabled with `set_option linter.haveLet 0`
 -/
 #guard_msgs in
 set_option linter.haveLet 2 in
@@ -57,7 +57,7 @@ example : True := by
 warning: declaration uses 'sorry'
 ---
 warning: '_zero : ℕ' is a Type and not a Prop. Consider using 'let' instead of 'have'.
-You can disable this linter using `set_option linter.haveLet 0`
+note: this linter can be disabled with `set_option linter.haveLet 0`
 -/
 #guard_msgs in
 example : True := by
@@ -69,7 +69,7 @@ example : True := by
 warning: declaration uses 'sorry'
 ---
 warning: '_zero : ℕ' is a Type and not a Prop. Consider using 'let' instead of 'have'.
-You can disable this linter using `set_option linter.haveLet 0`
+note: this linter can be disabled with `set_option linter.haveLet 0`
 -/
 #guard_msgs in
 example : True := by
@@ -81,16 +81,16 @@ example : True := by
 warning: declaration uses 'sorry'
 ---
 warning: '_a : ℕ' is a Type and not a Prop. Consider using 'let' instead of 'have'.
-You can disable this linter using `set_option linter.haveLet 0`
+note: this linter can be disabled with `set_option linter.haveLet 0`
 ---
 warning: '_b : ℕ' is a Type and not a Prop. Consider using 'let' instead of 'have'.
-You can disable this linter using `set_option linter.haveLet 0`
+note: this linter can be disabled with `set_option linter.haveLet 0`
 ---
 warning: '_oh : ℕ' is a Type and not a Prop. Consider using 'let' instead of 'have'.
-You can disable this linter using `set_option linter.haveLet 0`
+note: this linter can be disabled with `set_option linter.haveLet 0`
 ---
 warning: '_b : ℕ' is a Type and not a Prop. Consider using 'let' instead of 'have'.
-You can disable this linter using `set_option linter.haveLet 0`
+note: this linter can be disabled with `set_option linter.haveLet 0`
 -/
 #guard_msgs in
 example : True := by
@@ -108,7 +108,7 @@ set_option linter.haveLet 1 in
 warning: declaration uses 'sorry'
 ---
 warning: 'this : ℕ' is a Type and not a Prop. Consider using 'let' instead of 'have'.
-You can disable this linter using `set_option linter.haveLet 0`
+note: this linter can be disabled with `set_option linter.haveLet 0`
 -/
 #guard_msgs in
 example : True := by
@@ -138,7 +138,7 @@ set_option linter.haveLet 1 in
 warning: declaration uses 'sorry'
 ---
 warning: 'this : ℕ' is a Type and not a Prop. Consider using 'let' instead of 'have'.
-You can disable this linter using `set_option linter.haveLet 0`
+note: this linter can be disabled with `set_option linter.haveLet 0`
 -/
 #guard_msgs in
 theorem ghi : True := by

--- a/MathlibTest/LintStyle.lean
+++ b/MathlibTest/LintStyle.lean
@@ -199,8 +199,10 @@ warning: Please, use '·' (typed as `\.`) instead of '.' as 'cdot'.
 note: this linter can be disabled with `set_option linter.style.cdot false`
 ---
 warning: This central dot `·` is isolated; please merge it with the next line.
+note: this linter can be disabled with `set_option linter.style.cdot false`
 ---
 warning: This central dot `·` is isolated; please merge it with the next line.
+note: this linter can be disabled with `set_option linter.style.cdot false`
 -/
 #guard_msgs in
 example : Nat := by

--- a/MathlibTest/LongFile.lean
+++ b/MathlibTest/LongFile.lean
@@ -19,6 +19,7 @@ section longFile
 warning: The default value of the `longFile` linter is 1500.
 The current value of 1500 does not exceed the allowed bound.
 Please, remove the `set_option linter.style.longFile 1500`.
+note: this linter can be disabled with `set_option linter.style.longFile 0`
 -/
 #guard_msgs in
 -- Do not allow setting a `longFile` linter option if the file does not exceed the `defValue`
@@ -28,8 +29,9 @@ set_option linter.style.longFile 1500
 warning: using 'exit' to interrupt Lean
 ---
 warning: The default value of the `longFile` linter is 50.
-This file is 38 lines long which does not exceed the allowed bound.
+This file is 40 lines long which does not exceed the allowed bound.
 Please, remove the `set_option linter.style.longFile 60`.
+note: this linter can be disabled with `set_option linter.style.longFile 0`
 -/
 #guard_msgs in
 -- Do not allow unnecessarily increasing the `longFile` linter option
@@ -40,10 +42,11 @@ set_option linter.style.longFile 60 in
 /--
 warning: using 'exit' to interrupt Lean
 ---
-warning: This file is 52 lines long, but the limit is 20.
+warning: This file is 55 lines long, but the limit is 20.
 
 You can extend the allowed length of the file using `set_option linter.style.longFile 200`.
 You can completely disable this linter by setting the length limit to `0`.
+note: this linter can be disabled with `set_option linter.style.longFile 0`
 -/
 #guard_msgs in
 -- We test that the `longFile` linter warns when a file exceeds the allowed value.
@@ -68,8 +71,9 @@ set_option linter.style.longFile 100 in
 /--
 warning: using 'exit' to interrupt Lean
 ---
-warning: This file is 78 lines long. The current limit is 101, but it is expected to be 200:
+warning: This file is 82 lines long. The current limit is 101, but it is expected to be 200:
 `set_option linter.style.longFile 200`.
+note: this linter can be disabled with `set_option linter.style.longFile 0`
 -/
 #guard_msgs in
 -- Check that a value different from `candidate` or `candidate - 100` value is not allowed
@@ -87,8 +91,9 @@ set_option linter.style.longFileDefValue 1000
 /--
 warning: using 'exit' to interrupt Lean
 ---
-warning: This file is 94 lines long. The current limit is 500, but it is expected to be 1000:
+warning: This file is 99 lines long. The current limit is 500, but it is expected to be 1000:
 `set_option linter.style.longFile 1000`.
+note: this linter can be disabled with `set_option linter.style.longFile 0`
 -/
 #guard_msgs in
 #exit
@@ -105,6 +110,7 @@ set_option linter.style.longFileDefValue 2000
 warning: The default value of the `longFile` linter is 2000.
 The current value of 1999 does not exceed the allowed bound.
 Please, remove the `set_option linter.style.longFile 1999`.
+note: this linter can be disabled with `set_option linter.style.longFile 0`
 -/
 #guard_msgs in
 -- Do not allow setting a `longFile` linter option if the file does not exceed the `defValue`
@@ -118,8 +124,9 @@ set_option linter.style.longFileDefValue 400
 warning: using 'exit' to interrupt Lean
 ---
 warning: The default value of the `longFile` linter is 400.
-This file is 126 lines long which does not exceed the allowed bound.
+This file is 133 lines long which does not exceed the allowed bound.
 Please, remove the `set_option linter.style.longFile 5000`.
+note: this linter can be disabled with `set_option linter.style.longFile 0`
 -/
 #guard_msgs in
 set_option linter.style.longFile 5000 in


### PR DESCRIPTION
Also adds `logLint0Disable` for those linters which use nat-valued options. Linters should never use `logWarning` to report linter warnings; `logLint` ensures a consistent style for all linter warnings which includes in particular the name of the linter which is firing.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
