### PR TITLE
[Merged by Bors] - chore(Data/Finset/Insert): make `cons` branch explicit in `Finset.induction`

### DIFF
--- a/Mathlib/Algebra/BigOperators/Associated.lean
+++ b/Mathlib/Algebra/BigOperators/Associated.lean
@@ -59,7 +59,7 @@ theorem Associated.prod {M : Type*} [CommMonoid M] {ι : Type*} (s : Finset ι) 
   | empty =>
     simp only [Finset.prod_empty]
     rfl
-  | @insert j s hjs IH =>
+  | insert j s hjs IH =>
     classical
     convert_to (∏ i ∈ insert j s, f i) ~ᵤ (∏ i ∈ insert j s, g i)
     rw [Finset.prod_insert hjs, Finset.prod_insert hjs]
@@ -89,7 +89,7 @@ theorem divisor_closure_eq_closure [CancelCommMonoidWithZero α]
     simp only [Set.mem_setOf]
     simp only [Multiset.prod_zero] at hprod
     left; exact isUnit_of_mul_eq_one _ _ hprod.symm
-  | @cons c s hind =>
+  | cons c s hind =>
     simp only [Multiset.mem_cons, forall_eq_or_imp, Set.mem_setOf] at hm
     simp only [Multiset.prod_cons] at hprod
     simp only [Set.mem_setOf_eq] at hind

