### PR TITLE
feat(CategoryTheory/Adjunction): lemmas on adjoint quadruples

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1854,6 +1854,7 @@ import Mathlib.CategoryTheory.Adjunction.Limits
 import Mathlib.CategoryTheory.Adjunction.Mates
 import Mathlib.CategoryTheory.Adjunction.Opposites
 import Mathlib.CategoryTheory.Adjunction.PartialAdjoint
+import Mathlib.CategoryTheory.Adjunction.Quadruple
 import Mathlib.CategoryTheory.Adjunction.Reflective
 import Mathlib.CategoryTheory.Adjunction.Restrict
 import Mathlib.CategoryTheory.Adjunction.Triple

--- a/Mathlib/CategoryTheory/Adjunction/Quadruple.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Quadruple.lean
@@ -1,4 +1,20 @@
+/-
+Copyright (c) 2025 Ben Eltschig. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Ben Eltschig
+-/
 import Mathlib.CategoryTheory.Adjunction.Triple
+
+/-!
+# Adjoint quadruples
+
+This file concerns adjoint quadruples `L ⊣ F ⊣ G ⊣ R` of functors `L G : C ⥤ D`, `F R : D ⥤ C`.
+Currently the only two results are the following:
+* When `F` and `R` are fully faithful, the components of the induced natural transformation `G ⟶ L`
+  are epic iff the components of the natural transformation `F ⟶ R` are monic.
+* When `L` and `G` are fully faithful, the components of the induced natural transformation `L ⟶ G`
+  are epic iff the components of the natural transformation `R ⟶ F` are monic.
+-/
 
 open CategoryTheory Limits
 

--- a/Mathlib/CategoryTheory/Adjunction/Quadruple.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Quadruple.lean
@@ -1,0 +1,97 @@
+import Mathlib.CategoryTheory.Adjunction.Triple
+
+open CategoryTheory Limits
+
+-- TODO: move these somewhere else
+section Misc
+
+/-- `f : X ⟶ Y` is an epimorphism iff for all `Z`, composition of morphisms `Y ⟶ Z` with `f`
+is injective. -/
+lemma CategoryTheory.epi_iff_forall_injective {C : Type*} [Category C] {X Y : C} {f : X ⟶ Y} :
+    Epi f ↔ ∀ Z, (fun g : Y ⟶ Z ↦ f ≫ g).Injective :=
+  ⟨fun _ _ _ _ hg ↦ (cancel_epi f).1 hg, fun h ↦ ⟨fun _ _ hg ↦ h _ hg⟩⟩
+
+/-- `f : X ⟶ Y` is a monomorphism iff for all `Z`, composition of morphisms `Z ⟶ X` with `f`
+is injective. -/
+lemma CategoryTheory.mono_iff_forall_injective {C : Type*} [Category C] {X Y : C} {f : X ⟶ Y} :
+    Mono f ↔ ∀ Z, (fun g : Z ⟶ X ↦ g ≫ f).Injective :=
+  ⟨fun _ _ _ _ hg ↦ (cancel_mono f).1 hg, fun h ↦ ⟨fun _ _ hg ↦ h _ hg⟩⟩
+
+@[simp]
+lemma CategoryTheory.op_mono_iff {C : Type*} [Category C] {X Y : C} {f : X ⟶ Y} :
+    Mono f.op ↔ Epi f :=
+  ⟨fun _ ↦ unop_epi_of_mono f.op, fun _ ↦ inferInstance⟩
+
+@[simp]
+lemma CategoryTheory.op_epi_iff {C : Type*} [Category C] {X Y : C} {f : X ⟶ Y} :
+    Epi f.op ↔ Mono f :=
+  ⟨fun _ ↦ unop_mono_of_epi f.op, fun _ ↦ inferInstance⟩
+
+end Misc
+
+namespace CategoryTheory.Adjunction
+
+variable {C D : Type*} [Category C] [Category D]
+variable {L G : C ⥤ D} {F R : D ⥤ C}
+variable (adj₁ : L ⊣ F) (adj₂ : F ⊣ G) (adj₃ : G ⊣ R)
+
+section FRFullyFaithful
+
+variable [F.Full] [F.Faithful]
+
+/-- For an adjoint quadruple `L ⊣ F ⊣ G ⊣ R` where `F` and `R` are fully faithful, all components
+of the natural transformation `G ⟶ L` are epic iff all components of the natural transformation
+`F ⟶ R` are monic. -/
+lemma GToL_app_epi_iff_FToR_app_mono :
+    (∀ X, Epi ((HToF adj₁ adj₂).app X)) ↔ ∀ X, Mono ((FToH adj₂ adj₃).app X) := by
+  simp_rw [FToH_app_mono_iff_unit_app_mono, HToF_eq_counits]
+  dsimp; simp only [NatIso.isIso_inv_app, Functor.comp_obj, Functor.id_obj,
+    whiskerLeft_app, Category.comp_id, Category.id_comp]
+  simp_rw [epi_isIso_comp_iff, epi_iff_forall_injective, mono_iff_forall_injective]
+  rw [forall_comm]; refine forall_congr' fun X ↦ forall_congr' fun Y ↦ ?_
+  rw [← (adj₁.homEquiv _ _).comp_injective _]
+  change (fun g ↦ adj₁.homEquiv _ _ _).Injective ↔ _
+  simp_rw [adj₁.homEquiv_naturality_left]
+  refine ((adj₁.homEquiv _ _).injective_comp fun f ↦ _).trans ?_
+  rw [← ((adj₂.homEquiv _ _).trans (adj₃.homEquiv _ _)).comp_injective _]
+  change (fun g ↦ adj₃.homEquiv _ _ (adj₂.homEquiv _ _ _)).Injective ↔ _
+  simp_rw [← adj₂.homEquiv_symm_id, ← adj₂.homEquiv_naturality_right_symm]
+  simp_rw [← adj₃.homEquiv_id, ← adj₃.homEquiv_naturality_left]
+  simp
+
+/-- For an adjoint quadruple `L ⊣ F ⊣ G ⊣ R` where `F` and `R` are fully faithful, their domain
+has all pushouts and their codomain has all pullbacks, the natural transformation `G ⟶ L` is epic
+iff the natural transformation `F ⟶ R` is monic. -/
+lemma GToL_epi_iff_FToR_mono [HasPullbacks C] [HasPushouts D] :
+    Epi (HToF adj₁ adj₂) ↔ Mono (FToH adj₂ adj₃) := by
+  rw [NatTrans.epi_iff_epi_app, NatTrans.mono_iff_mono_app]
+  exact adj₁.GToL_app_epi_iff_FToR_app_mono adj₂ adj₃
+
+end FRFullyFaithful
+
+section LGFullyFaithful
+
+variable [L.Full] [L.Faithful] [G.Full] [G.Faithful]
+
+/-- For an adjoint quadruple `L ⊣ F ⊣ G ⊣ R` where `L` and `G` are fully faithful, all components
+of the natural transformation `L ⟶ G` are epic iff all components of the natural transformation
+`R ⟶ F` are monic. -/
+lemma LToG_app_epi_iff_RToF_app_mono :
+    (∀ X, Epi ((FToH adj₁ adj₂).app X)) ↔ ∀ X, Mono ((HToF adj₂ adj₃).app X) := by
+  have h := GToL_app_epi_iff_FToR_app_mono adj₃.op adj₂.op adj₁.op
+  rw [← (Opposite.equivToOpposite (α := C)).forall_congr_right] at h
+  rw [← (Opposite.equivToOpposite (α := D)).forall_congr_right] at h
+  simp_rw [Opposite.equivToOpposite_coe, ← HToF_app_op, ← FToH_app_op, op_mono_iff, op_epi_iff] at h
+  exact h.symm
+
+/-- For an adjoint quadruple `L ⊣ F ⊣ G ⊣ R` where `L` and `G` are fully faithful, their domain
+has all pushouts and their codomain has all pullbacks, the natural transformation `L ⟶ G` is epic
+iff the natural transformation `R ⟶ F` is monic. -/
+lemma LToG_epi_iff_RToF_mono [HasPullbacks C] [HasPushouts D] :
+    Epi (FToH adj₁ adj₂) ↔ Mono (HToF adj₂ adj₃) := by
+  rw [NatTrans.epi_iff_epi_app, NatTrans.mono_iff_mono_app]
+  exact adj₁.LToG_app_epi_iff_RToF_app_mono adj₂ adj₃
+
+end LGFullyFaithful
+
+end CategoryTheory.Adjunction

