### PR TITLE
[Merged by Bors] - chore: remove double spaces between arguments

### DIFF
--- a/Mathlib/Algebra/Homology/ShortComplex/HomologicalComplex.lean
+++ b/Mathlib/Algebra/Homology/ShortComplex/HomologicalComplex.lean
@@ -816,7 +816,7 @@ lemma pOpcycles_opcyclesIsoSc'_hom :
 lemma opcyclesIsoSc'_inv_fromOpcycles :
     (K.opcyclesIsoSc' i j k hi hk).inv ≫ K.fromOpcycles j k =
       (K.sc' i j k).fromOpcycles := by
-  simp only [← cancel_epi (K.sc' i j k).pOpcycles,  pOpcycles_opcyclesIsoSc'_inv_assoc,
+  simp only [← cancel_epi (K.sc' i j k).pOpcycles, pOpcycles_opcyclesIsoSc'_inv_assoc,
     p_fromOpcycles, ShortComplex.p_fromOpcycles, shortComplexFunctor'_obj_g]
 
 /-- The opcycles of a homological complex in degree `j` can be computed

--- a/Mathlib/Algebra/Module/Submodule/Pointwise.lean
+++ b/Mathlib/Algebra/Module/Submodule/Pointwise.lean
@@ -473,7 +473,7 @@ lemma mem_singleton_set_smul [SMulCommClass R S M] (r : S) (x : M) :
     | smul₀ => aesop
     | @smul₁ t n mem h =>
       rcases h with ⟨n, hn, rfl⟩
-      exact ⟨t • n, by aesop,  smul_comm _ _ _⟩
+      exact ⟨t • n, by aesop, smul_comm _ _ _⟩
     | add mem₁ mem₂ h₁ h₂ =>
       rcases h₁ with ⟨m₁, h₁, rfl⟩
       rcases h₂ with ⟨m₂, h₂, rfl⟩

--- a/Mathlib/Algebra/Module/ZLattice/Basic.lean
+++ b/Mathlib/Algebra/Module/ZLattice/Basic.lean
@@ -270,7 +270,7 @@ def quotientEquiv [Fintype ι] :
     exact QuotientAddGroup.leftRel_apply.mp h
   · refine Quotient.inductionOn₂ x y (fun _ _ hxy => ?_)
     rw [Quotient.liftOn_mk (s := quotientRel (span ℤ (Set.range b))), fractRestrict,
-      Quotient.liftOn_mk (s := quotientRel (span ℤ (Set.range b))),  fractRestrict,
+      Quotient.liftOn_mk (s := quotientRel (span ℤ (Set.range b))), fractRestrict,
       Subtype.mk.injEq] at hxy
     apply Quotient.sound'
     rwa [QuotientAddGroup.leftRel_apply, mem_toAddSubgroup, ← fract_eq_fract]

--- a/Mathlib/Algebra/Order/Group/Unbundled/Abs.lean
+++ b/Mathlib/Algebra/Order/Group/Unbundled/Abs.lean
@@ -102,7 +102,7 @@ variable [MulRightMono α]
 
 @[to_additive (attr := simp) abs_nonneg] lemma one_le_mabs (a : α) : 1 ≤ |a|ₘ := by
   apply pow_two_semiclosed _
-  rw [mabs, pow_two, mul_sup,  sup_mul, ← pow_two, inv_mul_cancel, sup_comm, ← sup_assoc]
+  rw [mabs, pow_two, mul_sup, sup_mul, ← pow_two, inv_mul_cancel, sup_comm, ← sup_assoc]
   apply le_sup_right
 
 @[to_additive (attr := simp)] lemma mabs_mabs (a : α) : |(|a|ₘ)|ₘ = |a|ₘ :=

--- a/Mathlib/AlgebraicGeometry/Modules/Tilde.lean
+++ b/Mathlib/AlgebraicGeometry/Modules/Tilde.lean
@@ -105,7 +105,7 @@ noncomputable def sectionsSubmodule (U : (Opens (PrimeSpectrum R))ᵒᵖ) :
     intro a b ha hb x
     rcases ha x with ⟨Va, ma, ia, ra, sa, wa⟩
     rcases hb x with ⟨Vb, mb, ib, rb, sb, wb⟩
-    refine ⟨Va ⊓ Vb, ⟨ma, mb⟩, Opens.infLELeft _ _ ≫ ia,  sb• ra+ sa•rb , sa * sb, ?_⟩
+    refine ⟨Va ⊓ Vb, ⟨ma, mb⟩, Opens.infLELeft _ _ ≫ ia, sb• ra+ sa•rb , sa * sb, ?_⟩
     intro y
     rcases wa (Opens.infLELeft _ _ y : Va) with ⟨nma, wa⟩
     rcases wb (Opens.infLERight _ _ y : Vb) with ⟨nmb, wb⟩

--- a/Mathlib/Analysis/Calculus/ContDiff/Defs.lean
+++ b/Mathlib/Analysis/Calculus/ContDiff/Defs.lean
@@ -482,7 +482,7 @@ theorem ContDiffWithinAt.contDiffOn' (hm : m ≤ n) (h' : m = ∞ → n = ω)
     refine ⟨u, huo, hxu, ?_⟩
     suffices ContDiffOn 𝕜 ω f (insert x s ∩ u) from this.of_le le_top
     intro y hy
-    refine ⟨insert x s ∩ u, ?_, p, hp.mono hut,  fun i ↦ (h'p i).mono hut⟩
+    refine ⟨insert x s ∩ u, ?_, p, hp.mono hut, fun i ↦ (h'p i).mono hut⟩
     simp only [insert_eq_of_mem, hy, self_mem_nhdsWithin]
   · match m with
     | ω => simp [hn] at hm

--- a/Mathlib/Analysis/Normed/Group/Quotient.lean
+++ b/Mathlib/Analysis/Normed/Group/Quotient.lean
@@ -185,7 +185,7 @@ lemma norm_mk_eq_zero [hS : IsClosed (S : Set M)] : ‖(m : M ⧸ S)‖ = 0 ↔ 
 and `‖m‖ < ‖x‖ + ε`. -/
 @[to_additive "For any `x : M ⧸ S` and any `0 < ε`, there is `m : M` such that `mk' S m = x`
 and `‖m‖ < ‖x‖ + ε`."]
-lemma exists_norm_mk_lt (x : M ⧸ S) (hε : 0 < ε) : ∃ m : M,  m = x ∧ ‖m‖ < ‖x‖ + ε :=
+lemma exists_norm_mk_lt (x : M ⧸ S) (hε : 0 < ε) : ∃ m : M, m = x ∧ ‖m‖ < ‖x‖ + ε :=
   norm_lt_iff.1 <| lt_add_of_pos_right _ hε
 
 /-- For any `m : M` and any `0 < ε`, there is `s ∈ S` such that `‖m * s‖ < ‖mk' S m‖ + ε`. -/

--- a/Mathlib/Analysis/Normed/Unbundled/SeminormFromConst.lean
+++ b/Mathlib/Analysis/Normed/Unbundled/SeminormFromConst.lean
@@ -233,7 +233,7 @@ theorem seminormFromConst_apply_c : seminormFromConst' hf1 hc hpm c = f c :=
     have hseq : seminormFromConst_seq c f c = fun _n ↦ f c := by
       ext n
       simp only [seminormFromConst_seq]
-      rw [mul_comm, ← pow_succ, hpm _ le_add_self, pow_succ, mul_comm,  mul_div_assoc,
+      rw [mul_comm, ← pow_succ, hpm _ le_add_self, pow_succ, mul_comm, mul_div_assoc,
         div_self (pow_ne_zero n hc), mul_one]
     rw [hseq]
     exact tendsto_const_nhds

--- a/Mathlib/Analysis/SpecialFunctions/Bernstein.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Bernstein.lean
@@ -216,7 +216,7 @@ theorem bernsteinApproximation_uniform [LocallyConvexSpace ℝ E] (f : C(I, E)) 
       gauge_sum_le hUc (absorbent_nhds_zero hU₀) _ _
     _ = ∑ k : Fin (n + 1), bernstein n k x * gauge U (f k/ₙ - f x) := by
       simp only [gauge_smul_of_nonneg, bernstein_nonneg, smul_eq_mul]
-    _ = (∑ k ∈ S,  bernstein n k x * gauge U (f k/ₙ - f x)) +
+    _ = (∑ k ∈ S, bernstein n k x * gauge U (f k/ₙ - f x)) +
           ∑ k ∈ Sᶜ, bernstein n k x * gauge U (f k/ₙ - f x) :=
       (S.sum_add_sum_compl _).symm
     -- We'll now deal with the terms in `S` and the terms in `Sᶜ` in separate calc blocks.

--- a/Mathlib/CategoryTheory/Abelian/EpiWithInjectiveKernel.lean
+++ b/Mathlib/CategoryTheory/Abelian/EpiWithInjectiveKernel.lean
@@ -44,7 +44,7 @@ lemma epiWithInjectiveKernel_iff {X Y : C} (g : X ⟶ Y) :
       ⟨ShortComplex.Splitting.ofExactOfRetraction S
         (S.exact_of_f_is_kernel (kernelIsKernel g)) (Injective.factorThru (𝟙 _) (kernel.ι g))
         (by simp [S]) inferInstance⟩⟩
-  · rintro ⟨I, _,  f, w, ⟨σ⟩⟩
+  · rintro ⟨I, _, f, w, ⟨σ⟩⟩
     have : IsSplitEpi g := ⟨σ.s, σ.s_g⟩
     let e : I ≅ kernel g :=
       IsLimit.conePointUniqueUpToIso σ.shortExact.fIsKernel (limit.isLimit _)

--- a/Mathlib/CategoryTheory/Bicategory/Functor/LocallyDiscrete.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Functor/LocallyDiscrete.lean
@@ -15,7 +15,7 @@ bicategories.
 Firstly, we define the constructors `pseudofunctorOfIsLocallyDiscrete` and
 `oplaxFunctorOfIsLocallyDiscrete` for defining pseudofunctors and oplax functors
 from a locally discrete bicategories. In this situation, we do not need to care about
-the field `map₂`,  because all the `2`-morphisms in `B` are identities.
+the field `map₂`, because all the `2`-morphisms in `B` are identities.
 
 We also define a specialized constructor `LocallyDiscrete.mkPseudofunctor` when
 the source bicategory is of the form `B := LocallyDiscrete B₀` for a category `B₀`.

--- a/Mathlib/CategoryTheory/Localization/Monoidal.lean
+++ b/Mathlib/CategoryTheory/Localization/Monoidal.lean
@@ -319,7 +319,7 @@ lemma pentagon (Y₁ Y₂ Y₃ Y₄ : LocalizedMonoidal L W ε) :
           (α_ ((L').obj X₁) ((L').obj (X₂ ⊗ X₃)) ((L').obj X₄)).hom :=
     pentagon_aux₂ _ _ _ (μ L W ε X₂ X₃).symm
   rw [associator_hom_app, tensorHom_id, id_tensorHom, associator_hom_app, tensorHom_id,
-    whiskerLeft_comp, whiskerRight_comp,  whiskerRight_comp,  whiskerRight_comp, assoc, assoc,
+    whiskerLeft_comp, whiskerRight_comp, whiskerRight_comp, whiskerRight_comp, assoc, assoc,
     assoc, whiskerRight_comp, assoc,
     reassoc_of% this, associator_hom_app, tensorHom_id,
     ← pentagon_aux₁ (X₂ := (L').obj X₃) (X₃ := (L').obj X₄) (i := μ L W ε X₁ X₂),

--- a/Mathlib/Combinatorics/SimpleGraph/Basic.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Basic.lean
@@ -617,7 +617,7 @@ theorem fromEdgeSet_mono {s t : Set (Sym2 V)} (h : s ⊆ t) : fromEdgeSet s ≤ 
 
 @[simp] lemma disjoint_fromEdgeSet : Disjoint G (fromEdgeSet s) ↔ Disjoint G.edgeSet s := by
   conv_rhs => rw [← Set.diff_union_inter s {e : Sym2 V | e.IsDiag}]
-  rw [← disjoint_edgeSet,  edgeSet_fromEdgeSet, Set.disjoint_union_right, and_iff_left]
+  rw [← disjoint_edgeSet, edgeSet_fromEdgeSet, Set.disjoint_union_right, and_iff_left]
   exact Set.disjoint_left.2 fun e he he' ↦ not_isDiag_of_mem_edgeSet _ he he'.2
 
 @[simp] lemma fromEdgeSet_disjoint : Disjoint (fromEdgeSet s) G ↔ Disjoint s G.edgeSet := by

--- a/Mathlib/Computability/TMToPartrec.lean
+++ b/Mathlib/Computability/TMToPartrec.lean
@@ -855,7 +855,7 @@ theorem tr_ret_respects (k v s) : ∃ b₂,
         (fun x h => Bool.decide_false (trList_ne_consₗ _ _ h)) ⟨rfl, rfl⟩
     refine (move₂_ok (by decide) ?_ (splitAtPred_false _)).trans ?_; · rfl
     simp only [TM2.step, Option.mem_def, Option.elim, elim_update_stack, elim_main,
-      List.append_nil, elim_update_main,  id_eq, elim_update_aux, ne_eq, Function.update_of_ne,
+      List.append_nil, elim_update_main, id_eq, elim_update_aux, ne_eq, Function.update_of_ne,
       elim_aux, elim_stack]
     exact h₂
   | cons₂ ns k IH =>

--- a/Mathlib/Data/List/GetD.lean
+++ b/Mathlib/Data/List/GetD.lean
@@ -66,7 +66,7 @@ theorem getElem?_getD_replicate_default_eq (r n : ℕ) : (replicate r d)[n]?.get
 
 theorem getD_replicate {y i n} (h : i < n) :
     getD (replicate n x) i y = x := by
-  rw [getD_eq_getElem,  getElem_replicate]
+  rw [getD_eq_getElem, getElem_replicate]
   rwa [length_replicate]
 
 theorem getD_append (l l' : List α) (d : α) (n : ℕ) (h : n < l.length) :

--- a/Mathlib/Data/Matroid/Dual.lean
+++ b/Mathlib/Data/Matroid/Dual.lean
@@ -244,7 +244,7 @@ theorem coindep_iff_exists (hX : X ⊆ M.E := by aesop_mat) :
 theorem coindep_iff_subset_compl_isBase : M.Coindep X ↔ ∃ B, M.IsBase B ∧ X ⊆ M.E \ B := by
   simp_rw [coindep_iff_exists', subset_diff]
   exact ⟨fun ⟨⟨B, hB, _, hBX⟩, hX⟩ ↦ ⟨B, hB, hX, hBX.symm⟩,
-    fun ⟨B, hB, hXE, hXB⟩ ↦ ⟨⟨B, hB, hB.subset_ground,  hXB.symm⟩, hXE⟩⟩
+    fun ⟨B, hB, hXE, hXB⟩ ↦ ⟨⟨B, hB, hB.subset_ground, hXB.symm⟩, hXE⟩⟩
 
 @[aesop unsafe 10% (rule_sets := [Matroid])]
 theorem Coindep.subset_ground (hX : M.Coindep X) : X ⊆ M.E :=

--- a/Mathlib/Data/Matroid/Minor/Order.lean
+++ b/Mathlib/Data/Matroid/Minor/Order.lean
@@ -19,9 +19,9 @@ instead writing `N ≤m M` and `N <m M` for more convenient dot notation.
 
 # Main Declarations
 
-* `Matroid.IsMinor N M`, written `N ≤m M`,  means that `N = M ／ C ＼ D` for some
+* `Matroid.IsMinor N M`, written `N ≤m M`, means that `N = M ／ C ＼ D` for some
   subset `C` and `D` of `M.E`.
-* `Matroid.IsStrictMinor N M`, written `N <m M`,  means that `N = M ／ C ＼ D`
+* `Matroid.IsStrictMinor N M`, written `N <m M`, means that `N = M ／ C ＼ D`
   for some subsets `C` and `D` of `M.E` that are not both nonempty.
 * `Matroid.IsMinor.exists_eq_contract_delete_disjoint` : we can choose `C` and `D` disjoint.
 

--- a/Mathlib/Data/Nat/Log.lean
+++ b/Mathlib/Data/Nat/Log.lean
@@ -134,7 +134,7 @@ theorem log_eq_iff {b m n : ℕ} (h : m ≠ 0 ∨ 1 < b ∧ n ≠ 0) :
   rcases hbn with (hb | rfl)
   · obtain rfl | rfl := le_one_iff_eq_zero_or_eq_one.1 hb
     any_goals
-      simp only [ne_eq, zero_eq, reduceSucc, lt_self_iff_false,  not_lt_zero, false_and, or_false]
+      simp only [ne_eq, zero_eq, reduceSucc, lt_self_iff_false, not_lt_zero, false_and, or_false]
         at h
       simp [h, eq_comm (a := 0), Nat.zero_pow (Nat.pos_iff_ne_zero.2 _)] <;> omega
   · simp [@eq_comm _ 0, hm]

--- a/Mathlib/Data/Nat/Pairing.lean
+++ b/Mathlib/Data/Nat/Pairing.lean
@@ -130,7 +130,7 @@ theorem pair_lt_pair_right (a) {b₁ b₂} (h : b₁ < b₂) : pair a b₁ < pai
 
 theorem pair_lt_max_add_one_sq (m n : ℕ) : pair m n < (max m n + 1) ^ 2 := by
   simp only [pair, Nat.pow_two, Nat.mul_add, Nat.add_mul, Nat.mul_one, Nat.one_mul, Nat.add_assoc]
-  split_ifs <;> simp [Nat.max_eq_left, Nat.max_eq_right, Nat.le_of_lt,  not_lt.1, *] <;> omega
+  split_ifs <;> simp [Nat.max_eq_left, Nat.max_eq_right, Nat.le_of_lt, not_lt.1, *] <;> omega
 
 theorem max_sq_add_min_le_pair (m n : ℕ) : max m n ^ 2 + min m n ≤ pair m n := by
   rw [pair]

--- a/Mathlib/GroupTheory/CoprodI.lean
+++ b/Mathlib/GroupTheory/CoprodI.lean
@@ -426,7 +426,7 @@ private def equivPairAux (i) (w : Word M) : { p : Pair M i // rcons p = w } :=
             tail := w
             fstIdx_ne := ij ▸ h1 }
           property := by subst ij; simp [rcons, h2] }
-      else ⟨⟨1, cons m w h1 h2, by simp [cons, fstIdx, Ne.symm ij]⟩,  by simp [rcons]⟩
+      else ⟨⟨1, cons m w h1 h2, by simp [cons, fstIdx, Ne.symm ij]⟩, by simp [rcons]⟩
 
 /-- The equivalence between words and pairs. Given a word, it decomposes it as a pair by removing
 the first letter if it comes from `M i`. Given a pair, it prepends the head to the tail. -/

--- a/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/ConvexBody.lean
+++ b/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/ConvexBody.lean
@@ -256,7 +256,7 @@ norm and it used to define `convexBodySum`. -/
 noncomputable abbrev convexBodySumFun (x : mixedSpace K) : ℝ := ∑ w, mult w * normAtPlace w x
 
 theorem convexBodySumFun_apply (x : mixedSpace K) :
-    convexBodySumFun x = ∑ w,  mult w * normAtPlace w x := rfl
+    convexBodySumFun x = ∑ w, mult w * normAtPlace w x := rfl
 
 open scoped Classical in
 theorem convexBodySumFun_apply' (x : mixedSpace K) :
@@ -602,7 +602,7 @@ theorem exists_ne_zero_mem_ideal_of_norm_le {B : ℝ}
   obtain ⟨a, ha, rfl⟩ := hx
   refine ⟨a, ha, by simpa using h_nz, ?_⟩
   rw [← rpow_natCast, ← rpow_le_rpow_iff (by simp only [Rat.cast_abs, abs_nonneg])
-      (rpow_nonneg h2 _) h1, ← rpow_mul h2,  mul_inv_cancel₀ (Nat.cast_ne_zero.mpr
+      (rpow_nonneg h2 _) h1, ← rpow_mul h2, mul_inv_cancel₀ (Nat.cast_ne_zero.mpr
       (ne_of_gt finrank_pos)), rpow_one, le_div_iff₀' (Nat.cast_pos.mpr finrank_pos)]
   refine le_trans ?_ ((convexBodySum_mem K B).mp h_mem)
   rw [← le_div_iff₀' (Nat.cast_pos.mpr finrank_pos), ← sum_mult_eq, Nat.cast_sum]

--- a/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/FundamentalCone.lean
+++ b/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/FundamentalCone.lean
@@ -513,7 +513,7 @@ def idealSetEquiv : idealSet K J ≃
     ⟨fun _ _ h ↦ (by
         simp_rw [Subtype.ext_iff_val, idealSetMap_apply] at h
         rwa [Subtype.ext_iff_val]),
-    fun ⟨a, ha₂⟩ ↦ ⟨⟨a.val,  mem_idealSet.mpr ⟨a.prop.1,
+    fun ⟨a, ha₂⟩ ↦ ⟨⟨a.val, mem_idealSet.mpr ⟨a.prop.1,
         ⟨preimageOfMemIntegerSet a, ha₂, mixedEmbedding_preimageOfMemIntegerSet a⟩⟩⟩, rfl⟩⟩
 
 variable {K J}

--- a/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/NormLeOne.lean
+++ b/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/NormLeOne.lean
@@ -376,7 +376,7 @@ theorem sum_eq_zero_of_mem_span_completeFamily {x : realSpace K}
   induction hx using Submodule.span_induction with
   | mem _ h =>
       obtain ⟨w, rfl⟩ := h
-      simp_rw [completeFamily,  dif_neg w.prop, sum_expMap_symm_apply (coe_ne_zero _),
+      simp_rw [completeFamily, dif_neg w.prop, sum_expMap_symm_apply (coe_ne_zero _),
         Units.norm, Rat.cast_one, Real.log_one]
   | zero => simp
   | add _ _ _ _ hx hy => simp [sum_add_distrib, hx, hy]

--- a/Mathlib/NumberTheory/SmoothNumbers.lean
+++ b/Mathlib/NumberTheory/SmoothNumbers.lean
@@ -449,7 +449,7 @@ lemma eq_prod_primes_mul_sq_of_mem_smoothNumbers {n k : ℕ} (h : n ∈ smoothNu
     ∃ s ∈ k.primesBelow.powerset, ∃ m, n = m ^ 2 * (s.prod id) := by
   obtain ⟨l, m, H₁, H₂⟩ := sq_mul_squarefree n
   have hl : l ∈ smoothNumbers k := mem_smoothNumbers_of_dvd h (Dvd.intro_left (m ^ 2) H₁)
-  refine ⟨l.primeFactorsList.toFinset, ?_,  m, ?_⟩
+  refine ⟨l.primeFactorsList.toFinset, ?_, m, ?_⟩
   · simp only [toFinset_factors, Finset.mem_powerset]
     refine fun p hp ↦ mem_primesBelow.mpr ⟨?_, (mem_primeFactors.mp hp).1⟩
     rw [mem_primeFactors] at hp

--- a/Mathlib/Probability/Kernel/MeasurableIntegral.lean
+++ b/Mathlib/Probability/Kernel/MeasurableIntegral.lean
@@ -101,7 +101,7 @@ theorem StronglyMeasurable.integral_kernel_prod_right ⦃f : α → β → E⦄
         apply (hfx.norm.add hfx.norm).mono' (s' n x).aestronglyMeasurable
         filter_upwards with y
         simp_rw [s', SimpleFunc.coe_comp]; exact SimpleFunc.norm_approxOn_zero_le _ _ (x, y) n
-      simp only [f',  hfx, SimpleFunc.integral_eq_integral _ (this _), indicator_of_mem,
+      simp only [f', hfx, SimpleFunc.integral_eq_integral _ (this _), indicator_of_mem,
         mem_setOf_eq]
       refine
         tendsto_integral_of_dominated_convergence (fun y => ‖f x y‖ + ‖f x y‖)

--- a/Mathlib/RingTheory/AdicCompletion/Basic.lean
+++ b/Mathlib/RingTheory/AdicCompletion/Basic.lean
@@ -479,7 +479,7 @@ theorem mk_surjective : Function.Surjective (mk I M) := by
   · intro m n hmn
     rw [SModEq.def, ha m, ← mkQ_apply,
       ← factor_mk (Submodule.smul_mono_left (Ideal.pow_le_pow_right hmn)) (a n),
-      mkQ_apply,  ha n, x.property hmn]
+      mkQ_apply, ha n, x.property hmn]
   · ext n
     simp [ha n]
 

--- a/Mathlib/RingTheory/Ideal/Cotangent.lean
+++ b/Mathlib/RingTheory/Ideal/Cotangent.lean
@@ -125,7 +125,7 @@ theorem cotangentIdeal_square (I : Ideal R) : I.cotangentIdeal ^ 2 = ⊥ := by
 
 lemma mk_mem_cotangentIdeal {I : Ideal R} {x : R} :
     Quotient.mk (I ^ 2) x ∈ I.cotangentIdeal ↔ x ∈ I := by
-  refine ⟨fun ⟨y, hy, e⟩ ↦ ?_,  fun h ↦ ⟨x, h, rfl⟩⟩
+  refine ⟨fun ⟨y, hy, e⟩ ↦ ?_, fun h ↦ ⟨x, h, rfl⟩⟩
   simpa using sub_mem hy (Ideal.pow_le_self two_ne_zero
     ((Ideal.Quotient.mk_eq_mk_iff_sub_mem _ _).mp e))
 

--- a/Mathlib/RingTheory/Ideal/Quotient/PowTransition.lean
+++ b/Mathlib/RingTheory/Ideal/Quotient/PowTransition.lean
@@ -27,7 +27,7 @@ to `R ⧸ I ^ n` induced by the natural inclusion `I ^ n → I ^ m`.
 
 --Since `Mathlib.LinearAlgebra.Quotient.Basic` and `Mathlib.RingTheory.Ideal.Quotient.Defs`
 --do not import each other, and the first file that imports both of them is
---`Mathlib.RingTheory.Ideal.Quotient.Operations`,  which has already established
+--`Mathlib.RingTheory.Ideal.Quotient.Operations`, which has already established
 --the first isomophism theorem and Chinese remainder theorem, we put these pure technical lemmas
 --that involves both `Submodule.mapQ` and `Ideal.Quotient.factor` in this file.
 

--- a/Mathlib/Topology/Connected/PathConnected.lean
+++ b/Mathlib/Topology/Connected/PathConnected.lean
@@ -290,7 +290,7 @@ theorem isPathConnected_iff :
     IsPathConnected F ↔ F.Nonempty ∧ ∀ᵉ (x ∈ F) (y ∈ F), JoinedIn F x y :=
   ⟨fun h =>
     ⟨let ⟨b, b_in, _hb⟩ := h; ⟨b, b_in⟩, h.joinedIn⟩,
-    fun ⟨⟨b, b_in⟩, h⟩ => ⟨b, b_in,  h _ b_in⟩⟩
+    fun ⟨⟨b, b_in⟩, h⟩ => ⟨b, b_in, h _ b_in⟩⟩
 
 /-- If `f` is continuous on `F` and `F` is path-connected, so is `f(F)`. -/
 theorem IsPathConnected.image' (hF : IsPathConnected F)

--- a/Mathlib/Topology/LocalAtTarget.lean
+++ b/Mathlib/Topology/LocalAtTarget.lean
@@ -134,7 +134,7 @@ theorem isOpenMap_iff_restrictPreimage :
 
 theorem isClosedMap_iff_restrictPreimage :
     IsClosedMap f ↔ ∀ i, IsClosedMap ((U i).1.restrictPreimage f) := by
-  refine ⟨fun h i => h.restrictPreimage _,  fun H s hs ↦ ?_⟩
+  refine ⟨fun h i => h.restrictPreimage _, fun H s hs ↦ ?_⟩
   rw [hU.isClosed_iff_coe_preimage]
   intro i
   convert H i _ ⟨⟨_, hs.1, eq_compl_comm.mpr rfl⟩⟩

--- a/Mathlib/Topology/LocallyConstant/Basic.lean
+++ b/Mathlib/Topology/LocallyConstant/Basic.lean
@@ -65,7 +65,7 @@ theorem isClosed_fiber {f : X → Y} (hf : IsLocallyConstant f) (y : Y) : IsClos
   ⟨hf {y}ᶜ⟩
 
 theorem isClopen_fiber {f : X → Y} (hf : IsLocallyConstant f) (y : Y) : IsClopen { x | f x = y } :=
-  ⟨isClosed_fiber hf _,  isOpen_fiber hf _⟩
+  ⟨isClosed_fiber hf _, isOpen_fiber hf _⟩
 
 theorem iff_exists_open (f : X → Y) :
     IsLocallyConstant f ↔ ∀ x, ∃ U : Set X, IsOpen U ∧ x ∈ U ∧ ∀ x' ∈ U, f x' = f x :=


### PR DESCRIPTION
Mathlib style is to have only one space.
This also touches a handful of comments: while subjective, these were *all* such occurrences in mathlib. Starting a bikeshedding thread about those does not seem useful, and (unlike for spaces after periods) there are no competing style rules in other languages either. If that part is controversial, I'll happily revert it.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
