### PR TITLE
[Merged by Bors] - chore: correct typo

### DIFF
--- a/Mathlib/GroupTheory/SpecificGroups/ZGroup.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/ZGroup.lean
@@ -176,7 +176,7 @@ variable {p : ℕ} [Fact p.Prime]
 
 namespace IsPGroup
 
-/-- If a cyclic `p`-group `G` acts on a group `K` of coprime order, then the map `K × G → G`
+/-- If a group `K` acts on a cyclic `p`-group `G` of coprime order, then the map `K × G → G`
   defined by `(k, g) ↦ k • g * g⁻¹` is either trivial or surjective. -/
 theorem smul_mul_inv_trivial_or_surjective [IsCyclic G] (hG : IsPGroup p G)
     {K : Type*} [Group K] [MulDistribMulAction K G] (hGK : (Nat.card G).Coprime (Nat.card K)) :


### PR DESCRIPTION
---

Discovered when I was checking where [pow_pow_modEq_one](https://leanprover-community.github.io/mathlib4_docs/Mathlib/FieldTheory/Finite/Basic.html#pow_pow_modEq_one) is used.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
