### PR TITLE
[Merged by Bors] - feat(Matroid/Rank): more ENat rank API

### DIFF
--- a/Mathlib/Data/Matroid/Rank/ENat.lean
+++ b/Mathlib/Data/Matroid/Rank/ENat.lean
@@ -61,7 +61,7 @@ open Set ENat
 
 namespace Matroid
 
-variable {α : Type*} {M : Matroid α} {I B X Y Z : Set α} {n : ℕ∞} {e f : α}
+variable {α : Type*} {M : Matroid α} {I B X Y : Set α} {n : ℕ∞} {e f : α}
 
 section Basic
 
@@ -389,12 +389,12 @@ lemma eRk_insert_eq_add_one (he : e ∈ M.E \ M.closure X) : M.eRk (insert e X) 
   rw [← eRk_closure_eq, ← closure_insert_congr_right hI.closure_eq_closure, hI.eRk_eq_encard,
     eRk_closure_eq, Indep.eRk_eq_encard (by tauto), encard_insert_of_not_mem (by tauto)]
 
-lemma exists_eRk_insert_eq_add_one_of_lt (h : M.eRk X < M.eRk Z) :
-    ∃ z ∈ Z \ X, M.eRk (insert z X) = M.eRk X + 1 := by
-  by_cases hz : Z ∩ M.E ⊆ M.closure X
+lemma exists_eRk_insert_eq_add_one_of_lt (h : M.eRk X < M.eRk Y) :
+    ∃ y ∈ Y \ X, M.eRk (insert y X) = M.eRk X + 1 := by
+  by_cases hz : Y ∩ M.E ⊆ M.closure X
   · exact False.elim <| h.not_le <| by simpa using M.eRk_mono hz
-  obtain ⟨e, ⟨⟨heZ, heE⟩, heX⟩⟩ := not_subset.1 hz
-  exact ⟨e, ⟨heZ, fun heX' ↦ heX (mem_closure_of_mem' _ heX')⟩, eRk_insert_eq_add_one ⟨heE, heX⟩⟩
+  obtain ⟨e, ⟨heZ, heE⟩, heX⟩ := not_subset.1 hz
+  refine ⟨e, ⟨heZ, fun heX' ↦ heX (mem_closure_of_mem' _ heX')⟩, eRk_insert_eq_add_one ⟨heE, heX⟩⟩
 
 lemma IsRkFinite.closure_eq_closure_of_subset_of_forall_insert (hX : M.IsRkFinite X) (hXY : X ⊆ Y)
     (hY : ∀ e ∈ Y \ X, M.eRk (Insert.insert e X) ≤ M.eRk X) : M.closure X = M.closure Y := by
@@ -418,6 +418,8 @@ lemma indep_iff_eRk_eq_encard_of_finite (hI : I.Finite) : M.Indep I ↔ M.eRk I 
   · exact hJ.indep
   rw [← h, ← hJ.eRk_eq_encard]
 
+/-- In a matroid known to have finite rank, `Matroid.indep_iff_eRk_eq_encard_of_finite`
+is true without the finiteness assumption. -/
 lemma indep_iff_eRk_eq_encard [M.RankFinite] : M.Indep I ↔ M.eRk I = I.encard := by
   refine ⟨Indep.eRk_eq_encard, fun h ↦ ?_⟩
   obtain hfin | hinf := I.finite_or_infinite
@@ -527,8 +529,8 @@ lemma eRk_le_one_iff [M.Nonempty] (hX : X ⊆ M.E := by aesop_mat) :
   · obtain ⟨I, hI⟩ := M.exists_isBasis X
     rw [hI.eRk_eq_encard, encard_le_one_iff_eq] at h
     obtain (rfl | ⟨e, rfl⟩) := h
-    · exact ⟨M.ground_nonempty.some, M.ground_nonempty.some_mem,
-        hI.subset_closure.trans ((M.closure_subset_closure (empty_subset _)))⟩
+    · obtain ⟨e, he⟩ := M.ground_nonempty
+      exact ⟨e, he, hI.subset_closure.trans ((M.closure_subset_closure (empty_subset _)))⟩
     exact ⟨e, hI.indep.subset_ground rfl,  hI.subset_closure⟩
   refine (M.eRk_mono he).trans ?_
   rw [eRk_closure_eq, ← encard_singleton e]

