### PR TITLE
[Merged by Bors] - chore: document emoji reactions workflow

### DIFF
--- a/.github/workflows/maintainer_bors.yml
+++ b/.github/workflows/maintainer_bors.yml
@@ -134,4 +134,4 @@ jobs:
           ZULIP_EMAIL: github-mathlib4-bot@leanprover.zulipchat.com
           ZULIP_SITE: https://leanprover.zulipchat.com
         run: |
-          python scripts/zulip_emoji_merge_delegate.py "$ZULIP_API_KEY" "$ZULIP_EMAIL" "$ZULIP_SITE" "${{ steps.merge_or_delegate.outputs.mOrD }}" "${{ github.event.issue.number }}${{ github.event.pull_request.number }}"
+          python scripts/zulip_emoji_merge_delegate.py "$ZULIP_API_KEY" "$ZULIP_EMAIL" "$ZULIP_SITE" "${{ steps.merge_or_delegate.outputs.mOrD }}" "${{ steps.merge_or_delegate.outputs.mOrD }}" "${{ github.event.issue.number }}${{ github.event.pull_request.number }}"

--- a/.github/workflows/zulip_emoji_closed_pr.yaml
+++ b/.github/workflows/zulip_emoji_closed_pr.yaml
@@ -54,8 +54,6 @@ jobs:
           ZULIP_SITE: https://leanprover.zulipchat.com
         run: |
           # ${{ github.event.action }} is either "closed" or "reopened"
-          # however, it only matters that it is either "closed" or
-          # something different from "closed"
-          # the effect is to add the "closed-pr" emoji to the message, if it is "closed"
-          # and to remove it otherwise
-          python scripts/zulip_emoji_merge_delegate.py "$ZULIP_API_KEY" "$ZULIP_EMAIL" "$ZULIP_SITE" "${{ github.event.action }}" "${{ github.event.pull_request.number }}"
+          # We add the "closed-pr" emoji to the message, if it is "closed"
+          # and to remove the emoji if the action is "reopen".
+          python scripts/zulip_emoji_merge_delegate.py "$ZULIP_API_KEY" "$ZULIP_EMAIL" "$ZULIP_SITE" "${{ github.event.action }}" "none" "${{ github.event.pull_request.number }}"

--- a/.github/workflows/zulip_emoji_labelling.yaml
+++ b/.github/workflows/zulip_emoji_labelling.yaml
@@ -31,7 +31,7 @@ jobs:
         ZULIP_SITE: https://leanprover.zulipchat.com
         PR_NUMBER: ${{ github.event.number}}
         LABEL_STATUS: ${{ github.event.action }}
-        LABEL: ${{ github.event.label.name }}
+        LABEL_NAME: ${{ github.event.label.name }}
       run: |
         printf $'Running the python script with pr "%s"\n' "$PR_NUMBER" "$LABEL_STATUS" "$LABEL"
-        python scripts/zulip_emoji_merge_delegate.py "$ZULIP_API_KEY" "$ZULIP_EMAIL" "$ZULIP_SITE" "$LABEL_STATUS" "$LABEL" "$PR_NUMBER"
+        python scripts/zulip_emoji_merge_delegate.py "$ZULIP_API_KEY" "$ZULIP_EMAIL" "$ZULIP_SITE" "$LABEL_STATUS" "$LABEL_NAME" "$PR_NUMBER"

--- a/.github/workflows/zulip_emoji_labelling.yaml
+++ b/.github/workflows/zulip_emoji_labelling.yaml
@@ -31,6 +31,7 @@ jobs:
         ZULIP_SITE: https://leanprover.zulipchat.com
         PR_NUMBER: ${{ github.event.number}}
         LABEL_STATUS: ${{ github.event.action }}
+        LABEL: ${{ github.event.label.name }}
       run: |
