### PR TITLE
[Merged by Bors] - chore: deprecated_module for Tactic.FunProp.ContDiff

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -5598,6 +5598,7 @@ import Mathlib.Tactic.Finiteness
 import Mathlib.Tactic.Finiteness.Attr
 import Mathlib.Tactic.FunProp
 import Mathlib.Tactic.FunProp.Attr
+import Mathlib.Tactic.FunProp.ContDiff
 import Mathlib.Tactic.FunProp.Core
 import Mathlib.Tactic.FunProp.Decl
 import Mathlib.Tactic.FunProp.Differentiable

--- a/Mathlib/Tactic.lean
+++ b/Mathlib/Tactic.lean
@@ -92,6 +92,7 @@ import Mathlib.Tactic.Finiteness
 import Mathlib.Tactic.Finiteness.Attr
 import Mathlib.Tactic.FunProp
 import Mathlib.Tactic.FunProp.Attr
+import Mathlib.Tactic.FunProp.ContDiff
 import Mathlib.Tactic.FunProp.Core
 import Mathlib.Tactic.FunProp.Decl
 import Mathlib.Tactic.FunProp.Differentiable

--- a/Mathlib/Tactic/FunProp/ContDiff.lean
+++ b/Mathlib/Tactic/FunProp/ContDiff.lean
@@ -1,0 +1,16 @@
+/-
+Copyright (c) 2024 Tomáš Skřivan. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Tomáš Skřivan
+-/
+import Mathlib.Analysis.Calculus.IteratedDeriv.Lemmas
+import Mathlib.Analysis.SpecialFunctions.ExpDeriv
+import Mathlib.Analysis.SpecialFunctions.Log.Deriv
+
+
+import Mathlib.Tactic.FunProp
+import Mathlib.Tactic.FunProp.Differentiable
+
+deprecated_module
+  "fun_prop knows about ContDiff(At/On) directly; no need to import this file any more"
+  (since := "2025-05-13")


### PR DESCRIPTION
This file was removed in #24056. This file was probably not imported by users, but let's rather be safe than sorry.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
