### PR TITLE
[Merged by Bors] - refactor: change `CWComplex` from `abbrev` to its own `class`

### DIFF
--- a/Mathlib/Topology/CWComplex/Classical/Basic.lean
+++ b/Mathlib/Topology/CWComplex/Classical/Basic.lean
@@ -106,32 +106,68 @@ RelCWComplex.mapsto := Topology.RelCWComplex.mapsTo
 
 /-- Characterizing when a subspace `C` of a topological space `X` is a CW complex. Note that this
 requires `C` to be closed. If `C` is not closed choose `X` to be `C`. -/
-abbrev CWComplex {X : Type*} [TopologicalSpace X] (C : Set X) := RelCWComplex C ∅
+class CWComplex.{u} {X : Type u} [TopologicalSpace X] (C : Set X) where
+  /-- The indexing type of the cells of dimension `n`. -/
+  protected cell (n : ℕ) : Type u
+  /-- The characteristic map of the `n`-cell given by the index `i`.
+  This map is a bijection when restricting to `ball 0 1`, where we consider `(Fin n → ℝ)`
+  endowed with the maximum metric. -/
+  protected map (n : ℕ) (i : cell n) : PartialEquiv (Fin n → ℝ) X
+  /-- The source of every characteristic map of dimension `n` is
+  `(ball 0 1 : Set (Fin n → ℝ))`. -/
+  protected source_eq (n : ℕ) (i : cell n) : (map n i).source = ball 0 1
+  /-- The characteristic maps are continuous when restricting to `closedBall 0 1`. -/
+  protected continuousOn (n : ℕ) (i : cell n) : ContinuousOn (map n i) (closedBall 0 1)
+  /-- The inverse of the restriction to `ball 0 1` is continuous on the image. -/
+  protected continuousOn_symm (n : ℕ) (i : cell n) : ContinuousOn (map n i).symm (map n i).target
+  /-- The open cells are pairwise disjoint. Use `RelCWComplex.pairwiseDisjoint` or
+  `RelCWComplex.disjoint_openCell_of_ne` instead. -/
+  protected pairwiseDisjoint' :
+    (univ : Set (Σ n, cell n)).PairwiseDisjoint (fun ni ↦ map ni.1 ni.2 '' ball 0 1)
+  /-- The boundary of a cell is contained in a finite union of closed cells of a lower dimension.
+  Use `CWComplex.mapsTo` or `CWComplex.cellFrontier_subset_finite_closedCell` instead. -/
+  protected mapsTo' (n : ℕ) (i : cell n) : ∃ I : Π m, Finset (cell m),
+    MapsTo (map n i) (sphere 0 1) (⋃ (m < n) (j ∈ I m), map m j '' closedBall 0 1)
+  /-- A CW complex has weak topology, i.e. a set `A` in `X` is closed iff its intersection with
+  every closed cell is closed. Use `CWComplex.closed` instead. -/
+  protected closed' (A : Set X) (hAC : A ⊆ C) :
+    (∀ n j, IsClosed (A ∩ map n j '' closedBall 0 1)) → IsClosed A
+  /-- The union of all closed cells equals `C`. Use `CWComplex.union` instead. -/
+  protected union' : ⋃ (n : ℕ) (j : cell n), map n j '' closedBall 0 1 = C
 