-        printf $'Running the python script with pr "%s"\n' "$PR_NUMBER" "$LABEL_STATUS"
-        python scripts/zulip_emoji_merge_delegate.py "$ZULIP_API_KEY" "$ZULIP_EMAIL" "$ZULIP_SITE" "$LABEL_STATUS" "$PR_NUMBER"
+        printf $'Running the python script with pr "%s"\n' "$PR_NUMBER" "$LABEL_STATUS" "$LABEL"
+        python scripts/zulip_emoji_merge_delegate.py "$ZULIP_API_KEY" "$ZULIP_EMAIL" "$ZULIP_SITE" "$LABEL_STATUS" "$LABEL" "$PR_NUMBER"

--- a/.github/workflows/zulip_emoji_merge_delegate.yaml
+++ b/.github/workflows/zulip_emoji_merge_delegate.yaml
@@ -38,5 +38,5 @@ jobs:
           printf $'Scanning commits:\n%s\n\nContinuing\n' "$(git log --since="10 minutes ago" --pretty=oneline)"
           while read -r pr_number; do
             printf $'Running the python script with pr "%s"\n' "${pr_number}"
-            python scripts/zulip_emoji_merge_delegate.py "$ZULIP_API_KEY" "$ZULIP_EMAIL" "$ZULIP_SITE" "[Merged by Bors]" "${pr_number}"
+            python scripts/zulip_emoji_merge_delegate.py "$ZULIP_API_KEY" "$ZULIP_EMAIL" "$ZULIP_SITE" "[Merged by Bors]" "none" "${pr_number}"
           done < <(git log --oneline -n 10 | awk -F# '{ gsub(/)$/, ""); print $NF}')

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -112,9 +112,10 @@ please do not add new entries to these files. PRs removing (the need for) entrie
   * whenever a PR is labelled or unlabelled with `awaiting-author` or `maintainer-merge`
   It looks through all zulip posts containing a reference to the relevant PR
   and will post or update an emoji reaction corresponding to the current PR state to the message.
-  This reaction is `:peace_sign:` for delegated, `:bors:` for PRs sent to bors, `:merge` for merged
-  PRs, `:writing:` for PRs awaiting-author, `:hammer:` for maintainer-merged PRs and
-  `:closed-pr:` for closed PRs. Two of these are custom emojis configured on zulip.
+  This reaction is ✌️ (`:peace_sign:`) for delegated, `:bors:` for PRs sent to bors,
+  `:merge` for merged PRs, ✍️ (`:writing:`) for PRs awaiting-author,
+  🔨 (`:hammer:`) for maintainer-merged PRs and `:closed-pr:` for closed PRs.
+  Two of these are custom emojis configured on zulip.
 - `late_importers.sh` is the main script used by the `latest_import.yml` action: it formats
   the `linter.minImports` output, summarizing the data in a table.  See the module docs of
   `late_importers.sh` for further details.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -106,7 +106,7 @@ please do not add new entries to these files. PRs removing (the need for) entrie
 - `count-trans-deps.py`, `import-graph-report.py` and `import_trans_difference.sh` produce various
   summaries of changes in transitive imports that the `PR_summary` message incorporates.
 - `zulip_emoji_merge_delegate.py` is called
-  * every time a `bors d`, `bors merge` or `bors r+` comment is added to a PR,
+  * every time a `bors d`, `bors merge` or `bors r` comment is added to a PR,
   * whenever bors merges a PR,
   * whenever a PR is closed or reopened
   * whenever a PR is labelled or unlabelled with `awaiting-author` or `maintainer-merge`

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -106,11 +106,15 @@ please do not add new entries to these files. PRs removing (the need for) entrie
 - `count-trans-deps.py`, `import-graph-report.py` and `import_trans_difference.sh` produce various
   summaries of changes in transitive imports that the `PR_summary` message incorporates.
 - `zulip_emoji_merge_delegate.py` is called
-  * every time a `bors d`, `bors merge` or `bors r+` comment is added to a PR and
-  * on every push to `master`.
+  * every time a `bors d`, `bors merge` or `bors r+` comment is added to a PR,
+  * whenever bors merges a PR,
+  * whenever a PR is closed or reopened
+  * whenever a PR is labelled or unlabelled with `awaiting-author` or `maintainer-merge`
   It looks through all zulip posts containing a reference to the relevant PR
-  (delegated, or sent to bors, or merged) and it will post an emoji reaction
-  `:peace_sign:`, or `:bors:`, or `:merge:` respectively to the message.
+  and will post or update an emoji reaction corresponding to the current PR state to the message.
+  This reaction is `:peace_sign:` for delegated, `:bors:` for PRs sent to bors, `:merge` for merged
+  PRs, `:writing:` for PRs awaiting-author, `:hammer:` for maintainer-merged PRs and
+  `:closed-pr:` for closed PRs. Two of these are custom emojis configured on zulip.
 - `late_importers.sh` is the main script used by the `latest_import.yml` action: it formats
   the `linter.minImports` output, summarizing the data in a table.  See the module docs of
   `late_importers.sh` for further details.

--- a/scripts/zulip_emoji_merge_delegate.py
+++ b/scripts/zulip_emoji_merge_delegate.py
@@ -73,7 +73,8 @@ for message in messages:
     # Check for emoji reactions
     reactions = message['reactions']
     # Does this message have any reaction with an emoji |name|?
-    has_reaction = lambda name: any(reaction['emoji_name'] == name for reaction in reactions)
+    def has_reaction(name: str) -> bool:
+        return any(reaction['emoji_name'] == name for reaction in reactions)
 
     has_peace_sign = has_reaction('peace_sign')
     has_bors = has_reaction('bors')

--- a/scripts/zulip_emoji_merge_delegate.py
+++ b/scripts/zulip_emoji_merge_delegate.py
@@ -88,9 +88,6 @@ for message in messages:
     if match:
         print(f"matched: '{message}'")
 
-        # Removing all previous emoji reactions.
-        # If the emoji is a custom emoji, add the fields `emoji_code` and `reaction_type` as well.
-        print("Removing previous reactions, if present.")
         def remove_reaction(name: str, emoji_name: str, **kwargs) -> None:
             print(f'Removing {name}')
             result = client.remove_reaction({
@@ -99,6 +96,17 @@ for message in messages:
                 **kwargs
             })
             print(f"result: '{result}'")
+        def add_reaction(name: str, emoji_name: str) -> None:
+            print(f'adding {name} emoji')
+            client.add_reaction({
+                "message_id": message['id'],
+                "emoji_name": emoji_name
+            })
+
+        # Removing all previous emoji reactions.
+        # If the emoji is a custom emoji, add the fields `emoji_code` and `reaction_type` as well.
+        print("Removing previous reactions, if present.")
+
 
         if has_peace_sign:
             remove_reaction('delegated', 'peace_sign')
@@ -116,12 +124,6 @@ for message in messages:
 
         # Apply the appropriate emoji reaction.
         print("Applying reactions, as appropriate.")
-        def add_reaction(name: str, emoji_name: str) -> None:
-            print(f'adding {name} emoji')
-            client.add_reaction({
-                "message_id": message['id'],
-                "emoji_name": emoji_name
-            })
         if 'ready-to-merge' == LABEL_STATUS:
             add_reaction('ready-to-merge', 'bors')
         elif 'delegated' == LABEL_STATUS:
@@ -131,7 +133,6 @@ for message in messages:
                 add_reaction('awaiting-author', 'writing')
             elif LABEL_NAME == 'maintainer-merge':
                 add_reaction('maintainer-merge', 'hammer')
-
         elif LABEL_STATUS == 'closed':
             add_reaction('closed-pr', 'closed-pr')
         elif LABEL_STATUS == 'unlabeled':

--- a/scripts/zulip_emoji_merge_delegate.py
+++ b/scripts/zulip_emoji_merge_delegate.py
@@ -99,6 +99,9 @@ for message in messages:
     if match:
         print(f"matched: '{message}'")
 
+        # Removing all previous emoji reactions.
+        # If the emoji is a custom emoji, add the fields `emoji_code` and `reaction_type` as well.
+        print("Removing previous reactions, if present.")
         def remove_reaction(name: str, emoji_name: str, **kwargs) -> None:
             print(f'Removing {name}')
             result = client.remove_reaction({
@@ -107,23 +110,8 @@ for message in messages:
                 **kwargs
             })
             print(f"result: '{result}'")
-        def add_reaction(name: str, emoji_name: str) -> None:
-            print(f'adding {name} emoji')
-            client.add_reaction({
-                "message_id": message['id'],
-                "emoji_name": emoji_name
-            })
 
-        # The maintainer merge label is different from the others, as it is not mutually exclusive
-        # with them: just add or remove it manually and leave the other emojis alone.
-        if LABEL_NAME == "maintainer-merge":
-            if ACTION == "labeled":
-                add_reaction('maintainer-merge', 'hammer')
-            elif ACTION == "unlabeled":
-                remove_reaction('maintainer-merge', 'hammer')
-            continue
-
-        # Othewise, remove all previous mutually exclusive emoji reactions.
+        # Remove all previous emoji reactions.
         # If the emoji is a custom emoji, add the fields `emoji_code` and `reaction_type` as well.
         print("Removing previous reactions, if present.")
         if has_peace_sign:
@@ -132,6 +120,8 @@ for message in messages:
             remove_reaction("bors", "bors", emoji_code="22134", reaction_type="realm_emoji")
         if has_merge:
             remove_reaction('merge', 'merge')
+        if has_maintainer_merge:
+            remove_reaction('maintainer-merge', 'hammer')
         if has_awaiting_author:
             remove_reaction('awaiting-author', 'writing')
         if has_closed:
@@ -140,6 +130,12 @@ for message in messages:
 
         # Apply the appropriate emoji reaction.
         print("Applying reactions, as appropriate.")
+        def add_reaction(name: str, emoji_name: str) -> None:
+            print(f'adding {name} emoji')
+            client.add_reaction({
+                "message_id": message['id'],
+                "emoji_name": emoji_name
+            })
         match ACTION:
             case 'ready-to-merge':
                 add_reaction('ready-to-merge', 'bors')
@@ -148,6 +144,8 @@ for message in messages:
             case 'LABELED':
                 if LABEL_NAME == 'awaiting-author':
                     add_reaction('awaiting-author', 'writing')
+            case 'maintainer-merge':
+                add_reaction('maintainer-merge', 'hammer')
             case 'unlabeled':
                 if LABEL_NAME == 'awaiting-author':
                     print('awaiting-author removed')

--- a/scripts/zulip_emoji_merge_delegate.py
+++ b/scripts/zulip_emoji_merge_delegate.py
@@ -4,16 +4,26 @@ import zulip
 import re
 
 # Usage:
-# python scripts/zulip_emoji_merge_delegate.py $ZULIP_API_KEY $ZULIP_EMAIL $ZULIP_SITE $LABEL $PR_NUMBER
-# See .github/workflows/zulip_emoji_merge_delegate.yaml for the meaning of these variables
+# python scripts/zulip_emoji_merge_delegate.py $ZULIP_API_KEY $ZULIP_EMAIL $ZULIP_SITE $ACTION $LABEL_NAME $PR_NUMBER
+# See .github/workflows/zulip_emoji_merge_delegate.yaml for the meaning of the first three variables,
+# and the comment below for $ACTION and $LABEL_NAME.
 
 ZULIP_API_KEY = sys.argv[1]
 ZULIP_EMAIL = sys.argv[2]
 ZULIP_SITE = sys.argv[3]
-# e.g. 'labeled', 'unlabeled', 'delegated' or 'closed' (does not contain the label name when
-# a normal label was applied (as opposed to e.g. a bors command)
+# Describes the "action" that is performed to the PR. Depending on which action calls this script,
+# this takes rather different values:
+# - if a PR is closed/reopened, it is 'closed' resp. 'reopened' (though the particular value for
+#   reopening is not used in this script)
+# - if a PR was just merged by bors, it is '[Merged by Bors]'
+# - if a PR was labeled or unlabeled (with e.g. maintainer-merge or awaiting-review),
+#   it is 'labeled' resp. 'unlabeled' (and the next argument is the label name)
+# - if a PR was delegated or sent to bors (via bors r+, bors r-, bors merge, bors delegate,
+#   bors d+ or bors d-) command was issued, it is 'ready-to-merge' or 'delegated'
+#   TODO clarify: what is the input on a bors d- or bors r- command? Also that?
 LABEL_STATUS = sys.argv[4]
 # Name of the label that was applied or removed
+# (if applicable; is 'none' if a PR was closed, reopened or merged)
 LABEL_NAME = sys.argv[5]
 PR_NUMBER = sys.argv[6]
 

--- a/scripts/zulip_emoji_merge_delegate.py
+++ b/scripts/zulip_emoji_merge_delegate.py
@@ -21,13 +21,14 @@ ZULIP_SITE = sys.argv[3]
 # - if a PR was delegated or sent to bors (via bors r+, bors r-, bors merge, bors delegate,
 #   bors d+ or bors d-) command was issued, it is 'ready-to-merge' or 'delegated'
 #   TODO clarify: what is the input on a bors d- or bors r- command? Also that?
-LABEL_STATUS = sys.argv[4]
+ACTION = sys.argv[4]
 # Name of the label that was applied or removed
 # (if applicable; is 'none' if a PR was closed, reopened or merged)
 LABEL_NAME = sys.argv[5]
 PR_NUMBER = sys.argv[6]
 
-print(f"LABEL: '{LABEL_STATUS}'")
+print(f"ACTION: '{ACTION}'")
+print(f"LABEL_NAME: '{LABEL_NAME}'")
 print(f"PR_NUMBER: '{PR_NUMBER}'")
 
 # Initialize Zulip client
@@ -114,11 +115,11 @@ for message in messages:
             })
 
         # The maintainer merge label is different from the others, as it is not mutually exclusive
