### PR TITLE
feat: trace of unitarily similar matrices

### DIFF
--- a/Mathlib/LinearAlgebra/UnitaryGroup.lean
+++ b/Mathlib/LinearAlgebra/UnitaryGroup.lean
@@ -74,6 +74,13 @@ theorem det_of_mem_unitary {A : Matrix n n α} (hA : A ∈ Matrix.unitaryGroup n
   · simpa [star, det_transpose] using congr_arg det hA.1
   · simpa [star, det_transpose] using congr_arg det hA.2
 
+theorem tr_of_unitary_similar {A B U : Matrix n n α} {hU : U ∈ Matrix.unitaryGroup n α}
+    (hABU : U * B * star U = A) :
+    (star A * A).trace = (star B * B).trace := by
+  rw [← hABU, Matrix.star_mul, Matrix.star_mul, star_star,
+    ← Matrix.trace_mul_cycle, mul_assoc, mul_assoc (U * B), unitary.star_mul_self_of_mem hU,
+    mul_one, mul_assoc, ← mul_assoc (star U), unitary.star_mul_self_of_mem hU, one_mul]
+
 namespace UnitaryGroup
 
 instance coeMatrix : Coe (unitaryGroup n α) (Matrix n n α) :=


### PR DESCRIPTION
adds a theorem relating trace to unitarily similar matrices used in the easy direction of specht's theorem

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
