### PR TITLE
[Merged by Bors] - refactor: rename `LinearAlgebra.FreeProductOfPowers` to `LinearAlgebra.FreeProduct.asPowers`, add simp shortcut to lift lemmas

### DIFF
--- a/Mathlib/LinearAlgebra/FreeProduct/Basic.lean
+++ b/Mathlib/LinearAlgebra/FreeProduct/Basic.lean
@@ -127,7 +127,7 @@ of tensor powers are (noncomputably) equivalent as `R`-algebras. -/
     PowerAlgebra R A ≃ₐ[R] FreeTensorAlgebra R A :=
   TensorAlgebra.equivDirectSum.symm
 
-@[deprecated (since := "2025-05-05")] alias powerAlgebra_equiv_freeAlgebra := 
+@[deprecated (since := "2025-05-05")] alias powerAlgebra_equiv_freeAlgebra :=
   powerAlgebraEquivFreeTensorAlgebra
 
 /-- The generating equivalence relation for elements of the free tensor algebra

--- a/Mathlib/LinearAlgebra/FreeProduct/Basic.lean
+++ b/Mathlib/LinearAlgebra/FreeProduct/Basic.lean
@@ -123,7 +123,7 @@ abbrev PowerAlgebra := ⨁ (n : ℕ), TensorPower R n (⨁ i, A i)
 
 /-- The free tensor algebra and its representation as an infinite direct sum
 of tensor powers are (noncomputably) equivalent as `R`-algebras. -/
-@[reducible] noncomputable def equivPowerAlgebraFreeAlgebra :
+@[reducible] noncomputable def powerAlgebraEquivFreeTensorAlgebra :
     PowerAlgebra R A ≃ₐ[R] FreeTensorAlgebra R A :=
   TensorAlgebra.equivDirectSum.symm
 
@@ -159,7 +159,7 @@ alias _root_.LinearAlgebra.FreeProduct_ofPowers := asPowers
 alias _root_.LinearAlgebra.FreeProductOfPowers := asPowers
 
 /-- The `R`-algebra equivalence relating `FreeProduct` and `FreeProduct_ofPowers` -/
-noncomputable def equivAsPowers : asPowers R A ≃ₐ[R] FreeProduct R A :=
+noncomputable def asPowersEquiv : asPowers R A ≃ₐ[R] FreeProduct R A :=
   RingQuot.algEquivQuotAlgEquiv
     (equivPowerAlgebraFreeAlgebra R A |>.symm) (FreeProduct.rel R A)
   |>.symm
@@ -242,7 +242,7 @@ to a unique arrow `π` from `FreeProduct R A` such that  `π ∘ ι i = maps i`.
 /-- Universal property of the free product of algebras, property:
 for every `R`-algebra `B`, every family of maps `maps : (i : I) → (A i →ₐ[R] B)` lifts
 to a unique arrow `π` from `FreeProduct R A` such that  `π ∘ ι i = maps i`. -/
-@[simp↓] theorem lift_comp_ι : (lift R A maps) ∘ₐ (ι R A i) = maps := by
+@[simp↓] theorem lift_comp_ι : lift R A maps ∘ₐ ι R A i = maps := by
   ext a
   simp [lift_apply, ι]
 

--- a/Mathlib/LinearAlgebra/FreeProduct/Basic.lean
+++ b/Mathlib/LinearAlgebra/FreeProduct/Basic.lean
@@ -127,7 +127,8 @@ of tensor powers are (noncomputably) equivalent as `R`-algebras. -/
     PowerAlgebra R A ≃ₐ[R] FreeTensorAlgebra R A :=
   TensorAlgebra.equivDirectSum.symm
 
-@[deprecated (since := "2025-05-05")] alias powerAlgebra_equiv_freeAlgebra := powerAlgebraEquivFreeTensorAlgebra
+@[deprecated (since := "2025-05-05")] alias powerAlgebra_equiv_freeAlgebra := 
+  powerAlgebraEquivFreeTensorAlgebra
 
 /-- The generating equivalence relation for elements of the free tensor algebra
 that are identified in the free product -/

