### PR TITLE
[Merged by Bors] - feat(Tactic/Algebraize): Allow the `algebraize` tactic to use lemmas which don't (directly) mention RingHom

### DIFF
--- a/Mathlib/RingTheory/RingHom/StandardSmooth.lean
+++ b/Mathlib/RingTheory/RingHom/StandardSmooth.lean
@@ -68,6 +68,7 @@ lemma IsStandardSmoothOfRelativeDimension.equiv (e : R ≃+* S) :
   exact Algebra.IsStandardSmoothOfRelativeDimension.of_algebraMap_bijective e.bijective
 
 variable {T : Type*} [CommRing T]
+
 lemma IsStandardSmooth.comp {g : S →+* T} {f : R →+* S}
     (hg : IsStandardSmooth g) (hf : IsStandardSmooth f) :
     IsStandardSmooth (g.comp f) := by

--- a/Mathlib/RingTheory/RingHom/StandardSmooth.lean
+++ b/Mathlib/RingTheory/RingHom/StandardSmooth.lean
@@ -68,7 +68,6 @@ lemma IsStandardSmoothOfRelativeDimension.equiv (e : R ≃+* S) :
   exact Algebra.IsStandardSmoothOfRelativeDimension.of_algebraMap_bijective e.bijective
 
 variable {T : Type*} [CommRing T]
-set_option tactic.hygienic false
 lemma IsStandardSmooth.comp {g : S →+* T} {f : R →+* S}
     (hg : IsStandardSmooth g) (hf : IsStandardSmooth f) :
     IsStandardSmooth (g.comp f) := by

--- a/Mathlib/RingTheory/RingHom/StandardSmooth.lean
+++ b/Mathlib/RingTheory/RingHom/StandardSmooth.lean
@@ -68,7 +68,7 @@ lemma IsStandardSmoothOfRelativeDimension.equiv (e : R ≃+* S) :
   exact Algebra.IsStandardSmoothOfRelativeDimension.of_algebraMap_bijective e.bijective
 
 variable {T : Type*} [CommRing T]
-
+set_option tactic.hygienic false
 lemma IsStandardSmooth.comp {g : S →+* T} {f : R →+* S}
     (hg : IsStandardSmooth g) (hf : IsStandardSmooth f) :
     IsStandardSmooth (g.comp f) := by

--- a/Mathlib/Tactic/Algebraize.lean
+++ b/Mathlib/Tactic/Algebraize.lean
@@ -204,7 +204,7 @@ def addProperties (t : Array Expr) : TacticM Unit := withMainContext do
       else
         let pargs := pargs.set! (n - 1) decl.toExpr
         /- check that the lemma applies to the hypothesis -/
-        if ← isDefEq (← forallMetaBoundedTelescope cinfo.type n).fst.back! decl.type do
+        if ← isDefEq (← forallMetaBoundedTelescope cinfo.type n).fst.back! decl.type then
         let val ← mkAppOptM p pargs
         let tp ← inferType val -- This should be the type `Algebra.Property A B`
         /- find all arguments to `Algebra.Property A B` which are of the form

--- a/Mathlib/Tactic/Algebraize.lean
+++ b/Mathlib/Tactic/Algebraize.lean
@@ -204,7 +204,7 @@ def addProperties (t : Array Expr) : TacticM Unit := withMainContext do
       else
         let pargs := pargs.set! (n - 1) decl.toExpr
         /- check that the lemma applies to the hypothesis -/
-        if ← isDefEq (← forallMetaBoundedTelescope cinfo.type n).fst.back! decl.type then
+        if ← isDefEq (← inferType (← forallMetaBoundedTelescope cinfo.type n).fst.back!) decl.type then
         let val ← mkAppOptM p pargs
         let tp ← inferType val -- This should be the type `Algebra.Property A B`
         /- find all arguments to `Algebra.Property A B` which are of the form

--- a/Mathlib/Tactic/Algebraize.lean
+++ b/Mathlib/Tactic/Algebraize.lean
@@ -184,47 +184,37 @@ def addProperties (t : Array Expr) : TacticM Unit := withMainContext do
       /- If the attribute points to the corresponding `Algebra` property itself, we assume that it
       is definitionally the same as the `RingHom` property. Then, we just need to construct its type
       and the local declaration will already give a valid term. -/
