### PR TITLE
[Merged by Bors] - fix: pretty-printing of `#min_imports in`

### DIFF
--- a/Mathlib/Tactic/MinImports.lean
+++ b/Mathlib/Tactic/MinImports.lean
@@ -247,10 +247,10 @@ def minImpsCore (stx id : Syntax) : CommandElabM Unit := do
 
 /-- `#min_imports in cmd` scans the syntax `cmd` and the declaration obtained by elaborating `cmd`
 to find a collection of minimal imports that should be sufficient for `cmd` to work. -/
-syntax (name := minImpsStx) "#min_imports" "in" command : command
+syntax (name := minImpsStx) "#min_imports" " in " command : command
 
 @[inherit_doc minImpsStx]
-syntax "#min_imports" "in" term : command
+syntax "#min_imports" " in " term : command
 
 elab_rules : command
   | `(#min_imports in $cmd:command) => do


### PR DESCRIPTION
Found by #24465.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
