### PR TITLE
[Merged by Bors] - chore: deduplicate equivalence `M ≃ (ℕ →+ M)` for `M` an additive monoid

### DIFF
--- a/Mathlib/Algebra/Category/Grp/ForgetCorepresentable.lean
+++ b/Mathlib/Algebra/Category/Grp/ForgetCorepresentable.lean
@@ -19,6 +19,22 @@ universe u
 
 open CategoryTheory Opposite
 
+/-!
+### `(ULift ℤ →+ G) ≃ G`
+
+These universe-monomorphic variants of `zmultiplesHom`/`zpowersHom` are put here since they
+shouldn't be useful outside of category theory.
+-/
+
+/-- The equivalence `(ULift ℤ →+ G) ≃ G` for any additive group `G`. -/
+def uliftZMultiplesHom (G : Type u) [AddGroup G] : G ≃ (ULift.{u} ℤ →+ G) :=
+  (zmultiplesHom _).trans <| AddMonoidHom.precompEquiv .ulift _
+
+/-- The equivalence `(ULift (Multiplicative ℤ) →* G) ≃ G` for any group `G`. -/
+@[to_additive existing (attr := simps!)]
+def uliftZPowersHom (G : Type u) [Group G] : G ≃ (ULift.{u} (Multiplicative ℤ) →* G) :=
+  (zpowersHom _).trans <| MonoidHom.precompEquiv .ulift _
+
 namespace MonoidHom
 
 /-- The equivalence `(Multiplicative ℤ →* α) ≃ α` for any group `α`. -/

--- a/Mathlib/Algebra/Category/Grp/ForgetCorepresentable.lean
+++ b/Mathlib/Algebra/Category/Grp/ForgetCorepresentable.lean
@@ -22,61 +22,54 @@ open CategoryTheory Opposite
 namespace MonoidHom
 
 /-- The equivalence `(Multiplicative ℤ →* α) ≃ α` for any group `α`. -/
-@[simps]
-def fromMultiplicativeIntEquiv (α : Type u) [Group α] : (Multiplicative ℤ →* α) ≃ α where
-  toFun φ := φ (Multiplicative.ofAdd 1)
-  invFun x := zpowersHom α x
-  left_inv φ := by ext; simp
-  right_inv x := by simp
+@[deprecated zpowersHom (since := "2025-05-11")]
+def fromMultiplicativeIntEquiv (α : Type u) [Group α] : (Multiplicative ℤ →* α) ≃ α :=
+  (zpowersHom _).symm
 
 /-- The equivalence `(ULift (Multiplicative ℤ) →* α) ≃ α` for any group `α`. -/
-@[simps!]
+@[deprecated uliftZPowersHom (since := "2025-05-11")]
 def fromULiftMultiplicativeIntEquiv (α : Type u) [Group α] :
     (ULift.{u} (Multiplicative ℤ) →* α) ≃ α :=
-  (precompEquiv (MulEquiv.ulift.symm) _).trans (fromMultiplicativeIntEquiv α)
+  (uliftZPowersHom _).symm
 
 end MonoidHom
 
 namespace AddMonoidHom
 
 /-- The equivalence `(ℤ →+ α) ≃ α` for any additive group `α`. -/
-@[simps]
-def fromIntEquiv (α : Type u) [AddGroup α] : (ℤ →+ α) ≃ α where
-  toFun φ := φ 1
-  invFun x := zmultiplesHom α x
-  left_inv φ := by ext; simp
-  right_inv x := by simp
+@[deprecated zmultiplesHom (since := "2025-05-11")]
+def fromIntEquiv (α : Type u) [AddGroup α] : (ℤ →+ α) ≃ α := (zmultiplesHom _).symm
 
 /-- The equivalence `(ULift ℤ →+ α) ≃ α` for any additive group `α`. -/
-@[simps!]
+@[deprecated uliftZMultiplesHom (since := "2025-05-11")]
 def fromULiftIntEquiv (α : Type u) [AddGroup α] : (ULift.{u} ℤ →+ α) ≃ α :=
-  (precompEquiv (AddEquiv.ulift.symm) _).trans (fromIntEquiv α)
+  (uliftZMultiplesHom _).symm
 
 end AddMonoidHom
 
 /-- The forget functor `Grp.{u} ⥤ Type u` is corepresentable. -/
 def Grp.coyonedaObjIsoForget :
     coyoneda.obj (op (of (ULift.{u} (Multiplicative ℤ)))) ≅ forget Grp.{u} :=
