### PR TITLE
[Merged by Bors] - fix(pretty printing): line breaks in PR testing

### DIFF
--- a/.github/workflows/discover-lean-pr-testing.yml
+++ b/.github/workflows/discover-lean-pr-testing.yml
@@ -218,7 +218,7 @@ jobs:
           MESSAGE+=$'### ✅ Successfully merged branches:\n\n'
           for MERGE_INFO in $SUCCESSFUL_MERGES; do
             IFS='|' read -r PR_NUMBER GITHUB_DIFF BRANCH <<< "$MERGE_INFO"
-            MESSAGE+=$(printf -- '- lean#%s ([diff](%s))\n\n' "$PR_NUMBER" "$GITHUB_DIFF")
+            MESSAGE+=$(printf -- '- lean#%s ([diff](%s))' "$PR_NUMBER" "$GITHUB_DIFF")$'\n\n'
           done
           MESSAGE+=$'\n'
         else
@@ -230,9 +230,9 @@ jobs:
           MESSAGE+=$'### ❌ Failed merges:\n\nThe following branches need to be merged manually:\n\n'
           for MERGE_INFO in $FAILED_MERGES; do
             IFS='|' read -r PR_NUMBER GITHUB_DIFF BRANCH <<< "$MERGE_INFO"
-            MESSAGE+=$(printf 'Diff: %s\n\n' "$GITHUB_DIFF")
+            MESSAGE+=$(printf 'Diff: %s' "$GITHUB_DIFF")$'\n\n'
             MESSAGE+=$'```bash\n'
-            MESSAGE+=$(printf 'scripts/merge-lean-testing-pr.sh %s\n' "$PR_NUMBER")
+            MESSAGE+=$(printf 'scripts/merge-lean-testing-pr.sh %s' "$PR_NUMBER")$'\n'
             MESSAGE+=$'```\n\n'
           done
         else
@@ -240,7 +240,7 @@ jobs:
         fi
 
         # Output the message using the correct GitHub Actions syntax
-        printf 'msg<<EOF\n%s\nEOF' "$MESSAGE" >> "$GITHUB_OUTPUT"
+        printf 'msg<<EOF\n%s\nEOF' "$MESSAGE" | tee "$GITHUB_OUTPUT"
 
     - name: Send message on Zulip
       if: env.branches_exist == 'true'


### PR DESCRIPTION
Might be a fix for [#nightly-testing > Mergeable lean testing PRs @ 💬](https://leanprover.zulipchat.com/#narrow/channel/428973-nightly-testing/topic/Mergeable.20lean.20testing.20PRs/near/517796661).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