-        # with them: just add or remove it manually.
+        # with them: just add or remove it manually and leave the other emojis alone.
         if LABEL_NAME == "maintainer-merge":
-            if LABEL_STATUS == "labeled":
+            if ACTION == "labeled":
                 add_reaction('maintainer-merge', 'hammer')
-            elif LABEL_STATUS == "unlabeled":
+            elif ACTION == "unlabeled":
                 remove_reaction('maintainer-merge', 'hammer')
             continue
 
@@ -139,17 +140,17 @@ for message in messages:
 
         # Apply the appropriate emoji reaction.
         print("Applying reactions, as appropriate.")
-        if 'ready-to-merge' == LABEL_STATUS:
+        if 'ready-to-merge' == ACTION:
             add_reaction('ready-to-merge', 'bors')
-        elif 'delegated' == LABEL_STATUS:
+        elif 'delegated' == ACTION:
             add_reaction('delegated', 'peace_sign')
-        elif LABEL_STATUS == 'labeled':
+        elif ACTION == 'labeled':
             if LABEL_NAME == 'awaiting-author':
                 add_reaction('awaiting-author', 'writing')
-        elif LABEL_STATUS == 'closed':
+        elif ACTION == 'closed':
             add_reaction('closed-pr', 'closed-pr')
-        elif LABEL_STATUS == 'unlabeled':
+        elif ACTION == 'unlabeled':
             print('awaiting-author removed')
             # The reaction was already removed.
