### PR TITLE
[Merged by Bors] - feat(Algebra/Homology/DerivedCategory): `Ext` commutes with finite coproducts

### DIFF
--- a/Mathlib/Algebra/Homology/DerivedCategory/Ext/Basic.lean
+++ b/Mathlib/Algebra/Homology/DerivedCategory/Ext/Basic.lean
@@ -423,15 +423,15 @@ noncomputable def extFunctor (n : ℕ) : Cᵒᵖ ⥤ C ⥤ AddCommGrp.{w} where
     apply Ext.comp_assoc
     all_goals omega
 
+section
+
+attribute [local simp] Ext.mk₀_add
+
 instance (X : C) (n : ℕ) : (extFunctorObj X n).Additive where
-  map_add {_ _ _ _} := by
-    apply AddCommGrp.hom_ext
-    simp [Ext.mk₀_add]
 
 instance (n : ℕ) : (extFunctor (C := C) n).Additive where
-  map_add {_ _ _ _} := by
-    ext
-    simp [Ext.mk₀_add]
+
+end
 
 /-- `Ext` commutes with finite coproducts. -/
 noncomputable def Ext.coprodIso (X : C) {ι : Type*} [Finite ι] (Y : ι → C) (n : ℕ) :

--- a/Mathlib/Algebra/Homology/DerivedCategory/Ext/Basic.lean
+++ b/Mathlib/Algebra/Homology/DerivedCategory/Ext/Basic.lean
@@ -444,12 +444,31 @@ lemma Ext.mk₀_sum {X Y : C} {ι : Type*} [Fintype ι]
     mk₀ (∑ i, f i) = ∑ i, mk₀ (f i) :=
   map_sum addEquiv₀.symm _ _
 
-variable (X : C) {ι : Type*} [Fintype ι] {Y : ι → C} {c : Bicone Y} (hc : c.IsBilimit) (n : ℕ)
+variable {J : Type*} [Fintype J] {X : J → C} {c : Bicone X} (hc : c.IsBilimit) (Y : C) (n : ℕ)
 
-/-- `Ext` commutes with finite biproducts. -/
+/-- `Ext` commutes with biproducts in its first variable. -/
+noncomputable def Ext.biproductAddEquiv : Ext c.pt Y n ≃+ Π i, Ext (X i) Y n where
+  toFun e i := (Ext.mk₀ (c.ι i)).comp e (zero_add n)
+  invFun e := ∑ (i : J), (Ext.mk₀ (c.π i)).comp (e i) (zero_add n)
+  left_inv x := by
+    simp only [← comp_assoc_of_second_deg_zero, mk₀_comp_mk₀]
+    rw [← Ext.sum_comp, ← Ext.mk₀_sum, IsBilimit.total hc, mk₀_id_comp]
+  right_inv _ := by
+    ext i
+    simp only [Ext.comp_sum, ← comp_assoc_of_second_deg_zero, mk₀_comp_mk₀]
+    rw [Finset.sum_eq_single i _ (by simp), bicone_ι_π_self, mk₀_id_comp]
+    intro _ _ hij
+    rw [c.ι_π, dif_neg hij.symm, mk₀_zero, zero_comp]
+  map_add' _ _ := by
+    simp only [comp_add]
+    rfl
+
+variable (X : C) {J : Type*} [Fintype J] {Y : J → C} {c : Bicone Y} (hc : c.IsBilimit) (n : ℕ)
+
+/-- `Ext` commutes with biproducts in its second variable. -/
 noncomputable def Ext.addEquivBiproduct : Ext X c.pt n ≃+ Π i, Ext X (Y i) n where
   toFun e i := e.comp (Ext.mk₀ (c.π i)) (add_zero n)
-  invFun e := ∑ (i : ι), (e i).comp (Ext.mk₀ (c.ι i)) (add_zero n)
+  invFun e := ∑ (i : J), (e i).comp (Ext.mk₀ (c.ι i)) (add_zero n)
   left_inv _ := by
     simp only [comp_assoc_of_second_deg_zero, mk₀_comp_mk₀, ← Ext.comp_sum,
       ← Ext.mk₀_sum, IsBilimit.total hc, comp_mk₀_id]