--- a/Mathlib/CategoryTheory/Adjunction/Quadruple.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Quadruple.lean
@@ -18,33 +18,6 @@ Currently the only two results are the following:
 
 open CategoryTheory Limits
 
--- TODO: move these somewhere else
-section Misc
-
-/-- `f : X ⟶ Y` is an epimorphism iff for all `Z`, composition of morphisms `Y ⟶ Z` with `f`
-is injective. -/
-lemma CategoryTheory.epi_iff_forall_injective {C : Type*} [Category C] {X Y : C} {f : X ⟶ Y} :
-    Epi f ↔ ∀ Z, (fun g : Y ⟶ Z ↦ f ≫ g).Injective :=
-  ⟨fun _ _ _ _ hg ↦ (cancel_epi f).1 hg, fun h ↦ ⟨fun _ _ hg ↦ h _ hg⟩⟩
-
-/-- `f : X ⟶ Y` is a monomorphism iff for all `Z`, composition of morphisms `Z ⟶ X` with `f`
-is injective. -/
-lemma CategoryTheory.mono_iff_forall_injective {C : Type*} [Category C] {X Y : C} {f : X ⟶ Y} :
-    Mono f ↔ ∀ Z, (fun g : Z ⟶ X ↦ g ≫ f).Injective :=
-  ⟨fun _ _ _ _ hg ↦ (cancel_mono f).1 hg, fun h ↦ ⟨fun _ _ hg ↦ h _ hg⟩⟩
-
-@[simp]
-lemma CategoryTheory.op_mono_iff {C : Type*} [Category C] {X Y : C} {f : X ⟶ Y} :
-    Mono f.op ↔ Epi f :=
-  ⟨fun _ ↦ unop_epi_of_mono f.op, fun _ ↦ inferInstance⟩
-
-@[simp]
-lemma CategoryTheory.op_epi_iff {C : Type*} [Category C] {X Y : C} {f : X ⟶ Y} :
-    Epi f.op ↔ Mono f :=
-  ⟨fun _ ↦ unop_mono_of_epi f.op, fun _ ↦ inferInstance⟩
-
-end Misc
-
 namespace CategoryTheory.Adjunction
 
 variable {C D : Type*} [Category C] [Category D]

--- a/Mathlib/CategoryTheory/Adjunction/Triple.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Triple.lean
@@ -3,6 +3,7 @@ Copyright (c) 2024 Dagur Asgeirsson. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Dagur Asgeirsson, Ben Eltschig
 -/
+import Mathlib.CategoryTheory.Adjunction.Opposites
 import Mathlib.CategoryTheory.Adjunction.Unique
 import Mathlib.CategoryTheory.Limits.FunctorCategory.EpiMono
 import Mathlib.CategoryTheory.Monad.Adjunction
@@ -167,6 +168,18 @@ lemma counit_unit_eq_whiskerRight : adj₂.counit ≫ adj₁.unit = whiskerRight
   ext X; exact counit_unit_app_eq_map_HToF adj₁ adj₂
 
 /-- For an adjoint triple `F ⊣ G ⊣ H` where `G` is fully faithful, the natural transformation
+`H ⟶ F` is dual to the natural transformation `F.op ⟶ H.op` obtained from the dual adjoint
+triple `H.op ⊣ G.op ⊣ F.op`. -/
+lemma HToF_op : NatTrans.op (HToF adj₁ adj₂) = HToF adj₂.op adj₁.op := by
+  ext; rw [HToF, HToF_eq_counits]; simp
+
+/-- For an adjoint triple `F ⊣ G ⊣ H` where `G` is fully faithful, the components of the
+natural transformation `H ⟶ F` are dual to the components of the natural transformation
+`F.op ⟶ H.op` obtained from the dual adjoint triple `H.op ⊣ G.op ⊣ F.op`. -/
+lemma HToF_app_op {X : C} : ((HToF adj₁ adj₂).app X).op = (HToF adj₂.op adj₁.op).app (.op X) :=
+  NatTrans.congr_app (HToF_op adj₁ adj₂) _
+
+/-- For an adjoint triple `F ⊣ G ⊣ H` where `G` is fully faithful, the natural transformation
 `H ⟶ F` is epic at `X` iff the image of the unit of the adjunction `F ⊣ G` under `H` is. -/
 lemma HToF_app_epi_iff_map_unit_app_epi {X : C} :
     Epi ((HToF adj₁ adj₂).app X) ↔ Epi (H.map (adj₁.unit.app X)) := by
@@ -262,6 +275,18 @@ transformation `G ⋙ F ⟶ G ⋙ H` obtained from the units and counits of the 
 the natural transformation `F ⟶ H` whiskered from the left with `G`. -/
 lemma counit_unit_eq_whiskerLeft : adj₁.counit ≫ adj₂.unit = whiskerLeft G (FToH adj₁ adj₂) := by
   ext X; exact counit_unit_app_eq_FToH_app adj₁ adj₂
+
+/-- For an adjoint triple `F ⊣ G ⊣ H` where `F` and `H` are fully faithful, the natural
+transformation `F ⟶ H` is dual to the natural transformation `H.op ⟶ F.op` obtained from the
+dual adjoint triple `H.op ⊣ G.op ⊣ F.op`. -/
+lemma FToH_op : NatTrans.op (FToH adj₁ adj₂) = FToH adj₂.op adj₁.op := by
+  ext; rw [FToH, FToH_eq_counits]; simp
+
+/-- For an adjoint triple `F ⊣ G ⊣ H` where `F` and `H` are fully faithful, the components of the
+natural transformation `F ⟶ H` are dual to the components of the natural transformation
+`H.op ⟶ F.op` obtained from the dual adjoint triple `H.op ⊣ G.op ⊣ F.op`. -/
+lemma FToH_app_op {X : C} : ((FToH adj₁ adj₂).app X).op = (FToH adj₂.op adj₁.op).app (.op X) :=
+  NatTrans.congr_app (FToH_op adj₁ adj₂) _
 
 omit [H.Full] [H.Faithful] in
 /-- For an adjoint triple `F ⊣ G ⊣ H` where `F` and `H` are fully faithful, the natural

--- a/Mathlib/CategoryTheory/Adjunction/Triple.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Triple.lean
@@ -15,6 +15,8 @@ This file concerns adjoint triples `F ⊣ G ⊣ H` of functors `F H : C ⥤ D`, 
 Currently, the only result is that `F` is fully faithful if and only if `H` is fully faithful.
 -/
 
+open CategoryTheory Limits
+
 namespace CategoryTheory.Adjunction
 
 variable {C D : Type*} [Category C] [Category D]
@@ -52,79 +54,6 @@ noncomputable def fullyFaithfulEquiv : F.FullyFaithful ≃ H.FullyFaithful where
     adj₁.fullyFaithfulLOfIsIsoUnit
   left_inv _ := Subsingleton.elim _ _
   right_inv _ := Subsingleton.elim _ _
