### PR TITLE
feat(Algebra/QuadraticDiscriminant): Adding inequalities on quadratic from inequalities on discriminant

### DIFF
--- a/Mathlib/Algebra/QuadraticDiscriminant.lean
+++ b/Mathlib/Algebra/QuadraticDiscriminant.lean
@@ -116,6 +116,41 @@ theorem discrim_eq_zero_iff (ha : a ≠ 0) :
 
 end Field
 
+section LinearOrderedRing
+
+variable {K : Type*} [CommRing K] [LinearOrder K] [IsStrictOrderedRing K] {a b c : K}
+
+theorem nonneg_of_pos_of_discrim_le_zero {x : K} (ha : 0 < a) (h : discrim a b c ≤ 0) :
+    0 ≤ a * (x * x) + b * x + c := by
+  refine nonneg_of_mul_nonneg_left ?_ (mul_pos zero_lt_four ha)
+  convert_to 0 ≤ (2 * a * x + b)^2 + - discrim a b c using 1
+  · simp [discrim]
+    ring
+  exact add_nonneg (sq_nonneg (2 * a * x + b)) (neg_nonneg.mpr h)
+
+lemma nonpos_of_neg_of_discrim_le_zero {x : K} (ha : a < 0) (h : discrim a b c ≤ 0) :
+    a * (x * x) + b * x + c ≤ 0 := by
+  apply neg_nonneg.mp
+  simp only [neg_add, ← neg_mul]
+  exact nonneg_of_pos_of_discrim_le_zero (Left.neg_pos_iff.mpr ha) (by simpa)
+
+theorem pos_of_pos_of_discrim_lt_zero {x : K} (ha : 0 < a) (h : discrim a b c < 0) :
+    0 < a * (x * x) + b * x + c := by
+  refine pos_of_mul_pos_left ?_ (mul_pos zero_lt_four ha).le
+  convert_to 0 < (2 * a * x + b)^2 + - discrim a b c using 1
+  · simp [discrim]
+    ring
+
+  exact add_pos_of_nonneg_of_pos (sq_nonneg (2 * a * x + b)) (neg_pos.mpr h)
+
+lemma neg_of_neg_of_discrim_lt_zero {x : K} (ha : a < 0) (h : discrim a b c < 0) :
+    a * (x * x) + b * x + c < 0 := by
+  apply neg_pos.mp
+  simp only [neg_add, ← neg_mul]
+  apply pos_of_pos_of_discrim_lt_zero (Left.neg_pos_iff.mpr ha) (by simpa)
+
+end LinearOrderedRing
+
 section LinearOrderedField
 
 variable {K : Type*} [Field K] [LinearOrder K] [IsStrictOrderedRing K] {a b c : K}


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

This pr adds inequalities that relate `0` and `a * (x * x) + b * x + c` from inequalities of `a` and `discrim a b c`. For example, negative discriminant and negative leading coefficient implies value of quadratic expression is always negative and similar.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
