### PR TITLE
[Merged by Bors] - chore(Convex/Topology): golf

### DIFF
--- a/Mathlib/Analysis/Convex/Topology.lean
+++ b/Mathlib/Analysis/Convex/Topology.lean
@@ -445,6 +445,10 @@ protected theorem Convex.isPreconnected {s : Set E} (h : Convex ℝ s) : IsPreco
   s.eq_empty_or_nonempty.elim (fun h => h.symm ▸ isPreconnected_empty) fun hne =>
     (h.isConnected hne).isPreconnected
 
+/-- A subspace in a topological vector space over `ℝ` is path connected. -/
+theorem Submodule.isPathConnected (s : Submodule ℝ E) : IsPathConnected (s : Set E) :=
+  s.convex.isPathConnected s.nonempty
+
 /-- Every topological vector space over ℝ is path connected.
 
 Not an instance, because it creates enormous TC subproblems (turn on `pp.all`).
@@ -452,43 +456,19 @@ Not an instance, because it creates enormous TC subproblems (turn on `pp.all`).
 protected theorem IsTopologicalAddGroup.pathConnectedSpace : PathConnectedSpace E :=
   pathConnectedSpace_iff_univ.mpr <| convex_univ.isPathConnected ⟨(0 : E), trivial⟩
 
-end ContinuousSMul
-
-section ComplementsConnected
-
-variable {E : Type*} [AddCommGroup E] [Module ℝ E] [TopologicalSpace E] [IsTopologicalAddGroup E]
-
-local notation "π" => Submodule.linearProjOfIsCompl _ _
-
-attribute [local instance 100] IsTopologicalAddGroup.pathConnectedSpace
-
 /-- Given two complementary subspaces `p` and `q` in `E`, if the complement of `{0}`
 is path connected in `p` then the complement of `q` is path connected in `E`. -/
-theorem isPathConnected_compl_of_isPathConnected_compl_zero [ContinuousSMul ℝ E]
-    {p q : Submodule ℝ E} (hpq : IsCompl p q) (hpc : IsPathConnected ({0}ᶜ : Set p)) :
-    IsPathConnected (qᶜ : Set E) := by
-  rw [isPathConnected_iff] at hpc ⊢
-  constructor
-  · rcases hpc.1 with ⟨a, ha⟩
-    exact ⟨a, mt (Submodule.eq_zero_of_coe_mem_of_disjoint hpq.disjoint) ha⟩
-  · intro x hx y hy
-    have : π hpq x ≠ 0 ∧ π hpq y ≠ 0 := by
-      constructor <;> intro h <;> rw [Submodule.linearProjOfIsCompl_apply_eq_zero_iff hpq] at h <;>
-        [exact hx h; exact hy h]
-    rcases hpc.2 (π hpq x) this.1 (π hpq y) this.2 with ⟨γ₁, hγ₁⟩
-    let γ₂ := PathConnectedSpace.somePath (π hpq.symm x) (π hpq.symm y)
-    let γ₁' : Path (_ : E) _ := γ₁.map continuous_subtype_val
-    let γ₂' : Path (_ : E) _ := γ₂.map continuous_subtype_val
-    refine ⟨(γ₁'.add γ₂').cast (Submodule.linear_proj_add_linearProjOfIsCompl_eq_self hpq x).symm
-      (Submodule.linear_proj_add_linearProjOfIsCompl_eq_self hpq y).symm, fun t ↦ ?_⟩
-    rw [Path.cast_coe, Path.add_apply]
-    change γ₁ t + (γ₂ t : E) ∉ q
-    rw [← Submodule.linearProjOfIsCompl_apply_eq_zero_iff hpq, LinearMap.map_add,
-      Submodule.linearProjOfIsCompl_apply_right, add_zero,
-      Submodule.linearProjOfIsCompl_apply_eq_zero_iff]
-    exact mt (Submodule.eq_zero_of_coe_mem_of_disjoint hpq.disjoint) (hγ₁ t)
+theorem isPathConnected_compl_of_isPathConnected_compl_zero {p q : Submodule ℝ E}
+    (hpq : IsCompl p q) (hpc : IsPathConnected ({0}ᶜ : Set p)) : IsPathConnected (qᶜ : Set E) := by
+  convert (hpc.image continuous_subtype_val).add q.isPathConnected using 1
+  trans Submodule.prodEquivOfIsCompl p q hpq '' ({0}ᶜ ×ˢ univ)
+  · rw [prod_univ, LinearEquiv.image_eq_preimage]
+    ext
+    simp
+  · ext
+    simp [mem_add, and_assoc]
 
-end ComplementsConnected
+end ContinuousSMul
 
 section LinearOrderedField
 

--- a/Mathlib/Topology/Connected/PathConnected.lean
+++ b/Mathlib/Topology/Connected/PathConnected.lean
@@ -45,7 +45,7 @@ path-connected, and that every path-connected set/space is also connected.
 
 noncomputable section
 
-open Topology Filter unitInterval Set Function
+open Topology Filter unitInterval Set Function Pointwise
 
 variable {X Y : Type*} [TopologicalSpace X] [TopologicalSpace Y] {x y z : X} {ι : Type*}
 
@@ -71,6 +71,11 @@ theorem Joined.symm {x y : X} (h : Joined x y) : Joined y x :=
 @[trans]
 theorem Joined.trans {x y z : X} (hxy : Joined x y) (hyz : Joined y z) : Joined x z :=
   ⟨hxy.somePath.trans hyz.somePath⟩
+
+@[to_additive]
+theorem Joined.mul {M : Type*} [Mul M] [TopologicalSpace M] [ContinuousMul M]
+    {a b c d : M} (hs : Joined a b) (ht : Joined c d) : Joined (a * c) (b * d) :=
+  ⟨hs.somePath.mul ht.somePath⟩
 
 variable (X)
 
