### PR TITLE
[Merged by Bors] - fix(Module/Equiv): fix `LinearEquiv.coe_mk`

### DIFF
--- a/Mathlib/Algebra/Category/ModuleCat/Projective.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Projective.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus Himmel, Kim Morrison
 -/
 import Mathlib.Algebra.Category.ModuleCat.EpiMono
-import Mathlib.Algebra.Equiv.TransferInstance
+import Mathlib.Algebra.Small.Group
 import Mathlib.Algebra.Module.Projective
 import Mathlib.CategoryTheory.Preadditive.Projective.Basic
 
@@ -53,12 +53,9 @@ instance enoughProjectives [Small.{v} R] : EnoughProjectives (ModuleCat.{v} R) w
     ⟨{p := ModuleCat.of R (M →₀ Shrink.{v} R)
       projective := projective_of_free e
       f := ofHom <| e.constr ℕ _root_.id
-      epi := (epi_iff_range_eq_top _).mpr <| range_eq_top.2 fun m => ⟨Finsupp.single m 1, by
-        simp only [Basis.constr, Finsupp.mapRange.linearEquiv_apply, Finsupp.mapRange_single,
-          LinearEquiv.coe_mk, Finsupp.lmapDomain_id, id_comp, hom_ofHom, LinearMap.coe_comp,
-          Function.comp_apply, LinearEquiv.coe_coe, Shrink.linearEquiv_apply,
-          Finsupp.linearCombination_single, e]
-        rw [show (equivShrink R).symm 1 = 1 from (equivShrink R).symm_apply_apply 1]
-        exact MulAction.one_smul m⟩}⟩
+      epi := by
+        rw [epi_iff_range_eq_top, range_eq_top]
+        refine fun m ↦ ⟨Finsupp.single m 1, ?_⟩
+        simp [e, Basis.constr_apply] }⟩
 
 end ModuleCat

--- a/Mathlib/Algebra/Module/Equiv/Defs.lean
+++ b/Mathlib/Algebra/Module/Equiv/Defs.lean
@@ -175,8 +175,8 @@ theorem toLinearMap_eq_coe {e : M ≃ₛₗ[σ] M₂} : e.toLinearMap = Semiline
   rfl
 
 @[simp]
-theorem coe_mk {to_fun inv_fun map_add map_smul left_inv right_inv} :
-    (⟨⟨⟨to_fun, map_add⟩, map_smul⟩, inv_fun, left_inv, right_inv⟩ : M ≃ₛₗ[σ] M₂) = to_fun := rfl
+theorem coe_mk {f invFun left_inv right_inv} :
+    ((⟨f, invFun, left_inv, right_inv⟩ : M ≃ₛₗ[σ] M₂) : M → M₂) = f := rfl
 
 theorem coe_injective : @Injective (M ≃ₛₗ[σ] M₂) (M → M₂) CoeFun.coe :=
   DFunLike.coe_injective

--- a/Mathlib/Analysis/InnerProductSpace/Projection.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Projection.lean
@@ -642,11 +642,7 @@ def reflection : E ≃ₗᵢ[𝕜] E :=
       let v := x - w
       have : ⟪v, w⟫ = 0 := orthogonalProjection_inner_eq_zero x w w.2
       convert norm_sub_eq_norm_add this using 2
-      · rw [LinearEquiv.coe_mk, reflectionLinearEquiv, LinearEquiv.toFun_eq_coe,
-          LinearEquiv.coe_ofInvolutive, LinearMap.sub_apply, LinearMap.id_apply, two_smul,
-          LinearMap.add_apply, LinearMap.comp_apply, Submodule.subtype_apply,
-          ContinuousLinearMap.coe_coe]
-        dsimp [v]
+      · dsimp [reflectionLinearEquiv, v]
         abel
       · simp only [v, add_sub_cancel, eq_self_iff_true] }
 

