### PR TITLE
[Merged by Bors] - refactor(Analysis/Complex/UpperHalfPlane): split off Moebius action

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1456,6 +1456,7 @@ import Mathlib.Analysis.Complex.UpperHalfPlane.Exp
 import Mathlib.Analysis.Complex.UpperHalfPlane.FunctionsBoundedAtInfty
 import Mathlib.Analysis.Complex.UpperHalfPlane.Manifold
 import Mathlib.Analysis.Complex.UpperHalfPlane.Metric
+import Mathlib.Analysis.Complex.UpperHalfPlane.MoebiusAction
 import Mathlib.Analysis.Complex.UpperHalfPlane.Topology
 import Mathlib.Analysis.Complex.ValueDistribution.CountingFunction
 import Mathlib.Analysis.ConstantSpeed

--- a/Mathlib/Analysis/Complex/UpperHalfPlane/Basic.lean
+++ b/Mathlib/Analysis/Complex/UpperHalfPlane/Basic.lean
@@ -4,25 +4,17 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Alex Kontorovich, Heather Macbeth, Marc Masdeu
 -/
 import Mathlib.Analysis.Complex.Basic
-import Mathlib.Data.Fintype.Parity
-import Mathlib.LinearAlgebra.Matrix.GeneralLinearGroup.Defs
 
 /-!
-# The upper half plane and its automorphisms
+# The upper half plane
 
 This file defines `UpperHalfPlane` to be the upper half plane in `ℂ`.
-
-We furthermore equip it with the structure of a `GLPos 2 ℝ` action by
-fractional linear transformations.
 
 We define the notation `ℍ` for the upper half plane available in the locale
 `UpperHalfPlane` so as not to conflict with the quaternions.
 -/
 
 noncomputable section
-
-open Matrix Matrix.SpecialLinearGroup
-open scoped MatrixGroups
 
 /-- The open upper half plane, denoted as `ℍ` within the `UpperHalfPlane` namespace -/
 def UpperHalfPlane :=
@@ -33,23 +25,6 @@ def UpperHalfPlane :=
 open UpperHalfPlane
 
 namespace UpperHalfPlane
-
-/-- The coercion first into an element of  `GL(2, ℝ)⁺`, then  `GL(2, ℝ)` and finally a 2 × 2
-matrix.
-
-This notation is scoped in namespace `UpperHalfPlane`. -/
-scoped notation:1024 "↑ₘ" A:1024 =>
-  (((A : GL(2, ℝ)⁺) : GL (Fin 2) ℝ) : Matrix (Fin 2) (Fin 2) _)
-
-instance instCoeFun : CoeFun GL(2, ℝ)⁺ fun _ => Fin 2 → Fin 2 → ℝ where coe A := ↑ₘA
-
-/-- The coercion into an element of  `GL(2, R)` and finally a 2 × 2 matrix over `R`. This is
-similar to `↑ₘ`, but without positivity requirements, and allows the user to specify the ring `R`,
-which can be useful to help Lean elaborate correctly.
-
-This notation is scoped in namespace `UpperHalfPlane`. -/
-scoped notation:1024 "↑ₘ[" R "]" A:1024 =>
-  ((A : GL (Fin 2) R) : Matrix (Fin 2) (Fin 2) R)
 
 /-- Canonical embedding of the upper half-plane into `ℂ`. -/
 @[coe] protected def coe (z : ℍ) : ℂ := z.1
@@ -183,134 +158,6 @@ lemma ne_int (z : ℍ) : ∀ n : ℤ, z.1 ≠ n := by
   have h1 := z.2
   aesop
 
