### PR TITLE
[Merged by Bors] - feat(Geometry/Euclidean/Altitude): `altitudeFoot`, `height`

### DIFF
--- a/Mathlib/Geometry/Euclidean/Projection.lean
+++ b/Mathlib/Geometry/Euclidean/Projection.lean
@@ -564,19 +564,6 @@ theorem dist_sq_eq_dist_orthogonalProjection_sq_add_dist_orthogonalProjection_sq
     Submodule.inner_right_of_mem_orthogonal (vsub_orthogonalProjection_mem_direction p₂ hp₁)
       (orthogonalProjection_vsub_mem_direction_orthogonal _ p₂)
 
-variable {n : ℕ} [NeZero n] (s : Simplex ℝ P n)
-
-@[simp] lemma ne_orthogonalProjection_faceOpposite (i : Fin (n + 1)) :
-    s.points i ≠ (s.faceOpposite i).orthogonalProjectionSpan (s.points i) := by
-  intro h
-  rw [eq_comm, orthogonalProjectionSpan, EuclideanGeometry.orthogonalProjection_eq_self_iff,
-    mem_affineSpan_range_faceOpposite_points_iff] at h
-  simp at h
-
-lemma dist_orthogonalProjection_faceOpposite_pos (i : Fin (n + 1)) :
-    0 < dist (s.points i) ((s.faceOpposite i).orthogonalProjectionSpan (s.points i)) := by
-  simp
-
 end Simplex
 
 end Affine


### PR DESCRIPTION
As discussed in #23752, add definitions for the foot of an altitude of a simplex and the height of a vertex of a simplex.  Provide a minimal linkage to the definition of `altitude` (for example, `altitudeFoot` lies in the `altitude`).  No change is made to the definition or existing API for `altitude`.  (In particular, that definition uses an older style of `{n : ℕ} (s : Simplex ℝ P (n + 1))` where `faceOpposite` and `altitudeFoot` use the newer approach of `{n : ℕ} [NeZero n] (s : Simplex ℝ P n)`.)

The existing lemmas `ne_orthogonalProjection_faceOpposite` and `dist_orthogonalProjection_faceOpposite_pos` are changed to be about `altitudeFoot` and `height`, renamed and moved.  I think they are recent enough that no deprecations are needed.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
