### PR TITLE
[Merged by Bors] - feat: `CommGrp`-valued Yoneda embedding

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -123,6 +123,7 @@ import Mathlib.Algebra.Category.Grp.Limits
 import Mathlib.Algebra.Category.Grp.Preadditive
 import Mathlib.Algebra.Category.Grp.Subobject
 import Mathlib.Algebra.Category.Grp.Ulift
+import Mathlib.Algebra.Category.Grp.Yoneda
 import Mathlib.Algebra.Category.Grp.ZModuleEquivalence
 import Mathlib.Algebra.Category.Grp.Zero
 import Mathlib.Algebra.Category.GrpWithZero
@@ -187,6 +188,7 @@ import Mathlib.Algebra.Category.MonCat.Colimits
 import Mathlib.Algebra.Category.MonCat.FilteredColimits
 import Mathlib.Algebra.Category.MonCat.ForgetCorepresentable
 import Mathlib.Algebra.Category.MonCat.Limits
+import Mathlib.Algebra.Category.MonCat.Yoneda
 import Mathlib.Algebra.Category.Ring.Adjunctions
 import Mathlib.Algebra.Category.Ring.Basic
 import Mathlib.Algebra.Category.Ring.Colimits

--- a/Mathlib/Algebra/Category/Grp/Yoneda.lean
+++ b/Mathlib/Algebra/Category/Grp/Yoneda.lean
@@ -29,7 +29,7 @@ coyoneda embedding. -/
 "The `AddCommGrp`-valued coyoneda embedding composed with the forgetful functor is the usual
 coyoneda embedding."]
 def CommGrp.coyonedaForget :
-    coyoneda ⋙ (whiskeringRight _ _ _).obj (forget _) ≅ CategoryTheory.coyoneda :=
+    coyoneda ⋙ (Functor.whiskeringRight _ _ _).obj (forget _) ≅ CategoryTheory.coyoneda :=
   NatIso.ofComponents fun X ↦ NatIso.ofComponents fun Y ↦ { hom f := ofHom f, inv f := f.hom }
 
 /-- The Hom bifunctor sending a type `X` and a commutative group `G` to the commutative group

