### PR TITLE
feat(CategoryTheory/Monoidal): external product of diagrams in monoidal categories

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2311,6 +2311,7 @@ import Mathlib.CategoryTheory.Monoidal.Comon_
 import Mathlib.CategoryTheory.Monoidal.Conv
 import Mathlib.CategoryTheory.Monoidal.Discrete
 import Mathlib.CategoryTheory.Monoidal.End
+import Mathlib.CategoryTheory.Monoidal.ExternalProduct
 import Mathlib.CategoryTheory.Monoidal.Free.Basic
 import Mathlib.CategoryTheory.Monoidal.Free.Coherence
 import Mathlib.CategoryTheory.Monoidal.Functor

--- a/Mathlib/CategoryTheory/Monoidal/ExternalProduct.lean
+++ b/Mathlib/CategoryTheory/Monoidal/ExternalProduct.lean
@@ -70,8 +70,8 @@ Note that `(externalProductSwap _ _ _).app (F₁, F₂) : Prod.swap _ _ ⋙ F₁
 type checks. -/
 @[simps!]
 def externalProductSwap [BraidedCategory C] :
-    externalProductBifunctor J₁ J₂ C ⋙ (whiskeringLeft _ _ _|>.obj <| Prod.swap _ _)
-    ≅ Prod.swap _ _ ⋙ externalProductBifunctor J₂ J₁ C :=
+    externalProductBifunctor J₁ J₂ C ⋙ (whiskeringLeft _ _ _|>.obj <| Prod.swap _ _) ≅
+    Prod.swap _ _ ⋙ externalProductBifunctor J₂ J₁ C :=
   NatIso.ofComponents
     (fun _ ↦ NatIso.ofComponents (fun _ ↦ β_ _ _) (by simp [tensorHom_def, whisker_exchange]))
     (fun _ ↦ by ext; simp [tensorHom_def, whisker_exchange])
@@ -79,8 +79,9 @@ def externalProductSwap [BraidedCategory C] :
 /-- A version of `externalProductSwap` phrased in terms of the uncurried functors. -/
 @[simps!]
 def externalProductFlip [BraidedCategory C] :
-    (Functor.postcompose₂.obj <| flipFunctor _ _ _).obj (externalProductBifunctorUncurried J₁ J₂ C)
-    ≅ (externalProductBifunctorUncurried J₂ J₁ C).flip :=
+    (Functor.postcompose₂.obj <| flipFunctor _ _ _).obj
+      (externalProductBifunctorUncurried J₁ J₂ C) ≅
+    (externalProductBifunctorUncurried J₂ J₁ C).flip :=
   NatIso.ofComponents <| fun _ ↦ NatIso.ofComponents <|
     fun _ ↦ NatIso.ofComponents <| fun _ ↦ NatIso.ofComponents (fun _ ↦ β_ _ _)
 

--- a/Mathlib/CategoryTheory/Monoidal/ExternalProduct.lean
+++ b/Mathlib/CategoryTheory/Monoidal/ExternalProduct.lean
@@ -1,0 +1,98 @@
+/-
+Copyright (c) 2025 Robin Carlier. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robin Carlier
+-/
+import Mathlib.CategoryTheory.Monoidal.FunctorCategory
+import Mathlib.CategoryTheory.Functor.Currying
+
+/-!
+# External product of diagrams in a monoidal category
+
+In a monoidal category `C`, given a pair of diagrams `K₁ : J₁ ⥤ C` and `K₂ : J₂ ⥤ C`, we
+introduce the external product `K₁ ⊠ K₂ : J₁ × J₂ ⥤ C` as the bifunctor `(j₁, j₂) ↦ K₁ j₁ ⊗ K₂ j₂`.
+The notation `- ⊠ -` is scoped to `MonoidalCategory.ExternalProduct`.
+-/
+
+universe v₁ v₂ v₃ v₄ u₁ u₂ u₃ u₄
+
+namespace CategoryTheory.MonoidalCategory
+
+variable (J₁ : Type u₁) (J₂ : Type u₂) (C : Type u₃)
+    [Category.{v₁} J₁] [Category.{v₂} J₂] [Category.{v₃} C] [MonoidalCategory C]
+
+/-- The (uncurried version of the) external product bifunctor: Given diagrams
+`K₁ : J₁ ⥤ C` and `K₂ : J₂ ⥤ C`, this is the bifunctor `j₁ ↦ j₂ ↦ K₁ j₁ ⊗ K₂ j₂`. -/
+@[simps!]
+def externalProductBifunctorUncurried : (J₁ ⥤ C) ⥤ (J₂ ⥤ C) ⥤ J₁ ⥤ J₂ ⥤ C :=
+  (Functor.postcompose₂.obj <| (evaluation _ _).obj <| curriedTensor C).obj <| whiskeringLeft₂ C
+
+/-- The external product bifunctor: Given diagrams
+`K₁ : J₁ ⥤ C` and `K₂ : J₂ ⥤ C`, this is the bifunctor `(j₁, j₂) ↦ K₁ j₁ ⊗ K₂ j₂`. -/
+@[simps!]
+def externalProductBifunctor : ((J₁ ⥤ C) × (J₂ ⥤ C)) ⥤ J₁ × J₂ ⥤ C :=
+  uncurry.obj <| (Functor.postcompose₂.obj <| uncurry).obj <|
+    externalProductBifunctorUncurried J₁ J₂ C
+
+variable {J₁ J₂ C}
+/-- An abbreviation for the action of `externalProductBifunctor J₁ J₂ C` on objects. -/
+abbrev externalProduct (F₁ : J₁ ⥤ C) (F₂ : J₂ ⥤ C) :=
+  externalProductBifunctor J₁ J₂ C|>.obj (F₁, F₂)
+
+namespace ExternalProduct
+/-- Notation for `externalProduct`.
+```
+open scoped CategoryTheory.MonoidalCategory.ExternalProduct
+``` to bring this notation in scope. -/
+scoped infixr:80 " ⊠ " => externalProduct
+
+end ExternalProduct
+
+open scoped ExternalProduct
+
+variable (J₁ J₂ C)
+
+/-- When both diagrams have the same source category, composing the external product with
+the diagonal gives the pointwise functor tensor product.
+Note that `(externalProductCompDiagIso _ _).app (F₁, F₂) : Functor.diag J₁ ⋙ F₁ ⊠ F₂ ≅ F₁ ⊗ F₂`
+type checks. -/
+@[simps!]
+def externalProductCompDiagIso :
+    externalProductBifunctor J₁ J₁ C ⋙ (whiskeringLeft _ _ _|>.obj <| Functor.diag J₁) ≅
+    tensor (J₁ ⥤ C) :=
+  NatIso.ofComponents (fun _ ↦
+    NatIso.ofComponents (fun _ ↦ Iso.refl _)
+      (by simp [tensorHom_def])) (fun f ↦ by ext x; simp [tensorHom_def])
+
+/-- When `C` is braided, there is an isomorphism `Prod.swap _ _ ⋙ F₁ ⊠ F₂ ≅ F₂ ⊠ F₁`, natural
+in both `F₁` and `F₂`.
+Note that `(externalProductSwap _ _ _).app (F₁, F₂) : Prod.swap _ _ ⋙ F₁ ⊠ F₂ ≅ F₂ ⊠ F₁`
+type checks. -/
+@[simps!]
+def externalProductSwap [BraidedCategory C] :
+    externalProductBifunctor J₁ J₂ C ⋙ (whiskeringLeft _ _ _|>.obj <| Prod.swap _ _)
+    ≅ Prod.swap _ _ ⋙ externalProductBifunctor J₂ J₁ C :=
+  NatIso.ofComponents (fun _ ↦
+    NatIso.ofComponents (fun _ ↦ β_ _ _) (by simp [tensorHom_def, whisker_exchange]))
+    (fun f ↦ by ext x; simp [tensorHom_def, whisker_exchange])
+
+/-- A version of `externalProductSwap` phrased in terms of the uncurried functors. -/
+@[simps!]
+def externalProductFlip [BraidedCategory C] :
+    (Functor.postcompose₂.obj <| flipFunctor _ _ _).obj (externalProductBifunctorUncurried J₁ J₂ C)
+    ≅ (externalProductBifunctorUncurried J₂ J₁ C).flip :=
+  NatIso.ofComponents <| fun _ ↦ NatIso.ofComponents <| fun _ ↦ NatIso.ofComponents <| fun _ ↦
+    NatIso.ofComponents (fun _ ↦ β_ _ _)
+
+section Composition
+
+variable {J₁ J₂ C} {I₁ : Type u₃} {I₂ : Type u₄} [Category.{v₃} I₁] [Category.{v₄} I₂]
+
+/-- Composing F₁ × F₂ with (G₁ ⊠ G₂) is isomorphic to (F₁ ⋙ G₁) ⊠ (F₂ ⋙ G₂) -/
+@[simps!]
+def prodCompExternalProduct (F₁ : I₁ ⥤ J₁) (G₁ : J₁ ⥤ C) (F₂ : I₂ ⥤ J₂) (G₂ : J₂ ⥤ C) :
+   F₁.prod F₂ ⋙ G₁ ⊠ G₂ ≅ (F₁ ⋙ G₁) ⊠ (F₂ ⋙ G₂) := NatIso.ofComponents (fun _ ↦ Iso.refl _)
+
+end Composition
+
+end CategoryTheory.MonoidalCategory

--- a/Mathlib/CategoryTheory/Monoidal/ExternalProduct.lean
+++ b/Mathlib/CategoryTheory/Monoidal/ExternalProduct.lean
@@ -41,9 +41,8 @@ abbrev externalProduct (F₁ : J₁ ⥤ C) (F₂ : J₂ ⥤ C) :=
 
 namespace ExternalProduct
 /-- Notation for `externalProduct`.
-```
-open scoped CategoryTheory.MonoidalCategory.ExternalProduct
-``` to bring this notation in scope. -/
+Do `open scoped CategoryTheory.MonoidalCategory.ExternalProduct`
+to bring this notation in scope. -/
 scoped infixr:80 " ⊠ " => externalProduct
 
 end ExternalProduct

--- a/Mathlib/CategoryTheory/Monoidal/ExternalProduct.lean
+++ b/Mathlib/CategoryTheory/Monoidal/ExternalProduct.lean
@@ -88,7 +88,7 @@ section Composition
 
 variable {J₁ J₂ C} {I₁ : Type u₃} {I₂ : Type u₄} [Category.{v₃} I₁] [Category.{v₄} I₂]
 
-/-- Composing F₁ × F₂ with (G₁ ⊠ G₂) is isomorphic to (F₁ ⋙ G₁) ⊠ (F₂ ⋙ G₂) -/
+/-- Composing  `F₁ × F₂` with `G₁ ⊠ G₂` is isomorphic to `(F₁ ⋙ G₁) ⊠ (F₂ ⋙ G₂)`. -/
 @[simps!]
 def prodCompExternalProduct (F₁ : I₁ ⥤ J₁) (G₁ : J₁ ⥤ C) (F₂ : I₂ ⥤ J₂) (G₂ : J₂ ⥤ C) :
    F₁.prod F₂ ⋙ G₁ ⊠ G₂ ≅ (F₁ ⋙ G₁) ⊠ (F₂ ⋙ G₂) := NatIso.ofComponents (fun _ ↦ Iso.refl _)

--- a/Mathlib/CategoryTheory/Monoidal/ExternalProduct.lean
+++ b/Mathlib/CategoryTheory/Monoidal/ExternalProduct.lean
@@ -60,9 +60,9 @@ type checks. -/
 def externalProductCompDiagIso :
     externalProductBifunctor J₁ J₁ C ⋙ (whiskeringLeft _ _ _|>.obj <| Functor.diag J₁) ≅
     tensor (J₁ ⥤ C) :=
-  NatIso.ofComponents (fun _ ↦
-    NatIso.ofComponents (fun _ ↦ Iso.refl _)
-      (by simp [tensorHom_def])) (fun f ↦ by ext x; simp [tensorHom_def])
+  NatIso.ofComponents
+    (fun _ ↦ NatIso.ofComponents (fun _ ↦ Iso.refl _) (by simp [tensorHom_def]))
+    (fun _ ↦ by ext; simp [tensorHom_def])
 
 /-- When `C` is braided, there is an isomorphism `Prod.swap _ _ ⋙ F₁ ⊠ F₂ ≅ F₂ ⊠ F₁`, natural
 in both `F₁` and `F₂`.
@@ -72,17 +72,17 @@ type checks. -/
 def externalProductSwap [BraidedCategory C] :
     externalProductBifunctor J₁ J₂ C ⋙ (whiskeringLeft _ _ _|>.obj <| Prod.swap _ _)
     ≅ Prod.swap _ _ ⋙ externalProductBifunctor J₂ J₁ C :=
-  NatIso.ofComponents (fun _ ↦
-    NatIso.ofComponents (fun _ ↦ β_ _ _) (by simp [tensorHom_def, whisker_exchange]))
-    (fun f ↦ by ext x; simp [tensorHom_def, whisker_exchange])
+  NatIso.ofComponents
+    (fun _ ↦ NatIso.ofComponents (fun _ ↦ β_ _ _) (by simp [tensorHom_def, whisker_exchange]))
+    (fun _ ↦ by ext; simp [tensorHom_def, whisker_exchange])
 
 /-- A version of `externalProductSwap` phrased in terms of the uncurried functors. -/
 @[simps!]
 def externalProductFlip [BraidedCategory C] :
     (Functor.postcompose₂.obj <| flipFunctor _ _ _).obj (externalProductBifunctorUncurried J₁ J₂ C)
     ≅ (externalProductBifunctorUncurried J₂ J₁ C).flip :=
-  NatIso.ofComponents <| fun _ ↦ NatIso.ofComponents <| fun _ ↦ NatIso.ofComponents <| fun _ ↦
-    NatIso.ofComponents (fun _ ↦ β_ _ _)
+  NatIso.ofComponents <| fun _ ↦ NatIso.ofComponents <|
+    fun _ ↦ NatIso.ofComponents <| fun _ ↦ NatIso.ofComponents (fun _ ↦ β_ _ _)
 
 section Composition
 

--- a/Mathlib/CategoryTheory/Monoidal/ExternalProduct.lean
+++ b/Mathlib/CategoryTheory/Monoidal/ExternalProduct.lean
@@ -21,13 +21,13 @@ namespace CategoryTheory.MonoidalCategory
 variable (J₁ : Type u₁) (J₂ : Type u₂) (C : Type u₃)
     [Category.{v₁} J₁] [Category.{v₂} J₂] [Category.{v₃} C] [MonoidalCategory C]
 
-/-- The (curried version of the) external product bifunctor: Given diagrams
+/-- The (curried version of the) external product bifunctor: given diagrams
 `K₁ : J₁ ⥤ C` and `K₂ : J₂ ⥤ C`, this is the bifunctor `j₁ ↦ j₂ ↦ K₁ j₁ ⊗ K₂ j₂`. -/
 @[simps!]
 def externalProductBifunctorCurried : (J₁ ⥤ C) ⥤ (J₂ ⥤ C) ⥤ J₁ ⥤ J₂ ⥤ C :=
   (Functor.postcompose₂.obj <| (evaluation _ _).obj <| curriedTensor C).obj <| whiskeringLeft₂ C
 
-/-- The external product bifunctor: Given diagrams
+/-- The external product bifunctor: given diagrams
 `K₁ : J₁ ⥤ C` and `K₂ : J₂ ⥤ C`, this is the bifunctor `(j₁, j₂) ↦ K₁ j₁ ⊗ K₂ j₂`. -/
 @[simps!]
 def externalProductBifunctor : ((J₁ ⥤ C) × (J₂ ⥤ C)) ⥤ J₁ × J₂ ⥤ C :=
@@ -88,7 +88,7 @@ section Composition
 
 variable {J₁ J₂ C} {I₁ : Type u₃} {I₂ : Type u₄} [Category.{v₃} I₁] [Category.{v₄} I₂]
 
-/-- Composing  `F₁ × F₂` with `G₁ ⊠ G₂` is isomorphic to `(F₁ ⋙ G₁) ⊠ (F₂ ⋙ G₂)`. -/
+/-- Composing `F₁ × F₂` with `G₁ ⊠ G₂` is isomorphic to `(F₁ ⋙ G₁) ⊠ (F₂ ⋙ G₂)`. -/
 @[simps!]
 def prodCompExternalProduct (F₁ : I₁ ⥤ J₁) (G₁ : J₁ ⥤ C) (F₂ : I₂ ⥤ J₂) (G₂ : J₂ ⥤ C) :
    F₁.prod F₂ ⋙ G₁ ⊠ G₂ ≅ (F₁ ⋙ G₁) ⊠ (F₂ ⋙ G₂) := NatIso.ofComponents (fun _ ↦ Iso.refl _)

--- a/Mathlib/CategoryTheory/Monoidal/ExternalProduct.lean
+++ b/Mathlib/CategoryTheory/Monoidal/ExternalProduct.lean
@@ -21,10 +21,10 @@ namespace CategoryTheory.MonoidalCategory
 variable (J₁ : Type u₁) (J₂ : Type u₂) (C : Type u₃)
     [Category.{v₁} J₁] [Category.{v₂} J₂] [Category.{v₃} C] [MonoidalCategory C]
 
-/-- The (uncurried version of the) external product bifunctor: Given diagrams
+/-- The (curried version of the) external product bifunctor: Given diagrams
 `K₁ : J₁ ⥤ C` and `K₂ : J₂ ⥤ C`, this is the bifunctor `j₁ ↦ j₂ ↦ K₁ j₁ ⊗ K₂ j₂`. -/
 @[simps!]
-def externalProductBifunctorUncurried : (J₁ ⥤ C) ⥤ (J₂ ⥤ C) ⥤ J₁ ⥤ J₂ ⥤ C :=
+def externalProductBifunctorCurried : (J₁ ⥤ C) ⥤ (J₂ ⥤ C) ⥤ J₁ ⥤ J₂ ⥤ C :=
   (Functor.postcompose₂.obj <| (evaluation _ _).obj <| curriedTensor C).obj <| whiskeringLeft₂ C
 
 /-- The external product bifunctor: Given diagrams
@@ -32,7 +32,7 @@ def externalProductBifunctorUncurried : (J₁ ⥤ C) ⥤ (J₂ ⥤ C) ⥤ J₁ �
 @[simps!]
 def externalProductBifunctor : ((J₁ ⥤ C) × (J₂ ⥤ C)) ⥤ J₁ × J₂ ⥤ C :=
   uncurry.obj <| (Functor.postcompose₂.obj <| uncurry).obj <|
-    externalProductBifunctorUncurried J₁ J₂ C
+    externalProductBifunctorCurried J₁ J₂ C
 
 variable {J₁ J₂ C}
 /-- An abbreviation for the action of `externalProductBifunctor J₁ J₂ C` on objects. -/
@@ -75,12 +75,12 @@ def externalProductSwap [BraidedCategory C] :
     (fun _ ↦ NatIso.ofComponents (fun _ ↦ β_ _ _) (by simp [tensorHom_def, whisker_exchange]))
     (fun _ ↦ by ext; simp [tensorHom_def, whisker_exchange])
 
-/-- A version of `externalProductSwap` phrased in terms of the uncurried functors. -/
+/-- A version of `externalProductSwap` phrased in terms of the curried functors. -/
 @[simps!]
 def externalProductFlip [BraidedCategory C] :
     (Functor.postcompose₂.obj <| flipFunctor _ _ _).obj
-      (externalProductBifunctorUncurried J₁ J₂ C) ≅
-    (externalProductBifunctorUncurried J₂ J₁ C).flip :=
+      (externalProductBifunctorCurried J₁ J₂ C) ≅
+    (externalProductBifunctorCurried J₂ J₁ C).flip :=
   NatIso.ofComponents <| fun _ ↦ NatIso.ofComponents <|
     fun _ ↦ NatIso.ofComponents <| fun _ ↦ NatIso.ofComponents (fun _ ↦ β_ _ _)
 


### PR DESCRIPTION
Given functors `K₁ : J₁ ⥤ C` and `K₂ : J₂ ⥤ C` with values in a monoidal category, define a construction `externalProduct K₁ K₂` (denoted `K₁ ⊠ K₂`) as the bifunctor `(j₁, j₂) ↦ K₁ j₁ ⊗ K₂ j₂`.

We show that composition of this construction with the diagonal functor to the product recovers the pointwise tensor product of functors, and we show that this construction satisfies a symmetry whenever `C` is braided.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
