### PR TITLE
[Merged by Bors] - feat: more theorems about `Matrix.charpoly`

### DIFF
--- a/Mathlib/LinearAlgebra/Charpoly/Basic.lean
+++ b/Mathlib/LinearAlgebra/Charpoly/Basic.lean
@@ -45,8 +45,8 @@ def charpoly : R[X] :=
 theorem charpoly_def : f.charpoly = (toMatrix (chooseBasis R M) (chooseBasis R M) f).charpoly :=
   rfl
 
-theorem eval_charpoly (r : R) :
-    f.charpoly.eval r = (algebraMap _ _ r - f).det := by
+theorem eval_charpoly (t : R) :
+    f.charpoly.eval t = (algebraMap _ _ t - f).det := by
   rw [charpoly, Matrix.eval_charpoly, ← LinearMap.det_toMatrix (chooseBasis R M), map_sub,
     scalar_apply, toMatrix_algebraMap, scalar_apply]
 

--- a/Mathlib/LinearAlgebra/Charpoly/Basic.lean
+++ b/Mathlib/LinearAlgebra/Charpoly/Basic.lean
@@ -5,6 +5,7 @@ Authors: Riccardo Brasca
 -/
 import Mathlib.LinearAlgebra.FreeModule.Finite.Basic
 import Mathlib.LinearAlgebra.Matrix.Charpoly.Coeff
+import Mathlib.LinearAlgebra.Determinant
 import Mathlib.FieldTheory.Minpoly.Field
 
 /-!
@@ -43,6 +44,11 @@ def charpoly : R[X] :=
 
 theorem charpoly_def : f.charpoly = (toMatrix (chooseBasis R M) (chooseBasis R M) f).charpoly :=
   rfl
+
+theorem eval_charpoly (r : R) :
+    f.charpoly.eval r = (algebraMap _ _ r - f).det := by
+  rw [charpoly, Matrix.eval_charpoly, ← LinearMap.det_toMatrix (chooseBasis R M), map_sub,
+    scalar_apply, toMatrix_algebraMap, scalar_apply]
 
 @[simp]
 theorem charpoly_zero [StrongRankCondition R] :

--- a/Mathlib/LinearAlgebra/Charpoly/Basic.lean
+++ b/Mathlib/LinearAlgebra/Charpoly/Basic.lean
@@ -44,6 +44,15 @@ def charpoly : R[X] :=
 theorem charpoly_def : f.charpoly = (toMatrix (chooseBasis R M) (chooseBasis R M) f).charpoly :=
   rfl
 
+@[simp]
+theorem charpoly_zero [StrongRankCondition R] :
+    (0 : M →ₗ[R] M).charpoly = X ^ Module.finrank R M := by
+  simp [charpoly, Module.finrank_eq_card_chooseBasisIndex]
+
+theorem charpoly_one [StrongRankCondition R] :
+    (1 : M →ₗ[R] M).charpoly = (X - 1) ^ Module.finrank R M := by
+  simp [charpoly, Module.finrank_eq_card_chooseBasisIndex, Matrix.charpoly_one]
+
 end Basic
 
 section Coeff

