### PR TITLE
[Merged by Bors] - chore: rename arguments to `Matrix.submatrix`

### DIFF
--- a/Mathlib/Data/Matrix/ConjTranspose.lean
+++ b/Mathlib/Data/Matrix/ConjTranspose.lean
@@ -409,8 +409,8 @@ theorem star_mul [Fintype n] [NonUnitalNonAssocSemiring α] [StarRing α] (M N :
 end Star
 
 @[simp]
-theorem conjTranspose_submatrix [Star α] (A : Matrix m n α) (r_reindex : l → m)
-    (c_reindex : o → n) : (A.submatrix r_reindex c_reindex)ᴴ = Aᴴ.submatrix c_reindex r_reindex :=
+theorem conjTranspose_submatrix [Star α] (A : Matrix m n α) (r : l → m)
+    (c : o → n) : (A.submatrix r c)ᴴ = Aᴴ.submatrix c r :=
   ext fun _ _ => rfl
 
 theorem conjTranspose_reindex [Star α] (eₘ : m ≃ l) (eₙ : n ≃ o) (M : Matrix m n α) :

--- a/Mathlib/Data/Matrix/Defs.lean
+++ b/Mathlib/Data/Matrix/Defs.lean
@@ -378,16 +378,16 @@ theorem transpose_map {f : α → β} {M : Matrix m n α} : Mᵀ.map f = (M.map 
 
 end Transpose
 
-/-- Given maps `(r_reindex : l → m)` and `(c_reindex : o → n)` reindexing the rows and columns of
-a matrix `M : Matrix m n α`, the matrix `M.submatrix r_reindex c_reindex : Matrix l o α` is defined
-by `(M.submatrix r_reindex c_reindex) i j = M (r_reindex i) (c_reindex j)` for `(i,j) : l × o`.
+/-- Given maps `(r : l → m)` and `(c : o → n)` reindexing the rows and columns of
+a matrix `M : Matrix m n α`, the matrix `M.submatrix r c : Matrix l o α` is defined
+by `(M.submatrix r c) i j = M (r i) (c j)` for `(i,j) : l × o`.
 Note that the total number of row and columns does not have to be preserved. -/
-def submatrix (A : Matrix m n α) (r_reindex : l → m) (c_reindex : o → n) : Matrix l o α :=
-  of fun i j => A (r_reindex i) (c_reindex j)
+def submatrix (A : Matrix m n α) (r : l → m) (c : o → n) : Matrix l o α :=
+  of fun i j => A (r i) (c j)
 
 @[simp]
-theorem submatrix_apply (A : Matrix m n α) (r_reindex : l → m) (c_reindex : o → n) (i j) :
-    A.submatrix r_reindex c_reindex i j = A (r_reindex i) (c_reindex j) :=
+theorem submatrix_apply (A : Matrix m n α) (r : l → m) (c : o → n) (i j) :
+    A.submatrix r c i j = A (r i) (c j) :=
   rfl
 
 @[simp]
@@ -401,8 +401,8 @@ theorem submatrix_submatrix {l₂ o₂ : Type*} (A : Matrix m n α) (r₁ : l �
   ext fun _ _ => rfl
 
 @[simp]
-theorem transpose_submatrix (A : Matrix m n α) (r_reindex : l → m) (c_reindex : o → n) :
-    (A.submatrix r_reindex c_reindex)ᵀ = Aᵀ.submatrix c_reindex r_reindex :=
+theorem transpose_submatrix (A : Matrix m n α) (r : l → m) (c : o → n) :
+    (A.submatrix r c)ᵀ = Aᵀ.submatrix c r :=
   ext fun _ _ => rfl
 
 theorem submatrix_add [Add α] (A B : Matrix m n α) :


### PR DESCRIPTION
I'm suggesting this change for the following reasons:
(1) managing expectations — `r_reindex` looks more like a propositional argument at first glance
(2) the original naming does not do justice to its motivation — there is nothing called `r` and `c` here — it would need to be `row_reindex` and `col_reindex` or something like that (if we wanted to use the convention for naming constants even tho we are naming a variable here)

---

Old version:
https://github.com/leanprover-community/mathlib4/pull/24135