### PR TITLE
[Merged by Bors] - chore(Algebra): make sure items in docs have no odd indentation

### DIFF
--- a/Mathlib/Algebra/Algebra/NonUnitalHom.lean
+++ b/Mathlib/Algebra/Algebra/NonUnitalHom.lean
@@ -10,10 +10,10 @@ import Mathlib.Algebra.GroupWithZero.Action.Prod
 # Morphisms of non-unital algebras
 
 This file defines morphisms between two types, each of which carries:
- * an addition,
- * an additive zero,
- * a multiplication,
- * a scalar action.
+* an addition,
+* an additive zero,
+* a multiplication,
+* a scalar action.
 
 The multiplications are not assumed to be associative or unital, or even to be compatible with the
 scalar actions. In a typical application, the operations will satisfy compatibility conditions

--- a/Mathlib/Algebra/Algebra/RestrictScalars.lean
+++ b/Mathlib/Algebra/Algebra/RestrictScalars.lean
@@ -23,7 +23,7 @@ typeclass instead.
   between the restricted and original space (in fact, they are definitionally equal,
   but sometimes it is helpful to avoid using this fact, to keep instances from leaking).
 * `RestrictScalars.ringEquiv : RestrictScalars R S A ≃+* A`: the ring equivalence
-   between the restricted and original space when the module is an algebra.
+  between the restricted and original space when the module is an algebra.
 
 ## See also
 

--- a/Mathlib/Algebra/Algebra/Subalgebra/Directed.lean
+++ b/Mathlib/Algebra/Algebra/Subalgebra/Directed.lean
@@ -12,9 +12,9 @@ import Mathlib.Data.Set.UnionLift
 
 ## Main results
 
- * `Subalgebra.coe_iSup_of_directed`: a directed supremum consists of the union of the algebras
- * `Subalgebra.iSupLift`: define an algebra homomorphism on a directed supremum of subalgebras by
-   defining it on each subalgebra, and proving that it agrees on the intersection of subalgebras.
+* `Subalgebra.coe_iSup_of_directed`: a directed supremum consists of the union of the algebras
+* `Subalgebra.iSupLift`: define an algebra homomorphism on a directed supremum of subalgebras by
+  defining it on each subalgebra, and proving that it agrees on the intersection of subalgebras.
 -/
 
 namespace Subalgebra

--- a/Mathlib/Algebra/Algebra/Subalgebra/Pi.lean
+++ b/Mathlib/Algebra/Algebra/Subalgebra/Pi.lean
@@ -14,7 +14,7 @@ In this file we define the product of subalgebras as a subalgebra of the product
 
 ## Main definitions
 
- * `Subalgebra.pi`: the product of subalgebras.
+* `Subalgebra.pi`: the product of subalgebras.
 -/
 
 open Algebra

--- a/Mathlib/Algebra/Algebra/Subalgebra/Prod.lean
+++ b/Mathlib/Algebra/Algebra/Subalgebra/Prod.lean
@@ -13,7 +13,7 @@ In this file we define the product of two subalgebras as a subalgebra of the pro
 
 ## Main definitions
 
- * `Subalgebra.prod`: the product of two subalgebras.
+* `Subalgebra.prod`: the product of two subalgebras.
 -/
 
 

--- a/Mathlib/Algebra/Algebra/Subalgebra/Tower.lean
+++ b/Mathlib/Algebra/Algebra/Subalgebra/Tower.lean
@@ -17,12 +17,12 @@ compatibility condition `(r • s) • a = r • (s • a)`.
 
 ## Main results
 
- * `IsScalarTower.Subalgebra`: if `A/S/R` is a tower and `S₀` is a subalgebra
-   between `S` and `R`, then `A/S/S₀` is a tower
- * `IsScalarTower.Subalgebra'`: if `A/S/R` is a tower and `S₀` is a subalgebra
-   between `S` and `R`, then `A/S₀/R` is a tower
- * `Subalgebra.restrictScalars`: turn an `S`-subalgebra of `A` into an `R`-subalgebra of `A`,
-   given that `A/S/R` is a tower
+* `IsScalarTower.Subalgebra`: if `A/S/R` is a tower and `S₀` is a subalgebra
+  between `S` and `R`, then `A/S/S₀` is a tower
+* `IsScalarTower.Subalgebra'`: if `A/S/R` is a tower and `S₀` is a subalgebra
+  between `S` and `R`, then `A/S₀/R` is a tower
+* `Subalgebra.restrictScalars`: turn an `S`-subalgebra of `A` into an `R`-subalgebra of `A`,
+  given that `A/S/R` is a tower
 
 -/
 

--- a/Mathlib/Algebra/BigOperators/Finprod.lean
+++ b/Mathlib/Algebra/BigOperators/Finprod.lean
@@ -32,10 +32,10 @@ We use the following variables:
 Definitions in this file:
 
 * `finsum f : M` : the sum of `f x` as `x` ranges over the support of `f`, if it's finite.
-   Zero otherwise.
+  Zero otherwise.
 
 * `finprod f : M` : the product of `f x` as `x` ranges over the multiplicative support of `f`, if
-   it's finite. One otherwise.
+  it's finite. One otherwise.
 
 ## Notation
 

--- a/Mathlib/Algebra/Category/Ring/Limits.lean
+++ b/Mathlib/Algebra/Category/Ring/Limits.lean
@@ -424,7 +424,7 @@ All we need to do is notice that the limit point has a `CommRing` instance avail
 and then reuse the existing limit.
 -/
 instance :
-   CreatesLimit F (forget₂ CommRingCat.{u} RingCat.{u}) :=
+  CreatesLimit F (forget₂ CommRingCat.{u} RingCat.{u}) :=
   /-
     A terse solution here would be
     ```

--- a/Mathlib/Algebra/Category/Ring/Limits.lean
+++ b/Mathlib/Algebra/Category/Ring/Limits.lean
@@ -423,8 +423,7 @@ instance limitCommRing :
 All we need to do is notice that the limit point has a `CommRing` instance available,
 and then reuse the existing limit.
 -/
-instance :
-  CreatesLimit F (forget₂ CommRingCat.{u} RingCat.{u}) :=
+instance : CreatesLimit F (forget₂ CommRingCat.{u} RingCat.{u}) :=
   /-
     A terse solution here would be
     ```
