### PR TITLE
[Merged by Bors] - feat(MeasureTheory/Measure/Dirac): Dirac measure applied to a set is either 0 or 1

### DIFF
--- a/Mathlib/MeasureTheory/Measure/Dirac.lean
+++ b/Mathlib/MeasureTheory/Measure/Dirac.lean
@@ -41,6 +41,20 @@ theorem dirac_apply' (a : α) (hs : MeasurableSet s) : dirac a s = s.indicator 1
   toMeasure_apply _ _ hs
 
 @[simp]
+theorem dirac_apply'_ne_zero_iff_eq_one (a : α) (hs: MeasurableSet s) :
+      dirac a s ≠ 0 ↔ dirac a s = 1 := by
+    rw[Measure.dirac_apply']
+    · simp[Set.indicator]
+    exact hs
+
+@[simp]
+theorem dirac_apply'_ne_one_iff_eq_zero {a : α} (hs: MeasurableSet s) :
+      dirac a s ≠ 1 ↔ dirac a s = 0 := by
+    rw[Measure.dirac_apply']
+    · simp[Set.indicator]
+    exact hs
+
+@[simp]
 theorem dirac_apply_of_mem {a : α} (h : a ∈ s) : dirac a s = 1 := by
   have : ∀ t : Set α, a ∈ t → t.indicator (1 : α → ℝ≥0∞) a = 1 := fun t ht => indicator_of_mem ht 1
   refine le_antisymm (this univ trivial ▸ ?_) (this s h ▸ le_dirac_apply)

--- a/Mathlib/MeasureTheory/Measure/Dirac.lean
+++ b/Mathlib/MeasureTheory/Measure/Dirac.lean
@@ -42,7 +42,7 @@ theorem dirac_apply' (a : α) (hs : MeasurableSet s) : dirac a s = s.indicator 1
 
 theorem dirac_apply'_eq_zero_or_one (a : α) (hs : MeasurableSet s) :
     dirac a s = 0 ∨ dirac a s = 1 := by
-  simp[Measure.dirac_apply' a hs, Set.indicator]
+  simp [Measure.dirac_apply' a hs, Set.indicator]
   tauto
 
 @[simp]

--- a/Mathlib/MeasureTheory/Measure/Dirac.lean
+++ b/Mathlib/MeasureTheory/Measure/Dirac.lean
@@ -40,19 +40,20 @@ theorem le_dirac_apply {a} : s.indicator 1 a ≤ dirac a s :=
 theorem dirac_apply' (a : α) (hs : MeasurableSet s) : dirac a s = s.indicator 1 a :=
   toMeasure_apply _ _ hs
 
+theorem dirac_apply'_eq_zero_or_one (a : α) (hs : MeasurableSet s) :
+      dirac a s = 0 ∨ dirac a s = 1 := by
+  simp[Measure.dirac_apply' a hs, Set.indicator]
+  tauto
+
 @[simp]
 theorem dirac_apply'_ne_zero_iff_eq_one (a : α) (hs: MeasurableSet s) :
       dirac a s ≠ 0 ↔ dirac a s = 1 := by
-    rw[Measure.dirac_apply']
-    · simp[Set.indicator]
-    exact hs
+  simp[Measure.dirac_apply' a hs, Set.indicator]
 
 @[simp]
 theorem dirac_apply'_ne_one_iff_eq_zero {a : α} (hs: MeasurableSet s) :
       dirac a s ≠ 1 ↔ dirac a s = 0 := by
-    rw[Measure.dirac_apply']
-    · simp[Set.indicator]
-    exact hs
+  simp[Measure.dirac_apply' a hs, Set.indicator]
 
 @[simp]
 theorem dirac_apply_of_mem {a : α} (h : a ∈ s) : dirac a s = 1 := by

--- a/Mathlib/MeasureTheory/Measure/Dirac.lean
+++ b/Mathlib/MeasureTheory/Measure/Dirac.lean
@@ -41,18 +41,18 @@ theorem dirac_apply' (a : α) (hs : MeasurableSet s) : dirac a s = s.indicator 1
   toMeasure_apply _ _ hs
 
 theorem dirac_apply'_eq_zero_or_one (a : α) (hs : MeasurableSet s) :
-      dirac a s = 0 ∨ dirac a s = 1 := by
+    dirac a s = 0 ∨ dirac a s = 1 := by
   simp[Measure.dirac_apply' a hs, Set.indicator]
   tauto
 
 @[simp]
-theorem dirac_apply'_ne_zero_iff_eq_one (a : α) (hs: MeasurableSet s) :
-      dirac a s ≠ 0 ↔ dirac a s = 1 := by
+theorem dirac_apply'_ne_zero_iff_eq_one (a : α) (hs : MeasurableSet s) :
+    dirac a s ≠ 0 ↔ dirac a s = 1 := by
   simp[Measure.dirac_apply' a hs, Set.indicator]
 
 @[simp]
-theorem dirac_apply'_ne_one_iff_eq_zero {a : α} (hs: MeasurableSet s) :
-      dirac a s ≠ 1 ↔ dirac a s = 0 := by
+theorem dirac_apply'_ne_one_iff_eq_zero {a : α} (hs : MeasurableSet s) :
+    dirac a s ≠ 1 ↔ dirac a s = 0 := by
   simp[Measure.dirac_apply' a hs, Set.indicator]
 
 @[simp]

--- a/Mathlib/MeasureTheory/Measure/Dirac.lean
+++ b/Mathlib/MeasureTheory/Measure/Dirac.lean
@@ -45,15 +45,13 @@ theorem dirac_apply'_eq_zero_or_one (a : α) (hs : MeasurableSet s) :
   simp [Measure.dirac_apply' a hs, Set.indicator]
   tauto
 
-@[simp]
 theorem dirac_apply'_ne_zero_iff_eq_one (a : α) (hs : MeasurableSet s) :
     dirac a s ≠ 0 ↔ dirac a s = 1 := by
-  simp[Measure.dirac_apply' a hs, Set.indicator]
+  simp [Measure.dirac_apply' a hs, Set.indicator]
 
-@[simp]
 theorem dirac_apply'_ne_one_iff_eq_zero {a : α} (hs : MeasurableSet s) :
     dirac a s ≠ 1 ↔ dirac a s = 0 := by
-  simp[Measure.dirac_apply' a hs, Set.indicator]
+  simp [Measure.dirac_apply' a hs, Set.indicator]
 
 @[simp]
 theorem dirac_apply_of_mem {a : α} (h : a ∈ s) : dirac a s = 1 := by

--- a/Mathlib/MeasureTheory/Measure/Dirac.lean
+++ b/Mathlib/MeasureTheory/Measure/Dirac.lean
@@ -40,28 +40,23 @@ theorem le_dirac_apply {a} : s.indicator 1 a ≤ dirac a s :=
 theorem dirac_apply' (a : α) (hs : MeasurableSet s) : dirac a s = s.indicator 1 a :=
   toMeasure_apply _ _ hs
 
-theorem dirac_apply'_eq_zero_or_one {a : α} {s : Set α} :
+theorem dirac_apply_eq_zero_or_one :
     dirac a s = 0 ∨ dirac a s = 1 := by
-  rw [← measure_toMeasurable s, Measure.dirac_apply' a (by apply measurableSet_toMeasurable),
-    Set.indicator]
+  rw [← measure_toMeasurable s, dirac_apply' a (measurableSet_toMeasurable ..), indicator]
   simp
   tauto
 
 @[simp]
 theorem dirac_apply'_ne_zero_iff_eq_one {a : α} {s : Set α} :
-    dirac a s ≠ 0 ↔ dirac a s = 1 := by
-  constructor
-  · apply (dirac_apply'_eq_zero_or_one).resolve_left
-  · exact ne_zero_of_eq_one
+    dirac a s ≠ 0 ↔ dirac a s = 1 where
+  mp := dirac_apply'_eq_zero_or_one.resolve_left
+  mpr := ne_zero_of_eq_one
 
 @[simp]
 theorem dirac_apply'_ne_one_iff_eq_zero {a : α} {s : Set α} :
-    dirac a s ≠ 1 ↔ dirac a s = 0 := by
-  constructor
-  · apply (dirac_apply'_eq_zero_or_one).resolve_right
-  · intro h
-    rw [h]
-    exact Ne.symm one_ne_zero
+    dirac a s ≠ 1 ↔ dirac a s = 0 where
+  mp := dirac_apply'_eq_zero_or_one.resolve_right
+  mpr h := h ▸ zero_ne_one
 
 @[simp]
 theorem dirac_apply_of_mem {a : α} (h : a ∈ s) : dirac a s = 1 := by

--- a/Mathlib/MeasureTheory/Measure/Dirac.lean
+++ b/Mathlib/MeasureTheory/Measure/Dirac.lean
@@ -49,13 +49,13 @@ theorem dirac_apply_eq_zero_or_one :
 @[simp]
 theorem dirac_apply'_ne_zero_iff_eq_one {a : α} {s : Set α} :
     dirac a s ≠ 0 ↔ dirac a s = 1 where
-  mp := dirac_apply'_eq_zero_or_one.resolve_left
+  mp := dirac_apply_eq_zero_or_one.resolve_left
   mpr := ne_zero_of_eq_one
 
 @[simp]
 theorem dirac_apply'_ne_one_iff_eq_zero {a : α} {s : Set α} :
     dirac a s ≠ 1 ↔ dirac a s = 0 where
-  mp := dirac_apply'_eq_zero_or_one.resolve_right
+  mp := dirac_apply_eq_zero_or_one.resolve_right
   mpr h := h ▸ zero_ne_one
 
 @[simp]

--- a/Mathlib/MeasureTheory/Measure/Dirac.lean
+++ b/Mathlib/MeasureTheory/Measure/Dirac.lean
@@ -40,18 +40,28 @@ theorem le_dirac_apply {a} : s.indicator 1 a ≤ dirac a s :=
 theorem dirac_apply' (a : α) (hs : MeasurableSet s) : dirac a s = s.indicator 1 a :=
   toMeasure_apply _ _ hs
 
-theorem dirac_apply'_eq_zero_or_one (a : α) (hs : MeasurableSet s) :
+theorem dirac_apply'_eq_zero_or_one {a : α} {s : Set α} :
     dirac a s = 0 ∨ dirac a s = 1 := by
-  simp [Measure.dirac_apply' a hs, Set.indicator]
+  rw [← measure_toMeasurable s, Measure.dirac_apply' a (by apply measurableSet_toMeasurable),
+    Set.indicator]
+  simp
   tauto
 
-theorem dirac_apply'_ne_zero_iff_eq_one (a : α) (hs : MeasurableSet s) :
+@[simp]
+theorem dirac_apply'_ne_zero_iff_eq_one {a : α} {s : Set α} :
     dirac a s ≠ 0 ↔ dirac a s = 1 := by
-  simp [Measure.dirac_apply' a hs, Set.indicator]
+  constructor
+  · apply (dirac_apply'_eq_zero_or_one).resolve_left
+  · exact ne_zero_of_eq_one
 
-theorem dirac_apply'_ne_one_iff_eq_zero {a : α} (hs : MeasurableSet s) :
+@[simp]
+theorem dirac_apply'_ne_one_iff_eq_zero {a : α} {s : Set α} :
     dirac a s ≠ 1 ↔ dirac a s = 0 := by
-  simp [Measure.dirac_apply' a hs, Set.indicator]
+  constructor
+  · apply (dirac_apply'_eq_zero_or_one).resolve_right
+  · intro h
+    rw [h]
+    exact Ne.symm one_ne_zero
 
 @[simp]
 theorem dirac_apply_of_mem {a : α} (h : a ∈ s) : dirac a s = 1 := by

--- a/Mathlib/MeasureTheory/Measure/Dirac.lean
+++ b/Mathlib/MeasureTheory/Measure/Dirac.lean
@@ -47,13 +47,13 @@ theorem dirac_apply_eq_zero_or_one :
   tauto
 
 @[simp]
-theorem dirac_apply'_ne_zero_iff_eq_one {a : α} {s : Set α} :
+theorem dirac_apply_ne_zero_iff_eq_one :
     dirac a s ≠ 0 ↔ dirac a s = 1 where
   mp := dirac_apply_eq_zero_or_one.resolve_left
   mpr := ne_zero_of_eq_one
 
 @[simp]
-theorem dirac_apply'_ne_one_iff_eq_zero {a : α} {s : Set α} :
+theorem dirac_apply_ne_one_iff_eq_zero :
     dirac a s ≠ 1 ↔ dirac a s = 0 where
   mp := dirac_apply_eq_zero_or_one.resolve_right
   mpr h := h ▸ zero_ne_one

--- a/Mathlib/MeasureTheory/Measure/Dirac.lean
+++ b/Mathlib/MeasureTheory/Measure/Dirac.lean
@@ -43,7 +43,8 @@ theorem dirac_apply' (a : α) (hs : MeasurableSet s) : dirac a s = s.indicator 1
 theorem dirac_apply_eq_zero_or_one :
     dirac a s = 0 ∨ dirac a s = 1 := by
   rw [← measure_toMeasurable s, dirac_apply' a (measurableSet_toMeasurable ..), indicator]
-  simp
+  simp only [Pi.one_apply, ite_eq_right_iff, one_ne_zero, imp_false, ite_eq_left_iff, zero_ne_one,
+    not_not]
   tauto
 
 @[simp]


### PR DESCRIPTION
The Dirac measure at a point `a`, applied to a set `s`, is either 0 or 1. This feature provides two if and only ifs that can be used to turn statements in terms of `\ne` into statements in terms of `=`, as well as a "0 or 1 theorem".

(The reason for adding these is to avoid having to simplify in terms of `Set.indicator` over and over while working with Dirac)