-/-- Numerator of the formula for a fractional linear transformation -/
-def num (g : GL(2, ℝ)⁺) (z : ℍ) : ℂ := g 0 0 * z + g 0 1
-
-/-- Denominator of the formula for a fractional linear transformation -/
-def denom (g : GL(2, ℝ)⁺) (z : ℍ) : ℂ := g 1 0 * z + g 1 1
-
-theorem linear_ne_zero (cd : Fin 2 → ℝ) (z : ℍ) (h : cd ≠ 0) : (cd 0 : ℂ) * z + cd 1 ≠ 0 := by
-  contrapose! h
-  have : cd 0 = 0 := by
-    -- we will need this twice
-    apply_fun Complex.im at h
-    simpa only [z.im_ne_zero, Complex.add_im, add_zero, coe_im, zero_mul, or_false,
-      Complex.ofReal_im, Complex.zero_im, Complex.mul_im, mul_eq_zero] using h
-  simp only [this, zero_mul, Complex.ofReal_zero, zero_add, Complex.ofReal_eq_zero]
-    at h
-  ext i
-  fin_cases i <;> assumption
-
-theorem denom_ne_zero (g : GL(2, ℝ)⁺) (z : ℍ) : denom g z ≠ 0 := by
-  intro H
-  have DET := (mem_glpos _).1 g.prop
-  simp only [GeneralLinearGroup.val_det_apply] at DET
-  obtain hg | hz : g 1 0 = 0 ∨ z.im = 0 := by simpa [num, denom] using congr_arg Complex.im H
-  · simp only [hg, Complex.ofReal_zero, denom, zero_mul, zero_add, Complex.ofReal_eq_zero] at H
-    simp only [Matrix.det_fin_two g.1.1, H, hg, mul_zero, sub_zero, lt_self_iff_false] at DET
-  · exact z.prop.ne' hz
-
-theorem normSq_denom_pos (g : GL(2, ℝ)⁺) (z : ℍ) : 0 < Complex.normSq (denom g z) :=
-  Complex.normSq_pos.mpr (denom_ne_zero g z)
-
-theorem normSq_denom_ne_zero (g : GL(2, ℝ)⁺) (z : ℍ) : Complex.normSq (denom g z) ≠ 0 :=
-  ne_of_gt (normSq_denom_pos g z)
-
-/-- Fractional linear transformation, also known as the Moebius transformation -/
-def smulAux' (g : GL(2, ℝ)⁺) (z : ℍ) : ℂ :=
-  num g z / denom g z
-
-theorem smulAux'_im (g : GL(2, ℝ)⁺) (z : ℍ) :
-    (smulAux' g z).im = det ↑ₘg * z.im / Complex.normSq (denom g z) := by
-  simp only [smulAux', num, denom, Complex.div_im, Complex.add_im, Complex.mul_im,
-    Complex.ofReal_re, coe_im, Complex.ofReal_im, coe_re, zero_mul, add_zero, Complex.add_re,
-    Complex.mul_re, sub_zero, ← sub_div, g.1.1.det_fin_two]
-  ring
-
-/-- Fractional linear transformation, also known as the Moebius transformation -/
-def smulAux (g : GL(2, ℝ)⁺) (z : ℍ) : ℍ :=
-  mk (smulAux' g z) <| by
-    rw [smulAux'_im]
-    convert mul_pos ((mem_glpos _).1 g.prop)
-        (div_pos z.im_pos (Complex.normSq_pos.mpr (denom_ne_zero g z))) using 1
-    simp only [GeneralLinearGroup.val_det_apply]
-    ring
-
-theorem denom_cocycle (x y : GL(2, ℝ)⁺) (z : ℍ) :
-    denom (x * y) z = denom x (smulAux y z) * denom y z := by
-  change _ = (_ * (_ / _) + _) * _
-  field_simp [denom_ne_zero]
-  simp only [denom, Subgroup.coe_mul, Fin.isValue, Units.val_mul, mul_apply, Fin.sum_univ_succ,
-    Finset.univ_unique, Fin.default_eq_zero, Finset.sum_singleton, Fin.succ_zero_eq_one,
-    Complex.ofReal_add, Complex.ofReal_mul, num]
-  ring
-
-theorem mul_smul' (x y : GL(2, ℝ)⁺) (z : ℍ) : smulAux (x * y) z = smulAux x (smulAux y z) := by
-  ext1
-  change _ / _ = (_ * (_ / _) + _) / _
-  rw [denom_cocycle]
-  field_simp [denom_ne_zero]
-  simp only [num, Subgroup.coe_mul, Fin.isValue, Units.val_mul, mul_apply, Fin.sum_univ_succ,
-    Finset.univ_unique, Fin.default_eq_zero, Finset.sum_singleton, Fin.succ_zero_eq_one,
-    Complex.ofReal_add, Complex.ofReal_mul, denom]
-  ring
-
-/-- The action of `GLPos 2 ℝ` on the upper half-plane by fractional linear transformations. -/
-instance : MulAction GL(2, ℝ)⁺ ℍ where
-  smul := smulAux
-  one_smul z := by
-    ext1
-    change _ / _ = _
-    simp [num, denom]
-  mul_smul := mul_smul'
-
-instance SLAction {R : Type*} [CommRing R] [Algebra R ℝ] : MulAction SL(2, R) ℍ :=
-  MulAction.compHom ℍ <| SpecialLinearGroup.toGLPos.comp <| map (algebraMap R ℝ)
-
--- Porting note: in the statement, we used to have coercions `↑· : ℝ`
--- rather than `algebraMap R ℝ ·`.
-theorem specialLinearGroup_apply {R : Type*} [CommRing R] [Algebra R ℝ] (g : SL(2, R)) (z : ℍ) :
-    g • z =
-      mk
-        (((algebraMap R ℝ (g 0 0) : ℂ) * z + (algebraMap R ℝ (g 0 1) : ℂ)) /
-          ((algebraMap R ℝ (g 1 0) : ℂ) * z + (algebraMap R ℝ (g 1 1) : ℂ)))
-        (g • z).property :=
-  rfl
-
-variable (g : GL(2, ℝ)⁺) (z : ℍ)
-
-@[simp]
-theorem coe_smul : ↑(g • z) = num g z / denom g z :=
-  rfl
-
-@[simp]
-theorem re_smul : (g • z).re = (num g z / denom g z).re :=
-  rfl
-
-theorem im_smul : (g • z).im = (num g z / denom g z).im :=
-  rfl
-
-theorem im_smul_eq_div_normSq : (g • z).im = det ↑ₘg * z.im / Complex.normSq (denom g z) :=
-  smulAux'_im g z
-
-theorem c_mul_im_sq_le_normSq_denom : (g 1 0 * z.im) ^ 2 ≤ Complex.normSq (denom g z) := by
-  set c := g 1 0
-  set d := g 1 1
-  calc
-    (c * z.im) ^ 2 ≤ (c * z.im) ^ 2 + (c * z.re + d) ^ 2 := by nlinarith
-    _ = Complex.normSq (denom g z) := by dsimp [c, d, denom, Complex.normSq]; ring
-
-@[simp]
-theorem neg_smul : -g • z = g • z := by
-  ext1
-  change _ / _ = _ / _
-  field_simp [denom_ne_zero]
-  simp only [num, denom, Complex.ofReal_neg, neg_mul, GLPos.coe_neg_GL, Units.val_neg, neg_apply]
-  ring_nf
-
-lemma denom_one : denom 1 z = 1 := by
-  simp [denom]
-
 section PosRealAction
 
 instance posRealAction : MulAction { x : ℝ // 0 < x } ℍ where
@@ -357,131 +204,4 @@ theorem vadd_im : (x +ᵥ z).im = z.im :=
 
 end RealAddAction
 
-/- these next few lemmas are *not* flagged `@simp` because of the constructors on the RHS;
-instead we use the versions with coercions to `ℂ` as simp lemmas instead. -/
-theorem modular_S_smul (z : ℍ) : ModularGroup.S • z = mk (-z : ℂ)⁻¹ z.im_inv_neg_coe_pos := by
-  rw [specialLinearGroup_apply]; simp [ModularGroup.S, neg_div, inv_neg, toGL]
-
-theorem modular_T_zpow_smul (z : ℍ) (n : ℤ) : ModularGroup.T ^ n • z = (n : ℝ) +ᵥ z := by
-  rw [UpperHalfPlane.ext_iff, coe_vadd, add_comm, specialLinearGroup_apply, coe_mk]
-  simp [toGL, ModularGroup.coe_T_zpow,
-    of_apply, cons_val_zero, algebraMap.coe_one, Complex.ofReal_one, one_mul, cons_val_one,
-    head_cons, algebraMap.coe_zero, zero_mul, zero_add, div_one]
-
-theorem modular_T_smul (z : ℍ) : ModularGroup.T • z = (1 : ℝ) +ᵥ z := by
-  simpa only [Int.cast_one] using modular_T_zpow_smul z 1
-
-theorem exists_SL2_smul_eq_of_apply_zero_one_eq_zero (g : SL(2, ℝ)) (hc : g 1 0 = 0) :
-    ∃ (u : { x : ℝ // 0 < x }) (v : ℝ), (g • · : ℍ → ℍ) = (v +ᵥ ·) ∘ (u • ·) := by
-  obtain ⟨a, b, ha, rfl⟩ := g.fin_two_exists_eq_mk_of_apply_zero_one_eq_zero hc
-  refine ⟨⟨_, mul_self_pos.mpr ha⟩, b * a, ?_⟩
-  ext1 ⟨z, hz⟩; ext1
-  suffices ↑a * z * a + b * a = b * a + a * a * z by
-    simpa [toGL, specialLinearGroup_apply, add_mul]
-  ring
-
-theorem exists_SL2_smul_eq_of_apply_zero_one_ne_zero (g : SL(2, ℝ)) (hc : g 1 0 ≠ 0) :
-    ∃ (u : { x : ℝ // 0 < x }) (v w : ℝ),
-      (g • · : ℍ → ℍ) =
-        (w +ᵥ ·) ∘ (ModularGroup.S • · : ℍ → ℍ) ∘ (v +ᵥ · : ℍ → ℍ) ∘ (u • · : ℍ → ℍ) := by
-  have h_denom := denom_ne_zero g
-  induction g using Matrix.SpecialLinearGroup.fin_two_induction with | _ a b c d h => ?_
-  replace hc : c ≠ 0 := by simpa using hc
-  refine ⟨⟨_, mul_self_pos.mpr hc⟩, c * d, a / c, ?_⟩
-  ext1 ⟨z, hz⟩; ext1
-  suffices (↑a * z + b) / (↑c * z + d) = a / c - (c * d + ↑c * ↑c * z)⁻¹ by
-    simpa only [modular_S_smul, inv_neg, Function.comp_apply, coe_vadd, Complex.ofReal_mul,
-      coe_pos_real_smul, Complex.real_smul, Complex.ofReal_div, coe_mk]
-  replace hc : (c : ℂ) ≠ 0 := by norm_cast
-  replace h_denom : ↑c * z + d ≠ 0 := by simpa using h_denom ⟨z, hz⟩
-  have h_aux : (c : ℂ) * d + ↑c * ↑c * z ≠ 0 := by
-    rw [mul_assoc, ← mul_add, add_comm]
-    exact mul_ne_zero hc h_denom
-  replace h : (a * d - b * c : ℂ) = (1 : ℂ) := by norm_cast
-  field_simp
-  linear_combination (-(z * (c : ℂ) ^ 2) - c * d) * h
-
 end UpperHalfPlane
-
-namespace ModularGroup -- results specific to `SL(2, ℤ)`
-
-section ModularScalarTowers
-
-/-- Canonical embedding of `SL(2, ℤ)` into `GL(2, ℝ)⁺`. -/
-@[coe]
-def coe (g : SL(2, ℤ)) : GL(2, ℝ)⁺ := ((g : SL(2, ℝ)) : GL(2, ℝ)⁺)
-
-@[simp]
-lemma coe_inj (a b : SL(2, ℤ)) : coe a = coe b ↔ a = b := by
-  refine ⟨fun h ↦ a.ext b fun i j ↦ ?_, congr_arg _⟩
-  simp only [Subtype.ext_iff, GeneralLinearGroup.ext_iff] at h
-  simpa [coe] using h i j
-
-@[deprecated (since := "2024-11-19")] noncomputable alias coe' := coe
-
-instance : Coe SL(2, ℤ) GL(2, ℝ)⁺ :=
-  ⟨coe⟩
-
-/-- Canonical embedding of `SL(2, ℤ)` into `GL(2, ℝ)⁺`, bundled as a group hom. -/
-def coeHom : SL(2, ℤ) →* GL(2, ℝ)⁺ := toGLPos.comp <| map <| Int.castRingHom _
-
-@[simp] lemma coeHom_apply (g : SL(2, ℤ)) : coeHom g = coe g := rfl
-
-@[simp]
-theorem coe_apply_complex {g : SL(2, ℤ)} {i j : Fin 2} :
-    (Units.val <| Subtype.val <| coe g) i j = (Subtype.val g i j : ℂ) :=
-  rfl
-
-@[deprecated (since := "2024-11-19")] alias coe'_apply_complex := coe_apply_complex
-
-@[simp]
-theorem det_coe {g : SL(2, ℤ)} : det (Units.val <| Subtype.val <| coe g) = 1 := by
-  simp only [SpecialLinearGroup.coe_GLPos_coe_GL_coe_matrix, SpecialLinearGroup.det_coe, coe]
-
-@[deprecated (since := "2024-11-19")] alias det_coe' := det_coe
-
-lemma coe_one : coe 1 = 1 := by
-  simp only [coe, map_one]
-
-instance SLOnGLPos : SMul SL(2, ℤ) GL(2, ℝ)⁺ :=
-  ⟨fun s g => s * g⟩
-
-theorem SLOnGLPos_smul_apply (s : SL(2, ℤ)) (g : GL(2, ℝ)⁺) (z : ℍ) :
-    (s • g) • z = ((s : GL(2, ℝ)⁺) * g) • z :=
-  rfl
-
-instance SL_to_GL_tower : IsScalarTower SL(2, ℤ) GL(2, ℝ)⁺ ℍ where
-  smul_assoc s g z := by
-    simp only [SLOnGLPos_smul_apply]
-    apply mul_smul'
-
-end ModularScalarTowers
-
-section SLModularAction
-
-variable (g : SL(2, ℤ)) (z : ℍ)
-
-@[simp]
-theorem sl_moeb (A : SL(2, ℤ)) (z : ℍ) : A • z = (A : GL(2, ℝ)⁺) • z :=
-  rfl
-
-@[simp high]
-theorem SL_neg_smul (g : SL(2, ℤ)) (z : ℍ) : -g • z = g • z := by
-  simp only [coe_GLPos_neg, sl_moeb, coe_int_neg, neg_smul, coe]
-
-theorem im_smul_eq_div_normSq : (g • z).im = z.im / Complex.normSq (denom g z) := by
-  simpa only [coe, coe_GLPos_coe_GL_coe_matrix, (g : SL(2, ℝ)).prop, one_mul] using
-    z.im_smul_eq_div_normSq g
-
-theorem denom_apply (g : SL(2, ℤ)) (z : ℍ) :
-    denom g z = g 1 0 * z + g 1 1 := by
-  simp [denom, coe]
-
-@[simp]
-lemma denom_S (z : ℍ) : denom S z = z := by
-  simp only [S, denom_apply, of_apply, cons_val', cons_val_zero, empty_val', cons_val_fin_one,
-    cons_val_one, head_fin_const, Int.cast_one, one_mul, head_cons, Int.cast_zero, add_zero]
-
-end SLModularAction
-
-end ModularGroup

--- a/Mathlib/Analysis/Complex/UpperHalfPlane/MoebiusAction.lean
+++ b/Mathlib/Analysis/Complex/UpperHalfPlane/MoebiusAction.lean
@@ -1,0 +1,298 @@
+/-
+Copyright (c) 2021 Alex Kontorovich and Heather Macbeth and Marc Masdeu. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Alex Kontorovich, Heather Macbeth, Marc Masdeu
+-/
+import Mathlib.Analysis.Complex.UpperHalfPlane.Basic
+import Mathlib.Data.Fintype.Parity
+import Mathlib.LinearAlgebra.Matrix.GeneralLinearGroup.Defs
+
+/-!
+# The upper half plane and its automorphisms
+
+This file defines the `GLPos 2 ℝ` action on the upper half-plane by fractional linear
+transformations.
+-/
+
+noncomputable section
+
+open Matrix Matrix.SpecialLinearGroup
+open scoped MatrixGroups
+
+open UpperHalfPlane
+
+namespace UpperHalfPlane
+
+/-- The coercion first into an element of  `GL(2, ℝ)⁺`, then  `GL(2, ℝ)` and finally a 2 × 2
+matrix.
+
+This notation is scoped in namespace `UpperHalfPlane`. -/
+scoped notation:1024 "↑ₘ" A:1024 =>
+  (((A : GL(2, ℝ)⁺) : GL (Fin 2) ℝ) : Matrix (Fin 2) (Fin 2) _)
+
+instance instCoeFun : CoeFun GL(2, ℝ)⁺ fun _ => Fin 2 → Fin 2 → ℝ where coe A := ↑ₘA
+
+/-- The coercion into an element of  `GL(2, R)` and finally a 2 × 2 matrix over `R`. This is
+similar to `↑ₘ`, but without positivity requirements, and allows the user to specify the ring `R`,
+which can be useful to help Lean elaborate correctly.
+
+This notation is scoped in namespace `UpperHalfPlane`. -/
+scoped notation:1024 "↑ₘ[" R "]" A:1024 =>
+  ((A : GL (Fin 2) R) : Matrix (Fin 2) (Fin 2) R)
+
+/-- Numerator of the formula for a fractional linear transformation -/
+def num (g : GL(2, ℝ)⁺) (z : ℍ) : ℂ := g 0 0 * z + g 0 1
+
+/-- Denominator of the formula for a fractional linear transformation -/
+def denom (g : GL(2, ℝ)⁺) (z : ℍ) : ℂ := g 1 0 * z + g 1 1
+
+theorem linear_ne_zero (cd : Fin 2 → ℝ) (z : ℍ) (h : cd ≠ 0) : (cd 0 : ℂ) * z + cd 1 ≠ 0 := by
+  contrapose! h
+  have : cd 0 = 0 := by
+    -- we will need this twice
+    apply_fun Complex.im at h
+    simpa only [z.im_ne_zero, Complex.add_im, add_zero, coe_im, zero_mul, or_false,
+      Complex.ofReal_im, Complex.zero_im, Complex.mul_im, mul_eq_zero] using h
+  simp only [this, zero_mul, Complex.ofReal_zero, zero_add, Complex.ofReal_eq_zero]
+    at h
+  ext i
+  fin_cases i <;> assumption
+
+theorem denom_ne_zero (g : GL(2, ℝ)⁺) (z : ℍ) : denom g z ≠ 0 := by
+  intro H
+  have DET := (mem_glpos _).1 g.prop
+  simp only [GeneralLinearGroup.val_det_apply] at DET
+  obtain hg | hz : g 1 0 = 0 ∨ z.im = 0 := by simpa [num, denom] using congr_arg Complex.im H
+  · simp only [hg, Complex.ofReal_zero, denom, zero_mul, zero_add, Complex.ofReal_eq_zero] at H
+    simp only [Matrix.det_fin_two g.1.1, H, hg, mul_zero, sub_zero, lt_self_iff_false] at DET
+  · exact z.prop.ne' hz
+
+theorem normSq_denom_pos (g : GL(2, ℝ)⁺) (z : ℍ) : 0 < Complex.normSq (denom g z) :=
+  Complex.normSq_pos.mpr (denom_ne_zero g z)
+
+theorem normSq_denom_ne_zero (g : GL(2, ℝ)⁺) (z : ℍ) : Complex.normSq (denom g z) ≠ 0 :=
+  ne_of_gt (normSq_denom_pos g z)
+
+/-- Fractional linear transformation, also known as the Moebius transformation -/
+def smulAux' (g : GL(2, ℝ)⁺) (z : ℍ) : ℂ :=
+  num g z / denom g z
+
+theorem smulAux'_im (g : GL(2, ℝ)⁺) (z : ℍ) :
+    (smulAux' g z).im = det ↑ₘg * z.im / Complex.normSq (denom g z) := by
+  simp only [smulAux', num, denom, Complex.div_im, Complex.add_im, Complex.mul_im,
+    Complex.ofReal_re, coe_im, Complex.ofReal_im, coe_re, zero_mul, add_zero, Complex.add_re,
+    Complex.mul_re, sub_zero, ← sub_div, g.1.1.det_fin_two]
+  ring
+
+/-- Fractional linear transformation, also known as the Moebius transformation -/
+def smulAux (g : GL(2, ℝ)⁺) (z : ℍ) : ℍ :=
+  mk (smulAux' g z) <| by
+    rw [smulAux'_im]
+    convert mul_pos ((mem_glpos _).1 g.prop)
+        (div_pos z.im_pos (Complex.normSq_pos.mpr (denom_ne_zero g z))) using 1
+    simp only [GeneralLinearGroup.val_det_apply]
+    ring
+
+theorem denom_cocycle (x y : GL(2, ℝ)⁺) (z : ℍ) :
+    denom (x * y) z = denom x (smulAux y z) * denom y z := by
+  change _ = (_ * (_ / _) + _) * _
+  field_simp [denom_ne_zero]
+  simp only [denom, Subgroup.coe_mul, Fin.isValue, Units.val_mul, mul_apply, Fin.sum_univ_succ,
+    Finset.univ_unique, Fin.default_eq_zero, Finset.sum_singleton, Fin.succ_zero_eq_one,
+    Complex.ofReal_add, Complex.ofReal_mul, num]
+  ring
+
+theorem mul_smul' (x y : GL(2, ℝ)⁺) (z : ℍ) : smulAux (x * y) z = smulAux x (smulAux y z) := by
+  ext1
+  change _ / _ = (_ * (_ / _) + _) / _
+  rw [denom_cocycle]
+  field_simp [denom_ne_zero]
+  simp only [num, Subgroup.coe_mul, Fin.isValue, Units.val_mul, mul_apply, Fin.sum_univ_succ,
+    Finset.univ_unique, Fin.default_eq_zero, Finset.sum_singleton, Fin.succ_zero_eq_one,
+    Complex.ofReal_add, Complex.ofReal_mul, denom]
+  ring
+
+/-- The action of `GLPos 2 ℝ` on the upper half-plane by fractional linear transformations. -/
+instance : MulAction GL(2, ℝ)⁺ ℍ where
+  smul := smulAux
+  one_smul z := by
+    ext1
+    change _ / _ = _
+    simp [num, denom]
+  mul_smul := mul_smul'
+
+instance SLAction {R : Type*} [CommRing R] [Algebra R ℝ] : MulAction SL(2, R) ℍ :=
+  MulAction.compHom ℍ <| SpecialLinearGroup.toGLPos.comp <| map (algebraMap R ℝ)
+
+-- Porting note: in the statement, we used to have coercions `↑· : ℝ`
+-- rather than `algebraMap R ℝ ·`.
+theorem specialLinearGroup_apply {R : Type*} [CommRing R] [Algebra R ℝ] (g : SL(2, R)) (z : ℍ) :
+    g • z =
+      mk
+        (((algebraMap R ℝ (g 0 0) : ℂ) * z + (algebraMap R ℝ (g 0 1) : ℂ)) /
+          ((algebraMap R ℝ (g 1 0) : ℂ) * z + (algebraMap R ℝ (g 1 1) : ℂ)))
+        (g • z).property :=
+  rfl
+
+variable (g : GL(2, ℝ)⁺) (z : ℍ)
+
+@[simp]
+theorem coe_smul : ↑(g • z) = num g z / denom g z :=
+  rfl
+
+@[simp]
+theorem re_smul : (g • z).re = (num g z / denom g z).re :=
+  rfl
+
+theorem im_smul : (g • z).im = (num g z / denom g z).im :=
+  rfl
+
+theorem im_smul_eq_div_normSq : (g • z).im = det ↑ₘg * z.im / Complex.normSq (denom g z) :=
+  smulAux'_im g z
+
+theorem c_mul_im_sq_le_normSq_denom : (g 1 0 * z.im) ^ 2 ≤ Complex.normSq (denom g z) := by
+  set c := g 1 0
+  set d := g 1 1
+  calc
+    (c * z.im) ^ 2 ≤ (c * z.im) ^ 2 + (c * z.re + d) ^ 2 := by nlinarith
+    _ = Complex.normSq (denom g z) := by dsimp [c, d, denom, Complex.normSq]; ring
+
+@[simp]
+theorem neg_smul : -g • z = g • z := by
+  ext1
+  change _ / _ = _ / _
+  field_simp [denom_ne_zero]
+  simp only [num, denom, Complex.ofReal_neg, neg_mul, GLPos.coe_neg_GL, Units.val_neg, neg_apply]
+  ring_nf
+
+lemma denom_one : denom 1 z = 1 := by
+  simp [denom]
+
+/- these next few lemmas are *not* flagged `@simp` because of the constructors on the RHS;
+instead we use the versions with coercions to `ℂ` as simp lemmas instead. -/
+theorem modular_S_smul (z : ℍ) : ModularGroup.S • z = mk (-z : ℂ)⁻¹ z.im_inv_neg_coe_pos := by
+  rw [specialLinearGroup_apply]; simp [ModularGroup.S, neg_div, inv_neg, toGL]
+
+theorem modular_T_zpow_smul (z : ℍ) (n : ℤ) : ModularGroup.T ^ n • z = (n : ℝ) +ᵥ z := by
+  rw [UpperHalfPlane.ext_iff, coe_vadd, add_comm, specialLinearGroup_apply, coe_mk]
+  simp [toGL, ModularGroup.coe_T_zpow,
+    of_apply, cons_val_zero, algebraMap.coe_one, Complex.ofReal_one, one_mul, cons_val_one,
+    head_cons, algebraMap.coe_zero, zero_mul, zero_add, div_one]
+
+theorem modular_T_smul (z : ℍ) : ModularGroup.T • z = (1 : ℝ) +ᵥ z := by
+  simpa only [Int.cast_one] using modular_T_zpow_smul z 1
+
+theorem exists_SL2_smul_eq_of_apply_zero_one_eq_zero (g : SL(2, ℝ)) (hc : g 1 0 = 0) :
+    ∃ (u : { x : ℝ // 0 < x }) (v : ℝ), (g • · : ℍ → ℍ) = (v +ᵥ ·) ∘ (u • ·) := by
+  obtain ⟨a, b, ha, rfl⟩ := g.fin_two_exists_eq_mk_of_apply_zero_one_eq_zero hc
+  refine ⟨⟨_, mul_self_pos.mpr ha⟩, b * a, ?_⟩
+  ext1 ⟨z, hz⟩; ext1
+  suffices ↑a * z * a + b * a = b * a + a * a * z by
+    simpa [toGL, specialLinearGroup_apply, add_mul]
+  ring
+
+theorem exists_SL2_smul_eq_of_apply_zero_one_ne_zero (g : SL(2, ℝ)) (hc : g 1 0 ≠ 0) :
+    ∃ (u : { x : ℝ // 0 < x }) (v w : ℝ),
+      (g • · : ℍ → ℍ) =
+        (w +ᵥ ·) ∘ (ModularGroup.S • · : ℍ → ℍ) ∘ (v +ᵥ · : ℍ → ℍ) ∘ (u • · : ℍ → ℍ) := by
+  have h_denom := denom_ne_zero g
+  induction g using Matrix.SpecialLinearGroup.fin_two_induction with | _ a b c d h => ?_
+  replace hc : c ≠ 0 := by simpa using hc
+  refine ⟨⟨_, mul_self_pos.mpr hc⟩, c * d, a / c, ?_⟩
+  ext1 ⟨z, hz⟩; ext1
+  suffices (↑a * z + b) / (↑c * z + d) = a / c - (c * d + ↑c * ↑c * z)⁻¹ by
+    simpa only [modular_S_smul, inv_neg, Function.comp_apply, coe_vadd, Complex.ofReal_mul,
+      coe_pos_real_smul, Complex.real_smul, Complex.ofReal_div, coe_mk]
+  replace hc : (c : ℂ) ≠ 0 := by norm_cast
+  replace h_denom : ↑c * z + d ≠ 0 := by simpa using h_denom ⟨z, hz⟩
+  have h_aux : (c : ℂ) * d + ↑c * ↑c * z ≠ 0 := by
+    rw [mul_assoc, ← mul_add, add_comm]
+    exact mul_ne_zero hc h_denom
+  replace h : (a * d - b * c : ℂ) = (1 : ℂ) := by norm_cast
+  field_simp
+  linear_combination (-(z * (c : ℂ) ^ 2) - c * d) * h
+
+end UpperHalfPlane
+
+namespace ModularGroup -- results specific to `SL(2, ℤ)`
+
+section ModularScalarTowers
+
+/-- Canonical embedding of `SL(2, ℤ)` into `GL(2, ℝ)⁺`. -/
+@[coe]
+def coe (g : SL(2, ℤ)) : GL(2, ℝ)⁺ := ((g : SL(2, ℝ)) : GL(2, ℝ)⁺)
+
+@[simp]
+lemma coe_inj (a b : SL(2, ℤ)) : coe a = coe b ↔ a = b := by
+  refine ⟨fun h ↦ a.ext b fun i j ↦ ?_, congr_arg _⟩
+  simp only [Subtype.ext_iff, GeneralLinearGroup.ext_iff] at h
+  simpa [coe] using h i j
+
+@[deprecated (since := "2024-11-19")] noncomputable alias coe' := coe
+
+instance : Coe SL(2, ℤ) GL(2, ℝ)⁺ :=
+  ⟨coe⟩
+
+/-- Canonical embedding of `SL(2, ℤ)` into `GL(2, ℝ)⁺`, bundled as a group hom. -/
+def coeHom : SL(2, ℤ) →* GL(2, ℝ)⁺ := toGLPos.comp <| map <| Int.castRingHom _
+
+@[simp] lemma coeHom_apply (g : SL(2, ℤ)) : coeHom g = coe g := rfl
+
+@[simp]
+theorem coe_apply_complex {g : SL(2, ℤ)} {i j : Fin 2} :
+    (Units.val <| Subtype.val <| coe g) i j = (Subtype.val g i j : ℂ) :=
+  rfl
+
+@[deprecated (since := "2024-11-19")] alias coe'_apply_complex := coe_apply_complex
+
+@[simp]
+theorem det_coe {g : SL(2, ℤ)} : det (Units.val <| Subtype.val <| coe g) = 1 := by
+  simp only [SpecialLinearGroup.coe_GLPos_coe_GL_coe_matrix, SpecialLinearGroup.det_coe, coe]
+
+@[deprecated (since := "2024-11-19")] alias det_coe' := det_coe
+
+lemma coe_one : coe 1 = 1 := by
+  simp only [coe, map_one]
+
+instance SLOnGLPos : SMul SL(2, ℤ) GL(2, ℝ)⁺ :=
+  ⟨fun s g => s * g⟩
+
+theorem SLOnGLPos_smul_apply (s : SL(2, ℤ)) (g : GL(2, ℝ)⁺) (z : ℍ) :
+    (s • g) • z = ((s : GL(2, ℝ)⁺) * g) • z :=
+  rfl
+
+instance SL_to_GL_tower : IsScalarTower SL(2, ℤ) GL(2, ℝ)⁺ ℍ where
+  smul_assoc s g z := by
+    simp only [SLOnGLPos_smul_apply]
+    apply mul_smul'
+
+end ModularScalarTowers
+
+section SLModularAction
+
+variable (g : SL(2, ℤ)) (z : ℍ)
+
+@[simp]
+theorem sl_moeb (A : SL(2, ℤ)) (z : ℍ) : A • z = (A : GL(2, ℝ)⁺) • z :=
+  rfl
+
+@[simp high]
+theorem SL_neg_smul (g : SL(2, ℤ)) (z : ℍ) : -g • z = g • z := by
+  simp only [coe_GLPos_neg, sl_moeb, coe_int_neg, neg_smul, coe]
+
+theorem im_smul_eq_div_normSq : (g • z).im = z.im / Complex.normSq (denom g z) := by
+  simpa only [coe, coe_GLPos_coe_GL_coe_matrix, (g : SL(2, ℝ)).prop, one_mul] using
+    z.im_smul_eq_div_normSq g
+
+theorem denom_apply (g : SL(2, ℤ)) (z : ℍ) :
+    denom g z = g 1 0 * z + g 1 1 := by
+  simp [denom, coe]
+
+@[simp]
+lemma denom_S (z : ℍ) : denom S z = z := by
+  simp only [S, denom_apply, of_apply, cons_val', cons_val_zero, empty_val', cons_val_fin_one,
+    cons_val_one, head_fin_const, Int.cast_one, one_mul, head_cons, Int.cast_zero, add_zero]
+
+end SLModularAction
+
+end ModularGroup

--- a/Mathlib/Analysis/Complex/UpperHalfPlane/Topology.lean
+++ b/Mathlib/Analysis/Complex/UpperHalfPlane/Topology.lean
@@ -3,7 +3,7 @@ Copyright (c) 2022 Yury Kudryashov. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury Kudryashov
 -/
-import Mathlib.Analysis.Complex.UpperHalfPlane.Basic
+import Mathlib.Analysis.Complex.UpperHalfPlane.MoebiusAction
 import Mathlib.Analysis.Convex.Contractible
 import Mathlib.Analysis.LocallyConvex.WithSeminorms
 import Mathlib.Analysis.Complex.Convex

--- a/Mathlib/NumberTheory/Modular.lean
+++ b/Mathlib/NumberTheory/Modular.lean
@@ -3,7 +3,7 @@ Copyright (c) 2021 Alex Kontorovich and Heather Macbeth and Marc Masdeu. All rig
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Alex Kontorovich, Heather Macbeth, Marc Masdeu
 -/
-import Mathlib.Analysis.Complex.UpperHalfPlane.Basic
+import Mathlib.Analysis.Complex.UpperHalfPlane.MoebiusAction
 import Mathlib.LinearAlgebra.GeneralLinearGroup
 import Mathlib.LinearAlgebra.Matrix.GeneralLinearGroup.Basic
 import Mathlib.Topology.Instances.Matrix

--- a/Mathlib/NumberTheory/ModularForms/CongruenceSubgroups.lean
+++ b/Mathlib/NumberTheory/ModularForms/CongruenceSubgroups.lean
@@ -3,7 +3,7 @@ Copyright (c) 2022 Chris Birkbeck. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Birkbeck
 -/
-import Mathlib.Analysis.Complex.UpperHalfPlane.Basic
+import Mathlib.Analysis.Complex.UpperHalfPlane.MoebiusAction
 
 /-!
 # Congruence subgroups

--- a/Mathlib/NumberTheory/ModularForms/JacobiTheta/OneVariable.lean
+++ b/Mathlib/NumberTheory/ModularForms/JacobiTheta/OneVariable.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: David Loeffler
 -/
 import Mathlib.NumberTheory.ModularForms.JacobiTheta.TwoVariable
-import Mathlib.Analysis.Complex.UpperHalfPlane.Basic
+import Mathlib.Analysis.Complex.UpperHalfPlane.MoebiusAction
 
 /-! # Jacobi's theta function
 

--- a/Mathlib/NumberTheory/ModularForms/SlashActions.lean
+++ b/Mathlib/NumberTheory/ModularForms/SlashActions.lean
@@ -3,7 +3,7 @@ Copyright (c) 2022 Chris Birkbeck. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Birkbeck
 -/
-import Mathlib.Analysis.Complex.UpperHalfPlane.Basic
+import Mathlib.Analysis.Complex.UpperHalfPlane.MoebiusAction
 import Mathlib.LinearAlgebra.Matrix.GeneralLinearGroup.Defs
 import Mathlib.LinearAlgebra.Matrix.SpecialLinearGroup
 import Mathlib.Tactic.AdaptationNote


### PR DESCRIPTION
Split up `Mathlib.Analysis.Complex.UpperHalfPlane.Basic` into one file which is really basic (just elementary definitions) and another which does the GL(2, R)^+ action.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
