### PR TITLE
[Merged by Bors] - fix(zulip_emoji_merge_delegate.py): correct type hint

### DIFF
--- a/scripts/zulip_emoji_merge_delegate.py
+++ b/scripts/zulip_emoji_merge_delegate.py
@@ -111,7 +111,7 @@ for message in messages:
 
         # applying appropriate emoji reaction
         print("Applying reactions, as appropriate.")
-        def add_reaction(name: str, emoji_name: str) -> none:
+        def add_reaction(name: str, emoji_name: str) -> None:
             print(f'adding {name}')
             result = client.add_reaction({
                 "message_id": message['id'],

--- a/scripts/zulip_emoji_merge_delegate.py
+++ b/scripts/zulip_emoji_merge_delegate.py
@@ -83,7 +83,7 @@ for message in messages:
     if match:
         print(f"matched: '{message}'")
 
-        # removing previous emoji reactions
+        # Removing all previous emoji reactions.
         # If the emoji is a custom emoji, add the fields `emoji_code` and `reaction_type` as well.
         print("Removing previous reactions, if present.")
         def remove_reaction(name: str, emoji_name: str, **kwargs) -> None:
@@ -106,7 +106,7 @@ for message in messages:
         if has_awaiting_author:
             remove_reaction('awaiting-author', 'writing')
         if has_closed:
-            # 61282 was the earlier version of the emoji
+            # 61282 was the earlier version of the emoji.
             remove_reaction('closed-pr', 'closed-pr', emoji_code="61293", reaction_type="realm_emoji")
 
         # applying appropriate emoji reaction
@@ -129,6 +129,6 @@ for message in messages:
             add_reaction('closed-pr', 'closed-pr')
         elif LABEL == 'unlabeled':
             print('awaiting-author removed')
-            # the reaction was already removed.
+            # The reaction was already removed.
         elif LABEL.startswith("[Merged by Bors]"):
             add_reaction('[Merged by Bors]', 'merge')


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