--- a/Mathlib/LinearAlgebra/FreeProduct/Basic.lean
+++ b/Mathlib/LinearAlgebra/FreeProduct/Basic.lean
@@ -163,11 +163,11 @@ alias _root_.LinearAlgebra.FreeProductOfPowers := asPowers
 /-- The `R`-algebra equivalence relating `FreeProduct` and `FreeProduct_ofPowers` -/
 noncomputable def asPowersEquiv : asPowers R A ≃ₐ[R] FreeProduct R A :=
   RingQuot.algEquivQuotAlgEquiv
-    (equivPowerAlgebraFreeAlgebra R A |>.symm) (FreeProduct.rel R A)
+    (powerAlgebraEquivFreeTensorAlgebra R A |>.symm) (FreeProduct.rel R A)
   |>.symm
 
 @[deprecated (since := "2025-05-01")]
-alias equivPowerAlgebra := equivAsPowers
+alias equivPowerAlgebra := asPowersEquiv
 
 open RingQuot Function
 

--- a/Mathlib/LinearAlgebra/FreeProduct/Basic.lean
+++ b/Mathlib/LinearAlgebra/FreeProduct/Basic.lean
@@ -127,6 +127,8 @@ of tensor powers are (noncomputably) equivalent as `R`-algebras. -/
     PowerAlgebra R A ≃ₐ[R] FreeTensorAlgebra R A :=
   TensorAlgebra.equivDirectSum.symm
 
+@[deprecated (since := "2025-05-05")] alias powerAlgebra_equiv_freeAlgebra := powerAlgebraEquivFreeTensorAlgebra
+
 /-- The generating equivalence relation for elements of the free tensor algebra
 that are identified in the free product -/
 inductive rel : FreeTensorAlgebra R A → FreeTensorAlgebra R A → Prop

--- a/Mathlib/LinearAlgebra/FreeProduct/Basic.lean
+++ b/Mathlib/LinearAlgebra/FreeProduct/Basic.lean
@@ -161,7 +161,7 @@ alias _root_.LinearAlgebra.FreeProduct_ofPowers := asPowers
 @[deprecated (since := "2025-05-01")]
 alias _root_.LinearAlgebra.FreeProductOfPowers := asPowers
 
-/-- The `R`-algebra equivalence relating `FreeProduct` and `FreeProduct_ofPowers` -/
+/-- The `R`-algebra equivalence relating `FreeProduct` and `FreeProduct.asPowers`. -/
 noncomputable def asPowersEquiv : asPowers R A ≃ₐ[R] FreeProduct R A :=
   RingQuot.algEquivQuotAlgEquiv
     (powerAlgebraEquivFreeTensorAlgebra R A |>.symm) (FreeProduct.rel R A)

--- a/Mathlib/LinearAlgebra/FreeProduct/Basic.lean
+++ b/Mathlib/LinearAlgebra/FreeProduct/Basic.lean
@@ -21,8 +21,7 @@ to the whole tensor algebra in an `R`-linear way.
 
 The main result of this file is the universal property of the free product,
 which establishes the free product as the coproduct in the category of
-general $R$-algebras. (In the category of commutative $R$-algebras, the coproduct
-is just `PiTensorProduct`.)
+general $R$-algebras.
 
 ## Main definitions
 

--- a/Mathlib/LinearAlgebra/FreeProduct/Basic.lean
+++ b/Mathlib/LinearAlgebra/FreeProduct/Basic.lean
@@ -124,7 +124,7 @@ abbrev PowerAlgebra := ⨁ (n : ℕ), TensorPower R n (⨁ i, A i)
 
 /-- The free tensor algebra and its representation as an infinite direct sum
 of tensor powers are (noncomputably) equivalent as `R`-algebras. -/
-@[reducible] noncomputable def powerAlgebra_equiv_freeAlgebra :
+@[reducible] noncomputable def equivPowerAlgebraFreeAlgebra :
     PowerAlgebra R A ≃ₐ[R] FreeTensorAlgebra R A :=
   TensorAlgebra.equivDirectSum.symm
 
