### PR TITLE
[Merged by Bors] - feat(CategoryTheory/Join): embedding of `Sum` in `Join`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2088,6 +2088,7 @@ import Mathlib.CategoryTheory.Iso
 import Mathlib.CategoryTheory.IsomorphismClasses
 import Mathlib.CategoryTheory.Join.Basic
 import Mathlib.CategoryTheory.Join.Final
+import Mathlib.CategoryTheory.Join.Sum
 import Mathlib.CategoryTheory.LiftingProperties.Adjunction
 import Mathlib.CategoryTheory.LiftingProperties.Basic
 import Mathlib.CategoryTheory.LiftingProperties.Limits

--- a/Mathlib/CategoryTheory/Join/Sum.lean
+++ b/Mathlib/CategoryTheory/Join/Sum.lean
@@ -24,19 +24,17 @@ It sends `inl c` to `left c` and `inr d` to `right d`. -/
 @[simps! obj] -- Maps get characterized w.r.t the inclusions below
 def fromSum : C ⊕ D ⥤ C ⋆ D := (inclLeft C D).sum' <| inclRight C D
 
-variable {C D}
-
+variable {C} in
 @[simp]
 lemma fromSum_map_inl {c c' : C} (f : c ⟶ c') :
     (fromSum C D).map ((Sum.inl_ C D).map f) = (inclLeft C D).map f :=
   rfl
 
+variable {D} in
 @[simp]
 lemma fromSum_map_inr {d d' : D} (f : d ⟶ d') :
     (fromSum C D).map ((Sum.inr_ C D).map f) = (inclRight C D).map f :=
   rfl
-
-variable (C D)
 
 /-- Characterization of `fromSum` with respect to the left inclusion. -/
 @[simps! hom_app inv_app]

--- a/Mathlib/CategoryTheory/Join/Sum.lean
+++ b/Mathlib/CategoryTheory/Join/Sum.lean
@@ -1,0 +1,61 @@
+/-
+Copyright (c) 2025 Robin Carlier. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robin Carlier
+-/
+import Mathlib.CategoryTheory.Join.Basic
+import Mathlib.CategoryTheory.Sums.Basic
+
+/-!
+# Embedding of `C ⊕ D` into `C ⋆ D`
+
+This file constructs a canonical functor `Join.fromSum` from `C ⊕ D` to `C ⋆ D` and give
+its characterization in terms of the canonical inclusions.
+We also provide `Faithful` and `EssSurj` instances on this functor.
+
+-/
+
+namespace CategoryTheory.Join
+
+variable (C D : Type*) [Category C] [Category D]
+
+/-- The canonical functor from the sum to the join.
+It sends `inl c` to `left c` and `inr d` to `right d`. -/
+@[simps! obj] -- Maps get characterized w.r.t the inclusions below
+def fromSum : C ⊕ D ⥤ C ⋆ D := (inclLeft C D).sum' <| inclRight C D
+
+variable {C D}
+
+@[simp]
+lemma fromSum_map_inl {c c' : C} (f : c ⟶ c') :
+    (fromSum C D).map ((Sum.inl_ C D).map f) = (inclLeft C D).map f :=
+  rfl
+
+@[simp]
+lemma fromSum_map_inr {d d' : D} (f : d ⟶ d') :
+    (fromSum C D).map ((Sum.inr_ C D).map f) = (inclRight C D).map f :=
+  rfl
+
+variable (C D)
+
+/-- Characterization of `fromSum` with respect to the left inclusion. -/
+@[simps! hom_app inv_app]
+def inlCompFromSum : Sum.inl_ C D ⋙ fromSum C D ≅ inclLeft C D := Functor.inlCompSum' _ _
+
+/-- Characterization of `fromSum` with respect to the right inclusion. -/
+@[simps! hom_app inv_app]
+def inrCompFromSum : Sum.inr_ C D ⋙ fromSum C D ≅ inclRight C D := Functor.inrCompSum' _ _
+
+instance : (fromSum C D).EssSurj where
+  mem_essImage
+    | left c => Functor.obj_mem_essImage _ (Sum.inl c)
+    | right d => Functor.obj_mem_essImage _ (Sum.inr d)
+
+instance : (fromSum C D).Faithful where
+  map_injective {x y} h h' heq := by
+    cases h <;> cases h'
+    all_goals
+      simp only [fromSum_obj, Sum.inl__obj, fromSum_map_inl, Sum.inr__obj, fromSum_map_inr] at heq
+      simp [Functor.map_injective _ heq]
+
+end CategoryTheory.Join


### PR DESCRIPTION
Construct a canonical functor `C ⊕ D ⥤ C ⋆ D`. Characterize it with respect to the left and right inclusions. Show that it is faithful and essentially surjective.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

Suggested by @b-mehta during review of #23412.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
