### PR TITLE
[Merged by Bors] - feat(RingTheory): group-like elements

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -5606,6 +5606,7 @@ import Mathlib.RingTheory.Artinian.Ring
 import Mathlib.RingTheory.Bezout
 import Mathlib.RingTheory.Bialgebra.Basic
 import Mathlib.RingTheory.Bialgebra.Equiv
+import Mathlib.RingTheory.Bialgebra.GroupLike
 import Mathlib.RingTheory.Bialgebra.Hom
 import Mathlib.RingTheory.Bialgebra.MonoidAlgebra
 import Mathlib.RingTheory.Bialgebra.TensorProduct
@@ -5615,6 +5616,7 @@ import Mathlib.RingTheory.ClassGroup
 import Mathlib.RingTheory.Coalgebra.Basic
 import Mathlib.RingTheory.Coalgebra.Convolution
 import Mathlib.RingTheory.Coalgebra.Equiv
+import Mathlib.RingTheory.Coalgebra.GroupLike
 import Mathlib.RingTheory.Coalgebra.Hom
 import Mathlib.RingTheory.Coalgebra.MonoidAlgebra
 import Mathlib.RingTheory.Coalgebra.MulOpposite
@@ -5736,6 +5738,7 @@ import Mathlib.RingTheory.HahnSeries.Summable
 import Mathlib.RingTheory.HahnSeries.Valuation
 import Mathlib.RingTheory.Henselian
 import Mathlib.RingTheory.HopfAlgebra.Basic
+import Mathlib.RingTheory.HopfAlgebra.GroupLike
 import Mathlib.RingTheory.HopfAlgebra.MonoidAlgebra
 import Mathlib.RingTheory.HopfAlgebra.TensorProduct
 import Mathlib.RingTheory.HopkinsLevitzki

--- a/Mathlib/RingTheory/Bialgebra/GroupLike.lean
+++ b/Mathlib/RingTheory/Bialgebra/GroupLike.lean
@@ -21,8 +21,8 @@ variable [CommSemiring R] [Semiring A] [Bialgebra R A] {a b : A}
 
 /-- In a bialgebra, `1` is a group-like element. -/
 lemma IsGroupLikeElem.one : IsGroupLikeElem R (1 : A) where
-  counit_eq_one := by simp
-  comul_eq_tmul_self := by simp [Algebra.TensorProduct.one_def]
+  counit_eq_one := counit_one
+  comul_eq_tmul_self := comul_one
 
 /-- Group-like elements in a bialgebra are stable under multiplication. -/
 lemma IsGroupLikeElem.mul (ha : IsGroupLikeElem R a) (hb : IsGroupLikeElem R b) :