-        elif LABEL_STATUS.startswith("[Merged by Bors]"):
+        elif ACTION.startswith("[Merged by Bors]"):
             add_reaction('[Merged by Bors]', 'merge')

--- a/scripts/zulip_emoji_merge_delegate.py
+++ b/scripts/zulip_emoji_merge_delegate.py
@@ -103,19 +103,24 @@ for message in messages:
                 "emoji_name": emoji_name
             })
 
-        # Removing all previous emoji reactions.
+        # The maintainer merge label is different from the others, as it is not mutually exclusive
+        # with them: just add or remove it manually.
+        if LABEL_NAME == "maintainer-merge":
+            if LABEL_STATUS == "labeled":
+                add_reaction('maintainer-merge', 'hammer')
+            elif LABEL_STATUS == "unlabeled":
+                remove_reaction('maintainer-merge', 'hammer')
+            continue
+
+        # Othewise, remove all previous mutually exclusive emoji reactions.
         # If the emoji is a custom emoji, add the fields `emoji_code` and `reaction_type` as well.
         print("Removing previous reactions, if present.")
-
-
         if has_peace_sign:
             remove_reaction('delegated', 'peace_sign')
         if has_bors:
             remove_reaction("bors", "bors", emoji_code="22134", reaction_type="realm_emoji")
         if has_merge:
             remove_reaction('merge', 'merge')
