### PR TITLE
[Merged by Bors] - refactor(Geometry/Euclidean): split out altitudes

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3504,6 +3504,7 @@ import Mathlib.FieldTheory.SeparableDegree
 import Mathlib.FieldTheory.SplittingField.Construction
 import Mathlib.FieldTheory.SplittingField.IsSplittingField
 import Mathlib.FieldTheory.Tower
+import Mathlib.Geometry.Euclidean.Altitude
 import Mathlib.Geometry.Euclidean.Angle.Oriented.Affine
 import Mathlib.Geometry.Euclidean.Angle.Oriented.Basic
 import Mathlib.Geometry.Euclidean.Angle.Oriented.RightAngle

--- a/Mathlib/Geometry/Euclidean/Altitude.lean
+++ b/Mathlib/Geometry/Euclidean/Altitude.lean
@@ -1,0 +1,125 @@
+/-
+Copyright (c) 2020 Joseph Myers. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joseph Myers
+-/
+import Mathlib.Geometry.Euclidean.Projection
+
+/-!
+# Altitudes of a simplex
+
+This file defines the altitudes of a simplex.
+
+## Main definitions
+
+* `altitude` is the line that passes through a vertex of a simplex and
+  is orthogonal to the opposite face.
+
+## References
+
+* <https://en.wikipedia.org/wiki/Altitude_(triangle)>
+
+-/
+
+noncomputable section
+
+namespace Affine
+
+namespace Simplex
+
+open Finset AffineSubspace
+
+variable {V : Type*} {P : Type*} [NormedAddCommGroup V] [InnerProductSpace ℝ V] [MetricSpace P]
+  [NormedAddTorsor V P]
+
+/-- An altitude of a simplex is the line that passes through a vertex
+and is orthogonal to the opposite face. -/
+def altitude {n : ℕ} (s : Simplex ℝ P (n + 1)) (i : Fin (n + 2)) : AffineSubspace ℝ P :=
+  mk' (s.points i) (affineSpan ℝ (s.points '' ↑(univ.erase i))).directionᗮ ⊓
+    affineSpan ℝ (Set.range s.points)
+
+/-- The definition of an altitude. -/
+theorem altitude_def {n : ℕ} (s : Simplex ℝ P (n + 1)) (i : Fin (n + 2)) :
+    s.altitude i =
+      mk' (s.points i) (affineSpan ℝ (s.points '' ↑(univ.erase i))).directionᗮ ⊓
+        affineSpan ℝ (Set.range s.points) :=
+  rfl
+
+/-- A vertex lies in the corresponding altitude. -/
+theorem mem_altitude {n : ℕ} (s : Simplex ℝ P (n + 1)) (i : Fin (n + 2)) :
+    s.points i ∈ s.altitude i :=
+  (mem_inf_iff _ _ _).2 ⟨self_mem_mk' _ _, mem_affineSpan ℝ (Set.mem_range_self _)⟩
+
+/-- The direction of an altitude. -/
+theorem direction_altitude {n : ℕ} (s : Simplex ℝ P (n + 1)) (i : Fin (n + 2)) :
+    (s.altitude i).direction =
+      (vectorSpan ℝ (s.points '' ↑(Finset.univ.erase i)))ᗮ ⊓ vectorSpan ℝ (Set.range s.points) := by
+  rw [altitude_def,
+    direction_inf_of_mem (self_mem_mk' (s.points i) _) (mem_affineSpan ℝ (Set.mem_range_self _)),
+    direction_mk', direction_affineSpan, direction_affineSpan]
+
+/-- The vector span of the opposite face lies in the direction
+orthogonal to an altitude. -/
+theorem vectorSpan_isOrtho_altitude_direction {n : ℕ} (s : Simplex ℝ P (n + 1)) (i : Fin (n + 2)) :
+    vectorSpan ℝ (s.points '' ↑(Finset.univ.erase i)) ⟂ (s.altitude i).direction := by
+  rw [direction_altitude]
+  exact (Submodule.isOrtho_orthogonal_right _).mono_right inf_le_left
+
+open Module
+
+/-- An altitude is finite-dimensional. -/
+instance finiteDimensional_direction_altitude {n : ℕ} (s : Simplex ℝ P (n + 1)) (i : Fin (n + 2)) :
+    FiniteDimensional ℝ (s.altitude i).direction := by
+  rw [direction_altitude]
+  infer_instance
+
+/-- An altitude is one-dimensional (i.e., a line). -/
+@[simp]
+theorem finrank_direction_altitude {n : ℕ} (s : Simplex ℝ P (n + 1)) (i : Fin (n + 2)) :
+    finrank ℝ (s.altitude i).direction = 1 := by
+  rw [direction_altitude]
+  have h := Submodule.finrank_add_inf_finrank_orthogonal
+    (vectorSpan_mono ℝ (Set.image_subset_range s.points ↑(univ.erase i)))
+  have hc : #(univ.erase i) = n + 1 := by rw [card_erase_of_mem (mem_univ _)]; simp
+  refine add_left_cancel (_root_.trans h ?_)
+  classical
+  rw [s.independent.finrank_vectorSpan (Fintype.card_fin _), ← Finset.coe_image,
+    s.independent.finrank_vectorSpan_image_finset hc]
+
+/-- A line through a vertex is the altitude through that vertex if and
+only if it is orthogonal to the opposite face. -/
+theorem affineSpan_pair_eq_altitude_iff {n : ℕ} (s : Simplex ℝ P (n + 1)) (i : Fin (n + 2))
+    (p : P) :
+    line[ℝ, p, s.points i] = s.altitude i ↔
+      p ≠ s.points i ∧
+        p ∈ affineSpan ℝ (Set.range s.points) ∧
+          p -ᵥ s.points i ∈ (affineSpan ℝ (s.points '' ↑(Finset.univ.erase i))).directionᗮ := by
+  rw [eq_iff_direction_eq_of_mem (mem_affineSpan ℝ (Set.mem_insert_of_mem _ (Set.mem_singleton _)))
+      (s.mem_altitude _),
+    ← vsub_right_mem_direction_iff_mem (mem_affineSpan ℝ (Set.mem_range_self i)) p,
+    direction_affineSpan, direction_affineSpan, direction_affineSpan]
+  constructor
+  · intro h
+    constructor
+    · intro heq
+      rw [heq, Set.pair_eq_singleton, vectorSpan_singleton] at h
+      have hd : finrank ℝ (s.altitude i).direction = 0 := by rw [← h, finrank_bot]
+      simp at hd
+    · rw [← Submodule.mem_inf, _root_.inf_comm, ← direction_altitude, ← h]
+      exact
+        vsub_mem_vectorSpan ℝ (Set.mem_insert _ _) (Set.mem_insert_of_mem _ (Set.mem_singleton _))
+  · rintro ⟨hne, h⟩
+    rw [← Submodule.mem_inf, _root_.inf_comm, ← direction_altitude] at h
+    rw [vectorSpan_eq_span_vsub_set_left_ne ℝ (Set.mem_insert _ _),
+      Set.insert_diff_of_mem _ (Set.mem_singleton _),
+      Set.diff_singleton_eq_self fun h => hne (Set.mem_singleton_iff.1 h), Set.image_singleton]
+    refine Submodule.eq_of_le_of_finrank_eq ?_ ?_
+    · rw [Submodule.span_le]
+      simpa using h
+    · rw [finrank_direction_altitude, finrank_span_set_eq_card]
+      · simp
+      · exact LinearIndepOn.id_singleton _ <| by simpa using hne
+
+end Simplex
+
+end Affine

--- a/Mathlib/Geometry/Euclidean/Altitude.lean
+++ b/Mathlib/Geometry/Euclidean/Altitude.lean
@@ -3,7 +3,8 @@ Copyright (c) 2020 Joseph Myers. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Joseph Myers
 -/
-import Mathlib.Geometry.Euclidean.Projection
+import Mathlib.Analysis.InnerProductSpace.Projection
+import Mathlib.LinearAlgebra.AffineSpace.FiniteDimensional
 
 /-!
 # Altitudes of a simplex

--- a/Mathlib/Geometry/Euclidean/MongePoint.lean
+++ b/Mathlib/Geometry/Euclidean/MongePoint.lean
@@ -3,6 +3,7 @@ Copyright (c) 2020 Joseph Myers. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Joseph Myers
 -/
+import Mathlib.Geometry.Euclidean.Altitude
 import Mathlib.Geometry.Euclidean.Circumcenter
 
 /-!
@@ -23,9 +24,6 @@ generalization, the Monge point of a simplex.
   and is orthogonal to the opposite edge (in 2 dimensions, this is the
   same as an altitude).
 
-* `altitude` is the line that passes through a vertex of a simplex and
-  is orthogonal to the opposite face.
-
 * `orthocenter` is defined, for the case of a triangle, to be the same
   as its Monge point, then shown to be the point of concurrence of the
   altitudes.
@@ -37,7 +35,6 @@ generalization, the Monge point of a simplex.
 
 ## References
 
-* <https://en.wikipedia.org/wiki/Altitude_(triangle)>
 * <https://en.wikipedia.org/wiki/Monge_point>
 * <https://en.wikipedia.org/wiki/Orthocentric_system>
 * Małgorzata Buba-Brzozowa, [The Monge Point and the 3(n+1) Point
@@ -300,94 +297,6 @@ theorem eq_mongePoint_of_forall_mem_mongePlane {n : ℕ} {s : Simplex ℝ P (n +
     have h₁₂ : i₁ ≠ i₂ := (ne_of_mem_erase h₂).symm
     exact (Submodule.mem_inf.1 (h' i₂ h₁₂)).2
   exact Submodule.disjoint_def.1 (vectorSpan ℝ (Set.range s.points)).orthogonal_disjoint _ hv hi
-
-/-- An altitude of a simplex is the line that passes through a vertex
-and is orthogonal to the opposite face. -/
-def altitude {n : ℕ} (s : Simplex ℝ P (n + 1)) (i : Fin (n + 2)) : AffineSubspace ℝ P :=
-  mk' (s.points i) (affineSpan ℝ (s.points '' ↑(univ.erase i))).directionᗮ ⊓
-    affineSpan ℝ (Set.range s.points)
-
-/-- The definition of an altitude. -/
-theorem altitude_def {n : ℕ} (s : Simplex ℝ P (n + 1)) (i : Fin (n + 2)) :
-    s.altitude i =
-      mk' (s.points i) (affineSpan ℝ (s.points '' ↑(univ.erase i))).directionᗮ ⊓
-        affineSpan ℝ (Set.range s.points) :=
-  rfl
-
-/-- A vertex lies in the corresponding altitude. -/
-theorem mem_altitude {n : ℕ} (s : Simplex ℝ P (n + 1)) (i : Fin (n + 2)) :
-    s.points i ∈ s.altitude i :=
-  (mem_inf_iff _ _ _).2 ⟨self_mem_mk' _ _, mem_affineSpan ℝ (Set.mem_range_self _)⟩
-
-/-- The direction of an altitude. -/
-theorem direction_altitude {n : ℕ} (s : Simplex ℝ P (n + 1)) (i : Fin (n + 2)) :
-    (s.altitude i).direction =
-      (vectorSpan ℝ (s.points '' ↑(Finset.univ.erase i)))ᗮ ⊓ vectorSpan ℝ (Set.range s.points) := by
-  rw [altitude_def,
-    direction_inf_of_mem (self_mem_mk' (s.points i) _) (mem_affineSpan ℝ (Set.mem_range_self _)),
-    direction_mk', direction_affineSpan, direction_affineSpan]
-
-/-- The vector span of the opposite face lies in the direction
-orthogonal to an altitude. -/
-theorem vectorSpan_isOrtho_altitude_direction {n : ℕ} (s : Simplex ℝ P (n + 1)) (i : Fin (n + 2)) :
-    vectorSpan ℝ (s.points '' ↑(Finset.univ.erase i)) ⟂ (s.altitude i).direction := by
-  rw [direction_altitude]
-  exact (Submodule.isOrtho_orthogonal_right _).mono_right inf_le_left
-
-open Module
-
-/-- An altitude is finite-dimensional. -/
-instance finiteDimensional_direction_altitude {n : ℕ} (s : Simplex ℝ P (n + 1)) (i : Fin (n + 2)) :
-    FiniteDimensional ℝ (s.altitude i).direction := by
-  rw [direction_altitude]
-  infer_instance
-
-/-- An altitude is one-dimensional (i.e., a line). -/
-@[simp]
-theorem finrank_direction_altitude {n : ℕ} (s : Simplex ℝ P (n + 1)) (i : Fin (n + 2)) :
-    finrank ℝ (s.altitude i).direction = 1 := by
-  rw [direction_altitude]
-  have h := Submodule.finrank_add_inf_finrank_orthogonal
-    (vectorSpan_mono ℝ (Set.image_subset_range s.points ↑(univ.erase i)))
-  have hc : #(univ.erase i) = n + 1 := by rw [card_erase_of_mem (mem_univ _)]; simp
-  refine add_left_cancel (_root_.trans h ?_)
-  classical
-  rw [s.independent.finrank_vectorSpan (Fintype.card_fin _), ← Finset.coe_image,
-    s.independent.finrank_vectorSpan_image_finset hc]
-
-/-- A line through a vertex is the altitude through that vertex if and
-only if it is orthogonal to the opposite face. -/
-theorem affineSpan_pair_eq_altitude_iff {n : ℕ} (s : Simplex ℝ P (n + 1)) (i : Fin (n + 2))
-    (p : P) :
-    line[ℝ, p, s.points i] = s.altitude i ↔
-      p ≠ s.points i ∧
-        p ∈ affineSpan ℝ (Set.range s.points) ∧
-          p -ᵥ s.points i ∈ (affineSpan ℝ (s.points '' ↑(Finset.univ.erase i))).directionᗮ := by
-  rw [eq_iff_direction_eq_of_mem (mem_affineSpan ℝ (Set.mem_insert_of_mem _ (Set.mem_singleton _)))
-      (s.mem_altitude _),
-    ← vsub_right_mem_direction_iff_mem (mem_affineSpan ℝ (Set.mem_range_self i)) p,
-    direction_affineSpan, direction_affineSpan, direction_affineSpan]
-  constructor
-  · intro h
-    constructor
-    · intro heq
-      rw [heq, Set.pair_eq_singleton, vectorSpan_singleton] at h
-      have hd : finrank ℝ (s.altitude i).direction = 0 := by rw [← h, finrank_bot]
-      simp at hd
-    · rw [← Submodule.mem_inf, _root_.inf_comm, ← direction_altitude, ← h]
-      exact
-        vsub_mem_vectorSpan ℝ (Set.mem_insert _ _) (Set.mem_insert_of_mem _ (Set.mem_singleton _))
-  · rintro ⟨hne, h⟩
-    rw [← Submodule.mem_inf, _root_.inf_comm, ← direction_altitude] at h
-    rw [vectorSpan_eq_span_vsub_set_left_ne ℝ (Set.mem_insert _ _),
-      Set.insert_diff_of_mem _ (Set.mem_singleton _),
-      Set.diff_singleton_eq_self fun h => hne (Set.mem_singleton_iff.1 h), Set.image_singleton]
-    refine Submodule.eq_of_le_of_finrank_eq ?_ ?_
-    · rw [Submodule.span_le]
-      simpa using h
-    · rw [finrank_direction_altitude, finrank_span_set_eq_card]
-      · simp
-      · exact LinearIndepOn.id_singleton _ <| by simpa using hne
 
 end Simplex
 


### PR DESCRIPTION
Move the definition of `Affine.Simplex.altitude` and associated API from `MongePoint.lean` to a separate file, in preparation for setting up other associated definitions (as discussed in #23752) that are of use without involving the Monge point / orthocenter.

There are no changes to definitions, statements or proofs; this is just moving content from one file to another.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
