### PR TITLE
[Merged by Bors] - chore(SimplexCategory): golf

### DIFF
--- a/Mathlib/AlgebraicTopology/ExtraDegeneracy.lean
+++ b/Mathlib/AlgebraicTopology/ExtraDegeneracy.lean
@@ -218,24 +218,15 @@ protected noncomputable def extraDegeneracy (Δ : SimplexCategory) :
     ext j : 2
     dsimp [SimplicialObject.δ, SimplexCategory.δ, SSet.stdSimplex,
       objEquiv, Equiv.ulift, uliftFunctor]
-    by_cases h : j = 0
-    · subst h
-      simp only [Fin.succ_succAbove_zero, shiftFun_zero]
-    · obtain ⟨_, rfl⟩ := Fin.eq_succ_of_ne_zero <| h
-      simp only [Fin.succ_succAbove_succ, shiftFun_succ, Function.comp_apply,
-        Fin.succAboveOrderEmb_apply]
+    cases j using Fin.cases <;> simp
   s_comp_σ n i := by
     ext1 φ
     apply objEquiv.injective
     apply SimplexCategory.Hom.ext
     ext j : 2
-    dsimp [SimplicialObject.σ, SimplexCategory.σ, SSet.stdSimplex,
-      objEquiv, Equiv.ulift, uliftFunctor]
-    by_cases h : j = 0
-    · subst h
-      rfl
-    · obtain ⟨_, rfl⟩ := Fin.eq_succ_of_ne_zero h
-      simp only [Fin.succ_predAbove_succ, shiftFun_succ, Function.comp_apply]
+    dsimp [SimplicialObject.σ, SimplexCategory.σ, SSet.stdSimplex, objEquiv, Equiv.ulift,
+      uliftFunctor, Function.comp_def]
+    cases j using Fin.cases <;> simp
 
 instance nonempty_extraDegeneracy_stdSimplex (Δ : SimplexCategory) :
     Nonempty (SimplicialObject.Augmented.ExtraDegeneracy (stdSimplex.obj Δ)) :=
@@ -265,16 +256,9 @@ and by shifting the indices on the other projections. -/
 noncomputable def ExtraDegeneracy.s (n : ℕ) :
     f.cechNerve.obj (op ⦋n⦌) ⟶ f.cechNerve.obj (op ⦋n + 1⦌) :=
   WidePullback.lift (WidePullback.base _)
-    (fun i =>
-      dite (i = 0)
-        (fun _ => WidePullback.base _ ≫ S.section_)
-        (fun h => WidePullback.π _ (i.pred h)))
+    (Fin.cases (WidePullback.base _ ≫ S.section_) (WidePullback.π _))
     fun i => by
