### PR TITLE
[Merged by Bors] - refactor: make `LieAlgebra.SpecialLinear.Eb` take an `r` argument

### DIFF
--- a/Mathlib/Algebra/Lie/Classical.lean
+++ b/Mathlib/Algebra/Lie/Classical.lean
@@ -96,30 +96,30 @@ theorem sl_bracket [Fintype n] (A B : sl n R) : ⁅A, B⁆.val = A.val * B.val -
 
 section ElementaryBasis
 
-variable {n} [Fintype n] (i j : n)
+variable {n R} [Fintype n] (i j : n)
 
-/-- When j ≠ i, the elementary matrices are elements of sl n R, in fact they are part of a natural
-basis of `sl n R`. -/
-def Eb (h : j ≠ i) : sl n R :=
-  ⟨Matrix.stdBasisMatrix i j (1 : R),
-    show Matrix.stdBasisMatrix i j (1 : R) ∈ LinearMap.ker (Matrix.traceLinearMap n R R) from
-      Matrix.StdBasisMatrix.trace_zero i j (1 : R) h⟩
+/-- When `i ≠ j`, the elementary matrices are elements of `sl n R`, in fact they are part of a
+natural basis of `sl n R`. -/
+def Eb (h : i ≠ j) (r : R) : sl n R :=
+  ⟨Matrix.stdBasisMatrix i j r,
+    show Matrix.stdBasisMatrix i j r ∈ LinearMap.ker (Matrix.traceLinearMap n R R) from
+      Matrix.StdBasisMatrix.trace_zero i j r h⟩
 
 @[simp]
-theorem eb_val (h : j ≠ i) : (Eb R i j h).val = Matrix.stdBasisMatrix i j 1 :=
+theorem eb_val (h : i ≠ j) (r : R) : (Eb i j h r).val = Matrix.stdBasisMatrix i j r :=
   rfl
 
 end ElementaryBasis
 
 theorem sl_non_abelian [Fintype n] [Nontrivial R] (h : 1 < Fintype.card n) :
     ¬IsLieAbelian (sl n R) := by
-  rcases Fintype.exists_pair_of_one_lt_card h with ⟨j, i, hij⟩
-  let A := Eb R i j hij
-  let B := Eb R j i hij.symm
+  rcases Fintype.exists_pair_of_one_lt_card h with ⟨i, j, hij⟩
+  let A := Eb i j hij (1 : R)
+  let B := Eb j i hij.symm (1 : R)
   intro c
   have c' : A.val * B.val = B.val * A.val := by
     rw [← sub_eq_zero, ← sl_bracket, c.trivial, ZeroMemClass.coe_zero]
-  simpa [A, B, stdBasisMatrix, Matrix.mul_apply, hij] using congr_fun (congr_fun c' i) i
+  simpa [A, B, stdBasisMatrix, Matrix.mul_apply, hij.symm] using congr_fun (congr_fun c' i) i
 
 end SpecialLinear
 

--- a/Mathlib/Data/Matrix/Basis.lean
+++ b/Mathlib/Data/Matrix/Basis.lean
@@ -193,8 +193,8 @@ section
 variable [Zero α] (i j : n) (c : α)
 
 @[simp]
-theorem diag_zero (h : j ≠ i) : diag (stdBasisMatrix i j c) = 0 :=
-  funext fun _ => if_neg fun ⟨e₁, e₂⟩ => h (e₂.trans e₁.symm)
+theorem diag_zero (h : i ≠ j) : diag (stdBasisMatrix i j c) = 0 :=
+  funext fun _ => if_neg fun ⟨e₁, e₂⟩ => h (e₁.trans e₂.symm)
 
 @[simp]
 theorem diag_same : diag (stdBasisMatrix i i c) = Pi.single i c := by

--- a/Mathlib/LinearAlgebra/Matrix/Trace.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Trace.lean
@@ -238,7 +238,7 @@ variable {l m n : Type*} {R α : Type*} [DecidableEq l] [DecidableEq m] [Decidab
 variable [Fintype n] [AddCommMonoid α] (i j : n) (c : α)
 
 @[simp]
-theorem trace_zero (h : j ≠ i) : trace (stdBasisMatrix i j c) = 0 := by
+theorem trace_zero (h : i ≠ j) : trace (stdBasisMatrix i j c) = 0 := by
   -- Porting note: added `-diag_apply`
   simp [trace, -diag_apply, h]
 

--- a/Mathlib/LinearAlgebra/Trace.lean
+++ b/Mathlib/LinearAlgebra/Trace.lean
@@ -130,10 +130,9 @@ theorem trace_eq_contract_of_basis [Finite ι] (b : Basis ι R M) :
     rintro ⟨i, j⟩
     simp only [Function.comp_apply, Basis.tensorProduct_apply, Basis.coe_dualBasis, coe_comp]
     rw [trace_eq_matrix_trace R b, toMatrix_dualTensorHom]
-    by_cases hij : i = j
-    · rw [hij]
-      simp
-    rw [Matrix.StdBasisMatrix.trace_zero j i (1 : R) hij]
+    obtain rfl | hij := eq_or_ne i j
+    · simp
+    rw [Matrix.StdBasisMatrix.trace_zero j i (1 : R) hij.symm]
     simp [Finsupp.single_eq_pi_single, hij]
 
 /-- The trace of a linear map corresponds to the contraction pairing under the isomorphism


### PR DESCRIPTION
This makes it more consistent with `Matrix.stdBasisMatrix`. Also flips some `Ne` arguments to match the argument order.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