--- a/Mathlib/Data/Matroid/Rank/ENat.lean
+++ b/Mathlib/Data/Matroid/Rank/ENat.lean
@@ -352,7 +352,7 @@ lemma IsRkFinite.eRk_lt_top (h : M.IsRkFinite X) : M.eRk X < ⊤ :=
 
 @[deprecated (since := "2025-04-13")] alias eRk_lt_top_of_finite := IsRkFinite.eRk_lt_top
 
-/-- If `X` is a finite-rank-set, and `I` is a subset of `X` of cardinality
+/-- If `X` is a finite-rank set, and `I` is a subset of `X` of cardinality
 no larger than the rank of `X` that spans `X`, then `I` is a basis for `X`. -/
 lemma IsRkFinite.isBasis_of_subset_closure_of_subset_of_encard_le (hX : M.IsRkFinite X)
     (hXI : X ⊆ M.closure I) (hIX : I ⊆ X) (hI : I.encard ≤ M.eRk X) : M.IsBasis I X := by

--- a/Mathlib/Data/Matroid/Rank/ENat.lean
+++ b/Mathlib/Data/Matroid/Rank/ENat.lean
@@ -247,6 +247,17 @@ lemma Indep.encard_le_eRank (hI : M.Indep I) : I.encard ≤ M.eRank := by
   rw [← hI.eRk_eq_encard, eRank_def]
   exact M.eRk_mono hI.subset_ground
 
