### PR TITLE
[Merged by Bors] - feat(Deriv/Shift): add `derivWithin_comp_neg` etc

### DIFF
--- a/Mathlib/Analysis/Calculus/Deriv/CompMul.lean
+++ b/Mathlib/Analysis/Calculus/Deriv/CompMul.lean
@@ -39,6 +39,4 @@ theorem derivWithin_comp_mul_left :
 
 variable (c f x) in
 theorem deriv_comp_mul_left : deriv (f <| c * ·) x = c • deriv f (c * x) := by
-  rcases eq_or_ne c 0 with rfl | hc
-  · simp
-  · simp only [← derivWithin_univ, derivWithin_comp_mul_left, smul_set_univ₀ hc]
+  simp only [← smul_eq_mul, deriv, fderiv_comp_smul, ContinuousLinearMap.smul_apply]

--- a/Mathlib/Analysis/Calculus/Deriv/Shift.lean
+++ b/Mathlib/Analysis/Calculus/Deriv/Shift.lean
@@ -5,6 +5,7 @@ Authors: Michael Stoll, Yaël Dillies
 -/
 import Mathlib.Analysis.Calculus.Deriv.Add
 import Mathlib.Analysis.Calculus.Deriv.Comp
+import Mathlib.Analysis.Calculus.Deriv.CompMul
 
 /-!
 ### Invariance of the derivative under translation
@@ -12,6 +13,8 @@ import Mathlib.Analysis.Calculus.Deriv.Comp
 We show that if a function `f` has derivative `f'` at a point `a + x`, then `f (a + ·)`
 has derivative `f'` at `x`. Similarly for `x + a`.
 -/
+
+open scoped Pointwise
 
 variable {𝕜 F : Type*} [NontriviallyNormedField 𝕜] [NormedAddCommGroup F] [NormedSpace 𝕜 F]
   {f : 𝕜 → F} {f' : F}
@@ -36,28 +39,45 @@ lemma HasDerivAt.comp_sub_const (x a : 𝕜) (hf : HasDerivAt f f' (x - a)) :
     HasDerivAt (fun x ↦ f (x - a)) f' x := by
   simpa [Function.comp_def] using HasDerivAt.scomp (𝕜 := 𝕜) x hf <| hasDerivAt_id' x |>.sub_const a
 
-variable (f) (a x : 𝕜)
+variable (f)
+variable (a : 𝕜) (s : Set 𝕜) (x : 𝕜)
+
+lemma derivWithin_comp_neg : derivWithin (f <| -·) s x = -derivWithin f (-s) (-x) := by
+  simpa using derivWithin_comp_mul_left (-1) f s x
 
 /-- The derivative of `x ↦ f (-x)` at `a` is the negative of the derivative of `f` at `-a`. -/
 lemma deriv_comp_neg : deriv (fun x ↦ f (-x)) x = -deriv f (-x) := by
-  by_cases f : DifferentiableAt 𝕜 f (-x)
-  · simpa only [deriv_neg, neg_one_smul] using deriv.scomp _ f (differentiable_neg _)
-  · rw [deriv_zero_of_not_differentiableAt (differentiableAt_comp_neg.not.2 f),
-      deriv_zero_of_not_differentiableAt f, neg_zero]
+  simpa using deriv_comp_mul_left (-1) f x
+
+/-- Translation in the domain does not change the derivative. -/
+lemma derivWithin_comp_const_add :
+    derivWithin (f <| a + ·) s x = derivWithin f (a +ᵥ s) (a + x) := by
+  simp only [derivWithin, fderivWithin_comp_add_left]
 
 /-- Translation in the domain does not change the derivative. -/
 lemma deriv_comp_const_add : deriv (fun x ↦ f (a + x)) x = deriv f (a + x) := by
-  by_cases hf : DifferentiableAt 𝕜 f (a + x)
-  · exact HasDerivAt.deriv hf.hasDerivAt.comp_const_add
-  · rw [deriv_zero_of_not_differentiableAt (differentiableAt_comp_const_add.not.2 hf),
-      deriv_zero_of_not_differentiableAt hf]
+  simp only [deriv, fderiv_comp_add_left]
+
+/-- Translation in the domain does not change the derivative. -/
+lemma derivWithin_comp_add_const :
+    derivWithin (f <| · + a) s x = derivWithin f (a +ᵥ s) (x + a) := by
+  simp only [derivWithin, fderivWithin_comp_add_right]
 
 /-- Translation in the domain does not change the derivative. -/
 lemma deriv_comp_add_const : deriv (fun x ↦ f (x + a)) x = deriv f (x + a) := by
   simpa [add_comm] using deriv_comp_const_add f a x
 
+lemma derivWithin_comp_const_sub :
+    derivWithin (f <| a - ·) s x = -derivWithin f (a +ᵥ -s) (a - x) := by
+  simp only [sub_eq_add_neg]
+  rw [derivWithin_comp_neg (f <| a + ·), derivWithin_comp_const_add]
+
 lemma deriv_comp_const_sub : deriv (fun x ↦ f (a - x)) x = -deriv f (a - x) := by
   simp_rw [sub_eq_add_neg, deriv_comp_neg (f <| a + ·), deriv_comp_const_add]
+
+lemma derivWithin_comp_sub_const :
+    derivWithin (fun x ↦ f (x - a)) s x = derivWithin f (-a +ᵥ s) (x - a) := by
+  simp_rw [sub_eq_add_neg, derivWithin_comp_add_const]
 
 lemma deriv_comp_sub_const : deriv (fun x ↦ f (x - a)) x = deriv f (x - a) := by
   simp_rw [sub_eq_add_neg, deriv_comp_add_const]

--- a/Mathlib/Analysis/Calculus/FDeriv/Equiv.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Equiv.lean
@@ -552,6 +552,10 @@ theorem fderivWithin_comp_smul (c : 𝕜) (hs : UniqueDiffWithinAt 𝕜 s x) :
   · rw [fderivWithin_comp_smul_eq_fderivWithin_smul, fderivWithin_const_smul_field]
     exact hs.smul hc
 
+theorem fderiv_comp_smul (c : 𝕜) : fderiv 𝕜 (f <| c • ·) x = c • fderiv 𝕜 f (c • x) := by
+  rw [← fderivWithin_univ, fderivWithin_comp_smul _ uniqueDiffWithinAt_univ]
+  rcases eq_or_ne c 0 with rfl | hc <;> simp [smul_set_univ₀, *]
+
 end SMulLeft
 
 


### PR DESCRIPTION
I'm using `derivWithin_comp_const_sub` in #24754.

It increases imports of 1 file by 35 and adds 1 file to imports of ~200 files.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