-
-end CategoryTheory.Adjunction
-
-open CategoryTheory Limits
-
--- TODO: move these somewhere else
-section Misc
-
-/-- When `f` is an isomorphism, `f ≫ g` is epic iff `g` is.
-TODO: should this and the following lemmas be simp lemmas? might cause slowdowns because it triggers
-instance searches for `IsIso` whenever `simp` is used on a goal containing `Mono (f ≫ g)`. -/
-lemma CategoryTheory.epi_isIso_comp_iff {C : Type*} [Category C] {X Y Z : C} (f : X ⟶ Y) [IsIso f]
-    (g : Y ⟶ Z) : Epi (f ≫ g) ↔ Epi g := by
-  refine ⟨fun h ↦ ?_, fun h ↦ inferInstance⟩
-  simpa using (inferInstance : Epi (inv f ≫ f ≫ g))
-
-/-- When `g` is an isomorphism, `f ≫ g` is epic iff `f` is. -/
-lemma CategoryTheory.epi_comp_isIso_iff {C : Type*} [Category C] {X Y Z : C} (f : X ⟶ Y) (g : Y ⟶ Z)
-    [IsIso g] : Epi (f ≫ g) ↔ Epi f := by
-  refine ⟨fun h ↦ ?_, fun h ↦ inferInstance⟩
-  simpa using (inferInstance : Epi ((f ≫ g) ≫ inv g ))
-
-/-- When `f` is an isomorphism, `f ≫ g` is monic iff `g` is. -/
-lemma CategoryTheory.mono_isIso_comp_iff {C : Type*} [Category C] {X Y Z : C} (f : X ⟶ Y) [IsIso f]
-    (g : Y ⟶ Z) : Mono (f ≫ g) ↔ Mono g := by
-  refine ⟨fun h ↦ ?_, fun h ↦ inferInstance⟩
-  simpa using (inferInstance : Mono (inv f ≫ f ≫ g))
-
-/-- When `g` is an isomorphism, `f ≫ g` is monic iff `f` is. -/
-lemma CategoryTheory.mono_comp_isIso_iff {C : Type*} [Category C] {X Y Z : C} (f : X ⟶ Y)
-    (g : Y ⟶ Z) [IsIso g] : Mono (f ≫ g) ↔ Mono f := by
-  refine ⟨fun h ↦ ?_, fun h ↦ inferInstance⟩
-  simpa using (inferInstance : Mono ((f ≫ g) ≫ inv g ))
-
-/-- For any natural transformation `f : F ⟶ G`, if `X` and `Y` are isomorphic, the component of
-`f` at `X` is epic iff the component of `f` at `Y` is. -/
-lemma CategoryTheory.NatTrans.epi_app_congr_iso {C D : Type*} [Category C] [Category D]
-    {F G : C ⥤ D} {f : F ⟶ G} {X Y : C} (α : X ≅ Y) : Epi (f.app X) ↔ Epi (f.app Y) := by
-  refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
-  · rw [(IsIso.eq_inv_comp _).2 <| f.naturality α.hom]; infer_instance
-  · rw [(IsIso.eq_inv_comp _).2 <| f.naturality α.inv]; infer_instance
-
-/-- For any natural transformation `f : F ⟶ G`, if `X` and `Y` are isomorphic, the component of
-`f` at `X` is monic iff the component of `f` at `Y` is. -/
-lemma CategoryTheory.NatTrans.mono_app_congr_iso {C D : Type*} [Category C] [Category D]
-    {F G : C ⥤ D} {f : F ⟶ G} {X Y : C} (α : X ≅ Y) : Mono (f.app X) ↔ Mono (f.app Y) := by
-  refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
-  · rw [(IsIso.eq_inv_comp _).2 <| f.naturality α.hom]; infer_instance
-  · rw [(IsIso.eq_inv_comp _).2 <| f.naturality α.inv]; infer_instance
-
-/-- For any natural isomorphism `α : F ≅ G` and morphism `f : X ⟶ Y`, `F.map f` is epic
-iff `G.map f` is. -/
-lemma CategoryTheory.Functor.epi_map_congr_iso {C D : Type*} [Category C] [Category D]
-    {F G : C ⥤ D} {X Y : C} (f : X ⟶ Y) (α : F ≅ G) : Epi (F.map f) ↔ Epi (G.map f) := by
-  refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
-  · rw [← (IsIso.inv_comp_eq _).2 <| α.hom.naturality f]; infer_instance
-  · rw [← (IsIso.inv_comp_eq _).2 <| α.inv.naturality f]; infer_instance
-
-/-- For any natural isomorphism `α : F ≅ G` and morphism `f : X ⟶ Y`, `F.map f` is monic
-iff `G.map f` is. -/
-lemma CategoryTheory.Functor.mono_map_congr_iso {C D : Type*} [Category C] [Category D]
-    {F G : C ⥤ D} {X Y : C} (f : X ⟶ Y) (α : F ≅ G) : Mono (F.map f) ↔ Mono (G.map f) := by
-  refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
-  · rw [← (IsIso.inv_comp_eq _).2 <| α.hom.naturality f]; infer_instance
-  · rw [← (IsIso.inv_comp_eq _).2 <| α.inv.naturality f]; infer_instance
-
-end Misc
-
-namespace CategoryTheory.Adjunction
-
-variable {C D : Type*} [Category C] [Category D]
-variable {F H : C ⥤ D} {G : D ⥤ C}
-variable (adj₁ : F ⊣ G) (adj₂ : G ⊣ H)
 
 section InnerFullyFaithful
 

--- a/Mathlib/CategoryTheory/Adjunction/Triple.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Triple.lean
@@ -1,9 +1,10 @@
 /-
 Copyright (c) 2024 Dagur Asgeirsson. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Dagur Asgeirsson
+Authors: Dagur Asgeirsson, Ben Eltschig
 -/
 import Mathlib.CategoryTheory.Adjunction.Unique
+import Mathlib.CategoryTheory.Limits.FunctorCategory.EpiMono
 import Mathlib.CategoryTheory.Monad.Adjunction
 /-!
 
@@ -51,5 +52,304 @@ noncomputable def fullyFaithfulEquiv : F.FullyFaithful ≃ H.FullyFaithful where
     adj₁.fullyFaithfulLOfIsIsoUnit
   left_inv _ := Subsingleton.elim _ _
   right_inv _ := Subsingleton.elim _ _
