### PR TITLE
chore: move Algebra.Group.Hom.End to Algebra.Ring

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -360,7 +360,6 @@ import Mathlib.Algebra.Group.Graph
 import Mathlib.Algebra.Group.Hom.Basic
 import Mathlib.Algebra.Group.Hom.CompTypeclasses
 import Mathlib.Algebra.Group.Hom.Defs
-import Mathlib.Algebra.Group.Hom.End
 import Mathlib.Algebra.Group.Hom.Instances
 import Mathlib.Algebra.Group.Idempotent
 import Mathlib.Algebra.Group.Indicator
@@ -1104,6 +1103,7 @@ import Mathlib.Algebra.Ring.GeomSum
 import Mathlib.Algebra.Ring.GrindInstances
 import Mathlib.Algebra.Ring.Hom.Basic
 import Mathlib.Algebra.Ring.Hom.Defs
+import Mathlib.Algebra.Ring.Hom.End
 import Mathlib.Algebra.Ring.Hom.InjSurj
 import Mathlib.Algebra.Ring.Idempotent
 import Mathlib.Algebra.Ring.Identities

--- a/Mathlib/Algebra/Group/Hom/Instances.lean
+++ b/Mathlib/Algebra/Group/Hom/Instances.lean
@@ -18,8 +18,6 @@ is a commutative group. We also prove the same instances for additive situations
 
 Since these structures permit morphisms of morphisms, we also provide some composition-like
 operations.
-
-Finally, we provide the `Ring` structure on `AddMonoid.End`.
 -/
 
 assert_not_exists AddMonoidWithOne Ring

--- a/Mathlib/Algebra/Module/End.lean
+++ b/Mathlib/Algebra/Module/End.lean
@@ -3,8 +3,8 @@ Copyright (c) 2015 Nathaniel Thomas. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Nathaniel Thomas, Jeremy Avigad, Johannes Hölzl, Mario Carneiro
 -/
-import Mathlib.Algebra.Group.Hom.End
 import Mathlib.Algebra.Module.NatInt
+import Mathlib.Algebra.Ring.Hom.End
 
 /-!
 # Module structure and endomorphisms

--- a/Mathlib/Algebra/MonoidAlgebra/Division.lean
+++ b/Mathlib/Algebra/MonoidAlgebra/Division.lean
@@ -3,8 +3,8 @@ Copyright (c) 2022 Eric Wieser. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Eric Wieser
 -/
-import Mathlib.Algebra.Group.Hom.End
 import Mathlib.Algebra.MonoidAlgebra.Defs
+import Mathlib.Algebra.Ring.Hom.End
 
 /-!
 # Division of `AddMonoidAlgebra` by monomials

--- a/Mathlib/Algebra/Ring/Hom/End.lean
+++ b/Mathlib/Algebra/Ring/Hom/End.lean
@@ -10,11 +10,7 @@ import Mathlib.Algebra.Ring.Defs
 /-!
 # Instances on spaces of monoid and group morphisms
 
-This file does two things involving `AddMonoid.End` and `Ring`.
-They are separate, and if someone would like to split this file in two that may be helpful.
-
-* We provide the `Ring` structure on `AddMonoid.End`.
-* Results about `AddMonoid.End R` when `R` is a ring.
+This file provides the `Ring` structure on `AddMonoid.End`.
 -/
 
 


### PR DESCRIPTION
This moves us towards the goal of not depending on `Ring` under `Algebra.Group`; this is mentioned in https://github.com/leanprover-community/mathlib4/issues/11757 and on [Zulip](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Call.20for.20help.3A.20technical.2F.20organisational.20debt/near/512348574).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
