### PR TITLE
[Merged by Bors] - feat(GroupTheory): add Regular Wreath Product

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3727,6 +3727,7 @@ import Mathlib.GroupTheory.QuotientGroup.Basic
 import Mathlib.GroupTheory.QuotientGroup.Defs
 import Mathlib.GroupTheory.QuotientGroup.Finite
 import Mathlib.GroupTheory.Rank
+import Mathlib.GroupTheory.RegularWreathProduct
 import Mathlib.GroupTheory.Schreier
 import Mathlib.GroupTheory.SchurZassenhaus
 import Mathlib.GroupTheory.SemidirectProduct

--- a/Mathlib/Algebra/Group/End.lean
+++ b/Mathlib/Algebra/Group/End.lean
@@ -182,7 +182,7 @@ theorem symm_mul (e : Perm α) : e.symm * e = 1 :=
   Equiv.self_trans_symm e
 
 /-- If `α` is equivalent to `β`, then `Perm α` is isomorphic to `Perm β`. -/
-def permCongrHom {α β : Type*} (e : α ≃ β) : Equiv.Perm α ≃* Equiv.Perm β where
+def permCongrHom (e : α ≃ β) : Equiv.Perm α ≃* Equiv.Perm β where
   toFun x := e.symm.trans (x.trans e)
   invFun y := e.trans (y.trans e.symm)
   left_inv _ := by ext; simp

--- a/Mathlib/Algebra/Group/End.lean
+++ b/Mathlib/Algebra/Group/End.lean
@@ -181,6 +181,14 @@ theorem self_trans_inv (e : Perm α) : e.trans e⁻¹ = 1 :=
 theorem symm_mul (e : Perm α) : e.symm * e = 1 :=
   Equiv.self_trans_symm e
 
+/-- If `α` is equivalent to `β`, then `Perm α` is isomorphic to `Perm β`. -/
+def permCongrHom {α β : Type*} (e : α ≃ β) : Equiv.Perm α ≃* Equiv.Perm β where
+  toFun x := e.symm.trans (x.trans e)
+  invFun y := e.trans (y.trans e.symm)
+  left_inv _ := by ext; simp
+  right_inv _ := by ext; simp
+  map_mul' _ _ := by ext; simp
+
 /-! Lemmas about `Equiv.Perm.sumCongr` re-expressed via the group structure. -/
 
 

--- a/Mathlib/Combinatorics/Additive/AP/Three/Behrend.lean
+++ b/Mathlib/Combinatorics/Additive/AP/Three/Behrend.lean
@@ -194,7 +194,7 @@ theorem sum_sq_le_of_mem_box (hx : x ∈ box n d) : ∑ i : Fin n, x i ^ 2 ≤ n
   rw [mem_box] at hx
   have : ∀ i, x i ^ 2 ≤ (d - 1) ^ 2 := fun i =>
     Nat.pow_le_pow_left (Nat.le_sub_one_of_lt (hx i)) _
-  exact (sum_le_card_nsmul univ _ _ fun i _ => this i).trans (by rw [card_fin, smul_eq_mul])
+  exact (sum_le_card_nsmul univ _ _ fun i _ => this i).trans (by rw [Finset.card_fin, smul_eq_mul])
 
 theorem sum_eq : (∑ i : Fin n, d * (2 * d + 1) ^ (i : ℕ)) = ((2 * d + 1) ^ n - 1) / 2 := by
   refine (Nat.div_eq_of_eq_mul_left zero_lt_two ?_).symm

--- a/Mathlib/Data/Nat/Multiplicity.lean
+++ b/Mathlib/Data/Nat/Multiplicity.lean
@@ -160,6 +160,17 @@ theorem emultiplicity_factorial_mul {n p : ℕ} (hp : p.Prime) :
     congr 1
     rw [add_comm, add_assoc]
 
