### PR TITLE
[Merged by Bors] - feat(Probability): lemmas about variance

### DIFF
--- a/Mathlib/Probability/Variance.lean
+++ b/Mathlib/Probability/Variance.lean
@@ -220,7 +220,7 @@ lemma variance_const_add [IsProbabilityMeasure μ] (hX : AEStronglyMeasurable X 
     Var[fun ω ↦ c + X ω; μ] = Var[X; μ] := by
   simp_rw [add_comm c, variance_add_const hX c]
 
-lemma variance_neg [IsProbabilityMeasure μ] : Var[fun ω ↦ -X ω; μ] = Var[X; μ] := by
+lemma variance_neg : Var[fun ω ↦ -X ω; μ] = Var[X; μ] := by
   convert variance_mul (-1) X μ
   · ext; ring
   · simp

--- a/Mathlib/Probability/Variance.lean
+++ b/Mathlib/Probability/Variance.lean
@@ -220,10 +220,12 @@ lemma variance_const_add [IsProbabilityMeasure μ] (hX : AEStronglyMeasurable X 
     Var[fun ω ↦ c + X ω; μ] = Var[X; μ] := by
   simp_rw [add_comm c, variance_add_const hX c]
 
-lemma variance_neg : Var[fun ω ↦ -X ω; μ] = Var[X; μ] := by
+lemma variance_fun_neg : Var[fun ω ↦ -X ω; μ] = Var[X; μ] := by
   convert variance_mul (-1) X μ
   · ext; ring
   · simp
+
+lemma variance_neg : Var[-X; μ] = Var[X; μ] := variance_fun_neg
 
 lemma variance_sub_const [IsProbabilityMeasure μ] (hX : AEStronglyMeasurable X μ) (c : ℝ) :
     Var[fun ω ↦ X ω - c; μ] = Var[X; μ] := by
@@ -232,7 +234,7 @@ lemma variance_sub_const [IsProbabilityMeasure μ] (hX : AEStronglyMeasurable X 
 lemma variance_const_sub [IsProbabilityMeasure μ] (hX : AEStronglyMeasurable X μ) (c : ℝ) :
     Var[fun ω ↦ c - X ω; μ] = Var[X; μ] := by
   simp_rw [sub_eq_add_neg]
-  rw [variance_const_add (by fun_prop) c, variance_neg]
+  rw [variance_const_add (by fun_prop) c, variance_fun_neg]
 
 @[simp]
 lemma variance_dirac [MeasurableSingletonClass Ω] (x : Ω) : Var[X; Measure.dirac x] = 0 := by

--- a/Mathlib/Probability/Variance.lean
+++ b/Mathlib/Probability/Variance.lean
@@ -114,6 +114,10 @@ alias evariance_lt_top_iff_memℒp := evariance_lt_top_iff_memLp
 lemma evariance_eq_top_iff [IsFiniteMeasure μ] (hX : AEStronglyMeasurable X μ) :
     evariance X μ = ∞ ↔ ¬ MemLp X 2 μ := by simp [← evariance_lt_top_iff_memLp hX]
 
+lemma variance_of_not_memLp [IsFiniteMeasure μ] (hX : AEStronglyMeasurable X μ)
+    (hX_not : ¬ MemLp X 2 μ) :
+    variance X μ = 0 := by simp [variance, (evariance_eq_top_iff hX).mpr hX_not]
+
 theorem ofReal_variance [IsFiniteMeasure μ] (hX : MemLp X 2 μ) :
     .ofReal (variance X μ) = evariance X μ := by
   rw [variance, ENNReal.ofReal_toReal]
@@ -198,6 +202,56 @@ theorem variance_def' [IsProbabilityMeasure μ] {X : Ω → ℝ} (hX : MemLp X 2
   simp only [integral_const, measureReal_univ_eq_one, smul_eq_mul, one_mul, integral_mul_const,
     integral_const_mul, Pi.pow_apply]
   ring
+
+lemma variance_add_const [IsProbabilityMeasure μ] (hX : AEStronglyMeasurable X μ) (c : ℝ) :
+    Var[fun ω ↦ X ω + c; μ] = Var[X; μ] := by
+  by_cases hX_Lp : MemLp X 2 μ
+  · have hX_int : Integrable X μ := hX_Lp.integrable one_le_two
+    rw [variance_eq_integral (hX.add_const _).aemeasurable,
+      integral_add hX_int (by fun_prop), integral_const, variance_eq_integral hX.aemeasurable]
+    simp
+  · rw [variance_of_not_memLp (hX.add_const _), variance_of_not_memLp hX hX_Lp]
+    refine fun h_memLp ↦ hX_Lp ?_
+    have : X = fun ω ↦ X ω + c - c := by ext; ring
+    rw [this]
+    exact h_memLp.sub (memLp_const c)
+
+lemma variance_const_add [IsProbabilityMeasure μ] (hX : AEStronglyMeasurable X μ) (c : ℝ) :
+    Var[fun ω ↦ c + X ω; μ] = Var[X; μ] := by
+  simp_rw [add_comm c, variance_add_const hX c]
+
+lemma variance_neg [IsProbabilityMeasure μ] : Var[fun ω ↦ -X ω; μ] = Var[X; μ] := by
+  convert variance_mul (-1) X μ
+  · ext; ring
+  · simp
+
+lemma variance_sub_const [IsProbabilityMeasure μ] (hX : AEStronglyMeasurable X μ) (c : ℝ) :
+    Var[fun ω ↦ X ω - c; μ] = Var[X; μ] := by
+  simp_rw [sub_eq_add_neg, variance_add_const hX (-c)]
+
+lemma variance_const_sub [IsProbabilityMeasure μ] (hX : AEStronglyMeasurable X μ) (c : ℝ) :
+    Var[fun ω ↦ c - X ω; μ] = Var[X; μ] := by
+  simp_rw [sub_eq_add_neg]
+  rw [variance_const_add (by fun_prop) c, variance_neg]
+
+@[simp]
+lemma variance_dirac [MeasurableSingletonClass Ω] (x : Ω) : Var[X; Measure.dirac x] = 0 := by
+  rw [variance_eq_integral]
+  · simp
+  · exact aemeasurable_dirac
+
+lemma variance_map {Ω' : Type*} {mΩ' : MeasurableSpace Ω'} {μ : Measure Ω'}
+    {Y : Ω' → Ω} (hX : AEMeasurable X (μ.map Y)) (hY : AEMeasurable Y μ) :
+    Var[X; μ.map Y] = Var[X ∘ Y; μ] := by
+  rw [variance_eq_integral hX, integral_map hY, variance_eq_integral (hX.comp_aemeasurable hY),
+    integral_map hY]
+  · congr
+  · exact hX.aestronglyMeasurable
+  · refine AEStronglyMeasurable.pow ?_ _
+    exact AEMeasurable.aestronglyMeasurable (by fun_prop)
+
+lemma variance_id_map (hX : AEMeasurable X μ) : Var[id; μ.map X] = Var[X; μ] := by
+  simp [variance_map measurable_id.aemeasurable hX]
 
 theorem variance_le_expectation_sq [IsProbabilityMeasure μ] {X : Ω → ℝ}
     (hm : AEStronglyMeasurable X μ) : variance X μ ≤ μ[X ^ 2] := by


### PR DESCRIPTION
- `Var[fun ω ↦ X ω + c; μ] = Var[X; μ]`. Same for `c + X`, `-X`, `X - c` and `c - X`.
- The variance of a Dirac measure is 0
- `Var[X; μ.map Y] = Var[X ∘ Y; μ]`

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
