### PR TITLE
feat: `ramificationIdx` for `NumberField.InfinitePlace`

### DIFF
--- a/Mathlib/NumberTheory/NumberField/InfinitePlace/Ramification.lean
+++ b/Mathlib/NumberTheory/NumberField/InfinitePlace/Ramification.lean
@@ -162,6 +162,11 @@ An infinite place is unramified in a field extension if the restriction has the 
 -/
 def IsUnramified : Prop := mult (w.comap (algebraMap k K)) = mult w
 
+/--
+An infinite place is ramified in a field extension if it is not unramified.
+-/
+abbrev IsRamified : Prop := ¬w.IsUnramified k
+
 variable {k}
 
 lemma isUnramified_self : IsUnramified K w := rfl
@@ -212,6 +217,17 @@ lemma isUnramified_iff :
     IsUnramified k w ↔ IsReal w ∨ IsComplex (w.comap (algebraMap k K)) := by
   rw [← not_iff_not, not_isUnramified_iff, not_or,
     not_isReal_iff_isComplex, not_isComplex_iff_isReal]
+
+theorem isRamified_iff : w.IsRamified k ↔ w.IsComplex ∧ (w.comap (algebraMap k K)).IsReal :=
+  not_isUnramified_iff
+
+theorem IsRamified.ne_conjugate {w₁ w₂ : InfinitePlace K} (h : w₂.IsRamified k) :
+    w₁.embedding ≠ ComplexEmbedding.conjugate w₂.embedding := by
+  by_cases h_eq : w₁ = w₂
+  · rw [isRamified_iff, isComplex_iff] at h
+    exact Ne.symm (h_eq ▸ h.1)
+  · contrapose! h_eq
+    rw [← mk_embedding w₁, h_eq, mk_conjugate_eq, mk_embedding]
 
 variable (k)
 

--- a/Mathlib/NumberTheory/NumberField/InfinitePlace/Ramification.lean
+++ b/Mathlib/NumberTheory/NumberField/InfinitePlace/Ramification.lean
@@ -162,11 +162,6 @@ An infinite place is unramified in a field extension if the restriction has the 
 -/
 def IsUnramified : Prop := mult (w.comap (algebraMap k K)) = mult w
 
-/--
-An infinite place is ramified in a field extension if it is not unramified.
--/
-abbrev IsRamified : Prop := ¬w.IsUnramified k
-
 variable {k}
 
 lemma isUnramified_self : IsUnramified K w := rfl
@@ -217,17 +212,6 @@ lemma isUnramified_iff :
     IsUnramified k w ↔ IsReal w ∨ IsComplex (w.comap (algebraMap k K)) := by
   rw [← not_iff_not, not_isUnramified_iff, not_or,
     not_isReal_iff_isComplex, not_isComplex_iff_isReal]
-
-theorem isRamified_iff : w.IsRamified k ↔ w.IsComplex ∧ (w.comap (algebraMap k K)).IsReal :=
-  not_isUnramified_iff
-
-theorem IsRamified.ne_conjugate {w₁ w₂ : InfinitePlace K} (h : w₂.IsRamified k) :
-    w₁.embedding ≠ ComplexEmbedding.conjugate w₂.embedding := by
-  by_cases h_eq : w₁ = w₂
-  · rw [isRamified_iff, isComplex_iff] at h
-    exact Ne.symm (h_eq ▸ h.1)
-  · contrapose! h_eq
-    rw [← mk_embedding w₁, h_eq, mk_conjugate_eq, mk_embedding]
 
 variable (k)
 
@@ -495,3 +479,25 @@ lemma IsUnramifiedAtInfinitePlaces.card_infinitePlace [NumberField k] [NumberFie
   · exact Finset.compl_univ
   simp only [Finset.mem_univ, forall_true_left, Finset.filter_eq_empty_iff]
   exact InfinitePlace.isUnramifiedIn K
+
+section Extension
+
+namespace NumberField.InfinitePlace
+
+variable (K : Type*) (L : Type*) [Field K] [Field L] [Algebra K L] (w : InfinitePlace L)
+
+open scoped Classical in
+/-- If `w` is unramified over `K` then the ramification index is `1`, else `2`. -/
+noncomputable abbrev ramificationIdx := if w.IsUnramified K then 1 else 2
+
+variable {w}
+
+theorem ramificationIdx_eq_one (h : w.IsUnramified K) : ramificationIdx K w = 1 := by
+  rw [ramificationIdx, if_pos h]
+
+theorem ramificationIdx_eq_two (h : w.IsRamified K) : ramificationIdx K w = 2 := by
+  rw [ramificationIdx, if_neg h]
+
+end NumberField.InfinitePlace
+
+end Extension

--- a/Mathlib/NumberTheory/NumberField/InfinitePlace/Ramification.lean
+++ b/Mathlib/NumberTheory/NumberField/InfinitePlace/Ramification.lean
@@ -484,7 +484,7 @@ section Extension
 
 namespace NumberField.InfinitePlace
 
-variable (K : Type*) (L : Type*) [Field K] [Field L] [Algebra K L] (w : InfinitePlace L)
+variable (K : Type*) {L : Type*} [Field K] [Field L] [Algebra K L] (w : InfinitePlace L)
 
 open scoped Classical in
 /-- If `w` is unramified over `K` then the ramification index is `1`, else `2`. -/


### PR DESCRIPTION
---

- [x] depends on: #24880 

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