+
+end CategoryTheory.Adjunction
+
+open CategoryTheory Limits
+
+-- TODO: move these somewhere else
+section Misc
+
+/-- When `f` is an isomorphism, `f ≫ g` is epic iff `g` is.
+TODO: should this and the following lemmas be simp lemmas? might cause slowdowns because it triggers
+instance searches for `IsIso` whenever `simp` is used on a goal containing `Mono (f ≫ g)`. -/
+lemma CategoryTheory.epi_isIso_comp_iff {C : Type*} [Category C] {X Y Z : C} (f : X ⟶ Y) [IsIso f]
+    (g : Y ⟶ Z) : Epi (f ≫ g) ↔ Epi g := by
+  refine ⟨fun h ↦ ?_, fun h ↦ inferInstance⟩
+  simpa using (inferInstance : Epi (inv f ≫ f ≫ g))
+
+/-- When `g` is an isomorphism, `f ≫ g` is epic iff `f` is. -/
+lemma CategoryTheory.epi_comp_isIso_iff {C : Type*} [Category C] {X Y Z : C} (f : X ⟶ Y) (g : Y ⟶ Z)
+    [IsIso g] : Epi (f ≫ g) ↔ Epi f := by
+  refine ⟨fun h ↦ ?_, fun h ↦ inferInstance⟩
+  simpa using (inferInstance : Epi ((f ≫ g) ≫ inv g ))
+
+/-- When `f` is an isomorphism, `f ≫ g` is monic iff `g` is. -/
+lemma CategoryTheory.mono_isIso_comp_iff {C : Type*} [Category C] {X Y Z : C} (f : X ⟶ Y) [IsIso f]
+    (g : Y ⟶ Z) : Mono (f ≫ g) ↔ Mono g := by
+  refine ⟨fun h ↦ ?_, fun h ↦ inferInstance⟩
+  simpa using (inferInstance : Mono (inv f ≫ f ≫ g))
+
+/-- When `g` is an isomorphism, `f ≫ g` is monic iff `f` is. -/
+lemma CategoryTheory.mono_comp_isIso_iff {C : Type*} [Category C] {X Y Z : C} (f : X ⟶ Y)
+    (g : Y ⟶ Z) [IsIso g] : Mono (f ≫ g) ↔ Mono f := by
+  refine ⟨fun h ↦ ?_, fun h ↦ inferInstance⟩
+  simpa using (inferInstance : Mono ((f ≫ g) ≫ inv g ))
+
+/-- For any natural transformation `f : F ⟶ G`, if `X` and `Y` are isomorphic, the component of
+`f` at `X` is epic iff the component of `f` at `Y` is. -/
+lemma CategoryTheory.NatTrans.epi_app_congr_iso {C D : Type*} [Category C] [Category D]
+    {F G : C ⥤ D} {f : F ⟶ G} {X Y : C} (α : X ≅ Y) : Epi (f.app X) ↔ Epi (f.app Y) := by
+  refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
+  · rw [(IsIso.eq_inv_comp _).2 <| f.naturality α.hom]; infer_instance
+  · rw [(IsIso.eq_inv_comp _).2 <| f.naturality α.inv]; infer_instance
+
+/-- For any natural transformation `f : F ⟶ G`, if `X` and `Y` are isomorphic, the component of
+`f` at `X` is monic iff the component of `f` at `Y` is. -/
+lemma CategoryTheory.NatTrans.mono_app_congr_iso {C D : Type*} [Category C] [Category D]
+    {F G : C ⥤ D} {f : F ⟶ G} {X Y : C} (α : X ≅ Y) : Mono (f.app X) ↔ Mono (f.app Y) := by
+  refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
+  · rw [(IsIso.eq_inv_comp _).2 <| f.naturality α.hom]; infer_instance
+  · rw [(IsIso.eq_inv_comp _).2 <| f.naturality α.inv]; infer_instance
+
+/-- For any natural isomorphism `α : F ≅ G` and morphism `f : X ⟶ Y`, `F.map f` is epic
+iff `G.map f` is. -/
+lemma CategoryTheory.Functor.epi_map_congr_iso {C D : Type*} [Category C] [Category D]
+    {F G : C ⥤ D} {X Y : C} (f : X ⟶ Y) (α : F ≅ G) : Epi (F.map f) ↔ Epi (G.map f) := by
+  refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
+  · rw [← (IsIso.inv_comp_eq _).2 <| α.hom.naturality f]; infer_instance
+  · rw [← (IsIso.inv_comp_eq _).2 <| α.inv.naturality f]; infer_instance
+
+/-- For any natural isomorphism `α : F ≅ G` and morphism `f : X ⟶ Y`, `F.map f` is monic
+iff `G.map f` is. -/
+lemma CategoryTheory.Functor.mono_map_congr_iso {C D : Type*} [Category C] [Category D]
+    {F G : C ⥤ D} {X Y : C} (f : X ⟶ Y) (α : F ≅ G) : Mono (F.map f) ↔ Mono (G.map f) := by
+  refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
+  · rw [← (IsIso.inv_comp_eq _).2 <| α.hom.naturality f]; infer_instance
+  · rw [← (IsIso.inv_comp_eq _).2 <| α.inv.naturality f]; infer_instance
+
+end Misc
+
+namespace CategoryTheory.Adjunction
+
+variable {C D : Type*} [Category C] [Category D]
+variable {F H : C ⥤ D} {G : D ⥤ C}
+variable (adj₁ : F ⊣ G) (adj₂ : G ⊣ H)
+
+section InnerFullyFaithful
+
+variable [G.Full] [G.Faithful]
+
+/-- For an adjoint triple `F ⊣ G ⊣ H` where `G` is fully faithful, the two natural transformations
+`H ⋙ G ⋙ F ⟶ F ⋙ G ⋙ H` obtained by following the whiskered counit and units of either
+adjunction agree. Note that this is also true when `F` and `H` are fully faithful instead of `G`;
+see `whiskered_counit_unit_eq_of_outer` for the corresponding variant of this lemma. -/
+lemma whiskered_counit_unit_eq_of_inner :
+    whiskerLeft H adj₁.counit ≫ H.rightUnitor.hom ≫ H.leftUnitor.inv ≫
+    whiskerRight adj₁.unit H ≫ (Functor.associator _ _ _).hom =
+    (Functor.associator _ _ _).inv ≫ whiskerRight adj₂.counit F ≫ F.leftUnitor.hom ≫
+    F.rightUnitor.inv ≫ whiskerLeft F adj₂.unit := by
+  ext X
+  dsimp; simp only [Category.id_comp, Category.comp_id]
+  refine (adj₁.counit_naturality <| (whiskerRight adj₁.unit H).app X).symm.trans ?_
+  rw [whiskerRight_app, (asIso (adj₂.counit.app (G.obj _))).eq_comp_inv.2
+      (adj₂.counit_naturality (adj₁.unit.app X)),
+    ← (asIso _).comp_hom_eq_id.1 <| adj₂.left_triangle_components (F.obj X)]
+  simp
+
+/-- The natural transformation `H ⟶ F` that exists for every adjoint triple `F ⊣ G ⊣ H` where `G`
+is fully faithful, given here as the whiskered unit `H ⟶ F ⋙ G ⋙ H` of the first adjunction
+followed by the inverse of the whiskered unit `F ⟶ F ⋙ G ⋙ H` of the second. -/
+@[simps!]
+noncomputable def HToF : H ⟶ F :=
+  H.leftUnitor.inv ≫ whiskerRight adj₁.unit H ≫ (Functor.associator _ _ _).hom ≫
+  inv (whiskerLeft F adj₂.unit) ≫ F.rightUnitor.hom
+
+/-- The natural transformation `H ⟶ F` for an adjoint triple `F ⊣ G ⊣ H` with `G` fully faithful
+is also equal to the inverse of the whiskered counit `H ⋙ G ⋙ F ⟶ H` of the first adjunction
+followed by the whiskered counit `H ⋙ G ⋙ F ⟶ F` of the second. -/
+lemma HToF_eq :
+    HToF adj₁ adj₂ = H.rightUnitor.inv ≫ inv (whiskerLeft H adj₁.counit) ≫
+    (Functor.associator _ _ _).inv ≫ whiskerRight adj₂.counit F ≫ F.leftUnitor.hom := by
+  ext X; dsimp [HToF]
+  simp only [NatIso.isIso_inv_app, Functor.comp_obj, Category.comp_id, Category.id_comp]
+  rw [IsIso.comp_inv_eq]
+  simpa using congr_app (whiskered_counit_unit_eq_of_inner adj₁ adj₂) X
+
+omit [G.Full] [G.Faithful] in
+/-- For an adjoint triple `F ⊣ G ⊣ H`, the components of the natural transformation
+`H ⋙ G ⟶ F ⋙ G` obtained from the units and counits of the adjunctions are
+under the second adjunction adjunct to the image of the unit of the first adjunction under `H`. -/
+lemma homEquiv_counit_unit_app_eq_H_map_unit {X : C} :
+    adj₂.homEquiv _ _ (adj₂.counit.app X ≫ adj₁.unit.app X) = H.map (adj₁.unit.app X) := by
+  simp [Adjunction.homEquiv_apply]
+
+omit [G.Full] [G.Faithful] in
+/-- For an adjoint triple `F ⊣ G ⊣ H`, the components of the natural transformation
+`H ⋙ G ⟶ F ⋙ G` obtained from the units and counits of the adjunctions are
+under the first adjunction adjunct to the image of the counit of the second adjunction under `F`. -/
+lemma homEquiv_symm_counit_unit_app_eq_F_map_counit {X : C} :
+    (adj₁.homEquiv _ _).symm (adj₂.counit.app X ≫ adj₁.unit.app X) = F.map (adj₂.counit.app X) := by
+  simp [Adjunction.homEquiv_symm_apply]
+
+/-- For an adjoint triple `F ⊣ G ⊣ H` where `G` is fully faithful, the components of the natural
+transformation `H ⋙ G ⟶ F ⋙ G` obtained from the units and counits of the adjunctions are simply
+the images of the components of the natural transformation `H ⟶ F` under `G`. -/
+lemma counit_unit_app_eq_map_HToF {X : C} :
+    adj₂.counit.app X ≫ adj₁.unit.app X = G.map ((HToF adj₁ adj₂).app X) := by
+  refine ((adj₂.homEquiv _ _).symm_apply_apply _).symm.trans ?_
+  rw [homEquiv_counit_unit_app_eq_H_map_unit]; dsimp
+  rw [Adjunction.homEquiv_symm_apply, ← Adjunction.inv_map_unit, ← G.map_inv,
+    ← G.map_comp, HToF_app]
+
+/-- For an adjoint triple `F ⊣ G ⊣ H` where `G` is fully faithful, the natural transformation
+`H ⋙ G ⟶ F ⋙ G` obtained from the units and counits of the adjunctions is simply the
+natural transformation `H ⟶ F` whiskered with `G`. -/
+lemma counit_unit_eq_whiskerRight : adj₂.counit ≫ adj₁.unit = whiskerRight (HToF adj₁ adj₂) G := by
+  ext X; exact counit_unit_app_eq_map_HToF adj₁ adj₂
+
+/-- For an adjoint triple `F ⊣ G ⊣ H` where `G` is fully faithful, the natural transformation
+`H ⟶ F` is epic at `X` iff the image of the unit of the adjunction `F ⊣ G` under `H` is. -/
+lemma HToF_app_epi_iff_map_unit_app_epi {X : C} :
+    Epi ((HToF adj₁ adj₂).app X) ↔ Epi (H.map (adj₁.unit.app X)) := by
+  rw [← epi_isIso_comp_iff (H.map (adj₂.counit.app _)) (H.map (adj₁.unit.app _)),
+    ← H.map_comp, counit_unit_app_eq_map_HToF]
+  exact Functor.epi_map_congr_iso _ (asIso (adj₂.unit))
+
+/-- For an adjoint triple `F ⊣ G ⊣ H` where `G` is fully faithful and its codomain has
+all pushouts, the natural transformation `H ⟶ F` is epic iff the unit of the adjunction `F ⊣ G`
+whiskered with `H` is. -/
+lemma HToF_epi_iff_whiskerRight_unit_epi [HasPushouts D] :
+    Epi (HToF adj₁ adj₂) ↔ Epi (whiskerRight adj₁.unit H) := by
+  repeat rw [NatTrans.epi_iff_epi_app]
+  exact forall_congr' fun _ ↦ adj₁.HToF_app_epi_iff_map_unit_app_epi adj₂
+
+/-- For an adjoint triple `F ⊣ G ⊣ H` where `G` is fully faithful and `H` preserves epimorphisms
+(which is for example the case if `H` has a further right adjoint), the components of the natural
+transformation `H ⟶ F` are epic iff the respective components of the natural transformation
+`H ⋙ G ⟶ F ⋙ G` obtained from the units and counits of the adjunctions are. -/
+lemma HToF_app_epi_iff_counit_unit_app_epi [H.PreservesEpimorphisms] {X : C} :
+    Epi ((HToF adj₁ adj₂).app X) ↔ Epi (adj₂.counit.app X ≫ adj₁.unit.app X) := by
+  have _ := adj₂.isLeftAdjoint
+  refine ⟨fun h ↦ by rw [counit_unit_app_eq_map_HToF]; exact G.map_epi _, fun h ↦ ?_⟩
+  rw [HToF_app, ← homEquiv_counit_unit_app_eq_H_map_unit adj₁ adj₂, adj₂.homEquiv_apply]
+  infer_instance
+
+/-- For an adjoint triple `F ⊣ G ⊣ H` where `G` is fully faithful, `H` preserves epimorphisms
+(which is for example the case if `H` has a further right adjoint) and both categories have
+all pushouts, the natural transformation `H ⟶ F` is epic iff the natural transformation
+`H ⋙ G ⟶ F ⋙ G` obtained from the units and counits of the adjunctions is. -/
+lemma HToF_epi_iff_counit_unit_epi [HasPushouts C] [HasPushouts D] [H.PreservesEpimorphisms] :
+    Epi (HToF adj₁ adj₂) ↔ Epi (adj₂.counit ≫ adj₁.unit) := by
+  repeat rw [NatTrans.epi_iff_epi_app]
+  exact forall_congr' fun _ ↦ adj₁.HToF_app_epi_iff_counit_unit_app_epi adj₂
+
+end InnerFullyFaithful
+
+section OuterFullyFaithful
+
+variable [F.Full] [F.Faithful] [H.Full] [H.Faithful]
+
+omit [F.Full] [F.Faithful] in
+/-- For an adjoint triple `F ⊣ G ⊣ H` where `F` and `H` are fully faithful, the two natural
+transformations `H ⋙ G ⋙ F ⟶ F ⋙ G ⋙ H` obtained by following the whiskered counit and unit
+of either adjunction agree. Note that this is also true when `G` is fully faithful instead of `F`
+and `H`; see `whiskered_counit_unit_eq_of_inner` for the corresponding variant of this lemma. -/
+lemma whiskered_counit_unit_eq_of_outer :
+    whiskerLeft H adj₁.counit ≫ H.rightUnitor.hom ≫ H.leftUnitor.inv ≫
+    whiskerRight adj₁.unit H ≫ (Functor.associator _ _ _).hom =
+    (Functor.associator _ _ _).inv ≫ whiskerRight adj₂.counit F ≫ F.leftUnitor.hom ≫
+    F.rightUnitor.inv ≫ whiskerLeft F adj₂.unit := by
+  ext X
+  dsimp; simp only [Category.id_comp, Category.comp_id]
+  refine (adj₁.counit_naturality <| (whiskerRight adj₁.unit H).app X).symm.trans ?_
+  rw [whiskerRight_app, (asIso (adj₂.counit.app (G.obj _))).eq_comp_inv.2
+      (adj₂.counit_naturality (adj₁.unit.app X)),
+    ← (asIso _).comp_hom_eq_id.1 <| adj₂.left_triangle_components (F.obj X)]
+  simp
+
+/-- The natural transformation `F ⟶ H` that exists for every adjoint triple `F ⊣ G ⊣ H` where `F`
+and `H` are fully faithful, given here as the whiskered unit `F ⟶ F ⋙ G ⋙ H` of the second
+adjunction followed by the inverse of the whiskered unit `F ⋙ G ⋙ H ⟶ H` of the first. -/
+@[simps!]
+noncomputable def FToH : F ⟶ H :=
+  F.rightUnitor.inv ≫ whiskerLeft F adj₂.unit ≫ (Functor.associator _ _ _).inv ≫
+  inv (whiskerRight adj₁.unit H) ≫ H.leftUnitor.hom
+
+/-- The natural transformation `F ⟶ H` for an adjoint triple `F ⊣ G ⊣ H` with `F` and `H`
+fully faithful is also equal to the inverse of the whiskered counit `H ⋙ G ⋙ F ⟶ F` of the second
+adjunction followed by the whiskered counit `H ⋙ G ⋙ F ⟶ H` of the first. -/
+lemma FToH_eq :
+    FToH adj₁ adj₂ = F.leftUnitor.inv ≫ inv (whiskerRight adj₂.counit F) ≫
+    (Functor.associator _ _ _).hom ≫ whiskerLeft H adj₁.counit ≫ H.rightUnitor.hom := by
+  ext X; dsimp [FToH]
+  simp only [NatIso.isIso_inv_app, Functor.comp_obj, Category.comp_id, Category.id_comp]
+  rw [IsIso.comp_inv_eq]
+  simpa using congr_app (whiskered_counit_unit_eq_of_outer adj₁ adj₂).symm X
+
+omit [F.Full] [F.Faithful] [H.Full] [H.Faithful] in
+/-- For an adjoint triple `F ⊣ G ⊣ H`, the components of the natural transformation
+`G ⋙ F ⟶ G ⋙ H` obtained from the units and counits of the adjunctions are
+under the first adjunction adjunct to the image of the unit of the second adjunction under `G`. -/
+lemma homEquiv_counit_unit_app_eq_G_map_unit {X : D} :
+    adj₁.homEquiv _ _ (adj₁.counit.app X ≫ adj₂.unit.app X) = G.map (adj₂.unit.app X) := by
+  simp [homEquiv_apply]
+
+omit [F.Full] [F.Faithful] [H.Full] [H.Faithful] in
+/-- For an adjoint triple `F ⊣ G ⊣ H`, the components of the natural transformation
+`G ⋙ F ⟶ G ⋙ H` obtained from the units and counits of the adjunctions are
+under the second adjunction adjunct to the image of the counit of the first adjunction under `G`. -/
+lemma homEquiv_symm_counit_unit_app_eq_G_map_counit {X : D} :
+    (adj₂.homEquiv _ _).symm (adj₁.counit.app X ≫ adj₂.unit.app X) = G.map (adj₁.counit.app X) := by
+  simp [homEquiv_symm_apply]
+
+omit [H.Full] [H.Faithful] in
+/-- For an adjoint triple `F ⊣ G ⊣ H` where `F` and `H` are fully faithful, the components of the
+natural transformation `G ⋙ F ⟶ G ⋙ H` obtained from the units and counits of the adjunctions
+are simply the components of the natural transformation `F ⟶ H` at `G`. -/
+lemma counit_unit_app_eq_FToH_app {X : D} :
+    adj₁.counit.app X ≫ adj₂.unit.app X = (FToH adj₁ adj₂).app (G.obj X) := by
+  refine ((adj₂.homEquiv _ _).apply_symm_apply _).symm.trans ?_
+  rw [homEquiv_symm_counit_unit_app_eq_G_map_counit, adj₂.homEquiv_apply, FToH_app, ← H.map_inv]
+  congr
+  exact IsIso.eq_inv_of_hom_inv_id (adj₁.right_triangle_components _)
+
+omit [H.Full] [H.Faithful] in
+/-- For an adjoint triple `F ⊣ G ⊣ H` where `F` and `H` are fully faithful, the natural
+transformation `G ⋙ F ⟶ G ⋙ H` obtained from the units and counits of the adjunctions is simply
+the natural transformation `F ⟶ H` whiskered from the left with `G`. -/
+lemma counit_unit_eq_whiskerLeft : adj₁.counit ≫ adj₂.unit = whiskerLeft G (FToH adj₁ adj₂) := by
+  ext X; exact counit_unit_app_eq_FToH_app adj₁ adj₂
+
+omit [H.Full] [H.Faithful] in
+/-- For an adjoint triple `F ⊣ G ⊣ H` where `F` and `H` are fully faithful, the natural
+transformation `F ⟶ H` is monic at `X` iff the unit of the adjunction `G ⊣ H` is monic
+at `F.obj X`. -/
+lemma FToH_app_mono_iff_unit_app_mono {X : C} :
+    Mono ((FToH adj₁ adj₂).app X) ↔ Mono (adj₂.unit.app (F.obj X)) := by
+  rw [← mono_isIso_comp_iff (adj₁.counit.app _) (adj₂.unit.app _), counit_unit_app_eq_FToH_app]
+  exact NatTrans.mono_app_congr_iso (asIso (adj₁.unit.app X))
+
+omit [H.Full] [H.Faithful] in
+/-- For an adjoint triple `F ⊣ G ⊣ H` where `F` and `H` are fully faithful and their codomain has
+all pullbacks, the natural transformation `F ⟶ H` is monic iff `F` whiskered with the unit of the
+adjunction `G ⊣ H` is. -/
+lemma FToH_mono_iff_whiskerLeft_unit_mono [HasPullbacks D] :
+    Mono (FToH adj₁ adj₂) ↔ Mono (whiskerLeft F adj₂.unit) := by
+  repeat rw [NatTrans.mono_iff_mono_app]
+  exact forall_congr' fun _ ↦ adj₁.FToH_app_mono_iff_unit_app_mono adj₂
+
+/-- For an adjoint triple `F ⊣ G ⊣ H` where `F` and `H` are fully faithful, all components of the
+natural transformation `F ⟶ H` are monic iff all components of the natural transformation
+`G ⋙ F ⟶ G ⋙ H` obtained from the units and counits of the adjunctions are.
+Note that unlike `HToF_app_epi_iff_counit_unit_app_epi`, this equivalence does not make sense on a
+per-object basis because the components of the two natural transformations are indexed by different
+categories. -/
+lemma FToH_app_mono_iff_counit_unit_app_mono :
+    (∀ X, Mono ((FToH adj₁ adj₂).app X)) ↔ ∀ X, Mono (adj₁.counit.app X ≫ adj₂.unit.app X) := by
+  refine ⟨fun h X ↦ by rw [counit_unit_app_eq_FToH_app]; exact h _, fun h X ↦ ?_⟩
+  specialize h (H.obj X)
+  rw [counit_unit_app_eq_FToH_app] at h
+  exact (NatTrans.mono_app_congr_iso (asIso (adj₂.counit.app X))).1 h
+
+/-- For an adjoint triple `F ⊣ G ⊣ H` where `F` and `H` are fully faithful and their codomain has
+all pullbacks, the natural transformation `F ⟶ H` is monic iff the natural transformation
+`G ⋙ F ⟶ G ⋙ H` obtained from the units and counits of the adjunctions is. -/
+lemma FToH_mono_iff_counit_unit_mono [HasPullbacks D] :
+    Mono (FToH adj₁ adj₂) ↔ Mono (adj₁.counit ≫ adj₂.unit) := by
+  repeat rw [NatTrans.mono_iff_mono_app]
+  exact adj₁.FToH_app_mono_iff_counit_unit_app_mono adj₂
+
+end OuterFullyFaithful
 
 end CategoryTheory.Adjunction