-  (NatIso.ofComponents (fun M => (ConcreteCategory.homEquiv.trans
-    (MonoidHom.fromULiftMultiplicativeIntEquiv M.carrier)).toIso))
+  NatIso.ofComponents fun M ↦
+    (ConcreteCategory.homEquiv.trans (uliftZPowersHom M.carrier).symm).toIso
 
 /-- The forget functor `CommGrp.{u} ⥤ Type u` is corepresentable. -/
 def CommGrp.coyonedaObjIsoForget :
     coyoneda.obj (op (of (ULift.{u} (Multiplicative ℤ)))) ≅ forget CommGrp.{u} :=
-  (NatIso.ofComponents (fun M => (ConcreteCategory.homEquiv.trans
-    (MonoidHom.fromULiftMultiplicativeIntEquiv M.carrier)).toIso))
+  NatIso.ofComponents fun M ↦
+    (ConcreteCategory.homEquiv.trans (uliftZPowersHom M.carrier).symm).toIso
 
 /-- The forget functor `AddGrp.{u} ⥤ Type u` is corepresentable. -/
 def AddGrp.coyonedaObjIsoForget :
     coyoneda.obj (op (of (ULift.{u} ℤ))) ≅ forget AddGrp.{u} :=
-  (NatIso.ofComponents (fun M => (ConcreteCategory.homEquiv.trans
-    (AddMonoidHom.fromULiftIntEquiv M.carrier)).toIso))
+  NatIso.ofComponents fun M ↦
+    (ConcreteCategory.homEquiv.trans (uliftZMultiplesHom M.carrier).symm).toIso
 
 /-- The forget functor `AddCommGrp.{u} ⥤ Type u` is corepresentable. -/
 def AddCommGrp.coyonedaObjIsoForget :
     coyoneda.obj (op (of (ULift.{u} ℤ))) ≅ forget AddCommGrp.{u} :=
-  (NatIso.ofComponents (fun M => (ConcreteCategory.homEquiv.trans
-    (AddMonoidHom.fromULiftIntEquiv M.carrier)).toIso))
+  NatIso.ofComponents fun M ↦
+    (ConcreteCategory.homEquiv.trans (uliftZMultiplesHom M.carrier).symm).toIso
 
 instance Grp.forget_isCorepresentable :
     (forget Grp.{u}).IsCorepresentable :=

--- a/Mathlib/Algebra/Category/MonCat/ForgetCorepresentable.lean
+++ b/Mathlib/Algebra/Category/MonCat/ForgetCorepresentable.lean
@@ -23,6 +23,23 @@ universe u
 
 open CategoryTheory Opposite
 
+/-!
+### `(ULift ℕ →+ G) ≃ G`
+
+These universe-monomorphic variants of `multiplesHom`/`powersHom` are put here since they
+shouldn't be useful outside of category theory.
+-/
+
+/-- Monoid homomorphisms from `ULift ℕ` are defined by the image of `1`. -/
+def uliftMultiplesHom (M : Type u) [AddMonoid M] : M ≃ (ULift.{u} ℕ →+ M) :=
+  (multiplesHom _).trans <| AddMonoidHom.precompEquiv .ulift _
+
+/-- Monoid homomorphisms from `ULift (Multiplicative ℕ)` are defined by the image
+of `Multiplicative.ofAdd 1`. -/
+@[to_additive existing (attr := simps!)]
+def uliftPowersHom (M : Type u) [Monoid M] : M ≃ (ULift.{u} (Multiplicative ℕ) →* M) :=
+  (powersHom _).trans <| MonoidHom.precompEquiv .ulift _
+
 namespace MonoidHom
 
 /-- The equivalence `(Multiplicative ℕ →* α) ≃ α` for any monoid `α`. -/

--- a/Mathlib/Algebra/Category/MonCat/ForgetCorepresentable.lean
+++ b/Mathlib/Algebra/Category/MonCat/ForgetCorepresentable.lean
@@ -26,62 +26,55 @@ open CategoryTheory Opposite
 namespace MonoidHom
 
 /-- The equivalence `(Multiplicative ℕ →* α) ≃ α` for any monoid `α`. -/
-@[simps]
-def fromMultiplicativeNatEquiv (α : Type u) [Monoid α] : (Multiplicative ℕ →* α) ≃ α where
-  toFun φ := φ (Multiplicative.ofAdd 1)
-  invFun x := powersHom α x
-  left_inv φ := by ext; simp
-  right_inv x := by simp
+@[deprecated powersHom (since := "2025-05-11")]
+def fromMultiplicativeNatEquiv (α : Type u) [Monoid α] : (Multiplicative ℕ →* α) ≃ α :=
+  (powersHom _).symm
 
 /-- The equivalence `(ULift (Multiplicative ℕ) →* α) ≃ α` for any monoid `α`. -/
