### PR TITLE
[Merged by Bors] - feat: add RingOfIntegers.isPrincipalIdealRing_of_isPrincipal_of_le_pow_inertiaDeg_of_mem_primesOver_of_mem_Icc

### DIFF
--- a/Mathlib/NumberTheory/NumberField/ClassNumber.lean
+++ b/Mathlib/NumberTheory/NumberField/ClassNumber.lean
@@ -130,8 +130,6 @@ theorem isPrincipalIdealRing_of_isPrincipal_of_le_pow_inertiaDeg_of_mem_primesOv
     eq_bot_of_comap_eq_bot (R := ℤ) <| by simpa only [hp, submodule_span_eq, span_singleton_eq_bot]
   have hpprime := (span_singleton_prime hp0).mp
   simp only [← submodule_span_eq, ← hp] at hpprime
-  have hle : algebraMap ℤ (𝓞 K) p ∈ P := (mem_of_liesOver P (under ℤ P) p).mp <|
-    hp ▸ Submodule.mem_span_singleton_self p
   have hlies : P.LiesOver (span {p}) := by
     rcases abs_choice p with h | h <;>
     simpa [h, span_singleton_neg p, ← submodule_span_eq, ← hp] using over_under P

--- a/Mathlib/NumberTheory/NumberField/ClassNumber.lean
+++ b/Mathlib/NumberTheory/NumberField/ClassNumber.lean
@@ -25,8 +25,10 @@ enough to show that, for all (natural) primes `p ∈ Finset.Icc 1 ⌊(M K)⌋₊
 such that `p ^ (span ({p}).inertiaDeg P)` are principal. This is the standard technique to prove
 that `𝓞 K` is principal, see [marcus1977number], discussion after Theorem 37.
 
-The way this theorem should be used is to first of all compute `⌊(M K)⌋₊` and then use `fin_cases`
-to deal with the finite number of primes `p` in the interval.
+The theorem is stated using any `n : ℕ` such that `M K ≤ n` and for all `p ∈ Finset.Icc 1 n`. The
+way it should be used is to first of all choose `n` (in practice one should take `n = ⌊(M K)⌋₊` but
+there is no need to prove that `n - 1 ≤ M K`) and then use `fin_cases` to deal with the finite
+number of primes `p` in the interval.
 -/
 
 open scoped nonZeroDivisors Real
@@ -117,10 +119,12 @@ PID it is enough to show that, for all (natural) primes `p ∈ Finset.Icc 1 ⌊(
 above `p` such that `p ^ (span ({p}).inertiaDeg P)` are principal. This is the standard technique to
 prove that `𝓞 K` is principal, see [marcus1977number], discussion after Theorem 37.
 
-The way this theorem should be used is to first of all compute `⌊(M K)⌋₊` and then use `fin_cases`
-to deal with the finite number of primes `p` in the interval. -/
+The theorem is stated using any `n : ℕ` such that `M K ≤ n` and for all `p ∈ Finset.Icc 1 n`. The
+way it should be used is to first of all choose `n` (in practice one should take `n = ⌊(M K)⌋₊` but
+there is no need to prove that `n - 1 ≤ M K`) and then use `fin_cases` to deal with the finite
+number of primes `p` in the interval. -/
 theorem isPrincipalIdealRing_of_isPrincipal_of_le_pow_inertiaDeg_of_mem_primesOver_of_mem_Icc
-    (h : ∀ p ∈ Finset.Icc 1 ⌊(M K)⌋₊, p.Prime → ∀ (P : Ideal (𝓞 K)),
+    {n : ℕ } (hn : M K ≤ n) (h : ∀ p ∈ Finset.Icc 1 n, p.Prime → ∀ (P : Ideal (𝓞 K)),
       P ∈ Ideal.primesOver (span {(p : ℤ)}) (𝓞 K) → p ^ ((span ({↑p} : Set ℤ)).inertiaDeg P) ≤ M K →
       Submodule.IsPrincipal P) : IsPrincipalIdealRing (𝓞 K) := by
   refine isPrincipalIdealRing_of_isPrincipal_of_norm_le_of_isPrime <|
@@ -140,7 +144,7 @@ theorem isPrincipalIdealRing_of_isPrincipal_of_le_pow_inertiaDeg_of_mem_primesOv
   have hpabsprime := Int.prime_iff_natAbs_prime.mp (hpprime (hP.under _))
   refine h _ ?_ hpabsprime _ ⟨hP, ?_⟩ hple
   · suffices 0 < (span {(p.natAbs : ℤ)}).inertiaDeg P by
-      refine Finset.mem_Icc.mpr ⟨hpabsprime.one_le, le_floor <| le_trans ?_ hple⟩
+      refine Finset.mem_Icc.mpr ⟨hpabsprime.one_le, cast_le.mp <| le_trans (le_trans ?_ hple) hn⟩
       simpa only [← cast_pow, cast_le] using le_pow this
     have := (isPrime_of_prime (prime_span_singleton_iff.mpr <|
       hpprime (hP.under _))).isMaximal <| by simp [((hpprime (hP.under _))).ne_zero]

--- a/Mathlib/NumberTheory/NumberField/ClassNumber.lean
+++ b/Mathlib/NumberTheory/NumberField/ClassNumber.lean
@@ -117,7 +117,7 @@ PID it is enough to show that, for all (natural) primes `p ∈ Finset.Icc 1 ⌊(
 above `p` such that `p ^ (span ({p}).inertiaDeg P)` are principal. This is the standard technique to
 prove that `𝓞 K` is principal, see [marcus1977number], discussion after Theorem 37.
 
-The way this theorem should be used is to first of all compute `⌊(M K)⌋₊` and then use `fin_cases`
+The way this theorem should be used is to first compute `⌊(M K)⌋₊` and then to use `fin_cases`
 to deal with the finite number of primes `p` in the interval. -/
 theorem isPrincipalIdealRing_of_isPrincipal_of_le_pow_inertiaDeg_of_mem_primesOver_of_mem_Icc
     (h : ∀ p ∈ Finset.Icc 1 ⌊(M K)⌋₊, p.Prime → ∀ (P : Ideal (𝓞 K)),

--- a/Mathlib/NumberTheory/NumberField/ClassNumber.lean
+++ b/Mathlib/NumberTheory/NumberField/ClassNumber.lean
@@ -119,7 +119,7 @@ prove that `𝓞 K` is principal, see [marcus1977number], discussion after Theor
 
 The way this theorem should be used is to first compute `⌊(M K)⌋₊` and then to use `fin_cases`
 to deal with the finite number of primes `p` in the interval. -/
-theorem isPrincipalIdealRing_of_isPrincipal_of_le_pow_inertiaDeg_of_mem_primesOver_of_mem_Icc
+theorem isPrincipalIdealRing_of_isPrincipal_of_pow_inertiaDeg_le_of_mem_primesOver_of_mem_Icc
     (h : ∀ p ∈ Finset.Icc 1 ⌊(M K)⌋₊, p.Prime → ∀ (P : Ideal (𝓞 K)),
       P ∈ Ideal.primesOver (span {(p : ℤ)}) (𝓞 K) →
       p ^ ((span ({↑p} : Set ℤ)).inertiaDeg P) ≤ ⌊(M K)⌋₊ →

--- a/Mathlib/NumberTheory/NumberField/ClassNumber.lean
+++ b/Mathlib/NumberTheory/NumberField/ClassNumber.lean
@@ -21,7 +21,7 @@ on the class number.
 cardinality of the class group of its ring of integers
 - `isPrincipalIdealRing_of_isPrincipal_of_le_pow_inertiaDeg_of_mem_primesOver_of_mem_Icc`: let `K`
 be a number field and let `M K` be the Minkowski bound of `K`. To show that `𝓞 K` is a PID it is
-enough to show that, for all (natural) prime `p ∈ Finset.Icc 1 ⌊(M K)⌋₊`, all ideals `P` above `p`
+enough to show that, for all (natural) primes `p ∈ Finset.Icc 1 ⌊(M K)⌋₊`, all ideals `P` above `p`
 such that `p ^ (span ({p}).inertiaDeg P)` are principal. This is the standard technique to prove
 that `𝓞 K` is principal, see [marcus1977number], discussion after Theorem 37.
 
@@ -113,7 +113,7 @@ theorem isPrincipalIdealRing_of_isPrincipal_of_norm_le_of_isPrime
       UniqueFactorizationMonoid.dvd_of_mem_normalizedFactors hJ).trans hI
 
 /-- Let `K` be a number field and let `M K` be the Minkowski bound of `K`. To show that `𝓞 K` is a
-PID it is enough to show that, for all (natural) prime `p ∈ Finset.Icc 1 ⌊(M K)⌋₊`, all ideals `P`
+PID it is enough to show that, for all (natural) primes `p ∈ Finset.Icc 1 ⌊(M K)⌋₊`, all ideals `P`
 above `p` such that `p ^ (span ({p}).inertiaDeg P)` are principal. This is the standard technique to
 prove that `𝓞 K` is principal, see [marcus1977number], discussion after Theorem 37.
 

--- a/Mathlib/NumberTheory/NumberField/ClassNumber.lean
+++ b/Mathlib/NumberTheory/NumberField/ClassNumber.lean
@@ -19,10 +19,12 @@ on the class number.
 ## Main definitions
 - `NumberField.classNumber`: the class number of a number field is the (finite)
 cardinality of the class group of its ring of integers
-- `isPrincipalIdealRing_of_isPrincipal_of_le_pow_inertiaDeg_of_mem_primesOver_of_mem_Icc`: let `K`
-be a number field and let `M K` be the Minkowski bound of `K`. To show that `𝓞 K` is a PID it is
-enough to show that, for all (natural) primes `p ∈ Finset.Icc 1 ⌊(M K)⌋₊`, all ideals `P` above `p`
-such that `p ^ (span ({p}).inertiaDeg P)` are principal. This is the standard technique to prove
+- `isPrincipalIdealRing_of_isPrincipal_of_pow_inertiaDeg_le_of_mem_primesOver_of_mem_Icc`: let `K`
+be a number field and let `M K` be the Minkowski bound of `K` (by definition it is
+`(4 / π) ^ nrComplexPlaces K * ((finrank ℚ K)! / (finrank ℚ K) ^ (finrank ℚ K) * √|discr K|)`).
+To show that `𝓞 K` is a PID it is enough to show that, for all (natural) primes
+`p ∈ Finset.Icc 1 ⌊(M K)⌋₊`, all ideals `P` above `p` such that
+`p ^ (span ({p}).inertiaDeg P) ≤ ⌊(M K)⌋₊` are principal. This is the standard technique to prove
 that `𝓞 K` is principal, see [marcus1977number], discussion after Theorem 37.
 
 The way this theorem should be used is to first compute `⌊(M K)⌋₊` and then to use `fin_cases`
@@ -112,10 +114,12 @@ theorem isPrincipalIdealRing_of_isPrincipal_of_norm_le_of_isPrime
     absNorm_dvd_absNorm_of_le <| le_of_dvd <|
       UniqueFactorizationMonoid.dvd_of_mem_normalizedFactors hJ).trans hI
 
-/-- Let `K` be a number field and let `M K` be the Minkowski bound of `K`. To show that `𝓞 K` is a
-PID it is enough to show that, for all (natural) primes `p ∈ Finset.Icc 1 ⌊(M K)⌋₊`, all ideals `P`
-above `p` such that `p ^ (span ({p}).inertiaDeg P)` are principal. This is the standard technique to
-prove that `𝓞 K` is principal, see [marcus1977number], discussion after Theorem 37.
+/-- Let `K` be a number field and let `M K` be the Minkowski bound of `K` (by definition it is
+`(4 / π) ^ nrComplexPlaces K * ((finrank ℚ K)! / (finrank ℚ K) ^ (finrank ℚ K) * √|discr K|)`).
+To show that `𝓞 K` is a PID it is enough to show that, for all (natural) primes
+`p ∈ Finset.Icc 1 ⌊(M K)⌋₊`, all ideals `P` above `p` such that
+`p ^ (span ({p}).inertiaDeg P) ≤ ⌊(M K)⌋₊` are principal. This is the standard technique to prove
+that `𝓞 K` is principal, see [marcus1977number], discussion after Theorem 37.
 
 The way this theorem should be used is to first compute `⌊(M K)⌋₊` and then to use `fin_cases`
 to deal with the finite number of primes `p` in the interval. -/

--- a/Mathlib/NumberTheory/NumberField/ClassNumber.lean
+++ b/Mathlib/NumberTheory/NumberField/ClassNumber.lean
@@ -25,10 +25,8 @@ enough to show that, for all (natural) primes `p ∈ Finset.Icc 1 ⌊(M K)⌋₊
 such that `p ^ (span ({p}).inertiaDeg P)` are principal. This is the standard technique to prove
 that `𝓞 K` is principal, see [marcus1977number], discussion after Theorem 37.
 
-The theorem is stated using any `n : ℕ` such that `M K ≤ n` and for all `p ∈ Finset.Icc 1 n`. The
-way it should be used is to first of all choose `n` (in practice one should take `n = ⌊(M K)⌋₊` but
-there is no need to prove that `n - 1 ≤ M K`) and then use `fin_cases` to deal with the finite
-number of primes `p` in the interval.
+The way this theorem should be used is to first of all compute `⌊(M K)⌋₊` and then use `fin_cases`
+to deal with the finite number of primes `p` in the interval.
 -/
 
 open scoped nonZeroDivisors Real
@@ -119,13 +117,12 @@ PID it is enough to show that, for all (natural) primes `p ∈ Finset.Icc 1 ⌊(
 above `p` such that `p ^ (span ({p}).inertiaDeg P)` are principal. This is the standard technique to
 prove that `𝓞 K` is principal, see [marcus1977number], discussion after Theorem 37.
 
-The theorem is stated using any `n : ℕ` such that `M K ≤ n` and for all `p ∈ Finset.Icc 1 n`. The
-way it should be used is to first of all choose `n` (in practice one should take `n = ⌊(M K)⌋₊` but
-there is no need to prove that `n - 1 ≤ M K`) and then use `fin_cases` to deal with the finite
-number of primes `p` in the interval. -/
+The way this theorem should be used is to first of all compute `⌊(M K)⌋₊` and then use `fin_cases`
+to deal with the finite number of primes `p` in the interval. -/
 theorem isPrincipalIdealRing_of_isPrincipal_of_le_pow_inertiaDeg_of_mem_primesOver_of_mem_Icc
-    {n : ℕ } (hn : M K ≤ n) (h : ∀ p ∈ Finset.Icc 1 n, p.Prime → ∀ (P : Ideal (𝓞 K)),
-      P ∈ Ideal.primesOver (span {(p : ℤ)}) (𝓞 K) → p ^ ((span ({↑p} : Set ℤ)).inertiaDeg P) ≤ M K →
+    (h : ∀ p ∈ Finset.Icc 1 ⌊(M K)⌋₊, p.Prime → ∀ (P : Ideal (𝓞 K)),
+      P ∈ Ideal.primesOver (span {(p : ℤ)}) (𝓞 K) →
+      p ^ ((span ({↑p} : Set ℤ)).inertiaDeg P) ≤ ⌊(M K)⌋₊ →
       Submodule.IsPrincipal P) : IsPrincipalIdealRing (𝓞 K) := by
   refine isPrincipalIdealRing_of_isPrincipal_of_norm_le_of_isPrime <|
     fun ⟨P, HP⟩ hP hPN ↦ ?_
@@ -139,13 +136,13 @@ theorem isPrincipalIdealRing_of_isPrincipal_of_le_pow_inertiaDeg_of_mem_primesOv
     simpa [h, span_singleton_neg p, ← submodule_span_eq, ← hp] using over_under P
   have hspan : span {↑p.natAbs} = span {p} := by
     rcases abs_choice p with h | h <;> simp [h]
-  have hple : p.natAbs ^ (span {(p.natAbs : ℤ)}).inertiaDeg P ≤ M K := by
+  have hple : p.natAbs ^ (span {(p.natAbs : ℤ)}).inertiaDeg P ≤ ⌊(M K)⌋₊ := by
+    refine le_floor ?_
     simpa only [hspan, ← cast_pow, ← absNorm_eq_pow_inertiaDeg P (hpprime (hP.under _))] using hPN
   have hpabsprime := Int.prime_iff_natAbs_prime.mp (hpprime (hP.under _))
   refine h _ ?_ hpabsprime _ ⟨hP, ?_⟩ hple
   · suffices 0 < (span {(p.natAbs : ℤ)}).inertiaDeg P by
-      refine Finset.mem_Icc.mpr ⟨hpabsprime.one_le, cast_le.mp <| le_trans (le_trans ?_ hple) hn⟩
-      simpa only [← cast_pow, cast_le] using le_pow this
+      exact Finset.mem_Icc.mpr ⟨hpabsprime.one_le, le_trans (le_pow this) hple⟩
     have := (isPrime_of_prime (prime_span_singleton_iff.mpr <|
       hpprime (hP.under _))).isMaximal <| by simp [((hpprime (hP.under _))).ne_zero]
     exact hspan ▸ inertiaDeg_pos ..

--- a/Mathlib/NumberTheory/NumberField/ClassNumber.lean
+++ b/Mathlib/NumberTheory/NumberField/ClassNumber.lean
@@ -7,6 +7,7 @@ import Mathlib.NumberTheory.ClassNumber.AdmissibleAbs
 import Mathlib.NumberTheory.ClassNumber.Finite
 import Mathlib.NumberTheory.NumberField.Discriminant.Basic
 import Mathlib.RingTheory.Ideal.IsPrincipal
+import Mathlib.NumberTheory.RamificationInertia.Basic
 
 /-!
 # Class numbers of number fields
@@ -18,15 +19,26 @@ on the class number.
 ## Main definitions
 - `NumberField.classNumber`: the class number of a number field is the (finite)
 cardinality of the class group of its ring of integers
-- `RingOfIntegers.isPrincipalIdealRing_of_isPrincipal_of_mem_primesOver_of_le`: to show that the
-ring of integer of a number field is a PID it is enough to show that all ideals above any (natural)
-prime `p` smaller than Minkowski bound are principal. This is the standard technique to prove that
-`𝓞 K` is principal, see [marcus1977number], discussion after Theorem 37.
+- `isPrincipalIdealRing_of_isPrincipal_of_le_pow_inertiaDeg_of_mem_primesOver_of_mem_Icc`: let `K`
+be a number field and let `M K` be the Minkowski bound of `K`. To show that `𝓞 K` is a PID it is
+enough to show that, for all (natural) prime `p ∈ Finset.Icc 1 ⌊(M K)⌋₊`, all ideals `P` above `p`
+such that `p ^ (span ({p}).inertiaDeg P)` are principal. This is the standard technique to prove
+that `𝓞 K` is principal, see [marcus1977number], discussion after Theorem 37.
+
+The way this theorem should be used is to first of all compute `⌊(M K)⌋₊` and then use `fin_cases`
+to deal with the finite number of primes `p` in the interval.
 -/
 
-namespace NumberField
+open scoped nonZeroDivisors Real
+
+open Module NumberField InfinitePlace Ideal Nat
 
 variable (K : Type*) [Field K] [NumberField K]
+
+local notation "M " K:70 => (4 / π) ^ nrComplexPlaces K *
+  ((finrank ℚ K)! / (finrank ℚ K) ^ (finrank ℚ K) * √|discr K|)
+
+namespace NumberField
 
 namespace RingOfIntegers
 
@@ -45,14 +57,9 @@ variable {K}
 theorem classNumber_eq_one_iff : classNumber K = 1 ↔ IsPrincipalIdealRing (𝓞 K) :=
   card_classGroup_eq_one_iff
 
-open Module NumberField.InfinitePlace Ideal Nat
-
-open scoped nonZeroDivisors Real
-
 theorem exists_ideal_in_class_of_norm_le (C : ClassGroup (𝓞 K)) :
     ∃ I : (Ideal (𝓞 K))⁰, ClassGroup.mk0 I = C ∧
-      absNorm (I : Ideal (𝓞 K)) ≤ (4 / π) ^ nrComplexPlaces K *
-      ((finrank ℚ K)! / (finrank ℚ K) ^ (finrank ℚ K) * √|discr K|) := by
+      absNorm (I : Ideal (𝓞 K)) ≤ M K := by
   obtain ⟨J, hJ⟩ := ClassGroup.mk0_surjective C⁻¹
   obtain ⟨_, ⟨a, ha, rfl⟩, h_nz, h_nm⟩ :=
     exists_ne_zero_mem_ideal_of_norm_le_mul_sqrt_discr K (FractionalIdeal.mk0 K J)
@@ -73,23 +80,27 @@ theorem exists_ideal_in_class_of_norm_le (C : ClassGroup (𝓞 K)) :
     refine le_of_mul_le_mul_of_pos_left h_nm ?_
     exact cast_pos.mpr <| pos_of_ne_zero <| absNorm_ne_zero_of_nonZeroDivisors J
 
-theorem _root_.RingOfIntegers.isPrincipalIdealRing_of_isPrincipal_of_norm_le
-    (h : ∀ ⦃I : (Ideal (𝓞 K))⁰⦄, absNorm (I : Ideal (𝓞 K)) ≤ (4 / π) ^ nrComplexPlaces K *
-      ((finrank ℚ K)! / (finrank ℚ K) ^ (finrank ℚ K) * √|discr K|) →
-      Submodule.IsPrincipal (I : Ideal (𝓞 K))) :
-    IsPrincipalIdealRing (𝓞 K) := by
+end NumberField
+
+namespace RingOfIntegers
+
+variable {K}
+
+open scoped NumberField
+
+theorem isPrincipalIdealRing_of_isPrincipal_of_norm_le
+    (h : ∀ ⦃I : (Ideal (𝓞 K))⁰⦄, absNorm (I : Ideal (𝓞 K)) ≤ M K →
+      Submodule.IsPrincipal (I : Ideal (𝓞 K))) : IsPrincipalIdealRing (𝓞 K) := by
   rw [← classNumber_eq_one_iff, classNumber, Fintype.card_eq_one_iff]
   refine ⟨1, fun C ↦ ?_⟩
   obtain ⟨I, rfl, hI⟩ := exists_ideal_in_class_of_norm_le C
   simpa [← ClassGroup.mk0_eq_one_iff] using h hI
 
-theorem _root_.RingOfIntegers.isPrincipalIdealRing_of_isPrincipal_of_norm_le_of_isPrime
+theorem isPrincipalIdealRing_of_isPrincipal_of_norm_le_of_isPrime
     (h : ∀ ⦃I : (Ideal (𝓞 K))⁰⦄, (I : Ideal (𝓞 K)).IsPrime →
-      absNorm (I : Ideal (𝓞 K)) ≤ (4 / π) ^ nrComplexPlaces K *
-      ((finrank ℚ K)! / (finrank ℚ K) ^ (finrank ℚ K) * √|discr K|) →
-      Submodule.IsPrincipal (I : Ideal (𝓞 K))) :
+      absNorm (I : Ideal (𝓞 K)) ≤ M K → Submodule.IsPrincipal (I : Ideal (𝓞 K))) :
     IsPrincipalIdealRing (𝓞 K) := by
-  refine RingOfIntegers.isPrincipalIdealRing_of_isPrincipal_of_norm_le (fun I hI ↦ ?_)
+  refine isPrincipalIdealRing_of_isPrincipal_of_norm_le (fun I hI ↦ ?_)
   rw [← mem_isPrincipalSubmonoid_iff,
     ← prod_normalizedFactors_eq_self (nonZeroDivisors.coe_ne_zero I)]
   refine Submonoid.multiset_prod_mem _ _ (fun J hJ ↦ mem_isPrincipalSubmonoid_iff.mp ?_)
@@ -101,50 +112,57 @@ theorem _root_.RingOfIntegers.isPrincipalIdealRing_of_isPrincipal_of_norm_le_of_
     absNorm_dvd_absNorm_of_le <| le_of_dvd <|
       UniqueFactorizationMonoid.dvd_of_mem_normalizedFactors hJ).trans hI
 
-/-- To show that the ring of integer of a number field is a PID it is enough to show that all ideals
-above any (natural) prime `p`  smaller than Minkowski bound are principal. -/
-theorem _root_.RingOfIntegers.isPrincipalIdealRing_of_isPrincipal_of_mem_primesOver_of_le
-    (h : ∀ ⦃p : ℕ⦄, p.Prime → p ≤ (4 / π) ^ nrComplexPlaces K *
-      ((finrank ℚ K)! / (finrank ℚ K) ^ (finrank ℚ K) * √|discr K|) →
-      ∀ (I : Ideal (𝓞 K)), I ∈ Ideal.primesOver (span {(p : ℤ)}) (𝓞 K) →
-      Submodule.IsPrincipal I) :
-    IsPrincipalIdealRing (𝓞 K) := by
-  refine RingOfIntegers.isPrincipalIdealRing_of_isPrincipal_of_norm_le_of_isPrime <|
-    fun ⟨P, HP⟩ hP hPNorm ↦ ?_
+/-- Let `K` be a number field and let `M K` be the Minkowski bound of `K`. To show that `𝓞 K` is a
+PID it is enough to show that, for all (natural) prime `p ∈ Finset.Icc 1 ⌊(M K)⌋₊`, all ideals `P`
+above `p` such that `p ^ (span ({p}).inertiaDeg P)` are principal. This is the standard technique to
+prove that `𝓞 K` is principal, see [marcus1977number], discussion after Theorem 37.
+
+The way this theorem should be used is to first of all compute `⌊(M K)⌋₊` and then use `fin_cases`
+to deal with the finite number of primes `p` in the interval. -/
+theorem isPrincipalIdealRing_of_isPrincipal_of_le_pow_inertiaDeg_of_mem_primesOver_of_mem_Icc
+    (h : ∀ p ∈ Finset.Icc 1 ⌊(M K)⌋₊, p.Prime → ∀ (P : Ideal (𝓞 K)),
+      P ∈ Ideal.primesOver (span {(p : ℤ)}) (𝓞 K) → p ^ ((span ({↑p} : Set ℤ)).inertiaDeg P) ≤ M K →
+      Submodule.IsPrincipal P) : IsPrincipalIdealRing (𝓞 K) := by
+  refine isPrincipalIdealRing_of_isPrincipal_of_norm_le_of_isPrime <|
+    fun ⟨P, HP⟩ hP hPN ↦ ?_
   obtain ⟨p, hp⟩ := IsPrincipalIdealRing.principal <| under ℤ P
   have hp0 : p ≠ 0 := fun h ↦ nonZeroDivisors.coe_ne_zero ⟨P, HP⟩ <|
     eq_bot_of_comap_eq_bot (R := ℤ) <| by simpa only [hp, submodule_span_eq, span_singleton_eq_bot]
   have hpprime := (span_singleton_prime hp0).mp
-  rw [← submodule_span_eq, ← hp] at hpprime
+  simp only [← submodule_span_eq, ← hp] at hpprime
   have hle : algebraMap ℤ (𝓞 K) p ∈ P := (mem_of_liesOver P (under ℤ P) p).mp <|
     hp ▸ Submodule.mem_span_singleton_self p
-  refine h (Int.prime_iff_natAbs_prime.mp (hpprime (hP.under _))) ?_ _ ⟨hP, ?_⟩
-  · refine le_trans (cast_le.mpr <| Nat.le_of_dvd ?_ (Int.ofNat_dvd_right.mp ?_)) hPNorm
-    · exact Nat.pos_of_ne_zero <| fun h ↦ nonZeroDivisors.coe_ne_zero ⟨P, HP⟩ <|
-        absNorm_eq_zero_iff.mp h
-    suffices (Algebra.norm ℤ (algebraMap ℤ (𝓞 K) p)) = p ^ (Module.finrank ℚ K) by
-      obtain ⟨i, -, hi⟩ := (dvd_prime_pow (hpprime (IsPrime.comap _)) _).mp
-        (this ▸ absNorm_dvd_norm_of_mem hle)
-      refine dvd_trans (dvd_pow_self p (fun h ↦ hP.ne_top (absNorm_eq_one_iff.mp ?_))) hi.dvd'
-      simp only [h, pow_zero, associated_one_iff_isUnit] at hi
-      exact ZMod.eq_one_of_isUnit_natCast hi
-    exact Rat.intCast_injective (by simp [Algebra.coe_norm_int, ← Algebra.norm_algebraMap])
-  · rcases abs_choice p with h | h <;>
-    simpa [h, span_singleton_neg p, ← submodule_span_eq, ← hp] using over_under P
+  have hlies : P.LiesOver (span {p}) := by
+    rcases abs_choice p with h | h <;>
+    simpa [h, span_singleton_neg p, ← submodule_span_eq, ← hp] using over_under (A := ℤ) P
+  have hspan : span {↑p.natAbs} = span {p} := by
+    rcases abs_choice p with h | h <;> simp [h]
+  have hple : p.natAbs ^ (span {(p.natAbs : ℤ)}).inertiaDeg P ≤ M K := by
+    simpa only [hspan, ← cast_pow, ← absNorm_eq_pow_inertiaDeg P (hpprime (hP.under _))] using hPN
+  have hpabsprime := Int.prime_iff_natAbs_prime.mp (hpprime (hP.under _))
+  refine h p.natAbs ?_ hpabsprime _ ⟨hP, ?_⟩ hple
+  · suffices 0 < (span {(p.natAbs : ℤ)}).inertiaDeg P by
+      refine Finset.mem_Icc.mpr ⟨hpabsprime.one_le, le_floor <| le_trans ?_ hple⟩
+      simpa only [← cast_pow, cast_le] using le_pow this
+    rw [hspan]
+    have : (span {p}).IsMaximal := (isPrime_of_prime (prime_span_singleton_iff.mpr <|
+      hpprime (hP.under _))).isMaximal <| by simp [((hpprime (hP.under _))).ne_zero]
+    exact inertiaDeg_pos ..
+  · simpa only [hspan] using hlies
 
-theorem _root_.RingOfIntegers.isPrincipalIdealRing_of_abs_discr_lt
+theorem isPrincipalIdealRing_of_abs_discr_lt
     (h : |discr K| < (2 * (π / 4) ^ nrComplexPlaces K *
       ((finrank ℚ K) ^ (finrank ℚ K) / (finrank ℚ K)!)) ^ 2) :
     IsPrincipalIdealRing (𝓞 K) := by
   have : 0 < finrank ℚ K := finrank_pos -- Lean needs to know this for `positivity` to succeed
   rw [← Real.sqrt_lt (by positivity) (by positivity), mul_assoc, ← inv_mul_lt_iff₀' (by positivity),
     mul_inv, ← inv_pow, inv_div, inv_div, mul_assoc, Int.cast_abs] at h
-  refine RingOfIntegers.isPrincipalIdealRing_of_isPrincipal_of_norm_le (fun I hI ↦ ?_)
+  refine isPrincipalIdealRing_of_isPrincipal_of_norm_le (fun I hI ↦ ?_)
   rw [absNorm_eq_one_iff.mp <| le_antisymm (lt_succ.mp (cast_lt.mp
     (lt_of_le_of_lt hI h))) <| one_le_iff_ne_zero.mpr (absNorm_ne_zero_of_nonZeroDivisors I)]
   exact top_isPrincipal
 
-end NumberField
+end RingOfIntegers
 
 namespace Rat
 

--- a/Mathlib/NumberTheory/NumberField/ClassNumber.lean
+++ b/Mathlib/NumberTheory/NumberField/ClassNumber.lean
@@ -125,8 +125,7 @@ The way this theorem should be used is to first compute `⌊(M K)⌋₊` and the
 to deal with the finite number of primes `p` in the interval. -/
 theorem isPrincipalIdealRing_of_isPrincipal_of_pow_inertiaDeg_le_of_mem_primesOver_of_mem_Icc
     (h : ∀ p ∈ Finset.Icc 1 ⌊(M K)⌋₊, p.Prime → ∀ (P : Ideal (𝓞 K)),
-      P ∈ Ideal.primesOver (span {(p : ℤ)}) (𝓞 K) →
-      p ^ ((span ({↑p} : Set ℤ)).inertiaDeg P) ≤ ⌊(M K)⌋₊ →
+      P ∈ primesOver (span {(p : ℤ)}) (𝓞 K) → p ^ ((span ({↑p} : Set ℤ)).inertiaDeg P) ≤ ⌊(M K)⌋₊ →
       Submodule.IsPrincipal P) : IsPrincipalIdealRing (𝓞 K) := by
   refine isPrincipalIdealRing_of_isPrincipal_of_norm_le_of_isPrime <|
     fun ⟨P, HP⟩ hP hPN ↦ ?_

--- a/Mathlib/NumberTheory/NumberField/ClassNumber.lean
+++ b/Mathlib/NumberTheory/NumberField/ClassNumber.lean
@@ -134,21 +134,20 @@ theorem isPrincipalIdealRing_of_isPrincipal_of_le_pow_inertiaDeg_of_mem_primesOv
     hp ▸ Submodule.mem_span_singleton_self p
   have hlies : P.LiesOver (span {p}) := by
     rcases abs_choice p with h | h <;>
-    simpa [h, span_singleton_neg p, ← submodule_span_eq, ← hp] using over_under (A := ℤ) P
+    simpa [h, span_singleton_neg p, ← submodule_span_eq, ← hp] using over_under P
   have hspan : span {↑p.natAbs} = span {p} := by
     rcases abs_choice p with h | h <;> simp [h]
   have hple : p.natAbs ^ (span {(p.natAbs : ℤ)}).inertiaDeg P ≤ M K := by
     simpa only [hspan, ← cast_pow, ← absNorm_eq_pow_inertiaDeg P (hpprime (hP.under _))] using hPN
   have hpabsprime := Int.prime_iff_natAbs_prime.mp (hpprime (hP.under _))
-  refine h p.natAbs ?_ hpabsprime _ ⟨hP, ?_⟩ hple
+  refine h _ ?_ hpabsprime _ ⟨hP, ?_⟩ hple
   · suffices 0 < (span {(p.natAbs : ℤ)}).inertiaDeg P by
       refine Finset.mem_Icc.mpr ⟨hpabsprime.one_le, le_floor <| le_trans ?_ hple⟩
       simpa only [← cast_pow, cast_le] using le_pow this
-    rw [hspan]
-    have : (span {p}).IsMaximal := (isPrime_of_prime (prime_span_singleton_iff.mpr <|
+    have := (isPrime_of_prime (prime_span_singleton_iff.mpr <|
       hpprime (hP.under _))).isMaximal <| by simp [((hpprime (hP.under _))).ne_zero]
-    exact inertiaDeg_pos ..
-  · simpa only [hspan] using hlies
+    exact hspan ▸ inertiaDeg_pos ..
+  · exact hspan ▸ hlies
 
 theorem isPrincipalIdealRing_of_abs_discr_lt
     (h : |discr K| < (2 * (π / 4) ^ nrComplexPlaces K *

--- a/Mathlib/NumberTheory/NumberField/ClassNumber.lean
+++ b/Mathlib/NumberTheory/NumberField/ClassNumber.lean
@@ -25,7 +25,7 @@ enough to show that, for all (natural) primes `p ∈ Finset.Icc 1 ⌊(M K)⌋₊
 such that `p ^ (span ({p}).inertiaDeg P)` are principal. This is the standard technique to prove
 that `𝓞 K` is principal, see [marcus1977number], discussion after Theorem 37.
 
-The way this theorem should be used is to first of all compute `⌊(M K)⌋₊` and then use `fin_cases`
+The way this theorem should be used is to first compute `⌊(M K)⌋₊` and then to use `fin_cases`
 to deal with the finite number of primes `p` in the interval.
 -/
 

--- a/Mathlib/NumberTheory/RamificationInertia/Basic.lean
+++ b/Mathlib/NumberTheory/RamificationInertia/Basic.lean
@@ -6,6 +6,7 @@ Authors: Anne Baanen
 import Mathlib.LinearAlgebra.Dimension.DivisionRing
 import Mathlib.RingTheory.DedekindDomain.Ideal
 import Mathlib.RingTheory.Finiteness.Quotient
+import Mathlib.RingTheory.Ideal.Norm.AbsNorm
 
 /-!
 # Ramification index and inertia degree
@@ -238,6 +239,23 @@ lemma inertiaDeg_map_eq [p.IsMaximal] (P : Ideal S)
 
 end DecEq
 
+
+section absNorm
+
+/-- The absolute norm of an ideal `P` above a rational prime `p` is
+`|p| ^ ((span {p}).inertiaDeg P)`. -/
+lemma absNorm_eq_pow_inertiaDeg [IsDedekindDomain R] [Module.Free ℤ R] [Module.Finite ℤ R] {p : ℤ}
+      (P : Ideal R) [P.LiesOver (span {p})] (hp: Prime p) :
+    absNorm P = p.natAbs ^ ((span {p}).inertiaDeg P) := by
+  have : (span {p}).IsMaximal :=
+    (isPrime_of_prime (prime_span_singleton_iff.mpr hp)).isMaximal (by simp [hp.ne_zero])
+  have h : Module.Finite (ℤ ⧸ span {p}) (R ⧸ P) := module_finite_of_liesOver P (span {p})
+  let _ : Field (ℤ ⧸ span {p}) := Quotient.field (span {p})
+  rw [inertiaDeg_algebraMap, absNorm_apply, Submodule.cardQuot_apply,
+    Module.natCard_eq_pow_finrank (K := ℤ ⧸ span {p})]
+  simp [Nat.card_congr (Int.quotientSpanEquivZMod p).toEquiv]
+
+end absNorm
 section FinrankQuotientMap
 
 open scoped nonZeroDivisors


### PR DESCRIPTION
We improve the statement of `RingOfIntegers.isPrincipalIdealRing_of_isPrincipal_of_mem_primesOver_of_le` to `RingOfIntegers.isPrincipalIdealRing_of_isPrincipal_of_le_pow_inertiaDeg_of_mem_primesOver_of_mem_Icc`: it is enough to only test primes `p` and ideals `P` such that `p ^ ((span {p}).inertiaDeg P` is less than Minkowski's bound.

We also improve the structure of the file.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