-      dsimp
-      split_ifs with h
-      · subst h
-        simp only [assoc, SplitEpi.id, comp_id]
-      · simp only [WidePullback.π_arrow]
+      cases i using Fin.cases <;> simp
 
 -- Porting note (https://github.com/leanprover-community/mathlib4/issues/11119): @[simp] removed as the linter complains the LHS is not in normal form
 -- The problem is that the type of `ExtraDegeneracy.s` is not in normal form, this causes the `erw`
@@ -290,11 +274,7 @@ theorem ExtraDegeneracy.s_comp_π_0 (n : ℕ) :
 theorem ExtraDegeneracy.s_comp_π_succ (n : ℕ) (i : Fin (n + 1)) :
     ExtraDegeneracy.s f S n ≫ WidePullback.π _ i.succ =
       @WidePullback.π _ _ _ f.right (fun _ : Fin (n + 1) => f.left) (fun _ => f.hom) _ i := by
-  dsimp [ExtraDegeneracy.s]
-  simp only [WidePullback.lift_π]
-  split_ifs with h
-  · simp only [Fin.ext_iff, Fin.val_succ, Fin.val_zero, add_eq_zero, and_false, reduceCtorEq] at h
-  · simp only [Fin.pred_succ]
+  simp [ExtraDegeneracy.s]
 
 -- Porting note (https://github.com/leanprover-community/mathlib4/issues/11119): @[simp] removed as the linter complains the LHS is not in normal form
 theorem ExtraDegeneracy.s_comp_base (n : ℕ) :
@@ -325,14 +305,13 @@ noncomputable def extraDegeneracy :
     dsimp [SimplicialObject.δ, SimplexCategory.δ]
     ext j
     · simp only [assoc, WidePullback.lift_π]
-      by_cases h : j = 0
-      · subst h
+      cases j using Fin.cases with
+      | zero =>
         rw [Fin.succ_succAbove_zero]
         erw [ExtraDegeneracy.s_comp_π_0, ExtraDegeneracy.s_comp_π_0]
         dsimp
         simp only [WidePullback.lift_base_assoc]
-      · obtain ⟨k, hk⟩ := Fin.eq_succ_of_ne_zero h
-        subst hk
+      | succ k =>
         erw [Fin.succ_succAbove_succ, ExtraDegeneracy.s_comp_π_succ,
           ExtraDegeneracy.s_comp_π_succ]
         simp only [WidePullback.lift_π]
@@ -344,13 +323,12 @@ noncomputable def extraDegeneracy :
     dsimp [cechNerve, SimplicialObject.σ, SimplexCategory.σ]
     ext j
     · simp only [assoc, WidePullback.lift_π]
-      by_cases h : j = 0
-      · subst h
+      cases j using Fin.cases with
+      | zero =>
         erw [ExtraDegeneracy.s_comp_π_0, ExtraDegeneracy.s_comp_π_0]
         dsimp
         simp only [WidePullback.lift_base_assoc]
-      · obtain ⟨k, hk⟩ := Fin.eq_succ_of_ne_zero h
-        subst hk
+      | succ k =>
         erw [Fin.succ_predAbove_succ, ExtraDegeneracy.s_comp_π_succ,
           ExtraDegeneracy.s_comp_π_succ]
         simp only [WidePullback.lift_π]
@@ -394,37 +372,22 @@ noncomputable def homotopyEquiv [Preadditive C] [HasZeroObject C]
       ChainComplex.fromSingle₀Equiv_symm_apply_f_zero, s'_comp_ε]
     rfl)
   homotopyHomInvId :=
-    { hom := fun i j => by
-        by_cases i + 1 = j
-        · exact (-ed.s i) ≫ eqToHom (by congr)
-        · exact 0
-      zero := fun i j hij => by
-        dsimp
-        split_ifs with h
-        · exfalso
-          exact hij h
-        · simp only [eq_self_iff_true]
-      comm := fun i => by
-        rcases i with _|i
-        · rw [Homotopy.prevD_chainComplex, Homotopy.dNext_zero_chainComplex, zero_add]
+    { hom i := Pi.single (i + 1) (-ed.s i)
+      zero i j hij := Pi.single_eq_of_ne (Ne.symm hij) _
+      comm i := by
+        cases i with
+        | zero =>
+          rw [Homotopy.prevD_chainComplex, Homotopy.dNext_zero_chainComplex, zero_add]
           dsimp
           erw [ChainComplex.fromSingle₀Equiv_symm_apply_f_zero]
-          simp only [comp_id, ite_true, zero_add, ComplexShape.down_Rel, not_true,
-            AlternatingFaceMapComplex.obj_d_eq, Preadditive.neg_comp]
+          simp only [ComplexShape.down_Rel, AlternatingFaceMapComplex.obj_d_eq]
           rw [Fin.sum_univ_two]
-          simp only [Fin.val_zero, pow_zero, one_smul, Fin.val_one, pow_one, neg_smul,
-            Preadditive.comp_add, s_comp_δ₀, drop_obj, Preadditive.comp_neg, neg_add_rev,
-            neg_neg, neg_add_cancel_right, s₀_comp_δ₁,
-            AlternatingFaceMapComplex.ε_app_f_zero]
-        · rw [Homotopy.prevD_chainComplex, Homotopy.dNext_succ_chainComplex]
-          dsimp
-          simp only [Preadditive.neg_comp,
-            AlternatingFaceMapComplex.obj_d_eq, comp_id, ite_true, Preadditive.comp_neg,
-            @Fin.sum_univ_succ _ _ (i + 2), Fin.val_zero, pow_zero, one_smul, Fin.val_succ,
-            Preadditive.comp_add, drop_obj, s_comp_δ₀, Preadditive.sum_comp,
+          simp [s_comp_δ₀, s₀_comp_δ₁]
+        | succ i =>
+          rw [Homotopy.prevD_chainComplex, Homotopy.dNext_succ_chainComplex]
+          simp [Fin.sum_univ_succ (n := i + 2), s_comp_δ₀, Preadditive.sum_comp,
             Preadditive.zsmul_comp, Preadditive.comp_sum, Preadditive.comp_zsmul,
-            zsmul_neg, s_comp_δ, pow_add, pow_one, mul_neg, mul_one, neg_zsmul, neg_neg,
-            neg_add_cancel_comm_assoc, neg_add_cancel, zero_comp] }
+            s_comp_δ, pow_succ] }
 
 end ExtraDegeneracy
 

--- a/Mathlib/AlgebraicTopology/SimplexCategory/Basic.lean
+++ b/Mathlib/AlgebraicTopology/SimplexCategory/Basic.lean
@@ -792,7 +792,7 @@ theorem eq_comp_δ_of_not_surjective' {n : ℕ} {Δ : SimplexCategory} (θ : Δ 
     exact .symm <| this _ (hi _)
   intro j hj
   cases i using Fin.lastCases <;> simp [hj]
-  
+
 theorem eq_comp_δ_of_not_surjective {n : ℕ} {Δ : SimplexCategory} (θ : Δ ⟶ mk (n + 1))
     (hθ : ¬Function.Surjective θ.toOrderHom) :
     ∃ (i : Fin (n + 2)) (θ' : Δ ⟶ mk n), θ = θ' ≫ δ i := by

--- a/Mathlib/AlgebraicTopology/SimplexCategory/Basic.lean
+++ b/Mathlib/AlgebraicTopology/SimplexCategory/Basic.lean
@@ -229,9 +229,7 @@ def δ {n} (i : Fin (n + 2)) : ⦋n⦌ ⟶ ⦋n + 1⦌ :=
 
 /-- The `i`-th degeneracy map from `⦋n+1⦌` to `⦋n⦌` -/
 def σ {n} (i : Fin (n + 1)) : ⦋n + 1⦌ ⟶ ⦋n⦌ :=
-  mkHom
-    { toFun := Fin.predAbove i
-      monotone' := Fin.predAbove_right_monotone i }
+  mkHom i.predAboveOrderHom
 
 /-- The generic case of the first simplicial identity -/
 theorem δ_comp_δ {n} {i j : Fin (n + 2)} (H : i ≤ j) :
@@ -735,9 +733,9 @@ theorem eq_σ_comp_of_not_injective' {n : ℕ} {Δ' : SimplexCategory} (θ : mk 
     (i : Fin (n + 1)) (hi : θ.toOrderHom (Fin.castSucc i) = θ.toOrderHom i.succ) :
     ∃ θ' : mk n ⟶ Δ', θ = σ i ≫ θ' := by
   use δ i.succ ≫ θ
-  ext1; ext1; ext1 x
+  ext x : 3
   simp only [len_mk, σ, mkHom, comp_toOrderHom, Hom.toOrderHom_mk, OrderHom.comp_coe,
-    OrderHom.coe_mk, Function.comp_apply]
+    Function.comp_apply, Fin.predAboveOrderHom_coe]
   by_cases h' : x ≤ Fin.castSucc i
   · rw [Fin.predAbove_of_le_castSucc i x h']
     dsimp [δ]
@@ -787,31 +785,14 @@ theorem eq_σ_comp_of_not_injective {n : ℕ} {Δ' : SimplexCategory} (θ : mk (
 
 theorem eq_comp_δ_of_not_surjective' {n : ℕ} {Δ : SimplexCategory} (θ : Δ ⟶ mk (n + 1))
     (i : Fin (n + 2)) (hi : ∀ x, θ.toOrderHom x ≠ i) : ∃ θ' : Δ ⟶ mk n, θ = θ' ≫ δ i := by
-  by_cases h : i < Fin.last (n + 1)
-  · use θ ≫ σ (Fin.castPred i h.ne)
-    ext x : 3
-    simp only [len_mk, Category.assoc, comp_toOrderHom, OrderHom.comp_coe, Function.comp_apply]
-    by_cases h' : θ.toOrderHom x ≤ i
-    · simp only [σ, mkHom, Hom.toOrderHom_mk, OrderHom.coe_mk]
-      rw [Fin.predAbove_of_le_castSucc _ _ (by rwa [Fin.castSucc_castPred])]
-      dsimp [δ]
-      rw [Fin.succAbove_of_castSucc_lt i]
-      · rw [Fin.castSucc_castPred]
-      · rw [(hi x).le_iff_lt] at h'
-        exact h'
-    · simp only [not_le] at h'
-      dsimp [σ, δ]
-      rw [Fin.predAbove_of_castSucc_lt _ _ (by rwa [Fin.castSucc_castPred])]
-      rw [Fin.succAbove_of_le_castSucc i _]
-      · rw [Fin.succ_pred]
-      · exact Nat.le_sub_one_of_lt (Fin.lt_iff_val_lt_val.mp h')
-  · obtain rfl := le_antisymm (Fin.le_last i) (not_lt.mp h)
-    use θ ≫ σ (Fin.last _)
-    ext x : 3
+  use θ ≫ σ (.predAbove (.last n) i)
+  ext x : 3
+  suffices ∀ j ≠ i, i.succAbove (((Fin.last n).predAbove i).predAbove j) = j by
     dsimp [δ, σ]
-    simp_rw [Fin.succAbove_last, Fin.predAbove_last_apply]
-    rw [dif_neg (by simpa using hi x), Fin.castSucc_castPred]
-
+    exact .symm <| this _ (hi _)
+  intro j hj
+  cases i using Fin.lastCases <;> simp [hj]
+  
 theorem eq_comp_δ_of_not_surjective {n : ℕ} {Δ : SimplexCategory} (θ : Δ ⟶ mk (n + 1))
     (hθ : ¬Function.Surjective θ.toOrderHom) :
     ∃ (i : Fin (n + 2)) (θ' : Δ ⟶ mk n), θ = θ' ≫ δ i := by


### PR DESCRIPTION
Also reuse `Fin.predAboveOrderHom` and `Pi.single`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
