### PR TITLE
feat: `RamifiedExtension` and `UnramifiedExtension` types for `InfinitePlace.Extension`s

### DIFF
--- a/Mathlib/NumberTheory/NumberField/InfinitePlace/Ramification.lean
+++ b/Mathlib/NumberTheory/NumberField/InfinitePlace/Ramification.lean
@@ -162,6 +162,11 @@ An infinite place is unramified in a field extension if the restriction has the 
 -/
 def IsUnramified : Prop := mult (w.comap (algebraMap k K)) = mult w
 
+/--
+An infinite place is ramified in a field extension if it is not unramified.
+-/
+abbrev IsRamified : Prop := ¬w.IsUnramified k
+
 variable {k}
 
 lemma isUnramified_self : IsUnramified K w := rfl
@@ -212,6 +217,17 @@ lemma isUnramified_iff :
     IsUnramified k w ↔ IsReal w ∨ IsComplex (w.comap (algebraMap k K)) := by
   rw [← not_iff_not, not_isUnramified_iff, not_or,
     not_isReal_iff_isComplex, not_isComplex_iff_isReal]
+
+theorem isRamified_iff : w.IsRamified k ↔ w.IsComplex ∧ (w.comap (algebraMap k K)).IsReal :=
+  not_isUnramified_iff
+
+theorem IsRamified.ne_conjugate {w₁ w₂ : InfinitePlace K} (h : w₂.IsRamified k) :
+    w₁.embedding ≠ ComplexEmbedding.conjugate w₂.embedding := by
+  by_cases h_eq : w₁ = w₂
+  · rw [isRamified_iff, isComplex_iff] at h
+    exact Ne.symm (h_eq ▸ h.1)
+  · contrapose! h_eq
+    rw [← mk_embedding w₁, h_eq, mk_conjugate_eq, mk_embedding]
 
 variable (k)
 

--- a/Mathlib/NumberTheory/NumberField/InfinitePlace/Ramification.lean
+++ b/Mathlib/NumberTheory/NumberField/InfinitePlace/Ramification.lean
@@ -566,6 +566,67 @@ theorem isLift_or_isConjugateLift (v : InfinitePlace K) (w : v.Extension L) :
 
 end Extension
 
+/--
+Let `v : InfinitePlace K` be a fixed infinite place. `RamifiedExtension L v` is the subtype of
+all the infinite places of `L / K` that extend `v` and are ramified over `K`.
+-/
+abbrev RamifiedExtension (v : InfinitePlace K) :=
+  { w : InfinitePlace L // w.comap (algebraMap K L) = v ∧ w.IsRamified K }
+
+/--
+Let `v : InfinitePlace K` be a fixed infinite place. `UnramifiedExtension L v` is the subtype of
+all the infinite places of `L / K` that extend `v` and are unramified over `K`.
+-/
+abbrev UnramifiedExtension (v : InfinitePlace K) :=
+  { w : InfinitePlace L // w.comap (algebraMap K L) = v ∧ w.IsUnramified K }
+
+variable {L} {v : InfinitePlace K}
+
+/--
+Construct a `v.RamifiedExtension L` term from a `w : v.Extension L` such that
+`w.1.IsRamified K`.
+-/
+def Extension.toRamifiedExtension {w : v.Extension L} (h : w.1.IsRamified K) :
+    v.RamifiedExtension L := ⟨w.1, ⟨w.2, h⟩⟩
+
+/--
+Construct a `v.UnramifiedExtension L` term from a `w : v.Extension L` such that
+`w.1.IsUnramified K`.
+-/
+def Extension.toUnramifiedExtension {w : v.Extension L} (h : w.1.IsUnramified K) :
+    v.UnramifiedExtension L := ⟨w.1, ⟨w.2, h⟩⟩
+
+namespace RamifiedExtension
+
+theorem comap_eq (w : v.RamifiedExtension L) : w.1.comap (algebraMap K L) = v := w.2.1
+
+theorem isRamified (w : v.RamifiedExtension L) : w.1.IsRamified K := w.2.2
+
+theorem isReal_comap (w : v.RamifiedExtension L) : (w.1.comap (algebraMap K L)).IsReal :=
+  (isRamified_iff.1 w.isRamified).2
+
+instance : Coe (v.RamifiedExtension L) (v.Extension L) where
+  coe w := ⟨w.1, w.2.1⟩
+
+theorem isReal (w : v.RamifiedExtension L) : v.IsReal :=
+  w.comap_eq ▸ w.isReal_comap
+
+theorem isComplex (w : v.RamifiedExtension L) : (w.1 : InfinitePlace L).IsComplex :=
+  (isRamified_iff.1 w.isRamified).1
+
+end RamifiedExtension
+
+namespace UnramifiedExtension
+
+theorem comap_eq (w : UnramifiedExtension L v) : w.1.comap (algebraMap K L) = v := w.2.1
+
+theorem isUnramified (w : UnramifiedExtension L v) : w.1.IsUnramified K := w.2.2
+
+instance : Coe (v.UnramifiedExtension L) (v.Extension L) where
+  coe w := ⟨w.1, w.comap_eq⟩
+
+end UnramifiedExtension
+
 end NumberField.InfinitePlace
 
 end Extension


### PR DESCRIPTION
- `v.RamifiedExtension L` : the subtype of `v.Extension L` consisting of ramified extensions.
- `v.UnramifiedExtension L` : the subtype of `v.Extension L` consisting of unramified extensions.

---

- [ ] depends on: #24877 
- [x] depends on: #24880 

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
