### PR TITLE
[Merged by Bors] - feat(CategoryTheory/Join/Basic): equivalent categories have equivalent joins

### DIFF
--- a/Mathlib/CategoryTheory/Join/Basic.lean
+++ b/Mathlib/CategoryTheory/Join/Basic.lean
@@ -541,6 +541,38 @@ lemma mapIsoWhiskerLeft_inv (H : C ⥤ E) {Fᵣ : D ⥤ E'} {Gᵣ : D ⥤ E'} (�
 
 end NaturalTransforms
 
+section mapPairEquiv
+
+variable {E : Type u₃} [Category.{v₃} E]
+  {E' : Type u₄} [Category.{v₄} E']
+
+variable {C D}
+
+/-- Equivalent categories have equivalent joins. -/
+@[simps]
+def mapPairEquiv (Eₗ : C ≌ E) (Eᵣ : D ≌ E') : C ⋆ D ≌ E ⋆ E' where
+  functor := mapPair Eₗ.functor Eᵣ.functor
+  inverse := mapPair Eₗ.inverse Eᵣ.inverse
+  unitIso :=
+    mapPairId.symm ≪≫
+    mapIsoWhiskerRight Eₗ.unitIso _ ≪≫
+    mapIsoWhiskerLeft _ (Eᵣ.unitIso) ≪≫
+    mapPairComp _ _ _ _
+  counitIso :=
+    (mapPairComp _ _ _ _).symm ≪≫
+    mapIsoWhiskerRight Eₗ.counitIso _ ≪≫
+    mapIsoWhiskerLeft _ (Eᵣ.counitIso) ≪≫
+    mapPairId
+  functor_unitIso_comp x := by
+    cases x <;>
+    simp [← (inclLeft E E').map_comp, ← (inclRight E E').map_comp]
+
+instance isEquivalenceMapPair {Fₗ : C ⥤ E} {Fᵣ : D ⥤ E'} [Fₗ.IsEquivalence] [Fᵣ.IsEquivalence] :
+    (mapPair Fₗ Fᵣ).IsEquivalence :=
+  inferInstanceAs (mapPairEquiv Fₗ.asEquivalence Fᵣ.asEquivalence).functor.IsEquivalence
+
+end mapPairEquiv
+
 end Join
 
 end CategoryTheory

--- a/Mathlib/CategoryTheory/Join/Basic.lean
+++ b/Mathlib/CategoryTheory/Join/Basic.lean
@@ -555,14 +555,14 @@ def mapPairEquiv (e : C ≌ C') (e' : D ≌ D') : C ⋆ D ≌ C' ⋆ D' where
   inverse := mapPair e.inverse e'.inverse
   unitIso :=
     mapPairId.symm ≪≫
-    mapIsoWhiskerRight e.unitIso _ ≪≫
-    mapIsoWhiskerLeft _ e'.unitIso ≪≫
-    mapPairComp _ _ _ _
+      mapIsoWhiskerRight e.unitIso _ ≪≫
+      mapIsoWhiskerLeft _ e'.unitIso ≪≫
+      mapPairComp _ _ _ _
   counitIso :=
     (mapPairComp _ _ _ _).symm ≪≫
-    mapIsoWhiskerRight e.counitIso _ ≪≫
-    mapIsoWhiskerLeft _ e'.counitIso ≪≫
-    mapPairId
+      mapIsoWhiskerRight e.counitIso _ ≪≫
+      mapIsoWhiskerLeft _ e'.counitIso ≪≫
+      mapPairId
   functor_unitIso_comp x := by
     cases x <;>
     simp [← (inclLeft C' D').map_comp, ← (inclRight C' D').map_comp]

--- a/Mathlib/CategoryTheory/Join/Basic.lean
+++ b/Mathlib/CategoryTheory/Join/Basic.lean
@@ -543,33 +543,33 @@ end NaturalTransforms
 
 section mapPairEquiv
 
-variable {E : Type u₃} [Category.{v₃} E]
-  {E' : Type u₄} [Category.{v₄} E']
+variable {C' : Type u₃} [Category.{v₃} C']
+  {D' : Type u₄} [Category.{v₄} D']
 
 variable {C D}
 
 /-- Equivalent categories have equivalent joins. -/
 @[simps]
-def mapPairEquiv (Eₗ : C ≌ E) (Eᵣ : D ≌ E') : C ⋆ D ≌ E ⋆ E' where
-  functor := mapPair Eₗ.functor Eᵣ.functor
-  inverse := mapPair Eₗ.inverse Eᵣ.inverse
+def mapPairEquiv (e : C ≌ C') (e' : D ≌ D') : C ⋆ D ≌ C' ⋆ D' where
+  functor := mapPair e.functor e'.functor
+  inverse := mapPair e.inverse e'.inverse
   unitIso :=
     mapPairId.symm ≪≫
-    mapIsoWhiskerRight Eₗ.unitIso _ ≪≫
-    mapIsoWhiskerLeft _ (Eᵣ.unitIso) ≪≫
+    mapIsoWhiskerRight e.unitIso _ ≪≫
+    mapIsoWhiskerLeft _ e'.unitIso ≪≫
     mapPairComp _ _ _ _
   counitIso :=
     (mapPairComp _ _ _ _).symm ≪≫
-    mapIsoWhiskerRight Eₗ.counitIso _ ≪≫
-    mapIsoWhiskerLeft _ (Eᵣ.counitIso) ≪≫
+    mapIsoWhiskerRight e.counitIso _ ≪≫
+    mapIsoWhiskerLeft _ e'.counitIso ≪≫
     mapPairId
   functor_unitIso_comp x := by
     cases x <;>
-    simp [← (inclLeft E E').map_comp, ← (inclRight E E').map_comp]
+    simp [← (inclLeft C' D').map_comp, ← (inclRight C' D').map_comp]
 
-instance isEquivalenceMapPair {Fₗ : C ⥤ E} {Fᵣ : D ⥤ E'} [Fₗ.IsEquivalence] [Fᵣ.IsEquivalence] :
-    (mapPair Fₗ Fᵣ).IsEquivalence :=
-  inferInstanceAs (mapPairEquiv Fₗ.asEquivalence Fᵣ.asEquivalence).functor.IsEquivalence
+instance isEquivalenceMapPair {F : C ⥤ C'} {F' : D ⥤ D'} [F.IsEquivalence] [F'.IsEquivalence] :
+    (mapPair F F').IsEquivalence :=
+  inferInstanceAs (mapPairEquiv F.asEquivalence F'.asEquivalence).functor.IsEquivalence
 
 end mapPairEquiv
 


### PR DESCRIPTION
Promote the construction `Join.mapPair` to an equivalence of categories when both functors are equivalences. This is recorded both in terms of an explicit `mapPairEquiv` construction, and as an `IsEquivalence` instance when both functor have `IsEquivalence` instances.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