--- a/Mathlib/Algebra/BigOperators/Finsupp/Basic.lean
+++ b/Mathlib/Algebra/BigOperators/Finsupp/Basic.lean
@@ -282,7 +282,7 @@ theorem support_finset_sum [DecidableEq β] [AddCommMonoid M] {s : Finset α} {f
   rw [← Finset.sup_eq_biUnion]
   induction s using Finset.cons_induction_on with
   | empty => rfl
-  | cons _ ih =>
+  | cons _ _ _ ih =>
     rw [Finset.sum_cons, Finset.sup_cons]
     exact support_add.trans (Finset.union_subset_union (Finset.Subset.refl _) ih)
 

--- a/Mathlib/Algebra/BigOperators/GroupWithZero/Action.lean
+++ b/Mathlib/Algebra/BigOperators/GroupWithZero/Action.lean
@@ -130,6 +130,6 @@ theorem prod_smul
     ∏ i ∈ s, b i • f i = (∏ i ∈ s, b i) • ∏ i ∈ s, f i := by
   induction s using Finset.cons_induction_on with
   | empty =>  simp
-  | cons hj ih => rw [prod_cons, ih, smul_mul_smul_comm, ← prod_cons hj, ← prod_cons hj]
+  | cons _ _ hj ih => rw [prod_cons, ih, smul_mul_smul_comm, ← prod_cons hj, ← prod_cons hj]
 
 end Finset

--- a/Mathlib/Algebra/BigOperators/GroupWithZero/Finset.lean
+++ b/Mathlib/Algebra/BigOperators/GroupWithZero/Finset.lean
@@ -47,7 +47,7 @@ lemma prod_eq_zero_iff : ∏ x ∈ s, f x = 0 ↔ ∃ a ∈ s, f a = 0 := by
   classical
     induction s using Finset.induction_on with
     | empty => exact ⟨Not.elim one_ne_zero, fun ⟨_, H, _⟩ => by simp at H⟩
-    | insert ha ih => rw [prod_insert ha, mul_eq_zero, exists_mem_insert, ih]
+    | insert _ _ ha ih => rw [prod_insert ha, mul_eq_zero, exists_mem_insert, ih]
 
 lemma prod_ne_zero_iff : ∏ x ∈ s, f x ≠ 0 ↔ ∀ a ∈ s, f a ≠ 0 := by
   rw [Ne, prod_eq_zero_iff]

--- a/Mathlib/Algebra/BigOperators/Ring/Finset.lean
+++ b/Mathlib/Algebra/BigOperators/Ring/Finset.lean
@@ -118,8 +118,7 @@ lemma prod_sum (s : Finset ι) (t : ∀ i, Finset (κ i)) (f : ∀ i, κ i → �
   classical
   induction s using Finset.induction with
   | empty => simp
-  | insert ha ih =>
-    rename_i a s
+  | insert a s ha ih =>
     have h₁ : ∀ x ∈ t a, ∀ y ∈ t a, x ≠ y →
       Disjoint (image (Pi.cons s a x) (pi s t)) (image (Pi.cons s a y) (pi s t)) := by
       intro x _ y _ h

--- a/Mathlib/Algebra/Group/Subgroup/Finite.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Finite.lean
@@ -180,8 +180,7 @@ theorem pi_mem_of_mulSingle_mem_aux [DecidableEq η] (I : Finset η) {H : Subgro
       exact h1 i (Finset.not_mem_empty i)
     rw [this]
     exact one_mem H
-  | insert hnmem ih =>
-    rename_i i I
+  | insert i I hnmem ih =>
     have : x = Function.update x i 1 * Pi.mulSingle i (x i) := by
       ext j
       by_cases heq : j = i

--- a/Mathlib/Algebra/Lie/Submodule.lean
+++ b/Mathlib/Algebra/Lie/Submodule.lean
@@ -398,8 +398,7 @@ instance : SupSet (LieSubmodule R L M) where
         | empty =>
           replace hsm : m = 0 := by simpa using hsm
           simp [hsm]
-        | insert hqt ih =>
-          rename_i q t
+        | insert q t hqt ih =>
           rw [Finset.iSup_insert] at hsm
           obtain ⟨m', hm', u, hu, rfl⟩ := Submodule.mem_sup.mp hsm
           rw [lie_add]

--- a/Mathlib/Algebra/MvPolynomial/Variables.lean
+++ b/Mathlib/Algebra/MvPolynomial/Variables.lean
@@ -133,7 +133,7 @@ theorem vars_prod {ι : Type*} [DecidableEq σ] {s : Finset ι} (f : ι → MvPo
   classical
   induction s using Finset.induction_on with
   | empty => simp
-  | insert hs hsub =>
+  | insert _ _ hs hsub =>
     simp only [hs, Finset.biUnion_insert, Finset.prod_insert, not_false_iff]
     apply Finset.Subset.trans (vars_mul _ _)
     exact Finset.union_subset_union (Finset.Subset.refl _) hsub
@@ -164,7 +164,7 @@ theorem vars_sum_subset [DecidableEq σ] :
   classical
   induction t using Finset.induction_on with
   | empty => simp
-  | insert has hsum =>
+  | insert _ _ has hsum =>
     rw [Finset.biUnion_insert, Finset.sum_insert has]
     refine Finset.Subset.trans
       (vars_add_subset _ _) (Finset.union_subset_union (Finset.Subset.refl _) ?_)
@@ -175,7 +175,7 @@ theorem vars_sum_of_disjoint [DecidableEq σ] (h : Pairwise <| (Disjoint on fun 
   classical
   induction t using Finset.induction_on with
   | empty => simp
-  | insert has hsum =>
+  | insert _ _ has hsum =>
     rw [Finset.biUnion_insert, Finset.sum_insert has, vars_add_of_disjoint, hsum]
     unfold Pairwise onFun at h
     rw [hsum]

--- a/Mathlib/Algebra/Polynomial/PartialFractions.lean
+++ b/Mathlib/Algebra/Polynomial/PartialFractions.lean
@@ -96,7 +96,7 @@ theorem div_eq_quo_add_sum_rem_div (f : R[X]) {ι : Type*} {g : ι → R[X]} {s 
   | empty =>
     refine ⟨f, fun _ : ι => (0 : R[X]), fun i => ?_, by simp⟩
     rintro ⟨⟩
-  | @insert a b hab Hind => ?_
+  | insert a b hab Hind => ?_
   obtain ⟨q₀, r₁, r₂, hdeg₁, _, hf : (↑f : K) / _ = _⟩ :=
     div_eq_quo_add_rem_div_add_rem_div R K f
       (hg a (b.mem_insert_self a) : Monic (g a))

--- a/Mathlib/Analysis/Asymptotics/ExpGrowth.lean
+++ b/Mathlib/Analysis/Asymptotics/ExpGrowth.lean
@@ -345,7 +345,7 @@ lemma expGrowthSup_sum {α : Type*} (u : α → ℕ → ℝ≥0∞) (s : Finset 
   induction s using Finset.induction_on with
   | empty => rw [Finset.sum_empty, ← Finset.iSup_coe, Finset.coe_empty, iSup_emptyset,
     expGrowthSup_zero]
-  | @insert a t a_t ha => rw [Finset.sum_insert a_t, expGrowthSup_add, ← Finset.iSup_coe,
+  | insert a t a_t ha => rw [Finset.sum_insert a_t, expGrowthSup_add, ← Finset.iSup_coe,
     Finset.coe_insert a t, iSup_insert, Finset.iSup_coe, ha]
 
 end basic_properties

--- a/Mathlib/Analysis/Calculus/ContDiff/Bounds.lean
+++ b/Mathlib/Analysis/Calculus/ContDiff/Bounds.lean
@@ -296,7 +296,7 @@ theorem norm_iteratedFDerivWithin_prod_le [DecidableEq ι] [NormOneClass A'] {u 
     cases n with
     | zero => simp [Sym.eq_nil_of_card_zero]
     | succ n => simp [iteratedFDerivWithin_succ_const]
-  | @insert i u hi IH =>
+  | insert i u hi IH =>
     conv => lhs; simp only [Finset.prod_insert hi]
     simp only [Finset.mem_insert, forall_eq_or_imp] at hf
     refine le_trans (norm_iteratedFDerivWithin_mul_le hf.1 (contDiffOn_prod hf.2) hs hx hn) ?_

--- a/Mathlib/Analysis/Convex/Exposed.lean
+++ b/Mathlib/Analysis/Convex/Exposed.lean
@@ -139,7 +139,7 @@ theorem sInter [IsOrderedRing 𝕜] [ContinuousAdd 𝕜] {F : Finset (Set E)} (h
   classical
   induction F using Finset.induction with
   | empty => exfalso; exact Finset.not_nonempty_empty hF
-  | @insert C F _ hF' =>
+  | insert C F _ hF' =>
     rw [Finset.coe_insert, sInter_insert]
     obtain rfl | hFnemp := F.eq_empty_or_nonempty
     · rw [Finset.coe_empty, sInter_empty, inter_univ]

--- a/Mathlib/Analysis/Normed/Group/Ultra.lean
+++ b/Mathlib/Analysis/Normed/Group/Ultra.lean
@@ -293,7 +293,7 @@ theorem exists_norm_multiset_prod_le (s : Multiset ι) [Nonempty ι] {f : ι →
   inhabit ι
   induction s using Multiset.induction_on with
   | empty => simp
-  | @cons a t hM =>
+  | cons a t hM =>
       obtain ⟨M, hMs, hM⟩ := hM
       by_cases hMa : ‖f M‖ ≤ ‖f a‖
       · refine ⟨a, by simp, ?_⟩

--- a/Mathlib/Analysis/SpecialFunctions/Log/PosLog.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Log/PosLog.lean
@@ -116,7 +116,7 @@ theorem posLog_prod {α : Type*} (s : Finset α) (f : α → ℝ) :
   classical
   induction s using Finset.induction with
   | empty => simp [posLog]
-  | @insert a s ha hs =>
+  | insert a s ha hs =>
     calc log⁺ (∏ t ∈ insert a s, f t)
     _ = log⁺ (f a * ∏ t ∈ s, f t) := by rw [Finset.prod_insert ha]
     _ ≤ log⁺ (f a) + log⁺ (∏ t ∈ s, f t) := posLog_mul

--- a/Mathlib/Analysis/SpecialFunctions/Log/Summable.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Log/Summable.lean
@@ -132,7 +132,7 @@ lemma Finset.norm_prod_one_add_sub_one_le (t : Finset ι) (f : ι → R) :
   classical
   induction t using Finset.induction_on with
   | empty => simp
-  | @insert x t hx IH =>
+  | insert x t hx IH =>
     rw [Finset.prod_insert hx, Finset.sum_insert hx, Real.exp_add,
       show (1 + f x) * ∏ i ∈ t, (1 + f i) - 1 =
         (∏ i ∈ t, (1 + f i) - 1) + f x * ∏ x ∈ t, (1 + f x) by ring]

--- a/Mathlib/Analysis/SpecialFunctions/Pow/NNReal.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Pow/NNReal.lean
@@ -680,7 +680,7 @@ theorem prod_rpow_of_ne_top {ι} {s : Finset ι} {f : ι → ℝ≥0∞} (hf : �
   classical
   induction s using Finset.induction with
   | empty => simp
-  | @insert i s hi ih =>
+  | insert i s hi ih =>
     have h2f : ∀ i ∈ s, f i ≠ ∞ := fun i hi ↦ hf i <| mem_insert_of_mem hi
     rw [prod_insert hi, prod_insert hi, ih h2f, ← mul_rpow_of_ne_top <| hf i <| mem_insert_self ..]
     apply prod_ne_top h2f

--- a/Mathlib/Analysis/SpecialFunctions/Pow/NNReal.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Pow/NNReal.lean
@@ -667,7 +667,7 @@ theorem prod_coe_rpow {ι} (s : Finset ι) (f : ι → ℝ≥0) (r : ℝ) :
   classical
   induction s using Finset.induction with
   | empty => simp
-  | insert hi ih => simp_rw [prod_insert hi, ih, ← coe_mul_rpow, coe_mul]
+  | insert _ _ hi ih => simp_rw [prod_insert hi, ih, ← coe_mul_rpow, coe_mul]
 
 theorem mul_rpow_of_ne_zero {x y : ℝ≥0∞} (hx : x ≠ 0) (hy : y ≠ 0) (z : ℝ) :
     (x * y) ^ z = x ^ z * y ^ z := by simp [*, mul_rpow_eq_ite]
@@ -690,7 +690,7 @@ theorem prod_rpow_of_nonneg {ι} {s : Finset ι} {f : ι → ℝ≥0∞} {r : �
   classical
   induction s using Finset.induction with
   | empty => simp
-  | insert hi ih => simp_rw [prod_insert hi, ih, ← mul_rpow_of_nonneg _ _ hr]
+  | insert _ _ hi ih => simp_rw [prod_insert hi, ih, ← mul_rpow_of_nonneg _ _ hr]
 
 theorem inv_rpow (x : ℝ≥0∞) (y : ℝ) : x⁻¹ ^ y = (x ^ y)⁻¹ := by
   rcases eq_or_ne y 0 with (rfl | hy); · simp only [rpow_zero, inv_one]

--- a/Mathlib/CategoryTheory/Subobject/Lattice.lean
+++ b/Mathlib/CategoryTheory/Subobject/Lattice.lean
@@ -387,7 +387,7 @@ theorem finset_inf_factors {I : Type*} {A B : C} {s : Finset I} {P : I → Subob
   classical
   induction s using Finset.induction_on with
   | empty => simp [top_factors]
-  | insert _ ih => simp [ih]
+  | insert _ _ _ ih => simp [ih]
 
 -- `i` is explicit here because often we'd like to defer a proof of `m`
 theorem finset_inf_arrow_factors {I : Type*} {B : C} (s : Finset I) (P : I → Subobject B) (i : I)
@@ -396,7 +396,7 @@ theorem finset_inf_arrow_factors {I : Type*} {B : C} (s : Finset I) (P : I → S
   revert i m
   induction s using Finset.induction_on with
   | empty => rintro _ ⟨⟩
-  | insert _ ih =>
+  | insert _ _ _ ih =>
     intro _ m
     rw [Finset.inf_insert]
     simp only [Finset.mem_insert] at m
@@ -481,7 +481,7 @@ theorem finset_sup_factors {I : Type*} {A B : C} {s : Finset I} {P : I → Subob
   revert h
   induction s using Finset.induction_on with
   | empty => rintro ⟨_, ⟨⟨⟩, _⟩⟩
-  | insert _ ih =>
+  | insert _ _ _ ih =>
     rintro ⟨j, ⟨m, h⟩⟩
     simp only [Finset.sup_insert]
     simp only [Finset.mem_insert] at m

--- a/Mathlib/Combinatorics/Additive/PluenneckeRuzsa.lean
+++ b/Mathlib/Combinatorics/Additive/PluenneckeRuzsa.lean
@@ -120,8 +120,7 @@ theorem pluennecke_petridis_inequality_mul (C : Finset G)
     #(C * A * B) * #A ≤ #(A * B) * #(C * A) := by
   induction C using Finset.induction_on with
   | empty => simp
-  | insert _ ih =>
-    rename_i x C _
+  | insert x C _ ih =>
     set A' := A ∩ ({x}⁻¹ * C * A) with hA'
     set C' := insert x C with hC'
     have h₀ : {x} * A' = {x} * A ∩ (C * A) := by

--- a/Mathlib/Combinatorics/SetFamily/Compression/Down.lean
+++ b/Mathlib/Combinatorics/SetFamily/Compression/Down.lean
@@ -169,8 +169,7 @@ lemma memberFamily_induction_on {p : Finset (Finset α) → Prop}
     simp_rw [subset_empty] at hu
     rw [← subset_singleton_iff', subset_singleton_iff] at hu
     obtain rfl | rfl := hu <;> assumption
-  | insert _ ih =>
-    rename_i a u _
+  | insert a u _ ih =>
     refine subfamily a (ih _ ?_) (ih _ ?_)
     · simp only [mem_nonMemberSubfamily, and_imp]
       exact fun s hs has ↦ (subset_insert_iff_of_not_mem has).1 <| hu _ hs

--- a/Mathlib/Combinatorics/SetFamily/FourFunctions.lean
+++ b/Mathlib/Combinatorics/SetFamily/FourFunctions.lean
@@ -251,8 +251,7 @@ protected lemma Finset.four_functions_theorem (u : Finset α)
   | empty =>
     simp only [Finset.powerset_empty, Finset.subset_singleton_iff] at h𝒜 hℬ
     obtain rfl | rfl := h𝒜 <;> obtain rfl | rfl := hℬ <;> simp; exact h (subset_refl ∅) subset_rfl
-  | insert hu ih =>
-    rename_i a u
+  | insert a u hu ih =>
     specialize ih (collapse_nonneg h₁) (collapse_nonneg h₂) (collapse_nonneg h₃)
       (collapse_nonneg h₄) (collapse_modular hu h₁ h₂ h₃ h₄ h 𝒜 ℬ) Subset.rfl Subset.rfl
     have : 𝒜 ⊼ ℬ ⊆ powerset (insert a u) := by simpa using infs_subset h𝒜 hℬ

--- a/Mathlib/Combinatorics/SetFamily/HarrisKleitman.lean
+++ b/Mathlib/Combinatorics/SetFamily/HarrisKleitman.lean
@@ -60,8 +60,7 @@ theorem IsLowerSet.le_card_inter_finset' (h𝒜 : IsLowerSet (𝒜 : Set (Finset
     · simp only [card_empty, inter_empty, mul_zero, zero_mul, le_refl]
     · simp only [card_empty, pow_zero, inter_singleton_of_mem, mem_singleton, card_singleton,
         le_refl]
-  | insert hs ih =>
-  rename_i a s
+  | insert a s hs ih =>
   rw [card_insert_of_not_mem hs, ← card_memberSubfamily_add_card_nonMemberSubfamily a 𝒜, ←
     card_memberSubfamily_add_card_nonMemberSubfamily a ℬ, add_mul, mul_add, mul_add,
     add_comm (_ * _), add_add_add_comm]

--- a/Mathlib/Data/Finset/Insert.lean
+++ b/Mathlib/Data/Finset/Insert.lean
@@ -487,14 +487,14 @@ theorem cons_induction {α : Type*} {motive : Finset α → Prop} (empty : motiv
 
 @[elab_as_elim]
 theorem cons_induction_on {α : Type*} {motive : Finset α → Prop} (s : Finset α) (empty : motive ∅)
-    (cons : ∀ ⦃a : α⦄ {s : Finset α} (h : a ∉ s), motive s → motive (cons a s h)) : motive s :=
+    (cons : ∀ (a : α) (s : Finset α) (h : a ∉ s), motive s → motive (cons a s h)) : motive s :=
   cons_induction empty cons s
 
 @[elab_as_elim]
 protected theorem induction {α : Type*} {motive : Finset α → Prop} [DecidableEq α]
     (empty : motive ∅)
-    (insert : ∀ ⦃a : α⦄ {s : Finset α}, a ∉ s → motive s → motive (insert a s)) : ∀ s, motive s :=
-  cons_induction empty fun a s ha => (s.cons_eq_insert a ha).symm ▸ insert ha
+    (insert : ∀ (a : α) (s : Finset α), a ∉ s → motive s → motive (insert a s)) : ∀ s, motive s :=
+  cons_induction empty fun a s ha => (s.cons_eq_insert a ha).symm ▸ insert a s ha
 
 /-- To prove a proposition about an arbitrary `Finset α`,
 it suffices to prove it for the empty `Finset`,
@@ -504,7 +504,7 @@ then it holds for the `Finset` obtained by inserting a new element.
 @[elab_as_elim]
 protected theorem induction_on {α : Type*} {motive : Finset α → Prop} [DecidableEq α] (s : Finset α)
     (empty : motive ∅)
-    (insert : ∀ ⦃a : α⦄ {s : Finset α}, a ∉ s → motive s → motive (insert a s)) : motive s :=
+    (insert : ∀ (a : α) (s : Finset α), a ∉ s → motive s → motive (insert a s)) : motive s :=
   Finset.induction empty insert s
 
 /-- To prove a proposition about `S : Finset α`,

--- a/Mathlib/Data/Finset/Insert.lean
+++ b/Mathlib/Data/Finset/Insert.lean
@@ -515,11 +515,11 @@ then it holds for the `Finset` obtained by inserting a new element of `S`.
 @[elab_as_elim]
 theorem induction_on' {α : Type*} {motive : Finset α → Prop} [DecidableEq α] (S : Finset α)
     (empty : motive ∅)
-    (insert : ∀ {a s}, a ∈ S → s ⊆ S → a ∉ s → motive s → motive (insert a s)) : motive S :=
+    (insert : ∀ (a s), a ∈ S → s ⊆ S → a ∉ s → motive s → motive (insert a s)) : motive S :=
   @Finset.induction_on α (fun T => T ⊆ S → motive T) _ S (fun _ => empty)
-    (fun _ _ has hqs hs =>
+    (fun a s has hqs hs =>
       let ⟨hS, sS⟩ := Finset.insert_subset_iff.1 hs
-      insert hS sS has (hqs sS))
+      insert a s hS sS has (hqs sS))
     (Finset.Subset.refl S)
 
 /-- To prove a proposition about a nonempty `s : Finset α`, it suffices to show it holds for all

--- a/Mathlib/Data/Finset/Lattice/Fold.lean
+++ b/Mathlib/Data/Finset/Lattice/Fold.lean
@@ -198,7 +198,7 @@ theorem sup_le_of_le_directed {α : Type*} [SemilatticeSup α] [OrderBot α] (s 
     | empty =>
       simpa only [forall_prop_of_true, and_true, forall_prop_of_false, bot_le, not_false_iff,
         sup_empty, forall_true_iff, not_mem_empty]
-    | @insert a r _ ih =>
+    | insert a r _ ih =>
       intro h
       have incs : (r : Set α) ⊆ ↑(insert a r) := by
         rw [Finset.coe_subset]
@@ -610,7 +610,7 @@ theorem sup_mem_of_nonempty (hs : s.Nonempty) : s.sup f ∈ f '' s := by
   classical
   induction s using Finset.induction with
   | empty => exfalso; simp only [Finset.not_nonempty_empty] at hs
-  | @insert a s _ h =>
+  | insert a s _ h =>
     rw [Finset.sup_insert (b := a) (s := s) (f := f)]
     cases s.eq_empty_or_nonempty with
     | inl hs => simp [hs]

--- a/Mathlib/FieldTheory/IntermediateField/Adjoin/Defs.lean
+++ b/Mathlib/FieldTheory/IntermediateField/Adjoin/Defs.lean
@@ -664,7 +664,7 @@ theorem induction_on_adjoin_finset (S : Finset E) (P : IntermediateField F E →
     (ih : ∀ (K : IntermediateField F E), ∀ x ∈ S, P K → P (K⟮x⟯.restrictScalars F)) :
     P (adjoin F S) := by
   classical
-  refine Finset.induction_on' S ?_ (fun ha _ _ h => ?_)
+  refine Finset.induction_on' S ?_ (fun _ _ ha _ _ h => ?_)
   · simp [base]
   · rw [Finset.coe_insert, Set.insert_eq, Set.union_comm, ← adjoin_adjoin_left]
     exact ih (adjoin F _) _ ha h

--- a/Mathlib/GroupTheory/Perm/Cycle/Type.lean
+++ b/Mathlib/GroupTheory/Perm/Cycle/Type.lean
@@ -248,7 +248,7 @@ theorem Disjoint.cycleType_noncommProd {ι : Type*} {k : ι → Perm α} {s : Fi
   classical
   induction s using Finset.induction_on with
   | empty => simp
-  | @insert i s hi hrec =>
+  | insert i s hi hrec =>
     have hs' : (s : Set ι).Pairwise fun i j ↦ Disjoint (k i) (k j) :=
       hs.mono (by simp only [Finset.coe_insert, Set.subset_insert])
     rw [Finset.noncommProd_insert_of_not_mem _ _ _ _ hi, Finset.sum_insert hi]

--- a/Mathlib/GroupTheory/Perm/Support.lean
+++ b/Mathlib/GroupTheory/Perm/Support.lean
@@ -435,7 +435,7 @@ theorem support_noncommProd {ι : Type*} {k : ι → Perm α} {s : Finset ι}
   classical
   induction s using Finset.induction_on with
   | empty => simp
-  | @insert i s hi hrec =>
+  | insert i s hi hrec =>
     have hs' : (s : Set ι).Pairwise fun i j ↦ Disjoint (k i) (k j) :=
       hs.mono (by simp only [Finset.coe_insert, Set.subset_insert])
     rw [Finset.noncommProd_insert_of_not_mem _ _ _ _ hi, Finset.biUnion_insert]

--- a/Mathlib/LinearAlgebra/Eigenspace/Basic.lean
+++ b/Mathlib/LinearAlgebra/Eigenspace/Basic.lean
@@ -676,7 +676,7 @@ theorem independent_genEigenspace [NoZeroSMulDivisors R M] (f : End R M) (k : �
   intro μ₁ s
   induction s using Finset.induction_on with
   | empty => simp
-  | @insert μ₂ s _ ih =>
+  | insert μ₂ s _ ih =>
   intro hμ₁₂
   obtain ⟨hμ₁₂ : μ₁ ≠ μ₂, hμ₁ : μ₁ ∉ s⟩ := by rwa [Finset.mem_insert, not_or] at hμ₁₂
   specialize ih hμ₁

--- a/Mathlib/LinearAlgebra/Eigenspace/Pi.lean
+++ b/Mathlib/LinearAlgebra/Eigenspace/Pi.lean
@@ -100,7 +100,7 @@ lemma independent_iInf_maxGenEigenspace_of_forall_mapsTo
   intro χ₁ s
   induction s using Finset.induction_on with
   | empty => simp
-  | @insert χ₂ s _n ih =>
+  | insert χ₂ s _n ih =>
   intro hχ₁₂
   obtain ⟨hχ₁₂ : χ₁ ≠ χ₂, hχ₁ : χ₁ ∉ s⟩ := by rwa [Finset.mem_insert, not_or] at hχ₁₂
   specialize ih hχ₁

--- a/Mathlib/LinearAlgebra/FiniteDimensional/Basic.lean
+++ b/Mathlib/LinearAlgebra/FiniteDimensional/Basic.lean
@@ -352,7 +352,7 @@ theorem ker_noncommProd_eq_of_supIndep_ker [FiniteDimensional K V] {ι : Type*} 
   classical
   induction s using Finset.induction_on with
   | empty => simp [Module.End.one_eq_id]
-  | @insert i s hi ih =>
+  | insert i s hi ih =>
     replace ih : ker (Finset.noncommProd s f <| Set.Pairwise.mono (s.subset_insert i) comm) =
         ⨆ x ∈ s, ker (f x) := ih _ (h.subset (s.subset_insert i))
     rw [Finset.noncommProd_insert_of_not_mem _ _ _ _ hi, Module.End.mul_eq_comp,

--- a/Mathlib/LinearAlgebra/LinearIndependent/Basic.lean
+++ b/Mathlib/LinearAlgebra/LinearIndependent/Basic.lean
@@ -517,7 +517,7 @@ theorem linearIndependent_monoidHom (G : Type*) [MulOneClass G] (L : Type*) [Com
   intro s
   induction s using Finset.induction_on with
   | empty => simp
-  | @insert a s has ih =>
+  | insert a s has ih =>
   intro g hg
   -- Here
   -- * `a` is a new character we will insert into the `Finset` of characters `s`,

--- a/Mathlib/LinearAlgebra/LinearIndependent/Lemmas.lean
+++ b/Mathlib/LinearAlgebra/LinearIndependent/Lemmas.lean
@@ -375,7 +375,7 @@ theorem linearIndepOn_id_iUnion_finite {f : ι → Set M} (hl : ∀ i, LinearInd
   intro t
   induction t using Finset.induction_on with
   | empty => simp
-  | @insert i s his ih =>
+  | insert i s his ih =>
     rw [Finset.set_biUnion_insert]
     refine (hl _).id_union ih ?_
     rw [span_iUnion₂]

--- a/Mathlib/LinearAlgebra/Matrix/Determinant/Basic.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Determinant/Basic.lean
@@ -418,7 +418,7 @@ theorem det_updateRow_sum_aux (M : Matrix n n R) {j : n} (s : Finset n) (hj : j 
     (M.updateRow j (a • M j + ∑ k ∈ s, (c k) • M k)).det = a • M.det := by
   induction s using Finset.induction_on with
   | empty => rw [Finset.sum_empty, add_zero, smul_eq_mul, det_updateRow_smul, updateRow_eq_self]
-  | @insert k _ hk h_ind =>
+  | insert k _ hk h_ind =>
       have h : k ≠ j := fun h ↦ (h ▸ hj) (Finset.mem_insert_self _ _)
       rw [Finset.sum_insert hk, add_comm ((c k) • M k), ← add_assoc, det_updateRow_add,
         det_updateRow_smul, det_updateRow_eq_zero h, mul_zero, add_zero, h_ind]
@@ -515,7 +515,7 @@ theorem det_eq_of_forall_row_eq_smul_add_const_aux {A B : Matrix n n R} {s : Fin
     congr
     ext i j
     rw [A_eq, this, zero_mul, add_zero]
-  | @insert i s _hi ih =>
+  | insert i s _hi ih =>
     intro c hs k hk A_eq
     have hAi : A i = B i + c i • B k := funext (A_eq i)
     rw [@ih (updateRow B i (A i)) (Function.update c i 0), hAi, det_updateRow_add_smul_self]

--- a/Mathlib/LinearAlgebra/Multilinear/Basic.lean
+++ b/Mathlib/LinearAlgebra/Multilinear/Basic.lean
@@ -603,7 +603,7 @@ theorem map_update_sum {α : Type*} [DecidableEq ι] (t : Finset α) (i : ι) (g
   classical
     induction t using Finset.induction with
     | empty => simp
-    | insert has ih => simp [Finset.sum_insert has, ih]
+    | insert _ _ has ih => simp [Finset.sum_insert has, ih]
 
 end ApplySum
 

--- a/Mathlib/LinearAlgebra/TensorProduct/Basic.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Basic.lean
@@ -432,14 +432,14 @@ theorem sum_tmul {α : Type*} (s : Finset α) (m : α → M) (n : N) :
   classical
     induction s using Finset.induction with
     | empty => simp
-    | insert has ih => simp [Finset.sum_insert has, add_tmul, ih]
+    | insert _ _ has ih => simp [Finset.sum_insert has, add_tmul, ih]
 
 theorem tmul_sum (m : M) {α : Type*} (s : Finset α) (n : α → N) :
     (m ⊗ₜ[R] ∑ a ∈ s, n a) = ∑ a ∈ s, m ⊗ₜ[R] n a := by
   classical
     induction s using Finset.induction with
     | empty => simp
-    | insert has ih => simp [Finset.sum_insert has, tmul_add, ih]
+    | insert _ _ has ih => simp [Finset.sum_insert has, tmul_add, ih]
 
 end
 

--- a/Mathlib/MeasureTheory/Function/ConditionalExpectation/Basic.lean
+++ b/Mathlib/MeasureTheory/Function/ConditionalExpectation/Basic.lean
@@ -338,7 +338,7 @@ theorem condExp_finset_sum {ι : Type*} {s : Finset ι} {f : ι → α → E}
   classical
   induction s using Finset.induction_on with
   | empty => rw [Finset.sum_empty, Finset.sum_empty, condExp_zero]
-  | @insert i s his heq =>
+  | insert i s his heq =>
     rw [Finset.sum_insert his, Finset.sum_insert his]
     exact (condExp_add (hf i <| Finset.mem_insert_self i s)
       (integrable_finset_sum' _ <| Finset.forall_of_forall_insert hf) _).trans

--- a/Mathlib/MeasureTheory/Function/SimpleFunc.lean
+++ b/Mathlib/MeasureTheory/Function/SimpleFunc.lean
@@ -1163,7 +1163,7 @@ protected theorem induction {α γ} [MeasurableSpace α] [AddZeroClass γ]
     convert const 0 MeasurableSet.univ
     ext x
     simp [h]
-  | @insert x s hxs ih =>
+  | insert x s hxs ih =>
     have mx := f.measurableSet_preimage {x}
     let g := SimpleFunc.piecewise (f ⁻¹' {x}) mx 0 f
     have Pg : motive g := by
@@ -1205,7 +1205,7 @@ protected theorem induction' {α γ} [MeasurableSpace α] [Nonempty γ] {P : Sim
     convert const c
     ext x
     simp [h]
-  | @insert x s hxs ih =>
+  | insert x s hxs ih =>
     have mx := f.measurableSet_preimage {x}
     let g := SimpleFunc.piecewise (f ⁻¹' {x}) mx (SimpleFunc.const α c) f
     have Pg : P g := by

--- a/Mathlib/MeasureTheory/Integral/Bochner/Basic.lean
+++ b/Mathlib/MeasureTheory/Integral/Bochner/Basic.lean
@@ -947,7 +947,7 @@ theorem integral_finset_sum_measure {ι} {m : MeasurableSpace α} {f : α → G}
     ∫ a, f a ∂(∑ i ∈ s, μ i) = ∑ i ∈ s, ∫ a, f a ∂μ i := by
   induction s using Finset.cons_induction_on with
   | empty => simp
-  | cons h ih =>
+  | cons _ _ h ih =>
     rw [Finset.forall_mem_cons] at hf
     rw [Finset.sum_cons, Finset.sum_cons, ← ih hf.2]
     exact integral_add_measure hf.1 (integrable_finset_sum_measure.2 hf.2)

--- a/Mathlib/MeasureTheory/Integral/Bochner/Set.lean
+++ b/Mathlib/MeasureTheory/Integral/Bochner/Set.lean
@@ -103,7 +103,7 @@ theorem integral_finset_biUnion {ι : Type*} (t : Finset ι) {s : ι → Set X}
   classical
   induction t using Finset.induction_on with
   | empty => simp
-  | insert hat IH =>
+  | insert _ _ hat IH =>
     simp only [Finset.coe_insert, Finset.forall_mem_insert, Set.pairwise_insert,
       Finset.set_biUnion_insert] at hs hf h's ⊢
     rw [setIntegral_union _ _ hf.1 (integrableOn_finset_iUnion.2 hf.2)]

--- a/Mathlib/MeasureTheory/Integral/Marginal.lean
+++ b/Mathlib/MeasureTheory/Integral/Marginal.lean
@@ -216,7 +216,7 @@ theorem lmarginal_update_of_not_mem {i : δ}
     (∫⋯∫⁻_s, f ∂μ) (Function.update x i y) = (∫⋯∫⁻_s, f ∘ (Function.update · i y) ∂μ) x := by
   induction s using Finset.induction generalizing x with
   | empty => simp
-  | @insert i' s hi' ih =>
+  | insert i' s hi' ih =>
     rw [lmarginal_insert _ hf hi', lmarginal_insert _ (hf.comp measurable_update_left) hi']
     have hii' : i ≠ i' := mt (by rintro rfl; exact mem_insert_self i s) hi
     simp_rw [update_comm hii', ih (mt Finset.mem_insert_of_mem hi)]

--- a/Mathlib/MeasureTheory/Integral/Marginal.lean
+++ b/Mathlib/MeasureTheory/Integral/Marginal.lean
@@ -206,7 +206,7 @@ theorem lmarginal_image [DecidableEq δ'] {e : δ' → δ} (he : Injective e) (s
     measurable_pi_iff.mpr <| fun i ↦ measurable_pi_apply (e i)
   induction s using Finset.induction generalizing x with
   | empty => simp
-  | insert hi ih =>
+  | insert _ _ hi ih =>
     rw [image_insert, lmarginal_insert _ (hf.comp h) (he.mem_finset_image.not.mpr hi),
       lmarginal_insert _ hf hi]
     simp_rw [ih, ← update_comp_eq_of_injective' x he]

--- a/Mathlib/MeasureTheory/Integral/MeanInequalities.lean
+++ b/Mathlib/MeasureTheory/Integral/MeanInequalities.lean
@@ -193,7 +193,7 @@ theorem lintegral_prod_norm_pow_le {α ι : Type*} [MeasurableSpace α] {μ : Me
   induction s using Finset.induction generalizing p with
   | empty =>
     simp at hp
-  | @insert i₀ s hi₀ ih =>
+  | insert i₀ s hi₀ ih =>
     rcases eq_or_ne (p i₀) 1 with h2i₀|h2i₀
     · simp only [hi₀, not_false_eq_true, prod_insert]
       have h2p : ∀ i ∈ s, p i = 0 := by

--- a/Mathlib/MeasureTheory/Measure/AddContent.lean
+++ b/Mathlib/MeasureTheory/Measure/AddContent.lean
@@ -307,7 +307,7 @@ lemma addContent_biUnion_le {ι : Type*} (hC : IsSetRing C) {s : ι → Set α}
   classical
   induction S using Finset.induction with
   | empty => simp
-  | @insert i S hiS h =>
+  | insert i S hiS h =>
     rw [Finset.sum_insert hiS]
     simp_rw [← Finset.mem_coe, Finset.coe_insert, Set.biUnion_insert]
     simp only [Finset.mem_insert, forall_eq_or_imp] at hs
@@ -352,7 +352,7 @@ def IsSetRing.addContent_of_union (m : Set α → ℝ≥0∞) (hC : IsSetRing C)
     classical
     induction I using Finset.induction with
     | empty => simp only [Finset.coe_empty, Set.sUnion_empty, Finset.sum_empty, m_empty]
-    | @insert s I hsI h =>
+    | insert s I hsI h =>
       rw [Finset.coe_insert] at *
       rw [Set.insert_subset_iff] at h_ss
       rw [Set.pairwiseDisjoint_insert_of_not_mem] at h_dis

--- a/Mathlib/MeasureTheory/Measure/Hausdorff.lean
+++ b/Mathlib/MeasureTheory/Measure/Hausdorff.lean
@@ -143,7 +143,7 @@ theorem finset_iUnion_of_pairwise_separated (hm : IsMetric μ) {I : Finset ι} {
   classical
   induction I using Finset.induction_on with
   | empty => simp
-  | @insert i I hiI ihI =>
+  | insert i I hiI ihI =>
     simp only [Finset.mem_insert] at hI
     rw [Finset.set_biUnion_insert, hm, ihI, Finset.sum_insert hiI]
     exacts [fun i hi j hj hij => hI i (Or.inr hi) j (Or.inr hj) hij,

--- a/Mathlib/MeasureTheory/Measure/Real.lean
+++ b/Mathlib/MeasureTheory/Measure/Real.lean
@@ -144,7 +144,7 @@ theorem measureReal_biUnion_finset_le (s : Finset β) (f : β → Set α) :
   classical
   induction s using Finset.induction_on with
   | empty => simp
-  | insert hx IH =>
+  | insert _ _ hx IH =>
     simp only [hx, Finset.mem_insert, iUnion_iUnion_eq_or_left, not_false_eq_true,
       Finset.sum_insert]
     exact (measureReal_union_le _ _).trans (by gcongr)

--- a/Mathlib/MeasureTheory/OuterMeasure/Caratheodory.lean
+++ b/Mathlib/MeasureTheory/OuterMeasure/Caratheodory.lean
@@ -80,7 +80,7 @@ lemma IsCaratheodory.biUnion_of_finite {ι : Type*} {s : ι → Set α} {t : Set
   lift t to Finset ι using ht
   induction t using Finset.induction_on with
   | empty => simp
-  | @insert i t hi IH =>
+  | insert i t hi IH =>
     simp only [Finset.mem_coe, Finset.mem_insert, iUnion_iUnion_eq_or_left] at h ⊢
     exact m.isCaratheodory_union (h _ <| Or.inl rfl) (IH fun _ hj ↦ h _ <| Or.inr hj)
 

--- a/Mathlib/MeasureTheory/SetSemiring.lean
+++ b/Mathlib/MeasureTheory/SetSemiring.lean
@@ -156,7 +156,7 @@ lemma exists_disjoint_finset_diff_eq (hC : IsSetSemiring C) (hs : s ∈ C) (hI :
     refine ⟨{s}, singleton_subset_set_iff.mpr hs, ?_⟩
     simp only [coe_singleton, pairwiseDisjoint_singleton, sUnion_singleton, eq_self_iff_true,
       and_self_iff]
-  | @insert t I' _ h => ?_
+  | insert t I' _ h => ?_
 
   rw [coe_insert] at hI
   have ht : t ∈ C := hI (Set.mem_insert _ _)
@@ -465,7 +465,7 @@ lemma biUnion_mem {ι : Type*} (hC : IsSetRing C) {s : ι → Set α}
   classical
   induction S using Finset.induction with
   | empty => simp [hC.empty_mem]
-  | @insert i S _ h =>
+  | insert i S _ h =>
     simp_rw [← Finset.mem_coe, Finset.coe_insert, Set.biUnion_insert]
     refine hC.union_mem (hs i (mem_insert_self i S)) ?_
     exact h (fun n hnS ↦ hs n (mem_insert_of_mem hnS))
@@ -488,7 +488,7 @@ lemma finsetSup_mem (hC : IsSetRing C) {ι : Type*} {s : ι → Set α} {t : Fin
   classical
   induction t using Finset.induction_on with
   | empty => exact hC.empty_mem
-  | @insert m t hm ih =>
+  | insert m t hm ih =>
     simpa only [sup_insert] using
       hC.union_mem (hs m <| mem_insert_self m t) (ih <| fun i hi ↦ hs _ <| mem_insert_of_mem hi)
 

--- a/Mathlib/NumberTheory/ArithmeticFunction.lean
+++ b/Mathlib/NumberTheory/ArithmeticFunction.lean
@@ -557,7 +557,7 @@ theorem map_prod {ι : Type*} [CommMonoidWithZero R] (g : ι → ℕ) {f : Arith
   classical
     induction s using Finset.induction_on with
     | empty => simp [hf]
-    | insert has ih =>
+    | insert _ _ has ih =>
       rw [coe_insert, Set.pairwise_insert_of_symmetric (Coprime.symmetric.comap g)] at hs
       rw [prod_insert has, prod_insert has, hf.map_mul_of_coprime, ih hs.1]
       exact .prod_right fun i hi => hs.2 _ hi (hi.ne_of_not_mem has).symm

--- a/Mathlib/NumberTheory/EulerProduct/Basic.lean
+++ b/Mathlib/NumberTheory/EulerProduct/Basic.lean
@@ -87,7 +87,7 @@ lemma summable_and_hasSum_factoredNumbers_prod_filter_prime_tsum
     rw [factoredNumbers_empty]
     simp only [not_mem_empty, IsEmpty.forall_iff, forall_const, filter_true_of_mem, prod_empty]
     exact ⟨(Set.finite_singleton 1).summable (‖f ·‖), hf₁ ▸ hasSum_singleton 1 f⟩
-  | @insert p s hp ih =>
+  | insert p s hp ih =>
     rw [filter_insert]
     split_ifs with hpp
     · constructor

--- a/Mathlib/Order/Disjointed.lean
+++ b/Mathlib/Order/Disjointed.lean
@@ -96,7 +96,7 @@ lemma disjointedRec {f : ι → α} {p : α → Prop} (hdiff : ∀ ⦃t i⦄, p 
   intro s
   induction s using Finset.induction with
   | empty => simpa only [sup_empty, sdiff_bot] using hpi
-  | insert ht IH =>
+  | insert _ _ ht IH =>
     rw [sup_insert, sup_comm, ← sdiff_sdiff]
     exact hdiff IH
 

--- a/Mathlib/Order/Filter/Finite.lean
+++ b/Mathlib/Order/Filter/Finite.lean
@@ -226,7 +226,7 @@ theorem iInf_sets_induct {f : ι → Filter α} {s : Set α} (hs : s ∈ iInf f)
   rcases hs with ⟨is, his⟩
   induction is using Finset.induction_on generalizing s with
   | empty => rwa [mem_top.1 his]
-  | insert _ ih =>
+  | insert _ _ _ ih =>
     rw [Finset.inf_insert, mem_inf_iff] at his
     rcases his with ⟨s₁, hs₁, s₂, hs₂, rfl⟩
     exact ins hs₁ (ih hs₂)

--- a/Mathlib/Probability/Moments/SubGaussian.lean
+++ b/Mathlib/Probability/Moments/SubGaussian.lean
@@ -554,7 +554,7 @@ private lemma sum_of_iIndepFun_of_forall_aemeasurable
   classical
   induction s using Finset.induction_on with
   | empty => simp
-  | @insert i s his h =>
+  | insert i s his h =>
     simp_rw [← Finset.sum_apply, Finset.sum_insert his, Pi.add_apply, Finset.sum_apply]
     have h_indep' := (h_indep.indepFun_finset_sum_of_not_mem₀ h_meas his).symm
     refine add_of_indepFun (h_subG _ (Finset.mem_insert_self _ _)) (h ?_) ?_

--- a/Mathlib/RingTheory/DividedPowers/Basic.lean
+++ b/Mathlib/RingTheory/DividedPowers/Basic.lean
@@ -264,7 +264,7 @@ theorem prod_dpow {ι : Type*} {s : Finset ι} {n : ι → ℕ} (ha : a ∈ I) :
   | empty =>
     simp only [prod_empty, multinomial_empty, cast_one, sum_empty, one_mul]
     rw [hI.dpow_zero ha]
-  | insert hi hrec =>
+  | insert _ _ hi hrec =>
     rw [prod_insert hi, hrec, ← mul_assoc, mul_comm (hI.dpow (n _) a),
       mul_assoc, hI.mul_dpow ha, ← sum_insert hi, ← mul_assoc]
     apply congr_arg₂ _ _ rfl

--- a/Mathlib/RingTheory/DividedPowers/Basic.lean
+++ b/Mathlib/RingTheory/DividedPowers/Basic.lean
@@ -292,7 +292,7 @@ theorem dpow_sum' {M : Type*} [AddCommMonoid M] {I : AddSubmonoid M} (dpow : ℕ
       apply congr_arg
       rw [card_eq_zero, sym_eq_empty]
       exact ⟨hn, rfl⟩
-  | @insert a s ha ih =>
+  | insert a s ha ih =>
     -- This should be golfable using `Finset.symInsertEquiv`
     have hx' : ∀ i, i ∈ s → x i ∈ I := fun i hi ↦ hx i (mem_insert_of_mem hi)
     simp_rw [sum_insert ha,

--- a/Mathlib/RingTheory/Finiteness/Basic.lean
+++ b/Mathlib/RingTheory/Finiteness/Basic.lean
@@ -109,7 +109,7 @@ theorem fg_induction (R M : Type*) [Semiring R] [AddCommMonoid M] [Module R M]
     | empty =>
       rw [Finset.coe_empty, Submodule.span_empty, ← Submodule.span_zero_singleton]
       exact h₁ _
-    | insert _ ih =>
+    | insert _ _ _ ih =>
       rw [Finset.coe_insert, Submodule.span_insert]
       exact h₂ _ _ (h₁ _) ih
 

--- a/Mathlib/RingTheory/Ideal/IsPrimary.lean
+++ b/Mathlib/RingTheory/Ideal/IsPrimary.lean
@@ -68,7 +68,7 @@ lemma isPrimary_finset_inf {ι} {s : Finset ι} {f : ι → Ideal R} {i : ι} (h
   classical
   induction s using Finset.induction_on generalizing i with
   | empty => simp at hi
-  | @insert a s ha IH =>
+  | insert a s ha IH =>
     rcases s.eq_empty_or_nonempty with rfl|⟨y, hy⟩
     · simp only [insert_empty_eq, mem_singleton] at hi
       simpa [hi] using hs

--- a/Mathlib/RingTheory/Ideal/Operations.lean
+++ b/Mathlib/RingTheory/Ideal/Operations.lean
@@ -687,7 +687,7 @@ theorem isCoprime_biInf {J : ι → Ideal R} {s : Finset ι}
   induction s using Finset.induction with
   | empty =>
       simp
-  | @insert i s _ hs =>
+  | insert i s _ hs =>
       rw [Finset.iInf_insert, inf_comm, one_eq_top, eq_top_iff, ← one_eq_top]
       set K := ⨅ j ∈ s, J j
       calc

--- a/Mathlib/RingTheory/Ideal/Quotient/Index.lean
+++ b/Mathlib/RingTheory/Ideal/Quotient/Index.lean
@@ -88,7 +88,7 @@ lemma Ideal.finite_quotient_prod {ι : Type*} (I : ι → Ideal R) (s : Finset �
   classical
   induction s using Finset.induction_on with
   | empty => simp only [Finset.prod_empty, one_eq_top]; infer_instance
-  | @insert a s has IH =>
+  | insert a s has IH =>
     rw [Finset.prod_insert has, mul_comm]
     have := hI' a (by simp)
     have := IH (fun i hi ↦ hI _ (by simp [hi])) (fun i hi ↦ hI' _ (by simp [hi]))

--- a/Mathlib/RingTheory/MvPolynomial/MonomialOrder.lean
+++ b/Mathlib/RingTheory/MvPolynomial/MonomialOrder.lean
@@ -545,7 +545,7 @@ theorem degree_prod_le {ι : Type*} {P : ι → MvPolynomial σ R} {s : Finset �
   | empty =>
     simp only [Finset.prod_empty, Finset.sum_empty]
     rw [← C_1, m.degree_C, map_zero]
-  | @insert a s has hrec =>
+  | insert a s has hrec =>
     rw [Finset.prod_insert has, Finset.sum_insert has]
     apply le_trans degree_mul_le
     simp only [map_add, add_le_add_iff_left, hrec]
@@ -555,7 +555,7 @@ theorem coeff_prod_sum_degree {ι : Type*} (P : ι → MvPolynomial σ R) (s : F
   classical
   induction s using Finset.induction_on with
   | empty => simp
-  | @insert a s has hrec =>
+  | insert a s has hrec =>
     simp only [Finset.prod_insert has, Finset.sum_insert has]
     rw [coeff_mul_of_add_of_degree_le (le_of_eq rfl) degree_prod_le]
     exact congr_arg₂ _ rfl hrec

--- a/Mathlib/RingTheory/MvPowerSeries/Basic.lean
+++ b/Mathlib/RingTheory/MvPowerSeries/Basic.lean
@@ -650,7 +650,7 @@ theorem coeff_prod [DecidableEq σ]
     split_ifs
     · simp only [card_singleton, Nat.cast_one]
     · simp only [card_empty, Nat.cast_zero]
-  | @insert a s ha ih =>
+  | insert a s ha ih =>
     rw [finsuppAntidiag_insert ha, prod_insert ha, coeff_mul, sum_biUnion]
     · apply Finset.sum_congr rfl
       simp only [mem_antidiagonal, sum_map, Function.Embedding.coeFn_mk, coe_update, Prod.forall]

--- a/Mathlib/RingTheory/MvPowerSeries/Order.lean
+++ b/Mathlib/RingTheory/MvPowerSeries/Order.lean
@@ -316,7 +316,7 @@ theorem coeff_mul_prod_one_sub_of_lt_weightedOrder {R ι : Type*} [CommRing R] (
   classical
   induction s using Finset.induction_on with
   | empty => simp only [Finset.prod_empty, mul_one]
-  | @insert a s ha ih =>
+  | insert a s ha ih =>
     simp only [Finset.mem_insert, forall_eq_or_imp] at h
     rw [Finset.prod_insert ha, ← mul_assoc, mul_right_comm,
       coeff_mul_left_one_sub_of_lt_weightedOrder w h.1, ih h.2]

--- a/Mathlib/RingTheory/Nilpotent/Basic.lean
+++ b/Mathlib/RingTheory/Nilpotent/Basic.lean
@@ -155,7 +155,7 @@ protected lemma isNilpotent_sum {ι : Type*} {s : Finset ι} {f : ι → R}
   classical
   induction s using Finset.induction with
   | empty => simp
-  | @insert j s hj ih => ?_
+  | insert j s hj ih => ?_
   rw [Finset.sum_insert hj]
   apply Commute.isNilpotent_add
   · exact Commute.sum_right _ _ _ (fun i hi ↦ h_comm _ _ (by simp) (by simp [hi]))

--- a/Mathlib/Topology/Category/TopCat/Limits/Cofiltered.lean
+++ b/Mathlib/Topology/Category/TopCat/Limits/Cofiltered.lean
@@ -69,7 +69,7 @@ theorem isTopologicalBasis_cofiltered_limit (hC : IsLimit C) (T : ∀ j, Set (Se
         | empty =>
           intro P he _hh
           simpa
-        | @insert a E _ha hh1 =>
+        | insert a E _ha hh1 =>
           intro hh2 hh3 hh4 hh5
           rw [Finset.set_biInter_insert]
           refine hh4 _ _ (hh5 _ (Finset.mem_insert_self _ _)) (hh1 _ hh3 hh4 ?_)

--- a/Mathlib/Topology/Connected/Basic.lean
+++ b/Mathlib/Topology/Connected/Basic.lean
@@ -432,8 +432,7 @@ theorem isPreconnected_univ_pi [∀ i, TopologicalSpace (π i)] {s : ∀ i, Set 
   | empty =>
     refine ⟨g, hgs, ⟨?_, hgv⟩⟩
     simpa using hI
-  | insert _ ihI =>
-    rename_i i I _
+  | insert i I _ ihI =>
     rw [Finset.piecewise_insert] at hI
     have := I.piecewise_mem_set_pi hfs hgs
     refine (hsuv this).elim ihI fun h => ?_

--- a/Mathlib/Topology/Connected/Clopen.lean
+++ b/Mathlib/Topology/Connected/Clopen.lean
@@ -282,7 +282,7 @@ theorem isConnected_iff_sUnion_disjoint_open {s : Set α} :
   refine ⟨fun ⟨hne, h⟩ U hU hUo hsU => ?_, fun h => ⟨?_, fun u v hu hv hs hsuv => ?_⟩⟩
   · induction U using Finset.induction_on with
     | empty => exact absurd (by simpa using hsU) hne.not_subset_empty
-    | @insert u U uU IH =>
+    | insert u U uU IH =>
       simp only [← forall_cond_comm, Finset.forall_mem_insert, Finset.exists_mem_insert,
         Finset.coe_insert, sUnion_insert, implies_true, true_and] at *
       refine (h _ hUo.1 (⋃₀ ↑U) (isOpen_sUnion hUo.2) hsU ?_).imp_right ?_

--- a/Mathlib/Topology/Instances/ENNReal/Lemmas.lean
+++ b/Mathlib/Topology/Instances/ENNReal/Lemmas.lean
@@ -380,7 +380,7 @@ theorem tendsto_finset_prod_of_ne_top {ι : Type*} {f : ι → α → ℝ≥0∞
   classical
   induction s using Finset.induction with
   | empty => simp [tendsto_const_nhds]
-  | insert has IH =>
+  | insert _ _ has IH =>
     simp only [Finset.prod_insert has]
     apply Tendsto.mul (h _ (Finset.mem_insert_self _ _))
     · right

--- a/Mathlib/Topology/Irreducible.lean
+++ b/Mathlib/Topology/Irreducible.lean
@@ -230,7 +230,7 @@ theorem isIrreducible_iff_sInter :
   refine ⟨fun h U hu hU => ?_, fun h => ⟨?_, ?_⟩⟩
   · induction U using Finset.induction_on with
     | empty => simpa using h.nonempty
-    | @insert u U _ IH =>
+    | insert u U _ IH =>
       rw [Finset.coe_insert, sInter_insert]
       rw [Finset.forall_mem_insert] at hu hU
       exact h.2 _ _ hu.1 (U.finite_toSet.isOpen_sInter hu.2) hU.1 (IH hu.2 hU.2)

--- a/Mathlib/Topology/Semicontinuous.lean
+++ b/Mathlib/Topology/Semicontinuous.lean
@@ -538,7 +538,7 @@ theorem lowerSemicontinuousWithinAt_sum {f : ι → α → γ} {a : Finset ι}
   classical
     induction a using Finset.induction_on with
     | empty => exact lowerSemicontinuousWithinAt_const
-    | insert ia IH =>
+    | insert _ _ ia IH =>
       simp only [ia, Finset.sum_insert, not_false_iff]
       exact
         LowerSemicontinuousWithinAt.add (ha _ (Finset.mem_insert_self ..))

--- a/Mathlib/Topology/Separation/Basic.lean
+++ b/Mathlib/Topology/Separation/Basic.lean
@@ -651,7 +651,7 @@ theorem Dense.diff_finset [T1Space X] [∀ x : X, NeBot (𝓝[≠] x)] {s : Set 
   classical
   induction t using Finset.induction_on with
   | empty => simpa using hs
-  | insert _ ih =>
+  | insert _ _ _ ih =>
     rw [Finset.coe_insert, ← union_singleton, ← diff_diff]
     exact ih.diff_singleton _
 
@@ -958,8 +958,7 @@ theorem IsCompact.finite_compact_cover {s : Set X} (hs : IsCompact s) {ι : Type
   | empty =>
     refine ⟨fun _ => ∅, fun _ => isCompact_empty, fun i => empty_subset _, ?_⟩
     simpa only [subset_empty_iff, Finset.not_mem_empty, iUnion_false, iUnion_empty] using hsC
-  | insert hx ih =>
-    rename_i x t
+  | insert x t hx ih =>
     simp only [Finset.set_biUnion_insert] at hsC
     simp only [Finset.forall_mem_insert] at hU
     have hU' : ∀ i ∈ t, IsOpen (U i) := fun i hi => hU.2 i hi

--- a/Mathlib/Topology/Sets/Closeds.lean
+++ b/Mathlib/Topology/Sets/Closeds.lean
@@ -332,7 +332,7 @@ lemma coe_finset_sup (s : Finset ι) (U : ι → Clopens α) :
   classical
   induction s using Finset.induction_on with
   | empty => simp
-  | insert _ IH => simp [IH]
+  | insert _ _ _ IH => simp [IH]
 
 @[simp, norm_cast]
 lemma coe_disjoint {s t : Clopens α} : Disjoint (s : Set α) t ↔ Disjoint s t := by


### PR DESCRIPTION
Changes
```lean
@[elab_as_elim]
protected theorem induction {α : Type*} {motive : Finset α → Prop} [DecidableEq α]
    (empty : motive ∅)
    (insert : ∀ ⦃a : α⦄ {s : Finset α}, a ∉ s → motive s → motive (insert a s)) : ∀ s, motive s :=
```
to
```lean
@[elab_as_elim]
protected theorem induction {α : Type*} {motive : Finset α → Prop} [DecidableEq α]
    (empty : motive ∅)
    (insert : ∀ (a : α) (s : Finset α), a ∉ s → motive s → motive (insert a s)) : ∀ s, motive s :=
```
and the same for `Finset.cons_induction_on`, `Finset.induction_on`, and `Finset.induction_on'`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
