### PR TITLE
[Merged by Bors] - chore: whitespace fixes

### DIFF
--- a/Mathlib/Analysis/Meromorphic/Basic.lean
+++ b/Mathlib/Analysis/Meromorphic/Basic.lean
@@ -123,7 +123,7 @@ theorem prod {ι : Type*} {s : Finset ι} {f : ι → 𝕜 → 𝕜} {x : 𝕜}
 
 /-- Finite products of meromorphic functions are analytic. -/
 @[fun_prop]
-theorem fun_prod  {ι : Type*} {s : Finset ι} {f : ι → 𝕜 → 𝕜} {x : 𝕜}
+theorem fun_prod {ι : Type*} {s : Finset ι} {f : ι → 𝕜 → 𝕜} {x : 𝕜}
     (h : ∀ σ, MeromorphicAt (f σ) x) :
     MeromorphicAt (fun z ↦ ∏ n ∈ s, f n z) x := by
   convert prod h (s := s)

--- a/Mathlib/MeasureTheory/Function/LpSpace/ContinuousFunctions.lean
+++ b/Mathlib/MeasureTheory/Function/LpSpace/ContinuousFunctions.lean
@@ -132,7 +132,7 @@ variable (𝕜 : Type*) (p μ) [Fact (1 ≤ p)]
 space `α` as an element of `Lp`.  By definition, the norm on `C(α, E)` is the sup-norm, transferred
 from the space `α →ᵇ E` of bounded continuous functions, so this construction is just a matter of
 transferring the structure from `BoundedContinuousFunction.toLp` along the isometry. -/
-def toLp  : C(α, E) →L[𝕜] Lp E p μ :=
+def toLp : C(α, E) →L[𝕜] Lp E p μ :=
   (BoundedContinuousFunction.toLp p μ 𝕜).comp
     (linearIsometryBoundedOfCompact α E 𝕜).toLinearIsometry.toContinuousLinearMap
 

--- a/Mathlib/MeasureTheory/Measure/AEMeasurable.lean
+++ b/Mathlib/MeasureTheory/Measure/AEMeasurable.lean
@@ -169,12 +169,12 @@ theorem map_map_of_aemeasurable {g : β → γ} {f : α → β} (hg : AEMeasurab
     map_apply_of_aemeasurable (hg.comp_aemeasurable hf) hs, preimage_comp]
 
 @[fun_prop, measurability]
-protected theorem fst {f : α → β × γ} (hf :AEMeasurable f μ) :
+protected theorem fst {f : α → β × γ} (hf : AEMeasurable f μ) :
     AEMeasurable (fun x ↦ (f x).1) μ :=
   measurable_fst.comp_aemeasurable hf
 
 @[fun_prop, measurability]
-protected theorem snd {f : α → β × γ} (hf :AEMeasurable f μ) :
+protected theorem snd {f : α → β × γ} (hf : AEMeasurable f μ) :
     AEMeasurable (fun x ↦ (f x).2) μ :=
   measurable_snd.comp_aemeasurable hf
 

--- a/Mathlib/RingTheory/Localization/Basic.lean
+++ b/Mathlib/RingTheory/Localization/Basic.lean
@@ -239,7 +239,7 @@ section smul
 
 variable {R : Type*} [CommSemiring R] {S : Submonoid R}
 variable {R' : Type*} [CommSemiring R'] [Algebra R R'] [IsLocalization S R']
-variable {M': Type*} [AddCommMonoid M'] [Module R' M'] [Module R M'] [IsScalarTower R R' M']
+variable {M' : Type*} [AddCommMonoid M'] [Module R' M'] [Module R M'] [IsScalarTower R R' M']
 
 /-- If `x` in a `R' = S⁻¹ R`-module `M'`, then for a submodule `N'` of `M'`,
 `s • x ∈ N'` if and only if `x ∈ N'` for some `s` in S. -/

--- a/Mathlib/RingTheory/MvPowerSeries/Order.lean
+++ b/Mathlib/RingTheory/MvPowerSeries/Order.lean
@@ -459,7 +459,7 @@ def IsWeightedHomogeneous (f : MvPowerSeries σ R) (p : ℕ) : Prop :=
 
 variable {w} in
 theorem IsWeightedHomogeneous.coeff_eq_zero {f : MvPowerSeries σ R} {p : ℕ}
-    (hf : f.IsWeightedHomogeneous w p) {d : σ →₀ ℕ} (hd : weight w d  ≠ p) :
+    (hf : f.IsWeightedHomogeneous w p) {d : σ →₀ ℕ} (hd : weight w d ≠ p) :
     f.coeff R d = 0 := by
   simpa [Classical.not_not] using mt (@hf d) hd
 
@@ -590,7 +590,7 @@ def IsHomogeneous (f : MvPowerSeries σ R) (p : ℕ) : Prop :=
   IsWeightedHomogeneous 1 f p
 
 theorem IsHomogeneous.coeff_eq_zero {f : MvPowerSeries σ R} {p : ℕ}
-    (hf : f.IsHomogeneous p) {d : σ →₀ ℕ} (hd : degree d  ≠ p) :
+    (hf : f.IsHomogeneous p) {d : σ →₀ ℕ} (hd : degree d ≠ p) :
     f.coeff R d = 0 := by
   apply IsWeightedHomogeneous.coeff_eq_zero hf
   rwa [degree_eq_weight_one] at hd


### PR DESCRIPTION
Foud by #24465.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
