### PR TITLE
feat(LinearAlgebra): add inductive principle for the free product of algebras

### DIFF
--- a/Mathlib/LinearAlgebra/FreeProduct/Basic.lean
+++ b/Mathlib/LinearAlgebra/FreeProduct/Basic.lean
@@ -395,7 +395,7 @@ lemma empty_rel_false [inst : IsEmpty I] {x y} (h : rel R A x y) :
 @[simp] lemma empty_rel_bot [IsEmpty I] : rel R A = ⊥ := by
   ext x y; simp [empty_rel_false_iff]
 
-@[simp] lemma empty_rel'_bot [IsEmpty I] : rel' R A = ⊥ := by
+@[simp↓] lemma empty_rel'_bot [IsEmpty I] : rel' R A = ⊥ := by
   ext x y; simp [empty_rel_false_iff]
 
 /-- The free product over an empty type is isomorphic to the base ring. -/

--- a/Mathlib/LinearAlgebra/FreeProduct/Basic.lean
+++ b/Mathlib/LinearAlgebra/FreeProduct/Basic.lean
@@ -404,7 +404,7 @@ lemma empty_rel_false [inst : IsEmpty I] {x y} (h : rel R A x y) :
 @[simp] lemma empty_rel'_bot [IsEmpty I] : rel' R A = ⊥ := by
   ext x y; simp [empty_rel_false_iff]
 
-/--The free product over an empty type is isomorphic to the base ring.-/
+/-- The free product over an empty type is isomorphic to the base ring. -/
 @[simps!] def of_empty [inst : IsEmpty I] : FreeProduct R A ≃ₐ[R] R :=
   AlgEquiv.ofAlgHom
     (lift R A fun {i} => inst.elim i)
@@ -412,10 +412,12 @@ lemma empty_rel_false [inst : IsEmpty I] {x y} (h : rel R A x y) :
     (by ext)
     (by ext; exact inst.elim ‹_›)
 
+variable {R A}
+
 --Follows the proof in `Mathlib.Algebra.FreeAlgebra`.
-/--Inductive principle for `FreeProduct`. If a `Prop` can be proven for
+/-- Inductive principle for `FreeProduct`. If a `Prop` can be proven for
 all elements of the `A i`, including scalars `R`, and is preserved by
-multiplication and addition, then it holds for the whole of the algebra.-/
+multiplication and addition, then it holds for the whole of the algebra. -/
 @[elab_as_elim, induction_eliminator]
 theorem inductionOn {motive : FreeProduct R A → Prop} (x : FreeProduct R A)
     (scalar : ∀ r, motive (algebraMap R (FreeProduct R A) r))
@@ -432,11 +434,7 @@ theorem inductionOn {motive : FreeProduct R A → Prop} (x : FreeProduct R A)
   -- the mapping through the subalgebra is the identity
   have of_id : AlgHom.id R (FreeProduct R A) = s.val.comp (lift R A of) := by
     ext
