### PR TITLE
[Merged by Bors] - feat(BigOperators/Finset): add `Finset.card_preimage_eq_sum_card_image_eq`

### DIFF
--- a/Mathlib/Algebra/BigOperators/Ring/Nat.lean
+++ b/Mathlib/Algebra/BigOperators/Ring/Nat.lean
@@ -4,7 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Pim Otte
 -/
 import Mathlib.Algebra.BigOperators.Group.Finset.Lemmas
-import Mathlib.Algebra.Ring.Parity
+import Mathlib.Data.Set.Finite.Lattice
+import Mathlib.SetTheory.Cardinal.Finite
 
 /-!
 # Big operators on a finset in the natural numbers
@@ -28,5 +29,23 @@ lemma even_sum_iff_even_card_odd {s : Finset ι} (f : ι → ℕ) :
 lemma odd_sum_iff_odd_card_odd {s : Finset ι} (f : ι → ℕ) :
     Odd (∑ i ∈ s, f i) ↔ Odd #{x ∈ s | Odd (f x)} := by
   simp only [← Nat.not_even_iff_odd, even_sum_iff_even_card_odd]
+
+theorem card_preimage_eq_sum_card_image_eq {M : Type*} [DecidableEq M] {f : ι → M} {s : Finset M}
+    (hb : ∀ b ∈ s, Set.Finite {a | f a = b}) :
+    Nat.card (f⁻¹' s) = ∑ b ∈ s, Nat.card {a // f a = b} := by
+  -- `t = s ∩ Set.range f` as a `Finset`
+  let t := (Set.finite_coe_iff.mp (Finite.Set.finite_inter_of_left ↑s (Set.range f))).toFinset
+  rw [show Nat.card (f⁻¹' s) = Nat.card (f⁻¹' t) by simp [t]]
+  rw [show ∑ b ∈ s, Nat.card {a //f a = b} = ∑ b ∈ t, Nat.card {a | f a = b} by
+    exact (Finset.sum_subset (by simp [t]) (by aesop)).symm]
+  have ht : Set.Finite (f⁻¹' t) := Set.Finite.preimage' (finite_toSet t) (by aesop)
+  rw [Nat.card_eq_card_finite_toFinset ht, Finset.card_eq_sum_card_image (f := f)]
+  refine Finset.sum_congr ?_ fun m hm ↦ ?_
+  · simpa [← Finset.coe_inj, t] using Set.image_preimage_eq_inter_range
+  · rw [Nat.card_eq_card_finite_toFinset (hb _ (by aesop))]
+    suffices {a | f a = m} ⊆ ht.toFinset from
+      congr_arg (Finset.card ·) (Finset.ext_iff.mpr fun a ↦ by simpa using fun h ↦ this h)
+    intro _ h
+    simpa using by rwa [h]
 
 end Finset


### PR DESCRIPTION
Add a version of [Finset.card_eq_sum_card_image](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Algebra/BigOperators/Group/Finset/Basic.html#Finset.card_eq_sum_card_image) where the sum is overt the inverse image of a `Finset`:
```lean
theorem card_preimage_eq_sum_card_image_eq {M : Type*} [DecidableEq M] {f : ι → M} {s : Finset M}
    (hb : ∀ b ∈ s, Set.Finite {a | f a = b}) :
    Nat.card (f⁻¹' s) = ∑ b ∈ s, Nat.card {a // f a = b} 
```
However, since the ambient type `ι` is not necessary finite, this result is stated in terms of `Nat.card` and not `Finset.card`. For this reason, it cannot live in `Algebra.BigOperators.Group.Finset.Basic` like `Finset.card_eq_sum_card_image` since `Nat.card` (and some additional results about `Nat.card`) are not imported in this file and I didn't want to add imports to a basic file. 

In the end, I added it instead to `Algebra.BigOperators.Ring.Nat` which is about sums and natural numbers but still some modification of imports was necessary. The bot is reporting however that `there is no significant changes to the import graph`.

This PR is part of the proof of the Analytic Class Number Formula.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