--- a/Mathlib/Algebra/Homology/DerivedCategory/Ext/Basic.lean
+++ b/Mathlib/Algebra/Homology/DerivedCategory/Ext/Basic.lean
@@ -439,8 +439,7 @@ lemma Ext.sum_comp {X Y Z : C} {p : ℕ} {ι : Type*} [Fintype ι] (α : ι → 
     (∑ i, α i).comp β h = ∑ i, (α i).comp β h :=
   map_sum (β.postcomp X h) _ _
 
-lemma Ext.mk₀_sum {X Y : C} {ι : Type*} [Fintype ι]
-    (f : ι → (X ⟶ Y)) :
+lemma Ext.mk₀_sum {X Y : C} {ι : Type*} [Fintype ι] (f : ι → (X ⟶ Y)) :
     mk₀ (∑ i, f i) = ∑ i, mk₀ (f i) :=
   map_sum addEquiv₀.symm _ _
 

--- a/Mathlib/Algebra/Homology/DerivedCategory/Ext/Basic.lean
+++ b/Mathlib/Algebra/Homology/DerivedCategory/Ext/Basic.lean
@@ -421,7 +421,7 @@ noncomputable def extFunctor (n : ℕ) : Cᵒᵖ ⥤ C ⥤ AddCommGrp.{w} where
     apply Ext.comp_assoc
     all_goals omega
 
-section
+section biproduct
 
 attribute [local simp] Ext.mk₀_add
 
@@ -481,7 +481,7 @@ noncomputable def Ext.addEquivBiproduct : Ext X c.pt n ≃+ Π i, Ext X (Y i) n 
     simp only [add_comp]
     rfl
 
-end
+end biproduct
 
 section ChangeOfUniverse
 

--- a/Mathlib/Algebra/Homology/DerivedCategory/Ext/Basic.lean
+++ b/Mathlib/Algebra/Homology/DerivedCategory/Ext/Basic.lean
@@ -439,7 +439,6 @@ noncomputable def Ext.coprodIso (X : C) {ι : Type*} [Finite ι] (Y : ι → C) 
   PreservesCoproduct.iso (extFunctorObj X n) Y
 
 /-- `Ext` commutes with finite products. -/
--- TODO: Prove that `Ext` commutes with arbitrary products.
 noncomputable def Ext.prodIso (X : C) {ι : Type*} [Finite ι] (Y : ι → C) (n : ℕ) :
     AddCommGrp.of (Ext X (∏ᶜ Y) n) ≅ ∏ᶜ (fun i => AddCommGrp.of (Ext X (Y i) n)) :=
   PreservesProduct.iso (extFunctorObj X n) Y

--- a/Mathlib/Algebra/Homology/DerivedCategory/Ext/Basic.lean
+++ b/Mathlib/Algebra/Homology/DerivedCategory/Ext/Basic.lean
@@ -443,10 +443,9 @@ lemma Ext.mk₀_sum {X Y : C} {ι : Type*} [Fintype ι] (f : ι → (X ⟶ Y)) :
     mk₀ (∑ i, f i) = ∑ i, mk₀ (f i) :=
   map_sum addEquiv₀.symm _ _
 
-variable {J : Type*} [Fintype J] {X : J → C} {c : Bicone X} (hc : c.IsBilimit) (Y : C) (n : ℕ)
-
 /-- `Ext` commutes with biproducts in its first variable. -/
-noncomputable def Ext.biproductAddEquiv : Ext c.pt Y n ≃+ Π i, Ext (X i) Y n where
+noncomputable def Ext.biproductAddEquiv {J : Type*} [Fintype J] {X : J → C} {c : Bicone X}
+    (hc : c.IsBilimit) (Y : C) (n : ℕ): Ext c.pt Y n ≃+ Π i, Ext (X i) Y n where
   toFun e i := (Ext.mk₀ (c.ι i)).comp e (zero_add n)
   invFun e := ∑ (i : J), (Ext.mk₀ (c.π i)).comp (e i) (zero_add n)
   left_inv x := by
@@ -462,10 +461,9 @@ noncomputable def Ext.biproductAddEquiv : Ext c.pt Y n ≃+ Π i, Ext (X i) Y n 
     simp only [comp_add]
     rfl
 
-variable (X : C) {J : Type*} [Fintype J] {Y : J → C} {c : Bicone Y} (hc : c.IsBilimit) (n : ℕ)
-
 /-- `Ext` commutes with biproducts in its second variable. -/
-noncomputable def Ext.addEquivBiproduct : Ext X c.pt n ≃+ Π i, Ext X (Y i) n where
+noncomputable def Ext.addEquivBiproduct (X : C) {J : Type*} [Fintype J] {Y : J → C} {c : Bicone Y}
+    (hc : c.IsBilimit) (n : ℕ) : Ext X c.pt n ≃+ Π i, Ext X (Y i) n where
   toFun e i := e.comp (Ext.mk₀ (c.π i)) (add_zero n)
   invFun e := ∑ (i : J), (e i).comp (Ext.mk₀ (c.ι i)) (add_zero n)
   left_inv _ := by

--- a/Mathlib/Algebra/Homology/DerivedCategory/Ext/Basic.lean
+++ b/Mathlib/Algebra/Homology/DerivedCategory/Ext/Basic.lean
@@ -450,16 +450,18 @@ variable (X : C) {ι : Type*} [Fintype ι] {Y : ι → C} {c : Bicone Y} (hc : c
 noncomputable def Ext.addEquivBiproduct : Ext X c.pt n ≃+ Π i, Ext X (Y i) n where
   toFun e i := e.comp (Ext.mk₀ (c.π i)) (add_zero n)
   invFun e := ∑ (i : ι), (e i).comp (Ext.mk₀ (c.ι i)) (add_zero n)
-  left_inv e := by
+  left_inv _ := by
     simp only [comp_assoc_of_second_deg_zero, mk₀_comp_mk₀, ← Ext.comp_sum,
       ← Ext.mk₀_sum, IsBilimit.total hc, comp_mk₀_id]
-  right_inv e := by
+  right_inv _ := by
     ext i
     simp only [Ext.sum_comp, comp_assoc_of_second_deg_zero, mk₀_comp_mk₀]
     rw [Finset.sum_eq_single i _ (by simp), bicone_ι_π_self, comp_mk₀_id]
-    intro j _ hij
+    intro _ _ hij
     rw [c.ι_π, dif_neg hij, mk₀_zero, comp_zero]
-  map_add' := by aesop
+  map_add' _ _ := by
+    simp only [add_comp]
+    rfl
 
 end
 

--- a/Mathlib/Algebra/Homology/DerivedCategory/Ext/Basic.lean
+++ b/Mathlib/Algebra/Homology/DerivedCategory/Ext/Basic.lean
@@ -3,7 +3,8 @@ Copyright (c) 2024 Joël Riou. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Joël Riou
 -/
-import Mathlib.Algebra.Homology.DerivedCategory.Basic
+import Mathlib.Algebra.Category.Grp.Colimits
+import Mathlib.Algebra.Category.Grp.Limits
 import Mathlib.Algebra.Homology.DerivedCategory.FullyFaithful
 import Mathlib.CategoryTheory.Localization.SmallShiftedHom
 
@@ -17,7 +18,7 @@ the derived category of `C` are `w`-small. Under this assumption,
 we define `Ext.{w} X Y n : Type w` as shrunk versions of suitable
 types of morphisms in the derived category. In particular, when `C` has
 enough projectives or enough injectives, the property `HasExt.{v} C`
-shall hold (TODO).
+shall hold.
 
 Note: in certain situations, `w := v` shall be the preferred
 choice of universe (e.g. if `C := ModuleCat.{v} R` with `R : Type v`).
@@ -421,6 +422,27 @@ noncomputable def extFunctor (n : ℕ) : Cᵒᵖ ⥤ C ⥤ AddCommGrp.{w} where
     rw [← Ext.mk₀_comp_mk₀]
     apply Ext.comp_assoc
     all_goals omega
+
+instance (X : C) (n : ℕ) : (extFunctorObj X n).Additive where
+  map_add {_ _ _ _} := by
+    apply AddCommGrp.hom_ext
+    simp [Ext.mk₀_add]
+
+instance (n : ℕ) : (extFunctor (C := C) n).Additive where
+  map_add {_ _ _ _} := by
+    ext
+    simp [Ext.mk₀_add]
+
+/-- `Ext` commutes with finite coproducts. -/
+noncomputable def coprodIso (X : C) {ι : Type*} [Finite ι] (Y : ι → C) (n : ℕ) :
+    AddCommGrp.of (Ext X (∐ Y) n) ≅ ∐ (fun i => AddCommGrp.of (Ext X (Y i) n)) :=
+  PreservesCoproduct.iso (extFunctorObj X n) Y
+
+/-- `Ext` commutes with finite products. -/
+-- TODO: Prove that `Ext` commutes with arbitrary products.
+noncomputable def prodIso (X : C) {ι : Type*} [Finite ι] (Y : ι → C) (n : ℕ) :
+    AddCommGrp.of (Ext X (∏ᶜ Y) n) ≅ ∏ᶜ (fun i => AddCommGrp.of (Ext X (Y i) n)) :=
+  PreservesProduct.iso (extFunctorObj X n) Y
 
 section ChangeOfUniverse
 

--- a/Mathlib/Algebra/Homology/DerivedCategory/Ext/Basic.lean
+++ b/Mathlib/Algebra/Homology/DerivedCategory/Ext/Basic.lean
@@ -434,13 +434,13 @@ instance (n : ℕ) : (extFunctor (C := C) n).Additive where
     simp [Ext.mk₀_add]
 
 /-- `Ext` commutes with finite coproducts. -/
-noncomputable def coprodIso (X : C) {ι : Type*} [Finite ι] (Y : ι → C) (n : ℕ) :
+noncomputable def Ext.coprodIso (X : C) {ι : Type*} [Finite ι] (Y : ι → C) (n : ℕ) :
     AddCommGrp.of (Ext X (∐ Y) n) ≅ ∐ (fun i => AddCommGrp.of (Ext X (Y i) n)) :=
   PreservesCoproduct.iso (extFunctorObj X n) Y
 
 /-- `Ext` commutes with finite products. -/
 -- TODO: Prove that `Ext` commutes with arbitrary products.
-noncomputable def prodIso (X : C) {ι : Type*} [Finite ι] (Y : ι → C) (n : ℕ) :
+noncomputable def Ext.prodIso (X : C) {ι : Type*} [Finite ι] (Y : ι → C) (n : ℕ) :
     AddCommGrp.of (Ext X (∏ᶜ Y) n) ≅ ∏ᶜ (fun i => AddCommGrp.of (Ext X (Y i) n)) :=
   PreservesProduct.iso (extFunctorObj X n) Y
 

--- a/Mathlib/Algebra/Homology/DerivedCategory/Ext/Basic.lean
+++ b/Mathlib/Algebra/Homology/DerivedCategory/Ext/Basic.lean
@@ -3,8 +3,6 @@ Copyright (c) 2024 Joël Riou. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Joël Riou
 -/
-import Mathlib.Algebra.Category.Grp.Colimits
-import Mathlib.Algebra.Category.Grp.Limits
 import Mathlib.Algebra.Homology.DerivedCategory.FullyFaithful
 import Mathlib.CategoryTheory.Localization.SmallShiftedHom
 
@@ -446,7 +444,7 @@ lemma Ext.mk₀_sum {X Y : C} {ι : Type*} [Fintype ι]
     mk₀ (∑ i, f i) = ∑ i, mk₀ (f i) :=
   map_sum addEquiv₀.symm _ _
 
-variable {X : C} {ι : Type*} [Fintype ι] {Y : ι → C} {c : Bicone Y} (hc : c.IsBilimit) (n : ℕ)
+variable (X : C) {ι : Type*} [Fintype ι] {Y : ι → C} {c : Bicone Y} (hc : c.IsBilimit) (n : ℕ)
 
 /-- `Ext` commutes with finite biproducts. -/
 noncomputable def Ext.addEquivBiproduct : Ext X c.pt n ≃+ Π i, Ext X (Y i) n where

--- a/Mathlib/CategoryTheory/Preadditive/AdditiveFunctor.lean
+++ b/Mathlib/CategoryTheory/Preadditive/AdditiveFunctor.lean
@@ -162,6 +162,22 @@ instance (priority := 100) preservesFiniteBiproductsOfAdditive [Additive F] :
             simp_rw [F.mapBicone_π, F.mapBicone_ι, ← F.map_comp]
             erw [← F.map_sum, ← F.map_id, IsBilimit.total hb])⟩ } }
 
