### PR TITLE
[Merged by Bors] - refactor(zulip-emoji-merge-delegate.py): consolidate repeated logic

### DIFF
--- a/scripts/zulip_emoji_merge_delegate.py
+++ b/scripts/zulip_emoji_merge_delegate.py
@@ -86,13 +86,16 @@ for message in messages:
         # removing previous emoji reactions
         # if the emoji is a custom emoji, add the fields `emoji_code` and `reaction_type` as well
         print("Removing previous reactions, if present.")
-        if has_peace_sign:
-            print('Removing peace_sign')
+        def remove_reaction(name: str, emoji_name: str) -> none:
+            print(f'Removing {name}')
             result = client.remove_reaction({
                 "message_id": message['id'],
-                "emoji_name": "peace_sign"
+                "emoji_name": emoji_name
             })
             print(f"result: '{result}'")
+
+        if has_peace_sign:
+            remove_reaction('delegated', 'peace_sign')
         if has_bors:
             print('Removing bors')
             result = client.remove_reaction({
@@ -103,26 +106,11 @@ for message in messages:
             })
             print(f"result: '{result}'")
         if has_merge:
-            print('Removing merge')
-            result = client.remove_reaction({
-                "message_id": message['id'],
-                "emoji_name": "merge"
-            })
-            print(f"result: '{result}'")
+            remove_reaction('merge', 'merge')
         if has_maintainer_merge:
-            print('Removing maintainer-merge')
-            result = client.remove_reaction({
-                "message_id": message['id'],
-                "emoji_name": "hammer"
-            })
-            print(f"result: '{result}'")
+            remove_reaction('maintainer-merge', 'hammer')
         if has_awaiting_author:
-            print('Removing awaiting-author')
-            result = client.remove_reaction({
-                "message_id": message['id'],
-                "emoji_name": "writing"
-            })
-            print(f"result: '{result}'")
+            remove_reaction('awaiting-author', 'writing')
         if has_closed:
             print('Removing closed-pr')
             result = client.remove_reaction({

--- a/scripts/zulip_emoji_merge_delegate.py
+++ b/scripts/zulip_emoji_merge_delegate.py
@@ -124,42 +124,24 @@ for message in messages:
 
         # applying appropriate emoji reaction
         print("Applying reactions, as appropriate.")
+        def add_reaction(name: str, emoji_name: str) -> none:
+            print(f'adding {name}')
+            result = client.add_reaction({
+                "message_id": message['id'],
+                "emoji_name": emoji_name
+            })
         if 'ready-to-merge' == LABEL:
-            print('adding ready-to-merge')
-            client.add_reaction({
-                "message_id": message['id'],
-                "emoji_name": "bors"
-            })
+            add_reaction('ready-to-merge', 'bors')
         elif 'delegated' == LABEL:
-            print('adding delegated')
-            client.add_reaction({
-                "message_id": message['id'],
-                "emoji_name": "peace_sign"
-            })
+            add_reaction('delegated', 'peace_sign')
         elif 'maintainer-merge' == LABEL:
-            print('adding maintainer-merge')
-            client.add_reaction({
-                "message_id": message['id'],
-                "emoji_name": "hammer"
-            })
+            add_reaction('maintainer-merge', 'hammer')
         elif LABEL == 'labeled':
-            print('adding awaiting-author')
-            client.add_reaction({
-                "message_id": message['id'],
-                "emoji_name": "writing"
-            })
+            add_reaction('awaiting-author', 'writing')
         elif LABEL == 'closed':
-            print('adding closed-pr')
-            client.add_reaction({
-                "message_id": message['id'],
-                "emoji_name": "closed-pr"
-            })
+            add_reaction('closed-pr', 'closed-pr')
         elif LABEL == 'unlabeled':
             print('awaiting-author removed')
             # the reaction was already removed.
         elif LABEL.startswith("[Merged by Bors]"):
-            print('adding [Merged by Bors]')
-            client.add_reaction({
-                "message_id": message['id'],
-                "emoji_name": "merge"
-            })
+            add_reaction('[Merged by Bors]', 'merge')

--- a/scripts/zulip_emoji_merge_delegate.py
+++ b/scripts/zulip_emoji_merge_delegate.py
@@ -68,12 +68,15 @@ for message in messages:
     content = message['content']
     # Check for emoji reactions
     reactions = message['reactions']
-    has_peace_sign = any(reaction['emoji_name'] == 'peace_sign' for reaction in reactions)
-    has_bors = any(reaction['emoji_name'] == 'bors' for reaction in reactions)
-    has_merge = any(reaction['emoji_name'] == 'merge' for reaction in reactions)
-    has_awaiting_author = any(reaction['emoji_name'] == 'writing' for reaction in reactions)
-    has_maintainer_merge = any(reaction['emoji_name'] == 'hammer' for reaction in reactions)
-    has_closed = any(reaction['emoji_name'] == 'closed-pr' for reaction in reactions)
+    # Does this message have any reaction with an emoji |name|?
+    has_reaction = lambda name: any(reaction['emoji_name'] == name for reaction in reactions)
+
+    has_peace_sign = has_reaction('peace_sign')
+    has_bors = has_reaction('bors')
+    has_merge = has_reaction('merge')
+    has_awaiting_author = has_reaction('writing')
+    has_maintainer_merge = has_reaction('hammer')
+    has_closed = has_reaction('closed-pr')
     first_in_thread = hashPR.search(message['subject']) and message['display_recipient'] == 'PR reviews' and message['subject'] not in first_by_subject
     first_by_subject[message['subject']] = message['id']
     match = urlPR.search(content) or first_in_thread

--- a/scripts/zulip_emoji_merge_delegate.py
+++ b/scripts/zulip_emoji_merge_delegate.py
@@ -86,25 +86,19 @@ for message in messages:
         # removing previous emoji reactions
         # if the emoji is a custom emoji, add the fields `emoji_code` and `reaction_type` as well
         print("Removing previous reactions, if present.")
-        def remove_reaction(name: str, emoji_name: str) -> none:
+        def remove_reaction(name: str, emoji_name: str, **kwargs) -> none:
             print(f'Removing {name}')
             result = client.remove_reaction({
                 "message_id": message['id'],
-                "emoji_name": emoji_name
+                "emoji_name": emoji_name,
+                **kwargs
             })
             print(f"result: '{result}'")
 
         if has_peace_sign:
             remove_reaction('delegated', 'peace_sign')
         if has_bors:
-            print('Removing bors')
-            result = client.remove_reaction({
-                "message_id": message['id'],
-                "emoji_name": "bors",
-                "emoji_code": "22134",
-                "reaction_type": "realm_emoji",
-            })
-            print(f"result: '{result}'")
+            remove_reaction("bors", "bors", emoji_code="22134", reaction_type="realm_emoji")
         if has_merge:
             remove_reaction('merge', 'merge')
         if has_maintainer_merge:
@@ -112,15 +106,8 @@ for message in messages:
         if has_awaiting_author:
             remove_reaction('awaiting-author', 'writing')
         if has_closed:
-            print('Removing closed-pr')
-            result = client.remove_reaction({
-                "message_id": message['id'],
-                "emoji_name": "closed-pr",
-                "emoji_code": "61293",  # 61282 was the earlier version of the emoji
-                "reaction_type": "realm_emoji",
-            })
-            print(f"result: '{result}'")
-
+            # 61282 was the earlier version of the emoji
+            remove_reaction('closed-pr', 'closed-pr', emoji_code="61293", reaction_type="realm_emoji")
 
         # applying appropriate emoji reaction
         print("Applying reactions, as appropriate.")

--- a/scripts/zulip_emoji_merge_delegate.py
+++ b/scripts/zulip_emoji_merge_delegate.py
@@ -84,9 +84,9 @@ for message in messages:
         print(f"matched: '{message}'")
 
         # removing previous emoji reactions
-        # if the emoji is a custom emoji, add the fields `emoji_code` and `reaction_type` as well
+        # If the emoji is a custom emoji, add the fields `emoji_code` and `reaction_type` as well.
         print("Removing previous reactions, if present.")
-        def remove_reaction(name: str, emoji_name: str, **kwargs) -> none:
+        def remove_reaction(name: str, emoji_name: str, **kwargs) -> None:
             print(f'Removing {name}')
             result = client.remove_reaction({
                 "message_id": message['id'],


### PR DESCRIPTION
This script repeats the same logic for all ~5 different emojis now: extract the logic into short functions to make the code shorter.

---

Commits are best reviewed individually.

- [x] depends on: #24544

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
