### PR TITLE
[Merged by Bors] - chore: whitespace adaptations

### DIFF
--- a/Mathlib/Analysis/Calculus/ContDiff/Basic.lean
+++ b/Mathlib/Analysis/Calculus/ContDiff/Basic.lean
@@ -1238,7 +1238,7 @@ protected theorem ContDiffAt.fderiv {f : E → F → G} {g : E → F}
 
 @[fun_prop]
 protected theorem ContDiffAt.fderiv_succ {f : E → F → G} {g : E → F}
-    (hf : ContDiffAt 𝕜 (m+1) (Function.uncurry f) (x₀, g x₀)) (hg : ContDiffAt 𝕜 m g x₀) :
+    (hf : ContDiffAt 𝕜 (m + 1) (Function.uncurry f) (x₀, g x₀)) (hg : ContDiffAt 𝕜 m g x₀) :
     ContDiffAt 𝕜 m (fun x => fderiv 𝕜 (f x) (g x)) x₀ :=
   ContDiffAt.fderiv hf hg (le_refl _)
 
@@ -1247,7 +1247,7 @@ theorem ContDiffAt.fderiv_right (hf : ContDiffAt 𝕜 n f x₀) (hmn : m + 1 ≤
     ContDiffAt 𝕜 m (fderiv 𝕜 f) x₀ :=
   ContDiffAt.fderiv (ContDiffAt.comp (x₀, x₀) hf contDiffAt_snd) contDiffAt_id hmn
 
-theorem ContDiffAt.fderiv_right_succ (hf : ContDiffAt 𝕜 (n+1) f x₀) :
+theorem ContDiffAt.fderiv_right_succ (hf : ContDiffAt 𝕜 (n + 1) f x₀) :
     ContDiffAt 𝕜 n (fderiv 𝕜 f) x₀ :=
   ContDiffAt.fderiv (ContDiffAt.comp (x₀, x₀) hf contDiffAt_snd) contDiffAt_id (le_refl (n+1))
 
@@ -1264,7 +1264,7 @@ protected theorem ContDiff.fderiv {f : E → F → G} {g : E → F}
 
 @[fun_prop]
 protected theorem ContDiff.fderiv_succ {f : E → F → G} {g : E → F}
-    (hf : ContDiff 𝕜 (n+1) <| Function.uncurry f) (hg : ContDiff 𝕜 n g)  :
+    (hf : ContDiff 𝕜 (n + 1) <| Function.uncurry f) (hg : ContDiff 𝕜 n g) :
     ContDiff 𝕜 n fun x => fderiv 𝕜 (f x) (g x) :=
   contDiff_iff_contDiffAt.mpr fun _ => hf.contDiffAt.fderiv hg.contDiffAt (le_refl (n+1))
 
@@ -1278,7 +1278,7 @@ theorem ContDiff.iteratedFDeriv_right {i : ℕ} (hf : ContDiff 𝕜 n f)
   contDiff_iff_contDiffAt.mpr fun _x => hf.contDiffAt.iteratedFDeriv_right hmn
 
 @[fun_prop]
-theorem ContDiff.iteratedFDeriv_right' {i : ℕ} (hf : ContDiff 𝕜 (m+i) f) :
+theorem ContDiff.iteratedFDeriv_right' {i : ℕ} (hf : ContDiff 𝕜 (m + i) f) :
     ContDiff 𝕜 m (iteratedFDeriv 𝕜 i f) :=
   contDiff_iff_contDiffAt.mpr fun _x => hf.contDiffAt.iteratedFDeriv_right (le_refl _)
 
@@ -1296,7 +1296,7 @@ theorem Continuous.fderiv_one {f : E → F → G} {g : E → F}
 
 @[fun_prop]
 protected theorem Differentiable.fderiv_two {f : E → F → G} {g : E → F}
-    (hf : ContDiff 𝕜 2 <| Function.uncurry f) (hg : ContDiff 𝕜 1 g)  :
+    (hf : ContDiff 𝕜 2 <| Function.uncurry f) (hg : ContDiff 𝕜 1 g) :
     Differentiable 𝕜 fun x => fderiv 𝕜 (f x) (g x) :=
   ContDiff.differentiable
     (contDiff_iff_contDiffAt.mpr fun _ => hf.contDiffAt.fderiv hg.contDiffAt (le_refl 2))
@@ -1447,7 +1447,7 @@ theorem ContDiff.differentiable_deriv_two (h : ContDiff 𝕜 2 f₂) : Different
   unfold deriv; fun_prop
 
 @[fun_prop]
-theorem ContDiff.deriv' (h : ContDiff 𝕜 (n+1) f₂) : ContDiff 𝕜 n (deriv f₂) := by
+theorem ContDiff.deriv' (h : ContDiff 𝕜 (n + 1) f₂) : ContDiff 𝕜 n (deriv f₂) := by
   unfold deriv; fun_prop
 
 @[fun_prop]

--- a/Mathlib/Analysis/Calculus/IteratedDeriv/Defs.lean
+++ b/Mathlib/Analysis/Calculus/IteratedDeriv/Defs.lean
@@ -279,7 +279,7 @@ theorem ContDiff.differentiable_iteratedDeriv {n : WithTop ℕ∞} (m : ℕ) (h 
     (mod_cast (lt_add_one m))
 
 @[fun_prop]
-theorem ContDiff.differentiable_iteratedDeriv' (m : ℕ) (h : ContDiff 𝕜 (m+1) f) :
+theorem ContDiff.differentiable_iteratedDeriv' (m : ℕ) (h : ContDiff 𝕜 (m + 1) f) :
     Differentiable 𝕜 (iteratedDeriv m f) :=
   h.differentiable_iteratedDeriv m (Nat.cast_lt.mpr m.lt_succ_self)
 


### PR DESCRIPTION
Found by #24465.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
