### PR TITLE
[Merged by Bors] - chore(RingTheory/DedekindDomain/AdicValuation): Use intValuation over intValuationDef

### DIFF
--- a/Mathlib/NumberTheory/NumberField/FinitePlaces.lean
+++ b/Mathlib/NumberTheory/NumberField/FinitePlaces.lean
@@ -121,8 +121,7 @@ noncomputable instance instRankOneValuedAdicCompletion :
     constructor
     · simpa only [ne_eq, map_eq_zero, FaithfulSMul.algebraMap_eq_zero_iff]
     · apply ne_of_lt
-      rw [valuation_of_algebraMap, intValuation_lt_one_iff_dvd]
-      exact dvd_span_singleton.mpr hx1
+      rwa [valuation_of_algebraMap, intValuation_lt_one_iff_mem]
 
 /-- The `v`-adic completion of `K` is a normed field. -/
 noncomputable instance instNormedFieldValuedAdicCompletion : NormedField (adicCompletion K v) :=
@@ -196,8 +195,7 @@ theorem FinitePlace.norm_le_one (x : 𝓞 (WithVal (v.valuation K))) : ‖embedd
 theorem FinitePlace.norm_eq_one_iff_not_mem (x : 𝓞 (WithVal (v.valuation K))) :
     ‖embedding v x‖ = 1 ↔ x ∉ v.asIdeal := by
   rw [norm_def_int, NNReal.coe_eq_one, toNNReal_eq_one_iff (v.intValuation x)
-    (absNorm_ne_zero v) (one_lt_absNorm_nnreal v).ne', ← dvd_span_singleton,
-    ← intValuation_lt_one_iff_dvd, not_lt]
+    (absNorm_ne_zero v) (one_lt_absNorm_nnreal v).ne', ← intValuation_lt_one_iff_mem, not_lt]
   exact (intValuation_le_one v x).ge_iff_eq.symm
 
 @[deprecated (since := "2025-02-28")]
@@ -207,8 +205,7 @@ theorem FinitePlace.norm_eq_one_iff_not_mem (x : 𝓞 (WithVal (v.valuation K)))
 theorem FinitePlace.norm_lt_one_iff_mem (x : 𝓞 (WithVal (v.valuation K))) :
     ‖embedding v x‖ < 1 ↔ x ∈ v.asIdeal := by
   rw [norm_def_int, NNReal.coe_lt_one, toNNReal_lt_one_iff (one_lt_absNorm_nnreal v),
-    intValuation_lt_one_iff_dvd]
-  exact dvd_span_singleton
+    intValuation_lt_one_iff_mem]
 
 @[deprecated (since := "2025-02-28")] alias norm_lt_one_iff_mem := FinitePlace.norm_lt_one_iff_mem
 

--- a/Mathlib/NumberTheory/NumberField/FinitePlaces.lean
+++ b/Mathlib/NumberTheory/NumberField/FinitePlaces.lean
@@ -121,7 +121,7 @@ noncomputable instance instRankOneValuedAdicCompletion :
     constructor
     · simpa only [ne_eq, map_eq_zero, FaithfulSMul.algebraMap_eq_zero_iff]
     · apply ne_of_lt
-      rw [valuation_eq_intValuationDef, intValuation_lt_one_iff_dvd]
+      rw [valuation_of_algebraMap, intValuation_lt_one_iff_dvd]
       exact dvd_span_singleton.mpr hx1
 
 /-- The `v`-adic completion of `K` is a normed field. -/
@@ -158,8 +158,8 @@ theorem FinitePlace.norm_def' (x : WithVal (v.valuation K)) :
 /-- The norm of the image after the embedding associated to `v` is equal to the norm of `v` raised
 to the power of the `v`-adic valuation for integers. -/
 theorem FinitePlace.norm_def_int (x : 𝓞 (WithVal (v.valuation K))) :
