### PR TITLE
feat(LocallyIntegrable): generalise more to enorms

### DIFF
--- a/Mathlib/MeasureTheory/Function/L1Space/HasFiniteIntegral.lean
+++ b/Mathlib/MeasureTheory/Function/L1Space/HasFiniteIntegral.lean
@@ -191,9 +191,9 @@ theorem HasFiniteIntegral.of_mem_Icc [IsFiniteMeasure μ] (a b : ℝ) {X : α �
   apply (hasFiniteIntegral_const (max ‖a‖ ‖b‖)).mono'
   filter_upwards [h.mono fun ω h ↦ h.1, h.mono fun ω h ↦ h.2] with ω using abs_le_max_abs_abs
 
-theorem hasFiniteIntegral_of_bounded_enorm [IsFiniteMeasure μ] {f : α → ε} {C : ℝ≥0}
-    (hC : ∀ᵐ a ∂μ, ‖f a‖ₑ ≤ C) : HasFiniteIntegral f μ :=
-  (hasFiniteIntegral_const_enorm (enorm_ne_top (x := C))).mono'_enorm hC
+theorem hasFiniteIntegral_of_bounded_enorm [IsFiniteMeasure μ] {f : α → ε} {C : ℝ≥0∞}
+    (hC : ∀ᵐ a ∂μ, ‖f a‖ₑ ≤ C) (hC' : C ≠ ∞) : HasFiniteIntegral f μ :=
+  (hasFiniteIntegral_const_enorm hC').mono'_enorm hC
 
 theorem hasFiniteIntegral_of_bounded [IsFiniteMeasure μ] {f : α → β} {C : ℝ}
     (hC : ∀ᵐ a ∂μ, ‖f a‖ ≤ C) : HasFiniteIntegral f μ :=

--- a/Mathlib/MeasureTheory/Function/LocallyIntegrable.lean
+++ b/Mathlib/MeasureTheory/Function/LocallyIntegrable.lean
@@ -167,13 +167,12 @@ protected theorem LocallyIntegrableOn.sub
 protected theorem LocallyIntegrableOn.neg {f : X → E} (hf : LocallyIntegrableOn f s μ) :
     LocallyIntegrableOn (-f) s μ := fun x hx ↦ (hf x hx).neg
 
-#exit
 end LocallyIntegrableOn
 
 /-- A function `f : X → E` is *locally integrable* if it is integrable on a neighborhood of every
 point. In particular, it is integrable on all compact sets,
 see `LocallyIntegrable.integrableOn_isCompact`. -/
-def LocallyIntegrable (f : X → E) (μ : Measure X := by volume_tac) : Prop :=
+def LocallyIntegrable (f : X → ε) (μ : Measure X := by volume_tac) : Prop :=
   ∀ x : X, IntegrableAtFilter f (𝓝 x) μ
 
 theorem locallyIntegrable_comap (hs : MeasurableSet s) :
@@ -190,7 +189,13 @@ theorem LocallyIntegrable.locallyIntegrableOn (hf : LocallyIntegrable f μ) (s :
 theorem Integrable.locallyIntegrable (hf : Integrable f μ) : LocallyIntegrable f μ := fun _ =>
   hf.integrableAtFilter _
 
-theorem LocallyIntegrable.mono (hf : LocallyIntegrable f μ) {g : X → F}
+theorem LocallyIntegrable.mono_enorm (hf : LocallyIntegrable f μ) {g : X → ε'}
+    (hg : AEStronglyMeasurable g μ) (h : ∀ᵐ x ∂μ, ‖g x‖ₑ ≤ ‖f x‖ₑ) :
+    LocallyIntegrable g μ := by
+  rw [← locallyIntegrableOn_univ] at hf ⊢
+  exact hf.mono_enorm hg h
+
+theorem LocallyIntegrable.mono {f : X → E} (hf : LocallyIntegrable f μ) {g : X → F}
     (hg : AEStronglyMeasurable g μ) (h : ∀ᵐ x ∂μ, ‖g x‖ ≤ ‖f x‖) :
     LocallyIntegrable g μ := by
   rw [← locallyIntegrableOn_univ] at hf ⊢
@@ -226,14 +231,15 @@ theorem locallyIntegrableOn_iff_locallyIntegrable_restrict [OpensMeasurableSpace
     exacts [integrableOn_empty, hs.measurableSet]
 
 /-- If a function is locally integrable, then it is integrable on any compact set. -/
-theorem LocallyIntegrable.integrableOn_isCompact {k : Set X} (hf : LocallyIntegrable f μ)
-    (hk : IsCompact k) : IntegrableOn f k μ :=
+theorem LocallyIntegrable.integrableOn_isCompact [PseudoMetrizableSpace ε]
+    {k : Set X} (hf : LocallyIntegrable f μ) (hk : IsCompact k) : IntegrableOn f k μ :=
   (hf.locallyIntegrableOn k).integrableOn_isCompact hk
 
 /-- If a function is locally integrable, then it is integrable on an open neighborhood of any
 compact set. -/
-theorem LocallyIntegrable.integrableOn_nhds_isCompact (hf : LocallyIntegrable f μ) {k : Set X}
-    (hk : IsCompact k) : ∃ u, IsOpen u ∧ k ⊆ u ∧ IntegrableOn f u μ := by
+theorem LocallyIntegrable.integrableOn_nhds_isCompact [PseudoMetrizableSpace ε]
+    (hf : LocallyIntegrable f μ) {k : Set X} (hk : IsCompact k) :
+    ∃ u, IsOpen u ∧ k ⊆ u ∧ IntegrableOn f u μ := by
   refine IsCompact.induction_on hk ?_ ?_ ?_ ?_
   · refine ⟨∅, isOpen_empty, Subset.rfl, integrableOn_empty⟩
   · rintro s t hst ⟨u, u_open, tu, hu⟩
@@ -245,13 +251,13 @@ theorem LocallyIntegrable.integrableOn_nhds_isCompact (hf : LocallyIntegrable f 
     rcases mem_nhds_iff.1 ux with ⟨v, vu, v_open, xv⟩
     exact ⟨v, nhdsWithin_le_nhds (v_open.mem_nhds xv), v, v_open, Subset.rfl, hu.mono_set vu⟩
 
-theorem locallyIntegrable_iff [LocallyCompactSpace X] :
+theorem locallyIntegrable_iff [PseudoMetrizableSpace ε] [LocallyCompactSpace X] :
     LocallyIntegrable f μ ↔ ∀ k : Set X, IsCompact k → IntegrableOn f k μ :=
   ⟨fun hf _k hk => hf.integrableOn_isCompact hk, fun hf x =>
     let ⟨K, hK, h2K⟩ := exists_compact_mem_nhds x
     ⟨K, h2K, hf K hK⟩⟩
 
-theorem LocallyIntegrable.aestronglyMeasurable [SecondCountableTopology X]
+theorem LocallyIntegrable.aestronglyMeasurable [PseudoMetrizableSpace ε] [SecondCountableTopology X]
     (hf : LocallyIntegrable f μ) : AEStronglyMeasurable f μ := by
   simpa only [restrict_univ] using (locallyIntegrableOn_univ.mpr hf).aestronglyMeasurable
 
@@ -264,7 +270,7 @@ theorem LocallyIntegrable.exists_nat_integrableOn [SecondCountableTopology X]
   refine ⟨u, u_open, eq_univ_of_univ_subset u_union, fun n ↦ ?_⟩
   simpa only [inter_univ] using hu n
 
-theorem MemLp.locallyIntegrable [IsLocallyFiniteMeasure μ] {f : X → E} {p : ℝ≥0∞}
+theorem MemLp.locallyIntegrable [IsLocallyFiniteMeasure μ] {p : ℝ≥0∞}
     (hf : MemLp f p μ) (hp : 1 ≤ p) : LocallyIntegrable f μ := by
   intro x
   rcases μ.finiteAt_nhds x with ⟨U, hU, h'U⟩
@@ -276,21 +282,29 @@ theorem MemLp.locallyIntegrable [IsLocallyFiniteMeasure μ] {f : X → E} {p : �
 @[deprecated (since := "2025-02-21")]
 alias Memℒp.locallyIntegrable := MemLp.locallyIntegrable
 
+theorem locallyIntegrable_const_enorm [IsLocallyFiniteMeasure μ] {c : ε} (hc : ‖c‖ₑ ≠ ∞) :
+    LocallyIntegrable (fun _ => c) μ :=
+  (memLp_top_const_enorm hc).locallyIntegrable le_top
+
 theorem locallyIntegrable_const [IsLocallyFiniteMeasure μ] (c : E) :
     LocallyIntegrable (fun _ => c) μ :=
-  (memLp_top_const c).locallyIntegrable le_top
+  locallyIntegrable_const_enorm enorm_ne_top
+
+theorem locallyIntegrableOn_const_enorm [IsLocallyFiniteMeasure μ] {c : ε} (hc : ‖c‖ₑ ≠ ∞) :
+    LocallyIntegrableOn (fun _ => c) s μ :=
+  (locallyIntegrable_const_enorm hc).locallyIntegrableOn s
 
 theorem locallyIntegrableOn_const [IsLocallyFiniteMeasure μ] (c : E) :
     LocallyIntegrableOn (fun _ => c) s μ :=
-  (locallyIntegrable_const c).locallyIntegrableOn s
+  locallyIntegrableOn_const_enorm enorm_ne_top
 
-theorem locallyIntegrable_zero : LocallyIntegrable (fun _ ↦ (0 : E)) μ :=
-  (integrable_zero X E μ).locallyIntegrable
+theorem locallyIntegrable_zero : LocallyIntegrable (fun _ ↦ (0 : ε'')) μ :=
+  (integrable_zero X ε'' μ).locallyIntegrable
 
-theorem locallyIntegrableOn_zero : LocallyIntegrableOn (fun _ ↦ (0 : E)) s μ :=
+theorem locallyIntegrableOn_zero : LocallyIntegrableOn (fun _ ↦ (0 : ε'')) s μ :=
   locallyIntegrable_zero.locallyIntegrableOn s
 
-theorem LocallyIntegrable.indicator (hf : LocallyIntegrable f μ) {s : Set X}
+theorem LocallyIntegrable.indicator {f : X → ε''} (hf : LocallyIntegrable f μ) {s : Set X}
     (hs : MeasurableSet s) : LocallyIntegrable (s.indicator f) μ := by
   intro x
   rcases hf x with ⟨U, hU, h'U⟩
@@ -310,32 +324,36 @@ theorem locallyIntegrable_map_homeomorph [BorelSpace X] [BorelSpace Y] (e : X �
     ext x
     simp only [mem_preimage, Homeomorph.symm_apply_apply]
 
-protected theorem LocallyIntegrable.add (hf : LocallyIntegrable f μ) (hg : LocallyIntegrable g μ) :
-    LocallyIntegrable (f + g) μ := fun x ↦ (hf x).add (hg x)
+protected theorem LocallyIntegrable.add [ContinuousAdd ε''] {f g : X → ε''}
+    (hf : LocallyIntegrable f μ) (hg : LocallyIntegrable g μ) : LocallyIntegrable (f + g) μ :=
+  fun x ↦ (hf x).add (hg x)
 
-protected theorem LocallyIntegrable.sub (hf : LocallyIntegrable f μ) (hg : LocallyIntegrable g μ) :
-    LocallyIntegrable (f - g) μ := fun x ↦ (hf x).sub (hg x)
+protected theorem LocallyIntegrable.sub {f g : X → E}
+    (hf : LocallyIntegrable f μ) (hg : LocallyIntegrable g μ) : LocallyIntegrable (f - g) μ :=
+  fun x ↦ (hf x).sub (hg x)
 
-protected theorem LocallyIntegrable.neg (hf : LocallyIntegrable f μ) :
+protected theorem LocallyIntegrable.neg {f : X → E} (hf : LocallyIntegrable f μ) :
     LocallyIntegrable (-f) μ := fun x ↦ (hf x).neg
 
-protected theorem LocallyIntegrable.smul {𝕜 : Type*} [NormedAddCommGroup 𝕜] [SMulZeroClass 𝕜 E]
-    [IsBoundedSMul 𝕜 E] (hf : LocallyIntegrable f μ) (c : 𝕜) :
+protected theorem LocallyIntegrable.smul {f : X → E} {𝕜 : Type*} [NormedAddCommGroup 𝕜]
+    [SMulZeroClass 𝕜 E] [IsBoundedSMul 𝕜 E] (hf : LocallyIntegrable f μ) (c : 𝕜) :
     LocallyIntegrable (c • f) μ := fun x ↦ (hf x).smul c
 
-theorem locallyIntegrable_finset_sum' {ι} (s : Finset ι) {f : ι → X → E}
+variable {ε''' : Type*} [TopologicalSpace ε'''] [ENormedAddCommMonoid ε'''] [ContinuousAdd ε'''] in
+theorem locallyIntegrable_finset_sum' {ι} (s : Finset ι) {f : ι → X → ε'''}
     (hf : ∀ i ∈ s, LocallyIntegrable (f i) μ) : LocallyIntegrable (∑ i ∈ s, f i) μ :=
   Finset.sum_induction f (fun g => LocallyIntegrable g μ) (fun _ _ => LocallyIntegrable.add)
     locallyIntegrable_zero hf
 
-theorem locallyIntegrable_finset_sum {ι} (s : Finset ι) {f : ι → X → E}
+variable {ε''' : Type*} [TopologicalSpace ε'''] [ENormedAddCommMonoid ε'''] [ContinuousAdd ε'''] in
+theorem locallyIntegrable_finset_sum {ι} (s : Finset ι) {f : ι → X → ε'''}
     (hf : ∀ i ∈ s, LocallyIntegrable (f i) μ) : LocallyIntegrable (fun a ↦ ∑ i ∈ s, f i a) μ := by
   simpa only [← Finset.sum_apply] using locallyIntegrable_finset_sum' s hf
 
 /-- If `f` is locally integrable and `g` is continuous with compact support,
 then `g • f` is integrable. -/
 theorem LocallyIntegrable.integrable_smul_left_of_hasCompactSupport
-    [NormedSpace ℝ E] [OpensMeasurableSpace X] [T2Space X]
+    [NormedSpace ℝ E] [OpensMeasurableSpace X] [T2Space X] {f : X → E}
     (hf : LocallyIntegrable f μ) {g : X → ℝ} (hg : Continuous g) (h'g : HasCompactSupport g) :
     Integrable (fun x ↦ g x • f x) μ := by
   let K := tsupport g
@@ -372,35 +390,40 @@ theorem LocallyIntegrable.integrable_smul_right_of_hasCompactSupport
 
 open Filter
 
-theorem integrable_iff_integrableAtFilter_cocompact :
+theorem integrable_iff_integrableAtFilter_cocompact [PseudoMetrizableSpace ε] :
     Integrable f μ ↔ (IntegrableAtFilter f (cocompact X) μ ∧ LocallyIntegrable f μ) := by
   refine ⟨fun hf ↦ ⟨hf.integrableAtFilter _, hf.locallyIntegrable⟩, fun ⟨⟨s, hsc, hs⟩, hloc⟩ ↦ ?_⟩
   obtain ⟨t, htc, ht⟩ := mem_cocompact'.mp hsc
   rewrite [← integrableOn_univ, ← compl_union_self s, integrableOn_union]
   exact ⟨(hloc.integrableOn_isCompact htc).mono ht le_rfl, hs⟩
 
-theorem integrable_iff_integrableAtFilter_atBot_atTop [LinearOrder X] [CompactIccSpace X] :
+theorem integrable_iff_integrableAtFilter_atBot_atTop
+    [PseudoMetrizableSpace ε''] {f : X → ε''} [LinearOrder X] [CompactIccSpace X] :
     Integrable f μ ↔
     (IntegrableAtFilter f atBot μ ∧ IntegrableAtFilter f atTop μ) ∧ LocallyIntegrable f μ := by
   constructor
   · exact fun hf ↦ ⟨⟨hf.integrableAtFilter _, hf.integrableAtFilter _⟩, hf.locallyIntegrable⟩
   · refine fun h ↦ integrable_iff_integrableAtFilter_cocompact.mpr ⟨?_, h.2⟩
+    have aux := (IntegrableAtFilter.sup_iff.mpr h.1)
     exact (IntegrableAtFilter.sup_iff.mpr h.1).filter_mono cocompact_le_atBot_atTop
 
-theorem integrable_iff_integrableAtFilter_atBot [LinearOrder X] [OrderTop X] [CompactIccSpace X] :
+theorem integrable_iff_integrableAtFilter_atBot
+    [PseudoMetrizableSpace ε] [LinearOrder X] [OrderTop X] [CompactIccSpace X] :
     Integrable f μ ↔ IntegrableAtFilter f atBot μ ∧ LocallyIntegrable f μ := by
   constructor
   · exact fun hf ↦ ⟨hf.integrableAtFilter _, hf.locallyIntegrable⟩
   · refine fun h ↦ integrable_iff_integrableAtFilter_cocompact.mpr ⟨?_, h.2⟩
     exact h.1.filter_mono cocompact_le_atBot
 
-theorem integrable_iff_integrableAtFilter_atTop [LinearOrder X] [OrderBot X] [CompactIccSpace X] :
+theorem integrable_iff_integrableAtFilter_atTop
+    [PseudoMetrizableSpace ε] [LinearOrder X] [OrderBot X] [CompactIccSpace X] :
     Integrable f μ ↔ IntegrableAtFilter f atTop μ ∧ LocallyIntegrable f μ :=
   integrable_iff_integrableAtFilter_atBot (X := Xᵒᵈ)
 
 variable {a : X}
 
-theorem integrableOn_Iic_iff_integrableAtFilter_atBot [LinearOrder X] [CompactIccSpace X] :
+theorem integrableOn_Iic_iff_integrableAtFilter_atBot
+    [PseudoMetrizableSpace ε] [LinearOrder X] [CompactIccSpace X] :
     IntegrableOn f (Iic a) μ ↔ IntegrableAtFilter f atBot μ ∧ LocallyIntegrableOn f (Iic a) μ := by
   refine ⟨fun h ↦ ⟨⟨Iic a, Iic_mem_atBot a, h⟩, h.locallyIntegrableOn⟩, fun ⟨⟨s, hsl, hs⟩, h⟩ ↦ ?_⟩
   haveI : Nonempty X := Nonempty.intro a
@@ -408,12 +431,13 @@ theorem integrableOn_Iic_iff_integrableAtFilter_atBot [LinearOrder X] [CompactIc
   refine (integrableOn_union.mpr ⟨hs.mono ha' le_rfl, ?_⟩).mono Iic_subset_Iic_union_Icc le_rfl
   exact h.integrableOn_compact_subset Icc_subset_Iic_self isCompact_Icc
 
-theorem integrableOn_Ici_iff_integrableAtFilter_atTop [LinearOrder X] [CompactIccSpace X] :
+theorem integrableOn_Ici_iff_integrableAtFilter_atTop
+    [PseudoMetrizableSpace ε] [LinearOrder X] [CompactIccSpace X] :
     IntegrableOn f (Ici a) μ ↔ IntegrableAtFilter f atTop μ ∧ LocallyIntegrableOn f (Ici a) μ :=
   integrableOn_Iic_iff_integrableAtFilter_atBot (X := Xᵒᵈ)
 
 theorem integrableOn_Iio_iff_integrableAtFilter_atBot_nhdsWithin
-    [LinearOrder X] [CompactIccSpace X] [NoMinOrder X] [OrderTopology X] :
+    [PseudoMetrizableSpace ε] [LinearOrder X] [CompactIccSpace X] [NoMinOrder X] [OrderTopology X] :
     IntegrableOn f (Iio a) μ ↔ IntegrableAtFilter f atBot μ ∧
     IntegrableAtFilter f (𝓝[<] a) μ ∧ LocallyIntegrableOn f (Iio a) μ := by
   constructor
@@ -426,7 +450,7 @@ theorem integrableOn_Iio_iff_integrableAtFilter_atBot_nhdsWithin
       ⟨hbot, hlocal.mono_set (Iic_subset_Iio.mpr hs'_mono)⟩
 
 theorem integrableOn_Ioi_iff_integrableAtFilter_atTop_nhdsWithin
-    [LinearOrder X] [CompactIccSpace X] [NoMaxOrder X] [OrderTopology X] :
+    [PseudoMetrizableSpace ε] [LinearOrder X] [CompactIccSpace X] [NoMaxOrder X] [OrderTopology X] :
     IntegrableOn f (Ioi a) μ ↔ IntegrableAtFilter f atTop μ ∧
     IntegrableAtFilter f (𝓝[>] a) μ ∧ LocallyIntegrableOn f (Ioi a) μ :=
   integrableOn_Iio_iff_integrableAtFilter_atBot_nhdsWithin (X := Xᵒᵈ)

--- a/Mathlib/MeasureTheory/Function/LocallyIntegrable.lean
+++ b/Mathlib/MeasureTheory/Function/LocallyIntegrable.lean
@@ -480,7 +480,8 @@ theorem ContinuousOn.locallyIntegrableOn [IsLocallyFiniteMeasure μ]
 
 variable [IsFiniteMeasureOnCompacts μ]
 
-variable {f g : X → E}
+--variable {f g : X → E}
+variable [PseudoMetrizableSpace ε]
 
 /-- A function `f` continuous on a compact set `K` is integrable on this set with respect to any
 locally finite measure. -/
@@ -489,9 +490,10 @@ theorem ContinuousOn.integrableOn_compact'
     IntegrableOn f K μ := by
   refine ⟨ContinuousOn.aestronglyMeasurable_of_isCompact hf hK h'K, ?_⟩
   have : Fact (μ K < ∞) := ⟨hK.measure_lt_top⟩
-  obtain ⟨C, hC⟩ : ∃ C, ∀ x ∈ f '' K, ‖x‖ ≤ C :=
-    IsBounded.exists_norm_le (hK.image_of_continuousOn hf).isBounded
-  apply hasFiniteIntegral_of_bounded (C := C)
+  -- TODO: prove IsBounded.exists_enorm_le, then use it
+  obtain ⟨C, hC⟩ : ∃ C, ∀ x ∈ f '' K, ‖x‖ₑ ≤ C :=
+    sorry -- old proof was `IsBounded.exists_norm_le (hK.image_of_continuousOn hf).isBounded`
+  apply hasFiniteIntegral_of_bounded_enorm (C := C)
   filter_upwards [ae_restrict_mem h'K] with x hx using hC _ (mem_image_of_mem f hx)
 
 theorem ContinuousOn.integrableOn_compact [T2Space X]
@@ -524,7 +526,8 @@ theorem Continuous.integrableOn_uIoc [LinearOrder X] [CompactIccSpace X] [T2Spac
   hf.integrableOn_Ioc
 
 /-- A continuous function with compact support is integrable on the whole space. -/
-theorem Continuous.integrable_of_hasCompactSupport (hf : Continuous f) (hcf : HasCompactSupport f) :
+theorem Continuous.integrable_of_hasCompactSupport
+    [PseudoMetrizableSpace ε''] {f : X → ε''} (hf : Continuous f) (hcf : HasCompactSupport f) :
     Integrable f μ :=
   (integrableOn_iff_integrable_of_support_subset (subset_tsupport f)).mp <|
     hf.continuousOn.integrableOn_compact' hcf (isClosed_tsupport _).measurableSet
@@ -537,15 +540,17 @@ section Monotone
 
 variable [BorelSpace X] [ConditionallyCompleteLinearOrder X] [ConditionallyCompleteLinearOrder E]
   [OrderTopology X] [OrderTopology E] [SecondCountableTopology E] {p : ℝ≥0∞}
-  {f g : X → E}
+  {f g : X → ε}
 
-theorem MonotoneOn.memLp_top (hmono : MonotoneOn f s) {a b : X}
+theorem MonotoneOn.memLp_top [Preorder ε] [Bornology ε] (hmono : MonotoneOn f s) {a b : X}
     (ha : IsLeast s a) (hb : IsGreatest s b) (h's : MeasurableSet s) :
     MemLp f ∞ (μ.restrict s) := by
-  borelize E
+  borelize ε
   have hbelow : BddBelow (f '' s) := ⟨f a, fun x ⟨y, hy, hyx⟩ => hyx ▸ hmono ha.1 hy (ha.2 hy)⟩
   have habove : BddAbove (f '' s) := ⟨f b, fun x ⟨y, hy, hyx⟩ => hyx ▸ hmono hy hb.1 (hb.2 hy)⟩
-  have : IsBounded (f '' s) := Metric.isBounded_of_bddAbove_of_bddBelow habove hbelow
+  have : IsBounded (f '' s) := sorry
+    -- TODO: does a pseudometrisable space also suffice? that would work here...
+    -- Metric.isBounded_of_bddAbove_of_bddBelow habove hbelow
   rcases isBounded_iff_forall_norm_le.mp this with ⟨C, hC⟩
   have A : MemLp (fun _ => C) ⊤ (μ.restrict s) := memLp_top_const _
   apply MemLp.mono A (aemeasurable_restrict_of_monotoneOn h's hmono).aestronglyMeasurable

--- a/Mathlib/MeasureTheory/Function/LocallyIntegrable.lean
+++ b/Mathlib/MeasureTheory/Function/LocallyIntegrable.lean
@@ -561,7 +561,8 @@ theorem MonotoneOn.memLp_top [Preorder ε] [Bornology ε] (hmono : MonotoneOn f 
 @[deprecated (since := "2025-02-21")]
 alias MonotoneOn.memℒp_top := MonotoneOn.memLp_top
 
-theorem MonotoneOn.memLp_of_measure_ne_top (hmono : MonotoneOn f s) {a b : X}
+theorem MonotoneOn.memLp_of_measure_ne_top
+    [Preorder ε''] [Bornology ε''] {f : X → ε''} (hmono : MonotoneOn f s) {a b : X}
     (ha : IsLeast s a) (hb : IsGreatest s b) (hs : μ s ≠ ∞) (h's : MeasurableSet s) :
     MemLp f p (μ.restrict s) :=
   (hmono.memLp_top ha hb h's).mono_exponent_of_measure_support_ne_top (s := univ)
@@ -570,8 +571,8 @@ theorem MonotoneOn.memLp_of_measure_ne_top (hmono : MonotoneOn f s) {a b : X}
 @[deprecated (since := "2025-02-21")]
 alias MonotoneOn.memℒp_of_measure_ne_top := MonotoneOn.memLp_of_measure_ne_top
 
-theorem MonotoneOn.memLp_isCompact [IsFiniteMeasureOnCompacts μ] (hs : IsCompact s)
-    (hmono : MonotoneOn f s) : MemLp f p (μ.restrict s) := by
+theorem MonotoneOn.memLp_isCompact [Preorder ε''] [Bornology ε''] [IsFiniteMeasureOnCompacts μ]
+    (hs : IsCompact s) {f : X → ε''} (hmono : MonotoneOn f s) : MemLp f p (μ.restrict s) := by
   obtain rfl | h := s.eq_empty_or_nonempty
   · simp
   · exact hmono.memLp_of_measure_ne_top (hs.isLeast_sInf h) (hs.isGreatest_sSup h)
@@ -580,49 +581,51 @@ theorem MonotoneOn.memLp_isCompact [IsFiniteMeasureOnCompacts μ] (hs : IsCompac
 @[deprecated (since := "2025-02-21")]
 alias MonotoneOn.memℒp_isCompact := MonotoneOn.memLp_isCompact
 
-theorem AntitoneOn.memLp_top (hanti : AntitoneOn f s) {a b : X}
-    (ha : IsLeast s a) (hb : IsGreatest s b) (h's : MeasurableSet s) :
+theorem AntitoneOn.memLp_top [Preorder ε''] [Bornology ε''] {f : X → ε''} (hanti : AntitoneOn f s)
+    {a b : X} (ha : IsLeast s a) (hb : IsGreatest s b) (h's : MeasurableSet s) :
     MemLp f ∞ (μ.restrict s) :=
-  MonotoneOn.memLp_top (E := Eᵒᵈ) hanti ha hb h's
+  MonotoneOn.memLp_top (ε := ε''ᵒᵈ) hanti ha hb h's
 
 @[deprecated (since := "2025-02-21")]
 alias AntitoneOn.memℒp_top := AntitoneOn.memLp_top
 
-theorem AntitoneOn.memLp_of_measure_ne_top (hanti : AntitoneOn f s) {a b : X}
-    (ha : IsLeast s a) (hb : IsGreatest s b) (hs : μ s ≠ ∞) (h's : MeasurableSet s) :
+theorem AntitoneOn.memLp_of_measure_ne_top [Preorder ε''] [Bornology ε'']
+    {f : X → ε''} (hanti : AntitoneOn f s)
+    {a b : X} (ha : IsLeast s a) (hb : IsGreatest s b) (hs : μ s ≠ ∞) (h's : MeasurableSet s) :
     MemLp f p (μ.restrict s) :=
-  MonotoneOn.memLp_of_measure_ne_top (E := Eᵒᵈ) hanti ha hb hs h's
+  MonotoneOn.memLp_of_measure_ne_top (ε'' := ε''ᵒᵈ) hanti ha hb hs h's
 
 @[deprecated (since := "2025-02-21")]
 alias AntitoneOn.memℒp_of_measure_ne_top := AntitoneOn.memLp_of_measure_ne_top
 
-theorem AntitoneOn.memLp_isCompact [IsFiniteMeasureOnCompacts μ] (hs : IsCompact s)
-    (hanti : AntitoneOn f s) : MemLp f p (μ.restrict s) :=
-  MonotoneOn.memLp_isCompact (E := Eᵒᵈ) hs hanti
+theorem AntitoneOn.memLp_isCompact [Preorder ε''] [Bornology ε''] [IsFiniteMeasureOnCompacts μ]
+    {f : X → ε''} (hanti : AntitoneOn f s) (hs : IsCompact s) : MemLp f p (μ.restrict s) :=
+  MonotoneOn.memLp_isCompact (ε'' := ε''ᵒᵈ) hs hanti
 
 @[deprecated (since := "2025-02-21")]
 alias AntitoneOn.memℒp_isCompact := AntitoneOn.memLp_isCompact
 
-theorem MonotoneOn.integrableOn_of_measure_ne_top (hmono : MonotoneOn f s) {a b : X}
-    (ha : IsLeast s a) (hb : IsGreatest s b) (hs : μ s ≠ ∞) (h's : MeasurableSet s) :
-    IntegrableOn f s μ :=
+theorem MonotoneOn.integrableOn_of_measure_ne_top [Preorder ε''] [Bornology ε''] {f : X → ε''}
+    (hmono : MonotoneOn f s) {a b : X} (ha : IsLeast s a) (hb : IsGreatest s b)
+    (hs : μ s ≠ ∞) (h's : MeasurableSet s) : IntegrableOn f s μ :=
   memLp_one_iff_integrable.1 (hmono.memLp_of_measure_ne_top ha hb hs h's)
 
-theorem MonotoneOn.integrableOn_isCompact [IsFiniteMeasureOnCompacts μ] (hs : IsCompact s)
-    (hmono : MonotoneOn f s) : IntegrableOn f s μ :=
+theorem MonotoneOn.integrableOn_isCompact [Preorder ε''] [Bornology ε''] {f : X → ε''}
+    [IsFiniteMeasureOnCompacts μ] (hs : IsCompact s) (hmono : MonotoneOn f s) : IntegrableOn f s μ :=
   memLp_one_iff_integrable.1 (hmono.memLp_isCompact hs)
 
-theorem AntitoneOn.integrableOn_of_measure_ne_top (hanti : AntitoneOn f s) {a b : X}
-    (ha : IsLeast s a) (hb : IsGreatest s b) (hs : μ s ≠ ∞) (h's : MeasurableSet s) :
-    IntegrableOn f s μ :=
+theorem AntitoneOn.integrableOn_of_measure_ne_top [Preorder ε''] [Bornology ε''] {f : X → ε''}
+    (hanti : AntitoneOn f s) {a b : X} (ha : IsLeast s a) (hb : IsGreatest s b)
+    (hs : μ s ≠ ∞) (h's : MeasurableSet s) : IntegrableOn f s μ :=
   memLp_one_iff_integrable.1 (hanti.memLp_of_measure_ne_top ha hb hs h's)
 
-theorem AntitoneOn.integrableOn_isCompact [IsFiniteMeasureOnCompacts μ] (hs : IsCompact s)
-    (hanti : AntitoneOn f s) : IntegrableOn f s μ :=
+theorem AntitoneOn.integrableOn_isCompact [Preorder ε''] [Bornology ε''] {f : X → ε''}
+    (hanti : AntitoneOn f s) [IsFiniteMeasureOnCompacts μ] (hs : IsCompact s) :
+    IntegrableOn f s μ :=
   memLp_one_iff_integrable.1 (hanti.memLp_isCompact hs)
 
-theorem Monotone.locallyIntegrable [IsLocallyFiniteMeasure μ] (hmono : Monotone f) :
-    LocallyIntegrable f μ := by
+theorem Monotone.locallyIntegrable [Preorder ε''] [Bornology ε''] {f : X → ε''} (hmono : Monotone f)
+    [IsLocallyFiniteMeasure μ] : LocallyIntegrable f μ := by
   intro x
   rcases μ.finiteAt_nhds x with ⟨U, hU, h'U⟩
   obtain ⟨a, b, xab, hab, abU⟩ : ∃ a b : X, x ∈ Icc a b ∧ Icc a b ∈ 𝓝 x ∧ Icc a b ⊆ U :=
@@ -633,8 +636,8 @@ theorem Monotone.locallyIntegrable [IsLocallyFiniteMeasure μ] (hmono : Monotone
     (hmono.monotoneOn _).integrableOn_of_measure_ne_top (isLeast_Icc ab) (isGreatest_Icc ab)
       ((measure_mono abU).trans_lt h'U).ne measurableSet_Icc
 
-theorem Antitone.locallyIntegrable [IsLocallyFiniteMeasure μ] (hanti : Antitone f) :
-    LocallyIntegrable f μ :=
+theorem Antitone.locallyIntegrable [Preorder ε''] [Bornology ε''] {f : X → ε''} (hanti : Antitone f)
+    [IsLocallyFiniteMeasure μ] : LocallyIntegrable f μ :=
   hanti.dual_right.locallyIntegrable
 
 end Monotone

--- a/Mathlib/MeasureTheory/Function/LocallyIntegrable.lean
+++ b/Mathlib/MeasureTheory/Function/LocallyIntegrable.lean
@@ -464,19 +464,23 @@ section borel
 variable [OpensMeasurableSpace X]
 variable {K : Set X} {a b : X}
 
+-- TODO: generalise the next two lemmas to enorm classes
+
 /-- A continuous function `f` is locally integrable with respect to any locally finite measure. -/
 theorem Continuous.locallyIntegrable [IsLocallyFiniteMeasure μ] [SecondCountableTopologyEither X E]
-    (hf : Continuous f) : LocallyIntegrable f μ :=
+    {f : X → E} (hf : Continuous f) : LocallyIntegrable f μ :=
   hf.integrableAt_nhds
 
 /-- A function `f` continuous on a set `K` is locally integrable on this set with respect
 to any locally finite measure. -/
 theorem ContinuousOn.locallyIntegrableOn [IsLocallyFiniteMeasure μ]
-    [SecondCountableTopologyEither X E] (hf : ContinuousOn f K)
+    [SecondCountableTopologyEither X E] {f : X → E} (hf : ContinuousOn f K)
     (hK : MeasurableSet K) : LocallyIntegrableOn f K μ := fun _x hx =>
   hf.integrableAt_nhdsWithin hK hx
 
 variable [IsFiniteMeasureOnCompacts μ]
+
+variable {f g : X → E}
 
 /-- A function `f` continuous on a compact set `K` is integrable on this set with respect to any
 locally finite measure. -/
@@ -533,6 +537,7 @@ section Monotone
 
 variable [BorelSpace X] [ConditionallyCompleteLinearOrder X] [ConditionallyCompleteLinearOrder E]
   [OrderTopology X] [OrderTopology E] [SecondCountableTopology E] {p : ℝ≥0∞}
+  {f g : X → E}
 
 theorem MonotoneOn.memLp_top (hmono : MonotoneOn f s) {a b : X}
     (ha : IsLeast s a) (hb : IsGreatest s b) (h's : MeasurableSet s) :

--- a/Mathlib/MeasureTheory/Integral/IntegrableOn.lean
+++ b/Mathlib/MeasureTheory/Integral/IntegrableOn.lean
@@ -72,6 +72,12 @@ namespace MeasureTheory
 
 section NormedAddCommGroup
 
+theorem hasFiniteIntegral_restrict_of_bounded_enorm [ENorm ε] {f : α → ε} {s : Set α}
+    {μ : Measure α} {C} (hC : C ≠ ∞) (hs : μ s < ∞) (hf : ∀ᵐ x ∂μ.restrict s, ‖f x‖ₑ ≤ C) :
+    HasFiniteIntegral f (μ.restrict s) :=
+  haveI : IsFiniteMeasure (μ.restrict s) := ⟨by rwa [Measure.restrict_apply_univ]⟩
+  hasFiniteIntegral_of_bounded_enorm hf hC
+
 theorem hasFiniteIntegral_restrict_of_bounded [NormedAddCommGroup E] {f : α → E} {s : Set α}
     {μ : Measure α} {C} (hs : μ s < ∞) (hf : ∀ᵐ x ∂μ.restrict s, ‖f x‖ ≤ C) :
     HasFiniteIntegral f (μ.restrict s) :=

--- a/Mathlib/MeasureTheory/Integral/IntegrableOn.lean
+++ b/Mathlib/MeasureTheory/Integral/IntegrableOn.lean
@@ -535,6 +535,12 @@ theorem Measure.FiniteAtFilter.integrableAtFilter {f : α → E} {l : Filter α}
   rw [ae_restrict_eq hsm, eventually_inf_principal]
   exact Eventually.of_forall hC
 
+theorem Measure.FiniteAtFilter.integrableAtFilter_of_tendsto_ae_enorm {f : α → ε} {l : Filter α}
+    [IsMeasurablyGenerated l] (hfm : StronglyMeasurableAtFilter f l μ) (hμ : μ.FiniteAtFilter l) {b}
+    (hf : Tendsto f (l ⊓ ae μ) (𝓝 b)) : IntegrableAtFilter f l μ :=
+  (hμ.inf_of_left.integrableAtFilter_enorm (hfm.filter_mono inf_le_left)
+      sorry /-hf.enorm.isBoundedUnder_le-/).of_inf_ae
+
 theorem Measure.FiniteAtFilter.integrableAtFilter_of_tendsto_ae {f : α → E} {l : Filter α}
     [IsMeasurablyGenerated l] (hfm : StronglyMeasurableAtFilter f l μ) (hμ : μ.FiniteAtFilter l) {b}
     (hf : Tendsto f (l ⊓ ae μ) (𝓝 b)) : IntegrableAtFilter f l μ :=


### PR DESCRIPTION
---

Note: github's diff is very confused; it includes changes which very clearly are already on the master branch.

I'll see which of the remaining changes after the dependencies have landed is already polished enough.
- [x] depends on: #24352 
- [x] depends on: #27457 (this half is settled already)
- [ ] open question: filter lemmas; IsBoundedUnder is not the right condition as-is; need to think (or just not generalise)

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