--- a/Mathlib/Analysis/NormedSpace/Multilinear/Curry.lean
+++ b/Mathlib/Analysis/NormedSpace/Multilinear/Curry.lean
@@ -62,9 +62,7 @@ theorem ContinuousLinearMap.norm_map_tail_le
     ‖f (m 0) (tail m)‖ ≤ ‖f (m 0)‖ * ∏ i, ‖(tail m) i‖ := (f (m 0)).le_opNorm _
     _ ≤ ‖f‖ * ‖m 0‖ * ∏ i, ‖tail m i‖ := mul_le_mul_of_nonneg_right (f.le_opNorm _) <| by positivity
     _ = ‖f‖ * (‖m 0‖ * ∏ i, ‖(tail m) i‖) := by ring
-    _ = ‖f‖ * ∏ i, ‖m i‖ := by
-      rw [prod_univ_succ]
-      rfl
+    _ = ‖f‖ * ∏ i, ‖m i‖ := by simp only [prod_univ_succ, Fin.tail]
 
 theorem ContinuousMultilinearMap.norm_map_init_le
     (f : ContinuousMultilinearMap 𝕜 (fun i : Fin n => Ei <| castSucc i) (Ei (last n) →L[𝕜] G))
@@ -74,9 +72,7 @@ theorem ContinuousMultilinearMap.norm_map_init_le
     _ ≤ (‖f‖ * ∏ i, ‖(init m) i‖) * ‖m (last n)‖ :=
       (mul_le_mul_of_nonneg_right (f.le_opNorm _) (norm_nonneg _))
     _ = ‖f‖ * ((∏ i, ‖(init m) i‖) * ‖m (last n)‖) := mul_assoc _ _ _
-    _ = ‖f‖ * ∏ i, ‖m i‖ := by
-      rw [prod_univ_castSucc]
-      rfl
+    _ = ‖f‖ * ∏ i, ‖m i‖ := by simp only [prod_univ_castSucc, Fin.init]
 
 theorem ContinuousMultilinearMap.norm_map_cons_le (f : ContinuousMultilinearMap 𝕜 Ei G) (x : Ei 0)
     (m : ∀ i : Fin n, Ei i.succ) : ‖f (cons x m)‖ ≤ ‖f‖ * ‖x‖ * ∏ i, ‖m i‖ :=