+instance (priority := 100) preservesFiniteBiproductsOfShapeOfAdditive [Additive F]
+    (J : Type*) [Finite J] : PreservesBiproductsOfShape J F where
+  preserves := ⟨fun hb =>
+    have : Fintype J := Fintype.ofFinite J
+    ⟨isBilimitOfTotal _ (by
+      simp_rw [F.mapBicone_π, F.mapBicone_ι, ← F.map_comp]
+      erw [← F.map_sum, ← F.map_id, IsBilimit.total hb])⟩⟩
+
+instance (priority := 100) preservesCoproductOfAdditive [Additive F] {J : Type*} [Finite J]
+    (Y : J → C) : PreservesColimit (Discrete.functor Y) F :=
+  preservesCoproduct_of_preservesBiproduct F
+
+instance (priority := 100) preservesProductOfAdditive [Additive F] {J : Type*} [Finite J]
+    (Y : J → C) : PreservesLimit (Discrete.functor Y) F :=
+  preservesProduct_of_preservesBiproduct F
+
 theorem additive_of_preservesBinaryBiproducts [HasBinaryBiproducts C] [PreservesZeroMorphisms F]
     [PreservesBinaryBiproducts F] : Additive F where
   map_add {X Y f g} := by

--- a/Mathlib/CategoryTheory/Preadditive/AdditiveFunctor.lean
+++ b/Mathlib/CategoryTheory/Preadditive/AdditiveFunctor.lean
@@ -162,21 +162,13 @@ instance (priority := 100) preservesFiniteBiproductsOfAdditive [Additive F] :
             simp_rw [F.mapBicone_π, F.mapBicone_ι, ← F.map_comp]
             erw [← F.map_sum, ← F.map_id, IsBilimit.total hb])⟩ } }
 
