### PR TITLE
[Merged by Bors] - fix(file-removed): print with no braces

### DIFF
--- a/.github/workflows/PR_summary.yml
+++ b/.github/workflows/PR_summary.yml
@@ -81,7 +81,7 @@ jobs:
                 oldNew[oldFile]=file
               } END {
                 for(old in oldNew) {
-                  printf(""`%s` was renamed to `%s`\n", old, oldNew[old])
+                  printf("`%s` was renamed to `%s`\n", old, oldNew[old])
                 }
               }' | tee renamed_files.txt
 

--- a/.github/workflows/PR_summary.yml
+++ b/.github/workflows/PR_summary.yml
@@ -64,11 +64,26 @@ jobs:
         git diff --name-only --diff-filter D origin/${{ github.base_ref }}... | tee removed_files.txt
         echo "Checking for renamed files..."
 
-        # Shows the `R`enamed files, in the format
-        # ` rename oldName => newName (100%)`
-        # one per line. The `awk` pipe then prints "`oldName` was renamed to `newName`".
-        git diff --summary --diff-filter=R origin/${{ github.base_ref }}... |
-          awk '{printf("`%s` was renamed to `%s`\n", $2, $4)}' | tee renamed_files.txt
+        # Shows the `R`enamed files, in human readable format
+        # The `awk` pipe
+        # * extracts into an array the old name as the key and the new name as the value
+        # * eventually prints "`oldName` was renamed to `newName`" for each key-value pair.
+        git diff -p --summary --diff-filter=R origin/${{ github.base_ref }}... |
+          awk '
+            /^rename from / {
+                file=$0
+                gsub(/rename from /, "", file)
+                oldFile=file
+              }
+            /^rename to / {
+                file=$0
+                gsub(/rename to /, "", file)
+                oldNew[oldFile]=file
+              } END {
+                for(old in oldNew) {
+                  printf(""`%s` was renamed to `%s`\n", old, oldNew[old])
+                }
+              }' | tee renamed_files.txt
 
     - name: Compute (re)moved files without deprecation
       run: |


### PR DESCRIPTION
[This report](https://github.com/leanprover-community/mathlib4/pull/24675#issuecomment-2862416466) highlighted that `git diff` sometimes adds braces `{}` around paths.

This PR should fix this issue.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
