### PR TITLE
[Merged by Bors] - feat (Small) : Shrink.rec_equivShrink

### DIFF
--- a/Mathlib/Logic/Small/Defs.lean
+++ b/Mathlib/Logic/Small/Defs.lean
@@ -59,6 +59,12 @@ protected noncomputable def Shrink.rec {α : Type*} [Small.{w} α] {F : Shrink �
     (h : ∀ X, F (equivShrink _ X)) : ∀ X, F X :=
   fun X => ((equivShrink _).apply_symm_apply X) ▸ (h _)
 
+@[simp]
+lemma Shrink.rec_equivShrink {α : Type*} [Small.{w} α] {F : Shrink α → Sort v}
+    {f : (a : α) → F (equivShrink α a)} (a : α) : Shrink.rec f (equivShrink _ a) = f a := by
+  simp only [Shrink.rec, eqRec_eq_cast, cast_eq_iff_heq]
+  rw [Equiv.symm_apply_apply]
+
 instance small_self (α : Type v) : Small.{v} α :=
   Small.mk' <| Equiv.refl α
 


### PR DESCRIPTION
* Adds a convenience lemma `Shrink.rec_equivShrink` that is very nearly the definitional property of `Shrink.rec`, but for whatever reason can't be automatically proven by `simp`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
