### PR TITLE
[Merged by Bors] - feat: minimal elements exist in well-founded orders

### DIFF
--- a/Mathlib/Order/Minimal.lean
+++ b/Mathlib/Order/Minimal.lean
@@ -216,6 +216,25 @@ theorem not_maximal_iff_exists_gt (hx : P x) : ¬ Maximal P x ↔ ∃ y, x < y �
 
 alias ⟨exists_gt_of_not_maximal, _⟩ := not_maximal_iff_exists_gt
 
+variable (P) in
+lemma exists_minimal_of_wellFoundedLT [WellFoundedLT α] (hP : ∃ a, P a) : ∃ a, Minimal (P ·) a := by
+  simpa [not_lt_iff_le_imp_le] using wellFounded_lt.has_min _ hP
+
+variable (P) in
+lemma exists_maximal_of_wellFoundedGT [WellFoundedGT α] (hP : ∃ a, P a) : ∃ a, Maximal (P ·) a := by
+  simpa [not_lt_iff_le_imp_le] using wellFounded_gt.has_min _ hP
+
+variable (P a) in
+lemma exists_minimal_le_of_wellFoundedLT [WellFoundedLT α] (ha : P a) :
+    ∃ b ≤ a, Minimal (P ·) b := by
+  obtain ⟨b, ⟨hba, hb⟩, hbmin⟩ :=
+    exists_minimal_of_wellFoundedLT (fun b ↦ b ≤ a ∧ P b) ⟨a, le_rfl, ha⟩
+  exact ⟨b, hba, hb, fun c hc hcb ↦ hbmin ⟨hcb.trans hba, hc⟩ hcb⟩
+
+variable (P a) in
+lemma exists_maximal_ge_of_wellFoundedGT [WellFoundedGT α] (ha : P a) :
+    ∃ b, a ≤ b ∧ Maximal (P ·) b := exists_minimal_le_of_wellFoundedLT (α := αᵒᵈ) P a ha
+
 end Preorder
 
 section PartialOrder

--- a/Mathlib/Order/Minimal.lean
+++ b/Mathlib/Order/Minimal.lean
@@ -216,25 +216,37 @@ theorem not_maximal_iff_exists_gt (hx : P x) : ¬ Maximal P x ↔ ∃ y, x < y �
 
 alias ⟨exists_gt_of_not_maximal, _⟩ := not_maximal_iff_exists_gt
 
-variable (P) in
-lemma exists_minimal_of_wellFoundedLT [WellFoundedLT α] (hP : ∃ a, P a) : ∃ a, Minimal (P ·) a := by
-  simpa [not_lt_iff_le_imp_le] using wellFounded_lt.has_min _ hP
+section WellFoundedLT
+variable [WellFoundedLT α]
 
-variable (P) in
-lemma exists_maximal_of_wellFoundedGT [WellFoundedGT α] (hP : ∃ a, P a) : ∃ a, Maximal (P ·) a := by
-  simpa [not_lt_iff_le_imp_le] using wellFounded_gt.has_min _ hP
+lemma exists_minimalFor_of_wellFoundedLT (P : ι → Prop) (f : ι → α) (hP : ∃ i, P i) :
+    ∃ i, MinimalFor P f i := by
+  simpa [not_lt_iff_le_imp_le, InvImage] using (instIsWellFoundedInvImage (· < ·) f).wf.has_min _ hP
 
-variable (P a) in
-lemma exists_minimal_le_of_wellFoundedLT [WellFoundedLT α] (ha : P a) :
-    ∃ b ≤ a, Minimal (P ·) b := by
+lemma exists_minimal_of_wellFoundedLT (P : α → Prop) (hP : ∃ a, P a) : ∃ a, Minimal P a :=
+  exists_minimalFor_of_wellFoundedLT P id hP
+
+lemma exists_minimal_le_of_wellFoundedLT (P : α → Prop) (a : α) (ha : P a) :
+    ∃ b ≤ a, Minimal P b := by
   obtain ⟨b, ⟨hba, hb⟩, hbmin⟩ :=
     exists_minimal_of_wellFoundedLT (fun b ↦ b ≤ a ∧ P b) ⟨a, le_rfl, ha⟩
   exact ⟨b, hba, hb, fun c hc hcb ↦ hbmin ⟨hcb.trans hba, hc⟩ hcb⟩
 
-variable (P a) in
-lemma exists_maximal_ge_of_wellFoundedGT [WellFoundedGT α] (ha : P a) :
-    ∃ b, a ≤ b ∧ Maximal (P ·) b := exists_minimal_le_of_wellFoundedLT (α := αᵒᵈ) P a ha
+end WellFoundedLT
 
+section WellFoundedGT
+variable [WellFoundedGT α]
+
+lemma exists_maximalFor_of_wellFoundedGT (P : ι → Prop) (f : ι → α) (hP : ∃ i, P i) :
+    ∃ i, MaximalFor P f i := exists_minimalFor_of_wellFoundedLT (α := αᵒᵈ) P f hP
+
+lemma exists_maximal_of_wellFoundedGT (P : α → Prop) (hP : ∃ a, P a) : ∃ a, Maximal P a :=
+  exists_minimal_of_wellFoundedLT (α := αᵒᵈ) P hP
+
+lemma exists_maximal_ge_of_wellFoundedGT (P : α → Prop) (a : α) (ha : P a) :
+    ∃ b, a ≤ b ∧ Maximal P b := exists_minimal_le_of_wellFoundedLT (α := αᵒᵈ) P a ha
+
+end WellFoundedGT
 end Preorder
 
 section PartialOrder


### PR DESCRIPTION
From Toric


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
