### PR TITLE
[Merged by Bors] - fix(Tactic/GeneralizeProofs): handle `let`s correctly

### DIFF
--- a/Mathlib/Tactic/GeneralizeProofs.lean
+++ b/Mathlib/Tactic/GeneralizeProofs.lean
@@ -390,10 +390,10 @@ where
       if fvars.contains fvar then
         -- This is one of the hypotheses that was intentionally reverted.
         let tgt ← instantiateMVars <| ← g.getType
-        let ty := tgt.bindingDomain!.cleanupAnnotations
+        let ty := (if tgt.isLet then tgt.letType! else tgt.bindingDomain!).cleanupAnnotations
         if ← pure tgt.isLet <&&> Meta.isProp ty then
           -- Clear the proof value (using proof irrelevance) and `go` again
-          let tgt' := Expr.forallE tgt.bindingName! ty tgt.bindingBody! .default
+          let tgt' := Expr.forallE tgt.letName! ty tgt.letBody! .default
           let g' ← mkFreshExprSyntheticOpaqueMVar tgt' tag
           g.assign <| .app g' tgt.letValue!
           return ← go g'.mvarId! i hs

--- a/MathlibTest/GeneralizeProofs.lean
+++ b/MathlibTest/GeneralizeProofs.lean
@@ -136,3 +136,56 @@ example (H : ∀ x, x = 1) : (if h : ∃ (k : ℕ), k = 1 then Classical.choose 
   apply H
 
 end
+
+section
+
+-- make sure it handles `let` declarations well
+
+-- this was https://github.com/leanprover-community/mathlib4/issues/24222
+example : True := by
+  let n : Fin 1 := ⟨0, id Nat.zero_lt_one⟩
+  generalize_proofs h at *
+  guard_hyp h :ₛ 0 < 1
+  guard_hyp n :=ₛ ⟨0, h⟩
+  trivial
+
+example : True := by
+  have h := Nat.zero_lt_one
+  let n : Fin 1 := ⟨0, id Nat.zero_lt_one⟩
+  generalize_proofs at *
+  guard_hyp h :ₛ 0 < 1
+  guard_hyp n :=ₛ ⟨0, h⟩
+  trivial
+
+example : True := by
+  let p := id Nat.zero_lt_one
+  generalize_proofs at *
+  guard_hyp p :ₛ 0 < 1
+  trivial
+
+example : True := by
+  let p := Nat.zero_lt_one
+  generalize_proofs at *
+  guard_hyp p :ₛ 0 < 1
+  let q := id Nat.zero_lt_one
+  generalize_proofs at *
+  fail_if_success change _ at q
+  guard_hyp p :ₛ 0 < 1
+  trivial
+
+example (P : Sort*) (p : P) : True := by
+  let p' : P := p
+  generalize_proofs at *
+  guard_hyp p :ₛ P
+  guard_hyp p' :=ₛ p
+  trivial
+
+example (P : True → Sort*) (p : True → P (by decide)) : True := by
+  let p' := p (by decide)
+  generalize_proofs h at *
+  guard_hyp h :ₛ True
+  guard_hyp p :ₛ True → P h
+  guard_hyp p' :=ₛ p h
+  exact h
+
+end


### PR DESCRIPTION
Fixes #24222


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
