### PR TITLE
[Merged by Bors] - feat(CategoryTheory/Abelian/Projective/Dimension): `X` is a zero object if `proj.dim X < 0`

### DIFF
--- a/Mathlib/CategoryTheory/Abelian/Projective/Dimension.lean
+++ b/Mathlib/CategoryTheory/Abelian/Projective/Dimension.lean
@@ -88,12 +88,12 @@ lemma Limits.IsZero.hasProjectiveDimensionLT_zero (hX : IsZero X) :
 instance : HasProjectiveDimensionLT (0 : C) 0 :=
   (isZero_zero C).hasProjectiveDimensionLT_zero
 
-lemma isZero_of_hasProjectiveDimensionLT_zero (hX : HasProjectiveDimensionLT X 0) : IsZero X := by
+lemma isZero_of_hasProjectiveDimensionLT_zero [HasProjectiveDimensionLT X 0] : IsZero X := by
   letI := HasExt.standard C
-  rw [hasProjectiveDimensionLT_iff] at hX
-  exact (IsZero.iff_id_eq_zero X).mpr <|
-    ((Ext.addEquiv₀.symm_apply_eq ).mp (hX 0 (le_refl 0) (Ext.addEquiv₀.symm (𝟙 X)))).trans
-      (Ext.addEquiv₀ (X := X)).map_zero
+  rw [IsZero.iff_id_eq_zero]
+  apply Ext.homEquiv₀.symm.injective
+  simpa only [Ext.homEquiv₀_symm_apply, Ext.mk₀_zero]
+    using Abelian.Ext.eq_zero_of_hasProjectiveDimensionLT _ 0 (by rfl)
 
 lemma hasProjectiveDimensionLT_of_ge (m : ℕ) (h : n ≤ m)
     [HasProjectiveDimensionLT X n] :

--- a/Mathlib/CategoryTheory/Abelian/Projective/Dimension.lean
+++ b/Mathlib/CategoryTheory/Abelian/Projective/Dimension.lean
@@ -88,6 +88,14 @@ lemma Limits.IsZero.hasProjectiveDimensionLT_zero (hX : IsZero X) :
 instance : HasProjectiveDimensionLT (0 : C) 0 :=
   (isZero_zero C).hasProjectiveDimensionLT_zero
 
+lemma hasProjectiveDimensionLT_zero_iff_isZero : HasProjectiveDimensionLT X 0 ↔ IsZero X := by
+  letI := HasExt.standard C
+  refine ⟨fun hX ↦ ?_, fun hX ↦ hX.hasProjectiveDimensionLT_zero⟩
+  rw [hasProjectiveDimensionLT_iff] at hX
+  exact (IsZero.iff_id_eq_zero X).mpr <|
+    ((Ext.addEquiv₀.symm_apply_eq ).mp (hX 0 (le_refl 0) (Ext.addEquiv₀.symm (𝟙 X)))).trans
+      (Ext.addEquiv₀ (X := X)).map_zero
+
 lemma hasProjectiveDimensionLT_of_ge (m : ℕ) (h : n ≤ m)
     [HasProjectiveDimensionLT X n] :
     HasProjectiveDimensionLT X m := by

--- a/Mathlib/CategoryTheory/Abelian/Projective/Dimension.lean
+++ b/Mathlib/CategoryTheory/Abelian/Projective/Dimension.lean
@@ -88,9 +88,8 @@ lemma Limits.IsZero.hasProjectiveDimensionLT_zero (hX : IsZero X) :
 instance : HasProjectiveDimensionLT (0 : C) 0 :=
   (isZero_zero C).hasProjectiveDimensionLT_zero
 
-lemma hasProjectiveDimensionLT_zero_iff_isZero : HasProjectiveDimensionLT X 0 ↔ IsZero X := by
+lemma isZero_of_hasProjectiveDimensionLT_zero (hX : HasProjectiveDimensionLT X 0) : IsZero X := by
   letI := HasExt.standard C
-  refine ⟨fun hX ↦ ?_, fun hX ↦ hX.hasProjectiveDimensionLT_zero⟩
   rw [hasProjectiveDimensionLT_iff] at hX
   exact (IsZero.iff_id_eq_zero X).mpr <|
     ((Ext.addEquiv₀.symm_apply_eq ).mp (hX 0 (le_refl 0) (Ext.addEquiv₀.symm (𝟙 X)))).trans


### PR DESCRIPTION
Show that if `proj.dim X < 0` then `X` is a zero object. This is the converse of [CategoryTheory.Limits.IsZero.hasProjectiveDimensionLT_zero](https://leanprover-community.github.io/mathlib4_docs/Mathlib/CategoryTheory/Abelian/Projective/Dimension.html#CategoryTheory.Limits.IsZero.hasProjectiveDimensionLT_zero).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
