### PR TITLE
[Merged by Bors] - refactor: generalise the equivalence `Comon_ C ≌ C` to an arbitrary `MonoidalCategory` instance

### DIFF
--- a/Mathlib/CategoryTheory/Monoidal/Cartesian/Comon_.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Cartesian/Comon_.lean
@@ -39,10 +39,14 @@ variable {C}
 
 @[simp] theorem counit_eq_toUnit (A : Comon_ C) : A.counit = toUnit _ := by ext
 
+@[deprecated (since := "2025-05-09")] alias counit_eq_from := counit_eq_toUnit
+
 @[simp] theorem comul_eq_lift (A : Comon_ C) : A.comul = lift (𝟙 _) (𝟙 _) := by
   ext
   · simpa using A.comul_counit =≫ fst _ _
   · simpa using A.counit_comul =≫ snd _ _
+
+@[deprecated (since := "2025-05-09")] alias comul_eq_diag := comul_eq_lift
 
 /--
 Every comonoid object in a cartesian monoidal category is equivalent to

--- a/Mathlib/CategoryTheory/Monoidal/Cartesian/Comon_.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Cartesian/Comon_.lean
@@ -3,8 +3,8 @@ Copyright (c) 2023 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kim Morrison
 -/
+import Mathlib.CategoryTheory.ChosenFiniteProducts
 import Mathlib.CategoryTheory.Monoidal.Comon_
-import Mathlib.CategoryTheory.Monoidal.OfHasFiniteProducts
 
 /-!
 # Comonoid objects in a cartesian monoidal category.
@@ -13,37 +13,36 @@ The category of comonoid objects in a cartesian monoidal category is equivalent
 to the category itself, via the forgetful functor.
 -/
 
-open CategoryTheory MonoidalCategory Limits
+open CategoryTheory MonoidalCategory ChosenFiniteProducts Limits
 
 universe v u
 
 noncomputable section
 
-variable (C : Type u) [Category.{v} C] [HasTerminal C] [HasBinaryProducts C]
+variable (C : Type u) [Category.{v} C] [ChosenFiniteProducts C]
 
-attribute [local instance] monoidalOfHasFiniteProducts
-open monoidalOfHasFiniteProducts
-attribute [local simp] associator_hom associator_inv
+attribute [simp] leftUnitor_hom rightUnitor_hom
 
 /--
 The functor from a cartesian monoidal category to comonoids in that category,
 equipping every object with the diagonal map as a comultiplication.
 -/
 def cartesianComon_ : C ⥤ Comon_ C where
-  obj := fun X =>
-  { X := X
-    comul := diag X
-    counit := terminal.from X }
-  map := fun f => { hom := f }
+  obj X := {
+    X := X
+    comul := lift (𝟙 _) (𝟙 _)
+    counit := toUnit _
+  }
+  map f := { hom := f }
 
 variable {C}
 
-@[simp] theorem counit_eq_from (A : Comon_ C) : A.counit = terminal.from A.X := by ext
+@[simp] theorem counit_eq_toUnit (A : Comon_ C) : A.counit = toUnit _ := by ext
 
-@[simp] theorem comul_eq_diag (A : Comon_ C) : A.comul = diag A.X := by
+@[simp] theorem comul_eq_lift (A : Comon_ C) : A.comul = lift (𝟙 _) (𝟙 _) := by
   ext
-  · simpa using A.comul_counit =≫ prod.fst
-  · simpa using A.counit_comul =≫ prod.snd
+  · simpa using A.comul_counit =≫ fst _ _
+  · simpa using A.counit_comul =≫ snd _ _
 
 /--
 Every comonoid object in a cartesian monoidal category is equivalent to

--- a/Mathlib/CategoryTheory/Monoidal/Cartesian/Comon_.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Cartesian/Comon_.lean
@@ -21,7 +21,7 @@ noncomputable section
 
 variable (C : Type u) [Category.{v} C] [ChosenFiniteProducts C]
 
-attribute [simp] leftUnitor_hom rightUnitor_hom
+attribute [local simp] leftUnitor_hom rightUnitor_hom
 
 /--
 The functor from a cartesian monoidal category to comonoids in that category,


### PR DESCRIPTION
... instead of the one coming from arbitrary choices.

From Toric


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
