### PR TITLE
[Merged by Bors] - feat(RingTheory/Idempotents): binary version of `bijective_pi_of_isIdempotentElem`

### DIFF
--- a/Mathlib/RingTheory/Idempotents.lean
+++ b/Mathlib/RingTheory/Idempotents.lean
@@ -463,31 +463,16 @@ lemma RingHom.prod_bijective_of_isIdempotentElem {e f : R} (he : IsIdempotentEle
       simp [o, mul_comm, sub_mul, mul_sub, hef₂, ← hef₁]
   · simpa
 
-section
-
-variable {S : Type*} [CommRing S] [Algebra R S] {e f : S} (he : IsIdempotentElem e)
-  (hf : IsIdempotentElem f)
-
 variable (R) in
 /-- If `e` and `f` are idempotent elements such that `e + f = 1` and `e * f = 0`,
 `S` is isomorphic as an `R`-algebra to `S ⧸ (e) × S ⧸ (f)`. -/
-@[simps! -isSimp apply]
-noncomputable def AlgEquiv.prodQuotientOfIsIdempotentElem (hef₁ : e + f = 1) (hef₂ : e * f = 0) :
+@[simps! -isSimp apply, simps! apply_fst apply_snd]
+noncomputable def AlgEquiv.prodQuotientOfIsIdempotentElem
+    {S : Type*} [CommRing S] [Algebra R S] {e f : S} (he : IsIdempotentElem e)
+    (hf : IsIdempotentElem f) (hef₁ : e + f = 1) (hef₂ : e * f = 0) :
     S ≃ₐ[R] (S ⧸ Ideal.span {e}) × S ⧸ Ideal.span {f} :=
   AlgEquiv.ofBijective ((Ideal.Quotient.mkₐ _ _).prod (Ideal.Quotient.mkₐ _ _)) <|
     RingHom.prod_bijective_of_isIdempotentElem he hf hef₁ hef₂
-
-@[simp]
-lemma AlgEquiv.prodQuotientOfIsIdempotentElem_apply_fst (hef₁ : e + f = 1) (hef₂ : e * f = 0)
-    (s : S) : (AlgEquiv.prodQuotientOfIsIdempotentElem R he hf hef₁ hef₂ s).fst = s :=
-  rfl
-
-@[simp]
-lemma AlgEquiv.prodQuotientOfIsIdempotentElem_apply_snd (hef₁ : e + f = 1) (hef₂ : e * f = 0)
-    (s : S) : (AlgEquiv.prodQuotientOfIsIdempotentElem R he hf hef₁ hef₂ s).snd = s :=
-  rfl
-
-end
 
 end CommRing
 

--- a/Mathlib/RingTheory/Idempotents.lean
+++ b/Mathlib/RingTheory/Idempotents.lean
@@ -435,12 +435,15 @@ lemma CompleteOrthogonalIdempotents.bijective_pi' (he : CompleteOrthogonalIdempo
       Ideal.Quotient.mk (Ideal.span {e' i})) := ⟨_, funext (by simp), he.bijective_pi⟩
   exact h
 
-lemma RingHom.bijective_pi_of_isIdempotentElem (e : I → R)
+lemma RingHom.pi_bijective_of_isIdempotentElem (e : I → R)
     (he : ∀ i, IsIdempotentElem (e i))
     (he₁ : ∀ i j, i ≠ j → (1 - e i) * (1 - e j) = 0) (he₂ : ∏ i, e i = 0) :
     Function.Bijective (Pi.ringHom fun i ↦ Ideal.Quotient.mk (Ideal.span {e i})) :=
   (CompleteOrthogonalIdempotents.of_prod_one_sub
       ⟨fun i ↦ (he i).one_sub, he₁⟩ (by simpa using he₂)).bijective_pi'
+
+@[deprecated (since := "2025-01-05")]
+alias bijective_pi_of_isIdempotentElem := RingHom.pi_bijective_of_isIdempotentElem
 
 lemma RingHom.prod_bijective_of_isIdempotentElem {e f : R} (he : IsIdempotentElem e)
     (hf : IsIdempotentElem f) (hef₁ : e + f = 1) (hef₂ : e * f = 0) :
@@ -452,7 +455,7 @@ lemma RingHom.prod_bijective_of_isIdempotentElem {e f : R} (he : IsIdempotentEle
   show Function.Bijective
     (piFinTwoEquiv _ ∘ Pi.ringHom (fun i : Fin 2 ↦ Ideal.Quotient.mk (Ideal.span {o i})))
   rw [(Equiv.bijective _).of_comp_iff']
-  apply bijective_pi_of_isIdempotentElem
+  apply pi_bijective_of_isIdempotentElem
   · intro i
     fin_cases i <;> simpa [o]
   · intro i j hij

--- a/Mathlib/RingTheory/Idempotents.lean
+++ b/Mathlib/RingTheory/Idempotents.lean
@@ -435,12 +435,40 @@ lemma CompleteOrthogonalIdempotents.bijective_pi' (he : CompleteOrthogonalIdempo
       Ideal.Quotient.mk (Ideal.span {e' i})) := ⟨_, funext (by simp), he.bijective_pi⟩
   exact h
 
-lemma bijective_pi_of_isIdempotentElem (e : I → R)
+lemma RingHom.bijective_pi_of_isIdempotentElem (e : I → R)
     (he : ∀ i, IsIdempotentElem (e i))
     (he₁ : ∀ i j, i ≠ j → (1 - e i) * (1 - e j) = 0) (he₂ : ∏ i, e i = 0) :
     Function.Bijective (Pi.ringHom fun i ↦ Ideal.Quotient.mk (Ideal.span {e i})) :=
   (CompleteOrthogonalIdempotents.of_prod_one_sub
       ⟨fun i ↦ (he i).one_sub, he₁⟩ (by simpa using he₂)).bijective_pi'
+
+lemma RingHom.prod_bijective_of_isIdempotentElem {e f : R} (he : IsIdempotentElem e)
+    (hf : IsIdempotentElem f) (hef₁ : e + f = 1) (hef₂ : e * f = 0) :
+    Function.Bijective ((Ideal.Quotient.mk <| Ideal.span {e}).prod
+      (Ideal.Quotient.mk <| Ideal.span {f})) := by
+  let o (i : Fin 2) : R := match i with
+    | 0 => e
+    | 1 => f
+  show Function.Bijective
+    (piFinTwoEquiv _ ∘ Pi.ringHom (fun i : Fin 2 ↦ Ideal.Quotient.mk (Ideal.span {o i})))
+  rw [(Equiv.bijective _).of_comp_iff']
+  apply bijective_pi_of_isIdempotentElem
+  · intro i
+    fin_cases i <;> simpa [o]
+  · intro i j hij
+    fin_cases i <;> fin_cases j <;> simp at hij ⊢ <;>
+      simp [o, mul_comm, sub_mul, mul_sub, hef₂, ← hef₁]
+  · simpa
+
+/-- If `e` and `f` are idempotent elements such that `e + f = 1` and `e * f = 0`,
+`S` is isomorphic as an `R`-algebra to `S ⧸ (e) × S ⧸ (f)`. -/
+noncomputable
+def AlgEquiv.prodQuotientOfIsIdempotentElem {R S : Type*} [CommSemiring R] [CommRing S]
+    [Algebra R S] {e f : S} (he : IsIdempotentElem e) (hf : IsIdempotentElem f) (hef₁ : e + f = 1)
+    (hef₂ : e * f = 0) :
+    S ≃ₐ[R] (S ⧸ Ideal.span {e}) × S ⧸ Ideal.span {f} :=
+  AlgEquiv.ofBijective ((Ideal.Quotient.mkₐ _ _).prod (Ideal.Quotient.mkₐ _ _)) <|
+    RingHom.prod_bijective_of_isIdempotentElem he hf hef₁ hef₂
 
 end CommRing
 

--- a/Mathlib/RingTheory/Idempotents.lean
+++ b/Mathlib/RingTheory/Idempotents.lean
@@ -463,15 +463,31 @@ lemma RingHom.prod_bijective_of_isIdempotentElem {e f : R} (he : IsIdempotentEle
       simp [o, mul_comm, sub_mul, mul_sub, hef₂, ← hef₁]
   · simpa
 
+section
+
+variable {S : Type*} [CommRing S] [Algebra R S] {e f : S} (he : IsIdempotentElem e)
+  (hf : IsIdempotentElem f)
+
+variable (R) in
 /-- If `e` and `f` are idempotent elements such that `e + f = 1` and `e * f = 0`,
 `S` is isomorphic as an `R`-algebra to `S ⧸ (e) × S ⧸ (f)`. -/
-noncomputable
-def AlgEquiv.prodQuotientOfIsIdempotentElem {R S : Type*} [CommSemiring R] [CommRing S]
-    [Algebra R S] {e f : S} (he : IsIdempotentElem e) (hf : IsIdempotentElem f) (hef₁ : e + f = 1)
-    (hef₂ : e * f = 0) :
+@[simps! -isSimp apply]
+noncomputable def AlgEquiv.prodQuotientOfIsIdempotentElem (hef₁ : e + f = 1) (hef₂ : e * f = 0) :
     S ≃ₐ[R] (S ⧸ Ideal.span {e}) × S ⧸ Ideal.span {f} :=
   AlgEquiv.ofBijective ((Ideal.Quotient.mkₐ _ _).prod (Ideal.Quotient.mkₐ _ _)) <|
     RingHom.prod_bijective_of_isIdempotentElem he hf hef₁ hef₂
+
+@[simp]
+lemma AlgEquiv.prodQuotientOfIsIdempotentElem_apply_fst (hef₁ : e + f = 1) (hef₂ : e * f = 0)
+    (s : S) : (AlgEquiv.prodQuotientOfIsIdempotentElem R he hf hef₁ hef₂ s).fst = s :=
+  rfl
+
+@[simp]
+lemma AlgEquiv.prodQuotientOfIsIdempotentElem_apply_snd (hef₁ : e + f = 1) (hef₂ : e * f = 0)
+    (s : S) : (AlgEquiv.prodQuotientOfIsIdempotentElem R he hf hef₁ hef₂ s).snd = s :=
+  rfl
+
+end
 
 end CommRing
 


### PR DESCRIPTION
Also renames `bijective_pi_of_isIdempotentElem` to `RingHom.pi_bijective_of_isIdempotentElem`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
