### PR TITLE
[Merged by Bors] - feat: add import chain to `assert_not_imported` message

### DIFF
--- a/Mathlib/Util/AssertExists.lean
+++ b/Mathlib/Util/AssertExists.lean
@@ -77,6 +77,22 @@ elab "assert_exists " n:ident : command => do
   -- something that doesn't exist, otherwise succeeds
   let _ ← liftCoreM <| realizeGlobalConstNoOverloadWithInfo n
 
+/-- `importPathMessage env idx` produces a message laying out an import chain from `idx` to the
+current module.  The output is of the form
+```
+Mathlib.Init,
+  which is imported by Mathlib.Util.AssertExistsExt,
+  which is imported by Mathlib.Util.AssertExists,
+  which is imported by this file.
+```
+if `env` is an `Environment` and `idx` is the module index of `Mathlib.Init`.
+-/
+def importPathMessage (env : Environment) (idx : ModuleIdx) : MessageData :=
+  let modNames := env.header.moduleNames
+  let msg := (env.importPath modNames[idx]!).foldl (init := m!"{modNames[idx]!},")
+    (· ++ m!"\n  which is imported by {·},")
+  msg ++ m!"\n  which is imported by this file."
+
 /--
 `assert_not_exists d₁ d₂ ... dₙ` is a user command that asserts that the declarations named
 `d₁ d₂ ... dₙ` *do not exist* in the current import scope.
@@ -97,7 +113,6 @@ You should *not* delete the `assert_not_exists` statement without careful discus
 -/
 elab "assert_not_exists " ns:ident+ : command => do
   let env ← getEnv
-  let modNames := env.header.moduleNames
   for n in ns do
     let decl ←
       try liftCoreM <| realizeGlobalConstNoOverloadWithInfo n
@@ -108,11 +123,8 @@ elab "assert_not_exists " ns:ident+ : command => do
     let msg ← (do
       let mut some idx := env.getModuleIdxFor? decl
         | pure m!"Declaration {c} is defined in this file."
-      let mut msg := m!"Declaration {c} is not allowed to be imported by this file.\n\
-        It is defined in {modNames[idx.toNat]!},"
-      for mod in env.importPath modNames[idx.toNat]! do
-        msg := msg ++ m!"\n  which is imported by {mod},"
-      pure <| msg ++ m!"\n  which is imported by this file.")
+      pure m!"Declaration {c} is not allowed to be imported by this file.\n\
+        It is defined in {importPathMessage env idx}")
     logErrorAt n m!"{msg}\n\n\
       These invariants are maintained by `assert_not_exists` statements, \
       and exist in order to ensure that \"complicated\" parts of the library \
@@ -125,10 +137,11 @@ The command does not currently check whether the modules `m₁ m₂ ... mₙ` ac
 -/
 -- TODO: make sure that each one of `m₁ m₂ ... mₙ` is the name of an actually existing module!
 elab "assert_not_imported " ids:ident+ : command => do
-  let mods := (← getEnv).allImportedModuleNames
+  let env ← getEnv
   for id in ids do
-    if mods.contains id.getId then
-      logWarningAt id m!"the module '{id}' is (transitively) imported"
+    if let some idx := env.getModuleIdx? id.getId then
+      logWarningAt id
+        m!"the module '{id}' is (transitively) imported via\n{importPathMessage env idx}"
     else
       Mathlib.AssertNotExist.addDeclEntry false id.getId (← getMainModule)
 

--- a/MathlibTest/AssertExists.lean
+++ b/MathlibTest/AssertExists.lean
@@ -22,7 +22,17 @@ info:
 
 #check_assertions!
 
-/-- warning: the module 'Lean.Elab.Command' is (transitively) imported -/
+/--
+warning: the module 'Lean.Elab.Command' is (transitively) imported via
+Lean.Elab.Command,
+  which is imported by Mathlib.Tactic.Linter.DirectoryDependency,
+  which is imported by Mathlib.Tactic.Linter.Header,
+  which is imported by Mathlib.Tactic.Linter.DeprecatedSyntaxLinter,
+  which is imported by Mathlib.Init,
+  which is imported by Mathlib.Util.AssertExistsExt,
+  which is imported by Mathlib.Util.AssertExists,
+  which is imported by this file.
+-/
 #guard_msgs in
 assert_not_imported
   Mathlib.Tactic.Common


### PR DESCRIPTION
[#Is there code for X? > assert_not_imported @ 💬](https://leanprover.zulipchat.com/#narrow/channel/217875-Is-there-code-for-X.3F/topic/assert_not_imported/near/515952907)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
