### PR TITLE
[Merged by Bors] - refactor: reorder Topology/CWComplex/Classical/Basic.lean

### DIFF
--- a/Mathlib/Topology/CWComplex/Classical/Basic.lean
+++ b/Mathlib/Topology/CWComplex/Classical/Basic.lean
@@ -257,10 +257,9 @@ lemma CWComplex.closed (C : Set X) [CWComplex C] [T2Space X] (A : Set X) (asubc 
   simp_all
 
 lemma RelCWComplex.closedCell_subset_complex [RelCWComplex C D] (n : ℕ) (j : cell C n) :
-    closedCell n j ⊆ C :=  by
+    closedCell n j ⊆ C := by
   simp_rw [← union]
-  apply subset_union_of_subset_right
-  exact subset_iUnion₂ _ _
+  exact subset_union_of_subset_right (subset_iUnion₂ _ _) _
 
 lemma RelCWComplex.openCell_subset_complex [RelCWComplex C D] (n : ℕ) (j : cell C n) :
     openCell n j ⊆ C :=
@@ -297,7 +296,7 @@ lemma RelCWComplex.isClosed [T2Space X] [RelCWComplex C D] : IsClosed C := by
 
 /-- A helper lemma that is essentially the same as `RelCWComplex.iUnion_openCell_eq_skeletonLT`.
 Use that lemma instead. -/
-protected lemma RelCWComplex.iUnion_openCell_eq_iUnion_closedCell [RelCWComplex C D] (n : ℕ∞) :
+private lemma RelCWComplex.iUnion_openCell_eq_iUnion_closedCell [RelCWComplex C D] (n : ℕ∞) :
     D ∪ ⋃ (m : ℕ) (_ : m < n) (j : cell C m), openCell m j =
       D ∪ ⋃ (m : ℕ) (_ : m < n) (j : cell C m), closedCell m j := by
   apply subset_antisymm

--- a/Mathlib/Topology/CWComplex/Classical/Basic.lean
+++ b/Mathlib/Topology/CWComplex/Classical/Basic.lean
@@ -222,31 +222,6 @@ lemma RelCWComplex.map_zero_mem_closedCell [RelCWComplex C D] (n : ℕ) (i : cel
     map n i 0 ∈ closedCell n i :=
   openCell_subset_closedCell _ _ (map_zero_mem_openCell _ _)
 
-/-- A non-standard definition of the `n`-skeleton of a CW complex for `n ∈ ℕ ∪ {∞}`.
-This allows the base case of induction to be about the base instead of being about the union of
-the base and some points.
-The standard `skeleton` is defined in terms of `skeletonLT`. `skeletonLT` is preferred
-in statements. You should then derive the statement about `skeleton`. -/
-def RelCWComplex.skeletonLT (C : Set X) {D : Set X} [RelCWComplex C D] (n : ℕ∞) : Set X :=
-  D ∪ ⋃ (m : ℕ) (_ : m < n) (j : cell C m), closedCell m j
-
-/-- The `n`-skeleton of a CW complex, for `n ∈ ℕ ∪ {∞}`. For statements use `skeletonLT` instead
-and then derive the statement about `skeleton`. -/
-def RelCWComplex.skeleton (C : Set X) {D : Set X} [RelCWComplex C D] (n : ℕ∞) : Set X :=
-  skeletonLT C (n + 1)
-
-namespace CWComplex
-
-export RelCWComplex (skeletonLT skeleton)
-
-end CWComplex
-
-lemma RelCWComplex.skeletonLT_zero_eq_base [RelCWComplex C D] : skeletonLT C 0 = D := by
-  simp only [skeletonLT, ENat.not_lt_zero, iUnion_of_empty, iUnion_empty, union_empty]
-
-lemma CWComplex.skeletonLT_zero_eq_empty [CWComplex C] : skeletonLT C 0 = ∅ :=
-    RelCWComplex.skeletonLT_zero_eq_base
-
 lemma RelCWComplex.isCompact_closedCell [RelCWComplex C D] {n : ℕ} {i : cell C n} :
     IsCompact (closedCell n i) :=
   (isCompact_closedBall _ _).image_of_continuousOn (continuousOn n i)
@@ -281,91 +256,19 @@ lemma CWComplex.closed (C : Set X) [CWComplex C] [T2Space X] (A : Set X) (asubc 
   have := RelCWComplex.closed C A asubc
   simp_all
 
-@[simp] lemma RelCWComplex.skeletonLT_top [RelCWComplex C D] : skeletonLT C ⊤ = C := by
-  simp [skeletonLT, union]
-
-@[simp] lemma RelCWComplex.skeleton_top [RelCWComplex C D] : skeleton C ⊤ = C := skeletonLT_top
-
-lemma RelCWComplex.skeletonLT_mono [RelCWComplex C D] {n m : ℕ∞} (h : m ≤ n) :
-    skeletonLT C m ⊆ skeletonLT C n := by
-  apply union_subset_union_right
-  intro x xmem
-  simp_rw [mem_iUnion, exists_prop] at xmem ⊢
-  obtain ⟨l , lltm, xmeml⟩ := xmem
-  exact ⟨l, lt_of_lt_of_le lltm h, xmeml⟩
-
-lemma RelCWComplex.skeletonLT_monotone [RelCWComplex C D] : Monotone (skeletonLT C) :=
-  fun _ _ h ↦ skeletonLT_mono h
-
-lemma RelCWComplex.skeleton_mono [RelCWComplex C D] {n m : ℕ∞} (h : m ≤ n) :
-    skeleton C m ⊆ skeleton C n :=
-  skeletonLT_mono (add_le_add_right h 1)
-
-lemma RelCWComplex.skeleton_monotone [RelCWComplex C D] : Monotone (skeleton C) :=
-  fun _ _ h ↦ skeleton_mono h
-
-lemma RelCWComplex.skeletonLT_subset_complex [RelCWComplex C D] {n : ℕ∞} : skeletonLT C n ⊆ C := by
-  simp_rw [← skeletonLT_top (C := C) (D := D)]
-  exact skeletonLT_mono (OrderTop.le_top n)
-
-lemma RelCWComplex.skeleton_subset_complex [RelCWComplex C D] {n : ℕ∞} :
-    skeleton C n ⊆ C :=
-  skeletonLT_subset_complex
-
-lemma RelCWComplex.closedCell_subset_skeletonLT [RelCWComplex C D] (n : ℕ) (j : cell C n) :
-    closedCell n j ⊆ skeletonLT C (n + 1) := by
-  intro x xmem
-  right
-  simp_rw [mem_iUnion, exists_prop]
-  refine ⟨n, (by norm_cast; exact lt_add_one n), ⟨j,xmem⟩⟩
-
-lemma RelCWComplex.closedCell_subset_skeleton [RelCWComplex C D] (n : ℕ) (j : cell C n) :
-    closedCell n j ⊆ skeleton C n :=
-  closedCell_subset_skeletonLT n j
-
 lemma RelCWComplex.closedCell_subset_complex [RelCWComplex C D] (n : ℕ) (j : cell C n) :
-    closedCell n j ⊆ C :=
-  (closedCell_subset_skeleton n j).trans
-    (by simp_rw [← skeleton_top (C := C) (D := D)]; exact skeleton_mono le_top)
-
-lemma RelCWComplex.openCell_subset_skeletonLT [RelCWComplex C D] (n : ℕ) (j : cell C n) :
-    openCell n j ⊆ skeletonLT C (n + 1) :=
-  (openCell_subset_closedCell _ _).trans (closedCell_subset_skeletonLT _ _ )
-
-lemma RelCWComplex.openCell_subset_skeleton [RelCWComplex C D] (n : ℕ) (j : cell C n) :
-    openCell n j ⊆ skeleton C n :=
-  (openCell_subset_closedCell _ _).trans (closedCell_subset_skeleton _ _)
+    closedCell n j ⊆ C :=  by
+  simp_rw [← union]
+  apply subset_union_of_subset_right
+  exact subset_iUnion₂ _ _
 
 lemma RelCWComplex.openCell_subset_complex [RelCWComplex C D] (n : ℕ) (j : cell C n) :
-    openCell n j ⊆ C := by
-  apply subset_trans (openCell_subset_skeleton _ _)
-    (by simp_rw [← skeleton_top (C := C) (D := D)]; exact skeleton_mono le_top)
-
-lemma RelCWComplex.cellFrontier_subset_skeletonLT [RelCWComplex C D] (n : ℕ) (j : cell C n) :
-    cellFrontier n j ⊆ skeletonLT C n := by
-  obtain ⟨I, hI⟩ := cellFrontier_subset_base_union_finite_closedCell n j
-  apply subset_trans hI
-  apply union_subset_union_right
-  intro x xmem
-  simp only [mem_iUnion, exists_prop] at xmem ⊢
-  obtain ⟨i, iltn, j, _, xmem⟩ := xmem
-  exact ⟨i, by norm_cast, j, xmem⟩
-
-lemma RelCWComplex.cellFrontier_subset_skeleton [RelCWComplex C D] (n : ℕ) (j : cell C (n + 1)) :
-    cellFrontier (n + 1) j ⊆ skeleton C n :=
-  cellFrontier_subset_skeletonLT _ _
+    openCell n j ⊆ C :=
+  (openCell_subset_closedCell _ _).trans (closedCell_subset_complex _ _)
 
 lemma RelCWComplex.cellFrontier_subset_complex [RelCWComplex C D] (n : ℕ) (j : cell C n) :
     cellFrontier n j ⊆ C :=
   (cellFrontier_subset_closedCell n j).trans (closedCell_subset_complex n j)
-
-lemma RelCWComplex.iUnion_cellFrontier_subset_skeletonLT [RelCWComplex C D] (l : ℕ) :
-    ⋃ (j : cell C l), cellFrontier l j ⊆ skeletonLT C l :=
-  iUnion_subset (fun _ ↦ cellFrontier_subset_skeletonLT _ _)
-
-lemma RelCWComplex.iUnion_cellFrontier_subset_skeleton [RelCWComplex C D] (l : ℕ) :
-    ⋃ (j : cell C l), cellFrontier l j ⊆ skeleton C l :=
-  (iUnion_cellFrontier_subset_skeletonLT l).trans (skeletonLT_mono le_self_add)
 
 lemma RelCWComplex.closedCell_zero_eq_singleton [RelCWComplex C D] {j : cell C 0} :
     closedCell 0 j = {map 0 j ![]} := by
@@ -379,15 +282,9 @@ lemma RelCWComplex.cellFrontier_zero_eq_empty [RelCWComplex C D] {j : cell C 0} 
     cellFrontier 0 j = ∅ := by
   simp [cellFrontier, sphere_eq_empty_of_subsingleton]
 
-lemma RelCWComplex.base_subset_skeletonLT [RelCWComplex C D] (n : ℕ∞) : D ⊆ skeletonLT C n :=
-  subset_union_left
-
-lemma RelCWComplex.base_subset_skeleton [RelCWComplex C D] (n : ℕ∞) : D ⊆ skeleton C n :=
-  base_subset_skeletonLT (n + 1)
-
 lemma RelCWComplex.base_subset_complex [RelCWComplex C D] : D ⊆ C := by
-  simp_rw [← skeleton_top (C := C) (D := D)]
-  exact base_subset_skeleton ⊤
+  simp_rw [← union]
+  exact subset_union_left
 
 lemma RelCWComplex.isClosed [T2Space X] [RelCWComplex C D] : IsClosed C := by
   rw [closed C C (by rfl)]
@@ -398,27 +295,20 @@ lemma RelCWComplex.isClosed [T2Space X] [RelCWComplex C D] : IsClosed C := by
   · rw [inter_eq_right.2 base_subset_complex]
     exact isClosedBase C
 
-lemma RelCWComplex.skeletonLT_union_iUnion_closedCell_eq_skeletonLT_succ [RelCWComplex C D]
-    (n : ℕ) : skeletonLT C n ∪ ⋃ (j : cell C n), closedCell n j = skeletonLT C (n + 1)  := by
-  rw [skeletonLT, skeletonLT, union_assoc]
-  congr
-  norm_cast
-  exact (biUnion_lt_succ _ _).symm
-
-lemma RelCWComplex.skeleton_union_iUnion_closedCell_eq_skeleton_succ [RelCWComplex C D] (n : ℕ) :
-    skeleton C n ∪ ⋃ (j : cell C (n + 1)), closedCell (n + 1) j = skeleton C (n + 1) :=
-  skeletonLT_union_iUnion_closedCell_eq_skeletonLT_succ _
-
-/-- A version of the definition of `skeletonLT` with open cells. -/
-lemma RelCWComplex.iUnion_openCell_eq_skeletonLT [RelCWComplex C D] (n : ℕ∞) :
-    D ∪ ⋃ (m : ℕ) (_ : m < n) (j : cell C m), openCell m j = skeletonLT C n := by
+/-- A helper lemma that is essentially the same as `RelCWComplex.iUnion_openCell_eq_skeletonLT`.
+Use that lemma instead. -/
+protected lemma RelCWComplex.iUnion_openCell_eq_iUnion_closedCell [RelCWComplex C D] (n : ℕ∞) :
+    D ∪ ⋃ (m : ℕ) (_ : m < n) (j : cell C m), openCell m j =
+      D ∪ ⋃ (m : ℕ) (_ : m < n) (j : cell C m), closedCell m j := by
   apply subset_antisymm
   · apply union_subset
-    · exact base_subset_skeletonLT n
+    · exact subset_union_left
     · apply iUnion₂_subset fun m hm ↦ iUnion_subset fun j ↦ ?_
-      exact (openCell_subset_skeletonLT m j).trans (skeletonLT_mono (Order.add_one_le_of_lt hm))
-  · rw [skeletonLT]
-    apply union_subset subset_union_left
+      apply subset_union_of_subset_right
+      apply subset_iUnion₂_of_subset m hm
+      apply subset_iUnion_of_subset j
+      exact openCell_subset_closedCell m j
+  · apply union_subset subset_union_left
     refine iUnion₂_subset fun m hm ↦ iUnion_subset fun j ↦ ?_
     rw [← cellFrontier_union_openCell_eq_closedCell]
     apply union_subset
@@ -435,21 +325,12 @@ lemma RelCWComplex.iUnion_openCell_eq_skeletonLT [RelCWComplex C D] (n : ℕ∞)
           exact subset_iUnion₂_of_subset l ((ENat.coe_lt_coe.2 hl).trans hm) <| subset_iUnion _ i
     · exact subset_union_of_subset_right (subset_iUnion₂_of_subset m hm (subset_iUnion _ j)) _
 
-lemma CWComplex.iUnion_openCell_eq_skeletonLT [CWComplex C] (n : ℕ∞) :
-    ⋃ (m : ℕ) (_ : m < n) (j : cell C m), openCell m j = skeletonLT C n := by
-  rw [← RelCWComplex.iUnion_openCell_eq_skeletonLT, empty_union]
-
-lemma RelCWComplex.iUnion_openCell_eq_skeleton [RelCWComplex C D] (n : ℕ∞) :
-    D ∪ ⋃ (m : ℕ) (_ : m < n + 1) (j : cell C m), openCell m j = skeleton C n :=
-  iUnion_openCell_eq_skeletonLT _
-
-lemma CWComplex.iUnion_openCell_eq_skeleton [CWComplex C] (n : ℕ∞) :
-    ⋃ (m : ℕ) (_ : m < n + 1) (j : cell C m), openCell m j = skeleton C n :=
-  iUnion_openCell_eq_skeletonLT _
-
 lemma RelCWComplex.union_iUnion_openCell_eq_complex [RelCWComplex C D] :
     D ∪ ⋃ (n : ℕ) (j : cell C n), openCell n j = C := by
-  simp only [← skeletonLT_top, ← iUnion_openCell_eq_skeletonLT, ENat.coe_lt_top, iUnion_true]
+  suffices  D ∪ ⋃ n, ⋃ (j : cell C n), openCell n j =
+      D ∪ ⋃ (m : ℕ) (_ : m < (⊤ : ℕ∞)) (j : cell C m), closedCell m j by
+    simpa [union] using this
+  simp_rw [← RelCWComplex.iUnion_openCell_eq_iUnion_closedCell, ENat.coe_lt_top, iUnion_true]
 
 lemma CWComplex.iUnion_openCell_eq_complex [CWComplex C] :
     ⋃ (n : ℕ) (j : cell C n), openCell n j = C := by
@@ -462,83 +343,11 @@ lemma RelCWComplex.eq_of_not_disjoint_openCell [RelCWComplex C D] {n : ℕ} {j :
   contrapose! h
   exact disjoint_openCell_of_ne h
 
-lemma RelCWComplex.mem_skeletonLT_iff [RelCWComplex C D] {n : ℕ∞} {x : X} :
-    x ∈ skeletonLT C n ↔ x ∈ D ∨ ∃ (m : ℕ) (_ : m < n) (j : cell C m), x ∈ openCell m j := by
-  simp [← iUnion_openCell_eq_skeletonLT]
-
-lemma CWComplex.mem_skeletonLT_iff [CWComplex C] {n : ℕ∞} {x : X} :
-    x ∈ skeletonLT C n ↔ ∃ (m : ℕ) (_ : m < n) (j : cell C m), x ∈ openCell m j := by
-  simp [← iUnion_openCell_eq_skeletonLT]
-
-lemma RelCWComplex.mem_skeleton_iff [RelCWComplex C D] {n : ℕ∞} {x : X} :
-    x ∈ skeleton C n ↔ x ∈ D ∨ ∃ (m : ℕ) (_ : m ≤ n) (j : cell C m), x ∈ openCell m j := by
-  rw [skeleton, mem_skeletonLT_iff]
-  suffices ∀ (m : ℕ), m < n + 1 ↔ m ≤ n by simp_rw [this]
-  intro m
-  cases n
-  · simp
-  · rw [← Nat.cast_one, ← Nat.cast_add, Nat.cast_lt, Nat.cast_le, Order.lt_add_one_iff]
-
-lemma CWComplex.exists_mem_openCell_of_mem_skeleton [CWComplex C] {n : ℕ∞} {x : X} :
-    x ∈ skeleton C n ↔ ∃ (m : ℕ) (_ : m ≤ n) (j : cell C m), x ∈ openCell m j := by
-  rw [RelCWComplex.mem_skeleton_iff, mem_empty_iff_false, false_or]
-
-/-- A skeleton and an open cell of a higher dimension are disjoint. -/
-lemma RelCWComplex.disjoint_skeletonLT_openCell [RelCWComplex C D] {n : ℕ∞} {m : ℕ}
-    {j : cell C m} (hnm : n ≤ m) : Disjoint (skeletonLT C n) (openCell m j) := by
-  -- This is a consequence of `iUnion_openCell_eq_skeletonLT` and `disjoint_openCell_of_ne`
-  simp_rw [← iUnion_openCell_eq_skeletonLT, disjoint_union_left, disjoint_iUnion_left]
-  refine ⟨(disjointBase m j).symm, ?_⟩
-  intro l hln i
-  apply disjoint_openCell_of_ne
-  intro
-  simp_all only [Sigma.mk.inj_iff]
-  exact (lt_self_iff_false m).mp (ENat.coe_lt_coe.1 (hln.trans_le hnm))
-
-/-- A skeleton and an open cell of a higher dimension are disjoint. -/
-lemma RelCWComplex.disjoint_skeleton_openCell [RelCWComplex C D] {n : ℕ∞} {m : ℕ}
-    {j : cell C m} (nlem : n < m) : Disjoint (skeleton C n) (openCell m j) :=
-  disjoint_skeletonLT_openCell (Order.add_one_le_of_lt nlem)
-
 lemma RelCWComplex.disjoint_base_iUnion_openCell [RelCWComplex C D] :
     Disjoint D (⋃ (n : ℕ) (j : cell C n), openCell n j) := by
   simp_rw [disjoint_iff_inter_eq_empty, inter_iUnion, iUnion_eq_empty]
   intro n i
   rw [inter_comm, (disjointBase n i).inter_eq]
-
-lemma RelCWComplex.disjoint_interior_base_closedCell [T2Space X] [RelCWComplex C D] {n : ℕ}
-    {j : cell C n} : Disjoint (interior D) (closedCell n j) := by
-  rw [disjoint_iff_inter_eq_empty]
-  by_contra h
-  push_neg at h
-  rw [← closure_openCell_eq_closedCell, inter_comm,
-    closure_inter_open_nonempty_iff isOpen_interior] at h
-  rcases h with ⟨x, xmemcell, xmemD⟩
-  suffices x ∈ skeletonLT C 0 ∩ openCell n j by
-    rwa [(disjoint_skeletonLT_openCell n.cast_nonneg').inter_eq] at this
-  exact ⟨base_subset_skeletonLT 0 (interior_subset xmemD), xmemcell⟩
-
-lemma RelCWComplex.disjoint_interior_base_iUnion_closedCell [T2Space X] [RelCWComplex C D] :
-    Disjoint (interior D) (⋃ (n : ℕ) (j : cell C n), closedCell n j) := by
-  simp_rw [disjoint_iff_inter_eq_empty, inter_iUnion, disjoint_interior_base_closedCell.inter_eq,
-    iUnion_empty]
-
-/-- A skeleton intersected with a closed cell of a higher dimension is the skeleton intersected with
-the boundary of the cell. -/
-lemma RelCWComplex.skeletonLT_inter_closedCell_eq_skeletonLT_inter_cellFrontier [RelCWComplex C D]
-    {n : ℕ∞} {m : ℕ} {j : cell C m} (hnm : n ≤ m) :
-    skeletonLT C n ∩ closedCell m j = skeletonLT C n ∩ cellFrontier m j := by
-  refine subset_antisymm ?_ (inter_subset_inter_right _ (cellFrontier_subset_closedCell _ _))
-  rw [← cellFrontier_union_openCell_eq_closedCell, inter_union_distrib_left]
-  apply union_subset (by rfl)
-  rw [(disjoint_skeletonLT_openCell hnm).inter_eq]
-  exact empty_subset _
-
-/-- Version of `skeletonLT_inter_closedCell_eq_skeletonLT_inter_cellFrontier` using `skeleton`. -/
-lemma RelCWComplex.skeleton_inter_closedCell_eq_skeleton_inter_cellFrontier [RelCWComplex C D]
-    {n : ℕ∞} {m : ℕ} {j : cell C m} (hnm : n < m) :
-    skeleton C n ∩ closedCell m j = skeleton C n ∩ cellFrontier m j :=
-  skeletonLT_inter_closedCell_eq_skeletonLT_inter_cellFrontier (Order.add_one_le_of_lt hnm)
 
 /-- If for all `m ≤ n` and every `i : cell C m` the intersection `A ∩ closedCell m j` is closed
 and `A ∩ D` is closed then `A ∩ cellFrontier (n + 1) j` is closed for every
@@ -631,6 +440,209 @@ lemma CWComplex.cellFrontier_subset_finite_openCell [CWComplex C] (n : ℕ) (i :
     ∃ I : Π m, Finset (cell C m),
     cellFrontier n i ⊆ ⋃ (m < n) (j ∈ I m), openCell m j := by
   simpa using RelCWComplex.cellFrontier_subset_finite_openCell n i
+
+/-- A non-standard definition of the `n`-skeleton of a CW complex for `n ∈ ℕ ∪ {∞}`.
+This allows the base case of induction to be about the base instead of being about the union of
+the base and some points.
+The standard `skeleton` is defined in terms of `skeletonLT`. `skeletonLT` is preferred
+in statements. You should then derive the statement about `skeleton`. -/
+def RelCWComplex.skeletonLT (C : Set X) {D : Set X} [RelCWComplex C D] (n : ℕ∞) : Set X :=
+  D ∪ ⋃ (m : ℕ) (_ : m < n) (j : cell C m), closedCell m j
+
+/-- The `n`-skeleton of a CW complex, for `n ∈ ℕ ∪ {∞}`. For statements use `skeletonLT` instead
+and then derive the statement about `skeleton`. -/
+def RelCWComplex.skeleton (C : Set X) {D : Set X} [RelCWComplex C D] (n : ℕ∞) : Set X :=
+  skeletonLT C (n + 1)
+
+namespace CWComplex
+
+export RelCWComplex (skeletonLT skeleton)
+
+end CWComplex
+
+lemma RelCWComplex.skeletonLT_zero_eq_base [RelCWComplex C D] : skeletonLT C 0 = D := by
+  simp only [skeletonLT, ENat.not_lt_zero, iUnion_of_empty, iUnion_empty, union_empty]
+
+lemma CWComplex.skeletonLT_zero_eq_empty [CWComplex C] : skeletonLT C 0 = ∅ :=
+    RelCWComplex.skeletonLT_zero_eq_base
+
+@[simp] lemma RelCWComplex.skeletonLT_top [RelCWComplex C D] : skeletonLT C ⊤ = C := by
+  simp [skeletonLT, union]
+
+@[simp] lemma RelCWComplex.skeleton_top [RelCWComplex C D] : skeleton C ⊤ = C := skeletonLT_top
+
+lemma RelCWComplex.skeletonLT_mono [RelCWComplex C D] {n m : ℕ∞} (h : m ≤ n) :
+    skeletonLT C m ⊆ skeletonLT C n := by
+  apply union_subset_union_right
+  intro x xmem
+  simp_rw [mem_iUnion, exists_prop] at xmem ⊢
+  obtain ⟨l , lltm, xmeml⟩ := xmem
+  exact ⟨l, lt_of_lt_of_le lltm h, xmeml⟩
+
+lemma RelCWComplex.skeletonLT_monotone [RelCWComplex C D] : Monotone (skeletonLT C) :=
+  fun _ _ h ↦ skeletonLT_mono h
+
+lemma RelCWComplex.skeleton_mono [RelCWComplex C D] {n m : ℕ∞} (h : m ≤ n) :
+    skeleton C m ⊆ skeleton C n :=
+  skeletonLT_mono (add_le_add_right h 1)
+
+lemma RelCWComplex.skeleton_monotone [RelCWComplex C D] : Monotone (skeleton C) :=
+  fun _ _ h ↦ skeleton_mono h
+
+lemma RelCWComplex.skeletonLT_subset_complex [RelCWComplex C D] {n : ℕ∞} : skeletonLT C n ⊆ C := by
+  simp_rw [← skeletonLT_top (C := C) (D := D)]
+  exact skeletonLT_mono (OrderTop.le_top n)
+
+lemma RelCWComplex.skeleton_subset_complex [RelCWComplex C D] {n : ℕ∞} :
+    skeleton C n ⊆ C :=
+  skeletonLT_subset_complex
+
+lemma RelCWComplex.closedCell_subset_skeletonLT [RelCWComplex C D] (n : ℕ) (j : cell C n) :
+    closedCell n j ⊆ skeletonLT C (n + 1) := by
+  intro x xmem
+  right
+  simp_rw [mem_iUnion, exists_prop]
+  refine ⟨n, (by norm_cast; exact lt_add_one n), ⟨j,xmem⟩⟩
+
+lemma RelCWComplex.closedCell_subset_skeleton [RelCWComplex C D] (n : ℕ) (j : cell C n) :
+    closedCell n j ⊆ skeleton C n :=
+  closedCell_subset_skeletonLT n j
+
+lemma RelCWComplex.openCell_subset_skeletonLT [RelCWComplex C D] (n : ℕ) (j : cell C n) :
+    openCell n j ⊆ skeletonLT C (n + 1) :=
+  (openCell_subset_closedCell _ _).trans (closedCell_subset_skeletonLT _ _ )
+
+lemma RelCWComplex.openCell_subset_skeleton [RelCWComplex C D] (n : ℕ) (j : cell C n) :
+    openCell n j ⊆ skeleton C n :=
+  (openCell_subset_closedCell _ _).trans (closedCell_subset_skeleton _ _)
+
+lemma RelCWComplex.cellFrontier_subset_skeletonLT [RelCWComplex C D] (n : ℕ) (j : cell C n) :
+    cellFrontier n j ⊆ skeletonLT C n := by
+  obtain ⟨I, hI⟩ := cellFrontier_subset_base_union_finite_closedCell n j
+  apply subset_trans hI
+  apply union_subset_union_right
+  intro x xmem
+  simp only [mem_iUnion, exists_prop] at xmem ⊢
+  obtain ⟨i, iltn, j, _, xmem⟩ := xmem
+  exact ⟨i, by norm_cast, j, xmem⟩
+
+lemma RelCWComplex.cellFrontier_subset_skeleton [RelCWComplex C D] (n : ℕ) (j : cell C (n + 1)) :
+    cellFrontier (n + 1) j ⊆ skeleton C n :=
+  cellFrontier_subset_skeletonLT _ _
+
+lemma RelCWComplex.iUnion_cellFrontier_subset_skeletonLT [RelCWComplex C D] (l : ℕ) :
+    ⋃ (j : cell C l), cellFrontier l j ⊆ skeletonLT C l :=
+  iUnion_subset (fun _ ↦ cellFrontier_subset_skeletonLT _ _)
+
+lemma RelCWComplex.iUnion_cellFrontier_subset_skeleton [RelCWComplex C D] (l : ℕ) :
+    ⋃ (j : cell C l), cellFrontier l j ⊆ skeleton C l :=
+  (iUnion_cellFrontier_subset_skeletonLT l).trans (skeletonLT_mono le_self_add)
+
+lemma RelCWComplex.base_subset_skeletonLT [RelCWComplex C D] (n : ℕ∞) : D ⊆ skeletonLT C n :=
+  subset_union_left
+
+lemma RelCWComplex.base_subset_skeleton [RelCWComplex C D] (n : ℕ∞) : D ⊆ skeleton C n :=
+  base_subset_skeletonLT (n + 1)
+
+lemma RelCWComplex.skeletonLT_union_iUnion_closedCell_eq_skeletonLT_succ [RelCWComplex C D]
+    (n : ℕ) : skeletonLT C n ∪ ⋃ (j : cell C n), closedCell n j = skeletonLT C (n + 1)  := by
+  rw [skeletonLT, skeletonLT, union_assoc]
+  congr
+  norm_cast
+  exact (biUnion_lt_succ _ _).symm
+
+lemma RelCWComplex.skeleton_union_iUnion_closedCell_eq_skeleton_succ [RelCWComplex C D] (n : ℕ) :
+    skeleton C n ∪ ⋃ (j : cell C (n + 1)), closedCell (n + 1) j = skeleton C (n + 1) :=
+  skeletonLT_union_iUnion_closedCell_eq_skeletonLT_succ _
+
+/-- A version of the definition of `skeletonLT` with open cells. -/
+lemma RelCWComplex.iUnion_openCell_eq_skeletonLT [RelCWComplex C D] (n : ℕ∞) :
+    D ∪ ⋃ (m : ℕ) (_ : m < n) (j : cell C m), openCell m j = skeletonLT C n :=
+  RelCWComplex.iUnion_openCell_eq_iUnion_closedCell n
+
+lemma CWComplex.iUnion_openCell_eq_skeletonLT [CWComplex C] (n : ℕ∞) :
+    ⋃ (m : ℕ) (_ : m < n) (j : cell C m), openCell m j = skeletonLT C n := by
+  rw [← RelCWComplex.iUnion_openCell_eq_skeletonLT, empty_union]
+
+lemma RelCWComplex.iUnion_openCell_eq_skeleton [RelCWComplex C D] (n : ℕ∞) :
+    D ∪ ⋃ (m : ℕ) (_ : m < n + 1) (j : cell C m), openCell m j = skeleton C n :=
+  iUnion_openCell_eq_skeletonLT _
+
+lemma CWComplex.iUnion_openCell_eq_skeleton [CWComplex C] (n : ℕ∞) :
+    ⋃ (m : ℕ) (_ : m < n + 1) (j : cell C m), openCell m j = skeleton C n :=
+  iUnion_openCell_eq_skeletonLT _
+
+lemma RelCWComplex.mem_skeletonLT_iff [RelCWComplex C D] {n : ℕ∞} {x : X} :
+    x ∈ skeletonLT C n ↔ x ∈ D ∨ ∃ (m : ℕ) (_ : m < n) (j : cell C m), x ∈ openCell m j := by
+  simp [← iUnion_openCell_eq_skeletonLT]
+
+lemma CWComplex.mem_skeletonLT_iff [CWComplex C] {n : ℕ∞} {x : X} :
+    x ∈ skeletonLT C n ↔ ∃ (m : ℕ) (_ : m < n) (j : cell C m), x ∈ openCell m j := by
+  simp [← iUnion_openCell_eq_skeletonLT]
+
+lemma RelCWComplex.mem_skeleton_iff [RelCWComplex C D] {n : ℕ∞} {x : X} :
+    x ∈ skeleton C n ↔ x ∈ D ∨ ∃ (m : ℕ) (_ : m ≤ n) (j : cell C m), x ∈ openCell m j := by
+  rw [skeleton, mem_skeletonLT_iff]
+  suffices ∀ (m : ℕ), m < n + 1 ↔ m ≤ n by simp_rw [this]
+  intro m
+  cases n
+  · simp
+  · rw [← Nat.cast_one, ← Nat.cast_add, Nat.cast_lt, Nat.cast_le, Order.lt_add_one_iff]
+
+lemma CWComplex.exists_mem_openCell_of_mem_skeleton [CWComplex C] {n : ℕ∞} {x : X} :
+    x ∈ skeleton C n ↔ ∃ (m : ℕ) (_ : m ≤ n) (j : cell C m), x ∈ openCell m j := by
+  rw [RelCWComplex.mem_skeleton_iff, mem_empty_iff_false, false_or]
+
+/-- A skeleton and an open cell of a higher dimension are disjoint. -/
+lemma RelCWComplex.disjoint_skeletonLT_openCell [RelCWComplex C D] {n : ℕ∞} {m : ℕ}
+    {j : cell C m} (hnm : n ≤ m) : Disjoint (skeletonLT C n) (openCell m j) := by
+  -- This is a consequence of `iUnion_openCell_eq_skeletonLT` and `disjoint_openCell_of_ne`
+  simp_rw [← iUnion_openCell_eq_skeletonLT, disjoint_union_left, disjoint_iUnion_left]
+  refine ⟨(disjointBase m j).symm, ?_⟩
+  intro l hln i
+  apply disjoint_openCell_of_ne
+  intro
+  simp_all only [Sigma.mk.inj_iff]
+  exact (lt_self_iff_false m).mp (ENat.coe_lt_coe.1 (hln.trans_le hnm))
+
+/-- A skeleton and an open cell of a higher dimension are disjoint. -/
+lemma RelCWComplex.disjoint_skeleton_openCell [RelCWComplex C D] {n : ℕ∞} {m : ℕ}
+    {j : cell C m} (nlem : n < m) : Disjoint (skeleton C n) (openCell m j) :=
+  disjoint_skeletonLT_openCell (Order.add_one_le_of_lt nlem)
+
+/-- A skeleton intersected with a closed cell of a higher dimension is the skeleton intersected with
+the boundary of the cell. -/
+lemma RelCWComplex.skeletonLT_inter_closedCell_eq_skeletonLT_inter_cellFrontier [RelCWComplex C D]
+    {n : ℕ∞} {m : ℕ} {j : cell C m} (hnm : n ≤ m) :
+    skeletonLT C n ∩ closedCell m j = skeletonLT C n ∩ cellFrontier m j := by
+  refine subset_antisymm ?_ (inter_subset_inter_right _ (cellFrontier_subset_closedCell _ _))
+  rw [← cellFrontier_union_openCell_eq_closedCell, inter_union_distrib_left]
+  apply union_subset (by rfl)
+  rw [(disjoint_skeletonLT_openCell hnm).inter_eq]
+  exact empty_subset _
+
+/-- Version of `skeletonLT_inter_closedCell_eq_skeletonLT_inter_cellFrontier` using `skeleton`. -/
+lemma RelCWComplex.skeleton_inter_closedCell_eq_skeleton_inter_cellFrontier [RelCWComplex C D]
+    {n : ℕ∞} {m : ℕ} {j : cell C m} (hnm : n < m) :
+    skeleton C n ∩ closedCell m j = skeleton C n ∩ cellFrontier m j :=
+  skeletonLT_inter_closedCell_eq_skeletonLT_inter_cellFrontier (Order.add_one_le_of_lt hnm)
+
+lemma RelCWComplex.disjoint_interior_base_closedCell [T2Space X] [RelCWComplex C D] {n : ℕ}
+    {j : cell C n} : Disjoint (interior D) (closedCell n j) := by
+  rw [disjoint_iff_inter_eq_empty]
+  by_contra h
+  push_neg at h
+  rw [← closure_openCell_eq_closedCell, inter_comm,
+    closure_inter_open_nonempty_iff isOpen_interior] at h
+  rcases h with ⟨x, xmemcell, xmemD⟩
+  suffices x ∈ skeletonLT C 0 ∩ openCell n j by
+    rwa [(disjoint_skeletonLT_openCell n.cast_nonneg').inter_eq] at this
+  exact ⟨base_subset_skeletonLT 0 (interior_subset xmemD), xmemcell⟩
+
+lemma RelCWComplex.disjoint_interior_base_iUnion_closedCell [T2Space X] [RelCWComplex C D] :
+    Disjoint (interior D) (⋃ (n : ℕ) (j : cell C n), closedCell n j) := by
+  simp_rw [disjoint_iff_inter_eq_empty, inter_iUnion, disjoint_interior_base_closedCell.inter_eq,
+    iUnion_empty]
 
 namespace CWComplex
 


### PR DESCRIPTION
This PR reorders the file Topology/CWComplex/Classical/Basic.lean. This is to prepare for the addition of the notion of subcomplexes which will require turning `skeleton` and `skeletonLT` into a subcomplex. 

Co-authored-by: Floris van Doorn <fpvdoorn@gmail.com>

---

The reordering requires changing the proof of the following lemmas: 
- `RelCWComplex.closedCell_subset_complex`
- `RelCWComplex.openCell_subset_complex`
- `RelCWComplex.base_subset_complex`
- `RelCWComplex.union_iUnion_openCell_eq_complex`
- `RelCWComplex.iUnion_openCell_eq_skeletonLT`
And the addition of: 
- `RelCWComplex.iUnion_openCell_eq_iUnion_closedCell`

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