--- a/Mathlib/RingTheory/Bialgebra/GroupLike.lean
+++ b/Mathlib/RingTheory/Bialgebra/GroupLike.lean
@@ -1,0 +1,87 @@
+/-
+Copyright (c) 2025 Yaël Dillies, Michał Mrugała. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yaël Dillies, Michał Mrugała
+-/
+import Mathlib.RingTheory.Bialgebra.Basic
+import Mathlib.RingTheory.Coalgebra.GroupLike
+
+/-!
+# Group-like elements in a bialgebra
+
+This file proves that group-like elements in a bialgebra form a monoid.
+-/
+
+open Coalgebra Bialgebra
+
+variable {R A : Type*}
+
+section Semiring
+variable [CommSemiring R] [Semiring A] [Bialgebra R A] {a b : A}
+
+/-- In a bialgebra, `1` is a group-like element. -/
+lemma IsGroupLikeElem.one : IsGroupLikeElem R (1 : A) where
+  counit_eq_one := by simp
+  comul_eq_tmul_self := by simp [Algebra.TensorProduct.one_def]
+
+/-- Group-like elements in a bialgebra are stable under multiplication. -/
+lemma IsGroupLikeElem.mul (ha : IsGroupLikeElem R a) (hb : IsGroupLikeElem R b) :
+    IsGroupLikeElem R (a * b) where
+  counit_eq_one := by simp [ha, hb]
+  comul_eq_tmul_self := by simp [ha, hb]
+
+variable (R A) in
+/-- The group-like elements form a submonoid. -/
+def groupLikeSubmonoid : Submonoid A where
+  carrier := {a | IsGroupLikeElem R a}
+  one_mem' := .one
+  mul_mem' := .mul
+
+/-- Group-like elements in a bialgebra are stable under power. -/
+lemma IsGroupLikeElem.pow {n : ℕ} (ha : IsGroupLikeElem R a) : IsGroupLikeElem R (a ^ n) :=
+  (groupLikeSubmonoid R A).pow_mem ha _
+
+/-- Group-like elements in a bialgebra are stable under inverses, when they exist. -/
+lemma IsGroupLikeElem.of_mul_eq_one (hab : a * b = 1) (hba : b * a = 1) (ha : IsGroupLikeElem R a) :
+    IsGroupLikeElem R b where
+  counit_eq_one :=
+    left_inv_eq_right_inv (a := counit a) (by simp [← counit_mul, hba]) (by simp [ha])
+  comul_eq_tmul_self := left_inv_eq_right_inv (a := comul a) (by simp [← comul_mul, hba])
+    (by simp [ha, hab, Algebra.TensorProduct.one_def])
+
+/-- Group-like elements in a bialgebra are stable under inverses, when they exist. -/
+lemma isGroupLikeElem_iff_of_mul_eq_one (hab : a * b = 1) (hba : b * a = 1) :
+    IsGroupLikeElem R a ↔ IsGroupLikeElem R b := ⟨.of_mul_eq_one hab hba, .of_mul_eq_one hba hab⟩
+
+@[simp] lemma isGroupLikeElem_unitsInv {u : Aˣ} :
+    IsGroupLikeElem R u⁻¹.val ↔ IsGroupLikeElem R u.val :=
+  isGroupLikeElem_iff_of_mul_eq_one (by simp) (by simp)
+
+alias ⟨IsGroupLikeElem.of_unitsInv, IsGroupLikeElem.unitsInv⟩ := isGroupLikeElem_unitsInv
+
+namespace GroupLike
+
+instance : One (GroupLike R A) where one := ⟨1, .one⟩
+instance : Mul (GroupLike R A) where mul a b := ⟨a * b, a.2.mul b.2⟩
+instance : Pow (GroupLike R A) ℕ where pow a n := ⟨a ^ n, a.2.pow⟩
+
+@[simp] lemma val_one : (1 : GroupLike R A) = (1 : A) := rfl
+@[simp] lemma val_mul (a b : GroupLike R A) : ↑(a * b) = (a * b : A) := rfl
+@[simp] lemma val_pow (a : GroupLike R A) (n : ℕ) : ↑(a ^ n) = (a ^ n : A) := rfl
+
+instance : Monoid (GroupLike R A) := val_injective.monoid val val_one val_mul val_pow
+
+variable (R A) in
+/-- `GroupLike.val` as a monoid hom. -/
+@[simps] def valMonoidHom : GroupLike R A →* A where
+  toFun := val
+  map_one' := val_one
+  map_mul' := val_mul
+
+end GroupLike
+end Semiring
+
+variable [CommSemiring R] [CommSemiring A] [Bialgebra R A] {a b : A}
+
+instance GroupLike.instCommMonoid : CommMonoid (GroupLike R A) :=
+  val_injective.commMonoid val val_one val_mul val_pow

--- a/Mathlib/RingTheory/Coalgebra/GroupLike.lean
+++ b/Mathlib/RingTheory/Coalgebra/GroupLike.lean
@@ -30,7 +30,7 @@ variable (R) in
 /-- A group-like element in a coalgebra is an element `a` such that `ε(a) = 1` and `Δ(a) = a ⊗ₜ a`,
 where `ε` and `Δ` are the counit and comultiplication respectively. -/
 @[mk_iff]