-        if has_maintainer_merge:
-            remove_reaction('maintainer-merge', 'hammer')
         if has_awaiting_author:
             remove_reaction('awaiting-author', 'writing')
         if has_closed:
@@ -131,8 +136,6 @@ for message in messages:
         elif LABEL_STATUS == 'labeled':
             if LABEL_NAME == 'awaiting-author':
                 add_reaction('awaiting-author', 'writing')
-            elif LABEL_NAME == 'maintainer-merge':
-                add_reaction('maintainer-merge', 'hammer')
         elif LABEL_STATUS == 'closed':
             add_reaction('closed-pr', 'closed-pr')
         elif LABEL_STATUS == 'unlabeled':

--- a/scripts/zulip_emoji_merge_delegate.py
+++ b/scripts/zulip_emoji_merge_delegate.py
@@ -140,18 +140,19 @@ for message in messages:
 
         # Apply the appropriate emoji reaction.
         print("Applying reactions, as appropriate.")
-        if 'ready-to-merge' == ACTION:
-            add_reaction('ready-to-merge', 'bors')
-        elif 'delegated' == ACTION:
-            add_reaction('delegated', 'peace_sign')
-        elif ACTION == 'labeled':
-            if LABEL_NAME == 'awaiting-author':
-                add_reaction('awaiting-author', 'writing')
-        elif ACTION == 'closed':
-            add_reaction('closed-pr', 'closed-pr')
-        elif ACTION == 'unlabeled':
-            if LABEL_NAME == 'awaiting-author':
-                print('awaiting-author removed')
-                # The reaction was already removed.
-        elif ACTION == "[Merged by Bors]":
-            add_reaction('[Merged by Bors]', 'merge')
+        match ACTION:
+            case 'ready-to-merge':
+                add_reaction('ready-to-merge', 'bors')
+            case 'delegated':
+                add_reaction('delegated', 'peace_sign')
+            case 'LABELED':
+                if LABEL_NAME == 'awaiting-author':
+                    add_reaction('awaiting-author', 'writing')
+            case 'unlabeled':
+                if LABEL_NAME == 'awaiting-author':
+                    print('awaiting-author removed')
+                    # The reaction was already removed.
+            case 'closed':
+                add_reaction('closed-pr', 'closed-pr')
+            case "[Merged by Bors]":
+                add_reaction('[Merged by Bors]', 'merge')