--- a/Mathlib/CategoryTheory/Adjunction/Triple.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Triple.lean
@@ -10,9 +10,36 @@ import Mathlib.CategoryTheory.Monad.Adjunction
 
 # Adjoint triples
 
-This file concerns adjoint triples `F ⊣ G ⊣ H` of functors `F H : C ⥤ D`, `G : D ⥤ C`.
+This file concerns adjoint triples `F ⊣ G ⊣ H` of functors `F H : C ⥤ D`, `G : D ⥤ C`. We first
+prove that `F` is fully faithful iff `H` is, and then prove results about the two special cases
+where `G` is fully faithful or `F` and `H` are.
 
-Currently, the only result is that `F` is fully faithful if and only if `H` is fully faithful.
+## Main results
+
+All results are about an adjoint triple `F ⊣ G ⊣ H` where `adj₁ : F ⊣ G` and `adj₂ : G ⊣ H`.
+* `fullyFaithfulEquiv`: `F` is fully faithful iff `H` is.
+* `HToF`: the canonical natural transformation `H ⟶ F` that exists whenever `G` is fully faithful.
+  This is defined in terms of the units of the adjunctions, but a formula in terms of the counits
+  is also given.
+* `counit_unit_eq_whiskerRight`: when `G` is fully faithful, the natural transformation
+  `H ⋙ G ⟶ F ⋙ G` given by `adj₂.counit ≫ adj₁.unit` is just `HToF` whiskered with `G`.
+* `HToF_epi_iff_whiskerRight_unit_epi`: assuming `D` has all pushouts, `HToF : H ⟶ F` is epic iff
+  the whiskering `H ⟶ F ⋙ G ⋙ H` of `adj₁.unit` and `H` is. For the components this holds even
+  without assumptions on `D`.
+* `HToF_epi_iff_counit_unit_epi`: assuming `D` has all pushouts, `HToF : H ⟶ F` is epic iff
+  `adj₂.counit ≫ adj₁.unit : H ⋙ G ⟶ F ⋙ G` is. For the components this holds even without
+  assumptions on `D`.
+* `FToH`: the canonical natural transformation `F ⟶ H` that exists whenever `F` and `G` are fully
+  faithful. This is defined in terms of the units of the adjunctions, but a formula in terms of the
+  counits is also given.
+* `counit_unit_eq_whiskerLeft`: when `F` and `H` are fully faithful, the natural transformation
+  `G ⋙ F ⟶ G ⋙ H` given by `adj₁.counit ≫ adj₂.unit` is just `G` whiskered with `FToH`.
+* `FToH_mono_iff_whiskerLeft_unit_mono`: assuming `D` has all pullbacks, `FToH : F ⟶ H` is monic iff
+  the whiskering `F ⟶ F ⋙ G ⋙ H` of `F` and `adj₂.unit` is. For the components this holds even
+  without assumptions on `D`.
+* `FToH_mono_iff_counit_unit_mono`: assuming `D` has all pullbacks, `FToH : H ⟶ F` is monic iff
+  `adj₁.counit ≫ adj₂.unit : G ⋙ F ⟶ G ⋙ H` is. For the components this holds even without
+  assumptions on `D`.
 -/
 
 open CategoryTheory Limits
