### PR TITLE
[Merged by Bors] - chore: deprecate Topology.GDelta.UniformSpace

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -6053,6 +6053,7 @@ import Mathlib.Topology.FiberPartition
 import Mathlib.Topology.Filter
 import Mathlib.Topology.GDelta.Basic
 import Mathlib.Topology.GDelta.MetrizableSpace
+import Mathlib.Topology.GDelta.UniformSpace
 import Mathlib.Topology.Germ
 import Mathlib.Topology.Gluing
 import Mathlib.Topology.Hom.ContinuousEval

--- a/Mathlib/Topology/GDelta/UniformSpace.lean
+++ b/Mathlib/Topology/GDelta/UniformSpace.lean
@@ -1,0 +1,10 @@
+/-
+Copyright (c) 2019 Sébastien Gouëzel. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sébastien Gouëzel, Yury Kudryashov
+-/
+
+import Mathlib.Topology.GDelta.MetrizableSpace
+import Mathlib.Topology.Separation.GDelta
+
+deprecated_module (since := "2025-05-09")

--- a/Mathlib/Topology/GDelta/UniformSpace.lean
+++ b/Mathlib/Topology/GDelta/UniformSpace.lean
@@ -7,4 +7,4 @@ Authors: Sébastien Gouëzel, Yury Kudryashov
 import Mathlib.Topology.GDelta.MetrizableSpace
 import Mathlib.Topology.Separation.GDelta
 
-deprecated_module (since := "2025-05-09")
+deprecated_module (since := "2025-05-07")


### PR DESCRIPTION
It was removed without deprecation in #22256.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
