### PR TITLE
[Merged by Bors] - chore: deprecate ENormedSpace

### DIFF
--- a/Mathlib/Analysis/NormedSpace/ENormedSpace.lean
+++ b/Mathlib/Analysis/NormedSpace/ENormedSpace.lean
@@ -9,6 +9,12 @@ import Mathlib.LinearAlgebra.Basis.VectorSpace
 /-!
 # Extended norm
 
+**ATTENTION.** This file is deprecated. Mathlib now has classes `ENormed(Add)(Comm)Monoid` for
+(additive) (commutative) monoids with an `ENorm`: this is very similar to this definition, but
+much more general. Should the need arise, an enormed version of a normed space can be added later:
+this will be different from this file.
+
+
 In this file we define a structure `ENormedSpace 𝕜 V` representing an extended norm (i.e., a norm
 that can take the value `∞`) on a vector space `V` over a normed field `𝕜`. We do not use `class`
 for an `ENormedSpace` because the same space can have more than one extended norm.
@@ -38,12 +44,15 @@ open ENNReal
 
 /-- Extended norm on a vector space. As in the case of normed spaces, we require only
 `‖c • x‖ ≤ ‖c‖ * ‖x‖` in the definition, then prove an equality in `map_smul`. -/
+@[deprecated "Use ENormedAddCommMonoid or talk to the Carleson project" (since := "2025-05-07")]
 structure ENormedSpace (𝕜 : Type*) (V : Type*) [NormedField 𝕜] [AddCommGroup V] [Module 𝕜 V] where
   /-- the norm of an ENormedSpace, taking values into `ℝ≥0∞` -/
   toFun : V → ℝ≥0∞
   eq_zero' : ∀ x, toFun x = 0 → x = 0
   map_add_le' : ∀ x y : V, toFun (x + y) ≤ toFun x + toFun y
   map_smul_le' : ∀ (c : 𝕜) (x : V), toFun (c • x) ≤ ‖c‖₊ * toFun x
+
+set_option linter.deprecated false
 
 namespace ENormedSpace
 
@@ -55,21 +64,25 @@ attribute [coe] ENormedSpace.toFun
 instance : CoeFun (ENormedSpace 𝕜 V) fun _ => V → ℝ≥0∞ :=
   ⟨ENormedSpace.toFun⟩
 
+@[deprecated "Use ENormedAddCommMonoid or talk to the Carleson project" (since := "2025-05-07")]
 theorem coeFn_injective : Function.Injective ((↑) : ENormedSpace 𝕜 V → V → ℝ≥0∞) := by
   intro e₁ e₂ h
   cases e₁
   cases e₂
   congr
 
-@[ext]
+@[deprecated "Use ENormedAddCommMonoid or talk to the Carleson project" (since := "2025-05-07"),
+  ext]
 theorem ext {e₁ e₂ : ENormedSpace 𝕜 V} (h : ∀ x, e₁ x = e₂ x) : e₁ = e₂ :=
   coeFn_injective <| funext h
 
-@[simp, norm_cast]
+@[deprecated "Use ENormedAddCommMonoid or talk to the Carleson project" (since := "2025-05-07"),
+  simp, norm_cast]
 theorem coe_inj {e₁ e₂ : ENormedSpace 𝕜 V} : (e₁ : V → ℝ≥0∞) = e₂ ↔ e₁ = e₂ :=
   coeFn_injective.eq_iff
 
-@[simp]
+@[deprecated "Use ENormedAddCommMonoid or talk to the Carleson project" (since := "2025-05-07"),
+  simp]
 theorem map_smul (c : 𝕜) (x : V) : e (c • x) = ‖c‖₊ * e x := by
   apply le_antisymm (e.map_smul_le' c x)
   by_cases hc : c = 0
@@ -82,26 +95,32 @@ theorem map_smul (c : 𝕜) (x : V) : e (c • x) = ‖c‖₊ * e x := by
         one_mul]
         <;> simp [hc]
 
-@[simp]
+@[deprecated "Use ENormedAddCommMonoid or talk to the Carleson project" (since := "2025-05-07"),
+  simp]
 theorem map_zero : e 0 = 0 := by
   rw [← zero_smul 𝕜 (0 : V), e.map_smul]
   norm_num
 
-@[simp]
+@[deprecated "Use ENormedAddCommMonoid or talk to the Carleson project" (since := "2025-05-07"),
+  simp]
 theorem eq_zero_iff {x : V} : e x = 0 ↔ x = 0 :=
   ⟨e.eq_zero' x, fun h => h.symm ▸ e.map_zero⟩
 
-@[simp]
+@[deprecated "Use ENormedAddCommMonoid or talk to the Carleson project" (since := "2025-05-07"),
+  simp]
 theorem map_neg (x : V) : e (-x) = e x :=
   calc
     e (-x) = ‖(-1 : 𝕜)‖₊ * e x := by rw [← map_smul, neg_one_smul]
     _ = e x := by simp
 