-@[simps!]
+@[deprecated uliftPowersHom (since := "2025-05-11")]
 def fromULiftMultiplicativeNatEquiv (α : Type u) [Monoid α] :
     (ULift.{u} (Multiplicative ℕ) →* α) ≃ α :=
-  (precompEquiv (MulEquiv.ulift.symm) _).trans (fromMultiplicativeNatEquiv α)
+  (uliftPowersHom _).symm
 
 end MonoidHom
 
 namespace AddMonoidHom
 
 /-- The equivalence `(ℤ →+ α) ≃ α` for any additive group `α`. -/
-@[simps]
-def fromNatEquiv (α : Type u) [AddMonoid α] : (ℕ →+ α) ≃ α where
-  toFun φ := φ 1
-  invFun x := multiplesHom α x
-  left_inv φ := by ext; simp
-  right_inv x := by simp
+@[deprecated multiplesHom (since := "2025-05-11")]
+def fromNatEquiv (α : Type u) [AddMonoid α] : (ℕ →+ α) ≃ α := (multiplesHom _).symm
 
 /-- The equivalence `(ULift ℕ →+ α) ≃ α` for any additive monoid `α`. -/
-@[simps!]
+@[deprecated uliftMultiplesHom (since := "2025-05-11")]
 def fromULiftNatEquiv (α : Type u) [AddMonoid α] : (ULift.{u} ℕ →+ α) ≃ α :=
-  (precompEquiv (AddEquiv.ulift.symm) _).trans (fromNatEquiv α)
+  (uliftMultiplesHom _).symm
 
 end AddMonoidHom
 
 /-- The forgetful functor `MonCat.{u} ⥤ Type u` is corepresentable. -/
 def MonCat.coyonedaObjIsoForget :
     coyoneda.obj (op (of (ULift.{u} (Multiplicative ℕ)))) ≅ forget MonCat.{u} :=
-  (NatIso.ofComponents (fun M => (ConcreteCategory.homEquiv.trans
-    (MonoidHom.fromULiftMultiplicativeNatEquiv M.carrier)).toIso))
+  NatIso.ofComponents fun M ↦
+    (ConcreteCategory.homEquiv.trans (uliftPowersHom M.carrier).symm).toIso
 
 
 /-- The forgetful functor `CommMonCat.{u} ⥤ Type u` is corepresentable. -/
 def CommMonCat.coyonedaObjIsoForget :
     coyoneda.obj (op (of (ULift.{u} (Multiplicative ℕ)))) ≅ forget CommMonCat.{u} :=
-  (NatIso.ofComponents (fun M => (ConcreteCategory.homEquiv.trans
-    (MonoidHom.fromULiftMultiplicativeNatEquiv M.carrier)).toIso))
+  NatIso.ofComponents fun M ↦
+    (ConcreteCategory.homEquiv.trans (uliftPowersHom M.carrier).symm).toIso
 
 /-- The forgetful functor `AddMonCat.{u} ⥤ Type u` is corepresentable. -/
 def AddMonCat.coyonedaObjIsoForget :
     coyoneda.obj (op (of (ULift.{u} ℕ))) ≅ forget AddMonCat.{u} :=
-  (NatIso.ofComponents (fun M => (ConcreteCategory.homEquiv.trans
-    (AddMonoidHom.fromULiftNatEquiv M.carrier)).toIso))
+  NatIso.ofComponents fun M ↦
+    (ConcreteCategory.homEquiv.trans (uliftMultiplesHom M.carrier).symm).toIso
 
 /-- The forgetful functor `AddCommMonCat.{u} ⥤ Type u` is corepresentable. -/
 def AddCommMonCat.coyonedaObjIsoForget :
     coyoneda.obj (op (of (ULift.{u} ℕ))) ≅ forget AddCommMonCat.{u} :=
-  (NatIso.ofComponents (fun M => (ConcreteCategory.homEquiv.trans
-    (AddMonoidHom.fromULiftNatEquiv M.carrier)).toIso))
+  NatIso.ofComponents fun M ↦
+    (ConcreteCategory.homEquiv.trans (uliftMultiplesHom M.carrier).symm).toIso
 
 instance MonCat.forget_isCorepresentable :
     (forget MonCat.{u}).IsCorepresentable :=

