### PR TITLE
[Merged by Bors] - chore: swap the sides of the argument to `subtypePerm`

### DIFF
--- a/Mathlib/Algebra/Group/End.lean
+++ b/Mathlib/Algebra/Group/End.lean
@@ -418,7 +418,6 @@ theorem ofSubtype_apply_coe (f : Perm (Subtype p)) (x : Subtype p) : ofSubtype f
 theorem ofSubtype_apply_of_not_mem (f : Perm (Subtype p)) (ha : ¬p a) : ofSubtype f a = a :=
   extendDomain_apply_not_subtype _ _ ha
 
-@[simp]
 theorem ofSubtype_apply_mem_iff_mem (f : Perm (Subtype p)) (x : α) :
     p ((ofSubtype f : α → α) x) ↔ p x :=
   if h : p x then by

--- a/Mathlib/Algebra/Group/End.lean
+++ b/Mathlib/Algebra/Group/End.lean
@@ -331,15 +331,15 @@ variable {p : α → Prop} {f : Perm α}
 
 /-- If the permutation `f` fixes the subtype `{x // p x}`, then this returns the permutation
   on `{x // p x}` induced by `f`. -/
-def subtypePerm (f : Perm α) (h : ∀ x, p x ↔ p (f x)) : Perm { x // p x } where
-  toFun := fun x => ⟨f x, (h _).1 x.2⟩
-  invFun := fun x => ⟨f⁻¹ x, (h (f⁻¹ x)).2 <| by simpa using x.2⟩
+def subtypePerm (f : Perm α) (h : ∀ x, p (f x) ↔ p x) : Perm { x // p x } where
+  toFun := fun x => ⟨f x, (h _).2 x.2⟩
+  invFun := fun x => ⟨f⁻¹ x, (h (f⁻¹ x)).1 <| by simpa using x.2⟩
   left_inv _ := by simp only [Perm.inv_apply_self, Subtype.coe_eta, Subtype.coe_mk]
   right_inv _ := by simp only [Perm.apply_inv_self, Subtype.coe_eta, Subtype.coe_mk]
 
 @[simp]
-theorem subtypePerm_apply (f : Perm α) (h : ∀ x, p x ↔ p (f x)) (x : { x // p x }) :
-    subtypePerm f h x = ⟨f x, (h _).1 x.2⟩ :=
+theorem subtypePerm_apply (f : Perm α) (h : ∀ x, p (f x) ↔ p x) (x : { x // p x }) :
+    subtypePerm f h x = ⟨f x, (h _).2 x.2⟩ :=
   rfl
 
 @[simp]
@@ -349,10 +349,10 @@ theorem subtypePerm_one (p : α → Prop) (h := fun _ => Iff.rfl) : @subtypePerm
 @[simp]
 theorem subtypePerm_mul (f g : Perm α) (hf hg) :
     (f.subtypePerm hf * g.subtypePerm hg : Perm { x // p x }) =
-      (f * g).subtypePerm fun _ => (hg _).trans <| hf _ :=
+      (f * g).subtypePerm fun _ => (hf _).trans <| hg _ :=
   rfl
 
-private theorem inv_aux : (∀ x, p x ↔ p (f x)) ↔ ∀ x, p x ↔ p (f⁻¹ x) :=
+private theorem inv_aux : (∀ x, p (f x) ↔ p x) ↔ ∀ x, p (f⁻¹ x) ↔ p x :=
   f⁻¹.surjective.forall.trans <| by simp_rw [f.apply_inv_self, Iff.comm]
 
 /-- See `Equiv.Perm.inv_subtypePerm`. -/
@@ -366,9 +366,9 @@ theorem inv_subtypePerm (f : Perm α) (hf) :
     (f.subtypePerm hf : Perm { x // p x })⁻¹ = f⁻¹.subtypePerm (inv_aux.1 hf) :=
   rfl
 
-private theorem pow_aux (hf : ∀ x, p x ↔ p (f x)) : ∀ {n : ℕ} (x), p x ↔ p ((f ^ n) x)
+private theorem pow_aux (hf : ∀ x, p (f x) ↔ p x) : ∀ {n : ℕ} (x), p ((f ^ n) x) ↔ p x
   | 0, _ => Iff.rfl
-  | _ + 1, _ => (hf _).trans (pow_aux hf _)
+  | _ + 1, _ => (pow_aux hf (f _)).trans (hf _)
 
 @[simp]
 theorem subtypePerm_pow (f : Perm α) (n : ℕ) (hf) :
@@ -377,11 +377,11 @@ theorem subtypePerm_pow (f : Perm α) (n : ℕ) (hf) :
   | zero => simp
   | succ n ih => simp_rw [pow_succ', ih, subtypePerm_mul]
 
-private theorem zpow_aux (hf : ∀ x, p x ↔ p (f x)) : ∀ {n : ℤ} (x), p x ↔ p ((f ^ n) x)
+private theorem zpow_aux (hf : ∀ x, p (f x) ↔ p x) : ∀ {n : ℤ} (x), p ((f ^ n) x) ↔ p x
   | Int.ofNat _ => pow_aux hf
   | Int.negSucc n => by
     rw [zpow_negSucc]
-    exact inv_aux.1 (pow_aux hf)
+    exact pow_aux (inv_aux.1 hf)
 
 @[simp]
 theorem subtypePerm_zpow (f : Perm α) (n : ℤ) (hf) :
@@ -399,7 +399,7 @@ def ofSubtype : Perm (Subtype p) →* Perm α where
   map_one' := Equiv.Perm.extendDomain_one _
   map_mul' f g := (Equiv.Perm.extendDomain_mul _ f g).symm
 
-theorem ofSubtype_subtypePerm {f : Perm α} (h₁ : ∀ x, p x ↔ p (f x)) (h₂ : ∀ x, f x ≠ x → p x) :
+theorem ofSubtype_subtypePerm {f : Perm α} (h₁ : ∀ x, p (f x) ↔ p x) (h₂ : ∀ x, f x ≠ x → p x) :
     ofSubtype (subtypePerm f h₁) = f :=
   Equiv.ext fun x => by
     by_cases hx : p x
@@ -418,10 +418,11 @@ theorem ofSubtype_apply_coe (f : Perm (Subtype p)) (x : Subtype p) : ofSubtype f
 theorem ofSubtype_apply_of_not_mem (f : Perm (Subtype p)) (ha : ¬p a) : ofSubtype f a = a :=
   extendDomain_apply_not_subtype _ _ ha
 
-theorem mem_iff_ofSubtype_apply_mem (f : Perm (Subtype p)) (x : α) :
-    p x ↔ p ((ofSubtype f : α → α) x) :=
+@[simp]
+theorem ofSubtype_apply_mem_iff_mem (f : Perm (Subtype p)) (x : α) :
+    p ((ofSubtype f : α → α) x) ↔ p x :=
   if h : p x then by
-    simpa only [h, true_iff, MonoidHom.coe_mk, ofSubtype_apply_of_mem f h] using (f ⟨x, h⟩).2
+    simpa only [h, iff_true, MonoidHom.coe_mk, ofSubtype_apply_of_mem f h] using (f ⟨x, h⟩).2
   else by simp [h, ofSubtype_apply_of_not_mem f h]
 
 theorem ofSubtype_injective : Function.Injective (ofSubtype : Perm (Subtype p) → Perm α) := by
@@ -433,16 +434,16 @@ theorem ofSubtype_injective : Function.Injective (ofSubtype : Perm (Subtype p) �
 
 @[simp]
 theorem subtypePerm_ofSubtype (f : Perm (Subtype p)) :
-    subtypePerm (ofSubtype f) (mem_iff_ofSubtype_apply_mem f) = f :=
+    subtypePerm (ofSubtype f) (ofSubtype_apply_mem_iff_mem f) = f :=
   Equiv.ext fun x => Subtype.coe_injective (ofSubtype_apply_coe f x)
 
 theorem ofSubtype_subtypePerm_of_mem {p : α → Prop} [DecidablePred p]
-    {g : Perm α} (hg : ∀ (x : α), p x ↔ p (g x))
+    {g : Perm α} (hg : ∀ (x : α), p (g x) ↔ p x)
     {a : α} (ha : p a) : (ofSubtype (g.subtypePerm hg)) a = g a :=
   ofSubtype_apply_of_mem (g.subtypePerm hg) ha
 
 theorem ofSubtype_subtypePerm_of_not_mem {p : α → Prop} [DecidablePred p]
-    {g : Perm α} (hg : ∀ (x : α), p x ↔ p (g x))
+    {g : Perm α} (hg : ∀ (x : α), p (g x) ↔ p x)
     {a : α} (ha : ¬ p a) : (ofSubtype (g.subtypePerm hg)) a = a :=
   ofSubtype_apply_of_not_mem (g.subtypePerm hg) ha
 
@@ -453,9 +454,9 @@ protected def subtypeEquivSubtypePerm (p : α → Prop) [DecidablePred p] :
     Perm (Subtype p) ≃ { f : Perm α // ∀ a, ¬p a → f a = a } where
   toFun f := ⟨ofSubtype f, fun _ => f.ofSubtype_apply_of_not_mem⟩
   invFun f :=
-    (f : Perm α).subtypePerm fun a =>
-      ⟨Decidable.not_imp_not.1 fun hfa => f.val.injective (f.prop _ hfa) ▸ hfa,
-        Decidable.not_imp_not.1 fun ha hfa => ha <| f.prop a ha ▸ hfa⟩
+    (f : Perm α).subtypePerm fun _ =>
+      ⟨Decidable.not_imp_not.1 fun hfa => (f.prop _ hfa).symm ▸ hfa,
+        Decidable.not_imp_not.1 fun hfa ha => hfa <| f.val.injective (f.prop _ hfa).symm ▸ ha⟩
   left_inv := Equiv.Perm.subtypePerm_ofSubtype
   right_inv f :=
     Subtype.ext ((Equiv.Perm.ofSubtype_subtypePerm _) fun a => Not.decidable_imp_symm <| f.prop a)

--- a/Mathlib/GroupTheory/Perm/Centralizer.lean
+++ b/Mathlib/GroupTheory/Perm/Centralizer.lean
@@ -556,7 +556,7 @@ theorem kerParam_range_eq :
   · rintro - ⟨p, hp, rfl⟩
     simp only [coe_subtype]
     set u : Perm (Function.fixedPoints g) :=
-      subtypePerm p (fun x ↦ mem_fixedPoints_iff_apply_mem_of_mem_centralizer p.2)
+      subtypePerm p (fun x ↦ apply_mem_fixedPoints_iff_mem_of_mem_centralizer p.2)
     simp only [SetLike.mem_coe, mem_ker_toPermHom_iff, IsCycle.forall_commute_iff] at hp
     set v : (c : g.cycleFactorsFinset) → (Subgroup.zpowers c.val) :=
       fun c => ⟨ofSubtype

--- a/Mathlib/GroupTheory/Perm/Cycle/Basic.lean
+++ b/Mathlib/GroupTheory/Perm/Cycle/Basic.lean
@@ -738,7 +738,7 @@ theorem IsCycleOn.apply_mem_iff (hf : f.IsCycleOn s) : f x ∈ s ↔ x ∈ s :=
 
 /-- Note that the identity satisfies `IsCycleOn` for any subsingleton set, but not `IsCycle`. -/
 theorem IsCycleOn.isCycle_subtypePerm (hf : f.IsCycleOn s) (hs : s.Nontrivial) :
-    (f.subtypePerm fun _ => hf.apply_mem_iff.symm : Perm s).IsCycle := by
+    (f.subtypePerm fun _ => hf.apply_mem_iff : Perm s).IsCycle := by
   obtain ⟨a, ha⟩ := hs.nonempty
   exact
     ⟨⟨a, ha⟩, ne_of_apply_ne ((↑) : s → α) (hf.apply_ne hs ha), fun b _ =>
@@ -746,7 +746,7 @@ theorem IsCycleOn.isCycle_subtypePerm (hf : f.IsCycleOn s) (hs : s.Nontrivial) :
 
 /-- Note that the identity is a cycle on any subsingleton set, but not a cycle. -/
 protected theorem IsCycleOn.subtypePerm (hf : f.IsCycleOn s) :
-    (f.subtypePerm fun _ => hf.apply_mem_iff.symm : Perm s).IsCycleOn _root_.Set.univ := by
+    (f.subtypePerm fun _ => hf.apply_mem_iff : Perm s).IsCycleOn _root_.Set.univ := by
   obtain hs | hs := s.subsingleton_or_nontrivial
   · haveI := hs.coe_sort
     exact isCycleOn_of_subsingleton _ _
@@ -763,7 +763,7 @@ theorem IsCycleOn.pow_apply_eq {s : Finset α} (hf : f.IsCycleOn s) (ha : a ∈ 
   classical
     have h (x : s) : ¬f x = x := hf.apply_ne hs x.2
     have := (hf.isCycle_subtypePerm hs).orderOf
-    simp only [coe_sort_coe, support_subtype_perm, ne_eq, h, not_false_eq_true, univ_eq_attach,
+    simp only [coe_sort_coe, support_subtypePerm, ne_eq, h, not_false_eq_true, univ_eq_attach,
       mem_attach, imp_self, implies_true, filter_true_of_mem, card_attach] at this
     rw [← this, orderOf_dvd_iff_pow_eq_one,
       (hf.isCycle_subtypePerm hs).pow_eq_one_iff'
@@ -973,12 +973,12 @@ end Finset
 namespace Equiv.Perm
 
 theorem subtypePerm_apply_pow_of_mem {g : Perm α} {s : Finset α}
-    (hs : ∀ x : α, x ∈ s ↔ g x ∈ s) {n : ℕ} {x : α} (hx : x ∈ s) :
+    (hs : ∀ x : α, g x ∈ s ↔ x ∈ s) {n : ℕ} {x : α} (hx : x ∈ s) :
     ((g.subtypePerm hs ^ n) (⟨x, hx⟩ : s) : α) = (g ^ n) x := by
   simp only [subtypePerm_pow, subtypePerm_apply]
 
 theorem subtypePerm_apply_zpow_of_mem {g : Perm α} {s : Finset α}
-    (hs : ∀ x : α, x ∈ s ↔ g x ∈ s) {i : ℤ} {x : α} (hx : x ∈ s) :
+    (hs : ∀ x : α, g x ∈ s ↔ x ∈ s) {i : ℤ} {x : α} (hx : x ∈ s) :
     ((g.subtypePerm hs ^ i) (⟨x, hx⟩ : s) : α) = (g ^ i) x := by
   simp only [subtypePerm_zpow, subtypePerm_apply]
 
@@ -986,7 +986,7 @@ variable [Fintype α] [DecidableEq α]
 
 /-- Restrict a permutation to its support -/
 def subtypePermOfSupport (c : Perm α) : Perm c.support :=
-  subtypePerm c fun _ : α => apply_mem_support.symm
+  subtypePerm c fun _ : α => apply_mem_support
 
 /-- Restrict a permutation to a Finset containing its support -/
 def subtypePerm_of_support_le (c : Perm α) {s : Finset α}
@@ -1002,14 +1002,14 @@ theorem IsCycle.nonempty_support {g : Perm α} (hg : g.IsCycle) :
 /-- Centralizer of a cycle is a power of that cycle on the cycle -/
 theorem IsCycle.commute_iff' {g c : Perm α} (hc : c.IsCycle) :
     Commute g c ↔
-      ∃ hc' : ∀ x : α, x ∈ c.support ↔ g x ∈ c.support,
+      ∃ hc' : ∀ x : α, g x ∈ c.support ↔ x ∈ c.support,
         subtypePerm g hc' ∈ Subgroup.zpowers c.subtypePermOfSupport := by
   constructor
   · intro hgc
     have hgc' := mem_support_iff_of_commute hgc
     use hgc'
     obtain ⟨a, ha⟩ := IsCycle.nonempty_support hc
-    obtain ⟨i, hi⟩ := hc.sameCycle (mem_support.mp ha) (mem_support.mp ((hgc' a).mp ha))
+    obtain ⟨i, hi⟩ := hc.sameCycle (mem_support.mp ha) (mem_support.mp ((hgc' a).mpr ha))
     use i
     ext ⟨x, hx⟩
     simp only [subtypePermOfSupport, Subtype.coe_mk, subtypePerm_apply]
@@ -1033,13 +1033,13 @@ theorem IsCycle.commute_iff' {g c : Perm α} (hc : c.IsCycle) :
       exact hix.symm
     · rw [not_mem_support.mp hx, eq_comm, ← not_mem_support]
       contrapose! hx
-      exact (hc' x).mpr hx
+      exact (hc' x).mp hx
 
 /-- A permutation `g` commutes with a cycle `c` if and only if
   `c.support` is invariant under `g`, and `g` acts on it as a power of `c`. -/
 theorem IsCycle.commute_iff {g c : Perm α} (hc : c.IsCycle) :
     Commute g c ↔
-      ∃ hc' : ∀ x : α, x ∈ c.support ↔ g x ∈ c.support,
+      ∃ hc' : ∀ x : α, g x ∈ c.support ↔ x ∈ c.support,
         ofSubtype (subtypePerm g hc') ∈ Subgroup.zpowers c := by
   simp_rw [hc.commute_iff', Subgroup.mem_zpowers_iff]
   refine exists_congr fun hc' => exists_congr fun k => ?_
@@ -1055,7 +1055,7 @@ theorem IsCycle.commute_iff {g c : Perm α} (hc : c.IsCycle) :
 
 theorem zpow_eq_ofSubtype_subtypePerm_iff
     {g c : Equiv.Perm α} {s : Finset α}
-    (hg : ∀ x, x ∈ s ↔ g x ∈ s) (hc : c.support ⊆ s) (n : ℤ) :
+    (hg : ∀ x, g x ∈ s ↔ x ∈ s) (hc : c.support ⊆ s) (n : ℤ) :
     c ^ n = ofSubtype (g.subtypePerm hg) ↔
       c.subtypePerm (isInvariant_of_support_le hc) ^ n = g.subtypePerm hg := by
   constructor

--- a/Mathlib/GroupTheory/Perm/Cycle/Factors.lean
+++ b/Mathlib/GroupTheory/Perm/Cycle/Factors.lean
@@ -35,7 +35,7 @@ variable {f g : Perm α} {x y : α}
 
 /-- `f.cycleOf x` is the cycle of the permutation `f` to which `x` belongs. -/
 def cycleOf (f : Perm α) [DecidableRel f.SameCycle] (x : α) : Perm α :=
-  ofSubtype (subtypePerm f fun _ => sameCycle_apply_right.symm : Perm { y // SameCycle f x y })
+  ofSubtype (subtypePerm f fun _ => sameCycle_apply_right : Perm { y // SameCycle f x y })
 
 theorem cycleOf_apply (f : Perm α) [DecidableRel f.SameCycle] (x y : α) :
     cycleOf f x y = if SameCycle f x y then f y else y := by
@@ -779,7 +779,7 @@ theorem self_mem_cycle_factors_commute {g c : Perm α}
 /-- If `c` and `d` are cycles of `g`, then `d` stabilizes the support of `c` -/
 theorem mem_support_cycle_of_cycle {g d c : Perm α}
     (hc : c ∈ g.cycleFactorsFinset) (hd : d ∈ g.cycleFactorsFinset) :
-    ∀ x : α, x ∈ c.support ↔ d x ∈ c.support := by
+    ∀ x : α, d x ∈ c.support ↔ x ∈ c.support := by
   intro x
   simp only [mem_support, not_iff_not]
   by_cases h : c = d
@@ -790,7 +790,7 @@ theorem mem_support_cycle_of_cycle {g d c : Perm α}
 
 /-- If a permutation is a cycle of `g`, then its support is invariant under `g`. -/
 theorem mem_cycleFactorsFinset_support {g c : Perm α} (hc : c ∈ g.cycleFactorsFinset) (a : α) :
-    a ∈ c.support ↔ g a ∈ c.support :=
+    g a ∈ c.support ↔ a ∈ c.support :=
   mem_support_iff_of_commute (self_mem_cycle_factors_commute hc).symm a
 
 end CycleFactorsFinset
@@ -865,7 +865,7 @@ theorem cycleFactorsFinset_mul_inv_mem_eq_sdiff [DecidableEq α] [Fintype α] {f
 theorem IsCycle.forall_commute_iff [DecidableEq α] [Fintype α] (g z : Perm α) :
     (∀ c ∈ g.cycleFactorsFinset, Commute z c) ↔
       ∀ c ∈ g.cycleFactorsFinset,
-      ∃ (hc : ∀ x : α, x ∈ c.support ↔ z x ∈ c.support),
+      ∃ (hc : ∀ x : α, z x ∈ c.support ↔ x ∈ c.support),
         ofSubtype (subtypePerm z hc) ∈ Subgroup.zpowers c := by
   apply forall_congr'
   intro c
@@ -884,7 +884,7 @@ theorem subtypePerm_on_cycleFactorsFinset [DecidableEq α] [Fintype α]
 theorem commute_iff_of_mem_cycleFactorsFinset [DecidableEq α] [Fintype α] {g k c : Equiv.Perm α}
     (hc : c ∈ g.cycleFactorsFinset) :
     Commute k c ↔
-      ∃ hc' : ∀ x : α, x ∈ c.support ↔ k x ∈ c.support,
+      ∃ hc' : ∀ x : α, k x ∈ c.support ↔ x ∈ c.support,
         k.subtypePerm hc' ∈ Subgroup.zpowers
           (g.subtypePerm (mem_cycleFactorsFinset_support hc)) := by
   rw [IsCycle.commute_iff' (mem_cycleFactorsFinset_iff.mp hc).1]

--- a/Mathlib/GroupTheory/Perm/Finite.lean
+++ b/Mathlib/GroupTheory/Perm/Finite.lean
@@ -85,7 +85,7 @@ theorem perm_inv_on_of_perm_on_finite {f : Perm α} {p : α → Prop} [Finite { 
   `Equiv.Perm.subtypePerm`. -/
 abbrev subtypePermOfFintype (f : Perm α) {p : α → Prop} [Finite { x // p x }]
     (h : ∀ x, p x → p (f x)) : Perm { x // p x } :=
-  f.subtypePerm fun x => ⟨h x, fun h₂ => f.inv_apply_self x ▸ perm_inv_on_of_perm_on_finite h h₂⟩
+  f.subtypePerm fun x => ⟨fun h₂ => f.inv_apply_self x ▸ perm_inv_on_of_perm_on_finite h h₂, h x⟩
 
 @[simp]
 theorem subtypePermOfFintype_apply (f : Perm α) {p : α → Prop} [Finite { x // p x }]
@@ -214,9 +214,9 @@ theorem Disjoint.isConj_mul [Finite α] {σ τ π ρ : Perm α} (hc1 : IsConj σ
         · rwa [Subtype.coe_mk, Perm.mul_apply, (hd1 (τ x)).resolve_right hxτ,
             mem_coe, mem_support]
 
-theorem mem_fixedPoints_iff_apply_mem_of_mem_centralizer {g p : Perm α}
+theorem apply_mem_fixedPoints_iff_mem_of_mem_centralizer {g p : Perm α}
     (hp : p ∈ Subgroup.centralizer {g}) {x : α} :
-    x ∈ Function.fixedPoints g ↔ p x ∈ Function.fixedPoints g :=  by
+    p x ∈ Function.fixedPoints g ↔ x ∈ Function.fixedPoints g :=  by
   simp only [Subgroup.mem_centralizer_singleton_iff] at hp
   simp only [Function.mem_fixedPoints_iff]
   rw [← mul_apply, ← hp, mul_apply, EmbeddingLike.apply_eq_iff_eq]

--- a/Mathlib/GroupTheory/Perm/Sign.lean
+++ b/Mathlib/GroupTheory/Perm/Sign.lean
@@ -460,7 +460,7 @@ theorem eq_sign_of_surjective_hom {s : Perm α →* ℤˣ} (hs : Surjective s) :
     rw [← hl₁, ← l.prod_hom s, List.eq_replicate_length.2 hsl, List.length_map, List.prod_replicate,
       sign_prod_list_swap hl₂]
 
-theorem sign_subtypePerm (f : Perm α) {p : α → Prop} [DecidablePred p] (h₁ : ∀ x, p x ↔ p (f x))
+theorem sign_subtypePerm (f : Perm α) {p : α → Prop} [DecidablePred p] (h₁ : ∀ x, p (f x) ↔ p x)
     (h₂ : ∀ x, f x ≠ x → p x) : sign (subtypePerm f h₁) = sign f := by
   let l := (truncSwapFactors (subtypePerm f h₁)).out
   have hl' : ∀ g' ∈ l.1.map ofSubtype, IsSwap g' := fun g' hg' =>

--- a/Mathlib/GroupTheory/Perm/Support.lean
+++ b/Mathlib/GroupTheory/Perm/Support.lean
@@ -304,7 +304,7 @@ theorem support_congr (h : f.support ⊆ g.support) (h' : ∀ x ∈ g.support, f
 
 /-- If g and c commute, then g stabilizes the support of c -/
 theorem mem_support_iff_of_commute {g c : Perm α} (hgc : Commute g c) (x : α) :
-    x ∈ c.support ↔ g x ∈ c.support := by
+    g x ∈ c.support ↔ x ∈ c.support := by
   simp only [mem_support, not_iff_not, ← mul_apply]
   rw [← hgc, mul_apply, Equiv.apply_eq_iff_eq]
 

--- a/Mathlib/GroupTheory/Perm/Support.lean
+++ b/Mathlib/GroupTheory/Perm/Support.lean
@@ -339,7 +339,7 @@ theorem apply_mem_support {x : α} : f x ∈ f.support ↔ x ∈ f.support := by
 
 /-- The support of a permutation is invariant -/
 theorem isInvariant_of_support_le {c : Perm α} {s : Finset α} (hcs : c.support ≤ s) (x : α) :
-    x ∈ s ↔ c x ∈ s := by
+    c x ∈ s ↔ x ∈ s := by
   by_cases hx' : x ∈ c.support
   · simp only [hcs hx', true_iff, hcs (apply_mem_support.mpr hx')]
   · rw [not_mem_support.mp hx']
@@ -347,10 +347,10 @@ theorem isInvariant_of_support_le {c : Perm α} {s : Finset α} (hcs : c.support
 /-- A permutation c is the extension of a restriction of g to s
   iff its support is contained in s and its restriction is that of g -/
 lemma ofSubtype_eq_iff {g c : Equiv.Perm α} {s : Finset α}
-    (hg : ∀ x, x ∈ s ↔ g x ∈ s) :
+    (hg : ∀ x, g x ∈ s ↔ x ∈ s) :
     ofSubtype (g.subtypePerm hg) = c ↔
       c.support ≤ s ∧
-      ∀ (hc' : ∀ x, x ∈ s ↔ c x ∈ s), c.subtypePerm hc' = g.subtypePerm hg := by
+      ∀ (hc' : ∀ x, c x ∈ s ↔ x ∈ s), c.subtypePerm hc' = g.subtypePerm hg := by
   simp only [Equiv.ext_iff, subtypePerm_apply, Subtype.mk.injEq, Subtype.forall]
   constructor
   · intro h
@@ -652,7 +652,7 @@ end Card
 end support
 
 @[simp]
-theorem support_subtype_perm [DecidableEq α] {s : Finset α} (f : Perm α) (h) :
+theorem support_subtypePerm [DecidableEq α] {s : Finset α} (f : Perm α) (h) :
     (f.subtypePerm h : Perm s).support = ({x | f x ≠ x} : Finset s) := by
   ext; simp [Subtype.ext_iff]
 


### PR DESCRIPTION
This way the argument will not loop, when used with `simp`.
The argument also appears in many lemmas.

This change is a workaround for the extended simpNF linter, which runs `simp [h]` with `h` of that type.

Zulip: [#mathlib4 > simpNF lint with hyps @ 💬](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/simpNF.20lint.20with.20hyps/near/517741799)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
