### PR TITLE
[Merged by Bors] - chore(*): use notation for `Real.sqrt`

### DIFF
--- a/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Instances.lean
+++ b/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Instances.lean
@@ -243,9 +243,9 @@ lemma CFC.exists_sqrt_of_isSelfAdjoint_of_quasispectrumRestricts {A : Type*} [No
     [NonUnitalContinuousFunctionalCalculus ℝ A IsSelfAdjoint]
     {a : A} (ha₁ : IsSelfAdjoint a) (ha₂ : QuasispectrumRestricts a ContinuousMap.realToNNReal) :
     ∃ x : A, IsSelfAdjoint x ∧ QuasispectrumRestricts x ContinuousMap.realToNNReal ∧ x * x = a := by
-  use cfcₙ Real.sqrt a, cfcₙ_predicate Real.sqrt a
+  use cfcₙ (√·) a, cfcₙ_predicate (√·) a
   constructor
-  · simpa only [QuasispectrumRestricts.nnreal_iff, cfcₙ_map_quasispectrum Real.sqrt a,
+  · simpa only [QuasispectrumRestricts.nnreal_iff, cfcₙ_map_quasispectrum (√·) a,
       Set.mem_image, forall_exists_index, and_imp, forall_apply_eq_imp_iff₂]
         using fun x _ ↦ Real.sqrt_nonneg x
   · rw [← cfcₙ_mul ..]
@@ -290,9 +290,9 @@ lemma CFC.exists_sqrt_of_isSelfAdjoint_of_spectrumRestricts {A : Type*} [Ring A]
     [TopologicalSpace A] [Algebra ℝ A] [ContinuousFunctionalCalculus ℝ A IsSelfAdjoint]
     {a : A} (ha₁ : IsSelfAdjoint a) (ha₂ : SpectrumRestricts a ContinuousMap.realToNNReal) :
     ∃ x : A, IsSelfAdjoint x ∧ SpectrumRestricts x ContinuousMap.realToNNReal ∧ x ^ 2 = a := by
-  use cfc Real.sqrt a, cfc_predicate Real.sqrt a
+  use cfc (√·) a, cfc_predicate (√·) a
   constructor
-  · simpa only [SpectrumRestricts.nnreal_iff, cfc_map_spectrum Real.sqrt a, Set.mem_image,
+  · simpa only [SpectrumRestricts.nnreal_iff, cfc_map_spectrum (√·) a, Set.mem_image,
       forall_exists_index, and_imp, forall_apply_eq_imp_iff₂] using fun x _ ↦ Real.sqrt_nonneg x
   · rw [← cfc_pow ..]
     nth_rw 2 [← cfc_id ℝ a]

--- a/Mathlib/Analysis/CStarAlgebra/Module/Defs.lean
+++ b/Mathlib/Analysis/CStarAlgebra/Module/Defs.lean
@@ -160,7 +160,7 @@ open scoped InnerProductSpace in
 /-- The norm associated with a Hilbert C⋆-module. It is not registered as a norm, since a type
 might already have a norm defined on it. -/
 noncomputable def norm (A : Type*) {E : Type*} [Norm A] [Inner A E] : Norm E where
-  norm x := Real.sqrt ‖⟪x, x⟫_A‖
+  norm x := √‖⟪x, x⟫_A‖
 
 section
 include A
@@ -207,10 +207,9 @@ lemma inner_mul_inner_swap_le {x y : E} : ⟪x, y⟫ * ⟪y, x⟫ ≤ ‖x‖ ^ 
                   - ‖x‖ ^ 2 • (⟪x, y⟫ * star a) + ‖x‖ ^ 2 • (‖x‖ ^ 2 • ⟪y, y⟫) := by
                       gcongr
                       calc _ ≤ ‖⟪x, x⟫_A‖ • (a * star a) := CStarAlgebra.conjugate_le_norm_smul'
-                        _ = (Real.sqrt ‖⟪x, x⟫_A‖) ^ 2 • (a * star a) := by
-                                  congr
-                                  have : 0 ≤ ‖⟪x, x⟫_A‖ := by positivity
-                                  rw [Real.sq_sqrt this]
+                        _ = (√‖⟪x, x⟫_A‖) ^ 2 • (a * star a) := by
+                          rw [Real.sq_sqrt]
+                          positivity
                         _ = ‖x‖ ^ 2 • (a * star a) := by rw [← norm_eq_sqrt_norm_inner_self]
     specialize h₁ ⟪x, y⟫
     simp only [star_inner, sub_self, zero_sub, le_neg_add_iff_add_le, add_zero] at h₁

--- a/Mathlib/Analysis/Complex/AbelLimit.lean
+++ b/Mathlib/Analysis/Complex/AbelLimit.lean
@@ -70,26 +70,26 @@ theorem nhdsWithin_lt_le_nhdsWithin_stolzSet {M : ℝ} (hM : 1 < M) :
 -- An ugly technical lemma
 private lemma stolzCone_subset_stolzSet_aux' (s : ℝ) :
     ∃ M ε, 0 < M ∧ 0 < ε ∧ ∀ x y, 0 < x → x < ε → |y| < s * x →
-      sqrt (x ^ 2 + y ^ 2) < M * (1 - sqrt ((1 - x) ^ 2 + y ^ 2)) := by
-  refine ⟨2 * sqrt (1 + s ^ 2) + 1, 1 / (1 + s ^ 2), by positivity, by positivity,
+      √(x ^ 2 + y ^ 2) < M * (1 - √((1 - x) ^ 2 + y ^ 2)) := by
+  refine ⟨2 * √(1 + s ^ 2) + 1, 1 / (1 + s ^ 2), by positivity, by positivity,
     fun x y hx₀ hx₁ hy ↦ ?_⟩
-  have H : sqrt ((1 - x) ^ 2 + y ^ 2) ≤ 1 - x / 2 := by
-    calc sqrt ((1 - x) ^ 2 + y ^ 2)
-      _ ≤ sqrt ((1 - x) ^ 2 + (s * x) ^ 2) := sqrt_le_sqrt <| by rw [← sq_abs y]; gcongr
-      _ = sqrt (1 - 2 * x + (1 + s ^ 2) * x * x) := by congr 1; ring
-      _ ≤ sqrt (1 - 2 * x + (1 + s ^ 2) * (1 / (1 + s ^ 2)) * x) := sqrt_le_sqrt <| by gcongr
-      _ = sqrt (1 - x) := by congr 1; field_simp; ring
+  have H : √((1 - x) ^ 2 + y ^ 2) ≤ 1 - x / 2 := by
+    calc √((1 - x) ^ 2 + y ^ 2)
+      _ ≤ √((1 - x) ^ 2 + (s * x) ^ 2) := sqrt_le_sqrt <| by rw [← sq_abs y]; gcongr
+      _ = √(1 - 2 * x + (1 + s ^ 2) * x * x) := by congr 1; ring
+      _ ≤ √(1 - 2 * x + (1 + s ^ 2) * (1 / (1 + s ^ 2)) * x) := by gcongr
+      _ = √(1 - x) := by congr 1; field_simp; ring
       _ ≤ 1 - x / 2 := by
         simp_rw [sub_eq_add_neg, ← neg_div]
         refine sqrt_one_add_le <| neg_le_neg_iff.mpr (hx₁.trans_le ?_).le
         rw [div_le_one (by positivity)]
         exact le_add_of_nonneg_right <| sq_nonneg s
-  calc sqrt (x ^ 2 + y ^ 2)
-    _ ≤ sqrt (x ^ 2 + (s * x) ^ 2) := sqrt_le_sqrt <| by rw [← sq_abs y]; gcongr
-    _ = sqrt ((1 + s ^ 2) * x ^ 2) := by congr; ring
-    _ = sqrt (1 + s ^ 2) * x := by rw [sqrt_mul' _ (sq_nonneg x), sqrt_sq hx₀.le]
-    _ = 2 * sqrt (1 + s ^ 2) * (x / 2) := by ring
-    _ < (2 * sqrt (1 + s ^ 2) + 1) * (x / 2) := by gcongr; exact lt_add_one _
+  calc √(x ^ 2 + y ^ 2)
+    _ ≤ √(x ^ 2 + (s * x) ^ 2) := by rw [← sq_abs y]; gcongr
+    _ = √((1 + s ^ 2) * x ^ 2) := by congr; ring
+    _ = √(1 + s ^ 2) * x := by rw [sqrt_mul' _ (sq_nonneg x), sqrt_sq hx₀.le]
+    _ = 2 * √(1 + s ^ 2) * (x / 2) := by ring
+    _ < (2 * √(1 + s ^ 2) + 1) * (x / 2) := by gcongr; exact lt_add_one _
     _ ≤ _ := by gcongr; exact le_sub_comm.mpr H
 
 lemma stolzCone_subset_stolzSet_aux {s : ℝ} (hs : 0 < s) :

--- a/Mathlib/Analysis/InnerProductSpace/Basic.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Basic.lean
@@ -620,7 +620,7 @@ theorem dist_div_norm_sq_smul {x y : F} (hx : x ≠ 0) (hy : y ≠ 0) (R : ℝ) 
         √(‖(R / ‖x‖) ^ 2 • x - (R / ‖y‖) ^ 2 • y‖ ^ 2) := by
       rw [dist_eq_norm, sqrt_sq (norm_nonneg _)]
     _ = √((R ^ 2 / (‖x‖ * ‖y‖)) ^ 2 * ‖x - y‖ ^ 2) :=
-      congr_arg sqrt <| by
+      congr_arg (√·) <| by
         field_simp [sq, norm_sub_mul_self_real, norm_smul, real_inner_smul_left, inner_smul_right,
           Real.norm_of_nonneg (mul_self_nonneg _)]
         ring

--- a/Mathlib/Analysis/SpecialFunctions/ContinuousFunctionalCalculus/Rpow/Isometric.lean
+++ b/Mathlib/Analysis/SpecialFunctions/ContinuousFunctionalCalculus/Rpow/Isometric.lean
@@ -43,7 +43,7 @@ lemma nnnorm_sqrt (a : A) (ha : 0 ≤ a := by cfc_tac) : ‖sqrt a‖₊ = NNRea
   rw [sqrt_eq_nnrpow, NNReal.sqrt_eq_rpow]
   exact nnnorm_nnrpow a (by norm_num) ha
 
-lemma norm_sqrt (a : A) (ha : 0 ≤ a := by cfc_tac) : ‖sqrt a‖ = Real.sqrt ‖a‖ := by
+lemma norm_sqrt (a : A) (ha : 0 ≤ a := by cfc_tac) : ‖sqrt a‖ = √‖a‖ := by
   simpa using congr(NNReal.toReal $(nnnorm_sqrt a ha))
 
 end nonunital

--- a/Mathlib/Analysis/SpecialFunctions/MulExpNegMulSq.lean
+++ b/Mathlib/Analysis/SpecialFunctions/MulExpNegMulSq.lean
@@ -117,9 +117,9 @@ theorem lipschitzWith_one_mulExpNegMulSq (hε : 0 < ε) :
   exact nnnorm_deriv_mulExpNegMulSq_le_one hε
 
 theorem mulExpNegMulSq_eq_sqrt_mul_mulExpNegMulSq_one (hε : 0 < ε) (x : ℝ) :
-    mulExpNegMulSq ε x = (sqrt ε)⁻¹ * mulExpNegMulSq 1 (sqrt ε * x) := by
+    mulExpNegMulSq ε x = (√ε)⁻¹ * mulExpNegMulSq 1 (sqrt ε * x) := by
   simp only [mulExpNegMulSq, one_mul]
-  have h : sqrt ε * x * (sqrt ε * x) = ε * x * x := by
+  have h : √ε * x * (√ε * x) = ε * x * x := by
     ring_nf
     rw [sq_sqrt hε.le, mul_comm]
   rw [h, eq_inv_mul_iff_mul_eq₀ _]
@@ -128,16 +128,15 @@ theorem mulExpNegMulSq_eq_sqrt_mul_mulExpNegMulSq_one (hε : 0 < ε) (x : ℝ) :
     rw [← pow_eq_zero_iff (Ne.symm (Nat.zero_ne_add_one 1)), sq_sqrt hε.le] at h
     linarith
 
-/-- For fixed `ε > 0`, the mapping `x ↦ mulExpNegMulSq ε x` is bounded by `Real.sqrt ε⁻¹ -/
-theorem abs_mulExpNegMulSq_le (hε : 0 < ε) {x : ℝ} : |mulExpNegMulSq ε x| ≤ (sqrt ε)⁻¹ := by
-  rw [mulExpNegMulSq_eq_sqrt_mul_mulExpNegMulSq_one hε x, abs_mul,
-    abs_of_pos (inv_pos.mpr (sqrt_pos_of_pos hε))]
-  nth_rw 2 [← mul_one (sqrt ε)⁻¹]
-  rw [mul_le_mul_left (inv_pos.mpr (sqrt_pos_of_pos hε))]
-  exact abs_mulExpNegMulSq_one_le_one (sqrt ε * x)
+/-- For fixed `ε > 0`, the mapping `x ↦ mulExpNegMulSq ε x` is bounded by `(√ε)⁻¹ -/
+theorem abs_mulExpNegMulSq_le (hε : 0 < ε) {x : ℝ} : |mulExpNegMulSq ε x| ≤ (√ε)⁻¹ := by
+  rw [mulExpNegMulSq_eq_sqrt_mul_mulExpNegMulSq_one hε x, abs_mul, abs_of_pos (by positivity)]
+  apply mul_le_of_le_one_right
+  · positivity
+  · exact abs_mulExpNegMulSq_one_le_one (√ε * x)
 
 theorem dist_mulExpNegMulSq_le_two_mul_sqrt (hε : 0 < ε) (x y : ℝ) :
-    dist (mulExpNegMulSq ε x) (mulExpNegMulSq ε y) ≤ 2 * (sqrt ε)⁻¹ := by
+    dist (mulExpNegMulSq ε x) (mulExpNegMulSq ε y) ≤ 2 * (√ε)⁻¹ := by
   apply le_trans (dist_triangle (mulExpNegMulSq ε x) 0 (mulExpNegMulSq ε y))
   simp only [dist_zero_right, norm_eq_abs, dist_zero_left, two_mul]
   exact add_le_add (abs_mulExpNegMulSq_le hε) (abs_mulExpNegMulSq_le hε)

--- a/Mathlib/Analysis/SpecialFunctions/MulExpNegMulSqIntegral.lean
+++ b/Mathlib/Analysis/SpecialFunctions/MulExpNegMulSqIntegral.lean
@@ -32,7 +32,7 @@ contains results on the integral of `mulExpNegMulSq g ε` with respect to a fini
 
 `dist_integral_mulExpNegMulSq_comp_le`: For a subalgebra of functions `A`, if for any `g ∈ A` the
 integral with respect to two finite measures `P, P'` coincide, then the difference of the integrals
-of `mulExpNegMulSq ε ∘ g` with respect to `P, P'` is bounded by `6 * sqrt ε`.
+of `mulExpNegMulSq ε ∘ g` with respect to `P, P'` is bounded by `6 * √ε`.
 This is a key ingredient in the proof of theorem `ext_of_forall_mem_subalgebra_integral_eq`, where
 it is shown that a subalgebra of functions that separates points separates finite measures.
 -/
@@ -46,7 +46,7 @@ variable {E : Type*} [TopologicalSpace E] [MeasurableSpace E] [BorelSpace E]
 
 theorem integrable_mulExpNegMulSq_comp (f : C(E, ℝ)) (hε : 0 < ε) :
     Integrable (fun x => mulExpNegMulSq ε (f x)) P := by
-  apply integrable P ⟨⟨fun x => mulExpNegMulSq ε (f x), by fun_prop⟩, ⟨2 * (sqrt ε)⁻¹, _⟩⟩
+  apply integrable P ⟨⟨fun x => mulExpNegMulSq ε (f x), by fun_prop⟩, ⟨2 * (√ε)⁻¹, _⟩⟩
   exact fun x y => dist_mulExpNegMulSq_le_two_mul_sqrt hε (f x) (f y)
 
 theorem integrable_mulExpNegMulSq_comp_restrict_of_isCompact {K : Set E} (hK : IsCompact K)
@@ -129,7 +129,7 @@ theorem integral_mulExpNegMulSq_comp_eq {P' : Measure E} [IsFiniteMeasure P']
 
 theorem abs_integral_sub_setIntegral_mulExpNegMulSq_comp_lt (f : C(E, ℝ))
     {K : Set E} (hK : MeasurableSet K) (hε : 0 < ε) (hKP : P Kᶜ < ε.toNNReal) :
-    |∫ x, mulExpNegMulSq ε (f x) ∂P - ∫ x in K, mulExpNegMulSq ε (f x) ∂P| < sqrt ε := by
+    |∫ x, mulExpNegMulSq ε (f x) ∂P - ∫ x in K, mulExpNegMulSq ε (f x) ∂P| < √ε := by
   apply lt_of_le_of_lt (norm_integral_sub_setIntegral_le
     (Eventually.of_forall (fun _ => abs_mulExpNegMulSq_le hε)) hK
     (integrable_mulExpNegMulSq_comp f hε))
@@ -152,11 +152,11 @@ variable {E : Type*} [MeasurableSpace E] [PseudoEMetricSpace E] [BorelSpace E] [
 
 /-- If for any `g ∈ A` the integrals with respect to two finite measures `P, P'` coincide, then the
 difference of the integrals of `mulExpNegMulSq ε ∘ g` with respect to `P, P'` is bounded by
-`6 * sqrt ε`. -/
+`6 * √ε`. -/
 theorem dist_integral_mulExpNegMulSq_comp_le (f : E →ᵇ ℝ)
     {A : Subalgebra ℝ (E →ᵇ ℝ)} (hA : (A.map (toContinuousMapₐ ℝ)).SeparatesPoints)
     (heq : ∀ g ∈ A, ∫ x, (g : E → ℝ) x ∂P = ∫ x, (g : E → ℝ) x ∂P') (hε : 0 < ε) :
-    |∫ x, mulExpNegMulSq ε (f x) ∂P - ∫ x, mulExpNegMulSq ε (f x) ∂P'| ≤ 6 * sqrt ε := by
+    |∫ x, mulExpNegMulSq ε (f x) ∂P - ∫ x, mulExpNegMulSq ε (f x) ∂P'| ≤ 6 * √ε := by
   -- if both measures are zero, the result is trivial
   by_cases hPP' : P = 0 ∧ P' = 0
   · simp only [hPP', integral_zero_measure, sub_self, abs_zero, gt_iff_lt, Nat.ofNat_pos,
@@ -190,30 +190,30 @@ theorem dist_integral_mulExpNegMulSq_comp_le (f : E →ᵇ ℝ)
   simp only [Subalgebra.mem_map] at hg'A
   let g := hg'A.choose
   have hgA : g ∈ A := hg'A.choose_spec.1
-  have hgapprox : ∀ x ∈ K, ‖g x - f x‖ < sqrt ε * const⁻¹ := by
+  have hgapprox : ∀ x ∈ K, ‖g x - f x‖ < √ε * const⁻¹ := by
     rw [← coe_toContinuousMapₐ ℝ g, hg'A.choose_spec.2]
     exact hg'approx
   -- collect the results needed in the decomposition at the end of the proof
   have line1 : |∫ x, mulExpNegMulSq ε (f x) ∂P
-      - ∫ x in K, mulExpNegMulSq ε (f x) ∂P| < sqrt ε :=
+      - ∫ x in K, mulExpNegMulSq ε (f x) ∂P| < √ε :=
     abs_integral_sub_setIntegral_mulExpNegMulSq_comp_lt
       f (IsClosed.measurableSet hKcl) hε hKPbound
   have line3 : |∫ x in K, mulExpNegMulSq ε (g x) ∂P
-      - ∫ x, mulExpNegMulSq ε (g x) ∂P| < sqrt ε := by
+      - ∫ x, mulExpNegMulSq ε (g x) ∂P| < √ε := by
     rw [abs_sub_comm]
     exact (abs_integral_sub_setIntegral_mulExpNegMulSq_comp_lt
       g (IsClosed.measurableSet hKcl) hε hKPbound)
   have line5 : |∫ x, mulExpNegMulSq ε (g x) ∂P'
-      - ∫ x in K, mulExpNegMulSq ε (g x) ∂P'| < sqrt ε :=
+      - ∫ x in K, mulExpNegMulSq ε (g x) ∂P'| < √ε :=
     (abs_integral_sub_setIntegral_mulExpNegMulSq_comp_lt
       g (IsClosed.measurableSet hKcl) hε hKP'bound)
   have line7 : |∫ x in K, mulExpNegMulSq ε (f x) ∂P'
-      - ∫ x, mulExpNegMulSq ε (f x) ∂P'| < sqrt ε := by
+      - ∫ x, mulExpNegMulSq ε (f x) ∂P'| < √ε := by
     rw [abs_sub_comm]
     exact (abs_integral_sub_setIntegral_mulExpNegMulSq_comp_lt
       f (IsClosed.measurableSet hKcl) hε hKP'bound)
   have line2 : |∫ x in K, mulExpNegMulSq ε (f x) ∂P
-      - ∫ x in K, mulExpNegMulSq ε (g x) ∂P| ≤ sqrt ε := by
+      - ∫ x in K, mulExpNegMulSq ε (g x) ∂P| ≤ √ε := by
     rw [abs_sub_comm]
     apply le_trans (abs_setIntegral_mulExpNegMulSq_comp_sub_le_mul_measure hKco
       (IsClosed.measurableSet hKcl) f g hε hgapprox)
@@ -223,7 +223,7 @@ theorem dist_integral_mulExpNegMulSq_comp_le (f : E →ᵇ ℝ)
     exact (toReal_le_toReal (measure_ne_top P _) (measure_ne_top P _)).mpr
         (measure_mono (Set.subset_univ _))
   have line6 : |∫ x in K, mulExpNegMulSq ε (g x) ∂P'
-      - ∫ x in K, mulExpNegMulSq ε (f x) ∂P'| ≤ sqrt ε := by
+      - ∫ x in K, mulExpNegMulSq ε (f x) ∂P'| ≤ √ε := by
     apply le_trans (abs_setIntegral_mulExpNegMulSq_comp_sub_le_mul_measure hKco
       (IsClosed.measurableSet hKcl) f g hε hgapprox)
     rw [mul_assoc]
@@ -245,4 +245,4 @@ theorem dist_integral_mulExpNegMulSq_comp_le (f : E →ᵇ ℝ)
       + |∫ x in K, mulExpNegMulSq ε (g x) ∂P' - ∫ x in K, mulExpNegMulSq ε (f x) ∂P'|
       + |∫ x in K, mulExpNegMulSq ε (f x) ∂P' - ∫ x, mulExpNegMulSq ε (f x) ∂P'| :=
         @dist_triangle8 ℝ _ _ _ _ _ _ _ _ _
-  _ ≤ 6 * sqrt ε := by linarith
+  _ ≤ 6 * √ε := by linarith

--- a/Mathlib/Analysis/SpecialFunctions/Pow/Asymptotics.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Pow/Asymptotics.lean
@@ -246,11 +246,11 @@ theorem IsLittleO.rpow (hr : 0 < r) (hg : 0 ≤ᶠ[l] g) (h : f =o[l] g) :
   refine (h.forall_isBigOWith ?_).rpow ?_ ?_ hg <;> positivity
 
 protected lemma IsBigO.sqrt (hfg : f =O[l] g) (hg : 0 ≤ᶠ[l] g) :
-    (Real.sqrt <| f ·) =O[l] (Real.sqrt <| g ·) := by
+    (fun x ↦ √(f x)) =O[l] (fun x ↦ √(g x)) := by
   simpa [Real.sqrt_eq_rpow] using hfg.rpow one_half_pos.le hg
 
 protected lemma IsLittleO.sqrt (hfg : f =o[l] g) (hg : 0 ≤ᶠ[l] g) :
-    (Real.sqrt <| f ·) =o[l] (Real.sqrt <| g ·) := by
+    (fun x ↦ √(f x)) =o[l] (fun x ↦ √(g x)) := by
   simpa [Real.sqrt_eq_rpow] using hfg.rpow one_half_pos hg
 
 protected lemma IsTheta.sqrt (hfg : f =Θ[l] g) (hf : 0 ≤ᶠ[l] f) (hg : 0 ≤ᶠ[l] g) :

--- a/Mathlib/Analysis/SpecialFunctions/Pow/Real.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Pow/Real.lean
@@ -995,13 +995,13 @@ end Real
 
 namespace Complex
 
-lemma cpow_inv_two_re (x : ℂ) : (x ^ (2⁻¹ : ℂ)).re = sqrt ((‖x‖ + x.re) / 2) := by
+lemma cpow_inv_two_re (x : ℂ) : (x ^ (2⁻¹ : ℂ)).re = √((‖x‖ + x.re) / 2) := by
   rw [← ofReal_ofNat, ← ofReal_inv, cpow_ofReal_re, ← div_eq_mul_inv, ← one_div,
     ← Real.sqrt_eq_rpow, cos_half, ← sqrt_mul, ← mul_div_assoc, mul_add, mul_one, norm_mul_cos_arg]
   exacts [norm_nonneg _, (neg_pi_lt_arg _).le, arg_le_pi _]
 
 lemma cpow_inv_two_im_eq_sqrt {x : ℂ} (hx : 0 ≤ x.im) :
-    (x ^ (2⁻¹ : ℂ)).im = sqrt ((‖x‖ - x.re) / 2) := by
+    (x ^ (2⁻¹ : ℂ)).im = √((‖x‖ - x.re) / 2) := by
   rw [← ofReal_ofNat, ← ofReal_inv, cpow_ofReal_im, ← div_eq_mul_inv, ← one_div,
     ← Real.sqrt_eq_rpow, sin_half_eq_sqrt, ← sqrt_mul (norm_nonneg _), ← mul_div_assoc, mul_sub,
     mul_one, norm_mul_cos_arg]
@@ -1009,14 +1009,14 @@ lemma cpow_inv_two_im_eq_sqrt {x : ℂ} (hx : 0 ≤ x.im) :
   · linarith [pi_pos, arg_le_pi x]
 
 lemma cpow_inv_two_im_eq_neg_sqrt {x : ℂ} (hx : x.im < 0) :
-    (x ^ (2⁻¹ : ℂ)).im = -sqrt ((‖x‖ - x.re) / 2) := by
+    (x ^ (2⁻¹ : ℂ)).im = -√((‖x‖ - x.re) / 2) := by
   rw [← ofReal_ofNat, ← ofReal_inv, cpow_ofReal_im, ← div_eq_mul_inv, ← one_div,
     ← Real.sqrt_eq_rpow, sin_half_eq_neg_sqrt, mul_neg, ← sqrt_mul (norm_nonneg _),
     ← mul_div_assoc, mul_sub, mul_one, norm_mul_cos_arg]
   · linarith [pi_pos, neg_pi_lt_arg x]
   · exact (arg_neg_iff.2 hx).le
 
-lemma abs_cpow_inv_two_im (x : ℂ) : |(x ^ (2⁻¹ : ℂ)).im| = sqrt ((‖x‖ - x.re) / 2) := by
+lemma abs_cpow_inv_two_im (x : ℂ) : |(x ^ (2⁻¹ : ℂ)).im| = √((‖x‖ - x.re) / 2) := by
   rw [← ofReal_ofNat, ← ofReal_inv, cpow_ofReal_im, ← div_eq_mul_inv, ← one_div,
     ← Real.sqrt_eq_rpow, abs_mul, abs_of_nonneg (sqrt_nonneg _), abs_sin_half,
     ← sqrt_mul (norm_nonneg _), ← mul_div_assoc, mul_sub, mul_one, norm_mul_cos_arg]

--- a/Mathlib/Analysis/SpecialFunctions/Trigonometric/Basic.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Trigonometric/Basic.lean
@@ -464,20 +464,20 @@ theorem cos_eq_sqrt_one_sub_sin_sq {x : ℝ} (hl : -(π / 2) ≤ x) (hu : x ≤ 
     cos x = √(1 - sin x ^ 2) := by
   rw [← abs_cos_eq_sqrt_one_sub_sin_sq, abs_of_nonneg (cos_nonneg_of_mem_Icc ⟨hl, hu⟩)]
 
-lemma cos_half {x : ℝ} (hl : -π ≤ x) (hr : x ≤ π) : cos (x / 2) = sqrt ((1 + cos x) / 2) := by
+lemma cos_half {x : ℝ} (hl : -π ≤ x) (hr : x ≤ π) : cos (x / 2) = √((1 + cos x) / 2) := by
   have : 0 ≤ cos (x / 2) := cos_nonneg_of_mem_Icc <| by constructor <;> linarith
   rw [← sqrt_sq this, cos_sq, add_div, two_mul, add_halves]
 
-lemma abs_sin_half (x : ℝ) : |sin (x / 2)| = sqrt ((1 - cos x) / 2) := by
+lemma abs_sin_half (x : ℝ) : |sin (x / 2)| = √((1 - cos x) / 2) := by
   rw [← sqrt_sq_eq_abs, sin_sq_eq_half_sub, two_mul, add_halves, sub_div]
 
 lemma sin_half_eq_sqrt {x : ℝ} (hl : 0 ≤ x) (hr : x ≤ 2 * π) :
-    sin (x / 2) = sqrt ((1 - cos x) / 2) := by
+    sin (x / 2) = √((1 - cos x) / 2) := by
   rw [← abs_sin_half, abs_of_nonneg]
   apply sin_nonneg_of_nonneg_of_le_pi <;> linarith
 
 lemma sin_half_eq_neg_sqrt {x : ℝ} (hl : -(2 * π) ≤ x) (hr : x ≤ 0) :
-    sin (x / 2) = -sqrt ((1 - cos x) / 2) := by
+    sin (x / 2) = -√((1 - cos x) / 2) := by
   rw [← abs_sin_half, abs_of_nonpos, neg_neg]
   apply sin_nonpos_of_nonnpos_of_neg_pi_le <;> linarith
 
@@ -857,12 +857,12 @@ theorem tan_pi_div_four : tan (π / 4) = 1 := by
 theorem tan_pi_div_two : tan (π / 2) = 0 := by simp [tan_eq_sin_div_cos]
 
 @[simp]
-theorem tan_pi_div_six : tan (π / 6) = 1 / sqrt 3 := by
+theorem tan_pi_div_six : tan (π / 6) = 1 / √3 := by
   rw [tan_eq_sin_div_cos, sin_pi_div_six, cos_pi_div_six]
   ring
 
 @[simp]
-theorem tan_pi_div_three : tan (π / 3) = sqrt 3 := by
+theorem tan_pi_div_three : tan (π / 3) = √3 := by
   rw [tan_eq_sin_div_cos, sin_pi_div_three, cos_pi_div_three]
   ring
 

--- a/Mathlib/Analysis/SpecialFunctions/Trigonometric/Bounds.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Trigonometric/Bounds.lean
@@ -202,7 +202,7 @@ theorem le_tan {x : ℝ} (h1 : 0 ≤ x) (h2 : x < π / 2) : x ≤ tan x := by
 
 theorem cos_lt_one_div_sqrt_sq_add_one {x : ℝ} (hx1 : -(3 * π / 2) ≤ x) (hx2 : x ≤ 3 * π / 2)
     (hx3 : x ≠ 0) : cos x < (1 / √(x ^ 2 + 1) : ℝ) := by
-  suffices ∀ {y : ℝ}, 0 < y → y ≤ 3 * π / 2 → cos y < 1 / sqrt (y ^ 2 + 1) by
+  suffices ∀ {y : ℝ}, 0 < y → y ≤ 3 * π / 2 → cos y < 1 / √(y ^ 2 + 1) by
     rcases lt_or_lt_iff_ne.mpr hx3.symm with ⟨h⟩
     · exact this h hx2
     · convert this (by linarith : 0 < -x) (by linarith) using 1

--- a/Mathlib/Combinatorics/Extremal/RuzsaSzemeredi.lean
+++ b/Mathlib/Combinatorics/Extremal/RuzsaSzemeredi.lean
@@ -22,7 +22,7 @@ original set.
 * `ruzsaSzemerediNumberNat n`: Maximum number of edges a graph on `n` vertices can have such that
   each edge belongs to exactly one triangle.
 * `ruzsaSzemerediNumberNat_asymptotic_lower_bound`: There exists a graph with `n` vertices and
-  `Ω((n ^ 2 * exp (-4 * sqrt (log n))))` edges such that each edge belongs to exactly one triangle.
+  `Ω((n ^ 2 * exp (-4 * √(log n))))` edges such that each edge belongs to exactly one triangle.
 -/
 
 open Finset Nat Real SimpleGraph Sum3 SimpleGraph.TripartiteFromTriangles
@@ -219,10 +219,10 @@ theorem rothNumberNat_le_ruzsaSzemerediNumberNat' :
 /-- Explicit lower bound on the **Ruzsa-Szemerédi problem**.
 
 There exists a graph with `n` vertices and
-`(n / 3 - 2) * (n - 3) / 6 * exp (-4 * sqrt (log ((n - 3) / 6)))` edges such that each edge belongs
+`(n / 3 - 2) * (n - 3) / 6 * exp (-4 * √(log ((n - 3) / 6)))` edges such that each edge belongs
 to exactly one triangle. -/
 theorem ruzsaSzemerediNumberNat_lower_bound (n : ℕ) :
-    (n / 3 - 2 : ℝ) * ↑((n - 3) / 6) * exp (-4 * sqrt (log ↑((n - 3) / 6))) ≤
+    (n / 3 - 2 : ℝ) * ↑((n - 3) / 6) * exp (-4 * √(log ↑((n - 3) / 6))) ≤
       ruzsaSzemerediNumberNat n := by
   rw [mul_assoc]
   obtain hn | hn := le_total (n / 3 - 2 : ℝ) 0
@@ -235,12 +235,12 @@ open Asymptotics Filter
 
 /-- Asymptotic lower bound on the **Ruzsa-Szemerédi problem**.
 
-There exists a graph with `n` vertices and `Ω((n ^ 2 * exp (-4 * sqrt (log n))))` edges such that
+There exists a graph with `n` vertices and `Ω((n ^ 2 * exp (-4 * √(log n))))` edges such that
 each edge belongs to exactly one triangle. -/
 theorem ruzsaSzemerediNumberNat_asymptotic_lower_bound :
-   (fun n ↦ n ^ 2 * exp (-4 * sqrt (log n)) : ℕ → ℝ) =O[atTop]
+   (fun n ↦ n ^ 2 * exp (-4 * √(log n)) : ℕ → ℝ) =O[atTop]
      fun n ↦ (ruzsaSzemerediNumberNat n : ℝ) := by
-  trans fun n ↦ (n / 3 - 2) * ↑((n - 3) / 6) * exp (-4 * sqrt (log ↑((n - 3) / 6)))
+  trans fun n ↦ (n / 3 - 2) * ↑((n - 3) / 6) * exp (-4 * √(log ↑((n - 3) / 6)))
   · simp_rw [sq]
     refine (IsBigO.mul ?_ ?_).mul ?_
     · trans fun n ↦ n / 3

--- a/Mathlib/Data/Complex/Norm.lean
+++ b/Mathlib/Data/Complex/Norm.lean
@@ -19,9 +19,9 @@ namespace Complex
 variable {z : ℂ}
 
 instance instNorm : Norm ℂ where
-  norm z := Real.sqrt (normSq z)
+  norm z := √(normSq z)
 
-theorem norm_def (z : ℂ) : ‖z‖ = Real.sqrt (normSq z) := rfl
+theorem norm_def (z : ℂ) : ‖z‖ = √(normSq z) := rfl
 
 theorem norm_mul_self_eq_normSq (z : ℂ) : ‖z‖ * ‖z‖ = normSq z :=
   Real.mul_self_sqrt (normSq_nonneg _)
@@ -179,10 +179,10 @@ theorem sq_norm_sub_sq_re (z : ℂ) : ‖z‖ ^ 2 - z.re ^ 2 = z.im ^ 2 := by
 theorem sq_norm_sub_sq_im (z : ℂ) : ‖z‖ ^ 2 - z.im ^ 2 = z.re ^ 2 := by
   rw [← sq_norm_sub_sq_re, sub_sub_cancel]
 
-lemma norm_add_mul_I (x y : ℝ) : ‖x + y * I‖ = (x ^ 2 + y ^ 2).sqrt := by
+lemma norm_add_mul_I (x y : ℝ) : ‖x + y * I‖ = √(x ^ 2 + y ^ 2) := by
   rw [← normSq_add_mul_I]; rfl
 
-lemma norm_eq_sqrt_sq_add_sq (z : ℂ) : ‖z‖ = (z.re ^ 2 + z.im ^ 2).sqrt := by
+lemma norm_eq_sqrt_sq_add_sq (z : ℂ) : ‖z‖ = √(z.re ^ 2 + z.im ^ 2) := by
   rw [norm_def, normSq_apply, sq, sq]
 
 @[deprecated (since := "2025-02-16")] alias normSq_eq_abs := normSq_eq_norm_sq
@@ -201,7 +201,7 @@ protected theorem range_norm : range (‖·‖ : ℂ → ℝ) = Set.Ici 0 :=
 @[simp]
 theorem range_normSq : range normSq = Ici 0 :=
   Subset.antisymm (range_subset_iff.2 normSq_nonneg) fun x hx =>
-    ⟨Real.sqrt x, by rw [normSq_ofReal, Real.mul_self_sqrt hx]⟩
+    ⟨√x, by rw [normSq_ofReal, Real.mul_self_sqrt hx]⟩
 
 theorem norm_le_abs_re_add_abs_im (z : ℂ) : ‖z‖ ≤ |z.re| + |z.im| := by
     simpa [re_add_im] using norm_add_le (z.re : ℂ) (z.im * I)
@@ -240,22 +240,17 @@ lemma abs_im_eq_norm {z : ℂ} : |z.im| = ‖z‖ ↔ z.re = 0 :=
 @[deprecated (since := "2025-02-16")] alias abs_re_eq_abs := abs_re_eq_norm
 @[deprecated (since := "2025-02-16")] alias abs_im_eq_abs := abs_im_eq_norm
 
-theorem norm_le_sqrt_two_mul_max (z : ℂ) : ‖z‖ ≤ Real.sqrt 2 * max |z.re| |z.im| := by
+theorem norm_le_sqrt_two_mul_max (z : ℂ) : ‖z‖ ≤ √2 * max |z.re| |z.im| := by
   obtain ⟨x, y⟩ := z
   simp only [norm_def, normSq_mk, norm_def, ← sq]
-  by_cases hle : |x| ≤ |y|
-  · calc
-      Real.sqrt (x ^ 2 + y ^ 2) ≤ Real.sqrt (y ^ 2 + y ^ 2) :=
-        Real.sqrt_le_sqrt (add_le_add_right (sq_le_sq.2 hle) _)
-      _ = Real.sqrt 2 * max |x| |y| := by
-        rw [max_eq_right hle, ← two_mul, Real.sqrt_mul two_pos.le, Real.sqrt_sq_eq_abs]
-  · have hle' := le_of_not_le hle
-    rw [add_comm]
-    calc
-      Real.sqrt (y ^ 2 + x ^ 2) ≤ Real.sqrt (x ^ 2 + x ^ 2) :=
-        Real.sqrt_le_sqrt (add_le_add_right (sq_le_sq.2 hle') _)
-      _ = Real.sqrt 2 * max |x| |y| := by
-        rw [max_eq_left hle', ← two_mul, Real.sqrt_mul two_pos.le, Real.sqrt_sq_eq_abs]
+  set m := max |x| |y|
+  have hm₀ : 0 ≤ m := by positivity
+  calc
+    √(x ^ 2 + y ^ 2) ≤ √(m ^ 2 + m ^ 2) := by
+      gcongr √(?_ + ?_) <;> rw [sq_le_sq, abs_of_nonneg hm₀]
+      exacts [le_max_left _ _, le_max_right _ _]
+    _ = √2 * m := by
+      rw [← two_mul, Real.sqrt_mul, Real.sqrt_sq] <;> positivity
 
 theorem abs_re_div_norm_le_one (z : ℂ) : |z.re / ‖z‖| ≤ 1 :=
  if hz : z = 0 then by simp [hz, zero_le_one]

--- a/Mathlib/Data/Real/GoldenRatio.lean
+++ b/Mathlib/Data/Real/GoldenRatio.lean
@@ -99,7 +99,7 @@ theorem one_lt_gold : 1 < φ := by
   simp [← sq, gold_pos, zero_lt_one]
 
 theorem gold_lt_two : φ < 2 := by calc
-  (1 + sqrt 5) / 2 < (1 + 3) / 2 := by gcongr; rw [sqrt_lt'] <;> norm_num
+  (1 + √5) / 2 < (1 + 3) / 2 := by gcongr; rw [sqrt_lt'] <;> norm_num
   _ = 2 := by norm_num
 
 theorem goldConj_neg : ψ < 0 := by
@@ -208,7 +208,7 @@ theorem fib_golden_conj_exp (n : ℕ) : Nat.fib (n + 1) - φ * Nat.fib n = ψ ^ 
   repeat rw [coe_fib_eq]
   rw [mul_div, div_sub_div_same, mul_sub, ← pow_succ']
   ring_nf
-  have nz : sqrt 5 ≠ 0 := by norm_num
+  have nz : √5 ≠ 0 := by norm_num
   rw [← (mul_inv_cancel₀ nz).symm, one_mul]
 
 /-- Relationship between the Fibonacci Sequence, Golden Ratio and its exponents -/

--- a/Mathlib/LinearAlgebra/Matrix/PosDef.lean
+++ b/Mathlib/LinearAlgebra/Matrix/PosDef.lean
@@ -175,7 +175,7 @@ variable [DecidableEq n] {A : Matrix n n 𝕜} (hA : PosSemidef A)
 
 /-- The positive semidefinite square root of a positive semidefinite matrix -/
 noncomputable def sqrt : Matrix n n 𝕜 :=
-  hA.1.eigenvectorUnitary.1 * diagonal ((↑) ∘ Real.sqrt ∘ hA.1.eigenvalues) *
+  hA.1.eigenvectorUnitary.1 * diagonal ((↑) ∘ (√·) ∘ hA.1.eigenvalues) *
   (star hA.1.eigenvectorUnitary : Matrix n n 𝕜)
 
 open Lean PrettyPrinter.Delaborator SubExpr in
@@ -204,7 +204,7 @@ lemma posSemidef_sqrt : PosSemidef hA.sqrt := by
 @[simp]
 lemma sq_sqrt : hA.sqrt ^ 2 = A := by
   let C : Matrix n n 𝕜 := hA.1.eigenvectorUnitary
-  let E := diagonal ((↑) ∘ Real.sqrt ∘ hA.1.eigenvalues : n → 𝕜)
+  let E := diagonal ((↑) ∘ (√·) ∘ hA.1.eigenvalues : n → 𝕜)
   suffices C * (E * (star C * C) * E) * star C = A by
     rw [Matrix.PosSemidef.sqrt, pow_two]
     simpa only [← mul_assoc] using this

--- a/Mathlib/MeasureTheory/Measure/FiniteMeasureExt.lean
+++ b/Mathlib/MeasureTheory/Measure/FiniteMeasureExt.lean
@@ -48,7 +48,7 @@ theorem ext_of_forall_mem_subalgebra_integral_eq_of_pseudoEMetric_complete_count
     exact heq _ hgA_toReal
   apply ext_of_forall_integral_eq_of_IsFiniteMeasure
   intro f
-  have h0 : Tendsto (fun ε : ℝ => 6 * sqrt ε) (𝓝[>] 0) (𝓝 0) := by
+  have h0 : Tendsto (fun ε : ℝ => 6 * √ε) (𝓝[>] 0) (𝓝 0) := by
     nth_rewrite 3 [← mul_zero 6]
     apply tendsto_nhdsWithin_of_tendsto_nhds (Tendsto.const_mul 6 _)
     nth_rewrite 2 [← sqrt_zero]

--- a/Mathlib/MeasureTheory/Measure/Lebesgue/VolumeOfBalls.lean
+++ b/Mathlib/MeasureTheory/Measure/Lebesgue/VolumeOfBalls.lean
@@ -322,12 +322,12 @@ open Fintype Real MeasureTheory MeasureTheory.Measure ENNReal
 
 theorem volume_ball (x : EuclideanSpace ℝ ι) (r : ℝ) :
     volume (Metric.ball x r) = (.ofReal r) ^ card ι *
-      .ofReal (Real.sqrt π ^ card ι / Gamma (card ι / 2 + 1)) := by
+      .ofReal (√π ^ card ι / Gamma (card ι / 2 + 1)) := by
   obtain hr | hr := le_total r 0
   · rw [Metric.ball_eq_empty.mpr hr, measure_empty, ← zero_eq_ofReal.mpr hr, zero_pow card_ne_zero,
       zero_mul]
   · suffices volume (Metric.ball (0 : EuclideanSpace ℝ ι) 1) =
-        .ofReal (Real.sqrt π ^ card ι / Gamma (card ι / 2 + 1)) by
+        .ofReal (√π ^ card ι / Gamma (card ι / 2 + 1)) by
       rw [Measure.addHaar_ball _ _ hr, this, ofReal_pow hr, finrank_euclideanSpace]
     rw [← ((volume_preserving_measurableEquiv _).symm).measure_preimage
       measurableSet_ball.nullMeasurableSet]
@@ -339,7 +339,7 @@ theorem volume_ball (x : EuclideanSpace ℝ ι) (r : ℝ) :
 
 theorem volume_closedBall (x : EuclideanSpace ℝ ι) (r : ℝ) :
     volume (Metric.closedBall x r) = (.ofReal r) ^ card ι *
-      .ofReal (sqrt π ^ card ι / Gamma (card ι / 2 + 1)) := by
+      .ofReal (√π ^ card ι / Gamma (card ι / 2 + 1)) := by
   rw [addHaar_closedBall_eq_addHaar_ball, EuclideanSpace.volume_ball]
 
 end EuclideanSpace
@@ -358,7 +358,7 @@ variable [Nontrivial E]
 
 theorem volume_ball (x : E) (r : ℝ) :
     volume (Metric.ball x r) = (.ofReal r) ^ finrank ℝ E *
-      .ofReal (sqrt π ^ finrank ℝ E / Gamma (finrank ℝ E / 2 + 1)) := by
+      .ofReal (√π ^ finrank ℝ E / Gamma (finrank ℝ E / 2 + 1)) := by
   rw [← ((stdOrthonormalBasis ℝ E).measurePreserving_repr_symm).measure_preimage
       measurableSet_ball.nullMeasurableSet]
   have : Nonempty (Fin (finrank ℝ E)) := Fin.pos_iff_nonempty.mp finrank_pos
@@ -369,7 +369,7 @@ theorem volume_ball (x : E) (r : ℝ) :
 
 theorem volume_closedBall (x : E) (r : ℝ) :
     volume (Metric.closedBall x r) = (.ofReal r) ^ finrank ℝ E *
-      .ofReal (sqrt π ^ finrank ℝ E / Gamma (finrank ℝ E / 2 + 1)) := by
+      .ofReal (√π ^ finrank ℝ E / Gamma (finrank ℝ E / 2 + 1)) := by
   rw [addHaar_closedBall_eq_addHaar_ball, InnerProductSpace.volume_ball _]
 
 lemma volume_ball_of_dim_even {k : ℕ} (hk : finrank ℝ E = 2 * k) (x : E) (r : ℝ) :

--- a/Mathlib/Probability/Distributions/Gaussian.lean
+++ b/Mathlib/Probability/Distributions/Gaussian.lean
@@ -45,7 +45,7 @@ def gaussianPDFReal (μ : ℝ) (v : ℝ≥0) (x : ℝ) : ℝ :=
 
 lemma gaussianPDFReal_def (μ : ℝ) (v : ℝ≥0) :
     gaussianPDFReal μ v =
-      fun x ↦ (Real.sqrt (2 * π * v))⁻¹ * rexp (- (x - μ)^2 / (2 * v)) := rfl
+      fun x ↦ (√(2 * π * v))⁻¹ * rexp (- (x - μ)^2 / (2 * v)) := rfl
 
 @[simp]
 lemma gaussianPDFReal_zero_var (m : ℝ) : gaussianPDFReal m 0 = 0 := by
@@ -138,11 +138,11 @@ lemma gaussianPDFReal_inv_mul {μ : ℝ} {v : ℝ≥0} {c : ℝ} (hc : c ≠ 0) 
   · field_simp
     rw [Real.sqrt_sq_eq_abs]
     ring_nf
-    calc (Real.sqrt ↑v)⁻¹ * (Real.sqrt 2)⁻¹ * (Real.sqrt π)⁻¹
-      = (Real.sqrt ↑v)⁻¹ * (Real.sqrt 2)⁻¹ * (Real.sqrt π)⁻¹ * (|c| * |c|⁻¹) := by
+    calc (√↑v)⁻¹ * (√2)⁻¹ * (√π)⁻¹
+      = (√↑v)⁻¹ * (√2)⁻¹ * (√π)⁻¹ * (|c| * |c|⁻¹) := by
           rw [mul_inv_cancel₀, mul_one]
           simp only [ne_eq, abs_eq_zero, hc, not_false_eq_true]
-    _ = (Real.sqrt ↑v)⁻¹ * (Real.sqrt 2)⁻¹ * (Real.sqrt π)⁻¹ * |c| * |c|⁻¹ := by ring
+    _ = (√↑v)⁻¹ * (√2)⁻¹ * (√π)⁻¹ * |c| * |c|⁻¹ := by ring
   · congr 1
     field_simp
     congr 1

--- a/Mathlib/Topology/ContinuousMap/ContinuousSqrt.lean
+++ b/Mathlib/Topology/ContinuousMap/ContinuousSqrt.lean
@@ -20,7 +20,7 @@ open RCLike in
 noncomputable
 instance (priority := 100) instContinuousSqrtRCLike {𝕜 : Type*} [RCLike 𝕜] :
     ContinuousSqrt 𝕜 where
-  sqrt := ((↑) ∘ Real.sqrt ∘ re ∘ (fun z ↦ z.2 - z.1))
+  sqrt := ((↑) ∘ (√·) ∘ re ∘ (fun z ↦ z.2 - z.1))
   continuousOn_sqrt := by fun_prop
   sqrt_nonneg _ _ := by simp
   sqrt_mul_sqrt x hx := by


### PR DESCRIPTION
Also golf a couple of proofs using `gcongr` and `positivity`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