--- a/Mathlib/Algebra/Group/Nat/Hom.lean
+++ b/Mathlib/Algebra/Group/Nat/Hom.lean
@@ -3,10 +3,11 @@ Copyright (c) 2020 Yury Kudryashov. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury Kudryashov
 -/
-import Mathlib.Algebra.Group.Equiv.Defs
+import Mathlib.Algebra.Group.Equiv.Basic
 import Mathlib.Algebra.Group.Hom.Basic
 import Mathlib.Algebra.Group.Nat.Defs
 import Mathlib.Algebra.Group.TypeTags.Hom
+import Mathlib.Algebra.Group.ULift
 
 /-!
 # Extensionality of monoid homs from `ℕ`
@@ -16,7 +17,8 @@ assert_not_exists OrderedCommMonoid MonoidWithZero
 
 open Additive Multiplicative
 
-variable {M M : Type*}
+universe u
+variable {M : Type*}
 
 section AddMonoidHomClass
 
@@ -50,6 +52,10 @@ def multiplesHom : M ≃ (ℕ →+ M) where
   left_inv := one_nsmul
   right_inv f := AddMonoidHom.ext_nat <| one_nsmul (f 1)
 
+/-- Monoid homomorphisms from `ULift ℕ` are defined by the image of `1`. -/
+def uliftMultiplesHom (M : Type u) [AddMonoid M] : M ≃ (ULift.{u} ℕ →+ M) :=
+  (multiplesHom _).trans <| AddMonoidHom.precompEquiv .ulift _
+
 @[simp] lemma multiplesHom_apply (x : M) (n : ℕ) : multiplesHom M x n = n • x := rfl
 
 lemma multiplesHom_symm_apply (f : ℕ →+ M) : (multiplesHom M).symm f = f 1 := rfl
@@ -68,6 +74,12 @@ of `Multiplicative.ofAdd 1`. -/
 @[to_additive existing]
 def powersHom : M ≃ (Multiplicative ℕ →* M) :=
   Additive.ofMul.trans <| (multiplesHom _).trans <| AddMonoidHom.toMultiplicative''
+
+/-- Monoid homomorphisms from `ULift (Multiplicative ℕ)` are defined by the image
+of `Multiplicative.ofAdd 1`. -/
+@[to_additive existing (attr := simps!)]
+def uliftPowersHom (M : Type u) [Monoid M] : M ≃ (ULift.{u} (Multiplicative ℕ) →* M) :=
+  (powersHom _).trans <| MonoidHom.precompEquiv .ulift _
 
 @[to_additive existing (attr := simp)]
 lemma powersHom_apply (x : M) (n : Multiplicative ℕ) :

--- a/Mathlib/Algebra/Group/Nat/Hom.lean
+++ b/Mathlib/Algebra/Group/Nat/Hom.lean
@@ -3,11 +3,10 @@ Copyright (c) 2020 Yury Kudryashov. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury Kudryashov
 -/
-import Mathlib.Algebra.Group.Equiv.Basic
+import Mathlib.Algebra.Group.Equiv.Defs
 import Mathlib.Algebra.Group.Hom.Basic
 import Mathlib.Algebra.Group.Nat.Defs
 import Mathlib.Algebra.Group.TypeTags.Hom
-import Mathlib.Algebra.Group.ULift
 
 /-!
 # Extensionality of monoid homs from `ℕ`
@@ -17,7 +16,6 @@ assert_not_exists OrderedCommMonoid MonoidWithZero
 
 open Additive Multiplicative
 
-universe u
 variable {M : Type*}
 
 section AddMonoidHomClass
@@ -52,10 +50,6 @@ def multiplesHom : M ≃ (ℕ →+ M) where
   left_inv := one_nsmul
   right_inv f := AddMonoidHom.ext_nat <| one_nsmul (f 1)
 
-/-- Monoid homomorphisms from `ULift ℕ` are defined by the image of `1`. -/
-def uliftMultiplesHom (M : Type u) [AddMonoid M] : M ≃ (ULift.{u} ℕ →+ M) :=
-  (multiplesHom _).trans <| AddMonoidHom.precompEquiv .ulift _
-
 @[simp] lemma multiplesHom_apply (x : M) (n : ℕ) : multiplesHom M x n = n • x := rfl
 
 lemma multiplesHom_symm_apply (f : ℕ →+ M) : (multiplesHom M).symm f = f 1 := rfl
@@ -74,12 +68,6 @@ of `Multiplicative.ofAdd 1`. -/
 @[to_additive existing]
 def powersHom : M ≃ (Multiplicative ℕ →* M) :=
   Additive.ofMul.trans <| (multiplesHom _).trans <| AddMonoidHom.toMultiplicative''