+/- The multiplicity of a prime `p` in `p ^ n` is the sum of `p ^ i`, where `i` ranges between `0`
+  and `n - 1`. -/
+theorem multiplicity_factorial_pow {n p : ℕ} (hp : p.Prime) :
+    multiplicity p (p ^ n).factorial = ∑ i ∈ Finset.range n, p ^ i := by
+  rw [← ENat.coe_inj, ← (Nat.finiteMultiplicity_iff.2
+      ⟨hp.ne_one, (p ^ n).factorial_pos⟩).emultiplicity_eq_multiplicity]
+  induction n with
+  | zero => simp [hp.emultiplicity_one]
+  | succ n h =>
+    rw [pow_succ', hp.emultiplicity_factorial_mul, h, Finset.sum_range_succ, ENat.coe_add]
+
 /-- A prime power divides `n!` iff it is at most the sum of the quotients `n / p ^ i`.
   This sum is expressed over the set `Ico 1 b` where `b` is any bound greater than `log p n` -/
 theorem pow_dvd_factorial_iff {p : ℕ} {n r b : ℕ} (hp : p.Prime) (hbn : log p n < b) :

--- a/Mathlib/GroupTheory/RegularWreathProduct.lean
+++ b/Mathlib/GroupTheory/RegularWreathProduct.lean
@@ -174,8 +174,7 @@ given `D`-set `Λ`. -/
 def toPerm : D ≀ᵣ Q →* Equiv.Perm (Λ × Q) :=
   MulAction.toPermHom (D ≀ᵣ Q) (Λ × Q)
 
-theorem toPermInj [Nonempty Λ] :
-  Function.Injective (toPerm D Q Λ) := MulAction.toPerm_injective
+theorem toPermInj [Nonempty Λ] : Function.Injective (toPerm D Q Λ) := MulAction.toPerm_injective
 
 end perm
 

--- a/Mathlib/GroupTheory/RegularWreathProduct.lean
+++ b/Mathlib/GroupTheory/RegularWreathProduct.lean
@@ -160,7 +160,7 @@ lemma rsmul {w : D ≀ᵣ Q} {p : Λ × Q} :
 
 instance instMulActionRWP : MulAction (D ≀ᵣ Q) (Λ × Q) where
   one_smul := by simp
-  mul_smul := by by simp [smul_smul, mul_assoc]
+  mul_smul := by simp [smul_smul, mul_assoc]
 
 variable [FaithfulSMul D Λ]
 instance instFaithfulSMulRWP : FaithfulSMul (D ≀ᵣ Q) (Λ × Q) where

--- a/Mathlib/GroupTheory/RegularWreathProduct.lean
+++ b/Mathlib/GroupTheory/RegularWreathProduct.lean
@@ -11,7 +11,7 @@ import Mathlib.Algebra.Group.PUnit
 # Regular wreath product
 
 This file defines the regular wreath product of groups, and the canonical maps in and out of the
-product. The regular wreath product of `D` and `Q` is the product of sets with the group
+product. The regular wreath product of `D` and `Q` is the product `(Q → D) × Q` with the group
 `⟨d₁, q₁⟩ * ⟨d₂, q₂⟩ = ⟨d.1 * (fun x => q.1 (d.2⁻¹ * x)), d.2 * q.2⟩`
 
 ## Key definitions

--- a/Mathlib/GroupTheory/RegularWreathProduct.lean
+++ b/Mathlib/GroupTheory/RegularWreathProduct.lean
@@ -158,7 +158,7 @@ lemma rsmul {w : D ≀ᵣ Q} {p : Λ × Q} :
     w • p = ⟨(w.left (w.right * p.2)) • p.1, w.right * p.2⟩ := rfl
 
 instance instMulActionRWP : MulAction (D ≀ᵣ Q) (Λ × Q) where
-  one_smul := by simp;
+  one_smul := by simp
   mul_smul := by simp; intro x y a b; constructor
                  · rw [smul_smul]; group
                  · exact mul_assoc x.right y.right b
@@ -167,11 +167,11 @@ instance instMulActionRWP : MulAction (D ≀ᵣ Q) (Λ × Q) where
 variable [FaithfulSMul D Λ]
 instance instFaithfulSMulRWP : FaithfulSMul (D ≀ᵣ Q) (Λ × Q) where
   eq_of_smul_eq_smul := by
-    simp; intro m₁ m₂ h;
+    simp; intro m₁ m₂ h
     let ⟨a⟩ := ‹Nonempty Λ›
     let ⟨b⟩ := ‹Nonempty Q›
     ext q
-    · have hh := fun a => (h a (m₁.right⁻¹ * q)).1;
+    · have hh := fun a => (h a (m₁.right⁻¹ * q)).1
       rw [← (h a b).2] at hh
       group at hh
       apply FaithfulSMul.eq_of_smul_eq_smul at hh
@@ -261,8 +261,8 @@ lemma mu_eq {p n : ℕ} [Fact (Nat.Prime p)] :
         simp at h2
         simp at h1
         exact h2 h1
-    have h1: ∏ k ∈ S, (k + 1) ≠ 0 := by
-      apply Finset.prod_ne_zero_iff.mpr; intro x hx;
+    have h1 : ∏ k ∈ S, (k + 1) ≠ 0 := by
+      apply Finset.prod_ne_zero_iff.mpr; intro x hx
       exact Ne.symm (Nat.zero_ne_add_one x)
     have h2 : ∏ k ∈ Finset.range (p ^ (n + 1)) \ S, (k + 1) ≠ 0 := by
       apply Finset.prod_ne_zero_iff.mpr; intro x hx; exact Ne.symm (Nat.zero_ne_add_one x)
@@ -290,7 +290,7 @@ lemma mu_eq {p n : ℕ} [Fact (Nat.Prime p)] :
       have aux1 : p * (m₁ + 1) = f m₁ + 1 := Eq.symm (Nat.sub_add_cancel NeZero.one_le)
       have aux2 : p * (m₂ + 1) = f m₂ + 1 := Eq.symm (Nat.sub_add_cancel NeZero.one_le)
       have : p * (m₁ + 1) = p * (m₂ + 1) := by
-        rw [aux1, aux2];
+        rw [aux1, aux2]
         exact congrFun (congrArg HAdd.hAdd h_eq) 1
       exact Nat.succ_inj.mp (Nat.eq_of_mul_eq_mul_left (Nat.pos_of_neZero p) this)
     have hf_inj : Set.InjOn f ↑(Finset.range (p ^ n)) := fun ⦃x₁⦄ a ⦃x₂⦄ a ↦ hf_inj' x₁ x₂
@@ -309,13 +309,13 @@ lemma mu_eq {p n : ℕ} [Fact (Nat.Prime p)] :
         apply Nat.sub_one_lt_of_le aux
         exact hk1
       have x_fun : f (x-1) = k := by
-        apply Nat.eq_sub_of_add_eq at hx;
+        apply Nat.eq_sub_of_add_eq at hx
         have : f (x - 1) = p * (x - 1 + 1) - 1 := rfl
         rw [hx, this, Nat.sub_add_cancel aux]
       use (x - 1); exact ⟨List.mem_range.mpr x_bound, x_fun⟩
     have prod_reindex : ∏ m ∈ Finset.range (p^n), (p * (m + 1)) = ∏ k ∈ S, (k + 1) := by
       apply (Finset.prod_nbij f hf_mem hf_inj hf_surj)
-      intro a ha;
+      intro a ha
       apply (Nat.sub_eq_iff_eq_add NeZero.one_le ).mp; rfl
     rw [← prod_reindex] at res
     have h_prod : (∏ m ∈ Finset.range (p^n), (p * (m + 1))).factorization p =

--- a/Mathlib/GroupTheory/RegularWreathProduct.lean
+++ b/Mathlib/GroupTheory/RegularWreathProduct.lean
@@ -12,7 +12,7 @@ import Mathlib.Algebra.Group.PUnit
 
 This file defines the regular wreath product of groups, and the canonical maps in and out of the
 product. The regular wreath product of `D` and `Q` is the product `(Q → D) × Q` with the group
-`⟨d₁, q₁⟩ * ⟨d₂, q₂⟩ = ⟨d.1 * (fun x => q.1 (d.2⁻¹ * x)), d.2 * q.2⟩`
+`⟨d₁, q₁⟩ * ⟨d₂, q₂⟩ = ⟨d₁ * (fun x => q₁ (d₂⁻¹ * x)), d₂ * q₂⟩`
 
 ## Key definitions
 
@@ -30,7 +30,7 @@ variable (D Q : Type*) [Group D] [Group Q]
 
 /-- The regular wreath product of groups `Q` and `D`.
     It the product `(Q → D) × Q` with the group operation
-  `⟨d₁, q₁⟩ * ⟨d₂, q₂⟩ = ⟨d.1 * (fun x => q.1 (d.2⁻¹ * x)), d.2 * q.2⟩` -/
+  `⟨d₁, q₁⟩ * ⟨d₂, q₂⟩ = ⟨d₁ * (fun x => q₁ (d₂⁻¹ * x)), d₂ * q₂⟩` -/
 @[ext]
 structure RegularWreathProduct where
   /-- The function of Q → D -/

--- a/Mathlib/GroupTheory/RegularWreathProduct.lean
+++ b/Mathlib/GroupTheory/RegularWreathProduct.lean
@@ -16,7 +16,7 @@ product. The regular wreath product of `D` and `Q` is the product `(Q → D) × 
 
 ## Main definitions
 
-* `D ≀ᵣ Q` : The regular wreath product of groups `D` and `Q`.
+* `RegularWreathProduct D Q` : The regular wreath product of groups `D` and `Q`.
 * `rightHom` : The canonical projection `D ≀ᵣ Q →* Q`.
 * `inl` : The canonical map `Q →* D ≀ᵣ Q`.
 * `toPerm` : The homomorphism from `D ≀ᵣ Q` to `Equiv.Perm (Λ × Q)`, where `Λ` is a `D`-set.

--- a/Mathlib/GroupTheory/RegularWreathProduct.lean
+++ b/Mathlib/GroupTheory/RegularWreathProduct.lean
@@ -12,7 +12,7 @@ import Mathlib.Algebra.Group.PUnit
 
 This file defines the regular wreath product of groups, and the canonical maps in and out of the
 product. The regular wreath product of `D` and `Q` is the product `(Q → D) × Q` with the group
-`⟨a₁, a₂⟩ * ⟨b₁, b₂⟩ = ⟨a₁ * (fun x => b₁ (a₂⁻¹ * x)), a₂ * b₂⟩`
+`⟨a₁, a₂⟩ * ⟨b₁, b₂⟩ = ⟨a₁ * (fun x => b₁ (a₂⁻¹ * x)), a₂ * b₂⟩`.
 
 ## Main definitions
 

--- a/Mathlib/GroupTheory/RegularWreathProduct.lean
+++ b/Mathlib/GroupTheory/RegularWreathProduct.lean
@@ -120,9 +120,8 @@ omit [Group D] [Group Q] in
 lemma equivProdInj : Function.Injective (equivProd D Q).toFun := by
   intro a b; simp
 
-instance [Finite D] [Finite Q] : Finite (D ≀ᵣ Q) := by
-  apply (Equiv.finite_iff (equivProd D Q)).mpr
-  apply Finite.instProd
+instance [Finite D] [Finite Q] : Finite (D ≀ᵣ Q) :=
+  Finite.of_equiv _ (equivProd D Q).symm
 
 omit [Group D] [Group Q] in
 theorem card [Finite Q] :

--- a/Mathlib/GroupTheory/RegularWreathProduct.lean
+++ b/Mathlib/GroupTheory/RegularWreathProduct.lean
@@ -185,8 +185,8 @@ universe u
 
 /-- The wreath product of group `G` iterated `n` times. -/
 def IteratedWreathProduct (G : Type u) : (n : ℕ) → Type u
-| Nat.zero => PUnit
-| Nat.succ n => (IteratedWreathProduct G n) ≀ᵣ G
+| 0 => PUnit
+| n + 1 => (IteratedWreathProduct G n) ≀ᵣ G
 
 variable (G : Type u) [inst : Group G]
 variable (n : ℕ)

--- a/Mathlib/GroupTheory/RegularWreathProduct.lean
+++ b/Mathlib/GroupTheory/RegularWreathProduct.lean
@@ -188,20 +188,22 @@ end RegularWreathProduct
 
 section iterated
 
+universe u
+
 /-- The wreath product of group `G` iterated `n` times. -/
-def IteratedWreathProduct (G : Type) : (n : ℕ) → Type
+def IteratedWreathProduct (G : Type u) : (n : ℕ) → Type u
 | Nat.zero => PUnit
 | Nat.succ n => (IteratedWreathProduct G n) ≀ᵣ G
 
 @[simp]
-lemma IteratedWreathProduct_zero (G : Type) :
+lemma IteratedWreathProduct_zero (G : Type u) :
     IteratedWreathProduct G 0 = PUnit := rfl
 
 @[simp]
-lemma IteratedWreathProduct_succ (G : Type)(n : ℕ) :
+lemma IteratedWreathProduct_succ (G : Type u) (n : ℕ) :
     IteratedWreathProduct G (n+1) = (IteratedWreathProduct G n) ≀ᵣ G := rfl
 
-variable (G : Type) [inst : Group G]
+variable (G : Type u) [inst : Group G]
 variable (n : ℕ)
 
 instance : Group (IteratedWreathProduct G n) := by
@@ -218,7 +220,7 @@ lemma elem_P0 (p : ℕ) (P : Sylow p (Equiv.Perm (Fin (1)))) (x : P):
     x = 1 := Subsingleton.eq_one x
 
 theorem iter_wreath_card {p n : ℕ}
-    (G : Type) [Finite G] (h : Nat.card G = p) :
+    (G : Type u) [Finite G] (h : Nat.card G = p) :
     Nat.card (IteratedWreathProduct G n) = p ^ (∑ i ∈ Finset.range n, p ^ i) := by
   induction n with
   | zero => simp
@@ -237,7 +239,7 @@ lemma mu_eq {p n : ℕ} [hp : Fact (Nat.Prime p)] :
     rw [pow_succ', hp.out.emultiplicity_factorial_mul, h, Finset.sum_range_succ, ENat.coe_add]
 
 /-- If `α` is equivalent to `β`, then `Perm α` is isomorphic to `Perm β`. -/
-def Equiv.permCongrHom {α β : Type} (e : α ≃ β) : Equiv.Perm α ≃* Equiv.Perm β where
+def Equiv.permCongrHom {α β : Type u} (e : α ≃ β) : Equiv.Perm α ≃* Equiv.Perm β where
   toFun x := e.symm.trans (x.trans e)
   invFun y := e.trans (y.trans e.symm)
   left_inv _ := by ext; simp

--- a/Mathlib/GroupTheory/RegularWreathProduct.lean
+++ b/Mathlib/GroupTheory/RegularWreathProduct.lean
@@ -195,7 +195,7 @@ lemma IteratedWreathProduct_zero : IteratedWreathProduct G 0 = PUnit := rfl
 
 @[simp]
 lemma IteratedWreathProduct_succ :
-    IteratedWreathProduct G (n+1) = (IteratedWreathProduct G n) ≀ᵣ G := rfl
+    IteratedWreathProduct G (n + 1) = (IteratedWreathProduct G n) ≀ᵣ G := rfl
 
 instance [Finite G] : Finite (IteratedWreathProduct G n) := by
   induction n with
@@ -227,7 +227,7 @@ lemma mu_eq {p n : ℕ} [hp : Fact (Nat.Prime p)] :
     rw [pow_succ', hp.out.emultiplicity_factorial_mul, h, Finset.sum_range_succ, ENat.coe_add]
 
 /-- If `α` is equivalent to `β`, then `Perm α` is isomorphic to `Perm β`. -/
-def Equiv.permCongrHom {α β : Type u} (e : α ≃ β) : Equiv.Perm α ≃* Equiv.Perm β where
+def Equiv.permCongrHom {α β : Type*} (e : α ≃ β) : Equiv.Perm α ≃* Equiv.Perm β where
   toFun x := e.symm.trans (x.trans e)
   invFun y := e.trans (y.trans e.symm)
   left_inv _ := by ext; simp
@@ -237,8 +237,8 @@ def Equiv.permCongrHom {α β : Type u} (e : α ≃ β) : Equiv.Perm α ≃* Equ
 /-- The homomorphism from the wreath product of the Sylow `p`-subgroup and `Z_p` to
   the subgroup of `Perm (Fin p^(n+1))`. -/
 noncomputable def sylowWreathtoPermHom {p n : ℕ} (D : Sylow p (Equiv.Perm (Fin (p ^ n))))
-    (Z_p : Type) [Finite Z_p] [Group Z_p] (h : Nat.card Z_p = p) :
-    D ≀ᵣ Z_p →* Equiv.Perm (Fin (p ^ (n+1))) :=
+    (Z_p : Type*) [Finite Z_p] [Group Z_p] (h : Nat.card Z_p = p) :
+    D ≀ᵣ Z_p →* Equiv.Perm (Fin (p ^ (n + 1))) :=
   (Equiv.permCongrHom ((Equiv.prodCongrRight fun _ =>
   (Finite.equivFinOfCardEq h)).trans finProdFinEquiv)).toMonoidHom.comp
   (RegularWreathProduct.toPerm D Z_p (Fin (p ^ n)))
@@ -267,12 +267,12 @@ noncomputable def sylowIsIteratedWreathProduct (p n : ℕ) [Fact (Nat.Prime p)]
       map_mul' := by simp}
   | succ n h_n =>
       let P' : Sylow p (Equiv.Perm (Fin (p ^ n))) := Inhabited.default
-      have g : (IteratedWreathProduct Z_p (n+1)) ≃*
+      have g : (IteratedWreathProduct Z_p (n + 1)) ≃*
           MonoidHom.range (sylowWreathtoPermHom P' Z_p h) :=
         (RegularWreathProduct.congr (h_n P').symm (MulEquiv.refl Z_p)).trans
         (MonoidHom.ofInjective (sylowWreathtoPermHomInj P' Z_p h))
       have sylow_card : Nat.card (MonoidHom.range (sylowWreathtoPermHom P' Z_p h)) =
-          p ^ (Nat.card (Equiv.Perm (Fin (p ^ (n+1))))).factorization p := by
+          p ^ (Nat.card (Equiv.Perm (Fin (p ^ (n + 1))))).factorization p := by
         rw [Nat.card_congr (g.symm).toEquiv, iter_wreath_card Z_p, h]
         rw [Nat.card_eq_fintype_card, Fintype.card_perm, Fintype.card_fin, mu_eq]
       exact (P.equiv (Sylow.ofCard (MonoidHom.range (sylowWreathtoPermHom P' Z_p h))

--- a/Mathlib/GroupTheory/RegularWreathProduct.lean
+++ b/Mathlib/GroupTheory/RegularWreathProduct.lean
@@ -12,11 +12,17 @@ import Mathlib.Algebra.Group.PUnit
 
 This file defines the regular wreath product of groups, and the canonical maps in and out of the
 product. The regular wreath product of `D` and `Q` is the product `(Q → D) × Q` with the group
-`⟨d₁, q₁⟩ * ⟨d₂, q₂⟩ = ⟨d₁ * (fun x => q₁ (d₂⁻¹ * x)), d₂ * q₂⟩`
+`⟨a₁, a₂⟩ * ⟨b₁, b₂⟩ = ⟨a₁ * (fun x => b₁ (a₂⁻¹ * x)), a₂ * b₂⟩`
 
-## Key definitions
+## Main definitions
 
-There an hom into the regular wreath product `inl : D →* D ≀ᵣ Q`.
+* `D ≀ᵣ Q` : The regular wreath product of groups `D` and `Q`.
+* `rightHom` : The canonical projection `D ≀ᵣ Q →* Q`.
+* `inl` : The canonical map `Q →* D ≀ᵣ Q`.
+* `toPerm` : The homomorphism from `D ≀ᵣ Q` to `Equiv.Perm (Λ × Q)`, where `Λ` is a `D`-set.
+* `IteratedWreathProduct G n` : The iterated wreath product of a group `G` `n` times.
+* `sylowIsIteratedWreathProduct` : The isomorphism between the Sylow `p`-subgroup of `Perm p^n` and
+  the iterated wreath product of the cyclic group of order `p` `n` times.
 
 ## Notation
 
@@ -30,7 +36,7 @@ variable (D Q : Type*) [Group D] [Group Q]
 
 /-- The regular wreath product of groups `Q` and `D`.
     It the product `(Q → D) × Q` with the group operation
-  `⟨d₁, q₁⟩ * ⟨d₂, q₂⟩ = ⟨d₁ * (fun x => q₁ (d₂⁻¹ * x)), d₂ * q₂⟩` -/
+  `⟨a₁, a₂⟩ * ⟨b₁, b₂⟩ = ⟨a₁ * (fun x => b₁ (a₂⁻¹ * x)), a₂ * b₂⟩` -/
 @[ext]
 structure RegularWreathProduct where
   /-- The function of Q → D -/
@@ -44,10 +50,10 @@ namespace RegularWreathProduct
 variable {D Q}
 
 instance : Mul (RegularWreathProduct D Q) where
-  mul d q := ⟨d.1 * (fun x => q.1 (d.2⁻¹ * x)), d.2 * q.2⟩
+  mul a b := ⟨a.1 * (fun x => b.1 (a.2⁻¹ * x)), a.2 * b.2⟩
 
-lemma mul_def (d q : RegularWreathProduct D Q) :
-    d * q = ⟨d.1 * (fun x => q.1 (d.2⁻¹ * x)), d.2 * q.2⟩ := rfl
+lemma mul_def (a b : RegularWreathProduct D Q) :
+    a * b = ⟨a.1 * (fun x => b.1 (a.2⁻¹ * x)), a.2 * b.2⟩ := rfl
 
 @[simp]
 theorem mul_left (a b : D ≀ᵣ Q) :

--- a/Mathlib/GroupTheory/RegularWreathProduct.lean
+++ b/Mathlib/GroupTheory/RegularWreathProduct.lean
@@ -160,10 +160,7 @@ lemma rsmul {w : D ≀ᵣ Q} {p : Λ × Q} :
 
 instance instMulActionRWP : MulAction (D ≀ᵣ Q) (Λ × Q) where
   one_smul := by simp
-  mul_smul := by simp; intro x y a b; constructor
-                 · rw [smul_smul]; group
-                 · exact mul_assoc x.right y.right b
-
+  mul_smul := by by simp [smul_smul, mul_assoc]
 
 variable [FaithfulSMul D Λ]
 instance instFaithfulSMulRWP : FaithfulSMul (D ≀ᵣ Q) (Λ × Q) where

--- a/Mathlib/GroupTheory/RegularWreathProduct.lean
+++ b/Mathlib/GroupTheory/RegularWreathProduct.lean
@@ -43,7 +43,7 @@ structure RegularWreathProduct where
   /-- The element of Q -/
   right : Q
 
-@[inherit_doc] infix:65  " ≀ᵣ " => RegularWreathProduct
+@[inherit_doc] infix:65 " ≀ᵣ " => RegularWreathProduct
 
 namespace RegularWreathProduct
 variable {D Q}

--- a/Mathlib/GroupTheory/RegularWreathProduct.lean
+++ b/Mathlib/GroupTheory/RegularWreathProduct.lean
@@ -195,6 +195,9 @@ def IteratedWreathProduct (G : Type u) : (n : ℕ) → Type u
 | Nat.zero => PUnit
 | Nat.succ n => (IteratedWreathProduct G n) ≀ᵣ G
 
+variable (G : Type u) [inst : Group G]
+variable (n : ℕ)
+
 @[simp]
 lemma IteratedWreathProduct_zero (G : Type u) :
     IteratedWreathProduct G 0 = PUnit := rfl
@@ -202,9 +205,6 @@ lemma IteratedWreathProduct_zero (G : Type u) :
 @[simp]
 lemma IteratedWreathProduct_succ (G : Type u) (n : ℕ) :
     IteratedWreathProduct G (n+1) = (IteratedWreathProduct G n) ≀ᵣ G := rfl
-
-variable (G : Type u) [inst : Group G]
-variable (n : ℕ)
 
 instance : Group (IteratedWreathProduct G n) := by
  induction n with

--- a/Mathlib/GroupTheory/RegularWreathProduct.lean
+++ b/Mathlib/GroupTheory/RegularWreathProduct.lean
@@ -29,7 +29,7 @@ group, regular wreath product, sylow p-subgroup
 variable (D Q : Type*) [Group D] [Group Q]
 
 /-- The regular wreath product of groups `Q` and `D`.
-    It the product of sets with the group operation
+    It the product `(Q → D) × Q` with the group operation
   `⟨d₁, q₁⟩ * ⟨d₂, q₂⟩ = ⟨d.1 * (fun x => q.1 (d.2⁻¹ * x)), d.2 * q.2⟩` -/
 @[ext]
 structure RegularWreathProduct where

--- a/Mathlib/GroupTheory/RegularWreathProduct.lean
+++ b/Mathlib/GroupTheory/RegularWreathProduct.lean
@@ -191,33 +191,30 @@ def IteratedWreathProduct (G : Type u) : (n : ℕ) → Type u
 variable (G : Type u) (n : ℕ)
 
 @[simp]
-lemma IteratedWreathProduct_zero (G : Type u) :
-    IteratedWreathProduct G 0 = PUnit := rfl
+lemma IteratedWreathProduct_zero : IteratedWreathProduct G 0 = PUnit := rfl
 
 @[simp]
-lemma IteratedWreathProduct_succ (G : Type u) (n : ℕ) :
+lemma IteratedWreathProduct_succ :
     IteratedWreathProduct G (n+1) = (IteratedWreathProduct G n) ≀ᵣ G := rfl
+
+instance [Finite G] : Finite (IteratedWreathProduct G n) := by
+  induction n with
+  | zero => rw [IteratedWreathProduct_zero]; infer_instance
+  | succ n h => rw [IteratedWreathProduct_succ]; infer_instance
+
+theorem iter_wreath_card [Finite G] : Nat.card (IteratedWreathProduct G n) =
+    Nat.card G ^ (∑ i ∈ Finset.range n, Nat.card G ^ i) := by
+  induction n with
+  | zero => simp
+  | succ n h => rw [IteratedWreathProduct_succ, RegularWreathProduct.card,
+      h, geom_sum_succ, pow_succ, pow_mul']
 
 variable [Group G]
 
 instance : Group (IteratedWreathProduct G n) := by
  induction n with
- | zero => rw [IteratedWreathProduct_zero]; exact CommGroup.toGroup
- | succ n ih => rw [IteratedWreathProduct_succ]; exact RegularWreathProduct.instGroup
-
-instance [Finite G] : Finite (IteratedWreathProduct G n) := by
-  induction n with
-  | zero => rw [IteratedWreathProduct_zero]; exact Finite.of_subsingleton
-  | succ n h => rw [IteratedWreathProduct_succ]; exact RegularWreathProduct.instFinite
-
-theorem iter_wreath_card {p n : ℕ}
-    (G : Type u) [Finite G] (h : Nat.card G = p) :
-    Nat.card (IteratedWreathProduct G n) = p ^ (∑ i ∈ Finset.range n, p ^ i) := by
-  induction n with
-  | zero => simp
-  | succ n h_n =>
-    rw [geom_sum_succ, IteratedWreathProduct_succ]
-    rw [RegularWreathProduct.card, h_n, h]; group
+ | zero => rw [IteratedWreathProduct_zero]; infer_instance
+ | succ n ih => rw [IteratedWreathProduct_succ]; infer_instance
 
 lemma mu_eq {p n : ℕ} [hp : Fact (Nat.Prime p)] :
     (p ^ n).factorial.factorization p = ∑ i ∈ Finset.range n, p ^ i := by
@@ -275,9 +272,9 @@ noncomputable def sylowIsIteratedWreathProduct (p n : ℕ) [Fact (Nat.Prime p)]
         (RegularWreathProduct.congr (h_n P').symm (MulEquiv.refl Z_p)).trans
         (MonoidHom.ofInjective (sylowWreathtoPermHomInj P' Z_p h))
       have sylow_card : Nat.card (MonoidHom.range (sylowWreathtoPermHom P' Z_p h)) =
-      p ^ (Nat.card (Equiv.Perm (Fin (p^(n+1))))).factorization p := by
-        rw [Nat.card_congr (g.symm).toEquiv, iter_wreath_card Z_p h, Nat.card_eq_fintype_card]
-        rw [Fintype.card_perm,Fintype.card_fin,mu_eq]
+          p ^ (Nat.card (Equiv.Perm (Fin (p^(n+1))))).factorization p := by
+        rw [Nat.card_congr (g.symm).toEquiv, iter_wreath_card Z_p, h]
+        rw [Nat.card_eq_fintype_card, Fintype.card_perm, Fintype.card_fin, mu_eq]
       exact (P.equiv (Sylow.ofCard (MonoidHom.range (sylowWreathtoPermHom P' Z_p h))
       sylow_card)).trans (id g.symm)
 

--- a/Mathlib/GroupTheory/RegularWreathProduct.lean
+++ b/Mathlib/GroupTheory/RegularWreathProduct.lean
@@ -173,8 +173,7 @@ instance instFaithfulSMulRWP : FaithfulSMul (D ≀ᵣ Q) (Λ × Q) where
     · have hh := fun a => (h a (m₁.right⁻¹ * q)).1
       rw [← (h a b).2] at hh
       group at hh
-      apply FaithfulSMul.eq_of_smul_eq_smul at hh
-      exact hh
+      exact FaithfulSMul.eq_of_smul_eq_smul hh
     · exact (h a b).2
 
 /-- The map sending the wreath product `D ≀ᵣ Q` to its representation as a permutation of `Λ × Q`

--- a/Mathlib/GroupTheory/RegularWreathProduct.lean
+++ b/Mathlib/GroupTheory/RegularWreathProduct.lean
@@ -193,17 +193,17 @@ end RegularWreathProduct
 
 section iterated
 
-/- The iterated wreath product of group `G` `n` times. -/
+/-- The wreath product of group `G` iterated `n` times. -/
 def IteratedWreathProduct (G: Type) : (n:ℕ) → Type
 | Nat.zero => PUnit
 | Nat.succ n => (IteratedWreathProduct G n) ≀ᵣ G
 
 @[simp]
-lemma IteratedWreathProduct_zero (G : Type) [Group G] :
+lemma IteratedWreathProduct_zero (G : Type) :
   IteratedWreathProduct G 0 = PUnit := rfl
 
 @[simp]
-lemma IteratedWreathProduct_succ (G : Type) [Group G] (n : ℕ) :
+lemma IteratedWreathProduct_succ (G : Type)(n : ℕ) :
   IteratedWreathProduct G (n+1) = (IteratedWreathProduct G n) ≀ᵣ G := rfl
 
 variable (G: Type) [inst : Group G]
@@ -297,7 +297,6 @@ lemma mu_eq {p n :ℕ} [Fact (Nat.Prime p)]:
     have hf_surj : ∀ k ∈ S, ∃ m ∈ Finset.range (p^n), f m = k := by
       intro k hk
       apply Finset.mem_filter.mp at hk
-      have hk1 := List.mem_range.mp hk.1
       obtain ⟨x,hx⟩ := exists_eq_mul_right_of_dvd hk.2
       have : 0 < p * x := hx ▸ (Nat.zero_lt_succ k)
       have aux : 0 < x := by exact Nat.lt_of_mul_lt_mul_left this
@@ -344,7 +343,7 @@ lemma mu_eq {p n :ℕ} [Fact (Nat.Prime p)]:
     rw [h_back] at res; simp at res; rw [Nat.add_comm (p ^ n) _] at res
     exact res
 
-/- An auxilliary function -/
+/-- An auxilliary function -/
 def aux {A B : Type} (h : A ≃ B) : Equiv.Perm A →* Equiv.Perm B :=
   MonoidHom.mk'
     (fun k => h.symm.trans (k.trans h))
@@ -358,9 +357,8 @@ lemma aux_injective {A B : Type} (h : A ≃ B) : Function.Injective (aux h) := b
   simp at eq_fun
   exact eq_fun
 
-noncomputable
-/- An auxilliary function -/
-def f {p n : ℕ} [Fact (Nat.Prime p)] (D : Sylow p (Equiv.Perm (Fin (p^n))))
+/-- An auxilliary function -/
+noncomputable def f {p n : ℕ} (D : Sylow p (Equiv.Perm (Fin (p^n))))
   (G : Type) [Finite G] [Group G] (h: Nat.card G = p):
     D ≀ᵣ G →* Equiv.Perm (Fin (p^(n+1))) :=
      (aux ((Equiv.prodCongrRight fun _ => (Finite.equivFinOfCardEq h)).trans finProdFinEquiv)).comp
@@ -368,7 +366,7 @@ def f {p n : ℕ} [Fact (Nat.Prime p)] (D : Sylow p (Equiv.Perm (Fin (p^n))))
 
 
 lemma f_injective {p n : ℕ} [Fact (Nat.Prime p)] (D : Sylow p (Equiv.Perm (Fin (p^n))))
-  (G : Type) [Finite G] [Group G] [IsCyclic G] (h: Nat.card G = p):
+  (G : Type) [Finite G] [Group G] (h: Nat.card G = p):
     Function.Injective (f D G h) := by
       have : Function.Injective (RegularWreathProduct.toPerm D G (Fin (p^n))) :=
         RegularWreathProduct.toPermInj D G (Fin (p^n))
@@ -376,10 +374,9 @@ lemma f_injective {p n : ℕ} [Fact (Nat.Prime p)] (D : Sylow p (Equiv.Perm (Fin
         (aux_injective (((Equiv.prodCongrRight fun _ =>
         (Finite.equivFinOfCardEq h)).trans finProdFinEquiv))) this
 
-noncomputable
 /-The Sylow p-subgroups of S_{p^n} are isomorphic to the iterated wreathproduct -/
-def sylowIsIteratedWreathProduct (p n : ℕ) [Fact (Nat.Prime p)]
-  (Z_p : Type) [Group Z_p] [IsCyclic Z_p] [Finite Z_p] (h: Nat.card Z_p = p)
+noncomputable def sylowIsIteratedWreathProduct (p n : ℕ) [Fact (Nat.Prime p)]
+  (Z_p : Type) [Group Z_p] [Finite Z_p] (h: Nat.card Z_p = p)
   (P : Sylow p (Equiv.Perm (Fin (p^n)))) :
   P ≃* (IteratedWreathProduct Z_p n) := by
     induction n with

--- a/Mathlib/GroupTheory/RegularWreathProduct.lean
+++ b/Mathlib/GroupTheory/RegularWreathProduct.lean
@@ -1,0 +1,405 @@
+/-
+Copyright (c) 2025 Francisco Silva. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Francisco Silva
+-/
+
+import Mathlib.GroupTheory.Sylow
+import Mathlib.Algebra.Group.PUnit
+
+/-!
+# Regular wreath product
+
+This file defines the regular wreath product of groups, and the canonical maps in and out of the
+product. The regular wreath product of `D` and `Q` is the product of sets with the group
+`⟨d₁, q₁⟩ * ⟨d₂, q₂⟩ = ⟨d.1 * (fun x => q.1 (d.2⁻¹ * x)), d.2 * q.2⟩`
+
+## Key definitions
+
+There an hom into the regular wreath product `inl : D →* D ≀ᵣ Q`.
+
+## Notation
+
+This file introduces the global notation `D ≀ᵣ Q` for `RegularWreathProduct D Q`
+
+## Tags
+group, regular wreath product
+-/
+
+variable (D Q: Type*) [Group D] [Group Q]
+
+/-- The regular wreath product of groups `Q` and `D`.
+    It the product of sets with the group operation
+  `⟨n₁, g₁⟩ * ⟨n₂, g₂⟩ = ⟨n₁ * φ g₁ n₂, g₁ * g₂⟩` -/
+@[ext]
+structure RegularWreathProduct where
+  /-- The function of Q → D -/
+  left : Q → D
+  /-- The element of Q -/
+  right : Q
+
+@[inherit_doc] infix:65  " ≀ᵣ " => RegularWreathProduct
+
+namespace RegularWreathProduct
+variable {D Q}
+
+instance : Mul (RegularWreathProduct D Q) where
+  mul d q := ⟨d.1 * (fun x => q.1 (d.2⁻¹ * x)), d.2 * q.2⟩
+
+lemma mul_def (d q : RegularWreathProduct D Q) :
+  d * q = ⟨d.1 * (fun x => q.1 (d.2⁻¹ * x)), d.2 * q.2⟩ := rfl
+
+@[simp]
+theorem mul_left (a b : D ≀ᵣ Q) :
+  (a * b).left = a.left * (((fun x => b.left (a.right⁻¹ * x)))) := rfl
+
+@[simp]
+theorem mul_right (a b : D ≀ᵣ Q) : (a * b).right = a.right * b.right := rfl
+
+instance : One (RegularWreathProduct D Q) where one := ⟨1, 1⟩
+
+@[simp]
+theorem one_left : (1 : D ≀ᵣ Q).left = 1 := rfl
+
+@[simp]
+theorem one_right : (1 : D ≀ᵣ Q).right = 1 := rfl
+
+instance : Inv (RegularWreathProduct D Q) where
+  inv x := ⟨((fun k => x.1⁻¹ (x.2 * k))), x.2⁻¹⟩
+
+@[simp]
+theorem inv_left (a : D ≀ᵣ Q) :
+  a⁻¹.left = ((fun x => a.left⁻¹ (a.right * x))) := rfl
+
+@[simp]
+theorem inv_right (a : D ≀ᵣ Q) : a⁻¹.right = a.right⁻¹ := rfl
+
+instance : Group (RegularWreathProduct D Q) where
+  mul_assoc a b c := RegularWreathProduct.ext (by simp [mul_assoc]; rfl) (by simp [mul_assoc])
+  one_mul a := RegularWreathProduct.ext (by simp) (one_mul a.2)
+  mul_one a := RegularWreathProduct.ext (by simp; rfl) (mul_one _)
+  inv_mul_cancel a :=
+    RegularWreathProduct.ext (by simp; exact mul_eq_one_iff_eq_inv.mpr rfl) (by simp)
+
+instance : Inhabited (RegularWreathProduct D Q) := ⟨1⟩
+
+def rightHom : (D ≀ᵣ Q) →* Q where
+  toFun := RegularWreathProduct.right
+  map_one' := rfl
+  map_mul' _ _ := rfl
+
+def inl : Q →* (D ≀ᵣ Q) where
+  toFun q := ⟨1, q⟩
+  map_one' := rfl
+  map_mul' _ _ := by ext <;> simp
+
+@[simp]
+theorem left_inl (q : Q) : (inl q : D ≀ᵣ Q).left = 1 := rfl
+
+@[simp]
+theorem right_inl (q : Q) : (inl q : D ≀ᵣ Q).right = q := rfl
+
+@[simp]
+theorem rightHom_eq_right : (rightHom : D ≀ᵣ Q → Q) = right := rfl
+
+@[simp]
+theorem rightHom_comp_inl_eq_id : (rightHom : D ≀ᵣ Q →* Q).comp inl = MonoidHom.id _ := by ext; simp
+
+@[simp]
+theorem fun_id (q:Q) : rightHom (inl q : D ≀ᵣ Q) = q := by simp
+
+def equivProd D Q: D ≀ᵣ Q ≃ (Q → D) × Q where
+  toFun := fun ⟨d, q⟩ => ⟨d, q⟩
+  invFun := fun ⟨d, q⟩ => ⟨d, q⟩
+  left_inv := fun _ => rfl
+  right_inv := fun _ => rfl
+
+omit [Group D] [Group Q] in
+lemma equivProdInj: Function.Injective (equivProd D Q).toFun := by
+  intro a b; simp
+
+instance [Finite D] [Finite Q] : Finite (D ≀ᵣ Q) := by
+  apply (Equiv.finite_iff (equivProd D Q)).mpr
+  apply Finite.instProd
+
+omit [Group D] [Group Q] in
+theorem card [Finite D][Finite Q] :
+ Nat.card (D ≀ᵣ Q) = (Nat.card D^Nat.card Q) * Nat.card Q := by
+  rw [Nat.card_congr (equivProd D Q)]
+  rw [Nat.card_prod (Q → D) Q]
+  rw [Nat.card_fun]
+
+def congr_left {D₁ D₂ Q : Type*} [Group D₁] [Group D₂] [Group Q] (f : D₁ ≃* D₂):
+  D₁ ≀ᵣ Q ≃* D₂ ≀ᵣ Q where
+    toFun x := ⟨f ∘ x.left, x.right⟩
+    invFun x := ⟨f.symm ∘ x.left, x.right⟩
+    left_inv _ := by ext <;> simp
+    right_inv _ := by ext <;> simp
+    map_mul' x y := by ext <;> simp
+
+def congr_right {D Q₁ Q₂ : Type*} [Group D] [Group Q₁] [Group Q₂] (f : Q₁ ≃* Q₂):
+  D ≀ᵣ Q₁ ≃* D ≀ᵣ Q₂ where
+    toFun x := ⟨x.1.comp f.symm, f x.2⟩
+    invFun x := ⟨x.1.comp f, f.symm x.2⟩
+    left_inv x := by ext <;> simp
+    right_inv x := by ext <;> simp
+    map_mul' x y := by ext <;> simp
+
+def congr {D₁ Q₁ D₂ Q₂ : Type*} [Group D₁] [Group Q₁] [Group D₂] [Group Q₂]
+  (f : D₁ ≃* D₂) (g : Q₁ ≃* Q₂):
+    D₁ ≀ᵣ Q₁ ≃* D₂ ≀ᵣ Q₂ :=
+    (congr_left f).trans (congr_right g)
+
+section perm
+
+variable (D: Type*) [Group D]
+variable (Q: Type*) [Group Q] [Nonempty Q]
+variable (Λ : Type*) [Nonempty Λ] [MulAction D Λ]
+
+instance instSMulRWP : SMul (D ≀ᵣ Q) (Λ × Q) where
+  smul w := fun p => ⟨(w.left (w.right * p.2)) • p.1, w.right * p.2⟩
+
+omit [Nonempty Λ] [Nonempty Q] in
+@[simp]
+lemma rsmul {w: D ≀ᵣ Q} {p : Λ × Q}:
+ w • p = ⟨(w.left (w.right * p.2)) • p.1, w.right * p.2⟩ := rfl
+
+instance instMulActionRWP: MulAction (D ≀ᵣ Q) (Λ × Q) where
+  one_smul := by simp;
+  mul_smul := by simp; intro x y a b; constructor
+                 · rw [smul_smul]; group
+                 · exact mul_assoc x.right y.right b
+
+
+variable [FaithfulSMul D Λ]
+instance instFaithfulSMulRWP: FaithfulSMul (D ≀ᵣ Q) (Λ × Q) where
+  eq_of_smul_eq_smul := by
+    simp; intro m₁ m₂ h;
+    let ⟨a⟩ := ‹Nonempty Λ›
+    let ⟨b⟩ := ‹Nonempty Q›
+    ext q
+    · have hh := fun a => (h a (m₁.right⁻¹ * q)).1;
+      rw [← (h a b).2] at hh
+      group at hh
+      apply FaithfulSMul.eq_of_smul_eq_smul at hh
+      exact hh
+    · exact (h a b).2
+
+def toPerm : D ≀ᵣ Q →* Equiv.Perm (Λ × Q) :=
+    MulAction.toPermHom (D ≀ᵣ Q) (Λ × Q)
+
+theorem toPermInj:
+  Function.Injective (toPerm D Q Λ) := MulAction.toPerm_injective
+
+end perm
+
+end RegularWreathProduct
+
+
+section iterated
+
+def IteratedWreathProduct (G: Type) [Group G]: (n:ℕ) → Type
+| Nat.zero => PUnit
+| Nat.succ n => (IteratedWreathProduct G n) ≀ᵣ G
+
+@[simp]
+lemma IteratedWreathProduct_zero (G : Type) [Group G] :
+  IteratedWreathProduct G 0 = PUnit := rfl
+
+@[simp]
+lemma IteratedWreathProduct_succ (G : Type) [Group G] (n : ℕ) :
+  IteratedWreathProduct G (n+1) = (IteratedWreathProduct G n) ≀ᵣ G := rfl
+
+variable (G: Type) [inst : Group G]
+variable (n: ℕ)
+
+instance: Group (IteratedWreathProduct G n) := by
+ induction n with
+ | zero => rw [IteratedWreathProduct_zero]; exact CommGroup.toGroup
+ | succ n ih => rw [IteratedWreathProduct_succ]; exact RegularWreathProduct.instGroup
+
+instance [Finite G] : Finite (IteratedWreathProduct G n) := by
+  induction n with
+  | zero => rw [IteratedWreathProduct_zero]; exact Finite.of_subsingleton
+  | succ n h => rw [IteratedWreathProduct_succ]; exact RegularWreathProduct.instFinite
+
+
+lemma elem_P0 (p : ℕ) (P : Sylow p (Equiv.Perm (Fin (1)))) (x:P):
+  x = 1 := Subsingleton.eq_one x
+
+theorem iter_wreath_card {p n : ℕ}
+  (G : Type) [Group G] [Finite G] (h : Nat.card G = p) :
+  Nat.card (IteratedWreathProduct G n) = p ^ (∑ i ∈ Finset.range n, p ^ i) := by
+  induction n with
+  | zero => simp
+  | succ n h_n =>
+    rw [geom_sum_succ, IteratedWreathProduct_succ]
+    rw [RegularWreathProduct.card, h_n, h]; group
+
+lemma mu_eq {p n :ℕ} [Fact (Nat.Prime p)]:
+(p ^ n).factorial.factorization p = ∑ i ∈ Finset.range n, p ^ i := by
+  induction n with
+  | zero => simp
+  | succ n h =>
+    rw [Finset.sum_range_succ, ← h]
+    let S : Finset ℕ := { k ∈ Finset.range (p^(n+1)) | p ∣ (k+1)}
+    have h_disjoint : Disjoint S (Finset.range (p ^ (n + 1)) \ S) := Finset.disjoint_sdiff
+    have h_decomp : (p^(n+1)).factorial =
+      (∏ k ∈ S, (k+1)) * (∏ k ∈ (Finset.range (p^(n+1)) \ S), (k+1)) := by
+      rw [← Finset.prod_union h_disjoint]
+      rw [Finset.union_sdiff_of_subset (Finset.filter_subset (fun k ↦ p ∣ k + 1)
+        (Finset.range (p ^ (n + 1))))]
+      rw [Finset.prod_range_add_one_eq_factorial]
+    have h_compl : (∏ k ∈ (Finset.range (p^(n+1)) \ S), (k+1)).factorization p = 0 := by
+        rw [Nat.factorization_prod (fun x => (fun _ => Ne.symm (Nat.zero_ne_add_one x)))]
+        rw [Finsupp.finset_sum_apply (Finset.range (p ^ (n + 1)) \ S)
+          (fun i ↦ (i + 1).factorization) p ]
+        apply Finset.sum_eq_zero
+        intro x hx
+        apply Nat.factorization_eq_zero_of_not_dvd
+        apply Finset.mem_sdiff.mp at hx
+        have h1 := hx.left; have h2 := hx.right
+        have hhh : ¬ (x ∈ { k ∈ Finset.range (p^(n+1)) | p ∣ (k+1)}) ↔
+          ¬ (x ∈ Finset.range (p^(n+1)) ∧ (p ∣ (x+1))) :=
+          not_congr Finset.mem_filter
+        apply hhh.mp at h2
+        simp at h2
+        simp at h1
+        exact h2 h1
+    have h1: ∏ k ∈ S, (k + 1) ≠ 0 := by
+      apply Finset.prod_ne_zero_iff.mpr; intro x hx;
+      exact Ne.symm (Nat.zero_ne_add_one x)
+    have h2 : ∏ k ∈ Finset.range (p ^ (n + 1)) \ S, (k + 1) ≠ 0 := by
+      apply Finset.prod_ne_zero_iff.mpr; intro x hx; exact Ne.symm (Nat.zero_ne_add_one x)
+    have aux : ((∏ k ∈ S, (k + 1)).factorization +
+      (∏ k ∈ Finset.range (p ^ (n + 1)) \ S, (k + 1)).factorization) p =
+      (∏ k ∈ S, (k + 1)).factorization p +
+      (∏ k ∈ Finset.range (p ^ (n + 1)) \ S, (k + 1)).factorization p := rfl
+    have res : ((p^(n+1)).factorial).factorization p = (∏ k ∈ S, (k + 1)).factorization p := by
+      rw [h_decomp, Nat.factorization_mul h1 h2, aux, h_compl, Nat.add_zero]
+    let f : ℕ → ℕ := fun m => p * (m + 1) - 1
+    have hf_mem : ∀ m ∈ Finset.range (p^n), f m ∈ S := by
+      intro m hm
+      apply List.mem_range.mp at hm
+      have f_bound : f m < p ^ (n + 1) := by
+        replace hm := Nat.sub_le_sub_right (Nat.mul_le_mul_left p (Nat.succ_le_of_lt hm)) 1
+        rw [Nat.pow_succ']
+        have : p * p ^ n - 1 < p * p ^ n := Nat.sub_one_lt (Ne.symm (NeZero.ne' (p * p ^ n)))
+        exact Nat.lt_of_le_of_lt hm this
+      have dvd : p ∣ (f m + 1) := by
+        rw [Nat.sub_add_cancel NeZero.one_le]
+        exact Nat.dvd_mul_right p (m + 1)
+      exact Finset.mem_filter.mpr ⟨Finset.mem_range.mpr f_bound, dvd⟩
+    have hf_inj' : ∀ m₁ m₂ : ℕ , f m₁ = f m₂ → m₁ = m₂ := by
+      intro m₁ m₂ h_eq
+      have aux1 : p * (m₁ + 1) = f m₁ + 1 := Eq.symm (Nat.sub_add_cancel NeZero.one_le)
+      have aux2 : p * (m₂ + 1) = f m₂ + 1 := Eq.symm (Nat.sub_add_cancel NeZero.one_le)
+      have : p * (m₁ + 1) = p * (m₂ + 1) := by
+        rw [aux1, aux2];
+        exact congrFun (congrArg HAdd.hAdd h_eq) 1
+      exact Nat.succ_inj.mp (Nat.eq_of_mul_eq_mul_left (Nat.pos_of_neZero p) this)
+    have hf_inj : Set.InjOn f ↑(Finset.range (p ^ n)) := fun ⦃x₁⦄ a ⦃x₂⦄ a ↦ hf_inj' x₁ x₂
+    have hf_surj : ∀ k ∈ S, ∃ m ∈ Finset.range (p^n), f m = k := by
+      intro k hk
+      apply Finset.mem_filter.mp at hk
+      have hk1 := List.mem_range.mp hk.1; have hk2 := hk.2
+      obtain ⟨x,hx⟩ := exists_eq_mul_right_of_dvd hk.2
+      have : 0 < p * x := hx ▸ (Nat.zero_lt_succ k)
+      have aux : 0 < x := by exact Nat.lt_of_mul_lt_mul_left this
+      have x_bound : x - 1 < p^n := by
+        have hk1 := Nat.add_lt_add_right (List.mem_range.mp hk.1) 1
+        rw [hx, Nat.pow_succ'] at hk1
+        apply Nat.succ_le_of_lt at hk1
+        simp at hk1
+        apply le_of_nsmul_le_nsmul_right (NeZero.ne p) at hk1
+        apply Nat.sub_one_lt_of_le aux
+        exact hk1
+      have x_fun : f (x-1) = k := by
+        apply Nat.eq_sub_of_add_eq at hx;
+        have : f (x - 1) = p * (x - 1 + 1) - 1 := rfl
+        rw [hx, this, Nat.sub_add_cancel aux]
+      use (x - 1); exact ⟨List.mem_range.mpr x_bound, x_fun⟩
+    have prod_reindex : ∏ m ∈ Finset.range (p^n), (p * (m + 1)) = ∏ k ∈ S, (k + 1) := by
+      apply (Finset.prod_nbij f hf_mem hf_inj hf_surj)
+      intro a ha;
+      apply (Nat.sub_eq_iff_eq_add NeZero.one_le ).mp ; rfl
+    rw [← prod_reindex] at res
+    have h_prod : (∏ m ∈ Finset.range (p^n), (p * (m + 1))).factorization p =
+      ∑ m ∈ Finset.range (p^n), (p * (m + 1)).factorization p := by
+      rw [Nat.factorization_prod (fun x => (fun _ => Nat.mul_ne_zero ((NeZero.ne' p).symm)
+        (Nat.zero_ne_add_one x).symm))]
+      simp
+    rw [h_prod] at res
+    have h_each : ∀ m ∈ Finset.range (p^n), (p*(m+1)).factorization p =
+      1 + (m+1).factorization p := by
+      intro m hm
+      have aux : (p.factorization + (m + 1).factorization) p =
+        p.factorization p + (m + 1).factorization p := rfl
+      rw [Nat.factorization_mul ((NeZero.ne' p).symm) (Ne.symm (Nat.zero_ne_add_one m))]
+      rw [aux, Nat.Prime.factorization_self (Fact.out)]
+    rw [Finset.sum_congr rfl h_each] at res
+    rw [Finset.sum_add_distrib,Finset.sum_const, Finset.card_range] at res
+    have h_back : ∑ x ∈ Finset.range (p ^ n), (x + 1).factorization p =
+      (p ^ n).factorial.factorization p := by
+      have aux : ∑ x ∈ Finset.range (p ^ n), (x + 1).factorization p =
+        (∑ x ∈ Finset.range (p ^ n), (x + 1).factorization) p := by
+        simp
+      rw [← Finset.prod_range_add_one_eq_factorial]
+      rw [Nat.factorization_prod (fun x => (fun hx => (Nat.zero_ne_add_one x).symm)), aux]
+    rw [h_back] at res; simp at res; rw [Nat.add_comm (p ^ n) _] at res
+    exact res
+
+def aux {A B : Type} (h : A ≃ B) : Equiv.Perm A →* Equiv.Perm B :=
+  MonoidHom.mk'
+    (fun k => h.symm.trans (k.trans h))
+    (by intro a b; ext x; simp)
+
+lemma aux_injective {A B : Type} (h : A ≃ B) : Function.Injective (aux h) := by
+  intro x y h_eq; ext a
+  replace h_eq : h.symm.trans (x.trans h) = h.symm.trans (y.trans h) := h_eq
+  have eq_fun := Equiv.ext_iff.mp h_eq
+  specialize eq_fun (h a)
+  simp at eq_fun
+  exact eq_fun
+
+noncomputable
+def f {p n : ℕ} [Fact (Nat.Prime p)] (D : Sylow p (Equiv.Perm (Fin (p^n))))
+  (G : Type) [Finite G] [Group G] [IsCyclic G] (h: Nat.card G = p):
+    D ≀ᵣ G →* Equiv.Perm (Fin (p^(n+1))) :=
+     (aux ((Equiv.prodCongrRight fun _ => (Finite.equivFinOfCardEq h)).trans finProdFinEquiv)).comp
+      (RegularWreathProduct.toPerm D G (Fin (p^n)))
+
+
+lemma f_injective {p n : ℕ} [Fact (Nat.Prime p)] (D : Sylow p (Equiv.Perm (Fin (p^n))))
+  (G : Type) [Finite G] [Group G] [IsCyclic G] (h: Nat.card G = p):
+    Function.Injective (f D G h) := by
+      have : Function.Injective (RegularWreathProduct.toPerm D G (Fin (p^n))) :=
+        RegularWreathProduct.toPermInj D G (Fin (p^n))
+      exact (fun a b => Function.Injective.comp a b)
+        (aux_injective (((Equiv.prodCongrRight fun _ =>
+        (Finite.equivFinOfCardEq h)).trans finProdFinEquiv))) this
+
+/-The Sylow p-subgroups of S_{p^n} are isomorphic to the iterated wreathproduct -/
+noncomputable def sylowIsIteratedWreathProduct (p n : ℕ) [Fact (Nat.Prime p)]
+  (Z_p : Type) [Group Z_p] [IsCyclic Z_p] [Finite Z_p] (h: Nat.card Z_p = p)
+  (P : Sylow p (Equiv.Perm (Fin (p^n)))) :
+  P ≃* (IteratedWreathProduct Z_p n) := by
+    induction n with
+    | zero => exact {
+        toFun := 1
+        invFun := 1
+        left_inv x := by rw [Pi.one_apply, elem_P0 p P x]
+        right_inv x:= by rw [Pi.one_apply]; rfl
+        map_mul' := by simp}
+    | succ n h_n =>
+        let P' : Sylow p (Equiv.Perm (Fin (p ^ n))) := Inhabited.default
+        have g: (IteratedWreathProduct Z_p (n+1)) ≃* MonoidHom.range (f P' Z_p h) :=
+          (RegularWreathProduct.congr (h_n P').symm (MulEquiv.refl Z_p)).trans
+          (MonoidHom.ofInjective (f_injective P' Z_p h))
+        have sylow_card: Nat.card (MonoidHom.range (f P' Z_p h)) =
+        p ^ (Nat.card (Equiv.Perm (Fin (p^(n+1))))).factorization p := by
+          rw [Nat.card_congr (g.symm).toEquiv, iter_wreath_card Z_p h, Nat.card_eq_fintype_card]
+          rw [Fintype.card_perm,Fintype.card_fin,mu_eq]
+        exact (P.equiv (Sylow.ofCard (MonoidHom.range (f P' Z_p h)) sylow_card)).trans (id g.symm)
+
+end iterated

--- a/Mathlib/GroupTheory/RegularWreathProduct.lean
+++ b/Mathlib/GroupTheory/RegularWreathProduct.lean
@@ -31,6 +31,7 @@ variable (D Q: Type*) [Group D] [Group Q]
 /-- The regular wreath product of groups `Q` and `D`.
     It the product of sets with the group operation
   `⟨n₁, g₁⟩ * ⟨n₂, g₂⟩ = ⟨n₁ * φ g₁ n₂, g₁ * g₂⟩` -/
+
 @[ext]
 structure RegularWreathProduct where
   /-- The function of Q → D -/

--- a/Mathlib/GroupTheory/RegularWreathProduct.lean
+++ b/Mathlib/GroupTheory/RegularWreathProduct.lean
@@ -75,11 +75,10 @@ theorem inv_left (a : D ≀ᵣ Q) :
 theorem inv_right (a : D ≀ᵣ Q) : a⁻¹.right = a.right⁻¹ := rfl
 
 instance : Group (RegularWreathProduct D Q) where
-  mul_assoc a b c := RegularWreathProduct.ext (by simp [mul_assoc]; rfl) (by simp [mul_assoc])
-  one_mul a := RegularWreathProduct.ext (by simp) (one_mul a.2)
-  mul_one a := RegularWreathProduct.ext (by simp; rfl) (mul_one _)
-  inv_mul_cancel a :=
-    RegularWreathProduct.ext (by simp; exact mul_eq_one_iff_eq_inv.mpr rfl) (by simp)
+  mul_assoc a b c := by ext <;> simp [mul_assoc]
+  one_mul a := by ext <;> simp
+  mul_one a := by ext <;> simp
+  inv_mul_cancel a := by ext <;> simp
 
 instance : Inhabited (RegularWreathProduct D Q) := ⟨1⟩
 

--- a/Mathlib/GroupTheory/RegularWreathProduct.lean
+++ b/Mathlib/GroupTheory/RegularWreathProduct.lean
@@ -143,7 +143,7 @@ def congr {D₁ Q₁ D₂ Q₂ : Type*} [Group D₁] [Group Q₁] [Group D₂] [
 
 section perm
 
-variable (D Q Λ : Type*) [Group D] [Group Q] [MulAction D Λ]
+variable (D Q) (Λ : Type*) [MulAction D Λ]
 
 instance instSMulRWP : SMul (D ≀ᵣ Q) (Λ × Q) where
   smul w := fun p => ⟨(w.left (w.right * p.2)) • p.1, w.right * p.2⟩

--- a/Mathlib/GroupTheory/RegularWreathProduct.lean
+++ b/Mathlib/GroupTheory/RegularWreathProduct.lean
@@ -149,8 +149,7 @@ instance instSMulRWP : SMul (D ≀ᵣ Q) (Λ × Q) where
   smul w := fun p => ⟨(w.left (w.right * p.2)) • p.1, w.right * p.2⟩
 
 @[simp]
-lemma rsmul {w : D ≀ᵣ Q} {p : Λ × Q} :
-    w • p = ⟨(w.left (w.right * p.2)) • p.1, w.right * p.2⟩ := rfl
+lemma rsmul {w : D ≀ᵣ Q} {p : Λ × Q} : w • p = ⟨(w.1 (w.2 * p.2)) • p.1, w.2 * p.2⟩ := rfl
 
 instance instMulActionRWP : MulAction (D ≀ᵣ Q) (Λ × Q) where
   one_smul := by simp

--- a/Mathlib/GroupTheory/RegularWreathProduct.lean
+++ b/Mathlib/GroupTheory/RegularWreathProduct.lean
@@ -223,7 +223,7 @@ lemma elem_P0 (p : ℕ) (P : Sylow p (Equiv.Perm (Fin (1)))) (x:P):
   x = 1 := Subsingleton.eq_one x
 
 theorem iter_wreath_card {p n : ℕ}
-  (G : Type) [Group G] [Finite G] (h : Nat.card G = p) :
+  (G : Type) [Finite G] (h : Nat.card G = p) :
   Nat.card (IteratedWreathProduct G n) = p ^ (∑ i ∈ Finset.range n, p ^ i) := by
   induction n with
   | zero => simp
@@ -374,7 +374,7 @@ lemma f_injective {p n : ℕ} [Fact (Nat.Prime p)] (D : Sylow p (Equiv.Perm (Fin
         (aux_injective (((Equiv.prodCongrRight fun _ =>
         (Finite.equivFinOfCardEq h)).trans finProdFinEquiv))) this
 
-/-The Sylow p-subgroups of S_{p^n} are isomorphic to the iterated wreathproduct -/
+/-- The Sylow p-subgroups of S_{p^n} are isomorphic to the iterated wreathproduct -/
 noncomputable def sylowIsIteratedWreathProduct (p n : ℕ) [Fact (Nat.Prime p)]
   (Z_p : Type) [Group Z_p] [Finite Z_p] (h: Nat.card Z_p = p)
   (P : Sylow p (Equiv.Perm (Fin (p^n)))) :

--- a/Mathlib/GroupTheory/RegularWreathProduct.lean
+++ b/Mathlib/GroupTheory/RegularWreathProduct.lean
@@ -30,7 +30,7 @@ variable (D Q: Type*) [Group D] [Group Q]
 
 /-- The regular wreath product of groups `Q` and `D`.
     It the product of sets with the group operation
-  `⟨n₁, g₁⟩ * ⟨n₂, g₂⟩ = ⟨n₁ * φ g₁ n₂, g₁ * g₂⟩` -/
+  `⟨d₁, q₁⟩ * ⟨d₂, q₂⟩ = ⟨d.1 * (fun x => q.1 (d.2⁻¹ * x)), d.2 * q.2⟩` -/
 @[ext]
 structure RegularWreathProduct where
   /-- The function of Q → D -/

--- a/Mathlib/GroupTheory/RegularWreathProduct.lean
+++ b/Mathlib/GroupTheory/RegularWreathProduct.lean
@@ -165,7 +165,7 @@ instance instMulActionRWP : MulAction (D ≀ᵣ Q) (Λ × Q) where
 variable [FaithfulSMul D Λ]
 instance instFaithfulSMulRWP : FaithfulSMul (D ≀ᵣ Q) (Λ × Q) where
   eq_of_smul_eq_smul := by
-    simp
+    simp only [rsmul, Prod.mk.injEq, mul_left_inj, Prod.forall]
     intro m₁ m₂ h
     let ⟨a⟩ := ‹Nonempty Λ›
     let ⟨b⟩ := ‹Nonempty Q›

--- a/Mathlib/GroupTheory/RegularWreathProduct.lean
+++ b/Mathlib/GroupTheory/RegularWreathProduct.lean
@@ -209,9 +209,6 @@ instance [Finite G] : Finite (IteratedWreathProduct G n) := by
   | zero => rw [IteratedWreathProduct_zero]; exact Finite.of_subsingleton
   | succ n h => rw [IteratedWreathProduct_succ]; exact RegularWreathProduct.instFinite
 
-lemma elem_P0 (p : ℕ) (P : Sylow p (Equiv.Perm (Fin (1)))) (x : P):
-    x = 1 := Subsingleton.eq_one x
-
 theorem iter_wreath_card {p n : ℕ}
     (G : Type u) [Finite G] (h : Nat.card G = p) :
     Nat.card (IteratedWreathProduct G n) = p ^ (∑ i ∈ Finset.range n, p ^ i) := by
@@ -267,7 +264,7 @@ noncomputable def sylowIsIteratedWreathProduct (p n : ℕ) [Fact (Nat.Prime p)]
   | zero => exact {
       toFun := 1
       invFun := 1
-      left_inv x := by rw [Pi.one_apply, elem_P0 p P x]
+      left_inv x := by simp only [Nat.pow_zero]; apply Subsingleton.elim
       right_inv x:= by rw [Pi.one_apply]; rfl
       map_mul' := by simp}
   | succ n h_n =>

--- a/Mathlib/GroupTheory/RegularWreathProduct.lean
+++ b/Mathlib/GroupTheory/RegularWreathProduct.lean
@@ -129,26 +129,14 @@ theorem card [Finite D][Finite Q] :
   rw [Nat.card_prod (Q → D) Q]
   rw [Nat.card_fun]
 
-def congr_left {D₁ D₂ Q : Type*} [Group D₁] [Group D₂] [Group Q] (f : D₁ ≃* D₂):
-  D₁ ≀ᵣ Q ≃* D₂ ≀ᵣ Q where
-    toFun x := ⟨f ∘ x.left, x.right⟩
-    invFun x := ⟨f.symm ∘ x.left, x.right⟩
-    left_inv _ := by ext <;> simp
-    right_inv _ := by ext <;> simp
-    map_mul' x y := by ext <;> simp
-
-def congr_right {D Q₁ Q₂ : Type*} [Group D] [Group Q₁] [Group Q₂] (f : Q₁ ≃* Q₂):
-  D ≀ᵣ Q₁ ≃* D ≀ᵣ Q₂ where
-    toFun x := ⟨x.1.comp f.symm, f x.2⟩
-    invFun x := ⟨x.1.comp f, f.symm x.2⟩
+def congr {D₁ Q₁ D₂ Q₂ : Type*} [Group D₁] [Group Q₁] [Group D₂] [Group Q₂]
+(f : D₁ ≃* D₂) (g : Q₁ ≃* Q₂):
+  D₁ ≀ᵣ Q₁ ≃* D₂ ≀ᵣ Q₂ where
+    toFun x := ⟨f ∘ (x.left ∘ g.symm), g x.right⟩
+    invFun x := ⟨(f.symm ∘ x.left) ∘ g, g.symm x.right⟩
     left_inv x := by ext <;> simp
     right_inv x := by ext <;> simp
     map_mul' x y := by ext <;> simp
-
-def congr {D₁ Q₁ D₂ Q₂ : Type*} [Group D₁] [Group Q₁] [Group D₂] [Group Q₂]
-  (f : D₁ ≃* D₂) (g : Q₁ ≃* Q₂):
-    D₁ ≀ᵣ Q₁ ≃* D₂ ≀ᵣ Q₂ :=
-    (congr_left f).trans (congr_right g)
 
 section perm
 
@@ -222,7 +210,6 @@ instance [Finite G] : Finite (IteratedWreathProduct G n) := by
   induction n with
   | zero => rw [IteratedWreathProduct_zero]; exact Finite.of_subsingleton
   | succ n h => rw [IteratedWreathProduct_succ]; exact RegularWreathProduct.instFinite
-
 
 lemma elem_P0 (p : ℕ) (P : Sylow p (Equiv.Perm (Fin (1)))) (x:P):
   x = 1 := Subsingleton.eq_one x

--- a/Mathlib/GroupTheory/RegularWreathProduct.lean
+++ b/Mathlib/GroupTheory/RegularWreathProduct.lean
@@ -243,24 +243,19 @@ lemma mu_eq {p n : ℕ} [hp : Fact (Nat.Prime p)] :
     rw [pow_succ', hp.out.emultiplicity_factorial_mul, h, Finset.sum_range_succ, ENat.coe_add]
 
 /-- An auxilliary function -/
-def aux {A B : Type} (h : A ≃ B) : Equiv.Perm A →* Equiv.Perm B :=
-  MonoidHom.mk'
-    (fun k => h.symm.trans (k.trans h))
-    (by intro a b; ext x; simp)
-
-lemma aux_injective {A B : Type} (h : A ≃ B) : Function.Injective (aux h) := by
-  intro x y h_eq; ext a
-  replace h_eq : h.symm.trans (x.trans h) = h.symm.trans (y.trans h) := h_eq
-  have eq_fun := Equiv.ext_iff.mp h_eq
-  specialize eq_fun (h a)
-  simp at eq_fun
-  exact eq_fun
+def aux {A B : Type} (h : A ≃ B) : Equiv.Perm A ≃* Equiv.Perm B where
+  toFun x := h.symm.trans (x.trans h)
+  invFun y := h.trans (y.trans h.symm)
+  left_inv _ := by ext; simp
+  right_inv _ := by ext; simp
+  map_mul' _ _ := by ext; simp
 
 /-- An auxilliary function -/
 noncomputable def f {p n : ℕ} (D : Sylow p (Equiv.Perm (Fin (p^n))))
     (G : Type) [Finite G] [Group G] (h : Nat.card G = p) :
     D ≀ᵣ G →* Equiv.Perm (Fin (p^(n+1))) :=
-  (aux ((Equiv.prodCongrRight fun _ => (Finite.equivFinOfCardEq h)).trans finProdFinEquiv)).comp
+  (aux ((Equiv.prodCongrRight fun _ =>
+  (Finite.equivFinOfCardEq h)).trans finProdFinEquiv)).toMonoidHom.comp
   (RegularWreathProduct.toPerm D G (Fin (p^n)))
 
 lemma f_injective {p n : ℕ} [Fact (Nat.Prime p)] (D : Sylow p (Equiv.Perm (Fin (p^n))))
@@ -269,8 +264,8 @@ lemma f_injective {p n : ℕ} [Fact (Nat.Prime p)] (D : Sylow p (Equiv.Perm (Fin
   have : Function.Injective (RegularWreathProduct.toPerm D G (Fin (p^n))) :=
     RegularWreathProduct.toPermInj D G (Fin (p^n))
   exact (fun a b => Function.Injective.comp a b)
-    (aux_injective (((Equiv.prodCongrRight fun _ =>
-    (Finite.equivFinOfCardEq h)).trans finProdFinEquiv))) this
+    (aux (((Equiv.prodCongrRight fun _ =>
+    (Finite.equivFinOfCardEq h)).trans finProdFinEquiv))).injective this
 
 /-- The Sylow p-subgroups of S_{p^n} are isomorphic to the iterated wreathproduct -/
 noncomputable def sylowIsIteratedWreathProduct (p n : ℕ) [Fact (Nat.Prime p)]

--- a/Mathlib/GroupTheory/RegularWreathProduct.lean
+++ b/Mathlib/GroupTheory/RegularWreathProduct.lean
@@ -146,14 +146,11 @@ def congr {D₁ Q₁ D₂ Q₂ : Type*} [Group D₁] [Group Q₁] [Group D₂] [
 
 section perm
 
-variable (D : Type*) [Group D]
-variable (Q : Type*) [Group Q] [Nonempty Q]
-variable (Λ : Type*) [Nonempty Λ] [MulAction D Λ]
+variable (D Q Λ : Type*) [Group D] [Group Q] [MulAction D Λ]
 
 instance instSMulRWP : SMul (D ≀ᵣ Q) (Λ × Q) where
   smul w := fun p => ⟨(w.left (w.right * p.2)) • p.1, w.right * p.2⟩
 
-omit [Nonempty Λ] [Nonempty Q] in
 @[simp]
 lemma rsmul {w : D ≀ᵣ Q} {p : Λ × Q} :
     w • p = ⟨(w.left (w.right * p.2)) • p.1, w.right * p.2⟩ := rfl
@@ -163,7 +160,7 @@ instance instMulActionRWP : MulAction (D ≀ᵣ Q) (Λ × Q) where
   mul_smul := by simp [smul_smul, mul_assoc]
 
 variable [FaithfulSMul D Λ]
-instance instFaithfulSMulRWP : FaithfulSMul (D ≀ᵣ Q) (Λ × Q) where
+instance instFaithfulSMulRWP [Nonempty Q] [Nonempty Λ] : FaithfulSMul (D ≀ᵣ Q) (Λ × Q) where
   eq_of_smul_eq_smul := by
     simp only [rsmul, Prod.mk.injEq, mul_left_inj, Prod.forall]
     intro m₁ m₂ h
@@ -181,7 +178,7 @@ given `D`-set `Λ`. -/
 def toPerm : D ≀ᵣ Q →* Equiv.Perm (Λ × Q) :=
   MulAction.toPermHom (D ≀ᵣ Q) (Λ × Q)
 
-theorem toPermInj :
+theorem toPermInj [Nonempty Λ] :
   Function.Injective (toPerm D Q Λ) := MulAction.toPerm_injective
 
 end perm

--- a/Mathlib/GroupTheory/RegularWreathProduct.lean
+++ b/Mathlib/GroupTheory/RegularWreathProduct.lean
@@ -188,8 +188,7 @@ def IteratedWreathProduct (G : Type u) : (n : ℕ) → Type u
 | 0 => PUnit
 | n + 1 => (IteratedWreathProduct G n) ≀ᵣ G
 
-variable (G : Type u) [inst : Group G]
-variable (n : ℕ)
+variable (G : Type u) (n : ℕ)
 
 @[simp]
 lemma IteratedWreathProduct_zero (G : Type u) :
@@ -198,6 +197,8 @@ lemma IteratedWreathProduct_zero (G : Type u) :
 @[simp]
 lemma IteratedWreathProduct_succ (G : Type u) (n : ℕ) :
     IteratedWreathProduct G (n+1) = (IteratedWreathProduct G n) ≀ᵣ G := rfl
+
+variable [Group G]
 
 instance : Group (IteratedWreathProduct G n) := by
  induction n with

--- a/Mathlib/GroupTheory/RegularWreathProduct.lean
+++ b/Mathlib/GroupTheory/RegularWreathProduct.lean
@@ -232,117 +232,15 @@ theorem iter_wreath_card {p n : ℕ}
     rw [geom_sum_succ, IteratedWreathProduct_succ]
     rw [RegularWreathProduct.card, h_n, h]; group
 
-lemma mu_eq {p n : ℕ} [Fact (Nat.Prime p)] :
+lemma mu_eq {p n : ℕ} [hp : Fact (Nat.Prime p)] :
     (p ^ n).factorial.factorization p = ∑ i ∈ Finset.range n, p ^ i := by
+  rw [← Nat.multiplicity_eq_factorization hp.out (p ^ n).factorial_ne_zero, ← ENat.coe_inj,
+    ← (Nat.finiteMultiplicity_iff.2
+      ⟨hp.out.ne_one, (p ^ n).factorial_pos⟩).emultiplicity_eq_multiplicity]
   induction n with
-  | zero => simp
+  | zero => simp [hp.out.emultiplicity_one]
   | succ n h =>
-    rw [Finset.sum_range_succ, ← h]
-    let S : Finset ℕ := { k ∈ Finset.range (p^(n+1)) | p ∣ (k+1)}
-    have h_disjoint : Disjoint S (Finset.range (p ^ (n + 1)) \ S) := Finset.disjoint_sdiff
-    have h_decomp : (p^(n+1)).factorial =
-      (∏ k ∈ S, (k+1)) * (∏ k ∈ (Finset.range (p^(n+1)) \ S), (k+1)) := by
-      rw [← Finset.prod_union h_disjoint]
-      rw [Finset.union_sdiff_of_subset (Finset.filter_subset (fun k ↦ p ∣ k + 1)
-        (Finset.range (p ^ (n + 1))))]
-      rw [Finset.prod_range_add_one_eq_factorial]
-    have h_compl : (∏ k ∈ (Finset.range (p^(n+1)) \ S), (k+1)).factorization p = 0 := by
-        rw [Nat.factorization_prod (fun x => (fun _ => Ne.symm (Nat.zero_ne_add_one x)))]
-        rw [Finsupp.finset_sum_apply (Finset.range (p ^ (n + 1)) \ S)
-          (fun i ↦ (i + 1).factorization) p ]
-        apply Finset.sum_eq_zero
-        intro x hx
-        apply Nat.factorization_eq_zero_of_not_dvd
-        apply Finset.mem_sdiff.mp at hx
-        have h1 := hx.left; have h2 := hx.right
-        have hhh : ¬ (x ∈ { k ∈ Finset.range (p^(n+1)) | p ∣ (k+1)}) ↔
-          ¬ (x ∈ Finset.range (p^(n+1)) ∧ (p ∣ (x+1))) :=
-          not_congr Finset.mem_filter
-        apply hhh.mp at h2
-        simp at h2
-        simp at h1
-        exact h2 h1
-    have h1 : ∏ k ∈ S, (k + 1) ≠ 0 := by
-      apply Finset.prod_ne_zero_iff.mpr; intro x hx
-      exact Ne.symm (Nat.zero_ne_add_one x)
-    have h2 : ∏ k ∈ Finset.range (p ^ (n + 1)) \ S, (k + 1) ≠ 0 := by
-      apply Finset.prod_ne_zero_iff.mpr; intro x hx; exact Ne.symm (Nat.zero_ne_add_one x)
-    have aux : ((∏ k ∈ S, (k + 1)).factorization +
-      (∏ k ∈ Finset.range (p ^ (n + 1)) \ S, (k + 1)).factorization) p =
-      (∏ k ∈ S, (k + 1)).factorization p +
-      (∏ k ∈ Finset.range (p ^ (n + 1)) \ S, (k + 1)).factorization p := rfl
-    have res : ((p^(n+1)).factorial).factorization p = (∏ k ∈ S, (k + 1)).factorization p := by
-      rw [h_decomp, Nat.factorization_mul h1 h2, aux, h_compl, Nat.add_zero]
-    let f : ℕ → ℕ := fun m => p * (m + 1) - 1
-    have hf_mem : ∀ m ∈ Finset.range (p^n), f m ∈ S := by
-      intro m hm
-      apply List.mem_range.mp at hm
-      have f_bound : f m < p ^ (n + 1) := by
-        replace hm := Nat.sub_le_sub_right (Nat.mul_le_mul_left p (Nat.succ_le_of_lt hm)) 1
-        rw [Nat.pow_succ']
-        have : p * p ^ n - 1 < p * p ^ n := Nat.sub_one_lt (Ne.symm (NeZero.ne' (p * p ^ n)))
-        exact Nat.lt_of_le_of_lt hm this
-      have dvd : p ∣ (f m + 1) := by
-        rw [Nat.sub_add_cancel NeZero.one_le]
-        exact Nat.dvd_mul_right p (m + 1)
-      exact Finset.mem_filter.mpr ⟨Finset.mem_range.mpr f_bound, dvd⟩
-    have hf_inj' : ∀ m₁ m₂ : ℕ , f m₁ = f m₂ → m₁ = m₂ := by
-      intro m₁ m₂ h_eq
-      have aux1 : p * (m₁ + 1) = f m₁ + 1 := Eq.symm (Nat.sub_add_cancel NeZero.one_le)
-      have aux2 : p * (m₂ + 1) = f m₂ + 1 := Eq.symm (Nat.sub_add_cancel NeZero.one_le)
-      have : p * (m₁ + 1) = p * (m₂ + 1) := by
-        rw [aux1, aux2]
-        exact congrFun (congrArg HAdd.hAdd h_eq) 1
-      exact Nat.succ_inj.mp (Nat.eq_of_mul_eq_mul_left (Nat.pos_of_neZero p) this)
-    have hf_inj : Set.InjOn f ↑(Finset.range (p ^ n)) := fun ⦃x₁⦄ a ⦃x₂⦄ a ↦ hf_inj' x₁ x₂
-    have hf_surj : ∀ k ∈ S, ∃ m ∈ Finset.range (p^n), f m = k := by
-      intro k hk
-      apply Finset.mem_filter.mp at hk
-      obtain ⟨x,hx⟩ := exists_eq_mul_right_of_dvd hk.2
-      have : 0 < p * x := hx ▸ (Nat.zero_lt_succ k)
-      have aux : 0 < x := by exact Nat.lt_of_mul_lt_mul_left this
-      have x_bound : x - 1 < p^n := by
-        have hk1 := Nat.add_lt_add_right (List.mem_range.mp hk.1) 1
-        rw [hx, Nat.pow_succ'] at hk1
-        apply Nat.succ_le_of_lt at hk1
-        simp at hk1
-        apply le_of_nsmul_le_nsmul_right (NeZero.ne p) at hk1
-        apply Nat.sub_one_lt_of_le aux
-        exact hk1
-      have x_fun : f (x-1) = k := by
-        apply Nat.eq_sub_of_add_eq at hx
-        have : f (x - 1) = p * (x - 1 + 1) - 1 := rfl
-        rw [hx, this, Nat.sub_add_cancel aux]
-      use (x - 1); exact ⟨List.mem_range.mpr x_bound, x_fun⟩
-    have prod_reindex : ∏ m ∈ Finset.range (p^n), (p * (m + 1)) = ∏ k ∈ S, (k + 1) := by
-      apply (Finset.prod_nbij f hf_mem hf_inj hf_surj)
-      intro a ha
-      apply (Nat.sub_eq_iff_eq_add NeZero.one_le ).mp; rfl
-    rw [← prod_reindex] at res
-    have h_prod : (∏ m ∈ Finset.range (p^n), (p * (m + 1))).factorization p =
-      ∑ m ∈ Finset.range (p^n), (p * (m + 1)).factorization p := by
-      rw [Nat.factorization_prod (fun x => (fun _ => Nat.mul_ne_zero ((NeZero.ne' p).symm)
-        (Nat.zero_ne_add_one x).symm))]
-      simp
-    rw [h_prod] at res
-    have h_each : ∀ m ∈ Finset.range (p^n), (p*(m+1)).factorization p =
-      1 + (m+1).factorization p := by
-      intro m hm
-      have aux : (p.factorization + (m + 1).factorization) p =
-        p.factorization p + (m + 1).factorization p := rfl
-      rw [Nat.factorization_mul ((NeZero.ne' p).symm) (Ne.symm (Nat.zero_ne_add_one m))]
-      rw [aux, Nat.Prime.factorization_self (Fact.out)]
-    rw [Finset.sum_congr rfl h_each] at res
-    rw [Finset.sum_add_distrib,Finset.sum_const, Finset.card_range] at res
-    have h_back : ∑ x ∈ Finset.range (p ^ n), (x + 1).factorization p =
-      (p ^ n).factorial.factorization p := by
-      have aux : ∑ x ∈ Finset.range (p ^ n), (x + 1).factorization p =
-        (∑ x ∈ Finset.range (p ^ n), (x + 1).factorization) p := by
-        simp
-      rw [← Finset.prod_range_add_one_eq_factorial]
-      rw [Nat.factorization_prod (fun x => (fun hx => (Nat.zero_ne_add_one x).symm)), aux]
-    rw [h_back] at res; simp at res; rw [Nat.add_comm (p ^ n) _] at res
-    exact res
+    rw [pow_succ', hp.out.emultiplicity_factorial_mul, h, Finset.sum_range_succ, ENat.coe_add]
 
 /-- An auxilliary function -/
 def aux {A B : Type} (h : A ≃ B) : Equiv.Perm A →* Equiv.Perm B :=
@@ -364,7 +262,6 @@ noncomputable def f {p n : ℕ} (D : Sylow p (Equiv.Perm (Fin (p^n))))
     D ≀ᵣ G →* Equiv.Perm (Fin (p^(n+1))) :=
   (aux ((Equiv.prodCongrRight fun _ => (Finite.equivFinOfCardEq h)).trans finProdFinEquiv)).comp
   (RegularWreathProduct.toPerm D G (Fin (p^n)))
-
 
 lemma f_injective {p n : ℕ} [Fact (Nat.Prime p)] (D : Sylow p (Equiv.Perm (Fin (p^n))))
     (G : Type) [Finite G] [Group G] (h : Nat.card G = p) :

--- a/Mathlib/GroupTheory/RegularWreathProduct.lean
+++ b/Mathlib/GroupTheory/RegularWreathProduct.lean
@@ -236,19 +236,19 @@ def Equiv.permCongrHom {α β : Type u} (e : α ≃ β) : Equiv.Perm α ≃* Equ
 
 /-- The homomorphism from the wreath product of the Sylow `p`-subgroup and `Z_p` to
   the subgroup of `Perm (Fin p^(n+1))`. -/
-noncomputable def sylowWreathtoPermHom {p n : ℕ} (D : Sylow p (Equiv.Perm (Fin (p^n))))
+noncomputable def sylowWreathtoPermHom {p n : ℕ} (D : Sylow p (Equiv.Perm (Fin (p ^ n))))
     (Z_p : Type) [Finite Z_p] [Group Z_p] (h : Nat.card Z_p = p) :
-    D ≀ᵣ Z_p →* Equiv.Perm (Fin (p^(n+1))) :=
+    D ≀ᵣ Z_p →* Equiv.Perm (Fin (p ^ (n+1))) :=
   (Equiv.permCongrHom ((Equiv.prodCongrRight fun _ =>
   (Finite.equivFinOfCardEq h)).trans finProdFinEquiv)).toMonoidHom.comp
-  (RegularWreathProduct.toPerm D Z_p (Fin (p^n)))
+  (RegularWreathProduct.toPerm D Z_p (Fin (p ^ n)))
 
 lemma sylowWreathtoPermHomInj {p n : ℕ} [Fact (Nat.Prime p)]
-    (D : Sylow p (Equiv.Perm (Fin (p^n))))
+    (D : Sylow p (Equiv.Perm (Fin (p ^ n))))
     (G : Type) [Finite G] [Group G] (h : Nat.card G = p) :
     Function.Injective (sylowWreathtoPermHom D G h) := by
-  have : Function.Injective (RegularWreathProduct.toPerm D G (Fin (p^n))) :=
-    RegularWreathProduct.toPermInj D G (Fin (p^n))
+  have : Function.Injective (RegularWreathProduct.toPerm D G (Fin (p ^ n))) :=
+    RegularWreathProduct.toPermInj D G (Fin (p ^ n))
   exact (fun a b => Function.Injective.comp a b)
     (Equiv.permCongrHom (((Equiv.prodCongrRight fun _ =>
     (Finite.equivFinOfCardEq h)).trans finProdFinEquiv))).injective this
@@ -256,7 +256,7 @@ lemma sylowWreathtoPermHomInj {p n : ℕ} [Fact (Nat.Prime p)]
 /-- The Sylow `p`-subgroups of S_{p^n} are isomorphic to the iterated wreathproduct -/
 noncomputable def sylowIsIteratedWreathProduct (p n : ℕ) [Fact (Nat.Prime p)]
     (Z_p : Type) [Group Z_p] [Finite Z_p] (h : Nat.card Z_p = p)
-    (P : Sylow p (Equiv.Perm (Fin (p^n)))) :
+    (P : Sylow p (Equiv.Perm (Fin (p ^ n)))) :
     P ≃* (IteratedWreathProduct Z_p n) := by
   induction n with
   | zero => exact {
@@ -272,7 +272,7 @@ noncomputable def sylowIsIteratedWreathProduct (p n : ℕ) [Fact (Nat.Prime p)]
         (RegularWreathProduct.congr (h_n P').symm (MulEquiv.refl Z_p)).trans
         (MonoidHom.ofInjective (sylowWreathtoPermHomInj P' Z_p h))
       have sylow_card : Nat.card (MonoidHom.range (sylowWreathtoPermHom P' Z_p h)) =
-          p ^ (Nat.card (Equiv.Perm (Fin (p^(n+1))))).factorization p := by
+          p ^ (Nat.card (Equiv.Perm (Fin (p ^ (n+1))))).factorization p := by
         rw [Nat.card_congr (g.symm).toEquiv, iter_wreath_card Z_p, h]
         rw [Nat.card_eq_fintype_card, Fintype.card_perm, Fintype.card_fin, mu_eq]
       exact (P.equiv (Sylow.ofCard (MonoidHom.range (sylowWreathtoPermHom P' Z_p h))

--- a/Mathlib/GroupTheory/RegularWreathProduct.lean
+++ b/Mathlib/GroupTheory/RegularWreathProduct.lean
@@ -124,11 +124,8 @@ instance [Finite D] [Finite Q] : Finite (D ≀ᵣ Q) :=
   Finite.of_equiv _ (equivProd D Q).symm
 
 omit [Group D] [Group Q] in
-theorem card [Finite Q] :
-   Nat.card (D ≀ᵣ Q) = (Nat.card D^Nat.card Q) * Nat.card Q := by
-  rw [Nat.card_congr (equivProd D Q)]
-  rw [Nat.card_prod (Q → D) Q]
-  rw [Nat.card_fun]
+theorem card [Finite Q] : Nat.card (D ≀ᵣ Q) = Nat.card D ^ Nat.card Q * Nat.card Q := by
+  rw [Nat.card_congr (equivProd D Q), Nat.card_prod (Q → D) Q, Nat.card_fun]
 
 /-- Define an isomorphism from `D₁ ≀ᵣ Q₁` to `D₂ ≀ᵣ Q₂`
 given isomorphisms `D₁ ≀ᵣ Q₁` and `Q₁ ≃* Q₂`. -/

--- a/Mathlib/GroupTheory/RegularWreathProduct.lean
+++ b/Mathlib/GroupTheory/RegularWreathProduct.lean
@@ -54,8 +54,7 @@ instance : Mul (D ≀ᵣ Q) where
 lemma mul_def (a b : D ≀ᵣ Q) : a * b = ⟨a.1 * (fun x ↦ b.1 (a.2⁻¹ * x)), a.2 * b.2⟩ := rfl
 
 @[simp]
-theorem mul_left (a b : D ≀ᵣ Q) :
-    (a * b).left = a.left * (((fun x => b.left (a.right⁻¹ * x)))) := rfl
+theorem mul_left (a b : D ≀ᵣ Q) : (a * b).1 = a.1 * (((fun x => b.1 (a.2⁻¹ * x)))) := rfl
 
 @[simp]
 theorem mul_right (a b : D ≀ᵣ Q) : (a * b).right = a.right * b.right := rfl

--- a/Mathlib/GroupTheory/RegularWreathProduct.lean
+++ b/Mathlib/GroupTheory/RegularWreathProduct.lean
@@ -26,7 +26,7 @@ This file introduces the global notation `D ≀ᵣ Q` for `RegularWreathProduct 
 group, regular wreath product, sylow p-subgroup
 -/
 
-variable (D Q: Type*) [Group D] [Group Q]
+variable (D Q : Type*) [Group D] [Group Q]
 
 /-- The regular wreath product of groups `Q` and `D`.
     It the product of sets with the group operation
@@ -47,11 +47,11 @@ instance : Mul (RegularWreathProduct D Q) where
   mul d q := ⟨d.1 * (fun x => q.1 (d.2⁻¹ * x)), d.2 * q.2⟩
 
 lemma mul_def (d q : RegularWreathProduct D Q) :
-  d * q = ⟨d.1 * (fun x => q.1 (d.2⁻¹ * x)), d.2 * q.2⟩ := rfl
+    d * q = ⟨d.1 * (fun x => q.1 (d.2⁻¹ * x)), d.2 * q.2⟩ := rfl
 
 @[simp]
 theorem mul_left (a b : D ≀ᵣ Q) :
-  (a * b).left = a.left * (((fun x => b.left (a.right⁻¹ * x)))) := rfl
+    (a * b).left = a.left * (((fun x => b.left (a.right⁻¹ * x)))) := rfl
 
 @[simp]
 theorem mul_right (a b : D ≀ᵣ Q) : (a * b).right = a.right * b.right := rfl
@@ -69,7 +69,7 @@ instance : Inv (RegularWreathProduct D Q) where
 
 @[simp]
 theorem inv_left (a : D ≀ᵣ Q) :
-  a⁻¹.left = ((fun x => a.left⁻¹ (a.right * x))) := rfl
+    a⁻¹.left = ((fun x => a.left⁻¹ (a.right * x))) := rfl
 
 @[simp]
 theorem inv_right (a : D ≀ᵣ Q) : a⁻¹.right = a.right⁻¹ := rfl
@@ -108,17 +108,17 @@ theorem rightHom_eq_right : (rightHom : D ≀ᵣ Q → Q) = right := rfl
 theorem rightHom_comp_inl_eq_id : (rightHom : D ≀ᵣ Q →* Q).comp inl = MonoidHom.id _ := by ext; simp
 
 @[simp]
-theorem fun_id (q:Q) : rightHom (inl q : D ≀ᵣ Q) = q := by simp
+theorem fun_id (q : Q) : rightHom (inl q : D ≀ᵣ Q) = q := by simp
 
 /-- The equivalence map for the representation as a product. -/
-def equivProd D Q: D ≀ᵣ Q ≃ (Q → D) × Q where
+def equivProd D Q : D ≀ᵣ Q ≃ (Q → D) × Q where
   toFun := fun ⟨d, q⟩ => ⟨d, q⟩
   invFun := fun ⟨d, q⟩ => ⟨d, q⟩
   left_inv := fun _ => rfl
   right_inv := fun _ => rfl
 
 omit [Group D] [Group Q] in
-lemma equivProdInj: Function.Injective (equivProd D Q).toFun := by
+lemma equivProdInj : Function.Injective (equivProd D Q).toFun := by
   intro a b; simp
 
 instance [Finite D] [Finite Q] : Finite (D ≀ᵣ Q) := by
@@ -127,7 +127,7 @@ instance [Finite D] [Finite Q] : Finite (D ≀ᵣ Q) := by
 
 omit [Group D] [Group Q] in
 theorem card [Finite Q] :
- Nat.card (D ≀ᵣ Q) = (Nat.card D^Nat.card Q) * Nat.card Q := by
+   Nat.card (D ≀ᵣ Q) = (Nat.card D^Nat.card Q) * Nat.card Q := by
   rw [Nat.card_congr (equivProd D Q)]
   rw [Nat.card_prod (Q → D) Q]
   rw [Nat.card_fun]
@@ -135,18 +135,18 @@ theorem card [Finite Q] :
 /-- Define an isomorphism from `D₁ ≀ᵣ Q₁` to `D₂ ≀ᵣ Q₂`
 given isomorphisms `D₁ ≀ᵣ Q₁` and `Q₁ ≃* Q₂`. -/
 def congr {D₁ Q₁ D₂ Q₂ : Type*} [Group D₁] [Group Q₁] [Group D₂] [Group Q₂]
-(f : D₁ ≃* D₂) (g : Q₁ ≃* Q₂):
-  D₁ ≀ᵣ Q₁ ≃* D₂ ≀ᵣ Q₂ where
-    toFun x := ⟨f ∘ (x.left ∘ g.symm), g x.right⟩
-    invFun x := ⟨(f.symm ∘ x.left) ∘ g, g.symm x.right⟩
-    left_inv x := by ext <;> simp
-    right_inv x := by ext <;> simp
-    map_mul' x y := by ext <;> simp
+    (f : D₁ ≃* D₂) (g : Q₁ ≃* Q₂) :
+    D₁ ≀ᵣ Q₁ ≃* D₂ ≀ᵣ Q₂ where
+      toFun x := ⟨f ∘ (x.left ∘ g.symm), g x.right⟩
+      invFun x := ⟨(f.symm ∘ x.left) ∘ g, g.symm x.right⟩
+      left_inv x := by ext <;> simp
+      right_inv x := by ext <;> simp
+      map_mul' x y := by ext <;> simp
 
 section perm
 
-variable (D: Type*) [Group D]
-variable (Q: Type*) [Group Q] [Nonempty Q]
+variable (D : Type*) [Group D]
+variable (Q : Type*) [Group Q] [Nonempty Q]
 variable (Λ : Type*) [Nonempty Λ] [MulAction D Λ]
 
 instance instSMulRWP : SMul (D ≀ᵣ Q) (Λ × Q) where
@@ -154,10 +154,10 @@ instance instSMulRWP : SMul (D ≀ᵣ Q) (Λ × Q) where
 
 omit [Nonempty Λ] [Nonempty Q] in
 @[simp]
-lemma rsmul {w: D ≀ᵣ Q} {p : Λ × Q}:
- w • p = ⟨(w.left (w.right * p.2)) • p.1, w.right * p.2⟩ := rfl
+lemma rsmul {w : D ≀ᵣ Q} {p : Λ × Q} :
+    w • p = ⟨(w.left (w.right * p.2)) • p.1, w.right * p.2⟩ := rfl
 
-instance instMulActionRWP: MulAction (D ≀ᵣ Q) (Λ × Q) where
+instance instMulActionRWP : MulAction (D ≀ᵣ Q) (Λ × Q) where
   one_smul := by simp;
   mul_smul := by simp; intro x y a b; constructor
                  · rw [smul_smul]; group
@@ -165,7 +165,7 @@ instance instMulActionRWP: MulAction (D ≀ᵣ Q) (Λ × Q) where
 
 
 variable [FaithfulSMul D Λ]
-instance instFaithfulSMulRWP: FaithfulSMul (D ≀ᵣ Q) (Λ × Q) where
+instance instFaithfulSMulRWP : FaithfulSMul (D ≀ᵣ Q) (Λ × Q) where
   eq_of_smul_eq_smul := by
     simp; intro m₁ m₂ h;
     let ⟨a⟩ := ‹Nonempty Λ›
@@ -181,9 +181,9 @@ instance instFaithfulSMulRWP: FaithfulSMul (D ≀ᵣ Q) (Λ × Q) where
 /-- The map sending the wreath product `D ≀ᵣ Q` to its representation as a permutation of `Λ × Q`
 given `D`-set `Λ`. -/
 def toPerm : D ≀ᵣ Q →* Equiv.Perm (Λ × Q) :=
-    MulAction.toPermHom (D ≀ᵣ Q) (Λ × Q)
+  MulAction.toPermHom (D ≀ᵣ Q) (Λ × Q)
 
-theorem toPermInj:
+theorem toPermInj :
   Function.Injective (toPerm D Q Λ) := MulAction.toPerm_injective
 
 end perm
@@ -194,22 +194,22 @@ end RegularWreathProduct
 section iterated
 
 /-- The wreath product of group `G` iterated `n` times. -/
-def IteratedWreathProduct (G: Type) : (n:ℕ) → Type
+def IteratedWreathProduct (G : Type) : (n : ℕ) → Type
 | Nat.zero => PUnit
 | Nat.succ n => (IteratedWreathProduct G n) ≀ᵣ G
 
 @[simp]
 lemma IteratedWreathProduct_zero (G : Type) :
-  IteratedWreathProduct G 0 = PUnit := rfl
+    IteratedWreathProduct G 0 = PUnit := rfl
 
 @[simp]
 lemma IteratedWreathProduct_succ (G : Type)(n : ℕ) :
-  IteratedWreathProduct G (n+1) = (IteratedWreathProduct G n) ≀ᵣ G := rfl
+    IteratedWreathProduct G (n+1) = (IteratedWreathProduct G n) ≀ᵣ G := rfl
 
-variable (G: Type) [inst : Group G]
-variable (n: ℕ)
+variable (G : Type) [inst : Group G]
+variable (n : ℕ)
 
-instance: Group (IteratedWreathProduct G n) := by
+instance : Group (IteratedWreathProduct G n) := by
  induction n with
  | zero => rw [IteratedWreathProduct_zero]; exact CommGroup.toGroup
  | succ n ih => rw [IteratedWreathProduct_succ]; exact RegularWreathProduct.instGroup
@@ -219,20 +219,20 @@ instance [Finite G] : Finite (IteratedWreathProduct G n) := by
   | zero => rw [IteratedWreathProduct_zero]; exact Finite.of_subsingleton
   | succ n h => rw [IteratedWreathProduct_succ]; exact RegularWreathProduct.instFinite
 
-lemma elem_P0 (p : ℕ) (P : Sylow p (Equiv.Perm (Fin (1)))) (x:P):
-  x = 1 := Subsingleton.eq_one x
+lemma elem_P0 (p : ℕ) (P : Sylow p (Equiv.Perm (Fin (1)))) (x : P):
+    x = 1 := Subsingleton.eq_one x
 
 theorem iter_wreath_card {p n : ℕ}
-  (G : Type) [Finite G] (h : Nat.card G = p) :
-  Nat.card (IteratedWreathProduct G n) = p ^ (∑ i ∈ Finset.range n, p ^ i) := by
+    (G : Type) [Finite G] (h : Nat.card G = p) :
+    Nat.card (IteratedWreathProduct G n) = p ^ (∑ i ∈ Finset.range n, p ^ i) := by
   induction n with
   | zero => simp
   | succ n h_n =>
     rw [geom_sum_succ, IteratedWreathProduct_succ]
     rw [RegularWreathProduct.card, h_n, h]; group
 
-lemma mu_eq {p n :ℕ} [Fact (Nat.Prime p)]:
-(p ^ n).factorial.factorization p = ∑ i ∈ Finset.range n, p ^ i := by
+lemma mu_eq {p n : ℕ} [Fact (Nat.Prime p)] :
+    (p ^ n).factorial.factorization p = ∑ i ∈ Finset.range n, p ^ i := by
   induction n with
   | zero => simp
   | succ n h =>
@@ -359,42 +359,42 @@ lemma aux_injective {A B : Type} (h : A ≃ B) : Function.Injective (aux h) := b
 
 /-- An auxilliary function -/
 noncomputable def f {p n : ℕ} (D : Sylow p (Equiv.Perm (Fin (p^n))))
-  (G : Type) [Finite G] [Group G] (h: Nat.card G = p):
+    (G : Type) [Finite G] [Group G] (h : Nat.card G = p) :
     D ≀ᵣ G →* Equiv.Perm (Fin (p^(n+1))) :=
-     (aux ((Equiv.prodCongrRight fun _ => (Finite.equivFinOfCardEq h)).trans finProdFinEquiv)).comp
-      (RegularWreathProduct.toPerm D G (Fin (p^n)))
+  (aux ((Equiv.prodCongrRight fun _ => (Finite.equivFinOfCardEq h)).trans finProdFinEquiv)).comp
+  (RegularWreathProduct.toPerm D G (Fin (p^n)))
 
 
 lemma f_injective {p n : ℕ} [Fact (Nat.Prime p)] (D : Sylow p (Equiv.Perm (Fin (p^n))))
-  (G : Type) [Finite G] [Group G] (h: Nat.card G = p):
+    (G : Type) [Finite G] [Group G] (h : Nat.card G = p) :
     Function.Injective (f D G h) := by
-      have : Function.Injective (RegularWreathProduct.toPerm D G (Fin (p^n))) :=
-        RegularWreathProduct.toPermInj D G (Fin (p^n))
-      exact (fun a b => Function.Injective.comp a b)
-        (aux_injective (((Equiv.prodCongrRight fun _ =>
-        (Finite.equivFinOfCardEq h)).trans finProdFinEquiv))) this
+  have : Function.Injective (RegularWreathProduct.toPerm D G (Fin (p^n))) :=
+    RegularWreathProduct.toPermInj D G (Fin (p^n))
+  exact (fun a b => Function.Injective.comp a b)
+    (aux_injective (((Equiv.prodCongrRight fun _ =>
+    (Finite.equivFinOfCardEq h)).trans finProdFinEquiv))) this
 
 /-- The Sylow p-subgroups of S_{p^n} are isomorphic to the iterated wreathproduct -/
 noncomputable def sylowIsIteratedWreathProduct (p n : ℕ) [Fact (Nat.Prime p)]
-  (Z_p : Type) [Group Z_p] [Finite Z_p] (h: Nat.card Z_p = p)
-  (P : Sylow p (Equiv.Perm (Fin (p^n)))) :
-  P ≃* (IteratedWreathProduct Z_p n) := by
-    induction n with
-    | zero => exact {
-        toFun := 1
-        invFun := 1
-        left_inv x := by rw [Pi.one_apply, elem_P0 p P x]
-        right_inv x:= by rw [Pi.one_apply]; rfl
-        map_mul' := by simp}
-    | succ n h_n =>
-        let P' : Sylow p (Equiv.Perm (Fin (p ^ n))) := Inhabited.default
-        have g: (IteratedWreathProduct Z_p (n+1)) ≃* MonoidHom.range (f P' Z_p h) :=
-          (RegularWreathProduct.congr (h_n P').symm (MulEquiv.refl Z_p)).trans
-          (MonoidHom.ofInjective (f_injective P' Z_p h))
-        have sylow_card: Nat.card (MonoidHom.range (f P' Z_p h)) =
-        p ^ (Nat.card (Equiv.Perm (Fin (p^(n+1))))).factorization p := by
-          rw [Nat.card_congr (g.symm).toEquiv, iter_wreath_card Z_p h, Nat.card_eq_fintype_card]
-          rw [Fintype.card_perm,Fintype.card_fin,mu_eq]
-        exact (P.equiv (Sylow.ofCard (MonoidHom.range (f P' Z_p h)) sylow_card)).trans (id g.symm)
+    (Z_p : Type) [Group Z_p] [Finite Z_p] (h : Nat.card Z_p = p)
+    (P : Sylow p (Equiv.Perm (Fin (p^n)))) :
+    P ≃* (IteratedWreathProduct Z_p n) := by
+  induction n with
+  | zero => exact {
+      toFun := 1
+      invFun := 1
+      left_inv x := by rw [Pi.one_apply, elem_P0 p P x]
+      right_inv x:= by rw [Pi.one_apply]; rfl
+      map_mul' := by simp}
+  | succ n h_n =>
+      let P' : Sylow p (Equiv.Perm (Fin (p ^ n))) := Inhabited.default
+      have g : (IteratedWreathProduct Z_p (n+1)) ≃* MonoidHom.range (f P' Z_p h) :=
+        (RegularWreathProduct.congr (h_n P').symm (MulEquiv.refl Z_p)).trans
+        (MonoidHom.ofInjective (f_injective P' Z_p h))
+      have sylow_card : Nat.card (MonoidHom.range (f P' Z_p h)) =
+      p ^ (Nat.card (Equiv.Perm (Fin (p^(n+1))))).factorization p := by
+        rw [Nat.card_congr (g.symm).toEquiv, iter_wreath_card Z_p h, Nat.card_eq_fintype_card]
+        rw [Fintype.card_perm,Fintype.card_fin,mu_eq]
+      exact (P.equiv (Sylow.ofCard (MonoidHom.range (f P' Z_p h)) sylow_card)).trans (id g.symm)
 
 end iterated

--- a/Mathlib/GroupTheory/RegularWreathProduct.lean
+++ b/Mathlib/GroupTheory/RegularWreathProduct.lean
@@ -246,24 +246,26 @@ def Equiv.permCongrHom {α β : Type u} (e : α ≃ β) : Equiv.Perm α ≃* Equ
   right_inv _ := by ext; simp
   map_mul' _ _ := by ext; simp
 
-/-- An auxilliary function -/
-noncomputable def f {p n : ℕ} (D : Sylow p (Equiv.Perm (Fin (p^n))))
-    (G : Type) [Finite G] [Group G] (h : Nat.card G = p) :
-    D ≀ᵣ G →* Equiv.Perm (Fin (p^(n+1))) :=
+/-- The homomorphism from the wreath product of the Sylow `p`-subgroup and `Z_p` to
+  the subgroup of `Perm (Fin p^(n+1))`. -/
+noncomputable def sylowWreathtoPermHom {p n : ℕ} (D : Sylow p (Equiv.Perm (Fin (p^n))))
+    (Z_p : Type) [Finite Z_p] [Group Z_p] (h : Nat.card Z_p = p) :
+    D ≀ᵣ Z_p →* Equiv.Perm (Fin (p^(n+1))) :=
   (Equiv.permCongrHom ((Equiv.prodCongrRight fun _ =>
   (Finite.equivFinOfCardEq h)).trans finProdFinEquiv)).toMonoidHom.comp
-  (RegularWreathProduct.toPerm D G (Fin (p^n)))
+  (RegularWreathProduct.toPerm D Z_p (Fin (p^n)))
 
-lemma f_injective {p n : ℕ} [Fact (Nat.Prime p)] (D : Sylow p (Equiv.Perm (Fin (p^n))))
+lemma sylowWreathtoPermHomInj {p n : ℕ} [Fact (Nat.Prime p)]
+    (D : Sylow p (Equiv.Perm (Fin (p^n))))
     (G : Type) [Finite G] [Group G] (h : Nat.card G = p) :
-    Function.Injective (f D G h) := by
+    Function.Injective (sylowWreathtoPermHom D G h) := by
   have : Function.Injective (RegularWreathProduct.toPerm D G (Fin (p^n))) :=
     RegularWreathProduct.toPermInj D G (Fin (p^n))
   exact (fun a b => Function.Injective.comp a b)
     (Equiv.permCongrHom (((Equiv.prodCongrRight fun _ =>
     (Finite.equivFinOfCardEq h)).trans finProdFinEquiv))).injective this
 
-/-- The Sylow p-subgroups of S_{p^n} are isomorphic to the iterated wreathproduct -/
+/-- The Sylow `p`-subgroups of S_{p^n} are isomorphic to the iterated wreathproduct -/
 noncomputable def sylowIsIteratedWreathProduct (p n : ℕ) [Fact (Nat.Prime p)]
     (Z_p : Type) [Group Z_p] [Finite Z_p] (h : Nat.card Z_p = p)
     (P : Sylow p (Equiv.Perm (Fin (p^n)))) :
@@ -277,13 +279,15 @@ noncomputable def sylowIsIteratedWreathProduct (p n : ℕ) [Fact (Nat.Prime p)]
       map_mul' := by simp}
   | succ n h_n =>
       let P' : Sylow p (Equiv.Perm (Fin (p ^ n))) := Inhabited.default
-      have g : (IteratedWreathProduct Z_p (n+1)) ≃* MonoidHom.range (f P' Z_p h) :=
+      have g : (IteratedWreathProduct Z_p (n+1)) ≃*
+          MonoidHom.range (sylowWreathtoPermHom P' Z_p h) :=
         (RegularWreathProduct.congr (h_n P').symm (MulEquiv.refl Z_p)).trans
-        (MonoidHom.ofInjective (f_injective P' Z_p h))
-      have sylow_card : Nat.card (MonoidHom.range (f P' Z_p h)) =
+        (MonoidHom.ofInjective (sylowWreathtoPermHomInj P' Z_p h))
+      have sylow_card : Nat.card (MonoidHom.range (sylowWreathtoPermHom P' Z_p h)) =
       p ^ (Nat.card (Equiv.Perm (Fin (p^(n+1))))).factorization p := by
         rw [Nat.card_congr (g.symm).toEquiv, iter_wreath_card Z_p h, Nat.card_eq_fintype_card]
         rw [Fintype.card_perm,Fintype.card_fin,mu_eq]
-      exact (P.equiv (Sylow.ofCard (MonoidHom.range (f P' Z_p h)) sylow_card)).trans (id g.symm)
+      exact (P.equiv (Sylow.ofCard (MonoidHom.range (sylowWreathtoPermHom P' Z_p h))
+      sylow_card)).trans (id g.symm)
 
 end iterated

--- a/Mathlib/GroupTheory/RegularWreathProduct.lean
+++ b/Mathlib/GroupTheory/RegularWreathProduct.lean
@@ -135,11 +135,11 @@ given isomorphisms `D₁ ≀ᵣ Q₁` and `Q₁ ≃* Q₂`. -/
 def congr {D₁ Q₁ D₂ Q₂ : Type*} [Group D₁] [Group Q₁] [Group D₂] [Group Q₂]
     (f : D₁ ≃* D₂) (g : Q₁ ≃* Q₂) :
     D₁ ≀ᵣ Q₁ ≃* D₂ ≀ᵣ Q₂ where
-      toFun x := ⟨f ∘ (x.left ∘ g.symm), g x.right⟩
-      invFun x := ⟨(f.symm ∘ x.left) ∘ g, g.symm x.right⟩
-      left_inv x := by ext <;> simp
-      right_inv x := by ext <;> simp
-      map_mul' x y := by ext <;> simp
+  toFun x := ⟨f ∘ (x.left ∘ g.symm), g x.right⟩
+  invFun x := ⟨(f.symm ∘ x.left) ∘ g, g.symm x.right⟩
+  left_inv x := by ext <;> simp
+  right_inv x := by ext <;> simp
+  map_mul' x y := by ext <;> simp
 
 section perm
 

--- a/Mathlib/GroupTheory/RegularWreathProduct.lean
+++ b/Mathlib/GroupTheory/RegularWreathProduct.lean
@@ -179,8 +179,6 @@ theorem toPermInj [Nonempty Λ] : Function.Injective (toPerm D Q Λ) := MulActio
 end perm
 
 end RegularWreathProduct
-
-
 section iterated
 
 universe u

--- a/Mathlib/GroupTheory/RegularWreathProduct.lean
+++ b/Mathlib/GroupTheory/RegularWreathProduct.lean
@@ -34,9 +34,8 @@ group, regular wreath product, sylow p-subgroup
 
 variable (D Q : Type*) [Group D] [Group Q]
 
-/-- The regular wreath product of groups `Q` and `D`.
-    It the product `(Q → D) × Q` with the group operation
-  `⟨a₁, a₂⟩ * ⟨b₁, b₂⟩ = ⟨a₁ * (fun x => b₁ (a₂⁻¹ * x)), a₂ * b₂⟩` -/
+/-- The regular wreath product of groups `Q` and `D`. It the product `(Q → D) × Q` with the group
+operation `⟨a₁, a₂⟩ * ⟨b₁, b₂⟩ = ⟨a₁ * (fun x => b₁ (a₂⁻¹ * x)), a₂ * b₂⟩`. -/
 @[ext]
 structure RegularWreathProduct where
   /-- The function of Q → D -/

--- a/Mathlib/GroupTheory/RegularWreathProduct.lean
+++ b/Mathlib/GroupTheory/RegularWreathProduct.lean
@@ -20,7 +20,7 @@ There an hom into the regular wreath product `inl : D →* D ≀ᵣ Q`.
 
 ## Notation
 
-This file introduces the global notation `D ≀ᵣ Q` for `RegularWreathProduct D Q`
+This file introduces the global notation `D ≀ᵣ Q` for `RegularWreathProduct D Q`.
 
 ## Tags
 group, regular wreath product, sylow p-subgroup

--- a/Mathlib/GroupTheory/RegularWreathProduct.lean
+++ b/Mathlib/GroupTheory/RegularWreathProduct.lean
@@ -167,7 +167,8 @@ instance instMulActionRWP : MulAction (D ≀ᵣ Q) (Λ × Q) where
 variable [FaithfulSMul D Λ]
 instance instFaithfulSMulRWP : FaithfulSMul (D ≀ᵣ Q) (Λ × Q) where
   eq_of_smul_eq_smul := by
-    simp; intro m₁ m₂ h
+    simp
+    intro m₁ m₂ h
     let ⟨a⟩ := ‹Nonempty Λ›
     let ⟨b⟩ := ‹Nonempty Q›
     ext q

--- a/Mathlib/GroupTheory/RegularWreathProduct.lean
+++ b/Mathlib/GroupTheory/RegularWreathProduct.lean
@@ -242,10 +242,10 @@ lemma mu_eq {p n : ℕ} [hp : Fact (Nat.Prime p)] :
   | succ n h =>
     rw [pow_succ', hp.out.emultiplicity_factorial_mul, h, Finset.sum_range_succ, ENat.coe_add]
 
-/-- An auxilliary function -/
-def aux {A B : Type} (h : A ≃ B) : Equiv.Perm A ≃* Equiv.Perm B where
-  toFun x := h.symm.trans (x.trans h)
-  invFun y := h.trans (y.trans h.symm)
+/-- If `α` is equivalent to `β`, then `Perm α` is isomorphic to `Perm β`. -/
+def Equiv.permCongrHom {α β : Type} (e : α ≃ β) : Equiv.Perm α ≃* Equiv.Perm β where
+  toFun x := e.symm.trans (x.trans e)
+  invFun y := e.trans (y.trans e.symm)
   left_inv _ := by ext; simp
   right_inv _ := by ext; simp
   map_mul' _ _ := by ext; simp
@@ -254,7 +254,7 @@ def aux {A B : Type} (h : A ≃ B) : Equiv.Perm A ≃* Equiv.Perm B where
 noncomputable def f {p n : ℕ} (D : Sylow p (Equiv.Perm (Fin (p^n))))
     (G : Type) [Finite G] [Group G] (h : Nat.card G = p) :
     D ≀ᵣ G →* Equiv.Perm (Fin (p^(n+1))) :=
-  (aux ((Equiv.prodCongrRight fun _ =>
+  (Equiv.permCongrHom ((Equiv.prodCongrRight fun _ =>
   (Finite.equivFinOfCardEq h)).trans finProdFinEquiv)).toMonoidHom.comp
   (RegularWreathProduct.toPerm D G (Fin (p^n)))
 
@@ -264,7 +264,7 @@ lemma f_injective {p n : ℕ} [Fact (Nat.Prime p)] (D : Sylow p (Equiv.Perm (Fin
   have : Function.Injective (RegularWreathProduct.toPerm D G (Fin (p^n))) :=
     RegularWreathProduct.toPermInj D G (Fin (p^n))
   exact (fun a b => Function.Injective.comp a b)
-    (aux (((Equiv.prodCongrRight fun _ =>
+    (Equiv.permCongrHom (((Equiv.prodCongrRight fun _ =>
     (Finite.equivFinOfCardEq h)).trans finProdFinEquiv))).injective this
 
 /-- The Sylow p-subgroups of S_{p^n} are isomorphic to the iterated wreathproduct -/

--- a/Mathlib/GroupTheory/RegularWreathProduct.lean
+++ b/Mathlib/GroupTheory/RegularWreathProduct.lean
@@ -51,8 +51,7 @@ variable {D Q}
 instance : Mul (D ≀ᵣ Q) where
   mul a b := ⟨a.1 * (fun x => b.1 (a.2⁻¹ * x)), a.2 * b.2⟩
 
-lemma mul_def (a b : RegularWreathProduct D Q) :
-    a * b = ⟨a.1 * (fun x => b.1 (a.2⁻¹ * x)), a.2 * b.2⟩ := rfl
+lemma mul_def (a b : D ≀ᵣ Q) : a * b = ⟨a.1 * (fun x ↦ b.1 (a.2⁻¹ * x)), a.2 * b.2⟩ := rfl
 
 @[simp]
 theorem mul_left (a b : D ≀ᵣ Q) :

--- a/Mathlib/GroupTheory/RegularWreathProduct.lean
+++ b/Mathlib/GroupTheory/RegularWreathProduct.lean
@@ -31,7 +31,6 @@ variable (D Q: Type*) [Group D] [Group Q]
 /-- The regular wreath product of groups `Q` and `D`.
     It the product of sets with the group operation
   `⟨n₁, g₁⟩ * ⟨n₂, g₂⟩ = ⟨n₁ * φ g₁ n₂, g₁ * g₂⟩` -/
-
 @[ext]
 structure RegularWreathProduct where
   /-- The function of Q → D -/
@@ -84,12 +83,14 @@ instance : Group (RegularWreathProduct D Q) where
 
 instance : Inhabited (RegularWreathProduct D Q) := ⟨1⟩
 
-def rightHom : (D ≀ᵣ Q) →* Q where
+/-- The canonical projection map `D ≀ᵣ Q →* Q`, as a group hom. -/
+def rightHom : D ≀ᵣ Q →* Q where
   toFun := RegularWreathProduct.right
   map_one' := rfl
   map_mul' _ _ := rfl
 
-def inl : Q →* (D ≀ᵣ Q) where
+/-- The canonical map `Q →* D ≀ᵣ Q` sending `q` to `⟨1, q⟩` -/
+def inl : Q →* D ≀ᵣ Q where
   toFun q := ⟨1, q⟩
   map_one' := rfl
   map_mul' _ _ := by ext <;> simp
@@ -109,6 +110,7 @@ theorem rightHom_comp_inl_eq_id : (rightHom : D ≀ᵣ Q →* Q).comp inl = Mono
 @[simp]
 theorem fun_id (q:Q) : rightHom (inl q : D ≀ᵣ Q) = q := by simp
 
+/-- The equivalence map for the representation as a product. -/
 def equivProd D Q: D ≀ᵣ Q ≃ (Q → D) × Q where
   toFun := fun ⟨d, q⟩ => ⟨d, q⟩
   invFun := fun ⟨d, q⟩ => ⟨d, q⟩
@@ -124,12 +126,14 @@ instance [Finite D] [Finite Q] : Finite (D ≀ᵣ Q) := by
   apply Finite.instProd
 
 omit [Group D] [Group Q] in
-theorem card [Finite D][Finite Q] :
+theorem card [Finite Q] :
  Nat.card (D ≀ᵣ Q) = (Nat.card D^Nat.card Q) * Nat.card Q := by
   rw [Nat.card_congr (equivProd D Q)]
   rw [Nat.card_prod (Q → D) Q]
   rw [Nat.card_fun]
 
+/-- Define an isomorphism from `D₁ ≀ᵣ Q₁` to `D₂ ≀ᵣ Q₂`
+given isomorphisms `D₁ ≀ᵣ Q₁` and `Q₁ ≃* Q₂`. -/
 def congr {D₁ Q₁ D₂ Q₂ : Type*} [Group D₁] [Group Q₁] [Group D₂] [Group Q₂]
 (f : D₁ ≃* D₂) (g : Q₁ ≃* Q₂):
   D₁ ≀ᵣ Q₁ ≃* D₂ ≀ᵣ Q₂ where
@@ -174,6 +178,8 @@ instance instFaithfulSMulRWP: FaithfulSMul (D ≀ᵣ Q) (Λ × Q) where
       exact hh
     · exact (h a b).2
 
+/-- The map sending the wreath product `D ≀ᵣ Q` to its representation as a permutation of `Λ × Q`
+given `D`-set `Λ`. -/
 def toPerm : D ≀ᵣ Q →* Equiv.Perm (Λ × Q) :=
     MulAction.toPermHom (D ≀ᵣ Q) (Λ × Q)
 
@@ -187,7 +193,8 @@ end RegularWreathProduct
 
 section iterated
 
-def IteratedWreathProduct (G: Type) [Group G]: (n:ℕ) → Type
+/- The iterated wreath product of group `G` `n` times. -/
+def IteratedWreathProduct (G: Type) : (n:ℕ) → Type
 | Nat.zero => PUnit
 | Nat.succ n => (IteratedWreathProduct G n) ≀ᵣ G
 
@@ -290,7 +297,7 @@ lemma mu_eq {p n :ℕ} [Fact (Nat.Prime p)]:
     have hf_surj : ∀ k ∈ S, ∃ m ∈ Finset.range (p^n), f m = k := by
       intro k hk
       apply Finset.mem_filter.mp at hk
-      have hk1 := List.mem_range.mp hk.1; have hk2 := hk.2
+      have hk1 := List.mem_range.mp hk.1
       obtain ⟨x,hx⟩ := exists_eq_mul_right_of_dvd hk.2
       have : 0 < p * x := hx ▸ (Nat.zero_lt_succ k)
       have aux : 0 < x := by exact Nat.lt_of_mul_lt_mul_left this
@@ -310,7 +317,7 @@ lemma mu_eq {p n :ℕ} [Fact (Nat.Prime p)]:
     have prod_reindex : ∏ m ∈ Finset.range (p^n), (p * (m + 1)) = ∏ k ∈ S, (k + 1) := by
       apply (Finset.prod_nbij f hf_mem hf_inj hf_surj)
       intro a ha;
-      apply (Nat.sub_eq_iff_eq_add NeZero.one_le ).mp ; rfl
+      apply (Nat.sub_eq_iff_eq_add NeZero.one_le ).mp; rfl
     rw [← prod_reindex] at res
     have h_prod : (∏ m ∈ Finset.range (p^n), (p * (m + 1))).factorization p =
       ∑ m ∈ Finset.range (p^n), (p * (m + 1)).factorization p := by
@@ -337,6 +344,7 @@ lemma mu_eq {p n :ℕ} [Fact (Nat.Prime p)]:
     rw [h_back] at res; simp at res; rw [Nat.add_comm (p ^ n) _] at res
     exact res
 
+/- An auxilliary function -/
 def aux {A B : Type} (h : A ≃ B) : Equiv.Perm A →* Equiv.Perm B :=
   MonoidHom.mk'
     (fun k => h.symm.trans (k.trans h))
@@ -351,8 +359,9 @@ lemma aux_injective {A B : Type} (h : A ≃ B) : Function.Injective (aux h) := b
   exact eq_fun
 
 noncomputable
+/- An auxilliary function -/
 def f {p n : ℕ} [Fact (Nat.Prime p)] (D : Sylow p (Equiv.Perm (Fin (p^n))))
-  (G : Type) [Finite G] [Group G] [IsCyclic G] (h: Nat.card G = p):
+  (G : Type) [Finite G] [Group G] (h: Nat.card G = p):
     D ≀ᵣ G →* Equiv.Perm (Fin (p^(n+1))) :=
      (aux ((Equiv.prodCongrRight fun _ => (Finite.equivFinOfCardEq h)).trans finProdFinEquiv)).comp
       (RegularWreathProduct.toPerm D G (Fin (p^n)))
@@ -367,8 +376,9 @@ lemma f_injective {p n : ℕ} [Fact (Nat.Prime p)] (D : Sylow p (Equiv.Perm (Fin
         (aux_injective (((Equiv.prodCongrRight fun _ =>
         (Finite.equivFinOfCardEq h)).trans finProdFinEquiv))) this
 
+noncomputable
 /-The Sylow p-subgroups of S_{p^n} are isomorphic to the iterated wreathproduct -/
-noncomputable def sylowIsIteratedWreathProduct (p n : ℕ) [Fact (Nat.Prime p)]
+def sylowIsIteratedWreathProduct (p n : ℕ) [Fact (Nat.Prime p)]
   (Z_p : Type) [Group Z_p] [IsCyclic Z_p] [Finite Z_p] (h: Nat.card Z_p = p)
   (P : Sylow p (Equiv.Perm (Fin (p^n)))) :
   P ≃* (IteratedWreathProduct Z_p n) := by

--- a/Mathlib/GroupTheory/RegularWreathProduct.lean
+++ b/Mathlib/GroupTheory/RegularWreathProduct.lean
@@ -48,7 +48,7 @@ structure RegularWreathProduct where
 namespace RegularWreathProduct
 variable {D Q}
 
-instance : Mul (RegularWreathProduct D Q) where
+instance : Mul (D ≀ᵣ Q) where
   mul a b := ⟨a.1 * (fun x => b.1 (a.2⁻¹ * x)), a.2 * b.2⟩
 
 lemma mul_def (a b : RegularWreathProduct D Q) :

--- a/Mathlib/GroupTheory/RegularWreathProduct.lean
+++ b/Mathlib/GroupTheory/RegularWreathProduct.lean
@@ -23,7 +23,7 @@ There an hom into the regular wreath product `inl : D →* D ≀ᵣ Q`.
 This file introduces the global notation `D ≀ᵣ Q` for `RegularWreathProduct D Q`
 
 ## Tags
-group, regular wreath product
+group, regular wreath product, sylow p-subgroup
 -/
 
 variable (D Q: Type*) [Group D] [Group Q]

--- a/Mathlib/GroupTheory/RegularWreathProduct.lean
+++ b/Mathlib/GroupTheory/RegularWreathProduct.lean
@@ -13,7 +13,7 @@ import Mathlib.Data.Finite.Perm
 
 This file defines the regular wreath product of groups, and the canonical maps in and out of the
 product. The regular wreath product of `D` and `Q` is the product `(Q → D) × Q` with the group
-`⟨a₁, a₂⟩ * ⟨b₁, b₂⟩ = ⟨a₁ * (fun x => b₁ (a₂⁻¹ * x)), a₂ * b₂⟩`.
+operation `⟨a₁, a₂⟩ * ⟨b₁, b₂⟩ = ⟨a₁ * (fun x => b₁ (a₂⁻¹ * x)), a₂ * b₂⟩`.
 
 ## Main definitions
 

--- a/Mathlib/GroupTheory/RegularWreathProduct.lean
+++ b/Mathlib/GroupTheory/RegularWreathProduct.lean
@@ -120,10 +120,6 @@ def equivProd D Q : D ≀ᵣ Q ≃ (Q → D) × Q where
   left_inv := fun _ => rfl
   right_inv := fun _ => rfl
 
-omit [Group D] [Group Q] in
-lemma equivProdInj : Function.Injective (equivProd D Q).toFun := by
-  intro a b; simp
-
 instance [Finite D] [Finite Q] : Finite (D ≀ᵣ Q) :=
   Finite.of_equiv _ (equivProd D Q).symm
 

--- a/Mathlib/GroupTheory/RegularWreathProduct.lean
+++ b/Mathlib/GroupTheory/RegularWreathProduct.lean
@@ -52,7 +52,7 @@ variable {D Q}
 instance : Mul (D ≀ᵣ Q) where
   mul a b := ⟨a.1 * (fun x => b.1 (a.2⁻¹ * x)), a.2 * b.2⟩
 
-lemma mul_def (a b : D ≀ᵣ Q) : a * b = ⟨a.1 * (fun x ↦ b.1 (a.2⁻¹ * x)), a.2 * b.2⟩ := rfl
+lemma mul_def (a b : D ≀ᵣ Q) : a * b = ⟨a.1 * fun x ↦ b.1 (a.2⁻¹ * x), a.2 * b.2⟩ := rfl
 
 @[simp]
 theorem mul_left (a b : D ≀ᵣ Q) : (a * b).1 = a.1 * (((fun x => b.1 (a.2⁻¹ * x)))) := rfl

--- a/Mathlib/GroupTheory/RegularWreathProduct.lean
+++ b/Mathlib/GroupTheory/RegularWreathProduct.lean
@@ -180,6 +180,7 @@ theorem toPermInj [Nonempty Λ] : Function.Injective (toPerm D Q Λ) := MulActio
 end perm
 
 end RegularWreathProduct
+
 section iterated
 
 universe u

--- a/Mathlib/GroupTheory/RegularWreathProduct.lean
+++ b/Mathlib/GroupTheory/RegularWreathProduct.lean
@@ -257,7 +257,7 @@ noncomputable def sylowIsIteratedWreathProduct (p : ℕ) [Fact (Nat.Prime p)] (n
     (P : Sylow p (Equiv.Perm α)) :
     P ≃* IteratedWreathProduct G n := by
   let e1 : α ≃ (Fin n → G) := (Finite.equivFinOfCardEq hα).trans
-    (Finite.equivFinOfCardEq (by rw [Nat.card_fun, Nat.fin_card, hG])).symm
+    (Finite.equivFinOfCardEq (by rw [Nat.card_fun, Nat.card_fin, hG])).symm
   let f := (Equiv.Perm.permCongrHom e1.symm).toMonoidHom.comp (iteratedWreathToPermHom G n)
   have hf : Function.Injective f :=
     ((Equiv.Perm.permCongrHom e1.symm).comp_injective _).mpr (iteratedWreathToPermHomInj G n)

--- a/Mathlib/GroupTheory/RegularWreathProduct.lean
+++ b/Mathlib/GroupTheory/RegularWreathProduct.lean
@@ -254,7 +254,6 @@ lemma sylowWreathtoPermHomInj {p n : ℕ} [Fact (Nat.Prime p)]
     (Equiv.permCongrHom (((Equiv.prodCongrRight fun _ =>
     (Finite.equivFinOfCardEq h)).trans finProdFinEquiv))).injective this
 
-/-- The Sylow `p`-subgroups of S_{p^n} are isomorphic to the iterated wreathproduct -/
 def Fin.succFunEquiv (α : Type*) (n : ℕ) : (Fin (n + 1) → α) ≃ (Fin n → α) × α :=
   (Fin.appendEquiv n 1).symm.trans (Equiv.prodCongrRight fun _ ↦ Equiv.funUnique (Fin 1) α)
 
@@ -281,6 +280,7 @@ lemma iteratedWreathToPermHomInj (G : Type*) [Group G] :
       exact ((Fin.succFunEquiv G n).symm.permCongrHom.toEquiv.comp_injective _).mpr
         (RegularWreathProduct.toPermInj (IteratedWreathProduct G n) G (Fin n → G))
 
+/-- The Sylow `p`-subgroups of S_{p^n} are isomorphic to the iterated wreathproduct -/
 noncomputable def sylowIsIteratedWreathProduct (p : ℕ) [Fact (Nat.Prime p)] (n : ℕ)
     (α : Type*) [Finite α] (hα : Nat.card α = p ^ n)
     (G : Type*) [Group G] [Finite G] (hG : Nat.card G = p)

--- a/Mathlib/GroupTheory/RegularWreathProduct.lean
+++ b/Mathlib/GroupTheory/RegularWreathProduct.lean
@@ -7,6 +7,7 @@ Authors: Francisco Silva
 import Mathlib.GroupTheory.Sylow
 import Mathlib.Algebra.Group.PUnit
 import Mathlib.Data.Finite.Perm
+/- import SetTheory.Cardinal.Finite-/
 
 /-!
 # Regular wreath product
@@ -235,9 +236,6 @@ def Equiv.permCongrHom {α β : Type*} (e : α ≃ β) : Equiv.Perm α ≃* Equi
   left_inv _ := by ext; simp
   right_inv _ := by ext; simp
   map_mul' _ _ := by ext; simp
-
-lemma Nat.card_fin (n : ℕ) : Nat.card (Fin n) = n := by
-  rw [Nat.card_eq_fintype_card, Fintype.card_fin]
 
 /-- The homomorphism from `IteratedWreathProduct G n` to `Perm (Fin n → G)`. -/
 def iteratedWreathToPermHom (G : Type*) [Group G] :

--- a/Mathlib/GroupTheory/RegularWreathProduct.lean
+++ b/Mathlib/GroupTheory/RegularWreathProduct.lean
@@ -214,16 +214,6 @@ instance : Group (IteratedWreathProduct G n) := by
  | zero => rw [IteratedWreathProduct_zero]; infer_instance
  | succ n ih => rw [IteratedWreathProduct_succ]; infer_instance
 
-lemma mu_eq {p n : ℕ} [hp : Fact (Nat.Prime p)] :
-    (p ^ n).factorial.factorization p = ∑ i ∈ Finset.range n, p ^ i := by
-  rw [← Nat.multiplicity_eq_factorization hp.out (p ^ n).factorial_ne_zero, ← ENat.coe_inj,
-    ← (Nat.finiteMultiplicity_iff.2
-      ⟨hp.out.ne_one, (p ^ n).factorial_pos⟩).emultiplicity_eq_multiplicity]
-  induction n with
-  | zero => simp [hp.out.emultiplicity_one]
-  | succ n h =>
-    rw [pow_succ', hp.out.emultiplicity_factorial_mul, h, Finset.sum_range_succ, ENat.coe_add]
-
 /-- The homomorphism from `IteratedWreathProduct G n` to `Perm (Fin n → G)`. -/
 def iteratedWreathToPermHom (G : Type*) [Group G] :
     (n : ℕ) → (IteratedWreathProduct G n →* Equiv.Perm (Fin n → G))
@@ -246,7 +236,7 @@ lemma iteratedWreathToPermHomInj (G : Type*) [Group G] :
         (RegularWreathProduct.toPermInj (IteratedWreathProduct G n) G (Fin n → G))
 
 /-- The encoding of the Sylow `p`-subgroups of `Perm α` as an iterated wreath product. -/
-noncomputable def Sylow.mulEquivIteratedWreathProduct  (p : ℕ) [Fact (Nat.Prime p)] (n : ℕ)
+noncomputable def Sylow.mulEquivIteratedWreathProduct  (p : ℕ) [hp : Fact (Nat.Prime p)] (n : ℕ)
     (α : Type*) [Finite α] (hα : Nat.card α = p ^ n)
     (G : Type*) [Group G] [Finite G] (hG : Nat.card G = p)
     (P : Sylow p (Equiv.Perm α)) :
@@ -258,7 +248,9 @@ noncomputable def Sylow.mulEquivIteratedWreathProduct  (p : ℕ) [Fact (Nat.Prim
     ((Equiv.Perm.permCongrHom e1.symm).comp_injective _).mpr (iteratedWreathToPermHomInj G n)
   let g := (MonoidHom.ofInjective hf).symm
   let P' : Sylow p (Equiv.Perm α) := Sylow.ofCard (MonoidHom.range f) (by
-    rw [Nat.card_congr g.toEquiv, IteratedWreathProduct.card, hG, Nat.card_perm, hα, mu_eq])
+    rw [Nat.card_congr g.toEquiv, IteratedWreathProduct.card, hG, Nat.card_perm, hα,
+        ← Nat.multiplicity_eq_factorization hp.out (p ^ n).factorial_ne_zero,
+        Nat.Prime.multiplicity_factorial_pow hp.out])
   exact (P.equiv P').trans g
 
 end iterated

--- a/Mathlib/GroupTheory/RegularWreathProduct.lean
+++ b/Mathlib/GroupTheory/RegularWreathProduct.lean
@@ -56,7 +56,7 @@ instance : Mul (D ≀ᵣ Q) where
 lemma mul_def (a b : D ≀ᵣ Q) : a * b = ⟨a.1 * fun x ↦ b.1 (a.2⁻¹ * x), a.2 * b.2⟩ := rfl
 
 @[simp]
-theorem mul_left (a b : D ≀ᵣ Q) : (a * b).1 = a.1 * fun x => b.1 (a.2⁻¹ * x) := rfl
+theorem mul_left (a b : D ≀ᵣ Q) : (a * b).1 = a.1 * fun x ↦ b.1 (a.2⁻¹ * x) := rfl
 
 @[simp]
 theorem mul_right (a b : D ≀ᵣ Q) : (a * b).right = a.right * b.right := rfl
@@ -70,11 +70,10 @@ theorem one_left : (1 : D ≀ᵣ Q).left = 1 := rfl
 theorem one_right : (1 : D ≀ᵣ Q).right = 1 := rfl
 
 instance : Inv (RegularWreathProduct D Q) where
-  inv x := ⟨fun k => x.1⁻¹ (x.2 * k), x.2⁻¹⟩
+  inv x := ⟨fun k ↦ x.1⁻¹ (x.2 * k), x.2⁻¹⟩
 
 @[simp]
-theorem inv_left (a : D ≀ᵣ Q) :
-    a⁻¹.left = fun x => a.left⁻¹ (a.right * x) := rfl
+theorem inv_left (a : D ≀ᵣ Q) : a⁻¹.left = fun x ↦ a.left⁻¹ (a.right * x) := rfl
 
 @[simp]
 theorem inv_right (a : D ≀ᵣ Q) : a⁻¹.right = a.right⁻¹ := rfl

--- a/Mathlib/GroupTheory/RegularWreathProduct.lean
+++ b/Mathlib/GroupTheory/RegularWreathProduct.lean
@@ -236,10 +236,6 @@ def Equiv.permCongrHom {α β : Type*} (e : α ≃ β) : Equiv.Perm α ≃* Equi
   right_inv _ := by ext; simp
   map_mul' _ _ := by ext; simp
 
-/-- `Fin (n + 1) → α` and `(Fin n → α) × α` are equivalent. -/
-def Fin.succFunEquiv (α : Type*) (n : ℕ) : (Fin (n + 1) → α) ≃ (Fin n → α) × α :=
-  (Fin.appendEquiv n 1).symm.trans (Equiv.prodCongrRight fun _ ↦ Equiv.funUnique (Fin 1) α)
-
 lemma Nat.card_fin (n : ℕ) : Nat.card (Fin n) = n := by
   rw [Nat.card_eq_fintype_card, Fintype.card_fin]
 

--- a/Mathlib/GroupTheory/RegularWreathProduct.lean
+++ b/Mathlib/GroupTheory/RegularWreathProduct.lean
@@ -7,7 +7,6 @@ Authors: Francisco Silva
 import Mathlib.GroupTheory.Sylow
 import Mathlib.Algebra.Group.PUnit
 import Mathlib.Data.Finite.Perm
-/- import SetTheory.Cardinal.Finite-/
 
 /-!
 # Regular wreath product

--- a/Mathlib/GroupTheory/RegularWreathProduct.lean
+++ b/Mathlib/GroupTheory/RegularWreathProduct.lean
@@ -69,7 +69,7 @@ theorem one_left : (1 : D ≀ᵣ Q).left = 1 := rfl
 theorem one_right : (1 : D ≀ᵣ Q).right = 1 := rfl
 
 instance : Inv (RegularWreathProduct D Q) where
-  inv x := ⟨((fun k => x.1⁻¹ (x.2 * k))), x.2⁻¹⟩
+  inv x := ⟨fun k => x.1⁻¹ (x.2 * k), x.2⁻¹⟩
 
 @[simp]
 theorem inv_left (a : D ≀ᵣ Q) :

--- a/Mathlib/GroupTheory/RegularWreathProduct.lean
+++ b/Mathlib/GroupTheory/RegularWreathProduct.lean
@@ -6,6 +6,7 @@ Authors: Francisco Silva
 
 import Mathlib.GroupTheory.Sylow
 import Mathlib.Algebra.Group.PUnit
+import Mathlib.Data.Finite.Perm
 
 /-!
 # Regular wreath product

--- a/Mathlib/GroupTheory/RegularWreathProduct.lean
+++ b/Mathlib/GroupTheory/RegularWreathProduct.lean
@@ -143,7 +143,7 @@ section perm
 variable (D Q) (Λ : Type*) [MulAction D Λ]
 
 instance : SMul (D ≀ᵣ Q) (Λ × Q) where
-  smul w := fun p => ⟨(w.left (w.right * p.2)) • p.1, w.right * p.2⟩
+  smul w p := ⟨(w.left (w.right * p.2)) • p.1, w.right * p.2⟩
 
 @[simp]
 lemma smul_def {w : D ≀ᵣ Q} {p : Λ × Q} : w • p = ⟨(w.1 (w.2 * p.2)) • p.1, w.2 * p.2⟩ := rfl

--- a/Mathlib/GroupTheory/RegularWreathProduct.lean
+++ b/Mathlib/GroupTheory/RegularWreathProduct.lean
@@ -150,7 +150,7 @@ instance : SMul (D ≀ᵣ Q) (Λ × Q) where
   smul w := fun p => ⟨(w.left (w.right * p.2)) • p.1, w.right * p.2⟩
 
 @[simp]
-lemma rsmul {w : D ≀ᵣ Q} {p : Λ × Q} : w • p = ⟨(w.1 (w.2 * p.2)) • p.1, w.2 * p.2⟩ := rfl
+lemma smul_def {w : D ≀ᵣ Q} {p : Λ × Q} : w • p = ⟨(w.1 (w.2 * p.2)) • p.1, w.2 * p.2⟩ := rfl
 
 instance : MulAction (D ≀ᵣ Q) (Λ × Q) where
   one_smul := by simp
@@ -159,7 +159,7 @@ instance : MulAction (D ≀ᵣ Q) (Λ × Q) where
 variable [FaithfulSMul D Λ]
 instance [Nonempty Q] [Nonempty Λ] : FaithfulSMul (D ≀ᵣ Q) (Λ × Q) where
   eq_of_smul_eq_smul := by
-    simp only [rsmul, Prod.mk.injEq, mul_left_inj, Prod.forall]
+    simp only [smul_def, Prod.mk.injEq, mul_left_inj, Prod.forall]
     intro m₁ m₂ h
     let ⟨a⟩ := ‹Nonempty Λ›
     let ⟨b⟩ := ‹Nonempty Q›

--- a/Mathlib/GroupTheory/RegularWreathProduct.lean
+++ b/Mathlib/GroupTheory/RegularWreathProduct.lean
@@ -254,12 +254,14 @@ lemma sylowWreathtoPermHomInj {p n : ℕ} [Fact (Nat.Prime p)]
     (Equiv.permCongrHom (((Equiv.prodCongrRight fun _ =>
     (Finite.equivFinOfCardEq h)).trans finProdFinEquiv))).injective this
 
+/-- `Fin (n + 1) → α` and `(Fin n → α) × α` are equivalent. -/
 def Fin.succFunEquiv (α : Type*) (n : ℕ) : (Fin (n + 1) → α) ≃ (Fin n → α) × α :=
   (Fin.appendEquiv n 1).symm.trans (Equiv.prodCongrRight fun _ ↦ Equiv.funUnique (Fin 1) α)
 
 lemma Nat.card_fin (n : ℕ) : Nat.card (Fin n) = n := by
   rw [Nat.card_eq_fintype_card, Fintype.card_fin]
 
+/-- The homomorphism from `IteratedWreathProduct G n` to `Perm (Fin n → G)`. -/
 def iteratedWreathToPermHom (G : Type*) [Group G] :
     (n : ℕ) → (IteratedWreathProduct G n →* Equiv.Perm (Fin n → G))
   | 0 => 1
@@ -280,7 +282,7 @@ lemma iteratedWreathToPermHomInj (G : Type*) [Group G] :
       exact ((Fin.succFunEquiv G n).symm.permCongrHom.toEquiv.comp_injective _).mpr
         (RegularWreathProduct.toPermInj (IteratedWreathProduct G n) G (Fin n → G))
 
-/-- The Sylow `p`-subgroups of S_{p^n} are isomorphic to the iterated wreathproduct -/
+/-- The encoding of the Sylow `p`-subgroups of `Perm α` as an iterated wreath product. -/
 noncomputable def sylowIsIteratedWreathProduct (p : ℕ) [Fact (Nat.Prime p)] (n : ℕ)
     (α : Type*) [Finite α] (hα : Nat.card α = p ^ n)
     (G : Type*) [Group G] [Finite G] (hG : Nat.card G = p)

--- a/Mathlib/GroupTheory/RegularWreathProduct.lean
+++ b/Mathlib/GroupTheory/RegularWreathProduct.lean
@@ -7,6 +7,7 @@ Authors: Francisco Silva
 import Mathlib.GroupTheory.Sylow
 import Mathlib.Algebra.Group.PUnit
 import Mathlib.Data.Finite.Perm
+import Mathlib.Algebra.Group.End
 
 /-!
 # Regular wreath product
@@ -228,21 +229,13 @@ lemma mu_eq {p n : ℕ} [hp : Fact (Nat.Prime p)] :
   | succ n h =>
     rw [pow_succ', hp.out.emultiplicity_factorial_mul, h, Finset.sum_range_succ, ENat.coe_add]
 
-/-- If `α` is equivalent to `β`, then `Perm α` is isomorphic to `Perm β`. -/
-def Equiv.permCongrHom {α β : Type*} (e : α ≃ β) : Equiv.Perm α ≃* Equiv.Perm β where
-  toFun x := e.symm.trans (x.trans e)
-  invFun y := e.trans (y.trans e.symm)
-  left_inv _ := by ext; simp
-  right_inv _ := by ext; simp
-  map_mul' _ _ := by ext; simp
-
 /-- The homomorphism from `IteratedWreathProduct G n` to `Perm (Fin n → G)`. -/
 def iteratedWreathToPermHom (G : Type*) [Group G] :
     (n : ℕ) → (IteratedWreathProduct G n →* Equiv.Perm (Fin n → G))
   | 0 => 1
   | n + 1 => by
       let _ := MulAction.compHom (Fin n → G) (iteratedWreathToPermHom G n)
-      exact (Fin.succFunEquiv G n).symm.permCongrHom.toMonoidHom.comp
+      exact (Equiv.Perm.permCongrHom (Fin.succFunEquiv G n).symm).toMonoidHom.comp
         (RegularWreathProduct.toPerm (IteratedWreathProduct G n) G (Fin n → G))
 
 lemma iteratedWreathToPermHomInj (G : Type*) [Group G] :
@@ -254,7 +247,7 @@ lemma iteratedWreathToPermHomInj (G : Type*) [Group G] :
       let _ := MulAction.compHom (Fin n → G) (iteratedWreathToPermHom G n)
       have : FaithfulSMul (IteratedWreathProduct G n) (Fin n → G) :=
         ⟨fun h ↦ iteratedWreathToPermHomInj G n (Equiv.ext h)⟩
-      exact ((Fin.succFunEquiv G n).symm.permCongrHom.toEquiv.comp_injective _).mpr
+      exact ((Equiv.Perm.permCongrHom (Fin.succFunEquiv G n).symm).toEquiv.comp_injective _).mpr
         (RegularWreathProduct.toPermInj (IteratedWreathProduct G n) G (Fin n → G))
 
 /-- The encoding of the Sylow `p`-subgroups of `Perm α` as an iterated wreath product. -/
@@ -265,9 +258,9 @@ noncomputable def sylowIsIteratedWreathProduct (p : ℕ) [Fact (Nat.Prime p)] (n
     P ≃* IteratedWreathProduct G n := by
   let e1 : α ≃ (Fin n → G) := (Finite.equivFinOfCardEq hα).trans
     (Finite.equivFinOfCardEq (by rw [Nat.card_fun, Nat.fin_card, hG])).symm
-  let f := (Equiv.permCongrHom e1.symm).toMonoidHom.comp (iteratedWreathToPermHom G n)
+  let f := (Equiv.Perm.permCongrHom e1.symm).toMonoidHom.comp (iteratedWreathToPermHom G n)
   have hf : Function.Injective f :=
-    ((Equiv.permCongrHom e1.symm).comp_injective _).mpr (iteratedWreathToPermHomInj G n)
+    ((Equiv.Perm.permCongrHom e1.symm).comp_injective _).mpr (iteratedWreathToPermHomInj G n)
   let g := (MonoidHom.ofInjective hf).symm
   let P' : Sylow p (Equiv.Perm α) := Sylow.ofCard (MonoidHom.range f) (by
     rw [Nat.card_congr g.toEquiv, iter_wreath_card, hG, Nat.card_perm, hα, mu_eq])

--- a/Mathlib/GroupTheory/RegularWreathProduct.lean
+++ b/Mathlib/GroupTheory/RegularWreathProduct.lean
@@ -200,7 +200,7 @@ instance [Finite G] : Finite (IteratedWreathProduct G n) := by
   | zero => rw [IteratedWreathProduct_zero]; infer_instance
   | succ n h => rw [IteratedWreathProduct_succ]; infer_instance
 
-theorem iter_wreath_card [Finite G] : Nat.card (IteratedWreathProduct G n) =
+theorem IteratedWreathProduct.card [Finite G] : Nat.card (IteratedWreathProduct G n) =
     Nat.card G ^ (∑ i ∈ Finset.range n, Nat.card G ^ i) := by
   induction n with
   | zero => simp
@@ -258,7 +258,7 @@ noncomputable def Sylow.mulEquivIteratedWreathProduct  (p : ℕ) [Fact (Nat.Prim
     ((Equiv.Perm.permCongrHom e1.symm).comp_injective _).mpr (iteratedWreathToPermHomInj G n)
   let g := (MonoidHom.ofInjective hf).symm
   let P' : Sylow p (Equiv.Perm α) := Sylow.ofCard (MonoidHom.range f) (by
-    rw [Nat.card_congr g.toEquiv, iter_wreath_card, hG, Nat.card_perm, hα, mu_eq])
+    rw [Nat.card_congr g.toEquiv, IteratedWreathProduct.card, hG, Nat.card_perm, hα, mu_eq])
   exact (P.equiv P').trans g
 
 end iterated

--- a/Mathlib/GroupTheory/RegularWreathProduct.lean
+++ b/Mathlib/GroupTheory/RegularWreathProduct.lean
@@ -146,18 +146,18 @@ section perm
 
 variable (D Q) (Λ : Type*) [MulAction D Λ]
 
-instance instSMulRWP : SMul (D ≀ᵣ Q) (Λ × Q) where
+instance : SMul (D ≀ᵣ Q) (Λ × Q) where
   smul w := fun p => ⟨(w.left (w.right * p.2)) • p.1, w.right * p.2⟩
 
 @[simp]
 lemma rsmul {w : D ≀ᵣ Q} {p : Λ × Q} : w • p = ⟨(w.1 (w.2 * p.2)) • p.1, w.2 * p.2⟩ := rfl
 
-instance instMulActionRWP : MulAction (D ≀ᵣ Q) (Λ × Q) where
+instance : MulAction (D ≀ᵣ Q) (Λ × Q) where
   one_smul := by simp
   mul_smul := by simp [smul_smul, mul_assoc]
 
 variable [FaithfulSMul D Λ]
-instance instFaithfulSMulRWP [Nonempty Q] [Nonempty Λ] : FaithfulSMul (D ≀ᵣ Q) (Λ × Q) where
+instance [Nonempty Q] [Nonempty Λ] : FaithfulSMul (D ≀ᵣ Q) (Λ × Q) where
   eq_of_smul_eq_smul := by
     simp only [rsmul, Prod.mk.injEq, mul_left_inj, Prod.forall]
     intro m₁ m₂ h

--- a/Mathlib/GroupTheory/RegularWreathProduct.lean
+++ b/Mathlib/GroupTheory/RegularWreathProduct.lean
@@ -236,25 +236,6 @@ def Equiv.permCongrHom {α β : Type*} (e : α ≃ β) : Equiv.Perm α ≃* Equi
   right_inv _ := by ext; simp
   map_mul' _ _ := by ext; simp
 
-/-- The homomorphism from the wreath product of the Sylow `p`-subgroup and `Z_p` to
-  the subgroup of `Perm (Fin p^(n+1))`. -/
-noncomputable def sylowWreathtoPermHom {p n : ℕ} (D : Sylow p (Equiv.Perm (Fin (p ^ n))))
-    (Z_p : Type*) [Finite Z_p] [Group Z_p] (h : Nat.card Z_p = p) :
-    D ≀ᵣ Z_p →* Equiv.Perm (Fin (p ^ (n + 1))) :=
-  (Equiv.permCongrHom ((Equiv.prodCongrRight fun _ =>
-  (Finite.equivFinOfCardEq h)).trans finProdFinEquiv)).toMonoidHom.comp
-  (RegularWreathProduct.toPerm D Z_p (Fin (p ^ n)))
-
-lemma sylowWreathtoPermHomInj {p n : ℕ} [Fact (Nat.Prime p)]
-    (D : Sylow p (Equiv.Perm (Fin (p ^ n))))
-    (G : Type) [Finite G] [Group G] (h : Nat.card G = p) :
-    Function.Injective (sylowWreathtoPermHom D G h) := by
-  have : Function.Injective (RegularWreathProduct.toPerm D G (Fin (p ^ n))) :=
-    RegularWreathProduct.toPermInj D G (Fin (p ^ n))
-  exact (fun a b => Function.Injective.comp a b)
-    (Equiv.permCongrHom (((Equiv.prodCongrRight fun _ =>
-    (Finite.equivFinOfCardEq h)).trans finProdFinEquiv))).injective this
-
 /-- `Fin (n + 1) → α` and `(Fin n → α) × α` are equivalent. -/
 def Fin.succFunEquiv (α : Type*) (n : ℕ) : (Fin (n + 1) → α) ≃ (Fin n → α) × α :=
   (Fin.appendEquiv n 1).symm.trans (Equiv.prodCongrRight fun _ ↦ Equiv.funUnique (Fin 1) α)

--- a/Mathlib/GroupTheory/RegularWreathProduct.lean
+++ b/Mathlib/GroupTheory/RegularWreathProduct.lean
@@ -23,8 +23,8 @@ operation `⟨a₁, a₂⟩ * ⟨b₁, b₂⟩ = ⟨a₁ * (fun x ↦ b₁ (a₂
 * `inl` : The canonical map `Q →* D ≀ᵣ Q`.
 * `toPerm` : The homomorphism from `D ≀ᵣ Q` to `Equiv.Perm (Λ × Q)`, where `Λ` is a `D`-set.
 * `IteratedWreathProduct G n` : The iterated wreath product of a group `G` `n` times.
-* `sylowIsIteratedWreathProduct` : The isomorphism between the Sylow `p`-subgroup of `Perm p^n` and
-  the iterated wreath product of the cyclic group of order `p` `n` times.
+* `Sylow.mulEquivIteratedWreathProduct` : The isomorphism between the Sylow `p`-subgroup of `Perm
+  p^n` and the iterated wreath product of the cyclic group of order `p` `n` times.
 
 ## Notation
 
@@ -251,7 +251,7 @@ lemma iteratedWreathToPermHomInj (G : Type*) [Group G] :
         (RegularWreathProduct.toPermInj (IteratedWreathProduct G n) G (Fin n → G))
 
 /-- The encoding of the Sylow `p`-subgroups of `Perm α` as an iterated wreath product. -/
-noncomputable def sylowIsIteratedWreathProduct (p : ℕ) [Fact (Nat.Prime p)] (n : ℕ)
+noncomputable def Sylow.mulEquivIteratedWreathProduct  (p : ℕ) [Fact (Nat.Prime p)] (n : ℕ)
     (α : Type*) [Finite α] (hα : Nat.card α = p ^ n)
     (G : Type*) [Group G] [Finite G] (hG : Nat.card G = p)
     (P : Sylow p (Equiv.Perm α)) :

--- a/Mathlib/GroupTheory/RegularWreathProduct.lean
+++ b/Mathlib/GroupTheory/RegularWreathProduct.lean
@@ -73,7 +73,7 @@ instance : Inv (RegularWreathProduct D Q) where
 
 @[simp]
 theorem inv_left (a : D ≀ᵣ Q) :
-    a⁻¹.left = ((fun x => a.left⁻¹ (a.right * x))) := rfl
+    a⁻¹.left = fun x => a.left⁻¹ (a.right * x) := rfl
 
 @[simp]
 theorem inv_right (a : D ≀ᵣ Q) : a⁻¹.right = a.right⁻¹ := rfl

--- a/Mathlib/GroupTheory/RegularWreathProduct.lean
+++ b/Mathlib/GroupTheory/RegularWreathProduct.lean
@@ -14,7 +14,7 @@ import Mathlib.Algebra.Group.End
 
 This file defines the regular wreath product of groups, and the canonical maps in and out of the
 product. The regular wreath product of `D` and `Q` is the product `(Q → D) × Q` with the group
-operation `⟨a₁, a₂⟩ * ⟨b₁, b₂⟩ = ⟨a₁ * (fun x => b₁ (a₂⁻¹ * x)), a₂ * b₂⟩`.
+operation `⟨a₁, a₂⟩ * ⟨b₁, b₂⟩ = ⟨a₁ * (fun x ↦ b₁ (a₂⁻¹ * x)), a₂ * b₂⟩`.
 
 ## Main definitions
 
@@ -37,7 +37,7 @@ group, regular wreath product, sylow p-subgroup
 variable (D Q : Type*) [Group D] [Group Q]
 
 /-- The regular wreath product of groups `Q` and `D`. It the product `(Q → D) × Q` with the group
-operation `⟨a₁, a₂⟩ * ⟨b₁, b₂⟩ = ⟨a₁ * (fun x => b₁ (a₂⁻¹ * x)), a₂ * b₂⟩`. -/
+operation `⟨a₁, a₂⟩ * ⟨b₁, b₂⟩ = ⟨a₁ * (fun x ↦ b₁ (a₂⁻¹ * x)), a₂ * b₂⟩`. -/
 @[ext]
 structure RegularWreathProduct where
   /-- The function of Q → D -/
@@ -51,7 +51,7 @@ namespace RegularWreathProduct
 variable {D Q}
 
 instance : Mul (D ≀ᵣ Q) where
-  mul a b := ⟨a.1 * (fun x => b.1 (a.2⁻¹ * x)), a.2 * b.2⟩
+  mul a b := ⟨a.1 * (fun x ↦ b.1 (a.2⁻¹ * x)), a.2 * b.2⟩
 
 lemma mul_def (a b : D ≀ᵣ Q) : a * b = ⟨a.1 * fun x ↦ b.1 (a.2⁻¹ * x), a.2 * b.2⟩ := rfl
 

--- a/Mathlib/GroupTheory/RegularWreathProduct.lean
+++ b/Mathlib/GroupTheory/RegularWreathProduct.lean
@@ -55,7 +55,7 @@ instance : Mul (D ≀ᵣ Q) where
 lemma mul_def (a b : D ≀ᵣ Q) : a * b = ⟨a.1 * fun x ↦ b.1 (a.2⁻¹ * x), a.2 * b.2⟩ := rfl
 
 @[simp]
-theorem mul_left (a b : D ≀ᵣ Q) : (a * b).1 = a.1 * (((fun x => b.1 (a.2⁻¹ * x)))) := rfl
+theorem mul_left (a b : D ≀ᵣ Q) : (a * b).1 = a.1 * fun x => b.1 (a.2⁻¹ * x) := rfl
 
 @[simp]
 theorem mul_right (a b : D ≀ᵣ Q) : (a * b).right = a.right * b.right := rfl

--- a/Mathlib/GroupTheory/RegularWreathProduct.lean
+++ b/Mathlib/GroupTheory/RegularWreathProduct.lean
@@ -264,7 +264,7 @@ noncomputable def sylowIsIteratedWreathProduct (p : ℕ) [Fact (Nat.Prime p)] (n
     (P : Sylow p (Equiv.Perm α)) :
     P ≃* IteratedWreathProduct G n := by
   let e1 : α ≃ (Fin n → G) := (Finite.equivFinOfCardEq hα).trans
-    (Finite.equivFinOfCardEq (by rw [Nat.card_fun, Nat.card_fin, hG])).symm
+    (Finite.equivFinOfCardEq (by rw [Nat.card_fun, Nat.fin_card, hG])).symm
   let f := (Equiv.permCongrHom e1.symm).toMonoidHom.comp (iteratedWreathToPermHom G n)
   have hf : Function.Injective f :=
     ((Equiv.permCongrHom e1.symm).comp_injective _).mpr (iteratedWreathToPermHomInj G n)

--- a/Mathlib/GroupTheory/RegularWreathProduct.lean
+++ b/Mathlib/GroupTheory/RegularWreathProduct.lean
@@ -36,7 +36,7 @@ group, regular wreath product, sylow p-subgroup
 
 variable (D Q : Type*) [Group D] [Group Q]
 
-/-- The regular wreath product of groups `Q` and `D`. It the product `(Q → D) × Q` with the group
+/-- The regular wreath product of groups `Q` and `D`. It is the product `(Q → D) × Q` with the group
 operation `⟨a₁, a₂⟩ * ⟨b₁, b₂⟩ = ⟨a₁ * (fun x ↦ b₁ (a₂⁻¹ * x)), a₂ * b₂⟩`. -/
 @[ext]
 structure RegularWreathProduct where

--- a/Mathlib/Logic/Equiv/Fin/Basic.lean
+++ b/Mathlib/Logic/Equiv/Fin/Basic.lean
@@ -360,3 +360,7 @@ def Fin.appendEquiv {α : Type*} (m n : ℕ) :
   invFun f := ⟨fun i ↦ f (Fin.castAdd n i), fun i ↦ f (Fin.natAdd m i)⟩
   left_inv fg := by simp
   right_inv f := by simp [Fin.append_castAdd_natAdd]
+
+/-- `Fin (n + 1) → α` and `(Fin n → α) × α` are equivalent. -/
+def Fin.succFunEquiv (α : Type*) (n : ℕ) : (Fin (n + 1) → α) ≃ (Fin n → α) × α :=
+  (appendEquiv n 1).symm.trans (Equiv.prodCongrRight fun _ ↦ Equiv.funUnique (Fin 1) α)

--- a/Mathlib/Logic/Equiv/Fin/Basic.lean
+++ b/Mathlib/Logic/Equiv/Fin/Basic.lean
@@ -362,6 +362,6 @@ def Fin.appendEquiv {α : Type*} (m n : ℕ) :
   right_inv f := by simp [Fin.append_castAdd_natAdd]
 
 /-- `Fin (n + 1) → α` and `(Fin n → α) × α` are equivalent. -/
-@[simps]
+@[simps!]
 def Fin.succFunEquiv (α : Type*) (n : ℕ) : (Fin (n + 1) → α) ≃ (Fin n → α) × α :=
   (appendEquiv n 1).symm.trans (Equiv.prodCongrRight fun _ ↦ Equiv.funUnique (Fin 1) α)

--- a/Mathlib/Logic/Equiv/Fin/Basic.lean
+++ b/Mathlib/Logic/Equiv/Fin/Basic.lean
@@ -362,5 +362,6 @@ def Fin.appendEquiv {α : Type*} (m n : ℕ) :
   right_inv f := by simp [Fin.append_castAdd_natAdd]
 
 /-- `Fin (n + 1) → α` and `(Fin n → α) × α` are equivalent. -/
+@[simps]
 def Fin.succFunEquiv (α : Type*) (n : ℕ) : (Fin (n + 1) → α) ≃ (Fin n → α) × α :=
   (appendEquiv n 1).symm.trans (Equiv.prodCongrRight fun _ ↦ Equiv.funUnique (Fin 1) α)

--- a/Mathlib/SetTheory/Cardinal/Finite.lean
+++ b/Mathlib/SetTheory/Cardinal/Finite.lean
@@ -128,6 +128,9 @@ theorem _root_.Function.Surjective.bijective_of_nat_card_le [Finite α] {f : α 
 theorem card_eq_of_equiv_fin {α : Type*} {n : ℕ} (f : α ≃ Fin n) : Nat.card α = n := by
   simpa only [card_eq_fintype_card, Fintype.card_fin] using card_congr f
 
+lemma card_fin (n : ℕ) : Nat.card (Fin n) = n := by
+  rw [Nat.card_eq_fintype_card, Fintype.card_fin]
+
 section Set
 open Set
 variable {s t : Set α}

--- a/Mathlib/SetTheory/Cardinal/Finite.lean
+++ b/Mathlib/SetTheory/Cardinal/Finite.lean
@@ -128,7 +128,6 @@ theorem _root_.Function.Surjective.bijective_of_nat_card_le [Finite α] {f : α 
 theorem card_eq_of_equiv_fin {α : Type*} {n : ℕ} (f : α ≃ Fin n) : Nat.card α = n := by
   simpa only [card_eq_fintype_card, Fintype.card_fin] using card_congr f
 
-@[simp]
 lemma card_fin (n : ℕ) : Nat.card (Fin n) = n := by
   rw [Nat.card_eq_fintype_card, Fintype.card_fin]
 

--- a/Mathlib/SetTheory/Cardinal/Finite.lean
+++ b/Mathlib/SetTheory/Cardinal/Finite.lean
@@ -128,6 +128,7 @@ theorem _root_.Function.Surjective.bijective_of_nat_card_le [Finite α] {f : α 
 theorem card_eq_of_equiv_fin {α : Type*} {n : ℕ} (f : α ≃ Fin n) : Nat.card α = n := by
   simpa only [card_eq_fintype_card, Fintype.card_fin] using card_congr f
 
+@[simp]
 lemma card_fin (n : ℕ) : Nat.card (Fin n) = n := by
   rw [Nat.card_eq_fintype_card, Fintype.card_fin]
 

--- a/Mathlib/SetTheory/Cardinal/Finite.lean
+++ b/Mathlib/SetTheory/Cardinal/Finite.lean
@@ -128,7 +128,7 @@ theorem _root_.Function.Surjective.bijective_of_nat_card_le [Finite α] {f : α 
 theorem card_eq_of_equiv_fin {α : Type*} {n : ℕ} (f : α ≃ Fin n) : Nat.card α = n := by
   simpa only [card_eq_fintype_card, Fintype.card_fin] using card_congr f
 
-lemma fin_card (n : ℕ) : Nat.card (Fin n) = n := by
+lemma card_fin (n : ℕ) : Nat.card (Fin n) = n := by
   rw [Nat.card_eq_fintype_card, Fintype.card_fin]
 
 section Set

--- a/Mathlib/SetTheory/Cardinal/Finite.lean
+++ b/Mathlib/SetTheory/Cardinal/Finite.lean
@@ -128,7 +128,7 @@ theorem _root_.Function.Surjective.bijective_of_nat_card_le [Finite α] {f : α 
 theorem card_eq_of_equiv_fin {α : Type*} {n : ℕ} (f : α ≃ Fin n) : Nat.card α = n := by
   simpa only [card_eq_fintype_card, Fintype.card_fin] using card_congr f
 
-lemma card_fin (n : ℕ) : Nat.card (Fin n) = n := by
+lemma fin_card (n : ℕ) : Nat.card (Fin n) = n := by
   rw [Nat.card_eq_fintype_card, Fintype.card_fin]
 
 section Set


### PR DESCRIPTION
feat: add regular wreath product and some results; add iterated wreath product; add the isomorphism of iterated wreath product of Z_p to sylow p subgroup of S_{p^n}.
Needs some work simplifying final result.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
