### PR TITLE
[Merged by Bors] - feat(lint-style): enforce modules are named in UpperCamelCase

### DIFF
--- a/Mathlib/Tactic/Linter/TextBased.lean
+++ b/Mathlib/Tactic/Linter/TextBased.lean
@@ -6,6 +6,11 @@ Authors: Michael Rothgang
 
 import Batteries.Data.String.Matcher
 import Mathlib.Data.Nat.Notation
+import Lake.Util.Casing
+
+-- Don't warn about the lake import: the above file has almost no imports, and this PR has been
+-- benchmarked.
+set_option linter.style.header false
 
 /-!
 ## Text-based linters
@@ -327,5 +332,27 @@ def lintModules (nolints : Array String) (moduleNames : Array Lean.Name) (style 
   if allUnexpectedErrors.size > 0 then
     IO.eprintln s!"error: found {allUnexpectedErrors.size} new style error(s)"
   return numberErrorFiles
+
+/-- Verifies that all modules in `modules` are named in `UpperCamelCase`
+(except for explicitly discussed exceptions, which are hard-coded here).
+Return the number of modules violating this. -/
+def modulesNotUpperCamelCase (modules : Array Lean.Name) : IO Nat := do
+  -- Exceptions to this list should be discussed on zulip!
+  let exceptions := [
+    `Mathlib.Analysis.CStarAlgebra.lpSpace,
+    `Mathlib.Analysis.InnerProductSpace.l2Space,
+    `Mathlib.Analysis.Normed.Lp.lpSpace
+  ]
+  -- We allow only names in UpperCamelCase, possibly with a trailing underscore.
+  let badNames := modules.filter fun name ↦
+    let upperCamelName := Lake.toUpperCamelCase name
+    !exceptions.contains name &&
+    (upperCamelName != name && s!"{upperCamelName}_" != name.toString)
+  for bad in badNames do
+    let upperCamelName := Lake.toUpperCamelCase bad
+    let good := if bad.toString.endsWith "_" then s!"{upperCamelName}_" else upperCamelName.toString
+    IO.eprintln
+      s!"error: module name '{bad}' is not in 'UpperCamelCase': it should be '{good}' instead"
+  return badNames.size
 
 end Mathlib.Linter.TextBased

--- a/Mathlib/Tactic/Linter/TextBased.lean
+++ b/Mathlib/Tactic/Linter/TextBased.lean
@@ -347,7 +347,7 @@ def modulesNotUpperCamelCase (modules : Array Lean.Name) : IO Nat := do
   let badNames := modules.filter fun name ↦
     let upperCamelName := Lake.toUpperCamelCase name
     !exceptions.contains name &&
-    (upperCamelName != name && s!"{upperCamelName}_" != name.toString)
+      upperCamelName != name && s!"{upperCamelName}_" != name.toString
   for bad in badNames do
     let upperCamelName := Lake.toUpperCamelCase bad
     let good := if bad.toString.endsWith "_" then s!"{upperCamelName}_" else upperCamelName.toString

--- a/MathlibTest/ModuleCasing.lean
+++ b/MathlibTest/ModuleCasing.lean
@@ -1,0 +1,33 @@
+import Mathlib.Tactic.Linter.TextBased
+
+/-!
+Unit tests for the module name case check in the text-based linters.
+
+-/
+
+open Mathlib.Linter.TextBased
+
+/-- Some unit tests for `modulesNotUpperCamelCase` -/
+def testModulesNotUpperCamelCase : IO Unit := do
+  assert!((← modulesNotUpperCamelCase #[]) == 0)
+  assert!((← modulesNotUpperCamelCase #[`Mathlib.Fine]) == 0)
+  assert!((← modulesNotUpperCamelCase #[`Mathlib.AlsoFine_]) == 0)
+  assert!((← modulesNotUpperCamelCase #[`Mathlib.NotFine_.Foo]) == 1)
+
+  assert!((← modulesNotUpperCamelCase #[`bad_module]) == 1)
+  assert!((← modulesNotUpperCamelCase #[`GoodName, `bad_module, `bad_module]) == 2)
+  assert!((← modulesNotUpperCamelCase #[`Mathlib.BadModule__]) == 1)
+  assert!((← modulesNotUpperCamelCase #[`Mathlib.lowerCase]) == 1)
+  assert!((← modulesNotUpperCamelCase #[`Mathlib.snake_case]) == 1)
+
+/--
+info: error: module name 'Mathlib.NotFine_.Foo' is not in 'UpperCamelCase': it should be 'Mathlib.NotFine.Foo' instead
+error: module name 'bad_module' is not in 'UpperCamelCase': it should be 'BadModule' instead
+error: module name 'bad_module' is not in 'UpperCamelCase': it should be 'BadModule' instead
+error: module name 'bad_module' is not in 'UpperCamelCase': it should be 'BadModule' instead
+error: module name 'Mathlib.BadModule__' is not in 'UpperCamelCase': it should be 'Mathlib.BadModule_' instead
+error: module name 'Mathlib.lowerCase' is not in 'UpperCamelCase': it should be 'Mathlib.LowerCase' instead
+error: module name 'Mathlib.snake_case' is not in 'UpperCamelCase': it should be 'Mathlib.SnakeCase' instead
+-/
+#guard_msgs in
+#eval testModulesNotUpperCamelCase

--- a/MathlibTest/ModuleCasing.lean
+++ b/MathlibTest/ModuleCasing.lean
@@ -2,7 +2,6 @@ import Mathlib.Tactic.Linter.TextBased
 
 /-!
 Unit tests for the module name case check in the text-based linters.
-
 -/
 
 open Mathlib.Linter.TextBased

--- a/scripts/lint-style.lean
+++ b/scripts/lint-style.lean
@@ -124,7 +124,7 @@ def modulesNotUpperCamelCase (modules : Array Lean.Name) : IO Nat := do
   for bad in badNames do
     let upperCamelName := Lake.toUpperCamelCase bad
     let good := if bad.toString.endsWith "_" then s!"{upperCamelName}_" else upperCamelName.toString
-    IO.eprintln s!"error: module name {bad} is not in 'UpperCamelCase': it should be {good} instead"
+    IO.eprintln s!"error: module name '{bad}' is not in 'UpperCamelCase': it should be '{upperCamelName}' instead"
   return badNames.size
 
 /-- Some unit tests for `modulesNotUpperCamelCase` -/
@@ -140,6 +140,16 @@ def testModulesNotUpperCamelCase : IO Unit := do
   assert!((← modulesNotUpperCamelCase #[`Mathlib.lowerCase]) == 1)
   assert!((← modulesNotUpperCamelCase #[`Mathlib.snake_case]) == 1)
 
+/--
+info: error: module name 'Mathlib.NotFine_.Foo' is not in 'UpperCamelCase': it should be 'Mathlib.NotFine.Foo' instead
+error: module name 'bad_module' is not in 'UpperCamelCase': it should be 'BadModule' instead
+error: module name 'bad_module' is not in 'UpperCamelCase': it should be 'BadModule' instead
+error: module name 'bad_module' is not in 'UpperCamelCase': it should be 'BadModule' instead
+error: module name 'Mathlib.BadModule__' is not in 'UpperCamelCase': it should be 'Mathlib.BadModule_' instead
+error: module name 'Mathlib.lowerCase' is not in 'UpperCamelCase': it should be 'Mathlib.LowerCase' instead
+error: module name 'Mathlib.snake_case' is not in 'UpperCamelCase': it should be 'Mathlib.SnakeCase' instead
+-/
+#guard_msgs in
 #eval testModulesNotUpperCamelCase
 
 /-- Implementation of the `lint-style` command line program. -/

--- a/scripts/lint-style.lean
+++ b/scripts/lint-style.lean
@@ -122,8 +122,25 @@ def modulesNotUpperCamelCase (modules : Array Lean.Name) : IO Nat := do
     !exceptions.contains name &&
     (upperCamelName != name && s!"{upperCamelName}_" != name.toString)
   for bad in badNames do
-    IO.eprintln s!"error: module name {bad} is not in 'UpperCamelCase': it should be {Lake.toUpperCamelCase bad} instead"
+    let upperCamelName := Lake.toUpperCamelCase bad
+    let good := if bad.toString.endsWith "_" then s!"{upperCamelName}_" else upperCamelName.toString
+    IO.eprintln s!"error: module name {bad} is not in 'UpperCamelCase': it should be {good} instead"
   return badNames.size
+
+/-- Some unit tests for `modulesNotUpperCamelCase` -/
+def testModulesNotUpperCamelCase : IO Unit := do
+  assert!((← modulesNotUpperCamelCase #[]) == 0)
+  assert!((← modulesNotUpperCamelCase #[`Mathlib.Fine]) == 0)
+  assert!((← modulesNotUpperCamelCase #[`Mathlib.AlsoFine_]) == 0)
+  assert!((← modulesNotUpperCamelCase #[`Mathlib.NotFine_.Foo]) == 1)
+
+  assert!((← modulesNotUpperCamelCase #[`bad_module]) == 1)
+  assert!((← modulesNotUpperCamelCase #[`GoodName, `bad_module, `bad_module]) == 2)
+  assert!((← modulesNotUpperCamelCase #[`Mathlib.BadModule__]) == 1)
+  assert!((← modulesNotUpperCamelCase #[`Mathlib.lowerCase]) == 1)
+  assert!((← modulesNotUpperCamelCase #[`Mathlib.snake_case]) == 1)
+
+#eval testModulesNotUpperCamelCase
 
 /-- Implementation of the `lint-style` command line program. -/
 def lintStyleCli (args : Cli.Parsed) : IO UInt32 := do

--- a/scripts/lint-style.lean
+++ b/scripts/lint-style.lean
@@ -37,12 +37,10 @@ def explicitImports : Array Lean.Name := #[`Batteries, `Std]
 def eraseExplicitImports (names : Array Lean.Name) : Array Lean.Name :=
   explicitImports.foldl Array.erase names
 
-/-- Check that `Mathlib.Init` is transitively imported in all of Mathlib:
-if not, return the number of modules which did not import `Mathlib.Init`.
-
-Every file imported in `Mathlib.Init` should in turn import the `Header` linter
+/-- Check that `Mathlib.Init` is transitively imported in all of Mathlib.
+Moreover, every file imported in `Mathlib.Init` should in turn import the `Header` linter
 (except for the header linter itself, of course).
-Return `true` iff there was an error.
+Return the number of modules which violated one of these rules.
 -/
 def missingInitImports : IO Nat := do
   -- Find any file in the Mathlib directory which does not contain any Mathlib import.
@@ -87,7 +85,7 @@ def missingInitImports : IO Nat := do
 
 
 /-- Verifies that every file in the `scripts` directory is documented in `scripts/README.md`.
-Return the number of undocumented scripts (if any). -/
+Return the number of undocumented scripts. -/
 def undocumentedScripts : IO Nat := do
   -- Retrieve all scripts (except for the `bench` directory).
   let allScripts ← (walkDir "scripts" fun p ↦ pure (p.components.getD 1 "" != "bench"))
@@ -124,7 +122,7 @@ def modulesNotUpperCamelCase (modules : Array Lean.Name) : IO Nat := do
   for bad in badNames do
     let upperCamelName := Lake.toUpperCamelCase bad
     let good := if bad.toString.endsWith "_" then s!"{upperCamelName}_" else upperCamelName.toString
-    IO.eprintln s!"error: module name '{bad}' is not in 'UpperCamelCase': it should be '{upperCamelName}' instead"
+    IO.eprintln s!"error: module name '{bad}' is not in 'UpperCamelCase': it should be '{good}' instead"
   return badNames.size
 
 /-- Some unit tests for `modulesNotUpperCamelCase` -/

--- a/scripts/lint-style.lean
+++ b/scripts/lint-style.lean
@@ -105,7 +105,7 @@ def allScriptsDocumented : IO Bool := do
       {String.intercalate "," undocumented.toList}"
   return undocumented.size == 0
 
-/-- Verifies that all modules `modules` are named in `UpperCamelCase`
+/-- Verifies that all modules in `modules` are named in `UpperCamelCase`
 (except for explicitly discussed exceptions, which are hard-coded here). -/
 def checkModulesUpperCamelCase (modules : Array Lean.Name) : IO Bool := do
   -- Exceptions to this list should be discussed on zulip!
@@ -115,8 +115,10 @@ def checkModulesUpperCamelCase (modules : Array Lean.Name) : IO Bool := do
     `Mathlib.Analysis.Normed.Lp.lpSpace
   ]
   -- We allow only names in UpperCamelCase, possibly with a trailing underscore.
-  let badNames := modules.filter fun name ↦!exceptions.contains name &&
-    (Lake.toUpperCamelCase name != name && s!"{Lake.toUpperCamelCase name}_" != name.toString)
+  let badNames := modules.filter fun name ↦
+    let upperCamelName := Lake.toUpperCamelCase name
+    !exceptions.contains name &&
+    (upperCamelName != name && s!"{upperCamelName}_" != name.toString)
   for bad in badNames do
     IO.eprintln s!"error: module name {bad} is not in 'UpperCamelCase': it should be {Lake.toUpperCamelCase bad} instead"
   return badNames.size == 0


### PR DESCRIPTION
except for a handful of explicit exceptions

In passing, refactor the other two checks in `lint-style` to return the number of their errors (which is both meaningful and semantically clear), as opposed to a boolean (which can be accidentally inverted).

---

- [x] depends on: #23974 (right now, the linter complains about the two violations fixed in that PR)
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