@@ -55,6 +82,34 @@ noncomputable def fullyFaithfulEquiv : F.FullyFaithful ≃ H.FullyFaithful where
   left_inv _ := Subsingleton.elim _ _
   right_inv _ := Subsingleton.elim _ _
 
+/-- For an adjoint triple `F ⊣ G ⊣ H`, the components of the natural transformation
+`H ⋙ G ⟶ F ⋙ G` obtained from the units and counits of the adjunctions are
+under the second adjunction adjunct to the image of the unit of the first adjunction under `H`. -/
+lemma homEquiv_counit_unit_app_eq_H_map_unit {X : C} :
+    adj₂.homEquiv _ _ (adj₂.counit.app X ≫ adj₁.unit.app X) = H.map (adj₁.unit.app X) := by
+  simp [Adjunction.homEquiv_apply]
+
+/-- For an adjoint triple `F ⊣ G ⊣ H`, the components of the natural transformation
+`H ⋙ G ⟶ F ⋙ G` obtained from the units and counits of the adjunctions are
+under the first adjunction adjunct to the image of the counit of the second adjunction under `F`. -/
+lemma homEquiv_symm_counit_unit_app_eq_F_map_counit {X : C} :
+    (adj₁.homEquiv _ _).symm (adj₂.counit.app X ≫ adj₁.unit.app X) = F.map (adj₂.counit.app X) := by
+  simp [Adjunction.homEquiv_symm_apply]
+
+/-- For an adjoint triple `F ⊣ G ⊣ H`, the components of the natural transformation
+`G ⋙ F ⟶ G ⋙ H` obtained from the units and counits of the adjunctions are
+under the first adjunction adjunct to the image of the unit of the second adjunction under `G`. -/
+lemma homEquiv_counit_unit_app_eq_G_map_unit {X : D} :
+    adj₁.homEquiv _ _ (adj₁.counit.app X ≫ adj₂.unit.app X) = G.map (adj₂.unit.app X) := by
+  simp [homEquiv_apply]
+
+/-- For an adjoint triple `F ⊣ G ⊣ H`, the components of the natural transformation
+`G ⋙ F ⟶ G ⋙ H` obtained from the units and counits of the adjunctions are
+under the second adjunction adjunct to the image of the counit of the first adjunction under `G`. -/
+lemma homEquiv_symm_counit_unit_app_eq_G_map_counit {X : D} :
+    (adj₂.homEquiv _ _).symm (adj₁.counit.app X ≫ adj₂.unit.app X) = G.map (adj₁.counit.app X) := by
+  simp [homEquiv_symm_apply]
+
 section InnerFullyFaithful
 
 variable [G.Full] [G.Faithful]
