### PR TITLE
[Merged by Bors] - feat: Cartan matrices are non-singular

### DIFF
--- a/Mathlib/LinearAlgebra/Matrix/BilinearForm.lean
+++ b/Mathlib/LinearAlgebra/Matrix/BilinearForm.lean
@@ -338,8 +338,9 @@ theorem _root_.Matrix.Nondegenerate.toBilin' {M : Matrix ι ι R₂} (h : M.Nond
 
 @[simp]
 theorem _root_.Matrix.nondegenerate_toBilin'_iff {M : Matrix ι ι R₂} :
-    M.toBilin'.Nondegenerate ↔ M.Nondegenerate :=
-  ⟨fun h v hv => h v fun w => (M.toBilin'_apply' _ _).trans <| hv w, Matrix.Nondegenerate.toBilin'⟩
+    M.toBilin'.Nondegenerate ↔ M.Nondegenerate := by
+  refine ⟨fun h ↦ Matrix.Nondegenerate_def.mpr ?_, Matrix.Nondegenerate.toBilin'⟩
+  exact fun v hv => h v fun w => (M.toBilin'_apply' _ _).trans <| hv w
 
 theorem _root_.Matrix.Nondegenerate.toBilin {M : Matrix ι ι R₂} (h : M.Nondegenerate)
     (b : Basis ι R₂ M₂) : (Matrix.toBilin b M).Nondegenerate :=

--- a/Mathlib/LinearAlgebra/Matrix/BilinearForm.lean
+++ b/Mathlib/LinearAlgebra/Matrix/BilinearForm.lean
@@ -339,7 +339,7 @@ theorem _root_.Matrix.Nondegenerate.toBilin' {M : Matrix ι ι R₂} (h : M.Nond
 @[simp]
 theorem _root_.Matrix.nondegenerate_toBilin'_iff {M : Matrix ι ι R₂} :
     M.toBilin'.Nondegenerate ↔ M.Nondegenerate := by
-  refine ⟨fun h ↦ Matrix.Nondegenerate_def.mpr ?_, Matrix.Nondegenerate.toBilin'⟩
+  refine ⟨fun h ↦ Matrix.nondegenerate_def.mpr ?_, Matrix.Nondegenerate.toBilin'⟩
   exact fun v hv => h v fun w => (M.toBilin'_apply' _ _).trans <| hv w
 
 theorem _root_.Matrix.Nondegenerate.toBilin {M : Matrix ι ι R₂} (h : M.Nondegenerate)

--- a/Mathlib/LinearAlgebra/Matrix/Nondegenerate.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Nondegenerate.lean
@@ -22,7 +22,9 @@ namespace Matrix
 
 variable {m R A : Type*} [Fintype m] [CommRing R]
 
-/-- A matrix `M` is nondegenerate if for all `v ≠ 0`, there is a `w ≠ 0` with `w * M * v ≠ 0`. -/
+/-- A matrix `M` is nondegenerate if for all `v ≠ 0`, there is a `w ≠ 0` with `w * M * v ≠ 0`.
+
+TODO(?) assume `[Finite m]` for the definition and use `[Fintype m]` when necessary in the API? -/
 def Nondegenerate (M : Matrix m m R) :=
   ∀ v, (∀ w, dotProduct v (M *ᵥ w) = 0) → v = 0
 

--- a/Mathlib/LinearAlgebra/Matrix/Nondegenerate.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Nondegenerate.lean
@@ -24,7 +24,7 @@ variable {m R A : Type*} [CommRing R]
 
 /-- A matrix `M` is nondegenerate if for all `v ≠ 0`, there is a `w ≠ 0` with `w * M * v ≠ 0`. -/
 def Nondegenerate [Finite m] (M : Matrix m m R) :=
-  let _i : Fintype m := Fintype.ofFinite m
+  letI : Fintype m := Fintype.ofFinite m
   ∀ v, (∀ w, dotProduct v (M *ᵥ w) = 0) → v = 0
 
 variable [Fintype m]

--- a/Mathlib/LinearAlgebra/Matrix/Nondegenerate.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Nondegenerate.lean
@@ -20,18 +20,23 @@ import Mathlib.LinearAlgebra.Matrix.Adjugate
 
 namespace Matrix
 
