### PR TITLE
[Merged by Bors] - doc(Order): replicate the Algebra subfolders design in Order

### DIFF
--- a/Mathlib/Order/README.md
+++ b/Mathlib/Order/README.md
@@ -5,8 +5,7 @@ This folder contains order theory in a broad sense.
 ## Order hierarchy
 
 The basic order hierarchy is split across a series of subfolders that each depend on the previous:
-* `Order.Preorder` for preorders, partial orders
-* `Order.Lattice` for lattices, linear orders
+* `Order.Preorder` for preorders, partial orders, lattices, linear orders
 * `Order.BooleanAlgebra` for heyting/biheyting/coheyting/boolean algebras
 * `Order.CompleteLattice` for frames, coframes, complete lattices
 * `Order.ConditionallyCompleteLattice` for conditionally complete lattices

--- a/Mathlib/Order/README.md
+++ b/Mathlib/Order/README.md
@@ -1,0 +1,22 @@
+# Order
+
+This folder contains order theory in a broad sense.
+
+## Order hierarchy
+
+The basic order hierarchy is split across a series of subfolders that each depend on the previous:
+* `Order.Preorder` for preorders, partial orders
+* `Order.Lattice` for lattices, linear orders
+* `Order.BooleanAlgebra` for heyting/biheyting/coheyting/boolean algebras
+* `Order.CompleteLattice` for frames, coframes, complete lattices
+* `Order.ConditionallyCompleteLattice` for conditionally complete lattices
+* `Order.CompleteBooleanAlgebra` for complete boolean algebras
+
+Files in earlier subfolders should not import files in later ones.
+
+## TODO
+
+Succinctly explain the other subfolders.
+
+The above is still very much a vision. We need to sort the content of existing files into those
+order hierarchy subfolders.


### PR DESCRIPTION
The Algebra subfolders were hugely successful at untangling imports in a principled way. This PR is a proposal to start doing the same in Order.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