-      if cinfo.isInductive then
-        pargs[0]!.mvarId!.assignIfDefEq (args[0]!)
-        pargs[1]!.mvarId!.assignIfDefEq (args[1]!)
-        -- This should be the type `Algebra.Property A B`
-        let tp ← instantiateMVars tp'
-        if ← isDefEqGuarded decl.type tp then
-        /- Find all arguments to `Algebra.Property A B` which are of the form
-          `RingHom.toAlgebra x` or `Algebra.toModule (ringHom.toAlgebra x)`. -/
-        let algebra_args ← tp.getAppArgs.mapM <| fun x => liftMetaM do
-          let y := (← whnfUntil x ``Algebra.toModule) >>= (·.getAppArgs.back?)
-          whnfUntil (y.getD x) ``RingHom.toAlgebra
-        let ringHom_args := algebra_args.filterMap <| (· >>= (·.getAppArgs.back?))
-        /- Check that we're not reproving a local hypothesis, and that all involved `RingHom`s are
-          indeed arguments to the tactic. -/
-        unless (← synthInstance? tp).isSome || !(← ringHom_args.allM (fun z => t.anyM
-          (withoutModifyingMCtx <| isDefEq z ·))) do
-        liftMetaTactic fun mvarid => do
-          let nm ← mkFreshBinderNameForTactic `algebraizeInst
-          let (_, mvar) ← mvarid.note nm decl.toExpr tp
-          return [mvar]
-      /- Otherwise, the attribute points to a lemma or a constructor for the `Algebra` property.
-      In this case, we assume that the `RingHom` property is the last argument of the lemma or
-      constructor (and that this is all we need to supply explicitly). -/
-      else
-        try pargs.back!.mvarId!.assignIfDefEq decl.toExpr catch _ => return
-        let val ← instantiateMVars tp'
-        let tp ← inferType val -- This should be the type `Algebra.Property A B`.
-        /- Find all arguments to `Algebra.Property A B` which are of the form
-          `RingHom.toAlgebra x` or `Algebra.toModule (ringHom.toAlgebra x)`. -/
-        let algebra_args ← tp.getAppArgs.mapM <| fun x => liftMetaM do
-          let y := (← whnfUntil x ``Algebra.toModule) >>= (·.getAppArgs.back?)
-          whnfUntil (y.getD x) ``RingHom.toAlgebra
-        let ringHom_args := algebra_args.filterMap <| (· >>= (·.getAppArgs.back?))
-        /- Check that we're not reproving a local hypothesis, and that all involved `RingHom`s are
-          indeed arguments to the tactic. -/
-        unless (← synthInstance? tp).isSome || !(← ringHom_args.allM (fun z => t.anyM
-          (withoutModifyingMCtx <| isDefEq z ·))) do
-        liftMetaTactic fun mvarid => do
-          let nm ← mkFreshBinderNameForTactic `algebraizeInst
-          let (_, mvar) ← mvarid.note nm val
-          return [mvar]
+      let getValType : MetaM (Option (Expr × Expr)) := do
+        if cinfo.isInductive then
+          pargs[0]!.mvarId!.assignIfDefEq args[0]!
+          pargs[1]!.mvarId!.assignIfDefEq args[1]!
+          -- This should be the type `Algebra.Property A B`
+          let tp ← instantiateMVars tp'
+          if ← isDefEqGuarded decl.type tp then return (decl.toExpr,tp)
+          else return .none
+        /- Otherwise, the attribute points to a lemma or a constructor for the `Algebra` property.
+        In this case, we assume that the `RingHom` property is the last argument of the lemma or
+        constructor (and that this is all we need to supply explicitly). -/
+        else do
+          try pargs.back!.mvarId!.assignIfDefEq decl.toExpr catch _ => return .none
+          let val ← instantiateMVars tp'
+          let tp ← inferType val -- This should be the type `Algebra.Property A B`.
+          return (val,tp)
+      let .some (val,tp) ← getValType | return
+      /- Find all arguments to `Algebra.Property A B` which are of the form
+        `RingHom.toAlgebra x` or `Algebra.toModule (ringHom.toAlgebra x)`. -/
+      let algebra_args ← tp.getAppArgs.mapM <| fun x => liftMetaM do
+        let y := (← whnfUntil x ``Algebra.toModule) >>= (·.getAppArgs.back?)
+        whnfUntil (y.getD x) ``RingHom.toAlgebra
+      let ringHom_args := algebra_args.filterMap <| (· >>= (·.getAppArgs.back?))
+      /- Check that we're not reproving a local hypothesis, and that all involved `RingHom`s are
+        indeed arguments to the tactic. -/
+      unless (← synthInstance? tp).isSome || !(← ringHom_args.allM (fun z => t.anyM
+        (withoutModifyingMCtx <| isDefEq z ·))) do
+      liftMetaTactic fun mvarid => do
+        let nm ← mkFreshBinderNameForTactic `algebraizeInst
+        let (_, mvar) ← mvarid.note nm val tp
+        return [mvar]
     | none => return
 
 /-- Configuration for `algebraize`. -/

--- a/Mathlib/Tactic/Algebraize.lean
+++ b/Mathlib/Tactic/Algebraize.lean
@@ -203,6 +203,8 @@ def addProperties (t : Array Expr) : TacticM Unit := withMainContext do
       constructor (and that this is all we need to supply explicitly). -/
       else
         let pargs := pargs.set! (n - 1) decl.toExpr
+        /- check that the lemma applies to the hypothesis -/
+        if ← isDefEq (← forallMetaBoundedTelescope cinfo.type n).fst.back! decl.type do
         let val ← mkAppOptM p pargs
         let tp ← inferType val -- This should be the type `Algebra.Property A B`
         /- find all arguments to `Algebra.Property A B` which are of the form

--- a/Mathlib/Tactic/Algebraize.lean
+++ b/Mathlib/Tactic/Algebraize.lean
@@ -190,7 +190,7 @@ def addProperties (t : Array Expr) : TacticM Unit := withMainContext do
           pargs[1]!.mvarId!.assignIfDefEq args[1]!
           -- This should be the type `Algebra.Property A B`
           let tp ← instantiateMVars tp'
-          if ← isDefEqGuarded decl.type tp then return (decl.toExpr,tp)
+          if ← isDefEqGuarded decl.type tp then return (decl.toExpr, tp)
           else return .none
         /- Otherwise, the attribute points to a lemma or a constructor for the `Algebra` property.
         In this case, we assume that the `RingHom` property is the last argument of the lemma or
@@ -199,7 +199,7 @@ def addProperties (t : Array Expr) : TacticM Unit := withMainContext do
           try pargs.back!.mvarId!.assignIfDefEq decl.toExpr catch _ => return .none
           let val ← instantiateMVars tp'
           let tp ← inferType val -- This should be the type `Algebra.Property A B`.
-          return (val,tp)
+          return (val, tp)
       let .some (val,tp) ← getValType | return
       /- Find all arguments to `Algebra.Property A B` which are of the form
         `RingHom.toAlgebra x` or `Algebra.toModule (ringHom.toAlgebra x)`. -/

--- a/Mathlib/Tactic/Algebraize.lean
+++ b/Mathlib/Tactic/Algebraize.lean
@@ -181,10 +181,10 @@ def addProperties (t : Array Expr) : TacticM Unit := withMainContext do
       let (pargs,_,_) ← forallMetaTelescope (← inferType p')
       let tp' ← mkAppOptM' p' (pargs.map Option.some)
 
-      /- If the attribute points to the corresponding `Algebra` property itself, we assume that it
-      is definitionally the same as the `RingHom` property. Then, we just need to construct its type
-      and the local declaration will already give a valid term. -/
       let getValType : MetaM (Option (Expr × Expr)) := do
+        /- If the attribute points to the corresponding `Algebra` property itself, we assume that it
+        is definitionally the same as the `RingHom` property. Then, we just need to construct its
+        type and the local declaration will already give a valid term. -/
         if cinfo.isInductive then
           pargs[0]!.mvarId!.assignIfDefEq args[0]!
           pargs[1]!.mvarId!.assignIfDefEq args[1]!
@@ -195,7 +195,7 @@ def addProperties (t : Array Expr) : TacticM Unit := withMainContext do
         /- Otherwise, the attribute points to a lemma or a constructor for the `Algebra` property.
         In this case, we assume that the `RingHom` property is the last argument of the lemma or
         constructor (and that this is all we need to supply explicitly). -/
-        else do
+        else
           try pargs.back!.mvarId!.assignIfDefEq decl.toExpr catch _ => return .none
           let val ← instantiateMVars tp'
           let tp ← inferType val -- This should be the type `Algebra.Property A B`.

--- a/Mathlib/Tactic/Algebraize.lean
+++ b/Mathlib/Tactic/Algebraize.lean
@@ -203,8 +203,14 @@ def addProperties (t : Array Expr) : TacticM Unit := withMainContext do
       constructor (and that this is all we need to supply explicitly). -/
       else
         let pargs := pargs.set! (n - 1) decl.toExpr
-        /- check that the lemma applies to the hypothesis -/
-        if ← isDefEq (← inferType (← forallMetaBoundedTelescope cinfo.type n).fst.back!) decl.type then
+        -- /- check that the lemma applies to the hypothesis -/
+        -- let check ← do
+        --   let (args,_binfo,_t) ← forallMetaBoundedTelescope cinfo.type n
+        --   let argTypes ← args.mapM (inferType ·)
+        --   logInfo s!"{p} has arguments with types {argTypes}\n hypothesis has {decl.type}"
+        --   isDefEq argTypes.back! decl.type
+        -- logInfo s!"check is {check}"
+        -- if check then
         let val ← mkAppOptM p pargs
         let tp ← inferType val -- This should be the type `Algebra.Property A B`
         /- find all arguments to `Algebra.Property A B` which are of the form

--- a/Mathlib/Tactic/Algebraize.lean
+++ b/Mathlib/Tactic/Algebraize.lean
@@ -202,7 +202,7 @@ def addProperties (t : Array Expr) : TacticM Unit := withMainContext do
           return (val, tp)
       let .some (val,tp) ← getValType | return
       /- Find all arguments to `Algebra.Property A B` which are of the form
-        `RingHom.toAlgebra x` or `Algebra.toModule (ringHom.toAlgebra x)`. -/
+        `RingHom.toAlgebra x` or `Algebra.toModule (RingHom.toAlgebra x)`. -/
       let algebra_args ← tp.getAppArgs.mapM <| fun x => liftMetaM do
         let y := (← whnfUntil x ``Algebra.toModule) >>= (·.getAppArgs.back?)
         whnfUntil (y.getD x) ``RingHom.toAlgebra

--- a/Mathlib/Tactic/Algebraize.lean
+++ b/Mathlib/Tactic/Algebraize.lean
@@ -179,7 +179,7 @@ def addProperties (t : Array Expr) : TacticM Unit := withMainContext do
       let cinfo ← try getConstInfo p catch _ => return
       let p' ← mkConstWithFreshMVarLevels p
       let (pargs,_,_) ← forallMetaTelescope (← inferType p')
-      let tp' ← mkAppOptM' p' (pargs.map Option.some)
+      let tp' := mkAppN p' pargs
 
       let getValType : MetaM (Option (Expr × Expr)) := do
         /- If the attribute points to the corresponding `Algebra` property itself, we assume that it

--- a/MathlibTest/algebraize.lean
+++ b/MathlibTest/algebraize.lean
@@ -150,4 +150,30 @@ example {A B : Type*} [CommRing A] [CommRing B] (b : Bar A B) (h : b.Fooo) : Tru
   guard_hyp algebraizeInst : @Algebra.Fooo A B _ _ b.f.toAlgebra
   trivial
 
+structure Buz (A B : Type*) [CommRing A] [CommRing B] where
+  x : (A →+* B) ⊕ (A →+* B)
+
+@[algebraize Buz.fooo]
+def Buz.Fooo {A B : Type*} [CommRing A] [CommRing B] (b : Buz A B) :=
+  b.x.elim (@Algebra.Fooo A B _ _ ·.toAlgebra) (fun _ => False)
+
+lemma Buz.fooo {A B : Type*} [CommRing A] [CommRing B] (f : A →+* B) :
+  Buz.Fooo ⟨.inl f⟩ → @Algebra.Fooo A B _ _ f.toAlgebra := id
+
+-- check that this also works when the argument *contains* a ringhom
+example {A B : Type*} [CommRing A] [CommRing B] (f : A →+* B)
+  (hf : Buz.Fooo ⟨.inl f⟩) : True := by
+  algebraize [f]
+  guard_hyp algebraizeInst : @Algebra.Fooo A B _ _ f.toAlgebra
+  trivial
+
+-- check that there is no issue with trying the lemma on a mismatching argument.
+example {A B : Type*} [CommRing A] [CommRing B] (f : A →+* B)
+  (hf : Buz.Fooo ⟨.inr f⟩) : True := by
+  algebraize [f]
+  fail_if_success
+    guard_hyp algebraizeInst : @Algebra.Fooo A B _ _ f.toAlgebra
+  trivial
+
+
 end

--- a/MathlibTest/algebraize.lean
+++ b/MathlibTest/algebraize.lean
@@ -131,3 +131,23 @@ example (A B C : Type*) [CommRing A] [CommRing B] [CommRing C] (f : A →+* B) (
   guard_hyp algebraizeInst : Algebra.testProperty1 A C
   guard_hyp scalarTowerInst := IsScalarTower.of_algebraMap_eq' rfl
   trivial
+
+section
+/- Test that the algebraize tactic also works on non-RingHom types -/
+class Algebra.Fooo (A B : Type*) [CommRing A] [CommRing B] [Algebra A B] : Prop where
+
+structure Bar (A B : Type*) [CommRing A] [CommRing B] where
+  f : A →+* B
+
+@[algebraize fooo]
+def Bar.Fooo {A B : Type*} [CommRing A] [CommRing B] (b : Bar A B) : Prop := True
+
+lemma fooo {A B : Type*} [CommRing A] [CommRing B] (b : Bar A B) (h : b.Fooo) :
+  @Algebra.Fooo A B _ _ b.f.toAlgebra := @Algebra.Fooo.mk A B _ _ b.f.toAlgebra
+
+example {A B : Type*} [CommRing A] [CommRing B] (b : Bar A B) (h : b.Fooo) : True := by
+  algebraize [b.f]
+  guard_hyp algebraizeInst : @Algebra.Fooo A B _ _ b.f.toAlgebra
+  trivial
+
+end

--- a/MathlibTest/algebraize.lean
+++ b/MathlibTest/algebraize.lean
@@ -6,57 +6,57 @@ section example_definitions
 
 /-- Test property for when `RingHom` and `Algebra` properties are definitionally the same,
 see e.g. `RingHom.FiniteType` for a concrete example of this. -/
-class Algebra.testProperty1 (A B : Type*) [CommRing A] [CommRing B] [Algebra A B] : Prop where
+class Algebra.TestProperty1 (A B : Type*) [CommRing A] [CommRing B] [Algebra A B] : Prop where
   out : ∀ x : A, algebraMap A B x = 0
 
 /-- Test property for when `RingHom` and `Algebra` properties are definitionally the same,
 see e.g. `RingHom.FiniteType` for a concrete example of this. -/
 @[algebraize]
-def RingHom.testProperty1 {A B : Type*} [CommRing A] [CommRing B] (f : A →+* B) : Prop :=
-  @Algebra.testProperty1 A B _ _ f.toAlgebra
+def RingHom.TestProperty1 {A B : Type*} [CommRing A] [CommRing B] (f : A →+* B) : Prop :=
+  @Algebra.TestProperty1 A B _ _ f.toAlgebra
 
 /-- Test property for when the `RingHom` property corresponds to a `Module` property (that is
 definitionally the same). See e.g. `Module.Finite` for a concrete example of this. -/
-class Module.testProperty2 (A M : Type*) [Semiring A] [AddCommMonoid M] [Module A M] : Prop where
+class Module.TestProperty2 (A M : Type*) [Semiring A] [AddCommMonoid M] [Module A M] : Prop where
   out : ∀ x : A, ∀ M : M, x • M = 0
 
 /-- Test property for when the `RingHom` property corresponds to a `Module` property (that is
 definitionally the same). See e.g. `Module.Finite` for a concrete example of this. -/
-@[algebraize Module.testProperty2]
-def RingHom.testProperty2 {A B : Type*} [CommRing A] [CommRing B] (f : A →+* B) : Prop :=
+@[algebraize Module.TestProperty2]
+def RingHom.TestProperty2 {A B : Type*} [CommRing A] [CommRing B] (f : A →+* B) : Prop :=
   letI : Algebra A B := f.toAlgebra
-  Module.testProperty2 A B
+  Module.TestProperty2 A B
 
 /-- Test property for when the `RingHom` property corresponds to a `Algebra` property that is not
 definitionally the same, and needs to be created through a lemma. See e.g. `Algebra.IsIntegral` for
 an example. -/
-class Algebra.testProperty3 (A B : Type*) [CommRing A] [CommRing B] [Algebra A B] : Prop where
-  out : Algebra.testProperty1 A B
+class Algebra.TestProperty3 (A B : Type*) [CommRing A] [CommRing B] [Algebra A B] : Prop where
+  out : Algebra.TestProperty1 A B
 
 /- Test property for when the `RingHom` property corresponds to a `Algebra` property that is not
 definitionally the same, and needs to be created through a lemma. See e.g. `Algebra.IsIntegral` for
 an example. -/
-@[algebraize Algebra.testProperty3.mk]
-def RingHom.testProperty3 {A B : Type*} [CommRing A] [CommRing B] (f : A →+* B) : Prop :=
-  f.testProperty1
+@[algebraize Algebra.TestProperty3.mk]
+def RingHom.TestProperty3 {A B : Type*} [CommRing A] [CommRing B] (f : A →+* B) : Prop :=
+  f.TestProperty1
 
 /- Test property for when the `RingHom` (and `Algebra`) property have an extra explicit argument,
 and hence needs to be created through a lemma. See e.g.
 `Algebra.IsStandardSmoothOfRelativeDimension` for an example. -/
-class Algebra.testProperty4 (n : ℕ) (A B : Type*) [CommRing A] [CommRing B] [Algebra A B] : Prop where
+class Algebra.TestProperty4 (n : ℕ) (A B : Type*) [CommRing A] [CommRing B] [Algebra A B] : Prop where
   out : ∀ m, n = m
 
 /- Test property for when the `RingHom` (and `Algebra`) property have an extra explicit argument,
 and hence needs to be created through a lemma. See e.g.
 `Algebra.IsStandardSmoothOfRelativeDimension` for an example. -/
-@[algebraize testProperty4.toAlgebra]
-def RingHom.testProperty4 (n : ℕ) {A B : Type*} [CommRing A] [CommRing B] (_ : A →+* B) : Prop :=
+@[algebraize RingHom.TestProperty4.toAlgebra]
+def RingHom.TestProperty4 (n : ℕ) {A B : Type*} [CommRing A] [CommRing B] (_ : A →+* B) : Prop :=
   ∀ m, n = m
 
-lemma testProperty4.toAlgebra (n : ℕ) {A B : Type*} [CommRing A] [CommRing B] (f : A →+* B)
-    (hf : f.testProperty4 n) :
+lemma RingHom.TestProperty4.toAlgebra (n : ℕ) {A B : Type*} [CommRing A] [CommRing B] (f : A →+* B)
+    (hf : f.TestProperty4 n) :
     letI : Algebra A B := f.toAlgebra
-    Algebra.testProperty4 n A B :=
+    Algebra.TestProperty4 n A B :=
       letI : Algebra A B := f.toAlgebra
       { out := hf }
 
@@ -99,49 +99,47 @@ example (A B C : Type*) [CommRing A] [CommRing B] [CommRing C] (f : A →+* B) (
   guard_hyp scalarTowerInst := IsScalarTower.of_algebraMap_eq' rfl
   trivial
 
-example (A B : Type*) [CommRing A] [CommRing B] (f g : A →+* B) (hf : f.testProperty1)
-    (hg : g.testProperty1) : True := by
+example (A B : Type*) [CommRing A] [CommRing B] (f g : A →+* B) (hf : f.TestProperty1)
+    (hg : g.TestProperty1) : True := by
   algebraize [f]
-  guard_hyp algebraizeInst : @Algebra.testProperty1 A B _ _ f.toAlgebra
+  guard_hyp algebraizeInst : @Algebra.TestProperty1 A B _ _ f.toAlgebra
   fail_if_success
     guard_hyp algebraizeInst_1
   trivial
 
-example (A B : Type*) [CommRing A] [CommRing B] (f g : A →+* B) (hf : f.testProperty2)
-  (hg : g.testProperty2) : True := by
+example (A B : Type*) [CommRing A] [CommRing B] (f g : A →+* B) (hf : f.TestProperty2)
+    (hg : g.TestProperty2) : True := by
   algebraize [f]
-  guard_hyp algebraizeInst : @Module.testProperty2 A B _ _ f.toAlgebra.toModule
+  guard_hyp algebraizeInst : @Module.TestProperty2 A B _ _ f.toAlgebra.toModule
   fail_if_success
     guard_hyp algebraizeInst_1
   trivial
 
--- #print RingHom.testProperty3
-
-example (A B : Type*) [CommRing A] [CommRing B] (f g : A →+* B) (hf : f.testProperty3)
-    (hg : g.testProperty3) : True := by
+example (A B : Type*) [CommRing A] [CommRing B] (f g : A →+* B) (hf : f.TestProperty3)
+    (hg : g.TestProperty3) : True := by
   algebraize [f]
-  guard_hyp algebraizeInst : @Algebra.testProperty3 A B _ _ f.toAlgebra
+  guard_hyp algebraizeInst : @Algebra.TestProperty3 A B _ _ f.toAlgebra
   fail_if_success
     guard_hyp algebraizeInst_1
   trivial
 
-example (n m: ℕ) (A B : Type*) [CommRing A] [CommRing B] (f g : A →+* B) (hf : f.testProperty4 n)
-    (hg : g.testProperty4 m): True := by
+example (n m : ℕ) (A B : Type*) [CommRing A] [CommRing B] (f g : A →+* B) (hf : f.TestProperty4 n)
+    (hg : g.TestProperty4 m) : True := by
   algebraize [f]
-  guard_hyp algebraizeInst : Algebra.testProperty4 n A B
+  guard_hyp algebraizeInst : Algebra.TestProperty4 n A B
   fail_if_success
     guard_hyp algebraizeInst_1
   trivial
 
 /-- Synthesize from morphism property of a composition (and check that tower is also synthesized). -/
 example (A B C : Type*) [CommRing A] [CommRing B] [CommRing C] (f : A →+* B) (g : B →+* C)
-    (hfg : (g.comp f).testProperty1) : True := by
+    (hfg : (g.comp f).TestProperty1) : True := by
   fail_if_success -- Check that this instance is not available by default
     have h : Algebra.Flat A C := inferInstance
   fail_if_success
     have h : IsScalarTower A B C := inferInstance
   algebraize [f, g, g.comp f]
-  guard_hyp algebraizeInst : Algebra.testProperty1 A C
+  guard_hyp algebraizeInst : Algebra.TestProperty1 A C
   guard_hyp scalarTowerInst := IsScalarTower.of_algebraMap_eq' rfl
   trivial
 
@@ -151,26 +149,26 @@ section
 structure Bar (A B : Type*) [CommRing A] [CommRing B] where
   f : A →+* B
 
-@[algebraize testProperty1_ofBar]
+@[algebraize testProperty1_of_bar]
 def Bar.testProperty1 {A B : Type*} [CommRing A] [CommRing B] (b : Bar A B) : Prop :=
   ∀ z, b.f z = 0
 
-lemma testProperty1_ofBar {A B : Type*} [CommRing A] [CommRing B] (b : Bar A B) (h : b.testProperty1) :
-  @Algebra.testProperty1 A B _ _ b.f.toAlgebra := @Algebra.testProperty1.mk A B _ _ b.f.toAlgebra h
+lemma testProperty1_of_bar {A B : Type*} [CommRing A] [CommRing B] (b : Bar A B) (h : b.testProperty1) :
+  @Algebra.TestProperty1 A B _ _ b.f.toAlgebra := @Algebra.TestProperty1.mk A B _ _ b.f.toAlgebra h
 
-@[algebraize testProperty2_ofBar]
+@[algebraize testProperty2_of_bar]
 def Bar.testProperty2 {A B : Type*} [CommRing A] [CommRing B] (b : Bar A B) : Prop :=
   letI : Algebra A B := b.f.toAlgebra;
   ∀ (r : A) (M : B), r • M = 0
 
-lemma testProperty2_ofBar {A B : Type*} [CommRing A] [CommRing B] (b : Bar A B) (h : b.testProperty2) :
-  @Module.testProperty2 A B _ _ b.f.toAlgebra.toModule :=
-    @Module.testProperty2.mk A B _ _ b.f.toAlgebra.toModule h
+lemma testProperty2_of_bar {A B : Type*} [CommRing A] [CommRing B] (b : Bar A B) (h : b.testProperty2) :
+  @Module.TestProperty2 A B _ _ b.f.toAlgebra.toModule :=
+    @Module.TestProperty2.mk A B _ _ b.f.toAlgebra.toModule h
 
-example {A B : Type*} [CommRing A] [CommRing B] (b c: Bar A B) (hb : b.testProperty1)
+example {A B : Type*} [CommRing A] [CommRing B] (b c : Bar A B) (hb : b.testProperty1)
     (hc : c.testProperty1) : True := by
   algebraize [b.f]
-  guard_hyp algebraizeInst : @Algebra.testProperty1 A B _ _ b.f.toAlgebra
+  guard_hyp algebraizeInst : @Algebra.TestProperty1 A B _ _ b.f.toAlgebra
   fail_if_success -- make sure that only arguments are used
     guard_hyp algebraizeInst_1 : @Algebra.testProperty1 A B _ _ c.f.toAlgebra
   trivial
@@ -178,7 +176,7 @@ example {A B : Type*} [CommRing A] [CommRing B] (b c: Bar A B) (hb : b.testPrope
 example {A B : Type*} [CommRing A] [CommRing B] (b c : Bar A B) (hb : b.testProperty2)
     (hc : c.testProperty2) : True := by
   algebraize [b.f]
-  guard_hyp algebraizeInst : @Module.testProperty2 A B _ _ b.f.toAlgebra.toModule
+  guard_hyp algebraizeInst : @Module.TestProperty2 A B _ _ b.f.toAlgebra.toModule
   fail_if_success
     guard_hyp algebraizeInst_1 --: @Module.testProperty2 A B _ _ c.f.toAlgebra.toModule
   trivial
@@ -186,18 +184,18 @@ example {A B : Type*} [CommRing A] [CommRing B] (b c : Bar A B) (hb : b.testProp
 structure Buz (A B : Type*) [CommRing A] [CommRing B] where
   x : (A →+* B) ⊕ (A →+* B)
 
-@[algebraize testProperty1_ofBuz_inl]
+@[algebraize testProperty1_of_buz_inl]
 def Buz.testProperty1 {A B : Type*} [CommRing A] [CommRing B] (b : Buz A B) :=
-  b.x.elim (@Algebra.testProperty1 A B _ _ ·.toAlgebra) (fun _ => False)
+  b.x.elim (@Algebra.TestProperty1 A B _ _ ·.toAlgebra) (fun _ => False)
 
-lemma testProperty1_ofBuz_inl {A B : Type*} [CommRing A] [CommRing B] (f : A →+* B) :
-  Buz.testProperty1 ⟨.inl f⟩ → @Algebra.testProperty1 A B _ _ f.toAlgebra := id
+lemma testProperty1_of_buz_inl {A B : Type*} [CommRing A] [CommRing B] (f : A →+* B) :
+  Buz.testProperty1 ⟨.inl f⟩ → @Algebra.TestProperty1 A B _ _ f.toAlgebra := id
 
 -- check that this also works when the argument *contains* a ringhom
-example {A B : Type*} [CommRing A] [CommRing B] (f g: A →+* B)
-    (hf : Buz.testProperty1 ⟨.inl f⟩) (hg : Buz.testProperty1 ⟨.inl g⟩): True := by
+example {A B : Type*} [CommRing A] [CommRing B] (f g : A →+* B)
+    (hf : Buz.testProperty1 ⟨.inl f⟩) (hg : Buz.testProperty1 ⟨.inl g⟩) : True := by
   algebraize [f]
-  guard_hyp algebraizeInst : @Algebra.testProperty1 A B _ _ f.toAlgebra
+  guard_hyp algebraizeInst : @Algebra.TestProperty1 A B _ _ f.toAlgebra
   fail_if_success
     guard_hyp algebraizeInst_1 --: @Algebra.testProperty1 A B _ _ g.toAlgebra
   trivial

--- a/MathlibTest/algebraize.lean
+++ b/MathlibTest/algebraize.lean
@@ -150,10 +150,10 @@ structure Bar (A B : Type*) [CommRing A] [CommRing B] where
   f : A →+* B
 
 @[algebraize testProperty1_of_bar]
-def Bar.testProperty1 {A B : Type*} [CommRing A] [CommRing B] (b : Bar A B) : Prop :=
+def Bar.TestProperty1 {A B : Type*} [CommRing A] [CommRing B] (b : Bar A B) : Prop :=
   ∀ z, b.f z = 0
 
-lemma testProperty1_of_bar {A B : Type*} [CommRing A] [CommRing B] (b : Bar A B) (h : b.testProperty1) :
+lemma testProperty1_of_bar {A B : Type*} [CommRing A] [CommRing B] (b : Bar A B) (h : b.TestProperty1) :
   @Algebra.TestProperty1 A B _ _ b.f.toAlgebra := @Algebra.TestProperty1.mk A B _ _ b.f.toAlgebra h
 
 @[algebraize testProperty2_of_bar]
@@ -165,8 +165,8 @@ lemma testProperty2_of_bar {A B : Type*} [CommRing A] [CommRing B] (b : Bar A B)
   @Module.TestProperty2 A B _ _ b.f.toAlgebra.toModule :=
     @Module.TestProperty2.mk A B _ _ b.f.toAlgebra.toModule h
 
-example {A B : Type*} [CommRing A] [CommRing B] (b c : Bar A B) (hb : b.testProperty1)
-    (hc : c.testProperty1) : True := by
+example {A B : Type*} [CommRing A] [CommRing B] (b c : Bar A B) (hb : b.TestProperty1)
+    (hc : c.TestProperty1) : True := by
   algebraize [b.f]
   guard_hyp algebraizeInst : @Algebra.TestProperty1 A B _ _ b.f.toAlgebra
   fail_if_success -- make sure that only arguments are used
@@ -185,15 +185,15 @@ structure Buz (A B : Type*) [CommRing A] [CommRing B] where
   x : (A →+* B) ⊕ (A →+* B)
 
 @[algebraize testProperty1_of_buz_inl]
-def Buz.testProperty1 {A B : Type*} [CommRing A] [CommRing B] (b : Buz A B) :=
+def Buz.TestProperty1 {A B : Type*} [CommRing A] [CommRing B] (b : Buz A B) :=
   b.x.elim (@Algebra.TestProperty1 A B _ _ ·.toAlgebra) (fun _ => False)
 
 lemma testProperty1_of_buz_inl {A B : Type*} [CommRing A] [CommRing B] (f : A →+* B) :
-  Buz.testProperty1 ⟨.inl f⟩ → @Algebra.TestProperty1 A B _ _ f.toAlgebra := id
+  Buz.TestProperty1 ⟨.inl f⟩ → @Algebra.TestProperty1 A B _ _ f.toAlgebra := id
 
 -- check that this also works when the argument *contains* a ringhom
 example {A B : Type*} [CommRing A] [CommRing B] (f g : A →+* B)
-    (hf : Buz.testProperty1 ⟨.inl f⟩) (hg : Buz.testProperty1 ⟨.inl g⟩) : True := by
+    (hf : Buz.TestProperty1 ⟨.inl f⟩) (hg : Buz.TestProperty1 ⟨.inl g⟩) : True := by
   algebraize [f]
   guard_hyp algebraizeInst : @Algebra.TestProperty1 A B _ _ f.toAlgebra
   fail_if_success
@@ -202,7 +202,7 @@ example {A B : Type*} [CommRing A] [CommRing B] (f g : A →+* B)
 
 -- check that there is no issue with trying the lemma on a mismatching argument.
 example {A B : Type*} [CommRing A] [CommRing B] (f : A →+* B)
-    (hf : Buz.testProperty1 ⟨.inr f⟩) : True := by
+    (hf : Buz.TestProperty1 ⟨.inr f⟩) : True := by
   algebraize [f] -- this could error if it tried applying `testProperty1_ofBuz_inl` to `hf`
   fail_if_success
     guard_hyp algebraizeInst

--- a/MathlibTest/algebraize.lean
+++ b/MathlibTest/algebraize.lean
@@ -202,7 +202,7 @@ example {A B : Type*} [CommRing A] [CommRing B] (f g : A →+* B)
 
 -- check that there is no issue with trying the lemma on a mismatching argument.
 example {A B : Type*} [CommRing A] [CommRing B] (f : A →+* B)
-  (hf : Buz.testProperty1 ⟨.inr f⟩) : True := by
+    (hf : Buz.testProperty1 ⟨.inr f⟩) : True := by
   algebraize [f] -- this could error if it tried applying `testProperty1_ofBuz_inl` to `hf`
   fail_if_success
     guard_hyp algebraizeInst


### PR DESCRIPTION
This PR allows the `algebraize` tactic to be applied in more cases. Specifically, in cases where the assumption is not (directly) about RingHom, it should still be able to apply lemmas.

Written at the suggestion of @chrisflav , with the following example usecase:
```lean-4
import Mathlib