--- a/scripts/zulip_emoji_merge_delegate.py
+++ b/scripts/zulip_emoji_merge_delegate.py
@@ -10,10 +10,12 @@ import re
 ZULIP_API_KEY = sys.argv[1]
 ZULIP_EMAIL = sys.argv[2]
 ZULIP_SITE = sys.argv[3]
-LABEL = sys.argv[4]
+# e.g. 'labeled', 'unlabeled', 'delegated' or 'closed' (does not contain the label name when
+# a normal label was applied (as opposed to e.g. a bors command)
+LABEL_STATUS = sys.argv[4]
 PR_NUMBER = sys.argv[5]
 
-print(f"LABEL: '{LABEL}'")
+print(f"LABEL: '{LABEL_STATUS}'")
 print(f"PR_NUMBER: '{PR_NUMBER}'")
 
 # Initialize Zulip client
@@ -117,18 +119,18 @@ for message in messages:
                 "message_id": message['id'],
                 "emoji_name": emoji_name
             })
-        if 'ready-to-merge' == LABEL:
+        if 'ready-to-merge' == LABEL_STATUS:
             add_reaction('ready-to-merge', 'bors')
-        elif 'delegated' == LABEL:
+        elif 'delegated' == LABEL_STATUS:
             add_reaction('delegated', 'peace_sign')
-        elif 'maintainer-merge' == LABEL:
+        elif 'maintainer-merge' == LABEL_STATUS:
             add_reaction('maintainer-merge', 'hammer')
-        elif LABEL == 'labeled':
+        elif LABEL_STATUS == 'labeled':
             add_reaction('awaiting-author', 'writing')