-
-/-- Monoid homomorphisms from `ULift (Multiplicative ℕ)` are defined by the image
-of `Multiplicative.ofAdd 1`. -/
-@[to_additive existing (attr := simps!)]
-def uliftPowersHom (M : Type u) [Monoid M] : M ≃ (ULift.{u} (Multiplicative ℕ) →* M) :=
-  (powersHom _).trans <| MonoidHom.precompEquiv .ulift _
 
 @[to_additive existing (attr := simp)]
 lemma powersHom_apply (x : M) (n : Multiplicative ℕ) :

--- a/Mathlib/Data/Int/Cast/Lemmas.lean
+++ b/Mathlib/Data/Int/Cast/Lemmas.lean
@@ -26,7 +26,6 @@ assert_not_exists RelIso OrderedCommMonoid Field
 
 open Additive Function Multiplicative Nat
 
-universe u
 variable {F ι α β : Type*}
 
 namespace Int
@@ -276,15 +275,6 @@ of `Multiplicative.ofAdd 1`. -/
 @[to_additive existing]
 def zpowersHom : α ≃ (Multiplicative ℤ →* α) :=
   ofMul.trans <| (zmultiplesHom _).trans <| AddMonoidHom.toMultiplicative''
-
-/-- The equivalence `(ULift ℤ →+ G) ≃ G` for any additive group `G`. -/
-def uliftZMultiplesHom (G : Type u) [AddGroup G] : G ≃ (ULift.{u} ℤ →+ G) :=
-  (zmultiplesHom _).trans <| AddMonoidHom.precompEquiv .ulift _
-
-/-- The equivalence `(ULift (Multiplicative ℤ) →* G) ≃ G` for any group `G`. -/
-@[to_additive existing (attr := simps!)]
-def uliftZPowersHom (G : Type u) [Group G] : G ≃ (ULift.{u} (Multiplicative ℤ) →* G) :=
-  (zpowersHom _).trans <| MonoidHom.precompEquiv .ulift _
 
 lemma zmultiplesHom_apply (x : β) (n : ℤ) : zmultiplesHom β x n = n • x := rfl
 

--- a/Mathlib/Data/Int/Cast/Lemmas.lean
+++ b/Mathlib/Data/Int/Cast/Lemmas.lean
@@ -26,6 +26,7 @@ assert_not_exists RelIso OrderedCommMonoid Field
 
 open Additive Function Multiplicative Nat
 
+universe u
 variable {F ι α β : Type*}
 
 namespace Int
@@ -275,6 +276,15 @@ of `Multiplicative.ofAdd 1`. -/
 @[to_additive existing]
 def zpowersHom : α ≃ (Multiplicative ℤ →* α) :=
   ofMul.trans <| (zmultiplesHom _).trans <| AddMonoidHom.toMultiplicative''
+
+/-- The equivalence `(ULift ℤ →+ G) ≃ G` for any additive group `G`. -/
+def uliftZMultiplesHom (G : Type u) [AddGroup G] : G ≃ (ULift.{u} ℤ →+ G) :=
+  (zmultiplesHom _).trans <| AddMonoidHom.precompEquiv .ulift _
+
+/-- The equivalence `(ULift (Multiplicative ℤ) →* G) ≃ G` for any group `G`. -/
+@[to_additive existing (attr := simps!)]
+def uliftZPowersHom (G : Type u) [Group G] : G ≃ (ULift.{u} (Multiplicative ℤ) →* G) :=
+  (zpowersHom _).trans <| MonoidHom.precompEquiv .ulift _
 
 lemma zmultiplesHom_apply (x : β) (n : ℤ) : zmultiplesHom β x n = n • x := rfl
 


### PR DESCRIPTION
The second versions were introduced in #11669, with no discussion.

Moves:
* `AddMonoidHom.fromNatEquiv` → `multiplesHom`
* `AddMonoidHom.fromULiftNatEquiv` → `uliftMultiplesHom`
* `AddMonoidHom.fromIntEquiv` → `zmultiplesHom`
* `AddMonoidHom.fromULiftIntEquiv` → `uliftZMultiplesHom`
* `MonoidHom.fromMultiplicativeNatEquiv` → `powersHom`
* `MonoidHom.fromULiftMultiplicativeNatEquiv` → `uliftPowersHom`
* `MonoidHom.fromMultiplicativeIntEquiv` → `zpowersHom`
* `MonoidHom.fromULiftMultiplicativeIntEquiv` → `uliftZPowersHom`


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