@@ -137,7 +137,7 @@ inductive rel : FreeTensorAlgebra R A → FreeTensorAlgebra R A → Prop
         (tprod R (⨁ i, A i) 2 (fun | 0 => lof R I A i a₁ | 1 => lof R I A i a₂))
         (ι R <| lof R I A i (a₁ * a₂))
 
-open scoped Function -- required for scoped `on` notation
+open scoped Function
 
 /-- The generating equivalence relation for elements of the power algebra
 that are identified in the free product -/
@@ -152,16 +152,21 @@ theorem rel_id (i : I) : rel R A (ι R <| lof R I A i 1) 1 := rel.id
 
 /-- The free product of the collection of `R`-algebras `A i`,
 as a quotient of `PowerAlgebra R A` -/
-@[reducible] def _root_.LinearAlgebra.FreeProductOfPowers := RingQuot <| FreeProduct.rel' R A
+@[reducible] def asPowers := RingQuot <| FreeProduct.rel' R A
 
 @[deprecated (since := "2024-12-07")]
-alias _root_.LinearAlgebra.FreeProduct_ofPowers := LinearAlgebra.FreeProductOfPowers
+alias _root_.LinearAlgebra.FreeProduct_ofPowers := asPowers
+@[deprecated (since := "2025-05-01")]
+alias _root_.LinearAlgebra.FreeProductOfPowers := asPowers
 
 /-- The `R`-algebra equivalence relating `FreeProduct` and `FreeProduct_ofPowers` -/
-noncomputable def equivPowerAlgebra : FreeProductOfPowers R A ≃ₐ[R] FreeProduct R A :=
+noncomputable def equivAsPowers : asPowers R A ≃ₐ[R] FreeProduct R A :=
   RingQuot.algEquivQuotAlgEquiv
-    (FreeProduct.powerAlgebra_equiv_freeAlgebra R A |>.symm) (FreeProduct.rel R A)
+    (equivPowerAlgebraFreeAlgebra R A |>.symm) (FreeProduct.rel R A)
   |>.symm
+
+@[deprecated (since := "2025-05-01")]
+alias equivPowerAlgebra := equivAsPowers
 
 open RingQuot Function
 
@@ -238,9 +243,12 @@ to a unique arrow `π` from `FreeProduct R A` such that  `π ∘ ι i = maps i`.
 /-- Universal property of the free product of algebras, property:
 for every `R`-algebra `B`, every family of maps `maps : (i : I) → (A i →ₐ[R] B)` lifts
 to a unique arrow `π` from `FreeProduct R A` such that  `π ∘ ι i = maps i`. -/
-theorem lift_comp_ι : (lift R A maps) ∘ₐ (ι R A i) = maps := by
+@[simp↓] theorem lift_comp_ι : (lift R A maps) ∘ₐ (ι R A i) = maps := by
   ext a
   simp [lift_apply, ι]
+
+@[simp↓] theorem lift_algebraMap (r : R) : lift R A maps (algebraMap R _ r) = algebraMap R _ r := by
+  rw [lift_apply, AlgHom.commutes]
 
 @[aesop safe destruct] theorem lift_unique
     (f : FreeProduct R A →ₐ[R] B) (h : ∀ i, f ∘ₐ ι R A i = maps) :


### PR DESCRIPTION
* Change names of `FreeProductOfPowers` to `FreeProduct.asPowers` and `equivPowerAlgebra` to `equivAsPowers`, in preparation for a `feat` adding API for the power algebra formulation.
* Add convenience "simp shortcut" attributes to some lift lemmas.


---

I made a complete hash of my environment trying to resolve merge conflicts with #15686, and eventually just gave up and decided to make an entirely new PR instead. As requested, I'm splitting this into two: one that establishes the name `asPowers` and applies the maintenance-y changes, and a followup that adds most of the lines. (I've decided to drop the performance opts entirely, as it no longer seems necessary and the explicit `simp_rw`s detract from maintainability.)

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