+@[deprecated "Use ENormedAddCommMonoid or talk to the Carleson project" (since := "2025-05-07")]
 theorem map_sub_rev (x y : V) : e (x - y) = e (y - x) := by rw [← neg_sub, e.map_neg]
 
+@[deprecated "Use ENormedAddCommMonoid or talk to the Carleson project" (since := "2025-05-07")]
 theorem map_add_le (x y : V) : e (x + y) ≤ e x + e y :=
   e.map_add_le' x y
 
+@[deprecated "Use ENormedAddCommMonoid or talk to the Carleson project" (since := "2025-05-07")]
 theorem map_sub_le (x y : V) : e (x - y) ≤ e x + e y :=
   calc
     e (x - y) = e (x + -y) := by rw [sub_eq_add_neg]
@@ -132,6 +151,7 @@ noncomputable instance : Top (ENormedSpace 𝕜 V) :=
 noncomputable instance : Inhabited (ENormedSpace 𝕜 V) :=
   ⟨⊤⟩
 
+@[deprecated "Use ENormedAddCommMonoid or talk to the Carleson project" (since := "2025-05-07")]
 theorem top_map {x : V} (hx : x ≠ 0) : (⊤ : ENormedSpace 𝕜 V) x = ⊤ :=
   if_neg hx
 
@@ -154,15 +174,18 @@ noncomputable instance : SemilatticeSup (ENormedSpace 𝕜 V) :=
     le_sup_right := fun _ _ _ => le_max_right _ _
     sup_le := fun _ _ _ h₁ h₂ x => max_le (h₁ x) (h₂ x) }
 
-@[simp, norm_cast]
+@[deprecated "Use ENormedAddCommMonoid or talk to the Carleson project" (since := "2025-05-07"),
+  simp, norm_cast]
 theorem coe_max (e₁ e₂ : ENormedSpace 𝕜 V) : ⇑(e₁ ⊔ e₂) = fun x => max (e₁ x) (e₂ x) :=
   rfl
 
-@[norm_cast]
+@[deprecated "Use ENormedAddCommMonoid or talk to the Carleson project" (since := "2025-05-07"),
+  norm_cast]
 theorem max_map (e₁ e₂ : ENormedSpace 𝕜 V) (x : V) : (e₁ ⊔ e₂) x = max (e₁ x) (e₂ x) :=
   rfl
 
 /-- Structure of an `EMetricSpace` defined by an extended norm. -/
+@[deprecated "Use ENormedAddCommMonoid or talk to the Carleson project" (since := "2025-05-07")]
 abbrev emetricSpace : EMetricSpace V where
   edist x y := e (x - y)
   edist_self x := by simp
@@ -174,6 +197,7 @@ abbrev emetricSpace : EMetricSpace V where
       _ ≤ e (x - y) + e (y - z) := e.map_add_le (x - y) (y - z)
 
 /-- The subspace of vectors with finite ENormedSpace. -/
+@[deprecated "Use ENormedAddCommMonoid or talk to the Carleson project" (since := "2025-05-07")]
 def finiteSubspace : Subspace 𝕜 V where
   carrier := { x | e x < ⊤ }
   zero_mem' := by simp
@@ -191,9 +215,11 @@ instance metricSpace : MetricSpace e.finiteSubspace := by
   change e (x - y) ≠ ⊤
   exact ne_top_of_le_ne_top (ENNReal.add_lt_top.2 ⟨x.2, y.2⟩).ne (e.map_sub_le x y)
 
+@[deprecated "Use ENormedAddCommMonoid or talk to the Carleson project" (since := "2025-05-07")]
 theorem finite_dist_eq (x y : e.finiteSubspace) : dist x y = (e (x - y)).toReal :=
   rfl
 
+@[deprecated "Use ENormedAddCommMonoid or talk to the Carleson project" (since := "2025-05-07")]
 theorem finite_edist_eq (x y : e.finiteSubspace) : edist x y = e (x - y) :=
   rfl
 
@@ -203,6 +229,7 @@ instance normedAddCommGroup : NormedAddCommGroup e.finiteSubspace :=
     norm := fun x => (e x).toReal
     dist_eq := fun _ _ => rfl }
 
+@[deprecated "Use ENormedAddCommMonoid or talk to the Carleson project" (since := "2025-05-07")]
 theorem finite_norm_eq (x : e.finiteSubspace) : ‖x‖ = (e x).toReal :=
   rfl
 


### PR DESCRIPTION
This file is unused (and its original author has no future plans for it). Since its addition, the Carleson project has developed classes for types and monoids with a (possibly continuous) enorm; this design has proved worthwhile in Carleson and is gradually being adapted in mathlib. The Carleson project also has a better version of ENormedSpace, which can be added to mathlib if need be. In the meantime, deprecate this version as this is certainly not useful.


---

I am open to simply deleting it, but we can also wait for one mathlib release and delete it then.
Having this class around blocks upstreaming every result about enorms from the Carleson project, but there is enough other work for the next month.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
