### PR TITLE
[Merged by Bors] - feat(Data/Finsupp/MonomialOrder): give `≼[m]`/ `≺[m]` the same priority as `≤`/`<`

### DIFF
--- a/Mathlib/Data/Finsupp/MonomialOrder.lean
+++ b/Mathlib/Data/Finsupp/MonomialOrder.lean
@@ -98,11 +98,11 @@ lemma toSyn_strictMono : StrictMono (m.toSyn) := by
 
 /-- Given a monomial order, notation for the corresponding strict order relation on `σ →₀ ℕ` -/
 scoped
-notation:25 c " ≺[" m:25 "] " d:25 => (MonomialOrder.toSyn m c < MonomialOrder.toSyn m d)
+notation:50 c " ≺[" m:25 "] " d:50 => (MonomialOrder.toSyn m c < MonomialOrder.toSyn m d)
 
 /-- Given a monomial order, notation for the corresponding order relation on `σ →₀ ℕ` -/
 scoped
-notation:25 c " ≼[" m:25 "] " d:25 => (MonomialOrder.toSyn m c ≤ MonomialOrder.toSyn m d)
+notation:50 c " ≼[" m:25 "] " d:50 => (MonomialOrder.toSyn m c ≤ MonomialOrder.toSyn m d)
 
 end MonomialOrder
 


### PR DESCRIPTION
`a ≼[m] b ∨ b ≼[m] a` would be parsed as `(a ≼[m] b) ∨ (b ≼[m] a)`.

The previous priority of the left and right side of `≼[m]` and `≺[m]` is lower than logic connectives, which makes statements like `a ≼[m] b ∨ b ≼[m] a` parsed as `a ≼[m] (b ∨ b) ≼[m] a`, and statements like `(a ≼[m] b) ∨ b ≼[m] a` parsed as `((a ≼[m] b) ∨ b) ≼[m] a`. With this commit, both of them would be parsed as `(a ≼[m] b) ∨ (b ≼[m] a)`.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
