### PR TITLE
[Merged by Bors] - feat: more `NormSMulClass` instances

### DIFF
--- a/Mathlib/Analysis/Matrix.lean
+++ b/Mathlib/Analysis/Matrix.lean
@@ -17,6 +17,7 @@ In this file we provide the following non-instances for norms on matrices:
   * `Matrix.normedAddCommGroup`
   * `Matrix.normedSpace`
   * `Matrix.isBoundedSMul`
+  * `Matrix.normSMulClass`
 
 * The Frobenius norm:
 
@@ -26,6 +27,7 @@ In this file we provide the following non-instances for norms on matrices:
   * `Matrix.frobeniusNormedRing`
   * `Matrix.frobeniusNormedAlgebra`
   * `Matrix.frobeniusIsBoundedSMul`
+  * `Matrix.frobeniusNormSMulClass`
 
 * The $L^\infty$ operator norm:
 
@@ -33,6 +35,7 @@ In this file we provide the following non-instances for norms on matrices:
   * `Matrix.linftyOpNormedAddCommGroup`
   * `Matrix.linftyOpNormedSpace`
   * `Matrix.linftyOpIsBoundedSMul`
+  * `Matrix.linftyOpNormSMulClass`
   * `Matrix.linftyOpNonUnitalSemiNormedRing`
   * `Matrix.linftyOpSemiNormedRing`
   * `Matrix.linftyOpNonUnitalNormedRing`