-    ‖embedding v x‖ = toNNReal (absNorm_ne_zero v) (v.intValuationDef x) := by
-  rw [norm_def, adicAbv_def, valuation_eq_intValuationDef]
+    ‖embedding v x‖ = toNNReal (absNorm_ne_zero v) (v.intValuation x) := by
+  rw [norm_def, adicAbv_def, valuation_of_algebraMap]
 
 /-- The `v`-adic absolute value satisfies the ultrametric inequality. -/
 theorem RingOfIntegers.HeightOneSpectrum.adicAbv_add_le_max (x y : K) :
@@ -195,7 +195,7 @@ theorem FinitePlace.norm_le_one (x : 𝓞 (WithVal (v.valuation K))) : ‖embedd
 /-- The `v`-adic norm of an integer is 1 if and only if it is not in the ideal. -/
 theorem FinitePlace.norm_eq_one_iff_not_mem (x : 𝓞 (WithVal (v.valuation K))) :
     ‖embedding v x‖ = 1 ↔ x ∉ v.asIdeal := by
-  rw [norm_def_int, NNReal.coe_eq_one, toNNReal_eq_one_iff (v.intValuationDef x)
+  rw [norm_def_int, NNReal.coe_eq_one, toNNReal_eq_one_iff (v.intValuation x)
     (absNorm_ne_zero v) (one_lt_absNorm_nnreal v).ne', ← dvd_span_singleton,
     ← intValuation_lt_one_iff_dvd, not_lt]
   exact (intValuation_le_one v x).ge_iff_eq.symm
@@ -334,6 +334,6 @@ lemma embedding_mul_absNorm (v : HeightOneSpectrum (𝓞 K)) {x : 𝓞 (WithVal 
   rw [← zpow_natCast, ← zpow_add₀ <| mod_cast (zero_lt_one.trans (one_lt_absNorm_nnreal v)).ne']
   norm_cast
   rw [zpow_eq_one_iff_right₀ (Nat.cast_nonneg' _) (mod_cast (one_lt_absNorm_nnreal v).ne')]
-  simp [valuation_eq_intValuationDef, intValuationDef_if_neg, h_x_nezero]
+  simp [valuation_of_algebraMap, intValuation_if_neg, h_x_nezero]
 
 end IsDedekindDomain.HeightOneSpectrum

--- a/Mathlib/RingTheory/DedekindDomain/AdicValuation.lean
+++ b/Mathlib/RingTheory/DedekindDomain/AdicValuation.lean
@@ -232,7 +232,7 @@ theorem intValuation_lt_one_iff_dvd (r : R) :
 /-- The `v`-adic valuation of `r ∈ R` is less than 1 if and only if `r ∈ v`. -/
 theorem intValuation_lt_one_iff_mem (r : R) :
     v.intValuation r < 1 ↔ r ∈ v.asIdeal := by
-  rw [intValuation_lt_one_iff_dvd, Ideal.dvd_iff_le, Ideal.span_singleton_le_iff_mem]
+  rw [intValuation_lt_one_iff_dvd, Ideal.dvd_span_singleton]
 
 /-- The `v`-adic valuation of `r ∈ R` is less than `Multiplicative.ofAdd (-n)` if and only if
 `vⁿ` divides the ideal `(r)`. -/
@@ -250,7 +250,7 @@ theorem intValuation_le_pow_iff_dvd (r : R) (n : ℕ) :
 `r ∈ vⁿ`. -/
 theorem intValuation_le_pow_iff_mem (r : R) (n : ℕ) :
     v.intValuation r ≤ Multiplicative.ofAdd (-(n : ℤ)) ↔ r ∈ v.asIdeal ^ n := by
-  rw [intValuation_le_pow_iff_dvd, Ideal.dvd_iff_le, Ideal.span_singleton_le_iff_mem]
+  rw [intValuation_le_pow_iff_dvd, Ideal.dvd_span_singleton]
 
 /-- There exists `π ∈ R` with `v`-adic valuation `Multiplicative.ofAdd (-1)`. -/
 theorem intValuation_exists_uniformizer :
@@ -325,6 +325,12 @@ open scoped algebraMap in
 theorem valuation_lt_one_iff_dvd (r : R) :
     v.valuation K r < 1 ↔ v.asIdeal ∣ Ideal.span {r} := by
   rw [valuation_of_algebraMap]; exact v.intValuation_lt_one_iff_dvd r
+
+open scoped algebraMap in
+/-- The `v`-adic valuation of `r ∈ R` is less than 1 if and only if `r ∈ v`. -/
+theorem valuation_lt_one_iff_mem (r : R) :
+    v.valuation K r < 1 ↔ r ∈ v.asIdeal := by
+  rw [valuation_of_algebraMap]; exact v.intValuation_lt_one_iff_mem r
 
 variable (K)
 

--- a/Mathlib/RingTheory/DedekindDomain/AdicValuation.lean
+++ b/Mathlib/RingTheory/DedekindDomain/AdicValuation.lean
@@ -91,55 +91,6 @@ theorem intValuationDef_if_neg {r : R} (hr : r ≠ 0) :
         (-(Associates.mk v.asIdeal).count (Associates.mk (Ideal.span {r} : Ideal R)).factors : ℤ) :=
   if_neg hr
 
-/-- Nonzero elements have nonzero adic valuation. -/
-theorem intValuation_ne_zero (x : R) (hx : x ≠ 0) : v.intValuationDef x ≠ 0 := by
-  rw [intValuationDef, if_neg hx]
-  exact WithZero.coe_ne_zero
-
-/-- Nonzero divisors have nonzero valuation. -/
-theorem intValuation_ne_zero' (x : nonZeroDivisors R) : v.intValuationDef x ≠ 0 :=
-  v.intValuation_ne_zero x (nonZeroDivisors.coe_ne_zero x)
-
-/-- Nonzero divisors have valuation greater than zero. -/
-theorem intValuation_zero_le (x : nonZeroDivisors R) : 0 < v.intValuationDef x := by
-  rw [v.intValuationDef_if_neg (nonZeroDivisors.coe_ne_zero x)]
-  exact WithZero.zero_lt_coe _
-
-/-- The `v`-adic valuation on `R` is bounded above by 1. -/
-theorem intValuation_le_one (x : R) : v.intValuationDef x ≤ 1 := by
-  rw [intValuationDef]
-  by_cases hx : x = 0
-  · rw [if_pos hx]; exact WithZero.zero_le 1
-  · rw [if_neg hx, ← WithZero.coe_one, ← ofAdd_zero, WithZero.coe_le_coe, ofAdd_le,
-      Right.neg_nonpos_iff]
-    exact Int.natCast_nonneg _
-
-/-- The `v`-adic valuation of `r ∈ R` is less than 1 if and only if `v` divides the ideal `(r)`. -/
-theorem intValuation_lt_one_iff_dvd (r : R) :
-    v.intValuationDef r < 1 ↔ v.asIdeal ∣ Ideal.span {r} := by
-  classical
-  rw [intValuationDef]
-  split_ifs with hr
-  · simp [hr]
-  · rw [← WithZero.coe_one, ← ofAdd_zero, WithZero.coe_lt_coe, ofAdd_lt, neg_lt_zero, ←
-      Int.ofNat_zero, Int.ofNat_lt, zero_lt_iff]
-    have h : (Ideal.span {r} : Ideal R) ≠ 0 := by
-      rw [Ne, Ideal.zero_eq_bot, Ideal.span_singleton_eq_bot]
-      exact hr
-    apply Associates.count_ne_zero_iff_dvd h (by apply v.irreducible)
-
-/-- The `v`-adic valuation of `r ∈ R` is less than `Multiplicative.ofAdd (-n)` if and only if
-`vⁿ` divides the ideal `(r)`. -/
-theorem intValuation_le_pow_iff_dvd (r : R) (n : ℕ) :
-    v.intValuationDef r ≤ Multiplicative.ofAdd (-(n : ℤ)) ↔ v.asIdeal ^ n ∣ Ideal.span {r} := by
-  classical
-  rw [intValuationDef]
-  split_ifs with hr
-  · simp_rw [hr, Ideal.dvd_span_singleton, zero_le', Submodule.zero_mem]
-  · rw [WithZero.coe_le_coe, ofAdd_le, neg_le_neg_iff, Int.ofNat_le, Ideal.dvd_span_singleton, ←
-      Associates.le_singleton_iff,
-      Associates.prime_pow_dvd_iff_le (Associates.mk_ne_zero'.mpr hr)
-        (by apply v.associates_irreducible)]
 
 /-- The `v`-adic valuation of `0 : R` equals 0. -/
 theorem intValuation.map_zero' : v.intValuationDef 0 = 0 :=
@@ -212,7 +163,6 @@ theorem intValuation.map_add_le_max' (x y : R) :
         apply v.associates_irreducible
 
 /-- The `v`-adic valuation on `R`. -/
-@[simps]
 def intValuation : Valuation R ℤₘ₀ where
   toFun := v.intValuationDef
   map_zero' := intValuation.map_zero' v
@@ -223,9 +173,88 @@ def intValuation : Valuation R ℤₘ₀ where
 theorem intValuation_apply {r : R} (v : IsDedekindDomain.HeightOneSpectrum R) :
     intValuation v r = intValuationDef v r := rfl
 
+open scoped Classical in
+theorem intValuation_def {r : R} :
+    v.intValuation r = if r = 0 then 0 else
+    ↑(Multiplicative.ofAdd
+      (-(Associates.mk v.asIdeal).count (Associates.mk (Ideal.span {r} : Ideal R)).factors : ℤ)) :=
+  rfl
+
+@[deprecated intValuation_apply (since := "2025-04-26")]
+theorem intValuation_toFun (r : R) :
+    v.intValuation r = v.intValuationDef r := rfl
+
+open scoped Classical in
+theorem intValuation_if_neg {r : R} (hr : r ≠ 0) :
+    v.intValuation r =
+      Multiplicative.ofAdd
+        (-(Associates.mk v.asIdeal).count (Associates.mk (Ideal.span {r} : Ideal R)).factors : ℤ) :=
+  intValuationDef_if_neg _ hr
+
+/-- Nonzero elements have nonzero adic valuation. -/
+theorem intValuation_ne_zero (x : R) (hx : x ≠ 0) : v.intValuation x ≠ 0 := by
+  rw [v.intValuation_if_neg hx]
+  exact WithZero.coe_ne_zero
+
+/-- Nonzero divisors have nonzero valuation. -/
+theorem intValuation_ne_zero' (x : nonZeroDivisors R) : v.intValuation x ≠ 0 :=
+  v.intValuation_ne_zero x (nonZeroDivisors.coe_ne_zero x)
+
+/-- Nonzero divisors have valuation greater than zero. -/
+theorem intValuation_zero_lt (x : nonZeroDivisors R) : 0 < v.intValuation x := by
+  rw [v.intValuation_if_neg (nonZeroDivisors.coe_ne_zero x)]
+  exact WithZero.zero_lt_coe _
+
+@[deprecated (since := "2025-05-11")]
+alias intValuation_zero_le := intValuation_zero_lt
+
+/-- The `v`-adic valuation on `R` is bounded above by 1. -/
+theorem intValuation_le_one (x : R) : v.intValuation x ≤ 1 := by
+  by_cases hx : x = 0
+  · rw [hx, Valuation.map_zero]; exact WithZero.zero_le 1
+  · rw [v.intValuation_if_neg hx, ← WithZero.coe_one, ← ofAdd_zero, WithZero.coe_le_coe, ofAdd_le,
+      Right.neg_nonpos_iff]
+    exact Int.natCast_nonneg _
+
+/-- The `v`-adic valuation of `r ∈ R` is less than 1 if and only if `v` divides the ideal `(r)`. -/
+theorem intValuation_lt_one_iff_dvd (r : R) :
+    v.intValuation r < 1 ↔ v.asIdeal ∣ Ideal.span {r} := by
+  classical
+  by_cases hr : r = 0
+  · simp [hr]
+  · rw [v.intValuation_if_neg hr, ← WithZero.coe_one, ← ofAdd_zero, WithZero.coe_lt_coe, ofAdd_lt,
+      neg_lt_zero, ← Int.ofNat_zero, Int.ofNat_lt, zero_lt_iff]
+    have h : (Ideal.span {r} : Ideal R) ≠ 0 := by
+      rw [Ne, Ideal.zero_eq_bot, Ideal.span_singleton_eq_bot]
+      exact hr
+    apply Associates.count_ne_zero_iff_dvd h (by apply v.irreducible)
+
+/-- The `v`-adic valuation of `r ∈ R` is less than 1 if and only if `r ∈ v`. -/
+theorem intValuation_lt_one_iff_mem (r : R) :
+    v.intValuation r < 1 ↔ r ∈ v.asIdeal := by
+  rw [intValuation_lt_one_iff_dvd, Ideal.dvd_iff_le, Ideal.span_singleton_le_iff_mem]
+
+/-- The `v`-adic valuation of `r ∈ R` is less than `Multiplicative.ofAdd (-n)` if and only if
+`vⁿ` divides the ideal `(r)`. -/
+theorem intValuation_le_pow_iff_dvd (r : R) (n : ℕ) :
+    v.intValuation r ≤ Multiplicative.ofAdd (-(n : ℤ)) ↔ v.asIdeal ^ n ∣ Ideal.span {r} := by
+  classical
+  by_cases hr : r = 0
+  · simp_rw [hr, Valuation.map_zero, Ideal.dvd_span_singleton, zero_le', Submodule.zero_mem]
+  · rw [v.intValuation_if_neg hr, WithZero.coe_le_coe, ofAdd_le, neg_le_neg_iff, Int.ofNat_le,
+      Ideal.dvd_span_singleton, ← Associates.le_singleton_iff,
+      Associates.prime_pow_dvd_iff_le (Associates.mk_ne_zero'.mpr hr)
+        (by apply v.associates_irreducible)]
+
+/-- The `v`-adic valuation of `r ∈ R` is less than `Multiplicative.ofAdd (-n)` if and only if
+`r ∈ vⁿ`. -/
+theorem intValuation_le_pow_iff_mem (r : R) (n : ℕ) :
+    v.intValuation r ≤ Multiplicative.ofAdd (-(n : ℤ)) ↔ r ∈ v.asIdeal ^ n := by
+  rw [intValuation_le_pow_iff_dvd, Ideal.dvd_iff_le, Ideal.span_singleton_le_iff_mem]
+
 /-- There exists `π ∈ R` with `v`-adic valuation `Multiplicative.ofAdd (-1)`. -/
 theorem intValuation_exists_uniformizer :
-    ∃ π : R, v.intValuationDef π = Multiplicative.ofAdd (-1 : ℤ) := by
+    ∃ π : R, v.intValuation π = Multiplicative.ofAdd (-1 : ℤ) := by
   classical
   have hv : _root_.Irreducible (Associates.mk v.asIdeal) := v.associates_irreducible
   have hlt : v.asIdeal ^ 2 < v.asIdeal := by
@@ -240,7 +269,7 @@ theorem intValuation_exists_uniformizer :
     rw [h] at nmem
     exact nmem (Submodule.zero_mem (v.asIdeal ^ 2))
   use π
-  rw [intValuationDef, if_neg (Associates.mk_ne_zero'.mp hπ), WithZero.coe_inj]
+  rw [intValuation_if_neg _ (Associates.mk_ne_zero'.mp hπ), WithZero.coe_inj]
   apply congr_arg
   rw [neg_inj, ← Int.ofNat_one, Int.natCast_inj]
   rw [← Ideal.dvd_span_singleton, ← Associates.mk_le_mk_iff_dvd] at mem nmem
@@ -252,7 +281,7 @@ theorem intValuation_exists_uniformizer :
 theorem intValuation_singleton {r : R} (hr : r ≠ 0) (hv : v.asIdeal = Ideal.span {r}) :
     v.intValuation r = Multiplicative.ofAdd (-1 : ℤ) := by
   classical
-  rw [intValuation_apply, v.intValuationDef_if_neg hr, ← hv, Associates.count_self, Int.ofNat_one,
+  rw [v.intValuation_if_neg hr, ← hv, Associates.count_self, Int.ofNat_one,
     ofAdd_neg, WithZero.coe_inv]
   apply v.associates_irreducible
 
@@ -282,6 +311,7 @@ theorem valuation_of_algebraMap (r : R) : v.valuation K r = v.intValuation r := 
   rw [valuation_def, Valuation.extendToLocalization_apply_map_apply]
 
 open scoped algebraMap in
+@[deprecated valuation_of_algebraMap (since := "2025-05-11")]
 lemma valuation_eq_intValuationDef (r : R) : v.valuation K r = v.intValuationDef r :=
   Valuation.extendToLocalization_apply_map_apply ..
 
@@ -332,9 +362,8 @@ theorem mem_integers_of_valuation_le_one (x : K)
   have hv' := hv
   rw [Associates.irreducible_mk, irreducible_iff_prime] at hv
   specialize h ⟨v, Ideal.isPrime_of_prime hv, hv.ne_zero⟩
-  simp_rw [valuation_of_mk', intValuation, ← Valuation.toFun_eq_coe,
-    intValuationDef_if_neg _ hn0, intValuationDef_if_neg _ hd0, ← WithZero.coe_div,
-    ← WithZero.coe_one, WithZero.coe_le_coe, Associates.factors_mk _ (ine hn0),
+  simp_rw [valuation_of_mk', intValuation_if_neg _ hn0, intValuation_if_neg _ hd0,
+    ← WithZero.coe_div, ← WithZero.coe_one, WithZero.coe_le_coe, Associates.factors_mk _ (ine hn0),
     Associates.factors_mk _ (ine hd0), Associates.count_some hv'] at h
   simpa using h
 
@@ -486,8 +515,8 @@ open scoped algebraMap in -- to make the coercion from `R` fire
 /-- A global integer is in the local integers. -/
 lemma coe_mem_adicCompletionIntegers (r : R) :
     (r : adicCompletion K v) ∈ adicCompletionIntegers K v := by
-  rw [mem_adicCompletionIntegers, valuedAdicCompletion_eq_valuation, valuation_eq_intValuationDef]
-  exact intValuation_le_one v r
+  rw [mem_adicCompletionIntegers, valuedAdicCompletion_eq_valuation]
+  exact valuation_le_one v r
 
 @[simp]
 theorem coe_smul_adicCompletionIntegers (r : R) (x : v.adicCompletionIntegers K) :
@@ -527,7 +556,7 @@ lemma adicCompletion.mul_nonZeroDivisor_mem_adicCompletionIntegers (v : HeightOn
     refine ⟨ϖ^d.natAbs, pow_mem (mem_nonZeroDivisors_of_ne_zero hϖ0) _, ?_⟩
     -- now manually translate the goal (an inequality in ℤₘ₀) to an inequality in ℤ
     rw [mem_adicCompletionIntegers, algebraMap.coe_pow, map_mul, hd, map_pow,
-      valuedAdicCompletion_eq_valuation, valuation_eq_intValuationDef, hϖ, ← WithZero.coe_pow,
+      valuedAdicCompletion_eq_valuation, valuation_of_algebraMap, hϖ, ← WithZero.coe_pow,
       ← WithZero.coe_mul, WithZero.coe_le_one, ← toAdd_le, toAdd_mul, toAdd_ofAdd, toAdd_pow,
       toAdd_ofAdd, toAdd_one,
       show d.natAbs • (-1) = (d.natAbs : ℤ) • (-1) by simp only [nsmul_eq_mul,

--- a/Mathlib/RingTheory/DedekindDomain/FiniteAdeleRing.lean
+++ b/Mathlib/RingTheory/DedekindDomain/FiniteAdeleRing.lean
@@ -54,10 +54,10 @@ lemma HeightOneSpectrum.Support.finite (k : K) : (Support R k).Finite := by
     rw [Set.mem_setOf_eq, valuation_of_algebraMap]
     have := intValuation_le_one v n
     contrapose! this
-    rw [← intValuation_apply, ← hk, mul_comm]
+    rw [← hk, mul_comm]
     exact (lt_mul_of_one_lt_right (by simp) hv).trans_le <|
       mul_le_mul_of_nonneg_right this (by simp)
-  simp_rw [valuation_of_algebraMap, intValuation_apply, intValuation_lt_one_iff_dvd]
+  simp_rw [valuation_lt_one_iff_dvd]
   apply Ideal.finite_factors
   simpa only [Submodule.zero_eq_bot, ne_eq, Ideal.span_singleton_eq_bot]
 

--- a/Mathlib/RingTheory/LaurentSeries.lean
+++ b/Mathlib/RingTheory/LaurentSeries.lean
@@ -515,8 +515,7 @@ theorem intValuation_eq_of_coe (P : K[X]) :
     (Polynomial.idealX K).intValuation P = (idealX K).intValuation (P : K⟦X⟧) := by
   by_cases hP : P = 0
   · rw [hP, Valuation.map_zero, Polynomial.coe_zero, Valuation.map_zero]
-  simp only [intValuation_apply]
-  rw [intValuationDef_if_neg _ hP, intValuationDef_if_neg _ <| coe_ne_zero hP]
+  rw [intValuation_if_neg _ hP, intValuation_if_neg _ <| coe_ne_zero hP]
   simp only [idealX_span, ofAdd_neg, inv_inj, WithZero.coe_inj, EmbeddingLike.apply_eq_iff_eq,
     Nat.cast_inj]
   have span_ne_zero :
@@ -538,8 +537,8 @@ theorem intValuation_eq_of_coe (P : K[X]) :
 
 /-- The integral valuation of the power series `X : K⟦X⟧` equals `(ofAdd -1) : ℤₘ₀`. -/
 @[simp]
-theorem intValuation_X : (idealX K).intValuationDef X = ↑(Multiplicative.ofAdd (-1 : ℤ)) := by
-  rw [← Polynomial.coe_X, ← intValuation_apply, ← intValuation_eq_of_coe]
+theorem intValuation_X : (idealX K).intValuation X = ↑(Multiplicative.ofAdd (-1 : ℤ)) := by
+  rw [← Polynomial.coe_X, ← intValuation_eq_of_coe]
   apply intValuation_singleton _ Polynomial.X_ne_zero (by rfl)
 
 end PowerSeries
@@ -575,7 +574,7 @@ theorem valuation_X_pow (s : ℕ) :
     Valued.v (((X : K⟦X⟧) : K⸨X⸩) ^ s) = Multiplicative.ofAdd (-(s : ℤ)) := by
   rw [map_pow, ← one_mul (s : ℤ), ← neg_mul (1 : ℤ) s, Int.ofAdd_mul, WithZero.coe_zpow,
     ofAdd_neg, WithZero.coe_inv, zpow_natCast, valuation_def, ← LaurentSeries.coe_algebraMap,
-    valuation_of_algebraMap, intValuation_toFun, intValuation_X, ofAdd_neg, WithZero.coe_inv]
+    valuation_of_algebraMap, intValuation_X, ofAdd_neg, WithZero.coe_inv]
 
 theorem valuation_single_zpow (s : ℤ) :
     Valued.v (HahnSeries.single s (1 : K) : K⸨X⸩) =
@@ -597,7 +596,7 @@ theorem coeff_zero_of_lt_intValuation {n d : ℕ} {f : K⟦X⟧}
     n < d → coeff K n f = 0 := by
   intro hnd
   apply (PowerSeries.X_pow_dvd_iff).mp _ n hnd
-  rwa [← LaurentSeries.coe_algebraMap, valuation_def, valuation_of_algebraMap, intValuation_apply,
+  rwa [← LaurentSeries.coe_algebraMap, valuation_def, valuation_of_algebraMap,
     intValuation_le_pow_iff_dvd (PowerSeries.idealX K) f d, PowerSeries.idealX,
     Ideal.span_singleton_pow, span_singleton_dvd_span_singleton_iff_dvd] at H
 


### PR DESCRIPTION
`intValuationDef` exists so that we can prove its basic properties before defining `intValuation`, but it shouldn't be used afterwards. Change theorems which use `intValuation` in their names to actually use `intValution` and update usages.

---


[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
