### PR TITLE
[Merged by Bors] - doc: remove TODOs that have been implemented

### DIFF
--- a/Mathlib/Analysis/Meromorphic/Divisor.lean
+++ b/Mathlib/Analysis/Meromorphic/Divisor.lean
@@ -11,7 +11,8 @@ import Mathlib.Data.LocallyFinsupp
 # The Divisor of a meromorphic function
 
 This file defines the divisor of a meromorphic function and proves the most basic lemmas about those
-divisors.
+divisors. The lemma `MeromorphicOn.divisor_restrict` guarantees compatibility between restrictions
+of divisors and of meromorphic functions to subsets of their domain of definition.
 -/
 
 variable {𝕜 : Type*} [NontriviallyNormedField 𝕜] {U : Set 𝕜} {z : 𝕜}

--- a/Mathlib/Analysis/Meromorphic/Divisor.lean
+++ b/Mathlib/Analysis/Meromorphic/Divisor.lean
@@ -12,10 +12,6 @@ import Mathlib.Data.LocallyFinsupp
 
 This file defines the divisor of a meromorphic function and proves the most basic lemmas about those
 divisors.
-
-## TODO
-
-- Compatibility with restriction of divisors/functions
 -/
 
 variable {𝕜 : Type*} [NontriviallyNormedField 𝕜] {U : Set 𝕜} {z : 𝕜}

--- a/Mathlib/Analysis/Meromorphic/NormalForm.lean
+++ b/Mathlib/Analysis/Meromorphic/NormalForm.lean
@@ -18,10 +18,6 @@ the 'unique best' representative of any given equivalence class, where 'best'
 means that the representative can locally near any point `x` be written 'in
 normal form', as `f =ᶠ[𝓝 x] fun z ↦ (z - x) ^ n • g` where `g` is analytic and
 does not vanish at `x`.
-
-## TODO
-
-Establish the analogous notion `MeromorphicNFOn`.
 -/
 
 open Topology WithTop

--- a/Mathlib/Analysis/Meromorphic/NormalForm.lean
+++ b/Mathlib/Analysis/Meromorphic/NormalForm.lean
@@ -8,16 +8,17 @@ import Mathlib.Analysis.Meromorphic.Divisor
 /-!
 # Normal form of meromorphic functions and continuous extension
 
-If a function `f` is meromorphic on `U` and if `g` differs from `f` only along a
-set that is codiscrete within `U`, then `g` is likewise meromorphic. The set of
-meromorphic functions is therefore huge, and `=ᶠ[codiscreteWithin U]` defines an
-equivalence relation.
+If a function `f` is meromorphic on `U` and if `g` differs from `f` only along a set that is
+codiscrete within `U`, then `g` is likewise meromorphic. The set of meromorphic functions is
+therefore huge, and `=ᶠ[codiscreteWithin U]` defines an equivalence relation.
 
-This file implements continuous extension to provide an API that allows picking
-the 'unique best' representative of any given equivalence class, where 'best'
-means that the representative can locally near any point `x` be written 'in
-normal form', as `f =ᶠ[𝓝 x] fun z ↦ (z - x) ^ n • g` where `g` is analytic and
-does not vanish at `x`.
+This file implements continuous extension to provide an API that allows picking the 'unique best'
+representative of any given equivalence class, where 'best' means that the representative can
+locally near any point `x` be written 'in normal form', as `f =ᶠ[𝓝 x] fun z ↦ (z - x) ^ n • g`
+where `g` is analytic and does not vanish at `x`.
+
+The relevant notions are `MeromorphicNFAt` and `MeromorphicNFOn`, which , which guarantee normal
+form at a single point and along a set, respectively.
 -/
 
 open Topology WithTop

--- a/Mathlib/Analysis/Meromorphic/NormalForm.lean
+++ b/Mathlib/Analysis/Meromorphic/NormalForm.lean
@@ -17,7 +17,7 @@ representative of any given equivalence class, where 'best' means that the repre
 locally near any point `x` be written 'in normal form', as `f =ᶠ[𝓝 x] fun z ↦ (z - x) ^ n • g`
 where `g` is analytic and does not vanish at `x`.
 
-The relevant notions are `MeromorphicNFAt` and `MeromorphicNFOn`, which , which guarantee normal
+The relevant notions are `MeromorphicNFAt` and `MeromorphicNFOn`; these guarantee normal
 form at a single point and along a set, respectively.
 -/
 


### PR DESCRIPTION
Remove two TODOs from docstrings that have already been implemented.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