@@ -87,29 +142,13 @@ noncomputable def HToF : H ⟶ F :=
 /-- The natural transformation `H ⟶ F` for an adjoint triple `F ⊣ G ⊣ H` with `G` fully faithful
 is also equal to the inverse of the whiskered counit `H ⋙ G ⋙ F ⟶ H` of the first adjunction
 followed by the whiskered counit `H ⋙ G ⋙ F ⟶ F` of the second. -/
-lemma HToF_eq :
+lemma HToF_eq_counits :
     HToF adj₁ adj₂ = H.rightUnitor.inv ≫ inv (whiskerLeft H adj₁.counit) ≫
     (Functor.associator _ _ _).inv ≫ whiskerRight adj₂.counit F ≫ F.leftUnitor.hom := by
   ext X; dsimp [HToF]
   simp only [NatIso.isIso_inv_app, Functor.comp_obj, Category.comp_id, Category.id_comp]
   rw [IsIso.comp_inv_eq]
   simpa using congr_app (whiskered_counit_unit_eq_of_inner adj₁ adj₂) X
-
-omit [G.Full] [G.Faithful] in
-/-- For an adjoint triple `F ⊣ G ⊣ H`, the components of the natural transformation
-`H ⋙ G ⟶ F ⋙ G` obtained from the units and counits of the adjunctions are
-under the second adjunction adjunct to the image of the unit of the first adjunction under `H`. -/
-lemma homEquiv_counit_unit_app_eq_H_map_unit {X : C} :
-    adj₂.homEquiv _ _ (adj₂.counit.app X ≫ adj₁.unit.app X) = H.map (adj₁.unit.app X) := by
-  simp [Adjunction.homEquiv_apply]
-
-omit [G.Full] [G.Faithful] in
-/-- For an adjoint triple `F ⊣ G ⊣ H`, the components of the natural transformation
-`H ⋙ G ⟶ F ⋙ G` obtained from the units and counits of the adjunctions are
-under the first adjunction adjunct to the image of the counit of the second adjunction under `F`. -/
-lemma homEquiv_symm_counit_unit_app_eq_F_map_counit {X : C} :
-    (adj₁.homEquiv _ _).symm (adj₂.counit.app X ≫ adj₁.unit.app X) = F.map (adj₂.counit.app X) := by
-  simp [Adjunction.homEquiv_symm_apply]
 
 /-- For an adjoint triple `F ⊣ G ⊣ H` where `G` is fully faithful, the components of the natural
 transformation `H ⋙ G ⟶ F ⋙ G` obtained from the units and counits of the adjunctions are simply
@@ -198,29 +237,13 @@ noncomputable def FToH : F ⟶ H :=
 /-- The natural transformation `F ⟶ H` for an adjoint triple `F ⊣ G ⊣ H` with `F` and `H`
 fully faithful is also equal to the inverse of the whiskered counit `H ⋙ G ⋙ F ⟶ F` of the second
 adjunction followed by the whiskered counit `H ⋙ G ⋙ F ⟶ H` of the first. -/
-lemma FToH_eq :
+lemma FToH_eq_counits :
     FToH adj₁ adj₂ = F.leftUnitor.inv ≫ inv (whiskerRight adj₂.counit F) ≫
     (Functor.associator _ _ _).hom ≫ whiskerLeft H adj₁.counit ≫ H.rightUnitor.hom := by
   ext X; dsimp [FToH]
   simp only [NatIso.isIso_inv_app, Functor.comp_obj, Category.comp_id, Category.id_comp]
   rw [IsIso.comp_inv_eq]
   simpa using congr_app (whiskered_counit_unit_eq_of_outer adj₁ adj₂).symm X
-
-omit [F.Full] [F.Faithful] [H.Full] [H.Faithful] in
-/-- For an adjoint triple `F ⊣ G ⊣ H`, the components of the natural transformation
-`G ⋙ F ⟶ G ⋙ H` obtained from the units and counits of the adjunctions are
-under the first adjunction adjunct to the image of the unit of the second adjunction under `G`. -/
-lemma homEquiv_counit_unit_app_eq_G_map_unit {X : D} :
-    adj₁.homEquiv _ _ (adj₁.counit.app X ≫ adj₂.unit.app X) = G.map (adj₂.unit.app X) := by
-  simp [homEquiv_apply]
-
-omit [F.Full] [F.Faithful] [H.Full] [H.Faithful] in
-/-- For an adjoint triple `F ⊣ G ⊣ H`, the components of the natural transformation
-`G ⋙ F ⟶ G ⋙ H` obtained from the units and counits of the adjunctions are
-under the second adjunction adjunct to the image of the counit of the first adjunction under `G`. -/
-lemma homEquiv_symm_counit_unit_app_eq_G_map_counit {X : D} :
-    (adj₂.homEquiv _ _).symm (adj₁.counit.app X ≫ adj₂.unit.app X) = G.map (adj₁.counit.app X) := by
-  simp [homEquiv_symm_apply]
 
 omit [H.Full] [H.Faithful] in
 /-- For an adjoint triple `F ⊣ G ⊣ H` where `F` and `H` are fully faithful, the components of the

