### PR TITLE
[Merged by Bors] - feat(MeasureTheory/Group): add quasiMeasurePreserving group operation theorems

### DIFF
--- a/Mathlib/MeasureTheory/Group/Prod.lean
+++ b/Mathlib/MeasureTheory/Group/Prod.lean
@@ -396,7 +396,33 @@ end RightInvariant
 
 section QuasiMeasurePreserving
 
+/-- The map `(x, y) ↦ x * y` is quasi-measure-preserving. -/
+@[to_additive (attr := fun_prop) "The map `(x, y) ↦ x + y` is quasi-measure-preserving."]
+theorem quasiMeasurePreserving_mul [IsMulLeftInvariant ν] :
+    QuasiMeasurePreserving (fun p => p.1 * p.2) (μ.prod ν) ν :=
+  quasiMeasurePreserving_snd.comp (measurePreserving_prod_mul _ _).quasiMeasurePreserving
+
+/-- The map `(x, y) ↦ y * x` is quasi-measure-preserving. -/
+@[to_additive (attr := fun_prop) "The map `(x, y) ↦ y + x` is quasi-measure-preserving."]
+theorem quasiMeasurePreserving_mul_swap [IsMulLeftInvariant μ] :
+    QuasiMeasurePreserving (fun p => p.2 * p.1) (μ.prod ν) μ :=
+  quasiMeasurePreserving_snd.comp (measurePreserving_prod_mul_swap _ _).quasiMeasurePreserving
+
+section MeasurableInv
+
 variable [MeasurableInv G]
+
+/-- The map `(x, y) ↦ x⁻¹ * y` is quasi-measure-preserving. -/
+@[to_additive (attr := fun_prop) "The map `(x, y) ↦ -x + y` is quasi-measure-preserving."]
+theorem quasiMeasurePreserving_inv_mul [IsMulLeftInvariant ν] :
+    QuasiMeasurePreserving (fun p => p.1⁻¹ * p.2) (μ.prod ν) ν :=
+  quasiMeasurePreserving_snd.comp (measurePreserving_prod_inv_mul _ _).quasiMeasurePreserving
+
+/-- The map `(x, y) ↦ y⁻¹ * x` is quasi-measure-preserving. -/
+@[to_additive (attr := fun_prop) "The map `(x, y) ↦ -y + x` is quasi-measure-preserving."]
+theorem quasiMeasurePreserving_inv_mul_swap [IsMulLeftInvariant μ] :
+    QuasiMeasurePreserving (fun p => p.2⁻¹ * p.1) (μ.prod ν) μ :=
+  quasiMeasurePreserving_snd.comp (measurePreserving_prod_inv_mul_swap _ _).quasiMeasurePreserving
 
 @[to_additive]
 theorem quasiMeasurePreserving_inv_of_right_invariant [IsMulRightInvariant μ] :
@@ -435,7 +461,7 @@ theorem quasiMeasurePreserving_div [IsMulLeftInvariant μ] :
 
 /-- A *left*-invariant measure is quasi-preserved by *right*-multiplication.
 This should not be confused with `(measurePreserving_mul_right μ g).quasiMeasurePreserving`. -/
