### PR TITLE
[Merged by Bors] - fix: add a space to the pretty printer for `deprecated_module`

### DIFF
--- a/Mathlib/Tactic/Linter/DeprecatedModule.lean
+++ b/Mathlib/Tactic/Linter/DeprecatedModule.lean
@@ -81,7 +81,7 @@ This means that any file that directly imports `A` will get a notification on th
 suggesting to instead import the *direct imports* of `A`.
 -/
 elab (name := deprecated_modules)
-    "deprecated_module " msg?:(str)? "(" &"since " ":= " date:str ")" : command => do
+    "deprecated_module " msg?:(str ppSpace)? "(" &"since " ":= " date:str ")" : command => do
   if let .error _parsedDate := Std.Time.PlainDate.fromLeanDateString date.getString then
     throwError "Invalid date: the expected format is \"{← Std.Time.PlainDate.now}\""
   addModuleDeprecation <| msg?.map (·.getString)


### PR DESCRIPTION
This was discovered while developing #24861.

Without this change,
```lean
deprecated_module "hello" (since := "YYYY-MM-DD")
```
gets pretty-printed as
```lean
deprecated_module "hello"(since := "YYYY-MM-DD")
```
Note the missing space between `"hello"` and `(since...)`!


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