--- a/Mathlib/Algebra/Category/Grp/Yoneda.lean
+++ b/Mathlib/Algebra/Category/Grp/Yoneda.lean
@@ -1,0 +1,49 @@
+/-
+Copyright (c) 2025 Yaël Dillies, Andrew Yang. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yaël Dillies, Andrew Yang
+-/
+import Mathlib.Algebra.Category.Grp.Basic
+import Mathlib.Algebra.Group.Pi.Lemmas
+import Mathlib.CategoryTheory.Yoneda
+
+/-!
+# Yoneda embeddings
+
+This file defines a few Yoneda embeddings for the category of commutative groups.
+-/
+
+open CategoryTheory
+
+universe u
+
+/-- The `CommGrp`-valued coyoneda embedding. -/
+@[to_additive (attr := simps) "The `AddCommGrp`-valued coyoneda embedding."]
+def CommGrp.coyoneda : CommGrpᵒᵖ ⥤ CommGrp ⥤ CommGrp where
+  obj M := { obj N := of (M.unop →* N), map f := ofHom (.compHom f.hom) }
+  map f := { app N := ofHom (.compHom' f.unop.hom) }
+
+/-- The `CommGrp`-valued coyoneda embedding composed with the forgetful functor is the usual
+coyoneda embedding. -/
+@[to_additive (attr := simps!)
+"The `AddCommGrp`-valued coyoneda embedding composed with the forgetful functor is the usual
+coyoneda embedding."]
+def CommGrp.coyonedaForget :
+    coyoneda ⋙ (whiskeringRight _ _ _).obj (forget _) ≅ CategoryTheory.coyoneda :=
+  NatIso.ofComponents fun X ↦ NatIso.ofComponents fun Y ↦ { hom f := ofHom f, inv f := f.hom }
+
+/-- The Hom bifunctor sending a type `X` and a commutative group `G` to the commutative group
+`X → G` with pointwise operations.
+
+This is also the coyoneda embedding of `Type` into `CommGrp`-valued presheaves of commutative
+groups. -/
+@[to_additive (attr := simps)
+"The Hom bifunctor sending a type `X` and a commutative group `G` to the commutative group
+`X → G` with pointwise operations.
+
+This is also the coyoneda embedding of `Type` into `AddCommGrp`-valued presheaves of commutative
+groups."]
+def CommGrp.coyonedaType : (Type u)ᵒᵖ ⥤ CommGrp.{u} ⥤ CommGrp.{u} where
+  obj X := { obj G := of <| X.unop → G
+             map f := ofHom <| Pi.monoidHom fun i ↦ f.hom.comp <| Pi.evalMonoidHom _ i }
+  map f := { app G := ofHom <| Pi.monoidHom fun i ↦ Pi.evalMonoidHom _ <| f.unop i }

--- a/Mathlib/Algebra/Category/MonCat/Yoneda.lean
+++ b/Mathlib/Algebra/Category/MonCat/Yoneda.lean
@@ -1,0 +1,49 @@
+/-
+Copyright (c) 2025 Yaël Dillies, Andrew Yang. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yaël Dillies, Andrew Yang
+-/
+import Mathlib.Algebra.Category.MonCat.Basic
+import Mathlib.Algebra.Group.Pi.Lemmas
+import Mathlib.CategoryTheory.Yoneda
+
+/-!
+# Yoneda embeddings
+
+This file defines a few Yoneda embeddings for the category of commutative monoids.
+-/
+
+open CategoryTheory
+
+universe u
+
+/-- The `CommMonCat`-valued coyoneda embedding. -/
+@[to_additive (attr := simps) "The `AddCommMonCat`-valued coyoneda embedding."]
+def CommMonCat.coyoneda : CommMonCatᵒᵖ ⥤ CommMonCat ⥤ CommMonCat where
+  obj M := { obj N := of (M.unop →* N), map f := ofHom (.compHom f.hom) }
+  map f := { app N := ofHom (.compHom' f.unop.hom) }
+
+/-- The `CommMonCat`-valued coyoneda embedding composed with the forgetful functor is the usual
+coyoneda embedding. -/
+@[to_additive (attr := simps!)
+"The `AddCommMonCat`-valued coyoneda embedding composed with the forgetful functor is the usual
+coyoneda embedding."]
+def CommMonCat.coyonedaForget :
+    coyoneda ⋙ (whiskeringRight _ _ _).obj (forget _) ≅ CategoryTheory.coyoneda :=
+  NatIso.ofComponents fun X ↦ NatIso.ofComponents fun Y ↦ { hom f := ofHom f, inv f := f.hom }
+
+/-- The Hom bifunctor sending a type `X` and a commutative monoid `M` to the commutative monoid
+`X → M` with pointwise operations.
+
+This is also the coyoneda embedding of `Type` into `CommMonCat`-valued presheaves of commutative
+monoids. -/
+@[to_additive (attr := simps)
+"The Hom bifunctor sending a type `X` and a commutative monoid `M` to the commutative monoid
+`X → M` with pointwise operations.
+
+This is also the coyoneda embedding of `Type` into `AddCommMonCat`-valued presheaves of commutative
+monoids."]
+def CommMonCat.coyonedaType : (Type u)ᵒᵖ ⥤ CommMonCat.{u} ⥤ CommMonCat.{u} where
+  obj X := { obj M := of <| X.unop → M
+             map f := ofHom <| Pi.monoidHom fun i ↦ f.hom.comp <| Pi.evalMonoidHom _ i }
+  map f := { app N := ofHom <| Pi.monoidHom fun i ↦ Pi.evalMonoidHom _ <| f.unop i }

--- a/Mathlib/Algebra/Category/MonCat/Yoneda.lean
+++ b/Mathlib/Algebra/Category/MonCat/Yoneda.lean
@@ -29,7 +29,7 @@ coyoneda embedding. -/
 "The `AddCommMonCat`-valued coyoneda embedding composed with the forgetful functor is the usual
 coyoneda embedding."]
 def CommMonCat.coyonedaForget :
-    coyoneda ⋙ (whiskeringRight _ _ _).obj (forget _) ≅ CategoryTheory.coyoneda :=
+    coyoneda ⋙ (Functor.whiskeringRight _ _ _).obj (forget _) ≅ CategoryTheory.coyoneda :=
   NatIso.ofComponents fun X ↦ NatIso.ofComponents fun Y ↦ { hom f := ofHom f, inv f := f.hom }
 
 /-- The Hom bifunctor sending a type `X` and a commutative monoid `M` to the commutative monoid

--- a/Mathlib/CategoryTheory/Preadditive/Yoneda/Basic.lean
+++ b/Mathlib/CategoryTheory/Preadditive/Yoneda/Basic.lean
@@ -6,6 +6,7 @@ Authors: Markus Himmel
 import Mathlib.CategoryTheory.Preadditive.Opposite
 import Mathlib.Algebra.Category.ModuleCat.Basic
 import Mathlib.Algebra.Category.Grp.Preadditive
+import Mathlib.Algebra.Category.Grp.Yoneda
 
 /-!
 # The Yoneda embedding for preadditive categories
@@ -145,5 +146,10 @@ def preadditiveYonedaMap (X : C) :
   app Y := AddCommGrp.ofHom F.mapAddHom
 
 end
+
+/-- The preadditive coyoneda functor for the category `AddCommGrp` agrees with
+`AddCommGrp.coyoneda`. -/
+def _root_.AddCommGrp.preadditiveCoyonedaIso : preadditiveCoyoneda ≅ AddCommGrp.coyoneda :=
+  NatIso.ofComponents fun X ↦ NatIso.ofComponents fun Y ↦ AddCommGrp.homAddEquiv.toAddCommGrpIso
 
 end CategoryTheory


### PR DESCRIPTION
From Toric

Co-authored-by: Andrew Yang <the.erd.one@gmail.com>


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