-/-- A constructor for `CWComplex`. -/
-def CWComplex.mk.{u} {X : Type u} [TopologicalSpace X] (C : Set X)
-    (cell : ℕ → Type u) (map : (n : ℕ) → (i : cell n) → PartialEquiv (Fin n → ℝ) X)
-    (source_eq : ∀ (n : ℕ) (i : cell n), (map n i).source = ball 0 1)
-    (continuousOn : ∀ (n : ℕ) (i : cell n), ContinuousOn (map n i) (closedBall 0 1))
-    (continuousOn_symm : ∀ (n : ℕ) (i : cell n), ContinuousOn (map n i).symm (map n i).target)
-    (pairwiseDisjoint' :
-      (univ : Set (Σ n, cell n)).PairwiseDisjoint (fun ni ↦ map ni.1 ni.2 '' ball 0 1))
-    (mapsTo : ∀ n i, ∃ I : Π m, Finset (cell m),
-      MapsTo (map n i) (sphere 0 1) (⋃ (m < n) (j ∈ I m), map m j '' closedBall 0 1))
-    (closed' : ∀ (A : Set X), (asubc : A ⊆ C) →
-      (∀ n j, IsClosed (A ∩ map n j '' closedBall 0 1)) → IsClosed A)
-    (union' : ⋃ (n : ℕ) (j : cell n), map n j '' closedBall 0 1 = C) : CWComplex C where
-  cell := cell
+@[simps]
+instance (priority := high) CWComplex.instRelCWComplex {X : Type*} [TopologicalSpace X] (C : Set X)
+    [CWComplex C] : RelCWComplex C ∅ where
+  cell := CWComplex.cell C
+  map := CWComplex.map
+  source_eq := CWComplex.source_eq
+  continuousOn := CWComplex.continuousOn
+  continuousOn_symm := CWComplex.continuousOn_symm
+  pairwiseDisjoint' := CWComplex.pairwiseDisjoint'
+  disjointBase' := by simp [disjoint_empty]
+  mapsTo := by simpa only [empty_union] using CWComplex.mapsTo'
+  closed' := by simpa only [inter_empty, isClosed_empty, and_true] using CWComplex.closed'
+  isClosedBase := isClosed_empty
+  union' := by simpa only [empty_union] using CWComplex.union'
+
+@[simps -isSimp]
+def RelCWComplex.toCWComplex {X : Type*} [TopologicalSpace X] (C : Set X) [RelCWComplex C ∅] :
+    CWComplex C where
+  cell := cell C
   map := map
   source_eq := source_eq
   continuousOn := continuousOn
   continuousOn_symm := continuousOn_symm
   pairwiseDisjoint' := pairwiseDisjoint'
-  disjointBase' := by simp only [disjoint_empty, implies_true]
-  mapsTo := by simpa only [empty_union]
-  closed' := by simpa only [inter_empty, isClosed_empty, and_true]
-  isClosedBase := isClosed_empty
-  union' := by simpa only [empty_union]
+  mapsTo' := by simpa using mapsTo (C := C)
+  closed' := by
+    have := closed' (C := C)
+    simpa using closed' (C := C)
+  union' := by simpa using union' (C := C)
+
+lemma RelCWComplex.toCWComplex_eq {X : Type*} [TopologicalSpace X] (C : Set X)
+    [h : RelCWComplex C ∅] : (toCWComplex C).instRelCWComplex = h :=
+  rfl
 
 variable {X : Type*} [t : TopologicalSpace X] {C D : Set X}
 

--- a/Mathlib/Topology/CWComplex/Classical/Basic.lean
+++ b/Mathlib/Topology/CWComplex/Classical/Basic.lean
@@ -49,6 +49,18 @@ together.
   Overall this means that being a CW complex is treated more like a property than data.
 * The natural number is explicit in `openCell`, `closedCell` and `cellFrontier` because `cell n` and
   `cell m` might be the same type in an explicit CW complex even when `n` and `m` are different.
+* `CWComplex` is a separate class from `RelCWComplex`. This not only gives absolute CW complexes a
+  better constructor but also aids typeclass inference: a construction on relative CW complexes may
+  yield a base that for the special case of CW complexes is provably equal to the empty set but not
+  definitionally so. In that case we define an instance specifically for absolute CW complexes and
+  want this to be inferred over the relative version. Since the base is an `outParam` this is
+  especially necessary since you cannot provide typeclass inference with a specified base.
+  But having the type `CWComplex` be separate from `RelCWComplex` makes this specification possible.
+* For a similar reason to the previous bullet point we make the instance
+  `CWComplex.instRelCWComplex` have high priority. For example, when talking about the type of
+  cells `cell C` of an absolute CW complex `C`, this actually refers to `RelCWComplex.cell C`
+  through this instance. Again, we want typeclass inference to first consider absolute CW
+  structures.
 * For statements, the auxiliary construction `skeletonLT` is preferred over `skeleton` as it makes
   the base case of inductions easier. The statement about `skeleton` should then be derived from the
   one about `skeletonLT`.

--- a/Mathlib/Topology/CWComplex/Classical/Basic.lean
+++ b/Mathlib/Topology/CWComplex/Classical/Basic.lean
@@ -150,6 +150,7 @@ instance (priority := high) CWComplex.instRelCWComplex {X : Type*} [TopologicalS
   isClosedBase := isClosed_empty
   union' := by simpa only [empty_union] using CWComplex.union'
 
+/-- A relative CW complex with an empty base is an absolute CW complex. -/
 @[simps -isSimp]
 def RelCWComplex.toCWComplex {X : Type*} [TopologicalSpace X] (C : Set X) [RelCWComplex C ∅] :
     CWComplex C where

--- a/Mathlib/Topology/CWComplex/Classical/Basic.lean
+++ b/Mathlib/Topology/CWComplex/Classical/Basic.lean
@@ -135,7 +135,7 @@ class CWComplex.{u} {X : Type u} [TopologicalSpace X] (C : Set X) where
   /-- The union of all closed cells equals `C`. Use `CWComplex.union` instead. -/
   protected union' : ⋃ (n : ℕ) (j : cell n), map n j '' closedBall 0 1 = C
 
-@[simps]
+@[simps -isSimp]
 instance (priority := high) CWComplex.instRelCWComplex {X : Type*} [TopologicalSpace X] (C : Set X)
     [CWComplex C] : RelCWComplex C ∅ where
   cell := CWComplex.cell C

--- a/Mathlib/Topology/CWComplex/Classical/Basic.lean
+++ b/Mathlib/Topology/CWComplex/Classical/Basic.lean
@@ -94,7 +94,7 @@ class RelCWComplex.{u} {X : Type u} [TopologicalSpace X] (C : Set X) (D : outPar
     MapsTo (map n i) (sphere 0 1) (D ∪ ⋃ (m < n) (j ∈ I m), map m j '' closedBall 0 1)
   /-- A CW complex has weak topology, i.e. a set `A` in `X` is closed iff its intersection with
   every closed cell and `D` is closed. Use `RelCWComplex.closed` instead. -/
-  closed' (A : Set X) (asubc : A ⊆ C) :
+  closed' (A : Set X) (hAC : A ⊆ C) :
     ((∀ n j, IsClosed (A ∩ map n j '' closedBall 0 1)) ∧ IsClosed (A ∩ D)) → IsClosed A
   /-- The base `D` is closed. -/
   isClosedBase : IsClosed D
@@ -120,8 +120,8 @@ class CWComplex.{u} {X : Type u} [TopologicalSpace X] (C : Set X) where
   protected continuousOn (n : ℕ) (i : cell n) : ContinuousOn (map n i) (closedBall 0 1)
   /-- The inverse of the restriction to `ball 0 1` is continuous on the image. -/
   protected continuousOn_symm (n : ℕ) (i : cell n) : ContinuousOn (map n i).symm (map n i).target
-  /-- The open cells are pairwise disjoint. Use `RelCWComplex.pairwiseDisjoint` or
-  `RelCWComplex.disjoint_openCell_of_ne` instead. -/
+  /-- The open cells are pairwise disjoint. Use `CWComplex.pairwiseDisjoint` or
+  `CWComplex.disjoint_openCell_of_ne` instead. -/
   protected pairwiseDisjoint' :
     (univ : Set (Σ n, cell n)).PairwiseDisjoint (fun ni ↦ map ni.1 ni.2 '' ball 0 1)
   /-- The boundary of a cell is contained in a finite union of closed cells of a lower dimension.
@@ -161,9 +161,7 @@ def RelCWComplex.toCWComplex {X : Type*} [TopologicalSpace X] (C : Set X) [RelCW
   continuousOn_symm := continuousOn_symm
   pairwiseDisjoint' := pairwiseDisjoint'
   mapsTo' := by simpa using mapsTo (C := C)
-  closed' := by
-    have := closed' (C := C)
-    simpa using closed' (C := C)
+  closed' := by simpa using closed' (C := C)
   union' := by simpa using union' (C := C)
 
 lemma RelCWComplex.toCWComplex_eq {X : Type*} [TopologicalSpace X] (C : Set X)

--- a/Mathlib/Topology/CWComplex/Classical/Finite.lean
+++ b/Mathlib/Topology/CWComplex/Classical/Finite.lean
@@ -143,14 +143,12 @@ def CWComplex.mkFiniteType.{u} {X : Type u} [TopologicalSpace X] (C : Set X)
   continuousOn := continuousOn
   continuousOn_symm := continuousOn_symm
   pairwiseDisjoint' := pairwiseDisjoint'
-  disjointBase' := by simp only [disjoint_empty, implies_true]
-  mapsTo n i := by
+  mapsTo' n i := by
     use fun m ↦ finite_univ.toFinset (s := (univ : Set (cell m)))
-    simp only [Finite.mem_toFinset, mem_univ, iUnion_true, empty_union]
+    simp only [Finite.mem_toFinset, mem_univ, iUnion_true]
     exact mapsTo n i
-  closed' := by simpa only [inter_empty, isClosed_empty, and_true]
-  isClosedBase := isClosed_empty
-  union' := by simpa only [empty_union]
+  closed' := closed'
+  union' := union'
 
 /-- A CW complex that was constructed using `CWComplex.mkFiniteType` is of finite type. -/
 lemma CWComplex.finiteType_mkFiniteType.{u} {X : Type u} [TopologicalSpace X] (C : Set X)
@@ -259,10 +257,10 @@ def CWComplex.mkFinite.{u} {X : Type u} [TopologicalSpace X] (C : Set X)
     (continuousOn_symm : ∀ (n : ℕ) (i : cell n), ContinuousOn (map n i).symm (map n i).target)
     (pairwiseDisjoint' :
       (univ : Set (Σ n, cell n)).PairwiseDisjoint (fun ni ↦ map ni.1 ni.2 '' ball 0 1))
-    (mapsTo : ∀ (n : ℕ) (i : cell n),
+    (mapsTo' : ∀ (n : ℕ) (i : cell n),
       MapsTo (map n i) (sphere 0 1) (⋃ (m < n) (j : cell m), map m j '' closedBall 0 1))
     (union' : ⋃ (n : ℕ) (j : cell n), map n j '' closedBall 0 1 = C) :
-    CWComplex C := RelCWComplex.mkFinite C ∅
+    CWComplex C := (RelCWComplex.mkFinite C ∅
   (cell := cell)
   (map := map)
   (eventually_isEmpty_cell := eventually_isEmpty_cell)
@@ -274,7 +272,7 @@ def CWComplex.mkFinite.{u} {X : Type u} [TopologicalSpace X] (C : Set X)
   (disjointBase' := by simp only [disjoint_empty, implies_true])
   (mapsTo := by simpa only [empty_union])
   (isClosedBase := isClosed_empty)
-  (union' := by simpa only [empty_union])
+  (union' := by simpa only [empty_union])).toCWComplex
 
 /-- A CW complex that was constructed using `CWComplex.mkFinite` is finite. -/
 lemma CWComplex.finite_mkFinite.{u} {X : Type u} [TopologicalSpace X] (C : Set X)


### PR DESCRIPTION
This PR makes the classical absolute CW complex into its own class. This is done to
- make typeclass inference able to infer facts about `CWComplex` without always passing through `RelCWComplex`es, and
- to give `CWComplex` a constructor so constructing instances of `CWComplex` is easier.

The reason why the fields of `CWComplex` are `protected` is that we always want `cell` and `map` to refer to `RelCWComplex.cell` and `RelCWComplex.map` through the instance: that ensures that lemmas about `RelCWComplex` directly apply to `CWComplex`. Since all of these fields talk about the `CWComplex` versions of `map` and `cell` they should never be used.

Co-authored-by: Floris van Doorn <fpvdoorn@gmail.com>

---

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