-        elif LABEL == 'closed':
+        elif LABEL_STATUS == 'closed':
             add_reaction('closed-pr', 'closed-pr')
-        elif LABEL == 'unlabeled':
+        elif LABEL_STATUS == 'unlabeled':
             print('awaiting-author removed')
             # The reaction was already removed.
-        elif LABEL.startswith("[Merged by Bors]"):
+        elif LABEL_STATUS.startswith("[Merged by Bors]"):
             add_reaction('[Merged by Bors]', 'merge')

--- a/scripts/zulip_emoji_merge_delegate.py
+++ b/scripts/zulip_emoji_merge_delegate.py
@@ -5,7 +5,7 @@ import re
 
 # Usage:
 # python scripts/zulip_emoji_merge_delegate.py $ZULIP_API_KEY $ZULIP_EMAIL $ZULIP_SITE $ACTION $LABEL_NAME $PR_NUMBER
-# See .github/workflows/zulip_emoji_merge_delegate.yaml for the meaning of the first three variables,
+# The first three variables identify the lean4 Zulip chat and allow the bot to access it (see .github/workflows/zulip_emoji_merge_delegate.yaml),
 # and the comment below for $ACTION and $LABEL_NAME.
 
 ZULIP_API_KEY = sys.argv[1]
@@ -18,8 +18,8 @@ ZULIP_SITE = sys.argv[3]
 # - if a PR was just merged by bors, it is '[Merged by Bors]'
 # - if a PR was labeled or unlabeled (with e.g. maintainer-merge or awaiting-review),
 #   it is 'labeled' resp. 'unlabeled' (and the next argument is the label name)
-# - if a PR was delegated or sent to bors (via bors r+, bors r-, bors merge, bors delegate,
-#   bors d+ or bors d-) command was issued, it is 'ready-to-merge' or 'delegated'
+# - if a PR was delegated or sent to bors (via a bors r+, bors r-, bors merge, bors delegate,
+#   bors d+ or bors d- command), it is 'ready-to-merge' or 'delegated'
 #   TODO clarify: what is the input on a bors d- or bors r- command? Also that?
 ACTION = sys.argv[4]
 # Name of the label that was applied or removed

--- a/scripts/zulip_emoji_merge_delegate.py
+++ b/scripts/zulip_emoji_merge_delegate.py
@@ -153,5 +153,5 @@ for message in messages:
             if LABEL_NAME == 'awaiting-author':
                 print('awaiting-author removed')
                 # The reaction was already removed.
-        elif ACTION.startswith("[Merged by Bors]"):
+        elif ACTION == "[Merged by Bors]":
             add_reaction('[Merged by Bors]', 'merge')

--- a/scripts/zulip_emoji_merge_delegate.py
+++ b/scripts/zulip_emoji_merge_delegate.py
@@ -142,7 +142,7 @@ for message in messages:
                 add_reaction('ready-to-merge', 'bors')
             case 'delegated':
                 add_reaction('delegated', 'peace_sign')
-            case 'LABELED':
+            case 'labeled':
                 if LABEL_NAME == 'awaiting-author':
                     add_reaction('awaiting-author', 'writing')
             case 'maintainer-merge':

--- a/scripts/zulip_emoji_merge_delegate.py
+++ b/scripts/zulip_emoji_merge_delegate.py
@@ -13,7 +13,9 @@ ZULIP_SITE = sys.argv[3]
 # e.g. 'labeled', 'unlabeled', 'delegated' or 'closed' (does not contain the label name when
 # a normal label was applied (as opposed to e.g. a bors command)
 LABEL_STATUS = sys.argv[4]
-PR_NUMBER = sys.argv[5]
+# Name of the label that was applied or removed
+LABEL_NAME = sys.argv[5]
+PR_NUMBER = sys.argv[6]
 
 print(f"LABEL: '{LABEL_STATUS}'")
 print(f"PR_NUMBER: '{PR_NUMBER}'")

--- a/scripts/zulip_emoji_merge_delegate.py
+++ b/scripts/zulip_emoji_merge_delegate.py
@@ -150,7 +150,8 @@ for message in messages:
         elif ACTION == 'closed':
             add_reaction('closed-pr', 'closed-pr')
         elif ACTION == 'unlabeled':
