### PR TITLE
[Merged by Bors] - feat(Topology/Sober): add some stacks tags for QuasiSober and related statements

### DIFF
--- a/Mathlib/Topology/Irreducible.lean
+++ b/Mathlib/Topology/Irreducible.lean
@@ -119,7 +119,7 @@ theorem irreducibleComponents_eq_maximals_closed (X : Type*) [TopologicalSpace X
     exact le_trans subset_closure this
 
 @[stacks 004W "part 3"]
-lemma exists_irreducibleComponent_of_Irreducible (s : Set X) (hs : IsIrreducible s) :
+lemma exists_irreducibleComponent_subset_of_isIrreducible (s : Set X) (hs : IsIrreducible s) :
     ∃ u ∈ irreducibleComponents X, s ⊆ u := by
   obtain ⟨u,hu⟩ := exists_preirreducible s hs.isPreirreducible
   use u, ⟨⟨hs.left.mono hu.right.left,hu.left⟩,fun _ h hl => (hu.right.right _ h.right hl).le⟩

--- a/Mathlib/Topology/Irreducible.lean
+++ b/Mathlib/Topology/Irreducible.lean
@@ -119,7 +119,7 @@ theorem irreducibleComponents_eq_maximals_closed (X : Type*) [TopologicalSpace X
     exact le_trans subset_closure this
 
 @[stacks 004W "(3)"]
-lemma exists_irreducibleComponent_subset_of_isIrreducible (s : Set X) (hs : IsIrreducible s) :
+lemma exists_mem_irreducibleComponents_subset_of_isIrreducible (s : Set X) (hs : IsIrreducible s) :
     ∃ u ∈ irreducibleComponents X, s ⊆ u := by
   obtain ⟨u,hu⟩ := exists_preirreducible s hs.isPreirreducible
   use u, ⟨⟨hs.left.mono hu.right.left,hu.left⟩,fun _ h hl => (hu.right.right _ h.right hl).le⟩

--- a/Mathlib/Topology/Irreducible.lean
+++ b/Mathlib/Topology/Irreducible.lean
@@ -161,7 +161,7 @@ class PreirreducibleSpace (X : Type*) [TopologicalSpace X] : Prop where
 
 /-- An irreducible space is one that is nonempty
 and where there is no non-trivial pair of disjoint opens. -/
-@[stacks 004V "part 1, predicate on a Space"]
+@[stacks 004V "part 1, predicate on a space"]
 class IrreducibleSpace (X : Type*) [TopologicalSpace X] : Prop extends PreirreducibleSpace X where
   toNonempty : Nonempty X
 

--- a/Mathlib/Topology/Irreducible.lean
+++ b/Mathlib/Topology/Irreducible.lean
@@ -42,6 +42,7 @@ def IsPreirreducible (s : Set X) : Prop :=
 
 /-- An irreducible set `s` is one that is nonempty and
 where there is no non-trivial pair of disjoint opens on `s`. -/
+@[stacks 004V "part 1, predicate on subsets of a space"]
 def IsIrreducible (s : Set X) : Prop :=
   s.Nonempty ∧ IsPreirreducible s
 
@@ -68,6 +69,7 @@ theorem isPreirreducible_iff_closure : IsPreirreducible (closure s) ↔ IsPreirr
     iterate 3 rw [closure_inter_open_nonempty_iff]
     exacts [hu.inter hv, hv, hu]
 
+@[stacks 004W "part 1"]
 theorem isIrreducible_iff_closure : IsIrreducible (closure s) ↔ IsIrreducible s :=
   and_congr closure_nonempty_iff isPreirreducible_iff_closure
 
@@ -95,9 +97,11 @@ theorem exists_preirreducible (s : Set X) (H : IsPreirreducible s) :
   ⟨m, hm.prop, hsm, fun _u hu hmu => (hm.eq_of_subset hu hmu).symm⟩
 
 /-- The set of irreducible components of a topological space. -/
+@[stacks 004V "part 2"]
 def irreducibleComponents (X : Type*) [TopologicalSpace X] : Set (Set X) :=
   {s | Maximal IsIrreducible s}
 
+@[stacks 004W "part 2"]
 theorem isClosed_of_mem_irreducibleComponents (s) (H : s ∈ irreducibleComponents X) :
     IsClosed s := by
   rw [← closure_eq_iff_isClosed, eq_comm]
@@ -114,7 +118,15 @@ theorem irreducibleComponents_eq_maximals_closed (X : Type*) [TopologicalSpace X
     have : closure x ≤ s := H.2 ⟨isClosed_closure, h.closure⟩ (e.trans subset_closure)
     exact le_trans subset_closure this
 
+@[stacks 004W "part 3"]
+lemma exists_irreducibleComponent_of_Irreducible (s : Set X) (hs : IsIrreducible s) :
+    ∃ u ∈ irreducibleComponents X, s ⊆ u := by
+  obtain ⟨u,hu⟩ := exists_preirreducible s hs.isPreirreducible
+  use u, ⟨⟨hs.left.mono hu.right.left,hu.left⟩,fun _ h hl => (hu.right.right _ h.right hl).le⟩
+  exact hu.right.left
+
 /-- A maximal irreducible set that contains a given point. -/
+@[stacks 004W "part 4"]
 def irreducibleComponent (x : X) : Set X :=
   Classical.choose (exists_preirreducible {x} isPreirreducible_singleton)
 
@@ -124,6 +136,7 @@ theorem irreducibleComponent_property (x : X) :
         ∀ u, IsPreirreducible u → irreducibleComponent x ⊆ u → u = irreducibleComponent x :=
   Classical.choose_spec (exists_preirreducible {x} isPreirreducible_singleton)
 
+@[stacks 004W "part 4"]
 theorem mem_irreducibleComponent {x : X} : x ∈ irreducibleComponent x :=
   singleton_subset_iff.1 (irreducibleComponent_property x).2.1
 
@@ -148,6 +161,7 @@ class PreirreducibleSpace (X : Type*) [TopologicalSpace X] : Prop where
 
 /-- An irreducible space is one that is nonempty
 and where there is no non-trivial pair of disjoint opens. -/
+@[stacks 004V "part 1, predicate on a Space"]
 class IrreducibleSpace (X : Type*) [TopologicalSpace X] : Prop extends PreirreducibleSpace X where
   toNonempty : Nonempty X
 
@@ -191,6 +205,7 @@ theorem IsPreirreducible.image (H : IsPreirreducible s) (f : X → Y) (hf : Cont
     show x ∈ _ ∩ s
     simp [*]
 
+@[stacks 0379]
 theorem IsIrreducible.image (H : IsIrreducible s) (f : X → Y) (hf : ContinuousOn f s) :
     IsIrreducible (f '' s) :=
   ⟨H.nonempty.image _, H.isPreirreducible.image f hf⟩

--- a/Mathlib/Topology/Irreducible.lean
+++ b/Mathlib/Topology/Irreducible.lean
@@ -42,7 +42,7 @@ def IsPreirreducible (s : Set X) : Prop :=
 
 /-- An irreducible set `s` is one that is nonempty and
 where there is no non-trivial pair of disjoint opens on `s`. -/
-@[stacks 004V "part 1, predicate on subsets of a space"]
+@[stacks 004V "(1) as predicate on subsets of a space"]
 def IsIrreducible (s : Set X) : Prop :=
   s.Nonempty ∧ IsPreirreducible s
 
@@ -69,7 +69,7 @@ theorem isPreirreducible_iff_closure : IsPreirreducible (closure s) ↔ IsPreirr
     iterate 3 rw [closure_inter_open_nonempty_iff]
     exacts [hu.inter hv, hv, hu]
 
-@[stacks 004W "part 1"]
+@[stacks 004W "(1)"]
 theorem isIrreducible_iff_closure : IsIrreducible (closure s) ↔ IsIrreducible s :=
   and_congr closure_nonempty_iff isPreirreducible_iff_closure
 
@@ -97,11 +97,11 @@ theorem exists_preirreducible (s : Set X) (H : IsPreirreducible s) :
   ⟨m, hm.prop, hsm, fun _u hu hmu => (hm.eq_of_subset hu hmu).symm⟩
 
 /-- The set of irreducible components of a topological space. -/
-@[stacks 004V "part 2"]
+@[stacks 004V "(2)"]
 def irreducibleComponents (X : Type*) [TopologicalSpace X] : Set (Set X) :=
   {s | Maximal IsIrreducible s}
 
-@[stacks 004W "part 2"]
+@[stacks 004W "(2)"]
 theorem isClosed_of_mem_irreducibleComponents (s) (H : s ∈ irreducibleComponents X) :
     IsClosed s := by
   rw [← closure_eq_iff_isClosed, eq_comm]
@@ -118,7 +118,7 @@ theorem irreducibleComponents_eq_maximals_closed (X : Type*) [TopologicalSpace X
     have : closure x ≤ s := H.2 ⟨isClosed_closure, h.closure⟩ (e.trans subset_closure)
     exact le_trans subset_closure this
 
-@[stacks 004W "part 3"]
+@[stacks 004W "(3)"]
 lemma exists_irreducibleComponent_subset_of_isIrreducible (s : Set X) (hs : IsIrreducible s) :
     ∃ u ∈ irreducibleComponents X, s ⊆ u := by
   obtain ⟨u,hu⟩ := exists_preirreducible s hs.isPreirreducible
@@ -126,7 +126,7 @@ lemma exists_irreducibleComponent_subset_of_isIrreducible (s : Set X) (hs : IsIr
   exact hu.right.left
 
 /-- A maximal irreducible set that contains a given point. -/
-@[stacks 004W "part 4"]
+@[stacks 004W "(4)"]
 def irreducibleComponent (x : X) : Set X :=
   Classical.choose (exists_preirreducible {x} isPreirreducible_singleton)
 
@@ -136,7 +136,7 @@ theorem irreducibleComponent_property (x : X) :
         ∀ u, IsPreirreducible u → irreducibleComponent x ⊆ u → u = irreducibleComponent x :=
   Classical.choose_spec (exists_preirreducible {x} isPreirreducible_singleton)
 
-@[stacks 004W "part 4"]
+@[stacks 004W "(4)"]
 theorem mem_irreducibleComponent {x : X} : x ∈ irreducibleComponent x :=
   singleton_subset_iff.1 (irreducibleComponent_property x).2.1
 
@@ -161,7 +161,7 @@ class PreirreducibleSpace (X : Type*) [TopologicalSpace X] : Prop where
 
 /-- An irreducible space is one that is nonempty
 and where there is no non-trivial pair of disjoint opens. -/
-@[stacks 004V "part 1, predicate on a space"]
+@[stacks 004V "(1) as predicate on a space"]
 class IrreducibleSpace (X : Type*) [TopologicalSpace X] : Prop extends PreirreducibleSpace X where
   toNonempty : Nonempty X
 

--- a/Mathlib/Topology/Separation/Basic.lean
+++ b/Mathlib/Topology/Separation/Basic.lean
@@ -69,7 +69,7 @@ section Separation
 /-- A T₀ space, also known as a Kolmogorov space, is a topological space such that for every pair
 `x ≠ y`, there is an open set containing one but not the other. We formulate the definition in terms
 of the `Inseparable` relation. -/
-@[stacks 004X]
+@[stacks 004X "(2)"]
 class T0Space (X : Type u) [TopologicalSpace X] : Prop where
   /-- Two inseparable points in a T₀ space are equal. -/
   t0 : ∀ ⦃x y : X⦄, Inseparable x y → x = y

--- a/Mathlib/Topology/Separation/Basic.lean
+++ b/Mathlib/Topology/Separation/Basic.lean
@@ -9,7 +9,7 @@ import Mathlib.Topology.Piecewise
 import Mathlib.Topology.Separation.SeparatedNhds
 import Mathlib.Topology.Compactness.LocallyCompact
 import Mathlib.Topology.Bases
-
+import Mathlib.Tactic.StacksAttribute
 /-!
 # Separation properties of topological spaces
 
@@ -68,6 +68,7 @@ section Separation
 /-- A T₀ space, also known as a Kolmogorov space, is a topological space such that for every pair
 `x ≠ y`, there is an open set containing one but not the other. We formulate the definition in terms
 of the `Inseparable` relation. -/
+@[stacks 004X]
 class T0Space (X : Type u) [TopologicalSpace X] : Prop where
   /-- Two inseparable points in a T₀ space are equal. -/
   t0 : ∀ ⦃x y : X⦄, Inseparable x y → x = y
@@ -230,6 +231,7 @@ alias Embedding.t0Space := IsEmbedding.t0Space
 protected theorem Homeomorph.t0Space [TopologicalSpace Y] [T0Space X] (h : X ≃ₜ Y) : T0Space Y :=
   h.symm.isEmbedding.t0Space
 
+@[stacks 0B31 "part 1"]
 instance Subtype.t0Space [T0Space X] {p : X → Prop} : T0Space (Subtype p) :=
   IsEmbedding.subtypeVal.t0Space
 

--- a/Mathlib/Topology/Separation/Basic.lean
+++ b/Mathlib/Topology/Separation/Basic.lean
@@ -10,6 +10,7 @@ import Mathlib.Topology.Separation.SeparatedNhds
 import Mathlib.Topology.Compactness.LocallyCompact
 import Mathlib.Topology.Bases
 import Mathlib.Tactic.StacksAttribute
+
 /-!
 # Separation properties of topological spaces
 

--- a/Mathlib/Topology/Sober.lean
+++ b/Mathlib/Topology/Sober.lean
@@ -101,7 +101,7 @@ end genericPoint
 section Sober
 
 /-- A space is sober if every irreducible closed subset has a generic point. -/
-@[mk_iff, stacks 004X "part 3"]
+@[mk_iff, stacks 004X "(3)"]
 class QuasiSober (α : Type*) [TopologicalSpace α] : Prop where
   sober : ∀ {S : Set α}, IsIrreducible S → IsClosed S → ∃ x, IsGenericPoint x S
 

--- a/Mathlib/Topology/Sober.lean
+++ b/Mathlib/Topology/Sober.lean
@@ -101,7 +101,7 @@ end genericPoint
 section Sober
 
 /-- A space is sober if every irreducible closed subset has a generic point. -/
-@[mk_iff, stacks 004X]
+@[mk_iff, stacks 004X "part 3"]
 class QuasiSober (α : Type*) [TopologicalSpace α] : Prop where
   sober : ∀ {S : Set α}, IsIrreducible S → IsClosed S → ∃ x, IsGenericPoint x S
 

--- a/Mathlib/Topology/Sober.lean
+++ b/Mathlib/Topology/Sober.lean
@@ -31,7 +31,7 @@ variable {α β : Type*} [TopologicalSpace α] [TopologicalSpace β]
 section genericPoint
 
 /-- `x` is a generic point of `S` if `S` is the closure of `x`. -/
-@[stacks 004X]
+@[stacks 004X "(1)"]
 def IsGenericPoint (x : α) (S : Set α) : Prop :=
   closure ({x} : Set α) = S
 

--- a/Mathlib/Topology/Sober.lean
+++ b/Mathlib/Topology/Sober.lean
@@ -31,6 +31,7 @@ variable {α β : Type*} [TopologicalSpace α] [TopologicalSpace β]
 section genericPoint
 
 /-- `x` is a generic point of `S` if `S` is the closure of `x`. -/
+@[stacks 004X]
 def IsGenericPoint (x : α) (S : Set α) : Prop :=
   closure ({x} : Set α) = S
 
@@ -100,7 +101,7 @@ end genericPoint
 section Sober
 
 /-- A space is sober if every irreducible closed subset has a generic point. -/
-@[mk_iff]
+@[mk_iff, stacks 004X]
 class QuasiSober (α : Type*) [TopologicalSpace α] : Prop where
   sober : ∀ {S : Set α}, IsIrreducible S → IsClosed S → ∃ x, IsGenericPoint x S
 


### PR DESCRIPTION
Mark some declarations with stacks tags from stacks section 5.8
Also add the lemma `exists_irreducibleComponent_subset_of_isIrreducible`

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