--- a/Mathlib/CategoryTheory/Category/Basic.lean
+++ b/Mathlib/CategoryTheory/Category/Basic.lean
@@ -326,6 +326,18 @@ theorem epi_of_epi_fac {X Y Z : C} {f : X ⟶ Y} {g : Y ⟶ Z} {h : X ⟶ Z} [Ep
     (w : f ≫ g = h) : Epi g := by
   subst h; exact epi_of_epi f g
 
+/-- `f : X ⟶ Y` is a monomorphism iff for all `Z`, composition of morphisms `Z ⟶ X` with `f`
+is injective. -/
+lemma mono_iff_forall_injective {X Y : C} {f : X ⟶ Y} :
+    Mono f ↔ ∀ Z, (fun g : Z ⟶ X ↦ g ≫ f).Injective :=
+  ⟨fun _ _ _ _ hg ↦ (cancel_mono f).1 hg, fun h ↦ ⟨fun _ _ hg ↦ h _ hg⟩⟩
+
+/-- `f : X ⟶ Y` is an epimorphism iff for all `Z`, composition of morphisms `Y ⟶ Z` with `f`
+is injective. -/
+lemma epi_iff_forall_injective {X Y : C} {f : X ⟶ Y} :
+    Epi f ↔ ∀ Z, (fun g : Y ⟶ Z ↦ f ≫ g).Injective :=
+  ⟨fun _ _ _ _ hg ↦ (cancel_epi f).1 hg, fun h ↦ ⟨fun _ _ hg ↦ h _ hg⟩⟩
+
 section
 
 variable [Quiver.IsThin C] (f : X ⟶ Y)

--- a/Mathlib/CategoryTheory/EpiMono.lean
+++ b/Mathlib/CategoryTheory/EpiMono.lean
@@ -32,6 +32,26 @@ instance op_mono_of_epi {A B : C} (f : A ⟶ B) [Epi f] : Mono f.op :=
 instance op_epi_of_mono {A B : C} (f : A ⟶ B) [Mono f] : Epi f.op :=
   ⟨fun _ _ eq => Quiver.Hom.unop_inj ((cancel_mono f).1 (Quiver.Hom.op_inj eq))⟩
 
+@[simp]
+lemma op_mono_iff {X Y : C} {f : X ⟶ Y} :
+    Mono f.op ↔ Epi f :=
+  ⟨fun _ ↦ unop_epi_of_mono f.op, fun _ ↦ inferInstance⟩
+
+@[simp]
+lemma op_epi_iff {X Y : C} {f : X ⟶ Y} :
+    Epi f.op ↔ Mono f :=
+  ⟨fun _ ↦ unop_mono_of_epi f.op, fun _ ↦ inferInstance⟩
+
+@[simp]
+lemma unop_mono_iff {X Y : Cᵒᵖ} {f : X ⟶ Y} :
+    Mono f.unop ↔ Epi f :=
+  ⟨fun _ ↦ op_epi_of_mono f.unop, fun _ ↦ inferInstance⟩
+
+@[simp]
+lemma unop_epi_iff {X Y : Cᵒᵖ} {f : X ⟶ Y} :
+    Epi f.unop ↔ Mono f :=
+  ⟨fun _ ↦ op_mono_of_epi f.unop, fun _ ↦ inferInstance⟩
+
 /-- A split monomorphism is a morphism `f : X ⟶ Y` with a given retraction `retraction f : Y ⟶ X`
 such that `f ≫ retraction f = 𝟙 X`.
 

--- a/Mathlib/CategoryTheory/EpiMono.lean
+++ b/Mathlib/CategoryTheory/EpiMono.lean
@@ -242,4 +242,66 @@ instance {X Y : C} (f : X ⟶ Y) [hf : IsSplitEpi f] (F : C ⥤ D) : IsSplitEpi 
 
 end
 
+section
+
+/-- When `f` is an isomorphism, `f ≫ g` is epic iff `g` is.
+TODO: should this and the following lemmas be simp lemmas? might cause slowdowns because it triggers
+instance searches for `IsIso` whenever `simp` is used on a goal containing `Mono (f ≫ g)`. -/
+lemma epi_isIso_comp_iff {X Y Z : C} (f : X ⟶ Y) [IsIso f] (g : Y ⟶ Z) :
+    Epi (f ≫ g) ↔ Epi g := by
+  refine ⟨fun h ↦ ?_, fun h ↦ inferInstance⟩
+  simpa using (inferInstance : Epi (inv f ≫ f ≫ g))
+
+/-- When `g` is an isomorphism, `f ≫ g` is epic iff `f` is. -/
+lemma epi_comp_isIso_iff {X Y Z : C} (f : X ⟶ Y) (g : Y ⟶ Z) [IsIso g] :
+    Epi (f ≫ g) ↔ Epi f := by
+  refine ⟨fun h ↦ ?_, fun h ↦ inferInstance⟩
+  simpa using (inferInstance : Epi ((f ≫ g) ≫ inv g ))
+
+/-- When `f` is an isomorphism, `f ≫ g` is monic iff `g` is. -/
+lemma mono_isIso_comp_iff {X Y Z : C} (f : X ⟶ Y) [IsIso f] (g : Y ⟶ Z) :
+    Mono (f ≫ g) ↔ Mono g := by
+  refine ⟨fun h ↦ ?_, fun h ↦ inferInstance⟩
+  simpa using (inferInstance : Mono (inv f ≫ f ≫ g))
+
+/-- When `g` is an isomorphism, `f ≫ g` is monic iff `f` is. -/
+lemma mono_comp_isIso_iff {X Y Z : C} (f : X ⟶ Y) (g : Y ⟶ Z) [IsIso g] :
+    Mono (f ≫ g) ↔ Mono f := by
+  refine ⟨fun h ↦ ?_, fun h ↦ inferInstance⟩
+  simpa using (inferInstance : Mono ((f ≫ g) ≫ inv g ))
+
+/-- For any natural transformation `f : F ⟶ G`, if `X` and `Y` are isomorphic, the component of
+`f` at `X` is epic iff the component of `f` at `Y` is. -/
+lemma NatTrans.epi_app_congr_iso {C D : Type*} [Category C] [Category D]
+    {F G : C ⥤ D} {f : F ⟶ G} {X Y : C} (α : X ≅ Y) : Epi (f.app X) ↔ Epi (f.app Y) := by
+  refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
+  · rw [(IsIso.eq_inv_comp _).2 <| f.naturality α.hom]; infer_instance
+  · rw [(IsIso.eq_inv_comp _).2 <| f.naturality α.inv]; infer_instance
+
+/-- For any natural transformation `f : F ⟶ G`, if `X` and `Y` are isomorphic, the component of
+`f` at `X` is monic iff the component of `f` at `Y` is. -/
+lemma NatTrans.mono_app_congr_iso {C D : Type*} [Category C] [Category D]
+    {F G : C ⥤ D} {f : F ⟶ G} {X Y : C} (α : X ≅ Y) : Mono (f.app X) ↔ Mono (f.app Y) := by
+  refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
+  · rw [(IsIso.eq_inv_comp _).2 <| f.naturality α.hom]; infer_instance
+  · rw [(IsIso.eq_inv_comp _).2 <| f.naturality α.inv]; infer_instance
+
+/-- For any natural isomorphism `α : F ≅ G` and morphism `f : X ⟶ Y`, `F.map f` is epic
+iff `G.map f` is. -/
+lemma Functor.epi_map_congr_iso {C D : Type*} [Category C] [Category D]
+    {F G : C ⥤ D} {X Y : C} (f : X ⟶ Y) (α : F ≅ G) : Epi (F.map f) ↔ Epi (G.map f) := by
+  refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
+  · rw [← (IsIso.inv_comp_eq _).2 <| α.hom.naturality f]; infer_instance
+  · rw [← (IsIso.inv_comp_eq _).2 <| α.inv.naturality f]; infer_instance
+
+/-- For any natural isomorphism `α : F ≅ G` and morphism `f : X ⟶ Y`, `F.map f` is monic
+iff `G.map f` is. -/
+lemma Functor.mono_map_congr_iso {C D : Type*} [Category C] [Category D]
+    {F G : C ⥤ D} {X Y : C} (f : X ⟶ Y) (α : F ≅ G) : Mono (F.map f) ↔ Mono (G.map f) := by
+  refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
+  · rw [← (IsIso.inv_comp_eq _).2 <| α.hom.naturality f]; infer_instance
+  · rw [← (IsIso.inv_comp_eq _).2 <| α.inv.naturality f]; infer_instance
+
+end
+
 end CategoryTheory


### PR DESCRIPTION
Lemmas about adjoint quadruples `L ⊣ F ⊣ G ⊣ R` where some of the functors are fully faithful:
* If `F` and `R` are fully faithful, the components of the induced natural transformation `G ⟶ L`
  are epic iff the components of the natural transformation `F ⟶ R` are monic.
* If `L` and `G` are fully faithful, the components of the induced natural transformation `L ⟶ G`
  are epic iff the components of the natural transformation `R ⟶ F` are monic.

A variant of the first case appears as proposition 2.7 on the nlab [here](https://ncatlab.org/nlab/show/cohesive+topos); the second case is dual.

From [lean-orbifolds](https://github.com/peabrainiac/lean-orbifolds/blob/d599ff5f39aa831e8fa79b2f2fa7178b36bcbafd/Orbifolds/ForMathlib/Quadruple.lean).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

- [x] depends on: #27650 

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