open AlgebraicGeometry

attribute [algebraize flat_of_flat] Flat -- pretend this is added where `AlgebraicGeometry.Flat` is defined

lemma flat_of_flat {R S : Type u} [CommRing R] [CommRing S] (f : R →+* S) (h : Flat (Spec.map (CommRingCat.ofHom f))) : @Module.Flat R S _ _ f.toAlgebra.toModule := by
  have : f.Flat := sorry -- supposedly, this is true. ask christian.
  algebraize [f]
  assumption

set_option tactic.hygienic false -- allow the tactic to produce accessible names for testing

example {R S : Type u} [CommRing R] [CommRing S] (f : R →+* S) (h : Flat (Spec.map (CommRingCat.ofHom f))) : True := by
  algebraize [f]
  guard_hyp algebraizeInst : Module.Flat R S -- used to fail, succeeds now
  trivial
```

the key changes that makes this possible are the following:
- a different way of making lemma/type applications, creating a term which can be added to the context
- a different way of checking that the previously mentioned term actually relevant w/r/t the arguments provided to the tactic 

The previous check was ad-hoc and flimsy, making requirements of the precise order and the types of the arguments of lemmas or definitions, which resulted in the lemma being applicable in limited cases only.
Now we still have some requirements, but these are less stringent.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