-variable {m R A : Type*} [Fintype m] [CommRing R]
+variable {m R A : Type*} [CommRing R]
 
-/-- A matrix `M` is nondegenerate if for all `v ≠ 0`, there is a `w ≠ 0` with `w * M * v ≠ 0`.
-
-TODO(?) assume `[Finite m]` for the definition and use `[Fintype m]` when necessary in the API? -/
-def Nondegenerate (M : Matrix m m R) :=
+/-- A matrix `M` is nondegenerate if for all `v ≠ 0`, there is a `w ≠ 0` with `w * M * v ≠ 0`. -/
+def Nondegenerate [Finite m] (M : Matrix m m R) :=
+  let _i : Fintype m := Fintype.ofFinite m
   ∀ v, (∀ w, dotProduct v (M *ᵥ w) = 0) → v = 0
+
+variable [Fintype m]
+
+lemma Nondegenerate_def {M : Matrix m m R} :
+    M.Nondegenerate ↔ ∀ v, (∀ w, dotProduct v (M *ᵥ w) = 0) → v = 0 := by
+  refine forall_congr' fun v ↦ ⟨fun hM hv ↦ hM ?_, fun hM hv ↦ hM ?_⟩ <;> convert hv
 
 /-- If `M` is nondegenerate and `w * M * v = 0` for all `w`, then `v = 0`. -/
 theorem Nondegenerate.eq_zero_of_ortho {M : Matrix m m R} (hM : Nondegenerate M) {v : m → R}
     (hv : ∀ w, dotProduct v (M *ᵥ w) = 0) : v = 0 :=
-  hM v hv
+  Nondegenerate_def.mp hM v hv
 
 /-- If `M` is nondegenerate and `v ≠ 0`, then there is some `w` such that `w * M * v ≠ 0`. -/
 theorem Nondegenerate.exists_not_ortho_of_ne_zero {M : Matrix m m R} (hM : Nondegenerate M)
@@ -46,7 +51,7 @@ See also `BilinForm.nondegenerateOfDetNeZero'` and `BilinForm.nondegenerateOfDet
 -/
 theorem nondegenerate_of_det_ne_zero [DecidableEq m] {M : Matrix m m A} (hM : M.det ≠ 0) :
     Nondegenerate M := by
-  intro v hv
+  refine Nondegenerate_def.mpr fun v hv ↦ ?_
   ext i
   specialize hv (M.cramer (Pi.single i 1))
   refine (mul_eq_zero.mp ?_).resolve_right hM

--- a/Mathlib/LinearAlgebra/Matrix/Nondegenerate.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Nondegenerate.lean
@@ -29,14 +29,14 @@ def Nondegenerate [Finite m] (M : Matrix m m R) :=
 
 variable [Fintype m]
 
-lemma Nondegenerate_def {M : Matrix m m R} :
+lemma nondegenerate_def {M : Matrix m m R} :
     M.Nondegenerate ↔ ∀ v, (∀ w, dotProduct v (M *ᵥ w) = 0) → v = 0 := by
   refine forall_congr' fun v ↦ ⟨fun hM hv ↦ hM ?_, fun hM hv ↦ hM ?_⟩ <;> convert hv
 
 /-- If `M` is nondegenerate and `w * M * v = 0` for all `w`, then `v = 0`. -/
 theorem Nondegenerate.eq_zero_of_ortho {M : Matrix m m R} (hM : Nondegenerate M) {v : m → R}
     (hv : ∀ w, dotProduct v (M *ᵥ w) = 0) : v = 0 :=
-  Nondegenerate_def.mp hM v hv
+  nondegenerate_def.mp hM v hv
 
 /-- If `M` is nondegenerate and `v ≠ 0`, then there is some `w` such that `w * M * v ≠ 0`. -/
 theorem Nondegenerate.exists_not_ortho_of_ne_zero {M : Matrix m m R} (hM : Nondegenerate M)
@@ -51,7 +51,7 @@ See also `BilinForm.nondegenerateOfDetNeZero'` and `BilinForm.nondegenerateOfDet
 -/
 theorem nondegenerate_of_det_ne_zero [DecidableEq m] {M : Matrix m m A} (hM : M.det ≠ 0) :
     Nondegenerate M := by
