### PR TITLE
[Merged by Bors] - fix(docker_build.yml): add missing `id`

### DIFF
--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -4,8 +4,6 @@ on:
   schedule:
     - cron: '0 0 * * *'   # Runs at 00:00 UTC every day
   workflow_dispatch:  
-    branches:
-      - master
 
 permissions:
   contents: read
@@ -50,6 +48,7 @@ jobs:
         id: output-tag-name
         run: echo "::set-output name=tagname::${{ steps.meta.outputs.tags }}"
       - name: Build and push image
+        id: push
         uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0
         with:
           # action can do checkout, but I don't know the exact subdir syntax


### PR DESCRIPTION
Follow-up to #23844. The build was failing because `steps.push.outputs.digest` referenced in the `subject-digest` input to the attestation step was nonexistent, cf. https://github.com/leanprover-community/mathlib4/actions/runs/14915728318/job/41900735492

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