-@[to_additive
+@[to_additive (attr := fun_prop)
 "A *left*-invariant measure is quasi-preserved by *right*-addition.
 This should not be confused with `(measurePreserving_add_right μ g).quasiMeasurePreserving`. "]
 theorem quasiMeasurePreserving_mul_right [IsMulLeftInvariant μ] (g : G) :
@@ -445,7 +471,7 @@ theorem quasiMeasurePreserving_mul_right [IsMulLeftInvariant μ] (g : G) :
 
 /-- A *right*-invariant measure is quasi-preserved by *left*-multiplication.
 This should not be confused with `(measurePreserving_mul_left μ g).quasiMeasurePreserving`. -/
-@[to_additive
+@[to_additive (attr := fun_prop)
 "A *right*-invariant measure is quasi-preserved by *left*-addition.
 This should not be confused with `(measurePreserving_add_left μ g).quasiMeasurePreserving`. "]
 theorem quasiMeasurePreserving_mul_left [IsMulRightInvariant μ] (g : G) :
@@ -459,6 +485,8 @@ theorem quasiMeasurePreserving_mul_left [IsMulRightInvariant μ] (g : G) :
       (this.comp (quasiMeasurePreserving_inv_of_right_invariant μ))
   simp_rw [Function.comp_def, mul_inv_rev, inv_inv] at this
   exact this
+
+end MeasurableInv
 
 end QuasiMeasurePreserving
 

--- a/Mathlib/MeasureTheory/Group/Prod.lean
+++ b/Mathlib/MeasureTheory/Group/Prod.lean
@@ -399,13 +399,13 @@ section QuasiMeasurePreserving
 /-- The map `(x, y) ↦ x * y` is quasi-measure-preserving. -/
 @[to_additive (attr := fun_prop) "The map `(x, y) ↦ x + y` is quasi-measure-preserving."]
 theorem quasiMeasurePreserving_mul [IsMulLeftInvariant ν] :
-    QuasiMeasurePreserving (fun p => p.1 * p.2) (μ.prod ν) ν :=
+    QuasiMeasurePreserving (fun p ↦ p.1 * p.2) (μ.prod ν) ν :=
   quasiMeasurePreserving_snd.comp (measurePreserving_prod_mul _ _).quasiMeasurePreserving
 
 /-- The map `(x, y) ↦ y * x` is quasi-measure-preserving. -/
 @[to_additive (attr := fun_prop) "The map `(x, y) ↦ y + x` is quasi-measure-preserving."]
 theorem quasiMeasurePreserving_mul_swap [IsMulLeftInvariant μ] :
-    QuasiMeasurePreserving (fun p => p.2 * p.1) (μ.prod ν) μ :=
+    QuasiMeasurePreserving (fun p ↦ p.2 * p.1) (μ.prod ν) μ :=
   quasiMeasurePreserving_snd.comp (measurePreserving_prod_mul_swap _ _).quasiMeasurePreserving
 
 section MeasurableInv
@@ -415,13 +415,13 @@ variable [MeasurableInv G]
 /-- The map `(x, y) ↦ x⁻¹ * y` is quasi-measure-preserving. -/
 @[to_additive (attr := fun_prop) "The map `(x, y) ↦ -x + y` is quasi-measure-preserving."]
 theorem quasiMeasurePreserving_inv_mul [IsMulLeftInvariant ν] :
-    QuasiMeasurePreserving (fun p => p.1⁻¹ * p.2) (μ.prod ν) ν :=
+    QuasiMeasurePreserving (fun p ↦ p.1⁻¹ * p.2) (μ.prod ν) ν :=
   quasiMeasurePreserving_snd.comp (measurePreserving_prod_inv_mul _ _).quasiMeasurePreserving
 
 /-- The map `(x, y) ↦ y⁻¹ * x` is quasi-measure-preserving. -/
 @[to_additive (attr := fun_prop) "The map `(x, y) ↦ -y + x` is quasi-measure-preserving."]
 theorem quasiMeasurePreserving_inv_mul_swap [IsMulLeftInvariant μ] :
-    QuasiMeasurePreserving (fun p => p.2⁻¹ * p.1) (μ.prod ν) μ :=
+    QuasiMeasurePreserving (fun p ↦ p.2⁻¹ * p.1) (μ.prod ν) μ :=
   quasiMeasurePreserving_snd.comp (measurePreserving_prod_inv_mul_swap _ _).quasiMeasurePreserving
 
 @[to_additive (attr := fun_prop)]

--- a/Mathlib/MeasureTheory/Group/Prod.lean
+++ b/Mathlib/MeasureTheory/Group/Prod.lean
@@ -139,7 +139,7 @@ theorem measurePreserving_mul_prod_inv [IsMulLeftInvariant ν] :
   ext1 ⟨x, y⟩
   simp_rw [Function.comp_apply, mul_inv_rev, inv_mul_cancel_right]
 
-@[to_additive]
+@[to_additive (attr := fun_prop)]
 theorem quasiMeasurePreserving_inv : QuasiMeasurePreserving (Inv.inv : G → G) μ μ := by
   refine ⟨measurable_inv, AbsolutelyContinuous.mk fun s hsm hμs => ?_⟩
   rw [map_apply measurable_inv hsm, inv_preimage]
@@ -424,7 +424,7 @@ theorem quasiMeasurePreserving_inv_mul_swap [IsMulLeftInvariant μ] :
     QuasiMeasurePreserving (fun p => p.2⁻¹ * p.1) (μ.prod ν) μ :=
   quasiMeasurePreserving_snd.comp (measurePreserving_prod_inv_mul_swap _ _).quasiMeasurePreserving
 
-@[to_additive]
+@[to_additive (attr := fun_prop)]
 theorem quasiMeasurePreserving_inv_of_right_invariant [IsMulRightInvariant μ] :
     QuasiMeasurePreserving (Inv.inv : G → G) μ μ := by
   rw [← μ.inv_inv]


### PR DESCRIPTION
Add theorems that proves group multiplication is quasi-measure preserving and tag them with `fun_prop`. Also tags a few other theorems with `fun_prop`.  