+/-- A version of `erk_eq_zero_iff'` with no supportedness hypothesis. -/
+lemma erk_eq_zero_iff' : M.eRk X = 0 ↔ X ∩ M.E ⊆ M.loops := by
+  obtain ⟨I, hI⟩ := M.exists_isBasis (X ∩ M.E)
+  rw [← eRk_inter_ground, ← hI.encard_eq_eRk, encard_eq_zero]
+  refine ⟨fun h ↦ by simpa [h] using hI , fun h ↦ eq_empty_iff_forall_not_mem.2 fun e heI ↦ ?_⟩
+  exact (hI.indep.isNonloop_of_mem heI).not_isLoop (h (hI.subset heI))
+
+@[simp]
+lemma erk_eq_zero_iff (hX : X ⊆ M.E := by aesop_mat) : M.eRk X = 0 ↔ X ⊆ M.loops := by
+  rw [erk_eq_zero_iff', inter_eq_self_of_subset_left hX]
+
 /-! ### Submodularity -/
 
 /-- The `ℕ∞`-valued rank function is submodular. -/
@@ -404,10 +415,9 @@ lemma IsRkFinite.closure_eq_closure_of_subset_of_forall_insert (hX : M.IsRkFinit
 
 lemma eRk_eq_of_eRk_insert_le_forall (hXY : X ⊆ Y)
     (hY : ∀ e ∈ Y \ X, M.eRk (insert e X) ≤ M.eRk X) : M.eRk X = M.eRk Y := by
-  refine (M.eRk_mono hXY).eq_of_not_lt <| fun hlt ↦ ?_
-  obtain ⟨e, he, hins⟩ := exists_eRk_insert_eq_add_one_of_lt hlt
-  exact (hins.symm.trans_le <| hY e he).not_lt <|
-    (ENat.lt_add_one_iff (hlt.trans_le le_top).ne).2 rfl.le
+  by_cases hX : M.IsRkFinite X
+  · rw [← eRk_closure_eq, hX.closure_eq_closure_of_subset_of_forall_insert hXY hY, eRk_closure_eq]
+  rw [eRk_eq_top_iff.2 hX, eRk_eq_top_iff.2 (mt (fun h ↦ h.subset hXY) hX)]
 
 /-! ### Independence -/
 

--- a/Mathlib/Data/Matroid/Rank/ENat.lean
+++ b/Mathlib/Data/Matroid/Rank/ENat.lean
@@ -5,6 +5,7 @@ Authors: Peter Nelson
 -/
 import Mathlib.Data.ENat.Lattice
 import Mathlib.Data.Matroid.Rank.Finite
+import Mathlib.Data.Matroid.Loop
 import Mathlib.Tactic.TautoSet
 
 /-!
@@ -60,7 +61,7 @@ open Set ENat
 
 namespace Matroid
 
-variable {α : Type*} {M : Matroid α} {I B X Y : Set α} {n : ℕ∞} {e f : α}
+variable {α : Type*} {M : Matroid α} {I B X Y Z : Set α} {n : ℕ∞} {e f : α}
 
 section Basic
 
@@ -351,6 +352,188 @@ lemma IsRkFinite.eRk_lt_top (h : M.IsRkFinite X) : M.eRk X < ⊤ :=
 
 @[deprecated (since := "2025-04-13")] alias eRk_lt_top_of_finite := IsRkFinite.eRk_lt_top
 
+/-- If `X` is a finite-rank-set, and `I` is a subset of `X` of cardinality
+no larger than the rank of `X` that spans `X`, then `I` is a basis for `X`. -/
+lemma IsRkFinite.isBasis_of_subset_closure_of_subset_of_encard_le (hX : M.IsRkFinite X)
+    (hXI : X ⊆ M.closure I) (hIX : I ⊆ X) (hI : I.encard ≤ M.eRk X) : M.IsBasis I X := by
+  obtain ⟨J, hJ⟩ := M.exists_isBasis (I ∩ M.E)
+  have hIJ := hJ.subset.trans inter_subset_left
+  rw [← closure_inter_ground] at hXI
+  replace hXI := hXI.trans <| M.closure_subset_closure_of_subset_closure hJ.subset_closure
+  have hJX := hJ.indep.isBasis_of_subset_of_subset_closure (hIJ.trans hIX) hXI
+  rw [← hJX.encard_eq_eRk] at hI
+  rwa [← Finite.eq_of_subset_of_encard_le (hX.finite_of_isBasis hJX) hIJ hI]
+
+/-- If `X` is a finite-rank set, and `Y` is a superset of `X` of rank no larger than that of `X`,
+then `X` and `Y` have the same closure. -/
+lemma IsRkFinite.closure_eq_closure_of_subset_of_eRk_ge_eRk (hX : M.IsRkFinite X) (hXY : X ⊆ Y)
+    (hr : M.eRk Y ≤ M.eRk X) : M.closure X = M.closure Y := by
+  obtain ⟨I, hI⟩ := M.exists_isBasis' X
+  obtain ⟨J, hJ, hIJ⟩ := hI.indep.subset_isBasis'_of_subset (hI.subset.trans hXY)
+  rw [hI.eRk_eq_encard, hJ.eRk_eq_encard] at hr
+  rw [← closure_inter_ground, ← M.closure_inter_ground Y,
+    ← hI.isBasis_inter_ground.closure_eq_closure,
+    ← hJ.isBasis_inter_ground.closure_eq_closure, Finite.eq_of_subset_of_encard_le
+      (hI.indep.finite_of_subset_isRkFinite hI.subset hX) hIJ hr]
+
+/-! ### Insertion -/
+
+lemma eRk_insert_le_add_one (M : Matroid α) (e : α) (X : Set α) :
+    M.eRk (insert e X) ≤ M.eRk X + 1 :=
+  union_singleton ▸ (M.eRk_union_le_eRk_add_eRk _ _).trans <|
+    add_le_add_left (by simpa using M.eRk_le_encard {e}) _
+
+lemma eRk_insert_eq_add_one (he : e ∈ M.E \ M.closure X) : M.eRk (insert e X) = M.eRk X + 1 := by
+  obtain ⟨I, hI⟩ := M.exists_isBasis' X
+  rw [← hI.closure_eq_closure, mem_diff, hI.indep.mem_closure_iff', not_and] at he
+  rw [← eRk_closure_eq, ← closure_insert_congr_right hI.closure_eq_closure, hI.eRk_eq_encard,
+    eRk_closure_eq, Indep.eRk_eq_encard (by tauto), encard_insert_of_not_mem (by tauto)]
+
+lemma exists_eRk_insert_eq_add_one_of_lt (h : M.eRk X < M.eRk Z) :
+    ∃ z ∈ Z \ X, M.eRk (insert z X) = M.eRk X + 1 := by
+  by_cases hz : Z ∩ M.E ⊆ M.closure X
+  · exact False.elim <| h.not_le <| by simpa using M.eRk_mono hz
+  obtain ⟨e, ⟨⟨heZ, heE⟩, heX⟩⟩ := not_subset.1 hz
+  exact ⟨e, ⟨heZ, fun heX' ↦ heX (mem_closure_of_mem' _ heX')⟩, eRk_insert_eq_add_one ⟨heE, heX⟩⟩
+
+lemma IsRkFinite.closure_eq_closure_of_subset_of_forall_insert (hX : M.IsRkFinite X) (hXY : X ⊆ Y)
+    (hY : ∀ e ∈ Y \ X, M.eRk (Insert.insert e X) ≤ M.eRk X) : M.closure X = M.closure Y := by
+  refine hX.closure_eq_closure_of_subset_of_eRk_ge_eRk hXY <| not_lt.1 fun hlt ↦ ?_
+  obtain ⟨z, hz, hr⟩ := exists_eRk_insert_eq_add_one_of_lt hlt
+  simpa [hr, ENat.add_one_le_iff hX.eRk_lt_top.ne] using hY z hz
+
+lemma eRk_eq_of_eRk_insert_le_forall (hXY : X ⊆ Y)
+    (hY : ∀ e ∈ Y \ X, M.eRk (insert e X) ≤ M.eRk X) : M.eRk X = M.eRk Y := by
+  refine (M.eRk_mono hXY).eq_of_not_lt <| fun hlt ↦ ?_
+  obtain ⟨e, he, hins⟩ := exists_eRk_insert_eq_add_one_of_lt hlt
+  exact (hins.symm.trans_le <| hY e he).not_lt <|
+    (ENat.lt_add_one_iff (hlt.trans_le le_top).ne).2 rfl.le
+
+/-! ### Independence -/
+
+lemma indep_iff_eRk_eq_encard_of_finite (hI : I.Finite) : M.Indep I ↔ M.eRk I = I.encard := by
+  refine ⟨fun h ↦ by rw [h.eRk_eq_encard], fun h ↦ ?_⟩
+  obtain ⟨J, hJ⟩ := M.exists_isBasis' I
+  rw [← hI.eq_of_subset_of_encard_le' hJ.subset]
+  · exact hJ.indep
+  rw [← h, ← hJ.eRk_eq_encard]
+
+lemma indep_iff_eRk_eq_encard [M.RankFinite] : M.Indep I ↔ M.eRk I = I.encard := by
+  refine ⟨Indep.eRk_eq_encard, fun h ↦ ?_⟩
+  obtain hfin | hinf := I.finite_or_infinite
+  · rwa [indep_iff_eRk_eq_encard_of_finite hfin]
+  rw [hinf.encard_eq] at h
+  exact False.elim <| (M.isRkFinite_set I).eRk_lt_top.ne h
+
+lemma IsRkFinite.indep_of_encard_le_eRk (hX : M.IsRkFinite I) (h : encard I ≤ M.eRk I) :
+    M.Indep I := by
+  rw [indep_iff_eRk_eq_encard_of_finite _]
+  · exact (M.eRk_le_encard I).antisymm h
+  simpa using h.trans_lt hX.eRk_lt_top
+
+lemma eRk_lt_encard_of_dep_of_finite (h : X.Finite) (hX : M.Dep X) : M.eRk X < X.encard :=
+  lt_of_le_of_ne (M.eRk_le_encard X) fun h' ↦
+    ((indep_iff_eRk_eq_encard_of_finite h).mpr h').not_dep hX
+
+lemma eRk_lt_encard_iff_dep_of_finite (hX : X.Finite) (hXE : X ⊆ M.E := by aesop_mat) :
+    M.eRk X < X.encard ↔ M.Dep X := by
+  refine ⟨fun h ↦ ?_, fun h ↦ eRk_lt_encard_of_dep_of_finite hX h⟩
+  rw [← not_indep_iff, indep_iff_eRk_eq_encard_of_finite hX]
+  exact h.ne
+
+lemma Dep.eRk_lt_encard [M.RankFinite] (hX : M.Dep X) : M.eRk X < X.encard := by
+  refine (M.eRk_le_encard X).lt_of_ne ?_
+  rw [ne_eq, ← indep_iff_eRk_eq_encard]
+  exact hX.not_indep
+
+lemma eRk_lt_encard_iff_dep [M.RankFinite] (hXE : X ⊆ M.E := by aesop_mat) :
+    M.eRk X < X.encard ↔ M.Dep X :=
+  ⟨fun h ↦ (not_indep_iff).1 fun hi ↦ h.ne hi.eRk_eq_encard, Dep.eRk_lt_encard⟩
+
+lemma Indep.exists_insert_of_encard_lt {I J : Set α} (hI : M.Indep I) (hJ : M.Indep J)
+    (hcard : I.encard < J.encard) : ∃ e ∈ J \ I, M.Indep (insert e I) := by
+  have hIfin : I.Finite := encard_lt_top_iff.1 <| hcard.trans_le le_top
+  rw [← hI.eRk_eq_encard, ← hJ.eRk_eq_encard] at hcard
+  obtain ⟨e, he, hIe⟩ := exists_eRk_insert_eq_add_one_of_lt hcard
+  refine ⟨e, he, ?_⟩
+  rw [indep_iff_eRk_eq_encard_of_finite (hIfin.insert e), hIe, encard_insert_of_not_mem he.2,
+    hI.eRk_eq_encard]
+
+lemma isBasis'_iff_indep_encard_eq_of_finite (hIfin : I.Finite) :
+    M.IsBasis' I X ↔ I ⊆ X ∧ M.Indep I ∧ I.encard = M.eRk X := by
+  refine ⟨fun h ↦ ⟨h.subset,h.indep, h.eRk_eq_encard.symm⟩, fun ⟨hIX, hI, hcard⟩ ↦ ?_⟩
+  obtain ⟨J, hJ, hIJ⟩ := hI.subset_isBasis'_of_subset hIX
+  rwa [hIfin.eq_of_subset_of_encard_le hIJ (hJ.encard_eq_eRk.trans hcard.symm).le]
+
+lemma isBasis_iff_indep_encard_eq_of_finite (hIfin : I.Finite) (hX : X ⊆ M.E := by aesop_mat) :
+    M.IsBasis I X ↔ I ⊆ X ∧ M.Indep I ∧ I.encard = M.eRk X := by
+  rw [← isBasis'_iff_isBasis, isBasis'_iff_indep_encard_eq_of_finite hIfin]
+
+/-- If `I` is a finite independent subset of `X` for which `M.eRk X ≤ M.eRk I`,
+then `I` is a `Basis'` for `X`. -/
+lemma Indep.isBasis'_of_eRk_ge (hI : M.Indep I) (hIfin : I.Finite) (hIX : I ⊆ X)
+    (h : M.eRk X ≤ M.eRk I) : M.IsBasis' I X :=
+  (isBasis'_iff_indep_encard_eq_of_finite hIfin).2
+    ⟨hIX, hI, by rw [h.antisymm (M.eRk_mono hIX), hI.eRk_eq_encard]⟩
+
+lemma Indep.isBasis_of_eRk_ge (hI : M.Indep I) (hIfin : I.Finite) (hIX : I ⊆ X)
+    (h : M.eRk X ≤ M.eRk I) (hX : X ⊆ M.E := by aesop_mat) : M.IsBasis I X :=
+  (hI.isBasis'_of_eRk_ge hIfin hIX h).isBasis
+
+lemma Indep.isBase_of_eRk_ge (hI : M.Indep I) (hIfin : I.Finite) (h : M.eRank ≤ M.eRk I) :
+    M.IsBase I := by
+  simpa using hI.isBasis_of_eRk_ge hIfin hI.subset_ground (M.eRk_ground.trans_le h)
+
+lemma IsCircuit.eRk_add_one_eq {C : Set α} (hC : M.IsCircuit C) : M.eRk C + 1 = C.encard := by
+  obtain ⟨I, hI⟩ := M.exists_isBasis C
+  obtain ⟨e, ⟨heC, heI⟩, rfl⟩ := hC.isBasis_iff_insert_eq.1 hI
+  rw [hI.eRk_eq_encard, encard_insert_of_not_mem heI]
+
+/-! ### Singletons -/
+
+lemma IsLoop.eRk_eq (he : M.IsLoop e) : M.eRk {e} = 0 := by
+  rw [← eRk_closure_eq, he.closure, loops, eRk_closure_eq, eRk_empty]
+
+lemma IsNonloop.eRk_eq (he : M.IsNonloop e) : M.eRk {e} = 1 := by
+  rw [← he.indep.isBasis_self.encard_eq_eRk, encard_singleton]
+
+lemma eRk_singleton_eq [Loopless M] (he : e ∈ M.E := by aesop_mat) :
+    M.eRk {e} = 1 :=
+  (M.isNonloop_of_loopless he).eRk_eq
+
+@[simp]
+lemma eRk_singleton_le (M : Matroid α) (e : α) : M.eRk {e} ≤ 1 :=
+  (M.eRk_le_encard {e}).trans_eq <| encard_singleton e
+
+@[simp]
+lemma eRk_singleton_eq_one_iff {e : α} : M.eRk {e} = 1 ↔ M.IsNonloop e := by
+  refine ⟨fun h ↦ ?_, fun h ↦ h.eRk_eq⟩
+  rwa [← indep_singleton, indep_iff_eRk_eq_encard_of_finite (by simp), encard_singleton]
+
+lemma eRk_eq_one_iff (hX : X ⊆ M.E := by aesop_mat) :
+    M.eRk X = 1 ↔ ∃ e ∈ X, M.IsNonloop e ∧ X ⊆ M.closure {e} := by
+  refine ⟨?_, fun ⟨e, heX, he, hXe⟩ ↦ ?_⟩
+  · obtain ⟨I, hI⟩ := M.exists_isBasis X
+    rw [hI.eRk_eq_encard, encard_eq_one]
+    rintro ⟨e, rfl⟩
+    exact ⟨e, singleton_subset_iff.1 hI.subset, indep_singleton.1 hI.indep, hI.subset_closure⟩
+  rw [← he.eRk_eq]
+  exact ((M.eRk_mono hXe).trans (M.eRk_closure_eq _).le).antisymm
+    (M.eRk_mono (singleton_subset_iff.2 heX))
+
+lemma eRk_le_one_iff [M.Nonempty] (hX : X ⊆ M.E := by aesop_mat) :
+    M.eRk X ≤ 1 ↔ ∃ e ∈ M.E, X ⊆ M.closure {e} := by
+  refine ⟨fun h ↦ ?_, fun ⟨e, _, he⟩ ↦ ?_⟩
+  · obtain ⟨I, hI⟩ := M.exists_isBasis X
+    rw [hI.eRk_eq_encard, encard_le_one_iff_eq] at h
+    obtain (rfl | ⟨e, rfl⟩) := h
+    · exact ⟨M.ground_nonempty.some, M.ground_nonempty.some_mem,
+        hI.subset_closure.trans ((M.closure_subset_closure (empty_subset _)))⟩
+    exact ⟨e, hI.indep.subset_ground rfl,  hI.subset_closure⟩
+  refine (M.eRk_mono he).trans ?_
+  rw [eRk_closure_eq, ← encard_singleton e]
+  exact M.eRk_le_encard {e}
+
 /-! ### Constructions -/
 
 @[simp]
@@ -404,6 +587,9 @@ lemma eRk_freeOn (hXY : X ⊆ Y) : (freeOn Y).eRk X = X.encard := by
   rw [hI.eRk_eq_encard, (freeOn_indep hXY).eq_of_isBasis hI]
 
 /-! ### Duality -/
+
+lemma IsBase.encard_compl_eq (hB : M.IsBase B) : (M.E \ B).encard = M✶.eRank :=
+  (hB.compl_isBase_dual).encard_eq_eRank
 
 /-- A subtraction-free formula for the rank of a set in the dual matroid. -/
 lemma eRk_dual_add_eRank (M : Matroid α) (X : Set α) (hX : X ⊆ M.E := by aesop_mat) :


### PR DESCRIPTION
We add more basic API for `ENat`-valued matroid rank. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
