### PR TITLE
[Merged by Bors] - chore(RingTheory/DividedPowers/Basic): replace DecidableEq hypothesis

### DIFF
--- a/Mathlib/RingTheory/DividedPowers/Basic.lean
+++ b/Mathlib/RingTheory/DividedPowers/Basic.lean
@@ -87,9 +87,10 @@ structure DividedPowers where
   dpow_comp : ∀ {m n x} (_ : n ≠ 0) (_ : x ∈ I),
     dpow m (dpow n x) = uniformBell m n * dpow (m * n) x
 
+open Classical in
 variable (A) in
 /-- The canonical `DividedPowers` structure on the zero ideal -/
-def dividedPowersBot [DecidableEq A] : DividedPowers (⊥ : Ideal A) where
+noncomputable def dividedPowersBot : DividedPowers (⊥ : Ideal A) where
   dpow n a := ite (a = 0 ∧ n = 0) 1 0
   dpow_null {n a} ha := by
     simp only [mem_bot] at ha
@@ -138,7 +139,7 @@ def dividedPowersBot [DecidableEq A] : DividedPowers (⊥ : Ideal A) where
     · simp [hm, uniformBell_zero_left, hn]
     · simp only [hm, and_false, ite_false, false_or, if_neg hn]
 
-instance [DecidableEq A] : Inhabited (DividedPowers (⊥ : Ideal A)) :=
+noncomputable instance [DecidableEq A] : Inhabited (DividedPowers (⊥ : Ideal A)) :=
   ⟨dividedPowersBot A⟩
 
 /-- The coercion from the divided powers structures to functions -/

--- a/Mathlib/RingTheory/DividedPowers/Basic.lean
+++ b/Mathlib/RingTheory/DividedPowers/Basic.lean
@@ -138,6 +138,11 @@ noncomputable def dividedPowersBot : DividedPowers (⊥ : Ideal A) where
     · simp [hm, uniformBell_zero_left, hn]
     · simp only [hm, and_false, ite_false, false_or, if_neg hn]
 
+lemma dividedPowersBot_dpow_eq [DecidableEq A] (n : ℕ) (a : A) :
+    (dividedPowersBot A).dpow n a =
+      if a = 0 ∧ n = 0 then 1 else 0 := by
+  ext; simp [dividedPowersBot]
+
 noncomputable instance : Inhabited (DividedPowers (⊥ : Ideal A)) :=
   ⟨dividedPowersBot A⟩
 

--- a/Mathlib/RingTheory/DividedPowers/Basic.lean
+++ b/Mathlib/RingTheory/DividedPowers/Basic.lean
@@ -141,7 +141,7 @@ noncomputable def dividedPowersBot : DividedPowers (⊥ : Ideal A) where
 lemma dividedPowersBot_dpow_eq [DecidableEq A] (n : ℕ) (a : A) :
     (dividedPowersBot A).dpow n a =
       if a = 0 ∧ n = 0 then 1 else 0 := by
-  ext; simp [dividedPowersBot]
+  simp [dividedPowersBot]
 
 noncomputable instance : Inhabited (DividedPowers (⊥ : Ideal A)) :=
   ⟨dividedPowersBot A⟩

--- a/Mathlib/RingTheory/DividedPowers/Basic.lean
+++ b/Mathlib/RingTheory/DividedPowers/Basic.lean
@@ -87,11 +87,10 @@ structure DividedPowers where
   dpow_comp : ∀ {m n x} (_ : n ≠ 0) (_ : x ∈ I),
     dpow m (dpow n x) = uniformBell m n * dpow (m * n) x
 
-open Classical in
 variable (A) in
 /-- The canonical `DividedPowers` structure on the zero ideal -/
 noncomputable def dividedPowersBot : DividedPowers (⊥ : Ideal A) where
-  dpow n a := ite (a = 0 ∧ n = 0) 1 0
+  dpow n a := open Classical in ite (a = 0 ∧ n = 0) 1 0
   dpow_null {n a} ha := by
     simp only [mem_bot] at ha
     rw [if_neg]

--- a/Mathlib/RingTheory/DividedPowers/Basic.lean
+++ b/Mathlib/RingTheory/DividedPowers/Basic.lean
@@ -139,7 +139,7 @@ noncomputable def dividedPowersBot : DividedPowers (⊥ : Ideal A) where
     · simp [hm, uniformBell_zero_left, hn]
     · simp only [hm, and_false, ite_false, false_or, if_neg hn]
 
-noncomputable instance [DecidableEq A] : Inhabited (DividedPowers (⊥ : Ideal A)) :=
+noncomputable instance : Inhabited (DividedPowers (⊥ : Ideal A)) :=
   ⟨dividedPowersBot A⟩
 
 /-- The coercion from the divided powers structures to functions -/


### PR DESCRIPTION
Co-authored-by: @AntoineChambert-Loir 

Zulip thread: [#PR reviews > #24660 Use Classical or Decidable in definition @ 💬](https://leanprover.zulipchat.com/#narrow/channel/144837-PR-reviews/topic/.2324660.20Use.20Classical.20or.20Decidable.20in.20definition/near/516705644)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