@@ -466,9 +465,7 @@ def limitCone : Cone F :=
     inferInstanceAs <| Small.{u} (Functor.sections (F ⋙ forget _))
   liftLimit (limit.isLimit (F ⋙ forget₂ CommRingCat.{u} RingCat.{u}))
 
-/-- The chosen cone is a limit cone.
-(Generally, you'll just want to use `limit.cone F`.)
--/
+/-- The chosen cone is a limit cone. (Generally, you'll just want to use `limit.cone F`.) -/
 def limitConeIsLimit : IsLimit (limitCone.{v, u} F) :=
   liftedLimitIsLimit _
 

--- a/Mathlib/Algebra/CharP/Defs.lean
+++ b/Mathlib/Algebra/CharP/Defs.lean
@@ -12,9 +12,9 @@ import Mathlib.Order.Lattice
 # Characteristic of semirings
 
 ## Main definitions
- * `CharP R p` expresses that the ring (additive monoid with one) `R` has characteristic `p`
- * `ringChar`: the characteristic of a ring
- * `ExpChar R p` expresses that the ring (additive monoid with one) `R` has
+* `CharP R p` expresses that the ring (additive monoid with one) `R` has characteristic `p`
+* `ringChar`: the characteristic of a ring
+* `ExpChar R p` expresses that the ring (additive monoid with one) `R` has
     exponential characteristic `p` (which is `1` if `R` has characteristic 0, and `p` if it has
     prime characteristic `p`)
 -/

--- a/Mathlib/Algebra/ContinuedFractions/Computation/Translations.lean
+++ b/Mathlib/Algebra/ContinuedFractions/Computation/Translations.lean
@@ -16,15 +16,15 @@ This is a collection of simple lemmas between the different structures used for 
 of continued fractions defined in `Mathlib.Algebra.ContinuedFractions.Computation.Basic`.
 The file consists of three sections:
 1. Recurrences and inversion lemmas for `IntFractPair.stream`: these lemmas give us inversion
-   rules and recurrences for the computation of the stream of integer and fractional parts of
-   a value.
+  rules and recurrences for the computation of the stream of integer and fractional parts of
+  a value.
 2. Translation lemmas for the head term: these lemmas show us that the head term of the computed
-   continued fraction of a value `v` is `⌊v⌋` and how this head term is moved along the structures
-   used in the computation process.
+  continued fraction of a value `v` is `⌊v⌋` and how this head term is moved along the structures
+  used in the computation process.
 3. Translation lemmas for the sequence: these lemmas show how the sequences of the involved
-   structures (`IntFractPair.stream`, `IntFractPair.seq1`, and `GenContFract.of`) are connected,
-   i.e. how the values are moved along the structures and the termination of one sequence implies
-   the termination of another sequence.
+  structures (`IntFractPair.stream`, `IntFractPair.seq1`, and `GenContFract.of`) are connected,
+  i.e. how the values are moved along the structures and the termination of one sequence implies
+  the termination of another sequence.
 
 ## Main Theorems
 

--- a/Mathlib/Algebra/CubicDiscriminant.lean
+++ b/Mathlib/Algebra/CubicDiscriminant.lean
@@ -13,18 +13,18 @@ This file defines cubic polynomials over a semiring and their discriminants over
 
 ## Main definitions
 
- * `Cubic`: the structure representing a cubic polynomial.
- * `Cubic.disc`: the discriminant of a cubic polynomial.
+* `Cubic`: the structure representing a cubic polynomial.
+* `Cubic.disc`: the discriminant of a cubic polynomial.
 
 ## Main statements
 
- * `Cubic.disc_ne_zero_iff_roots_nodup`: the cubic discriminant is not equal to zero if and only if
+* `Cubic.disc_ne_zero_iff_roots_nodup`: the cubic discriminant is not equal to zero if and only if
     the cubic has no duplicate roots.
 
 ## References
 
- * https://en.wikipedia.org/wiki/Cubic_equation
- * https://en.wikipedia.org/wiki/Discriminant
+* https://en.wikipedia.org/wiki/Cubic_equation
+* https://en.wikipedia.org/wiki/Discriminant
 
 ## Tags
 

--- a/Mathlib/Algebra/Divisibility/Basic.lean
+++ b/Mathlib/Algebra/Divisibility/Basic.lean
@@ -14,7 +14,7 @@ This file defines the basics of the divisibility relation in the context of `(Co
 
 ## Main definitions
 
- * `semigroupDvd`
+* `semigroupDvd`
 
 ## Implementation notes
 

--- a/Mathlib/Algebra/Divisibility/Hom.lean
+++ b/Mathlib/Algebra/Divisibility/Hom.lean
@@ -12,7 +12,7 @@ import Mathlib.Algebra.Group.Hom.Defs
 
 ## Main definitions
 
- * `map_dvd`
+* `map_dvd`
 
 ## Tags
 

--- a/Mathlib/Algebra/Group/Conj.lean
+++ b/Mathlib/Algebra/Group/Conj.lean
@@ -170,10 +170,10 @@ Certain instances trigger further searches when they are considered as candidate
 these instances should be assigned a priority lower than the default of 1000 (for example, 900).
 
 The conditions for this rule are as follows:
- * a class `C` has instances `instT : C T` and `instT' : C T'`
- * types `T` and `T'` are both specializations of another type `S`
- * the parameters supplied to `S` to produce `T` are not (fully) determined by `instT`,
-   instead they have to be found by instance search
+* a class `C` has instances `instT : C T` and `instT' : C T'`
+* types `T` and `T'` are both specializations of another type `S`
+* the parameters supplied to `S` to produce `T` are not (fully) determined by `instT`,
+  instead they have to be found by instance search
 If those conditions hold, the instance `instT` should be assigned lower priority.
 
 For example, suppose the search for an instance of `DecidableEq (Multiset α)` tries the

--- a/Mathlib/Algebra/Group/Invertible/Defs.lean
+++ b/Mathlib/Algebra/Group/Invertible/Defs.lean
@@ -21,7 +21,7 @@ For constructions of the invertible element given a characteristic, see
 
 ## Notation
 
- * `⅟a` is `Invertible.invOf a`, the inverse of `a`
+* `⅟a` is `Invertible.invOf a`, the inverse of `a`
 
 ## Implementation notes
 

--- a/Mathlib/Algebra/Lie/BaseChange.lean
+++ b/Mathlib/Algebra/Lie/BaseChange.lean
@@ -16,9 +16,9 @@ scalars.
 
 ## Main definitions
 
- * `LieAlgebra.ExtendScalars.instLieAlgebra`
- * `LieAlgebra.ExtendScalars.instLieModule`
- * `LieAlgebra.RestrictScalars.lieAlgebra`
+* `LieAlgebra.ExtendScalars.instLieAlgebra`
+* `LieAlgebra.ExtendScalars.instLieModule`
+* `LieAlgebra.RestrictScalars.lieAlgebra`
 
 ## Tags
 

--- a/Mathlib/Algebra/Lie/Basic.lean
+++ b/Mathlib/Algebra/Lie/Basic.lean
@@ -30,10 +30,10 @@ modules, morphisms and equivalences, as well as various lemmas to make these def
 ## Notation
 
 Working over a fixed commutative ring `R`, we introduce the notations:
- * `L →ₗ⁅R⁆ L'` for a morphism of Lie algebras,
- * `L ≃ₗ⁅R⁆ L'` for an equivalence of Lie algebras,
- * `M →ₗ⁅R,L⁆ N` for a morphism of Lie algebra modules `M`, `N` over a Lie algebra `L`,
- * `M ≃ₗ⁅R,L⁆ N` for an equivalence of Lie algebra modules `M`, `N` over a Lie algebra `L`.
+* `L →ₗ⁅R⁆ L'` for a morphism of Lie algebras,
+* `L ≃ₗ⁅R⁆ L'` for an equivalence of Lie algebras,
+* `M →ₗ⁅R,L⁆ N` for a morphism of Lie algebra modules `M`, `N` over a Lie algebra `L`,
+* `M ≃ₗ⁅R,L⁆ N` for an equivalence of Lie algebra modules `M`, `N` over a Lie algebra `L`.
 
 ## Implementation notes
 

--- a/Mathlib/Algebra/Lie/CartanMatrix.lean
+++ b/Mathlib/Algebra/Lie/CartanMatrix.lean
@@ -30,10 +30,10 @@ In this file we provide the above construction. It is defined for any square mat
 the results for non-Cartan matrices should be regarded as junk.
 
 Recall that a Cartan matrix is a square matrix of integers `A` such that:
- * For diagonal values we have: `A i i = 2`.
- * For off-diagonal values (`i ≠ j`) we have: `A i j ∈ {-3, -2, -1, 0}`.
- * `A i j = 0 ↔ A j i = 0`.
- * There exists a diagonal matrix `D` over ℝ such that `D * A * D⁻¹` is symmetric positive definite.
+* For diagonal values we have: `A i i = 2`.
+* For off-diagonal values (`i ≠ j`) we have: `A i j ∈ {-3, -2, -1, 0}`.
+* `A i j = 0 ↔ A j i = 0`.
+* There exists a diagonal matrix `D` over ℝ such that `D * A * D⁻¹` is symmetric positive definite.
 
 ## Alternative construction
 

--- a/Mathlib/Algebra/Lie/Extension.lean
+++ b/Mathlib/Algebra/Lie/Extension.lean
@@ -12,14 +12,14 @@ homomorphisms. They are implemented in two ways: `IsExtension` is a `Prop`-value
 homomorphisms as parameters, and `Extension` is a structure that includes the middle Lie algebra.
 
 ## Main definitions
- * `LieAlgebra.IsExtension`: A `Prop`-valued class characterizing an extension of Lie algebras.
- * `LieAlgebra.Extension`: A bundled structure giving an extension of Lie algebras.
- * `LieAlgebra.IsExtension.extension`: A function that builds the bundled structure from the class.
+* `LieAlgebra.IsExtension`: A `Prop`-valued class characterizing an extension of Lie algebras.
+* `LieAlgebra.Extension`: A bundled structure giving an extension of Lie algebras.
+* `LieAlgebra.IsExtension.extension`: A function that builds the bundled structure from the class.
 
 ## TODO
- * `IsCentral` - central extensions
- * `Equiv` - equivalence of extensions
- * `ofTwoCocycle` - construction of extensions from 2-cocycles
+* `IsCentral` - central extensions
+* `Equiv` - equivalence of extensions
+* `ofTwoCocycle` - construction of extensions from 2-cocycles
 
 ## References
 * [N. Bourbaki, *Lie Groups and Lie Algebras, Chapters 1--3*](bourbaki1975)

--- a/Mathlib/Algebra/Lie/Killing.lean
+++ b/Mathlib/Algebra/Lie/Killing.lean
@@ -25,16 +25,16 @@ This file contains basic definitions and results for such Lie algebras.
 
 ## Main declarations
 
- * `LieAlgebra.IsKilling`: a typeclass encoding the fact that a Lie algebra has a non-singular
-   Killing form.
- * `LieAlgebra.IsKilling.instSemisimple`: if a finite-dimensional Lie algebra over a field
-   has non-singular Killing form then it is semisimple.
- * `LieAlgebra.IsKilling.instHasTrivialRadical`: if a Lie algebra over a PID
-   has non-singular Killing form then it has trivial radical.
+* `LieAlgebra.IsKilling`: a typeclass encoding the fact that a Lie algebra has a non-singular
+  Killing form.
+* `LieAlgebra.IsKilling.instSemisimple`: if a finite-dimensional Lie algebra over a field
+  has non-singular Killing form then it is semisimple.
+* `LieAlgebra.IsKilling.instHasTrivialRadical`: if a Lie algebra over a PID
+  has non-singular Killing form then it has trivial radical.
 
 ## TODO
 
- * Prove that in characteristic zero, a semisimple Lie algebra has non-singular Killing form.
+* Prove that in characteristic zero, a semisimple Lie algebra has non-singular Killing form.
 
 -/
 

--- a/Mathlib/Algebra/Lie/NonUnitalNonAssocAlgebra.lean
+++ b/Mathlib/Algebra/Lie/NonUnitalNonAssocAlgebra.lean
@@ -13,10 +13,10 @@ The definition of Lie algebras uses the `Bracket` typeclass for multiplication w
 separate `Mul` typeclass used for general algebras.
 
 It is useful to have a special typeclass for Lie algebras because:
- * it enables us to use the traditional notation `⁅x, y⁆` for the Lie multiplication,
- * associative algebras carry a natural Lie algebra structure via the ring commutator and so we
-   need them to carry both `Mul` and `Bracket` simultaneously,
- * more generally, Poisson algebras (not yet defined) need both typeclasses.
+* it enables us to use the traditional notation `⁅x, y⁆` for the Lie multiplication,
+* associative algebras carry a natural Lie algebra structure via the ring commutator and so we
+  need them to carry both `Mul` and `Bracket` simultaneously,
+* more generally, Poisson algebras (not yet defined) need both typeclasses.
 
 However there are times when it is convenient to be able to regard a Lie algebra as a general
 algebra and we provide some basic definitions for doing so here.

--- a/Mathlib/Algebra/Lie/OfAssociative.lean
+++ b/Mathlib/Algebra/Lie/OfAssociative.lean
@@ -20,12 +20,12 @@ make such a definition in this file.
 
 ## Main definitions
 
- * `LieAlgebra.ofAssociativeAlgebra`
- * `LieAlgebra.ofAssociativeAlgebraHom`
- * `LieModule.toEnd`
- * `LieAlgebra.ad`
- * `LinearEquiv.lieConj`
- * `AlgEquiv.toLieEquiv`
+* `LieAlgebra.ofAssociativeAlgebra`
+* `LieAlgebra.ofAssociativeAlgebraHom`
+* `LieModule.toEnd`
+* `LieAlgebra.ad`
+* `LinearEquiv.lieConj`
+* `AlgEquiv.toLieEquiv`
 
 ## Tags
 

--- a/Mathlib/Algebra/Lie/Semisimple/Lemmas.lean
+++ b/Mathlib/Algebra/Lie/Semisimple/Lemmas.lean
@@ -12,21 +12,21 @@ import Mathlib.Algebra.Lie.Semisimple.Basic
 This file is a home for lemmas about semisimple and reductive Lie algebras.
 
 ## Main definitions / results:
- * `LieAlgebra.hasCentralRadical_and_of_isIrreducible_of_isFaithful`: a finite-dimensional Lie
-   algebra with a irreducible faithful finite-dimensional representation is reductive.
- * `LieAlgebra.hasTrivialRadical_and_of_isIrreducible_of_isFaithful`: a finite-dimensional Lie
-   algebra with a irreducible faithful finite-dimensional trace-free representation is semisimple.
+* `LieAlgebra.hasCentralRadical_and_of_isIrreducible_of_isFaithful`: a finite-dimensional Lie
+  algebra with a irreducible faithful finite-dimensional representation is reductive.
+* `LieAlgebra.hasTrivialRadical_and_of_isIrreducible_of_isFaithful`: a finite-dimensional Lie
+  algebra with a irreducible faithful finite-dimensional trace-free representation is semisimple.
 
 ## TODO
 
- * It appears that the lemmas in this file may hold for any principal ideal domain (of
-   characteristic zero) instead of a field. The plan would be to define the nilradical of a Lie
-   algebra (currently missing) and use it with
-   `LieModule.exists_nontrivial_weightSpace_of_isNilpotent` instead of using the solvable radical
-   with `LieModule.exists_nontrivial_weightSpace_of_isSolvable`, as below. The conclusion of
-   `LieAlgebra.hasCentralRadical_and_of_isIrreducible_of_isFaithful` would then make a statement
-   that the nilradical vanishes and one would prove elsewhere that vanishing nilradical is
-   equivalent to `HasCentralRadical`.
+* It appears that the lemmas in this file may hold for any principal ideal domain (of
+  characteristic zero) instead of a field. The plan would be to define the nilradical of a Lie
+  algebra (currently missing) and use it with
+  `LieModule.exists_nontrivial_weightSpace_of_isNilpotent` instead of using the solvable radical
+  with `LieModule.exists_nontrivial_weightSpace_of_isSolvable`, as below. The conclusion of
+  `LieAlgebra.hasCentralRadical_and_of_isIrreducible_of_isFaithful` would then make a statement
+  that the nilradical vanishes and one would prove elsewhere that vanishing nilradical is
+  equivalent to `HasCentralRadical`.
 
 -/
 

--- a/Mathlib/Algebra/Lie/Sl2.lean
+++ b/Mathlib/Algebra/Lie/Sl2.lean
@@ -16,12 +16,12 @@ distinguished position in the general theory. This file provides some basic defi
 about `sl₂`.
 
 ## Main definitions:
- * `IsSl2Triple`: a structure representing a triple of elements in a Lie algebra which satisfy the
-   standard relations for `sl₂`.
- * `IsSl2Triple.HasPrimitiveVectorWith`: a structure representing a primitive vector in a
-   representation of a Lie algebra relative to a distinguished `sl₂` triple.
- * `IsSl2Triple.HasPrimitiveVectorWith.exists_nat`: the eigenvalue of a primitive vector must be a
-   natural number if the representation is finite-dimensional.
+* `IsSl2Triple`: a structure representing a triple of elements in a Lie algebra which satisfy the
+  standard relations for `sl₂`.
+* `IsSl2Triple.HasPrimitiveVectorWith`: a structure representing a primitive vector in a
+  representation of a Lie algebra relative to a distinguished `sl₂` triple.
+* `IsSl2Triple.HasPrimitiveVectorWith.exists_nat`: the eigenvalue of a primitive vector must be a
+  natural number if the representation is finite-dimensional.
 
 -/
 

--- a/Mathlib/Algebra/Lie/TraceForm.lean
+++ b/Mathlib/Algebra/Lie/TraceForm.lean
@@ -24,12 +24,12 @@ We define the trace / Killing form in this file and prove some basic properties.
 
 ## Main definitions
 
- * `LieModule.traceForm`: a finite, free representation of a Lie algebra `L` induces a bilinear form
-   on `L` called the trace Form.
- * `LieModule.traceForm_eq_zero_of_isNilpotent`: the trace form induced by a nilpotent
-   representation of a Lie algebra vanishes.
- * `killingForm`: the adjoint representation of a (finite, free) Lie algebra `L` induces a bilinear
-   form on `L` via the trace form construction.
+* `LieModule.traceForm`: a finite, free representation of a Lie algebra `L` induces a bilinear form
+  on `L` called the trace Form.
+* `LieModule.traceForm_eq_zero_of_isNilpotent`: the trace form induced by a nilpotent
+  representation of a Lie algebra vanishes.
+* `killingForm`: the adjoint representation of a (finite, free) Lie algebra `L` induces a bilinear
+  form on `L` via the trace form construction.
 -/
 
 variable (R K L M : Type*) [CommRing R] [LieRing L] [LieAlgebra R L]

--- a/Mathlib/Algebra/Lie/Weights/Chain.lean
+++ b/Mathlib/Algebra/Lie/Weights/Chain.lean
@@ -26,29 +26,29 @@ We provide basic definitions and results to support `α`-chain techniques in thi
 
 ## Main definitions / results
 
- * `LieModule.exists₂_genWeightSpace_smul_add_eq_bot`: given weights `χ₁`, `χ₂` if `χ₁ ≠ 0`, we can
-   find `p < 0` and `q > 0` such that the weight spaces `p • χ₁ + χ₂` and `q • χ₁ + χ₂` are both
-   trivial.
- * `LieModule.genWeightSpaceChain`: given weights `χ₁`, `χ₂` together with integers `p` and `q`,
-   this is the sum of the weight spaces `k • χ₁ + χ₂` for `p < k < q`.
- * `LieModule.trace_toEnd_genWeightSpaceChain_eq_zero`: given a root `α` relative to a Cartan
-   subalgebra `H`, there is a natural ideal `corootSpace α` in `H`. This lemma
-   states that this ideal acts by trace-zero endomorphisms on the sum of root spaces of any
-   `α`-chain, provided the weight spaces at the endpoints are both trivial.
- * `LieModule.exists_forall_mem_corootSpace_smul_add_eq_zero`: given a (potential) root
-   `α` relative to a Cartan subalgebra `H`, if we restrict to the ideal
-   `corootSpace α` of `H`, we may find an integral linear combination between
-   `α` and any weight `χ` of a representation.
+* `LieModule.exists₂_genWeightSpace_smul_add_eq_bot`: given weights `χ₁`, `χ₂` if `χ₁ ≠ 0`, we can
+  find `p < 0` and `q > 0` such that the weight spaces `p • χ₁ + χ₂` and `q • χ₁ + χ₂` are both
+  trivial.
+* `LieModule.genWeightSpaceChain`: given weights `χ₁`, `χ₂` together with integers `p` and `q`,
+  this is the sum of the weight spaces `k • χ₁ + χ₂` for `p < k < q`.
+* `LieModule.trace_toEnd_genWeightSpaceChain_eq_zero`: given a root `α` relative to a Cartan
+  subalgebra `H`, there is a natural ideal `corootSpace α` in `H`. This lemma
+  states that this ideal acts by trace-zero endomorphisms on the sum of root spaces of any
+  `α`-chain, provided the weight spaces at the endpoints are both trivial.
+* `LieModule.exists_forall_mem_corootSpace_smul_add_eq_zero`: given a (potential) root
+  `α` relative to a Cartan subalgebra `H`, if we restrict to the ideal
+  `corootSpace α` of `H`, we may find an integral linear combination between
+  `α` and any weight `χ` of a representation.
 
 ## TODO
 
 It should be possible to unify some of the definitions here such as `LieModule.chainBotCoeff`,
 `LieModule.chainTopCoeff` with corresponding definitions such as `RootPairing.chainBotCoeff`,
 `RootPairing.chainTopCoeff`. This is not quite trivial since:
- * The definitions here allow for chains in representations of Lie algebras.
- * The proof that the roots of a Lie algebra are a root system currently depends on these results.
-   (This can be resolved by proving the root reflection formula using the approach outlined in
-   Bourbaki Ch. VIII §2.2 Lemma 1 (page 80 of English translation, 88 of English PDF).)
+* The definitions here allow for chains in representations of Lie algebras.
+* The proof that the roots of a Lie algebra are a root system currently depends on these results.
+  (This can be resolved by proving the root reflection formula using the approach outlined in
+  Bourbaki Ch. VIII §2.2 Lemma 1 (page 80 of English translation, 88 of English PDF).)
 
 -/
 

--- a/Mathlib/Algebra/Lie/Weights/Killing.lean
+++ b/Mathlib/Algebra/Lie/Weights/Killing.lean
@@ -17,20 +17,20 @@ The file contains definitions and results about roots of Lie algebras with non-d
 forms.
 
 ## Main definitions
- * `LieAlgebra.IsKilling.ker_restrict_eq_bot_of_isCartanSubalgebra`: if the Killing form of
-   a Lie algebra is non-singular, it remains non-singular when restricted to a Cartan subalgebra.
- * `LieAlgebra.IsKilling.instIsLieAbelianOfIsCartanSubalgebra`: if the Killing form of a Lie
-   algebra is non-singular, then its Cartan subalgebras are Abelian.
- * `LieAlgebra.IsKilling.isSemisimple_ad_of_mem_isCartanSubalgebra`: over a perfect field, if a Lie
-   algebra has non-degenerate Killing form, Cartan subalgebras contain only semisimple elements.
- * `LieAlgebra.IsKilling.span_weight_eq_top`: given a splitting Cartan subalgebra `H` of a
-   finite-dimensional Lie algebra with non-singular Killing form, the corresponding roots span the
-   dual space of `H`.
- * `LieAlgebra.IsKilling.coroot`: the coroot corresponding to a root.
- * `LieAlgebra.IsKilling.isCompl_ker_weight_span_coroot`: given a root `α` with respect to a Cartan
-   subalgebra `H`, we have a natural decomposition of `H` as the kernel of `α` and the span of the
-   coroot corresponding to `α`.
- * `LieAlgebra.IsKilling.finrank_rootSpace_eq_one`: root spaces are one-dimensional.
+* `LieAlgebra.IsKilling.ker_restrict_eq_bot_of_isCartanSubalgebra`: if the Killing form of
+  a Lie algebra is non-singular, it remains non-singular when restricted to a Cartan subalgebra.
+* `LieAlgebra.IsKilling.instIsLieAbelianOfIsCartanSubalgebra`: if the Killing form of a Lie
+  algebra is non-singular, then its Cartan subalgebras are Abelian.
+* `LieAlgebra.IsKilling.isSemisimple_ad_of_mem_isCartanSubalgebra`: over a perfect field, if a Lie
+  algebra has non-degenerate Killing form, Cartan subalgebras contain only semisimple elements.
+* `LieAlgebra.IsKilling.span_weight_eq_top`: given a splitting Cartan subalgebra `H` of a
+  finite-dimensional Lie algebra with non-singular Killing form, the corresponding roots span the
+  dual space of `H`.
+* `LieAlgebra.IsKilling.coroot`: the coroot corresponding to a root.
+* `LieAlgebra.IsKilling.isCompl_ker_weight_span_coroot`: given a root `α` with respect to a Cartan
+  subalgebra `H`, we have a natural decomposition of `H` as the kernel of `α` and the span of the
+  coroot corresponding to `α`.
+* `LieAlgebra.IsKilling.finrank_rootSpace_eq_one`: root spaces are one-dimensional.
 
 -/
 

--- a/Mathlib/Algebra/Lie/Weights/Linear.lean
+++ b/Mathlib/Algebra/Lie/Weights/Linear.lean
@@ -15,9 +15,9 @@ studies `M` via its weights. These are functions `χ : L → R` whose correspond
 `LieModule.genWeightSpace M χ`, is non-trivial. If `L` is Abelian or if `R` has characteristic zero
 (and `M` is finite-dimensional) then such `χ` are necessarily `R`-linear. However in general
 non-linear weights do exist. For example if we take:
- * `R`: the field with two elements (or indeed any perfect field of characteristic two),
- * `L`: `sl₂` (this is nilpotent in characteristic two),
- * `M`: the natural two-dimensional representation of `L`,
+* `R`: the field with two elements (or indeed any perfect field of characteristic two),
+* `L`: `sl₂` (this is nilpotent in characteristic two),
+* `M`: the natural two-dimensional representation of `L`,
 
 then there is a single weight and it is non-linear. (See remark following Proposition 9 of
 chapter VII, §1.3 in [N. Bourbaki, Chapters 7--9](bourbaki1975b).)
@@ -27,15 +27,15 @@ have linear weights and provide typeclass instances in the two important cases t
 or `R` has characteristic zero.
 
 ## Main definitions
- * `LieModule.LinearWeights`: a typeclass encoding the fact that a given Lie module has linear
-   weights, and furthermore that the weights vanish on the derived ideal.
- * `LieModule.instLinearWeightsOfCharZero`: a typeclass instance encoding the fact that for an
-   Abelian Lie algebra, the weights of any Lie module are linear.
- * `LieModule.instLinearWeightsOfIsLieAbelian`: a typeclass instance encoding the fact that in
-   characteristic zero, the weights of any finite-dimensional Lie module are linear.
- * `LieModule.exists_forall_lie_eq_smul`: existence of simultaneous
-   eigenvectors from existence of simultaneous generalized eigenvectors for Noetherian Lie modules
-   with linear weights.
+* `LieModule.LinearWeights`: a typeclass encoding the fact that a given Lie module has linear
+  weights, and furthermore that the weights vanish on the derived ideal.
+* `LieModule.instLinearWeightsOfCharZero`: a typeclass instance encoding the fact that for an
+  Abelian Lie algebra, the weights of any Lie module are linear.
+* `LieModule.instLinearWeightsOfIsLieAbelian`: a typeclass instance encoding the fact that in
+  characteristic zero, the weights of any finite-dimensional Lie module are linear.
+* `LieModule.exists_forall_lie_eq_smul`: existence of simultaneous
+  eigenvectors from existence of simultaneous generalized eigenvectors for Noetherian Lie modules
+  with linear weights.
 
 -/
 

--- a/Mathlib/Algebra/Module/Bimodule.lean
+++ b/Mathlib/Algebra/Module/Bimodule.lean
@@ -34,11 +34,11 @@ This file is a place to collect results which are specific to bimodules.
 
 ## Main definitions
 
- * `Subbimodule.mk`
- * `Subbimodule.smul_mem`
- * `Subbimodule.smul_mem'`
- * `Subbimodule.toSubmodule`
- * `Subbimodule.toSubmodule'`
+* `Subbimodule.mk`
+* `Subbimodule.smul_mem`
+* `Subbimodule.smul_mem'`
+* `Subbimodule.toSubmodule`
+* `Subbimodule.toSubmodule'`
 
 ## Implementation details
 

--- a/Mathlib/Algebra/Module/LocalizedModule/Basic.lean
+++ b/Mathlib/Algebra/Module/LocalizedModule/Basic.lean
@@ -32,7 +32,7 @@ localize `M` by `S`. This gives us a `Localization S`-module.
 
 ## Future work
 
- * Redefine `Localization` for monoids and rings to coincide with `LocalizedModule`.
+* Redefine `Localization` for monoids and rings to coincide with `LocalizedModule`.
 -/
 
 

--- a/Mathlib/Algebra/Module/LocalizedModule/Int.lean
+++ b/Mathlib/Algebra/Module/LocalizedModule/Int.lean
@@ -14,7 +14,7 @@ This is a mirror of the corresponding notion for localizations of rings.
 
 ## Main definitions
 
- * `IsLocalizedModule.IsInteger` is a predicate stating that `m : M'` is in the image of `M`
+* `IsLocalizedModule.IsInteger` is a predicate stating that `m : M'` is in the image of `M`
 
 ## Implementation details
 

--- a/Mathlib/Algebra/Module/NatInt.lean
+++ b/Mathlib/Algebra/Module/NatInt.lean
@@ -19,7 +19,7 @@ This file concerns modules where the scalars are the natural numbers or the inte
 
 ## Main results
 
- * `AddCommMonoid.uniqueNatModule`: there is an unique `AddCommMonoid ℕ M` structure for any `M`
+* `AddCommMonoid.uniqueNatModule`: there is an unique `AddCommMonoid ℕ M` structure for any `M`
 
 ## Tags
 

--- a/Mathlib/Algebra/Module/Projective.lean
+++ b/Mathlib/Algebra/Module/Projective.lean
@@ -67,10 +67,10 @@ open LinearMap hiding id
 open Finsupp
 
 /- The actual implementation we choose: `P` is projective if the natural surjection
-   from the free `R`-module on `P` to `P` splits. -/
+from the free `R`-module on `P` to `P` splits. -/
 /-- An R-module is projective if it is a direct summand of a free module, or equivalently
-  if maps from the module lift along surjections. There are several other equivalent
-  definitions. -/
+if maps from the module lift along surjections. There are several other equivalent
+definitions. -/
 class Module.Projective (R : Type*) [Semiring R] (P : Type*) [AddCommMonoid P] [Module R P] :
     Prop where
   out : ∃ s : P →ₗ[R] P →₀ R, Function.LeftInverse (Finsupp.linearCombination R id) s

--- a/Mathlib/Algebra/Module/RingHom.lean
+++ b/Mathlib/Algebra/Module/RingHom.lean
@@ -12,8 +12,8 @@ import Mathlib.Algebra.Ring.Hom.Defs
 
 ## Main definitions
 
- * `Module.compHom`: compose a `Module` with a `RingHom`, with action `f s • m`.
- * `RingHom.toModule`: a `RingHom` defines a module structure by `r • x = f r * x`.
+* `Module.compHom`: compose a `Module` with a `RingHom`, with action `f s • m`.
+* `RingHom.toModule`: a `RingHom` defines a module structure by `r • x = f r * x`.
 
 ## Tags
 

--- a/Mathlib/Algebra/Module/SpanRank.lean
+++ b/Mathlib/Algebra/Module/SpanRank.lean
@@ -32,7 +32,7 @@ implemented as `spanFinrank` and `spanRank`.
 
 * `rank_eq_spanRank_of_free` : For a ring `R` (not necessarily commutative) satisfying
   `StrongRankCondition R`, if `M` is a free `R`-module, then the `spanRank` of `M` equals to the
-   rank of M.
+  rank of M.
 
 * `rank_le_spanRank` : For a ring `R` (not necessarily commutative) satisfying
   `StrongRankCondition R`, if `M` is an `R`-module, then the `spanRank` of `M` is less than or equal

--- a/Mathlib/Algebra/Module/Submodule/RestrictScalars.lean
+++ b/Mathlib/Algebra/Module/Submodule/RestrictScalars.lean
@@ -16,7 +16,7 @@ then we can turn an `R`-submodule into an `S`-submodule by forgetting the action
 this restriction of scalars for submodules.
 
 ## Main definitions:
- * `Submodule.restrictScalars`: regard an `R`-submodule as an `S`-submodule if `S` acts on `R`
+* `Submodule.restrictScalars`: regard an `R`-submodule as an `S`-submodule if `S` acts on `R`
 
 -/
 

--- a/Mathlib/Algebra/Order/AbsoluteValue/Basic.lean
+++ b/Mathlib/Algebra/Order/AbsoluteValue/Basic.lean
@@ -16,12 +16,12 @@ This file defines a bundled type of absolute values `AbsoluteValue R S`.
 
 ## Main definitions
 
- * `AbsoluteValue R S` is the type of absolute values on `R` mapping to `S`.
- * `AbsoluteValue.abs` is the "standard" absolute value on `S`, mapping negative `x` to `-x`.
- * `AbsoluteValue.toMonoidWithZeroHom`: absolute values mapping to a
-   linear ordered field preserve `0`, `*` and `1`
- * `IsAbsoluteValue`: a type class stating that `f : β → α` satisfies the axioms of an absolute
-   value
+* `AbsoluteValue R S` is the type of absolute values on `R` mapping to `S`.
+* `AbsoluteValue.abs` is the "standard" absolute value on `S`, mapping negative `x` to `-x`.
+* `AbsoluteValue.toMonoidWithZeroHom`: absolute values mapping to a
+  linear ordered field preserve `0`, `*` and `1`
+* `IsAbsoluteValue`: a type class stating that `f : β → α` satisfies the axioms of an absolute
+  value
 -/
 
 variable {ι α R S : Type*}

--- a/Mathlib/Algebra/Order/AbsoluteValue/Euclidean.lean
+++ b/Mathlib/Algebra/Order/AbsoluteValue/Euclidean.lean
@@ -14,10 +14,10 @@ absolute value is compatible with the Euclidean domain structure on its domain.
 
 ## Main definitions
 
- * `AbsoluteValue.IsEuclidean abv` is a predicate on absolute values on `R` mapping to `S`
-    that preserve the order on `R` arising from the Euclidean domain structure.
- * `AbsoluteValue.abs_isEuclidean` shows the "standard" absolute value on `ℤ`,
-   mapping negative `x` to `-x`, is euclidean.
+* `AbsoluteValue.IsEuclidean abv` is a predicate on absolute values on `R` mapping to `S`
+  that preserve the order on `R` arising from the Euclidean domain structure.
+* `AbsoluteValue.abs_isEuclidean` shows the "standard" absolute value on `ℤ`,
+  mapping negative `x` to `-x`, is euclidean.
 -/
 
 @[inherit_doc]

--- a/Mathlib/Algebra/Order/Hom/Basic.lean
+++ b/Mathlib/Algebra/Order/Hom/Basic.lean
@@ -47,13 +47,13 @@ Finitary versions of the current lemmas.
 
 library_note "out-param inheritance"/--
 Diamond inheritance cannot depend on `outParam`s in the following circumstances:
- * there are three classes `Top`, `Middle`, `Bottom`
- * all of these classes have a parameter `(α : outParam _)`
- * all of these classes have an instance parameter `[Root α]` that depends on this `outParam`
- * the `Root` class has two child classes: `Left` and `Right`, these are siblings in the hierarchy
- * the instance `Bottom.toMiddle` takes a `[Left α]` parameter
- * the instance `Middle.toTop` takes a `[Right α]` parameter
- * there is a `Leaf` class that inherits from both `Left` and `Right`.
+* there are three classes `Top`, `Middle`, `Bottom`
+* all of these classes have a parameter `(α : outParam _)`
+* all of these classes have an instance parameter `[Root α]` that depends on this `outParam`
+* the `Root` class has two child classes: `Left` and `Right`, these are siblings in the hierarchy
+* the instance `Bottom.toMiddle` takes a `[Left α]` parameter
+* the instance `Middle.toTop` takes a `[Right α]` parameter
+* there is a `Leaf` class that inherits from both `Left` and `Right`.
 In that case, given instances `Bottom α` and `Leaf α`, Lean cannot synthesize a `Top α` instance,
 even though the hypotheses of the instances `Bottom.toMiddle` and `Middle.toTop` are satisfied.
 

--- a/Mathlib/Algebra/Polynomial/Degree/CardPowDegree.lean
+++ b/Mathlib/Algebra/Polynomial/Degree/CardPowDegree.lean
@@ -15,13 +15,13 @@ to `q ^ degree p` (where `q ^ degree 0 = 0`) is an absolute value.
 
 ## Main definitions
 
- * `Polynomial.cardPowDegree` is an absolute value on `𝔽_q[t]`, the ring of
-   polynomials over a finite field of cardinality `q`, mapping a polynomial `p`
-   to `q ^ degree p` (where `q ^ degree 0 = 0`)
+* `Polynomial.cardPowDegree` is an absolute value on `𝔽_q[t]`, the ring of
+  polynomials over a finite field of cardinality `q`, mapping a polynomial `p`
+  to `q ^ degree p` (where `q ^ degree 0 = 0`)
 
 ## Main results
- * `Polynomial.cardPowDegree_isEuclidean`: `cardPowDegree` respects the
-   Euclidean domain structure on the ring of polynomials
+* `Polynomial.cardPowDegree_isEuclidean`: `cardPowDegree` respects the
+  Euclidean domain structure on the ring of polynomials
 
 -/
 

--- a/Mathlib/Algebra/Polynomial/Derivative.lean
+++ b/Mathlib/Algebra/Polynomial/Derivative.lean
@@ -12,8 +12,8 @@ import Mathlib.GroupTheory.GroupAction.Ring
 # The derivative map on polynomials
 
 ## Main definitions
- * `Polynomial.derivative`: The formal derivative of polynomials, expressed as a linear map.
- * `Polynomial.derivativeFinsupp`: Iterated derivatives as a finite support function.
+* `Polynomial.derivative`: The formal derivative of polynomials, expressed as a linear map.
+* `Polynomial.derivativeFinsupp`: Iterated derivatives as a finite support function.
 
 -/
 

--- a/Mathlib/Algebra/Polynomial/Module/FiniteDimensional.lean
+++ b/Mathlib/Algebra/Polynomial/Module/FiniteDimensional.lean
@@ -14,9 +14,9 @@ This file is a place to collect results about the `R[X]`-module structure induce
 by an `R`-linear endomorphism, which require the concept of finite-dimensionality.
 
 ## Main results:
- * `Module.AEval.isTorsion_of_finiteDimensional`: if a vector space `M` with coefficients in a field
-   `K` carries a natural `K`-linear endomorphism which belongs to a finite-dimensional algebra
-   over `K`, then the induced `K[X]`-module structure on `M` is pure torsion.
+* `Module.AEval.isTorsion_of_finiteDimensional`: if a vector space `M` with coefficients in a field
+  `K` carries a natural `K`-linear endomorphism which belongs to a finite-dimensional algebra
+  over `K`, then the induced `K[X]`-module structure on `M` is pure torsion.
 
 -/
 

--- a/Mathlib/Algebra/Polynomial/SumIteratedDerivative.lean
+++ b/Mathlib/Algebra/Polynomial/SumIteratedDerivative.lean
@@ -31,7 +31,7 @@ as a linear map. This is used in particular in the proof of the Lindemann-Weiers
 * `Polynomial.aeval_iterate_derivative_of_lt`, `Polynomial.aeval_iterate_derivative_self`,
   `Polynomial.aeval_iterate_derivative_of_ge`: applying `Polynomial.aeval` to iterated derivatives
 * `Polynomial.aeval_sumIDeriv`, `Polynomial.aeval_sumIDeriv_of_pos`: applying `Polynomial.aeval` to
-   `Polynomial.sumIDeriv`
+  `Polynomial.sumIDeriv`
 
 -/
 

--- a/Mathlib/Algebra/Quotient.lean
+++ b/Mathlib/Algebra/Quotient.lean
@@ -12,9 +12,9 @@ This file defines notation for algebraic quotients, e.g. quotient groups `G ⧸ 
 quotient modules `M ⧸ N` and ideal quotients `R ⧸ I`.
 
 The actual quotient structures are defined in the following files:
- * quotient group: `Mathlib/GroupTheory/QuotientGroup.lean`
- * quotient module: `Mathlib/LinearAlgebra/Quotient.lean`
- * quotient ring: `Mathlib/RingTheory/Ideal/Quotient.lean`
+* quotient group: `Mathlib/GroupTheory/QuotientGroup.lean`
+* quotient module: `Mathlib/LinearAlgebra/Quotient.lean`
+* quotient ring: `Mathlib/RingTheory/Ideal/Quotient.lean`
 
 ## Notations
 

--- a/Mathlib/Algebra/Ring/Fin.lean
+++ b/Mathlib/Algebra/Ring/Fin.lean
@@ -13,7 +13,7 @@ This file collects some basic results involving rings and the `Fin` type
 
 ## Main results
 
- * `RingEquiv.piFinTwo`: The product over `Fin 2` of some rings is the cartesian product
+* `RingEquiv.piFinTwo`: The product over `Fin 2` of some rings is the cartesian product
 
 -/
 

--- a/Mathlib/Algebra/Ring/Int/Units.lean
+++ b/Mathlib/Algebra/Ring/Int/Units.lean
@@ -14,7 +14,7 @@ This file contains lemmas on the units of `ℤ`.
 
 ## Main results
 
- * `Int.units_eq_one_or`: the invertible integers are 1 and -1.
+* `Int.units_eq_one_or`: the invertible integers are 1 and -1.
 
 See note [foundational algebra order theory].
 -/

--- a/Mathlib/Algebra/Vertex/VertexOperator.lean
+++ b/Mathlib/Algebra/Vertex/VertexOperator.lean
@@ -11,17 +11,17 @@ import Mathlib.Data.Int.Interval
 In this file we introduce vertex operators as linear maps to Laurent series.
 
 ## Definitions
- * `VertexOperator` is an `R`-linear map from an `R`-module `V` to `LaurentSeries V`.
- * `VertexOperator.ncoeff` is the coefficient of a vertex operator under normalized indexing.
+* `VertexOperator` is an `R`-linear map from an `R`-module `V` to `LaurentSeries V`.
+* `VertexOperator.ncoeff` is the coefficient of a vertex operator under normalized indexing.
 
 ## TODO
- * `HasseDerivative` : A divided-power derivative.
- * `Locality` : A weak form of commutativity.
- * `Residue products` : A family of products on `VertexOperator R V` parametrized by integers.
+* `HasseDerivative` : A divided-power derivative.
+* `Locality` : A weak form of commutativity.
+* `Residue products` : A family of products on `VertexOperator R V` parametrized by integers.
 
 ## References
- * [G. Mason, *Vertex rings and Pierce bundles*][mason2017]
- * [A. Matsuo, K. Nagatomo, *On axioms for a vertex algebra and locality of quantum
+* [G. Mason, *Vertex rings and Pierce bundles*][mason2017]
+* [A. Matsuo, K. Nagatomo, *On axioms for a vertex algebra and locality of quantum
    fields*][matsuo1997]
 -/
 


### PR DESCRIPTION
In all lines starting with " *" or " -", remove the leading space. That space is not required and does not match mathlib style.
Then, manually make indentation of subsequent lines match (often, decreasing by one, and sometimes two, space(s).)


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
