### PR TITLE
[Merged by Bors] - chore: restore `SemilatticeInf C → BraidedCategory C`

### DIFF
--- a/Mathlib/CategoryTheory/ChosenFiniteProducts/InfSemilattice.lean
+++ b/Mathlib/CategoryTheory/ChosenFiniteProducts/InfSemilattice.lean
@@ -32,6 +32,9 @@ a greatest element -/
 noncomputable scoped instance chosenFiniteProducts : ChosenFiniteProducts C :=
   .ofChosenFiniteProducts ⟨_, Preorder.isTerminalTop C⟩ fun X Y ↦ ⟨_, Preorder.isLimitBinaryFan X Y⟩
 
+/-- Braided structure for the preorder category of a meet-semilattice with a greatest element. -/
+noncomputable scoped instance braidedCategory : BraidedCategory C := .ofChosenFiniteProducts
+
 lemma tensorObj {C : Type u} [SemilatticeInf C] [OrderTop C] {X Y : C} : X ⊗ Y = X ⊓ Y := rfl
 
 lemma tensorUnit {C : Type u} [SemilatticeInf C] [OrderTop C] :


### PR DESCRIPTION
This was automatic before #24399.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
