### PR TITLE
[Merged by Bors] - chore(Determinant): add `@[nontriviality]` tag

### DIFF
--- a/Mathlib/LinearAlgebra/Determinant.lean
+++ b/Mathlib/LinearAlgebra/Determinant.lean
@@ -260,6 +260,7 @@ theorem det_eq_one_of_not_module_finite (h : ¬Module.Finite R M) (f : M →ₗ[
   rw [LinearMap.det, dif_neg, MonoidHom.one_apply]
   exact fun ⟨_, ⟨b⟩⟩ ↦ h (Module.Finite.of_basis b)
 
+@[nontriviality]
 theorem det_eq_one_of_subsingleton [Subsingleton M] (f : M →ₗ[R] M) :
     LinearMap.det (f : M →ₗ[R] M) = 1 := by
   have b : Basis (Fin 0) R M := Basis.empty M

--- a/Mathlib/RingTheory/Norm/Transitivity.lean
+++ b/Mathlib/RingTheory/Norm/Transitivity.lean
@@ -171,8 +171,7 @@ theorem LinearMap.det_restrictScalars [AddCommGroup A] [Module R A] [Module S A]
     [IsScalarTower R S A] [Module.Free S A] {f : A →ₗ[S] A} :
     (f.restrictScalars R).det = Algebra.norm R f.det := by
   nontriviality R
-  cases subsingleton_or_nontrivial A
-  · simp_rw [det_eq_one_of_subsingleton, map_one]
+  nontriviality A
   have := Module.nontrivial S A
   let ⟨ιS, bS⟩ := Module.Free.exists_basis (R := R) (M := S)
   let ⟨ιA, bA⟩ := Module.Free.exists_basis (R := S) (M := A)


### PR DESCRIPTION
... and use in `RingTheory/Norm/Transitivity`.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
