### PR TITLE
[Merged by Bors] - feat: `LinearIndepOn` versions of existing `LinearIndependent` lemmas

### DIFF
--- a/Mathlib/LinearAlgebra/LinearIndependent/Basic.lean
+++ b/Mathlib/LinearAlgebra/LinearIndependent/Basic.lean
@@ -216,10 +216,6 @@ theorem linearIndependent_finset_map_embedding_subtype (s : Set M)
 
 section Indexed
 
-theorem LinearIndepOn.mono {t s : Set ι} (hs : LinearIndepOn R v s) (h : t ⊆ s) :
-    LinearIndepOn R v t :=
-  hs.comp _ <| Set.inclusion_injective h
-
 @[deprecated (since := "2025-02-15")] alias LinearIndependent.mono := LinearIndepOn.mono
 
 theorem linearIndepOn_of_finite (s : Set ι) (H : ∀ t ⊆ s, Set.Finite t → LinearIndepOn R v t) :

--- a/Mathlib/LinearAlgebra/LinearIndependent/Defs.lean
+++ b/Mathlib/LinearAlgebra/LinearIndependent/Defs.lean
@@ -55,6 +55,8 @@ worlds.
 
 ## TODO
 
+This file contains much more than definitions.
+
 Rework proofs to hold in semirings, by avoiding the path through
 `ker (Finsupp.linearCombination R v) = ⊥`.
 

--- a/Mathlib/RingTheory/Flat/Basic.lean
+++ b/Mathlib/RingTheory/Flat/Basic.lean
@@ -506,15 +506,15 @@ lemma map_injective_of_flat_flat'
   exact (Module.Flat.rTensor_preserves_injective_linearMap f hf).comp
     (Module.Flat.lTensor_preserves_injective_linearMap g hg)
 
+variable {ι κ : Type*} {v : ι → M} {w : κ → N} {s : Set ι} {t : Set κ}
+
 /-- Tensor product of linearly independent families is linearly
 independent under some flatness conditions.
 
 The flatness condition could be removed over domains.
 See `LinearIndependent.tmul_of_isDomain`. -/