--- a/Mathlib/LinearAlgebra/Matrix/Charpoly/Basic.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Charpoly/Basic.lean
@@ -65,8 +65,7 @@ theorem charmatrix_zero : charmatrix (0 : Matrix n n R) = Matrix.scalar n (X : R
 @[simp]
 theorem charmatrix_diagonal (d : n → R) :
     charmatrix (diagonal d) = diagonal fun i => X - C (d i) := by
-  rw [charmatrix, scalar_apply, RingHom.mapMatrix_apply, Matrix.diagonal_map (map_zero _),
-    diagonal_sub]
+  rw [charmatrix, scalar_apply, RingHom.mapMatrix_apply, diagonal_map (map_zero _), diagonal_sub]
 
 @[simp]
 theorem charmatrix_one : charmatrix (1 : Matrix n n R) = diagonal fun _ => X - 1 :=
@@ -124,10 +123,16 @@ lemma charmatrix_blockTriangular_iff {α : Type*} [Preorder α] {M : Matrix n n 
 
 alias ⟨BlockTriangular.of_charmatrix, BlockTriangular.charmatrix⟩ := charmatrix_blockTriangular_iff
 
-/-- The characteristic polynomial of a matrix `M` is given by $\det (t I - M)$.
--/
+/-- The characteristic polynomial of a matrix `M` is given by $\det (t I - M)$. -/
 def charpoly (M : Matrix n n R) : R[X] :=
   (charmatrix M).det
+
+theorem eval_charpoly (A : Matrix m m R) (r : R) :
+    A.charpoly.eval r = (Matrix.scalar _ r - A).det := by
+  rw [Matrix.charpoly, ← Polynomial.coe_evalRingHom, RingHom.map_det, Matrix.charmatrix]
+  congr
+  ext i j
+  obtain rfl | hij := eq_or_ne i j <;> simp [*]
 
 @[simp]
 theorem charpoly_zero : charpoly (0 : Matrix n n R) = X ^ Fintype.card n := by
@@ -135,7 +140,6 @@ theorem charpoly_zero : charpoly (0 : Matrix n n R) = X ^ Fintype.card n := by
 
 theorem charpoly_diagonal (d : n → R) : charpoly (diagonal d) = ∏ i, (X - C (d i)) := by
   simp [charpoly]
-
 
 theorem charpoly_one : charpoly (1 : Matrix n n R) = (X - 1) ^ Fintype.card n := by
   simp [charpoly]
@@ -147,13 +151,6 @@ theorem charpoly_natCast (k : ℕ) :
 theorem charpoly_ofNat (k : ℕ) [k.AtLeastTwo] :
     charpoly (ofNat(k) : Matrix n n R) = (X - ofNat(k)) ^ Fintype.card n:=
   charpoly_natCast _
-
-theorem eval_charpoly (A : Matrix m m R) (r : R) :
-    A.charpoly.eval r = (Matrix.scalar _ r - A).det := by
-  rw [Matrix.charpoly, ← Polynomial.coe_evalRingHom, RingHom.map_det, Matrix.charmatrix]
-  congr
-  ext i j
-  obtain rfl | hij := eq_or_ne i j <;> simp [*]
 
 @[simp]
 theorem charpoly_transpose (M : Matrix n n R) : (Mᵀ).charpoly = M.charpoly := by

--- a/Mathlib/LinearAlgebra/Matrix/Charpoly/Basic.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Charpoly/Basic.lean
@@ -130,18 +130,22 @@ def charpoly (M : Matrix n n R) : R[X] :=
   (charmatrix M).det
 
 @[simp]
-theorem charpoly_zero : charpoly (0 : Matrix n n R) = X^Fintype.card n := by
+theorem charpoly_zero : charpoly (0 : Matrix n n R) = X ^ Fintype.card n := by
   simp [charpoly]
 
 theorem charpoly_diagonal (d : n → R) : charpoly (diagonal d) = ∏ i, (X - C (d i)) := by
   simp [charpoly]
 
+
+theorem charpoly_one : charpoly (1 : Matrix n n R) = (X - 1) ^ Fintype.card n := by
+  simp [charpoly]
+
 theorem charpoly_natCast (k : ℕ) :
-    charpoly (k : Matrix n n R) = (X - (k : R[X]))^Fintype.card n := by
+    charpoly (k : Matrix n n R) = (X - (k : R[X])) ^ Fintype.card n := by
   simp [charpoly]
 
 theorem charpoly_ofNat (k : ℕ) [k.AtLeastTwo] :
-    charpoly (ofNat(k) : Matrix n n R) = (X - ofNat(k))^Fintype.card n:=
+    charpoly (ofNat(k) : Matrix n n R) = (X - ofNat(k)) ^ Fintype.card n:=
   charpoly_natCast _
 
 theorem eval_charpoly (A : Matrix m m R) (r : R) :

--- a/Mathlib/LinearAlgebra/Matrix/Charpoly/Basic.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Charpoly/Basic.lean
@@ -127,8 +127,8 @@ alias ⟨BlockTriangular.of_charmatrix, BlockTriangular.charmatrix⟩ := charmat
 def charpoly (M : Matrix n n R) : R[X] :=
   (charmatrix M).det
 
-theorem eval_charpoly (A : Matrix m m R) (r : R) :
-    A.charpoly.eval r = (Matrix.scalar _ r - A).det := by
+theorem eval_charpoly (M : Matrix m m R) (t : R) :
+    M.charpoly.eval t = (Matrix.scalar _ t - M).det := by
   rw [Matrix.charpoly, ← Polynomial.coe_evalRingHom, RingHom.map_det, Matrix.charmatrix]
   congr
   ext i j

--- a/Mathlib/LinearAlgebra/Matrix/Charpoly/Basic.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Charpoly/Basic.lean
@@ -58,6 +58,34 @@ theorem charmatrix_apply_ne (h : i ≠ j) : charmatrix M i j = -C (M i j) := by
   simp only [charmatrix, RingHom.mapMatrix_apply, sub_apply, scalar_apply, diagonal_apply_ne _ h,
     map_apply, sub_eq_neg_self]
 
+@[simp]
+theorem charmatrix_zero : charmatrix (0 : Matrix n n R) = Matrix.scalar n (X : R[X]) := by
+  simp [charmatrix]
+
+@[simp]
+theorem charmatrix_diagonal (d : n → R) :
+    charmatrix (diagonal d) = diagonal fun i => X - C (d i) := by
+  rw [charmatrix, scalar_apply, RingHom.mapMatrix_apply, Matrix.diagonal_map (map_zero _),
+    diagonal_sub]
+
+@[simp]
+theorem charmatrix_one : charmatrix (1 : Matrix n n R) = diagonal fun _ => X - 1 :=
+  charmatrix_diagonal _
+
+@[simp]
+theorem charmatrix_natCast (k : ℕ) :
+    charmatrix (k : Matrix n n R) = diagonal fun _ => X - (k : R[X]) :=
+  charmatrix_diagonal _
+
+@[simp]
+theorem charmatrix_ofNat (k : ℕ) [k.AtLeastTwo] :
+    charmatrix (ofNat(k) : Matrix n n R) = diagonal fun _ => X - ofNat(k) :=
+  charmatrix_natCast _
+
+@[simp]
+theorem charmatrix_transpose (M : Matrix n n R) : (Mᵀ).charmatrix = M.charmatrixᵀ := by
+  simp [charmatrix, transpose_map]
+
 theorem matPolyEquiv_charmatrix : matPolyEquiv (charmatrix M) = X - C M := by
   ext k i j
   simp only [matPolyEquiv_coeff_apply, coeff_sub, Pi.sub_apply]
@@ -100,6 +128,32 @@ alias ⟨BlockTriangular.of_charmatrix, BlockTriangular.charmatrix⟩ := charmat
 -/
 def charpoly (M : Matrix n n R) : R[X] :=
   (charmatrix M).det
+
+@[simp]
+theorem charpoly_zero : charpoly (0 : Matrix n n R) = X^Fintype.card n := by
+  simp [charpoly]
+
+theorem charpoly_diagonal (d : n → R) : charpoly (diagonal d) = ∏ i, (X - C (d i)) := by
+  simp [charpoly]
+
+theorem charpoly_natCast (k : ℕ) :
+    charpoly (k : Matrix n n R) = (X - (k : R[X]))^Fintype.card n := by
+  simp [charpoly]
+
+theorem charpoly_ofNat (k : ℕ) [k.AtLeastTwo] :
+    charpoly (ofNat(k) : Matrix n n R) = (X - ofNat(k))^Fintype.card n:=
+  charpoly_natCast _
+
+theorem eval_charpoly (A : Matrix m m R) (r : R) :
+    A.charpoly.eval r = (Matrix.scalar _ r - A).det := by
+  rw [Matrix.charpoly, ← Polynomial.coe_evalRingHom, RingHom.map_det, Matrix.charmatrix]
+  congr
+  ext i j
+  obtain rfl | hij := eq_or_ne i j <;> simp [*]
+
+@[simp]
+theorem charpoly_transpose (M : Matrix n n R) : (Mᵀ).charpoly = M.charpoly := by
+  simp [charpoly]
 
 theorem charpoly_reindex (e : n ≃ m)
     (M : Matrix n n R) : (reindex e e M).charpoly = M.charpoly := by


### PR DESCRIPTION
The `eval` lemma was needed in the matrix cookbook.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