-  refine Nondegenerate_def.mpr fun v hv ↦ ?_
+  refine nondegenerate_def.mpr fun v hv ↦ ?_
   ext i
   specialize hv (M.cramer (Pi.single i 1))
   refine (mul_eq_zero.mp ?_).resolve_right hM

--- a/Mathlib/LinearAlgebra/Matrix/SesquilinearForm.lean
+++ b/Mathlib/LinearAlgebra/Matrix/SesquilinearForm.lean
@@ -629,9 +629,9 @@ theorem _root_.Matrix.Nondegenerate.toLinearMap₂' {M : Matrix ι ι R₁} (h :
 
 @[simp]
 theorem _root_.Matrix.separatingLeft_toLinearMap₂'_iff {M : Matrix ι ι R₁} :
-    (Matrix.toLinearMap₂' R₁ M).SeparatingLeft (R := R₁) ↔ M.Nondegenerate :=
-  ⟨fun h v hv => h v fun w => (M.toLinearMap₂'_apply' _ _).trans <| hv w,
-    Matrix.Nondegenerate.toLinearMap₂'⟩
+    (Matrix.toLinearMap₂' R₁ M).SeparatingLeft (R := R₁) ↔ M.Nondegenerate := by
+  refine ⟨fun h ↦ Matrix.Nondegenerate_def.mpr ?_, Matrix.Nondegenerate.toLinearMap₂'⟩
+  exact fun v hv => h v fun w => (M.toLinearMap₂'_apply' _ _).trans <| hv w
 
 theorem _root_.Matrix.Nondegenerate.toLinearMap₂ {M : Matrix ι ι R₁} (h : M.Nondegenerate)
     (b : Basis ι R₁ M₁) : (toLinearMap₂ b b M).SeparatingLeft :=

--- a/Mathlib/LinearAlgebra/Matrix/SesquilinearForm.lean
+++ b/Mathlib/LinearAlgebra/Matrix/SesquilinearForm.lean
@@ -630,7 +630,7 @@ theorem _root_.Matrix.Nondegenerate.toLinearMap₂' {M : Matrix ι ι R₁} (h :
 @[simp]
 theorem _root_.Matrix.separatingLeft_toLinearMap₂'_iff {M : Matrix ι ι R₁} :
     (Matrix.toLinearMap₂' R₁ M).SeparatingLeft (R := R₁) ↔ M.Nondegenerate := by
-  refine ⟨fun h ↦ Matrix.Nondegenerate_def.mpr ?_, Matrix.Nondegenerate.toLinearMap₂'⟩
+  refine ⟨fun h ↦ Matrix.nondegenerate_def.mpr ?_, Matrix.Nondegenerate.toLinearMap₂'⟩
   exact fun v hv => h v fun w => (M.toLinearMap₂'_apply' _ _).trans <| hv w
 
 theorem _root_.Matrix.Nondegenerate.toLinearMap₂ {M : Matrix ι ι R₁} (h : M.Nondegenerate)

--- a/Mathlib/LinearAlgebra/Matrix/ToLinearEquiv.lean
+++ b/Mathlib/LinearAlgebra/Matrix/ToLinearEquiv.lean
@@ -176,6 +176,28 @@ theorem nondegenerate_iff_det_ne_zero {A : Type*} [DecidableEq n] [CommRing A] [
     refine not_imp_not.mp (h v) (funext fun i => ?_)
     simpa only [dotProduct_mulVec, dotProduct_single, mul_one] using hv (Pi.single i 1)
 
+theorem Nondegenerate.mul_iff_right {A : Type*} [CommRing A] [IsDomain A]
+    {M N : Matrix n n A} (h : N.Nondegenerate) :
+    (M * N).Nondegenerate ↔ M.Nondegenerate := by
+  classical
+  simp only [nondegenerate_iff_det_ne_zero, det_mul] at h ⊢
+  exact mul_ne_zero_iff_right h
+
+theorem Nondegenerate.mul_iff_left {A : Type*} [CommRing A] [IsDomain A]
+    {M N : Matrix n n A} (h : M.Nondegenerate) :
+    (M * N).Nondegenerate ↔ N.Nondegenerate := by
+  classical
+  simp only [nondegenerate_iff_det_ne_zero, det_mul] at h ⊢
+  exact mul_ne_zero_iff_left h
+
+theorem Nondegenerate.smul_iff {A : Type*} [CommRing A] [IsDomain A]
+    {M : Matrix n n A} {t : A} (h : t ≠ 0) :
+    (t • M).Nondegenerate ↔ M.Nondegenerate := by
+  simp_rw [Nondegenerate, smul_mulVec_assoc, dotProduct_smul]
+  refine ⟨fun hM v hv ↦ hM v fun w ↦ ?_, fun hM v hv ↦ hM v fun w ↦ ?_⟩
+  · simp [hv]
+  · exact (mul_eq_zero_iff_left h).mp <| hv w
+
 alias ⟨Nondegenerate.det_ne_zero, Nondegenerate.of_det_ne_zero⟩ := nondegenerate_iff_det_ne_zero
 
 end Nondegenerate

--- a/Mathlib/LinearAlgebra/Matrix/ToLinearEquiv.lean
+++ b/Mathlib/LinearAlgebra/Matrix/ToLinearEquiv.lean
@@ -172,7 +172,7 @@ theorem nondegenerate_iff_det_ne_zero {A : Type*} [DecidableEq n] [CommRing A] [
   · intro hM v hv hMv
     obtain ⟨w, hwMv⟩ := hM.exists_not_ortho_of_ne_zero hv
     simp [dotProduct_mulVec, hMv, zero_dotProduct, ne_eq, not_true] at hwMv
-  · rw [Matrix.Nondegenerate_def]
+  · rw [Matrix.nondegenerate_def]
     intro h v hv
     refine not_imp_not.mp (h v) (funext fun i => ?_)
     simpa only [dotProduct_mulVec, dotProduct_single, mul_one] using hv (Pi.single i 1)

--- a/Mathlib/LinearAlgebra/Matrix/ToLinearEquiv.lean
+++ b/Mathlib/LinearAlgebra/Matrix/ToLinearEquiv.lean
@@ -172,7 +172,8 @@ theorem nondegenerate_iff_det_ne_zero {A : Type*} [DecidableEq n] [CommRing A] [
   · intro hM v hv hMv
     obtain ⟨w, hwMv⟩ := hM.exists_not_ortho_of_ne_zero hv
     simp [dotProduct_mulVec, hMv, zero_dotProduct, ne_eq, not_true] at hwMv
-  · intro h v hv
+  · rw [Matrix.Nondegenerate_def]
+    intro h v hv
     refine not_imp_not.mp (h v) (funext fun i => ?_)
     simpa only [dotProduct_mulVec, dotProduct_single, mul_one] using hv (Pi.single i 1)
 

--- a/Mathlib/LinearAlgebra/Matrix/ToLinearEquiv.lean
+++ b/Mathlib/LinearAlgebra/Matrix/ToLinearEquiv.lean
@@ -191,7 +191,8 @@ theorem Nondegenerate.mul_iff_left {A : Type*} [CommRing A] [IsDomain A]
   simp only [nondegenerate_iff_det_ne_zero, det_mul] at h ⊢
   exact mul_ne_zero_iff_left h
 
-theorem Nondegenerate.smul_iff {A : Type*} [CommRing A] [IsDomain A]
+omit [Fintype n] in
+theorem Nondegenerate.smul_iff [Finite n] {A : Type*} [CommRing A] [IsDomain A]
     {M : Matrix n n A} {t : A} (h : t ≠ 0) :
     (t • M).Nondegenerate ↔ M.Nondegenerate := by
   simp_rw [Nondegenerate, smul_mulVec_assoc, dotProduct_smul]

--- a/Mathlib/LinearAlgebra/RootSystem/Base.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Base.lean
@@ -225,17 +225,25 @@ section RootSystem
 variable {P : RootSystem ι R M N} (b : P.Base)
 
 /-- A base of a root system yields a basis of the root space. -/
-@[simps!] def toWeightBasis :
+def toWeightBasis :
     Basis b.support R M :=
   Basis.mk b.linearIndepOn_root <| by
     change ⊤ ≤ span R (range <| P.root ∘ ((↑) : b.support → ι))
     rw [top_le_iff, range_comp, Subtype.range_coe_subtype, setOf_mem_eq, b.span_root_support]
     exact P.span_root_eq_top
 
+@[simp] lemma toWeightBasis_apply (i : b.support) :
+    b.toWeightBasis i = P.root i := by
+  simp [toWeightBasis]
+
 /-- A base of a root system yields a basis of the coroot space. -/
 def toCoweightBasis :
     Basis b.support R N :=
   Base.toWeightBasis (P := P.flip) b.flip
+
+@[simp] lemma toCoweightBasis_apply (i : b.support) :
+    b.toCoweightBasis i = P.coroot i :=
+  b.flip.toWeightBasis_apply (P := P.flip) i
 
 include b
 variable [Fintype ι]

--- a/Mathlib/LinearAlgebra/RootSystem/CartanMatrix.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/CartanMatrix.lean
@@ -16,6 +16,7 @@ This file contains definitions and basic results about Cartan matrices of root p
 ## Main definitions:
  * `RootPairing.Base.cartanMatrix`: the Cartan matrix of a crystallographic root pairing, with
    respect to a base `b`.
+ * `RootPairing.Base.cartanMatrix_nondegenerate`: the Cartan matrix is non-degenerate.
 
 -/
 
@@ -63,8 +64,7 @@ lemma cartanMatrixIn_mul_diagonal_eq {P : RootSystem ι R M N} [P.IsValuedIn S]
   simp [B.two_mul_apply_root_root]
 
 lemma cartanMatrixIn_nondegenerate [IsDomain R] [NeZero (2 : R)] [FaithfulSMul S R] [IsDomain S]
-    {P : RootSystem ι R M N} [P.IsValuedIn S] [Fintype ι] [P.IsAnisotropic] (b : P.Base)
-    [Fintype b.support] :
+    {P : RootSystem ι R M N} [P.IsValuedIn S] [Fintype ι] [P.IsAnisotropic] (b : P.Base) :
     (b.cartanMatrixIn S).Nondegenerate := by
   classical
   obtain ⟨B, hB⟩ : ∃ B : P.InvariantForm, B.form.Nondegenerate :=
@@ -115,7 +115,7 @@ lemma cartanMatrix_mem_of_ne [Finite ι] [IsDomain R] {i j : b.support} (hij : i
   simp [contra, hij, hij.symm]
 
 lemma cartanMatrix_nondegenerate [Finite ι] [IsDomain R]
-    {P : RootSystem ι R M N} [P.IsCrystallographic] (b : P.Base) [Fintype b.support] :
+    {P : RootSystem ι R M N} [P.IsCrystallographic] (b : P.Base) :
     b.cartanMatrix.Nondegenerate :=
   let _i : Fintype ι := Fintype.ofFinite ι
   cartanMatrixIn_nondegenerate ℤ b

--- a/Mathlib/LinearAlgebra/RootSystem/Finite/Nondegenerate.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Finite/Nondegenerate.lean
@@ -215,6 +215,11 @@ lemma disjoint_corootSpan_ker_corootForm :
     Disjoint (P.corootSpan R) (LinearMap.ker P.CorootForm) :=
   P.flip.disjoint_rootSpan_ker_rootForm
 
+lemma _root_.RootSystem.rootForm_nondegenerate (P : RootSystem ι R M N) [P.IsAnisotropic] :
+    P.RootForm.Nondegenerate :=
+  LinearMap.BilinForm.nondegenerate_iff_ker_eq_bot.mpr <| by
+    simpa using P.disjoint_rootSpan_ker_rootForm
+
 end IsDomain
 
 section Field


### PR DESCRIPTION
We also change the definition of docs#Matrix.Nondegenerate to demand `[Finite m]` rather than `[Fintype m]`.

This is a useful change in its own right and is visible here in that we would otherwise need to supply the assumption `[Fintype b.support]` to `cartanMatrix_nondegenerate`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
