### PR TITLE
feat(ULift): conjugation by ULift.up/down, misc cast/heq lemmas

### DIFF
--- a/Mathlib/Data/ULift.lean
+++ b/Mathlib/Data/ULift.lean
@@ -138,4 +138,34 @@ lemma rec_update {β : ULift α → Type*} [DecidableEq α]
   Function.rec_update up_injective (ULift.rec ·) (fun _ _ => rfl) (fun
     | _, _, .up _, h => (h _ rfl).elim) _ _ _
 
+def conj {α β : Type*} (f : ULift α → ULift β) : α → β := fun x => (f ⟨x⟩).down
+
+@[simp]
+lemma map_conj {α β : Type*} (f : ULift α → ULift β) : ULift.map (conj f) = f := by
+  ext ⟨x⟩; rfl
+
+@[simp]
+lemma conj_map {α β : Type*} (f : α → β) : conj (ULift.map f) = f := by
+  ext x; rfl
+
+lemma down_heq_inj {α β : Type u} (x : ULift.{u'} α) (y : ULift.{u'} β)
+    (h : HEq x.down y.down) : HEq x y := by
+  cases x; cases y; cases h; rfl
+
+@[simp]
+lemma down_heq_inj_iff {α β : Type u} (h : α = β)
+    (x : ULift.{u'} α) (y : ULift.{u'} β) : HEq x y ↔ HEq x.down y.down := by
+  refine ⟨fun h' => ?_, ULift.down_heq_inj x y⟩
+  cases h; cases h'; rfl
+
+@[simp]
+lemma cast_up_comm {α β} {a : α} (h : α = β) (h' : ULift α = ULift β := congrArg ULift h)
+    : (cast h' ⟨a⟩) = ⟨cast h a⟩ := by
+  cases h; cases h'; rfl
+
+@[simp]
+lemma cast_down_comm {α β} {a : α} (h : α = β) (h' : ULift α = ULift β := congrArg ULift h)
+    : (cast h' ⟨a⟩).down = cast h a := by
+  cases h; cases h'; rfl
+
 end ULift

--- a/Mathlib/Data/ULift.lean
+++ b/Mathlib/Data/ULift.lean
@@ -138,6 +138,7 @@ lemma rec_update {β : ULift α → Type*} [DecidableEq α]
   Function.rec_update up_injective (ULift.rec ·) (fun _ _ => rfl) (fun
     | _, _, .up _, h => (h _ rfl).elim) _ _ _
 
+/-- Conjugate a function by `ULift`ing. An inverse to `map`. -/
 def conj {α β : Type*} (f : ULift α → ULift β) : α → β := fun x => (f ⟨x⟩).down
 
 @[simp]

--- a/Mathlib/Data/ULift.lean
+++ b/Mathlib/Data/ULift.lean
@@ -155,7 +155,7 @@ lemma ext_heq {α β : Type u} (x : ULift.{u'} α) (y : ULift.{u'} β)
 @[simp]
 lemma ext_heq_iff {α β : Type u} (h : α = β)
     (x : ULift.{u'} α) (y : ULift.{u'} β) : HEq x y ↔ HEq x.down y.down := by
-  refine ⟨fun h' => ?_, ULift.down_heq_inj x y⟩
+  refine ⟨fun h' => ?_, ULift.ext_heq x y⟩
   cases h; cases h'; rfl
 
 @[simp]
@@ -164,7 +164,7 @@ lemma cast_up {α β} {a : α} (h : α = β) (h' : ULift α = ULift β := congrA
   cases h; cases h'; rfl
 
 @[simp]
-lemma cast_down {α β} {a : ULift α} (h : α = β) (h' : ULift α = ULift β := congrArg ULift h) :
+lemma down_cast {α β} {a : ULift α} (h : α = β) (h' : ULift α = ULift β := congrArg ULift h) :
     (cast h' a).down = cast h a.down := by
   cases h; cases h'; rfl
 

--- a/Mathlib/Data/ULift.lean
+++ b/Mathlib/Data/ULift.lean
@@ -164,8 +164,8 @@ lemma cast_up_comm {α β} {a : α} (h : α = β) (h' : ULift α = ULift β := c
   cases h; cases h'; rfl
 
 @[simp]
-lemma cast_down_comm {α β} {a : α} (h : α = β) (h' : ULift α = ULift β := congrArg ULift h)
-    : (cast h' ⟨a⟩).down = cast h a := by
+lemma cast_down_comm {α β} {a : ULift α} (h : α = β) (h' : ULift α = ULift β := congrArg ULift h)
+    : (cast h' a).down = cast h a.down := by
   cases h; cases h'; rfl
 
 end ULift

--- a/Mathlib/Data/ULift.lean
+++ b/Mathlib/Data/ULift.lean
@@ -148,24 +148,24 @@ lemma map_conj {α β : Type*} (f : ULift α → ULift β) : ULift.map (conj f) 
 lemma conj_map {α β : Type*} (f : α → β) : conj (ULift.map f) = f := by
   ext x; rfl
 
-lemma down_heq_inj {α β : Type u} (x : ULift.{u'} α) (y : ULift.{u'} β)
+lemma ext_heq {α β : Type u} (x : ULift.{u'} α) (y : ULift.{u'} β)
     (h : HEq x.down y.down) : HEq x y := by
   cases x; cases y; cases h; rfl
 
 @[simp]
-lemma down_heq_inj_iff {α β : Type u} (h : α = β)
+lemma ext_heq_iff {α β : Type u} (h : α = β)
     (x : ULift.{u'} α) (y : ULift.{u'} β) : HEq x y ↔ HEq x.down y.down := by
   refine ⟨fun h' => ?_, ULift.down_heq_inj x y⟩
   cases h; cases h'; rfl
 
 @[simp]
-lemma cast_up_comm {α β} {a : α} (h : α = β) (h' : ULift α = ULift β := congrArg ULift h)
-    : (cast h' ⟨a⟩) = ⟨cast h a⟩ := by
+lemma cast_up {α β} {a : α} (h : α = β) (h' : ULift α = ULift β := congrArg ULift h) :
+    (cast h' ⟨a⟩) = ⟨cast h a⟩ := by
   cases h; cases h'; rfl
 
 @[simp]
-lemma cast_down_comm {α β} {a : ULift α} (h : α = β) (h' : ULift α = ULift β := congrArg ULift h)
-    : (cast h' a).down = cast h a.down := by
+lemma cast_down {α β} {a : ULift α} (h : α = β) (h' : ULift α = ULift β := congrArg ULift h) :
+    (cast h' a).down = cast h a.down := by
   cases h; cases h'; rfl
 
 end ULift


### PR DESCRIPTION
* Adds the convenience def `ULift.conj x := `down (f (up x))`, and corresponding basic lemmas 
* Adds lemmas showing that `ULift.up` and `.down` commute with casts and preserve `HEq`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