-    simp_rw [AlgHom.id_comp, AlgHom.comp_toLinearMap, LinearMap.comp_apply,
-             AlgHom.toLinearMap_apply, lift_apply, liftAlgHom_mkAlgHom_apply,
-             TensorAlgebra.lift_ι_apply, toModule_lof, AlgHom.toLinearMap_apply, ← AlgHom.comp_apply,
-             of, AlgHom.val_comp_codRestrict, FreeProduct.of, ι, ι', mkAlgHom,
-             AlgHom.ofLinearMap_apply, LinearMap.comp_apply, AlgHom.toLinearMap_apply]
+    simp [FreeProduct.of, ι, ι', of]
   -- finding a proof is finding an element of the subalgebra
   suffices x = lift R A of x by
     rw [this]
@@ -444,9 +442,9 @@ theorem inductionOn {motive : FreeProduct R A → Prop} (x : FreeProduct R A)
   simp [AlgHom.ext_iff] at of_id
   exact of_id x
 
-/--Inductive principle for `FreeProduct.asPowers`. If a `Prop` can be proven for
+/-- Inductive principle for `FreeProduct.asPowers`. If a `Prop` can be proven for
 all elements of the `A i`, including scalars `R`, and is preserved by
-multiplication and addition, then it holds for the whole of the algebra.-/
+multiplication and addition, then it holds for the whole of the algebra. -/
 @[elab_as_elim, induction_eliminator]
 theorem asPowers.inductionOn
     {motive : FreeProduct.asPowers R A → Prop} (x : FreeProduct.asPowers R A)
@@ -458,10 +456,8 @@ theorem asPowers.inductionOn
   simpa using
     FreeProduct.inductionOn (motive := motive ∘ ε.symm) (ε x)
       (by simpa using scalar)
-      (fun aᵢ ↦ by
-        convert iota aᵢ
-        simp_rw [of, FreeProduct.of, ε_def, comp_apply, ι_equiv_ι'])
-      (by convert (fun {x y} ↦ @mul (ε.symm x) (ε.symm y)); simp)
-      (by convert (fun {x y} ↦ @add (ε.symm x) (ε.symm y)); simp)
+      (by simpa [of, FreeProduct.of, ε_def] using iota ·)
+      (by simpa using (fun {x y} ↦ @mul (ε.symm x) (ε.symm y)))
+      (by simpa using (fun {x y} ↦ @add (ε.symm x) (ε.symm y)))
 
 end LinearAlgebra.FreeProduct

--- a/Mathlib/LinearAlgebra/FreeProduct/Basic.lean
+++ b/Mathlib/LinearAlgebra/FreeProduct/Basic.lean
@@ -354,16 +354,10 @@ to a unique arrow `π` from `FreeProduct R A` such that  `π ∘ ι i = maps i`.
   invFun π i := π ∘ₐ ι R A i
   left_inv π := by
     ext i aᵢ
-    simp_rw [ι, ι', AlgHom.comp_apply, AlgHom.ofLinearMap_apply,
-             LinearMap.comp_apply, AlgHom.toLinearMap_apply,
-             liftAlgHom_mkAlgHom_apply, TensorAlgebra.lift_ι_apply, toModule_lof,
-             AlgHom.toLinearMap_apply]
+    aesop (add simp [ι, ι'])
   right_inv maps := by
     ext i a
-    simp_rw [ι, ι', LinearMap.comp_apply, AlgHom.toLinearMap_apply, AlgHom.comp_apply,
-             liftAlgHom_mkAlgHom_apply, TensorAlgebra.lift_ι_apply, toModule_lof,
-             AlgHom.toLinearMap_apply, AlgHom.comp_apply, AlgHom.ofLinearMap_apply,
-             LinearMap.comp_apply, mkAlgHom, AlgHom.toLinearMap_apply]
+    aesop (add simp [ι, ι'])
 
 /-- Universal property of the free product of algebras, property:
 for every `R`-algebra `B`, every family of maps `maps : (i : I) → (A i →ₐ[R] B)` lifts

--- a/Mathlib/LinearAlgebra/FreeProduct/Basic.lean
+++ b/Mathlib/LinearAlgebra/FreeProduct/Basic.lean
@@ -27,14 +27,14 @@ general $R$-algebras.
 
 * `FreeProduct R A` is the free product of the `R`-algebras `A i`, defined as a quotient
   of the tensor algebra on the direct sum of the `A i`.
-* `FreeProduct_ofPowers R A` is the free product of the `R`-algebras `A i`, defined as a quotient
+* `FreeProduct.asPowers R A` is the free product of the `R`-algebras `A i`, defined as a quotient
   of the (infinite) direct sum of tensor powers of the `A i`.
 * `lift` is the universal property of the free product.
 
 ## Main results
 
-* `equivPowerAlgebra` establishes an equivalence between `FreeProduct R A` and
-  `FreeProduct_ofPowers R A`.
+* `equivAsPowers` establishes an equivalence between `FreeProduct R A` and
+  `FreeProduct.asPowers R A`.
 * `FreeProduct` is the coproduct in the category of `R`-algebras.
 
 ## TODO
@@ -110,6 +110,8 @@ variable {I : Type u} [DecidableEq I] {i : I} -- The type of the indexing set
   (maps : {i : I} → A i →ₐ[R] B) -- A family of `R`algebra homomorphisms
 
 namespace LinearAlgebra.FreeProduct
+open scoped Function TensorProduct
+
 
 instance : Module R (⨁ i, A i) := by infer_instance
 
@@ -120,6 +122,12 @@ abbrev FreeTensorAlgebra := TensorAlgebra R (⨁ i, A i)
 /-- The direct sum of tensor powers of a direct sum of `R`-algebras,
 before taking the quotient by the free product relation -/
 abbrev PowerAlgebra := ⨁ (n : ℕ), TensorPower R n (⨁ i, A i)
+
+/-- The canonical linear injection from the direct sum of the `A i` to the power algebra. -/
+@[simp] noncomputable def PowerAlgebra.ι : (⨁ i, A i) →ₗ[R] PowerAlgebra R A :=
+  DirectSum.lof R ℕ (⨂[R]^· (⨁ i, A i)) 1 ∘ₗ
+    (MultilinearMap.ofSubsingleton R (⨁ i, A i) _ (0 : Fin 1)
+      |>.symm (PiTensorProduct.tprod R))
 
 /-- The free tensor algebra and its representation as an infinite direct sum
 of tensor powers are (noncomputably) equivalent as `R`-algebras. -/
@@ -133,19 +141,62 @@ of tensor powers are (noncomputably) equivalent as `R`-algebras. -/
 /-- The generating equivalence relation for elements of the free tensor algebra
 that are identified in the free product -/
 inductive rel : FreeTensorAlgebra R A → FreeTensorAlgebra R A → Prop
+  /--`rel` relates the image of any `(1 : A i)` to `1`.-/
   | id  : ∀ {i : I}, rel (ι R <| lof R I A i 1) 1
+  /--`rel` relates the product of the images of two terms from the same `A i` to the image of their
+  product in `A i`.-/
   | prod : ∀ {i : I} {a₁ a₂ : A i},
       rel
         (tprod R (⨁ i, A i) 2 (fun | 0 => lof R I A i a₁ | 1 => lof R I A i a₂))
         (ι R <| lof R I A i (a₁ * a₂))
 
-open scoped Function
+-- We reproduce `rel.id` and `.prod here to make `R, A, i...` explicit.
+@[inherit_doc rel.id]
+theorem rel_id (i : I) : rel R A (ι R <| lof R I A i 1) 1 := rel.id
+
+@[inherit_doc rel.prod]
+theorem rel_prod (i : I) (a₁ a₂ : A i) :
+    rel R A (tprod R (⨁ i, A i) 2 (fun | 0 => lof R I A i a₁ | 1 => lof R I A i a₂))
+      (ι R <| lof R I A i (a₁ * a₂)) := rel.prod
 
 /-- The generating equivalence relation for elements of the power algebra
 that are identified in the free product -/
 @[reducible, simp] def rel' := rel R A on ofDirectSum
 
-theorem rel_id (i : I) : rel R A (ι R <| lof R I A i 1) 1 := rel.id
+--`rel'` never had `.id` and `prod` to begin with
+@[inherit_doc rel.id]
+theorem rel'_id (i : I) : rel' R A (PowerAlgebra.ι R A <| lof R I A i 1) 1 := by
+  have := rel_id R A i; rw [lof_eq_of] at this
+  aesop (add simp [Function.onFun, lof_eq_of])
+
+@[inherit_doc rel.prod]
+theorem rel'_prod (i : I) (a₁ a₂ : A i) :
+    rel' R A (lof R ℕ _ 2  <| ⨂ₜ[R] b, (fun | 0 => lof R I A i a₁ | 1 => lof R I A i a₂) b)
+      (PowerAlgebra.ι R A <| lof R I A i (a₁ * a₂)) := by
+  have := rel_prod R A i a₁ a₂; rw [lof_eq_of] at this
+  aesop (add simp [Function.onFun, lof_eq_of])
+
+@[elab_as_elim, induction_eliminator, cases_eliminator]
+theorem rel'_cases {motive : ∀ {x y}, rel' R A x y → Prop} {x y} (h : rel' R A x y)
+    (id : ∀ {i : I}, motive (rel'_id R A i))
+    (prod : ∀ {i : I} {a₁ a₂ : A i}, motive (rel'_prod R A i a₁ a₂)) : motive h := by
+  unfold rel' Function.onFun at h
+  set x' := ofDirectSum x with ← x'_def
+  set y' := ofDirectSum y with ← y'_def
+  have inj : Function.Injective <| ofDirectSum (R := R) (M := ⨁ i, A i) := by
+    fapply Function.LeftInverse.injective (g := toDirectSum)
+    intro x; simp
+  match x', y', h with
+  | _, 1, rel.id =>
+      rename_i i; convert @id i
+      all_goals {
+        apply_fun ofDirectSum using inj
+        simp [x'_def, y'_def, PowerAlgebra.ι, lof_eq_of] }
+  | _, _, rel.prod =>
+      rename_i i a₁ a₂; convert @prod i a₁ a₂
+      all_goals {
+        apply_fun ofDirectSum using inj
+        simp [x'_def, y'_def, PowerAlgebra.ι, lof_eq_of] }
 
 
 /-- The free product of the collection of `R`-algebras `A i`, as a quotient of
@@ -220,6 +271,70 @@ irreducible_def ι (i : I) : A i →ₐ[R] FreeProduct R A :=
 /-- The family of canonical injection maps, with `i` left implicit -/
 irreducible_def of {i : I} : A i →ₐ[R] FreeProduct R A := ι R A i
 
+namespace asPowers
+-- Since `PiTensorProduct` has suppressed compilation, most ways of engaging with it
+-- requires also suppressing compilation.
+suppress_compilation
+
+/-- The canonical quotient map `PowerAlgebra R A →ₐ[R] FreeProduct.asPowers R A`,
+as an `R`-algebra homomorphism. -/
+abbrev mkAlgHom : PowerAlgebra R A →ₐ[R] FreeProduct.asPowers R A :=
+  RingQuot.mkAlgHom R (rel' R A)
+
+/-- The canonical linear map from the direct sum of the `A i` to the free product. -/
+abbrev ι' : (⨁ i, A i) →ₗ[R] FreeProduct.asPowers R A :=
+  (mkAlgHom R A).toLinearMap ∘ₗ PowerAlgebra.ι R A
+
+theorem ι_apply (x : ⨁ i, A i) :
+    ⟨Quot.mk (Rel <| rel' R A) (PowerAlgebra.ι R A x)⟩ = ι' R A x := by
+  simp_rw [ι', mkAlgHom, RingQuot.mkAlgHom, mkRingHom, LinearMap.coe_comp, comp_apply,
+           AlgHom.toLinearMap_apply, AlgHom.coe_mk, RingHom.coe_mk, MonoidHom.coe_mk,
+           OneHom.coe_mk]
+
+/-- The injection into the free product of any `1 : A i` is the 1 of the free product. -/
+theorem identify_one (i : I) : ι' R A (DirectSum.lof R I A i 1) = 1 := by
+  suffices ι' R A (DirectSum.lof R I A i 1) = mkAlgHom R A 1 by simpa
+  exact RingQuot.mkAlgHom_rel R <| rel'_id R A (i := i)
+
+/-- Multiplication in the free product of the injections of any two `aᵢ aᵢ': A i` for
+the same `i` is just the injection of multiplication `aᵢ * aᵢ'` in `A i`. -/
+theorem mul_injections (a₁ a₂ : A i) :
+    ι' R A (DirectSum.lof R I A i a₁) * ι' R A (DirectSum.lof R I A i a₂)
+      = ι' R A (DirectSum.lof R I A i (a₁ * a₂)) := by
+  convert RingQuot.mkAlgHom_rel R <| rel'_prod R A i a₁ a₂
+  simp_rw [lof_eq_of, ι', mkAlgHom, LinearMap.coe_comp, comp_apply, AlgHom.toLinearMap_apply,
+           ← _root_.map_mul]
+  congr
+  rw [← TensorAlgebra.toDirectSum_tensorPower_tprod]
+  simp [lof_eq_of]
+
+/-- The `i`th canonical injection, from `A i` to the free product, as
+a linear map. -/
+abbrev lof (i : I) : A i →ₗ[R] FreeProduct.asPowers R A :=
+  ι' R A ∘ₗ DirectSum.lof R I A i
+
+/-- `lof R A i 1 = 1` for all `i`. -/
+theorem lof_map_one (i : I) : lof R A i 1 = 1 := by
+  rw [lof]; dsimp [mkAlgHom]; exact identify_one R A i
+
+/-- The `i`th canonical injection, from `A i` to the free product. -/
+noncomputable irreducible_def ι (i : I) : A i →ₐ[R] FreeProduct.asPowers R A :=
+  AlgHom.ofLinearMap (ι' R A ∘ₗ DirectSum.lof R I A i)
+    (lof_map_one R A i) (mul_injections R A · · |>.symm)
+
+/-- The family of canonical injection maps, with `i` left implicit. -/
+abbrev of {i : I} : A i →ₐ[R] FreeProduct.asPowers R A := ι R A i
+
+end asPowers
+
+@[simp] theorem ι_equiv_ι aᵢ : asPowersEquiv R A (asPowers.ι R A i aᵢ) = ι R A i aᵢ := by
+  simp_rw [asPowersEquiv, asPowers.ι, ι, powerAlgebraEquivFreeTensorAlgebra, algEquivQuotAlgEquiv]
+  convert RingQuot.liftAlgHom_mkAlgHom_apply R _ _ _
+  aesop (add simp [Function.onFun, lof_eq_of])
+
+@[simp] theorem ι_equiv_ι' aᵢ : (asPowersEquiv R A).symm (ι R A i aᵢ) = asPowers.ι R A i aᵢ := by
+  apply asPowersEquiv R A |>.injective
+  rw [ι_equiv_ι, AlgEquiv.apply_symm_apply]
 
 /-- Universal property of the free product of algebras:
 for every `R`-algebra `B`, every family of maps `maps : (i : I) → (A i →ₐ[R] B)` lifts

--- a/Mathlib/LinearAlgebra/FreeProduct/Basic.lean
+++ b/Mathlib/LinearAlgebra/FreeProduct/Basic.lean
@@ -101,7 +101,7 @@ def equivQuotEquiv {A B : Type v} [Semiring A] [Semiring B] (f : A ≃+* B) (rel
 
 end RingQuot
 
-open TensorAlgebra DirectSum TensorPower
+open TensorAlgebra DirectSum TensorPower TensorProduct
 
 variable {I : Type u} [DecidableEq I] {i : I} -- The type of the indexing set
   (R : Type v) [CommSemiring R] -- The commutative semiring `R`
@@ -238,8 +238,10 @@ abbrev ι' : (⨁ i, A i) →ₗ[R] FreeProduct R A :=
   (mkAlgHom R A).toLinearMap ∘ₗ TensorAlgebra.ι R (M := ⨁ i, A i)
 
 @[simp] theorem ι_apply (x : ⨁ i, A i) :
-  ⟨Quot.mk (Rel <| rel R A) (TensorAlgebra.ι R x)⟩ = ι' R A x := by
-    aesop (add simp [ι', mkAlgHom, RingQuot.mkAlgHom, mkRingHom])
+    ⟨Quot.mk (Rel <| rel R A) (TensorAlgebra.ι R x)⟩ = ι' R A x := by
+  simp_rw [ι', mkAlgHom, RingQuot.mkAlgHom, mkRingHom, LinearMap.coe_comp, comp_apply,
+           AlgHom.toLinearMap_apply, AlgHom.coe_mk, RingHom.coe_mk, MonoidHom.coe_mk,
+           OneHom.coe_mk]
 
 /-- The injection into the free product of any `1 : A i` is the 1 of the free product. -/
 theorem identify_one (i : I) : ι' R A (DirectSum.lof R I A i 1) = 1 := by


### PR DESCRIPTION
* Add `FreeProduct.inductionOn` and `.asPowers.inductionOn`.

- [ ] depends on: #24532

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

* `simp↓` on `empty_rel'_bot`: the LHS is indeed not in simp-normal form, but `simp` can't solve the full lemma (if only because `Function.onFun` isn't marked `@[simp]`) and the actual simp-normal form of `rel'` isn't terribly useful for humans. Since I do expect users to type `rel' R A` by hand, I claim this use of `simp↓` is justified.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