-lemma _root_.LinearIndependent.tmul_of_flat_left [Module.Flat R M]
-    {ι ι' : Type*} {v : ι → M} (hv : LinearIndependent R v)
-    {w : ι' → N} (hw : LinearIndependent R w) :
-    LinearIndependent R fun i : ι × ι' ↦ v i.1 ⊗ₜ[R] w i.2 := by
+lemma _root_.LinearIndependent.tmul_of_flat_left [Module.Flat R M] (hv : LinearIndependent R v)
+    (hw : LinearIndependent R w) : LinearIndependent R fun i : ι × κ ↦ v i.1 ⊗ₜ[R] w i.2 := by
   rw [LinearIndependent]
   convert (TensorProduct.map_injective_of_flat_flat _ _ hv hw).comp
     (finsuppTensorFinsupp' _ _ _).symm.injective
@@ -527,14 +527,30 @@ lemma _root_.LinearIndependent.tmul_of_flat_left [Module.Flat R M]
 independent under some flatness conditions.
 
 The flatness condition could be removed over domains.
+See `LinearIndepOn.tmul_of_isDomain`. -/
+nonrec lemma LinearIndepOn.tmul_of_flat_left [Module.Flat R M] (hv : LinearIndepOn R v s)
+    (hw : LinearIndepOn R w t) : LinearIndepOn R (fun i : ι × κ ↦ v i.1 ⊗ₜ[R] w i.2) (s ×ˢ t) :=
+  ((hv.tmul_of_flat_left hw).comp _ (Equiv.Set.prod _ _).injective:)
+
+/-- Tensor product of linearly independent families is linearly
+independent under some flatness conditions.
+
+The flatness condition could be removed over domains.
 See `LinearIndependent.tmul_of_isDomain`. -/
-lemma _root_.LinearIndependent.tmul_of_flat_right [Module.Flat R N]
-    {ι ι' : Type*} {v : ι → M} (hv : LinearIndependent R v)
-    {w : ι' → N} (hw : LinearIndependent R w) :
-    LinearIndependent R fun i : ι × ι' ↦ v i.1 ⊗ₜ[R] w i.2 :=
+lemma _root_.LinearIndependent.tmul_of_flat_right [Module.Flat R N] (hv : LinearIndependent R v)
+    (hw : LinearIndependent R w) : LinearIndependent R fun i : ι × κ ↦ v i.1 ⊗ₜ[R] w i.2 :=
   (((TensorProduct.comm R N M).toLinearMap.linearIndependent_iff_of_injOn
     (TensorProduct.comm R N M).injective.injOn).mpr
       (hw.tmul_of_flat_left hv)).comp Prod.swap Prod.swap_bijective.injective
+
+/-- Tensor product of linearly independent families is linearly
+independent under some flatness conditions.
+
+The flatness condition could be removed over domains.
+See `LinearIndepOn.tmul_of_isDomain`. -/
+nonrec lemma LinearIndepOn.tmul_of_flat_right [Module.Flat R N] (hv : LinearIndepOn R v s)
+    (hw : LinearIndepOn R w t) : LinearIndepOn R (fun i : ι × κ ↦ v i.1 ⊗ₜ[R] w i.2) (s ×ˢ t) :=
+  ((hv.tmul_of_flat_right hw).comp _ (Equiv.Set.prod _ _).injective:)
 
 variable (p : Submodule R M) (q : Submodule R N)
 

--- a/Mathlib/RingTheory/Flat/Domain.lean
+++ b/Mathlib/RingTheory/Flat/Domain.lean
@@ -15,7 +15,7 @@ and the ring is an integral domain.
 
 universe u
 
-variable {R M N : Type*} [CommRing R] [AddCommGroup M] [Module R M]
+variable {R M N : Type*} [CommRing R] [IsDomain R] [AddCommGroup M] [Module R M]
 variable [AddCommGroup N] [Module R N]
 variable {P Q : Type*} [AddCommGroup P] [Module R P] [AddCommGroup Q] [Module R Q]
 
@@ -25,7 +25,7 @@ attribute [local instance 1100] Module.Free.of_divisionRing Module.Flat.of_free 
 /-- Tensor product of injective maps over domains are injective under some flatness conditions.
 Also see `TensorProduct.map_injective_of_flat_flat`
 for different flatness conditions but without the domain assumption. -/
-lemma TensorProduct.map_injective_of_flat_flat_of_isDomain [IsDomain R]
+lemma TensorProduct.map_injective_of_flat_flat_of_isDomain
     (f : P →ₗ[R] M) (g : Q →ₗ[R] N) [H : Module.Flat R P] [Module.Flat R Q]
     (hf : Injective f) (hg : Injective g) : Injective (TensorProduct.map f g) := by
   let K := FractionRing R
@@ -50,13 +50,13 @@ lemma TensorProduct.map_injective_of_flat_flat_of_isDomain [IsDomain R]
     (((1 : K) • (algebraMap R K) 1 ⊗ₜ[R] f p) ⊗ₜ[R] g q)
   simp only [map_one, one_smul, AlgebraTensorModule.assoc_tmul]
 
+variable {ι κ : Type*} {v : ι → M} {w : κ → N} {s : Set ι} {t : Set κ}
+
 /-- Tensor product of linearly independent families is linearly independent over domains.
 This is true over non-domains if one of the modules is flat.
 See `LinearIndependent.tmul_of_flat_left`. -/
-lemma LinearIndependent.tmul_of_isDomain [IsDomain R]
-    {ι ι' : Type*} {v : ι → M} (hv : LinearIndependent R v)
-    {w : ι' → N} (hw : LinearIndependent R w) :
-    LinearIndependent R fun i : ι × ι' ↦ v i.1 ⊗ₜ[R] w i.2 := by
+lemma LinearIndependent.tmul_of_isDomain (hv : LinearIndependent R v) (hw : LinearIndependent R w) :
+    LinearIndependent R fun i : ι × κ ↦ v i.1 ⊗ₜ[R] w i.2 := by
   rw [LinearIndependent]
   convert (TensorProduct.map_injective_of_flat_flat_of_isDomain _ _ hv hw).comp
     (finsuppTensorFinsupp' _ _ _).symm.injective
@@ -64,3 +64,10 @@ lemma LinearIndependent.tmul_of_isDomain [IsDomain R]
   congr!
   ext i
   simp [finsuppTensorFinsupp'_symm_single_eq_single_one_tmul]
+
+/-- Tensor product of linearly independent families is linearly independent over domains.
+This is true over non-domains if one of the modules is flat.
+See `LinearIndepOn.tmul_of_flat_left`. -/
+nonrec lemma LinearIndepOn.tmul_of_isDomain (hv : LinearIndepOn R v s) (hw : LinearIndepOn R w t) :
+    LinearIndepOn R (fun i : ι × κ ↦ v i.1 ⊗ₜ[R] w i.2) (s ×ˢ t) :=
+  ((hv.tmul_of_isDomain hw).comp _ (Equiv.Set.prod _ _).injective:)


### PR DESCRIPTION
From Toric


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