@@ -194,6 +197,11 @@ protected theorem isBoundedSMul [SeminormedRing R] [SeminormedAddCommGroup α] [
 
 @[deprecated (since := "2025-03-10")] protected alias boundedSMul := Matrix.isBoundedSMul
 
+/-- This applies to the sup norm of sup norm. -/
+protected theorem normSMulClass [SeminormedRing R] [SeminormedAddCommGroup α] [Module R α]
+    [NormSMulClass R α] : NormSMulClass R (Matrix m n α) :=
+  Pi.instNormSMulClass
+
 variable [NormedField R] [SeminormedAddCommGroup α] [NormedSpace R α]
 
 /-- Normed space instance (using sup norm of sup norm) for matrices over a normed space.  Not
@@ -239,6 +247,13 @@ protected theorem linftyOpIsBoundedSMul
     [SeminormedRing R] [SeminormedAddCommGroup α] [Module R α] [IsBoundedSMul R α] :
     IsBoundedSMul R (Matrix m n α) :=
   (by infer_instance : IsBoundedSMul R (m → PiLp 1 fun j : n => α))
+
+/-- This applies to the sup norm of L1 norm. -/
+@[local instance]
+protected theorem linftyOpNormSMulClass
+    [SeminormedRing R] [SeminormedAddCommGroup α] [Module R α] [NormSMulClass R α] :
+    NormSMulClass R (Matrix m n α) :=
+  (by infer_instance : NormSMulClass R (m → PiLp 1 fun j : n => α))
 
 /-- Normed space instance (using sup norm of L1 norm) for matrices over a normed space.  Not
 declared as an instance because there are several natural choices for defining the norm of a
@@ -481,6 +496,13 @@ theorem frobeniusIsBoundedSMul [SeminormedRing R] [SeminormedAddCommGroup α] [M
     [IsBoundedSMul R α] :
     IsBoundedSMul R (Matrix m n α) :=
   (by infer_instance : IsBoundedSMul R (PiLp 2 fun i : m => PiLp 2 fun j : n => α))
+
+/-- This applies to the frobenius norm. -/
+@[local instance]
+theorem frobeniusNormSMulClass [SeminormedRing R] [SeminormedAddCommGroup α] [Module R α]
+    [NormSMulClass R α] :
+    NormSMulClass R (Matrix m n α) :=
+  (by infer_instance : NormSMulClass R (PiLp 2 fun i : m => PiLp 2 fun j : n => α))
 
 @[deprecated (since := "2025-03-10")] alias frobeniusBoundedSMul := frobeniusIsBoundedSMul
 

--- a/Mathlib/Analysis/Matrix.lean
+++ b/Mathlib/Analysis/Matrix.lean
@@ -497,7 +497,7 @@ theorem frobeniusIsBoundedSMul [SeminormedRing R] [SeminormedAddCommGroup α] [M
     IsBoundedSMul R (Matrix m n α) :=
   (by infer_instance : IsBoundedSMul R (PiLp 2 fun i : m => PiLp 2 fun j : n => α))
 
-/-- This applies to the frobenius norm. -/
+/-- This applies to the Frobenius norm. -/
 @[local instance]
 theorem frobeniusNormSMulClass [SeminormedRing R] [SeminormedAddCommGroup α] [Module R α]
     [NormSMulClass R α] :

--- a/Mathlib/Analysis/Normed/Lp/PiLp.lean
+++ b/Mathlib/Analysis/Normed/Lp/PiLp.lean
@@ -675,6 +675,19 @@ instance instIsBoundedSMul [SeminormedRing 𝕜] [∀ i, SeminormedAddCommGroup 
       simp_rw [← NNReal.mul_rpow, smul_apply]
       exact Finset.sum_le_sum fun i _ => NNReal.rpow_le_rpow (nnnorm_smul_le _ _) hp0.le
 
+instance instNormSMulClass [SeminormedRing 𝕜] [∀ i, SeminormedAddCommGroup (β i)]
+    [∀ i, Module 𝕜 (β i)] [∀ i, NormSMulClass 𝕜 (β i)] :
+    NormSMulClass 𝕜 (PiLp p β) :=
+  .of_nnnorm_smul fun c f => by
+    rcases p.dichotomy with (rfl | hp)
+    · rw [← nnnorm_equiv, ← nnnorm_equiv, WithLp.equiv_smul, nnnorm_smul]
+    · have hp0 : 0 < p.toReal := zero_lt_one.trans_le hp
+      have hpt : p ≠ ⊤ := p.toReal_pos_iff_ne_top.mp hp0
+      rw [nnnorm_eq_sum hpt, nnnorm_eq_sum hpt, one_div, NNReal.rpow_inv_eq_iff hp0.ne',
+        NNReal.mul_rpow, ← NNReal.rpow_mul, inv_mul_cancel₀ hp0.ne', NNReal.rpow_one,
+        Finset.mul_sum]
+      simp_rw [← NNReal.mul_rpow, smul_apply, nnnorm_smul]
+
 /-- The product of finitely many normed spaces is a normed space, with the `L^p` norm. -/
 instance normedSpace [NormedField 𝕜] [∀ i, SeminormedAddCommGroup (β i)]
     [∀ i, NormedSpace 𝕜 (β i)] : NormedSpace 𝕜 (PiLp p β) where

--- a/Mathlib/Analysis/Normed/Lp/ProdLp.lean
+++ b/Mathlib/Analysis/Normed/Lp/ProdLp.lean
@@ -852,6 +852,17 @@ def prodEquivₗᵢ : WithLp ∞ (α × β) ≃ₗᵢ[𝕜] α × β where
 
 end IsBoundedSMul
 
+instance instProdNormSMulClass [SeminormedRing 𝕜] [Module 𝕜 α] [Module 𝕜 β]
+    [NormSMulClass 𝕜 α] [NormSMulClass 𝕜 β] : NormSMulClass 𝕜 (WithLp p (α × β)) :=
+  .of_nnnorm_smul fun c f => by
+    rcases p.dichotomy with (rfl | hp)
+    · simp only [← prod_nnnorm_equiv, WithLp.equiv_smul, nnnorm_smul]
+    · have hp0 : 0 < p.toReal := zero_lt_one.trans_le hp
+      have hpt : p ≠ ⊤ := p.toReal_pos_iff_ne_top.mp hp0
+      rw [prod_nnnorm_eq_add hpt, prod_nnnorm_eq_add hpt, one_div, NNReal.rpow_inv_eq_iff hp0.ne',
+        NNReal.mul_rpow, ← NNReal.rpow_mul, inv_mul_cancel₀ hp0.ne', NNReal.rpow_one, mul_add,
+        ← NNReal.mul_rpow, ← NNReal.mul_rpow, smul_fst, smul_snd, nnnorm_smul, nnnorm_smul]
+
 section SeminormedAddCommGroup
 
 open ENNReal

--- a/Mathlib/Analysis/Normed/MulAction.lean
+++ b/Mathlib/Analysis/Normed/MulAction.lean
@@ -105,7 +105,13 @@ instance (priority := 100) NormMulClass.toNormSMulClass_op [SeminormedRing α] [
     NormSMulClass αᵐᵒᵖ α where
   norm_smul a b := mul_comm ‖b‖ ‖a‖ ▸ norm_mul b a.unop
 
-variable [SeminormedRing α] [SeminormedAddGroup β] [SMul α β] [NormSMulClass α β]
+variable [SeminormedRing α] [SeminormedAddGroup β] [SMul α β]
+
+theorem NormSMulClass.of_nnnorm_smul (h : ∀ (r : α) (x : β), ‖r • x‖₊ = ‖r‖₊ * ‖x‖₊) :
+    NormSMulClass α β where
+  norm_smul r b := congr_arg NNReal.toReal (h r b)
+
+variable [NormSMulClass α β]
 
 theorem nnnorm_smul (r : α) (x : β) : ‖r • x‖₊ = ‖r‖₊ * ‖x‖₊ :=
   NNReal.eq <| norm_smul r x


### PR DESCRIPTION
This adds instances for `ProdLp`, `PiLp`, and matrix norms.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
