### PR TITLE
[Merged by Bors] - feat(AlgebraicGeometry): `Γ` is a right adjoint

### DIFF
--- a/Mathlib/AlgebraicGeometry/GammaSpecAdjunction.lean
+++ b/Mathlib/AlgebraicGeometry/GammaSpecAdjunction.lean
@@ -5,6 +5,7 @@ Authors: Junyan Xu
 -/
 import Mathlib.AlgebraicGeometry.Restrict
 import Mathlib.CategoryTheory.Adjunction.Limits
+import Mathlib.CategoryTheory.Adjunction.Opposites
 import Mathlib.CategoryTheory.Adjunction.Reflective
 
 /-!
@@ -480,12 +481,6 @@ theorem ΓSpecIso_obj_hom {X : Scheme.{u}} (U : X.Opens) :
 /-! Immediate consequences of the adjunction. -/
 
 
-/-- Spec preserves limits. -/
-instance : Limits.PreservesLimits Spec.toLocallyRingedSpace :=
-  ΓSpec.locallyRingedSpaceAdjunction.rightAdjoint_preservesLimits
-
-instance Spec.preservesLimits : Limits.PreservesLimits Scheme.Spec :=
-  ΓSpec.adjunction.rightAdjoint_preservesLimits
 
 /-- The functor `Spec.toLocallyRingedSpace : CommRingCatᵒᵖ ⥤ LocallyRingedSpace`
 is fully faithful. -/
@@ -562,12 +557,6 @@ lemma Spec.preimage_comp {R S T : CommRingCat} (f : Spec R ⟶ Spec S) (g : Spec
 
 end
 
-instance : Spec.toLocallyRingedSpace.IsRightAdjoint :=
-  (ΓSpec.locallyRingedSpaceAdjunction).isRightAdjoint
-
-instance : Scheme.Spec.IsRightAdjoint :=
-  (ΓSpec.adjunction).isRightAdjoint
-
 instance : Reflective Spec.toLocallyRingedSpace where
   L := Γ.rightOp
   adj := ΓSpec.locallyRingedSpaceAdjunction
@@ -575,5 +564,10 @@ instance : Reflective Spec.toLocallyRingedSpace where
 instance Spec.reflective : Reflective Scheme.Spec where
   L := Scheme.Γ.rightOp
   adj := ΓSpec.adjunction
+
+instance : LocallyRingedSpace.Γ.IsRightAdjoint :=
+  ΓSpec.locallyRingedSpaceAdjunction.rightOp.isRightAdjoint
+
+instance : Scheme.Γ.IsRightAdjoint := ΓSpec.adjunction.rightOp.isRightAdjoint
 
 end AlgebraicGeometry


### PR DESCRIPTION
Also remove redundant instances.

From Toric


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