-            print('awaiting-author removed')
-            # The reaction was already removed.
+            if LABEL_NAME == 'awaiting-author':
+                print('awaiting-author removed')
+                # The reaction was already removed.
         elif ACTION.startswith("[Merged by Bors]"):
             add_reaction('[Merged by Bors]', 'merge')

--- a/scripts/zulip_emoji_merge_delegate.py
+++ b/scripts/zulip_emoji_merge_delegate.py
@@ -126,10 +126,12 @@ for message in messages:
             add_reaction('ready-to-merge', 'bors')
         elif 'delegated' == LABEL_STATUS:
             add_reaction('delegated', 'peace_sign')
-        elif 'maintainer-merge' == LABEL_STATUS:
-            add_reaction('maintainer-merge', 'hammer')
         elif LABEL_STATUS == 'labeled':
-            add_reaction('awaiting-author', 'writing')
+            if LABEL_NAME == 'awaiting-author':
+                add_reaction('awaiting-author', 'writing')
+            elif LABEL_NAME == 'maintainer-merge':
+                add_reaction('maintainer-merge', 'hammer')
+
         elif LABEL_STATUS == 'closed':
             add_reaction('closed-pr', 'closed-pr')
         elif LABEL_STATUS == 'unlabeled':

--- a/scripts/zulip_emoji_merge_delegate.py
+++ b/scripts/zulip_emoji_merge_delegate.py
@@ -18,9 +18,10 @@ ZULIP_SITE = sys.argv[3]
 # - if a PR was just merged by bors, it is '[Merged by Bors]'
 # - if a PR was labeled or unlabeled (with e.g. maintainer-merge or awaiting-review),
 #   it is 'labeled' resp. 'unlabeled' (and the next argument is the label name)
-# - if a PR was delegated or sent to bors (via a bors r+, bors r-, bors merge, bors delegate,
-#   bors d+ or bors d- command), it is 'ready-to-merge' or 'delegated'
-#   TODO clarify: what is the input on a bors d- or bors r- command? Also that?
+# - if a PR was delegated or sent to bors (via a bors r+, bors merge, bors delegate or bors d+
+#   command), it is 'ready-to-merge' or 'delegated'. On a bors merge-, bors r- or bors d- command,
+#   it is 'remove-label'. (This particular value is not used in this script.)
+#   Note that `bors d-` is *not* a bors command, so only has an effect on mathlib's PR labels.
 ACTION = sys.argv[4]
 # Name of the label that was applied or removed
 # (if applicable; is 'none' if a PR was closed, reopened or merged)

--- a/scripts/zulip_emoji_merge_delegate.py
+++ b/scripts/zulip_emoji_merge_delegate.py
@@ -109,11 +109,11 @@ for message in messages:
             # 61282 was the earlier version of the emoji.
             remove_reaction('closed-pr', 'closed-pr', emoji_code="61293", reaction_type="realm_emoji")
 
-        # applying appropriate emoji reaction
+        # Apply the appropriate emoji reaction.
         print("Applying reactions, as appropriate.")
         def add_reaction(name: str, emoji_name: str) -> None:
-            print(f'adding {name}')
-            result = client.add_reaction({
+            print(f'adding {name} emoji')
+            client.add_reaction({
                 "message_id": message['id'],
                 "emoji_name": emoji_name
             })


### PR DESCRIPTION
The underlying Python script `zulip_emoji_merge_delegate.py` is called from four different workflows with different inputs, which makes changing anything harder. In this PR, we document the status quo and prepare for fixing the maintainer merge handling. No behaviour changes are performed in this PR.

- document the current inputs to the script
- also pass in a label name (for labels to be added or removed), or `none` if not applicable
  This will be used in a future PR to differentiate adding/removing the `awaiting-author` and `maintainer-merge` labels.
- rename the inputs `ACTION` and `LABEL_NAME` to the script to match what they are doing,
- update the README description for the script (which became incomplete over time)

------

A future PR could rename the script. Or should that happen in this PR?

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
