### PR TITLE
[Merged by Bors] - fix(import diff bot): git checkout PR branch for the win

### DIFF
--- a/.github/workflows/PR_summary.yml
+++ b/.github/workflows/PR_summary.yml
@@ -104,7 +104,7 @@ jobs:
         done
 
         # we return to the PR branch, since the next step wants it!
-        git switch -
+        git checkout -
 
     - name: Compute transitive imports
       run: |

--- a/.github/workflows/PR_summary.yml
+++ b/.github/workflows/PR_summary.yml
@@ -103,6 +103,9 @@ jobs:
             tee -a moved_without_deprecation.txt
         done
 
+        # we return to the PR branch, since the next step wants it!
+        git switch -
+
     - name: Compute transitive imports
       run: |
         # the checkout dance, to avoid a detached head


### PR DESCRIPTION
This could be a fix for the issues reported in [#mathlib4 > import changes bot on PRs @ 💬](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/import.20changes.20bot.20on.20PRs/near/517233653).

The issue appears to be that the newly added steps to detect removed files leave the shell on `master`, but the import diff script expects to be on the PR branch.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
