### PR TITLE
[Merged by Bors] - feat : Add lemmas about `S⁻¹ R`-submodule membership

### DIFF
--- a/Mathlib/Algebra/Module/LocalizedModule/Submodule.lean
+++ b/Mathlib/Algebra/Module/LocalizedModule/Submodule.lean
@@ -211,8 +211,7 @@ In particular, if `M` is a localized module, then `x` is in the submodule `N'` i
 numerator under the image of `f` also lies in `N`. -/
 lemma mem_of_numerator_image_mem {N' : Submodule R' M'} {x : M'} {Num : M} {Den : S}
     (h : Den • x = f Num) (hNum : f Num ∈ N') : x ∈ N' := by
-  rw [← Submodule.smul_mem_iff_IsUnit N' (r := (algebraMap R R') Den)
-    (IsLocalization.map_units R' Den), algebraMap_smul]
+  rw [← Submodule.smul_mem_iff_IsUnit N' (IsLocalization.map_units R' Den), algebraMap_smul]
   show Den • x ∈ N'
   simpa [h] using hNum
 

--- a/Mathlib/Algebra/Module/LocalizedModule/Submodule.lean
+++ b/Mathlib/Algebra/Module/LocalizedModule/Submodule.lean
@@ -211,7 +211,7 @@ In particular, if `M` is a localized module, then `x` is in the submodule `N'` i
 numerator under the image of `f` also lies in `N`. -/
 lemma mem_of_numerator_image_mem {N' : Submodule R' M'} {x : M'} {Num : M} {Den : S}
     (h : Den • x = f Num) (hNum : f Num ∈ N') : x ∈ N' := by
-  rw [← smul_mem_iff_IsUnit N' (IsLocalization.map_units R' Den), algebraMap_smul]
+  rw [← smul_mem_iff_of_isUnit N' (IsLocalization.map_units R' Den), algebraMap_smul]
   show Den • x ∈ N'
   simpa [h] using hNum
 

