### PR TITLE
[Merged by Bors] - fix: rename `OddCommuteEquiv` to `oddCommuteEquiv`

### DIFF
--- a/Mathlib/GroupTheory/SpecificGroups/Dihedral.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/Dihedral.lean
@@ -273,6 +273,11 @@ def oddCommuteEquiv (hn : Odd n) : { p : DihedralGroup n × DihedralGroup n // C
 
 @[deprecated (since := "2025-05-07")] alias OddCommuteEquiv := oddCommuteEquiv
 
+@[deprecated (since := "2025-05-07")] alias
+OddCommuteEquiv_apply := DihedralGroup.oddCommuteEquiv_apply
+@[deprecated (since := "2025-05-07")] alias
+OddCommuteEquiv_symm_apply := DihedralGroup.oddCommuteEquiv_symm_apply
+
 /-- If n is odd, then the Dihedral group of order $2n$ has $n(n+3)$ pairs of commuting elements. -/
 lemma card_commute_odd (hn : Odd n) :
     Nat.card { p : DihedralGroup n × DihedralGroup n // Commute p.1 p.2 } = n * (n + 3) := by

--- a/Mathlib/GroupTheory/SpecificGroups/Dihedral.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/Dihedral.lean
@@ -237,7 +237,7 @@ lemma isCyclic_iff : IsCyclic (DihedralGroup n) ↔ n = 1 where
 /-- If n is odd, then the Dihedral group of order $2n$ has $n(n+3)$ pairs (represented as
 $n + n + n + n*n$) of commuting elements. -/
 @[simps]
-def OddCommuteEquiv (hn : Odd n) : { p : DihedralGroup n × DihedralGroup n // Commute p.1 p.2 } ≃
+def oddCommuteEquiv (hn : Odd n) : { p : DihedralGroup n × DihedralGroup n // Commute p.1 p.2 } ≃
     ZMod n ⊕ ZMod n ⊕ ZMod n ⊕ ZMod n × ZMod n :=
   let u := ZMod.unitOfCoprime 2 (Nat.prime_two.coprime_iff_not_dvd.mpr hn.not_two_dvd_nat)
   have hu : ∀ a : ZMod n, a + a = 0 ↔ a = 0 := fun _ => ZMod.add_self_eq_zero_iff_eq_zero hn
@@ -271,11 +271,13 @@ def OddCommuteEquiv (hn : Odd n) : { p : DihedralGroup n × DihedralGroup n // C
         congrArg (Sum.inr ∘ Sum.inr ∘ Sum.inl) <| two_mul (u⁻¹ * k) ▸ u.mul_inv_cancel_left k
       | .inr (.inr (.inr ⟨_, _⟩)) => rfl }
 
+@[deprecated (since := "2025-05-07")] alias OddCommuteEquiv := oddCommuteEquiv
+
 /-- If n is odd, then the Dihedral group of order $2n$ has $n(n+3)$ pairs of commuting elements. -/
 lemma card_commute_odd (hn : Odd n) :
     Nat.card { p : DihedralGroup n × DihedralGroup n // Commute p.1 p.2 } = n * (n + 3) := by
   have hn' : NeZero n := ⟨hn.pos.ne'⟩
-  simp_rw [Nat.card_congr (OddCommuteEquiv hn), Nat.card_sum, Nat.card_prod, Nat.card_zmod]
+  simp_rw [Nat.card_congr (oddCommuteEquiv hn), Nat.card_sum, Nat.card_prod, Nat.card_zmod]
   ring
 
 lemma card_conjClasses_odd (hn : Odd n) :


### PR DESCRIPTION
Per the naming convention, this definition (which is a term of some Type) should be named in lowerCamelCase.

Part of item 28 of the ["unquantifiable tech debt list"](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Call.20for.20help.3A.20technical.2F.20organisational.20debt).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
