### PR TITLE
feat(Tactic/ImportDiff): add `#import_diff` command

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -5590,6 +5590,7 @@ import Mathlib.Tactic.HaveI
 import Mathlib.Tactic.HigherOrder
 import Mathlib.Tactic.Hint
 import Mathlib.Tactic.ITauto
+import Mathlib.Tactic.ImportDiff
 import Mathlib.Tactic.InferParam
 import Mathlib.Tactic.Inhabit
 import Mathlib.Tactic.IntervalCases

--- a/Mathlib/Tactic.lean
+++ b/Mathlib/Tactic.lean
@@ -117,6 +117,7 @@ import Mathlib.Tactic.HaveI
 import Mathlib.Tactic.HigherOrder
 import Mathlib.Tactic.Hint
 import Mathlib.Tactic.ITauto
+import Mathlib.Tactic.ImportDiff
 import Mathlib.Tactic.InferParam
 import Mathlib.Tactic.Inhabit
 import Mathlib.Tactic.IntervalCases

--- a/Mathlib/Tactic/ImportDiff.lean
+++ b/Mathlib/Tactic/ImportDiff.lean
@@ -1,0 +1,23 @@
+/-
+Copyright (c) 2025 Paul Lezeau. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Paul Lezeau
+-/
+import Lean
+import Batteries.Data.List.Basic
+
+open Lean Elab Meta
+
+/-- `#import_diff foo` computes the new transitive imports that are added to a given file when
+module `foo` is added to the set of imports of the file. -/
+elab "#import_diff" n:ident : command => do
+  let name := n.getId
+  let env ← MonadEnv.getEnv
+  let current_all_imports := env.allImportedModuleNames
+  let current_imports := env.imports
+  let new_imports := current_imports.push { module := name }
+  let new_all_imports := (← Lean.importModules new_imports {}).allImportedModuleNames
+  let import_diff := new_all_imports.toList.diff current_all_imports.toList
+  Lean.logInfo s!"{import_diff}"
+
+--TODO(Paul-Lez): maybe we want to be able to take `#import_diff foo₁ foo₂ foo₃ ...`?

--- a/Mathlib/Tactic/ImportDiff.lean
+++ b/Mathlib/Tactic/ImportDiff.lean
@@ -3,8 +3,15 @@ Copyright (c) 2025 Paul Lezeau. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Paul Lezeau
 -/
-import Lean
 import Batteries.Data.List.Basic
+import Mathlib.Init
+
+/-! # The `#import_diff` command
+
+This file implements the `#import_diff` commmand, which is useful for debugging large import changes
+by determining the transitive imports added by a given import.
+
+-/
 
 open Lean Elab Meta
 
@@ -13,6 +20,9 @@ module `foo` is added to the set of imports of the file. -/
 elab "#import_diff" n:ident : command => do
   let name := n.getId
   let env ← MonadEnv.getEnv
+  --TODO(Paul-Lez): perhaps here it would be more sensible to compute the transitive imports
+  --once we have removed `n` from the imports (in order to cover the case where the user
+  --is already importing the `n`).
   let current_all_imports := env.allImportedModuleNames
   let current_imports := env.imports
   let new_imports := current_imports.push { module := name }


### PR DESCRIPTION
This PR adds the `#import_diff` command, which lists new transitive imports added by extending the list of imports of a file. The aim of this command is to help with debugging large import changes.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
