### PR TITLE
[Merged by Bors] - doc(docs/1000.yaml): add Szpilrajn theorem

### DIFF
--- a/Mathlib/Order/Extension/Linear.lean
+++ b/Mathlib/Order/Extension/Linear.lean
@@ -17,7 +17,7 @@ universe u
 
 open Set
 
-/-- **Szpilrajn extension theorem**: Any partial order can be extended to a linear order. -/
+/-- **Szpilrajn extension theorem**: any partial order can be extended to a linear order. -/
 theorem extend_partialOrder {α : Type u} (r : α → α → Prop) [IsPartialOrder α r] :
     ∃ s : α → α → Prop, IsLinearOrder α s ∧ r ≤ s := by
   let S := { s | IsPartialOrder α s }

--- a/Mathlib/Order/Extension/Linear.lean
+++ b/Mathlib/Order/Extension/Linear.lean
@@ -17,8 +17,7 @@ universe u
 
 open Set
 
-/-- Any partial order can be extended to a linear order.
--/
+/-- **Szpilrajn extension theorem**: Any partial order can be extended to a linear order. -/
 theorem extend_partialOrder {α : Type u} (r : α → α → Prop) [IsPartialOrder α r] :
     ∃ s : α → α → Prop, IsLinearOrder α s ∧ r ≤ s := by
   let S := { s | IsPartialOrder α s }

--- a/docs/1000.yaml
+++ b/docs/1000.yaml
@@ -936,6 +936,7 @@ Q869647:
   title: Szpilrajn extension theorem
   decl: extend_partialOrder
   authors: Bhavik Mehta
+  date: 2021
 
 Q872088:
   title: Boolean prime ideal theorem

--- a/docs/1000.yaml
+++ b/docs/1000.yaml
@@ -934,6 +934,8 @@ Q867839:
 
 Q869647:
   title: Szpilrajn extension theorem
+  decl: extend_partialOrder
+  authors: Bhavik Mehta
 
 Q872088:
   title: Boolean prime ideal theorem


### PR DESCRIPTION
Add Szpilrajn extension theorem to the 1000-theorems list and mention the name in the docstring of `extend_partialOrder`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
