### PR TITLE
[Merged by Bors] - fix(emojibot): apply the current emoji upon maintainer merge

### DIFF
--- a/scripts/zulip_emoji_reactions.py
+++ b/scripts/zulip_emoji_reactions.py
@@ -101,9 +101,6 @@ for message in messages:
     if match:
         print(f"matched: '{message}'")
 
-        # Removing all previous emoji reactions.
-        # If the emoji is a custom emoji, add the fields `emoji_code` and `reaction_type` as well.
-        print("Removing previous reactions, if present.")
         def remove_reaction(name: str, emoji_name: str, **kwargs) -> None:
             print(f'Removing {name}')
             result = client.remove_reaction({
@@ -112,8 +109,23 @@ for message in messages:
                 **kwargs
             })
             print(f"result: '{result}'")
+        def add_reaction(name: str, emoji_name: str) -> None:
+            print(f'adding {name} emoji')
+            client.add_reaction({
+                "message_id": message['id'],
+                "emoji_name": emoji_name
+            })
 
-        # Remove all previous emoji reactions.
+        # The maintainer merge label is different from the others, as it is not mutually exclusive
+        # with them: just add or remove it manually and leave the other emojis alone.
+        if LABEL_NAME == "maintainer-merge":
+            if ACTION == "labeled":
+                add_reaction('maintainer-merge', 'hammer')
+            elif ACTION == "unlabeled":
+                remove_reaction('maintainer-merge', 'hammer')
+            continue
+
+        # Othewise, remove all previous mutually exclusive emoji reactions.
         # If the emoji is a custom emoji, add the fields `emoji_code` and `reaction_type` as well.
         print("Removing previous reactions, if present.")
         if has_peace_sign:
@@ -122,8 +134,6 @@ for message in messages:
             remove_reaction("bors", "bors", emoji_code="22134", reaction_type="realm_emoji")
         if has_merge:
             remove_reaction('merge', 'merge')
-        if has_maintainer_merge:
-            remove_reaction('maintainer-merge', 'hammer')
         if has_awaiting_author:
             remove_reaction('awaiting-author', 'writing')
         if has_closed:
@@ -132,12 +142,6 @@ for message in messages:
 
         # Apply the appropriate emoji reaction.
         print("Applying reactions, as appropriate.")
-        def add_reaction(name: str, emoji_name: str) -> None:
-            print(f'adding {name} emoji')
-            client.add_reaction({
-                "message_id": message['id'],
-                "emoji_name": emoji_name
-            })
         match ACTION:
             case 'ready-to-merge':
                 add_reaction('ready-to-merge', 'bors')
@@ -146,8 +150,6 @@ for message in messages:
             case 'labeled':
                 if LABEL_NAME == 'awaiting-author':
                     add_reaction('awaiting-author', 'writing')
-            case 'maintainer-merge':
-                add_reaction('maintainer-merge', 'hammer')
             case 'unlabeled':
                 if LABEL_NAME == 'awaiting-author':
                     print('awaiting-author removed')


### PR DESCRIPTION
The emojibot assumed all labels were mutually exclusive: for maintainer-merge label, this is not true.
Fix the labelling by handling the maintainer-merge label separately, before the others.

[Zulip](https://leanprover.zulipchat.com/#narrow/channel/144837-PR-reviews/topic/.2324556.20Testing.20the.20new.20emojibot.20label)

---

- [ ] depends on: #24556 to document the current behaviour, and refactoring to pass in the label name
- [ ] depends on: #24671 to avoid conflicts

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
