### PR TITLE
[Merged by Bors] - feat(CategoryTheory/Limits/Final): `fromPUnit c` is final if `c` is terminal

### DIFF
--- a/Mathlib/CategoryTheory/Comma/StructuredArrow/Basic.lean
+++ b/Mathlib/CategoryTheory/Comma/StructuredArrow/Basic.lean
@@ -154,6 +154,13 @@ def isoMk {f f' : StructuredArrow S T} (g : f.right ≅ f'.right)
     f ≅ f' :=
   Comma.isoMk (eqToIso (by ext)) g (by simpa using w.symm)
 
+theorem obj_ext (x y : StructuredArrow S T) (hr : x.right = y.right)
+    (hh : x.hom ≫ T.map (eqToHom hr) = y.hom) : x = y := by
+  cases x
+  cases y
+  cases hr
+  aesop_cat
+
 theorem ext {A B : StructuredArrow S T} (f g : A ⟶ B) : f.right = g.right → f = g :=
   CommaMorphism.ext (Subsingleton.elim _ _)
 
@@ -499,6 +506,13 @@ and to check that the triangle commutes.
 def isoMk {f f' : CostructuredArrow S T} (g : f.left ≅ f'.left)
     (w : S.map g.hom ≫ f'.hom = f.hom := by aesop_cat) : f ≅ f' :=
   Comma.isoMk g (eqToIso (by ext)) (by simpa using w)
+
+theorem obj_ext (x y : CostructuredArrow S T) (hl : x.left = y.left)
+    (hh : S.map (eqToHom hl) ≫ y.hom = x.hom) : x = y := by
+  cases x
+  cases y
+  cases hl
+  aesop_cat
 
 theorem ext {A B : CostructuredArrow S T} (f g : A ⟶ B) (h : f.left = g.left) : f = g :=
   CommaMorphism.ext h (Subsingleton.elim _ _)

--- a/Mathlib/CategoryTheory/IsConnected.lean
+++ b/Mathlib/CategoryTheory/IsConnected.lean
@@ -457,4 +457,10 @@ theorem nonempty_hom_of_preconnected_groupoid {G} [Groupoid G] [IsPreconnected G
 
 attribute [instance] nonempty_hom_of_preconnected_groupoid
 
+instance PreconnectedOfSubsingleton {J : Type*} [Category J] [Subsingleton J] :
+    IsPreconnected J where
+  iso_constant {α} F j := ⟨NatIso.ofComponents (fun x ↦ eqToIso (by simp [Subsingleton.allEq x j]))⟩
+
+instance {J : Type*} [Category J] [Nonempty J] [Subsingleton J] : IsConnected J where
+
 end CategoryTheory

--- a/Mathlib/CategoryTheory/IsConnected.lean
+++ b/Mathlib/CategoryTheory/IsConnected.lean
@@ -457,8 +457,7 @@ theorem nonempty_hom_of_preconnected_groupoid {G} [Groupoid G] [IsPreconnected G
 
 attribute [instance] nonempty_hom_of_preconnected_groupoid
 
-instance PreconnectedOfSubsingleton [Subsingleton J] :
-    IsPreconnected J where
+instance PreconnectedOfSubsingleton [Subsingleton J] : IsPreconnected J where
   iso_constant {α} F j := ⟨NatIso.ofComponents (fun x ↦ eqToIso (by simp [Subsingleton.allEq x j]))⟩
 
 instance [Nonempty J] [Subsingleton J] : IsConnected J where

--- a/Mathlib/CategoryTheory/IsConnected.lean
+++ b/Mathlib/CategoryTheory/IsConnected.lean
@@ -457,10 +457,10 @@ theorem nonempty_hom_of_preconnected_groupoid {G} [Groupoid G] [IsPreconnected G
 
 attribute [instance] nonempty_hom_of_preconnected_groupoid
 
-instance PreconnectedOfSubsingleton {J : Type*} [Category J] [Subsingleton J] :
+instance PreconnectedOfSubsingleton [Subsingleton J] :
     IsPreconnected J where
   iso_constant {α} F j := ⟨NatIso.ofComponents (fun x ↦ eqToIso (by simp [Subsingleton.allEq x j]))⟩
 
-instance {J : Type*} [Category J] [Nonempty J] [Subsingleton J] : IsConnected J where
+instance [Nonempty J] [Subsingleton J] : IsConnected J where
 
 end CategoryTheory

--- a/Mathlib/CategoryTheory/IsConnected.lean
+++ b/Mathlib/CategoryTheory/IsConnected.lean
@@ -457,9 +457,10 @@ theorem nonempty_hom_of_preconnected_groupoid {G} [Groupoid G] [IsPreconnected G
 
 attribute [instance] nonempty_hom_of_preconnected_groupoid
 
-instance preconnected_of_subsingleton [Subsingleton J] : IsPreconnected J where
+instance isPreconnected_of_subsingleton [Subsingleton J] : IsPreconnected J where
   iso_constant {α} F j := ⟨NatIso.ofComponents (fun x ↦ eqToIso (by simp [Subsingleton.allEq x j]))⟩
 
-instance connected_of_nonempty_and_subsingleton [Nonempty J] [Subsingleton J] : IsConnected J where
+instance isConnected_of_nonempty_and_subsingleton [Nonempty J] [Subsingleton J] :
+    IsConnected J where
 
 end CategoryTheory

--- a/Mathlib/CategoryTheory/IsConnected.lean
+++ b/Mathlib/CategoryTheory/IsConnected.lean
@@ -457,9 +457,9 @@ theorem nonempty_hom_of_preconnected_groupoid {G} [Groupoid G] [IsPreconnected G
 
 attribute [instance] nonempty_hom_of_preconnected_groupoid
 
-instance PreconnectedOfSubsingleton [Subsingleton J] : IsPreconnected J where
+instance preconnected_of_subsingleton [Subsingleton J] : IsPreconnected J where
   iso_constant {α} F j := ⟨NatIso.ofComponents (fun x ↦ eqToIso (by simp [Subsingleton.allEq x j]))⟩
 
-instance [Nonempty J] [Subsingleton J] : IsConnected J where
+instance connected_of_nonempty_and_subsingleton [Nonempty J] [Subsingleton J] : IsConnected J where
 
 end CategoryTheory

--- a/Mathlib/CategoryTheory/Limits/Final.lean
+++ b/Mathlib/CategoryTheory/Limits/Final.lean
@@ -899,14 +899,14 @@ lemma fromPUnit_final_of_isTerminal (hc : Limits.IsTerminal c) : (fromPUnit c).F
   out c' := by
     letI : Inhabited (StructuredArrow c' (fromPUnit c)) := ⟨.mk (Y := default) (hc.from c')⟩
     letI : Subsingleton (StructuredArrow c' (fromPUnit c)) :=
-      ⟨fun i j ↦ StructuredArrow.obj_ext _ _ (by aesop_cat) (IsTerminal.hom_ext hc _ _)⟩
+      ⟨fun i j ↦ StructuredArrow.obj_ext _ _ (by aesop_cat) (hc.hom_ext _ _)⟩
     infer_instance
 
 lemma fromPUnit_initial_of_isInitial (hc : Limits.IsInitial c) : (fromPUnit c).Initial where
   out c' := by
     letI : Inhabited (CostructuredArrow (fromPUnit c) c') := ⟨.mk (Y := default) (hc.to c')⟩
     letI : Subsingleton (CostructuredArrow (fromPUnit c) c') :=
-      ⟨fun i j ↦ CostructuredArrow.obj_ext _ _ (by aesop_cat) (IsInitial.hom_ext hc _ _)⟩
+      ⟨fun i j ↦ CostructuredArrow.obj_ext _ _ (by aesop_cat) (hc.hom_ext _ _)⟩
     infer_instance
 
 end

--- a/Mathlib/CategoryTheory/Limits/Final.lean
+++ b/Mathlib/CategoryTheory/Limits/Final.lean
@@ -895,14 +895,14 @@ section
 
 variable {C : Type u₁} [Category.{v₁} C] {c : C}
 
-lemma fromPUnit_final_of_isTerminal (hc : Limits.IsTerminal c) : (fromPUnit c).Final where
+lemma final_fromPUnit_of_isTerminal (hc : Limits.IsTerminal c) : (fromPUnit c).Final where
   out c' := by
     letI : Inhabited (StructuredArrow c' (fromPUnit c)) := ⟨.mk (Y := default) (hc.from c')⟩
     letI : Subsingleton (StructuredArrow c' (fromPUnit c)) :=
       ⟨fun i j ↦ StructuredArrow.obj_ext _ _ (by aesop_cat) (hc.hom_ext _ _)⟩
     infer_instance
 
-lemma fromPUnit_initial_of_isInitial (hc : Limits.IsInitial c) : (fromPUnit c).Initial where
+lemma initial_fromPUnit_of_isInitial (hc : Limits.IsInitial c) : (fromPUnit c).Initial where
   out c' := by
     letI : Inhabited (CostructuredArrow (fromPUnit c) c') := ⟨.mk (Y := default) (hc.to c')⟩
     letI : Subsingleton (CostructuredArrow (fromPUnit c) c') :=

--- a/Mathlib/CategoryTheory/Limits/Final.lean
+++ b/Mathlib/CategoryTheory/Limits/Final.lean
@@ -891,6 +891,38 @@ theorem initial_iff_initial_comp [Initial F] : Initial G ↔ Initial (F ⋙ G) :
 
 end
 
+section
+
+variable {C : Type u₁} [Category.{v₁} C] {c : C}
+
+lemma fromPUnit_final_of_isTerminal (hc : Limits.IsTerminal c) : (fromPUnit c).Final where
+  out c' :=
+    letI : Inhabited (StructuredArrow c' (fromPUnit c)) := ⟨.mk (Y := default) (hc.from c')⟩
+    isConnected_of_zigzag fun j j' ↦ by
+      use [default, j']
+      constructor
+      · constructor
+        · exact Zag.of_hom (StructuredArrow.homMk (eqToHom rfl) (by apply hc.hom_ext))
+        · constructor
+          · exact Zag.of_hom (StructuredArrow.homMk (eqToHom rfl) (by apply hc.hom_ext))
+          · exact List.Chain.nil
+      · rfl
+
+lemma fromPUnit_initial_of_isInitial (hc : Limits.IsInitial c) : (fromPUnit c).Initial where
+  out c' :=
+    letI : Inhabited (CostructuredArrow (fromPUnit c) c') := ⟨.mk (Y := default) (hc.to c')⟩
+    isConnected_of_zigzag fun j j' ↦ by
+      use [default, j']
+      constructor
+      · constructor
+        · exact Zag.of_hom (CostructuredArrow.homMk (eqToHom rfl) (by apply hc.hom_ext))
+        · constructor
+          · exact Zag.of_hom (CostructuredArrow.homMk (eqToHom rfl) (by apply hc.hom_ext))
+          · exact List.Chain.nil
+      · rfl
+
+end
+
 end Functor
 
 section Filtered

--- a/Mathlib/CategoryTheory/Limits/Final.lean
+++ b/Mathlib/CategoryTheory/Limits/Final.lean
@@ -896,30 +896,18 @@ section
 variable {C : Type u₁} [Category.{v₁} C] {c : C}
 
 lemma fromPUnit_final_of_isTerminal (hc : Limits.IsTerminal c) : (fromPUnit c).Final where
-  out c' :=
+  out c' := by
     letI : Inhabited (StructuredArrow c' (fromPUnit c)) := ⟨.mk (Y := default) (hc.from c')⟩
-    isConnected_of_zigzag fun j j' ↦ by
-      use [default, j']
-      constructor
-      · constructor
-        · exact Zag.of_hom (StructuredArrow.homMk (eqToHom rfl) (by apply hc.hom_ext))
-        · constructor
-          · exact Zag.of_hom (StructuredArrow.homMk (eqToHom rfl) (by apply hc.hom_ext))
-          · exact List.Chain.nil
-      · rfl
+    letI : Subsingleton (StructuredArrow c' (fromPUnit c)) :=
+      ⟨fun i j ↦ StructuredArrow.obj_ext _ _ (by aesop_cat) (IsTerminal.hom_ext hc _ _)⟩
+    infer_instance
 
 lemma fromPUnit_initial_of_isInitial (hc : Limits.IsInitial c) : (fromPUnit c).Initial where
-  out c' :=
+  out c' := by
     letI : Inhabited (CostructuredArrow (fromPUnit c) c') := ⟨.mk (Y := default) (hc.to c')⟩
-    isConnected_of_zigzag fun j j' ↦ by
-      use [default, j']
-      constructor
-      · constructor
-        · exact Zag.of_hom (CostructuredArrow.homMk (eqToHom rfl) (by apply hc.hom_ext))
-        · constructor
-          · exact Zag.of_hom (CostructuredArrow.homMk (eqToHom rfl) (by apply hc.hom_ext))
-          · exact List.Chain.nil
-      · rfl
+    letI : Subsingleton (CostructuredArrow (fromPUnit c) c') :=
+      ⟨fun i j ↦ CostructuredArrow.obj_ext _ _ (by aesop_cat) (IsInitial.hom_ext hc _ _)⟩
+    infer_instance
 
 end
 


### PR DESCRIPTION
Given an object of a category `c`, the functor `fromPUnit c` is final if the object is terminal. Dually, we show that `fromPUnit c` is initial when the object is initial.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

Converses also hold, but will be work for an other day.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