@@ -190,6 +195,12 @@ theorem Topology.IsInducing.joinedIn_image {f : X → Y} (hf : IsInducing f) (hx
 
 @[deprecated (since := "2024-10-28")] alias Inducing.joinedIn_image := IsInducing.joinedIn_image
 
+@[to_additive]
+theorem JoinedIn.mul {M : Type*} [Mul M] [TopologicalSpace M] [ContinuousMul M]
+    {s t : Set M} {a b c d : M} (hs : JoinedIn s a b) (ht : JoinedIn t c d) :
+    JoinedIn (s * t) (a * c) (b * d) :=
+  ⟨hs.somePath.mul ht.somePath, fun t ↦ Set.mul_mem_mul (hs.somePath_mem t) (ht.somePath_mem t)⟩
+
 /-! ### Path component -/
 
 /-- The path component of `x` is the set of points that can be joined to `x`. -/
@@ -261,12 +272,12 @@ theorem pathComponentIn_mono {G : Set X} (h : F ⊆ G) :
 
 /-- A set `F` is path connected if it contains a point that can be joined to all other in `F`. -/
 def IsPathConnected (F : Set X) : Prop :=
-  ∃ x ∈ F, ∀ {y}, y ∈ F → JoinedIn F x y
+  ∃ x ∈ F, ∀ ⦃y⦄, y ∈ F → JoinedIn F x y
 
 theorem isPathConnected_iff_eq : IsPathConnected F ↔ ∃ x ∈ F, pathComponentIn x F = F := by
   constructor <;> rintro ⟨x, x_in, h⟩ <;> use x, x_in
   · ext y
-    exact ⟨fun hy => hy.mem.2, h⟩
+    exact ⟨fun hy => hy.mem.2, @h _⟩
   · intro y y_in
     rwa [← h] at y_in
 
@@ -279,7 +290,7 @@ theorem isPathConnected_iff :
     IsPathConnected F ↔ F.Nonempty ∧ ∀ᵉ (x ∈ F) (y ∈ F), JoinedIn F x y :=
   ⟨fun h =>
     ⟨let ⟨b, b_in, _hb⟩ := h; ⟨b, b_in⟩, h.joinedIn⟩,
-    fun ⟨⟨b, b_in⟩, h⟩ => ⟨b, b_in, fun x_in => h _ b_in _ x_in⟩⟩
+    fun ⟨⟨b, b_in⟩, h⟩ => ⟨b, b_in,  h _ b_in⟩⟩
 
 /-- If `f` is continuous on `F` and `F` is path-connected, so is `f(F)`. -/
 theorem IsPathConnected.image' (hF : IsPathConnected F)
@@ -294,6 +305,13 @@ theorem IsPathConnected.image' (hF : IsPathConnected F)
 theorem IsPathConnected.image (hF : IsPathConnected F) {f : X → Y} (hf : Continuous f) :
     IsPathConnected (f '' F) :=
   hF.image' hf.continuousOn
+
+@[to_additive]
+theorem IsPathConnected.mul {M : Type*} [Mul M] [TopologicalSpace M] [ContinuousMul M]
+    {s t : Set M} (hs : IsPathConnected s) (ht : IsPathConnected t) :
+    IsPathConnected (s * t) :=
+  let ⟨a, ha_mem, ha⟩ := hs; let ⟨b, hb_mem, hb⟩ := ht
+  ⟨a * b, mul_mem_mul ha_mem hb_mem, Set.forall_mem_image2.2 fun _x hx _y hy ↦ (ha hx).mul (hb hy)⟩
 
 /-- If `f : X → Y` is an inducing map, `f(F)` is path-connected iff `F` is. -/
 nonrec theorem Topology.IsInducing.isPathConnected_iff {f : X → Y} (hf : IsInducing f) :
@@ -334,7 +352,7 @@ theorem isPathConnected_singleton (x : X) : IsPathConnected ({x} : Set X) := by
   exact JoinedIn.refl rfl
 
 theorem isPathConnected_pathComponentIn (h : x ∈ F) : IsPathConnected (pathComponentIn x F) :=
-  ⟨x, mem_pathComponentIn_self h, fun ⟨γ, hγ⟩ ↦ by
+  ⟨x, mem_pathComponentIn_self h, fun _ ⟨γ, hγ⟩ ↦ by
     refine ⟨γ, fun t ↦
       ⟨(γ.truncateOfLE t.2.1).cast (γ.extend_zero.symm) (γ.extend_extends' t).symm, fun t' ↦ ?_⟩⟩
     dsimp [Path.truncateOfLE, Path.truncate]

--- a/Mathlib/Topology/Path.lean
+++ b/Mathlib/Topology/Path.lean
@@ -511,7 +511,7 @@ protected def mul [Mul X] [ContinuousMul X] {a₁ b₁ a₂ b₂ : X} (γ₁ : P
     Path (a₁ * a₂) (b₁ * b₂) :=
   (γ₁.prod γ₂).map continuous_mul
 
-@[to_additive]
+@[to_additive (attr := simp)]
 protected theorem mul_apply [Mul X] [ContinuousMul X] {a₁ b₁ a₂ b₂ : X} (γ₁ : Path a₁ b₁)
     (γ₂ : Path a₂ b₂) (t : unitInterval) : (γ₁.mul γ₂) t = γ₁ t * γ₂ t :=
   rfl


### PR DESCRIPTION
This PR golfs the proof
of `isPathConnected_compl_of_isPathConnected_compl_zero` by introducing `IsPathConnected.add` and dependencies.

Also use `∀ ⦃y⦄` instead of `∀ {y}` in the definition of `IsPathConnected`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