--- a/Mathlib/Algebra/Module/LocalizedModule/Submodule.lean
+++ b/Mathlib/Algebra/Module/LocalizedModule/Submodule.lean
@@ -197,26 +197,6 @@ lemma localized'_le_localized'_of_smul_le {P Q : Submodule R M} (x : p) (h : x �
     P.localized' S p f ≤ Q.localized' S p f :=
   localized₀_le_localized₀_of_smul_le p f x h
 
-section numerator
-
-variable {R : Type*} [CommSemiring R] (S : Submonoid R)
-variable {M M': Type*} [AddCommMonoid M']
-variable {R' : Type*} [CommSemiring R'] [Algebra R R'] [Module R' M'] [IsLocalization S R']
-variable [Module R M'] [IsScalarTower R R' M']
-variable (f : M → M')
-
-/-- If `x` in a `R' = S⁻¹ R`-module `M'` such that `Den • x = f Num` for some `Num : M` and
-`Den : S`, then `x` is in the submodule `N'` of `M'` if `f Num` is in `N'`.
-In particular, if `M` is a localized module, then `x` is in the submodule `N'` if its
-numerator under the image of `f` also lies in `N`. -/
-lemma mem_of_numerator_image_mem {N' : Submodule R' M'} {x : M'} {Num : M} {Den : S}
-    (h : Den • x = f Num) (hNum : f Num ∈ N') : x ∈ N' := by
-  rw [← smul_mem_iff_of_isUnit N' (IsLocalization.map_units R' Den), algebraMap_smul]
-  show Den • x ∈ N'
-  simpa [h] using hNum
-
-end numerator
-
 end Submodule
 
 section Quotient

--- a/Mathlib/Algebra/Module/LocalizedModule/Submodule.lean
+++ b/Mathlib/Algebra/Module/LocalizedModule/Submodule.lean
@@ -206,7 +206,9 @@ variable [Module R M'] [IsScalarTower R R' M']
 variable (f : M → M')
 
 /-- If `x` in a `R' = S⁻¹ R`-module `M'` such that `Den • x = f Num` for some `Num : M` and
-`Den : S`, then `x` is in the submodule `N'` of `M'` if `f Num` is in `N'`. -/
+`Den : S`, then `x` is in the submodule `N'` of `M'` if `f Num` is in `N'`.
+In particular, if `M` is a localized module, then `x` is in the submodule `N'` if its
+numerator under the image of `f` also lies in `N`. -/
 lemma mem_of_numerator_image_mem {N' : Submodule R' M'} {x : M'} {Num : M} {Den : S}
     (h : Den • x = f Num) (hNum : f Num ∈ N') : x ∈ N' := by
   rw [← Submodule.smul_mem_iff_IsUnit N' (r := (algebraMap R R') Den)

--- a/Mathlib/Algebra/Module/LocalizedModule/Submodule.lean
+++ b/Mathlib/Algebra/Module/LocalizedModule/Submodule.lean
@@ -197,6 +197,25 @@ lemma localized'_le_localized'_of_smul_le {P Q : Submodule R M} (x : p) (h : x �
     P.localized' S p f ≤ Q.localized' S p f :=
   localized₀_le_localized₀_of_smul_le p f x h
 
+section numerator
+
+variable {R : Type*} [CommSemiring R] (S : Submonoid R)
+variable {M M': Type*} [AddCommMonoid M']
+variable {R' : Type*} [CommSemiring R'] [Algebra R R'] [Module R' M'] [IsLocalization S R']
+variable [Module R M'] [IsScalarTower R R' M']
+variable (f : M → M')
+
+/-- If `x` in a `R' = S⁻¹ R`-module `M'` such that `Den • x = f Num` for some `Num : M` and
+`Den : S`, then `x` is in the submodule `N'` of `M'` if `f Num` is in `N'`. -/
+lemma mem_of_numerator_image_mem {N' : Submodule R' M'} {x : M'} {Num : M} {Den : S}
+    (h : Den • x = f Num) (hNum : f Num ∈ N') : x ∈ N' := by
+  rw [← Submodule.smul_mem_iff_IsUnit N' (r := (algebraMap R R') Den)
+    (IsLocalization.map_units R' Den), algebraMap_smul]
+  show Den • x ∈ N'
+  simpa [h] using hNum
+
+end numerator
+
 end Submodule
 
 section Quotient

--- a/Mathlib/Algebra/Module/LocalizedModule/Submodule.lean
+++ b/Mathlib/Algebra/Module/LocalizedModule/Submodule.lean
@@ -211,7 +211,7 @@ In particular, if `M` is a localized module, then `x` is in the submodule `N'` i
 numerator under the image of `f` also lies in `N`. -/
 lemma mem_of_numerator_image_mem {N' : Submodule R' M'} {x : M'} {Num : M} {Den : S}
     (h : Den • x = f Num) (hNum : f Num ∈ N') : x ∈ N' := by
-  rw [← Submodule.smul_mem_iff_IsUnit N' (IsLocalization.map_units R' Den), algebraMap_smul]
+  rw [← smul_mem_iff_IsUnit N' (IsLocalization.map_units R' Den), algebraMap_smul]
   show Den • x ∈ N'
   simpa [h] using hNum
 

--- a/Mathlib/Algebra/Module/Submodule/Defs.lean
+++ b/Mathlib/Algebra/Module/Submodule/Defs.lean
@@ -212,8 +212,7 @@ lemma smul_mem_iff'' [Invertible r] :
   rw [← invOf_smul_smul r x]
   exact p.smul_mem _ h
 
-@[simp]
-lemma smul_mem_iff_IsUnit (hr : IsUnit r) :
+lemma smul_mem_iff_of_isUnit (hr : IsUnit r) :
     r • x ∈ p ↔ x ∈ p :=
   let _ : Invertible r := hr.invertible
   smul_mem_iff'' p

--- a/Mathlib/Algebra/Module/Submodule/Defs.lean
+++ b/Mathlib/Algebra/Module/Submodule/Defs.lean
@@ -213,7 +213,7 @@ lemma smul_mem_iff'' [Invertible r] :
   exact p.smul_mem _ h
 
 @[simp]
-lemma smul_mem_iff_IsUnit (hr : IsUnit r) :
+lemma smul_mem_iff_of_isUnit (hr : IsUnit r) :
     r • x ∈ p ↔ x ∈ p :=
   let _ : Invertible r := hr.invertible
   smul_mem_iff'' p

--- a/Mathlib/Algebra/Module/Submodule/Defs.lean
+++ b/Mathlib/Algebra/Module/Submodule/Defs.lean
@@ -212,6 +212,12 @@ lemma smul_mem_iff'' [Invertible r] :
   rw [← invOf_smul_smul r x]
   exact p.smul_mem _ h
 
+@[simp]
+lemma smul_mem_iff_IsUnit (hr : IsUnit r) :
+    r • x ∈ p ↔ x ∈ p :=
+  let _ : Invertible r := hr.invertible
+  smul_mem_iff'' p
+
 instance add : Add p :=
   ⟨fun x y => ⟨x.1 + y.1, add_mem x.2 y.2⟩⟩
 

--- a/Mathlib/Algebra/Module/Submodule/Defs.lean
+++ b/Mathlib/Algebra/Module/Submodule/Defs.lean
@@ -212,7 +212,6 @@ lemma smul_mem_iff'' [Invertible r] :
   rw [← invOf_smul_smul r x]
   exact p.smul_mem _ h
 
-@[simp]
 lemma smul_mem_iff_of_isUnit (hr : IsUnit r) :
     r • x ∈ p ↔ x ∈ p :=
   let _ : Invertible r := hr.invertible

--- a/Mathlib/RingTheory/Localization/Basic.lean
+++ b/Mathlib/RingTheory/Localization/Basic.lean
@@ -235,6 +235,22 @@ theorem algEquivOfAlgEquiv_symm : (algEquivOfAlgEquiv S Q h H).symm =
 
 end AlgEquivOfAlgEquiv
 
+section smul
+
+variable {R : Type*} [CommSemiring R] (S : Submonoid R)
+variable {R' : Type*} [CommSemiring R'] [Algebra R R'] [IsLocalization S R']
+variable {M': Type*} [AddCommMonoid M'] [Module R' M'] [Module R M'] [IsScalarTower R R' M']
+
+/-- If `x` in a `R' = S⁻¹ R`-module `M'`, then for a submodule `N'` of `M'`,
+`s • x ∈ N'` if and only if `x ∈ N'` for some `s` in S. -/
+lemma smul_mem_iff {N' : Submodule R' M'} {x : M'} {s : S} :
+    s • x ∈ N' ↔ x ∈ N' := by
+  refine ⟨fun h ↦ ?_, fun h ↦ Submodule.smul_of_tower_mem N' s h⟩
+  rwa [← Submodule.smul_mem_iff_of_isUnit (r := algebraMap R R' s) N' (map_units R' s),
+    algebraMap_smul]
+
+end smul
+
 section at_units
 
 variable (R M)

--- a/Mathlib/RingTheory/Localization/Basic.lean
+++ b/Mathlib/RingTheory/Localization/Basic.lean
@@ -237,7 +237,7 @@ end AlgEquivOfAlgEquiv
 
 section smul
 
-variable {R : Type*} [CommSemiring R] (S : Submonoid R)
+variable {R : Type*} [CommSemiring R] {S : Submonoid R}
 variable {R' : Type*} [CommSemiring R'] [Algebra R R'] [IsLocalization S R']
 variable {M': Type*} [AddCommMonoid M'] [Module R' M'] [Module R M'] [IsScalarTower R R' M']
 


### PR DESCRIPTION
This PR introduces the lemma `IsLocalization.smul_mem_iff`. 
In particular, this lemma gives a criterion to verify an element's membership in submodules of localized modules.