-instance (priority := 100) preservesFiniteBiproductsOfShapeOfAdditive [Additive F]
-    (J : Type*) [Finite J] : PreservesBiproductsOfShape J F where
-  preserves := ⟨fun hb =>
-    have : Fintype J := Fintype.ofFinite J
-    ⟨isBilimitOfTotal _ (by
-      simp_rw [F.mapBicone_π, F.mapBicone_ι, ← F.map_comp]
-      erw [← F.map_sum, ← F.map_id, IsBilimit.total hb])⟩⟩
+instance (priority := 100) preservesFiniteCoproductsOfAdditive [Additive F] :
+    PreservesFiniteCoproducts F where
+  preserves _ := preservesCoproductsOfShape_of_preservesBiproductsOfShape F
 
-instance (priority := 100) preservesCoproductOfAdditive [Additive F] {J : Type*} [Finite J]
-    (Y : J → C) : PreservesColimit (Discrete.functor Y) F :=
-  preservesCoproduct_of_preservesBiproduct F
-
-instance (priority := 100) preservesProductOfAdditive [Additive F] {J : Type*} [Finite J]
-    (Y : J → C) : PreservesLimit (Discrete.functor Y) F :=
-  preservesProduct_of_preservesBiproduct F
+instance (priority := 100) preservesFiniteProductsOfAdditive [Additive F] :
+    PreservesFiniteProducts F where
+  preserves _ := preservesProductsOfShape_of_preservesBiproductsOfShape F
 
 theorem additive_of_preservesBinaryBiproducts [HasBinaryBiproducts C] [PreservesZeroMorphisms F]
     [PreservesBinaryBiproducts F] : Additive F where

--- a/Mathlib/CategoryTheory/Preadditive/Biproducts.lean
+++ b/Mathlib/CategoryTheory/Preadditive/Biproducts.lean
@@ -75,7 +75,7 @@ namespace Limits
 
 section Fintype
 
-variable {J : Type} [Fintype J]
+variable {J : Type*} [Fintype J]
 
 /-- In a preadditive category, we can construct a biproduct for `f : J → C` from
 any bicone `b` for `f` satisfying `total : ∑ j : J, b.π j ≫ b.ι j = 𝟙 b.X`.
@@ -165,7 +165,7 @@ end Fintype
 
 section Finite
 
-variable {J : Type} [Finite J]
+variable {J : Type*} [Finite J]
 
 /-- In a preadditive category, if the product over `f : J → C` exists,
     then the biproduct over `f` exists. -/
@@ -851,7 +851,7 @@ namespace Limits
 
 section Finite
 
-variable {J : Type} [Finite J]
+variable {J : Type*} [Finite J]
 
 /-- A functor between preadditive categories that preserves (zero morphisms and) finite biproducts
     preserves finite products. -/


### PR DESCRIPTION
Prove that `Ext` commutes with finite coproducts and products.

Co-authored-by: Nailin Guan @Thmoas-Guan

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