@@ -174,7 +170,7 @@ def continuousMultilinearCurryLeftEquiv :
       left_inv := ContinuousMultilinearMap.uncurry_curryLeft
       right_inv := ContinuousLinearMap.curry_uncurryLeft }
     (fun f => by
-      simp only [LinearEquiv.coe_mk]
+      simp only [LinearEquiv.coe_mk, LinearMap.coe_mk, AddHom.coe_mk]
       exact LinearMap.mkContinuous_norm_le _ (norm_nonneg f) _)
     (fun f => by
       simp only [LinearEquiv.coe_symm_mk]
@@ -288,7 +284,7 @@ def continuousMultilinearCurryRightEquiv :
       left_inv := ContinuousMultilinearMap.uncurry_curryRight
       right_inv := ContinuousMultilinearMap.curry_uncurryRight }
     (fun f => by
-      simp only [curryRight, LinearEquiv.coe_mk]
+      simp only [curryRight, LinearEquiv.coe_mk, LinearMap.coe_mk, AddHom.coe_mk]
       exact MultilinearMap.mkContinuous_norm_le _ (norm_nonneg f) _)
     (fun f => by
       simp only [uncurryRight, LinearEquiv.coe_symm_mk]

--- a/Mathlib/Analysis/NormedSpace/PiTensorProduct/InjectiveSeminorm.lean
+++ b/Mathlib/Analysis/NormedSpace/PiTensorProduct/InjectiveSeminorm.lean
@@ -269,12 +269,10 @@ noncomputable def liftIsometry : ContinuousMultilinearMap 𝕜 E F ≃ₗᵢ[�
     norm_map' := by
       intro f
       refine le_antisymm ?_ ?_
-      · simp only [liftEquiv, lift_symm, LinearEquiv.coe_mk]
+      · simp only [liftEquiv_apply]
         exact LinearMap.mkContinuous_norm_le _ (norm_nonneg f) _
-      · conv_lhs => rw [← (liftEquiv 𝕜 E F).left_inv f]
-        simp only [liftEquiv, lift_symm, AddHom.toFun_eq_coe, AddHom.coe_mk,
-          LinearEquiv.invFun_eq_symm, LinearEquiv.coe_symm_mk, LinearMap.mkContinuous_coe,
-          LinearEquiv.coe_mk]
+      · conv_lhs => rw [← (liftEquiv 𝕜 E F).symm_apply_apply f]
+        rw [liftEquiv_symm_apply]
         exact MultilinearMap.mkContinuous_norm_le _ (norm_nonneg _) _ }
 
 variable {𝕜 E F}

--- a/Mathlib/Data/Finsupp/Basic.lean
+++ b/Mathlib/Data/Finsupp/Basic.lean
@@ -1113,6 +1113,7 @@ theorem uncurry_curry (f : α × β →₀ M) : f.curry.uncurry = f := by
 
 /-- `finsuppProdEquiv` defines the `Equiv` between `((α × β) →₀ M)` and `(α →₀ (β →₀ M))` given by
 currying and uncurrying. -/
+@[simps]
 def finsuppProdEquiv : (α × β →₀ M) ≃ (α →₀ β →₀ M) where
   toFun := Finsupp.curry
   invFun := Finsupp.uncurry

--- a/Mathlib/LinearAlgebra/Finsupp/Defs.lean
+++ b/Mathlib/LinearAlgebra/Finsupp/Defs.lean
@@ -234,17 +234,13 @@ This is the `LinearEquiv` version of `Finsupp.finsuppProdEquiv`. -/
 noncomputable def finsuppProdLEquiv {α β : Type*} (R : Type*) {M : Type*} [Semiring R]
     [AddCommMonoid M] [Module R M] : (α × β →₀ M) ≃ₗ[R] α →₀ β →₀ M :=
   { finsuppProdEquiv with
-    map_add' := fun f g => by
-      ext
-      simp [finsuppProdEquiv, curry_apply]
-    map_smul' := fun c f => by
-      ext
-      simp [finsuppProdEquiv, curry_apply] }
+    map_add' f g := by ext; simp
+    map_smul' c f := by ext; simp }
 
 @[simp]
 theorem finsuppProdLEquiv_apply {α β R M : Type*} [Semiring R] [AddCommMonoid M] [Module R M]
     (f : α × β →₀ M) (x y) : finsuppProdLEquiv R f x y = f (x, y) := by
-  rw [finsuppProdLEquiv, LinearEquiv.coe_mk, finsuppProdEquiv, Finsupp.curry_apply]
+  simp [finsuppProdLEquiv]
 
 @[simp]
 theorem finsuppProdLEquiv_symm_apply {α β R M : Type*} [Semiring R] [AddCommMonoid M] [Module R M]
@@ -271,9 +267,9 @@ def Module.subsingletonEquiv (R M ι : Type*) [Semiring R] [Subsingleton R] [Add
     [Module R M] : M ≃ₗ[R] ι →₀ R where
   toFun _ := 0
   invFun _ := 0
-  left_inv m := by
-    letI := Module.subsingleton R M
-    simp only [eq_iff_true_of_subsingleton]
+  left_inv m :=
+    have := Module.subsingleton R M
+    Subsingleton.elim _ _
   right_inv f := by simp only [eq_iff_true_of_subsingleton]
   map_add' _ _ := (add_zero 0).symm
   map_smul' r _ := (smul_zero r).symm

--- a/Mathlib/LinearAlgebra/Matrix/SesquilinearForm.lean
+++ b/Mathlib/LinearAlgebra/Matrix/SesquilinearForm.lean
@@ -260,7 +260,7 @@ theorem LinearMap.toMatrix₂'_compl₁₂ (B : (n → R) →ₗ[R] (m → R) �
     toMatrix₂' R (B.compl₁₂ l r) = (toMatrix' l)ᵀ * toMatrix₂' R B * toMatrix' r := by
   ext i j
   simp only [LinearMap.toMatrix₂'_apply, LinearMap.compl₁₂_apply, transpose_apply, Matrix.mul_apply,
-    LinearMap.toMatrix', LinearEquiv.coe_mk, sum_mul]
+    LinearMap.toMatrix', LinearEquiv.coe_mk, LinearMap.coe_mk, AddHom.coe_mk, sum_mul]
   rw [sum_comm]
   conv_lhs => rw [← LinearMap.sum_repr_mul_repr_mul (Pi.basisFun R n) (Pi.basisFun R m) (l _) (r _)]
   rw [Finsupp.sum_fintype]

--- a/Mathlib/LinearAlgebra/Matrix/ToLin.lean
+++ b/Mathlib/LinearAlgebra/Matrix/ToLin.lean
@@ -328,11 +328,7 @@ theorem Matrix.toLin'_toMatrix' (f : (n → R) →ₗ[R] m → R) :
 @[simp]
 theorem LinearMap.toMatrix'_apply (f : (n → R) →ₗ[R] m → R) (i j) :
     LinearMap.toMatrix' f i j = f (fun j' ↦ if j' = j then 1 else 0) i := by
-  simp only [LinearMap.toMatrix', LinearEquiv.coe_mk, of_apply]
-  congr! with i
-  split_ifs with h
-  · rw [h, Pi.single_eq_same]
-  apply Pi.single_eq_of_ne h
+  simp [toMatrix', ← Pi.single_apply]
 
 @[simp]
 theorem Matrix.toLin'_apply (M : Matrix m n R) (v : n → R) : Matrix.toLin' M v = M *ᵥ v :=

--- a/Mathlib/LinearAlgebra/PiTensorProduct.lean
+++ b/Mathlib/LinearAlgebra/PiTensorProduct.lean
@@ -747,9 +747,7 @@ theorem reindex_reindex (e : ι ≃ ι₂) (e' : ι₂ ≃ ι₃) (x : ⨂[R] i,
 theorem reindex_symm (e : ι ≃ ι₂) :
     (reindex R (fun _ ↦ M) e).symm = reindex R (fun _ ↦ M) e.symm := by
   ext x
-  simp only [reindex, domDomCongrLinearEquiv', LinearEquiv.coe_symm_mk, LinearEquiv.coe_mk,
-    LinearEquiv.ofLinear_symm_apply, Equiv.symm_symm_apply, LinearEquiv.ofLinear_apply,
-    Equiv.piCongrLeft'_symm]
+  simp [reindex]
 
 @[simp]
 theorem reindex_refl : reindex R s (Equiv.refl ι) = LinearEquiv.refl R _ := by

--- a/Mathlib/NumberTheory/Padics/MahlerBasis.lean
+++ b/Mathlib/NumberTheory/Padics/MahlerBasis.lean
@@ -369,8 +369,7 @@ noncomputable def mahlerEquiv : C(ℤ_[p], E) ≃ₗᵢ[ℤ_[p]] C₀(ℕ, E) wh
     · rw [← (hasSum_mahler f).tsum_eq]
       refine (norm_tsum_le _).trans (ciSup_le fun n ↦ ?_)
       refine le_trans (le_of_eq ?_) (BoundedContinuousFunction.norm_coe_le_norm _ n)
-      simp only [ZeroAtInftyContinuousMap.toBCF_apply, ZeroAtInftyContinuousMap.coe_mk,
-        norm_mahlerTerm, (hasSum_mahler f).tsum_eq]
+      simp [(hasSum_mahler f).tsum_eq]
 
 lemma mahlerEquiv_apply (f : C(ℤ_[p], E)) : mahlerEquiv E f = fun n ↦ Δ_[1]^[n] f 0 := rfl
 


### PR DESCRIPTION
Make it work with any application of `LinearEquiv.mk`,
not only applications that go all the way to `AddHom.mk`.

Golf some of the proofs broken by this change.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