-structure IsGroupLikeElem (a : A) where
+structure IsGroupLikeElem (a : A) : Prop where
   /-- A group-like element `a` satisfies `ε(a) = 1`. -/
   counit_eq_one : counit (R := R) a = 1
   /-- A group-like element `a` satisfies `Δ(a) = a ⊗ₜ a`. -/

--- a/Mathlib/RingTheory/Coalgebra/GroupLike.lean
+++ b/Mathlib/RingTheory/Coalgebra/GroupLike.lean
@@ -1,0 +1,155 @@
+/-
+Copyright (c) 2025 Yaël Dillies, Michał Mrugała. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yaël Dillies, Michał Mrugała
+-/
+import Mathlib.RingTheory.Coalgebra.Equiv
+import Mathlib.RingTheory.Flat.Domain
+
+/-!
+# Group-like elements in a coalgebra
+
+This file defines group-like elements in a coalgebra, i.e. elements `a` such that `ε a = 1` and
+`Δ a = a ⊗ₜ a`.
+
+## Main declarations
+
+* `IsGroupLikeElem`: Predicate for an element in a coalgebra to be group-like.
+* `linearIndepOn_isGroupLikeElem`: Group-like elements over a domain are linearly independent.
+-/
+
+open Coalgebra Function TensorProduct
+
+variable {F R A B : Type*}
+
+section CommSemiring
+variable [CommSemiring R] [AddCommMonoid A] [AddCommMonoid B] [Module R A] [Coalgebra R A]
+  [Module R B] [Coalgebra R B] {a b : A}
+
+variable (R) in
+/-- A group-like element in a coalgebra is an element `a` such that `ε(a) = 1` and `Δ(a) = a ⊗ₜ a`,
+where `ε` and `Δ` are the counit and comultiplication respectively. -/
+@[mk_iff]
+structure IsGroupLikeElem (a : A) where
+  /-- A group-like element `a` satisfies `ε(a) = 1`. -/
+  counit_eq_one : counit (R := R) a = 1
+  /-- A group-like element `a` satisfies `Δ(a) = a ⊗ₜ a`. -/
+  comul_eq_tmul_self : comul a = a ⊗ₜ[R] a
+
+attribute [simp] IsGroupLikeElem.counit_eq_one IsGroupLikeElem.comul_eq_tmul_self
+
+@[simp] lemma isGroupLikeElem_self {r : R} : IsGroupLikeElem R r ↔ r = 1 := by
+  simp +contextual [isGroupLikeElem_iff]
+
+lemma IsGroupLikeElem.ne_zero [Nontrivial R] (ha : IsGroupLikeElem R a) : a ≠ 0 := by
+  rintro rfl; simpa using ha.counit_eq_one
+
+/-- A coalgebra homomorphism sends group-like elements to group-like elements. -/
+lemma IsGroupLikeElem.map [FunLike F A B] [CoalgHomClass F R A B] (f : F)
+    (ha : IsGroupLikeElem R a) : IsGroupLikeElem R (f a) where
+  counit_eq_one := by rw [CoalgHomClass.counit_comp_apply, ha.counit_eq_one]
+  comul_eq_tmul_self := by rw [← CoalgHomClass.map_comp_comul_apply, ha.comul_eq_tmul_self]; simp
+
+/-- A coalgebra isomorphism preserves group-like elements. -/
+@[simp] lemma isGroupLikeElem_map [EquivLike F A B] [CoalgEquivClass F R A B] (f : F) :
+    IsGroupLikeElem R (f a) ↔ IsGroupLikeElem R a where
+  mp ha := by
+    rw [← (CoalgEquivClass.toCoalgEquiv f).symm_apply_apply a]
+    exact ha.map (CoalgEquivClass.toCoalgEquiv f).symm
+  mpr := .map f
+
+variable (R A) in
+/-- The type of group-like elements in a coalgebra. -/
+@[ext]
+structure GroupLike where
+  /-- The underlying element of a group-like element. -/
+  val : A
+  isGroupLikeElem_val : IsGroupLikeElem R val
+
+namespace GroupLike
+
+attribute [coe] val
+
+instance instCoeOut : CoeOut (GroupLike R A) A where coe := val
+
+attribute [simp] isGroupLikeElem_val
+
+lemma val_injective : Injective (val : GroupLike R A → A) := by rintro ⟨a, ha⟩; congr!
+
+@[simp, norm_cast] lemma val_inj {a b : GroupLike R A} : a.val = b.val ↔ a = b :=
+  val_injective.eq_iff
+
+/-- Identity equivalence between `GroupLike R A` and `{a : A | IsGroupLikeElem R a}`. -/
+def valEquiv : GroupLike R A ≃ Subtype (IsGroupLikeElem R : A → Prop) where
+  toFun a := ⟨a.1, a.2⟩
+  invFun a := ⟨a.1, a.2⟩
+  left_inv _ := rfl
+  right_inv _ := rfl
+
+end GroupLike
+end CommSemiring
+
+section CommRing
+variable [CommRing R] [IsDomain R] [AddCommGroup A] [Module R A] [Coalgebra R A]
+  [NoZeroSMulDivisors R A]
+
+open Submodule in
+/-- Group-like elements over a domain are linearly independent. -/
+lemma linearIndepOn_isGroupLikeElem : LinearIndepOn R id {a : A | IsGroupLikeElem R a} := by
+  classical
+  -- We show that any finset `s` of group-like elements is linearly independent.
+  rw [linearIndepOn_iff_linearIndepOn_finset]
+  rintro s hs
+  -- For this, we do induction on `s`.
+  induction s using Finset.cons_induction with
+  -- The case `s = ∅` is trivial.
+  | empty => simp
+  -- Let's deal with the `s ∪ {a}` case.
+  | cons a s has ih =>
+  simp only [Finset.cons_eq_insert, Finset.coe_insert, Set.subset_def, Set.mem_insert_iff,
+    Finset.mem_coe, Set.mem_setOf_eq, forall_eq_or_imp] at hs
+  obtain ⟨ha, hs⟩ := hs
+  specialize ih hs
+  -- Assume that there is some `c : A → R` and `d : R` such that `∑ x ∈ s, c x • x = d • a`.
+  -- We want to prove `d = 0` and `∀ x ∈ s, c x = 0`.
+  rw [Finset.coe_cons]
+  refine ih.id_insert' ?_
+  simp only [mem_span_finset, forall_exists_index, and_imp]
+  rintro d c - hc
+  -- `x ⊗ y` over `x, y ∈ s` are linearly independent since `s` is linearly independent and
+  -- `R` is a domain.
+  replace ih := ih.tmul_of_isDomain ih
+  simp_rw [← Finset.coe_product, linearIndepOn_finset_iffₛ, id] at ih
+  -- Tensoring the equality `∑ x ∈ s, c x • x = d • a` with itself, we get by linear independence
+  -- that `c x ^ 2 = d * c x` and `c x * c y = 0` for `x ≠ y`.
+  have key := calc
+        ∑ x ∈ s, ∑ y ∈ s, (if x = y then d * c x else 0) • x ⊗ₜ[R] y
+    _ = d • ∑ x ∈ s, c x • x ⊗ₜ[R] x := by simp [Finset.smul_sum, mul_smul]
+    _ = d • comul (d • a) := by rw [← hc]; simp +contextual [(hs _ _).comul_eq_tmul_self]
+    _ = (d • a) ⊗ₜ (d • a) := by simp [ha.comul_eq_tmul_self, smul_tmul, tmul_smul, -neg_smul]
+    _ = ∑ x ∈ s, ∑ y ∈ s, (c x * c y) • x ⊗ₜ[R] y := by
+      simp_rw [← hc, sum_tmul, smul_tmul, Finset.smul_sum, tmul_sum, tmul_smul, mul_smul]
+  simp_rw [← Finset.sum_product'] at key
+  apply ih at key
+  -- Therefore, `c x = 0` for all `x ∈ s`.
+  replace key x (hx : x ∈ s) : c x = 0 := by
+    -- Otherwise, we deduce from `key` that `c y = 0` for any `y ≠ x` with `y ∈ s`.
+    by_contra! hcx
+    have hcy (y) (hys : y ∈ s) (hyx : y ≠ x) : c y = 0 := by
+      simpa [*] using (key (y, x) (by simp [*])).symm
+    -- Then substitute this into `hc` to get `c x • x = d • a`.
+    rw [Finset.sum_eq_single x (by simp +contextual [hcy]) (by simp [hx])] at hc
+    -- But `key` also says that `c x = d`.
+    have hcxa : d = c x := mul_left_injective₀ hcx (by simpa using (key (x, x) (by simp [*])))
+    -- So `x = a`...
+    obtain rfl : x = a := by rwa [hcxa, smul_right_inj hcx] at hc
+    -- ... which contradicts `x ∈ s` and `a ∉ s`.
+    contradiction
+  -- We are now done, since `d • a = ∑ x ∈ s, c x • x = 0`
+  simp_all [ha.ne_zero, eq_comm]
+
+/-- Group-like elements over a domain are linearly independent. -/
+lemma linearIndep_groupLikeVal : LinearIndependent R (GroupLike.val (R := R) (A := A)) := by
+  simpa using (linearIndependent_equiv GroupLike.valEquiv).2 linearIndepOn_isGroupLikeElem
+
+end CommRing

--- a/Mathlib/RingTheory/Coalgebra/GroupLike.lean
+++ b/Mathlib/RingTheory/Coalgebra/GroupLike.lean
@@ -66,11 +66,11 @@ structure GroupLike where
 
 namespace GroupLike
 
+attribute [simp] isGroupLikeElem_val
+
 attribute [coe] val
 
 instance instCoeOut : CoeOut (GroupLike R A) A where coe := val
-
-attribute [simp] isGroupLikeElem_val
 
 lemma val_injective : Injective (val : GroupLike R A → A) := by rintro ⟨a, ha⟩; congr!
 

--- a/Mathlib/RingTheory/Coalgebra/GroupLike.lean
+++ b/Mathlib/RingTheory/Coalgebra/GroupLike.lean
@@ -53,9 +53,7 @@ lemma IsGroupLikeElem.map [FunLike F A B] [CoalgHomClass F R A B] (f : F)
 /-- A coalgebra isomorphism preserves group-like elements. -/
 @[simp] lemma isGroupLikeElem_map [EquivLike F A B] [CoalgEquivClass F R A B] (f : F) :
     IsGroupLikeElem R (f a) ↔ IsGroupLikeElem R a where
-  mp ha := by
-    rw [← (CoalgEquivClass.toCoalgEquiv f).symm_apply_apply a]
-    exact ha.map (CoalgEquivClass.toCoalgEquiv f).symm
+  mp ha := (CoalgEquivClass.toCoalgEquiv f).symm_apply_apply a ▸ ha.map _
   mpr := .map f
 
 variable (R A) in

--- a/Mathlib/RingTheory/Coalgebra/GroupLike.lean
+++ b/Mathlib/RingTheory/Coalgebra/GroupLike.lean
@@ -51,7 +51,7 @@ lemma IsGroupLikeElem.map [FunLike F A B] [CoalgHomClass F R A B] (f : F)
   comul_eq_tmul_self := by rw [← CoalgHomClass.map_comp_comul_apply, ha.comul_eq_tmul_self]; simp
 
 /-- A coalgebra isomorphism preserves group-like elements. -/
-@[simp] lemma isGroupLikeElem_map [EquivLike F A B] [CoalgEquivClass F R A B] (f : F) :
+@[simp] lemma isGroupLikeElem_map_equiv [EquivLike F A B] [CoalgEquivClass F R A B] (f : F) :
     IsGroupLikeElem R (f a) ↔ IsGroupLikeElem R a where
   mp ha := (CoalgEquivClass.toCoalgEquiv f).symm_apply_apply a ▸ ha.map _
   mpr := .map f

--- a/Mathlib/RingTheory/Coalgebra/GroupLike.lean
+++ b/Mathlib/RingTheory/Coalgebra/GroupLike.lean
@@ -77,6 +77,8 @@ lemma val_injective : Injective (val : GroupLike R A → A) := by rintro ⟨a, h
 @[simp, norm_cast] lemma val_inj {a b : GroupLike R A} : a.val = b.val ↔ a = b :=
   val_injective.eq_iff
 
+@[simp] lemma mk_eq_mk (ha hb) : mk a ha = mk b hb ↔ a = b := by simp [← val_inj]
+
 /-- Identity equivalence between `GroupLike R A` and `{a : A // IsGroupLikeElem R a}`. -/
 def valEquiv : GroupLike R A ≃ Subtype (IsGroupLikeElem R : A → Prop) where
   toFun a := ⟨a.1, a.2⟩

--- a/Mathlib/RingTheory/Coalgebra/GroupLike.lean
+++ b/Mathlib/RingTheory/Coalgebra/GroupLike.lean
@@ -77,8 +77,6 @@ lemma val_injective : Injective (val : GroupLike R A → A) := by rintro ⟨a, h
 @[simp, norm_cast] lemma val_inj {a b : GroupLike R A} : a.val = b.val ↔ a = b :=
   val_injective.eq_iff
 
-@[simp] lemma mk_eq_mk (ha hb) : (mk a ha : GroupLike R A) = mk b hb ↔ a = b := by simp [← val_inj]
-
 /-- Identity equivalence between `GroupLike R A` and `{a : A // IsGroupLikeElem R a}`. -/
 def valEquiv : GroupLike R A ≃ Subtype (IsGroupLikeElem R : A → Prop) where
   toFun a := ⟨a.1, a.2⟩

--- a/Mathlib/RingTheory/Coalgebra/GroupLike.lean
+++ b/Mathlib/RingTheory/Coalgebra/GroupLike.lean
@@ -77,7 +77,7 @@ lemma val_injective : Injective (val : GroupLike R A → A) := by rintro ⟨a, h
 @[simp, norm_cast] lemma val_inj {a b : GroupLike R A} : a.val = b.val ↔ a = b :=
   val_injective.eq_iff
 
-/-- Identity equivalence between `GroupLike R A` and `{a : A | IsGroupLikeElem R a}`. -/
+/-- Identity equivalence between `GroupLike R A` and `{a : A // IsGroupLikeElem R a}`. -/
 def valEquiv : GroupLike R A ≃ Subtype (IsGroupLikeElem R : A → Prop) where
   toFun a := ⟨a.1, a.2⟩
   invFun a := ⟨a.1, a.2⟩

--- a/Mathlib/RingTheory/Coalgebra/GroupLike.lean
+++ b/Mathlib/RingTheory/Coalgebra/GroupLike.lean
@@ -77,7 +77,7 @@ lemma val_injective : Injective (val : GroupLike R A → A) := by rintro ⟨a, h
 @[simp, norm_cast] lemma val_inj {a b : GroupLike R A} : a.val = b.val ↔ a = b :=
   val_injective.eq_iff
 
-@[simp] lemma mk_eq_mk (ha hb) : mk a ha = mk b hb ↔ a = b := by simp [← val_inj]
+@[simp] lemma mk_eq_mk (ha hb) : (mk a ha : GroupLike R A) = mk b hb ↔ a = b := by simp [← val_inj]
 
 /-- Identity equivalence between `GroupLike R A` and `{a : A // IsGroupLikeElem R a}`. -/
 def valEquiv : GroupLike R A ≃ Subtype (IsGroupLikeElem R : A → Prop) where

--- a/Mathlib/RingTheory/HopfAlgebra/GroupLike.lean
+++ b/Mathlib/RingTheory/HopfAlgebra/GroupLike.lean
@@ -1,0 +1,70 @@
+/-
+Copyright (c) 2025 Yaël Dillies, Michał Mrugała. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yaël Dillies, Michał Mrugała
+-/
+import Mathlib.RingTheory.HopfAlgebra.Basic
+import Mathlib.RingTheory.Bialgebra.GroupLike
+
+/-!
+# Group-like elements in a Hopf algebra
+
+This file proves that group-like elements in a Hopf algebra form a group.
+-/
+
+open HopfAlgebra
+
+variable {R A : Type*}
+
+section Semiring
+variable [CommSemiring R] [Semiring A] [HopfAlgebra R A] {a b : A}
+
+@[simp] lemma IsGroupLikeElem.antipode_mul_cancel (ha : IsGroupLikeElem R a) :
+    antipode R a * a = 1 := by
+  simpa [ha, -mul_antipode_lTensor_comul_apply] using mul_antipode_rTensor_comul_apply (R := R) a
+
+@[simp] lemma IsGroupLikeElem.mul_antipode_cancel (ha : IsGroupLikeElem R a) :
+    a * antipode R a = 1 := by
+  simpa [ha, -mul_antipode_lTensor_comul_apply] using mul_antipode_lTensor_comul_apply (R := R) a
+
+variable (R) in
+/-- Turn a group-like element `a` into a unit with inverse its antipode. -/
+@[simps]
+def GroupLike.toUnits : GroupLike R A →* Aˣ where
+  toFun a := {
+    val := a
+    inv := antipode R a
+    val_inv := a.2.mul_antipode_cancel
+    inv_val := a.2.antipode_mul_cancel
+  }
+  map_one' := by ext; rfl
+  map_mul' a b := by ext; rfl
+
+lemma IsGroupLikeElem.isUnit (ha : IsGroupLikeElem R a) : IsUnit a :=
+  (GroupLike.toUnits R ⟨a, ha⟩).isUnit
+
+@[simp] protected lemma IsGroupLikeElem.antipode (ha : IsGroupLikeElem R a) :
+    IsGroupLikeElem R (antipode R a) :=
+  ha.of_mul_eq_one ha.mul_antipode_cancel ha.antipode_mul_cancel
+
+@[simp] lemma IsGroupLikeElem.antipode_antipode (ha : IsGroupLikeElem R a) :
+    antipode R (antipode R a) = a :=
+  left_inv_eq_right_inv ha.antipode.antipode_mul_cancel ha.antipode_mul_cancel
+
+namespace GroupLike
+
+instance : Inv (GroupLike R A) where inv a := ⟨antipode R a, a.2.antipode⟩
+
+@[simp] lemma val_inv (a : GroupLike R A) : ↑(a⁻¹) = (antipode R a : A) := rfl
+
+instance : Group (GroupLike R A) where
+  inv_mul_cancel a := by ext; simp
+
+end GroupLike
+end Semiring
+
+variable [CommSemiring R] [CommSemiring A] [HopfAlgebra R A] {a b : A}
+
+instance GroupLike.instCommGroup : CommGroup (GroupLike R A) where
+  __ := instCommMonoid
+  __ := instGroup


### PR DESCRIPTION
Define group-like elements in a bialgebra, ie elements such that `η a = 1` and `Δ a = a ⊗ₜ a`.

We prove that group-like elements of a coalgebra over a domain are linearly independent, group-like elements of a bialgebra form a monoid, group-like elements of a Hopf algebra form a group.

From Toric

Co-authored-by: Michał Mrugała <kiolterino@gmail.com>

---
- [x] depends on: #24747
- [x] depends on: #31515

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
