### PR TITLE
[Merged by Bors] - feat: `apply` and `coe` results for `UniformSpace.Completion.mapRingHom`

### DIFF
--- a/Mathlib/Topology/Algebra/UniformRing.lean
+++ b/Mathlib/Topology/Algebra/UniformRing.lean
@@ -178,6 +178,15 @@ instance topologicalRing : IsTopologicalRing (Completion α) where
 def mapRingHom (hf : Continuous f) : Completion α →+* Completion β :=
   extensionHom (coeRingHom.comp f) (continuous_coeRingHom.comp hf)
 
+theorem mapRingHom_apply {x : UniformSpace.Completion α} :
+    UniformSpace.Completion.mapRingHom f hf x = UniformSpace.Completion.map f x := rfl
+
+variable {f}
+
+theorem mapRingHom_coe (hf : UniformContinuous f) (a : α) :
+    mapRingHom f hf.continuous a = f a := by
+  rw [mapRingHom_apply, map_coe hf]
+
 section Algebra
 
 variable (A : Type*) [Ring A] [UniformSpace A] [IsUniformAddGroup A] [IsTopologicalRing A]


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
