### PR TITLE
[Merged by Bors] - style: modify `file-removed` message to warning

### DIFF
--- a/.github/workflows/PR_summary.yml
+++ b/.github/workflows/PR_summary.yml
@@ -67,7 +67,7 @@ jobs:
           if grep ^deprecated_module "${file}" ; then
             printf 'info: removed file %s contains a deprecation\n' "${file}"
           else
-            printf '\n**warning**: file `%s` was removed without a module deprecation\n' "${file}" | tee -a moved_without_deprecation.txt
+            printf '\n⚠️ **warning**: file `%s` was removed without a module deprecation\n' "${file}" | tee -a moved_without_deprecation.txt
           fi
         done
 
@@ -145,7 +145,11 @@ jobs:
         printf '%s [%s](%s)%s\n\n%s\n\n---\n\n%s\n\n---\n\n%s\n' "${title}" "$(git rev-parse --short HEAD)" "${hashURL}" "${high_percentages}" "${importCount}" "${declDiff}" "${techDebtVar}" > please_merge_master.md
 
         # At the end, include any errors about removed or renamed files without deprecation.
-        cat moved_without_deprecation.txt >> please_merge_master.md
+        if [ -s moved_without_deprecation.txt ]
+        then
+          printf '\n\n---\n\n' >> please_merge_master.md
+          cat moved_without_deprecation.txt >> please_merge_master.md
+        fi
 
         cat please_merge_master.md
         ./scripts/update_PR_comment.sh please_merge_master.md "${title}" "${PR}"

--- a/.github/workflows/PR_summary.yml
+++ b/.github/workflows/PR_summary.yml
@@ -67,7 +67,7 @@ jobs:
           if grep ^deprecated_module "${file}" ; then
             printf 'info: removed file %s contains a deprecation\n' "${file}"
           else
-            printf '**error**: file %s was removed without a module deprecation\n' "${file}" >> moved_without_deprecation.txt
+            printf '\n**warning**: file `%s` was removed without a module deprecation\n' "${file}" | tee -a moved_without_deprecation.txt
           fi
         done
 


### PR DESCRIPTION
The `file-removed` workflow has just been added. This PR simply changes
* `error` to `warning` in its message;
* adds a line break for added legibility;
* prints the warning message also in CI.

See
* #24675 for the "old" behaviour;
* #24677 for the proposed behaviour.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
