### PR TITLE
[Merged by Bors] - feat(RingTheory/PowerSeries/*): various small results

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -5264,6 +5264,7 @@ import Mathlib.RingTheory.PolynomialLaw.Basic
 import Mathlib.RingTheory.PowerBasis
 import Mathlib.RingTheory.PowerSeries.Basic
 import Mathlib.RingTheory.PowerSeries.Binomial
+import Mathlib.RingTheory.PowerSeries.CoeffMulMem
 import Mathlib.RingTheory.PowerSeries.Derivative
 import Mathlib.RingTheory.PowerSeries.Evaluation
 import Mathlib.RingTheory.PowerSeries.Inverse

--- a/Mathlib/Data/ENat/Basic.lean
+++ b/Mathlib/Data/ENat/Basic.lean
@@ -168,6 +168,11 @@ theorem toNat_top : toNat ⊤ = 0 :=
 
 @[simp] theorem toNat_eq_zero : toNat n = 0 ↔ n = 0 ∨ n = ⊤ := WithTop.untopD_eq_self_iff
 
+theorem lift_eq_toNat {x : ℕ∞} (hx : x < ⊤) : x.lift hx = x.toNat := by
+  rcases x with ⟨⟩ | x
+  · contradiction
+  · rfl
+
 @[simp]
 theorem recTopCoe_zero {C : ℕ∞ → Sort*} (d : C ⊤) (f : ∀ a : ℕ, C a) : @recTopCoe C d f 0 = f 0 :=
   rfl

--- a/Mathlib/Data/ENat/Basic.lean
+++ b/Mathlib/Data/ENat/Basic.lean
@@ -168,7 +168,7 @@ theorem toNat_top : toNat ⊤ = 0 :=
 
 @[simp] theorem toNat_eq_zero : toNat n = 0 ↔ n = 0 ∨ n = ⊤ := WithTop.untopD_eq_self_iff
 
-theorem lift_eq_toNat {x : ℕ∞} (hx : x < ⊤) : x.lift hx = x.toNat := by
+theorem lift_eq_toNat_of_lt_top {x : ℕ∞} (hx : x < ⊤) : x.lift hx = x.toNat := by
   rcases x with ⟨⟩ | x
   · contradiction
   · rfl

--- a/Mathlib/RingTheory/PowerSeries/CoeffMulMem.lean
+++ b/Mathlib/RingTheory/PowerSeries/CoeffMulMem.lean
@@ -11,44 +11,62 @@ import Mathlib.RingTheory.PowerSeries.Basic
 
 # Some results on the coefficients of multiplication of two power series
 
+## Main results
+
+- `PowerSeries.coeff_mul_mem_ideal_mul_ideal_of_coeff_mem_ideal`,
+  `PowerSeries.coeff_mul_mem_ideal_mul_ideal_of_coeff_mem_ideal'`:
+  if for all `i ≤ n` (resp. for all `i`), the `i`-th coefficients of power series `f` and `g` are
+  in ideals `I` and `J`, respectively, then for all `i ≤ n` (resp. for all `i`), the `i`-th
+  coefficients of `f * g` are in `I * J`.
+
+- `PowerSeries.coeff_mul_mem_ideal_of_coeff_right_mem_ideal`,
+  `PowerSeries.coeff_mul_mem_ideal_of_coeff_right_mem_ideal'`:
+  if for all `i ≤ n` (resp. for all `i`), the `i`-th coefficients of power series `g` are
+  in ideal `I`, then for all `i ≤ n` (resp. for all `i`), the `i`-th coefficients of `f * g` are
+  in `I`.
+
+- `PowerSeries.coeff_mul_mem_ideal_of_coeff_left_mem_ideal`,
+  `PowerSeries.coeff_mul_mem_ideal_of_coeff_left_mem_ideal'`:
+  if for all `i ≤ n` (resp. for all `i`), the `i`-th coefficients of power series `f` are
+  in ideal `I`, then for all `i ≤ n` (resp. for all `i`), the `i`-th coefficients of `f * g` are
+  in `I`.
+
 -/
 
 namespace PowerSeries
 
-variable {A : Type*} [Semiring A] {I J : Ideal A}
+variable {A : Type*} [Semiring A] {I J : Ideal A} {f g : A⟦X⟧} (n : ℕ)
 
-theorem coeff_mul_mem_ideal_mul_ideal_of_coeff_mem_ideal
-    (f g : A⟦X⟧) (n : ℕ) (hf : ∀ i ≤ n, coeff A i f ∈ I)
+theorem coeff_mul_mem_ideal_mul_ideal_of_coeff_mem_ideal (hf : ∀ i ≤ n, coeff A i f ∈ I)
     (hg : ∀ i ≤ n, coeff A i g ∈ J) : ∀ i ≤ n, coeff A i (f * g) ∈ I * J := fun i hi ↦ by
   rw [coeff_mul]
   exact Ideal.sum_mem _ fun p hp ↦ Ideal.mul_mem_mul
     (hf _ ((Finset.antidiagonal.fst_le hp).trans hi))
     (hg _ ((Finset.antidiagonal.snd_le hp).trans hi))
 
-theorem coeff_mul_mem_ideal_mul_ideal_of_coeff_mem_ideal'
-    (f g : A⟦X⟧) (hf : ∀ i, coeff A i f ∈ I)
+theorem coeff_mul_mem_ideal_mul_ideal_of_coeff_mem_ideal' (hf : ∀ i, coeff A i f ∈ I)
     (hg : ∀ i, coeff A i g ∈ J) : ∀ i, coeff A i (f * g) ∈ I * J :=
-  fun i ↦ f.coeff_mul_mem_ideal_mul_ideal_of_coeff_mem_ideal g i
+  fun i ↦ coeff_mul_mem_ideal_mul_ideal_of_coeff_mem_ideal i
     (fun i _ ↦ hf i) (fun i _ ↦ hg i) i le_rfl
 
 theorem coeff_mul_mem_ideal_of_coeff_right_mem_ideal
-    (f g : A⟦X⟧) (n : ℕ) (hg : ∀ i ≤ n, coeff A i g ∈ I) : ∀ i ≤ n, coeff A i (f * g) ∈ I := by
-  simpa using f.coeff_mul_mem_ideal_mul_ideal_of_coeff_mem_ideal (I := ⊤) g n (by simp) hg
+    (hg : ∀ i ≤ n, coeff A i g ∈ I) : ∀ i ≤ n, coeff A i (f * g) ∈ I := by
+  simpa using coeff_mul_mem_ideal_mul_ideal_of_coeff_mem_ideal (I := ⊤) (f := f) n (by simp) hg
 
 theorem coeff_mul_mem_ideal_of_coeff_right_mem_ideal'
-    (f g : A⟦X⟧) (hg : ∀ i, coeff A i g ∈ I) : ∀ i, coeff A i (f * g) ∈ I := by
-  simpa using f.coeff_mul_mem_ideal_mul_ideal_of_coeff_mem_ideal' (I := ⊤) g (by simp) hg
+    (hg : ∀ i, coeff A i g ∈ I) : ∀ i, coeff A i (f * g) ∈ I := by
+  simpa using coeff_mul_mem_ideal_mul_ideal_of_coeff_mem_ideal' (I := ⊤) (f := f) (by simp) hg
 
 variable [I.IsTwoSided]
 
 theorem coeff_mul_mem_ideal_of_coeff_left_mem_ideal
-    (f g : A⟦X⟧) (n : ℕ) (hf : ∀ i ≤ n, coeff A i f ∈ I) : ∀ i ≤ n, coeff A i (f * g) ∈ I := by
+    (hf : ∀ i ≤ n, coeff A i f ∈ I) : ∀ i ≤ n, coeff A i (f * g) ∈ I := by
   simpa only [Ideal.IsTwoSided.mul_one] using
-    f.coeff_mul_mem_ideal_mul_ideal_of_coeff_mem_ideal (J := 1) g n hf (by simp)
+    coeff_mul_mem_ideal_mul_ideal_of_coeff_mem_ideal (J := 1) (g := g) n hf (by simp)
 
 theorem coeff_mul_mem_ideal_of_coeff_left_mem_ideal'
-    (f g : A⟦X⟧) (hf : ∀ i, coeff A i f ∈ I) : ∀ i, coeff A i (f * g) ∈ I := by
+    (hf : ∀ i, coeff A i f ∈ I) : ∀ i, coeff A i (f * g) ∈ I := by
   simpa only [Ideal.IsTwoSided.mul_one] using
-    f.coeff_mul_mem_ideal_mul_ideal_of_coeff_mem_ideal' (J := 1) g hf (by simp)
+    coeff_mul_mem_ideal_mul_ideal_of_coeff_mem_ideal' (J := 1) (g := g) hf (by simp)
 
 end PowerSeries

--- a/Mathlib/RingTheory/PowerSeries/CoeffMulMem.lean
+++ b/Mathlib/RingTheory/PowerSeries/CoeffMulMem.lean
@@ -1,0 +1,50 @@
+/-
+Copyright (c) 2025 Jz Pan. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jz Pan
+-/
+import Mathlib.RingTheory.Ideal.Operations
+import Mathlib.RingTheory.Ideal.BigOperators
+import Mathlib.RingTheory.PowerSeries.Basic
+
+/-!
+
+# Some results on the coefficients of multiplication of two power series
+
+-/
+
+namespace PowerSeries
+
+variable {A B : Type*} [CommRing A] [CommRing B] {I J : Ideal A}
+
+theorem coeff_mul_mem_ideal_mul_ideal_of_coeff_mem_ideal
+    (f g : A⟦X⟧) (n : ℕ) (hf : ∀ i ≤ n, coeff A i f ∈ I)
+    (hg : ∀ i ≤ n, coeff A i g ∈ J) : ∀ i ≤ n, coeff A i (f * g) ∈ I * J := fun i hi ↦ by
+  rw [coeff_mul]
+  exact Ideal.sum_mem _ fun p hp ↦ Ideal.mul_mem_mul
+    (hf _ ((Finset.antidiagonal.fst_le hp).trans hi))
+    (hg _ ((Finset.antidiagonal.snd_le hp).trans hi))
+
+theorem coeff_mul_mem_ideal_mul_ideal_of_coeff_mem_ideal'
+    (f g : A⟦X⟧) (hf : ∀ i, coeff A i f ∈ I)
+    (hg : ∀ i, coeff A i g ∈ J) : ∀ i, coeff A i (f * g) ∈ I * J :=
+  fun i ↦ f.coeff_mul_mem_ideal_mul_ideal_of_coeff_mem_ideal g i
+    (fun i _ ↦ hf i) (fun i _ ↦ hg i) i le_rfl
+
+theorem coeff_mul_mem_ideal_of_coeff_left_mem_ideal
+    (f g : A⟦X⟧) (n : ℕ) (hf : ∀ i ≤ n, coeff A i f ∈ I) : ∀ i ≤ n, coeff A i (f * g) ∈ I := by
+  simpa using f.coeff_mul_mem_ideal_mul_ideal_of_coeff_mem_ideal (J := ⊤) g n hf (by simp)
+
+theorem coeff_mul_mem_ideal_of_coeff_right_mem_ideal
+    (f g : A⟦X⟧) (n : ℕ) (hg : ∀ i ≤ n, coeff A i g ∈ I) : ∀ i ≤ n, coeff A i (f * g) ∈ I := by
+  simpa using f.coeff_mul_mem_ideal_mul_ideal_of_coeff_mem_ideal (I := ⊤) g n (by simp) hg
+
+theorem coeff_mul_mem_ideal_of_coeff_left_mem_ideal'
+    (f g : A⟦X⟧) (hf : ∀ i, coeff A i f ∈ I) : ∀ i, coeff A i (f * g) ∈ I := by
+  simpa using f.coeff_mul_mem_ideal_mul_ideal_of_coeff_mem_ideal' (J := ⊤) g hf (by simp)
+
+theorem coeff_mul_mem_ideal_of_coeff_right_mem_ideal'
+    (f g : A⟦X⟧) (hg : ∀ i, coeff A i g ∈ I) : ∀ i, coeff A i (f * g) ∈ I := by
+  simpa using f.coeff_mul_mem_ideal_mul_ideal_of_coeff_mem_ideal' (I := ⊤) g (by simp) hg
+
+end PowerSeries

--- a/Mathlib/RingTheory/PowerSeries/CoeffMulMem.lean
+++ b/Mathlib/RingTheory/PowerSeries/CoeffMulMem.lean
@@ -15,7 +15,7 @@ import Mathlib.RingTheory.PowerSeries.Basic
 
 namespace PowerSeries
 
-variable {A B : Type*} [CommRing A] [CommRing B] {I J : Ideal A}
+variable {A : Type*} [Semiring A] {I J : Ideal A}
 
 theorem coeff_mul_mem_ideal_mul_ideal_of_coeff_mem_ideal
     (f g : A⟦X⟧) (n : ℕ) (hf : ∀ i ≤ n, coeff A i f ∈ I)
@@ -31,20 +31,24 @@ theorem coeff_mul_mem_ideal_mul_ideal_of_coeff_mem_ideal'
   fun i ↦ f.coeff_mul_mem_ideal_mul_ideal_of_coeff_mem_ideal g i
     (fun i _ ↦ hf i) (fun i _ ↦ hg i) i le_rfl
 
-theorem coeff_mul_mem_ideal_of_coeff_left_mem_ideal
-    (f g : A⟦X⟧) (n : ℕ) (hf : ∀ i ≤ n, coeff A i f ∈ I) : ∀ i ≤ n, coeff A i (f * g) ∈ I := by
-  simpa using f.coeff_mul_mem_ideal_mul_ideal_of_coeff_mem_ideal (J := ⊤) g n hf (by simp)
-
 theorem coeff_mul_mem_ideal_of_coeff_right_mem_ideal
     (f g : A⟦X⟧) (n : ℕ) (hg : ∀ i ≤ n, coeff A i g ∈ I) : ∀ i ≤ n, coeff A i (f * g) ∈ I := by
   simpa using f.coeff_mul_mem_ideal_mul_ideal_of_coeff_mem_ideal (I := ⊤) g n (by simp) hg
 
-theorem coeff_mul_mem_ideal_of_coeff_left_mem_ideal'
-    (f g : A⟦X⟧) (hf : ∀ i, coeff A i f ∈ I) : ∀ i, coeff A i (f * g) ∈ I := by
-  simpa using f.coeff_mul_mem_ideal_mul_ideal_of_coeff_mem_ideal' (J := ⊤) g hf (by simp)
-
 theorem coeff_mul_mem_ideal_of_coeff_right_mem_ideal'
     (f g : A⟦X⟧) (hg : ∀ i, coeff A i g ∈ I) : ∀ i, coeff A i (f * g) ∈ I := by
   simpa using f.coeff_mul_mem_ideal_mul_ideal_of_coeff_mem_ideal' (I := ⊤) g (by simp) hg
+
+variable [I.IsTwoSided]
+
+theorem coeff_mul_mem_ideal_of_coeff_left_mem_ideal
+    (f g : A⟦X⟧) (n : ℕ) (hf : ∀ i ≤ n, coeff A i f ∈ I) : ∀ i ≤ n, coeff A i (f * g) ∈ I := by
+  simpa only [Ideal.IsTwoSided.mul_one] using
+    f.coeff_mul_mem_ideal_mul_ideal_of_coeff_mem_ideal (J := 1) g n hf (by simp)
+
+theorem coeff_mul_mem_ideal_of_coeff_left_mem_ideal'
+    (f g : A⟦X⟧) (hf : ∀ i, coeff A i f ∈ I) : ∀ i, coeff A i (f * g) ∈ I := by
+  simpa only [Ideal.IsTwoSided.mul_one] using
+    f.coeff_mul_mem_ideal_mul_ideal_of_coeff_mem_ideal' (J := 1) g hf (by simp)
 
 end PowerSeries

--- a/Mathlib/RingTheory/PowerSeries/Trunc.lean
+++ b/Mathlib/RingTheory/PowerSeries/Trunc.lean
@@ -143,6 +143,19 @@ lemma trunc_C_mul (n : ℕ) (r : R) (f : R⟦X⟧) : trunc n (C R r * f) = .C r 
 lemma trunc_mul_C (n : ℕ) (f : R⟦X⟧) (r : R) : trunc n (f * C R r) = trunc n f * .C r := by
   ext i; simp [coeff_trunc]
 
+/-- Split off the first `n` coefficients. -/
+lemma eq_shift_mul_X_pow_add_trunc (n : ℕ) (f : R⟦X⟧) :
+    f = (mk fun i ↦ coeff R (i + n) f) * X ^ n + (f.trunc n : R⟦X⟧) := by
+  ext j
+  rw [map_add, Polynomial.coeff_coe, coeff_mul_X_pow', coeff_trunc]
+  simp_rw [← not_le]
+  split_ifs with h <;> simp [h]
+
+/-- Split off the first `n` coefficients. -/
+lemma eq_X_pow_mul_shift_add_trunc (n : ℕ) (f : R⟦X⟧) :
+    f = X ^ n * (mk fun i ↦ coeff R (i + n) f) + (f.trunc n : R⟦X⟧) := by
+  rw [← (commute_X_pow _ n).eq, ← eq_shift_mul_X_pow_add_trunc]
+
 end Trunc
 
 section Trunc


### PR DESCRIPTION
- `Mathlib/RingTheory/PowerSeries/CoeffMulMem.lean`: some results on the coefficients of multiplication of two power series
- `Mathlib/RingTheory/PowerSeries/Trunc.lean`: add two results `eq_shift_mul_X_pow_add_trunc` and `eq_X_pow_mul_shift_add_trunc` generalizing `eq_shift_mul_X_add_const` and `eq_X_mul_shift_add_const`
- `Mathlib/Data/ENat/Basic.lean`: add `ENat.lift_eq_toNat` which seems convenient (?)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

These results are used in #24584.