### PR TITLE
feat(CategoryTheory/Functor/KanExtension): preservations of Kan extensions

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2034,6 +2034,7 @@ import Mathlib.CategoryTheory.Functor.Hom
 import Mathlib.CategoryTheory.Functor.KanExtension.Adjunction
 import Mathlib.CategoryTheory.Functor.KanExtension.Basic
 import Mathlib.CategoryTheory.Functor.KanExtension.Pointwise
+import Mathlib.CategoryTheory.Functor.KanExtension.Preserves
 import Mathlib.CategoryTheory.Functor.OfSequence
 import Mathlib.CategoryTheory.Functor.ReflectsIso.Balanced
 import Mathlib.CategoryTheory.Functor.ReflectsIso.Basic

--- a/Mathlib/CategoryTheory/Functor/KanExtension/Basic.lean
+++ b/Mathlib/CategoryTheory/Functor/KanExtension/Basic.lean
@@ -391,39 +391,39 @@ section
 variable (L : C ⥤ D) (F : C ⥤ H) (G : H ⥤ D')
 
 /-- Given a left extension `E` of `F : C ⥤ H` along `L : C ⥤ D` and a functor `G : H ⥤ D'`,
-`E.whiskerRight G` is the extension of `F ⋙ G` along `L` obtained by whiskering by `G`
+`E.postcompose₂ G` is the extension of `F ⋙ G` along `L` obtained by whiskering by `G`
 on the right. -/
 @[simps!]
-def LeftExtension.whiskerRight : LeftExtension L F ⥤ LeftExtension L (F ⋙ G) :=
+def LeftExtension.postcompose₂ : LeftExtension L F ⥤ LeftExtension L (F ⋙ G) :=
   StructuredArrow.map₂
     (F := (whiskeringRight _ _ _).obj G)
     (G := (whiskeringRight _ _ _).obj G)
     (𝟙 _) ({app _ := (Functor.associator _ _ _).hom})
 
 /-- Given a right extension `E` of `F : C ⥤ H` along `L : C ⥤ D` and a functor `G : H ⥤ D'`,
-`E.whiskerRight G` is the extension of `F ⋙ G` along `L` obtained by whiskering by `G`
+`E.postcompose₂ G` is the extension of `F ⋙ G` along `L` obtained by whiskering by `G`
 on the right. -/
 @[simps!]
-def RightExtension.whiskerRight : RightExtension L F ⥤ RightExtension L (F ⋙ G) :=
+def RightExtension.postcompose₂ : RightExtension L F ⥤ RightExtension L (F ⋙ G) :=
   CostructuredArrow.map₂
     (F := (whiskeringRight _ _ _).obj G)
     (G := (whiskeringRight _ _ _).obj G)
     ({app _ := Functor.associator _ _ _|>.inv}) (𝟙 _)
 
 variable {L F} {F' : D ⥤ H}
-/-- An isomorphism to describe the action of `LeftExtension.whiskerRight` on terms of the form
+/-- An isomorphism to describe the action of `LeftExtension.postcompose₂` on terms of the form
 `LeftExtension.mk _ α`. -/
 @[simps!]
-def LeftExtension.whiskerRightIsoMk (α : F ⟶ L ⋙ F') :
-    (LeftExtension.whiskerRight L F G).obj (LeftExtension.mk F' α) ≅
+def LeftExtension.postcompose₂IsoMk (α : F ⟶ L ⋙ F') :
+    (LeftExtension.postcompose₂ L F G).obj (LeftExtension.mk F' α) ≅
     LeftExtension.mk (F' ⋙ G) <| CategoryTheory.whiskerRight α G ≫ (Functor.associator _ _ _).hom :=
   StructuredArrow.isoMk (Iso.refl _)
 
-/-- An isomorphism to describe the action of `RightExtension.whiskerRight` on terms of the form
+/-- An isomorphism to describe the action of `RightExtension.postcompose₂` on terms of the form
 `RightExtension.mk _ α`. -/
 @[simps!]
-def RightExtension.whiskerRightIsoMk (α : L ⋙ F' ⟶ F) :
-    (RightExtension.whiskerRight L F G).obj (RightExtension.mk F' α) ≅
+def RightExtension.postcompose₂IsoMk (α : L ⋙ F' ⟶ F) :
+    (RightExtension.postcompose₂ L F G).obj (RightExtension.mk F' α) ≅
     RightExtension.mk (F' ⋙ G) <| (Functor.associator _ _ _).inv ≫
       CategoryTheory.whiskerRight α G :=
   CostructuredArrow.isoMk (Iso.refl _)

--- a/Mathlib/CategoryTheory/Functor/KanExtension/Basic.lean
+++ b/Mathlib/CategoryTheory/Functor/KanExtension/Basic.lean
@@ -388,6 +388,50 @@ end
 
 section
 
+variable (L : C ⥤ D) (F : C ⥤ H) (G : H ⥤ D')
+
+/-- Given a left extension `E` of `F : C ⥤ H` along `L : C ⥤ D` and a functor `G : H ⥤ D'`,
+`E.whiskerRight G` is the extension of `F ⋙ G` along `L` obtained by whiskering by `G`
+on the right. -/
+@[simps!]
+def LeftExtension.whiskerRight : LeftExtension L F ⥤ LeftExtension L (F ⋙ G) :=
+  StructuredArrow.map₂
+    (F := (whiskeringRight _ _ _).obj G)
+    (G := (whiskeringRight _ _ _).obj G)
+    (𝟙 _) ({app _ := (Functor.associator _ _ _).hom})
+
+/-- Given a right extension `E` of `F : C ⥤ H` along `L : C ⥤ D` and a functor `G : H ⥤ D'`,
+`E.whiskerRight G` is the extension of `F ⋙ G` along `L` obtained by whiskering by `G`
+on the right. -/
+@[simps!]
+def RightExtension.whiskerRight : RightExtension L F ⥤ RightExtension L (F ⋙ G) :=
+  CostructuredArrow.map₂
+    (F := (whiskeringRight _ _ _).obj G)
+    (G := (whiskeringRight _ _ _).obj G)
+    ({app _ := Functor.associator _ _ _|>.inv}) (𝟙 _)
+
+variable {L F} {F' : D ⥤ H}
+/-- An isomorphism to describe the action of `LeftExtension.whiskerRight` on terms of the form
+`LeftExtension.mk _ α`. -/
+@[simps!]
+def LeftExtension.whiskerRightIsoMk (α : F ⟶ L ⋙ F') :
+    (LeftExtension.whiskerRight L F G).obj (LeftExtension.mk F' α) ≅
+    LeftExtension.mk (F' ⋙ G) <| CategoryTheory.whiskerRight α G ≫ (Functor.associator _ _ _).hom :=
+  StructuredArrow.isoMk (Iso.refl _)
+
+/-- An isomorphism to describe the action of `RightExtension.whiskerRight` on terms of the form
+`RightExtension.mk _ α`. -/
+@[simps!]
+def RightExtension.whiskerRightIsoMk (α : L ⋙ F' ⟶ F) :
+    (RightExtension.whiskerRight L F G).obj (RightExtension.mk F' α) ≅
+    RightExtension.mk (F' ⋙ G) <| (Functor.associator _ _ _).inv ≫
+      CategoryTheory.whiskerRight α G :=
+  CostructuredArrow.isoMk (Iso.refl _)
+
+end
+
+section
+
 variable (L : C ⥤ D) (F : C ⥤ H) (F' : D ⥤ H) (G : C' ⥤ C)
 
 /-- The functor `LeftExtension L F ⥤ LeftExtension (G ⋙ L) (G ⋙ F)`

--- a/Mathlib/CategoryTheory/Functor/KanExtension/Basic.lean
+++ b/Mathlib/CategoryTheory/Functor/KanExtension/Basic.lean
@@ -415,18 +415,18 @@ variable {L F} {F' : D ⥤ H}
 `LeftExtension.mk _ α`. -/
 @[simps!]
 def LeftExtension.postcompose₂IsoMk (α : F ⟶ L ⋙ F') :
-    (LeftExtension.postcompose₂ L F G).obj (LeftExtension.mk F' α) ≅
-    LeftExtension.mk (F' ⋙ G) <| CategoryTheory.whiskerRight α G ≫ (Functor.associator _ _ _).hom :=
-  StructuredArrow.isoMk (Iso.refl _)
+    (LeftExtension.postcompose₂ L F G).obj (.mk F' α) ≅
+    .mk (F' ⋙ G) <| CategoryTheory.whiskerRight α G ≫ (Functor.associator _ _ _).hom :=
+  StructuredArrow.isoMk (.refl _)
 
 /-- An isomorphism to describe the action of `RightExtension.postcompose₂` on terms of the form
 `RightExtension.mk _ α`. -/
 @[simps!]
 def RightExtension.postcompose₂IsoMk (α : L ⋙ F' ⟶ F) :
-    (RightExtension.postcompose₂ L F G).obj (RightExtension.mk F' α) ≅
-    RightExtension.mk (F' ⋙ G) <| (Functor.associator _ _ _).inv ≫
+    (RightExtension.postcompose₂ L F G).obj (.mk F' α) ≅
+    .mk (F' ⋙ G) <| (Functor.associator _ _ _).inv ≫
       CategoryTheory.whiskerRight α G :=
-  CostructuredArrow.isoMk (Iso.refl _)
+  CostructuredArrow.isoMk (.refl _)
 
 end
 

--- a/Mathlib/CategoryTheory/Functor/KanExtension/Preserves.lean
+++ b/Mathlib/CategoryTheory/Functor/KanExtension/Preserves.lean
@@ -143,7 +143,8 @@ noncomputable def lanFunctorCompOfPreserves [G.PreservesLeftKanExtensions L]
         (whiskerRight (L.leftKanExtensionUnit F') G ≫ (Functor.associator _ _ _).hom)
       have h' := descOfIsLeftKanExtension_fac_app (L.leftKanExtension F ⋙ G)
         (whiskerRight (L.leftKanExtensionUnit F) G ≫ (Functor.associator _ _ _).hom)
-      simp at h h'
+      simp only [comp_obj, NatTrans.comp_app, whiskerRight_app, associator_hom_app,
+        Category.comp_id] at h h'
       simp [h, reassoc_of% h'])
 
 end LeftKanExtension

--- a/Mathlib/CategoryTheory/Functor/KanExtension/Preserves.lean
+++ b/Mathlib/CategoryTheory/Functor/KanExtension/Preserves.lean
@@ -26,13 +26,15 @@ variable {A B C D : Type*} [Category A] [Category B] [Category C] [Category D]
 section LeftKanExtension
 
 /-- `G.PreservesLeftKanExtension F L` asserts that `G` preserves all left kan extensions
-of `F` along `L`. -/
+of `F` along `L`. See `PreservesLeftKanExtension.mk_of_preserves_isLeftKanExtension` for a
+constructor taking a single left Kan extension as input. -/
 class PreservesLeftKanExtension where
   preserves : ∀ (F' : C ⥤ B) (α : F ⟶ L ⋙ F') [IsLeftKanExtension F' α],
     IsLeftKanExtension (F' ⋙ G) <| whiskerRight α G ≫ (Functor.associator _ _ _).hom
 
 /-- Alternative constructor for `PreservesLeftKanExtension`, phrased in terms of
-`LeftExtension.IsUniversal` instead. -/
+`LeftExtension.IsUniversal` instead. See `PreservesLeftKanExtension.mk_of_preserves_universal`
+for a similar constructor taking as input a single `LeftExtension`. -/
 lemma PreservesLeftKanExtension.mk'
     (preserves : ∀ {E : LeftExtension L F}, E.IsUniversal →
       Nonempty (LeftExtension.postcompose₂ L F G|>.obj E).IsUniversal) :
@@ -40,6 +42,28 @@ lemma PreservesLeftKanExtension.mk'
   preserves _ _ h :=
     ⟨⟨Limits.IsInitial.equivOfIso
         (LeftExtension.postcompose₂IsoMk _ _) <| (preserves h.nonempty_isUniversal.some).some⟩⟩
+
+/-- Show that `G` preserves left Kan extensions if it maps some left Kan extension to a left
+Kan extension. -/
+lemma PreservesLeftKanExtension.mk_of_preserves_isLeftKanExtension
+    (F' : C ⥤ B) (α : F ⟶ L ⋙ F') [IsLeftKanExtension F' α]
+    (h : IsLeftKanExtension (F' ⋙ G) <| whiskerRight α G ≫ (Functor.associator _ _ _).hom) :
+    G.PreservesLeftKanExtension F L :=
+  .mk fun F'' α' h ↦
+    isLeftKanExtension_of_iso
+      (isoWhiskerRight (leftKanExtensionUnique F' α F'' α') G)
+      (whiskerRight α G ≫ (Functor.associator _ _ _).hom)
+      (whiskerRight α' G ≫ (Functor.associator _ _ _).hom)
+      (by ext x; simp [← G.map_comp])
+
+/-- Show that `G` preserves left Kan extensions if it maps some left Kan extension to a left
+Kan extension, phrased in terms of `IsUniversal`. -/
+lemma PreservesLeftKanExtension.mk_of_preserves_universal (E : LeftExtension L F)
+    (hE : E.IsUniversal) (h : Nonempty (LeftExtension.postcompose₂ L F G|>.obj E).IsUniversal) :
+    G.PreservesLeftKanExtension F L :=
+  .mk' G F L fun hE' ↦
+    ⟨Limits.IsInitial.equivOfIso
+      ((LeftExtension.postcompose₂ L F G).mapIso (Limits.IsInitial.uniqueUpToIso hE hE')) h.some⟩
 
 attribute [instance] PreservesLeftKanExtension.preserves
 
@@ -228,13 +252,15 @@ end LeftKanExtension
 section RightKanExtension
 
 /-- `G.PreservesRightKanExtension F L` asserts that `G` preserves all right kan extensions
-of `F` along `L` -/
+of `F` along `L`. See `PreservesRightKanExtension.mk_of_preserves_isRightKanExtension` for a
+constructor taking a single right Kan extension as input. -/
 class PreservesRightKanExtension where
   preserves : ∀ (F' : C ⥤ B) (α : L ⋙ F' ⟶ F) [IsRightKanExtension F' α],
     IsRightKanExtension (F' ⋙ G) <| (Functor.associator _ _ _).inv ≫ whiskerRight α G
 
 /-- Alternative constructor for `PreservesRightKanExtension`, phrased in terms of
-`RightExtension.IsUniversal` instead. -/
+`RightExtension.IsUniversal` instead. See `PreservesRightKanExtension.mk_of_preserves_universal`
+for a similar constructor taking as input a single `RightExtension`. -/
 lemma PreservesRightKanExtension.mk'
     (preserves : ∀ {E : RightExtension L F}, E.IsUniversal →
       Nonempty (RightExtension.postcompose₂ L F G|>.obj E).IsUniversal) :
@@ -242,6 +268,28 @@ lemma PreservesRightKanExtension.mk'
   preserves _ _ h :=
     ⟨⟨Limits.IsTerminal.equivOfIso
         (RightExtension.postcompose₂IsoMk _ _) <| (preserves h.nonempty_isUniversal.some).some⟩⟩
+
+/-- Show that `G` preserves right Kan extensions if it maps some right Kan extension to a right
+Kan extension. -/
+lemma PreservesRightKanExtension.mk_of_preserves_isRightKanExtension
+    (F' : C ⥤ B) (α : L ⋙ F' ⟶ F) [IsRightKanExtension F' α]
+    (h : IsRightKanExtension (F' ⋙ G) <| (Functor.associator _ _ _).inv ≫ whiskerRight α G ) :
+    G.PreservesRightKanExtension F L :=
+  .mk fun F'' α' h ↦
+    isRightKanExtension_of_iso
+      (isoWhiskerRight (rightKanExtensionUnique F' α F'' α') G)
+      ((Functor.associator _ _ _).inv ≫ whiskerRight α G )
+      ((Functor.associator _ _ _).inv ≫ whiskerRight α' G)
+      (by ext x; simp [← G.map_comp])
+
+/-- Show that `G` preserves right Kan extensions if it maps some right Kan extension to a left
+Kan extension, phrased in terms of `IsUniversal`. -/
+lemma PreservesRightKanExtension.mk_of_preserves_universal (E : RightExtension L F)
+    (hE : E.IsUniversal) (h : Nonempty (RightExtension.postcompose₂ L F G|>.obj E).IsUniversal) :
+    G.PreservesRightKanExtension F L :=
+  .mk' G F L fun hE' ↦
+    ⟨Limits.IsTerminal.equivOfIso
+      ((RightExtension.postcompose₂ L F G).mapIso (Limits.IsTerminal.uniqueUpToIso hE hE')) h.some⟩
 
 attribute [instance] PreservesRightKanExtension.preserves
 

--- a/Mathlib/CategoryTheory/Functor/KanExtension/Preserves.lean
+++ b/Mathlib/CategoryTheory/Functor/KanExtension/Preserves.lean
@@ -36,6 +36,7 @@ attribute [instance] PreservesLeftKanExtension.preserves
 /-- `G.PreservesLeftKanExtensionAt F L c` asserts that `G` preserves pointwise all left kan
 extensions of `F` along `L` at the point `c`. -/
 class PreservesPointwiseLeftKanExtensionAt (c : C) where
+  /-- `G` preserves every pointwise extensions of `F` along `L` at `c`. -/
   preserves : ∀ (E : LeftExtension L F), E.IsPointwiseLeftKanExtensionAt c →
     (LeftExtension.whiskerRight L F G|>.obj E).IsPointwiseLeftKanExtensionAt c
 
@@ -162,6 +163,7 @@ attribute [instance] PreservesRightKanExtension.preserves
 /-- `G.PreservesRightKanExtensionAt F L c` asserts that `G` preserves all right pointwise right kan
 extensions of `F` along `L` at `c`. -/
 class PreservesPointwiseRightKanExtensionAt (c : C) where
+  /-- `G` preserves every pointwise extensions of `F` along `L` at `c`. -/
   preserves : ∀ (E : RightExtension L F), E.IsPointwiseRightKanExtensionAt c →
     (RightExtension.whiskerRight L F G|>.obj E).IsPointwiseRightKanExtensionAt c
 

--- a/Mathlib/CategoryTheory/Functor/KanExtension/Preserves.lean
+++ b/Mathlib/CategoryTheory/Functor/KanExtension/Preserves.lean
@@ -33,7 +33,7 @@ class PreservesLeftKanExtension where
 
 /-- Alternative constructor for `PreservesLeftKanExtension`, phrased in terms of
 `LeftExtension.IsUniversal` instead. -/
-def PreservesLeftKanExtension.mk'
+lemma PreservesLeftKanExtension.mk'
     (preserves : ∀ {E : LeftExtension L F}, E.IsUniversal →
       Nonempty (LeftExtension.postcompose₂ L F G|>.obj E).IsUniversal) :
     G.PreservesLeftKanExtension F L where
@@ -235,7 +235,7 @@ class PreservesRightKanExtension where
 
 /-- Alternative constructor for `PreservesRightKanExtension`, phrased in terms of
 `RightExtension.IsUniversal` instead. -/
-def PreservesRightKanExtension.mk'
+lemma PreservesRightKanExtension.mk'
     (preserves : ∀ {E : RightExtension L F}, E.IsUniversal →
       Nonempty (RightExtension.postcompose₂ L F G|>.obj E).IsUniversal) :
     G.PreservesRightKanExtension F L where

--- a/Mathlib/CategoryTheory/Functor/KanExtension/Preserves.lean
+++ b/Mathlib/CategoryTheory/Functor/KanExtension/Preserves.lean
@@ -160,7 +160,7 @@ lemma pointwiseLeftKanExtensionCompIsoOfPreserves_fac :
     (α := whiskerRight (L.pointwiseLeftKanExtensionUnit F) G ≫ (Functor.associator _ _ _).hom)
     (β := L.pointwiseLeftKanExtensionUnit (F ⋙ G))
 
-@[reassoc (attr := simp)]
+@[reassoc]
 lemma pointwiseLeftKanExtensionCompIsoOfPreserves_fac_app (a : A) :
     G.map ((L.pointwiseLeftKanExtensionUnit F).app a) ≫
       (G.pointwiseLeftKanExtensionCompIsoOfPreserves F L).hom.app (L.obj a) =
@@ -328,7 +328,7 @@ lemma pointwiseRightKanExtensionCompIsoOfPreserves_fac :
     ((Functor.associator _ _ _).inv ≫ whiskerRight (L.pointwiseRightKanExtensionCounit F) G):= by
   simp [pointwiseRightKanExtensionCompIsoOfPreserves]
 
-@[reassoc (attr := simp)]
+@[reassoc]
 lemma pointwiseRightKanExtensionCompIsoOfPreserves_fac_app (a : A) :
     (G.pointwiseRightKanExtensionCompIsoOfPreserves F L).hom.app (L.obj a) ≫
       (L.pointwiseRightKanExtensionCounit (F ⋙ G)).app a =

--- a/Mathlib/CategoryTheory/Functor/KanExtension/Preserves.lean
+++ b/Mathlib/CategoryTheory/Functor/KanExtension/Preserves.lean
@@ -31,6 +31,16 @@ class PreservesLeftKanExtension where
   preserves : ∀ (F' : C ⥤ B) (α : F ⟶ L ⋙ F') [IsLeftKanExtension F' α],
     IsLeftKanExtension (F' ⋙ G) <| whiskerRight α G ≫ (Functor.associator _ _ _).hom
 
+/-- Alternative constructor for `PreservesLeftKanExtension`, phrased in terms of
+`LeftExtension.IsUniversal` instead. -/
+def PreservesLeftKanExtension.mk'
+    (preserves : ∀ {E : LeftExtension L F}, E.IsUniversal →
+      Nonempty (LeftExtension.whiskerRight L F G|>.obj E).IsUniversal) :
+    G.PreservesLeftKanExtension F L where
+  preserves _ _ h :=
+    ⟨⟨Limits.IsInitial.equivOfIso
+        (LeftExtension.whiskerRightIsoMk _ _) <| (preserves h.nonempty_isUniversal.some).some⟩⟩
+
 attribute [instance] PreservesLeftKanExtension.preserves
 
 /-- `G.PreservesLeftKanExtensionAt F L c` asserts that `G` preserves pointwise all left kan
@@ -192,6 +202,16 @@ of `F` along `L` -/
 class PreservesRightKanExtension where
   preserves : ∀ (F' : C ⥤ B) (α : L ⋙ F' ⟶ F) [IsRightKanExtension F' α],
     IsRightKanExtension (F' ⋙ G) <| (Functor.associator _ _ _).inv ≫ whiskerRight α G
+
+/-- Alternative constructor for `PreservesRightKanExtension`, phrased in terms of
+`RightExtension.IsUniversal` instead. -/
+def PreservesRightKanExtension.mk'
+    (preserves : ∀ {E : RightExtension L F}, E.IsUniversal →
+      Nonempty (RightExtension.whiskerRight L F G|>.obj E).IsUniversal) :
+    G.PreservesRightKanExtension F L where
+  preserves _ _ h :=
+    ⟨⟨Limits.IsTerminal.equivOfIso
+        (RightExtension.whiskerRightIsoMk _ _) <| (preserves h.nonempty_isUniversal.some).some⟩⟩
 
 attribute [instance] PreservesRightKanExtension.preserves
 

--- a/Mathlib/CategoryTheory/Functor/KanExtension/Preserves.lean
+++ b/Mathlib/CategoryTheory/Functor/KanExtension/Preserves.lean
@@ -72,7 +72,6 @@ instance hasPointwiseLeftKanExtension_of_preserves [L.HasPointwiseLeftKanExtensi
 
 /-- Extract an isomorphism `(leftKanExtension L F) ⋙ G ≅ leftKanExtension L (F ⋙ G)` when `G`
 preserves left Kan extensions. -/
-@[simps!]
 noncomputable def leftKanExtensionCompIsoOfPreserves [PreservesLeftKanExtension G F L]
     [L.HasLeftKanExtension F] :
     L.leftKanExtension F ⋙ G ≅ L.leftKanExtension (F ⋙ G) :=
@@ -81,6 +80,29 @@ noncomputable def leftKanExtensionCompIsoOfPreserves [PreservesLeftKanExtension 
     (whiskerRight (L.leftKanExtensionUnit F) G ≫ (Functor.associator _ _ _).hom)
     (L.leftKanExtension <| F ⋙ G)
     (L.leftKanExtensionUnit <| F ⋙ G)
+
+section
+
+variable [PreservesLeftKanExtension G F L] [L.HasLeftKanExtension F]
+
+@[reassoc (attr := simp)]
+lemma leftKanExtensionCompIsoOfPreserves_fac :
+    whiskerRight (L.leftKanExtensionUnit F) G ≫ (Functor.associator _ _ _).hom ≫
+      whiskerLeft L (leftKanExtensionCompIsoOfPreserves G F L).hom =
+    (L.leftKanExtensionUnit <| F ⋙ G) := by
+  simpa [leftKanExtensionCompIsoOfPreserves] using descOfIsLeftKanExtension_fac
+    (α := whiskerRight (L.leftKanExtensionUnit F) G ≫ (Functor.associator _ _ _).hom)
+    (β := L.leftKanExtensionUnit (F ⋙ G))
+
+@[reassoc (attr := simp)]
+lemma leftKanExtensionCompIsoOfPreserves_fac_app (a : A) :
+    G.map ((L.leftKanExtensionUnit F).app a) ≫
+      (G.leftKanExtensionCompIsoOfPreserves F L).hom.app (L.obj a) =
+    (L.leftKanExtensionUnit (F ⋙ G)).app a := by
+  simpa [- leftKanExtensionCompIsoOfPreserves_fac] using congrArg (fun t ↦ t.app a)
+    (leftKanExtensionCompIsoOfPreserves_fac G F L)
+
+end
 
 /-- A functor that preserves the colimit of `(CostructuredArrow.proj L c ⋙ F)` preserves
 the pointwise left kan extension of `F` along `L` at c. -/
@@ -105,7 +127,6 @@ noncomputable instance preservesPointwiseLKEOfHasPointwiseAndPreservesPointwise
 /-- Extract an isomorphism
 `(pointwiseLeftKanExtension L F) ⋙ G ≅ pointwiseLeftKanExtension L (F ⋙ G)` when `G` preserves
 left Kan extensions. -/
-@[simps!]
 noncomputable def pointwiseLeftKanExtensionCompIsoOfPreserves
     [PreservesPointwiseLeftKanExtension G F L]
     [L.HasPointwiseLeftKanExtension F] :
@@ -115,6 +136,29 @@ noncomputable def pointwiseLeftKanExtensionCompIsoOfPreserves
     (whiskerRight (L.pointwiseLeftKanExtensionUnit F) G ≫ (Functor.associator _ _ _).hom)
     (L.pointwiseLeftKanExtension <| F ⋙ G)
     (L.pointwiseLeftKanExtensionUnit <| F ⋙ G)
+
+section
+
+variable [PreservesPointwiseLeftKanExtension G F L] [L.HasPointwiseLeftKanExtension F]
+
+@[reassoc (attr := simp)]
+lemma pointwiseLeftKanExtensionCompIsoOfPreserves_fac :
+    whiskerRight (L.pointwiseLeftKanExtensionUnit F) G ≫ (Functor.associator _ _ _).hom ≫
+      whiskerLeft L (pointwiseLeftKanExtensionCompIsoOfPreserves G F L).hom =
+    (L.pointwiseLeftKanExtensionUnit <| F ⋙ G) := by
+  simpa [pointwiseLeftKanExtensionCompIsoOfPreserves] using descOfIsLeftKanExtension_fac
+    (α := whiskerRight (L.pointwiseLeftKanExtensionUnit F) G ≫ (Functor.associator _ _ _).hom)
+    (β := L.pointwiseLeftKanExtensionUnit (F ⋙ G))
+
+@[reassoc (attr := simp)]
+lemma pointwiseLeftKanExtensionCompIsoOfPreserves_fac_app (a : A) :
+    G.map ((L.pointwiseLeftKanExtensionUnit F).app a) ≫
+      (G.pointwiseLeftKanExtensionCompIsoOfPreserves F L).hom.app (L.obj a) =
+    (L.pointwiseLeftKanExtensionUnit (F ⋙ G)).app a := by
+  simpa [- pointwiseLeftKanExtensionCompIsoOfPreserves_fac] using congrArg (fun t ↦ t.app a)
+    (pointwiseLeftKanExtensionCompIsoOfPreserves_fac G F L)
+
+end
 
 /-- `G.PreservesLeftKanExtensions L` means that `G : B ⥤ D` preserves all left Kan extensions along
 `L : A ⥤ C` of every functor `A ⥤ B`. -/
@@ -137,16 +181,7 @@ noncomputable def lanFunctorCompOfPreserves [G.PreservesLeftKanExtensions L]
         (whiskerRight (L.leftKanExtensionUnit F) G ≫ (Functor.associator _ _ _).hom)
       dsimp [lan]
       ext
-      simp only [comp_obj, leftKanExtensionCompIsoOfPreserves_hom, Category.assoc,
-        NatTrans.comp_app, whiskerRight_app, associator_hom_app, whiskerLeft_app, Category.id_comp,
-        ← G.map_comp_assoc]
-      have h := descOfIsLeftKanExtension_fac_app (L.leftKanExtension F' ⋙ G)
-        (whiskerRight (L.leftKanExtensionUnit F') G ≫ (Functor.associator _ _ _).hom)
-      have h' := descOfIsLeftKanExtension_fac_app (L.leftKanExtension F ⋙ G)
-        (whiskerRight (L.leftKanExtensionUnit F) G ≫ (Functor.associator _ _ _).hom)
-      simp only [comp_obj, NatTrans.comp_app, whiskerRight_app, associator_hom_app,
-        Category.comp_id] at h h'
-      simp [h, reassoc_of% h'])
+      simp [← G.map_comp_assoc])
 
 end LeftKanExtension
 
@@ -199,7 +234,6 @@ instance hasPointwiseRightKanExtension_of_preserves [L.HasPointwiseRightKanExten
 
 /-- Extract an isomorphism `(rightKanExtension L F) ⋙ G ≅ rightKanExtension L (F ⋙ G)` when `G`
 preserves left Kan extensions. -/
-@[simps!]
 noncomputable def rightKanExtensionCompIsoOfPreserves [PreservesRightKanExtension G F L]
     [L.HasRightKanExtension F] :
     L.rightKanExtension F ⋙ G ≅ L.rightKanExtension (F ⋙ G) :=
@@ -208,6 +242,26 @@ noncomputable def rightKanExtensionCompIsoOfPreserves [PreservesRightKanExtensio
     ((Functor.associator _ _ _).inv ≫ whiskerRight (L.rightKanExtensionCounit F) G)
     (L.rightKanExtension <| F ⋙ G)
     (L.rightKanExtensionCounit <| F ⋙ G)
+
+section
+
+variable [PreservesRightKanExtension G F L] [L.HasRightKanExtension F]
+
+@[reassoc (attr := simp)]
+lemma rightKanExtensionCompIsoOfPreserves_fac :
+    whiskerLeft L (rightKanExtensionCompIsoOfPreserves G F L).hom ≫
+      (L.rightKanExtensionCounit <| F ⋙ G) =
+    ((Functor.associator _ _ _).inv ≫ whiskerRight (L.rightKanExtensionCounit F) G):= by
+  simp [rightKanExtensionCompIsoOfPreserves]
+
+@[reassoc (attr := simp)]
+lemma rightKanExtensionCompIsoOfPreserves_fac_app (a : A) :
+    (G.rightKanExtensionCompIsoOfPreserves F L).hom.app (L.obj a) ≫
+      (L.rightKanExtensionCounit (F ⋙ G)).app a =
+    G.map ((L.rightKanExtensionCounit F).app a) := by
+  simp [rightKanExtensionCompIsoOfPreserves]
+
+end
 
 /-- A functor that preserves the colimit of `(StructuredArrow.proj L c ⋙ F)` preserves
 the pointwise right kan extension of `F` along `L` at c. -/
@@ -232,7 +286,6 @@ noncomputable instance preservesPointwiseRKEOfHasPointwiseAndPreservesPointwise
 /-- Extract an isomorphism
 `(pointwiseRightKanExtension L F) ⋙ G ≅ pointwiseRightKanExtension L (F ⋙ G)` when `G` preserves
 right Kan extensions. -/
-@[simps!]
 noncomputable def pointwiseRightKanExtensionCompIsoOfPreserves
     [PreservesPointwiseRightKanExtension G F L]
     [L.HasPointwiseRightKanExtension F] :
@@ -242,6 +295,28 @@ noncomputable def pointwiseRightKanExtensionCompIsoOfPreserves
     ((Functor.associator _ _ _).inv ≫ whiskerRight (L.pointwiseRightKanExtensionCounit F) G)
     (L.pointwiseRightKanExtension <| F ⋙ G)
     (L.pointwiseRightKanExtensionCounit <| F ⋙ G)
+
+section
+
+variable [PreservesPointwiseRightKanExtension G F L]
+    [L.HasPointwiseRightKanExtension F]
+
+@[reassoc (attr := simp)]
+lemma pointwiseRightKanExtensionCompIsoOfPreserves_fac :
+    whiskerLeft L (pointwiseRightKanExtensionCompIsoOfPreserves G F L).hom ≫
+      (L.pointwiseRightKanExtensionCounit <| F ⋙ G) =
+    ((Functor.associator _ _ _).inv ≫ whiskerRight (L.pointwiseRightKanExtensionCounit F) G):= by
+  simp [pointwiseRightKanExtensionCompIsoOfPreserves]
+
+@[reassoc (attr := simp)]
+lemma pointwiseRightKanExtensionCompIsoOfPreserves_fac_app (a : A) :
+    (G.pointwiseRightKanExtensionCompIsoOfPreserves F L).hom.app (L.obj a) ≫
+      (L.pointwiseRightKanExtensionCounit (F ⋙ G)).app a =
+    G.map ((L.pointwiseRightKanExtensionCounit F).app a) := by
+  simpa [-pointwiseRightKanExtensionCompIsoOfPreserves_fac] using
+    congrArg (fun t ↦ t.app a) <| pointwiseRightKanExtensionCompIsoOfPreserves_fac G F L
+
+end
 
 /-- `G.PreservesRightKanExtensions L` means that `G : B ⥤ D` preserves all right Kan extensions
 along `L : A ⥤ C` of every functor `A ⥤ B`. -/
@@ -264,17 +339,10 @@ noncomputable def ranFunctorCompOfPreserves [G.PreservesRightKanExtensions L]
         (L.rightKanExtensionCounit <| F' ⋙ G)
       dsimp [ran]
       ext
-      simp only [comp_obj, rightKanExtensionCompIsoOfPreserves_hom, Category.assoc,
-        NatTrans.comp_app, whiskerRight_app, associator_hom_app, whiskerLeft_app, Category.id_comp,
-        ← G.map_comp_assoc]
-      have h := liftOfIsRightKanExtension_fac_app (L.rightKanExtension F' ⋙ G)
-        ((Functor.associator _ _ _).inv ≫ whiskerRight (L.rightKanExtensionCounit F') G)
-      have h' := liftOfIsRightKanExtension_fac_app (L.rightKanExtension F ⋙ G)
-        ((Functor.associator _ _ _).inv ≫ whiskerRight (L.rightKanExtensionCounit F) G)
-      simp only [comp_obj, NatTrans.comp_app, associator_inv_app, whiskerRight_app,
-        Category.id_comp] at h h'
-      simp only [liftOfIsRightKanExtension_fac_app, NatTrans.comp_app, comp_obj, associator_inv_app,
-        whiskerRight_app, Category.id_comp, liftOfIsRightKanExtension_fac_app_assoc, ← G.map_comp])
+      simp only [comp_obj, Category.assoc, rightKanExtensionCompIsoOfPreserves_fac,
+        NatTrans.comp_app, whiskerLeft_app, whiskerRight_app, associator_inv_app, Category.id_comp,
+        liftOfIsRightKanExtension_fac, rightKanExtensionCompIsoOfPreserves_fac_assoc, ← G.map_comp ]
+      simp)
 
 end RightKanExtension
 

--- a/Mathlib/CategoryTheory/Functor/KanExtension/Preserves.lean
+++ b/Mathlib/CategoryTheory/Functor/KanExtension/Preserves.lean
@@ -1,0 +1,214 @@
+/-
+Copyright (c) 2025 Robin Carlier. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robin Carlier
+-/
+import Mathlib.CategoryTheory.Functor.KanExtension.Pointwise
+import Mathlib.CategoryTheory.Limits.Preserves.Basic
+
+/-!
+# Preservation of Kan extensions
+
+Given functors `F : A ⥤ B`, `L : B ⥤ C`, and `G : B ⥤ D`,
+we introduce a typeclass `G.PreservesLeftKanExtension F L`, which encodes the fact that
+the left Kan extension of `F` along `L` is preserved by the functor `G`.
+
+When the Kan extension is pointwise, It suffices that `G` preserves colimits of the relevant
+diagrams.
+
+TODO: better namespaces
+
+-/
+
+namespace CategoryTheory.Functor
+
+variable {A B C D: Type*} [Category A] [Category B] [Category C] [Category D]
+  (G : B ⥤ D) (F : A ⥤ B) (L : A ⥤ C)
+
+section LeftKanExtension
+
+/-- TODO -/
+class PreservesLeftKanExtension where
+  preserves : ∀ (F' : C ⥤ B) (α : F ⟶ L ⋙ F') [IsLeftKanExtension F' α],
+    IsLeftKanExtension (F' ⋙ G) <| whiskerRight α G ≫ (Functor.associator _ _ _).hom
+
+attribute [instance] PreservesLeftKanExtension.preserves
+
+/-- TODO -/
+class PreservesPointwiseLeftKanExtensionAt (c : C) where
+  preserves : ∀ (E : LeftExtension L F), E.IsPointwiseLeftKanExtensionAt c →
+    (LeftExtension.whiskerRight L F G|>.obj E).IsPointwiseLeftKanExtensionAt c
+
+/-- TODO -/
+abbrev PreservesPointwiseLeftKanExtension := ∀ c : C, PreservesPointwiseLeftKanExtensionAt G F L c
+
+/-- Given a pointwise left kan extension of `F` at `L`, exhibits
+`(LeftExtension.whiskerRight L F G).obj E` as a pointwise left Kan extension of `F ⋙ G` at `L`. -/
+def PreservesPointwiseLeftKanExtension.preserves [h : PreservesPointwiseLeftKanExtension G F L]
+    (E : LeftExtension L F) (hE : E.IsPointwiseLeftKanExtension) :
+    LeftExtension.whiskerRight L F G|>.obj E|>.IsPointwiseLeftKanExtension := fun c ↦
+  (h c).preserves E (hE c)
+
+/-- The cocone at a point of the whiskering right by `G`of an extension is isomorphic to the
+action of `G` on the cocone at that point for the original extension. -/
+@[simps!]
+def coconeAtWhiskerRightIso (E : LeftExtension L F) (c : C) :
+    ((LeftExtension.whiskerRight L F G).obj E).coconeAt c ≅ G.mapCocone (E.coconeAt c) :=
+  Limits.Cocones.ext (Iso.refl _)
+
+instance hasLeftKanExtension_of_preserves [L.HasLeftKanExtension F]
+    [PreservesLeftKanExtension G F L] : L.HasLeftKanExtension (F ⋙ G) :=
+  @HasLeftKanExtension.mk _ _ _ _ _ _ _ _ _ _ <|
+    letI : (L.leftKanExtension F).IsLeftKanExtension <| L.leftKanExtensionUnit F := by infer_instance
+    PreservesLeftKanExtension.preserves (L.leftKanExtension F) (L.leftKanExtensionUnit F)
+
+instance hasPointwiseLeftKanExtension_of_preserves [L.HasPointwiseLeftKanExtension F]
+    [PreservesPointwiseLeftKanExtension G F L] : L.HasPointwiseLeftKanExtension (F ⋙ G) :=
+  (PreservesPointwiseLeftKanExtension.preserves G F L _
+    <| pointwiseLeftKanExtensionIsPointwiseLeftKanExtension L F).hasPointwiseLeftKanExtension
+
+/-- Extract an isomorphism `(leftKanExtension L F) ⋙ G ≅ leftKanExtension L (F ⋙ G)` when `G`
+preserves left Kan extensions. -/
+@[simps!]
+noncomputable def leftKanExtensionCompIsoOfPreserves [PreservesLeftKanExtension G F L]
+    [L.HasLeftKanExtension F] :
+    L.leftKanExtension F ⋙ G ≅ L.leftKanExtension (F ⋙ G) :=
+  leftKanExtensionUnique
+    (L.leftKanExtension F ⋙ G)
+    (whiskerRight (L.leftKanExtensionUnit F) G ≫ (Functor.associator _ _ _).hom)
+    (L.leftKanExtension <| F ⋙ G)
+    (L.leftKanExtensionUnit <| F ⋙ G)
+
+/-- A functor that preserves the colimit of `(CostructuredArrow.proj L c ⋙ F)` preserves
+the pointwise left kan extension of `F` along `L` at c. -/
+noncomputable instance preservesPointwiseLeftKanExtensionAtOfPreservesColimit (c : C)
+    [Limits.PreservesColimit (CostructuredArrow.proj L c ⋙ F) G] :
+    G.PreservesPointwiseLeftKanExtensionAt F L c where
+  preserves E p :=
+    Limits.IsColimit.ofIsoColimit
+      (Limits.PreservesColimit.preserves p).some
+      (coconeAtWhiskerRightIso G _ _ E c).symm
+
+/-- If there is a pointwise left Kan extension of `F` along `L`, and if `G` preserves them,
+then `G` preserves left Kan extensions of `F` along `L`. -/
+noncomputable instance preservesPointwiseLKEOfHasPointwiseAndPreservesPointwise
+    [HasPointwiseLeftKanExtension L F] [G.PreservesPointwiseLeftKanExtension F L] :
+    G.PreservesLeftKanExtension F L where
+  preserves F' α _ :=
+    (LeftExtension.isPointwiseLeftKanExtensionEquivOfIso (LeftExtension.whiskerRightIsoMk G α) <|
+      PreservesPointwiseLeftKanExtension.preserves G F L _ <|
+        isPointwiseLeftKanExtensionOfIsLeftKanExtension F' α).isLeftKanExtension
+
+/-- Extract an isomorphism
+`(pointwiseLeftKanExtension L F) ⋙ G ≅ pointwiseLeftKanExtension L (F ⋙ G)` when `G` preserves
+left Kan extensions. -/
+@[simps!]
+noncomputable def pointwiseLeftKanExtensionCompIsoOfPreserves [PreservesPointwiseLeftKanExtension G F L]
+    [L.HasPointwiseLeftKanExtension F] :
+    L.pointwiseLeftKanExtension F ⋙ G ≅ L.pointwiseLeftKanExtension (F ⋙ G) :=
+  leftKanExtensionUnique
+    (L.pointwiseLeftKanExtension F ⋙ G)
+    (whiskerRight (L.pointwiseLeftKanExtensionUnit F) G ≫ (Functor.associator _ _ _).hom)
+    (L.pointwiseLeftKanExtension <| F ⋙ G)
+    (L.pointwiseLeftKanExtensionUnit <| F ⋙ G)
+
+/-- `G.PreservesLeftKanExtensions L` means that `G : B ⥤ D` preserves all left Kan extensions along
+`L : A ⥤ C` of every functor `A ⥤ B`. -/
+abbrev preservesLeftKanExtensions := ∀ (F : A ⥤ B), G.PreservesLeftKanExtension F L
+
+/-- `G.PreservesPointwiseLeftKanExtensions L` means that `G : B ⥤ D` preserves all pointwise left Kan
+extensions along `L : A ⥤ C` of every functor `A ⥤ B`. -/
+abbrev preservesPointwiseLeftKanExtensions := ∀ (F : A ⥤ B), G.PreservesPointwiseLeftKanExtension F L
+
+end LeftKanExtension
+
+section RightKanExtension
+
+/-- TODO -/
+class PreservesRightKanExtension where
+  preserves : ∀ (F' : C ⥤ B) (α : L ⋙ F' ⟶ F) [IsRightKanExtension F' α],
+    IsRightKanExtension (F' ⋙ G) <| (Functor.associator _ _ _).inv ≫ whiskerRight α G
+
+attribute [instance] PreservesRightKanExtension.preserves
+
+/-- TODO -/
+class PreservesPointwiseRightKanExtensionAt (c : C) where
+  preserves : ∀ (E : RightExtension L F), E.IsPointwiseRightKanExtensionAt c →
+    (RightExtension.whiskerRight L F G|>.obj E).IsPointwiseRightKanExtensionAt c
+
+/-- TODO -/
+abbrev PreservesPointwiseRightKanExtension := ∀ c : C, PreservesPointwiseRightKanExtensionAt G F L c
+
+/-- Given a pointwise left kan extension of `F` at `L`, exhibits
+`(RightExtension.whiskerRight L F G).obj E` as a pointwise left Kan extension of `F ⋙ G` at `L`. -/
+def PreservesPointwiseRightKanExtension.preserves [h : PreservesPointwiseRightKanExtension G F L]
+    (E : RightExtension L F) (hE : E.IsPointwiseRightKanExtension) :
+    RightExtension.whiskerRight L F G|>.obj E|>.IsPointwiseRightKanExtension := fun c ↦
+  (h c).preserves E (hE c)
+
+/-- The cocone at a point of the whiskering right by `G`of an extension is isomorphic to the
+action of `G` on the cocone at that point for the original extension. -/
+@[simps!]
+def coneAtWhiskerRightIso (E : RightExtension L F) (c : C) :
+    (RightExtension.whiskerRight L F G|>.obj E).coneAt c ≅ G.mapCone (E.coneAt c) :=
+  Limits.Cones.ext (Iso.refl _)
+
+instance hasRightKanExtension_of_preserves [L.HasRightKanExtension F]
+    [PreservesRightKanExtension G F L] : L.HasRightKanExtension (F ⋙ G) :=
+  @HasRightKanExtension.mk _ _ _ _ _ _ _ _ _ _ <|
+    letI : (L.rightKanExtension F).IsRightKanExtension <| L.rightKanExtensionCounit F := by infer_instance
+    PreservesRightKanExtension.preserves (L.rightKanExtension F) (L.rightKanExtensionCounit F)
+
+instance hasPointwiseRightKanExtension_of_preserves [L.HasPointwiseRightKanExtension F]
+    [PreservesPointwiseRightKanExtension G F L] : L.HasPointwiseRightKanExtension (F ⋙ G) :=
+  (PreservesPointwiseRightKanExtension.preserves G F L _
+    <| pointwiseRightKanExtensionIsPointwiseRightKanExtension L F).hasPointwiseRightKanExtension
+
+/-- Extract an isomorphism `(rightKanExtension L F) ⋙ G ≅ rightKanExtension L (F ⋙ G)` when `G`
+preserves left Kan extensions. -/
+@[simps!]
+noncomputable def rightKanExtensionCompIsoOfPreserves [PreservesRightKanExtension G F L]
+    [L.HasRightKanExtension F] :
+    L.rightKanExtension F ⋙ G ≅ L.rightKanExtension (F ⋙ G) :=
+  rightKanExtensionUnique
+    (L.rightKanExtension F ⋙ G)
+    ((Functor.associator _ _ _).inv ≫ whiskerRight (L.rightKanExtensionCounit F) G)
+    (L.rightKanExtension <| F ⋙ G)
+    (L.rightKanExtensionCounit <| F ⋙ G)
+
+/-- A functor that preserves the colimit of `(CostructuredArrow.proj L c ⋙ F)` preserves
+the pointwise left kan extension of `F` along `L` at c. -/
+noncomputable instance preservesPointwiseRightKanExtensionAtOfPreservesColimit (c : C)
+    [Limits.PreservesLimit (StructuredArrow.proj c L ⋙ F) G] :
+    G.PreservesPointwiseRightKanExtensionAt F L c where
+  preserves E p :=
+    Limits.IsLimit.ofIsoLimit
+      (Limits.PreservesLimit.preserves p).some
+      (coneAtWhiskerRightIso G _ _ E c).symm
+
+/-- If there is a pointwise left Kan extension of `F` along `L`, and if `G` preserves them,
+then `G` preserves left Kan extensions of `F` along `L`. -/
+noncomputable instance preservesPointwiseRKEOfHasPointwiseAndPreservesPointwise
+    [HasPointwiseRightKanExtension L F] [G.PreservesPointwiseRightKanExtension F L] :
+    G.PreservesRightKanExtension F L where
+  preserves F' α _ :=
+    (RightExtension.isPointwiseRightKanExtensionEquivOfIso (RightExtension.whiskerRightIsoMk G α) <|
+      PreservesPointwiseRightKanExtension.preserves G F L _ <|
+        isPointwiseRightKanExtensionOfIsRightKanExtension F' α).isRightKanExtension
+
+/-- Extract an isomorphism
+`(pointwiseRightKanExtension L F) ⋙ G ≅ pointwiseRightKanExtension L (F ⋙ G)` when `G` preserves
+left Kan extensions. -/
+@[simps!]
+noncomputable def pointwiseRightKanExtensionCompIsoOfPreserves [PreservesPointwiseRightKanExtension G F L]
+    [L.HasPointwiseRightKanExtension F] :
+    L.pointwiseRightKanExtension F ⋙ G ≅ L.pointwiseRightKanExtension (F ⋙ G) :=
+  rightKanExtensionUnique
+    (L.pointwiseRightKanExtension F ⋙ G)
+    ((Functor.associator _ _ _).inv ≫ whiskerRight (L.pointwiseRightKanExtensionCounit F) G)
+    (L.pointwiseRightKanExtension <| F ⋙ G)
+    (L.pointwiseRightKanExtensionCounit <| F ⋙ G)
+
+end RightKanExtension
+
+end CategoryTheory.Functor

--- a/Mathlib/CategoryTheory/Functor/KanExtension/Preserves.lean
+++ b/Mathlib/CategoryTheory/Functor/KanExtension/Preserves.lean
@@ -96,7 +96,7 @@ section
 variable [PreservesLeftKanExtension G F L] [L.HasLeftKanExtension F]
 
 @[reassoc (attr := simp)]
-lemma leftKanExtensionCompIsoOfPreserves_fac :
+lemma leftKanExtensionCompIsoOfPreserves_hom_fac :
     whiskerRight (L.leftKanExtensionUnit F) G ≫ (Functor.associator _ _ _).hom ≫
       whiskerLeft L (leftKanExtensionCompIsoOfPreserves G F L).hom =
     (L.leftKanExtensionUnit <| F ⋙ G) := by
@@ -105,12 +105,27 @@ lemma leftKanExtensionCompIsoOfPreserves_fac :
     (β := L.leftKanExtensionUnit (F ⋙ G))
 
 @[reassoc (attr := simp)]
-lemma leftKanExtensionCompIsoOfPreserves_fac_app (a : A) :
+lemma leftKanExtensionCompIsoOfPreserves_hom_fac_app (a : A) :
     G.map ((L.leftKanExtensionUnit F).app a) ≫
       (G.leftKanExtensionCompIsoOfPreserves F L).hom.app (L.obj a) =
     (L.leftKanExtensionUnit (F ⋙ G)).app a := by
-  simpa [- leftKanExtensionCompIsoOfPreserves_fac] using congrArg (fun t ↦ t.app a)
-    (leftKanExtensionCompIsoOfPreserves_fac G F L)
+  simpa [- leftKanExtensionCompIsoOfPreserves_hom_fac] using congrArg (fun t ↦ t.app a)
+    (leftKanExtensionCompIsoOfPreserves_hom_fac G F L)
+
+@[reassoc (attr := simp)]
+lemma leftKanExtensionCompIsoOfPreserves_inv_fac :
+    (L.leftKanExtensionUnit <| F ⋙ G) ≫
+      whiskerLeft L (leftKanExtensionCompIsoOfPreserves G F L).inv =
+    whiskerRight (L.leftKanExtensionUnit F) G ≫ (Functor.associator _ _ _).hom := by
+  simp [leftKanExtensionCompIsoOfPreserves]
+
+@[reassoc (attr := simp)]
+lemma leftKanExtensionCompIsoOfPreserves_inv_fac_app (a : A) :
+    (L.leftKanExtensionUnit (F ⋙ G)).app a ≫
+      (G.leftKanExtensionCompIsoOfPreserves F L).inv.app (L.obj a) =
+    G.map ((L.leftKanExtensionUnit F).app a) := by
+  simpa [- leftKanExtensionCompIsoOfPreserves_inv_fac] using congrArg (fun t ↦ t.app a)
+    (leftKanExtensionCompIsoOfPreserves_inv_fac G F L)
 
 end
 
@@ -152,7 +167,7 @@ section
 variable [PreservesPointwiseLeftKanExtension G F L] [L.HasPointwiseLeftKanExtension F]
 
 @[reassoc (attr := simp)]
-lemma pointwiseLeftKanExtensionCompIsoOfPreserves_fac :
+lemma pointwiseLeftKanExtensionCompIsoOfPreserves_hom_fac :
     whiskerRight (L.pointwiseLeftKanExtensionUnit F) G ≫ (Functor.associator _ _ _).hom ≫
       whiskerLeft L (pointwiseLeftKanExtensionCompIsoOfPreserves G F L).hom =
     (L.pointwiseLeftKanExtensionUnit <| F ⋙ G) := by
@@ -161,12 +176,27 @@ lemma pointwiseLeftKanExtensionCompIsoOfPreserves_fac :
     (β := L.pointwiseLeftKanExtensionUnit (F ⋙ G))
 
 @[reassoc]
-lemma pointwiseLeftKanExtensionCompIsoOfPreserves_fac_app (a : A) :
+lemma pointwiseLeftKanExtensionCompIsoOfPreserves_hom_fac_app (a : A) :
     G.map ((L.pointwiseLeftKanExtensionUnit F).app a) ≫
       (G.pointwiseLeftKanExtensionCompIsoOfPreserves F L).hom.app (L.obj a) =
     (L.pointwiseLeftKanExtensionUnit (F ⋙ G)).app a := by
-  simpa [- pointwiseLeftKanExtensionCompIsoOfPreserves_fac] using congrArg (fun t ↦ t.app a)
-    (pointwiseLeftKanExtensionCompIsoOfPreserves_fac G F L)
+  simpa [- pointwiseLeftKanExtensionCompIsoOfPreserves_hom_fac] using congrArg (fun t ↦ t.app a)
+    (pointwiseLeftKanExtensionCompIsoOfPreserves_hom_fac G F L)
+
+@[reassoc (attr := simp)]
+lemma pointwiseLeftKanExtensionCompIsoOfPreserves_inv_fac :
+    (L.pointwiseLeftKanExtensionUnit <| F ⋙ G) ≫
+      whiskerLeft L (pointwiseLeftKanExtensionCompIsoOfPreserves G F L).inv =
+    whiskerRight (L.pointwiseLeftKanExtensionUnit F) G ≫ (Functor.associator _ _ _).hom := by
+  simp [pointwiseLeftKanExtensionCompIsoOfPreserves]
+
+@[reassoc]
+lemma pointwiseLeftKanExtensionCompIsoOfPreserves_fac_app (a : A) :
+    (L.pointwiseLeftKanExtensionUnit (F ⋙ G)).app a ≫
+      (G.pointwiseLeftKanExtensionCompIsoOfPreserves F L).inv.app (L.obj a) =
+    G.map ((L.pointwiseLeftKanExtensionUnit F).app a) := by
+  simpa [-pointwiseLeftKanExtensionCompIsoOfPreserves_inv_fac] using congrArg (fun t ↦ t.app a)
+    (pointwiseLeftKanExtensionCompIsoOfPreserves_inv_fac G F L)
 
 end
 
@@ -268,18 +298,33 @@ section
 variable [PreservesRightKanExtension G F L] [L.HasRightKanExtension F]
 
 @[reassoc (attr := simp)]
-lemma rightKanExtensionCompIsoOfPreserves_fac :
+lemma rightKanExtensionCompIsoOfPreserves_hom_fac :
     whiskerLeft L (rightKanExtensionCompIsoOfPreserves G F L).hom ≫
       (L.rightKanExtensionCounit <| F ⋙ G) =
     ((Functor.associator _ _ _).inv ≫ whiskerRight (L.rightKanExtensionCounit F) G):= by
   simp [rightKanExtensionCompIsoOfPreserves]
 
 @[reassoc (attr := simp)]
-lemma rightKanExtensionCompIsoOfPreserves_fac_app (a : A) :
+lemma rightKanExtensionCompIsoOfPreserves_hom_fac_app (a : A) :
     (G.rightKanExtensionCompIsoOfPreserves F L).hom.app (L.obj a) ≫
       (L.rightKanExtensionCounit (F ⋙ G)).app a =
     G.map ((L.rightKanExtensionCounit F).app a) := by
   simp [rightKanExtensionCompIsoOfPreserves]
+
+@[reassoc (attr := simp)]
+lemma rightKanExtensionCompIsoOfPreserves_inv_fac :
+    whiskerLeft L (rightKanExtensionCompIsoOfPreserves G F L).inv ≫
+      ((Functor.associator _ _ _).inv ≫ whiskerRight (L.rightKanExtensionCounit F) G) =
+    (L.rightKanExtensionCounit <| F ⋙ G) := by
+  simp [rightKanExtensionCompIsoOfPreserves]
+
+@[reassoc (attr := simp)]
+lemma rightKanExtensionCompIsoOfPreserves_inv_fac_app (a : A) :
+    (G.rightKanExtensionCompIsoOfPreserves F L).inv.app (L.obj a) ≫
+      G.map ((L.rightKanExtensionCounit F).app a) =
+    (L.rightKanExtensionCounit (F ⋙ G)).app a := by
+  simpa [-rightKanExtensionCompIsoOfPreserves_inv_fac] using
+    congrArg (fun t ↦ t.app a) <| rightKanExtensionCompIsoOfPreserves_inv_fac G F L
 
 end
 
@@ -322,19 +367,34 @@ variable [PreservesPointwiseRightKanExtension G F L]
     [L.HasPointwiseRightKanExtension F]
 
 @[reassoc (attr := simp)]
-lemma pointwiseRightKanExtensionCompIsoOfPreserves_fac :
+lemma pointwiseRightKanExtensionCompIsoOfPreserves_hom_fac :
     whiskerLeft L (pointwiseRightKanExtensionCompIsoOfPreserves G F L).hom ≫
       (L.pointwiseRightKanExtensionCounit <| F ⋙ G) =
     ((Functor.associator _ _ _).inv ≫ whiskerRight (L.pointwiseRightKanExtensionCounit F) G):= by
   simp [pointwiseRightKanExtensionCompIsoOfPreserves]
 
 @[reassoc]
-lemma pointwiseRightKanExtensionCompIsoOfPreserves_fac_app (a : A) :
+lemma pointwiseRightKanExtensionCompIsoOfPreserves_hom_fac_app (a : A) :
     (G.pointwiseRightKanExtensionCompIsoOfPreserves F L).hom.app (L.obj a) ≫
       (L.pointwiseRightKanExtensionCounit (F ⋙ G)).app a =
     G.map ((L.pointwiseRightKanExtensionCounit F).app a) := by
-  simpa [-pointwiseRightKanExtensionCompIsoOfPreserves_fac] using
-    congrArg (fun t ↦ t.app a) <| pointwiseRightKanExtensionCompIsoOfPreserves_fac G F L
+  simpa [-pointwiseRightKanExtensionCompIsoOfPreserves_hom_fac] using
+    congrArg (fun t ↦ t.app a) <| pointwiseRightKanExtensionCompIsoOfPreserves_hom_fac G F L
+
+@[reassoc (attr := simp)]
+lemma pointwiseRightKanExtensionCompIsoOfPreserves_inv_fac :
+    whiskerLeft L (pointwiseRightKanExtensionCompIsoOfPreserves G F L).inv ≫
+      ((Functor.associator _ _ _).inv ≫ whiskerRight (L.pointwiseRightKanExtensionCounit F) G) =
+    (L.pointwiseRightKanExtensionCounit <| F ⋙ G) := by
+  simp [pointwiseRightKanExtensionCompIsoOfPreserves]
+
+@[reassoc]
+lemma pointwiseRightKanExtensionCompIsoOfPreserves_inv_fac_app (a : A) :
+    (G.pointwiseRightKanExtensionCompIsoOfPreserves F L).inv.app (L.obj a) ≫
+      G.map ((L.pointwiseRightKanExtensionCounit F).app a) =
+    (L.pointwiseRightKanExtensionCounit (F ⋙ G)).app a := by
+  simpa [-pointwiseRightKanExtensionCompIsoOfPreserves_inv_fac] using
+    congrArg (fun t ↦ t.app a) <| pointwiseRightKanExtensionCompIsoOfPreserves_inv_fac G F L
 
 end
 
@@ -359,9 +419,10 @@ noncomputable def ranFunctorCompOfPreserves [G.PreservesRightKanExtensions L]
         (L.rightKanExtensionCounit <| F' ⋙ G)
       dsimp [ran]
       ext
-      simp only [comp_obj, Category.assoc, rightKanExtensionCompIsoOfPreserves_fac,
+      simp only [comp_obj, Category.assoc, rightKanExtensionCompIsoOfPreserves_hom_fac,
         NatTrans.comp_app, whiskerLeft_app, whiskerRight_app, associator_inv_app, Category.id_comp,
-        liftOfIsRightKanExtension_fac, rightKanExtensionCompIsoOfPreserves_fac_assoc, ← G.map_comp ]
+        liftOfIsRightKanExtension_fac, rightKanExtensionCompIsoOfPreserves_hom_fac_assoc,
+        ← G.map_comp ]
       simp)
 
 end RightKanExtension

--- a/Mathlib/CategoryTheory/Functor/KanExtension/Preserves.lean
+++ b/Mathlib/CategoryTheory/Functor/KanExtension/Preserves.lean
@@ -35,11 +35,11 @@ class PreservesLeftKanExtension where
 `LeftExtension.IsUniversal` instead. -/
 def PreservesLeftKanExtension.mk'
     (preserves : ∀ {E : LeftExtension L F}, E.IsUniversal →
-      Nonempty (LeftExtension.whiskerRight L F G|>.obj E).IsUniversal) :
+      Nonempty (LeftExtension.postcompose₂ L F G|>.obj E).IsUniversal) :
     G.PreservesLeftKanExtension F L where
   preserves _ _ h :=
     ⟨⟨Limits.IsInitial.equivOfIso
-        (LeftExtension.whiskerRightIsoMk _ _) <| (preserves h.nonempty_isUniversal.some).some⟩⟩
+        (LeftExtension.postcompose₂IsoMk _ _) <| (preserves h.nonempty_isUniversal.some).some⟩⟩
 
 attribute [instance] PreservesLeftKanExtension.preserves
 
@@ -48,7 +48,7 @@ extensions of `F` along `L` at the point `c`. -/
 class PreservesPointwiseLeftKanExtensionAt (c : C) where
   /-- `G` preserves every pointwise extensions of `F` along `L` at `c`. -/
   preserves : ∀ (E : LeftExtension L F), E.IsPointwiseLeftKanExtensionAt c →
-    (LeftExtension.whiskerRight L F G|>.obj E).IsPointwiseLeftKanExtensionAt c
+    (LeftExtension.postcompose₂ L F G|>.obj E).IsPointwiseLeftKanExtensionAt c
 
 /-- `G.PreservesLeftKanExtension F L` asserts that `G` preserves all pointwise left kan extensions
 of `F` along `L`. -/
@@ -58,14 +58,14 @@ abbrev PreservesPointwiseLeftKanExtension := ∀ c : C, PreservesPointwiseLeftKa
 `(LeftExtension.whiskerRight L F G).obj E` as a pointwise left Kan extension of `F ⋙ G` at `L`. -/
 def PreservesPointwiseLeftKanExtension.preserves [h : PreservesPointwiseLeftKanExtension G F L]
     (E : LeftExtension L F) (hE : E.IsPointwiseLeftKanExtension) :
-    LeftExtension.whiskerRight L F G|>.obj E|>.IsPointwiseLeftKanExtension := fun c ↦
+    LeftExtension.postcompose₂ L F G|>.obj E|>.IsPointwiseLeftKanExtension := fun c ↦
   (h c).preserves E (hE c)
 
 /-- The cocone at a point of the whiskering right by `G`of an extension is isomorphic to the
 action of `G` on the cocone at that point for the original extension. -/
 @[simps!]
 def LeftExtension.coconeAtWhiskerRightIso (E : LeftExtension L F) (c : C) :
-    ((LeftExtension.whiskerRight L F G).obj E).coconeAt c ≅ G.mapCocone (E.coconeAt c) :=
+    ((LeftExtension.postcompose₂ L F G).obj E).coconeAt c ≅ G.mapCocone (E.coconeAt c) :=
   Limits.Cocones.ext (Iso.refl _)
 
 instance hasLeftKanExtension_of_preserves [L.HasLeftKanExtension F]
@@ -130,7 +130,7 @@ noncomputable instance preservesPointwiseLKEOfHasPointwiseAndPreservesPointwise
     [HasPointwiseLeftKanExtension L F] [G.PreservesPointwiseLeftKanExtension F L] :
     G.PreservesLeftKanExtension F L where
   preserves F' α _ :=
-    (LeftExtension.isPointwiseLeftKanExtensionEquivOfIso (LeftExtension.whiskerRightIsoMk G α) <|
+    (LeftExtension.isPointwiseLeftKanExtensionEquivOfIso (LeftExtension.postcompose₂IsoMk G α) <|
       PreservesPointwiseLeftKanExtension.preserves G F L _ <|
         isPointwiseLeftKanExtensionOfIsLeftKanExtension F' α).isLeftKanExtension
 
@@ -207,11 +207,11 @@ class PreservesRightKanExtension where
 `RightExtension.IsUniversal` instead. -/
 def PreservesRightKanExtension.mk'
     (preserves : ∀ {E : RightExtension L F}, E.IsUniversal →
-      Nonempty (RightExtension.whiskerRight L F G|>.obj E).IsUniversal) :
+      Nonempty (RightExtension.postcompose₂ L F G|>.obj E).IsUniversal) :
     G.PreservesRightKanExtension F L where
   preserves _ _ h :=
     ⟨⟨Limits.IsTerminal.equivOfIso
-        (RightExtension.whiskerRightIsoMk _ _) <| (preserves h.nonempty_isUniversal.some).some⟩⟩
+        (RightExtension.postcompose₂IsoMk _ _) <| (preserves h.nonempty_isUniversal.some).some⟩⟩
 
 attribute [instance] PreservesRightKanExtension.preserves
 
@@ -220,7 +220,7 @@ extensions of `F` along `L` at `c`. -/
 class PreservesPointwiseRightKanExtensionAt (c : C) where
   /-- `G` preserves every pointwise extensions of `F` along `L` at `c`. -/
   preserves : ∀ (E : RightExtension L F), E.IsPointwiseRightKanExtensionAt c →
-    (RightExtension.whiskerRight L F G|>.obj E).IsPointwiseRightKanExtensionAt c
+    (RightExtension.postcompose₂ L F G|>.obj E).IsPointwiseRightKanExtensionAt c
 
 /-- `G.PreservesRightKanExtensions L` asserts that `G` preserves all pointwise right kan
 extensions of `F` along `L` for every `F`. -/
@@ -230,14 +230,14 @@ abbrev PreservesPointwiseRightKanExtension := ∀ c : C, PreservesPointwiseRight
 `(RightExtension.whiskerRight L F G).obj E` as a pointwise left Kan extension of `F ⋙ G` at `L`. -/
 def PreservesPointwiseRightKanExtension.preserves [h : PreservesPointwiseRightKanExtension G F L]
     (E : RightExtension L F) (hE : E.IsPointwiseRightKanExtension) :
-    RightExtension.whiskerRight L F G|>.obj E|>.IsPointwiseRightKanExtension := fun c ↦
+    RightExtension.postcompose₂ L F G|>.obj E|>.IsPointwiseRightKanExtension := fun c ↦
   (h c).preserves E (hE c)
 
 /-- The cocone at a point of the whiskering right by `G`of an extension is isomorphic to the
 action of `G` on the cocone at that point for the original extension. -/
 @[simps!]
 def RightExtension.coneAtWhiskerRightIso (E : RightExtension L F) (c : C) :
-    (RightExtension.whiskerRight L F G|>.obj E).coneAt c ≅ G.mapCone (E.coneAt c) :=
+    (RightExtension.postcompose₂ L F G|>.obj E).coneAt c ≅ G.mapCone (E.coneAt c) :=
   Limits.Cones.ext (Iso.refl _)
 
 instance hasRightKanExtension_of_preserves [L.HasRightKanExtension F]
@@ -299,7 +299,7 @@ noncomputable instance preservesPointwiseRKEOfHasPointwiseAndPreservesPointwise
     [HasPointwiseRightKanExtension L F] [G.PreservesPointwiseRightKanExtension F L] :
     G.PreservesRightKanExtension F L where
   preserves F' α _ :=
-    (RightExtension.isPointwiseRightKanExtensionEquivOfIso (RightExtension.whiskerRightIsoMk G α) <|
+    (RightExtension.isPointwiseRightKanExtensionEquivOfIso (RightExtension.postcompose₂IsoMk G α) <|
       PreservesPointwiseRightKanExtension.preserves G F L _ <|
         isPointwiseRightKanExtensionOfIsRightKanExtension F' α).isRightKanExtension
 

--- a/Mathlib/CategoryTheory/Functor/KanExtension/Preserves.lean
+++ b/Mathlib/CategoryTheory/Functor/KanExtension/Preserves.lean
@@ -10,10 +10,10 @@ import Mathlib.CategoryTheory.Limits.Preserves.Basic
 # Preservation of Kan extensions
 
 Given functors `F : A ⥤ B`, `L : B ⥤ C`, and `G : B ⥤ D`,
-we introduce a typeclass `G.PreservesLeftKanExtension F L`, which encodes the fact that
+we introduce a typeclass `G.PreservesLeftKanExtension F L` which encodes the fact that
 the left/right Kan extension of `F` along `L` is preserved by the functor `G`.
 
-When the Kan extension is pointwise, It suffices that `G` preserves (co)limits of the relevant
+When the Kan extension is pointwise, it suffices that `G` preserves (co)limits of the relevant
 diagrams.
 
 -/
@@ -67,7 +67,7 @@ lemma PreservesLeftKanExtension.mk_of_preserves_universal (E : LeftExtension L F
 
 attribute [instance] PreservesLeftKanExtension.preserves
 
-/-- `G.PreservesLeftKanExtensionAt F L c` asserts that `G` preserves pointwise all left kan
+/-- `G.PreservesLeftKanExtensionAt F L c` asserts that `G` preserves all pointwise left kan
 extensions of `F` along `L` at the point `c`. -/
 class PreservesPointwiseLeftKanExtensionAt (c : C) where
   /-- `G` preserves every pointwise extensions of `F` along `L` at `c`. -/
@@ -91,6 +91,18 @@ action of `G` on the cocone at that point for the original extension. -/
 def LeftExtension.coconeAtWhiskerRightIso (E : LeftExtension L F) (c : C) :
     (LeftExtension.postcompose₂ L F G|>.obj E).coconeAt c ≅ G.mapCocone (E.coconeAt c) :=
   Limits.Cocones.ext (Iso.refl _)
+
+/-- If `G` preserves any pointwise left Kan extension of `F` along `L` at `c`, then it preserves
+all of them. -/
+def PreservesPointwiseLeftKanExtensionAt.mk' (c : C) {E : LeftExtension L F}
+  (hE : E.IsPointwiseLeftKanExtensionAt c)
+  (hGE : (LeftExtension.postcompose₂ L F G|>.obj E).IsPointwiseLeftKanExtensionAt c) :
+    G.PreservesPointwiseLeftKanExtensionAt F L c where
+  preserves E' hE' :=
+    Limits.IsColimit.ofIsoColimit hGE <|
+      (E.coconeAtWhiskerRightIso G F L c) ≪≫
+        (Limits.Cocones.functoriality _ _).mapIso (hE.uniqueUpToIso hE') ≪≫
+        (E'.coconeAtWhiskerRightIso G F L c).symm
 
 instance hasLeftKanExtension_of_preserves [L.HasLeftKanExtension F]
     [PreservesLeftKanExtension G F L] : L.HasLeftKanExtension (F ⋙ G) :=
@@ -304,19 +316,31 @@ class PreservesPointwiseRightKanExtensionAt (c : C) where
 extensions of `F` along `L` for every `F`. -/
 abbrev PreservesPointwiseRightKanExtension := ∀ c : C, PreservesPointwiseRightKanExtensionAt G F L c
 
-/-- Given a pointwise left kan extension of `F` at `L`, exhibits
-`(RightExtension.whiskerRight L F G).obj E` as a pointwise left Kan extension of `F ⋙ G` at `L`. -/
+/-- Given a pointwise right kan extension of `F` at `L`, exhibits
+`(RightExtension.whiskerRight L F G).obj E` as a pointwise right Kan extension of `F ⋙ G` at `L`. -/
 def PreservesPointwiseRightKanExtension.preserves [h : PreservesPointwiseRightKanExtension G F L]
     (E : RightExtension L F) (hE : E.IsPointwiseRightKanExtension) :
     RightExtension.postcompose₂ L F G|>.obj E|>.IsPointwiseRightKanExtension := fun c ↦
   (h c).preserves E (hE c)
 
-/-- The cocone at a point of the whiskering right by `G`of an extension is isomorphic to the
-action of `G` on the cocone at that point for the original extension. -/
+/-- The cone at a point of the whiskering right by `G`of an extension is isomorphic to the
+action of `G` on the cone at that point for the original extension. -/
 @[simps!]
 def RightExtension.coneAtWhiskerRightIso (E : RightExtension L F) (c : C) :
     (RightExtension.postcompose₂ L F G|>.obj E).coneAt c ≅ G.mapCone (E.coneAt c) :=
   Limits.Cones.ext (Iso.refl _)
+
+/-- If `G` preserves any pointwise right Kan extension of `F` along `L` at `c`, then it preserves
+all of them. -/
+def PreservesPointwiseRightKanExtensionAt.mk' (c : C) {E : RightExtension L F}
+  (hE : E.IsPointwiseRightKanExtensionAt c)
+  (hGE : (RightExtension.postcompose₂ L F G|>.obj E).IsPointwiseRightKanExtensionAt c) :
+    G.PreservesPointwiseRightKanExtensionAt F L c where
+  preserves E' hE' :=
+    Limits.IsLimit.ofIsoLimit hGE <|
+      (E.coneAtWhiskerRightIso G F L c) ≪≫
+        (Limits.Cones.functoriality _ _).mapIso (hE.uniqueUpToIso hE') ≪≫
+        (E'.coneAtWhiskerRightIso G F L c).symm
 
 instance hasRightKanExtension_of_preserves [L.HasRightKanExtension F]
     [PreservesRightKanExtension G F L] : L.HasRightKanExtension (F ⋙ G) :=
@@ -330,8 +354,8 @@ instance hasPointwiseRightKanExtension_of_preserves [L.HasPointwiseRightKanExten
   (PreservesPointwiseRightKanExtension.preserves G F L _
     <| pointwiseRightKanExtensionIsPointwiseRightKanExtension L F).hasPointwiseRightKanExtension
 
-/-- Extract an isomorphism `(rightKanExtension L F) ⋙ G ≅ rightKanExtension L (F ⋙ G)` when `G`
-preserves left Kan extensions. -/
+/-- Extract an isomorphism `rightKanExtension L F ⋙ G ≅ rightKanExtension L (F ⋙ G)` when `G`
+preserves right Kan extensions. -/
 noncomputable def rightKanExtensionCompIsoOfPreserves [PreservesRightKanExtension G F L]
     [L.HasRightKanExtension F] :
     L.rightKanExtension F ⋙ G ≅ L.rightKanExtension (F ⋙ G) :=
@@ -356,7 +380,7 @@ lemma rightKanExtensionCompIsoOfPreserves_hom_fac :
 lemma rightKanExtensionCompIsoOfPreserves_hom_fac_app (a : A) :
     (G.rightKanExtensionCompIsoOfPreserves F L).hom.app (L.obj a) ≫
       (L.rightKanExtensionCounit (F ⋙ G)).app a =
-    G.map ((L.rightKanExtensionCounit F).app a) := by
+    G.map (L.rightKanExtensionCounit F|>.app a) := by
   simp [rightKanExtensionCompIsoOfPreserves]
 
 @[reassoc (attr := simp)]
@@ -369,14 +393,14 @@ lemma rightKanExtensionCompIsoOfPreserves_inv_fac :
 @[reassoc (attr := simp)]
 lemma rightKanExtensionCompIsoOfPreserves_inv_fac_app (a : A) :
     (G.rightKanExtensionCompIsoOfPreserves F L).inv.app (L.obj a) ≫
-      G.map ((L.rightKanExtensionCounit F).app a) =
+      G.map (L.rightKanExtensionCounit F|>.app a) =
     (L.rightKanExtensionCounit (F ⋙ G)).app a := by
   simpa [-rightKanExtensionCompIsoOfPreserves_inv_fac] using
     congrArg (fun t ↦ t.app a) <| rightKanExtensionCompIsoOfPreserves_inv_fac G F L
 
 end
 
-/-- A functor that preserves the colimit of `(StructuredArrow.proj L c ⋙ F)` preserves
+/-- A functor that preserves the limit of `(StructuredArrow.proj L c ⋙ F)` preserves
 the pointwise right kan extension of `F` along `L` at c. -/
 noncomputable instance preservesPointwiseRightKanExtensionAtOfPreservesColimit (c : C)
     [Limits.PreservesLimit (StructuredArrow.proj c L ⋙ F) G] :
@@ -397,7 +421,7 @@ noncomputable instance preservesPointwiseRKEOfHasPointwiseAndPreservesPointwise
         isPointwiseRightKanExtensionOfIsRightKanExtension F' α).isRightKanExtension
 
 /-- Extract an isomorphism
-`(pointwiseRightKanExtension L F) ⋙ G ≅ pointwiseRightKanExtension L (F ⋙ G)` when `G` preserves
+`L.pointwiseRightKanExtension F ⋙ G ≅ L.pointwiseRightKanExtension (F ⋙ G)` when `G` preserves
 right Kan extensions. -/
 noncomputable def pointwiseRightKanExtensionCompIsoOfPreserves
     [PreservesPointwiseRightKanExtension G F L]

--- a/Mathlib/CategoryTheory/Functor/KanExtension/Preserves.lean
+++ b/Mathlib/CategoryTheory/Functor/KanExtension/Preserves.lean
@@ -89,7 +89,7 @@ def PreservesPointwiseLeftKanExtension.preserves [h : PreservesPointwiseLeftKanE
 action of `G` on the cocone at that point for the original extension. -/
 @[simps!]
 def LeftExtension.coconeAtWhiskerRightIso (E : LeftExtension L F) (c : C) :
-    ((LeftExtension.postcompose₂ L F G).obj E).coconeAt c ≅ G.mapCocone (E.coconeAt c) :=
+    (LeftExtension.postcompose₂ L F G|>.obj E).coconeAt c ≅ G.mapCocone (E.coconeAt c) :=
   Limits.Cocones.ext (Iso.refl _)
 
 instance hasLeftKanExtension_of_preserves [L.HasLeftKanExtension F]
@@ -197,13 +197,13 @@ lemma pointwiseLeftKanExtensionCompIsoOfPreserves_hom_fac :
     (L.pointwiseLeftKanExtensionUnit <| F ⋙ G) := by
   simpa [pointwiseLeftKanExtensionCompIsoOfPreserves] using descOfIsLeftKanExtension_fac
     (α := whiskerRight (L.pointwiseLeftKanExtensionUnit F) G ≫ (Functor.associator _ _ _).hom)
-    (β := L.pointwiseLeftKanExtensionUnit (F ⋙ G))
+    (β := L.pointwiseLeftKanExtensionUnit <| F ⋙ G)
 
 @[reassoc]
 lemma pointwiseLeftKanExtensionCompIsoOfPreserves_hom_fac_app (a : A) :
     G.map ((L.pointwiseLeftKanExtensionUnit F).app a) ≫
       (G.pointwiseLeftKanExtensionCompIsoOfPreserves F L).hom.app (L.obj a) =
-    (L.pointwiseLeftKanExtensionUnit (F ⋙ G)).app a := by
+    (L.pointwiseLeftKanExtensionUnit <| F ⋙ G).app a := by
   simpa [- pointwiseLeftKanExtensionCompIsoOfPreserves_hom_fac] using congrArg (fun t ↦ t.app a)
     (pointwiseLeftKanExtensionCompIsoOfPreserves_hom_fac G F L)
 
@@ -216,9 +216,9 @@ lemma pointwiseLeftKanExtensionCompIsoOfPreserves_inv_fac :
 
 @[reassoc]
 lemma pointwiseLeftKanExtensionCompIsoOfPreserves_fac_app (a : A) :
-    (L.pointwiseLeftKanExtensionUnit (F ⋙ G)).app a ≫
+    (L.pointwiseLeftKanExtensionUnit <| F ⋙ G).app a ≫
       (G.pointwiseLeftKanExtensionCompIsoOfPreserves F L).inv.app (L.obj a) =
-    G.map ((L.pointwiseLeftKanExtensionUnit F).app a) := by
+    G.map (L.pointwiseLeftKanExtensionUnit F|>.app a) := by
   simpa [-pointwiseLeftKanExtensionCompIsoOfPreserves_inv_fac] using congrArg (fun t ↦ t.app a)
     (pointwiseLeftKanExtensionCompIsoOfPreserves_inv_fac G F L)
 
@@ -349,7 +349,7 @@ variable [PreservesRightKanExtension G F L] [L.HasRightKanExtension F]
 lemma rightKanExtensionCompIsoOfPreserves_hom_fac :
     whiskerLeft L (rightKanExtensionCompIsoOfPreserves G F L).hom ≫
       (L.rightKanExtensionCounit <| F ⋙ G) =
-    ((Functor.associator _ _ _).inv ≫ whiskerRight (L.rightKanExtensionCounit F) G):= by
+    (Functor.associator _ _ _).inv ≫ whiskerRight (L.rightKanExtensionCounit F) G := by
   simp [rightKanExtensionCompIsoOfPreserves]
 
 @[reassoc (attr := simp)]
@@ -418,29 +418,29 @@ variable [PreservesPointwiseRightKanExtension G F L]
 lemma pointwiseRightKanExtensionCompIsoOfPreserves_hom_fac :
     whiskerLeft L (pointwiseRightKanExtensionCompIsoOfPreserves G F L).hom ≫
       (L.pointwiseRightKanExtensionCounit <| F ⋙ G) =
-    ((Functor.associator _ _ _).inv ≫ whiskerRight (L.pointwiseRightKanExtensionCounit F) G):= by
+    (Functor.associator _ _ _).inv ≫ whiskerRight (L.pointwiseRightKanExtensionCounit F) G := by
   simp [pointwiseRightKanExtensionCompIsoOfPreserves]
 
 @[reassoc]
 lemma pointwiseRightKanExtensionCompIsoOfPreserves_hom_fac_app (a : A) :
     (G.pointwiseRightKanExtensionCompIsoOfPreserves F L).hom.app (L.obj a) ≫
-      (L.pointwiseRightKanExtensionCounit (F ⋙ G)).app a =
-    G.map ((L.pointwiseRightKanExtensionCounit F).app a) := by
+      (L.pointwiseRightKanExtensionCounit <| F ⋙ G).app a =
+    G.map (L.pointwiseRightKanExtensionCounit F|>.app a) := by
   simpa [-pointwiseRightKanExtensionCompIsoOfPreserves_hom_fac] using
     congrArg (fun t ↦ t.app a) <| pointwiseRightKanExtensionCompIsoOfPreserves_hom_fac G F L
 
 @[reassoc (attr := simp)]
 lemma pointwiseRightKanExtensionCompIsoOfPreserves_inv_fac :
     whiskerLeft L (pointwiseRightKanExtensionCompIsoOfPreserves G F L).inv ≫
-      ((Functor.associator _ _ _).inv ≫ whiskerRight (L.pointwiseRightKanExtensionCounit F) G) =
+      (Functor.associator _ _ _).inv ≫ whiskerRight (L.pointwiseRightKanExtensionCounit F) G =
     (L.pointwiseRightKanExtensionCounit <| F ⋙ G) := by
   simp [pointwiseRightKanExtensionCompIsoOfPreserves]
 
 @[reassoc]
 lemma pointwiseRightKanExtensionCompIsoOfPreserves_inv_fac_app (a : A) :
     (G.pointwiseRightKanExtensionCompIsoOfPreserves F L).inv.app (L.obj a) ≫
-      G.map ((L.pointwiseRightKanExtensionCounit F).app a) =
-    (L.pointwiseRightKanExtensionCounit (F ⋙ G)).app a := by
+      G.map (L.pointwiseRightKanExtensionCounit F|>.app a) =
+    (L.pointwiseRightKanExtensionCounit <| F ⋙ G).app a := by
   simpa [-pointwiseRightKanExtensionCompIsoOfPreserves_inv_fac] using
     congrArg (fun t ↦ t.app a) <| pointwiseRightKanExtensionCompIsoOfPreserves_inv_fac G F L
 

--- a/Mathlib/CategoryTheory/Functor/KanExtension/Preserves.lean
+++ b/Mathlib/CategoryTheory/Functor/KanExtension/Preserves.lean
@@ -11,10 +11,12 @@ import Mathlib.CategoryTheory.Limits.Preserves.Basic
 
 Given functors `F : A ⥤ B`, `L : B ⥤ C`, and `G : B ⥤ D`,
 we introduce a typeclass `G.PreservesLeftKanExtension F L` which encodes the fact that
-the left/right Kan extension of `F` along `L` is preserved by the functor `G`.
+the left Kan extension of `F` along `L` is preserved by the functor `G`.
 
 When the Kan extension is pointwise, it suffices that `G` preserves (co)limits of the relevant
 diagrams.
+
+We introduce the dual typeclass `G.PreservesRightKanExtension`.
 
 -/
 
@@ -25,7 +27,7 @@ variable {A B C D : Type*} [Category A] [Category B] [Category C] [Category D]
 
 section LeftKanExtension
 
-/-- `G.PreservesLeftKanExtension F L` asserts that `G` preserves all left kan extensions
+/-- `G.PreservesLeftKanExtension F L` asserts that `G` preserves all left Kan extensions
 of `F` along `L`. See `PreservesLeftKanExtension.mk_of_preserves_isLeftKanExtension` for a
 constructor taking a single left Kan extension as input. -/
 class PreservesLeftKanExtension where
@@ -63,22 +65,22 @@ lemma PreservesLeftKanExtension.mk_of_preserves_universal (E : LeftExtension L F
     G.PreservesLeftKanExtension F L :=
   .mk' G F L fun hE' ↦
     ⟨Limits.IsInitial.equivOfIso
-      ((LeftExtension.postcompose₂ L F G).mapIso (Limits.IsInitial.uniqueUpToIso hE hE')) h.some⟩
+      (LeftExtension.postcompose₂ L F G|>.mapIso <| Limits.IsInitial.uniqueUpToIso hE hE') h.some⟩
 
 attribute [instance] PreservesLeftKanExtension.preserves
 
-/-- `G.PreservesLeftKanExtensionAt F L c` asserts that `G` preserves all pointwise left kan
+/-- `G.PreservesLeftKanExtensionAt F L c` asserts that `G` preserves all pointwise left Kan
 extensions of `F` along `L` at the point `c`. -/
 class PreservesPointwiseLeftKanExtensionAt (c : C) where
   /-- `G` preserves every pointwise extensions of `F` along `L` at `c`. -/
   preserves : ∀ (E : LeftExtension L F), E.IsPointwiseLeftKanExtensionAt c →
     (LeftExtension.postcompose₂ L F G|>.obj E).IsPointwiseLeftKanExtensionAt c
 
-/-- `G.PreservesLeftKanExtension F L` asserts that `G` preserves all pointwise left kan extensions
+/-- `G.PreservesLeftKanExtension F L` asserts that `G` preserves all pointwise left Kan extensions
 of `F` along `L`. -/
 abbrev PreservesPointwiseLeftKanExtension := ∀ c : C, PreservesPointwiseLeftKanExtensionAt G F L c
 
-/-- Given a pointwise left kan extension of `F` at `L`, exhibits
+/-- Given a pointwise left Kan extension of `F` at `L`, exhibits
 `(LeftExtension.whiskerRight L F G).obj E` as a pointwise left Kan extension of `F ⋙ G` at `L`. -/
 def PreservesPointwiseLeftKanExtension.preserves [h : PreservesPointwiseLeftKanExtension G F L]
     (E : LeftExtension L F) (hE : E.IsPointwiseLeftKanExtension) :
@@ -136,17 +138,18 @@ lemma leftKanExtensionCompIsoOfPreserves_hom_fac :
     whiskerRight (L.leftKanExtensionUnit F) G ≫ (Functor.associator _ _ _).hom ≫
       whiskerLeft L (leftKanExtensionCompIsoOfPreserves G F L).hom =
     (L.leftKanExtensionUnit <| F ⋙ G) := by
-  simpa [leftKanExtensionCompIsoOfPreserves] using descOfIsLeftKanExtension_fac
-    (α := whiskerRight (L.leftKanExtensionUnit F) G ≫ (Functor.associator _ _ _).hom)
-    (β := L.leftKanExtensionUnit (F ⋙ G))
+  simpa [leftKanExtensionCompIsoOfPreserves] using
+    descOfIsLeftKanExtension_fac
+      (α := whiskerRight (L.leftKanExtensionUnit F) G ≫ (Functor.associator _ _ _).hom)
+      (β := L.leftKanExtensionUnit (F ⋙ G))
 
 @[reassoc (attr := simp)]
 lemma leftKanExtensionCompIsoOfPreserves_hom_fac_app (a : A) :
     G.map ((L.leftKanExtensionUnit F).app a) ≫
       (G.leftKanExtensionCompIsoOfPreserves F L).hom.app (L.obj a) =
     (L.leftKanExtensionUnit (F ⋙ G)).app a := by
-  simpa [- leftKanExtensionCompIsoOfPreserves_hom_fac] using congrArg (fun t ↦ t.app a)
-    (leftKanExtensionCompIsoOfPreserves_hom_fac G F L)
+  simpa [- leftKanExtensionCompIsoOfPreserves_hom_fac] using
+    NatTrans.congr_app (leftKanExtensionCompIsoOfPreserves_hom_fac G F L) a
 
 @[reassoc (attr := simp)]
 lemma leftKanExtensionCompIsoOfPreserves_inv_fac :
@@ -160,13 +163,13 @@ lemma leftKanExtensionCompIsoOfPreserves_inv_fac_app (a : A) :
     (L.leftKanExtensionUnit (F ⋙ G)).app a ≫
       (G.leftKanExtensionCompIsoOfPreserves F L).inv.app (L.obj a) =
     G.map ((L.leftKanExtensionUnit F).app a) := by
-  simpa [- leftKanExtensionCompIsoOfPreserves_inv_fac] using congrArg (fun t ↦ t.app a)
-    (leftKanExtensionCompIsoOfPreserves_inv_fac G F L)
+  simpa [- leftKanExtensionCompIsoOfPreserves_inv_fac] using
+    NatTrans.congr_app (leftKanExtensionCompIsoOfPreserves_inv_fac G F L) a
 
 end
 
-/-- A functor that preserves the colimit of `(CostructuredArrow.proj L c ⋙ F)` preserves
-the pointwise left kan extension of `F` along `L` at c. -/
+/-- A functor that preserves the colimit of `CostructuredArrow.proj L c ⋙ F` preserves
+the pointwise left Kan extension of `F` along `L` at `c`. -/
 noncomputable instance preservesPointwiseLeftKanExtensionAtOfPreservesColimit (c : C)
     [Limits.PreservesColimit (CostructuredArrow.proj L c ⋙ F) G] :
     G.PreservesPointwiseLeftKanExtensionAt F L c where
@@ -207,17 +210,18 @@ lemma pointwiseLeftKanExtensionCompIsoOfPreserves_hom_fac :
     whiskerRight (L.pointwiseLeftKanExtensionUnit F) G ≫ (Functor.associator _ _ _).hom ≫
       whiskerLeft L (pointwiseLeftKanExtensionCompIsoOfPreserves G F L).hom =
     (L.pointwiseLeftKanExtensionUnit <| F ⋙ G) := by
-  simpa [pointwiseLeftKanExtensionCompIsoOfPreserves] using descOfIsLeftKanExtension_fac
-    (α := whiskerRight (L.pointwiseLeftKanExtensionUnit F) G ≫ (Functor.associator _ _ _).hom)
-    (β := L.pointwiseLeftKanExtensionUnit <| F ⋙ G)
+  simpa [pointwiseLeftKanExtensionCompIsoOfPreserves] using
+    descOfIsLeftKanExtension_fac
+      (α := whiskerRight (L.pointwiseLeftKanExtensionUnit F) G ≫ (Functor.associator _ _ _).hom)
+      (β := L.pointwiseLeftKanExtensionUnit <| F ⋙ G)
 
 @[reassoc]
 lemma pointwiseLeftKanExtensionCompIsoOfPreserves_hom_fac_app (a : A) :
     G.map ((L.pointwiseLeftKanExtensionUnit F).app a) ≫
       (G.pointwiseLeftKanExtensionCompIsoOfPreserves F L).hom.app (L.obj a) =
     (L.pointwiseLeftKanExtensionUnit <| F ⋙ G).app a := by
-  simpa [- pointwiseLeftKanExtensionCompIsoOfPreserves_hom_fac] using congrArg (fun t ↦ t.app a)
-    (pointwiseLeftKanExtensionCompIsoOfPreserves_hom_fac G F L)
+  simpa [- pointwiseLeftKanExtensionCompIsoOfPreserves_hom_fac] using
+    NatTrans.congr_app (pointwiseLeftKanExtensionCompIsoOfPreserves_hom_fac G F L) a
 
 @[reassoc (attr := simp)]
 lemma pointwiseLeftKanExtensionCompIsoOfPreserves_inv_fac :
@@ -231,8 +235,8 @@ lemma pointwiseLeftKanExtensionCompIsoOfPreserves_fac_app (a : A) :
     (L.pointwiseLeftKanExtensionUnit <| F ⋙ G).app a ≫
       (G.pointwiseLeftKanExtensionCompIsoOfPreserves F L).inv.app (L.obj a) =
     G.map (L.pointwiseLeftKanExtensionUnit F|>.app a) := by
-  simpa [-pointwiseLeftKanExtensionCompIsoOfPreserves_inv_fac] using congrArg (fun t ↦ t.app a)
-    (pointwiseLeftKanExtensionCompIsoOfPreserves_inv_fac G F L)
+  simpa [-pointwiseLeftKanExtensionCompIsoOfPreserves_inv_fac] using
+    NatTrans.congr_app (pointwiseLeftKanExtensionCompIsoOfPreserves_inv_fac G F L) a
 
 end
 
@@ -263,7 +267,7 @@ end LeftKanExtension
 
 section RightKanExtension
 
-/-- `G.PreservesRightKanExtension F L` asserts that `G` preserves all right kan extensions
+/-- `G.PreservesRightKanExtension F L` asserts that `G` preserves all right Kan extensions
 of `F` along `L`. See `PreservesRightKanExtension.mk_of_preserves_isRightKanExtension` for a
 constructor taking a single right Kan extension as input. -/
 class PreservesRightKanExtension where
@@ -301,22 +305,22 @@ lemma PreservesRightKanExtension.mk_of_preserves_universal (E : RightExtension L
     G.PreservesRightKanExtension F L :=
   .mk' G F L fun hE' ↦
     ⟨Limits.IsTerminal.equivOfIso
-      ((RightExtension.postcompose₂ L F G).mapIso (Limits.IsTerminal.uniqueUpToIso hE hE')) h.some⟩
+      (RightExtension.postcompose₂ L F G|>.mapIso <| Limits.IsTerminal.uniqueUpToIso hE hE') h.some⟩
 
 attribute [instance] PreservesRightKanExtension.preserves
 
-/-- `G.PreservesRightKanExtensionAt F L c` asserts that `G` preserves all right pointwise right kan
+/-- `G.PreservesRightKanExtensionAt F L c` asserts that `G` preserves all right pointwise right Kan
 extensions of `F` along `L` at `c`. -/
 class PreservesPointwiseRightKanExtensionAt (c : C) where
   /-- `G` preserves every pointwise extensions of `F` along `L` at `c`. -/
   preserves : ∀ (E : RightExtension L F), E.IsPointwiseRightKanExtensionAt c →
     (RightExtension.postcompose₂ L F G|>.obj E).IsPointwiseRightKanExtensionAt c
 
-/-- `G.PreservesRightKanExtensions L` asserts that `G` preserves all pointwise right kan
+/-- `G.PreservesRightKanExtensions L` asserts that `G` preserves all pointwise right Kan
 extensions of `F` along `L` for every `F`. -/
 abbrev PreservesPointwiseRightKanExtension := ∀ c : C, PreservesPointwiseRightKanExtensionAt G F L c
 
-/-- Given a pointwise right kan extension of `F` at `L`, exhibits
+/-- Given a pointwise right Kan extension of `F` at `L`, exhibits
 `(RightExtension.whiskerRight L F G).obj E` as a pointwise right Kan extension of `F ⋙ G` at `L`. -/
 def PreservesPointwiseRightKanExtension.preserves [h : PreservesPointwiseRightKanExtension G F L]
     (E : RightExtension L F) (hE : E.IsPointwiseRightKanExtension) :
@@ -396,12 +400,12 @@ lemma rightKanExtensionCompIsoOfPreserves_inv_fac_app (a : A) :
       G.map (L.rightKanExtensionCounit F|>.app a) =
     (L.rightKanExtensionCounit (F ⋙ G)).app a := by
   simpa [-rightKanExtensionCompIsoOfPreserves_inv_fac] using
-    congrArg (fun t ↦ t.app a) <| rightKanExtensionCompIsoOfPreserves_inv_fac G F L
+    NatTrans.congr_app (rightKanExtensionCompIsoOfPreserves_inv_fac G F L) a
 
 end
 
 /-- A functor that preserves the limit of `(StructuredArrow.proj L c ⋙ F)` preserves
-the pointwise right kan extension of `F` along `L` at c. -/
+the pointwise right Kan extension of `F` along `L` at c. -/
 noncomputable instance preservesPointwiseRightKanExtensionAtOfPreservesColimit (c : C)
     [Limits.PreservesLimit (StructuredArrow.proj c L ⋙ F) G] :
     G.PreservesPointwiseRightKanExtensionAt F L c where
@@ -451,7 +455,7 @@ lemma pointwiseRightKanExtensionCompIsoOfPreserves_hom_fac_app (a : A) :
       (L.pointwiseRightKanExtensionCounit <| F ⋙ G).app a =
     G.map (L.pointwiseRightKanExtensionCounit F|>.app a) := by
   simpa [-pointwiseRightKanExtensionCompIsoOfPreserves_hom_fac] using
-    congrArg (fun t ↦ t.app a) <| pointwiseRightKanExtensionCompIsoOfPreserves_hom_fac G F L
+    NatTrans.congr_app (pointwiseRightKanExtensionCompIsoOfPreserves_hom_fac G F L) a
 
 @[reassoc (attr := simp)]
 lemma pointwiseRightKanExtensionCompIsoOfPreserves_inv_fac :
@@ -466,7 +470,7 @@ lemma pointwiseRightKanExtensionCompIsoOfPreserves_inv_fac_app (a : A) :
       G.map (L.pointwiseRightKanExtensionCounit F|>.app a) =
     (L.pointwiseRightKanExtensionCounit <| F ⋙ G).app a := by
   simpa [-pointwiseRightKanExtensionCompIsoOfPreserves_inv_fac] using
-    congrArg (fun t ↦ t.app a) <| pointwiseRightKanExtensionCompIsoOfPreserves_inv_fac G F L
+    NatTrans.congr_app (pointwiseRightKanExtensionCompIsoOfPreserves_inv_fac G F L) a
 
 end
 
@@ -494,7 +498,7 @@ noncomputable def ranFunctorCompOfPreserves [G.PreservesRightKanExtensions L]
       simp only [comp_obj, Category.assoc, rightKanExtensionCompIsoOfPreserves_hom_fac,
         NatTrans.comp_app, whiskerLeft_app, whiskerRight_app, associator_inv_app, Category.id_comp,
         liftOfIsRightKanExtension_fac, rightKanExtensionCompIsoOfPreserves_hom_fac_assoc,
-        ← G.map_comp ]
+        ← G.map_comp]
       simp)
 
 end RightKanExtension


### PR DESCRIPTION
Introduce a typeclass `G.PreservesLeftKanExtension F L` that asserts that a functor `G` preserves the left Kan extension of `F` along a functor `L`. Introduce a pointwise variant, and relate it to the non-pointwise version when pointwise extensions exist.

Show that a functor that preserves the relevant colimits preserve pointwise left Kan extensions. Construct isomorphisms `L.leftKanExtension F ⋙ G ≅ L.leftKanExtension (F ⋙ G)` when `G.PreservesLeftKanExtension F L` holds.  Also construct a functorial version, as an isomorphism `L.lan ⋙ (whiskeringRight _ _ _).obj G ≅ (whiskeringRight _ _ _).obj G ⋙ L.lan`.

All results are dualised to right Kan extensions.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
