### PR TITLE
feat: register more tactics for `hint`

### DIFF
--- a/Mathlib/Tactic/ComputeDegree.lean
+++ b/Mathlib/Tactic/ComputeDegree.lean
@@ -504,3 +504,8 @@ macro "monicity!" : tactic =>
 end Tactic
 
 end Mathlib.Tactic.ComputeDegree
+
+/-!
+ We register `compute_degree` with the `hint` tactic.
+ -/
+register_hint compute_degree

--- a/Mathlib/Tactic/FieldSimp.lean
+++ b/Mathlib/Tactic/FieldSimp.lean
@@ -213,3 +213,8 @@ elab_rules : tactic
   _ ← simpLocation r.ctx {} dis loc
 
 end Mathlib.Tactic.FieldSimp
+
+/-!
+ We register `field_simp` with the `hint` tactic.
+ -/
+register_hint field_simp

--- a/Mathlib/Tactic/Finiteness.lean
+++ b/Mathlib/Tactic/Finiteness.lean
@@ -62,3 +62,8 @@ macro (name := finiteness_nonterminal) "finiteness_nonterminal" c:Aesop.tactic_c
     (config := { introsTransparency? := some .reducible, terminal := false, enableSimp := false,
                  warnOnNonterminal := false  })
     (rule_sets := [$(Lean.mkIdent `finiteness):ident, -default, -builtin]))
+
+/-!
+ We register `finiteness` with the `hint` tactic.
+ -/
+register_hint finiteness


### PR DESCRIPTION
The following example shows test cases that `hint` now supports, which were unsupported prior to this PR:

```
import Mathlib

-- The tactics registered in this PR
register_hint compute_degree
register_hint field_simp
register_hint finiteness

-- "hint" now correctly suggests "compute_degree" which closes the goal (no closing tactic suggested prior to this PR)
open Polynomial in
example : natDegree ((X + 1) : Nat[X]) ≤ 1 := by hint

-- "hint" now correctly suggests "field_simp" which closes the goal (no closing tactic suggested prior to this PR)
example (R : Type) (a b : R) [CommRing R] (u₁ : Rˣ) : a /ₚ u₁ + b /ₚ u₁ = (a + b) /ₚ u₁ := by hint

-- "hint" now correctly suggests "finiteness" which closes the goal (no closing tactic suggested prior to this PR)
example (a : ℝ) : (ENNReal.ofReal (1 + a ^ 2))⁻¹ < ⊤ := by hint
```